### PR TITLE
feat: add uint64 to uint

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -341,6 +341,7 @@ impl UInt64 {
   op_sub(UInt64, UInt64) -> UInt64
   to_int64(UInt64) -> Int64
   to_string(UInt64) -> String
+  to_uint(UInt64) -> UInt
   trunc_double(Double) -> UInt64
 }
 impl Double {

--- a/builtin/int64.js.mbt
+++ b/builtin/int64.js.mbt
@@ -477,6 +477,11 @@ pub fn UInt64::op_mod(self : UInt64, other : UInt64) -> UInt64 {
 
 pub fn UInt64::to_int64(self : UInt64) -> Int64 = "%identity"
 
+// TODO: make it intrinsic
+pub fn UInt64::to_uint(self : UInt64) -> UInt {
+  self.land(0xFFFF_FFFFUL).to_int64().to_int().to_uint()
+}
+
 pub fn UInt64::compare(self : UInt64, other : UInt64) -> Int {
   MyInt64::from_uint64(self).compare_u(MyInt64::from_uint64(other))
 }

--- a/builtin/int64.wasm-gc.mbt
+++ b/builtin/int64.wasm-gc.mbt
@@ -72,6 +72,11 @@ pub fn Int64::to_uint64(self : Int64) -> UInt64 = "%i64.to_u64_reinterpret"
 
 pub fn UInt64::to_int64(self : UInt64) -> Int64 = "%u64.to_i64_reinterpret"
 
+// TODO: make it intrinsic
+pub fn UInt64::to_uint(self : UInt64) -> UInt {
+  self.land(0xFFFF_FFFFUL).to_int64().to_int().to_uint()
+}
+
 pub fn UInt64::op_add(self : UInt64, other : UInt64) -> UInt64 = "%u64.add"
 
 pub fn UInt64::op_sub(self : UInt64, other : UInt64) -> UInt64 = "%u64.sub"

--- a/builtin/int64.wasm.mbt
+++ b/builtin/int64.wasm.mbt
@@ -72,6 +72,11 @@ pub fn Int64::to_uint64(self : Int64) -> UInt64 = "%i64.to_u64_reinterpret"
 
 pub fn UInt64::to_int64(self : UInt64) -> Int64 = "%u64.to_i64_reinterpret"
 
+// TODO: make it intrinsic
+pub fn UInt64::to_uint(self : UInt64) -> UInt {
+  self.land(0xFFFF_FFFFUL).to_int64().to_int().to_uint()
+}
+
 pub fn UInt64::op_add(self : UInt64, other : UInt64) -> UInt64 = "%u64.add"
 
 pub fn UInt64::op_sub(self : UInt64, other : UInt64) -> UInt64 = "%u64.sub"

--- a/builtin/intrinsics_wbtest.mbt
+++ b/builtin/intrinsics_wbtest.mbt
@@ -103,6 +103,7 @@ test "uint64 test" {
   inspect!(100UL > 0UL, content="true")
   inspect!(9223372036854775808UL.to_int64(), content="-9223372036854775808")
   inspect!((-9223372036854775808L).to_uint64(), content="9223372036854775808")
+  inspect!((9223372036854775808UL + 1UL).to_uint(), content="1")
   inspect!(9223372036854775808UL + 1UL, content="9223372036854775809")
   inspect!(0UL - 1UL, content="18446744073709551615")
   inspect!(9223372036854775808UL * 2UL, content="0")


### PR DESCRIPTION
cc @Yoorkin, I couldn't find a proper intrinsic in wasm. The closest I found is `i32.wrap_i64` and it doesn't seem correct?
 