### PR TITLE
test: improve coverage for `builtin/show.mbt`

### DIFF
--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -231,3 +231,13 @@ test "Show for Char" {
   inspect!('\''.to_string(), content="'")
   inspect!('\\'.to_string(), content="\\")
 }
+
+test "char show hex digits" {
+  inspect!('\x01', content="'\\x01'")
+  inspect!('\x0b', content="'\\x0b'")
+}
+
+test "char_special" {
+  inspect!('\r', content="'\\r'")
+  inspect!('\b', content="'\\b'")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/show.mbt`: 79.3% -> 89.7%
```