### PR TITLE
refactor: use for in

### DIFF
--- a/array/deprecated.mbt
+++ b/array/deprecated.mbt
@@ -46,7 +46,7 @@ pub fn FixedArray::new[T](length : Int, value : () -> T) -> FixedArray[T] {
     []
   } else {
     let array = FixedArray::make(length, value())
-    for i = 1; i < length; i = i + 1 {
+    for i in 1..<length {
       array[i] = value()
     }
     array

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -244,7 +244,7 @@ pub fn FixedArray::map[T, U](
     return []
   }
   let res = FixedArray::make(self.length(), f(self[0]))
-  for i = 1; i < self.length(); i = i + 1 {
+  for i in 1..<self.length() {
     res[i] = f(self[i])
   }
   res
@@ -279,7 +279,7 @@ pub fn FixedArray::mapi[T, U](
     return []
   }
   let res = FixedArray::make(self.length(), f(0, self[0]))
-  for i = 1; i < self.length(); i = i + 1 {
+  for i in 1..<self.length() {
     res[i] = f(i, self[i])
   }
   res
@@ -338,7 +338,7 @@ pub fn FixedArray::makei[T](length : Int, value : (Int) -> T) -> FixedArray[T] {
     []
   } else {
     let array = FixedArray::make(length, value(0))
-    for i = 1; i < length; i = i + 1 {
+    for i in 1..<length {
       array[i] = value(i)
     }
     array
@@ -544,7 +544,7 @@ test "rev_foldi" {
 /// ```
 pub fn FixedArray::rev_inplace[T](self : FixedArray[T]) -> Unit {
   let mid_len = self.length() / 2
-  for i = 0; i < mid_len; i = i + 1 {
+  for i in 0..<mid_len {
     let j = self.length() - i - 1
     let temp = self[i]
     self[i] = self[j]
@@ -578,7 +578,7 @@ pub fn FixedArray::rev[T](self : FixedArray[T]) -> FixedArray[T] {
     [.., first] => {
       let res = FixedArray::make(self.length(), first)
       let len = self.length()
-      for i = 1; i < len; i = i + 1 {
+      for i in 1..<len {
         res[i] = self[len - 1 - i]
       }
       res
@@ -683,7 +683,7 @@ test "swap" {
 /// assert_false!(arr.all(fn(ele) { ele < 5 }))
 /// ```
 pub fn FixedArray::all[T](self : FixedArray[T], f : (T) -> Bool) -> Bool {
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     if not(f(self[i])) {
       return false
     }
@@ -719,7 +719,7 @@ test "all" {
 /// assert_true!(arr.any(fn(ele) { ele < 5 }))
 /// ```
 pub fn FixedArray::any[T](self : FixedArray[T], f : (T) -> Bool) -> Bool {
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     if f(self[i]) {
       return true
     }
@@ -770,7 +770,7 @@ test "fill" {
 /// assert_eq!(arr.search(3), Some(0))
 /// ```
 pub fn FixedArray::search[T : Eq](self : FixedArray[T], value : T) -> Int? {
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     if self[i] == value {
       return Some(i)
     }
@@ -806,7 +806,7 @@ test "search" {
 /// assert_true!(arr.contains(3))
 /// ```
 pub fn FixedArray::contains[T : Eq](self : FixedArray[T], value : T) -> Bool {
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     if self[i] == value {
       return true
     }
@@ -848,7 +848,7 @@ pub fn FixedArray::starts_with[T : Eq](
   if prefix.length() > self.length() {
     return false
   }
-  for i = 0; i < prefix.length(); i = i + 1 {
+  for i in 0..<prefix.length() {
     if self[i] != prefix[i] {
       return false
     }
@@ -898,7 +898,7 @@ pub fn FixedArray::ends_with[T : Eq](
   if suf_len > self_len {
     return false
   }
-  for i = 0; i < suf_len; i = i + 1 {
+  for i in 0..<suf_len {
     if self[self_len - suf_len + i] != suffix[i] {
       return false
     }
@@ -967,7 +967,7 @@ pub impl[T : Eq] Eq for FixedArray[T] with op_equal(
   if self.length() != that.length() {
     return false
   }
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     if self[i] != that[i] {
       return false
     }
@@ -1012,7 +1012,7 @@ fn deep_clone[T](arr : FixedArray[T]) -> FixedArray[T] {
     []
   } else {
     let result = FixedArray::make(len, arr[0])
-    for i = 0; i < len; i = i + 1 {
+    for i in 0..<len {
       result[i] = arr[i]
     }
     result
@@ -1073,10 +1073,10 @@ pub fn FixedArray::op_add[T](
     deep_clone(self)
   } else {
     let result = FixedArray::make(slen + nlen, self[0])
-    for i = 1; i < slen; i = i + 1 {
+    for i in 1..<slen {
       result[i] = self[i]
     }
-    for i = 0; i < nlen; i = i + 1 {
+    for i in 0..<nlen {
       result[i + slen] = other[i]
     }
     result

--- a/array/fixedarray_sort.mbt
+++ b/array/fixedarray_sort.mbt
@@ -306,7 +306,7 @@ fn fixed_get_limit(len : Int) -> Int {
 fn fixed_try_bubble_sort[T : Compare](arr : FixedArraySlice[T]) -> Bool {
   let max_tries = 8
   let mut tries = 0
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     let mut sorted = true
     for j = i; j > 0 && arr[j - 1] > arr[j]; j = j - 1 {
       sorted = false
@@ -329,7 +329,7 @@ fn fixed_try_bubble_sort[T : Compare](arr : FixedArraySlice[T]) -> Bool {
 /// 
 /// Returns whether the array is sorted.
 fn fixed_bubble_sort[T : Compare](arr : FixedArraySlice[T]) -> Unit {
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     for j = i; j > 0 && arr[j - 1] > arr[j]; j = j - 1 {
       arr.swap(j, j - 1)
     }
@@ -353,7 +353,7 @@ fn fixed_partition[T : Compare](
   let pivot = arr[arr.length() - 1]
   let mut i = 0
   let mut partitioned = true
-  for j = 0; j < arr.length() - 1; j = j + 1 {
+  for j in 0..<(arr.length() - 1) {
     if arr[j] < pivot {
       if i != j {
         arr.swap(i, j)
@@ -543,7 +543,7 @@ test "stable_sort_complex" {
   let arr = FixedArray::make(total_len, 0)
   let mut index = 0
   for i = 0, len = run_lens.length(); i < len; i = i + 1 {
-    for j = 0; j < run_lens[i]; j = j + 1 {
+    for j in 0..<run_lens[i] {
       arr[index] = j
       index += 1
     }

--- a/array/fixedarray_sort_by.mbt
+++ b/array/fixedarray_sort_by.mbt
@@ -200,7 +200,7 @@ fn fixed_try_bubble_sort_by[T](
 ) -> Bool {
   let max_tries = 8
   let mut tries = 0
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     let mut sorted = true
     for j = i; j > 0 && cmp(arr[j - 1], arr[j]) > 0; j = j - 1 {
       sorted = false
@@ -226,7 +226,7 @@ fn fixed_bubble_sort_by[T](
   arr : FixedArraySlice[T],
   cmp : (T, T) -> Int
 ) -> Unit {
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     for j = i; j > 0 && cmp(arr[j - 1], arr[j]) > 0; j = j - 1 {
       arr.swap(j, j - 1)
     }
@@ -256,7 +256,7 @@ fn fixed_partition_by[T](
   let pivot = arr[arr.length() - 1]
   let mut i = 0
   let mut partitioned = true
-  for j = 0; j < arr.length() - 1; j = j + 1 {
+  for j in 0..<(arr.length() - 1) {
     if cmp(arr[j], pivot) < 0 {
       if i != j {
         arr.swap(i, j)

--- a/array/sort.mbt
+++ b/array/sort.mbt
@@ -110,7 +110,7 @@ fn get_limit(len : Int) -> Int {
 fn try_bubble_sort[T : Compare](arr : ArrayView[T]) -> Bool {
   let max_tries = 8
   let mut tries = 0
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     let mut sorted = true
     for j = i; j > 0 && arr[j - 1] > arr[j]; j = j - 1 {
       sorted = false
@@ -129,7 +129,7 @@ fn try_bubble_sort[T : Compare](arr : ArrayView[T]) -> Bool {
 ///|
 /// Used when the array is small enough (<=16) to avoid recursion overhead.
 fn ArrayView::insertion_sort[T : Compare](arr : ArrayView[T]) -> Unit {
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     for j = i; j > 0 && arr[j - 1] > arr[j]; j = j - 1 {
       arr.swap(j, j - 1)
     }
@@ -142,7 +142,7 @@ fn partition[T : Compare](arr : ArrayView[T], pivot_index : Int) -> (Int, Bool) 
   let pivot = arr[arr.length() - 1]
   let mut i = 0
   let mut partitioned = true
-  for j = 0; j < arr.length() - 1; j = j + 1 {
+  for j in 0..<(arr.length() - 1) {
     if arr[j] < pivot {
       if i != j {
         arr.swap(i, j)

--- a/array/sort_by.mbt
+++ b/array/sort_by.mbt
@@ -124,7 +124,7 @@ fn quick_sort_by[T](
 fn try_bubble_sort_by[T](arr : ArrayView[T], cmp : (T, T) -> Int) -> Bool {
   let max_tries = 8
   let mut tries = 0
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     let mut sorted = true
     for j = i; j > 0 && cmp(arr[j - 1], arr[j]) > 0; j = j - 1 {
       sorted = false
@@ -147,7 +147,7 @@ fn try_bubble_sort_by[T](arr : ArrayView[T], cmp : (T, T) -> Int) -> Bool {
 ///
 /// Returns whether the array is sorted.
 fn bubble_sort_by[T](arr : ArrayView[T], cmp : (T, T) -> Int) -> Unit {
-  for i = 1; i < arr.length(); i = i + 1 {
+  for i in 1..<arr.length() {
     for j = i; j > 0 && cmp(arr[j - 1], arr[j]) > 0; j = j - 1 {
       arr.swap(j, j - 1)
     }
@@ -164,7 +164,7 @@ fn partition_by[T](
   let pivot = arr[arr.length() - 1]
   let mut i = 0
   let mut partitioned = true
-  for j = 0; j < arr.length() - 1; j = j + 1 {
+  for j in 0..<(arr.length() - 1) {
     if cmp(arr[j], pivot) < 0 {
       if i != j {
         arr.swap(i, j)

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -44,7 +44,7 @@ pub typealias View[T] = ArrayView[T]
 /// ```
 pub fn View::rev_inplace[T](self : View[T]) -> Unit {
   let mid_len = self.length() / 2
-  for i = 0; i < mid_len; i = i + 1 {
+  for i in 0..<mid_len {
     let j = self.length() - i - 1
     self.swap(i, j)
   }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -658,7 +658,7 @@ pub fn Array::is_sorted[T : Compare](self : Array[T]) -> Bool {
 /// }
 /// ```
 pub fn Array::rev_inplace[T](self : Array[T]) -> Unit {
-  for i = 0; i < self.length() / 2; i = i + 1 {
+  for i in 0..<(self.length() / 2) {
     let temp = self.unsafe_get(i)
     self.unsafe_set(i, self.unsafe_get(self.length() - i - 1))
     self.unsafe_set(self.length() - i - 1, temp)
@@ -686,7 +686,7 @@ pub fn Array::rev_inplace[T](self : Array[T]) -> Unit {
 /// ```
 pub fn Array::rev[T](self : Array[T]) -> Array[T] {
   let arr = Array::make_uninit(self.length())
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     arr.unsafe_set(i, self.unsafe_get(self.length() - i - 1))
   }
   arr
@@ -790,7 +790,7 @@ pub fn Array::starts_with[T : Eq](self : Array[T], prefix : Array[T]) -> Bool {
   if prefix.length() > self.length() {
     return false
   }
-  for i = 0; i < prefix.length(); i = i + 1 {
+  for i in 0..<prefix.length() {
     if self.unsafe_get(i) != prefix.unsafe_get(i) {
       break false
     }
@@ -829,7 +829,7 @@ pub fn Array::ends_with[T : Eq](self : Array[T], suffix : Array[T]) -> Bool {
   if suffix.length() > self.length() {
     return false
   }
-  for i = 0; i < suffix.length(); i = i + 1 {
+  for i in 0..<suffix.length() {
     if self.unsafe_get(self.length() - suffix.length() + i) !=
       suffix.unsafe_get(i) {
       break false
@@ -1278,7 +1278,7 @@ pub fn Array::flatten[T](self : Array[Array[T]]) -> Array[T] {
 /// ```
 pub fn Array::repeat[T](self : Array[T], times : Int) -> Array[T] {
   let v = Array::new(capacity=self.length() * times)
-  for i = 0; i < times; i = i + 1 {
+  for i in 0..<times {
     v.append(self)
   }
   v
@@ -1473,7 +1473,7 @@ pub fn Array::dedup[T : Eq](self : Array[T]) -> Unit {
     return
   }
   let mut w = 1
-  for i = 1; i < self.length(); i = i + 1 {
+  for i in 1..<self.length() {
     if self[i] != self[w - 1] {
       self[w] = self[i]
       w = w + 1
@@ -1509,13 +1509,13 @@ pub fn Array::dedup[T : Eq](self : Array[T]) -> Unit {
 pub fn Array::extract_if[T](self : Array[T], f : (T) -> Bool) -> Array[T] {
   let v = []
   let indices = []
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     if f(self[i]) {
       v.push(self[i])
       indices.push(i)
     }
   }
-  for i = 0; i < indices.length(); i = i + 1 {
+  for i in 0..<indices.length() {
     self.remove(indices[i] - i) |> ignore
   }
   v

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -64,7 +64,7 @@ pub(all) type ArgsLoc Array[SourceLoc?] derive(Show)
 pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
   let buf = StringBuilder::new(size_hint=10)
   buf.write_char('[')
-  for i = 0; i < self._.length(); i = i + 1 {
+  for i in 0..<self._.length() {
     if i != 0 {
       buf.write_string(", ")
     }

--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -380,7 +380,7 @@ fn BigInt::grade_school_mul(self : BigInt, other : BigInt) -> BigInt {
   let other_len = other.len
   let mut len = self_len + other_len
   let limbs = FixedArray::make(len, 0U)
-  for i = 0; i < self_len; i = i + 1 {
+  for i in 0..<self_len {
     let mut carry = 0UL
     for j = 0; j < other_len || carry != 0; j = j + 1 {
       let product = limbs[i + j].to_uint64() +
@@ -585,11 +585,11 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   let divisor = divisor << lshift
   let b_len = divisor.len
   let b = FixedArray::make(b_len, 0UL)
-  for i = 0; i < b_len; i = i + 1 {
+  for i in 0..<b_len {
     b[i] = divisor.limbs[i].to_uint64()
   }
   let a = FixedArray::make(a_len + 1, 0UL)
-  for i = 0; i < a_len; i = i + 1 {
+  for i in 0..<a_len {
     a[i] = dividend.limbs[i].to_uint64()
   } else {
     if dividend.limbs.length() > i {
@@ -618,7 +618,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
     // D4 divident = divident - qh * divisor
     let mut borrow = 0L
     let mut carry = 0UL
-    for j = 0; j < b_len; j = j + 1 {
+    for j in 0..<b_len {
       carry += qh * b[j]
       borrow += a[i + j].reinterpret_as_int64()
       borrow -= (carry & radix_mask).reinterpret_as_int64()
@@ -632,7 +632,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
     borrow = borrow >> radix_bit_len
     if borrow < 0L {
       carry = 0UL
-      for j = 0; j < b_len; j = j + 1 {
+      for j in 0..<b_len {
         carry += a[i + j]
         carry += b[j]
         a[i + j] = carry & radix_mask
@@ -659,7 +659,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
     i += 1
   }
   let modulo = FixedArray::make(i, 0U)
-  for j = 0; j < i; j = j + 1 {
+  for j in 0..<i {
     modulo[j] = a[j].to_uint()
   }
   let modulo = { limbs: modulo, sign: Positive, len: i }
@@ -712,7 +712,7 @@ pub fn BigInt::op_shl(self : BigInt, n : Int) -> BigInt {
     let mut len = self.len + lz
     if r != 0 {
       let mut carry = 0UL
-      for i = 0; i < self.len; i = i + 1 {
+      for i in 0..<self.len {
         carry = carry | (a[i].to_uint64() << r)
         new_limbs[i + lz] = (carry % radix).to_uint()
         carry = carry >> radix_bit_len
@@ -901,7 +901,7 @@ pub impl Eq for BigInt with op_equal(self, other) {
   if self.sign != other.sign || self.len != other.len {
     return false
   }
-  for i = 0; i < self.len; i = i + 1 {
+  for i in 0..<self.len {
     if self.limbs[i] != other.limbs[i] {
       return false
     }
@@ -950,7 +950,7 @@ pub fn BigInt::to_string(self : BigInt) -> String {
   let mut v_idx = 0
   for i = self.len - 1; i >= 0; i = i - 1 {
     let mut x = self.limbs[i].to_uint64().reinterpret_as_int64()
-    for j = 0; j < v_idx; j = j + 1 {
+    for j in 0..<v_idx {
       let y = (v[j] << radix_bit_len) | x
       x = y / decimal_mask
       v[j] = y % decimal_mask
@@ -962,8 +962,8 @@ pub fn BigInt::to_string(self : BigInt) -> String {
     }
   }
   let mut ret = ""
-  for i = 0; i < v_idx - 1; i = i + 1 {
-    for j = 0; j < decimal_radix_bit_len; j = j + 1 {
+  for i in 0..<(v_idx - 1) {
+    for j in 0..<decimal_radix_bit_len {
       let x = v[i] % 10L
       v[i] /= 10L
       ret = x.to_string() + ret
@@ -1060,7 +1060,7 @@ pub fn BigInt::from_string(input : String) -> BigInt {
       abort("invalid character")
     }
     let mut carry = x.reinterpret_as_uint().to_uint64()
-    for j = 0; j < b_len; j = j + 1 {
+    for j in 0..<b_len {
       carry += b[j].to_uint64() * 10
       b[j] = (carry % radix).to_uint()
       carry /= radix
@@ -1140,13 +1140,13 @@ pub fn BigInt::from_hex(input : String) -> BigInt {
   let b = FixedArray::make(b_len, 0U)
   if mod != 0 {
     let start = len - quotient * nb_char - mod
-    for i = 0; i < mod; i = i + 1 {
+    for i in 0..<mod {
       b[b_len - 1] = (b[b_len - 1] << 4) | char_from_hex(input[start + i])
     }
   }
-  for i = 0; i < quotient; i = i + 1 {
+  for i in 0..<quotient {
     let start = len - (i + 1) * nb_char
-    for j = 0; j < nb_char; j = j + 1 {
+    for j in 0..<nb_char {
       b[i] = (b[i] << 4) | char_from_hex(input[start + j])
     }
   }
@@ -1204,7 +1204,7 @@ pub fn BigInt::to_hex(self : BigInt, uppercase~ : Bool = true) -> String {
     if i != self.len - 1 && tmp.length() < radix_bit_len / 4 {
       let pad = radix_bit_len / 4 - tmp.length()
       // pad with zeros if not the last limb(the front of the BigInt)
-      for j = 0; j < pad; j = j + 1 {
+      for j in 0..<pad {
         tmp = "0" + tmp
       }
     }
@@ -1366,14 +1366,14 @@ pub fn BigInt::from_octets(input : Bytes, signum~ : Int = 1) -> BigInt {
   let limbs_len = if mod == 0 { div } else { div + 1 }
   let limbs = FixedArray::make(limbs_len, 0U)
   // head at most significant limb
-  for i = 0; i < mod / 8; i = i + 1 {
+  for i in 0..<(mod / 8) {
     limbs[limbs_len - 1] = (limbs[limbs_len - 1] << 8) |
       input[i].to_int().reinterpret_as_uint()
   }
   let byte_per_limb = radix_bit_len / 8
   // tail
-  for i = 0; i < div; i = i + 1 {
-    for j = 0; j < byte_per_limb; j = j + 1 {
+  for i in 0..<div {
+    for j in 0..<byte_per_limb {
       let bytes_idx = len - byte_per_limb - i * byte_per_limb + j
       limbs[i] = (limbs[i] << 8) |
         input[bytes_idx].to_int().reinterpret_as_uint()
@@ -1499,10 +1499,10 @@ pub fn BigInt::land(self : BigInt, other : BigInt) -> BigInt {
 
   // Calculate the complement code per 2
   if self.sign == Negative {
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] = x_limbs[i] ^ 0xFFFFFFFFU
     }
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] += 1
       if x_limbs[i] != 0x0U {
         break
@@ -1510,10 +1510,10 @@ pub fn BigInt::land(self : BigInt, other : BigInt) -> BigInt {
     }
   }
   if other.sign == Negative {
-    for i = 0; i < y_limbs.length(); i = i + 1 {
+    for i in 0..<y_limbs.length() {
       y_limbs[i] = y_limbs[i] ^ 0xFFFFFFFFU
     }
-    for i = 0; i < y_limbs.length(); i = i + 1 {
+    for i in 0..<y_limbs.length() {
       y_limbs[i] += 1
       if y_limbs[i] != 0x0U {
         break
@@ -1522,7 +1522,7 @@ pub fn BigInt::land(self : BigInt, other : BigInt) -> BigInt {
   }
 
   // Bit Ops
-  for i = 0; i < x_limbs.length(); i = i + 1 {
+  for i in 0..<x_limbs.length() {
     x_limbs[i] = x_limbs[i] & y_limbs[i]
   }
 
@@ -1535,13 +1535,13 @@ pub fn BigInt::land(self : BigInt, other : BigInt) -> BigInt {
 
   // Restore as true code
   if new_sign == Negative {
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] -= 1
       if x_limbs[i] != 0xFFFFFFFFU {
         break
       }
     }
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] = x_limbs[i] ^ 0xFFFFFFFFU
     }
   }
@@ -1608,10 +1608,10 @@ pub fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt {
 
   // Calculate the complement code per 2
   if self.sign == Negative {
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] = x_limbs[i] ^ 0xFFFFFFFFU
     }
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] += 1
       if x_limbs[i] != 0x0U {
         break
@@ -1619,10 +1619,10 @@ pub fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt {
     }
   }
   if other.sign == Negative {
-    for i = 0; i < y_limbs.length(); i = i + 1 {
+    for i in 0..<y_limbs.length() {
       y_limbs[i] = y_limbs[i] ^ 0xFFFFFFFFU
     }
-    for i = 0; i < y_limbs.length(); i = i + 1 {
+    for i in 0..<y_limbs.length() {
       y_limbs[i] += 1
       if y_limbs[i] != 0x0U {
         break
@@ -1631,7 +1631,7 @@ pub fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt {
   }
 
   // Bit Ops
-  for i = 0; i < x_limbs.length(); i = i + 1 {
+  for i in 0..<x_limbs.length() {
     x_limbs[i] = x_limbs[i] | y_limbs[i]
   }
 
@@ -1644,13 +1644,13 @@ pub fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt {
 
   // Restore as true code
   if new_sign == Negative {
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] -= 1
       if x_limbs[i] != 0xFFFFFFFFU {
         break
       }
     }
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] = x_limbs[i] ^ 0xFFFFFFFFU
     }
   }
@@ -1720,10 +1720,10 @@ pub fn BigInt::lxor(self : BigInt, other : BigInt) -> BigInt {
 
   // Calculate the complement code per 2
   if self.sign == Negative {
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] = x_limbs[i] ^ 0xFFFFFFFFU
     }
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] += 1
       if x_limbs[i] != 0x0U {
         break
@@ -1731,10 +1731,10 @@ pub fn BigInt::lxor(self : BigInt, other : BigInt) -> BigInt {
     }
   }
   if other.sign == Negative {
-    for i = 0; i < y_limbs.length(); i = i + 1 {
+    for i in 0..<y_limbs.length() {
       y_limbs[i] = y_limbs[i] ^ 0xFFFFFFFFU
     }
-    for i = 0; i < y_limbs.length(); i = i + 1 {
+    for i in 0..<y_limbs.length() {
       y_limbs[i] += 1
       if y_limbs[i] != 0x0U {
         break
@@ -1743,7 +1743,7 @@ pub fn BigInt::lxor(self : BigInt, other : BigInt) -> BigInt {
   }
 
   // Bit Ops
-  for i = 0; i < x_limbs.length(); i = i + 1 {
+  for i in 0..<x_limbs.length() {
     x_limbs[i] = x_limbs[i] ^ y_limbs[i]
   }
 
@@ -1756,13 +1756,13 @@ pub fn BigInt::lxor(self : BigInt, other : BigInt) -> BigInt {
 
   // Restore as true code
   if new_sign == Negative {
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] -= 1
       if x_limbs[i] != 0xFFFFFFFFU {
         break
       }
     }
-    for i = 0; i < x_limbs.length(); i = i + 1 {
+    for i in 0..<x_limbs.length() {
       x_limbs[i] = x_limbs[i] ^ 0xFFFFFFFFU
     }
   }

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -43,7 +43,7 @@ pub fn Bytes::makei(length : Int, value : (Int) -> Byte) -> Bytes {
     return []
   }
   let arr = FixedArray::make(length, value(0))
-  for i = 1; i < length; i = i + 1 {
+  for i in 1..<length {
     arr[i] = value(i)
   }
   FixedArray::unsafe_to_bytes(arr)
@@ -426,7 +426,7 @@ pub impl Eq for Bytes with op_equal(self : Bytes, other : Bytes) -> Bool {
     false
   } else {
     let len = self.length()
-    for i = 0; i < len; i = i + 1 {
+    for i in 0..<len {
       if self[i] != other[i] {
         break false
       }

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -112,7 +112,7 @@ fn base64_encode(data : FixedArray[Byte]) -> String {
 ///|
 fn base64_encode_string_codepoint(s : String) -> String {
   let data : FixedArray[Byte] = FixedArray::make(s.codepoint_length() * 4, 0)
-  for i = 0; i < s.codepoint_length(); i = i + 1 {
+  for i in 0..<s.codepoint_length() {
     let c = s.codepoint_at(i).to_int()
     data[i * 4] = (c & 0xFF).to_byte()
     data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()

--- a/builtin/fixedarray_block.mbt
+++ b/builtin/fixedarray_block.mbt
@@ -42,7 +42,7 @@ pub fn FixedArray::unsafe_blit[A](
   len : Int
 ) -> Unit {
   if physical_equal(dst, src) && dst_offset < src_offset {
-    for i = 0; i < len; i = i + 1 {
+    for i in 0..<len {
       dst[dst_offset + i] = src[src_offset + i]
     }
   } else {

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -362,7 +362,7 @@ pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
 /// }
 /// ```
 pub fn Hasher::combine_string(self : Hasher, value : String) -> Unit {
-  for i = 0; i < value.length(); i = i + 1 {
+  for i in 0..<value.length() {
     self.combine_uint(value[i].to_uint())
   }
 }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -459,7 +459,7 @@ test "eachi" {
 fn test_from_array[T](arr : Array[T]) -> Iter[T] {
   Iter::new(fn {
     yield_ =>
-      for i = 0; i < arr.length(); i = i + 1 {
+      for i in 0..<arr.length() {
         if yield_(arr[i]) == IterEnd {
           break IterEnd
         }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -382,7 +382,7 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 ///|
 fn Map::debug_entries[K : Show, V : Show](self : Map[K, V]) -> String {
   let buf = StringBuilder::new()
-  for i = 0; i < self.entries.length(); i = i + 1 {
+  for i in 0..<self.entries.length() {
     if i > 0 {
       buf.write_char(',')
     }
@@ -559,7 +559,7 @@ pub fn Map::of[K : Hash + Eq, V](arr : FixedArray[(K, V)]) -> Map[K, V] {
   let length = arr.length()
   let m = Map::new(capacity=length)
   // arr.iter(fn(e) { m.set(e.0, e.1) })
-  for i = 0; i < length; i = i + 1 {
+  for i in 0..<length {
     let e = arr[i]
     m.set(e.0, e.1)
   }

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -192,7 +192,7 @@ test "clear" {
   assert_eq!(m.capacity, 8)
   assert_eq!(m.head, None)
   assert_eq!(m.tail, None)
-  for i = 0; i < m.capacity; i = i + 1 {
+  for i in 0..<m.capacity {
     assert_eq!(m.entries[i], None)
   }
 }
@@ -407,7 +407,7 @@ test "clear" {
   assert_eq!(m.capacity, 8)
   assert_eq!(m.head, None)
   assert_eq!(m.tail, None)
-  for i = 0; i < m.capacity; i = i + 1 {
+  for i in 0..<m.capacity {
     assert_eq!(m.entries[i], None)
   }
 }
@@ -455,7 +455,7 @@ test "new" {
   assert_eq!(m.capacity, 8)
   assert_eq!(m.head, None)
   assert_eq!(m.tail, None)
-  for i = 0; i < m.capacity; i = i + 1 {
+  for i in 0..<m.capacity {
     assert_eq!(m.entries[i], None)
   }
 }
@@ -548,7 +548,7 @@ test "clear" {
   assert_eq!(m.capacity, 8)
   assert_eq!(m.head, None)
   assert_eq!(m.tail, None)
-  for i = 0; i < m.capacity; i = i + 1 {
+  for i in 0..<m.capacity {
     assert_eq!(m.entries[i], None)
   }
 }
@@ -641,7 +641,7 @@ test "clear" {
   assert_eq!(m.capacity, 8)
   assert_eq!(m.head, None)
   assert_eq!(m.tail, None)
-  for i = 0; i < m.capacity; i = i + 1 {
+  for i in 0..<m.capacity {
     assert_eq!(m.entries[i], None)
   }
 }

--- a/builtin/linked_hash_set.mbt
+++ b/builtin/linked_hash_set.mbt
@@ -328,7 +328,7 @@ fn Set::grow[K : Hash + Eq](self : Set[K]) -> Unit {
 ///|
 fn Set::debug_entries[K : Show](self : Set[K]) -> String {
   let buf = StringBuilder::new()
-  for i = 0; i < self.entries.length(); i = i + 1 {
+  for i in 0..<self.entries.length() {
     if i > 0 {
       buf.write_char(',')
     }
@@ -459,7 +459,7 @@ pub fn Set::of[K : Hash + Eq](arr : FixedArray[K]) -> Set[K] {
   let length = arr.length()
   let m = Set::new(capacity=length)
   // arr.iter(fn(e) { m.set(e.0, e.1) })
-  for i = 0; i < length; i = i + 1 {
+  for i in 0..<length {
     let e = arr[i]
     m.add(e)
   }

--- a/builtin/linked_hash_set_test.mbt
+++ b/builtin/linked_hash_set_test.mbt
@@ -171,7 +171,7 @@ test "from_array" {
 ///|
 test "insert_and_grow" {
   let m = Set::new()
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)
@@ -226,7 +226,7 @@ test "clear_and_reinsert" {
 ///|
 test "insert_and_grow" {
   let m = Set::new()
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -102,7 +102,7 @@ pub impl Show for String with output(self, logger) {
     }
   }
 
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     let c = self[i]
     match c {
       '"' | '\\' => {

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -200,7 +200,7 @@ pub fn of(arr : FixedArray[Byte]) -> Bytes {
 /// ```
 pub fn to_array(self : Bytes) -> Array[Byte] {
   let rv = Array::make(self.length(), b'0')
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     rv[i] = self[i]
   }
   rv
@@ -278,10 +278,10 @@ pub fn Bytes::op_add(self : Bytes, other : Bytes) -> Bytes {
     self.length() + other.length(),
     0,
   )
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     rv[i] = self[i]
   }
-  for i = 0; i < other.length(); i = i + 1 {
+  for i in 0..<other.length() {
     rv[self.length() + i] = other[i]
   }
   unsafe_to_bytes(rv)

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -40,7 +40,7 @@ pub fn CoverageCounter::incr(self : CoverageCounter, idx : Int) -> Unit {
 ///|
 pub impl Show for CoverageCounter with output(self, logger) {
   logger.write_char('[')
-  for i = 0; i < self.counter.length(); i = i + 1 {
+  for i in 0..<self.counter.length() {
     if i != 0 {
       logger.write_string(", ")
     }
@@ -106,10 +106,10 @@ pub fn end() -> Unit {
   let sbuf = StringBuffer::StringBuffer([])
   coverage_log(counters.val, sbuf)
   let line_buf = StringBuilder::new()
-  for i = 0; i < sbuf._.length(); i = i + 1 {
+  for i in 0..<sbuf._.length() {
     let str = sbuf._[i]
     let mut start = 0
-    for j = 0; j < str.length(); j = j + 1 {
+    for j in 0..<str.length() {
       if str[j] == '\n' {
         line_buf.write_substring(str, start, j)
         println(line_buf.to_string())
@@ -133,7 +133,7 @@ pub fn end() -> Unit {
 fn coverage_reset(counters : MList[(String, CoverageCounter)]) -> Unit {
   loop counters {
     MCons((_, counter), xs) => {
-      for i = 0; i < counter.counter.length(); i = i + 1 {
+      for i in 0..<counter.counter.length() {
         counter.counter[i] = 0
       }
       continue xs

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -76,7 +76,7 @@ pub fn from_array[A](arr : Array[A]) -> T[A] {
     head: 0,
     tail: arr.length() - 1,
   }
-  for i = 0; i < arr.length(); i = i + 1 {
+  for i in 0..<arr.length() {
     deq.buf[i] = arr[i]
   }
   deq
@@ -141,7 +141,7 @@ pub fn of[A](arr : FixedArray[A]) -> T[A] {
     head: 0,
     tail: arr.length() - 1,
   }
-  for i = 0; i < arr.length(); i = i + 1 {
+  for i in 0..<arr.length() {
     deq.buf[i] = arr[i]
   }
   deq
@@ -589,7 +589,7 @@ pub impl[A : Eq] Eq for T[A] with op_equal(self, other) {
   if self.len != other.len {
     return false
   }
-  for i = 0; i < self.len; i = i + 1 {
+  for i in 0..<self.len {
     if self[i] != other[i] {
       return false
     }
@@ -707,7 +707,7 @@ pub fn map[A, U](self : T[A], f : (A) -> U) -> T[U] {
     new()
   } else {
     let buf : UninitializedArray[U] = UninitializedArray::make(self.len)
-    for i = 0; i < self.len; i = i + 1 {
+    for i in 0..<self.len {
       buf[i] = f(self.buf[i])
     }
     T::{ buf, len: self.len, head: 0, tail: self.len - 1 }
@@ -728,7 +728,7 @@ pub fn mapi[A, U](self : T[A], f : (Int, A) -> U) -> T[U] {
     new()
   } else {
     let buf : UninitializedArray[U] = UninitializedArray::make(self.len)
-    for i = 0; i < self.len; i = i + 1 {
+    for i in 0..<self.len {
       buf[i] = f(i, self.buf[i])
     }
     T::{ buf, len: self.len, head: 0, tail: self.len - 1 }
@@ -770,7 +770,7 @@ pub fn is_empty[A](self : T[A]) -> Bool {
 /// }
 /// ```
 pub fn search[A : Eq](self : T[A], value : A) -> Int? {
-  for i = 0; i < self.len; i = i + 1 {
+  for i in 0..<self.len {
     if self.buf[i] == value {
       return Some(i)
     }
@@ -822,7 +822,7 @@ pub fn reserve_capacity[A](self : T[A], capacity : Int) -> Unit {
   self.buf = new_buf
   self.head = 0
   self.tail = 0
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     let idx = (head + i) % buf.length()
     self.buf[i] = buf[idx]
     self.tail += 1
@@ -851,7 +851,7 @@ pub fn shrink_to_fit[A](self : T[A]) -> Unit {
   self.buf = UninitializedArray::make(len)
   self.head = 0
   self.tail = 0
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     let idx = (head + i) % buf.length()
     self.buf[i] = buf[idx]
   }

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -418,11 +418,11 @@ test "from_array with single element" {
 test "unsafe_pop_front after many push_front" {
   let dq = @deque.new()
   // First fill some elements to create a buffer with some capacity
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     dq.push_front(i)
   }
   // Pop all elements except one
-  for i = 0; i < 9; i = i + 1 {
+  for i in 0..<9 {
     dq.unsafe_pop_front()
   }
   // Now head should be at the end of buffer
@@ -651,7 +651,7 @@ test "test_from_vec" {
       }
       let vd = @deque.from_array(vec)
       assert_eq!(vd.length(), vec.length())
-      for i = 0; i < vd.length(); i = i + 1 {
+      for i in 0..<vd.length() {
         assert_eq!(vd[i], vec[i])
       }
     }
@@ -662,11 +662,11 @@ test "test_from_vec" {
 test "test_from_array" {
   fn test_fn!(n : Int) -> Unit {
     let array : FixedArray[Int] = FixedArray::make(n, 0)
-    for index = 0; index < n; index = index + 1 {
+    for index in 0..<n {
       array[index] = index
     }
     let deq = @deque.of(array)
-    for index = 0; index < n; index = index + 1 {
+    for index in 0..<n {
       assert_eq!(deq[index], array[index])
     }
     assert_eq!(deq.length(), array.length())
@@ -684,16 +684,16 @@ test "test_clone_from" {
   let m = FixedArray::make(8, 1)
   let n = FixedArray::make(12, 2)
   let limit = 8
-  for pfv = 0; pfv < limit; pfv = pfv + 1 {
-    for pfu = 0; pfu < limit; pfu = pfu + 1 {
-      for longer = 0; longer < 2; longer = longer + 1 {
+  for pfv in 0..<limit {
+    for pfu in 0..<limit {
+      for longer in 0..<2 {
         let (vr, ur) = if longer == 0 { (m, n) } else { (n, m) }
         let v = @deque.of(vr)
-        for _idx = 0; _idx < pfv; _idx = _idx + 1 {
+        for _idx in 0..<pfv {
           v.push_front(1)
         }
         let u = @deque.of(ur)
-        for _idx = 0; _idx < pfu; _idx = _idx + 1 {
+        for _idx in 0..<pfu {
           u.push_front(2)
         }
         let v = @deque.copy(u)

--- a/deque/deque_wbtest.mbt
+++ b/deque/deque_wbtest.mbt
@@ -15,10 +15,10 @@
 ///|
 test "unsafe_pop_front after many push_front" {
   let dq = new()
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     dq.push_front(i)
   }
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     dq.unsafe_pop_front()
   }
   assert_eq!(dq.head, dq.tail)

--- a/double/internal/ryu/ryu.mbt
+++ b/double/internal/ryu/ryu.mbt
@@ -493,7 +493,7 @@ fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
   let scientificNotation = not(exp >= -6 && exp < 21)
   if scientificNotation {
     // Print the decimal digits.
-    for i = 0; i < olength - 1; i = i + 1 {
+    for i in 0..<(olength - 1) {
       let c = output % 10
       output /= 10
       // 48 is ASCII '0', the same applies below.
@@ -551,14 +551,14 @@ fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
         index += 1
       }
       let current = index
-      for i = 0; i < olength; i = i + 1 {
+      for i in 0..<olength {
         result[current + olength - i - 1] = (48 + (output % 10).to_int()).to_byte()
         output /= 10
         index += 1
       }
     } else if exp + 1 >= olength {
       // Decimal dot is after any of the digits.
-      for i = 0; i < olength; i = i + 1 {
+      for i in 0..<olength {
         result[index + olength - i - 1] = (48 + (output % 10).to_int()).to_byte()
         output /= 10
       }
@@ -570,7 +570,7 @@ fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
     } else {
       // Decimal dot is somewhere between the digits.
       let mut current = index + 1
-      for i = 0; i < olength; i = i + 1 {
+      for i in 0..<olength {
         if olength - i - 1 == exp {
           result[current + olength - i - 1] = b'.'
           current -= 1

--- a/double/trig_nonjs.mbt
+++ b/double/trig_nonjs.mbt
@@ -217,7 +217,7 @@ fn rem_pio2(x : Double, y : Array[Double]) -> Int {
   let e0 = (ix >> 20) - 1046 // e0 = ilogb(z) - 23
   z = set_high_word(z, (ix - (e0 << 20)).reinterpret_as_uint())
   let tx = [0.0, 0.0, 0.0]
-  for i = 0; i < 2; i = i + 1 {
+  for i in 0..<2 {
     tx[i] = z.to_int().to_double()
     z = (z - tx[i]) * TWO24
   }

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -19,7 +19,7 @@ fn get_cli_args_ffi() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
 fn get_cli_args_internal() -> Array[String] {
   let tmp = get_cli_args_ffi()
   let res = Array::new(capacity=tmp.length())
-  for i = 0; i < tmp.length(); i = i + 1 {
+  for i in 0..<tmp.length() {
     res.push(utf8_bytes_to_mbt_string(tmp[i]))
   }
   res

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -414,7 +414,7 @@ fn grow[K : Eq, V](self : T[K, V]) -> Unit {
   self.entries = FixedArray::make(new_capacity, None)
   self.capacity = new_capacity
   self.size = 0
-  for i = 0; i < old_entries.length(); i = i + 1 {
+  for i in 0..<old_entries.length() {
     match old_entries[i] {
       Some({ key, value, hash, .. }) => self.set_with_hash(key, value, hash)
       None => ()
@@ -573,7 +573,7 @@ test "clear" {
   m.clear()
   assert_eq!(m.size(), 0)
   assert_eq!(m.capacity(), 8)
-  for i = 0; i < m.capacity(); i = i + 1 {
+  for i in 0..<m.capacity() {
     @test.same_object!(m.entries[i], None)
   }
 }

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -324,7 +324,7 @@ pub fn is_empty[K, V](self : T[K, V]) -> Bool {
 /// }
 /// ```
 pub fn each[K, V](self : T[K, V], f : (K, V) -> Unit) -> Unit {
-  for i = 0; i < self.capacity; i = i + 1 {
+  for i in 0..<self.capacity {
     match self.entries[i] {
       Some({ key, value, .. }) => f(key, value)
       None => ()

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -162,7 +162,7 @@ pub fn each[K](self : T[K], f : (K) -> Unit) -> Unit {
 /// Iterate over all keys of the set, with index.
 pub fn eachi[K](self : T[K], f : (Int, K) -> Unit) -> Unit {
   let mut idx = 0
-  for i = 0; i < self.capacity; i = i + 1 {
+  for i in 0..<self.capacity {
     match self.entries[i] {
       Some({ key, .. }) => {
         f(idx, key)
@@ -176,7 +176,7 @@ pub fn eachi[K](self : T[K], f : (Int, K) -> Unit) -> Unit {
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
 pub fn clear[K](self : T[K]) -> Unit {
-  for i = 0; i < self.capacity; i = i + 1 {
+  for i in 0..<self.capacity {
     self.entries[i] = None
   }
   self.size = 0
@@ -280,7 +280,7 @@ fn grow[K : Hash + Eq](self : T[K]) -> Unit {
   self.capacity = self.capacity * 2
   self.growAt = calc_grow_threshold(self.capacity)
   self.size = 0
-  for i = 0; i < old_entries.length(); i = i + 1 {
+  for i in 0..<old_entries.length() {
     match old_entries[i] {
       Some({ key, .. }) => self.add(key)
       None => ()
@@ -315,7 +315,7 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 ///|
 fn debug_entries[K : Show](self : T[K]) -> String {
   let mut s = ""
-  for i = 0; i < self.entries.length(); i = i + 1 {
+  for i in 0..<self.entries.length() {
     if i > 0 {
       s += ","
     }
@@ -435,7 +435,7 @@ test "clear" {
   m.clear()
   assert_eq!(m.size(), 0)
   assert_eq!(m.capacity(), 8)
-  for i = 0; i < m.capacity(); i = i + 1 {
+  for i in 0..<m.capacity() {
     @test.same_object!(m.entries[i], None)
   }
 }

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -162,7 +162,7 @@ test "from_array" {
 ///|
 test "insert_and_grow" {
   let m = @hashset.new()
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)
@@ -207,7 +207,7 @@ test "clear_and_reinsert" {
 ///|
 test "insert_and_grow" {
   let m = @hashset.new()
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     m.add(i.to_string())
   }
   assert_eq!(m.size(), 10)

--- a/immut/array/array_wbtest.mbt
+++ b/immut/array/array_wbtest.mbt
@@ -39,7 +39,7 @@ test "new_by_leaves" {
 test "mix" {
   let mut v = new()
   inspect!(v.tree.is_empty_tree(), content="true")
-  for i = 0; i < 100; i = i + 1 {
+  for i in 0..<100 {
     v = v.push(i)
   }
   inspect!(
@@ -47,7 +47,7 @@ test "mix" {
     content="@immut/array.of([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99])",
   )
   let mut v2 = v
-  for i = 0; i < 100; i = i + 1 {
+  for i in 0..<100 {
     v2 = v2.set(i, i * 2)
   }
   let mut ct = 0
@@ -63,12 +63,12 @@ test "mix" {
   inspect!(v.tree.is_empty_tree(), content="false")
   let large_const = branching_factor * branching_factor + 1
   let mut v = new()
-  for i = 0; i < large_const; i = i + 1 {
+  for i in 0..<large_const {
     v = v.push(i)
   }
   let vec = []
   v.eachi(fn(i, _e) { vec.push(i) })
-  for i = 0; i < large_const; i = i + 1 {
+  for i in 0..<large_const {
     assert_eq!(vec[i], i)
   }
 }
@@ -135,7 +135,7 @@ test "concat-multiple-random-tree" {
 /// - `len_gen`: a function that generates the length of the array to be concatenated
 fn gen_concat_seq(n : Int, len_gen : (Int) -> Int) -> Array[Op] {
   let ret = []
-  for i = 0; i < n; i = i + 1 {
+  for i in 0..<n {
     ret.push(Op::Concat(random_array(len_gen(i))))
   }
   ret
@@ -147,7 +147,7 @@ fn gen_concat_seq(n : Int, len_gen : (Int) -> Int) -> Array[Op] {
 /// to be concatenated is given as an array.
 fn gen_concat_seq_from_len_array(len : Array[Int]) -> Array[Op] {
   let ret = []
-  for i = 0; i < len.length(); i = i + 1 {
+  for i in 0..<len.length() {
     ret.push(Op::Concat(random_array(len[i])))
   }
   ret

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -317,13 +317,13 @@ fn Tree::eachi[A](
   match self {
     Empty => ()
     Leaf(l) =>
-      for i = 0; i < l.length(); i = i + 1 {
+      for i in 0..<l.length() {
         f(start + i, l[i])
       }
     Node(ns, None) => {
       let child_shift = shift - num_bits
       let mut start = start
-      for i = 0; i < ns.length(); i = i + 1 {
+      for i in 0..<ns.length() {
         ns[i].eachi(f, child_shift, start)
         start += 1 << shift
       }
@@ -331,7 +331,7 @@ fn Tree::eachi[A](
     Node(ns, Some(sizes)) => {
       let child_shift = shift - num_bits
       let mut start = start
-      for i = 0; i < ns.length(); i = i + 1 {
+      for i in 0..<ns.length() {
         ns[i].eachi(f, child_shift, start)
         start += sizes[i]
       }
@@ -613,7 +613,7 @@ fn redis[A](
 
     let mut old_leaf_elems = FixedArray::default()
     let mut old_leaf_len = 0
-    for i = 0; i < node_nums; i = i + 1 {
+    for i in 0..<node_nums {
 
       // old_t[j] is the next to be redistributed
       // old_offset is the index of the next node to be redistributed in old_t[j]
@@ -655,7 +655,7 @@ fn redis[A](
 
     let mut old_node_chldrn = FixedArray::default()
     let mut old_node_len = 0
-    for i = 0; i < node_nums; i = i + 1 {
+    for i in 0..<node_nums {
       old_node_chldrn = old_t[j].node_children()
       old_node_len = old_node_chldrn.length()
       if old_offset == 0 && old_node_len == node_counts[i] {
@@ -704,7 +704,7 @@ fn compute_sizes[A](
   let mut sum = 0
   let mut flag = true
   let full_subtree_size = branching_factor << shift
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     let sz = children[i].size(shift)
     flag = flag && sz == full_subtree_size
     sum += sz
@@ -734,7 +734,7 @@ impl[A : Show] Show for Tree[A] with output(self, logger : &Logger) {
       Empty => indent_str("Empty", ident)
       Leaf(l) => {
         let mut s = "Leaf("
-        for i = 0; i < l.length(); i = i + 1 {
+        for i in 0..<l.length() {
           s += l[i].to_string()
           if i != l.length() - 1 {
             s += ", "
@@ -745,7 +745,7 @@ impl[A : Show] Show for Tree[A] with output(self, logger : &Logger) {
       }
       Node(children, _sizes) => {
         let mut s = indent_str("Node(", ident) + "\n"
-        for i = 0; i < children.length(); i = i + 1 {
+        for i in 0..<children.length() {
           s += rec(children[i], ident + 2)
         }
         s + indent_str(")", ident) + "\n"

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -36,7 +36,7 @@ fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
   // Start constructing the array
   let ret = []
   let mut cur_len = 0
-  for i = 0; i < times; i = i + 1 {
+  for i in 0..<times {
     let op = rng.int(limit=op_count)
     match op {
       0 => {
@@ -90,7 +90,7 @@ fn execute_array_test(rs : Array[Op]) -> Unit! {
       Concat(v) => {
         // concat
         let len = v.length()
-        for i = 0; i < len; i = i + 1 {
+        for i in 0..<len {
           a.push(v[i])
         }
         t = t.concat(from_array(v))
@@ -110,7 +110,7 @@ fn execute_array_test(rs : Array[Op]) -> Unit! {
 /// Compute the power of the branching factor.
 fn branching_factor_power(a : Int) -> Int {
   let mut ret = 1
-  for i = 0; i < a; i = i + 1 {
+  for i in 0..<a {
     ret *= branching_factor
   }
   ret
@@ -123,7 +123,7 @@ fn branching_factor_power(a : Int) -> Int {
 fn check_array_eq(a : Array[Int], t : T[Int]) -> Unit! {
   assert_eq!(a.length(), t.size)
   let len = t.size
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     assert_eq!(t[i], a[i])
   }
 }
@@ -135,7 +135,7 @@ fn check_array_eq(a : Array[Int], t : T[Int]) -> Unit! {
 fn check_fixedarray_eq(a : FixedArray[Int], t : T[Int]) -> Unit! {
   assert_eq!(a.length(), t.size)
   let len = t.size
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     assert_eq!(t[i], a[i])
   }
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -27,7 +27,7 @@ test "HAMT" {
     100, map => map
     i, map => continue i + 1, map.add(i, i)
   }
-  for i = 0; i < 100; i = i + 1 {
+  for i in 0..<100 {
     assert_eq!((i, map.find(i)), (i, Some(i)))
   }
   inspect!((100, map.find(100)), content="(100, None)")
@@ -50,7 +50,7 @@ test "HAMT::remove" {
     100, map => map
     i, map => continue i + 1, map.add(i, i)
   }
-  for i = 0; i < 100; i = i + 1 {
+  for i in 0..<100 {
     assert_eq!((i, map.find(i)), (i, Some(i)))
   }
   let map = loop 0, map {

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -18,7 +18,7 @@ test "Set" {
     100, map => map
     i, map => continue i + 1, map.add(i)
   }
-  for i = 0; i < 100; i = i + 1 {
+  for i in 0..<100 {
     assert_eq!((i, map.contains(i)), (i, true))
   }
   inspect!((100, map.contains(100)), content="(100, false)")
@@ -41,7 +41,7 @@ test "@hashset.remove" {
     100, map => map
     i, map => continue i + 1, map.add(i)
   }
-  for i = 0; i < 100; i = i + 1 {
+  for i in 0..<100 {
     assert_eq!((i, map.contains(i)), (i, true))
   }
   let map = loop 0, map {

--- a/immut/internal/sparse_array/sparse_array.mbt
+++ b/immut/internal/sparse_array/sparse_array.mbt
@@ -88,7 +88,7 @@ pub fn size[X](self : SparseArray[X]) -> Int {
 ///
 /// Iterate through elements in a sparse array
 pub fn each[X](self : SparseArray[X], f : (X) -> Unit) -> Unit {
-  for i = 0; i < self.elem_info.size(); i = i + 1 {
+  for i in 0..<self.elem_info.size() {
     f(self.data[i])
   }
 }

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -71,7 +71,7 @@ pub fn to_array[A : Compare](self : T[A]) -> Array[A] {
 pub fn iter[A : Compare](self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
     let arr = self.to_array()
-    for i = 0; i < arr.length(); i = i + 1 {
+    for i in 0..<arr.length() {
       if yield_(arr[i]) == IterEnd {
         break IterEnd
       }

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -140,7 +140,7 @@ pub impl[X : FromJson] FromJson for Array[X] with from_json(json, path) {
   }
   let res : Array[X] = Array::new(capacity=a.length())
   let idx = Index(path, index=0)
-  for i = 0; i < a.length(); i = i + 1 {
+  for i in 0..<a.length() {
     // TODO: it should be assert here
     if idx is (Index(_) as idx) {
       idx.index = i

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -64,7 +64,7 @@ fn ParseContext::lex_string(ctx : ParseContext) -> String!ParseError {
 ///|
 fn ParseContext::lex_hex_digits(ctx : ParseContext, n : Int) -> Int!ParseError {
   let mut r = 0
-  for i = 0; i < n; i = i + 1 {
+  for i in 0..<n {
     match ctx.read_char() {
       Some(c) =>
         if c >= 'A' {

--- a/json/utils.mbt
+++ b/json/utils.mbt
@@ -16,7 +16,7 @@
 fn offset_to_position(input : String, offset : Int) -> Position {
   let mut line = 1
   let mut column = 0
-  for i = 0; i < offset; i = i + 1 {
+  for i in 0..<offset {
     let c = input[i]
     if c == '\n' {
       line += 1

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -94,7 +94,7 @@ pub fn to_array[A : Compare](self : T[A]) -> Array[A] {
 pub fn iter[A : Compare](self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
     let arr = self.to_array()
-    for i = 0; i < arr.length(); i = i + 1 {
+    for i in 0..<arr.length() {
       if yield_(arr[i]) == IterEnd {
         break IterEnd
       }

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -102,7 +102,7 @@ pub impl Arbitrary for Char with arbitrary(_, rs) {
 pub impl Arbitrary for String with arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
   let mut s = ""
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     s = s + Char::arbitrary(i, rs).to_string()
   }
   s
@@ -121,7 +121,7 @@ pub impl Arbitrary for BigInt with arbitrary(size, rs) {
 pub impl[X : Arbitrary] Arbitrary for Iter[X] with arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
   Iter::new(fn(yield_) {
-    for i = 0; i < len; i = i + 1 {
+    for i in 0..<len {
       if yield_(X::arbitrary(i, rs)) == IterEnd {
         break IterEnd
       }

--- a/quickcheck/utils.mbt
+++ b/quickcheck/utils.mbt
@@ -16,7 +16,7 @@
 pub fn samples[X : Arbitrary](x : Int) -> Array[X] {
   let rs = @splitmix.new()
   let array = Array::make(x, X::arbitrary(0, rs))
-  for i = 1; i < x; i = i + 1 {
+  for i in 1..<x {
     array[i] = X::arbitrary(i, rs)
   }
   array

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -69,7 +69,7 @@ pub fn State::next(self : State) -> (UInt64, Bool) {
 ///|
 fn bytesToUInt64(b : FixedArray[Byte]) -> UInt64 {
   let mut result = 0UL
-  for i = 0; i < 8; i = i + 1 {
+  for i in 0..<8 {
     result = result | (b[i].to_int64().reinterpret_as_uint64() << (i * 8))
   }
   result
@@ -78,7 +78,7 @@ fn bytesToUInt64(b : FixedArray[Byte]) -> UInt64 {
 ///|
 test "bytesToUInt64" {
   let bytes = FixedArray::make(8, Byte::default())
-  for i = 0; i < 2; i = i + 1 {
+  for i in 0..<2 {
     bytes[i] = i.to_byte()
   }
   inspect!(bytesToUInt64(bytes), content="256")
@@ -91,7 +91,7 @@ fn State::init(self : State, seed : Bytes) -> Unit {
   let seed1 = FixedArray::make(8, Byte::default())
   let seed2 = FixedArray::make(8, Byte::default())
   let seed3 = FixedArray::make(8, Byte::default())
-  for i = 0; i < 8; i = i + 1 {
+  for i in 0..<8 {
     seed0[i] = seed[i]
     seed1[i] = seed[8 + i]
     seed2[i] = seed[16 + i]
@@ -111,7 +111,7 @@ fn State::init64(self : State, seed : FixedArray[UInt64]) -> Unit {
   // convert FixedArray[UInt64] size=[32] to FixedArray[FixedArray[UInt]] size=[16][4]
   let buffer = FixedArray::makei(16, fn(_i) { FixedArray::make(4, 0U) })
   // split u64 to 2 u32 and store in buffer to meet the function signature
-  for i = 0; i < 16; i = i + 1 {
+  for i in 0..<16 {
     let hi = self.buffer[i * 2]
     let lo = self.buffer[i * 2 + 1]
     buffer[i][0] = (hi >> 32).to_uint()
@@ -122,7 +122,7 @@ fn State::init64(self : State, seed : FixedArray[UInt64]) -> Unit {
   // [buffer] is changed in chacha_block
   chacha_block(self.seed, buffer, 0)
   // concat 2 u32 to u64 and store in self.buffer
-  for i = 0; i < 16; i = i + 1 {
+  for i in 0..<16 {
     for j = 0; j < 4; j = j + 2 {
       let lo = buffer[i][j]
       let hi = buffer[i][j + 1]
@@ -150,7 +150,7 @@ pub fn State::refill(self : State) -> Unit {
   // convert FixedArray[UInt64] size=[32] to FixedArray[FixedArray[UInt]] size=[16][4]
   let buffer = FixedArray::makei(16, fn(_i) { FixedArray::make(4, 0U) })
   // split u64 to 2 u32 and store in buffer to meet the function signature
-  for i = 0; i < 16; i = i + 1 {
+  for i in 0..<16 {
     let hi = self.buffer[i * 2]
     let lo = self.buffer[i * 2 + 1]
     buffer[i][0] = (hi >> 32).to_uint()
@@ -160,7 +160,7 @@ pub fn State::refill(self : State) -> Unit {
   }
   chacha_block(self.seed, buffer, self.c)
   // concat 2 u32 to u64 and store in self.buffer
-  for i = 0; i < 16; i = i + 1 {
+  for i in 0..<16 {
     for j = 0; j < 4; j = j + 2 {
       let lo = buffer[i][j]
       let hi = buffer[i][j + 1]
@@ -178,7 +178,7 @@ pub fn State::refill(self : State) -> Unit {
 ///|
 fn State::reseed(self : State) -> Unit {
   let seed = FixedArray::make(4, 0UL)
-  for i = 0; i < 4; i = i + 1 {
+  for i in 0..<4 {
     for {
       let x = self.next()
       if x.1 {
@@ -218,7 +218,7 @@ fn chacha_block(
   }
 
   setup(seed, buf, counter)
-  for i = 0; i < buf[0].length(); i = i + 1 {
+  for i in 0..<buf[0].length() {
     let mut b0 = buf[0][i]
     let mut b1 = buf[1][i]
     let mut b2 = buf[2][i]
@@ -235,7 +235,7 @@ fn chacha_block(
     let mut b13 = buf[13][i]
     let mut b14 = buf[14][i]
     let mut b15 = buf[15][i]
-    for round = 0; round < 4; round = round + 1 {
+    for round in 0..<4 {
       let tb1 = qr((b0, b4, b8, b12))
       b0 = tb1.0
       b4 = tb1.1
@@ -384,7 +384,7 @@ test "output" {
     }
   }
 
-  for i = 0; i < 372; i = i + 1 {
+  for i in 0..<372 {
     let x = uint64(s)
     res.push(x)
   }

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -208,7 +208,7 @@ pub fn from_double(value : Double) -> T!RationalError {
   if q > t_max_f {
     overflow_error!()
   }
-  for i = 0; i < max_iteration; i = i + 1 {
+  for i in 0..<max_iteration {
     if not(q >= -9223372036854775808.0 && q < 9223372036854775808.0) {
       break // overflow
     }

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -30,7 +30,7 @@ pub fn singleton[V : Compare](value : V) -> T[V] {
 /// Initialize an set from an array.
 pub fn from_array[V : Compare](array : Array[V]) -> T[V] {
   let set = new()
-  for i = 0; i < array.length(); i = i + 1 {
+  for i in 0..<array.length() {
     set.add(array[i])
   }
   set
@@ -39,7 +39,7 @@ pub fn from_array[V : Compare](array : Array[V]) -> T[V] {
 ///| @alert deprecated "Use @sorted_set.from_array instead"
 pub fn of[V : Compare](array : Array[V]) -> T[V] {
   let set = new()
-  for i = 0; i < array.length(); i = i + 1 {
+  for i in 0..<array.length() {
     set.add(array[i])
   }
   set

--- a/strconv/bool.mbt
+++ b/strconv/bool.mbt
@@ -40,7 +40,7 @@ test "parse_bool" {
     ("true", Ok(true)),
     ("True", Ok(true)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -495,7 +495,7 @@ fn new_digits(self : Decimal, s : Int) -> Int {
   let cheat_num = left_shift_cheats[s].1
   // check if the leading digits lexicographically less than cheats num.
   let mut less = false
-  for i = 0; i < cheat_num.length(); i = i + 1 {
+  for i in 0..<cheat_num.length() {
     if i >= self.digits_num {
       less = true
       break
@@ -581,15 +581,15 @@ pub impl Show for Decimal with output(self, logger) {
   if self.decimal_point <= 0 {
     // zeros filling between the decimal point and the digits
     logger.write_string("0.")
-    for i = 0; i < -self.decimal_point; i = i + 1 {
+    for i in 0..<-self.decimal_point {
       logger.write_char('0')
     }
-    for i = 0; i < self.digits_num; i = i + 1 {
+    for i in 0..<self.digits_num {
       logger.write_string(self.digits[i].to_int().to_string())
     }
   } else if self.decimal_point < self.digits_num {
     // decimal point in the middle of digits
-    for i = 0; i < self.digits_num; i = i + 1 {
+    for i in 0..<self.digits_num {
       if i == self.decimal_point {
         logger.write_char('.')
       }
@@ -597,10 +597,10 @@ pub impl Show for Decimal with output(self, logger) {
     }
   } else {
     // zeros filling between the digits and the decimal point
-    for i = 0; i < self.digits_num; i = i + 1 {
+    for i in 0..<self.digits_num {
       logger.write_string(self.digits[i].to_int().to_string())
     }
-    for i = 0; i < self.decimal_point - self.digits_num; i = i + 1 {
+    for i in 0..<(self.decimal_point - self.digits_num) {
       logger.write_char('0')
     }
   }
@@ -671,7 +671,7 @@ test "shift" {
     (195312L, 9, "99999744"),
     (1953125L, 9, "1000000000"),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     let d = Decimal::from_int64_priv(t.0)
     d.shift_priv(t.1)

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -273,7 +273,7 @@ test "parse_double" {
     ("123.5e+1__2", Err(syntax_err_str)),
     ("123.5e+12_", Err(syntax_err_str)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -281,7 +281,7 @@ test "parse_int64" {
     ("12345_", Err(syntax_err_str)),
     ("12345%", Err(syntax_err_str)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {
@@ -401,7 +401,7 @@ test "parse_int64_base" {
     ("0x+f", 0, Err(syntax_err_str)),
     ("0x-f", 0, Err(syntax_err_str)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {
@@ -443,7 +443,7 @@ test "parse_int" {
     ("12345_", Err(syntax_err_str)),
     ("123%45", Err(syntax_err_str)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {

--- a/strconv/int_test.mbt
+++ b/strconv/int_test.mbt
@@ -50,7 +50,7 @@ test "parse_int64_uncovered_lines" {
     ("[", 16, Err(syntax_err)),
     ("{", 16, Err(syntax_err)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(parse_as_result(t.0, base=t.1), t.2)
   }

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -96,7 +96,7 @@ fn is_empty(self : StringSlice) -> Bool {
 ///|
 fn StringSlice::to_string(self : StringSlice) -> String {
   let buf = StringBuilder::new(size_hint=self.length())
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     buf.write_char(self[i])
   }
   buf.to_string()
@@ -134,7 +134,7 @@ fn fold_digits[T](
   let mut ret = init
   let mut len = 0
   // let len = self.length()
-  for i = 0; i < self.length(); i = i + 1 {
+  for i in 0..<self.length() {
     if not(is_digit(self[i]) || self[i] == '_') {
       return (self.subfix_unchecked(i), ret, len)
     }

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -113,7 +113,7 @@ test "parse_uint64" {
     ("12345_", Err(syntax_err_str)),
     ("12345%", Err(syntax_err_str)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {
@@ -213,7 +213,7 @@ test "parse_uint64_base" {
     ("0x+f", 0, Err(syntax_err_str)),
     ("0x-f", 0, Err(syntax_err_str)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {
@@ -250,7 +250,7 @@ test "parse_uint" {
     ("12345_", Err(syntax_err_str)),
     ("123%45", Err(syntax_err_str)),
   ]
-  for i = 0; i < tests.length(); i = i + 1 {
+  for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq!(
       try {

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -103,7 +103,7 @@ pub impl Compare for String with compare(self, other) {
   let len = self.length()
   match len.compare(other.length()) {
     0 => {
-      for i = 0; i < len; i = i + 1 {
+      for i in 0..<len {
         let order = self[i].compare(other[i])
         if order != 0 {
           return order
@@ -158,7 +158,7 @@ pub fn to_array(self : String) -> Array[Char] {
 pub fn iter(self : String) -> Iter[Char] {
   Iter::new(fn(yield_) {
     let len = self.length()
-    for index = 0; index < len; index = index + 1 {
+    for index in 0..<len {
       let c1 = self.unsafe_charcode_at(index)
       if is_leading_surrogate(c1) && index + 1 < len {
         let c2 = self.unsafe_charcode_at(index + 1)
@@ -293,7 +293,7 @@ pub fn contains_char(self : String, c : Char) -> Bool {
 /// Removes all leading chars contained in the given string.
 pub fn trim_start(self : String, trim_set : String) -> String {
   let len = self.length()
-  for i = 0; i < len; i = i + 1 {
+  for i in 0..<len {
     let c1 = self.unsafe_charcode_at(i)
     // check surrogate pair
     if is_leading_surrogate(c1) && i + 1 < len {
@@ -386,7 +386,7 @@ pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
     }
     // check the rest
     if i <= max_idx {
-      for j = 1; j < sub_len; j = j + 1 {
+      for j in 1..<sub_len {
         if self[i + j] != str[j] {
           break
         }
@@ -654,7 +654,7 @@ pub fn pad_start(
     self
   } else {
     let buf = StringBuilder::new(size_hint=total_width)
-    for i = 0; i < total_width - len; i = i + 1 {
+    for i in 0..<(total_width - len) {
       buf.write_char(padding_char)
     }
     buf.write_string(self)
@@ -678,7 +678,7 @@ pub fn pad_end(self : String, total_width : Int, padding_char : Char) -> String 
   } else {
     let buf = StringBuilder::new(size_hint=total_width)
     buf.write_string(self)
-    for i = 0; i < total_width - len; i = i + 1 {
+    for i in 0..<(total_width - len) {
       buf.write_char(padding_char)
     }
     buf.to_string()


### PR DESCRIPTION
```yaml

suggested-for-in:
  search: |
    ((for_expression
      (for_binder
       (lowercase_identifier) @binderDefinition
        (expression
         (pipeline_expression
          (compound_expression
           (simple_expression
            (atomic_expression
             (literal
              (integer_literal) @rangeLower)))))))
        .
        (semicolon)
        (compound_expression
         (binary_expression
         (_) @binderConditional
         "<"
         (_) @rangeUpper))
        (semicolon)
        (for_binder
         (lowercase_identifier) @binderAssignment
         (expression
         (pipeline_expression
          (compound_expression
           (binary_expression
              (_) @binderUpdate
              "+"
              (_) @rangeStep)))))
        (block_expression) @forBody
        (else_clause)? @forBody)
     (#eq? @binderDefinition @binderConditional)
     (#eq? @binderDefinition @binderAssignment)
     (#eq? @binderDefinition @binderUpdate)
     (#eq? @rangeStep "1"))
  replace: |
    for $binderDefinition in $rangeLower..<($rangeUpper) $forBody
```