### PR TITLE
feat(deque): add `@deque.filter_map_inplace()`

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -697,6 +697,65 @@ pub fn truncate[A](self : T[A], len : Int) -> Unit {
 }
 
 ///|
+/// Filters and maps elements in-place using a provided function. Modifies the
+/// deque to retain only elements for which the provided function returns `Some`,
+/// and updates those elements with the values inside the `Some` variant.
+///
+/// Parameters:
+///
+/// * `self` : The deque to be filtered and mapped.
+/// * `f` : A function that takes an element and returns either `Some` with a new
+/// value to replace the element, or `None` to remove the element.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "filter_map_inplace" {
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   dq.filter_map_inplace(fn(x) { if x % 2 == 0 { Some(x * 2) } else { None } })
+///   inspect!(dq, content="@deque.of([4, 8])")
+/// }
+/// ```
+pub fn filter_map_inplace[A](self : T[A], f : (A) -> A?) -> Unit {
+  guard not(self.is_empty()) else { return }
+  let { head, buf, .. } = self
+  let cap = buf.length()
+  let head_len = cap - head
+  let mut idx = head
+  let (front, back) = self.as_views()
+  for cur in front {
+    match f(cur) {
+      Some(v) => {
+        buf[idx] = v
+        idx += 1
+      }
+      None => ()
+    }
+  }
+  if back.length() == 0 {
+    self.truncate(idx - head)
+    return
+  }
+  for cur in back {
+    if idx == cap {
+      idx = 0
+    }
+    match f(cur) {
+      Some(v) => {
+        buf[idx] = v
+        idx += 1
+      }
+      None => ()
+    }
+  }
+  if idx <= self.len - head_len {
+    self.truncate(idx + head_len)
+  } else {
+    self.truncate(idx - head)
+  }
+}
+
+///|
 pub fn iter[A](self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
     guard not(self.is_empty()) else { IterContinue }

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -13,6 +13,7 @@ impl T {
   copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
+  filter_map_inplace[A](Self[A], (A) -> A?) -> Unit
   from_array[A](Array[A]) -> Self[A]
   from_iter[A](Iter[A]) -> Self[A]
   front[A](Self[A]) -> A?

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -791,3 +791,50 @@ test "deque truncate" {
   dq.truncate(2)
   inspect!(dq.as_views(), content="([4, 5], [])")
 }
+
+test "deque filter_map_inplace" {
+  let inc_if = fn(pred) { fn(x) { if pred(x) { Some(x + 1) } else { None } } }
+  let is_even = fn(x) { x % 2 == 0 }
+  let inc_if_even = inc_if(is_even)
+
+  // Empty deque
+  let dq : @deque.T[Int] = @deque.new()
+  dq.filter_map_inplace(inc_if_even)
+  inspect!(dq, content="@deque.of([])")
+
+  // Non-empty deque
+  let dq = @deque.of([1, 2, 3, 4, 5])
+  dq.filter_map_inplace(inc_if_even)
+  inspect!(dq.as_views(), content="([3, 5], [])")
+
+  // Test split case (head_len < len)
+  fn dq!() {
+    // Push and pop to create a wrap-around situation
+    let dq = @deque.of([1, 2, 3, 4, 5, 6])
+      ..unsafe_pop_front()
+      ..unsafe_pop_front()
+      ..unsafe_pop_front()
+      ..push_back(7)
+      ..push_back(8)
+    // Current layout: [7, 8, X, 4, 5, 6]
+    inspect!(dq.as_views(), content="([4, 5, 6], [7, 8])")
+    dq
+  }
+
+  inspect!(
+    dq!()..filter_map_inplace(inc_if_even).as_views(),
+    content="([5, 7, 9], [])",
+  )
+  inspect!(
+    dq!()..filter_map_inplace(inc_if(fn(x) { x >= 5 })).as_views(),
+    content="([6, 7, 8], [9])",
+  )
+  inspect!(
+    dq!()..filter_map_inplace(inc_if(fn(x) { x >= 7 })).as_views(),
+    content="([8, 9], [])",
+  )
+  inspect!(
+    dq!()..filter_map_inplace(Option::Some).as_views(),
+    content="([4, 5, 6], [7, 8])",
+  )
+}


### PR DESCRIPTION
This is the implementation PR for `@deque.filter_map_inplace()` as required in cmark.

Mirrors Rust's [`VecDeque::retain_mut()`](https://doc.rust-lang.org/std/collections/vec_deque/struct.VecDeque.html#method.retain_mut).