### PR TITLE
deprecate Deque::truncate, rename it to unsafe_truncate

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -866,19 +866,21 @@ pub fn shrink_to_fit[A](self : T[A]) -> Unit {
 ///
 /// Parameters:
 ///
-/// * `self` : The deque to be truncated.
+/// * `self` : The deque to be unsafe_truncated.
 /// * `len` : The new length of the deque.
 ///
 /// Example:
 ///
 /// ```moonbit
-/// test "truncate" {
+/// test "unsafe_truncate" {
 ///   let dq = @deque.of([1, 2, 3, 4, 5])
-///   dq.truncate(3)
+///   dq.unsafe_truncate(3)
 ///   inspect!(dq, content="@deque.of([1, 2, 3])")
 /// }
 /// ```
-pub fn truncate[A](self : T[A], len : Int) -> Unit {
+/// 
+/// @alert unsafe "Panic if the len < 0."
+pub fn unsafe_truncate[A](self : T[A], len : Int) -> Unit {
   guard len < self.len else { return }
   guard len >= 0
   if len == 0 {
@@ -910,6 +912,13 @@ pub fn truncate[A](self : T[A], len : Int) -> Unit {
       set_null(buf, i)
     }
   }
+}
+
+///|
+/// @alert deprecated "Use `unsafe_truncate` instead"
+/// @coverage.skip
+pub fn truncate[A](self : T[A], len : Int) -> Unit {
+  self.unsafe_truncate(len)
 }
 
 ///|
@@ -949,7 +958,7 @@ pub fn retain_map[A](self : T[A], f : (A) -> A?) -> Unit {
     }
   }
   if back.length() == 0 {
-    self.truncate(idx - head)
+    self.unsafe_truncate(idx - head)
     return
   }
   for cur in back {
@@ -965,9 +974,9 @@ pub fn retain_map[A](self : T[A], f : (A) -> A?) -> Unit {
     }
   }
   if idx <= self.len - head_len {
-    self.truncate(idx + head_len)
+    self.unsafe_truncate(idx + head_len)
   } else {
-    self.truncate(idx - head)
+    self.unsafe_truncate(idx - head)
   }
 }
 
@@ -1015,7 +1024,7 @@ pub fn retain[A](self : T[A], f : (A) -> Bool) -> Unit {
     }
   }
   if back.length() == 0 {
-    self.truncate(idx - head)
+    self.unsafe_truncate(idx - head)
     return
   }
   for cur in back {
@@ -1028,9 +1037,9 @@ pub fn retain[A](self : T[A], f : (A) -> Bool) -> Unit {
     }
   }
   if idx <= self.len - head_len {
-    self.truncate(idx + head_len)
+    self.unsafe_truncate(idx + head_len)
   } else {
-    self.truncate(idx - head)
+    self.unsafe_truncate(idx - head)
   }
 }
 

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -749,23 +749,23 @@ test "deque guard iter2 coverage improvement" {
   test_n_via_push_front!(15)
 }
 
-test "deque truncate" {
+test "deque unsafe_truncate" {
   // Empty deque
   let dq : @deque.T[Int] = @deque.new()
-  dq.truncate(3)
+  dq.unsafe_truncate(3)
   inspect!(dq, content="@deque.of([])")
 
   // Length is greater than current length
   let dq = @deque.of([1, 2, 3, 4, 5])
-  dq.truncate(3)
+  dq.unsafe_truncate(3)
   inspect!(dq, content="@deque.of([1, 2, 3])")
 
   // Length is equal to current length
-  dq.truncate(3)
+  dq.unsafe_truncate(3)
   inspect!(dq, content="@deque.of([1, 2, 3])")
 
   // Length is less than current length
-  dq.truncate(2)
+  dq.unsafe_truncate(2)
   inspect!(dq, content="@deque.of([1, 2])")
 
   // Test split case (head_len < len)
@@ -778,20 +778,20 @@ test "deque truncate" {
     ..push_back(8)
   // Current layout: [7, 8, X, 4, 5, 6]
   inspect!(dq.as_views(), content="([4, 5, 6], [7, 8])")
-  dq.truncate(42)
+  dq.unsafe_truncate(42)
   // Current layout: [7, 8, X, 4, 5, 6]
   inspect!(dq.as_views(), content="([4, 5, 6], [7, 8])")
-  dq.truncate(4)
+  dq.unsafe_truncate(4)
   // Current layout: [7, X, X, 4, 5, 6]
   inspect!(dq.as_views(), content="([4, 5, 6], [7])")
   // Current layout: [X, X, X, 4, 5, X]
-  dq.truncate(2)
+  dq.unsafe_truncate(2)
   inspect!(dq.as_views(), content="([4, 5], [])")
 }
 
-test "panic deque truncate" {
+test "panic deque unsafe_truncate" {
   let dq = @deque.of([1, 2, 3, 4, 5])
-  dq.truncate(-1)
+  dq.unsafe_truncate(-1)
 }
 
 test "deque retain" {

--- a/deque/deque_wbtest.mbt
+++ b/deque/deque_wbtest.mbt
@@ -23,9 +23,9 @@ test "unsafe_pop_front after many push_front" {
   assert_eq!(dq.head, dq.tail)
 }
 
-test "truncate zero" {
+test "unsafe_truncate zero" {
   let dq = of([1, 2, 3])
-  dq.truncate(0)
+  dq.unsafe_truncate(0)
   assert_eq!(dq.len, 0)
   assert_eq!(dq.head, dq.tail)
 }


### PR DESCRIPTION
if a API might `panic`, I think rename it to `unsafe_xxx` would be better, or we can handle the `panic` case make it **safe**,

like this.

```moonbit
/// @alert unsafe "Panic if the array is empty."
pub fn Array::unsafe_pop[T](self : Array[T]) -> T
```

related issues.
- #1481 