### PR TITLE
add method [String::escape] that escapes a string using MoonBit syntax

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -394,6 +394,7 @@ impl Double {
   until(Double, Double, ~step : Double = ..) -> Iter[Double]
 }
 impl String {
+  escape(String) -> String
   get(String, Int) -> Char
   length(String) -> Int
   make(Int, Char) -> String

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -183,16 +183,10 @@ pub fn inspect(
 ) -> Unit!String {
   let actual = obj.to_string()
   if actual != content {
-    fn repr(s : String) -> String {
-      let buf = Buffer::new()
-      Show::output(s, buf)
-      buf.to_string()
-    }
-
-    let loc = repr(loc.to_string())
-    let args_loc = repr(args_loc.to_json())
-    let expect = repr(content)
-    let actual = repr(obj.to_string())
+    let loc = loc.to_string().escape()
+    let args_loc = args_loc.to_json().escape()
+    let expect = content.escape()
+    let actual = obj.to_string().escape()
     raise "@EXPECT_FAILED {\"loc\": \(loc), \"args_loc\": \(args_loc), \"expect\": \(expect), \"actual\": \(actual)}"
   }
 }

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -102,6 +102,14 @@ pub impl Show for String with output(self, logger) {
 
 pub impl Show for String with to_string(self) { self }
 
+/// Returns a valid MoonBit string literal representation of a string,
+/// add quotes and escape special characters.
+pub fn escape(self : String) -> String {
+  let buf = Buffer::new()
+  Show::output(self, buf)
+  buf.to_string()
+}
+
 pub impl[X : Show] Show for X? with output(self, logger) {
   match self {
     None => logger.write_string("None")

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -1,0 +1,40 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "String::escape" {
+  inspect!(
+    "abc,def".escape(),
+    content=
+      #|"abc,def"
+    ,
+  )
+  inspect!(
+    "\n\t\\".escape(),
+    content=
+      #|"\n\t\\"
+    ,
+  )
+  inspect!(
+    "\"'".escape(),
+    content=
+      #|"\"'"
+    ,
+  )
+  inspect!(
+    "\x00\x01\x20\x21".escape(),
+    content=
+      #|"\x00\x01 !"
+    ,
+  )
+}


### PR DESCRIPTION
Currently, `Show::to_string` instance for `String` returns the string itself. Escaping functionality of `String` is implemented in `Show::output`, but `Show::output` is not intended for direct use. This PR adds a `String::escape` method, which returns a valid MoonBit syntax representation of a string.

While testing the API I fix a small bug in `Show::output` implementation for `String`. It fail to escape some non-printable characters.