### PR TITLE
port to new map pattern semantic

### DIFF
--- a/hashmap/pattern_test.mbt
+++ b/hashmap/pattern_test.mbt
@@ -16,7 +16,7 @@ test "pattern" {
   let m = @hashmap.of(
     [("name", "John Doe"), ("age", "43"), ("is_human", "true")],
   )
-  let { "name": name, "age": age, "is_human": is_human } = m
+  let { "name"? : name, "age"? : age, "is_human"? : is_human } = m
   inspect!(
     (name, age, is_human),
     content=

--- a/immut/hashmap/pattern_test.mbt
+++ b/immut/hashmap/pattern_test.mbt
@@ -16,7 +16,7 @@ test "pattern" {
   let m = @hashmap.of(
     [("name", "John Doe"), ("age", "43"), ("is_human", "true")],
   )
-  let { "name": name, "age": age, "is_human": is_human } = m
+  let { "name"? : name, "age"? : age, "is_human"? : is_human } = m
   inspect!(
     (name, age, is_human),
     content=


### PR DESCRIPTION
The semantic of map pattern will receive a breaking change recently, the semantic of  `{ "key": value }` is changed to match only cases where `"key"` exists, and `value` matches the actual content of `"key"`. The old semantic of matching no matter `"key"` exists or not becomes `"key"? : value`.

This PR adapt usage of map pattern in core to the new semantic.