### PR TITLE
clean up bitwise functions

### DIFF
--- a/builtin/bigint.mbt
+++ b/builtin/bigint.mbt
@@ -415,8 +415,7 @@ fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
 
 // Bitwise Operations
 
-/// Left shift a bigint
-/// /// @alert deprecate "Use shl instead"
+/// @alert deprecated "Use infix bitwise operator `<<` instead"
 pub fn lsl(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
@@ -455,6 +454,7 @@ pub fn lsl(self : BigInt, n : Int) -> BigInt {
 /// Left shift a bigint
 /// The sign of the result is the same as the sign of the input.
 /// Only the absolute value is shifted.
+/// 
 pub fn op_shl(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
@@ -491,6 +491,8 @@ pub fn op_shl(self : BigInt, n : Int) -> BigInt {
 /// Left shift a bigint
 /// The sign of the result is the same as the sign of the input.
 /// Only the absolute value is shifted.
+/// 
+/// @alert deprecated "Use infix bitwise operator `<<` instead"
 pub fn shl(self : BigInt, n : Int) -> BigInt {
   self << n
 }
@@ -539,10 +541,13 @@ pub fn op_shr(self : BigInt, n : Int) -> BigInt {
 /// Right shift a bigint
 /// The sign of the result is the same as the sign of the input.
 /// Only the absolute value is shifted.
+/// 
+/// @alert deprecated "Use infix bitwise operator `>>` instead"
 pub fn shr(self : BigInt, n : Int) -> BigInt {
   self >> n
 }
 
+/// @alert deprecated "Use infix bitwise operator `>>` instead"
 pub fn asr(self : BigInt, n : Int) -> BigInt {
   self >> n
 }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -135,7 +135,7 @@ impl ArrayView {
 
 type BigInt
 impl BigInt {
-  asr(Self, Int) -> Self
+  asr(Self, Int) -> Self //deprecated
   compare(Self, Self) -> Int
   from_hex(String) -> Self
   from_int(Int) -> Self
@@ -143,7 +143,7 @@ impl BigInt {
   from_octets(Bytes, ~signum : Int = ..) -> Self
   from_string(String) -> Self
   is_zero(Self) -> Bool
-  lsl(Self, Int) -> Self
+  lsl(Self, Int) -> Self //deprecated
   op_add(Self, Self) -> Self
   op_div(Self, Self) -> Self
   op_equal(Self, Self) -> Bool
@@ -154,8 +154,8 @@ impl BigInt {
   op_shr(Self, Int) -> Self
   op_sub(Self, Self) -> Self
   pow(Self, Self, ~modulus : Self = ..) -> Self
-  shl(Self, Int) -> Self
-  shr(Self, Int) -> Self
+  shl(Self, Int) -> Self //deprecated
+  shr(Self, Int) -> Self //deprecated
   to_hex(Self, ~uppercase : Bool = ..) -> String
   to_json(Self) -> Json
   to_octets(Self, ~length? : Int) -> Bytes
@@ -345,8 +345,8 @@ impl Byte {
   land(Byte, Byte) -> Byte
   lnot(Byte) -> Byte
   lor(Byte, Byte) -> Byte
-  lsl(Byte, Int) -> Byte
-  lsr(Byte, Int) -> Byte
+  lsl(Byte, Int) -> Byte //deprecated
+  lsr(Byte, Int) -> Byte //deprecated
   lxor(Byte, Byte) -> Byte
   op_equal(Byte, Byte) -> Bool
   op_shl(Byte, Int) -> Byte
@@ -367,7 +367,7 @@ impl Char {
   to_string(Char) -> String
 }
 impl Int {
-  asr(Int, Int) -> Int
+  asr(Int, Int) -> Int //deprecated
   clz(Int) -> Int
   compare(Int, Int) -> Int
   ctz(Int) -> Int
@@ -379,8 +379,8 @@ impl Int {
   land(Int, Int) -> Int
   lnot(Int) -> Int
   lor(Int, Int) -> Int
-  lsl(Int, Int) -> Int
-  lsr(Int, Int) -> Int
+  lsl(Int, Int) -> Int //deprecated
+  lsr(Int, Int) -> Int //deprecated
   lxor(Int, Int) -> Int
   op_add(Int, Int) -> Int
   op_div(Int, Int) -> Int
@@ -394,8 +394,8 @@ impl Int {
   popcnt(Int) -> Int
   reinterpret_as_float(Int) -> Float
   reinterpret_as_uint(Int) -> UInt
-  shl(Int, Int) -> Int
-  shr(Int, Int) -> Int
+  shl(Int, Int) -> Int //deprecated
+  shr(Int, Int) -> Int //deprecated
   to_byte(Int) -> Byte
   to_double(Int) -> Double
   to_float(Int) -> Float
@@ -415,8 +415,8 @@ impl Int64 {
   land(Int64, Int64) -> Int64
   lnot(Int64) -> Int64
   lor(Int64, Int64) -> Int64
-  lsl(Int64, Int) -> Int64
-  lsr(Int64, Int) -> Int64
+  lsl(Int64, Int) -> Int64 //deprecated
+  lsr(Int64, Int) -> Int64 //deprecated
   lxor(Int64, Int64) -> Int64
   op_add(Int64, Int64) -> Int64
   op_div(Int64, Int64) -> Int64
@@ -429,8 +429,8 @@ impl Int64 {
   op_sub(Int64, Int64) -> Int64
   popcnt(Int64) -> Int
   reinterpret_as_double(Int64) -> Double
-  shl(Int64, Int) -> Int64
-  shr(Int64, Int) -> Int64
+  shl(Int64, Int) -> Int64 //deprecated
+  shr(Int64, Int) -> Int64 //deprecated
   to_byte(Int64) -> Byte
   to_double(Int64) -> Double
   to_float(Int64) -> Float
@@ -448,8 +448,8 @@ impl UInt {
   land(UInt, UInt) -> UInt
   lnot(UInt) -> UInt
   lor(UInt, UInt) -> UInt
-  lsl(UInt, Int) -> UInt
-  lsr(UInt, Int) -> UInt
+  lsl(UInt, Int) -> UInt //deprecated
+  lsr(UInt, Int) -> UInt //deprecated
   lxor(UInt, UInt) -> UInt
   op_add(UInt, UInt) -> UInt
   op_div(UInt, UInt) -> UInt
@@ -462,8 +462,8 @@ impl UInt {
   op_sub(UInt, UInt) -> UInt
   popcnt(UInt) -> Int
   reinterpret_as_int(UInt) -> Int
-  shl(UInt, Int) -> UInt
-  shr(UInt, Int) -> UInt
+  shl(UInt, Int) -> UInt //deprecated
+  shr(UInt, Int) -> UInt //deprecated
   to_float(UInt) -> Float
   to_int(UInt) -> Int //deprecated
   to_string(UInt) -> String
@@ -480,8 +480,8 @@ impl UInt64 {
   land(UInt64, UInt64) -> UInt64
   lnot(UInt64) -> UInt64
   lor(UInt64, UInt64) -> UInt64
-  lsl(UInt64, Int) -> UInt64
-  lsr(UInt64, Int) -> UInt64
+  lsl(UInt64, Int) -> UInt64 //deprecated
+  lsr(UInt64, Int) -> UInt64 //deprecated
   lxor(UInt64, UInt64) -> UInt64
   op_add(UInt64, UInt64) -> UInt64
   op_div(UInt64, UInt64) -> UInt64
@@ -492,8 +492,8 @@ impl UInt64 {
   op_shr(UInt64, Int) -> UInt64
   op_sub(UInt64, UInt64) -> UInt64
   popcnt(UInt64) -> Int
-  shl(UInt64, Int) -> UInt64
-  shr(UInt64, Int) -> UInt64
+  shl(UInt64, Int) -> UInt64 //deprecated
+  shr(UInt64, Int) -> UInt64 //deprecated
   to_byte(UInt64) -> Byte
   to_double(UInt64) -> Double
   to_float(UInt64) -> Float

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -87,10 +87,12 @@ pub fn Byte::op_shr(self : Byte, count : Int) -> Byte {
   (self.to_uint() >> count).reinterpret_as_int().to_byte()
 }
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn Byte::lsl(self : Byte, count : Int) -> Byte {
   (self.to_int() << count).to_byte()
 }
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn Byte::lsr(self : Byte, count : Int) -> Byte {
   (self.to_uint() >> count).reinterpret_as_int().to_byte()
 }

--- a/builtin/int64_js.mbt
+++ b/builtin/int64_js.mbt
@@ -363,16 +363,8 @@ pub fn Int64::op_div(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).op_div(MyInt64::from_int64(other)).to_int64()
 }
 
-pub fn Int64::div_u(self : Int64, other : Int64) -> Int64 {
-  MyInt64::from_int64(self).div_u(MyInt64::from_int64(other)).to_int64()
-}
-
 pub fn Int64::op_mod(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).op_mod(MyInt64::from_int64(other)).to_int64()
-}
-
-pub fn Int64::mod_u(self : Int64, other : Int64) -> Int64 {
-  MyInt64::from_int64(self).mod_u(MyInt64::from_int64(other)).to_int64()
 }
 
 pub fn Int64::lnot(self : Int64) -> Int64 {
@@ -391,23 +383,28 @@ pub fn Int64::lxor(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).lxor(MyInt64::from_int64(other)).to_int64()
 }
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn Int64::lsl(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).lsl(other).to_int64()
 }
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn Int64::shl(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).lsl(other).to_int64()
 }
 
-pub fn Int64::op_shl(self : Int64, other : Int) -> Int64 {
-  MyInt64::from_int64(self).lsl(other).to_int64()
-}
-
+/// @alert deprecated "Use UInt64 type and infix operator `>>` instead"
 pub fn Int64::lsr(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).lsr(other).to_int64()
 }
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn Int64::shr(self : Int64, other : Int) -> Int64 {
+  MyInt64::from_int64(self).asr(other).to_int64()
+}
+
+/// @alert deprecated "Use infix operator `>>` instead"
+pub fn Int64::asr(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).asr(other).to_int64()
 }
 
@@ -415,8 +412,8 @@ pub fn Int64::op_shr(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).asr(other).to_int64()
 }
 
-pub fn Int64::asr(self : Int64, other : Int) -> Int64 {
-  MyInt64::from_int64(self).asr(other).to_int64()
+pub fn Int64::op_shl(self : Int64, other : Int) -> Int64 {
+  MyInt64::from_int64(self).lsl(other).to_int64()
 }
 
 pub fn Int64::ctz(self : Int64) -> Int {
@@ -559,24 +556,28 @@ pub fn UInt64::lnot(self : UInt64) -> UInt64 {
   MyInt64::lnot(MyInt64::from_uint64(self)).to_uint64()
 }
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsr(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn UInt64::shl(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
-pub fn UInt64::op_shl(self : UInt64, shift : Int) -> UInt64 {
-  MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
-}
-
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn UInt64::shr(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsr(MyInt64::from_uint64(self), shift).to_uint64()
+}
+
+pub fn UInt64::op_shl(self : UInt64, shift : Int) -> UInt64 {
+  MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
 pub fn UInt64::op_shr(self : UInt64, shift : Int) -> UInt64 {

--- a/builtin/int64_js.mbt
+++ b/builtin/int64_js.mbt
@@ -181,9 +181,16 @@ fn MyInt64::lsr(self : MyInt64, shift : Int) -> MyInt64 {
   if shift == 0 {
     self
   } else if shift < 32 {
-    { hi: self.hi.lsr(shift), lo: self.lo.lsr(shift) | self.hi.lsl(32 - shift) }
+    {
+      hi: (self.hi.reinterpret_as_uint() >> shift).reinterpret_as_int(),
+      lo: (self.lo.reinterpret_as_uint() >> shift).reinterpret_as_int() |
+      (self.hi << (32 - shift)),
+    }
   } else {
-    { hi: 0, lo: self.hi.lsr(shift - 32) }
+    {
+      hi: 0,
+      lo: (self.hi.reinterpret_as_uint() >> (shift - 32)).reinterpret_as_int(),
+    }
   }
 }
 
@@ -192,9 +199,13 @@ fn MyInt64::asr(self : MyInt64, shift : Int) -> MyInt64 {
   if shift == 0 {
     self
   } else if shift < 32 {
-    { hi: self.hi.asr(shift), lo: self.lo.lsr(shift) | self.hi.lsl(32 - shift) }
+    {
+      hi: self.hi >> shift,
+      lo: (self.lo.reinterpret_as_uint() >> shift).reinterpret_as_int() |
+      (self.hi << (32 - shift)),
+    }
   } else {
-    { hi: self.hi.asr(31), lo: self.hi.asr(shift - 32) }
+    { hi: self.hi >> 31, lo: self.hi >> (shift - 32) }
   }
 }
 
@@ -268,7 +279,7 @@ extern "js" fn MyInt64::compare_u(self : MyInt64, other : MyInt64) -> Int =
   #|}
 
 fn MyInt64::from_int(value : Int) -> MyInt64 {
-  { hi: value.asr(31) & -1, lo: value | 0 }
+  { hi: (value >> 31) & -1, lo: value | 0 }
 }
 
 fn MyInt64::to_int(self : MyInt64) -> Int {

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -32,18 +32,22 @@ pub fn Int64::lor(self : Int64, other : Int64) -> Int64 = "%i64_lor"
 
 pub fn Int64::lxor(self : Int64, other : Int64) -> Int64 = "%i64_lxor"
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn Int64::lsl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn Int64::shl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 
-pub fn Int64::op_shl(self : Int64, other : Int) -> Int64 = "%i64_shl"
-
+/// @alert deprecated "Use UInt64 type and infix operator `>>` instead"
 pub fn Int64::lsr(self : Int64, other : Int) -> Int64 = "%u64.shr"
 
-/// @alert deprecated "Use shr instead"
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn Int64::asr(self : Int64, other : Int) -> Int64 = "%i64_shr"
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn Int64::shr(self : Int64, other : Int) -> Int64 = "%i64_shr"
+
+pub fn Int64::op_shl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 
 pub fn Int64::op_shr(self : Int64, other : Int) -> Int64 = "%i64_shr"
 
@@ -115,13 +119,19 @@ pub fn UInt64::lxor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitxor"
 
 pub fn UInt64::lnot(self : UInt64) -> UInt64 = "%u64.bitnot"
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn UInt64::shl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 
-pub fn UInt64::op_shl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
+/// @alert deprecated "Use infix operator `>>` instead"
+pub fn UInt64::shr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
+
+pub fn UInt64::op_shl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 
 pub fn UInt64::op_shr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 
@@ -130,7 +140,5 @@ pub fn UInt64::clz(self : UInt64) -> Int = "%u64.clz"
 pub fn UInt64::ctz(self : UInt64) -> Int = "%u64.ctz"
 
 pub fn UInt64::popcnt(self : UInt64) -> Int = "%u64.popcnt"
-
-pub fn UInt64::shr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 
 pub fn UInt64::to_float(self : UInt64) -> Float = "%u64.to_f32"

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -55,19 +55,24 @@ pub fn Int::lor(self : Int, other : Int) -> Int = "%i32_lor"
 
 pub fn Int::lxor(self : Int, other : Int) -> Int = "%i32_lxor"
 
-pub fn Int::lsl(self : Int, other : Int) -> Int = "%i32_shl"
-
-pub fn Int::shl(self : Int, other : Int) -> Int = "%i32_shl"
-
 pub fn Int::op_shl(self : Int, other : Int) -> Int = "%i32_shl"
 
+pub fn Int::op_shr(self : Int, other : Int) -> Int = "%i32_shr"
+
+/// @alert deprecated "Use infix operator `<<` instead"
+pub fn Int::lsl(self : Int, other : Int) -> Int = "%i32_shl"
+
+/// @alert deprecated "Use infix operator `<<` instead" 
+pub fn Int::shl(self : Int, other : Int) -> Int = "%i32_shl"
+
+/// @alert deprecated "Use UInt type and infix operator `>>` instead"
 pub fn Int::lsr(self : Int, other : Int) -> Int = "%u32.shr"
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn Int::asr(self : Int, other : Int) -> Int = "%i32_shr"
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn Int::shr(self : Int, other : Int) -> Int = "%i32_shr"
-
-pub fn Int::op_shr(self : Int, other : Int) -> Int = "%i32_shr"
 
 pub fn Int::ctz(self : Int) -> Int = "%i32_ctz"
 
@@ -233,15 +238,19 @@ pub fn UInt::lxor(self : UInt, other : UInt) -> UInt = "%u32.bitxor"
 
 pub fn UInt::lnot(self : UInt) -> UInt = "%u32.bitnot"
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn UInt::lsl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 
+/// @alert deprecated "Use infix operator `<<` instead"
 pub fn UInt::shl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 
-pub fn UInt::op_shl(self : UInt, shift : Int) -> UInt = "%u32.shl"
-
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn UInt::lsr(self : UInt, shift : Int) -> UInt = "%u32.shr"
 
+/// @alert deprecated "Use infix operator `>>` instead"
 pub fn UInt::shr(self : UInt, shift : Int) -> UInt = "%u32.shr"
+
+pub fn UInt::op_shl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 
 pub fn UInt::op_shr(self : UInt, shift : Int) -> UInt = "%u32.shr"
 

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -66,7 +66,9 @@ pub fn Int::lsl(self : Int, other : Int) -> Int = "%i32_shl"
 pub fn Int::shl(self : Int, other : Int) -> Int = "%i32_shl"
 
 /// @alert deprecated "Use UInt type and infix operator `>>` instead"
-pub fn Int::lsr(self : Int, other : Int) -> Int = "%u32.shr"
+pub fn Int::lsr(self : Int, other : Int) -> Int {
+  (self.reinterpret_as_uint() >> other).reinterpret_as_int()
+}
 
 /// @alert deprecated "Use infix operator `>>` instead"
 pub fn Int::asr(self : Int, other : Int) -> Int = "%i32_shr"

--- a/byte/byte.mbt
+++ b/byte/byte.mbt
@@ -15,7 +15,3 @@
 pub let max_value : Byte = b'\xFF'
 
 pub let min_value : Byte = b'\x00'
-
-pub fn to_uint(self : Byte) -> UInt {
-  self.to_int().reinterpret_as_uint()
-}

--- a/byte/byte.mbti
+++ b/byte/byte.mbti
@@ -6,9 +6,6 @@ let max_value : Byte
 let min_value : Byte
 
 // Types and methods
-impl Byte {
-  to_uint(Byte) -> UInt
-}
 
 // Type aliases
 


### PR DESCRIPTION
Per discussion with @bobzhang, we will only keep `op_shl` and `op_shr` for simplicity, and favor infix operator style `x >> y` over `x.op_shr(y)`.

After that, there is no need to bother with distinguishing API between logical right shift and arithmetic right shift for average user: all right shift operations perform division by powers of 2. For who want to use integer types as a bit vector, `UInt`/`UInt64` is recommended.

# Changes

- deprecate functions like `lsl`, `lsr`, `asr`, `shl`, `shr` 
- remove `mod_u` and `div_u` in int64_js.mbt

previous PR #1089 #1088