### PR TITLE
%fixedarray.set_null is mis-used or mis-compiled on wasm backend

### DIFF
--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -237,7 +237,10 @@ pub fn unsafe_pop[T](self : Array[T]) -> T {
   guard self.length() != 0
   let index = self.length() - 1
   let v = self.buffer()[index]
-  self.set_length(index)
+  // self.set_length(index)
+  self.buf.set_null(index) 
+  // comment out wasm compilation is find
+  self.len = index
   v
 }
 


### PR DESCRIPTION
```
CompileError: WebAssembly.Module(): Compiling function #303 failed: expected 1 elements on the stack for fallthru, found 2 @+25643
CompileError: WebAssembly.Module(): Compiling function #190 failed: expected 1 elements on the stack for fallthru, found 2 @+16908
CompileError: WebAssembly.Module(): Compiling function #170 failed: expected 1 elements on the stack for fallthru, found 2 @+16294
Failed to run the test
```