### PR TITLE
rename set operations to `intersection`, `difference`

### DIFF
--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -306,6 +306,12 @@ pub fn union[A : Compare](self : T[A], other : T[A]) -> T[A] {
 }
 
 ///|
+/// @alert deprecated "Use `intersection` instead"
+pub fn inter[A : Compare](self : T[A], other : T[A]) -> T[A] {
+  self.intersection(other)
+}
+
+///|
 /// Returns the intersection of self with other.
 /// 
 /// # Example
@@ -314,7 +320,7 @@ pub fn union[A : Compare](self : T[A], other : T[A]) -> T[A] {
 /// println(of([3, 4, 5]).inter(of([4, 5, 6])))
 /// // output: of([4, 5])
 /// ```
-pub fn inter[A : Compare](self : T[A], other : T[A]) -> T[A] {
+pub fn intersection[A : Compare](self : T[A], other : T[A]) -> T[A] {
   match (self, other) {
     (Empty, _) | (_, Empty) => Empty
     (Node(left=l1, value=v1, right=r1, ..), _) =>

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -334,7 +334,22 @@ pub fn inter[A : Compare](self : T[A], other : T[A]) -> T[A] {
 /// println(of([1, 2, 3]).diff(of([4, 5, 1])))
 /// // output: of([2, 3])
 /// ```
+/// 
+/// @alert deprecated "Use `difference` instead"
 pub fn diff[A : Compare](self : T[A], other : T[A]) -> T[A] {
+  self.difference(other)
+}
+
+///|
+/// Returns the difference between self and other.
+/// 
+/// # Example
+/// 
+/// ```
+/// println(of([1, 2, 3]).diff(of([4, 5, 1])))
+/// // output: of([2, 3])
+/// ```
+pub fn difference[A : Compare](self : T[A], other : T[A]) -> T[A] {
   match (self, other) {
     (Empty, _) => Empty
     (_, Empty) => self

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -317,7 +317,7 @@ pub fn inter[A : Compare](self : T[A], other : T[A]) -> T[A] {
 /// # Example
 /// 
 /// ```
-/// println(of([3, 4, 5]).inter(of([4, 5, 6])))
+/// println(of([3, 4, 5]).intersection(of([4, 5, 6])))
 /// // output: of([4, 5])
 /// ```
 pub fn intersection[A : Compare](self : T[A], other : T[A]) -> T[A] {
@@ -325,8 +325,8 @@ pub fn intersection[A : Compare](self : T[A], other : T[A]) -> T[A] {
     (Empty, _) | (_, Empty) => Empty
     (Node(left=l1, value=v1, right=r1, ..), _) =>
       match other.split(v1) {
-        (l2, false, r2) => l1.inter(l2).concat(r1.inter(r2))
-        (l2, true, r2) => join(l1.inter(l2), v1, r1.inter(r2))
+        (l2, false, r2) => l1.intersection(l2).concat(r1.intersection(r2))
+        (l2, true, r2) => join(l1.intersection(l2), v1, r1.intersection(r2))
       }
   }
 }
@@ -337,7 +337,7 @@ pub fn intersection[A : Compare](self : T[A], other : T[A]) -> T[A] {
 /// # Example
 /// 
 /// ```
-/// println(of([1, 2, 3]).diff(of([4, 5, 1])))
+/// println(of([1, 2, 3]).difference(of([4, 5, 1])))
 /// // output: of([2, 3])
 /// ```
 /// 
@@ -352,7 +352,7 @@ pub fn diff[A : Compare](self : T[A], other : T[A]) -> T[A] {
 /// # Example
 /// 
 /// ```
-/// println(of([1, 2, 3]).diff(of([4, 5, 1])))
+/// println(of([1, 2, 3]).difference(of([4, 5, 1])))
 /// // output: of([2, 3])
 /// ```
 pub fn difference[A : Compare](self : T[A], other : T[A]) -> T[A] {
@@ -361,8 +361,8 @@ pub fn difference[A : Compare](self : T[A], other : T[A]) -> T[A] {
     (_, Empty) => self
     (Node(left=l1, value=v1, right=r1, ..), _) =>
       match other.split(v1) {
-        (l2, false, r2) => join(l1.diff(l2), v1, r1.diff(r2))
-        (l2, true, r2) => l1.diff(l2).concat(r1.diff(r2))
+        (l2, false, r2) => join(l1.difference(l2), v1, r1.difference(r2))
+        (l2, true, r2) => l1.difference(l2).concat(r1.difference(r2))
       }
   }
 }

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -56,30 +56,30 @@ test "subset" {
 test "diff" {
   let empty = @sorted_set.new()
   inspect!(
-    empty.diff(@sorted_set.of([1, 2, 3])),
+    empty.difference(@sorted_set.of([1, 2, 3])),
     content="@immut/sorted_set.of([])",
   )
   inspect!(
-    @sorted_set.of([1, 2, 3]).diff(empty),
+    @sorted_set.of([1, 2, 3]).difference(empty),
     content="@immut/sorted_set.of([1, 2, 3])",
   )
   inspect!(
-    @sorted_set.of([1, 2, 3]).diff(@sorted_set.of([4, 5, 1])),
+    @sorted_set.of([1, 2, 3]).difference(@sorted_set.of([4, 5, 1])),
     content="@immut/sorted_set.of([2, 3])",
   )
   inspect!(
-    @sorted_set.of([1, 2, 3]).diff(@sorted_set.of([1, 2, 3])),
+    @sorted_set.of([1, 2, 3]).difference(@sorted_set.of([1, 2, 3])),
     content="@immut/sorted_set.of([])",
   )
 }
 
 test "inter" {
   inspect!(
-    @sorted_set.of([3, 4, 5]).inter(@sorted_set.of([4, 5, 6])),
+    @sorted_set.of([3, 4, 5]).intersection(@sorted_set.of([4, 5, 6])),
     content="@immut/sorted_set.of([4, 5])",
   )
   inspect!(
-    @sorted_set.of([3, 4]).inter(@sorted_set.of([5, 6])),
+    @sorted_set.of([3, 4]).intersection(@sorted_set.of([5, 6])),
     content="@immut/sorted_set.of([])",
   )
 }

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -22,7 +22,8 @@ impl T {
   from_array[A : Compare + Eq](Array[A]) -> Self[A]
   from_iter[A : Compare + Eq](Iter[A]) -> Self[A]
   from_json[A : @json.FromJson + Compare + Eq](Json) -> Self[A]!@json.JsonDecodeError
-  inter[A : Compare + Eq](Self[A], Self[A]) -> Self[A]
+  inter[A : Compare + Eq](Self[A], Self[A]) -> Self[A] //deprecated
+  intersection[A : Compare + Eq](Self[A], Self[A]) -> Self[A]
   is_empty[A : Compare + Eq](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
   map[A : Compare + Eq, B : Compare + Eq](Self[A], (A) -> B) -> Self[B]

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -13,7 +13,8 @@ impl T {
   any[A : Compare + Eq](Self[A], (A) -> Bool) -> Bool
   contains[A : Compare + Eq](Self[A], A) -> Bool
   default[A : Default]() -> Self[A]
-  diff[A : Compare + Eq](Self[A], Self[A]) -> Self[A]
+  diff[A : Compare + Eq](Self[A], Self[A]) -> Self[A] //deprecated
+  difference[A : Compare + Eq](Self[A], Self[A]) -> Self[A]
   disjoint[A : Compare + Eq](Self[A], Self[A]) -> Bool
   each[A](Self[A], (A) -> Unit) -> Unit
   filter[A : Compare + Eq](Self[A], (A) -> Bool) -> Self[A]

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -246,7 +246,17 @@ fn join_right[V : Compare](l : Node[V]?, v : V, r : Node[V]?) -> Node[V] {
 
 ///|
 /// Returns the difference of two sets.
+/// 
+/// @alert deprecated "Use `difference` instead"
 pub fn diff[V : Compare](self : T[V], src : T[V]) -> T[V] {
+  let ret = new()
+  self.each(fn(x) { if not(src.contains(x)) { ret.add(x) } })
+  ret
+}
+
+///|
+/// Returns the difference of two sets.
+pub fn difference[V : Compare](self : T[V], src : T[V]) -> T[V] {
   let ret = new()
   self.each(fn(x) { if not(src.contains(x)) { ret.add(x) } })
   ret

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -264,7 +264,14 @@ pub fn difference[V : Compare](self : T[V], src : T[V]) -> T[V] {
 
 ///|
 /// Returns the intersection of two sets.
+/// @alert deprecated "Use `intersection` instead"
 pub fn intersect[V : Compare](self : T[V], src : T[V]) -> T[V] {
+  self.intersection(src)
+}
+
+///|
+/// Returns the intersection of two sets.
+pub fn intersection[V : Compare](self : T[V], src : T[V]) -> T[V] {
   let ret = new()
   self.each(fn(x) { if src.contains(x) { ret.add(x) } })
   ret

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -44,14 +44,14 @@ test "subset" {
 
 test "diff" {
   inspect!(
-    @sorted_set.of([1, 2, 3]).diff(@sorted_set.of([4, 5, 1])),
+    @sorted_set.of([1, 2, 3]).difference(@sorted_set.of([4, 5, 1])),
     content="@sorted_set.of([2, 3])",
   )
 }
 
 test "intersect" {
   inspect!(
-    @sorted_set.of([3, 4, 5]).intersect(@sorted_set.of([4, 5, 6])),
+    @sorted_set.of([3, 4, 5]).intersection(@sorted_set.of([4, 5, 6])),
     content="@sorted_set.of([4, 5])",
   )
 }
@@ -153,9 +153,9 @@ test "mix_everything" {
   inspect!(set1, content="@sorted_set.of([1, 2, 3, 4, 5])")
   let set3 = set1.union(set2)
   inspect!(set3, content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8])")
-  let set4 = set1.diff(set2)
+  let set4 = set1.difference(set2)
   inspect!(set4, content="@sorted_set.of([1, 2, 3])")
-  let set5 = set1.intersect(set2)
+  let set5 = set1.intersection(set2)
   inspect!(set5, content="@sorted_set.of([4, 5])")
   inspect!(set1.subset(set3), content="true")
   set3.remove(3)

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -15,7 +15,8 @@ impl T {
   add[V : Compare + Eq](Self[V], V) -> Unit
   contains[V : Compare + Eq](Self[V], V) -> Bool
   deep_clone[V](Self[V]) -> Self[V]
-  diff[V : Compare + Eq](Self[V], Self[V]) -> Self[V]
+  diff[V : Compare + Eq](Self[V], Self[V]) -> Self[V] //deprecated
+  difference[V : Compare + Eq](Self[V], Self[V]) -> Self[V]
   disjoint[V : Compare + Eq](Self[V], Self[V]) -> Bool
   each[V](Self[V], (V) -> Unit) -> Unit
   eachi[V](Self[V], (Int, V) -> Unit) -> Unit

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -21,7 +21,8 @@ impl T {
   each[V](Self[V], (V) -> Unit) -> Unit
   eachi[V](Self[V], (Int, V) -> Unit) -> Unit
   from_iter[V : Compare + Eq](Iter[V]) -> Self[V]
-  intersect[V : Compare + Eq](Self[V], Self[V]) -> Self[V]
+  intersect[V : Compare + Eq](Self[V], Self[V]) -> Self[V] //deprecated
+  intersection[V : Compare + Eq](Self[V], Self[V]) -> Self[V]
   is_empty[V : Compare + Eq](Self[V]) -> Bool
   iter[V](Self[V]) -> Iter[V]
   op_equal[V : Compare + Eq](Self[V], Self[V]) -> Bool


### PR DESCRIPTION
#1113

- rename `diff` to `difference`
- rename `inter`/`intersect` to `intersection`
- deprecate old APIs