### PR TITLE
test: improve coverage for immut/hashset/HAMT.mbt

### DIFF
--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -129,3 +129,31 @@ test "from_iter empty iter" {
   let pq : @hashset.T[Int] = @hashset.from_iter(Iter::empty())
   inspect!(pq, content="@immut/hashset.of([])")
 }
+
+test "each on empty hashset" {
+  let empty : @hashset.T[Int] = @hashset.new()
+  let mut count = 0
+  empty.each(fn(x : Int) -> Unit { count = count + 1 })
+  inspect!(count, content="0")
+}
+
+test "remove_with_hash - leaf case 2" {
+  let set = @hashset.of([1])
+  let same = @hashset.remove(set, 2)
+  inspect!(same == set, content="true")
+}
+
+test "from_array - non-empty array" {
+  let arr = [1, 2, 3]
+  let set = @hashset.from_array(arr)
+  inspect!(set, content="@immut/hashset.of([3, 2, 1])")
+}
+
+test "hashset equality" {
+  let set1 = @hashset.of([1, 2])
+  let set2 = @hashset.of([2, 1])
+  let empty1 = @hashset.new()
+  let empty2 = @hashset.new()
+  inspect!(set1 == set2, content="true")
+  inspect!(empty1 == empty2, content="true")
+}

--- a/unit/unit_test.mbt
+++ b/unit/unit_test.mbt
@@ -40,3 +40,18 @@ test {
   let unit = ()
   assert_eq!(unit.hash(), 0)
 }
+
+test "Unit hash_combine test" {
+  let hasher = @builtin.Hasher::new()
+  let unit = ()
+  // We should use () directly in hash_combine
+  let _ = @builtin.Hash::hash_combine((), hasher)
+  let hash1 = hasher.finalize()
+  let hasher2 = @builtin.Hasher::new()
+  assert_not_eq!(hash1, hasher2.finalize())
+}
+
+test "Unit::default returns unit value" {
+  let unit = Unit::default()
+  inspect!(unit, content="()")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `immut/hashset/HAMT.mbt`: 71.4% -> 80.0%
```