### PR TITLE
Add coverage support for core libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 target/
 .mooncakes/
+
+# Coverage-related files
+moonbit-coverage-*.txt
+_coverage
+bisect.coverage

--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -1,3 +1,7 @@
 {
-  "import": ["moonbitlang/core/assertion", "moonbitlang/core/math"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/math",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/assertion/moon.pkg.json
+++ b/assertion/moon.pkg.json
@@ -1,1 +1,5 @@
-{}
+{
+    "import": [
+        "moonbitlang/core/coverage"
+    ]
+}

--- a/bool/moon.pkg.json
+++ b/bool/moon.pkg.json
@@ -1,1 +1,5 @@
-{}
+{
+    "import": [
+        "moonbitlang/core/coverage"
+    ]
+}

--- a/bytes/moon.pkg.json
+++ b/bytes/moon.pkg.json
@@ -1,5 +1,9 @@
 {
     "import": [
-        { "path": "moonbitlang/core/assertion", "alias": "assertion" }
+        {
+            "path": "moonbitlang/core/assertion",
+            "alias": "assertion"
+        },
+        "moonbitlang/core/coverage"
     ]
 }

--- a/char/moon.pkg.json
+++ b/char/moon.pkg.json
@@ -1,1 +1,5 @@
-{}
+{
+    "import": [
+        "moonbitlang/core/coverage"
+    ]
+}

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -49,7 +49,10 @@ fn CoverageCounter::debug_write(self : CoverageCounter, buf : Buffer) -> Unit {
 test "new_counter" {
   let counter = CoverageCounter::new(2)
   let result = counter.to_string()
-  @assertion.assert_eq(result, "[0, 0]")?
+  // @assertion.assert_eq(result, "[0, 0]")?
+  if result != "[0, 0]" {
+    return Err("Expected: [0, 0], got: " + result)
+  }
 }
 
 test "incr_counter" {
@@ -57,7 +60,10 @@ test "incr_counter" {
   counter.incr(0)
   counter.incr(9)
   let result = counter.to_string()
-  @assertion.assert_eq(result, "[1, 0, 0, 0, 0, 0, 0, 0, 0, 1]")?
+  // @assertion.assert_eq(result, "[1, 0, 0, 0, 0, 0, 0, 0, 0, 1]")?
+  if result != "[1, 0, 0, 0, 0, 0, 0, 0, 0, 1]" {
+    return Err("Expected: [1, 0, 0, 0, 0, 0, 0, 0, 0, 1], got: " + result)
+  }
 }
 
 /// The global list of counters currently tracking.
@@ -142,7 +148,10 @@ pub fn escape(s : String) -> String {
 test "backslash escape" {
   let s = "\n\r\t\b\"'\\"
   let expected = "\\n\\r\\t\\b\\\"\\'\\\\"
-  @assertion.assert_eq(escape(s), expected)?
+  // @assertion.assert_eq(escape(s), expected)?
+  if s != expected {
+    return Err("Expected: " + expected + ", got: " + s)
+  }
 }
 
 // FIXME: formatting string does not work, this test will be destroyed by formatting
@@ -196,7 +205,10 @@ test "log" {
     #|}
     #|
 
-  @assertion.assert_eq(result, expected)?
+  // @assertion.assert_eq(result, expected)?
+  if result != expected {
+    return Err("Expected: " + expected + ", got: " + result)
+  }
 }
 
 /// Output the counters to stdout for coverage report usages. The counter data

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -91,7 +91,7 @@ fn Output::output(self : Buffer, content : String) -> Unit {
 
 // TODO: This escape function should belong to the String package, but is 
 // not mature enough, so it's left here temporarily.
-/// Escape a string using standard C escape sequences to the given buffer,
+/// Escape a string using standard JSON escape sequences to the given buffer,
 /// usually for quoting uses.
 ///  
 /// This method only escapes characters below 0x20 and the following characters:
@@ -114,15 +114,14 @@ fn escape_to(s : String, buf : Buffer) -> Unit {
   while ix < s.length() {
     let ch = s[ix]
     match ch {
-      '"' | '\'' | '\\' => write_escaped_ch(ch)
+      '"' | '\\' => write_escaped_ch(ch)
       '\n' => write_escaped_ch('n')
       '\r' => write_escaped_ch('r')
       '\b' => write_escaped_ch('b')
       '\t' => write_escaped_ch('t')
       _ =>
         if ch.to_int() < 0x20 {
-          buf.write_char('\\')
-          buf.write_char('x')
+          buf.write_string("\\u00")
           let ich = ch.to_int()
           buf.write_char(to_hex_digit(ich / 16))
           buf.write_char(to_hex_digit(ich % 16))
@@ -147,10 +146,11 @@ pub fn escape(s : String) -> String {
 
 test "backslash escape" {
   let s = "\n\r\t\b\"'\\"
-  let expected = "\\n\\r\\t\\b\\\"\\'\\\\"
+  let expected = "\\n\\r\\t\\b\\\"'\\\\"
   // @assertion.assert_eq(escape(s), expected)?
-  if s != expected {
-    return Err("Expected: " + expected + ", got: " + s)
+  let escape_s = escape(s)
+  if escape_s != expected {
+    return Err("Expected: " + expected + ", got: " + escape_s)
   }
 }
 

--- a/coverage/moon.pkg.json
+++ b/coverage/moon.pkg.json
@@ -1,3 +1,3 @@
 {
-  "import": ["moonbitlang/core/assertion", "moonbitlang/core/string"]
+  "import": []
 }

--- a/deque/moon.pkg.json
+++ b/deque/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/assertion"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/double/moon.pkg.json
+++ b/double/moon.pkg.json
@@ -1,6 +1,7 @@
 {
     "import": [
         "moonbitlang/core/num",
-        "moonbitlang/core/assertion"
+        "moonbitlang/core/assertion",
+        "moonbitlang/core/coverage"
     ]
 }

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/core/int",
     "moonbitlang/core/list",
     "moonbitlang/core/array",
-    "moonbitlang/core/assertion"
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
   ]
 }

--- a/immutable_hashmap/moon.pkg.json
+++ b/immutable_hashmap/moon.pkg.json
@@ -1,3 +1,7 @@
 {
-  "import": ["moonbitlang/core/assertion", "moonbitlang/core/array"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/array",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/immutable_set/moon.pkg.json
+++ b/immutable_set/moon.pkg.json
@@ -2,6 +2,7 @@
   "import": [
     "moonbitlang/core/assertion",
     "moonbitlang/core/list",
-    "moonbitlang/core/array"
+    "moonbitlang/core/array",
+    "moonbitlang/core/coverage"
   ]
 }

--- a/int/moon.pkg.json
+++ b/int/moon.pkg.json
@@ -1,6 +1,7 @@
 {
-  "import": [ 
+  "import": [
     "moonbitlang/core/num",
-    "moonbitlang/core/assertion"
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
   ]
 }

--- a/int64/moon.pkg.json
+++ b/int64/moon.pkg.json
@@ -1,6 +1,7 @@
 {
     "import": [
         "moonbitlang/core/num",
-        "moonbitlang/core/assertion"
+        "moonbitlang/core/assertion",
+        "moonbitlang/core/coverage"
     ]
 }

--- a/list/moon.pkg.json
+++ b/list/moon.pkg.json
@@ -1,3 +1,7 @@
 {
-  "import": ["moonbitlang/core/assertion", "moonbitlang/core/array"]  
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/array",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/map/moon.pkg.json
+++ b/map/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/core/assertion",
     "moonbitlang/core/list",
     "moonbitlang/core/vec",
-    "moonbitlang/core/immutable_set"
+    "moonbitlang/core/immutable_set",
+    "moonbitlang/core/coverage"
   ]
 }

--- a/math/moon.pkg.json
+++ b/math/moon.pkg.json
@@ -1,3 +1,7 @@
 {
-  "import": ["moonbitlang/core/assertion", "moonbitlang/core/double"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/double",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/num/moon.pkg.json
+++ b/num/moon.pkg.json
@@ -1,1 +1,5 @@
-{}
+{
+    "import": [
+        "moonbitlang/core/coverage"
+    ]
+}

--- a/option/moon.pkg.json
+++ b/option/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/assertion"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/priority_queue/moon.pkg.json
+++ b/priority_queue/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/assertion"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/queue/moon.pkg.json
+++ b/queue/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/assertion"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/ref/moon.pkg.json
+++ b/ref/moon.pkg.json
@@ -2,6 +2,7 @@
   "import": [
     "moonbitlang/core/assertion",
     "moonbitlang/core/num",
-    "moonbitlang/core/int"
+    "moonbitlang/core/int",
+    "moonbitlang/core/coverage"
   ]
 }

--- a/result/moon.pkg.json
+++ b/result/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/assertion"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
+  ]
 }

--- a/stack/moon.pkg.json
+++ b/stack/moon.pkg.json
@@ -2,6 +2,7 @@
   "import": [
     "moonbitlang/core/assertion",
     "moonbitlang/core/list",
-    "moonbitlang/core/array"
+    "moonbitlang/core/array",
+    "moonbitlang/core/coverage"
   ]
 }

--- a/string/moon.pkg.json
+++ b/string/moon.pkg.json
@@ -1,1 +1,5 @@
-{}
+{
+    "import": [
+        "moonbitlang/core/coverage"
+    ]
+}

--- a/unit/moon.pkg.json
+++ b/unit/moon.pkg.json
@@ -1,1 +1,5 @@
-{}
+{
+    "import": [
+        "moonbitlang/core/coverage"
+    ]
+}

--- a/vec/moon.pkg.json
+++ b/vec/moon.pkg.json
@@ -1,3 +1,7 @@
 {
-  "import": ["moonbitlang/core/assertion", "moonbitlang/core/string"]
+  "import": [
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/string",
+    "moonbitlang/core/coverage"
+  ]
 }


### PR DESCRIPTION
This PR allows for coverage testing for all core libraries, except for the coverage library itself.

This PR removes external dependencies for the coverage library, in order to add it as a dependency of all other dependencies.

Remaining questions:

- Can we insert the dependency to `moonbitlang/core/coverage` from the build system iff coverage is enabled, instead of right here?
- Add coverage output into CI in this PR?

Blocking issues:

- [x] Bug in builtin library that makes string escaping fail in output
- [x] `moon test` does not return error when the test runner fails