### PR TITLE
add add_and_check, remove_and_check

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -320,6 +320,7 @@ impl[K : Show, V : Show] Show for Map[K, V]
 type Set
 impl Set {
   add[K : Hash + Eq](Self[K], K) -> Unit
+  add_and_check[K : Hash + Eq](Self[K], K) -> Bool
   capacity[K](Self[K]) -> Int
   clear[K](Self[K]) -> Unit
   contains[K : Hash + Eq](Self[K], K) -> Bool
@@ -336,6 +337,7 @@ impl Set {
   of[K : Hash + Eq](FixedArray[K]) -> Self[K]
   op_equal[K : Eq](Self[K], Self[K]) -> Bool
   remove[K : Hash + Eq](Self[K], K) -> Unit
+  remove_and_check[K : Hash + Eq](Self[K], K) -> Bool
   size[K](Self[K]) -> Int
   symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   to_array[K](Self[K]) -> Array[K]

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -191,7 +191,25 @@ pub fn contains[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Remove a key from hash set.
 pub fn remove[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  self.remove_and_check(key) |> ignore
+  let hash = key.hash()
+  for i = 0, idx = hash & self.capacity_mask {
+    match self.entries[idx] {
+      Some(entry) => {
+        if entry.hash == hash && entry.key == key {
+          self.entries[idx] = None
+          self.remove_entry(entry)
+          self.shift_back(idx)
+          self.size -= 1
+          break
+        }
+        if i > entry.psl {
+          break
+        }
+        continue i + 1, (idx + 1) & self.capacity_mask
+      }
+      None => break
+    }
+  }
 }
 
 ///|

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -128,8 +128,7 @@ pub fn add_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Insert a key into the hash set.
 pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  let _ = self.add_and_check(key)
-
+  self.add_and_check(key) |> ignore
 }
 
 ///|
@@ -155,8 +154,7 @@ pub fn contains[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Remove a key from hash set.
 pub fn remove[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  let _ = self.remove_and_check(key)
-
+  self.remove_and_check(key) |> ignore
 }
 
 ///|

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -83,8 +83,8 @@ pub fn insert[K : Hash + Eq](self : Set[K], key : K) -> Unit {
 }
 
 ///|
-/// Insert a key into the hash set.
-pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
+/// Insert a key into the hash set.if the key exists return false
+pub fn add_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
   if self.size >= self.growAt {
     self.grow()
   }
@@ -100,12 +100,12 @@ pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
           entry.idx = idx
           self.add_entry_to_tail(insert_entry)
           self.size += 1
-          break
+          break true
         }
         Some(curr_entry) => {
           let curr_node = self.list[curr_entry.idx]
           if curr_entry.hash == entry.hash && curr_entry.key == entry.key {
-            break
+            break false
           }
           if entry.psl > curr_entry.psl {
             self.entries[idx] = Some(entry)
@@ -123,6 +123,13 @@ pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
         }
       }
   }
+}
+
+///|
+/// Insert a key into the hash set.
+pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
+  let _ = self.add_and_check(key)
+
 }
 
 ///|
@@ -148,6 +155,13 @@ pub fn contains[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Remove a key from hash set.
 pub fn remove[K : Hash + Eq](self : Set[K], key : K) -> Unit {
+  let _ = self.remove_and_check(key)
+
+}
+
+///|
+/// Remove a key from hash set.if the key exists, delete it and return true
+pub fn remove_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
@@ -157,14 +171,14 @@ pub fn remove[K : Hash + Eq](self : Set[K], key : K) -> Unit {
           self.remove_entry(entry)
           self.shift_back(idx)
           self.size -= 1
-          break
+          break true
         }
         if i > entry.psl {
-          break
+          break false
         }
         continue i + 1, (idx + 1) & self.capacity_mask
       }
