### PR TITLE
fix: array.split_at shouldn't fail when index = length

### DIFF
--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -245,6 +245,12 @@ test "split_at" {
   let (v1, v2) = v.split_at(1)
   assert_eq!(v1, [3])
   assert_eq!(v2, [4, 5])
+  let (v1, v2) = v.split_at(0)
+  assert_eq!(v1, [])
+  assert_eq!(v2, [3, 4, 5])
+  let (v1, v2) = v.split_at(3)
+  assert_eq!(v1, [3, 4, 5])
+  assert_eq!(v2, [])
 }
 
 test "contains" {

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -369,7 +369,7 @@ pub fn rev[T](self : Array[T]) -> Array[T] {
 /// TODO: perf could be optimized
 /// @alert unsafe "Panic if index is out of bounds."
 pub fn split_at[T](self : Array[T], index : Int) -> (Array[T], Array[T]) {
-  if index < 0 || index >= self.length() {
+  if index < 0 || index > self.length() {
     let len = self.length()
     abort(
       "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
@@ -378,13 +378,15 @@ pub fn split_at[T](self : Array[T], index : Int) -> (Array[T], Array[T]) {
   let v1 = Array::make_uninit(index)
   let v2 = Array::make_uninit(self.length() - index)
   UninitializedArray::unsafe_blit(v1.buffer(), 0, self.buffer(), 0, index)
-  UninitializedArray::unsafe_blit(
-    v2.buffer(),
-    0,
-    self.buffer(),
-    index,
-    self.length() - index,
-  )
+  if index != self.length() {
+    UninitializedArray::unsafe_blit(
+      v2.buffer(),
+      0,
+      self.buffer(),
+      index,
+      self.length() - index,
+    )
+  }
   (v1, v2)
 }
 


### PR DESCRIPTION
As title

There's a check around the second `UninitializedArray::unsafe_blit` because when index equals length, `src + src_offset` is an illegal address (although it works too without check).