### PR TITLE
feat: implement `(From|To)Json` for more `@immut/*.T` types

### DIFF
--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -29,6 +29,18 @@ pub fn T::to_string[A : Show](xs : T[A]) -> String {
   Show::to_string(xs)
 }
 
+pub impl[A : ToJson] ToJson for T[A] with to_json(self) {
+  let capacity = self.length()
+  guard capacity != 0 else { return Array([]) }
+  let jsons = Array::new(~capacity)
+  self.each(fn(a) { jsons.push(a.to_json()) })
+  Array(jsons)
+}
+
+pub fn T::to_json[A : ToJson](self : T[A]) -> Json {
+  ToJson::to_json(self)
+}
+
 /// Convert array to list.
 ///
 /// # Example

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -41,6 +41,27 @@ pub fn T::to_json[A : ToJson](self : T[A]) -> Json {
   ToJson::to_json(self)
 }
 
+pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) {
+  match json {
+    Array(arr) =>
+      for i = arr.length() - 1, list = Nil; i >= 0; {
+        continue i - 1, list.add(A::from_json!(arr[i], path))
+      } else {
+        list
+      }
+    _ =>
+      raise @json.JsonDecodeError(
+        (path, "@immut/list.from_json: expected array"),
+      )
+  }
+}
+
+pub fn T::from_json[A : @json.FromJson](
+  json : Json
+) -> T[A]!@json.JsonDecodeError {
+  @json.from_json!(json)
+}
+
 /// Convert array to list.
 ///
 /// # Example

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -1,5 +1,6 @@
 package moonbitlang/core/immut/list
 
+alias @moonbitlang/core/json as @json
 alias @moonbitlang/core/quickcheck as @quickcheck
 
 // Values
