### PR TITLE
test: improve coverage for `json/lex_string.mbt`

### DIFF
--- a/json/lex_string_test.mbt
+++ b/json/lex_string_test.mbt
@@ -1,0 +1,26 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+test "lex_string with forward slash escape" {
+  inspect!(
+    @json.parse!("\"\\/\""),
+    content=
+      #|String("/")
+    ,
+  )
+}
+
+test "lex_hex_digits incomplete hex digits" {
+  inspect!(@json.parse?("\"\\u123"), content="Err(Unexpected end of file)")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `json/lex_string.mbt`: 76.5% -> 82.4%
```