### PR TITLE
add `concat`, `from_array` methods for String

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -68,7 +68,7 @@ pub fn Array::new_with_index[T](length : Int, value : (Int) -> T) -> Array[T] {
 ///
 /// The joined string.
 /// 
-/// @alert deprecated "Use `String::join` instead"
+/// @alert deprecated "Use `String::concat` instead"
 pub fn join[T : Show](self : Array[T], sep : String) -> String {
   let len = self.length()
   if len == 0 {

--- a/array/array.mbt
+++ b/array/array.mbt
@@ -113,33 +113,6 @@ pub fn Array::shuffle[T](arr : Array[T], ~rand : (Int) -> Int) -> Array[T] {
   new_arr
 }
 
-/// Joins the elements of an array into a single string, using the specified separator.
-///
-/// # Arguments
-///
-/// * `self` - The array of strings to join.
-/// * `sep` - The separator string to insert between each element.
-///
-/// # Returns
-///
-/// The joined string.
-pub fn join[T : Show](self : Array[T], sep : String) -> String {
-  let len = self.length()
-  if len == 0 {
-    return ""
-  }
-  let sep_size = sep.length() * (len - 1)
-  let self_size = self[0].to_string().length() * (len + 1) // + 1 to avoid allocation in buffer
-  let size = sep_size + self_size
-  let buf = Buffer::new(size_hint=size + 1) // + 1 to avoid allocation in buffer
-  buf.write_string(self[0].to_string())
-  for i in 1..<len {
-    buf.write_string(sep)
-    buf.write_string(self[i].to_string())
-  }
-  buf.to_string()
-}
-
 /// Returns a new array containing the elements of the original array that satisfy the given predicate.
 /// 
 /// # Arguments

--- a/array/array.mbt
+++ b/array/array.mbt
@@ -57,6 +57,35 @@ pub fn Array::new_with_index[T](length : Int, value : (Int) -> T) -> Array[T] {
   }
 }
 
+/// Joins the elements of an array into a single string, using the specified separator.
+///
+/// # Arguments
+///
+/// * `self` - The array of strings to join.
+/// * `sep` - The separator string to insert between each element.
+///
+/// # Returns
+///
+/// The joined string.
+/// 
+/// @alert deprecated "Use `String::join` instead"
+pub fn join[T : Show](self : Array[T], sep : String) -> String {
+  let len = self.length()
+  if len == 0 {
+    return ""
+  }
+  let sep_size = sep.length() * (len - 1)
+  let self_size = self[0].to_string().length() * (len + 1) // + 1 to avoid allocation in buffer
+  let size = sep_size + self_size
+  let buf = Buffer::new(size_hint=size + 1) // + 1 to avoid allocation in buffer
+  buf.write_string(self[0].to_string())
+  for i in 1..<len {
+    buf.write_string(sep)
+    buf.write_string(self[i].to_string())
+  }
+  buf.to_string()
+}
+
 pub fn Array::makei[T](length : Int, value : (Int) -> T) -> Array[T] {
   if length <= 0 {
     []

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -46,7 +46,6 @@ impl FixedArray {
 impl Array {
   copy[T](Self[T]) -> Self[T]
   from_iter[T](Iter[T]) -> Self[T]
-  join[T : Show](Self[T], String) -> String
   last[A](Self[A]) -> A?
   makei[T](Int, (Int) -> T) -> Self[T]
   map_option[A, B](Self[A], (A) -> B?) -> Self[B]

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -46,6 +46,7 @@ impl FixedArray {
 impl Array {
   copy[T](Self[T]) -> Self[T]
   from_iter[T](Iter[T]) -> Self[T]
+  join[T : Show](Self[T], String) -> String
   last[A](Self[A]) -> A?
   makei[T](Int, (Int) -> T) -> Self[T]
   map_option[A, B](Self[A], (A) -> B?) -> Self[B]

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -46,7 +46,7 @@ impl FixedArray {
 impl Array {
   copy[T](Self[T]) -> Self[T]
   from_iter[T](Iter[T]) -> Self[T]
-  join[T : Show](Self[T], String) -> String
+  join[T : Show](Self[T], String) -> String //deprecated
   last[A](Self[A]) -> A?
   makei[T](Int, (Int) -> T) -> Self[T]
   map_option[A, B](Self[A], (A) -> B?) -> Self[B]

--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -354,12 +354,6 @@ test "flatten" {
   assert_eq!(vv.length(), 4)
 }
 
-test "join" {
-  let v = [3, 4, 5]
-  let s = v.join(", ")
-  assert_eq!(s, "3, 4, 5")
-}
-
 test "fold" {
   let sum = [1, 2, 3, 4, 5].fold(init=0, fn { sum, elem => sum + elem })
   assert_eq!(sum, 15)

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -707,7 +707,7 @@ impl Hash for Result
 
 impl Hash for Bytes
 
-impl Hash for Hash
+impl Hash for $default_impl
 
 impl Hash for Tuple(2)
 
@@ -749,6 +749,8 @@ impl Show for Bytes
 
 impl Show for Ref
 
+impl Show for $default_impl
+
 impl Show for Array
 
 impl Show for ArrayView
@@ -762,8 +764,6 @@ impl Show for Iter
 impl Show for Iter2
 
 impl Show for Map
-
-impl Show for Show
 
 impl Show for SourceLoc
 

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -18,7 +18,7 @@
 /// String::from_array(['H', 'e', 'l', 'l', 'o']) // "Hello"  
 /// ```
 /// 
-/// Do not convert large datas to `Array[Char]` and build a string with `String::join`.
+/// Do not convert large datas to `Array[Char]` and build a string with `String::from_array`.
 /// 
 /// For efficiency considerations, it's recommended to use `Buffer` instead.
 pub fn String::from_array(chars : Array[Char]) -> String {
@@ -35,7 +35,6 @@ pub fn String::from_array(chars : Array[Char]) -> String {
 /// String::concat(["Hello", ", ", "world!"]) // "Hello, world!"
 /// String::concat(["a", "b", "c"], separator=",") // "a,b,c"
 /// ```
-/// 
 pub fn String::concat(
   strings : Array[String],
   ~separator : String = ""

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -33,31 +33,29 @@ pub fn String::from_array(chars : Array[Char]) -> String {
 /// 
 /// ```
 /// String::concat(["Hello", ", ", "world!"]) // "Hello, world!"
+/// String::concat(["a", "b", "c"], separator=",") // "a,b,c"
 /// ```
 /// 
-pub fn String::concat(strings : Array[String]) -> String {
+pub fn String::concat(
+  strings : Array[String],
+  ~separator : String = ""
+) -> String {
   let buf = Buffer::new()
-  for s in strings {
-    buf.write_string(s)
-  }
-  buf.to_string()
-}
-
-/// Join strings with a separator.
-/// 
-/// ```
-/// String::join(["Hello", "world!"], separator=", ") // "Hello, world!"
-/// ```
-pub fn String::join(strings : Array[String], ~separator : String) -> String {
-  let buf = Buffer::new()
-  let mut first = true
-  for s in strings {
-    if first {
-      first = false
-    } else {
-      buf.write_string(separator)
+  if separator == "" {
+    for s in strings {
+      buf.write_string(s)
     }
-    buf.write_string(s)
+  } else {
+    match strings {
+      [] => ()
+      [hd, .. as tl] => {
+        buf.write_string(hd)
+        for s in tl {
+          buf.write_string(separator)
+          buf.write_string(s)
+        }
+      }
+    }
   }
   buf.to_string()
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -43,6 +43,25 @@ pub fn String::concat(strings : Array[String]) -> String {
   buf.to_string()
 }
 
+/// Join strings with a separator.
+/// 
+/// ```
+/// String::join(["Hello", "world!"], separator=", ") // "Hello, world!"
+/// ```
+pub fn String::join(strings : Array[String], ~separator : String) -> String {
+  let buf = Buffer::new()
+  let mut first = true
+  for s in strings {
+    if first {
+      first = false
+    } else {
+      buf.write_string(separator)
+    }
+    buf.write_string(s)
+  }
+  buf.to_string()
+}
+
 /// Compare two strings.
 /// String with longer length is bigger.
 /// strings of the same length are compared in lexicalgraphic order.

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -12,6 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Convert char array to string.
+/// 
+/// ```
+/// String::from_array(['H', 'e', 'l', 'l', 'o']) // "Hello"  
+/// ```
+/// 
+/// Do not convert large datas to `Array[Char]` and build a string with `String::join`.
+/// 
+/// For efficiency considerations, it's recommended to use `Buffer` instead.
+pub fn String::from_array(chars : Array[Char]) -> String {
+  let buf = Buffer::new(size_hint=chars.length() * 4)
+  for c in chars {
+    buf.write_char(c)
+  }
+  buf.to_string()
+}
+
+/// Concatenate strings.
+/// 
+/// ```
+/// String::concat(["Hello", ", ", "world!"]) // "Hello, world!"
+/// ```
+/// 
+pub fn String::concat(strings : Array[String]) -> String {
+  let buf = Buffer::new()
+  for s in strings {
+    buf.write_string(s)
+  }
+  buf.to_string()
+}
+
 /// Compare two strings.
 /// String with longer length is bigger.
 /// strings of the same length are compared in lexicalgraphic order.

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -5,6 +5,7 @@ package moonbitlang/core/string
 // Types and methods
 impl String {
   compare(String, String) -> Int
+  concat(Array[String]) -> String
   contains(String, String) -> Bool
   contains_char(String, Char) -> Bool
   default() -> String
@@ -16,7 +17,7 @@ impl String {
   is_empty(String) -> Bool
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
-  join(Array[String]) -> String
+  join(Array[String], ~separator : String) -> String
   last_index_of(String, String, ~from : Int = ..) -> Int
   pad_end(String, Int, Char) -> String
   pad_start(String, Int, Char) -> String

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -5,7 +5,7 @@ package moonbitlang/core/string
 // Types and methods
 impl String {
   compare(String, String) -> Int
-  concat(Array[String]) -> String
+  concat(Array[String], ~separator : String = ..) -> String
   contains(String, String) -> Bool
   contains_char(String, Char) -> Bool
   default() -> String
@@ -17,7 +17,6 @@ impl String {
   is_empty(String) -> Bool
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
-  join(Array[String], ~separator : String) -> String
   last_index_of(String, String, ~from : Int = ..) -> Int
   pad_end(String, Int, Char) -> String
   pad_start(String, Int, Char) -> String

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -10,11 +10,13 @@ impl String {
   default() -> String
   ends_with(String, String) -> Bool
   fold[A](String, ~init : A, (A, Char) -> A) -> A
+  from_array(Array[Char]) -> String
   index_of(String, String, ~from : Int = ..) -> Int
   is_blank(String) -> Bool
   is_empty(String) -> Bool
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
+  join(Array[String]) -> String
   last_index_of(String, String, ~from : Int = ..) -> Int
   pad_end(String, Int, Char) -> String
   pad_start(String, Int, Char) -> String

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -18,14 +18,11 @@ test "String::from_array" {
 
 test "String::concat" {
   inspect!(String::concat(["123", "456"]), content="123456")
-}
-
-test "String::join" {
   inspect!(
-    String::join(["aaa", "bbb", "ccc"], separator=" "),
+    String::concat(["aaa", "bbb", "ccc"], separator=" "),
     content="aaa bbb ccc",
   )
-  inspect!(String::join([], separator=" "), content="")
+  inspect!(String::concat([], separator=" "), content="")
 }
 
 test "default" {

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -20,6 +20,14 @@ test "String::concat" {
   inspect!(String::concat(["123", "456"]), content="123456")
 }
 
+test "String::join" {
+  inspect!(
+    String::join(["aaa", "bbb", "ccc"], separator=" "),
+    content="aaa bbb ccc",
+  )
+  inspect!(String::join([], separator=" "), content="")
+}
+
 test "default" {
   inspect!(@string.default())
 }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+test "String::from_array" {
+  inspect!(String::from_array(['1', '2', '3', '4', '5']), content="12345")
+}
+
+test "String::concat" {
+  inspect!(String::concat(["123", "456"]), content="123456")
+}
+
 test "default" {
   inspect!(@string.default())
 }


### PR DESCRIPTION
- add `concat`, `from_array` methods for String
- remove `Array::join`
    The behavior of Array::join is not the same as javascript, because the `Show` trait is used to logging or debugging, the output result is always remains "as is".  e.g.  in moonbit,`["abc","def"].join() == "\"abc\"\"def\""`. So I prefer to remove this API and use `String::join` instead.

fix #989 