### PR TITLE
Improve immutableSet and add README

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -580,6 +580,42 @@ pub fn to_list[T](self : Array[T]) -> List[T] {
   }
 }
 
+/// Concat two arrays.
+/// 
+/// # Example
+///
+/// ```
+/// [1, 2, 3, 4, 5].concat([6, 7, 8, 9, 10]) //[1, 2, 3, 4, 5, 6, 7, 9, 10]
+/// ```
+pub fn concat[T](self : Array[T], last : Array[T]) -> Array[T] {
+  if self.length() == 0 {
+    last
+  } else if last.length() == 0 {
+    self
+  } else {
+    let mut j = 1
+    let arr = Array::make(self.length() + last.length(), self[0])
+    for i = 1; i < self.length(); i = i + 1 {
+      arr[j] = self[i]
+      j += 1
+    }
+    for i = 0; i < last.length(); i = i + 1 {
+      arr[j] = last[i]
+      j += 1
+    }
+    arr
+  }
+}
+
+test "concat" {
+  @assertion.assert_eq(
+    [1, 2, 3, 4, 5].concat([6, 7, 8, 9, 10]),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  )?
+  @assertion.assert_eq([].concat([6, 7, 8, 9, 10]), [6, 7, 8, 9, 10])?
+  @assertion.assert_eq([1, 2, 3, 4, 5].concat([]), [1, 2, 3, 4, 5])?
+}
+
 test "to_list" {
   let ls = [1, 2, 3, 4, 5].to_list()
   @assertion.assert_eq(ls, Cons(1, Cons(2, Cons(3, Cons(4, Cons(5, Nil))))))?

--- a/array/array.mbt
+++ b/array/array.mbt
@@ -614,6 +614,7 @@ test "concat" {
   )?
   @assertion.assert_eq([].concat([6, 7, 8, 9, 10]), [6, 7, 8, 9, 10])?
   @assertion.assert_eq([1, 2, 3, 4, 5].concat([]), [1, 2, 3, 4, 5])?
+  @assertion.assert_eq([1].concat([2]), [1, 2])?
 }
 
 test "to_list" {

--- a/immutable_set/README.md
+++ b/immutable_set/README.md
@@ -17,7 +17,7 @@ let set1 : ImmutableSet[Int] = ImmutableSet::new()
 let set2 = ImmutableSet::from_value(1)
 let set3 = ImmutableSet.from_list(Cons(1, Nil))
 let set4 = ImmutableSet.from_array([1])
-let set45= ImmutableSet::[1]
+let set5= ImmutableSet::[1]
 ```
 
 ### Convert

--- a/immutable_set/README.md
+++ b/immutable_set/README.md
@@ -15,8 +15,8 @@ You can create an empty ImmutableSet with a value separately through the followi
 ```moonbit
 let set1 : ImmutableSet[Int] = ImmutableSet::new()
 let set2 = ImmutableSet::from_value(1)
-let set3 = ImmutableSet.from_list(Cons(1, Nil))
-let set4 = ImmutableSet.from_array([1])
+let set3 = ImmutableSet::from_list(Cons(1, Nil))
+let set4 = ImmutableSet::from_array([1])
 let set5= ImmutableSet::[1]
 ```
 
@@ -50,7 +50,7 @@ You can use `remove` to remove a specific value or use `remove_min` to remove th
 You can use `contain` to query whether an element is in the set.
 
 ```moonbit
-let set = ImmutableSet.from_array([1, 2, 3, 4])
+let set = ImmutableSet::from_array([1, 2, 3, 4])
 set.contain(1) // true
 set.contain(5) // false
 ```
@@ -65,7 +65,7 @@ ImmutableSet::[1, 2, 3, 4, 5, 6].find_option(6) // Some(6)
 You can also use `min` and `max` to obtain the minimum or maximum value in the set. When the set is empty, an error will be reported, and they have corresponding Option versions to handle this.
 
 ```moonbit
-let set = ImmutableSet.from_array([1, 2, 3, 4])
+let set = ImmutableSet::from_array([1, 2, 3, 4])
 set.min() // 1
 set.max() // 4
 set.min_option() // Some(1)

--- a/immutable_set/README.md
+++ b/immutable_set/README.md
@@ -26,5 +26,126 @@ Instead, you can convert an ImmutableSet to a List, which will be sorted.
 
 ```moonbit
 let set = ImmutableSet::[3, 2, 1]
-println(set.to_list()); // List::[1, 2, 3]
+set // ImuutableSet::(1, 2, 3)
+```
+
+### Add & Remove
+
+You can use `add` to add an element to the ImmutableSet.
+
+```moonbit
+let set = ImmutableSet::[1, 2, 3, 4]
+set.add(5) // ImmutableSet::(1, 2, 3, 4, 5)
+```
+
+You can use `remove` to remove a specific value or use `remove_min` to remove the minimum value in the set.
+
+```moonbit
+(ImmutableSet::[3, 8, 1]).remove(8) // ImmutableSet::(1, 3)
+(ImmutableSet::[3, 4, 5]).remove_min() // ImmutableSet::(4, 5)
+```
+
+### Max & Min & Contain & Find
+
+You can use `contain` to query whether an element is in the set.
+
+```moonbit
+let set = ImmutableSet.from_array([1, 2, 3, 4])
+set.contain(1) // true
+set.contain(5) // false
+```
+
+Similarly, the `find` can achieve a similar effect, but it will directly return the value when it exists in the set.
+
+```moonbit
+ImmutableSet::[1, 2, 3, 4, 5, 6].find(6) // 6
+ImmutableSet::[1, 2, 3, 4, 5, 6].find_option(6) // Some(6)
+```
+
+You can also use `min` and `max` to obtain the minimum or maximum value in the set. When the set is empty, an error will be reported, and they have corresponding Option versions to handle this.
+
+```moonbit
+let set = ImmutableSet.from_array([1, 2, 3, 4])
+set.min() // 1
+set.max() // 4
+set.min_option() // Some(1)
+set.max_option() // Some(4)
+```
+
+### Split & Union & Inter & Diff & Filter
+
+You can provide an intermediate value to divide a set into two sets by `split`, and whether the intermediate value is in the set will also be returned as the return value.
+
+```moonbit
+let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(5)
+/// present // true
+/// left // ImmutableSet::(1, 2, 3, 4)
+/// right // ImmutableSet::(6, 7, 8, 9)
+```
+
+At the same time, you can use union and inter to take the union or intersection of two sets.
+
+```moonbit
+let set1 = ImmutableSet::[3, 4, 5]
+let set2 = ImmutableSet::[4, 5, 6]
+set1.union(set2) // ImmutableSet::(3, 4, 5, 6)
+set1.inter(set2) // ImmutableSet::(4, 5)
+```
+
+You can also use the `diff` function to obtain the difference between two sets.
+
+```moonbit
+ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]) // ImmutableSet::(2, 3)
+```
+
+You can use `filter` to filter the elements in the set.
+
+```moonbit
+ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0}) // ImmutableSet::(2, 4, 6)
+```
+
+### Subset & Disjoint
+
+You can use `subsets` and `disjoint` to determine the inclusion and separation relationship between two sets
+
+```moonbit
+ImmutableSet::[1, 2, 3].subset(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1]) // true
+ImmutableSet::[1, 2, 3].disjoint(ImmutableSet::[4, 5, 6]) // true
+```
+
+### Iter & Fold & Map
+
+Like other sequential containers, set also has iterative methods such as `iter`, `fold`, and `map`, and their order is based on the comparison being less than the order.
+
+```moonbit
+ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].iter(print)// output: 123456789
+ImmutableSet::[1, 2, 3, 4, 5].fold(0, fn(acc, x) { acc + x }) // 15
+ImmutableSet::[1, 2, 3].map(fn(x){ x * 2}) // ImmutableSet::(2, 4, 6)
+```
+
+### Forall & Exists
+
+`forall` and `exists` can detect whether all elements in the set match or if there are elements that match.
+
+```moonbit
+ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0}) // true
+ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0}) // true
+```
+
+### Stringify
+
+ImmutableSet implements to_string (i.e. Show trait), which allows you to directly output it.
+
+```moonbit
+println(ImmutableSet::[1, 2, 3]) // output ImmutableSet::(1, 2, 3)
+ImmutableSet::[1, 2, 3].to_string() // "ImmutableSet::(1, 2, 3)"
+```
+
+### Empty
+
+`is_empty` can determine whether a set is empty.
+
+```moonbit
+ImmutableSet::[].is_empty() // true
+ImmutableSet::[1].is_empty() // false
 ```

--- a/immutable_set/README.md
+++ b/immutable_set/README.md
@@ -14,7 +14,7 @@ You can create an empty ImmutableSet with a value separately through the followi
 
 ```moonbit
 let set1 : ImmutableSet[Int] = ImmutableSet::new()
-let set2 = ImmutableSet::from_value(1)
+let set2 = ImmutableSet::singleton(1)
 let set3 = ImmutableSet::from_list(Cons(1, Nil))
 let set4 = ImmutableSet::from_array([1])
 let set5= ImmutableSet::[1]
@@ -22,11 +22,13 @@ let set5= ImmutableSet::[1]
 
 ### Convert
 
-Instead, you can convert an ImmutableSet to a List, which will be sorted.
+Instead, you can convert an ImmutableSet to a List/Array/Vec, which will be sorted.
 
 ```moonbit
 let set = ImmutableSet::[3, 2, 1]
-set // ImuutableSet::[1, 2, 3]
+set.to_array() // [1, 2, 3]
+set.to_list() // List::[1, 2, 3]
+set.to_vec() // Vec::[1, 2, 3]
 ```
 
 ### Add & Remove
@@ -45,7 +47,7 @@ You can use `remove` to remove a specific value or use `remove_min` to remove th
 (ImmutableSet::[3, 4, 5]).remove_min() // ImmutableSet::[4, 5]
 ```
 
-### Max & Min & Contain & Find
+### Max & Min & Contain
 
 You can use `contain` to query whether an element is in the set.
 
@@ -53,13 +55,6 @@ You can use `contain` to query whether an element is in the set.
 let set = ImmutableSet::from_array([1, 2, 3, 4])
 set.contain(1) // true
 set.contain(5) // false
-```
-
-Similarly, the `find` can achieve a similar effect, but it will directly return the value when it exists in the set.
-
-```moonbit
-ImmutableSet::[1, 2, 3, 4, 5, 6].find(6) // 6
-ImmutableSet::[1, 2, 3, 4, 5, 6].find_option(6) // Some(6)
 ```
 
 You can also use `min` and `max` to obtain the minimum or maximum value in the set. When the set is empty, an error will be reported, and they have corresponding Option versions to handle this.

--- a/immutable_set/README.md
+++ b/immutable_set/README.md
@@ -1,0 +1,30 @@
+# Moonbit/Core ImmutableSet
+
+## Overview
+
+ImmutableSet is an immutable, persistent implementation of the set structure (each operation returns a new ImmutableSet), implemented here using a balance tree.
+
+## Usage
+
+### Create
+
+Since set is based on comparison, the type used to construct ImmutableSet needs to implement Compare trait.
+
+You can create an empty ImmutableSet with a value separately through the following methods, or create it directly from the Array and List.
+
+```moonbit
+let set1 : ImmutableSet[Int] = ImmutableSet::new()
+let set2 = ImmutableSet::from_value(1)
+let set3 = ImmutableSet.from_list(Cons(1, Nil))
+let set4 = ImmutableSet.from_array([1])
+let set45= ImmutableSet::[1]
+```
+
+### Convert
+
+Instead, you can convert an ImmutableSet to a List, which will be sorted.
+
+```moonbit
+let set = ImmutableSet::[3, 2, 1]
+println(set.to_list()); // List::[1, 2, 3]
+```

--- a/immutable_set/README.md
+++ b/immutable_set/README.md
@@ -26,7 +26,7 @@ Instead, you can convert an ImmutableSet to a List, which will be sorted.
 
 ```moonbit
 let set = ImmutableSet::[3, 2, 1]
-set // ImuutableSet::(1, 2, 3)
+set // ImuutableSet::[1, 2, 3]
 ```
 
 ### Add & Remove
@@ -35,14 +35,14 @@ You can use `add` to add an element to the ImmutableSet.
 
 ```moonbit
 let set = ImmutableSet::[1, 2, 3, 4]
-set.add(5) // ImmutableSet::(1, 2, 3, 4, 5)
+set.add(5) // ImmutableSet::[1, 2, 3, 4, 5]
 ```
 
 You can use `remove` to remove a specific value or use `remove_min` to remove the minimum value in the set.
 
 ```moonbit
-(ImmutableSet::[3, 8, 1]).remove(8) // ImmutableSet::(1, 3)
-(ImmutableSet::[3, 4, 5]).remove_min() // ImmutableSet::(4, 5)
+(ImmutableSet::[3, 8, 1]).remove(8) // ImmutableSet::[1, 3]
+(ImmutableSet::[3, 4, 5]).remove_min() // ImmutableSet::[4, 5]
 ```
 
 ### Max & Min & Contain & Find
@@ -79,8 +79,8 @@ You can provide an intermediate value to divide a set into two sets by `split`, 
 ```moonbit
 let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(5)
 /// present // true
-/// left // ImmutableSet::(1, 2, 3, 4)
-/// right // ImmutableSet::(6, 7, 8, 9)
+/// left // ImmutableSet::[1, 2, 3, 4]
+/// right // ImmutableSet::[6, 7, 8, 9]
 ```
 
 At the same time, you can use union and inter to take the union or intersection of two sets.
@@ -88,20 +88,20 @@ At the same time, you can use union and inter to take the union or intersection 
 ```moonbit
 let set1 = ImmutableSet::[3, 4, 5]
 let set2 = ImmutableSet::[4, 5, 6]
-set1.union(set2) // ImmutableSet::(3, 4, 5, 6)
-set1.inter(set2) // ImmutableSet::(4, 5)
+set1.union(set2) // ImmutableSet::[3, 4, 5, 6]
+set1.inter(set2) // ImmutableSet::[4, 5]
 ```
 
 You can also use the `diff` function to obtain the difference between two sets.
 
 ```moonbit
-ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]) // ImmutableSet::(2, 3)
+ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]) // ImmutableSet::[2, 3]
 ```
 
 You can use `filter` to filter the elements in the set.
 
 ```moonbit
-ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0}) // ImmutableSet::(2, 4, 6)
+ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0}) // ImmutableSet::[2, 4, 6]
 ```
 
 ### Subset & Disjoint
@@ -120,7 +120,7 @@ Like other sequential containers, set also has iterative methods such as `iter`,
 ```moonbit
 ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].iter(print)// output: 123456789
 ImmutableSet::[1, 2, 3, 4, 5].fold(0, fn(acc, x) { acc + x }) // 15
-ImmutableSet::[1, 2, 3].map(fn(x){ x * 2}) // ImmutableSet::(2, 4, 6)
+ImmutableSet::[1, 2, 3].map(fn(x){ x * 2}) // ImmutableSet::[2, 4, 6]
 ```
 
 ### Forall & Exists
@@ -137,8 +137,8 @@ ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0}) // true
 ImmutableSet implements to_string (i.e. Show trait), which allows you to directly output it.
 
 ```moonbit
-println(ImmutableSet::[1, 2, 3]) // output ImmutableSet::(1, 2, 3)
-ImmutableSet::[1, 2, 3].to_string() // "ImmutableSet::(1, 2, 3)"
+println(ImmutableSet::[1, 2, 3]) // output ImmutableSet::[1, 2, 3]
+ImmutableSet::[1, 2, 3].to_string() // "ImmutableSet::[1, 2, 3]"
 ```
 
 ### Empty

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -16,18 +16,10 @@
 // The types stored in set need to implement the Compare trait.
 // All operations over sets are purely applicative (no side-effects).
 
-/// ImmutableSets are represented by balanced binary trees (the heights of the children differ by at most 2).
-enum ImmutableSet[T] {
+// Construct a empty ImmutableSet.
+pub fn ImmutableSet::new[T]() -> ImmutableSet[T] {
   Empty
-  Node(Node[T])
-} derive(Default, Show, Debug, Eq)
-
-priv struct Node[T] {
-  left : ImmutableSet[T]
-  right : ImmutableSet[T]
-  height : Int
-  value : T
-} derive(Default, Show, Debug, Eq)
+}
 
 /// Returns the one-value ImmutableSet containing only `value`.
 pub fn ImmutableSet::from_value[T : Compare](value : T) -> ImmutableSet[T] {
@@ -108,21 +100,21 @@ pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
 pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
     Empty => Node({ left: Empty, value, right: Empty, height: 1 })
-    Node({ left, right, value: node_value, height: _ }) as node => {
+    Node({ left, right, value: node_value, height: _ })=> {
       let compare_result = value.compare(node_value)
       if compare_result == 0 {
-        node
+        self
       } else if compare_result < 0 {
         let ll = left.add(value)
         if physical_equal(left, ll) {
-          node
+          self
         } else {
           balance(ll, node_value, right)
         }
       } else {
         let rr = right.add(value)
         if physical_equal(right, rr) {
-          node
+          self
         } else {
           balance(left, node_value, rr)
         }
@@ -392,7 +384,7 @@ pub fn subset[T : Compare](
     (_, Empty) => false
     (
       Node({ left: l1, value: v1, right: r1, height: _ }),
-      Node({ left: l2, value: v2, right: r2, height: _ }) as node,
+      Node({ left: l2, value: v2, right: r2, height: _ }),
     ) => {
       let compare_result = v1.compare(v2)
       if compare_result == 0 {
@@ -400,11 +392,11 @@ pub fn subset[T : Compare](
       } else if compare_result < 0 {
         ImmutableSet::Node({ left: l1, value: v1, right: Empty, height: 0 }).subset(
           l2,
-        ) && r1.subset(node)
+        ) && r1.subset(self)
       } else {
         ImmutableSet::Node({ left: Empty, value: v1, right: r1, height: 0 }).subset(
           r2,
-        ) && l1.subset(node)
+        ) && l1.subset(self)
       }
     }
   }
@@ -466,13 +458,13 @@ pub fn iter[T : Compare](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
 /// ```
 pub fn fold[T : Compare, U : Compare](
   self : ImmutableSet[T],
-  initial : U,
-  f : (U, T) -> U
+  f : (U, T) -> U,
+  ~initial : U
 ) -> U {
   match self {
     Empty => initial
     Node({ left, value, right, height: _ }) =>
-      right.fold(f(left.fold(initial, f), value), f)
+      right.fold(~initial=f(left.fold(~initial, f), value), f)
   }
 }
 
