### PR TITLE
Add sum() to List and Array

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -568,3 +568,36 @@ test "ends_with" {
   @assertion.assert_true(arr.ends_with([3, 4, 5]))?
   @assertion.assert_false(arr.ends_with([2, 3, 4, 5]))?
 }
+
+/// Calculates the sum of the array.
+///
+/// Only available if the elements implements the `Default` trait and have the
+/// `op_add()` function. The result is simply adding all elements sequentially
+/// to the default value of the element type, which means the `sum()` of an
+/// empty array is the default value itself.
+///
+/// # Examples
+///
+/// ```
+/// let arr = [1, 2, 3, 4, 5]
+/// print(arr.sum())  // output: 15
+///
+/// let empty_arr: Array[Int] = []
+/// print(empty_arr.sum())  // output: 0
+/// ```
+pub fn sum[T : @num.Num + Default](self : Array[T]) -> T {
+  loop 0, T::default() {
+    i, acc =>
+      if i < self.length() {
+        continue i + 1, acc + self[i]
+      } else {
+        acc
+      }
+  }
+}
+
+test "sum" {
+  @assertion.assert_eq([].sum(), 0)?
+  @assertion.assert_eq([1024].sum(), 1024)?
+  @assertion.assert_eq([1, 2, 3, 4, 5].sum(), 15)?
+}

--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -2,6 +2,8 @@
   "import": [
     "moonbitlang/core/assertion",
     "moonbitlang/core/math",
+    "moonbitlang/core/num",
+    "moonbitlang/core/int",
     "moonbitlang/core/coverage"
   ]
 }

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1116,3 +1116,29 @@ test "intercalate" {
     List::[1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9],
   )?
 }
+
+/// Calculates the sum of the list.
+///
+/// Only available if the elements implements the `Default` trait and have the
+/// `op_add()` function. The result is simply adding all elements sequentially
+/// to the default value of the element type, which means the `sum()` of an
+/// empty list is the default value itself.
+///
+/// # Examples
+///
+/// ```
+/// let ls = List::[1, 2, 3, 4, 5]
+/// print(ls.sum())  // output: 15
+///
+/// let empty_list: List[Int] = Nil
+/// print(empty_list.sum())  // output: 0
+/// ```
+pub fn sum[T : @num.Num + Default](self : List[T]) -> T {
+  self.fold(T::default(), fn { acc, x => acc + x })
+}
+
+test "sum" {
+  @assertion.assert_eq(List::Nil.sum(), 0)?
+  @assertion.assert_eq(List::Cons(1024, Nil).sum(), 1024)?
+  @assertion.assert_eq(List::[1, 2, 3, 4, 5].sum(), 15)?
+}

--- a/list/moon.pkg.json
+++ b/list/moon.pkg.json
@@ -2,6 +2,8 @@
   "import": [
     "moonbitlang/core/assertion",
     "moonbitlang/core/array",
-    "moonbitlang/core/coverage"
+    "moonbitlang/core/coverage",
+    "moonbitlang/core/int",
+    "moonbitlang/core/num"
   ]
 }


### PR DESCRIPTION
- [x] ~Depends on `@math` package added in #35~
- [x] Depends on #49

I'm not sure if we even want the `sum()` functions directly on data structures, it seems like a better abstraction if we instead put it on an iterator (like Rust), only that we don't have iterators yet. So for testing/early-adopting purposes, I think it's fine to have them as demonstrated in this PR, even if it means we need to deprecate and remove them later.

Ported from [muts](https://gitee.com/fantix/muts/blob/v0.5.2/utils/math.mbt#L25).