### PR TITLE
add: a new method String::rev()

### DIFF
--- a/string/string.mbt
+++ b/string/string.mbt
@@ -441,3 +441,14 @@ pub fn to_upper(self : String) -> String {
   }
   buf.to_string()
 }
+
+/// Reverse string
+pub fn reverse(self : String) -> String {
+  // TODO: deal with non-ascii characters
+  let mut result : String = ""
+  let len = self.length()
+  for i = len - 1; i >= 0; i = i - 1 {
+    result = result + self[i].to_string()
+  }
+  result
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -443,7 +443,7 @@ pub fn to_upper(self : String) -> String {
 }
 
 /// Reverse string
-pub fn reverse(self : String) -> String {
+pub fn rev(self : String) -> String {
   // TODO: deal with non-ascii characters
   let mut result : String = ""
   let len = self.length()

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -16,7 +16,7 @@ impl String {
   last_index_of(String, String, ~from : Int = ..) -> Int
   replace(String, ~old : String, ~new : String) -> String
   replace_all(String, ~old : String, ~new : String) -> String
-  reverse(String) -> String
+  rev(String) -> String
   split(String, String) -> Iter[String]
   starts_with(String, String) -> Bool
   substring(String, ~start : Int = .., ~end : Int = ..) -> String

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -16,6 +16,7 @@ impl String {
   last_index_of(String, String, ~from : Int = ..) -> Int
   replace(String, ~old : String, ~new : String) -> String
   replace_all(String, ~old : String, ~new : String) -> String
+  reverse(String) -> String
   split(String, String) -> Iter[String]
   starts_with(String, String) -> Bool
   substring(String, ~start : Int = .., ~end : Int = ..) -> String

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -348,6 +348,12 @@ test "replace_all" {
   )
 }
 
+test "reverse" {
+  inspect!("hello".reverse(), content="olleh")
+  inspect!("Nothing".reverse(), content="gnihtoN")
+  inspect!("< >".reverse(), content="> <")
+}
+
 test "to_lower" {
   inspect!("ABCXYZ".to_lower(), content="abcxyz")
   inspect!("aBcXyZ".to_lower(), content="abcxyz")

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -349,9 +349,9 @@ test "replace_all" {
 }
 
 test "reverse" {
-  inspect!("hello".reverse(), content="olleh")
-  inspect!("Nothing".reverse(), content="gnihtoN")
-  inspect!("< >".reverse(), content="> <")
+  inspect!("hello".rev(), content="olleh")
+  inspect!("Nothing".rev(), content="gnihtoN")
+  inspect!("< >".rev(), content="> <")
 }
 
 test "to_lower" {


### PR DESCRIPTION
I have added a `reverse()` method to `String`. 

I think the reverse() method has some good points. First, it makes the String class more useful and easier to work with. It makes reversing a string simple, which is needed often in programming.   
I have tested it in my computer. I can run correctly.
And you can using it like this:
```
fn main {
  let x: String = "hello world";
  println(x.reverse())
}
```
It will display `dlrow olleh`