### PR TITLE
make capacity of array no longer a guarantee

### DIFF
--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -130,7 +130,6 @@ test "clear" {
   let v = [3, 4, 5]
   v.clear()
   @assertion.assert_eq(v.length(), 0)?
-  @assertion.assert_eq(v.capacity(), 3)?
 }
 
 test "map" {
@@ -296,21 +295,6 @@ test "insert" {
   v.insert(1, 6)
   @assertion.assert_eq(v, [3, 6, 4, 5])?
   @assertion.assert_eq(v.length(), 4)?
-  @assertion.assert_eq(v.capacity(), 6)?
-}
-
-test "fill" {
-  let v = with_capacity(3)
-  v.fill(3)
-  @assertion.assert_eq(v, [3, 3, 3])?
-  @assertion.assert_eq(v.length(), 3)?
-}
-
-test "fill_with" {
-  let v = with_capacity(3)
-  v.fill_with(fn() { 3 })
-  @assertion.assert_eq(v, [3, 3, 3])?
-  @assertion.assert_eq(v.length(), 3)?
 }
 
 test "flatten" {
@@ -400,14 +384,14 @@ test "split" {
 
 test "reserve_capacity" {
   let v = [1]
+  // Only test that it doesn't panic
   v.reserve_capacity(10)
-  @assertion.assert_true(v.capacity() == 10)?
 }
 
 test "reserve_capacity_2" {
   let v = [1, 2, 3, 4, 5]
+  // Only test that it doesn't panic
   v.reserve_capacity(3)
-  @assertion.assert_true(v.capacity() == 5)?
 }
 
 test "shrink_to_fit" {
@@ -415,16 +399,14 @@ test "shrink_to_fit" {
   v.push(1)
   v.push(2)
   v.push(3)
-  @assertion.assert_true(v.capacity() == 10)?
+  // Only test that it doesn't panic
   v.shrink_to_fit()
-  @assertion.assert_true(v.capacity() == 3)?
 }
 
 test "shrink_to_fit_2" {
   let v = [1, 2, 3]
-  @assertion.assert_true(v.capacity() == 3)?
+  // Only test that it doesn't panic
   v.shrink_to_fit()
-  @assertion.assert_true(v.capacity() == 3)?
 }
 
 test "as_iter" {

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -77,7 +77,7 @@ pub fn length[T](self : Array[T]) -> Int {
 }
 
 /// Returns the total number of elements the vector can hold without reallocating.
-pub fn capacity[T](self : Array[T]) -> Int {
+fn capacity[T](self : Array[T]) -> Int {
   self.buf.0.length()
 }
 
@@ -716,32 +716,6 @@ pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
   }
   self.buf[index] = value
   self.len = self.len + 1
-}
-
-/// Fill the vector (by capacity) with a given value.
-///
-/// # Example
-/// ```
-/// Array::with_capacity(3).fill(3)
-/// ```
-pub fn fill[T](self : Array[T], value : T) -> Unit {
-  for i = 0; i < self.capacity(); i = i + 1 {
-    self.buf[i] = value
-  }
-  self.len = self.capacity()
-}
-
-/// Fill the vector by calling a function (By capacity).
-///
-/// # Example
-/// ```
-/// Array::with_capacity(3).fill_with(fn() { 3 })
-/// ```
-pub fn fill_with[T](self : Array[T], f : () -> T) -> Unit {
-  for i = 0; i < self.capacity(); i = i + 1 {
-    self.buf[i] = f()
-  }
-  self.len = self.capacity()
 }
 
 /// Flattens a vector of vectors into a vector.

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -39,7 +39,6 @@ impl ArgsLoc {
 type Array
 impl Array {
   append[T](Self[T], Self[T]) -> Unit
-  capacity[T](Self[T]) -> Int
   chunk_by[T](Self[T], (T, T) -> Bool) -> Self[Self[T]]
   chunks[T](Self[T], Int) -> Self[Self[T]]
   clear[T](Self[T]) -> Unit
@@ -49,8 +48,6 @@ impl Array {
   drain[T](Self[T], Int, Int) -> Self[T]
   ends_with[T : Eq](Self[T], Self[T]) -> Bool
   extract_if[T](Self[T], (T) -> Bool) -> Self[T]
-  fill[T](Self[T], T) -> Unit
-  fill_with[T](Self[T], () -> T) -> Unit
   filter[T](Self[T], (T) -> Bool) -> Self[T]
   flatten[T](Self[Self[T]]) -> Self[T]
   fold_left[T, U](Self[T], (U, T) -> U, ~init : U) -> U


### PR DESCRIPTION
This PR make capacity of array no longer a guarantee.

With turning it to a hint, we can compile array to js native array without semantic inconsistent.