### PR TITLE
Add Clinger's fast path && `parse_number` test pass

### DIFF
--- a/strconv/UInt64.mbt
+++ b/strconv/UInt64.mbt
@@ -1,0 +1,125 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Pretend we have UInt64
+priv struct UInt64 {
+  inner : Int64
+}
+
+fn new_UInt64_Int64(value : Int64) -> UInt64 {
+  { inner: value }
+}
+
+fn new_UInt64_Int(value : Int) -> UInt64 {
+  { inner: value.to_int64() }
+}
+
+fn UInt64::op_equal(self : UInt64, b : UInt64) -> Bool {
+  self.inner == b.inner
+}
+
+fn UInt64::compare(self : UInt64, b : UInt64) -> Int {
+  if self.inner >= 0L && b.inner >= 0L || self.inner < 0L && b.inner < 0L {
+    return self.inner.compare(b.inner)
+  } else if self.inner < 0L { // b.inner >= 0
+    return 1
+  } else { // self.inner >= 0 && b.inner < 0
+    return -1
+  }
+}
+
+fn op_add(self : UInt64, b : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner + b.inner)
+}
+
+fn op_sub(self : UInt64, b : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner - b.inner)
+}
+
+fn op_mul(self : UInt64, b : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner * b.inner)
+}
+
+fn op_div(self : UInt64, b : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner / b.inner)
+}
+
+fn op_neg(self : UInt64) -> UInt64 {
+  new_UInt64_Int64(-self.inner)
+}
+
+fn lnot(self : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner.lnot())
+}
+
+fn land(self : UInt64, b : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner.land(b.inner))
+}
+
+fn lor(self : UInt64, b : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner.lor(b.inner))
+}
+
+fn lxor(self : UInt64, b : UInt64) -> UInt64 {
+  new_UInt64_Int64(self.inner.lxor(b.inner))
+}
+
+fn lsr(self : UInt64, b : Int) -> UInt64 {
+  new_UInt64_Int64(self.inner.lsr(b))
+}
+
+fn lsl(self : UInt64, b : Int) -> UInt64 {
+  new_UInt64_Int64(self.inner.lsl(b))
+}
+
+fn to_int64(self : UInt64) -> Int64 {
+  self.inner
+}
+
+fn to_double(self : UInt64) -> Double {
+  if self.inner >= 0L {
+    self.inner.to_double()
+  } else {
+    Int64::max_value().to_double() + (self.inner - Int64::min_value()).to_double() +
+    1.0
+  }
+}
+
+/// Returns None if the multiplication might overflow (there are some false-negative corner cases).
+/// Otherwise, returns Some(m), where m = self * b.
+fn checked_mul(self : UInt64, b : UInt64) -> Option[UInt64] {
+  if self.inner == 0L || b.inner == 0L {
+    return Some(new_UInt64_Int64(0L))
+  }
+  if self.inner == 1L {
+    return Some(b)
+  }
+  if b.inner == 1L {
+    return Some(self)
+  }
+  if b.inner < 0L || self.inner < 0L {
+    return None
+  }
+  let r = new_UInt64_Int64(Int64::max_value() / b.inner)
+  let q = new_UInt64_Int64(1L / b.inner)
+  if r + r + q < self {
+    return None
+  }
+  Some(self * b)
+}
+
+test "op_lt" {
+  @assertion.assert_true(new_UInt64_Int(1) < new_UInt64_Int(2))?
+  @assertion.assert_true(new_UInt64_Int64(-1L) > new_UInt64_Int64(2L))?
+}

--- a/strconv/UInt64.mbt
+++ b/strconv/UInt64.mbt
@@ -13,85 +13,81 @@
 // limitations under the License.
 
 /// Pretend we have UInt64
