### PR TITLE
hongbo/string output

### DIFF
--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -126,7 +126,7 @@ pub impl Show for String with output(self, logger) {
         logger.write_string("\\t")
       }
       code =>
-        if code < 0x20 {
+        if code < ' ' {
           flush_segment(i)
           logger
           ..write_char('\\')

--- a/string/string_unicode_test.mbt
+++ b/string/string_unicode_test.mbt
@@ -1,0 +1,37 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test {
+  struct Data {
+    val : String
+  } derive(Show)
+  let data = Data::{ val: "Hello, 世界\t\n!" }
+  // TODO: the data type annotation is not needed
+  inspect!(
+    data,
+    content=
+      #|{val: "Hello, 世界\t\n!"}
+    ,
+  )
+  let v = "\u{00AD}Hello, \u{2060}世界\t\n!\u{1D173}"
+  inspect!(
+    repr(v),
+    content=
+      #|"­Hello, ⁠世界\t\n!𝅳"
+    ,
+  )
+  // FIXME:The output is not ideal, we would prefer
+  // to see the Unicode code points, e.g.
+}


### PR DESCRIPTION
- **tweak**
- **add some tests**

Note in most programming languages, they don't print string properly by default for non-printable unicode characters (JS, OCaml), go has a dedicated function strconv.Quote for this, and fmt.Println does not do this very well either, but it does better than OCaml for CJK letters