### PR TITLE
remove some no longer needed wrapper methods

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1030,12 +1030,6 @@ pub fn split[T](self : Array[T], pred : (T) -> Bool) -> Array[Array[T]] {
 }
 
 ///|
-/// Converts the array to a string.
-pub fn to_string[T : Show](self : Array[T]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub fn iter[T](self : Array[T]) -> Iter[T] {
   Iter::new(
     fn(yield_) {

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -113,7 +113,6 @@ impl Array {
   strip_suffix[T : Eq](Self[T], Self[T]) -> Self[T]?
   swap[T](Self[T], Int, Int) -> Unit
   to_json[X : ToJson](Self[X]) -> Json
-  to_string[T : Show](Self[T]) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
   unsafe_pop[T](Self[T]) -> T
@@ -244,7 +243,6 @@ impl Iter {
   take_while[T](Self[T], (T) -> Bool) -> Self[T]
   tap[T](Self[T], (T) -> Unit) -> Self[T] //deprecated
   to_array[T](Self[T]) -> Array[T]
-  to_string[T : Show](Self[T]) -> String
 }
 impl[T : Show] Show for Iter[T]
 
@@ -256,7 +254,6 @@ impl Iter2 {
   new[A, B](((A, B) -> IterResult) -> IterResult) -> Self[A, B]
   run[A, B](Self[A, B], (A, B) -> IterResult) -> IterResult
   to_array[A, B](Self[A, B]) -> Array[(A, B)]
-  to_string[A : Show, B : Show](Self[A, B]) -> String
 }
 impl[A : Show, B : Show] Show for Iter2[A, B]
 
@@ -311,7 +308,6 @@ impl Map {
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
   to_json[K : Show, V : ToJson](Self[K, V]) -> Json
-  to_string[K : Show, V : Show](Self[K, V]) -> String
   values[K, V](Self[K, V]) -> Iter[V]
 }
 impl[K : Show, V : Show] Show for Map[K, V]
@@ -341,7 +337,6 @@ impl Set {
   symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   to_array[K](Self[K]) -> Array[K]
   to_json[X : ToJson](Self[X]) -> Json
-  to_string[K : Show](Self[K]) -> String
   union[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
 }
 impl[K : Show] Show for Set[K]
@@ -669,7 +664,6 @@ impl FixedArray {
   set[T](Self[T], Int, T) -> Unit
   set_utf16_char(Self[Byte], Int, Char) -> Int
   to_json[X : ToJson](Self[X]) -> Json
-  to_string[X : Show](Self[X]) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
 }
 
@@ -702,105 +696,90 @@ impl Logger {
 impl Tuple(2) {
   compare[T0 : Compare, T1 : Compare]((T0, T1), (T0, T1)) -> Int
   op_equal[T0 : Eq, T1 : Eq]((T0, T1), (T0, T1)) -> Bool
-  to_string[A : Show, B : Show]((A, B)) -> String
 }
 
 
 impl Tuple(3) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare]((T0, T1, T2), (T0, T1, T2)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq]((T0, T1, T2), (T0, T1, T2)) -> Bool
-  to_string[A : Show, B : Show, C : Show]((A, B, C)) -> String
 }
 
 
 impl Tuple(4) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare]((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq]((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
-  to_string[A : Show, B : Show, C : Show, D : Show]((A, B, C, D)) -> String
 }
 
 
 impl Tuple(5) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare]((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq]((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
-  to_string[A : Show, B : Show, C : Show, D : Show, E : Show]((A, B, C, D, E)) -> String
 }
 
 
 impl Tuple(6) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare]((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq]((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
-  to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show]((A, B, C, D, E, F)) -> String
 }
 
 
 impl Tuple(7) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare]((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq]((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
-  to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show]((A, B, C, D, E, F, G)) -> String
 }
 
 
 impl Tuple(8) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show]((T0, T1, T2, T3, T4, T5, T6, T7)) -> String
 }
 
 
 impl Tuple(9) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> String
 }
 
 
 impl Tuple(10) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> String
 }
 
 
 impl Tuple(11) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> String
 }
 
 
 impl Tuple(12) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> String
 }
 
 
 impl Tuple(13) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> String
 }
 
 
 impl Tuple(14) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> String
 }
 
 
 impl Tuple(15) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> String
 }
 
 
 impl Tuple(16) {
   compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Int
   op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
-  to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> String
 }
 
 // Type aliases

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -42,11 +42,6 @@ pub fn iter2[T](self : FixedArray[T]) -> Iter2[Int, T] {
 }
 
 ///|
