### PR TITLE
improve to_array for sorted_set

### DIFF
--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -24,7 +24,7 @@ struct Array[T] {
 }
 
 ///|
-fn Array::make_uninit[T](len : Int) -> Array[T] {
+pub fn Array::make_uninit[T](len : Int) -> Array[T] {
   { buf: UninitializedArray::make(len), len }
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -368,8 +368,8 @@ pub fn eachi[V](self : T[V], f : (Int, V) -> Unit) -> Unit {
 ///|
 /// Converts the set to an array.
 pub fn to_array[V](self : T[V]) -> Array[V] {
-  let arr = []
-  self.each(fn(v) { arr.push(v) })
+  let arr = Array::make_uninit(self.size.to_int())
+  self.eachi(fn(i, v) { arr[i] = v })
   arr
 }
 


### PR DESCRIPTION
I think `Array::make_uninit` should be public , and use it carefully, rename `make_uninit` to `unsafe_make_uninit` or another better name 