### PR TITLE
rename `contain`/`member` to `contains`

### DIFF
--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -45,7 +45,7 @@ pub fn Set::make[T]() -> Set[T] {
 }
 
 /// Lookup a value from the hash set
-pub fn contain[T : Eq + Hash](self : Set[T], key : T) -> Bool {
+pub fn contains[T : Eq + Hash](self : Set[T], key : T) -> Bool {
   loop self, key.hash() {
     Empty, _ => false
     Leaf(key1), _ => key == key1

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -18,11 +18,11 @@ test "Set" {
     i, map => continue i + 1, map.add(i)
   }
   for i = 0; i < 100; i = i + 1 {
-    @assertion.assert_eq((i, map.contain(i)), (i, true))?
+    @assertion.assert_eq((i, map.contains(i)), (i, true))?
   }
-  inspect((100, map.contain(100)), content="(100, false)")?
+  inspect((100, map.contains(100)), content="(100, false)")?
   let map = map.add(100)
-  inspect((100, map.contain(100)), content="(100, true)")?
+  inspect((100, map.contains(100)), content="(100, true)")?
 }
 
 test "Set::size" {
@@ -39,15 +39,15 @@ test "Set::remove" {
     i, map => continue i + 1, map.add(i)
   }
   for i = 0; i < 100; i = i + 1 {
-    @assertion.assert_eq((i, map.contain(i)), (i, true))?
+    @assertion.assert_eq((i, map.contains(i)), (i, true))?
   }
   let map = loop 0, map {
     100, map => map.remove(100) // test for removing non-existing element
     i, map => continue i + 2, map.remove(i)
   }
   for i = 0; i < 100; i = i + 2 {
-    @assertion.assert_eq(map.contain(i), false)?
-    @assertion.assert_eq(map.contain(i + 1), true)?
+    @assertion.assert_eq(map.contains(i), false)?
+    @assertion.assert_eq(map.contains(i + 1), true)?
   }
 }
 
@@ -65,10 +65,10 @@ test "Set::to_string" {
 
 test "Set::from_array" {
   let set = Set::["1", "2", "42"]
-  inspect(set.contain("1"), content="true")?
-  inspect(set.contain("2"), content="true")?
-  inspect(set.contain("42"), content="true")?
-  inspect(set.contain("43"), content="false")?
+  inspect(set.contains("1"), content="true")?
+  inspect(set.contains("2"), content="true")?
+  inspect(set.contains("42"), content="true")?
+  inspect(set.contains("43"), content="false")?
 }
 
 test "Set::is_empty" {

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -7,7 +7,7 @@ type Set
 impl Set {
   add[T : Eq + Hash](Self[T], T) -> Self[T]
   as_iter[T](Self[T]) -> Iter[T]
-  contain[T : Eq + Hash](Self[T], T) -> Bool
+  contains[T : Eq + Hash](Self[T], T) -> Bool
   debug_write[T : Debug](Self[T], Buffer) -> Unit
   from_array[T : Eq + Hash](Array[T]) -> Self[T]
   is_empty[T](Self[T]) -> Bool

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -530,7 +530,7 @@ pub fn op_add[T](self : List[T], other : List[T]) -> List[T] {
 }
 
 /// Check if the list contains the value.
-pub fn contain[T : Eq](self : List[T], value : T) -> Bool {
+pub fn contains[T : Eq](self : List[T], value : T) -> Bool {
   loop self {
     Nil => false
     Cons(x, xs) => if x == value { true } else { continue xs }

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -18,7 +18,7 @@ impl List {
   as_iter[T](Self[T]) -> Iter[T]
   concat[T](Self[T], Self[T]) -> Self[T]
   concat_map[T, U](Self[T], (T) -> Self[U]) -> Self[U]
-  contain[T : Eq](Self[T], T) -> Bool
+  contains[T : Eq](Self[T], T) -> Bool
   debug_write[T : Debug](Self[T], Buffer) -> Unit
   default[X]() -> Self[X]
   drop[T](Self[T], Int) -> Self[T]

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -249,11 +249,11 @@ test "sort" {
 
 test "contain" {
   let ls = List::[1, 2, 3]
-  inspect(ls.contain(1), content="true")?
-  inspect(ls.contain(2), content="true")?
-  inspect(ls.contain(3), content="true")?
-  inspect(ls.contain(0), content="false")?
-  inspect(ls.contain(4), content="false")?
+  inspect(ls.contains(1), content="true")?
+  inspect(ls.contains(2), content="true")?
+  inspect(ls.contains(3), content="true")?
+  inspect(ls.contains(0), content="false")?
+  inspect(ls.contains(4), content="false")?
 }
 
 test "unfold" {

--- a/immut/sorted_map/README.md
+++ b/immut/sorted_map/README.md
@@ -40,14 +40,14 @@ let map = Map::[("a", 1), ("b", 2), ("c", 3)]
 let map = map.remove("a")
 ```
 
-### Member
+### Contains
 
-You can use `member()` to check whether a key exists.
+You can use `contains()` to check whether a key exists.
 
 ```moonbit
 let map = Map::[("a", 1), ("b", 2), ("c", 3)]
-map.member("a") // true
-map.member("d") // false
+map.contains("a") // true
+map.contains("d") // false
 ```
 
 ### Size

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -49,15 +49,15 @@ test "lookup" {
   @assertion.assert_eq(m.lookup(4), None)?
 }
 
-test "member" {
+test "contains" {
   let m = Map::[(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")]
   inspect(
     m.debug_tree(),
     content="(3,three,(1,one,(0,zero,_,_),(2,two,_,_)),(8,eight,_,_))",
   )?
-  @assertion.assert_eq(m.member(8), true)?
-  @assertion.assert_eq(m.member(2), true)?
-  @assertion.assert_eq(m.member(4), false)?
+  @assertion.assert_eq(m.contains(8), true)?
+  @assertion.assert_eq(m.contains(2), true)?
+  @assertion.assert_eq(m.contains(4), false)?
 }
 
 test "size" {

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -9,6 +9,7 @@ fn singleton[K, V](K, V) -> Map[K, V]
 type Map
 impl Map {
   as_iter[K, V](Self[K, V]) -> Iter[Tuple[K, V]]
+  contains[K : Compare + Eq, V](Self[K, V], K) -> Bool
   debug_write[K : Debug, V : Debug](Self[K, V], Buffer) -> Unit
   elems[K, V](Self[K, V]) -> Array[V]
   filter[K : Compare + Eq, V](Self[K, V], (V) -> Bool) -> Self[K, V]
@@ -25,7 +26,6 @@ impl Map {
   lookup[K : Compare + Eq, V](Self[K, V], K) -> V?
   map[K, X, Y](Self[K, X], (X) -> Y) -> Self[K, Y]
   map_with_key[K, X, Y](Self[K, X], (K, X) -> Y) -> Self[K, Y]
-  member[K : Compare + Eq, V](Self[K, V], K) -> Bool
   op_equal[K : Eq, V : Eq](Self[K, V], Self[K, V]) -> Bool
   op_get[K : Compare + Eq, V](Self[K, V], K) -> V?
   remove[K : Compare + Eq, V](Self[K, V], K) -> Self[K, V]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -24,7 +24,7 @@ pub fn singleton[K, V](key : K, value : V) -> Map[K, V] {
 
 /// Check if the map contains a key.
 /// O(log n).
-pub fn member[K : Compare, V](self : Map[K, V], key : K) -> Bool {
+pub fn contains[K : Compare, V](self : Map[K, V], key : K) -> Bool {
   loop self {
     Empty => false
     Tree(k, l, r, ..) => {

--- a/immut/sorted_set/README.md
+++ b/immut/sorted_set/README.md
@@ -45,14 +45,14 @@ You can use `remove` to remove a specific value or use `remove_min` to remove th
 (ImmutableSet::[3, 4, 5]).remove_min() // ImmutableSet::[4, 5]
 ```
 
-### Max & Min & Contain
+### Max & Min & Contains
 
-You can use `contain` to query whether an element is in the set.
+You can use `contains` to query whether an element is in the set.
 
 ```moonbit
 let set = ImmutableSet::from_array([1, 2, 3, 4])
-set.contain(1) // true
-set.contain(5) // false
+set.contains(1) // true
+set.contains(5) // false
 ```
 
 You can also use `min` and `max` to obtain the minimum or maximum value in the set. When the set is empty, an error will be reported, and they have corresponding Option versions to handle this.

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -255,12 +255,12 @@ pub fn is_empty[T : Compare](self : ImmutableSet[T]) -> Bool {
 }
 
 /// Return true if value contain in ImmutableSet
-pub fn contain[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
+pub fn contains[T : Compare](self : ImmutableSet[T], value : T) -> Bool {
   match self {
     Empty => false
     Node(~left, ~right, value=node_value, ..) => {
       let compare_result = value.compare(node_value)
-      compare_result == 0 || (if compare_result < 0 { left } else { right }).contain(
+      compare_result == 0 || (if compare_result < 0 { left } else { right }).contains(
         value,
       )
     }

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -148,10 +148,10 @@ test "split" {
 
 test "contain" {
   inspect(
-    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).contain(5),
+    ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].add(5).contains(5),
     content="true",
   )?
-  inspect(ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].contain(5), content="false")?
+  inspect(ImmutableSet::[7, 2, 9, 4, 6, 3, 8, 1].contains(5), content="false")?
 }
 
 test "to_array" {

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -7,7 +7,7 @@ type ImmutableSet
 impl ImmutableSet {
   add[T : Compare + Eq](Self[T], T) -> Self[T]
   as_iter[T](Self[T]) -> Iter[T]
-  contain[T : Compare + Eq](Self[T], T) -> Bool
+  contains[T : Compare + Eq](Self[T], T) -> Bool
   debug_write[T : Debug](Self[T], Buffer) -> Unit
   default[T : Default]() -> Self[T]
   diff[T : Compare + Eq](Self[T], Self[T]) -> Self[T]

--- a/sorted_set/README.md
+++ b/sorted_set/README.md
@@ -38,8 +38,8 @@ Whether an element is in the set.
 
 ```moonbit
 let set = MutableSet::from_array([1, 2, 3, 4])
-set.contain(1) // true
-set.contain(5) // false
+set.contains(1) // true
+set.contains(5) // false
 ```
 
 Iterates over the elements in the set.


### PR DESCRIPTION
Rename the function `contain`/`member` in `immut/list`, `sorted_set`, `sorted_map` to `contains` to align with other collections.