### PR TITLE
add bitwise operations for UInt/UInt64

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -287,6 +287,12 @@ impl Int64 {
 impl UInt {
   compare(UInt, UInt) -> Int
   debug_write(UInt, Buffer) -> Unit
+  land(UInt, UInt) -> UInt
+  lnot(UInt) -> UInt
+  lor(UInt, UInt) -> UInt
+  lsl(UInt, Int) -> UInt
+  lsr(UInt, Int) -> UInt
+  lxor(UInt, UInt) -> UInt
   op_add(UInt, UInt) -> UInt
   op_div(UInt, UInt) -> UInt
   op_equal(UInt, UInt) -> Bool
@@ -301,6 +307,12 @@ impl UInt {
 impl UInt64 {
   compare(UInt64, UInt64) -> Int
   extend_uint(UInt) -> UInt64
+  land(UInt64, UInt64) -> UInt64
+  lnot(UInt64, UInt64) -> UInt64
+  lor(UInt64, UInt64) -> UInt64
+  lsl(UInt64, Int) -> UInt64
+  lsr(UInt64, Int) -> UInt64
+  lxor(UInt64, UInt64) -> UInt64
   op_add(UInt64, UInt64) -> UInt64
   op_div(UInt64, UInt64) -> UInt64
   op_equal(UInt64, UInt64) -> Bool

--- a/builtin/int64.js.mbt
+++ b/builtin/int64.js.mbt
@@ -488,3 +488,27 @@ pub fn UInt64::op_equal(self : UInt64, other : UInt64) -> Bool {
 pub fn UInt64::trunc_double(value : Double) -> UInt64 {
   MyInt64::trunc_double_u(value).to_uint64()
 }
+
+pub fn UInt64::land(self : UInt64, other : UInt64) -> UInt64 {
+  MyInt64::land(MyInt64::from_uint64(self), MyInt64::from_uint64(other)).to_uint64()
+}
+
+pub fn UInt64::lor(self : UInt64, other : UInt64) -> UInt64 {
+  MyInt64::lor(MyInt64::from_uint64(self), MyInt64::from_uint64(other)).to_uint64()
+}
+
+pub fn UInt64::lxor(self : UInt64, other : UInt64) -> UInt64 {
+  MyInt64::lxor(MyInt64::from_uint64(self), MyInt64::from_uint64(other)).to_uint64()
+}
+
+pub fn UInt64::lnot(self : UInt64) -> UInt64 {
+  MyInt64::lnot(MyInt64::from_uint64(self)).to_uint64()
+}
+
+pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 {
+  MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
+}
+
+pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 {
+  MyInt64::lsr(MyInt64::from_uint64(self), shift).to_uint64()
+}

--- a/builtin/int64.wasm-gc.mbt
+++ b/builtin/int64.wasm-gc.mbt
@@ -85,3 +85,15 @@ pub fn UInt64::op_mod(self : UInt64, other : UInt64) -> UInt64 = "%u64.mod"
 pub fn UInt64::compare(self : UInt64, other : UInt64) -> Int = "%u64.compare"
 
 pub fn UInt64::op_equal(self : UInt64, other : UInt64) -> Bool = "%u64.eq"
+
+pub fn UInt64::land(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitand"
+
+pub fn UInt64::lor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitor"
+
+pub fn UInt64::lxor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitxor"
+
+pub fn UInt64::lnot(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitnot"
+
+pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
+
+pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"

--- a/builtin/int64.wasm.mbt
+++ b/builtin/int64.wasm.mbt
@@ -85,3 +85,15 @@ pub fn UInt64::op_mod(self : UInt64, other : UInt64) -> UInt64 = "%u64.mod"
 pub fn UInt64::compare(self : UInt64, other : UInt64) -> Int = "%u64.compare"
 
 pub fn UInt64::op_equal(self : UInt64, other : UInt64) -> Bool = "%u64.eq"
+
+pub fn UInt64::land(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitand"
+
+pub fn UInt64::lor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitor"
+
+pub fn UInt64::lxor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitxor"
+
+pub fn UInt64::lnot(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitnot"
+
+pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
+
+pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -209,3 +209,15 @@ pub fn UInt::op_equal(self : UInt, other : UInt) -> Bool = "%u32.eq"
 pub fn UInt::op_neq(self : UInt, other : UInt) -> Bool = "%u32.ne"
 
 pub fn UInt::compare(self : UInt, other : UInt) -> Int = "%u32.compare"
+
+pub fn UInt::land(self : UInt, other : UInt) -> UInt = "%u32.bitand"
+
+pub fn UInt::lor(self : UInt, other : UInt) -> UInt = "%u32.bitor"
+
+pub fn UInt::lxor(self : UInt, other : UInt) -> UInt = "%u32.bitxor"
+
+pub fn UInt::lnot(self : UInt) -> UInt = "%u32.bitnot"
+
+pub fn UInt::lsl(self : UInt, shift : Int) -> UInt = "%u32.shl"
+
+pub fn UInt::lsr(self : UInt, shift : Int) -> UInt = "%u32.shr"

--- a/builtin/intrinsics_test.mbt
+++ b/builtin/intrinsics_test.mbt
@@ -89,6 +89,11 @@ test "uint test" {
   inspect(2147483647U * 2U, content="4294967294")!
   inspect(0x80000000U / 2U, content="1073741824")!
   inspect(4294967295U % 17U, content="0")!
+  inspect(0xFFFFFFFFU.land(0xFFFFU), content="65535")!
+  inspect(0xFF00U.lor(0xFFU), content="65535")!
+  inspect(0xFFFF00U.lxor(0xFF00FFU), content="65535")!
+  inspect(0x1U.lsl(31), content="2147483648")!
+  inspect(2147483648U.lsr(31), content="1")!
 }
 
 test "uint64 test" {
@@ -102,4 +107,9 @@ test "uint64 test" {
   inspect(9223372036854775808UL * 2UL, content="0")!
   inspect(0x8000000000000000UL / 2UL, content="4611686018427387904")!
   inspect(18446744073709551615UL % 17UL, content="0")!
+  inspect(0xFFFFFFFFUL.land(0xFFFFUL), content="65535")!
+  inspect(0xFF00UL.lor(0xFFUL), content="65535")!
+  inspect(0xFFFF00UL.lxor(0xFF00FFUL), content="65535")!
+  inspect(0x1UL.lsl(63), content="9223372036854775808")!
+  inspect(9223372036854775808UL.lsr(63), content="1")!
 }


### PR DESCRIPTION
add `land`,`lor`,`lxor`,`lnot`,`lsl`,`lsr` methods to `UInt`/`UInt64` types