### PR TITLE
Breaking change: indexing string returns `Int` instead of `Char`

### DIFF
--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -1042,20 +1042,23 @@ pub fn BigInt::from_string(input : String) -> BigInt {
   if len == 0 {
     abort("empty string")
   }
-  let sign : Sign = if input[0] == '-' { Negative } else { Positive }
+  let sign : Sign = if Char::from_int(input.unsafe_charcode_at(0)) == '-' {
+    Negative
+  } else {
+    Positive
+  }
   let mut b_len = (
       (len.to_double() / decimal_ratio).to_unchecked_int() + 1 + radix_bit_len
     ) /
     radix_bit_len +
     1
   let b = FixedArray::make(b_len, 0U)
-  for i = (match sign {
-          Negative => 1
-          Positive => 0
-        })
-      i < input.length()
-      i = i + 1 {
-    let x = input[i].to_int() - 48 // ASCII value of '0'
+  for
+    i in (match sign {
+      Negative => 1
+      Positive => 0
+    })..<input.length() {
+    let x = input.unsafe_charcode_at(i) - 48 // ASCII value of '0'
     if x < 0 || x > 9 {
       abort("invalid character")
     }
@@ -1108,8 +1111,7 @@ pub fn BigInt::from_string(input : String) -> BigInt {
 /// ```
 pub fn BigInt::from_hex(input : String) -> BigInt {
   // WARN: this implementation assumes that `radix_bit_len` is a multiple of 4.
-  fn char_from_hex(c : Char) -> UInt {
-    let x = c.to_int()
+  fn char_from_hex(x : Int) -> UInt {
     if x >= 48 && x <= 57 {
       // ASCII value of '0'
       (x - 48).reinterpret_as_uint()
@@ -1128,7 +1130,7 @@ pub fn BigInt::from_hex(input : String) -> BigInt {
   if len == 0 {
     abort("empty string")
   }
-  let (sign, number_len) = if input[0] == '-' {
+  let (sign, number_len) = if Char::from_int(input.unsafe_charcode_at(0)) == '-' {
     (Negative, len - 1)
   } else {
     (Positive, len)
@@ -1141,13 +1143,14 @@ pub fn BigInt::from_hex(input : String) -> BigInt {
   if mod != 0 {
     let start = len - quotient * nb_char - mod
     for i in 0..<mod {
-      b[b_len - 1] = (b[b_len - 1] << 4) | char_from_hex(input[start + i])
+      b[b_len - 1] = (b[b_len - 1] << 4) |
+        char_from_hex(input.unsafe_charcode_at(start + i))
     }
   }
   for i in 0..<quotient {
     let start = len - (i + 1) * nb_char
     for j in 0..<nb_char {
-      b[i] = (b[i] << 4) | char_from_hex(input[start + j])
+      b[i] = (b[i] << 4) | char_from_hex(input.unsafe_charcode_at(start + j))
     }
   }
   while b[b_len - 1] == 0 && b_len > 1 {

--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -1042,7 +1042,7 @@ pub fn BigInt::from_string(input : String) -> BigInt {
   if len == 0 {
     abort("empty string")
   }
-  let sign : Sign = if Char::from_int(input.unsafe_charcode_at(0)) == '-' {
+  let sign : Sign = if input.unsafe_charcode_at(0) == '-' {
     Negative
   } else {
     Positive
@@ -1058,7 +1058,7 @@ pub fn BigInt::from_string(input : String) -> BigInt {
       Negative => 1
       Positive => 0
     })..<input.length() {
-    let x = input.unsafe_charcode_at(i) - 48 // ASCII value of '0'
+    let x = input.unsafe_charcode_at(i) - '0'
     if x < 0 || x > 9 {
       abort("invalid character")
     }
@@ -1130,7 +1130,7 @@ pub fn BigInt::from_hex(input : String) -> BigInt {
   if len == 0 {
     abort("empty string")
   }
-  let (sign, number_len) = if Char::from_int(input.unsafe_charcode_at(0)) == '-' {
+  let (sign, number_len) = if input.unsafe_charcode_at(0) == '-' {
     (Negative, len - 1)
   } else {
     (Positive, len)

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -640,10 +640,12 @@ impl Double {
 
 impl String {
   charcode_at(String, Int) -> Int
+  #deprecated
   charcode_length(String) -> Int
   codepoint_at(String, Int) -> Char
   codepoint_length(String) -> Int
   escape(String) -> String
+  #deprecated
   get(String, Int) -> Char
   length(String) -> Int
   make(Int, Char) -> String

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -192,7 +192,7 @@ pub fn FixedArray::blit_from_string(
   guard length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
   let end_str_offset = str_offset + length
   for i = str_offset, j = bytes_offset; i < end_str_offset; i = i + 1, j = j + 2 {
-    let c = str[i].to_uint()
+    let c = str.unsafe_charcode_at(i).reinterpret_as_uint()
     self[j] = (c & 0xff).to_byte()
     self[j + 1] = (c >> 8).to_byte()
   }

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -363,7 +363,7 @@ pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
 /// ```
 pub fn Hasher::combine_string(self : Hasher, value : String) -> Unit {
   for i in 0..<value.length() {
-    self.combine_uint(value[i].to_uint())
+    self.combine_uint(value.unsafe_charcode_at(i).reinterpret_as_uint())
   }
 }
 

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1745,25 +1745,7 @@ pub fn FixedArray::make[T](len : Int, init : T) -> FixedArray[T] = "%fixedarray.
 pub fn String::length(self : String) -> Int = "%string_length"
 
 ///|
-/// Returns the length of the string in UTF-16 code units. This corresponds to
-/// the number of 16-bit elements needed to store the string's contents.
-///
-/// Parameters:
-///
-/// * `string` : The string whose length is to be determined.
-///
-/// Returns the number of UTF-16 code units in the string. Note that this may not
-/// equal the number of Unicode characters (code points) in the string, as some
-/// characters (like emojis) require two UTF-16 code units.
-///
-/// Example:
-///
-/// ```moonbit
-/// test "String::charcode_length" {
-///   let s = "Hello🤣"
-///   inspect!(s.charcode_length(), content="7") // 5 ASCII chars + 2 surrogate pairs for emoji
-/// }
-/// ```
+#deprecated("use `length` instead")
 pub fn String::charcode_length(self : String) -> Int = "%string_length"
 
 ///|
@@ -1796,6 +1778,7 @@ pub fn String::charcode_length(self : String) -> Int = "%string_length"
 /// ```
 ///
 /// @alert unsafe "Panic if index is out of bounds"
+#deprecated("use `charcode_at` instead")
 pub fn String::op_get(self : String, idx : Int) -> Char = "%string_get"
 
 ///|
@@ -1826,6 +1809,7 @@ pub fn String::op_get(self : String, idx : Int) -> Char = "%string_get"
 ///   ignore(s.get(5)) // Index equals length
 /// }
 /// ```
+#deprecated("use `charcode_at` instead")
 pub fn String::get(self : String, idx : Int) -> Char = "%string_get"
 
 ///|
@@ -1852,7 +1836,7 @@ pub fn String::get(self : String, idx : Int) -> Char = "%string_get"
 /// ```
 ///
 /// @alert unsafe "Panic if index is out of bounds."
-pub fn String::unsafe_charcode_at(self : String, idx : Int) -> Int = "%string_get"
+pub fn String::unsafe_charcode_at(self : String, idx : Int) -> Int = "%string.unsafe_get"
 
 ///|
 /// Concatenates two strings, creating a new string that contains all characters

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1778,7 +1778,6 @@ pub fn String::charcode_length(self : String) -> Int = "%string_length"
 /// ```
 ///
 /// @alert unsafe "Panic if index is out of bounds"
-#deprecated("use `charcode_at` instead")
 pub fn String::op_get(self : String, idx : Int) -> Char = "%string_get"
 
 ///|

--- a/builtin/output.mbt
+++ b/builtin/output.mbt
@@ -31,7 +31,9 @@ fn Int64::output(self : Int64, logger : &Logger, radix~ : Int = 10) -> Unit {
     if num2 != 0L {
       write_digits(num2)
     }
-    logger.write_char(ALPHABET[abs(num % radix).to_int()])
+    logger.write_char(
+      Char::from_int(ALPHABET.charcode_at(abs(num % radix).to_int())),
+    )
   }
 
   write_digits(abs(self))
@@ -55,7 +57,7 @@ fn Int::output(self : Int, logger : &Logger, radix~ : Int = 10) -> Unit {
     if num2 != 0 {
       write_digits(num2)
     }
-    logger.write_char(ALPHABET[abs(num % radix)])
+    logger.write_char(Char::from_int(ALPHABET.charcode_at(abs(num % radix))))
   }
 
   write_digits(abs(self))
@@ -69,7 +71,9 @@ fn UInt::output(self : UInt, logger : &Logger, radix~ : Int = 10) -> Unit {
     if num2 != 0U {
       write_digits(num2)
     }
-    logger.write_char(ALPHABET[(num % radix).reinterpret_as_int()])
+    logger.write_char(
+      Char::from_int(ALPHABET.charcode_at((num % radix).reinterpret_as_int())),
+    )
   }
 
   write_digits(self)
@@ -83,7 +87,9 @@ fn UInt64::output(self : UInt64, logger : &Logger, radix~ : Int = 10) -> Unit {
     if num2 != 0UL {
       write_digits(num2)
     }
-    logger.write_char(ALPHABET[(num % radix).to_int()])
+    logger.write_char(
+      Char::from_int(ALPHABET.charcode_at((num % radix).to_int())),
+    )
   }
 
   write_digits(self)

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -103,11 +103,10 @@ pub impl Show for String with output(self, logger) {
   }
 
   for i in 0..<self.length() {
-    let c = self.unsafe_charcode_at(i) |> Char::from_int
-    match c {
-      '"' | '\\' => {
+    match self.unsafe_charcode_at(i) {
+      '"' | '\\' as c => {
         flush_segment(i)
-        logger..write_char('\\').write_char(c)
+        logger..write_char('\\').write_char(Char::from_int(c))
       }
       '\n' => {
         flush_segment(i)
@@ -125,8 +124,7 @@ pub impl Show for String with output(self, logger) {
         flush_segment(i)
         logger.write_string("\\t")
       }
-      _ => {
-        let code = c.to_int()
+      code =>
         if code < 0x20 {
           flush_segment(i)
           logger
@@ -135,7 +133,6 @@ pub impl Show for String with output(self, logger) {
           ..write_char(to_hex_digit(code / 16))
           .write_char(to_hex_digit(code % 16))
         }
-      }
     }
   }
   flush_segment(self.length())

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -103,7 +103,7 @@ pub impl Show for String with output(self, logger) {
   }
 
   for i in 0..<self.length() {
-    let c = self[i]
+    let c = self.unsafe_charcode_at(i) |> Char::from_int
     match c {
       '"' | '\\' => {
         flush_segment(i)

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -71,12 +71,7 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 /// # Panics
 ///
 /// @alert unsafe "Panics if the index is out of bounds."
-pub fn String::charcode_at(self : String, index : Int) -> Int {
-  guard index >= 0 && index < self.length() else {
-    abort("index out of bounds")
-  }
-  self.unsafe_charcode_at(index)
-}
+pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 
 ///|
 /// Returns the Unicode code point at the given index.
@@ -98,7 +93,7 @@ pub fn String::charcode_at(self : String, index : Int) -> Int {
 /// - The index is out of bounds
 /// - The string contains an invalid surrogate pair
 pub fn String::codepoint_at(self : String, index : Int) -> Char {
-  let charcode_len = self.charcode_length()
+  let charcode_len = self.length()
   guard index >= 0 && index < charcode_len else { abort("index out of bounds") }
   for char_count = 0, utf16_offset = 0
       char_count < charcode_len && utf16_offset < index
@@ -145,7 +140,7 @@ pub fn String::codepoint_at(self : String, index : Int) -> Char {
 /// inspect!(s.charcode_length(), content = "7");  // 5 ASCII chars + 2 surrogate pairs
 /// ```
 pub fn String::codepoint_length(self : String) -> Int {
-  let charcode_len = self.charcode_length()
+  let charcode_len = self.length()
   for char_count = 0, len = 0
       char_count < charcode_len
       char_count = char_count + 1, len = len + 1 {
@@ -162,18 +157,6 @@ pub fn String::codepoint_length(self : String) -> Int {
     len
   }
 }
-
-///|
-// planned op_get method for String
-// pub fn String::op_get(self : String, index : Int) -> Char {
-//   codepoint_at(self, index)
-// }
-
-///|
-// planned length method for String
-// pub fn String::length(self : String) -> Int {
-//   codepoint_length(self)
-//}
 
 ///|
 /// @intrinsic %string.substring

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -110,7 +110,7 @@ pub fn end() -> Unit {
     let str = sbuf._[i]
     let mut start = 0
     for j in 0..<str.length() {
-      if Char::from_int(str.unsafe_charcode_at(j)) == '\n' {
+      if str.unsafe_charcode_at(j) == '\n' {
         line_buf.write_substring(str, start, j)
         println(line_buf.to_string())
         line_buf.reset()

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -110,7 +110,7 @@ pub fn end() -> Unit {
     let str = sbuf._[i]
     let mut start = 0
     for j in 0..<str.length() {
-      if str[j] == '\n' {
+      if Char::from_int(str.unsafe_charcode_at(j)) == '\n' {
         line_buf.write_substring(str, start, j)
         println(line_buf.to_string())
         line_buf.reset()

--- a/json/lex_misc.mbt
+++ b/json/lex_misc.mbt
@@ -15,12 +15,11 @@
 ///|
 fn ParseContext::read_char(ctx : ParseContext) -> Char? {
   if ctx.offset < ctx.end_offset {
-    let c = ctx.input[ctx.offset]
+    let c1 = ctx.input.unsafe_charcode_at(ctx.offset)
     ctx.offset += 1
-    let c1 = c.to_int()
     if c1 >= 0xD800 && c1 <= 0xDBFF {
       if ctx.offset < ctx.end_offset {
-        let c2 = ctx.input[ctx.offset].to_int()
+        let c2 = ctx.input.unsafe_charcode_at(ctx.offset)
         if c2 >= 0xDC00 && c2 <= 0xDFFF {
           ctx.offset += 1
           let c3 = (c1 << 10) + c2 - 0x35fdc00
@@ -28,7 +27,7 @@ fn ParseContext::read_char(ctx : ParseContext) -> Char? {
         }
       }
     }
-    Some(c)
+    Some(Char::from_int(c1))
   } else {
     None
   }
@@ -46,7 +45,7 @@ const SURROGATE_HIGH_CHAR = 0xDFFF
 /// otherwise raise an error, when it is an error, the position is unspecified.
 fn ParseContext::expect_char(ctx : ParseContext, c : Char) -> Unit!ParseError {
   guard ctx.offset < ctx.end_offset else { raise InvalidEof }
-  let c1 = ctx.input[ctx.offset].to_int()
+  let c1 = ctx.input.unsafe_charcode_at(ctx.offset)
   ctx.offset += 1
   let c0 = c.to_int()
   if c0 < 0xFFFF {
@@ -62,7 +61,7 @@ fn ParseContext::expect_char(ctx : ParseContext, c : Char) -> Unit!ParseError {
       ctx.offset < ctx.end_offset else {
       ctx.invalid_char!(shift=-1)
     }
-    let c2 = ctx.input[ctx.offset].to_int()
+    let c2 = ctx.input.unsafe_charcode_at(ctx.offset)
     let c3 = (c1 << 10) + c2 - 0x35fdc00
     if c3 != c0 {
       ctx.invalid_char!(shift=-1)
@@ -80,7 +79,7 @@ fn ParseContext::expect_ascii_char(
   c : Byte
 ) -> Unit!ParseError {
   guard ctx.offset < ctx.end_offset else { raise InvalidEof }
-  let c1 = ctx.input[ctx.offset].to_int()
+  let c1 = ctx.input.unsafe_charcode_at(ctx.offset)
   ctx.offset += 1
   if c.to_int() != c1 {
     ctx.invalid_char!(shift=-1)

--- a/json/utils.mbt
+++ b/json/utils.mbt
@@ -17,8 +17,7 @@ fn offset_to_position(input : String, offset : Int) -> Position {
   let mut line = 1
   let mut column = 0
   for i in 0..<offset {
-    let c = input.unsafe_charcode_at(i) |> Char::from_int
-    if c == '\n' {
+    if input.unsafe_charcode_at(i) == '\n' {
       line += 1
       column = 0
     } else {

--- a/json/utils.mbt
+++ b/json/utils.mbt
@@ -17,7 +17,7 @@ fn offset_to_position(input : String, offset : Int) -> Position {
   let mut line = 1
   let mut column = 0
   for i in 0..<offset {
-    let c = input[i]
+    let c = input.unsafe_charcode_at(i) |> Char::from_int
     if c == '\n' {
       line += 1
       column = 0
@@ -35,5 +35,8 @@ fn ParseContext::invalid_char[T](
 ) -> T!ParseError {
   let offset = ctx.offset + shift
   // FIXME: this should check the surrogate pair
-  raise InvalidChar(offset_to_position(ctx.input, offset), ctx.input[offset])
+  raise InvalidChar(
+    offset_to_position(ctx.input, offset),
+    ctx.input.unsafe_charcode_at(offset) |> Char::from_int,
+  )
 }

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -111,7 +111,7 @@ fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
         continue rest
       }
       if d.digits_num < d.digits.length() {
-        d.digits[d.digits_num] = (digit.to_int() - '0'.to_int()).to_byte()
+        d.digits[d.digits_num] = (digit - '0').to_byte()
         d.digits_num += 1
       } else if digit != '0' {
         d.truncated = true
@@ -141,7 +141,7 @@ fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
       let rest = loop rest {
         ['_', .. rest] => continue rest
         ['0'..='9' as digit, .. rest] => {
-          exp = exp * 10 + (digit.to_int() - '0'.to_int())
+          exp = exp * 10 + (digit - '0')
           continue rest
         }
         rest => rest
@@ -500,7 +500,7 @@ fn new_digits(self : Decimal, s : Int) -> Int {
       less = true
       break
     }
-    let d = cheat_num.unsafe_charcode_at(i) - '0'.to_int()
+    let d = cheat_num.unsafe_charcode_at(i) - '0'
     if self.digits[i].to_int() != d {
       less = self.digits[i].to_int() < d
       break
@@ -564,7 +564,7 @@ fn left_shift(self : Decimal, s : Int) -> Unit {
 ///|
 /// Trim trailing zeros.
 fn trim(self : Decimal) -> Unit {
-  while self.digits_num > 0 && self.digits[self.digits_num - 1].to_int() == 0 {
+  while self.digits_num > 0 && self.digits[self.digits_num - 1] == 0 {
     self.digits_num -= 1
   }
   if self.digits_num == 0 {

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -500,7 +500,7 @@ fn new_digits(self : Decimal, s : Int) -> Int {
       less = true
       break
     }
-    let d = cheat_num[i].to_int() - '0'.to_int()
+    let d = cheat_num.unsafe_charcode_at(i) - '0'.to_int()
     if self.digits[i].to_int() != d {
       less = self.digits[i].to_int() < d
       break

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -59,7 +59,7 @@ fn step(self : StringSlice, step : Int) -> StringSlice? {
   let mut step = step
   let mut start = c.start
   while start < c.end && step > 0 {
-    if Char::from_int(c.string.unsafe_charcode_at(start)) != '_' {
+    if c.string.unsafe_charcode_at(start) != '_' {
       step -= 1
     }
     start += 1

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -59,7 +59,7 @@ fn step(self : StringSlice, step : Int) -> StringSlice? {
   let mut step = step
   let mut start = c.start
   while start < c.end && step > 0 {
-    if c.string[start] != '_' {
+    if Char::from_int(c.string.unsafe_charcode_at(start)) != '_' {
       step -= 1
     }
     start += 1
@@ -80,7 +80,7 @@ fn step_1_unchecked(self : StringSlice) -> StringSlice {
 ///|
 /// Unsafe: make sure index is in bounds
 fn op_get(self : StringSlice, index : Int) -> Char {
-  self.string[self.start + index]
+  self.string.unsafe_charcode_at(self.start + index) |> Char::from_int
 }
 
 ///|
@@ -106,7 +106,7 @@ fn StringSlice::to_string(self : StringSlice) -> String {
 fn prefix_eq_ignore_case(self : StringSlice, s2 : String) -> Bool {
   for i = 0; i < s2.length() && i < self.length(); i = i + 1 {
     let c1 = self[i]
-    let c2 = s2[i]
+    let c2 = s2.unsafe_charcode_at(i) |> Char::from_int
     if lower(c1) != lower(c2) {
       return false
     }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -104,7 +104,9 @@ pub impl Compare for String with compare(self, other) {
   match len.compare(other.length()) {
     0 => {
       for i in 0..<len {
-        let order = self[i].compare(other[i])
+        let order = self
+          .unsafe_charcode_at(i)
+          .compare(other.unsafe_charcode_at(i))
         if order != 0 {
           return order
         }
@@ -307,7 +309,7 @@ pub fn trim_start(self : String, trim_set : String) -> String {
         }
       }
     }
-    if not(trim_set.contains_char(self[i])) {
+    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
       return self.substring(start=i)
     }
   } else {
@@ -333,7 +335,7 @@ pub fn trim_end(self : String, trim_set : String) -> String {
         }
       }
     }
-    if not(trim_set.contains_char(self[i])) {
+    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
       return self.substring(end=i + 1)
     }
   } else {
@@ -377,17 +379,17 @@ pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
   // Bound the starting position
   let from = if from < 0 { 0 } else if from >= len { len - 1 } else { from }
   let max_idx = len - sub_len
-  let first = str[0]
+  let first = str.unsafe_charcode_at(0)
   let mut i = from
   while i <= max_idx {
     // find first character
-    while i < len && self[i] != first {
+    while i < len && self.unsafe_charcode_at(i) != first {
       i += 1
     }
     // check the rest
     if i <= max_idx {
       for j in 1..<sub_len {
-        if self[i + j] != str[j] {
+        if self.unsafe_charcode_at(i + j) != str.unsafe_charcode_at(j) {
           break
         }
       } else {
@@ -423,11 +425,11 @@ pub fn last_index_of(
     return -1
   }
   let min = sub_len - 1
-  let last = str[sub_len - 1]
+  let last = str.unsafe_charcode_at(sub_len - 1)
   let mut i = from - 1
   while i >= 0 {
     // find last character
-    while i >= min && self[i] != last {
+    while i >= min && self.unsafe_charcode_at(i) != last {
       i -= 1
     }
     if i < min {
@@ -437,7 +439,7 @@ pub fn last_index_of(
     let mut k = sub_len - 2
     let start = i - sub_len
     let found = while j > start {
-      if self[j] != str[k] {
+      if self.unsafe_charcode_at(j) != str.unsafe_charcode_at(k) {
         break false
       }
       j -= 1
@@ -701,7 +703,7 @@ pub fn pad_end(self : String, total_width : Int, padding_char : Char) -> String 
 /// @alert unsafe "Panics if the index is out of bounds."
 pub fn String::rev_get(self : String, index : Int) -> Char {
   guard index >= 0 else { abort("index out of bounds") }
-  for utf16_offset = self.charcode_length() - 1, char_count = 0
+  for utf16_offset = self.length() - 1, char_count = 0
       utf16_offset >= 0 && char_count < index
       utf16_offset = utf16_offset - 1, char_count = char_count + 1 {
     let c1 = self.unsafe_charcode_at(utf16_offset)
@@ -736,7 +738,7 @@ pub fn String::rev_get(self : String, index : Int) -> Char {
 ///
 /// This has O(n) complexity where n is the length in the parameter.
 pub fn String::length_eq(self : String, len : Int) -> Bool {
-  let codeunit_len = self.charcode_length()
+  let codeunit_len = self.length()
   for index = 0, count = 0
       index < codeunit_len && count < len
       index = index + 1, count = count + 1 {
@@ -759,7 +761,7 @@ pub fn String::length_eq(self : String, len : Int) -> Bool {
 ///
 /// This has O(n) complexity where n is the length in the parameter.
 pub fn String::length_ge(self : String, len : Int) -> Bool {
-  let codeunit_len = self.charcode_length()
+  let codeunit_len = self.length()
   for index = 0, count = 0
       index < codeunit_len && count < len
       index = index + 1, count = count + 1 {

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -68,7 +68,7 @@ pub fn index_at(
   offset_by : Int,
   start~ : StringIndex = 0
 ) -> StringIndex? {
-  let str_len = self.charcode_length()
+  let str_len = self.length()
   guard start._ >= 0 && start._ <= str_len else { abort("Invalid start index") }
   let mut utf16_offset = start._
   let mut char_count = 0
@@ -121,7 +121,7 @@ pub fn index_at_rev(
   offset_by : Int,
   end? : StringIndex
 ) -> StringIndex? {
-  let str_len = self.charcode_length()
+  let str_len = self.length()
   let end = match end {
     None => str_len
     Some(end) => {
@@ -233,7 +233,7 @@ pub fn length_ge(self : View, len : Int) -> Bool {
 ///)
 /// ```
 pub fn String::op_as_view(self : String, start~ : Int = 0, end? : Int) -> View {
-  let str_len = self.charcode_length()
+  let str_len = self.length()
   let start = if start >= 0 {
     index_at(self, start, start=0).unwrap()._
   } else {
@@ -312,7 +312,7 @@ pub fn View::op_get(self : View, index : Int) -> Char {
   }
   let mut utf16_offset = self.start
   let mut char_count = 0
-  let code_unit_length = self.str.charcode_length()
+  let code_unit_length = self.str.length()
   while char_count < index && utf16_offset < self.end {
     let c1 = self.str.unsafe_charcode_at(utf16_offset)
     if is_leading_surrogate(c1) && utf16_offset + 1 < code_unit_length {


### PR DESCRIPTION
Breaking API change:
* `String::op_get` returns `Int` instead of `Char` to reflect that it reads the codeunit instead of the unicode codepoint

New API: 
* `String::unsafe_charcode_at` to avoid bound check

This PR also deprecates the following obsolete methods:
* `String::get()`
* `String::charcode_length()`