### PR TITLE
feat: add from/to json for uint/uint64

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -554,6 +554,7 @@ impl UInt {
   to_byte(UInt) -> Byte
   to_float(UInt) -> Float
   to_int(UInt) -> Int //deprecated
+  to_json(UInt) -> Json
   to_string(UInt) -> String
   to_uint64(UInt) -> UInt64
   trunc_double(Double) -> UInt
@@ -590,6 +591,7 @@ impl UInt64 {
   to_float(UInt64) -> Float
   to_int(UInt64) -> Int
   to_int64(UInt64) -> Int64 //deprecated
+  to_json(UInt64) -> Json
   to_string(UInt64) -> String
   to_uint(UInt64) -> UInt
   trunc_double(Double) -> UInt64

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -45,7 +45,17 @@ pub fn Int::to_json(self : Int) -> Json {
 
 ///|
 pub fn Int64::to_json(self : Int64) -> Json {
-  Number(self.to_double())
+  String::to_json(self.to_string())
+}
+
+///|
+pub fn UInt::to_json(self : UInt) -> Json {
+  Number(self.to_uint64().to_double())
+}
+
+///|
+pub fn UInt64::to_json(self : UInt64) -> Json {
+  String::to_json(self.to_string())
 }
 
 ///|

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -1,4 +1,4 @@
-// Copyright 2024 International Digital Economy Academy
+// Copyright 2025 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -54,8 +54,42 @@ pub impl FromJson for Int with from_json(json, path) {
 ///|
 pub impl FromJson for Int64 with from_json(json, path) {
   match json {
-    Number(n) => n.to_int64()
-    _ => decode_error!(path, "Int64::from_json: expected number")
+    String(str) =>
+      try {
+        @strconv.parse_int64!(str)
+      } catch {
+        error =>
+          decode_error!(path, "Int64::from_json: parsing failure \{error}")
+      }
+    _ =>
+      decode_error!(
+        path, "Int64::from_json: expected number in string representation",
+      )
+  }
+}
+
+///|
+pub impl FromJson for UInt with from_json(json, path) {
+  match json {
+    Number(n) => n.to_uint()
+    _ => decode_error!(path, "UInt::from_json: expected number")
+  }
+}
+
+///|
+pub impl FromJson for UInt64 with from_json(json, path) {
+  match json {
+    String(str) =>
+      try {
+        @strconv.parse_uint64!(str)
+      } catch {
+        error =>
+          decode_error!(path, "UInt64::from_json: parsing failure \{error}")
+      }
+    _ =>
+      decode_error!(
+        path, "UInt64::from_json: expected number in string representation",
+      )
   }
 }
 

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2024 International Digital Economy Academy
+// Copyright 2025 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -381,4 +381,52 @@ test "jsonvalue" {
       #|Object({"x": Number(1)})
     ,
   )
+}
+
+test "int roundtrip" {
+  let u = (123).to_json()
+  let v : Int = @json.from_json!(u)
+  inspect!(v, content="123")
+  let u = (-123).to_json()
+  let v : Int = @json.from_json!(u)
+  inspect!(v, content="-123")
+}
+
+test "uint roundtrip" {
+  let u = 123U.to_json()
+  let v : UInt = @json.from_json!(u)
+  inspect!(v, content="123")
+  let u = 4294967295U.to_json()
+  let v : UInt = @json.from_json!(u)
+  inspect!(v, content="4294967295")
+}
+
+test "uint" {
+  let v : UInt = @json.from_json!(Number(4294967295))
+  inspect!(v, content="4294967295")
+  let v : UInt = @json.from_json!(Number(-1))
+  inspect!(v, content="0")
+  let v : UInt = @json.from_json!(Number(4294967296))
+  inspect!(v, content="4294967295")
+}
+
+test "int64 roundtrip" {
+  let u = 123L.to_json()
+  let v : Int64 = @json.from_json!(u)
+  inspect!(v, content="123")
+  let u = 9223372036854775807L.to_json()
+  let v : Int64 = @json.from_json!(u)
+  inspect!(v, content="9223372036854775807")
+  let u = (-9223372036854775808L).to_json()
+  let v : Int64 = @json.from_json!(u)
+  inspect!(v, content="-9223372036854775808")
+}
+
+test "uint64 roundtrip" {
+  let u = 123UL.to_json()
+  let v : UInt64 = @json.from_json!(u)
+  inspect!(v, content="123")
+  let u = 18446744073709551615UL.to_json()
+  let v : UInt64 = @json.from_json!(u)
+  inspect!(v, content="18446744073709551615")
 }

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -66,6 +66,8 @@ impl FromJson for Bool
 impl FromJson for Char
 impl FromJson for Int
 impl FromJson for Int64
+impl FromJson for UInt
+impl FromJson for UInt64
 impl FromJson for Double
 impl FromJson for String
 impl[T : FromJson] FromJson for T?

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2024 International Digital Economy Academy
+// Copyright 2025 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,8 +21,44 @@ test "Int::to_json" {
   inspect!((42).to_json(), content="Number(42)")
 }
 
+test "UInt::to_json" {
+  inspect!(42U.to_json(), content="Number(42)")
+}
+
 test "Int64::to_json" {
-  inspect!(42L.to_json(), content="Number(42)")
+  inspect!(
+    42L.to_json(),
+    content=
+      #|String("42")
+    ,
+  )
+  inspect!(
+    (-9223372036854775808L).to_json(),
+    content=
+      #|String("-9223372036854775808")
+    ,
+  )
+  inspect!(
+    9223372036854775807L.to_json(),
+    content=
+      #|String("9223372036854775807")
+    ,
+  )
+}
+
+test "UInt64::to_json" {
+  inspect!(
+    42UL.to_json(),
+    content=
+      #|String("42")
+    ,
+  )
+  inspect!(
+    18446744073709551615UL.to_json(),
+    content=
+      #|String("18446744073709551615")
+    ,
+  )
 }
 
 test "Double::to_json" {


### PR DESCRIPTION
For `FromJson` and `ToJson`, we only guarantee the roundtrip property.

So for `UInt64` and `Int64`, we'll be using `String` as representation, and for `UInt` and `Int`, we'll be using `Number` as representation.