### PR TITLE
Use native array map under js target

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -264,26 +264,6 @@ pub fn clear[T](self : Array[T]) -> Unit {
 }
 
 ///|
-/// Maps a function over the elements of the array.
-///
-/// # Example
-/// ```
-/// let v = [3, 4, 5]
-/// let v2 = v.map(fn (x) {x + 1})
-/// assert_eq!(v2, [4, 5, 6])
-/// ```
-pub fn map[T, U](self : Array[T], f : (T) -> U) -> Array[U] {
-  if self.length() == 0 {
-    return []
-  }
-  let arr = Array::make_uninit(self.length())
-  for i, v in self {
-    arr.unsafe_set(i, f(v))
-  }
-  arr
-}
-
-///|
 /// Maps a function over the elements of the array in place.
 ///
 /// # Example

--- a/builtin/array_js.mbt
+++ b/builtin/array_js.mbt
@@ -1,0 +1,36 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+extern "js" fn JSArray::map(
+  self : JSArray,
+  f : (JSValue) -> JSValue
+) -> JSArray =
+  #| (arr, f) => arr.map(f)
+
+///|
+fn js_unsafe_cast_mapper[T, U](f : (T) -> U) -> (JSValue) -> JSValue = "%identity"
+
+///|
+/// Maps a function over the elements of the array.
+///
+/// # Example
+/// ```
+/// let v = [3, 4, 5]
+/// let v2 = v.map(fn (x) {x + 1})
+/// assert_eq!(v2, [4, 5, 6])
+/// ```
+pub fn map[T, U](self : Array[T], f : (T) -> U) -> Array[U] {
+  JSArray::ofAnyArray(self).map(js_unsafe_cast_mapper(f)).toAnyArray()
+}

--- a/builtin/array_nonjs.mbt
+++ b/builtin/array_nonjs.mbt
@@ -1,0 +1,33 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Maps a function over the elements of the array.
+///
+/// # Example
+/// ```
+/// let v = [3, 4, 5]
+/// let v2 = v.map(fn (x) {x + 1})
+/// assert_eq!(v2, [4, 5, 6])
+/// ```
+pub fn map[T, U](self : Array[T], f : (T) -> U) -> Array[U] {
+  if self.length() == 0 {
+    return []
+  }
+  let arr = Array::make_uninit(self.length())
+  for i, v in self {
+    arr.unsafe_set(i, f(v))
+  }
+  arr
+}

--- a/builtin/moon.pkg.json
+++ b/builtin/moon.pkg.json
@@ -21,6 +21,8 @@
     "bigint_nonjs_wbtest.mbt": ["not", "js"],
     "arraycore_js.mbt": ["js"],
     "arraycore_nonjs.mbt": ["not", "js"],
+    "array_js.mbt": ["js"],
+    "array_nonjs.mbt": ["not", "js"],
     "panic_test.mbt": ["not", "native"],
     "panic_wbtest.mbt": ["not", "native"],
     "panic_nonjs_test.mbt": ["wasm", "wasm-gc"],


### PR DESCRIPTION
This MR make `Array::map` implementation platform specific to use native JavaScript Array::map under js target.