### PR TITLE
feat(builtin): add `StringBuilder::is_empty()`

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -330,6 +330,7 @@ impl Show for SourceLoc
 
 type StringBuilder
 impl StringBuilder {
+  is_empty(Self) -> Bool
   new(size_hint~ : Int = ..) -> Self
   reset(Self) -> Unit
   to_string(Self) -> String

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -26,6 +26,12 @@ pub fn StringBuilder::new(size_hint~ : Int = 0) -> StringBuilder {
 }
 
 ///|
+/// Return whether the given buffer is empty.
+pub fn StringBuilder::is_empty(self : StringBuilder) -> Bool {
+  self.len == 0
+}
+
+///|
 fn StringBuilder::grow_if_necessary(
   self : StringBuilder,
   required : Int

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -22,6 +22,12 @@ pub fn StringBuilder::new(size_hint~ : Int = 0) -> StringBuilder {
 }
 
 ///|
+/// Return whether the given buffer is empty.
+pub fn StringBuilder::is_empty(self : StringBuilder) -> Bool {
+  self.val == ""
+}
+
+///|
 pub fn StringBuilder::write_string(self : StringBuilder, str : String) -> Unit {
   self.val += str
 }

--- a/builtin/stringbuilder_test.mbt
+++ b/builtin/stringbuilder_test.mbt
@@ -29,6 +29,15 @@ test "stringbuilder" {
   inspect!(buf.to_string(), content="hello wor")
 }
 
+test "is_empty method" {
+  let buf = StringBuilder::new()
+  inspect!(buf.is_empty(), content="true")
+  buf.write_string("Test")
+  inspect!(buf.is_empty(), content="false")
+  buf.reset()
+  inspect!(buf.is_empty(), content="true")
+}
+
 test {
   let data = ["a", "b", "c", "hello world"]
   @json.inspect!(data.map(id), content=["a", "b", "c", "hello world"])


### PR DESCRIPTION
Mirrored from the corresponding `@buffer.T` API, as required by https://github.com/moonbit-community/cmark.