### PR TITLE
remove unused import

### DIFF
--- a/char/moon.pkg.json
+++ b/char/moon.pkg.json
@@ -1,7 +1,6 @@
 {
     "import": [
         "moonbitlang/core/builtin",
-        "moonbitlang/core/test",
         "moonbitlang/core/coverage"
     ]
 }

--- a/deque/moon.pkg.json
+++ b/deque/moon.pkg.json
@@ -1,9 +1,7 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
-    "moonbitlang/core/coverage",
-    "moonbitlang/core/array"
+    "moonbitlang/core/coverage"
   ],
   "targets": {
     "panic_test.mbt": ["not", "native"]

--- a/double/internal/ryu/moon.pkg.json
+++ b/double/internal/ryu/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/bool",
-    "moonbitlang/core/int64",
     "moonbitlang/core/coverage"
   ]
 }

--- a/double/moon.pkg.json
+++ b/double/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/bool",
     "moonbitlang/core/int64",
     "moonbitlang/core/coverage",
     "moonbitlang/core/double/internal/ryu"

--- a/error/moon.pkg.json
+++ b/error/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
     "moonbitlang/core/coverage"
   ]
 }

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/coverage",
-    "moonbitlang/core/int",
     "moonbitlang/core/test",
     "moonbitlang/core/array",
     "moonbitlang/core/tuple",

--- a/immut/array/moon.pkg.json
+++ b/immut/array/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/test",
     {
       "path": "moonbitlang/core/array",
       "alias": "core/array"

--- a/immut/hashset/moon.pkg.json
+++ b/immut/hashset/moon.pkg.json
@@ -4,7 +4,6 @@
     "moonbitlang/core/array",
     "moonbitlang/core/coverage",
     "moonbitlang/core/immut/internal/sparse_array",
-    "moonbitlang/core/test",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/tuple"
   ],

--- a/immut/list/moon.pkg.json
+++ b/immut/list/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
     "moonbitlang/core/array",
     "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck",

--- a/immut/priority_queue/moon.pkg.json
+++ b/immut/priority_queue/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/test",
     "moonbitlang/core/coverage",
     "moonbitlang/core/immut/list",
     "moonbitlang/core/quickcheck"

--- a/immut/sorted_map/moon.pkg.json
+++ b/immut/sorted_map/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
     "moonbitlang/core/tuple",
     "moonbitlang/core/string",
     "moonbitlang/core/array",

--- a/int64/moon.pkg.json
+++ b/int64/moon.pkg.json
@@ -1,7 +1,6 @@
 {
     "import": [
         "moonbitlang/core/builtin",
-        "moonbitlang/core/test",
         "moonbitlang/core/coverage",
         "moonbitlang/core/bytes",
         "moonbitlang/core/uint"

--- a/json/moon.pkg.json
+++ b/json/moon.pkg.json
@@ -3,8 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/double",
     "moonbitlang/core/string",
-    "moonbitlang/core/char",
-    "moonbitlang/core/test",
     "moonbitlang/core/coverage",
     "moonbitlang/core/strconv"
   ],

--- a/option/moon.pkg.json
+++ b/option/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix",
-    "moonbitlang/core/test",
     "moonbitlang/core/coverage",
     "moonbitlang/core/double"
   ],

--- a/queue/moon.pkg.json
+++ b/queue/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
     "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck"
   ],

--- a/random/moon.pkg.json
+++ b/random/moon.pkg.json
@@ -1,7 +1,6 @@
 {
     "import": [
       "moonbitlang/core/builtin",
-      "moonbitlang/core/array",
       "moonbitlang/core/double",
       "moonbitlang/core/coverage",
       "moonbitlang/core/random/internal/random_source"

--- a/rational/moon.pkg.json
+++ b/rational/moon.pkg.json
@@ -1,11 +1,9 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
     "moonbitlang/core/result",
     "moonbitlang/core/double",
     "moonbitlang/core/int64",
-    "moonbitlang/core/string",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/coverage"
   ]

--- a/ref/moon.pkg.json
+++ b/ref/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",    
-    "moonbitlang/core/int",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/coverage"
   ],

--- a/result/moon.pkg.json
+++ b/result/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
     "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck"
   ],

--- a/sorted_set/moon.pkg.json
+++ b/sorted_set/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/test",
     "moonbitlang/core/array",
     "moonbitlang/core/option",
     "moonbitlang/core/quickcheck",

--- a/strconv/moon.pkg.json
+++ b/strconv/moon.pkg.json
@@ -1,13 +1,11 @@
 {
   "import": [
-    "moonbitlang/core/test",
     "moonbitlang/core/builtin",
     "moonbitlang/core/coverage",
     "moonbitlang/core/double",
     "moonbitlang/core/tuple",
     "moonbitlang/core/char",
     "moonbitlang/core/string",
-    "moonbitlang/core/int64",
     "moonbitlang/core/uint64"
   ]
 }

--- a/string/moon.pkg.json
+++ b/string/moon.pkg.json
@@ -1,7 +1,6 @@
 {
     "import": [
         "moonbitlang/core/builtin",
-        "moonbitlang/core/test",
         "moonbitlang/core/coverage",
         "moonbitlang/core/bytes",
         "moonbitlang/core/char"


### PR DESCRIPTION
This is not complete though. For example, when the type `Char` is used, the package `moonbitlang/core/char` will be considered used. But it's not true when all the things we need about the type `Char` can be found in `moonbitlang/core/builtin`.