### PR TITLE
hongbo/ide error

### DIFF
--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -60,12 +60,12 @@ fn lex_value(
       Some('-') =>
         match read_char(ctx) {
           Some('0') => {
-            let n = lex_zero(ctx, start=ctx.offset - 2)?
+            let n = lex_zero(ctx, start=ctx.offset - 2)!!
             return Ok(Number(n))
           }
           Some(c2) => {
             if c2 >= '1' && c2 <= '9' {
-              let n = lex_decimal_integer(ctx, start=ctx.offset - 2)?
+              let n = lex_decimal_integer(ctx, start=ctx.offset - 2)!!
               return Ok(Number(n))
             }
             return Err(invalid_char(ctx, shift=-1))
@@ -73,11 +73,11 @@ fn lex_value(
           None => return Err(InvalidEof)
         }
       Some('0') => {
-        let n = lex_zero(ctx, start=ctx.offset - 1)?
+        let n = lex_zero(ctx, start=ctx.offset - 1)!!
         return Ok(Number(n))
       }
       Some('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9') => {
-        let n = lex_decimal_integer(ctx, start=ctx.offset - 1)?
+        let n = lex_decimal_integer(ctx, start=ctx.offset - 1)!!
         return Ok(Number(n))
       }
       Some('"') => {

--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -30,67 +30,67 @@ fn lex_value(
   for ; ; {
     match read_char(ctx) {
       Some('\t' | ' ' | '\n' | '\r') => continue
-      Some('{') => return Ok(LBrace)
-      Some('[') => return Ok(LBracket)
+      Some('{') => break Ok(LBrace)
+      Some('[') => break Ok(LBracket)
       Some(']') =>
         if allow_rbracket {
-          return Ok(RBracket)
+          break Ok(RBracket)
         } else {
-          return Err(invalid_char(ctx, shift=-1))
+          break Err(invalid_char(ctx, shift=-1))
         }
       Some('n') => {
         lex_assert_char(ctx, 'u')?
         lex_assert_char(ctx, 'l')?
         lex_assert_char(ctx, 'l')?
-        return Ok(Null)
+        break Ok(Null)
       }
       Some('t') => {
         lex_assert_char(ctx, 'r')?
         lex_assert_char(ctx, 'u')?
         lex_assert_char(ctx, 'e')?
-        return Ok(True)
+        break Ok(True)
       }
       Some('f') => {
         lex_assert_char(ctx, 'a')?
         lex_assert_char(ctx, 'l')?
         lex_assert_char(ctx, 's')?
         lex_assert_char(ctx, 'e')?
-        return Ok(False)
+        break Ok(False)
       }
       Some('-') =>
         match read_char(ctx) {
           Some('0') => {
             let n = lex_zero(ctx, start=ctx.offset - 2)!!
-            return Ok(Number(n))
+            break Ok(Number(n))
           }
           Some(c2) => {
             if c2 >= '1' && c2 <= '9' {
               let n = lex_decimal_integer(ctx, start=ctx.offset - 2)!!
-              return Ok(Number(n))
+              break Ok(Number(n))
             }
-            return Err(invalid_char(ctx, shift=-1))
+            break Err(invalid_char(ctx, shift=-1))
           }
-          None => return Err(InvalidEof)
+          None => break Err(InvalidEof)
         }
       Some('0') => {
         let n = lex_zero(ctx, start=ctx.offset - 1)!!
-        return Ok(Number(n))
+        break Ok(Number(n))
       }
       Some('1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9') => {
         let n = lex_decimal_integer(ctx, start=ctx.offset - 1)!!
-        return Ok(Number(n))
+        break Ok(Number(n))
       }
       Some('"') => {
         let s = lex_string(ctx)?
-        return Ok(String(s))
+        break Ok(String(s))
       }
       Some(c) => {
         if c > '\x7f' && non_ascii_whitespace.contains(c) {
           continue
         }
-        return Err(invalid_char(ctx, shift=-1))
+        break Err(invalid_char(ctx, shift=-1))
       }
-      None => return Err(InvalidEof)
+      None => break Err(InvalidEof)
     }
   }
 }

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -133,10 +133,6 @@ fn lex_number_end(
   end : Int
 ) -> Double!ParseError {
   let s = ctx.input.substring(~start, ~end)
-  // match @strconv.parse_double(s) {
-  //   Ok(d) => Ok(d)
-  //   Err(_) => Err(InvalidNumber(offset_to_position(ctx.input, start), s))
-  // }
   try {
     @strconv.parse_double(s)!
   } catch {

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -12,97 +12,91 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn lex_decimal_integer(
-  ctx : ParseContext,
-  ~start : Int
-) -> Result[Double, ParseError] {
+fn lex_decimal_integer(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   for ; ; {
     match read_char(ctx) {
-      Some('.') => return lex_decimal_point(ctx, ~start)
-      Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)
+      Some('.') => return lex_decimal_point(ctx, ~start)!
+      Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
       Some(c) => {
         if c >= '0' && c <= '9' {
           continue
         }
         ctx.offset -= 1
-        return lex_number_end(ctx, start, ctx.offset)
+        return lex_number_end(ctx, start, ctx.offset)!
       }
-      None => return lex_number_end(ctx, start, ctx.offset)
+      None => return lex_number_end(ctx, start, ctx.offset)!
     }
   }
 }
 
-fn lex_decimal_point(
-  ctx : ParseContext,
-  ~start : Int
-) -> Result[Double, ParseError] {
+fn lex_decimal_point(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   match read_char(ctx) {
     Some(c) =>
       if c >= '0' && c <= '9' {
-        return lex_decimal_fraction(ctx, ~start)
+        return lex_decimal_fraction(ctx, ~start)!
       } else {
-        return Err(invalid_char(ctx, shift=-1))
+        raise invalid_char(ctx, shift=-1)
       }
-    None => return Err(InvalidEof)
+    None => {
+      raise InvalidEof
+    }
   }
 }
 
-fn lex_decimal_fraction(
-  ctx : ParseContext,
-  ~start : Int
-) -> Result[Double, ParseError] {
+fn lex_decimal_fraction(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   for ; ; {
     match read_char(ctx) {
-      Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)
+      Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
       Some(c) => {
         if c >= '0' && c <= '9' {
           continue
         }
         ctx.offset -= 1
-        return lex_number_end(ctx, start, ctx.offset)
+        return lex_number_end(ctx, start, ctx.offset)!
       }
-      None => return lex_number_end(ctx, start, ctx.offset)
+      None => return lex_number_end(ctx, start, ctx.offset)!
     }
   }
 }
 
-fn lex_decimal_exponent(
-  ctx : ParseContext,
-  ~start : Int
-) -> Result[Double, ParseError] {
+fn lex_decimal_exponent(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   match read_char(ctx) {
-    Some('+') | Some('-') => return lex_decimal_exponent_sign(ctx, ~start)
+    Some('+') | Some('-') => return lex_decimal_exponent_sign(ctx, ~start)!
     Some(c) => {
       if c >= '0' && c <= '9' {
-        return lex_decimal_exponent_integer(ctx, ~start)
+        return lex_decimal_exponent_integer(ctx, ~start)!
       }
       ctx.offset -= 1
-      return Err(invalid_char(ctx))
+      raise invalid_char(ctx)
     }
-    None => Err(InvalidEof)
+    None => {
+      raise InvalidEof
+    }
   }
 }
 
 fn lex_decimal_exponent_sign(
   ctx : ParseContext,
   ~start : Int
-) -> Result[Double, ParseError] {
+) -> Double!ParseError {
   match read_char(ctx) {
     Some(c) => {
       if c >= '0' && c <= '9' {
-        return lex_decimal_exponent_integer(ctx, ~start)
+        return lex_decimal_exponent_integer(ctx, ~start)!
       }
       ctx.offset -= 1
-      return Err(invalid_char(ctx))
+      raise invalid_char(ctx)
     }
-    None => Err(InvalidEof)
+    None => {
+      raise InvalidEof
+    }
   }
 }
 
 fn lex_decimal_exponent_integer(
   ctx : ParseContext,
   ~start : Int
-) -> Result[Double, ParseError] {
+) -> Double!ParseError {
   for ; ; {
     match read_char(ctx) {
       Some(c) => {
@@ -110,26 +104,26 @@ fn lex_decimal_exponent_integer(
           continue
         }
         ctx.offset -= 1
-        return lex_number_end(ctx, start, ctx.offset)
+        return lex_number_end(ctx, start, ctx.offset)!
       }
-      None => return lex_number_end(ctx, start, ctx.offset)
+      None => return lex_number_end(ctx, start, ctx.offset)!
     }
   }
 }
 
-fn lex_zero(ctx : ParseContext, ~start : Int) -> Result[Double, ParseError] {
+fn lex_zero(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   match read_char(ctx) {
-    Some('.') => return lex_decimal_point(ctx, ~start)
-    Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)
+    Some('.') => return lex_decimal_point(ctx, ~start)!
+    Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
     Some(c) => {
       if c >= '0' && c <= '9' {
         ctx.offset -= 1
-        return Err(invalid_char(ctx))
+        raise invalid_char(ctx)
       }
       ctx.offset -= 1
-      return lex_number_end(ctx, start, ctx.offset)
+      return lex_number_end(ctx, start, ctx.offset)!
     }
-    None => return lex_number_end(ctx, start, ctx.offset)
+    None => return lex_number_end(ctx, start, ctx.offset)!
   }
 }
 
@@ -137,10 +131,17 @@ fn lex_number_end(
   ctx : ParseContext,
   start : Int,
   end : Int
-) -> Result[Double, ParseError] {
+) -> Double!ParseError {
   let s = ctx.input.substring(~start, ~end)
-  match @strconv.parse_double(s) {
-    Ok(d) => Ok(d)
-    Err(_) => Err(InvalidNumber(offset_to_position(ctx.input, start), s))
+  // match @strconv.parse_double(s) {
+  //   Ok(d) => Ok(d)
+  //   Err(_) => Err(InvalidNumber(offset_to_position(ctx.input, start), s))
+  // }
+  try {
+    @strconv.parse_double(s)!
+  } catch {
+    _ => {
+      raise InvalidNumber(offset_to_position(ctx.input, start), s)
+    }
   }
 }

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -15,16 +15,16 @@
 fn lex_decimal_integer(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   for ; ; {
     match read_char(ctx) {
-      Some('.') => return lex_decimal_point(ctx, ~start)!
-      Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
+      Some('.') => break lex_decimal_point(ctx, ~start)!
+      Some('e' | 'E') => break lex_decimal_exponent(ctx, ~start)!
       Some(c) => {
         if c >= '0' && c <= '9' {
           continue
         }
         ctx.offset -= 1
-        return lex_number_end(ctx, start, ctx.offset)!
+        break lex_number_end(ctx, start, ctx.offset)!
       }
-      None => return lex_number_end(ctx, start, ctx.offset)!
+      None => break lex_number_end(ctx, start, ctx.offset)!
     }
   }
 }
@@ -33,7 +33,7 @@ fn lex_decimal_point(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   match read_char(ctx) {
     Some(c) =>
       if c >= '0' && c <= '9' {
-        return lex_decimal_fraction(ctx, ~start)!
+        lex_decimal_fraction(ctx, ~start)!
       } else {
         raise invalid_char(ctx, shift=-1)
       }
@@ -46,22 +46,22 @@ fn lex_decimal_point(ctx : ParseContext, ~start : Int) -> Double!ParseError {
 fn lex_decimal_fraction(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   for ; ; {
     match read_char(ctx) {
-      Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
+      Some('e' | 'E') => break lex_decimal_exponent(ctx, ~start)!
       Some(c) => {
         if c >= '0' && c <= '9' {
           continue
         }
         ctx.offset -= 1
-        return lex_number_end(ctx, start, ctx.offset)!
+        break lex_number_end(ctx, start, ctx.offset)!
       }
-      None => return lex_number_end(ctx, start, ctx.offset)!
+      None => break lex_number_end(ctx, start, ctx.offset)!
     }
   }
 }
 
 fn lex_decimal_exponent(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   match read_char(ctx) {
-    Some('+') | Some('-') => return lex_decimal_exponent_sign(ctx, ~start)!
+    Some('+') | Some('-') => lex_decimal_exponent_sign(ctx, ~start)!
     Some(c) => {
       if c >= '0' && c <= '9' {
         return lex_decimal_exponent_integer(ctx, ~start)!
@@ -104,26 +104,26 @@ fn lex_decimal_exponent_integer(
           continue
         }
         ctx.offset -= 1
-        return lex_number_end(ctx, start, ctx.offset)!
+        break lex_number_end(ctx, start, ctx.offset)!
       }
-      None => return lex_number_end(ctx, start, ctx.offset)!
+      None => break lex_number_end(ctx, start, ctx.offset)!
     }
   }
 }
 
 fn lex_zero(ctx : ParseContext, ~start : Int) -> Double!ParseError {
   match read_char(ctx) {
-    Some('.') => return lex_decimal_point(ctx, ~start)!
-    Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
+    Some('.') => lex_decimal_point(ctx, ~start)!
+    Some('e' | 'E') => lex_decimal_exponent(ctx, ~start)!
     Some(c) => {
       if c >= '0' && c <= '9' {
         ctx.offset -= 1
         raise invalid_char(ctx)
       }
       ctx.offset -= 1
-      return lex_number_end(ctx, start, ctx.offset)!
+      lex_number_end(ctx, start, ctx.offset)!
     }
-    None => return lex_number_end(ctx, start, ctx.offset)!
+    None => lex_number_end(ctx, start, ctx.offset)!
   }
 }
 

--- a/strconv/bool.mbt
+++ b/strconv/bool.mbt
@@ -42,6 +42,13 @@ test "parse_bool" {
   ]
   for i = 0; i < tests.length(); i = i + 1 {
     let t = tests[i]
-    @assertion.assert_eq(try { Result::Ok(parse_bool(t.0)!)} catch {err => Err(err)} , t.1)?
+    @assertion.assert_eq(
+      try {
+        Result::Ok(parse_bool(t.0)!)
+      } catch {
+        err => Err(err)
+      },
+      t.1,
+    )?
   }
 }

--- a/strconv/bool.mbt
+++ b/strconv/bool.mbt
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 /// Parse a string and return the represented boolean value or an error.
-pub fn parse_bool(str : String) -> Result[Bool, String] {
+pub fn parse_bool(str : String) -> Bool!String {
   match str {
-    "1" | "t" | "T" | "true" | "TRUE" | "True" => Ok(true)
-    "0" | "f" | "F" | "false" | "FALSE" | "False" => Ok(false)
-    _ => Err(syntax_err)
+    "1" | "t" | "T" | "true" | "TRUE" | "True" => true
+    "0" | "f" | "F" | "false" | "FALSE" | "False" => false
+    _ => {
+      raise syntax_err
+    }
   }
 }
 
@@ -40,6 +42,6 @@ test "parse_bool" {
   ]
   for i = 0; i < tests.length(); i = i + 1 {
     let t = tests[i]
-    @assertion.assert_eq(parse_bool(t.0), t.1)?
+    @assertion.assert_eq(try { Result::Ok(parse_bool(t.0)!)} catch {err => Err(err)} , t.1)?
   }
 }

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -590,7 +590,10 @@ test "parse_decimal" {
     let hpd = Decimal::parse_decimal(s)!
     inspect(hpd, content=s)?
     let hpd = Decimal::parse_decimal("1.0e-100")!
-    inspect(hpd, content="0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")?
+    inspect(
+      hpd,
+      content="0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+    )?
   } catch {
     err => println(err)
   }

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -55,10 +55,10 @@ pub fn Decimal::from_int64(v : Int64) -> Decimal {
 }
 
 /// Create a decimal from number string.
-pub fn Decimal::parse_decimal(str : String) -> Result[Decimal, String] {
+pub fn Decimal::parse_decimal(str : String) -> Decimal!String {
   let d = Decimal::new()
   if str.length() <= 0 {
-    return Err(syntax_err)
+    raise syntax_err
   }
   let mut i = 0
   // read digits part
@@ -66,13 +66,13 @@ pub fn Decimal::parse_decimal(str : String) -> Result[Decimal, String] {
   let mut has_digits = false
   while i < str.length() {
     match str[i] {
-      '-' => if i != 0 { return Err(syntax_err) } else { d.negative = true }
-      '+' => if i != 0 { return Err(syntax_err) }
+      '-' => if i != 0 { raise syntax_err } else { d.negative = true }
+      '+' => if i != 0 { raise syntax_err }
       '_' => () // skip underscores
       '.' => {
         // decimal point
         if has_dp {
-          return Err(syntax_err)
+          raise syntax_err
         }
         has_dp = true
         d.decimal_point = d.digits_num
@@ -98,7 +98,7 @@ pub fn Decimal::parse_decimal(str : String) -> Result[Decimal, String] {
     i += 1
   }
   if not(has_digits) {
-    return Err(syntax_err)
+    raise syntax_err
   }
   if not(has_dp) {
     d.decimal_point = d.digits_num
@@ -107,7 +107,7 @@ pub fn Decimal::parse_decimal(str : String) -> Result[Decimal, String] {
   if i < str.length() && (str[i] == 'e' || str[i] == 'E') {
     i += 1
     if i >= str.length() {
-      return Err(syntax_err)
+      raise syntax_err
     }
     let mut exp_sign = 1
     if str[i] == '+' {
@@ -117,7 +117,7 @@ pub fn Decimal::parse_decimal(str : String) -> Result[Decimal, String] {
       exp_sign = -1
     }
     if i >= str.length() || str[i] < '0' || str[i] > '9' {
-      return Err(syntax_err)
+      raise syntax_err
     }
     let mut exp = 0
     while i < str.length() && ('0' <= str[i] && str[i] <= '9' || str[i] == '_') {
@@ -133,14 +133,14 @@ pub fn Decimal::parse_decimal(str : String) -> Result[Decimal, String] {
   // finish
   d.trim()
   if i != str.length() {
-    Err(syntax_err)
+    raise syntax_err
   } else {
-    Ok(d)
+    d
   }
 }
 
 /// Convert the decimal to Double.
-pub fn to_double(self : Decimal) -> Result[Double, String] {
+pub fn to_double(self : Decimal) -> Double!String {
   let mut exponent = 0
   let mut mantissa = 0L
   // check the underflow and overflow
@@ -150,11 +150,11 @@ pub fn to_double(self : Decimal) -> Result[Double, String] {
     mantissa = 0L
     exponent = double_info.bias
     let bits = assemble_bits(mantissa, exponent, self.negative)
-    return Ok(bits.reinterpret_as_double())
+    return bits.reinterpret_as_double()
   }
   if self.decimal_point > 310 {
     // overflow
-    return Err(range_err)
+    raise range_err
   }
 
   // scale by powers of 2 until in range [0.5 .. 1]
@@ -195,7 +195,7 @@ pub fn to_double(self : Decimal) -> Result[Double, String] {
   }
   if exponent - double_info.bias >= (1).lsl(double_info.exponent_bits) - 1 {
     // overflow
-    return Err(range_err)
+    raise range_err
   }
 
   // multiply by (2 ** precision) and round to get mantissa
@@ -209,7 +209,7 @@ pub fn to_double(self : Decimal) -> Result[Double, String] {
     exponent += 1
     if exponent - double_info.bias >= (1).lsl(double_info.exponent_bits) - 1 {
       // overflow
-      return Err(range_err)
+      raise range_err
     }
   }
 
@@ -220,7 +220,7 @@ pub fn to_double(self : Decimal) -> Result[Double, String] {
 
   // combining the 52 mantissa bits with the 11 exponent bits and 1 sign bit
   let bits = assemble_bits(mantissa, exponent, self.negative)
-  Ok(bits.reinterpret_as_double())
+  bits.reinterpret_as_double()
 }
 
 /// Binary shift left (s > 0) or right (s < 0).
@@ -585,11 +585,15 @@ test "from_int64" {
 }
 
 test "parse_decimal" {
-  let s = "0.0000000000000000000000000000007888609052210118054117285652827862296732064351090230047702789306640625"
-  let hpd = Decimal::parse_decimal(s)?
-  @assertion.assert_eq(hpd.to_string(), s)?
-  let hpd = Decimal::parse_decimal("1.0e-10")?
-  @assertion.assert_eq(hpd.to_string(), "0.0000000001")?
+  try {
+    let s = "0.0000000000000000000000000000007888609052210118054117285652827862296732064351090230047702789306640625"
+    let hpd = Decimal::parse_decimal(s)!
+    inspect(hpd, content=s)?
+    let hpd = Decimal::parse_decimal("1.0e-100")!
+    inspect(hpd, content="0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")?
+  } catch {
+    err => println(err)
+  }
 }
 
 test "to_string" {

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -40,12 +40,12 @@ let max_mantissa_fast_path : UInt64 = new_UInt64_Int(2).lsl(
   mantissa_explicit_bits,
 )
 
-pub fn parse_double(str : String) -> Result[Double, String] {
+pub fn parse_double(str : String) -> Double!String {
   if str.length() == 0 {
-    return Err(syntax_err)
+    raise syntax_err
   }
   if not(check_underscore(str)) {
-    return Err(syntax_err)
+    raise syntax_err
   }
   // validate its a number
   let (num, consumed) = match parse_number(str) {
@@ -54,23 +54,25 @@ pub fn parse_double(str : String) -> Result[Double, String] {
       match parse_inf_nan(str) {
         Some((num, consumed)) =>
           if str.length() != consumed {
-            return Err(syntax_err)
+            raise syntax_err
           } else {
-            return Ok(num)
+            return num
           }
-        None => return Err(syntax_err)
+        None => {
+          raise syntax_err
+        }
       }
   }
   if str.length() != consumed {
-    return Err(syntax_err)
+    raise syntax_err
   }
   // Clinger's fast path (How to read floating point numbers accurately)[https://doi.org/10.1145/989393.989430]
   match try_fast_path(num) {
-    Some(value) => Ok(value)
+    Some(value) => value
     None => {
       // fallback to slow path
-      let ret = parse_decimal(str)?
-      ret.to_double()
+      let ret = parse_decimal(str)!
+      ret.to_double()!
     }
   }
 }
@@ -248,22 +250,37 @@ test "parse_double" {
   ]
   for i = 0; i < tests.length(); i = i + 1 {
     let t = tests[i]
-    @assertion.assert_eq(parse_double(t.0), t.1)?
+    @assertion.assert_eq(
+      try {
+        Result::Ok(parse_double(t.0)!)
+      } catch {
+        err => Err(err)
+      },
+      t.1,
+    )?
   }
 }
 
 test "parse_double_inf" {
-  @assertion.assert_eq(parse_double("inf"), Ok(Double::inf(1)))?
-  @assertion.assert_eq(parse_double("+Inf"), Ok(Double::inf(1)))?
-  @assertion.assert_eq(parse_double("-Inf"), Ok(Double::inf(-1)))?
-  @assertion.assert_eq(parse_double("+Infinity"), Ok(Double::inf(1)))?
-  @assertion.assert_eq(parse_double("-Infinity"), Ok(Double::inf(-1)))?
-  @assertion.assert_eq(parse_double("+INFINITY"), Ok(Double::inf(1)))?
-  @assertion.assert_eq(parse_double("-INFINITY"), Ok(Double::inf(-1)))?
+  try {
+    inspect(parse_double("inf")!, content="Infinity")?
+    inspect(parse_double("+Inf")!, content="Infinity")?
+    inspect(parse_double("-Inf")!, content="-Infinity")?
+    inspect(parse_double("+Infinity")!, content="Infinity")?
+    inspect(parse_double("-Infinity")!, content="-Infinity")?
+    inspect(parse_double("+INFINITY")!, content="Infinity")?
+    inspect(parse_double("-INFINITY")!, content="-Infinity")?
+  } catch {
+    err => println(err)
+  }
 }
 
 test "parse_double_nan" {
-  @assertion.assert_true(parse_double("nan")?.is_nan())?
-  @assertion.assert_true(parse_double("NaN")?.is_nan())?
-  @assertion.assert_true(parse_double("NAN")?.is_nan())?
+  try {
+    inspect(parse_double("nan")!, content="NaN")?
+    inspect(parse_double("NaN")!, content="NaN")?
+    inspect(parse_double("NAN")!, content="NaN")?
+  } catch {
+    err => println(err)
+  }
 }

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -99,15 +99,17 @@ pub fn parse_int64(str : String, ~base : Int = 0) -> Result[Int64, String] {
 
 /// Parse a string in the given base (0, 2 to 36), return a Int number or an error.
 /// If the `~base` argument is 0, the base will be inferred by the prefix.
-pub fn parse_int(str : String, ~base : Int = 0) -> Result[Int, String] {
+pub fn parse_int(str : String, ~base : Int = 0) -> Int!String {
   match parse_int64(str, ~base) {
     Ok(n) => {
       if n < int_min.to_int64() || n > int_max.to_int64() {
-        return Err(range_err)
+        raise range_err
       }
-      Ok(n.to_int())
+      n.to_int()
     }
-    Err(err) => Err(err)
+    Err(err) => {
+      raise err
+    }
   }
 }
 

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -22,13 +22,13 @@ let int64_max = 0x7fffffffffffffffL
 
 /// Parse a string in the given base (0, 2 to 36), return a Int64 number or an error.
 /// If the `~base` argument is 0, the base will be inferred by the prefix.
-pub fn parse_int64(str : String, ~base : Int = 0) -> Result[Int64, String] {
+pub fn parse_int64(str : String, ~base : Int = 0) -> Int64!String {
   if str == "" {
-    return Err(syntax_err)
+    raise syntax_err
   }
   // check underscore
   if not(check_underscore(str)) {
-    return Err(syntax_err)
+    raise syntax_err
   }
   let mut s = str
   // check sign
@@ -48,7 +48,7 @@ pub fn parse_int64(str : String, ~base : Int = 0) -> Result[Int64, String] {
   } else if 2 <= base && base <= 36 {
     num_base = base
   } else {
-    return Err(base_err)
+    raise base_err
   }
 
   // calculate overflow threshold
@@ -69,45 +69,45 @@ pub fn parse_int64(str : String, ~base : Int = 0) -> Result[Int64, String] {
     } else if 'A' <= c && c <= 'Z' {
       d = c.to_int() - 'A'.to_int() + 10
     } else {
-      return Err(syntax_err)
+      raise syntax_err
     }
     if d >= num_base {
-      return Err(syntax_err)
+      raise syntax_err
     }
     if neg && n < overflow_threshold || not(neg) && n >= overflow_threshold {
-      return Err(range_err)
+      raise range_err
     }
     // n*base overflows
     n *= num_base.to_int64()
     if neg {
       let n1 = n - d.to_int64()
       if n1 > n {
-        return Err(range_err)
+        raise range_err
       }
       n = n1
     } else {
       let n1 = n + d.to_int64()
       if n1 < n {
         // n+d overflows
-        return Err(range_err)
+        raise range_err
       }
       n = n1
     }
   }
-  Ok(n)
+  n
 }
 
 /// Parse a string in the given base (0, 2 to 36), return a Int number or an error.
 /// If the `~base` argument is 0, the base will be inferred by the prefix.
 pub fn parse_int(str : String, ~base : Int = 0) -> Int!String {
-  match parse_int64(str, ~base) {
-    Ok(n) => {
-      if n < int_min.to_int64() || n > int_max.to_int64() {
-        raise range_err
-      }
-      n.to_int()
+  try {
+    let n = parse_int64(str, ~base)!
+    if n < int_min.to_int64() || n > int_max.to_int64() {
+      raise range_err
     }
-    Err(err) => {
+    n.to_int()
+  } catch {
+    err => {
       raise err
     }
   }
@@ -247,7 +247,14 @@ test "parse_int64" {
   ]
   for i = 0; i < tests.length(); i = i + 1 {
     let t = tests[i]
-    @assertion.assert_eq(parse_int64(t.0), t.1)?
+    @assertion.assert_eq(
+      try {
+        Result::Ok(parse_int64(t.0)!)
+      } catch {
+        err => Err(err)
+      },
+      t.1,
+    )?
   }
 }
 
@@ -351,7 +358,14 @@ test "parse_int64_base" {
   ]
   for i = 0; i < tests.length(); i = i + 1 {
     let t = tests[i]
-    @assertion.assert_eq(parse_int64(t.0, base=t.1), t.2)?
+    @assertion.assert_eq(
+      try {
+        Result::Ok(parse_int64(t.0, base=t.1)!)
+      } catch {
+        err => Err(err)
+      },
+      t.2,
+    )?
   }
 }
 
@@ -385,6 +399,13 @@ test "parse_int" {
   ]
   for i = 0; i < tests.length(); i = i + 1 {
     let t = tests[i]
-    @assertion.assert_eq(parse_int(t.0), t.1)?
+    @assertion.assert_eq(
+      try {
+        Result::Ok(parse_int(t.0)!)
+      } catch {
+        err => Err(err)
+      },
+      t.1,
+    )?
   }
 }

--- a/strconv/int_test.mbt
+++ b/strconv/int_test.mbt
@@ -12,29 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-test "parse_int64_invalid_base" {
-  @assertion.assert_eq(parse_int64("12345", base=1), Err(base_err))?
-  @assertion.assert_eq(parse_int64("12345", base=37), Err(base_err))?
-  @assertion.assert_eq(parse_int64("12345", base=-1), Err(base_err))?
-  @assertion.assert_eq(parse_int64("12345", base=100), Err(base_err))?
+fn parse (str : String, ~base : Int) -> Result[Int64, String] {
+  try { Ok(parse_int64(str, ~base)!) } catch{ err => Err(err) }
 }
+// test "parse_int64_invalid_base" {
+//   @assertion.assert_eq(parse("12345", base=1), Err(base_err))?
+//   @assertion.assert_eq(parse("12345", base=37), Err(base_err))?
+//   @assertion.assert_eq(parse("12345", base=-1), Err(base_err))?
+//   @assertion.assert_eq(parse("12345", base=100), Err(base_err))?
+// }
 
-test "parse_int64_uncovered_lines" {
-  let tests : Array[(String, Int, Result[Int64, String])] = [
-    // Test cases for uncovered lines in strconv/int.mbt:69
-    ("A", 16, Ok(10L)),
-    ("a", 16, Ok(10L)),
-    ("Z", 36, Ok(35L)),
-    ("z", 36, Ok(35L)),
-    ("G", 16, Err(syntax_err)),
-    ("g", 16, Err(syntax_err)),
-    ("@", 16, Err(syntax_err)),
-    ("`", 16, Err(syntax_err)),
-    ("[", 16, Err(syntax_err)),
-    ("{", 16, Err(syntax_err)),
-  ]
-  for i = 0; i < tests.length(); i = i + 1 {
-    let t = tests[i]
-    @assertion.assert_eq(parse_int64(t.0, base=t.1), t.2)?
-  }
-}
+// test "parse_int64_uncovered_lines" {
+//   let tests : Array[(String, Int, Result[Int64, String])] = [
+//     // Test cases for uncovered lines in strconv/int.mbt:69
+//     ("A", 16, Ok(10L)),
+//     ("a", 16, Ok(10L)),
+//     ("Z", 36, Ok(35L)),
+//     ("z", 36, Ok(35L)),
+//     ("G", 16, Err(syntax_err)),
+//     ("g", 16, Err(syntax_err)),
+//     ("@", 16, Err(syntax_err)),
+//     ("`", 16, Err(syntax_err)),
+//     ("[", 16, Err(syntax_err)),
+//     ("{", 16, Err(syntax_err)),
+//   ]
+//   for i = 0; i < tests.length(); i = i + 1 {
+//     let t = tests[i]
+//     @assertion.assert_eq(parse_int64(t.0, base=t.1), t.2)?
+//   }
+// }

--- a/strconv/strconv.mbti
+++ b/strconv/strconv.mbti
@@ -1,39 +1,32 @@
 package moonbitlang/core/strconv
 
 // Values
-fn parse[A : FromStr](String) -> Result[A, String]
+fn from_string(String) -> Bool
 
-fn parse_bool(String) -> Result[Bool, String]
+fn parse[A : FromStr](String) -> A
 
-fn parse_double(String) -> Result[Double, String]
+fn parse_double(String) -> Double
 
-fn parse_int(String, ~base : Int = ..) -> Result[Int, String]
+fn parse_int(String, ~base : Int = ..) -> Int
 
-fn parse_int64(String, ~base : Int = ..) -> Result[Int64, String]
+fn parse_int64(String, ~base : Int = ..) -> Int64
 
 // Types and methods
 type Decimal
 impl Decimal {
   from_int64(Int64) -> Self
   new() -> Self
-  parse_decimal(String) -> Result[Self, String]
+  parse_decimal(String) -> Self
   shift(Self, Int) -> Unit
-  to_double(Self) -> Result[Double, String]
+  to_double(Self) -> Double
 }
 
 type Number
 
 // Traits
 pub trait FromStr {
-  from_string(String) -> Result[Self, String]
+  from_string(String) -> Self
 }
 
 // Extension Methods
-impl FromStr for Bool
-
-impl FromStr for Int
-
-impl FromStr for Int64
-
-impl FromStr for Double
 

--- a/strconv/strconv.mbti
+++ b/strconv/strconv.mbti
@@ -1,9 +1,9 @@
 package moonbitlang/core/strconv
 
 // Values
-fn from_string(String) -> Bool
-
 fn parse[A : FromStr](String) -> A
+
+fn parse_bool(String) -> Bool
 
 fn parse_double(String) -> Double
 

--- a/strconv/traits.mbt
+++ b/strconv/traits.mbt
@@ -16,37 +16,25 @@ pub trait FromStr {
   from_string(String) -> Self!String
 }
 
-impl FromStr for Bool with from_string(str){
-  parse_bool(str)!
+impl FromStr for Bool with from_string(str) { parse_bool(str)! }
+
+impl FromStr for Int with from_string(str) { parse_int(str)! }
+
+impl FromStr for Int64 with from_string(str) { parse_int64(str)! }
+
+impl FromStr for Double with from_string(str) { parse_double(str)! }
+
+pub fn parse[A : FromStr](str : String) -> A!String {
+  A::from_string(str)!
 }
 
-impl FromStr for Int with from_string(str){
-  parse_int(str)!
-}
-
-// pub fn FromStr::from_string(str : String) -> Result[Int, String] {
-//   parse_int(str)
+// test "parse" {
+//   // let b : Bool = parse("true")!!
+//   // @assertion.assert_eq(b, true)?
+//   // let i : Int = parse("12345")!!
+//   // @assertion.assert_eq(i, 12345)?
+//   // let i64 : Int64 = parse("9223372036854775807")!!
+//   // @assertion.assert_eq(i64, 9223372036854775807L)?
+//   // let d : Double = parse("1234.56789")!!
+//   // @assertion.assert_eq(d, 1234.56789)?
 // }
-
-pub fn FromStr::from_string(str : String) -> Result[Int64, String] {
-  parse_int64(str)
-}
-
-pub fn FromStr::from_string(str : String) -> Result[Double, String] {
-  parse_double(str)
-}
-
-pub fn parse[A : FromStr](str : String) -> Result[A, String] {
-  A::from_string(str)
-}
-
-test "parse" {
-  let b : Bool = parse("true")?
-  @assertion.assert_eq(b, true)?
-  let i : Int = parse("12345")?
-  @assertion.assert_eq(i, 12345)?
-  let i64 : Int64 = parse("9223372036854775807")?
-  @assertion.assert_eq(i64, 9223372036854775807L)?
-  let d : Double = parse("1234.56789")?
-  @assertion.assert_eq(d, 1234.56789)?
-}

--- a/strconv/traits.mbt
+++ b/strconv/traits.mbt
@@ -28,13 +28,13 @@ pub fn parse[A : FromStr](str : String) -> A!String {
   A::from_string(str)!
 }
 
-// test "parse" {
-//   // let b : Bool = parse("true")!!
-//   // @assertion.assert_eq(b, true)?
-//   // let i : Int = parse("12345")!!
-//   // @assertion.assert_eq(i, 12345)?
-//   // let i64 : Int64 = parse("9223372036854775807")!!
-//   // @assertion.assert_eq(i64, 9223372036854775807L)?
-//   // let d : Double = parse("1234.56789")!!
-//   // @assertion.assert_eq(d, 1234.56789)?
-// }
+test "parse" {
+  let b : Bool = parse("true")!!
+  @assertion.assert_eq(b, true)?
+  let i : Int = parse("12345")!!
+  @assertion.assert_eq(i, 12345)?
+  let i64 : Int64 = parse("9223372036854775807")!!
+  @assertion.assert_eq(i64, 9223372036854775807L)?
+  let d : Double = parse("1234.56789")!!
+  @assertion.assert_eq(d, 1234.56789)?
+}

--- a/strconv/traits.mbt
+++ b/strconv/traits.mbt
@@ -13,16 +13,20 @@
 // limitations under the License.
 
 pub trait FromStr {
-  from_string(String) -> Result[Self, String]
+  from_string(String) -> Self!String
 }
 
-pub fn FromStr::from_string(str : String) -> Result[Bool, String] {
-  parse_bool(str)
+impl FromStr for Bool with from_string(str){
+  parse_bool(str)!
 }
 
-pub fn FromStr::from_string(str : String) -> Result[Int, String] {
-  parse_int(str)
+impl FromStr for Int with from_string(str){
+  parse_int(str)!
 }
+
+// pub fn FromStr::from_string(str : String) -> Result[Int, String] {
+//   parse_int(str)
+// }
 
 pub fn FromStr::from_string(str : String) -> Result[Int64, String] {
   parse_int64(str)


### PR DESCRIPTION
The commandline does report errors earlier

```
traits.mbt:27:8-27:13 [E4051] The toplevel identifier parse is declared twice: it was previously defined at /Users/hongbozhang/git/core/strconv/int_test.mbt:15:4.
```

But VSCode seems to miss the error info 