### PR TITLE
Add append_fast and set methods to the array

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -172,6 +172,48 @@ pub fn append[T](self : Array[T], other : Array[T]) -> Unit {
 }
 
 ///|
+/// like append but faster than append implementation
+pub fn append_fast[T](self : Array[T], other : Array[T]) -> Unit {
+  if other.len == 0 {
+    return
+  }
+  let oldlen = self.len
+  let newLen = self.len + other.len
+  self.resize_buffer(newLen)
+  self.len = newLen
+  Array::unsafe_blit(self, oldlen, other, 0, other.len)
+}
+
+///|
+/// like blit
+/// copy the data of length len from the 'from' position of 'other' to the offset position of 'self' and overwrite it, 
+/// which will automatically expand the size
+pub fn set[T](
+  self : Array[T],
+  offset : Int,
+  other : Array[T],
+  from : Int,
+  len : Int
+) -> Unit {
+  if other.len == 0 {
+    return
+  }
+  let remain = other.len - from
+  if remain == 0 {
+    return
+  }
+  let len = if len >= remain { remain } else { len }
+  let offset = if offset < 0 || offset >= self.len { self.len } else { offset }
+  let oldlen = self.len
+  let newlen = offset + len
+  if oldlen < newlen {
+    self.resize_buffer(newlen)
+    self.len = newlen
+  }
+  Array::unsafe_blit(self, offset, other, from, len)
+}
+
+///|
 /// Iterates over the elements of the array.
 ///
 /// # Example

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -185,6 +185,35 @@ pub fn append_fast[T](self : Array[T], other : Array[T]) -> Unit {
 }
 
 ///|
+/// Appends select elements of other array into self
+pub fn appendex[T](
+  self : Array[T],
+  other : Array[T],
+  from : Int,
+  len : Int
+) -> Unit {
+  if from < 0 {
+    return
+  }
+  let remain = {
+    let l = other.len - from
+    if l < len {
+      len
+    } else {
+      l
+    }
+  }
+  if remain <= 0 {
+    return
+  }
+  let oldlen = self.len
+  let newLen = self.len + remain
+  self.resize_buffer(newLen)
+  self.len = newLen
+  Array::unsafe_blit(self, oldlen, other, from, remain)
+}
+
+///|
 /// like blit
 /// copy the data of length len from the 'from' position of 'other' to the offset position of 'self' and overwrite it, 
 /// which will automatically expand the size

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -193,7 +193,7 @@ pub fn append[T](
     return
   }
   let oldlen = self.len
-  let newLen = self.len + remain
+  let newLen = oldlen + remain
   self.resize_buffer(newLen)
   self.len = newLen
   Array::unsafe_blit(self, oldlen, other, from, remain)

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -154,6 +154,14 @@ pub fn op_add[T](self : Array[T], other : Array[T]) -> Array[T] {
   result
 }
 
+/// TODO: could be made more efficient doing direct mem.copy
+// pub fn append[T](self : Array[T], other : Array[T]) -> Unit {
+//   self.reserve_capacity(self.length() + other.length())
+//   for v in other {
+//     self.push(v)
+//   }
+// }
+
 ///|
 /// Appends all the elements of other array into self
 ///
