### PR TITLE
add Iter::map_option

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -224,6 +224,7 @@ impl Iter {
   just_run[T](Self[T], (T) -> IterResult) -> Unit
   last[A](Self[A]) -> A?
   map[T, R](Self[T], (T) -> R) -> Self[R]
+  map_option[A, B](Self[A], (A) -> B?) -> Self[B]
   map_while[A, B](Self[A], (A) -> B?) -> Self[B]
   new[T](((T) -> IterResult) -> IterResult) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -396,6 +396,21 @@ pub fn map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
   fn { yield => self.run(fn { a => yield(f(a)) }) }
 }
 
+/// Transforms the elements of the iterator using a mapping function that returns an `Option`.
+/// The elements for which the function returns `None` are filtered out.
+pub fn map_option[A, B](self : Iter[A], f : (A) -> B?) -> Iter[B] {
+  fn(yield) {
+    self.run(
+      fn(a) {
+        match f(a) {
+          Some(b) => yield(b)
+          None => IterContinue
+        }
+      },
+    )
+  }
+}
+
 /// Transforms each element of the iterator into an iterator and flattens the resulting iterators into a single iterator.
 ///
 /// # Type Parameters

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -215,6 +215,19 @@ test "map" {
   inspect!(exb, content="23456")
 }
 
+test "map_option" {
+  let arr = [1, 2, 3, 4, 5]
+  let r1 = arr
+    .iter()
+    .map_option(fn(x) { if x < 3 { None } else { Some(x) } })
+    .collect()
+  inspect!(r1, content="[3, 4, 5]")
+  let r2 : Array[Unit] = arr.iter().map_option(fn(_x) { None }).collect()
+  inspect!(r2, content="[]")
+  let r3 : Array[Unit] = [].iter().map_option(Option::Some).collect()
+  inspect!(r3, content="[]")
+}
+
 test "flat_map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = StringBuilder::new(size_hint=0)


### PR DESCRIPTION
Iter::map_option serves the same functionality as Array::map_option.