### PR TITLE
refactor: use StringBuilder instead of Buffer

### DIFF
--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -23,7 +23,7 @@ pub fn expect(
   self.reset()
   if current != content {
     fn repr(s : String) -> String {
-      let buf = Buffer::new()
+      let buf = StringBuilder::new()
       Show::output(s, buf)
       buf.to_string()
     }

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -86,7 +86,7 @@ test "from_iter empty iterator" {
 }
 
 test "iter" {
-  let buf = Buffer::new(size_hint=5)
+  let buf = StringBuilder::new(size_hint=5)
   b"abcde".iter().each(fn { x => buf.write_string(x.to_string()) })
   inspect!(buf, content="b'\\x61'b'\\x62'b'\\x63'b'\\x64'b'\\x65'")
   buf.reset()

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -18,7 +18,7 @@ test "to_string" {
 
 test "show output" {
   fn repr(chr) {
-    let buf = Buffer::new(size_hint=0)
+    let buf = StringBuilder::new(size_hint=0)
     Show::output(chr, buf)
     buf.to_string()
   }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -74,7 +74,7 @@ impl Output for StringBuffer with output(self : StringBuffer, content : String) 
   self._.push(content)
 }
 
-impl Output for Buffer with output(self, content) -> Unit {
+impl Output for StringBuilder with output(self, content) -> Unit {
   self.write_string(content)
 }
 
@@ -96,7 +96,7 @@ pub fn end() -> Unit {
   println("----- BEGIN MOONBIT COVERAGE -----")
   let sbuf = StringBuffer::StringBuffer([])
   coverage_log(counters.val, sbuf)
-  let line_buf = Buffer::new()
+  let line_buf = StringBuilder::new()
   for i = 0; i < sbuf._.length(); i = i + 1 {
     let str = sbuf._[i]
     let mut start = 0
@@ -181,7 +181,7 @@ test "log" {
     ("foo/foo", test_counter_a),
     MCons(("foo/bar", test_counter_b), MNil),
   )
-  let buf = Buffer::new(size_hint=1024)
+  let buf = StringBuilder::new(size_hint=1024)
   coverage_log(counters, buf)
   inspect!(
     buf,
@@ -207,7 +207,7 @@ test "reset" {
     ("foo/foo", test_counter_a),
     MCons(("foo/bar", test_counter_b), MNil),
   )
-  let buf = Buffer::new(size_hint=1024)
+  let buf = StringBuilder::new(size_hint=1024)
   coverage_log(counters, buf)
   inspect!(
     buf,
@@ -218,7 +218,7 @@ test "reset" {
     ,
   )
   coverage_reset(counters)
-  let buf = Buffer::new(size_hint=1024)
+  let buf = StringBuilder::new(size_hint=1024)
   coverage_log(counters, buf)
   inspect!(
     buf,

--- a/double/internal/ryu/ryu.mbt
+++ b/double/internal/ryu/ryu.mbt
@@ -16,7 +16,7 @@
 // This is a fork of the ryu crate adjusted to comply to the ECMAScript number-to-string algorithm,
 
 fn string_from_bytes(bytes : Bytes, from : Int, to : Int) -> String {
-  let buf = Buffer::new(size_hint=bytes.length())
+  let buf = StringBuilder::new(size_hint=bytes.length())
   for i = from; i < to; i = i + 1 {
     buf.write_char(Char::from_int(bytes[i].to_int()))
   }

--- a/immut/hashmap/bucket.mbt
+++ b/immut/hashmap/bucket.mbt
@@ -122,7 +122,7 @@ test "Bucket" {
 
 test "Bucket::iter" {
   let b : Bucket[_] = More(0, 0, More(1, 1, Just_One(31, 31)))
-  let buf = Buffer::new(size_hint=0)
+  let buf = StringBuilder::new(size_hint=0)
   let mut is_first = true
   b.each(
     fn(k, v) {
@@ -139,7 +139,7 @@ test "Bucket::iter" {
 
 test "Bucket::iter" {
   let b : Bucket[_] = More(0, 0, More(1, 1, Just_One(31, 31)))
-  let buf = Buffer::new(size_hint=0)
+  let buf = StringBuilder::new(size_hint=0)
   let mut is_first = true
   b
   .iter()

--- a/immut/hashset/bucket.mbt
+++ b/immut/hashset/bucket.mbt
@@ -112,7 +112,7 @@ test "Bucket" {
 
 test "Bucket::iter" {
   let b : Bucket[_] = More(0, More(1, Just_One(31)))
-  let buf = Buffer::new(size_hint=0)
+  let buf = StringBuilder::new(size_hint=0)
   let mut is_first = true
   b.each(
     fn(k) {
@@ -129,7 +129,7 @@ test "Bucket::iter" {
 
 test "Bucket::iter" {
   let b : Bucket[_] = More(0, More(1, Just_One(31)))
-  let buf = Buffer::new(size_hint=0)
+  let buf = StringBuilder::new(size_hint=0)
   let mut is_first = true
   b
   .iter()
@@ -194,7 +194,7 @@ test "Bucket iter" {
   let b0 : Bucket[_] = Just_One(0)
   let b1 = b0.add(1)
   let b2 = b1.add(2)
-  let buf = Buffer::new(size_hint=0)
+  let buf = StringBuilder::new(size_hint=0)
   let mut is_first = true
   b2.each(
     fn(k) {
@@ -213,7 +213,7 @@ test "Bucket iter" {
   let b0 : Bucket[_] = Just_One(0)
   let b1 = b0.add(1)
   let b2 = b1.add(2)
-  let buf = Buffer::new(size_hint=0)
+  let buf = StringBuilder::new(size_hint=0)
   let mut is_first = true
   b2
   .iter()

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -539,7 +539,7 @@ fn to_string(self : Decimal) -> String {
   if self.decimal_point < 0 {
     n += -self.decimal_point
   }
-  let buf = Buffer::new(size_hint=n)
+  let buf = StringBuilder::new(size_hint=n)
   if self.decimal_point <= 0 {
     // zeros filling between the decimal point and the digits
     buf.write_string("0.")

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -82,7 +82,7 @@ fn is_empty(self : StringSlice) -> Bool {
 }
 
 fn to_string(self : StringSlice) -> String {
-  let buf = Buffer::new(size_hint=self.length())
+  let buf = StringBuilder::new(size_hint=self.length())
   for i = 0; i < self.length(); i = i + 1 {
     buf.write_char(self[i])
   }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -22,7 +22,7 @@
 /// 
 /// For efficiency considerations, it's recommended to use `Buffer` instead.
 pub fn String::from_array(chars : Array[Char]) -> String {
-  let buf = Buffer::new(size_hint=chars.length() * 4)
+  let buf = StringBuilder::new(size_hint=chars.length() * 4)
   for c in chars {
     buf.write_char(c)
   }
@@ -39,7 +39,7 @@ pub fn String::concat(
   strings : Array[String],
   ~separator : String = ""
 ) -> String {
-  let buf = Buffer::new()
+  let buf = StringBuilder::new()
   if separator == "" {
     for s in strings {
       buf.write_string(s)
@@ -496,7 +496,7 @@ pub fn replace(self : String, ~old : String, ~new : String) -> String {
 
 /// Replace all old string in this string to new string.
 pub fn replace_all(self : String, ~old : String, ~new : String) -> String {
-  let buf = Buffer::new()
+  let buf = StringBuilder::new()
   let len = self.length()
   let old_len = old.length()
   if old_len == 0 {
@@ -528,7 +528,7 @@ pub fn replace_all(self : String, ~old : String, ~new : String) -> String {
 /// Converts this string to lowercase.
 pub fn to_lower(self : String) -> String {
   // TODO: deal with non-ascii characters
-  let buf = Buffer::new(size_hint=self.length())
+  let buf = StringBuilder::new(size_hint=self.length())
   for c in self {
     if c >= 'A' && c <= 'Z' {
       buf.write_char(Char::from_int(c.to_int() + 32))
@@ -542,7 +542,7 @@ pub fn to_lower(self : String) -> String {
 /// Converts this string to uppercase.
 pub fn to_upper(self : String) -> String {
   // TODO: deal with non-ascii characters
-  let buf = Buffer::new(size_hint=self.length())
+  let buf = StringBuilder::new(size_hint=self.length())
   for c in self {
     if c >= 'a' && c <= 'z' {
       buf.write_char(Char::from_int(c.to_int() - 32))
@@ -573,7 +573,7 @@ pub fn repeat(self : String, n : Int) -> String {
     return self
   }
   let len = self.length()
-  let buf = Buffer::new(size_hint=len * n)
+  let buf = StringBuilder::new(size_hint=len * n)
   for _ in 0..<n {
     buf.write_string(self)
   }
@@ -595,7 +595,7 @@ pub fn pad_start(
   if len >= total_width {
     self
   } else {
-    let buf = Buffer::new(size_hint=total_width)
+    let buf = StringBuilder::new(size_hint=total_width)
     for i = 0; i < total_width - len; i = i + 1 {
       buf.write_char(padding_char)
     }
@@ -615,7 +615,7 @@ pub fn pad_end(self : String, total_width : Int, padding_char : Char) -> String 
   if len >= total_width {
     self
   } else {
-    let buf = Buffer::new(size_hint=total_width)
+    let buf = StringBuilder::new(size_hint=total_width)
     buf.write_string(self)
     for i = 0; i < total_width - len; i = i + 1 {
       buf.write_char(padding_char)

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 fn debug_string[T : Show](t : T) -> String {
-  let buf = Buffer::new(size_hint=50)
+  let buf = StringBuilder::new(size_hint=50)
   t.output(buf)
   buf.to_string()
 }


### PR DESCRIPTION
This PR refactor all the usages of Buffer in core in favor of StringBuilder.

This PR is extracted from https://github.com/moonbitlang/core/pull/1084