### PR TITLE
minor: remove trailing comma in pkg.json

### DIFF
--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -8,6 +8,6 @@
     "moonbitlang/core/quickcheck"
   ],
   "test-import": [
-    "moonbitlang/core/string",
+    "moonbitlang/core/string"
   ]
 }

--- a/immut/hashset/moon.pkg.json
+++ b/immut/hashset/moon.pkg.json
@@ -8,6 +8,6 @@
   ],
   "test-import": [
     "moonbitlang/core/string",
-    "moonbitlang/core/int",
+    "moonbitlang/core/int"
   ]
 }


### PR DESCRIPTION
trailing comma is not support in standrad json, which cause publish failed