### PR TITLE
add [Show] implementation for [ArgsLoc]

### DIFF
--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -20,11 +20,7 @@ pub impl Show for SourceLoc with output(self, logger) {
   logger.write_string(self.to_string())
 }
 
-pub type ArgsLoc Array[SourceLoc?]
-
-pub fn ArgsLoc::to_string(self : ArgsLoc) -> String {
-  self._.to_string()
-}
+pub type ArgsLoc Array[SourceLoc?] derive(Show)
 
 pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
   let buf = StringBuilder::new(size_hint=10)

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -809,6 +809,8 @@ impl Show for Ref
 
 impl Show::to_string
 
+impl Show for ArgsLoc
+
 impl Show for Array
 
 impl Show for ArrayView


### PR DESCRIPTION
`ArgsLoc` only had a `to_string` method and did not implement `Show`