### PR TITLE
fix @string.index_of and refactor

### DIFF
--- a/string/string.mbt
+++ b/string/string.mbt
@@ -386,6 +386,7 @@ pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
           break
         }
       } else {
+        // the substring is found
         return i
       }
     }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -351,22 +351,27 @@ pub fn is_blank(self : String) -> Bool {
 ///|
 /// Returns the first index of the sub string.
 pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
-  let from = if from < 0 {
-    0
-  } else if from >= self.length() {
-    self.length() - 1
-  } else {
-    from
-  }
   let len = self.length()
   let sub_len = str.length()
-  let max_idx = len - sub_len
+
+  // Handle empty substring case
   if sub_len == 0 {
-    return 0
+    // Return 0 for empty string in empty string
+    if len == 0 {
+      return 0
+    }
+    // Bound from within valid range and return it
+    return if from < 0 { 0 } else if from >= len { len } else { from }
   }
+
+  // If substring is longer than string, it can't be found
   if sub_len > len {
     return -1
   }
+
+  // Bound the starting position
+  let from = if from < 0 { 0 } else if from >= len { len - 1 } else { from }
+  let max_idx = len - sub_len
   let first = str[0]
   let mut i = from
   while i <= max_idx {
@@ -376,14 +381,11 @@ pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
     }
     // check the rest
     if i <= max_idx {
-      let mut j = i + 1
-      let mut k = 1
-      let end = j + sub_len - 1
-      while j < end && self[j] == str[k] {
-        j += 1
-        k += 1
-      }
-      if j == end {
+      for j = 1; j < sub_len; j = j + 1 {
+        if self[i + j] != str[j] {
+          break
+        }
+      } else {
         return i
       }
     }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -288,6 +288,52 @@ test "index_of" {
 }
 
 ///|
+test "String::index_of empty strings" {
+  // Empty string cases
+  assert_eq!("".index_of(""), 0)
+  assert_eq!("abc".index_of(""), 0)
+  assert_eq!("".index_of("a"), -1)
+}
+
+///|
+test "String::index_of basic matching" {
+  // Basic substring matching
+  assert_eq!("abc".index_of("a"), 0)
+  assert_eq!("abc".index_of("b"), 1)
+  assert_eq!("abc".index_of("c"), 2)
+  assert_eq!("abc".index_of("ab"), 0)
+  assert_eq!("abc".index_of("bc"), 1)
+  assert_eq!("abc".index_of("abc"), 0)
+  assert_eq!("abc".index_of("d"), -1)
+  assert_eq!("abc".index_of("abcd"), -1)
+}
+
+///|
+test "String::index_of with from parameter" {
+  // Testing from parameter
+  assert_eq!("abcabc".index_of("a", from=1), 3)
+  assert_eq!("abcabc".index_of("a", from=4), -1)
+  assert_eq!("abcabc".index_of("bc", from=2), 4)
+  assert_eq!("abc".index_of("", from=1), 1)
+  assert_eq!("abc".index_of("", from=3), 3)
+  assert_eq!("abc".index_of("", from=4), 3) // Bounded to length
+}
+
+///|
+test "String::index_of with negative from" {
+  // Testing negative from parameter
+  assert_eq!("abc".index_of("a", from=-1), 0)
+  assert_eq!("abc".index_of("b", from=-2), 1)
+}
+
+///|
+test "String::index_of overlapping patterns" {
+  // Testing overlapping patterns
+  assert_eq!("aaa".index_of("aa"), 0)
+  assert_eq!("aaa".index_of("aa", from=1), 1)
+}
+
+///|
 test "last_index_of" {
   inspect!("abc".last_index_of("a"), content="0")
   inspect!("abc".last_index_of("b"), content="1")


### PR DESCRIPTION
The previous implementation was incorrect when the substring is empty. It returned 0 instead of the `from` parameter. This PR fixes this bug and refactored the code to make it more clear.