### PR TITLE
fix some unused/never supplied optional argument

### DIFF
--- a/array/fixedarray_sort.mbt
+++ b/array/fixedarray_sort.mbt
@@ -293,10 +293,8 @@ fn fixed_get_limit(len : Int) -> Int {
 /// It will only tolerate at most 8 unsorted elements. The time complexity is O(n).
 /// 
 /// Returns whether the array is sorted.
-fn fixed_try_bubble_sort[T : Compare](
-  arr : FixedArraySlice[T],
-  ~max_tries : Int = 8
-) -> Bool {
+fn fixed_try_bubble_sort[T : Compare](arr : FixedArraySlice[T]) -> Bool {
+  let max_tries = 8
   let mut tries = 0
   for i = 1; i < arr.length(); i = i + 1 {
     let mut sorted = true

--- a/array/fixedarray_sort_by.mbt
+++ b/array/fixedarray_sort_by.mbt
@@ -175,9 +175,9 @@ fn fixed_quick_sort_by[T](
 /// Returns whether the array is sorted.
 fn fixed_try_bubble_sort_by[T](
   arr : FixedArraySlice[T],
-  cmp : (T, T) -> Int,
-  ~max_tries : Int = 8
+  cmp : (T, T) -> Int
 ) -> Bool {
+  let max_tries = 8
   let mut tries = 0
   for i = 1; i < arr.length(); i = i + 1 {
     let mut sorted = true

--- a/array/sort.mbt
+++ b/array/sort.mbt
@@ -105,10 +105,8 @@ fn get_limit(len : Int) -> Int {
 /// It will only tolerate at most 8 unsorted elements. The time complexity is O(n).
 /// 
 /// Returns whether the array is sorted.
-fn try_bubble_sort[T : Compare](
-  arr : ArrayView[T],
-  ~max_tries : Int = 8
-) -> Bool {
+fn try_bubble_sort[T : Compare](arr : ArrayView[T]) -> Bool {
+  let max_tries = 8
   let mut tries = 0
   for i = 1; i < arr.length(); i = i + 1 {
     let mut sorted = true

--- a/array/sort_by.mbt
+++ b/array/sort_by.mbt
@@ -119,11 +119,8 @@ fn quick_sort_by[T](
 /// It will only tolerate at most 8 unsorted elements. The time complexity is O(n).
 /// 
 /// Returns whether the array is sorted.
-fn try_bubble_sort_by[T](
-  arr : ArrayView[T],
-  cmp : (T, T) -> Int,
-  ~max_tries : Int = 8
-) -> Bool {
+fn try_bubble_sort_by[T](arr : ArrayView[T], cmp : (T, T) -> Int) -> Bool {
+  let max_tries = 8
   let mut tries = 0
   for i = 1; i < arr.length(); i = i + 1 {
     let mut sorted = true

--- a/rational/rational_test.mbt
+++ b/rational/rational_test.mbt
@@ -89,18 +89,10 @@ test "from_double NaN check" {
 }
 
 // currently it requires the `content` argument to be passed int the second position
-fn inspect_double_array(
-  a : Array[Double],
-  ~content : String = "",
-  ~loc : SourceLoc = _,
-  ~args_loc : ArgsLoc = _
-) -> Unit! {
-  inspect!(
-    a.map(fn { x => @rational.from_double?(x) }),
-    ~content,
-    ~loc,
-    ~args_loc,
-  )
+fn from_double_array(
+  a : Array[Double]
+) -> Array[Result[@rational.T, @rational.RationalError]] {
+  a.map(fn { x => @rational.from_double?(x) })
 }
 
 test "from_double array" {
@@ -114,17 +106,18 @@ test "from_double array" {
   let a = [
     -10.0e200, 10.0e200, @double.infinity, @double.neg_infinity, @double.not_a_number,
   ]
-  a
-  |> inspect_double_array!(
+  from_double_array(a)
+  |> inspect!(
     content=
       #|[Err("Rational::from_double: overflow"), Err("Rational::from_double: overflow"), Err("Rational::from_double: overflow"), Err("Rational::from_double: overflow"), Err("Rational::from_double: cannot convert NaN")]
     ,
   )
-  inspect_double_array!(
+  inspect!(
     [
       2.2204460492503131e-16, 0.0, -0.0, 9_223_372_036_800_000_000.0, 9_223_372_036_854_775_807.1,
       9_223_372_036_854_775_807.0,
-    ],
+    ]
+    |> from_double_array,
     content=
       #|[Ok(1/4503599627370496), Ok(0), Ok(0), Ok(9223372036800000000), Err("Rational::from_double: overflow"), Err("Rational::from_double: overflow")]
     ,

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -67,8 +67,8 @@ fn new_node[V](
 
 fn new_node_update_height[V](
   value : V,
-  ~left : Node[V]? = None,
-  ~right : Node[V]? = None
+  ~left : Node[V]?,
+  ~right : Node[V]?
 ) -> Node[V] {
   { value, left, right, height: max(height(left), height(right)) + 1 }
 }


### PR DESCRIPTION
The bleeding compiler recently adds feature for detecting optional arguments that are never/always supplied. Several warnings are reported on core, this PR fixes the unused optional argument issues.

One notable case is a `inspect_double_array` function in `rational/rational_test.mbt`. This function is a wrapper over `inspect`, and has an optional argument `~content : String = ""` just like inspect. The problem is, this optional argument will be automatically filled by `moon test -u`, so its default value will only be used when the test is initially added. After the test result is promoted, the default value become unused.

This PR removes the `inspect_double_array` wrapper to fix the warning. `inspect` itself is public so no warning will be reported on it.