### PR TITLE
Add `@mem` package

### DIFF
--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -3,8 +3,14 @@ package moonbitlang/core/bytes
 // Values
 
 // Types and methods
+type BytesView
+fn BytesView::length(BytesView) -> Int
+fn BytesView::op_as_view(BytesView, Int, Int) -> BytesView
+fn BytesView::op_get(BytesView, Int) -> Int
+fn BytesView::op_set(BytesView, Int, Int) -> Unit
 fn Bytes::from_array(Array[Int]) -> Bytes
 fn Bytes::hash(Bytes) -> Int
+fn Bytes::op_as_view(Bytes, Int, Int) -> BytesView
 
 // Traits
 

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -1,0 +1,73 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct BytesView {
+  buf : Bytes
+  start : Int
+  len : Int
+}
+
+pub fn length(self : BytesView) -> Int {
+  self.len
+}
+
+pub fn op_get(self : BytesView, index : Int) -> Int {
+  if index < 0 || index >= self.len {
+    let len = self.len
+    abort(
+      "index out of bounds: the len is from 0 to \(len) but the index is \(index)",
+    )
+  }
+  self.buf[self.start + index]
+}
+
+pub fn op_set(self : BytesView, index : Int, value : Int) -> Unit {
+  if index < 0 || index >= self.len {
+    let len = self.len
+    abort(
+      "index out of bounds: the len is from 0 to \(len) but the index is \(index)",
+    )
+  }
+  self.buf[self.start + index] = value
+}
+
+pub fn op_as_view(self : Bytes, ~start : Int, ~end : Int) -> BytesView {
+  if start < 0 {
+    abort("Slice start index out of bounds")
+  } else if end > self.length() {
+    abort("Slice end index out of bounds")
+  } else if start > end {
+    abort("Slice start index greater than end index")
+  }
+  { buf: self, start, len: end - start }
+}
+
+pub fn op_as_view(self : BytesView, ~start : Int, ~end : Int) -> BytesView {
+  if start < 0 {
+    abort("Slice start index out of bounds")
+  } else if end > self.len {
+    abort("Slice end index out of bounds")
+  } else if start > end {
+    abort("Slice start index greater than end index")
+  }
+  { buf: self.buf, start: self.start + start, len: end - start }
+}
+
+test "slice" {
+  let v = Bytes::[1, 2, 3, 4, 5]
+  let s = v.op_as_view(start=1, end=4)
+  @assertion.assert_eq(s.length(), 3)?
+  @assertion.assert_eq(s[0], 2)?
+  @assertion.assert_eq(s[1], 3)?
+}

--- a/mem/load.mbt
+++ b/mem/load.mbt
@@ -1,0 +1,55 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub trait Loadable {
+  op_get(Self, Int) -> Int // XXX: -> Byte?
+  length(Self) -> Int
+  load_int(Self, Int, Endian) -> Int
+  load_int64(Self, Int, Endian) -> Int64
+  // XXX: needs the capability to use labelled params in trait
+  // https://github.com/moonbitlang/moonbit-docs/issues/190
+  // op_as_view(Self, ~start: Int, ~end: Int) -> Loadable
+}
+
+impl Loadable::load_int(self : Self, index : Int, endian : Endian) -> Int {
+  let bytes = 4
+  let idx = match endian {
+    Little => fn(i) { index + i }
+    Big => {
+      let start = index + bytes - 1
+      fn(i) { start - i }
+    }
+  }
+  for i = 0, rv = 0; i < bytes; {
+    continue i + 1, rv.lor(self[idx(i)].lsl(8 * i))
+  } else {
+    rv
+  }
+}
+
+impl Loadable::load_int64(self : Self, index : Int, endian : Endian) -> Int64 {
+  let bytes = 8
+  let idx = match endian {
+    Little => fn(i) { index + i }
+    Big => {
+      let start = index + bytes - 1
+      fn(i) { start - i }
+    }
+  }
+  for i = 0, rv = 0L; i < bytes; {
+    continue i + 1, rv.lor(self[idx(i)].to_int64().lsl(8 * i))
+  } else {
+    rv
+  }
+}

--- a/mem/mem.mbti
+++ b/mem/mem.mbti
@@ -1,0 +1,30 @@
+package moonbitlang/core/mem
+
+// Values
+fn copy(Storable, Loadable, Int) -> Unit
+
+// Types and methods
+pub enum Endian {
+  Little
+  Big
+}
+
+// Traits
+pub trait Loadable {
+  op_get(Self, Int) -> Int
+  length(Self) -> Int
+  load_int(Self, Int, Endian) -> Int
+  load_int64(Self, Int, Endian) -> Int64
+}
+
+pub trait Storable {
+  op_set(Self, Int, Int) -> Unit
+  store_int(Self, Int, Int, Endian) -> Unit
+  store_int64(Self, Int, Int64, Endian) -> Unit
+}
+
+// Extension Methods
+impl Loadable for Loadable
+
+impl Storable for Storable
+

