### PR TITLE
mark array.iter as intrinsic

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -24,6 +24,7 @@
 /// ```
 /// [1, 2, 3, 4, 5].iter(fn(x){ print("\(x) ") }) //output: 1 2 3 4 5
 /// ```
+/// @intrinsic %array.iter
 pub fn iter[T](self : Array[T], f : (T) -> Unit) -> Unit {
   for i = 0; i < self.length(); i = i + 1 {
     f(self[i])


### PR DESCRIPTION
Note the CI failure actually means intrinsic works, since `x.iter` gets inlined, and coverage drops, this works like charm