### PR TITLE
deprecated `codepoint_at` and provide `unsafe_codepoint_at`

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -40,8 +40,6 @@ fn println[T : Show](T) -> Unit
 
 fn repr[T : Show](T) -> String
 
-fn unsafe_codepoint_at(String, Int) -> Char
-
 // Types and methods
 pub(all) type ArgsLoc Array[SourceLoc?]
 impl ArgsLoc {

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -40,6 +40,8 @@ fn println[T : Show](T) -> Unit
 
 fn repr[T : Show](T) -> String
 
+fn unsafe_codepoint_at(String, Int) -> Char
+
 // Types and methods
 pub(all) type ArgsLoc Array[SourceLoc?]
 impl ArgsLoc {
@@ -643,6 +645,7 @@ impl String {
   charcode_at(String, Int) -> Int
   #deprecated
   charcode_length(String) -> Int
+  #deprecated
   codepoint_at(String, Int) -> Char
   codepoint_length(String) -> Int
   escape(String) -> String
@@ -655,6 +658,7 @@ impl String {
   substring(String, start~ : Int = .., end? : Int) -> String
   to_string(String) -> String
   unsafe_charcode_at(String, Int) -> Int
+  unsafe_codepoint_at(String, Int) -> Char
 }
 
 impl Option {

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -111,13 +111,25 @@ fn base64_encode(data : FixedArray[Byte]) -> String {
 
 ///|
 fn base64_encode_string_codepoint(s : String) -> String {
-  let data : FixedArray[Byte] = FixedArray::make(s.codepoint_length() * 4, 0)
-  for i in 0..<s.codepoint_length() {
-    let c = s.codepoint_at(i).to_int()
-    data[i * 4] = (c & 0xFF).to_byte()
-    data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()
-    data[i * 4 + 2] = ((c >> 16) & 0xFF).to_byte()
-    data[i * 4 + 3] = ((c >> 24) & 0xFF).to_byte()
+  // the input string is expected to be valid utf-16 string
+  let codepoint_length = s.codepoint_length()
+  let data : FixedArray[Byte] = FixedArray::make(codepoint_length * 4, 0)
+  for i = 0, utf16_index = 0
+      i < codepoint_length
+      i = i + 1, utf16_index = utf16_index + 1 {
+    let c = s.unsafe_codepoint_at(utf16_index).to_int()
+    if c > 0xFFFF {
+      data[i * 4] = (c & 0xFF).to_byte()
+      data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()
+      data[i * 4 + 2] = ((c >> 16) & 0xFF).to_byte()
+      data[i * 4 + 3] = ((c >> 24) & 0xFF).to_byte()
+      continue i + 1, utf16_index + 2
+    } else {
+      data[i * 4] = (c & 0xFF).to_byte()
+      data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()
+      data[i * 4 + 2] = 0
+      data[i * 4 + 3] = 0
+    }
   }
   base64_encode(data)
 }

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -133,7 +133,7 @@ pub fn String::codepoint_at(self : String, index : Int) -> Char {
 
 ///|
 /// Returns the Unicode code point at the given index without bounds checking.
-pub fn unsafe_codepoint_at(self : String, index : Int) -> Char {
+pub fn String::unsafe_codepoint_at(self : String, index : Int) -> Char {
   let c1 = self.unsafe_charcode_at(index)
   if is_leading_surrogate(c1) {
     let c2 = self.unsafe_charcode_at(index + 1)

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -97,6 +97,7 @@ pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 /// Panics if:
 /// - The index is out of bounds
 /// - The string contains an invalid surrogate pair
+#deprecated("The index will be changed to utf16 index. If you want to access n-th character, use `str.iter().nth(n).unwrap()` instead.")
 pub fn String::codepoint_at(self : String, index : Int) -> Char {
   let charcode_len = self.length()
   guard index >= 0 && index < charcode_len else { abort("index out of bounds") }
@@ -127,6 +128,18 @@ pub fn String::codepoint_at(self : String, index : Int) -> Char {
     } else {
       Char::from_int(c1)
     }
+  }
+}
+
+///|
+/// Returns the Unicode code point at the given index without bounds checking.
+pub fn unsafe_codepoint_at(self : String, index : Int) -> Char {
+  let c1 = self.unsafe_charcode_at(index)
+  if is_leading_surrogate(c1) {
+    let c2 = self.unsafe_charcode_at(index + 1)
+    code_point_of_surrogate_pair(c1, c2)
+  } else {
+    Char::from_int(c1)
   }
 }
 

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -87,6 +87,16 @@ test "codepoint_at emoji" {
 }
 
 ///|
+test "unsafe_codepoint_at" {
+  let s = "a👋b"
+  inspect!(s.unsafe_codepoint_at(0), content="a")
+  inspect!(s.unsafe_codepoint_at(1), content="👋")
+  // invalid char cannot be inspected
+  inspect!(s.unsafe_codepoint_at(2).to_int(), content="56395")
+  inspect!(s.unsafe_codepoint_at(3), content="b")
+}
+
+///|
 test "codepoint_length basic" {
   let str = "hello"
   inspect!(str.codepoint_length(), content="5")


### PR DESCRIPTION
The index `i` in `str.codepoint_at(i)` will be changed from unicode index to utf16 index.