### PR TITLE
Add `@uuid` package

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,6 @@
 [files]
 extend-exclude = ["**/*_gen.mbt"]
+
+[default.extend-identifiers]
+IDentifier = "IDentifier"
+

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -114,7 +114,7 @@ test "realloc" {
   @assertion.assert_eq(result, [4, 5, 6, 7, 8, 9, 10])?
 }
 
-/// Return the fornt element from a deque, or `None` if it is empty.
+/// Return the front element from a deque, or `None` if it is empty.
 /// 
 /// # Example
 /// ```
@@ -189,7 +189,7 @@ pub fn push_back[T](self : Deque[T], value : T) -> Unit {
   self.len += 1
 }
 
-/// Removes a fornt element from a deque.
+/// Removes a front element from a deque.
 /// 
 /// # Example
 /// ```
@@ -221,7 +221,7 @@ pub fn pop_back_exn[T](self : Deque[T]) -> Unit {
   self.len -= 1
 }
 
-/// Removes a fornt element from a deque and returns it, or `None` if it is empty.
+/// Removes a front element from a deque and returns it, or `None` if it is empty.
 /// 
 /// # Example
 /// ```

--- a/uuid/README.md
+++ b/uuid/README.md
@@ -1,0 +1,20 @@
+# Moonbit/Core UUID
+
+## Overview
+
+The `@uuid` package provides an implementation of the Universally Unique
+IDentifier per RFC 4122.
+
+Currently, `@uuid` does not assume any random generation; you'll have to bring
+your own random bytes to construct UUIDs.
+
+## Usage
+
+Construct a version 4 UUID:
+
+```moonbit
+let u = @uuid.from_hex("ddf99703-742f-7505-4c54-df36a9c243fe").as_version(@uuid.V4)
+```
+
+You can then use it as a key in mappings as it's immutable and implemented
+Hash, Eq (and Compare for b-tree).

--- a/uuid/moon.pkg.json
+++ b/uuid/moon.pkg.json
@@ -1,0 +1,11 @@
+{
+    "import": [
+        "moonbitlang/core/array",
+        "moonbitlang/core/builtin",
+        "moonbitlang/core/bytes",
+        "moonbitlang/core/coverage",
+        "moonbitlang/core/int64",
+        "moonbitlang/core/result",
+        "moonbitlang/core/string"
+    ]
+}

--- a/uuid/ops.mbt
+++ b/uuid/ops.mbt
@@ -1,0 +1,40 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn op_equal(self : UUID, other : UUID) -> Bool {
+  self.hi == other.hi && self.lo == other.lo
+}
+
+pub fn compare(self : UUID, other : UUID) -> Int {
+  match self.hi.compare(other.hi) {
+    0 => self.lo.compare(other.lo)
+    x => x
+  }
+}
+
+pub fn hash(self : UUID) -> Int {
+  self.lo.hash().lxor(self.hi.hash())
+}
+
+test "ops" {
+  let hex = "72212911-64d1-c441-e87d-de89b955ea34"
+  let u1 = from_hex(hex)?
+  let u1x = from_hex(hex)?
+  let u2 = from_hex("8e325b13-2bf1-d7f6-d2b0-c85a371c1878")?
+  inspect(u1 == u1x, content="true")?
+  inspect(u1.compare(u2), content="1")?
+  inspect(u2.compare(u1), content="-1")?
+  inspect(u1.compare(u1x), content="0")?
+  inspect(u1.hash() == u1x.hash(), content="true")?
+}

