### PR TITLE
explicitly disable test-import-all for json

### DIFF
--- a/json/moon.pkg.json
+++ b/json/moon.pkg.json
@@ -10,5 +10,6 @@
     "moonbitlang/core/option",
     "moonbitlang/core/unit",
     "moonbitlang/core/array"
-  ]
+  ],
+  "test-import-all": false
 }


### PR DESCRIPTION
We are about to change default value for "test-import-all" to true for blackbox tests. That will cause the blackbox tests @json package fail to type check so I just explicitly set "test-import-all" to false beforehand.