### PR TITLE
separate builtin package and prelude package

### DIFF
--- a/prelude/moon.pkg.json
+++ b/prelude/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ]
+}

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -1,0 +1,79 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub typealias @builtin.(
+  ArgsLoc,
+  Array[X],
+  ArrayView[X],
+  UninitializedArray[X],
+  BigInt,
+  Failure,
+  Hasher,
+  Iter[X],
+  Iter2[X, Y],
+  IterResult,
+  Json,
+  Map[K, V],
+  Set[X],
+  InspectError,
+  SnapshotError,
+  SourceLoc,
+  StringBuilder
+)
+
+///|
+pub traitalias @builtin.(Eq, Compare, Hash, Logger, Show, ToJson, Default)
+
+///|
+pub fnalias abort = @builtin.abort
+
+///|
+pub fnalias assert_eq = @builtin.assert_eq
+
+///|
+pub fnalias assert_not_eq = @builtin.assert_not_eq
+
+///|
+pub fnalias assert_true = @builtin.assert_true
+
+///|
+pub fnalias assert_false = @builtin.assert_false
+
+///|
+pub fnalias fail = @builtin.fail
+
+///|
+pub fnalias ignore = @builtin.ignore
+
+///|
+pub fnalias inspect = @builtin.inspect
+
+///|
+pub fnalias panic = @builtin.panic
+
+///|
+pub fnalias physical_equal = @builtin.physical_equal
+
+///|
+pub fnalias println = @builtin.println
+
+///|
+pub fnalias not = @builtin.not
+
+///|
+pub fnalias repr = @builtin.repr
+
+///|
+pub fnalias dump = @builtin.dump

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -1,0 +1,85 @@
+package moonbitlang/core/prelude
+
+// Values
+fn abort[T](String) -> T
+
+fn assert_eq[T : Eq + Show](T, T, loc~ : SourceLoc = _) -> Unit!
+
+fn assert_false(Bool, loc~ : SourceLoc = _) -> Unit!
+
+fn assert_not_eq[T : Eq + Show](T, T, loc~ : SourceLoc = _) -> Unit!
+
+fn assert_true(Bool, loc~ : SourceLoc = _) -> Unit!
+
+#deprecated
+fn dump[T](T, name? : String, loc~ : SourceLoc = _) -> T
+
+fn fail[T](String, loc~ : SourceLoc = _) -> T!Failure
+
+fn ignore[T](T) -> Unit
+
+fn inspect(&Show, content~ : String = .., loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit!InspectError
+
+fn not(Bool) -> Bool
+
+fn panic[T]() -> T
+
+fn physical_equal[T](T, T) -> Bool
+
+fn println[T : Show](T) -> Unit
+
+fn repr[T : Show](T) -> String
+
+// Types and methods
+
+// Type aliases
+pub typealias ArgsLoc = ArgsLoc
+
+pub typealias Array[X] = Array[X]
+
+pub typealias ArrayView[X] = ArrayView[X]
+
+pub typealias BigInt = BigInt
+
+pub typealias Failure = Failure
+
+pub typealias Hasher = Hasher
+
+pub typealias InspectError = InspectError
+
+pub typealias Iter[X] = Iter[X]
+
+pub typealias Iter2[X, Y] = Iter2[X, Y]
+
+pub typealias IterResult = IterResult
+
+pub typealias Json = Json
+
+pub typealias Map[K, V] = Map[K, V]
+
+pub typealias Set[X] = Set[X]
+
+pub typealias SnapshotError = SnapshotError
+
+pub typealias SourceLoc = SourceLoc
+
+pub typealias StringBuilder = StringBuilder
+
+pub typealias UninitializedArray[X] = UninitializedArray[X]
+
+pub traitalias Compare = Compare
+
+pub traitalias Default = Default
+
+pub traitalias Eq = Eq
+
+pub traitalias Hash = Hash
+
+pub traitalias Logger = Logger
+
+pub traitalias Show = Show
+
+pub traitalias ToJson = ToJson
+
+// Traits
+


### PR DESCRIPTION
Currently, `@builtin` serves two purpose in core:

1. hold fundamental definitions, such as arithmetic operators on builtin types, to resolve cyclic definition between other core packages
2. serve as a prelude package. The content of `@builtin` can be used directly, unqualified

But these two purposes are contradictory: as a place to hold fundamental definitions, we want `@builtin` to be as small as possible. Meanwhile, due to `@builtin`'s role as a prelude package, we have put heavy things such as linked hash map into `@builtin`.

So, we intend to split `@builtin` into two packages:

- `@builtin` will hold fundamental definitions, and should be as small as possible
- a new package `@prelude` will be added, and its content can be used directly unqualified. `@prelude` should not contain any actual code, it should just hold alias to other core packages

This way, types like `Map`/`Set` can be placed in their own package, while users can still use them unqualified via aliases is `@prelude`. The dependency structure would be:

```
@prelude -> other core packages -> @builtin
```

This PR introduces the aforementioned `@prelude` package. However, this migration require change in the compiler as well. So currently, `@prelude` is just a useless new package, until a compiler with `@prelude` support is released.