### PR TITLE
Add hashset

### DIFF
--- a/hashset/README.md
+++ b/hashset/README.md
@@ -1,0 +1,80 @@
+# Moonbit/Core HashSet
+
+## Overview
+
+A mutable hash set based on a Robin Hood hash table.
+
+## Usage
+
+### Create
+
+You can create an empty set using `new()` or construct it using `from_array()`.
+
+```moonbit
+let set1 : HashSet[String] = HashSet::new()
+let set2 = HashSet::[1, 2, 3, 4, 5]
+```
+
+When creating via `new()`, you can set a custom hasher by providing a labeled argument `~hasher`. 
+
+```moonbit
+// Create with custom hasher.
+let set = HashSet::new(~hasher=Some(fn(k) { k.length() }))
+```
+
+### Insert & Contain
+
+You can use `insert()` to add a key to the set, and `contains()` to check whether a key exists.
+
+```moonbit
+let set : HashSet[String] = HashSet::new()
+set.insert("a")
+set.contains("a") // true
+```
+
+### Remove
+
+You can use `remove()` to remove a key.
+
+```moonbit
+let set = HashSet::[("a"), ("b"), ("c")]
+set.remove("a")
+set.contains("a") // false
+```
+
+### Size & Capacity
+
+You can use `size()` to get the number of keys in the set, or `capacity()` to get the current capacity.
+
+```moonbit
+let set = HashSet::[("a"), ("b"), ("c")]
+set.size() // 3
+set.capacity() // 8
+```
+
+Similarly, you can use `is_empty()` to check whether the set is empty.
+
+```moonbit
+let set : HashSet[String] = HashSet::new()
+set.is_empty() // true
+```
+
+### Clear
+
+You can use `clear` to remove all keys from the set, but the allocated memory will not change.
+
+```moonbit
+let set = HashSet::[("a"), ("b"), ("c")]
+set.clear()
+set.is_empty() // true
+```
+
+### Iter
+
+You can use `iter()` or `iteri()` to iterate through all keys.
+
+```moonbit
+let set = HashSet::[("a"), ("b"), ("c")]
+set.iter(fn(k) { println("\(k)") })
+set.iteri(fn(i, k) { println("\(i)-\(k)") })
+```

--- a/hashset/README.md
+++ b/hashset/README.md
@@ -15,7 +15,7 @@ let set1 : HashSet[String] = HashSet::new()
 let set2 = HashSet::[1, 2, 3, 4, 5]
 ```
 
-When creating via `new()`, you can set a custom hasher by providing a labeled argument `~hasher`. 
+When creating via `new()`, you can set a custom hasher by providing a labeled argument `~hasher`.
 
 ```moonbit
 // Create with custom hasher.

