### PR TITLE
add to_unchecked_string, deprecate old APIs

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -64,9 +64,19 @@ pub fn is_empty(self : Buffer) -> Bool {
 }
 
 ///|
-/// Return a new String contains the data in buffer.
+/// Return a new string contains the data in buffer.
+/// 
+/// @alert deprecated "Use `Buffer::to_unchecked_string` instead"
 pub fn to_string(self : Buffer) -> String {
   self.bytes.sub_string(0, self.len)
+}
+
+///|
+/// Return a new unchecked string contains the data in buffer.
+/// Note this function does not validate the encoding of the byte sequence, 
+/// it simply copy the bytes into a new String.
+pub fn to_unchecked_string(self : Buffer) -> String {
+  self.bytes.to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -68,7 +68,7 @@ pub fn is_empty(self : Buffer) -> Bool {
 /// 
 /// @alert deprecated "Use `Buffer::to_unchecked_string` instead"
 pub fn to_string(self : Buffer) -> String {
-  self.bytes.sub_string(0, self.len)
+  self.bytes.to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|
@@ -163,5 +163,5 @@ pub fn to_bytes(self : Buffer) -> Bytes {
 
 ///|
 pub impl Show for Buffer with output(self, logger) {
-  logger.write_string(self.to_string())
+  logger.write_string(self.to_unchecked_string())
 }

--- a/buffer/buffer.mbti
+++ b/buffer/buffer.mbti
@@ -10,7 +10,8 @@ impl Buffer {
   new(~size_hint : Int = ..) -> Self
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes
-  to_string(Self) -> String
+  to_string(Self) -> String //deprecated
+  to_unchecked_string(Self) -> String
   write_byte(Self, Byte) -> Unit
   write_bytes(Self, Bytes) -> Unit
   write_char(Self, Char) -> Unit

--- a/builtin/buffer.mbt
+++ b/builtin/buffer.mbt
@@ -54,7 +54,7 @@ fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
 ///|
 /// Return a new String contains the data in buffer.
 pub fn to_string(self : Buffer) -> String {
-  self.bytes.sub_string(0, self.len)
+  self.bytes.to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -679,8 +679,9 @@ impl Bytes {
   op_set(Bytes, Int, Byte) -> Unit
   set_utf16_char(Bytes, Int, Char) -> Int
   set_utf8_char(Bytes, Int, Char) -> Int
-  sub_string(Bytes, Int, Int) -> String
-  to_string(Bytes) -> String
+  sub_string(Bytes, Int, Int) -> String //deprecated
+  to_string(Bytes) -> String //deprecated
+  to_unchecked_string(Bytes, ~offset : Int = .., ~length : Int = ..) -> String
 }
 
 

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -13,12 +13,6 @@
 // limitations under the License.
 
 ///|
-/// Create a new String from byte sequence.
-pub fn to_string(self : Bytes) -> String {
-  self.sub_string(0, self.length())
-}
-
-///|
 /// Create byte sequence from String.
 pub fn Bytes::of_string(str : String) -> Bytes {
   Bytes::new(str.length() * 2)..blit_from_string(0, str, 0, str.length())
@@ -27,18 +21,43 @@ pub fn Bytes::of_string(str : String) -> Bytes {
 ///|
 /// TODO: support local primitive declaration
 fn unsafe_sub_string(
-  self : Bytes,
+  bytes : Bytes,
   byte_offset : Int,
   byte_length : Int
 ) -> String = "$moonbit.unsafe_bytes_sub_string"
 
 ///|
-/// Return a new String, containing the subsequence of `self` that
+/// Return a new unchecked string, containing the subsequence of `self` that
 /// starts at `byte_offset` and has length `byte_length`.
+/// 
+/// @alert deprecated "Use `to_unchecked_string` instead"
 pub fn sub_string(self : Bytes, byte_offset : Int, byte_length : Int) -> String {
+  self.to_unchecked_string(offset=byte_offset, length=byte_length)
+}
+
+///|
+/// Create a new unchecked string from byte sequence.
+/// 
+/// @alert deprecated "Use `to_unchecked_string` instead"
+pub fn to_string(self : Bytes) -> String {
+  self.to_unchecked_string(offset=0, length=self.length())
+}
+
+///|
+/// Return an unchecked string, containing the subsequence of `self` that starts at 
+/// `offset` and has length `length`. Both `offset` and `length` 
+/// are indexed by byte.
+/// 
+/// Note this function does not validate the encoding of the byte sequence, 
+/// it simply copy the bytes into a new String.
+pub fn to_unchecked_string(
+  self : Bytes,
+  ~offset : Int = 0,
+  ~length : Int = self.length() - offset
+) -> String {
   let len = self.length()
-  guard byte_offset >= 0 && byte_length >= 0 && byte_offset + byte_length <= len
-  unsafe_sub_string(self, byte_offset, byte_length)
+  guard offset >= 0 && length >= 0 && offset + length <= len
+  unsafe_sub_string(self, offset, length)
 }
 
 ///|

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -14,7 +14,7 @@
 
 test "to_string" {
   let bytes = Bytes::of_string("Hello, World!")
-  assert_eq!(bytes.to_string(), "Hello, World!")
+  assert_eq!(bytes.to_unchecked_string(), "Hello, World!")
 }
 
 test "of_string" {
@@ -25,7 +25,7 @@ test "of_string" {
 
 test "sub_string" {
   let bytes = Bytes::of_string("Hello, World!")
-  assert_eq!(bytes.sub_string(0, 5 * 2), "Hello")
+  assert_eq!(bytes.to_unchecked_string(offset=0, length=5 * 2), "Hello")
   // assert_eq(bytes.sub_string(10, 5 * 2), "World")?
 }
 
@@ -33,13 +33,13 @@ test "blit_from_string" {
   let bytes = Bytes::new(10)
   let str = "Hello"
   bytes.blit_from_string(0, str, 0, str.length())
-  assert_eq!(bytes.sub_string(0, str.length() * 2), str)
+  assert_eq!(bytes.to_unchecked_string(offset=0, length=str.length() * 2), str)
 }
 
 test "copy" {
   let bytes = Bytes::of_string("Hello, World!")
   let copy_bytes = bytes.copy()
-  assert_eq!(copy_bytes.to_string(), bytes.to_string())
+  assert_eq!(copy_bytes.to_unchecked_string(), bytes.to_unchecked_string())
 }
 
 test "set_utf8_char" {
@@ -48,8 +48,8 @@ test "set_utf8_char" {
   let len = bytes.set_utf8_char(0, char)
   assert_eq!(len, 1)
   // FIXME: inconsistency between wasm-gc & js
-  bytes.sub_string(0, 1) |> ignore
-  inspect!(bytes.sub_string(0, 2), content="A")
+  bytes.to_unchecked_string(offset=0, length=1) |> ignore
+  inspect!(bytes.to_unchecked_string(offset=0, length=2), content="A")
 }
 
 test "set_utf16_char" {
@@ -57,7 +57,7 @@ test "set_utf16_char" {
   let char = 'A'
   let len = bytes.set_utf16_char(0, char)
   assert_eq!(len, 2)
-  assert_eq!(bytes.sub_string(0, 2), "A")
+  assert_eq!(bytes.to_unchecked_string(offset=0, length=2), "A")
 }
 
 test "op_equal" {

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -236,17 +236,17 @@ test "panic blit_out_of_bounds_dst" {
 
 test "panic sub_string with invalid byte_length" {
   let bytes = Bytes::of_string("Hello, World!")
-  bytes.sub_string(0, -1) |> ignore
+  bytes.to_unchecked_string(offset=0, length=-1) |> ignore
 }
 
 test "panic sub_string with invalid byte_offset" {
   let bytes = Bytes::of_string("Hello, World!")
-  bytes.sub_string(-1, 5) |> ignore
+  bytes.to_unchecked_string(offset=-1, length=5) |> ignore
 }
 
 test "panic sub_string with invalid byte_offset + byte_length" {
   let bytes = Bytes::of_string("Hello, World!")
-  bytes.sub_string(0, bytes.length() + 1) |> ignore
+  bytes.to_unchecked_string(offset=0, length=bytes.length() + 1) |> ignore
 }
 
 test "panic blit_from_string with invalid length" {

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -192,8 +192,8 @@ pub fn ArrayView::to_string[X : Show](self : ArrayView[X]) -> String {
 /// @intrinsic %char.to_string
 pub fn to_string(self : Char) -> String {
   let bytes = Bytes::new(4)
-  let len = bytes.set_utf16_char(0, self)
-  bytes.sub_string(0, len)
+  let length = bytes.set_utf16_char(0, self)
+  bytes.to_unchecked_string(offset=0, ~length)
 }
 
 ///|

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -18,7 +18,7 @@ fn unsafe_substring(str : String, start : Int, end : Int) -> String {
   let len = end - start
   let bytes = Bytes::new(len * 2)
   bytes.blit_from_string(0, str, start, len)
-  bytes.sub_string(0, bytes.length())
+  bytes.to_unchecked_string(offset=0, length=bytes.length())
 }
 
 ///|

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -73,13 +73,13 @@ pub fn StringBuilder::write_substring(
 
 ///|
 pub fn StringBuilder::to_string(self : StringBuilder) -> String {
-  self.bytes.sub_string(0, self.len)
+  self.bytes.to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|
 /// TODO: improve perf
 pub impl Show for StringBuilder with output(self, logger) {
-  logger.write_string(self.bytes.sub_string(0, self.len))
+  logger.write_string(self.bytes.to_unchecked_string(offset=0, length=self.len))
 }
 
 ///|

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -40,10 +40,10 @@ test "compare" {
 }
 
 test "to_bytes" {
-  assert_eq!("中文".to_bytes().to_string(), "中文")
-  assert_eq!("asdf".to_bytes().to_string(), "asdf")
-  assert_eq!("🤣🤣".to_bytes().to_string(), "🤣🤣")
-  assert_eq!("🤔".to_bytes().to_string(), "🤔")
+  assert_eq!("中文".to_bytes().to_unchecked_string(), "中文")
+  assert_eq!("asdf".to_bytes().to_unchecked_string(), "asdf")
+  assert_eq!("🤣🤣".to_bytes().to_unchecked_string(), "🤣🤣")
+  assert_eq!("🤔".to_bytes().to_unchecked_string(), "🤔")
 }
 
 test "Show::output" {


### PR DESCRIPTION
- add `to_unchecked_string(~offset,~length)` to Bytes 
- add `to_unchecked_string` to Buffer
- deprecate `Bytes::to_string` `Bytes::sub_string` `Buffer::to_string`