### PR TITLE
add `rev_concat()` for `immut/list`

### DIFF
--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -263,6 +263,21 @@ pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
   }
 }
 
+/// Reverse the first list and concatenate it with the second.
+///
+/// # Example
+///
+/// ```
+/// let ls = of([1, 2, 3, 4, 5]).concat(of([6, 7, 8, 9, 10]))
+/// println(ls) // output: @list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10])
+/// ```
+pub fn rev_concat[A](self : T[A], other : T[A]) -> T[A] {
+  loop self, other {
+    Nil, other => other
+    Cons(head, tail), other => continue tail, Cons(head, other)
+  }
+}
+
 /// Reverse the list.
 ///
 /// # Example
@@ -272,13 +287,7 @@ pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
 /// // output: from_array([5, 4, 3, 2, 1])
 /// ```
 pub fn rev[A](self : T[A]) -> T[A] {
-  loop self, (Nil : T[A]) {
-    xs, ys =>
-      match (xs, ys) {
-        (Nil, acc) => acc
-        (Cons(x, xs), acc) => continue xs, Cons(x, acc)
-      }
-  }
+  self.rev_concat(Nil)
 }
 
 /// Fold the list from left.

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -65,6 +65,7 @@ impl T {
   remove[A : Eq](Self[A], A) -> Self[A]
   remove_at[A](Self[A], Int) -> Self[A]
   rev[A](Self[A]) -> Self[A]
+  rev_concat[A](Self[A], Self[A]) -> Self[A]
   rev_fold[A, B](Self[A], ~init : B, (A, B) -> B) -> B
   rev_foldi[A, B](Self[A], ~init : B, (Int, A, B) -> B) -> B
   scan_left[A, E](Self[A], (E, A) -> E, ~init : E) -> Self[E]

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -136,6 +136,17 @@ test "concat" {
   inspect!(ls.concat(rs), content="@list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
 }
 
+test "rev_concat" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs = @list.of([6, 7, 8, 9, 10])
+  inspect!(@list.Nil.rev_concat(ls), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(rs.rev_concat(@list.Nil), content="@list.of([10, 9, 8, 7, 6])")
+  inspect!(
+    ls.rev_concat(rs),
+    content="@list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10])",
+  )
+}
+
 test "rev" {
   let ls = @list.of([1, 2, 3, 4, 5])
   let rs = @list.of([5, 4, 3, 2, 1])


### PR DESCRIPTION
This PR adds the `@list.rev_concat()` function (namely `List.rev_append` from OCaml), making it possible to do the `ls.rev().rev_concat(rs)` trick in Moonbit.

Also, `@list.rev()` is now considered as a special case of `@list.rev_concat()`.