### PR TITLE
test: improve coverage for `result/result.mbt`

### DIFF
--- a/result/result_test.mbt
+++ b/result/result_test.mbt
@@ -18,3 +18,34 @@ test "Result unwrap should return Ok value" {
   assert_eq!(ok_result.unwrap(), 42)
   assert_eq!(ok_result.unwrap_or_error!(), 42)
 }
+
+///|
+test "bind with Err" {
+  let x : Result[Int, String] = Err("error")
+  let y = x.bind(fn(v : Int) { Ok(v * 7) })
+  assert_eq!(y, Err("error"))
+}
+
+///|
+test "wrap0 with error" {
+  let f = fn() -> Int!Failure { raise Failure("error") }
+  let result = wrap0(f~)
+  inspect!(
+    result,
+    content=
+      #|Err("Failure(error)")
+    ,
+  )
+}
+
+///|
+test "wrap2 with error result" {
+  let f = fn(_, _) -> Unit!Failure { raise Failure("error") }
+  let r = wrap2(f~, 1, 2)
+  inspect!(
+    r,
+    content=
+      #|Err("Failure(error)")
+    ,
+  )
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `result/result.mbt`: 81.8% -> 90.9%
```