### PR TITLE
make `merges` priority queue stack safe

### DIFF
--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -131,17 +131,13 @@ fn meld[A : Compare](x : Node[A], y : Node[A]) -> Node[A] {
 
 ///|
 fn merges[A : Compare](x : Node[A]) -> Node[A] {
-  match x {
-    Nil => Nil
-    Cons(sibling=Nil, ..) => x
-    Cons(sibling=Cons(sibling=Nil, ..) as s, ..) as x => {
-      x.sibling = Nil
-      meld(x, s)
-    }
-    Cons(sibling=Cons(sibling=s2, ..) as s1, ..) as x => {
+  loop x, Nil {
+    Nil, acc => acc
+    Cons(sibling=Nil, ..) as x, acc => meld(acc, x)
+    Cons(sibling=Cons(sibling=s2, ..) as s1, ..) as x, acc => {
       x.sibling = Nil
       s1.sibling = Nil
-      meld(merges(s2), meld(x, s1))
+      continue s2, meld(acc, meld(x, s1))
     }
   }
 }

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -185,3 +185,17 @@ test "complex" {
   inspect!(pq.iter(), content="[]")
   assert_eq!(pq.length(), 0)
 }
+
+///|
+test "priority queue large data" {
+  let pq = new()
+  for i in 0..=10000000 {
+    pq.push(-i)
+  }
+  assert_eq!(pq.length(), 10000001)
+  for i in 0..=10000000 {
+    assert_eq!(pq.pop(), Some(-i))
+  }
+  inspect!(pq.iter(), content="[]")
+  assert_eq!(pq.length(), 0)
+}


### PR DESCRIPTION
This PR just rewrites the `merges` using loop to avoid stack overflow