### PR TITLE
fix: warning when run moon test --doc

### DIFF
--- a/immut/list/deprecated.mbt
+++ b/immut/list/deprecated.mbt
@@ -27,7 +27,7 @@ pub fn T::from_json[A : @json.FromJson](
 /// # Example
 ///
 /// ```
-/// assert_eq!(@list.of([1, 2, 3]).equal(@list.of([1, 2, 3])), true)
+/// assert_eq!(@list.of([1, 2, 3]) == @list.of([1, 2, 3]), true)
 /// ```
 /// @alert deprecated "use `==` instead"
 pub fn equal[A : Eq](self : T[A], other : T[A]) -> Bool {

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -70,28 +70,7 @@ fn Decimal::from_int64_priv(v : Int64) -> Decimal {
   Decimal::new_priv()..assign(v)
 }
 
-///|
-/// Parse a string into a decimal number. The string must contain at least one of:
-/// - An integer part (decimal digits)
-/// - A decimal point followed by a fractional part (decimal digits)
-/// - An exponent part ('e' or 'E' followed by an optional sign and decimal digits)
-///
-/// The string may optionally start with a sign ('+' or '-').
-/// For readability, underscores may appear between digits.
-///
-/// Examples:
-/// ```
-/// inspect!(parse_decimal!("123"), content="123")
-/// inspect!(parse_decimal!("12.34"), content="12.34")
-/// inspect!(parse_decimal!(".123"), content="0.123")
-/// inspect!(parse_decimal!("1e5"), content="100000")
-/// inspect!(parse_decimal!("1.2e-3"), content="0.0012")
-/// inspect!(parse_decimal!("1_234.5"), content="1234.5")
-/// ```
-///
-/// An exponent value exp scales the mantissa (significand) by 10^exp.
-/// For example, "1.23e2" represents 1.23 × 10² = 123.
-/// @alert deprecated "use `@strconv.parse_double` instead"
+///| @alert deprecated "use `@strconv.parse_double` instead"
 pub fn parse_decimal(str : String) -> Decimal!StrConvError {
   parse_decimal_from_view!(str[:])
 }


### PR DESCRIPTION
`parse_decimal` was deprecated, not need detailed documentation