### PR TITLE
test: improve coverage for `strconv/number.mbt`

### DIFF
--- a/strconv/number_test.mbt
+++ b/strconv/number_test.mbt
@@ -1,0 +1,25 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "parse_inf_nan positive NaN" {
+  let result = @strconv.parse_double!("+nan")
+  inspect!(@double.is_nan(result), content="true")
+}
+
+///|
+test "parse_inf_nan negative NaN" {
+  let result = @strconv.parse_double!("-nan")
+  inspect!(@double.is_nan(result), content="true")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `strconv/number.mbt`: 82.3% -> 85.5%
```