### PR TITLE
test: improve coverage for `builtin/console.mbt`

### DIFF
--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -67,3 +67,8 @@ pub fn inspect(
 ///|
 // Used by test driver
 pub(all) type! SnapshotError String
+
+test "panic error case of inspect" {
+  let x : Int = 42
+  inspect!(x, content="100")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/console.mbt`: 66.7% -> 100%
```