### PR TITLE
Breaking change: `String::codepoint_at`

### DIFF
--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -111,13 +111,24 @@ fn base64_encode(data : FixedArray[Byte]) -> String {
 
 ///|
 fn base64_encode_string_codepoint(s : String) -> String {
-  let data : FixedArray[Byte] = FixedArray::make(s.codepoint_length() * 4, 0)
-  for i in 0..<s.codepoint_length() {
-    let c = s.codepoint_at(i).to_int()
-    data[i * 4] = (c & 0xFF).to_byte()
-    data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()
-    data[i * 4 + 2] = ((c >> 16) & 0xFF).to_byte()
-    data[i * 4 + 3] = ((c >> 24) & 0xFF).to_byte()
+  let codepoint_len = s.codepoint_length()
+  let data : FixedArray[Byte] = FixedArray::make(codepoint_len * 4, 0)
+  for i = 0, utf16_index = 0
+      i < codepoint_len
+      i = i + 1, utf16_index = utf16_index + 1 {
+    let c = s.codepoint_at(utf16_index).to_int()
+    if c <= 0xFFFF {
+      data[i * 4] = (c & 0xFF).to_byte()
+      data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()
+      data[i * 4 + 2] = 0
+      data[i * 4 + 3] = 0
+    } else {
+      data[i * 4] = (c & 0xFF).to_byte()
+      data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()
+      data[i * 4 + 2] = ((c >> 16) & 0xFF).to_byte()
+      data[i * 4 + 3] = ((c >> 24) & 0xFF).to_byte()
+      continue i + 1, utf16_index + 2
+    }
   }
   base64_encode(data)
 }

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -79,10 +79,12 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 
 ///|
-/// Returns the Unicode code point at the given index.
+/// Returns the Unicode code point at the given index. Note that the index is
+/// still based on UTF-16 code units, not Unicode code points.
 ///
-/// This method counts Unicode code points (characters) rather than UTF-16 code units.
-/// It properly handles surrogate pairs to return the correct Unicode character.
+/// If the element at `index` is a UTF-16 leading surrogate, returns the code
+/// point of the surrogate pair. If the element at index is a UTF-16 trailing
+/// surrogate, returns only the trailing surrogate code unit.
 ///
 /// # Examples
 ///
@@ -90,6 +92,7 @@ pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 /// let s = "Hello🤣";
 /// inspect!(s.codepoint_at(0), content="H");
 /// inspect!(s.codepoint_at(5), content="🤣"); // Returns full emoji character
+/// inspect!(s.codepoint_at(6).to_int(), content="56611"); // Returns trailing surrogate
 /// ```
 ///
 /// # Panics
@@ -100,33 +103,20 @@ pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 pub fn String::codepoint_at(self : String, index : Int) -> Char {
   let charcode_len = self.length()
   guard index >= 0 && index < charcode_len else { abort("index out of bounds") }
-  for char_count = 0, utf16_offset = 0
-      char_count < charcode_len && utf16_offset < index
-      char_count = char_count + 1, utf16_offset = utf16_offset + 1 {
-    let c1 = self.unsafe_charcode_at(char_count)
-    if is_leading_surrogate(c1) && char_count + 1 < charcode_len {
-      let c2 = self.unsafe_charcode_at(char_count + 1)
-      if is_trailing_surrogate(c2) {
-        continue char_count + 2, utf16_offset + 1
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-  } else {
-    guard utf16_offset == index && char_count < charcode_len else {
-      abort("index out of bounds")
-    }
-    let c1 = self.unsafe_charcode_at(char_count)
-    if is_leading_surrogate(c1) && char_count + 1 < charcode_len {
-      let c2 = self.unsafe_charcode_at(char_count + 1)
+  let c1 = self.unsafe_charcode_at(index)
+  if is_leading_surrogate(c1) {
+    if index + 1 < charcode_len {
+      let c2 = self.unsafe_charcode_at(index + 1)
       if is_trailing_surrogate(c2) {
         code_point_of_surrogate_pair(c1, c2)
       } else {
         abort("invalid surrogate pair")
       }
     } else {
-      Char::from_int(c1)
+      abort("invalid surrogate pair")
     }
+  } else {
+    Char::from_int(c1)
   }
 }
 

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -51,7 +51,7 @@ test "substring" {
 ///|
 test "panic codepoint_at1" {
   let str = "Hello🤣🤣🤣"
-  let _ = str.codepoint_at(8)
+  let _ = str.codepoint_at(11)
 
 }
 
@@ -84,6 +84,7 @@ test "codepoint_at regular character at end of string" {
 test "codepoint_at emoji" {
   let s = "👋"
   inspect!(s.codepoint_at(0), content="👋")
+  inspect!(s.codepoint_at(1).to_int(), content="56395")
 }
 
 ///|


### PR DESCRIPTION
This PR changes the semantics of `String::codepoint_at(i: Int)`: Previously, this function returns the i-th unicode character and has time complexity of O(i). This PR changes `i` to the utf-16 index and has time complexity of O(1).