### PR TITLE
test: improve coverage for `int64/int64.mbt`

### DIFF
--- a/int64/int64_test.mbt
+++ b/int64/int64_test.mbt
@@ -163,3 +163,23 @@ test "grouped test for random cases" {
   // 1011111011101111110111101010110110111110111011111101111010101101
   inspect!(UInt64::popcnt(0xBEEFDEADBEEFDEADUL), content="48")
 }
+
+test "to_be_bytes" {
+  let num = 0x1234567890ABCDEFL
+  inspect!(
+    num.to_be_bytes(),
+    content=
+      #|b"\x12\x34\x56\x78\x90\xab\xcd\xef"
+    ,
+  )
+}
+
+test "to_le_bytes of negative Int64" {
+  let num = -0x1234567890ABCDEFL
+  inspect!(
+    num.to_le_bytes(),
+    content=
+      #|b"\x11\x32\x54\x6f\x87\xa9\xcb\xed"
+    ,
+  )
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `int64/int64.mbt`: 57.1% -> 85.7%
```