### PR TITLE
ci: Fix coverage command after bugfix in `moon_cove_report`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: coverage report
         run: |
-          moon coverage report -f summary summary > coverage_summary.txt
+          moon coverage report -f summary > coverage_summary.txt
           # Put the coverage report in the pipline output
           cat coverage_summary.txt >> "$GITHUB_STEP_SUMMARY"
           # We don't use the official coveralls upload tool because it takes >1min to build itself


### PR DESCRIPTION
There was a bug in `moon_cove_report` where the commandline interface
differs with the actual parser implementation. Namely, additional string
arguments were ignored when parsing the args, while in the docs they
should represent input coverage source metadata. The fix made the parser
consistent with the interface, but broke the CI that mistakenly had an
additional `summary` arg in the commandline in here and other projects,
which was ignored in previous versions, but would trigger an error in
the current version.
