### PR TITLE
test: improve coverage for `builtin/traits.mbt`

### DIFF
--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -1,0 +1,22 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "write_iter with trailing" {
+  let builder = StringBuilder::new()
+  let logger : &Logger = builder
+  let arr : Array[Int] = [1, 2]
+  logger.write_iter(arr.iter(), prefix="[", suffix="]", sep=",", trailing=true)
+  inspect!(builder.to_string(), content="[1,2,]")
+}


### PR DESCRIPTION
**Disclaimer:** This PR was generated by an LLM agent as part of an experiment.

## Summary

```
coverage of `builtin/traits.mbt`: 77.8% -> 88.9%
```