### PR TITLE
add [ToJson] trait & [to_json] method for builtin types

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -95,6 +95,7 @@ impl Array {
   strip_prefix[T : Eq](Self[T], Self[T]) -> Self[T]?
   strip_suffix[T : Eq](Self[T], Self[T]) -> Self[T]?
   swap[T](Self[T], Int, Int) -> Unit
+  to_json[X : ToJson](Self[X]) -> Json
   to_string[T : Show](Self[T]) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
@@ -266,6 +267,7 @@ impl Map {
   set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[Tuple[K, V]]
+  to_json[V : ToJson](Self[String, V]) -> Json
   to_string[K : Show, V : Show](Self[K, V]) -> String
   values[K, V](Self[K, V]) -> Iter[V]
 }
@@ -284,6 +286,7 @@ impl Bool {
   not(Bool) -> Bool
   op_compare(Bool, Bool) -> Int
   op_equal(Bool, Bool) -> Bool
+  to_json(Bool) -> Json
   to_string(Bool) -> String
 }
 impl Byte {
@@ -306,6 +309,7 @@ impl Char {
   from_int(Int) -> Char
   op_equal(Char, Char) -> Bool
   to_int(Char) -> Int
+  to_json(Char) -> Json
   to_string(Char) -> String
 }
 impl Int {
@@ -339,6 +343,7 @@ impl Int {
   to_byte(Int) -> Byte
   to_double(Int) -> Double
   to_int64(Int) -> Int64
+  to_json(Int) -> Json
   to_string(Int) -> String
   to_uint(Int) -> UInt
   until(Int, Int, ~step : Int = ..) -> Iter[Int]
@@ -371,6 +376,7 @@ impl Int64 {
   to_byte(Int64) -> Byte
   to_double(Int64) -> Double
   to_int(Int64) -> Int
+  to_json(Int64) -> Json
   to_string(Int64) -> String
   to_uint64(Int64) -> UInt64
   until(Int64, Int64, ~step : Int64 = ..) -> Iter[Int64]
@@ -443,6 +449,7 @@ impl Double {
   sqrt(Double) -> Double
   to_int(Double) -> Int
   to_int64(Double) -> Int64
+  to_json(Double) -> Json
   until(Double, Double, ~step : Double = ..) -> Iter[Double]
 }
 impl String {
@@ -454,6 +461,7 @@ impl String {
   op_equal(String, String) -> Bool
   op_get(String, Int) -> Char
   to_js_string(String) -> Js_string
+  to_json(String) -> Json
   to_string(String) -> String
 }
 impl Option {
@@ -577,6 +585,10 @@ pub trait Logger {
 pub trait Show {
   output(Self, Logger) -> Unit
   to_string(Self) -> String
+}
+
+pub trait ToJson {
+  to_json(Self) -> Json
 }
 
 // Extension Methods

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -21,3 +21,46 @@ pub enum Json {
   Array(Array[Json])
   Object(Map[String, Json])
 } derive(Eq)
+
+/// Trait for types that can be converted to `Json`
+pub trait ToJson {
+  to_json(Self) -> Json
+}
+
+pub fn Bool::to_json(self : Bool) -> Json {
+  if self {
+    True
+  } else {
+    False
+  }
+}
+
+pub fn Int::to_json(self : Int) -> Json {
+  Number(self.to_double())
+}
+
+pub fn Int64::to_json(self : Int64) -> Json {
+  Number(self.to_double())
+}
+
+pub fn Double::to_json(self : Double) -> Json {
+  Number(self)
+}
+
+pub fn String::to_json(self : String) -> Json {
+  String(self)
+}
+
+pub fn Char::to_json(self : Char) -> Json {
+  String(self.to_string())
+}
+
+pub fn Array::to_json[X : ToJson](self : Array[X]) -> Json {
+  Array(self.map(ToJson::to_json))
+}
+
+pub fn Map::to_json[V : ToJson](self : Map[String, V]) -> Json {
+  let object = {  }
+  self.each(fn(k, v) { object[k] = v.to_json() })
+  Object(object)
+}

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -1,0 +1,82 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "Bool::to_json" {
+  inspect!(true.to_json(), content="True")
+  inspect!(false.to_json(), content="False")
+}
+
+test "Int::to_json" {
+  inspect!((42).to_json(), content="Number(42.0)")
+}
+
+test "Int64::to_json" {
+  inspect!(42L.to_json(), content="Number(42.0)")
+}
+
+test "Double::to_json" {
+  inspect!(42.0.to_json(), content="Number(42.0)")
+}
+
+test "String::to_json" {
+  inspect!(
+    "abc".to_json(),
+    content=
+      #|String("abc")
+    ,
+  )
+  inspect!(
+    "a,\"b\",c".to_json(),
+    content=
+      #|String("a,\"b\",c")
+    ,
+  )
+}
+
+test "Char::to_json" {
+  inspect!(
+    'a'.to_json(),
+    content=
+      #|String("a")
+    ,
+  )
+  inspect!(
+    '字'.to_json(),
+    content=
+      #|String("字")
+    ,
+  )
+}
+
+test "Array::to_json" {
+  inspect!(
+    [1, 2, 3].to_json(),
+    content="Array([Number(1.0), Number(2.0), Number(3.0)])",
+  )
+  inspect!(
+    [[], ["1"], ["1", "2"]].to_json(),
+    content=
+      #|Array([Array([]), Array([String("1")]), Array([String("1"), String("2")])])
+    ,
+  )
+}
+
+test "Map::to_json" {
+  inspect!(
+    { "x": [1], "y": [2] }.to_json(),
+    content=
+      #|Object({"x": Array([Number(1.0)]), "y": Array([Number(2.0)])})
+    ,
+  )
+}


### PR DESCRIPTION
- add `to_json` method to builtin types
- add `ToJson` trait, so that the compiler can automatically `derive(ToJson)` in the future