### PR TITLE
add double constants

### DIFF
--- a/double/double.mbt
+++ b/double/double.mbt
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let not_a_number : Double = 0x7FF8000000000001L.reinterpret_as_double()
+pub let not_a_number : Double = 0.0 / 0.0
 
-let positive_infinity : Double = 0x7FF0000000000000L.reinterpret_as_double()
+pub let infinity : Double = 1.0 / 0.0
 
-let negative_infinity : Double = 0xFFF0000000000000L.reinterpret_as_double()
+pub let neg_infinity : Double = -1.0 / 0.0
 
-let max_val : Double = 0x7FEFFFFFFFFFFFFFL.reinterpret_as_double()
+pub let max : Double = 1.7976931348623157e+308
 
-let min_val : Double = 0x1L.reinterpret_as_double()
+pub let min : Double = -1.7976931348623157e+308
 
-let min_norm : Double = 0x0010000000000000L.reinterpret_as_double()
+pub let min_positive : Double = 2.2250738585072014e-308
 
 let sign_mask : Int64 = 0x8000_0000_0000_0000L
 
@@ -163,32 +163,37 @@ pub fn signum(self : Double) -> Double {
 }
 
 // Returns a "not-a-number" value
+/// @alert deprecated "Use `@double.not_a_number` instead"
 pub fn Double::nan() -> Double {
   not_a_number
 }
 
 // Returns positive infinity if sign >= 0, negative infinity if sign < 0.
+/// @alert deprecated "Use `@double.infinity` and `@double.neg_infinity` instead"
 pub fn Double::inf(sign : Int) -> Double {
   if sign >= 0 {
-    positive_infinity
+    infinity
   } else {
-    negative_infinity
+    neg_infinity
   }
 }
 
 // Returns the largest positive finite value of Double
+/// @alert deprecated "Use `@double.max` instead"
 pub fn Double::max_value() -> Double {
-  max_val
+  max
 }
 
 // Returns the smallest positive nonzero value of Double
+/// @alert deprecated "Use `@double.min` instead"
 pub fn Double::min_value() -> Double {
-  min_val
+  min
 }
 
 // Returns the smallest positive normal value of Double
+/// @alert deprecated "Use `@double.min_positive` instead"
 pub fn Double::min_normal() -> Double {
-  min_norm
+  min_positive
 }
 
 // Check whether the double is a "not-a-number" value
