### PR TITLE
feat: add Option::as_iter

### DIFF
--- a/option/option.mbt
+++ b/option/option.mbt
@@ -321,3 +321,36 @@ pub fn unwrap[X](self : X?) -> X {
 pub fn Option::default[X]() -> X? {
   None
 }
+
+pub fn as_iter[T](self : T?) -> Iter[T] {
+  match self {
+    Some(v) => Iter::singleton(v)
+    None => Iter::empty()
+  }
+}
+
+test "as_iter" {
+  let x = Option::Some(42)
+  let exb = Buffer::make(0)
+  x.as_iter().iter(
+    fn(x) {
+      exb.write_string(x.to_string())
+      exb.write_char('\n')
+    },
+  )
+  exb.expect(
+    content=
+      #|42
+      #|
+    ,
+  )?
+  exb.reset()
+  let y : Int? = None
+  y.as_iter().iter(
+    fn(x) {
+      exb.write_string(x.to_string())
+      exb.write_char('\n')
+    },
+  )
+  exb.expect(content="")?
+}

--- a/option/option.mbti
+++ b/option/option.mbti
@@ -11,6 +11,7 @@ fn when[T](Bool, () -> T) -> T?
 
 // Types and methods
 impl Option {
+  as_iter[T](T?) -> Iter[T]
   bind[T, U](T?, (T) -> U?) -> U?
   compare[X : Compare + Eq](X?, X?) -> Int
   default[X]() -> X?


### PR DESCRIPTION
This new method allows an `Option` to be converted into an iterator, making it easier to use with `Iter::flat_map`.