### PR TITLE
add `@prelude` to test imports of all packages

### DIFF
--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -7,7 +7,11 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix"
   ],
-  "test-import": ["moonbitlang/core/random", "moonbitlang/core/json"],
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/random",
+    "moonbitlang/core/json"
+  ],
   "targets": {
     "array_js.mbt": ["js"],
     "array_nonjs.mbt": ["not", "js"],

--- a/bool/moon.pkg.json
+++ b/bool/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/buffer/moon.pkg.json
+++ b/buffer/moon.pkg.json
@@ -3,5 +3,8 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/bytes",
     "moonbitlang/core/array"
+  ],
+  "test-import": [
+    "moonbitlang/core/prelude"
   ]
 }

--- a/byte/moon.pkg.json
+++ b/byte/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/bytes/moon.pkg.json
+++ b/bytes/moon.pkg.json
@@ -1,6 +1,7 @@
 {
   "import": ["moonbitlang/core/builtin"],
   "test-import": [
+    "moonbitlang/core/prelude",
     "moonbitlang/core/array",
     "moonbitlang/core/double",
     "moonbitlang/core/test"

--- a/char/moon.pkg.json
+++ b/char/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/cmp/moon.pkg.json
+++ b/cmp/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/core/builtin"
   ],
   "test-import": [
+    "moonbitlang/core/prelude",
     "moonbitlang/core/int"
   ]
 }

--- a/deque/moon.pkg.json
+++ b/deque/moon.pkg.json
@@ -7,6 +7,7 @@
     "panic_test.mbt": ["not", "native"]
   },
   "test-import": [
+    "moonbitlang/core/prelude",
     "moonbitlang/core/array"
   ]
 }

--- a/double/internal/ryu/moon.pkg.json
+++ b/double/internal/ryu/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/bool"]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/bool"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/double/moon.pkg.json
+++ b/double/moon.pkg.json
@@ -29,6 +29,7 @@
     "hypot_nonjs.mbt" : ["not", "js"]
   },
   "test-import": [
+    "moonbitlang/core/prelude",
     "moonbitlang/core/test"
   ]
 }

--- a/env/moon.pkg.json
+++ b/env/moon.pkg.json
@@ -4,6 +4,9 @@
     "moonbitlang/core/bytes",
     "moonbitlang/core/option"
   ],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
   "targets": {
     "env_wasm.mbt": ["wasm", "wasm-gc"],
     "env_js.mbt": ["js"],

--- a/error/moon.pkg.json
+++ b/error/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/float/moon.pkg.json
+++ b/float/moon.pkg.json
@@ -1,6 +1,9 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/double", "moonbitlang/core/uint"],
-  "test-import": ["moonbitlang/core/quickcheck"],
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/quickcheck"
+  ],
   "targets": {
     "round_js.mbt": ["js"],
     "round_wasm.mbt": ["wasm", "wasm-gc"],

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -6,5 +6,9 @@
     "moonbitlang/core/tuple",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": ["moonbitlang/core/string", "moonbitlang/core/json"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/string",
+    "moonbitlang/core/json"
+  ]
 }

--- a/hashset/moon.pkg.json
+++ b/hashset/moon.pkg.json
@@ -5,5 +5,9 @@
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": ["moonbitlang/core/string", "moonbitlang/core/int"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/string",
+    "moonbitlang/core/int"
+  ]
 }

--- a/immut/array/moon.pkg.json
+++ b/immut/array/moon.pkg.json
@@ -7,6 +7,9 @@
       "alias": "_core/array"
     }
   ],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
   "targets": {
     "panic_test.mbt": [
       "not",

--- a/immut/hashmap/moon.pkg.json
+++ b/immut/hashmap/moon.pkg.json
@@ -7,6 +7,7 @@
     "moonbitlang/core/immut/internal/sparse_array"
   ],
   "test-import": [
+    "moonbitlang/core/prelude",
     "moonbitlang/core/int",
     "moonbitlang/core/string",
     "moonbitlang/core/option"

--- a/immut/hashset/moon.pkg.json
+++ b/immut/hashset/moon.pkg.json
@@ -5,5 +5,9 @@
     "moonbitlang/core/immut/internal/sparse_array",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": ["moonbitlang/core/string", "moonbitlang/core/int"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/string",
+    "moonbitlang/core/int"
+  ]
 }

--- a/immut/internal/sparse_array/moon.pkg.json
+++ b/immut/internal/sparse_array/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/array"]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/array"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/immut/list/moon.pkg.json
+++ b/immut/list/moon.pkg.json
@@ -6,6 +6,9 @@
     "moonbitlang/core/json",
     "moonbitlang/core/option"
   ],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/immut/priority_queue/moon.pkg.json
+++ b/immut/priority_queue/moon.pkg.json
@@ -5,7 +5,10 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/math"
   ],
-  "test-import": ["moonbitlang/core/random"],
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/random"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/immut/sorted_map/moon.pkg.json
+++ b/immut/sorted_map/moon.pkg.json
@@ -7,6 +7,9 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/json"
   ],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
   "targets": {
     "panic_wbtest.mbt": ["not", "native"]
   }

--- a/immut/sorted_set/moon.pkg.json
+++ b/immut/sorted_set/moon.pkg.json
@@ -5,6 +5,9 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/json"
   ],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/int/moon.pkg.json
