### PR TITLE
refactor buffer to use `FixedArray[Byte]` instead of `Bytes`

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -33,16 +33,16 @@ pub(all) typealias Buffer = T
 /// println(buf.to_string()) // output: Test
 /// ```
 struct T {
-  mut bytes : FixedArray[Byte]
+  mut data : FixedArray[Byte]
   mut len : Int
-  initial_bytes : FixedArray[Byte]
+  initial_data : FixedArray[Byte]
 }
 
 ///|
 /// Expand the buffer size if capacity smaller than required space.
 fn grow_if_necessary(self : T, required : Int) -> Unit {
   // TODO: get rid of mut
-  let mut enough_space = self.bytes.length()
+  let mut enough_space = self.data.length()
   if enough_space <= 0 {
     enough_space = 1
   }
@@ -50,10 +50,10 @@ fn grow_if_necessary(self : T, required : Int) -> Unit {
   while enough_space < required {
     enough_space = enough_space * 2
   }
-  if enough_space != self.bytes.length() {
-    self.bytes = FixedArray::make(enough_space, Byte::default())..unsafe_blit(
+  if enough_space != self.data.length() {
+    self.data = FixedArray::make(enough_space, Byte::default())..unsafe_blit(
       0,
-      self.bytes,
+      self.data,
       0,
       self.len,
     )
@@ -85,7 +85,7 @@ pub fn to_string(self : T) -> String {
 /// Note this function does not validate the encoding of the byte sequence, 
 /// it simply copy the bytes into a new String.
 pub fn to_unchecked_string(self : T) -> String {
-  Bytes::cast_from_fixedarray(self.bytes).to_unchecked_string(
+  Bytes::from_fixedarray(self.data).to_unchecked_string(
     offset=0,
     length=self.len,
   )
@@ -95,15 +95,15 @@ pub fn to_unchecked_string(self : T) -> String {
 /// Create a buffer with initial capacity (in bytes).
 pub fn T::new(size_hint~ : Int = 0) -> T {
   let initial = if size_hint < 1 { 1 } else { size_hint }
-  let bytes = FixedArray::make(initial, Byte::default())
-  { bytes, len: 0, initial_bytes: bytes }
+  let data = FixedArray::make(initial, Byte::default())
+  { data, len: 0, initial_data: data }
 }
 
 ///|
 /// Write a string into buffer.
 pub fn write_string(self : T, value : String) -> Unit {
   self.grow_if_necessary(self.len + value.length() * 2)
-  self.bytes.bytearray_blit_from_string(self.len, value, 0, value.length())
+  self.data.blit_from_string(self.len, value, 0, value.length())
   self.len += value.length() * 2
 }
 
@@ -116,7 +116,7 @@ pub fn write_object(self : T, value : Show) -> Unit {
 pub fn write_bytes(self : T, value : Bytes) -> Unit {
   let val_len = value.length()
   self.grow_if_necessary(self.len + val_len)
-  self.bytes.unsafe_blit(self.len, value.cast_to_fixedarray(), 0, val_len)
+  self.data.blit_from_bytes(self.len, value, 0, val_len)
   self.len += val_len
 }
 
@@ -130,7 +130,7 @@ pub fn write_substring(
 ) -> Unit {
   guard start >= 0 && len >= 0 && start + len <= value.length()
   self.grow_if_necessary(self.len + len * 2)
-  self.bytes.bytearray_blit_from_string(self.len, value, start, len)
+  self.data.blit_from_string(self.len, value, start, len)
   self.len += len * 2
 }
 
@@ -150,7 +150,7 @@ pub fn write_sub_string(
 /// Write a char into buffer.
 pub fn write_char(self : T, value : Char) -> Unit {
   self.grow_if_necessary(self.len + 4)
-  let inc = self.bytes.bytearray_set_utf16_char(self.len, value)
+  let inc = self.data.set_utf16_char(self.len, value)
   self.len += inc
 }
 
@@ -158,21 +158,19 @@ pub fn write_char(self : T, value : Char) -> Unit {
 /// Write a byte into buffer.
 pub fn write_byte(self : T, value : Byte) -> Unit {
   self.grow_if_necessary(self.len + 1)
-  self.bytes[self.len] = value
+  self.data[self.len] = value
   self.len += 1
 }
 
 ///|
 pub fn reset(self : T) -> Unit {
-  self.bytes = self.initial_bytes
+  self.data = self.initial_data
   self.len = 0
 }
 
 ///|
 pub fn to_bytes(self : T) -> Bytes {
-  let bytes = FixedArray::make(self.len, Byte::default())
-  bytes.unsafe_blit(0, self.bytes, 0, self.len)
-  Bytes::cast_from_fixedarray(bytes)
+  Bytes::from_fixedarray(self.data, len=self.len)
 }
 
 ///|

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -33,9 +33,9 @@ pub(all) typealias Buffer = T
 /// println(buf.to_string()) // output: Test
 /// ```
 struct T {
-  mut bytes : Bytes
+  mut bytes : FixedArray[Byte]
   mut len : Int
-  initial_bytes : Bytes
+  initial_bytes : FixedArray[Byte]
 }
 
 ///|
@@ -51,7 +51,12 @@ fn grow_if_necessary(self : T, required : Int) -> Unit {
     enough_space = enough_space * 2
   }
   if enough_space != self.bytes.length() {
-    self.bytes = Bytes::new(enough_space)..blit(0, self.bytes, 0, self.len)
+    self.bytes = FixedArray::make(enough_space, Byte::default())..unsafe_blit(
+      0,
+      self.bytes,
+      0,
+      self.len,
+    )
   }
 }
 
@@ -72,7 +77,7 @@ pub fn is_empty(self : T) -> Bool {
 /// 
 /// @alert deprecated "Use `Buffer::to_unchecked_string` instead"
 pub fn to_string(self : T) -> String {
-  self.bytes.to_unchecked_string(offset=0, length=self.len)
+  self.to_unchecked_string()
 }
 
 ///|
@@ -80,14 +85,17 @@ pub fn to_string(self : T) -> String {
 /// Note this function does not validate the encoding of the byte sequence, 
 /// it simply copy the bytes into a new String.
 pub fn to_unchecked_string(self : T) -> String {
-  self.bytes.to_unchecked_string(offset=0, length=self.len)
+  Bytes::cast_from_fixedarray(self.bytes).to_unchecked_string(
+    offset=0,
+    length=self.len,
+  )
 }
 
 ///|
 /// Create a buffer with initial capacity (in bytes).
 pub fn T::new(size_hint~ : Int = 0) -> T {
   let initial = if size_hint < 1 { 1 } else { size_hint }
-  let bytes = Bytes::new(initial)
+  let bytes = FixedArray::make(initial, Byte::default())
   { bytes, len: 0, initial_bytes: bytes }
 }
 
@@ -95,7 +103,7 @@ pub fn T::new(size_hint~ : Int = 0) -> T {
 /// Write a string into buffer.
 pub fn write_string(self : T, value : String) -> Unit {
   self.grow_if_necessary(self.len + value.length() * 2)
-  self.bytes.blit_from_string(self.len, value, 0, value.length())
+  self.bytes.bytearray_blit_from_string(self.len, value, 0, value.length())
   self.len += value.length() * 2
 }
 
@@ -108,7 +116,7 @@ pub fn write_object(self : T, value : Show) -> Unit {
 pub fn write_bytes(self : T, value : Bytes) -> Unit {
   let val_len = value.length()
   self.grow_if_necessary(self.len + val_len)
-  self.bytes.blit(self.len, value, 0, val_len)
+  self.bytes.unsafe_blit(self.len, value.cast_to_fixedarray(), 0, val_len)
   self.len += val_len
 }
 
@@ -122,7 +130,7 @@ pub fn write_substring(
 ) -> Unit {
   guard start >= 0 && len >= 0 && start + len <= value.length()
   self.grow_if_necessary(self.len + len * 2)
-  self.bytes.blit_from_string(self.len, value, start, len)
+  self.bytes.bytearray_blit_from_string(self.len, value, start, len)
   self.len += len * 2
 }
 
@@ -142,7 +150,7 @@ pub fn write_sub_string(
 /// Write a char into buffer.
 pub fn write_char(self : T, value : Char) -> Unit {
   self.grow_if_necessary(self.len + 4)
-  let inc = self.bytes.set_utf16_char(self.len, value)
+  let inc = self.bytes.bytearray_set_utf16_char(self.len, value)
   self.len += inc
 }
 
@@ -162,7 +170,9 @@ pub fn reset(self : T) -> Unit {
 
 ///|
 pub fn to_bytes(self : T) -> Bytes {
-  Bytes::new(self.len)..blit(0, self.bytes, 0, self.len)
+  let bytes = FixedArray::make(self.len, Byte::default())
+  bytes.unsafe_blit(0, self.bytes, 0, self.len)
+  Bytes::cast_from_fixedarray(bytes)
 }
 
 ///|

--- a/buffer/moon.pkg.json
+++ b/buffer/moon.pkg.json
@@ -3,5 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/coverage",
     "moonbitlang/core/bytes"
-  ]
+  ],
+  "alert-list": "-unstable"
 }

--- a/buffer/moon.pkg.json
+++ b/buffer/moon.pkg.json
@@ -1,3 +1,7 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/coverage"]
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/coverage",
+    "moonbitlang/core/bytes"
+  ]
 }

--- a/buffer/moon.pkg.json
+++ b/buffer/moon.pkg.json
@@ -3,6 +3,5 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/coverage",
     "moonbitlang/core/bytes"
-  ],
-  "alert-list": "-unstable"
+  ]
 }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -655,6 +655,8 @@ impl Result {
 
 impl FixedArray {
   blit_to[A](Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit
+  bytearray_blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
+  bytearray_set_utf16_char(Self[Byte], Int, Char) -> Int
   default[X]() -> Self[X]
   fill[T](Self[T], T) -> Unit
   get[T](Self[T], Int) -> T

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -654,9 +654,9 @@ impl Result {
 
 
 impl FixedArray {
+  blit_from_bytes(Self[Byte], Int, Bytes, Int, Int) -> Unit
+  blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
   blit_to[A](Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit
-  bytearray_blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
-  bytearray_set_utf16_char(Self[Byte], Int, Char) -> Int
   default[X]() -> Self[X]
   fill[T](Self[T], T) -> Unit
   get[T](Self[T], Int) -> T
@@ -667,6 +667,7 @@ impl FixedArray {
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   set[T](Self[T], Int, T) -> Unit
+  set_utf16_char(Self[Byte], Int, Char) -> Int
   to_json[X : ToJson](Self[X]) -> Json
   to_string[X : Show](Self[X]) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -86,6 +86,31 @@ pub fn blit_from_string(
 }
 
 ///|
+/// Copy `length` chars from string `str`, starting at `str_offset`,
+/// into byte sequence `self`, starting at `bytes_offset`.
+pub fn bytearray_blit_from_string(
+  self : FixedArray[Byte],
+  bytes_offset : Int,
+  str : String,
+  str_offset : Int,
+  length : Int
+) -> Unit {
+  let s1 = bytes_offset
+  let s2 = str_offset
+  let e1 = bytes_offset + length - 1
+  let e2 = str_offset + length - 1
+  let len1 = self.length()
+  let len2 = str.length()
+  guard length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
+  let end_str_offset = str_offset + length
+  for i = str_offset, j = bytes_offset; i < end_str_offset; i = i + 1, j = j + 2 {
+    let c = str[i].to_uint()
+    self[j] = (c & 0xff).to_byte()
+    self[j + 1] = (c >> 8).to_byte()
+  }
+}
+
+///|
 /// Return a new Bytes that contains the same byte sequence.
 pub fn copy(self : Bytes) -> Bytes {
   Bytes::new(self.length())..blit(0, self, 0, self.length())
@@ -125,6 +150,34 @@ pub fn set_utf8_char(self : Bytes, offset : Int, value : Char) -> Int {
 /// It return the length of bytes has been written.
 /// @alert unsafe "Panic if the [value] is out of range"
 pub fn set_utf16_char(self : Bytes, offset : Int, value : Char) -> Int {
+  let code = value.to_uint()
+  if code < 0x10000 {
+    self[offset] = (code & 0xFF).to_byte()
+    self[offset + 1] = (code >> 8).to_byte()
+    2
+  } else if code < 0x110000 {
+    let hi = code - 0x10000
+    let lo = (hi >> 10) | 0xD800
+    let hi = (hi & 0x3FF) | 0xDC00
+    self[offset] = (lo & 0xFF).to_byte()
+    self[offset + 1] = (lo >> 8).to_byte()
+    self[offset + 2] = (hi & 0xFF).to_byte()
+    self[offset + 3] = (hi >> 8).to_byte()
+    4
+  } else {
+    abort("Char out of range")
+  }
+}
+
+///|
+/// Fill utf16 encoded char `value` into byte sequence `self`, starting at `offset`.
+/// It return the length of bytes has been written.
+/// @alert unsafe "Panic if the [value] is out of range"
+pub fn bytearray_set_utf16_char(
+  self : FixedArray[Byte],
+  offset : Int,
+  value : Char
+) -> Int {
   let code = value.to_uint()
   if code < 0x10000 {
     self[offset] = (code & 0xFF).to_byte()

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -88,7 +88,7 @@ pub fn blit_from_string(
 ///|
 /// Copy `length` chars from string `str`, starting at `str_offset`,
 /// into byte sequence `self`, starting at `bytes_offset`.
-pub fn bytearray_blit_from_string(
+pub fn blit_from_string(
   self : FixedArray[Byte],
   bytes_offset : Int,
   str : String,
@@ -107,6 +107,29 @@ pub fn bytearray_blit_from_string(
     let c = str[i].to_uint()
     self[j] = (c & 0xff).to_byte()
     self[j + 1] = (c >> 8).to_byte()
+  }
+}
+
+///|
+/// Copy `length` chars from byte sequence `src`, starting at `src_offset`,
+/// into byte sequence `self`, starting at `bytes_offset`.
+pub fn blit_from_bytes(
+  self : FixedArray[Byte],
+  bytes_offset : Int,
+  src : Bytes,
+  src_offset : Int,
+  length : Int
+) -> Unit {
+  let s1 = bytes_offset
+  let s2 = src_offset
+  let e1 = bytes_offset + length - 1
+  let e2 = src_offset + length - 1
+  let len1 = self.length()
+  let len2 = src.length()
+  guard length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
+  let end_src_offset = src_offset + length
+  for i = src_offset, j = bytes_offset; i < end_src_offset; i = i + 1, j = j + 1 {
+    self[j] = src[i]
   }
 }
 
@@ -173,7 +196,7 @@ pub fn set_utf16_char(self : Bytes, offset : Int, value : Char) -> Int {
 /// Fill utf16 encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
 /// @alert unsafe "Panic if the [value] is out of range"
-pub fn bytearray_set_utf16_char(
+pub fn set_utf16_char(
   self : FixedArray[Byte],
   offset : Int,
   value : Char

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -56,3 +56,20 @@ test "op_equal" {
   assert_eq!(bytes, copy_bytes)
   assert_not_eq!(bytes, Bytes::new(10))
 }
+
+test "fixedarray_byte_blit_from_string" {
+  let arr : FixedArray[Byte] = FixedArray::make(10, Byte::default())
+  let str = "Hello"
+  arr.blit_from_string(0, str, 0, str.length())
+  inspect!(
+    arr,
+    content="[b'\\x48', b'\\x00', b'\\x65', b'\\x00', b'\\x6C', b'\\x00', b'\\x6C', b'\\x00', b'\\x6F', b'\\x00']",
+  )
+}
+
+test "fixedarray_byte_blit_from_bytes" {
+  let arr : FixedArray[Byte] = FixedArray::make(5, Byte::default())
+  let bytes = b"Hello"
+  arr.blit_from_bytes(0, bytes, 0, bytes.length())
+  inspect!(arr, content="[b'\\x48', b'\\x65', b'\\x6C', b'\\x6C', b'\\x6F']")
+}

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -31,12 +31,13 @@ pub fn Bytes::from_array(arr : Array[Byte]) -> Bytes {
 
 ///|
 /// Makes a new Bytes from a fixedarray.
-pub fn Bytes::from_fixedarray(
-  arr : FixedArray[Byte],
-  len~ : Int = arr.length()
-) -> Bytes {
+pub fn Bytes::from_fixedarray(arr : FixedArray[Byte], len? : Int) -> Bytes {
+  let len = match len {
+    None => arr.length()
+    Some(x) => x
+  }
   let bytes = Bytes::new(len)
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     bytes[i] = arr[i]
   }
   bytes
@@ -44,12 +45,13 @@ pub fn Bytes::from_fixedarray(
 
 ///|
 /// Converts a Bytes to a fixedarray.
-pub fn Bytes::to_fixedarray(
-  self : Bytes,
-  len~ : Int = self.length()
-) -> FixedArray[Byte] {
+pub fn Bytes::to_fixedarray(self : Bytes, len? : Int) -> FixedArray[Byte] {
+  let len = match len {
+    None => self.length()
+    Some(x) => x
+  }
   let arr = FixedArray::make(len, Byte::default())
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     arr[i] = self[i]
   }
   arr

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -30,12 +30,12 @@ pub fn Bytes::from_array(arr : Array[Byte]) -> Bytes {
 }
 
 ///|
-/// Cast a fixedarray to bytes.
-/// @alert unstable "The behavior is subject to change. Use it only when you know what you are doing."
-// TODO: this will be replaced by an identity-like intrinsics
-pub fn Bytes::cast_from_fixedarray(arr : FixedArray[Byte]) -> Bytes {
-  let bytes = Bytes::new(arr.length())
-  let len = arr.length()
+/// Makes a new Bytes from a fixedarray.
+pub fn Bytes::from_fixedarray(
+  arr : FixedArray[Byte],
+  len~ : Int = arr.length()
+) -> Bytes {
+  let bytes = Bytes::new(len)
   for i = 0; i < len; i = i + 1 {
     bytes[i] = arr[i]
   }
@@ -43,11 +43,11 @@ pub fn Bytes::cast_from_fixedarray(arr : FixedArray[Byte]) -> Bytes {
 }
 
 ///|
-/// Cast a bytes to a fixedarray.
-/// @alert unstable "The behavior is subject to change. Use it only when you know what you are doing."
-// TODO: this will be replaced by an identity-like intrinsics
-pub fn Bytes::cast_to_fixedarray(self : Bytes) -> FixedArray[Byte] {
-  let len = self.length()
+/// Converts a Bytes to a fixedarray.
+pub fn Bytes::to_fixedarray(
+  self : Bytes,
+  len~ : Int = self.length()
+) -> FixedArray[Byte] {
   let arr = FixedArray::make(len, Byte::default())
   for i = 0; i < len; i = i + 1 {
     arr[i] = self[i]

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -30,6 +30,32 @@ pub fn Bytes::from_array(arr : Array[Byte]) -> Bytes {
 }
 
 ///|
+/// Cast a fixedarray to bytes.
+/// @alert unstable "The behavior is subject to change. Use it only when you know what you are doing."
+// TODO: this will be replaced by an identity-like intrinsics
+pub fn Bytes::cast_from_fixedarray(arr : FixedArray[Byte]) -> Bytes {
+  let bytes = Bytes::new(arr.length())
+  let len = arr.length()
+  for i = 0; i < len; i = i + 1 {
+    bytes[i] = arr[i]
+  }
+  bytes
+}
+
+///|
+/// Cast a bytes to a fixedarray.
+/// @alert unstable "The behavior is subject to change. Use it only when you know what you are doing."
+// TODO: this will be replaced by an identity-like intrinsics
+pub fn Bytes::cast_to_fixedarray(self : Bytes) -> FixedArray[Byte] {
+  let len = self.length()
+  let arr = FixedArray::make(len, Byte::default())
+  for i = 0; i < len; i = i + 1 {
+    arr[i] = self[i]
+  }
+  arr
+}
+
+///|
 pub fn Bytes::from_iter(iter : Iter[Byte]) -> Bytes {
   Bytes::from_array(iter.collect())
 }

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -6,6 +6,8 @@ package moonbitlang/core/bytes
 
 
 impl Bytes {
+  cast_from_fixedarray(FixedArray[Byte]) -> Bytes
+  cast_to_fixedarray(Bytes) -> FixedArray[Byte]
   default() -> Bytes
   from_array(Array[Byte]) -> Bytes
   from_iter(Iter[Byte]) -> Bytes

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -8,12 +8,12 @@ package moonbitlang/core/bytes
 impl Bytes {
   default() -> Bytes
   from_array(Array[Byte]) -> Bytes
-  from_fixedarray(FixedArray[Byte], len~ : Int = ..) -> Bytes
+  from_fixedarray(FixedArray[Byte], len? : Int) -> Bytes
   from_iter(Iter[Byte]) -> Bytes
   iter(Bytes) -> Iter[Byte]
   of(FixedArray[Byte]) -> Bytes
   to_array(Bytes) -> Array[Byte]
-  to_fixedarray(Bytes, len~ : Int = ..) -> FixedArray[Byte]
+  to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
 }
 
 // Type aliases

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -6,14 +6,14 @@ package moonbitlang/core/bytes
 
 
 impl Bytes {
-  cast_from_fixedarray(FixedArray[Byte]) -> Bytes
-  cast_to_fixedarray(Bytes) -> FixedArray[Byte]
   default() -> Bytes
   from_array(Array[Byte]) -> Bytes
+  from_fixedarray(FixedArray[Byte], len~ : Int = ..) -> Bytes
   from_iter(Iter[Byte]) -> Bytes
   iter(Bytes) -> Iter[Byte]
   of(FixedArray[Byte]) -> Bytes
   to_array(Bytes) -> Array[Byte]
+  to_fixedarray(Bytes, len~ : Int = ..) -> FixedArray[Byte]
 }
 
 // Type aliases


### PR DESCRIPTION
This refactor is a preparation for making `Bytes` immutable. It basically changes the use of `Bytes` in the type `Buffer` to `FixedArray[Byte]`, and added `Bytes::cast_from_fixedarray` and `cast_to_fixedarray` to convert between `Bytes` and `FixedArray[Byte]`. Currently, these casts need to allocate, and we plan to implement these casts as primitives in the compiler to avoid the allocation eventually.