### PR TITLE
refactor: simplify loop syntax in rev_eachi and rev_inplace functions

### DIFF
--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -171,7 +171,7 @@ test "rev_each" {
 /// ```
 pub fn rev_eachi[T](self : FixedArray[T], f : (Int, T) -> Unit) -> Unit {
   let len = self.length()
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     f(i, self[len - i - 1])
   }
 }

--- a/array/slice.mbt
+++ b/array/slice.mbt
@@ -41,9 +41,10 @@ fn swap[T](self : FixedArraySlice[T], a : Int, b : Int) -> Unit {
 
 ///|
 fn rev_inplace[T](self : FixedArraySlice[T]) -> Unit {
-  let mid_len = self.length() / 2
-  for i = 0; i < mid_len; i = i + 1 {
-    let j = self.length() - i - 1
+  let len = self.length()
+  let mid_len = len / 2
+  for i in 0..<mid_len {
+    let j = len - i - 1
     self.swap(i, j)
   }
 }


### PR DESCRIPTION
This pull request includes improvements to the iteration logic in the `FixedArray` and `FixedArraySlice` classes. The most important changes involve updating the loop syntax for better readability and performance.

Improvements to iteration logic:

* [`array/fixedarray.mbt`](diffhunk://#diff-2284abe8d2ad886166df021851de56aa4239a390fcc582304cf2a08426f6ae2dL174-R174): Modified the `rev_eachi` method to use the `0..<len` loop syntax instead of `i = 0; i < len; i = i + 1`.
* [`array/slice.mbt`](diffhunk://#diff-f88e9e9c6253e182f3528354996c8d1c94fe3bfe113d746fa29dd2b16d80278cL44-R47): Updated the `rev_inplace` method to use the `0..<mid_len` loop syntax and refactored the calculation of `mid_len` and `j` for better readability.