### PR TITLE
to_string_by_radix method for standard integers

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -454,7 +454,7 @@ impl Int {
   to_int16(Int) -> Int16
   to_int64(Int) -> Int64
   to_json(Int) -> Json
-  to_string(Int) -> String
+  to_string(Int, radix~ : Int = ..) -> String
   to_uint(Int) -> UInt //deprecated
   to_uint16(Int) -> UInt16
   to_uint64(Int) -> UInt64
@@ -466,7 +466,7 @@ impl Int16 {
   to_byte(Int16) -> Byte
   to_int(Int16) -> Int
   to_int64(Int16) -> Int64
-  to_string(Int16) -> String
+  to_string(Int16, radix~ : Int = ..) -> String
 }
 
 impl Int64 {
@@ -501,7 +501,7 @@ impl Int64 {
   to_int(Int64) -> Int
   to_int16(Int64) -> Int16
   to_json(Int64) -> Json
-  to_string(Int64) -> String
+  to_string(Int64, radix~ : Int = ..) -> String
   to_uint16(Int64) -> UInt16
   to_uint64(Int64) -> UInt64 //deprecated
   until(Int64, Int64, step~ : Int64 = .., inclusive~ : Bool = ..) -> Iter[Int64]
@@ -536,7 +536,7 @@ impl UInt {
   to_float(UInt) -> Float
   to_int(UInt) -> Int //deprecated
   to_json(UInt) -> Json
-  to_string(UInt) -> String
+  to_string(UInt, radix~ : Int = ..) -> String
   to_uint64(UInt) -> UInt64
   trunc_double(Double) -> UInt
   upto(UInt, UInt, inclusive~ : Bool = ..) -> Iter[UInt] //deprecated
@@ -546,7 +546,7 @@ impl UInt16 {
   to_byte(UInt16) -> Byte
   to_int(UInt16) -> Int
   to_int64(UInt16) -> Int64
-  to_string(UInt16) -> String
+  to_string(UInt16, radix~ : Int = ..) -> String
 }
 
 impl UInt64 {
@@ -580,7 +580,7 @@ impl UInt64 {
   to_int(UInt64) -> Int
   to_int64(UInt64) -> Int64 //deprecated
   to_json(UInt64) -> Json
-  to_string(UInt64) -> String
+  to_string(UInt64, radix~ : Int = ..) -> String
   to_uint(UInt64) -> UInt
   trunc_double(Double) -> UInt64
   upto(UInt64, UInt64, inclusive~ : Bool = ..) -> Iter[UInt64] //deprecated

--- a/builtin/to_string.mbt
+++ b/builtin/to_string.mbt
@@ -22,7 +22,10 @@ pub fn Bool::to_string(self : Bool) -> String {
 }
 
 ///|
-pub fn Int64::to_string(self : Int64) -> String {
+const ALPHABET : String = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+///|
+pub fn Int64::to_string(self : Int64, radix~ : Int = 10) -> String {
   fn abs(n : Int64) -> Int64 {
     if n < 0L {
       0L - n
@@ -31,27 +34,36 @@ pub fn Int64::to_string(self : Int64) -> String {
     }
   }
 
-  // The min and max value of i64 are -9223372036854775808 and 9223372036854775807,
-  // so max=20 is enough.
-
-  let buf = StringBuilder::new(size_hint=20)
+  let size_hint = match radix {
+    2..<7 => 70 // max length is 64, 70 is enough
+    8..<15 => 30 // max length is 23, 30 is enough
+    16..=36 => 20 // max length is 17, 20 is enough
+    _ => abort("radix must be between 2 and 36")
+  }
+  let buf = StringBuilder::new(size_hint~)
   if self < 0L {
     buf.write_char('-')
   }
-  fn write_digits(num) {
-    let num2 = num / 10L
+  let radix : Int64 = radix.to_int64()
+  fn write_digits(num : Int64) {
+    let num2 = num / radix
     if num2 != 0L {
       write_digits(num2)
     }
-    buf.write_char(Char::from_int(abs(num % 10L).to_int() + 48))
+    buf.write_char(ALPHABET[abs(num % radix).to_int()])
   }
 
-  write_digits(self)
+  write_digits(abs(self))
   buf.to_string()
 }
 
 ///|
-pub fn Int::to_string(self : Int) -> String {
+pub impl Show for Int64 with to_string(self) {
+  self.to_string(radix=10)
+}
+
+///|
+pub fn Int::to_string(self : Int, radix~ : Int = 10) -> String {
   fn abs(n : Int) -> Int {
     if n < 0 {
       0 - n
@@ -60,19 +72,49 @@ pub fn Int::to_string(self : Int) -> String {
     }
   }
 
-  // The min and max value of i32 are -2147483648 and 2147483647,
-  // so max=11 is enough.
-
-  let buf = StringBuilder::new()
+  let size_hint = match radix {
+    2..<7 => 36 // max length is 32, 36 is enough
+    8..<15 => 18 // max length is 12, 18 is enough
+    16..=36 => 10 // max length is 8, 10 is enough
+    _ => abort("radix must be between 2 and 36")
+  }
+  let buf = StringBuilder::new(size_hint~)
   if self < 0 {
     buf.write_char('-')
   }
-  fn write_digits(num) {
-    let num2 = num / 10
+  fn write_digits(num : Int) {
+    let num2 = num / radix
     if num2 != 0 {
       write_digits(num2)
     }
-    buf.write_char(Char::from_int(abs(num % 10) + 48))
+    buf.write_char(ALPHABET[abs(num % radix)])
+  }
+
+  write_digits(abs(self))
+  buf.to_string()
+}
+
+///|
+pub impl Show for Int with to_string(self) {
+  self.to_string(radix=10)
+}
+
+///|
+pub fn UInt::to_string(self : UInt, radix~ : Int = 10) -> String {
+  let size_hint = match radix {
+    2..<7 => 36 // max length is 32, 36 is enough
+    8..<15 => 18 // max length is 11, 18 is enough
+    16..=36 => 10 // max length is 8, 10 is enough
+    _ => abort("radix must be between 2 and 36")
+  }
+  let buf = StringBuilder::new(size_hint~)
+  let radix : UInt = radix.reinterpret_as_uint()
+  fn write_digits(num : UInt) {
+    let num2 = num / radix
+    if num2 != 0U {
+      write_digits(num2)
+    }
+    buf.write_char(ALPHABET[(num % radix).reinterpret_as_int()])
   }
 
   write_digits(self)
@@ -80,18 +122,8 @@ pub fn Int::to_string(self : Int) -> String {
 }
 
 ///|
-pub fn UInt::to_string(self : UInt) -> String {
-  let buf = StringBuilder::new()
-  fn write_digits(num) {
-    let num2 = num / 10U
-    if num2 != 0U {
-      write_digits(num2)
-    }
-    buf.write_char(Char::from_int((num % 10U).reinterpret_as_int() + 48))
-  }
-
-  write_digits(self)
-  buf.to_string()
+pub impl Show for UInt with to_string(self) {
+  self.to_string(radix=10)
 }
 
 ///|
@@ -102,16 +134,21 @@ test "UInt::to_string" {
 }
 
 ///|
-pub fn UInt64::to_string(self : UInt64) -> String {
-  let buf = StringBuilder::new()
+pub fn UInt64::to_string(self : UInt64, radix~ : Int = 10) -> String {
+  let size_hint = match radix {
+    2..<7 => 70 // max length is 64, 70 is enough
+    8..<15 => 30 // max length is 23, 30 is enough
+    16..=36 => 20 // max length is 17, 20 is enough
+    _ => abort("radix must be between 2 and 36")
+  }
+  let buf = StringBuilder::new(size_hint~)
+  let radix : UInt64 = radix.to_uint64()
   fn write_digits(num : UInt64) {
-    let num2 = num / 10UL
+    let num2 = num / radix
     if num2 != 0UL {
       write_digits(num2)
     }
-    buf.write_char(
-      Char::from_int((num % 10UL).reinterpret_as_int64().to_int() + 48),
-    )
+    buf.write_char(ALPHABET[(num % radix).to_int()])
   }
 
   write_digits(self)
@@ -119,11 +156,122 @@ pub fn UInt64::to_string(self : UInt64) -> String {
 }
 
 ///|
-pub fn Int16::to_string(self : Int16) -> String {
-  self.to_int().to_string()
+pub impl Show for UInt64 with to_string(self) {
+  self.to_string(radix=10)
 }
 
 ///|
-pub fn UInt16::to_string(self : UInt16) -> String {
-  self.to_int().to_string()
+pub fn Int16::to_string(self : Int16, radix~ : Int = 10) -> String {
+  self.to_int().to_string(radix~)
+}
+
+///|
+pub impl Show for Int16 with to_string(self) {
+  self.to_string(radix=10)
+}
+
+///|
+pub fn UInt16::to_string(self : UInt16, radix~ : Int = 10) -> String {
+  self.to_int().to_string(radix~)
+}
+
+///|
+pub impl Show for UInt16 with to_string(self) {
+  self.to_string(radix=10)
+}
+
+///|
+test "to_string" {
+  assert_eq!((0x100).to_string(), "256")
+  assert_eq!("\{0x100}", "256")
+  assert_eq!(0x200U.to_string(), "512")
+  assert_eq!("\{0x200U}", "512")
+  assert_eq!(0x300L.to_string(), "768")
+  assert_eq!("\{0x300L}", "768")
+  assert_eq!(0x400UL.to_string(), "1024")
+  assert_eq!("\{0x400UL}", "1024")
+}
+
+///|
+test "to_string with radix" {
+  // Binary
+  inspect!((0).to_string(radix=2), content="0")
+  inspect!((1).to_string(radix=2), content="1")
+  inspect!((2).to_string(radix=2), content="10")
+  inspect!((255).to_string(radix=2), content="11111111")
+  inspect!((-255).to_string(radix=2), content="-11111111")
+
+  // Octal
+  inspect!((0).to_string(radix=8), content="0")
+  inspect!((8).to_string(radix=8), content="10")
+  inspect!((64).to_string(radix=8), content="100")
+  inspect!((-64).to_string(radix=8), content="-100")
+
+  // Decimal
+  inspect!((0).to_string(radix=10), content="0")
+  inspect!((123).to_string(radix=10), content="123")
+  inspect!((-123).to_string(radix=10), content="-123")
+  inspect!(
+    0x7fff_ffff_ffff_ffffL.to_string(radix=10),
+    content="9223372036854775807",
+  )
+  inspect!(
+    0x8000_0000_0000_0000L.to_string(radix=10),
+    content="-9223372036854775808",
+  )
+
+  // Hexadecimal
+  inspect!((0).to_string(radix=16), content="0")
+  inspect!((0x11).to_string(radix=16), content="11")
+  inspect!((0x15ef).to_string(radix=16), content="15ef")
+  inspect!((-0xabcd).to_string(radix=16), content="-abcd")
+  inspect!(
+    (1.0 : Float).reinterpret_as_int().to_string(radix=16),
+    content="3f800000",
+  )
+
+  // UInt
+  inspect!(0U.to_string(radix=16), content="0")
+  inspect!(0x1AU.to_string(radix=16), content="1a")
+  inspect!(0xabcdU.to_string(radix=16), content="abcd")
+  inspect!(
+    (-2.0 : Float).reinterpret_as_uint().to_string(radix=16),
+    content="c0000000",
+  )
+  inspect!((-1).reinterpret_as_uint().to_string(radix=16), content="ffffffff")
+
+  // Int64
+  inspect!(0L.to_string(radix=16), content="0")
+  inspect!(0x2fL.to_string(radix=16), content="2f")
+  inspect!(0xf0aeL.to_string(radix=16), content="f0ae")
+  inspect!((-0x1234eacbL).to_string(radix=16), content="-1234eacb")
+  inspect!(
+    1.0.reinterpret_as_uint64().to_string(radix=16),
+    content="3ff0000000000000",
+  )
+
+  // UInt64
+  inspect!(0UL.to_string(radix=16), content="0")
+  inspect!(0x11UL.to_string(radix=16), content="11")
+  inspect!(0x12bdUL.to_string(radix=16), content="12bd")
+  inspect!(
+    (-1L).reinterpret_as_uint64().to_string(radix=16),
+    content="ffffffffffffffff",
+  )
+  inspect!(
+    2.0.reinterpret_as_uint64().to_string(radix=16),
+    content="4000000000000000",
+  )
+}
+
+///|
+test "panic to_string_by_radix/illegal_radix" {
+  ignore((1).to_string(radix=1))
+  ignore((1).to_string(radix=37))
+  ignore(1L.to_string(radix=0))
+  ignore(1L.to_string(radix=42))
+  ignore(1U.to_string(radix=-1))
+  ignore(1U.to_string(radix=73))
+  ignore(1UL.to_string(radix=-100))
+  ignore(1UL.to_string(radix=100))
 }


### PR DESCRIPTION
This PR introduces the new feature described in #1500 .  

**Closes #1500 .**  

In JavaScript, the `toString` method allows converting numbers to strings. By default, `toString()` returns the decimal format, while `toString(16)` returns the hexadecimal format.  

However, directly modifying `to_string` in MoonBit can lead to issues. For example:  

```moonbit
let x = 1
println("x = \{x}")
// ^ This calls `x.to_string()`, which requires `to_string` keeping type `(Int) -> String`.
```

To address this, I've added a new function `to_string_by_radix`. If there's a better name for this function, I'm open to suggestions! 