### PR TITLE
iter: mvp version

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -58,7 +58,7 @@ test "iter" {
   @assertion.assert_eq(i, 5)?
 }
 
-/// Iterates over the array with index. 
+/// Iterates over the array with index.
 ///
 /// # Arguments
 ///
@@ -150,7 +150,7 @@ test "iter_rev" {
   @assertion.assert_eq(i, 1)?
 }
 
-/// Iterates over the array with index in reversed turn. 
+/// Iterates over the array with index in reversed turn.
 ///
 /// # Arguments
 ///
@@ -162,7 +162,7 @@ test "iter_rev" {
 /// ```
 /// [1, 2, 3, 4, 5].iter_revi(fn(index, elem){
 ///   print("(\(index),\(elem)) ")
-/// }) //output: (4,5) (3,4) (2,3) (1,2) (0,1) 
+/// }) //output: (4,5) (3,4) (2,3) (1,2) (0,1)
 /// ```
 pub fn iter_revi[T](self : Array[T], f : (Int, T) -> Unit) -> Unit {
   let len = self.length()
@@ -238,7 +238,7 @@ test "map" {
 }
 
 /// Maps a function over the elements of the arr with index.
-/// 
+///
 /// # Example
 /// ```
 /// let arr = [3, 4, 5]
@@ -329,7 +329,7 @@ test "from_array" {
 }
 
 /// Fold out values from an array according to certain rules.
-/// 
+///
 /// # Example
 /// ```
 /// let sum = [1, 2, 3, 4, 5].fold_left(init=0, fn { sum, elem => sum + elem })
@@ -353,7 +353,7 @@ test "fold_left" {
 }
 
 /// Fold out values from an array according to certain rules in reversed turn.
-/// 
+///
 /// # Example
 /// ```
 /// let sum = [1, 2, 3, 4, 5].fold_right(init=0, fn { sum, elem => sum + elem })
@@ -377,7 +377,7 @@ test "fold_right" {
 }
 
 /// Fold out values from an array according to certain rules with index.
-/// 
+///
 /// # Example
 /// ```
 /// let sum = [1, 2, 3, 4, 5].fold_lefti(init=0, fn { index, sum, elem => sum + index })
@@ -406,7 +406,7 @@ test "fold_lefti" {
 }
 
 /// Fold out values from an array according to certain rules in reversed turn with index.
-/// 
+///
 /// # Example
 /// ```
 /// let sum = [1, 2, 3, 4, 5].fold_righti(init=0, fn { index, sum, elem => sum + index })
@@ -436,7 +436,7 @@ test "fold_righti" {
 }
 
 /// Reverses the order of elements in the slice, in place.
-/// 
+///
 /// # Example
 /// ```
 /// let arr = [1, 2, 3, 4, 5]
@@ -477,9 +477,9 @@ test "reverse" {
 }
 
 /// Swap two elements in the array.
-/// 
-/// # Example 
-/// 
+///
+/// # Example
+///
 /// ```
 /// let arr = [1, 2, 3, 4, 5]
 /// arr.swap(0, 1)
@@ -512,9 +512,9 @@ test "swap" {
 }
 
 /// Check if all the elements in the array match the condition.
-/// 
-/// # Example 
-/// 
+///
+/// # Example
+///
 /// ```
 /// let arr = [1, 2, 3, 4, 5]
 /// arr.all(fn(ele) { ele < 6 }) // true
@@ -546,9 +546,9 @@ test "all" {
 }
 
 /// Check if any of the elements in the array match the condition.
-/// 
-/// # Example 
-/// 
+///
+/// # Example
+///
 /// ```
 /// let arr = [1, 2, 3, 4, 5]
 /// arr.any(fn(ele) { ele < 6 }) // true
@@ -580,7 +580,7 @@ test "any" {
 }
 
 /// Fill the array with a given value.
-/// 
+///
 /// # Example
 /// ```
 /// [0, 0, 0, 0, 0].fill(3) // [3, 3, 3, 3, 3]
@@ -608,7 +608,7 @@ test "fill" {
 }
 
 /// Search the array index for a given element.
-/// 
+///
 /// # Example
 /// ```
 /// let arr = [3, 4, 5]
@@ -642,7 +642,7 @@ test "search" {
 }
 
 /// Checks if the array contains an element.
-/// 
+///
 /// # Example
 /// ```
 /// let arr = [3, 4, 5]
@@ -676,7 +676,7 @@ test "contains" {
 }
 
 /// Check if the array starts with a given prefix.
-/// 
+///
 /// # Example
 /// ```
 /// let arr = [3, 4, 5]
@@ -719,7 +719,7 @@ test "starts_with" {
 }
 
 /// Check if the array ends with a given suffix.
-/// 
+///
 /// # Example
 /// ```
 /// let v = [3, 4, 5]
@@ -768,7 +768,7 @@ test "ends_with" {
 }
 
 /// Convert array to list.
-/// 
+///
 /// # Example
 ///
 /// ```
@@ -892,5 +892,39 @@ test "op_add" {
   inspect(
     [1, 2, 3, 4, 5] + [6, 7, 8, 9, 10],
     content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+  )?
+}
+
+/// @intrinsic %iter.from_array
+pub fn to_iter[T](self : Array[T]) -> @iter.Iter[T] {
+  @iter.Iter::_unstable_internal_make(
+    fn(yield) {
+      for i = 0, len = self.length(); i < len; i = i + 1 {
+        if yield(self[i]).not() {
+          break
+        }
+      }
+    },
+  )
+}
+
+test "to_iter" {
+  let arr = [1, 2, 3, 4, 5]
+  let iter = arr.to_iter()
+  let exb = Buffer::make(0)
+  let mut i = 0
+  iter.iter(fn(x) {
+    exb.write_string(x.to_string())
+    exb.write_char('\n')
+    i = i + 1
+  })
+  @assertion.assert_eq(i, arr.length())?
+  exb.expect(~content=
+    #|1
+    #|2
+    #|3
+    #|4
+    #|5
+    #|
   )?
 }

--- a/array/array.mbt
+++ b/array/array.mbt
@@ -896,7 +896,7 @@ test "op_add" {
 }
 
 /// @intrinsic %iter.from_array
-pub fn to_iter[T](self : Array[T]) -> @iter.Iter[T] {
+pub fn as_iter[T](self : Array[T]) -> @iter.Iter[T] {
   @iter.Iter::_unstable_internal_make(
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
@@ -908,9 +908,9 @@ pub fn to_iter[T](self : Array[T]) -> @iter.Iter[T] {
   )
 }
 
-test "to_iter" {
+test "as_iter" {
   let arr = [1, 2, 3, 4, 5]
-  let iter = arr.to_iter()
+  let iter = arr.as_iter()
   let exb = Buffer::make(0)
   let mut i = 0
   iter.iter(fn(x) {

--- a/array/array.mbt
+++ b/array/array.mbt
@@ -901,9 +901,9 @@ pub fn to_iter[T](self : Array[T]) -> @iter.Iter[T] {
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
         if yield(self[i]).not() {
-          break
+          break false
         }
-      }
+      } else { true }
     },
   )
 }

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -35,6 +35,7 @@ fn Array::sort_by_key[T, K : Compare + Eq](Array[T], (T) -> K) -> Unit
 fn Array::stable_sort[T : Compare + Eq](Array[T]) -> Unit
 fn Array::starts_with[T : Eq](Array[T], Array[T]) -> Bool
 fn Array::swap[T](Array[T], Int, Int) -> Unit
+fn Array::to_iter[T](Array[T]) -> @moonbitlang/core/iter.Iter[T]
 fn Array::to_list[T](Array[T]) -> List[T]
 
 // Traits

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -1,5 +1,7 @@
 package moonbitlang/core/array
 
+alias @moonbitlang/core/iter as @iter
+
 // Values
 fn is_sorted[T : Compare + Eq](Array[T]) -> Bool
 
@@ -11,6 +13,7 @@ fn new_with_index[T](Int, (Int) -> T) -> Array[T]
 type TimSortRun
 fn Array::all[T](Array[T], (T) -> Bool) -> Bool
 fn Array::any[T](Array[T], (T) -> Bool) -> Bool
+fn Array::as_iter[T](Array[T]) -> @iter.Iter[T]
 fn Array::contains[T : Eq](Array[T], T) -> Bool
 fn Array::ends_with[T : Eq](Array[T], Array[T]) -> Bool
 fn Array::fill[T](Array[T], T) -> Unit
@@ -35,7 +38,6 @@ fn Array::sort_by_key[T, K : Compare + Eq](Array[T], (T) -> K) -> Unit
 fn Array::stable_sort[T : Compare + Eq](Array[T]) -> Unit
 fn Array::starts_with[T : Eq](Array[T], Array[T]) -> Bool
 fn Array::swap[T](Array[T], Int, Int) -> Unit
-fn Array::to_iter[T](Array[T]) -> @moonbitlang/core/iter.Iter[T]
 fn Array::to_list[T](Array[T]) -> List[T]
 
 // Traits

--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -4,6 +4,7 @@
     "moonbitlang/core/assertion",
     "moonbitlang/core/math",
     "moonbitlang/core/coverage",
-    "moonbitlang/core/vec"
+    "moonbitlang/core/vec",
+    "moonbitlang/core/iter"
   ]
 }

--- a/iter/consumers.mbt
+++ b/iter/consumers.mbt
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 /// Iterates over each element in the iterator, applying the function `f` to each element.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// - `self`: The iterator to consume.
 /// - `f`: A function that takes an element of type `T` and returns `Unit`. This function is applied to each element of the iterator.
 /// @intrinsic %iter.iter
@@ -31,29 +31,29 @@ pub fn iter[T](self : Iter[T], f : (T) -> Unit) -> Unit {
         true
       }
     },
-  )
+  ) |> ignore
 }
 
 /// Folds the elements of the iterator using the given function, starting with the given initial value.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 /// - `B`: The type of the accumulator value.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// - `self`: The iterator to consume.
 /// - `f`: A function that takes an accumulator of type `B` and an element of type `T`, and returns a new accumulator value.
 /// - `init`: The initial value for the fold operation.
