### PR TITLE
feat: Add to_array method to Bytes

### DIFF
--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -31,9 +31,9 @@ pub fn Bytes::from_array(arr : Array[Int]) -> Bytes {
 }
 
 pub fn to_array(self : Bytes) -> Array[Int] {
-  let rv = Array::with_capacity(self.length())
+  let rv = Array::make(self.length(), 0)
   for i = 0; i < self.length(); i = i + 1 {
-    rv.push(self[i].to_int())
+    rv[i] = self[i].to_int()
   }
   rv
 }

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -29,3 +29,11 @@ pub fn Bytes::from_array(arr : Array[Int]) -> Bytes {
   }
   rv
 }
+
+pub fn to_array(self : Bytes) -> Array[Int] {
+  let rv = Array::with_capacity(self.length())
+  for i = 0; i < self.length(); i = i + 1 {
+    rv.push(self[i].to_int())
+  }
+  rv
+}

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -6,6 +6,7 @@ package moonbitlang/core/bytes
 impl Bytes {
   from_array(Array[Int]) -> Bytes
   hash(Bytes) -> Int
+  to_array(Bytes) -> Array[Int]
 }
 
 // Traits

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -14,7 +14,7 @@
 
 test "from_array" {
   let b = Bytes::[65, 0, 66, 0, 67, 0]
-  inspect(b.to_string(), content="ABC")?
+  inspect(b, content="ABC")?
 }
 
 test "hash" {
@@ -33,4 +33,9 @@ test "hash" {
   inspect(b1.hash() == b1.hash(), content="true")?
   inspect(b2.hash() == b2.hash(), content="true")?
   inspect(b1.hash() == b2.hash(), content="false")?
+}
+
+test "to_array" {
+  let b = Bytes::[65, 0, 66, 0, 67, 0]
+  inspect(b.to_array(), content="[65, 0, 66, 0, 67, 0]")?
 }


### PR DESCRIPTION
Used in Unicode encoding (https://github.com/moonbitlang/x/commit/daa53ced0ca9ef3538064de41e80dae8bb730fee)
But Bytes itself should also mean byte array, so this may be confusing