### PR TITLE
fix/improve/add missing `Show` impl

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -344,19 +344,16 @@ fn debug_entries[K : Show, V : Show](self : Map[K, V]) -> String {
 }
 
 pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
-  if self.size == 0 {
-    logger.write_string("{}")
-    return
-  }
+  logger.write_string("{")
   loop 0, self.head {
     _, None => logger.write_string("}")
     i, Some({ key, value, idx, .. }) => {
       if i > 0 {
         logger.write_string(", ")
       }
-      key.output(logger)
+      Show::output(key, logger)
       logger.write_string(": ")
-      value.output(logger)
+      Show::output(value, logger)
       continue i + 1, self.list[idx].next
     }
   }

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -663,14 +663,14 @@ test "to_string" {
   inspect!(
     m.to_string(),
     content=
-      #|"a": 1, "b": 2, "c": 3}
+      #|{"a": 1, "b": 2, "c": 3}
     ,
   )
   let nested_m = { "a": { "b": 2 }, "B": { "C": 3 } }
   inspect!(
     nested_m.to_string(),
     content=
-      #|"a": "b": 2}, "B": "C": 3}}
+      #|{"a": {"b": 2}, "B": {"C": 3}}
     ,
   )
 }

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -47,7 +47,22 @@ pub trait Logger {
 
 /// Trait for types that can be converted to `String`
 pub trait Show {
+  // `output` is used for composition of aggregate structure.
+  // `output` writes a string representation of `self` to a logger.
+  // `output` should produce a valid MoonBit-syntax representation if possible.
+  // For example, `Show::output` for `String` should be quoted
   output(Self, Logger) -> Unit
+  // `to_string` should be used by end users of `Show`,
+  // for printing, interpolation, etc. only, and should not be used for composition.
+  // By default `to_string` is implemented using `output` and a buffer,
+  // but some types, such as `String`, may override `to_string`,
+  // for different (unescaped) behavior when interpolated/printed directly
+  //
+  // By default, `to_string` cannot be called via dot directly.
+  // If implementors of `Show` wants to allow `.to_string()` usage,
+  // they should create a method wrapper manually:
+  //
+  //    fn to_string(self : T) -> String { Show::to_string(self) }
   to_string(Self) -> String
 }
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -28,16 +28,12 @@ pub fn Deque::new[T](~capacity : Int = 0) -> Deque[T] {
 }
 
 pub impl[T : Show] Show for Deque[T] with output(self, logger) {
-  if self.length() == 0 {
-    logger.write_string("Deque::[]")
-    return
-  }
   logger.write_string("Deque::[")
   for i = 0; i < self.length(); i = i + 1 {
     if i > 0 {
       logger.write_string(", ")
     }
-    self[i].output(logger)
+    Show::output(self[i], logger)
   }
   logger.write_string("]")
 }

--- a/hashmap/hashmap.mbti
+++ b/hashmap/hashmap.mbti
@@ -23,9 +23,11 @@ impl HashMap {
   set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[Tuple[K, V]]
+  to_string[K : Show, V : Show](Self[K, V]) -> String
 }
 
 // Traits
 
 // Extension Methods
+impl Show for HashMap
 

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -101,3 +101,24 @@ pub fn eachi[K, V](self : HashMap[K, V], f : (Int, K, V) -> Unit) -> Unit {
     }
   }
 }
