### PR TITLE
add list package back to immut/list

### DIFF
--- a/immut/list/README.md
+++ b/immut/list/README.md
@@ -1,0 +1,134 @@
+# moonbitlang/immut/list
+
+## Overview
+
+List is implemented as a **linked list**, supporting O(1) head access.
+- Moonbit list is **homogeneous** list, which means all elements in the list must be of the same type.
+- Moonbit list does not support random access well, you can only access elements by iterating through the list. If you need randomly access the nth element, you should use `Array` instead.
+
+## Usage
+
+### Building lists 
+You can create a list manually via the `new()` or construct it using the `from_array()`.
+```moonbit
+let list0 : List[Int] = List::new()
+let list1 = List::[1, 2, 3, 4, 5]
+let list2 = List::from_array([1, 2, 3, 4, 5])
+```
+
+Or use `Cons` constructor directly (Adds a single element to the beginning of a list):
+```moonbit
+let list = Cons(1, Cons(2, Cons(3, Nil)))
+```
+
+Build a repeated list by using the `repeat()` method:
+```moonbit
+let list = repeat(3, 1) // List::[1, 1, 1]
+```
+
+### Pattern matching
+You can use pattern matching to destructure a list:
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+match list {
+    Cons(head, tail) => print(head)
+    Nil => print("Empty list")
+}
+```
+
+### Iterating over a list
+The standard library provides a lot of tools for iterating over a list, such as `iter()`, `iteri()`, etc. (For details check the API documentation)
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+let list1 = list.iter(fn (ele) { print(ele) }) 
+```
+
+### Appending / Joining lists
+To simply concatenate two lists, you can use the `concat()` method (or `+` operator):
+```moonbit
+let list1 = List::[1, 2, 3]
+let list2 = List::[4, 5, 6]
+let list3 = list1.concat(list2) // List::[1, 2, 3, 4, 5, 6]
+let list4 = list1 + list2 // List::[1, 2, 3, 4, 5, 6]
+```
+
+For concatenating multiple lists (especially the length is unknown), you can use the `flatten()` method:
+```moonbit
+let list1 = List::[1, 2, 3]
+let list2 = List::[4, 5, 6]
+let list3 = List::[7, 8, 9]
+let list4 = List::flatten([list1, list2, list3]) // List::[1, 2, 3, 4, 5, 6, 7, 8, 9]
+```
+
+To concatenate a list with a delimiter, `intercalate()` is useful:
+```moonbit
+let list = List::[List::[1, 2, 3], List::[4, 5, 6], List::[7, 8, 9]]
+let list1 = list.intercalate(List::[0]) // List::[1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]
+```
+
+### Filtering / Rejecting / Selecting elements
+There are three ways to filter / reject / select multiple elements from a list:
+- Go through the entire list and decide whether the element should be present in the resultant list or not. Use `filter` for this.
+- To extract the first (or last) N elements of a list (and N is independent of the contents of the list). Use `take` or `drop` in this case.
+- To stop selecting elements (terminate the iteration) as soon as a condition is met, using `take_while` or `drop_while`
+
+```moonbit
+let ls = List::[1, 2, 3, 4, 5]
+ls.filter(fn (ele) { ele % 2 == 0 }) // List::[2, 4]
+ls.take(2) // List::[1, 2]
+ls.drop(2) // List::[3, 4, 5]
+ls.take_while(fn (ele) { ele < 3 }) // List::[1, 2]
+ls.drop_while(fn (ele) { ele < 3 }) // List::[3, 4, 5]
+```
+
+### Accessing elements / sub-lists
+You can access the head of the list using the `head()` (O(1)) method. It returns `Some(head)` or `None` if the list is empty.
+And access the last element using the `last()` method (O(n)). The unsafe version of `head()` is `head_exn()`, which panics if the list is empty.
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+list.head() // Some(1)
+list.head_exn() // 1
+list.last() // 5
+```
+
+For randomly accessing, you can use the `nth_exn()` method, which returns the nth element in the list (O(n)). 
+This method will panic if the index is out of bounds. For a safe alternative, use `nth()` method.
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+list.nth_exn(2) // 3
+list.nth(2) // Some(3)
+```
+
+To get a sub-list from the list, you can use the `init_()` method for getting all elements except the last one, and `tail()` for getting all elements except the first one.
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+list.init_() // List::[1, 2, 3, 4]
+list.tail() // List::[2, 3, 4, 5]
+```
+
+### Reducing Lists
+You can reduce (fold) a list to a single value using the `fold()` method.
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+list.fold(0, fn(acc, x) { acc + x }) // 15
+```
+
+#### Special folds
+- `any` returns true if any element in the list satisfies the predicate.
+- `all` returns true if all elements in the list satisfy the predicate.
+- `sum` returns the sum of all elements in the list.
+- `maximum` returns the maximum element in the list.
+- `minimum` returns the minimum element in the list.
+
+### List transformations
+To transform list elements, you can use the `map()` method.
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+list.map(fn (ele) { ele * 2 }) // List::[2, 4, 6, 8, 10]
+```
+
+The `reverse` method reverses the list.
+```moonbit
+let list = List::[1, 2, 3, 4, 5]
+list.reverse() // List::[5, 4, 3, 2, 1]
+```

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -1,0 +1,826 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub enum List[T] {
+  Nil
+  Cons(T, List[T])
+} derive(Eq)
+
+pub fn List::to_string[T : Show](xs : List[T]) -> String {
+  let elems = match xs {
+    Nil => ""
+    Cons(x, xs) =>
+      xs.fold_left(
+        fn(acc, x) { acc + ", " + x.to_string() },
+        init=x.to_string(),
+      )
+  }
+  "List::[" + elems + "]"
+}
+
+pub fn List::debug_write[T : Debug](xs : List[T], buf : Buffer) -> Unit {
+  xs.iteri(
+    fn(i, x) {
+      x.debug_write(buf)
+      if i != xs.length() - 1 {
+        buf.write_string(", ")
+      }
+    },
+  )
+}
+
+/// Convert array to list.
+/// 
+/// # Example
+///
+/// ```
+/// let ls = List::[1, 2, 3, 4, 5]
+/// println(ls) // output: List::[1, 2, 3, 4, 5]
+/// ```
+pub fn List::from_array[T](arr : Array[T]) -> List[T] {
+  for i = arr.length() - 1, list = List::Nil; i >= 0; {
+    continue i - 1, List::Cons(arr[i], list)
+  } else {
+    list
+  }
+}
+
+/// Get the length of the list.
+pub fn length[T](self : List[T]) -> Int {
+  loop self, 0 {
+    Nil, len => len
+    Cons(_, rest), acc => continue rest, acc + 1
+  }
+}
+
+/// Iterates over the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// List::[1, 2, 3, 4, 5].iter(print) // output: 12345
+/// ```
+pub fn iter[T](self : List[T], f : (T) -> Unit) -> Unit {
+  loop self {
+    Nil => ()
+    Cons(head, tail) => {
+      f(head)
+      continue tail
+    }
+  }
+}
+
+/// Iterates over the list with index.
+/// 
+/// # Example
+/// 
+/// ```
+/// List::[1, 2, 3, 4, 5].iteri(fn(i, x) { print("(\(i),\(x)) ") }) 
+/// // output: (0,1) (1,2) (2,3) (3,4) (4,5)
+/// ```
+pub fn iteri[T](self : List[T], f : (Int, T) -> Unit) -> Unit {
+  loop self, 0 {
+    Nil, _ => ()
+    Cons(x, xs), i => {
+      f(i, x)
+      continue xs, i + 1
+    }
+  }
+}
+
+/// Maps the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].map(fn(x){ x * 2}))
+/// // output: List::[2, 4, 6, 8, 10]
+/// ```
+pub fn map[T, U](self : List[T], f : (T) -> U) -> List[U] {
+  match self {
+    Nil => Nil
+    Cons(head, tail) => Cons(f(head), map(tail, f))
+  }
+}
+
+/// Maps the list with index.
+pub fn mapi[T, U](self : List[T], f : (Int, T) -> U) -> List[U] {
+  fn go(xs : List[T], i : Int, f : (Int, T) -> U) -> List[U] {
+    match xs {
+      Nil => Nil
+      Cons(x, xs) => Cons(f(i, x), go(xs, i + 1, f))
+    }
+  }
+
+  go(self, 0, f)
+}
+
+/// Convert list to array.
+pub fn to_array[T](self : List[T]) -> Array[T] {
+  match self {
+    Nil => []
+    Cons(head, _) => {
+      let arr = Array::make(self.length(), head)
+      self.iteri(fn(i, x) { arr[i] = x })
+      arr
+    }
+  }
+}
+
+/// Filter the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].filter(fn(x){ x % 2 == 0}))
+/// // output: from_array([2, 4])
+/// ```
+pub fn filter[T](self : List[T], f : (T) -> Bool) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(head, tail) =>
+      if f(head) {
+        Cons(head, filter(tail, f))
+      } else {
+        filter(tail, f)
+      }
+  }
+}
+
+/// Test if all elements of the list satisfy the predicate.
+pub fn all[T](self : List[T], f : (T) -> Bool) -> Bool {
+  match self {
+    Nil => true
+    Cons(head, tail) => f(head) && all(tail, f)
+  }
+}
+
+/// Test if any element of the list satisfies the predicate.
+pub fn any[T](self : List[T], f : (T) -> Bool) -> Bool {
+  match self {
+    Nil => false
+    Cons(head, tail) => f(head) || any(tail, f)
+  }
+}
+
+/// Tail of the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].tail())
+/// // output: from_array([2, 3, 4, 5])
+/// ```
+pub fn tail[T](self : List[T]) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(_, tail) => tail
+  }
+}
+
+/// Get first element of the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].head_exn())
+/// // output: 1
+/// ```
+/// @alert unsafe "Panic if the list is empty"
+pub fn head_exn[T](self : List[T]) -> T {
+  match self {
+    Nil => abort("head of empty list")
+    Cons(head, _) => head
+  }
+}
+
+/// Get first element of the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].head())
+/// // output: Some(1)
+/// debug(from_array([]).head())
+/// // output: None
+/// ```
+pub fn head[T](self : List[T]) -> T? {
+  match self {
+    Nil => None
+    Cons(head, _) => Some(head)
+  }
+}
+
+/// Last element of the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].last())
+/// // output: 5
+/// ```
+/// @alert unsafe "Panic if the list is empty"
+pub fn last[T](self : List[T]) -> T {
+  loop self {
+    Nil => abort("last of empty list")
+    Cons(head, Nil) => head
+    Cons(_, tail) => continue tail
+  }
+}
+
+/// Init of the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].init_())
+/// // output: from_array([1, 2, 3, 4])
+/// ```
+pub fn init_[T](self : List[T]) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(_, Nil) => Nil
+    Cons(head, tail) => Cons(head, init_(tail))
+  }
+}
+
+/// Concatenate two lists.
+///
+/// # Example
+///  
+/// ```
+/// let ls = List::[1, 2, 3, 4, 5].concat(from_array([6, 7, 8, 9, 10]))
+/// debug(ls) // output: from_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+/// ```
+pub fn concat[T](self : List[T], other : List[T]) -> List[T] {
+  match self {
+    Nil => other
+    Cons(head, tail) => Cons(head, concat(tail, other))
+  }
+}
+
+/// Reverse the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// debug(List::[1, 2, 3, 4, 5].reverse())
+/// // output: from_array([5, 4, 3, 2, 1])
+/// ```
+pub fn reverse[T](self : List[T]) -> List[T] {
+  loop self, (Nil : List[T]) {
+    xs, ys =>
+      match (xs, ys) {
+        (Nil, acc) => acc
+        (Cons(x, xs), acc) => continue xs, Cons(x, acc)
+      }
+  }
+}
+
+/// Fold the list from left.
+///
+/// # Example
+/// 
+/// ```
+/// let r = List::[1, 2, 3, 4, 5].fold_left(~init=0, fn(acc, x) { acc + x })
+/// debug(r) // output: 15
+/// ```
+pub fn fold_left[T, U](self : List[T], f : (U, T) -> U, ~init : U) -> U {
+  match self {
+    Nil => init
+    Cons(head, tail) => tail.fold_left(f, init=f(init, head))
+  }
+}
+
+/// Fold the list from right.
+/// 
+/// # Example
+/// ```
+/// let r = List::[1, 2, 3, 4, 5].fold_right(fn(x, acc) { x + acc }, ~init=0)
+/// ```
+pub fn fold_right[T, U](self : List[T], f : (T, U) -> U, ~init : U) -> U {
+  match self {
+    Nil => init
+    Cons(head, tail) => f(head, tail.fold_right(f, ~init))
+  }
+}
+
+/// Fold the list from left with index.
+pub fn fold_lefti[T, U](self : List[T], f : (Int, U, T) -> U, ~init : U) -> U {
+  fn go(xs : List[T], i : Int, f : (Int, U, T) -> U, acc : U) -> U {
+    match xs {
+      Nil => acc
+      Cons(x, xs) => go(xs, i + 1, f, f(i, acc, x))
+    }
+  }
+
+  go(self, 0, f, init)
+}
+
+/// Fold the list from right with index.
+pub fn fold_righti[T, U](self : List[T], f : (Int, T, U) -> U, ~init : U) -> U {
+  fn go(xs : List[T], i : Int, f : (Int, T, U) -> U, acc : U) -> U {
+    match xs {
+      Nil => acc
+      Cons(x, xs) => f(i, x, go(xs, i + 1, f, acc))
+    }
+  }
+
+  go(self, 0, f, init)
+}
+
+/// Zip two lists.
+///
+/// # Example
+/// 
+/// ```
+/// let r = zip(List::[1, 2, 3, 4, 5], from_array([6, 7, 8, 9, 10]))
+/// debug(r) // output: from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]
+/// ```
+/// 
+/// @alert unsafe "Panic if the two lists have different lengths."
+pub fn zip[T, U](self : List[T], other : List[U]) -> List[(T, U)] {
+  match (self, other) {
+    (Nil, Nil) => Nil
+    (Cons(x, xs), Cons(y, ys)) => Cons((x, y), zip(xs, ys))
+    _ => abort("zip: lists have different lengths")
+  }
+}
+
+/// map over the list and concat all results.
+///
+/// `concat_map(f, ls)` equal to `ls.map(f).fold(Nil, fn(acc, x) { acc.concat(x) })))`
+///
+/// # Example
+/// 
+/// ```
+/// let ls = from_array([1, 2, 3])
+/// let r = ls.concat_map(fn(x) { [x, x * 2] })
+/// debug(r) // output: from_array([1, 2, 2, 4, 3, 6])
+/// ```
+pub fn concat_map[T, U](self : List[T], f : (T) -> List[U]) -> List[U] {
+  match self {
+    Nil => Nil
+    Cons(head, tail) => concat(f(head), concat_map(tail, f))
+  }
+}
+
+/// Get nth element of the list
+/// @alert unsafe "Panic if the index is out of bounds"
+pub fn nth_exn[T](self : List[T], n : Int) -> T {
+  loop self, n {
+    Nil, _ => abort("nth: index out of bounds")
+    Cons(head, _), 0 => head
+    Cons(_, tail), n => continue tail, n - 1
+  }
+}
+
+/// Get nth element of the list or None if the index is out of bounds
+pub fn nth[T](self : List[T], n : Int) -> T? {
+  loop self, n {
+    Nil, _ => None
+    Cons(head, _), 0 => Some(head)
+    Cons(_, tail), n => continue tail, n - 1
+  }
+}
+
+/// Create a list of length n with the given value
+///
+/// # Example
+/// 
+/// ```
+/// debug(repeat(5, 1)) // output: from_array([1, 1, 1, 1, 1])
+/// ```
+pub fn repeat[T](n : Int, x : T) -> List[T] {
+  if n == 0 {
+    Nil
+  } else {
+    Cons(x, repeat(n - 1, x))
+  }
+}
+
+/// Insert separator to the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// let ls = from_array(["1", "2", "3", "4", "5"]).intersperse("|")
+/// debug(ls) // output: from_array(["1", "|", "2", "|", "3", "|", "4", "|", "5"])
+/// ```
+pub fn intersperse[T](self : List[T], separator : T) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(head, Nil) => Cons(head, Nil)
+    Cons(head, tail) =>
+      Cons(head, Cons(separator, intersperse(tail, separator)))
+  }
+}
+
+/// Check if the list is empty.
+pub fn is_empty[T](self : List[T]) -> Bool {
+  match self {
+    Nil => true
+    _ => false
+  }
+}
+
+/// Unzip two lists.
+///
+/// # Example
+///
+/// ```
+/// let (a,b) = unzip(from_array([(1,2),(3,4),(5,6)]))
+/// debug(a) // output: from_array([1, 3, 5])
+/// debug(b) // output: from_array([2, 4, 6])
+/// ```
+pub fn unzip[T, U](list : List[(T, U)]) -> (List[T], List[U]) {
+  match list {
+    Nil => (Nil, Nil)
+    Cons((x, y), xs) => {
+      let (xs, ys) = unzip(xs)
+      (Cons(x, xs), Cons(y, ys))
+    }
+  }
+}
+
+/// flatten a list of lists.
+/// 
+/// # Example
+/// 
+/// ```
+/// let ls = flatten(from_array([from_array([1,2,3]), from_array([4,5,6]), from_array([7,8,9])]))
+/// debug(ls) // output: from_array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+/// ```
+pub fn flatten[T](self : List[List[T]]) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(head, tail) => concat(head, flatten(tail))
+  }
+}
+
+/// Get maximum element of the list.
+/// @alert unsafe "Panic if the list is empty"
+pub fn maximum[T : Compare](self : List[T]) -> T {
+  match self {
+    Nil => abort("maximum: empty list")
+    Cons(x, Nil) => x
+    Cons(x, xs) => {
+      let y = maximum(xs)
+      if x > y {
+        x
+      } else {
+        y
+      }
+    }
+  }
+}
+
+/// Get minimum element of the list.
+/// @alert unsafe "Panic if the list is empty"
+pub fn minimum[T : Compare](self : List[T]) -> T {
+  match self {
+    Nil => abort("minimum: empty list")
+    Cons(x, Nil) => x
+    Cons(x, xs) => {
+      let y = minimum(xs)
+      if x < y {
+        x
+      } else {
+        y
+      }
+    }
+  }
+}
+
+/// Sort the list in ascending order.
+///
+/// # Example
+/// 
+/// ```
+/// let ls = sort(from_array([1,123,52,3,6,0,-6,-76]))
+/// debug(ls) // output: from_array([-76, -6, 0, 1, 3, 6, 52, 123])
+/// ```
+pub fn sort[T : Compare](self : List[T]) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(x, xs) => {
+      let smaller = filter(xs, fn(y) { y < x })
+      let greater = filter(xs, fn(y) { y >= x })
+      concat(sort(smaller), Cons(x, sort(greater)))
+    }
+  }
+}
+
+/// Concatenate two lists.
+///
+/// `a + b` equal to `a.concat(b)`
+pub fn op_add[T](self : List[T], other : List[T]) -> List[T] {
+  self.concat(other)
+}
+
+/// Check if the list contains the value.
+pub fn contain[T : Eq](self : List[T], value : T) -> Bool {
+  loop self {
+    Nil => false
+    Cons(x, xs) => if x == value { true } else { continue xs }
+  }
+}
+
+/// Produces a collection iteratively.
+///
+/// # Example
+///
+/// ```
+/// // from_array([0, 1, 2])
+/// unfold(0, fn { i => if i == 3 { None } else { Some(i, i + 1) } }) |> debug 
+/// ```
+pub fn unfold[T, State](f : (State) -> (T, State)?, ~init : State) -> List[T] {
+  match f(init) {
+    Some((element, new_state)) => Cons(element, unfold(init=new_state, f))
+    None => Nil
+  }
+}
+
+/// Take first n elements of the list.
+///
+/// # Example
+///
+/// ```
+/// List::[1, 2, 3, 4, 5].take(3)
+/// ```
+pub fn take[T](self : List[T], n : Int) -> List[T] {
+  if n <= 0 {
+    Nil
+  } else {
+    unsafe_take(n, self)
+  }
+}
+
+fn unsafe_take[T](n : Int, xs : List[T]) -> List[T] {
+  match (n, xs) {
+    (1, Cons(x, _)) => Cons(x, Nil)
+    (_, Cons(x, xs)) => Cons(x, unsafe_take(n - 1, xs))
+    _ => abort("take: index out of bounds")
+  }
+}
+
+/// Drop first n elements of the list.
+///
+/// # Example
+///
+/// ```
+/// List::[1, 2, 3, 4, 5].drop(3)
+/// ```
+pub fn drop[T](self : List[T], n : Int) -> List[T] {
+  if n <= 0 {
+    self
+  } else {
+    unsafe_drop(n, self)
+  }
+}
+
+fn unsafe_drop[T](n : Int, xs : List[T]) -> List[T] {
+  match (n, xs) {
+    (1, Cons(_, xs)) => xs
+    (_, Cons(_, xs)) => unsafe_drop(n - 1, xs)
+    (x, _) => abort("drop: index out of bounds" + x.to_string())
+  }
+}
+
+/// Take the longest prefix of a list of elements that satisfies a given predicate.
+///
+/// # Example
+///
+/// ```
+/// from_array([1, 2, 3, 4]).take_while(fn(x) { x < 3 })
+/// ```
+pub fn take_while[T](self : List[T], p : (T) -> Bool) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(x, xs) => if p(x) { Cons(x, xs.take_while(p)) } else { Nil }
+  }
+}
+
+/// Drop the longest prefix of a list of elements that satisfies a given predicate.
+///
+/// # Example
+///
+/// ```
+/// from_array([1, 2, 3, 4]).drop_while(fn(x) { x < 3 })
+/// ```
+pub fn drop_while[T](self : List[T], p : (T) -> Bool) -> List[T] {
+  loop self {
+    Nil => Nil
+    Cons(x, xs) => if p(x) { continue xs } else { Cons(x, xs) }
+  }
+}
+
+/// Fold a list and return a list of successive reduced values from the left
+///
+/// # Example
+///
+/// ```
+/// let ls = List::[1, 2, 3, 4, 5]
+/// ls.scan_left(fn(acc, x) { acc + x }, ~init=0) 
+/// ```
+pub fn scan_left[T, E](self : List[T], f : (E, T) -> E, ~init : E) -> List[E] {
+  Cons(
+    init,
+    match self {
+      Nil => Nil
+      Cons(x, xs) => xs.scan_left(f, init=f(init, x))
+    },
+  )
+}
+
+/// Fold a list and return a list of successive reduced values from the right
+/// 
+/// Note that the order of parameters on the accumulating function are reversed.
+/// 
+/// # Example
+/// ```
+/// let ls = List::[1, 2, 3, 4, 5]
+/// ls.scan_right(fn(x, acc) { acc + x }, ~init=0)
+/// ```
+pub fn scan_right[T, E](self : List[T], f : (T, E) -> E, ~init : E) -> List[E] {
+  match self {
+    Nil => Cons(init, Nil)
+    Cons(x, xs) => {
+      let qs = xs.scan_right(f, ~init)
+      Cons(f(x, qs.head_exn()), qs)
+    }
+  }
+}
+
+/// Looks up a key in an association list.
+///
+/// # Example
+///
+/// ```
+/// let ls = from_array([(1, "a"), (2, "b"), (3, "c")])
+/// ls.lookup(3) // output: Some("c")
+/// ```
+pub fn lookup[T : Eq, E](self : List[(T, E)], v : T) -> E? {
+  loop self {
+    Nil => None
+    Cons((x, y), xs) => if x == v { Some(y) } else { continue xs }
+  }
+}
+
+/// Find the first element in the list that satisfies f.
+///
+/// # Example
+///
+/// ```
+/// println(List::[1, 3, 5, 8].find(fn(element) -> Bool { element % 2 == 0}))
+/// // output: Some(8)
+/// ```
+pub fn find[T](self : List[T], f : (T) -> Bool) -> T? {
+  loop self {
+    Nil => None
+    Cons(element, list) =>
+      if f(element) {
+        Some(element)
+      } else {
+        continue list
+      }
+  }
+}
+
+/// Find the first element in the list that satisfies f and passes the index as an argument.
+///
+/// # Example
+///
+/// ```
+/// println(List::[1, 3, 5, 8].findi(fn(element) -> Bool { (element % 2 == 0) && (i == 3) }))
+/// // output: Some(8)
+///
+/// println(List::[1, 3, 8, 5].findi(fn(element) -> Bool { (element % 2 == 0) && (i == 3) }))
+/// // output: None
+/// ```
+pub fn findi[T](self : List[T], f : (T, Int) -> Bool) -> T? {
+  loop self, 0 {
+    list, index =>
+      match list {
+        Nil => None
+        Cons(element, list) =>
+          if f(element, index) {
+            Some(element)
+          } else {
+            continue list, index + 1
+          }
+      }
+  }
+}
+
+/// Removes the element at the specified index in the list.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(List::[1, 2, 3, 4, 5].remove_at(2))
+/// // output: from_array([1, 2, 4, 5])
+/// ```
+pub fn remove_at[T](self : List[T], index : Int) -> List[T] {
+  match (index, self) {
+    (0, Cons(_, tail)) => tail
+    (_, Cons(head, tail)) => Cons(head, remove_at(tail, index - 1))
+    (_, Nil) => Nil
+    // abort("remove_at: index out of bounds")
+  }
+}
+
+/// Removes the first occurrence of the specified element from the list, if it is present.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(List::[1, 2, 3, 4, 5].remove(3))
+/// // output: from_array([1, 2, 4, 5])
+/// ```
+pub fn remove[T : Eq](self : List[T], elem : T) -> List[T] {
+  match self {
+    Nil => Nil
+    Cons(head, tail) =>
+      if head == elem {
+        tail
+      } else {
+        Cons(head, remove(tail, elem))
+      }
+  }
+}
+
+/// Returns true if list starts with prefix.
+///
+/// # Example
+/// 
+/// ```
+/// println(List::[1, 2, 3, 4, 5].is_prefix(List::[1, 2, 3]))
+/// // output: true
+/// ```
+pub fn is_prefix[T : Eq](self : List[T], prefix : List[T]) -> Bool {
+  match (self, prefix) {
+    (_, Nil) => true
+    (Nil, Cons(_)) => false
+    (Cons(h1, t1), Cons(h2, t2)) => h1 == h2 && t1.is_prefix(t2)
+  }
+}
+
+/// Compares two lists for equality.
+///
+/// # Example
+///
+/// ```
+/// println(List::[1, 2, 3].equal(List::[1, 2, 3]))
+/// // output: true
+/// ```
+pub fn equal[T : Eq](self : List[T], other : List[T]) -> Bool {
+  match (self, other) {
+    (Nil, Nil) => true
+    (Cons(h, t), Cons(h1, t1)) => h == h1 && t.equal(t1)
+    _ => false
+  }
+}
+
+/// Returns true if list ends with suffix.
+///
+/// # Example
+///
+/// ```
+/// println(List::[1, 2, 3, 4, 5].is_suffix(List::[3, 4, 5]))
+/// // output: true
+/// ```
+pub fn is_suffix[T : Eq](self : List[T], suffix : List[T]) -> Bool {
+  self.reverse().is_prefix(suffix.reverse())
+}
+
+/// Similar to intersperse but with a list of values.
+/// 
+/// # Example 
+/// ```
+/// let ls = List::[
+///    List::[1, 2, 3],
+///    List::[4, 5, 6],
+///    List::[7, 8, 9],
+/// ]
+/// ls.intercalate(List::[0])
+/// ```
+pub fn intercalate[T](self : List[List[T]], sep : List[T]) -> List[T] {
+  self.intersperse(sep).flatten()
+}
+
+/// The empty list
+pub fn List::default[X]() -> List[X] {
+  Nil
+}

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -1,0 +1,73 @@
+package moonbitlang/core/immut/list
+
+// Values
+fn repeat[T](Int, T) -> List[T]
+
+fn unfold[T, State]((State) -> Option[Tuple[T, State]], ~init : State) -> List[T]
+
+fn unzip[T, U](List[Tuple[T, U]]) -> Tuple[List[T], List[U]]
+
+// Types and methods
+pub enum List {
+  Nil
+  Cons(T, List[T])
+}
+impl List {
+  all[T](Self[T], (T) -> Bool) -> Bool
+  any[T](Self[T], (T) -> Bool) -> Bool
+  concat[T](Self[T], Self[T]) -> Self[T]
+  concat_map[T, U](Self[T], (T) -> Self[U]) -> Self[U]
+  contain[T : Eq](Self[T], T) -> Bool
+  debug_write[T : Debug](Self[T], Buffer) -> Unit
+  default[X]() -> Self[X]
+  drop[T](Self[T], Int) -> Self[T]
+  drop_while[T](Self[T], (T) -> Bool) -> Self[T]
+  equal[T : Eq](Self[T], Self[T]) -> Bool
+  filter[T](Self[T], (T) -> Bool) -> Self[T]
+  find[T](Self[T], (T) -> Bool) -> Option[T]
+  findi[T](Self[T], (T, Int) -> Bool) -> Option[T]
+  flatten[T](Self[Self[T]]) -> Self[T]
+  fold_left[T, U](Self[T], (U, T) -> U, ~init : U) -> U
+  fold_lefti[T, U](Self[T], (Int, U, T) -> U, ~init : U) -> U
+  fold_right[T, U](Self[T], (T, U) -> U, ~init : U) -> U
+  fold_righti[T, U](Self[T], (Int, T, U) -> U, ~init : U) -> U
+  from_array[T](Array[T]) -> Self[T]
+  head[T](Self[T]) -> Option[T]
+  head_exn[T](Self[T]) -> T
+  init_[T](Self[T]) -> Self[T]
+  intercalate[T](Self[Self[T]], Self[T]) -> Self[T]
+  intersperse[T](Self[T], T) -> Self[T]
+  is_empty[T](Self[T]) -> Bool
+  is_prefix[T : Eq](Self[T], Self[T]) -> Bool
+  is_suffix[T : Eq](Self[T], Self[T]) -> Bool
+  iter[T](Self[T], (T) -> Unit) -> Unit
+  iteri[T](Self[T], (Int, T) -> Unit) -> Unit
+  last[T](Self[T]) -> T
+  length[T](Self[T]) -> Int
+  lookup[T : Eq, E](Self[Tuple[T, E]], T) -> Option[E]
+  map[T, U](Self[T], (T) -> U) -> Self[U]
+  mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
+  maximum[T : Compare + Eq](Self[T]) -> T
+  minimum[T : Compare + Eq](Self[T]) -> T
+  nth[T](Self[T], Int) -> Option[T]
+  nth_exn[T](Self[T], Int) -> T
+  op_add[T](Self[T], Self[T]) -> Self[T]
+  op_equal[T : Eq](Self[T], Self[T]) -> Bool
+  remove[T : Eq](Self[T], T) -> Self[T]
+  remove_at[T](Self[T], Int) -> Self[T]
+  reverse[T](Self[T]) -> Self[T]
+  scan_left[T, E](Self[T], (E, T) -> E, ~init : E) -> Self[E]
+  scan_right[T, E](Self[T], (T, E) -> E, ~init : E) -> Self[E]
+  sort[T : Compare + Eq](Self[T]) -> Self[T]
+  tail[T](Self[T]) -> Self[T]
+  take[T](Self[T], Int) -> Self[T]
+  take_while[T](Self[T], (T) -> Bool) -> Self[T]
+  to_array[T](Self[T]) -> Array[T]
+  to_string[T : Show](Self[T]) -> String
+  zip[T, U](Self[T], Self[U]) -> Self[Tuple[T, U]]
+}
+
+// Traits
+
+// Extension Methods
+

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -1,0 +1,416 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "from_array" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = Nil
+  inspect(ls, content="List::[1, 2, 3, 4, 5]")?
+  inspect(el, content="List::[]")?
+}
+
+test "length" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.length(), content="5")?
+}
+
+test "iter" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let mut i = 0
+  let mut failed = false
+  ls.iter(
+    fn(x) {
+      i = i + 1
+      if x != i {
+        failed = true
+      }
+    },
+  )
+  inspect(failed, content="false")?
+}
+
+test "iteri" {
+  let mut v = 0
+  let mut failed = false
+  let ls = List::[1, 2, 3, 4, 5]
+  ls.iteri(
+    fn(i, x) {
+      if x != v + 1 || i != v {
+        failed = true
+      }
+      v = v + 1
+    },
+  )
+  inspect(failed, content="false")?
+}
+
+test "map" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let rs : List[Int] = Nil
+  inspect(ls.map(fn(x) { x * 2 }), content="List::[2, 4, 6, 8, 10]")?
+  inspect(rs.map(fn(x) { x * 2 }), content="List::[]")?
+}
+
+test "mapi" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = Nil
+  inspect(ls.mapi(fn(i, x) { i * x }), content="List::[0, 2, 6, 12, 20]")?
+  inspect(el.mapi(fn(i, x) { i * x }), content="List::[]")?
+}
+
+test "to_array" {
+  let list = List::[1, 2, 3, 4, 5]
+  let empty : List[Int] = Nil
+  let array = to_array(list)
+  let earray = to_array(empty)
+  inspect(array, content="[1, 2, 3, 4, 5]")?
+  inspect(earray, content="[]")?
+}
+
+test "filter" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let rs : List[Int] = Nil
+  inspect(ls.filter(fn(x) { x % 2 == 0 }), content="List::[2, 4]")?
+  inspect(rs.filter(fn(x) { x % 2 == 0 }), content="List::[]")?
+}
+
+test "all" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.all(fn(x) { x > 0 }), content="true")?
+  inspect(ls.all(fn(x) { x > 1 }), content="false")?
+}
+
+test "any" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.any(fn(x) { x > 4 }), content="true")?
+  inspect(ls.any(fn(x) { x > 5 }), content="false")?
+}
+
+test "tail" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = Nil
+  inspect(ls.tail(), content="List::[2, 3, 4, 5]")?
+  inspect(el.tail(), content="List::[]")?
+}
+
+test "head_exn" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.head_exn(), content="1")?
+}
+
+test "head" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = List::[]
+  inspect(ls.head(), content="Some(1)")?
+  inspect(el.head(), content="None")?
+}
+
+test "last" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.last(), content="5")?
+}
+
+test "init_" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = Nil
+  inspect(ls.init_(), content="List::[1, 2, 3, 4]")?
+  inspect(el.init_(), content="List::[]")?
+}
+
+test "concat" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let rs = List::[6, 7, 8, 9, 10]
+  inspect(ls.concat(Nil), content="List::[1, 2, 3, 4, 5]")?
+  inspect((Nil : List[Int]).concat(rs), content="List::[6, 7, 8, 9, 10]")?
+  inspect(ls.concat(rs), content="List::[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]")?
+}
+
+test "reverse" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let rs = List::[5, 4, 3, 2, 1]
+  inspect(rs.reverse(), content="List::[1, 2, 3, 4, 5]")?
+  inspect(ls.reverse().reverse(), content="List::[1, 2, 3, 4, 5]")?
+}
+
+test "fold_left" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = Nil
+  inspect(el.fold_left(fn(acc, x) { acc + x }, init=0), content="0")?
+  inspect(ls.fold_left(fn(acc, x) { acc + x }, init=0), content="15")?
+}
+
+test "fold_right" {
+  let ls = List::["1", "2", "3", "4", "5"]
+  let el : List[String] = Nil
+  inspect(ls.fold_right(fn(x, acc) { x + acc }, init=""), content="12345")?
+  inspect(el.fold_right(fn(x, acc) { x + acc }, init="init"), content="init")?
+}
+
+test "fold_lefti" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = Nil
+  inspect(ls.fold_lefti(fn(i, acc, x) { acc + i * x }, init=0), content="40")?
+  inspect(el.fold_lefti(fn(i, acc, x) { acc + i * x }, init=0), content="0")?
+}
+
+test "fold_righti" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let el : List[Int] = Nil
+  inspect(ls.fold_righti(fn(i, x, acc) { x * i + acc }, init=0), content="40")?
+  inspect(el.fold_righti(fn(i, x, acc) { x * i + acc }, init=0), content="0")?
+}
+
+test "zip" {
+  let ls = List::[1, 2, 3, 4, 5]
+  let rs = List::[6, 7, 8, 9, 10]
+  inspect(ls.zip(rs), content="List::[(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]")?
+}
+
+test "concat_map" {
+  let ls = List::[1, 2, 3]
+  let rs : List[Int] = Nil
+  inspect(rs.concat_map(fn(x) { List::[x, x * 2] }), content="List::[]")?
+  inspect(
+    ls.concat_map(fn(x) { List::[x, x * 2] }),
+    content="List::[1, 2, 2, 4, 3, 6]",
+  )?
+}
+
+test "nth_exn" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.nth_exn(0), content="1")?
+  inspect(ls.nth_exn(1), content="2")?
+}
+
+test "nth" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.nth(0), content="Some(1)")?
+  inspect(ls.nth(20), content="None")?
+}
+
+test "repeat" {
+  inspect(repeat(5, 1), content="List::[1, 1, 1, 1, 1]")?
+  inspect(repeat(0, 10), content="List::[]")?
+}
+
+test "intersperse" {
+  let ls = List::["1", "2", "3", "4", "5"]
+  let el : List[String] = Nil
+  inspect(ls.intersperse("|"), content="List::[1, |, 2, |, 3, |, 4, |, 5]")?
+  inspect(el.intersperse("|"), content="List::[]")?
+}
+
+test "is_empty" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.is_empty(), content="false")?
+  inspect((List::Nil : List[Unit]).is_empty(), content="true")?
+}
+
+test "unzip" {
+  let ls = List::[(1, 2), (3, 4), (5, 6)]
+  let (a, b) = unzip(ls)
+  inspect(a, content="List::[1, 3, 5]")?
+  inspect(b, content="List::[2, 4, 6]")?
+}
+
+test "flatten" {
+  let ls = List::[List::[1, 2, 3], List::[4, 5, 6], List::[7, 8, 9]]
+  let el : List[List[Int]] = Nil
+  inspect(ls.flatten(), content="List::[1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+  inspect(el.flatten(), content="List::[]")?
+}
+
+test "maximum" {
+  let ls = List::[1, 123, 52, 3, 6, 0, -6, -76]
+  inspect(ls.maximum(), content="123")?
+}
+
+test "minimum" {
+  let ls = List::[1, 123, 52, 3, 6, 0, -6, -76]
+  inspect(ls.minimum(), content="-76")?
+}
+
+test "sort" {
+  let ls = List::[1, 123, 52, 3, 6, 0, -6, -76]
+  let el : List[Int] = Nil
+  inspect(el.sort(), content="List::[]")?
+  inspect(ls.sort(), content="List::[-76, -6, 0, 1, 3, 6, 52, 123]")?
+}
+
+test "contain" {
+  let ls = List::[1, 2, 3]
+  inspect(ls.contain(1), content="true")?
+  inspect(ls.contain(2), content="true")?
+  inspect(ls.contain(3), content="true")?
+  inspect(ls.contain(0), content="false")?
+  inspect(ls.contain(4), content="false")?
+}
+
+test "unfold" {
+  let ls = unfold(
+    init=0,
+    fn { i => if i == 3 { None } else { Some((i, i + 1)) } },
+  )
+  inspect(ls, content="List::[0, 1, 2]")?
+}
+
+test "take" {
+  let ls = List::[1, 2, 3, 4, 5].take(3)
+  inspect(ls, content="List::[1, 2, 3]")?
+  inspect(ls.take(-1), content="List::[]")?
+  inspect(ls.take(0), content="List::[]")?
+  inspect(ls, content="List::[1, 2, 3]")?
+}
+
+test "drop" {
+  let ls = List::[1, 2, 3, 4, 5].drop(3)
+  let el : List[Int] = Nil
+  inspect(ls, content="List::[4, 5]")?
+  inspect(ls.drop(-10), content="List::[4, 5]")?
+  inspect(ls.drop(0), content="List::[4, 5]")?
+  inspect(el.drop(0), content="List::[]")?
+}
+
+test "take_while" {
+  let ls = take_while(List::[0, 1, 2, 3, 4], fn(x) { x < 3 })
+  let el : List[Int] = take_while(Nil, fn(_e) { true })
+  inspect(ls, content="List::[0, 1, 2]")?
+  inspect(el, content="List::[]")?
+}
+
+test "drop_while" {
+  let ls = drop_while(List::[0, 1, 2, 3, 4], fn(x) { x < 3 })
+  let el : List[Int] = drop_while(Nil, fn(_e) { true })
+  inspect(ls, content="List::[3, 4]")?
+  inspect(el, content="List::[]")?
+}
+
+test "scan_left" {
+  let el = List::[].scan_left(fn(acc, x) { acc + x }, init=0)
+  let ls = List::[1, 2, 3, 4, 5].scan_left(fn(acc, x) { acc + x }, init=0)
+  let ls2 = List::[1, 2, 3, 4].scan_left(fn(acc, x) { acc - x }, init=100)
+  inspect(el, content="List::[0]")?
+  inspect(ls, content="List::[0, 1, 3, 6, 10, 15]")?
+  inspect(ls2, content="List::[100, 99, 97, 94, 90]")?
+}
+
+test "scan_right" {
+  let el = List::[].scan_right(fn(x, acc) { x + acc }, init=0)
+  let ls = List::[1, 2, 3, 4].scan_right(fn(x, acc) { x + acc }, init=0)
+  let ls2 = List::[1, 2, 3, 4].scan_right(fn(x, acc) { x - acc }, init=100)
+  inspect(el, content="List::[0]")?
+  inspect(ls, content="List::[10, 9, 7, 4, 0]")?
+  inspect(ls2, content="List::[98, -97, 99, -96, 100]")?
+}
+
+test "lookup" {
+  let ls = List::[(1, "a"), (2, "b"), (3, "c")]
+  let el : List[(Int, Int)] = Nil
+  inspect(el.lookup(1), content="None")?
+  inspect(ls.lookup(3), content="Some(c)")?
+  inspect(ls.lookup(4), content="None")?
+}
+
+test "find" {
+  inspect(
+    List::[1, 3, 5, 8].find(fn(element) -> Bool { element % 2 == 0 }),
+    content="Some(8)",
+  )?
+  inspect(
+    List::[1, 3, 5, 7].find(fn(element) -> Bool { element % 2 == 0 }),
+    content="None",
+  )?
+  inspect(
+    (Nil : List[Int]).find(fn(element) -> Bool { element % 2 == 0 }),
+    content="None",
+  )?
+}
+
+test "findi" {
+  inspect(
+    List::[1, 3, 5, 8].findi(
+      fn(element, i) -> Bool { element % 2 == 0 && i == 3 },
+    ),
+    content="Some(8)",
+  )?
+  inspect(
+    List::[1, 3, 8, 5].findi(
+      fn(element, i) -> Bool { element % 2 == 0 && i == 3 },
+    ),
+    content="None",
+  )?
+  inspect(
+    (Nil : List[Int]).findi(
+      fn(element, i) -> Bool { element % 2 == 0 && i == 3 },
+    ),
+    content="None",
+  )?
+}
+
+test "remove_at" {
+  let ls = List::[1, 2, 3, 4, 5]
+  inspect(ls.remove_at(2), content="List::[1, 2, 4, 5]")?
+  inspect(ls.remove_at(0), content="List::[2, 3, 4, 5]")?
+  inspect(
+    List::["a", "b", "c", "d", "e"].remove_at(2),
+    content="List::[a, b, d, e]",
+  )?
+  inspect(
+    List::["a", "b", "c", "d", "e"].remove_at(5),
+    content="List::[a, b, c, d, e]",
+  )?
+}
+
+test "remove" {
+  inspect(List::[1, 2, 3, 4, 5].remove(3), content="List::[1, 2, 4, 5]")?
+  inspect(
+    List::["a", "b", "c", "d", "e"].remove("c"),
+    content="List::[a, b, d, e]",
+  )?
+  inspect(
+    List::["a", "b", "c", "d", "e"].remove("f"),
+    content="List::[a, b, c, d, e]",
+  )?
+}
+
+test "is_prefix" {
+  inspect(List::[1, 2, 3, 4, 5].is_prefix(List::[1, 2, 3]), content="true")?
+  inspect(List::[1, 2, 3, 4, 5].is_prefix(List::[3, 2, 3]), content="false")?
+  inspect(List::Nil.is_prefix(List::[1, 2, 3]), content="false")?
+}
+
+test "equal" {
+  inspect(List::[1, 2, 3].equal(List::[1, 2, 3]), content="true")?
+  inspect(List::[1, 2, 3].equal(List::[1, 3, 3]), content="false")?
+  inspect(List::Nil.equal(List::[1]), content="false")?
+}
+
+test "is_suffix" {
+  inspect(List::[1, 2, 3, 4, 5].is_suffix(List::[3, 4, 5]), content="true")?
+  inspect(List::[1, 2, 3, 4, 5].is_suffix(List::[3, 4, 6]), content="false")?
+}
+
+test "intercalate" {
+  let ls = List::[List::[1, 2, 3], List::[4, 5, 6], List::[7, 8, 9]]
+  let el : List[List[Int]] = Nil
+  inspect(
+    ls.intercalate(List::[0]),
+    content="List::[1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]",
+  )?
+  inspect(el.intersperse(List::[1]), content="List::[]")?
+}
+
+test "default" {
+  let ls : List[Int] = List::default()
+  inspect(ls, content="List::[]")?
+}

--- a/immut/list/moon.pkg.json
+++ b/immut/list/moon.pkg.json
@@ -1,0 +1,9 @@
+{
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/assertion",
+    "moonbitlang/core/array",
+    "moonbitlang/core/tuple",
+    "moonbitlang/core/coverage"
+  ]
+}


### PR DESCRIPTION
This package (`immut/list`) is essentially the same as the previously removed package `moonbitlang/core/list`. The only difference is that the `List` type is now defined within the package itself; it's no longer a special built-in type.

The built-in `List` type in the compiler is scheduled to be removed in the release next week.