### PR TITLE
Move `double` method to func in `math` 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -40,7 +40,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-File random/rand.mbt is adapted from Golang's [`math/rand/v2`](https://pkg.go.dev/math/rand/v2) package.
+File random/random.mbt is adapted from Golang's [`math/rand/v2`](https://pkg.go.dev/math/rand/v2) package.
 
 License from Golang:
 Copyright 2009 The Go Authors.

--- a/math/exp.mbt
+++ b/math/exp.mbt
@@ -1,0 +1,17 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn exp(input : Double) -> Double {
+  input.exp()
+}

--- a/math/log.mbt
+++ b/math/log.mbt
@@ -1,0 +1,25 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn ln(input : Double) -> Double {
+  input.ln()
+}
+
+pub fn log2(input : Double) -> Double {
+  input.log2()
+}
+
+pub fn log10(input : Double) -> Double {
+  input.log10()
+}

--- a/math/math.mbti
+++ b/math/math.mbti
@@ -9,6 +9,14 @@ fn atan(Double) -> Double
 
 fn cos(Double) -> Double
 
+fn exp(Double) -> Double
+
+fn ln(Double) -> Double
+
+fn log10(Double) -> Double
+
+fn log2(Double) -> Double
+
 fn maximum[T : Compare + Eq](T, T) -> T
 
 fn minimum[T : Compare + Eq](T, T) -> T


### PR DESCRIPTION
This pull request focuses on deprecating several mathematical functions in the `Double` type and moving their implementations to the `math` module. Key changes include marking functions as deprecated, adding new implementations, and updating tests accordingly.

Deprecation and Implementation Changes:

* [`double/double.mbti`](diffhunk://#diff-b5e29dc0857a725de75305a745ae9b4ec1532ed9ab6b94de17e5477feb6523d8L20-R20): Marked `exp`, `log10`, `log2`, `min_normal`, and `nan` as deprecated. [[1]](diffhunk://#diff-b5e29dc0857a725de75305a745ae9b4ec1532ed9ab6b94de17e5477feb6523d8L20-R20) [[2]](diffhunk://#diff-b5e29dc0857a725de75305a745ae9b4ec1532ed9ab6b94de17e5477feb6523d8L30-R31)
* `double/exp_js.mbt` and `double/exp_nonjs.mbt`: Added deprecation alerts for `exp` and provided new implementations. [[1]](diffhunk://#diff-1477511d4dddeaa6c106af92afefeacd213fd7dab20766f99576010b554768f5R15) [[2]](diffhunk://#diff-4dac36c16ac6b806c421131e73fb487e51cbff1fe0c3f18301d03373f7ef8af5R30)
* [`double/log.mbt`](diffhunk://#diff-a30ee99f2f54e13db9139a0a56c07e170bc14c3743e2e805d4e7997cad0ed27bR62-R64): Commented out deprecation for `ln` and added deprecation alerts for `log2` and `log10`. [[1]](diffhunk://#diff-a30ee99f2f54e13db9139a0a56c07e170bc14c3743e2e805d4e7997cad0ed27bR62-R64) [[2]](diffhunk://#diff-a30ee99f2f54e13db9139a0a56c07e170bc14c3743e2e805d4e7997cad0ed27bR89) [[3]](diffhunk://#diff-a30ee99f2f54e13db9139a0a56c07e170bc14c3743e2e805d4e7997cad0ed27bR98-L141)

New Implementations in `math` Module:

* `math/exp_js.mbt` and `math/exp_nonjs.mbt`: Added new implementations for `exp` function. [[1]](diffhunk://#diff-17dbcbbee38faf1f3abe733bae66f1d4203f5381128082849d3db757b964ad1eR1-R16) [[2]](diffhunk://#diff-4f25984db57dc8b111846454d7b0b894f0499ffb36ee67efa08e08136c290571R1-R122)
* [`math/log.mbt`](diffhunk://#diff-069996ab50fbb578ce32dea3c4f12f792e196c1c56d78c0a45df9e21c25c89edR1-R141): Added new implementations for `ln`, `log2`, and `log10` functions.

Test Updates:

* [`double/exp_test.mbt`](diffhunk://#diff-58bc924ac061f6c20bcad9bbcaed9ed14833bd0fd6d7dd3efa7921e030693aa4L1-L42): Removed old tests for `exp`, `log2`, `log10`, and `ln`. [[1]](diffhunk://#diff-58bc924ac061f6c20bcad9bbcaed9ed14833bd0fd6d7dd3efa7921e030693aa4L1-L42) [[2]](diffhunk://#diff-a30ee99f2f54e13db9139a0a56c07e170bc14c3743e2e805d4e7997cad0ed27bR98-L141)
* [`math/exp_test.mbt`](diffhunk://#diff-f8b8283471593b81a1853b3aff452f2db86ce7d84c269b4c98468a2405263644R1-R42): Added new tests for `exp`, including special values and overflow/underflow cases.
* [`math/log.mbt`](diffhunk://#diff-069996ab50fbb578ce32dea3c4f12f792e196c1c56d78c0a45df9e21c25c89edR1-R141): Added new tests for `log2`, `log10`, and `ln`.

Other Changes:

* [`math/math.mbti`](diffhunk://#diff-1e4a6330ef8f614c76cb6fa440be67459ac73968ab5d9559826bd4e74b05fb10R12-R19): Added function signatures for `exp`, `ln`, `log10`, and `log2`.
* [`math/moon.pkg.json`](diffhunk://#diff-1f2193c61f110ac56a394cadf6a9e2fbecdb972e3424ffaa7f08c2a60b8aabecL9-R13): Updated package configuration to include new targets for `exp_js.mbt` and `exp_nonjs.mbt`.
Some problems encounterd

1. `double::ln` is used by `log2` and `log10`, so a deprecation notice will persist since we also want to deprecate `ln`
2. `sqrt` is implemented as method (and overloaded to support both `float` and `double`) and function argument cannot be overloaded, so it's not possible to migrate this.

close #1046 