### PR TITLE
[break change] tweak Bytes API, migrate to Byte type

### DIFF
--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -69,7 +69,7 @@ fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
     enough_space = enough_space * 2
   }
   if enough_space != self.bytes.length() {
-    let new_bytes = Bytes::make(enough_space, 0)
+    let new_bytes = Bytes::make(enough_space, b'\x00')
     blit(new_bytes, 0, self.bytes, 0, self.len)
     self.bytes = new_bytes
   }
@@ -83,7 +83,7 @@ pub fn to_string(self : Buffer) -> String {
 /// Create a buffer with initial capacity.
 pub fn Buffer::make(initial_capacity : Int) -> Buffer {
   let initial = if initial_capacity < 1 { 1 } else { initial_capacity }
-  let bytes = Bytes::make(initial, 0)
+  let bytes = Bytes::make(initial, b'\x00')
   { bytes, len: 0, initial_bytes: bytes }
 }
 
@@ -116,13 +116,20 @@ pub fn write_char(self : Buffer, value : Char) -> Unit {
   self.len = self.len + inc
 }
 
+/// Write a byte into buffer.
+pub fn write_byte(self : Buffer, value : Byte) -> Unit {
+  self.grow_if_necessary(self.len + 1)
+  self.bytes[self.len] = value
+  self.len += 1
+}
+
 pub fn reset(self : Buffer) -> Unit {
   self.bytes = self.initial_bytes
   self.len = 0
 }
 
 pub fn to_bytes(self : Buffer) -> Bytes {
-  let bytes = Bytes::make(self.len, 0)
+  let bytes = Bytes::make(self.len, b'\x00')
   bytes.blit(0, self.bytes, 0, self.len)
   bytes
 }

--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -69,7 +69,7 @@ fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
     enough_space = enough_space * 2
   }
   if enough_space != self.bytes.length() {
-    let new_bytes = Bytes::make(enough_space, b'\x00')
+    let new_bytes = Bytes::make(enough_space)
     blit(new_bytes, 0, self.bytes, 0, self.len)
     self.bytes = new_bytes
   }