--- a/uuid/uuid.mbt
+++ b/uuid/uuid.mbt
@@ -1,0 +1,190 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// UUID that complies with RFC 4122.
+///
+/// UUID objects are immutable, hashable and usable as mapping keys.
+/// The Display of UUIDs is like `12345678-1234-1234-1234-123456789abc`;
+/// UUIDs can be constructed using such strings, or 16-bytes strings with big-
+/// endian byte order.
+///
+/// # Usage
+///
+/// ```moonbit
+/// let u = @uuid.from_hex("ddf99703-742f-7505-4c54-df36a9c243fe")
+/// let u2 = @uuid.from_bytes(Bytes::[221, 249, 151, 3, 116, 47, 117, 5, 76, 84, 223, 54, 169, 194, 67, 254])
+/// @assertion.assert_eq(u, u2)
+/// ```
+///
+/// Construct an RFC-4122-compliant v4 UUID:
+///
+/// ```moonbit
+/// let u = @uuid
+///   .from_hex("9558cfadb48547c70f9adf1f75cdef29")
+///   .as_version(@uuid.V4)
+/// ```
+///
+struct UUID {
+  // XXX: replace with an 128-bit data structure when there is one
+  hi : Int64
+  lo : Int64
+}
+
+/// Constructs a UUID with the given big-endian bytes.
+///
+/// The produced UUID is not RFC-4122 compliant; see also `as_version()`.
+///
+pub fn from_bytes(bytes : Bytes) -> Result[UUID, String] {
+  if bytes.length() != 16 {
+    return Err("requires 16 bytes")
+  }
+  // XXX: this is ideally Int64::from_bytes() (needs a cheap slicing method)
+  let hi = for rv = 0L, i = 0; i < 8; {
+    continue rv.lor(bytes[i].to_int64().lsl((7 - i) * 8)), i + 1
+  } else {
+    rv
+  }
+  let lo = for rv = 0L, i = 8; i < 16; {
+    continue rv.lor(bytes[i].to_int64().lsl((15 - i) * 8)), i + 1
+  } else {
+    rv
+  }
+  Ok({ hi, lo })
+}
+
+/// The UUID as a 16-byte string.
+pub fn to_bytes(self : UUID) -> Bytes {
+  // XXX: replace with a cheaper way
+  let rv = Bytes::make(16, 0)
+  for i = 0; i < 8; i = i + 1 {
+    rv[i] = self.hi.lsr((7 - i) * 8).to_int()
+  }
+  for i = 8; i < 16; i = i + 1 {
+    rv[i] = self.lo.lsr((15 - i) * 8).to_int()
+  }
+  rv
+}
+
+test "bytes" {
+  let buf = Bytes::[
+    201, 130, 251, 104, 223, 80, 76, 161, 145, 248, 186, 162, 4, 9, 229, 185,
+  ]
+  inspect(from_bytes(buf)?.to_bytes(), content="苉棻僟ꅌꊺऄ맥")? // XXX: this is a terrible Show
+  inspect(from_bytes(Bytes::make(15, 0)), content="Err(requires 16 bytes)")?
+  inspect(from_bytes(Bytes::make(17, 0)), content="Err(requires 16 bytes)")?
+}
+
+fn hex_char_to_int64(c : Char) -> Result[Int64, String] {
+  let d = if '0' <= c && c <= '9' {
+    c.to_int() - '0'.to_int()
+  } else if 'a' <= c && c <= 'f' {
+    c.to_int() - 'a'.to_int() + 10
+  } else if 'A' <= c && c <= 'F' {
+    c.to_int() - 'A'.to_int() + 10
+  } else {
+    return Err("invalid syntax")
+  }
+  Ok(d.to_int64())
+}
+
+/// Constructs a UUID with the given hexadecimal string.
+///
+/// This function ignores dashes (`-`) in the given string. The remaining
+/// letters must be exactly 32 hexadecimals, or an error will be raised.
+///
+pub fn from_hex(hex : String) -> Result[UUID, String] {
+  // XXX: ideally we should use strconv here, but we don't have sufficient
+  // tooling around String yet
+  let (hi, i) = for hi = 0L, i = 0, n = 0; n < 16; {
+    if i >= hex.length() {
+      return Err("not enough hexadecimal in UUID string")
+    }
+    let c = hex[i]
+    if c == '-' {
+      continue hi, i + 1, n
+    } else {
+      let d = hex_char_to_int64(c)?
+      continue hi.lor(d.lsl((15 - n) * 4)), i + 1, n + 1
+    }
+  } else {
+    (hi, i)
+  }
+  let (lo, i) = for lo = 0L, i = i, n = 0; n < 16; {
+    if i >= hex.length() {
+      return Err("not enough hexadecimal in UUID string")
+    }
+    let c = hex[i]
+    if c == '-' {
+      continue lo, i + 1, n
+    } else {
+      let d = hex_char_to_int64(c)?
+      continue lo.lor(d.lsl((15 - n) * 4)), i + 1, n + 1
+    }
+  } else {
+    (lo, i)
+  }
+  if i == hex.length() {
+    Ok({ hi, lo })
+  } else {
+    Err("badly formed hexadecimal UUID string")
+  }
+}
+
+let hex_table : Array[Int] = "0123456789abcdef".to_array().map(
+  fn { c => c.to_int() },
+)
+
+let dash : Int = '-'.to_int()
+
+let segments = [8, 4, 4, 0, 4, 12]
+
+// XXX: use sum() instead; weird `moon fmt`
+let size : Int = (segments.fold_left(fn { acc, x => acc + x }, init=0) + segments.length() -
+  2) * 2
+
+pub fn to_string(self : UUID) -> String {
+  // This is a manually-composed UTF-16 string
+  let rv = Bytes::make(size, 0)
+  for v = self.lo, c = size - 1, i = size - 1, d = segments.length() - 1 {
+    let s = segments[d] * 2
+    if s == 0 {
+      continue self.hi, c, i, d - 1
+    } else if i > c - s {
+      rv[i - 1] = hex_table[v.land(0xfL).to_int()]
+      continue v.lsr(4), c, i - 2, d
+    } else if i > 0 {
+      rv[i - 1] = dash
+      continue v, i - 2, i - 2, d - 1
+    } else {
+      break rv.to_string()
+    }
+  }
+}
+
+test "from_hex" {
+  let hex = "13cb501c-1234-5678-9034-abcdef937e20"
+  inspect(from_hex(hex)?, content=hex)?
+  inspect(
+    from_hex("12345678-1234-1234-1234-ABCDEF098765")?,
+    content="12345678-1234-1234-1234-abcdef098765",
+  )?
+  inspect(
+    from_hex("13cb"),
+    content="Err(not enough hexadecimal in UUID string)",
+  )?
+  inspect(
+    from_hex("13cb501c-99a8-c889-3234"),
+    content="Err(not enough hexadecimal in UUID string)",
+  )?
+}

