### PR TITLE
add `push_iter` method to array

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -26,6 +26,21 @@ pub fn iter[T](self : Array[T]) -> Iter[T] {
   )
 }
 
+/// Adds all elements from an iterator to the end of the array.
+///
+/// This function iterates over each element in the provided iterator
+/// and adds them to the array using the `push` method.
+///
+/// # Example
+/// ```
+/// let u = [1, 2, 3]
+/// let v = [4, 5, 6]
+/// u.push_iter(v.iter())
+/// ```
+pub fn push_iter[T](self : Array[T], iter : Iter[T]) -> Unit {
+  iter.each(fn { x => self.push(x) })
+}
+
 pub fn copy[T](self : Array[T]) -> Array[T] {
   let len = self.length()
   if len == 0 {

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -40,6 +40,7 @@ impl Array {
   iter[T](Self[T]) -> Iter[T]
   join[T : Show](Self[T], String) -> String
   new_with_index[T](Int, (Int) -> T) -> Self[T]
+  push_iter[T](Self[T], Iter[T]) -> Unit
   shuffle[T](Self[T], ~rand : (Int) -> Int) -> Self[T]
   shuffle_in_place[T](Self[T], ~rand : (Int) -> Int) -> Unit
   sort[T : Compare + Eq](Self[T]) -> Unit

--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -76,6 +76,13 @@ test "push" {
   @test.eq(v, [6, 4, 5])!
 }
 
+test "push_iter" {
+  let u = [1, 2, 3]
+  let v = [4, 5, 6]
+  u.push_iter(v.iter())
+  inspect(u, content="[1, 2, 3, 4, 5, 6]")!
+}
+
 test "drain" {
   let v = [3, 4, 5]
   let v2 = [1, 2, 3, 4, 5]


### PR DESCRIPTION
This PR introduces the `push_iter` method to the `array`, allowing users to append all elements from an iterator to the end of an array.

### Changes
- Implemented the `push_iter` method in `array/array.mbt`.
- The method iterates over each element provided by the iterator and appends it to the array using the built-in `push` method.

### Example
```moonbit
let u = [1, 2, 3]
let v = [4, 5, 6]
u.push_iter(v.iter())
```