### PR TITLE
add [op_get] for map and immutable hash map

### DIFF
--- a/immutable_hashmap/HAMT.mbt
+++ b/immutable_hashmap/HAMT.mbt
@@ -63,6 +63,10 @@ pub fn find[K : Eq + Hash, V](self : Map[K, V], key : K) -> Option[V] {
   }
 }
 
+pub fn op_get[K : Eq + Hash, V](self : Map[K, V], key : K) -> Option[V] {
+  self.find(key)
+}
+
 fn add_with_hash[K : Eq, V](
   self : Map[K, V],
   key : K,

--- a/immutable_hashmap/immutable_hashmap.mbti
+++ b/immutable_hashmap/immutable_hashmap.mbti
@@ -14,6 +14,7 @@ impl Map {
   from_array[K : Eq + Hash, V](Array[Tuple[K, V]]) -> Self[K, V]
   iter[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   make[K, V]() -> Self[K, V]
+  op_get[K : Eq + Hash, V](Self[K, V], K) -> Option[V]
   remove[K : Eq + Hash, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
   to_string[K : Debug, V : Debug](Self[K, V]) -> String

--- a/map/map.mbti
+++ b/map/map.mbti
@@ -26,6 +26,7 @@ impl Map {
   map_with_key[K, X, Y](Self[K, X], (K, X) -> Y) -> Self[K, Y]
   member[K : Compare + Eq, V](Self[K, V], K) -> Bool
   op_equal[K : Eq, V : Eq](Self[K, V], Self[K, V]) -> Bool
+  op_get[K : Compare + Eq, V](Self[K, V], K) -> Option[V]
   remove[K : Compare + Eq, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
   to_vec[K, V](Self[K, V]) -> @vec.Vec[Tuple[K, V]]

--- a/map/utils.mbt
+++ b/map/utils.mbt
@@ -75,6 +75,10 @@ pub fn lookup[K : Compare, V](self : Map[K, V], key : K) -> Option[V] {
   }
 }
 
+pub fn op_get[K : Compare, V](self : Map[K, V], key : K) -> Option[V] {
+  self.lookup(key)
+}
+
 /// Iterate over the key-value pairs in the map.
 pub fn iter[K, V](self : Map[K, V], f : (K, V) -> Unit) -> Unit {
   match self {


### PR DESCRIPTION
add `op_get` for the lookup/find operations of maps, so that they can utilize the to-be-landed map pattern syntax.