### PR TITLE
Add balanced binary tree based immutable_set implementation

### DIFF
--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -56,8 +56,8 @@ pub fn to_list[T](self : ImmutableSet[T]) -> List[T] {
   fn values_aux(set : ImmutableSet[T], list : List[T]) {
     match set {
       Empty => list
-      Node(node) =>
-        values_aux(node.left, Cons(node.value, values_aux(node.right, list)))
+      Node({ left, right, value, height: _ }) =>
+        values_aux(left, Cons(value, values_aux(right, list)))
     }
   }
 
@@ -68,10 +68,10 @@ pub fn to_list[T](self : ImmutableSet[T]) -> List[T] {
 pub fn remove_min[T](self : ImmutableSet[T]) -> ImmutableSet[T] {
   match self {
     Empty => abort("remove_min: empty ImmutableSet")
-    Node(node) =>
-      match node.left {
-        Empty => node.right
-        _ => balance(node.left.remove_min(), node.value, node.right)
+    Node({ left, right, value, height: _ }) =>
+      match left {
+        Empty => right
+        _ => balance(left.remove_min(), value, right)
       }
   }
 }
@@ -80,23 +80,23 @@ pub fn remove_min[T](self : ImmutableSet[T]) -> ImmutableSet[T] {
 pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
     Empty => Node({ left: Empty, value, right: Empty, height: 1 })
-    Node(node) => {
-      let compare_result = value.compare(node.value)
+    Node({ left, right, value: node_value, height: _ }) as node => {
+      let compare_result = value.compare(node_value)
       if compare_result == 0 {
-        Node(node)
+        node
       } else if compare_result < 0 {
-        let left = node.left.add(value)
-        if physical_equal(node.left, left) {
-          Node(node)
+        let ll = left.add(value)
+        if physical_equal(left, ll) {
+          node
         } else {
-          balance(left, node.value, node.right)
+          balance(ll, node_value, right)
         }
       } else {
-        let right = node.right.add(value)
-        if physical_equal(right, node.right) {
-          Node(node)
+        let rr = right.add(value)
+        if physical_equal(right, rr) {
+          node
         } else {
-          balance(node.left, node.value, right)
+          balance(left, node_value, rr)
         }
       }
     }
@@ -229,19 +229,22 @@ pub fn union[T : Compare](
   match (self, other) {
     (Empty, other) => other
     (self, Empty) => self
-    (Node(node), Node(node1)) =>
-      if node.height >= node1.height {
-        if node1.height == 1 {
-          self.add(node1.value)
+    (
+      Node({ left: l1, value: v1, right: r1, height: h1 }),
+      Node({ left: l2, value: v2, right: r2, height: h2 }),
+    ) =>
+      if h1 >= h2 {
+        if h2 == 1 {
+          self.add(v2)
         } else {
-          let (left, _, right) = other.split(node.value)
-          join(node.left.union(left), node.value, node.right.union(right))
+          let (l2, _, r2) = other.split(v1)
+          join(l1.union(l2), v1, r1.union(r2))
         }
-      } else if node.height == 1 {
-        other.add(node.value)
+      } else if h1 == 1 {
+        other.add(v1)
       } else {
-        let (left, _, right) = self.split(node1.value)
-        join(left.union(node1.left), node1.value, right.union(node1.right))
+        let (l1, _, r1) = self.split(v2)
+        join(l1.union(l2), v2, r1.union(r2))
       }
   }
 }
@@ -302,36 +305,28 @@ fn balance[T](
   if left_height > right_height + 2 {
     match left {
       Empty => abort("balance: left is empty.")
-      Node(node) =>
-        if node.left.height() >= node.right.height() {
-          create(node.left, node.value, create(node.right, value, right))
+      Node({ left: ll, value: lv, right: lr, height: _ }) =>
+        if ll.height() >= lr.height() {
+          create(ll, lv, create(lr, value, right))
         } else {
-          match node.right {
+          match lr {
             Empty => abort("balance: right left.right is empty.")
-            Node(right_node) =>
-              create(
-                create(node.left, node.value, right_node.left),
-                right_node.value,
-                create(right_node.right, value, right),
-              )
+            Node({ left: lrl, value: lrv, right: lrr, height: _ }) =>
+              create(create(ll, lv, lrl), lrv, create(lrr, value, right))
           }
         }
     }
   } else if right_height > left_height + 2 {
     match right {
       Empty => abort("balance: right is empty")
-      Node(node) =>
-        if node.right.height() >= node.left.height() {
-          create(create(left, value, node.left), node.value, node.right)
+      Node({ left: rl, value: rv, right: rr, height: _ }) =>
+        if rr.height() >= rl.height() {
+          create(create(left, value, rl), rv, rr)
         } else {
-          match node.left {
+          match rl {
             Empty => abort("balance: right.left is empty")
-            Node(left_node) =>
-              create(
-                create(left, value, left_node.left),
-                left_node.value,
-                create(left_node.right, node.value, node.right),
-              )
+            Node({ left: rll, value: rlv, right: rlr, height: _ }) =>
+              create(create(left, value, rll), rlv, create(rlr, rv, rr))
           }
         }
     }
@@ -354,14 +349,16 @@ fn balance[T](
 fn add_min_value[T](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
     Empty => new(value)
-    Node(node) => balance(node.left.add_min_value(value), value, node.right)
+    Node({ left, value: node_value, right, height: _ }) =>
+      balance(left.add_min_value(value), node_value, right)
   }
 }
 
 fn add_max_value[T](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
     Empty => new(value)
-    Node(node) => balance(node.left, value, node.right.add_max_value(value))
+    Node({ left, value: node_value, right, height: _ }) =>
+      balance(left, node_value, right.add_max_value(value))
   }
 }
 
@@ -374,19 +371,14 @@ fn join[T](
   match (left, right) {
     (Empty, _) => right.add_min_value(value)
     (_, Empty) => left.add_max_value(value)
-    (Node(left_node), Node(right_node)) =>
-      if left_node.height > right_node.height + 2 {
-        balance(
-          left_node.left,
-          left_node.value,
-          join(left_node.right, value, right),
-        )
-      } else if right_node.height > left_node.height + 2 {
-        balance(
-          join(left, value, right_node.left),
-          right_node.value,
-          right_node.right,
-        )
+    (
+      Node({ left: ll, value: lv, right: lr, height: lh }),
+      Node({ left: rl, value: rv, right: rr, height: rh }),
+    ) =>
+      if lh > rh + 2 {
+        balance(ll, lv, join(lr, value, right))
+      } else if rh > lh + 2 {
+        balance(join(left, value, rl), rv, rr)
       } else {
         create(left, value, right)
       }

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -222,6 +222,45 @@ pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
   }
 }
 
+pub fn union[T : Compare](
+  self : ImmutableSet[T],
+  other : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  match (self, other) {
+    (Empty, other) => other
+    (self, Empty) => self
+    (Node(node), Node(node1)) =>
+      if node.height >= node1.height {
+        if node1.height == 1 {
+          self.add(node1.value)
+        } else {
+          let (left, _, right) = other.split(node.value)
+          join(node.left.union(left), node.value, node.right.union(right))
+        }
+      } else if node.height == 1 {
+        other.add(node.value)
+      } else {
+        let (left, _, right) = self.split(node1.value)
+        join(left.union(node1.left), node1.value, right.union(node1.right))
+      }
+  }
+}
+
+// pub fn diff[T](
+//   self : ImmutableSet[T],
+//   other : ImmutableSet[T]
+// ) -> ImmutableSet[T] {
+// 
+// }
+// 
+// pub fn disjoint[T](self : ImmutableSet[T], other : ImmutableSet[T]) -> Bool {
+// 
+// }
+// 
+// pub fn elements[T](self : ImmutableSet[T]) -> Int {
+// 
+// }
+
 /// Get the height of set.
 fn height[T](self : ImmutableSet[T]) -> Int {
   match self {
@@ -262,13 +301,13 @@ fn balance[T](
   let right_height = right.height()
   if left_height > right_height + 2 {
     match left {
-      Empty => abort("balance: left subtree is empty.")
+      Empty => abort("balance: left is empty.")
       Node(node) =>
         if node.left.height() >= node.right.height() {
-          create(node.left, node.value, create(node.right, node.value, right))
+          create(node.left, node.value, create(node.right, value, right))
         } else {
           match node.right {
-            Empty => abort("balance: right subtree is empty.")
+            Empty => abort("balance: right left.right is empty.")
             Node(right_node) =>
               create(
                 create(node.left, node.value, right_node.left),
@@ -280,13 +319,13 @@ fn balance[T](
     }
   } else if right_height > left_height + 2 {
     match right {
-      Empty => abort("balance: right subtree is empty")
+      Empty => abort("balance: right is empty")
       Node(node) =>
-        if node.right.height() > node.left.height() {
+        if node.right.height() >= node.left.height() {
           create(create(left, value, node.left), node.value, node.right)
         } else {
           match node.left {
-            Empty => abort("balance: right subtree is empty")
+            Empty => abort("balance: right.left is empty")
             Node(left_node) =>
               create(
                 create(left, value, left_node.left),
@@ -418,7 +457,7 @@ fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
         let left_length = n / 2
         let (left, list) = sub(left_length, list)
         match list {
-          Nil => abort("of_sorted_list: cannot constructs the left subtree")
+          Nil => abort("of_sorted_list: cannot constructs the left")
           Cons(mid, list) => {
             let (right, list) = sub(n - left_length - 1, list)
             (create(left, mid, right), list)
@@ -430,6 +469,15 @@ fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
 
   let (set, _) = sub(list.length(), list)
   set
+}
+
+test "union" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[3, 4, 5]).union(
+      ImmutableSet::from_list(List::[4, 5, 6]),
+    ).to_list(),
+    List::[3, 4, 5, 6],
+  )?
 }
 
 test "max" {
@@ -446,11 +494,17 @@ test "split" {
   @assertion.assert_true(present)?
   @assertion.assert_eq(left.to_list(), List::[1, 2, 3, 4])?
   @assertion.assert_eq(right.to_list(), List::[6, 7, 8, 9])?
+  let (left, present, right) = ImmutableSet::from_list(
+    List::[7, 2, 9, 4, 5, 6, 3, 8, 1],
+  ).split(0)
+  @assertion.assert_false(present)?
+  @assertion.assert_eq(left.to_list(), Nil)?
+  @assertion.assert_eq(right.to_list(), List::[1, 2, 3, 4, 5, 6, 7, 8, 9])?
 }
 
 test "exists" {
   @assertion.assert_true(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).exists(5),
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 6, 3, 8, 1]).add(5).exists(5),
   )?
 }
 

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -262,8 +262,8 @@ pub fn is_empty[T : Compare](self : ImmutableSet[T]) -> Bool {
   }
 }
 
-/// Return true if value exists in ImmutableSet
-pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
+/// Return true if value contain in ImmutableSet
+pub fn contain[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
   match self {
     Empty => false
     Node(node) => {
@@ -272,7 +272,7 @@ pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
         node.left
       } else {
         node.right
-      }).exists(value)
+      }).contain(value)
     }
   }
 }
@@ -419,6 +419,164 @@ pub fn disjoint[T : Compare](
           Found => false
         }
       }
+  }
+}
+
+/// Iterates over the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).iter(print)
+/// // output: 123456789
+/// ```
+pub fn iter[T : Compare](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
+  match self {
+    Empty => ()
+    Node({ left, value, right, height: _ }) => {
+      left.iter(f)
+      f(value)
+      right.iter(f)
+    }
+  }
+}
+
+/// Fold the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 2, 3, 4, 5]).fold(0, fn(acc, x) { acc + x }))
+/// // output: 15
+/// ```
+pub fn fold[T : Compare, U : Compare](
+  self : ImmutableSet[T],
+  initial : U,
+  f : (U, T) -> U
+) -> U {
+  match self {
+    Empty => initial
+    Node({ left, value, right, height: _ }) =>
+      right.fold(f(left.fold(initial, f), value), f)
+  }
+}
+
+/// Maps the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 2, 3]).map(fn(x){ x * 2}).to_list())
+/// // output: Cons(2, Cons(4, Cons(6, Nil)))
+/// ```
+pub fn map[T : Compare, U : Compare](
+  self : ImmutableSet[T],
+  f : (T) -> U
+) -> ImmutableSet[U] {
+  match self {
+    Empty => Empty
+    Node({ left, value, right, height: _ }) =>
+      try_join(left.map(f), f(value), right.map(f))
+  }
+}
+
+/// Test if all values of the ImmutableSet satisfy the predicate.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[2, 4, 6]).forall(fn(v) { v % 2 == 0}))
+/// // output: true
+/// ```
+pub fn forall[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
+  match self {
+    Empty => true
+    Node({ left, value, right, height: _ }) =>
+      f(value) && left.forall(f) && right.forall(f)
+  }
+}
+
+/// Checks if at least one element of the set satisfies the predicate.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 4, 3]).exists(fn(v) { v % 2 == 0}))
+/// // output: true
+/// ```
+pub fn exists[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
+  match self {
+    Empty => false
+    Node({ left, value, right, height: _ }) =>
+      f(value) || left.exists(f) || right.exists(f)
+  }
+}
+
+/// Filter the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).filter(fn(v) { v % 2 == 0}).to_list())
+/// // output: Cons(2, Cons(4, Cons(6, Nil)))
+/// ```
+pub fn filter[T : Compare](
+  self : ImmutableSet[T],
+  f : (T) -> Bool
+) -> ImmutableSet[T] {
+  match self {
+    Empty => Empty
+    Node({ left, value, right, height: _ }) as node => {
+      let l = left.filter(f)
+      let v = f(value)
+      let r = right.filter(f)
+      if v {
+        if physical_equal(l, left) && physical_equal(r, right) {
+          node
+        } else {
+          join(l, value, r)
+        }
+      } else {
+        l.concat(r)
+      }
+    }
+  }
+}
+
+/// Find value in self and return value if present, otherwise abort.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).find(6))
+/// // output: 6
+/// ```
+pub fn find[T : Compare](self : ImmutableSet[T], value : T) -> T {
+  match self {
+    Empty => abort("find: not found")
+    Node({ left, value: node_value, right, height: _ }) => {
+      let compare_result = value.compare(node_value)
+      if compare_result == 0 {
+        node_value
+      } else {
+        (if compare_result < 0 { left } else { right }).find(value)
+      }
+    }
+  }
+}
+
+/// Same as find, but returns None if value is not found.
+pub fn find_option[T : Compare](self : ImmutableSet[T], value : T) -> Option[T] {
+  match self {
+    Empty => None
+    Node({ left, value: node_value, right, height: _ }) => {
+      let compare_result = value.compare(node_value)
+      if compare_result == 0 {
+        Some(node_value)
+      } else {
+        Some((if compare_result < 0 { left } else { right }).find(value))
+      }
+    }
   }
 }
 
@@ -593,6 +751,20 @@ fn join[T : Compare](
   }
 }
 
+fn try_join[T : Compare](
+  left : ImmutableSet[T],
+  value : T,
+  right : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  if (left == Empty || left.max().compare(value) < 0) && (right == Empty || value.compare(
+    right.min(),
+  ) < 0) {
+    join(left, value, right)
+  } else {
+    left.union(right.add(value))
+  }
+}
+
 /// Merge two ImmutableSet[T] into one. 
 /// All values of left must precede the values of r.
 fn merge[T : Compare](
@@ -727,6 +899,57 @@ test "union" {
   )?
 }
 
+test "map" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[1, 2, 3, 4, 5]).map(fn(x) { x * 2 }).to_list(),
+    List::[2, 4, 6, 8, 10],
+  )?
+}
+
+test "forall" {
+  @assertion.assert_true(
+    ImmutableSet::from_list(List::[2, 4, 6]).forall(fn(v) { v % 2 == 0 }),
+  )?
+  @assertion.assert_false(
+    ImmutableSet::from_list(List::[1, 3, 5]).forall(fn(v) { v % 2 == 0 }),
+  )?
+}
+
+test "exists" {
+  @assertion.assert_true(
+    ImmutableSet::from_list(List::[1, 4, 3]).exists(fn(v) { v % 2 == 0 }),
+  )?
+  @assertion.assert_false(
+    ImmutableSet::from_list(List::[1, 5, 3]).exists(fn(v) { v % 2 == 0 }),
+  )?
+}
+
+test "fold" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[1, 2, 3, 4, 5]).fold(
+      0,
+      fn(acc, x) { acc + x },
+    ),
+    15,
+  )?
+}
+
+test "filter" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).filter(
+      fn(v) { v % 2 == 0 },
+    ).to_list(),
+    List::[2, 4, 6],
+  )?
+}
+
+test "find" {
+  @assertion.assert_eq(
+    6,
+    ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).find(6),
+  )?
+}
+
 test "max" {
   @assertion.assert_eq(
     9,
@@ -749,9 +972,9 @@ test "split" {
   @assertion.assert_eq(right.to_list(), List::[1, 2, 3, 4, 5, 6, 7, 8, 9])?
 }
 
-test "exists" {
+test "contain" {
   @assertion.assert_true(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 6, 3, 8, 1]).add(5).exists(5),
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 6, 3, 8, 1]).add(5).contain(5),
   )?
 }
 

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -34,7 +34,7 @@ pub fn ImmutableSet::from_value[T : Compare](value : T) -> ImmutableSet[T] {
   Node({ left: Empty, value, right: Empty, height: 1 })
 }
 
-/// Initialize an ImmutableSet[T] from a List[T], T : Compare
+/// Initialize an ImmutableSet[T] from a List[T]
 pub fn ImmutableSet::from_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
   match list {
     Nil => Empty
@@ -51,6 +51,18 @@ pub fn ImmutableSet::from_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
         value4,
       )
     _ => of_sorted_list(list.sort())
+  }
+}
+
+/// Initialize an ImmutableSet[T] from a Array[T]
+pub fn ImmutableSet::from_array[T : Compare](
+  array : Array[T]
+) -> ImmutableSet[T] {
+  for i = array.length() - 1, set = ImmutableSet::Empty; i >= 0; {
+    continue i - 1,
+      set.add(array[i])
+  } else {
+    set
   }
 }
 
@@ -387,9 +399,13 @@ pub fn subset[T : Compare](
       if compare_result == 0 {
         l1.subset(l2) && r1.subset(r2)
       } else if compare_result < 0 {
-        Node::new(l1, v1, Empty, 0).subset(l2) && r1.subset(node)
+        ImmutableSet::Node({ left: l1, value: v1, right: Empty, height: 0 }).subset(
+          l2,
+        ) && r1.subset(node)
       } else {
-        Node::new(Empty, v1, r1, 0).subset(r2) && l1.subset(node)
+        ImmutableSet::Node({ left: Empty, value: v1, right: r1, height: 0 }).subset(
+          r2,
+        ) && l1.subset(node)
       }
     }
   }
@@ -643,15 +659,6 @@ fn create[T : Compare](
       },
     },
   )
