### PR TITLE
add two tests based on coverage report

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -584,3 +584,8 @@ test "to_list" {
   let ls = [1, 2, 3, 4, 5].to_list()
   @assertion.assert_eq(ls, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil))))))?
 }
+
+test "op_equal" {
+  inspect([1, 2] == [1], ~content="false")?
+  inspect(starts_with([1, 2, 3], [1, 3]), ~content="false")?
+}


### PR DESCRIPTION
cc @lynzrand 

note the coverage shows code in `test block`, this should be ignored ideally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added tests for array equality comparison and checking if one array starts with another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->