### PR TITLE
fix some unused mutability & make some type private

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -697,7 +697,7 @@ impl Hash for Option
 
 impl Hash for Result
 
-impl Hash for $default_impl
+impl Hash::hash
 
 impl Hash for Tuple(2)
 
@@ -739,7 +739,7 @@ impl Show for Bytes
 
 impl Show for Ref
 
-impl Show for $default_impl
+impl Show::to_string
 
 impl Show for Array
 

--- a/math/algebraic_test.mbt
+++ b/math/algebraic_test.mbt
@@ -56,5 +56,5 @@ test "minimum.ref" {
 
 // For testing purposes
 priv struct T {
-  mut x : Int
+  x : Int
 } derive(Show, Eq, Compare)

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -14,7 +14,7 @@
 
 struct RandomState {
   mut seed : UInt64
-  mut gamma : UInt64
+  gamma : UInt64
 } derive(Show, Default)
 
 let golden_gamma : UInt64 = 0x9e3779b97f4a7c15

--- a/strconv/number.mbt
+++ b/strconv/number.mbt
@@ -14,7 +14,7 @@
 
 let min_19digit_int : UInt64 = 100_0000_0000_0000_0000UL
 
-struct Number {
+priv struct Number {
   exponent : Int64
   mantissa : UInt64
   negative : Bool

--- a/strconv/strconv.mbti
+++ b/strconv/strconv.mbti
@@ -21,8 +21,6 @@ impl Decimal {
   to_double(Self) -> Double!StrConvError
 }
 
-type Number
-
 pub type! StrConvError String
 
 // Type aliases

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -16,8 +16,8 @@
 /// TODO: make it a monad
 priv struct StringSlice {
   string : String
-  mut start : Int
-  mut end : Int
+  start : Int
+  end : Int
 }
 
 fn slice(s : String, start : Int, end : Int) -> StringSlice {


### PR DESCRIPTION
While improving MoonBit's unused warning, I found several struct field with unused mutability & some types that should be made private on core. This PR fixes these unused things