### PR TITLE
hongbo/tweak logger interface

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -803,6 +803,7 @@ pub(open) trait Logger {
   write_substring(Self, String, Int, Int) -> Unit
   write_char(Self, Char) -> Unit
 }
+impl Logger::write_char
 
 pub(open) trait Mod {
   op_mod(Self, Self) -> Self

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -801,10 +801,8 @@ impl[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] Hash 
 pub(open) trait Logger {
   write_string(Self, String) -> Unit
   write_substring(Self, String, Int, Int) -> Unit
-  write_sub_string(Self, String, Int, Int) -> Unit
   write_char(Self, Char) -> Unit
 }
-impl Logger::write_sub_string
 
 pub(open) trait Mod {
   op_mod(Self, Self) -> Self

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -56,6 +56,11 @@ pub(open) trait Logger {
 }
 
 ///|
+impl Logger with write_char(self, value) {
+  self.write_string([value])
+}
+
+///|
 /// Trait for types that can be converted to `String`
 pub(open) trait Show {
   // `output` is used for composition of aggregate structure.

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -52,14 +52,7 @@ pub(open) trait Default {
 pub(open) trait Logger {
   write_string(Self, String) -> Unit
   write_substring(Self, String, Int, Int) -> Unit
-  /// @alert deprecated "use `Logger::write_substring` instead"
-  write_sub_string(Self, String, Int, Int) -> Unit
   write_char(Self, Char) -> Unit
-}
-
-///|
-impl Logger with write_sub_string(self, value, start, len) {
-  self.write_substring(value, start, len)
 }
 
 ///|


### PR DESCRIPTION
- **refactor: remove deprecated functions and update buffer interface**
- **remove deprecated trait method `write_sub_string`**
- **make write_char defaultable**