-/// 
+///
 /// # Returns
-/// 
+///
 /// Returns the final accumulator value after folding all elements of the iterator.
 /// @intrinsic %iter.reduce
 pub fn fold[T, B](self : Iter[T], f : (B, T) -> B, init : B) -> B {
   let mut acc = init
-  (self.0)(
+  let _ = (self.0)(
     fn {
       yield => {
         acc = f(acc, yield)
@@ -65,17 +65,17 @@ pub fn fold[T, B](self : Iter[T], f : (B, T) -> B, init : B) -> B {
 }
 
 /// Counts the number of elements in the iterator.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// - `self`: The iterator to consume.
-/// 
+///
 /// # Returns
-/// 
+///
 /// Returns the number of elements in the iterator.
 pub fn count[T](self : Iter[T]) -> Int {
   self.fold(fn { acc, _ => acc + 1 }, 0)

--- a/iter/consumers.mbt
+++ b/iter/consumers.mbt
@@ -1,0 +1,43 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @intrinsic %iter.iter
+pub fn iter[T](self : Iter[T], f : (T) -> Unit) -> Unit {
+  (self.0)(
+    fn {
+      yield => {
+        f(yield)
+        true
+      }
+    },
+  )
+}
+
+/// @intrinsic %iter.reduce
+pub fn fold[T, B](self : Iter[T], f : (B, T) -> B, init : B) -> B {
+  let mut acc = init
+  (self.0)(
+    fn {
+      yield => {
+        acc = f(acc, yield)
+        true
+      }
+    },
+  )
+  acc
+}
+
+pub fn count[T](self : Iter[T]) -> Int {
+  self.fold(fn { acc, _ => acc + 1 }, 0)
+}

--- a/iter/consumers.mbt
+++ b/iter/consumers.mbt
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Iterates over each element in the iterator, applying the function `f` to each element.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+/// 
+/// # Arguments
+/// 
+/// - `self`: The iterator to consume.
+/// - `f`: A function that takes an element of type `T` and returns `Unit`. This function is applied to each element of the iterator.
 /// @intrinsic %iter.iter
 pub fn iter[T](self : Iter[T], f : (T) -> Unit) -> Unit {
   (self.0)(
@@ -24,6 +34,22 @@ pub fn iter[T](self : Iter[T], f : (T) -> Unit) -> Unit {
   )
 }
 
+/// Folds the elements of the iterator using the given function, starting with the given initial value.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+/// - `B`: The type of the accumulator value.
+/// 
+/// # Arguments
+/// 
+/// - `self`: The iterator to consume.
+/// - `f`: A function that takes an accumulator of type `B` and an element of type `T`, and returns a new accumulator value.
+/// - `init`: The initial value for the fold operation.
+/// 
+/// # Returns
+/// 
+/// Returns the final accumulator value after folding all elements of the iterator.
 /// @intrinsic %iter.reduce
 pub fn fold[T, B](self : Iter[T], f : (B, T) -> B, init : B) -> B {
   let mut acc = init
@@ -38,6 +64,19 @@ pub fn fold[T, B](self : Iter[T], f : (B, T) -> B, init : B) -> B {
   acc
 }
 
+/// Counts the number of elements in the iterator.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+/// 
+/// # Arguments
+/// 
+/// - `self`: The iterator to consume.
+/// 
+/// # Returns
+/// 
+/// Returns the number of elements in the iterator.
 pub fn count[T](self : Iter[T]) -> Int {
   self.fold(fn { acc, _ => acc + 1 }, 0)
 }

--- a/iter/iter.mbti
+++ b/iter/iter.mbti
@@ -1,0 +1,27 @@
+package moonbitlang/core/iter
+
+// Values
+
+// Types and methods
+type Iter
+fn Iter::_unstable_internal_make[T](((T) -> Bool) -> Unit) -> Iter[T]
+fn Iter::count[T](Iter[T]) -> Int
+fn Iter::drop[T](Iter[T], Int) -> Iter[T]
+fn Iter::drop_while[T](Iter[T], (T) -> Bool) -> Iter[T]
+fn Iter::empty[T]() -> Iter[T]
+fn Iter::filter[T](Iter[T], (T) -> Bool) -> Iter[T]
+fn Iter::find_first[T](Iter[T], (T) -> Bool) -> Option[T]
+fn Iter::flat_map[T, R](Iter[T], (T) -> Iter[R]) -> Iter[R]
+fn Iter::fold[T, B](Iter[T], (B, T) -> B, B) -> B
+fn Iter::iter[T](Iter[T], (T) -> Unit) -> Unit
+fn Iter::map[T, R](Iter[T], (T) -> R) -> Iter[R]
+fn Iter::repeat[T](T) -> Iter[T]
+fn Iter::singleton[T](T) -> Iter[T]
+fn Iter::take[T](Iter[T], Int) -> Iter[T]
+fn Iter::take_while[T](Iter[T], (T) -> Bool) -> Iter[T]
+fn Iter::tap[T](Iter[T], (T) -> Unit) -> Iter[T]
+
+// Traits
+
+// Extension Methods
+

--- a/iter/iter.mbti
+++ b/iter/iter.mbti
@@ -4,7 +4,9 @@ package moonbitlang/core/iter
 
 // Types and methods
 type Iter
-fn Iter::_unstable_internal_make[T](((T) -> Bool) -> Unit) -> Iter[T]
+fn Iter::_unstable_internal_make[T](((T) -> Bool) -> Bool) -> Iter[T]
+fn Iter::append[T](Iter[T], T) -> Iter[T]
+fn Iter::concat[T](Iter[T], Iter[T]) -> Iter[T]
 fn Iter::count[T](Iter[T]) -> Int
 fn Iter::drop[T](Iter[T], Int) -> Iter[T]
 fn Iter::drop_while[T](Iter[T], (T) -> Bool) -> Iter[T]
@@ -15,6 +17,8 @@ fn Iter::flat_map[T, R](Iter[T], (T) -> Iter[R]) -> Iter[R]
 fn Iter::fold[T, B](Iter[T], (B, T) -> B, B) -> B
 fn Iter::iter[T](Iter[T], (T) -> Unit) -> Unit
 fn Iter::map[T, R](Iter[T], (T) -> R) -> Iter[R]
+fn Iter::op_add[T](Iter[T], Iter[T]) -> Iter[T]
+fn Iter::prepend[T](Iter[T], T) -> Iter[T]
 fn Iter::repeat[T](T) -> Iter[T]
 fn Iter::singleton[T](T) -> Iter[T]
 fn Iter::take[T](Iter[T], Int) -> Iter[T]

--- a/iter/iter_test.mbt
+++ b/iter/iter_test.mbt
@@ -136,9 +136,9 @@ fn from_array[T](arr: Array[T]) -> Iter[T] {
     yield => {
       for i = 0; i < arr.length(); i = i + 1 {
         if yield(arr[i]).not() {
-          break
+          break false
         }
-      }
+      } else { true }
     }
   })
 }

--- a/iter/iter_test.mbt
+++ b/iter/iter_test.mbt
@@ -1,0 +1,144 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "empty" {
+  let iter = Iter::empty()
+  let exb = Buffer::make(0)
+  iter.iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect()?
+}
+
+test "singleton" {
+  let iter = Iter::singleton('1')
+  let exb = Buffer::make(0)
+  iter.iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="1")?
+}
+
+test "repeat" {
+  let iter = Iter::repeat('1')
+  let exb = Buffer::make(0)
+  iter.take(3).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="111")?
+}
+
+test "count" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  @assertion.assert_eq(iter.count(), 5)?
+}
+
+test "take" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.take(3).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="123")?
+}
+
+test "take_while" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.take_while(fn { x => x != '4' }).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="123")?
+}
+
+test "drop" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.drop(3).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="45")?
+}
+
+test "drop_while" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.drop_while(fn { x => x != '4' }).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="45")?
+}
+
+test "filter" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.filter(fn { x => x != '4' }).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="1235")?
+}
+
+test "map" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.map(fn { x => Char::from_int(x.to_int() + 1) }).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="23456")?
+}
+
+test "flat_map" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.flat_map(fn { x => Iter::repeat(x).take(2) }).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="1122334455")?
+}
+
+test "fold" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let result = Char::from_int(iter.fold(fn { acc, x => acc + x.to_int() }, 0) / 5)
+  @assertion.assert_eq(result, '3')?
+}
+
+test "find_first" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let result = iter.find_first(fn { x => x > '3' })
+  @assertion.assert_eq(result, Some('4'))?
+  let result2 = iter.find_first(fn { x => x > '5' })
+  @assertion.assert_eq(result2, None)?
+}
+
+test "tap" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.tap(fn { x => exb.write_char(x) }).iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="1234512345")?
+}
+
+// For testing purposes
+fn from_array[T](arr: Array[T]) -> Iter[T] {
+  Iter::_unstable_internal_make(fn {
+    yield => {
+      for i = 0; i < arr.length(); i = i + 1 {
+        if yield(arr[i]).not() {
+          break
+        }
+      }
+    }
+  })
+}

