### PR TITLE
ci: disable `dedup_wasm` checks on macOS runners

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,7 +53,7 @@ jobs:
           moon test --target native --release
 
       - name: moon test with dedup_wasm
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
           moon clean
           ulimit -s 8176


### PR DESCRIPTION
Similar to #1549, this should help mitigate our CI bottleneck caused by the shortage of macOS runners.