### PR TITLE
Remove coverage import altogether

### DIFF
--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -1,14 +1,12 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    
+
     "moonbitlang/core/test",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix"
   ],
-  "test-import": [
-    "moonbitlang/core/random"
-  ],
+  "test-import": ["moonbitlang/core/random"],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/bool/moon.pkg.json
+++ b/bool/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/buffer/moon.pkg.json
+++ b/buffer/moon.pkg.json
@@ -1,7 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
-    "moonbitlang/core/bytes"
-  ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/bytes"]
 }

--- a/builtin/moon.pkg.json
+++ b/builtin/moon.pkg.json
@@ -6,7 +6,6 @@
     "moonbitlang/core/bytes",
     "moonbitlang/core/int",
     "moonbitlang/core/double",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/uint64",
     "moonbitlang/core/array",
     "moonbitlang/core/int64",

--- a/byte/moon.pkg.json
+++ b/byte/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-    "import": [
-        "moonbitlang/core/builtin",
-        "moonbitlang/core/coverage"
-    ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/bytes/moon.pkg.json
+++ b/bytes/moon.pkg.json
@@ -1,9 +1,4 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
-  ],
-  "test-import": [
-    "moonbitlang/core/array"
-  ]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": ["moonbitlang/core/array"]
 }

--- a/char/moon.pkg.json
+++ b/char/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-    "import": [
-        "moonbitlang/core/builtin",
-        "moonbitlang/core/coverage"
-    ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/deque/moon.pkg.json
+++ b/deque/moon.pkg.json
@@ -1,8 +1,5 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
-  ],
+  "import": ["moonbitlang/core/builtin"],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/double/internal/ryu/moon.pkg.json
+++ b/double/internal/ryu/moon.pkg.json
@@ -1,7 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/bool",
-    "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/bool"]
 }

--- a/double/moon.pkg.json
+++ b/double/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/int64",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/double/internal/ryu"
   ],
   "targets": {

--- a/error/moon.pkg.json
+++ b/error/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/float/moon.pkg.json
+++ b/float/moon.pkg.json
@@ -1,9 +1,5 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
-    "moonbitlang/core/double"
-  ],
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/double"],
   "test-import": ["moonbitlang/core/quickcheck"],
   "targets": {
     "round_js.mbt": ["js"],

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -1,13 +1,10 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/test",
     "moonbitlang/core/array",
     "moonbitlang/core/tuple",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": [
-    "moonbitlang/core/string"
-  ]
+  "test-import": ["moonbitlang/core/string"]
 }

--- a/hashset/moon.pkg.json
+++ b/hashset/moon.pkg.json
@@ -3,11 +3,7 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/test",
     "moonbitlang/core/array",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": [
-    "moonbitlang/core/string",
-    "moonbitlang/core/int"
-  ]
+  "test-import": ["moonbitlang/core/string", "moonbitlang/core/int"]
 }

--- a/immut/array/moon.pkg.json
+++ b/immut/array/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck",
     {
       "path": "moonbitlang/core/array",

--- a/immut/hashmap/moon.pkg.json
+++ b/immut/hashmap/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/tuple",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/immut/internal/sparse_array"

--- a/immut/hashset/moon.pkg.json
+++ b/immut/hashset/moon.pkg.json
@@ -2,12 +2,8 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/immut/internal/sparse_array",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": [
-    "moonbitlang/core/string",
-    "moonbitlang/core/int"
-  ]
+  "test-import": ["moonbitlang/core/string", "moonbitlang/core/int"]
 }

--- a/immut/internal/sparse_array/moon.pkg.json
+++ b/immut/internal/sparse_array/moon.pkg.json
@@ -1,7 +1,3 @@
 {
-    "import": [
-      "moonbitlang/core/builtin",
-      "moonbitlang/core/array",
-      "moonbitlang/core/coverage"
-    ]
-  }
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/array"]
+}

--- a/immut/list/moon.pkg.json
+++ b/immut/list/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/json"
   ],

--- a/immut/priority_queue/moon.pkg.json
+++ b/immut/priority_queue/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/immut/list",
     "moonbitlang/core/quickcheck"
   ],

--- a/immut/sorted_map/moon.pkg.json
+++ b/immut/sorted_map/moon.pkg.json
@@ -4,7 +4,6 @@
     "moonbitlang/core/tuple",
     "moonbitlang/core/string",
     "moonbitlang/core/array",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/json"
   ],

--- a/immut/sorted_set/moon.pkg.json
+++ b/immut/sorted_set/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/json"
   ],
   "targets": {

--- a/int/moon.pkg.json
+++ b/int/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/int64/moon.pkg.json
+++ b/int64/moon.pkg.json
@@ -1,8 +1,3 @@
 {
-    "import": [
-        "moonbitlang/core/builtin",
-        "moonbitlang/core/coverage",
-        "moonbitlang/core/bytes",
-        "moonbitlang/core/uint"
-    ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/bytes", "moonbitlang/core/uint"]
 }

--- a/json/moon.pkg.json
+++ b/json/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/double",
     "moonbitlang/core/string",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/strconv"
   ],
   "test-import": [

--- a/math/moon.pkg.json
+++ b/math/moon.pkg.json
@@ -1,11 +1,5 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",    
-    "moonbitlang/core/double",    
-    "moonbitlang/core/coverage"
-  ],
-  "test-import": [
-    "moonbitlang/core/test"
-  ],
-  "test-import-all" : true
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/double"],
+  "test-import": ["moonbitlang/core/test"],
+  "test-import-all": true
 }

