### PR TITLE
make sure only error type can be raised

### DIFF
--- a/option/option.mbt
+++ b/option/option.mbt
@@ -368,7 +368,7 @@ test "iter" {
   exb.expect!(content="")
 }
 
-pub fn or_error[T, Err](self : T?, err : Err) -> T!Err {
+pub fn or_error[T, Err : Error](self : T?, err : Err) -> T!Err {
   match self {
     Some(v) => v
     None => raise err
@@ -378,17 +378,17 @@ pub fn or_error[T, Err](self : T?, err : Err) -> T!Err {
 test "or error" {
   @test.eq!(
     try {
-      (None : String?).or_error!("This is serious")
+      (None : String?).or_error!(Failure("This is serious"))
     } catch {
-      err => err
+      Failure(err) => err
     },
     "This is serious",
   )
   @test.eq!(
     try {
-      Some("This is ok").or_error!("This is serious")
+      Some("This is ok").or_error!(Failure("This is serious"))
     } catch {
-      err => err
+      Failure(err) => err
     },
     "This is ok",
   )

--- a/option/option.mbti
+++ b/option/option.mbti
@@ -24,7 +24,7 @@ impl Option {
   or[T](T?, T) -> T
   or_default[T : Default](T?) -> T
   or_else[T](T?, () -> T) -> T
-  or_error[T, Err](T?, Err) -> T!Err
+  or_error[T, Err : Error](T?, Err) -> T!Err
 }
 
 // Traits

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -330,7 +330,7 @@ test "show" {
   )
 }
 
-pub fn unwrap_or_error[T, E](self : Result[T, E]) -> T!E {
+pub fn unwrap_or_error[T, E : Error](self : Result[T, E]) -> T!E {
   match self {
     Ok(x) => x
     Err(e) => raise e
@@ -338,15 +338,20 @@ pub fn unwrap_or_error[T, E](self : Result[T, E]) -> T!E {
 }
 
 test "unwrap exn" {
-  inspect!(
-    wrap1(f=unwrap_or_error, (Err("This is serious") : Result[Unit, String])),
+  try {
+    (Err(Failure("This is serious")) : Result[Unit, Failure]).unwrap_or_error!()
+    |> Ok
+  } catch {
+    Failure(msg) => Err(msg)
+  }
+  |> inspect!(
     content=
       #|Err("This is serious")
     ,
   )
 }
 
-pub fn wrap0[T, E](~f : () -> T!E) -> Result[T, E] {
+pub fn wrap0[T, E : Error](~f : () -> T!E) -> Result[T, E] {
   try {
     f!() |> Ok
   } catch {
@@ -354,7 +359,7 @@ pub fn wrap0[T, E](~f : () -> T!E) -> Result[T, E] {
   }
 }
 
-pub fn wrap1[T, A, E](~f : (A) -> T!E, a : A) -> Result[T, E] {
+pub fn wrap1[T, A, E : Error](~f : (A) -> T!E, a : A) -> Result[T, E] {
   try {
     f!(a) |> Ok
   } catch {
@@ -362,7 +367,11 @@ pub fn wrap1[T, A, E](~f : (A) -> T!E, a : A) -> Result[T, E] {
   }
 }
 
-pub fn wrap2[T, A, B, E](~f : (A, B) -> T!E, a : A, b : B) -> Result[T, E] {
+pub fn wrap2[T, A, B, E : Error](
+  ~f : (A, B) -> T!E,
+  a : A,
+  b : B
+) -> Result[T, E] {
   try {
     f!(a, b) |> Ok
   } catch {

--- a/result/result.mbti
+++ b/result/result.mbti
@@ -5,11 +5,11 @@ fn err[T, E](E) -> Result[T, E]
 
 fn ok[T, E](T) -> Result[T, E]
 
-fn wrap0[T, E](~f : () -> T!E) -> Result[T, E]
+fn wrap0[T, E : Error](~f : () -> T!E) -> Result[T, E]
 
-fn wrap1[T, A, E](~f : (A) -> T!E, A) -> Result[T, E]
+fn wrap1[T, A, E : Error](~f : (A) -> T!E, A) -> Result[T, E]
 
-fn wrap2[T, A, B, E](~f : (A, B) -> T!E, A, B) -> Result[T, E]
+fn wrap2[T, A, B, E : Error](~f : (A, B) -> T!E, A, B) -> Result[T, E]
 
 // Types and methods
 impl Result {
@@ -26,7 +26,7 @@ impl Result {
   to_option[T, E](Self[T, E]) -> T?
   to_string[T : Show, E : Show](Self[T, E]) -> String
   unwrap[T, E](Self[T, E]) -> T
-  unwrap_or_error[T, E](Self[T, E]) -> T!E
+  unwrap_or_error[T, E : Error](Self[T, E]) -> T!E
 }
 
 // Traits


### PR DESCRIPTION
Soon, only `Error` types will be allowed to be raised. For polymorphic error handling functions, their error type parameter must be annotated with the `Error` bound.

This PR prepare core for this upcoming language change, add [Error] bound to polymorphic error handling APIs, and adapt codes that raises non-error type.