-      None => break
+      None => break false
     }
   }
 }

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -128,7 +128,44 @@ pub fn add_and_check[K : Hash + Eq](self : Set[K], key : K) -> Bool {
 ///|
 /// Insert a key into the hash set.
 pub fn add[K : Hash + Eq](self : Set[K], key : K) -> Unit {
-  self.add_and_check(key) |> ignore
+  if self.size >= self.growAt {
+    self.grow()
+  }
+  let hash = key.hash()
+  let insert_entry = { idx: -1, psl: 0, hash, key }
+  let list_node : SListNode[K] = { prev: None, next: None }
+  loop 0, hash & self.capacity_mask, insert_entry, list_node {
+    i, idx, entry, node =>
+      match self.entries[idx] {
+        None => {
+          self.entries[idx] = Some(entry)
+          self.list[idx] = node
+          entry.idx = idx
+          self.add_entry_to_tail(insert_entry)
+          self.size += 1
+          break
+        }
+        Some(curr_entry) => {
+          let curr_node = self.list[curr_entry.idx]
+          if curr_entry.hash == entry.hash && curr_entry.key == entry.key {
+            break
+          }
+          if entry.psl > curr_entry.psl {
+            self.entries[idx] = Some(entry)
+            self.list[idx] = node
+            entry.idx = idx
+            curr_entry.psl += 1
+            continue i + 1,
+              (idx + 1) & self.capacity_mask,
+              curr_entry,
+              curr_node
+          } else {
+            entry.psl += 1
+            continue i + 1, (idx + 1) & self.capacity_mask, entry, node
+          }
+        }
+      }
+  }
 }
 
 ///|

--- a/builtin/linked_hash_set_test.mbt
+++ b/builtin/linked_hash_set_test.mbt
@@ -32,6 +32,22 @@ test "insert" {
   assert_false!(m.contains("d"))
 }
 
+test "add remove" {
+  let m = Set::new()
+  m.add("a")
+  m.add("b")
+  m.add("c")
+  if m.remove_and_check("a") {
+    m.add("d")
+  }
+  assert_true!(m.add_and_check("test"))
+  assert_false!(m.add_and_check("test"))
+  assert_true!(m.contains("a").not() && m.contains("d"))
+  assert_true!(m.contains("b"))
+  assert_true!(m.contains("c"))
+  assert_true!(m.contains("d"))
+}
+
 test "from_array" {
   let m = Set::of(["a", "b", "c"])
   assert_true!(m.contains("a"))


### PR DESCRIPTION
This pull request introduces new methods to the `Set` type in the `builtin` module and updates existing methods to improve functionality. The changes primarily focus on adding and removing elements with checks and enhancing the test coverage.

### Additions and Enhancements to `Set` Type:

* Added `add_and_check` method to `Set` for inserting a key and returning a boolean indicating success (`builtin/builtin.mbti`, `builtin/linked_hash_set.mbt`). [[1]](diffhunk://#diff-979a8cf0c39b3e1340630ddd48d1ed130df1eb2f6f8d94b9eb1b8613a9415875R323) [[2]](diffhunk://#diff-5cfaceb7277acdfdf25ddb09f41f85d52e6fa7c221c3e8eb6fced672d66fcd44L86-R87)
* Added `remove_and_check` method to `Set` for removing a key and returning a boolean indicating success (`builtin/builtin.mbti`, `builtin/linked_hash_set.mbt`). [[1]](diffhunk://#diff-979a8cf0c39b3e1340630ddd48d1ed130df1eb2f6f8d94b9eb1b8613a9415875R340) [[2]](diffhunk://#diff-5cfaceb7277acdfdf25ddb09f41f85d52e6fa7c221c3e8eb6fced672d66fcd44R158-R164)

### Updates to Existing Methods:

* Modified `add` method to utilize `add_and_check` internally and return a boolean (`builtin/linked_hash_set.mbt`).
* Updated `remove` method to utilize `remove_and_check` internally and return a boolean (`builtin/linked_hash_set.mbt`).

### Test Coverage:

* Added new test case "add remove" to verify the functionality of `add_and_check` and `remove_and_check` methods (`builtin/linked_hash_set_test.mbt`).