### PR TITLE
add separate packages for builtin types

### DIFF
--- a/iter/iter.mbt
+++ b/iter/iter.mbt
@@ -1,0 +1,186 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub typealias T[X] = Iter[X]
+
+///|
+pub fn all[T](it : Iter[T], f : (T) -> Bool) -> Bool {
+  it.all(f)
+}
+
+///|
+pub fn any[T](it : Iter[T], f : (T) -> Bool) -> Bool {
+  it.any(f)
+}
+
+///|
+pub fn append[T](it : Iter[T], elt : T) -> Iter[T] {
+  it.append(elt)
+}
+
+///|
+pub fn collect[T](it : Iter[T]) -> Array[T] {
+  it.collect()
+}
+
+///|
+pub fn concat[T](it1 : Iter[T], it2 : Iter[T]) -> Iter[T] {
+  it1.concat(it2)
+}
+
+///|
+pub fn contains[A : Eq](it : Iter[A], elt : A) -> Bool {
+  it.contains(elt)
+}
+
+///|
+pub fn count[T](it : Iter[T]) -> Int {
+  it.count()
+}
+
+///|
+pub fn drop[T](it : Iter[T], n : Int) -> Iter[T] {
+  it.drop(n)
+}
+
+///|
+pub fn drop_while[T](it : Iter[T], f : (T) -> Bool) -> Iter[T] {
+  it.drop_while(f)
+}
+
+///|
+pub fn each[T](it : Iter[T], f : (T) -> Unit) -> Unit {
+  it.each(f)
+}
+
+///|
+pub fn eachi[T](it : Iter[T], f : (Int, T) -> Unit) -> Unit {
+  it.eachi(f)
+}
+
+///|
+pub fn empty[T]() -> Iter[T] {
+  Iter::empty()
+}
+
+///|
+pub fn filter[T](it : Iter[T], f : (T) -> Bool) -> Iter[T] {
+  it.filter(f)
+}
+
+///|
+pub fn filter_map[A, B](it : Iter[A], f : (A) -> B?) -> Iter[B] {
+  it.filter_map(f)
+}
+
+///|
+pub fn find_first[T](it : Iter[T], f : (T) -> Bool) -> T? {
+  it.find_first(f)
+}
+
+///|
+pub fn flat_map[T, R](it : Iter[T], f : (T) -> Iter[R]) -> Iter[R] {
+  it.flat_map(f)
+}
+
+///|
+pub fn fold[T, B](it : Iter[T], init~ : B, f : (B, T) -> B) -> B {
+  it.fold(init~, f)
+}
+
+///|
+pub fn head[A](it : Iter[A]) -> A? {
+  it.head()
+}
+
+///|
+pub fn intersperse[A](it : Iter[A], sep : A) -> Iter[A] {
+  it.intersperse(sep)
+}
+
+///|
+pub fn iter[T](it : Iter[T]) -> Iter[T] {
+  it.iter()
+}
+
+///|
+pub fn just_run[T](it : Iter[T], f : (T) -> IterResult) -> Unit {
+  it.just_run(f)
+}
+
+///|
+pub fn last[A](it : Iter[A]) -> A? {
+  it.last()
+}
+
+///|
+pub fn map[T, R](it : Iter[T], f : (T) -> R) -> Iter[R] {
+  it.map(f)
+}
+
+///|
+pub fn map_while[A, B](it : Iter[A], f : (A) -> B?) -> Iter[B] {
+  it.map_while(f)
+}
+
+///|
+pub fn new[T](f : ((T) -> IterResult) -> IterResult) -> Iter[T] {
+  Iter::new(f)
+}
+
+///|
+pub fn peek[T](it : Iter[T]) -> T? {
+  it.peek()
+}
+
+///|
+pub fn prepend[T](it : Iter[T], elt : T) -> Iter[T] {
+  it.prepend(elt)
+}
+
+///|
+pub fn repeat[T](elt : T) -> Iter[T] {
+  Iter::repeat(elt)
+}
+
+///|
+pub fn run[T](it : Iter[T], f : (T) -> IterResult) -> IterResult {
+  it.run(f)
+}
+
+///|
+pub fn singleton[T](elt : T) -> Iter[T] {
+  Iter::singleton(elt)
+}
+
+///|
+pub fn take[T](it : Iter[T], n : Int) -> Iter[T] {
+  it.take(n)
+}
+
+///|
+pub fn take_while[T](it : Iter[T], f : (T) -> Bool) -> Iter[T] {
+  it.take_while(f)
+}
+
+///|
+pub fn tap[T](it : Iter[T], f : (T) -> Unit) -> Iter[T] {
+  it.tap(f)
+}
+
+///|
+pub fn to_array[T](it : Iter[T]) -> Array[T] {
+  it.to_array()
+}

