### PR TITLE
fix!: remove @test.is

### DIFF
--- a/test/test.mbt
+++ b/test/test.mbt
@@ -86,13 +86,6 @@ pub fn same_object[T : Show](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 }
 
 ///|
-/// @alert deprecated "Use `same_object` instead"
-/// @coverage.skip
-pub fn is[T : Show](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
-  same_object!(a, b, loc~)
-}
-
-///|
 /// Assert referential inequality of two values.
 ///
 /// Returns Ok if the two arguments are NOT the same object by reference, using

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -5,8 +5,6 @@ fn eq[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit! //deprecated
 
 fn fail[T](String, loc~ : SourceLoc = _) -> T!
 
-fn is[T : Show](T, T, loc~ : SourceLoc = _) -> Unit! //deprecated
-
 fn is_false(Bool, loc~ : SourceLoc = _) -> Unit! //deprecated
 
 fn is_not[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!


### PR DESCRIPTION
We add `is` as a reserved keyword in bleeding compiler. This PR remove the already deprecated `@test.is` function so that the bleeding check on CI will pass.