### PR TITLE
fix: Json::op_equal returns false when the keys of 2 maps have different order

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -302,7 +302,7 @@ impl Map {
   keys[K, V](Self[K, V]) -> Iter[K]
   new[K, V](~capacity : Int = ..) -> Self[K, V]
   of[K : Hash + Eq, V](FixedArray[(K, V)]) -> Self[K, V]
-  op_equal[K : Eq, V : Eq](Self[K, V], Self[K, V]) -> Bool
+  op_equal[K : Hash + Eq, V : Eq](Self[K, V], Self[K, V]) -> Bool
   op_get[K : Hash + Eq, V](Self[K, V], K) -> V?
   op_set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   remove[K : Hash + Eq, V](Self[K, V], K) -> Unit

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -479,20 +479,20 @@ pub fn to_array[K, V](self : Map[K, V]) -> Array[(K, V)] {
   arr
 }
 
-pub fn op_equal[K : Eq, V : Eq](self : Map[K, V], that : Map[K, V]) -> Bool {
+pub fn op_equal[K : Hash + Eq, V : Eq](
+  self : Map[K, V],
+  that : Map[K, V]
+) -> Bool {
   if self.size != that.size {
     return false
   }
-  loop self.head, that.head {
-    None, None => true
-    Some({ key: k1, value: v1, idx: i1, .. }),
-    Some({ key: k2, value: v2, idx: i2, .. }) => {
-      if k1 != k2 || v1 != v2 {
-        return false
-      }
-      continue self.list[i1].next, that.list[i2].next
+  for k, v in self {
+    match that.get(k) {
+      None => break false
+      Some(v_) => if v_ != v { break false }
     }
-    _, _ => false
+  } else {
+    true
   }
 }
 

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -632,7 +632,7 @@ test "to_array" {
   assert_eq!(m.to_array(), [("a", 1), ("b", 2), ("c", 3)])
 }
 
-test "op_equal" {
+test "op_equal_1" {
   let m1 : Map[String, Int] = Map::new()
   m1.set("a", 1)
   m1.set("b", 2)
@@ -641,6 +641,14 @@ test "op_equal" {
   inspect!(m1 == m2, content="true")
   inspect!({ "a": 1 } == {}, content="false")
   inspect!({ 1: 2, 2: 3 } == { 1: 3, 2: 4 }, content="false")
+}
+
+test "op_equal_2" {
+  let map1 = { "a": 1, "b": 2 }
+  let map2 = { "b": 2, "a": 1 }
+  let map3 = { "a": 1, "b": 2 }
+  inspect!(map1 == map2, content="true")
+  inspect!(map1 == map3, content="true")
 }
 
 test "to_string" {


### PR DESCRIPTION
- #1188