### PR TITLE
add `Array::dedup_consecutive` for removing consecutive repeated elements in array

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -843,11 +843,17 @@ pub fn dedup[T : Eq](self : Array[T]) -> Unit {
 /// v.dedup_consecutive() // v = [3, 4, 5, 6, 4]
 /// ```
 pub fn dedup_consecutive[T : Eq](self : Array[T]) -> Unit {
-  for i = 0; i < self.length(); i = i + 1 {
-    while i + 1 < self.length() && self[i] == self[i + 1] {
-      self.remove(i + 1) |> ignore
+  if self.is_empty() {
+    return
+  }
+  let mut w = 1
+  for i = 1; i < self.length(); i = i + 1 {
+    if self[i] != self[w - 1] {
+      self[w] = self[i]
+      w = w + 1
     }
   }
+  self.unsafe_truncate_to_length(w)
 }
 
 /// Extract elements from the array according to the given function.

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -843,13 +843,9 @@ pub fn dedup[T : Eq](self : Array[T]) -> Unit {
 /// v.unique() // v = [3, 4, 5, 6, 4]
 /// ```
 pub fn unique[T : Eq](self : Array[T]) -> Unit {
-  for i in 0..<self.length() {
-    for j = i + 1; j < self.length(); j = j + 1 {
-      if self[i] == self[j] {
-        self.remove(j) |> ignore
-      } else {
-        break
-      }
+  for i = 0; i < self.length(); i = i + 1 {
+    while i + 1 < self.length() && self[i] == self[i + 1] {
+      self.remove(i + 1) |> ignore
     }
   }
 }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -835,6 +835,25 @@ pub fn dedup[T : Eq](self : Array[T]) -> Unit {
   }
 }
 
+/// Removes consecutive repeated elements in the array according to the Eq trait.
+/// 
+/// # Example
+/// ```
+/// let v = [3, 4, 5, 6, 6, 4]
+/// v.unique() // v = [3, 4, 5, 6, 4]
+/// ```
+pub fn unique[T: Eq](self : Array[T]) -> Unit {
+  for i in 0..<self.length() {
+    for j = i + 1; j < self.length(); j = j + 1 {
+      if self[i] == self[j] {
+        self.remove(j) |> ignore
+      } else {
+        break
+      }
+    }
+  }
+}
+
 /// Extract elements from the array according to the given function.
 ///
 /// This function will remove the elements from the original array and return a new array.

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -840,9 +840,9 @@ pub fn dedup[T : Eq](self : Array[T]) -> Unit {
 /// # Example
 /// ```
 /// let v = [3, 4, 5, 6, 6, 4]
-/// v.unique() // v = [3, 4, 5, 6, 4]
+/// v.dedup_consecutive() // v = [3, 4, 5, 6, 4]
 /// ```
-pub fn unique[T : Eq](self : Array[T]) -> Unit {
+pub fn dedup_consecutive[T : Eq](self : Array[T]) -> Unit {
   for i = 0; i < self.length(); i = i + 1 {
     while i + 1 < self.length() && self[i] == self[i + 1] {
       self.remove(i + 1) |> ignore

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -815,7 +815,7 @@ pub fn fold_righti[T, U](self : Array[T], f : (Int, U, T) -> U, ~init : U) -> U 
   self.rev_foldi(~init, f)
 }
 
-/// Removes consecutive repeated elements in the array according to the Eq trait.
+/// Removes repeated elements in the array according to the Eq trait.
 ///
 /// # Example
 /// ```

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -842,7 +842,7 @@ pub fn dedup[T : Eq](self : Array[T]) -> Unit {
 /// let v = [3, 4, 5, 6, 6, 4]
 /// v.unique() // v = [3, 4, 5, 6, 4]
 /// ```
-pub fn unique[T: Eq](self : Array[T]) -> Unit {
+pub fn unique[T : Eq](self : Array[T]) -> Unit {
   for i in 0..<self.length() {
     for j = i + 1; j < self.length(); j = j + 1 {
       if self[i] == self[j] {

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -815,34 +815,25 @@ pub fn fold_righti[T, U](self : Array[T], f : (Int, U, T) -> U, ~init : U) -> U 
   self.rev_foldi(~init, f)
 }
 
-/// Removes repeated elements in the array according to the Eq trait.
+/// Removes consecutive repeated elements in the array according to the Eq trait.
 ///
 /// # Example
+///
 /// ```
 /// let v = [3, 4, 4, 5, 5, 5]
 /// v.dedup() // v = [3, 4, 5]
 /// ```
+///
+/// # Notes
+///
+/// Usually, you might want to sort the array before calling this function. For example:
+///
+/// ```
+/// let v = [3, 4, 5, 4, 5, 5]
+/// v.sort()
+/// v.dedup() // v = [3, 4, 5]
+/// ```
 pub fn dedup[T : Eq](self : Array[T]) -> Unit {
-  for i = 0; i < self.length(); i = i + 1 {
-    let mut j = i + 1
-    while j < self.length() {
-      if self[i] == self[j] {
-        self.remove(j) |> ignore
-      } else {
-        j = j + 1
-      }
-    }
-  }
-}
-
-/// Removes consecutive repeated elements in the array according to the Eq trait.
-/// 
-/// # Example
-/// ```
-/// let v = [3, 4, 5, 6, 6, 4]
-/// v.dedup_consecutive() // v = [3, 4, 5, 6, 4]
-/// ```
-pub fn dedup_consecutive[T : Eq](self : Array[T]) -> Unit {
   if self.is_empty() {
     return
   }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -543,26 +543,26 @@ test "array_binary_search_by_test" {
   assert_eq!(arr.binary_search_by(cmp), Err(4))
 }
 
-test "unique" {
+test "dedup_consecutive" {
   let array = [3, 4, 5, 6, 6, 4]
-  array.unique()
+  array.dedup_consecutive()
   inspect!(array, content="[3, 4, 5, 6, 4]")
 }
 
-test "unique - long" {
+test "dedup_consecutive - long" {
   let array = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 6, 6, 4, 3, 2, 1, 1, 1]
-  array.unique()
+  array.dedup_consecutive()
   inspect!(array, content="[1, 2, 3, 4, 5, 6, 4, 3, 2, 1]")
 }
 
-test "unique - edge cases" {
+test "dedup_consecutive - edge cases" {
   let array = [1, 1, 1, 1, 1]
-  array.unique()
+  array.dedup_consecutive()
   inspect!(array, content="[1]")
   let array : Array[Int] = []
-  array.unique()
+  array.dedup_consecutive()
   inspect!(array, content="[]")
   let array = [1, 2, 3, 4, 5]
-  array.unique()
+  array.dedup_consecutive()
   inspect!(array, content="[1, 2, 3, 4, 5]")
 }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -548,3 +548,9 @@ test "unique" {
   array.unique()
   inspect!(array, content="[3, 4, 5, 6, 4]")
 }
+
+test "unique - long" {
+  let array = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 6, 6, 4, 3, 2, 1, 1, 1]
+  array.unique()
+  inspect!(array, content="[1, 2, 3, 4, 5, 6, 4, 3, 2, 1]")
+}

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -542,3 +542,9 @@ test "array_binary_search_by_test" {
   target = { num: 49 }
   assert_eq!(arr.binary_search_by(cmp), Err(4))
 }
+
+test "unique" {
+  let array = [3, 4, 5, 6, 6, 4]
+  array.unique()
+  inspect!(array, content="[3, 4, 5, 6, 4]")
+}

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -554,3 +554,15 @@ test "unique - long" {
   array.unique()
   inspect!(array, content="[1, 2, 3, 4, 5, 6, 4, 3, 2, 1]")
 }
+
+test "unique - edge cases" {
+  let array = [1, 1, 1, 1, 1]
+  array.unique()
+  inspect!(array, content="[1]")
+  let array : Array[Int] = []
+  array.unique()
+  inspect!(array, content="[]")
+  let array = [1, 2, 3, 4, 5]
+  array.unique()
+  inspect!(array, content="[1, 2, 3, 4, 5]")
+}

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -543,26 +543,26 @@ test "array_binary_search_by_test" {
   assert_eq!(arr.binary_search_by(cmp), Err(4))
 }
 
-test "dedup_consecutive" {
+test "array_dedup" {
   let array = [3, 4, 5, 6, 6, 4]
-  array.dedup_consecutive()
+  array.dedup()
   inspect!(array, content="[3, 4, 5, 6, 4]")
 }
 
-test "dedup_consecutive - long" {
+test "array_dedup - long" {
   let array = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 6, 6, 4, 3, 2, 1, 1, 1]
-  array.dedup_consecutive()
+  array.dedup()
   inspect!(array, content="[1, 2, 3, 4, 5, 6, 4, 3, 2, 1]")
 }
 
-test "dedup_consecutive - edge cases" {
+test "array_dedup - edge cases" {
   let array = [1, 1, 1, 1, 1]
-  array.dedup_consecutive()
+  array.dedup()
   inspect!(array, content="[1]")
   let array : Array[Int] = []
-  array.dedup_consecutive()
+  array.dedup()
   inspect!(array, content="[]")
   let array = [1, 2, 3, 4, 5]
-  array.dedup_consecutive()
+  array.dedup()
   inspect!(array, content="[1, 2, 3, 4, 5]")
 }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -113,6 +113,7 @@ impl Array {
   swap[T](Self[T], Int, Int) -> Unit
   to_json[X : ToJson](Self[X]) -> Json
   to_string[T : Show](Self[T]) -> String
+  unique[T : Eq](Self[T]) -> Unit
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
   unsafe_pop[T](Self[T]) -> T

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -55,6 +55,7 @@ impl Array {
   compare[T : Compare + Eq](Self[T], Self[T]) -> Int
   contains[T : Eq](Self[T], T) -> Bool
   dedup[T : Eq](Self[T]) -> Unit
+  dedup_consecutive[T : Eq](Self[T]) -> Unit
   drain[T](Self[T], Int, Int) -> Self[T]
   each[T](Self[T], (T) -> Unit) -> Unit
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit
@@ -113,7 +114,6 @@ impl Array {
   swap[T](Self[T], Int, Int) -> Unit
   to_json[X : ToJson](Self[X]) -> Json
   to_string[T : Show](Self[T]) -> String
-  unique[T : Eq](Self[T]) -> Unit
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
   unsafe_pop[T](Self[T]) -> T

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -55,7 +55,6 @@ impl Array {
   compare[T : Compare + Eq](Self[T], Self[T]) -> Int
   contains[T : Eq](Self[T], T) -> Bool
   dedup[T : Eq](Self[T]) -> Unit
-  dedup_consecutive[T : Eq](Self[T]) -> Unit
   drain[T](Self[T], Int, Int) -> Self[T]
   each[T](Self[T], (T) -> Unit) -> Unit
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit


### PR DESCRIPTION
For backward compatibility, this PR updates the documentation for `Array::dedup`, so that it shall not break any existing code that use this function. This PR also add another function (`Array::unique`) to implement the originally proposed functionality, i.e. de-duplication of consecutive repeated elements.

cc @Demonmasterlqx

close #1061 

## Implementation in other programming language

| Language | Consecutive | Non-consecutive |
|----------|-------------|-----------------|
| C++      | [`unique`](https://en.cppreference.com/w/cpp/algorithm/unique) | N/A |
| Rust     | [`dedup`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.dedup) | [`unique`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.unique) |
| NumPy    | N/A | [`unique`](https://numpy.org/doc/2.0/reference/generated/numpy.unique.html) |
| JavaScript | N/A | N/A |
| Python   | N/A | N/A |
| Scala    | N/A | [`distinct`](https://www.scala-lang.org/api/2.13.9/scala/collection/immutable/List.html#distinct:C) |
| *nix     | [`uniq`](https://man7.org/linux/man-pages/man1/uniq.1.html) | N/A |
| Haskell  | N/A | [`Data.List.Unique`](https://hackage.haskell.org/package/Unique-0.4.7.9/docs/Data-List-Unique.html) |

See more on https://rosettacode.org/wiki/Remove_duplicate_elements

## Algorithm Complexity

For the time-complexity of removing non-consecutive duplications:

> There are basically three approaches seen here:
> - Put the elements into a hash table which does not allow duplicates. The complexity is O(n) on average, and O(n^2) worst case. This approach requires a hash function for your type (which is compatible with equality), either built-in to your language, or provided by the user.
> - Sort the elements and remove consecutive duplicate elements. The complexity of the best sorting algorithms is O(n * log(n)). This approach requires that your type be "comparable", i.e., have an ordering. Putting the elements into a self-balancing binary search tree is a special case of sorting.
> - Go through the list, and for each element, check the rest of the list to see if it appears again, and discard it if it does. The complexity is O(n^2). The up-shot is that this always works on any type (provided that you can test for equality).

quoted from https://rosettacode.org/wiki/Remove_duplicate_elements

Removing consecutive duplications should only require `Eq` trait and of `O(n)` time complexity.