### PR TITLE
fix: tuple with some

### DIFF
--- a/list/list.mbt
+++ b/list/list.mbt
@@ -669,13 +669,13 @@ pub fn unfold[T, State](
   f : (State) -> Option[(T, State)]
 ) -> List[T] {
   match f(init) {
-    Some(element, new_state) => Cons(element, unfold(new_state, f))
+    Some((element, new_state)) => Cons(element, unfold(new_state, f))
     None => Nil
   }
 }
 
 test "unfold" {
-  let ls = unfold(0, fn { i => if i == 3 { None } else { Some(i, i + 1) } })
+  let ls = unfold(0, fn { i => if i == 3 { None } else { Some((i, i + 1)) } })
   @assertion.assert_eq(ls, Cons(0, Cons(1, Cons(2, Nil))))?
 }
 


### PR DESCRIPTION
`Some(a, b)` seems not to be a valid syntax with the latest moonbit version.

```sh
moon 0.1.0 (73a0162 2024-03-11)
```