### PR TITLE
perf(deque): use `@deque.rev_iter[2]()` for `@deque.rev_each[i]()`

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -662,6 +662,59 @@ pub fn iter2[A](self : T[A]) -> Iter2[Int, A] {
 }
 
 ///|
+pub fn rev_iter[A](self : T[A]) -> Iter[A] {
+  Iter::new(fn(yield_) {
+    guard not(self.is_empty()) else { IterContinue }
+    let { head, buf, len, .. } = self
+    let cap = buf.length()
+    let head_len = cap - head
+    if head_len >= len {
+      for i = head + len - 1; i >= head; i = i - 1 {
+        guard let IterContinue = yield_(buf[i]) else { x => return x }
+
+      }
+    } else {
+      for i = len - head_len - 1; i >= 0; i = i - 1 {
+        guard let IterContinue = yield_(buf[i]) else { x => return x }
+
+      }
+      for i = cap - 1; i >= head; i = i - 1 {
+        guard let IterContinue = yield_(buf[i]) else { x => return x }
+
+      }
+    }
+    IterContinue
+  })
+}
+
+///|
+pub fn rev_iter2[A](self : T[A]) -> Iter2[Int, A] {
+  Iter2::new(fn(yield_) {
+    guard not(self.is_empty()) else { IterContinue }
+    let { head, buf, len, .. } = self
+    let cap = buf.length()
+    let head_len = cap - head
+    let mut j = 0
+    if head_len >= len {
+      for i = head + len - 1; i >= head; i = i - 1 {
+        guard let IterContinue = yield_(j, buf[i]) else { x => return x }
+        j += 1
+      }
+    } else {
+      for i = len - head_len - 1; i >= 0; i = i - 1 {
+        guard let IterContinue = yield_(j, buf[i]) else { x => return x }
+        j += 1
+      }
+      for i = cap - 1; i >= head; i = i - 1 {
+        guard let IterContinue = yield_(j, buf[i]) else { x => return x }
+        j += 1
+      }
+    }
+    IterContinue
+  })
+}
+
+///|
 pub fn T::from_iter[A](iter : Iter[A]) -> T[A] {
   let dq = T::new()
   iter.each(fn(e) { dq.push_back(e) })

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -431,8 +431,8 @@ pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
 /// assert_eq!(sum, 15)
 /// ```
 pub fn rev_each[A](self : T[A], f : (A) -> Unit) -> Unit {
-  for i = self.length() - 1; i >= 0; i = i - 1 {
-    f(self[i])
+  for v in self.rev_iter() {
+    f(v)
   }
 }
 
@@ -447,8 +447,8 @@ pub fn rev_each[A](self : T[A], f : (A) -> Unit) -> Unit {
 /// assert_eq!(idx_sum, 10)
 /// ```
 pub fn rev_eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
-  for i = 0; i < self.len; i = i + 1 {
-    f(i, self[self.len - i - 1])
+  for i, v in self.rev_iter2() {
+    f(i, v)
   }
 }
 

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -35,6 +35,8 @@ impl T {
   reserve_capacity[A](Self[A], Int) -> Unit
   rev_each[A](Self[A], (A) -> Unit) -> Unit
   rev_eachi[A](Self[A], (Int, A) -> Unit) -> Unit
+  rev_iter[A](Self[A]) -> Iter[A]
+  rev_iter2[A](Self[A]) -> Iter2[Int, A]
   search[A : Eq](Self[A], A) -> Int?
   shrink_to_fit[A](Self[A]) -> Unit
   unsafe_pop_back[A](Self[A]) -> Unit

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -129,7 +129,7 @@ test "mapi" {
   inspect!(dve.mapi(fn(_idx, x) { x }), content="@deque.of([])")
 }
 
-test "iter_rev" {
+test "rev_each" {
   let mut i = 6
   let mut failed = false
   @deque.of([1, 2, 3, 4, 5]).rev_each(fn(elem) {
@@ -141,7 +141,7 @@ test "iter_rev" {
   assert_false!(failed)
 }
 
-test "iter_revi" {
+test "rev_eachi" {
   let mut i = 6
   let mut j = 0
   let mut failed = false
@@ -445,6 +445,33 @@ test "iter2 when tail needs to wrap around" {
   dq.unsafe_pop_front() // head = 1
   dq.push_back(3) // tail = 0 (wraps around)
   inspect!(dq.iter2().to_array(), content="[(0, 2), (1, 3)]")
+}
+
+test "rev_iter when head needs to wrap around" {
+  let dq = @deque.new(capacity=4)
+  dq.push_back(1)
+  dq.unsafe_pop_front()
+  dq.push_back(2)
+  dq.unsafe_pop_front()
+  for i in 3..=6 {
+    dq.push_back(i)
+  }
+  inspect!(dq.rev_iter().to_array(), content="[6, 5, 4, 3]")
+}
+
+test "rev_iter2 when head needs to wrap around" {
+  let dq = @deque.new(capacity=4)
+  dq.push_back(1)
+  dq.unsafe_pop_front()
+  dq.push_back(2)
+  dq.unsafe_pop_front()
+  for i in 3..=6 {
+    dq.push_back(i)
+  }
+  inspect!(
+    dq.rev_iter2().to_array(),
+    content="[(0, 6), (1, 5), (2, 4), (3, 3)]",
+  )
 }
 
 test "deque push_front when empty" {


### PR DESCRIPTION
This pull request includes changes to the `deque` module to improve iteration methods and add tests for reverse iteration. The most important changes include refactoring existing iteration methods to use new reverse iteration methods and adding tests to ensure the correctness of these new methods.

Refactoring iteration methods:

* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL434-R435): Refactored `rev_each` and `rev_eachi` methods to use the new `rev_iter` and `rev_iter2` methods respectively. [[1]](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL434-R435) [[2]](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL450-R451)
* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abR664-R716): Added new methods `rev_iter` and `rev_iter2` for reverse iteration over the deque.

Adding tests for reverse iteration:

* [`deque/deque_test.mbt`](diffhunk://#diff-46a7f13b15b6d6de84cc5c2201ce14d99af98ef107c85918796ad6ce2a03de2fL132-R132): Renamed existing tests to match the new method names (`rev_each` and `rev_eachi`). [[1]](diffhunk://#diff-46a7f13b15b6d6de84cc5c2201ce14d99af98ef107c85918796ad6ce2a03de2fL132-R132) [[2]](diffhunk://#diff-46a7f13b15b6d6de84cc5c2201ce14d99af98ef107c85918796ad6ce2a03de2fL144-R144)
* [`deque/deque_test.mbt`](diffhunk://#diff-46a7f13b15b6d6de84cc5c2201ce14d99af98ef107c85918796ad6ce2a03de2fR450-R467): Added new tests for `rev_iter` and `rev_iter2` to verify their functionality, including scenarios where the head needs to wrap around.