### PR TITLE
Fix trigonometric function's output when input is inf

### DIFF
--- a/math/trigonometric.mbt
+++ b/math/trigonometric.mbt
@@ -41,7 +41,7 @@ let sin_ = [
 ///|
 pub fn sin(x : Double) -> Double {
   if Double::is_inf(x) || Double::is_nan(x) {
-    x
+    @double.not_a_number
   } else {
     let mut sign = false
     let mut x_ = x
@@ -100,7 +100,7 @@ let cos_ = [
 ///|
 pub fn cos(x : Double) -> Double {
   if Double::is_inf(x) || Double::is_nan(x) {
-    x
+    @double.not_a_number
   } else {
     let mut sign = false
     let x_ = x.abs()
@@ -163,7 +163,7 @@ let tan_q = [
 ///|
 pub fn tan(x : Double) -> Double {
   if Double::is_inf(x) || Double::is_nan(x) {
-    x
+    @double.not_a_number
   } else {
     let x_ = x.abs()
     let mut j = (x_ * pi4).to_int64()
@@ -255,7 +255,7 @@ pub fn atan(x : Double) -> Double {
 
 ///|
 pub fn asin(x : Double) -> Double {
-  if Double::is_inf(x) || Double::is_nan(x) || x == 0.0 {
+  if Double::is_nan(x) || x == 0.0 {
     x
   } else {
     let x_ = x.abs()
@@ -271,7 +271,7 @@ pub fn asin(x : Double) -> Double {
 
 ///|
 pub fn acos(x : Double) -> Double {
-  if Double::is_inf(x) || Double::is_nan(x) {
+  if Double::is_nan(x) {
     x
   } else {
     PI / 2.0 - asin(x)

--- a/math/trigonometric_test.mbt
+++ b/math/trigonometric_test.mbt
@@ -44,8 +44,8 @@ test "sin" {
     -6.7344058693131973066e-01,
   ]
   inspect!(@math.sin(@double.not_a_number), content="NaN")
-  inspect!(@math.sin(@double.infinity), content="Infinity")
-  inspect!(@math.sin(@double.neg_infinity), content="-Infinity")
+  inspect!(@math.sin(@double.infinity), content="NaN")
+  inspect!(@math.sin(@double.neg_infinity), content="NaN")
   let mut max_inaccuracy = 0.0
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(imprecise_equal(@math.sin(vf[i]), sin_res[i]), content="true")
@@ -79,8 +79,8 @@ test "cos" {
     -7.3924135157173099849e-01,
   ]
   inspect!(@math.cos(@double.not_a_number), content="NaN")
-  inspect!(@math.cos(@double.infinity), content="Infinity")
-  inspect!(@math.cos(@double.neg_infinity), content="-Infinity")
+  inspect!(@math.cos(@double.infinity), content="NaN")
+  inspect!(@math.cos(@double.neg_infinity), content="NaN")
   let mut max_inaccuracy = 0.0
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(imprecise_equal(@math.cos(vf[i]), cos_res[i]), content="true")
@@ -114,8 +114,8 @@ test "tan" {
     9.1098879344275101051e-01,
   ]
   inspect!(@math.tan(@double.not_a_number), content="NaN")
-  inspect!(@math.tan(@double.infinity), content="Infinity")
-  inspect!(@math.tan(@double.neg_infinity), content="-Infinity")
+  inspect!(@math.tan(@double.infinity), content="NaN")
+  inspect!(@math.tan(@double.neg_infinity), content="NaN")
   let mut max_inaccuracy = 0.0
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(imprecise_equal(@math.tan(vf[i]), tan_res[i]), content="true")
@@ -164,8 +164,8 @@ test "asin" {
     -1.0523547536021497774980928e+00,
   ]
   inspect!(@math.asin(@double.not_a_number), content="NaN")
-  inspect!(@math.asin(@double.infinity), content="Infinity")
-  inspect!(@math.asin(@double.neg_infinity), content="-Infinity")
+  inspect!(@math.asin(@double.infinity), content="NaN")
+  inspect!(@math.asin(@double.neg_infinity), content="NaN")
   let mut max_inaccuracy = 0.0
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(
@@ -188,8 +188,8 @@ test "acos" {
     2.6231510803970463967294145e+00,
   ]
   inspect!(@math.acos(@double.not_a_number), content="NaN")
-  inspect!(@math.acos(@double.infinity), content="Infinity")
-  inspect!(@math.acos(@double.neg_infinity), content="-Infinity")
+  inspect!(@math.acos(@double.infinity), content="NaN")
+  inspect!(@math.acos(@double.neg_infinity), content="NaN")
   let mut max_inaccuracy = 0.0
   for i = 0; i < vf.length(); i = i + 1 {
     inspect!(


### PR DESCRIPTION
There are some problems:

`sin(inf)` should be `NaN`, not `Infinity`
`sin(-inf)` should be `NaN`, not `-Infinity`
`cos(inf)` should be `NaN`, not `Infinity`
`cos(-inf)` should be `NaN`, not `-Infinity`
`tan(inf)` should be `NaN`, not `Infinity`
`tan(-inf)` should be `NaN`, not `-Infinity`
`asin(inf)` should be `NaN`, not `Infinity`
`asin(-inf)` should be `NaN`, not `-Infinity`
`acos(inf)` should be `NaN`, not `Infinity`
`acos(-inf)` should be `NaN`, not `-Infinity`

Verify it in python (Not only python, I get same resutlt in C, rust, and the like):

```python
>>> import numpy as np
>>> import warnings
>>> warnings.simplefilter("ignore") # ignore warnings because numpy will throw warnings when output contains `nan`
>>> numbers_contain_inf = np.array([-np.inf, np.inf, 0.0, 1.0])
>>> np.sin(numbers_contain_inf)
array([       nan,        nan, 0.        , 0.84147098])
>>> np.cos(numbers_contain_inf)
array([       nan,        nan, 1.        , 0.54030231])
>>> np.tan(numbers_contain_inf)
array([       nan,        nan, 0.        , 1.55740772])
>>> np.arcsin(numbers_contain_inf)
array([       nan,        nan, 0.        , 1.57079633])
>>> np.arccos(numbers_contain_inf)
array([       nan,        nan, 1.57079633, 0.        ])
>>> 
```