### PR TITLE
simplify code with method for trait object & cascade operator

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -492,6 +492,9 @@ impl Bytes {
   sub_string(Bytes, Int, Int) -> String
   to_string(Bytes) -> String
 }
+impl Logger {
+  write_object[Obj : Show](Self, Obj) -> Unit
+}
 impl Tuple {
   op_equal[T0 : Eq, T1 : Eq](Self[T0, T1], Self[T0, T1]) -> Bool
   to_string[A : Show, B : Show](Self[A, B]) -> String

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -351,9 +351,7 @@ pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
       if i > 0 {
         logger.write_string(", ")
       }
-      Show::output(key, logger)
-      logger.write_string(": ")
-      Show::output(value, logger)
+      logger..write_object(key)..write_string(": ").write_object(value)
       continue i + 1, self.list[idx].next
     }
   }

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -65,8 +65,7 @@ pub impl Show for String with output(self, logger) {
     match c {
       '"' | '\\' => {
         flush_segment(i)
-        logger.write_char('\\')
-        logger.write_char(c)
+        logger..write_char('\\').write_char(c)
       }
       '\n' => {
         flush_segment(i)
@@ -88,10 +87,11 @@ pub impl Show for String with output(self, logger) {
         let code = c.to_int()
         if code < 0x20 {
           flush_segment(i)
-          logger.write_char('\\')
-          logger.write_char('x')
-          logger.write_char(to_hex_digit(code / 16))
-          logger.write_char(to_hex_digit(code % 16))
+          logger
+          ..write_char('\\')
+          ..write_char('x')
+          ..write_char(to_hex_digit(code / 16))
+          .write_char(to_hex_digit(code % 16))
         }
       }
     }
@@ -113,33 +113,20 @@ pub fn escape(self : String) -> String {
 pub impl[X : Show] Show for X? with output(self, logger) {
   match self {
     None => logger.write_string("None")
-    Some(arg) => {
-      logger.write_string("Some(")
-      arg.output(logger)
-      logger.write_string(")")
-    }
+    Some(arg) =>
+      logger..write_string("Some(")..write_object(arg).write_string(")")
   }
 }
 
 pub impl[T : Show, E : Show] Show for Result[T, E] with output(self, logger) {
   match self {
-    Ok(x) => {
-      logger.write_string("Ok(")
-      x.output(logger)
-      logger.write_string(")")
-    }
-    Err(e) => {
-      logger.write_string("Err(")
-      e.output(logger)
-      logger.write_string(")")
-    }
+    Ok(x) => logger..write_string("Ok(")..write_object(x).write_string(")")
+    Err(e) => logger..write_string("Err(")..write_object(e).write_string(")")
   }
 }
 
 pub impl[X : Show] Show for Ref[X] with output(self, logger) {
-  logger.write_string("{val: ")
-  self.val.output(logger)
-  logger.write_string("}")
+  logger..write_string("{val: ")..write_object(self.val).write_string("}")
 }
 
 pub impl[X : Show] Show for FixedArray[X] with output(self, logger) {
@@ -194,10 +181,7 @@ pub impl Show for Char with output(self, logger) {
 
   logger.write_char('\'')
   match self {
-    '\'' | '\\' => {
-      logger.write_char('\\')
-      logger.write_char(self)
-    }
+    '\'' | '\\' => logger..write_char('\\').write_char(self)
     '\n' => logger.write_string("\\n")
     '\r' => logger.write_string("\\r")
     '\b' => logger.write_string("\\b")
@@ -205,10 +189,11 @@ pub impl Show for Char with output(self, logger) {
     _ => {
       let code = self.to_int()
       if code < 0x20 {
-        logger.write_char('\\')
-        logger.write_char('x')
-        logger.write_char(to_hex_digit(code / 16))
-        logger.write_char(to_hex_digit(code % 16))
+        logger
+        ..write_char('\\')
+        ..write_char('x')
+        ..write_char(to_hex_digit(code / 16))
+        .write_char(to_hex_digit(code % 16))
       } else {
         logger.write_char(self)
       }

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -78,3 +78,7 @@ impl Show with to_string(self) {
   self.output(logger)
   logger.to_string()
 }
+
+pub fn Logger::write_object[Obj : Show](self : Logger, obj : Obj) -> Unit {
+  obj.output(self)
+}

--- a/builtin/tuple_show.mbt
+++ b/builtin/tuple_show.mbt
@@ -14,11 +14,12 @@
 
 pub impl[A : Show, B : Show] Show for (A, B) with output(self, logger) {
   let (a, b) = self
-  logger.write_string("(")
-  a.output(logger)
-  logger.write_string(", ")
-  b.output(logger)
-  logger.write_string(")")
+  logger
+  ..write_string("(")
+  ..write_object(a)
+  ..write_string(", ")
+  ..write_object(b)
+  .write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show](self : (A, B)) -> String {
@@ -30,13 +31,14 @@ pub impl[A : Show, B : Show, C : Show] Show for (A, B, C) with output(
   logger
 ) {
   let (a, b, c) = self
-  logger.write_string("(")
-  a.output(logger)
-  logger.write_string(", ")
-  b.output(logger)
-  logger.write_string(", ")
-  c.output(logger)
-  logger.write_string(")")
+  logger
+  ..write_string("(")
+  ..write_object(a)
+  ..write_string(", ")
+  ..write_object(b)
+  ..write_string(", ")
+  ..write_object(c)
+  .write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show](self : (A, B, C)) -> String {
@@ -48,15 +50,16 @@ pub impl[A : Show, B : Show, C : Show, D : Show] Show for (A, B, C, D) with outp
   logger
 ) {
   let (a, b, c, d) = self
-  logger.write_string("(")
-  a.output(logger)
-  logger.write_string(", ")
-  b.output(logger)
-  logger.write_string(", ")
-  c.output(logger)
-  logger.write_string(", ")
-  d.output(logger)
-  logger.write_string(")")
+  logger
+  ..write_string("(")
+  ..write_object(a)
+  ..write_string(", ")
+  ..write_object(b)
+  ..write_string(", ")
+  ..write_object(c)
+  ..write_string(", ")
+  ..write_object(d)
+  .write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show](
@@ -73,17 +76,18 @@ pub impl[A : Show, B : Show, C : Show, D : Show, E : Show] Show for (
   E,
 ) with output(self, logger) {
   let (a, b, c, d, e) = self
-  logger.write_string("(")
-  a.output(logger)
-  logger.write_string(", ")
-  b.output(logger)
-  logger.write_string(", ")
-  c.output(logger)
-  logger.write_string(", ")
-  d.output(logger)
-  logger.write_string(", ")
-  e.output(logger)
-  logger.write_string(")")
+  logger
+  ..write_string("(")
+  ..write_object(a)
+  ..write_string(", ")
+  ..write_object(b)
+  ..write_string(", ")
+  ..write_object(c)
+  ..write_string(", ")
+  ..write_object(d)
+  ..write_string(", ")
+  ..write_object(e)
+  .write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show](
@@ -101,19 +105,20 @@ pub impl[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Show for (
   F,
 ) with output(self, logger) {
   let (a, b, c, d, e, f) = self
-  logger.write_string("(")
-  a.output(logger)
-  logger.write_string(", ")
-  b.output(logger)
-  logger.write_string(", ")
-  c.output(logger)
-  logger.write_string(", ")
-  d.output(logger)
-  logger.write_string(", ")
-  e.output(logger)
-  logger.write_string(", ")
-  f.output(logger)
-  logger.write_string(")")
+  logger
+  ..write_string("(")
+  ..write_object(a)
+  ..write_string(", ")
+  ..write_object(b)
+  ..write_string(", ")
+  ..write_object(c)
+  ..write_string(", ")
+  ..write_object(d)
+  ..write_string(", ")
+  ..write_object(e)
+  ..write_string(", ")
+  ..write_object(f)
+  .write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show](
@@ -132,21 +137,22 @@ pub impl[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show] S
   G,
 ) with output(self, logger) {
   let (a, b, c, d, e, f, g) = self
-  logger.write_string("(")
-  a.output(logger)
-  logger.write_string(", ")
-  b.output(logger)
-  logger.write_string(", ")
-  c.output(logger)
-  logger.write_string(", ")
-  d.output(logger)
-  logger.write_string(", ")
-  e.output(logger)
-  logger.write_string(", ")
-  f.output(logger)
-  logger.write_string(", ")
-  g.output(logger)
-  logger.write_string(")")
+  logger
+  ..write_string("(")
+  ..write_object(a)
+  ..write_string(", ")
+  ..write_object(b)
+  ..write_string(", ")
+  ..write_object(c)
+  ..write_string(", ")
+  ..write_object(d)
+  ..write_string(", ")
+  ..write_object(e)
+  ..write_string(", ")
+  ..write_object(f)
+  ..write_string(", ")
+  ..write_object(g)
+  .write_string(")")
 }
 
 pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show](

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -115,11 +115,12 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
       if i > 0 {
         logger.write_string(", ")
       }
-      logger.write_string("(")
-      Show::output(k, logger)
-      logger.write_string(", ")
-      Show::output(v, logger)
-      logger.write_string(")")
+      logger
+      ..write_string("(")
+      ..write_object(k)
+      ..write_string(", ")
+      ..write_object(v)
+      .write_string(")")
     },
   )
   logger.write_string("])")

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -225,11 +225,12 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
       } else {
         logger.write_string(", ")
       }
-      logger.write_string("(")
-      k.output(logger)
-      logger.write_string(", ")
-      v.output(logger)
-      logger.write_string(")")
+      logger
+      ..write_string("(")
+      ..write_object(k)
+      ..write_string(", ")
+      ..write_object(v)
+      .write_string(")")
     },
   )
   logger.write_string("])")

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -64,11 +64,12 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
       if i > 0 {
         logger.write_string(", ")
       }
-      logger.write_string("(")
-      Show::output(k, logger)
-      logger.write_string(", ")
-      Show::output(v, logger)
-      logger.write_string(")")
+      logger
+      ..write_string("(")
+      ..write_object(k)
+      ..write_string(", ")
+      ..write_object(v)
+      .write_string(")")
     },
   )
   logger.write_string("])")


### PR DESCRIPTION
- add `Logger::write_object` method to trait object type `Logger`
- using this method, many `Show` implementation can be simplified using cascade method call