--- a/iter/iter.mbti
+++ b/iter/iter.mbti
@@ -1,0 +1,78 @@
+package moonbitlang/core/iter
+
+// Values
+fn all[T](Iter[T], (T) -> Bool) -> Bool
+
+fn any[T](Iter[T], (T) -> Bool) -> Bool
+
+fn append[T](Iter[T], T) -> Iter[T]
+
+fn collect[T](Iter[T]) -> Array[T]
+
+fn concat[T](Iter[T], Iter[T]) -> Iter[T]
+
+fn contains[A : Eq](Iter[A], A) -> Bool
+
+fn count[T](Iter[T]) -> Int
+
+fn drop[T](Iter[T], Int) -> Iter[T]
+
+fn drop_while[T](Iter[T], (T) -> Bool) -> Iter[T]
+
+fn each[T](Iter[T], (T) -> Unit) -> Unit
+
+fn eachi[T](Iter[T], (Int, T) -> Unit) -> Unit
+
+fn empty[T]() -> Iter[T]
+
+fn filter[T](Iter[T], (T) -> Bool) -> Iter[T]
+
+fn filter_map[A, B](Iter[A], (A) -> B?) -> Iter[B]
+
+fn find_first[T](Iter[T], (T) -> Bool) -> T?
+
+fn flat_map[T, R](Iter[T], (T) -> Iter[R]) -> Iter[R]
+
+fn fold[T, B](Iter[T], init~ : B, (B, T) -> B) -> B
+
+fn head[A](Iter[A]) -> A?
+
+fn intersperse[A](Iter[A], A) -> Iter[A]
+
+fn iter[T](Iter[T]) -> Iter[T]
+
+fn just_run[T](Iter[T], (T) -> IterResult) -> Unit
+
+fn last[A](Iter[A]) -> A?
+
+fn map[T, R](Iter[T], (T) -> R) -> Iter[R]
+
+fn map_while[A, B](Iter[A], (A) -> B?) -> Iter[B]
+
+fn new[T](((T) -> IterResult) -> IterResult) -> Iter[T]
+
+fn peek[T](Iter[T]) -> T?
+
+fn prepend[T](Iter[T], T) -> Iter[T]
+
+fn repeat[T](T) -> Iter[T]
+
+fn run[T](Iter[T], (T) -> IterResult) -> IterResult
+
+fn singleton[T](T) -> Iter[T]
+
+fn take[T](Iter[T], Int) -> Iter[T]
+
+fn take_while[T](Iter[T], (T) -> Bool) -> Iter[T]
+
+fn tap[T](Iter[T], (T) -> Unit) -> Iter[T]
+
+fn to_array[T](Iter[T]) -> Array[T]
+
+// Types and methods
+
+// Type aliases
+pub typealias T[X] = Iter[X]
+
+// Traits
+

--- a/iter/moon.pkg.json
+++ b/iter/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ]
+}

