### PR TITLE
Remove impl Hash for String with hash which is the same as the default

### DIFF
--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -129,11 +129,11 @@ fn endian32(input : Bytes, cur : Int) -> Int {
   )
 }
 
-pub impl Hash for String with hash(self) {
-  let hasher = Hasher::new()
-  hasher.combine(self)
-  hasher.finalize()
-}
+// pub impl Hash for String with hash(self) {
+//   let hasher = Hasher::new()
+//   hasher.combine(self)
+//   hasher.finalize()
+// }
 
 pub impl Hash for String with hash_combine(self, hasher) {
   hasher.combine_string(self)


### PR DESCRIPTION
Currently, such types have different behavior with the default:
1. Bool
2. Byte
3. Int
4. Char
5. Double
6. Unit