-priv struct UInt64 {
-  inner : Int64
-}
+priv type UInt64  Int64 derive(Eq)
+
 
 fn new_UInt64_Int64(value : Int64) -> UInt64 {
-  { inner: value }
+  UInt64 (value)
 }
 
 fn new_UInt64_Int(value : Int) -> UInt64 {
-  { inner: value.to_int64() }
+  UInt64 (value.to_int64())
 }
 
-fn UInt64::op_equal(self : UInt64, b : UInt64) -> Bool {
-  self.inner == b.inner
-}
 
 fn UInt64::compare(self : UInt64, b : UInt64) -> Int {
-  if self.inner >= 0L && b.inner >= 0L || self.inner < 0L && b.inner < 0L {
-    return self.inner.compare(b.inner)
-  } else if self.inner < 0L { // b.inner >= 0
-    return 1
-  } else { // self.inner >= 0 && b.inner < 0
-    return -1
+  if self.0 >= 0L && b.0 >= 0L || self.0 < 0L && b.0 < 0L {
+     self.0.compare(b.0)
+  } else if self.0 < 0L { // b.0 >= 0
+     1
+  } else { // self.0 >= 0 && b.0 < 0
+     -1
   }
 }
 
 fn op_add(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner + b.inner)
+  new_UInt64_Int64(self.0 + b.0)
 }
 
 fn op_sub(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner - b.inner)
+  new_UInt64_Int64(self.0 - b.0)
 }
 
 fn op_mul(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner * b.inner)
+  new_UInt64_Int64(self.0 * b.0)
 }
 
 fn op_div(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner / b.inner)
+  new_UInt64_Int64(self.0 / b.0)
 }
 
 fn op_neg(self : UInt64) -> UInt64 {
-  new_UInt64_Int64(-self.inner)
+  new_UInt64_Int64(-self.0)
 }
 
 fn lnot(self : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner.lnot())
+  new_UInt64_Int64(self.0.lnot())
 }
 
 fn land(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner.land(b.inner))
+  new_UInt64_Int64(self.0.land(b.0))
 }
 
 fn lor(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner.lor(b.inner))
+  new_UInt64_Int64(self.0.lor(b.0))
 }
 
 fn lxor(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.inner.lxor(b.inner))
