### PR TITLE
enhance Array::blit_to to allow grow destination array

### DIFF
--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -63,7 +63,6 @@ pub fn Array::unsafe_blit_fixed[A](
 /// - `dst_offset` is negative  
 /// - `src_offset + len` exceeds source array length
 /// - `dst_offset` exceeds destination array length
-
 pub fn Array::blit_to[A](
   self : Array[A],
   dst : Array[A],

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -76,7 +76,7 @@ pub fn Array::blit_to[A](
     dst_offset <= dst.length() &&
     src_offset + len <= self.length()
   if dst_offset + len > dst.length() {
-    dst.resize_uninit(dst_offset + len)
+    dst.unsafe_grow_to_length(dst_offset + len)
   }
   Array::unsafe_blit(dst, dst_offset, self, src_offset, len)
 }

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -47,6 +47,23 @@ pub fn Array::unsafe_blit_fixed[A](
 }
 
 ///|
+/// Copies elements from one array to another array. The destination array will grow if necessary.
+/// 
+/// # Arguments
+/// - `self`: The source array to copy elements from
+/// - `dst`: The destination array to copy elements to
+/// - `len`: The number of elements to copy
+/// - `src_offset`: Starting index in the source array (default: 0)
+/// - `dst_offset`: Starting index in the destination array (default: 0)
+///
+/// # Panics
+/// Panics if:
+/// - `len` is negative
+/// - `src_offset` is negative
+/// - `dst_offset` is negative  
+/// - `src_offset + len` exceeds source array length
+/// - `dst_offset` exceeds destination array length
+
 pub fn Array::blit_to[A](
   self : Array[A],
   dst : Array[A],
@@ -57,33 +74,101 @@ pub fn Array::blit_to[A](
   guard len >= 0 &&
     dst_offset >= 0 &&
     src_offset >= 0 &&
-    dst_offset + len <= dst.length() &&
+    dst_offset <= dst.length() &&
     src_offset + len <= self.length()
+  if dst_offset + len > dst.length() {
+    dst.resize_uninit(dst_offset + len)
+  }
   Array::unsafe_blit(dst, dst_offset, self, src_offset, len)
 }
 
-test "Array::blit_to - basic functionality" {
+test "Array::blit_to/basic" {
+  let src = [1, 2, 3, 4, 5]
+  let dst = [0, 0, 0, 0, 0]
+  Array::blit_to(src, dst, len=3, src_offset=1, dst_offset=2)
+  inspect!(dst, content="[0, 0, 2, 3, 4]")
+}
+
+test "Array::blit_to/basic" {
   let src = [1, 2, 3, 4, 5]
   let dst = [0, 0, 0, 0, 0]
   Array::blit_to(src, dst, len=3)
   inspect!(dst, content="[1, 2, 3, 0, 0]")
 }
 
-test "Array::blit_to - edge cases" {
+test "Array::blit_to/zero_length" {
+  let src = [1, 2, 3]
+  let dst = [4, 5, 6]
+  Array::blit_to(src, dst, len=0)
+  inspect!(dst, content="[4, 5, 6]")
+}
+
+test "Array::blit_to/grow_destination" {
+  let src = [1, 2, 3, 4, 5]
+  let dst = [0, 0]
+  Array::blit_to(src, dst, len=3, dst_offset=1)
+  inspect!(dst, content="[0, 1, 2, 3]")
+}
+
+test "Array::blit_to/edge_cases" {
+  // Test with src_offset and dst_offset
   let src = [1, 2, 3, 4, 5]
   let dst = [0, 0, 0, 0, 0]
-
-  // Test with src_offset and dst_offset
   Array::blit_to(src, dst, len=2, src_offset=1, dst_offset=2)
   inspect!(dst, content="[0, 0, 2, 3, 0]")
+
+  // Test when src and dst are the same array
+  Array::blit_to(src, src, len=2, src_offset=0, dst_offset=3)
+  inspect!(src, content="[1, 2, 3, 1, 2]")
+
+  // Test with len equal to 0
+  Array::blit_to(src, dst, len=0, src_offset=0, dst_offset=0)
+  inspect!(dst, content="[0, 0, 2, 3, 0]")
+
+  // Test with len equal to the length of src
+  Array::blit_to(src, dst, len=5)
+  inspect!(dst, content="[1, 2, 3, 1, 2]")
+}
+
+test "Array::blit_to/edge_cases" {
+  let src = [1, 2, 3, 4, 5]
+  let dst = [0, 0, 0, 0, 0]
+  // Test with len equal to 0
+  Array::blit_to(src, dst, len=0, src_offset=0, dst_offset=0)
+  inspect!(dst, content="[0, 0, 0, 0, 0]")
 
   // Test with len equal to the length of src
   Array::blit_to(src, dst, len=5, src_offset=0, dst_offset=0)
   inspect!(dst, content="[1, 2, 3, 4, 5]")
+}
 
-  // Test with len equal to 0
-  Array::blit_to(src, dst, len=0, src_offset=0, dst_offset=0)
-  inspect!(dst, content="[1, 2, 3, 4, 5]")
+test "panic Array::blit_to/boundary_cases" {
+  let src = [1, 2, 3, 4, 5]
+  let dst = [0, 0, 0, 0, 0]
+
+  // Invalid len
+  ignore(Array::blit_to(src, dst, len=-1))
+}
+
+test "panic Array::blit_to/boundary_cases" {
+  let src = [1, 2, 3, 4, 5]
+  let dst = [0, 0, 0, 0, 0]
+  // Invalid src_offset
+  ignore(Array::blit_to(src, dst, len=2, src_offset=-1))
+}
+
+test "panic Array::blit_to/boundary_cases" {
+  let src = [1, 2, 3, 4, 5]
+  let dst = [0, 0, 0, 0, 0]
+  // len exceeding src length
+  ignore(Array::blit_to(src, dst, len=6))
+}
+
+test "panic Array::blit_to/boundary_cases" {
+  let src = [1, 2, 3, 4, 5]
+  let dst = [0, 0, 0, 0, 0]
+  // dst offset exceeding dst length
+  ignore(Array::blit_to(src, dst, len=5, dst_offset=6))
 }
 
 /// TODO

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -281,14 +281,10 @@ pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
 ///
 /// If `new_len` is greater than `len`, the array will be extended by the 
 /// difference, and the values in the new slots are left uninitilized.
-///  If `new_len` is less than `len`, the array will be truncated.
+///  If `new_len` is less than `len`, it will panic
 ///
 /// @alert unsafe "Panic if new length is negative."
-fn resize_uninit[T](self : Array[T], new_len : Int) -> Unit {
-  guard new_len >= 0 else { abort("negative new length") }
-  if new_len < self.length() {
-    self.unsafe_truncate_to_length(new_len)
-  } else {
-    JSArray::ofAnyArray(self).set_length(new_len)
-  }
+fn unsafe_grow_to_length[T](self : Array[T], new_len : Int) -> Unit {
+  guard new_len >= self.length()
+  JSArray::ofAnyArray(self).set_length(new_len)
 }

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -275,3 +275,20 @@ pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
   let _ = JSArray::ofAnyArray(self).splice1(index, 0, JSValue::ofAny(value))
 
 }
+
+///|
+/// Resize the array in-place so that `len` is equal to `new_len`.
+///
+/// If `new_len` is greater than `len`, the array will be extended by the 
+/// difference, and the values in the new slots are left uninitilized.
+///  If `new_len` is less than `len`, the array will be truncated.
+///
+/// @alert unsafe "Panic if new length is negative."
+fn resize_uninit[T](self : Array[T], new_len : Int) -> Unit {
+  guard new_len >= 0 else { abort("negative new length") }
+  if new_len < self.length() {
+    self.unsafe_truncate_to_length(new_len)
+  } else {
+    JSArray::ofAnyArray(self).set_length(new_len)
+  }
+}

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -348,17 +348,13 @@ pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
 ///
 /// If `new_len` is greater than `len`, the array will be extended by the 
 /// difference, and the values in the new slots are left uninitilized.
-///  If `new_len` is less than `len`, the array will be truncated.
+///  If `new_len` is less than `len`, it will panic
 ///
 /// @alert unsafe "Panic if new length is negative."
-fn resize_uninit[T](self : Array[T], new_len : Int) -> Unit {
-  guard new_len >= 0 else { abort("negative new length") }
-  if new_len < self.length() {
-    self.unsafe_truncate_to_length(new_len)
-  } else {
-    let new_buf = UninitializedArray::make(new_len)
-    UninitializedArray::unsafe_blit(new_buf, 0, self.buf, 0, self.len)
-    self.len = new_len
-    self.buf = new_buf
-  }
+fn unsafe_grow_to_length[T](self : Array[T], new_len : Int) -> Unit {
+  guard new_len >= self.length()
+  let new_buf = UninitializedArray::make(new_len)
+  UninitializedArray::unsafe_blit(new_buf, 0, self.buf, 0, self.len)
+  self.len = new_len
+  self.buf = new_buf
 }

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -342,3 +342,23 @@ pub fn insert[T](self : Array[T], index : Int, value : T) -> Unit {
   self.unsafe_set(index, value)
   self.len = length + 1
 }
+
+///|
+/// Resize the array in-place so that `len` is equal to `new_len`.
+///
+/// If `new_len` is greater than `len`, the array will be extended by the 
+/// difference, and the values in the new slots are left uninitilized.
+///  If `new_len` is less than `len`, the array will be truncated.
+///
+/// @alert unsafe "Panic if new length is negative."
+fn resize_uninit[T](self : Array[T], new_len : Int) -> Unit {
+  guard new_len >= 0 else { abort("negative new length") }
+  if new_len < self.length() {
+    self.unsafe_truncate_to_length(new_len)
+  } else {
+    let new_buf = UninitializedArray::make(new_len)
+    UninitializedArray::unsafe_blit(new_buf, 0, self.buf, 0, self.len)
+    self.len = new_len
+    self.buf = new_buf
+  }
+}


### PR DESCRIPTION
This PR completes #1267 to allow the destination array to grow in the following case:

Before blit:
```
src array: [ 0  1  2  3  4 ]
src range:      ^--------^
dst array: [ 0  0  0  0  0 ]
dst range:               ^--------^
```
after blit:
```
dst array: [ 0  0  0  1  2  3  4]
```

If the start position of the dst range does not overlap with the dst array, it will panic:
```
dst array: [ 0  0  0  0  0 ]
dst range:                               ^--------^
```