--- a/iter/iter_test.mbt
+++ b/iter/iter_test.mbt
@@ -130,6 +130,35 @@ test "tap" {
   exb.expect(~content="1234512345")?
 }
 
+test "prepend" {
+  let iter = from_array(['0', '1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.prepend('X').iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="X012345")?
+}
+
+test "append" {
+  let iter = from_array(['1', '2', '3', '4', '5'])
+  let exb = Buffer::make(0)
+  iter.append('6').iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="123456")?
+}
+
+test "concat" {
+  let iter1 = from_array(['1', '2', '3'])
+  let iter2 = from_array(['4', '5', '6'])
+  let combined_iter = Iter::concat(iter1, iter2)
+  let exb = Buffer::make(0)
+  combined_iter.iter(fn {
+    x => exb.write_char(x)
+  })
+  exb.expect(~content="123456")?
+}
+
 // For testing purposes
 fn from_array[T](arr: Array[T]) -> Iter[T] {
   Iter::_unstable_internal_make(fn {

--- a/iter/moon.pkg.json
+++ b/iter/moon.pkg.json
@@ -1,0 +1,7 @@
+{
+    "import": [
+        "moonbitlang/core/builtin",
+        "moonbitlang/core/assertion",
+        "moonbitlang/core/coverage"
+    ]
+}

--- a/iter/moon.pkg.json
+++ b/iter/moon.pkg.json
@@ -3,5 +3,8 @@
         "moonbitlang/core/builtin",
         "moonbitlang/core/assertion",
         "moonbitlang/core/coverage"
+    ],
+    "test_import": [
+        "moonbitlang/core/char"
     ]
 }

--- a/iter/operators.mbt
+++ b/iter/operators.mbt
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 /// Filters the elements of the iterator based on a predicate function.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
-/// 
+///
 /// # Arguments
 ///
 /// * `self` - The input iterator.
@@ -33,9 +33,9 @@ pub fn filter[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
 }
 
 /// Transforms the elements of the iterator using a mapping function.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 /// - `R`: The type of the transformed elements.
 ///
@@ -52,9 +52,9 @@ pub fn map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
 }
 
 /// Transforms each element of the iterator into an iterator and flattens the resulting iterators into a single iterator.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 /// - `R`: The type of the transformed elements.
 ///
@@ -67,25 +67,13 @@ pub fn map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
 ///
 /// A new iterator that contains the flattened elements.
 pub fn flat_map[T, R](self : Iter[T], f : (T) -> Iter[R]) -> Iter[R] {
-  Iter::Iter(
-    fn {
-      yield =>
-        (self.0)(
-          fn {
-            a => {
-              (f(a).0)(yield)
-              true
-            }
-          },
-        )
-    },
-  )
+  Iter::Iter(fn { yield => (self.0)(fn { x => (f(x).0)(yield).not() }) })
 }
 
 /// Applies a function to each element of the iterator without modifying the iterator.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 ///
 /// # Arguments
@@ -102,9 +90,9 @@ pub fn tap[T](self : Iter[T], f : (T) -> Unit) -> Iter[T] {
 }
 
 /// Takes the first `n` elements from the iterator.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 ///
 /// # Arguments
@@ -136,11 +124,10 @@ pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
   )
 }
 