@@ -83,7 +83,7 @@ pub fn to_string(self : Buffer) -> String {
 /// Create a buffer with initial capacity.
 pub fn Buffer::make(initial_capacity : Int) -> Buffer {
   let initial = if initial_capacity < 1 { 1 } else { initial_capacity }
-  let bytes = Bytes::make(initial, b'\x00')
+  let bytes = Bytes::make(initial)
   { bytes, len: 0, initial_bytes: bytes }
 }
 
@@ -129,7 +129,7 @@ pub fn reset(self : Buffer) -> Unit {
 }
 
 pub fn to_bytes(self : Buffer) -> Bytes {
-  let bytes = Bytes::make(self.len, b'\x00')
+  let bytes = Bytes::make(self.len)
   bytes.blit(0, self.bytes, 0, self.len)
   bytes
 }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -213,7 +213,7 @@ impl Bytes {
   blit_from_string(Bytes, Int, String, Int, Int) -> Unit
   copy(Bytes) -> Bytes
   length(Bytes) -> Int
-  make(Int, Byte) -> Bytes
+  make(Int, ~init : Byte = ..) -> Bytes
   of_string(String) -> Bytes
   op_get(Bytes, Int) -> Byte
   op_set(Bytes, Int, Byte) -> Unit

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -41,6 +41,7 @@ impl Buffer {
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes
   to_string(Self) -> String
+  write_byte(Self, Byte) -> Unit
   write_char(Self, Char) -> Unit
   write_string(Self, String) -> Unit
   write_sub_string(Self, String, Int, Int) -> Unit
@@ -77,6 +78,7 @@ impl Byte {
   debug_write(Byte, Buffer) -> Unit
   op_equal(Byte, Byte) -> Bool
   to_int(Byte) -> Int
+  to_int64(Byte) -> Int64
   to_string(Byte) -> String
 }
 impl Char {
@@ -114,6 +116,7 @@ impl Int {
   op_neg(Int) -> Int
   op_sub(Int, Int) -> Int
   popcnt(Int) -> Int
+  to_byte(Int) -> Byte
   to_double(Int) -> Double
   to_int64(Int) -> Int64
   to_string(Int) -> String
@@ -145,6 +148,7 @@ impl Int64 {
   op_sub(Int64, Int64) -> Int64
   popcnt(Int64) -> Int
   reinterpret_as_double(Int64) -> Double
+  to_byte(Int64) -> Byte
   to_double(Int64) -> Double
   to_int(Int64) -> Int
   to_string(Int64) -> String
@@ -209,10 +213,10 @@ impl Bytes {
   blit_from_string(Bytes, Int, String, Int, Int) -> Unit
   copy(Bytes) -> Bytes
   length(Bytes) -> Int
-  make(Int, Int) -> Bytes
+  make(Int, Byte) -> Bytes
   of_string(String) -> Bytes
-  op_get(Bytes, Int) -> Int
-  op_set(Bytes, Int, Int) -> Unit
+  op_get(Bytes, Int) -> Byte
+  op_set(Bytes, Int, Byte) -> Unit
   set_utf16_char(Bytes, Int, Char) -> Int
   set_utf8_char(Bytes, Int, Char) -> Int
   sub_string(Bytes, Int, Int) -> String

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -64,7 +64,7 @@ pub fn to_string(self : Bytes) -> String {
 
 /// Create byte sequence from String.
 pub fn Bytes::of_string(str : String) -> Bytes {
-  let bytes = Bytes::make(str.length() * 2, 0)
+  let bytes = Bytes::make(str.length() * 2, b'\x00')
   bytes.blit_from_string(0, str, 0, str.length())
   bytes
 }
@@ -102,15 +102,15 @@ pub fn blit_from_string(
         i < end_str_offset
         i = i + 1, j = j + 2 {
       let c = str[i].to_int()
-      self[j] = c.land(0xff)
-      self[j + 1] = c.lsr(8)
+      self[j] = c.land(0xff).to_byte()
+      self[j + 1] = c.lsr(8).to_byte()
     }
   }
 }
 
 /// Return a new Bytes that contains the same byte sequence.
 pub fn copy(self : Bytes) -> Bytes {
-  let dst = Bytes::make(self.length(), 0)
+  let dst = Bytes::make(self.length(), b'\x00')
   blit(dst, 0, self, 0, self.length())
   dst
 }
@@ -120,22 +120,22 @@ pub fn copy(self : Bytes) -> Bytes {
 pub fn set_utf8_char(self : Bytes, offset : Int, value : Char) -> Int {
   let code = value.to_int()
   if code < 0x80 {
-    self[offset] = code.land(0x7F).lor(0x00)
+    self[offset] = code.land(0x7F).lor(0x00).to_byte()
     1
   } else if code < 0x0800 {
-    self[offset] = code.lsr(6).land(0x1F).lor(0xC0)
-    self[offset + 1] = code.land(0x3F).lor(0x80)
+    self[offset] = code.lsr(6).land(0x1F).lor(0xC0).to_byte()
+    self[offset + 1] = code.land(0x3F).lor(0x80).to_byte()
     2
   } else if code < 0x010000 {
-    self[offset] = code.lsr(12).land(0x0F).lor(0xE0)
-    self[offset + 1] = code.lsr(6).land(0x3F).lor(0x80)
-    self[offset + 2] = code.land(0x3F).lor(0x80)
+    self[offset] = code.lsr(12).land(0x0F).lor(0xE0).to_byte()
+    self[offset + 1] = code.lsr(6).land(0x3F).lor(0x80).to_byte()
+    self[offset + 2] = code.land(0x3F).lor(0x80).to_byte()
     3
   } else if code < 0x110000 {
-    self[offset] = code.lsr(18).land(0x07).lor(0xF0)
-    self[offset + 1] = code.lsr(12).land(0x3F).lor(0x80)
-    self[offset + 2] = code.lsr(6).land(0x3F).lor(0x80)
-    self[offset + 3] = code.land(0x3F).lor(0x80)
+    self[offset] = code.lsr(18).land(0x07).lor(0xF0).to_byte()
+    self[offset + 1] = code.lsr(12).land(0x3F).lor(0x80).to_byte()
+    self[offset + 2] = code.lsr(6).land(0x3F).lor(0x80).to_byte()
+    self[offset + 3] = code.land(0x3F).lor(0x80).to_byte()
     4
   } else {
     abort("Char out of range")
@@ -147,17 +147,17 @@ pub fn set_utf8_char(self : Bytes, offset : Int, value : Char) -> Int {
 pub fn set_utf16_char(self : Bytes, offset : Int, value : Char) -> Int {
   let code = value.to_int()
   if code < 0x10000 {
-    self[offset] = code.land(0xFF)
-    self[offset + 1] = code.lsr(8)
+    self[offset] = code.land(0xFF).to_byte()
+    self[offset + 1] = code.lsr(8).to_byte()
     2
   } else {
     let hi = code - 0x10000
     let lo = hi.lsr(10).lor(0xD800)
     let hi = hi.land(0x3FF).lor(0xDC00)
-    self[offset] = lo.land(0xFF)
-    self[offset + 1] = lo.lsr(8)
-    self[offset + 2] = hi.land(0xFF)
-    self[offset + 3] = hi.lsr(8)
+    self[offset] = lo.land(0xFF).to_byte()
+    self[offset + 1] = lo.lsr(8).to_byte()
+    self[offset + 2] = hi.land(0xFF).to_byte()
+    self[offset + 3] = hi.lsr(8).to_byte()
     4
   }
 }

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -64,7 +64,7 @@ pub fn to_string(self : Bytes) -> String {
 
 /// Create byte sequence from String.
 pub fn Bytes::of_string(str : String) -> Bytes {
-  let bytes = Bytes::make(str.length() * 2, b'\x00')
+  let bytes = Bytes::make(str.length() * 2)
   bytes.blit_from_string(0, str, 0, str.length())
   bytes
 }
@@ -110,7 +110,7 @@ pub fn blit_from_string(
 
 /// Return a new Bytes that contains the same byte sequence.
 pub fn copy(self : Bytes) -> Bytes {
-  let dst = Bytes::make(self.length(), b'\x00')
+  let dst = Bytes::make(self.length())
   blit(dst, 0, self, 0, self.length())
   dst
 }

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -200,7 +200,11 @@ pub fn Bytes::op_set(self : Bytes, idx : Int, val : Byte) -> Unit = "%bytes_set"
 
 pub fn Bytes::length(self : Bytes) -> Int = "%bytes_length"
 
-pub fn Bytes::make(len : Int, init : Byte) -> Bytes = "%bytes_make"
+fn byte_make(len : Int, init : Byte) -> Bytes = "%bytes_make"
+
+pub fn Bytes::make(len : Int, ~init : Byte = b'\x00') -> Bytes {
+  byte_make(len, init)
+}
 
 fn identity[A, B](x : A) -> B = "%identity"
 

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -194,13 +194,23 @@ pub fn Char::default() -> Char = "%char_default"
 
 // Bytes primitive ops
 
-pub fn Bytes::op_get(self : Bytes, idx : Int) -> Int = "%bytes_get"
+pub fn Bytes::op_get(self : Bytes, idx : Int) -> Byte = "%bytes_get"
 
-pub fn Bytes::op_set(self : Bytes, idx : Int, val : Int) -> Unit = "%bytes_set"
+pub fn Bytes::op_set(self : Bytes, idx : Int, val : Byte) -> Unit = "%bytes_set"
 
 pub fn Bytes::length(self : Bytes) -> Int = "%bytes_length"
 
-pub fn Bytes::make(len : Int, init : Int) -> Bytes = "%bytes_make"
+pub fn Bytes::make(len : Int, init : Byte) -> Bytes = "%bytes_make"
+
+fn identity[A,B](x : A) -> B = "%identity"
+
+pub fn Int::to_byte(self : Int) -> Byte {
+  identity(self.land(0xFF))
+}
+
+pub fn Int64::to_byte(self : Int64) -> Byte {
+  identity(self.to_int().land(0xFF))
+}
 
 // Array primitive ops
 
@@ -237,3 +247,8 @@ pub type UnsafeMaybeUninit[_]
 
 // Byte primitive
 pub fn Byte::to_int(self : Byte) -> Int = "%byte_to_int"
+
+pub fn Byte::to_int64(self : Byte) -> Int64 {
+  self.to_int().to_int64()
+}
+

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -202,7 +202,7 @@ pub fn Bytes::length(self : Bytes) -> Int = "%bytes_length"
 
 pub fn Bytes::make(len : Int, init : Byte) -> Bytes = "%bytes_make"
 
-fn identity[A,B](x : A) -> B = "%identity"
+fn identity[A, B](x : A) -> B = "%identity"
 
 pub fn Int::to_byte(self : Int) -> Byte {
   identity(self.land(0xFF))
@@ -251,4 +251,3 @@ pub fn Byte::to_int(self : Byte) -> Int = "%byte_to_int"
 pub fn Byte::to_int64(self : Byte) -> Int64 {
   self.to_int().to_int64()
 }
-

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -23,9 +23,9 @@
 /// ```
 /// 
 pub fn Bytes::from_array(arr : Array[Int]) -> Bytes {
-  let rv = Bytes::make(arr.length(), 0)
+  let rv = Bytes::make(arr.length(), b'\x00')
   for i = 0; i < arr.length(); i = i + 1 {
-    rv[i] = arr[i]
+    rv[i] = arr[i].to_byte()
   }
   rv
 }

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -23,7 +23,7 @@
 /// ```
 /// 
 pub fn Bytes::from_array(arr : Array[Int]) -> Bytes {
-  let rv = Bytes::make(arr.length(), b'\x00')
+  let rv = Bytes::make(arr.length())
   for i = 0; i < arr.length(); i = i + 1 {
     rv[i] = arr[i].to_byte()
   }

--- a/bytes/xxhash.mbt
+++ b/bytes/xxhash.mbt
@@ -54,9 +54,9 @@ fn avalanche(h : Int) -> Int {
 }
 
 fn endian32(input : Bytes, cur : Int) -> Int {
-  input[cur + 0].lor(
-    input[cur + 1].lsl(8).lor(
-      input[cur + 2].lsl(16).lor(input[cur + 3].lsl(24)),
+  input[cur + 0].to_int().lor(
+    input[cur + 1].to_int().lsl(8).lor(
+      input[cur + 2].to_int().lsl(16).lor(input[cur + 3].to_int().lsl(24)),
     ),
   )
 }
@@ -75,7 +75,7 @@ fn finalize(h : Int, input : Bytes, cur : Int, remain : Int) -> Int {
     )
   } else if remain > 0 {
     finalize(
-      rotl(h + input[cur] * gPRIME5, 11) * gPRIME1,
+      rotl(h + input[cur].to_int() * gPRIME5, 11) * gPRIME1,
       input,
       cur + 1,
       remain - 1,

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -14,7 +14,7 @@
 
 /// Convert Char to String
 pub fn to_string(self : Char) -> String {
-  let bytes = Bytes::make(4, b'\x00')
+  let bytes = Bytes::make(4)
   let len = bytes.set_utf16_char(0, self)
   bytes.sub_string(0, len)
 }

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -14,7 +14,7 @@
 
 /// Convert Char to String
 pub fn to_string(self : Char) -> String {
-  let bytes = Bytes::make(4, 0)
+  let bytes = Bytes::make(4, b'\x00')
   let len = bytes.set_utf16_char(0, self)
   bytes.sub_string(0, len)
 }

--- a/double/ryu.mbt
+++ b/double/ryu.mbt
@@ -29,7 +29,7 @@ fn log10Pow2(e : Int) -> Int {
 fn string_from_bytes(bytes : Bytes, from : Int, to : Int) -> String {
   let buf = Buffer::make(bytes.length())
   for i = from; i < to; i = i + 1 {
-    buf.write_char(Char::from_int(bytes[i]))
+    buf.write_char(Char::from_int(bytes[i].to_int()))
   }
   buf.to_string()
 }
@@ -495,10 +495,10 @@ fn d2d(ieeeMantissa : Int64, ieeeExponent : Int) -> FloatingDecimal64 {
 
 fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
   // Step 5: Print the decimal representation.
-  let result = Bytes::make(24, 0)
+  let result = Bytes::make(24, (0).to_byte())
   let mut index : Int = 0
   if sign {
-    result[index] = '-'.to_int()
+    result[index] = '-'.to_int().to_byte()
     index = index + 1
   }
   let mut output : Int64 = v.mantissa
@@ -510,23 +510,23 @@ fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
     for i = 0; i < olength - 1; i = i + 1 {
       let c = output % 10L
       output = output / 10L
-      result[index + olength - i] = '0'.to_int() + c.to_int()
+      result[index + olength - i] = ('0'.to_int() + c.to_int()).to_byte()
     }
-    result[index] = '0'.to_int() + output.to_int() % 10
+    result[index] = ('0'.to_int() + output.to_int() % 10).to_byte()
 
     // Always print point
-    result[index + 1] = '.'.to_int()
+    result[index + 1] = '.'.to_int().to_byte()
     index = index + olength + 1
     if olength == 1 {
-      result[index] = '0'.to_int()
+      result[index] = '0'.to_int().to_byte()
       index = index + 1
     }
 
     // Print the exponent.
-    result[index] = 'e'.to_int()
+    result[index] = 'e'.to_int().to_byte()
     index = index + 1
     if exp < 0 {
-      result[index] = '-'.to_int()
+      result[index] = '-'.to_int().to_byte()
       index = index + 1
       exp = -exp
     }
@@ -534,62 +534,62 @@ fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
       let a = exp / 100
       let b = exp / 10 % 10
       let c = exp % 10
-      result[index + 0] = '0'.to_int() + a
-      result[index + 1] = '0'.to_int() + b
-      result[index + 2] = '0'.to_int() + c
+      result[index + 0] = ('0'.to_int() + a).to_byte()
+      result[index + 1] = ('0'.to_int() + b).to_byte()
+      result[index + 2] = ('0'.to_int() + c).to_byte()
       index = index + 3
     } else if exp >= 10 {
       let a = exp / 10
       let b = exp % 10
-      result[index + 0] = '0'.to_int() + a
-      result[index + 1] = '0'.to_int() + b
+      result[index + 0] = ('0'.to_int() + a).to_byte()
+      result[index + 1] = ('0'.to_int() + b).to_byte()
       index = index + 2
     } else {
-      result[index] = '0'.to_int() + exp
+      result[index] = ('0'.to_int() + exp).to_byte()
       index = index + 1
     }
     string_from_bytes(result, 0, index)
   } else {
     if exp < 0 {
       // Decimal dot is before any of the digits.
-      result[index] = '0'.to_int()
+      result[index] = '0'.to_int().to_byte()
       index = index + 1
-      result[index] = '.'.to_int()
+      result[index] = '.'.to_int().to_byte()
       index = index + 1
       for i = -1; i > exp; i = i - 1 {
-        result[index] = '0'.to_int()
+        result[index] = '0'.to_int().to_byte()
         index = index + 1
       }
       let current = index
       for i = 0; i < olength; i = i + 1 {
-        result[current + olength - i - 1] = '0'.to_int() + (output % 10L).to_int()
+        result[current + olength - i - 1] = ('0'.to_int() + (output % 10L).to_int()).to_byte()
         output = output / 10L
         index = index + 1
       }
     } else if exp + 1 >= olength {
       // Decimal dot is after any of the digits.
       for i = 0; i < olength; i = i + 1 {
-        result[index + olength - i - 1] = '0'.to_int() + (output % 10L).to_int()
+        result[index + olength - i - 1] = ('0'.to_int() + (output % 10L).to_int()).to_byte()
         output = output / 10L
       }
       index = index + olength
       for i = olength; i < exp + 1; i = i + 1 {
-        result[index] = '0'.to_int()
+        result[index] = '0'.to_int().to_byte()
         index = index + 1
       }
-      result[index] = '.'.to_int()
+      result[index] = '.'.to_int().to_byte()
       index = index + 1
-      result[index] = '0'.to_int()
+      result[index] = '0'.to_int().to_byte()
       index = index + 1
     } else {
       // Decimal dot is somewhere between the digits.
       let mut current = index + 1
       for i = 0; i < olength; i = i + 1 {
         if olength - i - 1 == exp {
-          result[current + olength - i - 1] = '.'.to_int()
+          result[current + olength - i - 1] = '.'.to_int().to_byte()
           current = current - 1
         }
-        result[current + olength - i - 1] = '0'.to_int() + (output % 10L).to_int()
+        result[current + olength - i - 1] = ('0'.to_int() + (output % 10L).to_int()).to_byte()
         output = output / 10L
       }
       index = index + olength + 1

--- a/double/ryu.mbt
+++ b/double/ryu.mbt
@@ -495,7 +495,7 @@ fn d2d(ieeeMantissa : Int64, ieeeExponent : Int) -> FloatingDecimal64 {
 
 fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
   // Step 5: Print the decimal representation.
-  let result = Bytes::make(24, (0).to_byte())
+  let result = Bytes::make(24)
   let mut index : Int = 0
   if sign {
     result[index] = '-'.to_int().to_byte()

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -39,7 +39,7 @@ let powtab = [
 /// Create a zero decimal.
 pub fn Decimal::new() -> Decimal {
   {
-    digits: Bytes::make(800, 0),
+    digits: Bytes::make(800, b'\x00'),
     digits_num: 0,
     decimal_point: 0,
     negative: false,
@@ -87,7 +87,7 @@ pub fn Decimal::parse_decimal(str : String) -> Result[Decimal, String] {
           continue
         }
         if d.digits_num < d.digits.length() {
-          d.digits[d.digits_num] = str[i].to_int() - '0'.to_int()
+          d.digits[d.digits_num] = (str[i].to_int() - '0'.to_int()).to_byte()
           d.digits_num += 1
         } else if str[i] != '0' {
           d.truncated = true
@@ -170,7 +170,7 @@ pub fn to_double(self : Decimal) -> Result[Double, String] {
     exponent += n
   }
   // left shift
-  while self.decimal_point < 0 || self.decimal_point == 0 && self.digits[0] < 5 {
+  while self.decimal_point < 0 || self.decimal_point == 0 && self.digits[0].to_int() < 5 {
     let mut n = 0
     if -self.decimal_point >= powtab.length() {
       n = 60
@@ -289,29 +289,29 @@ fn should_round_up(self : Decimal, d : Int) -> Bool {
   if d < 0 || d >= self.digits_num {
     return false
   }
-  if self.digits[d] == 5 && d + 1 == self.digits_num {
+  if self.digits[d].to_int() == 5 && d + 1 == self.digits_num {
     // half-way between two integers
     // if truncated, the real value is higher than stored value, round up.
     if self.truncated {
       return true
     }
     // round to even
-    return d > 0 && self.digits[d - 1] % 2 != 0
+    return d > 0 && self.digits[d - 1].to_int() % 2 != 0
   }
   // normal case
-  self.digits[d] >= 5
+  self.digits[d].to_int() >= 5
 }
 
 /// Assign a Int64 value to decimal.
 fn assign(self : Decimal, v : Int64) -> Unit {
-  let buf = Bytes::make(24, 0)
+  let buf = Bytes::make(24, b'\x00')
 
   // write value to buf
   let mut n = 0
   let mut v = v
   while v > 0L {
     let v1 = v / 10L
-    buf[n] = (v - 10L * v1).to_int()
+    buf[n] = (v - 10L * v1).to_byte()
     n += 1
     v = v1
   }
@@ -352,7 +352,7 @@ fn right_shift(self : Decimal, s : Int) -> Unit {
   while read_index < self.digits_num {
     // output (acc >> s)
     let out = acc.lsr(s).to_int()
-    self.digits[write_index] = out
+    self.digits[write_index] = out.to_byte()
     write_index += 1
     // contract
     acc = acc.land(mask)
@@ -366,7 +366,7 @@ fn right_shift(self : Decimal, s : Int) -> Unit {
   while acc > 0L {
     let out = acc.lsr(s).to_int()
     if write_index < self.digits.length() {
-      self.digits[write_index] = out
+      self.digits[write_index] = out.to_byte()
       write_index += 1
     } else if out > 0 {
       self.truncated = true
@@ -459,8 +459,8 @@ fn new_digits(self : Decimal, s : Int) -> Int {
       break
     }
     let d = cheat_num[i].to_int() - '0'.to_int()
-    if self.digits[i] != d {
-      less = self.digits[i] < d
+    if self.digits[i].to_int() != d {
+      less = self.digits[i].to_int() < d
       break
     }
   }
@@ -488,7 +488,7 @@ fn left_shift(self : Decimal, s : Int) -> Unit {
     let rem = (acc - quo * 10L).to_int()
     write_index -= 1
     if write_index < self.digits.length() {
-      self.digits[write_index] = rem
+      self.digits[write_index] = rem.to_byte()
     } else if rem != 0 {
       self.truncated = true
     }
@@ -502,7 +502,7 @@ fn left_shift(self : Decimal, s : Int) -> Unit {
     let rem = (acc - 10L * quo).to_int()
     write_index -= 1
     if write_index < self.digits.length() {
-      self.digits[write_index] = rem
+      self.digits[write_index] = rem.to_byte()
     } else if rem != 0 {
       self.truncated = true
     }
@@ -520,7 +520,7 @@ fn left_shift(self : Decimal, s : Int) -> Unit {
 
 /// Trim trailing zeros.
 fn trim(self : Decimal) -> Unit {
-  while self.digits_num > 0 && self.digits[self.digits_num - 1] == 0 {
+  while self.digits_num > 0 && self.digits[self.digits_num - 1].to_int() == 0 {
     self.digits_num -= 1
   }
   if self.digits_num == 0 {
@@ -547,7 +547,7 @@ fn to_string(self : Decimal) -> String {
       buf.write_char('0')
     }
     for i = 0; i < self.digits_num; i = i + 1 {
-      buf.write_string(self.digits[i].to_string())
+      buf.write_string(self.digits[i].to_int().to_string())
     }
   } else if self.decimal_point < self.digits_num {
     // decimal point in the middle of digits
@@ -555,12 +555,12 @@ fn to_string(self : Decimal) -> String {
       if i == self.decimal_point {
         buf.write_char('.')
       }
-      buf.write_string(self.digits[i].to_string())
+      buf.write_string(self.digits[i].to_int().to_string())
     }
   } else {
     // zeros filling between the digits and the decimal point
     for i = 0; i < self.digits_num; i = i + 1 {
-      buf.write_string(self.digits[i].to_string())
+      buf.write_string(self.digits[i].to_int().to_string())
     }
     for i = 0; i < self.decimal_point - self.digits_num; i = i + 1 {
       buf.write_char('0')

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -39,7 +39,7 @@ let powtab = [
 /// Create a zero decimal.
 pub fn Decimal::new() -> Decimal {
   {
-    digits: Bytes::make(800, b'\x00'),
+    digits: Bytes::make(800),
     digits_num: 0,
     decimal_point: 0,
     negative: false,
@@ -305,7 +305,7 @@ fn should_round_up(self : Decimal, d : Int) -> Bool {
 
 /// Assign a Int64 value to decimal.
 fn assign(self : Decimal, v : Int64) -> Unit {
-  let buf = Bytes::make(24, b'\x00')
+  let buf = Bytes::make(24)
 
   // write value to buf
   let mut n = 0

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -170,7 +170,8 @@ pub fn to_double(self : Decimal) -> Result[Double, String] {
     exponent += n
   }
   // left shift
-  while self.decimal_point < 0 || self.decimal_point == 0 && self.digits[0].to_int() < 5 {
+  while self.decimal_point < 0 || self.decimal_point == 0 && self.digits[0].to_int() <
+        5 {
     let mut n = 0
     if -self.decimal_point >= powtab.length() {
       n = 60

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -48,7 +48,7 @@ pub fn String::default() -> String {
 
 pub fn to_bytes(self : String) -> Bytes {
   let len = self.length()
-  let bytes = Bytes::make(len * 2, 0)
+  let bytes = Bytes::make(len * 2, b'\x00')
   bytes.blit_from_string(0, self, 0, len)
   bytes
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -48,7 +48,7 @@ pub fn String::default() -> String {
 
 pub fn to_bytes(self : String) -> Bytes {
   let len = self.length()
-  let bytes = Bytes::make(len * 2, b'\x00')
+  let bytes = Bytes::make(len * 2)
   bytes.blit_from_string(0, self, 0, len)
   bytes
 }


### PR DESCRIPTION
MoonBit has introduced a `Byte` type, which represents an 8-bit unsigned integer. Currently we lacks the necessary primitives to convert between `Byte` and other basic types,  which limits its usability.

---

In this PR:

- add some intrinsics and arithmetic operations for byte: 
    - `Int::to_byte` `Int64::to_byte` `Byte::to_int64` 
- refine Bytes APIs (`Bytes::make` `Bytes::op_set` `Bytes::op_get`) to use `Byte` type, update codebase to adapt this changes
- add new method `Buffer::write_byte` for `moonbitlang/x/encoding`
---

NOTE: This PR requires collaboration with the compiler as it involves intrinsics. For the sake of easy testing and review, the implementations of `Int::to_byte` and `Int64::to_byte` in `intrinsics.mbt` temporarily use `%identity`. **These implementations will be replaced by intrinsics provided by the compiler later.**