### PR TITLE
test: improve coverage for `builtin/string.mbt`

### DIFF
--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -57,3 +57,51 @@ test "panic codepoint_at2" {
   let _ = str.codepoint_at(-1)
 
 }
+
+test "panic charcode_at with negative index" {
+  let s = "Hello"
+  ignore(charcode_at(s, -1))
+}
+
+test "charcode_at with valid index" {
+  let s = "Hello"
+  inspect!(charcode_at(s, 0), content="72")
+}
+
+test "codepoint_at regular character at end of string" {
+  let s = "Hello"
+  inspect!(codepoint_at(s, 4), content="'o'")
+}
+
+test "codepoint_at emoji" {
+  let s = "👋"
+  inspect!(codepoint_at(s, 0), content="'👋'")
+}
+
+test "codepoint_length basic" {
+  let str = "hello"
+  inspect!(codepoint_length(str), content="5")
+}
+
+test "codepoint_length with surrogate pairs" {
+  let str = "Hello🤣"
+  inspect!(codepoint_length(str), content="6")
+}
+
+test "panic String::make with negative length" {
+  ignore(String::make(-1, 'A'))
+}
+
+test "String::make with zero length" {
+  inspect!(String::make(0, 'A'), content="")
+}
+
+test "panic codepoint_length with invalid surrogate pair" {
+  // Create a string with a leading surrogate (0xD800) followed by an invalid trailing surrogate
+  let s = String::from_array([
+      Char::from_int(0xD800), // leading surrogate
+      'a',
+    ], // invalid trailing surrogate
+  )
+  ignore(@builtin.codepoint_length(s))
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/string.mbt`: 44.7% -> 94.7%
```