### PR TITLE
implement unicode safe api for String

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -674,7 +674,6 @@ impl String {
   op_add(String, String) -> String
   op_equal(String, String) -> Bool
   op_get(String, Int) -> Char
-  rev_get(String, Int) -> Char
   substring(String, start~ : Int = .., end? : Int) -> String
   to_json(String) -> Json
   to_string(String) -> String

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -663,6 +663,10 @@ impl Double {
 }
 
 impl String {
+  charcode_at(String, Int) -> Int
+  charcode_length(String) -> Int
+  codepoint_at(String, Int) -> Char
+  codepoint_length(String) -> Int
   escape(String) -> String
   get(String, Int) -> Char
   length(String) -> Int
@@ -670,9 +674,11 @@ impl String {
   op_add(String, String) -> String
   op_equal(String, String) -> Bool
   op_get(String, Int) -> Char
+  rev_get(String, Int) -> Char
   substring(String, start~ : Int = .., end? : Int) -> String
   to_json(String) -> Json
   to_string(String) -> String
+  unsafe_charcode_at(String, Int) -> Int
 }
 
 impl Option {

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -289,10 +289,16 @@ pub fn FixedArray::make[T](len : Int, init : T) -> FixedArray[T] = "%fixedarray.
 pub fn String::length(self : String) -> Int = "%string_length"
 
 ///|
+pub fn String::charcode_length(self : String) -> Int = "%string_length"
+
+///|
 pub fn String::op_get(self : String, idx : Int) -> Char = "%string_get"
 
 ///|
 pub fn String::get(self : String, idx : Int) -> Char = "%string_get"
+
+///|
+pub fn String::unsafe_charcode_at(self : String, idx : Int) -> Int = "%string_get"
 
 ///|
 pub fn String::op_add(self : String, other : String) -> String = "%string_add"

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -159,52 +159,6 @@ pub fn codepoint_length(self : String) -> Int {
 //}
 
 ///|
-/// Returns the character at the given index from the end of the string.
-///
-/// # Examples
-///
-/// ```moonbit
-/// let s = "Hello🤣🤣🤣"
-/// inspect!(s.rev_get(0), content="'🤣'")
-/// inspect!(s.rev_get(4), content="'l'")
-/// ```
-///
-/// # Panics
-///
-/// Panics if the index is out of bounds.
-pub fn rev_get(self : String, index : Int) -> Char {
-  guard index >= 0 else { abort("index out of bounds") }
-  for utf16_offset = self.charcode_length() - 1, char_count = 0
-      utf16_offset >= 0 && char_count < index
-      utf16_offset = utf16_offset - 1, char_count = char_count + 1 {
-    let c1 = self.unsafe_charcode_at(utf16_offset)
-    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
-      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
-      if is_leading_surrogate(c2) {
-        continue utf16_offset - 2, char_count + 1
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-  } else {
-    guard char_count == index && utf16_offset >= 0 else {
-      abort("index out of bounds")
-    }
-    let c1 = self.unsafe_charcode_at(utf16_offset)
-    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
-      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
-      if is_leading_surrogate(c2) {
-        code_point_of_surrogate_pair(c2, c1)
-      } else {
-        abort("invalid surrogate pair")
-      }
-    } else {
-      Char::from_int(c1)
-    }
-  }
-}
-
-///|
 /// @intrinsic %string.substring
 fn unsafe_substring(str : String, start : Int, end : Int) -> String {
   let len = end - start

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -13,6 +13,198 @@
 // limitations under the License.
 
 ///|
+let min_leading_surrogate = 0xD800
+
+///|
+let max_leading_surrogate = 0xDBFF
+
+///|
+let min_trailing_surrogate = 0xDC00
+
+///|
+let max_trailing_surrogate = 0xDFFF
+
+///|
+fn is_leading_surrogate(c : Int) -> Bool {
+  min_leading_surrogate <= c && c <= max_leading_surrogate
+}
+
+///|
+fn is_trailing_surrogate(c : Int) -> Bool {
+  min_trailing_surrogate <= c && c <= max_trailing_surrogate
+}
+
+///|
+fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
+  Char::from_int((leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000)
+}
+
+///|
+/// Returns the UTF-16 code unit at the given index.
+///
+/// # Examples
+///
+/// ```
+/// let s = "Hello🤣";
+/// inspect!(s.charcode_at(0), content="72");
+/// inspect!(s.charcode_at(5), content="55358"); // First surrogate of 🤣
+/// inspect!(s.charcode_at(6), content="56611"); // Second surrogate of 🤣
+/// ```
+///
+/// # Panics
+///
+/// Panics if the index is out of bounds.
+pub fn charcode_at(self : String, index : Int) -> Int {
+  guard index >= 0 && index < self.length() else {
+    abort("index out of bounds")
+  }
+  self.unsafe_charcode_at(index)
+}
+
+///|
+/// Returns the Unicode code point at the given index.
+///
+/// This method counts Unicode code points (characters) rather than UTF-16 code units.
+/// It properly handles surrogate pairs to return the correct Unicode character.
+///
+/// # Examples
+///
+/// ```
+/// let s = "Hello🤣";
+/// inspect!(s.codepoint_at(0), content="'H'");
+/// inspect!(s.codepoint_at(5), content="'🤣'"); // Returns full emoji character
+/// ```
+///
+/// # Panics
+///
+/// Panics if:
+/// - The index is out of bounds
+/// - The string contains an invalid surrogate pair
+pub fn codepoint_at(self : String, index : Int) -> Char {
+  let charcode_len = self.charcode_length()
+  guard index >= 0 && index < charcode_len else { abort("index out of bounds") }
+  for char_count = 0, utf16_offset = 0
+      char_count < charcode_len && utf16_offset < index
+      char_count = char_count + 1, utf16_offset = utf16_offset + 1 {
+    let c1 = self.unsafe_charcode_at(char_count)
+    if is_leading_surrogate(c1) && char_count + 1 < charcode_len {
+      let c2 = self.unsafe_charcode_at(char_count + 1)
+      if is_trailing_surrogate(c2) {
+        continue char_count + 2, utf16_offset + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    guard utf16_offset == index && char_count < charcode_len else {
+      abort("index out of bounds")
+    }
+    let c1 = self.unsafe_charcode_at(char_count)
+    if is_leading_surrogate(c1) && char_count + 1 < charcode_len {
+      let c2 = self.unsafe_charcode_at(char_count + 1)
+      if is_trailing_surrogate(c2) {
+        code_point_of_surrogate_pair(c1, c2)
+      } else {
+        abort("invalid surrogate pair")
+      }
+    } else {
+      Char::from_int(c1)
+    }
+  }
+}
+
+///|
+/// Returns the number of Unicode code points (characters) in the string.
+///
+/// This method counts actual Unicode characters, properly handling surrogate pairs
+/// that represent single characters like emojis. For the raw UTF-16 code unit count,
+/// use `code_unit_length()` instead.
+///
+/// # Examples
+///
+/// ```
+/// let s = "Hello🤣";
+/// inspect!(s.codepoint_length(), content = "6"); // 6 actual characters
+/// inspect!(s.charcode_length(), content = "7");  // 5 ASCII chars + 2 surrogate pairs
+/// ```
+pub fn codepoint_length(self : String) -> Int {
+  let charcode_len = self.charcode_length()
+  for char_count = 0, len = 0
+      char_count < charcode_len
+      char_count = char_count + 1, len = len + 1 {
+    let c1 = self.unsafe_charcode_at(char_count)
+    if is_leading_surrogate(c1) && char_count + 1 < charcode_len {
+      let c2 = self.unsafe_charcode_at(char_count + 1)
+      if is_trailing_surrogate(c2) {
+        continue char_count + 2, len + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    len
+  }
+}
+
+///|
+// planned op_get method for String
+// pub fn String::op_get(self : String, index : Int) -> Char {
+//   codepoint_at(self, index)
+// }
+
+///|
+// planned length method for String
+// pub fn String::length(self : String) -> Int {
+//   codepoint_length(self)
+//}
+
+///|
+/// Returns the character at the given index from the end of the string.
+///
+/// # Examples
+///
+/// ```moonbit
+/// let s = "Hello🤣🤣🤣"
+/// inspect!(s.rev_get(0), content="'🤣'")
+/// inspect!(s.rev_get(4), content="'l'")
+/// ```
+///
+/// # Panics
+///
+/// Panics if the index is out of bounds.
+pub fn rev_get(self : String, index : Int) -> Char {
+  guard index >= 0 else { abort("index out of bounds") }
+  for utf16_offset = self.charcode_length() - 1, char_count = 0
+      utf16_offset >= 0 && char_count < index
+      utf16_offset = utf16_offset - 1, char_count = char_count + 1 {
+    let c1 = self.unsafe_charcode_at(utf16_offset)
+    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
+      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
+      if is_leading_surrogate(c2) {
+        continue utf16_offset - 2, char_count + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    guard char_count == index && utf16_offset >= 0 else {
+      abort("index out of bounds")
+    }
+    let c1 = self.unsafe_charcode_at(utf16_offset)
+    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
+      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
+      if is_leading_surrogate(c2) {
+        code_point_of_surrogate_pair(c2, c1)
+      } else {
+        abort("invalid surrogate pair")
+      }
+    } else {
+      Char::from_int(c1)
+    }
+  }
+}
+
+///|
 /// @intrinsic %string.substring
 fn unsafe_substring(str : String, start : Int, end : Int) -> String {
   let len = end - start

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -46,18 +46,6 @@ test "substring" {
   assert_eq!("abc".substring(start=1, end=2), "b")
 }
 
-test "panic rev_get1" {
-  let str = "Hello🤣🤣🤣"
-  let _ = str.rev_get(-1)
-
-}
-
-test "panic rev_get2" {
-  let str = "Hello🤣🤣🤣"
-  let _ = str.rev_get(8)
-
-}
-
 test "panic codepoint_at1" {
   let str = "Hello🤣🤣🤣"
   let _ = str.codepoint_at(8)

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -45,3 +45,27 @@ test "substring" {
   assert_eq!("abc".substring(end=2), "ab")
   assert_eq!("abc".substring(start=1, end=2), "b")
 }
+
+test "panic rev_get1" {
+  let str = "Hello🤣🤣🤣"
+  let _ = str.rev_get(-1)
+
+}
+
+test "panic rev_get2" {
+  let str = "Hello🤣🤣🤣"
+  let _ = str.rev_get(8)
+
+}
+
+test "panic codepoint_at1" {
+  let str = "Hello🤣🤣🤣"
+  let _ = str.codepoint_at(8)
+
+}
+
+test "panic codepoint_at2" {
+  let str = "Hello🤣🤣🤣"
+  let _ = str.codepoint_at(-1)
+
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -154,9 +154,9 @@ pub fn iter(self : String) -> Iter[Char] {
   Iter::new(fn(yield_) {
     let len = self.length()
     for index = 0; index < len; index = index + 1 {
-      let c1 = self[index]
+      let c1 = self.unsafe_charcode_at(index)
       if is_leading_surrogate(c1) && index + 1 < len {
-        let c2 = self[index + 1]
+        let c2 = self.unsafe_charcode_at(index + 1)
         if is_trailing_surrogate(c2) {
           let c = code_point_of_surrogate_pair(c1, c2)
           guard let IterContinue = yield_(c) else { x => break x }
@@ -164,7 +164,7 @@ pub fn iter(self : String) -> Iter[Char] {
         }
       }
       //TODO: handle garbage input
-      guard let IterContinue = yield_(c1) else { x => break x }
+      guard let IterContinue = yield_(Char::from_int(c1)) else { x => break x }
 
     } else {
       IterContinue
@@ -177,9 +177,9 @@ pub fn iter2(self : String) -> Iter2[Int, Char] {
   Iter2::new(fn(yield_) {
     let len = self.length()
     for index = 0, n = 0; index < len; index = index + 1, n = n + 1 {
-      let c1 = self[index]
+      let c1 = self.unsafe_charcode_at(index)
       if is_leading_surrogate(c1) && index + 1 < len {
-        let c2 = self[index + 1]
+        let c2 = self.unsafe_charcode_at(index + 1)
         if is_trailing_surrogate(c2) {
           let c = code_point_of_surrogate_pair(c1, c2)
           guard let IterContinue = yield_(n, c) else { x => break x }
@@ -187,7 +187,9 @@ pub fn iter2(self : String) -> Iter2[Int, Char] {
         }
       }
       //TODO: handle garbage input
-      guard let IterContinue = yield_(n, c1) else { x => break x }
+      guard let IterContinue = yield_(n, Char::from_int(c1)) else {
+        x => break x
+      }
 
     } else {
       IterContinue
@@ -245,9 +247,9 @@ pub fn rev_iter(self : String) -> Iter[Char] {
   Iter::new(fn(yield_) {
     let len = self.length()
     for index = len - 1; index >= 0; index = index - 1 {
-      let c1 = self[index]
+      let c1 = self.unsafe_charcode_at(index)
       if is_trailing_surrogate(c1) && index - 1 >= 0 {
-        let c2 = self[index - 1]
+        let c2 = self.unsafe_charcode_at(index - 1)
         if is_leading_surrogate(c2) {
           let c = code_point_of_surrogate_pair(c2, c1)
           guard let IterContinue = yield_(c) else { x => break x }
@@ -255,7 +257,7 @@ pub fn rev_iter(self : String) -> Iter[Char] {
         }
       }
       // TODO: handle garbage input
-      guard let IterContinue = yield_(c1) else { x => break x }
+      guard let IterContinue = yield_(Char::from_int(c1)) else { x => break x }
 
     } else {
       IterContinue
@@ -289,10 +291,10 @@ pub fn contains_char(self : String, c : Char) -> Bool {
 pub fn trim_start(self : String, trim_set : String) -> String {
   let len = self.length()
   for i = 0; i < len; i = i + 1 {
-    let c1 = self[i]
+    let c1 = self.unsafe_charcode_at(i)
     // check surrogate pair
     if is_leading_surrogate(c1) && i + 1 < len {
-      let c2 = self[i + 1]
+      let c2 = self.unsafe_charcode_at(i + 1)
       if is_trailing_surrogate(c2) {
         let ch = code_point_of_surrogate_pair(c1, c2)
         if trim_set.contains_char(ch) {
@@ -315,10 +317,10 @@ pub fn trim_start(self : String, trim_set : String) -> String {
 pub fn trim_end(self : String, trim_set : String) -> String {
   let len = self.length()
   for i = len - 1; i >= 0; i = i - 1 {
-    let c2 = self[i]
+    let c2 = self.unsafe_charcode_at(i)
     // check surrogate pair
     if is_trailing_surrogate(c2) && i - 1 >= 0 {
-      let c1 = self[i - 1]
+      let c1 = self.unsafe_charcode_at(i - 1)
       if is_leading_surrogate(c1) {
         let ch = code_point_of_surrogate_pair(c1, c2)
         if trim_set.contains_char(ch) {
@@ -674,5 +676,97 @@ pub fn pad_end(self : String, total_width : Int, padding_char : Char) -> String 
       buf.write_char(padding_char)
     }
     buf.to_string()
+  }
+}
+
+///|
+/// Returns the character at the given index from the end of the string.
+///
+/// # Examples
+///
+/// ```moonbit
+/// let s = "Hello🤣🤣🤣"
+/// inspect!(s.rev_get(0), content="'🤣'")
+/// inspect!(s.rev_get(4), content="'l'")
+/// ```
+///
+/// # Panics
+///
+/// Panics if the index is out of bounds.
+pub fn String::rev_get(self : String, index : Int) -> Char {
+  guard index >= 0 else { abort("index out of bounds") }
+  for utf16_offset = self.charcode_length() - 1, char_count = 0
+      utf16_offset >= 0 && char_count < index
+      utf16_offset = utf16_offset - 1, char_count = char_count + 1 {
+    let c1 = self.unsafe_charcode_at(utf16_offset)
+    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
+      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
+      if is_leading_surrogate(c2) {
+        continue utf16_offset - 2, char_count + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    guard char_count == index && utf16_offset >= 0 else {
+      abort("index out of bounds")
+    }
+    let c1 = self.unsafe_charcode_at(utf16_offset)
+    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
+      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
+      if is_leading_surrogate(c2) {
+        code_point_of_surrogate_pair(c2, c1)
+      } else {
+        abort("invalid surrogate pair")
+      }
+    } else {
+      Char::from_int(c1)
+    }
+  }
+}
+
+///|
+/// Test if the length of the string is equal to the given length.
+///
+/// This has O(n) complexity where n is the length in the parameter.
+pub fn String::length_eq(self : String, len : Int) -> Bool {
+  let codeunit_len = self.charcode_length()
+  for index = 0, count = 0
+      index < codeunit_len && count < len
+      index = index + 1, count = count + 1 {
+    let c1 = self.unsafe_charcode_at(index)
+    if is_leading_surrogate(c1) && index + 1 < codeunit_len {
+      let c2 = self.unsafe_charcode_at(index + 1)
+      if is_trailing_surrogate(c2) {
+        continue index + 2, count + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    count == len && index == codeunit_len
+  }
+}
+
+///|
+/// Test if the length of the string is greater than or equal to the given length.
+///
+/// This has O(n) complexity where n is the length in the parameter.
+pub fn String::length_ge(self : String, len : Int) -> Bool {
+  let codeunit_len = self.charcode_length()
+  for index = 0, count = 0
+      index < codeunit_len && count < len
+      index = index + 1, count = count + 1 {
+    let c1 = self.unsafe_charcode_at(index)
+    if is_leading_surrogate(c1) && index + 1 < codeunit_len {
+      let c2 = self.unsafe_charcode_at(index + 1)
+      if is_trailing_surrogate(c2) {
+        continue index + 2, count + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    count >= len
   }
 }

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -44,6 +44,8 @@ impl String {
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
   last_index_of(String, String, from~ : Int = ..) -> Int
+  length_eq(String, Int) -> Bool
+  length_ge(String, Int) -> Bool
   op_as_view(String, start~ : StringIndex = .., end? : StringIndex) -> StringView
   pad_end(String, Int, Char) -> String
   pad_start(String, Int, Char) -> String
@@ -52,6 +54,7 @@ impl String {
   replace_all(String, old~ : String, new~ : String) -> String
   rev(String) -> String
   rev_fold[A](String, init~ : A, (A, Char) -> A) -> A
+  rev_get(String, Int) -> Char
   rev_iter(String) -> Iter[Char]
   split(String, String) -> Iter[String]
   starts_with(String, String) -> Bool

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -516,3 +516,28 @@ test "pad_right" {
   inspect!("22".pad_end(2, '0'), content="22")
   inspect!("5".pad_end(4, 'x'), content="5xxx")
 }
+
+test "panic rev_get1" {
+  let str = "Hello🤣🤣🤣"
+  let _ = str.rev_get(-1)
+
+}
+
+test "panic rev_get2" {
+  let str = "Hello🤣🤣🤣"
+  let _ = str.rev_get(8)
+
+}
+
+test "length_ge" {
+  let str = "Hello🤣🤣🤣"
+  assert_true!(str.length_ge(0))
+  assert_true!(str.length_ge(8))
+  assert_false!(str.length_ge(9))
+}
+
+test "length_eq" {
+  let str = "Hello🤣🤣🤣"
+  assert_true!(str.length_eq(8))
+  assert_false!(str.length_eq(9))
+}

--- a/string/utils.mbt
+++ b/string/utils.mbt
@@ -25,37 +25,33 @@ let min_trailing_surrogate = 0xDC00
 let max_trailing_surrogate = 0xDFFF
 
 ///|
-fn is_leading_surrogate(c : Char) -> Bool {
-  let code = c.to_int()
-  min_leading_surrogate <= code && code <= max_leading_surrogate
+fn is_leading_surrogate(c : Int) -> Bool {
+  min_leading_surrogate <= c && c <= max_leading_surrogate
 }
 
 test "is_leading_surrogate" {
-  inspect!(is_leading_surrogate("🤣"[0]), content="true")
-  inspect!(is_leading_surrogate("🤣"[1]), content="false")
+  inspect!(is_leading_surrogate("🤣".charcode_at(0)), content="true")
+  inspect!(is_leading_surrogate("🤣".charcode_at(1)), content="false")
 }
 
 ///|
-fn is_trailing_surrogate(c : Char) -> Bool {
-  let code = c.to_int()
-  min_trailing_surrogate <= code && code <= max_trailing_surrogate
+fn is_trailing_surrogate(c : Int) -> Bool {
+  min_trailing_surrogate <= c && c <= max_trailing_surrogate
 }
 
 test "is_trailing_surrogate" {
-  inspect!(is_trailing_surrogate("🤣"[0]), content="false")
-  inspect!(is_trailing_surrogate("🤣"[1]), content="true")
+  inspect!(is_trailing_surrogate("🤣".charcode_at(0)), content="false")
+  inspect!(is_trailing_surrogate("🤣".charcode_at(1)), content="true")
 }
 
 ///|
-fn code_point_of_surrogate_pair(leading : Char, trailing : Char) -> Char {
-  Char::from_int(
-    (leading.to_int() - 0xD800) * 0x400 + trailing.to_int() - 0xDC00 + 0x10000,
-  )
+fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
+  Char::from_int((leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000)
 }
 
 test "code_point_of_surrogate_pair" {
   let s = "😀"
-  let leading = s[0]
-  let trailing = s[1]
+  let leading = s.charcode_at(0)
+  let trailing = s.charcode_at(1)
   inspect!(code_point_of_surrogate_pair(leading, trailing), content="'😀'")
 }

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -66,10 +66,10 @@ pub fn index_at(
   let mut utf16_offset = start._
   let mut char_count = 0
   while utf16_offset < str_len && char_count < offset_by {
-    let c1 = self[utf16_offset]
+    let c1 = self.unsafe_charcode_at(utf16_offset)
     // check if this is a surrogate pair
     if is_leading_surrogate(c1) && utf16_offset + 1 < str_len {
-      let c2 = self[utf16_offset + 1]
+      let c2 = self.unsafe_charcode_at(utf16_offset + 1)
       if is_trailing_surrogate(c2) {
         utf16_offset = utf16_offset + 2
         char_count = char_count + 1
@@ -127,9 +127,9 @@ pub fn index_at_rev(
   // Iterating backwards from the end of the string. [utf16_offset] always 
   // points to the last skipped character.
   while utf16_offset > 0 && char_count < offset_by {
-    let c1 = self[utf16_offset - 1]
+    let c1 = self.unsafe_charcode_at(utf16_offset - 1)
     if is_trailing_surrogate(c1) && utf16_offset - 2 >= 0 {
-      let c2 = self[utf16_offset - 2]
+      let c2 = self.unsafe_charcode_at(utf16_offset - 2)
       if is_leading_surrogate(c2) {
         utf16_offset = utf16_offset - 2
         char_count = char_count + 1
@@ -154,9 +154,9 @@ pub fn index_at_rev(
 pub fn StringView::length(self : StringView) -> Int {
   let mut len = 0
   for index = self.start; index < self.end; index = index + 1 {
-    let c1 = self.str[index]
+    let c1 = self.str.unsafe_charcode_at(index)
     if is_leading_surrogate(c1) && index + 1 < self.end {
-      let c2 = self.str[index + 1]
+      let c2 = self.str.unsafe_charcode_at(index + 1)
       if is_trailing_surrogate(c2) {
         len = len + 1
         continue index + 2
@@ -177,9 +177,9 @@ pub fn length_eq(self : StringView, len : Int) -> Bool {
   for index = self.start, self_len = 0
       index < self.end && self_len < len
       index = index + 1, self_len = self_len + 1 {
-    let c1 = self.str[index]
+    let c1 = self.str.unsafe_charcode_at(index)
     if is_leading_surrogate(c1) && index + 1 < self.end {
-      let c2 = self.str[index + 1]
+      let c2 = self.str.unsafe_charcode_at(index + 1)
       if is_trailing_surrogate(c2) {
         continue index + 2, self_len + 1
       } else {
@@ -199,9 +199,9 @@ pub fn length_ge(self : StringView, len : Int) -> Bool {
   for index = self.start, self_len = 0
       index < self.end && self_len < len
       index = index + 1, self_len = self_len + 1 {
-    let c1 = self.str[index]
+    let c1 = self.str.unsafe_charcode_at(index)
     if is_leading_surrogate(c1) && index + 1 < self.end {
-      let c2 = self.str[index + 1]
+      let c2 = self.str.unsafe_charcode_at(index + 1)
       if is_trailing_surrogate(c2) {
         continue index + 2, self_len + 1
       } else {
@@ -323,9 +323,9 @@ pub fn StringView::op_get(self : StringView, index : Int) -> Char {
   let mut utf16_offset = self.start
   let mut char_count = 0
   while char_count < index && utf16_offset < self.end {
-    let c1 = self.str[utf16_offset]
+    let c1 = self.str.unsafe_charcode_at(utf16_offset)
     if is_leading_surrogate(c1) && utf16_offset + 1 < self.str.length() {
-      let c2 = self.str[utf16_offset + 1]
+      let c2 = self.str.unsafe_charcode_at(utf16_offset + 1)
       if is_trailing_surrogate(c2) {
         utf16_offset = utf16_offset + 2
         char_count = char_count + 1
@@ -340,16 +340,16 @@ pub fn StringView::op_get(self : StringView, index : Int) -> Char {
   guard char_count == index && utf16_offset < self.end else {
     abort("Index out of bounds: cannot access index \{index}")
   }
-  let c1 = self.str[utf16_offset]
+  let c1 = self.str.unsafe_charcode_at(utf16_offset)
   if is_leading_surrogate(c1) {
-    let c2 = self.str[utf16_offset + 1]
+    let c2 = self.str.unsafe_charcode_at(utf16_offset + 1)
     if is_trailing_surrogate(c2) {
       code_point_of_surrogate_pair(c1, c2)
     } else {
       abort("invalid surrogate pair")
     }
   } else {
-    c1
+    Char::from_int(c1)
   }
 }
 
@@ -376,9 +376,9 @@ pub fn rev_get(self : StringView, index : Int) -> Char {
   let mut utf16_offset = self.end - 1
   let mut char_count = 0
   while char_count < index && utf16_offset >= self.start {
-    let c1 = self.str[utf16_offset]
+    let c1 = self.str.unsafe_charcode_at(utf16_offset)
     if is_trailing_surrogate(c1) && utf16_offset - 1 >= self.start {
-      let c2 = self.str[utf16_offset - 1]
+      let c2 = self.str.unsafe_charcode_at(utf16_offset - 1)
       if is_leading_surrogate(c2) {
         utf16_offset = utf16_offset - 2
         char_count = char_count + 1
@@ -393,16 +393,16 @@ pub fn rev_get(self : StringView, index : Int) -> Char {
   guard char_count == index && utf16_offset >= self.start else {
     abort("Index out of bounds: cannot access index \{index} in reverse")
   }
-  let c1 = self.str[utf16_offset]
+  let c1 = self.str.unsafe_charcode_at(utf16_offset)
   if is_trailing_surrogate(c1) {
-    let c2 = self.str[utf16_offset - 1]
+    let c2 = self.str.unsafe_charcode_at(utf16_offset - 1)
     if is_leading_surrogate(c2) {
       code_point_of_surrogate_pair(c2, c1)
     } else {
       abort("invalid surrogate pair")
     }
   } else {
-    c1
+    Char::from_int(c1)
   }
 }
 
@@ -417,16 +417,16 @@ pub impl Show for StringView with output(self, logger) {
 pub fn StringView::iter(self : StringView) -> Iter[Char] {
   Iter::new(fn(yield_) {
     for index = self.start; index < self.end; index = index + 1 {
-      let c1 = self.str[index]
+      let c1 = self.str.unsafe_charcode_at(index)
       if is_leading_surrogate(c1) && index + 1 < self.end {
-        let c2 = self.str[index + 1]
+        let c2 = self.str.unsafe_charcode_at(index + 1)
         if is_trailing_surrogate(c2) {
           let c = code_point_of_surrogate_pair(c1, c2)
           guard let IterContinue = yield_(c) else { x => break x }
           continue index + 2
         }
       }
-      guard let IterContinue = yield_(c1) else { x => break x }
+      guard let IterContinue = yield_(Char::from_int(c1)) else { x => break x }
 
     } else {
       IterContinue


### PR DESCRIPTION
Part of #1452

This PR adds the following APIs for String in builtin for general purpose usage:
```
charcode_at(String, Int) -> Int
charcode_length(String) -> Int
codepoint_at(String, Int) -> Char
codepoint_length(String) -> Int
unsafe_charcode_at(String, Int) -> Int // charcode_at without bound checking
```

And adds the following APIs for implementing pattern matching on string:
```
length_eq(String, Int) -> Bool
length_ge(String, Int) -> Bool
rev_get(String, Int) -> Char
```

The next step is to change the behavior of `op_get` and `length` to `codepoint_at` and `codepoint_length`, and fix the various misuses.

One subtlety is that the `codepoint_at` here has different behavior that `code_point_at` in JavaScript. Here the index is the count of code points, whereas for JavaScript, the index is the count of utf16 code units. @bobzhang 