### PR TITLE
perf(deque): use `@deque.iter[2]()` for `@deque.each[i]()`

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -346,8 +346,8 @@ pub fn op_equal[A : Eq](self : T[A], other : T[A]) -> Bool {
 /// assert_eq!(sum, 15)
 /// ```
 pub fn each[A](self : T[A], f : (A) -> Unit) -> Unit {
-  for i = 0; i < self.length(); i = i + 1 {
-    f(self[i])
+  for v in self {
+    f(v)
   }
 }
 
@@ -362,8 +362,8 @@ pub fn each[A](self : T[A], f : (A) -> Unit) -> Unit {
 /// assert_eq!(idx_sum, 10)
 /// ```
 pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
-  for i = 0; i < self.length(); i = i + 1 {
-    f(i, self[i])
+  for i, v in self {
+    f(i, v)
   }
 }
 


### PR DESCRIPTION
Continuation of https://github.com/moonbitlang/core/pull/1354.

## Summary

Improvements to iteration methods:

* `pub fn each[A](self : T[A], f : (A) -> Unit) -> Unit`: Updated the method to use a direct iteration over the collection instead of indexing.
* `pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit`: Updated the method to use a direct iteration with index over the collection instead of indexing.