### PR TITLE
add immutable hash map data structure

### DIFF
--- a/immutable_hashmap/HAMT.mbt
+++ b/immutable_hashmap/HAMT.mbt
@@ -1,0 +1,242 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An implementation of HAMT (Hash Array Mapped Trie) in MoonBit.
+//
+// Hash-Array-Mapped-Trie (HAMT) is a persistent hash-table data structure.
+// It is a trie over the hash of keys (i.e. strings of binary digits)
+// 
+// Every level in a HAMT can have up to 32 branches (5 digits),
+// so HAMT has a tree height of at most 7,
+// and is more efficient compared to most other tree data structures.
+// 
+// HAMT uses bitmap-based sparse array to avoid space waste
+// 
+// Some references:
+// - <https://handwiki.org/wiki/Hash%20array%20mapped%20trie>
+// - <https://lampwww.epfl.ch/papers/idealhashtrees.pdf>
+
+/// An immutable hash-map data structure
+enum Map[K, V] {
+  Empty
+  Leaf(K, V) // optimize for the case of no collision
+  Collision(Bucket[K, V]) // use a list of buckets to resolve collision
+  Branch(Sparse_Array[Map[K, V]])
+}
+
+// The number of bits consumed at every [Branch] node
+let segment_length : Int = 5
+
+pub fn Map::make[K, V]() -> Map[K, V] {
+  Empty
+}
+
+/// Lookup a key from a hash map
+pub fn find[K : Eq + Hash, V](self : Map[K, V], key : K) -> Option[V] {
+  loop self, key.hash() {
+    Empty, _ => None
+    Leaf(key1, value), _ => if key == key1 { Some(value) } else { None }
+    Collision(bucket), _ => bucket.find(key)
+    Branch(children), hash => {
+      // get the first segment (lower 5 bits) of the hash value
+      let idx = hash.land((1).lsl(segment_length) - 1)
+      match children[idx] {
+        Some(child) =>
+          // when searching recursively, drop the segment just used
+          continue child, hash.lsr(segment_length)
+        None => None
+      }
+    }
+  }
+}
+
+fn add_with_hash[K : Eq, V](
+  self : Map[K, V],
+  key : K,
+  depth : Int,
+  hash : Int,
+  value : V
+) -> Map[K, V] {
+  // make sure leaf nodes always appear at the bottom of the tree
+  fn make_leaf(depth : Int, key : K, hash : Int, value : V) {
+    if depth >= 32 {
+      Map::Leaf(key, value)
+    } else {
+      let idx = hash.land((1).lsl(segment_length) - 1)
+      let child = make_leaf(
+        depth + segment_length,
+        key,
+        hash.lsr(segment_length),
+        value,
+      )
+      Map::Branch(Sparse_Array::make(idx, child))
+    }
+  }
+
+  match self {
+    Empty => make_leaf(depth, key, hash, value)
+    Leaf(key1, value1) =>
+      if key == key1 {
+        Leaf(key, value)
+      } else {
+        Collision(More(key, value, Just_One(key1, value1)))
+      }
+    Collision(bucket) => Collision(bucket.add(key, value))
+    Branch(children) => {
+      let idx = hash.land((1).lsl(segment_length) - 1)
+      match children[idx] {
+        Some(child) => {
+          let child = child.add_with_hash(
+            key,
+            depth + segment_length,
+            hash.lsr(segment_length),
+            value,
+          )
+          Branch(children.replace(idx, child))
+        }
+        None => {
+          let child = make_leaf(
+            depth + segment_length,
+            key,
+            hash.lsr(segment_length),
+            value,
+          )
+          Branch(children.add(idx, child))
+        }
+      }
+    }
+  }
+}
+
+/// Add a key-value pair to the hashmap.
+///
+/// If a pair with the same key already exists, the old one is replaced
+pub fn add[K : Eq + Hash, V](self : Map[K, V], key : K, value : V) -> Map[K, V] {
+  self.add_with_hash(key, 0, key.hash(), value)
+}
+
+test "HAMT" {
+  let map = loop 0, Map::make() {
+    100, map => map
+    i, map => continue i + 1, map.add(i, i)
+  }
+  for i = 0; i < 100; i = i + 1 {
+    @assertion.assert_eq((i, map.find(i)), (i, Some(i)))?
+  }
+  @assertion.assert_eq((100, map.find(100)), (100, None))?
+  let map = map.add(100, 100)
+  @assertion.assert_eq((100, map.find(100)), (100, Some(100)))?
+  // test for replacement
+  let map = loop 0, map {
+    100, map => map
+    i, map => continue i + 2, map.add(i, i + 1)
+  }
+  for i = 0; i < 100; i = i + 2 {
+    @assertion.assert_eq((i, map.find(i)), (i, Some(i + 1)))?
+    @assertion.assert_eq((i + 1, map.find(i + 1)), (i + 1, Some(i + 1)))?
+  }
+}
+
+/// Calculate the size of a map.
+///
+/// WARNING: this operation is `O(N)` in map size
+pub fn size[K, V](self : Map[K, V]) -> Int {
+  match self {
+    Empty => 0
+    Leaf(_) => 1
+    Collision(bucket) => bucket.size()
+    Branch(children) => {
+      let mut total_size = 0
+      for i = 0; i < children.data.length(); i = i + 1 {
+        total_size = total_size + children.data[i].size()
+      }
+      total_size
+    }
+  }
+}
+
+test "HAMT::size" {
+  for i = 0, map = Map::make(); i < 20; i = i + 1, map = map.add(i, i) {
+    @assertion.assert_eq(map.size(), i)?
+  } else {
+    @assertion.assert_eq(map.add(0, 0).size(), 20)?
+  }
+}
+
+/// Iterate through the elements in a hash map
+pub fn iter[K, V](self : Map[K, V], f : (K, V) -> Unit) -> Unit {
+  match self {
+    Empty => ()
+    Leaf(k, v) => f(k, v)
+    Collision(bucket) => bucket.iter(f)
+    Branch(children) => children.iter(fn { child => child.iter(f) })
+  }
+}
+
+pub fn debug_write[K : Debug, V : Debug](
+  self : Map[K, V],
+  buf : Buffer
+) -> Unit {
+  let mut is_first = true
+  buf.write_string("@immutable_hashmap.Map::[")
+  self.iter(
+    fn(k, v) {
+      if is_first {
+        is_first = false
+      } else {
+        buf.write_string(", ")
+      }
+      buf.write_string("(")
+      k.debug_write(buf)
+      buf.write_string(", ")
+      v.debug_write(buf)
+      buf.write_string(")")
+    },
+  )
+  buf.write_string("]")
+}
+
+pub fn to_string[K : Debug, V : Debug](self : Map[K, V]) -> String {
+  let buf = Buffer::make(0)
+  self.debug_write(buf)
+  buf.to_string()
+}
+
+test "HAMT::to_string" {
+  let map = Map::make().add(1, 1).add(3, 3).add(0x0f_ff_ff_ff, 0x0f_ff_ff_ff).add(
+    42, 42,
+  )
+  @assertion.assert_eq(
+    map.to_string(),
+    "@immutable_hashmap.Map::[(1, 1), (3, 3), (42, 42), (268435455, 268435455)]",
+  )?
+}
+
+pub fn Map::from_array[K : Eq + Hash, V](arr : Array[(K, V)]) -> Map[K, V] {
+  loop arr.length(), Map::make() {
+    0, map => map
+    n, map => {
+      let (k, v) = arr[n - 1]
+      continue n - 1, map.add(k, v)
+    }
+  }
+}
+
+test "HAMT::from_array" {
+  let map = Map::[(1, "1"), (2, "2"), (42, "42")]
+  @assertion.assert_eq((1, map.find(1)), (1, Some("1")))?
+  @assertion.assert_eq((2, map.find(2)), (2, Some("2")))?
+  @assertion.assert_eq((42, map.find(42)), (42, Some("42")))?
+  @assertion.assert_eq((43, map.find(43)), (43, None))?
+}

