### PR TITLE
factor out UninitializedArray, avoid code duplication in three places

### DIFF
--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -12,24 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-priv type UninitializedArray[T] FixedArray[UnsafeMaybeUninit[T]]
-
-fn UninitializedArray::make[T](size : Int) -> UninitializedArray[T] = "%fixedarray.make_uninit"
-
-fn op_get[T](self : UninitializedArray[T], index : Int) -> T = "%fixedarray.get"
-
-fn op_set[T](self : UninitializedArray[T], index : Int, value : T) = "%fixedarray.set"
-
-fn UninitializedArray::unsafe_blit[T](
-  dst : UninitializedArray[T],
-  dst_offset : Int,
-  src : UninitializedArray[T],
-  src_offset : Int,
-  len : Int
-) -> Unit {
-  FixedArray::unsafe_blit(dst._, dst_offset, src._, src_offset, len)
-}
-
 /// @intrinsic %fixedarray.copy
 fn UninitializedArray::unsafe_blit_fixed[T](
   dst : UninitializedArray[T],

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -12,25 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-priv type UninitializedArray[T] FixedArray[UnsafeMaybeUninit[T]]
-
-fn UninitializedArray::make[T](size : Int) -> UninitializedArray[T] = "%fixedarray.make_uninit"
-
-fn op_get[T](self : UninitializedArray[T], index : Int) -> T = "%fixedarray.get"
-
-fn op_set[T](self : UninitializedArray[T], index : Int, value : T) = "%fixedarray.set"
-
 fn set_null[T](self : UninitializedArray[T], index : Int) = "%fixedarray.set_null"
-
-fn UninitializedArray::unsafe_blit[T](
-  dst : UninitializedArray[T],
-  dst_offset : Int,
-  src : UninitializedArray[T],
-  src_offset : Int,
-  len : Int
-) -> Unit {
-  FixedArray::unsafe_blit(dst._, dst_offset, src._, src_offset, len)
-}
 
 /// @intrinsic %fixedarray.copy
 fn UninitializedArray::unsafe_blit_fixed[T](

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -358,7 +358,13 @@ impl StringBuilder {
   write_substring(Self, String, Int, Int) -> Unit
 }
 
-pub type UnsafeMaybeUninit
+type UninitializedArray
+impl UninitializedArray {
+  length[A](Self[A]) -> Int
+  make[T](Int) -> Self[T]
+  op_get[T](Self[T], Int) -> T
+  op_set[T](Self[T], Int, T) -> Unit
+}
 impl Unit {
   op_equal(Unit, Unit) -> Bool
   to_json(Unit) -> Json

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -206,7 +206,7 @@ pub fn String::to_string(self : String) -> String = "%string_to_string"
 pub fn String::to_js_string(self : String) -> Js_string = "%string_to_jsstring"
 
 // For internal use only
-pub type UnsafeMaybeUninit[_]
+priv type UnsafeMaybeUninit[_]
 
 // Byte primitive
 pub fn Byte::to_int(self : Byte) -> Int = "%byte_to_int"

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -1,0 +1,64 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+type UninitializedArray[T] FixedArray[UnsafeMaybeUninit[T]]
+
+/// Creates an uninitialized array of the specified size.
+///
+/// Parameters:
+///
+/// - `size` : The number of elements the array should hold.
+///
+/// Returns an uninitialized array of type `T` with the specified size.
+pub fn UninitializedArray::make[T](size : Int) -> UninitializedArray[T] = "%fixedarray.make_uninit"
+
+/// Retrieves the element at the specified index from an uninitialized array.
+///
+/// Parameters:
+///
+/// - `array` : The uninitialized array from which to retrieve the element.
+/// - `index` : The index of the element to retrieve.
+///
+/// Returns the element at the specified index.
+pub fn op_get[T](self : UninitializedArray[T], index : Int) -> T = "%fixedarray.get"
+
+/// Sets the value at the specified index in an uninitialized array.
+///
+/// Parameters:
+///
+/// - `array` : The uninitialized array where the value will be set.
+/// - `index` : The position in the array where the value will be set.
+/// - `value` : The value to be set at the specified index.
+pub fn op_set[T](self : UninitializedArray[T], index : Int, value : T) = "%fixedarray.set"
+
+/// Returns the length of an uninitialized array.
+///
+/// Parameters:
+///
+/// - `array` : The uninitialized array whose length is to be determined.
+///
+/// Returns the length of the uninitialized array as an integer.
+pub fn length[A](self : UninitializedArray[A]) -> Int {
+  self._.length()
+}
+
+fn UninitializedArray::unsafe_blit[T](
+  dst : UninitializedArray[T],
+  dst_offset : Int,
+  src : UninitializedArray[T],
+  src_offset : Int,
+  len : Int
+) -> Unit {
+  FixedArray::unsafe_blit(dst._, dst_offset, src._, src_offset, len)
+}

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -12,16 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn UninitializedArray::make[A](size : Int) -> UninitializedArray[A] = "%fixedarray.make_uninit"
-
-fn op_get[A](self : UninitializedArray[A], index : Int) -> A = "%fixedarray.get"
-
-fn op_set[A](self : UninitializedArray[A], index : Int, value : A) = "%fixedarray.set"
-
-fn length[A](self : UninitializedArray[A]) -> Int {
-  self._.length()
-}
-
 /// Creates a new, empty deque.
 pub fn T::new[A](~capacity : Int = 0) -> T[A] {
   T::{ buf: UninitializedArray::make(capacity), len: 0, head: 0, tail: 0 }
@@ -475,7 +465,7 @@ pub fn reserve_capacity[A](self : T[A], capacity : Int) -> Unit {
   self.head = 0
   self.tail = 0
   for i = 0; i < len; i = i + 1 {
-    let idx = (head + i) % buf._.length()
+    let idx = (head + i) % buf.length()
     self.buf[i] = buf[idx]
     self.tail += 1
   }
@@ -503,7 +493,7 @@ pub fn shrink_to_fit[A](self : T[A]) -> Unit {
   self.head = 0
   self.tail = 0
   for i = 0; i < len; i = i + 1 {
-    let idx = (head + i) % buf._.length()
+    let idx = (head + i) % buf.length()
     self.buf[i] = buf[idx]
   }
 }

--- a/deque/types.mbt
+++ b/deque/types.mbt
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-priv type UninitializedArray[A] FixedArray[UnsafeMaybeUninit[A]]
-
 // head and tail point to non-empty slots. When the buffer is empty, head and tail points to the same slot.
 struct T[A] {
   mut buf : UninitializedArray[A]


### PR DESCRIPTION
This pull request includes significant changes to the handling of uninitialized arrays in various files. The primary update involves the consolidation and redefinition of the `UninitializedArray` type and its associated functions.

### Consolidation and Redefinition of `UninitializedArray`:

* [`builtin/uninitialized_array.mbt`](diffhunk://#diff-e53e092c10c27e9466d1027ae9efd6a7333529a3cb4b90ab6180bea0d97ad416R1-R64): Introduced a new file that defines the `UninitializedArray` type and its associated functions, including `make`, `op_get`, `op_set`, `length`, and `unsafe_blit`.

### Removal of Redundant Definitions:

* [`builtin/arraycore_js.mbt`](diffhunk://#diff-2531d56d432314b54a5a0a6b7e0552381bdde29b2ebcbb117f28c2fc12400c9aL15-L32): Removed the previous definitions of `UninitializedArray` and its associated functions.
* [`builtin/arraycore_nonjs.mbt`](diffhunk://#diff-b5f7899b1eaf5a490bd91de87fc678ba6502a2875c4ac292a82b5b22bc59e2b8L15-L34): Removed the previous definitions of `UninitializedArray` and its associated functions.
* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL15-L24): Removed the redundant definitions of `UninitializedArray` and its associated functions.

### Code Adjustments:

* [`builtin/builtin.mbti`](diffhunk://#diff-979a8cf0c39b3e1340630ddd48d1ed130df1eb2f6f8d94b9eb1b8613a9415875L361-R367): Updated to define `UninitializedArray` and implement its functions.
* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL478-R468): Modified to use the new `length` function of `UninitializedArray` in `reserve_capacity` and `shrink_to_fit` methods. [[1]](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL478-R468) [[2]](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL506-R496)

### Code Cleanup:

* [`builtin/intrinsics.mbt`](diffhunk://#diff-432bf1c16a65332f183bdf4445e5c053673d0faf9e6523bd4928668be5eb98caL209-R209): Changed the visibility of `UnsafeMaybeUninit` to private.
* [`deque/types.mbt`](diffhunk://#diff-8b41a42d0d14b1e259de8e3c2ef811372260663239cdff1917719f7094930a72L15-L16): Removed the redundant type definition of `UninitializedArray`.