--- a/iter2/iter2.mbt
+++ b/iter2/iter2.mbt
@@ -1,0 +1,46 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub typealias T[X, Y] = Iter2[X, Y]
+
+///|
+pub fn each[A, B](it : Iter2[A, B], f : (A, B) -> Unit) -> Unit {
+  it.each(f)
+}
+
+///|
+pub fn iter[A, B](it : Iter2[A, B]) -> Iter[(A, B)] {
+  it.iter()
+}
+
+///|
+pub fn iter2[A, B](it : Iter2[A, B]) -> Iter2[A, B] {
+  it.iter2()
+}
+
+///|
+pub fn new[A, B](f : ((A, B) -> IterResult) -> IterResult) -> Iter2[A, B] {
+  Iter2::new(f)
+}
+
+///|
+pub fn run[A, B](it : Iter2[A, B], f : (A, B) -> IterResult) -> IterResult {
+  it.run(f)
+}
+
+///|
+pub fn to_array[A, B](it : Iter2[A, B]) -> Array[(A, B)] {
+  it.to_array()
+}

--- a/iter2/iter2.mbti
+++ b/iter2/iter2.mbti
@@ -1,0 +1,22 @@
+package moonbitlang/core/iter2
+
+// Values
+fn each[A, B](Iter2[A, B], (A, B) -> Unit) -> Unit
+
+fn iter[A, B](Iter2[A, B]) -> Iter[(A, B)]
+
+fn iter2[A, B](Iter2[A, B]) -> Iter2[A, B]
+
+fn new[A, B](((A, B) -> IterResult) -> IterResult) -> Iter2[A, B]
+
+fn run[A, B](Iter2[A, B], (A, B) -> IterResult) -> IterResult
+
+fn to_array[A, B](Iter2[A, B]) -> Array[(A, B)]
+
+// Types and methods
+
+// Type aliases
+pub typealias T[X, Y] = Iter2[X, Y]
+
+// Traits
+

--- a/iter2/moon.pkg.json
+++ b/iter2/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ]
+}

--- a/map/map.mbt
+++ b/map/map.mbt
@@ -1,0 +1,139 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub typealias T[K, V] = Map[K, V]
+
+///|
+pub fn capacity[K, V](map : Map[K, V]) -> Int {
+  map.capacity()
+}
+
+///|
+pub fn clear[K, V](map : Map[K, V]) -> Unit {
+  map.clear()
+}
+
+///|
+pub fn contains[K : Hash + Eq, V](map : Map[K, V], k : K) -> Bool {
+  map.contains(k)
+}
+
+///|
+pub fn default[K, V]() -> Map[K, V] {
+  Map::default()
+}
+
+///|
+pub fn each[K, V](map : Map[K, V], f : (K, V) -> Unit) -> Unit {
+  map.each(f)
+}
+
+///|
+pub fn eachi[K, V](map : Map[K, V], f : (Int, K, V) -> Unit) -> Unit {
+  map.eachi(f)
+}
+
+///|
+pub fn from_array[K : Hash + Eq, V](arr : Array[(K, V)]) -> Map[K, V] {
+  Map::from_array(arr)
+}
+
+///|
+pub fn from_iter[K : Hash + Eq, V](iter : Iter[(K, V)]) -> Map[K, V] {
+  Map::from_iter(iter)
+}
+
+///|
+pub fn get[K : Hash + Eq, V](map : Map[K, V], k : K) -> V? {
+  map.get(k)
+}
+
+///|
+pub fn get_or_default[K : Hash + Eq, V](
+  map : Map[K, V],
+  k : K,
+  default : V
+) -> V {
+  map.get_or_default(k, default)
+}
+
+///|
+pub fn get_or_init[K : Hash + Eq, V](
+  map : Map[K, V],
+  k : K,
+  init : () -> V
+) -> V {
+  map.get_or_init(k, init)
+}
+
+///|
+pub fn is_empty[K, V](map : Map[K, V]) -> Bool {
+  map.is_empty()
+}
+
+///|
+pub fn iter[K, V](map : Map[K, V]) -> Iter[(K, V)] {
+  map.iter()
+}
+
+///|
+pub fn iter2[K, V](map : Map[K, V]) -> Iter2[K, V] {
+  map.iter2()
+}
+
+///|
+pub fn keys[K, V](map : Map[K, V]) -> Iter[K] {
+  map.keys()
+}
+
+///|
+pub fn new[K, V](capacity~ : Int = 8) -> Map[K, V] {
+  Map::new(capacity~)
+}
+
+///|
+pub fn of[K : Hash + Eq, V](arr : FixedArray[(K, V)]) -> Map[K, V] {
+  Map::of(arr)
+}
+
+///|
+pub fn remove[K : Hash + Eq, V](map : Map[K, V], k : K) -> Unit {
+  map.remove(k)
+}
+
+///|
+pub fn set[K : Hash + Eq, V](map : Map[K, V], k : K, v : V) -> Unit {
+  map.set(k, v)
+}
+
+///|
+pub fn size[K, V](map : Map[K, V]) -> Int {
+  map.size()
+}
+
+///|
+pub fn to_array[K, V](map : Map[K, V]) -> Array[(K, V)] {
+  map.to_array()
+}
+
+///|
+pub fn to_json[K : Show, V : ToJson](map : Map[K, V]) -> Json {
+  map.to_json()
+}
+
+///|
+pub fn values[K, V](map : Map[K, V]) -> Iter[V] {
+  map.values()
+}

