### PR TITLE
chore: migrate @alert deprecated to #deprecated

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -169,7 +169,7 @@ pub fn filter_map[A, B](self : Array[A], f : (A) -> B?) -> Array[B] {
 /// 
 /// # Returns
 /// 
-/// @alert deprecated "Use `Array::filter_map` instead"
+#deprecated("Use `Array::filter_map` instead")
 pub fn map_option[A, B](self : Array[A], f : (A) -> B?) -> Array[B] {
   self.filter_map(f)
 }

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -12,6 +12,7 @@ fn join(Array[String], String) -> String
 
 fn last[A](Array[A]) -> A?
 
+#deprecated
 fn map_option[A, B](Array[A], (A) -> B?) -> Array[B]
 
 fn push_iter[T](Array[T], Iter[T]) -> Unit
@@ -37,9 +38,13 @@ impl FixedArray {
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit
   ends_with[T : Eq](Self[T], Self[T]) -> Bool
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
+  #deprecated
   fold_left[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  #deprecated
   fold_lefti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
+  #deprecated
   fold_right[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  #deprecated
   fold_righti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
   from_array[T](Array[T]) -> Self[T]
@@ -49,7 +54,9 @@ impl FixedArray {
   makei[T](Int, (Int) -> T) -> Self[T]
   map[T, U](Self[T], (T) -> U) -> Self[U]
   mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
+  #deprecated
   new[T](Int, () -> T) -> Self[T]
+  #deprecated
   new_with_index[T](Int, (Int) -> T) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
   rev[T](Self[T]) -> Self[T]
@@ -76,6 +83,7 @@ impl Array {
   join(Self[String], String) -> String
   last[A](Self[A]) -> A?
   makei[T](Int, (Int) -> T) -> Self[T]
+  #deprecated
   map_option[A, B](Self[A], (A) -> B?) -> Self[B]
   push_iter[T](Self[T], Iter[T]) -> Unit
   shuffle[T](Self[T], rand~ : (Int) -> Int) -> Self[T]

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -12,7 +12,7 @@ fn join(Array[String], String) -> String
 
 fn last[A](Array[A]) -> A?
 
-fn map_option[A, B](Array[A], (A) -> B?) -> Array[B] //deprecated
+fn map_option[A, B](Array[A], (A) -> B?) -> Array[B]
 
 fn push_iter[T](Array[T], Iter[T]) -> Unit
 
@@ -37,10 +37,10 @@ impl FixedArray {
   eachi[T](Self[T], (Int, T) -> Unit) -> Unit
   ends_with[T : Eq](Self[T], Self[T]) -> Bool
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
-  fold_left[T, U](Self[T], (U, T) -> U, init~ : U) -> U //deprecated
-  fold_lefti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U //deprecated
-  fold_right[T, U](Self[T], (U, T) -> U, init~ : U) -> U //deprecated
-  fold_righti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U //deprecated
+  fold_left[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  fold_lefti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
+  fold_right[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  fold_righti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
   from_array[T](Array[T]) -> Self[T]
   from_iter[T](Iter[T]) -> Self[T]
@@ -49,8 +49,8 @@ impl FixedArray {
   makei[T](Int, (Int) -> T) -> Self[T]
   map[T, U](Self[T], (T) -> U) -> Self[U]
   mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
-  new[T](Int, () -> T) -> Self[T] //deprecated
-  new_with_index[T](Int, (Int) -> T) -> Self[T] //deprecated
+  new[T](Int, () -> T) -> Self[T]
+  new_with_index[T](Int, (Int) -> T) -> Self[T]
   op_add[T](Self[T], Self[T]) -> Self[T]
   rev[T](Self[T]) -> Self[T]
   rev_each[T](Self[T], (T) -> Unit) -> Unit
@@ -76,7 +76,7 @@ impl Array {
   join(Self[String], String) -> String
   last[A](Self[A]) -> A?
   makei[T](Int, (Int) -> T) -> Self[T]
-  map_option[A, B](Self[A], (A) -> B?) -> Self[B] //deprecated
+  map_option[A, B](Self[A], (A) -> B?) -> Self[B]
   push_iter[T](Self[T], Iter[T]) -> Unit
   shuffle[T](Self[T], rand~ : (Int) -> Int) -> Self[T]
   shuffle_in_place[T](Self[T], rand~ : (Int) -> Int) -> Unit

--- a/array/deprecated.mbt
+++ b/array/deprecated.mbt
@@ -39,7 +39,7 @@
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `FixedArray::makei` instead"
+#deprecated("Use `FixedArray::makei` instead")
 #coverage.skip
 pub fn FixedArray::new[T](length : Int, value : () -> T) -> FixedArray[T] {
   if length <= 0 {
@@ -75,7 +75,7 @@ pub fn FixedArray::new[T](length : Int, value : () -> T) -> FixedArray[T] {
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `FixedArray::makei` instead"
+#deprecated("Use `FixedArray::makei` instead")
 #coverage.skip
 pub fn FixedArray::new_with_index[T](
   length : Int,
@@ -92,7 +92,7 @@ pub fn FixedArray::new_with_index[T](
 /// let sum = [1, 2, 3, 4, 5].fold(init=0, fn { sum, elem => sum + elem })
 /// assert_eq!(sum, 15)
 /// ```
-/// @alert deprecated "Use `fold` instead"
+#deprecated("Use `fold` instead")
 #coverage.skip
 pub fn FixedArray::fold_left[T, U](
   self : FixedArray[T],
@@ -110,7 +110,7 @@ pub fn FixedArray::fold_left[T, U](
 /// let sum = [1, 2, 3, 4, 5].rev_fold(init=0, fn { sum, elem => sum + elem })
 /// assert_eq!(sum, 15)
 /// ```
-/// @alert deprecated "Use `rev_fold` instead"
+#deprecated("Use `rev_fold` instead")
 #coverage.skip
 pub fn FixedArray::fold_right[T, U](
   self : FixedArray[T],
@@ -128,7 +128,7 @@ pub fn FixedArray::fold_right[T, U](
 /// let sum = [1, 2, 3, 4, 5].foldi(init=0, fn { index, sum, _elem => sum + index })
 /// assert_eq!(sum, 10)
 /// ```
-/// @alert deprecated "Use `foldi` instead"
+#deprecated("Use `foldi` instead")
 #coverage.skip
 pub fn FixedArray::fold_lefti[T, U](
   self : FixedArray[T],
@@ -146,7 +146,7 @@ pub fn FixedArray::fold_lefti[T, U](
 /// let sum = [1, 2, 3, 4, 5].rev_foldi(init=0, fn { index, sum, _elem => sum + index })
 /// assert_eq!(sum, 10)
 /// ```
-/// @alert deprecated "Use `rev_foldi` instead"
+#deprecated("Use `rev_foldi` instead")
 #coverage.skip
 pub fn FixedArray::fold_righti[T, U](
   self : FixedArray[T],

--- a/buffer/buffer.mbti
+++ b/buffer/buffer.mbti
@@ -15,8 +15,10 @@ fn reset(T) -> Unit
 
 fn to_bytes(T) -> Bytes
 
+#deprecated
 fn to_string(T) -> String
 
+#deprecated
 fn to_unchecked_string(T) -> String
 
 fn write_byte(T, Byte) -> Unit
@@ -45,6 +47,7 @@ fn write_iter(T, Iter[Byte]) -> Unit
 
 fn write_object(T, &Show) -> Unit
 
+#deprecated
 fn write_sub_string(T, String, Int, Int) -> Unit
 
 fn write_uint64_be(T, UInt64) -> Unit
@@ -61,10 +64,13 @@ impl T {
   contents(Self) -> Bytes
   is_empty(Self) -> Bool
   length(Self) -> Int
+  #deprecated
   new(size_hint~ : Int = ..) -> Self
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes
+  #deprecated
   to_string(Self) -> String
+  #deprecated
   to_unchecked_string(Self) -> String
   write_byte(Self, Byte) -> Unit
   write_bytes(Self, Bytes) -> Unit
@@ -79,6 +85,7 @@ impl T {
   write_int_le(Self, Int) -> Unit
   write_iter(Self, Iter[Byte]) -> Unit
   write_object(Self, &Show) -> Unit
+  #deprecated
   write_sub_string(Self, String, Int, Int) -> Unit
   write_uint64_be(Self, UInt64) -> Unit
   write_uint64_le(Self, UInt64) -> Unit

--- a/buffer/buffer.mbti
+++ b/buffer/buffer.mbti
@@ -15,9 +15,9 @@ fn reset(T) -> Unit
 
 fn to_bytes(T) -> Bytes
 
-fn to_string(T) -> String //deprecated
+fn to_string(T) -> String
 
-fn to_unchecked_string(T) -> String //deprecated
+fn to_unchecked_string(T) -> String
 
 fn write_byte(T, Byte) -> Unit
 
@@ -45,7 +45,7 @@ fn write_iter(T, Iter[Byte]) -> Unit
 
 fn write_object(T, &Show) -> Unit
 
-fn write_sub_string(T, String, Int, Int) -> Unit //deprecated
+fn write_sub_string(T, String, Int, Int) -> Unit
 
 fn write_uint64_be(T, UInt64) -> Unit
 
@@ -61,11 +61,11 @@ impl T {
   contents(Self) -> Bytes
   is_empty(Self) -> Bool
   length(Self) -> Int
-  new(size_hint~ : Int = ..) -> Self //deprecated
+  new(size_hint~ : Int = ..) -> Self
   reset(Self) -> Unit
   to_bytes(Self) -> Bytes
-  to_string(Self) -> String //deprecated
-  to_unchecked_string(Self) -> String //deprecated
+  to_string(Self) -> String
+  to_unchecked_string(Self) -> String
   write_byte(Self, Byte) -> Unit
   write_bytes(Self, Bytes) -> Unit
   write_bytesview(Self, @bytes.View) -> Unit
@@ -79,7 +79,7 @@ impl T {
   write_int_le(Self, Int) -> Unit
   write_iter(Self, Iter[Byte]) -> Unit
   write_object(Self, &Show) -> Unit
-  write_sub_string(Self, String, Int, Int) -> Unit //deprecated
+  write_sub_string(Self, String, Int, Int) -> Unit
   write_uint64_be(Self, UInt64) -> Unit
   write_uint64_le(Self, UInt64) -> Unit
   write_uint_be(Self, UInt) -> Unit

--- a/buffer/deprecated.mbt
+++ b/buffer/deprecated.mbt
@@ -15,7 +15,7 @@
 ///|
 /// Return a new string contains the data in buffer.
 ///
-/// @alert deprecated "Use `Buffer::contents` to read the contents of the buffer"
+#deprecated("Use `Buffer::contents` to read the contents of the buffer")
 #coverage.skip
 pub fn to_string(self : T) -> String {
   self.contents().to_unchecked_string(offset=0, length=self.len)
@@ -26,7 +26,7 @@ pub fn to_string(self : T) -> String {
 /// Note this function does not validate the encoding of the byte sequence,
 /// it simply copy the bytes into a new String.
 ///
-/// @alert deprecated "Use `Buffer::contents` to read the contents of the buffer"
+#deprecated("Use `Buffer::contents` to read the contents of the buffer")
 #coverage.skip
 pub fn to_unchecked_string(self : T) -> String {
   self.contents().to_unchecked_string(offset=0, length=self.len)
@@ -43,7 +43,7 @@ pub fn to_unchecked_string(self : T) -> String {
 /// * `offset` : The starting position in the source string (inclusive).
 /// * `length` : The number of characters to write from the starting position.
 ///
-/// @alert deprecated "Use `Buffer::write_substring` instead"
+#deprecated("Use `Buffer::write_substring` instead")
 #coverage.skip
 pub fn write_sub_string(
   self : T,
@@ -55,7 +55,7 @@ pub fn write_sub_string(
 }
 
 ///|
-/// @alert deprecated "use `@buffer.new` instead"
+#deprecated("use `@buffer.new` instead")
 #coverage.skip
 pub fn T::new(size_hint~ : Int = 0) -> T {
   new(size_hint~)

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -958,7 +958,7 @@ pub fn Array::search[T : Eq](self : Array[T], value : T) -> Int? {
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `search_by` instead."
+#deprecated("Use `search_by` instead.")
 #coverage.skip
 pub fn Array::find_index[T](self : Array[T], f : (T) -> Bool) -> Int? {
   self.search_by(f)
@@ -1370,7 +1370,7 @@ pub fn Array::rev_foldi[A, B](
 /// let sum = [1, 2, 3, 4, 5].fold(init=0, fn { sum, elem => sum + elem })
 /// assert_eq!(sum, 15)
 /// ```
-/// @alert deprecated "Use `fold` instead."
+#deprecated("Use `fold` instead.")
 #coverage.skip
 pub fn Array::fold_left[T, U](self : Array[T], f : (U, T) -> U, init~ : U) -> U {
   self.fold(init~, f)
@@ -1385,7 +1385,7 @@ pub fn Array::fold_left[T, U](self : Array[T], f : (U, T) -> U, init~ : U) -> U 
 /// let sum = [1, 2, 3, 4, 5].rev_fold(init=0, fn { sum, elem => sum + elem })
 /// assert_eq!(sum, 15)
 /// ```
-/// @alert deprecated "Use `rev_fold` instead."
+#deprecated("Use `rev_fold` instead.")
 #coverage.skip
 pub fn Array::fold_right[T, U](
   self : Array[T],
@@ -1404,7 +1404,7 @@ pub fn Array::fold_right[T, U](
 /// let sum = [1, 2, 3, 4, 5].foldi(init=0, fn { index, sum, _elem => sum + index })
 /// assert_eq!(sum, 10)
 /// ```
-/// @alert deprecated "Use `foldi` instead."
+#deprecated("Use `foldi` instead.")
 #coverage.skip
 pub fn Array::fold_lefti[T, U](
   self : Array[T],
@@ -1423,7 +1423,7 @@ pub fn Array::fold_lefti[T, U](
 /// let sum = [1, 2, 3, 4, 5].rev_foldi(init=0, fn { index, sum, _elem => sum + index })
 /// assert_eq!(sum, 10)
 /// ```
-/// @alert deprecated "Use `rev_foldi` instead."
+#deprecated("Use `rev_foldi` instead.")
 #coverage.skip
 pub fn Array::fold_righti[T, U](
   self : Array[T],

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -201,7 +201,7 @@ pub fn Array::pop[T](self : Array[T]) -> T? {
 }
 
 ///|
-/// @alert deprecated "Use `unsafe_pop` instead"
+#deprecated("Use `unsafe_pop` instead")
 #coverage.skip
 pub fn Array::pop_exn[T](self : Array[T]) -> T {
   self.unsafe_pop()

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -281,7 +281,7 @@ pub fn Array::pop[T](self : Array[T]) -> T? {
 }
 
 ///|
-/// @alert deprecated "Use `unsafe_pop` instead"
+#deprecated("Use `unsafe_pop` instead")
 #coverage.skip
 pub fn Array::pop_exn[T](self : Array[T]) -> T {
   self.unsafe_pop()

--- a/builtin/bigint_deprecated.mbt
+++ b/builtin/bigint_deprecated.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "Use infix bitwise operator `>>` instead"
+#deprecated("Use infix bitwise operator `>>` instead")
 #coverage.skip
 pub fn BigInt::asr(self : BigInt, n : Int) -> BigInt {
   self >> n
@@ -24,7 +24,7 @@ pub fn BigInt::asr(self : BigInt, n : Int) -> BigInt {
 /// The sign of the result is the same as the sign of the input.
 /// Only the absolute value is shifted.
 ///
-/// @alert deprecated "Use infix bitwise operator `<<` instead"
+#deprecated("Use infix bitwise operator `<<` instead")
 #coverage.skip
 pub fn BigInt::shl(self : BigInt, n : Int) -> BigInt {
   self << n
@@ -35,7 +35,7 @@ pub fn BigInt::shl(self : BigInt, n : Int) -> BigInt {
 /// The sign of the result is the same as the sign of the input.
 /// Only the absolute value is shifted.
 ///
-/// @alert deprecated "Use infix bitwise operator `<<` instead"
+#deprecated("Use infix bitwise operator `<<` instead")
 #coverage.skip
 pub fn BigInt::lsl(self : BigInt, n : Int) -> BigInt {
   self << n
@@ -46,7 +46,7 @@ pub fn BigInt::lsl(self : BigInt, n : Int) -> BigInt {
 /// The sign of the result is the same as the sign of the input.
 /// Only the absolute value is shifted.
 ///
-/// @alert deprecated "Use infix bitwise operator `>>` instead"
+#deprecated("Use infix bitwise operator `>>` instead")
 #coverage.skip
 pub fn BigInt::shr(self : BigInt, n : Int) -> BigInt {
   self >> n

--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -1220,7 +1220,7 @@ pub fn BigInt::to_hex(self : BigInt, uppercase~ : Bool = true) -> String {
 }
 
 ///|
-/// @alert deprecated "Use `copy` instead"
+#deprecated("Use `copy` instead")
 #coverage.skip
 fn BigInt::deep_clone(self : BigInt) -> BigInt {
   BigInt::copy(self)

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -11,6 +11,7 @@ fn assert_not_eq[T : Eq + Show](T, T, loc~ : SourceLoc = _) -> Unit!
 
 fn assert_true(Bool, loc~ : SourceLoc = _) -> Unit!
 
+#deprecated
 fn dump[T](T, name? : String, loc~ : SourceLoc = _) -> T
 
 fn fail[T](String, loc~ : SourceLoc = _) -> T!Failure
@@ -64,12 +65,17 @@ impl Array {
   ends_with[T : Eq](Self[T], Self[T]) -> Bool
   extract_if[T](Self[T], (T) -> Bool) -> Self[T]
   filter[T](Self[T], (T) -> Bool) -> Self[T]
+  #deprecated
   find_index[T](Self[T], (T) -> Bool) -> Int?
   flatten[T](Self[Self[T]]) -> Self[T]
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
+  #deprecated
   fold_left[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  #deprecated
   fold_lefti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
+  #deprecated
   fold_right[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  #deprecated
   fold_righti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
   from_fixed_array[T](FixedArray[T]) -> Self[T]
@@ -91,6 +97,7 @@ impl Array {
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   pop[T](Self[T]) -> T?
+  #deprecated
   pop_exn[T](Self[T]) -> T
   push[T](Self[T], T) -> Unit
   remove[T](Self[T], Int) -> T
@@ -138,6 +145,7 @@ impl[X : ToJson] ToJson for ArrayView[X]
 
 type BigInt
 impl BigInt {
+  #deprecated
   asr(Self, Int) -> Self
   from_hex(String) -> Self
   from_int(Int) -> Self
@@ -149,6 +157,7 @@ impl BigInt {
   is_zero(Self) -> Bool
   land(Self, Self) -> Self
   lor(Self, Self) -> Self
+  #deprecated
   lsl(Self, Int) -> Self
   lxor(Self, Self) -> Self
   op_add(Self, Self) -> Self
@@ -160,7 +169,9 @@ impl BigInt {
   op_shr(Self, Int) -> Self
   op_sub(Self, Self) -> Self
   pow(Self, Self, modulus? : Self) -> Self
+  #deprecated
   shl(Self, Int) -> Self
+  #deprecated
   shr(Self, Int) -> Self
   to_hex(Self, uppercase~ : Bool = ..) -> String
   to_int(Self) -> Int
@@ -226,6 +237,7 @@ impl Iter {
   just_run[T](Self[T], (T) -> IterResult) -> Unit
   last[A](Self[A]) -> A?
   map[T, R](Self[T], (T) -> R) -> Self[R]
+  #deprecated
   map_option[A, B](Self[A], (A) -> B?) -> Self[B]
   map_while[A, B](Self[A], (A) -> B?) -> Self[B]
   maximum[T : Compare](Self[T]) -> T?
@@ -319,6 +331,7 @@ impl Set {
   eachi[K](Self[K], (Int, K) -> Unit) -> Unit
   from_array[K : Hash + Eq](Array[K]) -> Self[K]
   from_iter[K : Hash + Eq](Iter[K]) -> Self[K]
+  #deprecated
   insert[K : Hash + Eq](Self[K], K) -> Unit
   intersection[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   is_empty[K](Self[K]) -> Bool
@@ -366,7 +379,9 @@ impl UninitializedArray {
 }
 
 impl Bool {
+  #deprecated
   not(Bool) -> Bool
+  #deprecated
   op_compare(Bool, Bool) -> Int
   to_string(Bool) -> String
 }
@@ -375,7 +390,9 @@ impl Byte {
   land(Byte, Byte) -> Byte
   lnot(Byte) -> Byte
   lor(Byte, Byte) -> Byte
+  #deprecated
   lsl(Byte, Int) -> Byte
+  #deprecated
   lsr(Byte, Int) -> Byte
   lxor(Byte, Byte) -> Byte
   op_add(Byte, Byte) -> Byte
@@ -401,6 +418,7 @@ impl Char {
 }
 
 impl Int {
+  #deprecated
   asr(Int, Int) -> Int
   clz(Int) -> Int
   ctz(Int) -> Int
@@ -411,7 +429,9 @@ impl Int {
   land(Int, Int) -> Int
   lnot(Int) -> Int
   lor(Int, Int) -> Int
+  #deprecated
   lsl(Int, Int) -> Int
+  #deprecated
   lsr(Int, Int) -> Int
   lxor(Int, Int) -> Int
   op_add(Int, Int) -> Int
@@ -425,7 +445,9 @@ impl Int {
   popcnt(Int) -> Int
   reinterpret_as_float(Int) -> Float
   reinterpret_as_uint(Int) -> UInt
+  #deprecated
   shl(Int, Int) -> Int
+  #deprecated
   shr(Int, Int) -> Int
   to_byte(Int) -> Byte
   to_double(Int) -> Double
@@ -433,10 +455,12 @@ impl Int {
   to_int16(Int) -> Int16
   to_int64(Int) -> Int64
   to_string(Int, radix~ : Int = ..) -> String
+  #deprecated
   to_uint(Int) -> UInt
   to_uint16(Int) -> UInt16
   to_uint64(Int) -> UInt64
   until(Int, Int, step~ : Int = .., inclusive~ : Bool = ..) -> Iter[Int]
+  #deprecated
   upto(Int, Int, inclusive~ : Bool = ..) -> Iter[Int]
 }
 
@@ -448,13 +472,16 @@ impl Int16 {
 }
 
 impl Int64 {
+  #deprecated
   asr(Int64, Int) -> Int64
   clz(Int64) -> Int
   ctz(Int64) -> Int
   land(Int64, Int64) -> Int64
   lnot(Int64) -> Int64
   lor(Int64, Int64) -> Int64
+  #deprecated
   lsl(Int64, Int) -> Int64
+  #deprecated
   lsr(Int64, Int) -> Int64
   lxor(Int64, Int64) -> Int64
   op_add(Int64, Int64) -> Int64
@@ -468,7 +495,9 @@ impl Int64 {
   popcnt(Int64) -> Int
   reinterpret_as_double(Int64) -> Double
   reinterpret_as_uint64(Int64) -> UInt64
+  #deprecated
   shl(Int64, Int) -> Int64
+  #deprecated
   shr(Int64, Int) -> Int64
   to_byte(Int64) -> Byte
   to_double(Int64) -> Double
@@ -477,8 +506,10 @@ impl Int64 {
   to_int16(Int64) -> Int16
   to_string(Int64, radix~ : Int = ..) -> String
   to_uint16(Int64) -> UInt16
+  #deprecated
   to_uint64(Int64) -> UInt64
   until(Int64, Int64, step~ : Int64 = .., inclusive~ : Bool = ..) -> Iter[Int64]
+  #deprecated
   upto(Int64, Int64, inclusive~ : Bool = ..) -> Iter[Int64]
 }
 
@@ -488,7 +519,9 @@ impl UInt {
   land(UInt, UInt) -> UInt
   lnot(UInt) -> UInt
   lor(UInt, UInt) -> UInt
+  #deprecated
   lsl(UInt, Int) -> UInt
+  #deprecated
   lsr(UInt, Int) -> UInt
   lxor(UInt, UInt) -> UInt
   op_add(UInt, UInt) -> UInt
@@ -502,15 +535,19 @@ impl UInt {
   popcnt(UInt) -> Int
   reinterpret_as_float(UInt) -> Float
   reinterpret_as_int(UInt) -> Int
+  #deprecated
   shl(UInt, Int) -> UInt
+  #deprecated
   shr(UInt, Int) -> UInt
   to_byte(UInt) -> Byte
   to_double(UInt) -> Double
   to_float(UInt) -> Float
+  #deprecated
   to_int(UInt) -> Int
   to_string(UInt, radix~ : Int = ..) -> String
   to_uint64(UInt) -> UInt64
   trunc_double(Double) -> UInt
+  #deprecated
   upto(UInt, UInt, inclusive~ : Bool = ..) -> Iter[UInt]
 }
 
@@ -528,7 +565,9 @@ impl UInt64 {
   land(UInt64, UInt64) -> UInt64
   lnot(UInt64) -> UInt64
   lor(UInt64, UInt64) -> UInt64
+  #deprecated
   lsl(UInt64, Int) -> UInt64
+  #deprecated
   lsr(UInt64, Int) -> UInt64
   lxor(UInt64, UInt64) -> UInt64
   op_add(UInt64, UInt64) -> UInt64
@@ -541,16 +580,20 @@ impl UInt64 {
   popcnt(UInt64) -> Int
   reinterpret_as_double(UInt64) -> Double
   reinterpret_as_int64(UInt64) -> Int64
+  #deprecated
   shl(UInt64, Int) -> UInt64
+  #deprecated
   shr(UInt64, Int) -> UInt64
   to_byte(UInt64) -> Byte
   to_double(UInt64) -> Double
   to_float(UInt64) -> Float
   to_int(UInt64) -> Int
+  #deprecated
   to_int64(UInt64) -> Int64
   to_string(UInt64, radix~ : Int = ..) -> String
   to_uint(UInt64) -> UInt
   trunc_double(Double) -> UInt64
+  #deprecated
   upto(UInt64, UInt64, inclusive~ : Bool = ..) -> Iter[UInt64]
 }
 
@@ -566,6 +609,7 @@ impl Float {
   sqrt(Float) -> Float
   to_double(Float) -> Double
   until(Float, Float, step~ : Float = .., inclusive~ : Bool = ..) -> Iter[Float]
+  #deprecated
   upto(Float, Float, inclusive~ : Bool = ..) -> Iter[Float]
 }
 
@@ -578,8 +622,10 @@ impl Double {
   op_neg(Double) -> Double
   op_neq(Double, Double) -> Bool
   op_sub(Double, Double) -> Double
+  #deprecated
   reinterpret_as_i64(Double) -> Int64
   reinterpret_as_int64(Double) -> Int64
+  #deprecated
   reinterpret_as_u64(Double) -> UInt64
   reinterpret_as_uint64(Double) -> UInt64
   sqrt(Double) -> Double
@@ -588,6 +634,7 @@ impl Double {
   to_int64(Double) -> Int64
   to_uint64(Double) -> UInt64
   until(Double, Double, step~ : Double = .., inclusive~ : Bool = ..) -> Iter[Double]
+  #deprecated
   upto(Double, Double, inclusive~ : Bool = ..) -> Iter[Double]
 }
 
@@ -626,6 +673,7 @@ impl FixedArray {
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   set[T](Self[T], Int, T) -> Unit
+  #deprecated
   set_utf16_char(Self[Byte], Int, Char) -> Int
   set_utf16be_char(Self[Byte], Int, Char) -> Int
   set_utf16le_char(Self[Byte], Int, Char) -> Int
@@ -642,7 +690,9 @@ impl Bytes {
   new(Int) -> Bytes
   of_string(String) -> Bytes
   op_get(Bytes, Int) -> Byte
+  #deprecated
   sub_string(Bytes, Int, Int) -> String
+  #deprecated
   to_string(Bytes) -> String
   to_unchecked_string(Bytes, offset~ : Int = .., length~ : Int = ..) -> String
   unsafe_get(Bytes, Int) -> Byte

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -11,7 +11,7 @@ fn assert_not_eq[T : Eq + Show](T, T, loc~ : SourceLoc = _) -> Unit!
 
 fn assert_true(Bool, loc~ : SourceLoc = _) -> Unit!
 
-fn dump[T](T, name? : String, loc~ : SourceLoc = _) -> T //deprecated
+fn dump[T](T, name? : String, loc~ : SourceLoc = _) -> T
 
 fn fail[T](String, loc~ : SourceLoc = _) -> T!Failure
 
@@ -64,13 +64,13 @@ impl Array {
   ends_with[T : Eq](Self[T], Self[T]) -> Bool
   extract_if[T](Self[T], (T) -> Bool) -> Self[T]
   filter[T](Self[T], (T) -> Bool) -> Self[T]
-  find_index[T](Self[T], (T) -> Bool) -> Int? //deprecated
+  find_index[T](Self[T], (T) -> Bool) -> Int?
   flatten[T](Self[Self[T]]) -> Self[T]
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
-  fold_left[T, U](Self[T], (U, T) -> U, init~ : U) -> U //deprecated
-  fold_lefti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U //deprecated
-  fold_right[T, U](Self[T], (U, T) -> U, init~ : U) -> U //deprecated
-  fold_righti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U //deprecated
+  fold_left[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  fold_lefti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
+  fold_right[T, U](Self[T], (U, T) -> U, init~ : U) -> U
+  fold_righti[T, U](Self[T], (Int, U, T) -> U, init~ : U) -> U
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
   from_fixed_array[T](FixedArray[T]) -> Self[T]
   get[T](Self[T], Int) -> T?
@@ -91,7 +91,7 @@ impl Array {
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   pop[T](Self[T]) -> T?
-  pop_exn[T](Self[T]) -> T //deprecated
+  pop_exn[T](Self[T]) -> T
   push[T](Self[T], T) -> Unit
   remove[T](Self[T], Int) -> T
   repeat[T](Self[T], Int) -> Self[T]
@@ -138,7 +138,7 @@ impl[X : ToJson] ToJson for ArrayView[X]
 
 type BigInt
 impl BigInt {
-  asr(Self, Int) -> Self //deprecated
+  asr(Self, Int) -> Self
   from_hex(String) -> Self
   from_int(Int) -> Self
   from_int64(Int64) -> Self
@@ -149,7 +149,7 @@ impl BigInt {
   is_zero(Self) -> Bool
   land(Self, Self) -> Self
   lor(Self, Self) -> Self
-  lsl(Self, Int) -> Self //deprecated
+  lsl(Self, Int) -> Self
   lxor(Self, Self) -> Self
   op_add(Self, Self) -> Self
   op_div(Self, Self) -> Self
@@ -160,8 +160,8 @@ impl BigInt {
   op_shr(Self, Int) -> Self
   op_sub(Self, Self) -> Self
   pow(Self, Self, modulus? : Self) -> Self
-  shl(Self, Int) -> Self //deprecated
-  shr(Self, Int) -> Self //deprecated
+  shl(Self, Int) -> Self
+  shr(Self, Int) -> Self
   to_hex(Self, uppercase~ : Bool = ..) -> String
   to_int(Self) -> Int
   to_int64(Self) -> Int64
@@ -226,7 +226,7 @@ impl Iter {
   just_run[T](Self[T], (T) -> IterResult) -> Unit
   last[A](Self[A]) -> A?
   map[T, R](Self[T], (T) -> R) -> Self[R]
-  map_option[A, B](Self[A], (A) -> B?) -> Self[B] //deprecated
+  map_option[A, B](Self[A], (A) -> B?) -> Self[B]
   map_while[A, B](Self[A], (A) -> B?) -> Self[B]
   maximum[T : Compare](Self[T]) -> T?
   minimum[T : Compare](Self[T]) -> T?
@@ -319,7 +319,7 @@ impl Set {
   eachi[K](Self[K], (Int, K) -> Unit) -> Unit
   from_array[K : Hash + Eq](Array[K]) -> Self[K]
   from_iter[K : Hash + Eq](Iter[K]) -> Self[K]
-  insert[K : Hash + Eq](Self[K], K) -> Unit //deprecated
+  insert[K : Hash + Eq](Self[K], K) -> Unit
   intersection[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   is_empty[K](Self[K]) -> Bool
   iter[K](Self[K]) -> Iter[K]
@@ -366,8 +366,8 @@ impl UninitializedArray {
 }
 
 impl Bool {
-  not(Bool) -> Bool //deprecated
-  op_compare(Bool, Bool) -> Int //deprecated
+  not(Bool) -> Bool
+  op_compare(Bool, Bool) -> Int
   to_string(Bool) -> String
 }
 
@@ -375,8 +375,8 @@ impl Byte {
   land(Byte, Byte) -> Byte
   lnot(Byte) -> Byte
   lor(Byte, Byte) -> Byte
-  lsl(Byte, Int) -> Byte //deprecated
-  lsr(Byte, Int) -> Byte //deprecated
+  lsl(Byte, Int) -> Byte
+  lsr(Byte, Int) -> Byte
   lxor(Byte, Byte) -> Byte
   op_add(Byte, Byte) -> Byte
   op_div(Byte, Byte) -> Byte
@@ -401,7 +401,7 @@ impl Char {
 }
 
 impl Int {
-  asr(Int, Int) -> Int //deprecated
+  asr(Int, Int) -> Int
   clz(Int) -> Int
   ctz(Int) -> Int
   is_neg(Int) -> Bool
@@ -411,8 +411,8 @@ impl Int {
   land(Int, Int) -> Int
   lnot(Int) -> Int
   lor(Int, Int) -> Int
-  lsl(Int, Int) -> Int //deprecated
-  lsr(Int, Int) -> Int //deprecated
+  lsl(Int, Int) -> Int
+  lsr(Int, Int) -> Int
   lxor(Int, Int) -> Int
   op_add(Int, Int) -> Int
   op_div(Int, Int) -> Int
@@ -425,19 +425,19 @@ impl Int {
   popcnt(Int) -> Int
   reinterpret_as_float(Int) -> Float
   reinterpret_as_uint(Int) -> UInt
-  shl(Int, Int) -> Int //deprecated
-  shr(Int, Int) -> Int //deprecated
+  shl(Int, Int) -> Int
+  shr(Int, Int) -> Int
   to_byte(Int) -> Byte
   to_double(Int) -> Double
   to_float(Int) -> Float
   to_int16(Int) -> Int16
   to_int64(Int) -> Int64
   to_string(Int, radix~ : Int = ..) -> String
-  to_uint(Int) -> UInt //deprecated
+  to_uint(Int) -> UInt
   to_uint16(Int) -> UInt16
   to_uint64(Int) -> UInt64
   until(Int, Int, step~ : Int = .., inclusive~ : Bool = ..) -> Iter[Int]
-  upto(Int, Int, inclusive~ : Bool = ..) -> Iter[Int] //deprecated
+  upto(Int, Int, inclusive~ : Bool = ..) -> Iter[Int]
 }
 
 impl Int16 {
@@ -448,14 +448,14 @@ impl Int16 {
 }
 
 impl Int64 {
-  asr(Int64, Int) -> Int64 //deprecated
+  asr(Int64, Int) -> Int64
   clz(Int64) -> Int
   ctz(Int64) -> Int
   land(Int64, Int64) -> Int64
   lnot(Int64) -> Int64
   lor(Int64, Int64) -> Int64
-  lsl(Int64, Int) -> Int64 //deprecated
-  lsr(Int64, Int) -> Int64 //deprecated
+  lsl(Int64, Int) -> Int64
+  lsr(Int64, Int) -> Int64
   lxor(Int64, Int64) -> Int64
   op_add(Int64, Int64) -> Int64
   op_div(Int64, Int64) -> Int64
@@ -468,8 +468,8 @@ impl Int64 {
   popcnt(Int64) -> Int
   reinterpret_as_double(Int64) -> Double
   reinterpret_as_uint64(Int64) -> UInt64
-  shl(Int64, Int) -> Int64 //deprecated
-  shr(Int64, Int) -> Int64 //deprecated
+  shl(Int64, Int) -> Int64
+  shr(Int64, Int) -> Int64
   to_byte(Int64) -> Byte
   to_double(Int64) -> Double
   to_float(Int64) -> Float
@@ -477,9 +477,9 @@ impl Int64 {
   to_int16(Int64) -> Int16
   to_string(Int64, radix~ : Int = ..) -> String
   to_uint16(Int64) -> UInt16
-  to_uint64(Int64) -> UInt64 //deprecated
+  to_uint64(Int64) -> UInt64
   until(Int64, Int64, step~ : Int64 = .., inclusive~ : Bool = ..) -> Iter[Int64]
-  upto(Int64, Int64, inclusive~ : Bool = ..) -> Iter[Int64] //deprecated
+  upto(Int64, Int64, inclusive~ : Bool = ..) -> Iter[Int64]
 }
 
 impl UInt {
@@ -488,8 +488,8 @@ impl UInt {
   land(UInt, UInt) -> UInt
   lnot(UInt) -> UInt
   lor(UInt, UInt) -> UInt
-  lsl(UInt, Int) -> UInt //deprecated
-  lsr(UInt, Int) -> UInt //deprecated
+  lsl(UInt, Int) -> UInt
+  lsr(UInt, Int) -> UInt
   lxor(UInt, UInt) -> UInt
   op_add(UInt, UInt) -> UInt
   op_div(UInt, UInt) -> UInt
@@ -502,16 +502,16 @@ impl UInt {
   popcnt(UInt) -> Int
   reinterpret_as_float(UInt) -> Float
   reinterpret_as_int(UInt) -> Int
-  shl(UInt, Int) -> UInt //deprecated
-  shr(UInt, Int) -> UInt //deprecated
+  shl(UInt, Int) -> UInt
+  shr(UInt, Int) -> UInt
   to_byte(UInt) -> Byte
   to_double(UInt) -> Double
   to_float(UInt) -> Float
-  to_int(UInt) -> Int //deprecated
+  to_int(UInt) -> Int
   to_string(UInt, radix~ : Int = ..) -> String
   to_uint64(UInt) -> UInt64
   trunc_double(Double) -> UInt
-  upto(UInt, UInt, inclusive~ : Bool = ..) -> Iter[UInt] //deprecated
+  upto(UInt, UInt, inclusive~ : Bool = ..) -> Iter[UInt]
 }
 
 impl UInt16 {
@@ -528,8 +528,8 @@ impl UInt64 {
   land(UInt64, UInt64) -> UInt64
   lnot(UInt64) -> UInt64
   lor(UInt64, UInt64) -> UInt64
-  lsl(UInt64, Int) -> UInt64 //deprecated
-  lsr(UInt64, Int) -> UInt64 //deprecated
+  lsl(UInt64, Int) -> UInt64
+  lsr(UInt64, Int) -> UInt64
   lxor(UInt64, UInt64) -> UInt64
   op_add(UInt64, UInt64) -> UInt64
   op_div(UInt64, UInt64) -> UInt64
@@ -541,17 +541,17 @@ impl UInt64 {
   popcnt(UInt64) -> Int
   reinterpret_as_double(UInt64) -> Double
   reinterpret_as_int64(UInt64) -> Int64
-  shl(UInt64, Int) -> UInt64 //deprecated
-  shr(UInt64, Int) -> UInt64 //deprecated
+  shl(UInt64, Int) -> UInt64
+  shr(UInt64, Int) -> UInt64
   to_byte(UInt64) -> Byte
   to_double(UInt64) -> Double
   to_float(UInt64) -> Float
   to_int(UInt64) -> Int
-  to_int64(UInt64) -> Int64 //deprecated
+  to_int64(UInt64) -> Int64
   to_string(UInt64, radix~ : Int = ..) -> String
   to_uint(UInt64) -> UInt
   trunc_double(Double) -> UInt64
-  upto(UInt64, UInt64, inclusive~ : Bool = ..) -> Iter[UInt64] //deprecated
+  upto(UInt64, UInt64, inclusive~ : Bool = ..) -> Iter[UInt64]
 }
 
 impl Float {
@@ -566,7 +566,7 @@ impl Float {
   sqrt(Float) -> Float
   to_double(Float) -> Double
   until(Float, Float, step~ : Float = .., inclusive~ : Bool = ..) -> Iter[Float]
-  upto(Float, Float, inclusive~ : Bool = ..) -> Iter[Float] //deprecated
+  upto(Float, Float, inclusive~ : Bool = ..) -> Iter[Float]
 }
 
 impl Double {
@@ -578,9 +578,9 @@ impl Double {
   op_neg(Double) -> Double
   op_neq(Double, Double) -> Bool
   op_sub(Double, Double) -> Double
-  reinterpret_as_i64(Double) -> Int64 //deprecated
+  reinterpret_as_i64(Double) -> Int64
   reinterpret_as_int64(Double) -> Int64
-  reinterpret_as_u64(Double) -> UInt64 //deprecated
+  reinterpret_as_u64(Double) -> UInt64
   reinterpret_as_uint64(Double) -> UInt64
   sqrt(Double) -> Double
   to_float(Double) -> Float
@@ -588,7 +588,7 @@ impl Double {
   to_int64(Double) -> Int64
   to_uint64(Double) -> UInt64
   until(Double, Double, step~ : Double = .., inclusive~ : Bool = ..) -> Iter[Double]
-  upto(Double, Double, inclusive~ : Bool = ..) -> Iter[Double] //deprecated
+  upto(Double, Double, inclusive~ : Bool = ..) -> Iter[Double]
 }
 
 impl String {
@@ -626,7 +626,7 @@ impl FixedArray {
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
   set[T](Self[T], Int, T) -> Unit
-  set_utf16_char(Self[Byte], Int, Char) -> Int //deprecated
+  set_utf16_char(Self[Byte], Int, Char) -> Int
   set_utf16be_char(Self[Byte], Int, Char) -> Int
   set_utf16le_char(Self[Byte], Int, Char) -> Int
   set_utf8_char(Self[Byte], Int, Char) -> Int
@@ -642,8 +642,8 @@ impl Bytes {
   new(Int) -> Bytes
   of_string(String) -> Bytes
   op_get(Bytes, Int) -> Byte
-  sub_string(Bytes, Int, Int) -> String //deprecated
-  to_string(Bytes) -> String //deprecated
+  sub_string(Bytes, Int, Int) -> String
+  to_string(Bytes) -> String
   to_unchecked_string(Bytes, offset~ : Int = .., length~ : Int = ..) -> String
   unsafe_get(Bytes, Int) -> Byte
 }

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -327,7 +327,7 @@ pub fn Byte::op_shr(self : Byte, count : Int) -> Byte {
 ///
 /// Returns the resulting `Byte` value after the bitwise left shift operation.
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn Byte::lsl(self : Byte, count : Int) -> Byte {
   (self.to_int() << count).to_byte()
@@ -343,7 +343,7 @@ pub fn Byte::lsl(self : Byte, count : Int) -> Byte {
 ///
 /// Returns the result of the logical shift right operation as a `Byte`.
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn Byte::lsr(self : Byte, count : Int) -> Byte {
   (self.to_uint() >> count).reinterpret_as_int().to_byte()

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -86,7 +86,7 @@ fn unsafe_sub_string(
 /// Return a new unchecked string, containing the subsequence of `self` that
 /// starts at `byte_offset` and has length `byte_length`.
 /// 
-/// @alert deprecated "Use `to_unchecked_string` instead"
+#deprecated("Use `to_unchecked_string` instead")
 #coverage.skip
 pub fn Bytes::sub_string(
   self : Bytes,
@@ -118,7 +118,7 @@ pub fn Bytes::sub_string(
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `to_unchecked_string` instead"
+#deprecated("Use `to_unchecked_string` instead")
 #coverage.skip
 pub fn Bytes::to_string(self : Bytes) -> String {
   self.to_unchecked_string(offset=0, length=self.length())
@@ -317,7 +317,7 @@ pub fn FixedArray::set_utf8_char(
 /// Fill utf16 encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
 /// @alert unsafe "Panic if the [value] is out of range"
-/// @alert deprecated "Use `set_utf16le_char` instead"
+#deprecated("Use `set_utf16le_char` instead")
 #coverage.skip
 pub fn FixedArray::set_utf16_char(
   self : FixedArray[Byte],

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -41,7 +41,7 @@ pub fn println[T : Show](input : T) -> Unit {
 
 ///|
 /// Prints and returns the value of a given expression for quick and dirty debugging.
-/// @alert deprecated "This function is for debugging only and should not be used in production"
+#deprecated("This function is for debugging only and should not be used in production")
 pub fn dump[T](t : T, name? : String, loc~ : SourceLoc = _) -> T {
   let name = match name {
     Some(name) => name

--- a/builtin/int64_js.mbt
+++ b/builtin/int64_js.mbt
@@ -422,35 +422,35 @@ pub fn Int64::lxor(self : Int64, other : Int64) -> Int64 {
 }
 
 ///|
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn Int64::lsl(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).lsl(other).to_int64()
 }
 
 ///|
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn Int64::shl(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).lsl(other).to_int64()
 }
 
 ///|
-/// @alert deprecated "Use UInt64 type and infix operator `>>` instead"
+#deprecated("Use UInt64 type and infix operator `>>` instead")
 #coverage.skip
 pub fn Int64::lsr(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).lsr(other).to_int64()
 }
 
 ///|
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn Int64::shr(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).asr(other).to_int64()
 }
 
 ///|
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn Int64::asr(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).asr(other).to_int64()
@@ -557,7 +557,7 @@ pub fn UInt16::to_int64(self : UInt16) -> Int64 {
 }
 
 ///|
-/// @alert deprecated "Use `reinterpret_as_int64` instead"
+#deprecated("Use `reinterpret_as_int64` instead")
 #coverage.skip
 pub fn Double::reinterpret_as_i64(self : Double) -> Int64 {
   MyInt64::reinterpret_double(self).to_int64()
@@ -569,7 +569,7 @@ pub fn Double::reinterpret_as_int64(self : Double) -> Int64 {
 }
 
 ///|
-/// @alert deprecated "Use `reinterpret_as_uint64` instead"
+#deprecated("Use `reinterpret_as_uint64` instead")
 #coverage.skip
 pub fn Double::reinterpret_as_u64(self : Double) -> UInt64 {
   MyInt64::reinterpret_double(self).to_uint64()
@@ -597,7 +597,7 @@ fn MyInt64::to_uint64(self : MyInt64) -> UInt64 = "%identity"
 fn MyInt64::from_uint64(value : UInt64) -> MyInt64 = "%identity"
 
 ///|
-/// @alert deprecated "Use `reinterpret_as_uint64` instead"
+#deprecated("Use `reinterpret_as_uint64` instead")
 #coverage.skip
 pub fn Int64::to_uint64(self : Int64) -> UInt64 = "%identity"
 
@@ -630,7 +630,7 @@ pub fn UInt64::op_mod(self : UInt64, other : UInt64) -> UInt64 {
 }
 
 ///|
-/// @alert deprecated "Use reinterpret_as_int64 instead"
+#deprecated("Use reinterpret_as_int64 instead")
 #coverage.skip
 pub fn UInt64::to_int64(self : UInt64) -> Int64 = "%identity"
 
@@ -688,28 +688,28 @@ pub fn UInt64::lnot(self : UInt64) -> UInt64 {
 }
 
 ///|
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
 ///|
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsr(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
 ///|
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn UInt64::shl(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
 ///|
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn UInt64::shr(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsr(MyInt64::from_uint64(self), shift).to_uint64()

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -284,7 +284,7 @@ pub fn Int64::lxor(self : Int64, other : Int64) -> Int64 = "%i64_lxor"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn Int64::lsl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 
@@ -309,7 +309,7 @@ pub fn Int64::lsl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn Int64::shl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 
@@ -336,7 +336,7 @@ pub fn Int64::shl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use UInt64 type and infix operator `>>` instead"
+#deprecated("Use UInt64 type and infix operator `>>` instead")
 #coverage.skip
 pub fn Int64::lsr(self : Int64, other : Int) -> Int64 = "%u64.shr"
 
@@ -364,7 +364,7 @@ pub fn Int64::lsr(self : Int64, other : Int) -> Int64 = "%u64.shr"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn Int64::asr(self : Int64, other : Int) -> Int64 = "%i64_shr"
 
@@ -390,7 +390,7 @@ pub fn Int64::asr(self : Int64, other : Int) -> Int64 = "%i64_shr"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn Int64::shr(self : Int64, other : Int) -> Int64 = "%i64_shr"
 
@@ -890,7 +890,7 @@ pub fn UInt16::to_int64(self : UInt16) -> Int64 = "%u16_to_i64"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `reinterpret_as_int64` instead"
+#deprecated("Use `reinterpret_as_int64` instead")
 #coverage.skip
 pub fn Double::reinterpret_as_i64(self : Double) -> Int64 = "%f64_to_i64_reinterpret"
 
@@ -942,7 +942,7 @@ pub fn Double::reinterpret_as_int64(self : Double) -> Int64 = "%f64_to_i64_reint
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `reinterpret_as_uint64` instead"
+#deprecated("Use `reinterpret_as_uint64` instead")
 #coverage.skip
 pub fn Double::reinterpret_as_u64(self : Double) -> UInt64 = "%f64_to_i64_reinterpret"
 
@@ -1016,7 +1016,7 @@ pub fn Double::convert_uint64(val : UInt64) -> Double = "%u64.to_f64"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `reinterpret_as_uint64` instead"
+#deprecated("Use `reinterpret_as_uint64` instead")
 #coverage.skip
 pub fn Int64::to_uint64(self : Int64) -> UInt64 = "%i64.to_u64_reinterpret"
 
@@ -1064,7 +1064,7 @@ pub fn Int64::reinterpret_as_uint64(self : Int64) -> UInt64 = "%i64.to_u64_reint
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `reinterpret_as_int64` instead"
+#deprecated("Use `reinterpret_as_int64` instead")
 #coverage.skip
 pub fn UInt64::to_int64(self : UInt64) -> Int64 = "%u64.to_i64_reinterpret"
 
@@ -1462,7 +1462,7 @@ pub fn UInt64::lnot(self : UInt64) -> UInt64 = "%u64.bitnot"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 
@@ -1488,7 +1488,7 @@ pub fn UInt64::lsl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn UInt64::shl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 
@@ -1512,7 +1512,7 @@ pub fn UInt64::shl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn UInt64::shr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 
@@ -1539,7 +1539,7 @@ pub fn UInt64::shr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -134,7 +134,7 @@ pub fn not(x : Bool) -> Bool = "%bool_not"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `not(x)` instead"
+#deprecated("Use `not(x)` instead")
 pub fn Bool::not(self : Bool) -> Bool = "%bool_not"
 
 ///|
@@ -190,7 +190,7 @@ pub impl Eq for Bool with op_equal(self : Bool, other : Bool) -> Bool = "%bool_e
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `compare` instead"
+#deprecated("Use `compare` instead")
 #coverage.skip
 pub fn Bool::op_compare(self : Bool, other : Bool) -> Int = "%bool_compare"
 
@@ -561,7 +561,7 @@ pub fn Int::op_shr(self : Int, other : Int) -> Int = "%i32_shr"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn Int::lsl(self : Int, other : Int) -> Int = "%i32_shl"
 
@@ -589,7 +589,7 @@ pub fn Int::lsl(self : Int, other : Int) -> Int = "%i32_shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn Int::shl(self : Int, other : Int) -> Int = "%i32_shl"
 
@@ -617,7 +617,7 @@ pub fn Int::shl(self : Int, other : Int) -> Int = "%i32_shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use UInt type and infix operator `>>` instead"
+#deprecated("Use UInt type and infix operator `>>` instead")
 #coverage.skip
 pub fn Int::lsr(self : Int, other : Int) -> Int {
   (self.reinterpret_as_uint() >> other).reinterpret_as_int()
@@ -645,7 +645,7 @@ pub fn Int::lsr(self : Int, other : Int) -> Int {
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn Int::asr(self : Int, other : Int) -> Int = "%i32_shr"
 
@@ -671,7 +671,7 @@ pub fn Int::asr(self : Int, other : Int) -> Int = "%i32_shr"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn Int::shr(self : Int, other : Int) -> Int = "%i32_shr"
 
@@ -897,7 +897,7 @@ pub fn Int::reinterpret_as_uint(self : Int) -> UInt = "%i32.to_u32_reinterpret"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `reinterpret_as_uint` instead"
+#deprecated("Use `reinterpret_as_uint` instead")
 #coverage.skip
 pub fn Int::to_uint(self : Int) -> UInt = "%i32.to_u32_reinterpret"
 // Double primitive ops
@@ -2003,7 +2003,7 @@ pub fn UInt::reinterpret_as_int(self : UInt) -> Int = "%u32.to_i32_reinterpret"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `reinterpret_as_int` instead"
+#deprecated("Use `reinterpret_as_int` instead")
 #coverage.skip
 pub fn UInt::to_int(self : UInt) -> Int = "%u32.to_i32_reinterpret"
 
@@ -2336,7 +2336,7 @@ pub fn UInt::lnot(self : UInt) -> UInt = "%u32.bitnot"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn UInt::lsl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 
@@ -2362,7 +2362,7 @@ pub fn UInt::lsl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `<<` instead"
+#deprecated("Use infix operator `<<` instead")
 #coverage.skip
 pub fn UInt::shl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 
@@ -2388,7 +2388,7 @@ pub fn UInt::shl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn UInt::lsr(self : UInt, shift : Int) -> UInt = "%u32.shr"
 
@@ -2413,7 +2413,7 @@ pub fn UInt::lsr(self : UInt, shift : Int) -> UInt = "%u32.shr"
 /// }
 /// ```
 ///
-/// @alert deprecated "Use infix operator `>>` instead"
+#deprecated("Use infix operator `>>` instead")
 #coverage.skip
 pub fn UInt::shr(self : UInt, shift : Int) -> UInt = "%u32.shr"
 

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -433,7 +433,7 @@ pub fn Iter::filter_map[A, B](self : Iter[A], f : (A) -> B?) -> Iter[B] {
 /// Transforms the elements of the iterator using a mapping function that returns an `Option`.
 /// The elements for which the function returns `None` are filtered out.
 ///
-/// @alert deprecated "Use `Iter::filter_map` instead"
+#deprecated("Use `Iter::filter_map` instead")
 pub fn Iter::map_option[A, B](self : Iter[A], f : (A) -> B?) -> Iter[B] {
   self.filter_map(f)
 }

--- a/builtin/iter_upto.mbt
+++ b/builtin/iter_upto.mbt
@@ -24,7 +24,7 @@
 /// # Returns
 ///
 /// Returns an iterator that iterates over the range of Int from `start` to `end - 1`.
-/// @alert deprecated "Use `..<` in for loop or `until` method instead"
+#deprecated("Use `..<` in for loop or `until` method instead")
 #coverage.skip
 pub fn Int::upto(self : Int, end : Int, inclusive~ : Bool = false) -> Iter[Int] {
   fn(yield_) {
@@ -55,7 +55,7 @@ pub fn Int::upto(self : Int, end : Int, inclusive~ : Bool = false) -> Iter[Int] 
 /// # Returns
 ///
 /// Returns an iterator that iterates over the range of UInt from `start` to `end - 1`.
-/// @alert deprecated "Use `..<` in for loop or `until` method instead"
+#deprecated("Use `..<` in for loop or `until` method instead")
 #coverage.skip
 pub fn UInt::upto(
   self : UInt,
@@ -90,7 +90,7 @@ pub fn UInt::upto(
 /// # Returns
 ///
 /// Returns an iterator that iterates over the range of UInt64 from `start` to `end - 1`.
-/// @alert deprecated "Use `..<` in for loop or `until` method instead"
+#deprecated("Use `..<` in for loop or `until` method instead")
 #coverage.skip
 pub fn UInt64::upto(
   self : UInt64,
@@ -125,7 +125,7 @@ pub fn UInt64::upto(
 /// # Returns
 ///
 /// Returns an iterator that iterates over the range of Int64 from `start` to `end - 1`.
-/// @alert deprecated "Use `..<` in for loop or `until` method instead"
+#deprecated("Use `..<` in for loop or `until` method instead")
 #coverage.skip
 pub fn Int64::upto(
   self : Int64,
@@ -160,7 +160,7 @@ pub fn Int64::upto(
 /// # Returns
 ///
 /// Returns an iterator that iterates over the range of Float from `start` to `end - 1`.
-/// @alert deprecated "Use `..<` in for loop or `until` method instead"
+#deprecated("Use `..<` in for loop or `until` method instead")
 #coverage.skip
 pub fn Float::upto(
   self : Float,
@@ -195,7 +195,7 @@ pub fn Float::upto(
 /// # Returns
 ///
 /// Returns an iterator that iterates over the range of Double from `start` to `end - 1`.
-/// @alert deprecated "Use `..<` in for loop or `until` method instead"
+#deprecated("Use `..<` in for loop or `until` method instead")
 #coverage.skip
 pub fn Double::upto(
   self : Double,

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -77,7 +77,7 @@ pub fn Set::from_array[K : Hash + Eq](arr : Array[K]) -> Set[K] {
 ///|
 /// Insert a key into the hash set.
 ///
-/// @alert deprecated "Use `add` instead."
+#deprecated("Use `add` instead.")
 #coverage.skip
 pub fn Set::insert[K : Hash + Eq](self : Set[K], key : K) -> Unit {
   self.add(key)

--- a/deque/deprecated.mbt
+++ b/deque/deprecated.mbt
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@deque.new` instead"
+#deprecated("use `@deque.new` instead")
 #coverage.skip
 pub fn T::new[A](capacity~ : Int = 0) -> T[A] {
   new(capacity~)
 }
 
 ///|
-/// @alert deprecated "use `@deque.from_array` instead"
+#deprecated("use `@deque.from_array` instead")
 #coverage.skip
 pub fn T::from_array[A](arr : Array[A]) -> T[A] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@deque.of` instead"
+#deprecated("use `@deque.of` instead")
 #coverage.skip
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
   of(arr)
 }
 
 ///|
-/// @alert deprecated "use `@deque.from_iter` instead"
+#deprecated("use `@deque.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[A](iter : Iter[A]) -> T[A] {
   from_iter(iter)

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -349,7 +349,7 @@ pub fn unsafe_pop_front[A](self : T[A]) -> Unit {
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `unsafe_pop_front` instead"
+#deprecated("Use `unsafe_pop_front` instead")
 #coverage.skip
 pub fn pop_front_exn[A](self : T[A]) -> Unit {
   unsafe_pop_front(self)
@@ -406,7 +406,7 @@ pub fn unsafe_pop_back[A](self : T[A]) -> Unit {
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `unsafe_pop_back` instead"
+#deprecated("Use `unsafe_pop_back` instead")
 #coverage.skip
 pub fn pop_back_exn[A](self : T[A]) -> Unit {
   unsafe_pop_back(self)
@@ -976,7 +976,7 @@ pub fn retain_map[A](self : T[A], f : (A) -> A?) -> Unit {
 /// deque to retain only elements for which the provided function returns `Some`,
 /// and updates those elements with the values inside the `Some` variant.
 ///
-/// @alert deprecated "Use `@deque.retain_map` instead"
+#deprecated("Use `@deque.retain_map` instead")
 pub fn filter_map_inplace[A](self : T[A], f : (A) -> A?) -> Unit {
   self.retain_map(f)
 }

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -17,7 +17,7 @@ fn each[A](T[A], (A) -> Unit) -> Unit
 
 fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
 
-fn filter_map_inplace[A](T[A], (A) -> A?) -> Unit //deprecated
+fn filter_map_inplace[A](T[A], (A) -> A?) -> Unit
 
 fn from_array[A](Array[A]) -> T[A]
 
@@ -47,11 +47,11 @@ fn op_set[A](T[A], Int, A) -> Unit
 
 fn pop_back[A](T[A]) -> A?
 
-fn pop_back_exn[A](T[A]) -> Unit //deprecated
+fn pop_back_exn[A](T[A]) -> Unit
 
 fn pop_front[A](T[A]) -> A?
 
-fn pop_front_exn[A](T[A]) -> Unit //deprecated
+fn pop_front_exn[A](T[A]) -> Unit
 
 fn push_back[A](T[A], A) -> Unit
 
@@ -94,9 +94,9 @@ impl T {
   copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
-  filter_map_inplace[A](Self[A], (A) -> A?) -> Unit //deprecated
-  from_array[A](Array[A]) -> Self[A] //deprecated
-  from_iter[A](Iter[A]) -> Self[A] //deprecated
+  filter_map_inplace[A](Self[A], (A) -> A?) -> Unit
+  from_array[A](Array[A]) -> Self[A]
+  from_iter[A](Iter[A]) -> Self[A]
   front[A](Self[A]) -> A?
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
@@ -104,14 +104,14 @@ impl T {
   length[A](Self[A]) -> Int
   map[A, U](Self[A], (A) -> U) -> Self[U]
   mapi[A, U](Self[A], (Int, A) -> U) -> Self[U]
-  new[A](capacity~ : Int = ..) -> Self[A] //deprecated
-  of[A](FixedArray[A]) -> Self[A] //deprecated
+  new[A](capacity~ : Int = ..) -> Self[A]
+  of[A](FixedArray[A]) -> Self[A]
   op_get[A](Self[A], Int) -> A
   op_set[A](Self[A], Int, A) -> Unit
   pop_back[A](Self[A]) -> A?
-  pop_back_exn[A](Self[A]) -> Unit //deprecated
+  pop_back_exn[A](Self[A]) -> Unit
   pop_front[A](Self[A]) -> A?
-  pop_front_exn[A](Self[A]) -> Unit //deprecated
+  pop_front_exn[A](Self[A]) -> Unit
   push_back[A](Self[A], A) -> Unit
   push_front[A](Self[A], A) -> Unit
   reserve_capacity[A](Self[A], Int) -> Unit

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -17,6 +17,7 @@ fn each[A](T[A], (A) -> Unit) -> Unit
 
 fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
 
+#deprecated
 fn filter_map_inplace[A](T[A], (A) -> A?) -> Unit
 
 fn from_array[A](Array[A]) -> T[A]
@@ -47,10 +48,12 @@ fn op_set[A](T[A], Int, A) -> Unit
 
 fn pop_back[A](T[A]) -> A?
 
+#deprecated
 fn pop_back_exn[A](T[A]) -> Unit
 
 fn pop_front[A](T[A]) -> A?
 
+#deprecated
 fn pop_front_exn[A](T[A]) -> Unit
 
 fn push_back[A](T[A], A) -> Unit
@@ -94,8 +97,11 @@ impl T {
   copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
+  #deprecated
   filter_map_inplace[A](Self[A], (A) -> A?) -> Unit
+  #deprecated
   from_array[A](Array[A]) -> Self[A]
+  #deprecated
   from_iter[A](Iter[A]) -> Self[A]
   front[A](Self[A]) -> A?
   is_empty[A](Self[A]) -> Bool
@@ -104,13 +110,17 @@ impl T {
   length[A](Self[A]) -> Int
   map[A, U](Self[A], (A) -> U) -> Self[U]
   mapi[A, U](Self[A], (Int, A) -> U) -> Self[U]
+  #deprecated
   new[A](capacity~ : Int = ..) -> Self[A]
+  #deprecated
   of[A](FixedArray[A]) -> Self[A]
   op_get[A](Self[A], Int) -> A
   op_set[A](Self[A], Int, A) -> Unit
   pop_back[A](Self[A]) -> A?
+  #deprecated
   pop_back_exn[A](Self[A]) -> Unit
   pop_front[A](Self[A]) -> A?
+  #deprecated
   pop_front_exn[A](Self[A]) -> Unit
   push_back[A](Self[A], A) -> Unit
   push_front[A](Self[A], A) -> Unit

--- a/double/double.mbt
+++ b/double/double.mbt
@@ -111,7 +111,7 @@ pub fn signum(self : Double) -> Double {
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `@double.not_a_number` instead"
+#deprecated("Use `@double.not_a_number` instead")
 #coverage.skip
 pub fn Double::nan() -> Double {
   not_a_number
@@ -119,7 +119,7 @@ pub fn Double::nan() -> Double {
 
 ///|
 /// Returns positive infinity if sign >= 0, negative infinity if sign < 0.
-/// @alert deprecated "Use `@double.infinity` and `@double.neg_infinity` instead"
+#deprecated("Use `@double.infinity` and `@double.neg_infinity` instead")
 #coverage.skip
 pub fn Double::inf(sign : Int) -> Double {
   if sign >= 0 {
@@ -145,7 +145,7 @@ pub fn Double::inf(sign : Int) -> Double {
 /// }
 /// ```
 ///
-/// @alert deprecated "Use `@double.min_positive` instead"
+#deprecated("Use `@double.min_positive` instead")
 #coverage.skip
 pub fn Double::min_normal() -> Double {
   min_positive

--- a/double/double.mbti
+++ b/double/double.mbti
@@ -110,7 +110,7 @@ impl Double {
   floor(Double) -> Double
   from_int(Int) -> Double
   hypot(Double, Double) -> Double
-  inf(Int) -> Double //deprecated
+  inf(Int) -> Double
   is_close(Double, Double, relative_tolerance~ : Double = .., absolute_tolerance~ : Double = ..) -> Bool
   is_inf(Double) -> Bool
   is_nan(Double) -> Bool
@@ -120,8 +120,8 @@ impl Double {
   ln_1p(Double) -> Double
   log10(Double) -> Double
   log2(Double) -> Double
-  min_normal() -> Double //deprecated
-  nan() -> Double //deprecated
+  min_normal() -> Double
+  nan() -> Double
   op_mod(Double, Double) -> Double
   pow(Double, Double) -> Double
   round(Double) -> Double

--- a/double/double.mbti
+++ b/double/double.mbti
@@ -110,6 +110,7 @@ impl Double {
   floor(Double) -> Double
   from_int(Int) -> Double
   hypot(Double, Double) -> Double
+  #deprecated
   inf(Int) -> Double
   is_close(Double, Double, relative_tolerance~ : Double = .., absolute_tolerance~ : Double = ..) -> Bool
   is_inf(Double) -> Bool
@@ -120,7 +121,9 @@ impl Double {
   ln_1p(Double) -> Double
   log10(Double) -> Double
   log2(Double) -> Double
+  #deprecated
   min_normal() -> Double
+  #deprecated
   nan() -> Double
   op_mod(Double, Double) -> Double
   pow(Double, Double) -> Double

--- a/hashmap/deprecated.mbt
+++ b/hashmap/deprecated.mbt
@@ -35,7 +35,7 @@
 /// }
 /// ```
 ///
-/// @alert deprecated "use `@hashmap.new` instead"
+#deprecated("use `@hashmap.new` instead")
 #coverage.skip
 pub fn T::new[K, V](capacity~ : Int = 8) -> T[K, V] {
   new(capacity~)
@@ -63,7 +63,7 @@ pub fn T::new[K, V](capacity~ : Int = 8) -> T[K, V] {
 /// }
 /// ```
 ///
-/// @alert deprecated "use `@hashmap.from_array` instead"
+#deprecated("use `@hashmap.from_array` instead")
 #coverage.skip
 pub fn T::from_array[K : Hash + Eq, V](arr : Array[(K, V)]) -> T[K, V] {
   from_array(arr)
@@ -89,7 +89,7 @@ pub fn T::from_array[K : Hash + Eq, V](arr : Array[(K, V)]) -> T[K, V] {
 /// }
 /// ```
 ///
-/// @alert deprecated "use `@hashmap.of` instead"
+#deprecated("use `@hashmap.of` instead")
 #coverage.skip
 pub fn T::of[K : Eq + Hash, V](arr : FixedArray[(K, V)]) -> T[K, V] {
   of(arr)

--- a/hashmap/hashmap.mbti
+++ b/hashmap/hashmap.mbti
@@ -53,16 +53,16 @@ impl T {
   contains[K : Hash + Eq, V](Self[K, V], K) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
-  from_array[K : Hash + Eq, V](Array[(K, V)]) -> Self[K, V] //deprecated
-  from_iter[K : Hash + Eq, V](Iter[(K, V)]) -> Self[K, V] //deprecated
+  from_array[K : Hash + Eq, V](Array[(K, V)]) -> Self[K, V]
+  from_iter[K : Hash + Eq, V](Iter[(K, V)]) -> Self[K, V]
   get[K : Hash + Eq, V](Self[K, V], K) -> V?
   get_or_default[K : Hash + Eq, V](Self[K, V], K, V) -> V
   get_or_init[K : Hash + Eq, V](Self[K, V], K, () -> V) -> V
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
-  new[K, V](capacity~ : Int = ..) -> Self[K, V] //deprecated
-  of[K : Eq + Hash, V](FixedArray[(K, V)]) -> Self[K, V] //deprecated
+  new[K, V](capacity~ : Int = ..) -> Self[K, V]
+  of[K : Eq + Hash, V](FixedArray[(K, V)]) -> Self[K, V]
   op_get[K : Hash + Eq, V](Self[K, V], K) -> V?
   op_set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   remove[K : Hash + Eq, V](Self[K, V], K) -> Unit

--- a/hashmap/hashmap.mbti
+++ b/hashmap/hashmap.mbti
@@ -53,7 +53,9 @@ impl T {
   contains[K : Hash + Eq, V](Self[K, V], K) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
+  #deprecated
   from_array[K : Hash + Eq, V](Array[(K, V)]) -> Self[K, V]
+  #deprecated
   from_iter[K : Hash + Eq, V](Iter[(K, V)]) -> Self[K, V]
   get[K : Hash + Eq, V](Self[K, V], K) -> V?
   get_or_default[K : Hash + Eq, V](Self[K, V], K, V) -> V
@@ -61,7 +63,9 @@ impl T {
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
+  #deprecated
   new[K, V](capacity~ : Int = ..) -> Self[K, V]
+  #deprecated
   of[K : Eq + Hash, V](FixedArray[(K, V)]) -> Self[K, V]
   op_get[K : Hash + Eq, V](Self[K, V], K) -> V?
   op_set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -184,7 +184,7 @@ pub fn from_iter[K : Hash + Eq, V](iter : Iter[(K, V)]) -> T[K, V] {
 /// }
 /// ```
 ///
-/// @alert deprecated "use `@hashmap.from_iter` instead"
+#deprecated("use `@hashmap.from_iter` instead")
 pub fn T::from_iter[K : Hash + Eq, V](iter : Iter[(K, V)]) -> T[K, V] {
   from_iter(iter)
 }

--- a/hashset/deprecated.mbt
+++ b/hashset/deprecated.mbt
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@hashset.new` instead"
+#deprecated("use `@hashset.new` instead")
 #coverage.skip
 pub fn T::new[K](capacity~ : Int = default_init_capacity) -> T[K] {
   new(capacity~)
 }
 
 ///|
-/// @alert deprecated "use `@hashset.from_array` instead"
+#deprecated("use `@hashset.from_array` instead")
 #coverage.skip
 pub fn T::from_array[K : Hash + Eq](arr : Array[K]) -> T[K] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@hashset.of` instead"
+#deprecated("use `@hashset.of` instead")
 #coverage.skip
 pub fn T::of[K : Hash + Eq](arr : FixedArray[K]) -> T[K] {
   of(arr)
 }
 
 ///|
-/// @alert deprecated "use `@hashset.from_iter` instead"
+#deprecated("use `@hashset.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[K : Hash + Eq](iter : Iter[K]) -> T[K] {
   from_iter(iter)

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -45,7 +45,7 @@ pub fn of[K : Hash + Eq](arr : FixedArray[K]) -> T[K] {
 ///|
 /// Insert a key into hash set.
 /// @alert unsafe "Panic if the hash set is full."
-/// @alert deprecated "Use `add` instead."
+#deprecated("Use `add` instead.")
 #coverage.skip
 pub fn insert[K : Hash + Eq](self : T[K], key : K) -> Unit {
   self.add(key)

--- a/hashset/hashset.mbti
+++ b/hashset/hashset.mbti
@@ -21,7 +21,7 @@ fn from_array[K : Hash + Eq](Array[K]) -> T[K]
 
 fn from_iter[K : Hash + Eq](Iter[K]) -> T[K]
 
-fn insert[K : Hash + Eq](T[K], K) -> Unit //deprecated
+fn insert[K : Hash + Eq](T[K], K) -> Unit
 
 fn intersection[K : Hash + Eq](T[K], T[K]) -> T[K]
 
@@ -53,14 +53,14 @@ impl T {
   difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   each[K](Self[K], (K) -> Unit) -> Unit
   eachi[K](Self[K], (Int, K) -> Unit) -> Unit
-  from_array[K : Hash + Eq](Array[K]) -> Self[K] //deprecated
-  from_iter[K : Hash + Eq](Iter[K]) -> Self[K] //deprecated
-  insert[K : Hash + Eq](Self[K], K) -> Unit //deprecated
+  from_array[K : Hash + Eq](Array[K]) -> Self[K]
+  from_iter[K : Hash + Eq](Iter[K]) -> Self[K]
+  insert[K : Hash + Eq](Self[K], K) -> Unit
   intersection[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   is_empty[K](Self[K]) -> Bool
   iter[K](Self[K]) -> Iter[K]
-  new[K](capacity~ : Int = ..) -> Self[K] //deprecated
-  of[K : Hash + Eq](FixedArray[K]) -> Self[K] //deprecated
+  new[K](capacity~ : Int = ..) -> Self[K]
+  of[K : Hash + Eq](FixedArray[K]) -> Self[K]
   remove[K : Hash + Eq](Self[K], K) -> Unit
   size[K](Self[K]) -> Int
   symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]

--- a/hashset/hashset.mbti
+++ b/hashset/hashset.mbti
@@ -21,6 +21,7 @@ fn from_array[K : Hash + Eq](Array[K]) -> T[K]
 
 fn from_iter[K : Hash + Eq](Iter[K]) -> T[K]
 
+#deprecated
 fn insert[K : Hash + Eq](T[K], K) -> Unit
 
 fn intersection[K : Hash + Eq](T[K], T[K]) -> T[K]
@@ -53,13 +54,18 @@ impl T {
   difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   each[K](Self[K], (K) -> Unit) -> Unit
   eachi[K](Self[K], (Int, K) -> Unit) -> Unit
+  #deprecated
   from_array[K : Hash + Eq](Array[K]) -> Self[K]
+  #deprecated
   from_iter[K : Hash + Eq](Iter[K]) -> Self[K]
+  #deprecated
   insert[K : Hash + Eq](Self[K], K) -> Unit
   intersection[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
   is_empty[K](Self[K]) -> Bool
   iter[K](Self[K]) -> Iter[K]
+  #deprecated
   new[K](capacity~ : Int = ..) -> Self[K]
+  #deprecated
   of[K : Hash + Eq](FixedArray[K]) -> Self[K]
   remove[K : Hash + Eq](Self[K], K) -> Unit
   size[K](Self[K]) -> Int

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -45,7 +45,7 @@ pub fn of[A](arr : FixedArray[A]) -> T[A] {
 /// Since it is an immutable data structure,
 /// it is rarely the case that you would need this function.
 /// 
-/// @alert deprecated "We don't copy immutable array"
+#deprecated("We don't copy immutable array")
 #coverage.skip
 pub fn copy[A](self : T[A]) -> T[A] {
   fn copy(t : Tree[A]) -> Tree[A] {
@@ -262,7 +262,7 @@ pub fn rev_fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
 /// let v = @array.of([1, 2, 3, 4, 5])
 /// assert_eq!(v.fold(fn(a, b) { a + b }, init=0), 15)
 /// ```
-/// @alert deprecated "Use `fold` instead"
+#deprecated("Use `fold` instead")
 #coverage.skip
 pub fn fold_left[A](self : T[A], f : (A, A) -> A, init~ : A) -> A {
   self.fold(init~, f)
@@ -276,7 +276,7 @@ pub fn fold_left[A](self : T[A], f : (A, A) -> A, init~ : A) -> A {
 /// let v = @array.of([1, 2, 3, 4, 5])
 /// assert_eq!(v.rev_fold(fn(a, b) { a + b }, init=0), 15)
 /// ```
-/// @alert deprecated "Use `rev_fold` instead"
+#deprecated("Use `rev_fold` instead")
 #coverage.skip
 pub fn fold_right[A](self : T[A], f : (A, A) -> A, init~ : A) -> A {
   self.rev_fold(init~, f)

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -5,6 +5,7 @@ alias @moonbitlang/core/quickcheck as @quickcheck
 // Values
 fn concat[A](T[A], T[A]) -> T[A]
 
+#deprecated
 fn copy[A](T[A]) -> T[A]
 
 fn each[A](T[A], (A) -> Unit) -> Unit
@@ -13,8 +14,10 @@ fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
 
 fn fold[A, B](T[A], init~ : B, (B, A) -> B) -> B
 
+#deprecated
 fn fold_left[A](T[A], (A, A) -> A, init~ : A) -> A
 
+#deprecated
 fn fold_right[A](T[A], (A, A) -> A, init~ : A) -> A
 
 fn from_array[A](Array[A]) -> T[A]
@@ -53,21 +56,30 @@ fn to_array[A](T[A]) -> Array[A]
 type T[A]
 impl T {
   concat[A](Self[A], Self[A]) -> Self[A]
+  #deprecated
   copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
+  #deprecated
   fold_left[A](Self[A], (A, A) -> A, init~ : A) -> A
+  #deprecated
   fold_right[A](Self[A], (A, A) -> A, init~ : A) -> A
+  #deprecated
   from_array[A](Array[A]) -> Self[A]
+  #deprecated
   from_iter[A](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
+  #deprecated
   make[A](Int, A) -> Self[A]
+  #deprecated
   makei[A](Int, (Int) -> A) -> Self[A]
   map[A, B](Self[A], (A) -> B) -> Self[B]
+  #deprecated
   new[A]() -> Self[A]
+  #deprecated
   of[A](FixedArray[A]) -> Self[A]
   op_add[A](Self[A], Self[A]) -> Self[A]
   op_get[A](Self[A], Int) -> A

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -5,7 +5,7 @@ alias @moonbitlang/core/quickcheck as @quickcheck
 // Values
 fn concat[A](T[A], T[A]) -> T[A]
 
-fn copy[A](T[A]) -> T[A] //deprecated
+fn copy[A](T[A]) -> T[A]
 
 fn each[A](T[A], (A) -> Unit) -> Unit
 
@@ -13,9 +13,9 @@ fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
 
 fn fold[A, B](T[A], init~ : B, (B, A) -> B) -> B
 
-fn fold_left[A](T[A], (A, A) -> A, init~ : A) -> A //deprecated
+fn fold_left[A](T[A], (A, A) -> A, init~ : A) -> A
 
-fn fold_right[A](T[A], (A, A) -> A, init~ : A) -> A //deprecated
+fn fold_right[A](T[A], (A, A) -> A, init~ : A) -> A
 
 fn from_array[A](Array[A]) -> T[A]
 
@@ -53,22 +53,22 @@ fn to_array[A](T[A]) -> Array[A]
 type T[A]
 impl T {
   concat[A](Self[A], Self[A]) -> Self[A]
-  copy[A](Self[A]) -> Self[A] //deprecated
+  copy[A](Self[A]) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
-  fold_left[A](Self[A], (A, A) -> A, init~ : A) -> A //deprecated
-  fold_right[A](Self[A], (A, A) -> A, init~ : A) -> A //deprecated
-  from_array[A](Array[A]) -> Self[A] //deprecated
-  from_iter[A](Iter[A]) -> Self[A] //deprecated
+  fold_left[A](Self[A], (A, A) -> A, init~ : A) -> A
+  fold_right[A](Self[A], (A, A) -> A, init~ : A) -> A
+  from_array[A](Array[A]) -> Self[A]
+  from_iter[A](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
-  make[A](Int, A) -> Self[A] //deprecated
-  makei[A](Int, (Int) -> A) -> Self[A] //deprecated
+  make[A](Int, A) -> Self[A]
+  makei[A](Int, (Int) -> A) -> Self[A]
   map[A, B](Self[A], (A) -> B) -> Self[B]
-  new[A]() -> Self[A] //deprecated
-  of[A](FixedArray[A]) -> Self[A] //deprecated
+  new[A]() -> Self[A]
+  of[A](FixedArray[A]) -> Self[A]
   op_add[A](Self[A], Self[A]) -> Self[A]
   op_get[A](Self[A], Int) -> A
   push[A](Self[A], A) -> Self[A]

--- a/immut/array/deprecated.mbt
+++ b/immut/array/deprecated.mbt
@@ -13,42 +13,42 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@immut/array.new` instead"
+#deprecated("use `@immut/array.new` instead")
 #coverage.skip
 pub fn T::new[A]() -> T[A] {
   new()
 }
 
 ///|
-/// @alert deprecated "use `@immut/array.from_iter` instead"
+#deprecated("use `@immut/array.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[A](iter : Iter[A]) -> T[A] {
   from_iter(iter)
 }
 
 ///|
-/// @alert deprecated "use `@immut/array.from_array` instead"
+#deprecated("use `@immut/array.from_array` instead")
 #coverage.skip
 pub fn T::from_array[A](arr : Array[A]) -> T[A] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@immut/array.make` instead"
+#deprecated("use `@immut/array.make` instead")
 #coverage.skip
 pub fn T::make[A](len : Int, value : A) -> T[A] {
   make(len, value)
 }
 
 ///|
-/// @alert deprecated "use `@immut/array.makei` instead"
+#deprecated("use `@immut/array.makei` instead")
 #coverage.skip
 pub fn T::makei[A](len : Int, f : (Int) -> A) -> T[A] {
   makei(len, f)
 }
 
 ///|
-/// @alert deprecated "use `@immut/array.of` instead"
+#deprecated("use `@immut/array.of` instead")
 #coverage.skip
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
   of(arr)

--- a/immut/hashmap/deprecated.mbt
+++ b/immut/hashmap/deprecated.mbt
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@immut/hashmap.new` instead"
+#deprecated("use `@immut/hashmap.new` instead")
 #coverage.skip
 pub fn T::new[K, V]() -> T[K, V] {
   new()
 }
 
 ///|
-/// @alert deprecated "use `@immut/hashmap.from_iter` instead"
+#deprecated("use `@immut/hashmap.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[K : Eq + Hash, V](iter : Iter[(K, V)]) -> T[K, V] {
   from_iter(iter)
 }
 
 ///|
-/// @alert deprecated "use `@immut/hashmap.from_array` instead"
+#deprecated("use `@immut/hashmap.from_array` instead")
 #coverage.skip
 pub fn T::from_array[K : Eq + Hash, V](arr : Array[(K, V)]) -> T[K, V] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@immut/hashmap.of` instead"
+#deprecated("use `@immut/hashmap.of` instead")
 #coverage.skip
 pub fn T::of[K : Eq + Hash, V](arr : FixedArray[(K, V)]) -> T[K, V] {
   of(arr)

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -33,11 +33,15 @@ impl T {
   add[K : Eq + Hash, V](Self[K, V], K, V) -> Self[K, V]
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   find[K : Eq + Hash, V](Self[K, V], K) -> V?
+  #deprecated
   from_array[K : Eq + Hash, V](Array[(K, V)]) -> Self[K, V]
+  #deprecated
   from_iter[K : Eq + Hash, V](Iter[(K, V)]) -> Self[K, V]
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
+  #deprecated
   new[K, V]() -> Self[K, V]
+  #deprecated
   of[K : Eq + Hash, V](FixedArray[(K, V)]) -> Self[K, V]
   op_get[K : Eq + Hash, V](Self[K, V], K) -> V?
   remove[K : Eq + Hash, V](Self[K, V], K) -> Self[K, V]

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -33,12 +33,12 @@ impl T {
   add[K : Eq + Hash, V](Self[K, V], K, V) -> Self[K, V]
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   find[K : Eq + Hash, V](Self[K, V], K) -> V?
-  from_array[K : Eq + Hash, V](Array[(K, V)]) -> Self[K, V] //deprecated
-  from_iter[K : Eq + Hash, V](Iter[(K, V)]) -> Self[K, V] //deprecated
+  from_array[K : Eq + Hash, V](Array[(K, V)]) -> Self[K, V]
+  from_iter[K : Eq + Hash, V](Iter[(K, V)]) -> Self[K, V]
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
-  new[K, V]() -> Self[K, V] //deprecated
-  of[K : Eq + Hash, V](FixedArray[(K, V)]) -> Self[K, V] //deprecated
+  new[K, V]() -> Self[K, V]
+  of[K : Eq + Hash, V](FixedArray[(K, V)]) -> Self[K, V]
   op_get[K : Eq + Hash, V](Self[K, V], K) -> V?
   remove[K : Eq + Hash, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int

--- a/immut/hashset/deprecated.mbt
+++ b/immut/hashset/deprecated.mbt
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@immut/hashset.new` instead"
+#deprecated("use `@immut/hashset.new` instead")
 #coverage.skip
 pub fn T::new[A]() -> T[A] {
   new()
 }
 
 ///|
-/// @alert deprecated "use `@immut/hashset.from_iter` instead"
+#deprecated("use `@immut/hashset.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[A : Eq + Hash](iter : Iter[A]) -> T[A] {
   from_iter(iter)
 }
 
 ///|
-/// @alert deprecated "use `@immut/hashset.from_array` instead"
+#deprecated("use `@immut/hashset.from_array` instead")
 #coverage.skip
 pub fn T::from_array[A : Eq + Hash](arr : Array[A]) -> T[A] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@immut/hashset.of` instead"
+#deprecated("use `@immut/hashset.of` instead")
 #coverage.skip
 pub fn T::of[A : Eq + Hash](arr : FixedArray[A]) -> T[A] {
   of(arr)

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -31,12 +31,12 @@ impl T {
   add[A : Eq + Hash](Self[A], A) -> Self[A]
   contains[A : Eq + Hash](Self[A], A) -> Bool
   each[A](Self[A], (A) -> Unit) -> Unit
-  from_array[A : Eq + Hash](Array[A]) -> Self[A] //deprecated
-  from_iter[A : Eq + Hash](Iter[A]) -> Self[A] //deprecated
+  from_array[A : Eq + Hash](Array[A]) -> Self[A]
+  from_iter[A : Eq + Hash](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
-  new[A]() -> Self[A] //deprecated
-  of[A : Eq + Hash](FixedArray[A]) -> Self[A] //deprecated
+  new[A]() -> Self[A]
+  of[A : Eq + Hash](FixedArray[A]) -> Self[A]
   remove[A : Eq + Hash](Self[A], A) -> Self[A]
   size[A](Self[A]) -> Int
 }

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -31,11 +31,15 @@ impl T {
   add[A : Eq + Hash](Self[A], A) -> Self[A]
   contains[A : Eq + Hash](Self[A], A) -> Bool
   each[A](Self[A], (A) -> Unit) -> Unit
+  #deprecated
   from_array[A : Eq + Hash](Array[A]) -> Self[A]
+  #deprecated
   from_iter[A : Eq + Hash](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
+  #deprecated
   new[A]() -> Self[A]
+  #deprecated
   of[A : Eq + Hash](FixedArray[A]) -> Self[A]
   remove[A : Eq + Hash](Self[A], A) -> Self[A]
   size[A](Self[A]) -> Int

--- a/immut/list/deprecated.mbt
+++ b/immut/list/deprecated.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@immut/list.from_json` instead"
+#deprecated("use `@immut/list.from_json` instead")
 #coverage.skip
 pub fn T::from_json[A : @json.FromJson](
   json : Json
@@ -29,7 +29,7 @@ pub fn T::from_json[A : @json.FromJson](
 /// ```
 /// assert_eq!(@list.of([1, 2, 3]) == @list.of([1, 2, 3]), true)
 /// ```
-/// @alert deprecated "use `==` instead"
+#deprecated("use `==` instead")
 pub fn equal[A : Eq](self : T[A], other : T[A]) -> Bool {
   loop self, other {
     Nil, Nil => true
@@ -39,28 +39,28 @@ pub fn equal[A : Eq](self : T[A], other : T[A]) -> Bool {
 }
 
 ///|
-/// @alert deprecated "use `@immut/list.from_array` instead"
+#deprecated("use `@immut/list.from_array` instead")
 #coverage.skip
 pub fn T::from_array[A](arr : Array[A]) -> T[A] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@immut/list.default` instead"
+#deprecated("use `@immut/list.default` instead")
 #coverage.skip
 pub fn T::default[X]() -> T[X] {
   Nil
 }
 
 ///|
-/// @alert deprecated "use `@immut/list.from_iter` instead"
+#deprecated("use `@immut/list.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[A](iter : Iter[A]) -> T[A] {
   from_iter(iter)
 }
 
 ///|
-/// @alert deprecated "use `@immut/list.of` instead"
+#deprecated("use `@immut/list.of` instead")
 #coverage.skip
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
   of(arr)

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -248,7 +248,7 @@ pub fn unsafe_head[A](self : T[A]) -> A {
 }
 
 ///|
-/// @alert deprecated "Use `unsafe_head` instead"
+#deprecated("Use `unsafe_head` instead")
 #coverage.skip
 pub fn head_exn[A](self : T[A]) -> A {
   unsafe_head(self)
@@ -395,7 +395,7 @@ pub fn rev_fold[A, B](self : T[A], init~ : B, f : (A, B) -> B) -> B {
 /// let r = @list.of([1, 2, 3, 4, 5]).fold(init=0, fn(acc, x) { acc + x })
 /// assert_eq!(r, 15)
 /// ```
-/// @alert deprecated "Use `fold` instead"
+#deprecated("Use `fold` instead")
 #coverage.skip
 pub fn fold_left[A, B](self : T[A], f : (B, A) -> B, init~ : B) -> B {
   self.fold(init~, f)
@@ -409,7 +409,7 @@ pub fn fold_left[A, B](self : T[A], f : (B, A) -> B, init~ : B) -> B {
 /// let r = @list.of([1, 2, 3, 4, 5]).rev_fold(fn(x, acc) { x + acc }, init=0)
 /// assert_eq!(r, 15)
 /// ```
-/// @alert deprecated "Use `rev_fold` instead"
+#deprecated("Use `rev_fold` instead")
 #coverage.skip
 pub fn fold_right[A, B](self : T[A], f : (A, B) -> B, init~ : B) -> B {
   match self {
@@ -446,7 +446,7 @@ pub fn rev_foldi[A, B](self : T[A], init~ : B, f : (Int, A, B) -> B) -> B {
 
 ///|
 /// Fold the list from left with index.
-/// @alert deprecated "Use `foldi` instead"
+#deprecated("Use `foldi` instead")
 #coverage.skip
 pub fn fold_lefti[A, B](self : T[A], f : (Int, B, A) -> B, init~ : B) -> B {
   fn go(xs : T[A], i : Int, f : (Int, B, A) -> B, acc : B) -> B {
@@ -461,7 +461,7 @@ pub fn fold_lefti[A, B](self : T[A], f : (Int, B, A) -> B, init~ : B) -> B {
 
 ///|
 /// Fold the list from right with index.
-/// @alert deprecated "Use `rev_foldi` instead"
+#deprecated("Use `rev_foldi` instead")
 #coverage.skip
 pub fn fold_righti[A, B](self : T[A], f : (Int, A, B) -> B, init~ : B) -> B {
   fn go(xs : T[A], i : Int, f : (Int, A, B) -> B, acc : B) -> B {
@@ -509,7 +509,7 @@ pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)]? {
 /// let r = ls.flat_map(fn(x) { @list.from_array([x, x * 2]) })
 /// assert_eq!(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// ```
-/// @alert deprecated "Use `flat_map` instead"
+#deprecated("Use `flat_map` instead")
 #coverage.skip
 pub fn concat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
   flat_map(self, f)
@@ -566,7 +566,7 @@ pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
 }
 
 ///|
-/// @alert deprecated "Use `unsafe_nth` instead"
+#deprecated("Use `unsafe_nth` instead")
 #coverage.skip
 pub fn nth_exn[A](self : T[A], n : Int) -> A {
   unsafe_nth(self, n)

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -12,7 +12,7 @@ fn any[A](T[A], (A) -> Bool) -> Bool
 
 fn concat[A](T[A], T[A]) -> T[A]
 
-fn concat_map[A, B](T[A], (A) -> T[B]) -> T[B] //deprecated
+fn concat_map[A, B](T[A], (A) -> T[B]) -> T[B]
 
 fn contains[A : Eq](T[A], A) -> Bool
 
@@ -26,7 +26,7 @@ fn each[A](T[A], (A) -> Unit) -> Unit
 
 fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
 
-fn equal[A : Eq](T[A], T[A]) -> Bool //deprecated
+fn equal[A : Eq](T[A], T[A]) -> Bool
 
 fn filter[A](T[A], (A) -> Bool) -> T[A]
 
@@ -42,13 +42,13 @@ fn flatten[A](T[T[A]]) -> T[A]
 
 fn fold[A, B](T[A], init~ : B, (B, A) -> B) -> B
 
-fn fold_left[A, B](T[A], (B, A) -> B, init~ : B) -> B //deprecated
+fn fold_left[A, B](T[A], (B, A) -> B, init~ : B) -> B
 
-fn fold_lefti[A, B](T[A], (Int, B, A) -> B, init~ : B) -> B //deprecated
+fn fold_lefti[A, B](T[A], (Int, B, A) -> B, init~ : B) -> B
 
-fn fold_right[A, B](T[A], (A, B) -> B, init~ : B) -> B //deprecated
+fn fold_right[A, B](T[A], (A, B) -> B, init~ : B) -> B
 
-fn fold_righti[A, B](T[A], (Int, A, B) -> B, init~ : B) -> B //deprecated
+fn fold_righti[A, B](T[A], (Int, A, B) -> B, init~ : B) -> B
 
 fn foldi[A, B](T[A], init~ : B, (Int, B, A) -> B) -> B
 
@@ -62,7 +62,7 @@ fn from_json[A : @json.FromJson](Json) -> T[A]!@json.JsonDecodeError
 
 fn head[A](T[A]) -> A?
 
-fn head_exn[A](T[A]) -> A //deprecated
+fn head_exn[A](T[A]) -> A
 
 fn init_[A](T[A]) -> T[A]
 
@@ -96,7 +96,7 @@ fn minimum[A : Compare](T[A]) -> A?
 
 fn nth[A](T[A], Int) -> A?
 
-fn nth_exn[A](T[A], Int) -> A //deprecated
+fn nth_exn[A](T[A], Int) -> A
 
 fn of[A](FixedArray[A]) -> T[A]
 
@@ -162,14 +162,14 @@ impl T {
   all[A](Self[A], (A) -> Bool) -> Bool
   any[A](Self[A], (A) -> Bool) -> Bool
   concat[A](Self[A], Self[A]) -> Self[A]
-  concat_map[A, B](Self[A], (A) -> Self[B]) -> Self[B] //deprecated
+  concat_map[A, B](Self[A], (A) -> Self[B]) -> Self[B]
   contains[A : Eq](Self[A], A) -> Bool
-  default[X]() -> Self[X] //deprecated
+  default[X]() -> Self[X]
   drop[A](Self[A], Int) -> Self[A]
   drop_while[A](Self[A], (A) -> Bool) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
-  equal[A : Eq](Self[A], Self[A]) -> Bool //deprecated
+  equal[A : Eq](Self[A], Self[A]) -> Bool
   filter[A](Self[A], (A) -> Bool) -> Self[A]
   filter_map[A, B](Self[A], (A) -> B?) -> Self[B]
   find[A](Self[A], (A) -> Bool) -> A?
@@ -177,16 +177,16 @@ impl T {
   flat_map[A, B](Self[A], (A) -> Self[B]) -> Self[B]
   flatten[A](Self[Self[A]]) -> Self[A]
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
-  fold_left[A, B](Self[A], (B, A) -> B, init~ : B) -> B //deprecated
-  fold_lefti[A, B](Self[A], (Int, B, A) -> B, init~ : B) -> B //deprecated
-  fold_right[A, B](Self[A], (A, B) -> B, init~ : B) -> B //deprecated
-  fold_righti[A, B](Self[A], (Int, A, B) -> B, init~ : B) -> B //deprecated
+  fold_left[A, B](Self[A], (B, A) -> B, init~ : B) -> B
+  fold_lefti[A, B](Self[A], (Int, B, A) -> B, init~ : B) -> B
+  fold_right[A, B](Self[A], (A, B) -> B, init~ : B) -> B
+  fold_righti[A, B](Self[A], (Int, A, B) -> B, init~ : B) -> B
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
-  from_array[A](Array[A]) -> Self[A] //deprecated
-  from_iter[A](Iter[A]) -> Self[A] //deprecated
-  from_json[A : @json.FromJson](Json) -> Self[A]!@json.JsonDecodeError //deprecated
+  from_array[A](Array[A]) -> Self[A]
+  from_iter[A](Iter[A]) -> Self[A]
+  from_json[A : @json.FromJson](Json) -> Self[A]!@json.JsonDecodeError
   head[A](Self[A]) -> A?
-  head_exn[A](Self[A]) -> A //deprecated
+  head_exn[A](Self[A]) -> A
   init_[A](Self[A]) -> Self[A]
   intercalate[A](Self[Self[A]], Self[A]) -> Self[A]
   intersperse[A](Self[A], A) -> Self[A]
@@ -203,8 +203,8 @@ impl T {
   maximum[A : Compare](Self[A]) -> A?
   minimum[A : Compare](Self[A]) -> A?
   nth[A](Self[A], Int) -> A?
-  nth_exn[A](Self[A], Int) -> A //deprecated
-  of[A](FixedArray[A]) -> Self[A] //deprecated
+  nth_exn[A](Self[A], Int) -> A
+  of[A](FixedArray[A]) -> Self[A]
   op_add[A](Self[A], Self[A]) -> Self[A]
   remove[A : Eq](Self[A], A) -> Self[A]
   remove_at[A](Self[A], Int) -> Self[A]

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -12,6 +12,7 @@ fn any[A](T[A], (A) -> Bool) -> Bool
 
 fn concat[A](T[A], T[A]) -> T[A]
 
+#deprecated
 fn concat_map[A, B](T[A], (A) -> T[B]) -> T[B]
 
 fn contains[A : Eq](T[A], A) -> Bool
@@ -26,6 +27,7 @@ fn each[A](T[A], (A) -> Unit) -> Unit
 
 fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
 
+#deprecated
 fn equal[A : Eq](T[A], T[A]) -> Bool
 
 fn filter[A](T[A], (A) -> Bool) -> T[A]
@@ -42,12 +44,16 @@ fn flatten[A](T[T[A]]) -> T[A]
 
 fn fold[A, B](T[A], init~ : B, (B, A) -> B) -> B
 
+#deprecated
 fn fold_left[A, B](T[A], (B, A) -> B, init~ : B) -> B
 
+#deprecated
 fn fold_lefti[A, B](T[A], (Int, B, A) -> B, init~ : B) -> B
 
+#deprecated
 fn fold_right[A, B](T[A], (A, B) -> B, init~ : B) -> B
 
+#deprecated
 fn fold_righti[A, B](T[A], (Int, A, B) -> B, init~ : B) -> B
 
 fn foldi[A, B](T[A], init~ : B, (Int, B, A) -> B) -> B
@@ -62,6 +68,7 @@ fn from_json[A : @json.FromJson](Json) -> T[A]!@json.JsonDecodeError
 
 fn head[A](T[A]) -> A?
 
+#deprecated
 fn head_exn[A](T[A]) -> A
 
 fn init_[A](T[A]) -> T[A]
@@ -96,6 +103,7 @@ fn minimum[A : Compare](T[A]) -> A?
 
 fn nth[A](T[A], Int) -> A?
 
+#deprecated
 fn nth_exn[A](T[A], Int) -> A
 
 fn of[A](FixedArray[A]) -> T[A]
@@ -162,13 +170,16 @@ impl T {
   all[A](Self[A], (A) -> Bool) -> Bool
   any[A](Self[A], (A) -> Bool) -> Bool
   concat[A](Self[A], Self[A]) -> Self[A]
+  #deprecated
   concat_map[A, B](Self[A], (A) -> Self[B]) -> Self[B]
   contains[A : Eq](Self[A], A) -> Bool
+  #deprecated
   default[X]() -> Self[X]
   drop[A](Self[A], Int) -> Self[A]
   drop_while[A](Self[A], (A) -> Bool) -> Self[A]
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
+  #deprecated
   equal[A : Eq](Self[A], Self[A]) -> Bool
   filter[A](Self[A], (A) -> Bool) -> Self[A]
   filter_map[A, B](Self[A], (A) -> B?) -> Self[B]
@@ -177,15 +188,23 @@ impl T {
   flat_map[A, B](Self[A], (A) -> Self[B]) -> Self[B]
   flatten[A](Self[Self[A]]) -> Self[A]
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
+  #deprecated
   fold_left[A, B](Self[A], (B, A) -> B, init~ : B) -> B
+  #deprecated
   fold_lefti[A, B](Self[A], (Int, B, A) -> B, init~ : B) -> B
+  #deprecated
   fold_right[A, B](Self[A], (A, B) -> B, init~ : B) -> B
+  #deprecated
   fold_righti[A, B](Self[A], (Int, A, B) -> B, init~ : B) -> B
   foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
+  #deprecated
   from_array[A](Array[A]) -> Self[A]
+  #deprecated
   from_iter[A](Iter[A]) -> Self[A]
+  #deprecated
   from_json[A : @json.FromJson](Json) -> Self[A]!@json.JsonDecodeError
   head[A](Self[A]) -> A?
+  #deprecated
   head_exn[A](Self[A]) -> A
   init_[A](Self[A]) -> Self[A]
   intercalate[A](Self[Self[A]], Self[A]) -> Self[A]
@@ -203,7 +222,9 @@ impl T {
   maximum[A : Compare](Self[A]) -> A?
   minimum[A : Compare](Self[A]) -> A?
   nth[A](Self[A], Int) -> A?
+  #deprecated
   nth_exn[A](Self[A], Int) -> A
+  #deprecated
   of[A](FixedArray[A]) -> Self[A]
   op_add[A](Self[A], Self[A]) -> Self[A]
   remove[A : Eq](Self[A], A) -> Self[A]

--- a/immut/priority_queue/deprecated.mbt
+++ b/immut/priority_queue/deprecated.mbt
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@immut/priority_queue.new` instead"
+#deprecated("use `@immut/priority_queue.new` instead")
 #coverage.skip
 pub fn T::new[A : Compare]() -> T[A] {
   new()
 }
 
 ///|
-/// @alert deprecated "use `@immut/priority_queue.from_array` instead"
+#deprecated("use `@immut/priority_queue.from_array` instead")
 #coverage.skip
 pub fn T::from_array[A : Compare](arr : Array[A]) -> T[A] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@immut/priority_queue.of` instead"
+#deprecated("use `@immut/priority_queue.of` instead")
 #coverage.skip
 pub fn T::of[A : Compare](arr : FixedArray[A]) -> T[A] {
   of(arr)

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -143,7 +143,7 @@ pub fn unsafe_pop[A : Compare](self : T[A]) -> T[A] {
 }
 
 ///|
-/// @alert deprecated "Use `unsafe_pop` instead"
+#deprecated("Use `unsafe_pop` instead")
 #coverage.skip
 pub fn pop_exn[A : Compare](self : T[A]) -> T[A] {
   unsafe_pop(self)

--- a/immut/priority_queue/priority_queue.mbti
+++ b/immut/priority_queue/priority_queue.mbti
@@ -19,6 +19,7 @@ fn peek[A](T[A]) -> A?
 
 fn pop[A : Compare](T[A]) -> T[A]?
 
+#deprecated
 fn pop_exn[A : Compare](T[A]) -> T[A]
 
 fn push[A : Compare](T[A], A) -> T[A]
@@ -30,15 +31,19 @@ fn unsafe_pop[A : Compare](T[A]) -> T[A]
 // Types and methods
 type T[A]
 impl T {
+  #deprecated
   from_array[A : Compare](Array[A]) -> Self[A]
   from_iter[A : Compare](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A : Compare](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
+  #deprecated
   new[A : Compare]() -> Self[A]
+  #deprecated
   of[A : Compare](FixedArray[A]) -> Self[A]
   peek[A](Self[A]) -> A?
   pop[A : Compare](Self[A]) -> Self[A]?
+  #deprecated
   pop_exn[A : Compare](Self[A]) -> Self[A]
   push[A : Compare](Self[A], A) -> Self[A]
   to_array[A : Compare](Self[A]) -> Array[A]

--- a/immut/priority_queue/priority_queue.mbti
+++ b/immut/priority_queue/priority_queue.mbti
@@ -19,7 +19,7 @@ fn peek[A](T[A]) -> A?
 
 fn pop[A : Compare](T[A]) -> T[A]?
 
-fn pop_exn[A : Compare](T[A]) -> T[A] //deprecated
+fn pop_exn[A : Compare](T[A]) -> T[A]
 
 fn push[A : Compare](T[A], A) -> T[A]
 
@@ -30,16 +30,16 @@ fn unsafe_pop[A : Compare](T[A]) -> T[A]
 // Types and methods
 type T[A]
 impl T {
-  from_array[A : Compare](Array[A]) -> Self[A] //deprecated
+  from_array[A : Compare](Array[A]) -> Self[A]
   from_iter[A : Compare](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A : Compare](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
-  new[A : Compare]() -> Self[A] //deprecated
-  of[A : Compare](FixedArray[A]) -> Self[A] //deprecated
+  new[A : Compare]() -> Self[A]
+  of[A : Compare](FixedArray[A]) -> Self[A]
   peek[A](Self[A]) -> A?
   pop[A : Compare](Self[A]) -> Self[A]?
-  pop_exn[A : Compare](Self[A]) -> Self[A] //deprecated
+  pop_exn[A : Compare](Self[A]) -> Self[A]
   push[A : Compare](Self[A], A) -> Self[A]
   to_array[A : Compare](Self[A]) -> Array[A]
   unsafe_pop[A : Compare](Self[A]) -> Self[A]

--- a/immut/sorted_map/deprecated.mbt
+++ b/immut/sorted_map/deprecated.mbt
@@ -16,49 +16,49 @@
 /// Create a new map with a key-value pair inserted.
 /// O(log n).
 ///
-/// @alert deprecated "Use `add` instead"
+#deprecated("Use `add` instead")
 #coverage.skip
 pub fn insert[K : Compare, V](self : T[K, V], key : K, value : V) -> T[K, V] {
   self.add(key, value)
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_map.new` instead"
+#deprecated("use `@immut/sorted_map.new` instead")
 #coverage.skip
 pub fn T::new[K, V]() -> T[K, V] {
   Empty
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_map.singleton` instead"
+#deprecated("use `@immut/sorted_map.singleton` instead")
 #coverage.skip
 pub fn T::singleton[K, V](key : K, value : V) -> T[K, V] {
   singleton(key, value)
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_map.from_array` instead"
+#deprecated("use `@immut/sorted_map.from_array` instead")
 #coverage.skip
 pub fn T::from_array[K : Compare, V](array : Array[(K, V)]) -> T[K, V] {
   from_array(array)
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_map.from_iter` instead"
+#deprecated("use `@immut/sorted_map.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[K : Compare, V](iter : Iter[(K, V)]) -> T[K, V] {
   from_iter(iter)
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_map.of` instead"
+#deprecated("use `@immut/sorted_map.of` instead")
 #coverage.skip
 pub fn T::of[K : Compare, V](array : FixedArray[(K, V)]) -> T[K, V] {
   of(array)
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_map.from_json` instead"
+#deprecated("use `@immut/sorted_map.from_json` instead")
 #coverage.skip
 pub fn T::from_json[V : @json.FromJson](
   json : Json

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -30,7 +30,7 @@ fn from_iter[K : Compare, V](Iter[(K, V)]) -> T[K, V]
 
 fn from_json[V : @json.FromJson](Json) -> T[String, V]!@json.JsonDecodeError
 
-fn insert[K : Compare, V](T[K, V], K, V) -> T[K, V] //deprecated
+fn insert[K : Compare, V](T[K, V], K, V) -> T[K, V]
 
 fn is_empty[K, V](T[K, V]) -> Bool
 
@@ -70,16 +70,16 @@ impl T {
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
   elems[K, V](Self[K, V]) -> Array[V]
-  empty[K, V]() -> Self[K, V] //deprecated
+  empty[K, V]() -> Self[K, V]
   filter[K : Compare, V](Self[K, V], (V) -> Bool) -> Self[K, V]
   filter_with_key[K : Compare, V](Self[K, V], (K, V) -> Bool) -> Self[K, V]
   fold[K, V, A](Self[K, V], init~ : A, (A, V) -> A) -> A
   foldl_with_key[K, V, A](Self[K, V], (A, K, V) -> A, init~ : A) -> A
   foldr_with_key[K, V, A](Self[K, V], (A, K, V) -> A, init~ : A) -> A
-  from_array[K : Compare, V](Array[(K, V)]) -> Self[K, V] //deprecated
-  from_iter[K : Compare, V](Iter[(K, V)]) -> Self[K, V] //deprecated
-  from_json[V : @json.FromJson](Json) -> Self[String, V]!@json.JsonDecodeError //deprecated
-  insert[K : Compare, V](Self[K, V], K, V) -> Self[K, V] //deprecated
+  from_array[K : Compare, V](Array[(K, V)]) -> Self[K, V]
+  from_iter[K : Compare, V](Iter[(K, V)]) -> Self[K, V]
+  from_json[V : @json.FromJson](Json) -> Self[String, V]!@json.JsonDecodeError
+  insert[K : Compare, V](Self[K, V], K, V) -> Self[K, V]
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
@@ -87,11 +87,11 @@ impl T {
   lookup[K : Compare, V](Self[K, V], K) -> V?
   map[K, X, Y](Self[K, X], (X) -> Y) -> Self[K, Y]
   map_with_key[K, X, Y](Self[K, X], (K, X) -> Y) -> Self[K, Y]
-  new[K, V]() -> Self[K, V] //deprecated
-  of[K : Compare, V](FixedArray[(K, V)]) -> Self[K, V] //deprecated
+  new[K, V]() -> Self[K, V]
+  of[K : Compare, V](FixedArray[(K, V)]) -> Self[K, V]
   op_get[K : Compare, V](Self[K, V], K) -> V?
   remove[K : Compare, V](Self[K, V], K) -> Self[K, V]
-  singleton[K, V](K, V) -> Self[K, V] //deprecated
+  singleton[K, V](K, V) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
   to_json[K : Show, V : ToJson](Self[K, V]) -> Json

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -30,6 +30,7 @@ fn from_iter[K : Compare, V](Iter[(K, V)]) -> T[K, V]
 
 fn from_json[V : @json.FromJson](Json) -> T[String, V]!@json.JsonDecodeError
 
+#deprecated
 fn insert[K : Compare, V](T[K, V], K, V) -> T[K, V]
 
 fn is_empty[K, V](T[K, V]) -> Bool
@@ -70,15 +71,20 @@ impl T {
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
   elems[K, V](Self[K, V]) -> Array[V]
+  #deprecated
   empty[K, V]() -> Self[K, V]
   filter[K : Compare, V](Self[K, V], (V) -> Bool) -> Self[K, V]
   filter_with_key[K : Compare, V](Self[K, V], (K, V) -> Bool) -> Self[K, V]
   fold[K, V, A](Self[K, V], init~ : A, (A, V) -> A) -> A
   foldl_with_key[K, V, A](Self[K, V], (A, K, V) -> A, init~ : A) -> A
   foldr_with_key[K, V, A](Self[K, V], (A, K, V) -> A, init~ : A) -> A
+  #deprecated
   from_array[K : Compare, V](Array[(K, V)]) -> Self[K, V]
+  #deprecated
   from_iter[K : Compare, V](Iter[(K, V)]) -> Self[K, V]
+  #deprecated
   from_json[V : @json.FromJson](Json) -> Self[String, V]!@json.JsonDecodeError
+  #deprecated
   insert[K : Compare, V](Self[K, V], K, V) -> Self[K, V]
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
@@ -87,10 +93,13 @@ impl T {
   lookup[K : Compare, V](Self[K, V], K) -> V?
   map[K, X, Y](Self[K, X], (X) -> Y) -> Self[K, Y]
   map_with_key[K, X, Y](Self[K, X], (K, X) -> Y) -> Self[K, Y]
+  #deprecated
   new[K, V]() -> Self[K, V]
+  #deprecated
   of[K : Compare, V](FixedArray[(K, V)]) -> Self[K, V]
   op_get[K : Compare, V](Self[K, V], K) -> V?
   remove[K : Compare, V](Self[K, V], K) -> Self[K, V]
+  #deprecated
   singleton[K, V](K, V) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///| Create an empty map.
-/// @alert deprecated "Use `new()` instead"
+#deprecated("Use `new()` instead")
 #coverage.skip
 pub fn T::empty[K, V]() -> T[K, V] {
   Empty

--- a/immut/sorted_set/deprecated.mbt
+++ b/immut/sorted_set/deprecated.mbt
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@immut/sorted_set.new` instead"
+#deprecated("use `@immut/sorted_set.new` instead")
 #coverage.skip
 pub fn T::new[A]() -> T[A] {
   Empty
 }
 
 ///|
-/// @alert deprecated "use `immut/sorted_set.singleton` instead"
+#deprecated("use `immut/sorted_set.singleton` instead")
 #coverage.skip
 pub fn T::singleton[A : Compare](value : A) -> T[A] {
   singleton(value)
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_set.from_array` instead"
+#deprecated("use `@immut/sorted_set.from_array` instead")
 #coverage.skip
 pub fn T::from_array[A : Compare](array : Array[A]) -> T[A] {
   from_array(array)
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_set.from_json` instead"
+#deprecated("use `@immut/sorted_set.from_json` instead")
 #coverage.skip
 pub fn T::from_json[A : @json.FromJson + Compare](
   json : Json
@@ -43,7 +43,7 @@ pub fn T::from_json[A : @json.FromJson + Compare](
 }
 
 ///|
-/// @alert deprecated "use `@immut/sorted_set.of` instead"
+#deprecated("use `@immut/sorted_set.of` instead")
 #coverage.skip
 pub fn T::of[A : Compare](array : FixedArray[A]) -> T[A] {
   of(array)

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -308,7 +308,7 @@ pub fn op_add[A : Compare](self : T[A], other : T[A]) -> T[A] {
 }
 
 ///|
-/// @alert deprecated "Use `intersection` instead"
+#deprecated("Use `intersection` instead")
 #coverage.skip
 pub fn inter[A : Compare](self : T[A], other : T[A]) -> T[A] {
   self.intersection(other)
@@ -342,7 +342,7 @@ pub fn intersection[A : Compare](self : T[A], other : T[A]) -> T[A] {
 /// assert_eq!(@sorted_set.of([1, 2, 3]).difference(@sorted_set.of([4, 5, 1])), @sorted_set.of([2, 3]))
 /// ```
 ///
-/// @alert deprecated "Use `difference` instead"
+#deprecated("Use `difference` instead")
 #coverage.skip
 pub fn diff[A : Compare](self : T[A], other : T[A]) -> T[A] {
   self.difference(other)

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -12,7 +12,7 @@ fn any[A : Compare](T[A], (A) -> Bool) -> Bool
 
 fn contains[A : Compare](T[A], A) -> Bool
 
-fn diff[A : Compare](T[A], T[A]) -> T[A] //deprecated
+fn diff[A : Compare](T[A], T[A]) -> T[A]
 
 fn difference[A : Compare](T[A], T[A]) -> T[A]
 
@@ -30,7 +30,7 @@ fn from_iter[A : Compare](Iter[A]) -> T[A]
 
 fn from_json[A : @json.FromJson + Compare](Json) -> T[A]!@json.JsonDecodeError
 
-fn inter[A : Compare](T[A], T[A]) -> T[A] //deprecated
+fn inter[A : Compare](T[A], T[A]) -> T[A]
 
 fn intersection[A : Compare](T[A], T[A]) -> T[A]
 
@@ -79,16 +79,16 @@ impl T {
   all[A : Compare](Self[A], (A) -> Bool) -> Bool
   any[A : Compare](Self[A], (A) -> Bool) -> Bool
   contains[A : Compare](Self[A], A) -> Bool
-  diff[A : Compare](Self[A], Self[A]) -> Self[A] //deprecated
+  diff[A : Compare](Self[A], Self[A]) -> Self[A]
   difference[A : Compare](Self[A], Self[A]) -> Self[A]
   disjoint[A : Compare](Self[A], Self[A]) -> Bool
   each[A](Self[A], (A) -> Unit) -> Unit
   filter[A : Compare](Self[A], (A) -> Bool) -> Self[A]
   fold[A : Compare, B](Self[A], init~ : B, (B, A) -> B) -> B
-  from_array[A : Compare](Array[A]) -> Self[A] //deprecated
+  from_array[A : Compare](Array[A]) -> Self[A]
   from_iter[A : Compare](Iter[A]) -> Self[A] //deprecated
-  from_json[A : @json.FromJson + Compare](Json) -> Self[A]!@json.JsonDecodeError //deprecated
-  inter[A : Compare](Self[A], Self[A]) -> Self[A] //deprecated
+  from_json[A : @json.FromJson + Compare](Json) -> Self[A]!@json.JsonDecodeError
+  inter[A : Compare](Self[A], Self[A]) -> Self[A]
   intersection[A : Compare](Self[A], Self[A]) -> Self[A]
   is_empty[A : Compare](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
@@ -97,12 +97,12 @@ impl T {
   max_option[A : Compare](Self[A]) -> A?
   min[A : Compare](Self[A]) -> A
   min_option[A : Compare](Self[A]) -> A?
-  new[A]() -> Self[A] //deprecated
-  of[A : Compare](FixedArray[A]) -> Self[A] //deprecated
+  new[A]() -> Self[A]
+  of[A : Compare](FixedArray[A]) -> Self[A]
   op_add[A : Compare](Self[A], Self[A]) -> Self[A]
   remove[A : Compare](Self[A], A) -> Self[A]
   remove_min[A : Compare](Self[A]) -> Self[A]
-  singleton[A : Compare](A) -> Self[A] //deprecated
+  singleton[A : Compare](A) -> Self[A]
   size[A : Compare](Self[A]) -> Int
   split[A : Compare](Self[A], A) -> (Self[A], Bool, Self[A])
   subset[A : Compare](Self[A], Self[A]) -> Bool

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -12,6 +12,7 @@ fn any[A : Compare](T[A], (A) -> Bool) -> Bool
 
 fn contains[A : Compare](T[A], A) -> Bool
 
+#deprecated
 fn diff[A : Compare](T[A], T[A]) -> T[A]
 
 fn difference[A : Compare](T[A], T[A]) -> T[A]
@@ -30,6 +31,7 @@ fn from_iter[A : Compare](Iter[A]) -> T[A]
 
 fn from_json[A : @json.FromJson + Compare](Json) -> T[A]!@json.JsonDecodeError
 
+#deprecated
 fn inter[A : Compare](T[A], T[A]) -> T[A]
 
 fn intersection[A : Compare](T[A], T[A]) -> T[A]
@@ -79,15 +81,19 @@ impl T {
   all[A : Compare](Self[A], (A) -> Bool) -> Bool
   any[A : Compare](Self[A], (A) -> Bool) -> Bool
   contains[A : Compare](Self[A], A) -> Bool
+  #deprecated
   diff[A : Compare](Self[A], Self[A]) -> Self[A]
   difference[A : Compare](Self[A], Self[A]) -> Self[A]
   disjoint[A : Compare](Self[A], Self[A]) -> Bool
   each[A](Self[A], (A) -> Unit) -> Unit
   filter[A : Compare](Self[A], (A) -> Bool) -> Self[A]
   fold[A : Compare, B](Self[A], init~ : B, (B, A) -> B) -> B
+  #deprecated
   from_array[A : Compare](Array[A]) -> Self[A]
   from_iter[A : Compare](Iter[A]) -> Self[A] //deprecated
+  #deprecated
   from_json[A : @json.FromJson + Compare](Json) -> Self[A]!@json.JsonDecodeError
+  #deprecated
   inter[A : Compare](Self[A], Self[A]) -> Self[A]
   intersection[A : Compare](Self[A], Self[A]) -> Self[A]
   is_empty[A : Compare](Self[A]) -> Bool
@@ -97,11 +103,14 @@ impl T {
   max_option[A : Compare](Self[A]) -> A?
   min[A : Compare](Self[A]) -> A
   min_option[A : Compare](Self[A]) -> A?
+  #deprecated
   new[A]() -> Self[A]
+  #deprecated
   of[A : Compare](FixedArray[A]) -> Self[A]
   op_add[A : Compare](Self[A], Self[A]) -> Self[A]
   remove[A : Compare](Self[A], A) -> Self[A]
   remove_min[A : Compare](Self[A]) -> Self[A]
+  #deprecated
   singleton[A : Compare](A) -> Self[A]
   size[A : Compare](Self[A]) -> Int
   split[A : Compare](Self[A], A) -> (Self[A], Bool, Self[A])

--- a/queue/deprecated.mbt
+++ b/queue/deprecated.mbt
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@queue.new` instead"
+#deprecated("use `@queue.new` instead")
 #coverage.skip
 pub fn T::new[A]() -> T[A] {
   new()
 }
 
 ///|
-/// @alert deprecated "use `@queue.from_array` instead"
+#deprecated("use `@queue.from_array` instead")
 #coverage.skip
 pub fn T::from_array[A](arr : Array[A]) -> T[A] {
   from_array(arr)
 }
 
 ///|
-/// @alert deprecated "use `@queue.from_iter` instead"
+#deprecated("use `@queue.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[A](iter : Iter[A]) -> T[A] {
   from_iter(iter)
 }
 
 ///|
-/// @alert deprecated "use `@queue.of` instead"
+#deprecated("use `@queue.of` instead")
 #coverage.skip
 pub fn T::of[A](arr : FixedArray[A]) -> T[A] {
   of(arr)

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -152,7 +152,7 @@ pub fn unsafe_peek[A](self : T[A]) -> A {
 }
 
 ///|
-/// @alert deprecated "Use `unsafe_peek` instead"
+#deprecated("Use `unsafe_peek` instead")
 #coverage.skip
 pub fn peek_exn[A](self : T[A]) -> A {
   unsafe_peek(self)
@@ -198,7 +198,7 @@ pub fn unsafe_pop[A](self : T[A]) -> A {
 }
 
 ///|
-/// @alert deprecated "Use `unsafe_pop` instead"
+#deprecated("Use `unsafe_pop` instead")
 #coverage.skip
 pub fn pop_exn[A](self : T[A]) -> A {
   unsafe_pop(self)

--- a/queue/queue.mbti
+++ b/queue/queue.mbti
@@ -29,11 +29,11 @@ fn of[A](FixedArray[A]) -> T[A]
 
 fn peek[A](T[A]) -> A?
 
-fn peek_exn[A](T[A]) -> A //deprecated
+fn peek_exn[A](T[A]) -> A
 
 fn pop[A](T[A]) -> A?
 
-fn pop_exn[A](T[A]) -> A //deprecated
+fn pop_exn[A](T[A]) -> A
 
 fn push[A](T[A], A) -> Unit
 
@@ -51,17 +51,17 @@ impl T {
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
-  from_array[A](Array[A]) -> Self[A] //deprecated
-  from_iter[A](Iter[A]) -> Self[A] //deprecated
+  from_array[A](Array[A]) -> Self[A]
+  from_iter[A](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
-  new[A]() -> Self[A] //deprecated
-  of[A](FixedArray[A]) -> Self[A] //deprecated
+  new[A]() -> Self[A]
+  of[A](FixedArray[A]) -> Self[A]
   peek[A](Self[A]) -> A?
-  peek_exn[A](Self[A]) -> A //deprecated
+  peek_exn[A](Self[A]) -> A
   pop[A](Self[A]) -> A?
-  pop_exn[A](Self[A]) -> A //deprecated
+  pop_exn[A](Self[A]) -> A
   push[A](Self[A], A) -> Unit
   transfer[A](Self[A], Self[A]) -> Unit
   unsafe_peek[A](Self[A]) -> A

--- a/queue/queue.mbti
+++ b/queue/queue.mbti
@@ -29,10 +29,12 @@ fn of[A](FixedArray[A]) -> T[A]
 
 fn peek[A](T[A]) -> A?
 
+#deprecated
 fn peek_exn[A](T[A]) -> A
 
 fn pop[A](T[A]) -> A?
 
+#deprecated
 fn pop_exn[A](T[A]) -> A
 
 fn push[A](T[A], A) -> Unit
@@ -51,16 +53,22 @@ impl T {
   each[A](Self[A], (A) -> Unit) -> Unit
   eachi[A](Self[A], (Int, A) -> Unit) -> Unit
   fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
+  #deprecated
   from_array[A](Array[A]) -> Self[A]
+  #deprecated
   from_iter[A](Iter[A]) -> Self[A]
   is_empty[A](Self[A]) -> Bool
   iter[A](Self[A]) -> Iter[A]
   length[A](Self[A]) -> Int
+  #deprecated
   new[A]() -> Self[A]
+  #deprecated
   of[A](FixedArray[A]) -> Self[A]
   peek[A](Self[A]) -> A?
+  #deprecated
   peek_exn[A](Self[A]) -> A
   pop[A](Self[A]) -> A?
+  #deprecated
   pop_exn[A](Self[A]) -> A
   push[A](Self[A], A) -> Unit
   transfer[A](Self[A], Self[A]) -> Unit

--- a/rational/deprecated.mbt
+++ b/rational/deprecated.mbt
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@rational.new` instead"
+#deprecated("use `@rational.new` instead")
 #coverage.skip
 pub fn T::new(numerator : Int64, denominator : Int64) -> T? {
   new(numerator, denominator)
 }
 
 ///|
-/// @alert deprecated "use `@rational.from_double` instead"
+#deprecated("use `@rational.from_double` instead")
 #coverage.skip
 pub fn T::from_double(value : Double) -> T!RationalError {
   from_double!(value)

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -42,9 +42,11 @@ impl T {
   ceil(Self) -> Int64
   floor(Self) -> Int64
   fract(Self) -> Self
+  #deprecated
   from_double(Double) -> Self!RationalError
   is_integer(Self) -> Bool
   neg(Self) -> Self
+  #deprecated
   new(Int64, Int64) -> Self?
   op_add(Self, Self) -> Self
   op_div(Self, Self) -> Self

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -42,10 +42,10 @@ impl T {
   ceil(Self) -> Int64
   floor(Self) -> Int64
   fract(Self) -> Self
-  from_double(Double) -> Self!RationalError //deprecated
+  from_double(Double) -> Self!RationalError
   is_integer(Self) -> Bool
   neg(Self) -> Self
-  new(Int64, Int64) -> Self? //deprecated
+  new(Int64, Int64) -> Self?
   op_add(Self, Self) -> Self
   op_div(Self, Self) -> Self
   op_mul(Self, Self) -> Self

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@sorted_map.from_iter` instead"
+#deprecated("use `@sorted_map.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[K : Compare, V](iter : Iter[(K, V)]) -> T[K, V] {
   from_iter(iter)

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -34,7 +34,7 @@ pub fn new[K, V]() -> T[K, V] {
 }
 
 ///|
-/// @alert deprecated "Use @sorted_map.from_array instead"
+#deprecated("Use @sorted_map.from_array instead")
 pub fn of[K : Compare, V](entries : Array[(K, V)]) -> T[K, V] {
   let map = { root: None, size: 0 }
   entries.each(fn(e) { map.add(e.0, e.1) })

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -29,7 +29,7 @@ fn keys[K, V](T[K, V]) -> Array[K]
 
 fn new[K, V]() -> T[K, V]
 
-fn of[K : Compare, V](Array[(K, V)]) -> T[K, V] //deprecated
+fn of[K : Compare, V](Array[(K, V)]) -> T[K, V]
 
 fn op_get[K : Compare, V](T[K, V], K) -> V?
 
@@ -53,7 +53,7 @@ impl T {
   contains[K : Compare, V](Self[K, V], K) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
-  from_iter[K : Compare, V](Iter[(K, V)]) -> Self[K, V] //deprecated
+  from_iter[K : Compare, V](Iter[(K, V)]) -> Self[K, V]
   get[K : Compare, V](Self[K, V], K) -> V?
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -29,6 +29,7 @@ fn keys[K, V](T[K, V]) -> Array[K]
 
 fn new[K, V]() -> T[K, V]
 
+#deprecated
 fn of[K : Compare, V](Array[(K, V)]) -> T[K, V]
 
 fn op_get[K : Compare, V](T[K, V], K) -> V?
@@ -53,6 +54,7 @@ impl T {
   contains[K : Compare, V](Self[K, V], K) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
+  #deprecated
   from_iter[K : Compare, V](Iter[(K, V)]) -> Self[K, V]
   get[K : Compare, V](Self[K, V], K) -> V?
   is_empty[K, V](Self[K, V]) -> Bool

--- a/sorted_set/deprecated.mbt
+++ b/sorted_set/deprecated.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "use `@sorted_set.from_iter` instead"
+#deprecated("use `@sorted_set.from_iter` instead")
 #coverage.skip
 pub fn T::from_iter[V : Compare](iter : Iter[V]) -> T[V] {
   from_iter(iter)

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -49,7 +49,7 @@ pub fn of[V : Compare](array : Array[V]) -> T[V] {
 /// It is just copying the tree structure, not the values.
 /// It requires a Clone trait on T, which we don't have yet.
 ///
-/// @alert deprecated "Use `copy` instead"
+#deprecated("Use `copy` instead")
 #coverage.skip
 pub fn deep_clone[V](self : T[V]) -> T[V] {
   copy(self)
@@ -268,7 +268,7 @@ fn join_right[V : Compare](l : Node[V]?, v : V, r : Node[V]?) -> Node[V] {
 ///|
 /// Returns the difference of two sets.
 /// 
-/// @alert deprecated "Use `difference` instead"
+#deprecated("Use `difference` instead")
 #coverage.skip
 pub fn diff[V : Compare](self : T[V], src : T[V]) -> T[V] {
   let ret = new()
@@ -286,7 +286,7 @@ pub fn difference[V : Compare](self : T[V], src : T[V]) -> T[V] {
 
 ///|
 /// Returns the intersection of two sets.
-/// @alert deprecated "Use `intersection` instead"
+#deprecated("Use `intersection` instead")
 #coverage.skip
 pub fn intersect[V : Compare](self : T[V], src : T[V]) -> T[V] {
   self.intersection(src)

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -9,8 +9,10 @@ fn contains[V : Compare](T[V], V) -> Bool
 
 fn copy[V](T[V]) -> T[V]
 
+#deprecated
 fn deep_clone[V](T[V]) -> T[V]
 
+#deprecated
 fn diff[V : Compare](T[V], T[V]) -> T[V]
 
 fn difference[V : Compare](T[V], T[V]) -> T[V]
@@ -25,6 +27,7 @@ fn from_array[V : Compare](Array[V]) -> T[V]
 
 fn from_iter[V : Compare](Iter[V]) -> T[V]
 
+#deprecated
 fn intersect[V : Compare](T[V], T[V]) -> T[V]
 
 fn intersection[V : Compare](T[V], T[V]) -> T[V]
@@ -57,13 +60,17 @@ impl T {
   add[V : Compare](Self[V], V) -> Unit
   contains[V : Compare](Self[V], V) -> Bool
   copy[V](Self[V]) -> Self[V]
+  #deprecated
   deep_clone[V](Self[V]) -> Self[V]
+  #deprecated
   diff[V : Compare](Self[V], Self[V]) -> Self[V]
   difference[V : Compare](Self[V], Self[V]) -> Self[V]
   disjoint[V : Compare](Self[V], Self[V]) -> Bool
   each[V](Self[V], (V) -> Unit) -> Unit
   eachi[V](Self[V], (Int, V) -> Unit) -> Unit
+  #deprecated
   from_iter[V : Compare](Iter[V]) -> Self[V]
+  #deprecated
   intersect[V : Compare](Self[V], Self[V]) -> Self[V]
   intersection[V : Compare](Self[V], Self[V]) -> Self[V]
   is_empty[V : Compare](Self[V]) -> Bool

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -9,9 +9,9 @@ fn contains[V : Compare](T[V], V) -> Bool
 
 fn copy[V](T[V]) -> T[V]
 
-fn deep_clone[V](T[V]) -> T[V] //deprecated
+fn deep_clone[V](T[V]) -> T[V]
 
-fn diff[V : Compare](T[V], T[V]) -> T[V] //deprecated
+fn diff[V : Compare](T[V], T[V]) -> T[V]
 
 fn difference[V : Compare](T[V], T[V]) -> T[V]
 
@@ -25,7 +25,7 @@ fn from_array[V : Compare](Array[V]) -> T[V]
 
 fn from_iter[V : Compare](Iter[V]) -> T[V]
 
-fn intersect[V : Compare](T[V], T[V]) -> T[V] //deprecated
+fn intersect[V : Compare](T[V], T[V]) -> T[V]
 
 fn intersection[V : Compare](T[V], T[V]) -> T[V]
 
@@ -57,14 +57,14 @@ impl T {
   add[V : Compare](Self[V], V) -> Unit
   contains[V : Compare](Self[V], V) -> Bool
   copy[V](Self[V]) -> Self[V]
-  deep_clone[V](Self[V]) -> Self[V] //deprecated
-  diff[V : Compare](Self[V], Self[V]) -> Self[V] //deprecated
+  deep_clone[V](Self[V]) -> Self[V]
+  diff[V : Compare](Self[V], Self[V]) -> Self[V]
   difference[V : Compare](Self[V], Self[V]) -> Self[V]
   disjoint[V : Compare](Self[V], Self[V]) -> Bool
   each[V](Self[V], (V) -> Unit) -> Unit
   eachi[V](Self[V], (Int, V) -> Unit) -> Unit
-  from_iter[V : Compare](Iter[V]) -> Self[V] //deprecated
-  intersect[V : Compare](Self[V], Self[V]) -> Self[V] //deprecated
+  from_iter[V : Compare](Iter[V]) -> Self[V]
+  intersect[V : Compare](Self[V], Self[V]) -> Self[V]
   intersection[V : Compare](Self[V], Self[V]) -> Self[V]
   is_empty[V : Compare](Self[V]) -> Bool
   iter[V](Self[V]) -> Iter[V]

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -42,7 +42,7 @@ let powtab = [
 
 ///|
 /// Create a zero decimal.
-/// @alert deprecated "Decimal will be changed to private. Use `@strconv.parse_double` instead"
+#deprecated("Decimal will be changed to private. Use `@strconv.parse_double` instead")
 pub fn Decimal::new() -> Decimal {
   Decimal::new_priv()
 }
@@ -60,7 +60,7 @@ fn Decimal::new_priv() -> Decimal {
 
 ///|
 /// Create a decimal with an Int64 value.
-/// @alert deprecated "Decimal will be changed to private. Use `@strconv.parse_double` instead"
+#deprecated("Decimal will be changed to private. Use `@strconv.parse_double` instead")
 pub fn Decimal::from_int64(v : Int64) -> Decimal {
   Decimal::from_int64_priv(v)
 }
@@ -255,7 +255,7 @@ fn to_double_priv(self : Decimal) -> Double!StrConvError {
 ///|
 /// Binary shift left (s > 0) or right (s < 0).
 /// The shift count must not larger than the max_shift to avoid overflow.
-/// @alert deprecated "use `@strconv.parse_double` instead to avoid using this method."
+#deprecated("use `@strconv.parse_double` instead to avoid using this method.")
 pub fn shift(self : Decimal, s : Int) -> Unit {
   self.shift_priv(s)
 }

--- a/strconv/strconv.mbti
+++ b/strconv/strconv.mbti
@@ -17,17 +17,17 @@ fn parse_uint(String, base~ : Int = ..) -> UInt!StrConvError
 
 fn parse_uint64(String, base~ : Int = ..) -> UInt64!StrConvError
 
-fn shift(Decimal, Int) -> Unit //deprecated
+fn shift(Decimal, Int) -> Unit
 
 fn to_double(Decimal) -> Double!StrConvError //deprecated
 
 // Types and methods
 type Decimal //deprecated
 impl Decimal {
-  from_int64(Int64) -> Self //deprecated
-  new() -> Self //deprecated
+  from_int64(Int64) -> Self
+  new() -> Self
   parse_decimal(String) -> Self!StrConvError //deprecated
-  shift(Self, Int) -> Unit //deprecated
+  shift(Self, Int) -> Unit
   to_double(Self) -> Double!StrConvError //deprecated
 }
 impl Show for Decimal

--- a/strconv/strconv.mbti
+++ b/strconv/strconv.mbti
@@ -17,6 +17,7 @@ fn parse_uint(String, base~ : Int = ..) -> UInt!StrConvError
 
 fn parse_uint64(String, base~ : Int = ..) -> UInt64!StrConvError
 
+#deprecated
 fn shift(Decimal, Int) -> Unit
 
 fn to_double(Decimal) -> Double!StrConvError //deprecated
@@ -24,9 +25,12 @@ fn to_double(Decimal) -> Double!StrConvError //deprecated
 // Types and methods
 type Decimal //deprecated
 impl Decimal {
+  #deprecated
   from_int64(Int64) -> Self
+  #deprecated
   new() -> Self
   parse_decimal(String) -> Self!StrConvError //deprecated
+  #deprecated
   shift(Self, Int) -> Unit
   to_double(Self) -> Double!StrConvError //deprecated
 }

--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 ///|
-/// @alert deprecated "Use `String::trim_start` instead"
+#deprecated("Use `String::trim_start` instead")
 #coverage.skip
 pub fn trim_left(self : String, trim_set : String) -> String {
   self.trim_start(trim_set)
 }
 
 ///|
-/// @alert deprecated "Use `String::trim_end` instead"
+#deprecated("Use `String::trim_end` instead")
 #coverage.skip
 pub fn trim_right(self : String, trim_set : String) -> String {
   self.trim_end(trim_set)

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -71,9 +71,9 @@ fn trim(String, String) -> String
 
 fn trim_end(String, String) -> String
 
-fn trim_left(String, String) -> String //deprecated
+fn trim_left(String, String) -> String
 
-fn trim_right(String, String) -> String //deprecated
+fn trim_right(String, String) -> String
 
 fn trim_space(String) -> String
 
@@ -132,8 +132,8 @@ impl String {
   to_upper(String) -> String
   trim(String, String) -> String
   trim_end(String, String) -> String
-  trim_left(String, String) -> String //deprecated
-  trim_right(String, String) -> String //deprecated
+  trim_left(String, String) -> String
+  trim_right(String, String) -> String
   trim_space(String) -> String
   trim_start(String, String) -> String
 }

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -71,8 +71,10 @@ fn trim(String, String) -> String
 
 fn trim_end(String, String) -> String
 
+#deprecated
 fn trim_left(String, String) -> String
 
+#deprecated
 fn trim_right(String, String) -> String
 
 fn trim_space(String) -> String
@@ -132,7 +134,9 @@ impl String {
   to_upper(String) -> String
   trim(String, String) -> String
   trim_end(String, String) -> String
+  #deprecated
   trim_left(String, String) -> String
+  #deprecated
   trim_right(String, String) -> String
   trim_space(String) -> String
   trim_start(String, String) -> String

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -20,7 +20,7 @@ fn debug_string[T : Show](t : T) -> String {
 }
 
 ///|
-/// @alert deprecated "Use built-in `assert_eq` instead"
+#deprecated("Use built-in `assert_eq` instead")
 #coverage.skip
 pub fn eq[T : Show + Eq](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
   if a != b {
@@ -31,7 +31,7 @@ pub fn eq[T : Show + Eq](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 }
 
 ///|
-/// @alert deprecated "Use built-in `assert_not_eq` instead"
+#deprecated("Use built-in `assert_not_eq` instead")
 #coverage.skip
 pub fn ne[T : Show + Eq](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
   if not(a != b) {
@@ -42,7 +42,7 @@ pub fn ne[T : Show + Eq](a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 }
 
 ///|
-/// @alert deprecated "Use built-in `assert_true` instead"
+#deprecated("Use built-in `assert_true` instead")
 #coverage.skip
 pub fn is_true(x : Bool, loc~ : SourceLoc = _) -> Unit! {
   if not(x) {
@@ -52,7 +52,7 @@ pub fn is_true(x : Bool, loc~ : SourceLoc = _) -> Unit! {
 }
 
 ///|
-/// @alert deprecated "Use built-in `assert_false` instead"
+#deprecated("Use built-in `assert_false` instead")
 #coverage.skip
 pub fn is_false(x : Bool, loc~ : SourceLoc = _) -> Unit! {
   if x {

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -1,17 +1,17 @@
 package moonbitlang/core/test
 
 // Values
-fn eq[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit! //deprecated
+fn eq[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit!
 
 fn fail[T](String, loc~ : SourceLoc = _) -> T!
 
-fn is_false(Bool, loc~ : SourceLoc = _) -> Unit! //deprecated
+fn is_false(Bool, loc~ : SourceLoc = _) -> Unit!
 
 fn is_not[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!
 
-fn is_true(Bool, loc~ : SourceLoc = _) -> Unit! //deprecated
+fn is_true(Bool, loc~ : SourceLoc = _) -> Unit!
 
-fn ne[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit! //deprecated
+fn ne[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit!
 
 fn same_object[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!
 

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -1,16 +1,20 @@
 package moonbitlang/core/test
 
 // Values
+#deprecated
 fn eq[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit!
 
 fn fail[T](String, loc~ : SourceLoc = _) -> T!
 
+#deprecated
 fn is_false(Bool, loc~ : SourceLoc = _) -> Unit!
 
 fn is_not[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!
 
+#deprecated
 fn is_true(Bool, loc~ : SourceLoc = _) -> Unit!
 
+#deprecated
 fn ne[T : Show + Eq](T, T, loc~ : SourceLoc = _) -> Unit!
 
 fn same_object[T : Show](T, T, loc~ : SourceLoc = _) -> Unit!


### PR DESCRIPTION
This PR is with help of tree-sitter.

```yaml
deprecated:
  search: |
    ((structure
      (comment) @deprecated
      .
      (semicolon)?
      .
      (structure_item (function_definition)))
     (#match? @deprecated "^/// @alert deprecated\\s+(?<message>\".*\")"))
  replace: |
    #deprecated($message)
```