### PR TITLE
remove deprecated API when moon test --doc

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -30,7 +30,7 @@ pub(all) typealias Buffer = T
 /// let buf = @buffer.new(size_hint=100)
 /// buf.write_string("Tes")
 /// buf.write_char('t')
-/// assert_eq!(buf.to_unchecked_string(), "Test")
+/// assert_eq!(buf.contents(), b"T\x00e\x00s\x00t\x00")
 /// ```
 struct T {
   mut data : FixedArray[Byte]


### PR DESCRIPTION
```
PS C:\illu\repo\moonbit\core>  moon test --doc
Warning: [2000]
    ╭─[C:\illu\repo\moonbit\core\buffer\buffer.mbt:33:20]
    │
 33 │ /// assert_eq!(buf.to_unchecked_string(), "Test")
    │                    ─────────┬─────────
    │                             ╰─────────── Warning (Alert deprecated): Use `Buffer::contents` to read the contents of the buffer
```