### PR TITLE
clean up functions in bool, int, int64 packages

### DIFF
--- a/bool/bool.mbt
+++ b/bool/bool.mbt
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub trait Boolean {
-  to_bool(Self) -> Bool
-}
-
-pub fn Bool::to_bool(self : Bool) -> Bool {
-  self
-}
-
 pub fn to_int(self : Bool) -> Int {
   if self {
     1

--- a/bool/bool.mbti
+++ b/bool/bool.mbti
@@ -4,7 +4,6 @@ package moonbitlang/core/bool
 
 // Types and methods
 impl Bool {
-  to_bool(Bool) -> Bool
   to_int(Bool) -> Int
   to_int64(Bool) -> Int64
 }
@@ -12,9 +11,6 @@ impl Bool {
 // Type aliases
 
 // Traits
-pub trait Boolean {
-  to_bool(Self) -> Bool
-}
 
 // Extension Methods
 impl Hash for Bool

--- a/bool/bool_test.mbt
+++ b/bool/bool_test.mbt
@@ -28,8 +28,3 @@ test {
   m[{ flag: false, x: 1 }] = '3'
   inspect!(m, content="{{flag: true, x: 1}: '3', {flag: false, x: 1}: '3'}")
 }
-
-test "to_bool" {
-  inspect!(true.to_bool(), content="true")
-  inspect!(false.to_bool(), content="false")
-}

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -16,25 +16,11 @@ let max_val = 2147483647
 
 let min_val = -2147483648
 
-pub fn Int::from_int(i : Int) -> Int {
-  i
-}
-
 pub fn abs(self : Int) -> Int {
   if self < 0 {
     -self
   } else {
     self
-  }
-}
-
-pub fn signum(self : Int) -> Int {
-  if self < 0 {
-    -1
-  } else if self > 0 {
-    1
-  } else {
-    0
   }
 }
 

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -35,4 +35,3 @@ pub fn Int::max_value() -> Int {
 pub fn Int::min_value() -> Int {
   min
 }
-

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let max_val = 2147483647
+pub let max = 2147483647
 
-let min_val = -2147483648
+pub let min = -2147483648
 
 pub fn abs(self : Int) -> Int {
   if self < 0 {
@@ -24,12 +24,15 @@ pub fn abs(self : Int) -> Int {
   }
 }
 
-// Returns the largest positive finite value of Int
+/// Returns the largest positive finite value of Int
+/// @alert deprecated "Use `@int.max` instead"
 pub fn Int::max_value() -> Int {
-  max_val
+  max
 }
 
-// Returns the smallest positive nonzero value of Int
+/// Returns the smallest positive nonzero value of Int
+/// @alert deprecated "Use `@int.min` instead"
 pub fn Int::min_value() -> Int {
-  min_val
+  min
 }
+

--- a/int/int.mbti
+++ b/int/int.mbti
@@ -1,6 +1,9 @@
 package moonbitlang/core/int
 
 // Values
+let max : Int
+
+let min : Int
 
 // Types and methods
 impl Int {

--- a/int/int.mbti
+++ b/int/int.mbti
@@ -5,10 +5,8 @@ package moonbitlang/core/int
 // Types and methods
 impl Int {
   abs(Int) -> Int
-  from_int(Int) -> Int
   max_value() -> Int
   min_value() -> Int
-  signum(Int) -> Int
 }
 
 // Type aliases

--- a/int/int_test.mbt
+++ b/int/int_test.mbt
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-test "fromint" {
-  inspect!(@int.from_int(3), content="3")
-  inspect!(@int.signum(3), content="1")
-  inspect!(@int.signum(-3), content="-1")
-  inspect!(@int.signum(0), content="0")
-}
-
 test "overflow" {
   // signed integer expected to be negative
   inspect!(0xC2B2AE3D, content="-1028477379")

--- a/int/int_test.mbt
+++ b/int/int_test.mbt
@@ -43,6 +43,6 @@ test "abs function coverage" {
   assert_eq!(Int::abs(5), 5)
   assert_eq!(Int::abs(-5), 5)
   assert_eq!(Int::abs(0), 0)
-  assert_eq!(Int::abs(Int::min_value()), Int::min_value().abs())
-  assert_eq!(Int::abs(Int::max_value()), Int::max_value())
+  assert_eq!(Int::abs(@int.min), @int.min.abs())
+  assert_eq!(Int::abs(@int.max), @int.max)
 }

--- a/int64/int64.mbt
+++ b/int64/int64.mbt
@@ -39,4 +39,3 @@ pub fn Int64::max_value() -> Int64 {
 pub fn Int64::min_value() -> Int64 {
   min
 }
-

--- a/int64/int64.mbt
+++ b/int64/int64.mbt
@@ -28,16 +28,6 @@ pub fn abs(self : Int64) -> Int64 {
   }
 }
 
-pub fn signum(self : Int64) -> Int64 {
-  if self < 0L {
-    -1L
-  } else if self > 0L {
-    1L
-  } else {
-    0L
-  }
-}
-
 // Returns the largest positive finite value of Int64
 pub fn Int64::max_value() -> Int64 {
   max_val

--- a/int64/int64.mbt
+++ b/int64/int64.mbt
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let max_val = 9223372036854775807L
+pub let max = 9223372036854775807L
 
-let min_val = -9223372036854775808L
+pub let min = -9223372036854775808L
 
 pub fn Int64::from_int(i : Int) -> Int64 {
   i.to_int64()
@@ -28,12 +28,15 @@ pub fn abs(self : Int64) -> Int64 {
   }
 }
 
-// Returns the largest positive finite value of Int64
+/// Returns the largest positive finite value of Int64
+/// @alert deprecated "Use `@int64.max` instead"
 pub fn Int64::max_value() -> Int64 {
-  max_val
+  max
 }
 
-// Returns the smallest positive nonzero value of Int64
+/// Returns the smallest positive nonzero value of Int64
+/// @alert deprecated "Use `@int64.min` instead"
 pub fn Int64::min_value() -> Int64 {
-  min_val
+  min
 }
+

--- a/int64/int64.mbti
+++ b/int64/int64.mbti
@@ -8,7 +8,6 @@ impl Int64 {
   from_int(Int) -> Int64
   max_value() -> Int64
   min_value() -> Int64
-  signum(Int64) -> Int64
 }
 
 // Type aliases

--- a/int64/int64.mbti
+++ b/int64/int64.mbti
@@ -1,6 +1,9 @@
 package moonbitlang/core/int64
 
 // Values
+let max : Int64
+
+let min : Int64
 
 // Types and methods
 impl Int64 {

--- a/int64/int64_test.mbt
+++ b/int64/int64_test.mbt
@@ -19,15 +19,6 @@ test "overflow" {
   inspect!(-0x7fffffffffffffffL, content="-9223372036854775807")
 }
 
-test "signum function tests" {
-  // Test for signum function
-  inspect!(@int64.signum(0L), content="0")
-  inspect!(@int64.signum(1L), content="1")
-  inspect!(@int64.signum(-1L), content="-1")
-  inspect!(@int64.signum(Int64::max_value()), content="1")
-  inspect!(@int64.signum(Int64::min_value()), content="-1")
-}
-
 test "Int64::min_value" {
   let min_value = Int64::min_value()
   assert_eq!(min_value, -9223372036854775808L)

--- a/int64/int64_test.mbt
+++ b/int64/int64_test.mbt
@@ -20,7 +20,7 @@ test "overflow" {
 }
 
 test "Int64::min_value" {
-  let min_value = Int64::min_value()
+  let min_value = @int64.min
   assert_eq!(min_value, -9223372036854775808L)
 }
 

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -174,7 +174,7 @@ pub fn T::from_double(value : Double) -> T!RationalError {
   let mut d0 = 1L
   let mut n1 = 1L
   let mut d1 = 0L
-  let t_max = Int64::max_value()
+  let t_max = @int64.max
   let t_max_f = t_max.to_double()
   let epsilon = 1.0 / t_max_f
   let max_iteration = 30


### PR DESCRIPTION
- add `max` `min` constants to `int` `int64` packages, mark `max_value()` `min_value()` functions deprecated
- remove unused Boolean trait and methods of Num trait