### PR TITLE
rename debug to trace and use %trace intrinsic

### DIFF
--- a/builtin/debug.mbt
+++ b/builtin/debug.mbt
@@ -29,6 +29,12 @@ pub fn trace[X : Debug](x : X) -> Unit {
   trace_string(buf.to_string())
 }
 
+/// print a value to the console using [Debug], with a tailing newline
+/// @alert deprecated "Use trace instead"
+pub fn debug[X : Debug](x : X) -> Unit {
+  trace(x)
+}
+
 pub fn debug_write(self : Unit, buf : Buffer) -> Unit {
   let _ = self
   buf.write_string("()")

--- a/builtin/debug.mbt
+++ b/builtin/debug.mbt
@@ -17,11 +17,16 @@ pub trait Debug {
   debug_write(Self, Buffer) -> Unit
 }
 
+/// @intrinsic %trace
+fn trace_string(s : String) -> Unit {
+  println(s)
+}
+
 /// print a value to the console using [Debug], with a tailing newline
-pub fn debug[X : Debug](x : X) -> Unit {
+pub fn trace[X : Debug](x : X) -> Unit {
   let buf = Buffer::make(10)
   x.debug_write(buf)
-  println(buf.to_string())
+  trace_string(buf.to_string())
 }
 
 pub fn debug_write(self : Unit, buf : Buffer) -> Unit {


### PR DESCRIPTION
Our expectation is for users to use `debug` more frequently, rather than `println`. However, presently, the situation is the opposite, and I believe the issue lies in the name 'debug'.

This PR renames 'debug' to the more common 'trace', and introduces the `%trace` intrinsic to allow compiling it to `console.log` on the JavaScript backend.
