### PR TITLE
fix BigInt 'from_string' when input is 0

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -599,7 +599,7 @@ pub fn from_string(input : String) -> BigInt {
       carry /= radix
     }
   }
-  while b[b_len - 1] == 0 {
+  while b[b_len - 1] == 0 && b_len > 1 {
     b_len -= 1
   }
   { limbs: b, sign, len: b_len }

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -377,6 +377,9 @@ test "lsr" {
 }
 
 test "decimal_string" {
+  let a = from_string("0")
+  check_len(a)?
+  inspect(a.to_string(), content="0")?
   let a = from_string("123")
   check_len(a)?
   inspect(a.to_string(), content="123")?


### PR DESCRIPTION
a missing case: from_string("0") , which will cause RuntimeError if not fix