### PR TITLE
Add LinkedHashMap

### DIFF
--- a/linked_hashmap/README.md
+++ b/linked_hashmap/README.md
@@ -1,0 +1,91 @@
+# Moonbit/Core LinkedHashMap
+
+## Overview
+
+A mutable linked hash map based on a Robin Hood hash table, links all entry nodes in a linked list to mantains the order of insertion.
+
+## Usage
+
+### Create
+
+You can create an empty map using `new()` or construct it using `from_array()`.
+
+```moonbit
+let map1 : LinkedHashMap[String, Int] = LinkedHashMap::new()
+let map2 = LinkedHashMap::[("one", 1), ("two", 2), ("three", 3), ("four", 4), ("five", 5)]
+```
+
+When creating via `new()`, you can set a custom hasher by providing a labeled argument `~hasher`. 
+
+```moonbit
+// Create with custom hasher.
+let map = LinkedHashMap::new(~hasher=Some(fn(k) { k.length() }))
+```
+
+### Set & Get
+
+You can use `set()` to add a key-value pair to the map, and use `get()` to get a key-value pair.
+
+```moonbit
+let map : LinkedHashMap[String, Int] = LinkedHashMap::new()
+map.set("a", 1)
+map.get("a") // 1
+map.get_or_default("a", 0) // 1
+map.get_or_default("b", 0) // 0
+```
+
+### Remove
+
+You can use `remove()` to remove a key-value pair.
+
+```moonbit
+let map = LinkedHashMap::[("a", 1), ("b", 2), ("c", 3)]
+map.remove("a")
+```
+
+### Contains
+
+You can use `contains()` to check whether a key exists.
+
+```moonbit
+let map = LinkedHashMap::[("a", 1), ("b", 2), ("c", 3)]
+map.contains("a") // true
+map.contains("d") // false
+```
+
+### Size & Capacity
+
+You can use `size()` to get the number of key-value pairs in the map, or `capacity()` to get the current capacity.
+
+```moonbit
+let map = LinkedHashMap::[("a", 1), ("b", 2), ("c", 3)]
+map.size() // 3
+map.capacity() // 8
+```
+
+Similarly, you can use `is_empty()` to check whether the map is empty.
+
+```moonbit
+let map : LinkedHashMap[String, Int] = LinkedHashMap::new()
+map.is_empty() // true
+```
+
+### Clear
+
+You can use `clear` to remove all key-value pairs from the map, but the allocated memory will not change.
+
+```moonbit
+let map = LinkedHashMap::[("a", 1), ("b", 2), ("c", 3)]
+map.clear()
+map.is_empty() // true
+```
+
+### Iter
+
+You can use `iter()` or `iteri()` to iterate through all key-value pairs in the order of insertion.
+
+```moonbit
+let map = LinkedHashMap::[("a", 1), ("b", 2), ("c", 3)]
+map.iter(fn(k, v) { println("\(k)-\(v)") })
+map.iteri(fn(i, k, v) { println("\(i)-\(k)-\(v)") })
+```

--- a/linked_hashmap/impl.mbt
+++ b/linked_hashmap/impl.mbt
@@ -1,0 +1,294 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Default initial capacity
+let default_init_capacity = 8
+
+/// Create a hash map.
+pub fn LinkedHashMap::new[K, V](
+  ~hasher : Option[(K) -> Int] = None
+) -> LinkedHashMap[K, V] {
+  {
+    size: 0,
+    capacity: default_init_capacity,
+    growAt: calc_grow_threshold(default_init_capacity),
+    hasher,
+    entries: @array.new(default_init_capacity, fn() { Empty }),
+    head: None,
+    tail: None,
+  }
+}
+
+/// Create a hash map from array.
+pub fn LinkedHashMap::from_array[K : Hash + Eq, V](
+  arr : Array[(K, V)]
+) -> LinkedHashMap[K, V] {
+  let m = new()
+  arr.iter(fn(e) { m.set(e.0, e.1) })
+  m
+}
+
+/// Set a key-value pair into the hash map.
+/// @alert unsafe "Panic if the hash map is full."
+pub fn set[K : Hash + Eq, V](
+  self : LinkedHashMap[K, V],
+  key : K,
+  value : V
+) -> Unit {
+  if self.capacity == 0 || self.size >= self.growAt {
+    self.grow()
+  }
+  let hash = self.make_hash(key)
+  let insert_entry = Entry::Valid(
+    psl=0,
+    ~hash,
+    ~key,
+    ~value,
+    prev=None,
+    next=None,
+  )
+  loop 0, self.index(hash), insert_entry {
+    i, idx, Valid(~psl, ~hash, ~key, ~value, ..) as entry => {
+      if i == self.capacity {
+        abort("HashMap is full")
+      }
+      match self.entries[idx] {
+        Empty => {
+          self.entries[idx] = entry
+          self.size += 1
+          self.add_entry_to_tail(insert_entry)
+          break
+        }
+        Valid(_) as curr_entry => {
+          if curr_entry.hash == hash && curr_entry.key == key {
+            curr_entry.value = value
+            break
+          }
+          if psl > curr_entry.psl {
+            self.entries[idx] = entry
+            curr_entry.psl += 1
+            continue i + 1, self.next_index(idx), curr_entry
+          } else {
+            entry.psl += 1
+            continue i + 1, self.next_index(idx), entry
+          }
+        }
+      }
+    }
+    _, _, _ => break
+  }
+}
+
+pub fn op_set[K : Hash + Eq, V](
+  self : LinkedHashMap[K, V],
+  key : K,
+  value : V
+) -> Unit {
+  self.set(key, value)
+}
+
+/// Get the value associated with a key.
+pub fn get[K : Hash + Eq, V](self : LinkedHashMap[K, V], key : K) -> Option[V] {
+  let hash = self.make_hash(key)
+  for i = 0, idx = self.index(hash)
+      i < self.capacity
+      i = i + 1, idx = self.next_index(idx) {
+    match self.entries[idx] {
+      Valid(_) as entry => {
+        if entry.hash == hash && entry.key == key {
+          break Some(entry.value)
+        }
+        if i > entry.psl {
+          break None
+        }
+      }
+      Empty => break None
+    }
+  } else {
+    None
+  }
+}
+
+pub fn op_get[K : Hash + Eq, V](
+  self : LinkedHashMap[K, V],
+  key : K
+) -> Option[V] {
+  self.get(key)
+}
+
+/// Get the value associated with a key, 
+/// returns the provided default value if the key does not exist.
+pub fn get_or_default[K : Hash + Eq, V](
+  self : LinkedHashMap[K, V],
+  key : K,
+  default : V
+) -> V {
+  match self.get(key) {
+    Some(v) => v
+    None => default
+  }
+}
+
+/// Check if the hash map contains a key.
+pub fn contains[K : Hash + Eq, V](self : LinkedHashMap[K, V], key : K) -> Bool {
+  match self.get(key) {
+    Some(_) => true
+    None => false
+  }
+}
+
+/// Remove a key-value pair from hash map.
+pub fn remove[K : Hash + Eq, V](self : LinkedHashMap[K, V], key : K) -> Unit {
+  let hash = self.make_hash(key)
+  for i = 0, idx = self.index(hash)
+      i < self.capacity
+      i = i + 1, idx = self.next_index(idx) {
+    match self.entries[idx] {
+      Valid(_) as entry => {
+        if entry.hash == hash && entry.key == key {
+          self.entries[idx] = Empty
+          self.shift_back(idx)
+          self.size -= 1
+          self.remove_entry(entry)
+          break
+        }
+        if i > entry.psl {
+          return
+        }
+      }
+      Empty => ()
+    }
+  }
+}
+
+fn add_entry_to_tail[K : Eq, V](
+  self : LinkedHashMap[K, V],
+  entry : Entry[K, V]
+) -> Unit {
+  match entry {
+    Valid(_) as e =>
+      if self.tail.is_empty() {
+        self.head = Some(entry)
+        self.tail = Some(entry)
+      } else {
+        match self.tail.unwrap() {
+          Valid(_) as tail => {
+            tail.next = Some(entry)
+            e.prev = Some(tail)
+            self.tail = Some(entry)
+          }
+          _ => ()
+        }
+      }
+    _ => ()
+  }
+}
+
+fn remove_entry[K : Eq, V](
+  self : LinkedHashMap[K, V],
+  entry : Entry[K, V]
+) -> Unit {
+  match entry {
+    Valid(_) as e => {
+      if self.is_empty() {
+        self.head = None
+        self.tail = None
+      } else {
+        if e == self.head.unwrap() {
+          self.head = e.next
+        }
+        if e == self.tail.unwrap() {
+          self.tail = e.prev
+        }
+        match e.prev {
+          Some(Valid(_) as prev) => prev.next = e.next
+          _ => ()
+        }
+        match e.next {
+          Some(Valid(_) as next) => next.prev = e.prev
+          _ => ()
+        }
+      }
+      e.prev = None
+      e.next = None
+    }
+    _ => ()
+  }
+}
+
+fn shift_back[K : Hash, V](
+  self : LinkedHashMap[K, V],
+  start_index : Int
+) -> Unit {
+  for i = 0, prev = start_index, curr = self.next_index(start_index)
+      i < self.entries.length()
+      i = i + 1, prev = curr, curr = self.next_index(curr) {
+    match self.entries[curr] {
+      Valid(~psl, ..) as entry => {
+        if psl == 0 {
+          break
+        }
+        entry.psl -= 1
+        self.entries[prev] = entry
+        self.entries[curr] = Empty
+      }
+      Empty => break
+    }
+  }
+}
+
+fn grow[K : Hash + Eq, V](self : LinkedHashMap[K, V]) -> Unit {
+  // handle zero capacity
+  if self.capacity == 0 {
+    self.capacity = default_init_capacity
+    self.growAt = calc_grow_threshold(self.capacity)
+    self.size = 0
+    self.entries = @array.new(self.capacity, fn() { Empty })
+    return
+  }
+  let old_head = self.head
+  self.entries = @array.new(self.capacity * 2, fn() { Empty })
+  self.capacity = self.capacity * 2
+  self.growAt = calc_grow_threshold(self.capacity)
+  self.size = 0
+  self.head = None
+  loop old_head {
+    Some(Valid(~key, ~value, ~next, ..)) => {
+      self.set(key, value)
+      continue next
+    }
+    _ => break
+  }
+}
+
+fn make_hash[K : Hash, V](self : LinkedHashMap[K, V], key : K) -> Int {
+  let hash : Int = match self.hasher {
+    Some(hasher) => hasher(key)
+    None => key.hash()
+  }
+  // Let higher 16 bits of the hash value participate in the calculation
+  hash.lxor(hash.lsr(16))
+}
+
+fn index[K : Hash, V](self : LinkedHashMap[K, V], hash : Int) -> Int {
+  hash.abs().land(self.capacity - 1)
+}
+
+fn next_index[K : Hash, V](self : LinkedHashMap[K, V], index : Int) -> Int {
+  (index + 1).land(self.capacity - 1)
+}
+
+fn calc_grow_threshold(capacity : Int) -> Int {
+  capacity * 13 / 16
+}

