### PR TITLE
test: improve coverage for `int/int.mbt`

### DIFF
--- a/int/int_test.mbt
+++ b/int/int_test.mbt
@@ -46,3 +46,23 @@ test "abs function coverage" {
   assert_eq!(Int::abs(@int.min_value), @int.min_value.abs())
   assert_eq!(Int::abs(@int.max_value), @int.max_value)
 }
+
+test "to_le_bytes" {
+  let bytes = @int.to_le_bytes(0x12345678)
+  inspect!(
+    bytes,
+    content=
+      #|b"\x78\x56\x34\x12"
+    ,
+  )
+}
+
+test "to_be_bytes" {
+  let bytes = @int.to_be_bytes(0x12345678)
+  inspect!(
+    bytes,
+    content=
+      #|b"\x12\x34\x56\x78"
+    ,
+  )
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `int/int.mbt`: 60.0% -> 100%
```