--- a/immutable_hashmap/HAMT.mbt
+++ b/immutable_hashmap/HAMT.mbt
@@ -32,7 +32,7 @@ enum Map[K, V] {
   Empty
   Leaf(K, V) // optimize for the case of no collision
   Collision(Bucket[K, V]) // use a list of buckets to resolve collision
-  Branch(Sparse_Array[Map[K, V]])
+  Branch(SparseArray[Map[K, V]])
 }
 
 // The number of bits consumed at every [Branch] node
@@ -80,7 +80,7 @@ fn add_with_hash[K : Eq, V](
         hash.lsr(segment_length),
         value,
       )
-      Map::Branch(Sparse_Array::make(idx, child))
+      Map::Branch(SparseArray::make(idx, child))
     }
   }
 

--- a/immutable_hashmap/README.md
+++ b/immutable_hashmap/README.md
@@ -1,0 +1,17 @@
+This package provides an immutable hash map data structure.
+
+## Basic usage
+```
+test {
+  let h =
+    @immutable_hashmap.empty()
+    .add(1, 1)
+    .add(2, 2)
+  let h2 = h.add(3, 3)
+  @assert.assert_eq(h.find(3), None)
+  @assert.assert_eq(h2.find(3), Some(3))
+}
+```
+
+## TODO
+More API, in particular removal.