@@ -541,13 +533,13 @@ pub fn filter[T : Compare](
 ) -> ImmutableSet[T] {
   match self {
     Empty => Empty
-    Node({ left, value, right, height: _ }) as node => {
+    Node({ left, value, right, height: _ }) => {
       let l = left.filter(f)
       let v = f(value)
       let r = right.filter(f)
       if v {
         if physical_equal(l, left) && physical_equal(r, right) {
-          node
+          self
         } else {
           join(l, value, r)
         }
@@ -573,8 +565,10 @@ pub fn find[T : Compare](self : ImmutableSet[T], value : T) -> T {
       let compare_result = value.compare(node_value)
       if compare_result == 0 {
         node_value
+      } else if compare_result < 0 {
+        left.find(value)
       } else {
-        (if compare_result < 0 { left } else { right }).find(value)
+        right.find(value)
       }
     }
   }
@@ -586,11 +580,15 @@ pub fn find_option[T : Compare](self : ImmutableSet[T], value : T) -> Option[T] 
     Empty => None
     Node({ left, value: node_value, right, height: _ }) => {
       let compare_result = value.compare(node_value)
-      if compare_result == 0 {
-        Some(node_value)
-      } else {
-        Some((if compare_result < 0 { left } else { right }).find(value))
-      }
+      Some(
+        if compare_result == 0 {
+          node_value
+        } else if compare_result < 0 {
+          left.find(value)
+        } else {
+          right.find(value)
+        },
+      )
     }
   }
 }
@@ -798,7 +796,6 @@ fn concat[T : Compare](
 
 // Convert a sorted list into a balanced binary search tree to facilitate subsequent search, insertion, and deletion operations.
 fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
-
   // Recursively process the input list and build a balanced binary search tree based on the length n of the list.
   fn sub(n : Int, list : List[T]) -> (ImmutableSet[T], List[T]) {
     match (n, list) {
@@ -848,8 +845,7 @@ fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
     }
   }
 
-  let (set, _) = sub(list.length(), list)
-  set
+  sub(list.length(), list).0
 }
 
 test "disjoint" {
@@ -933,7 +929,7 @@ test "exists" {
 test "fold" {
   @assertion.assert_eq(
     ImmutableSet::from_list(List::[1, 2, 3, 4, 5]).fold(
-      0,
+      ~initial=0,
       fn(acc, x) { acc + x },
     ),
     15,

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -70,13 +70,22 @@ pub fn to_list[T : Compare](self : ImmutableSet[T]) -> List[T] {
   values_aux(self, Nil)
 }
 
+/// Convert ImmutableSet[T] to Array[T], the result must be ordered.
+pub fn to_array[T : Compare](self : ImmutableSet[T]) -> Array[T] {
+  match self {
+    Empty => []
+    Node({ left, value, right, height: _ }) =>
+      to_array(left).concat([value]).concat(to_array(right))
+  }
+}
+
 /// Remove the smallest value,
 /// 
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[3, 4, 5]).remove_min().to_list())
-/// // output: Cons(4, Cons(5, Nil))
+/// println(ImmutableSet::[3, 4, 5].remove_min())
+/// // output: ImmutableSet::(4, 5)
 /// ```
 pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
   match self {
@@ -94,13 +103,13 @@ pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[6, 3, 8, 1]).add(5).to_list())
-/// // output: Cons(1, Cons(3, Cons(5, Cons(6, Cons(8, Nil)))))
+/// println(ImmutableSet::[6, 3, 8, 1].add(5))
+/// // output: ImmutableSet::(1, 3, 5, 6, 8)
 /// ```
 pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
     Empty => Node({ left: Empty, value, right: Empty, height: 1 })
-    Node({ left, right, value: node_value, height: _ })=> {
+    Node({ left, right, value: node_value, height: _ }) => {
       let compare_result = value.compare(node_value)
       if compare_result == 0 {
         self
@@ -128,8 +137,8 @@ pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[3, 8, 1]).remove(8).to_list())
-/// // output: Cons(1, Cons(3, Nil))
+/// println(ImmutableSet::[3, 8, 1].remove(8))
+/// // output: ImmutableSet::(1, 3)
 /// ```
 pub fn remove[T : Compare](
   self : ImmutableSet[T],
@@ -165,7 +174,7 @@ pub fn remove[T : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).min())
+/// println(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].min())
 /// // output: 1
 /// ```
 pub fn min[T : Compare](self : ImmutableSet[T]) -> T {
@@ -197,7 +206,7 @@ pub fn min_option[T : Compare](self : ImmutableSet[T]) -> Option[T] {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).max())
+/// println(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].max())
 /// // output: 9
 /// ```
 pub fn max[T : Compare](self : ImmutableSet[T]) -> T {
@@ -231,10 +240,10 @@ pub fn max_option[T : Compare](self : ImmutableSet[T]) -> Option[T] {
 /// # Example
 /// 
 /// ```
-/// let (left, present, right) = ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1],).split(5)
+/// let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(5)
 /// println(present) // output: true
-/// println(left.to_list()) // output: Cons(1, Cons(2, Cons(3, Cons(4, Nil))))
-/// println(right.to_list()) // output: Cons(6, Cons(7, Cons(8, Cons(9, Nil))))
+/// println(left) // output: ImmutableSet::(1, 2, 3, 4)
+/// println(right) // output:ImmutableSet::(6, 7, 8, 9)
 /// ```
 pub fn split[T : Compare](
   self : ImmutableSet[T],
@@ -285,10 +294,8 @@ pub fn contain[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[3, 4, 5])
-///           .union(ImmutableSet::from_list(List::[4, 5, 6]))
-///           .to_list())
-/// // output: Cons(3, Cons(4, Cons(5, Cons(6, Nil))))
+/// println(ImmutableSet::[3, 4, 5].union(ImmutableSet::[4, 5, 6]))
+/// // output: ImmutableSet::(3, 4, 5, 6)
 /// ```
 pub fn union[T : Compare](
   self : ImmutableSet[T],
@@ -322,10 +329,8 @@ pub fn union[T : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[3, 4, 5])
-///           .inter(ImmutableSet::from_list(List::[4, 5, 6]))
-///           .to_list())
-/// // output: Cons(4, Cons(5, Nil))
+/// println(ImmutableSet::[3, 4, 5].inter(ImmutableSet::[4, 5, 6]))
+/// // output: ImmutableSet::(4, 5)
 /// ```
 pub fn inter[T : Compare](
   self : ImmutableSet[T],
@@ -346,10 +351,8 @@ pub fn inter[T : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 2, 3])
-///           .diff(ImmutableSet::from_list(List::[4, 5, 1]))
-///           .to_list())
-/// // output: Cons(2, Cons(3, Nil))
+/// println(ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]))
+/// // output: ImmutableSet::(2, 3)
 /// ```
 pub fn diff[T : Compare](
   self : ImmutableSet[T],
@@ -371,8 +374,7 @@ pub fn diff[T : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 2, 3]).subset(
-///   ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]))))
+/// println(ImmutableSet::[1, 2, 3].subset(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1]))
 /// // output: true
 /// ```
 pub fn subset[T : Compare](
@@ -407,8 +409,7 @@ pub fn subset[T : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 2, 3]).disjoint(
-///    ImmutableSet::from_list(List::[4, 5, 6]))))
+/// println(ImmutableSet::[1, 2, 3].disjoint(ImmutableSet::[4, 5, 6]))
 /// // output: true
 /// ```
 pub fn disjoint[T : Compare](
@@ -434,7 +435,7 @@ pub fn disjoint[T : Compare](
 /// # Example
 /// 
 /// ```
-/// ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).iter(print)
+/// ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].iter(print)
 /// // output: 123456789
 /// ```
 pub fn iter[T : Compare](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
@@ -453,10 +454,10 @@ pub fn iter[T : Compare](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 2, 3, 4, 5]).fold(0, fn(acc, x) { acc + x }))
+/// println(ImmutableSet::[1, 2, 3, 4, 5].fold(0, fn(acc, x) { acc + x }))
 /// // output: 15
 /// ```
-pub fn fold[T : Compare, U : Compare](
+pub fn fold[T : Compare, U](
   self : ImmutableSet[T],
   f : (U, T) -> U,
   ~initial : U
@@ -473,8 +474,8 @@ pub fn fold[T : Compare, U : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 2, 3]).map(fn(x){ x * 2}).to_list())
-/// // output: Cons(2, Cons(4, Cons(6, Nil)))
+/// println(ImmutableSet::[1, 2, 3].map(fn(x){ x * 2}))
+/// // output: ImmutableSet::(2, 4, 6)
 /// ```
 pub fn map[T : Compare, U : Compare](
   self : ImmutableSet[T],
@@ -492,7 +493,7 @@ pub fn map[T : Compare, U : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[2, 4, 6]).forall(fn(v) { v % 2 == 0}))
+/// println(ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0}))
 /// // output: true
 /// ```
 pub fn forall[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
@@ -508,7 +509,7 @@ pub fn forall[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 4, 3]).exists(fn(v) { v % 2 == 0}))
+/// println(ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0}))
 /// // output: true
 /// ```
 pub fn exists[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
@@ -524,8 +525,8 @@ pub fn exists[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).filter(fn(v) { v % 2 == 0}).to_list())
-/// // output: Cons(2, Cons(4, Cons(6, Nil)))
+/// println(ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0}))
+/// // output: ImmutableSet::(2, 4, 6)
 /// ```
 pub fn filter[T : Compare](
   self : ImmutableSet[T],
@@ -550,45 +551,32 @@ pub fn filter[T : Compare](
   }
 }
 
-/// Find value in self and return value if present, otherwise abort.
+/// Find value in self and return value if present with Option, otherwise None.
 /// 
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).find(6))
-/// // output: 6
+/// println(ImmutableSet::[1, 2, 3, 4, 5, 6].find(6))
+/// // output: Some(6)
 /// ```
-pub fn find[T : Compare](self : ImmutableSet[T], value : T) -> T {
-  match self {
-    Empty => abort("find: not found")
-    Node({ left, value: node_value, right, height: _ }) => {
-      let compare_result = value.compare(node_value)
-      if compare_result == 0 {
-        node_value
-      } else if compare_result < 0 {
-        left.find(value)
-      } else {
-        right.find(value)
-      }
-    }
+pub fn find[T : Compare](self : ImmutableSet[T], value : T) -> Option[T] {
+  match self.contain(value) {
+    true => Some(value)
+    false => None
   }
 }
 
-/// Same as find, but returns None if value is not found.
-pub fn find_option[T : Compare](self : ImmutableSet[T], value : T) -> Option[T] {
+pub fn to_string[T : Show + Compare](self : ImmutableSet[T]) -> String {
   match self {
-    Empty => None
-    Node({ left, value: node_value, right, height: _ }) => {
-      let compare_result = value.compare(node_value)
-      Some(
-        if compare_result == 0 {
-          node_value
-        } else if compare_result < 0 {
-          left.find(value)
-        } else {
-          right.find(value)
-        },
-      )
+    Empty => "ImmutableSet::()"
+    _ => {
+      let linear = self.to_array()
+      let len = linear.length()
+      for i = 0, str = "ImmutableSet::("; i < len - 1; {
+        continue i + 1, str + linear[i].to_string() + ", "
+      } else {
+        str + linear[len - 1].to_string() + ")"
+      }
     }
   }
 }
@@ -850,214 +838,164 @@ fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
 
 test "disjoint" {
   @assertion.assert_true(
-    ImmutableSet::from_list(List::[1, 2, 3]).disjoint(
-      ImmutableSet::from_list(List::[4, 5, 6]),
-    ),
+    ImmutableSet::[1, 2, 3].disjoint(ImmutableSet::[4, 5, 6]),
   )?
   @assertion.assert_false(
-    ImmutableSet::from_list(List::[1, 2, 3]).subset(
-      ImmutableSet::from_list(List::[3, 4, 5]),
-    ),
+    ImmutableSet::[1, 2, 3].subset(ImmutableSet::[3, 4, 5]),
   )?
 }
 
 test "subset" {
   @assertion.assert_true(
-    ImmutableSet::from_list(List::[1, 2, 3]).subset(
-      ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
-    ),
+    ImmutableSet::[1, 2, 3].subset(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
   )?
   @assertion.assert_false(
-    ImmutableSet::from_list(List::[1, 2, 3]).subset(
-      ImmutableSet::from_list(List::[10, 11, 12, 13, 14]),
-    ),
+    ImmutableSet::[1, 2, 3].subset(ImmutableSet::[10, 11, 12, 13, 14]),
   )?
 }
 
 test "diff" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[1, 2, 3]).diff(
-      ImmutableSet::from_list(List::[4, 5, 1]),
-    ).to_list(),
-    List::[2, 3],
+    ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]).to_array(),
+    [2, 3],
   )?
 }
 
 test "inter" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[3, 4, 5]).inter(
-      ImmutableSet::from_list(List::[4, 5, 6]),
-    ).to_list(),
-    List::[4, 5],
+    ImmutableSet::[3, 4, 5].inter(ImmutableSet::[4, 5, 6]).to_array(),
+    [4, 5],
   )?
 }
 
 test "union" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[3, 4, 5]).union(
-      ImmutableSet::from_list(List::[4, 5, 6]),
-    ).to_list(),
-    List::[3, 4, 5, 6],
+    ImmutableSet::[3, 4, 5].union(ImmutableSet::[4, 5, 6]).to_array(),
+    [3, 4, 5, 6],
   )?
 }
 
 test "map" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[1, 2, 3, 4, 5]).map(fn(x) { x * 2 }).to_list(),
-    List::[2, 4, 6, 8, 10],
+    ImmutableSet::[1, 2, 3, 4, 5].map(fn(x) { x * 2 }).to_array(),
+    [2, 4, 6, 8, 10],
   )?
 }
 
 test "forall" {
-  @assertion.assert_true(
-    ImmutableSet::from_list(List::[2, 4, 6]).forall(fn(v) { v % 2 == 0 }),
-  )?
-  @assertion.assert_false(
-    ImmutableSet::from_list(List::[1, 3, 5]).forall(fn(v) { v % 2 == 0 }),
-  )?
+  @assertion.assert_true(ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0 }))?
+  @assertion.assert_false(ImmutableSet::[1, 3, 5].forall(fn(v) { v % 2 == 0 }))?
 }
 
 test "exists" {
-  @assertion.assert_true(
-    ImmutableSet::from_list(List::[1, 4, 3]).exists(fn(v) { v % 2 == 0 }),
-  )?
-  @assertion.assert_false(
-    ImmutableSet::from_list(List::[1, 5, 3]).exists(fn(v) { v % 2 == 0 }),
-  )?
+  @assertion.assert_true(ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0 }))?
+  @assertion.assert_false(ImmutableSet::[1, 5, 3].exists(fn(v) { v % 2 == 0 }))?
 }
 
 test "fold" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[1, 2, 3, 4, 5]).fold(
-      ~initial=0,
-      fn(acc, x) { acc + x },
-    ),
+    ImmutableSet::[1, 2, 3, 4, 5].fold(~initial=0, fn(acc, x) { acc + x }),
     15,
   )?
 }
 
 test "filter" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).filter(
-      fn(v) { v % 2 == 0 },
-    ).to_list(),
-    List::[2, 4, 6],
+    ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0 }).to_array(),
+    [2, 4, 6],
   )?
 }
 
 test "find" {
-  @assertion.assert_eq(
-    6,
-    ImmutableSet::from_list(List::[1, 2, 3, 4, 5, 6]).find(6),
-  )?
+  @assertion.assert_eq(ImmutableSet::[1, 2, 3, 4, 5, 6].find(6), Some(6))?
+  @assertion.assert_eq(ImmutableSet::[1, 2, 3, 4, 5, 6].find(7), None)?
 }
 
 test "max" {
-  @assertion.assert_eq(
-    9,
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).max(),
-  )?
+  @assertion.assert_eq(9, ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].max())?
 }
 
 test "split" {
-  let (left, present, right) = ImmutableSet::from_list(
-    List::[7, 2, 9, 4, 5, 6, 3, 8, 1],
-  ).split(5)
+  let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(
+    5,
+  )
   @assertion.assert_true(present)?
-  @assertion.assert_eq(left.to_list(), List::[1, 2, 3, 4])?
-  @assertion.assert_eq(right.to_list(), List::[6, 7, 8, 9])?
-  let (left, present, right) = ImmutableSet::from_list(
-    List::[7, 2, 9, 4, 5, 6, 3, 8, 1],
-  ).split(0)
+  @assertion.assert_eq(left.to_array(), [1, 2, 3, 4])?
+  @assertion.assert_eq(right.to_array(), [6, 7, 8, 9])?
+  let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(
+    0,
+  )
   @assertion.assert_false(present)?
-  @assertion.assert_eq(left.to_list(), Nil)?
-  @assertion.assert_eq(right.to_list(), List::[1, 2, 3, 4, 5, 6, 7, 8, 9])?
+  @assertion.assert_eq(left.to_array(), [])?
+  @assertion.assert_eq(right.to_array(), [1, 2, 3, 4, 5, 6, 7, 8, 9])?
 }
 
 test "contain" {
   @assertion.assert_true(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 6, 3, 8, 1]).add(5).contain(5),
