### PR TITLE
refactor: improve test speed

### DIFF
--- a/immut/array/array_mix_wbtest.mbt
+++ b/immut/array/array_mix_wbtest.mbt
@@ -12,31 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// The naming of test follows the format
-///   random seed - number of operations - maximum level of the tree
-/// If the given random seed is shorter than 32, it will be repeated
-/// up to 32 chars.
-
-test "DEADBEEF-10-4" {
-  run_test!("DEADBEEF", 10, 4)
-}
-
-test "LIVEBEEF-50-3" {
-  run_test!("LIVEBEEF", 50, 3)
-}
-
-test "HAPPYDOG-1000-2" {
-  run_test!("HAPPYDOG", 200, 2)
-}
-
-test "HELLOWOLRD-5-3" {
-  run_test!("HELLOWOLRD", 4, 1)
+test "random property tests" {
+  run_test!(104UL, 10, 4)
+  run_test!(503UL, 50, 3)
+  run_test!(10002UL, 200, 2)
+  run_test!(53UL, 4, 1)
 }
 
 ///|
-fn run_test(seed : String, rep : Int, max_lvl : Int) -> Unit! {
-  let seed = repeat_up_to_32(seed)
-  let rng = @random.new(seed~)
+fn run_test(seed : UInt64, rep : Int, max_lvl : Int) -> Unit! {
+  let rng = Random({ val: seed })
   let rs = random_test_gen(rng, rep, max_lvl)
   execute_array_test!(rs)
 }

--- a/immut/array/array_wbtest.mbt
+++ b/immut/array/array_wbtest.mbt
@@ -114,7 +114,7 @@ test "concat-multiple-full-tree" {
 
 test "concat-multiple-random-tree" {
   let bf = branching_factor_power(2)
-  let rng = @random.new(seed=b"DEADBEEFDEADBEEFDEADBEEFDEADBEEF")
+  let rng = Random({ val: 0UL })
   execute_array_test!(gen_concat_seq(2, fn(_i) { rng.int(limit=bf) }))
 }
 

--- a/immut/array/moon.pkg.json
+++ b/immut/array/moon.pkg.json
@@ -7,10 +7,6 @@
       "alias": "_core/array"
     }
   ],
-  "wbtest-import": [
-    "moonbitlang/core/random",
-    "moonbitlang/core/bytes"
-  ],
   "targets": {
     "panic_test.mbt": [
       "not",

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -27,7 +27,7 @@ enum Op {
 /// - `rng`: a random number generator
 /// - `times`: the number of operations to be generated
 /// - `max_lvl`: the maximum level of the tree
-fn random_test_gen(rng : @random.Rand, times : Int, max_lvl : Int) -> Array[Op] {
+fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
   // Hyperparameters
   let op_count = 3
   let max_len = branching_factor_power(max_lvl)
@@ -93,7 +93,7 @@ fn execute_array_test(rs : Array[Op]) -> Unit! {
         for i = 0; i < len; i = i + 1 {
           a.push(v[i])
         }
-        t = t.concat(from_iter(v.iter()))
+        t = t.concat(from_array(v))
         check_array_eq!(a, t)
       }
       Set(idx, v) => {
@@ -114,22 +114,6 @@ fn branching_factor_power(a : Int) -> Int {
     ret *= branching_factor
   }
   ret
-}
-
-///|
-/// Repeat the given string up to 32 characters.
-/// Used to generate a random seed for the test.
-fn repeat_up_to_32(s : String) -> Bytes {
-  let a_len = 32
-  let s_len = s.length()
-  let a = FixedArray::make(a_len, b'0')
-  let mut j = 0
-  for i = 0; i < a_len; i = i + 1 {
-    let l = a.set_utf8_char(i, s[j])
-    guard l == 1
-    j = (j + 1) % s_len
-  }
-  Bytes::from_fixedarray(a)
 }
 
 ///|
@@ -159,6 +143,19 @@ fn check_fixedarray_eq(a : FixedArray[Int], t : T[Int]) -> Unit! {
 ///|
 /// Generate a random array of length `n`.
 fn random_array(n : Int) -> Array[Int] {
-  let rng = @random.new(seed=b"DEADBEEFLIVEBEEFDEADBEEFDEADBEEF")
+  let rng = Random({ val: 0 })
   Array::makei(n, fn(i) { rng.int(limit=i) })
+}
+
+///|
+type Random Ref[UInt64]
+
+///|
+fn int(self : Random, limit~ : Int) -> Int {
+  let limit = if limit == 0 { 1L << 32 } else { limit.to_int64() }
+  let a = 1UL << 48
+  let c = 11UL
+  let m = 25214903917UL
+  self._.val = (a * self._.val + c) % m
+  (self._.val.reinterpret_as_int64() % limit).to_int()
 }


### PR DESCRIPTION
Use LCG instead of chacha8

Use from_array instead of from_iter

This should make the test time half as before