### PR TITLE
hongbo/cleanup arrayview

### DIFF
--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -259,8 +259,6 @@ pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
       "index out of bounds: the len is \{self.length()} but the index is (\{begin}, \{end})",
     )
   }
-
-
   JSArray::ofAnyArray(self).splice(begin, end - begin).toAnyArray()
 }
 

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -233,10 +233,9 @@ pub fn unsafe_pop[T](self : Array[T]) -> T {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn remove[T](self : Array[T], index : Int) -> T {
-  if index < 0 || index >= self.length() {
-    let len = self.length()
+  guard index >= 0 && index < self.length() else {
     abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
     )
   }
   let value = self.buffer()[index]
@@ -255,16 +254,13 @@ pub fn remove[T](self : Array[T], index : Int) -> T {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
-  if begin < 0 ||
-    begin >= self.length() ||
-    end < 0 ||
-    end > self.length() ||
-    begin > end {
-    let len = self.length()
+  guard begin >= 0 && end <= self.length() && begin <= end else {
     abort(
-      "index out of bounds: the len is \{len} but the index is (\{begin}, \{end})",
+      "index out of bounds: the len is \{self.length()} but the index is (\{begin}, \{end})",
     )
   }
+
+
   JSArray::ofAnyArray(self).splice(begin, end - begin).toAnyArray()
 }
 

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -270,10 +270,9 @@ pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
-  if index < 0 || index > self.length() {
-    let len = self.length()
+  guard index >= 0 && index <= self.length() else {
     abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
     )
   }
   let _ = JSArray::ofAnyArray(self).splice1(index, 0, JSValue::ofAny(value))

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -286,10 +286,9 @@ pub fn unsafe_pop[T](self : Array[T]) -> T {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn remove[T](self : Array[T], index : Int) -> T {
-  if index < 0 || index >= self.length() {
-    let len = self.length()
+  guard index >= 0 && index < self.length() else {
     abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
     )
   }
   let value = self.buffer()[index]
@@ -338,10 +337,9 @@ pub fn drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
 /// ```
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
-  if index < 0 || index > self.length() {
-    let len = self.length()
+  guard index >= 0 && index <= self.length() else {
     abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
     )
   }
   if self.length() == self.buffer()._.length() {

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -24,30 +24,27 @@ pub fn length[T](self : ArrayView[T]) -> Int {
 }
 
 pub fn op_get[T](self : ArrayView[T], index : Int) -> T {
-  if index < 0 || index >= self.len {
-    let len = self.len
+  guard index >= 0 && index < self.len else {
     abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{self.len} but the index is \{index}",
     )
   }
   self.buf[self.start + index]
 }
 
 pub fn op_set[T](self : ArrayView[T], index : Int, value : T) -> Unit {
-  if index < 0 || index >= self.len {
-    let len = self.len
+  guard index >= 0 && index < self.len else {
     abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{self.len} but the index is \{index}",
     )
   }
   self.buf[self.start + index] = value
 }
 
 pub fn swap[T](self : ArrayView[T], i : Int, j : Int) -> Unit {
-  if i >= self.len || j >= self.len || i < 0 || j < 0 {
-    let len = self.len
+  guard i >= 0 && i < self.len && j >= 0 && j < self.len else {
     abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is (\{i}, \{j})",
+      "index out of bounds: the len is from 0 to \{self.len} but the index is (\{i}, \{j})",
     )
   }
   let temp = self.buf[self.start + i]


### PR DESCRIPTION
This pull request includes changes to improve the safety and readability of array operations by using `guard` statements instead of `if` statements for index bounds checking. The changes are applied across multiple functions in different files.

Improvements to array operations:

* [`builtin/arraycore_js.mbt`](diffhunk://#diff-2531d56d432314b54a5a0a6b7e0552381bdde29b2ebcbb117f28c2fc12400c9aL236-R238): Replaced `if` statements with `guard` statements for index bounds checking in `remove`, `drain`, and `insert` functions. This change ensures that the code is more concise and easier to read. [[1]](diffhunk://#diff-2531d56d432314b54a5a0a6b7e0552381bdde29b2ebcbb117f28c2fc12400c9aL236-R238) [[2]](diffhunk://#diff-2531d56d432314b54a5a0a6b7e0552381bdde29b2ebcbb117f28c2fc12400c9aL258-R259) [[3]](diffhunk://#diff-2531d56d432314b54a5a0a6b7e0552381bdde29b2ebcbb117f28c2fc12400c9aL279-R275)

* [`builtin/arraycore_nonjs.mbt`](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L289-R291): Applied similar changes as above in the `remove` and `insert` functions to maintain consistency across different environments. [[1]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L289-R291) [[2]](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L341-R342)

* [`builtin/arrayview.mbt`](diffhunk://#diff-98b9bb089df74c5abd7171d3eebd05843d006f42d05e333c79d4ee40a1c009e9L27-R47): Updated `op_get`, `op_set`, and `swap` functions to use `guard` statements for bounds checking, enhancing code readability and safety.
- **clean up arrayview**
- **replace all preconditions with  guard**
- **fmt**
- **tweak**