+    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).contain(5),
   )?
+  @assertion.assert_false(ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].contain(5))?
 }
 
 test "from_list" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
-    Node(
-      {
-        left: Node(
-          {
-            left: Node(
-              {
-                left: Node({ left: Empty, right: Empty, height: 1, value: 1 }),
-                right: Empty,
-                height: 2,
-                value: 2,
-              },
-            ),
-            right: Node({ left: Empty, right: Empty, height: 1, value: 4 }),
-            height: 3,
-            value: 3,
-          },
-        ),
-        right: Node(
-          {
-            left: Node(
-              {
-                left: Node({ left: Empty, right: Empty, height: 1, value: 6 }),
-                right: Empty,
-                height: 2,
-                value: 7,
-              },
-            ),
-            right: Node({ left: Empty, right: Empty, height: 1, value: 9 }),
-            height: 3,
-            value: 8,
-          },
-        ),
-        height: 4,
-        value: 5,
-      },
-    ),
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).to_array(),
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
   )?
 }
 
 test "to_list" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).to_list(),
-    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
+  )?
+}
+
+test "to_array" {
+  @assertion.assert_eq(
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
   )?
 }
 
 test "from_array" {
   @assertion.assert_eq(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_list(),
-    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
   )?
 }
 
 test "remove_min" {
-  let set = ImmutableSet::from_list(List::[3, 4, 5]).remove_min()
-  @assertion.assert_eq(set.to_list(), List::[4, 5])?
+  @assertion.assert_eq(ImmutableSet::[3, 4, 5].remove_min().to_array(), [4, 5])?
 }
 
 test "add" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 6, 3, 8, 1]).add(5).to_list(),
