### PR TITLE
Add mutable sorted map

### DIFF
--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -32,7 +32,7 @@ pub fn new[K, V]() -> T[K, V] {
 /// Creates a sorted map from given entries.
 pub fn of[K : Compare, V](entries : Array[(K, V)]) -> T[K, V] {
   let map = { root: None, size: 0 }
-  entries.iter(fn(e) { map.add(e.0, e.1) })
+  entries.each(fn(e) { map.add(e.0, e.1) })
   map
 }
 

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -1,0 +1,119 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Returns a new sorted map.
+pub fn new[K, V]() -> T[K, V] {
+  { root: None, size: 0 }
+}
+
+/// Creates a sorted map from given entries.
+pub fn of[K : Compare, V](entries : Array[(K, V)]) -> T[K, V] {
+  let map = { root: None, size: 0 }
+  entries.iter(fn(e) { map.add(e.0, e.1) })
+  map
+}
+
+/// Inserts a key-value pair.
+pub fn add[K : Compare, V](self : T[K, V], key : K, value : V) -> Unit {
+  if self.size == 0 {
+    self.root = Some(new_node(key, value))
+    self.size += 1
+    return
+  }
+  let parent = loop self.root, self.root {
+    Some(curr), _ =>
+      continue if key < curr.key { curr.left } else { curr.right }, Some(curr)
+    None, parent => parent
+  }
+  let new = new_node(key, value, ~parent)
+  if parent.is_empty() {
+    self.root = Some(new)
+  } else if key < parent.unwrap().key {
+    parent.unwrap().left = Some(new)
+  } else {
+    parent.unwrap().right = Some(new)
+  }
+  new.parent = parent
+  self.balance(new)
+  self.size += 1
+}
+
+/// Removes a key-value pair.
+pub fn remove[K : Compare, V](self : T[K, V], key : K) -> Unit {
+  // Find node
+  let node = loop self.root {
+    Some(node) =>
+      if key == node.key {
+        break node
+      } else if key < node.key {
+        continue node.left
+      } else {
+        continue node.right
+      }
+    None => return
+  }
+  self.delete_node(node)
+  self.balance(node)
+  node.parent = None
+  self.size -= 1
+}
+
+/// Gets a value by a key.
+pub fn get[K : Compare, V](self : T[K, V], key : K) -> V? {
+  loop self.root {
+    Some(node) => {
+      let cmp = key.compare(node.key)
+      if cmp == 0 {
+        break Some(node.value)
+      } else if cmp > 0 {
+        continue node.right
+      } else {
+        continue node.left
+      }
+    }
+    None => break None
+  }
+}
+
+/// Checks if map contains a key-value pair.
+pub fn contains[K : Compare, V](self : T[K, V], key : K) -> Bool {
+  match self.get(key) {
+    Some(_) => true
+    None => false
+  }
+}
+
+pub fn op_set[K : Compare, V](self : T[K, V], key : K, value : V) -> Unit {
+  self.add(key, value)
+}
+
+pub fn op_get[K : Compare, V](self : T[K, V], key : K) -> V? {
+  self.get(key)
+}
+
+/// Returns true if map is empty.
+pub fn is_empty[K, V](self : T[K, V]) -> Bool {
+  self.size == 0
+}
+
+/// Returns the count of key-value pairs in the map.
+pub fn size[K, V](self : T[K, V]) -> Int {
+  self.size
+}
+
+/// Clears the map.
+pub fn clear[K, V](self : T[K, V]) -> Unit {
+  self.root = None
+  self.size = 0
+}

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -38,11 +38,6 @@ pub fn of[K : Compare, V](entries : Array[(K, V)]) -> T[K, V] {
 
 /// Inserts a key-value pair.
 pub fn add[K : Compare, V](self : T[K, V], key : K, value : V) -> Unit {
-  if self.size == 0 {
-    self.root = Some(new_node(key, value))
-    self.size += 1
-    return
-  }
   let parent = loop self.root, self.root {
     Some(curr), _ =>
       continue if key < curr.key { curr.left } else { curr.right }, Some(curr)
@@ -247,6 +242,7 @@ fn update_height[K, V](self : Node[K, V]) -> Unit {
 fn balance[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
   loop node.parent {
     Some(parent) => {
+      let pp = parent.parent
       parent.update_height()
       if height(parent.left) > height(parent.right) + 1 {
         self.rotate_right(parent)
@@ -254,7 +250,7 @@ fn balance[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
       if height(parent.right) > height(parent.left) + 1 {
         self.rotate_left(parent)
       }
-      continue parent.parent
+      continue pp
     }
     None => break
   }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -12,6 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub fn op_set[K : Compare, V](self : T[K, V], key : K, value : V) -> Unit {
+  self.add(key, value)
+}
+
+pub fn op_get[K : Compare, V](self : T[K, V], key : K) -> V? {
+  self.get(key)
+}
+
+pub fn op_equal[K : Eq, V : Eq](self : T[K, V], other : T[K, V]) -> Bool {
+  self.to_array() == other.to_array()
+}
+
 /// Returns a new sorted map.
 pub fn new[K, V]() -> T[K, V] {
   { root: None, size: 0 }
@@ -94,14 +106,6 @@ pub fn contains[K : Compare, V](self : T[K, V], key : K) -> Bool {
   }
 }
 
-pub fn op_set[K : Compare, V](self : T[K, V], key : K, value : V) -> Unit {
-  self.add(key, value)
-}
-
-pub fn op_get[K : Compare, V](self : T[K, V], key : K) -> V? {
-  self.get(key)
-}
-
 /// Returns true if map is empty.
 pub fn is_empty[K, V](self : T[K, V]) -> Bool {
   self.size == 0
@@ -116,4 +120,182 @@ pub fn size[K, V](self : T[K, V]) -> Int {
 pub fn clear[K, V](self : T[K, V]) -> Unit {
   self.root = None
   self.size = 0
+}
+
+/// Iterates the map.
+pub fn each[K, V](self : T[K, V], f : (K, V) -> Unit) -> Unit {
+  let s = []
+  let mut p = self.root
+  while p.is_empty().not() || s.is_empty().not() {
+    while p.is_empty().not() {
+      s.push(p)
+      p = p.unwrap().left
+    }
+    if s.is_empty().not() {
+      p = s.pop_exn()
+      f(p.unwrap().key, p.unwrap().value)
+      p = p.unwrap().right
+    }
+  }
+}
+
+/// Iterates the map with index.
+pub fn eachi[K, V](self : T[K, V], f : (Int, K, V) -> Unit) -> Unit {
+  let s = []
+  let mut p = self.root
+  let mut i = 0
+  while p.is_empty().not() || s.is_empty().not() {
+    while p.is_empty().not() {
+      s.push(p)
+      p = p.unwrap().left
+    }
+    if s.is_empty().not() {
+      p = s.pop_exn()
+      f(i, p.unwrap().key, p.unwrap().value)
+      p = p.unwrap().right
+      i += 1
+    }
+  }
+}
+
+/// Returns all keys in the map.
+pub fn keys[K, V](self : T[K, V]) -> Array[K] {
+  let keys = []
+  self.each(fn(k, _v) { keys.push(k) })
+  keys
+}
+
+/// Returns all values in the map.
+pub fn values[K, V](self : T[K, V]) -> Array[V] {
+  let values = []
+  self.each(fn(_k, v) { values.push(v) })
+  values
+}
+
+/// Converts the map to an array.
+pub fn to_array[K, V](self : T[K, V]) -> Array[(K, V)] {
+  let arr = []
+  self.each(fn(k, v) { arr.push((k, v)) })
+  arr
+}
+
+/// Returns a iterator.
+pub fn iter[K, V](self : T[K, V]) -> Iter[(K, V)] {
+  Iter::_unstable_internal_make(
+    fn(yield) {
+      let arr = self.to_array()
+      for i = 0, len = arr.length(); i < len; i = i + 1 {
+        match arr[i] {
+          (key, value) => if yield((key, value)) == IterEnd { break IterEnd }
+        }
+      } else {
+        IterContinue
+      }
+    },
+  )
+}
+
+// Private functions
+
+fn delete_node[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
+  if node.left.is_empty() {
+    self.replace_node(node, node.right)
+  } else if node.right.is_empty() {
+    self.replace_node(node, node.left)
+  } else {
+    let succ = min_node(node.right.unwrap())
+    if succ.parent != Some(node) {
+      self.replace_node(succ, succ.right)
+      succ.right = node.right
+      node.right.unwrap().parent = Some(succ)
+    }
+    self.replace_node(node, Some(succ))
+    succ.left = node.left
+    succ.left.unwrap().parent = Some(succ)
+    succ.update_height()
+  }
+}
+
+fn min_node[K, V](root : Node[K, V]) -> Node[K, V] {
+  loop root, root.left {
+    _, Some(n) => continue n, n.left
+    n, None => n
+  }
+}
+
+fn replace_node[K : Compare, V](
+  self : T[K, V],
+  u : Node[K, V],
+  v : Node[K, V]?
+) -> Unit {
+  if u.parent.is_empty() {
+    self.root = v
+  } else if u.parent.unwrap().left == Some(u) {
+    u.parent.unwrap().left = v
+  } else {
+    u.parent.unwrap().right = v
+  }
+  if v.is_empty().not() {
+    v.unwrap().parent = u.parent
+  }
+}
+
+fn update_height[K, V](self : Node[K, V]) -> Unit {
+  self.height = 1 + max(height(self.left), height(self.right))
+}
+
+fn balance[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
+  loop node.parent {
+    Some(parent) => {
+      parent.update_height()
+      if height(parent.left) > height(parent.right) + 1 {
+        self.rotate_right(parent)
+      }
+      if height(parent.right) > height(parent.left) + 1 {
+        self.rotate_left(parent)
+      }
+      continue parent.parent
+    }
+    None => break
+  }
+}
+
+fn rotate_left[K : Compare, V](self : T[K, V], target : Node[K, V]) -> Unit {
+  let pivot = target.right.unwrap()
+  target.right = pivot.left
+  if pivot.left.is_empty().not() {
+    pivot.left.unwrap().parent = Some(target)
+  }
+  pivot.parent = target.parent
+  if target.parent.is_empty() {
+    self.root = Some(pivot)
+  } else if target.parent.unwrap().left == Some(target) {
+    target.parent.unwrap().left = Some(pivot)
+  } else {
+    target.parent.unwrap().right = Some(pivot)
+  }
+  pivot.left = Some(target)
+  target.parent = Some(pivot)
+  target.update_height()
+  pivot.update_height()
+}
+
+fn rotate_right[K : Compare, V](self : T[K, V], target : Node[K, V]) -> Unit {
+  let pivot = target.left.unwrap()
+  target.left = pivot.right
+  if pivot.right.is_empty().not() {
+    pivot.right.unwrap().parent = Some(target)
+  }
+  pivot.parent = target.parent
+  if target.parent.is_empty() {
+    self.root = Some(pivot)
+  } else if target.parent.unwrap().left == Some(target) {
+    target.parent.unwrap().left = Some(pivot)
+  } else {
+    target.parent.unwrap().right = Some(pivot)
+  }
+  pivot.right = Some(target)
+  target.parent = Some(pivot)
+  target.update_height()
+  pivot.update_height()
 }

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -1,0 +1,92 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "should create with entries" {
+  let map = of([(1, "a"), (2, "b"), (3, "c")])
+  inspect(map.debug_tree(), content="([1]2,b,([0]1,a,_,_),([0]3,c,_,_))")?
+  inspect(map.size(), content="3")?
+}
+
+test "should correctly add node" {
+  let map = new()
+  map.add(8, "a")
+  map.add(7, "b")
+  map.add(6, "c")
+  map.add(5, "d")
+  map.add(4, "e")
+  map.add(3, "f")
+  map.add(2, "g")
+  map.add(1, "h")
+  inspect(
+    map.debug_tree(),
+    content="([3]5,d,([2]3,f,([1]2,g,([0]1,h,_,_),_),([0]4,e,_,_)),([1]7,b,([0]6,c,_,_),([0]8,a,_,_)))",
+  )?
+  inspect(map.size(), content="8")?
+}
+
+test "should correctly remove node and rebalance" {
+  let map = of(
+    [
+      (1, "a"),
+      (2, "b"),
+      (3, "c"),
+      (4, "d"),
+      (5, "e"),
+      (6, "f"),
+      (7, "g"),
+      (8, "h"),
+    ],
+  )
+  inspect(
+    map.debug_tree(),
+    content="([3]4,d,([1]2,b,([0]1,a,_,_),([0]3,c,_,_)),([2]6,f,([0]5,e,_,_),([1]7,g,_,([0]8,h,_,_))))",
+  )?
+  inspect(map.size(), content="8")?
+  map.remove(6)
+  inspect(
+    map.debug_tree(),
+    content="([2]4,d,([1]2,b,([0]1,a,_,_),([0]3,c,_,_)),([1]7,g,([0]5,e,_,_),([0]8,h,_,_)))",
+  )?
+  inspect(map.size(), content="7")?
+  map.remove(4)
+  inspect(
+    map.debug_tree(),
+    content="([2]5,e,([1]2,b,([0]1,a,_,_),([0]3,c,_,_)),([1]7,g,_,([0]8,h,_,_)))",
+  )?
+  inspect(map.size(), content="6")?
+  map.remove(2)
+  inspect(
+    map.debug_tree(),
+    content="([2]5,e,([1]3,c,([0]1,a,_,_),_),([1]7,g,_,([0]8,h,_,_)))",
+  )?
+  inspect(map.size(), content="5")?
+  map.remove(3)
+  inspect(
+    map.debug_tree(),
+    content="([2]5,e,([0]1,a,_,_),([1]7,g,_,([0]8,h,_,_)))",
+  )?
+  inspect(map.size(), content="4")?
+  map.remove(5)
+  inspect(map.debug_tree(), content="([1]7,g,([0]1,a,_,_),([0]8,h,_,_))")?
+  inspect(map.size(), content="3")?
+  map.remove(7)
+  inspect(map.debug_tree(), content="([1]8,h,([0]1,a,_,_),_)")?
+  inspect(map.size(), content="2")?
+  map.remove(8)
+  inspect(map.debug_tree(), content="([0]1,a,_,_)")?
+  inspect(map.size(), content="1")?
+  map.remove(1)
+  inspect(map.debug_tree(), content="_")?
+  inspect(map.size(), content="0")?
+}

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-test "should create with entries" {
-  let map = of([(1, "a"), (2, "b"), (3, "c")])
+test "new" {
+  let map : T[Int, String] = new()
+  inspect(map.debug_tree(), content="_")?
+  inspect(map.size(), content="0")?
+}
+
+test "of" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
   inspect(map.debug_tree(), content="([1]2,b,([0]1,a,_,_),([0]3,c,_,_))")?
   inspect(map.size(), content="3")?
 }
 
-test "should correctly add node" {
+test "add" {
   let map = new()
   map.add(8, "a")
   map.add(7, "b")
@@ -35,7 +41,7 @@ test "should correctly add node" {
   inspect(map.size(), content="8")?
 }
 
-test "should correctly remove node and rebalance" {
+test "remove" {
   let map = of(
     [
       (1, "a"),
@@ -89,4 +95,98 @@ test "should correctly remove node and rebalance" {
   map.remove(1)
   inspect(map.debug_tree(), content="_")?
   inspect(map.size(), content="0")?
+}
+
+test "get" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map.get(1), content="Some(a)")?
+  inspect(map.get(2), content="Some(b)")?
+  inspect(map.get(3), content="Some(c)")?
+  inspect(map.get(4), content="None")?
+}
+
+test "contains" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map.contains(1), content="true")?
+  inspect(map.contains(2), content="true")?
+  inspect(map.contains(3), content="true")?
+  inspect(map.contains(4), content="false")?
+}
+
+test "op_set" {
+  let map = new()
+  map[1] = "a"
+  map[2] = "b"
+  map[3] = "c"
+  inspect(map.debug_tree(), content="([1]2,b,([0]1,a,_,_),([0]3,c,_,_))")?
+}
+
+test "op_get" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map[1], content="Some(a)")?
+  inspect(map[2], content="Some(b)")?
+  inspect(map[3], content="Some(c)")?
+  inspect(map[4], content="None")?
+}
+
+test "op_equal" {
+  let a = of([(3, "c"), (2, "b"), (1, "a")])
+  let b = of([(4, "d"), (5, "e"), (6, "f")])
+  inspect(a == a, content="true")?
+  inspect(b == b, content="true")?
+  inspect(a == b, content="false")?
+  inspect(b == a, content="false")?
+}
+
+test "is_empty" {
+  let map : T[Int, String] = new()
+  inspect(map.is_empty(), content="true")?
+  map[1] = "a"
+  inspect(map.is_empty(), content="false")?
+}
+
+test "size" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map.size == map.size(), content="true")?
+}
+
+test "clear" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  map.clear()
+  inspect(map.debug_tree(), content="_")?
+  inspect(map.size, content="0")?
+}
+
+test "each" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  let buf = Buffer::make(0)
+  map.each(fn(k, v) { buf.write_string("\(k)\(v)") })
+  inspect(buf.to_string(), content="1a2b3c")?
+}
+
+test "eachi" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  let buf = Buffer::make(0)
+  map.eachi(fn(i, k, v) { buf.write_string("[\(i)]\(k)\(v)") })
+  inspect(buf.to_string(), content="[0]1a[1]2b[2]3c")?
+}
+
+test "keys" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map.keys(), content="[1, 2, 3]")?
+}
+
+test "values" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map.values(), content="[a, b, c]")?
+}
+
+test "to_array" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map.to_array(), content="[(1, a), (2, b), (3, c)]")?
+}
+
+test "iter" {
+  let map = of([(3, "c"), (2, "b"), (1, "a")])
+  inspect(map.iter().collect(), content="[(1, a), (2, b), (3, c)]")?
 }

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -41,6 +41,30 @@ test "add" {
   inspect(map.size(), content="8")?
 }
 