--- a/map/map.mbti
+++ b/map/map.mbti
@@ -1,0 +1,56 @@
+package moonbitlang/core/map
+
+// Values
+fn capacity[K, V](Map[K, V]) -> Int
+
+fn clear[K, V](Map[K, V]) -> Unit
+
+fn contains[K : Hash + Eq, V](Map[K, V], K) -> Bool
+
+fn default[K, V]() -> Map[K, V]
+
+fn each[K, V](Map[K, V], (K, V) -> Unit) -> Unit
+
+fn eachi[K, V](Map[K, V], (Int, K, V) -> Unit) -> Unit
+
+fn from_array[K : Hash + Eq, V](Array[(K, V)]) -> Map[K, V]
+
+fn from_iter[K : Hash + Eq, V](Iter[(K, V)]) -> Map[K, V]
+
+fn get[K : Hash + Eq, V](Map[K, V], K) -> V?
+
+fn get_or_default[K : Hash + Eq, V](Map[K, V], K, V) -> V
+
+fn get_or_init[K : Hash + Eq, V](Map[K, V], K, () -> V) -> V
+
+fn is_empty[K, V](Map[K, V]) -> Bool
+
+fn iter[K, V](Map[K, V]) -> Iter[(K, V)]
+
+fn iter2[K, V](Map[K, V]) -> Iter2[K, V]
+
+fn keys[K, V](Map[K, V]) -> Iter[K]
+
+fn new[K, V](capacity~ : Int = ..) -> Map[K, V]
+
+fn of[K : Hash + Eq, V](FixedArray[(K, V)]) -> Map[K, V]
+
+fn remove[K : Hash + Eq, V](Map[K, V], K) -> Unit
+
+fn set[K : Hash + Eq, V](Map[K, V], K, V) -> Unit
+
+fn size[K, V](Map[K, V]) -> Int
+
+fn to_array[K, V](Map[K, V]) -> Array[(K, V)]
+
+fn to_json[K : Show, V : ToJson](Map[K, V]) -> Json
+
+fn values[K, V](Map[K, V]) -> Iter[V]
+
+// Types and methods
+
+// Type aliases
+pub typealias T[K, V] = Map[K, V]
+
+// Traits
+

--- a/map/moon.pkg.json
+++ b/map/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ]
+}

--- a/set/moon.pkg.json
+++ b/set/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ]
+}

