### PR TITLE
add [Hash] implementation for some builtin types

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -497,13 +497,43 @@ pub trait Show {
 }
 
 // Extension Methods
+impl Hash for Unit
+
+impl Hash for Bool
+
 impl Hash for Byte
 
 impl Hash for Int
 
+impl Hash for Int64
+
+impl Hash for UInt
+
+impl Hash for UInt64
+
+impl Hash for Double
+
 impl Hash for String
 
+impl Hash for Option
+
+impl Hash for Result
+
+impl Hash for Bytes
+
 impl Hash for Hash
+
+impl Hash for Tuple
+
+impl Hash for Tuple
+
+impl Hash for Tuple
+
+impl Hash for Tuple
+
+impl Hash for Tuple
+
+impl Hash for Tuple
 
 impl Show for Unit
 

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -139,6 +139,10 @@ pub impl Hash for String with hash_combine(self, hasher) {
   hasher.combine_string(self)
 }
 
+pub impl Hash for Bytes with hash_combine(self, hasher) {
+  hasher.combine_bytes(self)
+}
+
 // https://github.com/skeeto/hash-prospector
 pub impl Hash for Int with hash(self) {
   let mut x = self.lxor(self.lsr(17))
@@ -153,4 +157,45 @@ pub impl Hash for Int with hash(self) {
 
 pub impl Hash for Int with hash_combine(self, hasher) {
   hasher.combine_int(self)
+}
+
+pub impl Hash for UInt with hash_combine(self, hasher) {
+  hasher.combine_uint(self)
+}
+
+pub impl Hash for Int64 with hash_combine(self, hasher) {
+  hasher.combine_int64(self)
+}
+
+pub impl Hash for UInt64 with hash_combine(self, hasher) {
+  hasher.combine_uint64(self)
+}
+
+pub impl Hash for Double with hash_combine(self, hasher) {
+  hasher.combine_double(self)
+}
+
+pub impl Hash for Bool with hash_combine(self, hasher) {
+  hasher.combine_bool(self)
+}
+
+pub impl Hash for Unit with hash_combine(_self, hasher) {
+  hasher.combine_unit()
+}
+
+pub impl[X : Hash] Hash for X? with hash_combine(self, hasher) {
+  match self {
+    None => hasher.combine_int(0)
+    Some(x) => hasher..combine_int(1).combine(x)
+  }
+}
+
+pub impl[T : Hash, E : Hash] Hash for Result[T, E] with hash_combine(
+  self,
+  hasher
+) {
+  match self {
+    Ok(x) => hasher..combine_int(0).combine(x)
+    Err(x) => hasher..combine_int(1).combine(x)
+  }
 }

--- a/builtin/tuple_hash.mbt
+++ b/builtin/tuple_hash.mbt
@@ -1,0 +1,72 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub impl[A : Hash, B : Hash] Hash for (A, B) with hash_combine(self, hasher) {
+  let (a, b) = self
+  hasher..combine(a).combine(b)
+}
+
+pub impl[A : Hash, B : Hash, C : Hash] Hash for (A, B, C) with hash_combine(
+  self,
+  hasher
+) {
+  let (a, b, c) = self
+  hasher..combine(a)..combine(b).combine(c)
+}
+
+pub impl[A : Hash, B : Hash, C : Hash, D : Hash] Hash for (A, B, C, D) with hash_combine(
+  self,
+  hasher
+) {
+  let (a, b, c, d) = self
+  hasher..combine(a)..combine(b)..combine(c).combine(d)
+}
+
+pub impl[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash] Hash for (
+  A,
+  B,
+  C,
+  D,
+  E,
+) with hash_combine(self, hasher) {
+  let (a, b, c, d, e) = self
+  hasher..combine(a)..combine(b)..combine(c)..combine(d).combine(e)
+}
+
+pub impl[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash] Hash for (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+) with hash_combine(self, hasher) {
+  let (a, b, c, d, e, f) = self
+  hasher..combine(a)..combine(b)..combine(c)..combine(d)..combine(e).combine(f)
+}
+
+pub impl[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] Hash for (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+) with hash_combine(self, hasher) {
+  let (a, b, c, d, e, f, g) = self
+  hasher..combine(a)..combine(b)..combine(c)..combine(d)..combine(e)..combine(f).combine(
+    g,
+  )
+}


### PR DESCRIPTION
add `Hash` implementation to builtin numeric types, `Bytes`, `Bool`, `Unit`, `Option`, `Result` and tuples