### PR TITLE
move json type to builtin

### DIFF
--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -451,9 +451,10 @@ test "iter" {
   [1, 2, 3, 4, 5].iter().each(fn { x => buf.write_string(x.to_string()) })
   inspect!(buf, content="12345")
   buf.reset()
-  [1, 2, 3, 4, 5].iter().take(2).each(
-    fn { x => buf.write_string(x.to_string()) },
-  )
+  [1, 2, 3, 4, 5]
+  .iter()
+  .take(2)
+  .each(fn { x => buf.write_string(x.to_string()) })
   inspect!(buf, content="12")
 }
 

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -225,6 +225,19 @@ impl Js_string {
   op_add(Self, Self) -> Self
 }
 
+pub enum Json {
+  Null
+  True
+  False
+  Number(Double)
+  String(String)
+  Array(Array[Json])
+  Object(Map[String, Json])
+}
+impl Json {
+  op_equal(Self, Self) -> Bool
+}
+
 type Map
 impl Map {
   capacity[K, V](Self[K, V]) -> Int

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -122,10 +122,13 @@ fn rotl(x : Int, r : Int) -> Int {
 }
 
 fn endian32(input : Bytes, cur : Int) -> Int {
-  input[cur + 0].to_int().lor(
-    input[cur + 1].to_int().lsl(8).lor(
-      input[cur + 2].to_int().lsl(16).lor(input[cur + 3].to_int().lsl(24)),
-    ),
+  input[cur + 0]
+  .to_int()
+  .lor(
+    input[cur + 1]
+    .to_int()
+    .lsl(8)
+    .lor(input[cur + 2].to_int().lsl(16).lor(input[cur + 3].to_int().lsl(24))),
   )
 }
 

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -146,11 +146,14 @@ test "combine byte" {
 
 test "combine all" {
   let hasher = Hasher::new()
-  hasher..combine_int(1)..combine_int64(2147483648)..combine_uint(2)..combine_uint64(
-    4294967296,
-  )..combine_double(1.234)..combine_string("Moonbit").combine_bytes(
-    Bytes::make(10, b'1'),
-  )
+  hasher
+  ..combine_int(1)
+  ..combine_int64(2147483648)
+  ..combine_uint(2)
+  ..combine_uint64(4294967296)
+  ..combine_double(1.234)
+  ..combine_string("Moonbit")
+  .combine_bytes(Bytes::make(10, b'1'))
   inspect!(hasher.finalize(), content="1982681228")
   inspect!(hasher.finalize() == hasher.finalize(), content="true")
 }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -48,9 +48,10 @@ test "take" {
 test "take2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = Buffer::new(size_hint=0)
-  iter.take(10).concat(Iter::repeat('6').take(1)).each(
-    fn { x => exb.write_char(x) },
-  )
+  iter
+  .take(10)
+  .concat(Iter::repeat('6').take(1))
+  .each(fn { x => exb.write_char(x) })
   exb.expect!(content="123456")
 }
 
@@ -64,35 +65,37 @@ test "take_while" {
 test "take_while2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = Buffer::new(size_hint=0)
-  iter.take_while(fn { x => x != '4' }).concat(singleton('6')).each(
-    fn { x => exb.write_char(x) },
-  )
+  iter
+  .take_while(fn { x => x != '4' })
+  .concat(singleton('6'))
+  .each(fn { x => exb.write_char(x) })
   exb.expect!(content="1236")
 }
 
 test "take_while3" {
   let iter = test_from_array([1, 2, 3])
-  let res = iter.take_while(fn { x => x != 4 }).concat(singleton(4)).find_first(
-    fn { x => x % 2 == 0 },
-  )
+  let res = iter
+    .take_while(fn { x => x != 4 })
+    .concat(singleton(4))
+    .find_first(fn { x => x % 2 == 0 })
   inspect!(res, content="Some(2)")
 }
 
 test "take_while4" {
   let iter = test_from_array([1, 2, 3, 4, 5, 6])
-  let res = iter.take_while(fn { x => x <= 5 }).take(4).fold(
-    init=0,
-    fn(x, y) { x + y },
-  )
+  let res = iter
+    .take_while(fn { x => x <= 5 })
+    .take(4)
+    .fold(init=0, fn(x, y) { x + y })
   inspect!(res, content="10")
 }
 
 test "take_while5" {
   let iter = test_from_array([1, 2, 3, 4, 5, 6])
-  let res = iter.take(4).take_while(fn { x => x >= 5 }).fold(
-    fn(x, y) { x + y },
-    init=0,
-  )
+  let res = iter
+    .take(4)
+    .take_while(fn { x => x >= 5 })
+    .fold(fn(x, y) { x + y }, init=0)
   inspect!(res, content="0")
 }
 
@@ -112,23 +115,27 @@ test "drop_while" {
 
 test "drop_while2" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let res = iter.drop_while(fn { x => x <= 3 }).concat(singleton(6)).find_first(
-    fn { x => x % 3 == 0 },
-  )
+  let res = iter
+    .drop_while(fn { x => x <= 3 })
+    .concat(singleton(6))
+    .find_first(fn { x => x % 3 == 0 })
   inspect!(res, content="Some(6)")
 }
 
 test "drop_while3" {
   let iter = test_from_array([1, 2, 3, 4, 5])
   let exb = Buffer::new(size_hint=0)
-  let res = iter.drop_while(fn { x => x < 3 }).concat(singleton(6)).find_first(
-    fn {
-      x => {
-        exb.write_char('x')
-        x % 3 == 0
-      }
-    },
-  )
+  let res = iter
+    .drop_while(fn { x => x < 3 })
+    .concat(singleton(6))
+    .find_first(
+      fn {
+        x => {
+          exb.write_char('x')
+          x % 3 == 0
+        }
+      },
+    )
   // make sure the predicate in find_first is called only once
   exb.expect!(content="x")
   inspect!(res, content="Some(3)")
@@ -136,9 +143,11 @@ test "drop_while3" {
 
 test "drop_while4" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let res = iter.drop_while(fn { x => x <= 3 }).concat(singleton(6)).drop(3).find_first(
-    fn { x => x % 3 == 0 },
-  )
+  let res = iter
+    .drop_while(fn { x => x <= 3 })
+    .concat(singleton(6))
+    .drop(3)
+    .find_first(fn { x => x % 3 == 0 })
   inspect!(res, content="None")
 }
 
@@ -152,27 +161,27 @@ test "filter" {
 test "map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = Buffer::new(size_hint=0)
-  iter.map(fn { x => Char::from_int(x.to_int() + 1) }).each(
-    fn { x => exb.write_char(x) },
-  )
+  iter
+  .map(fn { x => Char::from_int(x.to_int() + 1) })
+  .each(fn { x => exb.write_char(x) })
   exb.expect!(content="23456")
 }
 
 test "flat_map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = Buffer::new(size_hint=0)
-  iter.flat_map(fn { x => Iter::repeat(x).take(2) }).each(
-    fn { x => exb.write_char(x) },
-  )
+  iter
+  .flat_map(fn { x => Iter::repeat(x).take(2) })
+  .each(fn { x => exb.write_char(x) })
   exb.expect!(content="1122334455")
 }
 
 test "flat_map2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = Buffer::new(size_hint=0)
-  iter.flat_map(fn { x => Iter::singleton(x) }).each(
-    fn { x => exb.write_char(x) },
-  )
+  iter
+  .flat_map(fn { x => Iter::singleton(x) })
+  .each(fn { x => exb.write_char(x) })
   exb.expect!(content="12345")
 }
 
@@ -256,9 +265,10 @@ test "range" {
     content="[0, 1, 2, 3, 4, 0, 1]",
   )
   inspect!(
-    0x80000000L.until(0x80000000L + 10L).take(5).concat(
-      (0x80000000L + 10L).until(0x80000000L + 20L).take(3),
-    ),
+    0x80000000L
+    .until(0x80000000L + 10L)
+    .take(5)
+    .concat((0x80000000L + 10L).until(0x80000000L + 20L).take(3)),
     content="[2147483648, 2147483649, 2147483650, 2147483651, 2147483652, 2147483658, 2147483659, 2147483660]",
   )
   inspect!(

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -1,0 +1,23 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub enum Json {
+  Null
+  True
+  False
+  Number(Double)
+  String(String)
+  Array(Array[Json])
+  Object(Map[String, Json])
+} derive(Eq)

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -202,7 +202,9 @@ test "grow" {
 test "iter" {
   let buf = Buffer::new(size_hint=20)
   let map = { 1: "one", 2: "two", 3: "three" }
-  map.iter().each(
+  map
+  .iter()
+  .each(
     fn(e) {
       let (k, v) = e
       buf.write_string("[\{k}-\{v}]")
@@ -210,7 +212,10 @@ test "iter" {
   )
   inspect!(buf, content="[1-one][2-two][3-three]")
   buf.reset()
-  map.iter().take(2).each(
+  map
+  .iter()
+  .take(2)
+  .each(
     fn(e) {
       let (k, v) = e
       buf.write_string("[\{k}-\{v}]")

--- a/builtin/tuple_hash.mbt
+++ b/builtin/tuple_hash.mbt
@@ -66,7 +66,12 @@ pub impl[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] H
   G,
 ) with hash_combine(self, hasher) {
   let (a, b, c, d, e, f, g) = self
-  hasher..combine(a)..combine(b)..combine(c)..combine(d)..combine(e)..combine(f).combine(
-    g,
-  )
+  hasher
+  ..combine(a)
+  ..combine(b)
+  ..combine(c)
+  ..combine(d)
+  ..combine(e)
+  ..combine(f)
+  .combine(g)
 }

--- a/bytes/xxhash.mbt
+++ b/bytes/xxhash.mbt
@@ -58,10 +58,13 @@ fn avalanche(h : Int) -> Int {
 }
 
 fn endian32(input : Bytes, cur : Int) -> Int {
-  input[cur + 0].to_int().lor(
-    input[cur + 1].to_int().lsl(8).lor(
-      input[cur + 2].to_int().lsl(16).lor(input[cur + 3].to_int().lsl(24)),
-    ),
+  input[cur + 0]
+  .to_int()
+  .lor(
+    input[cur + 1]
+    .to_int()
+    .lsl(8)
+    .lor(input[cur + 2].to_int().lsl(16).lor(input[cur + 3].to_int().lsl(24))),
   )
 }
 

--- a/double/double.mbt
+++ b/double/double.mbt
@@ -114,9 +114,14 @@ pub fn round(self : Double) -> Double {
   } else if biased_exp < 1022 {
     return u64.land(sign_mask).reinterpret_as_double()
   } else if biased_exp == 1022 {
-    return u64.land(sign_mask).lor(0x3FF0_0000_0000_0000L).reinterpret_as_double()
+    return u64
+      .land(sign_mask)
+      .lor(0x3FF0_0000_0000_0000L)
+      .reinterpret_as_double()
   }
-  let trunced = u64.land(sign_mask.asr(biased_exp - 1012)).reinterpret_as_double()
+  let trunced = u64
+    .land(sign_mask.asr(biased_exp - 1012))
+    .reinterpret_as_double()
   if u64.land(sign_mask.lsr(biased_exp - 1011)) == 0L {
     return trunced
   } else if self > 0.0 {

--- a/double/log.mbt
+++ b/double/log.mbt
@@ -52,7 +52,10 @@ fn frexp(f : Double) -> (Double, Int) {
   let (norm_f, exp) = normalize(f)
   let u = norm_f.reinterpret_as_i64()
   let exp = exp + u.lsr(52).land(0x7FFL).to_int() - 1022
-  let frac = u.land(0x7FFL.lsl(52).lnot()).lor(1022L.lsl(52)).reinterpret_as_double()
+  let frac = u
+    .land(0x7FFL.lsl(52).lnot())
+    .lor(1022L.lsl(52))
+    .reinterpret_as_double()
   return (frac, exp)
 }
 

--- a/double/ryu.mbt
+++ b/double/ryu.mbt
@@ -198,9 +198,11 @@ fn double_computePow5(i : Int) -> (UInt64, UInt64) {
     high1 = high1 + 1UL
   }
   let delta : Int = pow5bits(i) - pow5bits(base2)
-  let a = shiftright128(low0, sum, delta) + gPOW5_OFFSETS[i / 16].lsr(
-      (i % 16).lsl(1),
-    ).land(3).to_int64().to_uint64()
+  let a = shiftright128(low0, sum, delta) + gPOW5_OFFSETS[i / 16]
+    .lsr((i % 16).lsl(1))
+    .land(3)
+    .to_int64()
+    .to_uint64()
   let b = shiftright128(sum, high1, delta)
   (a, b)
 }
@@ -223,9 +225,10 @@ fn double_computeInvPow5(i : Int) -> (UInt64, UInt64) {
     high1 = high1 + 1
   }
   let delta : Int = pow5bits(base2) - pow5bits(i)
-  let a = shiftright128(low0, sum, delta) + 1 + gPOW5_INV_OFFSETS[i / 16].lsr(
-      (i % 16).lsl(1),
-    ).land(3).to_uint64()
+  let a = shiftright128(low0, sum, delta) + 1 + gPOW5_INV_OFFSETS[i / 16]
+    .lsr((i % 16).lsl(1))
+    .land(3)
+    .to_uint64()
   let b = shiftright128(sum, high1, delta)
   (a, b)
 }
@@ -448,7 +451,9 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : Int) -> FloatingDecimal64 {
       lastRemovedDigit = 4
     }
     output = vr + ((vr == vm && (not(acceptBounds) || not(vmIsTrailingZeros))) ||
-      lastRemovedDigit >= 5).to_int64().to_uint64()
+      lastRemovedDigit >= 5)
+      .to_int64()
+      .to_uint64()
   } else {
     // Specialized for the common case (~99.3%). Percentages below are relative to this.
     let mut roundUp = false
@@ -618,13 +623,14 @@ fn ryu_to_string(self : Double) -> String {
   let bits : UInt64 = self.reinterpret_as_u64()
 
   // Decode bits into sign, mantissa, and exponent.
-  let ieeeSign = bits.lsr(gDOUBLE_MANTISSA_BITS + gDOUBLE_EXPONENT_BITS).land(
-      1UL,
-    ) != 0UL
+  let ieeeSign = bits
+    .lsr(gDOUBLE_MANTISSA_BITS + gDOUBLE_EXPONENT_BITS)
+    .land(1UL) != 0UL
   let ieeeMantissa : UInt64 = bits.land(1UL.lsl(gDOUBLE_MANTISSA_BITS) - 1UL)
-  let ieeeExponent : Int = bits.lsr(gDOUBLE_MANTISSA_BITS).land(
-    1UL.lsl(gDOUBLE_EXPONENT_BITS) - 1UL,
-  ).to_int()
+  let ieeeExponent : Int = bits
+    .lsr(gDOUBLE_MANTISSA_BITS)
+    .land(1UL.lsl(gDOUBLE_EXPONENT_BITS) - 1UL)
+    .to_int()
   if ieeeExponent == (1).lsl(gDOUBLE_EXPONENT_BITS) - 1 || (ieeeExponent == 0 &&
   ieeeMantissa == 0UL) {
     return copy_special_str(ieeeSign, ieeeExponent != 0, ieeeMantissa != 0UL)

--- a/double/ryu_test.mbt
+++ b/double/ryu_test.mbt
@@ -272,7 +272,12 @@ fn ieee_parts_to_double(
   ieeeExponent : Int,
   ieeeMantissa : Int64
 ) -> Double {
-  sign.to_int64().lsl(63).lor(ieeeExponent.to_int64().lsl(52)).lor(ieeeMantissa).reinterpret_as_double()
+  sign
+  .to_int64()
+  .lsl(63)
+  .lor(ieeeExponent.to_int64().lsl(52))
+  .lor(ieeeMantissa)
+  .reinterpret_as_double()
 }
 
 test "double/ryu.mbt:90" {

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -130,7 +130,9 @@ test "iteri" {
 test "iter" {
   let buf = Buffer::new(size_hint=20)
   let map = @hashmap.of([(1, "one"), (2, "two"), (3, "three")])
-  map.iter().each(
+  map
+  .iter()
+  .each(
     fn(e) {
       let (k, v) = e
       buf.write_string("[\{k}-\{v}]")
@@ -138,7 +140,10 @@ test "iter" {
   )
   inspect!(buf, content="[2-two][1-one][3-three]")
   buf.reset()
-  map.iter().take(2).each(
+  map
+  .iter()
+  .take(2)
+  .each(
     fn(e) {
       let (k, v) = e
       buf.write_string("[\{k}-\{v}]")

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -68,9 +68,11 @@ test "HAMT::iter" {
 }
 
 test "HAMT::to_string" {
-  let map = @hashmap.new().add(1, 1).add(3, 3).add(0x0f_ff_ff_ff, 0x0f_ff_ff_ff).add(
-    42, 42,
-  )
+  let map = @hashmap.new()
+    .add(1, 1)
+    .add(3, 3)
+    .add(0x0f_ff_ff_ff, 0x0f_ff_ff_ff)
+    .add(42, 42)
   inspect!(
     map,
     content="@immut/hashmap.of([(3, 3), (42, 42), (1, 1), (268435455, 268435455)])",

--- a/immut/hashmap/bucket.mbt
+++ b/immut/hashmap/bucket.mbt
@@ -141,7 +141,9 @@ test "Bucket::iter" {
   let b : Bucket[_] = More(0, 0, More(1, 1, Just_One(31, 31)))
   let buf = Buffer::new(size_hint=0)
   let mut is_first = true
-  b.iter().each(
+  b
+  .iter()
+  .each(
     fn {
       (k, v) => {
         // weird syntax conventions that

--- a/immut/hashset/bucket.mbt
+++ b/immut/hashset/bucket.mbt
@@ -131,7 +131,9 @@ test "Bucket::iter" {
   let b : Bucket[_] = More(0, More(1, Just_One(31)))
   let buf = Buffer::new(size_hint=0)
   let mut is_first = true
-  b.iter().each(
+  b
+  .iter()
+  .each(
     fn {
       k => {
         // weird syntax conventions that
@@ -213,7 +215,9 @@ test "Bucket iter" {
   let b2 = b1.add(2)
   let buf = Buffer::new(size_hint=0)
   let mut is_first = true
-  b2.iter().each(
+  b2
+  .iter()
+  .each(
     fn {
       k => {
         if is_first {

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -67,7 +67,15 @@ test "pop_exn" {
   let first = queue.pop_exn()
   inspect!(first.peek(), content="Some(3)")
   inspect!(
-    queue.pop_exn().push(-1).push(10).push(11).pop_exn().pop_exn().push(50).peek(),
+    queue
+    .pop_exn()
+    .push(-1)
+    .push(10)
+    .push(11)
+    .pop_exn()
+    .pop_exn()
+    .push(50)
+    .peek(),
     content="Some(50)",
   )
 }

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -209,9 +209,11 @@ test "from_array" {
 test "insert" {
   let m = of([(3, "three"), (8, "eight"), (1, "one")])
   inspect!(m.debug_tree(), content="(3,three,(1,one,_,_),(8,eight,_,_))")
-  let m = m.insert(5, "five").insert(2, "two").insert(0, "zero").insert(
-    1, "one_updated",
-  )
+  let m = m
+    .insert(5, "five")
+    .insert(2, "two")
+    .insert(0, "zero")
+    .insert(1, "one_updated")
   inspect!(
     m.debug_tree(),
     content="(3,three,(1,one_updated,(0,zero,_,_),(2,two,_,_)),(8,eight,(5,five,_,_),_))",
@@ -284,9 +286,11 @@ test "singleton" {
 test "insert" {
   let m = of([(3, "three"), (8, "eight"), (1, "one")])
   inspect!(m.debug_tree(), content="(3,three,(1,one,_,_),(8,eight,_,_))")
-  let m = m.insert(5, "five").insert(2, "two").insert(0, "zero").insert(
-    1, "one_updated",
-  )
+  let m = m
+    .insert(5, "five")
+    .insert(2, "two")
+    .insert(0, "zero")
+    .insert(1, "one_updated")
   inspect!(
     m.debug_tree(),
     content="(3,three,(1,one_updated,(0,zero,_,_),(2,two,_,_)),(8,eight,(5,five,_,_),_))",

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -106,7 +106,9 @@ test "op_equal" {
 test "iter" {
   let buf = Buffer::new(size_hint=20)
   let map = @sorted_map.of([(1, "one"), (2, "two"), (3, "three")])
-  map.iter().each(
+  map
+  .iter()
+  .each(
     fn(e) {
       let (k, v) = e
       buf.write_string("[\{k}-\{v}]")
@@ -114,7 +116,10 @@ test "iter" {
   )
   inspect!(buf, content="[1-one][2-two][3-three]")
   buf.reset()
-  map.iter().take(2).each(
+  map
+  .iter()
+  .take(2)
+  .each(
     fn(e) {
       let (k, v) = e
       buf.write_string("[\{k}-\{v}]")

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -30,8 +30,8 @@ pub fn T::from_iter[A : Compare](iter : Iter[A]) -> T[A] {
 
 test {
   let buf = Buffer::new(size_hint=20)
-  of([2, 7, 1, 2, 3, 4, 5]).iter().each(
-    fn { x => buf.write_string(x.to_string()) },
-  )
+  of([2, 7, 1, 2, 3, 4, 5])
+  .iter()
+  .each(fn { x => buf.write_string(x.to_string()) })
   inspect!(buf, content="123457")
 }

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -1,7 +1,7 @@
 package moonbitlang/core/json
 
 // Values
-fn parse(String) -> JsonValue!ParseError
+fn parse(String) -> Json!ParseError
 
 fn valid(String) -> Bool
 
@@ -17,30 +17,6 @@ impl ErrorData {
   to_string(Self) -> String
 }
 
-pub enum JsonValue {
-  Null
-  True
-  False
-  Number(Double)
-  String(String)
-  Array(Array[JsonValue])
-  Object(Map[String, JsonValue])
-}
-impl JsonValue {
-  as_array(Self) -> Array[Self]?
-  as_bool(Self) -> Bool?
-  as_null(Self) -> Unit?
-  as_number(Self) -> Double?
-  as_object(Self) -> Map[String, Self]?
-  as_string(Self) -> String?
-  item(Self, Int) -> Self?
-  op_equal(Self, Self) -> Bool
-  stringify(Self) -> String
-  to_json(Self) -> Self
-  to_string(Self) -> String
-  value(Self, String) -> Self?
-}
-
 pub type! ParseError ErrorData
 impl ParseError {
   op_equal(Self, Self) -> Bool
@@ -54,15 +30,29 @@ pub struct Position {
 impl Position {
   op_equal(Self, Self) -> Bool
 }
+impl Json {
+  as_array(Self) -> Array[Self]?
+  as_bool(Self) -> Bool?
+  as_null(Self) -> Unit?
+  as_number(Self) -> Double?
+  as_object(Self) -> Map[String, Self]?
+  as_string(Self) -> String?
+  item(Self, Int) -> Self?
+  stringify(Self) -> String
+  to_json(Self) -> Self
+  to_string(Self) -> String
+  value(Self, String) -> Self?
+}
 
 // Type aliases
+pub typealias JsonValue = Json
 
 // Traits
 
 // Extension Methods
-impl Show for ErrorData
+impl Show for Json
 
-impl Show for JsonValue
+impl Show for ErrorData
 
 impl Show for ParseError
 

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -128,23 +128,23 @@ test "get as array" {
     ,
   )
   inspect!(
-    @json.JsonValue::Array([@json.JsonValue::String("Hello World")]).item(0).bind(
-      @json.as_string,
-    ),
+    @json.JsonValue::Array([@json.JsonValue::String("Hello World")])
+    .item(0)
+    .bind(@json.as_string),
     content=
       #|Some("Hello World")
     ,
   )
   inspect!(
-    @json.JsonValue::Array([@json.JsonValue::String("Hello World")]).item(1).bind(
-      @json.as_string,
-    ),
+    @json.JsonValue::Array([@json.JsonValue::String("Hello World")])
+    .item(1)
+    .bind(@json.as_string),
     content="None",
   )
   inspect!(
-    @json.JsonValue::Array([@json.JsonValue::String("Hello World")]).item(0).bind(
-      @json.as_number,
-    ),
+    @json.JsonValue::Array([@json.JsonValue::String("Hello World")])
+    .item(0)
+    .bind(@json.as_number),
     content="None",
   )
   inspect!(
@@ -215,7 +215,9 @@ test "get as object" {
           ("value", @json.JsonValue::Number(100.0)),
         ],
       ),
-    ).value("key").bind(@json.as_string),
+    )
+    .value("key")
+    .bind(@json.as_string),
     content=
       #|Some("key")
     ,
@@ -228,7 +230,9 @@ test "get as object" {
           ("value", @json.JsonValue::Number(100.0)),
         ],
       ),
-    ).value("value").bind(@json.as_number),
+    )
+    .value("value")
+    .bind(@json.as_number),
     content="Some(100.0)",
   )
   inspect!(
@@ -239,7 +243,9 @@ test "get as object" {
           ("value", @json.JsonValue::Number(100.0)),
         ],
       ),
-    ).value("key").bind(@json.as_number),
+    )
+    .value("key")
+    .bind(@json.as_number),
     content="None",
   )
   inspect!(
@@ -250,7 +256,9 @@ test "get as object" {
           ("value", @json.JsonValue::Number(100.0)),
         ],
       ),
-    ).value("asdf").bind(@json.as_number),
+    )
+    .value("asdf")
+    .bind(@json.as_number),
     content="None",
   )
 }
@@ -305,9 +313,11 @@ test "deep access" {
     content="Some([])",
   )
   inspect!(
-    json.value("key").bind(fn { array => array.item(4) }).bind(@json.as_object).map(
-      Map::to_array,
-    ),
+    json
+    .value("key")
+    .bind(fn { array => array.item(4) })
+    .bind(@json.as_object)
+    .map(Map::to_array),
     content=
       #|Some([("key", String("value")), ("value", Number(100.0))])
     ,

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub enum JsonValue {
-  Null
-  True
-  False
-  Number(Double)
-  String(String)
-  Array(Array[JsonValue])
-  Object(Map[String, JsonValue])
-} derive(Eq)
+/// @alert deprecated "Definition of json is moved to builtin package, use `Json` instead"
+pub typealias JsonValue = Json
 
 pub struct Position {
   line : Int // 1-based

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -345,7 +345,9 @@ pub fn iter[T](self : T?) -> Iter[T] {
 test "iter" {
   let x = Option::Some(42)
   let exb = Buffer::new(size_hint=0)
-  x.iter().each(
+  x
+  .iter()
+  .each(
     fn(x) {
       exb.write_string(x.to_string())
       exb.write_char('\n')
@@ -359,7 +361,9 @@ test "iter" {
   )
   exb.reset()
   let y : Int? = None
-  y.iter().each(
+  y
+  .iter()
+  .each(
     fn(x) {
       exb.write_string(x.to_string())
       exb.write_char('\n')

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -39,9 +39,9 @@ pub fn RandomState::init_state(~seed : Int = 0) -> RandomState {
 
 fn twist(self : RandomState) -> Unit {
   for i = 0; i < n32; i = i + 1 {
-    let x = self.state[i].land(upper_mask_32).lor(
-      self.state[(i + 1) % n32].land(lower_mask_32),
-    )
+    let x = self.state[i]
+      .land(upper_mask_32)
+      .lor(self.state[(i + 1) % n32].land(lower_mask_32))
     self.state[i] = self.state[(i + m32) % m32].lxor(x.asr(1))
     if x % 2 != 0 {
       self.state[i] = self.state[i].lxor(matrix_a_32)

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -274,9 +274,10 @@ pub impl Show for T with output(self, logger) {
   } else if self.denominator == 1L {
     logger.write_string(self.numerator.to_string())
   } else {
-    logger..write_string(self.numerator.to_string())..write_string("/").write_string(
-      self.denominator.to_string(),
-    )
+    logger
+    ..write_string(self.numerator.to_string())
+    ..write_string("/")
+    .write_string(self.denominator.to_string())
   }
 }
 

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -248,7 +248,9 @@ fn assemble_bits(mantissa : Int64, exponent : Int, negative : Bool) -> Int64 {
   // set the mantissa bits
   let mut bits = mantissa.land(1L.lsl(double_info.mantissa_bits) - 1L)
   // set the exponent bits
-  let exp_bits = biased_exp.land((1).lsl(double_info.exponent_bits) - 1).to_int64()
+  let exp_bits = biased_exp
+    .land((1).lsl(double_info.exponent_bits) - 1)
+    .to_int64()
   bits = bits.lor(exp_bits.lsl(double_info.mantissa_bits))
   // set the sign bit
   if negative {

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -46,7 +46,9 @@ pub fn to_bytes(self : String) -> Bytes {
 
 /// Converts the String into an array of Chars.
 pub fn to_array(self : String) -> Array[Char] {
-  self.iter().fold(
+  self
+  .iter()
+  .fold(
     init=Array::new(capacity=self.length()),
     fn(rv, c) {
       rv.push(c)
@@ -354,7 +356,9 @@ pub fn replace_all(self : String, ~old : String, ~new : String) -> String {
   let old_len = old.length()
   if old_len == 0 {
     buf.write_string(new)
-    self.iter().each(
+    self
+    .iter()
+    .each(
       fn(c) {
         buf.write_char(c)
         buf.write_string(new)
@@ -380,7 +384,9 @@ pub fn replace_all(self : String, ~old : String, ~new : String) -> String {
 pub fn to_lower(self : String) -> String {
   // TODO: deal with non-ascii characters
   let buf = Buffer::new(size_hint=self.length())
-  self.iter().each(
+  self
+  .iter()
+  .each(
     fn(c) {
       if c >= 'A' && c <= 'Z' {
         buf.write_char(Char::from_int(c.to_int() + 32))
@@ -396,7 +402,9 @@ pub fn to_lower(self : String) -> String {
 pub fn to_upper(self : String) -> String {
   // TODO: deal with non-ascii characters
   let buf = Buffer::new(size_hint=self.length())
-  self.iter().each(
+  self
+  .iter()
+  .each(
     fn(c) {
       if c >= 'a' && c <= 'z' {
         buf.write_char(Char::from_int(c.to_int() - 32))

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -72,9 +72,9 @@ test "substring" {
 
 test "chars" {
   let mut str = ""
-  "A😊𠮷BA😊𠮷B".iter().each(
-    fn(c) { str = str + c.to_int().to_string() + "\n" },
-  )
+  "A😊𠮷BA😊𠮷B"
+  .iter()
+  .each(fn(c) { str = str + c.to_int().to_string() + "\n" })
   inspect!(
     str,
     content=


### PR DESCRIPTION
Move the `@json.JsonValue` type to builtin package, so that:

- it can be referenced more easily with `Json` directly
- builtin types can have a `.to_json` method

Note that we don't want to pull all the json parsing and processing stuff into builtin, just the type definition. To make this work some compiler special treatment is needed, so that `@json` can define methods for the `Json` type. So this PR need compiler adoption before merging.

A type alias is placed in the `@json` package, so this PR is backward compatible. All existing code that make use of `@json.JsonValue` will continue to work.