### PR TITLE
Refactor array and fix memleak issue

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -12,84 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-priv type UninitializedArray[T] FixedArray[UnsafeMaybeUninit[T]]
-
-/// An `Array` is a collection of values that supports random access and can
-/// grow in size.
-struct Array[T] {
-  mut buf : UninitializedArray[T]
-  mut len : Int
-}
-
-fn UninitializedArray::make[T](size : Int) -> UninitializedArray[T] = "%make_array_maybe_uninit"
-
-fn op_get[T](self : UninitializedArray[T], index : Int) -> T = "%array_get"
-
-fn op_set[T](self : UninitializedArray[T], index : Int, value : T) = "%array_set"
-
-/// Converts the vector to a string.
-pub fn to_string[T : Show](self : Array[T]) -> String {
-  if self.len == 0 {
-    return "[]"
-  }
-  let first = self.buf[0]
-  // CR: format issues
-  for i = 1, init = "[\(first)" {
-    if i >= self.len {
-      break "\(init)]"
-    }
-    let cur = self.buf[i]
-    continue i + 1, "\(init), \(cur)"
-  }
-}
-
 /// Creates a new, empty vector.
 pub fn Array::new[T]() -> Array[T] {
   []
 }
 
-/// Creates a new, empty vector with a specified initial capacity.
-pub fn Array::with_capacity[T](cap : Int) -> Array[T] {
-  { buf: UninitializedArray::make(cap), len: 0 }
-}
-
 /// Creates a new vector from an array.
 pub fn Array::from_fixed_array[T](arr : FixedArray[T]) -> Array[T] {
   let len = arr.length()
-  let buf = UninitializedArray::make(len)
+  let arr2 = Array::make_uninit(len)
   for i = 0; i < len; i = i + 1 {
-    buf[i] = arr[i]
+    arr2.buffer()[i] = arr[i]
   }
-  { buf, len }
+  arr2
 }
 
 pub fn Array::make[T](len : Int, elem : T) -> Array[T] {
-  let buf = UninitializedArray::make(len)
+  let arr = Array::make_uninit(len)
   for i = 0; i < len; i = i + 1 {
-    buf[i] = elem
+    arr.buffer()[i] = elem
   }
-  { buf, len }
-}
-
-/// Returns the number of elements in the vector.
-pub fn length[T](self : Array[T]) -> Int {
-  self.len
+  arr
 }
 
 /// Returns the total number of elements the vector can hold without reallocating.
 fn capacity[T](self : Array[T]) -> Int {
-  self.buf.0.length()
+  self.buffer().0.length()
 }
 
 /// Reallocate the vector with a new capacity.
 fn realloc[T](self : Array[T]) -> Unit {
-  let old_cap = self.len
+  let old_cap = self.length()
   let new_cap = if old_cap == 0 { 8 } else { old_cap * 2 }
-  let new_buf = UninitializedArray::make(new_cap)
-  for i = 0; i < old_cap; i = i + 1 {
-    new_buf[i] = self.buf[i]
-  }
-  self.buf = new_buf
+  self.resize_buffer(new_cap)
 }
 
 /// Retrieves the element at the specified index from the vector.
