### PR TITLE
Only expose println in core

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -23,10 +23,6 @@ fn panic[T]() -> T
 
 fn physical_equal[T](T, T) -> Bool
 
-fn print[T : Show](T) -> Unit
-
-fn print_string(String) -> Unit
-
 fn println[T : Show](T) -> Unit
 
 // Types and methods

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+fn print_string(s : String) -> Unit = "%print_string"
+
 pub fn println[T : Show](input : T) -> Unit {
   print_string(input.to_string())
   print_string("\n")
 }
 
-pub fn print[T : Show](input : T) -> Unit {
-  print_string(input.to_string())
-}
 
 pub fn to_string(self : Bool) -> String {
   if self {

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -19,7 +19,6 @@ pub fn println[T : Show](input : T) -> Unit {
   print_string("\n")
 }
 
-
 pub fn to_string(self : Bool) -> String {
   if self {
     "true"

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -16,7 +16,7 @@ pub fn ignore[T](t : T) -> Unit = "%ignore"
 
 pub fn physical_equal[T](a : T, b : T) -> Bool = "%refeq"
 
-pub fn print_string(s : String) -> Unit = "%print_string"
+
 
 pub fn abort[T](msg : String) -> T {
   ignore(msg)

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -16,8 +16,6 @@ pub fn ignore[T](t : T) -> Unit = "%ignore"
 
 pub fn physical_equal[T](a : T, b : T) -> Bool = "%refeq"
 
-
-
 pub fn abort[T](msg : String) -> T {
   ignore(msg)
   panic()

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -13,22 +13,22 @@
 // limitations under the License.
 
 /// The `CoverageCounter` structure is used for keeping track of the number of
-/// times each chunk of code is executed. It's not very useful outside of 
+/// times each chunk of code is executed. It's not very useful outside of
 /// generated code.
 struct CoverageCounter {
   counter : FixedArray[Int]
 } derive(Show)
 
 /// Create a new coverage counter with the given size.
-/// 
-/// @coverage.skip 
+///
+/// @coverage.skip
 pub fn CoverageCounter::new(size : Int) -> CoverageCounter {
   { counter: FixedArray::make(size, 0) }
 }
 
 /// Increment the specified tracking index.
-/// 
-/// @coverage.skip 
+///
+/// @coverage.skip
 pub fn CoverageCounter::incr(self : CoverageCounter, idx : Int) -> Unit {
   let counter = self.counter[idx]
   if counter < 0x7fffffff { // prevent overflow
@@ -57,7 +57,7 @@ priv enum MList[T] {
 let counters : Ref[MList[(String, CoverageCounter)]] = { val: MNil }
 
 /// Add the given counter along its ID to the tracking list.
-/// 
+///
 /// @coverage.skip
 pub fn track(name : String, counter : CoverageCounter) -> Unit {
   counters.val = MCons((name, counter), counters.val)
@@ -66,23 +66,28 @@ pub fn track(name : String, counter : CoverageCounter) -> Unit {
 trait Output {
   output(Self, String) -> Unit
 }
+type StringBuffer Array[String]
 
-type IO Int
-
-fn output(self : IO, content : String) -> Unit {
-  ignore(self)
-  print(content)
+impl Output for StringBuffer with output(self : StringBuffer, content : String) -> Unit {
+    self.0.push(content)
 }
+
+// type IO Int
+
+// fn output(self : IO, content : String) -> Unit {
+//   ignore(self)
+//   println(content)
+// }
 
 fn Output::output(self : Buffer, content : String) -> Unit {
   self.write_string(content)
 }
 
-// TODO: This escape function should belong to the String package, but is 
+// TODO: This escape function should belong to the String package, but is
 // not mature enough, so it's left here temporarily.
 /// Escape a string using standard JSON escape sequences to the given buffer,
 /// usually for quoting uses.
-///  
+///
 /// This method only escapes characters below 0x20 and the following characters:
 /// `"`, `'`, `\`.
 fn escape_to(s : String, buf : Buffer) -> Unit {
@@ -122,7 +127,7 @@ fn escape_to(s : String, buf : Buffer) -> Unit {
 
 /// Escape a string using standard C escape sequences and return the escaped string,
 /// usually for quoting uses.
-///  
+///
 /// This method only escapes characters below 0x20 and the following characters:
 /// `"`, `'`, `\`.
 pub fn escape(s : String) -> String {
@@ -134,9 +139,9 @@ pub fn escape(s : String) -> String {
 /// Output the counters to stdout for coverage report usages. The counter data
 /// is printed as a map of `{ counter_id: counter_contents }`, enclosed between
 /// a pair of delimiters.
-/// 
+///
 /// An example output of this function is like the following:
-/// 
+///
 /// ```plaintext
 /// ----- BEGIN MOONBIT COVERAGE -----
 /// {
@@ -147,7 +152,28 @@ pub fn escape(s : String) -> String {
 /// ```
 pub fn end() -> Unit {
   println("----- BEGIN MOONBIT COVERAGE -----")
-  coverage_log(counters.val, IO::IO(0))
+  let sbuf = StringBuffer::StringBuffer([])
+  coverage_log(counters.val, sbuf)
+  let line_buf = Buffer::new()
+  for i = 0; i < sbuf.0.length(); i = i + 1 {
+    let str = sbuf.0[i]
+    let mut start = 0
+    for j = 0; j < str.length(); j = j + 1 {
+      if str[j] == '\n' {
+        line_buf.write_sub_string(str, start, j)
+        println(line_buf.to_string())
+        line_buf.reset()
+        start = j + 1
+      }
+    }
+    if start < str.length() {
+      line_buf.write_sub_string(str, start, str.length())
+    }
+  }
+  let trailing_line = line_buf.to_string()
+  if trailing_line.length() > 0 {
+    println(trailing_line)
+  }
   println("----- END MOONBIT COVERAGE -----")
 }
 

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -74,7 +74,6 @@ impl Output for StringBuffer with output(self : StringBuffer, content : String) 
   self.0.push(content)
 }
 
-
 fn Output::output(self : Buffer, content : String) -> Unit {
   self.write_string(content)
 }
@@ -199,5 +198,5 @@ fn coverage_log(
     }
     MNil, _ => ()
   }
-  println("}")
+  print("}")
 }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -74,12 +74,6 @@ impl Output for StringBuffer with output(self : StringBuffer, content : String) 
   self.0.push(content)
 }
 
-// type IO Int
-
-// fn output(self : IO, content : String) -> Unit {
-//   ignore(self)
-//   println(content)
-// }
 
 fn Output::output(self : Buffer, content : String) -> Unit {
   self.write_string(content)

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -19,16 +19,17 @@ struct CoverageCounter {
   counter : FixedArray[Int]
 } derive(Show)
 
+// REMARK: Fow now `@coverage.skip` must have arguments, so we pass an empty string as an workaround.
 /// Create a new coverage counter with the given size.
 ///
-/// @coverage.skip
+/// @coverage.skip ""
 pub fn CoverageCounter::new(size : Int) -> CoverageCounter {
   { counter: FixedArray::make(size, 0) }
 }
 
 /// Increment the specified tracking index.
 ///
-/// @coverage.skip
+/// @coverage.skip ""
 pub fn CoverageCounter::incr(self : CoverageCounter, idx : Int) -> Unit {
   let counter = self.counter[idx]
   if counter < 0x7fffffff { // prevent overflow
@@ -66,10 +67,11 @@ pub fn track(name : String, counter : CoverageCounter) -> Unit {
 trait Output {
   output(Self, String) -> Unit
 }
-type StringBuffer Array[String]
+
+priv type StringBuffer Array[String]
 
 impl Output for StringBuffer with output(self : StringBuffer, content : String) -> Unit {
-    self.0.push(content)
+  self.0.push(content)
 }
 
 // type IO Int

--- a/coverage/coverage.mbti
+++ b/coverage/coverage.mbti
@@ -15,8 +15,6 @@ impl CoverageCounter {
   to_string(Self) -> String
 }
 
-type IO
-
 // Traits
 
 // Extension Methods

--- a/coverage/coverage_test.mbt
+++ b/coverage/coverage_test.mbt
@@ -60,17 +60,14 @@ test "log" {
   )
   let buf = Buffer::new(size_hint=1024)
   coverage_log(counters, buf)
-  let result = buf.to_string()
-  let expected =
-    #|{ "foo/foo": [1, 0]
-    #|, "foo/bar": [0, 1]
-    #|}
-    #|
-
-  // @assertion.assert_eq(result, expected)?
-  if result != expected {
-    return Err("Expected: " + expected + ", got: " + result)
-  }
+  inspect(
+    buf,
+    content=
+      #|{ "foo/foo": [1, 0]
+      #|, "foo/bar": [0, 1]
+      #|}
+    ,
+  )?
 }
 
 test "escape_to" {


### PR DESCRIPTION
TODO:
- [x] adapt coverage print only new println
- [x] provide a builtin %println instead of %print_string
