### PR TITLE
ci: fix format diff

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,7 +69,7 @@ jobs:
       - name: format diff
         run: |
           moon fmt
-          git diff
+          git diff --exit-code
 
   build-on-mac:
     runs-on: macos-latest
@@ -103,7 +103,7 @@ jobs:
       - name: format diff
         run: |
           moon fmt
-          git diff
+          git diff --exit-code
 
   build-on-mac-bleeding:
     runs-on: macos-14
@@ -138,7 +138,7 @@ jobs:
       - name: format diff
         run: |
           moon fmt
-          git diff
+          git diff --exit-code
 
   coverage-check-bleeding:
     runs-on: macos-14


### PR DESCRIPTION
Added `--exit-code` to report exit code correctly

The CI should pass after #314 merged.