### PR TITLE
Fix error message of assert_ne() to use `!=`

### DIFF
--- a/assertion/assertion.mbt
+++ b/assertion/assertion.mbt
@@ -37,7 +37,7 @@ pub fn assert_ne[T : Debug + Eq](a : T, b : T) -> Result[Unit, String] {
   } else {
     let a = debug_string(a)
     let b = debug_string(b)
-    Err("assertion failed for `\(a) == \(b)`")
+    Err("assertion failed for `\(a) != \(b)`")
   }
 }
 


### PR DESCRIPTION
Unfortunately, it's not yet easy to write a test to cover this due to the lack of `@string` capabilities.