### PR TITLE
refactor(string): provide generic trim_start and trim_end

### DIFF
--- a/string/generic.mbt
+++ b/string/generic.mbt
@@ -1,0 +1,50 @@
+///|
+pub fn trim_start_by[S : StringLike, P : CharPredicate](s : S, p : P) -> View {
+  loop s.to_fullview() {
+    [] as v => v
+    [c, .. rest] as v => if p.match_char(c) { continue rest } else { v }
+  }
+}
+
+///|
+pub fn trim_prefix[S1 : StringLike, S2 : StringLike](
+  s : S1,
+  prefix : S2
+) -> View {
+  let prefix_len = prefix.length()
+  let len = s.length()
+  guard len >= prefix_len else { return s.to_fullview() }
+  for i in 0..<prefix_len {
+    guard s.unsafe_charcode_at(i) == prefix.unsafe_charcode_at(i) else {
+      return s.to_fullview()
+    }
+
+  }
+  s.to_subview(start_offset=prefix_len, end_offset=len)
+}
+
+///|
+pub fn trim_end_by[S : StringLike, P : CharPredicate](s : S, p : P) -> View {
+  loop s.to_fullview() {
+    [] as v => v
+    [.. rest, c] as v => if p.match_char(c) { continue rest } else { v }
+  }
+}
+
+///|
+pub fn trim_suffix[S1 : StringLike, S2 : StringLike](
+  s : S1,
+  suffix : S2
+) -> View {
+  let suffix_len = suffix.length()
+  let len = s.length()
+  guard len >= suffix_len else { return s.to_fullview() }
+  for i in 0..<suffix_len {
+    guard s.unsafe_charcode_at(len - i - 1) ==
+      suffix.unsafe_charcode_at(suffix_len - i - 1) else {
+      return s.to_fullview()
+    }
+
+  }
+  s.to_subview(start_offset=0, end_offset=len - suffix_len)
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -274,7 +274,10 @@ pub fn trim(self : String, trim_set : String) -> String {
   if self == "" || trim_set == "" {
     self
   } else {
-    self.trim_start(trim_set).trim_end(trim_set)
+    self
+    .trim_start_by(trim_set.iter().collect())
+    .trim_end_by(trim_set.iter().collect())
+    .to_string()
   }
 }
 
@@ -285,54 +288,82 @@ pub fn contains_char(self : String, c : Char) -> Bool {
 
 ///|
 /// Removes all leading chars contained in the given string.
+#deprecated("use `self.trim_start_by(trim_set.iter().collect()).to_string()` instead.")
 pub fn trim_start(self : String, trim_set : String) -> String {
-  let len = self.length()
-  for i in 0..<len {
-    let c1 = self.unsafe_charcode_at(i)
-    // check surrogate pair
-    if is_leading_surrogate(c1) && i + 1 < len {
-      let c2 = self.unsafe_charcode_at(i + 1)
-      if is_trailing_surrogate(c2) {
-        let ch = code_point_of_surrogate_pair(c1, c2)
-        if trim_set.contains_char(ch) {
-          continue i + 2
-        } else {
-          return self.substring(start=i)
-        }
-      }
-    }
-    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
-      return self.substring(start=i)
-    }
-  } else {
-    ""
-  }
+  self.trim_start_by(trim_set.iter().collect()).to_string()
+}
+
+///| 
+/// Removes all leading chars satisifed by the predicate.
+/// 
+/// # Example
+/// 
+/// ```
+/// let s = "Hello, World!"
+/// let v1 = s.trim_start_by(@string.CharFn(fn(c) { c == 'H' || c == 'e' }))
+/// inspect!(v1, content="llo, World!")
+/// let v2 = s.trim_start_by(['H', 'e'])
+/// inspect!(v2, content="llo, World!")
+/// let v3 = s.trim_start_by('H')
+/// inspect!(v3, content="ello, World!")
+/// ```
+pub fn String::trim_start_by[P : CharPredicate](self : String, p : P) -> View {
+  trim_start_by(self, p)
+}
+
+///|
+/// Removes all leading chars contained in the given string.
+/// 
+/// # Example
+/// ```
+/// let s = "Hello, World!"
+/// let v1 = s.trim_prefix("Hello")
+/// inspect!(v1, content=", World!")
+/// let v2 = s.trim_prefix("Hello, ".view())
+/// inspect!(v2, content="World!")
+/// ```
+pub fn String::trim_prefix[S : StringLike](self : String, prefix : S) -> View {
+  trim_prefix(self, prefix)
 }
 
 ///|
 /// Removes all trailing chars contained in the given string.
+#deprecated("use `self.trim_end_by(trim_set.iter().collect()).to_string()` instead.")
 pub fn trim_end(self : String, trim_set : String) -> String {
-  let len = self.length()
-  for i = len - 1; i >= 0; i = i - 1 {
-    let c2 = self.unsafe_charcode_at(i)
-    // check surrogate pair
-    if is_trailing_surrogate(c2) && i - 1 >= 0 {
-      let c1 = self.unsafe_charcode_at(i - 1)
-      if is_leading_surrogate(c1) {
-        let ch = code_point_of_surrogate_pair(c1, c2)
-        if trim_set.contains_char(ch) {
-          continue i - 2
-        } else {
-          return self.substring(end=i + 1)
-        }
-      }
-    }
-    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
-      return self.substring(end=i + 1)
-    }
-  } else {
-    ""
-  }
+  self.trim_end_by(trim_set.iter().collect()).to_string()
+}
+
+///| 
+/// Removes all trailing chars satisifed by the predicate.
+/// 
+/// # Example
+/// 
+/// ```
+/// let s = "Hello, World!"
+/// let v1 = s.trim_end_by(@string.CharFn(fn(c) { c == '!' || c == 'd' }))
+/// inspect!(v1, content="Hello, Worl")
+/// let v2 = s.trim_end_by(['!', 'd'])
+/// inspect!(v2, content="Hello, Worl")
+/// let v3 = s.trim_end_by('!')
+/// inspect!(v3, content="Hello, World")
+/// ```
+pub fn String::trim_end_by[P : CharPredicate](self : String, p : P) -> View {
+  trim_end_by(self, p)
+}
+
+///|
+/// Removes all leading chars contained in the given string.
+/// 
+/// # Example
+/// ```
+/// let s = "Hello, World!"
+/// let v1 = s.trim_suffix("!")
+/// inspect!(v1, content="Hello, World")
+/// let v2 = s.trim_suffix("Hello, ".view())
+/// inspect!(v2, content="Hello, World!")
+/// ```
+pub fn String::trim_suffix[S : StringLike](self : String, prefix : S) -> View {
+  trim_suffix(self, prefix)
 }
 
 ///|

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -74,13 +74,26 @@ fn to_upper(String) -> String
 
 fn trim(String, String) -> String
 
