### PR TITLE
test: improve coverage for `ref/ref.mbt`

### DIFF
--- a/ref/ref_test.mbt
+++ b/ref/ref_test.mbt
@@ -56,3 +56,8 @@ test "update with identity function" {
   @ref.update(a, fn(x) { x })
   assert_eq!(a.val, 1)
 }
+
+test "Ref::new with string" {
+  let r = Ref::new("hello")
+  inspect!(r, content="{val: \"hello\"}")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `ref/ref.mbt`: 71.4% -> 85.7%
```