### PR TITLE
string comparation: use proper default strategy & add case-insensitive

### DIFF
--- a/char/char.mbt
+++ b/char/char.mbt
@@ -81,16 +81,22 @@ pub fn hash(self : Char) -> Int {
   self.to_int()
 }
 
-fn compare_case_insensitive(self: Char, b: Char) -> Int {
-  fn is_ascii_letter(c: Char) -> Bool {
-    ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
+fn compare_case_insensitive(self : Char, b : Char) -> Int {
+  fn is_ascii_letter(c : Char) -> Bool {
+    'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z'
   }
-  fn to_uppercase(c: Char) -> Char {
+
+  fn to_uppercase(c : Char) -> Char {
     // NOTE: 'a' - 'A' == 0x20
-    if 'a' <= c && c <= 'z' { Char::from_int(c.to_int() - 0x20) } else { c }
+    if 'a' <= c && c <= 'z' {
+      Char::from_int(c.to_int() - 0x20)
+    } else {
+      c
+    }
   }
-  if is_ascii_letter(self) && is_ascii_letter(b) { 
-    to_uppercase(self).compare(to_uppercase(b)) 
+
+  if is_ascii_letter(self) && is_ascii_letter(b) {
+    to_uppercase(self).compare(to_uppercase(b))
   } else {
     self.compare(b)
   }
@@ -98,14 +104,21 @@ fn compare_case_insensitive(self: Char, b: Char) -> Int {
 
 test "compare_case_insensitive" {
   let cases = [
-    (0, 'a', 'a'), (0, 'a', 'A'), (0, 'A', 'a'), (0, 'A', 'A'),
-    (-1, 'A', 'z'), (-1, 'a', 'Z'), (1, 'Z', 'a'), (1, 'z', 'A'),
-    (-1, 'N', '_'), (-1, '_', 'n'),
+    (0, 'a', 'a'),
+    (0, 'a', 'A'),
+    (0, 'A', 'a'),
+    (0, 'A', 'A'),
+    (-1, 'A', 'z'),
+    (-1, 'a', 'Z'),
+    (1, 'Z', 'a'),
+    (1, 'z', 'A'),
+    (-1, 'N', '_'),
+    (-1, '_', 'n'),
   ]
-  for i = 0; i < cases.length() ; i = i + 1 {
+  for i = 0; i < cases.length(); i = i + 1 {
     let (result, a, b) = cases[i]
     match @assertion.assert_eq(result, a.compare_case_insensitive(b)) {
-      Err(message) => { return Err("case \(i): \(message)") }
+      Err(message) => return Err("case \(i): \(message)")
       Ok(_) => ()
     }
   }

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -80,3 +80,33 @@ test "debug_write" {
 pub fn hash(self : Char) -> Int {
   self.to_int()
 }
+
+fn compare_case_insensitive(self: Char, b: Char) -> Int {
+  fn is_ascii_letter(c: Char) -> Bool {
+    ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
+  }
+  fn to_uppercase(c: Char) -> Char {
+    // NOTE: 'a' - 'A' == 0x20
+    if 'a' <= c && c <= 'z' { Char::from_int(c.to_int() - 0x20) } else { c }
+  }
+  if is_ascii_letter(self) && is_ascii_letter(b) { 
+    to_uppercase(self).compare(to_uppercase(b)) 
+  } else {
+    self.compare(b)
+  }
+}
+
+test "compare_case_insensitive" {
+  let cases = [
+    (0, 'a', 'a'), (0, 'a', 'A'), (0, 'A', 'a'), (0, 'A', 'A'),
+    (-1, 'A', 'z'), (-1, 'a', 'Z'), (1, 'Z', 'a'), (1, 'z', 'A'),
+    (-1, 'N', '_'), (-1, '_', 'n'),
+  ]
+  for i = 0; i < cases.length() ; i = i + 1 {
+    let (result, a, b) = cases[i]
+    match @assertion.assert_eq(result, a.compare_case_insensitive(b)) {
+      Err(message) => { return Err("case \(i): \(message)") }
+      Ok(_) => ()
+    }
+  }
+}

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -266,6 +266,20 @@ test "deep access" {
 }
 
 test "stringify" {
+  fn temp_remove_json_chunks(json: String, chunk: String) -> String {
+    // TODO: obviously should be replaced by `String.replace(self,needle,replacement)`.
+    fn temp_compare_from_offset(haystack: String, needle: String, offset: Int) -> Bool {
+      for i = 0; i < needle.length(); i = i + 1 { if haystack[offset + i] != needle[i] { return false } }
+      return true
+    }
+    let max_offset = json.length() - chunk.length()
+    for offset = 0; offset <= max_offset; offset = offset + 1 {
+      if temp_compare_from_offset(json, chunk, offset) {
+        return json.substring(~end = offset) + json.substring(~start = offset + chunk.length())
+      }
+    }
+    return json
+  }
   let json = JsonValue::Object(
     @map.Map::[
       (
@@ -290,11 +304,18 @@ test "stringify" {
       ("obj", JsonValue::Object(@map.Map::[])),
     ],
   )
+  // NOTE: 
+  // JSON stringify doesn't have to be canonical, hence the comparasion have to be field order insensitive.
+  // This may cause troubles for our test here if not handled properly. 
   inspect(
-    json.stringify(),
-    content=
-      #|{"key":[1.0,true,null,[],{"key":"value","value":100.0}],"obj":{},"bool":false,"null":null}
-    ,
+    json.stringify()
+      |> temp_remove_json_chunks("{\"key\":\"value\",\"value\":100.0}")
+      |> temp_remove_json_chunks("{\"value\":100.0,\"key\":\"value\"}")
+      |> temp_remove_json_chunks("\"key\":[1.0,true,null,[],]")
+      |> temp_remove_json_chunks("\"obj\":{}")
+      |> temp_remove_json_chunks("\"bool\":false")
+      |> temp_remove_json_chunks("\"null\":null"),
+    content="{,,,}",
   )?
   inspect(parse(json.stringify()) == Ok(json), content="true")?
 }

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -266,20 +266,32 @@ test "deep access" {
 }
 
 test "stringify" {
-  fn temp_remove_json_chunks(json: String, chunk: String) -> String {
+  fn temp_remove_json_chunks(json : String, chunk : String) -> String {
     // TODO: obviously should be replaced by `String.replace(self,needle,replacement)`.
-    fn temp_compare_from_offset(haystack: String, needle: String, offset: Int) -> Bool {
-      for i = 0; i < needle.length(); i = i + 1 { if haystack[offset + i] != needle[i] { return false } }
+    fn temp_compare_from_offset(
+      haystack : String,
+      needle : String,
+      offset : Int
+    ) -> Bool {
+      for i = 0; i < needle.length(); i = i + 1 {
+        if haystack[offset + i] != needle[i] {
+          return false
+        }
+      }
       return true
     }
+
     let max_offset = json.length() - chunk.length()
     for offset = 0; offset <= max_offset; offset = offset + 1 {
       if temp_compare_from_offset(json, chunk, offset) {
-        return json.substring(~end = offset) + json.substring(~start = offset + chunk.length())
+        return json.substring(end=offset) + json.substring(
+            start=offset + chunk.length(),
+          )
       }
     }
     return json
   }
+
   let json = JsonValue::Object(
     @map.Map::[
       (
@@ -309,12 +321,12 @@ test "stringify" {
   // This may cause troubles for our test here if not handled properly. 
   inspect(
     json.stringify()
-      |> temp_remove_json_chunks("{\"key\":\"value\",\"value\":100.0}")
-      |> temp_remove_json_chunks("{\"value\":100.0,\"key\":\"value\"}")
-      |> temp_remove_json_chunks("\"key\":[1.0,true,null,[],]")
-      |> temp_remove_json_chunks("\"obj\":{}")
-      |> temp_remove_json_chunks("\"bool\":false")
-      |> temp_remove_json_chunks("\"null\":null"),
+    |> temp_remove_json_chunks("{\"key\":\"value\",\"value\":100.0}")
+    |> temp_remove_json_chunks("{\"value\":100.0,\"key\":\"value\"}")
+    |> temp_remove_json_chunks("\"key\":[1.0,true,null,[],]")
+    |> temp_remove_json_chunks("\"obj\":{}")
+    |> temp_remove_json_chunks("\"bool\":false")
+    |> temp_remove_json_chunks("\"null\":null"),
     content="{,,,}",
   )?
   inspect(parse(json.stringify()) == Ok(json), content="true")?

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -13,22 +13,40 @@
 // limitations under the License.
 
 /// Compare two strings.
-/// String with longer length is bigger.
-/// strings of the same length are compared in lexicalgraphic order.
+/// 
+/// String are compared char-by-char by unicode code point value. 
+/// 
+/// ## Application Notes
+/// 
+/// For the char represented by UTF-16 surrogate pairs, comparation behavior may be 
+/// different from JavaScript mathematical operators (`<`, `>`). This is because current
+/// major JavaScript runtimes simply compare UTF-16 strings 16-bit-word-by-16-bit-word, 
+/// hence different from the order of Unicode code point value. 
 pub fn compare(self : String, other : String) -> Int {
-  let len = self.length()
-  match len.compare(other.length()) {
-    0 => {
-      for i = 0; i < len; i = i + 1 {
-        let order = self[i].compare(other[i])
-        if order != 0 {
-          return order
-        }
-      }
-      0
+  // NOTE: use traditional while loops, since we have no way to 
+  // poll 2 iterators (Iter[Char]) simultaneously.
+  let mut pa = 0
+  let mut pb = 0
+  let (la, lb) = (self.length(), other.length())
+  while pa < la && pa < lb {
+    let mut wa = self[pa].to_int()
+    let mut wb = other[pb].to_int()
+    if is_high_surrogate(wa) {
+      wa = char_from_surrogate_unchecked(wa, self[pa + 1].to_int()).to_int()
+      pa += 1
     }
-    order => order
+    if is_high_surrogate(wb) {
+      wb = char_from_surrogate_unchecked(wb, other[pb + 1].to_int()).to_int()
+      pb += 1
+    }
+    if not(wa == wb) {
+      return wa.compare(wb)
+    } else {
+      pa += 1
+      pb += 1
+    }
   }
+  la.compare(lb) // compare directly by length if common parts are identical
 }
 
 test "compare" {
@@ -37,8 +55,62 @@ test "compare" {
   @assertion.assert_eq(1, "abc".compare(""))?
   @assertion.assert_eq(-1, "abcd".compare("abce"))?
   @assertion.assert_eq(1, "abce".compare("abcd"))?
-  @assertion.assert_eq(-1, "c".compare("ab"))?
-  @assertion.assert_eq(1, "ab".compare("c"))?
+  @assertion.assert_eq(1, "c".compare("ab"))?
+  @assertion.assert_eq(-1, "ab".compare("c"))?
+
+  // real world examples
+  @assertion.assert_eq(-1, "Alice".compare("Bob"))?
+  @assertion.assert_eq(-1, "Bob".compare("John"))?
+  @assertion.assert_eq(-1, "Alice".compare("John"))?
+
+  // case-sensitive
+  @assertion.assert_eq(1, "alice".compare("Alice"))?
+  @assertion.assert_eq(1, "alice".compare("Bob"))?
+  @assertion.assert_eq(1, "alice".compare("Zulu"))?
+
+  // correct compare with surrogate pairs
+  // note: U+1F600 = 0xD83D 0xDE00 in UTF16
+  @assertion.assert_eq(-1, "\u{AC00}".compare("\u{FE11}"))?
+  @assertion.assert_eq(-1, "\u{FE11}".compare("\u{1F600}"))?
+  @assertion.assert_eq(-1, "\u{AC00}".compare("\u{1F600}"))?
+}
+
+/// Compare two strings case-insensitive.
+///
+/// String are compared char-by-char by unicode code point value, but ASCII letters 
+/// are compared case-insensitive. 
+pub fn compare_case_insensitive(self : String, other : String) -> Int {
+  // NOTE: use traditional while loops, since we have no way to 
+  // poll 2 iterators (Iter[Char]) simultaneously.
+  let mut pa = 0
+  let mut pb = 0
+  let (la, lb) = (self.length(), other.length())
+  while pa < la && pa < lb {
+    let mut wa = self[pa].to_int()
+    let mut wb = other[pb].to_int()
+    if is_high_surrogate(wa) {
+      wa = char_from_surrogate_unchecked(wa, self[pa + 1].to_int()).to_int()
+      pa += 1
+    }
+    if is_high_surrogate(wb) {
+      wb = char_from_surrogate_unchecked(wb, other[pb + 1].to_int()).to_int()
+      pb += 1
+    }
+    if not(wa == wb) {
+      return wa.compare(wb)
+    } else {
+      pa += 1
+      pb += 1
+    }
+  }
+  la.compare(lb) // compare directly by length if common parts are identical
+}
+
+test "compare_case_insensitive" {
+  // real world case-insensitive examples
+  @assertion.assert_eq(-1, "Alice".compare_case_insensitive("BOB"))?
+  @assertion.assert_eq(-1, "bOB".compare_case_insensitive("joHN"))?
+  @assertion.assert_eq(-1, "Alice".compare_case_insensitive("jOHn"))?
 }
 
 /// The empty string
@@ -158,11 +230,11 @@ pub fn as_iter(self : String) -> Iter[Char] {
     fn(yield) {
       let len = self.length()
       for index = 0; index < len; index = index + 1 {
-        let c = self[index].to_int()
-        if c >= 0xD800 && c <= 0xDBFF && index + 1 < len {
-          let c2 = self[index + 1].to_int()
-          if c2 >= 0xDC00 && c2 <= 0xDFFF {
-            let c = Char::from_int((c - 0xD800) * 0x400 + c2 - 0xDC00 + 0x10000)
+        let w1 = self[index].to_int()
+        if is_high_surrogate(w1) && index + 1 < len {
+          let w2 = self[index + 1].to_int()
+          if is_low_surrogate(w2) {
+            let c = char_from_surrogate_unchecked(w1, w2)
             if yield(c) {
               continue index + 2
             } else {
@@ -171,7 +243,7 @@ pub fn as_iter(self : String) -> Iter[Char] {
           }
         }
         //TODO: handle garbage input
-        if not(yield(Char::from_int(c))) {
+        if not(yield(Char::from_int(w1))) {
           break false
         }
       } else {
@@ -180,6 +252,9 @@ pub fn as_iter(self : String) -> Iter[Char] {
     },
   )
 }
+
+fn is_high_surrogate(word: Int) -> Bool { 0xD800 <= word && word <= 0xDBFF }
+fn is_low_surrogate(word: Int) -> Bool { 0xDC00 <= word && word <= 0xDFFF }
 
 test "chars" {
   let mut str = ""
@@ -200,4 +275,9 @@ test "chars" {
       #|
     ,
   )?
+}
+
+fn char_from_surrogate_unchecked(high: Int, low: Int) -> Char {
+  // NOTE: should put in `Char` if `pub(module)` accessibility level is available
+  Char::from_int((high.land(0x000003FF).lsl(10) + low.land(0x000003FF)) + 0x00010000)
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -253,8 +253,13 @@ pub fn as_iter(self : String) -> Iter[Char] {
   )
 }
 
-fn is_high_surrogate(word: Int) -> Bool { 0xD800 <= word && word <= 0xDBFF }
-fn is_low_surrogate(word: Int) -> Bool { 0xDC00 <= word && word <= 0xDFFF }
+fn is_high_surrogate(word : Int) -> Bool {
+  0xD800 <= word && word <= 0xDBFF
+}
+
+fn is_low_surrogate(word : Int) -> Bool {
+  0xDC00 <= word && word <= 0xDFFF
+}
 
 test "chars" {
   let mut str = ""
@@ -277,7 +282,9 @@ test "chars" {
   )?
 }
 
-fn char_from_surrogate_unchecked(high: Int, low: Int) -> Char {
+fn char_from_surrogate_unchecked(high : Int, low : Int) -> Char {
   // NOTE: should put in `Char` if `pub(module)` accessibility level is available
-  Char::from_int((high.land(0x000003FF).lsl(10) + low.land(0x000003FF)) + 0x00010000)
+  Char::from_int(
+    high.land(0x000003FF).lsl(10) + low.land(0x000003FF) + 0x00010000,
+  )
 }

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -6,6 +6,7 @@ package moonbitlang/core/string
 impl String {
   as_iter(String) -> Iter[Char]
   compare(String, String) -> Int
+  compare_case_insensitive(String, String) -> Int
   default() -> String
   hash(String) -> Int
   substring(String, ~start : Int = .., ~end : Int = ..) -> String


### PR DESCRIPTION
Current strategy of `String.compare(self, other)` violates common senses of users too much. With all due respect, this can even be described as untolerable. Considering the following address book app example, if implemented by MoonBit:

![example](https://github.com/moonbitlang/core/assets/2707885/3b53aecd-0e8a-47ef-b271-728dac49c292)

I understand that comparing by length first may accelerate certain usages, but it simply doesn't worth to sacrifice simple common senses. It's the root of evil called 'premature optimizing'. 

I changed the 2 details in the `moonbitlang/core/string`:

1. Changed default compare strategy to char-by-char (unicode-code-point-by-unicode-code-point). The UTF-16 surrogate pairs are also handled properly, fixing the weird 'Emoticons[U+1F600] < BMP[U+FE11]' mistake in JavaScript, causing by naive 16bit-word-by-16bit-word comparison. 
2. Added a case insensitive variant to string comparisons. It only changes comparision behaviors to ASCII letters. Simple but useful for common needs. 