+#deprecated
 fn trim_end(String, String) -> String
+
+fn trim_end_by[S : StringLike, P : CharPredicate](S, P) -> StringView
+
+fn trim_prefix[S1 : StringLike, S2 : StringLike](S1, S2) -> StringView
 
 fn trim_space(String) -> String
 
+#deprecated
 fn trim_start(String, String) -> String
 
+fn trim_start_by[S : StringLike, P : CharPredicate](S, P) -> StringView
+
+fn trim_suffix[S1 : StringLike, S2 : StringLike](S1, S2) -> StringView
+
 // Types and methods
+pub(all) type CharFn (Char) -> Bool
+impl CharPredicate for CharFn
+
 type StringIndex
 impl Eq for StringIndex
 impl Show for StringIndex
@@ -107,10 +120,15 @@ impl StringView {
   #deprecated
   rev_get(Self, Int) -> Char
   rev_iter(Self) -> Iter[Char]
+  trim_end_by[P : CharPredicate](Self, P) -> Self
+  trim_prefix[S : StringLike](Self, S) -> Self
+  trim_start_by[P : CharPredicate](Self, P) -> Self
+  trim_suffix[S : StringLike](Self, S) -> Self
 }
 impl Compare for StringView
 impl Eq for StringView
 impl Show for StringView