-
 /// Takes elements from the iterator as long as the predicate function returns `true`.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 ///
 /// # Arguments
@@ -158,9 +145,9 @@ pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
 }
 
 /// Skips the first `n` elements from the iterator.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 ///
 /// # Arguments
@@ -193,9 +180,9 @@ pub fn drop[T](self : Iter[T], n : Int) -> Iter[T] {
 }
 
 /// Skips elements from the iterator as long as the predicate function returns `true`.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 ///
 /// # Arguments
@@ -228,9 +215,9 @@ pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
 }
 
 /// Finds the first element in the iterator that satisfies the predicate function.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// - `T`: The type of the elements in the iterator.
 ///
 /// # Arguments
@@ -243,7 +230,7 @@ pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
 /// An `Option` that contains the first element that satisfies the predicate function, or `None` if no such element is found.
 pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> Option[T] {
   let mut result : Option[T] = None
-  (self.0)(
+  let _ = (self.0)(
     fn {
       a =>
         if f(a) {

--- a/iter/operators.mbt
+++ b/iter/operators.mbt
@@ -243,3 +243,62 @@ pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> Option[T] {
   )
   result
 }
+
+/// Prepends a single element to the beginning of the iterator.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `a` - The element to be prepended to the iterator.
+///
+/// # Returns
+///
+/// Returns a new iterator with the element `a` prepended to the original iterator.
+pub fn prepend[T](self : Iter[T], a : T) -> Iter[T] {
+  Iter::Iter(fn(yield) { yield(a) && (self.0)(yield) })
+}
+
+/// Appends a single element to the end of the iterator.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `a` - The element to be appended to the iterator.
+///
+/// # Returns
+///
+/// Returns a new iterator with the element `a` appended to the original iterator.
+pub fn append[T](self : Iter[T], a : T) -> Iter[T] {
+  Iter::Iter(fn(yield) { (self.0)(yield) && yield(a) })
+}
+
+/// Combines two iterators into one by appending the elements of the second iterator to the first.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterators.
+///
+/// # Arguments
+///
+/// * `self` - The first input iterator.
+/// * `other` - The second input iterator to be appended to the first.
+///
+/// # Returns
+///
+/// Returns a new iterator that contains the elements of `self` followed by the elements of `other`.
+/// @intrinsic %iter.concat
+pub fn Iter::concat[T](this : Iter[T], other : Iter[T]) -> Iter[T] {
+  Iter::Iter(fn(yield) { (this.0)(yield) && (other.0)(yield) })
+}
+
+pub fn op_add[T](self : Iter[T], other : Iter[T]) -> Iter[T] {
+  Iter::concat(self, other)
+}

--- a/iter/operators.mbt
+++ b/iter/operators.mbt
@@ -1,0 +1,133 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @intrinsic %iter.filter
+pub fn filter[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
+  Iter::Iter(
+    fn { yield => (self.0)(fn { a => if f(a) { yield(a) } else { true } }) },
+  )
+}
+
+/// @intrinsic %iter.map
+pub fn map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
+  Iter::Iter(fn { yield => (self.0)(fn { a => yield(f(a)) }) })
+}
+
+/// @intrinsic %iter.flat_map
+pub fn flat_map[T, R](self : Iter[T], f : (T) -> Iter[R]) -> Iter[R] {
+  Iter::Iter(
+    fn {
+      yield =>
+        (self.0)(
+          fn {
+            a => {
+              (f(a).0)(yield)
+              true
+            }
+          },
+        )
+    },
+  )
+}
+
+pub fn tap[T](self : Iter[T], f : (T) -> Unit) -> Iter[T] {
+  self.iter(f)
+  self
+}
+
+/// @intrinsic %iter.take
+pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
+  Iter::Iter(
+    fn {
+      yield => {
+        let mut i = 0
+        (self.0)(
+          fn {
+            a =>
+              if i < n {
+                i = i + 1
+                yield(a)
+              } else {
+                false
+              }
+          },
+        )
+      }
+    },
+  )
+}
+
+pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
+  Iter::Iter(
+    fn { yield => (self.0)(fn { a => if f(a) { yield(a) } else { false } }) },
+  )
+}
+
+pub fn drop[T](self : Iter[T], n : Int) -> Iter[T] {
+  Iter::Iter(
+    fn {
+      yield => {
+        let mut i = 0
+        (self.0)(
+          fn {
+            a =>
+              if i < n {
+                i = i + 1
+                true
+              } else {
+                yield(a)
+              }
+          },
+        )
+      }
+    },
+  )
+}
+
+pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
+  Iter::Iter(
+    fn {
+      yield => {
+        let mut dropping = true
+        (self.0)(
+          fn {
+            a =>
+              if dropping && f(a) {
+                true
+              } else {
+                dropping = false
+                yield(a)
+              }
+          },
+        )
+      }
+    },
+  )
+}
+
+pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> Option[T] {
+  let mut result : Option[T] = None
+  (self.0)(
+    fn {
+      a =>
+        if f(a) {
+          result = Some(a)
+          false
+        } else {
+          true
+        }
+    },
+  )
+  result
+}

