### PR TITLE
rename functions `x_exn` to `unsafe_x`

### DIFF
--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -59,13 +59,13 @@ test "pop" {
   assert_eq!(v.pop(), None)
 }
 
-test "pop_exn" {
+test "unsafe_pop" {
   let v = []
   v.push(3)
   v.push(4)
   assert_eq!(v.length(), 2)
-  assert_eq!(v.pop_exn(), 4)
-  assert_eq!(v.pop_exn(), 3)
+  assert_eq!(v.unsafe_pop(), 4)
+  assert_eq!(v.unsafe_pop(), 3)
   assert_eq!(v.length(), 0)
 }
 

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -148,15 +148,15 @@ pub fn pop[T](self : Array[T]) -> T? {
   }
 }
 
-/// Removes the last element from a array and returns it.
-///
-/// # Example
-/// ```
-/// let v = [1, 2, 3]
-/// v.pop_exn() // 3
-/// ```
-/// @alert unsafe "Panic if the array is empty."
+/// @alert deprecated "Use `unsafe_pop` instead"
 pub fn pop_exn[T](self : Array[T]) -> T {
+  self.unsafe_pop()
+}
+
+/// Removes the last element from a array and returns it.
+/// 
+/// @alert unsafe "Panic if the array is empty."
+pub fn unsafe_pop[T](self : Array[T]) -> T {
   if self.length() == 0 {
     abort("pop from an empty Array")
   }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -88,7 +88,7 @@ test "array_pop" {
 
 test "array_pop_exn" {
   let arr = [1, 2, 3]
-  assert_eq!(arr.pop_exn(), 3)
+  assert_eq!(arr.unsafe_pop(), 3)
   assert_eq!(arr.length(), 2)
 }
 
@@ -462,7 +462,7 @@ test "array_pop_empty" {
 
 test "panic array_pop_exn_empty" {
   let arr : Array[Int] = Array::new()
-  arr.pop_exn() |> ignore // This should panic
+  arr.unsafe_pop() |> ignore // This should panic
 }
 
 test "panic array_drain_out_of_bounds" {

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -111,6 +111,7 @@ impl Array {
   to_string[T : Show](Self[T]) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
+  unsafe_pop[T](Self[T]) -> T
 }
 
 type ArrayView

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -186,7 +186,7 @@ pub fn push_back[A](self : T[A], value : A) -> Unit {
 /// dv.pop_front_exn()
 /// ```
 /// @alert unsafe "Panic if the deque is empty."
-pub fn pop_front_exn[A](self : T[A]) -> Unit {
+pub fn unsafe_pop_front[A](self : T[A]) -> Unit {
   if self.len == 0 {
     abort("The deque is empty!")
   }
@@ -194,20 +194,30 @@ pub fn pop_front_exn[A](self : T[A]) -> Unit {
   self.len -= 1
 }
 
+/// @alert deprecated "Use `unsafe_pop_front` instead"
+pub fn pop_front_exn[A](self : T[A]) -> Unit {
+  unsafe_pop_front(self)
+}
+
 /// Removes a back element from a deque.
 ///
 /// # Example
 /// ```
 /// let dv = of([1, 2, 3, 4, 5])
-/// dv.pop_back_exn()
+/// dv.pop_back()
 /// ```
 /// @alert unsafe "Panic if the deque is empty."
-pub fn pop_back_exn[A](self : T[A]) -> Unit {
+pub fn unsafe_pop_back[A](self : T[A]) -> Unit {
   if self.len == 0 {
     abort("The deque is empty!")
   }
   self.tail = if self.tail > 0 { self.tail - 1 } else { self.buf.length() - 1 }
   self.len -= 1
+}
+
+/// @alert deprecated "Use `unsafe_pop_back` instead"
+pub fn pop_back_exn[A](self : T[A]) -> Unit {
+  unsafe_pop_back(self)
 }
 
 /// Removes a front element from a deque and returns it, or `None` if it is empty.

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -36,6 +36,8 @@ impl T {
   search[A : Eq](Self[A], A) -> Int?
   shrink_to_fit[A](Self[A]) -> Unit
   to_string[A : Show](Self[A]) -> String
+  unsafe_pop_back[A](Self[A]) -> Unit
+  unsafe_pop_front[A](Self[A]) -> Unit
 }
 
 // Type aliases

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -190,8 +190,8 @@ test "iter" {
 
 test "iter2" {
   let v = @deque.of([1, 2, 3, 4, 5])
-  v.pop_front_exn()
-  v.pop_back_exn()
+  v.unsafe_pop_front()
+  v.unsafe_pop_back()
   let mut sum = 0
   v.each(fn { x => sum += x })
   inspect!(sum, content="9")
@@ -212,12 +212,12 @@ test "from_array" {
   inspect!(@deque.of([1, 2, 3]), content="Deque::[1, 2, 3]")
 }
 
-test "panic pop_front_exn" {
-  @deque.from_array(([] : Array[Int])).pop_front_exn()
+test "panic unsafe_pop_front" {
+  @deque.from_array(([] : Array[Int])).unsafe_pop_front()
 }
 
-test "panic pop_back_exn" {
-  @deque.from_array(([] : Array[Int])).pop_back_exn()
+test "panic unsafe_pop_back" {
+  @deque.from_array(([] : Array[Int])).unsafe_pop_back()
 }
 
 test "panic op_get" {

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -400,13 +400,13 @@ pub fn fold_righti[A, B](self : T[A], f : (Int, A, B) -> B, ~init : B) -> B {
 /// let r = zip(of[1, 2, 3, 4, 5]), of([6, 7, 8, 9, 10]))
 /// println(r) // output: Some(of([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)])
 /// ```
-pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)]?{
+pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)]? {
   match (self, other) {
     (Nil, Nil) => Some(Nil)
-    (Cons(x, xs), Cons(y, ys)) => 
-      match zip(xs,ys) {
+    (Cons(x, xs), Cons(y, ys)) =>
+      match zip(xs, ys) {
         None => None
-        Some(ls) => Some(Cons((x,y), ls))
+        Some(ls) => Some(Cons((x, y), ls))
       }
     _ => None
   }
@@ -663,7 +663,7 @@ pub fn take[A](self : T[A], n : Int) -> T[A] {
   fn go {
     _, Nil => Nil
     1, Cons(x, _) => Cons(x, Nil)
-    n, Cons(x,xs) => Cons(x, go(n - 1, xs))
+    n, Cons(x, xs) => Cons(x, go(n - 1, xs))
   }
 
   if n <= 0 {
@@ -672,6 +672,7 @@ pub fn take[A](self : T[A], n : Int) -> T[A] {
     go(n, self)
   }
 }
+
 /// Drop first n elements of the list.
 /// If the list is shorter than n, return an empty list.
 ///
@@ -686,14 +687,13 @@ pub fn drop[A](self : T[A], n : Int) -> T[A] {
     1, Cons(_, xs) => xs
     n, Cons(_, xs) => go(n - 1, xs)
   }
-  
+
   if n <= 0 {
     self
   } else {
-    go(n,self)
+    go(n, self)
   }
 }
-
 
 /// Take the longest prefix of a list of elements that satisfies a given predicate.
 ///
@@ -965,4 +965,3 @@ pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
     list
   }
 }
-

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -184,19 +184,17 @@ pub fn tail[A](self : T[A]) -> T[A] {
 }
 
 /// Get first element of the list.
-///
-/// # Example
-///
-/// ```
-/// println(of([1, 2, 3, 4, 5]).head_exn())
-/// // output: 1
-/// ```
 /// @alert unsafe "Panic if the list is empty"
-pub fn head_exn[A](self : T[A]) -> A {
+pub fn unsafe_head[A](self : T[A]) -> A {
   match self {
     Nil => abort("head of empty list")
     Cons(head, _) => head
   }
+}
+
+/// @alert deprecated "Use `unsafe_head` instead"
+pub fn head_exn[A](self : T[A]) -> A {
+  unsafe_head(self)
 }
 
 /// Get first element of the list.
@@ -206,13 +204,20 @@ pub fn head_exn[A](self : T[A]) -> A {
 /// ```
 /// println(of([1, 2, 3, 4, 5]).head())
 /// // output: Some(1)
-/// println(from_array([]).head())
-/// // output: None
 /// ```
 pub fn head[A](self : T[A]) -> A? {
   match self {
     Nil => None
     Cons(head, _) => Some(head)
+  }
+}
+
+/// @alert unsafe "Panic if the list is empty"
+pub fn unsafe_last[A](self : T[A]) -> A {
+  loop self {
+    Nil => abort("last of empty list")
+    Cons(head, Nil) => head
+    Cons(_, tail) => continue tail
   }
 }
 
@@ -222,9 +227,8 @@ pub fn head[A](self : T[A]) -> A? {
 ///
 /// ```
 /// println(of([1, 2, 3, 4, 5]).last())
-/// // output: 5
+/// // output: Some(5)
 /// ```
-/// @alert unsafe "Panic if the list is empty"
 pub fn last[A](self : T[A]) -> A {
   loop self {
     Nil => abort("last of empty list")
@@ -254,8 +258,8 @@ pub fn init_[A](self : T[A]) -> T[A] {
 /// # Example
 ///
 /// ```
-/// let ls = of([1, 2, 3, 4, 5]).concat(from_array([6, 7, 8, 9, 10]))
-/// println(ls) // output: from_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+/// let ls = of([1, 2, 3, 4, 5]).concat(of([6, 7, 8, 9, 10]))
+/// println(ls) // output: @list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 /// ```
 pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
   match self {
@@ -388,20 +392,23 @@ pub fn fold_righti[A, B](self : T[A], f : (Int, A, B) -> B, ~init : B) -> B {
 }
 
 /// Zip two lists.
+/// If the lists have different lengths, it will return None.
 ///
 /// # Example
 ///
 /// ```
-/// let r = zip(of([1, 2, 3, 4, 5]), from_array([6, 7, 8, 9, 10]))
-/// println(r) // output: from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]
+/// let r = zip(of[1, 2, 3, 4, 5]), of([6, 7, 8, 9, 10]))
+/// println(r) // output: Some(of([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)])
 /// ```
-///
-/// @alert unsafe "Panic if the two lists have different lengths."
-pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)] {
+pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)]?{
   match (self, other) {
-    (Nil, Nil) => Nil
-    (Cons(x, xs), Cons(y, ys)) => Cons((x, y), zip(xs, ys))
-    _ => abort("zip: lists have different lengths")
+    (Nil, Nil) => Some(Nil)
+    (Cons(x, xs), Cons(y, ys)) => 
+      match zip(xs,ys) {
+        None => None
+        Some(ls) => Some(Cons((x,y), ls))
+      }
+    _ => None
   }
 }
 
@@ -439,14 +446,18 @@ pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
   }
 }
 
-/// Get nth element of the list
 /// @alert unsafe "Panic if the index is out of bounds"
-pub fn nth_exn[A](self : T[A], n : Int) -> A {
+pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
   loop self, n {
     Nil, _ => abort("nth: index out of bounds")
     Cons(head, _), 0 => head
     Cons(_, tail), n => continue tail, n - 1
   }
+}
+
+/// @alert deprecated "Use `unsafe_nth` instead"
+pub fn nth_exn[A](self : T[A], n : Int) -> A {
+  unsafe_nth(self, n)
 }
 
 /// Get nth element of the list or None if the index is out of bounds
@@ -532,14 +543,13 @@ pub fn flatten[A](self : T[T[A]]) -> T[A] {
   }
 }
 
-/// Get maximum element of the list.
 /// @alert unsafe "Panic if the list is empty"
-pub fn maximum[A : Compare](self : T[A]) -> A {
+pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
   match self {
     Nil => abort("maximum: empty list")
     Cons(x, Nil) => x
     Cons(x, xs) => {
-      let y = maximum(xs)
+      let y = unsafe_maximum(xs)
       if x > y {
         x
       } else {
@@ -549,20 +559,46 @@ pub fn maximum[A : Compare](self : T[A]) -> A {
   }
 }
 
-/// Get minimum element of the list.
+/// Get maximum element of the list.
+/// Returns None if the list is empty.
+pub fn maximum[A : Compare](self : T[A]) -> A? {
+  match self {
+    Nil => None
+    Cons(x, Nil) => Some(x)
+    Cons(x, xs) =>
+      match maximum(xs) {
+        None => Some(x)
+        Some(y) => Some(if x > y { x } else { y })
+      }
+  }
+}
+
 /// @alert unsafe "Panic if the list is empty"
-pub fn minimum[A : Compare](self : T[A]) -> A {
+pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
   match self {
     Nil => abort("minimum: empty list")
     Cons(x, Nil) => x
     Cons(x, xs) => {
-      let y = minimum(xs)
+      let y = unsafe_minimum(xs)
       if x < y {
         x
       } else {
         y
       }
     }
+  }
+}
+
+/// Get minimum element of the list.
+pub fn minimum[A : Compare](self : T[A]) -> A? {
+  match self {
+    Nil => None
+    Cons(x, Nil) => Some(x)
+    Cons(x, xs) =>
+      match minimum(xs) {
+        None => Some(x)
+        Some(y) => Some(if x < y { x } else { y })
+      }
   }
 }
 
@@ -616,6 +652,7 @@ pub fn unfold[A, S](f : (S) -> (A, S)?, ~init : S) -> T[A] {
 }
 
 /// Take first n elements of the list.
+/// If the list is shorter than n, return the whole list.
 ///
 /// # Example
 ///
@@ -623,22 +660,20 @@ pub fn unfold[A, S](f : (S) -> (A, S)?, ~init : S) -> T[A] {
 /// of([1, 2, 3, 4, 5]).take(3)
 /// ```
 pub fn take[A](self : T[A], n : Int) -> T[A] {
+  fn go {
+    _, Nil => Nil
+    1, Cons(x, _) => Cons(x, Nil)
+    n, Cons(x,xs) => Cons(x, go(n - 1, xs))
+  }
+
   if n <= 0 {
     Nil
   } else {
-    unsafe_take(n, self)
+    go(n, self)
   }
 }
-
-fn unsafe_take[A](n : Int, xs : T[A]) -> T[A] {
-  match (n, xs) {
-    (1, Cons(x, _)) => Cons(x, Nil)
-    (_, Cons(x, xs)) => Cons(x, unsafe_take(n - 1, xs))
-    _ => abort("take: index out of bounds")
-  }
-}
-
 /// Drop first n elements of the list.
+/// If the list is shorter than n, return an empty list.
 ///
 /// # Example
 ///
@@ -646,20 +681,19 @@ fn unsafe_take[A](n : Int, xs : T[A]) -> T[A] {
 /// of([1, 2, 3, 4, 5]).drop(3)
 /// ```
 pub fn drop[A](self : T[A], n : Int) -> T[A] {
+  fn go {
+    _, Nil => Nil
+    1, Cons(_, xs) => xs
+    n, Cons(_, xs) => go(n - 1, xs)
+  }
+  
   if n <= 0 {
     self
   } else {
-    unsafe_drop(n, self)
+    go(n,self)
   }
 }
 
-fn unsafe_drop[A](n : Int, xs : T[A]) -> T[A] {
-  match (n, xs) {
-    (1, Cons(_, xs)) => xs
-    (_, Cons(_, xs)) => unsafe_drop(n - 1, xs)
-    (x, _) => abort("drop: index out of bounds" + x.to_string())
-  }
-}
 
 /// Take the longest prefix of a list of elements that satisfies a given predicate.
 ///
@@ -721,7 +755,7 @@ pub fn scan_right[A, B](self : T[A], f : (A, B) -> B, ~init : B) -> T[B] {
     Nil => Cons(init, Nil)
     Cons(x, xs) => {
       let qs = xs.scan_right(f, ~init)
-      Cons(f(x, qs.head_exn()), qs)
+      Cons(f(x, qs.unsafe_head()), qs)
     }
   }
 }
@@ -932,10 +966,3 @@ pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
   }
 }
 
-test "panic unsafe_drop" {
-  unsafe_drop(5, of([1, 2, 3, 4])) |> ignore
-}
-
-test "panic unsafe_take" {
-  unsafe_take(5, of([1, 2, 3, 4])) |> ignore
-}

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -52,8 +52,8 @@ impl T {
   lookup[A : Eq, B](Self[Tuple[A, B]], A) -> B?
   map[A, B](Self[A], (A) -> B) -> Self[B]
   mapi[A, B](Self[A], (Int, A) -> B) -> Self[B]
-  maximum[A : Compare + Eq](Self[A]) -> A
-  minimum[A : Compare + Eq](Self[A]) -> A
+  maximum[A : Compare + Eq](Self[A]) -> A?
+  minimum[A : Compare + Eq](Self[A]) -> A?
   nth[A](Self[A], Int) -> A?
   nth_exn[A](Self[A], Int) -> A
   of[A](FixedArray[A]) -> Self[A]
@@ -72,7 +72,12 @@ impl T {
   take_while[A](Self[A], (A) -> Bool) -> Self[A]
   to_array[A](Self[A]) -> Array[A]
   to_string[A : Show](Self[A]) -> String
-  zip[A, B](Self[A], Self[B]) -> Self[Tuple[A, B]]
+  unsafe_head[A](Self[A]) -> A
+  unsafe_last[A](Self[A]) -> A
+  unsafe_maximum[A : Compare + Eq](Self[A]) -> A
+  unsafe_minimum[A : Compare + Eq](Self[A]) -> A
+  unsafe_nth[A](Self[A], Int) -> A
+  zip[A, B](Self[A], Self[B]) -> Self[Tuple[A, B]]?
 }
 
 // Type aliases

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -99,7 +99,7 @@ test "tail" {
 
 test "head_exn" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  inspect!(ls.head_exn(), content="1")
+  inspect!(ls.head(), content="Some(1)")
 }
 
 test "head" {
@@ -176,7 +176,7 @@ test "zip" {
   let rs = @list.of([6, 7, 8, 9, 10])
   inspect!(
     ls.zip(rs),
-    content="@list.of([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)])",
+    content="Some(@list.of([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]))",
   )
 }
 
@@ -190,14 +190,14 @@ test "flat_map" {
   )
 }
 
-test "nth_exn" {
+test "nth" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  inspect!(ls.nth_exn(0), content="1")
-  inspect!(ls.nth_exn(1), content="2")
+  inspect!(ls.nth(0), content="Some(1)")
+  inspect!(ls.nth(1), content="Some(2)")
 }
 
 test "panic nth_exn" {
-  @list.Nil.nth_exn(0)
+  @list.Nil.unsafe_nth(0)
 }
 
 test "nth" {
@@ -247,12 +247,12 @@ test "flatten" {
 
 test "maximum" {
   let ls = @list.of([1, 123, 52, 3, 6, 0, -6, -76])
-  inspect!(ls.maximum(), content="123")
+  inspect!(ls.maximum(), content="Some(123)")
 }
 
 test "minimum" {
   let ls = @list.of([1, 123, 52, 3, 6, 0, -6, -76])
-  inspect!(ls.minimum(), content="-76")
+  inspect!(ls.minimum(), content="Some(-76)")
 }
 
 test "sort" {
@@ -280,11 +280,12 @@ test "unfold" {
 }
 
 test "take" {
-  let ls = @list.of([1, 2, 3, 4, 5]).take(3)
-  inspect!(ls, content="@list.of([1, 2, 3])")
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.take(3), content="@list.of([1, 2, 3])")
   inspect!(ls.take(-1), content="@list.of([])")
+  inspect!(ls.take(7), content="@list.of([1, 2, 3, 4, 5])")
   inspect!(ls.take(0), content="@list.of([])")
-  inspect!(ls, content="@list.of([1, 2, 3])")
+  inspect!(ls.take(5), content="@list.of([1, 2, 3, 4, 5])")
 }
 
 test "drop" {
@@ -292,6 +293,8 @@ test "drop" {
   let el : @list.T[Int] = @list.Nil
   inspect!(ls, content="@list.of([4, 5])")
   inspect!(ls.drop(-10), content="@list.of([4, 5])")
+  inspect!(ls.drop(10), content="@list.of([])")
+  inspect!(ls.drop(2), content="@list.of([])")
   inspect!(ls.drop(0), content="@list.of([4, 5])")
   inspect!(el.drop(0), content="@list.of([])")
 }
@@ -484,12 +487,12 @@ test "List::output with empty list" {
 
 test "List::head_exn with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let head = @list.head_exn(list)
-  assert_eq!(head, 1)
+  let head = @list.head(list)
+  assert_eq!(head, Some(1))
 }
 
 test "panic @list.exn with empty list" {
-  @list.Nil.head_exn()
+  @list.Nil.unsafe_head()
 }
 
 test "List::last with non-empty list" {
@@ -501,39 +504,47 @@ test "List::last with non-empty list" {
 test "List::zip with lists of equal length" {
   let list1 = @list.of([1, 2, 3])
   let list2 = @list.of(["a", "b", "c"])
-  let zipped = @list.zip(list1, list2)
-  let expected = @list.of([(1, "a"), (2, "b"), (3, "c")])
+  let zipped = list1.zip(list2)
+  let expected = Some(@list.of([(1, "a"), (2, "b"), (3, "c")]))
   assert_eq!(zipped, expected)
 }
 
-test "panic @list.zip with empty list" {
-  @list.of([1]).zip((@list.Nil : @list.T[Int])) |> ignore
+test "@list.zip with empty list" {
+  inspect!(@list.of([1]).zip((@list.Nil : @list.T[Int])), content="None"
+  )
 }
 
 test "List::nth_exn with valid index" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let nth = @list.nth_exn(list, 2)
-  assert_eq!(nth, 3)
+  let nth = @list.nth(list, 2)
+  assert_eq!(nth, Some(3))
 }
 
 test "List::maximum with non-empty list" {
   let list = @list.of([1, 3, 5, 2, 4])
   let max = @list.maximum(list)
-  assert_eq!(max, 5)
+  assert_eq!(max, Some(5))
 }
 
-test "panic @list.maxium with empty list" {
-  (@list.Nil : @list.T[Int]).maximum() |> ignore
+test "@list.maximum with empty list" {
+  inspect!((@list.Nil : @list.T[Int]).maximum(), content="None") 
+}
+
+test "panic @list.unsafe_maximum with empty list" {
+  inspect!((@list.Nil : @list.T[Int]).unsafe_maximum()) 
 }
 
 test "List::minimum with non-empty list" {
   let list = @list.of([1, 3, 5, 2, 4])
   let min = @list.minimum(list)
-  assert_eq!(min, 1)
+  assert_eq!(min, Some(1))
 }
 
-test "panic @list.minimum with empty list" {
+test "@list.minimum with empty list" {
   (@list.Nil : @list.T[Int]).minimum() |> ignore
+}
+test "panic @list.unsafe_minimum with empty list" {
+  inspect!((@list.Nil : @list.T[Int]).unsafe_minimum())
 }
 
 test "op_add" {

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -510,8 +510,7 @@ test "List::zip with lists of equal length" {
 }
 
 test "@list.zip with empty list" {
-  inspect!(@list.of([1]).zip((@list.Nil : @list.T[Int])), content="None"
-  )
+  inspect!(@list.of([1]).zip((@list.Nil : @list.T[Int])), content="None")
 }
 
 test "List::nth_exn with valid index" {
@@ -527,11 +526,11 @@ test "List::maximum with non-empty list" {
 }
 
 test "@list.maximum with empty list" {
-  inspect!((@list.Nil : @list.T[Int]).maximum(), content="None") 
+  inspect!((@list.Nil : @list.T[Int]).maximum(), content="None")
 }
 
 test "panic @list.unsafe_maximum with empty list" {
-  inspect!((@list.Nil : @list.T[Int]).unsafe_maximum()) 
+  inspect!((@list.Nil : @list.T[Int]).unsafe_maximum())
 }
 
 test "List::minimum with non-empty list" {
@@ -543,6 +542,7 @@ test "List::minimum with non-empty list" {
 test "@list.minimum with empty list" {
   (@list.Nil : @list.T[Int]).minimum() |> ignore
 }
+
 test "panic @list.unsafe_minimum with empty list" {
   inspect!((@list.Nil : @list.T[Int]).unsafe_minimum())
 }

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -123,11 +123,16 @@ pub fn pop[A : Compare](self : T[A]) -> T[A]? {
 /// let queue = of([1, 2, 3, 4])
 /// let first = queue.pop()
 /// ```
-pub fn pop_exn[A : Compare](self : T[A]) -> T[A] {
+pub fn unsafe_pop[A : Compare](self : T[A]) -> T[A] {
   match self.body {
     Empty => abort("The ImmutablePriorityQueue is empty!")
     Node(_, ts) => { body: merges(ts), len: self.len - 1 }
   }
+}
+
+/// @alert deprecated "Use `unsafe_pop` instead"
+pub fn pop_exn[A : Compare](self : T[A]) -> T[A] {
+  unsafe_pop(self)
 }
 
 /// Adds a value to the immutable priority queue.

--- a/immut/priority_queue/priority_queue.mbti
+++ b/immut/priority_queue/priority_queue.mbti
@@ -18,6 +18,7 @@ impl T {
   push[A : Compare + Eq](Self[A], A) -> Self[A]
   to_array[A : Compare + Eq](Self[A]) -> Array[A]
   to_string[A : Show + Compare + Eq](Self[A]) -> String
+  unsafe_pop[A : Compare + Eq](Self[A]) -> Self[A]
 }
 
 // Type aliases

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -64,16 +64,16 @@ test "pop" {
 
 test "pop_exn" {
   let queue = @priority_queue.of([1, 2, 3, 4])
-  let first = queue.pop_exn()
+  let first = queue.unsafe_pop()
   inspect!(first.peek(), content="Some(3)")
   inspect!(
     queue
-    .pop_exn()
+    .unsafe_pop()
     .push(-1)
     .push(10)
     .push(11)
-    .pop_exn()
-    .pop_exn()
+    .unsafe_pop()
+    .unsafe_pop()
     .push(50)
     .peek(),
     content="Some(50)",
@@ -100,13 +100,13 @@ test "is_empty" {
 test "length" {
   let pq = @priority_queue.of([1, 2])
   inspect!(pq.length(), content="2")
-  inspect!(pq.pop_exn().length(), content="1")
-  inspect!(pq.pop_exn().pop_exn().length(), content="0")
+  inspect!(pq.unsafe_pop().length(), content="1")
+  inspect!(pq.unsafe_pop().unsafe_pop().length(), content="0")
 }
 
-test "panic pop_exn" {
+test "panic unsafe_pop" {
   let pq = @priority_queue.of([1])
-  pq.pop_exn().pop_exn() |> ignore
+  pq.unsafe_pop().unsafe_pop() |> ignore
 }
 
 test "from_iter multiple elements iter" {

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -144,15 +144,20 @@ pub fn length[A](self : T[A]) -> Int {
 /// # Example
 /// ```
 /// let queue = of([1, 2, 3, 4])
-/// let first = queue.pop_exn() // 4
+/// let first = queue.unsafe_pop() // 4
 /// ```
 /// @alert unsafe "Panic if the queue is empty."
-pub fn pop_exn[A : Compare](self : T[A]) -> Unit {
+pub fn unsafe_pop[A : Compare](self : T[A]) -> Unit {
   self.top = match self.top {
     Nil => abort("The PriorityQueue is empty!")
     Cons(~child, ..) => merges(child)
   }
   self.len -= 1
+}
+
+/// @alert deprecated "Use `unsafe_pop` instead"
+pub fn pop_exn[A : Compare](self : T[A]) -> Unit {
+  unsafe_pop(self)
 }
 
 /// Pops the first value from the priority queue, which returns None if the queue is empty.

--- a/priority_queue/priority_queue.mbti
+++ b/priority_queue/priority_queue.mbti
@@ -20,6 +20,7 @@ impl T {
   push[A : Compare + Eq](Self[A], A) -> Unit
   to_array[A : Compare + Eq](Self[A]) -> Array[A]
   to_string[A : Show + Compare + Eq](Self[A]) -> String
+  unsafe_pop[A : Compare + Eq](Self[A]) -> Unit
 }
 
 // Type aliases

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -65,26 +65,26 @@ test "length" {
   assert_eq!(pq.length(), 1)
   pq.push(2)
   assert_eq!(pq.length(), 2)
-  pq.pop_exn()
+  pq.unsafe_pop()
   assert_eq!(pq.length(), 1)
 }
 
-test "pop_exn" {
+test "unsafe_pop" {
   let pq = @priority_queue.of([5, 5, 4, 3, 2, 1])
   inspect!(pq.length(), content="6")
   assert_eq!(pq.peek(), Some(5))
-  pq.pop_exn()
+  pq.unsafe_pop()
   assert_eq!(pq.peek(), Some(5))
-  pq.pop_exn()
+  pq.unsafe_pop()
   assert_eq!(pq.peek(), Some(4))
   let pq_ = @priority_queue.of([1])
-  pq_.pop_exn()
+  pq_.unsafe_pop()
   inspect!(pq_.length(), content="0")
 }
 
-test "panic pop_exn" {
+test "panic unsafe_pop" {
   let pq : @priority_queue.T[Int] = @priority_queue.of([])
-  pq.pop_exn()
+  pq.unsafe_pop()
 }
 
 test "pop" {

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -193,6 +193,7 @@ pub fn unsafe_pop[A](self : T[A]) -> A {
   }
 }
 
+/// @alert deprecated "Use `unsafe_pop` instead"
 pub fn pop_exn[A](self : T[A]) -> A {
   unsafe_pop(self)
 }

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -141,14 +141,19 @@ pub fn push[A](self : T[A], x : A) -> Unit {
 /// # Example
 /// ```
 /// let queue : Queue[Int] = of([1, 2, 3, 4])
-/// let first = queue.peek_exn()
+/// let first = queue.unsafe_peek()
 /// ```
 /// @alert unsafe "Panics if the queue is empty."
-pub fn peek_exn[A](self : T[A]) -> A {
+pub fn unsafe_peek[A](self : T[A]) -> A {
   match self.first {
     Nil => abort("Queue is empty")
     Cons(first) => first.content
   }
+}
+
+/// @alert deprecated "Use `unsafe_peek` instead"
+pub fn peek_exn[A](self : T[A]) -> A {
+  unsafe_peek(self)
 }
 
 /// Peeks at the first value in the queue, which returns None if the queue is empty.
@@ -170,10 +175,10 @@ pub fn peek[A](self : T[A]) -> A? {
 /// # Example
 /// ```
 /// let queue : Queue[Int] = of([1, 2, 3, 4])
-/// let first = queue.pop_exn()
+/// let first = queue.unsafe_pop()
 /// ```
 /// @alert unsafe "Panics if the queue is empty."
-pub fn pop_exn[A](self : T[A]) -> A {
+pub fn unsafe_pop[A](self : T[A]) -> A {
   match self.first {
     Nil => abort("Queue is empty")
     Cons({ content, next: Nil }) => {
@@ -188,6 +193,10 @@ pub fn pop_exn[A](self : T[A]) -> A {
   }
 }
 
+pub fn pop_exn[A](self : T[A]) -> A {
+  unsafe_pop(self)
+}
+
 /// Pops the first value from the queue, which returns None if the queue is empty.
 ///
 /// # Example
@@ -199,7 +208,7 @@ pub fn pop[A](self : T[A]) -> A? {
   if self.length == 0 {
     None
   } else {
-    Some(self.pop_exn())
+    Some(self.unsafe_pop())
   }
 }
 
@@ -343,7 +352,7 @@ test "from_fixed_array_2" {
   let q = of([1, 2, 3, 4])
   q.push(11)
   assert_eq!(q, of([1, 2, 3, 4, 11]))
-  q.pop_exn() |> ignore
+  q.unsafe_pop() |> ignore
   assert_eq!(q, of([2, 3, 4, 11]))
 }
 
@@ -351,7 +360,7 @@ test "from_array_2" {
   let q = of([1, 2, 3, 4])
   q.push(11)
   assert_eq!(q, of([1, 2, 3, 4, 11]))
-  q.pop_exn() |> ignore
+  q.unsafe_pop() |> ignore
   assert_eq!(q, of([2, 3, 4, 11]))
 }
 
@@ -361,7 +370,7 @@ test "op_equal" {
   let queue3 = of([1, 2, 3, 5])
   assert_true!(queue == queue2)
   assert_false!(queue == queue3)
-  queue.pop_exn() |> ignore
+  queue.unsafe_pop() |> ignore
   assert_false!(queue == queue2)
   assert_eq!(queue, of([2, 3, 4]))
 }

--- a/queue/queue.mbti
+++ b/queue/queue.mbti
@@ -24,6 +24,8 @@ impl T {
   push[A](Self[A], A) -> Unit
   to_string[A : Show](Self[A]) -> String
   transfer[A](Self[A], Self[A]) -> Unit
+  unsafe_peek[A](Self[A]) -> A
+  unsafe_pop[A](Self[A]) -> A
 }
 
 // Type aliases

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -21,11 +21,11 @@ test "from_fixed_array_1" {
   let queue = @queue.of([1, 2, 3, 4])
   let queue2 = @queue.of([1])
   assert_eq!(queue.length(), 4)
-  assert_eq!(queue.pop_exn(), 1)
-  assert_eq!(queue.pop_exn(), 2)
-  assert_eq!(queue.pop_exn(), 3)
-  assert_eq!(queue.pop_exn(), 4)
-  assert_eq!(queue2.pop_exn(), 1)
+  assert_eq!(queue.unsafe_pop(), 1)
+  assert_eq!(queue.unsafe_pop(), 2)
+  assert_eq!(queue.unsafe_pop(), 3)
+  assert_eq!(queue.unsafe_pop(), 4)
+  assert_eq!(queue2.unsafe_pop(), 1)
   assert_eq!(queue2.length(), 0)
 }
 
@@ -38,11 +38,11 @@ test "from_array_1" {
   let queue = @queue.of([1, 2, 3, 4])
   let queue2 = @queue.of([1])
   assert_eq!(queue.length(), 4)
-  assert_eq!(queue.pop_exn(), 1)
-  assert_eq!(queue.pop_exn(), 2)
-  assert_eq!(queue.pop_exn(), 3)
-  assert_eq!(queue.pop_exn(), 4)
-  assert_eq!(queue2.pop_exn(), 1)
+  assert_eq!(queue.unsafe_pop(), 1)
+  assert_eq!(queue.unsafe_pop(), 2)
+  assert_eq!(queue.unsafe_pop(), 3)
+  assert_eq!(queue.unsafe_pop(), 4)
+  assert_eq!(queue2.unsafe_pop(), 1)
   assert_eq!(queue2.length(), 0)
 }
 
@@ -56,7 +56,7 @@ test "to_string" {
   inspect!(queue, content="@queue.of([1, 2, 3, 4])")
   queue.push(11)
   inspect!(queue, content="@queue.of([1, 2, 3, 4, 11])")
-  queue.pop_exn() |> ignore
+  queue.unsafe_pop() |> ignore
   inspect!(queue, content="@queue.of([2, 3, 4, 11])")
 }
 
@@ -77,17 +77,17 @@ test "is_empty" {
   assert_false!(queue.is_empty())
 }
 
-test "peek_exn" {
+test "unsafe_peek" {
   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
-  assert_eq!(queue.peek_exn(), 1)
+  assert_eq!(queue.unsafe_peek(), 1)
   assert_eq!(queue.length(), 4)
-  assert_eq!(queue.pop_exn(), 1)
-  assert_eq!(queue.peek_exn(), 2)
+  assert_eq!(queue.unsafe_pop(), 1)
+  assert_eq!(queue.unsafe_peek(), 2)
   assert_eq!(queue.length(), 3)
 }
 
-test "panic peek_exn" {
-  @queue.of([]).peek_exn()
+test "panic unsafe_peek" {
+  @queue.of([]).unsafe_peek()
 }
 
 test "peek" {
@@ -97,17 +97,17 @@ test "peek" {
   assert_eq!(queue.peek(), None)
 }
 
-test "pop_exn" {
+test "unsafe_pop" {
   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
-  assert_eq!(queue.pop_exn(), 1)
-  assert_eq!(queue.pop_exn(), 2)
-  assert_eq!(queue.pop_exn(), 3)
-  assert_eq!(queue.pop_exn(), 4)
+  assert_eq!(queue.unsafe_pop(), 1)
+  assert_eq!(queue.unsafe_pop(), 2)
+  assert_eq!(queue.unsafe_pop(), 3)
+  assert_eq!(queue.unsafe_pop(), 4)
   assert_eq!(queue.length(), 0)
 }
 
-test "panic pop_exn" {
-  @queue.of([]).pop_exn()
+test "panic unsafe_pop" {
+  @queue.of([]).unsafe_pop()
 }
 
 test "pop" {

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -114,7 +114,7 @@ pub fn each[K, V](self : T[K, V], f : (K, V) -> Unit) -> Unit {
       p = p.unwrap().left
     }
     if s.is_empty().not() {
-      p = s.pop_exn()
+      p = s.unsafe_pop()
       f(p.unwrap().key, p.unwrap().value)
       p = p.unwrap().right
     }
@@ -132,7 +132,7 @@ pub fn eachi[K, V](self : T[K, V], f : (Int, K, V) -> Unit) -> Unit {
       p = p.unwrap().left
     }
     if s.is_empty().not() {
-      p = s.pop_exn()
+      p = s.unsafe_pop()
       f(i, p.unwrap().key, p.unwrap().value)
       p = p.unwrap().right
       i += 1

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -293,7 +293,7 @@ fn each[V](self : Node[V], f : (V) -> Unit) -> Unit {
       p = p.unwrap().left
     }
     if s.is_empty().not() {
-      p = s.pop_exn()
+      p = s.unsafe_pop()
       f(p.unwrap().value)
       p = p.unwrap().right
     }
@@ -318,7 +318,7 @@ fn eachi[V](self : Node[V], f : (Int, V) -> Unit) -> Unit {
       p = p.unwrap().left
     }
     if s.is_empty().not() {
-      p = s.pop_exn()
+      p = s.unsafe_pop()
       f(i, p.unwrap().value)
       p = p.unwrap().right
       i += 1


### PR DESCRIPTION
# Changes

- Mark `x_exn` functions as deprecated (e.g., `pop_exn`, `peek_exn`, `nth_exn`, `head_exn`), and add new `unsafe_x` functions.
- `immut/list`
  - Correct the behaviors of the `take` and `drop` functions in `immut/list`.
    The result of `@list.of([1,2,3]).take(5)` should be `@list.of([1,2,3])`, but it currently causes a program abort when the index is out of bounds. The `drop` function also has this issue.
  - Change the return type of `maximum`, `minimum`, and `zip` to `Option[...]`.