### PR TITLE
migrate operator overloading to using traits

### DIFF
--- a/array/array.mbti
+++ b/array/array.mbti
@@ -58,7 +58,6 @@ impl FixedArray {
   new[T](Int, () -> T) -> Self[T]
   #deprecated
   new_with_index[T](Int, (Int) -> T) -> Self[T]
-  op_add[T](Self[T], Self[T]) -> Self[T]
   rev[T](Self[T]) -> Self[T]
   rev_each[T](Self[T], (T) -> Unit) -> Unit
   rev_eachi[T](Self[T], (Int, T) -> Unit) -> Unit
@@ -73,6 +72,7 @@ impl FixedArray {
   starts_with[T : Eq](Self[T], Self[T]) -> Bool
   swap[T](Self[T], Int, Int) -> Unit
 }
+impl[T] Add for FixedArray[T]
 impl[T : Eq] Eq for FixedArray[T]
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for FixedArray[X]
 

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -1061,10 +1061,7 @@ test "deep_clone" {
 ///   inspect!(arr1 + arr2, content="[1, 2, 3, 4, 5, 6]")
 /// }
 /// ```
-pub fn FixedArray::op_add[T](
-  self : FixedArray[T],
-  other : FixedArray[T]
-) -> FixedArray[T] {
+pub impl[T] Add for FixedArray[T] with op_add(self, other) {
   let slen = self.length()
   let nlen = other.length()
   if slen == 0 {

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -319,7 +319,7 @@ pub impl[T : Compare] Compare for Array[T] with compare(self, other) {
 ///   inspect!(a + b, content="[1, 2, 3, 4, 5]")
 /// }
 /// ```
-pub fn Array::op_add[T](self : Array[T], other : Array[T]) -> Array[T] {
+pub impl[T] Add for Array[T] with op_add(self, other) {
   let result = Array::make_uninit(self.length() + other.length())
   UninitializedArray::unsafe_blit(
     result.buffer(),

--- a/builtin/bigint_js.mbt
+++ b/builtin/bigint_js.mbt
@@ -151,28 +151,58 @@ pub extern "js" fn BigInt::is_zero(self : BigInt) -> Bool =
   #|(x) => x === 0n
 
 ///|
-pub extern "js" fn BigInt::op_neg(self : BigInt) -> BigInt =
+extern "js" fn BigInt::op_neg_ffi(self : BigInt) -> BigInt =
   #|(x) => -x
 
 ///|
-pub extern "js" fn BigInt::op_add(self : BigInt, other : BigInt) -> BigInt =
+pub impl Neg for BigInt with op_neg(self) {
+  self.op_neg_ffi()
+}
+
+///|
+extern "js" fn BigInt::op_add_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x + y
 
 ///|
-pub extern "js" fn BigInt::op_sub(self : BigInt, other : BigInt) -> BigInt =
+pub impl Add for BigInt with op_add(self, other) {
+  self.op_add_ffi(other)
+}
+
+///|
+extern "js" fn BigInt::op_sub_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x - y
 
 ///|
-pub extern "js" fn BigInt::op_mul(self : BigInt, other : BigInt) -> BigInt =
+pub impl Sub for BigInt with op_sub(self, other) {
+  self.op_sub_ffi(other)
+}
+
+///|
+extern "js" fn BigInt::op_mul_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x * y
 
 ///|
-pub extern "js" fn BigInt::op_div(self : BigInt, other : BigInt) -> BigInt =
+pub impl Mul for BigInt with op_mul(self, other) {
+  self.op_mul_ffi(other)
+}
+
+///|
+extern "js" fn BigInt::op_div_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x / y
 
 ///|
-pub extern "js" fn BigInt::op_mod(self : BigInt, other : BigInt) -> BigInt =
+pub impl Div for BigInt with op_div(self, other) {
+  self.op_div_ffi(other)
+}
+
+///|
+extern "js" fn BigInt::op_mod_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x % y
+
+///|
+pub impl Mod for BigInt with op_mod(self, other) {
+  self.op_mod_ffi(other)
+}
 
 ///|
 extern "js" fn BigInt::modpow_ffi(
@@ -211,7 +241,7 @@ extern "js" fn BigInt::to_byte(self : BigInt) -> Byte =
   #|(x) => Number(BigInt.asUintN(8, x)) | 0
 
 ///|
-pub fn BigInt::op_shl(self : BigInt, n : Int) -> BigInt {
+pub impl Shl for BigInt with op_shl(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
   }
@@ -219,7 +249,7 @@ pub fn BigInt::op_shl(self : BigInt, n : Int) -> BigInt {
 }
 
 ///|
-pub fn BigInt::op_shr(self : BigInt, n : Int) -> BigInt {
+pub impl Shr for BigInt with op_shr(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
   }
@@ -235,16 +265,31 @@ extern "js" fn BigInt::js_shr(self : BigInt, other : Int) -> BigInt =
   #|(x, y) => x >> BigInt(y)
 
 ///|
-pub extern "js" fn BigInt::land(self : BigInt, other : BigInt) -> BigInt =
+extern "js" fn BigInt::js_land(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x & y
 
 ///|
-pub extern "js" fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt =
+pub impl BitAnd for BigInt with land(self, other) {
+  self.js_land(other)
+}
+
+///|
+extern "js" fn BigInt::js_lor(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x | y
 
 ///|
-pub extern "js" fn BigInt::lxor(self : BigInt, other : BigInt) -> BigInt =
+pub impl BitOr for BigInt with lor(self, other) {
+  self.js_lor(other)
+}
+
+///|
+extern "js" fn BigInt::js_lxor(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x ^ y
+
+///|
+pub impl BitXOr for BigInt with lxor(self, other) {
+  self.js_lxor(other)
+}
 
 ///|
 /// Converts a `BigInt` to an unsigned 32-bit integer (`UInt`).

--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -208,7 +208,7 @@ pub fn BigInt::from_uint64(n : UInt64) -> BigInt {
 ///   inspect!(-0N, content="0")
 /// }
 /// ```
-pub fn BigInt::op_neg(self : BigInt) -> BigInt {
+pub impl Neg for BigInt with op_neg(self : BigInt) -> BigInt {
   if self.is_zero() {
     return zero
   }
@@ -237,7 +237,7 @@ pub fn BigInt::op_neg(self : BigInt) -> BigInt {
 ///   inspect!(-a + -b, content="-9223372036854775808")
 /// }
 /// ```
-pub fn BigInt::op_add(self : BigInt, other : BigInt) -> BigInt {
+pub impl Add for BigInt with op_add(self : BigInt, other : BigInt) -> BigInt {
   if self.sign == Negative {
     if other.sign == Negative {
       return -(-other + -self)
@@ -285,7 +285,7 @@ pub fn BigInt::op_add(self : BigInt, other : BigInt) -> BigInt {
 ///   inspect!(-a - b, content="-22222222112222222211")
 /// }
 /// ```
-pub fn BigInt::op_sub(self : BigInt, other : BigInt) -> BigInt {
+pub impl Sub for BigInt with op_sub(self : BigInt, other : BigInt) -> BigInt {
   // first make sure self and other > 0
   if self.sign == Negative {
     if other.sign == Negative {
@@ -361,7 +361,7 @@ pub fn BigInt::op_sub(self : BigInt, other : BigInt) -> BigInt {
 ///   inspect!(a * 0N, content="0")
 /// }
 /// ```
-pub fn BigInt::op_mul(self : BigInt, other : BigInt) -> BigInt {
+pub impl Mul for BigInt with op_mul(self : BigInt, other : BigInt) -> BigInt {
   if self.is_zero() || other.is_zero() {
     return zero
   }
@@ -458,7 +458,7 @@ fn BigInt::split(self : BigInt, half : Int) -> (BigInt, BigInt) {
 ///   ignore(a / b) // Division by zero
 /// }
 /// ```
-pub fn BigInt::op_div(self : BigInt, other : BigInt) -> BigInt {
+pub impl Div for BigInt with op_div(self : BigInt, other : BigInt) -> BigInt {
   // TODO:
   // guard (other != zero, "division by zero")
   if other == zero {
@@ -507,7 +507,7 @@ pub fn BigInt::op_div(self : BigInt, other : BigInt) -> BigInt {
 ///   ignore(a % 0N) // Division by zero
 /// }
 /// ```
-pub fn BigInt::op_mod(self : BigInt, other : BigInt) -> BigInt {
+pub impl Mod for BigInt with op_mod(self : BigInt, other : BigInt) -> BigInt {
   if other == zero {
     abort("division by zero")
   }
@@ -697,7 +697,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
 ///   ignore(x << -1) // Panics with "negative shift count"
 /// }
 /// ```
-pub fn BigInt::op_shl(self : BigInt, n : Int) -> BigInt {
+pub impl Shl for BigInt with op_shl(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
   }
@@ -761,7 +761,7 @@ pub fn BigInt::op_shl(self : BigInt, n : Int) -> BigInt {
 ///   ignore(n >> -1) // Panics with "negative shift count"
 /// }
 /// ```
-pub fn BigInt::op_shr(self : BigInt, n : Int) -> BigInt {
+pub impl Shr for BigInt with op_shr(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
   }
@@ -1474,7 +1474,7 @@ pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
 ///   inspect!(a & b, content="-8") // ~0b1011 + 1
 /// }
 /// ```
-pub fn BigInt::land(self : BigInt, other : BigInt) -> BigInt {
+pub impl BitAnd for BigInt with land(self : BigInt, other : BigInt) -> BigInt {
   let max_length = if self.limbs.length() < other.limbs.length() {
     other.limbs.length() + 1
   } else {
@@ -1583,7 +1583,7 @@ pub fn BigInt::land(self : BigInt, other : BigInt) -> BigInt {
 ///   inspect!(c | d, content="-4")
 /// }
 /// ```
-pub fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt {
+pub impl BitOr for BigInt with lor(self : BigInt, other : BigInt) -> BigInt {
   let max_length = if self.limbs.length() < other.limbs.length() {
     other.limbs.length() + 1
   } else {
@@ -1695,7 +1695,7 @@ pub fn BigInt::lor(self : BigInt, other : BigInt) -> BigInt {
 ///   inspect!(a ^ a, content="0") // XOR with self gives 0
 /// }
 /// ```
-pub fn BigInt::lxor(self : BigInt, other : BigInt) -> BigInt {
+pub impl BitXOr for BigInt with lxor(self : BigInt, other : BigInt) -> BigInt {
   let max_length = if self.limbs.length() < other.limbs.length() {
     other.limbs.length() + 1
   } else {

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -92,7 +92,6 @@ impl Array {
   mapi[T, U](Self[T], (Int, T) -> U) -> Self[U]
   mapi_inplace[T](Self[T], (Int, T) -> T) -> Unit
   new[T](capacity~ : Int = ..) -> Self[T]
-  op_add[T](Self[T], Self[T]) -> Self[T]
   op_as_view[T](Self[T], start~ : Int = .., end? : Int) -> ArrayView[T]
   op_get[T](Self[T], Int) -> T
   op_set[T](Self[T], Int, T) -> Unit
@@ -126,6 +125,7 @@ impl Array {
   unsafe_get[T](Self[T], Int) -> T
   unsafe_pop[T](Self[T]) -> T
 }
+impl[T] Add for Array[T]
 impl[T : Compare] Compare for Array[T]
 impl[T] Default for Array[T]
 impl[T : Eq] Eq for Array[T]
@@ -155,19 +155,8 @@ impl BigInt {
   from_uint(UInt) -> Self
   from_uint64(UInt64) -> Self
   is_zero(Self) -> Bool
-  land(Self, Self) -> Self
-  lor(Self, Self) -> Self
   #deprecated
   lsl(Self, Int) -> Self
-  lxor(Self, Self) -> Self
-  op_add(Self, Self) -> Self
-  op_div(Self, Self) -> Self
-  op_mod(Self, Self) -> Self
-  op_mul(Self, Self) -> Self
-  op_neg(Self) -> Self
-  op_shl(Self, Int) -> Self
-  op_shr(Self, Int) -> Self
-  op_sub(Self, Self) -> Self
   pow(Self, Self, modulus? : Self) -> Self
   #deprecated
   shl(Self, Int) -> Self
@@ -181,9 +170,20 @@ impl BigInt {
   to_uint(Self) -> UInt
   to_uint64(Self) -> UInt64
 }
+impl Add for BigInt
+impl BitAnd for BigInt
+impl BitOr for BigInt
+impl BitXOr for BigInt
 impl Compare for BigInt
+impl Div for BigInt
 impl Eq for BigInt
+impl Mod for BigInt
+impl Mul for BigInt
+impl Neg for BigInt
+impl Shl for BigInt
 impl Show for BigInt
+impl Shr for BigInt
+impl Sub for BigInt
 impl ToJson for BigInt
 
 pub(all) type! Failure String
@@ -244,7 +244,6 @@ impl Iter {
   minimum[T : Compare](Self[T]) -> T?
   new[T](((T) -> IterResult) -> IterResult) -> Self[T]
   nth[T](Self[T], Int) -> T?
-  op_add[T](Self[T], Self[T]) -> Self[T]
   op_as_view[A](Self[A], start~ : Int = .., end? : Int) -> Self[A]
   peek[T](Self[T]) -> T?
   prepend[T](Self[T], T) -> Self[T]
@@ -256,6 +255,7 @@ impl Iter {
   tap[T](Self[T], (T) -> Unit) -> Self[T]
   to_array[T](Self[T]) -> Array[T]
 }
+impl[T] Add for Iter[T]
 impl[T : Show] Show for Iter[T]
 
 type Iter2[A, B]
@@ -384,20 +384,11 @@ impl Bool {
 }
 
 impl Byte {
-  land(Byte, Byte) -> Byte
   lnot(Byte) -> Byte
-  lor(Byte, Byte) -> Byte
   #deprecated
   lsl(Byte, Int) -> Byte
   #deprecated
   lsr(Byte, Int) -> Byte
-  lxor(Byte, Byte) -> Byte
-  op_add(Byte, Byte) -> Byte
-  op_div(Byte, Byte) -> Byte
-  op_mul(Byte, Byte) -> Byte
-  op_shl(Byte, Int) -> Byte
-  op_shr(Byte, Int) -> Byte
-  op_sub(Byte, Byte) -> Byte
   to_double(Byte) -> Double
   to_float(Byte) -> Float
   to_int(Byte) -> Int
@@ -433,14 +424,6 @@ impl Int {
   #deprecated
   lsr(Int, Int) -> Int
   lxor(Int, Int) -> Int
-  op_add(Int, Int) -> Int
-  op_div(Int, Int) -> Int
-  op_mod(Int, Int) -> Int
-  op_mul(Int, Int) -> Int
-  op_neg(Int) -> Int
-  op_shl(Int, Int) -> Int
-  op_shr(Int, Int) -> Int
-  op_sub(Int, Int) -> Int
   popcnt(Int) -> Int
   reinterpret_as_float(Int) -> Float
   reinterpret_as_uint(Int) -> UInt
@@ -475,22 +458,11 @@ impl Int64 {
   asr(Int64, Int) -> Int64
   clz(Int64) -> Int
   ctz(Int64) -> Int
-  land(Int64, Int64) -> Int64
   lnot(Int64) -> Int64
-  lor(Int64, Int64) -> Int64
   #deprecated
   lsl(Int64, Int) -> Int64
   #deprecated
   lsr(Int64, Int) -> Int64
-  lxor(Int64, Int64) -> Int64
-  op_add(Int64, Int64) -> Int64
-  op_div(Int64, Int64) -> Int64
-  op_mod(Int64, Int64) -> Int64
-  op_mul(Int64, Int64) -> Int64
-  op_neg(Int64) -> Int64
-  op_shl(Int64, Int) -> Int64
-  op_shr(Int64, Int) -> Int64
-  op_sub(Int64, Int64) -> Int64
   popcnt(Int64) -> Int
   reinterpret_as_double(Int64) -> Double
   reinterpret_as_uint64(Int64) -> UInt64
@@ -523,14 +495,7 @@ impl UInt {
   #deprecated
   lsr(UInt, Int) -> UInt
   lxor(UInt, UInt) -> UInt
-  op_add(UInt, UInt) -> UInt
-  op_div(UInt, UInt) -> UInt
-  op_mod(UInt, UInt) -> UInt
-  op_mul(UInt, UInt) -> UInt
   op_neq(UInt, UInt) -> Bool
-  op_shl(UInt, Int) -> UInt
-  op_shr(UInt, Int) -> UInt
-  op_sub(UInt, UInt) -> UInt
   popcnt(UInt) -> Int
   reinterpret_as_float(UInt) -> Float
   reinterpret_as_int(UInt) -> Int
@@ -561,21 +526,11 @@ impl UInt64 {
   clz(UInt64) -> Int
   ctz(UInt64) -> Int
   extend_uint(UInt) -> UInt64
-  land(UInt64, UInt64) -> UInt64
   lnot(UInt64) -> UInt64
-  lor(UInt64, UInt64) -> UInt64
   #deprecated
   lsl(UInt64, Int) -> UInt64
   #deprecated
   lsr(UInt64, Int) -> UInt64
-  lxor(UInt64, UInt64) -> UInt64
-  op_add(UInt64, UInt64) -> UInt64
-  op_div(UInt64, UInt64) -> UInt64
-  op_mod(UInt64, UInt64) -> UInt64
-  op_mul(UInt64, UInt64) -> UInt64
-  op_shl(UInt64, Int) -> UInt64
-  op_shr(UInt64, Int) -> UInt64
-  op_sub(UInt64, UInt64) -> UInt64
   popcnt(UInt64) -> Int
   reinterpret_as_double(UInt64) -> Double
   reinterpret_as_int64(UInt64) -> Int64
@@ -597,12 +552,7 @@ impl UInt64 {
 }
 
 impl Float {
-  op_add(Float, Float) -> Float
-  op_div(Float, Float) -> Float
-  op_mul(Float, Float) -> Float
-  op_neg(Float) -> Float
   op_neq(Float, Float) -> Bool
-  op_sub(Float, Float) -> Float
   reinterpret_as_int(Float) -> Int
   reinterpret_as_uint(Float) -> UInt
   sqrt(Float) -> Float
@@ -615,12 +565,7 @@ impl Float {
 impl Double {
   convert_uint(UInt) -> Double
   convert_uint64(UInt64) -> Double
-  op_add(Double, Double) -> Double
-  op_div(Double, Double) -> Double
-  op_mul(Double, Double) -> Double
-  op_neg(Double) -> Double
   op_neq(Double, Double) -> Bool
-  op_sub(Double, Double) -> Double
   #deprecated
   reinterpret_as_i64(Double) -> Int64
   reinterpret_as_int64(Double) -> Int64
@@ -649,7 +594,6 @@ impl String {
   get(String, Int) -> Char
   length(String) -> Int
   make(Int, Char) -> String
-  op_add(String, String) -> String
   op_get(String, Int) -> Char
   substring(String, start~ : Int = .., end? : Int) -> String
   to_string(String) -> String
@@ -712,18 +656,35 @@ impl Logger {
 pub(open) trait Add {
   op_add(Self, Self) -> Self
 }
+impl Add for Byte
+impl Add for Int
+impl Add for Int64
+impl Add for UInt
+impl Add for UInt64
+impl Add for Float
+impl Add for Double
+impl Add for String
 
 pub(open) trait BitAnd {
   land(Self, Self) -> Self
 }
+impl BitAnd for Byte
+impl BitAnd for Int64
+impl BitAnd for UInt64
 
 pub(open) trait BitOr {
   lor(Self, Self) -> Self
 }
+impl BitOr for Byte
+impl BitOr for Int64
+impl BitOr for UInt64
 
 pub(open) trait BitXOr {
   lxor(Self, Self) -> Self
 }
+impl BitXOr for Byte
+impl BitXOr for Int64
+impl BitXOr for UInt64
 
 pub(open) trait Compare : Eq {
   compare(Self, Self) -> Int
@@ -770,6 +731,13 @@ impl[X] Default for FixedArray[X]
 pub(open) trait Div {
   op_div(Self, Self) -> Self
 }
+impl Div for Byte
+impl Div for Int
+impl Div for Int64
+impl Div for UInt
+impl Div for UInt64
+impl Div for Float
+impl Div for Double
 
 pub(open) trait Eq {
   op_equal(Self, Self) -> Bool
@@ -834,18 +802,38 @@ impl Logger::write_sub_string
 pub(open) trait Mod {
   op_mod(Self, Self) -> Self
 }
+impl Mod for Int
+impl Mod for Int64
+impl Mod for UInt
+impl Mod for UInt64
 
 pub(open) trait Mul {
   op_mul(Self, Self) -> Self
 }
+impl Mul for Byte
+impl Mul for Int
+impl Mul for Int64
+impl Mul for UInt
+impl Mul for UInt64
+impl Mul for Float
+impl Mul for Double
 
 pub(open) trait Neg {
   op_neg(Self) -> Self
 }
+impl Neg for Int
+impl Neg for Int64
+impl Neg for Float
+impl Neg for Double
 
 pub(open) trait Shl {
   op_shl(Self, Int) -> Self
 }
+impl Shl for Byte
+impl Shl for Int
+impl Shl for Int64
+impl Shl for UInt
+impl Shl for UInt64
 
 pub(open) trait Show {
   output(Self, &Logger) -> Unit
@@ -887,10 +875,22 @@ impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show
 pub(open) trait Shr {
   op_shr(Self, Int) -> Self
 }
+impl Shr for Byte
+impl Shr for Int
+impl Shr for Int64
+impl Shr for UInt
+impl Shr for UInt64
 
 pub(open) trait Sub {
   op_sub(Self, Self) -> Self
 }
+impl Sub for Byte
+impl Sub for Int
+impl Sub for Int64
+impl Sub for UInt
+impl Sub for UInt64
+impl Sub for Float
+impl Sub for Double
 
 pub(open) trait ToJson {
   to_json(Self) -> Json

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -35,7 +35,7 @@
 ///   inspect!(c * c, content="b'\\x01'") // 255 * 255 = 65025, truncated to 1
 /// }
 /// ```
-pub fn Byte::op_mul(self : Byte, that : Byte) -> Byte {
+pub impl Mul for Byte with op_mul(self : Byte, that : Byte) -> Byte {
   (self.to_int() * that.to_int()).to_byte()
 }
 
@@ -65,7 +65,7 @@ pub fn Byte::op_mul(self : Byte, that : Byte) -> Byte {
 ///   ignore(a / b) // Division by zero
 /// }
 /// ```
-pub fn Byte::op_div(self : Byte, that : Byte) -> Byte {
+pub impl Div for Byte with op_div(self : Byte, that : Byte) -> Byte {
   (self.to_int() / that.to_int()).to_byte()
 }
 
@@ -91,7 +91,7 @@ pub impl Eq for Byte with op_equal(self : Byte, that : Byte) -> Bool {
 /// - `byte2` : The second `Byte` value to be added.
 ///
 /// Returns the sum of `byte1` and `byte2` as a `Byte`.
-pub fn Byte::op_add(self : Byte, that : Byte) -> Byte {
+pub impl Add for Byte with op_add(self : Byte, that : Byte) -> Byte {
   (self.to_int() + that.to_int()).to_byte()
 }
 
@@ -105,7 +105,7 @@ pub fn Byte::op_add(self : Byte, that : Byte) -> Byte {
 /// - `that` : The byte to subtract from the first byte.
 ///
 /// Returns the result of the subtraction as a byte.
-pub fn Byte::op_sub(self : Byte, that : Byte) -> Byte {
+pub impl Sub for Byte with op_sub(self : Byte, that : Byte) -> Byte {
   (self.to_int() - that.to_int()).to_byte()
 }
 
@@ -244,7 +244,7 @@ pub fn Byte::lnot(self : Byte) -> Byte {
 ///   with.
 ///
 /// Returns the result of the bitwise AND operation as a `Byte`.
-pub fn Byte::land(self : Byte, that : Byte) -> Byte {
+pub impl BitAnd for Byte with land(self : Byte, that : Byte) -> Byte {
   (self.to_int() & that.to_int()).to_byte()
 }
 
@@ -257,7 +257,7 @@ pub fn Byte::land(self : Byte, that : Byte) -> Byte {
 /// - `that` : The second `Byte` value.
 ///
 /// Returns a new `Byte` value resulting from the bitwise OR operation.
-pub fn Byte::lor(self : Byte, that : Byte) -> Byte {
+pub impl BitOr for Byte with lor(self : Byte, that : Byte) -> Byte {
   (self.to_int() | that.to_int()).to_byte()
 }
 
@@ -270,7 +270,7 @@ pub fn Byte::lor(self : Byte, that : Byte) -> Byte {
 /// - `that` : The second `Byte` value.
 ///
 /// Returns the result of the bitwise XOR operation as a `Byte`.
-pub fn Byte::lxor(self : Byte, that : Byte) -> Byte {
+pub impl BitXOr for Byte with lxor(self : Byte, that : Byte) -> Byte {
   (self.to_int() ^ that.to_int()).to_byte()
 }
 
@@ -297,7 +297,7 @@ pub fn Byte::to_uint(self : Byte) -> UInt {
 ///   the left.
 ///
 /// Returns the resulting `Byte` value after the shift operation.
-pub fn Byte::op_shl(self : Byte, count : Int) -> Byte {
+pub impl Shl for Byte with op_shl(self : Byte, count : Int) -> Byte {
   (self.to_int() << count).to_byte()
 }
 
@@ -312,7 +312,7 @@ pub fn Byte::op_shl(self : Byte, count : Int) -> Byte {
 ///   right.
 ///
 /// Returns the resulting `Byte` value after the bitwise right shift operation.
-pub fn Byte::op_shr(self : Byte, count : Int) -> Byte {
+pub impl Shr for Byte with op_shr(self : Byte, count : Int) -> Byte {
   (self.to_uint() >> count).reinterpret_as_int().to_byte()
 }
 

--- a/builtin/int64_js.mbt
+++ b/builtin/int64_js.mbt
@@ -26,7 +26,7 @@ fn MyInt64::to_int64(self : MyInt64) -> Int64 = "%identity"
 fn MyInt64::from_int64(value : Int64) -> MyInt64 = "%identity"
 
 ///|
-fn MyInt64::op_neg(self : MyInt64) -> MyInt64 {
+impl Neg for MyInt64 with op_neg(self : MyInt64) -> MyInt64 {
   if self.lo == 0 {
     { hi: self.hi.lnot() + 1, lo: 0 }
   } else {
@@ -47,12 +47,12 @@ fn MyInt64::add_hi_lo(self : MyInt64, bhi : Int, blo : Int) -> MyInt64 {
 }
 
 ///|
-fn MyInt64::op_add(self : MyInt64, other : MyInt64) -> MyInt64 {
+impl Add for MyInt64 with op_add(self : MyInt64, other : MyInt64) -> MyInt64 {
   self.add_hi_lo(other.hi, other.lo)
 }
 
 ///|
-fn MyInt64::op_sub(self : MyInt64, other : MyInt64) -> MyInt64 {
+impl Sub for MyInt64 with op_sub(self : MyInt64, other : MyInt64) -> MyInt64 {
   if other.lo == 0 {
     { hi: self.hi - other.hi, lo: self.lo }
   } else {
@@ -61,7 +61,7 @@ fn MyInt64::op_sub(self : MyInt64, other : MyInt64) -> MyInt64 {
 }
 
 ///|
-fn MyInt64::op_mul(self : MyInt64, other : MyInt64) -> MyInt64 {
+impl Mul for MyInt64 with op_mul(self : MyInt64, other : MyInt64) -> MyInt64 {
   let { hi: ahi, lo: alo } = self
   let { hi: bhi, lo: blo } = other
   let ahi = ahi.reinterpret_as_uint()
@@ -119,7 +119,7 @@ extern "js" fn get_int64_wasm_helper() -> Int64WasmHelper =
   #|}
 
 ///|
-fn MyInt64::op_div(self : MyInt64, other : MyInt64) -> MyInt64 {
+impl Div for MyInt64 with op_div(self : MyInt64, other : MyInt64) -> MyInt64 {
   let exports = get_int64_wasm_helper()
   let { hi: ahi, lo: alo } = self
   let { hi: bhi, lo: blo } = other
@@ -139,7 +139,7 @@ fn MyInt64::div_u(self : MyInt64, other : MyInt64) -> MyInt64 {
 }
 
 ///|
-fn MyInt64::op_mod(self : MyInt64, other : MyInt64) -> MyInt64 {
+impl Mod for MyInt64 with op_mod(self : MyInt64, other : MyInt64) -> MyInt64 {
   let exports = get_int64_wasm_helper()
   let { hi: ahi, lo: alo } = self
   let { hi: bhi, lo: blo } = other
@@ -372,32 +372,32 @@ extern "js" fn MyInt64::convert_to_double(self : MyInt64) -> Double =
 //endregion
 
 ///|
-pub fn Int64::op_neg(self : Int64) -> Int64 {
+pub impl Neg for Int64 with op_neg(self : Int64) -> Int64 {
   (-MyInt64::from_int64(self)).to_int64()
 }
 
 ///|
-pub fn Int64::op_add(self : Int64, other : Int64) -> Int64 {
+pub impl Add for Int64 with op_add(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).op_add(MyInt64::from_int64(other)).to_int64()
 }
 
 ///|
-pub fn Int64::op_sub(self : Int64, other : Int64) -> Int64 {
+pub impl Sub for Int64 with op_sub(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).op_sub(MyInt64::from_int64(other)).to_int64()
 }
 
 ///|
-pub fn Int64::op_mul(self : Int64, other : Int64) -> Int64 {
+pub impl Mul for Int64 with op_mul(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).op_mul(MyInt64::from_int64(other)).to_int64()
 }
 
 ///|
-pub fn Int64::op_div(self : Int64, other : Int64) -> Int64 {
+pub impl Div for Int64 with op_div(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).op_div(MyInt64::from_int64(other)).to_int64()
 }
 
 ///|
-pub fn Int64::op_mod(self : Int64, other : Int64) -> Int64 {
+pub impl Mod for Int64 with op_mod(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).op_mod(MyInt64::from_int64(other)).to_int64()
 }
 
@@ -407,17 +407,17 @@ pub fn Int64::lnot(self : Int64) -> Int64 {
 }
 
 ///|
-pub fn Int64::land(self : Int64, other : Int64) -> Int64 {
+pub impl BitAnd for Int64 with land(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).land(MyInt64::from_int64(other)).to_int64()
 }
 
 ///|
-pub fn Int64::lor(self : Int64, other : Int64) -> Int64 {
+pub impl BitOr for Int64 with lor(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).lor(MyInt64::from_int64(other)).to_int64()
 }
 
 ///|
-pub fn Int64::lxor(self : Int64, other : Int64) -> Int64 {
+pub impl BitXOr for Int64 with lxor(self : Int64, other : Int64) -> Int64 {
   MyInt64::from_int64(self).lxor(MyInt64::from_int64(other)).to_int64()
 }
 
@@ -457,12 +457,12 @@ pub fn Int64::asr(self : Int64, other : Int) -> Int64 {
 }
 
 ///|
-pub fn Int64::op_shr(self : Int64, other : Int) -> Int64 {
+pub impl Shr for Int64 with op_shr(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).asr(other).to_int64()
 }
 
 ///|
-pub fn Int64::op_shl(self : Int64, other : Int) -> Int64 {
+pub impl Shl for Int64 with op_shl(self : Int64, other : Int) -> Int64 {
   MyInt64::from_int64(self).lsl(other).to_int64()
 }
 
@@ -605,27 +605,27 @@ pub fn Int64::to_uint64(self : Int64) -> UInt64 = "%identity"
 pub fn Int64::reinterpret_as_uint64(self : Int64) -> UInt64 = "%identity"
 
 ///|
-pub fn UInt64::op_add(self : UInt64, other : UInt64) -> UInt64 {
+pub impl Add for UInt64 with op_add(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::from_uint64(self).op_add(MyInt64::from_uint64(other)).to_uint64()
 }
 
 ///|
-pub fn UInt64::op_sub(self : UInt64, other : UInt64) -> UInt64 {
+pub impl Sub for UInt64 with op_sub(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::from_uint64(self).op_sub(MyInt64::from_uint64(other)).to_uint64()
 }
 
 ///|
-pub fn UInt64::op_mul(self : UInt64, other : UInt64) -> UInt64 {
+pub impl Mul for UInt64 with op_mul(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::from_uint64(self).op_mul(MyInt64::from_uint64(other)).to_uint64()
 }
 
 ///|
-pub fn UInt64::op_div(self : UInt64, other : UInt64) -> UInt64 {
+pub impl Div for UInt64 with op_div(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::from_uint64(self).div_u(MyInt64::from_uint64(other)).to_uint64()
 }
 
 ///|
-pub fn UInt64::op_mod(self : UInt64, other : UInt64) -> UInt64 {
+pub impl Mod for UInt64 with op_mod(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::from_uint64(self).mod_u(MyInt64::from_uint64(other)).to_uint64()
 }
 
@@ -668,17 +668,17 @@ pub fn UInt64::trunc_double(value : Double) -> UInt64 {
 }
 
 ///|
-pub fn UInt64::land(self : UInt64, other : UInt64) -> UInt64 {
+pub impl BitAnd for UInt64 with land(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::land(MyInt64::from_uint64(self), MyInt64::from_uint64(other)).to_uint64()
 }
 
 ///|
-pub fn UInt64::lor(self : UInt64, other : UInt64) -> UInt64 {
+pub impl BitOr for UInt64 with lor(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::lor(MyInt64::from_uint64(self), MyInt64::from_uint64(other)).to_uint64()
 }
 
 ///|
-pub fn UInt64::lxor(self : UInt64, other : UInt64) -> UInt64 {
+pub impl BitXOr for UInt64 with lxor(self : UInt64, other : UInt64) -> UInt64 {
   MyInt64::lxor(MyInt64::from_uint64(self), MyInt64::from_uint64(other)).to_uint64()
 }
 
@@ -716,12 +716,12 @@ pub fn UInt64::shr(self : UInt64, shift : Int) -> UInt64 {
 }
 
 ///|
-pub fn UInt64::op_shl(self : UInt64, shift : Int) -> UInt64 {
+pub impl Shl for UInt64 with op_shl(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsl(MyInt64::from_uint64(self), shift).to_uint64()
 }
 
 ///|
-pub fn UInt64::op_shr(self : UInt64, shift : Int) -> UInt64 {
+pub impl Shr for UInt64 with op_shr(self : UInt64, shift : Int) -> UInt64 {
   MyInt64::lsr(MyInt64::from_uint64(self), shift).to_uint64()
 }
 

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -34,7 +34,7 @@
 ///   inspect!(-9223372036854775808L, content="-9223372036854775808") // negating min value
 /// }
 /// ```
-pub fn Int64::op_neg(self : Int64) -> Int64 = "%i64_neg"
+pub impl Neg for Int64 with op_neg(self : Int64) -> Int64 = "%i64_neg"
 
 ///|
 /// Adds two 64-bit integers together. Performs overflow checking and wrapping
@@ -57,7 +57,7 @@ pub fn Int64::op_neg(self : Int64) -> Int64 = "%i64_neg"
 ///   inspect!(42L + -42L, content="0")
 /// }
 /// ```
-pub fn Int64::op_add(self : Int64, other : Int64) -> Int64 = "%i64_add"
+pub impl Add for Int64 with op_add(self, other) = "%i64_add"
 
 ///|
 /// Performs subtraction between two 64-bit integers.
@@ -81,7 +81,7 @@ pub fn Int64::op_add(self : Int64, other : Int64) -> Int64 = "%i64_add"
 ///   inspect!(c - d, content="9223372036854775807")
 /// }
 /// ```
-pub fn Int64::op_sub(self : Int64, other : Int64) -> Int64 = "%i64_sub"
+pub impl Sub for Int64 with op_sub(self, other) = "%i64_sub"
 
 ///|
 /// Multiplies two 64-bit integers.
@@ -106,7 +106,7 @@ pub fn Int64::op_sub(self : Int64, other : Int64) -> Int64 = "%i64_sub"
 ///   inspect!(c * b, content="-4200")
 /// }
 /// ```
-pub fn Int64::op_mul(self : Int64, other : Int64) -> Int64 = "%i64_mul"
+pub impl Mul for Int64 with op_mul(self, other) = "%i64_mul"
 
 ///|
 /// Performs integer division between two 64-bit integers. Truncates the result
@@ -138,7 +138,7 @@ pub fn Int64::op_mul(self : Int64, other : Int64) -> Int64 = "%i64_mul"
 ///   ignore(a / 0L) // Division by zero
 /// }
 /// ```
-pub fn Int64::op_div(self : Int64, other : Int64) -> Int64 = "%i64_div"
+pub impl Div for Int64 with op_div(self, other) = "%i64_div"
 
 ///|
 /// Calculates the remainder of the division between two 64-bit integers. The
@@ -167,7 +167,7 @@ pub fn Int64::op_div(self : Int64, other : Int64) -> Int64 = "%i64_div"
 ///   ignore(7L % 0L) // Panics with division by zero
 /// }
 /// ```
-pub fn Int64::op_mod(self : Int64, other : Int64) -> Int64 = "%i64_mod"
+pub impl Mod for Int64 with op_mod(self, other) = "%i64_mod"
 
 ///|
 /// Performs a bitwise NOT operation on a 64-bit integer. Each bit in the input
@@ -212,7 +212,7 @@ pub fn Int64::lnot(self : Int64) -> Int64 = "%i64_lnot"
 ///   inspect!(a & b, content="251662080") // 0x0F000F00
 /// }
 /// ```
-pub fn Int64::land(self : Int64, other : Int64) -> Int64 = "%i64_land"
+pub impl BitAnd for Int64 with land(self, other) = "%i64_land"
 
 ///|
 /// Performs a bitwise OR operation between two 64-bit integers.
@@ -234,7 +234,7 @@ pub fn Int64::land(self : Int64, other : Int64) -> Int64 = "%i64_land"
 ///   inspect!(a | b, content="65520") // 1111_1111_1111_0000 = 65520
 /// }
 /// ```
-pub fn Int64::lor(self : Int64, other : Int64) -> Int64 = "%i64_lor"
+pub impl BitOr for Int64 with lor(self, other) = "%i64_lor"
 
 ///|
 /// Performs a bitwise XOR operation between two 64-bit integers. Each bit of the
@@ -259,7 +259,7 @@ pub fn Int64::lor(self : Int64, other : Int64) -> Int64 = "%i64_lor"
 ///   inspect!(a ^ a, content="0") // XOR with self gives 0
 /// }
 /// ```
-pub fn Int64::lxor(self : Int64, other : Int64) -> Int64 = "%i64_lxor"
+pub impl BitXOr for Int64 with lxor(self, other) = "%i64_lxor"
 
 ///|
 /// Performs a left shift operation on a 64-bit signed integer. Shifts each bit
@@ -418,7 +418,7 @@ pub fn Int64::shr(self : Int64, other : Int) -> Int64 = "%i64_shr"
 ///   inspect!(m << 2, content="-16") // -4 shifted left by 2 positions becomes -16
 /// }
 /// ```
-pub fn Int64::op_shl(self : Int64, other : Int) -> Int64 = "%i64_shl"
+pub impl Shl for Int64 with op_shl(self, other) = "%i64_shl"
 
 ///|
 /// Performs arithmetic right shift operation on a 64-bit integer value by a
@@ -445,7 +445,7 @@ pub fn Int64::op_shl(self : Int64, other : Int) -> Int64 = "%i64_shl"
 ///   inspect!(p >> 3, content="128") // Regular right shift for positive numbers
 /// }
 /// ```
-pub fn Int64::op_shr(self : Int64, other : Int) -> Int64 = "%i64_shr"
+pub impl Shr for Int64 with op_shr(self, other) = "%i64_shr"
 
 ///|
 /// Returns the number of trailing zero bits in a 64-bit integer. For zero input,
@@ -1190,7 +1190,7 @@ pub fn UInt64::to_double(self : UInt64) -> Double = "%u64.to_f64"
 ///   inspect!(max + 1UL, content="0")
 /// }
 /// ```
-pub fn UInt64::op_add(self : UInt64, other : UInt64) -> UInt64 = "%u64.add"
+pub impl Add for UInt64 with op_add(self, other) = "%u64.add"
 
 ///|
 /// Performs subtraction between two unsigned 64-bit integers. When the result
@@ -1216,7 +1216,7 @@ pub fn UInt64::op_add(self : UInt64, other : UInt64) -> UInt64 = "%u64.add"
 ///   inspect!(c - d, content="18446744073709551614") // wraps around to 2^64 - 2
 /// }
 /// ```
-pub fn UInt64::op_sub(self : UInt64, other : UInt64) -> UInt64 = "%u64.sub"
+pub impl Sub for UInt64 with op_sub(self, other) = "%u64.sub"
 
 ///|
 /// Performs multiplication between two unsigned 64-bit integers.
@@ -1242,7 +1242,7 @@ pub fn UInt64::op_sub(self : UInt64, other : UInt64) -> UInt64 = "%u64.sub"
 ///   inspect!(max * 2UL, content="18446744073709551614") // Wraps around to max - 1
 /// }
 /// ```
-pub fn UInt64::op_mul(self : UInt64, other : UInt64) -> UInt64 = "%u64.mul"
+pub impl Mul for UInt64 with op_mul(self, other) = "%u64.mul"
 
 ///|
 /// Performs division operation between two unsigned 64-bit integers.
@@ -1270,7 +1270,7 @@ pub fn UInt64::op_mul(self : UInt64, other : UInt64) -> UInt64 = "%u64.mul"
 ///   ignore(a / 0UL) // Throws runtime error: division by zero
 /// }
 /// ```
-pub fn UInt64::op_div(self : UInt64, other : UInt64) -> UInt64 = "%u64.div"
+pub impl Div for UInt64 with op_div(self, other) = "%u64.div"
 
 ///|
 /// Calculates the remainder of dividing one unsigned 64-bit integer by another.
@@ -1299,7 +1299,7 @@ pub fn UInt64::op_div(self : UInt64, other : UInt64) -> UInt64 = "%u64.div"
 ///   ignore(a % 0UL) // Panics: division by zero
 /// }
 /// ```
-pub fn UInt64::op_mod(self : UInt64, other : UInt64) -> UInt64 = "%u64.mod"
+pub impl Mod for UInt64 with op_mod(self, other) = "%u64.mod"
 
 ///|
 /// Compares two unsigned 64-bit integers and determines their relative order.
@@ -1370,7 +1370,7 @@ pub impl Eq for UInt64 with op_equal(self : UInt64, other : UInt64) -> Bool = "%
 ///   inspect!(a & b, content="17294086455919964160") // 0xF000F000F000F000
 /// }
 /// ```
-pub fn UInt64::land(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitand"
+pub impl BitAnd for UInt64 with land(self, other) = "%u64.bitand"
 
 ///|
 /// Performs a bitwise OR operation between two unsigned 64-bit integers.
@@ -1392,7 +1392,7 @@ pub fn UInt64::land(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitand"
 ///   inspect!(a | b, content="4294967295") // All bits set to 1
 /// }
 /// ```
-pub fn UInt64::lor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitor"
+pub impl BitOr for UInt64 with lor(self, other) = "%u64.bitor"
 
 ///|
 /// Performs a bitwise XOR operation between two unsigned 64-bit integers. For
@@ -1416,7 +1416,7 @@ pub fn UInt64::lor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitor"
 ///   inspect!(a ^ b, content="4294967295") // 0xFFFFFFFF
 /// }
 /// ```
-pub fn UInt64::lxor(self : UInt64, other : UInt64) -> UInt64 = "%u64.bitxor"
+pub impl BitXOr for UInt64 with lxor(self, other) = "%u64.bitxor"
 
 ///|
 /// Performs a bitwise NOT operation on a 64-bit unsigned integer. Flips all bits
@@ -1566,7 +1566,7 @@ pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 ///   inspect!(x << 63, content="9223372036854775808") // 1 shifted left by 63 positions
 /// }
 /// ```
-pub fn UInt64::op_shl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
+pub impl Shl for UInt64 with op_shl(self, shift) = "%u64.shl"
 
 ///|
 /// Performs a logical right shift operation on a 64-bit unsigned integer by a
@@ -1592,7 +1592,7 @@ pub fn UInt64::op_shl(self : UInt64, shift : Int) -> UInt64 = "%u64.shl"
 ///   inspect!(x >> 64, content="18374966859414961920") // Equivalent to x >> 0 due to masking
 /// }
 /// ```
-pub fn UInt64::op_shr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
+pub impl Shr for UInt64 with op_shr(self, shift) = "%u64.shr"
 
 ///|
 /// Counts the number of leading zero bits in a 64-bit unsigned integer, starting

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -233,7 +233,7 @@ pub impl Default for Bool with default() = "%bool_default"
 ///   inspect!(--2147483647, content="2147483647") // negating near min value
 /// }
 /// ```
-pub fn Int::op_neg(self : Int) -> Int = "%i32_neg"
+pub impl Neg for Int with op_neg(self) = "%i32_neg"
 
 ///|
 /// Adds two 32-bit signed integers. Performs two's complement arithmetic, which
@@ -257,7 +257,7 @@ pub fn Int::op_neg(self : Int) -> Int = "%i32_neg"
 ///   inspect!(2147483647 + 1, content="-2147483648") // Overflow wraps around to minimum value
 /// }
 /// ```
-pub fn Int::op_add(self : Int, other : Int) -> Int = "%i32_add"
+pub impl Add for Int with op_add(self, other) = "%i32_add"
 
 ///|
 /// Performs subtraction between two 32-bit integers, following standard two's
@@ -282,7 +282,7 @@ pub fn Int::op_add(self : Int, other : Int) -> Int = "%i32_add"
 ///   inspect!(max - -1, content="-2147483648") // Overflow case
 /// }
 /// ```
-pub fn Int::op_sub(self : Int, other : Int) -> Int = "%i32_sub"
+pub impl Sub for Int with op_sub(self, other) = "%i32_sub"
 
 ///|
 /// Multiplies two 32-bit integers. This is the implementation of the `*`
@@ -306,7 +306,7 @@ pub fn Int::op_sub(self : Int, other : Int) -> Int = "%i32_sub"
 ///   inspect!(max * 2, content="-2") // Overflow wraps around
 /// }
 /// ```
-pub fn Int::op_mul(self : Int, other : Int) -> Int = "%i32_mul"
+pub impl Mul for Int with op_mul(self, other) = "%i32_mul"
 
 ///|
 /// Performs integer division between two 32-bit integers. The result is
@@ -335,7 +335,7 @@ pub fn Int::op_mul(self : Int, other : Int) -> Int = "%i32_mul"
 ///   ignore(42 / 0) // Panics with division by zero
 /// }
 /// ```
-pub fn Int::op_div(self : Int, other : Int) -> Int = "%i32_div"
+pub impl Div for Int with op_div(self, other) = "%i32_div"
 
 ///|
 /// Calculates the remainder of dividing one integer by another. The result
@@ -363,7 +363,7 @@ pub fn Int::op_div(self : Int, other : Int) -> Int = "%i32_div"
 ///   ignore(7 % 0) // Panics with division by zero
 /// }
 /// ```
-pub fn Int::op_mod(self : Int, other : Int) -> Int = "%i32_mod"
+pub impl Mod for Int with op_mod(self, other) = "%i32_mod"
 
 ///|
 /// Performs a bitwise NOT operation on a 32-bit integer. Flips each bit in the
@@ -482,7 +482,7 @@ pub fn Int::lxor(self : Int, other : Int) -> Int = "%i32_lxor"
 ///   inspect!(y << 2, content="-16") // Binary: 100 -> 10000
 /// }
 /// ```
-pub fn Int::op_shl(self : Int, other : Int) -> Int = "%i32_shl"
+pub impl Shl for Int with op_shl(self, other) = "%i32_shl"
 
 ///|
 /// Performs an arithmetic right shift operation on an integer value. Shifts the
@@ -509,7 +509,7 @@ pub fn Int::op_shl(self : Int, other : Int) -> Int = "%i32_shl"
 ///   inspect!(p >> 2, content="4") // Regular right shift for positive numbers
 /// }
 /// ```
-pub fn Int::op_shr(self : Int, other : Int) -> Int = "%i32_shr"
+pub impl Shr for Int with op_shr(self, other) = "%i32_shr"
 
 ///|
 /// Performs a left shift operation on a 32-bit integer. Shifts each bit in the
@@ -922,7 +922,7 @@ pub fn Int::to_uint64(self : Int) -> UInt64 {
 ///   inspect!(-(0.0 / 0.0), content="NaN") // Negating NaN returns NaN
 /// }
 /// ```
-pub fn Double::op_neg(self : Double) -> Double = "%f64_neg"
+pub impl Neg for Double with op_neg(self) = "%f64_neg"
 
 ///|
 /// Adds two double-precision floating-point numbers together following IEEE 754
@@ -948,7 +948,7 @@ pub fn Double::op_neg(self : Double) -> Double = "%f64_neg"
 ///   inspect!(1.0 / 0.0 + -1.0 / 0.0, content="NaN") // Infinity + -Infinity = NaN
 /// }
 /// ```
-pub fn Double::op_add(self : Double, other : Double) -> Double = "%f64_add"
+pub impl Add for Double with op_add(self, other) = "%f64_add"
 
 ///|
 /// Performs subtraction between two double-precision floating-point numbers.
@@ -971,7 +971,7 @@ pub fn Double::op_add(self : Double, other : Double) -> Double = "%f64_add"
 ///   inspect!(0.0 / 0.0 - 1.0, content="NaN") // NaN - anything = NaN
 /// }
 /// ```
-pub fn Double::op_sub(self : Double, other : Double) -> Double = "%f64_sub"
+pub impl Sub for Double with op_sub(self, other) = "%f64_sub"
 
 ///|
 /// Multiplies two double-precision floating-point numbers. This is the
@@ -1001,7 +1001,7 @@ pub fn Double::op_sub(self : Double, other : Double) -> Double = "%f64_sub"
 ///   inspect!(nan * 1.0, content="NaN")
 /// }
 /// ```
-pub fn Double::op_mul(self : Double, other : Double) -> Double = "%f64_mul"
+pub impl Mul for Double with op_mul(self, other) = "%f64_mul"
 
 ///|
 /// Performs division between two double-precision floating-point numbers.
@@ -1031,7 +1031,7 @@ pub fn Double::op_mul(self : Double, other : Double) -> Double = "%f64_mul"
 ///   inspect!(1.0 / 0.0, content="Infinity")
 /// }
 /// ```
-pub fn Double::op_div(self : Double, other : Double) -> Double = "%f64_div"
+pub impl Div for Double with op_div(self, other) = "%f64_div"
 
 ///|
 /// Calculates the square root of a double-precision floating-point number. For
@@ -1832,7 +1832,7 @@ pub fn String::unsafe_charcode_at(self : String, idx : Int) -> Int = "%string.un
 ///   inspect!("" + "abc", content="abc") // concatenating with empty string
 /// }
 /// ```
-pub fn String::op_add(self : String, other : String) -> String = "%string_add"
+pub impl Add for String with op_add(self, other) = "%string_add"
 
 ///|
 /// Tests whether two strings are equal by comparing their characters.
@@ -1989,7 +1989,7 @@ pub fn UInt::to_int(self : UInt) -> Int = "%u32.to_i32_reinterpret"
 ///   inspect!(max + 1U, content="0")
 /// }
 /// ```
-pub fn UInt::op_add(self : UInt, other : UInt) -> UInt = "%u32.add"
+pub impl Add for UInt with op_add(self, other) = "%u32.add"
 
 ///|
 /// Performs subtraction between two unsigned 32-bit integers. When the result
@@ -2017,7 +2017,7 @@ pub fn UInt::op_add(self : UInt, other : UInt) -> UInt = "%u32.add"
 ///   inspect!(c - d, content="4294967294") // wraps around to 2^32 - 2
 /// }
 /// ```
-pub fn UInt::op_sub(self : UInt, other : UInt) -> UInt = "%u32.sub"
+pub impl Sub for UInt with op_sub(self, other) = "%u32.sub"
 
 ///|
 /// Performs multiplication between two unsigned 32-bit integers. The result
@@ -2043,7 +2043,7 @@ pub fn UInt::op_sub(self : UInt, other : UInt) -> UInt = "%u32.sub"
 ///   inspect!(max * 2U, content="4294967294") // Wraps around to max * 2 % 2^32
 /// }
 /// ```
-pub fn UInt::op_mul(self : UInt, other : UInt) -> UInt = "%u32.mul"
+pub impl Mul for UInt with op_mul(self, other) = "%u32.mul"
 
 ///|
 /// Performs division between two unsigned 32-bit integers. The operation follows
@@ -2071,7 +2071,7 @@ pub fn UInt::op_mul(self : UInt, other : UInt) -> UInt = "%u32.mul"
 ///   ignore(a / 0U) // Throws runtime error: division by zero
 /// }
 /// ```
-pub fn UInt::op_div(self : UInt, other : UInt) -> UInt = "%u32.div"
+pub impl Div for UInt with op_div(self, other) = "%u32.div"
 
 ///|
 /// Calculates the remainder of dividing one unsigned integer by another.
@@ -2100,7 +2100,7 @@ pub fn UInt::op_div(self : UInt, other : UInt) -> UInt = "%u32.div"
 ///   ignore(a % 0U) // Panics: division by zero
 /// }
 /// ```
-pub fn UInt::op_mod(self : UInt, other : UInt) -> UInt = "%u32.mod"
+pub impl Mod for UInt with op_mod(self, other) = "%u32.mod"
 
 ///|
 /// Compares two unsigned 32-bit integers for equality.
@@ -2398,7 +2398,7 @@ pub fn UInt::shr(self : UInt, shift : Int) -> UInt = "%u32.shr"
 ///   inspect!(y << 16, content="4294901760") // All bits after position 16 are discarded
 /// }
 /// ```
-pub fn UInt::op_shl(self : UInt, shift : Int) -> UInt = "%u32.shl"
+pub impl Shl for UInt with op_shl(self, shift) = "%u32.shl"
 
 ///|
 /// Performs a logical right shift operation on an unsigned 32-bit integer. The
@@ -2429,7 +2429,7 @@ pub fn UInt::op_shl(self : UInt, shift : Int) -> UInt = "%u32.shl"
 ///   inspect!(x >> 32, content="4278190080") // Same as x >> 0 due to masking
 /// }
 /// ```
-pub fn UInt::op_shr(self : UInt, shift : Int) -> UInt = "%u32.shr"
+pub impl Shr for UInt with op_shr(self, shift) = "%u32.shr"
 
 ///|
 /// Counts the number of leading zero bits in an unsigned 32-bit integer,
@@ -2602,7 +2602,7 @@ pub fn UInt::to_double(self : UInt) -> Double = "%u32.to_f64"
 ///   inspect!((-zero).to_double(), content="0")
 /// }
 /// ```
-pub fn Float::op_neg(self : Float) -> Float = "%f32.neg"
+pub impl Neg for Float with op_neg(self) = "%f32.neg"
 
 ///|
 /// Performs addition between two single-precision floating-point numbers.
@@ -2626,7 +2626,7 @@ pub fn Float::op_neg(self : Float) -> Float = "%f32.neg"
 ///   inspect!(sum.to_double(), content="6")
 /// }
 /// ```
-pub fn Float::op_add(self : Float, other : Float) -> Float = "%f32.add"
+pub impl Add for Float with op_add(self, other) = "%f32.add"
 
 ///|
 /// Performs subtraction between two single-precision floating-point numbers.
@@ -2649,7 +2649,7 @@ pub fn Float::op_add(self : Float, other : Float) -> Float = "%f32.add"
 ///   inspect!(result.to_double(), content="2.140000104904175")
 /// }
 /// ```
-pub fn Float::op_sub(self : Float, other : Float) -> Float = "%f32.sub"
+pub impl Sub for Float with op_sub(self, other) = "%f32.sub"
 
 ///|
 /// Performs multiplication between two single-precision floating-point numbers
@@ -2674,7 +2674,7 @@ pub fn Float::op_sub(self : Float, other : Float) -> Float = "%f32.sub"
 ///   inspect!(z.to_double(), content="6")
 /// }
 /// ```
-pub fn Float::op_mul(self : Float, other : Float) -> Float = "%f32.mul"
+pub impl Mul for Float with op_mul(self, other) = "%f32.mul"
 
 ///|
 /// Performs division between two 32-bit floating-point numbers according to IEEE
@@ -2703,7 +2703,7 @@ pub fn Float::op_mul(self : Float, other : Float) -> Float = "%f32.mul"
 ///   inspect!((0.0.to_float() / 0.0.to_float()).to_double(), content="NaN")
 /// }
 /// ```
-pub fn Float::op_div(self : Float, other : Float) -> Float = "%f32.div"
+pub impl Div for Float with op_div(self, other) = "%f32.div"
 
 ///|
 /// Calculates the square root of a floating-point number. For non-negative

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -769,7 +769,7 @@ pub fn Iter::concat[T](self : Iter[T], other : Iter[T]) -> Iter[T] {
 }
 
 ///|
-pub fn Iter::op_add[T](self : Iter[T], other : Iter[T]) -> Iter[T] {
+pub impl[T] Add for Iter[T] with op_add(self, other) {
   Iter::concat(self, other)
 }
 

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -273,7 +273,7 @@ fn unsafe_to_bytes(array : FixedArray[Byte]) -> Bytes = "%identity"
 /// * `self` : The first bytes sequence.
 /// * `other` : The second bytes sequence.
 /// TODO: marked as intrinsic, inline if it is constant
-pub fn Bytes::op_add(self : Bytes, other : Bytes) -> Bytes {
+pub impl Add for Bytes with op_add(self : Bytes, other : Bytes) -> Bytes {
   let rv : FixedArray[Byte] = FixedArray::make(
     self.length() + other.length(),
     0,

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -48,11 +48,11 @@ impl Bytes {
   from_iter(Iter[Byte]) -> Bytes
   iter(Bytes) -> Iter[Byte]
   of(FixedArray[Byte]) -> Bytes
-  op_add(Bytes, Bytes) -> Bytes
   op_as_view(Bytes, start~ : Int = .., end? : Int) -> View
   to_array(Bytes) -> Array[Byte]
   to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
 }
+impl Add for Bytes
 impl Default for Bytes
 impl Hash for Bytes
 

--- a/double/double.mbti
+++ b/double/double.mbti
@@ -65,8 +65,6 @@ let neg_infinity : Double
 
 let not_a_number : Double
 
-fn op_mod(Double, Double) -> Double
-
 fn pow(Double, Double) -> Double
 
 fn round(Double) -> Double
@@ -125,7 +123,6 @@ impl Double {
   min_normal() -> Double
   #deprecated
   nan() -> Double
-  op_mod(Double, Double) -> Double
   pow(Double, Double) -> Double
   round(Double) -> Double
   signum(Double) -> Double
@@ -140,6 +137,7 @@ impl Double {
   trunc(Double) -> Double
 }
 impl Hash for Double
+impl Mod for Double
 impl Show for Double
 
 // Type aliases

--- a/double/mod_js.mbt
+++ b/double/mod_js.mbt
@@ -36,5 +36,10 @@
 ///   inspect!(infinity.op_mod(3.0), content="NaN")
 /// }
 /// ```
-pub extern "js" fn op_mod(self : Double, other : Double) -> Double =
+extern "js" fn mod_ffi(self : Double, other : Double) -> Double =
   #| (a, b) => (a % b)
+
+///|
+pub impl Mod for Double with op_mod(self, other) {
+  self.mod_ffi(other)
+}

--- a/double/mod_nonjs.mbt
+++ b/double/mod_nonjs.mbt
@@ -36,7 +36,7 @@
 ///   inspect!(infinity.op_mod(3.0), content="NaN")
 /// }
 /// ```
-pub fn op_mod(self : Double, other : Double) -> Double {
+pub impl Mod for Double with op_mod(self : Double, other : Double) -> Double {
   let x = self
   let y = other
   let mut uint64_x = x.reinterpret_as_uint64()

--- a/float/float.mbti
+++ b/float/float.mbti
@@ -59,8 +59,6 @@ let neg_infinity : Float
 
 let not_a_number : Float
 
-fn op_mod(Float, Float) -> Float
-
 fn pow(Float, Float) -> Float
 
 fn round(Float) -> Float
@@ -105,7 +103,6 @@ impl Float {
   is_pos_inf(Float) -> Bool
   ln(Float) -> Float
   ln_1p(Float) -> Float
-  op_mod(Float, Float) -> Float
   pow(Float, Float) -> Float
   round(Float) -> Float
   sin(Float) -> Float
@@ -119,6 +116,7 @@ impl Float {
 }
 impl Default for Float
 impl Hash for Float
+impl Mod for Float
 impl Show for Float
 
 // Type aliases

--- a/float/mod.mbt
+++ b/float/mod.mbt
@@ -30,6 +30,6 @@
 ///   inspect!((-5.7 : Float).op_mod(2.0), content="-1.6999998092651367")
 /// }
 /// ```
-pub fn op_mod(self : Float, other : Float) -> Float {
+pub impl Mod for Float with op_mod(self : Float, other : Float) -> Float {
   (self.to_double() % other.to_double()).to_float()
 }

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -188,7 +188,7 @@ pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
 
 ///|
 /// Concat two arrays.
-pub fn op_add[A](self : T[A], other : T[A]) -> T[A] {
+pub impl[A] Add for T[A] with op_add(self, other) {
   self.concat(other)
 }
 

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -40,8 +40,6 @@ fn new[A]() -> T[A]
 
 fn of[A](FixedArray[A]) -> T[A]
 
-fn op_add[A](T[A], T[A]) -> T[A]
-
 fn op_get[A](T[A], Int) -> A
 
 fn push[A](T[A], A) -> T[A]
@@ -81,13 +79,13 @@ impl T {
   new[A]() -> Self[A]
   #deprecated
   of[A](FixedArray[A]) -> Self[A]
-  op_add[A](Self[A], Self[A]) -> Self[A]
   op_get[A](Self[A], Int) -> A
   push[A](Self[A], A) -> Self[A]
   rev_fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
   set[A](Self[A], Int, A) -> Self[A]
   to_array[A](Self[A]) -> Array[A]
 }
+impl[A] Add for T[A]
 impl[A : Eq] Eq for T[A]
 impl[A : Hash] Hash for T[A]
 impl[A : Show] Show for T[A]

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -749,7 +749,7 @@ pub fn sort[A : Compare](self : T[A]) -> T[A] {
 /// Concatenate two lists.
 ///
 /// `a + b` equal to `a.concat(b)`
-pub fn op_add[A](self : T[A], other : T[A]) -> T[A] {
+pub impl[A] Add for T[A] with op_add(self, other) {
   self.concat(other)
 }
 

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -108,8 +108,6 @@ fn nth_exn[A](T[A], Int) -> A
 
 fn of[A](FixedArray[A]) -> T[A]
 
-fn op_add[A](T[A], T[A]) -> T[A]
-
 fn remove[A : Eq](T[A], A) -> T[A]
 
 fn remove_at[A](T[A], Int) -> T[A]
@@ -226,7 +224,6 @@ impl T {
   nth_exn[A](Self[A], Int) -> A
   #deprecated
   of[A](FixedArray[A]) -> Self[A]
-  op_add[A](Self[A], Self[A]) -> Self[A]
   remove[A : Eq](Self[A], A) -> Self[A]
   remove_at[A](Self[A], Int) -> Self[A]
   rev[A](Self[A]) -> Self[A]
@@ -250,6 +247,7 @@ impl T {
   unzip[A, B](Self[(A, B)]) -> (Self[A], Self[B])
   zip[A, B](Self[A], Self[B]) -> Self[(A, B)]?
 }
+impl[A] Add for T[A]
 impl[X] Default for T[X]
 impl[A : Eq] Eq for T[A]
 impl[A : Hash] Hash for T[A]

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -303,7 +303,7 @@ pub fn union[A : Compare](self : T[A], other : T[A]) -> T[A] {
 /// ```
 /// assert_eq!(@sorted_set.of([3, 4, 5]) + (@sorted_set.of([4, 5, 6])), @sorted_set.of([3, 4, 5, 6]))
 /// ```
-pub fn op_add[A : Compare](self : T[A], other : T[A]) -> T[A] {
+pub impl[A : Compare] Add for T[A] with op_add(self, other) {
   return self.union(other)
 }
 

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -54,8 +54,6 @@ fn new[A]() -> T[A]
 
 fn of[A : Compare](FixedArray[A]) -> T[A]
 
-fn op_add[A : Compare](T[A], T[A]) -> T[A]
-
 fn remove[A : Compare](T[A], A) -> T[A]
 
 fn remove_min[A : Compare](T[A]) -> T[A]
@@ -107,7 +105,6 @@ impl T {
   new[A]() -> Self[A]
   #deprecated
   of[A : Compare](FixedArray[A]) -> Self[A]
-  op_add[A : Compare](Self[A], Self[A]) -> Self[A]
   remove[A : Compare](Self[A], A) -> Self[A]
   remove_min[A : Compare](Self[A]) -> Self[A]
   #deprecated
@@ -119,6 +116,7 @@ impl T {
   to_json[A : ToJson](Self[A]) -> Json
   union[A : Compare](Self[A], Self[A]) -> Self[A]
 }
+impl[A : Compare] Add for T[A]
 impl[A : Compare] Compare for T[A]
 impl[A] Default for T[A]
 impl[A : Eq] Eq for T[A]

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -19,22 +19,22 @@ pub let max_value : Int16 = 32767
 pub let min_value : Int16 = -32768
 
 ///|
-pub fn op_add(self : Int16, that : Int16) -> Int16 {
+pub impl Add for Int16 with op_add(self : Int16, that : Int16) -> Int16 {
   (self.to_int() + that.to_int()).to_int16()
 }
 
 ///|
-pub fn op_sub(self : Int16, that : Int16) -> Int16 {
+pub impl Sub for Int16 with op_sub(self : Int16, that : Int16) -> Int16 {
   (self.to_int() - that.to_int()).to_int16()
 }
 
 ///|
-pub fn op_mul(self : Int16, that : Int16) -> Int16 {
+pub impl Mul for Int16 with op_mul(self : Int16, that : Int16) -> Int16 {
   (self.to_int() * that.to_int()).to_int16()
 }
 
 ///|
-pub fn op_div(self : Int16, that : Int16) -> Int16 {
+pub impl Div for Int16 with op_div(self : Int16, that : Int16) -> Int16 {
   (self.to_int() / that.to_int()).to_int16()
 }
 

--- a/int16/int16.mbti
+++ b/int16/int16.mbti
@@ -5,24 +5,14 @@ let max_value : Int16
 
 let min_value : Int16
 
-fn op_add(Int16, Int16) -> Int16
-
-fn op_div(Int16, Int16) -> Int16
-
-fn op_mul(Int16, Int16) -> Int16
-
-fn op_sub(Int16, Int16) -> Int16
-
 // Types and methods
-impl Int16 {
-  op_add(Int16, Int16) -> Int16
-  op_div(Int16, Int16) -> Int16
-  op_mul(Int16, Int16) -> Int16
-  op_sub(Int16, Int16) -> Int16
-}
+impl Add for Int16
 impl Compare for Int16
+impl Div for Int16
 impl Eq for Int16
 impl Hash for Int16
+impl Mul for Int16
+impl Sub for Int16
 
 // Type aliases
 

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -66,7 +66,7 @@ fn new_unchecked(numerator : Int64, denominator : Int64) -> T {
 ///|
 /// NOTE: we don't check overflow here, to align with the `op_add` of `Int64`.
 /// TODO: add a `checked_add` method.
-pub fn op_add(self : T, other : T) -> T {
+pub impl Add for T with op_add(self : T, other : T) -> T {
   new_unchecked(
     self.numerator * other.denominator + other.numerator * self.denominator,
     self.denominator * other.denominator,
@@ -74,7 +74,7 @@ pub fn op_add(self : T, other : T) -> T {
 }
 
 ///|
-pub fn op_sub(self : T, other : T) -> T {
+pub impl Sub for T with op_sub(self : T, other : T) -> T {
   new_unchecked(
     self.numerator * other.denominator - other.numerator * self.denominator,
     self.denominator * other.denominator,
@@ -82,7 +82,7 @@ pub fn op_sub(self : T, other : T) -> T {
 }
 
 ///|
-pub fn op_mul(self : T, other : T) -> T {
+pub impl Mul for T with op_mul(self : T, other : T) -> T {
   new_unchecked(
     self.numerator * other.numerator,
     self.denominator * other.denominator,
@@ -90,7 +90,7 @@ pub fn op_mul(self : T, other : T) -> T {
 }
 
 ///|
-pub fn op_div(self : T, other : T) -> T {
+pub impl Div for T with op_div(self : T, other : T) -> T {
   if other.numerator < 0L {
     new_unchecked(
       self.numerator * -other.denominator,

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -17,14 +17,6 @@ fn neg(T) -> T
 
 fn new(Int64, Int64) -> T?
 
-fn op_add(T, T) -> T
-
-fn op_div(T, T) -> T
-
-fn op_mul(T, T) -> T
-
-fn op_sub(T, T) -> T
-
 fn reciprocal(T) -> T
 
 fn to_double(T) -> Double
@@ -48,17 +40,17 @@ impl T {
   neg(Self) -> Self
   #deprecated
   new(Int64, Int64) -> Self?
-  op_add(Self, Self) -> Self
-  op_div(Self, Self) -> Self
-  op_mul(Self, Self) -> Self
-  op_sub(Self, Self) -> Self
   reciprocal(Self) -> Self
   to_double(Self) -> Double
   trunc(Self) -> Int64
 }
+impl Add for T
 impl Compare for T
+impl Div for T
 impl Eq for T
+impl Mul for T
 impl Show for T
+impl Sub for T
 impl @moonbitlang/core/quickcheck.Arbitrary for T
 
 // Type aliases

--- a/uint16/uint16.mbt
+++ b/uint16/uint16.mbt
@@ -19,22 +19,22 @@ pub let max_value : UInt16 = 65535
 pub let min_value : UInt16 = 0
 
 ///|
-pub fn op_add(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Add for UInt16 with op_add(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() + that.to_int()).to_uint16()
 }
 
 ///|
-pub fn op_sub(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Sub for UInt16 with op_sub(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() - that.to_int()).to_uint16()
 }
 
 ///|
-pub fn op_mul(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Mul for UInt16 with op_mul(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() * that.to_int()).to_uint16()
 }
 
 ///|
-pub fn op_div(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Div for UInt16 with op_div(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() / that.to_int()).to_uint16()
 }
 

--- a/uint16/uint16.mbti
+++ b/uint16/uint16.mbti
@@ -5,24 +5,14 @@ let max_value : UInt16
 
 let min_value : UInt16
 
-fn op_add(UInt16, UInt16) -> UInt16
-
-fn op_div(UInt16, UInt16) -> UInt16
-
-fn op_mul(UInt16, UInt16) -> UInt16
-
-fn op_sub(UInt16, UInt16) -> UInt16
-
 // Types and methods
-impl UInt16 {
-  op_add(UInt16, UInt16) -> UInt16
-  op_div(UInt16, UInt16) -> UInt16
-  op_mul(UInt16, UInt16) -> UInt16
-  op_sub(UInt16, UInt16) -> UInt16
-}
+impl Add for UInt16
 impl Compare for UInt16
+impl Div for UInt16
 impl Eq for UInt16
 impl Hash for UInt16
+impl Mul for UInt16
+impl Sub for UInt16
 
 // Type aliases
 


### PR DESCRIPTION
This PR migrate overloaded operators to use traits in `builtin/operators.mbt`. Since trait implementations can be called via dot syntax directly, this change is compatible with current version of MoonBit, and allows seamless migration to new operator overloading semantic based on traits.

The only exception that cannot be migrated is `Char::op_sub`, whose return type is `Int` rather than `Char`. This operator is already deprecated in #1806, and will be removed in the future.