--- a/linked_hashmap/impl_test.mbt
+++ b/linked_hashmap/impl_test.mbt
@@ -1,0 +1,320 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "new" {
+  let m : LinkedHashMap[Int, Int] = LinkedHashMap::new()
+  @assertion.assert_eq(m.capacity, default_init_capacity)?
+  @assertion.assert_eq(m.size, 0)?
+}
+
+test "set" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new(
+    hasher=Some(fn(k) { k.length() }),
+  )
+  m.set("a", 1)
+  m.set("b", 1)
+  m.set("bc", 2)
+  m.set("abc", 3)
+  m.set("cd", 2)
+  m.set("c", 1)
+  m.set("d", 1)
+  @assertion.assert_eq(m.size, 7)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,a,1),(1,b,1),(2,c,1),(3,d,1),(3,bc,2),(4,cd,2),(4,abc,3),_,_,_,_,_,_,_,_",
+  )?
+}
+
+test "get" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  m.set("a", 1)
+  m.set("b", 2)
+  m.set("c", 3)
+  @assertion.assert_eq(m.get("a"), Some(1))?
+  @assertion.assert_eq(m.get("b"), Some(2))?
+  @assertion.assert_eq(m.get("c"), Some(3))?
+  @assertion.assert_eq(m.get("d"), None)?
+}
+
+test "get_or_default" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  m.set("a", 1)
+  m.set("b", 2)
+  m.set("c", 3)
+  @assertion.assert_eq(m.get_or_default("a", 42), 1)?
+  @assertion.assert_eq(m.get_or_default("b", 42), 2)?
+  @assertion.assert_eq(m.get_or_default("c", 42), 3)?
+  @assertion.assert_eq(m.get_or_default("d", 42), 42)?
+}
+
+test "op_set" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  m["a"] = 1
+  m["b"] = 2
+  @assertion.assert_eq(m.get("a"), Some(1))?
+  @assertion.assert_eq(m.get("b"), Some(2))?
+}
+
+test "op_get" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  m.set("a", 1)
+  m.set("b", 2)
+  @assertion.assert_eq(m["a"], Some(1))?
+  @assertion.assert_eq(m["b"], Some(2))?
+  @assertion.assert_eq(m["c"], None)?
+}
+
+test "set_update" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  m.set("a", 1)
+  m.set("b", 2)
+  @assertion.assert_eq(m.get("a"), Some(1))?
+  m.set("a", 2)
+  @assertion.assert_eq(m.get("a"), Some(2))?
+}
+
+test "contains" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  m.set("a", 1)
+  @assertion.assert_eq(m.contains("a"), true)?
+  @assertion.assert_eq(m.contains("b"), false)?
+}
+
+test "from_array" {
+  let m = LinkedHashMap::[("a", 1), ("b", 2), ("c", 3)]
+  @assertion.assert_eq(m.get("a"), Some(1))?
+  @assertion.assert_eq(m.get("b"), Some(2))?
+  @assertion.assert_eq(m.get("c"), Some(3))?
+}
+
+test "remove" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new(
+    hasher=Some(fn(k) { k.length() }),
+  )
+  m.set("a", 1)
+  m.set("ab", 2)
+  m.set("bc", 2)
+  m.set("cd", 2)
+  m.set("abc", 3)
+  m.set("abcdef", 6)
+  m.remove("ab")
+  @assertion.assert_eq(m.size(), 5)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,a,1),(0,bc,2),(1,cd,2),(1,abc,3),_,(0,abcdef,6),_",
+  )?
+}
+
+test "remove_unexist_key" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new(
+    hasher=Some(fn(k) { k.length() }),
+  )
+  m.set("a", 1)
+  m.set("ab", 2)
+  m.set("abc", 3)
+  m.remove("d")
+  @assertion.assert_eq(m.size(), 3)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,a,1),(0,ab,2),(0,abc,3),_,_,_,_",
+  )?
+}
+
+test "size" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  @assertion.assert_eq(m.size(), 0)?
+  m.set("a", 1)
+  @assertion.assert_eq(m.size(), 1)?
+}
+
+test "is_empty" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new()
+  @assertion.assert_eq(m.is_empty(), true)?
+  m.set("a", 1)
+  @assertion.assert_eq(m.is_empty(), false)?
+  m.remove("a")
+  @assertion.assert_eq(m.is_empty(), true)?
+}
+
+test "iter" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::[
+    ("a", 1),
+    ("b", 2),
+    ("c", 3),
+  ]
+  let mut sum = 0
+  m.iter(fn(_k, v) { sum += v })
+  @assertion.assert_eq(sum, 6)?
+}
+
+test "iteri" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::[
+    ("a", 1),
+    ("b", 2),
+    ("c", 3),
+  ]
+  let mut sum = 0
+  let mut s = ""
+  m.iteri(
+    fn(i, _k, v) {
+      s += i.to_string()
+      sum += v
+    },
+  )
+  @assertion.assert_eq(s, "012")?
+  @assertion.assert_eq(sum, 6)?
+}
+
+test "clear" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::[
+    ("a", 1),
+    ("b", 2),
+    ("c", 3),
+  ]
+  m.clear()
+  @assertion.assert_eq(m.size, 0)?
+  @assertion.assert_eq(m.capacity, 8)?
+  @assertion.assert_eq(m.head, None)?
+  @assertion.assert_eq(m.tail, None)?
+  for i = 0; i < m.capacity; i = i + 1 {
+    @assertion.assert_is(m.entries[i], Empty)?
+  }
+}
+
+test "grow" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::new(
+    hasher=Some(fn(k) { k.length() }),
+  )
+  m.set("C", 1)
+  m.set("Go", 2)
+  m.set("C++", 3)
+  m.set("Java", 4)
+  m.set("Scala", 5)
+  m.set("Julia", 5)
+  @assertion.assert_eq(m.size(), 6)?
+  @assertion.assert_eq(m.capacity(), 8)?
+  m.set("Cobol", 5)
+  @assertion.assert_eq(m.size(), 7)?
+  @assertion.assert_eq(m.capacity(), 16)?
+  m.set("Python", 6)
+  m.set("Haskell", 7)
+  m.set("Rescript", 8)
+  @assertion.assert_eq(m.size(), 10)?
+  @assertion.assert_eq(m.capacity(), 16)?
+  @assertion.assert_eq(
+    m.debug_entries(),
+    "_,(0,C,1),(0,Go,2),(0,C++,3),(0,Java,4),(0,Scala,5),(1,Julia,5),(2,Cobol,5),(2,Python,6),(2,Haskell,7),(2,Rescript,8),_,_,_,_,_",
+  )?
+}
+
+test "as_iter" {
+  let buf = Buffer::make(20)
+  let map = LinkedHashMap::[(1, "one"), (2, "two"), (3, "three")]
+  map.as_iter().iter(
+    fn(e) {
+      let (k, v) = e
+      buf.write_string("[\(k)-\(v)]")
+    },
+  )
+  inspect(buf, content="[1-one][2-two][3-three]")?
+  buf.reset()
+  map.as_iter().take(2).iter(
+    fn(e) {
+      let (k, v) = e
+      buf.write_string("[\(k)-\(v)]")
+    },
+  )
+  inspect(buf, content="[1-one][2-two]")?
+}
+
+test "iter order" {
+  let m = LinkedHashMap::[("one", 1)]
+  m["three"] = 3
+  m["two"] = 2
+  let buf = Buffer::make(0)
+  m.iter(fn(k, v) { buf.write_string("[\(k)-\(v)]") })
+  inspect(buf.to_string(), content="[one-1][three-3][two-2]")?
+}
+
+test "linked list" {
+  let m : LinkedHashMap[String, Int] = LinkedHashMap::[]
+  inspect(m.debug_linked_list(), content="end")?
+  m["one"] = 1
+  m["two"] = 2
+  m["three"] = 3
+  m["four"] = 4
+  m["five"] = 5
+  inspect(
+    m.debug_linked_list(),
+    content=
+      #|(-684895554,one,1,prev:_,next:1759431067)
+      #|(1759431067,two,2,prev:-684895554,next:957279207)
+      #|(957279207,three,3,prev:1759431067,next:-1028309232)
+      #|(-1028309232,four,4,prev:957279207,next:-1715640224)
+      #|(-1715640224,five,5,prev:-1028309232,next:_)
+      #|end
+    ,
+  )?
+  m.remove("three")
+  inspect(
+    m.debug_linked_list(),
+    content=
+      #|(-684895554,one,1,prev:_,next:1759431067)
+      #|(1759431067,two,2,prev:-684895554,next:-1028309232)
+      #|(-1028309232,four,4,prev:1759431067,next:-1715640224)
+      #|(-1715640224,five,5,prev:-1028309232,next:_)
+      #|end
+    ,
+  )?
+  m.set("two", 20)
+  inspect(
+    m.debug_linked_list(),
+    content=
+      #|(-684895554,one,1,prev:_,next:1759431067)
+      #|(1759431067,two,20,prev:-684895554,next:-1028309232)
+      #|(-1028309232,four,4,prev:1759431067,next:-1715640224)
+      #|(-1715640224,five,5,prev:-1028309232,next:_)
+      #|end
+    ,
+  )?
+  m.remove("one")
+  inspect(
+    m.debug_linked_list(),
+    content=
+      #|(1759431067,two,20,prev:_,next:-1028309232)
+      #|(-1028309232,four,4,prev:1759431067,next:-1715640224)
+      #|(-1715640224,five,5,prev:-1028309232,next:_)
+      #|end
+    ,
+  )?
+  m.remove("five")
+  inspect(
+    m.debug_linked_list(),
+    content=
+      #|(1759431067,two,20,prev:_,next:-1028309232)
+      #|(-1028309232,four,4,prev:1759431067,next:_)
+      #|end
+    ,
+  )?
+  m.remove("two")
+  inspect(
+    m.debug_linked_list(),
+    content=
+      #|(-1028309232,four,4,prev:_,next:_)
+      #|end
+    ,
+  )?
+  m.remove("four")
+  inspect(m.debug_linked_list(), content="end")?
+}

