### PR TITLE
add other function for Iter2 similar to Iter1

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -904,3 +904,20 @@ pub fn contains[A : Eq](self : Iter[A], value : A) -> Bool {
     false
   }
 }
+
+///|
+pub fn combine[A, B](self : Iter[A], b : Iter[B]) -> Iter2[A, B] {
+  Iter2::new(fn(k) {
+    let (x, xs) = (self.head(), self.drop(1))
+    let (y, ys) = (b.head(), b.drop(1))
+    match (x, y) {
+      (Some(x), Some(y)) =>
+        match k(x, y) {
+          IterEnd => IterEnd
+          IterContinue => xs.combine(ys).run(k)
+        }
+      (None, None) => IterEnd
+      _ => panic()
+    }
+  })
+}

--- a/builtin/iter2.mbt
+++ b/builtin/iter2.mbt
@@ -85,3 +85,22 @@ pub fn to_array[A, B](self : Iter2[A, B]) -> Array[(A, B)] {
   }
   arr
 }
+
+///|
+pub fn fold[A, B, S](self : Iter2[A, B], init~ : S, f : (S, A, B) -> S) -> S {
+  let mut acc = init
+  for a, b in self {
+    acc = f(acc, a, b)
+  }
+  acc
+}
+
+pub fn all[A, B](self : Iter2[A, B], p : (A, B) -> Bool) -> Bool {
+  self.fold(init=true, fn(s, a, b) { s && p(a, b) })
+}
+
+
+pub fn any[A, B](self : Iter2[A, B], p : (A, B) -> Bool) -> Bool {
+  self.fold(init=false, fn(s, a, b) { s || p(a, b) })
+}
+

--- a/builtin/iter2_test.mbt
+++ b/builtin/iter2_test.mbt
@@ -1,0 +1,75 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "Iter2::fold/basic" {
+  // Test basic functionality with integer keys and string values
+  let pairs = { 1: "a", 2: "b", 3: "c" }.iter2()
+  let result = pairs.fold(init=(0, ""), fn(acc, k, v) {
+    let (kacc, vacc) = acc
+    (kacc + k, vacc + v)
+  })
+  inspect!(result, content="(6, \"abc\")")
+}
+
+test "Iter2::fold/empty" {
+  // Test on empty iterator
+  let empty : Array[Unit] = []
+  let result = empty.iter2().fold(init=(0, ""), fn(acc, _, _) { acc })
+  inspect!(result, content="(0, \"\")")
+}
+
+test "Iter2::fold/single" {
+  // Test on single-element iterator
+  let single = { 42: "x" }.iter2()
+  let result = single.fold(init=0, fn(acc, k, _) { acc + k })
+  inspect!(result, content="42")
+}
+
+test "Iter2::all/empty" {
+  let map : Map[Int,Int] = {}
+  inspect!(map.iter2().all(fn(_, _) { false }), content="true")
+}
+
+test "Iter2::all/reference" {
+  let map = { 1: 1, 2: 2 }
+  let check_eq = fn(k : Int, v : Int) { k == v }
+  inspect!(map.iter2().all(check_eq), content="true")
+  let check_lt = fn(k : Int, v : Int) { k < v }
+  inspect!(map.iter2().all(check_lt), content="false")
+}
+
+test "Iter2::all/basic" {
+  let map = { 1: 2, 3: 4, 5: 6 }
+  inspect!(map.iter2().all(fn(k, v) { k < v }), content="true")
+  inspect!(map.iter2().all(fn(k, v) { k > v }), content="false")
+}
+
+
+test "Iter2::any/empty" {
+  let map : Map[Int,Int] = {}
+  inspect!(map.iter2().any(fn(_, _) { true }), content="false")
+}
+
+test "Iter2::any/basic" {
+  let map = { 1: 2 }
+  inspect!(map.iter2().any(fn(a, b) { a == 1 && b == 2 }), content="true")
+  inspect!(map.iter2().any(fn(a, b) { a == 2 || b == 1 }), content="false")
+}
+
+test "Iter2::any/multiple" {
+  let map = { 1: 2, 3: 4, 5: 6 }
+  inspect!(map.iter2().any(fn(a, b) { a == 3 && b == 4 }), content="true")
+  inspect!(map.iter2().any(fn(_, _) { false }), content="false")
+  inspect!(map.iter2().any(fn(a, _) { a > 10 }), content="false")
+}

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -543,3 +543,24 @@ test "peek function - random cases" {
   let iter5 = [0, 0, 0].iter()
   inspect!(iter5.peek(), content="Some(0)")
 }
+
+test "combine/basic" {
+  let a = [1, 2, 3].iter()
+  let b = ["a", "b", "c"].iter()
+  let result = a.combine(b).to_array()
+  inspect!(result, content="[(1, \"a\"), (2, \"b\"), (3, \"c\")]")
+}
+
+test "combine/empty" {
+  let a = ([] : Array[Int]).iter()
+  let b = ([] : Array[Int]).iter()
+  let result = a.combine(b).to_array()
+  inspect!(result, content="[]")
+}
+
+test "panic combine/unequal_length" {
+  let a = [1, 2, 3].iter()
+  let b = ["a", "b"].iter()
+  ignore(a.combine(b).to_array())
+  inspect!(a.combine(b).to_array(), content="[1]")
+}


### PR DESCRIPTION
Iter2::combine may conflict with Hasher::combine, `zip` will be better possible.

API reference

https://ocaml.org/manual/5.2/api/Array.html#VALcombine

https://hackage.haskell.org/package/base-4.21.0.0/docs/[Prelude](https://hackage.haskell.org/package/base-4.21.0.0/docs/Prelude.html#v:zip).html#v:zip