### PR TITLE
remove some unnecessary/wrong [to_string] methods

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -143,7 +143,6 @@ impl ArrayView {
   rev_foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
   swap[T](Self[T], Int, Int) -> Unit
   to_json[X : ToJson](Self[X]) -> Json
-  to_string[X : Show](Self[X]) -> String
   unsafe_get[T](Self[T], Int) -> T
 }
 impl[T : Compare] Compare for ArrayView[T]

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -78,13 +78,6 @@ pub impl Show for Bytes with output(self, logger) {
 }
 
 ///|
-pub impl Show for Bytes with to_string(self) {
-  let buf = StringBuilder::new()
-  Show::output(self, buf)
-  buf.to_string()
-}
-
-///|
 pub impl Show for BytesView with output(self, logger) {
   fn to_hex_digit(i : Int) -> Char {
     if i < 10 {
@@ -218,11 +211,6 @@ pub impl[X : Show] Show for Array[X] with output(self, logger) {
 ///|
 pub impl[X : Show] Show for ArrayView[X] with output(self, logger) {
   logger.write_iter(self.iter())
-}
-
-///|
-pub fn ArrayView::to_string[X : Show](self : ArrayView[X]) -> String {
-  Show::to_string(self)
 }
 
 ///|

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -1,0 +1,233 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "Show for Unit" {
+  inspect!(().to_string(), content="()")
+}
+
+test "Show for Bool" {
+  inspect!(true.to_string(), content="true")
+  inspect!(false.to_string(), content="false")
+}
+
+test "Show for Int" {
+  inspect!((0).to_string(), content="0")
+  inspect!(@int.max_value.to_string(), content="2147483647")
+  inspect!(@int.min_value.to_string(), content="-2147483648")
+}
+
+test "Show for Int64" {
+  inspect!((0 : Int64).to_string(), content="0")
+  inspect!(@int64.max_value.to_string(), content="9223372036854775807")
+  inspect!(@int64.min_value.to_string(), content="-9223372036854775808")
+}
+
+test "Show for Int16" {
+  inspect!((0 : Int16).to_string(), content="0")
+  inspect!((32767 : Int16).to_string(), content="32767")
+  inspect!((-32768 : Int16).to_string(), content="-32768")
+}
+
+test "Show for UInt" {
+  inspect!((0 : UInt).to_string(), content="0")
+  inspect!(@uint.max_value.to_string(), content="4294967295")
+  inspect!(@uint.min_value.to_string(), content="0")
+}
+
+test "Show for UInt64" {
+  inspect!((0 : UInt64).to_string(), content="0")
+  inspect!(@uint64.max_value.to_string(), content="18446744073709551615")
+  inspect!(@uint64.min_value.to_string(), content="0")
+}
+
+test "Show for UInt16" {
+  inspect!((0 : UInt16).to_string(), content="0")
+  inspect!((65535 : UInt16).to_string(), content="65535")
+}
+
+test "Show for Bytes" {
+  inspect!(
+    Show::to_string(b"abcdefg"),
+    content=
+      #|b"\x61\x62\x63\x64\x65\x66\x67"
+    ,
+  )
+  inspect!(
+    Show::to_string(b"\x00\xff\x63"),
+    content=
+      #|b"\x00\xff\x63"
+    ,
+  )
+}
+
+test "Show for BytesView" {
+  inspect!(
+    b"abcdefg"[1:5].to_string(),
+    content=
+      #|b"\x62\x63\x64\x65"
+    ,
+  )
+  inspect!(
+    b"\x00\xff\x63"[:].to_string(),
+    content=
+      #|b"\x00\xff\x63"
+    ,
+  )
+}
+
+test "Show for String" {
+  fn to_string_using_output(str) {
+    let buf = StringBuilder::new()
+    Show::output(str, buf)
+    buf.to_string()
+  }
+
+  inspect!(
+    to_string_using_output("abcdefg中文字符"),
+    content=
+      #|"abcdefg中文字符"
+    ,
+  )
+  inspect!(
+    Show::to_string("abcdefg中文字符"),
+    content="abcdefg中文字符",
+  )
+  inspect!(
+    to_string_using_output("---\"---'---\\---\n---\t---\x67---"),
+    content=
+      #|"---\"---'---\\---\n---\t---g---"
+    ,
+  )
+  // should be identity
+  inspect!(
+    Show::to_string("---\"---'---\\---\n---\t---\x67---"),
+    content=
+      #|---"---'---\---
+      #|---	---g---
+    ,
+  )
+}
+
+test "Show for Result" {
+  // use explicit type annotation to specify the type of Ok/Err
+  fn result_to_string(x : Result[String, String]) {
+    x.to_string()
+  }
+
+  inspect!(
+    result_to_string(Ok("abc")),
+    content=
+      #|Ok("abc")
+    ,
+  )
+  inspect!(
+    result_to_string(Err("def")),
+    content=
+      #|Err("def")
+    ,
+  )
+}
+
+test "Show for Ref" {
+  inspect!(
+    { val: "abc" }.to_string(),
+    content=
+      #|{val: "abc"}
+    ,
+  )
+}
+
+test "Show for FixedArray" {
+  inspect!(
+    (["a", "b", "c"] : FixedArray[_]).to_string(),
+    content=
+      #|["a", "b", "c"]
+    ,
+  )
+  inspect!(([] : FixedArray[String]).to_string(), content="[]")
+}
+
+test "Show for Array" {
+  inspect!(
+    ["a", "b", "c"].to_string(),
+    content=
+      #|["a", "b", "c"]
+    ,
+  )
+  inspect!(([] : Array[String]).to_string(), content="[]")
+}
+
+test "Show for ArrayView" {
+  let arr = ["a", "b", "c", "d"]
+  inspect!(
+    arr[1:3].to_string(),
+    content=
+      #|["b", "c"]
+    ,
+  )
+  inspect!(arr[2:2].to_string(), content="[]")
+}
+
+test "Show for Char" {
+  inspect!(Show::to_string('a'), content="'a'")
+  inspect!(Show::to_string('字'), content="'字'")
+  inspect!(
+    Show::to_string('\n'),
+    content=
+      #|'\n'
+    ,
+  )
+  inspect!(
+    Show::to_string('\t'),
+    content=
+      #|'\t'
+    ,
+  )
+  inspect!(
+    Show::to_string('"'),
+    content=
+      #|'"'
+    ,
+  )
+  inspect!(
+    Show::to_string('\''),
+    content=
+      #|'\''
+    ,
+  )
+  inspect!(
+    Show::to_string('\\'),
+    content=
+      #|'\\'
+    ,
+  )
+  inspect!('a'.to_string(), content="a")
+  inspect!('字'.to_string(), content="字")
+  inspect!(
+    '\n'.to_string(),
+    content=
+      #|
+      #|
+    ,
+  )
+  inspect!('\t'.to_string(), content="\t")
+  inspect!(
+    '"'.to_string(),
+    content=
+      #|"
+    ,
+  )
+  inspect!('\''.to_string(), content="'")
+  inspect!('\\'.to_string(), content="\\")
+}

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -23,11 +23,6 @@ pub impl[A : Show] Show for T[A] with output(xs, logger) {
 }
 
 ///|
-pub fn to_string[A : Show](self : T[A]) -> String {
-  Show::to_string(self)
-}
-
-///|
 pub impl[A : ToJson] ToJson for T[A] with to_json(self) {
   let capacity = self.length()
   guard capacity != 0 else { return [] }

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -89,7 +89,6 @@ impl T {
   take_while[A](Self[A], (A) -> Bool) -> Self[A]
   to_array[A](Self[A]) -> Array[A]
   to_json[A : ToJson](Self[A]) -> Json
-  to_string[A : Show](Self[A]) -> String
   unsafe_head[A](Self[A]) -> A
   unsafe_last[A](Self[A]) -> A
   unsafe_maximum[A : Compare](Self[A]) -> A

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -330,14 +330,6 @@ pub fn unwrap[T, E](self : Result[T, E]) -> T {
   }
 }
 
-///|
-pub fn to_string[T : Show, E : Show](self : Result[T, E]) -> String {
-  match self {
-    Ok(x) => "Ok(\{x})"
-    Err(e) => "Err(\{e})"
-  }
-}
-
 test "show" {
   let ok : Result[_, String] = Ok("hello")
   inspect!(

--- a/result/result.mbti
+++ b/result/result.mbti
@@ -26,7 +26,6 @@ impl Result {
   or[T, E](Self[T, E], T) -> T
   or_else[T, E](Self[T, E], () -> T) -> T
   to_option[T, E](Self[T, E]) -> T?
-  to_string[T : Show, E : Show](Self[T, E]) -> String
   unwrap[T, E](Self[T, E]) -> T
   unwrap_or_error[T, E : Error](Self[T, E]) -> T!E
 }


### PR DESCRIPTION
Since MoonBit allows calling `impl` with dot syntax now, it is no longer necessary to define `to_string` method wrappers to support `.to_string()` usage. This PR remove such unnecessary `to_string` wrapper methods.

One of the removed methods, `Result::to_string` in `@result`, actually has wrong behavior, forgetting to escape its arguments when necessary. This PR fixes the issue.

I also added tests for the `Show` impls.