### PR TITLE
[POC, DON'T MERGE] use error to implement early return of `Iter`

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -16,11 +16,7 @@ pub fn iter[T](self : Array[T]) -> Iter[T] {
   Iter::new(
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
-        if yield(self[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(self[i])
       }
     },
   )

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -945,11 +945,7 @@ pub fn iter[T](self : FixedArray[T]) -> Iter[T] {
   Iter::new(
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
-        if yield(self[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(self[i])
       }
     },
   )

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -82,15 +82,9 @@ pub fn op_as_view[T](
 }
 
 pub fn iter[A](self : ArrayView[A]) -> Iter[A] {
-  Iter::new(
-    fn(yield) {
-      for i = 0, len = self.length(); i < len; i = i + 1 {
-        if yield(self[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
-      }
-    },
-  )
+  fn!(yield) {
+    for i = 0, len = self.length(); i < len; i = i + 1 {
+      yield!(self[i])
+    }
+  }
 }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -186,25 +186,17 @@ impl Iter {
   fold[T, B](Self[T], ~init : B, (B, T) -> B) -> B
   iter[T](Self[T]) -> Self[T]
   map[T, R](Self[T], (T) -> R) -> Self[R]
-  new[T](((T) -> IterResult) -> IterResult) -> Self[T]
+  new[T](((T) -> Unit!Error) -> Unit!Error) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
   prepend[T](Self[T], T) -> Self[T]
   repeat[T](T) -> Self[T]
-  run[T](Self[T], (T) -> IterResult) -> IterResult
+  run[T](Self[T], (T) -> Unit!Error) -> Unit!Error
   singleton[T](T) -> Self[T]
   take[T](Self[T], Int) -> Self[T]
   take_while[T](Self[T], (T) -> Bool) -> Self[T]
   tap[T](Self[T], (T) -> Unit) -> Self[T]
   to_array[T](Self[T]) -> Array[T]
   to_string[T : Show](Self[T]) -> String
-}
-
-pub enum IterResult {
-  IterEnd
-  IterContinue
-}
-impl IterResult {
-  op_equal(Self, Self) -> Bool
 }
 
 pub type Js_string

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -13,17 +13,14 @@
 // limitations under the License.
 
 // Types
-type Iter[T] ((T) -> IterResult) -> IterResult
+type Iter[T] ((T) -> Unit!Error) -> Unit!Error
 
 //TODO: Add intrinsic for Iter::run
-pub fn run[T](self : Iter[T], f : (T) -> IterResult) -> IterResult {
-  (self.0)(f)
+pub fn run[T](self : Iter[T], f : (T) -> Unit!Error) -> Unit!Error {
+  (self.0)!(f)
 }
 
-pub enum IterResult {
-  IterEnd // false
-  IterContinue // true
-} derive(Eq)
+priv type! IterBreak Unit
 
 pub impl[T : Show] Show for Iter[T] with output(self, logger) {
   Show::output(self.to_array(), logger)
@@ -48,21 +45,33 @@ pub fn to_string[T : Show](self : Iter[T]) -> String {
 /// TODO: change the intrinsic to match the function name
 /// @intrinsic %iter.iter
 pub fn each[T](self : Iter[T], f : (T) -> Unit) -> Unit {
-  self.run(
-    fn(yield) {
-      f(yield)
-      IterContinue
-    },
-  )
-  |> ignore
+  try {
+    self.run!(fn { x => f(x) })
+  } catch {
+    _ => abort("unhandled error in iter")
+  }
 }
 
 pub fn any[T](self : Iter[T], f : (T) -> Bool) -> Bool {
-  self.run(fn(k) { if f(k) { IterEnd } else { IterContinue } }) != IterContinue
+  try {
+    self.run!(fn(x) { if f(x) { raise IterBreak(()) } })
+  } catch {
+    IterBreak(_) => true
+    _ => abort("unhandled error in iter")
+  } else {
+    _ => false
+  }
 }
 
 pub fn all[T](self : Iter[T], f : (T) -> Bool) -> Bool {
-  self.run(fn(k) { if not(f(k)) { IterEnd } else { IterContinue } }) == IterContinue
+  try {
+    self.run!(fn(x) { if not(f(x)) { raise IterBreak(()) } })
+  } catch {
+    IterBreak(_) => false
+    _ => abort("unhandled error in iter")
+  } else {
+    _ => true
+  }
 }
 
 /// Iterates over each element in the iterator, applying the function `f` to each element with index.
@@ -78,14 +87,16 @@ pub fn all[T](self : Iter[T], f : (T) -> Bool) -> Bool {
 /// TODO: Add intrinsic
 pub fn eachi[T](self : Iter[T], f : (Int, T) -> Unit) -> Unit {
   let mut i = 0
-  self.run(
-    fn(a) {
-      f(i, a)
-      i = i + 1
-      IterContinue
-    },
-  )
-  |> ignore
+  try {
+    self.run!(
+      fn(a) {
+        f(i, a)
+        i = i + 1
+      },
+    )
+  } catch {
+    _ => abort("unhandled error in iter")
+  }
 }
 
 /// Folds the elements of the iterator using the given function, starting with the given initial value.
@@ -107,13 +118,13 @@ pub fn eachi[T](self : Iter[T], f : (Int, T) -> Unit) -> Unit {
 /// @intrinsic %iter.reduce
 pub fn fold[T, B](self : Iter[T], ~init : B, f : (B, T) -> B) -> B {
   let mut acc = init
-  let _ = self.run(
-    fn(yield) {
-      acc = f(acc, yield)
-      IterContinue
-    },
-  )
-  acc
+  try {
+    self.run!(fn { x => acc = f(acc, x) })
+  } catch {
+    _ => abort("unhandled error in iter")
+  } else {
+    _ => acc
+  }
 }
 
 /// Counts the number of elements in the iterator.
@@ -136,7 +147,7 @@ pub fn count[T](self : Iter[T]) -> Int {
 // Producers
 
 /// Do not use this method, it is for internal use only.
-pub fn Iter::new[T](f : ((T) -> IterResult) -> IterResult) -> Iter[T] {
+pub fn Iter::new[T](f : ((T) -> Unit!Error) -> Unit!Error) -> Iter[T] {
   Iter(f)
 }
 
@@ -150,7 +161,7 @@ pub fn Iter::new[T](f : ((T) -> IterResult) -> IterResult) -> Iter[T] {
 ///
 /// Returns an empty iterator of type `Iter[T]`.
 pub fn Iter::empty[T]() -> Iter[T] {
-  fn { _ => IterContinue }
+  fn! { _ => () }
 }
 
 /// Creates an iterator that contains a single element.
@@ -167,7 +178,7 @@ pub fn Iter::empty[T]() -> Iter[T] {
 ///
 /// Returns an iterator of type `Iter[T]` that contains the single element `a`.
 pub fn Iter::singleton[T](a : T) -> Iter[T] {
-  fn { yield => yield(a) }
+  fn! { yield => yield!(a) }
 }
 
 /// Creates an iterator that repeats the given element indefinitely.
@@ -185,10 +196,9 @@ pub fn Iter::singleton[T](a : T) -> Iter[T] {
 /// Returns an iterator of type `Iter[T]` that repeats the element `a` indefinitely.
 /// @intrinsic %iter.repeat
 pub fn Iter::repeat[T](a : T) -> Iter[T] {
-  fn(yield) {
-    loop yield(a) {
-      IterContinue => continue yield(a)
-      IterEnd => IterEnd
+  fn!(yield) {
+    for {
+      yield!(a)
     }
   }
 }
@@ -210,24 +220,16 @@ pub fn until(self : Int, end : Int, ~step : Int = 1) -> Iter[Int] {
     return Iter::empty()
   }
   if step < 0 {
-    return fn(yield) {
+    return fn!(yield) {
       for i = self; i > end; i = i + step {
-        if yield(i) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(i)
       }
     }
   }
   // step > 0
-  fn(yield) {
+  fn!(yield) {
     for i = self; i < end; i = i + step {
-      if yield(i) == IterEnd {
-        break IterEnd
-      }
-    } else {
-      IterContinue
+      yield!(i)
     }
   }
 }
@@ -249,23 +251,15 @@ pub fn until(self : Int64, end : Int64, ~step : Int64 = 1L) -> Iter[Int64] {
     return Iter::empty()
   }
   if step < 0L {
-    return fn(yield) {
+    return fn!(yield) {
       for i = self; i > end; i = i + step {
-        if yield(i) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(i)
       }
     }
   }
-  fn(yield) {
+  fn!(yield) {
     for i = self; i < end; i = i + step {
-      if yield(i) == IterEnd {
-        break IterEnd
-      }
-    } else {
-      IterContinue
+      yield!(i)
     }
   }
 }
@@ -287,23 +281,15 @@ pub fn until(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] 
     return Iter::empty()
   }
   if step < 0.0 {
-    return fn(yield) {
+    return fn!(yield) {
       for i = self; i > end; i = i + step {
-        if yield(i) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(i)
       }
     }
   }
-  fn(yield) {
+  fn!(yield) {
     for i = self; i < end; i = i + step {
-      if yield(i) == IterEnd {
-        break IterEnd
-      }
-    } else {
-      IterContinue
+      yield!(i)
     }
   }
 }
@@ -326,7 +312,7 @@ pub fn until(self : Double, end : Double, ~step : Double = 1.0) -> Iter[Double] 
 /// A new iterator that only contains the elements for which the predicate function returns `IterContinue`.
 /// @intrinsic %iter.filter
 pub fn filter[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
-  fn(yield) { self.run(fn { a => if f(a) { yield(a) } else { IterContinue } }) }
+  fn!(yield) { self.run!(fn { a => if f(a) { yield!(a) } }) }
 }
 
 /// Transforms the elements of the iterator using a mapping function.
@@ -346,7 +332,7 @@ pub fn filter[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
 /// A new iterator that contains the transformed elements.
 /// @intrinsic %iter.map
 pub fn map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
-  fn { yield => self.run(fn { a => yield(f(a)) }) }
+  fn! { yield => self.run!(fn { a => yield!(f(a)) }) }
 }
 
 /// Transforms each element of the iterator into an iterator and flattens the resulting iterators into a single iterator.
@@ -366,7 +352,7 @@ pub fn map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
 /// A new iterator that contains the flattened elements.
 /// @intrinsic %iter.flat_map
 pub fn flat_map[T, R](self : Iter[T], f : (T) -> Iter[R]) -> Iter[R] {
-  fn { yield => self.run(fn { x => f(x).run(yield) }) }
+  fn! { yield => self.run!(fn { x => f(x).run!(yield) }) }
 }
 
 /// Applies a function to each element of the iterator without modifying the iterator.
@@ -390,6 +376,8 @@ pub fn tap[T](self : Iter[T], f : (T) -> Unit) -> Iter[T] {
   self
 }
 
+priv type! IterTake Unit
+
 /// Takes the first `n` elements from the iterator.
 ///
 /// # Type Parameters
@@ -406,27 +394,21 @@ pub fn tap[T](self : Iter[T], f : (T) -> Unit) -> Iter[T] {
 /// A new iterator that contains the first `n` elements.
 /// @intrinsic %iter.take
 pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
-  fn(yield) {
+  fn!(yield) {
     let mut i = 0
-    let iter_result = self.run(
-      fn {
-        a =>
-          if i < n && yield(a) == IterContinue {
-            i = i + 1
-            IterContinue
-          } else {
-            IterEnd
+    try {
+      self.run!(
+        fn(a) {
+          if i >= n {
+            raise IterTake(())
           }
-      },
-    )
-    // The `take` operator returns `IterEnd` only when any call to `yield(a)` returns `IterEnd`.
-    // Otherwise, it returns `IterContinue`, including when `i` reaches the count `n`.
-    if iter_result == IterContinue {
-      iter_result
-    } else if i == n {
-      IterContinue
-    } else {
-      IterEnd
+          i = i + 1
+          yield!(a)
+        },
+      )
+    } catch {
+      IterTake(_) => ()
+      err => raise err
     }
   }
 }
@@ -446,25 +428,13 @@ pub fn take[T](self : Iter[T], n : Int) -> Iter[T] {
 ///
 /// A new iterator that contains the elements as long as the predicate function returns `true`.
 pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
-  fn(yield) {
-    // `r` represents the overall return value. It is set to `IterEnd` only if `yield(a)` returns `IterEnd`.
-    let mut r : IterResult = IterContinue
-    self.run(
-      fn(a) {
-        if f(a) {
-          if yield(a) == IterContinue {
-            IterContinue
-          } else {
-            r = IterEnd
-            IterEnd
-          }
-        } else {
-          IterEnd
-        }
-      },
-    )
-    |> ignore
-    r
+  fn!(yield) {
+    try {
+      self.run!(fn(a) { if f(a) { yield!(a) } else { raise IterTake(()) } })
+    } catch {
+      IterTake(_) => ()
+      err => raise err
+    }
   }
 }
 
@@ -483,18 +453,9 @@ pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
 ///
 /// A new iterator that starts after skipping the first `n` elements.
 pub fn drop[T](self : Iter[T], n : Int) -> Iter[T] {
-  fn(yield) {
+  fn!(yield) {
     let mut i = 0
-    self.run(
-      fn(a) {
-        if i < n {
-          i = i + 1
-          IterContinue
-        } else {
-          yield(a)
-        }
-      },
-    )
+    self.run!(fn(a) { if i < n { i = i + 1 } else { yield!(a) } })
   }
 }
 
@@ -513,15 +474,13 @@ pub fn drop[T](self : Iter[T], n : Int) -> Iter[T] {
 ///
 /// A new iterator that starts after skipping the elements as long as the predicate function returns `true`.
 pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
-  fn(yield) {
+  fn!(yield) {
     let mut dropping = true
-    self.run(
+    self.run!(
       fn(a) {
-        if dropping && f(a) {
-          IterContinue
-        } else {
+        if not(dropping && f(a)) {
           dropping = false
-          yield(a)
+          yield!(a)
         }
       },
     )
@@ -544,16 +503,19 @@ pub fn drop_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
 /// An `Option` that contains the first element that satisfies the predicate function, or `None` if no such element is found.
 pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> T? {
   let mut result : T? = None
-  let _ = self.run(
-    fn(a) {
-      if f(a) {
-        result = Some(a)
-        IterEnd
-      } else {
-        IterContinue
-      }
-    },
-  )
+  try {
+    self.run!(
+      fn(a) {
+        if f(a) {
+          result = Some(a)
+          raise IterBreak(())
+        }
+      },
+    )
+  } catch {
+    IterBreak(_) => ()
+    _ => abort("unhandled error in iter")
+  }
   result
 }
 
@@ -572,7 +534,10 @@ pub fn find_first[T](self : Iter[T], f : (T) -> Bool) -> T? {
 ///
 /// Returns a new iterator with the element `a` prepended to the original iterator.
 pub fn prepend[T](self : Iter[T], a : T) -> Iter[T] {
-  fn(yield) { if yield(a) == IterContinue { self.run(yield) } else { IterEnd } }
+  fn!(yield) {
+    yield!(a)
+    self.run!(yield)
+  }
 }
 
 /// Appends a single element to the end of the iterator.
@@ -590,7 +555,10 @@ pub fn prepend[T](self : Iter[T], a : T) -> Iter[T] {
 ///
 /// Returns a new iterator with the element `a` appended to the original iterator.
 pub fn append[T](self : Iter[T], a : T) -> Iter[T] {
-  fn(yield) { if self.run(yield) == IterContinue { yield(a) } else { IterEnd } }
+  fn!(yield) {
+    self.run!(yield)
+    yield!(a)
+  }
 }
 
 /// Combines two iterators into one by appending the elements of the second iterator to the first.
@@ -609,12 +577,9 @@ pub fn append[T](self : Iter[T], a : T) -> Iter[T] {
 /// Returns a new iterator that contains the elements of `self` followed by the elements of `other`.
 /// @intrinsic %iter.concat
 pub fn Iter::concat[T](self : Iter[T], other : Iter[T]) -> Iter[T] {
-  fn(yield) {
-    if self.run(yield) == IterContinue {
-      other.run(yield)
-    } else {
-      IterEnd
-    }
+  fn!(yield) {
+    self.run!(yield)
+    other.run!(yield)
   }
 }
 

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -233,9 +233,8 @@ test "collect" {
   let iter = Iter::new(
     fn(yield) {
       for i = 0, len = arr.length(); i < len; i = i + 1 {
-        yield(arr[i]) |> ignore
+        yield!(arr[i])
       }
-      IterContinue
     },
   )
   let vec = iter.collect()
@@ -311,15 +310,10 @@ test "eachi" {
 // For testing purposes
 fn test_from_array[T](arr : Array[T]) -> Iter[T] {
   Iter::new(
-    fn {
-      yield =>
-        for i = 0; i < arr.length(); i = i + 1 {
-          if yield(arr[i]) == IterEnd {
-            break IterEnd
-          }
-        } else {
-          IterContinue
-        }
+    fn(yield) {
+      for i = 0; i < arr.length(); i = i + 1 {
+        yield!(arr[i])
+      }
     },
   )
 }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -410,49 +410,39 @@ pub fn clear[K, V](self : Map[K, V]) -> Unit {
 
 /// Returns the iterator of the hash map, provide elements in the order of insertion.
 pub fn iter[K, V](self : Map[K, V]) -> Iter[(K, V)] {
-  Iter::new(
-    fn(yield) {
-      loop self.head {
-        Some({ key, value, idx, .. }) => {
-          if yield((key, value)) == IterEnd {
-            break IterEnd
-          }
-          continue self.list[idx].next
-        }
-        None => break IterContinue
+  fn!(yield) {
+    loop self.head {
+      Some({ key, value, idx, .. }) => {
+        yield!((key, value))
+        continue self.list[idx].next
       }
-    },
-  )
+      None => ()
+    }
+  }
 }
 
 pub fn keys[K, V](self : Map[K, V]) -> Iter[K] {
-  Iter::new(
-    fn(yield) {
-      loop self.head {
-        Some({ key, idx, .. }) =>
-          match yield(key) {
-            IterEnd => IterEnd
-            IterContinue => continue self.list[idx].next
-          }
-        None => IterContinue
+  fn!(yield) {
+    loop self.head {
+      Some({ key, idx, .. }) => {
+        yield!(key)
+        continue self.list[idx].next
       }
-    },
-  )
+      None => ()
+    }
+  }
 }
 
 pub fn values[K, V](self : Map[K, V]) -> Iter[V] {
-  Iter::new(
-    fn(yield) {
-      loop self.head {
-        Some({ value, idx, .. }) =>
-          match yield(value) {
-            IterEnd => IterEnd
-            IterContinue => continue self.list[idx].next
-          }
-        None => IterContinue
+  fn!(yield) {
+    loop self.head {
+      Some({ value, idx, .. }) => {
+        yield!(value)
+        continue self.list[idx].next
       }
-    },
-  )
+      None => ()
+    }
+  }
 }
 
 /// Converts the hash map to an array.

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -514,11 +514,7 @@ pub fn iter[A](self : T[A]) -> Iter[A] {
   Iter::new(
     fn(yield) {
       for i = 0, len = self.length(); i < len; i = i + 1 {
-        if yield(self[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(self[i])
       }
     },
   )

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -38,14 +38,9 @@ pub fn iter[K, V](self : T[K, V]) -> Iter[(K, V)] {
       let len = self.entries.length()
       for i = 0; i < len; i = i + 1 {
         match self.entries[i] {
-          Some({ key, value, .. }) =>
-            if yield((key, value)) == IterEnd {
-              break IterEnd
-            }
+          Some({ key, value, .. }) => yield!((key, value))
           None => continue
         }
-      } else {
-        IterContinue
       }
     },
   )

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -197,11 +197,9 @@ pub fn iter[K](self : T[K]) -> Iter[K] {
     fn(yield) {
       for i = 0, len = self.entries.length(); i < len; i = i + 1 {
         match self.entries[i] {
-          Some({ key, .. }) => if yield(key) == IterEnd { break IterEnd }
+          Some({ key, .. }) => yield!(key)
           None => continue
         }
-      } else {
-        IterContinue
       }
     },
   )

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -49,11 +49,7 @@ pub fn iter[A](self : T[A]) -> Iter[A] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0; i < self.size; i = i + 1 {
-        if yield(arr[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(arr[i])
       }
     },
   )

--- a/immut/hashmap/bucket.mbt
+++ b/immut/hashmap/bucket.mbt
@@ -88,17 +88,14 @@ fn each[K, V](self : Bucket[K, V], f : (K, V) -> Unit) -> Unit {
 
 fn iter[K, V](self : Bucket[K, V]) -> Iter[(K, V)] {
   Iter::new(
-    fn {
-      f =>
-        loop self {
-          Just_One(k, v) => f((k, v))
-          More(k, v, rest) =>
-            if f((k, v)) == IterContinue {
-              continue rest
-            } else {
-              IterEnd
-            }
+    fn(yield) {
+      loop self {
+        Just_One(k, v) => yield!((k, v))
+        More(k, v, rest) => {
+          yield!((k, v))
+          continue rest
         }
+      }
     },
   )
 }

--- a/immut/hashset/bucket.mbt
+++ b/immut/hashset/bucket.mbt
@@ -78,17 +78,14 @@ fn each[T](self : Bucket[T], f : (T) -> Unit) -> Unit {
 
 fn iter[T](self : Bucket[T]) -> Iter[T] {
   Iter::new(
-    fn {
-      f =>
-        loop self {
-          Just_One(k) => f(k)
-          More(k, rest) =>
-            if f(k) == IterContinue {
-              continue rest
-            } else {
-              IterEnd
-            }
+    fn(yield) {
+      loop self {
+        Just_One(k) => yield!(k)
+        More(k, rest) => {
+          yield!(k)
+          continue rest
         }
+      }
     },
   )
 }

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -823,11 +823,9 @@ pub fn iter[A](self : T[A]) -> Iter[A] {
   Iter::new(
     fn(yield) {
       loop self {
-        Nil => IterContinue
+        Nil => ()
         Cons(head, tail) => {
-          if yield(head) == IterEnd {
-            break IterEnd
-          }
+          yield!(head)
           continue tail
         }
       }

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -67,11 +67,7 @@ pub fn iter[A : Compare](self : T[A]) -> Iter[A] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0; i < arr.length(); i = i + 1 {
-        if yield(arr[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(arr[i])
       }
     },
   )

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -192,11 +192,7 @@ pub fn iter[K, V](self : T[K, V]) -> Iter[(K, V)] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0, len = arr.length(); i < len; i = i + 1 {
-        match arr[i] {
-          (key, value) => if yield((key, value)) == IterEnd { break IterEnd }
-        }
-      } else {
-        IterContinue
+        yield!(arr[i])
       }
     },
   )

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -87,11 +87,7 @@ pub fn iter[A : Compare](self : T[A]) -> Iter[A] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0; i < arr.length(); i = i + 1 {
-        if yield(arr[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(arr[i])
       }
     },
   )

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -311,12 +311,10 @@ pub fn iter[A](self : T[A]) -> Iter[A] {
     fn(yield) {
       loop self.first {
         Cons({ content, next }) => {
-          if yield(content) == IterEnd {
-            break IterEnd
-          }
+          yield!(content)
           continue next
         }
-        Nil => IterContinue
+        Nil => ()
       }
     },
   )

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -164,14 +164,10 @@ pub fn to_array[K, V](self : T[K, V]) -> Array[(K, V)] {
 /// Returns a iterator.
 pub fn iter[K, V](self : T[K, V]) -> Iter[(K, V)] {
   Iter::new(
-    fn(yield) {
+    fn!(yield) {
       let arr = self.to_array()
       for i = 0, len = arr.length(); i < len; i = i + 1 {
-        match arr[i] {
-          (key, value) => if yield((key, value)) == IterEnd { break IterEnd }
-        }
-      } else {
-        IterContinue
+        yield!(arr[i])
       }
     },
   )

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -339,11 +339,7 @@ pub fn iter[V](self : T[V]) -> Iter[V] {
     fn(yield) {
       let arr = self.to_array()
       for i = 0, len = arr.length(); i < len; i = i + 1 {
-        if yield(arr[i]) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(arr[i])
       }
     },
   )

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -96,19 +96,12 @@ pub fn iter(self : String) -> Iter[Char] {
           let c2 = self[index + 1]
           if is_trailing_surrogate(c2) {
             let c = code_point_of_surrogate_pair(c1, c2)
-            if yield(c) == IterContinue {
-              continue index + 2
-            } else {
-              break IterEnd
-            }
+            yield!(c)
+            continue index + 2
           }
         }
         //TODO: handle garbage input
-        if yield(c1) == IterEnd {
-          break IterEnd
-        }
-      } else {
-        IterContinue
+        yield!(c1)
       }
     },
   )


### PR DESCRIPTION
This PR change the internal representation of `Iter` from `(() -> IterResult) -> IterResult` to `(() -> Unit!Error) -> Unit!Error`. This brings several benefits:

-  APIs such as `each_err` and `fold_err` are easier to implement
-  It is possible to distinguish different sources of early return in an `Iter`, via different error constructors. For example the implementation of `take` and `takeWhile` can be simplified
- `!` makes writing `Iter`s a lot simpler