### PR TITLE
test: improve coverage for `builtin/fixedarray_block.mbt`

### DIFF
--- a/builtin/fixedarray_block_test.mbt
+++ b/builtin/fixedarray_block_test.mbt
@@ -1,0 +1,21 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "panic blit_to with dst_offset out of bounds" {
+  let src = FixedArray::make(3, 1)
+  let dst = FixedArray::make(3, 0)
+  // dst_offset + len > dst.length()
+  let _ = src.blit_to(dst, len=2, dst_offset=2)
+
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/fixedarray_block.mbt`: 22.2% -> 44.4%
```