### PR TITLE
Adjust the position of the index parameter in Array::mapi

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -180,24 +180,25 @@ test "map" {
 /// 
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// v.mapi(fn (i, x) {x + i}) // [3, 5, 6]
+/// let arr = [3, 4, 5]
+/// let added = arr.mapi(fn (i, x) { x + i })
+/// debug(added) //output: [3, 5, 7]
 /// ```
-pub fn mapi[T, U](self : Array[T], f : (T, Int) -> U) -> Array[U] {
+pub fn mapi[T, U](self : Array[T], f : (Int, T) -> U) -> Array[U] {
   if self.length() == 0 {
     return []
   }
-  let res = Array::make(self.length(), f(self[0], 0))
+  let res = Array::make(self.length(), f(0, self[0]))
   for i = 1; i < self.length(); i = i + 1 {
-    res[i] = f(self[i], i)
+    res[i] = f(i, self[i])
   }
   res
 }
 
 test "mapi" {
   let arr = [1, 2, 3, 4, 5]
-  let doubled = arr.mapi(fn(x, i) { x * 2 + i })
-  let empty : Array[Int] = Array::default().mapi(fn(x, i) { x + i })
+  let doubled = arr.mapi(fn(i, x) { x * 2 + i })
+  let empty : Array[Int] = Array::default().mapi(fn(i, x) { x + i })
   @assertion.assert_eq(empty, [])?
   @assertion.assert_eq(doubled, [2, 5, 8, 11, 14])?
 }

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -24,7 +24,7 @@ fn Array::iter_rev[T](Array[T], (T) -> Unit) -> Unit
 fn Array::iter_revi[T](Array[T], (Int, T) -> Unit) -> Unit
 fn Array::iteri[T](Array[T], (Int, T) -> Unit) -> Unit
 fn Array::map[T, U](Array[T], (T) -> U) -> Array[U]
-fn Array::mapi[T, U](Array[T], (T, Int) -> U) -> Array[U]
+fn Array::mapi[T, U](Array[T], (Int, T) -> U) -> Array[U]
 fn Array::op_add[T](Array[T], Array[T]) -> Array[T]
 fn Array::op_equal[T : @moonbitlang/core/builtin.Eq](Array[T], Array[T]) -> Bool
 fn Array::reverse[T](Array[T]) -> Unit


### PR DESCRIPTION
Hi all,

This parameter `f : (T, Int) -> U` of the function `mapi` is not consistent with the function `iteri`. This patch adjusts the position of the index in `f : (T, Int) -> U` in order to maintain the consistency.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong