### PR TITLE
test: improve coverage for `strconv/uint.mbt`

### DIFF
--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -259,3 +259,8 @@ test "parse_uint" {
     )
   }
 }
+
+test "parse_uint64 uppercase hex and invalid base" {
+  inspect!(parse_uint64?("ABCD", base=16), content="Ok(43981)")
+  inspect!(parse_uint64?("1234", base=37), content="Err(invalid base)")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `strconv/uint.mbt`: 58.3% -> 62.5%
```