--- a/set/set.mbt
+++ b/set/set.mbt
@@ -1,0 +1,126 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub typealias T[K] = Set[K]
+
+///|
+pub fn add[K : Hash + Eq](set : Set[K], k : K) -> Unit {
+  set.add(k)
+}
+
+///|
+pub fn add_and_check[K : Hash + Eq](set : Set[K], k : K) -> Bool {
+  set.add_and_check(k)
+}
+
+///|
+pub fn capacity[K](set : Set[K]) -> Int {
+  set.capacity()
+}
+
+///|
+pub fn clear[K](set : Set[K]) -> Unit {
+  set.clear()
+}
+
+///|
+pub fn contains[K : Hash + Eq](set : Set[K], k : K) -> Bool {
+  set.contains(k)
+}
+
+///|
+pub fn difference[K : Hash + Eq](s1 : Set[K], s2 : Set[K]) -> Set[K] {
+  s1.difference(s2)
+}
+
+///|
+pub fn each[K](set : Set[K], f : (K) -> Unit) -> Unit {
+  set.each(f)
+}
+
+///|
+pub fn eachi[K](set : Set[K], f : (Int, K) -> Unit) -> Unit {
+  set.eachi(f)
+}
+
+///|
+pub fn from_array[K : Hash + Eq](arr : Array[K]) -> Set[K] {
+  Set::from_array(arr)
+}
+
+///|
+pub fn from_iter[K : Hash + Eq](iter : Iter[K]) -> Set[K] {
+  Set::from_iter(iter)
+}
+
+///|
+pub fn intersection[K : Hash + Eq](s1 : Set[K], s2 : Set[K]) -> Set[K] {
+  s1.intersection(s2)
+}
+
+///|
+pub fn is_empty[K](set : Set[K]) -> Bool {
+  set.is_empty()
+}
+
+///|
+pub fn iter[K](set : Set[K]) -> Iter[K] {
+  set.iter()
+}
+
+///|
+pub fn new[K](capacity~ : Int = 8) -> Set[K] {
+  Set::new(capacity~)
+}
+
+///|
+pub fn of[K : Hash + Eq](arr : FixedArray[K]) -> Set[K] {
+  Set::of(arr)
+}
+
+///|
+pub fn remove[K : Hash + Eq](set : Set[K], k : K) -> Unit {
+  set.remove(k)
+}
+
+///|
+pub fn remove_and_check[K : Hash + Eq](set : Set[K], k : K) -> Bool {
+  set.remove_and_check(k)
+}
+
+///|
+pub fn size[K](set : Set[K]) -> Int {
+  set.size()
+}
+
+///|
+pub fn symmetric_difference[K : Hash + Eq](s1 : Set[K], s2 : Set[K]) -> Set[K] {
+  s1.symmetric_difference(s2)
+}
+
+///|
+pub fn to_array[K](set : Set[K]) -> Array[K] {
+  set.to_array()
+}
+
+///|
+pub fn to_json[X : ToJson](set : Set[X]) -> Json {
+  set.to_json()
+}
+
+///|
+pub fn union[K : Hash + Eq](s1 : Set[K], s2 : Set[K]) -> Set[K] {
+  s1.union(s2)
+}

--- a/set/set.mbti
+++ b/set/set.mbti
@@ -1,0 +1,54 @@
+package moonbitlang/core/set
+
+// Values
+fn add[K : Hash + Eq](Set[K], K) -> Unit
+
+fn add_and_check[K : Hash + Eq](Set[K], K) -> Bool
+
+fn capacity[K](Set[K]) -> Int
+
+fn clear[K](Set[K]) -> Unit
+
+fn contains[K : Hash + Eq](Set[K], K) -> Bool
+
+fn difference[K : Hash + Eq](Set[K], Set[K]) -> Set[K]
+
+fn each[K](Set[K], (K) -> Unit) -> Unit
+
+fn eachi[K](Set[K], (Int, K) -> Unit) -> Unit
+
+fn from_array[K : Hash + Eq](Array[K]) -> Set[K]
+
+fn from_iter[K : Hash + Eq](Iter[K]) -> Set[K]
+
+fn intersection[K : Hash + Eq](Set[K], Set[K]) -> Set[K]
+
+fn is_empty[K](Set[K]) -> Bool
+
+fn iter[K](Set[K]) -> Iter[K]
+
+fn new[K](capacity~ : Int = ..) -> Set[K]
+
+fn of[K : Hash + Eq](FixedArray[K]) -> Set[K]
+
+fn remove[K : Hash + Eq](Set[K], K) -> Unit
+
+fn remove_and_check[K : Hash + Eq](Set[K], K) -> Bool
+
+fn size[K](Set[K]) -> Int
+
+fn symmetric_difference[K : Hash + Eq](Set[K], Set[K]) -> Set[K]
+
+fn to_array[K](Set[K]) -> Array[K]
+
+fn to_json[X : ToJson](Set[X]) -> Json
+
+fn union[K : Hash + Eq](Set[K], Set[K]) -> Set[K]
+
+// Types and methods
+
+// Type aliases
+pub typealias T[K] = Set[K]
+
+// Traits
+