-pub fn to_string[X : Show](self : FixedArray[X]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub fn FixedArray::default[X]() -> FixedArray[X] {
   []
 }

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -38,11 +38,6 @@ pub impl[T : Show] Show for Iter[T] with output(self, logger) {
   logger.write_iter(self)
 }
 
-///|
-pub fn to_string[T : Show](self : Iter[T]) -> String {
-  Show::to_string(self)
-}
-
 // Consumers
 
 ///|

--- a/builtin/iter2.mbt
+++ b/builtin/iter2.mbt
@@ -49,11 +49,6 @@ pub impl[A : Show, B : Show] Show for Iter2[A, B] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[A : Show, B : Show](self : Iter2[A, B]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub fn Iter2::new[A, B](
   f : ((A, B) -> IterResult) -> IterResult
 ) -> Iter2[A, B] {

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -372,11 +372,6 @@ pub impl[K : Show, V : Show] Show for Map[K, V] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[K : Show, V : Show](self : Map[K, V]) -> String {
-  Show::to_string(self)
-}
-
-///|
 /// Get the number of key-value pairs in the map.
 pub fn size[K, V](self : Map[K, V]) -> Int {
   self.size

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -355,11 +355,6 @@ pub impl[K : Show] Show for Set[K] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[K : Show](self : Set[K]) -> String {
-  Show::to_string(self)
-}
-
-///|
 /// Get the number of keys in the set.
 pub fn size[K](self : Set[K]) -> Int {
   self.size

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -77,12 +77,6 @@ pub(open) trait Show {
   // By default `to_string` is implemented using `output` and a buffer,
   // but some types, such as `String`, may override `to_string`,
   // for different (unescaped) behavior when interpolated/printed directly
-  //
-  // By default, `to_string` cannot be called via dot directly.
-  // If implementors of `Show` wants to allow `.to_string()` usage,
-  // they should create a method wrapper manually:
-  //
-  //    fn to_string(self : T) -> String { Show::to_string(self) }
   to_string(Self) -> String
 }
 

--- a/builtin/tuple_show.mbt
+++ b/builtin/tuple_show.mbt
@@ -24,11 +24,6 @@ pub impl[A : Show, B : Show] Show for (A, B) with output(self, logger) {
 }
 
 ///|
-pub fn to_string[A : Show, B : Show](self : (A, B)) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[A : Show, B : Show, C : Show] Show for (A, B, C) with output(
   self,
   logger
@@ -42,11 +37,6 @@ pub impl[A : Show, B : Show, C : Show] Show for (A, B, C) with output(
   ..write_string(", ")
   ..write_object(c)
   .write_string(")")
-}
-
-///|
-pub fn to_string[A : Show, B : Show, C : Show](self : (A, B, C)) -> String {
-  Show::to_string(self)
 }
 
 ///|
@@ -65,13 +55,6 @@ pub impl[A : Show, B : Show, C : Show, D : Show] Show for (A, B, C, D) with outp
   ..write_string(", ")
   ..write_object(d)
   .write_string(")")
-}
-
-///|
-pub fn to_string[A : Show, B : Show, C : Show, D : Show](
-  self : (A, B, C, D)
-) -> String {
-  Show::to_string(self)
 }
 
 ///|
@@ -98,13 +81,6 @@ pub impl[A : Show, B : Show, C : Show, D : Show, E : Show] Show for (
 }
 
 ///|
-pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show](
-  self : (A, B, C, D, E)
-) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Show for (
   A,
   B,
@@ -128,13 +104,6 @@ pub impl[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Show for (
   ..write_string(", ")
   ..write_object(f)
   .write_string(")")
-}
-
-///|
-pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show](
-  self : (A, B, C, D, E, F)
-) -> String {
-  Show::to_string(self)
 }
 
 ///|
@@ -167,13 +136,6 @@ pub impl[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show] S
 }
 
 ///|
-pub fn to_string[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show](
-  self : (A, B, C, D, E, F, G)
-) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show] Show for (
   T0,
   T1,
@@ -203,13 +165,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
   ..write_string(", ")
   ..write_object(x7)
   .write_string(")")
-}
-
-///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7)
-) -> String {
-  Show::to_string(self)
 }
 
 ///|
@@ -248,13 +203,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
 }
 
 ///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8)
-) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show] Show for (
   T0,
   T1,
@@ -290,13 +238,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
   ..write_string(", ")
   ..write_object(x9)
   .write_string(")")
-}
-
-///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
-) -> String {
-  Show::to_string(self)
 }
 
 ///|
@@ -341,13 +282,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
 }
 
 ///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show] Show for (
   T0,
   T1,
