### PR TITLE
deprecate [Char::op_sub]

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -412,6 +412,7 @@ impl Byte {
 
 impl Char {
   from_int(Int) -> Char
+  #deprecated
   op_sub(Char, Char) -> Int
   to_int(Char) -> Int
   to_uint(Char) -> UInt

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -32,6 +32,8 @@
 ///   inspect!(a - b, content="1") // Unicode point of 'b' (98) minus 'a' (97)
 /// }
 /// ```
+#deprecated("convert the `Char` to `Int` first")
+#converage.skip
 pub fn Char::op_sub(self : Char, that : Char) -> Int {
   self.to_int() - that.to_int()
 }

--- a/builtin/char_test.mbt
+++ b/builtin/char_test.mbt
@@ -13,13 +13,6 @@
 // limitations under the License.
 
 ///|
-test "char subtraction" {
-  let b = 'b'
-  let a = 'a'
-  inspect!(b - a, content="1")
-}
-
-///|
 test "char show" {
   assert_eq!('\b'.to_string(), "\u0008")
   // assert_eq!('\b'.to_string(), "\u{8}")

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -111,7 +111,7 @@ fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
         continue rest
       }
       if d.digits_num < d.digits.length() {
-        d.digits[d.digits_num] = (digit - '0').to_byte()
+        d.digits[d.digits_num] = (digit.to_int() - '0').to_byte()
         d.digits_num += 1
       } else if digit != '0' {
         d.truncated = true
@@ -141,7 +141,7 @@ fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
       let rest = loop rest {
         ['_', .. rest] => continue rest
         ['0'..='9' as digit, .. rest] => {
-          exp = exp * 10 + (digit - '0')
+          exp = exp * 10 + (digit.to_int() - '0')
           continue rest
         }
         rest => rest

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -108,10 +108,11 @@ pub fn parse_int64(str : String, base~ : Int = 0) -> Int64!StrConvError {
     ['_', ..], _, false => syntax_err!()
     ['_', .. rest], acc, true => continue rest, acc, false
     [c, .. rest], acc, _ => {
+      let c = c.to_int()
       let d = match c {
-        '0'..='9' => c.to_int() - '0'
-        'a'..='z' => c.to_int() - 'a' + 10
-        'A'..='Z' => c.to_int() - 'A' + 10
+        '0'..='9' => c - '0'
+        'a'..='z' => c + (10 - 'a')
+        'A'..='Z' => c + (10 - 'A')
         _ => syntax_err!()
       }
       guard d < num_base else { syntax_err!() }

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -109,9 +109,9 @@ pub fn parse_int64(str : String, base~ : Int = 0) -> Int64!StrConvError {
     ['_', .. rest], acc, true => continue rest, acc, false
     [c, .. rest], acc, _ => {
       let d = match c {
-        '0'..='9' => c - '0'
-        'a'..='z' => c - 'a' + 10
-        'A'..='Z' => c - 'A' + 10
+        '0'..='9' => c.to_int() - '0'
+        'a'..='z' => c.to_int() - 'a' + 10
+        'A'..='Z' => c.to_int() - 'A' + 10
         _ => syntax_err!()
       }
       guard d < num_base else { syntax_err!() }

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -65,10 +65,11 @@ pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
     ['_', ..], _, false => syntax_err!()
     ['_', .. rest], acc, true => continue rest, acc, false
     [c, .. rest], acc, _ => {
+      let c = c.to_int()
       let d = match c {
-        '0'..='9' => c.to_int() - '0'
-        'a'..='z' => c.to_int() - 'a' + 10
-        'A'..='Z' => c.to_int() - 'A' + 10
+        '0'..='9' => c - '0'
+        'a'..='z' => c + (10 - 'a')
+        'A'..='Z' => c + (10 - 'A')
         _ => syntax_err!()
       }
       guard d < num_base else { syntax_err!() }

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -66,9 +66,9 @@ pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
     ['_', .. rest], acc, true => continue rest, acc, false
     [c, .. rest], acc, _ => {
       let d = match c {
-        '0'..='9' => c - '0'
-        'a'..='z' => c - 'a' + 10
-        'A'..='Z' => c - 'A' + 10
+        '0'..='9' => c.to_int() - '0'
+        'a'..='z' => c.to_int() - 'a' + 10
+        'A'..='Z' => c.to_int() - 'A' + 10
         _ => syntax_err!()
       }
       guard d < num_base else { syntax_err!() }


### PR DESCRIPTION
We plan to migrate operator overloading from using methods to using traits. The trait for the `-` operator has the following signature:

```moonbit
trait Sub {
  op_sub(Self, Self) -> Self
}
```

However, the `Char::op_sub` operator is incompatible with this trait: it has type `(Char, Char) -> Int`. So this PR deprecates the `Char::op_sub` operator.

The typical usage of this operator is to calculate offset between characters, and most of the times the second operand is a char literal, such as `c - 'a'`. In this case, the program can be transformed to `c.to_int() - 'a'`. Thanks to recently introduced overloading of char literal to type `Int`, the second operand need no change.