### PR TITLE
test: improve coverage for `math/trigonometric.mbt`

### DIFF
--- a/math/trigonometric_test.mbt
+++ b/math/trigonometric_test.mbt
@@ -224,3 +224,63 @@ test "atan2" {
   }
   inspect!(max_inaccuracy, content="4.440892098500626e-16")
 }
+
+test "tan with very small value" {
+  let x = 1.0e-8 // x * x = 1.0e-16 < 1.0e-14  
+  inspect!(@math.tan(x), content="1e-8")
+}
+
+test "asin with value greater than 1" {
+  inspect!(@math.asin(1.5), content="NaN")
+}
+
+test "atan2 with NaN" {
+  let y = @double.not_a_number
+  let x = 1.0
+  inspect!(atan2(y, x), content="NaN")
+  inspect!(atan2(1.0, @double.not_a_number), content="NaN")
+}
+
+test "atan2 with zero x" {
+  inspect!(atan2(1.0, 0.0), content="1.5707963267948966")
+  inspect!(atan2(-1.0, 0.0), content="-1.5707963267948966")
+}
+
+test "atan2 with zero y" {
+  inspect!(atan2(0.0, 1.0), content="0")
+  inspect!(atan2(0.0, -1.0), content="3.141592653589793")
+}
+
+test "atan2 with infinite y and finite x" {
+  inspect!(atan2(@double.infinity, 1.0), content="1.5707963267948966")
+  inspect!(atan2(-@double.infinity, 1.0), content="-1.5707963267948966")
+}
+
+test "atan2 with infinite x and finite y" {
+  inspect!(@math.atan2(1.0, @double.infinity), content="0")
+  inspect!(@math.atan2(1.0, @double.neg_infinity), content="3.141592653589793")
+  inspect!(@math.atan2(-1.0, @double.infinity), content="0")
+  inspect!(
+    @math.atan2(-1.0, @double.neg_infinity),
+    content="-3.141592653589793",
+  )
+}
+
+test "atan2 with infinite x and infinite y" {
+  inspect!(
+    @math.atan2(@double.infinity, @double.infinity),
+    content="0.7853981633974483",
+  )
+  inspect!(
+    @math.atan2(@double.neg_infinity, @double.infinity),
+    content="-0.7853981633974483",
+  )
+  inspect!(
+    @math.atan2(@double.infinity, @double.neg_infinity),
+    content="2.356194490192345",
+  )
+  inspect!(
+    @math.atan2(@double.neg_infinity, @double.neg_infinity),
+    content="-2.356194490192345",
+  )
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `math/trigonometric.mbt`: 74.0% -> 98.6%
```