### PR TITLE
[DO NOT MERGE] Show the bug in json.stringify

### DIFF
--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -342,3 +342,18 @@ test "stringify" {
   }
   @test.eq!(newjson, json)
 }
+
+test "bug in @json.stringify" {
+  let json : @json.JsonValue = { "\"": "\n" }
+  inspect!(
+    json.stringify(),
+    content=
+      #|{""":"
+      #|"}
+    ,
+  )
+  match parse_as_result(json.stringify()) {
+    Err(e) => raise e
+    Ok(newjson) => @test.eq!(newjson, json)
+  }
+}


### PR DESCRIPTION
json.stringify does not handle the escaped characters