### PR TITLE
refactor(@string.View): API update

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -605,8 +605,8 @@ impl String {
   op_get(String, Int) -> Char
   substring(String, start~ : Int = .., end? : Int) -> String
   to_string(String) -> String
+  unsafe_char_at(String, Int) -> Char
   unsafe_charcode_at(String, Int) -> Int
-  unsafe_codepoint_at(String, Int) -> Char
 }
 
 impl Option {

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -117,7 +117,7 @@ fn base64_encode_string_codepoint(s : String) -> String {
   for i = 0, utf16_index = 0
       i < codepoint_length
       i = i + 1, utf16_index = utf16_index + 1 {
-    let c = s.unsafe_codepoint_at(utf16_index).to_int()
+    let c = s.unsafe_char_at(utf16_index).to_int()
     if c > 0xFFFF {
       data[i * 4] = (c & 0xFF).to_byte()
       data[i * 4 + 1] = ((c >> 8) & 0xFF).to_byte()

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -133,7 +133,7 @@ pub fn String::codepoint_at(self : String, index : Int) -> Char {
 
 ///|
 /// Returns the Unicode code point at the given index without bounds checking.
-pub fn String::unsafe_codepoint_at(self : String, index : Int) -> Char {
+pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
   let c1 = self.unsafe_charcode_at(index)
   if is_leading_surrogate(c1) {
     let c2 = self.unsafe_charcode_at(index + 1)

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -87,13 +87,13 @@ test "codepoint_at emoji" {
 }
 
 ///|
-test "unsafe_codepoint_at" {
+test "unsafe_char_at" {
   let s = "a👋b"
-  inspect!(s.unsafe_codepoint_at(0), content="a")
-  inspect!(s.unsafe_codepoint_at(1), content="👋")
+  inspect!(s.unsafe_char_at(0), content="a")
+  inspect!(s.unsafe_char_at(1), content="👋")
   // invalid char cannot be inspected
-  inspect!(s.unsafe_codepoint_at(2).to_int(), content="56395")
-  inspect!(s.unsafe_codepoint_at(3), content="b")
+  inspect!(s.unsafe_char_at(2).to_int(), content="56395")
+  inspect!(s.unsafe_char_at(3), content="b")
 }
 
 ///|

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -152,7 +152,7 @@ fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
     rest => rest
   }
   // finish
-  guard rest.length_eq(0) else { syntax_err!() }
+  guard rest is [] else { syntax_err!() }
   d..trim()
 }
 

--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -139,3 +139,107 @@ pub fn View::op_as_view(self : View, start~ : Int = 0, end? : Int) -> View {
 pub fn View::length(self : View) -> Int {
   self.char_length()
 }
+
+///|
+#deprecated("use View::char_length_eq instead")
+pub fn length_eq(self : View, len : Int) -> Bool {
+  self.char_length_eq(len)
+}
+
+///|
+#deprecated("use View::char_length_ge instead")
+pub fn length_ge(self : View, len : Int) -> Bool {
+  self.char_length_ge(len)
+}
+
+///|
+/// Returns the character at the given index from the end of the string.
+///
+/// # Examples
+///
+/// ```moonbit
+/// let s = "Hello🤣🤣🤣"
+/// inspect!(s.rev_get(0), content="🤣")
+/// inspect!(s.rev_get(4), content="l")
+/// ```
+///
+/// # Panics
+///
+/// @alert unsafe "Panics if the index is out of bounds."
+#deprecated("use String::rev_iter().nth(index).unwrap() instead")
+pub fn String::rev_get(self : String, index : Int) -> Char {
+  guard index >= 0
+  self.nth_char(-index - 1)
+}
+
+///|
+/// Test if the length of the string is equal to the given length.
+///
+/// This has O(n) complexity where n is the length in the parameter.
+#deprecated("use String::char_length_eq instead")
+pub fn String::length_eq(self : String, len : Int) -> Bool {
+  self.char_length_eq(len)
+}
+
+///|
+/// Test if the length of the string is greater than or equal to the given length.
+///
+/// This has O(n) complexity where n is the length in the parameter.
+#deprecated("use String::char_length_ge instead")
+pub fn String::length_ge(self : String, len : Int) -> Bool {
+  self.char_length_ge(len)
+}
+
+///|
+/// Return the character at the given index.
+/// 
+/// The time complexity is O(n) where n is the given index, as it needs to scan
+/// through the UTF-16 code units to find the nth Unicode character.
+/// 
+/// # Example
+/// 
+/// ```
+/// let str = "Hello🤣🤣🤣"
+/// let view = str[1:6]
+/// inspect!(view[0], content="e")
+/// inspect!(view[4], content="🤣")
+/// ```
+#deprecated("use View::iter().nth(index).unwrap() instead")
+pub fn View::op_get(self : View, index : Int) -> Char {
+  guard index >= 0
+  self.str.nth_char(index, start_offset=self.start, end_offset=self.end)
+}
+
+///|
+/// Returns the character at the given index from the end of the view.
+/// 
+/// The time complexity is O(n) where n is the given index, as it needs to scan
+/// through the UTF-16 code units to find the nth Unicode character.
+/// 
+/// # Example
+/// 
+/// ```
+/// let str = "Hello🤣🤣🤣"
+/// let view = str[1:6]
+/// inspect!(view.rev_get(0), content="🤣")
+/// inspect!(view.rev_get(4), content="e")
+/// ```
+#deprecated("use View::rev_iter().nth(index).unwrap() instead")
+pub fn rev_get(self : View, index : Int) -> Char {
+  guard index >= 0
+  self.str.nth_char(-index - 1, start_offset=self.start, end_offset=self.end)
+}
+
+///|
+fn String::nth_char(
+  self : String,
+  i : Int,
+  start_offset~ : Int = 0,
+  end_offset~ : Int = self.length()
+) -> Char {
+  if self.offset_of_nth_char(i, start_offset~, end_offset~) is Some(index) {
+    self.unsafe_char_at(index)
+  } else {
+    abort("index out of bounds")
+  }
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -679,98 +679,6 @@ pub fn pad_end(self : String, total_width : Int, padding_char : Char) -> String 
 }
 
 ///|
-/// Returns the character at the given index from the end of the string.
-///
-/// # Examples
-///
-/// ```moonbit
-/// let s = "Hello🤣🤣🤣"
-/// inspect!(s.rev_get(0), content="🤣")
-/// inspect!(s.rev_get(4), content="l")
-/// ```
-///
-/// # Panics
-///
-/// @alert unsafe "Panics if the index is out of bounds."
-pub fn String::rev_get(self : String, index : Int) -> Char {
-  guard index >= 0 else { abort("index out of bounds") }
-  for utf16_offset = self.length() - 1, char_count = 0
-      utf16_offset >= 0 && char_count < index
-      utf16_offset = utf16_offset - 1, char_count = char_count + 1 {
-    let c1 = self.unsafe_charcode_at(utf16_offset)
-    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
-      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
-      if is_leading_surrogate(c2) {
-        continue utf16_offset - 2, char_count + 1
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-  } else {
-    guard char_count == index && utf16_offset >= 0 else {
-      abort("index out of bounds")
-    }
-    let c1 = self.unsafe_charcode_at(utf16_offset)
-    if is_trailing_surrogate(c1) && utf16_offset - 1 >= 0 {
-      let c2 = self.unsafe_charcode_at(utf16_offset - 1)
-      if is_leading_surrogate(c2) {
-        code_point_of_surrogate_pair(c2, c1)
-      } else {
-        abort("invalid surrogate pair")
-      }
-    } else {
-      Char::from_int(c1)
-    }
-  }
-}
-
-///|
-/// Test if the length of the string is equal to the given length.
-///
-/// This has O(n) complexity where n is the length in the parameter.
-pub fn String::length_eq(self : String, len : Int) -> Bool {
-  let codeunit_len = self.length()
-  for index = 0, count = 0
-      index < codeunit_len && count < len
-      index = index + 1, count = count + 1 {
-    let c1 = self.unsafe_charcode_at(index)
-    if is_leading_surrogate(c1) && index + 1 < codeunit_len {
-      let c2 = self.unsafe_charcode_at(index + 1)
-      if is_trailing_surrogate(c2) {
-        continue index + 2, count + 1
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-  } else {
-    count == len && index == codeunit_len
-  }
-}
-
-///|
-/// Test if the length of the string is greater than or equal to the given length.
-///
-/// This has O(n) complexity where n is the length in the parameter.
-pub fn String::length_ge(self : String, len : Int) -> Bool {
-  let codeunit_len = self.length()
-  for index = 0, count = 0
-      index < codeunit_len && count < len
-      index = index + 1, count = count + 1 {
-    let c1 = self.unsafe_charcode_at(index)
-    if is_leading_surrogate(c1) && index + 1 < codeunit_len {
-      let c2 = self.unsafe_charcode_at(index + 1)
-      if is_trailing_surrogate(c2) {
-        continue index + 2, count + 1
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-  } else {
-    count >= len
-  }
-}
-
-///|
 /// Returns the index of the n-th (zero-indexed) character within the range [start, end).
 fn String::offset_of_nth_char_forward(
   self : String,
@@ -852,5 +760,68 @@ pub fn String::offset_of_nth_char(
   } else {
     // backward case
     self.offset_of_nth_char_backward(-i, start_offset~, end_offset~)
+  }
+}
+
+///|
+/// Returns the Unicode character at the given index.
+pub fn String::char_at(self : String, index : Int) -> Char {
+  guard index >= 0 && index < self.length() else {
+    abort("index out of bounds")
+  }
+  self.unsafe_char_at(index)
+}
+
+///|
+/// Test if the length of the string is equal to the given length.
+///
+/// This has O(n) complexity where n is the length in the parameter.
+pub fn String::char_length_eq(
+  self : String,
+  len : Int,
+  start_offset~ : Int = 0,
+  end_offset~ : Int = self.length()
+) -> Bool {
+  for index = start_offset, count = 0
+      index < end_offset && count < len
+      index = index + 1, count = count + 1 {
+    let c1 = self.unsafe_charcode_at(index)
+    if is_leading_surrogate(c1) && index + 1 < end_offset {
+      let c2 = self.unsafe_charcode_at(index + 1)
+      if is_trailing_surrogate(c2) {
+        continue index + 2, count + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    count == len && index == end_offset
+  }
+}
+
+///|
+/// Test if the length of the string is greater than or equal to the given length.
+///
+/// This has O(n) complexity where n is the length in the parameter.
+pub fn String::char_length_ge(
+  self : String,
+  len : Int,
+  start_offset~ : Int = 0,
+  end_offset~ : Int = self.length()
+) -> Bool {
+  for index = start_offset, count = 0
+      index < end_offset && count < len
+      index = index + 1, count = count + 1 {
+    let c1 = self.unsafe_charcode_at(index)
+    if is_leading_surrogate(c1) && index + 1 < end_offset {
+      let c2 = self.unsafe_charcode_at(index + 1)
+      if is_trailing_surrogate(c2) {
+        continue index + 2, count + 1
+      } else {
+        abort("invalid surrogate pair")
+      }
+    }
+  } else {
+    count >= len
   }
 }

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -35,8 +35,10 @@ fn iter2(String) -> Iter2[Int, Char]
 
 fn last_index_of(String, String, from~ : Int = ..) -> Int
 
+#deprecated
 fn length_eq(StringView, Int) -> Bool
 
+#deprecated
 fn length_ge(StringView, Int) -> Bool
 
 fn pad_end(String, Int, Char) -> String
@@ -53,6 +55,7 @@ fn rev(String) -> String
 
 fn rev_fold[A](String, init~ : A, (A, Char) -> A) -> A
 
+#deprecated
 fn rev_get(StringView, Int) -> Char
 
 fn rev_iter(String) -> Iter[Char]
@@ -86,21 +89,31 @@ type StringView
 impl StringView {
   char_at(Self, Int) -> Char
   char_length(Self) -> Int
+  char_length_eq(Self, Int) -> Bool
+  char_length_ge(Self, Int) -> Bool
   charcode_at(Self, Int) -> Int
   iter(Self) -> Iter[Char]
   #deprecated
   length(Self) -> Int
+  #deprecated
   length_eq(Self, Int) -> Bool
+  #deprecated
   length_ge(Self, Int) -> Bool
   offset_of_nth_char(Self, Int) -> Int?
   #deprecated
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
+  #deprecated
   op_get(Self, Int) -> Char
+  #deprecated
   rev_get(Self, Int) -> Char
+  rev_iter(Self) -> Iter[Char]
 }
 impl Show for StringView
 
 impl String {
+  char_at(String, Int) -> Char
+  char_length_eq(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
+  char_length_ge(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
   #deprecated
   concat(Array[String], separator~ : String = ..) -> String
   contains(String, String) -> Bool
@@ -119,7 +132,9 @@ impl String {
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
   last_index_of(String, String, from~ : Int = ..) -> Int
+  #deprecated
   length_eq(String, Int) -> Bool
+  #deprecated
   length_ge(String, Int) -> Bool
   offset_of_nth_char(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int?
   #deprecated
@@ -131,6 +146,7 @@ impl String {
   replace_all(String, old~ : String, new~ : String) -> String
   rev(String) -> String
   rev_fold[A](String, init~ : A, (A, Char) -> A) -> A
+  #deprecated
   rev_get(String, Int) -> Char
   rev_iter(String) -> Iter[Char]
   split(String, String) -> Iter[String]

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -717,7 +717,7 @@ test "offset_of_nth_char property" {
   let n = s.codepoint_length()
   for i in 0..<n {
     let index = s.offset_of_nth_char(i).unwrap()
-    assert_eq!(s.unsafe_codepoint_at(index), s.iter().nth(i).unwrap())
+    assert_eq!(s.unsafe_char_at(index), s.iter().nth(i).unwrap())
   }
 }
 
@@ -727,6 +727,6 @@ test "offset_of_nth_char property negative" {
   let n = s.codepoint_length()
   for i in 1..=n {
     let index = s.offset_of_nth_char(-i).unwrap()
-    assert_eq!(s.unsafe_codepoint_at(index), s.rev_iter().nth(i - 1).unwrap())
+    assert_eq!(s.unsafe_char_at(index), s.rev_iter().nth(i - 1).unwrap())
   }
 }

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -93,7 +93,7 @@ pub fn View::offset_of_nth_char(self : View, i : Int) -> Int? {
 ///|
 pub fn View::char_at(self : View, index : Int) -> Char {
   guard index >= 0 && index < self.len() else { abort("Index out of bounds") }
-  self.str.unsafe_codepoint_at(self.start + index)
+  self.str.unsafe_char_at(self.start + index)
 }
 
 ///|
@@ -115,147 +115,16 @@ pub fn View::char_length(self : View) -> Int {
 /// Test if the length of the view is equal to the given length.
 /// 
 /// This has O(n) complexity where n is the length in the parameter.
-pub fn length_eq(self : View, len : Int) -> Bool {
-  for index = self.start, self_len = 0
-      index < self.end && self_len < len
-      index = index + 1, self_len = self_len + 1 {
-    let c1 = self.str.unsafe_charcode_at(index)
-    if is_leading_surrogate(c1) && index + 1 < self.end {
-      let c2 = self.str.unsafe_charcode_at(index + 1)
-      if is_trailing_surrogate(c2) {
-        continue index + 2, self_len + 1
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-  } else {
-    self_len == len && index == self.end
-  }
+pub fn View::char_length_eq(self : View, len : Int) -> Bool {
+  self.str.char_length_eq(len, start_offset=self.start, end_offset=self.end)
 }
 
 ///|
 /// Test if the length of the view is greater than or equal to the given length.
 /// 
 /// This has O(n) complexity where n is the length in the parameter.
-pub fn length_ge(self : View, len : Int) -> Bool {
-  for index = self.start, self_len = 0
-      index < self.end && self_len < len
-      index = index + 1, self_len = self_len + 1 {
-    let c1 = self.str.unsafe_charcode_at(index)
-    if is_leading_surrogate(c1) && index + 1 < self.end {
-      let c2 = self.str.unsafe_charcode_at(index + 1)
-      if is_trailing_surrogate(c2) {
-        continue index + 2, self_len + 1
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-  } else {
-    self_len >= len
-  }
-}
-
-///|
-/// Return the character at the given index.
-/// 
-/// The time complexity is O(n) where n is the given index, as it needs to scan
-/// through the UTF-16 code units to find the nth Unicode character.
-/// 
-/// # Example
-/// 
-/// ```
-/// let str = "Hello🤣🤣🤣"
-/// let view = str[1:6]
-/// inspect!(view[0], content="e")
-/// inspect!(view[4], content="🤣")
-/// ```
-pub fn View::op_get(self : View, index : Int) -> Char {
-  guard index >= 0 else {
-    abort("Index out of bounds: cannot access negative index")
-  }
-  let mut utf16_offset = self.start
-  let mut char_count = 0
-  let code_unit_length = self.str.length()
-  while char_count < index && utf16_offset < self.end {
-    let c1 = self.str.unsafe_charcode_at(utf16_offset)
-    if is_leading_surrogate(c1) && utf16_offset + 1 < code_unit_length {
-      let c2 = self.str.unsafe_charcode_at(utf16_offset + 1)
-      if is_trailing_surrogate(c2) {
-        utf16_offset = utf16_offset + 2
-        char_count = char_count + 1
-        continue
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-    utf16_offset = utf16_offset + 1
-    char_count = char_count + 1
-  }
-  guard char_count == index && utf16_offset < self.end else {
-    abort("Index out of bounds: cannot access index \{index}")
-  }
-  let c1 = self.str.unsafe_charcode_at(utf16_offset)
-  if is_leading_surrogate(c1) {
-    let c2 = self.str.unsafe_charcode_at(utf16_offset + 1)
-    if is_trailing_surrogate(c2) {
-      code_point_of_surrogate_pair(c1, c2)
-    } else {
-      abort("invalid surrogate pair")
-    }
-  } else {
-    Char::from_int(c1)
-  }
-}
-
-///|
-/// Returns the character at the given index from the end of the view.
-/// 
-/// The time complexity is O(n) where n is the given index, as it needs to scan
-/// through the UTF-16 code units to find the nth Unicode character.
-/// 
-/// # Example
-/// 
-/// ```
-/// let str = "Hello🤣🤣🤣"
-/// let view = str[1:6]
-/// inspect!(view.rev_get(0), content="🤣")
-/// inspect!(view.rev_get(4), content="e")
-/// ```
-pub fn rev_get(self : View, index : Int) -> Char {
-  guard index >= 0 else {
-    abort("Index out of bounds: cannot access negative index")
-  }
-  let mut utf16_offset = self.end - 1
-  let mut char_count = 0
-  while char_count < index && utf16_offset >= self.start {
-    let c1 = self.str.unsafe_charcode_at(utf16_offset)
-    if is_trailing_surrogate(c1) && utf16_offset - 1 >= self.start {
-      let c2 = self.str.unsafe_charcode_at(utf16_offset - 1)
-      if is_leading_surrogate(c2) {
-        utf16_offset = utf16_offset - 2
-        char_count = char_count + 1
-        continue
-      } else {
-        abort("invalid surrogate pair")
-      }
-    }
-    utf16_offset = utf16_offset - 1
-    char_count = char_count + 1
-  }
-  guard char_count == index && utf16_offset >= self.start else {
-    abort("Index out of bounds: cannot access index \{index} in reverse")
-  }
-  let c1 = self.str.unsafe_charcode_at(utf16_offset)
-  if is_trailing_surrogate(c1) {
-    let c2 = self.str.unsafe_charcode_at(utf16_offset - 1)
-    if is_leading_surrogate(c2) {
-      code_point_of_surrogate_pair(c2, c1)
-    } else {
-      abort("invalid surrogate pair")
-    }
-  } else {
-    Char::from_int(c1)
-  }
+pub fn View::char_length_ge(self : View, len : Int) -> Bool {
+  self.str.char_length_ge(len, start_offset=self.start, end_offset=self.end)
 }
 
 ///|
@@ -282,7 +151,7 @@ pub impl Show for StringView with to_string(self) {
 /// Returns an iterator over the Unicode characters in the string view.
 pub fn View::iter(self : View) -> Iter[Char] {
   Iter::new(fn(yield_) {
-    for index = self.start; index < self.end; index = index + 1 {
+    for index in self.start..<self.end {
       let c1 = self.str.unsafe_charcode_at(index)
       if is_leading_surrogate(c1) && index + 1 < self.end {
         let c2 = self.str.unsafe_charcode_at(index + 1)
@@ -290,6 +159,28 @@ pub fn View::iter(self : View) -> Iter[Char] {
           let c = code_point_of_surrogate_pair(c1, c2)
           guard yield_(c) is IterContinue else { break IterEnd }
           continue index + 2
+        }
+      }
+      guard yield_(Char::from_int(c1)) is IterContinue else { break IterEnd }
+
+    } else {
+      IterContinue
+    }
+  })
+}
+
+///|
+/// Returns an iterator over the Unicode characters in the string view in reverse order.
+pub fn View::rev_iter(self : View) -> Iter[Char] {
+  Iter::new(fn(yield_) {
+    for index = self.end - 1; index >= self.start; index = index - 1 {
+      let c1 = self.str.unsafe_charcode_at(index)
+      if is_trailing_surrogate(c1) && index - 1 >= 0 {
+        let c2 = self.str.unsafe_charcode_at(index - 1)
+        if is_leading_surrogate(c2) {
+          let c = code_point_of_surrogate_pair(c2, c1)
+          guard yield_(c) is IterContinue else { break IterEnd }
+          continue index - 2
         }
       }
       guard yield_(Char::from_int(c1)) is IterContinue else { break IterEnd }

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -102,24 +102,24 @@ test "stringview length" {
 test "stingview length_eq" {
   let str = "hello"
   let view = str[1:4]
-  inspect!(view.length_eq(0), content="false")
-  inspect!(view.length_eq(1), content="false")
-  inspect!(view.length_eq(2), content="false")
-  inspect!(view.length_eq(3), content="true")
-  inspect!(view.length_eq(4), content="false")
-  inspect!(view.length_eq(5), content="false")
+  inspect!(view.char_length_eq(0), content="false")
+  inspect!(view.char_length_eq(1), content="false")
+  inspect!(view.char_length_eq(2), content="false")
+  inspect!(view.char_length_eq(3), content="true")
+  inspect!(view.char_length_eq(4), content="false")
+  inspect!(view.char_length_eq(5), content="false")
 }
 
 ///|
 test "stingview length_ge" {
   let str = "hello"
   let view = str[1:4]
-  inspect!(view.length_ge(0), content="true")
-  inspect!(view.length_ge(1), content="true")
-  inspect!(view.length_ge(2), content="true")
-  inspect!(view.length_ge(3), content="true")
-  inspect!(view.length_ge(4), content="false")
-  inspect!(view.length_ge(5), content="false")
+  inspect!(view.char_length_ge(0), content="true")
+  inspect!(view.char_length_ge(1), content="true")
+  inspect!(view.char_length_ge(2), content="true")
+  inspect!(view.char_length_ge(3), content="true")
+  inspect!(view.char_length_ge(4), content="false")
+  inspect!(view.char_length_ge(5), content="false")
 }
 
 ///|
@@ -320,6 +320,15 @@ test "stringview iter" {
 }
 
 ///|
+test "stringview rev_iter" {
+  let str = "hello🤣🤣🤣"
+  let view = str[1:6]
+  let iter = view.rev_iter()
+  inspect!(iter.count(), content="5")
+  inspect!(iter, content="['🤣', 'o', 'l', 'l', 'e']")
+}
+
+///|
 test "stringview negative index" {
   let str = "hello🤣😭😂"
   inspect!(str[-2:-1], content="😭")
@@ -366,15 +375,15 @@ test "length_eq test with surrogate pair" {
   // "🤣" is encoded as a surrogate pair
   let str = "🤣"
   let view = str[:]
-  assert_true!(view.length_eq(1))
+  assert_true!(view.char_length_eq(1))
 }
 
 ///|
 test "length_ge with high surrogate" {
   let str = "🐰" // This emoji is represented using a surrogate pair
   let view = str[0:]
-  assert_eq!(view.length_ge(1), true)
-  assert_eq!(view.length_ge(2), false)
+  assert_eq!(view.char_length_ge(1), true)
+  assert_eq!(view.char_length_ge(2), false)
 }
 
 ///|
@@ -417,7 +426,7 @@ test "panic length_eq should panic on invalid surrogate pair" {
   let str = String::from_array([Char::from_int(0xD800), 'A'])
   let view = str[:]
   // This will trigger abort("invalid surrogate pair") in length_eq
-  ignore(view.length_eq(1))
+  ignore(view.char_length_eq(1))
 }
 
 ///|
@@ -428,7 +437,7 @@ test "panic_length_ge invalid surrogate pair" {
   ])
   let view = invalid_surrogate_pair[:]
   // This should abort with "invalid surrogate pair"
-  let _ = view.length_ge(1)
+  let _ = view.char_length_ge(1)
 
 }
 


### PR DESCRIPTION
Deprecated APIs:
* `@string.View::{op_get, rev_get}`. Use `view.iter().nth(n)` or `view.rev_iter().nth()` instead
* `String::rev_get`. Use `str.rev_iter().nth()` instead. It's symmetric version `String::codepoint_at` has already been deprecated.

Renamed APIs:
* `{String, @string.View}::length_{eq, ge}` -> `{String, @string.View}::char_length_{eq, ge}`. Old API deprecated, and new API added.
* `String::unsafe_codepoint_at` -> `String::unsafe_char_at`. This is a newly added public API so I renamed it directly instead of deprecating it.

New APIs:
* `@string.View.rev_iter`
* `String::char_at`
