### PR TITLE
Refactor HashSet with labeled enum and add `as_iter`

### DIFF
--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -47,17 +47,17 @@ pub fn insert[K : Hash + Eq](self : HashSet[K], key : K) -> Unit {
       }
       match self.entries[idx] {
         Empty => {
-          self.entries[idx] = Valid(psl, hash, key)
+          self.entries[idx] = Valid(~psl, ~hash, ~key)
           self.size += 1
           break
         }
-        Valid(d, h, k) => {
+        Valid(psl=d, hash=h, key=k) => {
           if h == hash && k == key {
-            self.entries[idx] = Valid(d, h, key)
+            self.entries[idx] = Valid(psl=d, hash=h, ~key)
             break
           }
           if psl > d {
-            self.entries[idx] = Valid(psl, hash, key)
+            self.entries[idx] = Valid(~psl, ~hash, ~key)
             continue i + 1, self.next_index(idx), d + 1, h, k
           }
           continue i + 1, self.next_index(idx), psl + 1, hash, key
@@ -74,7 +74,7 @@ pub fn contains[K : Hash + Eq](self : HashSet[K], key : K) -> Bool {
       distance < self.capacity
       distance = distance + 1, idx = self.next_index(idx) {
     match self.entries[idx] {
-      Valid(d, h, k) => {
+      Valid(psl=d, hash=h, key=k) => {
         if h == hash && k == key {
           return true
         }
@@ -95,7 +95,7 @@ pub fn remove[K : Hash + Eq](self : HashSet[K], key : K) -> Unit {
       distance < self.capacity
       distance = distance + 1, idx = self.next_index(idx) {
     match self.entries[idx] {
-      Valid(d, h, k) => {
+      Valid(psl=d, hash=h, key=k) => {
         if h == hash && k == key {
           self.entries[idx] = Empty
           self.shift_back(idx)
@@ -136,8 +136,8 @@ pub fn iteri[K](self : HashSet[K], f : (Int, K) -> Unit) -> Unit {
   let mut idx = 0
   for i = 0; i < self.capacity; i = i + 1 {
     match self.entries[i] {
-      Valid(_, _, k) => {
-        f(idx, k)
+      Valid(~key, ..) => {
+        f(idx, key)
         idx += 1
       }
       _ => ()
@@ -196,16 +196,31 @@ pub fn symmetric_difference[K : Hash + Eq](
   m
 }
 
+pub fn as_iter[K](self : HashSet[K]) -> @iter.Iter[K] {
+  @iter.Iter::_unstable_internal_make(
+    fn(yield) {
+      for i = 0, len = self.entries.length(); i < len; i = i + 1 {
+        match self.entries[i] {
+          Valid(~key, ..) => if yield(key).not() { break false }
+          _ => continue
+        }
+      } else {
+        true
+      }
+    },
+  )
+}
+
 fn shift_back[K : Hash](self : HashSet[K], start_index : Int) -> Unit {
   for i = 0, prev = start_index, curr = self.next_index(start_index)
       i < self.entries.length()
       i = i + 1, prev = curr, curr = self.next_index(curr) {
     match self.entries[curr] {
-      Valid(d, h, k) => {
-        if d == 0 {
+      Valid(~psl, ~hash, ~key) => {
+        if psl == 0 {
           break
         }
-        self.entries[prev] = Valid(d - 1, h, k)
+        self.entries[prev] = Valid(psl=psl - 1, ~hash, ~key)
         self.entries[curr] = Empty
       }
       Empty => break
@@ -229,7 +244,7 @@ fn grow[K : Hash + Eq](self : HashSet[K]) -> Unit {
   self.size = 0
   for i = 0; i < old_entries.length(); i = i + 1 {
     match old_entries[i] {
-      Valid(_, _, k) => self.insert(k)
+      Valid(~key, ..) => self.insert(key)
       _ => ()
     }
   }
@@ -245,7 +260,15 @@ fn make_hash[K : Hash](self : HashSet[K], key : K) -> Int {
 }
 
 fn index[K : Hash](self : HashSet[K], hash : Int) -> Int {
-  hash.abs().land(self.capacity - 1)
+  abs(hash).land(self.capacity - 1)
+}
+
+fn abs(n : Int) -> Int {
+  if n < 0 {
+    -n
+  } else {
+    n
+  }
 }
 
 fn next_index[K : Hash](self : HashSet[K], index : Int) -> Int {
@@ -264,190 +287,8 @@ fn debug_entries[K : Show](self : HashSet[K]) -> String {
     }
     match self.entries[i] {
       Empty => s += "_"
-      Valid(d, _h, k) => s += "(\(d),\(k))"
+      Valid(~psl, ~key, ..) => s += "(\(psl),\(key))"
     }
   }
   s
-}
-
-test "new" {
-  let m : HashSet[Int] = HashSet::new()
-  @assertion.assert_eq(m.capacity, default_init_capacity)?
-  @assertion.assert_eq(m.size, 0)?
-}
-
-test "set" {
-  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
-  m.insert("a")
-  m.insert("b")
-  m.insert("bc")
-  m.insert("abc")
-  m.insert("cd")
-  m.insert("c")
-  m.insert("d")
-  @assertion.assert_eq(m.size, 7)?
-  @assertion.assert_eq(
-    m.debug_entries(),
-    "_,(0,a),(1,b),(2,c),(3,d),(3,bc),(4,cd),(4,abc),_,_,_,_,_,_,_,_",
-  )?
-}
-
-test "insert" {
-  let m : HashSet[String] = HashSet::new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("c")
-  @assertion.assert_true(m.contains("a"))?
-  @assertion.assert_true(m.contains("b"))?
-  @assertion.assert_true(m.contains("c"))?
-  @assertion.assert_false(m.contains("d"))?
-}
-
-test "from_array" {
-  let m = HashSet::["a", "b", "c"]
-  @assertion.assert_true(m.contains("a"))?
-  @assertion.assert_true(m.contains("b"))?
-  @assertion.assert_true(m.contains("c"))?
-  @assertion.assert_false(m.contains("d"))?
-}
-
-test "remove" {
-  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
-  m.insert("a")
-  m.insert("ab")
-  m.insert("bc")
-  m.insert("cd")
-  m.insert("abc")
-  m.insert("abcdef")
-  m.remove("ab")
-  @assertion.assert_eq(m.size(), 5)?
-  @assertion.assert_eq(
-    m.debug_entries(),
-    "_,(0,a),(0,bc),(1,cd),(1,abc),_,(0,abcdef),_",
-  )?
-}
-
-test "remove_unexist_key" {
-  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
-  m.insert("a")
-  m.insert("ab")
-  m.insert("abc")
-  m.remove("d")
-  @assertion.assert_eq(m.size(), 3)?
-  @assertion.assert_eq(m.debug_entries(), "_,(0,a),(0,ab),(0,abc),_,_,_,_")?
-}
-
-test "size" {
-  let m : HashSet[String] = HashSet::new()
-  @assertion.assert_eq(m.size(), 0)?
-  m.insert("a")
-  @assertion.assert_eq(m.size(), 1)?
-}
-
-test "is_empty" {
-  let m : HashSet[String] = HashSet::new()
-  @assertion.assert_eq(m.is_empty(), true)?
-  m.insert("a")
-  @assertion.assert_eq(m.is_empty(), false)?
-  m.remove("a")
-  @assertion.assert_eq(m.is_empty(), true)?
-}
-
-test "iter" {
-  let m : HashSet[String] = HashSet::["a", "b", "c"]
-  let mut sum = ""
-  m.iter(fn(k) { sum += k })
-  @assertion.assert_eq(sum, "cab")?
-}
-
-test "iteri" {
-  let m : HashSet[String] = HashSet::["1", "2", "3"]
-  let mut s = ""
-  let mut sum = 0
-  m.iteri(
-    fn(i, k) {
-      s += k
-      sum += i
-    },
-  )
-  @assertion.assert_eq(s, "321")?
-  @assertion.assert_eq(sum, 3)?
-}
-
-test "clear" {
-  let m : HashSet[String] = HashSet::["a", "b", "c"]
-  m.clear()
-  @assertion.assert_eq(m.size, 0)?
-  @assertion.assert_eq(m.capacity, 8)?
-  for i = 0; i < m.capacity; i = i + 1 {
-    @assertion.assert_is(m.entries[i], Empty)?
-  }
-}
-
-test "grow" {
-  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
-  m.insert("C")
-  m.insert("Go")
-  m.insert("C++")
-  m.insert("Java")
-  m.insert("Scala")
-  m.insert("Julia")
-  @assertion.assert_eq(m.size, 6)?
-  @assertion.assert_eq(m.capacity, 8)?
-  m.insert("Cobol")
-  @assertion.assert_eq(m.size, 7)?
-  @assertion.assert_eq(m.capacity, 16)?
-  m.insert("Python")
-  m.insert("Haskell")
-  m.insert("Rescript")
-  @assertion.assert_eq(m.size, 10)?
-  @assertion.assert_eq(m.capacity, 16)?
-  @assertion.assert_eq(
-    m.debug_entries(),
-    "_,(0,C),(0,Go),(0,C++),(0,Java),(0,Scala),(1,Julia),(2,Cobol),(2,Python),(2,Haskell),(2,Rescript),_,_,_,_,_",
-  )?
-}
-
-test "union" {
-  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
-  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
-  let m = m1.union(m2)
-  @assertion.assert_eq(m.size, 4)?
-  @assertion.assert_true(m.contains("a"))?
-  @assertion.assert_true(m.contains("b"))?
-  @assertion.assert_true(m.contains("c"))?
-  @assertion.assert_true(m.contains("d"))?
-}
-
-test "intersection" {
-  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
-  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
-  let m = m1.intersection(m2)
-  @assertion.assert_eq(m.size, 2)?
-  @assertion.assert_false(m.contains("a"))?
-  @assertion.assert_true(m.contains("b"))?
-  @assertion.assert_true(m.contains("c"))?
-  @assertion.assert_false(m.contains("d"))?
-}
-
-test "difference" {
-  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
-  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
-  let m = m1.difference(m2)
-  @assertion.assert_eq(m.size, 1)?
-  @assertion.assert_true(m.contains("a"))?
-  @assertion.assert_false(m.contains("b"))?
-  @assertion.assert_false(m.contains("c"))?
-  @assertion.assert_false(m.contains("d"))?
-}
-
-test "symmetric_difference" {
-  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
-  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
-  let m = m1.symmetric_difference(m2)
-  @assertion.assert_eq(m.size, 2)?
-  @assertion.assert_true(m.contains("a"))?
-  @assertion.assert_false(m.contains("b"))?
-  @assertion.assert_false(m.contains("c"))?
-  @assertion.assert_true(m.contains("d"))?
 }

--- a/hashset/hashset.mbti
+++ b/hashset/hashset.mbti
@@ -1,10 +1,13 @@
 package moonbitlang/core/hashset
 
+alias @moonbitlang/core/iter as @iter
+
 // Values
 
 // Types and methods
 type HashSet
 impl HashSet {
+  as_iter[K](Self[K]) -> @iter.Iter[K]
   capacity[K](Self[K]) -> Int
   clear[K](Self[K]) -> Unit
   contains[K : Hash + Eq](Self[K], K) -> Bool

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -1,0 +1,205 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "new" {
+  let m : HashSet[Int] = HashSet::new()
+  @assertion.assert_eq(m.capacity, default_init_capacity)?
+  @assertion.assert_eq(m.size, 0)?
+}
+
+test "set" {
+  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
+  m.insert("a")
+  m.insert("b")
+  m.insert("bc")
+  m.insert("abc")
+  m.insert("cd")
+  m.insert("c")
+  m.insert("d")
+  @assertion.assert_eq(m.size, 7)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,a),(1,b),(2,c),(3,d),(3,bc),(4,cd),(4,abc),_,_,_,_,_,_,_,_",
+  )?
+}
+
+test "insert" {
+  let m : HashSet[String] = HashSet::new()
+  m.insert("a")
+  m.insert("b")
+  m.insert("c")
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "from_array" {
+  let m = HashSet::["a", "b", "c"]
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "remove" {
+  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
+  m.insert("a")
+  m.insert("ab")
+  m.insert("bc")
+  m.insert("cd")
+  m.insert("abc")
+  m.insert("abcdef")
+  m.remove("ab")
+  @assertion.assert_eq(m.size(), 5)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,a),(0,bc),(1,cd),(1,abc),_,(0,abcdef),_",
+  )?
+}
+
+test "remove_unexist_key" {
+  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
+  m.insert("a")
+  m.insert("ab")
+  m.insert("abc")
+  m.remove("d")
+  @assertion.assert_eq(m.size(), 3)?
+  @assertion.assert_eq(m.debug_entries(), "_,(0,a),(0,ab),(0,abc),_,_,_,_")?
+}
+
+test "size" {
+  let m : HashSet[String] = HashSet::new()
+  @assertion.assert_eq(m.size(), 0)?
+  m.insert("a")
+  @assertion.assert_eq(m.size(), 1)?
+}
+
+test "is_empty" {
+  let m : HashSet[String] = HashSet::new()
+  @assertion.assert_eq(m.is_empty(), true)?
+  m.insert("a")
+  @assertion.assert_eq(m.is_empty(), false)?
+  m.remove("a")
+  @assertion.assert_eq(m.is_empty(), true)?
+}
+
+test "iter" {
+  let m : HashSet[String] = HashSet::["a", "b", "c"]
+  let mut sum = ""
+  m.iter(fn(k) { sum += k })
+  @assertion.assert_eq(sum, "cab")?
+}
+
+test "iteri" {
+  let m : HashSet[String] = HashSet::["1", "2", "3"]
+  let mut s = ""
+  let mut sum = 0
+  m.iteri(
+    fn(i, k) {
+      s += k
+      sum += i
+    },
+  )
+  @assertion.assert_eq(s, "321")?
+  @assertion.assert_eq(sum, 3)?
+}
+
+test "clear" {
+  let m : HashSet[String] = HashSet::["a", "b", "c"]
+  m.clear()
+  @assertion.assert_eq(m.size, 0)?
+  @assertion.assert_eq(m.capacity, 8)?
+  for i = 0; i < m.capacity; i = i + 1 {
+    @assertion.assert_is(m.entries[i], Empty)?
+  }
+}
+
+test "grow" {
+  let m : HashSet[String] = HashSet::new(hasher=Some(fn(k) { k.length() }))
+  m.insert("C")
+  m.insert("Go")
+  m.insert("C++")
+  m.insert("Java")
+  m.insert("Scala")
+  m.insert("Julia")
+  @assertion.assert_eq(m.size, 6)?
+  @assertion.assert_eq(m.capacity, 8)?
+  m.insert("Cobol")
+  @assertion.assert_eq(m.size, 7)?
+  @assertion.assert_eq(m.capacity, 16)?
+  m.insert("Python")
+  m.insert("Haskell")
+  m.insert("Rescript")
+  @assertion.assert_eq(m.size, 10)?
+  @assertion.assert_eq(m.capacity, 16)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,C),(0,Go),(0,C++),(0,Java),(0,Scala),(1,Julia),(2,Cobol),(2,Python),(2,Haskell),(2,Rescript),_,_,_,_,_",
+  )?
+}
+
+test "union" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.union(m2)
+  @assertion.assert_eq(m.size, 4)?
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_true(m.contains("d"))?
+}
+
+test "intersection" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.intersection(m2)
+  @assertion.assert_eq(m.size, 2)?
+  @assertion.assert_false(m.contains("a"))?
+  @assertion.assert_true(m.contains("b"))?
+  @assertion.assert_true(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "difference" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.difference(m2)
+  @assertion.assert_eq(m.size, 1)?
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_false(m.contains("b"))?
+  @assertion.assert_false(m.contains("c"))?
+  @assertion.assert_false(m.contains("d"))?
+}
+
+test "symmetric_difference" {
+  let m1 : HashSet[String] = HashSet::["a", "b", "c"]
+  let m2 : HashSet[String] = HashSet::["b", "c", "d"]
+  let m = m1.symmetric_difference(m2)
+  @assertion.assert_eq(m.size, 2)?
+  @assertion.assert_true(m.contains("a"))?
+  @assertion.assert_false(m.contains("b"))?
+  @assertion.assert_false(m.contains("c"))?
+  @assertion.assert_true(m.contains("d"))?
+}
+
+test "as_iter" {
+  let buf = Buffer::make(20)
+  let map = HashSet::["a", "b", "c"]
+  map.as_iter().iter(fn(e) { buf.write_string("[\(e)]") })
+  inspect(buf, content="[c][a][b]")?
+  buf.reset()
+  map.as_iter().take(2).iter(fn(e) { buf.write_string("[\(e)]") })
+  inspect(buf, content="[c][a]")?
+}

--- a/hashset/moon.pkg.json
+++ b/hashset/moon.pkg.json
@@ -1,11 +1,9 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/int",
-    "moonbitlang/core/list",
     "moonbitlang/core/array",
-    "moonbitlang/core/string",
-    "moonbitlang/core/assertion",
+    "moonbitlang/core/iter",
     "moonbitlang/core/coverage"
-  ]
+  ],
+  "test_import": ["moonbitlang/core/string", "moonbitlang/core/assertion"]
 }

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -15,7 +15,7 @@
 priv enum Entry[K] {
   Empty
   // (Probe Sequence Length, Hash, Key)
-  Valid(Int, Int, K)
+  Valid(~psl : Int, ~hash : Int, ~key : K)
 } derive(Debug)
 
 /// A mutable hash set implements with Robin Hood hashing.


### PR DESCRIPTION
- Move all tests to a test file.
- Refactor with labeled enum.
- Add `as_iter` method.
- Clean up the package import.