### PR TITLE
feat: add `@cmp.(max|min)imum_by_key`

### DIFF
--- a/cmp/cmp.mbt
+++ b/cmp/cmp.mbt
@@ -1,0 +1,49 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///| Returns the element that gives the maximum value from the specified function.
+///
+/// Returns the second argument if the comparison determines them to be equal.
+///
+/// # Examples
+///
+/// ```
+/// inspect!(@cmp.maximum_by_key(-2, 1, @int.abs), content="-2")
+/// inspect!(@cmp.maximum_by_key(-2, 2, @int.abs), content="2")
+/// ```
+pub fn maximum_by_key[T, K : Compare](x : T, y : T, f : (T) -> K) -> T {
+  if f(x) > f(y) {
+    x
+  } else {
+    y
+  }
+}
+
+///| Returns the element that gives the minimum value from the specified function.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+///
+/// # Examples
+///
+/// ```
+/// inspect!(@cmp.minimum_by_key(-2, 1, @int.abs), content="1")
+/// inspect!(@cmp.minimum_by_key(-2, 2, @int.abs), content="-2")
+/// ```
+pub fn minimum_by_key[T, K : Compare](x : T, y : T, f : (T) -> K) -> T {
+  if f(x) > f(y) {
+    y
+  } else {
+    x
+  }
+}

--- a/cmp/cmp.mbti
+++ b/cmp/cmp.mbti
@@ -1,0 +1,13 @@
+package moonbitlang/core/cmp
+
+// Values
+fn maximum_by_key[T, K : Compare](T, T, (T) -> K) -> T
+
+fn minimum_by_key[T, K : Compare](T, T, (T) -> K) -> T
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/cmp/cmp_test.mbt
+++ b/cmp/cmp_test.mbt
@@ -1,0 +1,27 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "maximum_by_key" {
+  assert_eq!(@cmp.maximum_by_key(1, -2, @int.abs), -2)
+  assert_eq!(@cmp.maximum_by_key(-2, 1, @int.abs), -2)
+  assert_eq!(@cmp.maximum_by_key(-2, 2, @int.abs), 2)
+}
+
+///|
+test "minimum_by_key" {
+  assert_eq!(@cmp.minimum_by_key(1, -2, @int.abs), 1)
+  assert_eq!(@cmp.minimum_by_key(-2, 1, @int.abs), 1)
+  assert_eq!(@cmp.minimum_by_key(-2, 2, @int.abs), -2)
+}

--- a/cmp/moon.pkg.json
+++ b/cmp/moon.pkg.json
@@ -1,0 +1,8 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ],
+  "test-import": [
+    "moonbitlang/core/int"
+  ]
+}


### PR DESCRIPTION
Mirrors Rust's [max_by_key](https://doc.rust-lang.org/std/cmp/fn.max_by_key.html#) and [min_by_key](https://doc.rust-lang.org/std/cmp/fn.min_by_key.html#) functions.