### PR TITLE
fix wrong atan2 result on -0.0

### DIFF
--- a/math/trigonometric.mbt
+++ b/math/trigonometric.mbt
@@ -279,8 +279,12 @@ pub fn acos(x : Double) -> Double {
 }
 
 ///|
+const SIGNBIT : UInt64 = 0x8000000000000000UL
+
+///|
 fn copysign(x : Double, y : Double) -> Double {
-  if y < 0 {
+  // should check the sign bit to distinguish +0/-0
+  if (y.reinterpret_as_uint64() & SIGNBIT) > 0 {
     -x.abs()
   } else {
     x.abs()

--- a/math/trigonometric_test.mbt
+++ b/math/trigonometric_test.mbt
@@ -249,6 +249,7 @@ test "atan2 with zero x" {
 test "atan2 with zero y" {
   inspect!(atan2(0.0, 1.0), content="0")
   inspect!(atan2(0.0, -1.0), content="3.141592653589793")
+  inspect!(atan2(-0.0, -1.0), content="-3.141592653589793")
 }
 
 test "atan2 with infinite y and finite x" {


### PR DESCRIPTION
It is reported in https://taolun.moonbitlang.com/t/topic/1128, that the result of `atan2(-0, -1)` is wrong.

According to IEEE754, atan2(±0, x) is ±π for x < 0.

The root cause of the issue is that the old copysign just checks if y < 0 and does not distinguish ±0.

This PR fixes this by checking the sign bit instead.