### PR TITLE
fix unnamed index in inline-wasm

### DIFF
--- a/double/round_wasm.mbt
+++ b/double/round_wasm.mbt
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 ///|
-pub fn trunc(self : Double) -> Double = "(func (param f64) (result f64) (f64.trunc (local.get 0)))"
+pub fn trunc(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.trunc (local.get $d)))"
 
 ///|
-pub fn ceil(self : Double) -> Double = "(func (param f64) (result f64) (f64.ceil (local.get 0)))"
+pub fn ceil(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.ceil (local.get $d)))"
 
 ///|
-pub fn floor(self : Double) -> Double = "(func (param f64) (result f64) (f64.floor (local.get 0)))"
+pub fn floor(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.floor (local.get $d)))"
 
 ///|
 // Round to nearest, ties to Ceiling

--- a/float/round_wasm.mbt
+++ b/float/round_wasm.mbt
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 ///|
-pub fn trunc(self : Float) -> Float = "(func (param f32) (result f32) (f32.trunc (local.get 0)))"
+pub fn trunc(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.trunc (local.get $f)))"
 
 ///|
-pub fn ceil(self : Float) -> Float = "(func (param f32) (result f32) (f32.ceil (local.get 0)))"
+pub fn ceil(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.ceil (local.get $f)))"
 
 ///|
-pub fn floor(self : Float) -> Float = "(func (param f32) (result f32) (f32.floor (local.get 0)))"
+pub fn floor(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.floor (local.get $f)))"
 
 ///|
 // Round to nearest, ties to Ceiling


### PR DESCRIPTION
The compiler will no longer support the unnamed index in inline-wasm.