### PR TITLE
tweak pad_start/end and deprecate pad_left/right

### DIFF
--- a/string/string.mbt
+++ b/string/string.mbt
@@ -213,7 +213,7 @@ pub fn trim(self : String, trim_set : String) -> String {
   if self == "" || trim_set == "" {
     self
   } else {
-    self.trim_left(trim_set).trim_right(trim_set)
+    self.trim_start(trim_set).trim_end(trim_set)
   }
 }
 
@@ -221,8 +221,13 @@ pub fn contains_char(self : String, c : Char) -> Bool {
   self.iter().any(fn(ch) { ch == c })
 }
 
-/// Removes all leading chars contained in the given string.
+/// @alert deprecated "Use `String::trim_start` instead"
 pub fn trim_left(self : String, trim_set : String) -> String {
+  self.trim_start(trim_set)
+}
+
+/// Removes all leading chars contained in the given string.
+pub fn trim_start(self : String, trim_set : String) -> String {
   let len = self.length()
   for i = 0; i < len; i = i + 1 {
     let c1 = self[i]
@@ -246,8 +251,13 @@ pub fn trim_left(self : String, trim_set : String) -> String {
   }
 }
 
-/// Removes all trailing chars contained in the given string.
+/// @alert deprecated "Use `String::trim_end` instead"
 pub fn trim_right(self : String, trim_set : String) -> String {
+  self.trim_end(trim_set)
+}
+
+/// Removes all trailing chars contained in the given string.
+pub fn trim_end(self : String, trim_set : String) -> String {
   let len = self.length()
   for i = len - 1; i >= 0; i = i - 1 {
     let c2 = self[i]

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -544,7 +544,7 @@ pub fn rev(self : String) -> String {
 /// Example:
 /// 
 /// ```"2".pad_left(3, '0') == "002"```
-pub fn pad_left(
+pub fn pad_start(
   self : String,
   total_width : Int,
   padding_char : Char
@@ -568,11 +568,7 @@ pub fn pad_left(
 /// Example:
 /// 
 /// ```"2".pad_right(3, 'x') == "2xx"```
-pub fn pad_right(
-  self : String,
-  total_width : Int,
-  padding_char : Char
-) -> String {
+pub fn pad_end(self : String, total_width : Int, padding_char : Char) -> String {
   let len = self.length()
   if len >= total_width {
     self

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -31,9 +31,11 @@ impl String {
   to_lower(String) -> String
   to_upper(String) -> String
   trim(String, String) -> String
+  trim_end(String, String) -> String
   trim_left(String, String) -> String
   trim_right(String, String) -> String
   trim_space(String) -> String
+  trim_start(String, String) -> String
 }
 
 // Type aliases

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -16,8 +16,8 @@ impl String {
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
   last_index_of(String, String, ~from : Int = ..) -> Int
-  pad_left(String, Int, Char) -> String
-  pad_right(String, Int, Char) -> String
+  pad_end(String, Int, Char) -> String
+  pad_start(String, Int, Char) -> String
   replace(String, ~old : String, ~new : String) -> String
   replace_all(String, ~old : String, ~new : String) -> String
   rev(String) -> String

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -173,24 +173,24 @@ test "panic substring_length_index_error" {
 }
 
 test "trim_left" {
-  inspect!("aaabcd".trim_left("a"), content="bcd")
-  inspect!("aaabcd".trim_left(" "), content="aaabcd")
-  inspect!("aaabcd".trim_left(""), content="aaabcd")
-  inspect!("  abc".trim_left(" "), content="abc")
+  inspect!("aaabcd".trim_start("a"), content="bcd")
+  inspect!("aaabcd".trim_start(" "), content="aaabcd")
+  inspect!("aaabcd".trim_start(""), content="aaabcd")
+  inspect!("  abc".trim_start(" "), content="abc")
   inspect!(
-    "哇你好月兔你好哇".trim_left("你好哇"),
+    "哇你好月兔你好哇".trim_start("你好哇"),
     content="月兔你好哇",
   )
   inspect!("😍😍😭😡😡".trim_left("😍"), content="😭😡😡")
 }
 
 test "trim_right" {
-  inspect!("abcddd".trim_right("d"), content="abc")
-  inspect!("abcddd".trim_right(" "), content="abcddd")
-  inspect!("abcddd".trim_right(""), content="abcddd")
-  inspect!("abc  ".trim_right(" "), content="abc")
+  inspect!("abcddd".trim_end("d"), content="abc")
+  inspect!("abcddd".trim_end(" "), content="abcddd")
+  inspect!("abcddd".trim_end(""), content="abcddd")
+  inspect!("abc  ".trim_end(" "), content="abc")
   inspect!(
-    "哇你好月兔你好哇".trim_right("你好哇"),
+    "哇你好月兔你好哇".trim_end("你好哇"),
     content="哇你好月兔",
   )
   inspect!("😍😍😭😡😡".trim_right("😡"), content="😍😍😭")

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -181,7 +181,7 @@ test "trim_left" {
     "哇你好月兔你好哇".trim_start("你好哇"),
     content="月兔你好哇",
   )
-  inspect!("😍😍😭😡😡".trim_left("😍"), content="😭😡😡")
+  inspect!("😍😍😭😡😡".trim_start("😍"), content="😭😡😡")
 }
 
 test "trim_right" {
@@ -193,7 +193,7 @@ test "trim_right" {
     "哇你好月兔你好哇".trim_end("你好哇"),
     content="哇你好月兔",
   )
-  inspect!("😍😍😭😡😡".trim_right("😡"), content="😍😍😭")
+  inspect!("😍😍😭😡😡".trim_end("😡"), content="😍😍😭")
 }
 
 test "trim" {

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -494,13 +494,13 @@ test "String::fold" {
 }
 
 test "pad_left" {
-  inspect!("2".pad_left(3, '0'), content="002")
-  inspect!("22".pad_left(2, '0'), content="22")
-  inspect!("5".pad_left(4, 'x'), content="xxx5")
+  inspect!("2".pad_start(3, '0'), content="002")
+  inspect!("22".pad_start(2, '0'), content="22")
+  inspect!("5".pad_start(4, 'x'), content="xxx5")
 }
 
 test "pad_right" {
-  inspect!("2".pad_right(3, 'x'), content="2xx")
-  inspect!("22".pad_right(2, '0'), content="22")
-  inspect!("5".pad_right(4, 'x'), content="5xxx")
+  inspect!("2".pad_end(3, 'x'), content="2xx")
+  inspect!("22".pad_end(2, '0'), content="22")
+  inspect!("5".pad_end(4, 'x'), content="5xxx")
 }


### PR DESCRIPTION
Follow up of #1002
- **tweak names to align js calling convention**
- **use pad/trim_start/end, deprecate pad/trim_left,right**
- **the string position is incorrect for such unicodes**
- **info**

cc @bikallem 
