### PR TITLE
fix: bigint bugs

### DIFF
--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -96,6 +96,9 @@ pub fn BigInt::from_int64(n : Int64) -> BigInt {
 
 /// Negate a bigint
 pub fn op_neg(self : BigInt) -> BigInt {
+  if self.is_zero() {
+    return zero
+  }
   // copy limbs
   let limbs = FixedArray::make(self.len, 0)
   limbs.unsafe_blit(0, self.limbs, 0, self.len)

--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -69,11 +69,7 @@ let one : BigInt = 1N
 
 /// Convert an Int to a BigInt.
 pub fn BigInt::from_int(n : Int) -> BigInt {
-  if n < 0 {
-    { limbs: FixedArray::make(1, -n), sign: Negative, len: 1 }
-  } else {
-    { limbs: FixedArray::make(1, n), sign: Positive, len: 1 }
-  }
+  BigInt::from_int64(n.to_int64())
 }
 
 /// Convert an Int64 to a BigInt.

--- a/builtin/bigint_wbtest.mbt
+++ b/builtin/bigint_wbtest.mbt
@@ -599,8 +599,8 @@ test "op_add coverage for max(self_len, other_len)" {
   let a = BigInt::from_int(123456789)
   let b = BigInt::from_int(987654321)
   let result = a + b
-  inspect!(a.len, content="1")
-  inspect!(b.len, content="1")
+  inspect!(a.len, content="2")
+  inspect!(b.len, content="2")
   inspect!(result.len, content="2")
 }
 
@@ -608,9 +608,9 @@ test "op_sub coverage for max(self_len, other_len)" {
   let a = BigInt::from_int(987654321)
   let b = BigInt::from_int(123456789)
   let result = a - b
-  inspect!(a.len, content="1")
-  inspect!(b.len, content="1")
-  inspect!(result.len, content="1")
+  inspect!(a.len, content="2")
+  inspect!(b.len, content="2")
+  inspect!(result.len, content="2")
 }
 
 test "panic op_div coverage for division by zero" {

--- a/builtin/bigint_wbtest.mbt
+++ b/builtin/bigint_wbtest.mbt
@@ -54,6 +54,15 @@ fn check_len(a : BigInt) -> Unit! {
   }
 }
 
+test "trivial property" {
+  let a = BigInt::from_int64(0L)
+  let b = -a
+  assert_eq!(a, b)
+  let a = BigInt::from_int(65537)
+  let b = BigInt::from_int64(65537)
+  assert_eq!(a, b)
+}
+
 test "neg" {
   let a = BigInt::from_int64(123456789012345678L)
   let b = -a


### PR DESCRIPTION
- `neg` didn't take into account of zero
- `from_int` broke invariant that `limbs[i]` < `radix`