### PR TITLE
feat: add `filter_map()` to `@immut/list`

### DIFF
--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -499,6 +499,26 @@ pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
   }
 }
 
+/// Map over the list and keep all `value`s for which the mapped result is `Some(value)`.
+///
+/// # Example
+///
+/// ```
+/// let ls = of([4, 2, 2, 6, 3, 1])
+/// let r = ls.filter_map(fn(x) { if (x >= 3) { Some(x) } else { None } })
+/// println(r) // output: of([4, 6, 3])
+/// ```
+pub fn filter_map[A, B](self : T[A], f : (A) -> B?) -> T[B] {
+  loop Nil, self {
+    acc, Nil => acc.rev()
+    acc, Cons(x, xs) =>
+      match f(x) {
+        Some(v) => continue acc.add(v), xs
+        None => continue acc, xs
+      }
+  }
+}
+
 /// @alert unsafe "Panic if the index is out of bounds"
 pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
   loop self, n {

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -31,6 +31,7 @@ impl T {
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   equal[A : Eq](Self[A], Self[A]) -> Bool
   filter[A](Self[A], (A) -> Bool) -> Self[A]
+  filter_map[A, B](Self[A], (A) -> B?) -> Self[B]
   find[A](Self[A], (A) -> Bool) -> A?
   findi[A](Self[A], (A, Int) -> Bool) -> A?
   flat_map[A, B](Self[A], (A) -> Self[B]) -> Self[B]

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -205,6 +205,19 @@ test "flat_map" {
   )
 }
 
+test "filter_map" {
+  let ls = @list.of([4, 2, 2, 6, 3, 1])
+  let rs : @list.T[Int] = @list.Nil
+  inspect!(
+    ls.filter_map(fn(x) { if x >= 3 { Some(x) } else { None } }),
+    content="@list.of([4, 6, 3])",
+  )
+  inspect!(
+    rs.filter_map(fn(x) { if x >= 3 { Some(x) } else { None } }),
+    content="@list.of([])",
+  )
+}
+
 test "nth" {
   let ls = @list.of([1, 2, 3, 4, 5])
   inspect!(ls.nth(0), content="Some(1)")


### PR DESCRIPTION
Mirrors OCaml's [`List.filter_map`](https://www.ocaml.org/manual/5.2/api/List.html#VALfilter_map).

### Implementation

* [`immut/list/list.mbt`](diffhunk://#diff-1b6611b3a18e093ea1e9aed64259213abe10161afbb5a32e5a62cfbbdbd945d2R502-R521): Added the `filter_map` function, which maps over the list and keeps all values for which the mapped result is `Some(value)`.
* [`immut/list/list.mbti`](diffhunk://#diff-9cf1552c7c627c956818a0169def34402ea101ed06b61603dd11125486637c52R34): Declared the `filter_map` function in the list type implementation.

### Testing

* [`immut/list/list_test.mbt`](diffhunk://#diff-721bf2f9e4d9e52cab5b73c33c8a03e50af765acac1072730cc5c9ca2831c99fR208-R220): Added test cases for the `filter_map` function to validate its behavior with both non-empty and empty lists.