### PR TITLE
improve @immut/array::from_iter

### DIFF
--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -126,46 +126,9 @@ pub fn from_iter[A](iter : Iter[A]) -> T[A] {
   if not(buf.is_empty()) {
     leaves.push(FixedArray::from_array(buf))
   }
-  fn dfs(leaves : ArrayView[FixedArray[A]], cap) -> Tree[A] {
-    if cap == branching_factor {
-      Leaf(leaves[0])
-    } else if leaves.length() <= branching_factor {
-      let arr = FixedArray::make(leaves.length(), Empty)
-      for i in 0..<leaves.length() {
-        arr[i] = Leaf(leaves[i])
-      }
-      Node(arr, None)
-    } else {
-      let len = leaves.length() * branching_factor
-      let child_cap = cap / branching_factor
-      let quot = len / child_cap
-      let rem = len % child_cap
-      let times = child_cap / branching_factor
-      let arr = if rem == 0 {
-        FixedArray::makei(quot, fn(i) {
-          dfs(leaves[i * times:(i + 1) * times], child_cap)
-        })
-      } else {
-        let arr = FixedArray::make(quot + 1, Tree::Empty)
-        for i in 0..<quot {
-          arr[i] = dfs(leaves[i * times:(i + 1) * times], child_cap)
-        }
-        arr[quot] = dfs(leaves[times * quot:], child_cap)
-        arr
-      }
-      Node(arr, None)
-    }
-  }
-
   let size = leaves.fold(init=0, fn(acc, xs) { acc + xs.length() })
-  let mut cap = branching_factor
-  let mut depth = 0
-  while cap < size {
-    cap *= branching_factor
-    depth += 1
-  }
-  let shift = num_bits * depth
-  let tree = if size == 0 { Empty } else { dfs(leaves[:], cap) }
+  let (shift, cap) = shift_cap_of_size(size)
+  let tree = if size == 0 { Empty } else { from_leaves(leaves[:], cap) }
   { shift, tree, size }
 }
 

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -114,7 +114,59 @@ pub fn from_array[A](arr : Array[A]) -> T[A] {
 
 ///|
 pub fn from_iter[A](iter : Iter[A]) -> T[A] {
-  iter.fold(init=new(), fn(arr, e) { arr.push(e) })
+  let buf = Array::new(capacity=branching_factor)
+  let leaves = []
+  iter.each(fn(x) {
+    if not(buf.length() < branching_factor) {
+      leaves.push(FixedArray::from_array(buf))
+      buf.clear()
+    }
+    buf.push(x)
+  })
+  if not(buf.is_empty()) {
+    leaves.push(FixedArray::from_array(buf))
+  }
+  fn dfs(leaves : ArrayView[FixedArray[A]], cap) -> Tree[A] {
+    if cap == branching_factor {
+      Leaf(leaves[0])
+    } else if leaves.length() <= branching_factor {
+      let arr = FixedArray::make(leaves.length(), Empty)
+      for i in 0..<leaves.length() {
+        arr[i] = Leaf(leaves[i])
+      }
+      Node(arr, None)
+    } else {
+      let len = leaves.length() * branching_factor
+      let child_cap = cap / branching_factor
+      let quot = len / child_cap
+      let rem = len % child_cap
+      let times = child_cap / branching_factor
+      let arr = if rem == 0 {
+        FixedArray::makei(quot, fn(i) {
+          dfs(leaves[i * times:(i + 1) * times], child_cap)
+        })
+      } else {
+        let arr = FixedArray::make(quot + 1, Tree::Empty)
+        for i in 0..<quot {
+          arr[i] = dfs(leaves[i * times:(i + 1) * times], child_cap)
+        }
+        arr[quot] = dfs(leaves[times * quot:], child_cap)
+        arr
+      }
+      Node(arr, None)
+    }
+  }
+
+  let size = leaves.fold(init=0, fn(acc, xs) { acc + xs.length() })
+  let mut cap = branching_factor
+  let mut depth = 0
+  while cap < size {
+    cap *= branching_factor
+    depth += 1
+  }
+  let shift = num_bits * depth
+  let tree = if size == 0 { Empty } else { dfs(leaves[:], cap) }
+  { shift, tree, size }
 }
 
 //-----------------------------------------------------------------------------

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -114,17 +114,28 @@ pub fn from_array[A](arr : Array[A]) -> T[A] {
 
 ///|
 pub fn from_iter[A](iter : Iter[A]) -> T[A] {
-  let buf = Array::new(capacity=branching_factor)
+  let mut buf : FixedArray[A] = []
+  let mut index = 0
   let leaves = []
   iter.each(fn(x) {
-    if not(buf.length() < branching_factor) {
-      leaves.push(FixedArray::from_array(buf))
-      buf.clear()
+    if index == 0 {
+      buf = FixedArray::make(branching_factor, x)
+      index += 1
+    } else if index < branching_factor {
+      buf[index] = x
+      index += 1
+    } else {
+      leaves.push(buf)
+      index = 1
+      buf = FixedArray::make(branching_factor, x)
     }
-    buf.push(x)
   })
-  if not(buf.is_empty()) {
-    leaves.push(FixedArray::from_array(buf))
+  if index == branching_factor {
+    leaves.push(buf)
+  } else if index > 0 {
+    let res = FixedArray::make(index, buf[0])
+    buf.blit_to(res, len=index)
+    leaves.push(res)
   }
   let size = leaves.fold(init=0, fn(acc, xs) { acc + xs.length() })
   let (shift, cap) = shift_cap_of_size(size)

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -208,6 +208,14 @@ test "from_iter multiple elements iter" {
     @array.from_iter([1, 2, 3].iter()),
     content="@immut/array.of([1, 2, 3])",
   )
+  inspect!(
+    (0).until(32) |> @array.from_iter(),
+    content="@immut/array.of([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])",
+  )
+  inspect!(
+    (0).until(33) |> @array.from_iter(),
+    content="@immut/array.of([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32])",
+  )
 }
 
 ///|


### PR DESCRIPTION
> That is exactly what Clojure’s persistent vector does, and it is done through balanced, ordered trees.

persistent vector is implemented using balanced tree and share Path during update/insert/remove, using Array as buffer avoids creating a lot of @immut/array[T].

- #1583