### PR TITLE
merge `T::with_capacity` and `T::new`, rename `T::make()` to `T::new()`

### DIFF
--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -410,7 +410,7 @@ test "shrink_to_fit_2" {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(5)
+  let buf = Buffer::new(size_hint=5)
   [1, 2, 3, 4, 5].as_iter().iter(fn { x => buf.write_string(x.to_string()) })
   inspect(buf, content="12345")?
   buf.reset()

--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -103,7 +103,7 @@ test "iter" {
 }
 
 test "iter_rev" {
-  let v = with_capacity(3)
+  let v = Array::new(capacity=3)
   v.push(3)
   v.push(4)
   v.push(5)
@@ -395,7 +395,7 @@ test "reserve_capacity_2" {
 }
 
 test "shrink_to_fit" {
-  let v = with_capacity(10)
+  let v = Array::new(capacity=10)
   v.push(1)
   v.push(2)
   v.push(3)

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -913,7 +913,7 @@ pub fn as_iter[T](self : FixedArray[T]) -> Iter[T] {
 test "as_iter" {
   let arr : FixedArray[_] = [1, 2, 3, 4, 5]
   let iter = arr.as_iter()
-  let exb = Buffer::make(0)
+  let exb = Buffer::new()
   let mut i = 0
   iter.iter(
     fn(x) {

--- a/array/sort_test.mbt
+++ b/array/sort_test.mbt
@@ -23,7 +23,7 @@ fn test_sort(f : (Array[Int]) -> Unit) -> Result[Unit, String] {
   f(arr)
   @assertion.assert_eq(arr, [1, 2, 3, 4, 5])?
   {
-    let arr = with_capacity(1000)
+    let arr = Array::new(capacity=1000)
     for i = 0; i < 1000; i = i + 1 {
       arr.push(1000 - i - 1)
     }
@@ -31,7 +31,7 @@ fn test_sort(f : (Array[Int]) -> Unit) -> Result[Unit, String] {
       arr.swap(i, i - 1)
     }
     f(arr)
-    let expected = with_capacity(1000)
+    let expected = Array::new(capacity=1000)
     for i = 0; i < 1000; i = i + 1 {
       expected.push(i)
     }

--- a/assertion/assertion.mbt
+++ b/assertion/assertion.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 fn debug_string[T : Debug](t : T) -> String {
-  let buf = Buffer::make(50)
+  let buf = Buffer::new(size_hint=50)
   t.debug_write(buf)
   buf.to_string()
 }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Creates a new, empty vector.
-pub fn Array::new[T]() -> Array[T] {
-  []
-}
-
 /// Creates a new vector from an array.
 pub fn Array::from_fixed_array[T](arr : FixedArray[T]) -> Array[T] {
   let len = arr.length()
@@ -701,7 +696,7 @@ pub fn flatten[T](self : Array[Array[T]]) -> Array[T] {
 /// [3, 4].repeat(2)
 /// ```
 pub fn repeat[T](self : Array[T], times : Int) -> Array[T] {
-  let v = Array::with_capacity(self.length() * times)
+  let v = Array::new(capacity=self.length() * times)
   for i = 0; i < times; i = i + 1 {
     v.append(self)
   }
@@ -841,7 +836,7 @@ pub fn chunks[T](self : Array[T], size : Int) -> Array[Array[T]] {
   let chunks = []
   let mut i = 0
   while i < self.length() {
-    let chunk = Array::with_capacity(size)
+    let chunk = Array::new(capacity=size)
     for j = 0; j < size && i < self.length(); j = j + 1 {
       chunk.push(self[i])
       i = i + 1

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -234,7 +234,7 @@ pub fn append[T](self : Array[T], other : Array[T]) -> Unit {
 ///
 /// # Example
 /// ```
-/// let v = Array::with_capacity(3)
+/// let v = Array::new(3)
 /// v.push(3)
 /// v.push(4)
 /// v.push(5)
@@ -257,7 +257,7 @@ pub fn iter_rev[T](self : Array[T], f : (T) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let v = Array::with_capacity(3)
+/// let v = Array::new(3)
 /// v.push(3)
 /// v.push(4)
 /// v.push(5)
@@ -914,7 +914,7 @@ pub fn reserve_capacity[T](self : Array[T], capacity : Int) -> Unit {
 /// # Example
 ///
 /// ```
-/// let v = Array::with_capacity(10)
+/// let v = Array::new(10)
 /// v.push(1)
 /// v.push(2)
 /// v.push(3)

--- a/builtin/arraycore.mbt
+++ b/builtin/arraycore.mbt
@@ -56,9 +56,13 @@ fn Array::make_uninit[T](len : Int) -> Array[T] {
   { buf: UninitializedArray::make(len), len }
 }
 
-/// Creates a new, empty vector with a specified initial capacity.
-pub fn Array::with_capacity[T](cap : Int) -> Array[T] {
-  { buf: UninitializedArray::make(cap), len: 0 }
+/// Creates a new vector.
+pub fn Array::new[T](~capacity : Int = 0) -> Array[T] {
+  if capacity == 0 {
+    []
+  } else {
+    { buf: UninitializedArray::make(capacity), len: 0 }
+  }
 }
 
 /// Returns the number of elements in the vector.

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -27,7 +27,7 @@ pub fn ArgsLoc::to_string(self : ArgsLoc) -> String {
 }
 
 pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
-  let buf = Buffer::make(10)
+  let buf = Buffer::new(size_hint=10)
   buf.write_char('[')
   for i = 0; i < self.0.length(); i = i + 1 {
     if i != 0 {

--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -20,7 +20,7 @@
 /// # Usage
 ///
 /// ```
-/// let buf = Buffer::make(100)
+/// let buf = Buffer::new(size_hint=100)
 /// buf.write_string("Tes")
 /// buf.write_char("t")
 /// println(buf.to_string()) // output: Test
@@ -41,7 +41,7 @@ pub fn expect(
   self.reset()
   if current != content {
     fn repr(s : String) -> String {
-      let buf = Buffer::make(10)
+      let buf = Buffer::new()
       s.debug_write(buf)
       buf.to_string()
     }
@@ -80,9 +80,15 @@ pub fn to_string(self : Buffer) -> String {
   self.bytes.sub_string(0, self.len)
 }
 
-/// Create a buffer with initial capacity.
+/// Create a buffer with initial capacity. 
+/// This function is deprecated, use `Buffer::new` instead.
 pub fn Buffer::make(initial_capacity : Int) -> Buffer {
-  let initial = if initial_capacity < 1 { 1 } else { initial_capacity }
+  Buffer::new(size_hint=initial_capacity)
+}
+
+/// Create a buffer with initial capacity.
+pub fn Buffer::new(~size_hint : Int = 0) -> Buffer {
+  let initial = if size_hint < 1 { 1 } else { size_hint }
   let bytes = Bytes::make(initial)
   { bytes, len: 0, initial_bytes: bytes }
 }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -315,6 +315,7 @@ impl Option {
   debug_write[X : Debug](X?, Buffer) -> Unit
   op_equal[X : Eq](X?, X?) -> Bool
   to_string[X : Show](X?) -> String
+  unwrap[X](X?) -> X
 }
 impl Result {
   debug_write[T : Debug, E : Debug](Self[T, E], Buffer) -> Unit

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -72,7 +72,7 @@ impl Array {
   map_inplace[T](Self[T], (T) -> T) -> Unit
   mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
   mapi_inplace[T](Self[T], (Int, T) -> T) -> Unit
-  new[T]() -> Self[T]
+  new[T](~capacity : Int = ..) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
   op_as_view[T](Self[T], ~start : Int, ~end : Int) -> ArrayView[T]
   op_equal[T : Eq](Self[T], Self[T]) -> Bool
@@ -98,7 +98,6 @@ impl Array {
   to_string[T : Show](Self[T]) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
-  with_capacity[T](Int) -> Self[T]
 }
 
 type ArrayView

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -113,6 +113,7 @@ type Buffer
 impl Buffer {
   expect(Self, ~content : String = .., ~loc : SourceLoc = _, ~args_loc : ArgsLoc = _) -> Result[Unit, String]
   make(Int) -> Self
+  new(~size_hint : Int = ..) -> Self
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes
   to_string(Self) -> String

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -41,7 +41,7 @@ pub fn to_string(self : Int64) -> String {
   // The min and max value of i64 are -9223372036854775808 and 9223372036854775807,
   // so max=20 is enough.
 
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   if self < 0L {
     buf.write_char('-')
   }
@@ -69,7 +69,7 @@ pub fn to_string(self : Int) -> String {
   // The min and max value of i32 are -2147483648 and 2147483647,
   // so max=11 is enough.
 
-  let buf = Buffer::make(11)
+  let buf = Buffer::new()
   if self < 0 {
     buf.write_char('-')
   }
@@ -148,7 +148,7 @@ pub fn inspect(
   let actual = obj.to_string()
   if actual != content {
     fn repr(s : String) -> String {
-      let buf = Buffer::make(10)
+      let buf = Buffer::new()
       s.debug_write(buf)
       buf.to_string()
     }

--- a/builtin/debug.mbt
+++ b/builtin/debug.mbt
@@ -19,7 +19,7 @@ pub trait Debug {
 
 /// print a value to the console using [Debug], with a tailing newline
 pub fn debug[X : Debug](x : X) -> Unit {
-  let buf = Buffer::make(10)
+  let buf = Buffer::new()
   x.debug_write(buf)
   println(buf.to_string())
 }

--- a/builtin/intrinsics_test.mbt
+++ b/builtin/intrinsics_test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // fn debug_string[T : Debug](t : T) -> String {
-//   let buf = Buffer::make(50)
+//   let buf = Buffer::new(size_hint=50)
 //   t.debug_write(buf)
 //   buf.to_string()
 // }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -14,21 +14,21 @@
 
 test "empty" {
   let iter = Iter::empty()
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.iter(fn { x => exb.write_char(x) })
   exb.expect()?
 }
 
 test "singleton" {
   let iter = Iter::singleton('1')
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.iter(fn { x => exb.write_char(x) })
   exb.expect(content="1")?
 }
 
 test "repeat" {
   let iter = Iter::repeat('1')
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.take(3).iter(fn { x => exb.write_char(x) })
   exb.expect(content="111")?
 }
@@ -40,14 +40,14 @@ test "count" {
 
 test "take" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.take(3).iter(fn { x => exb.write_char(x) })
   exb.expect(content="123")?
 }
 
 test "take2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.take(10).concat(Iter::repeat('6').take(1)).iter(
     fn { x => exb.write_char(x) },
   )
@@ -56,14 +56,14 @@ test "take2" {
 
 test "take_while" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.take_while(fn { x => x != '4' }).iter(fn { x => exb.write_char(x) })
   exb.expect(content="123")?
 }
 
 test "take_while2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.take_while(fn { x => x != '4' }).concat(singleton('6')).iter(
     fn { x => exb.write_char(x) },
   )
@@ -98,14 +98,14 @@ test "take_while5" {
 
 test "drop" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.drop(3).iter(fn { x => exb.write_char(x) })
   exb.expect(content="45")?
 }
 
 test "drop_while" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.drop_while(fn { x => x != '4' }).iter(fn { x => exb.write_char(x) })
   exb.expect(content="45")?
 }
@@ -120,7 +120,7 @@ test "drop_while2" {
 
 test "drop_while3" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   let res = iter.drop_while(fn { x => x < 3 }).concat(singleton(6)).find_first(
     fn {
       x => {
@@ -144,14 +144,14 @@ test "drop_while4" {
 
 test "filter" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.filter(fn { x => x != '4' }).iter(fn { x => exb.write_char(x) })
   exb.expect(content="1235")?
 }
 
 test "map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.map(fn { x => Char::from_int(x.to_int() + 1) }).iter(
     fn { x => exb.write_char(x) },
   )
@@ -160,7 +160,7 @@ test "map" {
 
 test "flat_map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.flat_map(fn { x => Iter::repeat(x).take(2) }).iter(
     fn { x => exb.write_char(x) },
   )
@@ -169,7 +169,7 @@ test "flat_map" {
 
 test "flat_map2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.flat_map(fn { x => Iter::singleton(x) }).iter(
     fn { x => exb.write_char(x) },
   )
@@ -200,21 +200,21 @@ test "find_first2" {
 
 test "tap" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.tap(fn { x => exb.write_char(x) }).iter(fn { x => exb.write_char(x) })
   exb.expect(content="1234512345")?
 }
 
 test "prepend" {
   let iter = test_from_array(['0', '1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.prepend('X').iter(fn { x => exb.write_char(x) })
   exb.expect(content="X012345")?
 }
 
 test "append" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   iter.append('6').iter(fn { x => exb.write_char(x) })
   exb.expect(content="123456")?
 }
@@ -223,7 +223,7 @@ test "concat" {
   let iter1 = test_from_array(['1', '2', '3'])
   let iter2 = test_from_array(['4', '5', '6'])
   let combined_iter = Iter::concat(iter1, iter2)
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   combined_iter.iter(fn { x => exb.write_char(x) })
   exb.expect(content="123456")?
 }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -309,7 +309,7 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 // Utils
 
 fn debug_entries[K : Show, V : Show](self : Map[K, V]) -> String {
-  let buf = Buffer::make(0)
+  let buf = Buffer::new()
   for i = 0; i < self.entries.length(); i = i + 1 {
     if i > 0 {
       buf.write_char(',')

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -411,7 +411,7 @@ pub fn as_iter[K, V](self : Map[K, V]) -> Iter[(K, V)] {
 
 /// Converts the hash map to an array.
 pub fn to_array[K, V](self : Map[K, V]) -> Array[(K, V)] {
-  let arr = Array::with_capacity(self.size)
+  let arr = Array::new(capacity=self.size)
   loop self.head {
     Some({ key, value, idx, .. }) => {
       arr.push((key, value))

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -59,13 +59,6 @@ struct Map[K, V] {
 
 // Implementations
 
-fn unwrap[X](self : X?) -> X {
-  match self {
-    None => panic()
-    Some(x) => x
-  }
-}
-
 fn power_2_above(x : Int, n : Int) -> Int {
   for i = x {
     if i >= n {

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -178,7 +178,7 @@ test "grow" {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   let map = { 1: "one", 2: "two", 3: "three" }
   map.as_iter().iter(
     fn(e) {
@@ -201,14 +201,14 @@ test "iter order" {
   let m = { "one": 1 }
   m["three"] = 3
   m["two"] = 2
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.iter(fn(k, v) { buf.write_string("[\(k)-\(v)]") })
   inspect(buf.to_string(), content="[one-1][three-3][two-2]")?
 }
 
 test "linked list" {
   let m = {  }
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(buf, content="end")?
   m["one"] = 1
@@ -216,7 +216,7 @@ test "linked list" {
   m["three"] = 3
   m["four"] = 4
   m["five"] = 5
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(
     buf,
@@ -230,7 +230,7 @@ test "linked list" {
     ,
   )?
   m.remove("three")
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(
     buf,
@@ -243,7 +243,7 @@ test "linked list" {
     ,
   )?
   m.set("two", 20)
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(
     buf,
@@ -256,7 +256,7 @@ test "linked list" {
     ,
   )?
   m.remove("one")
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(
     buf,
@@ -268,7 +268,7 @@ test "linked list" {
     ,
   )?
   m.remove("five")
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(
     buf,
@@ -279,7 +279,7 @@ test "linked list" {
     ,
   )?
   m.remove("two")
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(
     buf,
@@ -289,7 +289,7 @@ test "linked list" {
     ,
   )?
   m.remove("four")
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   m.debug_write(buf)
   inspect(buf, content="end")?
 }

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -26,3 +26,17 @@ pub fn to_string[X : Show](self : X?) -> String {
     Some(x) => "Some(" + x.to_string() + ")"
   }
 }
+
+/// Extract the value in `Some`.
+/// Panic if input is `None`.
+pub fn unwrap[X](self : X?) -> X {
+  match self {
+    None => panic()
+    Some(x) => x
+  }
+}
+
+test "panic" {
+  let _ : Int = Option::None.unwrap()
+
+}

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -62,7 +62,7 @@ pub fn debug_write(self : Char, buf : Buffer) -> Unit {
 
 test "debug_write" {
   fn repr(chr) {
-    let buf = Buffer::make(0)
+    let buf = Buffer::new(size_hint=0)
     debug_write(chr, buf)
     buf.to_string()
   }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -126,7 +126,7 @@ fn escape_to(s : String, buf : Buffer) -> Unit {
 /// This method only escapes characters below 0x20 and the following characters:
 /// `"`, `'`, `\`.
 pub fn escape(s : String) -> String {
-  let buf = Buffer::make(s.length())
+  let buf = Buffer::new(size_hint=s.length())
   escape_to(s, buf)
   buf.to_string()
 }

--- a/coverage/coverage_test.mbt
+++ b/coverage/coverage_test.mbt
@@ -58,7 +58,7 @@ test "log" {
     ("foo/foo", test_counter_a),
     MCons(("foo/bar", test_counter_b), MNil),
   )
-  let buf = Buffer::make(1024)
+  let buf = Buffer::new(size_hint=1024)
   coverage_log(counters, buf)
   let result = buf.to_string()
   let expected =

--- a/devec/README.md
+++ b/devec/README.md
@@ -15,10 +15,10 @@ let dv : Devec[Int] = Devec::new()
 let dv = Devec::[1, 2, 3, 4, 5]
 ```
 
-If you want to set the length at creation time to minimize expansion consumption, you can use `with_capacity()`.
+If you want to set the length at creation time to minimize expansion consumption, you can add parameter `capacity` to the `new()` function.
 
 ```moonbit
-let dv = Devec::with_capacity(100);
+let dv = Devec::new(capacity=10)
 ```
 
 ### Length & Capacity
@@ -50,7 +50,7 @@ println(dv.capacity()) // 10
 Also, you can use `shrink_to_fit` to shrink the capacity of the devec.
 
 ```moonbit
-let dv = Devec::with_capacity(10)
+let dv = Devec::new(capacity=10)
 dv.push_back(1)
 dv.push_back(2)
 dv.push_back(3)

--- a/devec/devec.mbt
+++ b/devec/devec.mbt
@@ -23,22 +23,17 @@ fn length[T](self : UninitializedArray[T]) -> Int {
 }
 
 /// Creates a new, empty devec.
-pub fn Devec::new[T]() -> Devec[T] {
-  Devec::{ buf: UninitializedArray::make(0), len: 0, head: 0, tail: 0 }
+pub fn Devec::new[T](~capacity : Int = 0) -> Devec[T] {
+  Devec::{ buf: UninitializedArray::make(capacity), len: 0, head: 0, tail: 0 }
 }
 
-/// Creates a new, empty devec with a specified initial capacity.
-pub fn Devec::with_capacity[T](cap : Int) -> Devec[T] {
-  Devec::{ buf: UninitializedArray::make(cap), len: 0, head: 0, tail: 0 }
-}
-
-test "with_capacity" {
-  let d : Devec[Int] = Devec::with_capacity(0)
+test "new_with_capacity" {
+  let d : Devec[Int] = Devec::new(capacity=0)
   @assertion.assert_eq(d.buf.length(), 0)?
 }
 
-test "with_capacity_non_zero" {
-  let d : Devec[Int] = Devec::with_capacity(10)
+test "new_with_capacity_non_zero" {
+  let d : Devec[Int] = Devec::new(capacity=10)
   @assertion.assert_eq(d.buf.length(), 10)?
 }
 
@@ -299,11 +294,11 @@ test "push_and_pop" {
 }
 
 test "push_realloc" {
-  let dv : Devec[Int] = Devec::with_capacity(0)
+  let dv : Devec[Int] = Devec::new()
   dv.push_front(1)
   @assertion.assert_eq(dv.pop_front(), Some(1))?
   @assertion.assert_true(dv.capacity() > 0)?
-  let dv : Devec[Int] = Devec::with_capacity(0)
+  let dv : Devec[Int] = Devec::new()
   dv.push_back(1)
   @assertion.assert_eq(dv.pop_back(), Some(1))?
   @assertion.assert_true(dv.capacity() > 0)?
@@ -723,22 +718,22 @@ pub fn as_iter[T](self : Devec[T]) -> Iter[T] {
 
 test "reserve and push" {
   // capacity > 0, len = 0
-  let a : Devec[Int?] = Devec::with_capacity(2)
+  let a : Devec[Int?] = Devec::new(capacity=2)
   a.push_back(Some(1))
   inspect(a.front(), content="Some(Some(1))")?
   inspect(a.back(), content="Some(Some(1))")?
   // capacity = 0, len = 0
-  let b : Devec[Int?] = Devec::with_capacity(0)
+  let b : Devec[Int?] = Devec::new(capacity=0)
   b.push_back(Some(1))
   inspect(b.front(), content="Some(Some(1))")?
   inspect(b.back(), content="Some(Some(1))")?
   // capacity > 0, len = 0
-  let c : Devec[Int?] = Devec::with_capacity(2)
+  let c : Devec[Int?] = Devec::new(capacity=2)
   c.push_front(Some(1))
   inspect(c.front(), content="Some(Some(1))")?
   inspect(c.back(), content="Some(Some(1))")?
   // capacity = 0, len = 0
-  let d : Devec[Int?] = Devec::with_capacity(0)
+  let d : Devec[Int?] = Devec::new(capacity=0)
   d.push_front(Some(1))
   inspect(d.front(), content="Some(Some(1))")?
   inspect(d.back(), content="Some(Some(1))")?

--- a/devec/devec.mbt
+++ b/devec/devec.mbt
@@ -328,20 +328,6 @@ pub fn op_get[T](self : Devec[T], index : Int) -> T {
   }
 }
 
-test "op_get" {
-  let dv = Devec::[1, 2, 3, 4, 5]
-  @assertion.assert_eq(dv[0], 1)?
-  @assertion.assert_eq(dv[1], 2)?
-  @assertion.assert_eq(dv[2], 3)?
-  @assertion.assert_eq(dv[3], 4)?
-  @assertion.assert_eq(dv[4], 5)?
-  let _ = dv.pop_front()
-  dv.push_back(1)
-  @assertion.assert_eq(dv[4], 1)?
-  dv.push_front(2)
-  @assertion.assert_eq(dv[0], 2)?
-}
-
 /// Sets the value of the element at the specified index.
 ///
 /// If you try to access an index which isn’t in the Devec, it will panic.
@@ -414,29 +400,6 @@ pub fn iter[T](self : Devec[T], f : (T) -> Unit) -> Unit {
   }
 }
 
-test "iter" {
-  let mut i = 0
-  let mut failed = false
-  Devec::[1, 2, 3, 4, 5].iter(
-    fn(elem) {
-      if elem != i + 1 {
-        failed = true
-      }
-      i = i + 1
-    },
-  )
-  @assertion.assert_false(failed)?
-}
-
-test "iter2" {
-  let v = Devec::[1, 2, 3, 4, 5]
-  v.pop_front_exn()
-  v.pop_back_exn()
-  let mut sum = 0
-  v.iter(fn { x => sum += x })
-  @assertion.assert_eq(sum, 9)?
-}
-
 /// Iterates over the elements of the devec with index.
 ///
 /// # Example
@@ -449,20 +412,6 @@ pub fn iteri[T](self : Devec[T], f : (Int, T) -> Unit) -> Unit {
   for i = 0; i < self.length(); i = i + 1 {
     f(i, self[i])
   }
-}
-
-test "iteri" {
-  let mut i = 0
-  let mut failed = false
-  Devec::[1, 2, 3, 4, 5].iteri(
-    fn(index, elem) {
-      if index != i || elem != i + 1 {
-        failed = true
-      }
-      i = i + 1
-    },
-  )
-  @assertion.assert_false(failed)?
 }
 
 /// Iterates over the elements of the devec in reversed turn.
@@ -479,20 +428,6 @@ pub fn iter_rev[T](self : Devec[T], f : (T) -> Unit) -> Unit {
   }
 }
 
-test "iter_rev" {
-  let mut i = 6
-  let mut failed = false
-  Devec::[1, 2, 3, 4, 5].iter_rev(
-    fn(elem) {
-      if elem != i - 1 {
-        failed = true
-      }
-      i = i - 1
-    },
-  )
-  @assertion.assert_false(failed)?
-}
-
 /// Iterates over the elements of the devec in reversed turn with index.
 ///
 /// # Example
@@ -505,22 +440,6 @@ pub fn iter_revi[T](self : Devec[T], f : (Int, T) -> Unit) -> Unit {
   for i = 0; i < self.len; i = i + 1 {
     f(i, self[self.len - i - 1])
   }
-}
-
-test "iter_revi" {
-  let mut i = 6
-  let mut j = 0
-  let mut failed = false
-  Devec::[1, 2, 3, 4, 5].iter_revi(
-    fn(index, elem) {
-      if index != j || elem != i - 1 {
-        failed = true
-      }
-      i = i - 1
-      j = j + 1
-    },
-  )
-  @assertion.assert_false(failed)?
 }
 
 /// Clears the devec, removing all values.
@@ -589,14 +508,6 @@ pub fn mapi[T, U](self : Devec[T], f : (Int, T) -> U) -> Devec[U] {
     }
     Devec::{ buf, len: self.len, head: 0, tail: self.len - 1 }
   }
-}
-
-test "mapi" {
-  let dv = Devec::[3, 4, 5]
-  let dvp = dv.mapi(fn(i, x) { x + i })
-  @assertion.assert_eq(dvp[0], 3)?
-  @assertion.assert_eq(dvp[1], 5)?
-  @assertion.assert_eq(dvp[2], 7)?
 }
 
 /// Test if the devec is empty.

--- a/devec/devec.mbt
+++ b/devec/devec.mbt
@@ -591,7 +591,7 @@ pub fn reserve_capacity[T](self : Devec[T], capacity : Int) -> Unit {
 /// # Example
 ///
 /// ```
-/// let dv = Devec::with_capacity(10)
+/// let dv = Devec::new(10)
 /// dv.push_back(1)
 /// dv.push_back(2)
 /// dv.push_back(3)

--- a/devec/devec.mbti
+++ b/devec/devec.mbti
@@ -20,7 +20,7 @@ impl Devec {
   length[T](Self[T]) -> Int
   map[T, U](Self[T], (T) -> U) -> Self[U]
   mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
-  new[T]() -> Self[T]
+  new[T](~capacity : Int = ..) -> Self[T]
   of[T](FixedArray[T]) -> Self[T]
   op_equal[T : Eq](Self[T], Self[T]) -> Bool
   op_get[T](Self[T], Int) -> T
@@ -34,7 +34,6 @@ impl Devec {
   reserve_capacity[T](Self[T], Int) -> Unit
   search[T : Eq](Self[T], T) -> Int?
   shrink_to_fit[T](Self[T]) -> Unit
-  with_capacity[T](Int) -> Self[T]
 }
 
 // Traits

--- a/devec/test/test.mbt
+++ b/devec/test/test.mbt
@@ -71,7 +71,7 @@ test "shrink_to_fit_2" {
 test "as_iter" {
   let dv = @devec.of([1, 2, 3, 4, 5])
   let iter = dv.as_iter()
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   let mut i = 0
   iter.iter(
     fn(x) {

--- a/devec/test/test.mbt
+++ b/devec/test/test.mbt
@@ -99,22 +99,22 @@ test "as_iter" {
 
 test "reserve and push" {
   // capacity > 0, len = 0
-  let a = @devec.with_capacity(2)
+  let a = @devec.new(capacity=2)
   a.push_back(Option::Some(1))
   inspect(a.front(), content="Some(Some(1))")?
   inspect(a.back(), content="Some(Some(1))")?
   // capacity = 0, len = 0
-  let b = @devec.with_capacity(0)
+  let b = @devec.new(capacity=0)
   b.push_back(Option::Some(1))
   inspect(b.front(), content="Some(Some(1))")?
   inspect(b.back(), content="Some(Some(1))")?
   // capacity > 0, len = 0
-  let c = @devec.with_capacity(2)
+  let c = @devec.new(capacity=2)
   c.push_front(Option::Some(1))
   inspect(c.front(), content="Some(Some(1))")?
   inspect(c.back(), content="Some(Some(1))")?
   // capacity = 0, len = 0
-  let d = @devec.with_capacity(0)
+  let d = @devec.new(capacity=0)
   d.push_front(Option::Some(1))
   inspect(d.front(), content="Some(Some(1))")?
   inspect(d.back(), content="Some(Some(1))")?

--- a/devec/test/test.mbt
+++ b/devec/test/test.mbt
@@ -96,3 +96,115 @@ test "as_iter" {
     content="6",
   )?
 }
+
+test "reserve and push" {
+  // capacity > 0, len = 0
+  let a = @devec.with_capacity(2)
+  a.push_back(Option::Some(1))
+  inspect(a.front(), content="Some(Some(1))")?
+  inspect(a.back(), content="Some(Some(1))")?
+  // capacity = 0, len = 0
+  let b = @devec.with_capacity(0)
+  b.push_back(Option::Some(1))
+  inspect(b.front(), content="Some(Some(1))")?
+  inspect(b.back(), content="Some(Some(1))")?
+  // capacity > 0, len = 0
+  let c = @devec.with_capacity(2)
+  c.push_front(Option::Some(1))
+  inspect(c.front(), content="Some(Some(1))")?
+  inspect(c.back(), content="Some(Some(1))")?
+  // capacity = 0, len = 0
+  let d = @devec.with_capacity(0)
+  d.push_front(Option::Some(1))
+  inspect(d.front(), content="Some(Some(1))")?
+  inspect(d.back(), content="Some(Some(1))")?
+}
+
+test "mapi" {
+  let dv = @devec.of([3, 4, 5])
+  let dvp = dv.mapi(fn(i, x) { x + i })
+  @assertion.assert_eq(dvp[0], 3)?
+  @assertion.assert_eq(dvp[1], 5)?
+  @assertion.assert_eq(dvp[2], 7)?
+}
+
+test "iter_rev" {
+  let mut i = 6
+  let mut failed = false
+  @devec.of([1, 2, 3, 4, 5]).iter_rev(
+    fn(elem) {
+      if elem != i - 1 {
+        failed = true
+      }
+      i = i - 1
+    },
+  )
+  @assertion.assert_false(failed)?
+}
+
+test "iter_revi" {
+  let mut i = 6
+  let mut j = 0
+  let mut failed = false
+  @devec.of([1, 2, 3, 4, 5]).iter_revi(
+    fn(index, elem) {
+      if index != j || elem != i - 1 {
+        failed = true
+      }
+      i = i - 1
+      j = j + 1
+    },
+  )
+  @assertion.assert_false(failed)?
+}
+
+test "iteri" {
+  let mut i = 0
+  let mut failed = false
+  @devec.of([1, 2, 3, 4, 5]).iteri(
+    fn(index, elem) {
+      if index != i || elem != i + 1 {
+        failed = true
+      }
+      i = i + 1
+    },
+  )
+  @assertion.assert_false(failed)?
+}
+
+test "iter" {
+  let mut i = 0
+  let mut failed = false
+  @devec.of([1, 2, 3, 4, 5]).iter(
+    fn(elem) {
+      if elem != i + 1 {
+        failed = true
+      }
+      i = i + 1
+    },
+  )
+  @assertion.assert_false(failed)?
+}
+
+test "iter2" {
+  let v = @devec.of([1, 2, 3, 4, 5])
+  v.pop_front_exn()
+  v.pop_back_exn()
+  let mut sum = 0
+  v.iter(fn { x => sum += x })
+  @assertion.assert_eq(sum, 9)?
+}
+
+test "op_get" {
+  let dv = @devec.of([1, 2, 3, 4, 5])
+  @assertion.assert_eq(dv[0], 1)?
+  @assertion.assert_eq(dv[1], 2)?
+  @assertion.assert_eq(dv[2], 3)?
+  @assertion.assert_eq(dv[3], 4)?
+  @assertion.assert_eq(dv[4], 5)?
+  let _ = dv.pop_front()
+  dv.push_back(1)
+  @assertion.assert_eq(dv[4], 1)?
+  dv.push_front(2)
+  @assertion.assert_eq(dv[0], 2)?
+}

--- a/double/ryu.mbt
+++ b/double/ryu.mbt
@@ -27,7 +27,7 @@ fn log10Pow2(e : Int) -> Int {
 }
 
 fn string_from_bytes(bytes : Bytes, from : Int, to : Int) -> String {
-  let buf = Buffer::make(bytes.length())
+  let buf = Buffer::new(size_hint=bytes.length())
   for i = from; i < to; i = i + 1 {
     buf.write_char(Char::from_int(bytes[i].to_int()))
   }

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -200,7 +200,7 @@ test "grow" {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   let map = HashMap::[(1, "one"), (2, "two"), (3, "three")]
   map.as_iter().iter(
     fn(e) {

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -213,7 +213,7 @@ test "symmetric_difference" {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   let map = of(["a", "b", "c"])
   map.as_iter().iter(fn(e) { buf.write_string("[\(e)]") })
   inspect(buf, content="[a][b][c]")?

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -76,7 +76,7 @@ pub fn as_iter[T](self : ImmutableVec[T]) -> Iter[T] {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   let v = ImmutableVec::[1, 2, 3]
   v.as_iter().iter(fn(e) { buf.write_string("[\(e)]") })
   inspect(buf, content="[1][2][3]")?

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -40,7 +40,7 @@ let segment_length : Int = 5
 
 let segment_mask : Int = 0b11111
 
-pub fn Map::make[K, V]() -> Map[K, V] {
+pub fn Map::new[K, V]() -> Map[K, V] {
   Empty
 }
 
@@ -242,7 +242,7 @@ pub fn to_string[K : Debug, V : Debug](self : Map[K, V]) -> String {
 }
 
 pub fn Map::from_array[K : Eq + Hash, V](arr : Array[(K, V)]) -> Map[K, V] {
-  loop arr.length(), Map::make() {
+  loop arr.length(), Map::new() {
     0, map => map
     n, map => {
       let (k, v) = arr[n - 1]

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -236,7 +236,7 @@ pub fn debug_write[K : Debug, V : Debug](
 }
 
 pub fn to_string[K : Debug, V : Debug](self : Map[K, V]) -> String {
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   self.debug_write(buf)
   buf.to_string()
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 test "HAMT::size" {
-  for i = 0, map = Map::make(); i < 20; i = i + 1, map = map.add(i, i) {
+  for i = 0, map = Map::new(); i < 20; i = i + 1, map = map.add(i, i) {
     @assertion.assert_eq(map.size(), i)?
   } else {
     @assertion.assert_eq(map.add(0, 0).size(), 20)?
@@ -21,7 +21,7 @@ test "HAMT::size" {
 }
 
 test "HAMT" {
-  let map = loop 0, Map::make() {
+  let map = loop 0, Map::new() {
     100, map => map
     i, map => continue i + 1, map.add(i, i)
   }
@@ -43,7 +43,7 @@ test "HAMT" {
 }
 
 test "HAMT::remove" {
-  let map = loop 0, Map::make() {
+  let map = loop 0, Map::new() {
     100, map => map
     i, map => continue i + 1, map.add(i, i)
   }
@@ -68,7 +68,7 @@ test "HAMT::as_iter" {
 }
 
 test "HAMT::to_string" {
-  let map = Map::make().add(1, 1).add(3, 3).add(0x0f_ff_ff_ff, 0x0f_ff_ff_ff).add(
+  let map = Map::new().add(1, 1).add(3, 3).add(0x0f_ff_ff_ff, 0x0f_ff_ff_ff).add(
     42, 42,
   )
   inspect(

--- a/immut/hashmap/bucket_test.mbt
+++ b/immut/hashmap/bucket_test.mbt
@@ -31,7 +31,7 @@ test "Bucket" {
 
 test "Bucket::iter" {
   let b : Bucket[_] = More(0, 0, More(1, 1, Just_One(31, 31)))
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   let mut is_first = true
   b.iter(
     fn(k, v) {
@@ -48,7 +48,7 @@ test "Bucket::iter" {
 
 test "Bucket::as_iter" {
   let b : Bucket[_] = More(0, 0, More(1, 1, Just_One(31, 31)))
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   let mut is_first = true
   b.as_iter().iter(
     fn {

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -11,7 +11,7 @@ impl Map {
   find[K : Eq + Hash, V](Self[K, V], K) -> V?
   from_array[K : Eq + Hash, V](Array[Tuple[K, V]]) -> Self[K, V]
   iter[K, V](Self[K, V], (K, V) -> Unit) -> Unit
-  make[K, V]() -> Self[K, V]
+  new[K, V]() -> Self[K, V]
   op_get[K : Eq + Hash, V](Self[K, V], K) -> V?
   remove[K : Eq + Hash, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -227,7 +227,7 @@ pub fn debug_write[T : Debug](self : Set[T], buf : Buffer) -> Unit {
 }
 
 pub fn to_string[T : Debug](self : Set[T]) -> String {
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   self.debug_write(buf)
   buf.to_string()
 }

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -40,7 +40,7 @@ let segment_length : Int = 5
 
 let segment_mask : Int = 0b11111
 
-pub fn Set::make[T]() -> Set[T] {
+pub fn Set::new[T]() -> Set[T] {
   Empty
 }
 
@@ -233,7 +233,7 @@ pub fn to_string[T : Debug](self : Set[T]) -> String {
 }
 
 pub fn Set::from_array[T : Eq + Hash](arr : Array[T]) -> Set[T] {
-  loop arr.length(), Set::make() {
+  loop arr.length(), Set::new() {
     0, set => set
     n, set => {
       let k = arr[n - 1]

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 test "Set" {
-  let map = loop 0, Set::make() {
+  let map = loop 0, Set::new() {
     100, map => map
     i, map => continue i + 1, map.add(i)
   }
@@ -26,7 +26,7 @@ test "Set" {
 }
 
 test "Set::size" {
-  for i = 0, set = Set::make(); i < 20; i = i + 1, set = set.add(i) {
+  for i = 0, set = Set::new(); i < 20; i = i + 1, set = set.add(i) {
     @assertion.assert_eq(set.size(), i)?
   } else {
     @assertion.assert_eq(set.add(0).size(), 20)?
@@ -34,7 +34,7 @@ test "Set::size" {
 }
 
 test "Set::remove" {
-  let map = loop 0, Set::make() {
+  let map = loop 0, Set::new() {
     100, map => map
     i, map => continue i + 1, map.add(i)
   }
@@ -59,7 +59,7 @@ test "Set::as_iter" {
 }
 
 test "Set::to_string" {
-  let set = Set::make().add(1).add(3).add(0x0f_ff_ff_ff).add(42)
+  let set = Set::new().add(1).add(3).add(0x0f_ff_ff_ff).add(42)
   inspect(set, content="@immutable_hashset.Set::[3, 42, 1, 268435455]")?
 }
 
@@ -72,7 +72,7 @@ test "Set::from_array" {
 }
 
 test "Set::is_empty" {
-  let set = Set::make()
+  let set = Set::new()
   inspect(set.is_empty(), content="true")?
   let set = set.add(1)
   inspect(set.is_empty(), content="false")?

--- a/immut/hashset/bucket_test.mbt
+++ b/immut/hashset/bucket_test.mbt
@@ -31,7 +31,7 @@ test "Bucket" {
 
 test "Bucket::iter" {
   let b : Bucket[_] = More(0, More(1, Just_One(31)))
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   let mut is_first = true
   b.iter(
     fn(k) {
@@ -48,7 +48,7 @@ test "Bucket::iter" {
 
 test "Bucket::as_iter" {
   let b : Bucket[_] = More(0, More(1, Just_One(31)))
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   let mut is_first = true
   b.as_iter().iter(
     fn {

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -12,7 +12,7 @@ impl Set {
   from_array[T : Eq + Hash](Array[T]) -> Self[T]
   is_empty[T](Self[T]) -> Bool
   iter[T](Self[T], (T) -> Unit) -> Unit
-  make[T]() -> Self[T]
+  new[T]() -> Self[T]
   remove[T : Eq + Hash](Self[T], T) -> Self[T]
   size[T](Self[T]) -> Int
   to_string[T : Debug](Self[T]) -> String

--- a/immut/internal/sparse_array/sparse_array_test.mbt
+++ b/immut/internal/sparse_array/sparse_array_test.mbt
@@ -37,7 +37,7 @@ test "SparseArray" {
 
 test "SparseArray::iter" {
   let arr = singleton(0, 0).add(1, 1).add(3, 3).add(31, 31)
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   let mut is_first = true
   arr.iter(
     fn(x) {

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -91,7 +91,7 @@ pub fn as_iter[T : Compare](self : ImmutablePriorityQueue[T]) -> Iter[T] {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   let v = ImmutablePriorityQueue::[1, 2, 3]
   v.as_iter().iter(fn(e) { buf.write_string("[\(e)]") })
   inspect(buf, content="[3][2][1]")?

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -236,7 +236,7 @@ test "op_equal" {
 
 test "debug_write" {
   let m = Map::[(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")]
-  let buffer = Buffer::make(0)
+  let buffer = Buffer::new(size_hint=0)
   m.debug_write(buffer)
   @assertion.assert_eq(
     buffer.to_string(),
@@ -245,7 +245,7 @@ test "debug_write" {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   let map = Map::[(1, "one"), (2, "two"), (3, "three")]
   map.as_iter().iter(
     fn(e) {

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -25,7 +25,7 @@ pub fn as_iter[T](self : ImmutableSet[T]) -> Iter[T] {
 }
 
 test {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   ImmutableSet::[2, 7, 1, 2, 3, 4, 5].as_iter().iter(
     fn { x => buf.write_string(x.to_string()) },
   )

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -72,7 +72,7 @@ pub fn value(self : JsonValue, key : String) -> JsonValue? {
 }
 
 pub fn stringify(self : JsonValue) -> String {
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   match self {
     Object(members) => {
       buf.write_char('{')

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -336,7 +336,7 @@ pub fn as_iter[T](self : T?) -> Iter[T] {
 
 test "as_iter" {
   let x = Option::Some(42)
-  let exb = Buffer::make(0)
+  let exb = Buffer::new(size_hint=0)
   x.as_iter().iter(
     fn(x) {
       exb.write_string(x.to_string())

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -322,15 +322,6 @@ test "compare" {
   @assertion.assert_eq(1, some2.compare(none))?
 }
 
-/// Extract the value in `Some`.
-/// Panic if input is `None`.
-pub fn unwrap[X](self : X?) -> X {
-  match self {
-    None => abort("called `Option::unwrap()` on a `None` value")
-    Some(x) => x
-  }
-}
-
 /// `None`
 pub fn Option::default[X]() -> X? {
   None

--- a/option/option.mbti
+++ b/option/option.mbti
@@ -24,7 +24,6 @@ impl Option {
   or[T](T?, T) -> T
   or_default[T : Default](T?) -> T
   or_else[T](T?, () -> T) -> T
-  unwrap[X](X?) -> X
 }
 
 // Traits

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -39,7 +39,7 @@ test "to_array" {
 }
 
 test "as_iter" {
-  let buf = Buffer::make(20)
+  let buf = Buffer::new(size_hint=20)
   let v = PriorityQueue::[1, 2, 3]
   v.as_iter().iter(fn(e) { buf.write_string("[\(e)]") })
   inspect(buf, content="[3][2][1]")?

--- a/sorted_set/mutable_set.mbt
+++ b/sorted_set/mutable_set.mbt
@@ -1159,7 +1159,7 @@ test "filter" {
 
 test "iter" {
   let set = MutableSet::[7, 2, 9, 4, 5, 6, 3, 8, 1]
-  let result = Buffer::make(10)
+  let result = Buffer::new(size_hint=10)
   set.iter(fn(x) { result.write_string(x.to_string()) })
   inspect(result.to_string(), content="123456789")?
   let set : MutableSet[Int] = new()
@@ -1222,11 +1222,11 @@ test "deep_clone" {
 }
 
 test "debug_write" {
-  let buf = Buffer::make(100)
+  let buf = Buffer::new(size_hint=100)
   let set = MutableSet::[1, 2, 3, 4, 5]
   set.debug_write(buf)
   inspect(buf.to_string(), content="MutableSet::[1, 2, 3, 4, 5]")?
-  let buf = Buffer::make(100)
+  let buf = Buffer::new(size_hint=100)
   let set : MutableSet[Int] = MutableSet::[]
   set.debug_write(buf)
   inspect(buf.to_string(), content="MutableSet::[]")?

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -540,7 +540,7 @@ fn to_string(self : Decimal) -> String {
   if self.decimal_point < 0 {
     n += -self.decimal_point
   }
-  let buf = Buffer::make(n)
+  let buf = Buffer::new(size_hint=n)
   if self.decimal_point <= 0 {
     // zeros filling between the decimal point and the digits
     buf.write_string("0.")

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -82,7 +82,7 @@ fn is_empty(self : StringSlice) -> Bool {
 }
 
 fn to_string(self : StringSlice) -> String {
-  let buf = Buffer::make(self.length())
+  let buf = Buffer::new(size_hint=self.length())
   for i = 0; i < self.length(); i = i + 1 {
     buf.write_char(self[i])
   }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -69,7 +69,7 @@ pub fn hash(self : String) -> Int {
 // due to cyclic dependency issue we can only test it here
 test "debug_write" {
   fn repr(s : String) {
-    let buf = Buffer::make(0)
+    let buf = Buffer::new(size_hint=0)
     s.debug_write(buf)
     buf.to_string()
   }
@@ -88,7 +88,7 @@ test "debug_write" {
 
 // test here to avlid cyclic dependency between assertion and builtin
 test "Buffer::to_bytes" {
-  let buffer = Buffer::make(16)
+  let buffer = Buffer::new(size_hint=16)
   buffer.write_string("中文")
   @assertion.assert_eq(buffer.to_bytes().to_string(), "中文")?
 }
@@ -118,7 +118,7 @@ test "to_array" {
 /// @intrinsic %string.substring
 fn unsafe_substring(str : String, start : Int, end : Int) -> String {
   let len = end - start
-  let buf = Buffer::make(len)
+  let buf = Buffer::new(size_hint=len)
   buf.write_sub_string(str, start, len)
   buf.to_string()
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -100,7 +100,7 @@ pub fn to_array(self : String) -> Array[Char] {
       rv.push(c)
       rv
     },
-    Array::with_capacity(self.length()),
+    Array::new(capacity=self.length()),
   )
 }
 

--- a/tuple/tuple_test.mbt
+++ b/tuple/tuple_test.mbt
@@ -189,7 +189,7 @@ test "debug_write" {
   let tuple3 = ("a", "b", "c")
   let tuple4 = (1, 2, 3, "hello")
   let tuple5 = ([1], "2", 3, ([4] : Array[_]), 5)
-  let buf = Buffer::make(0)
+  let buf = Buffer::new(size_hint=0)
   tuple2.debug_write(buf)
   inspect(buf, content="(1, 2)")?
   buf.reset()


### PR DESCRIPTION
In this pr:

- add optional parameter `capacity` (maybe rename to size_hint in future) to `T::new()`
- remove `T::with_capacity`
- rename `T::make()` to `T::new()`

This PR addresses part 1 of proposal #582.