### PR TITLE
port trait implementation to `impl`

### DIFF
--- a/array/array.mbti
+++ b/array/array.mbti
@@ -31,7 +31,6 @@ impl FixedArray {
   new[T](Int, () -> T) -> Self[T] //deprecated
   new_with_index[T](Int, (Int) -> T) -> Self[T] //deprecated
   op_add[T](Self[T], Self[T]) -> Self[T]
-  op_equal[T : Eq](Self[T], Self[T]) -> Bool
   rev[T](Self[T]) -> Self[T]
   rev_each[T](Self[T], (T) -> Unit) -> Unit
   rev_eachi[T](Self[T], (Int, T) -> Unit) -> Unit
@@ -46,6 +45,7 @@ impl FixedArray {
   starts_with[T : Eq](Self[T], Self[T]) -> Bool
   swap[T](Self[T], Int, Int) -> Unit
 }
+impl[T : Eq] Eq for FixedArray[T]
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for FixedArray[X]
 
 impl Array {

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -960,7 +960,7 @@ test "ends_with" {
 ///   inspect!(arr1 == arr3, content="false")
 /// }
 /// ```
-pub fn FixedArray::op_equal[T : Eq](
+pub impl[T : Eq] Eq for FixedArray[T] with op_equal(
   self : FixedArray[T],
   that : FixedArray[T]
 ) -> Bool {

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -190,7 +190,7 @@ pub fn new(size_hint~ : Int = 0) -> T {
 ///   )
 /// }
 /// ```
-pub fn write_string(self : T, value : String) -> Unit {
+pub impl Logger for T with write_string(self, value) {
   self.grow_if_necessary(self.len + value.length() * 2)
   self.data.blit_from_string(self.len, value, 0, value.length())
   self.len += value.length() * 2
@@ -614,7 +614,7 @@ pub fn write_bytesview(self : T, value : @bytes.View) -> Unit {
 ///   )
 /// }
 /// ```
-pub fn write_substring(
+pub impl Logger for Buffer with write_substring(
   self : T,
   value : String,
   start : Int,
@@ -646,7 +646,7 @@ pub fn write_substring(
 /// )
 /// }
 /// ```
-pub fn write_char(self : T, value : Char) -> Unit {
+pub impl Logger for Buffer with write_char(self : T, value : Char) -> Unit {
   self.grow_if_necessary(self.len + 4)
   let inc = self.data.set_utf16le_char(self.len, value)
   self.len += inc

--- a/buffer/buffer.mbti
+++ b/buffer/buffer.mbti
@@ -19,7 +19,6 @@ impl T {
   write_byte(Self, Byte) -> Unit
   write_bytes(Self, Bytes) -> Unit
   write_bytesview(Self, @bytes.View) -> Unit
-  write_char(Self, Char) -> Unit
   write_double_be(Self, Double) -> Unit
   write_double_le(Self, Double) -> Unit
   write_float_be(Self, Float) -> Unit
@@ -30,14 +29,13 @@ impl T {
   write_int_le(Self, Int) -> Unit
   write_iter(Self, Iter[Byte]) -> Unit
   write_object(Self, &Show) -> Unit
-  write_string(Self, String) -> Unit
   write_sub_string(Self, String, Int, Int) -> Unit //deprecated
-  write_substring(Self, String, Int, Int) -> Unit
   write_uint64_be(Self, UInt64) -> Unit
   write_uint64_le(Self, UInt64) -> Unit
   write_uint_be(Self, UInt) -> Unit
   write_uint_le(Self, UInt) -> Unit
 }
+impl Logger for T
 impl Show for T
 
 // Type aliases

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -241,7 +241,7 @@ pub fn Array::op_set[T](self : Array[T], index : Int, value : T) -> Unit {
 ///   inspect!(arr1 == arr3, content="false")
 /// }
 /// ```
-pub fn Array::op_equal[T : Eq](self : Array[T], other : Array[T]) -> Bool {
+pub impl[T : Eq] Eq for Array[T] with op_equal(self, other) {
   let self_len = self.length()
   let other_len = other.length()
   guard self_len == other_len else { return false }
@@ -285,7 +285,7 @@ pub fn Array::op_equal[T : Eq](self : Array[T], other : Array[T]) -> Bool {
 ///   inspect!(arr1.compare(arr1), content="0") // arr1 = arr1
 /// }
 /// ```
-pub fn Array::compare[T : Compare](self : Array[T], other : Array[T]) -> Int {
+pub impl[T : Compare] Compare for Array[T] with compare(self, other) {
   let len_self = self.length()
   let len_other = other.length()
   let cmp = len_self.compare(len_other)
@@ -1753,6 +1753,6 @@ pub fn Array::iter2[A](self : Array[A]) -> Iter2[Int, A] {
 ///   inspect!(arr.is_empty(), content="true")
 /// }
 /// ```
-pub fn Array::default[T]() -> Array[T] {
+pub impl[T] Default for Array[T] with default() {
   []
 }

--- a/builtin/bigint_js.mbt
+++ b/builtin/bigint_js.mbt
@@ -113,12 +113,22 @@ pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
 }
 
 ///|
-pub extern "js" fn BigInt::compare(self : BigInt, other : BigInt) -> Int =
+extern "js" fn BigInt::compare(self : BigInt, other : BigInt) -> Int =
   #|(x, y) => x < y ? -1 : x > y ? 1 : 0
 
 ///|
-pub extern "js" fn BigInt::op_equal(self : BigInt, other : BigInt) -> Bool =
+pub impl Compare for BigInt with compare(self, other) {
+  self.compare(other)
+}
+
+///|
+extern "js" fn BigInt::equal(self : BigInt, other : BigInt) -> Bool =
   #|(x, y) => x === y
+
+///|
+pub impl Eq for BigInt with op_equal(self, other) {
+  self.equal(other)
+}
 
 ///|
 pub extern "js" fn BigInt::from_int(x : Int) -> BigInt =

--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -850,7 +850,7 @@ pub fn BigInt::is_zero(self : BigInt) -> Bool {
 ///   inspect!(a.compare(a), content="0") // 42 = 42
 /// }
 /// ```
-pub fn BigInt::compare(self : BigInt, other : BigInt) -> Int {
+pub impl Compare for BigInt with compare(self, other) {
   if self.sign != other.sign {
     return if self.sign == Positive { 1 } else { -1 }
   }
@@ -897,7 +897,7 @@ pub fn BigInt::compare(self : BigInt, other : BigInt) -> Int {
 ///   inspect!(a == c, content="false")
 /// }
 /// ```
-pub fn BigInt::op_equal(self : BigInt, other : BigInt) -> Bool {
+pub impl Eq for BigInt with op_equal(self, other) {
   if self.sign != other.sign || self.len != other.len {
     return false
   }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -58,10 +58,8 @@ impl Array {
   chunk_by[T](Self[T], (T, T) -> Bool) -> Self[Self[T]]
   chunks[T](Self[T], Int) -> Self[Self[T]]
   clear[T](Self[T]) -> Unit
-  compare[T : Compare](Self[T], Self[T]) -> Int
   contains[T : Eq](Self[T], T) -> Bool
   dedup[T : Eq](Self[T]) -> Unit
-  default[T]() -> Self[T]
   drain[T](Self[T], Int, Int) -> Self[T]
   each[T](Self[T], (T) -> Unit) -> Unit
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit
@@ -92,7 +90,6 @@ impl Array {
   new[T](capacity~ : Int = ..) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
   op_as_view[T](Self[T], start~ : Int = .., end? : Int) -> ArrayView[T]
-  op_equal[T : Eq](Self[T], Self[T]) -> Bool
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   pop[T](Self[T]) -> T?
@@ -119,13 +116,16 @@ impl Array {
   strip_prefix[T : Eq](Self[T], Self[T]) -> Self[T]?
   strip_suffix[T : Eq](Self[T], Self[T]) -> Self[T]?
   swap[T](Self[T], Int, Int) -> Unit
-  to_json[X : ToJson](Self[X]) -> Json
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_blit_fixed[A](Self[A], Int, FixedArray[A], Int, Int) -> Unit
   unsafe_get[T](Self[T], Int) -> T
   unsafe_pop[T](Self[T]) -> T
 }
+impl[T : Compare] Compare for Array[T]
+impl[T] Default for Array[T]
+impl[T : Eq] Eq for Array[T]
 impl[X : Show] Show for Array[X]
+impl[X : ToJson] ToJson for Array[X]
 
 type ArrayView[T] //deprecated
 impl ArrayView {
@@ -134,14 +134,13 @@ impl ArrayView {
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   swap[T](Self[T], Int, Int) -> Unit
-  to_json[X : ToJson](Self[X]) -> Json
   unsafe_get[T](Self[T], Int) -> T
 }
+impl[X : ToJson] ToJson for ArrayView[X]
 
 type BigInt
 impl BigInt {
   asr(Self, Int) -> Self //deprecated
-  compare(Self, Self) -> Int
   from_hex(String) -> Self
   from_int(Int) -> Self
   from_int64(Int64) -> Self
@@ -156,7 +155,6 @@ impl BigInt {
   lxor(Self, Self) -> Self
   op_add(Self, Self) -> Self
   op_div(Self, Self) -> Self
-  op_equal(Self, Self) -> Bool
   op_mod(Self, Self) -> Self
   op_mul(Self, Self) -> Self
   op_neg(Self) -> Self
@@ -169,13 +167,15 @@ impl BigInt {
   to_hex(Self, uppercase~ : Bool = ..) -> String
   to_int(Self) -> Int
   to_int64(Self) -> Int64
-  to_json(Self) -> Json
   to_octets(Self, length? : Int) -> Bytes
   to_string(Self) -> String
   to_uint(Self) -> UInt
   to_uint64(Self) -> UInt64
 }
+impl Compare for BigInt
+impl Eq for BigInt
 impl Show for BigInt
+impl ToJson for BigInt
 
 pub(all) type! Failure String
 impl Show for Failure
@@ -295,17 +295,17 @@ impl Map {
   keys[K, V](Self[K, V]) -> Iter[K]
   new[K, V](capacity~ : Int = ..) -> Self[K, V]
   of[K : Hash + Eq, V](FixedArray[(K, V)]) -> Self[K, V]
-  op_equal[K : Hash + Eq, V : Eq](Self[K, V], Self[K, V]) -> Bool
   op_get[K : Hash + Eq, V](Self[K, V], K) -> V?
   op_set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   remove[K : Hash + Eq, V](Self[K, V], K) -> Unit
   set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
-  to_json[K : Show, V : ToJson](Self[K, V]) -> Json
   values[K, V](Self[K, V]) -> Iter[V]
 }
+impl[K : Hash + Eq, V : Eq] Eq for Map[K, V]
 impl[K : Show, V : Show] Show for Map[K, V]
+impl[K : Show, V : ToJson] ToJson for Map[K, V]
 
 type Set[K]
 impl Set {
@@ -325,16 +325,16 @@ impl Set {
   iter[K](Self[K]) -> Iter[K]
   new[K](capacity~ : Int = ..) -> Self[K]
   of[K : Hash + Eq](FixedArray[K]) -> Self[K]
-  op_equal[K : Eq](Self[K], Self[K]) -> Bool
   remove[K : Hash + Eq](Self[K], K) -> Unit
   remove_and_check[K : Hash + Eq](Self[K], K) -> Bool
   size[K](Self[K]) -> Int
   symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   to_array[K](Self[K]) -> Array[K]
-  to_json[X : ToJson](Self[X]) -> Json
   union[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
 }
+impl[K : Eq] Eq for Set[K]
 impl[K : Show] Show for Set[K]
+impl[X : ToJson] ToJson for Set[X]
 
 pub(all) type! SnapshotError String
 
@@ -350,12 +350,10 @@ impl StringBuilder {
   new(size_hint~ : Int = ..) -> Self
   reset(Self) -> Unit
   to_string(Self) -> String
-  write_char(Self, Char) -> Unit
   write_iter(Self, Iter[Char]) -> Unit
   write_object[T : Show](Self, T) -> Unit
-  write_string(Self, String) -> Unit
-  write_substring(Self, String, Int, Int) -> Unit
 }
+impl Logger for StringBuilder
 impl Show for StringBuilder
 
 type UninitializedArray[T]
@@ -367,23 +365,13 @@ impl UninitializedArray {
   op_set[T](Self[T], Int, T) -> Unit
 }
 
-impl Unit {
-  op_equal(Unit, Unit) -> Bool
-  to_json(Unit) -> Json
-}
-
 impl Bool {
-  compare(Bool, Bool) -> Int
-  default() -> Bool
   not(Bool) -> Bool //deprecated
   op_compare(Bool, Bool) -> Int //deprecated
-  op_equal(Bool, Bool) -> Bool
-  to_json(Bool) -> Json
   to_string(Bool) -> String
 }
 
 impl Byte {
-  compare(Byte, Byte) -> Int
   default() -> Byte
   land(Byte, Byte) -> Byte
   lnot(Byte) -> Byte
@@ -393,7 +381,6 @@ impl Byte {
   lxor(Byte, Byte) -> Byte
   op_add(Byte, Byte) -> Byte
   op_div(Byte, Byte) -> Byte
-  op_equal(Byte, Byte) -> Bool
   op_mul(Byte, Byte) -> Byte
   op_shl(Byte, Int) -> Byte
   op_shr(Byte, Int) -> Byte
@@ -408,22 +395,16 @@ impl Byte {
 }
 
 impl Char {
-  compare(Char, Char) -> Int
-  default() -> Char
   from_int(Int) -> Char
-  op_equal(Char, Char) -> Bool
   op_sub(Char, Char) -> Int
   to_int(Char) -> Int
-  to_json(Char) -> Json
   to_uint(Char) -> UInt
 }
 
 impl Int {
   asr(Int, Int) -> Int //deprecated
   clz(Int) -> Int
-  compare(Int, Int) -> Int
   ctz(Int) -> Int
-  default() -> Int
   is_neg(Int) -> Bool
   is_non_neg(Int) -> Bool
   is_non_pos(Int) -> Bool
@@ -436,7 +417,6 @@ impl Int {
   lxor(Int, Int) -> Int
   op_add(Int, Int) -> Int
   op_div(Int, Int) -> Int
-  op_equal(Int, Int) -> Bool
   op_mod(Int, Int) -> Int
   op_mul(Int, Int) -> Int
   op_neg(Int) -> Int
@@ -453,7 +433,6 @@ impl Int {
   to_float(Int) -> Float
   to_int16(Int) -> Int16
   to_int64(Int) -> Int64
-  to_json(Int) -> Json
   to_string(Int, radix~ : Int = ..) -> String
   to_uint(Int) -> UInt //deprecated
   to_uint16(Int) -> UInt16
@@ -472,7 +451,6 @@ impl Int16 {
 impl Int64 {
   asr(Int64, Int) -> Int64 //deprecated
   clz(Int64) -> Int
-  compare(Int64, Int64) -> Int
   ctz(Int64) -> Int
   default() -> Int64
   land(Int64, Int64) -> Int64
@@ -483,7 +461,6 @@ impl Int64 {
   lxor(Int64, Int64) -> Int64
   op_add(Int64, Int64) -> Int64
   op_div(Int64, Int64) -> Int64
-  op_equal(Int64, Int64) -> Bool
   op_mod(Int64, Int64) -> Int64
   op_mul(Int64, Int64) -> Int64
   op_neg(Int64) -> Int64
@@ -500,7 +477,6 @@ impl Int64 {
   to_float(Int64) -> Float
   to_int(Int64) -> Int
   to_int16(Int64) -> Int16
-  to_json(Int64) -> Json
   to_string(Int64, radix~ : Int = ..) -> String
   to_uint16(Int64) -> UInt16
   to_uint64(Int64) -> UInt64 //deprecated
@@ -510,7 +486,6 @@ impl Int64 {
 
 impl UInt {
   clz(UInt) -> Int
-  compare(UInt, UInt) -> Int
   ctz(UInt) -> Int
   land(UInt, UInt) -> UInt
   lnot(UInt) -> UInt
@@ -520,7 +495,6 @@ impl UInt {
   lxor(UInt, UInt) -> UInt
   op_add(UInt, UInt) -> UInt
   op_div(UInt, UInt) -> UInt
-  op_equal(UInt, UInt) -> Bool
   op_mod(UInt, UInt) -> UInt
   op_mul(UInt, UInt) -> UInt
   op_neq(UInt, UInt) -> Bool
@@ -535,7 +509,6 @@ impl UInt {
   to_byte(UInt) -> Byte
   to_float(UInt) -> Float
   to_int(UInt) -> Int //deprecated
-  to_json(UInt) -> Json
   to_string(UInt, radix~ : Int = ..) -> String
   to_uint64(UInt) -> UInt64
   trunc_double(Double) -> UInt
@@ -551,9 +524,7 @@ impl UInt16 {
 
 impl UInt64 {
   clz(UInt64) -> Int
-  compare(UInt64, UInt64) -> Int
   ctz(UInt64) -> Int
-  default() -> UInt64
   extend_uint(UInt) -> UInt64
   land(UInt64, UInt64) -> UInt64
   lnot(UInt64) -> UInt64
@@ -563,7 +534,6 @@ impl UInt64 {
   lxor(UInt64, UInt64) -> UInt64
   op_add(UInt64, UInt64) -> UInt64
   op_div(UInt64, UInt64) -> UInt64
-  op_equal(UInt64, UInt64) -> Bool
   op_mod(UInt64, UInt64) -> UInt64
   op_mul(UInt64, UInt64) -> UInt64
   op_shl(UInt64, Int) -> UInt64
@@ -579,7 +549,6 @@ impl UInt64 {
   to_float(UInt64) -> Float
   to_int(UInt64) -> Int
   to_int64(UInt64) -> Int64 //deprecated
-  to_json(UInt64) -> Json
   to_string(UInt64, radix~ : Int = ..) -> String
   to_uint(UInt64) -> UInt
   trunc_double(Double) -> UInt64
@@ -587,10 +556,8 @@ impl UInt64 {
 }
 
 impl Float {
-  compare(Float, Float) -> Int
   op_add(Float, Float) -> Float
   op_div(Float, Float) -> Float
-  op_equal(Float, Float) -> Bool
   op_mul(Float, Float) -> Float
   op_neg(Float) -> Float
   op_neq(Float, Float) -> Bool
@@ -599,19 +566,15 @@ impl Float {
   reinterpret_as_uint(Float) -> UInt
   sqrt(Float) -> Float
   to_double(Float) -> Double
-  to_json(Float) -> Json
   until(Float, Float, step~ : Float = .., inclusive~ : Bool = ..) -> Iter[Float]
   upto(Float, Float, inclusive~ : Bool = ..) -> Iter[Float] //deprecated
 }
 
 impl Double {
-  compare(Double, Double) -> Int
   convert_uint(UInt) -> Double
   convert_uint64(UInt64) -> Double
-  default() -> Double
   op_add(Double, Double) -> Double
   op_div(Double, Double) -> Double
-  op_equal(Double, Double) -> Bool
   op_mul(Double, Double) -> Double
   op_neg(Double) -> Double
   op_neq(Double, Double) -> Bool
@@ -624,7 +587,6 @@ impl Double {
   to_float(Double) -> Float
   to_int(Double) -> Int
   to_int64(Double) -> Int64
-  to_json(Double) -> Json
   to_uint64(Double) -> UInt64
   until(Double, Double, step~ : Double = .., inclusive~ : Bool = ..) -> Iter[Double]
   upto(Double, Double, inclusive~ : Bool = ..) -> Iter[Double] //deprecated
@@ -640,31 +602,21 @@ impl String {
   length(String) -> Int
   make(Int, Char) -> String
   op_add(String, String) -> String
-  op_equal(String, String) -> Bool
   op_get(String, Int) -> Char
   substring(String, start~ : Int = .., end? : Int) -> String
-  to_json(String) -> Json
   to_string(String) -> String
   unsafe_charcode_at(String, Int) -> Int
 }
 
 impl Option {
-  op_equal[X : Eq](X?, X?) -> Bool
-  to_json[T : ToJson](T?) -> Json
   to_string[X : Show](X?) -> String
   unwrap[X](X?) -> X
-}
-
-impl Result {
-  op_equal[T : Eq, E : Eq](Self[T, E], Self[T, E]) -> Bool
-  to_json[Ok : ToJson, Err : ToJson](Self[Ok, Err]) -> Json
 }
 
 impl FixedArray {
   blit_from_bytes(Self[Byte], Int, Bytes, Int, Int) -> Unit
   blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
   blit_to[A](Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit
-  compare[T : Compare](Self[T], Self[T]) -> Int
   default[X]() -> Self[X]
   fill[T](Self[T], T) -> Unit
   get[T](Self[T], Int) -> T
@@ -680,20 +632,17 @@ impl FixedArray {
   set_utf16be_char(Self[Byte], Int, Char) -> Int
   set_utf16le_char(Self[Byte], Int, Char) -> Int
   set_utf8_char(Self[Byte], Int, Char) -> Int
-  to_json[X : ToJson](Self[X]) -> Json
   unsafe_blit[A](Self[A], Int, Self[A], Int, Int) -> Unit
   unsafe_get[T](Self[T], Int) -> T
 }
 
 impl Bytes {
-  compare(Bytes, Bytes) -> Int
   copy(Bytes) -> Bytes
   length(Bytes) -> Int
   make(Int, Byte) -> Bytes
   makei(Int, (Int) -> Byte) -> Bytes
   new(Int) -> Bytes
   of_string(String) -> Bytes
-  op_equal(Bytes, Bytes) -> Bool
   op_get(Bytes, Int) -> Byte
   sub_string(Bytes, Int, Int) -> String //deprecated
   to_string(Bytes) -> String //deprecated
@@ -706,95 +655,80 @@ impl Logger {
   write_object[Obj : Show](&Self, Obj) -> Unit
 }
 
-impl Tuple(2) {
-  compare[T0 : Compare, T1 : Compare]((T0, T1), (T0, T1)) -> Int
-  op_equal[T0 : Eq, T1 : Eq]((T0, T1), (T0, T1)) -> Bool
-}
-
-impl Tuple(3) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare]((T0, T1, T2), (T0, T1, T2)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq]((T0, T1, T2), (T0, T1, T2)) -> Bool
-}
-
-impl Tuple(4) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare]((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq]((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
-}
-
-impl Tuple(5) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare]((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq]((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
-}
-
-impl Tuple(6) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare]((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq]((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
-}
-
-impl Tuple(7) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare]((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq]((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
-}
-
-impl Tuple(8) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
-}
-
-impl Tuple(9) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
-}
-
-impl Tuple(10) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
-}
-
-impl Tuple(11) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
-}
-
-impl Tuple(12) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
-}
-
-impl Tuple(13) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
-}
-
-impl Tuple(14) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
-}
-
-impl Tuple(15) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
-}
-
-impl Tuple(16) {
-  compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Int
-  op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq]((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
-}
-
 // Type aliases
 
 // Traits
 pub(open) trait Compare : Eq {
   compare(Self, Self) -> Int
 }
+impl Compare for Bool
+impl Compare for Byte
+impl Compare for Char
+impl Compare for Int
+impl Compare for Int64
+impl Compare for UInt
+impl Compare for UInt64
+impl Compare for Float
+impl Compare for Double
+impl[T : Compare] Compare for FixedArray[T]
+impl Compare for Bytes
+impl[T0 : Compare, T1 : Compare] Compare for (T0, T1)
+impl[T0 : Compare, T1 : Compare, T2 : Compare] Compare for (T0, T1, T2)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Compare for (T0, T1, T2, T3)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Compare for (T0, T1, T2, T3, T4)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Compare for (T0, T1, T2, T3, T4, T5)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Compare for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
 
 pub(open) trait Default {
   default() -> Self
 }
+impl Default for Bool
+impl Default for Char
+impl Default for Int
+impl Default for UInt64
+impl Default for Double
 
 pub(open) trait Eq {
   op_equal(Self, Self) -> Bool
 }
+impl Eq for Unit
+impl Eq for Bool
+impl Eq for Byte
+impl Eq for Char
+impl Eq for Int
+impl Eq for Int64
+impl Eq for UInt
+impl Eq for UInt64
+impl Eq for Float
+impl Eq for Double
+impl Eq for String
+impl[X : Eq] Eq for X?
+impl[T : Eq, E : Eq] Eq for Result[T, E]
+impl Eq for Bytes
+impl[T0 : Eq, T1 : Eq] Eq for (T0, T1)
+impl[T0 : Eq, T1 : Eq, T2 : Eq] Eq for (T0, T1, T2)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq] Eq for (T0, T1, T2, T3)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq] Eq for (T0, T1, T2, T3, T4)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq] Eq for (T0, T1, T2, T3, T4, T5)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
 
 pub(open) trait Hash {
   hash_combine(Self, Hasher) -> Unit
@@ -863,6 +797,19 @@ impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show
 pub(open) trait ToJson {
   to_json(Self) -> Json
 }
+impl ToJson for Unit
+impl ToJson for Bool
+impl ToJson for Char
+impl ToJson for Int
+impl ToJson for Int64
+impl ToJson for UInt
+impl ToJson for UInt64
+impl ToJson for Float
+impl ToJson for Double
+impl ToJson for String
+impl[T : ToJson] ToJson for T?
+impl[Ok : ToJson, Err : ToJson] ToJson for Result[Ok, Err]
+impl[X : ToJson] ToJson for FixedArray[X]
 impl[A : ToJson, B : ToJson] ToJson for (A, B)
 impl[A : ToJson, B : ToJson, C : ToJson] ToJson for (A, B, C)
 impl[A : ToJson, B : ToJson, C : ToJson, D : ToJson] ToJson for (A, B, C, D)

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -78,7 +78,7 @@ pub fn Byte::op_div(self : Byte, that : Byte) -> Byte {
 /// - `that` : The second `Byte` value to compare.
 ///
 /// Returns `true` if the two `Byte` values are equal, otherwise `false`.
-pub fn Byte::op_equal(self : Byte, that : Byte) -> Bool {
+pub impl Eq for Byte with op_equal(self : Byte, that : Byte) -> Bool {
   self.to_int() == that.to_int()
 }
 
@@ -122,7 +122,7 @@ pub fn Byte::op_sub(self : Byte, that : Byte) -> Byte {
 /// - A value less than 0 indicates that `byte1` is less than `byte2`.
 /// - A value of 0 indicates that `byte1` is equal to `byte2`.
 /// - A value greater than 0 indicates that `byte1` is greater than `byte2`.
-pub fn Byte::compare(self : Byte, that : Byte) -> Int {
+pub impl Compare for Byte with compare(self : Byte, that : Byte) -> Int {
   self.to_int().compare(that.to_int())
 }
 

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -421,7 +421,7 @@ pub fn FixedArray::set_utf16be_char(
 ///   inspect!(bytes1 == bytes3, content="false")
 /// }
 /// ```
-pub fn Bytes::op_equal(self : Bytes, other : Bytes) -> Bool {
+pub impl Eq for Bytes with op_equal(self : Bytes, other : Bytes) -> Bool {
   if self.length() != other.length() {
     false
   } else {
@@ -470,7 +470,7 @@ pub fn Bytes::op_equal(self : Bytes, other : Bytes) -> Bool {
 ///   inspect!(b.compare(a), content="1") // longer sequence is greater
 /// }
 /// ```
-pub fn Bytes::compare(self : Bytes, other : Bytes) -> Int {
+pub impl Compare for Bytes with compare(self, other) {
   let self_len = self.length()
   let other_len = other.length()
   let cmp = self_len.compare(other_len)

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -145,7 +145,7 @@ pub fn FixedArray::fill[T](self : FixedArray[T], value : T) -> Unit {
 ///   inspect!(arr1.compare(arr1), content="0") // arr1 = arr1
 /// }
 /// ```
-pub fn compare[T : Compare](self : FixedArray[T], other : FixedArray[T]) -> Int {
+pub impl[T : Compare] Compare for FixedArray[T] with compare(self, other) {
   let len_self = self.length()
   let len_other = other.length()
   if len_self < len_other {

--- a/builtin/int64_js.mbt
+++ b/builtin/int64_js.mbt
@@ -254,7 +254,7 @@ fn MyInt64::popcnt(self : MyInt64) -> Int {
 }
 
 ///|
-fn MyInt64::op_equal(self : MyInt64, other : MyInt64) -> Bool {
+impl Eq for MyInt64 with op_equal(self : MyInt64, other : MyInt64) -> Bool {
   self.hi == other.hi && self.lo == other.lo
 }
 
@@ -482,12 +482,12 @@ pub fn Int64::popcnt(self : Int64) -> Int {
 }
 
 ///|
-pub fn Int64::op_equal(self : Int64, other : Int64) -> Bool {
+pub impl Eq for Int64 with op_equal(self : Int64, other : Int64) -> Bool {
   MyInt64::from_int64(self) == MyInt64::from_int64(other)
 }
 
 ///|
-pub fn Int64::compare(self : Int64, other : Int64) -> Int {
+pub impl Compare for Int64 with compare(self : Int64, other : Int64) -> Int {
   MyInt64::compare(MyInt64::from_int64(self), MyInt64::from_int64(other))
 }
 
@@ -653,12 +653,12 @@ pub fn UInt64::to_double(self : UInt64) -> Double {
 }
 
 ///|
-pub fn UInt64::compare(self : UInt64, other : UInt64) -> Int {
+pub impl Compare for UInt64 with compare(self : UInt64, other : UInt64) -> Int {
   MyInt64::from_uint64(self).compare_u(MyInt64::from_uint64(other))
 }
 
 ///|
-pub fn UInt64::op_equal(self : UInt64, other : UInt64) -> Bool {
+pub impl Eq for UInt64 with op_equal(self : UInt64, other : UInt64) -> Bool {
   MyInt64::from_uint64(self).op_equal(MyInt64::from_uint64(other))
 }
 

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -539,7 +539,7 @@ pub fn Int64::popcnt(self : Int64) -> Int = "%i64_popcnt"
 ///   inspect!(a == c, content="false")
 /// }
 /// ```
-pub fn Int64::op_equal(self : Int64, other : Int64) -> Bool = "%i64_eq"
+pub impl Eq for Int64 with op_equal(self : Int64, other : Int64) -> Bool = "%i64_eq"
 
 ///|
 /// Compares two 64-bit integers and returns their relative order.
@@ -568,7 +568,7 @@ pub fn Int64::op_equal(self : Int64, other : Int64) -> Bool = "%i64_eq"
 ///   inspect!(a.compare(a), content="0") // 42 = 42
 /// }
 /// ```
-pub fn Int64::compare(self : Int64, other : Int64) -> Int = "%i64_compare"
+pub impl Compare for Int64 with compare(self, other) = "%i64_compare"
 
 ///|
 /// Returns the default value for `Int64` type, which is zero (0L).
@@ -1326,7 +1326,7 @@ pub fn UInt64::op_mod(self : UInt64, other : UInt64) -> UInt64 = "%u64.mod"
 ///   inspect!(a.compare(a), content="0") // 42 = 42
 /// }
 /// ```
-pub fn UInt64::compare(self : UInt64, other : UInt64) -> Int = "%u64.compare"
+pub impl Compare for UInt64 with compare(self, other) = "%u64.compare"
 
 ///|
 /// Compares two unsigned 64-bit integers for equality.
@@ -1349,7 +1349,7 @@ pub fn UInt64::compare(self : UInt64, other : UInt64) -> Int = "%u64.compare"
 ///   inspect!(a == c, content="false")
 /// }
 /// ```
-pub fn UInt64::op_equal(self : UInt64, other : UInt64) -> Bool = "%u64.eq"
+pub impl Eq for UInt64 with op_equal(self : UInt64, other : UInt64) -> Bool = "%u64.eq"
 
 ///|
 /// Performs a bitwise AND operation between two unsigned 64-bit integers.

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -158,7 +158,7 @@ pub fn Bool::not(self : Bool) -> Bool = "%bool_not"
 ///   inspect!(false == false, content="true")
 /// }
 /// ```
-pub fn Bool::op_equal(self : Bool, other : Bool) -> Bool = "%bool_eq"
+pub impl Eq for Bool with op_equal(self : Bool, other : Bool) -> Bool = "%bool_eq"
 
 ///|
 /// Compares two boolean values and returns their relative order. This is a
@@ -218,7 +218,7 @@ pub fn Bool::op_compare(self : Bool, other : Bool) -> Int = "%bool_compare"
 ///   inspect!(true.compare(true), content="0") // true = true
 /// }
 /// ```
-pub fn Bool::compare(self : Bool, other : Bool) -> Int = "%bool_compare"
+pub impl Compare for Bool with compare(self, other) = "%bool_compare"
 
 ///|
 /// Returns the default value for the `Bool` type, which is `false`.
@@ -233,7 +233,7 @@ pub fn Bool::compare(self : Bool, other : Bool) -> Int = "%bool_compare"
 ///   inspect!(b, content="false")
 /// }
 /// ```
-pub fn Bool::default() -> Bool = "%bool_default"
+pub impl Default for Bool with default() = "%bool_default"
 
 // int32 primitive ops
 
@@ -745,7 +745,7 @@ pub fn Int::popcnt(self : Int) -> Int = "%i32_popcnt"
 ///   inspect!(42 == -42, content="false")
 /// }
 /// ```
-pub fn Int::op_equal(self : Int, other : Int) -> Bool = "%i32_eq"
+pub impl Eq for Int with op_equal(self : Int, other : Int) -> Bool = "%i32_eq"
 
 ///|
 /// Compares two integers and returns their relative order.
@@ -772,7 +772,7 @@ pub fn Int::op_equal(self : Int, other : Int) -> Bool = "%i32_eq"
 ///   inspect!(a.compare(a), content="0") // 42 = 42
 /// }
 /// ```
-pub fn Int::compare(self : Int, other : Int) -> Int = "%i32_compare"
+pub impl Compare for Int with compare(self, other) = "%i32_compare"
 
 ///|
 pub fn Int::is_pos(self : Int) -> Bool = "%i32_is_pos"
@@ -819,7 +819,7 @@ pub fn Int::is_non_neg(self : Int) -> Bool = "%i32_is_non_neg"
 ///   inspect!(x, content="0")
 /// }
 /// ```
-pub fn Int::default() -> Int = "%i32_default"
+pub impl Default for Int with default() = "%i32_default"
 
 ///|
 /// Converts a 32-bit integer to a double-precision floating-point number. The
@@ -1109,7 +1109,7 @@ pub fn Double::sqrt(self : Double) -> Double = "%f64_sqrt"
 ///   inspect!(nan == nan, content="false") // Note: NaN equals itself in MoonBit
 /// }
 /// ```
-pub fn Double::op_equal(self : Double, other : Double) -> Bool = "%f64_eq"
+pub impl Eq for Double with op_equal(self : Double, other : Double) -> Bool = "%f64_eq"
 
 ///|
 /// Tests for inequality between two double-precision floating-point numbers.
@@ -1165,7 +1165,7 @@ pub fn Double::op_neq(self : Double, other : Double) -> Bool = "%f64_ne"
 ///   inspect!(a.compare(a), content="0") // 3.14 = 3.14
 /// }
 /// ```
-pub fn Double::compare(self : Double, other : Double) -> Int = "%f64_compare"
+pub impl Compare for Double with compare(self, other) = "%f64_compare"
 
 ///|
 /// Returns the default value for double-precision floating-point numbers (0.0).
@@ -1179,7 +1179,7 @@ pub fn Double::compare(self : Double, other : Double) -> Int = "%f64_compare"
 ///   inspect!(Double::default(), content="0")
 /// }
 /// ```
-pub fn Double::default() -> Double = "%f64_default"
+pub impl Default for Double with default() = "%f64_default"
 
 ///|
 fn Double::to_unchecked_int(self : Double) -> Int = "%f64_to_i32"
@@ -1283,7 +1283,7 @@ pub fn Char::from_int(val : Int) -> Char = "%char_from_int"
 ///   inspect!(a == c, content="false")
 /// }
 /// ```
-pub fn Char::op_equal(self : Char, other : Char) -> Bool = "%char_eq"
+pub impl Eq for Char with op_equal(self : Char, other : Char) -> Bool = "%char_eq"
 
 ///|
 /// Compares two characters based on their Unicode code points. Returns a
@@ -1311,7 +1311,7 @@ pub fn Char::op_equal(self : Char, other : Char) -> Bool = "%char_eq"
 ///   inspect!('a'.compare('a'), content="0")
 /// }
 /// ```
-pub fn Char::compare(self : Char, other : Char) -> Int = "%char_compare"
+pub impl Compare for Char with compare(self, other) = "%char_compare"
 
 ///|
 /// Returns the default value for the `Char` type, which is the null character
@@ -1326,7 +1326,7 @@ pub fn Char::compare(self : Char, other : Char) -> Int = "%char_compare"
 ///   assert_true!(Char::default().to_string() == "\x00")
 /// }
 /// ```
-pub fn Char::default() -> Char = "%char_default"
+pub impl Default for Char with default() = "%char_default"
 
 // Bytes primitive ops
 
@@ -1899,7 +1899,7 @@ pub fn String::op_add(self : String, other : String) -> String = "%string_add"
 ///   inspect!(str1 == str3, content="false")
 /// }
 /// ```
-pub fn String::op_equal(self : String, other : String) -> Bool = "%string_eq"
+pub impl Eq for String with op_equal(self : String, other : String) -> Bool = "%string_eq"
 
 ///|
 /// Returns the string itself without any modifications. This method is primarily
@@ -2166,7 +2166,7 @@ pub fn UInt::op_mod(self : UInt, other : UInt) -> UInt = "%u32.mod"
 ///   inspect!(a == c, content="false")
 /// }
 /// ```
-pub fn UInt::op_equal(self : UInt, other : UInt) -> Bool = "%u32.eq"
+pub impl Eq for UInt with op_equal(self : UInt, other : UInt) -> Bool = "%u32.eq"
 
 ///|
 /// Checks if two unsigned 32-bit integers are not equal.
@@ -2215,7 +2215,7 @@ pub fn UInt::op_neq(self : UInt, other : UInt) -> Bool = "%u32.ne"
 ///   inspect!(a.compare(a), content="0") // 42 = 42
 /// }
 /// ```
-pub fn UInt::compare(self : UInt, other : UInt) -> Int = "%u32.compare"
+pub impl Compare for UInt with compare(self, other) = "%u32.compare"
 
 ///|
 /// Performs a bitwise AND operation between two unsigned 32-bit integers. For
@@ -2777,7 +2777,7 @@ pub fn Float::sqrt(self : Float) -> Float = "%f32.sqrt"
 ///   inspect!(z == z, content="false") // NaN is not equal to itself
 /// }
 /// ```
-pub fn Float::op_equal(self : Float, other : Float) -> Bool = "%f32.eq"
+pub impl Eq for Float with op_equal(self : Float, other : Float) -> Bool = "%f32.eq"
 
 ///|
 /// Tests if two single-precision floating-point numbers are not equal. This
@@ -2831,7 +2831,7 @@ pub fn Float::op_neq(self : Float, other : Float) -> Bool = "%f32.ne"
 ///   inspect!(a.compare(a), content="0") // 3.14 = 3.14
 /// }
 /// ```
-pub fn Float::compare(self : Float, other : Float) -> Int = "%f32.compare"
+pub impl Compare for Float with compare(self, other) = "%f32.compare"
 
 ///|
 /// Converts a 32-bit floating-point number to a double-precision (64-bit)

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -30,7 +30,7 @@ pub(open) trait ToJson {
 }
 
 ///|
-pub fn Bool::to_json(self : Bool) -> Json {
+pub impl ToJson for Bool with to_json(self : Bool) -> Json {
   if self {
     true
   } else {
@@ -39,27 +39,27 @@ pub fn Bool::to_json(self : Bool) -> Json {
 }
 
 ///|
-pub fn Int::to_json(self : Int) -> Json {
+pub impl ToJson for Int with to_json(self : Int) -> Json {
   Number(self.to_double())
 }
 
 ///|
-pub fn Int64::to_json(self : Int64) -> Json {
+pub impl ToJson for Int64 with to_json(self : Int64) -> Json {
   String::to_json(self.to_string())
 }
 
 ///|
-pub fn UInt::to_json(self : UInt) -> Json {
+pub impl ToJson for UInt with to_json(self : UInt) -> Json {
   Number(self.to_uint64().to_double())
 }
 
 ///|
-pub fn UInt64::to_json(self : UInt64) -> Json {
+pub impl ToJson for UInt64 with to_json(self : UInt64) -> Json {
   String::to_json(self.to_string())
 }
 
 ///|
-pub fn Double::to_json(self : Double) -> Json {
+pub impl ToJson for Double with to_json(self : Double) -> Json {
   if self != self ||
     self > 0x7FEFFFFFFFFFFFFFL.reinterpret_as_double() ||
     self < 0xFFEFFFFFFFFFFFFFL.reinterpret_as_double() {
@@ -69,32 +69,32 @@ pub fn Double::to_json(self : Double) -> Json {
 }
 
 ///|
-pub fn Float::to_json(self : Float) -> Json {
+pub impl ToJson for Float with to_json(self : Float) -> Json {
   Number(self.to_double())
 }
 
 ///|
-pub fn String::to_json(self : String) -> Json {
+pub impl ToJson for String with to_json(self : String) -> Json {
   String(self)
 }
 
 ///|
-pub fn Char::to_json(self : Char) -> Json {
+pub impl ToJson for Char with to_json(self : Char) -> Json {
   String(self.to_string())
 }
 
 ///|
-pub fn BigInt::to_json(self : BigInt) -> Json {
+pub impl ToJson for BigInt with to_json(self : BigInt) -> Json {
   String(self.to_string())
 }
 
 ///|
-pub fn Array::to_json[X : ToJson](self : Array[X]) -> Json {
+pub impl[X : ToJson] ToJson for Array[X] with to_json(self) {
   Array(self.map(ToJson::to_json))
 }
 
 ///|
-pub fn FixedArray::to_json[X : ToJson](self : FixedArray[X]) -> Json {
+pub impl[X : ToJson] ToJson for FixedArray[X] with to_json(self) {
   let len = self.length()
   if len == 0 {
     return []
@@ -107,7 +107,7 @@ pub fn FixedArray::to_json[X : ToJson](self : FixedArray[X]) -> Json {
 }
 
 ///|
-pub fn ArrayView::to_json[X : ToJson](self : ArrayView[X]) -> Json {
+pub impl[X : ToJson] ToJson for ArrayView[X] with to_json(self) {
   let len = self.length()
   if len == 0 {
     return []
@@ -120,7 +120,7 @@ pub fn ArrayView::to_json[X : ToJson](self : ArrayView[X]) -> Json {
 }
 
 ///|
-pub fn Map::to_json[K : Show, V : ToJson](self : Map[K, V]) -> Json {
+pub impl[K : Show, V : ToJson] ToJson for Map[K, V] with to_json(self) {
   let object = {}
   for k, v in self {
     object[k.to_string()] = v.to_json()
@@ -129,7 +129,7 @@ pub fn Map::to_json[K : Show, V : ToJson](self : Map[K, V]) -> Json {
 }
 
 ///|
-pub fn Set::to_json[X : ToJson](self : Set[X]) -> Json {
+pub impl[X : ToJson] ToJson for Set[X] with to_json(self) {
   let array = []
   for v in self {
     array.push(v.to_json())
@@ -138,7 +138,7 @@ pub fn Set::to_json[X : ToJson](self : Set[X]) -> Json {
 }
 
 ///|
-pub fn Option::to_json[T : ToJson](self : T?) -> Json {
+pub impl[T : ToJson] ToJson for T? with to_json(self) {
   match self {
     None => Null
     Some(value) => [value.to_json()]
@@ -146,7 +146,7 @@ pub fn Option::to_json[T : ToJson](self : T?) -> Json {
 }
 
 ///|
-pub fn Result::to_json[Ok : ToJson, Err : ToJson](
+pub impl[Ok : ToJson, Err : ToJson] ToJson for Result[Ok, Err] with to_json(
   self : Result[Ok, Err]
 ) -> Json {
   match self {
@@ -157,7 +157,7 @@ pub fn Result::to_json[Ok : ToJson, Err : ToJson](
 
 ///|
 //| unit
-pub fn Unit::to_json(_self : Unit) -> Json {
+pub impl ToJson for Unit with to_json(_self) {
   Null
 }
 

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -23,7 +23,7 @@ priv struct Entry[K, V] {
 } derive(Show)
 
 ///|
-fn Entry::op_equal[K : Eq, V](self : Entry[K, V], other : Entry[K, V]) -> Bool {
+impl[K : Eq, V] Eq for Entry[K, V] with op_equal(self, other) {
   self.hash == other.hash && self.key == other.key
 }
 
@@ -535,7 +535,7 @@ pub fn Map::to_array[K, V](self : Map[K, V]) -> Array[(K, V)] {
 }
 
 ///|
-pub fn Map::op_equal[K : Hash + Eq, V : Eq](
+pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with op_equal(
   self : Map[K, V],
   that : Map[K, V]
 ) -> Bool {

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -23,7 +23,7 @@ priv struct SEntry[K] {
 } derive(Show)
 
 ///|
-fn SEntry::op_equal[K : Eq](self : SEntry[K], other : SEntry[K]) -> Bool {
+impl[K : Eq] Eq for SEntry[K] with op_equal(self, other) {
   self.hash == other.hash && self.key == other.key
 }
 
@@ -437,7 +437,7 @@ pub fn Set::to_array[K](self : Set[K]) -> Array[K] {
 }
 
 ///|
-pub fn Set::op_equal[K : Eq](self : Set[K], that : Set[K]) -> Bool {
+pub impl[K : Eq] Eq for Set[K] with op_equal(self, that) {
   if self.size != that.size {
     return false
   }

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn Option::op_equal[X : Eq](self : X?, other : X?) -> Bool {
+pub impl[X : Eq] Eq for X? with op_equal(self, other) {
   match (self, other) {
     (None, None) => true
     (Some(x), Some(y)) => x == y

--- a/builtin/result.mbt
+++ b/builtin/result.mbt
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn Result::op_equal[T : Eq, E : Eq](
-  self : Result[T, E],
-  other : Result[T, E]
-) -> Bool {
+pub impl[T : Eq, E : Eq] Eq for Result[T, E] with op_equal(self, other) {
   match (self, other) {
     (Ok(x), Ok(y)) => x == y
     (Err(x), Err(y)) => x == y

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -55,21 +55,21 @@ fn StringBuilder::grow_if_necessary(
 }
 
 ///|
-pub fn StringBuilder::write_string(self : StringBuilder, str : String) -> Unit {
+pub impl Logger for StringBuilder with write_string(self, str) {
   self.grow_if_necessary(self.len + str.length() * 2)
   self.data.blit_from_string(self.len, str, 0, str.length())
   self.len += str.length() * 2
 }
 
 ///|
-pub fn StringBuilder::write_char(self : StringBuilder, ch : Char) -> Unit {
+pub impl Logger for StringBuilder with write_char(self, ch) {
   self.grow_if_necessary(self.len + 4)
   let inc = self.data.set_utf16le_char(self.len, ch)
   self.len += inc
 }
 
 ///|
-pub fn StringBuilder::write_substring(
+pub impl Logger for StringBuilder with write_substring(
   self : StringBuilder,
   str : String,
   start : Int,

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -28,17 +28,17 @@ pub fn StringBuilder::is_empty(self : StringBuilder) -> Bool {
 }
 
 ///|
-pub fn StringBuilder::write_string(self : StringBuilder, str : String) -> Unit {
+pub impl Logger for StringBuilder with write_string(self, str) {
   self.val += str
 }
 
 ///|
-pub fn StringBuilder::write_char(self : StringBuilder, ch : Char) -> Unit {
+pub impl Logger for StringBuilder with write_char(self, ch) {
   self.val += Char::to_string(ch)
 }
 
 ///|
-pub fn StringBuilder::write_substring(
+pub impl Logger for StringBuilder with write_substring(
   self : StringBuilder,
   str : String,
   start : Int,

--- a/builtin/tuple_compare.mbt
+++ b/builtin/tuple_compare.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn Tuple2::compare[T0 : Compare, T1 : Compare](
+pub impl[T0 : Compare, T1 : Compare] Compare for (T0, T1) with compare(
   self : (T0, T1),
   other : (T0, T1)
 ) -> Int {
@@ -23,7 +23,7 @@ pub fn Tuple2::compare[T0 : Compare, T1 : Compare](
 }
 
 ///|
-pub fn Tuple3::compare[T0 : Compare, T1 : Compare, T2 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare] Compare for (T0, T1, T2) with compare(
   self : (T0, T1, T2),
   other : (T0, T1, T2)
 ) -> Int {
@@ -35,10 +35,12 @@ pub fn Tuple3::compare[T0 : Compare, T1 : Compare, T2 : Compare](
 }
 
 ///|
-pub fn Tuple4::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare](
-  self : (T0, T1, T2, T3),
-  other : (T0, T1, T2, T3)
-) -> Int {
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+) with compare(self : (T0, T1, T2, T3), other : (T0, T1, T2, T3)) -> Int {
   let t0 = self.0.compare(other.0)
   guard t0 == 0 else { return t0 }
   let t1 = self.1.compare(other.1)
@@ -49,10 +51,13 @@ pub fn Tuple4::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare](
 }
 
 ///|
-pub fn Tuple5::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare](
-  self : (T0, T1, T2, T3, T4),
-  other : (T0, T1, T2, T3, T4)
-) -> Int {
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+) with compare(self : (T0, T1, T2, T3, T4), other : (T0, T1, T2, T3, T4)) -> Int {
   let t0 = self.0.compare(other.0)
   guard t0 == 0 else { return t0 }
   let t1 = self.1.compare(other.1)
@@ -65,7 +70,14 @@ pub fn Tuple5::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T
 }
 
 ///|
-pub fn Tuple6::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5),
   other : (T0, T1, T2, T3, T4, T5)
 ) -> Int {
@@ -83,7 +95,15 @@ pub fn Tuple6::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T
 }
 
 ///|
-pub fn Tuple7::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6),
   other : (T0, T1, T2, T3, T4, T5, T6)
 ) -> Int {
@@ -103,7 +123,16 @@ pub fn Tuple7::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T
 }
 
 ///|
-pub fn Tuple8::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7),
   other : (T0, T1, T2, T3, T4, T5, T6, T7)
 ) -> Int {
@@ -125,7 +154,17 @@ pub fn Tuple8::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T
 }
 
 ///|
-pub fn Tuple9::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8)
 ) -> Int {
@@ -149,7 +188,18 @@ pub fn Tuple9::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T
 }
 
 ///|
-pub fn Tuple10::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
 ) -> Int {
@@ -175,7 +225,19 @@ pub fn Tuple10::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, 
 }
 
 ///|
-pub fn Tuple11::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
 ) -> Int {
@@ -203,7 +265,20 @@ pub fn Tuple11::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, 
 }
 
 ///|
-pub fn Tuple12::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
 ) -> Int {
@@ -233,7 +308,21 @@ pub fn Tuple12::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, 
 }
 
 ///|
-pub fn Tuple13::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
 ) -> Int {
@@ -265,7 +354,22 @@ pub fn Tuple13::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, 
 }
 
 ///|
-pub fn Tuple14::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+  T13,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
 ) -> Int {
@@ -299,7 +403,23 @@ pub fn Tuple14::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, 
 }
 
 ///|
-pub fn Tuple15::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+  T13,
+  T14,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
 ) -> Int {
@@ -335,7 +455,24 @@ pub fn Tuple15::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, 
 }
 
 ///|
-pub fn Tuple16::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare](
+pub impl[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Compare for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+  T13,
+  T14,
+  T15,
+) with compare(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
 ) -> Int {
@@ -371,171 +508,3 @@ pub fn Tuple16::compare[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, 
   guard t14 == 0 else { return t14 }
   self.15.compare(other.15)
 }
-
-// the type alias below are used to declare methods on tuple as:
-//
-//    fn TupleN::meth(...)
-//
-// so that this methods won't pollute the toplevel namespace of `builtin`
-
-///|
-typealias Tuple2[T0, T1] = (T0, T1)
-
-///|
-typealias Tuple3[T0, T1, T2] = (T0, T1, T2)
-
-///|
-typealias Tuple4[T0, T1, T2, T3] = (T0, T1, T2, T3)
-
-///|
-typealias Tuple5[T0, T1, T2, T3, T4] = (T0, T1, T2, T3, T4)
-
-///|
-typealias Tuple6[T0, T1, T2, T3, T4, T5] = (T0, T1, T2, T3, T4, T5)
-
-///|
-typealias Tuple7[T0, T1, T2, T3, T4, T5, T6] = (T0, T1, T2, T3, T4, T5, T6)
-
-///|
-typealias Tuple8[T0, T1, T2, T3, T4, T5, T6, T7] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-)
-
-///|
-typealias Tuple9[T0, T1, T2, T3, T4, T5, T6, T7, T8] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-)
-
-///|
-typealias Tuple10[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-  T9,
-)
-
-///|
-typealias Tuple11[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-  T9,
-  T10,
-)
-
-///|
-typealias Tuple12[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-  T9,
-  T10,
-  T11,
-)
-
-///|
-typealias Tuple13[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-  T9,
-  T10,
-  T11,
-  T12,
-)
-
-///|
-typealias Tuple14[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-  T9,
-  T10,
-  T11,
-  T12,
-  T13,
-)
-
-///|
-typealias Tuple15[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-  T9,
-  T10,
-  T11,
-  T12,
-  T13,
-  T14,
-)
-
-///|
-typealias Tuple16[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15] = (
-  T0,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5,
-  T6,
-  T7,
-  T8,
-  T9,
-  T10,
-  T11,
-  T12,
-  T13,
-  T14,
-  T15,
-)

--- a/builtin/tuple_eq.mbt
+++ b/builtin/tuple_eq.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn Tuple2::op_equal[T0 : Eq, T1 : Eq](
+pub impl[T0 : Eq, T1 : Eq] Eq for (T0, T1) with op_equal(
   self : (T0, T1),
   other : (T0, T1)
 ) -> Bool {
@@ -21,7 +21,7 @@ pub fn Tuple2::op_equal[T0 : Eq, T1 : Eq](
 }
 
 ///|
-pub fn Tuple3::op_equal[T0 : Eq, T1 : Eq, T2 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq] Eq for (T0, T1, T2) with op_equal(
   self : (T0, T1, T2),
   other : (T0, T1, T2)
 ) -> Bool {
@@ -29,7 +29,7 @@ pub fn Tuple3::op_equal[T0 : Eq, T1 : Eq, T2 : Eq](
 }
 
 ///|
-pub fn Tuple4::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq] Eq for (T0, T1, T2, T3) with op_equal(
   self : (T0, T1, T2, T3),
   other : (T0, T1, T2, T3)
 ) -> Bool {
@@ -40,10 +40,13 @@ pub fn Tuple4::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq](
 }
 
 ///|
-pub fn Tuple5::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq](
-  self : (T0, T1, T2, T3, T4),
-  other : (T0, T1, T2, T3, T4)
-) -> Bool {
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+) with op_equal(self : (T0, T1, T2, T3, T4), other : (T0, T1, T2, T3, T4)) -> Bool {
   self.0 == other.0 &&
   self.1 == other.1 &&
   self.2 == other.2 &&
@@ -52,7 +55,14 @@ pub fn Tuple5::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq](
 }
 
 ///|
-pub fn Tuple6::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5),
   other : (T0, T1, T2, T3, T4, T5)
 ) -> Bool {
@@ -65,7 +75,15 @@ pub fn Tuple6::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq](
 }
 
 ///|
-pub fn Tuple7::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6),
   other : (T0, T1, T2, T3, T4, T5, T6)
 ) -> Bool {
@@ -79,7 +97,16 @@ pub fn Tuple7::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6
 }
 
 ///|
-pub fn Tuple8::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7),
   other : (T0, T1, T2, T3, T4, T5, T6, T7)
 ) -> Bool {
@@ -94,7 +121,17 @@ pub fn Tuple8::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6
 }
 
 ///|
-pub fn Tuple9::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8)
 ) -> Bool {
@@ -110,7 +147,18 @@ pub fn Tuple9::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6
 }
 
 ///|
-pub fn Tuple10::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
 ) -> Bool {
@@ -127,7 +175,19 @@ pub fn Tuple10::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T
 }
 
 ///|
-pub fn Tuple11::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
 ) -> Bool {
@@ -145,7 +205,20 @@ pub fn Tuple11::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T
 }
 
 ///|
-pub fn Tuple12::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
 ) -> Bool {
@@ -164,7 +237,21 @@ pub fn Tuple12::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T
 }
 
 ///|
-pub fn Tuple13::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
 ) -> Bool {
@@ -184,7 +271,22 @@ pub fn Tuple13::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T
 }
 
 ///|
-pub fn Tuple14::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+  T13,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
 ) -> Bool {
@@ -205,7 +307,23 @@ pub fn Tuple14::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T
 }
 
 ///|
-pub fn Tuple15::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+  T13,
+  T14,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
 ) -> Bool {
@@ -227,7 +345,24 @@ pub fn Tuple15::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T
 }
 
 ///|
-pub fn Tuple16::op_equal[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq](
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq] Eq for (
+  T0,
+  T1,
+  T2,
+  T3,
+  T4,
+  T5,
+  T6,
+  T7,
+  T8,
+  T9,
+  T10,
+  T11,
+  T12,
+  T13,
+  T14,
+  T15,
+) with op_equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
 ) -> Bool {

--- a/builtin/uint64.mbt
+++ b/builtin/uint64.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn UInt64::default() -> UInt64 {
+pub impl Default for UInt64 with default() {
   0
 }
 

--- a/builtin/unit.mbt
+++ b/builtin/unit.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub fn Unit::op_equal(self : Unit, _other : Unit) -> Bool {
+pub impl Eq for Unit with op_equal(self : Unit, _other : Unit) -> Bool {
   let _ = self
   true
 }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -585,7 +585,7 @@ pub fn T::as_views[A](self : T[A]) -> (ArrayView[A], ArrayView[A]) {
 ///   inspect!(dq1 == dq3, content="false")
 /// }
 /// ```
-pub fn op_equal[A : Eq](self : T[A], other : T[A]) -> Bool {
+pub impl[A : Eq] Eq for T[A] with op_equal(self, other) {
   if self.len != other.len {
     return false
   }

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -32,7 +32,6 @@ impl T {
   mapi[A, U](Self[A], (Int, A) -> U) -> Self[U]
   new[A](capacity~ : Int = ..) -> Self[A] //deprecated
   of[A](FixedArray[A]) -> Self[A] //deprecated
-  op_equal[A : Eq](Self[A], Self[A]) -> Bool
   op_get[A](Self[A], Int) -> A
   op_set[A](Self[A], Int, A) -> Unit
   pop_back[A](Self[A]) -> A?
@@ -55,6 +54,7 @@ impl T {
   unsafe_pop_back[A](Self[A]) -> Unit
   unsafe_pop_front[A](Self[A]) -> Unit
 }
+impl[A : Eq] Eq for T[A]
 impl[A : Show] Show for T[A]
 
 // Type aliases

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -39,12 +39,12 @@ pub fn op_div(self : Int16, that : Int16) -> Int16 {
 }
 
 ///|
-pub fn op_equal(self : Int16, that : Int16) -> Bool {
+pub impl Eq for Int16 with op_equal(self, that) {
   self.to_int() == that.to_int()
 }
 
 ///|
-pub fn compare(self : Int16, that : Int16) -> Int {
+pub impl Compare for Int16 with compare(self, that) {
   self.to_int().compare(that.to_int())
 }
 

--- a/int16/int16.mbti
+++ b/int16/int16.mbti
@@ -7,13 +7,13 @@ let min_value : Int16
 
 // Types and methods
 impl Int16 {
-  compare(Int16, Int16) -> Int
   op_add(Int16, Int16) -> Int16
   op_div(Int16, Int16) -> Int16
-  op_equal(Int16, Int16) -> Bool
   op_mul(Int16, Int16) -> Int16
   op_sub(Int16, Int16) -> Int16
 }
+impl Compare for Int16
+impl Eq for Int16
 impl Hash for Int16
 
 // Type aliases

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -210,7 +210,7 @@ fn escape(str : String, escape_slash~ : Bool) -> String {
 
 ///|
 /// Useful for json interpolation
-pub fn to_json(self : JsonValue) -> JsonValue {
+pub impl ToJson for JsonValue with to_json(self) {
   self
 }
 

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -18,9 +18,9 @@ type JsonPath
 impl JsonPath {
   add_index(Self, Int) -> Self
   add_key(Self, String) -> Self
-  output(Self, &Logger) -> Unit
 }
 impl Eq for JsonPath
+impl Show for JsonPath
 
 pub(all) type! ParseError {
   InvalidChar(Position, Char)
@@ -49,10 +49,10 @@ impl Json {
   as_string(Self) -> String?
   item(Self, Int) -> Self?
   stringify(Self, escape_slash~ : Bool = .., indent~ : Int = ..) -> String
-  to_json(Self) -> Self
   value(Self, String) -> Self?
 }
 impl Show for Json
+impl ToJson for Json
 
 // Type aliases
 pub typealias JsonValue = Json

--- a/json/json_path.mbt
+++ b/json/json_path.mbt
@@ -30,7 +30,7 @@ pub fn add_key(self : JsonPath, key : String) -> JsonPath {
 }
 
 ///|
-pub fn output(self : JsonPath, logger : &Logger) -> Unit {
+pub impl Show for JsonPath with output(self, logger) {
   match self {
     Root => logger.write_string("$")
     Key(p, key~) => logger..write_object(p)..write_string(".").write_string(key)

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -54,7 +54,7 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 
 ///|
 /// Tests if two queue cells are equal.
-fn Cell::op_equal[T : Eq](self : Cell[T], other : Cell[T]) -> Bool {
+impl[T : Eq] Eq for Cell[T] with op_equal(self, other) {
   loop self, other {
     Nil, Nil => true
     Cons({ content: x, next: xs }), Cons({ content: y, next: ys }) =>
@@ -69,7 +69,7 @@ fn Cell::op_equal[T : Eq](self : Cell[T], other : Cell[T]) -> Bool {
 
 ///|
 /// Tests if two queues are equal.
-fn op_equal[A : Eq](self : T[A], other : T[A]) -> Bool {
+impl[A : Eq] Eq for T[A] with op_equal(self, other) {
   self.length == other.length && self.first == other.first
 }
 

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -128,13 +128,13 @@ pub fn abs(self : T) -> T {
 
 ///|
 /// Equal to operator for rational numbers.
-pub fn op_equal(self : T, other : T) -> Bool {
+pub impl Eq for T with op_equal(self : T, other : T) -> Bool {
   self.numerator * other.denominator == other.numerator * self.denominator
 }
 
 ///|
 /// Compares two rational numbers.
-pub fn compare(self : T, other : T) -> Int {
+pub impl Compare for T with compare(self : T, other : T) -> Int {
   let left = self.numerator * other.denominator
   let right = other.numerator * self.denominator
   if left < right {

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -14,7 +14,6 @@ type T
 impl T {
   abs(Self) -> Self
   ceil(Self) -> Int64
-  compare(Self, Self) -> Int
   floor(Self) -> Int64
   fract(Self) -> Self
   from_double(Double) -> Self!RationalError //deprecated
@@ -23,13 +22,14 @@ impl T {
   new(Int64, Int64) -> Self? //deprecated
   op_add(Self, Self) -> Self
   op_div(Self, Self) -> Self
-  op_equal(Self, Self) -> Bool
   op_mul(Self, Self) -> Self
   op_sub(Self, Self) -> Self
   reciprocal(Self) -> Self
   to_double(Self) -> Double
   trunc(Self) -> Int64
 }
+impl Compare for T
+impl Eq for T
 impl Show for T
 impl @moonbitlang/core/quickcheck.Arbitrary for T
 

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -23,7 +23,7 @@ pub fn op_get[K : Compare, V](self : T[K, V], key : K) -> V? {
 }
 
 ///|
-pub fn op_equal[K : Eq, V : Eq](self : T[K, V], other : T[K, V]) -> Bool {
+pub impl[K : Eq, V : Eq] Eq for T[K, V] with op_equal(self, other) {
   self.to_array() == other.to_array()
 }
 

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -25,7 +25,6 @@ impl T {
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
   keys[K, V](Self[K, V]) -> Array[K]
-  op_equal[K : Eq, V : Eq](Self[K, V], Self[K, V]) -> Bool
   op_get[K : Compare, V](Self[K, V], K) -> V?
   op_set[K : Compare, V](Self[K, V], K, V) -> Unit
   range[K : Compare, V](Self[K, V], K, K) -> Iter2[K, V]
@@ -34,6 +33,7 @@ impl T {
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
   values[K, V](Self[K, V]) -> Array[V]
 }
+impl[K : Eq, V : Eq] Eq for T[K, V]
 impl[K : Show, V : Show] Show for T[K, V]
 impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[K, V]
 

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -18,7 +18,7 @@ fn new_node[K, V](key : K, value : V) -> Node[K, V] {
 }
 
 ///|
-fn Node::op_equal[K : Eq, V](self : Node[K, V], other : Node[K, V]) -> Bool {
+impl[K : Eq, V] Eq for Node[K, V] with op_equal(self, other) {
   self.key == other.key
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -319,7 +319,7 @@ pub fn disjoint[V : Compare](self : T[V], src : T[V]) -> Bool {
 // General collection operations
 
 ///|
-pub fn op_equal[V : Compare](self : T[V], other : T[V]) -> Bool {
+pub impl[V : Compare] Eq for T[V] with op_equal(self, other) {
   self.to_array() == other.to_array()
 }
 

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -30,7 +30,6 @@ impl T {
   intersection[V : Compare](Self[V], Self[V]) -> Self[V]
   is_empty[V : Compare](Self[V]) -> Bool
   iter[V](Self[V]) -> Iter[V]
-  op_equal[V : Compare](Self[V], Self[V]) -> Bool
   range[V : Compare](Self[V], V, V) -> Iter[V]
   remove[V : Compare](Self[V], V) -> Unit
   size[V : Compare](Self[V]) -> Int
@@ -38,6 +37,7 @@ impl T {
   to_array[V](Self[V]) -> Array[V]
   union[V : Compare](Self[V], Self[V]) -> Self[V]
 }
+impl[V : Compare] Eq for T[V]
 impl[V : Show] Show for T[V]
 impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X]
 

--- a/sorted_set/utils.mbt
+++ b/sorted_set/utils.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn Node::op_equal[V : Eq](self : Node[V], other : Node[V]) -> Bool {
+impl[V : Eq] Eq for Node[V] with op_equal(self, other) {
   self.value == other.value
 }
 

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -94,7 +94,7 @@ pub fn concat(strings : Array[String], separator~ : String = "") -> String {
 /// Compare two strings.
 /// String with longer length is bigger.
 /// strings of the same length are compared in lexicalgraphic order.
-pub fn compare(self : String, other : String) -> Int {
+pub impl Compare for String with compare(self, other) {
   let len = self.length()
   match len.compare(other.length()) {
     0 => {

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -27,7 +27,6 @@ impl StringView {
 impl Show for StringView
 
 impl String {
-  compare(String, String) -> Int
   concat(Array[String], separator~ : String = ..) -> String
   contains(String, String) -> Bool
   contains_char(String, Char) -> Bool
@@ -69,6 +68,7 @@ impl String {
   trim_space(String) -> String
   trim_start(String, String) -> String
 }
+impl Compare for String
 
 // Type aliases
 pub typealias View = StringView

--- a/uint16/uint16.mbt
+++ b/uint16/uint16.mbt
@@ -39,12 +39,12 @@ pub fn op_div(self : UInt16, that : UInt16) -> UInt16 {
 }
 
 ///|
-pub fn op_equal(self : UInt16, that : UInt16) -> Bool {
+pub impl Eq for UInt16 with op_equal(self, that) {
   self.to_int() == that.to_int()
 }
 
 ///|
-pub fn compare(self : UInt16, that : UInt16) -> Int {
+pub impl Compare for UInt16 with compare(self, that) {
   self.to_int().compare(that.to_int())
 }
 

--- a/uint16/uint16.mbti
+++ b/uint16/uint16.mbti
@@ -7,13 +7,13 @@ let min_value : UInt16
 
 // Types and methods
 impl UInt16 {
-  compare(UInt16, UInt16) -> Int
   op_add(UInt16, UInt16) -> UInt16
   op_div(UInt16, UInt16) -> UInt16
-  op_equal(UInt16, UInt16) -> Bool
   op_mul(UInt16, UInt16) -> UInt16
   op_sub(UInt16, UInt16) -> UInt16
 }
+impl Compare for UInt16
+impl Eq for UInt16
 impl Hash for UInt16
 
 // Type aliases


### PR DESCRIPTION
In the future, we plan to remove the behavior of implicitly implementing a trait via regular methods, and favor explicit `impl` declaration instead, for several reasons:

1. `impl` can be called via dot syntax, so they are no harder to use than methods
2. explicit `impl` is more IDE friendly, for example it allows searching for all implementation of a trait/type
3. keeping only explicit `impl` makes the trait system conceptually simpler

This PR migrates all trait implementation on core to explicit `impl`. The compiler may emit a warning on implementing traits with methods in the future.