### PR TITLE
migration: remove old [..] syntax

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -181,7 +181,7 @@ pub fn filter_map[A, B](self : Array[A], f : (A) -> B?) -> Array[B] {
 pub fn last[A](self : Array[A]) -> A? {
   match self {
     [] => None
-    [.., last] => Some(last)
+    [.. _, last] => Some(last)
   }
 }
 

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -575,7 +575,7 @@ pub fn FixedArray::rev_inplace[T](self : FixedArray[T]) -> Unit {
 pub fn FixedArray::rev[T](self : FixedArray[T]) -> FixedArray[T] {
   match self {
     [] => []
-    [.., first] => {
+    [.. _, first] => {
       let res = FixedArray::make(self.length(), first)
       let len = self.length()
       for i in 1..<len {
@@ -1189,7 +1189,7 @@ pub fn FixedArray::from_iter[T](iter : Iter[T]) -> FixedArray[T] {
 pub fn FixedArray::last[A](self : FixedArray[A]) -> A? {
   match self {
     [] => None
-    [.., last] => Some(last)
+    [.. _, last] => Some(last)
   }
 }
 

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -209,11 +209,11 @@ test "panic Fixed::blit_from_bytesview 2" {
 ///|
 test "bytes pattern match" {
   let bytes : Bytes = "Hello, world!你好"
-  guard bytes is [.. b"Hello", ..] else { fail!("") }
-  guard bytes is [.. _x, .. "你好"] && _x is [.. "Hello, world!", ..] else {
+  guard bytes is [.. b"Hello", .. _] else { fail!("") }
+  guard bytes is [.. _x, .. "你好"] && _x is [.. "Hello, world!", .. _] else {
     fail!("")
   }
-  guard bytes is [.., .. "你好"] else { fail!("") }
+  guard bytes is [.. _, .. "你好"] else { fail!("") }
   // CR: ZYU: it's weird this works but below does not work
   // guard bytes is [.. _ , .. "你好"] else { fail!("") }
 

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -274,7 +274,7 @@ test "stringify" {
   // we do come across issues like ParseError not unified with String
   let newjson = @json.parse!(json.stringify())
   match json {
-    { "key": [_, _, _, _, { "value": Number(i), .. }, ..], .. } =>
+    { "key": [_, _, _, _, { "value": Number(i), .. }, .. _], .. } =>
       inspect!(i, content="100")
     _ => fail!("Failed to match the JSON")
   }

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -136,7 +136,7 @@ fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
         }
         rest => rest
       }
-      guard rest is ['0'..='9', ..] else { syntax_err!() }
+      guard rest is ['0'..='9', .. _] else { syntax_err!() }
       let mut exp = 0
       let rest = loop rest {
         ['_', .. rest] => continue rest

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -97,15 +97,15 @@ pub fn parse_int64(str : String, base~ : Int = 0) -> Int64!StrConvError {
   // calculate overflow threshold
   let overflow_threshold = overflow_threshold(num_base, neg)
   let has_digit = rest
-    is (['0'..='9' | 'a'..='z' | 'A'..='Z', ..]
-    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', ..])
+    is (['0'..='9' | 'a'..='z' | 'A'..='Z', .. _]
+    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', .. _])
   guard has_digit else { syntax_err!() }
   // convert
   loop rest, 0L, allow_underscore {
     ['_'], _, _ =>
       // the last character cannot be underscore
       syntax_err!()
-    ['_', ..], _, false => syntax_err!()
+    ['_', .. _], _, false => syntax_err!()
     ['_', .. rest], acc, true => continue rest, acc, false
     [c, .. rest], acc, _ => {
       let c = c.to_int()
@@ -179,7 +179,7 @@ fn check_underscore(str : String) -> Bool {
     // String ending with underscore is invalid
     ['_'], _, _ => false
     // Underscore not allowed in current position (e.g., between non-digits)
-    ['_', ..], false, _ => false
+    ['_', .. _], false, _ => false
     // Valid underscore - continue but mark that next char must be a digit
     ['_', .. rest], true, _ => continue rest, false, true
     // Handle non-underscore character
@@ -201,9 +201,9 @@ fn check_underscore(str : String) -> Bool {
 // Determine the base of the value.
 fn determine_base(s : String) -> Int {
   match s.view() {
-    ['0', 'x' | 'X', ..] => 16
-    ['0', 'o' | 'O', ..] => 8
-    ['0', 'b' | 'B', ..] => 2
+    ['0', 'x' | 'X', .. _] => 16
+    ['0', 'o' | 'O', .. _] => 8
+    ['0', 'b' | 'B', .. _] => 2
     _ => 10
   }
 }

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -41,7 +41,7 @@ const UINT64_MAX : UInt64 = 0xffffffffffffffffUL
 /// 
 pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
   guard str != "" else { syntax_err!() }
-  if str is ['+' | '-', ..] {
+  if str is ['+' | '-', .. _] {
     syntax_err!()
   }
 
@@ -58,14 +58,14 @@ pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
     _ => UINT64_MAX / num_base.to_uint64() + 1
   }
   let has_digit = rest
-    is (['0'..='9' | 'a'..='z' | 'A'..='Z', ..]
-    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', ..])
+    is (['0'..='9' | 'a'..='z' | 'A'..='Z', .. _]
+    | ['_', '0'..='9' | 'a'..='z' | 'A'..='Z', .. _])
   guard has_digit else { syntax_err!() }
   loop rest, 0UL, allow_underscore {
     ['_'], _, _ =>
       // the last character cannot be underscore
       syntax_err!()
-    ['_', ..], _, false => syntax_err!()
+    ['_', .. _], _, false => syntax_err!()
     ['_', .. rest], acc, true => continue rest, acc, false
     [c, .. rest], acc, _ => {
       let c = c.to_int()

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -636,8 +636,8 @@ test "string pattern matching" {
   } derive(Show)
   fn process_string(s : String) {
     match s {
-      [.. "true", ..] => True
-      [.. "false", ..] => False
+      [.. "true", .. _] => True
+      [.. "false", .. _] => False
       _ => Other
     }
   }


### PR DESCRIPTION
we are deprecating the old `..` and `.. as pat` syntax, in favor of `.. _` and `.. pat`. This PR migrates core.