### PR TITLE
feat(deque): add `@deque.truncate()`

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -647,6 +647,52 @@ pub fn shrink_to_fit[A](self : T[A]) -> Unit {
 }
 
 ///|
+/// Shortens the deque in-place, keeping the first `len` elements and dropping
+/// the rest.
+///
+/// If `len` is greater than or equal to the deque's current length, this has no
+/// effect.
+///
+/// Parameters:
+///
+/// * `self` : The deque to be truncated.
+/// * `len` : The new length of the deque.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "truncate" {
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   dq.truncate(3)
+///   inspect!(dq, content="@deque.of([1, 2, 3])")
+/// }
+/// ```
+pub fn truncate[A](self : T[A], len : Int) -> Unit {
+  let { head, buf, .. } = self
+  guard len < self.len else { return }
+  let (front, back) = self.as_views()
+  if front.length() < len {
+    // `len` is wrapping around the end of the buffer.
+    // Thus, we need to drop the latter part of the back view.
+    self.len = len
+    for i in (len - front.length())..<back.length() {
+      set_null(buf, i)
+    }
+  } else {
+    // `len` is not wrapping around the end of the buffer. Thus, we need to drop:
+    // - The latter part of the front view;
+    // - The entire back view.
+    self.len = len
+    for i in (head + len)..<(head + front.length()) {
+      set_null(buf, i)
+    }
+    for i in 0..<back.length() {
+      set_null(buf, i)
+    }
+  }
+}
+
+///|
 pub fn iter[A](self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
     guard not(self.is_empty()) else { IterContinue }

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -40,6 +40,7 @@ impl T {
   rev_iter2[A](Self[A]) -> Iter2[Int, A]
   search[A : Eq](Self[A], A) -> Int?
   shrink_to_fit[A](Self[A]) -> Unit
+  truncate[A](Self[A], Int) -> Unit
   unsafe_pop_back[A](Self[A]) -> Unit
   unsafe_pop_front[A](Self[A]) -> Unit
 }

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -539,3 +539,43 @@ test "deque as_views" {
   // Now the deque should be [3, 4, 5, 6] with internal wrap-around
   inspect!(dq3.as_views(), content="([3, 4], [5, 6])")
 }
+
+test "deque truncate" {
+  // Empty deque
+  let dq : @deque.T[Int] = @deque.new()
+  dq.truncate(3)
+  inspect!(dq, content="@deque.of([])")
+
+  // Length is greater than current length
+  let dq = @deque.of([1, 2, 3, 4, 5])
+  dq.truncate(3)
+  inspect!(dq, content="@deque.of([1, 2, 3])")
+
+  // Length is equal to current length
+  dq.truncate(3)
+  inspect!(dq, content="@deque.of([1, 2, 3])")
+
+  // Length is less than current length
+  dq.truncate(2)
+  inspect!(dq, content="@deque.of([1, 2])")
+
+  // Test split case (head_len < len)
+  // Push and pop to create a wrap-around situation
+  let dq = @deque.of([1, 2, 3, 4, 5, 6])
+    ..unsafe_pop_front()
+    ..unsafe_pop_front()
+    ..unsafe_pop_front()
+    ..push_back(7)
+    ..push_back(8)
+  // Current layout: [7, 8, X, 4, 5, 6]
+  inspect!(dq.as_views(), content="([4, 5, 6], [7, 8])")
+  dq.truncate(42)
+  // Current layout: [7, 8, X, 4, 5, 6]
+  inspect!(dq.as_views(), content="([4, 5, 6], [7, 8])")
+  dq.truncate(4)
+  // Current layout: [7, X, X, 4, 5, 6]
+  inspect!(dq.as_views(), content="([4, 5, 6], [7])")
+  // Current layout: [X, X, X, 4, 5, X]
+  dq.truncate(2)
+  inspect!(dq.as_views(), content="([4, 5], [])")
+}


### PR DESCRIPTION
This is a preparation PR for `@deque.filter_map_inplace()` as required in cmark.

The specific API in question mirrors Rust's [`VecDeque::truncate()`](https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.truncate).