### PR TITLE
ci: use `ubuntu-latest` for coverage checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,7 +97,7 @@ jobs:
           git diff --exit-code
 
   coverage-check:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should help mitigate our CI bottleneck caused by the shortage of macOS runners.