### PR TITLE
feat: add `rev_map()` to `@immut/list`

### DIFF
--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -148,6 +148,22 @@ pub fn mapi[A, B](self : T[A], f : (Int, A) -> B) -> T[B] {
   go(self, 0, f)
 }
 
+/// Maps the list and reverses the result.
+///
+/// `list.rev_map(f)` is equivalent to `list.map(f).rev()` but more efficient.
+///
+/// # Example
+/// ```
+/// println(@list.of([1, 2, 3, 4, 5]).rev_map(fn(x) { x * 2 }))
+/// // output: of([10, 8, 6, 4, 2])
+/// ```
+pub fn rev_map[A, B](self : T[A], f : (A) -> B) -> T[B] {
+  loop Nil, self {
+    acc, Nil => acc
+    acc, Cons(x, xs) => continue Cons(f(x), acc), xs
+  }
+}
+
 /// Convert list to array.
 pub fn to_array[A](self : T[A]) -> Array[A] {
   match self {

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -70,6 +70,7 @@ impl T {
   rev_concat[A](Self[A], Self[A]) -> Self[A]
   rev_fold[A, B](Self[A], ~init : B, (A, B) -> B) -> B
   rev_foldi[A, B](Self[A], ~init : B, (Int, A, B) -> B) -> B
+  rev_map[A, B](Self[A], (A) -> B) -> Self[B]
   scan_left[A, E](Self[A], (E, A) -> E, ~init : E) -> Self[E]
   scan_right[A, B](Self[A], (A, B) -> B, ~init : B) -> Self[B]
   sort[A : Compare + Eq](Self[A]) -> Self[A]

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -62,6 +62,13 @@ test "mapi" {
   inspect!(el.mapi(fn(i, x) { i * x }), content="@list.of([])")
 }
 
+test "rev_map" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs : @list.T[Int] = @list.Nil
+  inspect!(ls.rev_map(fn(x) { x * 2 }), content="@list.of([10, 8, 6, 4, 2])")
+  inspect!(rs.rev_map(fn(x) { x * 2 }), content="@list.of([])")
+}
+
 test "to_array" {
   let list = @list.of([1, 2, 3, 4, 5])
   let empty : @list.T[Int] = @list.Nil


### PR DESCRIPTION
Mirrors OCaml's [`List.rev_map`](https://www.ocaml.org/manual/5.2/api/List.html#VALrev_map), which is a more efficient version of `List.map` (by being tail-recursive) at the cost of getting a reversed list.

The blog post [_OCaml List rev_map vs map_](https://www.thekerneltrip.com/ocaml/ocaml-list-map-vs-revmap/) gives a pretty accurate description of the rationale of this method.