### PR TITLE
add `priv` mark to private traits

### DIFF
--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -64,7 +64,7 @@ pub fn track(name : String, counter : CoverageCounter) -> Unit {
   counters.val = MCons((name, counter), counters.val)
 }
 
-trait Output {
+priv trait Output {
   output(Self, String) -> Unit
 }
 


### PR DESCRIPTION
Yesterday's compiler release introduces abstract visibility to traits, allowing traits to be sealed. The default visibility of traits now changes from private to abstract, just like types. So private traits should be marked as `priv` explicitly to adapt to this semantic change. This PR fixes this for core.