### PR TITLE
feat: make Buffer::grow_if_necessary public

### DIFF
--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -75,6 +75,11 @@ pub fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
   }
 }
 
+/// Returns the total number of bytes the Buffer can hold without reallocating.
+pub fn capacity(self : Buffer) -> Int {
+  self.bytes.length()
+}
+
 /// Return a new String contains the data in buffer.
 pub fn to_string(self : Buffer) -> String {
   self.bytes.sub_string(0, self.len)

--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -58,7 +58,7 @@ pub fn expect(
 }
 
 /// Expand the buffer size if capacity smaller than required space.
-fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
+pub fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
   // TODO: get rid of mut
   let mut enough_space = self.bytes.length()
   if enough_space <= 0 {

--- a/builtin/buffer_test.mbt
+++ b/builtin/buffer_test.mbt
@@ -125,3 +125,8 @@ test "to_bytes method" {
   let bytes = buf.to_bytes()
   @assertion.assert_eq(bytes.length(), 8)? // Each character in "Test" is 2 bytes
 }
+
+test "buffer_capacity" {
+  let buf = Buffer::make(10)
+  @assertion.assert_true(buf.capacity() >= 10)?
+}

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -109,6 +109,7 @@ impl ArrayView {
 
 type Buffer
 impl Buffer {
+  capacity(Self) -> Int
   expect(Self, ~content : String = .., ~loc : SourceLoc = _, ~args_loc : ArgsLoc = _) -> Result[Unit, String]
   grow_if_necessary(Self, Int) -> Unit
   make(Int) -> Self

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -110,6 +110,7 @@ impl ArrayView {
 type Buffer
 impl Buffer {
   expect(Self, ~content : String = .., ~loc : SourceLoc = _, ~args_loc : ArgsLoc = _) -> Result[Unit, String]
+  grow_if_necessary(Self, Int) -> Unit
   make(Int) -> Self
   new(~size_hint : Int = ..) -> Self
   reset(Self) -> Unit


### PR DESCRIPTION
Making `Buffer::grow_if_necessary` public allows users to explicitly grow or pre-allocate memory, enabling various optimizations that can improve performance.