-    List::[1, 2, 3, 4, 5, 6, 7, 8, 9],
+    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).to_array(),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
   )?
 }
 
 test "remove" {
   @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(8).to_list(),
-    List::[1, 2, 3, 4, 5, 6, 7, 9],
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].remove(8).to_array(),
+    [1, 2, 3, 4, 5, 6, 7, 9],
   )?
 }
 
 test "min" {
-  @assertion.assert_eq(
-    1,
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).min(),
+  @assertion.assert_eq(1, ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].min())?
+}
+
+test "is_emtpy" {
+  @assertion.assert_true(ImmutableSet::[].is_empty())?
+  @assertion.assert_false(ImmutableSet::[1].is_empty())?
+}
+
+test "to_string" {
+  inspect(
+    ImmutableSet::[1, 2, 3, 4, 5],
+    ~content="ImmutableSet::(1, 2, 3, 4, 5)",
   )?
+  inspect(ImmutableSet::[], ~content="ImmutableSet::()")?
 }

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -933,10 +933,19 @@ test "contain" {
 }
 
 test "from_list" {
-  inspect(List::[1], ~content="List::[1]")?
-  inspect(List::[1, 2], ~content="List::[1, 2]")?
-  inspect(List::[1, 2, 3], ~content="List::[1, 2, 3]")?
-  inspect(List::[1, 2, 3, 4], ~content="List::[1, 2, 3, 4]")?
+  inspect(ImmutableSet::from_list(List::[1]), ~content="ImmutableSet::[1]")?
+  inspect(
+    ImmutableSet::from_list(List::[1, 2]),
+    ~content="ImmutableSet::[1, 2]",
+  )?
+  inspect(
+    ImmutableSet::from_list(List::[1, 2, 3]),
+    ~content="ImmutableSet::[1, 2, 3]",
+  )?
+  inspect(
+    ImmutableSet::from_list(List::[1, 2, 3, 4]),
+    ~content="ImmutableSet::[1, 2, 3, 4]",
+  )?
   inspect(
     ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
     ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
@@ -983,6 +992,11 @@ test "add" {
   inspect(ImmutableSet::[2].add(1), ~content="ImmutableSet::[1, 2]")?
   inspect(ImmutableSet::[2].add(3), ~content="ImmutableSet::[2, 3]")?
   inspect(ImmutableSet::[2].add(1).add(3), ~content="ImmutableSet::[1, 2, 3]")?
+  inspect(ImmutableSet::[1, 2].add(1), ~content="ImmutableSet::[1, 2]")?
+  inspect(ImmutableSet::[2, 3].add(3), ~content="ImmutableSet::[2, 3]")?
+  inspect(ImmutableSet::[1, 2, 3].add(1), ~content="ImmutableSet::[1, 2, 3]")?
+  inspect(ImmutableSet::[1, 2, 3].add(3), ~content="ImmutableSet::[1, 2, 3]")?
+  inspect(ImmutableSet::[1].add(2).add(2), ~content="ImmutableSet::[1, 2]")?
 }
 
 test "remove" {

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -974,6 +974,9 @@ test "add" {
     ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).to_array(),
     [1, 2, 3, 4, 5, 6, 7, 8, 9],
   )?
+  @assertion.assert_eq(ImmutableSet::[2].add(1).to_array(), [1, 2])?
+  @assertion.assert_eq(ImmutableSet::[2].add(3).to_array(), [2, 3])?
+  @assertion.assert_eq(ImmutableSet::[2].add(1).add(3).to_array(), [1, 2, 3])?
 }
 
 test "remove" {

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -22,7 +22,7 @@ pub fn ImmutableSet::new[T]() -> ImmutableSet[T] {
 }
 
 /// Returns the one-value ImmutableSet containing only `value`.
-pub fn ImmutableSet::from_value[T : Compare](value : T) -> ImmutableSet[T] {
+pub fn ImmutableSet::singleton[T : Compare](value : T) -> ImmutableSet[T] {
   Node({ left: Empty, value, right: Empty, height: 1 })
 }
 
@@ -31,17 +31,14 @@ pub fn ImmutableSet::from_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
   match list {
     Nil => Empty
     // For very small lists, adding values to the set directly using the add function is much faster than sorting and de-important the entire list.
-    Cons(value, Nil) => ImmutableSet::from_value(value)
-    Cons(value, Cons(value1, Nil)) =>
-      ImmutableSet::from_value(value).add(value1)
+    Cons(value, Nil) => singleton(value)
+    Cons(value, Cons(value1, Nil)) => singleton(value).add(value1)
     Cons(value, Cons(value1, Cons(value2, Nil))) =>
-      ImmutableSet::from_value(value).add(value1).add(value2)
+      singleton(value).add(value1).add(value2)
     Cons(value, Cons(value1, Cons(value2, Cons(value3, Nil)))) =>
-      ImmutableSet::from_value(value).add(value1).add(value2).add(value3)
+      singleton(value).add(value1).add(value2).add(value3)
     Cons(value, Cons(value1, Cons(value2, Cons(value3, Cons(value4, Nil))))) =>
-      ImmutableSet::from_value(value).add(value1).add(value2).add(value3).add(
-        value4,
-      )
+      singleton(value).add(value1).add(value2).add(value3).add(value4)
     _ => of_sorted_list(list.sort())
   }
 }
@@ -75,8 +72,15 @@ pub fn to_array[T : Compare](self : ImmutableSet[T]) -> Array[T] {
   match self {
     Empty => []
     Node({ left, value, right, .. }) =>
-      to_array(left).concat([value]).concat(to_array(right))
+      to_array(left) + [value] + to_array(right)
   }
+}
+
+/// Convert ImmutableSet[T] to Vec[T], the result must be ordered.
+pub fn to_vec[T : Compare](self : ImmutableSet[T]) -> @vec.Vec[T] {
+  // This approach is better than using vec splicing implementation 
+  // due to the existence of scaling costs for Vec
+  @vec.from_array(self.to_array())
 }
 
 /// Remove the smallest value,
@@ -551,21 +555,6 @@ pub fn filter[T : Compare](
   }
 }
 
-/// Find value in self and return value if present with Option, otherwise None.
-/// 
-/// # Example
-/// 
-/// ```
-/// println(ImmutableSet::[1, 2, 3, 4, 5, 6].find(6))
-/// // output: Some(6)
-/// ```
-pub fn find[T : Compare](self : ImmutableSet[T], value : T) -> Option[T] {
-  match self.contain(value) {
-    true => Some(value)
-    false => None
-  }
-}
-
 pub fn to_string[T : Show + Compare](self : ImmutableSet[T]) -> String {
   match self {
     Empty => "ImmutableSet::[]"
@@ -703,7 +692,7 @@ fn add_min_value[T : Compare](
   value : T
 ) -> ImmutableSet[T] {
   match self {
-    Empty => ImmutableSet::from_value(value)
+    Empty => singleton(value)
     Node({ left, value: node_value, right, .. }) =>
       balance(left.add_min_value(value), node_value, right)
   }
@@ -714,7 +703,7 @@ fn add_max_value[T : Compare](
   value : T
 ) -> ImmutableSet[T] {
   match self {
-    Empty => ImmutableSet::from_value(value)
+    Empty => singleton(value)
     Node({ left, value: node_value, right, .. }) =>
       balance(left, node_value, right.add_max_value(value))
   }
@@ -837,162 +826,146 @@ fn of_sorted_list[T : Compare](list : List[T]) -> ImmutableSet[T] {
 }
 
 test "disjoint" {
-  @assertion.assert_true(
+  inspect(
     ImmutableSet::[1, 2, 3].disjoint(ImmutableSet::[4, 5, 6]),
+    ~content="true",
   )?
-  @assertion.assert_false(
+  inspect(
     ImmutableSet::[1, 2, 3].subset(ImmutableSet::[3, 4, 5]),
+    ~content="false",
   )?
 }
 
 test "subset" {
-  @assertion.assert_true(
+  inspect(
     ImmutableSet::[1, 2, 3].subset(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    ~content="true",
   )?
-  @assertion.assert_false(
+  inspect(
     ImmutableSet::[1, 2, 3].subset(ImmutableSet::[10, 11, 12, 13, 14]),
+    ~content="false",
   )?
 }
 
 test "diff" {
-  @assertion.assert_eq(
-    ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]).to_array(),
-    [2, 3],
+  inspect(
+    ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]),
+    ~content="ImmutableSet::[2, 3]",
   )?
 }
 
 test "inter" {
-  @assertion.assert_eq(
-    ImmutableSet::[3, 4, 5].inter(ImmutableSet::[4, 5, 6]).to_array(),
-    [4, 5],
-  )?
+  inspect(ImmutableSet::[3, 4, 5].inter(ImmutableSet::[4, 5, 6]), ~content="ImmutableSet::[4, 5]")?
 }
 
 test "union" {
-  @assertion.assert_eq(
-    ImmutableSet::[3, 4, 5].union(ImmutableSet::[4, 5, 6]).to_array(),
-    [3, 4, 5, 6],
-  )?
+  inspect(ImmutableSet::[3, 4, 5].union(ImmutableSet::[4, 5, 6]), ~content="ImmutableSet::[3, 4, 5, 6]")?
 }
 
 test "map" {
-  @assertion.assert_eq(
-    ImmutableSet::[1, 2, 3, 4, 5].map(fn(x) { x * 2 }).to_array(),
-    [2, 4, 6, 8, 10],
-  )?
+  inspect(ImmutableSet::[1, 2, 3, 4, 5].map(fn(x) { x * 2 }), ~content="ImmutableSet::[2, 4, 6, 8, 10]")?
 }
 
 test "forall" {
-  @assertion.assert_true(ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0 }))?
-  @assertion.assert_false(ImmutableSet::[1, 3, 5].forall(fn(v) { v % 2 == 0 }))?
+  inspect(ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0 }), ~content="true")?
+  inspect(ImmutableSet::[1, 3, 5].forall(fn(v) { v % 2 == 0 }), ~content="false")?
 }
 
 test "exists" {
-  @assertion.assert_true(ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0 }))?
-  @assertion.assert_false(ImmutableSet::[1, 5, 3].exists(fn(v) { v % 2 == 0 }))?
+  inspect(ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0 }), ~content="true")?
+  inspect(ImmutableSet::[1, 5, 3].exists(fn(v) { v % 2 == 0 }), ~content="false")?
 }
 
 test "fold" {
-  @assertion.assert_eq(
-    ImmutableSet::[1, 2, 3, 4, 5].fold(~init=0, fn(acc, x) { acc + x }),
-    15,
-  )?
+  inspect(ImmutableSet::[1, 2, 3, 4, 5].fold(~init=0, fn(acc, x) { acc + x }), ~content="15")?
 }
 
 test "filter" {
-  @assertion.assert_eq(
-    ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0 }).to_array(),
-    [2, 4, 6],
-  )?
-}
-
-test "find" {
-  @assertion.assert_eq(ImmutableSet::[1, 2, 3, 4, 5, 6].find(6), Some(6))?
-  @assertion.assert_eq(ImmutableSet::[1, 2, 3, 4, 5, 6].find(7), None)?
+  inspect(ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0 }), ~content="ImmutableSet::[2, 4, 6]")?
 }
 
 test "max" {
-  @assertion.assert_eq(9, ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].max())?
+  inspect(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].max(), ~content="9")?
 }
 
 test "split" {
   let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(
     5,
   )
-  @assertion.assert_true(present)?
-  @assertion.assert_eq(left.to_array(), [1, 2, 3, 4])?
-  @assertion.assert_eq(right.to_array(), [6, 7, 8, 9])?
+  inspect(present, ~content="true")?
+  inspect(left, ~content="ImmutableSet::[1, 2, 3, 4]")?
+  inspect(right, ~content="ImmutableSet::[6, 7, 8, 9]")?
   let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(
     0,
   )
-  @assertion.assert_false(present)?
-  @assertion.assert_eq(left.to_array(), [])?
-  @assertion.assert_eq(right.to_array(), [1, 2, 3, 4, 5, 6, 7, 8, 9])?
+  inspect(present, ~content="false")?
+  inspect(left, ~content="ImmutableSet::[]")?
+  inspect(right, ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
 }
 
 test "contain" {
-  @assertion.assert_true(
+  inspect(
     ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).contain(5),
-  )?
-  @assertion.assert_false(ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].contain(5))?
+  ~content="true")?
+  inspect(ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].contain(5), ~content="false")?
 }
 
 test "from_list" {
-  @assertion.assert_eq(
-    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]).to_array(),
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
-  )?
+  inspect(
+    ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
+  ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
 }
 
 test "to_list" {
-  @assertion.assert_eq(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
-    [1, 2, 3, 4, 5, 6, 7, 8, 9],
-  )?
+  inspect(
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1],
+  ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
 }
 
 test "to_array" {
-  @assertion.assert_eq(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
-    [1, 2, 3, 4, 5, 6, 7, 8, 9],
-  )?
+  inspect(
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array()
+  , ~content="[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+}
+
+test "to_vec" {
+  inspect(
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_vec(),
+  ~content="Vec::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
 }
 
 test "from_array" {
-  @assertion.assert_eq(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
-    [1, 2, 3, 4, 5, 6, 7, 8, 9],
-  )?
+  inspect(
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1]
+  , ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
 }
 
 test "remove_min" {
-  @assertion.assert_eq(ImmutableSet::[3, 4, 5].remove_min().to_array(), [4, 5])?
+  inspect(ImmutableSet::[3, 4, 5].remove_min(), ~content="ImmutableSet::[4, 5]")?
 }
 
 test "add" {
-  @assertion.assert_eq(
-    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).to_array(),
-    [1, 2, 3, 4, 5, 6, 7, 8, 9],
-  )?
-  @assertion.assert_eq(ImmutableSet::[2].add(1).to_array(), [1, 2])?
-  @assertion.assert_eq(ImmutableSet::[2].add(3).to_array(), [2, 3])?
-  @assertion.assert_eq(ImmutableSet::[2].add(1).add(3).to_array(), [1, 2, 3])?
+  inspect(
+    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5)
+  , ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+  inspect(ImmutableSet::[2].add(1), ~content="ImmutableSet::[1, 2]")?
+  inspect(ImmutableSet::[2].add(3), ~content="ImmutableSet::[2, 3]")?
+  inspect(ImmutableSet::[2].add(1).add(3), ~content="ImmutableSet::[1, 2, 3]")?
 }
 
 test "remove" {
-  @assertion.assert_eq(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].remove(8).to_array(),
-    [1, 2, 3, 4, 5, 6, 7, 9],
-  )?
+  inspect(
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].remove(8)
+  , ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 9]")?
 }
 
 test "min" {
-  @assertion.assert_eq(1, ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].min())?
+  inspect(ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].min(), ~content="1")?
 }
 
 test "is_empty" {
-  @assertion.assert_true(ImmutableSet::[].is_empty())?
-  @assertion.assert_false(ImmutableSet::[1].is_empty())?
+  inspect(ImmutableSet::[].is_empty(), ~content="true")?
+  inspect(ImmutableSet::[1].is_empty(), ~content="false")?
 }
 
 test "to_string" {

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -85,7 +85,7 @@ pub fn to_array[T : Compare](self : ImmutableSet[T]) -> Array[T] {
 /// 
 /// ```
 /// println(ImmutableSet::[3, 4, 5].remove_min())
-/// // output: ImmutableSet::(4, 5)
+/// // output: ImmutableSet::[4, 5]
 /// ```
 pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
   match self {
@@ -104,7 +104,7 @@ pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
 /// 
 /// ```
 /// println(ImmutableSet::[6, 3, 8, 1].add(5))
-/// // output: ImmutableSet::(1, 3, 5, 6, 8)
+/// // output: ImmutableSet::[1, 3, 5, 6, 8]
 /// ```
 pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
@@ -138,7 +138,7 @@ pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
 /// 
 /// ```
 /// println(ImmutableSet::[3, 8, 1].remove(8))
-/// // output: ImmutableSet::(1, 3)
+/// // output: ImmutableSet::[1, 3]
 /// ```
 pub fn remove[T : Compare](
   self : ImmutableSet[T],
@@ -242,8 +242,8 @@ pub fn max_option[T : Compare](self : ImmutableSet[T]) -> Option[T] {
 /// ```
 /// let (left, present, right) = ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].split(5)
 /// println(present) // output: true
-/// println(left) // output: ImmutableSet::(1, 2, 3, 4)
-/// println(right) // output:ImmutableSet::(6, 7, 8, 9)
+/// println(left) // output: ImmutableSet::[1, 2, 3, 4]
+/// println(right) // output:ImmutableSet::[6, 7, 8, 9]
 /// ```
 pub fn split[T : Compare](
   self : ImmutableSet[T],
@@ -295,7 +295,7 @@ pub fn contain[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
 /// 
 /// ```
 /// println(ImmutableSet::[3, 4, 5].union(ImmutableSet::[4, 5, 6]))
-/// // output: ImmutableSet::(3, 4, 5, 6)
+/// // output: ImmutableSet::[3, 4, 5, 6]
 /// ```
 pub fn union[T : Compare](
   self : ImmutableSet[T],
@@ -330,7 +330,7 @@ pub fn union[T : Compare](
 /// 
 /// ```
 /// println(ImmutableSet::[3, 4, 5].inter(ImmutableSet::[4, 5, 6]))
-/// // output: ImmutableSet::(4, 5)
+/// // output: ImmutableSet::[4, 5]
 /// ```
 pub fn inter[T : Compare](
   self : ImmutableSet[T],
@@ -352,7 +352,7 @@ pub fn inter[T : Compare](
 /// 
 /// ```
 /// println(ImmutableSet::[1, 2, 3].diff(ImmutableSet::[4, 5, 1]))
-/// // output: ImmutableSet::(2, 3)
+/// // output: ImmutableSet::[2, 3]
 /// ```
 pub fn diff[T : Compare](
   self : ImmutableSet[T],
@@ -475,7 +475,7 @@ pub fn fold[T : Compare, U](
 /// 
 /// ```
 /// println(ImmutableSet::[1, 2, 3].map(fn(x){ x * 2}))
-/// // output: ImmutableSet::(2, 4, 6)
+/// // output: ImmutableSet::[2, 4, 6]
 /// ```
 pub fn map[T : Compare, U : Compare](
   self : ImmutableSet[T],
@@ -526,7 +526,7 @@ pub fn exists[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
 /// 
 /// ```
 /// println(ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0}))
-/// // output: ImmutableSet::(2, 4, 6)
+/// // output: ImmutableSet::[2, 4, 6]
 /// ```
 pub fn filter[T : Compare](
   self : ImmutableSet[T],
@@ -568,14 +568,14 @@ pub fn find[T : Compare](self : ImmutableSet[T], value : T) -> Option[T] {
 
 pub fn to_string[T : Show + Compare](self : ImmutableSet[T]) -> String {
   match self {
-    Empty => "ImmutableSet::()"
+    Empty => "ImmutableSet::[]"
     _ => {
       let linear = self.to_array()
       let len = linear.length()
-      for i = 0, str = "ImmutableSet::("; i < len - 1; {
+      for i = 0, str = "ImmutableSet::["; i < len - 1; {
         continue i + 1, str + linear[i].to_string() + ", "
       } else {
-        str + linear[len - 1].to_string() + ")"
+        str + linear[len - 1].to_string() + "]"
       }
     }
   }
@@ -998,7 +998,7 @@ test "is_empty" {
 test "to_string" {
   inspect(
     ImmutableSet::[1, 2, 3, 4, 5],
-    ~content="ImmutableSet::(1, 2, 3, 4, 5)",
+    ~content="ImmutableSet::[1, 2, 3, 4, 5]",
   )?
-  inspect(ImmutableSet::[], ~content="ImmutableSet::()")?
+  inspect(ImmutableSet::[], ~content="ImmutableSet::[]")?
 }

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -62,7 +62,7 @@ pub fn to_list[T : Compare](self : ImmutableSet[T]) -> List[T] {
   fn values_aux(set : ImmutableSet[T], list : List[T]) {
     match set {
       Empty => list
-      Node({ left, right, value,.. }) =>
+      Node({ left, right, value, .. }) =>
         values_aux(left, Cons(value, values_aux(right, list)))
     }
   }
@@ -534,7 +534,7 @@ pub fn filter[T : Compare](
 ) -> ImmutableSet[T] {
   match self {
     Empty => Empty
-    Node({ left, value, right,.. }) => {
+    Node({ left, value, right, .. }) => {
       let l = left.filter(f)
       let v = f(value)
       let r = right.filter(f)

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -855,33 +855,54 @@ test "diff" {
 }
 
 test "inter" {
-  inspect(ImmutableSet::[3, 4, 5].inter(ImmutableSet::[4, 5, 6]), ~content="ImmutableSet::[4, 5]")?
+  inspect(
+    ImmutableSet::[3, 4, 5].inter(ImmutableSet::[4, 5, 6]),
+    ~content="ImmutableSet::[4, 5]",
+  )?
 }
 
 test "union" {
-  inspect(ImmutableSet::[3, 4, 5].union(ImmutableSet::[4, 5, 6]), ~content="ImmutableSet::[3, 4, 5, 6]")?
+  inspect(
+    ImmutableSet::[3, 4, 5].union(ImmutableSet::[4, 5, 6]),
+    ~content="ImmutableSet::[3, 4, 5, 6]",
+  )?
 }
 
 test "map" {
-  inspect(ImmutableSet::[1, 2, 3, 4, 5].map(fn(x) { x * 2 }), ~content="ImmutableSet::[2, 4, 6, 8, 10]")?
+  inspect(
+    ImmutableSet::[1, 2, 3, 4, 5].map(fn(x) { x * 2 }),
+    ~content="ImmutableSet::[2, 4, 6, 8, 10]",
+  )?
 }
 
 test "forall" {
   inspect(ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0 }), ~content="true")?
-  inspect(ImmutableSet::[1, 3, 5].forall(fn(v) { v % 2 == 0 }), ~content="false")?
+  inspect(
+    ImmutableSet::[1, 3, 5].forall(fn(v) { v % 2 == 0 }),
+    ~content="false",
+  )?
 }
 
 test "exists" {
   inspect(ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0 }), ~content="true")?
-  inspect(ImmutableSet::[1, 5, 3].exists(fn(v) { v % 2 == 0 }), ~content="false")?
+  inspect(
+    ImmutableSet::[1, 5, 3].exists(fn(v) { v % 2 == 0 }),
+    ~content="false",
+  )?
 }
 
 test "fold" {
-  inspect(ImmutableSet::[1, 2, 3, 4, 5].fold(~init=0, fn(acc, x) { acc + x }), ~content="15")?
+  inspect(
+    ImmutableSet::[1, 2, 3, 4, 5].fold(~init=0, fn(acc, x) { acc + x }),
+    ~content="15",
+  )?
 }
 
 test "filter" {
-  inspect(ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0 }), ~content="ImmutableSet::[2, 4, 6]")?
+  inspect(
+    ImmutableSet::[1, 2, 3, 4, 5, 6].filter(fn(v) { v % 2 == 0 }),
+    ~content="ImmutableSet::[2, 4, 6]",
+  )?
 }
 
 test "max" {
@@ -906,38 +927,48 @@ test "split" {
 test "contain" {
   inspect(
     ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).contain(5),
-  ~content="true")?
+    ~content="true",
+  )?
   inspect(ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].contain(5), ~content="false")?
 }
 
 test "from_list" {
+  inspect(List::[1], ~content="List::[1]")?
+  inspect(List::[1, 2], ~content="List::[1, 2]")?
+  inspect(List::[1, 2, 3], ~content="List::[1, 2, 3]")?
+  inspect(List::[1, 2, 3, 4], ~content="List::[1, 2, 3, 4]")?
   inspect(
     ImmutableSet::from_list(List::[7, 2, 9, 4, 5, 6, 3, 8, 1]),
-  ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+    ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+  )?
 }
 
 test "to_list" {
   inspect(
     ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1],
-  ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+    ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+  )?
 }
 
 test "to_array" {
   inspect(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array()
-  , ~content="[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_array(),
+    ~content="[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+  )?
 }
 
 test "to_vec" {
   inspect(
     ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].to_vec(),
-  ~content="Vec::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+    ~content="Vec::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+  )?
 }
 
 test "from_array" {
   inspect(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1]
-  , ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1],
+    ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+  )?
 }
 
 test "remove_min" {
@@ -946,8 +977,9 @@ test "remove_min" {
 
 test "add" {
   inspect(
-    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5)
-  , ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5),
+    ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+  )?
   inspect(ImmutableSet::[2].add(1), ~content="ImmutableSet::[1, 2]")?
   inspect(ImmutableSet::[2].add(3), ~content="ImmutableSet::[2, 3]")?
   inspect(ImmutableSet::[2].add(1).add(3), ~content="ImmutableSet::[1, 2, 3]")?
@@ -955,8 +987,9 @@ test "add" {
 
 test "remove" {
   inspect(
-    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].remove(8)
-  , ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 9]")?
+    ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].remove(8),
+    ~content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 9]",
+  )?
 }
 
 test "min" {

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -987,7 +987,7 @@ test "min" {
   @assertion.assert_eq(1, ImmutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1].min())?
 }
 
-test "is_emtpy" {
+test "is_empty" {
   @assertion.assert_true(ImmutableSet::[].is_empty())?
   @assertion.assert_false(ImmutableSet::[1].is_empty())?
 }

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -62,7 +62,7 @@ pub fn to_list[T : Compare](self : ImmutableSet[T]) -> List[T] {
   fn values_aux(set : ImmutableSet[T], list : List[T]) {
     match set {
       Empty => list
-      Node({ left, right, value, height: _ }) =>
+      Node({ left, right, value,.. }) =>
         values_aux(left, Cons(value, values_aux(right, list)))
     }
   }
@@ -74,7 +74,7 @@ pub fn to_list[T : Compare](self : ImmutableSet[T]) -> List[T] {
 pub fn to_array[T : Compare](self : ImmutableSet[T]) -> Array[T] {
   match self {
     Empty => []
-    Node({ left, value, right, height: _ }) =>
+    Node({ left, value, right, .. }) =>
       to_array(left).concat([value]).concat(to_array(right))
   }
 }
@@ -90,7 +90,7 @@ pub fn to_array[T : Compare](self : ImmutableSet[T]) -> Array[T] {
 pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
   match self {
     Empty => abort("remove_min: empty ImmutableSet")
-    Node({ left, right, value, height: _ }) =>
+    Node({ left, right, value, .. }) =>
       match left {
         Empty => right
         _ => balance(left.remove_min(), value, right)
@@ -109,7 +109,7 @@ pub fn remove_min[T : Compare](self : ImmutableSet[T]) -> ImmutableSet[T] {
 pub fn add[T : Compare](self : ImmutableSet[T], value : T) -> ImmutableSet[T] {
   match self {
     Empty => Node({ left: Empty, value, right: Empty, height: 1 })
-    Node({ left, right, value: node_value, height: _ }) => {
+    Node({ left, right, value: node_value, .. }) => {
       let compare_result = value.compare(node_value)
       if compare_result == 0 {
         self
@@ -338,7 +338,7 @@ pub fn inter[T : Compare](
 ) -> ImmutableSet[T] {
   match (self, other) {
     (Empty, _) | (_, Empty) => Empty
-    (Node({ left: l1, value: v1, right: r1, height: _ }), _) =>
+    (Node({ left: l1, value: v1, right: r1, .. }), _) =>
       match other.split(v1) {
         (l2, false, r2) => l1.inter(l2).concat(r1.inter(r2))
         (l2, true, r2) => join(l1.inter(l2), v1, r1.inter(r2))
@@ -361,7 +361,7 @@ pub fn diff[T : Compare](
   match (self, other) {
     (Empty, _) => Empty
     (_, Empty) => self
-    (Node({ left: l1, value: v1, right: r1, height: _ }), _) =>
+    (Node({ left: l1, value: v1, right: r1, .. }), _) =>
       match other.split(v1) {
         (l2, false, r2) => join(l1.diff(l2), v1, r1.diff(r2))
         (l2, true, r2) => l1.diff(l2).concat(r1.diff(r2))
@@ -385,8 +385,8 @@ pub fn subset[T : Compare](
     (Empty, _) => true
     (_, Empty) => false
     (
-      Node({ left: l1, value: v1, right: r1, height: _ }),
-      Node({ left: l2, value: v2, right: r2, height: _ }),
+      Node({ left: l1, value: v1, right: r1, .. }),
+      Node({ left: l2, value: v2, right: r2, .. }),
     ) => {
       let compare_result = v1.compare(v2)
       if compare_result == 0 {
@@ -418,7 +418,7 @@ pub fn disjoint[T : Compare](
 ) -> Bool {
   match (self, other) {
     (Empty, _) | (_, Empty) => true
-    (Node({ left: l1, value: v1, right: r1, height: _ }), _) =>
+    (Node({ left: l1, value: v1, right: r1, .. }), _) =>
       if physical_equal(self, other) {
         false
       } else {
@@ -441,7 +441,7 @@ pub fn disjoint[T : Compare](
 pub fn iter[T : Compare](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
   match self {
     Empty => ()
-    Node({ left, value, right, height: _ }) => {
+    Node({ left, value, right, .. }) => {
       left.iter(f)
       f(value)
       right.iter(f)
@@ -460,12 +460,12 @@ pub fn iter[T : Compare](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
 pub fn fold[T : Compare, U](
   self : ImmutableSet[T],
   f : (U, T) -> U,
-  ~initial : U
+  ~init : U
 ) -> U {
   match self {
-    Empty => initial
-    Node({ left, value, right, height: _ }) =>
-      right.fold(~initial=f(left.fold(~initial, f), value), f)
+    Empty => init
+    Node({ left, value, right, .. }) =>
+      right.fold(~init=f(left.fold(~init, f), value), f)
   }
 }
 
@@ -483,7 +483,7 @@ pub fn map[T : Compare, U : Compare](
 ) -> ImmutableSet[U] {
   match self {
     Empty => Empty
-    Node({ left, value, right, height: _ }) =>
+    Node({ left, value, right, .. }) =>
       try_join(left.map(f), f(value), right.map(f))
   }
 }
@@ -499,7 +499,7 @@ pub fn map[T : Compare, U : Compare](
 pub fn forall[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
   match self {
     Empty => true
-    Node({ left, value, right, height: _ }) =>
+    Node({ left, value, right, .. }) =>
       f(value) && left.forall(f) && right.forall(f)
   }
 }
@@ -515,7 +515,7 @@ pub fn forall[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
 pub fn exists[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
   match self {
     Empty => false
-    Node({ left, value, right, height: _ }) =>
+    Node({ left, value, right, .. }) =>
       f(value) || left.exists(f) || right.exists(f)
   }
 }
@@ -534,7 +534,7 @@ pub fn filter[T : Compare](
 ) -> ImmutableSet[T] {
   match self {
     Empty => Empty
-    Node({ left, value, right, height: _ }) => {
+    Node({ left, value, right,.. }) => {
       let l = left.filter(f)
       let v = f(value)
       let r = right.filter(f)
@@ -593,7 +593,7 @@ priv enum SplitBis[T] {
 fn split_bis[T : Compare](self : ImmutableSet[T], value : T) -> SplitBis[T] {
   match self {
     Empty => NotFound(Empty, fn() -> ImmutableSet[T] { Empty })
-    Node({ left, value: node_value, right, height: _ }) => {
+    Node({ left, value: node_value, right, .. }) => {
       let compare_result = value.compare(node_value)
       if compare_result == 0 {
         Found
@@ -657,13 +657,13 @@ fn balance[T : Compare](
   if left_height > right_height + 2 {
     match left {
       Empty => abort("balance: left is empty.")
-      Node({ left: ll, value: lv, right: lr, height: _ }) =>
+      Node({ left: ll, value: lv, right: lr, .. }) =>
         if ll.height() >= lr.height() {
           create(ll, lv, create(lr, value, right))
         } else {
           match lr {
             Empty => abort("balance: right left.right is empty.")
-            Node({ left: lrl, value: lrv, right: lrr, height: _ }) =>
+            Node({ left: lrl, value: lrv, right: lrr, .. }) =>
               create(create(ll, lv, lrl), lrv, create(lrr, value, right))
           }
         }
@@ -671,13 +671,13 @@ fn balance[T : Compare](
   } else if right_height > left_height + 2 {
     match right {
       Empty => abort("balance: right is empty")
-      Node({ left: rl, value: rv, right: rr, height: _ }) =>
+      Node({ left: rl, value: rv, right: rr, .. }) =>
         if rr.height() >= rl.height() {
           create(create(left, value, rl), rv, rr)
         } else {
           match rl {
             Empty => abort("balance: right.left is empty")
-            Node({ left: rll, value: rlv, right: rlr, height: _ }) =>
+            Node({ left: rll, value: rlv, right: rlr, .. }) =>
               create(create(left, value, rll), rlv, create(rlr, rv, rr))
           }
         }
@@ -704,7 +704,7 @@ fn add_min_value[T : Compare](
 ) -> ImmutableSet[T] {
   match self {
     Empty => ImmutableSet::from_value(value)
-    Node({ left, value: node_value, right, height: _ }) =>
+    Node({ left, value: node_value, right, .. }) =>
       balance(left.add_min_value(value), node_value, right)
   }
 }
@@ -715,7 +715,7 @@ fn add_max_value[T : Compare](
 ) -> ImmutableSet[T] {
   match self {
     Empty => ImmutableSet::from_value(value)
-    Node({ left, value: node_value, right, height: _ }) =>
+    Node({ left, value: node_value, right, .. }) =>
       balance(left, node_value, right.add_max_value(value))
   }
 }
@@ -894,7 +894,7 @@ test "exists" {
 
 test "fold" {
   @assertion.assert_eq(
-    ImmutableSet::[1, 2, 3, 4, 5].fold(~initial=0, fn(acc, x) { acc + x }),
+    ImmutableSet::[1, 2, 3, 4, 5].fold(~init=0, fn(acc, x) { acc + x }),
     15,
   )?
 }

--- a/immutable_set/moon.pkg.json
+++ b/immutable_set/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/assertion",
     "moonbitlang/core/list",
+    "moonbitlang/core/vec",
     "moonbitlang/core/array",
     "moonbitlang/core/coverage"
   ]

--- a/immutable_set/types.mbt
+++ b/immutable_set/types.mbt
@@ -20,11 +20,11 @@
 enum ImmutableSet[T] {
   Empty
   Node(Node[T])
-} derive(Default, Show, Debug, Eq)
+} derive(Default, Debug, Eq)
 
 priv struct Node[T] {
   left : ImmutableSet[T]
   right : ImmutableSet[T]
   height : Int
   value : T
-} derive(Default, Show, Debug, Eq)
+} derive(Default, Debug, Eq)

--- a/immutable_set/types.mbt
+++ b/immutable_set/types.mbt
@@ -1,0 +1,30 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This module implements the set data structure.
+// The types stored in set need to implement the Compare trait.
+// All operations over sets are purely applicative (no side-effects).
+
+/// ImmutableSets are represented by balanced binary trees (the heights of the children differ by at most 2).
+enum ImmutableSet[T] {
+  Empty
+  Node(Node[T])
+} derive(Default, Show, Debug, Eq)
+
+priv struct Node[T] {
+  left : ImmutableSet[T]
+  right : ImmutableSet[T]
+  height : Int
+  value : T
+} derive(Default, Show, Debug, Eq)


### PR DESCRIPTION
- Add README to ImmutableSet
- Add concat method to Array (to be used in ImmutableSet)
- Add the to_string method to implement Show trait
- Add the to_array method
- Better test and document writing methods
- Fix the issue of fold requiring U to implement Compare
- Merge find and find_option
- Add `new` to construct an empty ImmutableSet
- Separate types into a separate file
- Refactored some redundant code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `concat` function for array concatenation in Rust.
	- Launched an `ImmutableSet` structure with comprehensive functionalities including creation, manipulation, and querying of sets.
- **Enhancements**
	- Improved `ImmutableSet` with new methods (`new`, `to_array`, `is_empty`, `to_string`) and refined existing operations for better performance and usability.
- **Documentation**
	- Updated README for `ImmutableSet` detailing its capabilities and usage.
- **Tests**
	- Added and updated test cases for both `concat` function and `ImmutableSet` module to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->