--- a/stringbuilder/moon.pkg.json
+++ b/stringbuilder/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ]
+}

--- a/stringbuilder/stringbuilder.mbt
+++ b/stringbuilder/stringbuilder.mbt
@@ -1,0 +1,61 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub typealias T = StringBuilder
+
+///|
+pub fn is_empty(b : StringBuilder) -> Bool {
+  b.is_empty()
+}
+
+///|
+pub fn new(size_hint~ : Int = 0) -> StringBuilder {
+  StringBuilder::new(size_hint~)
+}
+
+///|
+pub fn reset(b : StringBuilder) -> Unit {
+  b.reset()
+}
+
+///|
+pub fn to_string(b : StringBuilder) -> String {
+  b.to_string()
+}
+
+///|
+pub fn write_char(b : StringBuilder, c : Char) -> Unit {
+  b.write_char(c)
+}
+
+///|
+pub fn write_object[T : Show](b : StringBuilder, obj : T) -> Unit {
+  b.write_object(obj)
+}
+
+///|
+pub fn write_string(b : StringBuilder, s : String) -> Unit {
+  b.write_string(s)
+}
+
+///|
+pub fn write_substring(
+  b : StringBuilder,
+  s : String,
+  start : Int,
+  len : Int
+) -> Unit {
+  b.write_substring(s, start, len)
+}

--- a/stringbuilder/stringbuilder.mbti
+++ b/stringbuilder/stringbuilder.mbti
@@ -1,0 +1,26 @@
+package moonbitlang/core/stringbuilder
+
+// Values
+fn is_empty(StringBuilder) -> Bool
+
+fn new(size_hint~ : Int = ..) -> StringBuilder
+
+fn reset(StringBuilder) -> Unit
+
+fn to_string(StringBuilder) -> String
+
+fn write_char(StringBuilder, Char) -> Unit
+
+fn write_object[T : Show](StringBuilder, T) -> Unit
+
+fn write_string(StringBuilder, String) -> Unit
+
+fn write_substring(StringBuilder, String, Int, Int) -> Unit
+
+// Types and methods
+
+// Type aliases
+pub typealias T = StringBuilder
+
+// Traits
+


### PR DESCRIPTION
In #1472, the API style of builtin types and other types is different. Types defined in a regular package such as `@hashmap` will favor the syntax `@hashmap.new()` for calling things, while builtin types favor the syntax `Map::new()`. This is because some types in `@builtin` don't have their own package, such as `Map`/`Set`/`Iter`/`StringBuilder`.

This divergence of API style is bad, because sometimes it forbids abstraction over data structure. For example, if a user is using `@buffer.T` for internal use, but later find out that `StringBuilder` has better performance. If `StrnigBuilder` has its own package, the user can import `@stringbuilder` and alias it to `@buffer`, then everything should just work because `@buffer.T` and `StringBuilder` have similar API. But currently this is not possible because `StringBuilder` does not have its own package.

This PR add new packages for builtin types `Map`/`Set`/`Iter`/`Iter2`/`StringBuilder`. These new packages contain wrappers to the actual implementation in `@builtin`. This way, the API of these types would be more consistent with other types. In the future, we may also refactor `@builtin` and move the implementations to separated packages as well.