### PR TITLE
feat(iter): add `nth`

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -228,6 +228,7 @@ impl Iter {
   map_option[A, B](Self[A], (A) -> B?) -> Self[B] //deprecated
   map_while[A, B](Self[A], (A) -> B?) -> Self[B]
   new[T](((T) -> IterResult) -> IterResult) -> Self[T]
+  nth[T](Self[T], Int) -> T?
   op_add[T](Self[T], Self[T]) -> Self[T]
   op_as_view[A](Self[A], start~ : Int = .., end? : Int) -> Self[A]
   peek[T](Self[T]) -> T?

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -924,3 +924,10 @@ pub fn Iter::contains[A : Eq](self : Iter[A], value : A) -> Bool {
     false
   }
 }
+
+///|
+/// Returns the nth element of the iterator, or `None` if the iterator is
+/// shorter than `n` elements.
+pub fn Iter::nth[T](self : Iter[T], n : Int) -> T? {
+  self.drop(n).head()
+}

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -616,3 +616,17 @@ test "@builtin.join/multiple_elements_without_separator" {
   let iter : Iter[String] = ["A", "B", "C"].iter()
   inspect!(iter.join(""), content="ABC")
 }
+
+///|
+test "Iter::nth" {
+  let it = [1, 2, 3, 4, 5].iter()
+  inspect!(it.nth(2), content="Some(3)")
+  inspect!(it.nth(4), content="Some(5)")
+  inspect!(it.nth(5), content="None")
+  inspect!(it.concat(it).nth(5), content="Some(1)")
+  inspect!(it.concat(it).nth(10), content="None")
+  inspect!(it.drop(1).nth(3), content="Some(5)")
+  inspect!(it.drop(1).nth(4), content="None")
+  inspect!(it.take(1).nth(1), content="None")
+  inspect!(it.take(2).nth(1), content="Some(2)")
+}


### PR DESCRIPTION
I'm making some String methods deprecated. We currently have `codepoint_at(i)` to get the i-th codepoint in a string and this should be changed to `str.iter().nth(i)`.