### PR TITLE
add typealias to buffer

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+///| Extensible buffer.
+/// @alert deprecated "Use type `T` instead"
+pub(all) typealias Buffer = T
+
 ///|
 /// Extensible buffer.
 ///

--- a/buffer/buffer.mbti
+++ b/buffer/buffer.mbti
@@ -23,6 +23,7 @@ impl T {
 impl Show for T
 
 // Type aliases
+pub typealias Buffer = T
 
 // Traits
 


### PR DESCRIPTION
There is a bug in formatter and type checker, the `pub(all)` visibility is invalid for `typealias`. cc @Guest0x0 @Young-Flash 