### PR TITLE
remove deprecated Buffer::make

### DIFF
--- a/array/fixedarray_sort.mbt
+++ b/array/fixedarray_sort.mbt
@@ -176,8 +176,8 @@ fn provide_sorted_batch[T : Compare](
 fn collapse(runs : Array[TimSortRun], stop : Int) -> Int? {
   let n : Int = runs.length()
   if n >= 2 && (runs[n - 1].start + runs[n - 1].len == stop || runs[n - 2].len <=
-  runs[n - 1].len || n >= 3 && runs[n - 3].len <= runs[n - 2].len + runs[n - 1].len ||
-  n >= 4 && runs[n - 4].len <= runs[n - 3].len + runs[n - 2].len) {
+  runs[n - 1].len || (n >= 3 && runs[n - 3].len <= runs[n - 2].len + runs[n - 1].len) ||
+  (n >= 4 && runs[n - 4].len <= runs[n - 3].len + runs[n - 2].len)) {
     if n >= 3 && runs[n - 3].len < runs[n - 1].len {
       Some(n - 3)
     } else {

--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -77,12 +77,6 @@ pub fn to_string(self : Buffer) -> String {
   self.bytes.sub_string(0, self.len)
 }
 
-/// Create a buffer with initial capacity. 
-/// @alert deprecate "Use `Buffer::new` instead."
-pub fn Buffer::make(initial_capacity : Int) -> Buffer {
-  Buffer::new(size_hint=initial_capacity)
-}
-
 /// Create a buffer with initial capacity (in bytes).
 pub fn Buffer::new(~size_hint : Int = 0) -> Buffer {
   let initial = if size_hint < 1 { 1 } else { size_hint }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -111,7 +111,6 @@ impl ArrayView {
 type Buffer
 impl Buffer {
   expect(Self, ~content : String = .., ~loc : SourceLoc = _, ~args_loc : ArgsLoc = _) -> Unit!String
-  make(Int) -> Self
   new(~size_hint : Int = ..) -> Self
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes

--- a/double/ryu.mbt
+++ b/double/ryu.mbt
@@ -460,8 +460,8 @@ fn d2d(ieeeMantissa : Int64, ieeeExponent : Int) -> FloatingDecimal64 {
     if vrIsTrailingZeros && lastRemovedDigit == 5 && vr % 2L == 0L {
       lastRemovedDigit = 4
     }
-    output = vr + (vr == vm && (not(acceptBounds) || not(vmIsTrailingZeros)) || lastRemovedDigit >=
-      5).to_int64()
+    output = vr + ((vr == vm && (not(acceptBounds) || not(vmIsTrailingZeros))) ||
+      lastRemovedDigit >= 5).to_int64()
   } else {
     // Specialized for the common case (~99.3%). Percentages below are relative to this.
     let mut roundUp = false
@@ -638,8 +638,8 @@ fn ryu_to_string(self : Double) -> String {
   let ieeeExponent : Int = bits.lsr(gDOUBLE_MANTISSA_BITS).land(
     1L.lsl(gDOUBLE_EXPONENT_BITS) - 1L,
   ).to_int()
-  if ieeeExponent == (1).lsl(gDOUBLE_EXPONENT_BITS) - 1 || ieeeExponent == 0 && ieeeMantissa ==
-  0L {
+  if ieeeExponent == (1).lsl(gDOUBLE_EXPONENT_BITS) - 1 || (ieeeExponent == 0 &&
+  ieeeMantissa == 0L) {
     return copy_special_str(ieeeSign, ieeeExponent != 0, ieeeMantissa != 0L)
   }
   let mut v : FloatingDecimal64 = { mantissa: 0L, exponent: 0 }

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -36,8 +36,8 @@ pub fn Rational::new(numerator : Int64, denominator : Int64) -> Rational? {
   if denominator == 0L {
     None
   } else {
-    let sign = if numerator < 0L && denominator < 0L || numerator > 0L && denominator >
-    0L {
+    let sign = if (numerator < 0L && denominator < 0L) || (numerator > 0L && denominator >
+    0L) {
       1L
     } else {
       -1L

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -120,7 +120,7 @@ pub fn Decimal::parse_decimal(str : String) -> Decimal!String {
       raise syntax_err
     }
     let mut exp = 0
-    while i < str.length() && ('0' <= str[i] && str[i] <= '9' || str[i] == '_') {
+    while i < str.length() && (('0' <= str[i] && str[i] <= '9') || str[i] == '_') {
       if str[i] == '_' {
         i += 1
         continue
@@ -169,8 +169,8 @@ pub fn to_double(self : Decimal) -> Double!String {
     exponent += n
   }
   // left shift
-  while self.decimal_point < 0 || self.decimal_point == 0 && self.digits[0].to_int() <
-        5 {
+  while self.decimal_point < 0 || (self.decimal_point == 0 && self.digits[0].to_int() <
+        5) {
     let mut n = 0
     if -self.decimal_point >= powtab.length() {
       n = 60

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -74,7 +74,7 @@ pub fn parse_int64(str : String, ~base : Int = 0) -> Int64!String {
     if d >= num_base {
       raise syntax_err
     }
-    if neg && n < overflow_threshold || not(neg) && n >= overflow_threshold {
+    if (neg && n < overflow_threshold) || (not(neg) && n >= overflow_threshold) {
       raise range_err
     }
     // n*base overflows
@@ -134,7 +134,7 @@ fn check_underscore(str : String) -> Bool {
       last_char = '0'
       continue
     }
-    if hex && 'a' <= s[i] && s[i] <= 'f' || 'A' <= s[i] && s[i] <= 'F' {
+    if (hex && 'a' <= s[i] && s[i] <= 'f') || ('A' <= s[i] && s[i] <= 'F') {
       last_char = '0'
       continue
     }

--- a/strconv/number.mbt
+++ b/strconv/number.mbt
@@ -47,7 +47,7 @@ fn try_parse_19digits(
   let mut x = x
   let mut s = s
   let mut len = 0
-  while x < min_19digit_int && s.first_is_digit() || s.first_is('_') {
+  while (x < min_19digit_int && s.first_is_digit()) || s.first_is('_') {
     if s.first_is('_') {
       s = s.step_1_unchecked()
     }


### PR DESCRIPTION
There are some format diff caused by the changed behavior of moonfmt.

@qazxcdswe123 