+impl StringLike for StringView
 
 impl String {
   char_at(String, Int) -> Char
@@ -158,9 +176,15 @@ impl String {
   to_lower(String) -> String
   to_upper(String) -> String
   trim(String, String) -> String
+  #deprecated
   trim_end(String, String) -> String
+  trim_end_by[P : CharPredicate](String, P) -> StringView
+  trim_prefix[S : StringLike](String, S) -> StringView
   trim_space(String) -> String
+  #deprecated
   trim_start(String, String) -> String
+  trim_start_by[P : CharPredicate](String, P) -> StringView
+  trim_suffix[S : StringLike](String, S) -> StringView
   view(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> StringView
 }
 impl Compare for String
@@ -170,4 +194,10 @@ impl Default for String
 pub typealias View = StringView
 
 // Traits
+trait CharPredicate
+impl CharPredicate for Char
+impl CharPredicate for Array[Char]
+
+trait StringLike
+impl StringLike for String
 

--- a/string/trait.mbt
+++ b/string/trait.mbt
@@ -1,0 +1,73 @@
+///|
+/// An abstract trait that is only implemented as String and View.
+trait StringLike: Show {
+  unsafe_charcode_at(Self, Int) -> Int
+  length(Self) -> Int
+  to_fullview(Self) -> View
+  to_subview(Self, start_offset~ : Int, end_offset~ : Int) -> View
+}
+
+///|
+pub impl StringLike for String with unsafe_charcode_at(self, i) {
+  self.unsafe_charcode_at(i)
+}
+
+///|
+pub impl StringLike for String with length(self) {
+  self.length()
+}
+
+///|
+pub impl StringLike for String with to_fullview(self) {
+  self.view()
+}
+
+///|
+pub impl StringLike for String with to_subview(self, start_offset~, end_offset~) {
+  self.view(start_offset~, end_offset~)
+}
+
+///|
+pub impl StringLike for View with unsafe_charcode_at(self, i) {
+  self.str.unsafe_charcode_at(i + self.start)
+}
+
+///|
+pub impl StringLike for View with length(self) {
+  self.len()
+}
+
+///|
+pub impl StringLike for View with to_fullview(self) {
+  self
+}
+
+///|
+pub impl StringLike for View with to_subview(self, start_offset~, end_offset~) {
+  let start = self.start + start_offset
+  let end = end_offset
+  View::{ str: self.str, start, end }
+}
+
+///|
+trait CharPredicate {
+  match_char(Self, Char) -> Bool
+}
+
+///|
+pub impl CharPredicate for Char with match_char(self, c) {
+  self == c
+}
+
+///|
+pub impl CharPredicate for Array[Char] with match_char(self, c) {
+  self.contains(c)
+}
+
+///|
+pub(all) type CharFn (Char) -> Bool
+
+///|
+pub impl CharPredicate for CharFn with match_char(self, c) {
+  (self._)(c)
+}

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -232,3 +232,69 @@ pub impl Compare for View with compare(self, other) {
   }
   0
 }
+
+///| 
+/// Removes all leading chars satisifed by the predicate.
+/// 
+/// # Example
+/// 
+/// ```
+/// let s = "Hello, World!".view(start_offset=2)
+/// let v1 = s.trim_start_by(@string.CharFn(fn(c) { c == 'l' || c == 'o' }))
+/// inspect!(v1, content=", World!")
+/// let v2 = s.trim_start_by(['l', 'o'])
+/// inspect!(v2, content=", World!")
+/// let v3 = s.trim_start_by('l')
+/// inspect!(v3, content="o, World!")
+/// ```
+pub fn View::trim_start_by[P : CharPredicate](self : View, p : P) -> View {
+  trim_start_by(self, p)
+}
+
+///|
+/// Removes all leading chars contained in the given string.
+/// 
+/// # Example
+/// ```
+/// let s = "Hello, World!".view(start_offset=2)
+/// let v1 = s.trim_prefix("llo")
+/// inspect!(v1, content=", Worl")
+/// let v2 = s.trim_prefix("llo, ".view())
+/// inspect!(v2, content="Worl")
+/// ```
+pub fn View::trim_prefix[S : StringLike](self : View, prefix : S) -> View {
+  trim_prefix(self, prefix)
+}
+
+///| 
+/// Removes all trailing chars satisifed by the predicate.
+/// 
+/// # Example
+/// 
+/// ```
+/// let s = "Hello, World!".view(end_offset=11)
+/// let v1 = s.trim_end_by(@string.CharFn(fn(c) { c == 'r' || c == 'l' }))
+/// inspect!(v1, content="Hello, Wo")
+/// let v2 = s.trim_end_by(['r', 'l'])
+/// inspect!(v2, content="Hello, Wo")
+/// let v3 = s.trim_end_by('l')
+/// inspect!(v3, content="Hello, Wor")
+/// ```
+pub fn View::trim_end_by[P : CharPredicate](self : View, p : P) -> View {
+  trim_end_by(self, p)
+}
+
+///|
+/// Removes all leading chars contained in the given string.
+/// 
+/// # Example
+/// ```
+/// let s = "Hello, World!".view(end_offset=11)
+/// let v1 = s.trim_suffix("rl")
+/// inspect!(v1, content="Hello, Wo")
+/// let v2 = s.trim_suffix("rl".view())
+/// inspect!(v2, content="Hello, Wo")
+/// ```
+pub fn View::trim_suffix[S : StringLike](self : View, prefix : S) -> View {
+  trim_suffix(self, prefix)
+}


### PR DESCRIPTION
This PR is more about a PoC, and it shows how to use trait and generic functions for implement cleaner APIs for the `String` and `@string.View` type.

## Problem background

Take the function that trims from start of a string as an example, we would need the following functions:
```
fn trim_prefix(String, String) -> @string.View
fn trim_prefix_view(String, @string.View) -> @string.View
fn trim_start_by(String, (Char) -> Bool) -> @string.View
fn trim_start_any(String, Array[Char]) -> @string.View
fn trim_start_char(String, Char) -> @string.View
```
There will be quite a lot of code duplication and the situation also happens for functions such as `find_first`, `rfind_first`, `find_all`, `rfind_all`, `split_all`, `rsplit_all`, `split_first`, `rsplit_first`, `contains`, etc.

## Proposed Solution

Taking inspiration from Rust, we can divide the above methods into two groups:
```
fn trim_prefix[S: StringLike](Sting, S) -> @string.View
fn trim_start_by[P: CharPredicate](String, P) -> @string.View
```
with the corresponding trait implementations:
```
impl S for String
impl S for @string.View
impl P for Char
impl P for Array[Char]
impl P for CharFn
pub(all) CharFn (Char) -> Bool
```
Then we can write the code as follows:
```
let s = "Hello, World!"
let v1 = s.trim_start_by(@string.CharFn(fn(c) { c == 'H' || c == 'e' }))
let v2 = s.trim_start_by(['H', 'e'])
let v3 = s.trim_start_by('H')
let v4 = s.trim_prefix("Hello")
let v5 = s.trim_prefix("Hello, ".view())
```
The only suboptimal case is the usage of `@string.CharFn` constructor because we lack the ability of implement traits with function types.

## Main benefit

The API will have more easy-to-understand, and ergonomic names. 

## Implementation detail

Since the trim APIs are also needed for the `@string.View`, the generic functions are implemented in a more generic way:
```
fn trim_prefix[S1: StringLike, S2: StringLike](S1, S2) -> @string.View
fn trim_start_by[S1: StringLike, P: CharPredicate](S1, P) -> @string.View
```
and the methods for String and @string.View will call the corresponding generic functions.