### PR TITLE
make all methods defined in builtin qualified

### DIFF
--- a/builtin/bigint_js.mbt
+++ b/builtin/bigint_js.mbt
@@ -33,7 +33,7 @@ pub impl Show for BigInt with output(self, logger) {
 }
 
 ///|
-pub extern "js" fn to_string(self : BigInt) -> String =
+pub extern "js" fn BigInt::to_string(self : BigInt) -> String =
   #|(x) => String(x)
 
 ///|
@@ -41,7 +41,10 @@ pub extern "js" fn BigInt::from_hex(str : String) -> BigInt =
   #|(x) => x.startsWith('-') ? -BigInt(`0x${x.slice(1)}`) : BigInt(`0x${x}`)
 
 ///|
-pub extern "js" fn to_hex(self : BigInt, uppercase~ : Bool = true) -> String =
+pub extern "js" fn BigInt::to_hex(
+  self : BigInt,
+  uppercase~ : Bool = true
+) -> String =
   #|(x, uppercase) => {
   #|  const r = x.toString(16);
   #|  return uppercase ? r.toUpperCase() : r;
@@ -68,7 +71,7 @@ pub fn BigInt::from_octets(octets : Bytes, signum~ : Int = 1) -> BigInt {
 }
 
 ///|
-pub fn to_octets(self : BigInt, length? : Int) -> Bytes {
+pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
   if self < 0 {
     abort("negative BigInt")
   }
@@ -162,7 +165,7 @@ pub extern "js" fn BigInt::op_mod(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x % y
 
 ///|
-extern "js" fn modpow_ffi(
+extern "js" fn BigInt::modpow_ffi(
   self : BigInt,
   exponent : BigInt,
   modulus : BigInt
@@ -170,7 +173,7 @@ extern "js" fn modpow_ffi(
   #|(x, y, z) => x ** y % z
 
 ///|
-extern "js" fn pow_ffi(self : BigInt, exponent : BigInt) -> BigInt =
+extern "js" fn BigInt::pow_ffi(self : BigInt, exponent : BigInt) -> BigInt =
   #|(x, y) => x ** y
 
 ///|
@@ -187,9 +190,9 @@ pub fn BigInt::pow(
       if modulus <= 0 {
         abort("non-positive modulus")
       } else {
-        modpow_ffi(self, exponent, modulus)
+        self.modpow_ffi(exponent, modulus)
       }
-    None => pow_ffi(self, exponent)
+    None => self.pow_ffi(exponent)
   }
 }
 
@@ -214,23 +217,23 @@ pub fn BigInt::op_shr(self : BigInt, n : Int) -> BigInt {
 }
 
 ///|
-extern "js" fn js_shl(self : BigInt, other : Int) -> BigInt =
+extern "js" fn BigInt::js_shl(self : BigInt, other : Int) -> BigInt =
   #|(x, y) => x << BigInt(y)
 
 ///|
-extern "js" fn js_shr(self : BigInt, other : Int) -> BigInt =
+extern "js" fn BigInt::js_shr(self : BigInt, other : Int) -> BigInt =
   #|(x, y) => x >> BigInt(y)
 
 ///|
-pub extern "js" fn land(self : BigInt, other : BigInt) -> BigInt =
+pub extern "js" fn BigInt::land(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x & y
 
 ///|
-pub extern "js" fn lor(self : BigInt, other : BigInt) -> BigInt =
+pub extern "js" fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x | y
 
 ///|
-pub extern "js" fn lxor(self : BigInt, other : BigInt) -> BigInt =
+pub extern "js" fn BigInt::lxor(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x ^ y
 
 ///|

--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -215,16 +215,16 @@ pub fn BigInt::op_mul(self : BigInt, other : BigInt) -> BigInt {
     return zero
   }
   let ret = if self.len < karatsuba_threshold || other.len < karatsuba_threshold {
-    grade_school_mul(self, other)
+    self.grade_school_mul(other)
   } else {
-    karatsuba_mul(self, other)
+    self.karatsuba_mul(other)
   }
   { ..ret, sign: if self.sign == other.sign { Positive } else { Negative } }
 }
 
 ///|
 // Simplest way to multiply two BigInts.
-fn grade_school_mul(self : BigInt, other : BigInt) -> BigInt {
+fn BigInt::grade_school_mul(self : BigInt, other : BigInt) -> BigInt {
   let self_len = self.len
   let other_len = other.len
   let mut len = self_len + other_len
@@ -248,7 +248,7 @@ fn grade_school_mul(self : BigInt, other : BigInt) -> BigInt {
 
 ///|
 // Karatsuba multiplication
-fn karatsuba_mul(self : BigInt, other : BigInt) -> BigInt {
+fn BigInt::karatsuba_mul(self : BigInt, other : BigInt) -> BigInt {
   let half = (max(self.len, other.len) + 1) / 2
   let (xl, xh) = self.split(half)
   let (yl, yh) = other.split(half)
@@ -287,14 +287,14 @@ pub fn BigInt::op_div(self : BigInt, other : BigInt) -> BigInt {
   // Handle negative numbers
   if self.sign == Negative {
     if other.sign == Negative {
-      grade_school_div(-self, -other).0
+      BigInt::grade_school_div(-self, -other).0
     } else {
-      -grade_school_div(-self, other).0
+      -BigInt::grade_school_div(-self, other).0
     }
   } else if other.sign == Negative {
-    -grade_school_div(self, -other).0
+    -BigInt::grade_school_div(self, -other).0
   } else {
-    return grade_school_div(self, other).0
+    return BigInt::grade_school_div(self, other).0
   }
 }
 
@@ -307,21 +307,21 @@ pub fn BigInt::op_mod(self : BigInt, other : BigInt) -> BigInt {
   // Handle negative numbers
   if self.sign == Negative {
     if other.sign == Negative {
-      -grade_school_div(-self, -other).1
+      -BigInt::grade_school_div(-self, -other).1
     } else {
-      -grade_school_div(-self, other).1
+      -BigInt::grade_school_div(-self, other).1
     }
   } else if other.sign == Negative {
-    grade_school_div(self, -other).1
+    BigInt::grade_school_div(self, -other).1
   } else {
-    grade_school_div(self, other).1
+    BigInt::grade_school_div(self, other).1
   }
 }
 
 ///|
 // Simplest way to divide two BigInts.
 // Assumption: other != zero.
-fn grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
+fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   // Handle edge cases
   if self < other {
     return (zero, self)

--- a/builtin/int64_js.mbt
+++ b/builtin/int64_js.mbt
@@ -35,7 +35,7 @@ fn MyInt64::op_neg(self : MyInt64) -> MyInt64 {
 }
 
 ///|
-fn add_hi_lo(self : MyInt64, bhi : Int, blo : Int) -> MyInt64 {
+fn MyInt64::add_hi_lo(self : MyInt64, bhi : Int, blo : Int) -> MyInt64 {
   let { hi: ahi, lo: alo } = self
   let lo = alo + blo
   let s = lo >> 31
@@ -48,7 +48,7 @@ fn add_hi_lo(self : MyInt64, bhi : Int, blo : Int) -> MyInt64 {
 
 ///|
 fn MyInt64::op_add(self : MyInt64, other : MyInt64) -> MyInt64 {
-  add_hi_lo(self, other.hi, other.lo)
+  self.add_hi_lo(other.hi, other.lo)
 }
 
 ///|
@@ -56,7 +56,7 @@ fn MyInt64::op_sub(self : MyInt64, other : MyInt64) -> MyInt64 {
   if other.lo == 0 {
     { hi: self.hi - other.hi, lo: self.lo }
   } else {
-    add_hi_lo(self, other.hi.lnot(), other.lo.lnot() + 1)
+    self.add_hi_lo(other.hi.lnot(), other.lo.lnot() + 1)
   }
 }
 


### PR DESCRIPTION
This is a continuation of #1472. #1472 ensures there is no name clash between methods defined as `fn f(self : T, ..)` and regular functions. In the proposed semantic of #1472, all methods in `@builtin` should be qualified, because we don't want users to call these methods directly, unqualified using the `f(...)` syntax. However, several methods in `@builtin` are still unqualified in #1472, so this PR make them qualified.