### PR TITLE
add [each_err] & [fold_err] API to [Iter]

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -148,12 +148,14 @@ impl Iter {
   drop[T](Self[T], Int) -> Self[T]
   drop_while[T](Self[T], (T) -> Bool) -> Self[T]
   each[T](Self[T], (T) -> Unit) -> Unit
+  each_err[T, Err](Self[T], (T) -> Unit!Err) -> Unit!Err
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit
   empty[T]() -> Self[T]
   filter[T](Self[T], (T) -> Bool) -> Self[T]
   find_first[T](Self[T], (T) -> Bool) -> T?
   flat_map[T, R](Self[T], (T) -> Self[R]) -> Self[R]
   fold[T, B](Self[T], ~init : B, (B, T) -> B) -> B
+  fold_err[T, B, Err](Self[T], ~init : B, (B, T) -> B!Err) -> B!Err
   iter[T](Self[T]) -> Self[T]
   map[T, R](Self[T], (T) -> R) -> Self[R]
   new[T](((T) -> IterResult) -> IterResult) -> Self[T]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -75,6 +75,40 @@ pub fn eachi[T](self : Iter[T], f : (Int, T) -> Unit) -> Unit {
   |> ignore
 }
 
+/// Iterates over each element in the iterator, applying the function `f` to each element.
+/// If `f` raises any error, `each_err` will terminate immediately and raise the same error.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterator.
+/// - `Err`: The type of the error that `f` may raise.
+///
+/// # Arguments
+///
+/// - `self`: The iterator to consume.
+/// - `f`: A function that takes an element of type `T` and returns `Unit`.
+///    This function is applied to each element of the iterator and may raise error of type `Err`.
+pub fn each_err[T, Err](self : Iter[T], f : (T) -> Unit!Err) -> Unit!Err {
+  let mut err = None
+  fn action(elem) {
+    try {
+      f!(elem)
+      IterContinue
+    } catch {
+      error => {
+        err = Some(error)
+        IterEnd
+      }
+    }
+  }
+
+  let _ = (self.0)(action)
+  match err {
+    None => ()
+    Some(err) => raise err
+  }
+}
+
 /// Folds the elements of the iterator using the given function, starting with the given initial value.
 ///
 /// # Type Parameters
@@ -101,6 +135,51 @@ pub fn fold[T, B](self : Iter[T], ~init : B, f : (B, T) -> B) -> B {
     },
   )
   acc
+}
+
+/// Folds the elements of the iterator using the given function, starting with the given initial value.
+/// If the function `f` raises any error, `fold_err` will terminate immediately and raise the same error.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterator.
+/// - `B`: The type of the accumulator value.
+/// - `Err`: The type of error that `f` may raise.
+///
+/// # Arguments
+///
+/// - `self`: The iterator to consume.
+/// - `f`: A function that takes an accumulator of type `B` and an element of type `T`, and returns a new accumulator value.
+/// - `init`: The initial value for the fold operation.
+///
+/// # Returns
+///
+/// If `f` raises any error, `fold_err` raises the same error.
+/// Otherwise, it returns the final accumulator value after folding all elements of the iterator.
+pub fn fold_err[T, B, Err](
+  self : Iter[T],
+  ~init : B,
+  f : (B, T) -> B!Err
+) -> B!Err {
+  let mut err = None
+  let mut acc = init
+  fn action(elem) {
+    try {
+      acc = f!(acc, elem)
+      IterContinue
+    } catch {
+      error => {
+        err = Some(error)
+        IterEnd
+      }
+    }
+  }
+
+  let _ = (self.0)(action)
+  match err {
+    None => acc
+    Some(err) => raise err
+  }
 }
 
 /// Counts the number of elements in the iterator.

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -323,3 +323,61 @@ fn test_from_array[T](arr : Array[T]) -> Iter[T] {
     },
   )
 }
+
+test "each_err.no_error" {
+  let mut result = 0
+  let iter = test_from_array([1, 2, 3, 4, 5])
+  iter.each_err!(
+    fn(x) {
+      if x > 6 {
+        raise "Oops!"
+      }
+      result += x
+    },
+  )
+  inspect!(result, content="15")
+}
+
+test "each_err.error" {
+  let iter = test_from_array([1, 2, 3, 42, 5])
+  try {
+    iter.each_err!(fn(x) { if x == 42 { raise "answer" } })
+  } catch {
+    _ => ()
+  } else {
+    _ => raise "test failed"
+  }
+}
+
+test "fold_err.no_error" {
+  let iter = test_from_array([1, 2, 3, 4, 5])
+  let result = iter.fold_err!(
+    init=0,
+    fn(acc, x) {
+      if x > 6 {
+        raise "Oops!"
+      }
+      acc + x
+    },
+  )
+  inspect!(result, content="15")
+}
+
+test "fold_err.error" {
+  let iter = test_from_array([1, 2, 3, 42, 5])
+  try {
+    iter.fold_err!(
+      init=0,
+      fn(acc, x) {
+        if x == 42 {
+          raise "answer"
+        }
+        acc + x
+      },
+    )
+  } catch {
+    _ => ()
+  } else {
+    _ => raise "test failed"
+  }
+}


### PR DESCRIPTION
Add two APIs, `each_err` and `fold_err` to the `Iter` type. These two APIs are similar to `each` and `fold`, except that the callback may raise an error. If the callback raises any error, the iteration stops immediately and raises the same error.