--- a/hashset/README.md
+++ b/hashset/README.md
@@ -78,3 +78,17 @@ let set = HashSet::[("a"), ("b"), ("c")]
 set.iter(fn(k) { println("\(k)") })
 set.iteri(fn(i, k) { println("\(i)-\(k)") })
 ```
+
+### Set Operations
+
+You can use `union()`, `intersection()`, `difference()` and `symmetric_difference()` to perform set operations.
+
+```moonbit
+let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+let u = m1.union(m2) // HashSet::["a", "b", "c", "d"]
+let i = m1.intersection(m2) // HashSet::["b", "c"]
+let d = m1.difference(m2) // HashSet::["a"]
+let s = m1.symmetric_difference(m2) // HashSet::["a", "d"]
+```
+

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -1,0 +1,366 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache Licenseersion 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Default initial capacity
+let default_init_capacity = 8
+
+/// Create new hash set.
+pub fn HashSet::new[K](~hasher : Option[(K) -> Int] = None) -> HashSet[K] {
+  {
+    size: 0,
+    capacity: default_init_capacity,
+    growAt: calc_grow_threshold(default_init_capacity),
+    hasher,
+    entries: @array.new(default_init_capacity, fn() { Empty }),
+  }
+}
+
+/// Create new hash set from array.
+pub fn HashSet::from_array[K : Hash + Eq](arr : Array[K]) -> HashSet[K] {
+  let m = new()
+  arr.iter(fn(e) { m.insert(e) })
+  m
+}
+
+/// Insert a key into hash set.
+/// @alert unsafe "Panic if the hash set is full."
+pub fn insert[K : Hash + Eq](self : HashSet[K], key : K) -> Unit {
+  if self.capacity == 0 || self.size >= self.growAt {
+    self.grow()
+  }
+  let hash = self.make_hash(key)
+  loop 0, self.index(hash), 0, hash, key {
+    i, idx, psl, hash, key => {
+      if i == self.capacity {
+        abort("HashSet is full")
+      }
+      match self.entries[idx] {
+        Empty => {
+          self.entries[idx] = Valid(psl, hash, key)
+          self.size += 1
+          break
+        }
+        Valid(d, h, k) => {
+          if h == hash && k == key {
+            self.entries[idx] = Valid(d, h, key)
+            break
+          }
+          if psl > d {
+            self.entries[idx] = Valid(psl, hash, key)
+            continue i + 1, self.next_index(idx), d + 1, h, k
+          }
+          continue i + 1, self.next_index(idx), psl + 1, hash, key
+        }
+      }
+    }
+  }
+}
+
+/// Check if the hash set contains a key.
+pub fn contains[K : Hash + Eq](self : HashSet[K], key : K) -> Bool {
+  let hash = self.make_hash(key)
+  for distance = 0, idx = self.index(hash)
+      distance < self.capacity
+      distance = distance + 1, idx = self.next_index(idx) {
+    match self.entries[idx] {
+      Valid(d, h, k) => {
+        if h == hash && k == key {
+          return true
+        }
+        if distance > d {
+          return false
+        }
+      }
+      Empty => return false
+    }
+  }
+  false
+}
+
+/// Remove a key from hash set.
+pub fn remove[K : Hash + Eq](self : HashSet[K], key : K) -> Unit {
+  let hash = self.make_hash(key)
+  for distance = 0, idx = self.index(hash)
+      distance < self.capacity
+      distance = distance + 1, idx = self.next_index(idx) {
+    match self.entries[idx] {
+      Valid(d, h, k) => {
+        if h == hash && k == key {
+          self.entries[idx] = Empty
+          self.shift_back(idx)
+          self.size -= 1
+          break
+        }
+        if distance > d {
+          return
+        }
+      }
+      Empty => ()
+    }
+  }
+}
+
+/// Get the number of keys in the set.
+pub fn size[K](self : HashSet[K]) -> Int {
+  self.size
+}
+
+/// Get the capacity of the set.
+pub fn capacity[K](self : HashSet[K]) -> Int {
+  self.capacity
+}
+
+/// Check if the hash set is empty.
+pub fn is_empty[K](self : HashSet[K]) -> Bool {
+  self.size == 0
+}
+
+/// Iterate over all keys of the set.
+pub fn iter[K](self : HashSet[K], f : (K) -> Unit) -> Unit {
+  self.iteri(fn(_i, k) { f(k) })
+}
+
+/// Iterate over all keys of the set, with index.
+pub fn iteri[K](self : HashSet[K], f : (Int, K) -> Unit) -> Unit {
+  let mut idx = 0
+  for i = 0; i < self.capacity; i = i + 1 {
+    match self.entries[i] {
+      Valid(_, _, k) => {
+        f(idx, k)
+        idx += 1
+      }
+      _ => ()
+    }
+  }
+}
+
+/// Clears the set, removing all keys. Keeps the allocated space.
+pub fn clear[K](self : HashSet[K]) -> Unit {
+  for i = 0; i < self.capacity; i = i + 1 {
+    self.entries[i] = Empty
+  }
+  self.size = 0
+}
+
+fn shift_back[K : Hash](self : HashSet[K], start_index : Int) -> Unit {
+  for i = 0, prev = start_index, curr = self.next_index(start_index)
+      i < self.entries.length()
+      i = i + 1, prev = curr, curr = self.next_index(curr) {
+    match self.entries[curr] {
+      Valid(d, h, k) => {
+        if d == 0 {
+          break
+        }
+        self.entries[prev] = Valid(d - 1, h, k)
+        self.entries[curr] = Empty
+      }
+      Empty => break
+    }
+  }
+}
+
+fn grow[K : Hash + Eq](self : HashSet[K]) -> Unit {
+  // handle zero capacity
+  if self.capacity == 0 {
+    self.capacity = default_init_capacity
+    self.growAt = calc_grow_threshold(self.capacity)
+    self.size = 0
+    self.entries = @array.new(self.capacity, fn() { Empty })
+    return
+  }
+  let old_entries = self.entries
+  self.entries = @array.new(self.capacity * 2, fn() { Empty })
+  self.capacity = self.capacity * 2
+  self.growAt = calc_grow_threshold(self.capacity)
+  self.size = 0
+  for i = 0; i < old_entries.length(); i = i + 1 {
+    match old_entries[i] {
+      Valid(_, _, k) => self.insert(k)
+      _ => ()
+    }
+  }
+}
+
+fn make_hash[K : Hash](self : HashSet[K], key : K) -> Int {
+  let hash : Int = match self.hasher {
+    Some(hasher) => hasher(key)
+    None => key.hash()
+  }
+  // Let higher 16 bits of the hash value participate in the calculation
+  hash.lxor(hash.lsr(16))
+}
+
+fn index[K : Hash](self : HashSet[K], hash : Int) -> Int {
+  hash.abs().land(self.capacity - 1)
+}
+
+fn next_index[K : Hash](self : HashSet[K], index : Int) -> Int {
+  (index + 1).land(self.capacity - 1)
+}
+
+fn calc_grow_threshold(capacity : Int) -> Int {
+  capacity * 13 / 16
+}
+
+fn debug_entries[K : Show](self : HashSet[K]) -> String {
+  let mut s = ""
+  for i = 0; i < self.entries.length(); i = i + 1 {
+    if i > 0 {
+      s += ","
+    }
+    match self.entries[i] {
+      Empty => s += "_"
+      Valid(d, _h, k) => s += "(\(d),\(k))"
+    }
+  }
+  s
+}
+
+test "new" {
+  let m : HashSet[Int] = HashSet::new()
+  @assertion.assert_eq(m.capacity, default_init_capacity)?
+  @assertion.assert_eq(m.size, 0)?
+}
+
+test "set" {
+  let m : HashSet[String] = HashSet::new(~hasher=Some(fn(k) { k.length() }))
+  m.insert("a")
+  m.insert("b")
+  m.insert("bc")
+  m.insert("abc")
+  m.insert("cd")
+  m.insert("c")
+  m.insert("d")
+  @assertion.assert_eq(m.size, 7)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,a),(1,b),(2,c),(3,d),(3,bc),(4,cd),(4,abc),_,_,_,_,_,_,_,_",
+  )?
+}
+
+test "insert" {
+  let m : HashSet[String] = HashSet::new()
+  m.insert("a")
+  m.insert("b")
+  m.insert("c")
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "from_array" {
+  let m = HashSet::["a", "b", "c"]
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "remove" {
+  let m : HashSet[String] = HashSet::new(~hasher=Some(fn(k) { k.length() }))
+  m.insert("a")
+  m.insert("ab")
+  m.insert("bc")
+  m.insert("cd")
+  m.insert("abc")
+  m.insert("abcdef")
+  m.remove("ab")
+  @assertion.assert_eq(m.size(), 5)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,a),(0,bc),(1,cd),(1,abc),_,(0,abcdef),_",
+  )?
+}
+
+test "remove_unexist_key" {
+  let m : HashSet[String] = HashSet::new(~hasher=Some(fn(k) { k.length() }))
+  m.insert("a")
+  m.insert("ab")
+  m.insert("abc")
+  m.remove("d")
+  @assertion.assert_eq(m.size(), 3)?
+  @assertion.assert_eq(m.debug_entries(), "_,(0,a),(0,ab),(0,abc),_,_,_,_")?
+}
+
+test "size" {
+  let m : HashSet[String] = HashSet::new()
+  @assertion.assert_eq(m.size(), 0)?
+  m.insert("a")
+  @assertion.assert_eq(m.size(), 1)?
+}
+
+test "is_empty" {
+  let m : HashSet[String] = HashSet::new()
+  @assertion.assert_eq(m.is_empty(), true)?
+  m.insert("a")
+  @assertion.assert_eq(m.is_empty(), false)?
+  m.remove("a")
+  @assertion.assert_eq(m.is_empty(), true)?
+}
+
+test "iter" {
+  let m : HashSet[String] = HashSet::["a", "b", "c"]
+  let mut sum = ""
+  m.iter(fn(k) { sum += k })
+  @assertion.assert_eq(sum, "cba")?
+}
+
+test "iteri" {
+  let m : HashSet[String] = HashSet::["1", "2", "3"]
+  let mut s = ""
+  let mut sum = 0
+  m.iteri(
+    fn(i, k) {
+      s += k
+      sum += i
+    },
+  )
+  @assertion.assert_eq(s, "321")?
+  @assertion.assert_eq(sum, 3)?
+}
+
+test "clear" {
+  let m : HashSet[String] = HashSet::["a", "b", "c"]
+  m.clear()
+  @assertion.assert_eq(m.size, 0)?
+  @assertion.assert_eq(m.capacity, 8)?
+  for i = 0; i < m.capacity; i = i + 1 {
+    @assertion.assert_is(m.entries[i], Empty)?
+  }
+}
+
+test "grow" {
+  let m : HashSet[String] = HashSet::new(~hasher=Some(fn(k) { k.length() }))
+  m.insert("C")
+  m.insert("Go")
+  m.insert("C++")
+  m.insert("Java")
+  m.insert("Scala")
+  m.insert("Julia")
+  @assertion.assert_eq(m.size, 6)?
+  @assertion.assert_eq(m.capacity, 8)?
+  m.insert("Cobol")
+  @assertion.assert_eq(m.size, 7)?
+  @assertion.assert_eq(m.capacity, 16)?
+  m.insert("Python")
+  m.insert("Haskell")
+  m.insert("Rescript")
+  @assertion.assert_eq(m.size, 10)?
+  @assertion.assert_eq(m.capacity, 16)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,C),(0,Go),(0,C++),(0,Java),(0,Scala),(1,Julia),(2,Cobol),(2,Python),(2,Haskell),(2,Rescript),_,_,_,_,_",
+  )?
+}

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -153,6 +153,53 @@ pub fn clear[K](self : HashSet[K]) -> Unit {
   self.size = 0
 }
 
+/// Union of two hash sets.
+/// @alert unsafe "Panic if the hash set is full."
+pub fn union[K : Hash + Eq](self : HashSet[K], other : HashSet[K]) -> HashSet[K] {
+  let m = HashSet::new(~hasher=self.hasher)
+  self.iter(fn(k) { m.insert(k) })
+  other.iter(fn(k) { m.insert(k) })
+  m
+}
+
+/// Intersection of two hash sets.
+pub fn intersection[K : Hash + Eq](self : HashSet[K], other : HashSet[K]) -> HashSet[K] {
+  let m = HashSet::new(~hasher=self.hasher)
+  self.iter(fn(k) {
+    if other.contains(k) {
+      m.insert(k)
+    }
+  })
+  m
+}
+
+/// Difference of two hash sets.
+pub fn difference[K : Hash + Eq](self : HashSet[K], other : HashSet[K]) -> HashSet[K] {
+  let m = HashSet::new(~hasher=self.hasher)
+  self.iter(fn(k) {
+    if not(other.contains(k)) {
+      m.insert(k)
+    }
+  })
+  m
+}
+
+/// Symmetric difference of two hash sets.
+pub fn symmetric_difference[K : Hash + Eq](self : HashSet[K], other : HashSet[K]) -> HashSet[K] {
+  let m = HashSet::new(~hasher=self.hasher)
+  self.iter(fn(k) {
+    if not(other.contains(k)) {
+      m.insert(k)
+    }
+  })
+  other.iter(fn(k) {
+    if not(self.contains(k)) {
+      m.insert(k)
+    }
+  })
+  m
+}
+
 fn shift_back[K : Hash](self : HashSet[K], start_index : Int) -> Unit {
   for i = 0, prev = start_index, curr = self.next_index(start_index)
       i < self.entries.length()
@@ -314,7 +361,7 @@ test "iter" {
   let m : HashSet[String] = HashSet::["a", "b", "c"]
   let mut sum = ""
   m.iter(fn(k) { sum += k })
-  @assertion.assert_eq(sum, "cba")?
+  @assertion.assert_eq(sum, "cab")?
 }
 
 test "iteri" {
@@ -363,4 +410,48 @@ test "grow" {
     m.debug_entries(),
     "_,(0,C),(0,Go),(0,C++),(0,Java),(0,Scala),(1,Julia),(2,Cobol),(2,Python),(2,Haskell),(2,Rescript),_,_,_,_,_",
   )?
+}
+
+test "union" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.union(m2)
+  @assertion.assert_eq(m.size, 4)?
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_true(m.contains("d"))?
+}
+
+test "intersection" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.intersection(m2)
+  @assertion.assert_eq(m.size, 2)?
+  @assertion.assert_false(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "difference" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.difference(m2)
+  @assertion.assert_eq(m.size, 1)?
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_false(m.contains("b"))?
+  @assertion.assert_false(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "symmetric_difference" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.symmetric_difference(m2)
+  @assertion.assert_eq(m.size, 2)?
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_false(m.contains("b"))?
+  @assertion.assert_false(m.contains("c"))?
+  @assertion.assert_true(m.contains("d"))?
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -1,6 +1,6 @@
 // Copyright 2024 International Digital Economy Academy
 //
-// Licensed under the Apache Licenseersion 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/hashset/moon.pkg.json
+++ b/hashset/moon.pkg.json
@@ -1,0 +1,11 @@
+{
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/int",
+    "moonbitlang/core/list",
+    "moonbitlang/core/array",
+    "moonbitlang/core/string",
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/coverage"
+  ]
+}

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -1,0 +1,42 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache Licenseersion 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+priv enum Entry[K] {
+  Empty
+  // (Probe Sequence Length, Hash, Key)
+  Valid(Int, Int, K)
+} derive(Debug)
+
+/// A mutable hash set implements with Robin Hood hashing.
+/// 
+/// reference:
+/// - <https://programming.guide/robin-hood-hashing.html>
+/// - <https://cs.uwaterloo.ca/research/tr/1986/CS-86-14.pdf>
+
+/// Mutable hash set, not thread safe. 
+///  
+/// # Example
+/// 
+/// ```
+/// let set = HashSet::[(3, "three"), (8, "eight"), (1, "one")]
+/// set.insert(3)
+/// println(set.contains(3)) // output: true
+/// ```
+struct HashSet[K] {
+  mut entries : Array[Entry[K]]
+  mut size : Int // active key count
+  mut capacity : Int // current capacity 
+  mut growAt : Int // threshold that triggers grow
+  hasher : Option[(K) -> Int] // custom hasher
+}

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -1,6 +1,6 @@
 // Copyright 2024 International Digital Economy Academy
 //
-// Licensed under the Apache Licenseersion 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //


### PR DESCRIPTION
A brain-dead copy from hashmap, with hashset-specific features added (like intersection).

In Rust std, HashMap and HashSet are both simple wrappers over hashbrown. Such practice reduces redundant code while HashMap and HashSet stay independent. Should we adopt the same approach?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new mutable hash set implementation based on Robin Hood hashing with various functionalities such as insertion, containment checks, removal, and size management.
	- Added set operations like union, intersection, difference, and symmetric difference for enhanced data manipulation.
- **Documentation**
	- Provided detailed documentation for utilizing the new hash set features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->