### PR TITLE
test: improve coverage for `builtin/option.mbt`

### DIFF
--- a/builtin/option_test.mbt
+++ b/builtin/option_test.mbt
@@ -19,3 +19,13 @@ test {
   assert_not_eq!(Option::None, Option::Some(1))
   assert_not_eq!(Option::Some(1), Option::None)
 }
+
+test "to_string for Option None" {
+  let x : Int? = None
+  inspect!(x.to_string(), content="None")
+}
+
+test "to_string for Option Some" {
+  let x : Int? = Some(42)
+  inspect!(x.to_string(), content="Some(42)")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/option.mbt`: 70.0% -> 100%
```