--- a/immutable_hashmap/bitset.mbt
+++ b/immutable_hashmap/bitset.mbt
@@ -1,0 +1,127 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// a simple bit set to store a set of integers less than 32
+priv type Bitset Int
+
+let empty_bitset : Bitset = Bitset(0)
+
+/// `has(self: Bitset, idx: Int)`
+///
+/// Check if the given index is present in the bitset.
+fn has(self : Bitset, idx : Int) -> Bool {
+  self.0.land((1).lsl(idx)) != 0
+}
+
+test "Bitset::has" {
+  let b = empty_bitset.add(2)
+  @assertion.assert_false(b.has(0))?
+  @assertion.assert_true(b.has(2))?
+  let b = b.add(0)
+  @assertion.assert_true(b.has(0))?
+  @assertion.assert_true(b.has(2))?
+}
+
+/// `index_of(self: Bitset, idx: Int)`
+///
+/// Get the index of the bit in the bitset.
+fn index_of(self : Bitset, idx : Int) -> Int {
+  let items_below_idx = self.0.land((1).lsl(idx) - 1)
+  ctpop(items_below_idx)
+}
+
+test "Bitset::index_of" {
+  let b = empty_bitset.add(2)
+  @assertion.assert_eq(b.index_of(2), 0)?
+  let b = b.add(0)
+  @assertion.assert_eq(b.index_of(2), 1)?
+  let b = b.add(5)
+  @assertion.assert_eq(b.index_of(2), 1)?
+}
+
+/// `add(self: Bitset, idx: Int)`
+///
+/// Add a new index to the bitset.
+fn add(self : Bitset, idx : Int) -> Bitset {
+  Bitset(self.0.lor((1).lsl(idx)))
+}
+
+/// `remove(self: Bitset, idx: Int)`
+///
+/// Remove an index from the bitset.
+fn remove(self : Bitset, idx : Int) -> Bitset {
+  Bitset(self.0.lxor((1).lsl(idx)))
+}
+
+test "Bitset::remove" {
+  let b = empty_bitset.add(2).add(3)
+  @assertion.assert_true(b.has(2))?
+  @assertion.assert_true(b.has(3))?
+  @assertion.assert_eq(b.index_of(2), 0)?
+  @assertion.assert_eq(b.index_of(3), 1)?
+  let b = b.remove(2)
+  @assertion.assert_false(b.has(2))?
+  @assertion.assert_true(b.has(3))?
+  @assertion.assert_eq(b.index_of(3), 0)?
+}
+
+/// `size(self: Bitset) -> Int`
+///
+/// Calculate the size of a bitset
+fn size(self : Bitset) -> Int {
+  ctpop(self.0)
+}
+
+test "Bitset::size" {
+  let b = empty_bitset
+  @assertion.assert_eq(b.size(), 0)?
+  let b = b.add(0)
+  @assertion.assert_eq(b.size(), 1)?
+  let b = b.add(1)
+  @assertion.assert_eq(b.size(), 2)?
+  let b = b.add(1)
+  @assertion.assert_eq(b.size(), 2)?
+}
+
+/// `ctpop(n: Int)`
+///
+/// Count the number of set bits (1s) in a 32-bit integer.
+fn ctpop(n : Int) -> Int {
+  // extract the lower bit of every 2-bit group
+  let low_of_2bits = 0x55555555
+  // count the number of "1"s in every 2-bit group
+  // store the result in the same 2-bit group
+  let c2 = n.land(low_of_2bits) + n.lsr(1).land(low_of_2bits)
+  // count the number of "1"s in every 4-bit group (i.e. two 2-bit groups),
+  // store the result in the same 4-bit group
+  let low_of_4bits = 0x33333333
+  let c4 = c2.land(low_of_4bits) + c2.lsr(2).land(low_of_4bits)
+  // similarly for every 8-bit group
+  let low_of_8bits = 0x0f0f0f0f
+  let c8 = c4.land(low_of_8bits) + c4.lsr(4).land(low_of_8bits)
+  // 16-bit group.
+  // there will be only two groups left, without rist of overlapping,
+  // so there's no need to clean the unused higher bits
+  let c16 = c8 + c8.lsr(8)
+  // the final 32-bit group
+  // [ctpop(x) <= 32], so only the last 6 bits are meaningful
+  let lower_6bits = 63 // 0x3f
+  (c16 + c16.lsr(16)).land(lower_6bits)
+}
+
+test "Bitset::ctpop" {
+  @assertion.assert_eq(ctpop(0), 0)?
+  @assertion.assert_eq(ctpop(0xf0f0f0f0), 16)?
+  @assertion.assert_eq(ctpop(0x3c3c0ff0), 16)?
+}

