### PR TITLE
fix: builtin package should not contain unqualified method

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -780,7 +780,7 @@ pub fn Iter::collect[T](self : Iter[T]) -> Array[T] {
 
 ///|
 /// Collects the elements of the iterator into a string.
-pub fn join(self : Iter[String], sep : String) -> String {
+pub fn Iter::join(self : Iter[String], sep : String) -> String {
   let buf = StringBuilder::new()
   let mut first = true
   for str in self {

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -71,7 +71,7 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 /// # Panics
 ///
 /// @alert unsafe "Panics if the index is out of bounds."
-pub fn charcode_at(self : String, index : Int) -> Int {
+pub fn String::charcode_at(self : String, index : Int) -> Int {
   guard index >= 0 && index < self.length() else {
     abort("index out of bounds")
   }
@@ -97,7 +97,7 @@ pub fn charcode_at(self : String, index : Int) -> Int {
 /// Panics if:
 /// - The index is out of bounds
 /// - The string contains an invalid surrogate pair
-pub fn codepoint_at(self : String, index : Int) -> Char {
+pub fn String::codepoint_at(self : String, index : Int) -> Char {
   let charcode_len = self.charcode_length()
   guard index >= 0 && index < charcode_len else { abort("index out of bounds") }
   for char_count = 0, utf16_offset = 0
@@ -144,7 +144,7 @@ pub fn codepoint_at(self : String, index : Int) -> Char {
 /// inspect!(s.codepoint_length(), content = "6"); // 6 actual characters
 /// inspect!(s.charcode_length(), content = "7");  // 5 ASCII chars + 2 surrogate pairs
 /// ```
-pub fn codepoint_length(self : String) -> Int {
+pub fn String::codepoint_length(self : String) -> Int {
   let charcode_len = self.charcode_length()
   for char_count = 0, len = 0
       char_count < charcode_len

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -65,37 +65,37 @@ test "panic codepoint_at2" {
 ///|
 test "panic charcode_at with negative index" {
   let s = "Hello"
-  ignore(charcode_at(s, -1))
+  ignore(s.charcode_at(-1))
 }
 
 ///|
 test "charcode_at with valid index" {
   let s = "Hello"
-  inspect!(charcode_at(s, 0), content="72")
+  inspect!(s.charcode_at(0), content="72")
 }
 
 ///|
 test "codepoint_at regular character at end of string" {
   let s = "Hello"
-  inspect!(codepoint_at(s, 4), content="o")
+  inspect!(s.codepoint_at(4), content="o")
 }
 
 ///|
 test "codepoint_at emoji" {
   let s = "👋"
-  inspect!(codepoint_at(s, 0), content="👋")
+  inspect!(s.codepoint_at(0), content="👋")
 }
 
 ///|
 test "codepoint_length basic" {
   let str = "hello"
-  inspect!(codepoint_length(str), content="5")
+  inspect!(str.codepoint_length(), content="5")
 }
 
 ///|
 test "codepoint_length with surrogate pairs" {
   let str = "Hello🤣"
-  inspect!(codepoint_length(str), content="6")
+  inspect!(str.codepoint_length(), content="6")
 }
 
 ///|
@@ -116,5 +116,5 @@ test "panic codepoint_length with invalid surrogate pair" {
       'a',
     ], // invalid trailing surrogate
   )
-  ignore(@builtin.codepoint_length(s))
+  ignore(s.codepoint_length())
 }


### PR DESCRIPTION
unqualified methods (declared with `fn f(self : T, ..)`) will be included in the toplevel scope of the package. If the package is `@builtin`, it means everyone can call the method unqualified, which is probably undesirable. So `@builtin` should not contain unqualified method.

This PR fixes several unqualified methods in `@builtin` and make them qualified (`T::method_name`)