### PR TITLE
test: improve coverage for `builtin/assert.mbt`

### DIFF
--- a/builtin/assert_test.mbt
+++ b/builtin/assert_test.mbt
@@ -1,0 +1,22 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "panic assert_not_eq with equal values" {
+  let str = "test"
+  ignore(assert_not_eq!(str, str))
+}
+
+test "panic assert_false with true" {
+  ignore(assert_false!(true))
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/assert.mbt`: 36.4% -> 63.6%
```