### PR TITLE
test: improve coverage for `builtin/intrinsics.mbt`

### DIFF
--- a/builtin/intrinsics_test.mbt
+++ b/builtin/intrinsics_test.mbt
@@ -433,3 +433,9 @@ test "UInt::reinterpret_as_float roundtrip" {
     assert_eq!(roundtrip_value, value)
   }
 }
+
+test "convert byte to int64" {
+  let b = b'\xFF'
+  let result = b.to_int64()
+  inspect!(result, content="255")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/intrinsics.mbt`: 75.0% -> 87.5%
```