### PR TITLE
feat(deque): rename `@deque.filter_map_inplace()` to `.retain_map()`

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -926,13 +926,13 @@ pub fn truncate[A](self : T[A], len : Int) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-/// test "filter_map_inplace" {
+/// test "retain_map" {
 ///   let dq = @deque.of([1, 2, 3, 4, 5])
-///   dq.filter_map_inplace(fn(x) { if x % 2 == 0 { Some(x * 2) } else { None } })
+///   dq.retain_map(fn(x) { if x % 2 == 0 { Some(x * 2) } else { None } })
 ///   inspect!(dq, content="@deque.of([4, 8])")
 /// }
 /// ```
-pub fn filter_map_inplace[A](self : T[A], f : (A) -> A?) -> Unit {
+pub fn retain_map[A](self : T[A], f : (A) -> A?) -> Unit {
   guard not(self.is_empty()) else { return }
   let { head, buf, .. } = self
   let cap = buf.length()
@@ -969,6 +969,16 @@ pub fn filter_map_inplace[A](self : T[A], f : (A) -> A?) -> Unit {
   } else {
     self.truncate(idx - head)
   }
+}
+
+///|
+/// Filters and maps elements in-place using a provided function. Modifies the
+/// deque to retain only elements for which the provided function returns `Some`,
+/// and updates those elements with the values inside the `Some` variant.
+///
+/// @alert deprecated "Use `@deque.retain_map` instead"
+pub fn filter_map_inplace[A](self : T[A], f : (A) -> A?) -> Unit {
+  self.retain_map(f)
 }
 
 ///|

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -13,7 +13,7 @@ impl T {
   copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
-  filter_map_inplace[A](Self[A], (A) -> A?) -> Unit
+  filter_map_inplace[A](Self[A], (A) -> A?) -> Unit //deprecated
   from_array[A](Array[A]) -> Self[A]
   from_iter[A](Iter[A]) -> Self[A]
   front[A](Self[A]) -> A?
@@ -36,6 +36,7 @@ impl T {
   push_front[A](Self[A], A) -> Unit
   reserve_capacity[A](Self[A], Int) -> Unit
   retain[A](Self[A], (A) -> Bool) -> Unit
+  retain_map[A](Self[A], (A) -> A?) -> Unit
   rev_each[A](Self[A], (A) -> Unit) -> Unit
   rev_eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   rev_iter[A](Self[A]) -> Iter[A]

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -837,19 +837,19 @@ test "deque retain" {
   )
 }
 
-test "deque filter_map_inplace" {
+test "deque retain_map" {
   let inc_if = fn(pred) { fn(x) { if pred(x) { Some(x + 1) } else { None } } }
   let is_even = fn(x) { x % 2 == 0 }
   let inc_if_even = inc_if(is_even)
 
   // Empty deque
   let dq : @deque.T[Int] = @deque.new()
-  dq.filter_map_inplace(inc_if_even)
+  dq.retain_map(inc_if_even)
   inspect!(dq, content="@deque.of([])")
 
   // Non-empty deque
   let dq = @deque.of([1, 2, 3, 4, 5])
-  dq.filter_map_inplace(inc_if_even)
+  dq.retain_map(inc_if_even)
   inspect!(dq.as_views(), content="([3, 5], [])")
 
   // Test split case (head_len < len)
@@ -866,20 +866,17 @@ test "deque filter_map_inplace" {
     dq
   }
 
+  inspect!(dq!()..retain_map(inc_if_even).as_views(), content="([5, 7, 9], [])")
   inspect!(
-    dq!()..filter_map_inplace(inc_if_even).as_views(),
-    content="([5, 7, 9], [])",
-  )
-  inspect!(
-    dq!()..filter_map_inplace(inc_if(fn(x) { x >= 5 })).as_views(),
+    dq!()..retain_map(inc_if(fn(x) { x >= 5 })).as_views(),
     content="([6, 7, 8], [9])",
   )
   inspect!(
-    dq!()..filter_map_inplace(inc_if(fn(x) { x >= 7 })).as_views(),
+    dq!()..retain_map(inc_if(fn(x) { x >= 7 })).as_views(),
     content="([8, 9], [])",
   )
   inspect!(
-    dq!()..filter_map_inplace(Option::Some).as_views(),
+    dq!()..retain_map(Option::Some).as_views(),
     content="([4, 5, 6], [7, 8])",
   )
 }


### PR DESCRIPTION
... so that the naming is shorter and more consistent WRT `.retain()`.

## Function renaming and deprecation

* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abL929-R935): Renamed `filter_map_inplace` to `retain_map` and updated the corresponding test example.
* [`deque/deque.mbt`](diffhunk://#diff-38dbdcf314e0c64bb6564c48b049a68e997854ae69fdac00e490ce1d8b5906abR974-R983): Added a deprecation notice to `filter_map_inplace` and made it call `retain_map`.

## Function signature updates

* [`deque/deque.mbti`](diffhunk://#diff-737e400600b9637258470836512a543fcf682ffc779b855d5aa15c741d4a6006L16-R16): Marked `filter_map_inplace` as deprecated and added the new `retain_map` function signature. [[1]](diffhunk://#diff-737e400600b9637258470836512a543fcf682ffc779b855d5aa15c741d4a6006L16-R16) [[2]](diffhunk://#diff-737e400600b9637258470836512a543fcf682ffc779b855d5aa15c741d4a6006R39)

## Test updates

* [`deque/deque_test.mbt`](diffhunk://#diff-46a7f13b15b6d6de84cc5c2201ce14d99af98ef107c85918796ad6ce2a03de2fL840-R852): Updated tests to use `retain_map` instead of `filter_map_inplace`. [[1]](diffhunk://#diff-46a7f13b15b6d6de84cc5c2201ce14d99af98ef107c85918796ad6ce2a03de2fL840-R852) [[2]](diffhunk://#diff-46a7f13b15b6d6de84cc5c2201ce14d99af98ef107c85918796ad6ce2a03de2fR869-R879)