### PR TITLE
hongbo/use dot syntax

### DIFF
--- a/bool/bool_test.mbt
+++ b/bool/bool_test.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 test "Bool hash function" {
-  assert_eq!(Hash::hash(true), 1)
-  assert_eq!(Hash::hash(false), 0)
+  assert_eq!(true.hash(), 1)
+  assert_eq!(false.hash(), 0)
 }
 
 ///|

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -733,7 +733,7 @@ test "remove_entry_head" {
   // This should ensure the head is updated correctly
   assert_eq!(
     map.head,
-    Some({ idx: 1, psl: 0, hash: Hash::hash(2), key: 2, value: 2 }),
+    Some({ idx: 1, psl: 0, hash: (2).hash(), key: 2, value: 2 }),
   )
 }
 
@@ -745,7 +745,7 @@ test "remove_entry_tail" {
   // This should ensure the tail is updated correctly
   assert_eq!(
     map.tail,
-    Some(Entry::{ idx: 0, psl: 0, hash: Hash::hash(1), key: 1, value: 1 }),
+    Some(Entry::{ idx: 0, psl: 0, hash: (1).hash(), key: 1, value: 1 }),
   )
 }
 

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -79,13 +79,13 @@ test "hash" {
   let b4 = @bytes.of(
     [b'\x7f', b'\xff', b'\xff', b'\xff', b'\xff', b'\xff', b'\xff', b'\xff'],
   )
-  inspect!(Hash::hash(b1), content="273427599")
-  inspect!(Hash::hash(b2), content="2013728637")
-  inspect!(Hash::hash(b3), content="-983520567")
-  inspect!(Hash::hash(b4), content="-1652773543")
-  inspect!(Hash::hash(b1) == Hash::hash(b1), content="true")
-  inspect!(Hash::hash(b2) == Hash::hash(b2), content="true")
-  inspect!(Hash::hash(b1) == Hash::hash(b2), content="false")
+  inspect!(b1.hash(), content="273427599")
+  inspect!(b2.hash(), content="2013728637")
+  inspect!(b3.hash(), content="-983520567")
+  inspect!(b4.hash(), content="-1652773543")
+  inspect!(b1.hash() == b1.hash(), content="true")
+  inspect!(b2.hash() == b2.hash(), content="true")
+  inspect!(b1.hash() == b2.hash(), content="false")
 }
 
 test "to_array" {

--- a/double/double_test.mbt
+++ b/double/double_test.mbt
@@ -16,9 +16,9 @@ test "hash" {
   let d1 = 123.456
   let d2 = 789.012
   let d3 = 123.456
-  assert_eq!(Hash::hash(d1), d1.reinterpret_as_int64() |> Hash::hash())
-  assert_not_eq!(Hash::hash(d1), Hash::hash(d2))
-  assert_eq!(Hash::hash(d1), Hash::hash(d3))
+  assert_eq!(d1.hash(), d1.reinterpret_as_int64() |> Hash::hash())
+  assert_not_eq!(d1.hash(), d2.hash())
+  assert_eq!(d1.hash(), d3.hash())
 }
 
 test "is_close" {

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -215,10 +215,10 @@ test "from_iter empty iter" {
 test "hash" {
   let l1 = @array.of([1, 2, 3, 4, 5])
   let l2 = @array.of([1, 2, 3, 4, 5])
-  inspect!(Hash::hash(l1) == Hash::hash(l2), content="true")
+  inspect!(l1.hash() == l2.hash(), content="true")
   let l3 = @array.of([5, 4, 3, 2, 1])
-  inspect!(Hash::hash(l1) == Hash::hash(l3), content="false")
+  inspect!(l1.hash() == l3.hash(), content="false")
   let l4 : @array.T[Int] = @array.of([])
-  inspect!(Hash::hash(l1) == Hash::hash(l4), content="false")
-  inspect!(Hash::hash(l4) == Hash::hash(l4), content="true")
+  inspect!(l1.hash() == l4.hash(), content="false")
+  inspect!(l4.hash() == l4.hash(), content="true")
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -181,9 +181,9 @@ test "eq for random cases with different types" {
 test "hash" {
   let map1 = @hashmap.T::of([("one", 1), ("two", 2)])
   let map2 = @hashmap.T::of([("one", 1), ("two", 2)])
-  inspect!(Hash::hash(map1) == Hash::hash(map2), content="true")
+  inspect!(map1.hash() == map2.hash(), content="true")
   let map3 = @hashmap.T::of([("two", 2), ("one", 1)])
-  inspect!(Hash::hash(map1) == Hash::hash(map3), content="true")
+  inspect!(map1.hash() == map3.hash(), content="true")
   let map4 = @hashmap.T::of([("one", 1), ("two", 2), ("three", 3)])
-  inspect!(Hash::hash(map1) == Hash::hash(map4), content="false")
+  inspect!(map1.hash() == map4.hash(), content="false")
 }

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -601,10 +601,10 @@ test "from_iter empty iter" {
 test "hash" {
   let l1 = @list.of([1, 2, 3, 4, 5])
   let l2 = @list.of([1, 2, 3, 4, 5])
-  inspect!(Hash::hash(l1) == Hash::hash(l2), content="true")
+  inspect!(l1.hash() == l2.hash(), content="true")
   let l3 = @list.of([5, 4, 3, 2, 1])
-  inspect!(Hash::hash(l1) == Hash::hash(l3), content="false")
+  inspect!(l1.hash() == l3.hash(), content="false")
   let l4 : @list.T[Int] = @list.of([])
-  inspect!(Hash::hash(l1) == Hash::hash(l4), content="false")
-  inspect!(Hash::hash(l4) == Hash::hash(l4), content="true")
+  inspect!(l1.hash() == l4.hash(), content="false")
+  inspect!(l4.hash() == l4.hash(), content="true")
 }

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -126,14 +126,14 @@ test "from_iter empty iter" {
 test "hash" {
   let pq1 = @priority_queue.of([1, 2, 3, 4, 5])
   let pq2 = @priority_queue.of([1, 2, 3, 4, 5])
-  inspect!(Hash::hash(pq1) == Hash::hash(pq2), content="true")
+  inspect!(pq1.hash() == pq2.hash(), content="true")
   let pq3 = @priority_queue.of([5, 4, 3, 2, 1])
-  inspect!(Hash::hash(pq1) == Hash::hash(pq3), content="true")
+  inspect!(pq1.hash() == pq3.hash(), content="true")
   let pq4 : @priority_queue.T[Int] = @priority_queue.new()
-  inspect!(Hash::hash(pq1) == Hash::hash(pq4), content="false")
-  inspect!(Hash::hash(pq4) == Hash::hash(pq4), content="true")
+  inspect!(pq1.hash() == pq4.hash(), content="false")
+  inspect!(pq4.hash() == pq4.hash(), content="true")
   let pq5 = @priority_queue.of([1, 2, 3, 4, 6])
-  inspect!(Hash::hash(pq1) == Hash::hash(pq5), content="false")
+  inspect!(pq1.hash() == pq5.hash(), content="false")
 }
 
 test "equal" {

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -175,9 +175,9 @@ test "from_iter empty iter" {
 test "hash" {
   let map1 = @sorted_map.T::of([("one", 1), ("two", 2)])
   let map2 = @sorted_map.T::of([("one", 1), ("two", 2)])
-  inspect!(Hash::hash(map1) == Hash::hash(map2), content="true")
+  inspect!(map1.hash() == map2.hash(), content="true")
   let map3 = @sorted_map.T::of([("two", 2), ("one", 1)])
-  inspect!(Hash::hash(map1) == Hash::hash(map3), content="true")
+  inspect!(map1.hash() == map3.hash(), content="true")
   let map4 = @sorted_map.T::of([("one", 1), ("two", 2), ("three", 3)])
-  inspect!(Hash::hash(map1) == Hash::hash(map4), content="false")
+  inspect!(map1.hash() == map4.hash(), content="false")
 }

--- a/int/int_test.mbt
+++ b/int/int_test.mbt
@@ -24,17 +24,17 @@ test "overflow" {
 }
 
 test "hash" {
-  inspect!(Hash::hash(0), content="0")
-  inspect!(Hash::hash(1), content="69681622")
-  inspect!(Hash::hash(2), content="-236984087")
-  inspect!(Hash::hash(3), content="-1057966777")
-  inspect!(Hash::hash(4), content="-744398955")
-  inspect!(Hash::hash(5), content="-482482911")
-  inspect!(Hash::hash(6), content="-1506254959")
-  inspect!(Hash::hash(7), content="1327878809")
-  inspect!(Hash::hash(8), content="1120898975")
-  inspect!(Hash::hash(9), content="1567958539")
-  inspect!(Hash::hash(0x7fffffff), content="943411498")
+  inspect!((0).hash(), content="0")
+  inspect!((1).hash(), content="69681622")
+  inspect!((2).hash(), content="-236984087")
+  inspect!((3).hash(), content="-1057966777")
+  inspect!((4).hash(), content="-744398955")
+  inspect!((5).hash(), content="-482482911")
+  inspect!((6).hash(), content="-1506254959")
+  inspect!((7).hash(), content="1327878809")
+  inspect!((8).hash(), content="1120898975")
+  inspect!((9).hash(), content="1567958539")
+  inspect!((0x7fffffff).hash(), content="943411498")
   inspect!(Hash::hash(0x7fffffff + 1), content="963800214")
 }
 

--- a/int64/xxhash.mbt
+++ b/int64/xxhash.mbt
@@ -66,7 +66,7 @@ fn slow_hash(self : Int64) -> Int {
   b[2] = ((self >> 16) & 0xFF).to_byte()
   b[1] = ((self >> 8) & 0xFF).to_byte()
   b[0] = (self & 0xFF).to_byte()
-  Hash::hash(b)
+  b.hash()
 }
 
 test "int64 hash" {
@@ -77,11 +77,11 @@ test "int64 hash" {
   let i4 = gPRIME4.to_int64()
   let i5 = gPRIME5.to_int64()
   let i6 = 0L
-  inspect!(Hash::hash(i0).to_string(), content=i0.slow_hash().to_string())
-  inspect!(Hash::hash(i1).to_string(), content=i1.slow_hash().to_string())
-  inspect!(Hash::hash(i2).to_string(), content=i2.slow_hash().to_string())
-  inspect!(Hash::hash(i3).to_string(), content=i3.slow_hash().to_string())
-  inspect!(Hash::hash(i4).to_string(), content=i4.slow_hash().to_string())
-  inspect!(Hash::hash(i5).to_string(), content=i5.slow_hash().to_string())
-  inspect!(Hash::hash(i6).to_string(), content=i6.slow_hash().to_string())
+  inspect!(i0.hash().to_string(), content=i0.slow_hash().to_string())
+  inspect!(i1.hash().to_string(), content=i1.slow_hash().to_string())
+  inspect!(i2.hash().to_string(), content=i2.slow_hash().to_string())
+  inspect!(i3.hash().to_string(), content=i3.slow_hash().to_string())
+  inspect!(i4.hash().to_string(), content=i4.slow_hash().to_string())
+  inspect!(i5.hash().to_string(), content=i5.slow_hash().to_string())
+  inspect!(i6.hash().to_string(), content=i6.slow_hash().to_string())
 }

--- a/unit/unit_test.mbt
+++ b/unit/unit_test.mbt
@@ -38,5 +38,5 @@ test {
 
 test {
   let unit = ()
-  assert_eq!(Hash::hash(unit), 0)
+  assert_eq!(unit.hash(), 0)
 }


### PR DESCRIPTION
This pull request includes updates to various test files to replace the `Hash::hash` function calls with the `.hash()` method for consistency and readability.

Changes to hash function calls:

* [`bool/bool_test.mbt`](diffhunk://#diff-50c9897a87e4840f63d50f1c387812672fd2ded44347bc68a9e5a97cebc760c2L16-R17): Updated `Bool hash function` test to use `.hash()` method instead of `Hash::hash`.
* [`bytes/bytes_test.mbt`](diffhunk://#diff-14a7713b2fb77c60fa756aefa048230f4c8e84f40b4b63b3c9580213cfa07ceeL82-R88): Updated `hash` test to use `.hash()` method instead of `Hash::hash`.
* [`double/double_test.mbt`](diffhunk://#diff-f0be8cf6065fff36a23d0c1bd5e1df3ca36fc90052ffc092b54027743d66895cL19-R21): Updated `hash` test to use `.hash()` method instead of `Hash::hash`.
* [`int/int_test.mbt`](diffhunk://#diff-d3f2d24796c5c6d47193176f4f30c5bef490a78b15063be9fe6c3832af64e31aL27-R37): Updated `hash` test to use `.hash()` method instead of `Hash::hash`.
* [`unit/unit_test.mbt`](diffhunk://#diff-a37b0a4cad1c15a641353661bc8149a1940312155423307643e7481accacb56cL41-R41): Updated test to use `.hash()` method instead of `Hash::hash`.

Other updates include similar changes to hash function calls in multiple test files for collections and data structures.