### PR TITLE
fix(iter): tap

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -238,7 +238,7 @@ impl Iter {
   singleton[T](T) -> Self[T]
   take[T](Self[T], Int) -> Self[T]
   take_while[T](Self[T], (T) -> Bool) -> Self[T]
-  tap[T](Self[T], (T) -> Unit) -> Self[T] //deprecated
+  tap[T](Self[T], (T) -> Unit) -> Self[T]
   to_array[T](Self[T]) -> Array[T]
 }
 impl[T : Show] Show for Iter[T]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -474,12 +474,13 @@ pub fn flat_map[T, R](self : Iter[T], f : (T) -> Iter[R]) -> Iter[R] {
 /// # Returns
 ///
 /// The same iterator.
-/// 
-/// @alert deprecated "use cascade operator [..] instead"
-/// @coverage.skip
 pub fn tap[T](self : Iter[T], f : (T) -> Unit) -> Iter[T] {
-  self.each(f)
-  self
+  self.map(fn {
+    a => {
+      f(a)
+      a
+    }
+  })
 }
 
 ///|

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -269,8 +269,8 @@ test "find_first2" {
 test "tap" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = StringBuilder::new(size_hint=0)
-  iter..each(fn { x => exb.write_char(x) }).each(fn { x => exb.write_char(x) })
-  inspect!(exb, content="1234512345")
+  iter.tap(fn { x => exb.write_char(x) }).each(fn { x => exb.write_char(x) })
+  inspect!(exb, content="1122334455")
 }
 
 test "prepend" {


### PR DESCRIPTION
The `tap` should be used to perform side effects during the iteration of one item instead of rerunning the iteration.