### PR TITLE
fix the order of elements in `from_iter`

### DIFF
--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -1090,7 +1090,15 @@ pub fn iter2[A](self : T[A]) -> Iter2[Int, A] {
 }
 
 ///|
+/// Convert the iterator into a list. Preserves order of elements.
+/// This function is tail-recursive, but consumes 2*n memory. 
+/// If the order of elements is not important, use `from_iter_rev` instead.
 pub fn from_iter[A](iter : Iter[A]) -> T[A] {
+  iter.fold(init=Nil, fn(acc, e) { Cons(e, acc) }).rev()
+}
+
+///|
+pub fn from_iter_rev[A](iter : Iter[A]) -> T[A] {
   iter.fold(init=Nil, fn(acc, e) { Cons(e, acc) })
 }
 

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -10,6 +10,8 @@ fn from_array[A](Array[A]) -> T[A]
 
 fn from_iter[A](Iter[A]) -> T[A]
 
+fn from_iter_rev[A](Iter[A]) -> T[A]
+
 fn from_json[A : @json.FromJson](Json) -> T[A]!@json.JsonDecodeError
 
 fn of[A](FixedArray[A]) -> T[A]

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -660,7 +660,12 @@ test "op_add" {
 
 ///|
 test "from_iter multiple elements iter" {
-  inspect!(@list.from_iter([1, 2, 3].iter()), content="@list.of([3, 2, 1])")
+  inspect!(@list.from_iter([1, 2, 3].iter()), content="@list.of([1, 2, 3])")
+}
+
+///|
+test "from_iter_rev multiple elements iter" {
+  inspect!(@list.from_iter_rev([1, 2, 3].iter()), content="@list.of([3, 2, 1])")
 }
 
 ///|


### PR DESCRIPTION
The original implementation reverses the order. This PR fixes the order, and provides an efficient `from_iter_rev` for the use case where order is irrelevant. 