--- a/linked_hashmap/linked_hashmap.mbti
+++ b/linked_hashmap/linked_hashmap.mbti
@@ -1,0 +1,31 @@
+package moonbitlang/core/linked_hashmap
+
+alias @moonbitlang/core/iter as @iter
+
+// Values
+
+// Types and methods
+type LinkedHashMap
+impl LinkedHashMap {
+  as_iter[K, V](Self[K, V]) -> @iter.Iter[Tuple[K, V]]
+  capacity[K, V](Self[K, V]) -> Int
+  clear[K, V](Self[K, V]) -> Unit
+  contains[K : Hash + Eq, V](Self[K, V], K) -> Bool
+  from_array[K : Hash + Eq, V](Array[Tuple[K, V]]) -> Self[K, V]
+  get[K : Hash + Eq, V](Self[K, V], K) -> Option[V]
+  get_or_default[K : Hash + Eq, V](Self[K, V], K, V) -> V
+  is_empty[K, V](Self[K, V]) -> Bool
+  iter[K, V](Self[K, V], (K, V) -> Unit) -> Unit
+  iteri[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
+  new[K, V](~hasher : Option[(K) -> Int] = ..) -> Self[K, V]
+  op_get[K : Hash + Eq, V](Self[K, V], K) -> Option[V]
+  op_set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
+  remove[K : Hash + Eq, V](Self[K, V], K) -> Unit
+  set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
+  size[K, V](Self[K, V]) -> Int
+}
+
+// Traits
+
+// Extension Methods
+

--- a/linked_hashmap/moon.pkg.json
+++ b/linked_hashmap/moon.pkg.json
@@ -1,0 +1,11 @@
+{
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/coverage",
+    "moonbitlang/core/iter",
+    "moonbitlang/core/int",
+    "moonbitlang/core/array",
+    "moonbitlang/core/option"
+  ],
+  "test_import": ["moonbitlang/core/string", "moonbitlang/core/assertion"]
+}

