### PR TITLE
feat(deque): add `@deque.iter2()` and `@deque.copy()`

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -566,6 +566,33 @@ pub fn iter[A](self : T[A]) -> Iter[A] {
 }
 
 ///|
+pub fn iter2[A](self : T[A]) -> Iter2[Int, A] {
+  Iter2::new(fn(yield_) {
+    guard not(self.is_empty()) else { IterContinue }
+    let { head, buf, len, .. } = self
+    let cap = buf.length()
+    let head_len = cap - head
+    let mut j = 0
+    if head_len >= len {
+      for i in head..<(head + len) {
+        guard let IterContinue = yield_(j, buf[i]) else { x => return x }
+        j += 1
+      }
+    } else {
+      for i in head..<cap {
+        guard let IterContinue = yield_(j, buf[i]) else { x => return x }
+        j += 1
+      }
+      for i in 0..<(len - head_len) {
+        guard let IterContinue = yield_(j, buf[i]) else { x => return x }
+        j += 1
+      }
+    }
+    IterContinue
+  })
+}
+
+///|
 pub fn T::from_iter[A](iter : Iter[A]) -> T[A] {
   let dq = T::new()
   iter.each(fn(e) { dq.push_back(e) })

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -39,6 +39,22 @@ pub fn T::from_array[A](arr : Array[A]) -> T[A] {
 }
 
 ///|
+/// Creates a new copy of this deque.
+pub fn T::copy[A](self : T[A]) -> T[A] {
+  let len = self.len
+  let deq = T::{
+    buf: UninitializedArray::make(len),
+    len,
+    head: 0,
+    tail: len - 1,
+  }
+  for i, x in self {
+    deq.buf[i] = x
+  }
+  deq
+}
+
+///|
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
   let deq = T::{
     buf: UninitializedArray::make(arr.length()),

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -542,12 +542,26 @@ pub fn shrink_to_fit[A](self : T[A]) -> Unit {
 ///|
 pub fn iter[A](self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
-    for i in 0..<self.length() {
-      guard let IterContinue = yield_(self[i]) else { x => break x }
+    guard not(self.is_empty()) else { IterContinue }
+    let { head, buf, len, .. } = self
+    let cap = buf.length()
+    let head_len = cap - head
+    if head_len >= len {
+      for i in head..<(head + len) {
+        guard let IterContinue = yield_(buf[i]) else { x => return x }
 
+      }
     } else {
-      IterContinue
+      for i in head..<cap {
+        guard let IterContinue = yield_(buf[i]) else { x => return x }
+
+      }
+      for i in 0..<(len - head_len) {
+        guard let IterContinue = yield_(buf[i]) else { x => return x }
+
+      }
     }
+    IterContinue
   })
 }
 

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -16,6 +16,7 @@ impl T {
   front[A](Self[A]) -> A?
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
+  iter2[A](Self[A]) -> Iter2[Int, A]
   length[A](Self[A]) -> Int
   map[A, U](Self[A], (A) -> U) -> Self[U]
   mapi[A, U](Self[A], (Int, A) -> U) -> Self[U]

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -9,6 +9,7 @@ impl T {
   capacity[A](Self[A]) -> Int
   clear[A](Self[A]) -> Unit
   contains[A : Eq](Self[A], A) -> Bool
+  copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   from_array[A](Array[A]) -> Self[A]

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -374,3 +374,75 @@ test "from_iter empty iter" {
   let dq : @deque.T[Int] = @deque.T::from_iter(Iter::empty())
   inspect!(dq, content="@deque.of([])")
 }
+
+test "from_array with single element" {
+  let arr = [42]
+  let deque = @deque.T::from_array(arr)
+  assert_eq!(deque.length(), 1)
+  assert_eq!(deque.front(), Some(42))
+  assert_eq!(deque.back(), Some(42))
+}
+
+test "unsafe_pop_front after many push_front" {
+  let dq = @deque.new()
+  // First fill some elements to create a buffer with some capacity
+  for i = 0; i < 10; i = i + 1 {
+    dq.push_front(i)
+  }
+  // Pop all elements except one
+  for i = 0; i < 9; i = i + 1 {
+    dq.unsafe_pop_front()
+  }
+  // Now head should be at the end of buffer
+  // When we pop again, head should wrap around to 0
+  inspect!(dq.front(), content="Some(0)")
+  dq.unsafe_pop_front()
+  inspect!(dq.is_empty(), content="true")
+}
+
+test "unsafe_pop_back when tail needs to wrap around" {
+  let dq = @deque.new(capacity=2)
+  dq.push_back(1) // tail = 0
+  dq.push_back(2) // tail = 1
+  dq.unsafe_pop_front() // head = 1
+  dq.push_back(3) // tail = 0 (wraps around)
+  dq.unsafe_pop_back()
+  inspect!(dq.back(), content="Some(2)")
+}
+
+test "deque op_set wrapping case" {
+  let dq = @deque.new(capacity=4)
+  // Add elements until the deque wraps around
+  dq.push_back(1) // head=0, tail=0
+  dq.push_back(2) // head=0, tail=1
+  dq.push_back(3) // head=0, tail=2
+  dq.push_back(4) // head=0, tail=3
+  dq.push_front(0) // head=3, tail=3
+
+  // Now the deque is [0,1,2,3,4] with head=3, tail=3
+  // Setting dq[2] should trigger the uncovered branch
+  dq[2] = 10
+
+  // Verify the change
+  inspect!(dq, content="@deque.of([0, 10, 2, 3, 4])")
+}
+
+test "iter when tail needs to wrap around" {
+  let dq = @deque.new(capacity=2)
+  dq.push_back(1) // tail = 0
+  dq.push_back(2) // tail = 1
+  dq.unsafe_pop_front() // head = 1
+  dq.push_back(3) // tail = 0 (wraps around)
+  inspect!(dq.iter().to_array(), content="[2, 3]")
+  inspect!(dq.iter().filter(fn(x) { x % 2 == 0 }).to_array(), content="[2]")
+  inspect!(dq.iter().filter(fn(x) { x % 2 != 0 }).to_array(), content="[3]")
+}
+
+test "iter2 when tail needs to wrap around" {
+  let dq = @deque.new(capacity=2)
+  dq.push_back(1) // tail = 0
+  dq.push_back(2) // tail = 1
+  dq.unsafe_pop_front() // head = 1
+  dq.push_back(3) // tail = 0 (wraps around)
+  inspect!(dq.iter2().to_array(), content="[(0, 2), (1, 3)]")
+}

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -203,6 +203,15 @@ test "from_array" {
   inspect!(@deque.of([1, 2, 3]), content="@deque.of([1, 2, 3])")
 }
 
+test "copy" {
+  inspect!((@deque.new() : @deque.T[Int]).copy(), content="@deque.of([])")
+  let deq = @deque.of([1, 2, 3])
+  let deq1 = deq.copy()
+  deq1[0] = 111
+  inspect!(deq, content="@deque.of([1, 2, 3])")
+  inspect!(deq1, content="@deque.of([111, 2, 3])")
+}
+
 test "op_set" {
   let dv = @deque.of([1, 2, 3, 4, 5])
   dv[1] = 3


### PR DESCRIPTION
**Disclaimer:** The coverage improving part of this PR was generated by an LLM agent as part of an experiment.

## Summary

New methods added:

* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abR41-R56): Implemented the `copy` method, which creates a new copy of the deque.
* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL545-R607): Added the `iter2` method, which iterates over the deque with index and element pairs.
* [`deque/deque.mbti`](diffhunk://#diff-737e400600b9637258470836512a543fcf682ffc779b855d5aa15c741d4a6006R12-R20): Updated the `impl T` block to include the `copy` and `iter2` methods.

Optimizations:

* [`deque/deque.mbt`](https://github.com/moonbitlang/core/pull/1354/commits/f8203aeba93311d21990e35f45b670215124e677): Applied `iter2`'s implementation method to the existing `iter`.

## Coverage

```
coverage of `deque/deque.mbt`: 87.4% -> 93.7%
```
