### PR TITLE
fix(deque): fix incorrect `@deque.push*()` behavior when empty

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -157,8 +157,10 @@ pub fn push_front[A](self : T[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
   }
-  if self.len != 0 {
-    self.head = (self.head + self.buf.length() - 1) % self.buf.length()
+  self.head = if self.len == 0 {
+    self.tail
+  } else {
+    (self.head + self.buf.length() - 1) % self.buf.length()
   }
   self.buf[self.head] = value
   self.len += 1
@@ -179,8 +181,10 @@ pub fn push_back[A](self : T[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
   }
-  if self.len != 0 {
-    self.tail = (self.tail + self.buf.length() + 1) % self.buf.length()
+  self.tail = if self.len == 0 {
+    self.head
+  } else {
+    (self.tail + self.buf.length() + 1) % self.buf.length()
   }
   self.buf[self.tail] = value
   self.len += 1

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -427,6 +427,22 @@ test "deque op_set wrapping case" {
   inspect!(dq, content="@deque.of([0, 10, 2, 3, 4])")
 }
 
+test "deque push_front when empty" {
+  let d = @deque.of([0, 1])
+  ignore(d.pop_back())
+  guard let Some(f) = d.pop_back()
+  d.push_front(f)
+  inspect!(d, content="@deque.of([0])")
+}
+
+test "deque push_back when empty" {
+  let d = @deque.of([0, 1])
+  ignore(d.pop_front())
+  guard let Some(f) = d.pop_front()
+  d.push_back(f)
+  inspect!(d, content="@deque.of([1])")
+}
+
 test "iter when tail needs to wrap around" {
   let dq = @deque.new(capacity=2)
   dq.push_back(1) // tail = 0


### PR DESCRIPTION
Closes #1361 by addressing the immediate concern WRT the usage in `cmark`.

Whether `tail` should be a computed state instead of a save state is still an open question.