### PR TITLE
add rev_get for StringView

### DIFF
--- a/string/string.mbti
+++ b/string/string.mbti
@@ -14,6 +14,7 @@ impl StringView {
   length_ge(Self, Int) -> Bool
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
   op_get(Self, Int) -> Char
+  rev_get(Self, Int) -> Char
 }
 impl Show for StringView
 

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -303,7 +303,8 @@ pub fn op_as_view(
 ///|
 /// Return the character at the given index.
 /// 
-/// This method has O(n) complexity.
+/// The time complexity is O(n) where n is the given index, as it needs to scan
+/// through the UTF-16 code units to find the nth Unicode character.
 /// 
 /// # Example
 /// 
@@ -344,6 +345,59 @@ pub fn op_get(self : StringView, index : Int) -> Char {
     let c2 = self.str[utf16_offset + 1]
     if is_trailing_surrogate(c2) {
       code_point_of_surrogate_pair(c1, c2)
+    } else {
+      abort("invalid surrogate pair")
+    }
+  } else {
+    c1
+  }
+}
+
+///|
+/// Returns the character at the given index from the end of the view.
+/// 
+/// The time complexity is O(n) where n is the given index, as it needs to scan
+/// through the UTF-16 code units to find the nth Unicode character.
+/// 
+/// # Example
+/// 
+/// ```
+/// let str = "Hello🤣🤣🤣"
+/// guard let Some(start) = str.index_at(1)
+/// guard let Some(end) = str.index_at(6)
+/// let view = str[start:end]
+/// inspect!(view.rev_get(0), content="'🤣'")
+/// inspect!(view.rev_get(4), content="'e'")
+/// ```
+pub fn rev_get(self : StringView, index : Int) -> Char {
+  guard index >= 0 else {
+    abort("Index out of bounds: cannot access negative index")
+  }
+  let mut utf16_offset = self.end - 1
+  let mut char_count = 0
+  while char_count < index && utf16_offset >= self.start {
+    let c1 = self.str[utf16_offset]
+    if is_trailing_surrogate(c1) && utf16_offset - 1 >= self.start {
+      let c2 = self.str[utf16_offset - 1]
+      if is_leading_surrogate(c2) {
+        utf16_offset = utf16_offset - 2
+        char_count = char_count + 1
+        continue
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+    utf16_offset = utf16_offset - 1
+    char_count = char_count + 1
+  }
+  guard char_count == index && utf16_offset >= self.start else {
+    abort("Index out of bounds: cannot access index \{index} in reverse")
+  }
+  let c1 = self.str[utf16_offset]
+  if is_trailing_surrogate(c1) {
+    let c2 = self.str[utf16_offset - 1]
+    if is_leading_surrogate(c2) {
+      code_point_of_surrogate_pair(c2, c1)
     } else {
       abort("invalid surrogate pair")
     }

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -134,6 +134,15 @@ test "stringview op_get" {
   inspect!(view[4], content="'🤣'")
 }
 
+test "stringview rev_get" {
+  let str = "Hello🤣🤣🤣"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(6)
+  let view = str[start:end]
+  inspect!(view.rev_get(0), content="'🤣'")
+  inspect!(view.rev_get(4), content="'e'")
+}
+
 test "stringview length" {
   let str = "Hello🤣🤣🤣"
   guard let Some(start) = str.index_at(1)
@@ -415,5 +424,23 @@ test "panic negative index 9" {
   guard let Some(end) = str.index_at(4)
   let str_view = str[start:end]
   let _ = str_view[2:-2]
+
+}
+
+test "panic rev_get" {
+  let str = "Hello🤣🤣🤣"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(6)
+  let view = str[start:end]
+  let _ = view.rev_get(5)
+
+}
+
+test "panic rev_get2" {
+  let str = "Hello🤣🤣🤣"
+  guard let Some(start) = str.index_at(1)
+  guard let Some(end) = str.index_at(6)
+  let view = str[start:end]
+  let _ = view.rev_get(-1)
 
 }


### PR DESCRIPTION
This PR adds `rev_get` method for `StringView`. This is useful for implementing pattern match on `StringView`.