--- a/iter/operators.mbt
+++ b/iter/operators.mbt
@@ -12,19 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @intrinsic %iter.filter
+/// Filters the elements of the iterator based on a predicate function.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+/// 
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The predicate function that determines whether an element should be included in the filtered iterator.
+///
+/// # Returns
+///
+/// A new iterator that only contains the elements for which the predicate function returns `true`.
 pub fn filter[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
   Iter::Iter(
     fn { yield => (self.0)(fn { a => if f(a) { yield(a) } else { true } }) },
   )
 }
 
-/// @intrinsic %iter.map
+/// Transforms the elements of the iterator using a mapping function.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+/// - `R`: The type of the transformed elements.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The mapping function that transforms each element of the iterator.
+///
+/// # Returns
+///
+/// A new iterator that contains the transformed elements.
 pub fn map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
   Iter::Iter(fn { yield => (self.0)(fn { a => yield(f(a)) }) })
 }
 
-/// @intrinsic %iter.flat_map
+/// Transforms each element of the iterator into an iterator and flattens the resulting iterators into a single iterator.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+/// - `R`: The type of the transformed elements.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The function that transforms each element of the iterator into an iterator.
+///
+/// # Returns
+///
+/// A new iterator that contains the flattened elements.
 pub fn flat_map[T, R](self : Iter[T], f : (T) -> Iter[R]) -> Iter[R] {
   Iter::Iter(
     fn {
@@ -41,12 +82,39 @@ pub fn flat_map[T, R](self : Iter[T], f : (T) -> Iter[R]) -> Iter[R] {
   )
 }
 
+/// Applies a function to each element of the iterator without modifying the iterator.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The function to apply to each element of the iterator.
+///
+/// # Returns
+///
+/// The same iterator.
 pub fn tap[T](self : Iter[T], f : (T) -> Unit) -> Iter[T] {
   self.iter(f)
   self
 }
 
-/// @intrinsic %iter.take
+/// Takes the first `n` elements from the iterator.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `n` - The number of elements to take.
+///
+/// # Returns
+///
+/// A new iterator that contains the first `n` elements.
 pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
   Iter::Iter(
     fn {
@@ -68,12 +136,41 @@ pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
   )
 }
 
+
+/// Takes elements from the iterator as long as the predicate function returns `true`.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The predicate function that determines whether an element should be taken.
+///
+/// # Returns
+///
+/// A new iterator that contains the elements as long as the predicate function returns `true`.
 pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
   Iter::Iter(
     fn { yield => (self.0)(fn { a => if f(a) { yield(a) } else { false } }) },
   )
 }
 
+/// Skips the first `n` elements from the iterator.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `n` - The number of elements to skip.
+///
+/// # Returns
+///
+/// A new iterator that starts after skipping the first `n` elements.
 pub fn drop[T](self : Iter[T], n : Int) -> Iter[T] {
   Iter::Iter(
     fn {
@@ -95,6 +192,20 @@ pub fn drop[T](self : Iter[T], n : Int) -> Iter[T] {
   )
 }
 
+/// Skips elements from the iterator as long as the predicate function returns `true`.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The predicate function that determines whether an element should be skipped.
+///
+/// # Returns
+///
+/// A new iterator that starts after skipping the elements as long as the predicate function returns `true`.
 pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
   Iter::Iter(
     fn {
@@ -116,6 +227,20 @@ pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
   )
 }
 
+/// Finds the first element in the iterator that satisfies the predicate function.
+/// 
+/// # Type Parameters
+/// 
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The predicate function that determines whether an element is the first element to be found.
+///
+/// # Returns
+///
+/// An `Option` that contains the first element that satisfies the predicate function, or `None` if no such element is found.
 pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> Option[T] {
   let mut result : Option[T] = None
   (self.0)(

--- a/iter/producers.mbt
+++ b/iter/producers.mbt
@@ -17,14 +17,49 @@ pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Unit) -> Iter[T] {
   Iter::Iter(f)
 }
 
+/// Creates an empty iterator.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Returns
+///
+/// Returns an empty iterator of type `Iter[T]`.
 pub fn Iter::empty[T]() -> Iter[T] {
   Iter::Iter(fn { _ => () })
 }
 
+/// Creates an iterator that contains a single element.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the element in the iterator.
+///
+/// # Arguments
+///
+/// - `a`: The single element to be contained in the iterator.
+///
+/// # Returns
+///
+/// Returns an iterator of type `Iter[T]` that contains the single element `a`.
 pub fn Iter::singleton[T](a : T) -> Iter[T] {
   Iter::Iter(fn { yield => ignore(yield(a)) })
 }
 
+/// Creates an iterator that repeats the given element indefinitely.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// - `a`: The element to be repeated.
+///
+/// # Returns
+///
+/// Returns an iterator of type `Iter[T]` that repeats the element `a` indefinitely.
 /// @intrinsic %iter.cycle
 pub fn Iter::repeat[T](a : T) -> Iter[T] {
   Iter::Iter(

--- a/iter/producers.mbt
+++ b/iter/producers.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Do not use this method, it is for internal use only.
-pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Unit) -> Iter[T] {
+pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Bool) -> Iter[T] {
   Iter::Iter(f)
 }
 
@@ -27,7 +27,7 @@ pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Unit) -> Iter[T] {
 ///
 /// Returns an empty iterator of type `Iter[T]`.
 pub fn Iter::empty[T]() -> Iter[T] {
-  Iter::Iter(fn { _ => () })
+  Iter::Iter(fn { _ => true })
 }
 
 /// Creates an iterator that contains a single element.
@@ -44,7 +44,7 @@ pub fn Iter::empty[T]() -> Iter[T] {
 ///
 /// Returns an iterator of type `Iter[T]` that contains the single element `a`.
 pub fn Iter::singleton[T](a : T) -> Iter[T] {
-  Iter::Iter(fn { yield => ignore(yield(a)) })
+  Iter::Iter(fn { yield => yield(a) })
 }
 
 /// Creates an iterator that repeats the given element indefinitely.
@@ -60,13 +60,15 @@ pub fn Iter::singleton[T](a : T) -> Iter[T] {
 /// # Returns
 ///
 /// Returns an iterator of type `Iter[T]` that repeats the element `a` indefinitely.
-/// @intrinsic %iter.cycle
+/// @intrinsic %iter.repeat
 pub fn Iter::repeat[T](a : T) -> Iter[T] {
   Iter::Iter(
     fn(yield) {
       for ; ; {
-        if yield(a).not() {
-          break
+        if yield(a) {
+          continue
+        } else {
+          break false
         }
       }
     },

--- a/iter/producers.mbt
+++ b/iter/producers.mbt
@@ -1,0 +1,39 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Do not use this method, it is for internal use only.
+pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Unit) -> Iter[T] {
+  Iter::Iter(f)
+}
+
+pub fn Iter::empty[T]() -> Iter[T] {
+  Iter::Iter(fn { _ => () })
+}
+
+pub fn Iter::singleton[T](a : T) -> Iter[T] {
+  Iter::Iter(fn { yield => ignore(yield(a)) })
+}
+
+/// @intrinsic %iter.cycle
+pub fn Iter::repeat[T](a : T) -> Iter[T] {
+  Iter::Iter(
+    fn(yield) {
+      for ; ; {
+        if yield(a).not() {
+          break
+        }
+      }
+    },
+  )
+}

--- a/iter/types.mbt
+++ b/iter/types.mbt
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-type Iter[T] ((T) -> Bool) -> Unit
+type Iter[T] ((T) -> Bool) -> Bool

--- a/iter/types.mbt
+++ b/iter/types.mbt
@@ -1,0 +1,15 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+type Iter[T] ((T) -> Bool) -> Unit


### PR DESCRIPTION
This PR add Iter package to core. Closes #294 

also added a Array::to_iter method.

Other `to_iter`s will be added later in separated PRs