### PR TITLE
fix: bigint bug

### DIFF
--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -241,7 +241,18 @@ pub fn op_div(self : BigInt, other : BigInt) -> BigInt {
   if other == zero {
     abort("division by zero")
   }
-  grade_school_div(self, other).0
+  // Handle negative numbers
+  if self.sign == Negative {
+    if other.sign == Negative {
+      grade_school_div(-self, -other).0
+    } else {
+      -grade_school_div(-self, other).0
+    }
+  } else if other.sign == Negative {
+    -grade_school_div(self, -other).0
+  } else {
+    return grade_school_div(self, other).0
+  }
 }
 
 /// Modulo two bigint
@@ -249,41 +260,23 @@ pub fn op_mod(self : BigInt, other : BigInt) -> BigInt {
   if other == zero {
     abort("division by zero")
   }
-  let (_, remainder) = grade_school_div(self, other)
-  remainder
+  // Handle negative numbers
+  if self.sign == Negative {
+    if other.sign == Negative {
+      -grade_school_div(-self, -other).1
+    } else {
+      -grade_school_div(-self, other).1
+    }
+  } else if other.sign == Negative {
+    grade_school_div(self, -other).1
+  } else {
+    grade_school_div(self, other).1
+  }
 }
 
 // Simplest way to divide two BigInts.
 // Assumption: other != zero.
 fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
