### PR TITLE
Refactor int hash and hash in container

### DIFF
--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -40,7 +40,7 @@ pub fn set[K : Hash + Eq, V](self : HashMap[K, V], key : K, value : V) -> Unit {
   if self.capacity == 0 || self.size >= self.growAt {
     self.grow()
   }
-  let hash = make_hash(key)
+  let hash = key.hash()
   for i = 0, idx = self.index(hash), entry = { psl: 0, hash, key, value } {
     if i == self.capacity {
       panic()
@@ -79,7 +79,7 @@ pub fn op_set[K : Hash + Eq, V](
 
 /// Get the value associated with a key.
 pub fn get[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Option[V] {
-  let hash = make_hash(key)
+  let hash = key.hash()
   for i = 0, idx = self.index(hash) {
     if i == self.capacity {
       break None
@@ -127,7 +127,7 @@ pub fn contains[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Bool {
 
 /// Remove a key-value pair from hash map.
 pub fn remove[K : Hash + Eq, V](self : HashMap[K, V], key : K) -> Unit {
-  let hash = make_hash(key)
+  let hash = key.hash()
   for i = 0, idx = self.index(hash)
       i < self.capacity
       i = i + 1, idx = self.next_index(idx) {
@@ -185,12 +185,6 @@ fn grow[K : Hash + Eq, V](self : HashMap[K, V]) -> Unit {
       None => ()
     }
   }
-}
-
-fn make_hash[K : Hash](key : K) -> Int {
-  let hash : Int = key.hash()
-  // Let higher 16 bits of the hash value participate in the calculation
-  hash.lxor(hash.lsr(16))
 }
 
 fn index[K : Hash, V](self : HashMap[K, V], hash : Int) -> Int {

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -38,7 +38,7 @@ pub fn insert[K : Hash + Eq](self : HashSet[K], key : K) -> Unit {
   if self.capacity == 0 || self.size >= self.growAt {
     self.grow()
   }
-  let hash = make_hash(key)
+  let hash = key.hash()
   let entry = { psl: 0, hash, key }
   loop 0, self.index(hash), entry {
     i, idx, entry => {
@@ -71,7 +71,7 @@ pub fn insert[K : Hash + Eq](self : HashSet[K], key : K) -> Unit {
 
 /// Check if the hash set contains a key.
 pub fn contains[K : Hash + Eq](self : HashSet[K], key : K) -> Bool {
-  let hash = make_hash(key)
+  let hash = key.hash()
   for i = 0, idx = self.index(hash)
       i < self.capacity
       i = i + 1, idx = self.next_index(idx) {
@@ -92,7 +92,7 @@ pub fn contains[K : Hash + Eq](self : HashSet[K], key : K) -> Bool {
 
 /// Remove a key from hash set.
 pub fn remove[K : Hash + Eq](self : HashSet[K], key : K) -> Unit {
-  let hash = make_hash(key)
+  let hash = key.hash()
   for i = 0, idx = self.index(hash)
       i < self.capacity
       i = i + 1, idx = self.next_index(idx) {
@@ -251,12 +251,6 @@ fn grow[K : Hash + Eq](self : HashSet[K]) -> Unit {
       None => ()
     }
   }
-}
-
-fn make_hash[K : Hash](key : K) -> Int {
-  let hash = key.hash()
-  // Let higher 16 bits of the hash value participate in the calculation
-  hash.lxor(hash.lsr(16))
 }
 
 fn index[K : Hash](self : HashSet[K], hash : Int) -> Int {

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -48,6 +48,15 @@ pub fn Int::min_value() -> Int {
   min_val
 }
 
+// https://github.com/skeeto/hash-prospector
 pub fn hash(self : Int) -> Int {
-  self
+  let mut x = self.lxor(self.lsr(16))
+  x = x.lxor(x.lsr(17))
+  x = x * 0xed5ad4bb
+  x = x.lxor(x.lsr(11))
+  x = x * 0xac4c1b51
+  x = x.lxor(x.lsr(15))
+  x = x * 0x31848bab
+  x = x.lxor(x.lsr(14))
+  x
 }

--- a/linked_hashmap/impl.mbt
+++ b/linked_hashmap/impl.mbt
@@ -46,7 +46,7 @@ pub fn set[K : Hash + Eq, V](
   if self.capacity == 0 || self.size >= self.growAt {
     self.grow()
   }
-  let hash = make_hash(key)
+  let hash = key.hash()
   let insert_entry = { psl: 0, hash, key, value, prev: None, next: None }
   loop 0, self.index(hash), insert_entry {
     i, idx, entry => {
@@ -89,7 +89,7 @@ pub fn op_set[K : Hash + Eq, V](
 
 /// Get the value associated with a key.
 pub fn get[K : Hash + Eq, V](self : LinkedHashMap[K, V], key : K) -> Option[V] {
-  let hash = make_hash(key)
+  let hash = key.hash()
   for i = 0, idx = self.index(hash)
       i < self.capacity
       i = i + 1, idx = self.next_index(idx) {
@@ -139,7 +139,7 @@ pub fn contains[K : Hash + Eq, V](self : LinkedHashMap[K, V], key : K) -> Bool {
 
 /// Remove a key-value pair from hash map.
 pub fn remove[K : Hash + Eq, V](self : LinkedHashMap[K, V], key : K) -> Unit {
-  let hash = make_hash(key)
+  let hash = key.hash()
   for i = 0, idx = self.index(hash)
       i < self.capacity
       i = i + 1, idx = self.next_index(idx) {
@@ -250,12 +250,6 @@ fn grow[K : Hash + Eq, V](self : LinkedHashMap[K, V]) -> Unit {
     }
     None => break
   }
-}
-
-fn make_hash[K : Hash](key : K) -> Int {
-  let hash = key.hash()
-  // Let higher 16 bits of the hash value participate in the calculation
-  hash.lxor(hash.lsr(16))
 }
 
 fn index[K : Hash, V](self : LinkedHashMap[K, V], hash : Int) -> Int {


### PR DESCRIPTION
Changed the int hash function to a three round hash functions for 32 bit int, so we don't need additional hash function in hash container.
Hash function credit: https://github.com/skeeto/hash-prospector