@@ -199,17 +204,17 @@ pub fn is_nan(self : Double) -> Bool {
 
 // Check whether the double is infinity
 pub fn is_inf(self : Double) -> Bool {
-  self > max_val || self < -max_val
+  self > max || self < min
 }
 
 // Check whether the double is positive infinity
 pub fn is_pos_inf(self : Double) -> Bool {
-  self > max_val
+  self > max
 }
 
 // Check whether the double is negative infinity
 pub fn is_neg_inf(self : Double) -> Bool {
-  self < -max_val
+  self < min
 }
 
 test "from_int" {
@@ -236,51 +241,29 @@ test "is_nan" {
   assert_true!(is_nan(not_a_number))
   assert_false!(is_nan(0.0))
   assert_false!(is_nan(12345.678))
-  assert_false!(is_nan(positive_infinity))
-  assert_false!(is_nan(negative_infinity))
+  assert_false!(is_nan(infinity))
+  assert_false!(is_nan(neg_infinity))
 }
 
 test "is_inf" {
-  assert_true!(is_inf(positive_infinity))
-  assert_true!(is_inf(negative_infinity))
+  assert_true!(is_inf(infinity))
+  assert_true!(is_inf(neg_infinity))
   assert_false!(is_inf(0.0))
   assert_false!(is_inf(12345.678))
 }
 
 test "is_pos_inf" {
-  assert_true!(is_pos_inf(positive_infinity))
-  assert_false!(is_pos_inf(negative_infinity))
+  assert_true!(is_pos_inf(infinity))
+  assert_false!(is_pos_inf(neg_infinity))
   assert_false!(is_pos_inf(0.0))
   assert_false!(is_pos_inf(12345.678))
 }
 
 test "is_neg_inf" {
-  assert_false!(is_neg_inf(positive_infinity))
-  assert_true!(is_neg_inf(negative_infinity))
+  assert_false!(is_neg_inf(infinity))
+  assert_true!(is_neg_inf(neg_infinity))
   assert_false!(is_neg_inf(0.0))
   assert_false!(is_neg_inf(12345.678))
-}
-
-test "nan" {
-  assert_true!(Double::nan().is_nan())
-}
-
-test "inf" {
-  assert_eq!(Double::inf(1), positive_infinity)
-  assert_eq!(Double::inf(0), positive_infinity)
-  assert_eq!(Double::inf(-1), negative_infinity)
-}
-
-test "max_value" {
-  assert_eq!(Double::max_value(), max_val)
-}
-
-test "min_value" {
-  assert_eq!(Double::min_value(), min_val)
-}
-
-test "min_normal" {
-  assert_eq!(Double::min_normal(), min_norm)
 }
 
 pub impl Hash for Double with hash(self) {

--- a/double/double.mbt
+++ b/double/double.mbt
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub let not_a_number : Double = 0.0 / 0.0
+pub let not_a_number : Double = 0x7FF8000000000001L.reinterpret_as_double()
 
-pub let infinity : Double = 1.0 / 0.0
+pub let infinity : Double = 0x7FF0000000000000L.reinterpret_as_double()
 
-pub let neg_infinity : Double = -1.0 / 0.0
+pub let neg_infinity : Double = 0xFFF0000000000000L.reinterpret_as_double()
 
-pub let max : Double = 1.7976931348623157e+308
+pub let max : Double = 0x7FEFFFFFFFFFFFFFL.reinterpret_as_double()
 
-pub let min : Double = -1.7976931348623157e+308
+pub let min : Double = 0xFFEFFFFFFFFFFFFFL.reinterpret_as_double()
 
-pub let min_positive : Double = 2.2250738585072014e-308
+pub let min_positive : Double = 0x0010000000000000L.reinterpret_as_double()
 
 let sign_mask : Int64 = 0x8000_0000_0000_0000L
 
@@ -264,6 +264,10 @@ test "is_neg_inf" {
   assert_true!(is_neg_inf(neg_infinity))
   assert_false!(is_neg_inf(0.0))
   assert_false!(is_neg_inf(12345.678))
+}
+
+test "min equal to neg max" {
+  assert_true!(min == -max)
 }
 
 pub impl Hash for Double with hash(self) {

--- a/double/double.mbti
+++ b/double/double.mbti
@@ -1,6 +1,17 @@
 package moonbitlang/core/double
 
 // Values
+let infinity : Double
+
+let max : Double
+
+let min : Double
+
+let min_positive : Double
+
+let neg_infinity : Double
+
+let not_a_number : Double
 
 // Types and methods
 impl Double {

--- a/double/exp_test.mbt
+++ b/double/exp_test.mbt
@@ -30,9 +30,9 @@ test "exp" {
 }
 
 test "exp - special values" {
-  inspect!(@double.exp(Double::inf(-1)), content="0.0")
-  inspect!(@double.exp(Double::inf(1)), content="Infinity")
-  inspect!(@double.exp(Double::nan()), content="NaN")
+  inspect!(@double.exp(@double.neg_infinity), content="0.0")
+  inspect!(@double.exp(@double.infinity), content="Infinity")
+  inspect!(@double.exp(@double.not_a_number), content="NaN")
   inspect!(@double.exp(0.0), content="1.0")
 }
 

--- a/double/log.mbt
+++ b/double/log.mbt
@@ -39,7 +39,7 @@ let l6 = 1.531383769920937332e-01 // 3FC39A09 D078C69F
 let l7 = 1.479819860511658591e-01 // 3FC2F112 DF3E5244
 
 fn normalize(f : Double) -> (Double, Int) {
-  if f.abs() < Double::min_normal() {
+  if f.abs() < min_positive {
     return (f * 1L.lsl(52).to_double(), -52)
   }
   (f, 0)
@@ -63,9 +63,9 @@ pub fn ln(self : Double) -> Double {
   if self.is_nan() || self.is_inf() {
     return self
   } else if self < 0.0 {
-    return Double::nan()
+    return not_a_number
   } else if self == 0.0 {
-    return Double::inf(-1)
+    return neg_infinity
   }
   let (f1, ki) = frexp(self)
   let (f, k) = if f1 < sqrt2 / 2.0 {
@@ -110,9 +110,9 @@ test "log2 log10" {
 }
 
 test "ln" {
-  assert_true!(Double::nan().ln().is_nan())
-  assert_true!(Double::inf(1).ln().is_pos_inf())
-  assert_true!(Double::inf(-1).ln().is_neg_inf())
+  assert_true!(not_a_number.ln().is_nan())
+  assert_true!(infinity.ln().is_pos_inf())
+  assert_true!(neg_infinity.ln().is_neg_inf())
   assert_true!((-1.0).ln().is_nan())
   assert_true!(0.0.ln().is_neg_inf())
   assert_true!((-0.0).ln().is_neg_inf())
@@ -127,13 +127,13 @@ test "ln" {
     },
   )
   assert_true!(
-    match frexp(Double::inf(1)) {
+    match frexp(infinity) {
       (f, 0) => if f.is_pos_inf() { true } else { false }
       _ => false
     },
   )
   assert_true!(
-    match frexp(Double::nan()) {
+    match frexp(not_a_number) {
       (f, 0) => if f.is_nan() { true } else { false }
       _ => false
     },

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -323,11 +323,11 @@ test "stringify number" {
     9223372036854775807,
     9223372036854775808,
     999999999999223372036854775808,
-    @double.min_value().to_json(),
-    @double.max_value().to_json(),
-    @double.nan().to_json(),
-    @double.inf(1).to_json(),
-    @double.inf(-1).to_json(),
+    @double.min.to_json(),
+    @double.max.to_json(),
+    @double.not_a_number.to_json(),
+    @double.infinity.to_json(),
+    @double.neg_infinity.to_json(),
   ]
   inspect!(nums[0].stringify(), content="0")
   inspect!(nums[1].stringify(), content="0")
@@ -337,7 +337,7 @@ test "stringify number" {
   inspect!(nums[5].stringify(), content="9.223372036854776e18")
   inspect!(nums[6].stringify(), content="9.223372036854776e18")
   inspect!(nums[7].stringify(), content="9.999999999992234e29")
-  inspect!(nums[8].stringify(), content="5.0e-324")
+  inspect!(nums[8].stringify(), content="-1.7976931348623157e308")
   inspect!(nums[9].stringify(), content="1.7976931348623157e308")
   inspect!(nums[10].stringify(), content="NaN")
   inspect!(nums[11].stringify(), content="Infinity")

--- a/math/trigonometric.mbt
+++ b/math/trigonometric.mbt
@@ -235,7 +235,7 @@ pub fn asin(x : Double) -> Double {
   } else {
     let x_ = x.abs()
     if x_ > 1.0 {
-      Double::nan()
+      @double.not_a_number
     } else {
       let temp = (1.0 - x_ * x_).sqrt()
       if x > 0.7 { pi / 2.0 - satan(temp / x_) } else { satan(x_ / temp) } *

--- a/math/trigonometric_test.mbt
+++ b/math/trigonometric_test.mbt
@@ -38,9 +38,9 @@ test "sin" {
     -8.694568970959221300497e-01, 4.01956668098863248917e-01, 9.67786335404528727927e-01,
     -6.7344058693131973066e-01,
   ]
-  inspect!(@math.sin(Double::nan()), content="NaN")
-  inspect!(@math.sin(Double::inf(1)), content="Infinity")
-  inspect!(@math.sin(Double::inf(-1)), content="-Infinity")
+  inspect!(@math.sin(@double.not_a_number), content="NaN")
+  inspect!(@math.sin(@double.infinity), content="Infinity")
+  inspect!(@math.sin(@double.neg_infinity), content="-Infinity")
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(imprecise_equal(@math.sin(vf[i]), sin_res[i]), content="true")
     inspect!(
@@ -63,9 +63,9 @@ test "cos" {
     4.940088097314976789841e-01, -9.15658690217517835002e-01, -2.51772931436786954751e-01,
     -7.3924135157173099849e-01,
   ]
-  inspect!(@math.cos(Double::nan()), content="NaN")
-  inspect!(@math.cos(Double::inf(1)), content="Infinity")
-  inspect!(@math.cos(Double::inf(-1)), content="-Infinity")
+  inspect!(@math.cos(@double.not_a_number), content="NaN")
+  inspect!(@math.cos(@double.infinity), content="Infinity")
+  inspect!(@math.cos(@double.neg_infinity), content="-Infinity")
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(imprecise_equal(@math.cos(vf[i]), cos_res[i]), content="true")
     inspect!(
@@ -88,9 +88,9 @@ test "tan" {
     -1.760002817699722747043e+00, -4.38980891453536115952e-01, -3.84388555942723509071e+00,
     9.1098879344275101051e-01,
   ]
-  inspect!(@math.tan(Double::nan()), content="NaN")
-  inspect!(@math.tan(Double::inf(1)), content="Infinity")
-  inspect!(@math.tan(Double::inf(-1)), content="-Infinity")
+  inspect!(@math.tan(@double.not_a_number), content="NaN")
+  inspect!(@math.tan(@double.infinity), content="Infinity")
+  inspect!(@math.tan(@double.neg_infinity), content="-Infinity")
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(imprecise_equal(@math.tan(vf[i]), tan_res[i]), content="true")
     inspect!(
@@ -107,9 +107,9 @@ test "atan" {
     1.3818396865615168979966498e+00, 1.2194305844639670701091426e+00, 1.0696031952318783760193244e+00,
     -1.4561721938838084990898679e+00,
   ]
-  inspect!(@math.atan(Double::nan()), content="NaN")
-  inspect!(@math.atan(Double::inf(1)), content="Infinity")
-  inspect!(@math.atan(Double::inf(-1)), content="-Infinity")
+  inspect!(@math.atan(@double.not_a_number), content="NaN")
+  inspect!(@math.atan(@double.infinity), content="Infinity")
+  inspect!(@math.atan(@double.neg_infinity), content="-Infinity")
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(imprecise_equal(@math.atan(vf[i]), atan_res[i]), content="true")
   }
@@ -122,9 +122,9 @@ test "asin" {
     5.5025938468083370060258102e-01, 2.7629597861677201301553823e-01, 1.83559892257451475846656e-01,
     -1.0523547536021497774980928e+00,
   ]
-  inspect!(@math.asin(Double::nan()), content="NaN")
-  inspect!(@math.asin(Double::inf(1)), content="Infinity")
-  inspect!(@math.asin(Double::inf(-1)), content="-Infinity")
+  inspect!(@math.asin(@double.not_a_number), content="NaN")
+  inspect!(@math.asin(@double.infinity), content="Infinity")
+  inspect!(@math.asin(@double.neg_infinity), content="-Infinity")
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(
       imprecise_equal(@math.asin(vf[i] / 10.0), asin_res[i]),
@@ -140,9 +140,9 @@ test "acos" {
     1.0205369421140629186287407e+00, 1.2945003481781246062157835e+00, 1.3872364345374451433846657e+00,
     2.6231510803970463967294145e+00,
   ]
-  inspect!(@math.acos(Double::nan()), content="NaN")
-  inspect!(@math.acos(Double::inf(1)), content="Infinity")
-  inspect!(@math.acos(Double::inf(-1)), content="-Infinity")
+  inspect!(@math.acos(@double.not_a_number), content="NaN")
+  inspect!(@math.acos(@double.infinity), content="Infinity")
+  inspect!(@math.acos(@double.neg_infinity), content="-Infinity")
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(
       imprecise_equal(@math.acos(vf[i] / 10.0), acos_res[i]),

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -56,7 +56,7 @@ test "from_double overflow" {
 }
 
 test "from_double NaN" {
-  let result = Double::nan() |> @result.wrap1(f=@rational.from_double)
+  let result = @double.not_a_number |> @result.wrap1(f=@rational.from_double)
   assert_eq!(
     result,
     Err(RationalError("Rational::from_double: cannot convert NaN")),
@@ -81,7 +81,7 @@ test "from_double overflow check in continued fraction algorithm" {
 }
 
 test "from_double NaN check" {
-  let result = Double::nan() |> @result.wrap1(f=@rational.from_double)
+  let result = @double.not_a_number |> @result.wrap1(f=@rational.from_double)
   assert_eq!(
     result,
     Err(RationalError("Rational::from_double: cannot convert NaN")),
@@ -111,7 +111,9 @@ test "from_double array" {
     a,
     content="[Ok(1/2), Ok(5), Ok(2997/100), Ok(-2997/100), Ok(127/2), Ok(253/2), Ok(127), Ok(255/2), Ok(-127/2), Ok(-253/2), Ok(-127), Ok(-255/2)]",
   )
-  let a = [-10.0e200, 10.0e200, Double::inf(1), Double::inf(-1), Double::nan()]
+  let a = [
+    -10.0e200, 10.0e200, @double.infinity, @double.neg_infinity, @double.not_a_number,
+  ]
   a
   |> inspect_double_array!(
     content=

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -258,7 +258,7 @@ test "parse_double_inf" {
     } catch {
       _ => panic()
     },
-    Double::inf(1),
+    @double.infinity,
   )
   assert_eq!(
     try {
@@ -266,7 +266,7 @@ test "parse_double_inf" {
     } catch {
       _ => panic()
     },
-    Double::inf(1),
+    @double.infinity,
   )
   assert_eq!(
     try {
@@ -274,7 +274,7 @@ test "parse_double_inf" {
     } catch {
       _ => panic()
     },
-    Double::inf(-1),
+    @double.neg_infinity,
   )
   assert_eq!(
     try {
@@ -282,7 +282,7 @@ test "parse_double_inf" {
     } catch {
       _ => panic()
     },
-    Double::inf(1),
+    @double.infinity,
   )
   assert_eq!(
     try {
@@ -290,7 +290,7 @@ test "parse_double_inf" {
     } catch {
       _ => panic()
     },
-    Double::inf(-1),
+    @double.neg_infinity,
   )
   assert_eq!(
     try {
@@ -298,7 +298,7 @@ test "parse_double_inf" {
     } catch {
       _ => panic()
     },
-    Double::inf(1),
+    @double.infinity,
   )
   assert_eq!(
     try {
@@ -306,7 +306,7 @@ test "parse_double_inf" {
     } catch {
       _ => panic()
     },
-    Double::inf(-1),
+    @double.neg_infinity,
   )
 }
 

--- a/strconv/number.mbt
+++ b/strconv/number.mbt
@@ -194,23 +194,23 @@ fn parse_inf_nan(s : String) -> (Double, Int)? {
   let s = full_slice(s)
   if s.length() >= 3 {
     if s.prefix_eq_ignore_case("nan") {
-      return Some((Double::nan(), 3))
+      return Some((@double.not_a_number, 3))
     } else if s.prefix_eq_ignore_case("inf") {
-      return Some((Double::inf(1), parse_inf_rest(s)))
+      return Some((@double.infinity, parse_inf_rest(s)))
     } else if s.length() >= 4 {
       if s.first_is('+') {
         let s = s.step_1_unchecked()
         if s.prefix_eq_ignore_case("nan") {
-          return Some((Double::nan(), 4))
+          return Some((@double.not_a_number, 4))
         } else if s.prefix_eq_ignore_case("inf") {
-          return Some((Double::inf(1), 1 + parse_inf_rest(s)))
+          return Some((@double.infinity, 1 + parse_inf_rest(s)))
         }
       } else if s.first_is('-') {
         let s = s.step_1_unchecked()
         if s.prefix_eq_ignore_case("nan") {
-          return Some((Double::nan(), 4))
+          return Some((@double.not_a_number, 4))
         } else if s.prefix_eq_ignore_case("inf") {
-          return Some((Double::inf(-1), 1 + parse_inf_rest(s)))
+          return Some((@double.neg_infinity, 1 + parse_inf_rest(s)))
         }
       }
     }


### PR DESCRIPTION
Fix #885
- add double constants, rename `min_normal` to `min_positive`, and let `min` equal to `-max`.
- deprecate some functions that return constants.