+test "RL rotate" {
+  let map = new()
+  map.add(5, "a")
+  map.add(1, "b")
+  map.add(3, "c")
+  map.add(2, "d")
+  inspect(
+    map.debug_tree(),
+    content="([2]3,c,([1]1,b,_,([0]2,d,_,_)),([0]5,a,_,_))",
+  )?
+}
+
+test "LR rotate" {
+  let map = new()
+  map.add(2, "a")
+  map.add(5, "b")
+  map.add(3, "c")
+  map.add(4, "d")
+  inspect(
+    map.debug_tree(),
+    content="([2]3,c,([0]2,a,_,_),([1]5,b,([0]4,d,_,_),_))",
+  )?
+}
+
 test "remove" {
   let map = of(
     [
@@ -95,6 +119,12 @@ test "remove" {
   map.remove(1)
   inspect(map.debug_tree(), content="_")?
   inspect(map.size(), content="0")?
+}
+
+test "remove unexist" {
+  let map = of([(1, "a"), (2, "b"), (3, "c")])
+  map.remove(4)
+  inspect(map.size, content="3")?
 }
 
 test "get" {
@@ -189,4 +219,5 @@ test "to_array" {
 test "iter" {
   let map = of([(3, "c"), (2, "b"), (1, "a")])
   inspect(map.iter().collect(), content="[(1, a), (2, b), (3, c)]")?
+  inspect(map.iter().take(2).collect(), content="[(1, a), (2, b)]")?
 }

--- a/sorted_map/moon.pkg.json
+++ b/sorted_map/moon.pkg.json
@@ -1,6 +1,8 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
+    "moonbitlang/core/coverage",
+    "moonbitlang/core/option",
+    "moonbitlang/core/tuple"
   ]
 }

--- a/sorted_map/moon.pkg.json
+++ b/sorted_map/moon.pkg.json
@@ -1,0 +1,6 @@
+{
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/coverage"
+  ]
+}

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -1,0 +1,32 @@
+package moonbitlang/core/sorted_map
+
+// Values
+fn new[K, V]() -> T[K, V]
+
+fn of[K : Compare + Eq, V](Array[Tuple[K, V]]) -> T[K, V]
+
+// Types and methods
+type T
+impl T {
+  add[K : Compare + Eq, V](Self[K, V], K, V) -> Unit
+  clear[K, V](Self[K, V]) -> Unit
+  contains[K : Compare + Eq, V](Self[K, V], K) -> Bool
+  each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
+  eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
+  get[K : Compare + Eq, V](Self[K, V], K) -> V?
+  is_empty[K, V](Self[K, V]) -> Bool
+  iter[K, V](Self[K, V]) -> Iter[Tuple[K, V]]
+  keys[K, V](Self[K, V]) -> Array[K]
+  op_equal[K : Eq, V : Eq](Self[K, V], Self[K, V]) -> Bool
+  op_get[K : Compare + Eq, V](Self[K, V], K) -> V?
+  op_set[K : Compare + Eq, V](Self[K, V], K, V) -> Unit
+  remove[K : Compare + Eq, V](Self[K, V], K) -> Unit
+  size[K, V](Self[K, V]) -> Int
+  to_array[K, V](Self[K, V]) -> Array[Tuple[K, V]]
+  values[K, V](Self[K, V]) -> Array[V]
+}
+
+// Traits
+
+// Extension Methods
+

--- a/sorted_map/types.mbt
+++ b/sorted_map/types.mbt
@@ -1,0 +1,31 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+priv struct Node[K, V] {
+  mut key : K
+  mut value : V
+  mut left : Node[K, V]?
+  mut right : Node[K, V]?
+  mut parent : Node[K, V]?
+  mut height : Int
+}
+
+fn op_equal[K : Eq, V](self : Node[K, V], other : Node[K, V]) -> Bool {
+  self.key == other.key
+}
+
+struct T[K, V] {
+  mut root : Node[K, V]?
+  mut size : Int
+}

--- a/sorted_map/types.mbt
+++ b/sorted_map/types.mbt
@@ -13,16 +13,12 @@
 // limitations under the License.
 
 priv struct Node[K, V] {
-  mut key : K
+  key : K
   mut value : V
   mut left : Node[K, V]?
   mut right : Node[K, V]?
   mut parent : Node[K, V]?
   mut height : Int
-}
-
-fn op_equal[K : Eq, V](self : Node[K, V], other : Node[K, V]) -> Bool {
-  self.key == other.key
 }
 
 struct T[K, V] {

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -20,6 +20,10 @@ fn new_node[K, V](
   { key, value, parent, left: None, right: None, height: 0 }
 }
 
+fn op_equal[K : Eq, V](self : Node[K, V], other : Node[K, V]) -> Bool {
+  self.key == other.key
+}
+
 fn max(x : Int, y : Int) -> Int {
   if x > y {
     x
@@ -33,109 +37,6 @@ fn height[K, V](node : Node[K, V]?) -> Int {
     Some(n) => n.height
     None => -1
   }
-}
-
-fn delete_node[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
-  if node.left.is_empty() {
-    self.replace_node(node, node.right)
-  } else if node.right.is_empty() {
-    self.replace_node(node, node.left)
-  } else {
-    let succ = min_node(node.right.unwrap())
-    if succ.parent != Some(node) {
-      self.replace_node(succ, succ.right)
-      succ.right = node.right
-      node.right.unwrap().parent = Some(succ)
-    }
-    self.replace_node(node, Some(succ))
-    succ.left = node.left
-    succ.left.unwrap().parent = Some(succ)
-    succ.update_height()
-  }
-}
-
-fn min_node[K, V](root : Node[K, V]) -> Node[K, V] {
-  loop root, root.left {
-    _, Some(n) => continue n, n.left
-    n, None => n
-  }
-}
-
-fn replace_node[K : Compare, V](
-  self : T[K, V],
-  u : Node[K, V],
-  v : Node[K, V]?
-) -> Unit {
-  if u.parent.is_empty() {
-    self.root = v
-  } else if u.parent.unwrap().left == Some(u) {
-    u.parent.unwrap().left = v
-  } else {
-    u.parent.unwrap().right = v
-  }
-  if v.is_empty().not() {
-    v.unwrap().parent = u.parent
-  }
-}
-
-fn update_height[K, V](self : Node[K, V]) -> Unit {
-  self.height = 1 + max(height(self.left), height(self.right))
-}
-
-fn balance[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
-  loop node.parent {
-    Some(parent) => {
-      parent.update_height()
-      if height(parent.left) > height(parent.right) + 1 {
-        self.rotate_right(parent)
-      }
-      if height(parent.right) > height(parent.left) + 1 {
-        self.rotate_left(parent)
-      }
-      continue parent.parent
-    }
-    _ => break
-  }
-}
-
-fn rotate_left[K : Compare, V](self : T[K, V], target : Node[K, V]) -> Unit {
-  let pivot = target.right.unwrap()
-  target.right = pivot.left
-  if pivot.left.is_empty().not() {
-    pivot.left.unwrap().parent = Some(target)
-  }
-  pivot.parent = target.parent
-  if target.parent.is_empty() {
-    self.root = Some(pivot)
-  } else if target.parent.unwrap().left == Some(target) {
-    target.parent.unwrap().left = Some(pivot)
-  } else {
-    target.parent.unwrap().right = Some(pivot)
-  }
-  pivot.left = Some(target)
-  target.parent = Some(pivot)
-  target.update_height()
-  pivot.update_height()
-}
-
-fn rotate_right[K : Compare, V](self : T[K, V], target : Node[K, V]) -> Unit {
-  let pivot = target.left.unwrap()
-  target.left = pivot.right
-  if pivot.right.is_empty().not() {
-    pivot.right.unwrap().parent = Some(target)
-  }
-  pivot.parent = target.parent
-  if target.parent.is_empty() {
-    self.root = Some(pivot)
-  } else if target.parent.unwrap().left == Some(target) {
-    target.parent.unwrap().left = Some(pivot)
-  } else {
-    target.parent.unwrap().right = Some(pivot)
-  }
-  pivot.right = Some(target)
-  target.parent = Some(pivot)
-  target.update_height()
-  pivot.update_height()
 }
 
 fn debug_node[K : Show, V : Show](self : Node[K, V]) -> String {

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -1,0 +1,161 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn new_node[K, V](
+  key : K,
+  value : V,
+  ~parent : Node[K, V]? = None
+) -> Node[K, V] {
+  { key, value, parent, left: None, right: None, height: 0 }
+}
+
+fn max(x : Int, y : Int) -> Int {
+  if x > y {
+    x
+  } else {
+    y
+  }
+}
+
+fn height[K, V](node : Node[K, V]?) -> Int {
+  match node {
+    Some(n) => n.height
+    None => -1
+  }
+}
+
+fn delete_node[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
+  if node.left.is_empty() {
+    self.replace_node(node, node.right)
+  } else if node.right.is_empty() {
+    self.replace_node(node, node.left)
+  } else {
+    let succ = min_node(node.right.unwrap())
+    if succ.parent != Some(node) {
+      self.replace_node(succ, succ.right)
+      succ.right = node.right
+      node.right.unwrap().parent = Some(succ)
+    }
+    self.replace_node(node, Some(succ))
+    succ.left = node.left
+    succ.left.unwrap().parent = Some(succ)
+    succ.update_height()
+  }
+}
+
+fn min_node[K, V](root : Node[K, V]) -> Node[K, V] {
+  loop root, root.left {
+    _, Some(n) => continue n, n.left
+    n, None => n
+  }
+}
+
+fn replace_node[K : Compare, V](
+  self : T[K, V],
+  u : Node[K, V],
+  v : Node[K, V]?
+) -> Unit {
+  if u.parent.is_empty() {
+    self.root = v
+  } else if u.parent.unwrap().left == Some(u) {
+    u.parent.unwrap().left = v
+  } else {
+    u.parent.unwrap().right = v
+  }
+  if v.is_empty().not() {
+    v.unwrap().parent = u.parent
+  }
+}
+
+fn update_height[K, V](self : Node[K, V]) -> Unit {
+  self.height = 1 + max(height(self.left), height(self.right))
+}
+
+fn balance[K : Compare, V](self : T[K, V], node : Node[K, V]) -> Unit {
+  loop node.parent {
+    Some(parent) => {
+      parent.update_height()
+      if height(parent.left) > height(parent.right) + 1 {
+        self.rotate_right(parent)
+      }
+      if height(parent.right) > height(parent.left) + 1 {
+        self.rotate_left(parent)
+      }
+      continue parent.parent
+    }
+    _ => break
+  }
+}
+
+fn rotate_left[K : Compare, V](self : T[K, V], target : Node[K, V]) -> Unit {
+  let pivot = target.right.unwrap()
+  target.right = pivot.left
+  if pivot.left.is_empty().not() {
+    pivot.left.unwrap().parent = Some(target)
+  }
+  pivot.parent = target.parent
+  if target.parent.is_empty() {
+    self.root = Some(pivot)
+  } else if target.parent.unwrap().left == Some(target) {
+    target.parent.unwrap().left = Some(pivot)
+  } else {
+    target.parent.unwrap().right = Some(pivot)
+  }
+  pivot.left = Some(target)
+  target.parent = Some(pivot)
+  target.update_height()
+  pivot.update_height()
+}
+
+fn rotate_right[K : Compare, V](self : T[K, V], target : Node[K, V]) -> Unit {
+  let pivot = target.left.unwrap()
+  target.left = pivot.right
+  if pivot.right.is_empty().not() {
+    pivot.right.unwrap().parent = Some(target)
+  }
+  pivot.parent = target.parent
+  if target.parent.is_empty() {
+    self.root = Some(pivot)
+  } else if target.parent.unwrap().left == Some(target) {
+    target.parent.unwrap().left = Some(pivot)
+  } else {
+    target.parent.unwrap().right = Some(pivot)
+  }
+  pivot.right = Some(target)
+  target.parent = Some(pivot)
+  target.update_height()
+  pivot.update_height()
+}
+
+fn debug_node[K : Show, V : Show](self : Node[K, V]) -> String {
+  let l = match self.left {
+    Some(left) => left.debug_node()
+    None => "_"
+  }
+  let r = match self.right {
+    Some(right) => right.debug_node()
+    None => "_"
+  }
+  let key = self.key
+  let value = self.value
+  let height = self.height
+  "([\(height)]\(key),\(value),\(l),\(r))"
+}
+
+fn debug_tree[K : Show, V : Show](self : T[K, V]) -> String {
+  match self.root {
+    Some(root) => root.debug_node()
+    None => "_"
+  }
+}


### PR DESCRIPTION
This PR adds a sorted map package, contains a sorted map based on an iterative AVL tree.
Closes #497 