### PR TITLE
add get_or_init for hashmap

### DIFF
--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -118,6 +118,45 @@ pub fn op_get[K : Hash + Eq, V](self : T[K, V], key : K) -> V? {
 }
 
 ///|
+/// Gets the value associated with the given key. If the key doesn't exist in the
+/// map, initializes it with the given function and returns the new value.
+///
+/// Parameters:
+///
+/// * `map` : The hash map to operate on.
+/// * `key` : The key to look up in the map.
+/// * `init_fn` : A function that takes the key and returns a new value. This
+/// function is called only when the key is not found in the map.
+///
+/// Returns the value associated with the key, either existing or newly
+/// initialized.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "get_or_init" {
+///   let map : @hashmap.T[String, Int] = @hashmap.new()
+///   let v = map.get_or_init("key", fn(k) { k.length() })
+///   inspect!(v, content="3")
+///   inspect!(map.get("key"), content="Some(3)")
+/// }
+/// ```
+pub fn get_or_init[K : Hash + Eq, V](
+  self : T[K, V],
+  key : K,
+  init : (K) -> V
+) -> V {
+  match self.get(key) {
+    Some(v) => v
+    None => {
+      let v = init(key)
+      self.set(key, v)
+      v
+    }
+  }
+}
+
+///|
 /// Get the value associated with a key, 
 /// returns the provided default value if the key does not exist.
 pub fn get_or_default[K : Hash + Eq, V](

--- a/hashmap/hashmap.mbti
+++ b/hashmap/hashmap.mbti
@@ -16,6 +16,7 @@ impl T {
   from_iter[K : Hash + Eq, V](Iter[(K, V)]) -> Self[K, V]
   get[K : Hash + Eq, V](Self[K, V], K) -> V?
   get_or_default[K : Hash + Eq, V](Self[K, V], K, V) -> V
+  get_or_init[K : Hash + Eq, V](Self[K, V], K, (K) -> V) -> V
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -289,3 +289,37 @@ test "from_iter empty iter" {
   let map : @hashmap.T[Int, Int] = @hashmap.T::from_iter(Iter::empty())
   inspect!(map, content="HashMap::of([])")
 }
+
+test "@hashmap.T::get_or_init/init_new_key" {
+  let map : @hashmap.T[String, Int] = @hashmap.T::new()
+  // Test initialization of a new key
+  let v1 = map.get_or_init("test", fn(__) { __.length() })
+  inspect!(v1, content="4")
+  inspect!(map.get("test"), content="Some(4)")
+}
+
+test "@hashmap.T::get_or_init/existing_key" {
+  let map : @hashmap.T[String, Int] = @hashmap.T::new()
+  map.set("key", 42)
+  // Test retrieval of existing key without calling init function
+  let v2 = map.get_or_init("key", fn(__) { __.length() })
+  inspect!(v2, content="42")
+  inspect!(map.get("key"), content="Some(42)")
+}
+
+test "@hashmap.T::get_or_init/multiple_calls" {
+  let map : @hashmap.T[String, Int] = @hashmap.T::new()
+  let mut counter = 0
+  // Test that init function is only called once for the same key
+  let v1 = map.get_or_init("test", fn(__) {
+    counter = counter + 1
+    counter
+  })
+  let v2 = map.get_or_init("test", fn(__) {
+    counter = counter + 1
+    counter
+  })
+  inspect!(v1, content="1")
+  inspect!(v2, content="1")
+  inspect!(counter, content="1")
+}


### PR DESCRIPTION
Closes #1344 

This PR introduce `@hashmap.T::get_or_init`. It's signature slightly different from `linked_hashmap.T::get_or_init`. Which `init` parameter is a function takes key as argument. `linked_hashmap.T::get_or_init` doesn't.

There's no safe way to migrate `get_or_init` from old signature to new signature. Maybe introduce a new name `get_or_add`?
