### PR TITLE
fix physic_eq related tests

### DIFF
--- a/assertion/assertion.mbt
+++ b/assertion/assertion.mbt
@@ -142,16 +142,16 @@ pub fn assert_is[T : Debug](
 
 test "assert_is.is" {
   let x = 1
-  let s = "x:\(x)"
-  assert_eq(assert_is(s, s), Ok(()))?
+  let t = T::{ x, }
+  assert_eq(assert_is(t, t), Ok(()))?
 }
 
 test "assert_is.is.not" {
   let x = 1
-  let s1 = "x:\(x)"
-  let s2 = "x:\(x)"
-  assert_eq(assert_eq(s1, s2), Ok(()))?
-  assert_ne(assert_is(s1, s2), Ok(()))?
+  let t1 = T::{ x, }
+  let t2 = T::{ x, }
+  assert_eq(assert_eq(t1, t2), Ok(()))?
+  assert_ne(assert_is(t1, t2), Ok(()))?
 }
 
 /// Assert referential inequality of two values.
@@ -185,14 +185,19 @@ pub fn assert_is_not[T : Debug](
 
 test "assert_is_not.is" {
   let x = 1
-  let s = "x:\(x)"
-  assert_ne(assert_is_not(s, s), Ok(()))?
+  let t = T::{ x, }
+  assert_ne(assert_is_not(t, t), Ok(()))?
 }
 
 test "assert_is_not.is.not" {
   let x = 1
-  let s1 = "x:\(x)"
-  let s2 = "x:\(x)"
-  assert_eq(assert_eq(s1, s2), Ok(()))?
-  assert_eq(assert_is_not(s1, s2), Ok(()))?
+  let t1 = T::{ x, }
+  let t2 = T::{ x, }
+  assert_eq(assert_eq(t1, t2), Ok(()))?
+  assert_eq(assert_is_not(t1, t2), Ok(()))?
 }
+
+// For testing purposes
+struct T {
+  mut x : Int
+} derive(Eq, Debug)

--- a/math/algebraic.mbt
+++ b/math/algebraic.mbt
@@ -39,11 +39,11 @@ test "maximum.value" {
 test "maximum.ref" {
   let v1 = 1
   let v2 = 2
-  let x1 = "v\(v1)"
-  let x2 = "v\(v2)"
+  let x1 = T::{ x: v1 }
+  let x2 = T::{ x: v2 }
 
   // We need another value that equals to x2 by value but not reference
-  let x2t = "v\(v2)"
+  let x2t = T::{ x: v2 }
   @assertion.assert_is_not(x2, x2t).unwrap()
   @assertion.assert_is(maximum(x1, x2), x2)?
   @assertion.assert_is(maximum(x2, x1), x2)?
@@ -78,14 +78,19 @@ test "minimum.value" {
 test "minimum.ref" {
   let v1 = 1
   let v2 = 2
-  let x1 = "v\(v1)"
-  let x2 = "v\(v2)"
+  let x1 = T::{ x: v1 }
+  let x2 = T::{ x: v2 }
 
   // We need another value that equals to x2 by value but not reference
-  let x2t = "v\(v2)"
+  let x2t = T::{ x: v2 }
   @assertion.assert_is_not(x2, x2t).unwrap()
   @assertion.assert_is(minimum(x1, x2), x1)?
   @assertion.assert_is(minimum(x2, x1), x1)?
   @assertion.assert_is(minimum(x2, x2t), x2)?
   @assertion.assert_is(minimum(x2t, x2), x2t)?
 }
+
+// For testing purposes
+struct T {
+  mut x : Int
+} derive(Debug, Eq, Compare)


### PR DESCRIPTION
The semantic of physic eq is not cross platform consistent. 

This PR address this issue: use struct with mutable field to force consistent semantic across platforms.