### PR TITLE
add default start value for op_as_view

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -58,7 +58,11 @@ pub fn swap[T](self : ArrayView[T], i : Int, j : Int) -> Unit {
 }
 
 ///|
-pub fn op_as_view[T](self : Array[T], start~ : Int, end? : Int) -> ArrayView[T] {
+pub fn op_as_view[T](
+  self : Array[T],
+  start~ : Int = 0,
+  end? : Int
+) -> ArrayView[T] {
   let len = self.length()
   let end = match end {
     None => len
@@ -73,7 +77,7 @@ pub fn op_as_view[T](self : Array[T], start~ : Int, end? : Int) -> ArrayView[T] 
 ///|
 pub fn op_as_view[T](
   self : ArrayView[T],
-  start~ : Int,
+  start~ : Int = 0,
   end? : Int
 ) -> ArrayView[T] {
   let len = self.length()

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -85,7 +85,7 @@ impl Array {
   mapi_inplace[T](Self[T], (Int, T) -> T) -> Unit
   new[T](capacity~ : Int = ..) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
-  op_as_view[T](Self[T], start~ : Int, end? : Int) -> ArrayView[T]
+  op_as_view[T](Self[T], start~ : Int = .., end? : Int) -> ArrayView[T]
   op_equal[T : Eq](Self[T], Self[T]) -> Bool
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
@@ -125,7 +125,7 @@ impl ArrayView {
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
   iter[A](Self[A]) -> Iter[A]
   length[T](Self[T]) -> Int
-  op_as_view[T](Self[T], start~ : Int, end? : Int) -> Self[T]
+  op_as_view[T](Self[T], start~ : Int = .., end? : Int) -> Self[T]
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   rev_fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
@@ -216,7 +216,7 @@ impl Iter {
   map_while[A, B](Self[A], (A) -> B?) -> Self[B]
   new[T](((T) -> IterResult) -> IterResult) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
-  op_as_view[A](Self[A], start~ : Int, end? : Int) -> Self[A]
+  op_as_view[A](Self[A], start~ : Int = .., end? : Int) -> Self[A]
   peek[T](Self[T]) -> T?
   prepend[T](Self[T], T) -> Self[T]
   repeat[T](T) -> Self[T]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -861,7 +861,7 @@ pub fn intersperse[A](self : Iter[A], sep : A) -> Iter[A] {
 }
 
 ///|
-pub fn op_as_view[A](self : Iter[A], start~ : Int, end? : Int) -> Iter[A] {
+pub fn op_as_view[A](self : Iter[A], start~ : Int = 0, end? : Int) -> Iter[A] {
   // Note here we mark `end` as an optional parameter
   // since the meaningful default value of `end` is the length of the iterator
   // this is time consuming to calculate


### PR DESCRIPTION
Currently moonc compiler uses 0 as the default start value implicitly. Later, we want to change the compiler to use the user-supplied default value.