### PR TITLE
Change UInt::to_int to  UInt::reinterpret_as_int

### DIFF
--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -732,9 +732,9 @@ pub fn to_hex(self : BigInt) -> String {
       let y = x % 16
       x /= 16
       tmp = if y < 10 {
-          Char::from_int(y.to_int() + 48).to_string()
+          Char::from_int(y.reinterpret_as_int() + 48).to_string()
         } else {
-          Char::from_int(y.to_int() + 55).to_string()
+          Char::from_int(y.reinterpret_as_int() + 55).to_string()
         } +
         tmp
     }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -426,6 +426,7 @@ impl UInt {
   op_shl(UInt, Int) -> UInt
   op_shr(UInt, Int) -> UInt
   op_sub(UInt, UInt) -> UInt
+  reinterpret_as_int(UInt) -> Int
   shl(UInt, Int) -> UInt
   shr(UInt, Int) -> UInt
   to_float(UInt) -> Float

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -94,7 +94,7 @@ pub fn UInt::to_string(self : UInt) -> String {
     if num2 != 0U {
       write_digits(num2)
     }
-    buf.write_char(Char::from_int((num % 10U).to_int() + 48))
+    buf.write_char(Char::from_int((num % 10U).reinterpret_as_int() + 48))
   }
 
   write_digits(self)

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -55,7 +55,7 @@ pub fn combine_int64(self : Hasher, value : Int64) -> Unit {
 }
 
 pub fn combine_uint(self : Hasher, value : UInt) -> Unit {
-  self.combine_int(value.to_int())
+  self.combine_int(value.reinterpret_as_int())
 }
 
 pub fn combine_uint64(self : Hasher, value : UInt64) -> Unit {

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -194,7 +194,13 @@ pub fn Byte::to_int64(self : Byte) -> Int64 {
   self.to_int().to_int64()
 }
 
-// UInt primitive
+/// reinterpret the unsigned int as signed int
+/// For number within the range of 0..=2^31-1, 
+/// the value is the same. For number within the range of 2^31..=2^32-1,
+/// the value is negative
+pub fn UInt::reinterpret_as_int(self : UInt) -> Int = "%u32.to_i32_reinterpret"
+
+/// @alert deprecated "Use `reinterpret_as_int` instead"
 pub fn UInt::to_int(self : UInt) -> Int = "%u32.to_i32_reinterpret"
 
 pub fn UInt::op_add(self : UInt, other : UInt) -> UInt = "%u32.add"

--- a/builtin/intrinsics_test.mbt
+++ b/builtin/intrinsics_test.mbt
@@ -59,11 +59,22 @@ test "Int::lsl should perform left shift operation" {
   inspect!((7).lsl(32), content="7")
 }
 
+test "reinterpret: UInt -> Int" {
+  inspect!(0U.reinterpret_as_int(), content="0")
+  inspect!(1U.reinterpret_as_int(), content="1")
+  inspect!((0x7fff_ffff : UInt).reinterpret_as_int(), content="2147483647")
+  inspect!((0x7fff_ffff : UInt), content="2147483647")
+  inspect!((0x8000_0000 : UInt).reinterpret_as_int(), content="-2147483648")
+  inspect!((0x8000_0000 : UInt), content="2147483648")
+  inspect!((0xffff_ffff : UInt).reinterpret_as_int(), content="-1")
+  inspect!((0xffff_ffff : UInt), content="4294967295")
+}
+
 test "uint test" {
   inspect!(100U == 100U, content="true")
   inspect!(0U < 100U, content="true")
   inspect!(100U > 0U, content="true")
-  inspect!(2147483648U.to_int(), content="-2147483648")
+  inspect!(2147483648U.reinterpret_as_int(), content="-2147483648")
   inspect!((-2147483648).to_uint(), content="2147483648")
   inspect!((2147483648U + 1000000000U).to_uint64(), content="3147483648")
   inspect!(2147483647U + 1U, content="2147483648")
@@ -188,4 +199,9 @@ test "float" {
   inspect!(b'5'.to_float().to_double(), content="53")
   inspect!((123456).to_float().to_double(), content="123456")
   // inspect!((0.36 : Float).sqrt().to_double(), content="0.6000000238418579")
+}
+
+test "Int::to_double" {
+  inspect!((10).to_double(), content="10")
+  inspect!((20).to_double(), content="20")
 }

--- a/double/exp.wasm-gc.mbt
+++ b/double/exp.wasm-gc.mbt
@@ -49,7 +49,7 @@ pub fn exp(self : Double) -> Double {
   let two1023 = 8.988465674311579539e307
   let mut k : Int = 0
   let mut hx : UInt = get_high_word(self)
-  let xsb : Int = ((hx >> 31) & 1).to_int()
+  let xsb : Int = ((hx >> 31) & 1).reinterpret_as_int()
   hx = hx & 0x7FFFFFFF
   if hx >= 0x40862E42 {
     if hx >= 0x7FF00000 {
@@ -94,7 +94,9 @@ pub fn exp(self : Double) -> Double {
   let t = x * x
   let twopk = if k >= -1021 {
     insert_words(
-      (0x3FF00000 + (k.to_uint() << 20).to_int()).to_int64().to_uint64(),
+      (0x3FF00000 + (k.to_uint() << 20).reinterpret_as_int())
+      .to_int64()
+      .to_uint64(),
       0,
     )
   } else {

--- a/double/internal/ryu/ryu.mbt
+++ b/double/internal/ryu/ryu.mbt
@@ -284,7 +284,10 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
     m2 = ieeeMantissa
   } else {
     // Add implicit leading 1.
-    e2 = ieeeExponent.to_int() - gDOUBLE_BIAS - gDOUBLE_MANTISSA_BITS - 2
+    e2 = ieeeExponent.reinterpret_as_int() -
+      gDOUBLE_BIAS -
+      gDOUBLE_MANTISSA_BITS -
+      2
     m2 = 1UL.lsl(gDOUBLE_MANTISSA_BITS).lor(ieeeMantissa)
   }
   let even = m2.land(1UL) == 0UL

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -54,7 +54,7 @@ pub fn State::next(self : State) -> (UInt64, Bool) {
     return (0, false)
   }
   self.i = i + 1
-  (self.buffer[i.to_int() & 31], true)
+  (self.buffer[i.reinterpret_as_int() & 31], true)
 }
 
 fn bytesToUInt64(b : Bytes) -> UInt64 {

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -55,7 +55,7 @@ pub fn Rand::int(self : Rand, ~limit : Int = 0) -> Int {
     // Range [0, 2^31)
     self.next().lsr(33).to_int()
   } else {
-    self.uint(limit=limit.to_uint()).to_int()
+    self.uint(limit=limit.to_uint()).reinterpret_as_int()
   }
 }
 

--- a/random/splitmix/random.mbt
+++ b/random/splitmix/random.mbt
@@ -53,7 +53,7 @@ pub fn next_two_uint(self : RandomState) -> (UInt, UInt) {
 }
 
 pub fn next_int(self : RandomState) -> Int {
-  self.next_uint().to_int()
+  self.next_uint().reinterpret_as_int()
 }
 
 pub fn next_double(self : RandomState) -> Double {

--- a/uint/uint.mbt
+++ b/uint/uint.mbt
@@ -17,7 +17,7 @@ pub let min_value : UInt = 0U
 pub let max_value : UInt = 4294967295U
 
 pub fn to_byte(self : UInt) -> Byte {
-  self.to_int().to_byte()
+  self.reinterpret_as_int().to_byte()
 }
 
 pub fn to_int64(self : UInt) -> Int64 {


### PR DESCRIPTION
the latter is more descriptive, deprecate the former
cc @Yoorkin @qazxcdswe123 