### PR TITLE
get rid of array spread in builtin

### DIFF
--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -14,31 +14,14 @@
 
 test "Map keys iter" {
   let map = { "a": 1, "b": 2, "c": 3 }
-  let v = {
-      [..map.keys()]
-    }
+  let v = map.keys()
   inspect!(
     v,
     content=
       #|["a", "b", "c"]
     ,
   )
-  inspect!(
-    {
-      [..map.values()]
-    },
-    content="[1, 2, 3]",
-  )
-  inspect!(
-    {
-      [..({  } : Map[String, Int]).keys()]
-    },
-    content="[]",
-  )
-  inspect!(
-    {
-      [..({  } : Map[String, Int]).values()]
-    },
-    content="[]",
-  )
+  inspect!(map.values(), content="[1, 2, 3]")
+  inspect!(({  } : Map[String, Int]).keys(), content="[]")
+  inspect!(({  } : Map[String, Int]).values(), content="[]")
 }


### PR DESCRIPTION
Desugaring of array spread `[ a, ..xs, b ]` requires `iter` method and `push_iter` method of `Array`, which are in the `array` package, not `builtin`. So using array spread in `builtin` is not stable w.r.t. location of API & desugaring of array spread.

This PR removes unnecessary usage of array spread in builtin package.