### PR TITLE
feat(deque): add `@deque.as_views()`

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -374,6 +374,7 @@ type UninitializedArray
 impl UninitializedArray {
   length[A](Self[A]) -> Int
   make[T](Int) -> Self[T]
+  op_as_view[T](Self[T], start~ : Int = .., end? : Int) -> ArrayView[T]
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
 }

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -47,6 +47,37 @@ pub fn op_get[T](self : UninitializedArray[T], index : Int) -> T = "%fixedarray.
 pub fn op_set[T](self : UninitializedArray[T], index : Int, value : T) = "%fixedarray.set"
 
 ///|
+/// Creates a view into a portion of the uninitialized array.
+///
+/// Parameters:
+///
+/// * `array` : The uninitialized array to create a view from.
+/// * `start` : The starting index of the view (inclusive). Defaults to 0.
+/// * `end` : The ending index of the view (exclusive). If not provided, defaults
+/// to the length of the array.
+///
+/// Returns an `ArrayView` that provides a window into the specified portion of
+/// the array.
+///
+/// Throws an error if the indices are out of bounds or if `start` is greater
+/// than `end`.
+pub fn op_as_view[T](
+  self : UninitializedArray[T],
+  start~ : Int = 0,
+  end? : Int
+) -> ArrayView[T] {
+  let len = self.length()
+  let end = match end {
+    None => len
+    Some(end) => end
+  }
+  guard start >= 0 && start <= end && end <= len else {
+    abort("View start index out of bounds")
+  }
+  { buf: self, start, len: end - start }
+}
+
+///|
 /// Returns the length of an uninitialized array.
 ///
 /// Parameters:
@@ -67,4 +98,21 @@ fn UninitializedArray::unsafe_blit[T](
   len : Int
 ) -> Unit {
   FixedArray::unsafe_blit(dst._, dst_offset, src._, src_offset, len)
+}
+
+test "op_as_view with valid_range" {
+  let arr : UninitializedArray[Int] = UninitializedArray::make(5)
+  let view = arr[1:4]
+  inspect!(view.start, content="1")
+  inspect!(view.len, content="3")
+}
+
+test "panic op_as_view with invalid_start" {
+  let arr : UninitializedArray[Int] = UninitializedArray::make(5)
+  ignore(arr[-1:])
+}
+
+test "panic op_as_view with invalid_end" {
+  let arr : UninitializedArray[Int] = UninitializedArray::make(5)
+  ignore(arr[2:10])
 }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -375,6 +375,44 @@ pub fn op_set[A](self : T[A], index : Int, value : A) -> Unit {
 }
 
 ///|
+/// Returns two array views that together represent all elements in the deque in
+/// their correct order. The first view contains elements from the head to the
+/// end of the internal buffer, and the second view contains any remaining
+/// elements from the start of the buffer.
+///
+/// If the deque is empty, returns a pair of empty views. If all elements are
+/// contiguous in memory, the second view will be empty.
+///
+/// Parameters:
+///
+/// * `self` : The deque to be viewed.
+///
+/// Returns a tuple of two array views that together contain all elements of the
+/// deque in order.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "T::as_views" {
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   let (v1, v2) = dq.as_views()
+///   inspect!(v1.length(), content="5")
+///   inspect!(v2.length(), content="0")
+/// }
+/// ```
+pub fn T::as_views[A](self : T[A]) -> (ArrayView[A], ArrayView[A]) {
+  guard self.len != 0 else { ([][:], [][:]) }
+  let { buf, head, len, .. } = self
+  let cap = buf.length()
+  let head_len = cap - head
+  if head_len >= len {
+    (buf[head:head + len], [][:])
+  } else {
+    (buf[head:cap], buf[:len - head_len])
+  }
+}
+
+///|
 /// Compares two deques for equality.
 pub fn op_equal[A : Eq](self : T[A], other : T[A]) -> Bool {
   if self.len != other.len {

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -5,6 +5,7 @@ package moonbitlang/core/deque
 // Types and methods
 type T
 impl T {
+  as_views[A](Self[A]) -> (ArrayView[A], ArrayView[A])
   back[A](Self[A]) -> A?
   capacity[A](Self[A]) -> Int
   clear[A](Self[A]) -> Unit

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -519,3 +519,23 @@ test "deque push_back when empty" {
   d.push_back("b")
   inspect!(d, content="@deque.of([\"b\"])")
 }
+
+test "deque as_views" {
+  // Test empty deque
+  let dq1 : @deque.T[Int] = @deque.T::new()
+  inspect!(dq1.as_views(), content="([], [])")
+
+  // Test contiguous case (head_len >= len)
+  let dq2 = @deque.of([1, 2, 3])
+  inspect!(dq2.as_views(), content="([1, 2, 3], [])")
+
+  // Test split case (head_len < len)
+  let dq3 = @deque.of([1, 2, 3, 4])
+  // Push and pop to create a wrap-around situation
+  dq3.unsafe_pop_front()
+  dq3.unsafe_pop_front()
+  dq3.push_back(5)
+  dq3.push_back(6)
+  // Now the deque should be [3, 4, 5, 6] with internal wrap-around
+  inspect!(dq3.as_views(), content="([3, 4], [5, 6])")
+}


### PR DESCRIPTION
This is a preparation PR for `@deque.truncate()` as required in cmark.

The specific API in question mirrors Rust's [`VecDeque::as_slices()`](https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.as_slices).