-}
-
-fn Node::new[T : Compare](
-  left : ImmutableSet[T],
-  value : T,
-  right : ImmutableSet[T],
-  height : Int
-) -> ImmutableSet[T] {
-  Node({ left, value, right, height })
 }
 
 /// Same as create, but performs one step of rebalancing if necessary.
@@ -1023,6 +1030,13 @@ test "from_list" {
 test "to_list" {
   @assertion.assert_eq(
     ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).to_list(),
+    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
+  )?
+}
+
+test "from_array" {
+  @assertion.assert_eq(
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_list(),
     List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
   )?
 }

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -1,0 +1,551 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This module implements the set data structure.
+// The types stored in set need to implement the Compare trait.
+// All operations over sets are purely applicative (no side-effects).
+
+/// ImmutableSets are represented by balanced binary trees (the heights of the children differ by at most 2).
+enum ImmutableSet[T] {
+  Empty
+  Node(Node[T])
+} derive(Default, Show, Debug, Eq)
+
+priv struct Node[T] {
+  left : ImmutableSet[T]
+  right : ImmutableSet[T]
+  height : Int
+  value : T
+} derive(Default, Show, Debug, Eq)
+
+/// Returns the one-value ImmutableSet containing only `value`.
+pub fn ImmutableSet::new[T](value : T) -> ImmutableSet[T] {
+  Node({ left: Empty, value, right: Empty, height: 1 })
+}
+
+// Convert a sorted list into a balanced binary search tree to facilitate subsequent search, insertion, and deletion operations.
+fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
+
+  // Recursively process the input list and build a balanced binary search tree based on the length n of the list.
+  fn sub(n : Int, list : List[T]) -> (ImmutableSet[T], List[T]) {
+    match (n, list) {
+      (0, list) => (Empty, list)
+      (1, Cons(value, list)) =>
+        (Node({ left: Empty, value, right: Empty, height: 1 }), list)
+      (2, Cons(value, Cons(value1, list))) =>
+        (
+          Node(
+            {
+              left: Node({ left: Empty, value, right: Empty, height: 1 }),
+              value: value1,
+              right: Empty,
+              height: 2,
+            },
+          ),
+          list,
+        )
+      (3, Cons(value, Cons(value1, Cons(value2, list)))) =>
+        (
+          Node(
+            {
+              left: Node({ left: Empty, value, right: Empty, height: 1 }),
+              value: value1,
+              right: Node(
+                { left: Empty, value: value2, right: Empty, height: 1 },
+              ),
+              height: 2,
+            },
+          ),
+          list,
+        )
+
+      // For n > 3, the function first calculates the size of the left subtree,
+      // and then recursively constructs the left subtree.
+      _ => {
+        let left_length = n / 2
+        let (left, list) = sub(left_length, list)
+        match list {
+          Nil => abort("of_sorted_list: cannot constructs the left subtree")
+          Cons(mid, list) => {
+            let (right, list) = sub(n - left_length - 1, list)
+            (create(left, mid, right), list)
+          }
+        }
+      }
+    }
+  }
+
+  let (set, _) = sub(list.length(), list)
+  set
+}
+
+/// Initialize an ImmutableSet[T] from a List[T], T : Compare
+pub fn ImmutableSet::from_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
+  match list {
+    Nil => Empty
+    // For very small lists, adding values to the set directly using the add function is much faster than sorting and de-important the entire list.
+    Cons(value, Nil) => ImmutableSet::new(value)
+    Cons(value, Cons(value1, Nil)) => ImmutableSet::new(value).add(value1)
+    Cons(value, Cons(value1, Cons(value2, Nil))) =>
+      ImmutableSet::new(value).add(value1).add(value2)
+    Cons(value, Cons(value1, Cons(value2, Cons(value3, Nil)))) =>
+      ImmutableSet::new(value).add(value1).add(value2).add(value3)
+    Cons(value, Cons(value1, Cons(value2, Cons(value3, Cons(value4, Nil))))) =>
+      ImmutableSet::new(value).add(value1).add(value2).add(value3).add(value4)
+    _ => of_sorted_list(list.sort())
+  }
+}
+
+test "from_list" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    Node(
+      {
+        left: Node(
+          {
+            left: Node(
+              {
+                left: Node({ left: Empty, right: Empty, height: 1, value: 1 }),
+                right: Empty,
+                height: 2,
+                value: 2,
+              },
+            ),
+            right: Node({ left: Empty, right: Empty, height: 1, value: 4 }),
+            height: 3,
+            value: 3,
+          },
+        ),
+        right: Node(
+          {
+            left: Node(
+              {
+                left: Node({ left: Empty, right: Empty, height: 1, value: 6 }),
+                right: Empty,
+                height: 2,
+                value: 7,
+              },
+            ),
+            right: Node({ left: Empty, right: Empty, height: 1, value: 9 }),
+            height: 3,
+            value: 8,
+          },
+        ),
+        height: 4,
+        value: 5,
+      },
+    ),
+  )?
+}
+
+/// Convert ImmutableSet[T] to List[T], the result must be ordered.
+pub fn to_list[T](self : ImmutableSet[T]) -> List[T] {
+  fn values_aux(set : ImmutableSet[T], list : List[T]) {
+    match set {
+      Empty => list
+      Node(node) =>
+        values_aux(node.left, Cons(node.value, values_aux(node.right, list)))
+    }
+  }
+
+  values_aux(self, Nil)
+}
+
+test "to_list" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).to_list(),
+    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
+  )?
+}
+
+/// Get the height of set.
+fn height[T](self : ImmutableSet[T]) -> Int {
+  match self {
+    Empty => 0
+    Node(node) => node.height
+  }
+}
+
+test "height" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).height(),
+    4,
+  )?
+}
+
+/// Creates a new node.
+fn create[T](
+  left : ImmutableSet[T],
+  value : T,
+  right : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  let left_height = left.height()
+  let right_height = right.height()
+  Node(
+    {
+      left,
+      right,
+      value,
+      height: if left_height >= right_height {
+        left_height + 1
+      } else {
+        right_height + 1
+      },
+    },
+  )
+}
+
+/// Same as create, but performs one step of rebalancing if necessary.
+fn balance[T](
+  left : ImmutableSet[T],
+  value : T,
+  right : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  let left_height = left.height()
+  let right_height = right.height()
+  if left_height > right_height + 2 {
+    match left {
+      Empty => abort("balance: left subtree is empty.")
+      Node(node) =>
+        if node.left.height() >= node.right.height() {
+          create(node.left, node.value, create(node.right, node.value, right))
+        } else {
+          match node.right {
+            Empty => abort("balance: right subtree is empty.")
+            Node(right_node) =>
+              create(
+                create(node.left, node.value, right_node.left),
+                right_node.value,
+                create(right_node.right, value, right),
+              )
+          }
+        }
+    }
+  } else if right_height > left_height + 2 {
+    match right {
+      Empty => abort("balance: right subtree is empty")
+      Node(node) =>
+        if node.right.height() > node.left.height() {
+          create(create(left, value, node.left), node.value, node.right)
+        } else {
+          match node.left {
+            Empty => abort("balance: right subtree is empty")
+            Node(left_node) =>
+              create(
+                create(left, value, left_node.left),
+                left_node.value,
+                create(left_node.right, node.value, node.right),
+              )
+          }
+        }
+    }
+  } else {
+    Node(
+      {
+        left,
+        value,
+        right,
+        height: if left_height >= right_height {
+          left_height + 1
+        } else {
+          right_height + 1
+        },
+      },
+    )
+  }
+}
+
+fn add_min_value[T](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
+  match self {
+    Empty => new(value)
+    Node(node) => balance(node.left.add_min_value(value), value, node.right)
+  }
+}
+
+fn add_max_value[T](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
+  match self {
+    Empty => new(value)
+    Node(node) => balance(node.left, value, node.right.add_max_value(value))
+  }
+}
+
+/// Same as create and balance, but no assumptions are made on the relative heights of left and right.
+fn join[T](
+  left : ImmutableSet[T],
+  value : T,
+  right : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  match (left, right) {
+    (Empty, _) => right.add_min_value(value)
+    (_, Empty) => left.add_max_value(value)
+    (Node(left_node), Node(right_node)) =>
+      if left_node.height > right_node.height + 2 {
+        balance(
+          left_node.left,
+          left_node.value,
+          join(left_node.right, value, right),
+        )
+      } else if right_node.height > left_node.height + 2 {
+        balance(
+          join(left, value, right_node.left),
+          right_node.value,
+          right_node.right,
+        )
+      } else {
+        create(left, value, right)
+      }
+  }
+}
+
+/// Merge two ImmutableSet[T] into one. 
+/// All values of left must precede the values of r.
+fn merge[T](self : ImmutableSet[T], other : ImmutableSet[T]) -> ImmutableSet[T] {
+  match (self, other) {
+    (Empty, other) => other
+    (self, Empty) => self
+    (_, _) => balance(self, other.min(), other.remove_min())
+  }
+}
+
+/// Same as merge, but no assumption on the heights of self and other.
+fn concat[T](
+  self : ImmutableSet[T],
+  other : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  match (self, other) {
+    (Empty, other) => other
+    (self, Empty) => self
+    (_, _) => join(self, other.min(), other.remove_min())
+  }
+}
+
+/// Remove the smallest value,
+pub fn remove_min[T](self : ImmutableSet[T]) -> ImmutableSet[T] {
+  match self {
+    Empty => abort("remove_min: empty ImmutableSet")
+    Node(node) =>
+      match node.left {
+        Empty => node.right
+        _ => balance(node.left.remove_min(), node.value, node.right)
+      }
+  }
+}
+
+test "remove_min" {
+  let set = create(ImmutableSet::new(1), 3, ImmutableSet::new(2)).remove_min()
+  @assertion.assert_eq(
+    set,
+    Node(
+      {
+        left: Empty,
+        right: Node({ left: Empty, right: Empty, height: 1, value: 2 }),
+        height: 2,
+        value: 3,
+      },
+    ),
+  )?
+}
+
+/// Insert a value into the ImmutableSet.
+pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
+  match self {
+    Empty => Node({ left: Empty, value, right: Empty, height: 1 })
+    Node(node) => {
+      let compare_result = value.compare(node.value)
+      if compare_result == 0 {
+        Node(node)
+      } else if compare_result < 0 {
+        let left = node.left.add(value)
+        if physical_equal(node.left, left) {
+          Node(node)
+        } else {
+          balance(left, node.value, node.right)
+        }
+      } else {
+        let right = node.right.add(value)
+        if physical_equal(right, node.right) {
+          Node(node)
+        } else {
+          balance(node.left, node.value, right)
+        }
+      }
+    }
+  }
+}
+
+test "add" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 6, 3, 8, 1]).add(5).to_list(),
+    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
+  )?
+}
+
+pub fn remove[T : Compare](
+  self : ImmutableSet[T],
+  value : T
+) -> ImmutableSet[T] {
+  match self {
+    Empty => Empty
+    Node(node) => {
+      let compare_result = value.compare(node.value)
+      if compare_result == 0 {
+        node.left.merge(node.right)
+      } else if compare_result < 0 {
+        let left = node.left.remove(value)
+        if physical_equal(node.left, left) {
+          Node(node)
+        } else {
+          balance(left, node.value, node.right)
+        }
+      } else {
+        let right = node.right.remove(value)
+        if physical_equal(node.right, right) {
+          Node(node)
+        } else {
+          balance(node.left, node.value, right)
+        }
+      }
+    }
+  }
+}
+
+test "remove" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(8).to_list(),
+    List::[1, 2, 3, 4, 5, 6, 7, 9],
+  )?
+}
+
+pub fn min[T](self : ImmutableSet[T]) -> T {
+  match self {
+    Empty => abort("min: there are no values in ImmutableSet.")
+    Node(node) =>
+      match node.left {
+        Empty => node.value
+        _ => node.left.min()
+      }
+  }
+}
+
+test "min" {
+  @assertion.assert_eq(
+    1,
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).min(),
+  )?
+}
+
+pub fn min_option[T](self : ImmutableSet[T]) -> Option[T] {
+  match self {
+    Empty => None
+    Node(node) =>
+      match node.left {
+        Empty => Some(node.value)
+        _ => node.left.min_option()
+      }
+  }
+}
+
+pub fn max[T](self : ImmutableSet[T]) -> T {
+  match self {
+    Empty => abort("max: there are no values in ImmutableSet.")
+    Node(node) =>
+      match node.right {
+        Empty => node.value
+        _ => node.right.max()
+      }
+  }
+}
+
+test "max" {
+  @assertion.assert_eq(
+    9,
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).max(),
+  )?
+}
+
+pub fn max_option[T](self : ImmutableSet[T]) -> Option[T] {
+  match self {
+    Empty => None
+    Node(node) =>
+      match node.right {
+        Empty => Some(node.value)
+        _ => node.right.max_option()
+      }
+  }
+}
+
+/// Returns a triple (left, present, right), left < divide < right
+/// present is false if self contains no element equal to divide, 
+/// or true if self contains an element equal to divide.
+pub fn split[T : Compare](
+  self : ImmutableSet[T],
+  divide : T
+) -> (ImmutableSet[T], Bool, ImmutableSet[T]) {
+  match self {
+    Empty => (Empty, false, Empty)
+    Node(node) => {
+      let compare_result = divide.compare(node.value)
+      if compare_result == 0 {
+        (node.left, true, node.right)
+      } else if compare_result < 0 {
+        let (left_left, present, right_left) = node.left.split(divide)
+        (left_left, present, join(right_left, node.value, node.right))
+      } else {
+        let (left_right, present, right_right) = node.right.split(divide)
+        (join(node.left, node.value, left_right), present, right_right)
+      }
+    }
+  }
+}
+
+test "split" {
+  let (left, present, right) = ImmutableSet::from_list(
+    List::[7, 2, 9, 4, 5, 6, 3, 8, 1],
+  ).split(5)
+  @assertion.assert_true(present)?
+  @assertion.assert_eq(left.to_list(), List::[1, 2, 3, 4])?
+  @assertion.assert_eq(right.to_list(), List::[6, 7, 8, 9])?
+}
+
+pub fn is_empty[T](self : ImmutableSet[T]) -> Bool {
+  match self {
+    Empty => true
+    _ => false
+  }
+}
+
+/// Whether value exists in ImmutableSet
+pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
+  match self {
+    Empty => false
+    Node(node) => {
+      let compare_result = value.compare(node.value)
+      compare_result == 0 || (if compare_result < 0 {
+        node.left
+      } else {
+        node.right
+      }).exists(value)
+    }
+  }
+}
+
+test "exists" {
+  @assertion.assert_true(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).exists(5),
+  )?
+}
+
+test "Mass data testing" {
+  
+}

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -34,62 +34,6 @@ pub fn ImmutableSet::new[T](value : T) -> ImmutableSet[T] {
   Node({ left: Empty, value, right: Empty, height: 1 })
 }
 