--- a/immutable_hashmap/bucket.mbt
+++ b/immutable_hashmap/bucket.mbt
@@ -1,0 +1,103 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A bucket is a non-empty linked list of key-value pair,
+/// used to resolve hash collision in HAMT
+priv enum Bucket[K, V] {
+  Just_One(K, V) // must be non-empty
+  More(K, V, Bucket[K, V])
+}
+
+/// Lookup a key from the bucket
+fn find[K : Eq, V](self : Bucket[K, V], key : K) -> Option[V] {
+  match self {
+    Just_One(key1, value) => if key == key1 { Some(value) } else { None }
+    More(key1, value, rest) =>
+      if key == key1 {
+        Some(value)
+      } else {
+        rest.find(key)
+      }
+  }
+}
+
+/// Add a new key-value pair to a bucket.
+/// Replace the old entry if one with the same key already exists.
+fn add[K : Eq, V](self : Bucket[K, V], key : K, value : V) -> Bucket[K, V] {
+  match self {
+    Just_One(key1, _) =>
+      if key == key1 {
+        Just_One(key, value)
+      } else {
+        More(key, value, self)
+      }
+    More(key1, value1, rest) =>
+      if key == key1 {
+        More(key, value, rest)
+      } else {
+        More(key1, value1, rest.add(key, value))
+      }
+  }
+}
+
+/// Get the size of a bucket
+fn size[K, V](self : Bucket[K, V]) -> Int {
+  match self {
+    Just_One(_) => 1
+    More(_, _, rest) => rest.size() + 1
+  }
+}
+
+test "Bucket" {
+  let b : Bucket[_] = Just_One(0, 0)
+  @assertion.assert_eq(b.find(0), Some(0))?
+  @assertion.assert_eq(b.find(1), None)?
+  @assertion.assert_eq(b.size(), 1)?
+  let b = b.add(1, 1)
+  @assertion.assert_eq(b.find(0), Some(0))?
+  @assertion.assert_eq(b.find(1), Some(1))?
+  @assertion.assert_eq(b.size(), 2)?
+  let b = b.add(0, 2)
+  @assertion.assert_eq(b.find(0), Some(2))?
+  @assertion.assert_eq(b.find(1), Some(1))?
+  @assertion.assert_eq(b.size(), 2)?
+}
+
+/// Iterate through elements of a bucket
+fn iter[K, V](self : Bucket[K, V], f : (K, V) -> Unit) -> Unit {
+  loop self {
+    Just_One(k, v) => f(k, v)
+    More(k, v, rest) => {
+      f(k, v)
+      continue rest
+    }
+  }
+}
+
+test "Bucket::iter" {
+  let b : Bucket[_] = More(0, 0, More(1, 1, Just_One(31, 31)))
+  let buf = Buffer::make(0)
+  let mut is_first = true
+  b.iter(
+    fn(k, v) {
+      if is_first {
+        is_first = false
+      } else {
+        buf.write_string(", ")
+      }
+      buf.write_string("\(k) => \(v)")
+    },
+  )
+  @assertion.assert_eq(buf.to_string(), "0 => 0, 1 => 1, 31 => 31")?
+}

--- a/immutable_hashmap/moon.pkg.json
+++ b/immutable_hashmap/moon.pkg.json
@@ -1,0 +1,12 @@
+{
+    "import": [
+        {
+            "path": "moonbitlang/core/assertion",
+            "alias": "assertion"
+        },
+        {
+            "path": "moonbitlang/core/array",
+            "alias": "array"
+        }
+    ]
+}