--- a/option/moon.pkg.json
+++ b/option/moon.pkg.json
@@ -2,8 +2,7 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/quickcheck/splitmix",
-    "moonbitlang/core/coverage"
+    "moonbitlang/core/quickcheck/splitmix"
   ],
   "targets": {
     "panic_test.mbt": ["not", "native"]

--- a/priority_queue/moon.pkg.json
+++ b/priority_queue/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck/splitmix"
   ],
   "targets": {

--- a/queue/moon.pkg.json
+++ b/queue/moon.pkg.json
@@ -1,12 +1,6 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
-    "moonbitlang/core/quickcheck"
-  ],
-  "test-import": [
-    "moonbitlang/core/array"
-  ],
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"],
+  "test-import": ["moonbitlang/core/array"],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/quickcheck/moon.pkg.json
+++ b/quickcheck/moon.pkg.json
@@ -1,7 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/quickcheck/splitmix",
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/quickcheck/splitmix", "moonbitlang/core/builtin"]
 }

--- a/quickcheck/splitmix/moon.pkg.json
+++ b/quickcheck/splitmix/moon.pkg.json
@@ -1,3 +1,3 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/coverage"]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/random/internal/random_source/moon.pkg.json
+++ b/random/internal/random_source/moon.pkg.json
@@ -1,7 +1,3 @@
 {
-    "import": [
-        "moonbitlang/core/builtin",
-        "moonbitlang/core/array",
-        "moonbitlang/core/coverage"
-    ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/array"]
 }

--- a/random/moon.pkg.json
+++ b/random/moon.pkg.json
@@ -1,11 +1,8 @@
 {
-    "import": [
-      "moonbitlang/core/builtin",
-      "moonbitlang/core/double",
-      "moonbitlang/core/coverage",
-      "moonbitlang/core/random/internal/random_source"
-    ],
-    "test-import": [
-      "moonbitlang/core/float"
-    ]
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/double",
+    "moonbitlang/core/random/internal/random_source"
+  ],
+  "test-import": ["moonbitlang/core/float"]
 }

--- a/rational/moon.pkg.json
+++ b/rational/moon.pkg.json
@@ -4,7 +4,6 @@
     "moonbitlang/core/result",
     "moonbitlang/core/double",
     "moonbitlang/core/int64",
-    "moonbitlang/core/quickcheck",
-    "moonbitlang/core/coverage"
+    "moonbitlang/core/quickcheck"
   ]
 }

--- a/ref/moon.pkg.json
+++ b/ref/moon.pkg.json
@@ -1,7 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",    
-    "moonbitlang/core/quickcheck",
-    "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"]
 }

--- a/result/moon.pkg.json
+++ b/result/moon.pkg.json
@@ -1,9 +1,5 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
-    "moonbitlang/core/quickcheck"
-  ],
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/sorted_map/moon.pkg.json
+++ b/sorted_map/moon.pkg.json
@@ -1,12 +1,9 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/option",
     "moonbitlang/core/tuple",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": [
-    "moonbitlang/core/array"
-  ]
+  "test-import": ["moonbitlang/core/array"]
 }

--- a/sorted_set/moon.pkg.json
+++ b/sorted_set/moon.pkg.json
@@ -1,11 +1,4 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/option",
-    "moonbitlang/core/quickcheck",
-    "moonbitlang/core/coverage"
-  ],
-  "test-import":[
-    "moonbitlang/core/array"
-  ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/option", "moonbitlang/core/quickcheck"],
+  "test-import": ["moonbitlang/core/array"]
 }

--- a/strconv/moon.pkg.json
+++ b/strconv/moon.pkg.json
@@ -1,7 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/double",
-    "moonbitlang/core/uint64"
-  ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/double", "moonbitlang/core/uint64"]
 }

--- a/string/moon.pkg.json
+++ b/string/moon.pkg.json
@@ -1,14 +1,7 @@
 {
-    "import": [
-        "moonbitlang/core/builtin",
-        "moonbitlang/core/coverage"
-    ],
-    "test-import": [
-      "moonbitlang/core/immut/list",
-      "moonbitlang/core/json"
-    ],
-    "targets": {
-      "panic_test.mbt": ["not", "native"]
-    }
-
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": ["moonbitlang/core/immut/list", "moonbitlang/core/json"],
+  "targets": {
+    "panic_test.mbt": ["not", "native"]
+  }
 }

--- a/test/moon.pkg.json
+++ b/test/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-  "import": [
-      "moonbitlang/core/builtin",
-      "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/tuple/moon.pkg.json
+++ b/tuple/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix"
   ]

--- a/uint/moon.pkg.json
+++ b/uint/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-    "import": [
-        "moonbitlang/core/builtin",
-        "moonbitlang/core/coverage"
-    ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/uint64/moon.pkg.json
+++ b/uint64/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-    "import": [
-        "moonbitlang/core/builtin",
-        "moonbitlang/core/coverage"
-    ]
+  "import": ["moonbitlang/core/builtin"]
 }

--- a/unit/moon.pkg.json
+++ b/unit/moon.pkg.json
@@ -1,6 +1,3 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/coverage"
-  ]
+  "import": ["moonbitlang/core/builtin"]
 }


### PR DESCRIPTION
Remove import of `coverage` from all modules.

Should be added after https://github.com/moonbitlang/moon/pull/415 is merged, so coverage imports are added automatically.