-// Convert a sorted list into a balanced binary search tree to facilitate subsequent search, insertion, and deletion operations.
-fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
-
-  // Recursively process the input list and build a balanced binary search tree based on the length n of the list.
-  fn sub(n : Int, list : List[T]) -> (ImmutableSet[T], List[T]) {
-    match (n, list) {
-      (0, list) => (Empty, list)
-      (1, Cons(value, list)) =>
-        (Node({ left: Empty, value, right: Empty, height: 1 }), list)
-      (2, Cons(value, Cons(value1, list))) =>
-        (
-          Node(
-            {
-              left: Node({ left: Empty, value, right: Empty, height: 1 }),
-              value: value1,
-              right: Empty,
-              height: 2,
-            },
-          ),
-          list,
-        )
-      (3, Cons(value, Cons(value1, Cons(value2, list)))) =>
-        (
-          Node(
-            {
-              left: Node({ left: Empty, value, right: Empty, height: 1 }),
-              value: value1,
-              right: Node(
-                { left: Empty, value: value2, right: Empty, height: 1 },
-              ),
-              height: 2,
-            },
-          ),
-          list,
-        )
-
-      // For n > 3, the function first calculates the size of the left subtree,
-      // and then recursively constructs the left subtree.
-      _ => {
-        let left_length = n / 2
-        let (left, list) = sub(left_length, list)
-        match list {
-          Nil => abort("of_sorted_list: cannot constructs the left subtree")
-          Cons(mid, list) => {
-            let (right, list) = sub(n - left_length - 1, list)
-            (create(left, mid, right), list)
-          }
-        }
-      }
-    }
-  }
-
-  let (set, _) = sub(list.length(), list)
-  set
-}
-
 /// Initialize an ImmutableSet[T] from a List[T], T : Compare
 pub fn ImmutableSet::from_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
   match list {
@@ -107,48 +51,6 @@ pub fn ImmutableSet::from_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
   }
 }
 
