### PR TITLE
cleanup some dead code

### DIFF
--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -18,16 +18,6 @@ test "new" {
   assert_eq!(m.size(), 0)
 }
 
-type MyString String derive(Eq)
-
-impl Hash for MyString with hash(self) { self._.length() }
-
-impl Hash for MyString with hash_combine(self, hasher) {
-  hasher.combine_string(self._)
-}
-
-impl Show for MyString with output(self, logger) { logger.write_string(self._) }
-
 test "get" {
   let m = @hashmap.new()
   m.set("a", 1)

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -27,16 +27,6 @@ test "new" {
   assert_eq!(m.size(), 0)
 }
 
-type MyString String derive(Eq)
-
-impl Hash for MyString with hash(self) { self._.length() }
-
-impl Hash for MyString with hash_combine(self, hasher) {
-  hasher.combine_string(self._)
-}
-
-impl Show for MyString with output(self, logger) { logger.write_string(self._) }
-
 test "insert" {
   let m = @hashset.new()
   m.insert("a")


### PR DESCRIPTION
When experimenting with an improved version of unused warning in the MoonBit compiler, I discover some dead code in core. This PR removes these dead code