+
+pub impl[K : Show, V : Show] Show for HashMap[K, V] with output(self, logger) {
+  logger.write_string("HashMap::of([")
+  self.eachi(
+    fn(i, k, v) {
+      if i > 0 {
+        logger.write_string(", ")
+      }
+      logger.write_string("(")
+      Show::output(k, logger)
+      logger.write_string(", ")
+      Show::output(v, logger)
+      logger.write_string(")")
+    },
+  )
+  logger.write_string("])")
+}
+
+pub fn to_string[K : Show, V : Show](self : HashMap[K, V]) -> String {
+  Show::to_string(self)
+}

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -294,9 +294,16 @@ fn debug_entries[K : Show](self : HashSet[K]) -> String {
 }
 
 pub impl[K : Show] Show for HashSet[K] with output(self, logger) {
-  logger.write_string("@hashset.of(")
-  Show::output(self.iter().collect(), logger)
-  logger.write_string(")")
+  logger.write_string("@hashset.of([")
+  self.eachi(
+    fn(i, x) {
+      if i > 0 {
+        logger.write_string(", ")
+      }
+      Show::output(x, logger)
+    },
+  )
+  logger.write_string("])")
 }
 
 // Reuse the default implementation of [Show::to_string] here

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -24,7 +24,7 @@ test "is_empty" {
 }
 
 pub impl[T : Show] Show for ImmutableVec[T] with output(self, logger) {
-  logger.write_string("ImmutableVec::[")
+  logger.write_string("@immut/array.of([")
   self.eachi(
     fn(i, v) {
       if i > 0 {
@@ -33,7 +33,7 @@ pub impl[T : Show] Show for ImmutableVec[T] with output(self, logger) {
       v.output(logger)
     },
   )
-  logger.write_string("]")
+  logger.write_string("])")
 }
 
 pub fn to_string[T : Show](self : ImmutableVec[T]) -> String {
@@ -43,8 +43,8 @@ pub fn to_string[T : Show](self : ImmutableVec[T]) -> String {
 test "to_string" {
   let v = of([1, 2, 3, 4, 5])
   let ve : ImmutableVec[Int] = ImmutableVec::empty()
-  inspect!(v, content="ImmutableVec::[1, 2, 3, 4, 5]")
-  inspect!(ve, content="ImmutableVec::[]")
+  inspect!(v, content="@immut/array.of([1, 2, 3, 4, 5])")
+  inspect!(ve, content="@immut/array.of([])")
 }
 
 pub fn is_empty[T](v : ImmutableVec[T]) -> Bool {
@@ -115,12 +115,12 @@ pub fn copy[T](self : ImmutableVec[T]) -> ImmutableVec[T] {
 test "copy" {
   let v = of([1, 2, 3, 4, 5])
   let vc = v.copy()
-  inspect!(vc, content="ImmutableVec::[1, 2, 3, 4, 5]")
+  inspect!(vc, content="@immut/array.of([1, 2, 3, 4, 5])")
   inspect!(v == vc, content="true")
   @test.is_false!(physical_equal(v, vc))
   let v = ImmutableVec::empty()
   let vc : ImmutableVec[Int] = v.copy()
-  inspect!(vc, content="ImmutableVec::[]")
+  inspect!(vc, content="@immut/array.of([])")
   inspect!(v == vc, content="true")
   @test.is_false!(physical_equal(v, vc))
 }
@@ -185,8 +185,8 @@ test "set" {
   let v = of([1, 2, 3, 4, 5])
   let v1 = v.set(1, 10)
   let v2 = v.set(2, 10)
-  inspect!(v1, content="ImmutableVec::[1, 10, 3, 4, 5]")
-  inspect!(v2, content="ImmutableVec::[1, 2, 10, 4, 5]")
+  inspect!(v1, content="@immut/array.of([1, 10, 3, 4, 5])")
+  inspect!(v2, content="@immut/array.of([1, 2, 10, 4, 5])")
 }
 
 /// Push a value to the end of the array.
@@ -214,10 +214,10 @@ pub fn push[T](self : ImmutableVec[T], value : T) -> ImmutableVec[T] {
 
 test "push" {
   let v = ImmutableVec::empty().push(1).push(2).push(3)
-  inspect!(v, content="ImmutableVec::[1, 2, 3]")
-  inspect!(v.push(1), content="ImmutableVec::[1, 2, 3, 1]")
-  inspect!(v.push(2), content="ImmutableVec::[1, 2, 3, 2]")
-  inspect!(v.push(3), content="ImmutableVec::[1, 2, 3, 3]")
+  inspect!(v, content="@immut/array.of([1, 2, 3])")
+  inspect!(v.push(1), content="@immut/array.of([1, 2, 3, 1])")
+  inspect!(v.push(2), content="@immut/array.of([1, 2, 3, 2])")
+  inspect!(v.push(3), content="@immut/array.of([1, 2, 3, 3])")
 }
 
 /// Create a persistent array from an array.
@@ -233,10 +233,10 @@ pub fn ImmutableVec::from_array[T](arr : Array[T]) -> ImmutableVec[T] {
 test "from_array" {
   let v = of([1, 1, 4, 5, 1, 4])
   let vv = ImmutableVec::from_array(Array::make(30, 1))
-  inspect!(v, content="ImmutableVec::[1, 1, 4, 5, 1, 4]")
+  inspect!(v, content="@immut/array.of([1, 1, 4, 5, 1, 4])")
   inspect!(
     vv,
-    content="ImmutableVec::[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]",
+    content="@immut/array.of([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])",
   )
 }
 
@@ -405,20 +405,20 @@ pub fn map[T, U](self : ImmutableVec[T], f : (T) -> U) -> ImmutableVec[U] {
 
 test "map" {
   let v = of([1, 2, 3, 4, 5])
-  inspect!(v.map(fn(e) { e * 2 }), content="ImmutableVec::[2, 4, 6, 8, 10]")
+  inspect!(v.map(fn(e) { e * 2 }), content="@immut/array.of([2, 4, 6, 8, 10])")
   inspect!(
     v.map(fn(e) { e.to_string() }),
     content=
-      #|ImmutableVec::["1", "2", "3", "4", "5"]
+      #|@immut/array.of(["1", "2", "3", "4", "5"])
     ,
   )
   inspect!(
     v.map(fn(e) { e % 2 == 0 }),
-    content="ImmutableVec::[false, true, false, true, false]",
+    content="@immut/array.of([false, true, false, true, false])",
   )
   inspect!(
     ImmutableVec::empty().map(fn(e : Int) { e }),
-    content="ImmutableVec::[]",
+    content="@immut/array.of([])",
   )
 }
 
@@ -467,16 +467,16 @@ test "new_by_leaves" {
   )
   let v = new_by_leaves(5, fn(_s, l) { Array::make(l, 1) })
   let v2 = new_by_leaves(33, fn(_s, l) { Array::make(l, 10) })
-  inspect!(e, content="ImmutableVec::[]")
-  inspect!(v, content="ImmutableVec::[1, 1, 1, 1, 1]")
+  inspect!(e, content="@immut/array.of([])")
+  inspect!(v, content="@immut/array.of([1, 1, 1, 1, 1])")
   inspect!(
     v2,
-    content="ImmutableVec::[10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]",
+    content="@immut/array.of([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])",
   )
   let v3 = new_by_leaves(32, fn(_s, l) { Array::make(l, 10) })
   inspect!(
     v3,
-    content="ImmutableVec::[10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]",
+    content="@immut/array.of([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])",
   )
 }
 
@@ -488,10 +488,10 @@ pub fn ImmutableVec::new[T](len : Int, value : T) -> ImmutableVec[T] {
 test "new" {
   let v = ImmutableVec::new(5, 1)
   let v2 = ImmutableVec::new(33, 10)
-  inspect!(v, content="ImmutableVec::[1, 1, 1, 1, 1]")
+  inspect!(v, content="@immut/array.of([1, 1, 1, 1, 1])")
   inspect!(
     v2,
-    content="ImmutableVec::[10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]",
+    content="@immut/array.of([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])",
   )
 }
 
@@ -506,10 +506,10 @@ pub fn ImmutableVec::new_with_index[T](
 test "new_with" {
   let v = new_with_index(5, fn(i) { i })
   let v2 = new_with_index(33, fn(i) { i * 10 })
-  inspect!(v, content="ImmutableVec::[0, 1, 2, 3, 4]")
+  inspect!(v, content="@immut/array.of([0, 1, 2, 3, 4])")
   inspect!(
     v2,
-    content="ImmutableVec::[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, 300, 310, 320]",
+    content="@immut/array.of([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, 300, 310, 320])",
   )
 }
 
@@ -521,7 +521,7 @@ test "mix" {
   }
   inspect!(
     v,
-    content="ImmutableVec::[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]",
+    content="@immut/array.of([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99])",
   )
   let mut v2 = v.copy()
   for i = 0; i < 100; i = i + 1 {

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -33,11 +33,11 @@ test "panic set with empty array" {
 test "set with valid index" {
   let v = @array.of([1, 2, 3, 4, 5])
   let v1 = v.set(2, 10) // This should not trigger the panic
-  inspect!(v1, content="ImmutableVec::[1, 2, 10, 4, 5]")
+  inspect!(v1, content="@immut/array.of([1, 2, 10, 4, 5])")
 }
 
 test "set with valid index at end" {
   let v = @array.of([1, 2, 3, 4, 5])
   let v1 = v.set(4, 10) // This should not trigger the panic
-  inspect!(v1, content="ImmutableVec::[1, 2, 3, 4, 10]")
+  inspect!(v1, content="@immut/array.of([1, 2, 3, 4, 10])")
 }

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -236,7 +236,7 @@ pub fn debug_write[K : Debug, V : Debug](
 
 pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
   let mut is_first = true
-  logger.write_string("@immutable_hashmap.Map::[")
+  logger.write_string("@immut/hashmap.of([")
   self.each(
     fn(k, v) {
       if is_first {
@@ -251,7 +251,7 @@ pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
       logger.write_string(")")
     },
   )
-  logger.write_string("]")
+  logger.write_string("])")
 }
 
 pub fn to_string[K : Show, V : Show](self : Map[K, V]) -> String {

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -73,7 +73,7 @@ test "HAMT::to_string" {
   )
   inspect!(
     map,
-    content="@immutable_hashmap.Map::[(3, 3), (42, 42), (1, 1), (268435455, 268435455)]",
+    content="@immut/hashmap.of([(3, 3), (42, 42), (1, 1), (268435455, 268435455)])",
   )
 }
 

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -227,7 +227,7 @@ pub fn debug_write[T : Debug](self : Set[T], buf : Buffer) -> Unit {
 
 pub impl[T : Show] Show for Set[T] with output(self, logger) {
   let mut is_first = true
-  logger.write_string("@immutable_hashset.Set::[")
+  logger.write_string("@immut/hashset.of([")
   self.each(
     fn(k) {
       if is_first {
@@ -238,7 +238,7 @@ pub impl[T : Show] Show for Set[T] with output(self, logger) {
       k.output(logger)
     },
   )
-  logger.write_string("]")
+  logger.write_string("])")
 }
 
 pub fn to_string[T : Show](self : Set[T]) -> String {

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -60,7 +60,7 @@ test "@hashset.iter" {
 
 test "@hashset.to_string" {
   let set = @hashset.new().add(1).add(3).add(0x0f_ff_ff_ff).add(42)
-  inspect!(set, content="@immutable_hashset.Set::[3, 42, 1, 268435455]")
+  inspect!(set, content="@immut/hashset.of([3, 42, 1, 268435455])")
 }
 
 test "@hashset.from_array" {

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -32,9 +32,11 @@ impl Map {
   remove[K : Compare + Eq, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[Tuple[K, V]]
+  to_string[K : Show, V : Show](Self[K, V]) -> String
 }
 
 // Traits
 
 // Extension Methods
+impl Show for Map
 

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -242,3 +242,24 @@ pub fn Map::of[K : Compare, V](array : FixedArray[(K, V)]) -> Map[K, V] {
     mp
   }
 }
+
+pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
+  logger.write_string("@immut/sorted_map.of([")
+  self.eachi(
+    fn(i, k, v) {
+      if i > 0 {
+        logger.write_string(", ")
+      }
+      logger.write_string("(")
+      Show::output(k, logger)
+      logger.write_string(", ")
+      Show::output(v, logger)
+      logger.write_string(")")
+    },
+  )
+  logger.write_string("])")
+}
+
+pub fn to_string[K : Show, V : Show](self : Map[K, V]) -> String {
+  Show::to_string(self)
+}

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -414,7 +414,7 @@ pub fn disjoint[T : Compare](
 /// of([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(print)
 /// // output: 123456789
 /// ```
-pub fn each[T : Compare](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
+pub fn each[T](self : ImmutableSet[T], f : (T) -> Unit) -> Unit {
   match self {
     Empty => ()
     Node(~left, ~value, ~right, ..) => {
@@ -525,25 +525,23 @@ pub fn filter[T : Compare](
   }
 }
 
-pub impl[T : Show + Compare] Show for ImmutableSet[T] with output(self, logger) {
-  match self {
-    Empty => logger.write_string("ImmutableSet::[]")
-    _ => {
-      let linear = self.to_array()
-      let len = linear.length()
-      logger.write_string("ImmutableSet::[")
-      for i = 0; i < len; i = i + 1 {
-        if i > 0 {
-          logger.write_string(", ")
-        }
-        linear[i].output(logger)
+pub impl[T : Show] Show for ImmutableSet[T] with output(self, logger) {
+  logger.write_string("@immut/sorted_set.of([")
+  let mut is_first = true
+  self.each(
+    fn(x) {
+      if is_first {
+        is_first = false
+      } else {
+        logger.write_string(", ")
       }
-      logger.write_string("]")
-    }
-  }
+      Show::output(x, logger)
+    },
+  )
+  logger.write_string("])")
 }
 
-pub fn to_string[T : Show + Compare](self : ImmutableSet[T]) -> String {
+pub fn to_string[T : Show](self : ImmutableSet[T]) -> String {
   Show::to_string(self)
 }
 
@@ -763,7 +761,7 @@ test "balance with left height greater" {
   let value = 4
   let right = of([5])
   let balanced_set = balance(left, value, right)
-  inspect!(balanced_set, content="ImmutableSet::[1, 2, 3, 4, 5]")
+  inspect!(balanced_set, content="@immut/sorted_set.of([1, 2, 3, 4, 5])")
 }
 
 test "balance with right height greater" {
@@ -771,7 +769,7 @@ test "balance with right height greater" {
   let value = 2
   let right = of([3, 4, 5])
   let balanced_set = balance(left, value, right)
-  inspect!(balanced_set, content="ImmutableSet::[1, 2, 3, 4, 5]")
+  inspect!(balanced_set, content="@immut/sorted_set.of([1, 2, 3, 4, 5])")
 }
 
 test "join with different heights" {
@@ -779,5 +777,5 @@ test "join with different heights" {
   let value = 4
   let right = of([5, 6, 7])
   let joined_set = join(left, value, right)
-  inspect!(joined_set, content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7]")
+  inspect!(joined_set, content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7])")
 }

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -18,7 +18,7 @@
 
 test "new" {
   let empty : @sorted_set.ImmutableSet[Int] = @sorted_set.new()
-  inspect!(empty, content="ImmutableSet::[]")
+  inspect!(empty, content="@immut/sorted_set.of([])")
 }
 
 test "disjoint" {
@@ -55,29 +55,32 @@ test "subset" {
 
 test "diff" {
   let empty = @sorted_set.new()
-  inspect!(empty.diff(@sorted_set.of([1, 2, 3])), content="ImmutableSet::[]")
+  inspect!(
+    empty.diff(@sorted_set.of([1, 2, 3])),
+    content="@immut/sorted_set.of([])",
+  )
   inspect!(
     @sorted_set.of([1, 2, 3]).diff(empty),
-    content="ImmutableSet::[1, 2, 3]",
+    content="@immut/sorted_set.of([1, 2, 3])",
   )
   inspect!(
     @sorted_set.of([1, 2, 3]).diff(@sorted_set.of([4, 5, 1])),
-    content="ImmutableSet::[2, 3]",
+    content="@immut/sorted_set.of([2, 3])",
   )
   inspect!(
     @sorted_set.of([1, 2, 3]).diff(@sorted_set.of([1, 2, 3])),
-    content="ImmutableSet::[]",
+    content="@immut/sorted_set.of([])",
   )
 }
 
 test "inter" {
   inspect!(
     @sorted_set.of([3, 4, 5]).inter(@sorted_set.of([4, 5, 6])),
-    content="ImmutableSet::[4, 5]",
+    content="@immut/sorted_set.of([4, 5])",
   )
   inspect!(
     @sorted_set.of([3, 4]).inter(@sorted_set.of([5, 6])),
-    content="ImmutableSet::[]",
+    content="@immut/sorted_set.of([])",
   )
 }
 
@@ -85,30 +88,30 @@ test "union" {
   let empty = @sorted_set.new()
   inspect!(
     empty.union(@sorted_set.of([4, 5, 6])),
-    content="ImmutableSet::[4, 5, 6]",
+    content="@immut/sorted_set.of([4, 5, 6])",
   )
   inspect!(
     @sorted_set.of([4, 5, 6]).union(empty),
-    content="ImmutableSet::[4, 5, 6]",
+    content="@immut/sorted_set.of([4, 5, 6])",
   )
   inspect!(
     @sorted_set.of([3]).union(@sorted_set.of([4, 5, 6])),
-    content="ImmutableSet::[3, 4, 5, 6]",
+    content="@immut/sorted_set.of([3, 4, 5, 6])",
   )
   inspect!(
     @sorted_set.of([3, 4, 5]).union(@sorted_set.of([6])),
-    content="ImmutableSet::[3, 4, 5, 6]",
+    content="@immut/sorted_set.of([3, 4, 5, 6])",
   )
   inspect!(
     @sorted_set.of([3, 4, 5]).union(@sorted_set.of([4, 5, 6])),
-    content="ImmutableSet::[3, 4, 5, 6]",
+    content="@immut/sorted_set.of([3, 4, 5, 6])",
   )
 }
 
 test "map" {
   inspect!(
     @sorted_set.of([1, 2, 3, 4, 5]).map(fn(x) { x * 2 }),
-    content="ImmutableSet::[2, 4, 6, 8, 10]",
+    content="@immut/sorted_set.of([2, 4, 6, 8, 10])",
   )
 }
 
@@ -132,7 +135,7 @@ test "fold" {
 test "filter" {
   inspect!(
     @sorted_set.of([1, 2, 3, 4, 5, 6]).filter(fn(v) { v % 2 == 0 }),
-    content="ImmutableSet::[2, 4, 6]",
+    content="@immut/sorted_set.of([2, 4, 6])",
   )
 }
 
@@ -141,14 +144,14 @@ test "split" {
     5,
   )
   inspect!(present, content="true")
-  inspect!(left, content="ImmutableSet::[1, 2, 3, 4]")
-  inspect!(right, content="ImmutableSet::[6, 7, 8, 9]")
+  inspect!(left, content="@immut/sorted_set.of([1, 2, 3, 4])")
+  inspect!(right, content="@immut/sorted_set.of([6, 7, 8, 9])")
   let (left, present, right) = @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).split(
     0,
   )
   inspect!(present, content="false")
-  inspect!(left, content="ImmutableSet::[]")
-  inspect!(right, content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]")
+  inspect!(left, content="@immut/sorted_set.of([])")
+  inspect!(right, content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9])")
 }
 
 test "contain" {
@@ -172,61 +175,79 @@ test "to_array" {
 test "from_fixed_array" {
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]),
-    content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9])",
   )
 }
 
 test "from_array" {
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]),
-    content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9])",
   )
 }
 
 test "remove_min" {
   inspect!(
     @sorted_set.of([3, 4, 5]).remove_min(),
-    content="ImmutableSet::[4, 5]",
+    content="@immut/sorted_set.of([4, 5])",
   )
 }
 
 test "add" {
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 6, 3, 8, 1]).add(5),
-    content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9])",
   )
-  inspect!(@sorted_set.of([2]).add(1), content="ImmutableSet::[1, 2]")
-  inspect!(@sorted_set.of([2]).add(3), content="ImmutableSet::[2, 3]")
-  inspect!(@sorted_set.of([2]).add(1).add(3), content="ImmutableSet::[1, 2, 3]")
-  inspect!(@sorted_set.of([1, 2]).add(1), content="ImmutableSet::[1, 2]")
-  inspect!(@sorted_set.of([2, 3]).add(3), content="ImmutableSet::[2, 3]")
-  inspect!(@sorted_set.of([1, 2, 3]).add(1), content="ImmutableSet::[1, 2, 3]")
-  inspect!(@sorted_set.of([1, 2, 3]).add(3), content="ImmutableSet::[1, 2, 3]")
-  inspect!(@sorted_set.of([1]).add(2).add(2), content="ImmutableSet::[1, 2]")
+  inspect!(@sorted_set.of([2]).add(1), content="@immut/sorted_set.of([1, 2])")
+  inspect!(@sorted_set.of([2]).add(3), content="@immut/sorted_set.of([2, 3])")
+  inspect!(
+    @sorted_set.of([2]).add(1).add(3),
+    content="@immut/sorted_set.of([1, 2, 3])",
+  )
+  inspect!(
+    @sorted_set.of([1, 2]).add(1),
+    content="@immut/sorted_set.of([1, 2])",
+  )
+  inspect!(
+    @sorted_set.of([2, 3]).add(3),
+    content="@immut/sorted_set.of([2, 3])",
+  )
+  inspect!(
+    @sorted_set.of([1, 2, 3]).add(1),
+    content="@immut/sorted_set.of([1, 2, 3])",
+  )
+  inspect!(
+    @sorted_set.of([1, 2, 3]).add(3),
+    content="@immut/sorted_set.of([1, 2, 3])",
+  )
+  inspect!(
+    @sorted_set.of([1]).add(2).add(2),
+    content="@immut/sorted_set.of([1, 2])",
+  )
 }
 
 test "remove" {
   let empty = @sorted_set.new()
-  inspect!(empty.remove(1), content="ImmutableSet::[]")
+  inspect!(empty.remove(1), content="@immut/sorted_set.of([])")
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(1),
-    content="ImmutableSet::[2, 3, 4, 5, 6, 7, 8, 9]",
+    content="@immut/sorted_set.of([2, 3, 4, 5, 6, 7, 8, 9])",
   )
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(9),
-    content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8])",
   )
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(8),
-    content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 9]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 9])",
   )
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(0),
-    content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9])",
   )
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(10),
-    content="ImmutableSet::[1, 2, 3, 4, 5, 6, 7, 8, 9]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9])",
   )
 }
 
@@ -267,11 +288,11 @@ test "is_empty" {
 test "to_string" {
   inspect!(
     @sorted_set.of([1, 2, 3, 4, 5]),
-    content="ImmutableSet::[1, 2, 3, 4, 5]",
+    content="@immut/sorted_set.of([1, 2, 3, 4, 5])",
   )
   inspect!(
     (@sorted_set.of([]) : @sorted_set.ImmutableSet[Int]),
-    content="ImmutableSet::[]",
+    content="@immut/sorted_set.of([])",
   )
 }
 
@@ -359,14 +380,14 @@ test "split with value not in set" {
   let set = @sorted_set.of([1, 2, 3, 4, 5])
   let (left, present, right) = set.split(6)
   inspect!(present, content="false")
-  inspect!(left, content="ImmutableSet::[1, 2, 3, 4, 5]")
-  inspect!(right, content="ImmutableSet::[]")
+  inspect!(left, content="@immut/sorted_set.of([1, 2, 3, 4, 5])")
+  inspect!(right, content="@immut/sorted_set.of([])")
 }
 
 test "remove_min on non-empty set" {
   let set = @sorted_set.of([3, 4, 5])
   let new_set = set.remove_min()
-  inspect!(new_set, content="ImmutableSet::[4, 5]")
+  inspect!(new_set, content="@immut/sorted_set.of([4, 5])")
 }
 
 test "min on non-empty set" {
@@ -385,7 +406,7 @@ test "union with different heights" {
   let set1 = @sorted_set.of([3, 4, 5])
   let set2 = @sorted_set.of([4, 5, 6])
   let union_set = set1.union(set2)
-  inspect!(union_set, content="ImmutableSet::[3, 4, 5, 6]")
+  inspect!(union_set, content="@immut/sorted_set.of([3, 4, 5, 6])")
 }
 
 test "disjoint with different sets" {
@@ -399,7 +420,7 @@ test "union with different heights" {
   let set1 = @sorted_set.of([3, 4, 5])
   let set2 = @sorted_set.of([4, 5, 6])
   let union_set = set1.union(set2)
-  inspect!(union_set, content="ImmutableSet::[3, 4, 5, 6]")
+  inspect!(union_set, content="@immut/sorted_set.of([3, 4, 5, 6])")
 }
 
 test "disjoint with different sets" {
@@ -413,7 +434,7 @@ test "union with different heights" {
   let set1 = @sorted_set.of([3, 4, 5])
   let set2 = @sorted_set.of([4, 5, 6])
   let union_set = set1.union(set2)
-  inspect!(union_set, content="ImmutableSet::[3, 4, 5, 6]")
+  inspect!(union_set, content="@immut/sorted_set.of([3, 4, 5, 6])")
 }
 
 test "disjoint with different sets" {

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -13,7 +13,7 @@ impl ImmutableSet {
   default[T : Default]() -> Self[T]
   diff[T : Compare + Eq](Self[T], Self[T]) -> Self[T]
   disjoint[T : Compare + Eq](Self[T], Self[T]) -> Bool
-  each[T : Compare + Eq](Self[T], (T) -> Unit) -> Unit
+  each[T](Self[T], (T) -> Unit) -> Unit
   filter[T : Compare + Eq](Self[T], (T) -> Bool) -> Self[T]
   fold[T : Compare + Eq, U](Self[T], (U, T) -> U, ~init : U) -> U
   from_array[T : Compare + Eq](Array[T]) -> Self[T]
@@ -34,7 +34,7 @@ impl ImmutableSet {
   split[T : Compare + Eq](Self[T], T) -> Tuple[Self[T], Bool, Self[T]]
   subset[T : Compare + Eq](Self[T], Self[T]) -> Bool
   to_array[T : Compare + Eq](Self[T]) -> Array[T]
-  to_string[T : Show + Compare + Eq](Self[T]) -> String
+  to_string[T : Show](Self[T]) -> String
   union[T : Compare + Eq](Self[T], Self[T]) -> Self[T]
 }
 

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -297,7 +297,7 @@ test "deep access" {
   inspect!(
     json.value("key").bind(@json.as_array),
     content=
-      #|Some([Number(1.0), True, Null, Array([]), Object("key": String("value"), "value": Number(100.0)})])
+      #|Some([Number(1.0), True, Null, Array([]), Object({"key": String("value"), "value": Number(100.0)})])
     ,
   )
   inspect!(

--- a/json/parse_test.mbt
+++ b/json/parse_test.mbt
@@ -34,13 +34,13 @@ test "parses object" {
   inspect!(
     parse_as_result("{\"a\":1}"),
     content=
-      #|Ok(Object("a": Number(1.0)}))
+      #|Ok(Object({"a": Number(1.0)}))
     ,
   )
   inspect!(
     parse_as_result("{\"a\":1,\"b\":2}"),
     content=
-      #|Ok(Object("a": Number(1.0), "b": Number(2.0)}))
+      #|Ok(Object({"a": Number(1.0), "b": Number(2.0)}))
     ,
   )
 }
@@ -49,7 +49,7 @@ test "parses multiple properties" {
   inspect!(
     parse_as_result("{\"abc\":1,\"def\":2}"),
     content=
-      #|Ok(Object("abc": Number(1.0), "def": Number(2.0)}))
+      #|Ok(Object({"abc": Number(1.0), "def": Number(2.0)}))
     ,
   )
 }
@@ -58,7 +58,7 @@ test "parses nested objects" {
   inspect!(
     parse_as_result("{\"a\":{\"b\":2}}"),
     content=
-      #|Ok(Object("a": Object("b": Number(2.0)})}))
+      #|Ok(Object({"a": Object({"b": Number(2.0)})}))
     ,
   )
 }
@@ -327,7 +327,7 @@ test "parse muti-lines json" {
   inspect!(
     result,
     content=
-      #|Ok(Object("a": Number(2.0), "b": Number(3.0)}))
+      #|Ok(Object({"a": Number(2.0), "b": Number(3.0)}))
     ,
   )
 }

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -43,7 +43,7 @@ pub fn Queue::from_array[T](arr : Array[T]) -> Queue[T] {
 }
 
 pub impl[T : Show] Show for Queue[T] with output(self, logger) {
-  logger.write_string("Queue::[")
+  logger.write_string("@queue.of([")
   self.eachi(
     fn(i, t) {
       if i > 0 {
@@ -52,7 +52,7 @@ pub impl[T : Show] Show for Queue[T] with output(self, logger) {
       t.output(logger)
     },
   )
-  logger.write_string("]")
+  logger.write_string("])")
 }
 
 // Reuse the default implementation of [Show::to_string] here

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -31,7 +31,7 @@ test "from_fixed_array_1" {
 
 test "from_fixed_array_3" {
   let q : @queue.Queue[Int] = @queue.of([])
-  inspect!(q, content="Queue::[]")
+  inspect!(q, content="@queue.of([])")
 }
 
 test "from_array_1" {
@@ -48,16 +48,16 @@ test "from_array_1" {
 
 test "from_array_3" {
   let q : @queue.Queue[Int] = @queue.of([])
-  inspect!(q, content="Queue::[]")
+  inspect!(q, content="@queue.of([])")
 }
 
 test "to_string" {
   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
-  inspect!(queue, content="Queue::[1, 2, 3, 4]")
+  inspect!(queue, content="@queue.of([1, 2, 3, 4])")
   queue.push(11)
-  inspect!(queue, content="Queue::[1, 2, 3, 4, 11]")
+  inspect!(queue, content="@queue.of([1, 2, 3, 4, 11])")
   queue.pop_exn() |> ignore
-  inspect!(queue, content="Queue::[2, 3, 4, 11]")
+  inspect!(queue, content="@queue.of([2, 3, 4, 11])")
 }
 
 test "clear" {

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -23,10 +23,12 @@ impl T {
   remove[K : Compare + Eq, V](Self[K, V], K) -> Unit
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[Tuple[K, V]]
+  to_string[K : Show, V : Show](Self[K, V]) -> String
   values[K, V](Self[K, V]) -> Array[V]
 }
 
 // Traits
 
 // Extension Methods
+impl Show for T
 

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -56,3 +56,24 @@ fn debug_tree[K : Show, V : Show](self : T[K, V]) -> String {
     None => "_"
   }
 }
+
+pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
+  logger.write_string("@sorted_map.of([")
+  self.eachi(
+    fn(i, k, v) {
+      if i > 0 {
+        logger.write_string(", ")
+      }
+      logger.write_string("(")
+      Show::output(k, logger)
+      logger.write_string(", ")
+      Show::output(v, logger)
+      logger.write_string(")")
+    },
+  )
+  logger.write_string("])")
+}
+
+pub fn to_string[K : Show, V : Show](self : T[K, V]) -> String {
+  Show::to_string(self)
+}

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -278,8 +278,15 @@ pub fn size[V : Compare](self : T[V]) -> Int64 {
 
 /// Iterates the set.
 pub fn each[V](self : T[V], f : (V) -> Unit) -> Unit {
+  match self.root {
+    None => ()
+    Some(root) => root.each(f)
+  }
+}
+
+fn each[V](self : Node[V], f : (V) -> Unit) -> Unit {
   let s = []
-  let mut p = self.root
+  let mut p = Some(self)
   while p.is_empty().not() || s.is_empty().not() {
     while p.is_empty().not() {
       s.push(p)
@@ -295,8 +302,15 @@ pub fn each[V](self : T[V], f : (V) -> Unit) -> Unit {
 
 /// Iterates the set with index.
 pub fn eachi[V](self : T[V], f : (Int, V) -> Unit) -> Unit {
+  match self.root {
+    None => ()
+    Some(root) => root.eachi(f)
+  }
+}
+
+fn eachi[V](self : Node[V], f : (Int, V) -> Unit) -> Unit {
   let s = []
-  let mut p = self.root
+  let mut p = Some(self)
   let mut i = 0
   while p.is_empty().not() || s.is_empty().not() {
     while p.is_empty().not() {
@@ -355,7 +369,7 @@ pub fn debug_write[V : Debug](self : T[V], buf : Buffer) -> Unit {
 /// Converts the set to string.
 pub impl[V : Show] Show for T[V] with output(self, logger) {
   match self.root {
-    None => logger.write_string("{}")
+    None => logger.write_string("@sorted_set.of([])")
     Some(node) => Show::output(node, logger)
   }
 }
@@ -365,20 +379,16 @@ pub fn to_string[V : Show](self : T[V]) -> String {
 }
 
 impl[T : Show] Show for Node[T] with output(self, logger) {
-  let linear = self.to_array()
-  let len = linear.length()
-  if len == 0 {
-    logger.write_string("{}")
-    return
-  }
-  logger.write_string("{")
-  for i = 0; i < len; i = i + 1 {
-    if i > 0 {
-      logger.write_string(", ")
-    }
-    linear[i].output(logger)
-  }
-  logger.write_string("}")
+  logger.write_string("@sorted_set.of([")
+  self.eachi(
+    fn(i, x) {
+      if i > 0 {
+        logger.write_string(", ")
+      }
+      Show::output(x, logger)
+    },
+  )
+  logger.write_string("])")
 }
 
 fn to_array[T](self : Node[T]) -> Array[T] {
@@ -540,11 +550,11 @@ fn delete_node[V : Compare](root : Node[V], value : V) -> (Node[V]?, Bool) {
 test "deep_clone" {
   let set = of([1, 2, 3, 4, 5])
   let clone = set.deep_clone()
-  inspect!(clone, content="{1, 2, 3, 4, 5}")
+  inspect!(clone, content="@sorted_set.of([1, 2, 3, 4, 5])")
   inspect!(set.debug_tree() == clone.debug_tree(), content="true")
   let set : T[Int] = of([])
   let clone = set.deep_clone()
-  inspect!(clone, content="{}")
+  inspect!(clone, content="@sorted_set.of([])")
   inspect!(set.debug_tree() == clone.debug_tree(), content="true")
 }
 
@@ -553,7 +563,7 @@ test "union" {
   let set1 = of([1, 2, 3])
   let set2 = of([4, 5, 6])
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3, 4, 5, 6}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 3, 4, 5, 6])")
   inspect!(
     set3.debug_tree(),
     content="([3]3,([2]2,([1]1,_,_),_),([2]5,([1]4,_,_),([1]6,_,_)))",
@@ -563,33 +573,33 @@ test "union" {
   let set1 = of([1, 2, 3])
   let set2 = of([2, 3, 4])
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3, 4}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 3, 4])")
   inspect!(set3.debug_tree(), content="([3]2,([1]1,_,_),([2]3,_,([1]4,_,_)))")
 
   // Test 3: Union of two sets where one is a subset of the other
   let set1 = of([1, 2, 3])
   let set2 = of([2, 3])
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 3])")
   inspect!(set3.debug_tree(), content="([2]2,([1]1,_,_),([1]3,_,_))")
 
   // Test 4: Union of two empty sets
   let set1 : T[Int] = new()
   let set2 = new()
   let set3 = set1.union(set2)
-  inspect!(set3, content="{}")
+  inspect!(set3, content="@sorted_set.of([])")
   inspect!(set3.debug_tree(), content="_")
 
   // Test 5: Union of an empty set with a non-empty set
   let set1 = of([1, 2, 3])
   let set2 = of([])
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 3])")
   inspect!(set3.debug_tree(), content="([2]2,([1]1,_,_),([1]3,_,_))")
   let set1 = of([])
   let set2 = of([1, 2, 3])
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 3])")
   inspect!(set3.debug_tree(), content="([2]2,([1]1,_,_),([1]3,_,_))")
 
   // Test 6: Union of two large sets with no common elements
@@ -598,7 +608,7 @@ test "union" {
   let set3 = set1.union(set2)
   inspect!(
     set3,
-    content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}",
+    content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])",
   )
   inspect!(
     set3.debug_tree(),
@@ -609,7 +619,10 @@ test "union" {
   let set1 = of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
   let set2 = of([6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}")
+  inspect!(
+    set3,
+    content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])",
+  )
   inspect!(
     set3.debug_tree(),
     content="([5]11,([4]4,([2]2,([1]1,_,_),([1]3,_,_)),([3]8,([2]6,([1]5,_,_),([1]7,_,_)),([2]9,_,([1]10,_,_)))),([3]13,([1]12,_,_),([2]14,_,([1]15,_,_))))",
@@ -619,7 +632,7 @@ test "union" {
   let set1 = of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
   let set2 = of([6, 7, 8, 9, 10])
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set3.debug_tree(),
     content="([4]4,([2]2,([1]1,_,_),([1]3,_,_)),([3]8,([2]6,([1]5,_,_),([1]7,_,_)),([2]9,_,([1]10,_,_))))",
@@ -628,17 +641,17 @@ test "union" {
 
 test "split" {
   let (l, r) = split(of([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 5)
-  inspect!(l, content="Some({1, 2, 3, 4})")
-  inspect!(r, content="Some({6, 7, 8, 9})")
+  inspect!(l, content="Some(@sorted_set.of([1, 2, 3, 4]))")
+  inspect!(r, content="Some(@sorted_set.of([6, 7, 8, 9]))")
   let (l, r) = split(of([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 0)
   inspect!(l, content="None")
-  inspect!(r, content="Some({1, 2, 3, 4, 5, 6, 7, 8, 9})")
+  inspect!(r, content="Some(@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9]))")
   let (l, r) = split(of([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 10)
-  inspect!(l, content="Some({1, 2, 3, 4, 5, 6, 7, 8, 9})")
+  inspect!(l, content="Some(@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9]))")
   inspect!(r, content="None")
   let (l, r) = split(of([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 4)
-  inspect!(l, content="Some({1, 2, 3})")
-  inspect!(r, content="Some({5, 6, 7, 8, 9})")
+  inspect!(l, content="Some(@sorted_set.of([1, 2, 3]))")
+  inspect!(r, content="Some(@sorted_set.of([5, 6, 7, 8, 9]))")
   let (l, r) = split(of([]).root, 7)
   inspect!(l, content="None")
   inspect!(r, content="None")
@@ -657,11 +670,11 @@ test "split" {
   )
   inspect!(
     l,
-    content="Some({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49})",
+    content="Some(@sorted_set.of([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]))",
   )
   inspect!(
     r,
-    content="Some({51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100})",
+    content="Some(@sorted_set.of([51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]))",
   )
 }
 
@@ -670,20 +683,29 @@ test "join" {
   let r = of([27, 28, 40, 35, 33])
   inspect!(
     join(l.root, 26, r.root),
-    content="{1, 6, 8, 11, 13, 15, 17, 25, 26, 27, 28, 33, 35, 40}",
+    content="@sorted_set.of([1, 6, 8, 11, 13, 15, 17, 25, 26, 27, 28, 33, 35, 40])",
   )
   let l = of([3, 2, 5, 1, 4])
   let r = of([7])
-  inspect!(join(l.root, 6, r.root), content="{1, 2, 3, 4, 5, 6, 7}")
+  inspect!(
+    join(l.root, 6, r.root),
+    content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7])",
+  )
   let l = of([3, 2, 5, 1, 4])
   let r = of([])
-  inspect!(join(l.root, 6, r.root), content="{1, 2, 3, 4, 5, 6}")
+  inspect!(
+    join(l.root, 6, r.root),
+    content="@sorted_set.of([1, 2, 3, 4, 5, 6])",
+  )
   let l = of([])
   let r = of([])
-  inspect!(join(l.root, 6, r.root), content="{6}")
+  inspect!(join(l.root, 6, r.root), content="@sorted_set.of([6])")
   let l = of([])
   let r = of([7, 8, 9, 10, 11, 12])
-  inspect!(join(l.root, 6, r.root), content="{6, 7, 8, 9, 10, 11, 12}")
+  inspect!(
+    join(l.root, 6, r.root),
+    content="@sorted_set.of([6, 7, 8, 9, 10, 11, 12])",
+  )
 }
 
 test "add to empty set" {
@@ -726,7 +748,7 @@ test "add multiple values" {
 test "add_and_remove" {
   let set = of([7, 2, 9, 4, 5, 6, 3, 8, 1])
   set.remove(8)
-  inspect!(set, content="{1, 2, 3, 4, 5, 6, 7, 9}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 9])")
   inspect!(
     set.debug_tree(),
     content="([4]5,([3]3,([2]2,([1]1,_,_),_),([1]4,_,_)),([2]7,([1]6,_,_),([1]9,_,_)))",
@@ -735,25 +757,25 @@ test "add_and_remove" {
 
   // Test 1: Remove elements
   set.remove(1)
-  inspect!(set, content="{2, 3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([2, 3, 4, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]4,([2]2,_,([1]3,_,_)),([3]8,([2]6,([1]5,_,_),([1]7,_,_)),([2]9,_,([1]10,_,_))))",
   )
   set.remove(5)
-  inspect!(set, content="{2, 3, 4, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([2, 3, 4, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]4,([2]2,_,([1]3,_,_)),([3]8,([2]6,_,([1]7,_,_)),([2]9,_,([1]10,_,_))))",
   )
   set.remove(10)
-  inspect!(set, content="{2, 3, 4, 6, 7, 8, 9}")
+  inspect!(set, content="@sorted_set.of([2, 3, 4, 6, 7, 8, 9])")
   inspect!(
     set.debug_tree(),
     content="([4]4,([2]2,_,([1]3,_,_)),([3]8,([2]6,_,([1]7,_,_)),([1]9,_,_)))",
   )
   set.remove(4)
-  inspect!(set, content="{2, 3, 6, 7, 8, 9}")
+  inspect!(set, content="@sorted_set.of([2, 3, 6, 7, 8, 9])")
   inspect!(
     set.debug_tree(),
     content="([3]6,([2]2,_,([1]3,_,_)),([2]8,([1]7,_,_),([1]9,_,_)))",
@@ -761,25 +783,25 @@ test "add_and_remove" {
 
   // Test 2: Add elements
   set.add(1)
-  inspect!(set, content="{1, 2, 3, 6, 7, 8, 9}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 6, 7, 8, 9])")
   inspect!(
     set.debug_tree(),
     content="([3]6,([2]2,([1]1,_,_),([1]3,_,_)),([2]8,([1]7,_,_),([1]9,_,_)))",
   )
   set.add(5)
-  inspect!(set, content="{1, 2, 3, 5, 6, 7, 8, 9}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 5, 6, 7, 8, 9])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([3]2,([1]1,_,_),([2]3,_,([1]5,_,_))),([2]8,([1]7,_,_),([1]9,_,_)))",
   )
   set.add(10)
-  inspect!(set, content="{1, 2, 3, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([3]2,([1]1,_,_),([2]3,_,([1]5,_,_))),([3]8,([1]7,_,_),([2]9,_,([1]10,_,_))))",
   )
   set.add(4)
-  inspect!(set, content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([3]2,([1]1,_,_),([2]4,([1]3,_,_),([1]5,_,_))),([3]8,([1]7,_,_),([2]9,_,([1]10,_,_))))",
@@ -787,13 +809,13 @@ test "add_and_remove" {
 
   // Test 3: Add and remove the same element
   set.add(11)
-  inspect!(set, content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([3]2,([1]1,_,_),([2]4,([1]3,_,_),([1]5,_,_))),([3]8,([1]7,_,_),([2]10,([1]9,_,_),([1]11,_,_))))",
   )
   set.remove(11)
-  inspect!(set, content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([3]2,([1]1,_,_),([2]4,([1]3,_,_),([1]5,_,_))),([3]8,([1]7,_,_),([2]10,([1]9,_,_),_)))",
@@ -801,90 +823,90 @@ test "add_and_remove" {
 
   // Test 4: Remove an element that doesn't exist
   set.remove(12)
-  inspect!(set, content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
 
   // Test 5: Add an element that already exists
   set.add(10)
-  inspect!(set, content="{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
 
   // Test 6: Remove all elements
   set.remove(1)
-  inspect!(set, content="{2, 3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([2, 3, 4, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([3]4,([2]2,_,([1]3,_,_)),([1]5,_,_)),([3]8,([1]7,_,_),([2]10,([1]9,_,_),_)))",
   )
   set.remove(2)
-  inspect!(set, content="{3, 4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([3, 4, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([2]4,([1]3,_,_),([1]5,_,_)),([3]8,([1]7,_,_),([2]10,([1]9,_,_),_)))",
   )
   set.remove(3)
-  inspect!(set, content="{4, 5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([4, 5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([4]6,([2]4,_,([1]5,_,_)),([3]8,([1]7,_,_),([2]10,([1]9,_,_),_)))",
   )
   set.remove(4)
-  inspect!(set, content="{5, 6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([5, 6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([3]8,([2]6,([1]5,_,_),([1]7,_,_)),([2]10,([1]9,_,_),_))",
   )
   set.remove(5)
-  inspect!(set, content="{6, 7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([6, 7, 8, 9, 10])")
   inspect!(
     set.debug_tree(),
     content="([3]8,([2]6,_,([1]7,_,_)),([2]10,([1]9,_,_),_))",
   )
   set.remove(6)
-  inspect!(set, content="{7, 8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([7, 8, 9, 10])")
   inspect!(set.debug_tree(), content="([3]8,([1]7,_,_),([2]10,([1]9,_,_),_))")
   set.remove(7)
-  inspect!(set, content="{8, 9, 10}")
+  inspect!(set, content="@sorted_set.of([8, 9, 10])")
   inspect!(set.debug_tree(), content="([2]9,([1]8,_,_),([1]10,_,_))")
   set.remove(8)
-  inspect!(set, content="{9, 10}")
+  inspect!(set, content="@sorted_set.of([9, 10])")
   inspect!(set.debug_tree(), content="([2]9,_,([1]10,_,_))")
   set.remove(9)
-  inspect!(set, content="{10}")
+  inspect!(set, content="@sorted_set.of([10])")
   inspect!(set.debug_tree(), content="([1]10,_,_)")
   set.remove(10)
-  inspect!(set, content="{}")
+  inspect!(set, content="@sorted_set.of([])")
   inspect!(set.debug_tree(), content="_")
   let set = of([7, 2, 9, 4, 5, 6, 3, 1])
   set.remove(3)
-  inspect!(set, content="{1, 2, 4, 5, 6, 7, 9}")
+  inspect!(set, content="@sorted_set.of([1, 2, 4, 5, 6, 7, 9])")
   inspect!(
     set.debug_tree(),
     content="([3]5,([2]2,([1]1,_,_),([1]4,_,_)),([2]7,([1]6,_,_),([1]9,_,_)))",
   )
   set.remove(2)
-  inspect!(set, content="{1, 4, 5, 6, 7, 9}")
+  inspect!(set, content="@sorted_set.of([1, 4, 5, 6, 7, 9])")
   inspect!(
     set.debug_tree(),
     content="([3]5,([2]4,([1]1,_,_),_),([2]7,([1]6,_,_),([1]9,_,_)))",
   )
   set.remove(5)
-  inspect!(set, content="{1, 4, 6, 7, 9}")
+  inspect!(set, content="@sorted_set.of([1, 4, 6, 7, 9])")
   inspect!(
     set.debug_tree(),
     content="([3]6,([2]4,([1]1,_,_),_),([2]7,_,([1]9,_,_)))",
   )
   set.remove(9)
-  inspect!(set, content="{1, 4, 6, 7}")
+  inspect!(set, content="@sorted_set.of([1, 4, 6, 7])")
   inspect!(set.debug_tree(), content="([3]6,([2]4,([1]1,_,_),_),([1]7,_,_))")
   set.remove(1)
-  inspect!(set, content="{4, 6, 7}")
+  inspect!(set, content="@sorted_set.of([4, 6, 7])")
   inspect!(set.debug_tree(), content="([2]6,([1]4,_,_),([1]7,_,_))")
   set.remove(7)
-  inspect!(set, content="{4, 6}")
+  inspect!(set, content="@sorted_set.of([4, 6])")
   inspect!(set.debug_tree(), content="([2]6,([1]4,_,_),_)")
   set.remove(4)
-  inspect!(set, content="{6}")
+  inspect!(set, content="@sorted_set.of([6])")
   inspect!(set.debug_tree(), content="([1]6,_,_)")
   set.remove(6)
-  inspect!(set, content="{}")
+  inspect!(set, content="@sorted_set.of([])")
   inspect!(set.debug_tree(), content="_")
 }

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -45,14 +45,14 @@ test "subset" {
 test "diff" {
   inspect!(
     @sorted_set.of([1, 2, 3]).diff(@sorted_set.of([4, 5, 1])),
-    content="{2, 3}",
+    content="@sorted_set.of([2, 3])",
   )
 }
 
 test "intersect" {
   inspect!(
     @sorted_set.of([3, 4, 5]).intersect(@sorted_set.of([4, 5, 6])),
-    content="{4, 5}",
+    content="@sorted_set.of([4, 5])",
   )
 }
 
@@ -102,14 +102,20 @@ test "to_array" {
 }
 
 test "to_string" {
-  inspect!(@sorted_set.of([1, 2, 3, 4, 5]), content="{1, 2, 3, 4, 5}")
-  inspect!((@sorted_set.of([]) : @sorted_set.T[Int]), content="{}")
+  inspect!(
+    @sorted_set.of([1, 2, 3, 4, 5]),
+    content="@sorted_set.of([1, 2, 3, 4, 5])",
+  )
+  inspect!(
+    (@sorted_set.of([]) : @sorted_set.T[Int]),
+    content="@sorted_set.of([])",
+  )
 }
 
 test "from_array" {
   inspect!(
     @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]),
-    content="{1, 2, 3, 4, 5, 6, 7, 8, 9}",
+    content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9])",
   )
 }
 
@@ -146,31 +152,34 @@ test "mix_everything" {
   let set1 = @sorted_set.of([1, 2, 3, 4, 5])
   let set2 = @sorted_set.of([4, 5, 6, 7, 8])
   set1.add(6)
-  inspect!(set1, content="{1, 2, 3, 4, 5, 6}")
+  inspect!(set1, content="@sorted_set.of([1, 2, 3, 4, 5, 6])")
   set1.remove(6)
-  inspect!(set1, content="{1, 2, 3, 4, 5}")
+  inspect!(set1, content="@sorted_set.of([1, 2, 3, 4, 5])")
   let set3 = set1.union(set2)
-  inspect!(set3, content="{1, 2, 3, 4, 5, 6, 7, 8}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8])")
   let set4 = set1.diff(set2)
-  inspect!(set4, content="{1, 2, 3}")
+  inspect!(set4, content="@sorted_set.of([1, 2, 3])")
   let set5 = set1.intersect(set2)
-  inspect!(set5, content="{4, 5}")
+  inspect!(set5, content="@sorted_set.of([4, 5])")
   inspect!(set1.subset(set3), content="true")
   set3.remove(3)
-  inspect!(set3, content="{1, 2, 4, 5, 6, 7, 8}")
+  inspect!(set3, content="@sorted_set.of([1, 2, 4, 5, 6, 7, 8])")
   inspect!(set3.size(), content="7")
   inspect!(set3.is_empty(), content="false")
   inspect!(set3.contains(1), content="true")
   inspect!(set3.contains(3), content="false")
   inspect!(set3.disjoint(set1), content="false")
   let set6 = set3.union(@sorted_set.of([]))
-  inspect!(set6, content="{1, 2, 4, 5, 6, 7, 8}")
+  inspect!(set6, content="@sorted_set.of([1, 2, 4, 5, 6, 7, 8])")
   let set7 = set3.union(@sorted_set.of([12, 13, 14, 33, 22]))
-  inspect!(set7, content="{1, 2, 4, 5, 6, 7, 8, 12, 13, 14, 22, 33}")
+  inspect!(
+    set7,
+    content="@sorted_set.of([1, 2, 4, 5, 6, 7, 8, 12, 13, 14, 22, 33])",
+  )
   for i = 1; i <= 5; i = i + 1 {
     set7.remove(i)
   }
-  inspect!(set7, content="{6, 7, 8, 12, 13, 14, 22, 33}")
+  inspect!(set7, content="@sorted_set.of([6, 7, 8, 12, 13, 14, 22, 33])")
   for i = 6; i <= 33; i = i + 1 {
     set7.remove(i)
   }
@@ -183,12 +192,12 @@ test "mix_everything" {
   set.remove(70)
   inspect!(
     set,
-    content="{8, 11, 13, 35, 38, 39, 40, 44, 49, 52, 54, 58, 67, 80, 84, 90, 93, 95, 97}",
+    content="@sorted_set.of([8, 11, 13, 35, 38, 39, 40, 44, 49, 52, 54, 58, 67, 80, 84, 90, 93, 95, 97])",
   )
   set.remove(52)
   inspect!(
     set,
-    content="{8, 11, 13, 35, 38, 39, 40, 44, 49, 54, 58, 67, 80, 84, 90, 93, 95, 97}",
+    content="@sorted_set.of([8, 11, 13, 35, 38, 39, 40, 44, 49, 54, 58, 67, 80, 84, 90, 93, 95, 97])",
   )
 }
 


### PR DESCRIPTION
This PR:

- add missing `Show` impl to `sorted_map` and `immut/sorted_map`
- unify the convention of `Show` impl for collections to `@pkg.of([ ... ])`
- fix some bugs in `Show` impls, for example, the `Show` impl for linked hashmap in `builtin` is missing a left brace
- improve various `Show` impls by simplifying the code and avoiding intermediate allocation