### PR TITLE
Revert "Defer last option breaking (#1114)"

### DIFF
--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -257,11 +257,10 @@ pub fn unsafe_last[A](self : T[A]) -> A {
 /// println(of([1, 2, 3, 4, 5]).last())
 /// // output: Some(5)
 /// ```
-/// @alert deprecated "In the next release `last` will return an `Option`. Use `unsafe_last` instead"
-pub fn last[A](self : T[A]) -> A {
+pub fn last[A](self : T[A]) -> A? {
   loop self {
-    Nil => abort("last of empty list")
-    Cons(head, Nil) => head
+    Nil => None
+    Cons(head, Nil) => Some(head)
     Cons(_, tail) => continue tail
   }
 }

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -52,7 +52,7 @@ impl T {
   is_suffix[A : Eq](Self[A], Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
   iter2[A](Self[A]) -> Iter2[Int, A]
-  last[A](Self[A]) -> A //deprecated
+  last[A](Self[A]) -> A?
   length[A](Self[A]) -> Int
   lookup[A : Eq, B](Self[(A, B)], A) -> B?
   map[A, B](Self[A], (A) -> B) -> Self[B]

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -109,10 +109,10 @@ test "head" {
   inspect!(el.head(), content="None")
 }
 
-// test "last" {
-//   let ls = @list.of([1, 2, 3, 4, 5])
-//   inspect!(ls.last(), content="5")
-// }
+test "last" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.last(), content="Some(5)")
+}
 
 test "init_" {
   let ls = @list.of([1, 2, 3, 4, 5])
@@ -510,11 +510,11 @@ test "List::head_exn with non-empty list" {
   assert_eq!(head, Some(1))
 }
 
-// test "List::last with non-empty list" {
-//   let list = @list.of([1, 2, 3, 4, 5])
-//   let last = @list.last(list)
-//   assert_eq!(last, 5)
-// }
+test "List::last with non-empty list" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  let last = @list.last(list)
+  assert_eq!(last, Some(5))
+}
 
 test "List::zip with lists of equal length" {
   let list1 = @list.of([1, 2, 3])

--- a/immut/list/panic_test.mbt
+++ b/immut/list/panic_test.mbt
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// test "panic last" {
-//   @list.Nil.last()
-// }
+test "last None" {
+  assert_eq!(@list.Nil.last(), (None : Unit?))
+}
 
 test "panic nth_exn" {
   @list.Nil.unsafe_nth(0)


### PR DESCRIPTION
This reverts commit b458397a37084b20792bc0c24ddb95c0d397550a.

Reintroduced `last` that returns `Option`