### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # moonbitlang/core
 
-moonbitlang/core is the standard library of the [MoonBit language](moonbitlang.com). It is released alongside the compiler. You can view the documentation for the latest official release at <https://mooncakes.io/docs/#/moonbitlang/core/>. This repository serves as the development repository.
+moonbitlang/core is the standard library of the [MoonBit language](https://moonbitlang.com). It is released alongside the compiler. You can view the documentation for the latest official release at <https://mooncakes.io/docs/#/moonbitlang/core/>. This repository serves as the development repository.
 
 ## Current status
 


### PR DESCRIPTION
The current link will redirect to `https://github.com/moonbitlang/core/blob/main/moonbitlang.com`.