### PR TITLE
hongbo/char test

### DIFF
--- a/builtin/char_test.mbt
+++ b/builtin/char_test.mbt
@@ -19,7 +19,7 @@ test "char subtraction" {
   inspect!(b - a, content="1")
 }
 
-
+///|
 test "char show" {
   assert_eq!('\b'.to_string(), "\u0008")
   // assert_eq!('\b'.to_string(), "\u{8}")
@@ -31,4 +31,3 @@ test "char show" {
   assert_eq!('\u0002'.to_string(), "\u0002")
   assert_eq!('\b'.to_string().escape(), "\"\\b\"")
 }
-

--- a/builtin/char_test.mbt
+++ b/builtin/char_test.mbt
@@ -18,3 +18,17 @@ test "char subtraction" {
   let a = 'a'
   inspect!(b - a, content="1")
 }
+
+
+test "char show" {
+  assert_eq!('\b'.to_string(), "\u0008")
+  // assert_eq!('\b'.to_string(), "\u{8}")
+  assert_eq!('\r'.to_string(), "\u000d")
+  assert_eq!('\n'.to_string(), "\u000a")
+  assert_eq!('\t'.to_string(), "\u0009")
+  assert_eq!('\u0000'.to_string(), "\u0000")
+  assert_eq!('\u0001'.to_string(), "\u0001")
+  assert_eq!('\u0002'.to_string(), "\u0002")
+  assert_eq!('\b'.to_string().escape(), "\"\\b\"")
+}
+

--- a/builtin/stringbuilder.mbt
+++ b/builtin/stringbuilder.mbt
@@ -17,7 +17,7 @@ pub fn StringBuilder::write_object[T : Show](
   self : StringBuilder,
   obj : T
 ) -> Unit {
-  self.write_string(obj.to_string())
+  obj.output(self)
 }
 
 ///|

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -80,11 +80,11 @@ test "iter" {
   inspect!(
     buf,
     content=
-      #|0: zero
-      #|1: one
-      #|2: two
-      #|3: three
-      #|8: eight
+      #|0: "zero"
+      #|1: "one"
+      #|2: "two"
+      #|3: "three"
+      #|8: "eight"
       #|(0, "zero")
       #|(1, "one")
       #|(2, "two")


### PR DESCRIPTION
- **test: improve coverage for `builtin/char_test.mbt`**
- **use obj.output which is the API to compose**

For [T:Show] in generics, we should use `output` which is the API to compose
