### PR TITLE
Fix blit from fixed array

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -21,13 +21,7 @@ pub fn Array::new[T]() -> Array[T] {
 pub fn Array::from_fixed_array[T](arr : FixedArray[T]) -> Array[T] {
   let len = arr.length()
   let arr2 = Array::make_uninit(len)
-  UninitializedArray::unsafe_blit(
-    arr2.buffer(),
-    0,
-    UninitializedArray::from(arr),
-    0,
-    len,
-  )
+  UninitializedArray::unsafe_blit_fixed(arr2.buffer(), 0, arr, 0, len)
   arr2
 }
 

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -22,6 +22,22 @@ pub fn Array::unsafe_blit[A](
   FixedArray::unsafe_blit(dst.buf.0, dst_offset, src.buf.0, src_offset, len)
 }
 
+pub fn Array::unsafe_blit_fixed[A](
+  dst : Array[A],
+  dst_offset : Int,
+  src : FixedArray[A],
+  src_offset : Int,
+  len : Int
+) -> Unit {
+  UninitializedArray::unsafe_blit_fixed(
+    dst.buf,
+    dst_offset,
+    src,
+    src_offset,
+    len,
+  )
+}
+
 pub fn Array::blit_to[A](
   self : Array[A],
   dst : Array[A],

--- a/builtin/arraycore.mbt
+++ b/builtin/arraycore.mbt
@@ -22,8 +22,6 @@ fn op_set[T](self : UninitializedArray[T], index : Int, value : T) = "%array_set
 
 fn set_null[T](self : UninitializedArray[T], index : Int) = "%array_set_null"
 
-fn UninitializedArray::from[T](self : FixedArray[T]) -> UninitializedArray[T] = "%identity"
-
 fn UninitializedArray::unsafe_blit[T](
   dst : UninitializedArray[T],
   dst_offset : Int,
@@ -32,6 +30,19 @@ fn UninitializedArray::unsafe_blit[T](
   len : Int
 ) -> Unit {
   FixedArray::unsafe_blit(dst.0, dst_offset, src.0, src_offset, len)
+}
+
+/// @intrinsic %array.copy
+fn UninitializedArray::unsafe_blit_fixed[T](
+  dst : UninitializedArray[T],
+  dst_offset : Int,
+  src : FixedArray[T],
+  src_offset : Int,
+  len : Int
+) -> Unit {
+  for i = len - 1; i >= 0; i = i - 1 {
+    dst[dst_offset + i] = src[src_offset + i]
+  }
 }
 
 /// An `Array` is a collection of values that supports random access and can

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -97,6 +97,7 @@ impl Array {
   swap[T](Self[T], Int, Int) -> Unit
   to_string[T : Show](Self[T]) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
+  unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
   with_capacity[T](Int) -> Self[T]
 }
 

--- a/builtin/test/array_test.mbt
+++ b/builtin/test/array_test.mbt
@@ -15,7 +15,8 @@
 test {
   inspect(Array::from_fixed_array([1, 2, 3, 4]), content="[1, 2, 3, 4]")?
   inspect(
-    Array::from_fixed_array([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }])
+    Array::from_fixed_array([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }]),
+    content="[{x: 1}, {x: 2}, {x: 3}, {x: 4}]",
   )?
 }
 

--- a/builtin/test/array_test.mbt
+++ b/builtin/test/array_test.mbt
@@ -14,4 +14,12 @@
 
 test {
   inspect(Array::from_fixed_array([1, 2, 3, 4]), content="[1, 2, 3, 4]")?
+  inspect(
+    Array::from_fixed_array([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }])
+  )?
 }
+
+// For testing purposes
+priv struct T {
+  mut x : Int
+} derive(Eq, Show, Debug)


### PR DESCRIPTION
Previous implementation has bug on `FixedArray[T]` while T is a ref type. This PR fixed it.

This PR also add a pub `Array::unsafe_blit_fixed` method.