### PR TITLE
feat: Add Devec::as_iter method

### DIFF
--- a/devec/devec.mbt
+++ b/devec/devec.mbt
@@ -769,4 +769,8 @@ test "as_iter" {
       #|
     ,
   )?
+  inspect(
+    iter.take(4).filter(fn(x) { x % 2 == 0 }).fold(fn(a, x) { a + x }, 0),
+    content="6",
+  )?
 }

--- a/devec/devec.mbt
+++ b/devec/devec.mbt
@@ -731,3 +731,42 @@ test "shrink_to_fit_2" {
   dv.shrink_to_fit()
   @assertion.assert_true(dv.capacity() == 3)?
 }
+
+pub fn as_iter[T](self : Devec[T]) -> @iter.Iter[T] {
+  @iter.Iter::_unstable_internal_make(
+    fn(yield) {
+      for i = 0, len = self.length(); i < len; i = i + 1 {
+        if yield(self[i]).not() {
+          break false
+        }
+      } else {
+        true
+      }
+    },
+  )
+}
+
+test "as_iter" {
+  let dv = Devec::[1, 2, 3, 4, 5]
+  let iter = dv.as_iter()
+  let buf = Buffer::make(0)
+  let mut i = 0
+  iter.iter(
+    fn(x) {
+      buf.write_string(x.to_string())
+      buf.write_char('\n')
+      i = i + 1
+    },
+  )
+  @assertion.assert_eq(i, dv.length())?
+  buf.expect(
+    content=
+      #|1
+      #|2
+      #|3
+      #|4
+      #|5
+      #|
+    ,
+  )?
+}

--- a/devec/devec.mbti
+++ b/devec/devec.mbti
@@ -1,10 +1,13 @@
 package moonbitlang/core/devec
 
+alias @moonbitlang/core/iter as @iter
+
 // Values
 
 // Types and methods
 type Devec
 impl Devec {
+  as_iter[T](Self[T]) -> @iter.Iter[T]
   back[T](Self[T]) -> Option[T]
   capacity[T](Self[T]) -> Int
   clear[T](Self[T]) -> Unit

--- a/devec/moon.pkg.json
+++ b/devec/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/assertion",
     "moonbitlang/core/coverage",
-    "moonbitlang/core/array"
+    "moonbitlang/core/array",
+    "moonbitlang/core/iter"
   ]
 }


### PR DESCRIPTION
As described in #50 , this attempted to `add as_iter for each data structure`