### PR TITLE
Use native array copy under js target

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -37,18 +37,6 @@ pub fn push_iter[T](self : Array[T], iter : Iter[T]) -> Unit {
 }
 
 ///|
-pub fn copy[T](self : Array[T]) -> Array[T] {
-  let len = self.length()
-  if len == 0 {
-    []
-  } else {
-    let arr = Array::make(len, self[0])
-    Array::unsafe_blit(arr, 0, self, 0, len)
-    arr
-  }
-}
-
-///|
 pub fn Array::makei[T](length : Int, value : (Int) -> T) -> Array[T] {
   if length <= 0 {
     []

--- a/array/array_js.mbt
+++ b/array/array_js.mbt
@@ -1,0 +1,31 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+type JSArray
+
+///|
+fn JSArray::ofAnyArray[T](array : Array[T]) -> JSArray = "%identity"
+
+///|
+fn JSArray::toAnyArray[T](self : JSArray) -> Array[T] = "%identity"
+
+///|
+extern "js" fn JSArray::copy(self : JSArray) -> JSArray =
+  #|(arr) => arr.slice(0)
+
+///|
+pub fn copy[T](self : Array[T]) -> Array[T] {
+  JSArray::ofAnyArray(self).copy().toAnyArray()
+}

--- a/array/array_nonjs.mbt
+++ b/array/array_nonjs.mbt
@@ -1,0 +1,25 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub fn copy[T](self : Array[T]) -> Array[T] {
+  let len = self.length()
+  if len == 0 {
+    []
+  } else {
+    let arr = Array::make(len, self[0])
+    Array::unsafe_blit(arr, 0, self, 0, len)
+    arr
+  }
+}

--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -8,6 +8,8 @@
   ],
   "test-import": ["moonbitlang/core/random"],
   "targets": {
+    "array_js.mbt": ["js"],
+    "array_nonjs.mbt": ["not", "js"],
     "panic_test.mbt": ["not", "native"]
   }
 }


### PR DESCRIPTION
This PR make `Array::copy` implementation platform specific to get native speed under js target.