### PR TITLE
provide length_eq and length_ge for StringView

### DIFF
--- a/string/string.mbti
+++ b/string/string.mbti
@@ -10,6 +10,8 @@ impl Show for StringIndex
 type StringView
 impl StringView {
   length(Self) -> Int
+  length_eq(Self, Int) -> Bool
+  length_ge(Self, Int) -> Bool
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
   op_get(Self, Int) -> Char
 }

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -170,6 +170,50 @@ pub fn length(self : StringView) -> Int {
 }
 
 ///|
+/// Test if the length of the view is equal to the given length.
+/// 
+/// This has O(n) complexity where n is the length in the parameter.
+pub fn length_eq(self : StringView, len : Int) -> Bool {
+  for index = self.start, self_len = 0
+      index < self.end && self_len < len
+      index = index + 1, self_len = self_len + 1 {
+    let c1 = self.str[index]
+    if is_leading_surrogate(c1) && index + 1 < self.end {
+      let c2 = self.str[index + 1]
+      if is_trailing_surrogate(c2) {
+        continue index + 2, self_len + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    self_len == len && index == self.end
+  }
+}
+
+///|
+/// Test if the length of the view is greater than or equal to the given length.
+/// 
+/// This has O(n) complexity where n is the length in the parameter.
+pub fn length_ge(self : StringView, len : Int) -> Bool {
+  for index = self.start, self_len = 0
+      index < self.end && self_len < len
+      index = index + 1, self_len = self_len + 1 {
+    let c1 = self.str[index]
+    if is_leading_surrogate(c1) && index + 1 < self.end {
+      let c2 = self.str[index + 1]
+      if is_trailing_surrogate(c2) {
+        continue index + 2, self_len + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    self_len >= len
+  }
+}
+
+///|
 /// Creates a `StringView` into a `String`.
 /// 
 /// # Example

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -142,6 +142,32 @@ test "stringview length" {
   inspect!(view.length(), content="5")
 }
 
+test "stingview length_eq" {
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let view = str[start:end]
+  inspect!(view.length_eq(0), content="false")
+  inspect!(view.length_eq(1), content="false")
+  inspect!(view.length_eq(2), content="false")
+  inspect!(view.length_eq(3), content="true")
+  inspect!(view.length_eq(4), content="false")
+  inspect!(view.length_eq(5), content="false")
+}
+
+test "stingview length_ge" {
+  let str = "hello"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(4)
+  let view = str[start:end]
+  inspect!(view.length_ge(0), content="true")
+  inspect!(view.length_ge(1), content="true")
+  inspect!(view.length_ge(2), content="true")
+  inspect!(view.length_ge(3), content="true")
+  inspect!(view.length_ge(4), content="false")
+  inspect!(view.length_ge(5), content="false")
+}
+
 test "stringview empty" {
   let str = "hello"
   guard let Some(start) = str.index_at(0)


### PR DESCRIPTION
Because the `length` method for `StringView` has `O(n)` time complexity, we provide two auxiliary methods `length_eq` and `length_ge` which are fast when the target length is small.