### PR TITLE
move string hasher into builtin

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -451,4 +451,7 @@ pub trait Show {
 }
 
 // Extension Methods
+impl Hash for String
+
+impl Hash for Hash
 

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -91,6 +91,11 @@ pub fn combine_string(self : Hasher, value : String) -> Unit {
   }
 }
 
+
+pub impl Hash for String with hash_combine(self, hasher) {
+  hasher.combine_string(self)
+}
+
 pub fn combine_char(self : Hasher, value : Char) -> Unit {
   self.combine_int(value.to_int())
 }

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -33,6 +33,12 @@ pub trait Hash {
   hash(Self) -> Int
 }
 
+impl Hash with hash(self) {
+  let hasher = Hasher::new()
+  hasher.combine(self)
+  hasher.finalize()
+}
+
 /// Trait for types with a default value
 pub trait Default {
   default() -> Self

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -44,15 +44,6 @@ pub fn to_bytes(self : String) -> Bytes {
   bytes
 }
 
-pub fn hash(self : String) -> Int {
-  let hasher = Hasher::new()
-  hasher.combine(self)
-  hasher.finalize()
-}
-
-pub fn hash_combine(self : String, hasher : Hasher) -> Unit {
-  hasher.combine_string(self)
-}
 
 /// Converts the String into an array of Chars.
 pub fn to_array(self : String) -> Array[Char] {

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -8,8 +8,6 @@ impl String {
   contains(String, String) -> Bool
   default() -> String
   ends_with(String, String) -> Bool
-  hash(String) -> Int
-  hash_combine(String, Hasher) -> Unit
   index_of(String, String, ~from : Int = ..) -> Int
   is_blank(String) -> Bool
   is_empty(String) -> Bool


### PR DESCRIPTION
I provided a default implementation for Hash trait and moved String:Hash into builtin, but found some errors
@yj-qin do you have any idea why?