--- a/linked_hashmap/types.mbt
+++ b/linked_hashmap/types.mbt
@@ -1,0 +1,61 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+priv enum Entry[K, V] {
+  Empty
+  Valid(
+    mut ~psl : Int,
+    ~hash : Int,
+    ~key : K,
+    mut ~value : V,
+    mut ~prev : Option[Entry[K, V]],
+    mut ~next : Option[Entry[K, V]]
+  )
+} derive(Debug)
+
+fn op_equal[K : Eq, V](self : Entry[K, V], other : Entry[K, V]) -> Bool {
+  match (self, other) {
+    (Empty, Empty) => true
+    (Valid(_), Empty) => false
+    (Empty, Valid(_)) => false
+    (Valid(hash=h1, key=k1, ..), Valid(hash=h2, key=k2, ..)) =>
+      h1 == h2 && k1 == k2
+  }
+}
+
+/// Mutable linked hash map that maintains the order of insertion, not thread safe. 
+///  
+/// # Example
+/// 
+/// ```
+/// let map = HashMap::[(3, "three"), (8, "eight"), (1, "one")]
+/// println(map.get(2)) // output: None
+/// println(map.get(3)) // output: Some("three")
+/// map.set(3, "updated")
+/// println(map.get(3)) // output: Some("updated")
+/// map.iter(fn(k, v) { println("\(k)-\(v)") })
+/// // output:
+/// // 3-three
+/// // 8-eight
+/// // 1-one
+/// ```
+struct LinkedHashMap[K, V] {
+  mut entries : Array[Entry[K, V]]
+  mut size : Int // active key-value pairs count
+  mut capacity : Int // current capacity 
+  mut growAt : Int // threshold that triggers grow
+  hasher : Option[(K) -> Int] // custom hasher
+  mut head : Option[Entry[K, V]] // head of linked list
+  mut tail : Option[Entry[K, V]] // tail of linked list
+}

