### PR TITLE
fix: incorrect doc from docs PRs

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -118,7 +118,7 @@ pub fn capacity[T](self : Array[T]) -> Int {
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds"
+/// @intrinsic %array.unsafe_get
 pub fn unsafe_get[T](self : Array[T], idx : Int) -> T {
   self.buffer()[idx]
 }

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -80,6 +80,7 @@ pub fn Array::new[T](capacity~ : Int = 0) -> Array[T] {
 ///   inspect!(empty.length(), content="0")
 /// }
 /// ```
+/// @intrinsic %array.length
 pub fn length[T](self : Array[T]) -> Int {
   self.len
 }

--- a/double/exp_js.mbt
+++ b/double/exp_js.mbt
@@ -39,5 +39,4 @@
 ///   inspect!(not_a_number.exp().is_nan(), content="true")
 /// }
 /// ```
-/// ```
 pub fn exp(self : Double) -> Double = "Math" "exp"


### PR DESCRIPTION
Fix incorrect documentation, including:

1. Missing instrinsics.
2. Extra code fence
3. Incorrect alert message.