### PR TITLE
refactor: rewrite match with wildcard pattern to is pattern

### DIFF
--- a/array/fixedarray_sort.mbt
+++ b/array/fixedarray_sort.mbt
@@ -260,19 +260,17 @@ fn fixed_quick_sort[T : Compare](
     if not(balanced) {
       limit -= 1
     }
-    match pred {
-      Some(pred) =>
-        // pred is less than all elements in arr
-        // If pivot equals to pred, then we can skip all elements that are equal to pred.
-        if pred == arr[pivot] {
-          let mut i = pivot
-          while i < len && pred == arr[i] {
-            i = i + 1
-          }
-          arr = arr.slice(i, len)
-          continue
+    if pred is Some(pred) {
+      // pred is less than all elements in arr
+      // If pivot equals to pred, then we can skip all elements that are equal to pred.
+      if pred == arr[pivot] {
+        let mut i = pivot
+        while i < len && pred == arr[i] {
+          i = i + 1
         }
-      _ => ()
+        arr = arr.slice(i, len)
+        continue
+      }
     }
     let left = arr.slice(0, pivot)
     let right = arr.slice(pivot + 1, len)

--- a/array/fixedarray_sort_by.mbt
+++ b/array/fixedarray_sort_by.mbt
@@ -162,19 +162,17 @@ fn fixed_quick_sort_by[T](
     if not(balanced) {
       limit -= 1
     }
-    match pred {
-      Some(pred) =>
-        // pred is less than all elements in arr
-        // If pivot equals to pred, then we can skip all elements that are equal to pred.
-        if cmp(pred, arr[pivot]) == 0 {
-          let mut i = pivot
-          while i < len && cmp(pred, arr[i]) == 0 {
-            i = i + 1
-          }
-          arr = arr.slice(i, len)
-          continue
+    if pred is Some(pred) {
+      // pred is less than all elements in arr
+      // If pivot equals to pred, then we can skip all elements that are equal to pred.
+      if cmp(pred, arr[pivot]) == 0 {
+        let mut i = pivot
+        while i < len && cmp(pred, arr[i]) == 0 {
+          i = i + 1
         }
-      _ => ()
+        arr = arr.slice(i, len)
+        continue
+      }
     }
     let left = arr.slice(0, pivot)
     let right = arr.slice(pivot + 1, len)

--- a/array/sort.mbt
+++ b/array/sort.mbt
@@ -64,19 +64,17 @@ fn quick_sort[T : Compare](arr : ArrayView[T], pred : T?, limit : Int) -> Unit {
     if not(balanced) {
       limit -= 1
     }
-    match pred {
-      Some(pred) =>
-        // pred is less than all elements in arr
-        // If pivot equals to pred, then we can skip all elements that are equal to pred.
-        if pred == arr[pivot] {
-          let mut i = pivot
-          while i < len && pred == arr[i] {
-            i = i + 1
-          }
-          arr = arr[i:len]
-          continue
+    if pred is Some(pred) {
+      // pred is less than all elements in arr
+      // If pivot equals to pred, then we can skip all elements that are equal to pred.
+      if pred == arr[pivot] {
+        let mut i = pivot
+        while i < len && pred == arr[i] {
+          i = i + 1
         }
-      _ => ()
+        arr = arr[i:len]
+        continue
+      }
     }
     let left = arr[0:pivot]
     let right = arr[pivot + 1:len]

--- a/array/sort_by.mbt
+++ b/array/sort_by.mbt
@@ -89,19 +89,17 @@ fn quick_sort_by[T](
     if not(balanced) {
       limit -= 1
     }
-    match pred {
-      Some(pred) =>
-        // pred is less than all elements in arr
-        // If pivot equals to pred, then we can skip all elements that are equal to pred.
-        if cmp(pred, arr[pivot]) == 0 {
-          let mut i = pivot
-          while i < len && cmp(pred, arr[i]) == 0 {
-            i = i + 1
-          }
-          arr = arr[i:len]
-          continue
+    if pred is Some(pred) {
+      // pred is less than all elements in arr
+      // If pivot equals to pred, then we can skip all elements that are equal to pred.
+      if cmp(pred, arr[pivot]) == 0 {
+        let mut i = pivot
+        while i < len && cmp(pred, arr[i]) == 0 {
+          i = i + 1
         }
-      _ => ()
+        arr = arr[i:len]
+        continue
+      }
     }
     let left = arr[0:pivot]
     let right = arr[pivot + 1:len]

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -213,12 +213,9 @@ pub fn T::from_iter[K : Hash + Eq, V](iter : Iter[(K, V)]) -> T[K, V] {
 pub fn to_array[K, V](self : T[K, V]) -> Array[(K, V)] {
   let mut i = 0
   let res = while i < self.capacity {
-    match self.entries[i] {
-      Some({ key, value, .. }) => {
-        i += 1
-        break Array::make(self.size, (key, value))
-      }
-      _ => ()
+    if self.entries[i] is Some({ key, value, .. }) {
+      i += 1
+      break Array::make(self.size, (key, value))
     }
     i += 1
   } else {
@@ -227,12 +224,9 @@ pub fn to_array[K, V](self : T[K, V]) -> Array[(K, V)] {
   if not(res.is_empty()) {
     let mut res_idx = 1
     while res_idx < res.length() && i < self.capacity {
-      match self.entries[i] {
-        Some({ key, value, .. }) => {
-          res[res_idx] = (key, value)
-          res_idx += 1
-        }
-        _ => ()
+      if self.entries[i] is Some({ key, value, .. }) {
+        res[res_idx] = (key, value)
+        res_idx += 1
       }
       i += 1
     }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -444,12 +444,9 @@ test "clear" {
 pub fn to_array[K](self : T[K]) -> Array[K] {
   let mut i = 0
   let res = while i < self.capacity {
-    match self.entries[i] {
-      Some({ key, .. }) => {
-        i += 1
-        break Array::make(self.size, key)
-      }
-      _ => ()
+    if self.entries[i] is Some({ key, .. }) {
+      i += 1
+      break Array::make(self.size, key)
     }
     i += 1
   } else {
@@ -458,12 +455,9 @@ pub fn to_array[K](self : T[K]) -> Array[K] {
   if not(res.is_empty()) {
     let mut res_idx = 1
     while res_idx < res.length() && i < self.capacity {
-      match self.entries[i] {
-        Some({ key, .. }) => {
-          res[res_idx] = key
-          res_idx += 1
-        }
-        _ => ()
+      if self.entries[i] is Some({ key, .. }) {
+        res[res_idx] = key
+        res_idx += 1
       }
       i += 1
     }

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -66,10 +66,7 @@ fn new_branch_left[T](leaf : FixedArray[T], shift : Int) -> Tree[T] {
 
 ///|
 fn Tree::is_empty_tree[T](self : Tree[T]) -> Bool {
-  match self {
-    Tree::Empty => true
-    _ => false
-  }
+  self is Empty
 }
 
 //-----------------------------------------------------------------------------

--- a/immut/array/tree_utils.mbt
+++ b/immut/array/tree_utils.mbt
@@ -18,26 +18,17 @@
 ///|
 /// If the tree is a `Node`.
 fn Tree::is_node[A](self : Tree[A]) -> Bool {
-  match self {
-    Node(_, _) => true
-    _ => false
-  }
+  self is Node(_, _)
 }
 
 ///|
 fn Tree::is_leaf[A](self : Tree[A]) -> Bool {
-  match self {
-    Leaf(_) => true
-    _ => false
-  }
+  self is Leaf(_)
 }
 
 ///|
 fn Tree::is_empty[A](self : Tree[A]) -> Bool {
-  match self {
-    Empty => true
-    _ => false
-  }
+  self is Empty
 }
 
 ///|
@@ -63,19 +54,19 @@ fn Tree::left_child[A](self : Tree[A]) -> Tree[A] {
 ///|
 /// Get the leaf contents. Abort if it is not a `Leaf`.
 fn Tree::leaf_elements[A](self : Tree[A]) -> FixedArray[A] {
-  match self {
-    Leaf(children) => children
-    _ => abort("Should not call `get_leaf_elements` on non-leaf nodes")
+  guard self is Leaf(children) else {
+    abort("Should not call `get_leaf_elements` on non-leaf nodes")
   }
+  children
 }
 
 ///|
 /// Get the children of a `Node`. Abort if it is not a `Node`.
 fn Tree::node_children[A](self : Tree[A]) -> FixedArray[Tree[A]] {
-  match self {
-    Node(children, _) => children
-    _ => abort("Should not call `node_children` on non-`Node`s")
+  guard self is Node(children, _) else {
+    abort("Should not call `node_children` on non-`Node`s")
   }
+  children
 }
 
 ///|

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -181,10 +181,7 @@ pub fn size[A](self : T[A]) -> Int {
 ///|
 /// Returns true if the hash set is empty.
 pub fn is_empty[A](self : T[A]) -> Bool {
-  match self {
-    Empty => true
-    _ => false
-  }
+  self is Empty
 }
 
 ///|

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -40,17 +40,13 @@ pub fn to_json[A : ToJson](self : T[A]) -> Json {
 
 ///|
 pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) {
-  match json {
-    Array(arr) =>
-      for i = arr.length() - 1, list = Nil; i >= 0; {
-        continue i - 1, list.add(A::from_json!(arr[i], path))
-      } else {
-        list
-      }
-    _ =>
-      raise @json.JsonDecodeError(
-        (path, "@immut/list.from_json: expected array"),
-      )
+  guard json is Array(arr) else {
+    raise @json.JsonDecodeError((path, "@immut/list.from_json: expected array"))
+  }
+  for i = arr.length() - 1, list = Nil; i >= 0; {
+    continue i - 1, list.add(A::from_json!(arr[i], path))
+  } else {
+    list
   }
 }
 

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -186,10 +186,7 @@ pub fn peek[A](self : T[A]) -> A? {
 /// assert_eq!(queue.push(1).is_empty(), false)
 /// ```
 pub fn is_empty[A](self : T[A]) -> Bool {
-  match self.body {
-    Empty => true
-    _ => false
-  }
+  self.body is Empty
 }
 
 ///|

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -81,17 +81,14 @@ pub impl[V : @json.FromJson] @json.FromJson for T[String, V] with from_json(
   json,
   path
 ) {
-  match json {
-    Object(obj) => {
-      let mut map = new()
-      for k, v in obj {
-        map = map.add(k, V::from_json!(v, path))
-      }
-      map
-    }
-    _ =>
-      raise @json.JsonDecodeError(
-        (path, "@immut/sorted_map.from_json: expected object"),
-      )
+  guard json is Object(obj) else {
+    raise @json.JsonDecodeError(
+      (path, "@immut/sorted_map.from_json: expected object"),
+    )
   }
+  let mut map = new()
+  for k, v in obj {
+    map = map.add(k, V::from_json!(v, path))
+  }
+  map
 }

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -76,9 +76,10 @@ pub fn remove_min[A : Compare](self : T[A]) -> T[A] {
   match self {
     Empty => abort("remove_min: empty ImmutableSet")
     Node(left~, right~, value~, ..) =>
-      match left {
-        Empty => right
-        _ => balance(left.remove_min(), value, right)
+      if left is Empty {
+        right
+      } else {
+        balance(left.remove_min(), value, right)
       }
   }
 }
@@ -163,11 +164,7 @@ pub fn remove[A : Compare](self : T[A], value : A) -> T[A] {
 pub fn min[A : Compare](self : T[A]) -> A {
   match self {
     Empty => abort("min: there are no values in sorted_set.")
-    Node(left~, value~, ..) =>
-      match left {
-        Empty => value
-        _ => left.min()
-      }
+    Node(left~, value~, ..) => if left is Empty { value } else { left.min() }
   }
 }
 
@@ -178,9 +175,10 @@ pub fn min_option[A : Compare](self : T[A]) -> A? {
   match self {
     Empty => None
     Node(left~, value~, ..) =>
-      match left {
-        Empty => Some(value)
-        _ => left.min_option()
+      if left is Empty {
+        Some(value)
+      } else {
+        left.min_option()
       }
   }
 }
@@ -197,11 +195,7 @@ pub fn min_option[A : Compare](self : T[A]) -> A? {
 pub fn max[A : Compare](self : T[A]) -> A {
   match self {
     Empty => abort("max: there are no values in ImmutableSet.")
-    Node(right~, value~, ..) =>
-      match right {
-        Empty => value
-        _ => right.max()
-      }
+    Node(right~, value~, ..) => if right is Empty { value } else { right.max() }
   }
 }
 
@@ -212,9 +206,10 @@ pub fn max_option[A : Compare](self : T[A]) -> A? {
   match self {
     Empty => None
     Node(right~, value~, ..) =>
-      match right {
-        Empty => Some(value)
-        _ => right.max_option()
+      if right is Empty {
+        Some(value)
+      } else {
+        right.max_option()
       }
   }
 }
@@ -253,10 +248,7 @@ pub fn split[A : Compare](self : T[A], divide : A) -> (T[A], Bool, T[A]) {
 ///|
 /// Returns true if sorted_set is empty
 pub fn is_empty[A : Compare](self : T[A]) -> Bool {
-  match self {
-    Empty => true
-    _ => false
-  }
+  self is Empty
 }
 
 ///|
@@ -564,19 +556,16 @@ pub impl[A : @json.FromJson + Compare] @json.FromJson for T[A] with from_json(
   json,
   path
 ) {
-  match json {
-    Array(arr) => {
-      let mut set = new()
-      for i in arr {
-        set = set.add(A::from_json!(i, path))
-      }
-      set
-    }
-    _ =>
-      raise @json.JsonDecodeError(
-        (path, "@immut/sorted_set.from_json: expected array"),
-      )
+  guard json is Array(arr) else {
+    raise @json.JsonDecodeError(
+      (path, "@immut/sorted_set.from_json: expected array"),
+    )
   }
+  let mut set = new()
+  for i in arr {
+    set = set.add(A::from_json!(i, path))
+  }
+  set
 }
 
 ///|

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -53,18 +53,15 @@ pub impl FromJson for Int with from_json(json, path) {
 
 ///|
 pub impl FromJson for Int64 with from_json(json, path) {
-  match json {
-    String(str) =>
-      try {
-        @strconv.parse_int64!(str)
-      } catch {
-        error =>
-          decode_error!(path, "Int64::from_json: parsing failure \{error}")
-      }
-    _ =>
-      decode_error!(
-        path, "Int64::from_json: expected number in string representation",
-      )
+  guard json is String(str) else {
+    decode_error!(
+      path, "Int64::from_json: expected number in string representation",
+    )
+  }
+  try {
+    @strconv.parse_int64!(str)
+  } catch {
+    error => decode_error!(path, "Int64::from_json: parsing failure \{error}")
   }
 }
 
@@ -78,18 +75,15 @@ pub impl FromJson for UInt with from_json(json, path) {
 
 ///|
 pub impl FromJson for UInt64 with from_json(json, path) {
-  match json {
-    String(str) =>
-      try {
-        @strconv.parse_uint64!(str)
-      } catch {
-        error =>
-          decode_error!(path, "UInt64::from_json: parsing failure \{error}")
-      }
-    _ =>
-      decode_error!(
-        path, "UInt64::from_json: expected number in string representation",
-      )
+  guard json is String(str) else {
+    decode_error!(
+      path, "UInt64::from_json: expected number in string representation",
+    )
+  }
+  try {
+    @strconv.parse_uint64!(str)
+  } catch {
+    error => decode_error!(path, "UInt64::from_json: parsing failure \{error}")
   }
 }
 
@@ -111,25 +105,23 @@ pub impl FromJson for String with from_json(json, path) {
 
 ///|
 pub impl FromJson for Char with from_json(json, path) {
-  match json {
-    String(a) => {
-      let len = a.length()
-      if len == 1 {
-        a.unsafe_charcode_at(0) |> Char::from_int
-      } else if len == 2 {
-        let c1 = a.unsafe_charcode_at(0)
-        let c2 = a.unsafe_charcode_at(1)
-        if c1 >= 0xD800 && c1 <= 0xDBFF && c2 >= 0xDC00 && c2 <= 0xDFFF {
-          let c3 = (c1 << 10) + c2 - 0x35fdc00
-          Char::from_int(c3)
-        } else {
-          decode_error!(path, "Char::from_json: invalid surrogate pair")
-        }
-      } else {
-        decode_error!(path, "Char::from_json: expected single character")
-      }
+  guard json is String(a) else {
+    decode_error!(path, "Char::from_json: expected string")
+  }
+  let len = a.length()
+  if len == 1 {
+    a.unsafe_charcode_at(0) |> Char::from_int
+  } else if len == 2 {
+    let c1 = a.unsafe_charcode_at(0)
+    let c2 = a.unsafe_charcode_at(1)
+    if c1 >= 0xD800 && c1 <= 0xDBFF && c2 >= 0xDC00 && c2 <= 0xDFFF {
+      let c3 = (c1 << 10) + c2 - 0x35fdc00
+      Char::from_int(c3)
+    } else {
+      decode_error!(path, "Char::from_json: invalid surrogate pair")
     }
-    _ => decode_error!(path, "Char::from_json: expected string")
+  } else {
+    decode_error!(path, "Char::from_json: expected single character")
   }
 }
 
@@ -218,22 +210,19 @@ pub impl[Ok : FromJson, Err : FromJson] FromJson for Result[Ok, Err] with from_j
   json,
   path
 ) {
-  match json {
-    Object(obj) => {
-      if obj.size() != 1 {
-        decode_error!(path, "Result::from_json: expected object with one field")
-      }
-      match obj {
-        { "Ok": ok, .. } => Ok(FromJson::from_json!(ok, path.add_key("Ok")))
-        { "Err": err, .. } =>
-          Err(FromJson::from_json!(err, path.add_key("Err")))
-        _ =>
-          decode_error!(
-            path, "Result::from_json: expected object with Ok or Err field",
-          )
-      }
-    }
-    _ => decode_error!(path, "Result::from_json: expected object")
+  guard json is Object(obj) else {
+    decode_error!(path, "Result::from_json: expected object")
+  }
+  if obj.size() != 1 {
+    decode_error!(path, "Result::from_json: expected object with one field")
+  }
+  match obj {
+    { "Ok": ok, .. } => Ok(FromJson::from_json!(ok, path.add_key("Ok")))
+    { "Err": err, .. } => Err(FromJson::from_json!(err, path.add_key("Err")))
+    _ =>
+      decode_error!(
+        path, "Result::from_json: expected object with Ok or Err field",
+      )
   }
 }
 

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -15,10 +15,8 @@
 ///|
 /// Try to get this element as a Null
 pub fn as_null(self : JsonValue) -> Unit? {
-  match self {
-    Null => Some(())
-    _ => None
-  }
+  guard self is Null else { return None }
+  Some(())
 }
 
 ///|
@@ -34,28 +32,22 @@ pub fn as_bool(self : JsonValue) -> Bool? {
 ///|
 /// Try to get this element as a Number
 pub fn as_number(self : JsonValue) -> Double? {
-  match self {
-    Number(n) => Some(n)
-    _ => None
-  }
+  guard self is Number(n) else { return None }
+  Some(n)
 }
 
 ///|
 /// Try to get this element as a String
 pub fn as_string(self : JsonValue) -> String? {
-  match self {
-    String(s) => Some(s)
-    _ => None
-  }
+  guard self is String(s) else { return None }
+  Some(s)
 }
 
 ///|
 /// Try to get this element as an Array
 pub fn as_array(self : JsonValue) -> Array[JsonValue]? {
-  match self {
-    Array(arr) => Some(arr)
-    _ => None
-  }
+  guard self is Array(arr) else { return None }
+  Some(arr)
 }
 
 ///|
@@ -70,10 +62,8 @@ pub fn item(self : JsonValue, index : Int) -> JsonValue? {
 ///|
 /// Try to get this element as an Object
 pub fn as_object(self : JsonValue) -> Map[String, JsonValue]? {
-  match self {
-    Object(obj) => Some(obj)
-    _ => None
-  }
+  guard self is Object(obj) else { return None }
+  Some(obj)
 }
 
 ///|

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -234,10 +234,7 @@ test "flatten" {
 ///|
 /// Checks if the option is empty.
 pub fn is_empty[T](self : T?) -> Bool {
-  match self {
-    None => true
-    _ => false
-  }
+  self is None
 }
 
 ///|

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -107,10 +107,7 @@ test "ok" {
 ///|
 /// Check if a `Result` is an `Ok`.
 pub fn is_ok[T, E](self : Result[T, E]) -> Bool {
-  match self {
-    Ok(_) => true
-    _ => false
-  }
+  self is Ok(_)
 }
 
 ///|
@@ -124,10 +121,7 @@ test "is_ok" {
 ///|
 /// Check if a `Result` is an `Err`.
 pub fn is_err[T, E](self : Result[T, E]) -> Bool {
-  match self {
-    Err(_) => true
-    _ => false
-  }
+  self is Err(_)
 }
 
 ///|

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -326,10 +326,7 @@ pub impl[V : Compare] Eq for T[V] with op_equal(self, other) {
 ///|
 /// Returns if MutableSet is empty.
 pub fn is_empty[V : Compare](self : T[V]) -> Bool {
-  match self.root {
-    None => true
-    _ => false
-  }
+  self.root is None
 }
 
 ///|

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -96,11 +96,9 @@ pub fn parse_int64(str : String, base~ : Int = 0) -> Int64!StrConvError {
 
   // calculate overflow threshold
   let overflow_threshold = overflow_threshold(num_base, neg)
-  let has_digit = match rest {
-    ['0'..='9' | 'a'..='z' | 'A'..='Z', ..]
-    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', ..] => true
-    _ => false
-  }
+  let has_digit = rest
+    is (['0'..='9' | 'a'..='z' | 'A'..='Z', ..]
+    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', ..])
   guard has_digit else { syntax_err!() }
   // convert
   loop rest, 0L, allow_underscore {

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -41,9 +41,8 @@ const UINT64_MAX : UInt64 = 0xffffffffffffffffUL
 /// 
 pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
   guard str != "" else { syntax_err!() }
-  match str[:] {
-    ['+' | '-', ..] => syntax_err!()
-    _ => ()
+  if str[:] is ['+' | '-', ..] {
+    syntax_err!()
   }
 
   // `allow_underscore` is used to check validity of underscores
@@ -55,11 +54,9 @@ pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
     16 => UINT64_MAX / 16 + 1
     _ => UINT64_MAX / num_base.to_uint64() + 1
   }
-  let has_digit = match rest {
-    ['0'..='9' | 'a'..='z' | 'A'..='Z', ..]
-    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', ..] => true
-    _ => false
-  }
+  let has_digit = rest
+    is (['0'..='9' | 'a'..='z' | 'A'..='Z', ..]
+    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', ..])
   guard has_digit else { syntax_err!() }
   loop rest, 0UL, allow_underscore {
     ['_'], _, _ =>


### PR DESCRIPTION
This PR rewrite match with wildcard pattern to is pattern, thus avoid fragile pattern matching warnings. And result's better readability.