@@ -389,13 +323,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
   ..write_string(", ")
   ..write_object(x11)
   .write_string(")")
-}
-
-///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-) -> String {
-  Show::to_string(self)
 }
 
 ///|
@@ -446,13 +373,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
 }
 
 ///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show] Show for (
   T0,
   T1,
@@ -500,13 +420,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
   ..write_string(", ")
   ..write_object(x13)
   .write_string(")")
-}
-
-///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-) -> String {
-  Show::to_string(self)
 }
 
 ///|
@@ -563,13 +476,6 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
 }
 
 ///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show] Show for (
   T0,
   T1,
@@ -623,11 +529,4 @@ pub impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : 
   ..write_string(", ")
   ..write_object(x15)
   .write_string(")")
-}
-
-///|
-pub fn to_string[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show](
-  self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-) -> String {
-  Show::to_string(self)
 }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -50,11 +50,6 @@ pub impl Show for CoverageCounter with output(self, logger) {
 }
 
 ///|
-pub fn to_string(self : CoverageCounter) -> String {
-  Show::to_string(self)
-}
-
-///|
 priv enum MList[T] {
   MNil
   MCons(T, MList[T])

--- a/coverage/coverage.mbti
+++ b/coverage/coverage.mbti
@@ -10,7 +10,6 @@ type CoverageCounter
 impl CoverageCounter {
   incr(Self, Int) -> Unit
   new(Int) -> Self
-  to_string(Self) -> String
 }
 impl Show for CoverageCounter
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -24,11 +24,6 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[A : Show](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 /// Creates a new deque from an array.
 pub fn T::from_array[A](arr : Array[A]) -> T[A] {
   let deq = T::{

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -35,7 +35,6 @@ impl T {
   rev_eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   search[A : Eq](Self[A], A) -> Int?
   shrink_to_fit[A](Self[A]) -> Unit
-  to_string[A : Show](Self[A]) -> String
   unsafe_pop_back[A](Self[A]) -> Unit
   unsafe_pop_front[A](Self[A]) -> Unit
 }

--- a/float/float.mbt
+++ b/float/float.mbt
@@ -40,11 +40,6 @@ pub fn abs(self : Float) -> Float {
 }
 
 ///|
-pub fn to_string(self : Float) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl Show for Float with output(self, logger) {
   logger.write_string(self.to_double().to_string())
 }

--- a/float/float.mbti
+++ b/float/float.mbti
@@ -24,7 +24,6 @@ impl Float {
   floor(Float) -> Float
   ln(Float) -> Float
   round(Float) -> Float
-  to_string(Float) -> String
   trunc(Float) -> Float
 }
 

--- a/hashmap/hashmap.mbti
+++ b/hashmap/hashmap.mbti
@@ -26,7 +26,6 @@ impl T {
   set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
-  to_string[K : Show, V : Show](Self[K, V]) -> String
 }
 impl[K : Show, V : Show] Show for T[K, V]
 impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[K, V]

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -136,8 +136,3 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
   )
   logger.write_string("])")
 }
-
-///|
-pub fn to_string[K : Show, V : Show](self : T[K, V]) -> String {
-  Show::to_string(self)
-}

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -334,12 +334,6 @@ pub impl[K : Show] Show for T[K] with output(self, logger) {
 }
 
 ///|
-// Reuse the default implementation of [Show::to_string] here
-pub fn to_string[K : Show](self : T[K]) -> String {
-  Show::to_string(self)
-}
-
-///|
 priv type MyString String derive(Eq)
 
 ///|

--- a/hashset/hashset.mbti
+++ b/hashset/hashset.mbti
@@ -25,7 +25,6 @@ impl T {
   remove[K : Hash + Eq](Self[K], K) -> Unit
   size[K](Self[K]) -> Int
   symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
-  to_string[K : Show](Self[K]) -> String
   union[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
 }
 impl[K : Show] Show for T[K]

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -24,11 +24,6 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[A : Show](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub fn is_empty[A](self : T[A]) -> Bool {
   self.size == 0
 }

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -28,7 +28,6 @@ impl T {
   rev_fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
   set[A](Self[A], Int, A) -> Self[A]
   to_array[A](Self[A]) -> Array[A]
-  to_string[A : Show](Self[A]) -> String
 }
 impl[A : Eq] Eq for T[A]
 impl[A : Hash] Hash for T[A]

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -227,11 +227,6 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[K : Show, V : Show](self : T[K, V]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub fn T::from_array[K : Eq + Hash, V](arr : Array[(K, V)]) -> T[K, V] {
   loop arr.length(), T::new() {
     0, map => map

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -18,7 +18,6 @@ impl T {
   op_get[K : Eq + Hash, V](Self[K, V], K) -> V?
   remove[K : Eq + Hash, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
-  to_string[K : Show, V : Show](Self[K, V]) -> String
 }
 impl[K : Eq + Hash, V : Eq] Eq for T[K, V]
 impl[K : Hash, V : Hash] Hash for T[K, V]

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -220,11 +220,6 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[A : Show](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub fn T::from_array[A : Eq + Hash](arr : Array[A]) -> T[A] {
   loop arr.length(), T::new() {
     0, set => set

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -18,7 +18,6 @@ impl T {
   of[A : Eq + Hash](FixedArray[A]) -> Self[A]
   remove[A : Eq + Hash](Self[A], A) -> Self[A]
   size[A](Self[A]) -> Int
-  to_string[A : Show](Self[A]) -> String
 }
 impl[A : Eq] Eq for T[A]
 impl[A : Hash] Hash for T[A]

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -235,11 +235,6 @@ pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X] wit
 }
 
 ///|
-pub fn to_string[A : Show + Compare](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[A : Compare] Eq for T[A] with op_equal(self, other) {
   self.length() == other.length() && self.to_array() == other.to_array()
 }

--- a/immut/priority_queue/priority_queue.mbti
+++ b/immut/priority_queue/priority_queue.mbti
@@ -19,7 +19,6 @@ impl T {
   pop_exn[A : Compare](Self[A]) -> Self[A] //deprecated
   push[A : Compare](Self[A], A) -> Self[A]
   to_array[A : Compare](Self[A]) -> Array[A]
-  to_string[A : Show + Compare](Self[A]) -> String
   unsafe_pop[A : Compare](Self[A]) -> Self[A]
 }
 impl[A : Compare] Eq for T[A]

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -37,7 +37,6 @@ impl T {
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
   to_json[K : Show, V : ToJson](Self[K, V]) -> Json
-  to_string[K : Show, V : Show](Self[K, V]) -> String
 }
 impl[K : Eq, V : Eq] Eq for T[K, V]
 impl[K : Hash, V : Hash] Hash for T[K, V]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -279,11 +279,6 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[K : Show, V : Show](self : T[K, V]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[K : Show, V : ToJson] ToJson for T[K, V] with to_json(self) {
   let capacity = self.size()
   guard capacity != 0 else { return Object(Map::new()) }

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -528,11 +528,6 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[A : Show](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[A : ToJson] ToJson for T[A] with to_json(self) {
   let capacity = self.iter().count()
   guard capacity != 0 else { return Array([]) }

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -40,7 +40,6 @@ impl T {
   subset[A : Compare](Self[A], Self[A]) -> Bool
   to_array[A : Compare](Self[A]) -> Array[A]
   to_json[A : ToJson](Self[A]) -> Json
-  to_string[A : Show](Self[A]) -> String
   union[A : Compare](Self[A], Self[A]) -> Self[A]
 }
 impl[A : Default] Default for T[A]

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -59,7 +59,6 @@ impl Json {
   item(Self, Int) -> Self?
   stringify(Self, escape_slash~ : Bool = .., indent~ : Int = ..) -> String
   to_json(Self) -> Self
-  to_string(Self) -> String
   value(Self, String) -> Self?
 }
 

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -48,16 +48,6 @@ pub impl Show for ParseError with output(self, logger) {
   logger.write_string(self.to_string())
 }
 
-// pub fn ParseError::to_string(self : ParseError) -> String {
-//   match self {
-//     ParseError(e) => e.to_string()
-//   }
-// }
-
-// pub impl Show for ParseError with output(self, logger) {
-//   logger.write_string(self.to_string())
-// }
-
 ///|
 pub impl Show for JsonValue with output(self, logger) {
   match self {
@@ -85,9 +75,4 @@ pub impl Show for JsonValue with output(self, logger) {
       logger.write_string(")")
     }
   }
-}
-
-///|
-pub fn to_string(self : JsonValue) -> String {
-  Show::to_string(self)
 }

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -283,11 +283,6 @@ pub impl[A : Show + Compare] Show for T[A] with output(self, logger) {
 }
 
 ///|
-pub fn to_string[A : Show + Compare](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X] with arbitrary(
   size,
   rs

--- a/priority_queue/priority_queue.mbti
+++ b/priority_queue/priority_queue.mbti
@@ -21,7 +21,6 @@ impl T {
   pop_exn[A : Compare](Self[A]) -> Unit //deprecated
   push[A : Compare](Self[A], A) -> Unit
   to_array[A : Compare](Self[A]) -> Array[A]
-  to_string[A : Show + Compare](Self[A]) -> String
   unsafe_pop[A : Compare](Self[A]) -> Unit
 }
 impl[A : Show + Compare] Show for T[A]

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -53,12 +53,6 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 }
 
 ///|
-// Reuse the default implementation of [Show::to_string] here
-pub fn to_string[A : Show](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 /// Tests if two queue cells are equal.
 fn op_equal[T : Eq](self : Cell[T], other : Cell[T]) -> Bool {
   loop self, other {

--- a/queue/queue.mbti
+++ b/queue/queue.mbti
@@ -24,7 +24,6 @@ impl T {
   pop[A](Self[A]) -> A?
   pop_exn[A](Self[A]) -> A //deprecated
   push[A](Self[A], A) -> Unit
-  to_string[A : Show](Self[A]) -> String
   transfer[A](Self[A], Self[A]) -> Unit
   unsafe_peek[A](Self[A]) -> A
   unsafe_pop[A](Self[A]) -> A

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -330,11 +330,6 @@ pub impl @quickcheck.Arbitrary for T with arbitrary(size, rs) {
 }
 
 ///|
-pub fn to_string(self : T) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub fn is_integer(self : T) -> Bool {
   self.denominator == 1L
 }
@@ -594,17 +589,17 @@ test "fract" {
 test "to_string" {
   // 1/2 -> "1/2"
   let a = T::new_unchecked(1L, 2L)
-  let b = to_string(a)
+  let b = a.to_string()
   assert_eq!(b, "1/2")
 
   // 4/4 -> "1"
   let a = T::new_unchecked(4L, 4L)
-  let b = to_string(a)
+  let b = a.to_string()
   assert_eq!(b, "1")
 
   // 0/1 -> "0"
   let a = T::new_unchecked(0L, 1L)
-  let b = to_string(a)
+  let b = a.to_string()
   assert_eq!(b, "0")
 }
 

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -25,7 +25,6 @@ impl T {
   op_sub(Self, Self) -> Self
   reciprocal(Self) -> Self
   to_double(Self) -> Double
-  to_string(Self) -> String
   trunc(Self) -> Int64
 }
 impl Show for T

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -18,12 +18,6 @@ pub fn Ref::new[T](x : T) -> Ref[T] {
   { val: x }
 }
 
-///|
-pub fn to_string[X : Show](self : Ref[X]) -> String {
-  let v = self.val
-  "{val: \{v}}"
-}
-
 test "to_string" {
   inspect!(new(3), content="{val: 3}")
 }

--- a/ref/ref.mbti
+++ b/ref/ref.mbti
@@ -12,7 +12,6 @@ impl Ref {
   new[T](T) -> Self[T]
   protect[T, R](Self[T], T, () -> R) -> R
   swap[T](Self[T], Self[T]) -> Unit
-  to_string[X : Show](Self[X]) -> String
   update[T](Self[T], (T) -> T) -> Unit
 }
 

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -27,7 +27,6 @@ impl T {
   remove[K : Compare, V](Self[K, V], K) -> Unit
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
-  to_string[K : Show, V : Show](Self[K, V]) -> String
   values[K, V](Self[K, V]) -> Array[V]
 }
 impl[K : Show, V : Show] Show for T[K, V]

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -64,8 +64,3 @@ fn debug_tree[K : Show, V : Show](self : T[K, V]) -> String {
 pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
   logger.write_iter(self.iter(), prefix="@sorted_map.of([", suffix="])")
 }
-
-///|
-pub fn to_string[K : Show, V : Show](self : T[K, V]) -> String {
-  Show::to_string(self)
-}

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -438,11 +438,6 @@ pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X] wit
 }
 
 ///|
-pub fn to_string[V : Show](self : T[V]) -> String {
-  Show::to_string(self)
-}
-
-///|
 impl[T : Show] Show for Node[T] with output(self, logger) {
   logger.write_iter(self.iter(), prefix="@sorted_set.of([", suffix="])")
 }

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -30,7 +30,6 @@ impl T {
   size[V : Compare](Self[V]) -> Int64
   subset[V : Compare](Self[V], Self[V]) -> Bool
   to_array[V](Self[V]) -> Array[V]
-  to_string[V : Show](Self[V]) -> String
   union[V : Compare](Self[V], Self[V]) -> Self[V]
 }
 impl[V : Show] Show for T[V]


### PR DESCRIPTION
The most recent compiler release allows calling trait `impl`s via dot, so long as the `impl` is located in the package of self type. So many `to_string` wrapper methods in core are no longer needed to support the `.to_string()` call syntax. This PR removes these wrapper methods.