-test "from_list" {
-  @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
-    Node(
-      {
-        left: Node(
-          {
-            left: Node(
-              {
-                left: Node({ left: Empty, right: Empty, height: 1, value: 1 }),
-                right: Empty,
-                height: 2,
-                value: 2,
-              },
-            ),
-            right: Node({ left: Empty, right: Empty, height: 1, value: 4 }),
-            height: 3,
-            value: 3,
-          },
-        ),
-        right: Node(
-          {
-            left: Node(
-              {
-                left: Node({ left: Empty, right: Empty, height: 1, value: 6 }),
-                right: Empty,
-                height: 2,
-                value: 7,
-              },
-            ),
-            right: Node({ left: Empty, right: Empty, height: 1, value: 9 }),
-            height: 3,
-            value: 8,
-          },
-        ),
-        height: 4,
-        value: 5,
-      },
-    ),
-  )?
-}
-
 /// Convert ImmutableSet[T] to List[T], the result must be ordered.
 pub fn to_list[T](self : ImmutableSet[T]) -> List[T] {
   fn values_aux(set : ImmutableSet[T], list : List[T]) {
@@ -162,11 +64,162 @@ pub fn to_list[T](self : ImmutableSet[T]) -> List[T] {
   values_aux(self, Nil)
 }
 
-test "to_list" {
-  @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).to_list(),
-    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
-  )?
+/// Remove the smallest value,
+pub fn remove_min[T](self : ImmutableSet[T]) -> ImmutableSet[T] {
+  match self {
+    Empty => abort("remove_min: empty ImmutableSet")
+    Node(node) =>
+      match node.left {
+        Empty => node.right
+        _ => balance(node.left.remove_min(), node.value, node.right)
+      }
+  }
+}
+
+/// Insert a value into the ImmutableSet.
+pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
+  match self {
+    Empty => Node({ left: Empty, value, right: Empty, height: 1 })
+    Node(node) => {
+      let compare_result = value.compare(node.value)
+      if compare_result == 0 {
+        Node(node)
+      } else if compare_result < 0 {
+        let left = node.left.add(value)
+        if physical_equal(node.left, left) {
+          Node(node)
+        } else {
+          balance(left, node.value, node.right)
+        }
+      } else {
+        let right = node.right.add(value)
+        if physical_equal(right, node.right) {
+          Node(node)
+        } else {
+          balance(node.left, node.value, right)
+        }
+      }
+    }
+  }
+}
+
+pub fn remove[T : Compare](
+  self : ImmutableSet[T],
+  value : T
+) -> ImmutableSet[T] {
+  match self {
+    Empty => Empty
+    Node(node) => {
+      let compare_result = value.compare(node.value)
+      if compare_result == 0 {
+        node.left.merge(node.right)
+      } else if compare_result < 0 {
+        let left = node.left.remove(value)
+        if physical_equal(node.left, left) {
+          Node(node)
+        } else {
+          balance(left, node.value, node.right)
+        }
+      } else {
+        let right = node.right.remove(value)
+        if physical_equal(node.right, right) {
+          Node(node)
+        } else {
+          balance(node.left, node.value, right)
+        }
+      }
+    }
+  }
+}
+
+pub fn min[T](self : ImmutableSet[T]) -> T {
+  match self {
+    Empty => abort("min: there are no values in ImmutableSet.")
+    Node(node) =>
+      match node.left {
+        Empty => node.value
+        _ => node.left.min()
+      }
+  }
+}
+
+pub fn min_option[T](self : ImmutableSet[T]) -> Option[T] {
+  match self {
+    Empty => None
+    Node(node) =>
+      match node.left {
+        Empty => Some(node.value)
+        _ => node.left.min_option()
+      }
+  }
+}
+
+pub fn max[T](self : ImmutableSet[T]) -> T {
+  match self {
+    Empty => abort("max: there are no values in ImmutableSet.")
+    Node(node) =>
+      match node.right {
+        Empty => node.value
+        _ => node.right.max()
+      }
+  }
+}
+
+pub fn max_option[T](self : ImmutableSet[T]) -> Option[T] {
+  match self {
+    Empty => None
+    Node(node) =>
+      match node.right {
+        Empty => Some(node.value)
+        _ => node.right.max_option()
+      }
+  }
+}
+
+/// Returns a triple (left, present, right), left < divide < right
+/// present is false if self contains no element equal to divide, 
+/// or true if self contains an element equal to divide.
+pub fn split[T : Compare](
+  self : ImmutableSet[T],
+  divide : T
+) -> (ImmutableSet[T], Bool, ImmutableSet[T]) {
+  match self {
+    Empty => (Empty, false, Empty)
+    Node(node) => {
+      let compare_result = divide.compare(node.value)
+      if compare_result == 0 {
+        (node.left, true, node.right)
+      } else if compare_result < 0 {
+        let (left_left, present, right_left) = node.left.split(divide)
+        (left_left, present, join(right_left, node.value, node.right))
+      } else {
+        let (left_right, present, right_right) = node.right.split(divide)
+        (join(node.left, node.value, left_right), present, right_right)
+      }
+    }
+  }
+}
+
+pub fn is_empty[T](self : ImmutableSet[T]) -> Bool {
+  match self {
+    Empty => true
+    _ => false
+  }
+}
+
+/// Whether value exists in ImmutableSet
+pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
+  match self {
+    Empty => false
+    Node(node) => {
+      let compare_result = value.compare(node.value)
+      compare_result == 0 || (if compare_result < 0 {
+        node.left
+      } else {
+        node.right
+      }).exists(value)
+    }
+  }
 }
 
 /// Get the height of set.
