### PR TITLE
fix: proper option fromjson

### DIFF
--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -125,7 +125,7 @@ pub fn Map::to_json[K : Show, V : ToJson](self : Map[K, V]) -> Json {
 pub fn Option::to_json[T : ToJson](self : T?) -> Json {
   match self {
     None => Null
-    Some(value) => value.to_json()
+    Some(value) => { "Some": value.to_json() }
   }
 }
 

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -125,7 +125,7 @@ pub fn Map::to_json[K : Show, V : ToJson](self : Map[K, V]) -> Json {
 pub fn Option::to_json[T : ToJson](self : T?) -> Json {
   match self {
     None => Null
-    Some(value) => { "Some": value.to_json() }
+    Some(value) => [value.to_json()]
   }
 }
 

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -144,8 +144,24 @@ pub impl[V : FromJson] FromJson for Map[String, V] with from_json(json, path) {
 
 pub impl[T : FromJson] FromJson for T? with from_json(json, path) {
   match json {
+    Object(obj) => {
+      if obj.size() != 1 {
+        decode_error!(path, "Option::from_json: expected object with one field")
+      }
+      match obj {
+        { "Some": value } =>
+          Some(FromJson::from_json!(value, path.add_key("Some")))
+        _ =>
+          decode_error!(
+            path, "Option::from_json: expected object with None or Some field",
+          )
+      }
+    }
     Null => None
-    _ => Some(FromJson::from_json!(json, path))
+    _ =>
+      decode_error!(
+        path, "Option::from_json: expected object with None or Some field",
+      )
   }
 }
 

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -144,24 +144,9 @@ pub impl[V : FromJson] FromJson for Map[String, V] with from_json(json, path) {
 
 pub impl[T : FromJson] FromJson for T? with from_json(json, path) {
   match json {
-    Object(obj) => {
-      if obj.size() != 1 {
-        decode_error!(path, "Option::from_json: expected object with one field")
-      }
-      match obj {
-        { "Some": value } =>
-          Some(FromJson::from_json!(value, path.add_key("Some")))
-        _ =>
-          decode_error!(
-            path, "Option::from_json: expected object with None or Some field",
-          )
-      }
-    }
     Null => None
-    _ =>
-      decode_error!(
-        path, "Option::from_json: expected object with None or Some field",
-      )
+    Array([value]) => Some(FromJson::from_json!(value, path.add_index(0)))
+    _ => decode_error!(path, "Option::from_json: expected array or null")
   }
 }
 

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -314,6 +314,12 @@ test "Option" {
   let u = Some(1).to_json()
   let v : Int? = @json.from_json!(u)
   inspect!(v, content="Some(1)")
+  let nested : Json = (Some(None) : Unit??).to_json()
+  let v : Unit?? = @json.from_json!(nested)
+  inspect!(v, content="Some(None)")
+  let nested : Json = (Some(Some(None)) : Unit???).to_json()
+  let v : Unit??? = @json.from_json!(nested)
+  inspect!(v, content="Some(Some(None))")
 }
 
 test "Result" {

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -129,24 +129,38 @@ test "Map::to_json" {
   )
 }
 
+struct Opt {
+  x : Int?
+  t : Int??
+} derive(ToJson)
+
 test "Option::to_json" {
-  inspect!(
-    (Some(42) : Int?).to_json(),
-    content=
-      #|Object({"Some": Number(42)})
-    ,
-  )
+  inspect!((Some(42) : Int?).to_json(), content="Array([Number(42)])")
   inspect!((None : Int?).to_json(), content="Null")
-  inspect!(
-    (Some(None) : Unit??).to_json(),
-    content=
-      #|Object({"Some": Null})
-    ,
-  )
+  inspect!((Some(None) : Unit??).to_json(), content="Array([Null])")
   inspect!(
     (Some(Some(None)) : Unit???).to_json(),
+    content="Array([Array([Null])])",
+  )
+  let opt = { x: Some(42), t: Some(Some(42)) }
+  inspect!(
+    opt.to_json(),
     content=
-      #|Object({"Some": Object({"Some": Null})})
+      #|Object({"x": Array([Number(42)]), "t": Array([Array([Number(42)])])})
+    ,
+  )
+  let opt = { x: None, t: None }
+  inspect!(
+    opt.to_json(),
+    content=
+      #|Object({"x": Null, "t": Null})
+    ,
+  )
+  let opt = { x: None, t: Some(None) }
+  inspect!(
+    opt.to_json(),
+    content=
+      #|Object({"x": Null, "t": Array([Null])})
     ,
   )
 }

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -130,8 +130,25 @@ test "Map::to_json" {
 }
 
 test "Option::to_json" {
-  inspect!((Some(42) : Int?).to_json(), content="Number(42)")
+  inspect!(
+    (Some(42) : Int?).to_json(),
+    content=
+      #|Object({"Some": Number(42)})
+    ,
+  )
   inspect!((None : Int?).to_json(), content="Null")
+  inspect!(
+    (Some(None) : Unit??).to_json(),
+    content=
+      #|Object({"Some": Null})
+    ,
+  )
+  inspect!(
+    (Some(Some(None)) : Unit???).to_json(),
+    content=
+      #|Object({"Some": Object({"Some": Null})})
+    ,
+  )
 }
 
 test "Tuple::to_json" {


### PR DESCRIPTION
mainly for `Option[Option[T]]`

> for T? inside record, e.g,
struct Hello[T] {
x : T?
y : Int
}
when x is None, it does not show up in JSON, when x is Some(val), only val shows up

This needs to be changed in compiler