### PR TITLE
json5: Use StringBuilder instead of Buffer to avoid expensive bytes operations

### DIFF
--- a/json5/internal_types.mbt
+++ b/json5/internal_types.mbt
@@ -57,3 +57,27 @@ priv enum Token {
   Comma
   Colon
 } derive(Eq, Debug, Show)
+
+priv struct StringBuilder {
+  mut buffer : String
+}
+
+fn StringBuilder::make() -> StringBuilder {
+  { buffer: "" }
+}
+
+fn add_string(self : StringBuilder, s : String) -> Unit {
+  self.buffer = self.buffer + s
+}
+
+fn add_substring(self :  StringBuilder, s : String, start : Int, end : Int) -> Unit {
+  self.buffer = self.buffer + s.substring(~start, ~end)
+}
+
+fn add_char(self : StringBuilder, c : Char) -> Unit {
+  self.buffer = self.buffer + c.to_string()
+}
+
+fn to_string(self : StringBuilder) -> String {
+  self.buffer
+}

--- a/json5/lex_number.mbt
+++ b/json5/lex_number.mbt
@@ -196,7 +196,7 @@ fn lex_number_end(
   start : Int,
   end : Int
 ) -> Result[Double, ParseError] {
-  let s = slice_string(ctx.input, start, end)
+  let s = ctx.input.substring(~start, ~end)
   match @strconv.parse_double(s) {
     Ok(d) => Ok(d)
     Err(_) => Err(InvalidNumber(offset_to_position(ctx.input, start), s))

--- a/json5/lex_prop.mbt
+++ b/json5/lex_prop.mbt
@@ -30,8 +30,8 @@ fn lex_property_name(ctx : ParseContext) -> Result[Token, ParseError] {
       let c = Char::from_int(c)
       if c == '$' || c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' ||
       c > '\x7f' && non_ascii_id_start.contains(c) {
-        let buffer = Buffer::make(1)
-        buffer.write_char(c)
+        let buffer = StringBuilder::make()
+        buffer.add_char(c)
         let s = lex_ident(ctx, ctx.offset, ~buffer)?
         Ok(String(s))
       } else {
@@ -54,12 +54,12 @@ fn lex_property_name(ctx : ParseContext) -> Result[Token, ParseError] {
 fn lex_ident(
   ctx : ParseContext,
   start : Int,
-  ~buffer : Buffer = Buffer::make(0)
+  ~buffer : StringBuilder = StringBuilder::make()
 ) -> Result[String, ParseError] {
   let mut start = start
   fn flush(end : Int) {
     if start > 0 && end > start {
-      buffer.write_sub_string(ctx.input, start, end - start)
+      buffer.add_substring(ctx.input, start, end)
     }
   }
 
@@ -72,7 +72,7 @@ fn lex_ident(
         let c = Char::from_int(c)
         if c == '$' || c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' ||
         c >= '0' && c <= '9' || c > '\x7f' && non_ascii_id_continue.contains(c) {
-          buffer.write_char(c)
+          buffer.add_char(c)
           start = ctx.offset
           continue
         } else {

--- a/json5/lex_string.mbt
+++ b/json5/lex_string.mbt
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 fn lex_string(ctx : ParseContext, quote : Char) -> Result[String, ParseError] {
-  let buf = Buffer::make(0)
+  let buf = StringBuilder::make()
   let mut start = ctx.offset
   fn flush(end : Int) {
     if start > 0 && end > start {
-      buf.write_sub_string(ctx.input, start, end - start)
+      buf.add_substring(ctx.input, start, end)
     }
   }
 
@@ -32,15 +32,15 @@ fn lex_string(ctx : ParseContext, quote : Char) -> Result[String, ParseError] {
       Some('\\') => {
         flush(ctx.offset - 1)
         match read_char(ctx) {
-          Some('b') => buf.write_char('\b')
-          Some('f') => buf.write_char('\x0C')
-          Some('n') => buf.write_char('\n')
-          Some('r') => buf.write_char('\r')
-          Some('t') => buf.write_char('\t')
-          Some('v') => buf.write_char('\x0B')
-          Some('\'') => buf.write_char('\'')
-          Some('"') => buf.write_char('"')
-          Some('\\') => buf.write_char('\\')
+          Some('b') => buf.add_char('\b')
+          Some('f') => buf.add_char('\x0C')
+          Some('n') => buf.add_char('\n')
+          Some('r') => buf.add_char('\r')
+          Some('t') => buf.add_char('\t')
+          Some('v') => buf.add_char('\x0B')
+          Some('\'') => buf.add_char('\'')
+          Some('"') => buf.add_char('"')
+          Some('\\') => buf.add_char('\\')
           Some('0') => {
             match read_char(ctx) {
               None => ()
@@ -51,21 +51,21 @@ fn lex_string(ctx : ParseContext, quote : Char) -> Result[String, ParseError] {
                 }
               }
             }
-            buf.write_char('\x00')
+            buf.add_char('\x00')
           }
           Some('x') => {
             let c = lex_hex_digits(ctx, 2)?
-            buf.write_char(Char::from_int(c))
+            buf.add_char(Char::from_int(c))
           }
           Some('u') => {
             let c = lex_hex_digits(ctx, 4)?
-            buf.write_char(Char::from_int(c))
+            buf.add_char(Char::from_int(c))
           }
           Some(c) => {
             if c >= '1' && c <= '9' {
               return Err(invalid_char(ctx, shift=-1))
             }
-            buf.write_char(c)
+            buf.add_char(c)
           }
           None => return Err(InvalidEof)
         }

--- a/json5/util.mbt
+++ b/json5/util.mbt
@@ -32,12 +32,6 @@ fn invalid_char(ctx : ParseContext, ~shift : Int = 0) -> ParseError {
   InvalidChar(offset_to_position(ctx.input, offset), ctx.input[offset])
 }
 
-fn slice_string(s : String, start : Int, end : Int) -> String {
-  let buf = Buffer::make(0)
-  buf.write_sub_string(s, start, end - start)
-  buf.to_string()
-}
-
 fn hex_digit_to_int(c : Char) -> Int {
   if c >= 'A' {
     c.to_int().land((32).lnot()) - 'A'.to_int() + 10


### PR DESCRIPTION
Note: This may made bad performance on wasm target. We will solve that if anyone care it.