### PR TITLE
make new/make function consistent

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -52,7 +52,20 @@ pub fn copy[T](self : Array[T]) -> Array[T] {
   }
 }
 
+/// @alert deprecated "Use Array::make_with_index instead"
 pub fn Array::new_with_index[T](length : Int, value : (Int) -> T) -> Array[T] {
+  if length <= 0 {
+    []
+  } else {
+    let array = Array::make(length, value(0))
+    for i = 1; i < length; i = i + 1 {
+      array[i] = value(i)
+    }
+    array
+  }
+}
+
+pub fn Array::make_with_index[T](length : Int, value : (Int) -> T) -> Array[T] {
   if length <= 0 {
     []
   } else {

--- a/array/array.mbt
+++ b/array/array.mbt
@@ -52,7 +52,7 @@ pub fn copy[T](self : Array[T]) -> Array[T] {
   }
 }
 
-/// @alert deprecated "Use Array::make_with_index instead"
+/// @alert deprecated "Use `Array::makei` instead"
 pub fn Array::new_with_index[T](length : Int, value : (Int) -> T) -> Array[T] {
   if length <= 0 {
     []
@@ -65,7 +65,7 @@ pub fn Array::new_with_index[T](length : Int, value : (Int) -> T) -> Array[T] {
   }
 }
 
-pub fn Array::make_with_index[T](length : Int, value : (Int) -> T) -> Array[T] {
+pub fn Array::makei[T](length : Int, value : (Int) -> T) -> Array[T] {
   if length <= 0 {
     []
   } else {

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -18,7 +18,7 @@ impl FixedArray {
   from_array[T](Array[T]) -> Self[T]
   is_sorted[T : Compare + Eq](Self[T]) -> Bool
   iter[T](Self[T]) -> Iter[T]
-  make_with_index[T](Int, (Int) -> T) -> Self[T]
+  makei[T](Int, (Int) -> T) -> Self[T]
   map[T, U](Self[T], (T) -> U) -> Self[U]
   mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
   new[T](Int, () -> T) -> Self[T]
@@ -40,7 +40,7 @@ impl Array {
   copy[T](Self[T]) -> Self[T]
   iter[T](Self[T]) -> Iter[T]
   join[T : Show](Self[T], String) -> String
-  make_with_index[T](Int, (Int) -> T) -> Self[T]
+  makei[T](Int, (Int) -> T) -> Self[T]
   new_with_index[T](Int, (Int) -> T) -> Self[T]
   push_iter[T](Self[T], Iter[T]) -> Unit
   shuffle[T](Self[T], ~rand : (Int) -> Int) -> Self[T]

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -18,6 +18,7 @@ impl FixedArray {
   from_array[T](Array[T]) -> Self[T]
   is_sorted[T : Compare + Eq](Self[T]) -> Bool
   iter[T](Self[T]) -> Iter[T]
+  make_with_index[T](Int, (Int) -> T) -> Self[T]
   map[T, U](Self[T], (T) -> U) -> Self[U]
   mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
   new[T](Int, () -> T) -> Self[T]
@@ -39,6 +40,7 @@ impl Array {
   copy[T](Self[T]) -> Self[T]
   iter[T](Self[T]) -> Iter[T]
   join[T : Show](Self[T], String) -> String
+  make_with_index[T](Int, (Int) -> T) -> Self[T]
   new_with_index[T](Int, (Int) -> T) -> Self[T]
   push_iter[T](Self[T], Iter[T]) -> Unit
   shuffle[T](Self[T], ~rand : (Int) -> Int) -> Self[T]

--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -493,17 +493,17 @@ test "copy" {
   inspect!(([] : Array[Int]).copy(), content="[]")
 }
 
-test "Array::new_with_index with positive length" {
-  let arr = Array::new_with_index(5, fn(i) { i * 2 })
+test "Array::make_with_index with positive length" {
+  let arr = Array::make_with_index(5, fn(i) { i * 2 })
   @test.eq!(arr, [0, 2, 4, 6, 8])
 }
 
-test "Array::new_with_index with zero length" {
-  let arr = Array::new_with_index(0, fn(i) { i * 2 })
+test "Array::make_with_index with zero length" {
+  let arr = Array::make_with_index(0, fn(i) { i * 2 })
   @test.eq!(arr, [])
 }
 
-test "Array::new_with_index with negative length" {
-  let arr = Array::new_with_index(-1, fn(i) { i * 2 })
+test "Array::make_with_index with negative length" {
+  let arr = Array::make_with_index(-1, fn(i) { i * 2 })
   @test.eq!(arr, [])
 }

--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -493,17 +493,17 @@ test "copy" {
   inspect!(([] : Array[Int]).copy(), content="[]")
 }
 
-test "Array::make_with_index with positive length" {
-  let arr = Array::make_with_index(5, fn(i) { i * 2 })
+test "Array::makei with positive length" {
+  let arr = Array::makei(5, fn(i) { i * 2 })
   @test.eq!(arr, [0, 2, 4, 6, 8])
 }
 
-test "Array::make_with_index with zero length" {
-  let arr = Array::make_with_index(0, fn(i) { i * 2 })
+test "Array::makei with zero length" {
+  let arr = Array::makei(0, fn(i) { i * 2 })
   @test.eq!(arr, [])
 }
 
-test "Array::make_with_index with negative length" {
-  let arr = Array::make_with_index(-1, fn(i) { i * 2 })
+test "Array::makei with negative length" {
+  let arr = Array::makei(-1, fn(i) { i * 2 })
   @test.eq!(arr, [])
 }

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -282,13 +282,13 @@ pub fn FixedArray::new[T](length : Int, value : () -> T) -> FixedArray[T] {
   }
 }
 
-test "new" {
-  let empty = new(0, fn() { { val: 3 } })
+test "makei" {
+  let empty = FixedArray::makei(0, fn(_i) { { val: 3 } })
   @test.eq!(empty.length(), 0)
-  let simple_arr = new(1, fn() { { val: 2 } })
+  let simple_arr = FixedArray::makei(1, fn(_i) { { val: 2 } })
   @test.eq!(simple_arr.length(), 1)
   @test.eq!(simple_arr[0].val, 2)
-  let arr = new(2, fn() { { val: 1 } })
+  let arr = FixedArray::makei(2, fn(_i) { { val: 1 } })
   @test.eq!(arr.length(), 2)
   @test.is_not!(arr[0], arr[1])
   @test.eq!(arr[0].val, 1)

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -269,6 +269,7 @@ test "mapi" {
 }
 
 /// Create a new array. Values are lazily built.
+/// @alert deprecated "Use FixedArray::make_with_index instead"
 pub fn FixedArray::new[T](length : Int, value : () -> T) -> FixedArray[T] {
   if length <= 0 {
     []
@@ -295,7 +296,16 @@ test "new" {
 }
 
 /// Create a new array. Values are built from indexes.
+/// @alert deprecated "Use FixedArray::make_with_index instead"
 pub fn FixedArray::new_with_index[T](
+  length : Int,
+  value : (Int) -> T
+) -> FixedArray[T] {
+  FixedArray::make_with_index(length, value)
+}
+
+/// Create a new array. Values are built from indexes.
+pub fn FixedArray::make_with_index[T](
   length : Int,
   value : (Int) -> T
 ) -> FixedArray[T] {
@@ -311,12 +321,12 @@ pub fn FixedArray::new_with_index[T](
 }
 
 test "fixedarray_new_with_index" {
-  let empty = FixedArray::new_with_index(0, fn { i => i })
+  let empty = FixedArray::make_with_index(0, fn { i => i })
   @test.eq!(empty.length(), 0)
-  let simple_arr = FixedArray::new_with_index(1, fn { i => i })
+  let simple_arr = FixedArray::make_with_index(1, fn { i => i })
   @test.eq!(simple_arr.length(), 1)
   @test.eq!(simple_arr[0], 0)
-  let arr = FixedArray::new_with_index(2, fn { i => i })
+  let arr = FixedArray::make_with_index(2, fn { i => i })
   @test.eq!(arr.length(), 2)
   @test.eq!(arr[0], 0)
   @test.eq!(arr[1], 1)
@@ -324,7 +334,7 @@ test "fixedarray_new_with_index" {
 
 /// Create a new array with given values.
 pub fn FixedArray::from_array[T](array : Array[T]) -> FixedArray[T] {
-  FixedArray::new_with_index(array.length(), fn(i) { array[i] })
+  FixedArray::make_with_index(array.length(), fn(i) { array[i] })
 }
 
 test "from_array" {

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -269,7 +269,7 @@ test "mapi" {
 }
 
 /// Create a new array. Values are lazily built.
-/// @alert deprecated "Use FixedArray::make_with_index instead"
+/// @alert deprecated "Use `FixedArray::makei` instead"
 pub fn FixedArray::new[T](length : Int, value : () -> T) -> FixedArray[T] {
   if length <= 0 {
     []
@@ -296,19 +296,16 @@ test "new" {
 }
 
 /// Create a new array. Values are built from indexes.
-/// @alert deprecated "Use FixedArray::make_with_index instead"
+/// @alert deprecated "Use `FixedArray::makei` instead"
 pub fn FixedArray::new_with_index[T](
   length : Int,
   value : (Int) -> T
 ) -> FixedArray[T] {
-  FixedArray::make_with_index(length, value)
+  FixedArray::makei(length, value)
 }
 
 /// Create a new array. Values are built from indexes.
-pub fn FixedArray::make_with_index[T](
-  length : Int,
-  value : (Int) -> T
-) -> FixedArray[T] {
+pub fn FixedArray::makei[T](length : Int, value : (Int) -> T) -> FixedArray[T] {
   if length <= 0 {
     []
   } else {
@@ -321,12 +318,12 @@ pub fn FixedArray::make_with_index[T](
 }
 
 test "fixedarray_new_with_index" {
-  let empty = FixedArray::make_with_index(0, fn { i => i })
+  let empty = FixedArray::makei(0, fn { i => i })
   @test.eq!(empty.length(), 0)
-  let simple_arr = FixedArray::make_with_index(1, fn { i => i })
+  let simple_arr = FixedArray::makei(1, fn { i => i })
   @test.eq!(simple_arr.length(), 1)
   @test.eq!(simple_arr[0], 0)
-  let arr = FixedArray::make_with_index(2, fn { i => i })
+  let arr = FixedArray::makei(2, fn { i => i })
   @test.eq!(arr.length(), 2)
   @test.eq!(arr[0], 0)
   @test.eq!(arr[1], 1)
@@ -334,7 +331,7 @@ test "fixedarray_new_with_index" {
 
 /// Create a new array with given values.
 pub fn FixedArray::from_array[T](array : Array[T]) -> FixedArray[T] {
-  FixedArray::make_with_index(array.length(), fn(i) { array[i] })
+  FixedArray::makei(array.length(), fn(i) { array[i] })
 }
 
 test "from_array" {

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Return a new empty array
-pub fn T::empty[A]() -> T[A] {
+pub fn T::new[A]() -> T[A] {
   { tree: Tree::empty(), size: 0, shift: 0 }
 }
 
@@ -149,7 +149,7 @@ pub fn push[A](self : T[A], value : A) -> T[A] {
 /// let v = @immut/array.of([1, 2, 3])
 /// ```
 pub fn T::from_array[A](arr : Array[A]) -> T[A] {
-  new_with_index(arr.length(), fn(i) { arr[i] })
+  make_with_index(arr.length(), fn(i) { arr[i] })
 }
 
 /// Iterate over the array.
@@ -283,7 +283,7 @@ fn new_by_leaves[A](len : Int, gen_leaf : (Int, Int) -> Array[A]) -> T[A] {
   }
 
   if len == 0 {
-    T::empty()
+    T::new()
   } else {
     let (cap, shift) = loop len, branching_factor, 1 {
       len, m_pow, depth =>
@@ -314,21 +314,21 @@ test "new_by_leaves" {
 }
 
 /// Create a persistent array with a given length and value.
-pub fn T::new[A](len : Int, value : A) -> T[A] {
+pub fn T::make[A](len : Int, value : A) -> T[A] {
   new_by_leaves(len, fn(_s, l) { Array::make(l, value) })
 }
 
 /// Create a persistent array with a given length and a function to generate values.
-pub fn T::new_with_index[A](len : Int, f : (Int) -> A) -> T[A] {
+pub fn T::make_with_index[A](len : Int, f : (Int) -> A) -> T[A] {
   new_by_leaves(len, fn(s, l) { Array::new_with_index(l, fn(i) { f(s + i) }) })
 }
 
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
-  new_with_index(arr.length(), fn(i) { arr[i] })
+  make_with_index(arr.length(), fn(i) { arr[i] })
 }
 
 test "mix" {
-  let mut v = T::empty()
+  let mut v = T::new()
   inspect!(v.tree.is_empty_tree(), content="true")
   for i = 0; i < 100; i = i + 1 {
     v = v.push(i)
@@ -353,7 +353,7 @@ test "mix" {
   inspect!(ct2, content="19800")
   inspect!(v.tree.is_empty_tree(), content="false")
   let large_const = branching_factor * branching_factor + 1
-  let mut v = T::empty()
+  let mut v = T::new()
   for i = 0; i < large_const; i = i + 1 {
     v = v.push(i)
   }

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -68,8 +68,7 @@ pub fn copy[A](self : T[A]) -> T[A] {
     match t {
       Leaf(l) => Leaf(l.copy())
       Empty => Empty
-      Node(node) =>
-        Node(Array::make_with_index(node.length(), fn(i) { copy(node[i]) }))
+      Node(node) => Node(Array::makei(node.length(), fn(i) { copy(node[i]) }))
     }
   }
 
@@ -149,7 +148,7 @@ pub fn push[A](self : T[A], value : A) -> T[A] {
 /// let v = @immut/array.of([1, 2, 3])
 /// ```
 pub fn T::from_array[A](arr : Array[A]) -> T[A] {
-  make_with_index(arr.length(), fn(i) { arr[i] })
+  makei(arr.length(), fn(i) { arr[i] })
 }
 
 /// Iterate over the array.
@@ -254,7 +253,7 @@ pub fn map[A, B](self : T[A], f : (A) -> B) -> T[B] {
     match t {
       Empty => Empty
       Leaf(l) => Leaf(l.map(f))
-      Node(n) => Node(Array::make_with_index(n.length(), fn(i) { go(n[i]) }))
+      Node(n) => Node(Array::makei(n.length(), fn(i) { go(n[i]) }))
     }
   }
 
@@ -278,7 +277,7 @@ fn new_by_leaves[A](len : Int, gen_leaf : (Int, Int) -> Array[A]) -> T[A] {
         tree(cap / branching_factor, len, i)
       }
 
-      Node(Array::make_with_index(child_count, child))
+      Node(Array::makei(child_count, child))
     }
   }
 
@@ -319,12 +318,12 @@ pub fn T::make[A](len : Int, value : A) -> T[A] {
 }
 
 /// Create a persistent array with a given length and a function to generate values.
-pub fn T::make_with_index[A](len : Int, f : (Int) -> A) -> T[A] {
-  new_by_leaves(len, fn(s, l) { Array::make_with_index(l, fn(i) { f(s + i) }) })
+pub fn T::makei[A](len : Int, f : (Int) -> A) -> T[A] {
+  new_by_leaves(len, fn(s, l) { Array::makei(l, fn(i) { f(s + i) }) })
 }
 
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
-  make_with_index(arr.length(), fn(i) { arr[i] })
+  makei(arr.length(), fn(i) { arr[i] })
 }
 
 test "mix" {

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -69,7 +69,7 @@ pub fn copy[A](self : T[A]) -> T[A] {
       Leaf(l) => Leaf(l.copy())
       Empty => Empty
       Node(node) =>
-        Node(Array::new_with_index(node.length(), fn(i) { copy(node[i]) }))
+        Node(Array::make_with_index(node.length(), fn(i) { copy(node[i]) }))
     }
   }
 
@@ -254,7 +254,7 @@ pub fn map[A, B](self : T[A], f : (A) -> B) -> T[B] {
     match t {
       Empty => Empty
       Leaf(l) => Leaf(l.map(f))
-      Node(n) => Node(Array::new_with_index(n.length(), fn(i) { go(n[i]) }))
+      Node(n) => Node(Array::make_with_index(n.length(), fn(i) { go(n[i]) }))
     }
   }
 
@@ -278,7 +278,7 @@ fn new_by_leaves[A](len : Int, gen_leaf : (Int, Int) -> Array[A]) -> T[A] {
         tree(cap / branching_factor, len, i)
       }
 
-      Node(Array::new_with_index(child_count, child))
+      Node(Array::make_with_index(child_count, child))
     }
   }
 
@@ -320,7 +320,7 @@ pub fn T::make[A](len : Int, value : A) -> T[A] {
 
 /// Create a persistent array with a given length and a function to generate values.
 pub fn T::make_with_index[A](len : Int, f : (Int) -> A) -> T[A] {
-  new_by_leaves(len, fn(s, l) { Array::new_with_index(l, fn(i) { f(s + i) }) })
+  new_by_leaves(len, fn(s, l) { Array::make_with_index(l, fn(i) { f(s + i) }) })
 }
 
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -8,16 +8,16 @@ impl T {
   copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
-  empty[A]() -> Self[A]
   fold_left[A](Self[A], (A, A) -> A, ~init : A) -> A
   fold_right[A](Self[A], (A, A) -> A, ~init : A) -> A
   from_array[A](Array[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
+  make[A](Int, A) -> Self[A]
+  make_with_index[A](Int, (Int) -> A) -> Self[A]
   map[A, B](Self[A], (A) -> B) -> Self[B]
-  new[A](Int, A) -> Self[A]
-  new_with_index[A](Int, (Int) -> A) -> Self[A]
+  new[A]() -> Self[A]
   of[A](FixedArray[A]) -> Self[A]
   op_equal[A : Eq](Self[A], Self[A]) -> Bool
   op_get[A](Self[A], Int) -> A

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -15,7 +15,7 @@ impl T {
   iter[A](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
   make[A](Int, A) -> Self[A]
-  make_with_index[A](Int, (Int) -> A) -> Self[A]
+  makei[A](Int, (Int) -> A) -> Self[A]
   map[A, B](Self[A], (A) -> B) -> Self[B]
   new[A]() -> Self[A]
   of[A](FixedArray[A]) -> Self[A]

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -205,8 +205,8 @@ test "new" {
 }
 
 test "new_with" {
-  let v = @array.make_with_index(5, fn(i) { i })
-  let v2 = @array.make_with_index(33, fn(i) { i * 10 })
+  let v = @array.makei(5, fn(i) { i })
+  let v2 = @array.makei(33, fn(i) { i * 10 })
   inspect!(v, content="@immut/array.of([0, 1, 2, 3, 4])")
   inspect!(
     v2,

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -14,7 +14,7 @@
 
 test "is_empty" {
   let v = @array.of([1, 2, 3, 4, 5])
-  let ve : @array.T[Int] = @array.empty()
+  let ve : @array.T[Int] = @array.new()
   inspect!(v.is_empty(), content="false")
   inspect!(ve.is_empty(), content="true")
 }
@@ -32,7 +32,7 @@ test "panic set with negative index" {
 }
 
 test "panic set with empty array" {
-  let v = @array.empty()
+  let v = @array.new()
   let v1 = v.set(0, 10) // This should trigger the panic in set function
   inspect!(v1, content="ImmutableVec::[]")
 }
@@ -51,7 +51,7 @@ test "set with valid index at end" {
 
 test "to_string" {
   let v = @array.of([1, 2, 3, 4, 5])
-  let ve : @array.T[Int] = @array.empty()
+  let ve : @array.T[Int] = @array.new()
   inspect!(v, content="@immut/array.of([1, 2, 3, 4, 5])")
   inspect!(ve, content="@immut/array.of([])")
 }
@@ -74,7 +74,7 @@ test "iter" {
 
 test "length" {
   let v = @array.of([1, 2, 3, 4, 5])
-  let ve : @array.T[Int] = @array.empty()
+  let ve : @array.T[Int] = @array.new()
   inspect!(v.length(), content="5")
   inspect!(ve.length(), content="0")
 }
@@ -85,7 +85,7 @@ test "copy" {
   inspect!(vc, content="@immut/array.of([1, 2, 3, 4, 5])")
   inspect!(v == vc, content="true")
   @test.is_false!(physical_equal(v, vc))
-  let v = @array.empty()
+  let v = @array.new()
   let vc : @array.T[Int] = v.copy()
   inspect!(vc, content="@immut/array.of([])")
   inspect!(v == vc, content="true")
@@ -110,7 +110,7 @@ test "set" {
 }
 
 test "push" {
-  let v = @array.empty().push(1).push(2).push(3)
+  let v = @array.new().push(1).push(2).push(3)
   inspect!(v, content="@immut/array.of([1, 2, 3])")
   inspect!(v.push(1), content="@immut/array.of([1, 2, 3, 1])")
   inspect!(v.push(2), content="@immut/array.of([1, 2, 3, 2])")
@@ -132,12 +132,12 @@ test "iter" {
   let mut s = 0
   v.each(fn(e) { s = s + e })
   inspect!(s, content="15")
-  let v : @array.T[Int] = @array.empty()
+  let v : @array.T[Int] = @array.new()
   v.each(fn(_e) { abort("never reach") })
 }
 
 test "iteri" {
-  let v : @array.T[Int] = @array.empty()
+  let v : @array.T[Int] = @array.new()
   v.eachi(fn(_i, _e) { abort("never reach") })
   let v = @array.of([1, 2, 3, 4, 5])
   let mut s = 0
@@ -154,9 +154,9 @@ test "op_equal" {
   let v2 = @array.of([1, 2, 3, 4, 5])
   let v3 = @array.of([1, 2, 3, 4, 6])
   let v4 = @array.of([1, 2, 3, 4])
-  let v5 = @array.new(5, 1)
+  let v5 = @array.make(5, 1)
   let v6 = @array.of([1, 1, 1, 1, 1])
-  inspect!(v0 == @array.empty(), content="true")
+  inspect!(v0 == @array.new(), content="true")
   inspect!(v1 == v2, content="true")
   inspect!(v1 == v3, content="false")
   inspect!(v1 == v4, content="false")
@@ -164,14 +164,14 @@ test "op_equal" {
 }
 
 test "fold_left" {
-  let e = @array.empty()
+  let e = @array.new()
   let v = @array.of([1, 2, 3, 4, 5])
   inspect!(e.fold_left(fn(a, b) { a + b }, init=0), content="0")
   inspect!(v.fold_left(fn(a, b) { a + b }, init=0), content="15")
 }
 
 test "fold_right" {
-  let e = @array.empty()
+  let e = @array.new()
   inspect!(e.fold_right(fn(a, b) { a + b }, init=0), content="0")
   let v = @array.of([1, 2, 3, 4, 5])
   inspect!(e.fold_left(fn(a, b) { a + b }, init=0), content="0")
@@ -191,12 +191,12 @@ test "map" {
     v.map(fn(e) { e % 2 == 0 }),
     content="@immut/array.of([false, true, false, true, false])",
   )
-  inspect!(@array.empty().map(fn(e : Int) { e }), content="@immut/array.of([])")
+  inspect!(@array.new().map(fn(e : Int) { e }), content="@immut/array.of([])")
 }
 
 test "new" {
-  let v = @array.new(5, 1)
-  let v2 = @array.new(33, 10)
+  let v = @array.make(5, 1)
+  let v2 = @array.make(33, 10)
   inspect!(v, content="@immut/array.of([1, 1, 1, 1, 1])")
   inspect!(
     v2,
@@ -205,8 +205,8 @@ test "new" {
 }
 
 test "new_with" {
-  let v = @array.new_with_index(5, fn(i) { i })
-  let v2 = @array.new_with_index(33, fn(i) { i * 10 })
+  let v = @array.make_with_index(5, fn(i) { i })
+  let v2 = @array.make_with_index(33, fn(i) { i * 10 })
   inspect!(v, content="@immut/array.of([0, 1, 2, 3, 4])")
   inspect!(
     v2,


### PR DESCRIPTION
close #582

# Changes
- core/array
    - mark `Array::new_with_index` `FixedArray::new(Int, ()->T)` `FixedArray::new_with_index` deprecated
    - add `FixedArray::makei` to align with other collections
- core/immut/array
    - remove `empty()` `new[A](Int,A)` `new_with_index[A](Int, (Int)->A)`
    - add `make[A](Int,A)` `makei[A](Int, (Int)->A)` `new[A]()`