### PR TITLE
chore: adjust api and remove error

### DIFF
--- a/char/char.mbt
+++ b/char/char.mbt
@@ -134,18 +134,19 @@ pub fn is_control(self : Char) -> Bool {
   }
 }
 
-///| Checks if a char is a digit in the given radix (range from 2 to 36).
-pub fn is_digit(self : Char, radix : UInt) -> Bool!Error {
-  guard radix >= 2 && radix <= 36 else {
-    fail!("radix must be in the range from 2 to 36")
-  }
+///| 
+/// Checks if a char is a digit in the given radix (range from 2 to 36).
+/// 
+/// panic if the radix is invalid.
+pub fn is_digit(self : Char, radix : UInt) -> Bool {
   let v = self.to_uint()
   match radix {
     2..=10 => v >= 48 && v <= radix + 47
-    _ =>
+    11..=36 =>
       (v >= 48 && v <= 57) ||
       (v >= 65 && v <= radix + 54) ||
       (v >= 97 && v <= radix + 86)
+    _ => panic()
   }
 }
 

--- a/char/char.mbti
+++ b/char/char.mbti
@@ -16,7 +16,7 @@ impl Char {
   is_ascii_uppercase(Char) -> Bool
   is_ascii_whitespace(Char) -> Bool
   is_control(Char) -> Bool
-  is_digit(Char, UInt) -> Bool!
+  is_digit(Char, UInt) -> Bool
   is_numeric(Char) -> Bool
   is_whitespace(Char) -> Bool
 }

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -251,21 +251,25 @@ test "is_control" {
 }
 
 test "is_digit" {
-  assert_eq!(true, 'a'.is_digit!(11))
-  assert_eq!(true, 'a'.is_digit!(12))
-  assert_eq!(true, 'a'.is_digit!(13))
-  assert_eq!(true, 'a'.is_digit!(14))
-  assert_eq!(true, 'a'.is_digit!(15))
-  assert_eq!(true, 'a'.is_digit!(16))
-  assert_eq!(true, 'A'.is_digit!(11))
-  assert_eq!(true, 'B'.is_digit!(12))
-  assert_eq!(true, 'C'.is_digit!(13))
-  assert_eq!(true, 'D'.is_digit!(14))
-  assert_eq!(true, 'E'.is_digit!(15))
-  assert_eq!(true, 'F'.is_digit!(16))
-  assert_eq!(false, 'A'.is_digit!(8))
-  assert_eq!(true, '1'.is_digit!(2))
-  assert_eq!(true, 'z'.is_digit!(36))
+  assert_eq!(true, 'a'.is_digit(11))
+  assert_eq!(true, 'a'.is_digit(12))
+  assert_eq!(true, 'a'.is_digit(13))
+  assert_eq!(true, 'a'.is_digit(14))
+  assert_eq!(true, 'a'.is_digit(15))
+  assert_eq!(true, 'a'.is_digit(16))
+  assert_eq!(true, 'A'.is_digit(11))
+  assert_eq!(true, 'B'.is_digit(12))
+  assert_eq!(true, 'C'.is_digit(13))
+  assert_eq!(true, 'D'.is_digit(14))
+  assert_eq!(true, 'E'.is_digit(15))
+  assert_eq!(true, 'F'.is_digit(16))
+  assert_eq!(false, 'A'.is_digit(8))
+  assert_eq!(true, '1'.is_digit(2))
+  assert_eq!(true, 'z'.is_digit(36))
+}
+
+test "panic on invalid radix" {
+  ignore('a'.is_digit(1))
 }
 
 test "is_numeric" {


### PR DESCRIPTION
The user should validate the input as throwing error has little sense in this case:

```moonbit
let radix = ...
try {
  is_digit!('a', radix)
} catch {
  _ => error handling
}
```

Should just be
```moonbit
let radix = ...
if radix >= 2 && radix <= 36 {
  is_digit('a', radix)
} else {
  ...
}
```

Throwing error will cause performance penalty and necessary error handling