+  new_UInt64_Int64(self.0.lxor(b.0))
 }
 
 fn lsr(self : UInt64, b : Int) -> UInt64 {
-  new_UInt64_Int64(self.inner.lsr(b))
+  new_UInt64_Int64(self.0.lsr(b))
 }
 
 fn lsl(self : UInt64, b : Int) -> UInt64 {
-  new_UInt64_Int64(self.inner.lsl(b))
+  new_UInt64_Int64(self.0.lsl(b))
 }
 
 fn to_int64(self : UInt64) -> Int64 {
-  self.inner
+  self.0
 }
 
 fn to_double(self : UInt64) -> Double {
-  if self.inner >= 0L {
-    self.inner.to_double()
+  if self.0 >= 0L {
+    self.0.to_double()
   } else {
-    Int64::max_value().to_double() + (self.inner - Int64::min_value()).to_double() +
+    Int64::max_value().to_double() + (self.0 - Int64::min_value()).to_double() +
     1.0
   }
 }
@@ -99,20 +95,20 @@ fn to_double(self : UInt64) -> Double {
 /// Returns None if the multiplication might overflow (there are some false-negative corner cases).
 /// Otherwise, returns Some(m), where m = self * b.
 fn checked_mul(self : UInt64, b : UInt64) -> Option[UInt64] {
-  if self.inner == 0L || b.inner == 0L {
+  if self.0 == 0L || b.0 == 0L {
     return Some(new_UInt64_Int64(0L))
   }
-  if self.inner == 1L {
+  if self.0 == 1L {
     return Some(b)
   }
-  if b.inner == 1L {
+  if b.0 == 1L {
     return Some(self)
   }
-  if b.inner < 0L || self.inner < 0L {
+  if b.0 < 0L || self.0 < 0L {
     return None
   }
-  let r = new_UInt64_Int64(Int64::max_value() / b.inner)
-  let q = new_UInt64_Int64(1L / b.inner)
+  let r = new_UInt64_Int64(Int64::max_value() / b.0)
+  let q = new_UInt64_Int64(1L / b.0)
   if r + r + q < self {
     return None
   }

--- a/strconv/UInt64.mbt
+++ b/strconv/UInt64.mbt
@@ -47,9 +47,9 @@ fn op_mul(self : UInt64, b : UInt64) -> UInt64 {
   new_UInt64_Int64(self.0 * b.0)
 }
 
-fn op_div(self : UInt64, b : UInt64) -> UInt64 {
-  new_UInt64_Int64(self.0 / b.0)
-}
+// fn op_div(self : UInt64, b : UInt64) -> UInt64 {
+//   new_UInt64_Int64(self.0 / b.0)
+// }
 
 fn op_neg(self : UInt64) -> UInt64 {
   new_UInt64_Int64(-self.0)

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -24,61 +24,118 @@ let double_info : FloatInfo = {
   bias: -1023,
 }
 
-/// Convert a string to a 64 bit floating point number.
+/// TODO: For `f32` it is 23, but we don't have `f32` yet. 
+let mantissa_explicit_bits = 52
+
+/// TODO: For `f32` it is -10, but we don't have `f32` yet.
+let min_exponent_fast_path : Int64 = -22L
+
+/// TODO: For `f32` it is 10, but we don't have `f32` yet.
+let max_exponent_fast_path : Int64 = 22L
+
+/// TODO: For `f32` it is 17, but we don't have `f32` yet.
+let max_exponent_disguised_fast_path : Int64 = 37L
+
+let max_mantissa_fast_path : UInt64 = new_UInt64_Int(2).lsl(
+  mantissa_explicit_bits,
+)
+
 pub fn parse_double(str : String) -> Result[Double, String] {
-  match special_value(str) {
-    Some(v) => return Ok(v)
-    _ => ()
+  if str.length() == 0 {
+    return Err(syntax_err)
   }
   if not(check_underscore(str)) {
     return Err(syntax_err)
   }
-  let hpd = parse_decimal(str)?
-  hpd.to_double()
+  // validate its a number
+  let (num, consumed) = match parse_number(str) {
+    Some(r) => r
+    None =>
+      match parse_inf_nan(str) {
+        Some((num, consumed)) =>
+          if str.length() != consumed {
+            return Err(syntax_err)
+          } else {
+            return Ok(num)
+          }
+        None => return Err(syntax_err)
+      }
+  }
+  if str.length() != consumed {
+    return Err(syntax_err)
+  }
+  // Clinger's fast path (How to read floating point numbers accurately)[https://doi.org/10.1145/989393.989430]
+  match try_fast_path(num) {
+    Some(value) => Ok(value)
+    None => {
+      // fallback to slow path
+      let ret = parse_decimal(str)?
+      ret.to_double()
+    }
+  }
 }
 
-/// Parse the special floating point value.
-fn special_value(str : String) -> Option[Double] {
-  if str.length() == 0 {
-    return None
-  }
-  let mut s = str
-  // check sign
-  let mut sign = 1
-  if s[0] == '+' || s[0] == '-' {
-    if s[0] == '-' {
-      sign = -1
+fn is_fast_path(self : Number) -> Bool {
+  min_exponent_fast_path <= self.exponent && self.exponent <= max_exponent_disguised_fast_path &&
+  self.mantissa <= max_mantissa_fast_path && not(self.many_digits)
+}
+
+let table = [
+  1.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 10000000.0, 100000000.0,
+  1000000000.0, 10000000000.0, 100000000000.0, 1000000000000.0, 10000000000000.0,
+  100000000000000.0, 1000000000000000.0, 10000000000000000.0, 100000000000000000.0,
+  1000000000000000000.0, 10000000000000000000.0, 100000000000000000000.0, 1000000000000000000000.0,
+  10000000000000000000000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+]
+
+fn pow10_fast_path(exponent : Int) -> Double {
+  table[exponent.land(31)]
+}
+
+let int_pow10 : Array[UInt64] = [
+  new_UInt64_Int64(1L),
+  new_UInt64_Int64(10L),
+  new_UInt64_Int64(100L),
+  new_UInt64_Int64(1000L),
+  new_UInt64_Int64(10000L),
+  new_UInt64_Int64(100000L),
+  new_UInt64_Int64(1000000L),
+  new_UInt64_Int64(10000000L),
+  new_UInt64_Int64(100000000L),
+  new_UInt64_Int64(1000000000L),
+  new_UInt64_Int64(10000000000L),
+  new_UInt64_Int64(100000000000L),
+  new_UInt64_Int64(1000000000000L),
+  new_UInt64_Int64(10000000000000L),
+  new_UInt64_Int64(100000000000000L),
+  new_UInt64_Int64(1000000000000000L),
+]
+
+fn try_fast_path(self : Number) -> Option[Double] {
+  if self.is_fast_path() {
+    let mut value = if self.exponent <= max_exponent_fast_path {
+      // normal fast path
+      let value = self.mantissa.to_double()
+      if self.exponent < 0L {
+        value / pow10_fast_path(-self.exponent.to_int())
+      } else {
+        value * pow10_fast_path(self.exponent.to_int())
+      }
+    } else {
+      // disguised fast path
+      let shift = self.exponent - max_exponent_fast_path
+      let mantissa = self.mantissa.checked_mul(int_pow10[shift.to_int()])?
+      if mantissa > max_mantissa_fast_path {
+        return None
+      }
+      mantissa.to_double() * pow10_fast_path(max_exponent_fast_path.to_int())
     }
-    s = substring(s, 1, s.length() - 1)
-  }
-  if eq_ignore_case(s, "inf") || eq_ignore_case(s, "infinity") {
-    Some(Double::inf(sign))
-  } else if eq_ignore_case(s, "nan") {
-    Some(Double::nan())
+    if self.negative {
+      value = -value
+    }
+    Some(value)
   } else {
     None
-  }
-}
-
-fn eq_ignore_case(s1 : String, s2 : String) -> Bool {
-  if s1.length() != s2.length() {
-    return false
-  }
-  for i = 0; i < s1.length(); i = i + 1 {
-    let c1 = s1[i]
-    let c2 = s2[i]
-    if lower(c1) != lower(c2) {
-      return false
-    }
-  }
-  true
-}
-
-fn lower(c : Char) -> Char {
-  if 'A' <= c && c <= 'Z' {
-    Char::from_int(c.to_int() + 'a'.to_int() - 'A'.to_int())
-  } else {
-    c
   }
 }
 
@@ -209,17 +266,4 @@ test "parse_double_nan" {
   @assertion.assert_true(parse_double("nan")?.is_nan())?
   @assertion.assert_true(parse_double("NaN")?.is_nan())?
   @assertion.assert_true(parse_double("NAN")?.is_nan())?
-}
-
-test "lower" {
-  @assertion.assert_eq(lower('Z'), 'z')?
-  @assertion.assert_eq(lower('A'), 'a')?
-  @assertion.assert_eq(lower('a'), 'a')?
-  @assertion.assert_eq(lower('z'), 'z')?
-}
-
-test "eq_ignore_case" {
-  @assertion.assert_true(eq_ignore_case("nan", "NaN"))?
-  @assertion.assert_true(eq_ignore_case("inf", "inf"))?
-  @assertion.assert_true(eq_ignore_case("inf", "Inf"))?
 }

--- a/strconv/moon.pkg.json
+++ b/strconv/moon.pkg.json
@@ -1,9 +1,11 @@
 {
   "import": [
-    "moonbitlang/core/assertion", 
+    "moonbitlang/core/assertion",
     "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage", 
+    "moonbitlang/core/coverage",
     "moonbitlang/core/double",
-    "moonbitlang/core/char"
+    "moonbitlang/core/tuple",
+    "moonbitlang/core/char",
+    "moonbitlang/core/int64"
   ]
 }

--- a/strconv/number.mbt
+++ b/strconv/number.mbt
@@ -1,0 +1,208 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let min_19digit_int : UInt64 = new_UInt64_Int64(100_0000_0000_0000_0000L)
+
+struct Number {
+  exponent : Int64
+  mantissa : UInt64
+  negative : Bool
+  many_digits : Bool
+} 
+
+fn is_digit(c : Char) -> Bool {
+  c >= '0' && c <= '9'
+}
+
+fn to_digit(c : Char) -> Int {
+  c.to_int() - 48
+}
+
+/// Returns the remaining slice, the parsed number, and the number of digits parsed.
+fn parse_digits(s : StringSlice, x : UInt64) -> (StringSlice, UInt64, Int) {
+  fold_digits(
+    s,
+    x,
+    fn(digit, acc : UInt64) { acc * new_UInt64_Int(10) + new_UInt64_Int(digit) },
+  )
+}
+
+fn try_parse_19digits(
+  s : StringSlice,
+  x : UInt64
+) -> (StringSlice, UInt64, Int) {
+  let mut x = x
+  let mut s = s
+  let mut len = 0
+  while x < min_19digit_int && s.first_is_digit() || s.first_is('_') {
+    if s.first_is('_') {
+      s = s.step_1_unchecked()
+    }
+    len += 1
+    x = x * new_UInt64_Int(10) + new_UInt64_Int(to_digit(s[0])) // no overflows here
+    s = s.step_1_unchecked()
+  }
+  (s, x, len)
+}
+
+fn parse_scientific(s : StringSlice) -> Option[(StringSlice, Int64)] {
+  // the first character is 'e'/'E' and scientific mode is enabled
+  let mut s = s.step(1)?
+  let exp_num = 0L
+  let mut neg_exp = false
+  if s.first_is_either('-', '+') {
+    neg_exp = s[0] == '-'
+    s = s.step_1_unchecked()
+  }
+  if s.first_is_digit() {
+    let (s, exp_num, _) = fold_digits(
+      s,
+      exp_num,
+      fn(digit, exp_num : Int64) {
+        if exp_num < 0x10000L {
+          10L * exp_num + digit.to_int64() // no overflows here
+        } else {
+          exp_num
+        }
+      },
+    )
+    if neg_exp {
+      Some((s, -exp_num))
+    } else {
+      Some((s, exp_num))
+    }
+  } else {
+    None
+  }
+}
+
+/// Parse the number from the string, returning the number and the length of the parsed string.
+fn parse_number(s : String) -> Option[(Number, Int)] {
+  let mut s = full_slice(s)
+  let start = s
+
+  // handle optional +/- sign
+  let mut negative = false
+  if s.first_is('-') {
+    negative = true
+    s = s.step_1_unchecked()
+  } else if s.first_is('+') {
+    s = s.step_1_unchecked()
+  }
+  if s.is_empty() {
+    return None
+  }
+
+  // parse initial digits before dot
+  let (s, mantissa, consumed) = parse_digits(s, new_UInt64_Int(0))
+  let mut mantissa = mantissa
+  let mut s = s
+  let mut n_digits = consumed
+
+  // handle dot with the following digits
+  let mut n_after_dot = 0
+  let mut exponent = 0L
+  if s.first_is('.') {
+    s = s.step_1_unchecked()
+    // TODO: optimization chance. In the original Rust implementation,
+    // the the digits are stored as consecutive bytes in the string.
+    // It directly reads 8 bytes to `u64`.
+    let (new_s, new_mantissa, consumed_digit) = parse_digits(s, mantissa)
+    s = new_s
+    mantissa = new_mantissa
+    n_after_dot = consumed_digit
+    exponent = -n_after_dot.to_int64()
+  }
+  n_digits += n_after_dot
+  if n_digits == 0 {
+    return None
+  }
+
+  // handle scientific format
+  let exp_number = 0L
+  if s.first_is_either('e', 'E') {
+    let (new_s, exp_number) = parse_scientific(s)?
+    s = new_s
+    exponent += exp_number
+  }
+  let len = start.length() - s.length()
+
+  // handle uncommon case with many digits
+  if n_digits <= 19 {
+    return Some(({ exponent, mantissa, negative, many_digits: false }, len))
+  }
+  n_digits -= 19
+  let mut many_digits = false
+  let mut p = start
+  while p.first_is_either('0', '.') {
+    n_digits -= (p[0].to_int() - 46) / 2 // '0' = b'.' + 2
+    p = p.step_1_unchecked()
+  }
+  let mut mantissa = mantissa
+  if n_digits > 0 {
+    // at this point we have more than 19 significant digits, let's try again
+    many_digits = true
+    mantissa = new_UInt64_Int64(0L)
+    let s = start
+    let (s, new_mantissa, consumed_digit) = try_parse_19digits(s, mantissa)
+    mantissa = new_mantissa
+    exponent = (if mantissa >= min_19digit_int {
+      consumed_digit // big int
+    } else {
+      let s = s.step(1)? // fractional component, skip the '.'
+      let (_, new_mantissa, consumed_digit) = try_parse_19digits(s, mantissa)
+      mantissa = new_mantissa
+      consumed_digit
+    }).to_int64()
+    exponent += exp_number
+  } // add back the explicit part
+  Some(({ exponent, mantissa, negative, many_digits }, len))
+}
+
+/// Parse the number from the string, returning the number and the length of the parsed string.
+fn parse_inf_nan(s : String) -> Option[(Double, Int)] {
+  fn parse_inf_rest(s : StringSlice) -> Int {
+    if s.length() >= 8 && s.subfix_unchecked(3).prefix_eq_ignore_case("inity") {
+      8
+    } else {
+      3
+    }
+  }
+
+  let s = full_slice(s)
+  if s.length() >= 3 {
+    if s.prefix_eq_ignore_case("nan") {
+      return Some((Double::nan(), 3))
+    } else if s.prefix_eq_ignore_case("inf") {
+      return Some((Double::inf(1), parse_inf_rest(s)))
+    } else if s.length() >= 4 {
+      if s.first_is('+') {
+        let s = s.step_1_unchecked()
+        if s.prefix_eq_ignore_case("nan") {
+          return Some((Double::nan(), 4))
+        } else if s.prefix_eq_ignore_case("inf") {
+          return Some((Double::inf(1), 1 + parse_inf_rest(s)))
+        }
+      } else if s.first_is('-') {
+        let s = s.step_1_unchecked()
+        if s.prefix_eq_ignore_case("nan") {
+          return Some((Double::nan(), 4))
+        } else if s.prefix_eq_ignore_case("inf") {
+          return Some((Double::inf(-1), 1 + parse_inf_rest(s)))
+        }
+      }
+    }
+  }
+  None
+}

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -1,0 +1,144 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A slice of a string.
+/// TODO: make it a monad
+priv struct StringSlice {
+  string : String
+  mut start : Int
+  mut end : Int
+}
+
+fn slice(s : String, start : Int, end : Int) -> StringSlice {
+  { string: s, start, end }
+}
+
+fn full_slice(s : String) -> StringSlice {
+  slice(s, 0, s.length())
+}
+
+fn subfix_unchecked(self : StringSlice, start : Int) -> StringSlice {
+  { string: self.string, start: self.start + start, end: self.end }
+}
+
+fn first_is(self : StringSlice, c : Char) -> Bool {
+  self.length() > 0 && self[0] == c
+}
+
+fn first_is_either(self : StringSlice, c1 : Char, c2 : Char) -> Bool {
+  self.length() > 0 && (self[0] == c1 || self[0] == c2)
+}
+
+fn first_is_digit(self : StringSlice) -> Bool {
+  self.length() > 0 && is_digit(self[0])
+}
+
+/// Step over `step` non-underscore characters. 
+/// Return None if there are not enough characters.
+fn step(self : StringSlice, step : Int) -> Option[StringSlice] {
+  let c = self
+  let mut step = step
+  let mut start = c.start
+  while start < c.end && step > 0 {
+    if c.string[start] != '_' {
+      step -= 1
+    }
+    start += 1
+  }
+  if step == 0 {
+    Some(c.subfix_unchecked(start - c.start))
+  } else {
+    None
+  }
+}
+
+/// Step over the first character without checking.
+fn step_1_unchecked(self : StringSlice) -> StringSlice {
+  { string: self.string, start: self.start + 1, end: self.end }
+}
+
+/// Unsafe: make sure index is in bounds
+fn op_get(self : StringSlice, index : Int) -> Char {
+  self.string[self.start + index]
+}
+
+fn length(self : StringSlice) -> Int {
+  self.end - self.start
+}
+
+fn is_empty(self : StringSlice) -> Bool {
+  self.start == self.end
+}
+
+fn to_string(self : StringSlice) -> String {
+  let buf = Buffer::make(self.length())
+  for i = 0; i < self.length(); i = i + 1 {
+    buf.write_char(self[i])
+  }
+  buf.to_string()
+}
+
+fn prefix_eq_ignore_case(self : StringSlice, s2 : String) -> Bool {
+  for i = 0; i < s2.length() && i < self.length(); i = i + 1 {
+    let c1 = self[i]
+    let c2 = s2[i]
+    if lower(c1) != lower(c2) {
+      return false
+    }
+  }
+  true
+}
+
+fn lower(c : Char) -> Char {
+  if 'A' <= c && c <= 'Z' {
+    Char::from_int(c.to_int() + 'a'.to_int() - 'A'.to_int())
+  } else {
+    c
+  }
+}
+
+/// Returns the accumulated value, the slice left, and the number of digits consumed.
+/// It ignores underscore and stops when a non-digit character is found.
+fn fold_digits[T](
+  self : StringSlice,
+  init : T,
+  f : (Int, T) -> T
+) -> (StringSlice, T, Int) {
+  let mut ret = init
+  let mut len = 0
+  // let len = self.length()
+  for i = 0; i < self.length(); i = i + 1 {
+    if not(is_digit(self[i]) || self[i] == '_') {
+      return (self.subfix_unchecked(i), ret, len)
+    }
+    if self[i] != '_' {
+      len += 1
+      ret = f(to_digit(self[i]), ret)
+    }
+  }
+  (self.subfix_unchecked(self.length()), ret, len)
+}
+
+test "eq_ignore_case" {
+  @assertion.assert_true(prefix_eq_ignore_case(full_slice("nan"), "NaN"))?
+  @assertion.assert_true(prefix_eq_ignore_case(full_slice("inf"), "inf"))?
+  @assertion.assert_true(prefix_eq_ignore_case(full_slice("inf"), "Inf"))?
+}
+
+test "lower" {
+  @assertion.assert_eq(lower('Z'), 'z')?
+  @assertion.assert_eq(lower('A'), 'a')?
+  @assertion.assert_eq(lower('a'), 'a')?
+  @assertion.assert_eq(lower('z'), 'z')?
+}


### PR DESCRIPTION
Moved from #228 
Add Clinger's fast path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new custom data type for handling unsigned 64-bit integers with arithmetic and logical operations.
  - Enhanced number parsing functionality with support for scientific notation and special values like infinity and NaN.
  - Added a `StringSlice` struct for efficient string manipulation and comparison.
  
- **Enhancements**
  - Improved number parsing with fast path logic for quicker calculations and conversions.
  
- **Documentation**
  - Updated package configuration to include new core library imports.
  
- **Bug Fixes**
  - Removed deprecated functions and tests to streamline number parsing modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->