### PR TITLE
refine behavior of Show::to_string(Bytes)

### DIFF
--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -39,7 +39,29 @@ pub impl Show for Byte with output(self, logger) {
 }
 
 pub impl Show for Bytes with output(self, logger) {
-  logger.write_string(self.to_string())
+  fn to_hex_digit(i : Int) -> Char {
+    if i < 10 {
+      Char::from_int('0'.to_int() + i)
+    } else {
+      Char::from_int('a'.to_int() + (i - 10))
+    }
+  }
+
+  logger.write_string("b\"")
+  for i = 0; i < self.length(); i = i + 1 {
+    let byte = self[i].to_int()
+    logger
+    ..write_string("\\x")
+    ..write_char(to_hex_digit(byte / 16))
+    .write_char(to_hex_digit(byte % 16))
+  }
+  logger.write_string("\"")
+}
+
+pub impl Show for Bytes with to_string(self) {
+  let buf = Buffer::new()
+  Show::output(self, buf)
+  buf.to_string()
 }
 
 pub impl Show for String with output(self, logger) {

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -12,9 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+test "bytes literal" {
+  inspect!(
+    b"ABC",
+    content=
+      #|b"\x41\x42\x43"
+    ,
+  )
+  
+  inspect!(
+    b"\x65\x66\x67",
+    content=
+      #|b"\x65\x66\x67"
+    ,
+  )
+}
+
 test "from_array" {
   let b = @bytes.of([b'\x41', b'\x00', b'\x42', b'\x00', b'\x43', b'\x00'])
-  inspect!(b, content="ABC")
+  inspect!(b, content=
+    #|b"\x41\x00\x42\x00\x43\x00"
+  )
 }
 
 test "hash" {

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -19,19 +19,21 @@ test "bytes literal" {
       #|b"\x41\x42\x43"
     ,
   )
-  
   inspect!(
-    b"\x65\x66\x67",
+    b"\x41\x42\x43",
     content=
-      #|b"\x65\x66\x67"
+      #|b"\x41\x42\x43"
     ,
   )
 }
 
 test "from_array" {
   let b = @bytes.of([b'\x41', b'\x00', b'\x42', b'\x00', b'\x43', b'\x00'])
-  inspect!(b, content=
-    #|b"\x41\x00\x42\x00\x43\x00"
+  inspect!(
+    b,
+    content=
+      #|b"\x41\x00\x42\x00\x43\x00"
+    ,
   )
 }
 


### PR DESCRIPTION
#291


- Change the behavior of Show trait implementation for Bytes

     > We should add bytes literal syntax, e.g, b"xx.." and use make Byte::to_string confirm to the format
   
    Now it will print something like `b"\x00\x00..."` when inspecting a Bytes.

- This pr does not change any API.

