### PR TITLE
Fix to bytes

### DIFF
--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -119,3 +119,7 @@ pub fn length(self : Buffer) -> Int {
 pub fn reset(self : Buffer) -> Unit {
   self.len = 0
 }
+
+pub fn to_bytes(self : Buffer) -> Bytes {
+  self.bytes.copy()
+}

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -79,7 +79,7 @@ pub fn sub_string(self : Bytes, byte_offset : Int, byte_length : Int) -> String 
   }
 }
 
-/// Copy `length` bytes from string `str`, starting at `str_offset`,
+/// Copy `length` chars from string `str`, starting at `str_offset`,
 /// into byte sequence `self`, starting at `bytes_offset`.
 pub fn blit_from_string(
   self : Bytes,

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -57,6 +57,7 @@ test "to_bytes" {
   @assertion.assert_eq("中文".to_bytes().to_string(), "中文")?
   @assertion.assert_eq("asdf".to_bytes().to_string(), "asdf")?
   @assertion.assert_eq("🤣🤣".to_bytes().to_string(), "🤣🤣")?
+  @assertion.assert_eq("🤔".to_bytes().to_string(), "🤔")?
 }
 
 pub fn hash(self : String) -> Int {

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -55,6 +55,12 @@ pub fn to_bytes(self : String) -> Bytes {
   buf
 }
 
+test "to_bytes" {
+  @assertion.assert_eq("中文".to_bytes().to_string(), "中文")?
+  @assertion.assert_eq("asdf".to_bytes().to_string(), "asdf")?
+  @assertion.assert_eq("🤣🤣".to_bytes().to_string(), "🤣🤣")?
+}
+
 pub fn hash(self : String) -> Int {
   self.to_bytes().hash()
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -48,11 +48,9 @@ pub fn String::default() -> String {
 
 pub fn to_bytes(self : String) -> Bytes {
   let len = self.length()
-  let buf = Bytes::make(len, 0)
-  for i = 0; i < len; i = i + 1 {
-    buf[i] = self[i].to_int()
-  }
-  buf
+  let bytes = Bytes::make(len * 2, 0)
+  bytes.blit_from_string(0, self, 0, len)
+  bytes
 }
 
 test "to_bytes" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new public function `to_bytes(self: Buffer) -> Bytes` to the `Buffer` module for converting buffer content to bytes.
- **Enhancements**
	- Improved efficiency of string to bytes conversion by utilizing a `Buffer` to store the string.
- **Tests**
	- Added new test cases to validate the behavior of the `to_bytes` function in `string/string.mbt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->