### PR TITLE
还是想加一个remove_if_exists

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -320,7 +320,7 @@ impl[K : Show, V : Show] Show for Map[K, V]
 type Set
 impl Set {
   add[K : Hash + Eq](Self[K], K) -> Unit
-  add_if_noexists[K : Hash + Eq](Self[K], K) -> Bool
+  add_and_check[K : Hash + Eq](Self[K], K) -> Bool
   capacity[K](Self[K]) -> Int
   clear[K](Self[K]) -> Unit
   contains[K : Hash + Eq](Self[K], K) -> Bool
@@ -337,7 +337,7 @@ impl Set {
   of[K : Hash + Eq](FixedArray[K]) -> Self[K]
   op_equal[K : Eq](Self[K], Self[K]) -> Bool
   remove[K : Hash + Eq](Self[K], K) -> Unit
-  remove_if_exists[K : Hash + Eq](Self[K], K) -> Bool
+  remove_and_check[K : Hash + Eq](Self[K], K) -> Bool
   size[K](Self[K]) -> Int
   symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   to_array[K](Self[K]) -> Array[K]

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -320,6 +320,7 @@ impl[K : Show, V : Show] Show for Map[K, V]
 type Set
 impl Set {
   add[K : Hash + Eq](Self[K], K) -> Unit
+  add_if_noexists[K : Hash + Eq](Self[K], K) -> Bool
   capacity[K](Self[K]) -> Int
   clear[K](Self[K]) -> Unit
   contains[K : Hash + Eq](Self[K], K) -> Bool
@@ -336,6 +337,7 @@ impl Set {
   of[K : Hash + Eq](FixedArray[K]) -> Self[K]
   op_equal[K : Eq](Self[K], Self[K]) -> Bool
   remove[K : Hash + Eq](Self[K], K) -> Unit
+  remove_if_exists[K : Hash + Eq](Self[K], K) -> Bool
   size[K](Self[K]) -> Int
   symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   to_array[K](Self[K]) -> Array[K]

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -84,7 +84,7 @@ pub fn insert[K : Hash + Eq](self : Set[K], key : K) -> Unit {
 
 ///|
 /// Insert a key into the hash set.if the key exists return false
-pub fn add_if_noexists[K : Hash + Eq](self : Set[K], key : K) -> Bool {
+pub fn add_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
   if self.size >= self.growAt {
     self.grow()
   }
@@ -128,7 +128,7 @@ pub fn add_if_noexists[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Insert a key into the hash set.
 pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  let _ = self.add_if_noexists(key)
+  let _ = self.add_and_check(key)
 
 }
 
@@ -155,13 +155,13 @@ pub fn contains[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Remove a key from hash set.
 pub fn remove[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  let _ = self.remove_if_exists(key)
+  let _ = self.remove_and_check(key)
 
 }
 
 ///|
 /// Remove a key from hash set.if the key exists, delete it and return true
-pub fn remove_if_exists[K : Hash + Eq](self : Set[K], key : K) -> Bool {
+pub fn remove_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -128,44 +128,8 @@ pub fn add_if_noexists[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Insert a key into the hash set.
 pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  if self.size >= self.growAt {
-    self.grow()
-  }
-  let hash = key.hash()
-  let insert_entry = { idx: -1, psl: 0, hash, key }
-  let list_node : SListNode[K] = { prev: None, next: None }
-  loop 0, hash & self.capacity_mask, insert_entry, list_node {
-    i, idx, entry, node =>
-      match self.entries[idx] {
-        None => {
-          self.entries[idx] = Some(entry)
-          self.list[idx] = node
-          entry.idx = idx
-          self.add_entry_to_tail(insert_entry)
-          self.size += 1
-          break
-        }
-        Some(curr_entry) => {
-          let curr_node = self.list[curr_entry.idx]
-          if curr_entry.hash == entry.hash && curr_entry.key == entry.key {
-            break
-          }
-          if entry.psl > curr_entry.psl {
-            self.entries[idx] = Some(entry)
-            self.list[idx] = node
-            entry.idx = idx
-            curr_entry.psl += 1
-            continue i + 1,
-              (idx + 1) & self.capacity_mask,
-              curr_entry,
-              curr_node
-          } else {
-            entry.psl += 1
-            continue i + 1, (idx + 1) & self.capacity_mask, entry, node
-          }
-        }
-      }
-  }
+  let _ = self.add_if_noexists(key)
+
 }
 
 ///|
@@ -191,25 +155,8 @@ pub fn contains[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Remove a key from hash set.
 pub fn remove[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  let hash = key.hash()
-  for i = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
-      Some(entry) => {
-        if entry.hash == hash && entry.key == key {
-          self.entries[idx] = None
-          self.remove_entry(entry)
-          self.shift_back(idx)
-          self.size -= 1
-          break
-        }
-        if i > entry.psl {
-          break
-        }
-        continue i + 1, (idx + 1) & self.capacity_mask
-      }
-      None => break
-    }
-  }
+  let _ = self.remove_if_exists(key)
+
 }
 
 ///|

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -83,6 +83,49 @@ pub fn insert[K : Hash + Eq](self : Set[K], key : K) -> Unit {
 }
 
 ///|
+/// Insert a key into the hash set.if the key exists return false
+pub fn add_if_noexists[K : Hash + Eq](self : Set[K], key : K) -> Bool {
+  if self.size >= self.growAt {
+    self.grow()
+  }
+  let hash = key.hash()
+  let insert_entry = { idx: -1, psl: 0, hash, key }
+  let list_node : SListNode[K] = { prev: None, next: None }
+  loop 0, hash & self.capacity_mask, insert_entry, list_node {
+    i, idx, entry, node =>
+      match self.entries[idx] {
+        None => {
+          self.entries[idx] = Some(entry)
+          self.list[idx] = node
+          entry.idx = idx
+          self.add_entry_to_tail(insert_entry)
+          self.size += 1
+          break true
+        }
+        Some(curr_entry) => {
+          let curr_node = self.list[curr_entry.idx]
+          if curr_entry.hash == entry.hash && curr_entry.key == entry.key {
+            break false
+          }
+          if entry.psl > curr_entry.psl {
+            self.entries[idx] = Some(entry)
+            self.list[idx] = node
+            entry.idx = idx
+            curr_entry.psl += 1
+            continue i + 1,
+              (idx + 1) & self.capacity_mask,
+              curr_entry,
+              curr_node
+          } else {
+            entry.psl += 1
+            continue i + 1, (idx + 1) & self.capacity_mask, entry, node
+          }
+        }
+      }
+  }
+}
+
+///|
 /// Insert a key into the hash set.
 pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
   if self.size >= self.growAt {
@@ -165,6 +208,30 @@ pub fn remove[K : Hash + Eq](self : Set[K], key : K) -> Unit {
         continue i + 1, (idx + 1) & self.capacity_mask
       }
       None => break
+    }
+  }
+}
+
+///|
+/// Remove a key from hash set.if the key exists, delete it and return true
+pub fn remove_if_exists[K : Hash + Eq](self : Set[K], key : K) -> Bool {
+  let hash = key.hash()
+  for i = 0, idx = hash & self.capacity_mask {
+    match self.entries[idx] {
+      Some(entry) => {
+        if entry.hash == hash && entry.key == key {
+          self.entries[idx] = None
+          self.remove_entry(entry)
+          self.shift_back(idx)
+          self.size -= 1
+          break true
+        }
+        if i > entry.psl {
+          break false
+        }
+        continue i + 1, (idx + 1) & self.capacity_mask
+      }
+      None => break false
     }
   }
 }

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -129,6 +129,7 @@ pub fn add_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 /// Insert a key into the hash set.
 pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
   let _ = self.add_and_check(key)
+
 }
 
 ///|

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -129,7 +129,6 @@ pub fn add_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 /// Insert a key into the hash set.
 pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
   let _ = self.add_and_check(key)
-
 }
 
 ///|

--- a/builtin/linked_hash_set_test.mbt
+++ b/builtin/linked_hash_set_test.mbt
@@ -37,11 +37,11 @@ test "add remove" {
   m.add("a")
   m.add("b")
   m.add("c")
-  if m.remove_if_exists("a") {
+  if m.remove_and_check("a") {
     m.add("d")
   }
-  assert_true!(m.add_if_noexists("test"))
-  assert_false!(m.add_if_noexists("test"))
+  assert_true!(m.add_and_check("test"))
+  assert_false!(m.add_and_check("test"))
   assert_true!(m.contains("a").not() && m.contains("d"))
   assert_true!(m.contains("b"))
   assert_true!(m.contains("c"))

--- a/builtin/linked_hash_set_test.mbt
+++ b/builtin/linked_hash_set_test.mbt
@@ -32,6 +32,20 @@ test "insert" {
   assert_false!(m.contains("d"))
 }
 
+test "add remove" {
+  let m = Set::new()
+  m.add("a")
+  m.add("b")
+  m.add("c")
+  if m.remove_if_exists("a") {
+    m.add("d")
+  }
+  assert_true!(m.contains("a").not() && m.contains("d"))
+  assert_true!(m.contains("b"))
+  assert_true!(m.contains("c"))
+  assert_true!(m.contains("d"))
+}
+
 test "from_array" {
   let m = Set::of(["a", "b", "c"])
   assert_true!(m.contains("a"))

--- a/builtin/linked_hash_set_test.mbt
+++ b/builtin/linked_hash_set_test.mbt
@@ -40,6 +40,8 @@ test "add remove" {
   if m.remove_if_exists("a") {
     m.add("d")
   }
+  assert_true!(m.add_if_noexists("test"))
+  assert_false!(m.add_if_noexists("test"))
   assert_true!(m.contains("a").not() && m.contains("d"))
   assert_true!(m.contains("b"))
   assert_true!(m.contains("c"))


### PR DESCRIPTION
直接修改原函数的返回值，确实破坏了API的一致性原则导致不兼容，那么增加函数是否可以呢？主要是在使用过程中会有很多
if set.contains(b){
   set.remove(b)
   .....//执行其他代码
}
有不少这类逻辑的，实际上remove本身就判定了是否存在，如果这种代码多，相当于执行性能就要降低一半，故建议增加
remove_if_exists这种函数，将contains跟remove能合并的，同时增加一个add_if_noexists，将contains和add合并