### PR TITLE
Do not deprecate lsl lsr for bigint 

### DIFF
--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -441,7 +441,7 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
 // Bitwise Operations
 
 /// Left shift a bigint
-/// @alert deprecate "Use shl instead"
+/// /// @alert deprecate "Use shl instead"
 pub fn lsl(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
@@ -517,7 +517,7 @@ pub fn shl(self : BigInt, n : Int) -> BigInt {
 
 /// Right shift a bigint
 /// it fills the vacated bits on the left with zeros.
-/// @alert deprecate "Use shr instead"
+/// /// @alert deprecate "Use shr instead"
 pub fn lsr(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -112,7 +112,6 @@ impl ArrayView {
 
 type BigInt
 impl BigInt {
-  asr(Self, Int) -> Self
   compare(Self, Self) -> Int
   from_hex(String) -> Self
   from_int(Int) -> Self

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -112,6 +112,7 @@ impl ArrayView {
 
 type BigInt
 impl BigInt {
+  asr(Self, Int) -> Self
   compare(Self, Self) -> Int
   from_hex(String) -> Self
   from_int(Int) -> Self


### PR DESCRIPTION
to avoid confusion.