### PR TITLE
change hash trait

### DIFF
--- a/bool/bool.mbt
+++ b/bool/bool.mbt
@@ -39,3 +39,7 @@ pub fn to_int64(self : Bool) -> Int64 {
 pub fn hash(self : Bool) -> Int {
   self.to_int()
 }
+
+pub fn hash_combine(self : Bool, hasher : Hasher) -> Unit {
+  hasher.combine_bool(self)
+}

--- a/bool/bool.mbti
+++ b/bool/bool.mbti
@@ -5,6 +5,7 @@ package moonbitlang/core/bool
 // Types and methods
 impl Bool {
   hash(Bool) -> Int
+  hash_combine(Bool, Hasher) -> Unit
   to_bool(Bool) -> Bool
   to_int(Bool) -> Int
   to_int64(Bool) -> Int64

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -124,14 +124,18 @@ impl Buffer {
 
 type Hasher
 impl Hasher {
+  combine[T : Hash](Self, T) -> Unit
+  combine_bool(Self, Bool) -> Unit
   combine_byte(Self, Byte) -> Unit
   combine_bytes(Self, Bytes) -> Unit
+  combine_char(Self, Char) -> Unit
   combine_double(Self, Double) -> Unit
   combine_int(Self, Int) -> Unit
   combine_int64(Self, Int64) -> Unit
   combine_string(Self, String) -> Unit
   combine_uint(Self, UInt) -> Unit
   combine_uint64(Self, UInt64) -> Unit
+  combine_unit(Self) -> Unit
   finalize(Self) -> Int
   new(~seed : Int = ..) -> Self
 }
@@ -230,6 +234,8 @@ impl Bool {
 impl Byte {
   compare(Byte, Byte) -> Int
   debug_write(Byte, Buffer) -> Unit
+  hash(Byte) -> Int
+  hash_combine(Byte, Hasher) -> Unit
   op_equal(Byte, Byte) -> Bool
   to_int(Byte) -> Int
   to_int64(Byte) -> Int64
@@ -436,6 +442,7 @@ pub trait Eq {
 }
 
 pub trait Hash {
+  hash_combine(Self, Hasher) -> Unit
   hash(Self) -> Int
 }
 

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -58,3 +58,11 @@ pub fn debug_write(self : Byte, buf : Buffer) -> Unit {
   buf.write_string(lo)
   buf.write_string("'")
 }
+
+pub fn hash(self : Byte) -> Int {
+  self.to_int()
+}
+
+pub fn hash_combine(self : Byte, hasher : Hasher) -> Unit {
+  hasher.combine_byte(self)
+}

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -31,6 +31,18 @@ pub fn Hasher::new(~seed : Int = 0) -> Hasher {
   { acc: seed + gPRIME5 }
 }
 
+pub fn combine[T : Hash](self : Hasher, value : T) -> Unit {
+  value.hash_combine(self)
+}
+
+pub fn combine_unit(self : Hasher) -> Unit {
+  self.combine_int(0)
+}
+
+pub fn combine_bool(self : Hasher, value : Bool) -> Unit {
+  self.combine_int(if value { 1 } else { 0 })
+}
+
 pub fn combine_int(self : Hasher, value : Int) -> Unit {
   self.acc += 4
   self.consume4(value)
@@ -77,6 +89,10 @@ pub fn combine_string(self : Hasher, value : String) -> Unit {
   for i = 0; i < value.length(); i = i + 1 {
     self.combine_int(value[i].to_int())
   }
+}
+
+pub fn combine_char(self : Hasher, value : Char) -> Unit {
+  self.combine_int(value.to_int())
 }
 
 pub fn finalize(self : Hasher) -> Int {

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -98,6 +98,7 @@ test "combine string" {
   inspect!(hash("abc") == hash("abc"), content="true")
   inspect!(hash("a") == hash("a"), content="true")
   inspect!(hash("a") == hash("abc"), content="false")
+  inspect!(hash("five") == hash("five"), content="true")
 }
 
 test "combine bytes" {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -16,6 +16,10 @@ type MyString String derive(Eq)
 
 impl Hash for MyString with hash(self) { self.0.length() }
 
+impl Hash for MyString with hash_combine(self, hasher) {
+  hasher.combine_string(self.0)
+}
+
 impl Show for MyString with to_string(self) { self.0 }
 
 test "new" {

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -29,6 +29,7 @@ pub trait Compare: Eq {
 
 /// Trait for types that can be hashed
 pub trait Hash {
+  hash_combine(Self, Hasher) -> Unit
   hash(Self) -> Int
 }
 

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -6,6 +6,7 @@ package moonbitlang/core/bytes
 impl Bytes {
   from_array(Array[Int]) -> Bytes
   hash(Bytes) -> Int
+  hash_combine(Bytes, Hasher) -> Unit
   of(FixedArray[Int]) -> Bytes
   to_array(Bytes) -> Array[Int]
 }

--- a/bytes/xxhash.mbt
+++ b/bytes/xxhash.mbt
@@ -35,6 +35,10 @@ pub fn hash(self : Bytes) -> Int {
   xxhash32(self, 0)
 }
 
+pub fn hash_combine(self : Bytes, hasher : Hasher) -> Unit {
+  hasher.combine_bytes(self)
+}
+
 fn rotl(x : Int, r : Int) -> Int {
   x.lsl(r).lor(x.lsr(32 - r))
 }

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -81,3 +81,7 @@ test "debug_write" {
 pub fn hash(self : Char) -> Int {
   self.to_int()
 }
+
+pub fn hash_combine(self : Char, hasher : Hasher) -> Unit {
+  hasher.combine_char(self)
+}

--- a/char/char.mbti
+++ b/char/char.mbti
@@ -6,6 +6,7 @@ package moonbitlang/core/char
 impl Char {
   debug_write(Char, Buffer) -> Unit
   hash(Char) -> Int
+  hash_combine(Char, Hasher) -> Unit
   to_string(Char) -> String
 }
 

--- a/double/double.mbt
+++ b/double/double.mbt
@@ -281,3 +281,7 @@ test "min_normal" {
 pub fn hash(self : Double) -> Int {
   self.reinterpret_as_i64().hash()
 }
+
+pub fn hash_combine(self : Double, hasher : Hasher) -> Unit {
+  hasher.combine_double(self)
+}

--- a/double/double.mbti
+++ b/double/double.mbti
@@ -10,6 +10,7 @@ impl Double {
   floor(Double) -> Double
   from_int(Int) -> Double
   hash(Double) -> Int
+  hash_combine(Double, Hasher) -> Unit
   inf(Int) -> Double
   is_inf(Double) -> Bool
   is_nan(Double) -> Bool

--- a/hashmap/hashmap_wbtest.mbt
+++ b/hashmap/hashmap_wbtest.mbt
@@ -22,6 +22,10 @@ type MyString String derive(Eq)
 
 impl Hash for MyString with hash(self) { self.0.length() }
 
+impl Hash for MyString with hash_combine(self, hasher) {
+  hasher.combine_string(self.0)
+}
+
 impl Show for MyString with to_string(self) { self.0 }
 
 test "set" {

--- a/hashset/hashset_wbtest.mbt
+++ b/hashset/hashset_wbtest.mbt
@@ -22,6 +22,10 @@ type MyString String derive(Eq)
 
 impl Hash for MyString with hash(self) { self.0.length() }
 
+impl Hash for MyString with hash_combine(self, hasher) {
+  hasher.combine_string(self.0)
+}
+
 impl Show for MyString with to_string(self) { self.0 }
 
 test "set" {
@@ -110,7 +114,7 @@ test "iter" {
   let m : HashSet[String] = HashSet::of(["a", "b", "c"])
   let mut sum = ""
   m.each(fn(k) { sum += k })
-  @test.eq(sum, "abc")!
+  inspect!(sum, content="cab")
 }
 
 test "iteri" {
@@ -123,8 +127,8 @@ test "iteri" {
       sum += i
     },
   )
-  @test.eq(s, "213")!
-  @test.eq(sum, 3)!
+  inspect!(s, content="231")
+  inspect!(sum, content="3")
 }
 
 test "clear" {
@@ -213,10 +217,10 @@ test "iter" {
   let buf = Buffer::new(size_hint=20)
   let map = of(["a", "b", "c"])
   map.iter().each(fn(e) { buf.write_string("[\(e)]") })
-  inspect!(buf, content="[a][b][c]")
+  inspect!(buf, content="[c][a][b]")
   buf.reset()
   map.iter().take(2).each(fn(e) { buf.write_string("[\(e)]") })
-  inspect!(buf, content="[a][b]")
+  inspect!(buf, content="[c][a]")
 }
 
 test "from_array" {

--- a/immut/hashset/HAMT_wbtest.mbt
+++ b/immut/hashset/HAMT_wbtest.mbt
@@ -55,7 +55,7 @@ test "Set::iter" {
   let data = of(["a", "b", "d", "e", "f"])
   let mut s = ""
   data.iter().each(fn { k => s += " \(k)" })
-  inspect!(s, content=" d e b a f")
+  inspect!(s, content=" e f b a d")
 }
 
 test "Set::to_string" {

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -59,3 +59,7 @@ pub fn hash(self : Int) -> Int {
   x = x.lxor(x.lsr(14))
   x
 }
+
+pub fn hash_combine(self : Int, hasher : Hasher) -> Unit {
+  hasher.combine_int(self)
+}

--- a/int/int.mbti
+++ b/int/int.mbti
@@ -7,6 +7,7 @@ impl Int {
   abs(Int) -> Int
   from_int(Int) -> Int
   hash(Int) -> Int
+  hash_combine(Int, Hasher) -> Unit
   max_value() -> Int
   min_value() -> Int
   signum(Int) -> Int

--- a/int64/int64.mbti
+++ b/int64/int64.mbti
@@ -7,6 +7,7 @@ impl Int64 {
   abs(Int64) -> Int64
   from_int(Int) -> Int64
   hash(Int64) -> Int
+  hash_combine(Int64, Hasher) -> Unit
   max_value() -> Int64
   min_value() -> Int64
   signum(Int64) -> Int64

--- a/int64/xxhash.mbt
+++ b/int64/xxhash.mbt
@@ -43,3 +43,7 @@ pub fn hash(self : Int64) -> Int {
   acc = acc.lxor(acc.lsr(16))
   acc
 }
+
+pub fn hash_combine(self : Int64, hasher : Hasher) -> Unit {
+  hasher.combine_int64(self)
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -45,7 +45,13 @@ pub fn to_bytes(self : String) -> Bytes {
 }
 
 pub fn hash(self : String) -> Int {
-  self.to_bytes().hash()
+  let hasher = Hasher::new()
+  hasher.combine(self)
+  hasher.finalize()
+}
+
+pub fn hash_combine(self : String, hasher : Hasher) -> Unit {
+  hasher.combine_string(self)
 }
 
 /// Converts the String into an array of Chars.

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -9,6 +9,7 @@ impl String {
   default() -> String
   ends_with(String, String) -> Bool
   hash(String) -> Int
+  hash_combine(String, Hasher) -> Unit
   index_of(String, String, ~from : Int = ..) -> Int
   is_blank(String) -> Bool
   is_empty(String) -> Bool

--- a/unit/unit.mbt
+++ b/unit/unit.mbt
@@ -22,6 +22,11 @@ pub fn hash(self : Unit) -> Int {
   0
 }
 
+pub fn hash_combine(self : Unit, hasher : Hasher) -> Unit {
+  let _ = self
+  hasher.combine_unit()
+}
+
 pub fn Unit::default() -> Unit {
   ()
 }

--- a/unit/unit.mbti
+++ b/unit/unit.mbti
@@ -7,6 +7,7 @@ impl Unit {
   compare(Unit, Unit) -> Int
   default() -> Unit
   hash(Unit) -> Int
+  hash_combine(Unit, Hasher) -> Unit
   to_string(Unit) -> String
 }
 


### PR DESCRIPTION
This PR changes the hash trait to follow the first step of #689 .
- add `hash_combine(Self, Hasher)` to hash trait.
- add `hash_combine` method to types that should impl the hash trait.
- adjust some tests.