@@ -175,13 +228,6 @@ fn height[T](self : ImmutableSet[T]) -> Int {
     Empty => 0
     Node(node) => node.height
   }
-}
-
-test "height" {
-  @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).height(),
-    4,
-  )?
 }
 
 /// Creates a new node.
@@ -330,16 +376,131 @@ fn concat[T](
   }
 }
 
-/// Remove the smallest value,
-pub fn remove_min[T](self : ImmutableSet[T]) -> ImmutableSet[T] {
-  match self {
-    Empty => abort("remove_min: empty ImmutableSet")
-    Node(node) =>
-      match node.left {
-        Empty => node.right
-        _ => balance(node.left.remove_min(), node.value, node.right)
+// Convert a sorted list into a balanced binary search tree to facilitate subsequent search, insertion, and deletion operations.
+fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
+
+  // Recursively process the input list and build a balanced binary search tree based on the length n of the list.
+  fn sub(n : Int, list : List[T]) -> (ImmutableSet[T], List[T]) {
+    match (n, list) {
+      (0, list) => (Empty, list)
+      (1, Cons(value, list)) =>
+        (Node({ left: Empty, value, right: Empty, height: 1 }), list)
+      (2, Cons(value, Cons(value1, list))) =>
+        (
+          Node(
+            {
+              left: Node({ left: Empty, value, right: Empty, height: 1 }),
+              value: value1,
+              right: Empty,
+              height: 2,
+            },
+          ),
+          list,
+        )
+      (3, Cons(value, Cons(value1, Cons(value2, list)))) =>
+        (
+          Node(
+            {
+              left: Node({ left: Empty, value, right: Empty, height: 1 }),
+              value: value1,
+              right: Node(
+                { left: Empty, value: value2, right: Empty, height: 1 },
+              ),
+              height: 2,
+            },
+          ),
+          list,
+        )
+
+      // For n > 3, the function first calculates the size of the left subtree,
+      // and then recursively constructs the left subtree.
+      _ => {
+        let left_length = n / 2
+        let (left, list) = sub(left_length, list)
+        match list {
+          Nil => abort("of_sorted_list: cannot constructs the left subtree")
+          Cons(mid, list) => {
+            let (right, list) = sub(n - left_length - 1, list)
+            (create(left, mid, right), list)
+          }
+        }
       }
+    }
   }
+
+  let (set, _) = sub(list.length(), list)
+  set
+}
+
+test "max" {
+  @assertion.assert_eq(
+    9,
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).max(),
+  )?
+}
+
+test "split" {
+  let (left, present, right) = ImmutableSet::from_list(
+    List::[7, 2, 9, 4, 5, 6, 3, 8, 1],
+  ).split(5)
+  @assertion.assert_true(present)?
+  @assertion.assert_eq(left.to_list(), List::[1, 2, 3, 4])?
+  @assertion.assert_eq(right.to_list(), List::[6, 7, 8, 9])?
+}
+
+test "exists" {
+  @assertion.assert_true(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).exists(5),
+  )?
+}
+
+test "from_list" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    Node(
+      {
+        left: Node(
+          {
+            left: Node(
+              {
+                left: Node({ left: Empty, right: Empty, height: 1, value: 1 }),
+                right: Empty,
+                height: 2,
+                value: 2,
+              },
+            ),
+            right: Node({ left: Empty, right: Empty, height: 1, value: 4 }),
+            height: 3,
+            value: 3,
+          },
+        ),
+        right: Node(
+          {
+            left: Node(
+              {
+                left: Node({ left: Empty, right: Empty, height: 1, value: 6 }),
+                right: Empty,
+                height: 2,
+                value: 7,
+              },
+            ),
+            right: Node({ left: Empty, right: Empty, height: 1, value: 9 }),
+            height: 3,
+            value: 8,
+          },
+        ),
+        height: 4,
+        value: 5,
+      },
+    ),
+  )?
+}
+
+test "to_list" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).to_list(),
+    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
+  )?
 }
 
 test "remove_min" {
@@ -357,67 +518,11 @@ test "remove_min" {
   )?
 }
 
