### PR TITLE
refactor: @immut/array.make and @immut/array.makei

### DIFF
--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -25,13 +25,47 @@ pub fn new[A]() -> T[A] {
 ///|
 /// Create a persistent array with a given length and value.
 pub fn make[A](len : Int, value : A) -> T[A] {
-  new_by_leaves(len, fn(_s, l) { FixedArray::make(l, value) })
+  let quot = len / branching_factor
+  let rem = len % branching_factor
+  let leaves = if rem == 0 {
+    Array::make(quot, FixedArray::make(branching_factor, value))
+  } else {
+    let arr : Array[FixedArray[A]] = Array::make(quot + 1, [])
+    for k in 0..<quot {
+      arr[k] = FixedArray::make(branching_factor, value)
+    }
+    arr[quot] = FixedArray::make(rem, value)
+    arr
+  }
+  let size = len
+  let (shift, cap) = shift_cap_of_size(size)
+  let tree = if size == 0 { Empty } else { from_leaves(leaves[:], cap) }
+  { shift, tree, size }
 }
 
 ///|
 /// Create a persistent array with a given length and a function to generate values.
 pub fn makei[A](len : Int, f : (Int) -> A) -> T[A] {
-  new_by_leaves(len, fn(s, l) { FixedArray::makei(l, fn(i) { f(s + i) }) })
+  let quot = len / branching_factor
+  let rem = len % branching_factor
+  let leaves = if rem == 0 {
+    Array::makei(quot, fn(k) {
+      FixedArray::makei(branching_factor, fn(i) { f(k * branching_factor + i) })
+    })
+  } else {
+    let arr : Array[FixedArray[A]] = Array::make(quot + 1, [])
+    for k in 0..<quot {
+      arr[k] = FixedArray::makei(branching_factor, fn(i) {
+        f(k * branching_factor + i)
+      })
+    }
+    arr[quot] = FixedArray::makei(rem, fn(i) { f(quot * branching_factor + i) })
+    arr
+  }
+  let size = len
+  let (shift, cap) = shift_cap_of_size(size)
+  let tree = if size == 0 { Empty } else { from_leaves(leaves[:], cap) }
+  { shift, tree, size }
 }
 
 ///|
@@ -328,41 +362,47 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 //-----------------------------------------------------------------------------
 
 ///|
-fn new_by_leaves[A](len : Int, gen_leaf : (Int, Int) -> FixedArray[A]) -> T[A] {
-  fn tree(cap, len, s) -> Tree[A] {
-    if cap == branching_factor {
-      Leaf(gen_leaf(s, len))
-    } else {
-      let child_cap = cap / branching_factor
-      let part = len / child_cap
-      let (child_count, last_child_len) = match len % child_cap {
-        0 => (part, child_cap)
-        r => (part + 1, r)
-      }
-      fn child(k) {
-        let i = s + k * child_cap
-        let len = if k + 1 == child_count { last_child_len } else { child_cap }
-        tree(cap / branching_factor, len, i)
-      }
-
-      // Use None here because the implementation of `new_by_leaves` ensures that the tree is full
-      // and we can use radix indexing.
-      Node(FixedArray::makei(child_count, child), None)
+fn from_leaves[A](leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
+  if cap == branching_factor {
+    Leaf(leaves[0])
+  } else if leaves.length() <= branching_factor {
+    let arr = FixedArray::make(leaves.length(), Empty)
+    for i in 0..<leaves.length() {
+      arr[i] = Leaf(leaves[i])
     }
-  }
-
-  if len == 0 {
-    new()
+    Node(arr, None)
   } else {
-    let (cap, shift) = loop len, branching_factor, 1 {
-      len, m_pow, depth =>
-        match len <= m_pow {
-          false => continue len, m_pow * branching_factor, depth + 1
-          true => (m_pow, (depth - 1) * num_bits)
-        }
+    let len = leaves.length() * branching_factor
+    let child_cap = cap / branching_factor
+    let quot = len / child_cap
+    let rem = len % child_cap
+    let times = child_cap / branching_factor
+    let arr = if rem == 0 {
+      FixedArray::makei(quot, fn(i) {
+        from_leaves(leaves[i * times:(i + 1) * times], child_cap)
+      })
+    } else {
+      let arr = FixedArray::make(quot + 1, Tree::Empty)
+      for i in 0..<quot {
+        arr[i] = from_leaves(leaves[i * times:(i + 1) * times], child_cap)
+      }
+      arr[quot] = from_leaves(leaves[times * quot:], child_cap)
+      arr
     }
-    { shift, tree: tree(cap, len, 0), size: len }
+    Node(arr, None)
   }
+}
+
+///|
+fn shift_cap_of_size(size : Int) -> (Int, Int) {
+  let mut cap = branching_factor
+  let mut depth = 0
+  while cap < size {
+    cap *= branching_factor
+    depth += 1
+  }
+  let shift = num_bits * depth
+  (shift, cap)
 }
 
 ///|

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -30,10 +30,10 @@ pub fn make[A](len : Int, value : A) -> T[A] {
   let leaves = if rem == 0 {
     Array::make(quot, FixedArray::make(branching_factor, value))
   } else {
-    let arr : Array[FixedArray[A]] = Array::make(quot + 1, [])
-    for k in 0..<quot {
-      arr[k] = FixedArray::make(branching_factor, value)
-    }
+    let arr : Array[FixedArray[A]] = Array::make(
+      quot + 1,
+      FixedArray::make(branching_factor, value),
+    )
     arr[quot] = FixedArray::make(rem, value)
     arr
   }

--- a/immut/array/array_wbtest.mbt
+++ b/immut/array/array_wbtest.mbt
@@ -13,29 +13,6 @@
 // limitations under the License.
 
 ///|
-test "new_by_leaves" {
-  let full : T[Int] = new_by_leaves(branching_factor_power(2), fn(_s, l) {
-    FixedArray::make(l, 1)
-  })
-  let full_arr = FixedArray::make(branching_factor_power(2), 1)
-  check_fixedarray_eq!(full_arr, full)
-  let e : T[Int] = new_by_leaves(0, fn(_s, _l) { abort("never reach") })
-  let v = new_by_leaves(5, fn(_s, l) { FixedArray::make(l, 1) })
-  let v2 = new_by_leaves(33, fn(_s, l) { FixedArray::make(l, 10) })
-  inspect!(e, content="@immut/array.of([])")
-  inspect!(v, content="@immut/array.of([1, 1, 1, 1, 1])")
-  inspect!(
-    v2,
-    content="@immut/array.of([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])",
-  )
-  let v3 = new_by_leaves(32, fn(_s, l) { FixedArray::make(l, 10) })
-  inspect!(
-    v3,
-    content="@immut/array.of([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])",
-  )
-}
-
-///|
 test "mix" {
   let mut v = new()
   inspect!(v.tree.is_empty_tree(), content="true")

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -128,18 +128,6 @@ fn check_array_eq(a : Array[Int], t : T[Int]) -> Unit! {
   }
 }
 
-///|  
-/// Use this function to check if the FixedArray and the @immut/array are equal.
-/// If we `inspect` the array, it will raise an error if the arrays are too long.
-/// I guess that's because it exceeds the heap limit of the VM.
-fn check_fixedarray_eq(a : FixedArray[Int], t : T[Int]) -> Unit! {
-  assert_eq!(a.length(), t.size)
-  let len = t.size
-  for i in 0..<len {
-    assert_eq!(t[i], a[i])
-  }
-}
-
 ///|
 /// Generate a random array of length `n`.
 fn random_array(n : Int) -> Array[Int] {


### PR DESCRIPTION
avoid use closure

And this implementation will be a bit simpler than the previous new_by_leaves, and can also be reused by from_iter

- #1583 