### PR TITLE
deprecate `immut/sorted_map.empty`

### DIFF
--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -330,7 +330,7 @@ test "filter_with_key" {
 }
 
 test "empty" {
-  let m : T[Int, Int] = empty()
+  let m : T[Int, Int] = T::new()
   assert_eq!(m.debug_tree(), "_")
 }
 

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -31,7 +31,7 @@ test "size" {
 }
 
 test "is_empty" {
-  let m : @sorted_map.T[Int, Int] = @sorted_map.empty()
+  let m : @sorted_map.T[Int, Int] = @sorted_map.new()
   assert_eq!(m.is_empty(), true)
   let m = m.add(1, 1)
   assert_eq!(m.is_empty(), false)

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -13,7 +13,7 @@ impl T {
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
   elems[K, V](Self[K, V]) -> Array[V]
-  empty[K, V]() -> Self[K, V]
+  empty[K, V]() -> Self[K, V] //deprecated
   filter[K : Compare, V](Self[K, V], (V) -> Bool) -> Self[K, V]
   filter_with_key[K : Compare, V](Self[K, V], (K, V) -> Bool) -> Self[K, V]
   fold[K, V, A](Self[K, V], init~ : A, (A, V) -> A) -> A
@@ -30,6 +30,7 @@ impl T {
   lookup[K : Compare, V](Self[K, V], K) -> V?
   map[K, X, Y](Self[K, X], (X) -> Y) -> Self[K, Y]
   map_with_key[K, X, Y](Self[K, X], (K, X) -> Y) -> Self[K, Y]
+  new[K, V]() -> Self[K, V]
   of[K : Compare, V](FixedArray[(K, V)]) -> Self[K, V]
   op_get[K : Compare, V](Self[K, V], K) -> V?
   remove[K : Compare, V](Self[K, V], K) -> Self[K, V]

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub impl[K, V] Default for T[K, V] with default() { empty() }
+pub impl[K, V] Default for T[K, V] with default() { T::new() }
 
 ///|
 pub impl[K : Eq, V : Eq] Eq for T[K, V] with op_equal(self, other) -> Bool {
@@ -81,7 +81,7 @@ pub impl[V : @json.FromJson] @json.FromJson for T[String, V] with from_json(
 ) {
   match json {
     Object(obj) => {
-      let mut map = T::empty()
+      let mut map = T::new()
       for k, v in obj {
         map = map.add(k, V::from_json!(v, path))
       }

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-///|
-/// Create an empty map.
+///| Create an empty map.
+/// @alert deprecated "Use `new()` instead"
 pub fn T::empty[K, V]() -> T[K, V] {
+  Empty
+}
+
+///| Create an empty map.
+pub fn T::new[K, V]() -> T[K, V] {
   Empty
 }
 

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -253,7 +253,7 @@ pub fn iter2[K, V](self : T[K, V]) -> Iter2[K, V] {
 
 ///|
 pub fn T::from_iter[K : Compare, V](iter : Iter[(K, V)]) -> T[K, V] {
-  iter.fold(init=T::empty(), fn(m, e) { m.add(e.0, e.1) })
+  iter.fold(init=T::new(), fn(m, e) { m.add(e.0, e.1) })
 }
 
 ///|

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -75,7 +75,7 @@ test "iter" {
 }
 
 test "op_get with empty map" {
-  let map : @sorted_map.T[Int, String] = @sorted_map.empty()
+  let map : @sorted_map.T[Int, String] = @sorted_map.new()
   assert_eq!(map[3], None)
 }
 
@@ -89,7 +89,7 @@ test "to_json with non-empty map" {
 }
 
 test "to_json with empty map" {
-  let map : @sorted_map.T[Int, String] = @sorted_map.empty()
+  let map : @sorted_map.T[Int, String] = @sorted_map.new()
   @json.inspect!(map.to_json(), content={})
 }
 


### PR DESCRIPTION
#1295 

We have already chosen the naming convention for collection creation: use `new` instead of `empty`.