--- a/immutable_hashmap/sparse_array.mbt
+++ b/immutable_hashmap/sparse_array.mbt
@@ -1,0 +1,129 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A sparse array with at most 32 elements, where elements are not required to have contiguous index.
+/// Empty elements don't waste any space, without losing constant-time access
+priv struct Sparse_Array[X] {
+  // record which elements are present
+  elem_info : Bitset
+  data : Array[X]
+}
+
+fn Sparse_Array::make[X](idx : Int, value : X) -> Sparse_Array[X] {
+  { elem_info: empty_bitset.add(idx), data: [value] }
+}
+
+fn has[X](self : Sparse_Array[X], idx : Int) -> Bool {
+  self.elem_info.has(idx)
+}
+
+fn op_get[X](self : Sparse_Array[X], idx : Int) -> Option[X] {
+  if self.elem_info.has(idx) {
+    Some(self.data[self.elem_info.index_of(idx)])
+  } else {
+    None
+  }
+}
+
+/// `add(self: Sparse_Array[X], idx: Int, value: X)`
+///
+/// Add a new element into the sparse array.
+/// [idx] must be absent from [self]
+fn add[X](self : Sparse_Array[X], idx : Int, value : X) -> Sparse_Array[X] {
+  let new_len = self.data.length() + 1
+  let pos_of_new_item = self.elem_info.index_of(idx)
+  let new_data = Array::make(new_len, value)
+  let mut i = 0
+  while i < pos_of_new_item {
+    new_data[i] = self.data[i]
+    i = i + 1
+  }
+  new_data[i] = value
+  i = i + 1
+  while i < new_len {
+    new_data[i] = self.data[i - 1]
+    i = i + 1
+  }
+  { elem_info: self.elem_info.add(idx), data: new_data }
+}
+
+/// `replace(self: Sparse_Array[X], idx: Int, value: X)`
+///
+// replace an existing element in the sparse array.
+fn replace[X](self : Sparse_Array[X], idx : Int, value : X) -> Sparse_Array[X] {
+  let len = self.data.length()
+  let pos_of_new_item = self.elem_info.index_of(idx)
+  let new_data = Array::make(len, value)
+  for i = 0; i < len; i = i + 1 {
+    new_data[i] = if i == pos_of_new_item { value } else { self.data[i] }
+  }
+  { elem_info: self.elem_info, data: new_data }
+}
+
+test "Sparse_Array" {
+  let arr = Sparse_Array::make(1, 1)
+  @assertion.assert_false(arr.has(0))?
+  @assertion.assert_eq(arr[0], None)?
+  @assertion.assert_true(arr.has(1))?
+  @assertion.assert_eq(arr[1], Some(1))?
+  @assertion.assert_false(arr.has(2))?
+  @assertion.assert_eq(arr[2], None)?
+  let arr = arr.add(2, 2)
+  @assertion.assert_false(arr.has(0))?
+  @assertion.assert_eq(arr[0], None)?
+  @assertion.assert_true(arr.has(1))?
+  @assertion.assert_eq(arr[1], Some(1))?
+  @assertion.assert_true(arr.has(2))?
+  @assertion.assert_eq(arr[2], Some(2))?
+  let arr = arr.add(0, 0)
+  @assertion.assert_true(arr.has(0))?
+  @assertion.assert_eq(arr[0], Some(0))?
+  @assertion.assert_true(arr.has(1))?
+  @assertion.assert_eq(arr[1], Some(1))?
+  @assertion.assert_true(arr.has(2))?
+  @assertion.assert_eq(arr[2], Some(2))?
+  let arr = arr.replace(1, 42)
+  @assertion.assert_true(arr.has(0))?
+  @assertion.assert_eq(arr[0], Some(0))?
+  @assertion.assert_true(arr.has(1))?
+  @assertion.assert_eq(arr[1], Some(42))?
+  @assertion.assert_true(arr.has(2))?
+  @assertion.assert_eq(arr[2], Some(2))?
+}
+
+/// `iter(self: Sparse_Array[X], f: (X) -> Unit) -> Unit`
+///
+/// Iterate through elements in a sparse array
+fn iter[X](self : Sparse_Array[X], f : (X) -> Unit) -> Unit {
+  for i = 0; i < self.elem_info.size(); i = i + 1 {
+    f(self.data[i])
+  }
+}
+
+test "Sparse_Array::iter" {
+  let arr = Sparse_Array::make(0, 0).add(1, 1).add(3, 3).add(31, 31)
+  let buf = Buffer::make(0)
+  let mut is_first = true
+  arr.iter(
+    fn(x) {
+      if is_first {
+        is_first = false
+      } else {
+        buf.write_string(", ")
+      }
+      buf.write_string(x.to_string())
+    },
+  )
+  @assertion.assert_eq(buf.to_string(), "0, 1, 3, 31")?
+}

