### PR TITLE
add `Float::exp`

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -71,8 +71,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-File `float/exp.mbt` and `float/log.mbt` is adapted from [musl](https://www.musl-libc.org/),
-Specifically:
+File `float/exp.mbt` and `float/log.mbt` is adapted from
+[musl](https://www.musl-libc.org/), specifically:
 - `float/log.mbt` is adapted from `src/math/logf.c`, `src/math/logf_data.h`,
   and `src/math/logf_data.c`.
 - `float/exp.mbt` is adapted from `src/math/expf.c`, `src/math/exp2f_data.h`,

--- a/NOTICE
+++ b/NOTICE
@@ -71,10 +71,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-File `float/exp.mbt` is adapted from [musl](https://www.musl-libc.org/),
-Specifically, it is adapted from `src/math/logf.c`, `src/math/logf_data.h`, and
-`src/math/logf_data.c`. These files are Copyright (c) 2017-2018 Arm Limited and
-licensed under the MIT license.
+File `float/exp.mbt` and `float/log.mbt` is adapted from [musl](https://www.musl-libc.org/),
+Specifically:
+- `float/log.mbt` is adapted from `src/math/logf.c`, `src/math/logf_data.h`,
+  and `src/math/logf_data.c`.
+- `float/exp.mbt` is adapted from `src/math/expf.c`, `src/math/exp2f_data.h`,
+  and `src/math/exp2f_data.c`.
+These files are Copyright (c) 2017-2018 Arm Limited and licensed under the MIT
+license.
 
 Here is a copy of MIT license:
 

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -32,7 +32,6 @@ let exp2f_table_bits = 5
 
 priv struct Exp2fData {
   tab : Array[UInt64]
-  poly : Array[Double]
   shift : Double
   invln2_scaled : Double
   poly_scaled : Array[Double]
@@ -53,7 +52,6 @@ let exp2f_data : Exp2fData = {
     0x3feee89f995ad3ad, 0x3feeff76f2fb5e47, 0x3fef199bdd85529c, 0x3fef3720dcef9069,
     0x3fef5818dcfba487, 0x3fef7c97337b9b5f, 0x3fefa4afa2a490da, 0x3fefd0765b6e4540,
   ],
-  poly: [0x1.c6af84b912394p-5, 0x1.ebfce50fac4f3p-3, 0x1.62e42ff0c52d6p-1],
   shift: 0x1.8p+52,
   invln2_scaled: 0x1.71547652b82fep+0 * exp2f_data_n,
   poly_scaled: [
@@ -91,7 +89,7 @@ pub fn exp(self : Float) -> Float {
   let s = t.to_int64().reinterpret_as_double()
   let z = exp2f_data.poly_scaled[0] * r + exp2f_data.poly_scaled[1]
   let r2 = r * r
-  let y = exp2f_data.poly[2] * r + 1
+  let y = exp2f_data.poly_scaled[2] * r + 1
   let y = z * r2 + y
   let y = y * s
   y.to_float()

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -1,0 +1,102 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn top12(x : Float) -> UInt {
+  x.reinterpret_as_int().reinterpret_as_uint() >> 20
+}
+
+fn __math_xflowf(sign : UInt, y : Float) -> Float {
+  return (if sign != 0 { -y } else { y }) * y
+}
+
+fn __math_oflowf(sign : UInt) -> Float {
+  return __math_xflowf(sign, 0x1.0p97)
+}
+
+fn __math_uflowf(sign : UInt) -> Float {
+  return __math_xflowf(sign, 0x1.0p-95)
+}
+
+let exp2f_table_bits = 5
+
+let exp2f_poly_order = 3
+
+struct Exp2fData {
+  tab : Array[UInt64]
+  shift_scaled : Double
+  poly : Array[Double]
+  shift : Double
+  invln2_scaled : Double
+  poly_scaled : Array[Double]
+}
+
+let expf_n : UInt64 = (1 << exp2f_table_bits).to_int64().to_uint64()
+
+let exp2f_data_n : Double = (1 << exp2f_table_bits).to_double()
+
+let exp2f_data : Exp2fData = {
+  tab: [
+    0x3ff0000000000000, 0x3fefd9b0d3158574, 0x3fefb5586cf9890f, 0x3fef9301d0125b51,
+    0x3fef72b83c7d517b, 0x3fef54873168b9aa, 0x3fef387a6e756238, 0x3fef1e9df51fdee1,
+    0x3fef06fe0a31b715, 0x3feef1a7373aa9cb, 0x3feedea64c123422, 0x3feece086061892d,
+    0x3feebfdad5362a27, 0x3feeb42b569d4f82, 0x3feeab07dd485429, 0x3feea47eb03a5585,
+    0x3feea09e667f3bcd, 0x3fee9f75e8ec5f74, 0x3feea11473eb0187, 0x3feea589994cce13,
+    0x3feeace5422aa0db, 0x3feeb737b0cdc5e5, 0x3feec49182a3f090, 0x3feed503b23e255d,
+    0x3feee89f995ad3ad, 0x3feeff76f2fb5e47, 0x3fef199bdd85529c, 0x3fef3720dcef9069,
+    0x3fef5818dcfba487, 0x3fef7c97337b9b5f, 0x3fefa4afa2a490da, 0x3fefd0765b6e4540,
+  ],
+  shift_scaled: 0x1.8p+52 / exp2f_data_n,
+  poly: [0x1.c6af84b912394p-5, 0x1.ebfce50fac4f3p-3, 0x1.62e42ff0c52d6p-1],
+  shift: 0x1.8p+52,
+  invln2_scaled: 0x1.71547652b82fep+0 * exp2f_data_n,
+  poly_scaled: [
+    0x1.c6af84b912394p-5 / exp2f_data_n / exp2f_data_n / exp2f_data_n,
+    0x1.ebfce50fac4f3p-3 / exp2f_data_n / exp2f_data_n,
+    0x1.62e42ff0c52d6p-1 / exp2f_data_n,
+  ],
+}
+
+fn exp(self : Float) -> Float {
+  let xd = self.to_double()
+  let abstop = top12(self) & 0x7ff
+  if abstop >= top12(88.0) {
+    if self.reinterpret_as_int().reinterpret_as_uint() ==
+      neg_infinity.reinterpret_as_int().reinterpret_as_uint() {
+      return 0.0
+    }
+    if abstop >= top12(infinity) {
+      return self + self
+    }
+    if self > 0x1.62e42ep6 {
+      return __math_oflowf(0)
+    }
+    if self < -0x1.9fe368p6 {
+      return __math_uflowf(0)
+    }
+  }
+  let z = exp2f_data.invln2_scaled * xd
+  let kd = z + exp2f_data.shift
+  let ki = kd.reinterpret_as_u64()
+  let kd = kd - exp2f_data.shift
+  let r = z - kd
+  let t = exp2f_data.tab[(ki % expf_n).to_int()]
+  let t = t + (ki << (52 - exp2f_table_bits))
+  let s = t.to_int64().reinterpret_as_double()
+  let z = exp2f_data.poly_scaled[0] * r + exp2f_data.poly_scaled[1]
+  let r2 = r * r;
+  let y = exp2f_data.poly[2] * r + 1
+  let y = z * r2 + y;
+  let y = y * s;
+  y.to_float()
+}

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -67,7 +67,7 @@ let exp2f_data : Exp2fData = {
   ],
 }
 
-fn exp(self : Float) -> Float {
+pub fn exp(self : Float) -> Float {
   let xd = self.to_double()
   let abstop = top12(self) & 0x7ff
   if abstop >= top12(88.0) {

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -30,7 +30,7 @@ fn __math_uflowf(sign : UInt) -> Float {
 
 let exp2f_table_bits = 5
 
-struct Exp2fData {
+priv struct Exp2fData {
   tab : Array[UInt64]
   poly : Array[Double]
   shift : Double

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -30,11 +30,8 @@ fn __math_uflowf(sign : UInt) -> Float {
 
 let exp2f_table_bits = 5
 
-let exp2f_poly_order = 3
-
 struct Exp2fData {
   tab : Array[UInt64]
-  shift_scaled : Double
   poly : Array[Double]
   shift : Double
   invln2_scaled : Double
@@ -56,7 +53,6 @@ let exp2f_data : Exp2fData = {
     0x3feee89f995ad3ad, 0x3feeff76f2fb5e47, 0x3fef199bdd85529c, 0x3fef3720dcef9069,
     0x3fef5818dcfba487, 0x3fef7c97337b9b5f, 0x3fefa4afa2a490da, 0x3fefd0765b6e4540,
   ],
-  shift_scaled: 0x1.8p+52 / exp2f_data_n,
   poly: [0x1.c6af84b912394p-5, 0x1.ebfce50fac4f3p-3, 0x1.62e42ff0c52d6p-1],
   shift: 0x1.8p+52,
   invln2_scaled: 0x1.71547652b82fep+0 * exp2f_data_n,

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -31,10 +31,10 @@ fn __math_uflowf(sign : UInt) -> Float {
 let exp2f_table_bits = 5
 
 priv struct Exp2fData {
-  tab : Array[UInt64]
+  tab : FixedArray[UInt64]
   shift : Double
   invln2_scaled : Double
-  poly_scaled : Array[Double]
+  poly_scaled : FixedArray[Double]
 }
 
 let expf_n : UInt64 = (1 << exp2f_table_bits).to_int64().to_uint64()

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -90,9 +90,9 @@ pub fn exp(self : Float) -> Float {
   let t = t + (ki << (52 - exp2f_table_bits))
   let s = t.to_int64().reinterpret_as_double()
   let z = exp2f_data.poly_scaled[0] * r + exp2f_data.poly_scaled[1]
-  let r2 = r * r;
+  let r2 = r * r
   let y = exp2f_data.poly[2] * r + 1
-  let y = z * r2 + y;
-  let y = y * s;
+  let y = z * r2 + y
+  let y = y * s
   y.to_float()
 }

--- a/float/exp_test.mbt
+++ b/float/exp_test.mbt
@@ -9,3 +9,24 @@ test "exp" {
   inspect!((89 : Float).exp(), content="Infinity")
   inspect!((-104 : Float).exp(), content="0")
 }
+
+test "exp - quickcheck" {
+  let double : Array[Double] = @quickcheck.samples(4)
+  inspect!(
+    double,
+    content="[0.12125190562607557, 0.2656190379663609, 0.7248184591724188, 0.8261703932281662]",
+  )
+  inspect!(
+    double.map(fn(x) { x.exp() }),
+    content="[1.1289092551447675, 1.3042380988330389, 2.064356300995553, 2.2845530266177425]",
+  )
+  let float = double.map(Double::to_float)
+  inspect!(
+    float,
+    content="[0.1212519034743309, 0.26561903953552246, 0.7248184680938721, 0.8261703848838806]",
+  )
+  inspect!(
+    float.map(fn(x) { x.exp() }),
+    content="[1.1289092302322388, 1.3042380809783936, 2.0643563270568848, 2.284553050994873]",
+  )
+}

--- a/float/exp_test.mbt
+++ b/float/exp_test.mbt
@@ -1,0 +1,11 @@
+test "exp" {
+  inspect!((0.5 : Float).exp(), content="1.740578055381775")
+  inspect!((1.0 : Float).exp(), content="3.020629644393921")
+  inspect!((0.0 : Float).exp(), content="1")
+  inspect!((2.0 : Float).exp(), content="9.026880264282227")
+  inspect!((-1.0 : Float).exp(), content="0.32666537165641785")
+  inspect!(@float.infinity.exp(), content="Infinity")
+  inspect!(@float.neg_infinity.exp(), content="0")
+  inspect!((89 : Float).exp(), content="Infinity")
+  inspect!((-104 : Float).exp(), content="0")
+}

--- a/float/exp_test.mbt
+++ b/float/exp_test.mbt
@@ -1,3 +1,17 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 test "exp" {
   inspect!((0.5 : Float).exp(), content="1.6487212181091309")
   inspect!((1.0 : Float).exp(), content="2.7182817459106445")

--- a/float/exp_test.mbt
+++ b/float/exp_test.mbt
@@ -1,9 +1,9 @@
 test "exp" {
-  inspect!((0.5 : Float).exp(), content="1.740578055381775")
-  inspect!((1.0 : Float).exp(), content="3.020629644393921")
+  inspect!((0.5 : Float).exp(), content="1.6487212181091309")
+  inspect!((1.0 : Float).exp(), content="2.7182817459106445")
   inspect!((0.0 : Float).exp(), content="1")
-  inspect!((2.0 : Float).exp(), content="9.026880264282227")
-  inspect!((-1.0 : Float).exp(), content="0.32666537165641785")
+  inspect!((2.0 : Float).exp(), content="7.389056205749512")
+  inspect!((-1.0 : Float).exp(), content="0.3678794503211975")
   inspect!(@float.infinity.exp(), content="Infinity")
   inspect!(@float.neg_infinity.exp(), content="0")
   inspect!((89 : Float).exp(), content="Infinity")

--- a/float/float.mbti
+++ b/float/float.mbti
@@ -16,6 +16,7 @@ let not_a_number : Float
 // Types and methods
 impl Float {
   abs(Float) -> Float
+  exp(Float) -> Float
   ln(Float) -> Float
   to_string(Float) -> String
 }

--- a/float/moon.pkg.json
+++ b/float/moon.pkg.json
@@ -3,5 +3,8 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/coverage",
     "moonbitlang/core/double"
+  ],
+  "test-import": [
+    "moonbitlang/core/quickcheck"
   ]
 }


### PR DESCRIPTION
This PR adds `Float::exp`. The code is basically transcribed from the musl libc.

https://git.musl-libc.org/cgit/musl/tree/src/math/expf.c