@@ -102,13 +57,13 @@ fn realloc[T](self : Array[T]) -> Unit {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds"
 pub fn op_get[T](self : Array[T], index : Int) -> T {
-  if index < 0 || index >= self.len {
-    let len = self.len
+  if index < 0 || index >= self.length() {
+    let len = self.length()
     abort(
       "index out of bounds: the len is from 0 to \(len) but the index is \(index)",
     )
   }
-  self.buf[index]
+  self.buffer()[index]
 }
 
 /// Retrieves the element at the specified index from the vector, or `None` if index is out of bounds
@@ -120,10 +75,10 @@ pub fn op_get[T](self : Array[T], index : Int) -> T {
 /// println(v.get(0)) // Some(3)
 /// ```
 pub fn get[T](self : Array[T], index : Int) -> T? {
-  if index < 0 || index >= self.len {
+  if index < 0 || index >= self.length() {
     return None
   }
-  Some(self.buf[index])
+  Some(self.buffer()[index])
 }
 
 /// Sets the value of the element at the specified index.
@@ -136,23 +91,23 @@ pub fn get[T](self : Array[T], index : Int) -> T? {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn op_set[T](self : Array[T], index : Int, value : T) -> Unit {
-  if index < 0 || index >= self.len {
-    let len = self.len
+  if index < 0 || index >= self.length() {
+    let len = self.length()
     abort(
       "index out of bounds: the len is from 0 to \(len) but the index is \(index)",
     )
   }
-  self.buf[index] = value
+  self.buffer()[index] = value
 }
 
 /// Compares two vectors for equality.
 pub fn op_equal[T : Eq](self : Array[T], other : Array[T]) -> Bool {
-  if self.len != other.len {
+  if self.length() != other.length() {
     return false
   }
   for i = 0 {
     // CR: format issue
-    if i >= self.len {
+    if i >= self.length() {
       break true
     }
     if self[i] != other[i] {
@@ -162,32 +117,15 @@ pub fn op_equal[T : Eq](self : Array[T], other : Array[T]) -> Bool {
   }
 }
 
-fn deep_clone[T](vec : Array[T]) -> Array[T] {
-  let result = Array::{ buf: UninitializedArray::make(vec.len), len: vec.len }
-  for i = 0; i < vec.len; i = i + 1 {
-    result[i] = vec[i]
+pub fn op_add[T](self : Array[T], other : Array[T]) -> Array[T] {
+  let result = Array::make_uninit(self.length() + other.length())
+  for i = 0; i < self.length(); i = i + 1 {
+    result.buffer()[i] = self.buffer()[i]
+  }
+  for i = 0; i < other.length(); i = i + 1 {
+    result.buffer()[i + self.length()] = other.buffer()[i]
   }
   result
-}
-
-pub fn op_add[T](self : Array[T], other : Array[T]) -> Array[T] {
-  if self.len == 0 {
-    deep_clone(other)
-  } else if other.len == 0 {
-    deep_clone(self)
-  } else {
-    let result = Array::{
-      buf: UninitializedArray::make(self.len + other.len),
-      len: self.len + other.len,
-    }
-    for i = 0; i < self.len; i = i + 1 {
-      result[i] = self[i]
-    }
-    for i = 0; i < other.len; i = i + 1 {
-      result[i + self.len] = other[i]
-    }
-    result
-  }
 }
 
 /// Removes the last element from a vector and returns it, or `None` if it is empty.
@@ -198,12 +136,13 @@ pub fn op_add[T](self : Array[T], other : Array[T]) -> Array[T] {
 /// v.pop()
 /// ```
 pub fn pop[T](self : Array[T]) -> T? {
-  if self.len == 0 {
+  if self.length() == 0 {
     None
   } else {
-    self.len -= 1
-    // TODO: should fill the element with a dummy slot to avoid memory leak?
-    Some(self.buf[self.len])
+    let index = self.length() - 1
+    let v = self.buffer()[index]
+    self.set_length(index)
+    Some(v)
   }
 }
 
@@ -216,11 +155,13 @@ pub fn pop[T](self : Array[T]) -> T? {
 /// ```
 /// @alert unsafe "Panic if the vector is empty."
 pub fn pop_exn[T](self : Array[T]) -> T {
-  if self.len == 0 {
+  if self.length() == 0 {
     abort("pop from an empty Array")
   }
-  self.len -= 1
-  self.buf[self.len]
+  let index = self.length() - 1
+  let v = self.buffer()[index]
+  self.set_length(index)
+  v
 }
 
 /// Adds an element to the end of the vector.
@@ -233,11 +174,12 @@ pub fn pop_exn[T](self : Array[T]) -> T {
 /// v.push(3)
 /// ```
 pub fn push[T](self : Array[T], value : T) -> Unit {
-  if self.len == self.buf.0.length() {
+  if self.length() == self.buffer().0.length() {
     self.realloc()
   }
-  self.buf[self.len] = value
-  self.len += 1
+  let length = self.length()
+  self.buffer()[length] = value
+  self.set_length(length + 1)
 }
 
 /// Removes the specified range from the vector and returns it.
@@ -251,22 +193,22 @@ pub fn push[T](self : Array[T], value : T) -> Unit {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
-  if begin < 0 || begin >= self.len || end < 0 || end > self.len || begin > end {
-    let len = self.len
+  if begin < 0 || begin >= self.length() || end < 0 || end > self.length() || begin >
+  end {
+    let len = self.length()
     abort(
       "index out of bounds: the len is \(len) but the index is (\(begin), \(end))",
     )
   }
   let num = end - begin
-  let v = Array::with_capacity(num)
+  let v = Array::make_uninit(num)
   for i = begin; i < end; i = i + 1 {
-    v.buf[i - begin] = self[i]
+    v.buffer()[i - begin] = self.buffer()[i]
   }
-  v.len = num
-  for i = end; i < self.len; i = i + 1 {
-    self.buf[i - num] = self.buf[i]
+  for i = end; i < self.length(); i = i + 1 {
+    self.buffer()[i - num] = self.buffer()[i]
   }
-  self.len -= num
+  self.set_length(self.length() - num)
   v
 }
 
@@ -280,7 +222,7 @@ pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
 /// ```
 /// TODO: could be made more efficient
 pub fn append[T](self : Array[T], other : Array[T]) -> Unit {
-  for i = 0; i < other.len; i = i + 1 {
+  for i = 0; i < other.length(); i = i + 1 {
     self.push(other[i])
   }
 }
@@ -297,7 +239,7 @@ pub fn append[T](self : Array[T], other : Array[T]) -> Unit {
 /// v.iter(fn (x) {sum = sum + x})
 /// ```
 pub fn iter[T](self : Array[T], f : (T) -> Unit) -> Unit {
-  for i = 0; i < self.len; i = i + 1 {
+  for i = 0; i < self.length(); i = i + 1 {
     f(self[i])
   }
 }
@@ -320,7 +262,7 @@ pub fn iter_rev[T](self : Array[T], f : (T) -> Unit) -> Unit {
 /// v.iteri(fn (i, x) {sum = sum + x + i})
 /// ```
 pub fn iteri[T](self : Array[T], f : (Int, T) -> Unit) -> Unit {
-  for i = 0; i < self.len; i = i + 1 {
+  for i = 0; i < self.length(); i = i + 1 {
     f(i, self[i])
   }
 }
@@ -342,7 +284,7 @@ pub fn iter_revi[T](self : Array[T], f : (Int, T) -> Unit) -> Unit {
 /// v.clear()
 /// ```
 pub fn clear[T](self : Array[T]) -> Unit {
-  self.len = 0
+  self.set_length(0)
 }
 
 /// Maps a function over the elements of the vector.
@@ -356,11 +298,11 @@ pub fn map[T, U](self : Array[T], f : (T) -> U) -> Array[U] {
   if self.length() == 0 {
     return []
   }
-  let buf : UninitializedArray[U] = UninitializedArray::make(self.length())
+  let arr = Array::make_uninit(self.length())
   for i = 0; i < self.length(); i = i + 1 {
-    buf[i] = f(self[i])
+    arr.buffer()[i] = f(self.buffer()[i])
   }
-  Array::{ buf, len: self.length() }
+  arr
 }
 
 /// Maps a function over the elements of the vector in place.
@@ -372,7 +314,7 @@ pub fn map[T, U](self : Array[T], f : (T) -> U) -> Array[U] {
 /// ```
 pub fn map_inplace[T](self : Array[T], f : (T) -> T) -> Unit {
   for i = 0; i < self.length(); i = i + 1 {
-    self[i] = f(self[i])
+    self.buffer()[i] = f(self.buffer()[i])
   }
 }
 
@@ -387,11 +329,11 @@ pub fn mapi[T, U](self : Array[T], f : (Int, T) -> U) -> Array[U] {
   if self.length() == 0 {
     return []
   }
-  let buf : UninitializedArray[U] = UninitializedArray::make(self.length())
+  let arr = Array::make_uninit(self.length())
   for i = 0; i < self.length(); i = i + 1 {
-    buf[i] = f(i, self[i])
+    arr.buffer()[i] = f(i, self.buffer()[i])
   }
-  Array::{ buf, len: self.length() }
+  arr
 }
 
 /// Maps a function over the elements of the vector with index in place.
@@ -428,7 +370,7 @@ pub fn filter[T](self : Array[T], f : (T) -> Bool) -> Array[T] {
 /// v.is_empty()
 /// ```
 pub fn is_empty[T](self : Array[T]) -> Bool {
-  self.len == 0
+  self.length() == 0
 }
 
 /// Test if the vector is sorted.
@@ -440,7 +382,7 @@ pub fn is_empty[T](self : Array[T]) -> Bool {
 /// ```
 pub fn is_sorted[T : Compare](self : Array[T]) -> Bool {
   for i = 1 {
-    if i >= self.len {
+    if i >= self.length() {
       break true
     }
     if self[i - 1] > self[i] {
@@ -458,10 +400,10 @@ pub fn is_sorted[T : Compare](self : Array[T]) -> Bool {
 /// v.reverse()
 /// ```
 pub fn reverse[T](self : Array[T]) -> Unit {
-  for i = 0; i < self.len / 2; i = i + 1 {
-    let temp = self.buf[i]
-    self.buf[i] = self.buf[self.len - i - 1]
-    self.buf[self.len - i - 1] = temp
+  for i = 0; i < self.length() / 2; i = i + 1 {
+    let temp = self.buffer()[i]
+    self.buffer()[i] = self.buffer()[self.length() - i - 1]
+    self.buffer()[self.length() - i - 1] = temp
   }
 }
 
@@ -475,19 +417,19 @@ pub fn reverse[T](self : Array[T]) -> Unit {
 /// TODO: perf could be optimized
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn split_at[T](self : Array[T], index : Int) -> (Array[T], Array[T]) {
-  if index < 0 || index >= self.len {
-    let len = self.len
+  if index < 0 || index >= self.length() {
+    let len = self.length()
     abort(
       "index out of bounds: the len is from 0 to \(len) but the index is \(index)",
     )
   }
-  let v1 = Array::with_capacity(index)
-  let v2 = Array::with_capacity(self.len - index)
+  let v1 = Array::make_uninit(index)
+  let v2 = Array::make_uninit(self.length() - index)
   for i = 0; i < index; i = i + 1 {
-    v1.push(self.buf[i])
+    v1[i] = self.buffer()[i]
   }
-  for i = index; i < self.len; i = i + 1 {
-    v2.push(self.buf[i])
+  for i = index; i < self.length(); i = i + 1 {
+    v2[i - index] = self.buffer()[i]
   }
   (v1, v2)
 }
@@ -500,8 +442,8 @@ pub fn split_at[T](self : Array[T], index : Int) -> (Array[T], Array[T]) {
 /// v.contains(3)
 /// ```
 pub fn contains[T : Eq](self : Array[T], value : T) -> Bool {
-  for i = 0; i < self.len; i = i + 1 {
-    if self.buf[i] == value {
+  for i = 0; i < self.length(); i = i + 1 {
+    if self.buffer()[i] == value {
       break true
     }
   } else {
@@ -517,11 +459,11 @@ pub fn contains[T : Eq](self : Array[T], value : T) -> Bool {
 /// v.starts_with([3, 4])
 /// ```
 pub fn starts_with[T : Eq](self : Array[T], prefix : Array[T]) -> Bool {
-  if prefix.len > self.len {
+  if prefix.length() > self.length() {
     return false
   }
-  for i = 0; i < prefix.len; i = i + 1 {
-    if self.buf[i] != prefix.buf[i] {
+  for i = 0; i < prefix.length(); i = i + 1 {
+    if self.buffer()[i] != prefix.buffer()[i] {
       break false
     }
   } else {
@@ -537,11 +479,11 @@ pub fn starts_with[T : Eq](self : Array[T], prefix : Array[T]) -> Bool {
 /// v.ends_with([5])
 /// ```
 pub fn ends_with[T : Eq](self : Array[T], suffix : Array[T]) -> Bool {
-  if suffix.len > self.len {
+  if suffix.length() > self.length() {
     return false
   }
-  for i = 0; i < suffix.len; i = i + 1 {
-    if self.buf[self.len - suffix.len + i] != suffix.buf[i] {
+  for i = 0; i < suffix.length(); i = i + 1 {
+    if self.buffer()[self.length() - suffix.length() + i] != suffix.buffer()[i] {
       break false
     }
   } else {
@@ -560,11 +502,10 @@ pub fn ends_with[T : Eq](self : Array[T], suffix : Array[T]) -> Bool {
 /// ```
 pub fn strip_prefix[T : Eq](self : Array[T], prefix : Array[T]) -> Array[T]? {
   if self.starts_with(prefix) {
-    let v = Array::with_capacity(self.len - prefix.len)
-    for i = prefix.len; i < self.len; i = i + 1 {
-      v.buf[i - prefix.len] = self.buf[i]
+    let v = Array::make_uninit(self.length() - prefix.length())
+    for i = prefix.length(); i < self.length(); i = i + 1 {
+      v.buffer()[i - prefix.length()] = self.buffer()[i]
     }
-    v.len = self.len - prefix.len
     Some(v)
   } else {
     None
@@ -582,11 +523,11 @@ pub fn strip_prefix[T : Eq](self : Array[T], prefix : Array[T]) -> Array[T]? {
 /// ```
 pub fn strip_suffix[T : Eq](self : Array[T], suffix : Array[T]) -> Array[T]? {
   if self.ends_with(suffix) {
-    let v = Array::with_capacity(self.len - suffix.len)
-    for i = 0; i < self.len - suffix.len; i = i + 1 {
-      v.buf[i] = self.buf[i]
+    let v = Array::make_uninit(self.length() - suffix.length())
+    let len = self.length() - suffix.length()
+    for i = 0; i < len; i = i + 1 {
+      v.buffer()[i] = self.buffer()[i]
     }
-    v.len = self.len - suffix.len
     Some(v)
   } else {
     None
@@ -601,8 +542,8 @@ pub fn strip_suffix[T : Eq](self : Array[T], suffix : Array[T]) -> Array[T]? {
 /// v.search(3)
 /// ```
 pub fn search[T : Eq](self : Array[T], value : T) -> Int? {
-  for i = 0; i < self.len; i = i + 1 {
-    if self.buf[i] == value {
+  for i = 0; i < self.length(); i = i + 1 {
+    if self.buffer()[i] == value {
       break Some(i)
     }
   } else {
@@ -619,15 +560,15 @@ pub fn search[T : Eq](self : Array[T], value : T) -> Int? {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn swap[T](self : Array[T], i : Int, j : Int) -> Unit {
-  if i >= self.len || j >= self.len || i < 0 || j < 0 {
-    let len = self.len
+  if i >= self.length() || j >= self.length() || i < 0 || j < 0 {
+    let len = self.length()
     abort(
       "index out of bounds: the len is from 0 to \(len) but the index is (\(i), \(j))",
     )
   }
-  let temp = self.buf[i]
-  self.buf[i] = self.buf[j]
-  self.buf[j] = temp
+  let temp = self.buffer()[i]
+  self.buffer()[i] = self.buffer()[j]
+  self.buffer()[j] = temp
 }
 
 /// Remove an element from the vector at a given index.
@@ -641,17 +582,17 @@ pub fn swap[T](self : Array[T], i : Int, j : Int) -> Unit {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn remove[T](self : Array[T], index : Int) -> T {
-  if index < 0 || index >= self.len {
-    let len = self.len
+  if index < 0 || index >= self.length() {
+    let len = self.length()
     abort(
       "index out of bounds: the len is from 0 to \(len) but the index is \(index)",
     )
   }
-  let value = self.buf[index]
-  for i = index; i < self.len - 1; i = i + 1 {
-    self.buf[i] = self.buf[i + 1]
+  let value = self.buffer()[index]
+  for i = index; i < self.length() - 1; i = i + 1 {
+    self.buffer()[i] = self.buffer()[i + 1]
   }
-  self.len = self.len - 1
+  self.set_length(self.length() - 1)
   value
 }
 
@@ -665,8 +606,8 @@ pub fn remove[T](self : Array[T], index : Int) -> T {
 /// TODO: perf could be improved
 pub fn retain[T](self : Array[T], f : (T) -> Bool) -> Unit {
   let mut i = 0
-  while i < self.len {
-    if f(self.buf[i]).not() {
+  while i < self.length() {
+    if f(self.buffer()[i]).not() {
       self.remove(i) |> ignore
     } else {
       i = i + 1
@@ -685,10 +626,10 @@ pub fn resize[T](self : Array[T], new_len : Int, f : T) -> Unit {
   if new_len < 0 {
     abort("negative new length")
   }
-  if new_len < self.len {
-    self.len = new_len
+  if new_len < self.length() {
+    self.set_length(new_len)
   } else {
-    for i = self.len; i < new_len; i = i + 1 {
+    for i = self.length(); i < new_len; i = i + 1 {
       self.push(f)
     }
   }
@@ -702,20 +643,21 @@ pub fn resize[T](self : Array[T], new_len : Int, f : T) -> Unit {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
-  if index < 0 || index > self.len {
-    let len = self.len
+  if index < 0 || index > self.length() {
+    let len = self.length()
     abort(
       "index out of bounds: the len is from 0 to \(len) but the index is \(index)",
     )
   }
-  if self.len == self.buf.0.length() {
+  if self.length() == self.buffer().0.length() {
     self.realloc()
   }
-  for i = self.len; i > index; i = i - 1 {
-    self.buf[i] = self.buf[i - 1]
+  for i = self.length(); i > index; i = i - 1 {
+    self.buffer()[i] = self.buffer()[i - 1]
   }
-  self.buf[index] = value
-  self.len = self.len + 1
+  let length = self.length()
+  self.buffer()[index] = value
+  self.set_length(length + 1)
 }
 
 /// Flattens a vector of vectors into a vector.
@@ -726,7 +668,7 @@ pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
 /// ```
 pub fn flatten[T](self : Array[Array[T]]) -> Array[T] {
   let v = []
-  for i = 0; i < self.len; i = i + 1 {
+  for i = 0; i < self.length(); i = i + 1 {
     v.append(self[i])
   }
   v
@@ -739,7 +681,7 @@ pub fn flatten[T](self : Array[Array[T]]) -> Array[T] {
 /// [3, 4].repeat(2)
 /// ```
 pub fn repeat[T](self : Array[T], times : Int) -> Array[T] {
-  let v = Array::with_capacity(self.len * times)
+  let v = Array::with_capacity(self.length() * times)
   for i = 0; i < times; i = i + 1 {
     v.append(self)
   }
@@ -754,9 +696,9 @@ pub fn repeat[T](self : Array[T], times : Int) -> Array[T] {
 /// ```
 pub fn join[T](self : Array[Array[T]], sep : T) -> Array[T] {
   let v = []
-  for i = 0; i < self.len; i = i + 1 {
+  for i = 0; i < self.length(); i = i + 1 {
     v.append(self[i])
-    if i < self.len - 1 {
+    if i < self.length() - 1 {
       v.push(sep)
     }
   }
@@ -816,8 +758,8 @@ pub fn fold_lefti[T, U](self : Array[T], f : (Int, U, T) -> U, ~init : U) -> U {
 /// sum // 10
 /// ```
 pub fn fold_righti[T, U](self : Array[T], f : (Int, U, T) -> U, ~init : U) -> U {
-  for i = self.len - 1, acc = init; i >= 0; {
-    continue i - 1, f(self.len - i - 1, acc, self[i])
+  for i = self.length() - 1, acc = init; i >= 0; {
+    continue i - 1, f(self.length() - i - 1, acc, self[i])
   } else {
     acc
   }
@@ -831,9 +773,9 @@ pub fn fold_righti[T, U](self : Array[T], f : (Int, U, T) -> U, ~init : U) -> U 
 /// v.dedup() // v = [3, 4, 5]
 /// ```
 pub fn dedup[T : Eq](self : Array[T]) -> Unit {
-  for i = 0; i < self.len; i = i + 1 {
+  for i = 0; i < self.length(); i = i + 1 {
     let mut j = i + 1
-    while j < self.len {
+    while j < self.length() {
       if self[i] == self[j] {
         self.remove(j) |> ignore
       } else {
@@ -854,13 +796,13 @@ pub fn dedup[T : Eq](self : Array[T]) -> Unit {
 pub fn extract_if[T](self : Array[T], f : (T) -> Bool) -> Array[T] {
   let v = []
   let indices = []
-  for i = 0; i < self.len; i = i + 1 {
+  for i = 0; i < self.length(); i = i + 1 {
     if f(self[i]) {
       v.push(self[i])
       indices.push(i)
     }
   }
-  for i = 0; i < indices.len; i = i + 1 {
+  for i = 0; i < indices.length(); i = i + 1 {
     self.remove(indices[i] - i) |> ignore
   }
   v
@@ -878,9 +820,9 @@ pub fn extract_if[T](self : Array[T], f : (T) -> Bool) -> Array[T] {
 pub fn chunks[T](self : Array[T], size : Int) -> Array[Array[T]] {
   let chunks = []
   let mut i = 0
-  while i < self.len {
+  while i < self.length() {
     let chunk = Array::with_capacity(size)
-    for j = 0; j < size && i < self.len; j = j + 1 {
+    for j = 0; j < size && i < self.length(); j = j + 1 {
       chunk.push(self[i])
       i = i + 1
     }
@@ -900,11 +842,11 @@ pub fn chunks[T](self : Array[T], size : Int) -> Array[Array[T]] {
 pub fn chunk_by[T](self : Array[T], pred : (T, T) -> Bool) -> Array[Array[T]] {
   let chunks = []
   let mut i = 0
-  while i < self.len {
+  while i < self.length() {
     let chunk = []
     chunk.push(self[i])
     i = i + 1
-    while i < self.len && pred(self[i - 1], self[i]) {
+    while i < self.length() && pred(self[i - 1], self[i]) {
       chunk.push(self[i])
       i = i + 1
     }
@@ -923,9 +865,9 @@ pub fn chunk_by[T](self : Array[T], pred : (T, T) -> Bool) -> Array[Array[T]] {
 pub fn split[T](self : Array[T], pred : (T) -> Bool) -> Array[Array[T]] {
   let chunks = []
   let mut i = 0
-  while i < self.len {
+  while i < self.length() {
     let chunk = []
-    while i < self.len && pred(self[i]).not() {
+    while i < self.length() && pred(self[i]).not() {
       chunk.push(self[i])
       i = i + 1
     }
@@ -949,11 +891,7 @@ pub fn reserve_capacity[T](self : Array[T], capacity : Int) -> Unit {
   if self.capacity() >= capacity {
     return
   }
-  let new_buf : UninitializedArray[T] = UninitializedArray::make(capacity)
-  for i = 0; i < self.length(); i = i + 1 {
-    new_buf[i] = self.buf[i]
-  }
-  self.buf = new_buf
+  self.resize_buffer(capacity)
 }
 
 /// Shrinks the capacity of the vector as much as possible.
@@ -973,9 +911,21 @@ pub fn shrink_to_fit[T](self : Array[T]) -> Unit {
   if self.capacity() <= self.length() {
     return
   }
-  let new_buf : UninitializedArray[T] = UninitializedArray::make(self.length())
-  for i = 0; i < self.length(); i = i + 1 {
-    new_buf[i] = self.buf[i]
+  self.resize_buffer(self.length())
+}
+
+/// Converts the vector to a string.
+pub fn to_string[T : Show](self : Array[T]) -> String {
+  if self.length() == 0 {
+    return "[]"
   }
-  self.buf = new_buf
+  let first = self.buffer()[0]
+  // CR: format issues
+  for i = 1, init = "[\(first)" {
+    if i >= self.length() {
+      break "\(init)]"
+    }
+    let cur = self.buffer()[i]
+    continue i + 1, "\(init), \(cur)"
+  }
 }

--- a/builtin/arraycore.mbt
+++ b/builtin/arraycore.mbt
@@ -1,0 +1,69 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+priv type UninitializedArray[T] FixedArray[UnsafeMaybeUninit[T]]
+
+fn UninitializedArray::make[T](size : Int) -> UninitializedArray[T] = "%make_array_maybe_uninit"
+
+fn op_get[T](self : UninitializedArray[T], index : Int) -> T = "%array_get"
+
+fn op_set[T](self : UninitializedArray[T], index : Int, value : T) = "%array_set"
+
+fn set_null[T](self : UninitializedArray[T], index : Int) = "%array_set_null"
+
+/// An `Array` is a collection of values that supports random access and can
+/// grow in size.
+struct Array[T] {
+  mut buf : UninitializedArray[T]
+  mut len : Int
+}
+
+fn Array::make_uninit[T](len : Int) -> Array[T] {
+  { buf: UninitializedArray::make(len), len }
+}
+
+/// Creates a new, empty vector with a specified initial capacity.
+pub fn Array::with_capacity[T](cap : Int) -> Array[T] {
+  { buf: UninitializedArray::make(cap), len: 0 }
+}
+
+/// Returns the number of elements in the vector.
+pub fn length[T](self : Array[T]) -> Int {
+  self.len
+}
+
+fn set_length[T](self : Array[T], new_len : Int) -> Unit {
+  // assert new_len >= 0 && new_len <= self.buf.len
+  if new_len < self.len {
+    for i = new_len; i < self.len; i = i + 1 {
+      self.buf.set_null(i)
+    }
+  }
+  self.len = new_len
+}
+
+fn buffer[T](self : Array[T]) -> UninitializedArray[T] {
+  self.buf
+}
+
+fn resize_buffer[T](self : Array[T], new_capacity : Int) -> Unit {
+  let new_buf = UninitializedArray::make(new_capacity)
+  let old_buf = self.buf
+  let old_cap = old_buf.0.length()
+  let copy_len = if old_cap < new_capacity { old_cap } else { new_capacity }
+  for i = 0; i < copy_len; i = i + 1 {
+    new_buf[i] = old_buf[i]
+  }
+  self.buf = new_buf
+}

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -63,7 +63,7 @@ pub fn op_as_view[T](self : Array[T], ~start : Int, ~end : Int) -> ArrayView[T] 
   } else if start > end {
     abort("Slice start index greater than end index")
   }
-  ArrayView::{ buf: self.buf, start, len: end - start }
+  ArrayView::{ buf: self.buffer(), start, len: end - start }
 }
 
 pub fn op_as_view[T](


### PR DESCRIPTION
This PR refactor "builtin/array.mbt" to "builtin/arraycore.mbt" and "builtin/array.mbt".

The file "builtin/arraycore.mbt" contains core primitives to implement an array. And "builtin/array.mbt" has zero knowledge about what's the underlying type of `Array`. 

This abstraction make it easier to introducing compiling array to js native array.

This PR also fix the memleak issue.