### PR TITLE
remove duplicated `impl` in builtin and other packages

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -683,29 +683,19 @@ pub trait ToJson {
 }
 
 // Extension Methods
-impl Hash for Unit
-
-impl Hash for Bool
-
 impl Hash for Byte
 
 impl Hash for Int
 
-impl Hash for Int64
-
 impl Hash for UInt
 
 impl Hash for UInt64
-
-impl Hash for Double
 
 impl Hash for String
 
 impl Hash for Option
 
 impl Hash for Result
-
-impl Hash for Bytes
 
 impl Hash for $default_impl
 

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -139,10 +139,6 @@ pub impl Hash for String with hash_combine(self, hasher) {
   hasher.combine_string(self)
 }
 
-pub impl Hash for Bytes with hash_combine(self, hasher) {
-  hasher.combine_bytes(self)
-}
-
 // https://github.com/skeeto/hash-prospector
 pub impl Hash for Int with hash(self) {
   let mut x = self ^ self.lsr(17)
@@ -163,24 +159,8 @@ pub impl Hash for UInt with hash_combine(self, hasher) {
   hasher.combine_uint(self)
 }
 
-pub impl Hash for Int64 with hash_combine(self, hasher) {
-  hasher.combine_int64(self)
-}
-
 pub impl Hash for UInt64 with hash_combine(self, hasher) {
   hasher.combine_uint64(self)
-}
-
-pub impl Hash for Double with hash_combine(self, hasher) {
-  hasher.combine_double(self)
-}
-
-pub impl Hash for Bool with hash_combine(self, hasher) {
-  hasher.combine_bool(self)
-}
-
-pub impl Hash for Unit with hash_combine(_self, hasher) {
-  hasher.combine_unit()
 }
 
 pub impl[X : Hash] Hash for X? with hash_combine(self, hasher) {


### PR DESCRIPTION
There are duplicated `impl` of `Hash::hash_combine` for types `Bytes`, `Int64`, `Double`, `Bool` and `Unit`, in builtin package and their own package. This PR removes duplicated `impl` in builtin package.

The compiler should be responsible for report error on such duplicated `impl`, so there is also a compiler bug involved here that should be fixed.