### PR TITLE
fix(array): quick_sort store wrong pred pivot element

### DIFF
--- a/array/fixedarray_sort.mbt
+++ b/array/fixedarray_sort.mbt
@@ -279,8 +279,8 @@ fn fixed_quick_sort[T : Compare](
     // Reduce the stack depth by only call fixed_quick_sort on the smaller fixed_partition.
     if left.length() < right.length() {
       fixed_quick_sort(left, pred, limit)
-      arr = right
       pred = Some(arr[pivot])
+      arr = right
     } else {
       fixed_quick_sort(right, Some(arr[pivot]), limit)
       arr = left

--- a/array/fixedarray_sort_by.mbt
+++ b/array/fixedarray_sort_by.mbt
@@ -162,8 +162,8 @@ fn fixed_quick_sort_by[T](
     // Reduce the stack depth by only call quick_sort on the smaller partition.
     if left.length() < right.length() {
       fixed_quick_sort_by(left, cmp, pred, limit)
-      arr = right
       pred = Some(arr[pivot])
+      arr = right
     } else {
       fixed_quick_sort_by(right, cmp, Some(arr[pivot]), limit)
       arr = left

--- a/array/sort.mbt
+++ b/array/sort.mbt
@@ -83,8 +83,8 @@ fn quick_sort[T : Compare](arr : ArrayView[T], pred : T?, limit : Int) -> Unit {
     // Reduce the stack depth by only call quick_sort on the smaller partition.
     if left.length() < right.length() {
       quick_sort(left, pred, limit)
-      arr = right
       pred = Some(arr[pivot])
+      arr = right
     } else {
       quick_sort(right, Some(arr[pivot]), limit)
       arr = left
@@ -273,6 +273,19 @@ test "insertion_sort" {
 
 test "sort" {
   test_sort!(fn(arr) { arr.sort() })
+}
+
+test "sort with same pivot optimization" {
+  let arr = [
+    35, 43, 72, 83, 39, 4, 83, 18, 43, 25, 88, 51, 43, 60, 83, 6, 36, 68, 79, 86,
+  ]
+  arr.sort()
+  assert_eq!(
+    arr,
+    [
+      4, 6, 18, 25, 35, 36, 39, 43, 43, 43, 51, 60, 68, 72, 79, 83, 83, 83, 86, 88,
+    ],
+  )
 }
 
 test "heap_sort coverage" {

--- a/array/sort_by.mbt
+++ b/array/sort_by.mbt
@@ -108,8 +108,8 @@ fn quick_sort_by[T](
     // Reduce the stack depth by only call quick_sort on the smaller partition.
     if left.length() < right.length() {
       quick_sort_by(left, cmp, pred, limit)
-      arr = right
       pred = Some(arr[pivot])
+      arr = right
     } else {
       quick_sort_by(right, cmp, Some(arr[pivot]), limit)
       arr = left


### PR DESCRIPTION
We should store the pred pivot element before updating arr.

And, there is a test case added which will trigger this bug.