### PR TITLE
add trait definition for operators overloading

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -757,6 +757,50 @@ pub(open) trait Logger {
 }
 impl Logger::write_sub_string
 
+pub(open) trait OperatorAdd {
+  op_add(Self, Self) -> Self
+}
+
+pub(open) trait OperatorBitAnd {
+  land(Self, Self) -> Self
+}
+
+pub(open) trait OperatorBitOr {
+  lor(Self, Self) -> Self
+}
+
+pub(open) trait OperatorBitXOr {
+  lxor(Self, Self) -> Self
+}
+
+pub(open) trait OperatorDiv {
+  op_div(Self, Self) -> Self
+}
+
+pub(open) trait OperatorMod {
+  op_mod(Self, Self) -> Self
+}
+
+pub(open) trait OperatorMul {
+  op_mul(Self, Self) -> Self
+}
+
+pub(open) trait OperatorNeg {
+  op_neg(Self) -> Self
+}
+
+pub(open) trait OperatorShl {
+  op_shl(Self, Int) -> Self
+}
+
+pub(open) trait OperatorShr {
+  op_shr(Self, Int) -> Self
+}
+
+pub(open) trait OperatorSub {
+  op_sub(Self, Self) -> Self
+}
+
 pub(open) trait Show {
   output(Self, &Logger) -> Unit
   to_string(Self) -> String

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -655,6 +655,22 @@ impl Logger {
 // Type aliases
 
 // Traits
+pub(open) trait Add {
+  op_add(Self, Self) -> Self
+}
+
+pub(open) trait BitAnd {
+  land(Self, Self) -> Self
+}
+
+pub(open) trait BitOr {
+  lor(Self, Self) -> Self
+}
+
+pub(open) trait BitXOr {
+  lxor(Self, Self) -> Self
+}
+
 pub(open) trait Compare : Eq {
   compare(Self, Self) -> Int
 }
@@ -696,6 +712,10 @@ impl Default for Int64
 impl Default for UInt64
 impl Default for Double
 impl[X] Default for FixedArray[X]
+
+pub(open) trait Div {
+  op_div(Self, Self) -> Self
+}
 
 pub(open) trait Eq {
   op_equal(Self, Self) -> Bool
@@ -757,48 +777,20 @@ pub(open) trait Logger {
 }
 impl Logger::write_sub_string
 
-pub(open) trait OperatorAdd {
-  op_add(Self, Self) -> Self
-}
-
-pub(open) trait OperatorBitAnd {
-  land(Self, Self) -> Self
-}
-
-pub(open) trait OperatorBitOr {
-  lor(Self, Self) -> Self
-}
-
-pub(open) trait OperatorBitXOr {
-  lxor(Self, Self) -> Self
-}
-
-pub(open) trait OperatorDiv {
-  op_div(Self, Self) -> Self
-}
-
-pub(open) trait OperatorMod {
+pub(open) trait Mod {
   op_mod(Self, Self) -> Self
 }
 
-pub(open) trait OperatorMul {
+pub(open) trait Mul {
   op_mul(Self, Self) -> Self
 }
 
-pub(open) trait OperatorNeg {
+pub(open) trait Neg {
   op_neg(Self) -> Self
 }
 
-pub(open) trait OperatorShl {
+pub(open) trait Shl {
   op_shl(Self, Int) -> Self
-}
-
-pub(open) trait OperatorShr {
-  op_shr(Self, Int) -> Self
-}
-
-pub(open) trait OperatorSub {
-  op_sub(Self, Self) -> Self
 }
 
 pub(open) trait Show {
@@ -837,6 +829,14 @@ impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show
 impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show] Show for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
 impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show] Show for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
 impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show] Show for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+
+pub(open) trait Shr {
+  op_shr(Self, Int) -> Self
+}
+
+pub(open) trait Sub {
+  op_sub(Self, Self) -> Self
+}
 
 pub(open) trait ToJson {
   to_json(Self) -> Json

--- a/builtin/operators.mbt
+++ b/builtin/operators.mbt
@@ -14,66 +14,66 @@
 
 ///|
 /// types implementing this trait can use the `+` operator
-pub(open) trait OperatorAdd {
+pub(open) trait Add {
   op_add(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `-` operator
-pub(open) trait OperatorSub {
+pub(open) trait Sub {
   op_sub(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `*` operator
-pub(open) trait OperatorMul {
+pub(open) trait Mul {
   op_mul(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `/` operator
-pub(open) trait OperatorDiv {
+pub(open) trait Div {
   op_div(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the unary `-` operator
-pub(open) trait OperatorNeg {
+pub(open) trait Neg {
   op_neg(Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `%` operator
-pub(open) trait OperatorMod {
+pub(open) trait Mod {
   op_mod(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `&` operator
-pub(open) trait OperatorBitAnd {
+pub(open) trait BitAnd {
   land(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `|` operator
-pub(open) trait OperatorBitOr {
+pub(open) trait BitOr {
   lor(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `^` operator
-pub(open) trait OperatorBitXOr {
+pub(open) trait BitXOr {
   lxor(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `<<` operator
-pub(open) trait OperatorShl {
+pub(open) trait Shl {
   op_shl(Self, Int) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `>>` operator
-pub(open) trait OperatorShr {
+pub(open) trait Shr {
   op_shr(Self, Int) -> Self
 }

--- a/builtin/operators.mbt
+++ b/builtin/operators.mbt
@@ -1,0 +1,79 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// types implementing this trait can use the `+` operator
+pub(open) trait OperatorAdd {
+  op_add(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `-` operator
+pub(open) trait OperatorSub {
+  op_sub(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `*` operator
+pub(open) trait OperatorMul {
+  op_mul(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `/` operator
+pub(open) trait OperatorDiv {
+  op_div(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the unary `-` operator
+pub(open) trait OperatorNeg {
+  op_neg(Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `%` operator
+pub(open) trait OperatorMod {
+  op_mod(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `&` operator
+pub(open) trait OperatorBitAnd {
+  land(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `|` operator
+pub(open) trait OperatorBitOr {
+  lor(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `^` operator
+pub(open) trait OperatorBitXOr {
+  lxor(Self, Self) -> Self
+}
+
+///|
+/// types implementing this trait can use the `<<` operator
+pub(open) trait OperatorShl {
+  op_shl(Self, Int) -> Self
+}
+
+///|
+/// types implementing this trait can use the `>>` operator
+pub(open) trait OperatorShr {
+  op_shr(Self, Int) -> Self
+}


### PR DESCRIPTION
We plan to migrate the operator overloading mechanism from using methods to using traits. This would give:

- give better type inference for operators
- better documentation for operator overloading, the intent of overloading operators would become explicit
- allows user-defined traits to include builtin types' operators via super trait

This PR is a starter for this migration, it adds trait definitions for each overload-able MoonBit operator. Note that this PR alone has no effect yet, compiler changes are necessary too, which would hopefully be released next week.

After the compiler migrates operator overloading to traits, current user code that uses method for operator overloading will not receive hard break, because currently we still allow implementing traits with methods. But a warning will be emitted in this case, so there would be a graceful period of migration for free, until we completely remove the behavior of implementing traits with methods.