### PR TITLE
feat: add @bytes.View::{bytes,start}

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -587,7 +587,7 @@ pub fn write_bytesview(self : T, value : @bytes.View) -> Unit {
   self.data.blit_from_bytes(
     self.len,
     value.data(),
-    value.start_of_data(),
+    value.start_offset(),
     value.length(),
   )
   self.len += val_len

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -584,7 +584,12 @@ pub fn write_bytes(self : T, value : Bytes) -> Unit {
 pub fn write_bytesview(self : T, value : @bytes.View) -> Unit {
   let val_len = value.length()
   self.grow_if_necessary(self.len + val_len)
-  self.data.blit_from_bytesview(self.len, value)
+  self.data.blit_from_bytes(
+    self.len,
+    value.data(),
+    value.start_of_data(),
+    value.length(),
+  )
   self.len += val_len
 }
 

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -20,10 +20,12 @@ fn to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
 // Types and methods
 type View
 impl View {
+  bytes(Self) -> Bytes
   iter(Self) -> Iter[Byte]
   length(Self) -> Int
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
   op_get(Self, Int) -> Byte
+  start(Self) -> Int
   to_double_be(Self) -> Double
   to_double_le(Self) -> Double
   to_float_be(Self) -> Float

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -20,12 +20,12 @@ fn to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
 // Types and methods
 type View
 impl View {
-  bytes(Self) -> Bytes
+  data(Self) -> Bytes
   iter(Self) -> Iter[Byte]
   length(Self) -> Int
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
   op_get(Self, Int) -> Byte
-  start(Self) -> Int
+  start_of_data(Self) -> Int
   to_double_be(Self) -> Double
   to_double_le(Self) -> Double
   to_float_be(Self) -> Float

--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -25,7 +25,7 @@ impl View {
   length(Self) -> Int
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
   op_get(Self, Int) -> Byte
-  start_of_data(Self) -> Int
+  start_offset(Self) -> Int
   to_double_be(Self) -> Double
   to_double_le(Self) -> Double
   to_float_be(Self) -> Float

--- a/bytes/moon.pkg.json
+++ b/bytes/moon.pkg.json
@@ -1,4 +1,8 @@
 {
   "import": ["moonbitlang/core/builtin"],
-  "test-import": ["moonbitlang/core/array", "moonbitlang/core/double"]
+  "test-import": [
+    "moonbitlang/core/array",
+    "moonbitlang/core/double",
+    "moonbitlang/core/test"
+  ]
 }

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -648,6 +648,6 @@ pub fn View::data(self : View) -> Bytes {
 
 ///|
 /// Retrieves the start index of the view.
-pub fn View::start_of_data(self : View) -> Int {
+pub fn View::start_offset(self : View) -> Int {
   self.start
 }

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -639,3 +639,15 @@ pub impl Compare for View with compare(self, other) -> Int {
   }
   0
 }
+
+///|
+/// Retrieves the underlying `Bytes` from a `View`.
+pub fn View::bytes(self : View) -> Bytes {
+  self.bytes
+}
+
+///|
+/// Retrieves the start index of the view.
+pub fn View::start(self : View) -> Int {
+  self.start
+}

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -642,12 +642,12 @@ pub impl Compare for View with compare(self, other) -> Int {
 
 ///|
 /// Retrieves the underlying `Bytes` from a `View`.
-pub fn View::bytes(self : View) -> Bytes {
+pub fn View::data(self : View) -> Bytes {
   self.bytes
 }
 
 ///|
 /// Retrieves the start index of the view.
-pub fn View::start(self : View) -> Int {
+pub fn View::start_of_data(self : View) -> Int {
   self.start
 }

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -461,12 +461,12 @@ test "BytesView::eq" {
 test "View::bytes" {
   let bytes = b"abcabc"
   let view = bytes[1:4]
-  @test.same_object!(view.bytes(), bytes)
+  @test.same_object!(view.data(), bytes)
 }
 
 ///|
 test "View::start" {
   let bytes = b"abcabc"
   let view = bytes[1:4]
-  inspect!(view.start(), content="1")
+  inspect!(view.start_of_data(), content="1")
 }

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -468,5 +468,5 @@ test "View::bytes" {
 test "View::start" {
   let bytes = b"abcabc"
   let view = bytes[1:4]
-  inspect!(view.start_of_data(), content="1")
+  inspect!(view.start_offset(), content="1")
 }

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -456,3 +456,17 @@ test "BytesView::eq" {
   inspect!(bytes[0:3] == bytes[2:5], content="false")
   inspect!(bytes[0:4] == bytes[3:6], content="false")
 }
+
+///|
+test "View::bytes" {
+  let bytes = b"abcabc"
+  let view = bytes[1:4]
+  @test.same_object!(view.bytes(), bytes)
+}
+
+///|
+test "View::start" {
+  let bytes = b"abcabc"
+  let view = bytes[1:4]
+  inspect!(view.start(), content="1")
+}


### PR DESCRIPTION
This PR adds the following two methods to `@bytes.View`:

1. `bytes`: Returns the underlying `Bytes`.
2. `start`: Returns the start index of this view.

These two functions can be helpful when passing MoonBit `@bytes.View` to the C side without creating a new `Bytes` object.

For example, the declaration of the `write` syscall on Unix is as follows:

```c
ssize_t write(int fd, const void *buf, size_t n_byte);
```

If we could retrieve the underlying bytes from `@bytes.View`, we can obtain a pointer to
the start of the `@bytes.View` on the C side:

```c
int moonbit_write_wrapper(int fd, const void *bytes, int start, int length) {
  const void *buf = bytes + start;
  return write(fd, buf, length);
}
```

And we can bind to such function on MoonBit side as:

```moonbit
extern "c" fn write_wrapper(fd : Int, bytes : Bytes, offset : Int, length : Int) -> Int = "moonbit_write_wrapper"

pub fn write(fd : Int, view : @bytes.View) -> Int {
  return write_wrapper(fd, view.bytes(), view.start())
}
```

And the user of the library could just use `@bytes.View` as the input, without additional cost of copying the bytes.

```moonbit
test {
  let bytes_view : @bytes.View = { ... }
  let fd : Int = { ... }
  write(fd, bytes_view)
}
```