### PR TITLE
add `FixedArray[Byte]` method `set_utf_char`

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -150,7 +150,7 @@ pub fn write_sub_string(
 /// Write a char into buffer.
 pub fn write_char(self : T, value : Char) -> Unit {
   self.grow_if_necessary(self.len + 4)
-  let inc = self.data.set_utf16_char(self.len, value)
+  let inc = self.data.set_utf16le_char(self.len, value)
   self.len += inc
 }
 

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -682,7 +682,7 @@ impl Bytes {
   op_equal(Bytes, Bytes) -> Bool
   op_get(Bytes, Int) -> Byte
   op_set(Bytes, Int, Byte) -> Unit
-  set_utf16_char(Bytes, Int, Char) -> Int //deprecated
+  set_utf16_char(Bytes, Int, Char) -> Int
   set_utf8_char(Bytes, Int, Char) -> Int //deprecated
   sub_string(Bytes, Int, Int) -> String //deprecated
   to_string(Bytes) -> String //deprecated

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -662,7 +662,10 @@ impl FixedArray {
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   set[T](Self[T], Int, T) -> Unit
-  set_utf16_char(Self[Byte], Int, Char) -> Int
+  set_utf16_char(Self[Byte], Int, Char) -> Int //deprecated
+  set_utf16be_char(Self[Byte], Int, Char) -> Int
+  set_utf16le_char(Self[Byte], Int, Char) -> Int
+  set_utf8_char(Self[Byte], Int, Char) -> Int
   to_json[X : ToJson](Self[X]) -> Json
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
 }
@@ -679,7 +682,7 @@ impl Bytes {
   op_equal(Bytes, Bytes) -> Bool
   op_get(Bytes, Int) -> Byte
   op_set(Bytes, Int, Byte) -> Unit
-  set_utf16_char(Bytes, Int, Char) -> Int
+  set_utf16_char(Bytes, Int, Char) -> Int //deprecated
   set_utf8_char(Bytes, Int, Char) -> Int //deprecated
   sub_string(Bytes, Int, Int) -> String //deprecated
   to_string(Bytes) -> String //deprecated

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -140,7 +140,7 @@ pub fn copy(self : Bytes) -> Bytes {
 }
 
 ///|
-/// Fill utf8 encoded char `value` into byte sequence `self`, starting at `offset`.
+/// Fill UTF8 encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
 /// @alert deprecated "The type Bytes is about to be changed to be immutable. Use `FixedArray[Byte]` or `Buffer` instead."
 pub fn set_utf8_char(self : Bytes, offset : Int, value : Char) -> Int {
@@ -169,9 +169,42 @@ pub fn set_utf8_char(self : Bytes, offset : Int, value : Char) -> Int {
 }
 
 ///|
-/// Fill utf16 encoded char `value` into byte sequence `self`, starting at `offset`.
+/// Fill UTF8 encoded char `value` into byte sequence `self`, starting at `offset`.
+/// It return the length of bytes has been written.
+pub fn set_utf8_char(
+  self : FixedArray[Byte],
+  offset : Int,
+  value : Char
+) -> Int {
+  let code = value.to_uint()
+  if code < 0x80 {
+    self[offset] = ((code & 0x7F) | 0x00).to_byte()
+    1
+  } else if code < 0x0800 {
+    self[offset] = (((code >> 6) & 0x1F) | 0xC0).to_byte()
+    self[offset + 1] = ((code & 0x3F) | 0x80).to_byte()
+    2
+  } else if code < 0x010000 {
+    self[offset] = (((code >> 12) & 0x0F) | 0xE0).to_byte()
+    self[offset + 1] = (((code >> 6) & 0x3F) | 0x80).to_byte()
+    self[offset + 2] = ((code & 0x3F) | 0x80).to_byte()
+    3
+  } else if code < 0x110000 {
+    self[offset] = (((code >> 18) & 0x07) | 0xF0).to_byte()
+    self[offset + 1] = (((code >> 12) & 0x3F) | 0x80).to_byte()
+    self[offset + 2] = (((code >> 6) & 0x3F) | 0x80).to_byte()
+    self[offset + 3] = ((code & 0x3F) | 0x80).to_byte()
+    4
+  } else {
+    abort("Char out of range")
+  }
+}
+
+///|
+/// Fill UTF16 encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
 /// @alert unsafe "Panic if the [value] is out of range"
+/// @alert deprecated "The type Bytes is about to be changed to be immutable. Use `FixedArray[Byte]` or `Buffer` instead."
 pub fn set_utf16_char(self : Bytes, offset : Int, value : Char) -> Int {
   let code = value.to_uint()
   if code < 0x10000 {
@@ -196,6 +229,7 @@ pub fn set_utf16_char(self : Bytes, offset : Int, value : Char) -> Int {
 /// Fill utf16 encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
 /// @alert unsafe "Panic if the [value] is out of range"
+/// @alert deprecated "Use `set_utf16le_char` instead"
 pub fn set_utf16_char(
   self : FixedArray[Byte],
   offset : Int,
@@ -214,6 +248,62 @@ pub fn set_utf16_char(
     self[offset + 1] = (lo >> 8).to_byte()
     self[offset + 2] = (hi & 0xFF).to_byte()
     self[offset + 3] = (hi >> 8).to_byte()
+    4
+  } else {
+    abort("Char out of range")
+  }
+}
+
+///|
+/// Fill UTF16LE encoded char `value` into byte sequence `self`, starting at `offset`.
+/// It return the length of bytes has been written.
+/// @alert unsafe "Panic if the [value] is out of range"
+pub fn set_utf16le_char(
+  self : FixedArray[Byte],
+  offset : Int,
+  value : Char
+) -> Int {
+  let code = value.to_uint()
+  if code < 0x10000 {
+    self[offset] = (code & 0xFF).to_byte()
+    self[offset + 1] = (code >> 8).to_byte()
+    2
+  } else if code < 0x110000 {
+    let hi = code - 0x10000
+    let lo = (hi >> 10) | 0xD800
+    let hi = (hi & 0x3FF) | 0xDC00
+    self[offset] = (lo & 0xFF).to_byte()
+    self[offset + 1] = (lo >> 8).to_byte()
+    self[offset + 2] = (hi & 0xFF).to_byte()
+    self[offset + 3] = (hi >> 8).to_byte()
+    4
+  } else {
+    abort("Char out of range")
+  }
+}
+
+///|
+/// Fill UTF16BE encoded char `value` into byte sequence `self`, starting at `offset`.
+/// It return the length of bytes has been written.
+/// @alert unsafe "Panic if the [value] is out of range"
+pub fn set_utf16be_char(
+  self : FixedArray[Byte],
+  offset : Int,
+  value : Char
+) -> Int {
+  let code = value.to_uint()
+  if code < 0x10000 {
+    self[offset] = (code >> 0xFF).to_byte()
+    self[offset + 1] = (code & 0xFF).to_byte()
+    2
+  } else if code < 0x110000 {
+    let hi = code - 0x10000
+    let lo = (hi >> 10) | 0xD800
+    let hi = (hi & 0x3FF) | 0xDC00
+    self[offset] = (lo >> 8).to_byte()
+    self[offset + 1] = (lo & 0xFF).to_byte()
+    self[offset + 2] = (hi >> 8).to_byte()
+    self[offset + 3] = (hi & 0xFF).to_byte()
     4
   } else {
     abort("Char out of range")

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -204,7 +204,6 @@ pub fn set_utf8_char(
 /// Fill UTF16 encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
 /// @alert unsafe "Panic if the [value] is out of range"
-/// @alert deprecated "The type Bytes is about to be changed to be immutable. Use `FixedArray[Byte]` or `Buffer` instead."
 pub fn set_utf16_char(self : Bytes, offset : Int, value : Char) -> Int {
   let code = value.to_uint()
   if code < 0x10000 {

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -42,12 +42,90 @@ test "copy" {
   assert_eq!(copy_bytes.to_unchecked_string(), bytes.to_unchecked_string())
 }
 
-test "set_utf16_char" {
-  let bytes = Bytes::new(10)
+test "set_utf8_char (ASCII)" {
+  let arr = FixedArray::makei(4, fn { _ => b'\x00' })
   let char = 'A'
-  let len = bytes.set_utf16_char(0, char)
+  let len = arr.set_utf8_char(0, char)
+  let bytes = @bytes.from_fixedarray(arr)
+  assert_eq!(len, 1)
+  inspect!(
+    bytes,
+    content=
+      #|b"\x41\x00\x00\x00"
+    ,
+  )
+}
+
+test "set_utf8_char (CJK)" {
+  let arr = FixedArray::makei(4, fn { _ => b'\x00' })
+  let char = '拼'
+  let len = arr.set_utf8_char(0, char)
+  let bytes = @bytes.from_fixedarray(arr)
+  assert_eq!(len, 3)
+  inspect!(
+    bytes,
+    content=
+      #|b"\xe6\x8b\xbc\x00"
+    ,
+  )
+}
+
+test "set_utf8_char (Emoji)" {
+  let arr = FixedArray::makei(4, fn { _ => b'\x00' })
+  let char = '🙅'
+  let len = arr.set_utf8_char(0, char)
+  let bytes = @bytes.from_fixedarray(arr)
+  assert_eq!(len, 4)
+  inspect!(
+    bytes,
+    content=
+      #|b"\xf0\x9f\x99\x85"
+    ,
+  )
+}
+
+test "set_utf16le_char" {
+  let arr = FixedArray::makei(4, fn { _ => b'\x00' })
+  let char = 'A'
+  let len = arr.set_utf16le_char(0, char)
+  let bytes = @bytes.from_fixedarray(arr)
   assert_eq!(len, 2)
   assert_eq!(bytes.to_unchecked_string(offset=0, length=2), "A")
+  inspect!(
+    bytes,
+    content=
+      #|b"\x41\x00\x00\x00"
+    ,
+  )
+}
+
+test "set_utf16le_char (surrogate pair)" {
+  let arr = FixedArray::makei(4, fn { _ => b'\x00' })
+  let char = '🉑'
+  let len = arr.set_utf16le_char(0, char)
+  let bytes = @bytes.from_fixedarray(arr)
+  assert_eq!(len, 4)
+  assert_eq!(bytes.to_unchecked_string(offset=0, length=4), "🉑")
+  inspect!(
+    bytes,
+    content=
+      #|b"\x3c\xd8\x51\xde"
+    ,
+  )
+}
+
+test "set_utf16be_char" {
+  let arr = FixedArray::makei(4, fn { _ => b'\x00' })
+  let char = 'A'
+  let len = arr.set_utf16be_char(0, char)
+  let bytes = @bytes.from_fixedarray(arr)
+  assert_eq!(len, 2)
+  inspect!(
+    bytes,
+    content=
+      #|b"\x00\x41\x00\x00"
+    ,
+  )
 }
 
 test "op_equal" {

--- a/builtin/moon.pkg.json
+++ b/builtin/moon.pkg.json
@@ -3,6 +3,7 @@
   "test-import": [
     "moonbitlang/core/char",
     "moonbitlang/core/string",
+    "moonbitlang/core/bytes",
     "moonbitlang/core/int",
     "moonbitlang/core/double",
     "moonbitlang/core/coverage",

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -279,10 +279,16 @@ test "panic blit_from_string with invalid str_offset + length" {
   bytes.blit_from_string(0, str, 0, str.length() + 1) |> ignore
 }
 
-test "panic set_utf16_char with invalid code point" {
-  let bytes = Bytes::new(10)
+test "panic set_utf16le_char with invalid code point" {
+  let arr = FixedArray::makei(10, fn { _ => b'\x00' })
   let char = Char::from_int(0x110000)
-  bytes.set_utf16_char(0, char) |> ignore
+  arr.set_utf16le_char(0, char) |> ignore
+}
+
+test "panic set_utf16be_char with invalid code point" {
+  let arr = FixedArray::makei(10, fn { _ => b'\x00' })
+  let char = Char::from_int(0x110000)
+  arr.set_utf16le_char(0, char) |> ignore
 }
 
 test "panic" {


### PR DESCRIPTION
~~deprecate `Bytes` method `set_utf16_char`~~ in future request
    
deprecate `FixedArray[Byte]` ambiguous method `set_utf16_char`
new `FixedArray[Byte]` method `set_utf8_char`, `set_utf16le_char` and `set_utf16be_char`