--- a/immutable_hashmap/sparse_array.mbt
+++ b/immutable_hashmap/sparse_array.mbt
@@ -14,21 +14,21 @@
 
 /// A sparse array with at most 32 elements, where elements are not required to have contiguous index.
 /// Empty elements don't waste any space, without losing constant-time access
-priv struct Sparse_Array[X] {
+priv struct SparseArray[X] {
   // record which elements are present
   elem_info : Bitset
   data : Array[X]
 }
 
-fn Sparse_Array::make[X](idx : Int, value : X) -> Sparse_Array[X] {
+fn SparseArray::make[X](idx : Int, value : X) -> SparseArray[X] {
   { elem_info: empty_bitset.add(idx), data: [value] }
 }
 
-fn has[X](self : Sparse_Array[X], idx : Int) -> Bool {
+fn has[X](self : SparseArray[X], idx : Int) -> Bool {
   self.elem_info.has(idx)
 }
 
-fn op_get[X](self : Sparse_Array[X], idx : Int) -> Option[X] {
+fn op_get[X](self : SparseArray[X], idx : Int) -> Option[X] {
   if self.elem_info.has(idx) {
     Some(self.data[self.elem_info.index_of(idx)])
   } else {
@@ -36,11 +36,11 @@ fn op_get[X](self : Sparse_Array[X], idx : Int) -> Option[X] {
   }
 }
 
-/// `add(self: Sparse_Array[X], idx: Int, value: X)`
+/// `add(self: SparseArray[X], idx: Int, value: X)`
 ///
 /// Add a new element into the sparse array.
 /// [idx] must be absent from [self]
-fn add[X](self : Sparse_Array[X], idx : Int, value : X) -> Sparse_Array[X] {
+fn add[X](self : SparseArray[X], idx : Int, value : X) -> SparseArray[X] {
   let new_len = self.data.length() + 1
   let pos_of_new_item = self.elem_info.index_of(idx)
   let new_data = Array::make(new_len, value)
@@ -58,10 +58,10 @@ fn add[X](self : Sparse_Array[X], idx : Int, value : X) -> Sparse_Array[X] {
   { elem_info: self.elem_info.add(idx), data: new_data }
 }
 
-/// `replace(self: Sparse_Array[X], idx: Int, value: X)`
+/// `replace(self: SparseArray[X], idx: Int, value: X)`
 ///
 // replace an existing element in the sparse array.
-fn replace[X](self : Sparse_Array[X], idx : Int, value : X) -> Sparse_Array[X] {
+fn replace[X](self : SparseArray[X], idx : Int, value : X) -> SparseArray[X] {
   let len = self.data.length()
   let pos_of_new_item = self.elem_info.index_of(idx)
   let new_data = Array::make(len, value)
@@ -71,8 +71,8 @@ fn replace[X](self : Sparse_Array[X], idx : Int, value : X) -> Sparse_Array[X] {
   { elem_info: self.elem_info, data: new_data }
 }
 
-test "Sparse_Array" {
-  let arr = Sparse_Array::make(1, 1)
+test "SparseArray" {
+  let arr = SparseArray::make(1, 1)
   @assertion.assert_false(arr.has(0))?
   @assertion.assert_eq(arr[0], None)?
   @assertion.assert_true(arr.has(1))?
@@ -102,17 +102,17 @@ test "Sparse_Array" {
   @assertion.assert_eq(arr[2], Some(2))?
 }
 
-/// `iter(self: Sparse_Array[X], f: (X) -> Unit) -> Unit`
+/// `iter(self: SparseArray[X], f: (X) -> Unit) -> Unit`
 ///
 /// Iterate through elements in a sparse array
-fn iter[X](self : Sparse_Array[X], f : (X) -> Unit) -> Unit {
+fn iter[X](self : SparseArray[X], f : (X) -> Unit) -> Unit {
   for i = 0; i < self.elem_info.size(); i = i + 1 {
     f(self.data[i])
   }
 }
 
-test "Sparse_Array::iter" {
-  let arr = Sparse_Array::make(0, 0).add(1, 1).add(3, 3).add(31, 31)
+test "SparseArray::iter" {
+  let arr = SparseArray::make(0, 0).add(1, 1).add(3, 3).add(31, 31)
   let buf = Buffer::make(0)
   let mut is_first = true
   arr.iter(


### PR DESCRIPTION
add immutable hash map data structure, implemented using HAMT (Hash Array Mapped Trie). Most of the code come from the HAMT example on the playground, with some small tweaks and tests.