### PR TITLE
Tweak the hash map

### DIFF
--- a/hashmap/README.md
+++ b/hashmap/README.md
@@ -15,7 +15,7 @@ let map1 : HashMap[String, Int] = HashMap::new()
 let map2 = HashMap::[1, 2, 3, 4, 5]
 ```
 
-When creating via `new()`, you can set initial capacity and custom hasher by providing labeled argument `~capacity` and `~hasher`.
+When creating via `new()`, you can set initial capacity and custom hasher by providing labeled argument `~capacity` and `~hasher`. Note that the capacity must be a zero or a power of 2.
 
 ```moonbit
 // Create with custom hasher and capacity.

--- a/hashmap/README.md
+++ b/hashmap/README.md
@@ -15,11 +15,11 @@ let map1 : HashMap[String, Int] = HashMap::new()
 let map2 = HashMap::[1, 2, 3, 4, 5]
 ```
 
-When creating via `new()`, you can set initial capacity and custom hasher by providing labeled argument `~capacity` and `~hasher`. Note that the capacity must be a zero or a power of 2.
+When creating via `new()`, you can set a custom hasher by providing a labeled argument `~hasher`. 
 
 ```moonbit
-// Create with custom hasher and capacity.
-let map = HashMap::new(~capacity=32, ~hasher=Some(fn(k) { k.length() }))
+// Create with custom hasher.
+let map = HashMap::new(~hasher=Some(fn(k) { k.length() }))
 ```
 
 ### Set & Get

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -51,6 +51,9 @@ pub fn HashMap::new[K, V](
   ~capacity : Int = default_init_capacity,
   ~hasher : Option[(K) -> Int] = None
 ) -> HashMap[K, V] {
+  if capacity != 0 && not(is_power_of_two(capacity)) {
+    abort("The capacity is not a zero or a power of 2.")
+  }
   {
     size: 0,
     capacity,
@@ -58,6 +61,10 @@ pub fn HashMap::new[K, V](
     hasher,
     entries: @array.new(capacity, fn() { Empty }),
   }
+}
+
+fn is_power_of_two(n : Int) -> Bool {
+  n > 0 && n.land(n - 1) == 0
 }
 
 /// Create new hash map from array.

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -18,9 +18,36 @@ let default_init_capacity = 8
 enum Entry[K, V] {
   Empty
   // (Probe Sequence Length, Hash, Key, Value)
-  Valid((Int, Int, K, V))
+  Valid(Int, Int, K, V)
 } derive(Debug)
 
+fn psl[K, V](self : Entry[K, V]) -> Option[Int] {
+  match self {
+    Valid(psl, _, _, _) => Some(psl)
+    Empty => None
+  }
+}
+
+fn hash[K, V](self : Entry[K, V]) -> Option[Int] {
+  match self {
+    Valid(_, hash, _, _) => Some(hash)
+    Empty => None
+  }
+}
+
+fn key[K, V](self : Entry[K, V]) -> Option[K] {
+  match self {
+    Valid(_, _, k, _) => Some(k)
+    Empty => None
+  }
+}
+
+fn value[K, V](self : Entry[K, V]) -> Option[V] {
+  match self {
+    Valid(_, _, _, v) => Some(v)
+    Empty => None
+  }
+}
 /// A mutable hash map implements with Robin Hood hashing.
 /// 
 /// reference:
@@ -76,29 +103,34 @@ pub fn set[K : Hash + Eq, V](self : HashMap[K, V], key : K, value : V) -> Unit {
   }
   let hash = self.make_hash(key)
   let mut idx = self.index(hash)
-  let mut entry = (0, hash, key, value)
+  let mut entry : Entry[K, V] = Valid(0, hash, key, value)
   let mut i = 0
   while i < self.capacity {
     match self.entries[idx] {
       Empty => {
-        self.entries[idx] = Valid(entry)
+        self.entries[idx] = entry
         self.size += 1
         break
       }
-      Valid((d, h, k, v)) => {
-        if h == entry.1 && k == entry.2 {
-          self.entries[idx] = Valid((d, h, k, value))
+      Valid(d, h, k, v) => {
+        if h == entry.hash().unwrap() && k == entry.key().unwrap() {
+          self.entries[idx] = Valid(d, h, k, value)
           break
         }
-        if entry.0 > d {
-          let tmp = (d, h, k, v)
-          self.entries[idx] = Valid(entry)
+        if entry.psl().unwrap() > d {
+          let tmp : Entry[K, V] = Valid(d, h, k, v)
+          self.entries[idx] = entry
           entry = tmp
         }
       }
     }
     idx = self.next_index(idx)
-    entry = (entry.0 + 1, entry.1, entry.2, entry.3)
+    entry = Valid(
+      entry.psl().unwrap() + 1,
+      entry.hash().unwrap(),
+      entry.key().unwrap(),
+      entry.value().unwrap(),
+    )
     i += 1
   }
   if i == self.capacity {
@@ -120,7 +152,7 @@ pub fn get[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Option[V] {
   let mut idx = self.index(hash)
   for distance = 0; distance < self.capacity; distance = distance + 1 {
     match self.entries[idx] {
-      Valid((d, h, k, v)) => {
+      Valid(d, h, k, v) => {
         if h == hash && k == key {
           return Some(v)
         }
@@ -153,7 +185,7 @@ pub fn remove[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Unit {
   let mut idx = self.index(hash)
   for distance = 0; distance < self.capacity; distance = distance + 1 {
     match self.entries[idx] {
-      Valid((d, h, k, _)) => {
+      Valid(d, h, k, _) => {
         if h == hash && k == key {
           self.entries[idx] = Empty
           self.shift_back(idx)
@@ -195,7 +227,7 @@ pub fn iteri[K, V](self : HashMap[K, V], f : (Int, K, V) -> Unit) -> Unit {
   let mut idx = 0
   for i = 0; i < self.capacity; i = i + 1 {
     match self.entries[i] {
-      Valid((_, _, k, v)) => {
+      Valid(_, _, k, v) => {
         f(idx, k, v)
         idx += 1
       }
@@ -217,11 +249,11 @@ fn shift_back[K : Hash, V](self : HashMap[K, V], start_index : Int) -> Unit {
   let mut curr = self.next_index(prev)
   for i = 0; i < self.entries.length(); i = i + 1 {
     match self.entries[curr] {
-      Valid((d, h, k, v)) => {
+      Valid(d, h, k, v) => {
         if d == 0 {
           break
         }
-        self.entries[prev] = Valid((d - 1, h, k, v))
+        self.entries[prev] = Valid(d - 1, h, k, v)
         self.entries[curr] = Empty
       }
       Empty => break
@@ -247,19 +279,19 @@ fn grow[K : Hash + Eq, V](self : HashMap[K, V]) -> Unit {
   self.size = 0
   for i = 0; i < old_entries.length(); i = i + 1 {
     match old_entries[i] {
-      Valid((_, _, k, v)) => self.set(k, v)
+      Valid(_, _, k, v) => self.set(k, v)
       _ => ()
     }
   }
 }
 
 fn make_hash[K : Hash, V](self : HashMap[K, V], key : K) -> Int {
-  let hash: Int = match self.hasher {
+  let hash : Int = match self.hasher {
     Some(hasher) => hasher(key)
     None => key.hash()
   }
   // Let higher 16 bits of the hash value participate in the calculation
-  hash.lxor((hash.lsr(16)))
+  hash.lxor(hash.lsr(16))
 }
 
 fn index[K : Hash, V](self : HashMap[K, V], hash : Int) -> Int {
@@ -282,7 +314,7 @@ fn debug_entries[K : Show, V : Show](self : HashMap[K, V]) -> String {
     }
     match self.entries[i] {
       Empty => s += "_"
-      Valid((d, _h, k, v)) => s += "(\(d),\(k),\(v))"
+      Valid(d, _h, k, v) => s += "(\(d),\(k),\(v))"
     }
   }
   s

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -21,33 +21,6 @@ enum Entry[K, V] {
   Valid(Int, Int, K, V)
 } derive(Debug)
 
-fn psl[K, V](self : Entry[K, V]) -> Option[Int] {
-  match self {
-    Valid(psl, _, _, _) => Some(psl)
-    Empty => None
-  }
-}
-
-fn hash[K, V](self : Entry[K, V]) -> Option[Int] {
-  match self {
-    Valid(_, hash, _, _) => Some(hash)
-    Empty => None
-  }
-}
-
-fn key[K, V](self : Entry[K, V]) -> Option[K] {
-  match self {
-    Valid(_, _, k, _) => Some(k)
-    Empty => None
-  }
-}
-
-fn value[K, V](self : Entry[K, V]) -> Option[V] {
-  match self {
-    Valid(_, _, _, v) => Some(v)
-    Empty => None
-  }
-}
 /// A mutable hash map implements with Robin Hood hashing.
 /// 
 /// reference:
@@ -102,39 +75,30 @@ pub fn set[K : Hash + Eq, V](self : HashMap[K, V], key : K, value : V) -> Unit {
     self.grow()
   }
   let hash = self.make_hash(key)
-  let mut idx = self.index(hash)
-  let mut entry : Entry[K, V] = Valid(0, hash, key, value)
-  let mut i = 0
-  while i < self.capacity {
-    match self.entries[idx] {
-      Empty => {
-        self.entries[idx] = entry
-        self.size += 1
-        break
+  loop 0, self.index(hash), 0, hash, key, value {
+    i, idx, psl, hash, key, value => {
+      if i == self.capacity {
+        abort("HashMap is full")
       }
-      Valid(d, h, k, v) => {
-        if h == entry.hash().unwrap() && k == entry.key().unwrap() {
-          self.entries[idx] = Valid(d, h, k, value)
+      match self.entries[idx] {
+        Empty => {
+          self.entries[idx] = Entry::Valid(psl, hash, key, value)
+          self.size += 1
           break
         }
-        if entry.psl().unwrap() > d {
-          let tmp : Entry[K, V] = Valid(d, h, k, v)
-          self.entries[idx] = entry
-          entry = tmp
+        Valid(d, h, k, v) => {
+          if h == hash && k == key {
+            self.entries[idx] = Valid(d, h, k, value)
+            break
+          }
+          if psl > d {
+            self.entries[idx] = Entry::Valid(psl, hash, key, value)
+            continue i + 1, self.next_index(idx), d + 1, h, k, v
+          }
+          continue i + 1, self.next_index(idx), psl + 1, hash, key, value
         }
       }
     }
-    idx = self.next_index(idx)
-    entry = Valid(
-      entry.psl().unwrap() + 1,
-      entry.hash().unwrap(),
-      entry.key().unwrap(),
-      entry.value().unwrap(),
-    )
-    i += 1
-  }
-  if i == self.capacity {
-    abort("HashMap is full")
   }
 }
 
@@ -149,8 +113,9 @@ pub fn op_set[K : Hash + Eq, V](
 /// Get the value associated with a key.
 pub fn get[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Option[V] {
   let hash = self.make_hash(key)
-  let mut idx = self.index(hash)
-  for distance = 0; distance < self.capacity; distance = distance + 1 {
+  for distance = 0, idx = self.index(hash);
+      distance < self.capacity;
+      distance = distance + 1, idx = self.next_index(idx) {
     match self.entries[idx] {
       Valid(d, h, k, v) => {
         if h == hash && k == key {
@@ -162,7 +127,6 @@ pub fn get[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Option[V] {
       }
       Empty => return None
     }
-    idx = self.next_index(idx)
   }
   None
 }
@@ -182,8 +146,9 @@ pub fn contains[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Bool {
 /// Remove a key-value pair from hash map.
 pub fn remove[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Unit {
   let hash = self.make_hash(key)
-  let mut idx = self.index(hash)
-  for distance = 0; distance < self.capacity; distance = distance + 1 {
+  for distance = 0, idx = self.index(hash);
+      distance < self.capacity;
+      distance = distance + 1, idx = self.next_index(idx) {
     match self.entries[idx] {
       Valid(d, h, k, _) => {
         if h == hash && k == key {
@@ -198,7 +163,6 @@ pub fn remove[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Unit {
       }
       Empty => ()
     }
-    idx = self.next_index(idx)
   }
 }
 
@@ -245,9 +209,9 @@ pub fn clear[K, V](self : HashMap[K, V]) -> Unit {
 }
 
 fn shift_back[K : Hash, V](self : HashMap[K, V], start_index : Int) -> Unit {
-  let mut prev = start_index
-  let mut curr = self.next_index(prev)
-  for i = 0; i < self.entries.length(); i = i + 1 {
+  for i = 0, prev = start_index, curr = self.next_index(start_index);
+      i < self.entries.length();
+      i = i + 1, prev = curr, curr = self.next_index(curr) {
     match self.entries[curr] {
       Valid(d, h, k, v) => {
         if d == 0 {
@@ -258,8 +222,6 @@ fn shift_back[K : Hash, V](self : HashMap[K, V], start_index : Int) -> Unit {
       }
       Empty => break
     }
-    prev = curr
-    curr = self.next_index(curr)
   }
 }
 

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -48,23 +48,15 @@ struct HashMap[K, V] {
 
 /// Create new hash map.
 pub fn HashMap::new[K, V](
-  ~capacity : Int = default_init_capacity,
   ~hasher : Option[(K) -> Int] = None
 ) -> HashMap[K, V] {
-  if capacity != 0 && not(is_power_of_two(capacity)) {
-    abort("The capacity is not a zero or a power of 2.")
-  }
   {
     size: 0,
-    capacity,
-    growAt: calc_grow_threshold(capacity),
+    capacity: default_init_capacity,
+    growAt: calc_grow_threshold(default_init_capacity),
     hasher,
-    entries: @array.new(capacity, fn() { Empty }),
+    entries: @array.new(default_init_capacity, fn() { Empty }),
   }
-}
-
-fn is_power_of_two(n : Int) -> Bool {
-  n > 0 && n.land(n - 1) == 0
 }
 
 /// Create new hash map from array.
@@ -297,8 +289,7 @@ test "new" {
 
 test "set" {
   let m : HashMap[String, Int] = HashMap::new(
-    ~hasher=Some(fn(k) { k.length() }),
-    ~capacity=16,
+    ~hasher=Some(fn(k) { k.length() })
   )
   m.set("a", 1)
   m.set("b", 1)
@@ -367,8 +358,7 @@ test "from_array" {
 
 test "remove" {
   let m : HashMap[String, Int] = HashMap::new(
-    ~hasher=Some(fn(k) { k.length() }),
-    ~capacity=16,
+    ~hasher=Some(fn(k) { k.length() })
   )
   m.set("a", 1)
   m.set("ab", 2)
@@ -380,7 +370,7 @@ test "remove" {
   @assertion.assert_eq(m.size(), 5)?
   @assertion.assert_eq(
     m.debug_entries(),
-    "_,(0,a,1),(0,bc,2),(1,cd,2),(1,abc,3),_,(0,abcdef,6),_,_,_,_,_,_,_,_,_",
+    "_,(0,a,1),(0,bc,2),(1,cd,2),(1,abc,3),_,(0,abcdef,6),_",
   )?
 }
 
@@ -404,11 +394,6 @@ test "size" {
   @assertion.assert_eq(m.size(), 0)?
   m.set("a", 1)
   @assertion.assert_eq(m.size(), 1)?
-}
-
-test "capacity" {
-  let m : HashMap[String, Int] = HashMap::new(~capacity=128)
-  @assertion.assert_eq(m.capacity(), 128)?
 }
 
 test "is_empty" {
@@ -475,12 +460,4 @@ test "grow" {
     m.debug_entries(),
     "_,(0,C,1),(0,Go,2),(0,C++,3),(0,Java,4),(0,Scala,5),(1,Julia,5),(2,Cobol,5),(2,Python,6),(2,Haskell,7),(2,Rescript,8),_,_,_,_,_",
   )?
-}
-
-test "zero_capacity_grow" {
-  let m : HashMap[String, Int] = HashMap::new(~capacity=0)
-  @assertion.assert_eq(m.capacity(), 0)?
-  m.set("a", 1)
-  @assertion.assert_eq(m.size(), 1)?
-  @assertion.assert_eq(m.capacity(), 8)?
 }

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -254,10 +254,12 @@ fn grow[K : Hash + Eq, V](self : HashMap[K, V]) -> Unit {
 }
 
 fn make_hash[K : Hash, V](self : HashMap[K, V], key : K) -> Int {
-  match self.hasher {
+  let hash: Int = match self.hasher {
     Some(hasher) => hasher(key)
     None => key.hash()
   }
+  // Let higher 16 bits of the hash value participate in the calculation
+  hash.lxor((hash.lsr(16)))
 }
 
 fn index[K : Hash, V](self : HashMap[K, V], hash : Int) -> Int {

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -17,7 +17,8 @@ let default_init_capacity = 8
 
 enum Entry[K, V] {
   Empty
-  Valid((Int, K, V))
+  // (Probe Sequence Length, Hash, Key, Value)
+  Valid((Int, Int, K, V))
 } derive(Debug)
 
 /// A mutable hash map implements with Robin Hood hashing.
@@ -73,8 +74,9 @@ pub fn set[K : Hash + Eq, V](self : HashMap[K, V], key : K, value : V) -> Unit {
   if self.capacity == 0 || self.size >= self.growAt {
     self.grow()
   }
-  let mut idx = self.hash(key)
-  let mut entry = (0, key, value) // (distance, key, value)
+  let hash = self.make_hash(key)
+  let mut idx = self.index(hash)
+  let mut entry = (0, hash, key, value)
   let mut i = 0
   while i < self.capacity {
     match self.entries[idx] {
@@ -83,20 +85,20 @@ pub fn set[K : Hash + Eq, V](self : HashMap[K, V], key : K, value : V) -> Unit {
         self.size += 1
         break
       }
-      Valid((d, k, v)) => {
-        if k == entry.1 {
-          self.entries[idx] = Valid((d, k, value))
+      Valid((d, h, k, v)) => {
+        if h == entry.1 && k == entry.2 {
+          self.entries[idx] = Valid((d, h, k, value))
           break
         }
         if entry.0 > d {
-          let tmp = (d, k, v)
+          let tmp = (d, h, k, v)
           self.entries[idx] = Valid(entry)
           entry = tmp
         }
       }
     }
     idx = self.next_index(idx)
-    entry = (entry.0 + 1, entry.1, entry.2)
+    entry = (entry.0 + 1, entry.1, entry.2, entry.3)
     i += 1
   }
   if i == self.capacity {
@@ -114,12 +116,12 @@ pub fn op_set[K : Hash + Eq, V](
 
 /// Get the value associated with a key.
 pub fn get[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Option[V] {
-  let mut idx = self.hash(key)
-  let mut distance = 0
-  for i = 0; i < self.capacity; i = i + 1 {
+  let hash = self.make_hash(key)
+  let mut idx = self.index(hash)
+  for distance = 0; distance < self.capacity; distance = distance + 1 {
     match self.entries[idx] {
-      Valid((d, k, v)) => {
-        if k == key {
+      Valid((d, h, k, v)) => {
+        if h == hash && k == key {
           return Some(v)
         }
         if distance > d {
@@ -128,7 +130,6 @@ pub fn get[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Option[V] {
       }
       Empty => return None
     }
-    distance += 1
     idx = self.next_index(idx)
   }
   None
@@ -148,16 +149,21 @@ pub fn contains[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Bool {
 
 /// Remove a key-value pair from hash map.
 pub fn remove[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Unit {
-  let mut idx = self.hash(key)
-  for i = 0; i < self.capacity; i = i + 1 {
+  let hash = self.make_hash(key)
+  let mut idx = self.index(hash)
+  for distance = 0; distance < self.capacity; distance = distance + 1 {
     match self.entries[idx] {
-      Valid((_, k, _)) =>
-        if k == key {
+      Valid((d, h, k, _)) => {
+        if h == hash && k == key {
           self.entries[idx] = Empty
           self.shift_back(idx)
           self.size -= 1
           break
         }
+        if distance > d {
+          return
+        }
+      }
       Empty => ()
     }
     idx = self.next_index(idx)
@@ -189,7 +195,7 @@ pub fn iteri[K, V](self : HashMap[K, V], f : (Int, K, V) -> Unit) -> Unit {
   let mut idx = 0
   for i = 0; i < self.capacity; i = i + 1 {
     match self.entries[i] {
-      Valid((_, k, v)) => {
+      Valid((_, _, k, v)) => {
         f(idx, k, v)
         idx += 1
       }
@@ -211,11 +217,11 @@ fn shift_back[K : Hash, V](self : HashMap[K, V], start_index : Int) -> Unit {
   let mut curr = self.next_index(prev)
   for i = 0; i < self.entries.length(); i = i + 1 {
     match self.entries[curr] {
-      Valid((d, k, v)) => {
+      Valid((d, h, k, v)) => {
         if d == 0 {
           break
         }
-        self.entries[prev] = Valid((d - 1, k, v))
+        self.entries[prev] = Valid((d - 1, h, k, v))
         self.entries[curr] = Empty
       }
       Empty => break
@@ -241,17 +247,21 @@ fn grow[K : Hash + Eq, V](self : HashMap[K, V]) -> Unit {
   self.size = 0
   for i = 0; i < old_entries.length(); i = i + 1 {
     match old_entries[i] {
-      Valid((_, k, v)) => self.set(k, v)
+      Valid((_, _, k, v)) => self.set(k, v)
       _ => ()
     }
   }
 }
 
-fn hash[K : Hash, V](self : HashMap[K, V], key : K) -> Int {
+fn make_hash[K : Hash, V](self : HashMap[K, V], key : K) -> Int {
   match self.hasher {
-    Some(hasher) => hasher(key).abs().land(self.capacity - 1)
-    None => key.hash().abs().land(self.capacity - 1)
+    Some(hasher) => hasher(key)
+    None => key.hash()
   }
+}
+
+fn index[K : Hash, V](self : HashMap[K, V], hash : Int) -> Int {
+  hash.abs().land(self.capacity - 1)
 }
 
 fn next_index[K : Hash, V](self : HashMap[K, V], index : Int) -> Int {
@@ -270,7 +280,7 @@ fn debug_entries[K : Show, V : Show](self : HashMap[K, V]) -> String {
     }
     match self.entries[i] {
       Empty => s += "_"
-      Valid((d, k, v)) => s += "(\(d),\(k),\(v))"
+      Valid((d, _h, k, v)) => s += "(\(d),\(k),\(v))"
     }
   }
   s


### PR DESCRIPTION
- Caching the hash value in the entry to speeds up the lookup operation for non-integer keys.
- Tweak the hash calculation to let the higher 16 bits of the hash value participate in the calculation.