### PR TITLE
Implement map* and filter for ArrayView

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -216,7 +216,7 @@ pub fn map_inplace[T](self : ArrayView[T], f : (T) -> T) -> Unit {
 /// ```
 /// let v = [3, 4, 5]
 /// let v2 = v[1:].mapi(fn (i, x) {x + i})
-/// assert_eq!(v2, [3, 4, 6])
+/// assert_eq!(v2, [4, 6])
 /// ```
 pub fn mapi[T, U](self : ArrayView[T], f : (Int, T) -> U) -> Array[U] {
   if self.length() == 0 {

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -173,3 +173,92 @@ pub fn rev_foldi[A, B](
     acc
   }
 }
+
+///|
+/// Maps a function over the elements of the array view.
+///
+/// # Example
+/// ```
+/// let v = [3, 4, 5]
+/// let v2 = v[1:].map(fn (x) {x + 1})
+/// assert_eq!(v2, [5, 6])
+/// ```
+pub fn map[T, U](self : ArrayView[T], f : (T) -> U) -> Array[U] {
+  if self.length() == 0 {
+    return []
+  }
+  let arr = Array::make_uninit(self.length())
+  for i, v in self {
+    arr.unsafe_set(i, f(v))
+  }
+  arr
+}
+
+///|
+/// Maps a function over the elements of the array view in place.
+///
+/// # Example
+/// ```
+/// let v = [3, 4, 5]
+/// v[1:].map_inplace(fn (x) {x + 1})
+/// assert_eq!(v, [3, 5, 6])
+/// ```
+pub fn map_inplace[T](self : ArrayView[T], f : (T) -> T) -> Unit {
+  for i, v in self {
+    self[i] = f(v)
+  }
+}
+
+///|
+/// Maps a function over the elements of the array view with index.
+///
+/// # Example
+/// ```
+/// let v = [3, 4, 5]
+/// let v2 = v[1:].mapi(fn (i, x) {x + i})
+/// assert_eq!(v2, [3, 4, 6])
+/// ```
+pub fn mapi[T, U](self : ArrayView[T], f : (Int, T) -> U) -> Array[U] {
+  if self.length() == 0 {
+    return []
+  }
+  let arr = Array::make_uninit(self.length())
+  for i, v in self {
+    arr.unsafe_set(i, f(i, v))
+  }
+  arr
+}
+
+///|
+/// Maps a function over the elements of the array view with index in place.
+///
+/// # Example
+/// ```
+/// let v = [3, 4, 5]
+/// v[1:].mapi_inplace(fn (i, x) {x + i})
+/// assert_eq!(v, [3, 4, 6])
+/// ```
+pub fn mapi_inplace[T](self : ArrayView[T], f : (Int, T) -> T) -> Unit {
+  for i, v in self {
+    self[i] = f(i, v)
+  }
+}
+
+///|
+/// Filters the array view with a predicate function.
+///
+/// # Example
+/// ```
+/// let arr = [1, 2, 3, 4, 5, 6]
+/// let v = arr[2:].filter(fn (x) { x % 2 == 0 })
+/// assert_eq!(v, [4, 6])
+/// ```
+pub fn filter[T](self : ArrayView[T], f : (T) -> Bool) -> Array[T] {
+  let arr = []
+  for v in self {
+    if f(v) {
+      arr.push(v)
+    }
+  }
+  arr
+}

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -78,3 +78,46 @@ test "arrayview_rev_foldi" {
   let sum = arr.rev_foldi(fn(i, acc, x) { acc + i + x }, init=0)
   inspect!(sum, content="9")
 }
+
+test "arrayview_map" {
+  let arr = [1, 2, 3]
+  let mapped = arr[1:].map(fn(x) { x * 2 })
+  assert_eq!(mapped.length(), 2)
+  assert_eq!(mapped[0], 4)
+  assert_eq!(mapped[1], 6)
+  @json.inspect!(([1] : Array[Int])[1:].map(fn(x) { x }), content=[])
+}
+
+test "arrayview_map_inplace" {
+  let arr = [1, 2, 3]
+  arr[1:].map_inplace(fn(x) { x * 2 })
+  assert_eq!(arr.length(), 3)
+  assert_eq!(arr[0], 1)
+  assert_eq!(arr[1], 4)
+  assert_eq!(arr[2], 6)
+}
+
+test "arrayview_mapi" {
+  let arr = [1, 2, 3]
+  let mapped = arr[1:].mapi(fn(i, x) { i + x })
+  assert_eq!(mapped.length(), 2)
+  assert_eq!(mapped[0], 2)
+  assert_eq!(mapped[1], 4)
+  inspect!(([1] : Array[Int])[1:].mapi(fn(_idx, x) { x }), content="[]")
+}
+
+test "arrayview_mapi_inplace" {
+  let arr = [1, 2, 3]
+  arr[1:].mapi_inplace(fn(i, x) { i + x })
+  assert_eq!(arr.length(), 3)
+  assert_eq!(arr[0], 1)
+  assert_eq!(arr[1], 2)
+  assert_eq!(arr[2], 4)
+}
+
+test "arrayview_filter" {
+  let arr = [1, 2, 3, 4, 5]
+  let filtered = arr[2:].filter(fn(x) { x % 2 == 0 })
+  assert_eq!(filtered.length(), 1)
+  assert_eq!(filtered[0], 4)
+}

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -121,10 +121,15 @@ impl[X : Show] Show for Array[X]
 
 type ArrayView
 impl ArrayView {
+  filter[T](Self[T], (T) -> Bool) -> Array[T]
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
   iter[A](Self[A]) -> Iter[A]
   length[T](Self[T]) -> Int
+  map[T, U](Self[T], (T) -> U) -> Array[U]
+  map_inplace[T](Self[T], (T) -> T) -> Unit
+  mapi[T, U](Self[T], (Int, T) -> U) -> Array[U]
+  mapi_inplace[T](Self[T], (Int, T) -> T) -> Unit
   op_as_view[T](Self[T], start~ : Int = .., end? : Int) -> Self[T]
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit


### PR DESCRIPTION
This PR is for discussion purposes.
It relates to #1013 and #1275.

I believe that it is _MUCH_ more flexible for the `map*` functions to return an `Array` (instead of an `ArrayView`).
Then, code that was performing a map on an entire array could easily insert a `[1:]` and now map all but the first entry without modifying any other code.

Additionally, it is much easier to turn an `Array` into an `ArrayView` than to go the other direction.