--- a/uuid/uuid.mbti
+++ b/uuid/uuid.mbti
@@ -1,0 +1,42 @@
+package moonbitlang/core/uuid
+
+// Values
+fn from_bytes(Bytes) -> Result[UUID, String]
+
+fn from_hex(String) -> Result[UUID, String]
+
+// Types and methods
+type UUID
+fn UUID::as_version(UUID, Version) -> UUID
+fn UUID::compare(UUID, UUID) -> Int
+fn UUID::hash(UUID) -> Int
+fn UUID::op_equal(UUID, UUID) -> Bool
+fn UUID::to_bytes(UUID) -> Bytes
+fn UUID::to_string(UUID) -> String
+fn UUID::variant(UUID) -> Variant
+fn UUID::version(UUID) -> Option[Version]
+
+pub enum Variant {
+  ReservedNCS
+  RFC4122(Version)
+  ReservedMicrosoft
+  ReservedFuture
+}
+fn Variant::debug_write(Variant, @moonbitlang/core/builtin.Buffer) -> Unit
+fn Variant::to_string(Variant) -> String
+
+pub enum Version {
+  V1
+  V2
+  V3
+  V4
+  V5
+  Unknown(Int)
+}
+fn Version::debug_write(Version, @moonbitlang/core/builtin.Buffer) -> Unit
+fn Version::to_string(Version) -> String
+
+// Traits
+
+// Extension Methods
+

