### PR TITLE
refactor: make assert_eq private

### DIFF
--- a/builtin/assert.mbt
+++ b/builtin/assert.mbt
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub fn assert_eq[T : Eq + Show](
-  a : T,
-  b : T,
-  ~loc : SourceLoc = _
-) -> Unit!String {
+fn assert_eq[T : Eq + Show](a : T, b : T, ~loc : SourceLoc = _) -> Unit!String {
   if a != b {
     raise "FAILED: \(loc) `\(a) == \(b)`"
   }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -3,8 +3,6 @@ package moonbitlang/core/builtin
 // Values
 fn abort[T](String) -> T
 
-fn assert_eq[T : Eq + Show](T, T, ~loc : SourceLoc = _) -> Unit!String
-
 fn ignore[T](T) -> Unit
 
 fn inspect(Show, ~content : String = .., ~loc : SourceLoc = _, ~args_loc : ArgsLoc = _) -> Unit!String


### PR DESCRIPTION
Or else it will show up in auto completion in IDE, which shouldn't be the case?