+++ b/int/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/uint"]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/uint"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/int16/moon.pkg.json
+++ b/int16/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/int64/moon.pkg.json
+++ b/int64/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/bytes", "moonbitlang/core/uint", "moonbitlang/core/uint64"]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/bytes", "moonbitlang/core/uint", "moonbitlang/core/uint64"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/json/moon.pkg.json
+++ b/json/moon.pkg.json
@@ -6,6 +6,7 @@
     "moonbitlang/core/strconv"
   ],
   "test-import": [
+    "moonbitlang/core/prelude",
     "moonbitlang/core/result",
     "moonbitlang/core/option",
     "moonbitlang/core/unit",

--- a/math/moon.pkg.json
+++ b/math/moon.pkg.json
@@ -1,5 +1,7 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/double"],
-  "test-import": ["moonbitlang/core/test"]
-
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/test"
+  ]
 }

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,5 +1,6 @@
 {
   "name": "moonbitlang/core",
+  "warn-list": "-29",
   "version": "0.1.0",
   "readme": "README.md",
   "repository": "https://github.com/moonbitlang/core",

--- a/option/moon.pkg.json
+++ b/option/moon.pkg.json
@@ -4,6 +4,9 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix"
   ],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/priority_queue/moon.pkg.json
+++ b/priority_queue/moon.pkg.json
@@ -5,7 +5,10 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix"
   ],
-  "test-import": ["moonbitlang/core/random"],
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/random"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/queue/moon.pkg.json
+++ b/queue/moon.pkg.json
@@ -1,6 +1,9 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"],
-  "test-import": ["moonbitlang/core/array"],
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/array"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/quickcheck/moon.pkg.json
+++ b/quickcheck/moon.pkg.json
@@ -3,5 +3,8 @@
     "moonbitlang/core/quickcheck/splitmix",
     "moonbitlang/core/builtin"
   ],
-  "test-import": ["moonbitlang/core/array"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/array"
+  ]
 }

--- a/quickcheck/splitmix/moon.pkg.json
+++ b/quickcheck/splitmix/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/random/moon.pkg.json
+++ b/random/moon.pkg.json
@@ -4,5 +4,8 @@
     "moonbitlang/core/double",
     "moonbitlang/core/random/internal/random_source"
   ],
-  "test-import": ["moonbitlang/core/float"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/float"
+  ]
 }

--- a/rational/moon.pkg.json
+++ b/rational/moon.pkg.json
@@ -6,5 +6,8 @@
     "moonbitlang/core/int64",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": ["moonbitlang/core/array"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/array"
+  ]
 }

--- a/ref/moon.pkg.json
+++ b/ref/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/result/moon.pkg.json
+++ b/result/moon.pkg.json
@@ -1,5 +1,8 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/sorted_map/moon.pkg.json
+++ b/sorted_map/moon.pkg.json
@@ -5,5 +5,8 @@
     "moonbitlang/core/tuple",
     "moonbitlang/core/quickcheck"
   ],
-  "test-import": ["moonbitlang/core/array"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/array"
+  ]
 }

--- a/sorted_set/moon.pkg.json
+++ b/sorted_set/moon.pkg.json
@@ -1,4 +1,7 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/option", "moonbitlang/core/quickcheck"],
-  "test-import": ["moonbitlang/core/array"]
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/array"
+  ]
 }

--- a/strconv/moon.pkg.json
+++ b/strconv/moon.pkg.json
@@ -4,5 +4,8 @@
     "moonbitlang/core/double",
     "moonbitlang/core/uint64",
     "moonbitlang/core/string"
+  ],
+  "test-import": [
+    "moonbitlang/core/prelude"
   ]
 }

--- a/string/moon.pkg.json
+++ b/string/moon.pkg.json
@@ -1,6 +1,10 @@
 {
   "import": ["moonbitlang/core/builtin"],
-  "test-import": ["moonbitlang/core/immut/list", "moonbitlang/core/json"],
+  "test-import": [
+    "moonbitlang/core/prelude",
+    "moonbitlang/core/immut/list",
+    "moonbitlang/core/json"
+  ],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/tuple/moon.pkg.json
+++ b/tuple/moon.pkg.json
@@ -3,5 +3,8 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix"
+  ],
+  "test-import": [
+    "moonbitlang/core/prelude"
   ]
 }

--- a/uint/moon.pkg.json
+++ b/uint/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/uint16/moon.pkg.json
+++ b/uint16/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }

--- a/unit/moon.pkg.json
+++ b/unit/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": ["moonbitlang/core/builtin"],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ]
 }


### PR DESCRIPTION
This PR add `@moonbitlang/core/prelude` to the `test-imports` of all core packages.

We plan to migrate the package that can be use unqualified to `@prelude` soon. But inside core, the "prelude" of packages are still `@builtin`, to avoid cyclic dependency issues.

However, for black box tests, `@prelude` should be used as the prelude package, to match the behavior users see outside core, and to allow using things in `@prelude` after we move various things outside `@builtin` in the future.

This PR itself currently has no effect, but is necessary for the MoonBit compiler counterpart of migrating to `@prelude`.

In the future, maybe we should allow black-box tests in core to use all core packages implicitly, just like users outside core.