### PR TITLE
deprecate `@test.is` so that we can add `is` as a reserved word

### DIFF
--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -299,7 +299,7 @@ test "clear" {
   assert_eq!(m.size(), 0)
   assert_eq!(m.capacity(), 8)
   for i = 0; i < m.capacity(); i = i + 1 {
-    @test.is!(m.entries[i], None)
+    @test.same_object!(m.entries[i], None)
   }
 }
 

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -434,6 +434,6 @@ test "clear" {
   assert_eq!(m.size(), 0)
   assert_eq!(m.capacity(), 8)
   for i = 0; i < m.capacity(); i = i + 1 {
-    @test.is!(m.entries[i], None)
+    @test.same_object!(m.entries[i], None)
   }
 }

--- a/math/algebraic_test.mbt
+++ b/math/algebraic_test.mbt
@@ -27,10 +27,10 @@ test "maximum.ref" {
   // We need another value that equals to x2 by value but not reference
   let x2t = T::{ x: v2 }
   @test.is_not!(x2, x2t)
-  @test.is!(@math.maximum(x1, x2), x2)
-  @test.is!(@math.maximum(x2, x1), x2)
-  @test.is!(@math.maximum(x2, x2t), x2t)
-  @test.is!(@math.maximum(x2t, x2), x2)
+  @test.same_object!(@math.maximum(x1, x2), x2)
+  @test.same_object!(@math.maximum(x2, x1), x2)
+  @test.same_object!(@math.maximum(x2, x2t), x2t)
+  @test.same_object!(@math.maximum(x2t, x2), x2)
 }
 
 test "minimum.value" {
@@ -48,10 +48,10 @@ test "minimum.ref" {
   // We need another value that equals to x2 by value but not reference
   let x2t = T::{ x: v2 }
   @test.is_not!(x2, x2t)
-  @test.is!(@math.minimum(x1, x2), x1)
-  @test.is!(@math.minimum(x2, x1), x1)
-  @test.is!(@math.minimum(x2, x2t), x2)
-  @test.is!(@math.minimum(x2t, x2), x2t)
+  @test.same_object!(@math.minimum(x1, x2), x1)
+  @test.same_object!(@math.minimum(x2, x1), x1)
+  @test.same_object!(@math.minimum(x2, x2t), x2)
+  @test.same_object!(@math.minimum(x2t, x2), x2t)
 }
 
 test "exp" {

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -70,15 +70,21 @@ pub fn is_false(x : Bool, loc~ : SourceLoc = _) -> Unit! {
 /// ```
 /// let a = "4" + "2"
 /// let b = "4" + "2"
-/// is(a, a)!  // this is okay
-/// is(a, b)!  // yields an error
+/// same_object(a, a)!  // this is okay
+/// same_object(a, b)!  // yields an error
 /// ```
-pub fn is[T : Show](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
+pub fn same_object[T : Show](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
   if not(physical_equal(a, b)) {
     let a = debug_string(a)
     let b = debug_string(b)
     fail!("FAILED: \{loc} `\{a} is \{b}`")
   }
+}
+
+///|
+/// @alert deprecated "Use `same_object` instead"
+pub fn is[T : Show](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
+  same_object!(a, b, loc~)
 }
 
 ///|

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -5,7 +5,7 @@ fn eq[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit! //deprecated
 
 fn fail[T](String, loc~ : SourceLoc = _) -> T!
 
-fn is[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!
+fn is[T : Show](T, T, loc~ : SourceLoc = _) -> Unit! //deprecated
 
 fn is_false(Bool, loc~ : SourceLoc = _) -> Unit! //deprecated
 
@@ -14,6 +14,8 @@ fn is_not[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!
 fn is_true(Bool, loc~ : SourceLoc = _) -> Unit! //deprecated
 
 fn ne[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit! //deprecated
+
+fn same_object[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!
 
 // Types and methods
 pub(all) struct T {


### PR DESCRIPTION
We want to make `is` an reserved word in the future, but currently package `@test` has a API called `is` for asserting the physical equality of two objects. This PR deprecates this API and rename it to `@test.same_object`.