### PR TITLE
Add trait `Boolean` with `to_bool()`

### DIFF
--- a/assertion/assertion.mbt
+++ b/assertion/assertion.mbt
@@ -71,11 +71,15 @@ test "assert_ne.eq" {
   }
 }
 
-pub fn assert_false(x : Bool, ~loc : SourceLoc = _) -> Result[Unit, String] {
-  if x == false {
-    Ok(())
+pub fn assert_false[T : Debug + @bool.Boolean](
+  x : T,
+  ~loc : SourceLoc = _
+) -> Result[Unit, String] {
+  if x.to_bool() {
+    let x = debug_string(x)
+    Err("FAILED:\(loc) `\(x)` is not false")
   } else {
-    Err("FAILED:\(loc)")
+    Ok(())
   }
 }
 
@@ -87,11 +91,15 @@ test "assert_false.true" {
   assert_ne(assert_false(true), Ok(()))?
 }
 
-pub fn assert_true(x : Bool, ~loc : SourceLoc = _) -> Result[Unit, String] {
-  if x {
+pub fn assert_true[T : Debug + @bool.Boolean](
+  x : T,
+  ~loc : SourceLoc = _
+) -> Result[Unit, String] {
+  if x.to_bool() {
     Ok(())
   } else {
-    Err("FAILED:\(loc)")
+    let x = debug_string(x)
+    Err("FAILED:\(loc): `\(x)` is not true")
   }
 }
 

--- a/assertion/moon.pkg.json
+++ b/assertion/moon.pkg.json
@@ -1,6 +1,7 @@
 {
     "import": [
         "moonbitlang/core/builtin",
+        "moonbitlang/core/bool",
         "moonbitlang/core/coverage"
     ]
 }

--- a/bool/bool.mbt
+++ b/bool/bool.mbt
@@ -11,3 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+pub trait Boolean {
+  to_bool(Self) -> Bool
+}
+
+pub fn Bool::to_bool(self : Bool) -> Bool {
+  self
+}


### PR DESCRIPTION
This allows writing more generic `@test.is_true()` and `is_false()`.

- [x] ~Depends on #162~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced assertion functions to support a wider range of types by checking their boolean value.
- **Refactor**
	- Introduced a `Boolean` trait with a `to_bool` method for better type handling in assertions.
- **Chores**
	- Updated package dependencies to include core boolean functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->