### PR TITLE
deprecate `Bytes::blit_from_string` and `Bytes::set_utf16_char`

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -85,10 +85,7 @@ pub fn to_string(self : T) -> String {
 /// Note this function does not validate the encoding of the byte sequence, 
 /// it simply copy the bytes into a new String.
 pub fn to_unchecked_string(self : T) -> String {
-  Bytes::from_fixedarray(self.data).to_unchecked_string(
-    offset=0,
-    length=self.len,
-  )
+  self.data.to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -75,17 +75,25 @@ pub fn is_empty(self : T) -> Bool {
 ///|
 /// Return a new string contains the data in buffer.
 /// 
-/// @alert deprecated "Use `Buffer::to_unchecked_string` instead"
+/// @alert deprecated "Use `Buffer::contents` to read the contents of the buffer"
 pub fn to_string(self : T) -> String {
-  self.to_unchecked_string()
+  self.contents().to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|
 /// Return a new unchecked string contains the data in buffer.
 /// Note this function does not validate the encoding of the byte sequence, 
 /// it simply copy the bytes into a new String.
+/// 
+/// @alert deprecated "Use `Buffer::contents` to read the contents of the buffer"
 pub fn to_unchecked_string(self : T) -> String {
-  self.data.to_unchecked_string(offset=0, length=self.len)
+  self.contents().to_unchecked_string(offset=0, length=self.len)
+}
+
+///|
+/// Return the contents of the buffer as a Bytes.
+pub fn contents(self : T) -> Bytes {
+  Bytes::from_fixedarray(self.data, len=self.len)
 }
 
 ///|
@@ -172,5 +180,5 @@ pub fn to_bytes(self : T) -> Bytes {
 
 ///|
 pub impl Show for T with output(self, logger) {
-  logger.write_string(self.to_unchecked_string())
+  logger.write_string(self.contents().to_unchecked_string())
 }

--- a/buffer/buffer.mbti
+++ b/buffer/buffer.mbti
@@ -5,13 +5,14 @@ package moonbitlang/core/buffer
 // Types and methods
 type T
 impl T {
+  contents(Self) -> Bytes
   is_empty(Self) -> Bool
   length(Self) -> Int
   new(size_hint~ : Int = ..) -> Self
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes
   to_string(Self) -> String //deprecated
-  to_unchecked_string(Self) -> String
+  to_unchecked_string(Self) -> String //deprecated
   write_byte(Self, Byte) -> Unit
   write_bytes(Self, Bytes) -> Unit
   write_char(Self, Char) -> Unit

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -640,19 +640,21 @@ impl FixedArray {
   make[T](Int, T) -> Self[T]
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
+  reinterpret_as_bytes(Self[Byte]) -> Bytes
   set[T](Self[T], Int, T) -> Unit
   set_utf16_char(Self[Byte], Int, Char) -> Int //deprecated
   set_utf16be_char(Self[Byte], Int, Char) -> Int
   set_utf16le_char(Self[Byte], Int, Char) -> Int
   set_utf8_char(Self[Byte], Int, Char) -> Int
   to_json[X : ToJson](Self[X]) -> Json
+  to_unchecked_string(Self[Byte], offset~ : Int = .., length~ : Int = ..) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
 }
 
 
 impl Bytes {
   blit(Bytes, Int, Bytes, Int, Int) -> Unit
-  blit_from_string(Bytes, Int, String, Int, Int) -> Unit
+  blit_from_string(Bytes, Int, String, Int, Int) -> Unit //deprecated
   copy(Bytes) -> Bytes
   length(Bytes) -> Int
   make(Int, Byte) -> Bytes
@@ -661,7 +663,8 @@ impl Bytes {
   op_equal(Bytes, Bytes) -> Bool
   op_get(Bytes, Int) -> Byte
   op_set(Bytes, Int, Byte) -> Unit
-  set_utf16_char(Bytes, Int, Char) -> Int
+  reinterpret_as_fixedarray(Bytes) -> FixedArray[Byte]
+  set_utf16_char(Bytes, Int, Char) -> Int //deprecated
   set_utf8_char(Bytes, Int, Char) -> Int //deprecated
   sub_string(Bytes, Int, Int) -> String //deprecated
   to_string(Bytes) -> String //deprecated

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -640,14 +640,12 @@ impl FixedArray {
   make[T](Int, T) -> Self[T]
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
-  reinterpret_as_bytes(Self[Byte]) -> Bytes
   set[T](Self[T], Int, T) -> Unit
   set_utf16_char(Self[Byte], Int, Char) -> Int //deprecated
   set_utf16be_char(Self[Byte], Int, Char) -> Int
   set_utf16le_char(Self[Byte], Int, Char) -> Int
   set_utf8_char(Self[Byte], Int, Char) -> Int
   to_json[X : ToJson](Self[X]) -> Json
-  to_unchecked_string(Self[Byte], offset~ : Int = .., length~ : Int = ..) -> String
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
 }
 
@@ -663,7 +661,6 @@ impl Bytes {
   op_equal(Bytes, Bytes) -> Bool
   op_get(Bytes, Int) -> Byte
   op_set(Bytes, Int, Byte) -> Unit
-  reinterpret_as_fixedarray(Bytes) -> FixedArray[Byte]
   set_utf16_char(Bytes, Int, Char) -> Int //deprecated
   set_utf8_char(Bytes, Int, Char) -> Int //deprecated
   sub_string(Bytes, Int, Int) -> String //deprecated

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -13,9 +13,19 @@
 // limitations under the License.
 
 ///|
+/// Reinterpret the byte sequence as Bytes.
+pub fn reinterpret_as_bytes(self : FixedArray[Byte]) -> Bytes = "%identity"
+
+///|
+/// Reinterpret the byte sequence as FixedArray[Byte].
+pub fn reinterpret_as_fixedarray(self : Bytes) -> FixedArray[Byte] = "%identity"
+
+///|
 /// Create byte sequence from String.
 pub fn Bytes::of_string(str : String) -> Bytes {
-  Bytes::new(str.length() * 2)..blit_from_string(0, str, 0, str.length())
+  FixedArray::make(str.length() * 2, Byte::default())
+  ..blit_from_string(0, str, 0, str.length())
+  .reinterpret_as_bytes()
 }
 
 ///|
@@ -61,8 +71,24 @@ pub fn to_unchecked_string(
 }
 
 ///|
+/// Return an unchecked string, containing the subsequence of `self` that starts at 
+/// `offset` and has length `length`. Both `offset` and `length` 
+/// are indexed by byte.
+/// 
+/// Note this function does not validate the encoding of the byte sequence, 
+/// it simply copy the bytes into a new String.
+pub fn to_unchecked_string(
+  self : FixedArray[Byte],
+  offset~ : Int = 0,
+  length~ : Int = self.length() - offset
+) -> String {
+  self.reinterpret_as_bytes().to_unchecked_string(offset~, length~)
+}
+
+///|
 /// Copy `length` chars from string `str`, starting at `str_offset`,
 /// into byte sequence `self`, starting at `bytes_offset`.
+/// @alert deprecated "The type Bytes is about to be changed to be immutable. Use `FixedArray[Byte]` or `Buffer` instead."
 pub fn blit_from_string(
   self : Bytes,
   bytes_offset : Int,
@@ -212,6 +238,7 @@ pub fn set_utf8_char(
 /// Fill UTF16 encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
 /// @alert unsafe "Panic if the [value] is out of range"
+/// @alert deprecated "The type Bytes is about to be changed to be immutable. Use `FixedArray[Byte]` or `Buffer` instead."
 pub fn set_utf16_char(self : Bytes, offset : Int, value : Char) -> Int {
   let code = value.to_uint()
   if code < 0x10000 {

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -14,18 +14,14 @@
 
 ///|
 /// Reinterpret the byte sequence as Bytes.
-pub fn reinterpret_as_bytes(self : FixedArray[Byte]) -> Bytes = "%identity"
-
-///|
-/// Reinterpret the byte sequence as FixedArray[Byte].
-pub fn reinterpret_as_fixedarray(self : Bytes) -> FixedArray[Byte] = "%identity"
+fn unsafe_to_bytes(self : FixedArray[Byte]) -> Bytes = "%identity"
 
 ///|
 /// Create byte sequence from String.
 pub fn Bytes::of_string(str : String) -> Bytes {
   FixedArray::make(str.length() * 2, Byte::default())
   ..blit_from_string(0, str, 0, str.length())
-  .reinterpret_as_bytes()
+  .unsafe_to_bytes()
 }
 
 ///|
@@ -68,21 +64,6 @@ pub fn to_unchecked_string(
   let len = self.length()
   guard offset >= 0 && length >= 0 && offset + length <= len
   unsafe_sub_string(self, offset, length)
-}
-
-///|
-/// Return an unchecked string, containing the subsequence of `self` that starts at 
-/// `offset` and has length `length`. Both `offset` and `length` 
-/// are indexed by byte.
-/// 
-/// Note this function does not validate the encoding of the byte sequence, 
-/// it simply copy the bytes into a new String.
-pub fn to_unchecked_string(
-  self : FixedArray[Byte],
-  offset~ : Int = 0,
-  length~ : Int = self.length() - offset
-) -> String {
-  self.reinterpret_as_bytes().to_unchecked_string(offset~, length~)
 }
 
 ///|

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -30,7 +30,7 @@ test "sub_string" {
 }
 
 test "blit_from_string" {
-  let bytes = Bytes::new(10)
+  let bytes = FixedArray::make(10, Byte::default())
   let str = "Hello"
   bytes.blit_from_string(0, str, 0, str.length())
   assert_eq!(bytes.to_unchecked_string(offset=0, length=str.length() * 2), str)

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -33,7 +33,7 @@ test "blit_from_string" {
   let bytes = FixedArray::make(10, Byte::default())
   let str = "Hello"
   bytes.blit_from_string(0, str, 0, str.length())
-  assert_eq!(bytes.to_unchecked_string(offset=0, length=str.length() * 2), str)
+  assert_eq!(Bytes::from_fixedarray(bytes).to_unchecked_string(), str)
 }
 
 test "copy" {

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -250,31 +250,31 @@ test "panic sub_string with invalid byte_offset + byte_length" {
 }
 
 test "panic blit_from_string with invalid length" {
-  let bytes = Bytes::new(10)
+  let bytes = FixedArray::make(10, Byte::default())
   let str = "Hello"
   bytes.blit_from_string(0, str, 0, -1) |> ignore
 }
 
 test "panic blit_from_string with invalid bytes_offset" {
-  let bytes = Bytes::new(10)
+  let bytes = FixedArray::make(10, Byte::default())
   let str = "Hello"
   bytes.blit_from_string(-1, str, 0, str.length()) |> ignore
 }
 
 test "panic blit_from_string with invalid str_offset" {
-  let bytes = Bytes::new(10)
+  let bytes = FixedArray::make(10, Byte::default())
   let str = "Hello"
   bytes.blit_from_string(0, str, -1, str.length()) |> ignore
 }
 
 test "panic blit_from_string with invalid bytes_offset + length" {
-  let bytes = Bytes::new(10)
+  let bytes = FixedArray::make(10, Byte::default())
   let str = "Hello"
   bytes.blit_from_string(0, str, 0, bytes.length() + 1) |> ignore
 }
 
 test "panic blit_from_string with invalid str_offset + length" {
-  let bytes = Bytes::new(10)
+  let bytes = FixedArray::make(10, Byte::default())
   let str = "Hello"
   bytes.blit_from_string(0, str, 0, str.length() + 1) |> ignore
 }

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -193,7 +193,7 @@ pub fn ArrayView::to_string[X : Show](self : ArrayView[X]) -> String {
 pub fn to_string(self : Char) -> String {
   let bytes = FixedArray::make(4, Byte::default())
   let length = bytes.set_utf16le_char(0, self)
-  bytes.to_unchecked_string(offset=0, length~)
+  bytes.unsafe_to_bytes().to_unchecked_string(offset=0, length~)
 }
 
 ///|

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -191,8 +191,8 @@ pub fn ArrayView::to_string[X : Show](self : ArrayView[X]) -> String {
 /// Convert Char to String
 /// @intrinsic %char.to_string
 pub fn to_string(self : Char) -> String {
-  let bytes = Bytes::new(4)
-  let length = bytes.set_utf16_char(0, self)
+  let bytes = FixedArray::make(4, Byte::default())
+  let length = bytes.set_utf16le_char(0, self)
   bytes.to_unchecked_string(offset=0, length~)
 }
 

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -18,7 +18,7 @@ fn unsafe_substring(str : String, start : Int, end : Int) -> String {
   let len = end - start
   let bytes = FixedArray::make(len * 2, Byte::default())
   bytes.blit_from_string(0, str, start, len)
-  bytes.to_unchecked_string(offset=0, length=bytes.length())
+  bytes.unsafe_to_bytes().to_unchecked_string()
 }
 
 ///|

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -16,7 +16,7 @@
 /// @intrinsic %string.substring
 fn unsafe_substring(str : String, start : Int, end : Int) -> String {
   let len = end - start
-  let bytes = Bytes::new(len * 2)
+  let bytes = FixedArray::make(len * 2, Byte::default())
   bytes.blit_from_string(0, str, start, len)
   bytes.to_unchecked_string(offset=0, length=bytes.length())
 }

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -14,15 +14,15 @@
 
 ///|
 struct StringBuilder {
-  mut bytes : Bytes
+  mut data : FixedArray[Byte]
   mut len : Int
 }
 
 ///|
 pub fn StringBuilder::new(size_hint~ : Int = 0) -> StringBuilder {
   let initial = if size_hint < 1 { 1 } else { size_hint }
-  let bytes = Bytes::new(initial)
-  { bytes, len: 0 }
+  let data = FixedArray::make(initial, Byte::default())
+  { data, len: 0 }
 }
 
 ///|
@@ -31,7 +31,7 @@ fn StringBuilder::grow_if_necessary(
   required : Int
 ) -> Unit {
   // TODO: get rid of mut
-  let mut enough_space = self.bytes.length()
+  let mut enough_space = self.data.length()
   if enough_space <= 0 {
     enough_space = 1
   }
@@ -39,22 +39,27 @@ fn StringBuilder::grow_if_necessary(
   while enough_space < required {
     enough_space = enough_space * 2
   }
-  if enough_space != self.bytes.length() {
-    self.bytes = Bytes::new(enough_space)..blit(0, self.bytes, 0, self.len)
+  if enough_space != self.data.length() {
+    self.data = FixedArray::make(enough_space, Byte::default())..unsafe_blit(
+      0,
+      self.data,
+      0,
+      self.len,
+    )
   }
 }
 
 ///|
 pub fn StringBuilder::write_string(self : StringBuilder, str : String) -> Unit {
   self.grow_if_necessary(self.len + str.length() * 2)
-  self.bytes.blit_from_string(self.len, str, 0, str.length())
+  self.data.blit_from_string(self.len, str, 0, str.length())
   self.len += str.length() * 2
 }
 
 ///|
 pub fn StringBuilder::write_char(self : StringBuilder, ch : Char) -> Unit {
   self.grow_if_necessary(self.len + 4)
-  let inc = self.bytes.set_utf16_char(self.len, ch)
+  let inc = self.data.set_utf16le_char(self.len, ch)
   self.len += inc
 }
 
@@ -67,19 +72,19 @@ pub fn StringBuilder::write_substring(
 ) -> Unit {
   guard start >= 0 && len >= 0 && start + len <= str.length()
   self.grow_if_necessary(self.len + len * 2)
-  self.bytes.blit_from_string(self.len, str, start, len)
+  self.data.blit_from_string(self.len, str, start, len)
   self.len += len * 2
 }
 
 ///|
 pub fn StringBuilder::to_string(self : StringBuilder) -> String {
-  self.bytes.to_unchecked_string(offset=0, length=self.len)
+  self.data.to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|
 /// TODO: improve perf
 pub impl Show for StringBuilder with output(self, logger) {
-  logger.write_string(self.bytes.to_unchecked_string(offset=0, length=self.len))
+  logger.write_string(self.data.to_unchecked_string(offset=0, length=self.len))
 }
 
 ///|

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -78,13 +78,15 @@ pub fn StringBuilder::write_substring(
 
 ///|
 pub fn StringBuilder::to_string(self : StringBuilder) -> String {
-  self.data.to_unchecked_string(offset=0, length=self.len)
+  self.data.unsafe_to_bytes().to_unchecked_string(offset=0, length=self.len)
 }
 
 ///|
 /// TODO: improve perf
 pub impl Show for StringBuilder with output(self, logger) {
-  logger.write_string(self.data.to_unchecked_string(offset=0, length=self.len))
+  logger.write_string(
+    self.data.unsafe_to_bytes().to_unchecked_string(offset=0, length=self.len),
+  )
 }
 
 ///|

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -101,10 +101,7 @@ pub fn String::default() -> String {
 ///|
 /// `String` holds a sequence of UTF-16 code units encoded in little endian format
 pub fn to_bytes(self : String) -> Bytes {
-  let len = self.length()
-  let bytes = Bytes::new(len * 2)
-  bytes.blit_from_string(0, self, 0, len)
-  bytes
+  Bytes::of_string(self)
 }
 
 ///|


### PR DESCRIPTION
This PR:
1) deprecated `Bytes::blit_from_string` and `Bytes::set_utf16_char`
2) refactored stringbuilder_buffer.mbt to use `FixedArray[Byte]` instead of `Bytes`
3) Added `FixedArray::reinterpreted_as_bytes` and `Bytes::reinterpreted_as_fixedarray` for non-copy conversion between the two types.