-  if other.is_zero() {
-    abort("division by zero")
-  }
-  // Handle negative numbers
-  if self.sign == Negative {
-    if other.sign == Negative {
-      let (quotient, remainder) = grade_school_div(-self, -other)
-      if remainder == zero {
-        return (quotient, zero)
-      } else {
-        return (quotient, -remainder)
-      }
-    } else {
-      let (quotient, remainder) = grade_school_div(-self, other)
-      if remainder == zero {
-        return (-quotient, zero)
-      } else {
-        return (-quotient, -remainder)
-      }
-    }
-  } else if other.sign == Negative {
-    let (quotient, remainder) = grade_school_div(self, -other)
-    if remainder == zero {
-      return (-quotient, zero)
-    } else {
-      return (-quotient, remainder)
-    }
-  }
 
   // Handle edge cases
   if self < other {

--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -256,6 +256,9 @@ pub fn op_mod(self : BigInt, other : BigInt) -> BigInt {
 // Simplest way to divide two BigInts.
 // Assumption: other != zero.
 fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
+  if other.is_zero() {
+    abort("division by zero")
+  }
   // Handle negative numbers
   if self.sign == Negative {
     if other.sign == Negative {
@@ -290,9 +293,6 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   }
   if other.len == 1 {
     let number = other.limbs[0]
-    if number == 0 {
-      abort("divided by zero")
-    }
     let ret = self.deep_clone()
     if number == 1 {
       return (ret, zero)
@@ -319,28 +319,37 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   let dividend = self
   let divisor = other
 
-  // normalize 
-  let mut lshift = 0
-  let mut back = divisor.limbs[divisor.len - 1].to_int64()
-  while back < radix / 2L {
-    back = back.lsl(1)
-    lshift += 1
-  }
+  // D1. normalize
+  // m = divident.limbs.length() - divisor.limbs.length()
+  // left shift divident & divisor such that 
+  // - divisor.limbs.last() >= radix / 2
+  // - divident.limbs.length() = self.limbs.length() + 1
+  let lshift = max(
+    0,
+    64 - 1 - divisor.limbs[divisor.len - 1].to_int64().clz() - radix_bit_len,
+  )
+  let a_len = dividend.len
   let dividend = dividend.shl(lshift)
   let divisor = divisor.shl(lshift)
-  let a_len = dividend.len
   let b_len = divisor.len
   let b = FixedArray::make(b_len, 0L)
   for i = 0; i < b_len; i = i + 1 {
     b[i] = divisor.limbs[i].to_int64()
   }
-  let a = FixedArray::make(a_len, 0L)
+  let a = FixedArray::make(a_len + 1, 0L)
   for i = 0; i < a_len; i = i + 1 {
     a[i] = dividend.limbs[i].to_int64()
+  } else {
+    if dividend.limbs.length() > i {
+      a[i] = dividend.limbs[i].to_int64()
+    }
   }
+  let a_len = a_len + 1
+  // a is the adjusted dividend and b is the adjusted divisor
   let v1 = b[b_len - 1]
   let v2 = b[b_len - 2]
   let q = FixedArray::make(a_len - b_len, 0)
+  // D2 - D7 loop through m to 0
   for i = q.length() - 1; i >= 0; i = i - 1 {
     let u0 = a[i + b_len]
     let u1 = a[i + b_len - 1]

--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -25,9 +25,10 @@
 //
 // Invariants:
 // - len > 0
-// - forall i in 0..len-1, 0 <= limbs[i] < radix
-// - limbs[len-1] > 0
-// - forall i in len..limbs.length(), limbs[i] == 0
+// - forall 0 <= i < len. 0 <= limbs[i] < radix
+// - (exists 0 <= i < len. limbs[i] > 0) => limbs[len-1] > 0
+// - (forall 0 <= i < len. limbs[i] == 0) => limbs[0] == 0 and len == 1
+// - forall len <= i < limbs.length(). limbs[i] == 0
 struct BigInt {
   limbs : FixedArray[Int] // Note: do not use limbs.length(), use len instead because of leading zeros
   sign : Sign // true for positive, false for negative

--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -319,7 +319,7 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   // - divident.limbs.length() = self.limbs.length() + 1
   let lshift = max(
     0,
-    64 - 1 - divisor.limbs[divisor.len - 1].to_int64().clz() - radix_bit_len,
+    radix_bit_len - (64 - divisor.limbs[divisor.len - 1].to_int64().clz()),
   )
   let a_len = dividend.len
   let dividend = dividend.shl(lshift)
@@ -337,6 +337,10 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
       a[i] = dividend.limbs[i].to_int64()
     }
   }
+  // invariant : divisor.limbs.last() >= radix / 2
+  // if b[b_len - 1] < radix / 2 {
+  //   panic()
+  // }
   let a_len = a_len + 1
   // a is the adjusted dividend and b is the adjusted divisor
   let v1 = b[b_len - 1]

--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -322,7 +322,8 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   // - divident.limbs.length() = self.limbs.length() + 1
   let lshift = max(
     0,
-    radix_bit_len - (64 - divisor.limbs[divisor.len - 1].to_int64().clz()),
+    radix_bit_len -
+    (64 - divisor.limbs[divisor.len - 1].to_uint64().to_int64().clz()),
   )
   let a_len = dividend.len
   let dividend = dividend.shl(lshift)
@@ -332,12 +333,12 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   for i = 0; i < b_len; i = i + 1 {
     b[i] = divisor.limbs[i].to_uint64()
   }
-  let a = FixedArray::make(a_len + 1, 0L)
+  let a = FixedArray::make(a_len + 1, 0UL)
   for i = 0; i < a_len; i = i + 1 {
-    a[i] = dividend.limbs[i].to_int64()
+    a[i] = dividend.limbs[i].to_uint64()
   } else {
     if dividend.limbs.length() > i {
-      a[i] = dividend.limbs[i].to_int64()
+      a[i] = dividend.limbs[i].to_uint64()
     }
   }
   // invariant : divisor.limbs.last() >= radix / 2
@@ -348,7 +349,7 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   // a is the adjusted dividend and b is the adjusted divisor
   let v1 = b[b_len - 1]
   let v2 = b[b_len - 2]
-  let q = FixedArray::make(a_len - b_len, 0)
+  let q = FixedArray::make(a_len - b_len, 0U)
   // D2 - D7 loop through m to 0
   for i = q.length() - 1; i >= 0; i = i - 1 {
     let u0 = a[i + b_len]

--- a/builtin/bigint_wbtest.mbt
+++ b/builtin/bigint_wbtest.mbt
@@ -63,7 +63,7 @@ test "trivial property" {
   assert_eq!(a, b)
   let a = BigInt::from_int(65537)
   let b = BigInt::from_int(65536)
-  inspect!(a / b)
+  inspect!(a / b, content="1")
 }
 
 test "neg" {

--- a/builtin/bigint_wbtest.mbt
+++ b/builtin/bigint_wbtest.mbt
@@ -628,12 +628,6 @@ test "panic op_mod coverage for modulo by zero" {
   a % b |> ignore
 }
 
-test "panic grade_school_div coverage for division by zero" {
-  let a = BigInt::from_int(123456789)
-  let b = BigInt::from_int(0)
-  grade_school_div(a, b) |> ignore
-}
-
 test "panic shl coverage for negative shift" {
   let a = BigInt::from_int(123456789)
   a.shl(-1) |> ignore

--- a/builtin/bigint_wbtest.mbt
+++ b/builtin/bigint_wbtest.mbt
@@ -61,6 +61,9 @@ test "trivial property" {
   let a = BigInt::from_int(65537)
   let b = BigInt::from_int64(65537)
   assert_eq!(a, b)
+  let a = BigInt::from_int(65537)
+  let b = BigInt::from_int(65536)
+  inspect!(a / b)
 }
 
 test "neg" {


### PR DESCRIPTION
Div is not correct when having two numbers of the same `len` because the normalization step was not performed correctly.