### PR TITLE
rename `insert` in x_map and x_set to `add`

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -319,6 +319,7 @@ impl[K : Show, V : Show] Show for Map[K, V]
 
 type Set
 impl Set {
+  add[K : Hash + Eq](Self[K], K) -> Unit
   capacity[K](Self[K]) -> Int
   clear[K](Self[K]) -> Unit
   contains[K : Hash + Eq](Self[K], K) -> Bool
@@ -327,7 +328,7 @@ impl Set {
   eachi[K](Self[K], (Int, K) -> Unit) -> Unit
   from_array[K : Hash + Eq](Array[K]) -> Self[K]
   from_iter[K : Hash + Eq](Iter[K]) -> Self[K]
-  insert[K : Hash + Eq](Self[K], K) -> Unit
+  insert[K : Hash + Eq](Self[K], K) -> Unit //deprecated
   intersection[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   is_empty[K](Self[K]) -> Bool
   iter[K](Self[K]) -> Iter[K]

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -70,7 +70,7 @@ pub fn Set::new[K](~capacity : Int = 8) -> Set[K] {
 /// Create a hash set from array.
 pub fn Set::from_array[K : Hash + Eq](arr : Array[K]) -> Set[K] {
   let m = Set::new(capacity=arr.length())
-  arr.each(fn(e) { m.insert(e) })
+  arr.each(fn(e) { m.add(e) })
   m
 }
 
@@ -248,7 +248,7 @@ fn grow[K : Hash + Eq](self : Set[K]) -> Unit {
   self.tail = None
   loop old_head {
     Some({ idx, key, .. }) => {
-      self.insert(key)
+      self.add(key)
       continue old_list[idx].next
     }
     None => break
@@ -399,7 +399,7 @@ pub fn Set::of[K : Hash + Eq](arr : FixedArray[K]) -> Set[K] {
   // arr.iter(fn(e) { m.set(e.0, e.1) })
   for i = 0; i < length; i = i + 1 {
     let e = arr[i]
-    m.insert(e)
+    m.add(e)
   }
   m
 }
@@ -407,14 +407,14 @@ pub fn Set::of[K : Hash + Eq](arr : FixedArray[K]) -> Set[K] {
 ///|
 pub fn Set::from_iter[K : Hash + Eq](iter : Iter[K]) -> Set[K] {
   let m = Set::new()
-  iter.each(fn(e) { m.insert(e) })
+  iter.each(fn(e) { m.add(e) })
   m
 }
 
 ///|
 pub fn difference[K : Hash + Eq](self : Set[K], other : Set[K]) -> Set[K] {
   let m = Set::new()
-  self.each(fn(k) { if not(other.contains(k)) { m.insert(k) } })
+  self.each(fn(k) { if not(other.contains(k)) { m.add(k) } })
   m
 }
 
@@ -424,22 +424,22 @@ pub fn symmetric_difference[K : Hash + Eq](
   other : Set[K]
 ) -> Set[K] {
   let m = Set::new()
-  self.each(fn(k) { if not(other.contains(k)) { m.insert(k) } })
-  other.each(fn(k) { if not(self.contains(k)) { m.insert(k) } })
+  self.each(fn(k) { if not(other.contains(k)) { m.add(k) } })
+  other.each(fn(k) { if not(self.contains(k)) { m.add(k) } })
   m
 }
 
 ///|
 pub fn union[K : Hash + Eq](self : Set[K], other : Set[K]) -> Set[K] {
   let m = Set::new()
-  self.each(fn(k) { m.insert(k) })
-  other.each(fn(k) { m.insert(k) })
+  self.each(fn(k) { m.add(k) })
+  other.each(fn(k) { m.add(k) })
   m
 }
 
 ///|
 pub fn intersection[K : Hash + Eq](self : Set[K], other : Set[K]) -> Set[K] {
   let m = Set::new()
-  self.each(fn(k) { if other.contains(k) { m.insert(k) } })
+  self.each(fn(k) { if other.contains(k) { m.add(k) } })
   m
 }

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -76,7 +76,15 @@ pub fn Set::from_array[K : Hash + Eq](arr : Array[K]) -> Set[K] {
 
 ///|
 /// Insert a key into the hash set.
+/// 
+/// @alert deprecated "Use `add` instead."
 pub fn insert[K : Hash + Eq](self : Set[K], key : K) -> Unit {
+  self.add(key)
+}
+
+///|
+/// Insert a key into the hash set.
+pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
   if self.size >= self.growAt {
     self.grow()
   }

--- a/builtin/linked_hash_set_test.mbt
+++ b/builtin/linked_hash_set_test.mbt
@@ -23,9 +23,9 @@ test "new" {
 
 test "insert" {
   let m = Set::new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("c")
+  m.add("a")
+  m.add("b")
+  m.add("c")
   assert_true!(m.contains("a"))
   assert_true!(m.contains("b"))
   assert_true!(m.contains("c"))
@@ -43,14 +43,14 @@ test "from_array" {
 test "size" {
   let m = Set::new()
   assert_eq!(m.size(), 0)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.size(), 1)
 }
 
 test "is_empty" {
   let m = Set::new()
   assert_eq!(m.is_empty(), true)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.is_empty(), false)
   m.remove("a")
   assert_eq!(m.is_empty(), true)
@@ -143,7 +143,7 @@ test "from_array" {
 test "insert_and_grow" {
   let m = Set::new()
   for i = 0; i < 10; i = i + 1 {
-    m.insert(i.to_string())
+    m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)
   assert_eq!(m.capacity(), 16)
@@ -160,10 +160,10 @@ test "array unique via Set" {
 
 test "remove_and_shift_back" {
   let m = Set::new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("c")
-  m.insert("d")
+  m.add("a")
+  m.add("b")
+  m.add("c")
+  m.add("d")
   m.remove("b")
   assert_false!(m.contains("b"))
   assert_true!(m.contains("a"))
@@ -175,17 +175,17 @@ test "capacity_and_size" {
   let m = Set::new()
   assert_eq!(m.capacity(), default_init_capacity)
   assert_eq!(m.size(), 0)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.size(), 1)
 }
 
 test "clear_and_reinsert" {
   let m = Set::new()
-  m.insert("a")
-  m.insert("b")
+  m.add("a")
+  m.add("b")
   m.clear()
   assert_eq!(m.size(), 0)
-  m.insert("c")
+  m.add("c")
   assert_eq!(m.size(), 1)
   assert_true!(m.contains("c"))
 }
@@ -193,7 +193,7 @@ test "clear_and_reinsert" {
 test "insert_and_grow" {
   let m = Set::new()
   for i = 0; i < 10; i = i + 1 {
-    m.insert(i.to_string())
+    m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)
   assert_eq!(m.capacity(), 16)
@@ -201,10 +201,10 @@ test "insert_and_grow" {
 
 test "remove_and_shift_back" {
   let m = Set::new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("c")
-  m.insert("d")
+  m.add("a")
+  m.add("b")
+  m.add("c")
+  m.add("d")
   m.remove("b")
   assert_false!(m.contains("b"))
   assert_true!(m.contains("a"))
@@ -216,17 +216,17 @@ test "capacity_and_size" {
   let m = Set::new()
   assert_eq!(m.capacity(), default_init_capacity)
   assert_eq!(m.size(), 0)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.size(), 1)
 }
 
 test "clear_and_reinsert" {
   let m = Set::new()
-  m.insert("a")
-  m.insert("b")
+  m.add("a")
+  m.add("b")
   m.clear()
   assert_eq!(m.size(), 0)
-  m.insert("c")
+  m.add("c")
   assert_eq!(m.size(), 1)
   assert_true!(m.contains("c"))
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -45,7 +45,14 @@ pub fn T::of[K : Hash + Eq](arr : FixedArray[K]) -> T[K] {
 ///|
 /// Insert a key into hash set.
 /// @alert unsafe "Panic if the hash set is full."
+/// @alert deprecated "Use `add` instead."
 pub fn insert[K : Hash + Eq](self : T[K], key : K) -> Unit {
+  self.add(key)
+}
+
+///|
+/// Insert a key into hash set.
+pub fn add[K : Hash + Eq](self : T[K], key : K) -> Unit {
   if self.capacity == 0 || self.size >= self.growAt {
     self.grow()
   }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -31,14 +31,14 @@ pub fn T::new[K]() -> T[K] {
 /// Create new hash set from array.
 pub fn T::from_array[K : Hash + Eq](arr : Array[K]) -> T[K] {
   let m = new()
-  arr.each(fn(e) { m.insert(e) })
+  arr.each(fn(e) { m.add(e) })
   m
 }
 
 ///|
 pub fn T::of[K : Hash + Eq](arr : FixedArray[K]) -> T[K] {
   let m = new()
-  arr.each(fn(e) { m.insert(e) })
+  arr.each(fn(e) { m.add(e) })
   m
 }
 
@@ -186,8 +186,8 @@ pub fn clear[K](self : T[K]) -> Unit {
 /// @alert unsafe "Panic if the hash set is full."
 pub fn union[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
   let m = T::new()
-  self.each(fn(k) { m.insert(k) })
-  other.each(fn(k) { m.insert(k) })
+  self.each(fn(k) { m.add(k) })
+  other.each(fn(k) { m.add(k) })
   m
 }
 
@@ -195,7 +195,7 @@ pub fn union[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
 /// Intersection of two hash sets.
 pub fn intersection[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
   let m = T::new()
-  self.each(fn(k) { if other.contains(k) { m.insert(k) } })
+  self.each(fn(k) { if other.contains(k) { m.add(k) } })
   m
 }
 
@@ -203,7 +203,7 @@ pub fn intersection[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
 /// Difference of two hash sets.
 pub fn difference[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
   let m = T::new()
-  self.each(fn(k) { if not(other.contains(k)) { m.insert(k) } })
+  self.each(fn(k) { if not(other.contains(k)) { m.add(k) } })
   m
 }
 
@@ -211,8 +211,8 @@ pub fn difference[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
 /// Symmetric difference of two hash sets.
 pub fn symmetric_difference[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
   let m = T::new()
-  self.each(fn(k) { if not(other.contains(k)) { m.insert(k) } })
-  other.each(fn(k) { if not(self.contains(k)) { m.insert(k) } })
+  self.each(fn(k) { if not(other.contains(k)) { m.add(k) } })
+  other.each(fn(k) { if not(self.contains(k)) { m.add(k) } })
   m
 }
 
@@ -235,7 +235,7 @@ pub fn iter[K](self : T[K]) -> Iter[K] {
 ///|
 pub fn T::from_iter[K : Hash + Eq](iter : Iter[K]) -> T[K] {
   let s = T::new()
-  iter.each(fn(e) { s.insert(e) })
+  iter.each(fn(e) { s.add(e) })
   s
 }
 
@@ -283,7 +283,7 @@ fn grow[K : Hash + Eq](self : T[K]) -> Unit {
   self.size = 0
   for i = 0; i < old_entries.length(); i = i + 1 {
     match old_entries[i] {
-      Some({ key, .. }) => self.insert(key)
+      Some({ key, .. }) => self.add(key)
       None => ()
     }
   }
@@ -355,13 +355,13 @@ impl Show for MyString with output(self, logger) { logger.write_string(self._) }
 
 test "set" {
   let m : T[MyString] = T::new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("bc")
-  m.insert("abc")
-  m.insert("cd")
-  m.insert("c")
-  m.insert("d")
+  m.add("a")
+  m.add("b")
+  m.add("bc")
+  m.add("abc")
+  m.add("cd")
+  m.add("c")
+  m.add("d")
   assert_eq!(m.size, 7)
   assert_eq!(
     m.debug_entries(),
@@ -375,12 +375,12 @@ test "remove" {
     MyString::MyString(s)
   }
 
-  m.insert("a" |> i)
-  m.insert("ab" |> i)
-  m.insert("bc" |> i)
-  m.insert("cd" |> i)
-  m.insert("abc" |> i)
-  m.insert("abcdef" |> i)
+  m.add("a" |> i)
+  m.add("ab" |> i)
+  m.add("bc" |> i)
+  m.add("cd" |> i)
+  m.add("abc" |> i)
+  m.add("abcdef" |> i)
   m.remove("ab" |> i)
   assert_eq!(m.size(), 5)
   assert_eq!(m.debug_entries(), "_,(0,a),(0,bc),(1,cd),(1,abc),_,(0,abcdef),_")
@@ -392,9 +392,9 @@ test "remove_unexist_key" {
     MyString::MyString(s)
   }
 
-  m.insert("a" |> i)
-  m.insert("ab" |> i)
-  m.insert("abc" |> i)
+  m.add("a" |> i)
+  m.add("ab" |> i)
+  m.add("abc" |> i)
   m.remove("d" |> i)
   assert_eq!(m.size(), 3)
   assert_eq!(m.debug_entries(), "_,(0,a),(0,ab),(0,abc),_,_,_,_")
@@ -406,20 +406,20 @@ test "grow" {
     MyString::MyString(s)
   }
 
-  m.insert("C" |> i)
-  m.insert("Go" |> i)
-  m.insert("C++" |> i)
-  m.insert("Java" |> i)
-  m.insert("Scala" |> i)
-  m.insert("Julia" |> i)
+  m.add("C" |> i)
+  m.add("Go" |> i)
+  m.add("C++" |> i)
+  m.add("Java" |> i)
+  m.add("Scala" |> i)
+  m.add("Julia" |> i)
   assert_eq!(m.size, 6)
   assert_eq!(m.capacity, 8)
-  m.insert("Cobol" |> i)
+  m.add("Cobol" |> i)
   assert_eq!(m.size, 7)
   assert_eq!(m.capacity, 16)
-  m.insert("Python" |> i)
-  m.insert("Haskell" |> i)
-  m.insert("Rescript" |> i)
+  m.add("Python" |> i)
+  m.add("Haskell" |> i)
+  m.add("Rescript" |> i)
   assert_eq!(m.size, 10)
   assert_eq!(m.capacity, 16)
   assert_eq!(

--- a/hashset/hashset.mbti
+++ b/hashset/hashset.mbti
@@ -7,6 +7,7 @@ alias @moonbitlang/core/quickcheck as @quickcheck
 // Types and methods
 type T
 impl T {
+  add[K : Hash + Eq](Self[K], K) -> Unit
   capacity[K](Self[K]) -> Int
   clear[K](Self[K]) -> Unit
   contains[K : Hash + Eq](Self[K], K) -> Bool
@@ -15,7 +16,7 @@ impl T {
   eachi[K](Self[K], (Int, K) -> Unit) -> Unit
   from_array[K : Hash + Eq](Array[K]) -> Self[K]
   from_iter[K : Hash + Eq](Iter[K]) -> Self[K]
-  insert[K : Hash + Eq](Self[K], K) -> Unit
+  insert[K : Hash + Eq](Self[K], K) -> Unit //deprecated
   intersection[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   is_empty[K](Self[K]) -> Bool
   iter[K](Self[K]) -> Iter[K]

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -17,8 +17,8 @@ let default_init_capacity = 8
 
 test "doc" {
   let set = @hashset.of([3, 8, 1])
-  set.insert(3)
-  set.insert(4)
+  set.add(3)
+  set.add(4)
   inspect!(set, content="@hashset.of([3, 4, 1, 8])")
 }
 
@@ -30,9 +30,9 @@ test "new" {
 
 test "insert" {
   let m = @hashset.new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("c")
+  m.add("a")
+  m.add("b")
+  m.add("c")
   assert_true!(m.contains("a"))
   assert_true!(m.contains("b"))
   assert_true!(m.contains("c"))
@@ -50,14 +50,14 @@ test "from_array" {
 test "size" {
   let m = @hashset.new()
   assert_eq!(m.size(), 0)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.size(), 1)
 }
 
 test "is_empty" {
   let m = @hashset.new()
   assert_eq!(m.is_empty(), true)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.is_empty(), false)
   m.remove("a")
   assert_eq!(m.is_empty(), true)
@@ -150,7 +150,7 @@ test "from_array" {
 test "insert_and_grow" {
   let m = @hashset.new()
   for i = 0; i < 10; i = i + 1 {
-    m.insert(i.to_string())
+    m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)
   assert_eq!(m.capacity(), 16)
@@ -158,10 +158,10 @@ test "insert_and_grow" {
 
 test "remove_and_shift_back" {
   let m = @hashset.new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("c")
-  m.insert("d")
+  m.add("a")
+  m.add("b")
+  m.add("c")
+  m.add("d")
   m.remove("b")
   assert_false!(m.contains("b"))
   assert_true!(m.contains("a"))
@@ -173,17 +173,17 @@ test "capacity_and_size" {
   let m = @hashset.new()
   assert_eq!(m.capacity(), default_init_capacity)
   assert_eq!(m.size(), 0)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.size(), 1)
 }
 
 test "clear_and_reinsert" {
   let m = @hashset.new()
-  m.insert("a")
-  m.insert("b")
+  m.add("a")
+  m.add("b")
   m.clear()
   assert_eq!(m.size(), 0)
-  m.insert("c")
+  m.add("c")
   assert_eq!(m.size(), 1)
   assert_true!(m.contains("c"))
 }
@@ -191,7 +191,7 @@ test "clear_and_reinsert" {
 test "insert_and_grow" {
   let m = @hashset.new()
   for i = 0; i < 10; i = i + 1 {
-    m.insert(i.to_string())
+    m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)
   assert_eq!(m.capacity(), 16)
@@ -199,10 +199,10 @@ test "insert_and_grow" {
 
 test "remove_and_shift_back" {
   let m = @hashset.new()
-  m.insert("a")
-  m.insert("b")
-  m.insert("c")
-  m.insert("d")
+  m.add("a")
+  m.add("b")
+  m.add("c")
+  m.add("d")
   m.remove("b")
   assert_false!(m.contains("b"))
   assert_true!(m.contains("a"))
@@ -214,17 +214,17 @@ test "capacity_and_size" {
   let m = @hashset.new()
   assert_eq!(m.capacity(), default_init_capacity)
   assert_eq!(m.size(), 0)
-  m.insert("a")
+  m.add("a")
   assert_eq!(m.size(), 1)
 }
 
 test "clear_and_reinsert" {
   let m = @hashset.new()
-  m.insert("a")
-  m.insert("b")
+  m.add("a")
+  m.add("b")
   m.clear()
   assert_eq!(m.size(), 0)
-  m.insert("c")
+  m.add("c")
   assert_eq!(m.size(), 1)
   assert_true!(m.contains("c"))
 }

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -238,11 +238,7 @@ test "from_array" {
 test "insert" {
   let m = of([(3, "three"), (8, "eight"), (1, "one")])
   inspect!(m.debug_tree(), content="(3,three,(1,one,_,_),(8,eight,_,_))")
-  let m = m
-    .add(5, "five")
-    .add(2, "two")
-    .add(0, "zero")
-    .add(1, "one_updated")
+  let m = m.add(5, "five").add(2, "two").add(0, "zero").add(1, "one_updated")
   inspect!(
     m.debug_tree(),
     content="(3,three,(1,one_updated,(0,zero,_,_),(2,two,_,_)),(8,eight,(5,five,_,_),_))",
@@ -315,11 +311,7 @@ test "singleton" {
 test "insert" {
   let m = of([(3, "three"), (8, "eight"), (1, "one")])
   inspect!(m.debug_tree(), content="(3,three,(1,one,_,_),(8,eight,_,_))")
-  let m = m
-    .add(5, "five")
-    .add(2, "two")
-    .add(0, "zero")
-    .add(1, "one_updated")
+  let m = m.add(5, "five").add(2, "two").add(0, "zero").add(1, "one_updated")
   inspect!(
     m.debug_tree(),
     content="(3,three,(1,one_updated,(0,zero,_,_),(2,two,_,_)),(8,eight,(5,five,_,_),_))",

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -239,10 +239,10 @@ test "insert" {
   let m = of([(3, "three"), (8, "eight"), (1, "one")])
   inspect!(m.debug_tree(), content="(3,three,(1,one,_,_),(8,eight,_,_))")
   let m = m
-    .insert(5, "five")
-    .insert(2, "two")
-    .insert(0, "zero")
-    .insert(1, "one_updated")
+    .add(5, "five")
+    .add(2, "two")
+    .add(0, "zero")
+    .add(1, "one_updated")
   inspect!(
     m.debug_tree(),
     content="(3,three,(1,one_updated,(0,zero,_,_),(2,two,_,_)),(8,eight,(5,five,_,_),_))",
@@ -316,10 +316,10 @@ test "insert" {
   let m = of([(3, "three"), (8, "eight"), (1, "one")])
   inspect!(m.debug_tree(), content="(3,three,(1,one,_,_),(8,eight,_,_))")
   let m = m
-    .insert(5, "five")
-    .insert(2, "two")
-    .insert(0, "zero")
-    .insert(1, "one_updated")
+    .add(5, "five")
+    .add(2, "two")
+    .add(0, "zero")
+    .add(1, "one_updated")
   inspect!(
     m.debug_tree(),
     content="(3,three,(1,one_updated,(0,zero,_,_),(2,two,_,_)),(8,eight,(5,five,_,_),_))",

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -15,13 +15,23 @@
 ///|
 /// Create a new map with a key-value pair inserted.
 /// O(log n).
+/// 
+/// @alert deprecated "Use `add` instead"
 pub fn insert[K : Compare, V](self : T[K, V], key : K, value : V) -> T[K, V] {
+  self.add(key, value)
+}
+
+///|
+/// Create a new map with a key-value pair inserted.
+/// O(log n).
+/// 
+pub fn add[K : Compare, V](self : T[K, V], key : K, value : V) -> T[K, V] {
   match self {
     Empty => singleton(key, value)
     Tree(k, value=v, l, r, ..) =>
       match key.compare(k) {
-        -1 => balance(k, v, insert(l, key, value), r)
-        1 => balance(k, v, l, insert(r, key, value))
+        -1 => balance(k, v, add(l, key, value), r)
+        1 => balance(k, v, l, add(r, key, value))
         _ => new(k, value, l, r)
       }
   }

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -33,7 +33,7 @@ test "size" {
 test "is_empty" {
   let m : @sorted_map.T[Int, Int] = @sorted_map.empty()
   assert_eq!(m.is_empty(), true)
-  let m = m.insert(1, 1)
+  let m = m.add(1, 1)
   assert_eq!(m.is_empty(), false)
 }
 

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -8,6 +8,7 @@ alias @moonbitlang/core/quickcheck as @quickcheck
 // Types and methods
 type T
 impl T {
+  add[K : Compare + Eq, V](Self[K, V], K, V) -> Self[K, V]
   contains[K : Compare + Eq, V](Self[K, V], K) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
@@ -21,7 +22,7 @@ impl T {
   from_array[K : Compare + Eq, V](Array[(K, V)]) -> Self[K, V]
   from_iter[K : Compare + Eq, V](Iter[(K, V)]) -> Self[K, V]
   from_json[V : @json.FromJson](Json) -> Self[String, V]!@json.JsonDecodeError
-  insert[K : Compare + Eq, V](Self[K, V], K, V) -> Self[K, V]
+  insert[K : Compare + Eq, V](Self[K, V], K, V) -> Self[K, V] //deprecated
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -198,7 +198,7 @@ fn debug_tree[K : Show, V : Show](self : T[K, V]) -> String {
 pub fn T::from_array[K : Compare, V](array : Array[(K, V)]) -> T[K, V] {
   for i = 0, mp = Empty; i < array.length(); {
     let (k, v) = array[i]
-    continue i + 1, mp.insert(k, v)
+    continue i + 1, mp.add(k, v)
   } else {
     mp
   }
@@ -248,7 +248,7 @@ pub fn iter2[K, V](self : T[K, V]) -> Iter2[K, V] {
 
 ///|
 pub fn T::from_iter[K : Compare, V](iter : Iter[(K, V)]) -> T[K, V] {
-  iter.fold(init=T::empty(), fn(m, e) { m.insert(e.0, e.1) })
+  iter.fold(init=T::empty(), fn(m, e) { m.add(e.0, e.1) })
 }
 
 ///|
@@ -267,7 +267,7 @@ pub fn elems[K, V](self : T[K, V]) -> Array[V] {
 pub fn T::of[K : Compare, V](array : FixedArray[(K, V)]) -> T[K, V] {
   for i = 0, mp = Empty; i < array.length(); {
     let (k, v) = array[i]
-    continue i + 1, mp.insert(k, v)
+    continue i + 1, mp.add(k, v)
   } else {
     mp
   }
@@ -306,7 +306,7 @@ pub impl[V : @json.FromJson] @json.FromJson for T[String, V] with from_json(
     Object(obj) => {
       let mut map = T::empty()
       for k, v in obj {
-        map = map.insert(k, V::from_json!(v, path))
+        map = map.add(k, V::from_json!(v, path))
       }
       map
     }

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -30,7 +30,7 @@ test "op_get after insertion" {
   let map = @sorted_map.of(
     [(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")],
   )
-  let map = map.insert(4, "four")
+  let map = map.add(4, "four")
   assert_eq!(map[4], Some("four"))
 }
 


### PR DESCRIPTION
#1113

In `x_map` and `x_set`, there are two names for inserting a new element into collections: `add` and `insert`. This PR renames them to `add` and deprecates the old APIs.