--- a/linked_hashmap/utils.mbt
+++ b/linked_hashmap/utils.mbt
@@ -1,0 +1,111 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn debug_entries[K : Show, V : Show](self : LinkedHashMap[K, V]) -> String {
+  let buf = Buffer::make(0)
+  for i = 0; i < self.entries.length(); i = i + 1 {
+    if i > 0 {
+      buf.write_char(',')
+    }
+    match self.entries[i] {
+      Empty => buf.write_char('_')
+      Valid(~psl, ~key, ~value, ..) =>
+        buf.write_string("(\(psl),\(key),\(value))")
+    }
+  }
+  buf.to_string()
+}
+
+fn debug_linked_list[K : Show, V : Show](self : LinkedHashMap[K, V]) -> String {
+  let buf = Buffer::make(0)
+  loop self.head {
+    Some(Valid(~key, ~value, ~prev, ~next, ~hash, ..)) => {
+      buf.write_char('(')
+      buf.write_string("\(hash),\(key),\(value)")
+      buf.write_string(",prev:")
+      match prev {
+        Some(Valid(~hash, ..)) => buf.write_string(hash.to_string())
+        _ => buf.write_char('_')
+      }
+      buf.write_string(",next:")
+      match next {
+        Some(Valid(~hash, ..)) => buf.write_string(hash.to_string())
+        _ => buf.write_char('_')
+      }
+      buf.write_char(')')
+      buf.write_char('\n')
+      continue next
+    }
+    _ => buf.write_string("end")
+  }
+  buf.to_string()
+}
+
+/// Get the number of key-value pairs in the map.
+pub fn size[K, V](self : LinkedHashMap[K, V]) -> Int {
+  self.size
+}
+
+/// Get the capacity of the map.
+pub fn capacity[K, V](self : LinkedHashMap[K, V]) -> Int {
+  self.capacity
+}
+
+/// Check if the hash map is empty.
+pub fn is_empty[K, V](self : LinkedHashMap[K, V]) -> Bool {
+  self.size == 0
+}
+
+/// Iterate over all key-value pairs of the map in the order of insertion.
+pub fn iter[K, V](self : LinkedHashMap[K, V], f : (K, V) -> Unit) -> Unit {
+  self.iteri(fn(_i, k, v) { f(k, v) })
+}
+
+/// Iterate over all key-value pairs of the map in the order of insertion, with index.
+pub fn iteri[K, V](self : LinkedHashMap[K, V], f : (Int, K, V) -> Unit) -> Unit {
+  loop 0, self.head {
+    idx, Some(Valid(~key, ~value, ~next, ..)) => {
+      f(idx, key, value)
+      continue idx + 1, next
+    }
+    _, _ => break
+  }
+}
+
+/// Clear the map, removing all key-value pairs. Keeps the allocated space.
+pub fn clear[K, V](self : LinkedHashMap[K, V]) -> Unit {
+  for i = 0; i < self.capacity; i = i + 1 {
+    self.entries[i] = Empty
+  }
+  self.size = 0
+  self.head = None
+  self.tail = None
+}
+
+/// Return the iterator of the hash map, provide elements in the order of insertion.
+pub fn as_iter[K, V](self : LinkedHashMap[K, V]) -> @iter.Iter[(K, V)] {
+  @iter.Iter::_unstable_internal_make(
+    fn(yield) {
+      loop self.head {
+        Some(Valid(~key, ~value, ~next, ..)) => {
+          if yield((key, value)).not() {
+            break false
+          }
+          continue next
+        }
+        _ => break true
+      }
+    },
+  )
+}


### PR DESCRIPTION
This PR adds a linked hash map that maintains the order of insertion while iterating. 

TODO:
- [x] Modify comments and README