### PR TITLE
Support using negative index to take StringView

### DIFF
--- a/string/string.mbti
+++ b/string/string.mbti
@@ -26,6 +26,7 @@ impl String {
   from_array(Array[Char]) -> String
   from_iter(Iter[Char]) -> String
   index_at(String, Int, start~ : StringIndex = ..) -> StringIndex?
+  index_at_rev(String, Int, end? : StringIndex) -> StringIndex?
   index_of(String, String, from~ : Int = ..) -> Int
   is_blank(String) -> Bool
   is_empty(String) -> Bool

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -40,7 +40,8 @@ type StringIndex Int derive(Show, Eq)
 
 ///|
 /// Returns a `StringIndex` representing the position after skipping `offset_by` 
-/// Unicode characters.
+/// Unicode characters. If the string has `n` Unicode characters, the returned 
+/// index will be `Some` if `0 <= offset_by <= n`, otherwise `None`.
 ///
 /// # Examples
 /// 
@@ -52,7 +53,7 @@ type StringIndex Int derive(Show, Eq)
 /// guard let Some(offset) = str.index_at(start=offset, 1)  // Skip 2 characters
 /// inspect!(offset, content="StringIndex(4)")              // Points to third emoji
 ///
-/// let offset = str.index_at(3)                            // Skip 3 characters
+/// let offset = str.index_at(4)                            // Skip 4 characters
 /// inspect!(offset, content="None")                        // Beyond end of string
 /// ```
 pub fn index_at(
@@ -72,6 +73,8 @@ pub fn index_at(
         utf16_offset = utf16_offset + 2
         char_count = char_count + 1
         continue
+      } else {
+        abort("invalid surrogate pair")
       }
     }
     // single utf-16 code unit
@@ -81,7 +84,7 @@ pub fn index_at(
   // Return None if:
   // 1. We couldn't reach the requested character offset
   // 2. The resulting offset is beyond the end of the string
-  if char_count < offset_by || utf16_offset >= str_len {
+  if char_count < offset_by || utf16_offset > str_len {
     None
   } else {
     Some(utf16_offset)

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -62,6 +62,7 @@ pub fn index_at(
   start~ : StringIndex = 0
 ) -> StringIndex? {
   let str_len = self.length()
+  guard start._ >= 0 && start._ <= str_len else { abort("Invalid start index") }
   let mut utf16_offset = start._
   let mut char_count = 0
   while utf16_offset < str_len && char_count < offset_by {
@@ -85,6 +86,60 @@ pub fn index_at(
   // 1. We couldn't reach the requested character offset
   // 2. The resulting offset is beyond the end of the string
   if char_count < offset_by || utf16_offset > str_len {
+    None
+  } else {
+    Some(utf16_offset)
+  }
+}
+
+///|
+/// Returns a `StringIndex` representing the position before skipping `offset_by` 
+/// Unicode characters from the end of the string.
+/// 
+/// # Example
+/// 
+/// ```
+/// let str = "🤣🤣🤣"
+/// guard let Some(offset) = str.index_at_rev(0)
+/// inspect!(offset, content="StringIndex(6)")
+/// guard let Some(offset) = str.index_at_rev(1)
+/// inspect!(offset, content="StringIndex(4)")
+/// guard let Some(offset) = str.index_at_rev(2, end = offset)
+/// inspect!(offset, content="StringIndex(0)")
+/// let offset = str.index_at_rev(4)
+/// inspect!(offset, content="None")
+/// ```
+pub fn index_at_rev(
+  self : String,
+  offset_by : Int,
+  end? : StringIndex
+) -> StringIndex? {
+  let str_len = self.length()
+  let end = match end {
+    None => str_len
+    Some(end) => {
+      guard end._ >= 0 && end._ <= str_len else { abort("Invalid end index") }
+      end._
+    }
+  }
+  let mut utf16_offset = end
+  let mut char_count = 0
+  // Iterating backwards from the end of the string. [utf16_offset] always 
+  // points to the last skipped character.
+  while utf16_offset > 0 && char_count < offset_by {
+    let c1 = self[utf16_offset - 1]
+    if is_trailing_surrogate(c1) && utf16_offset - 2 >= 0 {
+      let c2 = self[utf16_offset - 2]
+      if is_leading_surrogate(c2) {
+        utf16_offset = utf16_offset - 2
+        char_count = char_count + 1
+        continue
+      }
+    }
+    utf16_offset = utf16_offset - 1
+    char_count = char_count + 1
+  }
+  if char_count < offset_by || utf16_offset < 0 {
     None
   } else {
     Some(utf16_offset)

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -220,23 +220,40 @@ pub fn op_as_view(
   start~ : Int = 0,
   end? : Int
 ) -> StringView {
-  match end {
-    Some(end) => {
-      guard start <= end else { abort("Invalid index for StringView") }
-      guard let Some(start) = index_at(self.str, start, start=self.start)
-      // TODO: provide index_at_rev or index_at2 to avoid repeatedly iterate the string
-      guard let Some(end) = index_at(self.str, end, start=self.start)
-      guard start._ <= self.end && end._ <= self.end else {
-        abort("Invalid index for StringView")
-      }
-      { str: self.str, start: start._, end: end._ }
+  let start = if start >= 0 {
+    guard let Some(start_offset) = index_at(self.str, start, start=self.start) else {
+      _ => abort("Invalid start index")
     }
-    None => {
-      guard let Some(start) = index_at(self.str, start, start=self.start)
-      guard start._ <= self.end else { abort("Invalid index for StringView") }
-      { str: self.str, start: start._, end: self.end }
+    start_offset._
+  } else {
+    guard let Some(start_offset) = index_at_rev(self.str, -start, end=self.end) else {
+      _ => abort("Invalid start index")
     }
+    start_offset._
   }
+  let end = match end {
+    Some(end) =>
+      if end >= 0 {
+        guard let Some(end_offset) = index_at(self.str, end, start=self.start) else {
+          _ => abort("Invalid end index")
+        }
+        end_offset._
+      } else {
+        guard let Some(end_offset) = index_at_rev(self.str, -end, end=self.end) else {
+          _ => abort("Invalid end index")
+        }
+        end_offset._
+      }
+    None => self.end
+  }
+  guard start >= self.start &&
+    start <= self.end &&
+    end >= self.start &&
+    end <= self.end &&
+    start <= end else {
+    abort("Invalid index for StringView")
+  }
+  { str: self.str, start, end }
 }
 
 ///|

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -202,3 +202,192 @@ test "index_at_rev" {
   guard let Some(offset) = str.index_at_rev(1, end=offset)
   inspect!(offset, content="StringIndex(2)")
 }
+
+test "stringview negative index" {
+  let str = "Hello🤣🤣🤣"
+  let str_view = str[:]
+  let view = str_view[-1:]
+  inspect!(
+    view,
+    content=
+      #|"🤣"
+    ,
+  )
+  let view = str_view[-2:]
+  inspect!(
+    view,
+    content=
+      #|"🤣🤣"
+    ,
+  )
+  let view = str_view[-3:]
+  inspect!(
+    view,
+    content=
+      #|"🤣🤣🤣"
+    ,
+  )
+  let view = str_view[-4:]
+  inspect!(
+    view,
+    content=
+      #|"o🤣🤣🤣"
+    ,
+  )
+  let view = str_view[:-1]
+  inspect!(
+    view,
+    content=
+      #|"Hello🤣🤣"
+    ,
+  )
+  let view = str_view[:-2]
+  inspect!(
+    view,
+    content=
+      #|"Hello🤣"
+    ,
+  )
+  let view = str_view[:-3]
+  inspect!(
+    view,
+    content=
+      #|"Hello"
+    ,
+  )
+  let view = str_view[:-4]
+  inspect!(
+    view,
+    content=
+      #|"Hell"
+    ,
+  )
+  let view = str_view[-2:-1]
+  inspect!(
+    view,
+    content=
+      #|"🤣"
+    ,
+  )
+  let view = str_view[-3:-1]
+  inspect!(
+    view,
+    content=
+      #|"🤣🤣"
+    ,
+  )
+  let view = str_view[-4:-1]
+  inspect!(
+    view,
+    content=
+      #|"o🤣🤣"
+    ,
+  )
+  let view = str_view[-4:-2]
+  inspect!(
+    view,
+    content=
+      #|"o🤣"
+    ,
+  )
+  let view = str_view[-4:-4]
+  inspect!(
+    view,
+    content=
+      #|""
+    ,
+  )
+  let view = str_view[-3:-3]
+  inspect!(
+    view,
+    content=
+      #|""
+    ,
+  )
+}
+
+test "panic negative index 1" {
+  // index_at_rev fails
+  let str = "hello"
+  let str_view = str[:]
+  let _ = str_view[-6:]
+
+}
+
+test "panic negative index 2" {
+  // index_at_rev fails
+  let str = "hello"
+  let str_view = str[:]
+  let _ = str_view[:-6]
+
+}
+
+test "panic negative index 3" {
+  // index_at_rev returns an index not in bounds of the view
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let str_view = str[start:end]
+  let _ = str_view[-4:]
+
+}
+
+test "panic negative index 4" {
+  // index_at_rev returns an index not in bounds of the view
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let str_view = str[start:end]
+  let _ = str_view[:-4]
+
+}
+
+test "panic negative index 5" {
+  // index_at_rev returns an index not in bounds of the view
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let str_view = str[start:end]
+  let _ = str_view[4:]
+
+}
+
+test "panic negative index 6" {
+  // index_at_rev returns an index not in bounds of the view
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let str_view = str[start:end]
+  let _ = str_view[:4]
+
+}
+
+test "panic negative index 7" {
+  // start > end
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let str_view = str[start:end]
+  let _ = str_view[-1:-2]
+
+}
+
+test "panic negative index 8" {
+  // start > end
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let str_view = str[start:end]
+  let _ = str_view[-1:1]
+
+}
+
+test "panic negative index 9" {
+  // start > end
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let str_view = str[start:end]
+  let _ = str_view[2:-2]
+
+}

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -14,19 +14,23 @@
 
 test "index_at" {
   let str = "Hello"
-  let offset = str.index_at(3)
-  inspect!(offset, content="Some(StringIndex(3))")
-  let offset = str.index_at(5)
+  guard let Some(offset) = str.index_at(3)
+  inspect!(offset, content="StringIndex(3)")
+  guard let Some(offset) = str.index_at(5)
+  inspect!(offset, content="StringIndex(5)")
+  let offset = str.index_at(6)
   inspect!(offset, content="None")
 }
 
 test "index_at with surrogate pairs" {
   let str = "🤣🤣🤣"
-  let offset = str.index_at(1)
-  inspect!(offset, content="Some(StringIndex(2))")
-  let offset = str.index_at(2)
-  inspect!(offset, content="Some(StringIndex(4))")
-  let offset = str.index_at(3)
+  guard let Some(offset) = str.index_at(1)
+  inspect!(offset, content="StringIndex(2)")
+  guard let Some(offset) = str.index_at(2)
+  inspect!(offset, content="StringIndex(4)")
+  guard let Some(offset) = str.index_at(3)
+  inspect!(offset, content="StringIndex(6)")
+  let offset = str.index_at(4)
   inspect!(offset, content="None")
 }
 

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -185,3 +185,20 @@ test "panic out of bounds4" {
   let _ = view[0]
 
 }
+
+test "index_at_rev" {
+  let str = "🤣🤣🤣"
+  guard let Some(offset) = str.index_at_rev(0)
+  inspect!(offset, content="StringIndex(6)")
+  guard let Some(offset) = str.index_at_rev(1)
+  inspect!(offset, content="StringIndex(4)")
+  guard let Some(offset) = str.index_at_rev(2)
+  inspect!(offset, content="StringIndex(2)")
+  guard let Some(offset) = str.index_at_rev(3)
+  inspect!(offset, content="StringIndex(0)")
+  let offset = str.index_at_rev(4)
+  inspect!(offset, content="None")
+  guard let Some(offset) = str.index_at_rev(1)
+  guard let Some(offset) = str.index_at_rev(1, end=offset)
+  inspect!(offset, content="StringIndex(2)")
+}


### PR DESCRIPTION
Several changes:

* Given `str` with `n` code points, previously `String::index(str, i)` returns `Some` if `0 <= i < n`. This PR changes this behavior so that it return `Some` if `0 <= i <= n`. This is because the result `StringIndex` is used for taking StringView where index is allowed to be the length of string.
* Added `String::index_by_rev` to search for an index backwards
* Enhanced `StringView::op_as_view` so that it can take negative index, and when the index is negative, it uses `String::index_by_rev` to create the new view.