@@ -163,41 +171,19 @@ pub fn op_add[T](self : Array[T], other : Array[T]) -> Array[T] {
 /// let v2 = [6, 7, 8]
 /// v1.append(v2)
 /// ```
-/// TODO: could be made more efficient doing direct mem.copy
-pub fn append[T](self : Array[T], other : Array[T]) -> Unit {
-  self.reserve_capacity(self.length() + other.length())
-  for v in other {
-    self.push(v)
-  }
-}
-
-///|
-/// like append but faster than append implementation
-pub fn append_fast[T](self : Array[T], other : Array[T]) -> Unit {
-  if other.len == 0 {
-    return
-  }
-  let oldlen = self.len
-  let newLen = self.len + other.len
-  self.resize_buffer(newLen)
-  self.len = newLen
-  Array::unsafe_blit(self, oldlen, other, 0, other.len)
-}
-
-///|
-/// Appends select elements of other array into self
-pub fn appendex[T](
+pub fn append[T](
   self : Array[T],
   other : Array[T],
-  from : Int,
-  len : Int
+  from~ : Int = 0,
+  len~ : Int = 0
 ) -> Unit {
   if from < 0 {
     return
   }
+  let len = if len <= 0 { other.len } else { len }
   let remain = {
     let l = other.len - from
-    if l < len {
+    if l > len {
       len
     } else {
       l
@@ -224,22 +210,7 @@ pub fn set[T](
   from : Int,
   len : Int
 ) -> Unit {
-  if other.len == 0 {
-    return
-  }
-  let remain = other.len - from
-  if remain == 0 {
-    return
-  }
-  let len = if len >= remain { remain } else { len }
-  let offset = if offset < 0 || offset >= self.len { self.len } else { offset }
-  let oldlen = self.len
-  let newlen = offset + len
-  if oldlen < newlen {
-    self.resize_buffer(newlen)
-    self.len = newlen
-  }
-  Array::unsafe_blit(self, offset, other, from, len)
+  other.blit_to(self, len~, src_offset=from, dst_offset=offset)
 }
 
 ///|

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -47,6 +47,24 @@ pub fn Array::unsafe_blit_fixed[A](
 }
 
 ///|
+// pub fn Array::blit_to[A](
+//   self : Array[A],
+//   dst : Array[A],
+//   len~ : Int,
+//   src_offset~ : Int = 0,
+//   dst_offset~ : Int = 0
+// ) -> Unit {
+//   guard len >= 0 &&
+//     dst_offset >= 0 &&
+//     src_offset >= 0 &&
+//     dst_offset + len <= dst.length() &&
+//     src_offset + len <= self.length()
+//   Array::unsafe_blit(dst, dst_offset, self, src_offset, len)
+// }
+
+///| 
+/// automatic expansion
+/// if dst_offset <0 || dst_offset>=dst.len will append
 pub fn Array::blit_to[A](
   self : Array[A],
   dst : Array[A],
@@ -54,11 +72,28 @@ pub fn Array::blit_to[A](
   src_offset~ : Int = 0,
   dst_offset~ : Int = 0
 ) -> Unit {
-  guard len >= 0 &&
-    dst_offset >= 0 &&
-    src_offset >= 0 &&
-    dst_offset + len <= dst.length() &&
-    src_offset + len <= self.length()
+  if self.len == 0 || src_offset >= self.len || src_offset < 0 {
+    return
+  }
+  let len = {
+    let remain = self.len - src_offset
+    if len >= remain {
+      remain
+    } else {
+      len
+    }
+  }
+  let oldlen = dst.len
+  let dst_offset = if dst_offset < 0 || dst_offset >= oldlen {
+    dst.len
+  } else {
+    dst_offset
+  }
+  let newlen = dst_offset + len
+  if oldlen < newlen {
+    dst.resize_buffer(newlen)
+    dst.len = newlen
+  }
   Array::unsafe_blit(dst, dst_offset, self, src_offset, len)
 }
 

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -571,14 +571,11 @@ test "array_dedup - edge cases" {
 test "append_fast" {
   let b : Array[Byte] = [1, 3, 6]
   let b2 : Array[Byte] = [7, 8, 9]
-  b.append_fast(b2)
+  b.append(b2)
   assert_eq!(b, [1, 3, 6, 7, 8, 9])
-}
-
-test "appendex" {
   let b : Array[Byte] = [1, 3, 6]
   let b2 : Array[Byte] = [7, 8, 9, 10, 11]
-  b.appendex(b2, 2, 3)
+  b.append(b2, from=2, len=3)
   assert_eq!(b, [1, 3, 6, 9, 10, 11])
 }
 

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -575,6 +575,13 @@ test "append_fast" {
   assert_eq!(b, [1, 3, 6, 7, 8, 9])
 }
 
+test "appendex" {
+  let b : Array[Byte] = [1, 3, 6]
+  let b2 : Array[Byte] = [7, 8, 9, 10, 11]
+  b.appendex(b2, 2, 3)
+  assert_eq!(b, [1, 3, 6, 9, 10, 11])
+}
+
 test "set" {
   let b : Array[Byte] = [1, 3, 6]
   let b2 : Array[Byte] = [4, 5, 6, 7, 8, 9]

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -568,6 +568,20 @@ test "array_dedup - edge cases" {
   inspect!(array, content="[1, 2, 3, 4, 5]")
 }
 
+test "append_fast" {
+  let b : Array[Byte] = [1, 3, 6]
+  let b2 : Array[Byte] = [7, 8, 9]
+  b.append_fast(b2)
+  assert_eq!(b, [1, 3, 6, 7, 8, 9])
+}
+
+test "set" {
+  let b : Array[Byte] = [1, 3, 6]
+  let b2 : Array[Byte] = [4, 5, 6, 7, 8, 9]
+  b.set(2, b2, 2, 3)
+  assert_eq!(b, [1, 3, 6, 7, 8])
+}
+
 ///|
 struct MX {
   mm_num : Array[Int]

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -47,6 +47,7 @@ type Array
 impl Array {
   append[T](Self[T], Self[T]) -> Unit
   append_fast[T](Self[T], Self[T]) -> Unit
+  appendex[T](Self[T], Self[T], Int, Int) -> Unit
   binary_search[T : Compare + Eq](Self[T], T) -> Result[Int, Int]
   binary_search_by[T](Self[T], (T) -> Int) -> Result[Int, Int]
   blit_to[A](Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -46,6 +46,7 @@ impl Show for ArgsLoc
 type Array
 impl Array {
   append[T](Self[T], Self[T]) -> Unit
+  append_fast[T](Self[T], Self[T]) -> Unit
   binary_search[T : Compare + Eq](Self[T], T) -> Result[Int, Int]
   binary_search_by[T](Self[T], (T) -> Int) -> Result[Int, Int]
   blit_to[A](Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit
@@ -106,6 +107,7 @@ impl Array {
   rev_inplace[T](Self[T]) -> Unit
   search[T : Eq](Self[T], T) -> Int?
   search_by[T](Self[T], (T) -> Bool) -> Int?
+  set[T](Self[T], Int, Self[T], Int, Int) -> Unit
   shrink_to_fit[T](Self[T]) -> Unit
   split[T](Self[T], (T) -> Bool) -> Self[Self[T]]
   split_at[T](Self[T], Int) -> (Self[T], Self[T])

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -45,9 +45,7 @@ impl Show for ArgsLoc
 
 type Array
 impl Array {
-  append[T](Self[T], Self[T]) -> Unit
-  append_fast[T](Self[T], Self[T]) -> Unit
-  appendex[T](Self[T], Self[T], Int, Int) -> Unit
+  append[T](Self[T], Self[T], from~ : Int = .., len~ : Int = ..) -> Unit
   binary_search[T : Compare + Eq](Self[T], T) -> Result[Int, Int]
   binary_search_by[T](Self[T], (T) -> Int) -> Result[Int, Int]
   blit_to[A](Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit


### PR DESCRIPTION
I have looked at the methods of batch adding arrays to array, and they all directly use push to add them one by one. This method is not a problem when dealing with small amounts of data, but when dealing with large amounts of data, it can be time-consuming. Recently, [when implementing msgpack encoding](https://github.com/suiyunonghen/moonvalue), I have been trying to find out if there is an efficient batch operation function in the core library. Blit is what I need, but I found that it limits the length of the array. Therefore, I adjusted two functions based on the relevant code, both of which can automatically expand and use batch operation functions, thus reducing the instruction count