### PR TITLE
hongbo/move inproper method

### DIFF
--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -13,15 +13,7 @@
 // limitations under the License.
 
 ///|
-#deprecated("Use `String::trim_start` instead")
-#coverage.skip
-pub fn trim_left(self : String, trim_set : String) -> String {
-  self.trim_start(trim_set)
-}
-
-///|
-#deprecated("Use `String::trim_end` instead")
-#coverage.skip
-pub fn trim_right(self : String, trim_set : String) -> String {
-  self.trim_end(trim_set)
+#deprecated("Use `@string.concat` instead")
+pub fn String::concat(self : Array[String], separator~ : String = "") -> String {
+  concat(self, separator~)
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -60,10 +60,7 @@ pub fn from_iter(iter : Iter[Char]) -> String {
 /// let s = @string.concat(["a", "b", "c"], separator=",")
 /// assert_eq!(s, "a,b,c")
 /// ```
-pub fn String::concat(
-  strings : Array[String],
-  separator~ : String = ""
-) -> String {
+pub fn concat(strings : Array[String], separator~ : String = "") -> String {
   match strings {
     [] => ""
     [hd, .. tl] => {
@@ -87,12 +84,6 @@ pub fn String::concat(
       buf.to_string()
     }
   }
-}
-
-///|
-/// same as `String::concat`
-pub fn concat(strings : Array[String], separator~ : String = "") -> String {
-  String::concat(strings, separator~)
 }
 
 ///|

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -71,12 +71,6 @@ fn trim(String, String) -> String
 
 fn trim_end(String, String) -> String
 
-#deprecated
-fn trim_left(String, String) -> String
-
-#deprecated
-fn trim_right(String, String) -> String
-
 fn trim_space(String) -> String
 
 fn trim_start(String, String) -> String
@@ -99,6 +93,7 @@ impl StringView {
 impl Show for StringView
 
 impl String {
+  #deprecated
   concat(Array[String], separator~ : String = ..) -> String
   contains(String, String) -> Bool
   contains_char(String, Char) -> Bool
@@ -134,10 +129,6 @@ impl String {
   to_upper(String) -> String
   trim(String, String) -> String
   trim_end(String, String) -> String
-  #deprecated
-  trim_left(String, String) -> String
-  #deprecated
-  trim_right(String, String) -> String
   trim_space(String) -> String
   trim_start(String, String) -> String
 }


### PR DESCRIPTION
- **refactor: remove deprecated deque functions and documentation**
- **remove deprecated code and move String::concat from a method to regular function**