-/// Insert a value into the ImmutableSet.
-pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
-  match self {
-    Empty => Node({ left: Empty, value, right: Empty, height: 1 })
-    Node(node) => {
-      let compare_result = value.compare(node.value)
-      if compare_result == 0 {
-        Node(node)
-      } else if compare_result < 0 {
-        let left = node.left.add(value)
-        if physical_equal(node.left, left) {
-          Node(node)
-        } else {
-          balance(left, node.value, node.right)
-        }
-      } else {
-        let right = node.right.add(value)
-        if physical_equal(right, node.right) {
-          Node(node)
-        } else {
-          balance(node.left, node.value, right)
-        }
-      }
-    }
-  }
-}
-
 test "add" {
   @assertion.assert_eq(
     ImmutableSet::from_list(List::[7, 2, 9, 4, 6, 3, 8, 1]).add(5).to_list(),
     List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
   )?
-}
-
-pub fn remove[T : Compare](
-  self : ImmutableSet[T],
-  value : T
-) -> ImmutableSet[T] {
-  match self {
-    Empty => Empty
-    Node(node) => {
-      let compare_result = value.compare(node.value)
-      if compare_result == 0 {
-        node.left.merge(node.right)
-      } else if compare_result < 0 {
-        let left = node.left.remove(value)
-        if physical_equal(node.left, left) {
-          Node(node)
-        } else {
-          balance(left, node.value, node.right)
-        }
-      } else {
-        let right = node.right.remove(value)
-        if physical_equal(node.right, right) {
-          Node(node)
-        } else {
-          balance(node.left, node.value, right)
-        }
-      }
-    }
-  }
 }
 
 test "remove" {
@@ -427,125 +532,9 @@ test "remove" {
   )?
 }
 
-pub fn min[T](self : ImmutableSet[T]) -> T {
-  match self {
-    Empty => abort("min: there are no values in ImmutableSet.")
-    Node(node) =>
-      match node.left {
-        Empty => node.value
-        _ => node.left.min()
-      }
-  }
-}
-
 test "min" {
   @assertion.assert_eq(
     1,
     ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).min(),
   )?
-}
-
-pub fn min_option[T](self : ImmutableSet[T]) -> Option[T] {
-  match self {
-    Empty => None
-    Node(node) =>
-      match node.left {
-        Empty => Some(node.value)
-        _ => node.left.min_option()
-      }
-  }
-}
-
-pub fn max[T](self : ImmutableSet[T]) -> T {
-  match self {
-    Empty => abort("max: there are no values in ImmutableSet.")
-    Node(node) =>
-      match node.right {
-        Empty => node.value
-        _ => node.right.max()
-      }
-  }
-}
-
-test "max" {
-  @assertion.assert_eq(
-    9,
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).max(),
-  )?
-}
-
-pub fn max_option[T](self : ImmutableSet[T]) -> Option[T] {
-  match self {
-    Empty => None
-    Node(node) =>
-      match node.right {
-        Empty => Some(node.value)
-        _ => node.right.max_option()
-      }
-  }
-}
-
-/// Returns a triple (left, present, right), left < divide < right
-/// present is false if self contains no element equal to divide, 
-/// or true if self contains an element equal to divide.
-pub fn split[T : Compare](
-  self : ImmutableSet[T],
-  divide : T
-) -> (ImmutableSet[T], Bool, ImmutableSet[T]) {
-  match self {
-    Empty => (Empty, false, Empty)
-    Node(node) => {
-      let compare_result = divide.compare(node.value)
-      if compare_result == 0 {
-        (node.left, true, node.right)
-      } else if compare_result < 0 {
-        let (left_left, present, right_left) = node.left.split(divide)
-        (left_left, present, join(right_left, node.value, node.right))
-      } else {
-        let (left_right, present, right_right) = node.right.split(divide)
-        (join(node.left, node.value, left_right), present, right_right)
-      }
-    }
-  }
-}
-
-test "split" {
-  let (left, present, right) = ImmutableSet::from_list(
-    List::[7, 2, 9, 4, 5, 6, 3, 8, 1],
-  ).split(5)
-  @assertion.assert_true(present)?
-  @assertion.assert_eq(left.to_list(), List::[1, 2, 3, 4])?
-  @assertion.assert_eq(right.to_list(), List::[6, 7, 8, 9])?
-}
-
-pub fn is_empty[T](self : ImmutableSet[T]) -> Bool {
-  match self {
-    Empty => true
-    _ => false
-  }
-}
-
-/// Whether value exists in ImmutableSet
-pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
-  match self {
-    Empty => false
-    Node(node) => {
-      let compare_result = value.compare(node.value)
-      compare_result == 0 || (if compare_result < 0 {
-        node.left
-      } else {
-        node.right
-      }).exists(value)
-    }
-  }
-}
-
-test "exists" {
-  @assertion.assert_true(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).exists(5),
-  )?
-}
-
-test "Mass data testing" {
-  
 }

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -30,7 +30,7 @@ priv struct Node[T] {
 } derive(Default, Show, Debug, Eq)
 
 /// Returns the one-value ImmutableSet containing only `value`.
-pub fn ImmutableSet::new[T](value : T) -> ImmutableSet[T] {
+pub fn ImmutableSet::from_value[T : Compare](value : T) -> ImmutableSet[T] {
   Node({ left: Empty, value, right: Empty, height: 1 })
 }
 
@@ -39,20 +39,23 @@ pub fn ImmutableSet::from_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
   match list {
     Nil => Empty
     // For very small lists, adding values to the set directly using the add function is much faster than sorting and de-important the entire list.
-    Cons(value, Nil) => ImmutableSet::new(value)
-    Cons(value, Cons(value1, Nil)) => ImmutableSet::new(value).add(value1)
+    Cons(value, Nil) => ImmutableSet::from_value(value)
+    Cons(value, Cons(value1, Nil)) =>
+      ImmutableSet::from_value(value).add(value1)
     Cons(value, Cons(value1, Cons(value2, Nil))) =>
-      ImmutableSet::new(value).add(value1).add(value2)
+      ImmutableSet::from_value(value).add(value1).add(value2)
     Cons(value, Cons(value1, Cons(value2, Cons(value3, Nil)))) =>
-      ImmutableSet::new(value).add(value1).add(value2).add(value3)
+      ImmutableSet::from_value(value).add(value1).add(value2).add(value3)
     Cons(value, Cons(value1, Cons(value2, Cons(value3, Cons(value4, Nil))))) =>
-      ImmutableSet::new(value).add(value1).add(value2).add(value3).add(value4)
+      ImmutableSet::from_value(value).add(value1).add(value2).add(value3).add(
+        value4,
+      )
     _ => of_sorted_list(list.sort())
   }
 }
 
 /// Convert ImmutableSet[T] to List[T], the result must be ordered.