@@ -40,6 +41,7 @@ impl T {
   foldi[A, B](Self[A], ~init : B, (Int, B, A) -> B) -> B
   from_array[A](Array[A]) -> Self[A]
   from_iter[A](Iter[A]) -> Self[A]
+  from_json[A : @json.FromJson](Json) -> Self[A]!@json.JsonDecodeError
   head[A](Self[A]) -> A?
   head_exn[A](Self[A]) -> A //deprecated
   init_[A](Self[A]) -> Self[A]
@@ -93,6 +95,8 @@ impl T {
 impl Show for T
 
 impl ToJson for T
+
+impl @json.FromJson for T
 
 impl @quickcheck.Arbitrary for T
 

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -75,6 +75,7 @@ impl T {
   take[A](Self[A], Int) -> Self[A]
   take_while[A](Self[A], (A) -> Bool) -> Self[A]
   to_array[A](Self[A]) -> Array[A]
+  to_json[A : ToJson](Self[A]) -> Json
   to_string[A : Show](Self[A]) -> String
   unsafe_head[A](Self[A]) -> A
   unsafe_last[A](Self[A]) -> A
@@ -90,6 +91,8 @@ impl T {
 
 // Extension Methods
 impl Show for T
+
+impl ToJson for T
 
 impl @quickcheck.Arbitrary for T
 

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -498,6 +498,12 @@ test "List::to_json with empty list" {
   @json.inspect!(ToJson::to_json(list), content=[])
 }
 
+test "List::from_json" {
+  for xs in (@quickcheck.samples(20) : Array[@list.T[Int]]) {
+    assert_eq!(xs, @json.from_json!(xs.to_json()))
+  }
+}
+
 test "List::head_exn with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
   let head = @list.head(list)

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -488,6 +488,16 @@ test "List::output with empty list" {
   inspect!(buf, content="@list.of([])")
 }
 
+test "List::to_json with non-empty list" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  @json.inspect!(ToJson::to_json(list), content=[1, 2, 3, 4, 5])
+}
+
+test "List::to_json with empty list" {
+  let list : @list.T[Int] = Nil
+  @json.inspect!(ToJson::to_json(list), content=[])
+}
+
 test "List::head_exn with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
   let head = @list.head(list)

--- a/immut/list/moon.pkg.json
+++ b/immut/list/moon.pkg.json
@@ -4,7 +4,8 @@
     "moonbitlang/core/test",
     "moonbitlang/core/array",
     "moonbitlang/core/coverage",
-    "moonbitlang/core/quickcheck"
+    "moonbitlang/core/quickcheck",
+    "moonbitlang/core/json"
   ],
   "targets": {
     "panic_test.mbt": ["not", "native"]

--- a/immut/sorted_map/moon.pkg.json
+++ b/immut/sorted_map/moon.pkg.json
@@ -6,7 +6,8 @@
     "moonbitlang/core/string",
     "moonbitlang/core/array",
     "moonbitlang/core/coverage",
-    "moonbitlang/core/quickcheck"
+    "moonbitlang/core/quickcheck",
+    "moonbitlang/core/json"
   ],
   "targets": {
     "panic_wbtest.mbt": ["not", "native"]

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -34,6 +34,7 @@ impl T {
   singleton[K, V](K, V) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
+  to_json[K : Show, V : ToJson](Self[K, V]) -> Json
   to_string[K : Show, V : Show](Self[K, V]) -> String
 }
 
@@ -43,6 +44,8 @@ impl T {
 
 // Extension Methods
 impl Show for T
+
+impl ToJson for T
 
 impl @quickcheck.Arbitrary for T
 

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -1,5 +1,6 @@
 package moonbitlang/core/immut/sorted_map
 
+alias @moonbitlang/core/json as @json
 alias @moonbitlang/core/quickcheck as @quickcheck
 
 // Values
@@ -19,6 +20,7 @@ impl T {
   foldr_with_key[K, V, A](Self[K, V], (A, K, V) -> A, ~init : A) -> A
   from_array[K : Compare + Eq, V](Array[(K, V)]) -> Self[K, V]
   from_iter[K : Compare + Eq, V](Iter[(K, V)]) -> Self[K, V]
+  from_json[V : @json.FromJson](Json) -> Self[String, V]!@json.JsonDecodeError
   insert[K : Compare + Eq, V](Self[K, V], K, V) -> Self[K, V]
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
@@ -46,6 +48,8 @@ impl T {
 impl Show for T
 
 impl ToJson for T
+
+impl @json.FromJson for T
 
 impl @quickcheck.Arbitrary for T
 

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -269,3 +269,28 @@ pub impl[K : Show, V : ToJson] ToJson for T[K, V] with to_json(self) {
 pub fn to_json[K : Show, V : ToJson](self : T[K, V]) -> Json {
   ToJson::to_json(self)
 }
+
+pub impl[V : @json.FromJson] @json.FromJson for T[String, V] with from_json(
+  json,
+  path
+) {
+  match json {
+    Object(obj) => {
+      let mut map = T::empty()
+      for k, v in obj {
+        map = map.insert(k, V::from_json!(v, path))
+      }
+      map
+    }
+    _ =>
+      raise @json.JsonDecodeError(
+        (path, "@immut/sorted_map.from_json: expected object"),
+      )
+  }
+}
+
+pub fn T::from_json[V : @json.FromJson](
+  json : Json
+) -> T[String, V]!@json.JsonDecodeError {
+  @json.from_json!(json)
+}

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -257,3 +257,15 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
 pub fn to_string[K : Show, V : Show](self : T[K, V]) -> String {
   Show::to_string(self)
 }
+
+pub impl[K : Show, V : ToJson] ToJson for T[K, V] with to_json(self) {
+  let capacity = self.size()
+  guard capacity != 0 else { return Object(Map::new()) }
+  let jsons = Map::new(~capacity)
+  self.each(fn(k, v) { jsons[k.to_string()] = v.to_json() })
+  Object(jsons)
+}
+
+pub fn to_json[K : Show, V : ToJson](self : T[K, V]) -> Json {
+  ToJson::to_json(self)
+}

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -92,3 +92,9 @@ test "to_json with empty map" {
   let map : @sorted_map.T[Int, String] = @sorted_map.empty()
   @json.inspect!(map.to_json(), content={})
 }
+
+test "from_json" {
+  for xs in (@quickcheck.samples(20) : Array[@sorted_map.T[String, Int]]) {
+    assert_eq!(xs, @json.from_json!(xs.to_json()))
+  }
+}

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -78,3 +78,17 @@ test "op_get with empty map" {
   let map : @sorted_map.T[Int, String] = @sorted_map.empty()
   assert_eq!(map[3], None)
 }
+
+test "to_json with non-empty map" {
+  let map = [(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")]
+    |> @sorted_map.of
+  @json.inspect!(
+    map.to_json(),
+    content={ "0": "zero", "1": "one", "2": "two", "3": "three", "8": "eight" },
+  )
+}
+
+test "to_json with empty map" {
+  let map : @sorted_map.T[Int, String] = @sorted_map.empty()
+  @json.inspect!(map.to_json(), content={})
+}

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -41,11 +41,7 @@ pub fn T::from_iter[A : Compare](iter : Iter[A]) -> T[A] {
 }
 
 test {
-  let buf = StringBuilder::new(size_hint=20)
-  of([2, 7, 1, 2, 3, 4, 5])
-  .iter()
-  .each(fn { x => buf.write_string(x.to_string()) })
-  inspect!(buf, content="123457")
+  @json.inspect!(of([2, 7, 1, 2, 3, 4, 5]), content=[1, 2, 3, 4, 5, 7])
 }
 
 pub fn T::op_equal[A : Eq](self : T[A], other : T[A]) -> Bool {

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -47,3 +47,56 @@ test {
   .each(fn { x => buf.write_string(x.to_string()) })
   inspect!(buf, content="123457")
 }
+
+pub fn T::op_equal[A : Eq](self : T[A], other : T[A]) -> Bool {
+  // There's no `Iter::zip` (https://github.com/moonbitlang/core/issues/994#issuecomment-2350935193),
+  // so we have to use the manual implementation below:
+  let iter = InorderIterator::new(self)
+  let iter1 = InorderIterator::new(other)
+  loop iter.next(), iter1.next() {
+    None, None => true
+    Some(a), Some(b) => {
+      guard a == b else { break false }
+      continue iter.next(), iter1.next()
+    }
+    _, _ => false
+  }
+}
+
+priv type InorderIterator[A] Array[T[A]]
+
+fn InorderIterator::new[A](root : T[A]) -> InorderIterator[A] {
+  InorderIterator([])..move_left(root)
+}
+
+fn InorderIterator::move_left[A](
+  self : InorderIterator[A],
+  node : T[A]
+) -> Unit {
+  loop node {
+    Empty => ()
+    Node(~left, ..) as curr => {
+      self._.push(curr)
+      continue left
+    }
+  }
+}
+
+fn InorderIterator::next[A](self : InorderIterator[A]) -> A? {
+  guard let Some(curr) = self._.pop() else { _ => return None }
+  guard let Node(~right, ~value, ..) = curr
+  self.move_left(right)
+  Some(value)
+}
+
+test "InorderIterator" {
+  let arr : FixedArray[_] = [1, 2, 3, 4, 5, 6, 7]
+  let set = of(arr)
+  let iter = InorderIterator::new(set)
+  for i = 0; ; i = i + 1 {
+    match iter.next() {
+      None => break
+      Some(value) => assert_eq!(value, arr[i])
+    }
+  }
+}

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -499,6 +499,18 @@ pub fn to_string[A : Show](self : T[A]) -> String {
   Show::to_string(self)
 }
 
+pub impl[A : ToJson] ToJson for T[A] with to_json(self) {
+  let capacity = self.iter().count()
+  guard capacity != 0 else { return Array([]) }
+  let jsons = Array::new(~capacity)
+  self.each(fn(a) { jsons.push(a.to_json()) })
+  Array(jsons)
+}
+
+pub fn T::to_json[A : ToJson](self : T[A]) -> Json {
+  ToJson::to_json(self)
+}
+
 pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X] with arbitrary(
   size,
   rs

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -511,6 +511,31 @@ pub fn T::to_json[A : ToJson](self : T[A]) -> Json {
   ToJson::to_json(self)
 }
 
+pub impl[A : @json.FromJson + Compare] @json.FromJson for T[A] with from_json(
+  json,
+  path
+) {
+  match json {
+    Array(arr) => {
+      let mut set = T::new()
+      for i in arr {
+        set = set.add(A::from_json!(i, path))
+      }
+      set
+    }
+    _ =>
+      raise @json.JsonDecodeError(
+        (path, "@immut/sorted_set.from_json: expected array"),
+      )
+  }
+}
+
+pub fn T::from_json[A : @json.FromJson + Compare](
+  json : Json
+) -> T[A]!@json.JsonDecodeError {
+  @json.from_json!(json)
+}
+
 pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X] with arbitrary(
   size,
   rs

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -293,6 +293,19 @@ test "to_string" {
   )
 }
 
+test "op_equal" {
+  let xss : Array[@sorted_set.T[Int]] = @quickcheck.samples(5)
+  for xs in xss {
+    for ys in xss {
+      if xs.to_array() == ys.to_array() {
+        assert_eq!(xs, ys)
+      } else {
+        assert_not_eq!(xs, ys)
+      }
+    }
+  }
+}
+
 test "iter" {
   let mut s = ""
   @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(fn(x) { s += x.to_string() })

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -306,6 +306,11 @@ test "op_equal" {
   }
 }
 
+test "to_json" {
+  @json.inspect!(@sorted_set.of([5, 2, 4, 3, 1]), content=[1, 2, 3, 4, 5])
+  @json.inspect!((@sorted_set.of([]) : @sorted_set.T[Int]), content=[])
+}
+
 test "iter" {
   let mut s = ""
   @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(fn(x) { s += x.to_string() })

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -311,6 +311,12 @@ test "to_json" {
   @json.inspect!((@sorted_set.of([]) : @sorted_set.T[Int]), content=[])
 }
 
+test "from_json" {
+  for xs in (@quickcheck.samples(20) : Array[@sorted_set.T[Int]]) {
+    assert_eq!(xs, @json.from_json!(xs.to_json()))
+  }
+}
+
 test "iter" {
   let mut s = ""
   @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(fn(x) { s += x.to_string() })

--- a/immut/sorted_set/moon.pkg.json
+++ b/immut/sorted_set/moon.pkg.json
@@ -3,7 +3,8 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/coverage"
+    "moonbitlang/core/coverage",
+    "moonbitlang/core/json"
   ],
   "targets": {
     "panic_test.mbt": ["not", "native"]

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -36,6 +36,7 @@ impl T {
   split[A : Compare + Eq](Self[A], A) -> (Self[A], Bool, Self[A])
   subset[A : Compare + Eq](Self[A], Self[A]) -> Bool
   to_array[A : Compare + Eq](Self[A]) -> Array[A]
+  to_json[A : ToJson](Self[A]) -> Json
   to_string[A : Show](Self[A]) -> String
   union[A : Compare + Eq](Self[A], Self[A]) -> Self[A]
 }
@@ -46,6 +47,8 @@ impl T {
 
 // Extension Methods
 impl Show for T
+
+impl ToJson for T
 
 impl @quickcheck.Arbitrary for T
 

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -1,5 +1,6 @@
 package moonbitlang/core/immut/sorted_set
 
+alias @moonbitlang/core/json as @json
 alias @moonbitlang/core/quickcheck as @quickcheck
 
 // Values
@@ -19,6 +20,7 @@ impl T {
   fold[A : Compare + Eq, B](Self[A], ~init : B, (B, A) -> B) -> B
   from_array[A : Compare + Eq](Array[A]) -> Self[A]
   from_iter[A : Compare + Eq](Iter[A]) -> Self[A]
+  from_json[A : @json.FromJson + Compare + Eq](Json) -> Self[A]!@json.JsonDecodeError
   inter[A : Compare + Eq](Self[A], Self[A]) -> Self[A]
   is_empty[A : Compare + Eq](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
@@ -49,6 +51,8 @@ impl T {
 impl Show for T
 
 impl ToJson for T
+
+impl @json.FromJson for T
 
 impl @quickcheck.Arbitrary for T
 

--- a/immut/sorted_set/types.mbt
+++ b/immut/sorted_set/types.mbt
@@ -20,4 +20,4 @@
 enum T[A] {
   Empty
   Node(~left : T[A], ~right : T[A], ~height : Int, ~value : A)
-} derive(Default, Eq)
+} derive(Default)


### PR DESCRIPTION
This pull request introduces JSON (de)serialization functionality to various immutable data structures (`list`, `sorted_map`, and `sorted_set`). The changes include implementing the `(From|To)Json` traits for these structures, adding corresponding methods, and updating the test cases to validate the new functionality.

As previously discussed with @bobzhang.