### PR TITLE
use int64's popcnt

### DIFF
--- a/random/splitmix/random.mbt
+++ b/random/splitmix/random.mbt
@@ -88,10 +88,8 @@ fn mix64variant13(z0 : UInt64) -> UInt64 {
 }
 
 fn pop_count(c : UInt64) -> Int {
-  loop 0, c {
-    x, 0 => x
-    c, w => continue c + 1, w & (w - 1)
-  }
+  c.to_int64().popcnt()
+}
 }
 
 fn mix_gamma(z0 : UInt64) -> UInt64 {

--- a/random/splitmix/random.mbt
+++ b/random/splitmix/random.mbt
@@ -90,6 +90,9 @@ fn mix64variant13(z0 : UInt64) -> UInt64 {
 fn pop_count(c : UInt64) -> Int {
   c.to_int64().popcnt()
 }
+
+test {
+  inspect!(pop_count(0x7000_0001_1F00_100FUL), content="14")
 }
 
 fn mix_gamma(z0 : UInt64) -> UInt64 {


### PR DESCRIPTION
the following code in js backend will cause an infinity loop in https://github.com/moonbitlang/core/pull/978 

It is a compiler bug. This PR fixes it by using Int64's popcnt method. The compiler bug should be fixed later.

```
fn pop_count(c : UInt64) -> Int {
  loop 0, c {
    x, 0 => x
    c, w => continue c + 1, w & (w - 1)
  }
}

test {
  let _ = pop_count(1UL)
}
```