### PR TITLE
[POC] Stringview

### DIFF
--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -1,0 +1,57 @@
+struct StringView {
+  buf : Ref[String]
+  start : Int
+  len : Int
+}
+
+pub fn length(self : StringView) -> Int {
+  self.len
+}
+
+pub fn op_get(self : StringView, index : Int) -> Char {
+  if index >= self.len {
+    let len = self.len
+    abort(
+      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+    )
+  }
+  self.buf.val[self.start + index]
+}
+
+pub fn op_as_view(self : String, ~start : Int, ~end? : Int) -> StringView {
+  let len = self.length()
+  let end = match end {
+    None => len
+    Some(end) => end
+  }
+  guard start >= 0 && start <= end && end <= len else {
+    abort("View start index out of bounds")
+  }
+  StringView::{ buf: { val: self }, start, len: end - start }
+}
+
+pub fn op_as_view(self : StringView, ~start : Int, ~end? : Int) -> StringView {
+  let len = self.len
+  let end = match end {
+    None => len
+    Some(end) => end
+  }
+  guard start >= 0 && start <= end && end <= len else {
+    abort("View start index out of bounds")
+  }
+  StringView::{ buf: self.buf, start: self.start + start, len: end - start }
+}
+
+pub fn iter(self : StringView) -> Iter[Char] {
+  Iter::new(
+    fn(yield) {
+      for i = 0; i < self.len; i = i + 1 {
+        let v = self[i]
+        guard let IterContinue = yield(v) else { x => break x }
+
+      } else {
+        IterContinue
+      }
+    },
+  )
+}

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -1,3 +1,17 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 struct StringView {
   buf : Ref[String]
   start : Int

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -1,0 +1,83 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "string_as_view" {
+  inspect!("123"[:].length(), content="3")
+}
+
+test "view_as_view" {
+  inspect!("123"[:][:].length(), content="3")
+}
+
+test "op_get" {
+  inspect!("123"[:][1], content="'2'")
+  inspect!("123"[:][2], content="'3'")
+}
+
+test "panic string_as_view_start_index_error" {
+  "123"[-1:0] |> ignore
+}
+
+test "panic string_as_view_start_index_error" {
+  "123"[-1:0] |> ignore
+}
+
+test "panic string_as_view_end_index_error" {
+  "123"[0:-1] |> ignore
+}
+
+test "panic string_as_view_end_index_error" {
+  "123"[0:-1] |> ignore
+}
+
+test "panic string_as_view_length_index_error" {
+  "123"[0:4] |> ignore
+}
+
+test "panic view_as_view_start_index_error" {
+  "123"[:][-1:0] |> ignore
+}
+
+test "panic view_as_view_start_index_error" {
+  "123"[:][-1:0] |> ignore
+}
+
+test "panic view_as_view_end_index_error" {
+  "123"[:][0:-1] |> ignore
+}
+
+test "panic view_as_view_end_index_error" {
+  "123"[:][0:-1] |> ignore
+}
+
+test "panic view_as_view_length_index_error" {
+  "123"[:][0:4] |> ignore
+}
+
+test "panic string_as_view_get_index_error" {
+  "123"[:][5] |> ignore
+}
+
+test "iter" {
+  let string = "012345678910"
+  inspect!(
+    string[:].iter().to_string(),
+    content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '1', '0']",
+  )
+  inspect!(
+    string[5:].iter().to_string(),
+    content="['5', '6', '7', '8', '9', '1', '0']",
+  )
+  inspect!(string[5:9].iter().to_string(), content="['5', '6', '7', '8']")
+}


### PR DESCRIPTION
The main idea is to eliminate the cost of constructing an Array from String then ArrayView it.

However, this implementation lacks some important property, like

```
match view {
  ['-', '>', .. as rest] => ...
}
```

Which is extensively used in minimoonbit's implementation. This is not ideal, and the compiler should be able to handle this case