### PR TITLE
test: improve coverage for `builtin/iter2.mbt`

### DIFF
--- a/builtin/iter2_test.mbt
+++ b/builtin/iter2_test.mbt
@@ -1,0 +1,31 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "iter2_to_iter" {
+  let numbers = [1, 2, 3]
+  let iter2_numbers = numbers.iter2() // creates Iter2[Int, Int] from Array
+  let iter = @builtin.Iter2::iter(iter2_numbers) // converts Iter2 to Iter of tuples
+  let result = iter.to_array() // collect results to array for inspection
+  inspect!(result, content="[(0, 1), (1, 2), (2, 3)]")
+}
+
+test "iter2 identity function should return its input" {
+  let m : @builtin.Map[String, Int] = @builtin.Map::new()
+  m.set("x", 1)
+  m.set("y", 2)
+  let iter2 = m.iter2()
+  let same_iter2 = @builtin.Iter2::iter2(iter2)
+  let result = same_iter2.to_array()
+  inspect!(result, content="[(\"x\", 1), (\"y\", 2)]")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/iter2.mbt`: 70.0% -> 100%
```