### PR TITLE
Refactor StringBuilder API to include `write_iter` method for character iteration and improve documentation. Removed unused methods and added examples for better clarity.

### DIFF
--- a/builtin/stringbuilder.mbt
+++ b/builtin/stringbuilder.mbt
@@ -19,3 +19,30 @@ pub fn StringBuilder::write_object[T : Show](
 ) -> Unit {
   self.write_string(obj.to_string())
 }
+
+///|
+/// Writes characters from an iterator to the StringBuilder. 
+///
+/// Parameters:
+///
+/// * `self` : The StringBuilder to write to.
+/// * `iter` : An iterator yielding characters to write.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "write_iter" {
+///   let sb = StringBuilder::new()
+///   let chars = "Hello🤣".iter()
+///   sb.write_iter(chars)
+///   assert_eq!(sb.to_string(), "Hello🤣")
+/// }
+/// ```
+pub fn StringBuilder::write_iter(
+  self : StringBuilder,
+  iter : Iter[Char]
+) -> Unit {
+  for ch in iter {
+    self.write_char(ch)
+  }
+}

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -69,33 +69,6 @@ pub fn StringBuilder::write_char(self : StringBuilder, ch : Char) -> Unit {
 }
 
 ///|
-/// Writes characters from an iterator to the StringBuilder. 
-///
-/// Parameters:
-///
-/// * `self` : The StringBuilder to write to.
-/// * `iter` : An iterator yielding characters to write.
-///
-/// Example:
-///
-/// ```moonbit
-/// test "write_iter" {
-///   let sb = StringBuilder::new()
-///   let chars = "Hello🤣".iter()
-///   sb.write_iter(chars)
-///   assert_eq!(sb.to_string(), "Hello🤣")
-/// }
-/// ```
-pub fn StringBuilder::write_iter(
-  self : StringBuilder,
-  iter : Iter[Char]
-) -> Unit {
-  for ch in iter {
-    self.write_char(ch)
-  }
-}
-
-///|
 pub fn StringBuilder::write_substring(
   self : StringBuilder,
   str : String,

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -48,16 +48,6 @@ pub fn StringBuilder::write_substring(
 }
 
 ///|
-pub fn StringBuilder::write_iter(
-  self : StringBuilder,
-  iter : Iter[Char]
-) -> Unit {
-  for ch in iter {
-    self.write_char(ch)
-  }
-}
-
-///|
 pub impl Show for StringBuilder with output(self, logger) {
   logger.write_string(self.val)
 }


### PR DESCRIPTION
cc @Yu-zh 