### PR TITLE
refine design of the [Show] trait

### DIFF
--- a/array/array_wbtest.mbt
+++ b/array/array_wbtest.mbt
@@ -143,10 +143,20 @@ test "map" {
   let v = [3, 4, 5]
   let e : Array[Int] = []
   inspect!(v.map(fn(x) { x + 1 }), content="[4, 5, 6]")
-  inspect!(v.map(fn(x) { x.to_string() }), content="[3, 4, 5]")
+  inspect!(
+    v.map(fn(x) { x.to_string() }),
+    content=
+      #|["3", "4", "5"]
+    ,
+  )
   inspect!(e.map(fn(x) { x + 1 }), content="[]")
   // Is it correct?
-  inspect!(["a", "b", "c"], content="[a, b, c]")
+  inspect!(
+    ["a", "b", "c"],
+    content=
+      #|["a", "b", "c"]
+    ,
+  )
 }
 
 test "map_inplace" {
@@ -162,7 +172,12 @@ test "mapi" {
   let v = [3, 4, 5]
   let e : Array[Int] = []
   inspect!(v.mapi(fn(i, x) { x + i }), content="[3, 5, 7]")
-  inspect!(v.mapi(fn(i, x) { (x + i).to_string() }), content="[3, 5, 7]")
+  inspect!(
+    v.mapi(fn(i, x) { (x + i).to_string() }),
+    content=
+      #|["3", "5", "7"]
+    ,
+  )
   inspect!(e.mapi(fn(_i, x) { x + 1 }), content="[]")
 }
 

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -922,18 +922,7 @@ pub fn shrink_to_fit[T](self : Array[T]) -> Unit {
 
 /// Converts the array to a string.
 pub fn to_string[T : Show](self : Array[T]) -> String {
-  if self.length() == 0 {
-    return "[]"
-  }
-  let first = self.buffer()[0]
-  // CR: format issues
-  for i = 1, init = "[\(first)" {
-    if i >= self.length() {
-      break "\(init)]"
-    }
-    let cur = self.buffer()[i]
-    continue i + 1, "\(init), \(cur)"
-  }
+  Show::to_string(self)
 }
 
 /// Find the index of the first element that satisfies the predicate.

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -20,6 +20,10 @@ pub fn SourceLoc::debug_write(self : SourceLoc, buf : Buffer) -> Unit {
   buf.write_string(self.to_string())
 }
 
+pub impl Show for SourceLoc with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
 pub type ArgsLoc Array[SourceLoc?]
 
 pub fn ArgsLoc::to_string(self : ArgsLoc) -> String {

--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -130,3 +130,7 @@ pub fn to_bytes(self : Buffer) -> Bytes {
   bytes.blit(0, self.bytes, 0, self.len)
   bytes
 }
+
+pub impl Show for Buffer with output(self, logger) {
+  logger.write_string(self.to_string())
+}

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -446,9 +446,55 @@ pub trait Hash {
   hash(Self) -> Int
 }
 
+pub trait Logger {
+  write_string(Self, String) -> Unit
+  write_sub_string(Self, String, Int, Int) -> Unit
+  write_char(Self, Char) -> Unit
+}
+
 pub trait Show {
+  output(Self, Logger) -> Unit
   to_string(Self) -> String
 }
 
 // Extension Methods
+impl Show for Unit
+
+impl Show for Bool
+
+impl Show for Byte
+
+impl Show for Int
+
+impl Show for Int64
+
+impl Show for UInt
+
+impl Show for UInt64
+
+impl Show for String
+
+impl Show for Option
+
+impl Show for Result
+
+impl Show for FixedArray
+
+impl Show for Bytes
+
+impl Show for Ref
+
+impl Show for Array
+
+impl Show for ArrayView
+
+impl Show for Buffer
+
+impl Show for Iter
+
+impl Show for Map
+
+impl Show for Show
+
+impl Show for SourceLoc
 

--- a/builtin/debug.mbt
+++ b/builtin/debug.mbt
@@ -21,7 +21,7 @@ pub trait Debug {
 pub fn debug[X : Debug](x : X) -> Unit {
   let buf = Buffer::new()
   x.debug_write(buf)
-  println(buf.to_string())
+  println_mono(buf.to_string())
 }
 
 pub fn debug_write(self : Unit, buf : Buffer) -> Unit {

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -20,6 +20,10 @@ pub enum IterResult {
   IterContinue // true
 } derive(Eq)
 
+pub impl[T : Show] Show for Iter[T] with output(self, logger) {
+  Show::output(self.to_array(), logger)
+}
+
 pub fn to_string[T : Show](self : Iter[T]) -> String {
   self.to_array().to_string()
 }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -343,21 +343,27 @@ fn debug_entries[K : Show, V : Show](self : Map[K, V]) -> String {
   buf.to_string()
 }
 
-pub fn to_string[K : Show, V : Show](self : Map[K, V]) -> String {
+pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
   if self.size == 0 {
-    return "{}"
+    logger.write_string("{}")
+    return
   }
-  loop 0, self.head, "{" {
-    _, None, _ as acc => return acc + "}"
-    i, Some({ key, value, idx, .. }), acc => {
-      let nxt = self.list[idx].next
+  loop 0, self.head {
+    _, None => logger.write_string("}")
+    i, Some({ key, value, idx, .. }) => {
       if i > 0 {
-        // remove the trailing comma
-        continue i + 1, nxt, acc + ", \(key):\(value)"
+        logger.write_string(", ")
       }
-      continue i + 1, nxt, acc + "\(key): \(value)"
+      key.output(logger)
+      logger.write_string(": ")
+      value.output(logger)
+      continue i + 1, self.list[idx].next
     }
   }
+}
+
+pub fn to_string[K : Show, V : Show](self : Map[K, V]) -> String {
+  Show::to_string(self)
 }
 
 /// Get the number of key-value pairs in the map.

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -17,7 +17,12 @@ test "Map keys iter" {
   let v = {
       [..map.keys()]
     }
-  inspect!(v, content="[a, b, c]")
+  inspect!(
+    v,
+    content=
+      #|["a", "b", "c"]
+    ,
+  )
   inspect!(
     {
       [..map.values()]

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -20,7 +20,7 @@ impl Hash for MyString with hash_combine(self, hasher) {
   hasher.combine_string(self.0)
 }
 
-impl Show for MyString with to_string(self) { self.0 }
+impl Show for MyString with output(self, logger) { logger.write_string(self.0) }
 
 test "new" {
   let m : Map[Int, Int] = Map::new()
@@ -299,7 +299,12 @@ test "linked list" {
 
 test "to_array" {
   let map = { 1: "one", 2: "two", 3: "three" }
-  inspect!(map.to_array(), content="[(1, one), (2, two), (3, three)]")
+  inspect!(
+    map.to_array(),
+    content=
+      #|[(1, "one"), (2, "two"), (3, "three")]
+    ,
+  )
 }
 
 test "set_existing_key" {
@@ -655,9 +660,19 @@ test "to_string" {
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
-  inspect!(m.to_string(), content="{a: 1, b:2, c:3}")
+  inspect!(
+    m.to_string(),
+    content=
+      #|"a": 1, "b": 2, "c": 3}
+    ,
+  )
   let nested_m = { "a": { "b": 2 }, "B": { "C": 3 } }
-  inspect!(nested_m.to_string(), content="{a: {b: 2}, B:{C: 3}}")
+  inspect!(
+    nested_m.to_string(),
+    content=
+      #|"a": "b": 2}, "B": "C": 3}}
+    ,
+  )
 }
 
 test "hash collision" {

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -1,0 +1,168 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub impl Show for Unit with output(_self, logger) { logger.write_string("()") }
+
+pub impl Show for Bool with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for Int with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for Int64 with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for UInt with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for UInt64 with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for Byte with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for Bytes with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for String with output(self, logger) {
+  logger.write_char('"')
+  let mut segment_start = 0
+  fn flush_segment(i : Int) {
+    if i > segment_start {
+      logger.write_sub_string(self, segment_start, i - segment_start)
+    }
+    segment_start = i + 1
+  }
+
+  fn to_hex_digit(i : Int) -> Char {
+    if i < 10 {
+      Char::from_int('0'.to_int() + i)
+    } else {
+      Char::from_int('a'.to_int() + (i - 10))
+    }
+  }
+
+  for i = 0; i < self.length(); i = i + 1 {
+    let c = self[i]
+    match c {
+      '"' | '\\' => {
+        flush_segment(i)
+        logger.write_char('\\')
+        logger.write_char(c)
+      }
+      '\n' => {
+        flush_segment(i)
+        logger.write_string("\\n")
+      }
+      '\r' => {
+        flush_segment(i)
+        logger.write_string("\\r")
+      }
+      '\b' => {
+        flush_segment(i)
+        logger.write_string("\\b")
+      }
+      '\t' => {
+        flush_segment(i)
+        logger.write_string("\\t")
+      }
+      _ => {
+        let code = c.to_int()
+        if code < 0x20 {
+          flush_segment(i)
+          logger.write_char('\\')
+          logger.write_char('x')
+          logger.write_char(to_hex_digit(code / 16))
+          logger.write_char(to_hex_digit(code % 16))
+        }
+      }
+    }
+  }
+  flush_segment(self.length())
+  logger.write_char('"')
+}
+
+pub impl Show for String with to_string(self) { self }
+
+pub impl[X : Show] Show for X? with output(self, logger) {
+  match self {
+    None => logger.write_string("None")
+    Some(arg) => {
+      logger.write_string("Some(")
+      arg.output(logger)
+      logger.write_string(")")
+    }
+  }
+}
+
+pub impl[T : Show, E : Show] Show for Result[T, E] with output(self, logger) {
+  match self {
+    Ok(x) => {
+      logger.write_string("Ok(")
+      x.output(logger)
+      logger.write_string(")")
+    }
+    Err(e) => {
+      logger.write_string("Err(")
+      e.output(logger)
+      logger.write_string(")")
+    }
+  }
+}
+
+pub impl[X : Show] Show for Ref[X] with output(self, logger) {
+  logger.write_string("{val: ")
+  self.val.output(logger)
+  logger.write_string("}")
+}
+
+pub impl[X : Show] Show for FixedArray[X] with output(self, logger) {
+  logger.write_char('[')
+  for i = 0; i < self.length(); i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
+    }
+    self[i].output(logger)
+  }
+  logger.write_char(']')
+}
+
+pub impl[X : Show] Show for Array[X] with output(self, logger) {
+  logger.write_char('[')
+  for i = 0; i < self.length(); i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
+    }
+    self[i].output(logger)
+  }
+  logger.write_char(']')
+}
+
+pub impl[X : Show] Show for ArrayView[X] with output(self, logger) {
+  logger.write_char('[')
+  for i = 0; i < self.length(); i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
+    }
+    self[i].output(logger)
+  }
+  logger.write_char(']')
+}

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -38,7 +38,22 @@ pub trait Default {
   default() -> Self
 }
 
+/// Trait for a logger, where debug logs can be written into
+pub trait Logger {
+  write_string(Self, String) -> Unit
+  write_sub_string(Self, String, Int, Int) -> Unit
+  write_char(Self, Char) -> Unit
+}
+
 /// Trait for types that can be converted to `String`
 pub trait Show {
+  output(Self, Logger) -> Unit
   to_string(Self) -> String
+}
+
+// Default implementation for `Show::to_string`, uses a `Buffer`
+impl Show with to_string(self) {
+  let logger = Buffer::new()
+  self.output(logger)
+  logger.to_string()
 }

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -20,6 +20,40 @@ pub fn to_string(self : Char) -> String {
   bytes.sub_string(0, len)
 }
 
+pub impl Show for Char with output(self, logger) {
+  fn to_hex_digit(i : Int) -> Char {
+    if i < 10 {
+      Char::from_int('0'.to_int() + i)
+    } else {
+      Char::from_int('a'.to_int() + (i - 10))
+    }
+  }
+
+  logger.write_char('\'')
+  match self {
+    '\'' | '\\' => {
+      logger.write_char('\\')
+      logger.write_char(self)
+    }
+    '\n' => logger.write_string("\\n")
+    '\r' => logger.write_string("\\r")
+    '\b' => logger.write_string("\\b")
+    '\t' => logger.write_string("\\t")
+    _ => {
+      let code = self.to_int()
+      if code < 0x20 {
+        logger.write_char('\\')
+        logger.write_char('x')
+        logger.write_char(to_hex_digit(code / 16))
+        logger.write_char(to_hex_digit(code % 16))
+      } else {
+        logger.write_char(self)
+      }
+    }
+  }
+  logger.write_char('\'')
+}
+
 test "to_string" {
   @test.eq!('a'.to_string(), "a")
 }

--- a/char/char.mbti
+++ b/char/char.mbti
@@ -13,4 +13,5 @@ impl Char {
 // Traits
 
 // Extension Methods
+impl Show for Char
 

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -17,7 +17,7 @@
 /// generated code.
 struct CoverageCounter {
   counter : FixedArray[UInt]
-} derive(Show)
+}
 
 /// Create a new coverage counter with the given size.
 ///
@@ -32,6 +32,21 @@ pub fn CoverageCounter::new(size : Int) -> CoverageCounter {
 pub fn CoverageCounter::incr(self : CoverageCounter, idx : Int) -> Unit {
   let counter = self.counter[idx]
   self.counter[idx] = counter + 1
+}
+
+pub impl Show for CoverageCounter with output(self, logger) {
+  logger.write_char('[')
+  for i = 0; i < self.counter.length(); i = i + 1 {
+    if i != 0 {
+      logger.write_string(", ")
+    }
+    Show::output(self.counter[i], logger)
+  }
+  logger.write_char(']')
+}
+
+pub fn to_string(self : CoverageCounter) -> String {
+  Show::to_string(self)
 }
 
 /// Output the contents of this counter in JSON format.

--- a/coverage/coverage.mbti
+++ b/coverage/coverage.mbti
@@ -18,4 +18,5 @@ impl CoverageCounter {
 // Traits
 
 // Extension Methods
+impl Show for CoverageCounter
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -27,18 +27,23 @@ pub fn Deque::new[T](~capacity : Int = 0) -> Deque[T] {
   Deque::{ buf: UninitializedArray::make(capacity), len: 0, head: 0, tail: 0 }
 }
 
-pub fn to_string[T : Show](self : Deque[T]) -> String {
+pub impl[T : Show] Show for Deque[T] with output(self, logger) {
   if self.length() == 0 {
-    return "Deque::[]"
+    logger.write_string("Deque::[]")
+    return
   }
-  let first = self[0]
-  for i = 1, init = "Deque::[\(first)" {
-    if i >= self.length() {
-      break "\(init)]"
+  logger.write_string("Deque::[")
+  for i = 0; i < self.length(); i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
     }
-    let cur = self[i]
-    continue i + 1, "\(init), \(cur)"
+    self[i].output(logger)
   }
+  logger.write_string("]")
+}
+
+pub fn to_string[T : Show](self : Deque[T]) -> String {
+  Show::to_string(self)
 }
 
 /// Creates a new deque from an array.

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -40,4 +40,5 @@ impl Deque {
 // Traits
 
 // Extension Methods
+impl Show for Deque
 

--- a/double/double.mbti
+++ b/double/double.mbti
@@ -32,4 +32,5 @@ impl Double {
 // Traits
 
 // Extension Methods
+impl Show for Double
 

--- a/double/ryu.mbt
+++ b/double/ryu.mbt
@@ -670,3 +670,7 @@ pub fn to_string(self : Double) -> String {
 pub fn debug_write(self : Double, buf : Buffer) -> Unit {
   buf.write_string(self.to_string())
 }
+
+pub impl Show for Double with output(self, logger) {
+  logger.write_string(self.to_string())
+}

--- a/hashmap/hashmap_wbtest.mbt
+++ b/hashmap/hashmap_wbtest.mbt
@@ -26,7 +26,7 @@ impl Hash for MyString with hash_combine(self, hasher) {
   hasher.combine_string(self.0)
 }
 
-impl Show for MyString with to_string(self) { self.0 }
+impl Show for MyString with output(self, logger) { logger.write_string(self.0) }
 
 test "set" {
   let m : HashMap[MyString, Int] = HashMap::new()
@@ -225,7 +225,12 @@ test "iter" {
 
 test "to_array" {
   let map = of([(1, "one"), (2, "two"), (3, "three")])
-  inspect!(map.to_array(), content="[(2, two), (1, one), (3, three)]")
+  inspect!(
+    map.to_array(),
+    content=
+      #|[(2, "two"), (1, "one"), (3, "three")]
+    ,
+  )
 }
 
 test "get_nonexistent_key" {

--- a/hashmap/pattern_wbtest.mbt
+++ b/hashmap/pattern_wbtest.mbt
@@ -17,6 +17,8 @@ test "pattern" {
   let { "name": name, "age": age, "is_human": is_human } = m
   inspect!(
     (name, age, is_human),
-    content="(Some(John Doe), Some(43), Some(true))",
+    content=
+      #|(Some("John Doe"), Some("43"), Some("true"))
+    ,
   )
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -293,9 +293,13 @@ fn debug_entries[K : Show](self : HashSet[K]) -> String {
   s
 }
 
+pub impl[K : Show] Show for HashSet[K] with output(self, logger) {
+  logger.write_string("@hashset.of(")
+  Show::output(self.iter().collect(), logger)
+  logger.write_string(")")
+}
+
+// Reuse the default implementation of [Show::to_string] here
 pub fn to_string[K : Show](self : HashSet[K]) -> String {
-  let mut s = "@hashset.of("
-  s += self.iter().collect().to_string()
-  s += ")"
-  s
+  Show::to_string(self)
 }

--- a/hashset/hashset.mbti
+++ b/hashset/hashset.mbti
@@ -28,4 +28,5 @@ impl HashSet {
 // Traits
 
 // Extension Methods
+impl Show for HashSet
 

--- a/hashset/hashset_wbtest.mbt
+++ b/hashset/hashset_wbtest.mbt
@@ -26,7 +26,7 @@ impl Hash for MyString with hash_combine(self, hasher) {
   hasher.combine_string(self.0)
 }
 
-impl Show for MyString with to_string(self) { self.0 }
+impl Show for MyString with output(self, logger) { logger.write_string(self.0) }
 
 test "set" {
   let m : HashSet[MyString] = HashSet::new()

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -23,18 +23,21 @@ test "is_empty" {
   inspect!(is_empty(ve), content="true")
 }
 
-pub fn to_string[T : Show](self : ImmutableVec[T]) -> String {
-  let mut s = "ImmutableVec::[".to_string()
+pub impl[T : Show] Show for ImmutableVec[T] with output(self, logger) {
+  logger.write_string("ImmutableVec::[")
   self.eachi(
     fn(i, v) {
-      s = s + v.to_string()
-      if i < self.size - 1 {
-        s = s + ", "
+      if i > 0 {
+        logger.write_string(", ")
       }
+      v.output(logger)
     },
   )
-  s = s + "]"
-  s
+  logger.write_string("]")
+}
+
+pub fn to_string[T : Show](self : ImmutableVec[T]) -> String {
+  Show::to_string(self)
 }
 
 test "to_string" {
@@ -405,7 +408,9 @@ test "map" {
   inspect!(v.map(fn(e) { e * 2 }), content="ImmutableVec::[2, 4, 6, 8, 10]")
   inspect!(
     v.map(fn(e) { e.to_string() }),
-    content="ImmutableVec::[1, 2, 3, 4, 5]",
+    content=
+      #|ImmutableVec::["1", "2", "3", "4", "5"]
+    ,
   )
   inspect!(
     v.map(fn(e) { e % 2 == 0 }),

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -36,4 +36,5 @@ impl ImmutableVec {
 // Traits
 
 // Extension Methods
+impl Show for ImmutableVec
 

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -234,10 +234,28 @@ pub fn debug_write[K : Debug, V : Debug](
   buf.write_string("]")
 }
 
-pub fn to_string[K : Debug, V : Debug](self : Map[K, V]) -> String {
-  let buf = Buffer::new(size_hint=0)
-  self.debug_write(buf)
-  buf.to_string()
+pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
+  let mut is_first = true
+  logger.write_string("@immutable_hashmap.Map::[")
+  self.each(
+    fn(k, v) {
+      if is_first {
+        is_first = false
+      } else {
+        logger.write_string(", ")
+      }
+      logger.write_string("(")
+      k.output(logger)
+      logger.write_string(", ")
+      v.output(logger)
+      logger.write_string(")")
+    },
+  )
+  logger.write_string("]")
+}
+
+pub fn to_string[K : Show, V : Show](self : Map[K, V]) -> String {
+  Show::to_string(self)
 }
 
 pub fn Map::from_array[K : Eq + Hash, V](arr : Array[(K, V)]) -> Map[K, V] {

--- a/immut/hashmap/HAMT_wbtest.mbt
+++ b/immut/hashmap/HAMT_wbtest.mbt
@@ -79,8 +79,23 @@ test "HAMT::to_string" {
 
 test "HAMT::from_array" {
   let map = of([(1, "1"), (2, "2"), (42, "42")])
-  inspect!((1, map.find(1)), content="(1, Some(1))")
-  inspect!((2, map.find(2)), content="(2, Some(2))")
-  inspect!((42, map.find(42)), content="(42, Some(42))")
+  inspect!(
+    (1, map.find(1)),
+    content=
+      #|(1, Some("1"))
+    ,
+  )
+  inspect!(
+    (2, map.find(2)),
+    content=
+      #|(2, Some("2"))
+    ,
+  )
+  inspect!(
+    (42, map.find(42)),
+    content=
+      #|(42, Some("42"))
+    ,
+  )
   inspect!((43, map.find(43)), content="(43, None)")
 }

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -16,10 +16,11 @@ impl Map {
   op_get[K : Eq + Hash, V](Self[K, V], K) -> V?
   remove[K : Eq + Hash, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
-  to_string[K : Debug, V : Debug](Self[K, V]) -> String
+  to_string[K : Show, V : Show](Self[K, V]) -> String
 }
 
 // Traits
 
 // Extension Methods
+impl Show for Map
 

--- a/immut/hashmap/pattern_wbtest.mbt
+++ b/immut/hashmap/pattern_wbtest.mbt
@@ -17,6 +17,8 @@ test "pattern" {
   let { "name": name, "age": age, "is_human": is_human } = m
   inspect!(
     (name, age, is_human),
-    content="(Some(John Doe), Some(43), Some(true))",
+    content=
+      #|(Some("John Doe"), Some("43"), Some("true"))
+    ,
   )
 }

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -225,10 +225,24 @@ pub fn debug_write[T : Debug](self : Set[T], buf : Buffer) -> Unit {
   buf.write_string("]")
 }
 
-pub fn to_string[T : Debug](self : Set[T]) -> String {
-  let buf = Buffer::new(size_hint=0)
-  self.debug_write(buf)
-  buf.to_string()
+pub impl[T : Show] Show for Set[T] with output(self, logger) {
+  let mut is_first = true
+  logger.write_string("@immutable_hashset.Set::[")
+  self.each(
+    fn(k) {
+      if is_first {
+        is_first = false
+      } else {
+        logger.write_string(", ")
+      }
+      k.output(logger)
+    },
+  )
+  logger.write_string("]")
+}
+
+pub fn to_string[T : Show](self : Set[T]) -> String {
+  Show::to_string(self)
 }
 
 pub fn Set::from_array[T : Eq + Hash](arr : Array[T]) -> Set[T] {

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -16,10 +16,11 @@ impl Set {
   of[T : Eq + Hash](FixedArray[T]) -> Self[T]
   remove[T : Eq + Hash](Self[T], T) -> Self[T]
   size[T](Self[T]) -> Int
-  to_string[T : Debug](Self[T]) -> String
+  to_string[T : Show](Self[T]) -> String
 }
 
 // Traits
 
 // Extension Methods
+impl Show for Set
 

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -17,16 +17,21 @@ pub enum List[T] {
   Cons(T, List[T])
 } derive(Eq)
 
+pub impl[T : Show] Show for List[T] with output(xs, logger) {
+  logger.write_string("List::[")
+  xs.eachi(
+    fn(i, x) {
+      if i > 0 {
+        logger.write_string(", ")
+      }
+      x.output(logger)
+    },
+  )
+  logger.write_string("]")
+}
+
 pub fn List::to_string[T : Show](xs : List[T]) -> String {
-  let elems = match xs {
-    Nil => ""
-    Cons(x, xs) =>
-      xs.fold_left(
-        fn(acc, x) { acc + ", " + x.to_string() },
-        init=x.to_string(),
-      )
-  }
-  "List::[" + elems + "]"
+  Show::to_string(xs)
 }
 
 pub fn List::debug_write[T : Debug](xs : List[T], buf : Buffer) -> Unit {

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -72,4 +72,5 @@ impl List {
 // Traits
 
 // Extension Methods
+impl Show for List
 

--- a/immut/list/list_wbtest.mbt
+++ b/immut/list/list_wbtest.mbt
@@ -217,7 +217,12 @@ test "repeat" {
 test "intersperse" {
   let ls = of(["1", "2", "3", "4", "5"])
   let el : List[String] = Nil
-  inspect!(ls.intersperse("|"), content="List::[1, |, 2, |, 3, |, 4, |, 5]")
+  inspect!(
+    ls.intersperse("|"),
+    content=
+      #|List::["1", "|", "2", "|", "3", "|", "4", "|", "5"]
+    ,
+  )
   inspect!(el.intersperse("|"), content="List::[]")
 }
 
@@ -336,7 +341,12 @@ test "lookup" {
   let ls = of([(1, "a"), (2, "b"), (3, "c")])
   let el : List[(Int, Int)] = Nil
   inspect!(el.lookup(1), content="None")
-  inspect!(ls.lookup(3), content="Some(c)")
+  inspect!(
+    ls.lookup(3),
+    content=
+      #|Some("c")
+    ,
+  )
   inspect!(ls.lookup(4), content="None")
 }
 
@@ -382,11 +392,15 @@ test "remove_at" {
   inspect!(ls.remove_at(0), content="List::[2, 3, 4, 5]")
   inspect!(
     of(["a", "b", "c", "d", "e"]).remove_at(2),
-    content="List::[a, b, d, e]",
+    content=
+      #|List::["a", "b", "d", "e"]
+    ,
   )
   inspect!(
     of(["a", "b", "c", "d", "e"]).remove_at(5),
-    content="List::[a, b, c, d, e]",
+    content=
+      #|List::["a", "b", "c", "d", "e"]
+    ,
   )
 }
 
@@ -394,11 +408,15 @@ test "remove" {
   inspect!(of([1, 2, 3, 4, 5]).remove(3), content="List::[1, 2, 4, 5]")
   inspect!(
     of(["a", "b", "c", "d", "e"]).remove("c"),
-    content="List::[a, b, d, e]",
+    content=
+      #|List::["a", "b", "d", "e"]
+    ,
   )
   inspect!(
     of(["a", "b", "c", "d", "e"]).remove("f"),
-    content="List::[a, b, c, d, e]",
+    content=
+      #|List::["a", "b", "c", "d", "e"]
+    ,
   )
 }
 

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -525,19 +525,26 @@ pub fn filter[T : Compare](
   }
 }
 
-pub fn to_string[T : Show + Compare](self : ImmutableSet[T]) -> String {
+pub impl[T : Show + Compare] Show for ImmutableSet[T] with output(self, logger) {
   match self {
-    Empty => "ImmutableSet::[]"
+    Empty => logger.write_string("ImmutableSet::[]")
     _ => {
       let linear = self.to_array()
       let len = linear.length()
-      for i = 0, str = "ImmutableSet::["; i < len - 1; {
-        continue i + 1, str + linear[i].to_string() + ", "
-      } else {
-        str + linear[len - 1].to_string() + "]"
+      logger.write_string("ImmutableSet::[")
+      for i = 0; i < len; i = i + 1 {
+        if i > 0 {
+          logger.write_string(", ")
+        }
+        linear[i].output(logger)
       }
+      logger.write_string("]")
     }
   }
+}
+
+pub fn to_string[T : Show + Compare](self : ImmutableSet[T]) -> String {
+  Show::to_string(self)
 }
 
 // The following are the helper functions or types used by the internal implementation of ImmutableSet
@@ -547,10 +554,10 @@ priv enum SplitBis[T] {
   NotFound(ImmutableSet[T], () -> ImmutableSet[T])
 }
 
-fn to_string[T : Show](self : SplitBis[T]) -> String {
+impl[T : Show] Show for SplitBis[T] with output(self, logger) {
   match self {
-    Found => "Found"
-    NotFound(_) => "NotFound"
+    Found => logger.write_string("Found")
+    NotFound(_) => logger.write_string("NotFound")
   }
 }
 

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -41,4 +41,5 @@ impl ImmutableSet {
 // Traits
 
 // Extension Methods
+impl Show for ImmutableSet
 

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -54,4 +54,7 @@ impl Position {
 // Traits
 
 // Extension Methods
+impl Show for JsonValue
+
+impl Show for ParseError
 

--- a/json/json_wbtest.mbt
+++ b/json/json_wbtest.mbt
@@ -61,7 +61,9 @@ test "get as string" {
   inspect!(JsonValue::Number(1.0) |> as_string, content="None")
   inspect!(
     JsonValue::String("Hello World") |> as_string,
-    content="Some(Hello World)",
+    content=
+      #|Some("Hello World")
+    ,
   )
   inspect!(
     JsonValue::Array([JsonValue::String("Hello World")]) |> as_string,
@@ -87,12 +89,14 @@ test "get as array" {
   inspect!(
     JsonValue::Array([JsonValue::String("Hello World")]) |> as_array,
     content=
-      #|Some([String(\"Hello World\")])
+      #|Some([String("Hello World")])
     ,
   )
   inspect!(
     JsonValue::Array([JsonValue::String("Hello World")]).item(0).bind(as_string),
-    content="Some(Hello World)",
+    content=
+      #|Some("Hello World")
+    ,
   )
   inspect!(
     JsonValue::Array([JsonValue::String("Hello World")]).item(1).bind(as_string),
@@ -149,7 +153,7 @@ test "get as object" {
     |> as_object
     |> Option::map(Map::to_array),
     content=
-      #|Some([(key, String(\"key\")), (value, Number(100.0))])
+      #|Some([("key", String("key")), ("value", Number(100.0))])
     ,
   )
   inspect!(
@@ -158,7 +162,9 @@ test "get as object" {
         [("key", JsonValue::String("key")), ("value", JsonValue::Number(100.0))],
       ),
     ).value("key").bind(as_string),
-    content="Some(key)",
+    content=
+      #|Some("key")
+    ,
   )
   inspect!(
     JsonValue::Object(
@@ -228,7 +234,7 @@ test "deep access" {
   inspect!(
     json.value("key").bind(as_array),
     content=
-      #|Some([Number(1.0), True, Null, Array([]), Object({key: String(\"value\"), value:Number(100.0)})])
+      #|Some([Number(1.0), True, Null, Array([]), Object("key": String("value"), "value": Number(100.0)})])
     ,
   )
   inspect!(
@@ -240,7 +246,7 @@ test "deep access" {
       Map::to_array,
     ),
     content=
-      #|Some([(key, String(\"value\")), (value, Number(100.0))])
+      #|Some([("key", String("value")), ("value", Number(100.0))])
     ,
   )
   inspect!(

--- a/json/parse_wbtest.mbt
+++ b/json/parse_wbtest.mbt
@@ -27,24 +27,35 @@ test "parses empty object" {
 }
 
 test "parses object" {
-  inspect!(parse_as_result("{\"a\":1}"), content="Ok(Object({a: Number(1.0)}))")
+  inspect!(
+    parse_as_result("{\"a\":1}"),
+    content=
+      #|Ok(Object("a": Number(1.0)}))
+    ,
+  )
   inspect!(
     parse_as_result("{\"a\":1,\"b\":2}"),
-    content="Ok(Object({a: Number(1.0), b:Number(2.0)}))",
+    content=
+      #|Ok(Object("a": Number(1.0), "b": Number(2.0)}))
+    ,
   )
 }
 
 test "parses multiple properties" {
   inspect!(
     parse_as_result("{\"abc\":1,\"def\":2}"),
-    content="Ok(Object({abc: Number(1.0), def:Number(2.0)}))",
+    content=
+      #|Ok(Object("abc": Number(1.0), "def": Number(2.0)}))
+    ,
   )
 }
 
 test "parses nested objects" {
   inspect!(
     parse_as_result("{\"a\":{\"b\":2}}"),
-    content="Ok(Object({a: Object({b: Number(2.0)})}))",
+    content=
+      #|Ok(Object("a": Object("b": Number(2.0)})}))
+    ,
   )
 }
 //endregion
@@ -297,7 +308,12 @@ test "parse muti-lines json" {
     #|}
     ,
   )
-  inspect!(result, content="Ok(Object({a: Number(2.0), b:Number(3.0)}))")
+  inspect!(
+    result,
+    content=
+      #|Ok(Object("a": Number(2.0), "b": Number(3.0)}))
+    ,
+  )
 }
 
 test "parse muti-lines json error" {

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -46,14 +46,38 @@ pub fn ParseError::to_string(self : ParseError) -> String {
   }
 }
 
-pub fn to_string(self : JsonValue) -> String {
+pub impl Show for ParseError with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+pub impl Show for JsonValue with output(self, logger) {
   match self {
-    Null => "Null"
-    True => "True"
-    False => "False"
-    Number(n) => "Number(\(n))"
-    String(s) => "String(" + "\\\"" + s + "\\\")"
-    Array(a) => "Array(" + a.to_string() + ")"
-    Object(o) => "Object(" + o.to_string() + ")"
+    Null => logger.write_string("Null")
+    True => logger.write_string("True")
+    False => logger.write_string("False")
+    Number(n) => {
+      logger.write_string("Number(")
+      Show::output(n, logger)
+      logger.write_string(")")
+    }
+    String(s) => {
+      logger.write_string("String(")
+      Show::output(s, logger)
+      logger.write_string(")")
+    }
+    Array(a) => {
+      logger.write_string("Array(")
+      Show::output(a, logger)
+      logger.write_string(")")
+    }
+    Object(o) => {
+      logger.write_string("Object(")
+      Show::output(o, logger)
+      logger.write_string(")")
+    }
   }
+}
+
+pub fn to_string(self : JsonValue) -> String {
+  Show::to_string(self)
 }

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -42,17 +42,22 @@ pub fn Queue::from_array[T](arr : Array[T]) -> Queue[T] {
   queue
 }
 
-pub fn to_string[T : Show](self : Queue[T]) -> String {
-  let mut res = "Queue::["
+pub impl[T : Show] Show for Queue[T] with output(self, logger) {
+  logger.write_string("Queue::[")
   self.eachi(
     fn(i, t) {
       if i > 0 {
-        res += ", "
+        logger.write_string(", ")
       }
-      res += t.to_string()
+      t.output(logger)
     },
   )
-  res + "]"
+  logger.write_string("]")
+}
+
+// Reuse the default implementation of [Show::to_string] here
+pub fn to_string[T : Show](self : Queue[T]) -> String {
+  Show::to_string(self)
 }
 
 pub fn debug_write[T : Show](self : Queue[T], buf : Buffer) -> Unit {

--- a/queue/queue.mbti
+++ b/queue/queue.mbti
@@ -29,4 +29,5 @@ impl Queue {
 // Traits
 
 // Extension Methods
+impl Show for Queue
 

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -247,14 +247,20 @@ pub fn fract(self : Rational) -> Rational {
   new_unchecked(self.numerator % self.denominator, self.denominator)
 }
 
-pub fn to_string(self : Rational) -> String {
+pub impl Show for Rational with output(self, logger) {
   if self.numerator == 0L {
-    "0".to_string()
+    logger.write_string("0")
   } else if self.denominator == 1L {
-    self.numerator.to_string()
+    logger.write_string(self.numerator.to_string())
   } else {
-    self.numerator.to_string() + "/" + self.denominator.to_string()
+    logger..write_string(self.numerator.to_string())..write_string("/").write_string(
+      self.denominator.to_string(),
+    )
   }
+}
+
+pub fn to_string(self : Rational) -> String {
+  Show::to_string(self)
 }
 
 pub fn is_integer(self : Rational) -> Bool {

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -29,4 +29,5 @@ impl Rational {
 // Traits
 
 // Extension Methods
+impl Show for Rational
 

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -306,9 +306,19 @@ pub fn to_string[T : Show, E : Show](self : Result[T, E]) -> String {
 
 test "show" {
   let ok : Result[_, String] = Ok("hello")
-  inspect!(ok, content="Ok(hello)")
+  inspect!(
+    ok,
+    content=
+      #|Ok("hello")
+    ,
+  )
   let err : Result[String, _] = Err("world")
-  inspect!(err, content="Err(world)")
+  inspect!(
+    err,
+    content=
+      #|Err("world")
+    ,
+  )
 }
 
 pub fn unwrap_or_error[T, E](self : Result[T, E]) -> T!E {
@@ -323,7 +333,9 @@ pub fn unwrap_or_error[T, E](self : Result[T, E]) -> T!E {
 test "unwrap exn" {
   inspect!(
     (Err("This is serious") : Result[Int, String]).unwrap_or_error()!!,
-    content="Err(This is serious)",
+    content=
+      #|Err("This is serious")
+    ,
   )
 }
 

--- a/sorted_map/map_wbtest.mbt
+++ b/sorted_map/map_wbtest.mbt
@@ -164,9 +164,24 @@ test "remove on empty map" {
 
 test "get" {
   let map = of([(3, "c"), (2, "b"), (1, "a")])
-  inspect!(map.get(1), content="Some(a)")
-  inspect!(map.get(2), content="Some(b)")
-  inspect!(map.get(3), content="Some(c)")
+  inspect!(
+    map.get(1),
+    content=
+      #|Some("a")
+    ,
+  )
+  inspect!(
+    map.get(2),
+    content=
+      #|Some("b")
+    ,
+  )
+  inspect!(
+    map.get(3),
+    content=
+      #|Some("c")
+    ,
+  )
   inspect!(map.get(4), content="None")
 }
 
@@ -188,9 +203,24 @@ test "op_set" {
 
 test "op_get" {
   let map = of([(3, "c"), (2, "b"), (1, "a")])
-  inspect!(map[1], content="Some(a)")
-  inspect!(map[2], content="Some(b)")
-  inspect!(map[3], content="Some(c)")
+  inspect!(
+    map[1],
+    content=
+      #|Some("a")
+    ,
+  )
+  inspect!(
+    map[2],
+    content=
+      #|Some("b")
+    ,
+  )
+  inspect!(
+    map[3],
+    content=
+      #|Some("c")
+    ,
+  )
   inspect!(map[4], content="None")
 }
 
@@ -243,16 +273,36 @@ test "keys" {
 
 test "values" {
   let map = of([(3, "c"), (2, "b"), (1, "a")])
-  inspect!(map.values(), content="[a, b, c]")
+  inspect!(
+    map.values(),
+    content=
+      #|["a", "b", "c"]
+    ,
+  )
 }
 
 test "to_array" {
   let map = of([(3, "c"), (2, "b"), (1, "a")])
-  inspect!(map.to_array(), content="[(1, a), (2, b), (3, c)]")
+  inspect!(
+    map.to_array(),
+    content=
+      #|[(1, "a"), (2, "b"), (3, "c")]
+    ,
+  )
 }
 
 test "iter" {
   let map = of([(3, "c"), (2, "b"), (1, "a")])
-  inspect!(map.iter().collect(), content="[(1, a), (2, b), (3, c)]")
-  inspect!(map.iter().take(2).collect(), content="[(1, a), (2, b)]")
+  inspect!(
+    map.iter().collect(),
+    content=
+      #|[(1, "a"), (2, "b"), (3, "c")]
+    ,
+  )
+  inspect!(
+    map.iter().take(2).collect(),
+    content=
+      #|[(1, "a"), (2, "b")]
+    ,
+  )
 }

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -353,24 +353,32 @@ pub fn debug_write[V : Debug](self : T[V], buf : Buffer) -> Unit {
 }
 
 /// Converts the set to string.
-pub fn to_string[V : Show](self : T[V]) -> String {
+pub impl[V : Show] Show for T[V] with output(self, logger) {
   match self.root {
-    None => "{}"
-    Some(node) => node.to_string()
+    None => logger.write_string("{}")
+    Some(node) => Show::output(node, logger)
   }
 }
 
-fn to_string[T : Show](self : Node[T]) -> String {
+pub fn to_string[V : Show](self : T[V]) -> String {
+  Show::to_string(self)
+}
+
+impl[T : Show] Show for Node[T] with output(self, logger) {
   let linear = self.to_array()
   let len = linear.length()
   if len == 0 {
-    return "{}"
+    logger.write_string("{}")
+    return
   }
-  for i = 0, str = "{"; i < len - 1; {
-    continue i + 1, str + linear[i].to_string() + ", "
-  } else {
-    str + linear[len - 1].to_string() + "}"
+  logger.write_string("{")
+  for i = 0; i < len; i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
+    }
+    linear[i].output(logger)
   }
+  logger.write_string("}")
 }
 
 fn to_array[T](self : Node[T]) -> Array[T] {

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -33,4 +33,5 @@ impl T {
 // Traits
 
 // Extension Methods
+impl Show for T
 

--- a/string/string_wbtest.mbt
+++ b/string/string_wbtest.mbt
@@ -54,13 +54,13 @@ test "debug_write" {
 
 test "to_array" {
   let a = "你好！mbt😀".to_array()
-  inspect!(a[0], content="你")
-  inspect!(a[1], content="好")
-  inspect!(a[2], content="！")
-  inspect!(a[3], content="m")
-  inspect!(a[4], content="b")
-  inspect!(a[5], content="t")
-  inspect!(a[6], content="😀")
+  inspect!(a[0], content="'你'")
+  inspect!(a[1], content="'好'")
+  inspect!(a[2], content="'！'")
+  inspect!(a[3], content="'m'")
+  inspect!(a[4], content="'b'")
+  inspect!(a[5], content="'t'")
+  inspect!(a[6], content="'😀'")
 }
 
 test "substring" {
@@ -89,10 +89,13 @@ test "chars" {
       #|
     ,
   )
-  inspect!("A😊𠮷BA😊𠮷B".iter().take(2).collect(), content="[A, 😊]")
+  inspect!(
+    "A😊𠮷BA😊𠮷B".iter().take(2).collect(),
+    content="['A', '😊']",
+  )
   inspect!(
     "A😊𠮷BA😊𠮷B".iter().take(4).collect(),
-    content="[A, 😊, 𠮷, B]",
+    content="['A', '😊', '𠮷', 'B']",
   )
 }
 
@@ -278,19 +281,43 @@ test "ends_with" {
 }
 
 test "split" {
-  inspect!("a,b,c,d,e".split(","), content="[a, b, c, d, e]")
-  inspect!("abcde".split(""), content="[a, b, c, d, e]")
-  inspect!("a b c d e".split(" "), content="[a, b, c, d, e]")
-  inspect!("abcde".split("x"), content="[abcde]")
+  inspect!(
+    "a,b,c,d,e".split(","),
+    content=
+      #|["a", "b", "c", "d", "e"]
+    ,
+  )
+  inspect!(
+    "abcde".split(""),
+    content=
+      #|["a", "b", "c", "d", "e"]
+    ,
+  )
+  inspect!(
+    "a b c d e".split(" "),
+    content=
+      #|["a", "b", "c", "d", "e"]
+    ,
+  )
+  inspect!(
+    "abcde".split("x"),
+    content=
+      #|["abcde"]
+    ,
+  )
   inspect!("".split(""), content="[]")
   inspect!("".split("x"), content="[]")
   inspect!(
     "你 wow 好 wow 月 wow 兔".split(" wow "),
-    content="[你, 好, 月, 兔]",
+    content=
+      #|["你", "好", "月", "兔"]
+    ,
   )
   inspect!(
     "👍😍😭👍😍😭👍😍😭👍".split("😍😭"),
-    content="[👍, 👍, 👍, 👍]",
+    content=
+      #|["👍", "👍", "👍", "👍"]
+    ,
   )
 }
 

--- a/string/utils.mbt
+++ b/string/utils.mbt
@@ -50,5 +50,5 @@ test "code_point_of_surrogate_pair" {
   let s = "😀"
   let leading = s[0]
   let trailing = s[1]
-  inspect!(code_point_of_surrogate_pair(leading, trailing), content="😀")
+  inspect!(code_point_of_surrogate_pair(leading, trailing), content="'😀'")
 }

--- a/tuple/tuple.mbti
+++ b/tuple/tuple.mbti
@@ -79,4 +79,15 @@ impl Tuple {
 // Traits
 
 // Extension Methods
+impl Show for Tuple
+
+impl Show for Tuple
+
+impl Show for Tuple
+
+impl Show for Tuple
+
+impl Show for Tuple
+
+impl Show for Tuple
 

--- a/tuple/tuple_show.mbt
+++ b/tuple/tuple_show.mbt
@@ -12,39 +12,145 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub impl[A : Show, B : Show] Show for (A, B) with output(self, logger) {
+  let (a, b) = self
+  logger.write_string("(")
+  a.output(logger)
+  logger.write_string(", ")
+  b.output(logger)
+  logger.write_string(")")
+}
+
 pub fn to_string[A : Show, B : Show](self : (A, B)) -> String {
-  "(".to_string() + self.0.to_string() + ", " + self.1.to_string() + ")"
+  Show::to_string(self)
+}
+
+pub impl[A : Show, B : Show, C : Show] Show for (A, B, C) with output(
+  self,
+  logger
+) {
+  let (a, b, c) = self
+  logger.write_string("(")
+  a.output(logger)
+  logger.write_string(", ")
+  b.output(logger)
+  logger.write_string(", ")
+  c.output(logger)
+  logger.write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show](self : (A, B, C)) -> String {
-  "(".to_string() + self.0.to_string() + ", " + self.1.to_string() + ", " + self.2.to_string() +
-  ")"
+  Show::to_string(self)
+}
+
+pub impl[A : Show, B : Show, C : Show, D : Show] Show for (A, B, C, D) with output(
+  self,
+  logger
+) {
+  let (a, b, c, d) = self
+  logger.write_string("(")
+  a.output(logger)
+  logger.write_string(", ")
+  b.output(logger)
+  logger.write_string(", ")
+  c.output(logger)
+  logger.write_string(", ")
+  d.output(logger)
+  logger.write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show](
   self : (A, B, C, D)
 ) -> String {
-  "(".to_string() + self.0.to_string() + ", " + self.1.to_string() + ", " + self.2.to_string() +
-  ", " + self.3.to_string() + ")"
+  Show::to_string(self)
+}
+
+pub impl[A : Show, B : Show, C : Show, D : Show, E : Show] Show for (
+  A,
+  B,
+  C,
+  D,
+  E,
+) with output(self, logger) {
+  let (a, b, c, d, e) = self
+  logger.write_string("(")
+  a.output(logger)
+  logger.write_string(", ")
+  b.output(logger)
+  logger.write_string(", ")
+  c.output(logger)
+  logger.write_string(", ")
+  d.output(logger)
+  logger.write_string(", ")
+  e.output(logger)
+  logger.write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show](
   self : (A, B, C, D, E)
 ) -> String {
-  "(".to_string() + self.0.to_string() + ", " + self.1.to_string() + ", " + self.2.to_string() +
-  ", " + self.3.to_string() + ", " + self.4.to_string() + ")"
+  Show::to_string(self)
+}
+
+pub impl[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Show for (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+) with output(self, logger) {
+  let (a, b, c, d, e, f) = self
+  logger.write_string("(")
+  a.output(logger)
+  logger.write_string(", ")
+  b.output(logger)
+  logger.write_string(", ")
+  c.output(logger)
+  logger.write_string(", ")
+  d.output(logger)
+  logger.write_string(", ")
+  e.output(logger)
+  logger.write_string(", ")
+  f.output(logger)
+  logger.write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show](
   self : (A, B, C, D, E, F)
 ) -> String {
-  let (a, b, c, d, e, f) = self
-  "(\(a), \(b), \(c), \(d), \(e), \(f))"
+  Show::to_string(self)
+}
+
+pub impl[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show] Show for (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+) with output(self, logger) {
+  let (a, b, c, d, e, f, g) = self
+  logger.write_string("(")
+  a.output(logger)
+  logger.write_string(", ")
+  b.output(logger)
+  logger.write_string(", ")
+  c.output(logger)
+  logger.write_string(", ")
+  d.output(logger)
+  logger.write_string(", ")
+  e.output(logger)
+  logger.write_string(", ")
+  f.output(logger)
+  logger.write_string(", ")
+  g.output(logger)
+  logger.write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show](
   self : (A, B, C, D, E, F, G)
 ) -> String {
-  let (a, b, c, d, e, f, g) = self
-  "(\(a), \(b), \(c), \(d), \(e), \(f), \(g))"
+  Show::to_string(self)
 }

--- a/tuple/tuple_wbtest.mbt
+++ b/tuple/tuple_wbtest.mbt
@@ -217,9 +217,24 @@ test "to_string" {
   let tuple4 = (1, 2, 3, "hello")
   let tuple5 = ([1], "2", 3, ([4] : Array[_]), 5)
   inspect!(tuple2, content="(1, 2)")
-  inspect!(tuple3, content="(a, b, c)")
-  inspect!(tuple4, content="(1, 2, 3, hello)")
-  inspect!(tuple5, content="([1], 2, 3, [4], 5)")
+  inspect!(
+    tuple3,
+    content=
+      #|("a", "b", "c")
+    ,
+  )
+  inspect!(
+    tuple4,
+    content=
+      #|(1, 2, 3, "hello")
+    ,
+  )
+  inspect!(
+    tuple5,
+    content=
+      #|([1], "2", 3, [4], 5)
+    ,
+  )
   inspect!((1, 2, 3, 4, 5, 6), content="(1, 2, 3, 4, 5, 6)")
   inspect!((1, 2, 3, 4, 5, 6, 7), content="(1, 2, 3, 4, 5, 6, 7)")
 }


### PR DESCRIPTION
This PR refine the design of the `Show` trait.

## Problem with the previous design
Consider the problem of `Show` implementation for `String`: should it add quotes and escapes?

- For interpolation `"... \(str) ..."` and `println(str)` where `str : String`, we want `str` itself to be interpolated/printed as-is
- Whenever a `String` occur in nested structure, such as `Ref[String]`, it should be quoted for a sensible result

Previously, the `Show` trait has only a `to_string` method, which is not enough to produce the correct behavior above. Furthermore, combining `to_string` with string concatenation is inefficient.

## The proposed design here
The new `Show` trait in this PR is:
```rust
trait Show {
  output(Self, Logger) -> Unit
  to_string(Self) -> String
}
```
Here `output` is for composition, it write a string representation of `Self` to a `Logger` (which is a trait object for logging stuffs). This allows efficient composition without intermediate allocation. End users of the `Show` trait can still use the familiar `to_string` method.

The method `to_string` has a default implementation using `output`, so library authors only need to implement the `output` method to implement the `Show` trait.

`String` overrides the default `to_string` in its implementation of `Show` and returns the string itself. In the mean time, `String`'s implementation for `output`, which is used for composition, will escape and quote the string. So when a `String` occurs inside nested structure, it is properly quoted and escaped. When a `String` is used directly for `println` and interpolation, the identity `to_string` will be used.