### PR TITLE
cleanup old extension method syntax in core

### DIFF
--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -86,7 +86,7 @@ impl Output for StringBuffer with output(self : StringBuffer, content : String) 
   self.0.push(content)
 }
 
-fn Output::output(self : Buffer, content : String) -> Unit {
+impl Output for Buffer with output(self, content) -> Unit {
   self.write_string(content)
 }
 


### PR DESCRIPTION
The `fn Trait::method(...)` syntax for implementing traits explicitly is deprecated in favor of the `impl Trait for Type with method(...)` syntax, and may be removed soon. This PR cleanup usage of the old syntax in core