### PR TITLE
hongbo/unsafe truncate length

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -211,7 +211,7 @@ pub fn eachi[T](self : Array[T], f : (Int, T) -> Unit) -> Unit {
 /// v.clear()
 /// ```
 pub fn clear[T](self : Array[T]) -> Unit {
-  self.set_length(0)
+  self.unsafe_truncate_to_length(0)
 }
 
 /// Maps a function over the elements of the array.
@@ -652,7 +652,8 @@ pub fn retain[T](self : Array[T], f : (T) -> Bool) -> Unit {
     }
     continue i + 1, j
   } else {
-    self.set_length(j)
+    // we use `else` here to capture `j`  
+    self.unsafe_truncate_to_length(j)
   }
 }
 
@@ -668,7 +669,7 @@ pub fn resize[T](self : Array[T], new_len : Int, f : T) -> Unit {
     abort("negative new length")
   }
   if new_len < self.length() {
-    self.set_length(new_len)
+    self.unsafe_truncate_to_length(new_len)
   } else {
     for i = self.length(); i < new_len; i = i + 1 {
       self.push(f)

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -102,7 +102,7 @@ pub fn Array::new[T](~capacity : Int = 0) -> Array[T] {
 /// Returns the number of elements in the array.
 pub fn length[T](self : Array[T]) -> Int = "%fixedarray.length"
 
-fn set_length[T](self : Array[T], new_len : Int) -> Unit {
+fn unsafe_truncate_to_length[T](self : Array[T], new_len : Int) -> Unit {
   JSArray::ofAnyArray(self).set_length(new_len)
 }
 

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -70,14 +70,52 @@ pub fn length[T](self : Array[T]) -> Int {
   self.len
 }
 
-fn set_length[T](self : Array[T], new_len : Int) -> Unit {
-  let len = self.len
-  if new_len < len {
-    for i in new_len..<len {
-      self.buf.set_null(i)
-    }
+/// Truncates the array to the specified length. This function is marked as
+/// `unsafe` because it directly manipulates the internal buffer of the array,
+/// which can lead to undefined behavior if not used carefully.
+///
+/// # Parameters
+///
+/// - `self` : The array to be truncated.
+/// - `new_len` : The new length to which the array should be truncated. Must be
+/// less than or equal to the current length of the array.
+///
+/// # Returns
+///
+/// - `Unit` : This function does not return a value.
+///
+/// # Errors
+///
+/// - This function does not explicitly raise errors, but improper use (e.g.,
+/// setting `new_len` greater than the current length) can lead to undefined
+/// behavior.
+///
+/// # Examples
+///
+/// ```moonbit
+/// test "unsafe_truncate_to_length example" {
+///  let mut arr = [1, 2, 3, 4, 5]
+///  unsafe_truncate_to_length(arr, 3)
+///  inspect!(arr, content="[1, 2, 3]")
+/// }
+/// ```
+fn unsafe_truncate_to_length[T](self : Array[T], new_len : Int) -> Unit {
+  let len = self.length()
+  guard new_len <= len
+  for i in new_len..<len {
+    self.buf.set_null(i)
   }
   self.len = new_len
+}
+
+
+test "unsafe_truncate_to_length" {
+  let arr = [1, 2, 3, 4, 5]
+  unsafe_truncate_to_length(arr, 3)
+  assert_eq!(arr.length(), 3)
+  assert_eq!(arr[0], 1)
+  assert_eq!(arr[1], 2)
+  assert_eq!(arr[2], 3)
 }
 
 fn buffer[T](self : Array[T]) -> UninitializedArray[T] {
@@ -219,7 +257,7 @@ pub fn pop[T](self : Array[T]) -> T? {
   } else {
     let index = self.length() - 1
     let v = self.buffer()[index]
-    self.set_length(index)
+    self.unsafe_truncate_to_length(index)
     Some(v)
   }
 }
@@ -236,7 +274,7 @@ pub fn unsafe_pop[T](self : Array[T]) -> T {
   guard self.length() != 0
   let index = self.length() - 1
   let v = self.buffer()[index]
-  self.set_length(index)
+  self.unsafe_truncate_to_length(index)
   v
 }
 
@@ -265,7 +303,7 @@ pub fn remove[T](self : Array[T], index : Int) -> T {
     index + 1,
     self.length() - index - 1,
   )
-  self.set_length(self.length() - 1)
+  self.unsafe_truncate_to_length(self.length() - 1)
   value
 }
 
@@ -300,7 +338,7 @@ pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
     end,
     self.length() - end,
   )
-  self.set_length(self.length() - num)
+  self.unsafe_truncate_to_length(self.length() - num)
   v
 }
 

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -99,6 +99,7 @@ pub fn length[T](self : Array[T]) -> Int {
 ///  inspect!(arr, content="[1, 2, 3]")
 /// }
 /// ```
+/// TODO: this can be optimized by using the intrinsic to null out the range
 fn unsafe_truncate_to_length[T](self : Array[T], new_len : Int) -> Unit {
   let len = self.length()
   guard new_len <= len
@@ -112,7 +113,6 @@ test "unsafe_truncate_to_length" {
   let arr = [1, 2, 3, 4, 5]
   unsafe_truncate_to_length(arr, 3)
   inspect!(arr, content="[1, 2, 3]")
-  
 }
 
 fn buffer[T](self : Array[T]) -> UninitializedArray[T] {
@@ -315,16 +315,7 @@ pub fn remove[T](self : Array[T], index : Int) -> T {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
-  if begin < 0 ||
-    begin >= self.length() ||
-    end < 0 ||
-    end > self.length() ||
-    begin > end {
-    let len = self.length()
-    abort(
-      "index out of bounds: the len is \{len} but the index is (\{begin}, \{end})",
-    )
-  }
+  guard begin >= 0 && end <= self.length() && begin <= end
   let num = end - begin
   let v = Array::make_uninit(num)
   UninitializedArray::unsafe_blit(v.buffer(), 0, self.buffer(), begin, num)

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -108,7 +108,6 @@ fn unsafe_truncate_to_length[T](self : Array[T], new_len : Int) -> Unit {
   self.len = new_len
 }
 
-
 test "unsafe_truncate_to_length" {
   let arr = [1, 2, 3, 4, 5]
   unsafe_truncate_to_length(arr, 3)

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -111,10 +111,8 @@ fn unsafe_truncate_to_length[T](self : Array[T], new_len : Int) -> Unit {
 test "unsafe_truncate_to_length" {
   let arr = [1, 2, 3, 4, 5]
   unsafe_truncate_to_length(arr, 3)
-  assert_eq!(arr.length(), 3)
-  assert_eq!(arr[0], 1)
-  assert_eq!(arr[1], 2)
-  assert_eq!(arr[2], 3)
+  inspect!(arr, content="[1, 2, 3]")
+  
 }
 
 fn buffer[T](self : Array[T]) -> UninitializedArray[T] {


### PR DESCRIPTION
This pull request focuses on replacing the `set_length` method with a new `unsafe_truncate_to_length` method across various array manipulation functions. This change aims to improve safety and clarity by marking the truncation operation as `unsafe`.

### Replacing `set_length` with `unsafe_truncate_to_length`:

* `builtin/array.mbt`:
  - Updated `clear`, `retain`, and `resize` methods to use `unsafe_truncate_to_length` instead of `set_length`. [[1]](diffhunk://#diff-acc21918bc4fd893932049c31941e1bb51f47be542aeafd5b7f075ada0b07afcL214-R214) [[2]](diffhunk://#diff-acc21918bc4fd893932049c31941e1bb51f47be542aeafd5b7f075ada0b07afcL655-R656) [[3]](diffhunk://#diff-acc21918bc4fd893932049c31941e1bb51f47be542aeafd5b7f075ada0b07afcL671-R672)

* `builtin/arraycore_js.mbt`:
  - Renamed `set_length` to `unsafe_truncate_to_length` in the `Array::new` function.

* `builtin/arraycore_nonjs.mbt`:
  - Replaced `set_length` with `unsafe_truncate_to_length` in the `length`, `pop`, `unsafe_pop`, `remove`, and `drain` functions. Added detailed documentation for `unsafe_truncate_to_length`. [[1]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L73-R117) [[2]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L222-R257) [[3]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L239-R274) [[4]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L268-R303) [[5]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L283-R318) [[6]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L303-R329)

- **change the unsafe primitive from `set_length` to `unsafe_truncate_length` (used only in shrinking and document it)**
- **fmt**
- **tweak**
