### PR TITLE
adapt new array slice syntax

### DIFF
--- a/array/fixedarray_sort.mbt
+++ b/array/fixedarray_sort.mbt
@@ -89,8 +89,8 @@ fn FixedArraySlice::insertion_sort[T : Compare](
   }
 }
 
-/// Merges non-decreasing runs `arr[..mid]` and `arr[mid..]`. Copy `arr[mid..]` to buf and merge 
-/// `buf` and `arr[..mid]` to `arr[..]`
+/// Merges non-decreasing runs `arr[:mid]` and `arr[mid:]`. Copy `arr[mid:]` to buf and merge 
+/// `buf` and `arr[:mid]` to `arr[:]`
 fn merge[T : Compare](arr : FixedArraySlice[T], mid : Int) -> Unit {
   let buf_len = arr.length() - mid
   let buf : FixedArray[T] = FixedArray::make(buf_len, arr[mid])
@@ -156,7 +156,7 @@ fn provide_sorted_batch[T : Compare](
   // merge sort on short sequences, so this significantly improves performance.
   let start_end_diff = end - start
   if start_end_diff < min_insertion_run && end < len {
-    // v[start_found..end] are elements that are already sorted in the input. We want to extend
+    // v[start_found:end] are elements that are already sorted in the input. We want to extend
     // the sorted region to the left, so we push up MIN_INSERTION_RUN - 1 to the right. Which is
     // more efficient that trying to push those already sorted elements to the left.
     let sort_end = minimum(len, start + min_insertion_run)

--- a/array/view_test.mbt
+++ b/array/view_test.mbt
@@ -14,7 +14,7 @@
 
 test "slice" {
   let v = [1, 2, 3, 4, 5]
-  let s = v[1..4]
+  let s = v[1:4]
   @test.eq(s.length(), 3)!
   @test.eq(s[0], 2)!
   @test.eq(s[1], 3)!

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -13,27 +13,27 @@
 // limitations under the License.
 
 test "array_as_view" {
-  inspect([1, 2, 3][..].length(), content="3")!
+  inspect([1, 2, 3][:].length(), content="3")!
 }
 
 test "view_as_view" {
-  inspect([1, 2, 3][..][..].length(), content="3")!
+  inspect([1, 2, 3][:][:].length(), content="3")!
 }
 
 test "op_get" {
-  inspect([1, 2, 3][..][1], content="2")!
-  inspect([1, 2, 3][..][2], content="3")!
+  inspect([1, 2, 3][:][1], content="2")!
+  inspect([1, 2, 3][:][2], content="3")!
 }
 
 test "op_set" {
-  let v = [1, 2, 3][..]
+  let v = [1, 2, 3][:]
   inspect(v[1], content="2")!
   v[1] = 4
   inspect(v[1], content="4")!
 }
 
 test "swap" {
-  let v = [1, 2, 3][..]
+  let v = [1, 2, 3][:]
   inspect(v[1], content="2")!
   v.swap(1, 2)
   inspect(v[1], content="3")!
@@ -60,33 +60,33 @@ test "panic array_as_view_length_index_error" {
 }
 
 test "panic view_as_view_start_index_error" {
-  [1, 2, 3][..].op_as_view(start=-1, end=0) |> ignore
+  [1, 2, 3][:].op_as_view(start=-1, end=0) |> ignore
 }
 
 test "panic view_as_view_start_index_error" {
-  [1, 2, 3][..].op_as_view(start=-1, end=0) |> ignore
+  [1, 2, 3][:].op_as_view(start=-1, end=0) |> ignore
 }
 
 test "panic view_as_view_end_index_error" {
-  [1, 2, 3][..].op_as_view(start=0, end=-1) |> ignore
+  [1, 2, 3][:].op_as_view(start=0, end=-1) |> ignore
 }
 
 test "panic view_as_view_end_index_error" {
-  [1, 2, 3][..].op_as_view(start=0, end=-1) |> ignore
+  [1, 2, 3][:].op_as_view(start=0, end=-1) |> ignore
 }
 
 test "panic view_as_view_length_index_error" {
-  [1, 2, 3][..].op_as_view(start=0, end=4) |> ignore
+  [1, 2, 3][:].op_as_view(start=0, end=4) |> ignore
 }
 
 test "panic array_as_view_get_index_error" {
-  [1, 2, 3][..][5] |> ignore
+  [1, 2, 3][:][5] |> ignore
 }
 
 test "panic array_as_view_set_index_error" {
-  [1, 2, 3][..][5] = 0
+  [1, 2, 3][:][5] = 0
 }
 
 test "panic array_as_view_swap_index_error" {
-  [1, 2, 3][..].swap(1, 9)
+  [1, 2, 3][:].swap(1, 9)
 }

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -269,7 +269,7 @@ test "split_bis" {
 //     }
 //   }
 
-//   sub(array.length(), array[..]).0
+//   sub(array.length(), array[:]).0
 // }
 
 test "panic remove_min on empty set" {

--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -27,7 +27,7 @@ fn lex_value(
   ctx : ParseContext,
   ~allow_rbracket : Bool = false
 ) -> Token!ParseError {
-  for ; ; {
+  for {
     match read_char(ctx) {
       Some('\t' | ' ' | '\n' | '\r') => continue
       Some('{') => return LBrace

--- a/json/lex_misc.mbt
+++ b/json/lex_misc.mbt
@@ -34,7 +34,7 @@ fn read_char(ctx : ParseContext) -> Char? {
 }
 
 fn lex_skip_whitespace(ctx : ParseContext) -> Unit {
-  for ; ; {
+  for {
     match read_char(ctx) {
       Some('\t' | '\u000B' | '\u000C' | ' ' | '\n' | '\r') => continue
       Some(c) => {

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 fn lex_decimal_integer(ctx : ParseContext, ~start : Int) -> Double!ParseError {
-  for ; ; {
+  for {
     match read_char(ctx) {
       Some('.') => return lex_decimal_point(ctx, ~start)!
       Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
@@ -44,7 +44,7 @@ fn lex_decimal_point(ctx : ParseContext, ~start : Int) -> Double!ParseError {
 }
 
 fn lex_decimal_fraction(ctx : ParseContext, ~start : Int) -> Double!ParseError {
-  for ; ; {
+  for {
     match read_char(ctx) {
       Some('e' | 'E') => return lex_decimal_exponent(ctx, ~start)!
       Some(c) => {
@@ -97,7 +97,7 @@ fn lex_decimal_exponent_integer(
   ctx : ParseContext,
   ~start : Int
 ) -> Double!ParseError {
-  for ; ; {
+  for {
     match read_char(ctx) {
       Some(c) => {
         if c >= '0' && c <= '9' {

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -21,7 +21,7 @@ fn lex_string(ctx : ParseContext) -> String!ParseError {
     }
   }
 
-  for ; ; {
+  for {
     match read_char(ctx) {
       Some('"') => {
         flush(ctx.offset - 1)

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -248,7 +248,7 @@ pub fn last_index_of(
   let min = sub_len - 1
   let last = str[sub_len - 1]
   let mut i = from - 1
-  for ; ; {
+  for {
     // find last character
     while i >= min && self[i] != last {
       i -= 1


### PR DESCRIPTION
The syntax for array slice has been changed from `arr[b..e]` to `arr[b:e]`, and the old syntax will be removed shortly. This PR ports core to the new syntax. The old syntax will be removed shortly.

There are also some formatter change in the most recent compiler release. Since the formatter will now format the old `arr[b..e]` to the new `arr[b:e]`, these changes must be shipped together.