### PR TITLE
add `Bool::negate`, avoid usage like `x.not()`

### DIFF
--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -580,7 +580,7 @@ test "swap" {
 /// ```
 pub fn all[T](self : FixedArray[T], f : (T) -> Bool) -> Bool {
   for i = 0; i < self.length(); i = i + 1 {
-    if f(self[i]).not() {
+    if not(f(self[i])) {
       return false
     }
   }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1038,7 +1038,7 @@ pub fn split[T](self : Array[T], pred : (T) -> Bool) -> Array[Array[T]] {
   let mut i = 0
   while i < self.length() {
     let chunk = []
-    while i < self.length() && pred(self[i]).not() {
+    while i < self.length() && not(pred(self[i])) {
       chunk.push(self[i])
       i = i + 1
     }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -364,6 +364,7 @@ impl Unit {
 impl Bool {
   compare(Bool, Bool) -> Int
   default() -> Bool
+  negate(Bool) -> Bool
   not(Bool) -> Bool
   op_compare(Bool, Bool) -> Int //deprecated
   op_equal(Bool, Bool) -> Bool

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -29,8 +29,12 @@ pub fn panic[T]() -> T = "%panic"
 
 // Bool primitive ops
 
-///|
-pub fn Bool::not(self : Bool) -> Bool = "%bool_not"
+///| Return the logical negation of the boolean value.
+/// This function will be replace by the `not x` syntax in the future.
+pub fn Bool::not(x : Bool) -> Bool = "%bool_not"
+
+///| Return the logical negation of the boolean value.
+pub fn Bool::negate(self : Bool) -> Bool = "%bool_not"
 
 ///|
 pub fn Bool::op_equal(self : Bool, other : Bool) -> Bool = "%bool_eq"

--- a/builtin/linked_hash_set_test.mbt
+++ b/builtin/linked_hash_set_test.mbt
@@ -42,7 +42,7 @@ test "add remove" {
   }
   assert_true!(m.add_and_check("test"))
   assert_false!(m.add_and_check("test"))
-  assert_true!(m.contains("a").not() && m.contains("d"))
+  assert_true!(not(m.contains("a")) && m.contains("d"))
   assert_true!(m.contains("b"))
   assert_true!(m.contains("c"))
   assert_true!(m.contains("d"))

--- a/math/trigonometric.mbt
+++ b/math/trigonometric.mbt
@@ -56,7 +56,7 @@ pub fn sin(x : Double) -> Double {
     let y = j.to_double()
     j = j & 7L
     if j > 3L {
-      sign = sign.not()
+      sign = not(sign)
       j -= 4L
     }
     let z = x_ - y * pi4a - y * pi4b - y * pi4c
@@ -111,12 +111,12 @@ pub fn cos(x : Double) -> Double {
     let y = j.to_double()
     j = j & 7L
     if j > 3L {
-      sign = sign.not()
+      sign = not(sign)
       j -= 4L
     }
     let z = x_ - y * pi4a - y * pi4b - y * pi4c
     if j > 1L {
-      sign = sign.not()
+      sign = not(sign)
     }
     let zz = z * z
     (if j == 1L || j == 2L {

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -60,7 +60,7 @@ test "when" {
 /// An `Option` value that is `Some(value())` if the condition is false, otherwise `None`.
 ///
 pub fn unless[T](condition : Bool, value : () -> T) -> T? {
-  when(condition.not(), value)
+  when(not(condition), value)
 }
 
 test "unless" {

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -121,12 +121,12 @@ pub fn clear[K, V](self : T[K, V]) -> Unit {
 pub fn each[K, V](self : T[K, V], f : (K, V) -> Unit) -> Unit {
   let s = []
   let mut p = self.root
-  while p.is_empty().not() || s.is_empty().not() {
-    while p.is_empty().not() {
+  while p.is_empty().negate() || s.is_empty().negate() {
+    while p.is_empty().negate() {
       s.push(p)
       p = p.unwrap().left
     }
-    if s.is_empty().not() {
+    if s.is_empty().negate() {
       p = s.unsafe_pop()
       f(p.unwrap().key, p.unwrap().value)
       p = p.unwrap().right
@@ -140,12 +140,12 @@ pub fn eachi[K, V](self : T[K, V], f : (Int, K, V) -> Unit) -> Unit {
   let s = []
   let mut p = self.root
   let mut i = 0
-  while p.is_empty().not() || s.is_empty().not() {
-    while p.is_empty().not() {
+  while p.is_empty().negate() || s.is_empty().negate() {
+    while p.is_empty().negate() {
       s.push(p)
       p = p.unwrap().left
     }
-    if s.is_empty().not() {
+    if s.is_empty().negate() {
       p = s.unsafe_pop()
       f(i, p.unwrap().key, p.unwrap().value)
       p = p.unwrap().right

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -328,12 +328,12 @@ pub fn each[V](self : T[V], f : (V) -> Unit) -> Unit {
 fn each[V](self : Node[V], f : (V) -> Unit) -> Unit {
   let s = []
   let mut p = Some(self)
-  while p.is_empty().not() || s.is_empty().not() {
-    while p.is_empty().not() {
+  while p.is_empty().negate() || s.is_empty().negate() {
+    while p.is_empty().negate() {
       s.push(p)
       p = p.unwrap().left
     }
-    if s.is_empty().not() {
+    if s.is_empty().negate() {
       p = s.unsafe_pop()
       f(p.unwrap().value)
       p = p.unwrap().right
@@ -355,12 +355,12 @@ fn eachi[V](self : Node[V], f : (Int, V) -> Unit) -> Unit {
   let s = []
   let mut p = Some(self)
   let mut i = 0
-  while p.is_empty().not() || s.is_empty().not() {
-    while p.is_empty().not() {
+  while p.is_empty().negate() || s.is_empty().negate() {
+    while p.is_empty().negate() {
       s.push(p)
       p = p.unwrap().left
     }
-    if s.is_empty().not() {
+    if s.is_empty().negate() {
       p = s.unsafe_pop()
       f(i, p.unwrap().value)
       p = p.unwrap().right

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -275,7 +275,7 @@ pub fn trim_start(self : String, trim_set : String) -> String {
         }
       }
     }
-    if trim_set.contains_char(self[i]).not() {
+    if not(trim_set.contains_char(self[i])) {
       return self.substring(start=i)
     }
   } else {
@@ -301,7 +301,7 @@ pub fn trim_end(self : String, trim_set : String) -> String {
         }
       }
     }
-    if trim_set.contains_char(self[i]).not() {
+    if not(trim_set.contains_char(self[i])) {
       return self.substring(end=i + 1)
     }
   } else {


### PR DESCRIPTION
We will introduce the `not x` syntax to avoid the illusion of LLM. For any code written like `not(x)` or `not x`, it will not break, except for `x.not()`. This PR remove usage like `x.not()` in core and introduces the `Bool::negate` method.