### PR TITLE
migrate core to adapt new compiler change

### DIFF
--- a/array/array_js.mbt
+++ b/array/array_js.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-priv type JSArray
+priv extern type JSArray
 
 ///|
 fn JSArray::ofAnyArray[T](array : Array[T]) -> JSArray = "%identity"

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -17,7 +17,7 @@
 // generic type parameters of extern ffi
 
 ///|
-priv type JSValue
+priv extern type JSValue
 
 ///|
 fn JSValue::ofAny[T](array : T) -> JSValue = "%identity"
@@ -26,7 +26,7 @@ fn JSValue::ofAny[T](array : T) -> JSValue = "%identity"
 fn JSValue::toAny[T](self : JSValue) -> T = "%identity"
 
 ///|
-priv type JSArray
+priv extern type JSArray
 
 ///|
 fn JSArray::ofAnyArray[T](array : Array[T]) -> JSArray = "%identity"
@@ -68,7 +68,7 @@ extern "js" fn JSArray::splice1(
 ///|
 /// An `Array` is a collection of values that supports random access and can
 /// grow in size.
-type Array[T]
+extern type Array[T]
 
 ///|
 fn Array::make_uninit[T](len : Int) -> Array[T] = "%fixedarray.make_uninit"

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -20,7 +20,7 @@
 /// This type is public to all packages but its internal representation is
 /// opaque. Users cannot construct values of this type directly; they are
 /// automatically created by the compiler when needed.
-pub(all) type SourceLoc
+pub(all) extern type SourceLoc
 
 ///|
 /// Converts a source location to its string representation.

--- a/builtin/bigint_js.mbt
+++ b/builtin/bigint_js.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-type BigInt
+extern type BigInt
 
 ///|
 pub fn BigInt::from_string(str : String) -> BigInt {

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -338,7 +338,7 @@ impl[K : Show] Show for Set[K]
 
 pub(all) type! SnapshotError String
 
-pub(all) type SourceLoc
+pub(all) extern type SourceLoc
 impl SourceLoc {
   to_string(Self) -> String
 }

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1923,7 +1923,7 @@ pub fn String::to_string(self : String) -> String = "%string_to_string"
 
 ///|
 // For internal use only
-priv type UnsafeMaybeUninit[_]
+priv extern type UnsafeMaybeUninit[_]
 
 ///|
 /// Converts a byte value to a 32-bit signed integer. The resulting integer will

--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 ///|
-priv type XStringReadHandle
+priv extern type XStringReadHandle
 
 ///|
-priv type XExternString
+priv extern type XExternString
 
 ///|
 fn begin_read_string(s : XExternString) -> XStringReadHandle = "__moonbit_fs_unstable" "begin_read_string"
@@ -45,10 +45,10 @@ fn string_from_extern(e : XExternString) -> String {
 }
 
 ///|
-priv type XStringArrayReadHandle
+priv extern type XStringArrayReadHandle
 
 ///|
-priv type XExternStringArray
+priv extern type XExternStringArray
 
 ///|
 fn begin_read_string_array(sa : XExternStringArray) -> XStringArrayReadHandle = "__moonbit_fs_unstable" "begin_read_string_array"

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -589,8 +589,8 @@ test "string pattern matching" {
   } derive(Show)
   fn process_string(s : String) {
     match s {
-      [.."true", ..] => True
-      [.."false", ..] => False
+      [.. "true", ..] => True
+      [.. "false", ..] => False
       _ => Other
     }
   }


### PR DESCRIPTION
This compiler migrate core to adapt compiler changes from the latest release.

The most significant change in the syntax of declaring external FFI type. Previously the syntax is `type T`, and in the future the syntax will be migrated to the more explicit `extern type T`. Currently the old syntax will be warned, and the formatter will automatically change `type T` to `extern type T`, so run `moon fmt` is adequate for migration.

The `type T` syntax, whose visual intuition is abstract type rather than external type, may be reused in the future for other purpose.

There is one more minor formatter style change. A space will be added after `..` in string pattern, such as `[ .."literal" ]`.