### PR TITLE
[draft] hongbo/cleanup assert api

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -229,7 +229,7 @@ pub fn new[T](length : Int, value : () -> T) -> Array[T] {
 
 test "new" {
   let arr = new(2, fn() { { val: 1 } })
-  @assertion.assert_is_not(arr[0], arr[1])?
+  @assertion.assert_not_physical_equal(arr[0], arr[1])?
 }
 
 /// Create a new array. Values are built from indexes.

--- a/assertion/assertion.mbt
+++ b/assertion/assertion.mbt
@@ -111,6 +111,20 @@ test "assert_true.false" {
   assert_ne(assert_true(false), Ok(()))?
 }
 
+pub fn assert_is[T : Debug + Eq](
+  a : T,
+  b : T,
+  ~loc : SourceLoc = _
+) -> Result[Unit, String] {
+  if a == b {
+    Ok(())
+  } else {
+    let a = debug_string(a)
+    let b = debug_string(b)
+    Err("FAILED:\(loc) `\(a) is \(b)`")
+  }
+}
+
 /// Assert referential equality of two values.
 ///
 /// Returns Ok if the two arguments are the same object by reference, using
@@ -126,7 +140,7 @@ test "assert_true.false" {
 /// assert_is(a, a)?  // this is okay
 /// assert_is(a, b)?  // yields an error
 /// ```
-pub fn assert_is[T : Debug](
+pub fn assert_physical_equal[T : Debug](
   a : T,
   b : T,
   ~loc : SourceLoc = _
@@ -151,7 +165,7 @@ test "assert_is.is.not" {
   let t1 = T::{ x, }
   let t2 = T::{ x, }
   assert_eq(assert_eq(t1, t2), Ok(()))?
-  assert_ne(assert_is(t1, t2), Ok(()))?
+  assert_ne(assert_physical_equal(t1, t2), Ok(()))?
 }
 
 /// Assert referential inequality of two values.

--- a/assertion/assertion.mbt
+++ b/assertion/assertion.mbt
@@ -183,7 +183,21 @@ test "assert_is.is.not" {
 /// assert_is_not(a, b)?  // this is okay
 /// assert_is_not(a, a)?  // yields an error
 /// ```
-pub fn assert_is_not[T : Debug](
+pub fn assert_not_physical_equal[T : Debug](
+  a : T,
+  b : T,
+  ~loc : SourceLoc = _
+) -> Result[Unit, String] {
+  if not(physical_equal(a, b)) {
+    Ok(())
+  } else {
+    let a = debug_string(a)
+    let b = debug_string(b)
+    Err("FAILED:\(loc) `not(\(a) is \(b))`")
+  }
+}
+
+pub fn assert_is_not[T : Debug+Eq](
   a : T,
   b : T,
   ~loc : SourceLoc = _

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -17,7 +17,7 @@ priv enum Entry[K, V] {
   Empty
   // (Probe Sequence Length, Hash, Key, Value)
   Valid(Int, Int, K, V)
-} derive(Debug)
+} derive(Debug, Eq)
 
 /// A mutable hash map implements with Robin Hood hashing.
 /// 

--- a/immutable_set/immutable_set.mbt
+++ b/immutable_set/immutable_set.mbt
@@ -1011,7 +1011,7 @@ test "min" {
 }
 
 test "is_empty" {
-  inspect(ImmutableSet::[].is_empty(), ~content="true")?
+  inspect((ImmutableSet::[]:ImmutableSet[Int]).is_empty(), ~content="true")?
   inspect(ImmutableSet::[1].is_empty(), ~content="false")?
 }
 
@@ -1020,5 +1020,5 @@ test "to_string" {
     ImmutableSet::[1, 2, 3, 4, 5],
     ~content="ImmutableSet::[1, 2, 3, 4, 5]",
   )?
-  inspect(ImmutableSet::[], ~content="ImmutableSet::[]")?
+  inspect((ImmutableSet::[] : ImmutableSet[Int]), ~content="ImmutableSet::[]")?
 }


### PR DESCRIPTION
- add type annotation
- add `assert_is` using normal semantics and `assert_physical_equal` for physical_equal
- add assert_not_physical_equal and assert_is_not
