### PR TITLE
feat(env): make `now()` more precise on native targets

### DIFF
--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -72,14 +72,8 @@ fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
 }
 
 ///|
-extern "c" fn time(ptr : Int) -> UInt64 = "time"
-
-///|
-fn now_internal() -> UInt64 {
-  // time returns seconds since 1970-01-01 00:00:00 UTC
-  // to be consistent with other backends, we convert to milliseconds
-  time(0) * 1000
-}
+/// Returns the number of milliseconds since the epoch (1970-01-01T00:00:00Z).
+extern "c" fn now_internal() -> UInt64 = "now_internal"
 
 ///|
 extern "c" fn getcwd(ptr : Bytes, size : Int) -> Int = "getcwd"

--- a/env/moon.pkg.json
+++ b/env/moon.pkg.json
@@ -9,5 +9,6 @@
     "env_js.mbt": ["js"],
     "env_native.mbt": ["native"]
   },
+  "native-stub": ["native_stub.c"],
   "warn-list": "-29"
 }

--- a/env/native_stub.c
+++ b/env/native_stub.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+#ifdef _WIN32
+#include <windows.h>
+
+// Adapted from https://stackoverflow.com/a/26085827.
+uint64_t now_internal() {
+  // Note: some broken versions only have 8 trailing zero's, the correct epoch
+  // has 9 trailing zero's. This magic number is the number of 100 nanosecond
+  // intervals since January 1, 1601 (UTC) until 00:00:00 January 1, 1970
+  static const uint64_t EPOCH = ((uint64_t)116444736000000000ULL);
+
+  SYSTEMTIME system_time;
+  FILETIME file_time;
+
+  GetSystemTime(&system_time);
+  SystemTimeToFileTime(&system_time, &file_time);
+  uint64_t time = ((uint64_t)file_time.dwHighDateTime << 32) +
+                  (uint64_t)file_time.dwLowDateTime;
+
+  return (uint64_t)((time - EPOCH) / 10000) +
+         (uint64_t)(system_time.wMilliseconds);
+}
+#else
+#include <stddef.h>
+#include <sys/time.h>
+
+uint64_t now_internal() {
+  struct timeval res;
+  gettimeofday(&res, NULL);
+  return (uint64_t)res.tv_sec * 1000 + (uint64_t)res.tv_usec / 1000;
+}
+#endif


### PR DESCRIPTION
Upstreams https://github.com/moonbitlang/x/pull/122.

Manually tested on both Unix and Windows (in https://github.com/moonbitlang/core/actions/runs/14168177735/job/39685877322?pr=1856), both can provide the correct timestamp.

@Young-Flash suggests that this cannot be merged yet since `moon` will not recognize the native_stub.