### PR TITLE
Add String.pad_left and String.pad_right

### DIFF
--- a/string/string.mbt
+++ b/string/string.mbt
@@ -538,8 +538,8 @@ pub fn rev(self : String) -> String {
   result
 }
 
-/// Returns a new string with length `total_width` and `padding_char` prefixed 
-/// if `self.length() < total_width`.
+/// `pad_left` is a new string with `padding_char`s prefixed to `self` if `self.length() < total_width`. The length of the
+/// returned string is `total_width`.
 /// 
 /// Example:
 /// 
@@ -558,6 +558,30 @@ pub fn pad_left(
       buf.write_char(padding_char)
     }
     buf.write_string(self)
+    buf.to_string()
+  }
+}
+
+/// `pad_right` is a new String with `padding_char`s suffixed to `self` if `self.length() < total_width`. The length of the
+/// returned string is `total_width`.
+/// 
+/// Example:
+/// 
+/// ```"2".pad_right(3, 'x') == "2xx"```
+pub fn pad_right(
+  self : String,
+  total_width : Int,
+  padding_char : Char
+) -> String {
+  let len = self.length()
+  if len >= total_width {
+    self
+  } else {
+    let buf = Buffer::new(size_hint=total_width)
+    buf.write_string(self)
+    for i = 0; i < total_width - len; i = i + 1 {
+      buf.write_char(padding_char)
+    }
     buf.to_string()
   }
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -537,3 +537,27 @@ pub fn rev(self : String) -> String {
   }
   result
 }
+
+/// Returns a new string with length `total_width` and `padding_char` prefixed 
+/// if `self.length() < total_width`.
+/// 
+/// Example:
+/// 
+/// ```"2".pad_left(3, '0') == "002"```
+pub fn pad_left(
+  self : String,
+  total_width : Int,
+  padding_char : Char
+) -> String {
+  let len = self.length()
+  if len >= total_width {
+    self
+  } else {
+    let buf = Buffer::new(size_hint=total_width)
+    for i = 0; i < total_width - len; i = i + 1 {
+      buf.write_char(padding_char)
+    }
+    buf.write_string(self)
+    buf.to_string()
+  }
+}

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -17,6 +17,7 @@ impl String {
   iter2(String) -> Iter2[Int, Char]
   last_index_of(String, String, ~from : Int = ..) -> Int
   pad_left(String, Int, Char) -> String
+  pad_right(String, Int, Char) -> String
   replace(String, ~old : String, ~new : String) -> String
   replace_all(String, ~old : String, ~new : String) -> String
   rev(String) -> String

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -16,6 +16,7 @@ impl String {
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
   last_index_of(String, String, ~from : Int = ..) -> Int
+  pad_left(String, Int, Char) -> String
   replace(String, ~old : String, ~new : String) -> String
   replace_all(String, ~old : String, ~new : String) -> String
   rev(String) -> String

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -492,3 +492,9 @@ test "String::fold" {
     content="@list.of(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
 }
+
+test "pad_left" {
+  inspect!("2".pad_left(3, '0'), content="002")
+  inspect!("22".pad_left(2, '0'), content="22")
+  inspect!("5".pad_left(4, 'x'), content="xxx5")
+}

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -498,3 +498,9 @@ test "pad_left" {
   inspect!("22".pad_left(2, '0'), content="22")
   inspect!("5".pad_left(4, 'x'), content="xxx5")
 }
+
+test "pad_right" {
+  inspect!("2".pad_right(3, 'x'), content="2xx")
+  inspect!("22".pad_right(2, '0'), content="22")
+  inspect!("5".pad_right(4, 'x'), content="5xxx")
+}


### PR DESCRIPTION
This PR adds 2 string methods that I have been copy pasting in a few projects. It would be nice if moonbit core library supports them out of the box. 
1. pad_left - given a total_width and a padding_char, pads the left of the string.
2. pad_right - given a total_width and a padding_char, pads the right of the string.

With regards to implementation details, I have used the buffer approach rather than the string concatenation approach. However, I can be convinced to use the string concatenation approach since string allocations are minimal for our use case. 