### PR TITLE
add `length()` and `is_empty()` to `Buffer`

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -52,6 +52,18 @@ fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
 }
 
 ///|
+/// Return the given buffer's length in bytes.
+pub fn length(self : Buffer) -> Int {
+  self.len
+}
+
+///|
+/// Return whether the given buffer is empty.
+pub fn is_empty(self : Buffer) -> Bool {
+  self.len == 0
+}
+
+///|
 /// Return a new String contains the data in buffer.
 pub fn to_string(self : Buffer) -> String {
   self.bytes.sub_string(0, self.len)

--- a/buffer/buffer.mbti
+++ b/buffer/buffer.mbti
@@ -5,6 +5,8 @@ package moonbitlang/core/buffer
 // Types and methods
 type Buffer
 impl Buffer {
+  is_empty(Self) -> Bool
+  length(Self) -> Int
   new(~size_hint : Int = ..) -> Self
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes

--- a/buffer/buffer_test.mbt
+++ b/buffer/buffer_test.mbt
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+test "length method" {
+  let buf = @buffer.new(size_hint=100)
+  inspect!(buf.length(), content="0")
+  buf.write_string("Test")
+  inspect!(buf.length(), content="8")
+}
+
+test "is_empty method" {
+  let buf = @buffer.new(size_hint=100)
+  inspect!(buf.is_empty(), content="true")
+  buf.write_string("Test")
+  inspect!(buf.is_empty(), content="false")
+}
+
 test "expect method with matching content" {
   let buf = @buffer.new(size_hint=100)
   buf.write_string("Test")


### PR DESCRIPTION
As required in the Markdown parser implementation.