--- a/uuid/variant.mbt
+++ b/uuid/variant.mbt
@@ -1,0 +1,123 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is partially derived from the Python project:
+//   https://github.com/python/cpython/blob/3.12/Lib/uuid.py
+
+/// The UUID variant.
+pub enum Variant {
+  ReservedNCS
+  RFC4122(Version)
+  ReservedMicrosoft
+  ReservedFuture
+} derive(Debug, Show)
+
+/// The UUID version number.
+///
+/// This is only used when the variant is `RFC4122`.
+///
+pub enum Version {
+  V1
+  V2
+  V3
+  V4
+  V5
+  Unknown(Int)
+} derive(Debug, Show)
+
+fn Version::from_int64(int : Int64) -> Version {
+  match int {
+    1L => V1
+    2L => V2
+    3L => V3
+    4L => V4
+    5L => V5
+    ver => Unknown(ver.to_int())
+  }
+}
+
+fn to_int64(self : Version) -> Int64 {
+  match self {
+    V1 => 1L
+    V2 => 2L
+    V3 => 3L
+    V4 => 4L
+    V5 => 5L
+    Unknown(ver) => ver.to_int64()
+  }
+}
+
+/// Retrieves the variant of the UUID.
+pub fn variant(self : UUID) -> Variant {
+  if self.lo.land(0x8000L.lsl(48)) == 0L {
+    ReservedNCS
+  } else if self.lo.land(0x4000L.lsl(48)) == 0L {
+    RFC4122(from_int64(self.hi.lsr(12).land(0xfL)))
+  } else if self.lo.land(0x2000L.lsl(48)) == 0L {
+    ReservedMicrosoft
+  } else {
+    ReservedFuture
+  }
+}
+
+/// Retrieves the version number of the UUID.
+///
+/// If the variant of the UUID is not `RFC4122`, returns `None`.
+///
+pub fn version(self : UUID) -> Option[Version] {
+  match self.variant() {
+    RFC4122(ver) => Some(ver)
+    _ => None
+  }
+}
+
+/// Converts this UUID to RFC-4122 with the given version number.
+pub fn as_version(self : UUID, version : Version) -> UUID {
+  let { hi, lo } = self
+  // Set the variant to RFC 4122.
+  let lo = lo.land(0xc000L.lsl(48).lnot()).lor(0x8000L.lsl(48))
+  // Set the version number.
+  let hi = hi.land(0xf000L.lnot()).lor(version.to_int64().lsl(12))
+  { hi, lo }
+}
+
+test "variant" {
+  inspect(
+    from_hex("81a277a6-771b-1a55-6246-fa3763226aa0")?.variant(),
+    content="ReservedNCS",
+  )?
+  inspect(
+    from_hex("42e0e55d-cee5-044c-b3a6-18a7dc5ae8b4")?.variant(),
+    content="RFC4122(Unknown(0))",
+  )?
+  inspect(
+    from_hex("1db64c57-6b48-fd91-dab2-d3accd060480")?.variant(),
+    content="ReservedMicrosoft",
+  )?
+  inspect(
+    from_hex("96b2d68d-f97d-9358-f2b1-79cbc6d43c83")?.variant(),
+    content="ReservedFuture",
+  )?
+}
+
+test "version" {
+  let u = from_hex("907976bf-6784-5a4f-5d7d-33c04dd8fa1a")?
+  inspect(u.version(), content="None")?
+  inspect(u.as_version(V1).version(), content="Some(V1)")?
+  inspect(u.as_version(V2).version(), content="Some(V2)")?
+  inspect(u.as_version(V3).version(), content="Some(V3)")?
+  inspect(u.as_version(V4).version(), content="Some(V4)")?
+  inspect(u.as_version(V5).version(), content="Some(V5)")?
+  inspect(u.as_version(Unknown(9)).version(), content="Some(Unknown(9))")?
+}


### PR DESCRIPTION
This PR adds RFC 4122 UUID with basic functions.

Reference: https://github.com/python/cpython/blob/3.12/Lib/uuid.py

Depends on:

- [x] #254 
- [x] #255 
- [x] #259