### PR TITLE
fix(builtin/json): fix `String::to_json()`-`@json.from_json()` round trip

### DIFF
--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -74,44 +74,8 @@ pub fn Float::to_json(self : Float) -> Json {
 }
 
 ///|
-fn escape_json_string(str : String) -> String {
-  fn to_hex_digit(i : Int) -> Char {
-    if i < 10 {
-      Char::from_int('0'.to_int() + i)
-    } else {
-      Char::from_int('a'.to_int() + (i - 10))
-    }
-  }
-
-  let len = str.length()
-  let buf = StringBuilder::new(size_hint=len)
-  for i in 0..<len {
-    let c = str[i]
-    match c {
-      '\n' => buf.write_string("\\n")
-      '\r' => buf.write_string("\\r")
-      '\b' => buf.write_string("\\b")
-      '\t' => buf.write_string("\\t")
-      _ => {
-        let code = c.to_int()
-        if code == 0x0C {
-          buf.write_string("\\f")
-        } else if code < 0x20 {
-          buf.write_string("\\u00")
-          buf.write_char(to_hex_digit(code / 16))
-          buf.write_char(to_hex_digit(code % 16))
-        } else {
-          buf.write_char(c)
-        }
-      }
-    }
-  }
-  buf.to_string()
-}
-
-///|
 pub fn String::to_json(self : String) -> Json {
-  String(escape_json_string(self))
+  String(self)
 }
 
 ///|

--- a/builtin/json_test.mbt
+++ b/builtin/json_test.mbt
@@ -104,21 +104,36 @@ test "test UInt64::to_json" {
 test "escape control characters" {
   let str = "abc\x01def" // Control character with code 1
   let json = str.to_json()
-  inspect!(json, content="String(\"abc\\\\u0001def\")")
+  inspect!(
+    json,
+    content=
+      #|String("abc\x01def")
+    ,
+  )
 }
 
 ///|
 test "test carriage return and backspace" {
   let test_string = "CR\rBS\b"
   let json = test_string.to_json()
-  inspect!(json, content="String(\"CR\\\\rBS\\\\b\")")
+  inspect!(
+    json,
+    content=
+      #|String("CR\rBS\b")
+    ,
+  )
 }
 
 ///|
 test "test form feed" {
   let test_string = "Form\u000CFeed"
   let json = test_string.to_json()
-  inspect!(json, content="String(\"Form\\\\fFeed\")")
+  inspect!(
+    json,
+    content=
+      #|String("Form\x0cFeed")
+    ,
+  )
 }
 
 ///|
@@ -143,7 +158,7 @@ test "Bool::to_json true" {
 test "to_hex_digit" {
   let str = "\n\r\b\t\x0C\x00"
   let escaped = str.to_json().as_string().unwrap()
-  inspect!(escaped, content="\\n\\r\\b\\t\\f\\u0000")
+  inspect!(escaped, content="\n\r\b\t\x0c\x00")
 }
 
 ///|

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -348,6 +348,22 @@ test "stringify escape round trip" {
 }
 
 ///|
+test "string from and to json round trip" {
+  let greeting =
+    #|
+    #|     (\(\
+    #|     ( -.-)
+    #|     o_(")(")
+    #|     __  __     ____         __  ___                  ____  _ __
+    #|    / / / /__  / / /___     /  |/  /___  ____  ____  / __ )(_) /_
+    #|   / /_/ / _ \/ / / __ \   / /|_/ / __ \/ __ \/ __ \/ __  / / __/
+    #|  / __  /  __/ / / /_/ /  / /  / / /_/ / /_/ / / / / /_/ / / /_
+    #| /_/ /_/\___/_/_/\____/  /_/  /_/\____/\____/_/ /_/_____/_/\__/
+    #|
+  assert_eq!(@json.from_json!(greeting.to_json()), greeting)
+}
+
+///|
 test "escape" {
   let s = "http://example.com/"
   inspect!(

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -102,19 +102,19 @@ test "String::to_json" {
   inspect!(
     "\x00".to_json(),
     content=
-      #|String("\\u0000")
+      #|String("\x00")
     ,
   )
   inspect!(
     "\n\r\b\t\\".to_json(),
     content=
-      #|String("\\n\\r\\b\\t\\")
+      #|String("\n\r\b\t\\")
     ,
   )
   inspect!(
     "\x0c\x0d\x0f".to_json(),
     content=
-      #|String("\\f\\r\\u000f")
+      #|String("\x0c\r\x0f")
     ,
   )
 }


### PR DESCRIPTION
Closes #1684.

There are no differences between `@json`'s `String` data model and MoonBit's native `String` data model, so there are no conversions/escapes to be done. The only place where conversions/escapes are needed is when printing the resulting `Json` as a string, i.e. in `@json.stringify()`. As such, `escape_json_string()` is redundant.