### PR TITLE
deprecate Js_string

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -31,7 +31,7 @@ fn panic[T]() -> T
 
 fn physical_equal[T](T, T) -> Bool
 
-fn print[T : Show](T) -> Unit
+fn print[T : Show](T) -> Unit //deprecated
 
 fn println[T : Show](T) -> Unit
 
@@ -259,7 +259,7 @@ impl IterResult {
   op_equal(Self, Self) -> Bool
 }
 
-pub type Js_string
+pub type Js_string //deprecated
 impl Js_string {
   log(Self) -> Unit
   new(String) -> Self

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -18,7 +18,7 @@ pub fn println[T : Show](input : T) -> Unit {
   println_mono(input.to_string())
 }
 
-/// @alert deprecate "Use `println` instead"
+/// @alert deprecated "Use `println` instead"
 pub fn print[T : Show](input : T) -> Unit {
   println(input)
 }
@@ -147,6 +147,7 @@ pub fn op_notequal[T : Eq](x : T, y : T) -> Bool {
 }
 
 /// A reference to string in host JS.
+/// @alert deprecated "Use js-string-builtins api instead"
 pub type Js_string
 
 /// Create a JS string from a string in Moonbit by calling intrinsic primitive


### PR DESCRIPTION
We will support the Js-string-builtin proposal, so the legacy Js-string is removed.