### PR TITLE
rename `forall/exists` to `all/any` in sorted_set

### DIFF
--- a/immut/sorted_set/README.md
+++ b/immut/sorted_set/README.md
@@ -116,13 +116,13 @@ ImmutableSet::[1, 2, 3, 4, 5].fold(0, fn(acc, x) { acc + x }) // 15
 ImmutableSet::[1, 2, 3].map(fn(x){ x * 2}) // ImmutableSet::[2, 4, 6]
 ```
 
-### Forall & Exists
+### All & Any
 
-`forall` and `exists` can detect whether all elements in the set match or if there are elements that match.
+`all` and `any` can detect whether all elements in the set match or if there are elements that match.
 
 ```moonbit
-ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0}) // true
-ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0}) // true
+ImmutableSet::[2, 4, 6].all(fn(v) { v % 2 == 0}) // true
+ImmutableSet::[1, 4, 3].any(fn(v) { v % 2 == 0}) // true
 ```
 
 ### Stringify

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -469,14 +469,14 @@ pub fn map[T : Compare, U : Compare](
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0}))
+/// println(ImmutableSet::[2, 4, 6].all(fn(v) { v % 2 == 0}))
 /// // output: true
 /// ```
-pub fn forall[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
+pub fn all[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
   match self {
     Empty => true
     Node(~left, ~value, ~right, ..) =>
-      f(value) && left.forall(f) && right.forall(f)
+      f(value) && left.all(f) && right.all(f)
   }
 }
 
@@ -485,14 +485,14 @@ pub fn forall[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
 /// # Example
 /// 
 /// ```
-/// println(ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0}))
+/// println(ImmutableSet::[1, 4, 3].any(fn(v) { v % 2 == 0}))
 /// // output: true
 /// ```
-pub fn exists[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
+pub fn any[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
   match self {
     Empty => false
     Node(~left, ~value, ~right, ..) =>
-      f(value) || left.exists(f) || right.exists(f)
+      f(value) || left.any(f) || right.any(f)
   }
 }
 

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -475,8 +475,7 @@ pub fn map[T : Compare, U : Compare](
 pub fn all[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
   match self {
     Empty => true
-    Node(~left, ~value, ~right, ..) =>
-      f(value) && left.all(f) && right.all(f)
+    Node(~left, ~value, ~right, ..) => f(value) && left.all(f) && right.all(f)
   }
 }
 
@@ -491,8 +490,7 @@ pub fn all[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
 pub fn any[T : Compare](self : ImmutableSet[T], f : (T) -> Bool) -> Bool {
   match self {
     Empty => false
-    Node(~left, ~value, ~right, ..) =>
-      f(value) || left.any(f) || right.any(f)
+    Node(~left, ~value, ~right, ..) => f(value) || left.any(f) || right.any(f)
   }
 }
 

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -107,14 +107,14 @@ test "map" {
   )?
 }
 
-test "forall" {
-  inspect(ImmutableSet::[2, 4, 6].forall(fn(v) { v % 2 == 0 }), content="true")?
-  inspect(ImmutableSet::[1, 3, 5].forall(fn(v) { v % 2 == 0 }), content="false")?
+test "all" {
+  inspect(ImmutableSet::[2, 4, 6].all(fn(v) { v % 2 == 0 }), content="true")?
+  inspect(ImmutableSet::[1, 3, 5].all(fn(v) { v % 2 == 0 }), content="false")?
 }
 
-test "exists" {
-  inspect(ImmutableSet::[1, 4, 3].exists(fn(v) { v % 2 == 0 }), content="true")?
-  inspect(ImmutableSet::[1, 5, 3].exists(fn(v) { v % 2 == 0 }), content="false")?
+test "any" {
+  inspect(ImmutableSet::[1, 4, 3].any(fn(v) { v % 2 == 0 }), content="true")?
+  inspect(ImmutableSet::[1, 5, 3].any(fn(v) { v % 2 == 0 }), content="false")?
 }
 
 test "fold" {

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -6,16 +6,16 @@ package moonbitlang/core/immut/sorted_set
 type ImmutableSet
 impl ImmutableSet {
   add[T : Compare + Eq](Self[T], T) -> Self[T]
+  all[T : Compare + Eq](Self[T], (T) -> Bool) -> Bool
+  any[T : Compare + Eq](Self[T], (T) -> Bool) -> Bool
   as_iter[T](Self[T]) -> Iter[T]
   contains[T : Compare + Eq](Self[T], T) -> Bool
   debug_write[T : Debug](Self[T], Buffer) -> Unit
   default[T : Default]() -> Self[T]
   diff[T : Compare + Eq](Self[T], Self[T]) -> Self[T]
   disjoint[T : Compare + Eq](Self[T], Self[T]) -> Bool
-  exists[T : Compare + Eq](Self[T], (T) -> Bool) -> Bool
   filter[T : Compare + Eq](Self[T], (T) -> Bool) -> Self[T]
   fold[T : Compare + Eq, U](Self[T], (U, T) -> U, ~init : U) -> U
-  forall[T : Compare + Eq](Self[T], (T) -> Bool) -> Bool
   from_array[T : Compare + Eq](Array[T]) -> Self[T]
   inter[T : Compare + Eq](Self[T], Self[T]) -> Self[T]
   is_empty[T : Compare + Eq](Self[T]) -> Bool


### PR DESCRIPTION
 Both `forall/exists` and `all/any` make sense to me, but `all/any` are shorter. So in this PR, the `forall/exists` in sorted_set will be renamed to align with other collections.

