### PR TITLE
feat: add `Iter::map_while`

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -190,6 +190,7 @@ impl Iter {
   fold[T, B](Self[T], ~init : B, (B, T) -> B) -> B
   iter[T](Self[T]) -> Self[T]
   map[T, R](Self[T], (T) -> R) -> Self[R]
+  map_while[A, B](Self[A], (A) -> B?) -> Self[B]
   new[T](((T) -> IterResult) -> IterResult) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
   prepend[T](Self[T], T) -> Self[T]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -469,6 +469,29 @@ pub fn take_while[T](self : Iter[T], f : (T) -> Bool) -> Iter[T] {
   }
 }
 
+/// Transforms the elements of the iterator using a mapping function until the function returns `None`.
+pub fn map_while[A, B](self : Iter[A], f : (A) -> B?) -> Iter[B] {
+  fn(yield) {
+    let mut r : IterResult = IterContinue
+    self.run(
+      fn(a) {
+        match f(a) {
+          Some(b) =>
+            if yield(b) == IterContinue {
+              IterContinue
+            } else {
+              r = IterEnd
+              IterEnd
+            }
+          None => IterEnd
+        }
+      },
+    )
+    |> ignore
+    r
+  }
+}
+
 /// Skips the first `n` elements from the iterator.
 ///
 /// # Type Parameters

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -99,6 +99,52 @@ test "take_while5" {
   inspect!(res, content="0")
 }
 
+test "map_while1" {
+  let iter = test_from_array([1, 2, 3, 4, 5])
+  let exb = Buffer::new(size_hint=0)
+  iter
+  .map_while(fn { x => if x != 4 { Some(x) } else { None } })
+  .each(fn { x => exb.write_string("\{x}\n") })
+  exb.expect!(content="1\n2\n3\n")
+}
+
+test "map_while2" {
+  let iter = test_from_array([1, 2, 3, 4, 5])
+  let exb = Buffer::new(size_hint=0)
+  iter
+  .map_while(fn { x => if x != 4 { Some(x) } else { None } })
+  .concat(singleton(6))
+  .each(fn { x => exb.write_string("\{x}\n") })
+  exb.expect!(content="1\n2\n3\n6\n")
+}
+
+test "map_while3" {
+  let iter = test_from_array([1, 2, 3])
+  let res = iter
+    .map_while(fn { x => if x != 4 { Some(x) } else { None } })
+    .concat(singleton(4))
+    .find_first(fn { x => x % 2 == 0 })
+  inspect!(res, content="Some(2)")
+}
+
+test "map_while4" {
+  let iter = test_from_array([1, 2, 3, 4, 5, 6])
+  let res = iter
+    .map_while(fn { x => if x <= 5 { Some(x) } else { None } })
+    .take(4)
+    .fold(init=0, fn(x, y) { x + y })
+  inspect!(res, content="10")
+}
+
+test "map_while5" {
+  let iter = test_from_array([1, 2, 3, 4, 5, 6])
+  let res = iter
+    .take(4)
+    .map_while(fn { x => if x >= 5 { Some(x) } else { None } })
+    .fold(fn(x, y) { x + y }, init=0)
+  inspect!(res, content="0")
+}
+
 test "drop" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = Buffer::new(size_hint=0)


### PR DESCRIPTION
Introduces `map_while`, an iterator that maps elements and continues while a predicate returns `Some(_)`, stopping at the first `None`. 
This method simplifies the process by removing the need to call `Option::unwrap`.