--- a/mem/mem_test.mbt
+++ b/mem/mem_test.mbt
@@ -1,0 +1,94 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn test_load(m : Loadable) -> Result[Unit, String] {
+  inspect(m.load_int(1, Big), content="33752069")?
+  inspect(m.load_int64(1, Big), content="144964032628459529")?
+  inspect(m.load_int(1, Little), content="84148994")?
+  inspect(m.load_int64(1, Little), content="650777868590383874")?
+  Ok(())
+}
+
+test "load bytes" {
+  test_load(Bytes::[1, 2, 3, 4, 5, 6, 7, 8, 9])?
+}
+
+test "load bytes view" {
+  test_load(
+    {
+      Bytes::[0, 1, 2, 3, 4, 5, 6, 7, 8, 9][1..]
+    },
+  )?
+}
+
+test "load int vec" {
+  test_load(@vec.Vec::[1, 2, 3, 4, 5, 6, 7, 8, 9])?
+}
+
+test "load int vec view" {
+  test_load(
+    {
+      @vec.Vec::[0, 1, 2, 3, 4, 5, 6, 7, 8, 9][1..]
+    },
+  )?
+}
+
+test "bytes" {
+  let v = Bytes::make(9, 0x04)
+  (v as Storable).store_int(2, 0x08080808, Big)
+  inspect(v, content="ЄࠈࠈЄ")?
+  (v as Storable).store_int64(1, 0x0607080901020304L, Big)
+  inspect(v, content="\u{604}ࠇĉ\u{302}")?
+}
+
+test "bytes view" {
+  let v = Bytes::make(9, 0x04)
+  ((v[1..]) as Storable).store_int(2, 0x08080808, Big)
+  inspect(v, content="ЄࠄࠈЈ")?
+  ((v[1..]) as Storable).store_int64(0, 0x0607080901020304L, Big)
+  inspect(v, content="\u{604}ࠇĉ\u{302}")?
+}
+
+test "int vec" {
+  let v = @vec.with_capacity(9)
+  v.fill(0)
+  (v as Storable).store_int(2, 1239873143, Big)
+  inspect(v, content="Vec::[0, 0, 73, 230, 246, 119, 0, 0, 0]")?
+  (v as Storable).store_int64(1, 1239873143123719283L, Big)
+  inspect(v, content="Vec::[0, 17, 52, 234, 13, 246, 111, 180, 115]")?
+}
+
+test "int vec view" {
+  let v = @vec.with_capacity(9)
+  v.fill(0)
+  ((v[1..]) as Storable).store_int(3, 1239873143, Big)
+  inspect(v, content="Vec::[0, 0, 0, 0, 73, 230, 246, 119, 0]")?
+  ((v[1..]) as Storable).store_int64(0, 1239873143123719283L, Big)
+  inspect(v, content="Vec::[0, 17, 52, 234, 13, 246, 111, 180, 115]")?
+}
+
+test "copy" {
+  let src = @vec.Vec::[1, 2, 3, 4, 5]
+  let dst = @vec.Vec::[0, 0, 0, 0, 0]
+  copy(
+    {
+      dst[1..]
+    },
+    {
+      src[2..]
+    },
+    3,
+  )
+  inspect(dst, content="Vec::[0, 3, 4, 5, 0]")?
+}

--- a/mem/moon.pkg.json
+++ b/mem/moon.pkg.json
@@ -1,0 +1,11 @@
+{
+  "import": [
+      "moonbitlang/core/builtin",
+      "moonbitlang/core/coverage"
+  ],
+  "test_import": [
+      "moonbitlang/core/bytes",
+      "moonbitlang/core/iter",
+      "moonbitlang/core/vec"
+  ]
+}

--- a/mem/ops.mbt
+++ b/mem/ops.mbt
@@ -1,0 +1,19 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn copy(dst : Storable, src : Loadable, len : Int) -> Unit {
+  for i = 0; i < len; i = i + 1 {
+    dst[i] = src[i]
+  }
+}

--- a/mem/store.mbt
+++ b/mem/store.mbt
@@ -1,0 +1,54 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub trait Storable {
+  op_set(Self, Int, Int) -> Unit // XXX: take Byte?
+  store_int(Self, Int, Int, Endian) -> Unit
+  store_int64(Self, Int, Int64, Endian) -> Unit
+}
+
+impl Storable::store_int(self : Self, index : Int, value : Int, endian : Endian) -> Unit {
+  let bytes = 4
+  let idx = match endian {
+    Little => fn(i) { index + i }
+    Big => {
+      let start = index + bytes - 1
+      fn(i) { start - i }
+    }
+  }
+  for i = 0, v = value; i < bytes; {
+    self[idx(i)] = v.land(0xff)
+    continue i + 1, v.lsr(8)
+  }
+}
+
+impl Storable::store_int64(
+  self : Self,
+  index : Int,
+  value : Int64,
+  endian : Endian
+) -> Unit {
+  let bytes = 8
+  let idx = match endian {
+    Little => fn(i) { index + i }
+    Big => {
+      let start = index + bytes - 1
+      fn(i) { start - i }
+    }
+  }
+  for i = 0, v = value; i < bytes; {
+    self[idx(i)] = v.land(0xffL).to_int()
+    continue i + 1, v.lsr(8)
+  }
+}

--- a/mem/types.mbt
+++ b/mem/types.mbt
@@ -1,0 +1,18 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub enum Endian {
+  Little
+  Big
+}


### PR DESCRIPTION
This PR adds int/int64 load/store with little/big endian, as well as `@mem.copy()` to memory-like objects.

Ideally, such operations should use appropriate intrinsics.

Depends on:

- [ ] #328