### PR TITLE
Explicit iter result

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -16,11 +16,11 @@ pub fn as_iter[T](self : Array[T]) -> Iter[T] {
   Iter::_unstable_internal_make(
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
-        if yield(self[i]).not() {
-          break false
+        if yield(self[i]) == IterEnd {
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -900,11 +900,11 @@ pub fn as_iter[T](self : FixedArray[T]) -> Iter[T] {
   Iter::_unstable_internal_make(
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
-        if yield(self[i]).not() {
-          break false
+        if yield(self[i]) == IterEnd {
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -125,7 +125,7 @@ impl Buffer {
 
 type Iter
 impl Iter {
-  _unstable_internal_make[T](((T) -> Bool) -> Bool) -> Self[T]
+  _unstable_internal_make[T](((T) -> IterResult) -> IterResult) -> Self[T]
   append[T](Self[T], T) -> Self[T]
   collect[T](Self[T]) -> Array[T]
   concat[T](Self[T], Self[T]) -> Self[T]
@@ -149,7 +149,10 @@ impl Iter {
   to_array[T](Self[T]) -> Array[T]
 }
 
-type IterResult
+pub enum IterResult {
+  IterContinue
+  IterEnd
+}
 impl IterResult {
   op_equal(Self, Self) -> Bool
 }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -149,6 +149,11 @@ impl Iter {
   to_array[T](Self[T]) -> Array[T]
 }
 
+type IterResult
+impl IterResult {
+  op_equal(Self, Self) -> Bool
+}
+
 pub type Js_string
 impl Js_string {
   log(Self) -> Unit

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -247,12 +247,12 @@ impl Int {
   op_neg(Int) -> Int
   op_sub(Int, Int) -> Int
   popcnt(Int) -> Int
-  to(Int, Int, ~step : Int = ..) -> Iter[Int]
   to_byte(Int) -> Byte
   to_double(Int) -> Double
   to_int64(Int) -> Int64
   to_string(Int) -> String
   trunc_double_u(Double) -> Int
+  until(Int, Int, ~step : Int = ..) -> Iter[Int]
 }
 impl Int64 {
   asr(Int64, Int) -> Int64
@@ -280,12 +280,12 @@ impl Int64 {
   op_sub(Int64, Int64) -> Int64
   popcnt(Int64) -> Int
   reinterpret_as_double(Int64) -> Double
-  to(Int64, Int64, ~step : Int64 = ..) -> Iter[Int64]
   to_byte(Int64) -> Byte
   to_double(Int64) -> Double
   to_int(Int64) -> Int
   to_string(Int64) -> String
   trunc_double_u(Double) -> Int64
+  until(Int64, Int64, ~step : Int64 = ..) -> Iter[Int64]
 }
 impl Double {
   compare(Double, Double) -> Int
@@ -302,9 +302,9 @@ impl Double {
   op_sub(Double, Double) -> Double
   reinterpret_as_i64(Double) -> Int64
   sqrt(Double) -> Double
-  to(Double, Double, ~step : Double = ..) -> Iter[Double]
   to_int(Double) -> Int
   to_int64(Double) -> Int64
+  until(Double, Double, ~step : Double = ..) -> Iter[Double]
 }
 impl String {
   debug_write(String, Buffer) -> Unit

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -310,7 +310,7 @@ pub fn to(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] {
 ///
 /// # Returns
 ///
-/// A new iterator that only contains the elements for which the predicate function returns `true`.
+/// A new iterator that only contains the elements for which the predicate function returns `IterContinue`.
 /// @intrinsic %iter.filter
 pub fn filter[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
   Iter(
@@ -418,9 +418,8 @@ pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
           IterEnd
         }
       }
-      // when the `take` operator exits, the overall return value is false only when
-      // any of the `yield(a)` return false. Otherwise, it returns true, including
-      // the case when `i` reaches the iteration count `n`.
+      // The `take` operator returns `IterEnd` only when any call to `yield(a)` returns `IterEnd`.
+      // Otherwise, it returns `IterContinue`, including when `i` reaches the count `n`.
     },
   )
 }
@@ -443,7 +442,7 @@ pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
   Iter(
     fn {
       yield => {
-        // `r` is the overall return value, which is false only when `yield(a)` returns false
+        // `r` represents the overall return value. It is set to `IterEnd` only if `yield(a)` returns `IterEnd`.
         let mut r : IterResult = IterContinue
         (self.0)(
           fn {

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -172,12 +172,12 @@ pub fn Iter::repeat[T](a : T) -> Iter[T] {
 /// # Returns
 /// 
 /// Returns an iterator that iterates over the range of Int from `start` to `end - 1`.
-pub fn to(self : Int, end : Int, ~step : Int = 1) -> Iter[Int] {
+pub fn until(self : Int, end : Int, ~step : Int = 1) -> Iter[Int] {
   if step < 0 {
     return Iter(
       fn(yield) {
         for i = self; i > end; i = i + step {
-          if not(yield(i)) {
+          if yield(i) == IterEnd {
             break IterEnd
           }
         } else {
@@ -190,7 +190,7 @@ pub fn to(self : Int, end : Int, ~step : Int = 1) -> Iter[Int] {
   Iter(
     fn(yield) {
       for i = self; i < end; i = i + step {
-        if not(yield(i)) {
+        if yield(i) == IterEnd {
           break IterEnd
         }
       } else {
@@ -212,12 +212,12 @@ pub fn to(self : Int, end : Int, ~step : Int = 1) -> Iter[Int] {
 /// # Returns
 /// 
 /// Returns an iterator that iterates over the range of Int64 from `start` to `end - 1`.
-pub fn to(self : Int64, end : Int64, ~step : Int64 = 1L) -> Iter[Int64] {
+pub fn until(self : Int64, end : Int64, ~step : Int64 = 1L) -> Iter[Int64] {
   if step < 0L {
     return Iter(
       fn(yield) {
         for i = self; i > end; i = i + step {
-          if not(yield(i)) {
+          if yield(i) == IterEnd {
             break IterEnd
           }
         } else {
@@ -229,7 +229,7 @@ pub fn to(self : Int64, end : Int64, ~step : Int64 = 1L) -> Iter[Int64] {
   Iter(
     fn(yield) {
       for i = self; i < end; i = i + step {
-        if not(yield(i)) {
+        if yield(i) == IterEnd {
           break IterEnd
         }
       } else {
@@ -251,12 +251,12 @@ pub fn to(self : Int64, end : Int64, ~step : Int64 = 1L) -> Iter[Int64] {
 /// # Returns
 /// 
 /// Returns an iterator that iterates over the range of Double from `start` to `end - 1`.
-pub fn to(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] {
+pub fn until(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] {
   if step < 0.0 {
     return Iter(
       fn(yield) {
         for i = self; i > end; i = i + step {
-          if not(yield(i)) {
+          if yield(i) == IterEnd {
             break IterEnd
           }
         } else {
@@ -268,7 +268,7 @@ pub fn to(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] {
   Iter(
     fn(yield) {
       for i = self; i < end; i = i + step {
-        if not(yield(i)) {
+        if yield(i) == IterEnd {
           break IterEnd
         }
       } else {

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 // Types
-type Iter[T] ((T) -> Bool) -> Bool
+type Iter[T] ((T) -> IterResult) -> IterResult
+
+enum IterResult {
+  IterContinue // true
+  IterEnd // false
+} derive(Eq)
 
 fn to_string[T : Show](self : Iter[T]) -> String {
   self.to_array().to_string()
@@ -37,7 +42,7 @@ pub fn iter[T](self : Iter[T], f : (T) -> Unit) -> Unit {
     fn {
       yield => {
         f(yield)
-        true
+        IterContinue
       }
     },
   )
@@ -67,7 +72,7 @@ pub fn fold[T, B](self : Iter[T], f : (B, T) -> B, init : B) -> B {
     fn {
       yield => {
         acc = f(acc, yield)
-        true
+        IterContinue
       }
     },
   )
@@ -93,9 +98,28 @@ pub fn count[T](self : Iter[T]) -> Int {
 
 // Producers
 
+fn iter_result_of_bool(b : Bool) -> IterResult {
+  if b {
+    IterContinue
+  } else {
+    IterEnd
+  }
+}
+
+fn bool_of_iter_result(r : IterResult) -> Bool {
+  match r {
+    IterContinue => true
+    IterEnd => false
+  }
+}
+
 /// Do not use this method, it is for internal use only.
 pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Bool) -> Iter[T] {
-  Iter(f)
+  Iter(
+    fn {
+      yield => iter_result_of_bool(f(fn { x => bool_of_iter_result(yield(x)) }))
+    },
+  )
 }
 
 /// Creates an empty iterator.
@@ -108,7 +132,7 @@ pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Bool) -> Iter[T] {
 ///
 /// Returns an empty iterator of type `Iter[T]`.
 pub fn Iter::empty[T]() -> Iter[T] {
-  Iter(fn { _ => true })
+  Iter(fn { _ => IterContinue })
 }
 
 /// Creates an iterator that contains a single element.
@@ -145,12 +169,9 @@ pub fn Iter::singleton[T](a : T) -> Iter[T] {
 pub fn Iter::repeat[T](a : T) -> Iter[T] {
   Iter(
     fn(yield) {
-      for ; ; {
-        if yield(a) {
-          continue
-        } else {
-          break false
-        }
+      loop yield(a) {
+        IterContinue => continue yield(a)       
+        IterEnd =>   IterEnd      
       }
     },
   )
@@ -292,7 +313,11 @@ pub fn to(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] {
 /// A new iterator that only contains the elements for which the predicate function returns `true`.
 /// @intrinsic %iter.filter
 pub fn filter[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
-  Iter(fn { yield => (self.0)(fn { a => if f(a) { yield(a) } else { true } }) })
+  Iter(
+    fn {
+      yield => (self.0)(fn { a => if f(a) { yield(a) } else { IterContinue } })
+    },
+  )
 }
 
 /// Transforms the elements of the iterator using a mapping function.
@@ -374,21 +399,28 @@ pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
     fn {
       yield => {
         let mut i = 0
-        (self.0)(
+        let iter_result = (self.0)(
           fn {
             a =>
-              if i < n && yield(a) {
+              if i < n && yield(a) == IterContinue {
                 i = i + 1
-                true
+                IterContinue
               } else {
-                false
+                IterEnd
               }
           },
-        ) || i == n
-        // when the `take` operator exits, the overall return value is false only when
-        // any of the `yield(a)` return false. Otherwise, it returns true, including
-        // the case when `i` reaches the iteration count `n`.
+        )
+        if iter_result == IterContinue {
+          iter_result
+        } else if i == n {
+          IterContinue
+        } else {
+          IterEnd
+        }
       }
+      // when the `take` operator exits, the overall return value is false only when
+      // any of the `yield(a)` return false. Otherwise, it returns true, including
+      // the case when `i` reaches the iteration count `n`.
     },
   )
 }
@@ -412,19 +444,19 @@ pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
     fn {
       yield => {
         // `r` is the overall return value, which is false only when `yield(a)` returns false
-        let mut r = true
+        let mut r : IterResult = IterContinue
         (self.0)(
           fn {
             a =>
               if f(a) {
-                if yield(a) {
-                  true
+                if yield(a) == IterContinue {
+                  IterContinue
                 } else {
-                  r = false
-                  false
+                  r = IterEnd
+                  IterEnd
                 }
               } else {
-                false
+                IterEnd
               }
           },
         )
@@ -459,7 +491,7 @@ pub fn drop[T](self : Iter[T], n : Int) -> Iter[T] {
             a =>
               if i < n {
                 i = i + 1
-                true
+                IterContinue
               } else {
                 yield(a)
               }
@@ -493,7 +525,7 @@ pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
           fn {
             a =>
               if dropping && f(a) {
-                true
+                IterContinue
               } else {
                 dropping = false
                 yield(a)
@@ -526,9 +558,9 @@ pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> T? {
       a =>
         if f(a) {
           result = Some(a)
-          false
+          IterEnd
         } else {
-          true
+          IterContinue
         }
     },
   )
@@ -550,7 +582,15 @@ pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> T? {
 ///
 /// Returns a new iterator with the element `a` prepended to the original iterator.
 pub fn prepend[T](self : Iter[T], a : T) -> Iter[T] {
-  Iter(fn(yield) { yield(a) && (self.0)(yield) })
+  Iter(
+    fn(yield) {
+      if yield(a) == IterContinue {
+        (self.0)(yield)
+      } else {
+        IterEnd
+      }
+    },
+  )
 }
 
 /// Appends a single element to the end of the iterator.
@@ -568,7 +608,15 @@ pub fn prepend[T](self : Iter[T], a : T) -> Iter[T] {
 ///
 /// Returns a new iterator with the element `a` appended to the original iterator.
 pub fn append[T](self : Iter[T], a : T) -> Iter[T] {
-  Iter(fn(yield) { (self.0)(yield) && yield(a) })
+  Iter(
+    fn(yield) {
+      if (self.0)(yield) == IterContinue {
+        yield(a)
+      } else {
+        IterEnd
+      }
+    },
+  )
 }
 
 /// Combines two iterators into one by appending the elements of the second iterator to the first.
@@ -587,7 +635,15 @@ pub fn append[T](self : Iter[T], a : T) -> Iter[T] {
 /// Returns a new iterator that contains the elements of `self` followed by the elements of `other`.
 /// @intrinsic %iter.concat
 pub fn Iter::concat[T](self : Iter[T], other : Iter[T]) -> Iter[T] {
-  Iter(fn(yield) { (self.0)(yield) && (other.0)(yield) })
+  Iter(
+    fn(yield) {
+      if (self.0)(yield) == IterContinue {
+        (other.0)(yield)
+      } else {
+        IterEnd
+      }
+    },
+  )
 }
 
 pub fn op_add[T](self : Iter[T], other : Iter[T]) -> Iter[T] {

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -195,10 +195,10 @@ pub fn to(self : Int, end : Int, ~step : Int = 1) -> Iter[Int] {
       fn(yield) {
         for i = self; i > end; i = i + step {
           if not(yield(i)) {
-            break false
+            break IterEnd
           }
         } else {
-          true
+          IterContinue
         }
       },
     )
@@ -208,10 +208,10 @@ pub fn to(self : Int, end : Int, ~step : Int = 1) -> Iter[Int] {
     fn(yield) {
       for i = self; i < end; i = i + step {
         if not(yield(i)) {
-          break false
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )
@@ -235,10 +235,10 @@ pub fn to(self : Int64, end : Int64, ~step : Int64 = 1L) -> Iter[Int64] {
       fn(yield) {
         for i = self; i > end; i = i + step {
           if not(yield(i)) {
-            break false
+            break IterEnd
           }
         } else {
-          true
+          IterContinue
         }
       },
     )
@@ -247,10 +247,10 @@ pub fn to(self : Int64, end : Int64, ~step : Int64 = 1L) -> Iter[Int64] {
     fn(yield) {
       for i = self; i < end; i = i + step {
         if not(yield(i)) {
-          break false
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )
@@ -274,10 +274,10 @@ pub fn to(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] {
       fn(yield) {
         for i = self; i > end; i = i + step {
           if not(yield(i)) {
-            break false
+            break IterEnd
           }
         } else {
-          true
+          IterContinue
         }
       },
     )
@@ -286,10 +286,10 @@ pub fn to(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] {
     fn(yield) {
       for i = self; i < end; i = i + step {
         if not(yield(i)) {
-          break false
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -170,8 +170,8 @@ pub fn Iter::repeat[T](a : T) -> Iter[T] {
   Iter(
     fn(yield) {
       loop yield(a) {
-        IterContinue => continue yield(a)       
-        IterEnd =>   IterEnd      
+        IterContinue => continue yield(a)
+        IterEnd => IterEnd
       }
     },
   )

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -15,7 +15,7 @@
 // Types
 type Iter[T] ((T) -> IterResult) -> IterResult
 
-enum IterResult {
+pub enum IterResult {
   IterContinue // true
   IterEnd // false
 } derive(Eq)
@@ -98,28 +98,11 @@ pub fn count[T](self : Iter[T]) -> Int {
 
 // Producers
 
-fn iter_result_of_bool(b : Bool) -> IterResult {
-  if b {
-    IterContinue
-  } else {
-    IterEnd
-  }
-}
-
-fn bool_of_iter_result(r : IterResult) -> Bool {
-  match r {
-    IterContinue => true
-    IterEnd => false
-  }
-}
-
 /// Do not use this method, it is for internal use only.
-pub fn Iter::_unstable_internal_make[T](f : ((T) -> Bool) -> Bool) -> Iter[T] {
-  Iter(
-    fn {
-      yield => iter_result_of_bool(f(fn { x => bool_of_iter_result(yield(x)) }))
-    },
-  )
+pub fn Iter::_unstable_internal_make[T](
+  f : ((T) -> IterResult) -> IterResult
+) -> Iter[T] {
+  Iter(fn { yield => f(fn { x => yield(x) }) })
 }
 
 /// Creates an empty iterator.

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed until in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
@@ -244,46 +244,49 @@ test "collect" {
 
 test "range" {
   // edge cases
-  inspect((0).to(10).take(100), content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")?
-  inspect((100).to(10).take(100), content="[]")?
-  inspect((100).to(101, step=4), content="[100]")?
-  // to
-  inspect((0).to(10).take(5).concat((0).to(2)), content="[0, 1, 2, 3, 4, 0, 1]")?
+  inspect((0).until(10).take(100), content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")?
+  inspect((100).until(10).take(100), content="[]")?
+  inspect((100).until(101, step=4), content="[100]")?
+  // until
   inspect(
-    0x80000000L.to(0x80000000L + 10L).take(5).concat(
-      (0x80000000L + 10L).to(0x80000000L + 20L).take(3),
+    (0).until(10).take(5).concat((0).until(2)),
+    content="[0, 1, 2, 3, 4, 0, 1]",
+  )?
+  inspect(
+    0x80000000L.until(0x80000000L + 10L).take(5).concat(
+      (0x80000000L + 10L).until(0x80000000L + 20L).take(3),
     ),
     content="[2147483648, 2147483649, 2147483650, 2147483651, 2147483652, 2147483658, 2147483659, 2147483660]",
   )?
   inspect(
-    0.0.to(10.0).take(5).concat(0.0.to(2.0)),
+    0.0.until(10.0).take(5).concat(0.0.until(2.0)),
     content="[0.0, 1.0, 2.0, 3.0, 4.0, 0.0, 1.0]",
   )?
   inspect(
-    (-50).to(50, step=10).take(100),
+    (-50).until(50, step=10).take(100),
     content="[-50, -40, -30, -20, -10, 0, 10, 20, 30, 40]",
   )?
   inspect(
-    0.1.to(0.4, step=0.1).take(5),
+    0.1.until(0.4, step=0.1).take(5),
     content="[0.1, 0.2, 0.30000000000000004]",
   )?
-  inspect(0.1.to(0.3, step=0.1), content="[0.1, 0.2]")?
+  inspect(0.1.until(0.3, step=0.1), content="[0.1, 0.2]")?
   inspect(
-    0.1.to(0.4, step=0.1).take(5),
+    0.1.until(0.4, step=0.1).take(5),
     content="[0.1, 0.2, 0.30000000000000004]",
   )?
   inspect(
-    0x80000000L.to(0x80000000L + 10L, step=2L),
+    0x80000000L.until(0x80000000L + 10L, step=2L),
     content="[2147483648, 2147483650, 2147483652, 2147483654, 2147483656]",
   )?
   // step < 0
-  inspect((10).to(0, step=-1).take(5), content="[10, 9, 8, 7, 6]")?
+  inspect((10).until(0, step=-1).take(5), content="[10, 9, 8, 7, 6]")?
   inspect(
-    0x80000000L.to(0x80000000L - 10L, step=-2L).take(5),
+    0x80000000L.until(0x80000000L - 10L, step=-2L).take(5),
     content="[2147483648, 2147483646, 2147483644, 2147483642, 2147483640]",
   )?
   inspect(
-    0.0.to(-1.0, step=-0.1).take(5),
+    0.0.until(-1.0, step=-0.1).take(5),
     content="[0.0, -0.1, -0.2, -0.30000000000000004, -0.4]",
   )?
 }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed until in writing, software
+// Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -235,7 +235,7 @@ test "collect" {
       for i = 0, len = arr.length(); i < len; i = i + 1 {
         yield(arr[i]) |> ignore
       }
-      true
+      IterContinue
     },
   )
   let vec = iter.collect()
@@ -294,11 +294,11 @@ fn test_from_array[T](arr : Array[T]) -> Iter[T] {
     fn {
       yield =>
         for i = 0; i < arr.length(); i = i + 1 {
-          if yield(arr[i]).not() {
-            break false
+          if yield(arr[i]) == IterEnd {
+            break IterEnd
           }
         } else {
-          true
+          IterContinue
         }
     },
   )

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -391,12 +391,12 @@ pub fn as_iter[K, V](self : Map[K, V]) -> Iter[(K, V)] {
     fn(yield) {
       loop self.head {
         Some({ key, value, idx, .. }) => {
-          if yield((key, value)).not() {
-            break false
+          if yield((key, value)) == IterEnd {
+            break IterEnd
           }
           continue self.list[idx].next
         }
-        None => break true
+        None => break IterContinue
       }
     },
   )

--- a/devec/devec.mbt
+++ b/devec/devec.mbt
@@ -617,11 +617,11 @@ pub fn as_iter[T](self : Devec[T]) -> Iter[T] {
   Iter::_unstable_internal_make(
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
-        if yield(self[i]).not() {
-          break false
+        if yield(self[i]) == IterEnd {
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -39,13 +39,13 @@ pub fn as_iter[K, V](self : HashMap[K, V]) -> Iter[(K, V)] {
       for i = 0; i < len; i = i + 1 {
         match self.entries[i] {
           Some({ key, value, .. }) =>
-            if yield((key, value)).not() {
-              break false
+            if yield((key, value)) == IterEnd {
+              break IterEnd
             }
           None => continue
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -209,11 +209,11 @@ pub fn as_iter[K](self : HashSet[K]) -> Iter[K] {
     fn(yield) {
       for i = 0, len = self.entries.length(); i < len; i = i + 1 {
         match self.entries[i] {
-          Some({ key, .. }) => if yield(key).not() { break false }
+          Some({ key, .. }) => if yield(key) == IterEnd { break IterEnd }
           None => continue
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -65,11 +65,11 @@ pub fn as_iter[T](self : ImmutableVec[T]) -> Iter[T] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0; i < self.size; i = i + 1 {
-        if yield(arr[i]).not() {
-          break false
+        if yield(arr[i]) == IterEnd {
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/immut/hashmap/bucket.mbt
+++ b/immut/hashmap/bucket.mbt
@@ -92,7 +92,12 @@ fn as_iter[K, V](self : Bucket[K, V]) -> Iter[(K, V)] {
       f =>
         loop self {
           Just_One(k, v) => f((k, v))
-          More(k, v, rest) => if f((k, v)) { continue rest } else { false }
+          More(k, v, rest) =>
+            if f((k, v)) == IterContinue {
+              continue rest
+            } else {
+              IterEnd
+            }
         }
     },
   )

--- a/immut/hashset/bucket.mbt
+++ b/immut/hashset/bucket.mbt
@@ -82,7 +82,12 @@ fn as_iter[T](self : Bucket[T]) -> Iter[T] {
       f =>
         loop self {
           Just_One(k) => f(k)
-          More(k, rest) => if f(k) { continue rest } else { false }
+          More(k, rest) =>
+            if f(k) == IterContinue {
+              continue rest
+            } else {
+              IterEnd
+            }
         }
     },
   )

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -829,10 +829,10 @@ pub fn as_iter[T](self : List[T]) -> Iter[T] {
   Iter::_unstable_internal_make(
     fn(yield) {
       loop self {
-        Nil => true
+        Nil => IterContinue
         Cons(head, tail) => {
-          if yield(head).not() {
-            break false
+          if yield(head) == IterEnd {
+            break IterEnd
           }
           continue tail
         }

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -80,11 +80,11 @@ pub fn as_iter[T : Compare](self : ImmutablePriorityQueue[T]) -> Iter[T] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0; i < arr.length(); i = i + 1 {
-        if yield(arr[i]).not() {
-          break false
+        if yield(arr[i]) == IterEnd {
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -215,10 +215,10 @@ pub fn as_iter[K, V](self : Map[K, V]) -> Iter[(K, V)] {
       let arr = self.to_array()
       for i = 0, len = arr.length(); i < len; i = i + 1 {
         match arr[i] {
-          (key, value) => if yield((key, value)).not() { break false }
+          (key, value) => if yield((key, value)) == IterEnd { break IterEnd }
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -89,11 +89,11 @@ pub fn as_iter[T : Compare](self : PriorityQueue[T]) -> Iter[T] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0; i < arr.length(); i = i + 1 {
-        if yield(arr[i]).not() {
-          break false
+        if yield(arr[i]) == IterEnd {
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -310,12 +310,12 @@ pub fn as_iter[T](self : Queue[T]) -> Iter[T] {
     fn(yield) {
       loop self.first {
         Cons({ content, next }) => {
-          if yield(content).not() {
-            break false
+          if yield(content) == IterEnd {
+            break IterEnd
           }
           continue next
         }
-        Nil => true
+        Nil => IterContinue
       }
     },
   )

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -163,19 +163,19 @@ pub fn as_iter(self : String) -> Iter[Char] {
           let c2 = self[index + 1].to_int()
           if c2 >= 0xDC00 && c2 <= 0xDFFF {
             let c = Char::from_int((c - 0xD800) * 0x400 + c2 - 0xDC00 + 0x10000)
-            if yield(c) {
+            if yield(c) == IterContinue {
               continue index + 2
             } else {
-              break false
+              break IterEnd
             }
           }
         }
         //TODO: handle garbage input
-        if not(yield(Char::from_int(c))) {
-          break false
+        if yield(Char::from_int(c)) == IterEnd {
+          break IterEnd
         }
       } else {
-        true
+        IterContinue
       }
     },
   )


### PR DESCRIPTION
This is part 2 of https://github.com/moonbitlang/core/pull/538

Which added explicit iter result support, and removed helper function `iter_result_of_bool` and `bool_of_iter_result`