-pub fn to_list[T](self : ImmutableSet[T]) -> List[T] {
+pub fn to_list[T : Compare](self : ImmutableSet[T]) -> List[T] {
   fn values_aux(set : ImmutableSet[T], list : List[T]) {
     match set {
       Empty => list
@@ -65,7 +68,14 @@ pub fn to_list[T](self : ImmutableSet[T]) -> List[T] {
 }
 
 /// Remove the smallest value,
-pub fn remove_min[T](self : ImmutableSet[T]) -> ImmutableSet[T] {
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[3, 4, 5]).remove_min().to_list())
+/// // output: Cons(4, Cons(5, Nil))
+/// ```
+pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
   match self {
     Empty => abort("remove_min: empty ImmutableSet")
     Node({ left, right, value, height: _ }) =>
@@ -77,6 +87,13 @@ pub fn remove_min[T](self : ImmutableSet[T]) -> ImmutableSet[T] {
 }
 
 /// Insert a value into the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[6, 3, 8, 1]).add(5).to_list())
+/// // output: Cons(1, Cons(3, Cons(5, Cons(6, Cons(8, Nil)))))
+/// ```
 pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
     Empty => Node({ left: Empty, value, right: Empty, height: 1 })
@@ -103,6 +120,14 @@ pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   }
 }
 
+/// Remove n value from the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[3, 8, 1]).remove(8).to_list())
+/// // output: Cons(1, Cons(3, Nil))
+/// ```
 pub fn remove[T : Compare](
   self : ImmutableSet[T],
   value : T
@@ -132,7 +157,15 @@ pub fn remove[T : Compare](
   }
 }
 
-pub fn min[T](self : ImmutableSet[T]) -> T {
+/// Returns the smallest value in the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).min())
+/// // output: 1
+/// ```
+pub fn min[T : Compare](self : ImmutableSet[T]) -> T {
   match self {
     Empty => abort("min: there are no values in ImmutableSet.")
     Node(node) =>
@@ -143,7 +176,9 @@ pub fn min[T](self : ImmutableSet[T]) -> T {
   }
 }
 
-pub fn min_option[T](self : ImmutableSet[T]) -> Option[T] {
+/// Returns the smallest value in the ImmutableSet.
+/// But returns None when the value does not exist.
+pub fn min_option[T : Compare](self : ImmutableSet[T]) -> Option[T] {
   match self {
     Empty => None
     Node(node) =>
@@ -154,7 +189,15 @@ pub fn min_option[T](self : ImmutableSet[T]) -> Option[T] {
   }
 }
 
-pub fn max[T](self : ImmutableSet[T]) -> T {
+/// Returns the largest value in the ImmutableSet.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).max())
+/// // output: 9
+/// ```
+pub fn max[T : Compare](self : ImmutableSet[T]) -> T {
   match self {
     Empty => abort("max: there are no values in ImmutableSet.")
     Node(node) =>
@@ -165,7 +208,9 @@ pub fn max[T](self : ImmutableSet[T]) -> T {
   }
 }
 
-pub fn max_option[T](self : ImmutableSet[T]) -> Option[T] {
+/// Returns the largest value in the ImmutableSet.
+/// But returns None when the value does not exist.
+pub fn max_option[T : Compare](self : ImmutableSet[T]) -> Option[T] {
   match self {
     Empty => None
     Node(node) =>
@@ -176,9 +221,18 @@ pub fn max_option[T](self : ImmutableSet[T]) -> Option[T] {
   }
 }
 
-/// Returns a triple (left, present, right), left < divide < right
-/// present is false if self contains no element equal to divide, 
-/// or true if self contains an element equal to divide.
+/// Returns a triple (left, present, right), where left < divide < right.
+/// present == false if self contains no value equal to divide, 
+/// present == true  if self contains an value equal to divide.
+/// 
+/// # Example
+/// 
+/// ```
+/// let (left, present, right) = ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1],).split(5)
+/// println(present) // output: true
+/// println(left.to_list()) // output: Cons(1, Cons(2, Cons(3, Cons(4, Nil))))
+/// println(right.to_list()) // output: Cons(6, Cons(7, Cons(8, Cons(9, Nil))))
+/// ```
 pub fn split[T : Compare](
   self : ImmutableSet[T],
   divide : T
@@ -200,14 +254,15 @@ pub fn split[T : Compare](
   }
 }
 
-pub fn is_empty[T](self : ImmutableSet[T]) -> Bool {
+/// Returns true if ImmutableSet is empty
+pub fn is_empty[T : Compare](self : ImmutableSet[T]) -> Bool {
   match self {
     Empty => true
     _ => false
   }
 }
 
-/// Whether value exists in ImmutableSet
+/// Return true if value exists in ImmutableSet
 pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
   match self {
     Empty => false
@@ -222,13 +277,23 @@ pub fn exists[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
   }
 }
 
+/// Returns the union of self and other.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[3, 4, 5])
+///           .union(ImmutableSet::from_list(List::[4, 5, 6]))
+///           .to_list())
+/// // output: Cons(3, Cons(4, Cons(5, Cons(6, Nil))))
+/// ```
 pub fn union[T : Compare](
   self : ImmutableSet[T],
   other : ImmutableSet[T]
 ) -> ImmutableSet[T] {
   match (self, other) {
-    (Empty, other) => other
-    (self, Empty) => self
+    (Empty, _) => other
+    (_, Empty) => self
     (
       Node({ left: l1, value: v1, right: r1, height: h1 }),
       Node({ left: l2, value: v2, right: r2, height: h2 }),
@@ -249,23 +314,151 @@ pub fn union[T : Compare](
   }
 }
 
-// pub fn diff[T](
-//   self : ImmutableSet[T],
-//   other : ImmutableSet[T]
-// ) -> ImmutableSet[T] {
-// 
-// }
-// 
-// pub fn disjoint[T](self : ImmutableSet[T], other : ImmutableSet[T]) -> Bool {
-// 
-// }
-// 
-// pub fn elements[T](self : ImmutableSet[T]) -> Int {
-// 
-// }
+/// Returns the intersection of self with other.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[3, 4, 5])
+///           .inter(ImmutableSet::from_list(List::[4, 5, 6]))
+///           .to_list())
+/// // output: Cons(4, Cons(5, Nil))
+/// ```
+pub fn inter[T : Compare](
+  self : ImmutableSet[T],
+  other : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  match (self, other) {
+    (Empty, _) | (_, Empty) => Empty
+    (Node({ left: l1, value: v1, right: r1, height: _ }), _) =>
+      match other.split(v1) {
+        (l2, false, r2) => l1.inter(l2).concat(r1.inter(r2))
+        (l2, true, r2) => join(l1.inter(l2), v1, r1.inter(r2))
+      }
+  }
+}
+
+/// Returns the difference between self and other.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 2, 3])
+///           .diff(ImmutableSet::from_list(List::[4, 5, 1]))
+///           .to_list())
+/// // output: Cons(2, Cons(3, Nil))
+/// ```
+pub fn diff[T : Compare](
+  self : ImmutableSet[T],
+  other : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  match (self, other) {
+    (Empty, _) => Empty
+    (_, Empty) => self
+    (Node({ left: l1, value: v1, right: r1, height: _ }), _) =>
+      match other.split(v1) {
+        (l2, false, r2) => join(l1.diff(l2), v1, r1.diff(r2))
+        (l2, true, r2) => l1.diff(l2).concat(r1.diff(r2))
+      }
+  }
+}
+
+/// Returns true if self is a subset of other.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 2, 3]).subset(
+///   ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]))))
+/// // output: true
+/// ```
+pub fn subset[T : Compare](
+  self : ImmutableSet[T],
+  other : ImmutableSet[T]
+) -> Bool {
+  match (self, other) {
+    (Empty, _) => true
+    (_, Empty) => false
+    (
+      Node({ left: l1, value: v1, right: r1, height: _ }),
+      Node({ left: l2, value: v2, right: r2, height: _ }) as node,
+    ) => {
+      let compare_result = v1.compare(v2)
+      if compare_result == 0 {
+        l1.subset(l2) && r1.subset(r2)
+      } else if compare_result < 0 {
+        Node::new(l1, v1, Empty, 0).subset(l2) && r1.subset(node)
+      } else {
+        Node::new(Empty, v1, r1, 0).subset(r2) && l1.subset(node)
+      }
+    }
+  }
+}
+
+/// Returns true if the two sets do not intersect.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(ImmutableSet::from_list(List::[1, 2, 3]).disjoint(
+///    ImmutableSet::from_list(List::[4, 5, 6]))))
+/// // output: true
+/// ```
+pub fn disjoint[T : Compare](
+  self : ImmutableSet[T],
+  other : ImmutableSet[T]
+) -> Bool {
+  match (self, other) {
+    (Empty, _) | (_, Empty) => true
+    (Node({ left: l1, value: v1, right: r1, height: _ }), _) =>
+      if physical_equal(self, other) {
+        false
+      } else {
+        match other.split_bis(v1) {
+          NotFound(l2, r2) => l1.disjoint(l2) && r1.disjoint(r2())
+          Found => false
+        }
+      }
+  }
+}
+
+// The following are the helper functions or types used by the internal implementation of ImmutableSet
+
+priv enum SplitBis[T] {
+  Found
+  NotFound(ImmutableSet[T], () -> ImmutableSet[T])
+}
+
+/// Same as split, but compute the left and right only if the pivot value is not in the ImmutableSet.
+/// The right is computed on demand.
+fn split_bis[T : Compare](self : ImmutableSet[T], value : T) -> SplitBis[T] {
+  match self {
+    Empty => NotFound(Empty, fn() -> ImmutableSet[T] { Empty })
+    Node({ left, value: node_value, right, height: _ }) => {
+      let compare_result = value.compare(node_value)
+      if compare_result == 0 {
+        Found
+      } else if compare_result < 0 {
+        match left.split_bis(value) {
+          Found => Found
+          NotFound(ll, rl) =>
+            NotFound(
+              ll,
+              fn() -> ImmutableSet[T] { join(rl(), node_value, right) },
+            )
+        }
+      } else {
+        match right.split_bis(value) {
+          Found => Found
+          NotFound(lr, rr) => NotFound(join(left, node_value, lr), rr)
+        }
+      }
+    }
+  }
+}
 
 /// Get the height of set.
-fn height[T](self : ImmutableSet[T]) -> Int {
+fn height[T : Compare](self : ImmutableSet[T]) -> Int {
   match self {
     Empty => 0
     Node(node) => node.height
@@ -273,7 +466,7 @@ fn height[T](self : ImmutableSet[T]) -> Int {
 }
 
 /// Creates a new node.
-fn create[T](
+fn create[T : Compare](
   left : ImmutableSet[T],
   value : T,
   right : ImmutableSet[T]
@@ -294,8 +487,17 @@ fn create[T](
   )
 }
 
+fn Node::new[T : Compare](
+  left : ImmutableSet[T],
+  value : T,
+  right : ImmutableSet[T],
+  height : Int
+) -> ImmutableSet[T] {
+  Node({ left, value, right, height })
+}
+
 /// Same as create, but performs one step of rebalancing if necessary.
-fn balance[T](
+fn balance[T : Compare](
   left : ImmutableSet[T],
   value : T,
   right : ImmutableSet[T]
@@ -346,24 +548,30 @@ fn balance[T](
   }
 }
 
-fn add_min_value[T](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
+fn add_min_value[T : Compare](
+  self : ImmutableSet[T],
+  value : T
+) -> ImmutableSet[T] {
   match self {
-    Empty => new(value)
+    Empty => ImmutableSet::from_value(value)
     Node({ left, value: node_value, right, height: _ }) =>
       balance(left.add_min_value(value), node_value, right)
   }
 }
 
-fn add_max_value[T](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
+fn add_max_value[T : Compare](
+  self : ImmutableSet[T],
+  value : T
+) -> ImmutableSet[T] {
   match self {
-    Empty => new(value)
+    Empty => ImmutableSet::from_value(value)
     Node({ left, value: node_value, right, height: _ }) =>
       balance(left, node_value, right.add_max_value(value))
   }
 }
 
 /// Same as create and balance, but no assumptions are made on the relative heights of left and right.
-fn join[T](
+fn join[T : Compare](
   left : ImmutableSet[T],
   value : T,
   right : ImmutableSet[T]
@@ -387,23 +595,26 @@ fn join[T](
 
 /// Merge two ImmutableSet[T] into one. 
 /// All values of left must precede the values of r.
-fn merge[T](self : ImmutableSet[T], other : ImmutableSet[T]) -> ImmutableSet[T] {
-  match (self, other) {
-    (Empty, other) => other
-    (self, Empty) => self
-    (_, _) => balance(self, other.min(), other.remove_min())
-  }
-}
-
-/// Same as merge, but no assumption on the heights of self and other.
-fn concat[T](
+fn merge[T : Compare](
   self : ImmutableSet[T],
   other : ImmutableSet[T]
 ) -> ImmutableSet[T] {
   match (self, other) {
-    (Empty, other) => other
-    (self, Empty) => self
-    (_, _) => join(self, other.min(), other.remove_min())
+    (Empty, _) => other
+    (_, Empty) => self
+    _ => balance(self, other.min(), other.remove_min())
+  }
+}
+
+/// Same as merge, but no assumption on the heights of self and other.
+fn concat[T : Compare](
+  self : ImmutableSet[T],
+  other : ImmutableSet[T]
+) -> ImmutableSet[T] {
+  match (self, other) {
+    (Empty, _) => other
+    (_, Empty) => self
+    _ => join(self, other.min(), other.remove_min())
   }
 }
 
@@ -461,6 +672,50 @@ fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
 
   let (set, _) = sub(list.length(), list)
   set
+}
+
+test "disjoint" {
+  @assertion.assert_true(
+    ImmutableSet::from_list(List::[1, 2, 3]).disjoint(
+      ImmutableSet::from_list(List::[4, 5, 6]),
+    ),
+  )?
+  @assertion.assert_false(
+    ImmutableSet::from_list(List::[1, 2, 3]).subset(
+      ImmutableSet::from_list(List::[3, 4, 5]),
+    ),
+  )?
+}
+
+test "subset" {
+  @assertion.assert_true(
+    ImmutableSet::from_list(List::[1, 2, 3]).subset(
+      ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    ),
+  )?
+  @assertion.assert_false(
+    ImmutableSet::from_list(List::[1, 2, 3]).subset(
+      ImmutableSet::from_list(List::[10, 11, 12, 13, 14]),
+    ),
+  )?
+}
+
+test "diff" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[1, 2, 3]).diff(
+      ImmutableSet::from_list(List::[4, 5, 1]),
+    ).to_list(),
+    List::[2, 3],
+  )?
+}
+
+test "inter" {
+  @assertion.assert_eq(
+    ImmutableSet::from_list(List::[3, 4, 5]).inter(
+      ImmutableSet::from_list(List::[4, 5, 6]),
+    ).to_list(),
+    List::[4, 5],
+  )?
 }
 
 test "union" {
@@ -550,18 +805,8 @@ test "to_list" {
 }
 
 test "remove_min" {
-  let set = create(ImmutableSet::new(1), 3, ImmutableSet::new(2)).remove_min()
-  @assertion.assert_eq(
-    set,
-    Node(
-      {
-        left: Empty,
-        right: Node({ left: Empty, right: Empty, height: 1, value: 2 }),
-        height: 2,
-        value: 3,
-      },
-    ),
-  )?
+  let set = ImmutableSet::from_list(List::[3, 4, 5]).remove_min()
+  @assertion.assert_eq(set.to_list(), List::[4, 5])?
 }
 
 test "add" {

--- a/immutable_set/moon.pkg.json
+++ b/immutable_set/moon.pkg.json
@@ -1,0 +1,16 @@
+{
+    "import": [
+        {
+            "path": "moonbitlang/core/assertion",
+            "alias": "assertion"
+        },
+        {
+            "path": "moonbitlang/core/list",
+            "alias": "list"
+        },
+        {
+            "path": "moonbitlang/core/array",
+            "alias": "array"
+        }
+    ]
+}


### PR DESCRIPTION
> When creating this PR, I found that the work of immutable_set seems to partially overlap with #53 

This PR implements a set data structure without side effects based on a balanced binary tree, this means the add and find value take time logarithmic in the size of the set.