### PR TITLE
Add to_array and to_string funtions for Iter2

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -203,6 +203,7 @@ impl Iter {
   each[T](Self[T], (T) -> Unit) -> Unit
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit
   empty[T]() -> Self[T]
+  enumerate[T](Self[T]) -> Iter2[Int, T]
   filter[T](Self[T], (T) -> Bool) -> Self[T]
   find_first[T](Self[T], (T) -> Bool) -> T?
   flat_map[T, R](Self[T], (T) -> Self[R]) -> Self[R]
@@ -235,6 +236,8 @@ impl Iter2 {
   iter2[A, B](Self[A, B]) -> Self[A, B]
   new[A, B](((A, B) -> IterResult) -> IterResult) -> Self[A, B]
   run[A, B](Self[A, B], (A, B) -> IterResult) -> IterResult
+  to_array[A, B](Self[A, B]) -> Array[Tuple[A, B]]
+  to_string[A : Show, B : Show](Self[A, B]) -> String
 }
 
 pub enum IterResult {
@@ -721,6 +724,8 @@ impl Show for BigInt
 impl Show for Buffer
 
 impl Show for Iter
+
+impl Show for Iter2
 
 impl Show for Map
 

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -203,7 +203,6 @@ impl Iter {
   each[T](Self[T], (T) -> Unit) -> Unit
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit
   empty[T]() -> Self[T]
-  enumerate[T](Self[T]) -> Iter2[Int, T]
   filter[T](Self[T], (T) -> Bool) -> Self[T]
   find_first[T](Self[T], (T) -> Bool) -> T?
   flat_map[T, R](Self[T], (T) -> Self[R]) -> Self[R]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -66,40 +66,6 @@ pub fn all[T](self : Iter[T], f : (T) -> Bool) -> Bool {
   IterContinue
 }
 
-/// Enumerates the elements of an iterator, pairing each element with its index.
-///
-/// # Returns
-///
-/// An iterator of pairs, where the first element of each pair is the index
-/// (starting from 0) and the second element is the corresponding element from
-/// the input iterator.
-///
-/// # Examples
-///
-/// ```
-/// let array = [5, 6, 7]
-/// for id, item in array.iter().enumerate() {
-///   println("\{id}, \{item}")
-/// }
-/// ```
-pub fn enumerate[T](self : Iter[T]) -> Iter2[Int, T] {
-  Iter2::new(
-    fn(yield) {
-      let mut index = 0
-      self.run(
-        fn(element) {
-          if yield(index, element) == IterEnd {
-            IterEnd
-          } else {
-            index = index + 1
-            IterContinue
-          }
-        },
-      )
-    },
-  )
-}
-
 /// Iterates over each element in the iterator, applying the function `f` to each element with index.
 ///
 /// # Type Parameters

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -66,6 +66,40 @@ pub fn all[T](self : Iter[T], f : (T) -> Bool) -> Bool {
   IterContinue
 }
 
+/// Enumerates the elements of an iterator, pairing each element with its index.
+///
+/// # Returns
+///
+/// An iterator of pairs, where the first element of each pair is the index
+/// (starting from 0) and the second element is the corresponding element from
+/// the input iterator.
+///
+/// # Examples
+///
+/// ```
+/// let array = [5, 6, 7]
+/// for id, item in array.iter().enumerate() {
+///   println("\{id}, \{item}")
+/// }
+/// ```
+pub fn enumerate[T](self : Iter[T]) -> Iter2[Int, T] {
+  Iter2::new(
+    fn(yield) {
+      let mut index = 0
+      self.run(
+        fn(element) {
+          if yield(index, element) == IterEnd {
+            IterEnd
+          } else {
+            index = index + 1
+            IterContinue
+          }
+        },
+      )
+    },
+  )
+}
+
 /// Iterates over each element in the iterator, applying the function `f` to each element with index.
 ///
 /// # Type Parameters

--- a/builtin/iter2.mbt
+++ b/builtin/iter2.mbt
@@ -27,11 +27,11 @@ pub fn run[A, B](self : Iter2[A, B], f : (A, B) -> IterResult) -> IterResult {
 }
 
 pub impl[A : Show, B : Show] Show for Iter2[A, B] with output(self, logger) {
-  Show::output(self.iter().to_array(), logger)
+  Show::output(self.to_array(), logger)
 }
 
 pub fn to_string[A : Show, B : Show](self : Iter2[A, B]) -> String {
-  self.iter().to_array().to_string()
+  self.to_array().to_string()
 }
 
 pub fn Iter2::new[A, B](

--- a/builtin/iter2.mbt
+++ b/builtin/iter2.mbt
@@ -26,6 +26,14 @@ pub fn run[A, B](self : Iter2[A, B], f : (A, B) -> IterResult) -> IterResult {
   (self._)(f)
 }
 
+pub impl[A : Show, B : Show] Show for Iter2[A, B] with output(self, logger) {
+  Show::output(self.iter().to_array(), logger)
+}
+
+pub fn to_string[A : Show, B : Show](self : Iter2[A, B]) -> String {
+  self.iter().to_array().to_string()
+}
+
 pub fn Iter2::new[A, B](
   f : ((A, B) -> IterResult) -> IterResult
 ) -> Iter2[A, B] {
@@ -51,4 +59,8 @@ pub fn iter2[A, B](self : Iter2[A, B]) -> Iter2[A, B] {
   // `for k,v in map.iter2() { ... }` 
   // still work    
   self
+}
+
+pub fn to_array[A, B](self : Iter2[A, B]) -> Array[(A, B)] {
+  self.iter().to_array()
 }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -577,3 +577,10 @@ test "Iter::as_view" {
   inspect!([1, 2, 3].iter()[1:], content="[2, 3]")
   inspect!([1, 2, 3].iter()[:], content="[1, 2, 3]")
 }
+
+test "Iter::enumerate" {
+  inspect!([1, 2, 3].iter2(), content="[(0, 1), (1, 2), (2, 3)]")
+  inspect!([1, 2, 3].iter2().to_string(), content="[(0, 1), (1, 2), (2, 3)]")
+  inspect!([1, 2, 3].iter().enumerate(), content="[(0, 1), (1, 2), (2, 3)]")
+  inspect!([10].iter().enumerate().to_string(), content="[(0, 10)]")
+}

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -581,6 +581,4 @@ test "Iter::as_view" {
 test "Iter::enumerate" {
   inspect!([1, 2, 3].iter2(), content="[(0, 1), (1, 2), (2, 3)]")
   inspect!([1, 2, 3].iter2().to_string(), content="[(0, 1), (1, 2), (2, 3)]")
-  inspect!([1, 2, 3].iter().enumerate(), content="[(0, 1), (1, 2), (2, 3)]")
-  inspect!([10].iter().enumerate().to_string(), content="[(0, 10)]")
 }


### PR DESCRIPTION
I've implemented `to_string` and `to_array` functions and the `Show` trait for `Iter2`.