### PR TITLE
refactor(string): use View ubiquitously in public APIs

### DIFF
--- a/json/json.mbt
+++ b/json/json.mbt
@@ -80,7 +80,7 @@ fn indent_str(level : Int, indent : Int) -> String {
   if indent == 0 {
     ""
   } else {
-    "\n" + " ".repeat(indent * level)
+    "\n" + String::make(indent * level, ' ')
   }
 }
 

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -1,0 +1,821 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Returns the offset of the first occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn View::find(self : View, str : View) -> Int? {
+  let len = self.len()
+  let sub_len = str.len()
+  // Handle empty substring case
+  guard sub_len > 0 else { return Some(0) }
+  // If substring is longer than string, it can't be found
+  guard sub_len <= len else { return None }
+  let max_idx = len - sub_len
+  let first = str.unsafe_charcode_at(0)
+  let mut i = 0
+  while i <= max_idx {
+    // find first character
+    while i < len && self.unsafe_charcode_at(i) != first {
+      i += 1
+    }
+    // check the rest
+    if i <= max_idx {
+      for j in 1..<sub_len {
+        if self.unsafe_charcode_at(i + j) != str.unsafe_charcode_at(j) {
+          break
+        }
+      } else {
+        // the substring is found
+        return Some(i)
+      }
+    }
+    i += 1
+  }
+  None
+}
+
+///|
+/// Returns the offset of the first occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn String::find(self : String, str : View) -> Int? {
+  self.view().find(str)
+}
+
+///|
+test "find" {
+  inspect!("hello".find("o"), content="Some(4)")
+  inspect!("hello".find("l"), content="Some(2)")
+  inspect!("hello".find("hello"), content="Some(0)")
+  inspect!("hello".find("h"), content="Some(0)")
+  inspect!("hello".find(""), content="Some(0)")
+  inspect!("hello".find("world"), content="None")
+  inspect!("".find(""), content="Some(0)")
+  inspect!("".find("a"), content="None")
+  inspect!("hello hello".find("hello"), content="Some(0)")
+  inspect!("aaa".find("aa"), content="Some(0)")
+  inspect!("😀😀".find("😀"), content="Some(0)")
+}
+
+///|
+/// Returns the offset of the last occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn View::rfind(self : View, str : View) -> Int? {
+  let len = self.len()
+  let sub_len = str.len()
+  guard sub_len > 0 else { return Some(len) }
+  guard sub_len <= len else { return None }
+  let min_idx = sub_len - 1
+  let last = str.unsafe_charcode_at(sub_len - 1)
+  let mut i = len - 1
+  while i >= min_idx {
+    while i >= 0 && self.unsafe_charcode_at(i) != last {
+      i -= 1
+    }
+    if i >= min_idx {
+      for j in 1..<sub_len {
+        if self.unsafe_charcode_at(i - j) !=
+          str.unsafe_charcode_at(sub_len - 1 - j) {
+          break
+        }
+      } else {
+        return Some(i - sub_len + 1)
+      }
+    }
+    i -= 1
+  }
+  None
+}
+
+///|
+/// Returns the offset of the last occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn String::rfind(self : String, str : View) -> Int? {
+  self.view().rfind(str)
+}
+
+///|
+test "rfind" {
+  inspect!("hello".rfind("o"), content="Some(4)")
+  inspect!("hello".rfind("l"), content="Some(3)")
+  inspect!("hello".rfind("hello"), content="Some(0)")
+  inspect!("hello".rfind("h"), content="Some(0)")
+  inspect!("hello".rfind(""), content="Some(5)")
+  inspect!("hello".rfind("world"), content="None")
+  inspect!("".rfind(""), content="Some(0)")
+  inspect!("".rfind("a"), content="None")
+  inspect!("hello hello".rfind("hello"), content="Some(6)")
+  inspect!("aaa".rfind("aa"), content="Some(1)")
+  inspect!("😀😀".rfind("😀"), content="Some(2)")
+}
+
+///|
+/// Returns true if this string contains the given substring.
+pub fn View::contains(self : View, str : View) -> Bool {
+  self.find(str) is Some(_)
+}
+
+// TODO: add back the following method when the deprecated `contains` is removed
+// pub fn String::contains(self : String, str : View) -> Bool {
+//   self.view().contains(str)
+// }
+
+///|
+test "contains" {
+  inspect!("hello".contains("h"), content="true")
+  inspect!("hello".contains("e"), content="true")
+  inspect!("hello".contains("l"), content="true")
+  inspect!("hello".contains("o"), content="true")
+  inspect!("hello".contains("lo"), content="true")
+  inspect!("hello".contains("hello"), content="true")
+  inspect!("hello".contains(""), content="true")
+  inspect!("hello".contains("world"), content="false")
+  inspect!("".contains(""), content="true")
+  inspect!("".contains("a"), content="false")
+  inspect!("hello world".contains("world"), content="true")
+  inspect!("hello world".contains("o w"), content="true")
+  inspect!("😀😀".contains("😀"), content="true")
+  inspect!("😀😀".contains("😀😀"), content="true")
+  inspect!("😀😀".contains("😃"), content="false") // be careful that the last emoji is different 
+}
+
+///|
+/// Returns true if this string contains the given character.
+pub fn View::contains_char(self : View, c : Char) -> Bool {
+  self.iter().any(fn(ch) { ch == c })
+}
+
+///|
+/// Returns true if this string contains the given character.
+pub fn String::contains_char(self : String, c : Char) -> Bool {
+  self.view().contains_char(c)
+}
+
+///|
+#deprecated("Use `str.contains_char(c)` instead.")
+pub fn contains_char(s : String, c : Char) -> Bool {
+  s.contains_char(c)
+}
+
+///|
+test "contains_char" {
+  inspect!("hello".contains_char('h'), content="true")
+  inspect!("hello".contains_char('e'), content="true")
+  inspect!("hello".contains_char('l'), content="true")
+  inspect!("hello".contains_char('o'), content="true")
+  inspect!("hello".contains_char('x'), content="false")
+  inspect!("".contains_char('a'), content="false")
+  inspect!("hello world".contains_char(' '), content="true")
+  inspect!("hello world".contains_char('w'), content="true")
+  inspect!("😀😀".contains_char('😀'), content="true")
+  inspect!("😀😀".contains_char('😃'), content="false")
+  inspect!("hello".contains_char(Char::from_int(104)), content="true") // 'h' is 104 in ASCII
+}
+
+///| 
+/// Returns true if the given substring is suffix of this string.
+pub fn View::has_suffix(self : View, str : View) -> Bool {
+  self.rfind(str) is Some(i) && i == self.len() - str.len()
+}
+
+///|
+/// Returns true if the given substring is suffix of this string.
+pub fn String::has_suffix(self : String, str : View) -> Bool {
+  self.view().has_suffix(str)
+}
+
+///|
+test "has_suffix" {
+  inspect!("hello".has_suffix("lo"), content="true")
+  inspect!("hello".has_suffix("hello"), content="true")
+  inspect!("hello".has_suffix(""), content="true")
+  inspect!("hello".has_suffix("world"), content="false")
+  inspect!("hello".has_suffix("hel"), content="false")
+  inspect!("".has_suffix(""), content="true")
+  inspect!("".has_suffix("a"), content="false")
+  inspect!("hello world".has_suffix("world"), content="true")
+  inspect!("😀😀".has_suffix("😀"), content="true")
+  inspect!("😀😀".has_suffix("😀😀"), content="true")
+}
+
+///|
+/// Returns true if this string starts with the given substring.
+pub fn View::has_prefix(self : View, str : View) -> Bool {
+  self.find(str) is Some(i) && i == 0
+}
+
+///|
+/// Returns true if this string starts with the given substring.
+pub fn String::has_prefix(self : String, str : View) -> Bool {
+  self.view().has_prefix(str)
+}
+
+///|
+test "has_prefix" {
+  inspect!("hello".has_prefix("h"), content="true")
+  inspect!("hello".has_prefix("he"), content="true")
+  inspect!("hello".has_prefix(""), content="true")
+  inspect!("hello".has_prefix("world"), content="false")
+  inspect!("hello".has_prefix("lo"), content="false")
+  inspect!("".has_prefix(""), content="true")
+  inspect!("".has_prefix("a"), content="false")
+  inspect!("😀hello".has_prefix("😀"), content="true")
+  inspect!("😀😃hello".has_prefix("😀😃"), content="true")
+  inspect!("😀hello".has_prefix("😃"), content="false")
+  inspect!("hello😀".has_prefix("😀"), content="false")
+}
+
+///|
+/// Returns the view of the string without the leading characters that are in
+/// the given string.
+pub fn View::trim_left(self : View, char_set : View) -> View {
+  loop self {
+    [] as v => v
+    [c, .. rest] as v =>
+      if char_set.contains_char(c) {
+        continue rest
+      } else {
+        v
+      }
+  }
+}
+
+///|
+/// Returns the view of the string without the leading characters that are in
+/// the given string.
+pub fn String::trim_left(self : String, char_set : View) -> View {
+  self.view().trim_left(char_set)
+}
+
+///|
+test "trim_left" {
+  inspect!("hello".trim_left(['h']), content="ello")
+  inspect!("hello".trim_left(['h', 'e']), content="llo")
+  inspect!("hello".trim_left(['e', 'h']), content="llo")
+  inspect!("hello".trim_left(['x']), content="hello")
+  inspect!("hello".trim_left([]), content="hello")
+  inspect!("".trim_left(['a']), content="")
+  inspect!("   hello".trim_left([' ']), content="hello")
+  inspect!("hello world".trim_left(['h', 'e', 'l', 'o']), content=" world")
+  inspect!("😀😀hello".trim_left(['😀']), content="hello")
+  inspect!("😀😃hello".trim_left(['😀', '😃']), content="hello")
+  inspect!("aaaabc".trim_left(['a']), content="bc")
+  inspect!("aaaa".trim_left(['a']), content="")
+}
+
+///|
+/// Returns the view of the string without the trailing characters that are in
+/// the given string.
+pub fn View::trim_right(self : View, char_set : View) -> View {
+  loop self {
+    [] as v => v
+    [.. rest, c] as v =>
+      if char_set.contains_char(c) {
+        continue rest
+      } else {
+        v
+      }
+  }
+}
+
+///|
+/// Returns the view of the string without the trailing characters that are in
+/// the given string.
+pub fn String::trim_right(self : String, char_set : View) -> View {
+  self.view().trim_right(char_set)
+}
+
+///|
+test "trim_right" {
+  inspect!("hello".trim_end(['o']), content="hell")
+  inspect!("hello".trim_end(['l', 'o']), content="he")
+  inspect!("hello".trim_end(['x']), content="hello")
+  inspect!("hello".trim_end([]), content="hello")
+  inspect!("".trim_end(['a']), content="")
+  inspect!("hello   ".trim_end([' ']), content="hello")
+  inspect!("hello world".trim_end(['d', 'l', 'r', 'o', 'w', ' ']), content="he")
+  inspect!("hello😀😀".trim_end(['😀']), content="hello")
+  inspect!("hello😀😃".trim_end(['😀', '😃']), content="hello")
+  inspect!("abcccc".trim_end(['c']), content="ab")
+  inspect!("cccc".trim_end(['c']), content="")
+}
+
+///|
+/// Returns the view of the string without the leading and trailing characters
+/// that are in the given string.
+pub fn View::trim(self : View, char_set : View) -> View {
+  self.trim_left(char_set).trim_right(char_set)
+}
+
+///|
+test "trim" {
+  inspect!("hello".trim(['h']), content="ello")
+  inspect!("hello".trim(['o']), content="hell")
+  inspect!("hello".trim(['h', 'o']), content="ell")
+  inspect!("hello".trim(['o', 'h']), content="ell")
+  inspect!("hello".trim(['x']), content="hello")
+  inspect!("hello".trim([]), content="hello")
+  inspect!("".trim(['a']), content="")
+  inspect!("   hello   ".trim([' ']), content="hello")
+  inspect!("hello world".trim(['h', 'd']), content="ello worl")
+  inspect!("😀hello😀".trim(['😀']), content="hello")
+  inspect!("😀😃hello😀😃".trim(['😀', '😃']), content="hello")
+  inspect!("aaaabcaaa".trim(['a']), content="bc")
+  inspect!("aaaa".trim(['a']), content="")
+  inspect!("  hello world  ".trim([' ']), content="hello world")
+  inspect!("abcabc".trim(['a', 'b', 'c']), content="")
+}
+
+///| 
+/// Returns the view of the string without the leading and trailing spaces.
+pub fn View::trim_space(self : View) -> View {
+  self.trim(" \n\r\t".view())
+}
+
+// todo: add the method `trim_space` for String when the deprecated `trim_space`
+// is removed
+
+///|
+test "trim_space" {
+  inspect!("hello".trim_space(), content="hello")
+  inspect!("  hello  ".trim_space(), content="hello")
+  inspect!("hello  ".trim_space(), content="hello")
+  inspect!("  hello".trim_space(), content="hello")
+  inspect!("\t\nhello\r\n".trim_space(), content="hello")
+  inspect!("  hello world  ".trim_space(), content="hello world")
+  inspect!("  ".trim_space(), content="")
+  inspect!("\n\r\t".trim_space(), content="")
+  inspect!("".trim_space(), content="")
+  inspect!("  hello\nworld\t".trim_space(), content="hello\nworld")
+}
+
+///|
+/// Returns true if this string is empty.
+pub fn View::is_empty(self : View) -> Bool {
+  self.len() == 0
+}
+
+///|
+/// Returns true if this string is empty.
+pub fn String::is_empty(self : String) -> Bool {
+  self == ""
+}
+
+///|
+#deprecated("Use `str.is_empty()` instead.")
+pub fn is_empty(str : String) -> Bool {
+  str.is_empty()
+}
+
+///|
+test "is_empty" {
+  inspect!("".is_empty(), content="true")
+  inspect!("hello".is_empty(), content="false")
+  inspect!(" ".is_empty(), content="false")
+  inspect!("\n".is_empty(), content="false")
+  inspect!("\t".is_empty(), content="false")
+  inspect!("   ".is_empty(), content="false")
+
+  // Test with string views
+  let s = "hello"
+  let empty_view = s[0:0]
+  let non_empty_view = s[0:3]
+  inspect!(empty_view.is_empty(), content="true")
+  inspect!(non_empty_view.is_empty(), content="false")
+}
+
+///|
+/// Returns true if this string is blank.
+pub fn View::is_blank(self : View) -> Bool {
+  self.trim_space().is_empty()
+}
+
+///|
+/// Returns true if this string is blank.
+pub fn String::is_blank(self : String) -> Bool {
+  self.view().is_blank()
+}
+
+///|
+#deprecated("Use `str.is_blank()` instead.")
+pub fn is_blank(str : String) -> Bool {
+  str.is_blank()
+}
+
+///|
+test "is_blank" {
+  inspect!("".is_blank(), content="true")
+  inspect!("hello".is_blank(), content="false")
+  inspect!(" ".is_blank(), content="true")
+  inspect!("\n".is_blank(), content="true")
+  inspect!("\t".is_blank(), content="true")
+  inspect!("   ".is_blank(), content="true")
+  inspect!(" \n\t\r ".is_blank(), content="true")
+  inspect!("hello world".is_blank(), content="false")
+  inspect!("  hello  ".is_blank(), content="false")
+
+  // Test with string views
+  let s = "   hello  "
+  let blank_view = s[0:3] // "   "
+  let non_blank_view = s[3:8] // "hello"
+  inspect!(blank_view.is_blank(), content="true")
+  inspect!(non_blank_view.is_blank(), content="false")
+}
+
+///|
+/// Returns a new string with `padding_char`s prefixed to `self` if
+/// `self.char_length() < total_width`. The number of unicode characters in
+/// the returned string is `total_width` if padding is added.
+pub fn View::pad_start(
+  self : View,
+  total_width : Int,
+  padding_char : Char
+) -> View {
+  let len = self.char_length()
+  guard len < total_width else { return self }
+  let padding = String::make(total_width - len, padding_char)
+  [..padding, ..self]
+}
+
+// todo: add the method `pad_start` for String when the deprecated `pad_start` is
+// removed
+
+///|
+test "pad_start" {
+  // Test with regular strings
+  inspect!("2".pad_start(3, '0'), content="002")
+  inspect!("abc".pad_start(5, 'x'), content="xxabc")
+  inspect!("hello".pad_start(4, ' '), content="hello") // No padding needed
+  inspect!("".pad_start(3, '-'), content="---")
+
+  // Test with different padding characters
+  inspect!("test".pad_start(8, '*'), content="****test")
+  inspect!("123".pad_start(6, '0'), content="000123")
+
+  // Test with string views
+  let s = "hello"
+  let view = s[2:5] // "llo"
+  inspect!(view.pad_start(5, 'x'), content="xxllo")
+
+  // Test with Unicode characters
+  inspect!("🌟".pad_start(3, '✨'), content="✨✨🌟")
+
+  // Edge cases
+  inspect!("abc".pad_start(0, 'x'), content="abc") // width less than string length
+  inspect!("abc".pad_start(3, 'x'), content="abc") // width equal to string length
+}
+
+///|
+/// Returns a new string with `padding_char`s appended to `self` if
+/// `self.length() < total_width`. The number of unicode characters in
+/// the returned string is `total_width` if padding is added.
+pub fn View::pad_end(
+  self : View,
+  total_width : Int,
+  padding_char : Char
+) -> View {
+  let len = self.char_length()
+  guard len < total_width else { return self }
+  let padding = String::make(total_width - len, padding_char)
+  [..self, ..padding]
+}
+
+// todo: add the method `pad_end` for String when the deprecated `pad_end` is
+// removed
+
+///|
+test "pad_end" {
+  // Test with regular strings
+  inspect!("2".pad_end(3, '0'), content="200")
+  inspect!("abc".pad_end(5, 'x'), content="abcxx")
+  inspect!("hello".pad_end(4, ' '), content="hello") // No padding needed
+  inspect!("".pad_end(3, '-'), content="---")
+
+  // Test with different padding characters
+  inspect!("test".pad_end(8, '*'), content="test****")
+  inspect!("123".pad_end(6, '0'), content="123000")
+
+  // Test with string views
+  let s = "hello"
+  let view = s[2:5] // "llo"
+  inspect!(view.pad_end(5, 'x'), content="lloxx")
+
+  // Test with Unicode characters
+  inspect!("🌟".pad_end(3, '✨'), content="🌟✨✨")
+
+  // Edge cases
+  inspect!("abc".pad_end(0, 'x'), content="abc") // width less than string length
+  inspect!("abc".pad_end(3, 'x'), content="abc") // width equal to string length
+}
+
+///|
+/// Returns a new string with `self` repeated `n` times.
+pub fn View::repeat(self : View, n : Int) -> View {
+  match n {
+    _..=0 => ""
+    1 => self
+    _ => {
+      let len = self.len()
+      let buf = StringBuilder::new(size_hint=len * n)
+      let str = self.to_string()
+      for _ in 0..<n {
+        buf.write_string(str)
+      }
+      buf.to_string()
+    }
+  }
+}
+
+///|
+test "repeat" {
+  // Test with regular strings
+  inspect!("abc".repeat(3), content="abcabcabc")
+  inspect!("x".repeat(5), content="xxxxx")
+  inspect!("hello ".repeat(2), content="hello hello ")
+
+  // Test with empty string
+  inspect!("".repeat(10), content="")
+
+  // Test with string views
+  let s = "hello world"
+  let view = s[6:11] // "world"
+  inspect!(view.repeat(2), content="worldworld")
+
+  // Test with Unicode characters
+  inspect!("🌟".repeat(3), content="🌟🌟🌟")
+  inspect!("✨🌟".repeat(2), content="✨🌟✨🌟")
+
+  // Edge cases
+  inspect!("abc".repeat(0), content="")
+  inspect!("abc".repeat(-5), content="")
+  inspect!("abc".repeat(1), content="abc")
+}
+
+///|
+/// Returns a new string with the characters in reverse order. It respects
+/// Unicode characters and surrogate pairs but not grapheme clusters.
+pub fn View::rev(self : View) -> View {
+  let buf = StringBuilder::new(size_hint=self.len())
+  for c in self.rev_iter() {
+    buf.write_char(c)
+  }
+  buf.to_string()
+}
+
+///|
+test "rev" {
+  inspect!("hello".rev(), content="olleh")
+  inspect!("".rev(), content="")
+  inspect!("abc".rev(), content="cba")
+  inspect!("😀😃".rev(), content="😃😀")
+}
+
+///|
+/// Splits the string into all substrings separated by the given separator.
+/// 
+/// If the string does not contain the separator and the separator is not empty,
+/// the returned iterator will contain only one element, which is the original
+/// string.
+/// 
+/// If the separator is empty, the returned iterator will contain all the
+/// characters in the string as single elements.
+pub fn View::split(self : View, sep : View) -> Iter[View] {
+  let sep_len = sep.len()
+  if sep_len == 0 {
+    return self.iter().map(fn(c) { [c] })
+  }
+  Iter::new(fn(yield_) {
+    let mut view = self
+    while view.find(sep) is Some(end) {
+      guard yield_(view.view(end_offset=end)) is IterContinue else {
+        break IterEnd
+      }
+      view = view.view(start_offset=end + sep_len)
+    } else {
+      if view.is_empty() {
+        IterContinue
+      } else {
+        yield_(view)
+      }
+    }
+  })
+}
+
+///|
+test "split" {
+  assert_eq!("a,b,c".split(",").collect(), ["a", "b", "c"])
+  assert_eq!("a,b,c".split("").collect(), ["a", ",", "b", ",", "c"])
+  assert_eq!("apple::orange::banana".split("::").collect(), [
+    "apple", "orange", "banana",
+  ])
+  assert_eq!("abc".split("").collect(), ["a", "b", "c"])
+  assert_eq!("hello".split(",").collect(), ["hello"])
+  assert_eq!(",a,b,c".split(",").collect(), ["", "a", "b", "c"])
+  assert_eq!("a,b,c,".split(",").collect(), ["a", "b", "c"])
+  assert_eq!("a,b,c".split("").collect(), ["a", ",", "b", ",", "c"])
+  assert_eq!("".split("").collect(), [])
+  assert_eq!("".split(",").collect(), [])
+  assert_eq!("😀,😃,😄".split(",").collect(), ["😀", "😃", "😄"])
+  assert_eq!("a😀b😀c".split("😀").collect(), ["a", "b", "c"])
+}
+
+///|
+/// Replaces the first occurrence of `old` with `new` in `self`.
+/// 
+/// If `old` is empty, it matches the beginning of the string, and `new` is
+/// prepended to the string.
+pub fn View::replace(self : View, old~ : View, new~ : View) -> View {
+  match self.find(old) {
+    Some(end) =>
+      [
+        ..self.view(end_offset=end),
+        ..new,
+        ..self.view(start_offset=end + old.len()),
+      ]
+    None => self
+  }
+}
+
+///|
+test "replace" {
+  assert_eq!("hello".replace(old="o", new="a"), "hella")
+  assert_eq!("hello".replace(old="l", new="a"), "healo")
+  assert_eq!("hello".replace(old="hello", new="a"), "a")
+  assert_eq!("hello".replace(old="h", new="a"), "aello")
+  assert_eq!("hello".replace(old="", new="a"), "ahello")
+  assert_eq!("hello".replace(old="world", new="a"), "hello")
+  assert_eq!("".replace(old="", new="a"), "a")
+}
+
+///|
+/// Replaces all non-overlapping occurrences of `old` with `new` in `self`.
+/// 
+/// If `old` is empty, it matches at the beginning of the string and after each
+/// character in the string, so `new` is inserted at the beginning of the string
+/// and after each character.
+pub fn View::replace_all(self : View, old~ : View, new~ : View) -> View {
+  let buf = StringBuilder::new(size_hint=self.len())
+  let len = self.len()
+  let old_len = old.len()
+  // todo: improve performance
+  if old_len == 0 {
+    buf.write_string(new.to_string())
+    self
+    .iter()
+    .each(fn(c) {
+      buf.write_char(c)
+      buf.write_string(new.to_string())
+    })
+  } else {
+    let mut view = self
+    while view.find(old) is Some(end) {
+      buf.write_string(view.view(end_offset=end).to_string())
+      buf.write_string(new.to_string())
+      if end + old_len <= len {
+        view = view.view(start_offset=end + old_len)
+      } else {
+        break
+      }
+    }
+    buf.write_string(view.to_string())
+  }
+  buf.to_string()
+}
+
+///|
+test "replace_all" {
+  assert_eq!("hello".replace_all(old="o", new="a"), "hella")
+  assert_eq!("hello".replace_all(old="l", new="a"), "heaao")
+  assert_eq!("hello".replace_all(old="ll", new="rr"), "herro")
+  assert_eq!("hello".replace_all(old="hello", new="world"), "world")
+  assert_eq!("hello hello hello".replace_all(old="hello", new="hi"), "hi hi hi")
+  assert_eq!("hello".replace_all(old="", new="a"), "ahaealalaoa")
+  assert_eq!("hello".replace_all(old="world", new="a"), "hello")
+  assert_eq!("".replace_all(old="", new="a"), "a")
+  assert_eq!("aaa".replace_all(old="a", new="b"), "bbb")
+  assert_eq!("aaa".replace_all(old="a", new="bb"), "bbbbbb")
+  assert_eq!("aaa".replace_all(old="aa", new="b"), "ba")
+  assert_eq!("🤣🤣🤣".replace_all(old="🤣", new="😊"), "😊😊😊")
+  assert_eq!("abc123abc".replace_all(old="abc", new="xyz"), "xyz123xyz")
+  assert_eq!("abcabcabc".replace_all(old="abc", new=""), "")
+  assert_eq!("abc".replace_all(old="abc", new=""), "")
+  assert_eq!("abc".replace_all(old="", new="x"), "xaxbxcx")
+}
+
+///|
+/// Converts this string to lowercase.
+pub fn View::to_lower(self : View) -> View {
+  // TODO: deal with non-ascii characters
+  let buf = StringBuilder::new(size_hint=self.len())
+  for c in self {
+    if c >= 'A' && c <= 'Z' {
+      buf.write_char(Char::from_int(c.to_int() + 32))
+    } else {
+      buf.write_char(c)
+    }
+  }
+  buf.to_string()
+}
+
+///|
+test "to_lower" {
+  assert_eq!("Hello".to_lower(), "hello")
+  assert_eq!("HELLO".to_lower(), "hello")
+  assert_eq!("Hello, World!".to_lower(), "hello, world!")
+}
+
+///|
+/// Converts this string to uppercase.
+pub fn View::to_upper(self : View) -> View {
+  // TODO: deal with non-ascii characters
+  let buf = StringBuilder::new(size_hint=self.len())
+  for c in self {
+    if c >= 'a' && c <= 'z' {
+      buf.write_char(Char::from_int(c.to_int() - 32))
+    } else {
+      buf.write_char(c)
+    }
+  }
+  buf.to_string()
+}
+
+///|
+test "to_upper" {
+  assert_eq!("hello".to_upper(), "HELLO")
+  assert_eq!("HELLO".to_upper(), "HELLO")
+  assert_eq!("Hello, World!".to_upper(), "HELLO, WORLD!")
+}
+
+///|
+/// Folds the characters of the string into a single value.
+pub fn View::fold[A](self : View, init~ : A, f : (A, Char) -> A) -> A {
+  let mut rv = init
+  for c in self {
+    rv = f(rv, c)
+  }
+  rv
+}
+
+///| Folds the characters of the string into a single value.
+pub fn String::fold[A](self : String, init~ : A, f : (A, Char) -> A) -> A {
+  self.view().fold(init~, f)
+}
+
+///|
+#deprecated("Use `str.fold(init~, f)` instead.")
+pub fn fold[A](s : String, init~ : A, f : (A, Char) -> A) -> A {
+  s.view().fold(init~, f)
+}
+
+///|
+test "fold" {
+  assert_eq!("hello".fold(init=[], fn(acc, c) { acc..push(c) }), [
+    'h', 'e', 'l', 'l', 'o',
+  ])
+  assert_eq!(
+    "hello".fold(init=0, fn(acc, c) { acc + c.to_int() }),
+    104 + 101 + 108 + 108 + 111,
+  )
+}
+
+///|
+pub fn View::rev_fold[A](self : View, init~ : A, f : (A, Char) -> A) -> A {
+  let mut rv = init
+  for c in self.rev_iter() {
+    rv = f(rv, c)
+  }
+  rv
+}
+
+///|
+pub fn String::rev_fold[A](self : String, init~ : A, f : (A, Char) -> A) -> A {
+  self.view().rev_fold(init~, f)
+}
+
+///|
+#deprecated("Use `str.rev_fold(init~, f)` instead.")
+pub fn rev_fold[A](s : String, init~ : A, f : (A, Char) -> A) -> A {
+  s.view().rev_fold(init~, f)
+}
+
+///|
+test "rev_fold" {
+  assert_eq!("hello".rev_fold(init=[], fn(acc, c) { acc..push(c) }), [
+    'o', 'l', 'l', 'e', 'h',
+  ])
+  assert_eq!(
+    "hello".rev_fold(init=0, fn(acc, c) { acc + c.to_int() }),
+    111 + 108 + 108 + 101 + 104,
+  )
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -32,6 +32,7 @@ pub fn String::from_array(chars : Array[Char]) -> String {
 }
 
 ///| same as `String::from_array`
+#deprecated("Use `String::from_array(chars)` instead.")
 pub fn from_array(chars : Array[Char]) -> String {
   String::from_array(chars)
 }
@@ -46,6 +47,7 @@ pub fn String::from_iter(iter : Iter[Char]) -> String {
 
 ///|
 /// same as `String::from_iter`
+#deprecated("Use `String::from_iter(iter)` instead.")
 pub fn from_iter(iter : Iter[Char]) -> String {
   let chars = iter.collect()
   String::from_array(chars)
@@ -117,25 +119,23 @@ pub impl Default for String with default() {
 
 ///|
 /// same as `String::default`
+#deprecated("Use `String::default()` instead.")
 pub fn default() -> String {
   ""
 }
 
 ///|
 /// `String` holds a sequence of UTF-16 code units encoded in little endian format
+#deprecated("Use `Bytes::of_string(str)` instead.")
 pub fn to_bytes(self : String) -> Bytes {
   Bytes::of_string(self)
 }
 
 ///|
 /// Converts the String into an array of Chars.
+#deprecated("Use `str.iter().collect()` instead.")
 pub fn to_array(self : String) -> Array[Char] {
-  self
-  .iter()
-  .fold(init=Array::new(capacity=self.length()), fn(rv, c) {
-    rv.push(c)
-    rv
-  })
+  self.iter().collect()
 }
 
 ///|
@@ -149,7 +149,7 @@ pub fn to_array(self : String) -> Array[Char] {
 /// assert_eq!(s.iter().count(), 14); // Unicode characters
 /// assert_eq!(s.length(), 15); // Utf16 code units
 /// ```
-pub fn iter(self : String) -> Iter[Char] {
+pub fn String::iter(self : String) -> Iter[Char] {
   Iter::new(fn(yield_) {
     let len = self.length()
     for index in 0..<len {
@@ -172,7 +172,13 @@ pub fn iter(self : String) -> Iter[Char] {
 }
 
 ///|
-pub fn iter2(self : String) -> Iter2[Int, Char] {
+#deprecated("Use `str.iter()` instead.")
+pub fn iter(s : String) -> Iter[Char] {
+  s.iter()
+}
+
+///|
+pub fn String::iter2(self : String) -> Iter2[Int, Char] {
   Iter2::new(fn(yield_) {
     let len = self.length()
     for index = 0, n = 0; index < len; index = index + 1, n = n + 1 {
@@ -195,23 +201,9 @@ pub fn iter2(self : String) -> Iter2[Int, Char] {
 }
 
 ///|
-/// Note: This method operates on Unicode characters, not Utf16 code units.
-/// As a result, the count of characters passed to the folding function may not be equal to the length of the string.
-pub fn fold[A](self : String, init~ : A, f : (A, Char) -> A) -> A {
-  let mut rv = init
-  for c in self {
-    rv = f(rv, c)
-  }
-  rv
-}
-
-///|
-pub fn rev_fold[A](self : String, init~ : A, f : (A, Char) -> A) -> A {
-  let mut rv = init
-  for c in self.rev_iter() {
-    rv = f(rv, c)
-  }
-  rv
+#deprecated("Use `str.iter2()` instead.")
+pub fn iter2(s : String) -> Iter2[Int, Char] {
+  s.iter2()
 }
 
 ///|
@@ -240,7 +232,7 @@ pub fn rev_fold[A](self : String, init~ : A, f : (A, Char) -> A) -> A {
 /// let reversed = input.rev_iter().collect()
 /// assert_eq!(reversed, ['!', 'd', 'l', 'r', 'o', 'W', ' ', ',', 'o', 'l', 'l', 'e', 'H'])
 /// ```
-pub fn rev_iter(self : String) -> Iter[Char] {
+pub fn String::rev_iter(self : String) -> Iter[Char] {
   Iter::new(fn(yield_) {
     let len = self.length()
     for index = len - 1; index >= 0; index = index - 1 {
@@ -263,216 +255,103 @@ pub fn rev_iter(self : String) -> Iter[Char] {
 }
 
 ///|
-/// Removes all leading and trailing spaces.
+#deprecated("Use `str.rev_iter()` instead.")
+pub fn rev_iter(s : String) -> Iter[Char] {
+  s.rev_iter()
+}
+
+///|
+#deprecated("Use `str.view().trim_space().to_string()` instead.")
 pub fn trim_space(self : String) -> String {
-  self.trim(" \n\r\t")
+  self.view().trim_space().to_string()
 }
 
 ///|
-/// Removes all leading and trailing chars contained in the given string.
+#deprecated("Use `str.view().trim(trim_set).to_string()` instead.")
 pub fn trim(self : String, trim_set : String) -> String {
-  if self == "" || trim_set == "" {
-    self
-  } else {
-    self.trim_start(trim_set).trim_end(trim_set)
-  }
+  self.view().trim(trim_set).to_string()
 }
 
 ///|
-pub fn contains_char(self : String, c : Char) -> Bool {
-  self.iter().any(fn(ch) { ch == c })
-}
-
-///|
-/// Removes all leading chars contained in the given string.
+#deprecated("Use `str.trim_left(trim_set).to_string()` instead.")
 pub fn trim_start(self : String, trim_set : String) -> String {
-  let len = self.length()
-  for i in 0..<len {
-    let c1 = self.unsafe_charcode_at(i)
-    // check surrogate pair
-    if is_leading_surrogate(c1) && i + 1 < len {
-      let c2 = self.unsafe_charcode_at(i + 1)
-      if is_trailing_surrogate(c2) {
-        let ch = code_point_of_surrogate_pair(c1, c2)
-        if trim_set.contains_char(ch) {
-          continue i + 2
-        } else {
-          return self.substring(start=i)
-        }
-      }
-    }
-    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
-      return self.substring(start=i)
-    }
-  } else {
-    ""
-  }
+  self.trim_left(trim_set).to_string()
 }
 
 ///|
-/// Removes all trailing chars contained in the given string.
+#deprecated("Use `str.trim_right(trim_set).to_string()` instead.")
 pub fn trim_end(self : String, trim_set : String) -> String {
-  let len = self.length()
-  for i = len - 1; i >= 0; i = i - 1 {
-    let c2 = self.unsafe_charcode_at(i)
-    // check surrogate pair
-    if is_trailing_surrogate(c2) && i - 1 >= 0 {
-      let c1 = self.unsafe_charcode_at(i - 1)
-      if is_leading_surrogate(c1) {
-        let ch = code_point_of_surrogate_pair(c1, c2)
-        if trim_set.contains_char(ch) {
-          continue i - 2
-        } else {
-          return self.substring(end=i + 1)
-        }
-      }
-    }
-    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
-      return self.substring(end=i + 1)
-    }
-  } else {
-    ""
-  }
+  self.trim_right(trim_set).to_string()
 }
 
 ///|
-/// Returns true if this string is empty.
-pub fn is_empty(self : String) -> Bool {
-  self == ""
-}
-
-///|
-/// Returns true if this string is blank.
-pub fn is_blank(self : String) -> Bool {
-  self.trim_space() == ""
-}
-
-///|
-/// Returns the first index of the sub string.
+#deprecated("Use `s.find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
 pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
-  let len = self.length()
-  let sub_len = str.length()
-
-  // Handle empty substring case
-  if sub_len == 0 {
-    // Return 0 for empty string in empty string
-    if len == 0 {
-      return 0
+  if from <= 0 {
+    if self.find(str.view()) is Some(idx) {
+      idx
+    } else {
+      -1
     }
-    // Bound from within valid range and return it
-    return if from < 0 { 0 } else if from >= len { len } else { from }
-  }
-
-  // If substring is longer than string, it can't be found
-  if sub_len > len {
-    return -1
-  }
-
-  // Bound the starting position
-  let from = if from < 0 { 0 } else if from >= len { len - 1 } else { from }
-  let max_idx = len - sub_len
-  let first = str.unsafe_charcode_at(0)
-  let mut i = from
-  while i <= max_idx {
-    // find first character
-    while i < len && self.unsafe_charcode_at(i) != first {
-      i += 1
+  } else if from > self.length() {
+    if str.length() == 0 {
+      self.length()
+    } else {
+      -1
     }
-    // check the rest
-    if i <= max_idx {
-      for j in 1..<sub_len {
-        if self.unsafe_charcode_at(i + j) != str.unsafe_charcode_at(j) {
-          break
-        }
-      } else {
-        // the substring is found
-        return i
-      }
-    }
-    i += 1
+  } else if self.view(start_offset=from).find(str.view()) is Some(idx) {
+    idx + from
+  } else {
+    -1
   }
-  -1
 }
 
 ///|
 /// Returns the last index of the sub string.
+#deprecated("Use `s.rfind(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
 pub fn last_index_of(
   self : String,
   str : String,
   from~ : Int = self.length()
 ) -> Int {
-  let from = if from < 0 {
-    0
-  } else if from > self.length() {
-    self.length()
-  } else {
-    from
-  }
-  let len = self.length()
-  let sub_len = str.length()
-  if sub_len == 0 {
-    return from
-  }
-  if len < sub_len {
-    return -1
-  }
-  let min = sub_len - 1
-  let last = str.unsafe_charcode_at(sub_len - 1)
-  let mut i = from - 1
-  while i >= 0 {
-    // find last character
-    while i >= min && self.unsafe_charcode_at(i) != last {
-      i -= 1
-    }
-    if i < min {
-      return -1
-    }
-    let mut j = i - 1
-    let mut k = sub_len - 2
-    let start = i - sub_len
-    let found = while j > start {
-      if self.unsafe_charcode_at(j) != str.unsafe_charcode_at(k) {
-        break false
-      }
-      j -= 1
-      k -= 1
+  if from >= self.length() {
+    if self.rfind(str.view()) is Some(idx) {
+      idx
     } else {
-      true
+      -1
     }
-    if found {
-      return start + 1
+  } else if from < 0 {
+    if str.length() == 0 {
+      self.length()
+    } else {
+      -1
     }
-    i -= 1
+  } else if self.view(end_offset=from).rfind(str.view()) is Some(idx) {
+    idx
+  } else {
+    -1
   }
-  -1
 }
 
 ///|
 /// Returns true if this string contains given sub string.
+#deprecated("Use `s.view().contains(str)` instead.")
 pub fn contains(self : String, str : String) -> Bool {
-  self.index_of(str) >= 0
+  self.view().contains(str)
 }
 
 ///|
 /// Returns true if this string starts with a sub string.
+#deprecated("Use `s.has_prefix(str)` instead.")
 pub fn starts_with(self : String, str : String) -> Bool {
-  if str.length() > self.length() {
-    false
-  } else {
-    self.index_of(str) == 0
-  }
+  self.has_prefix(str)
 }
 
 ///|
 /// Returns true if this string ends with a sub string.
+#deprecated("Use `s.has_suffix(str)` instead.")
 pub fn ends_with(self : String, str : String) -> Bool {
-  let len = self.length()
-  let sub_len = str.length()
-  if sub_len > len {
-    false
-  } else {
-    self.last_index_of(str) == len - sub_len
-  }
+  self.has_suffix(str)
 }
 
 ///|
@@ -501,132 +380,53 @@ pub fn ends_with(self : String, str : String) -> Bool {
 /// let result = input.split(separator).collect()
 /// assert_eq!(result, ["a", "b", "c", "d"])
 /// ```
+#deprecated("Use `str.view().split(sep).map(View::to_string)` instead.")
 pub fn split(self : String, separator : String) -> Iter[String] {
-  let len = self.length()
-  let sep_len = separator.length()
-  if sep_len == 0 {
-    return self.iter().map(fn(c) { c.to_string() })
-  }
-  Iter::new(fn(yield_) {
-    let mut start = 0
-    while start < len {
-      let end = self.index_of(separator, from=start)
-      if end < 0 {
-        if yield_(self.substring(start~)) == IterEnd {
-          break IterEnd
-        }
-        break IterContinue
-      }
-      if yield_(self.substring(start~, end~)) == IterEnd {
-        break IterEnd
-      }
-      start = end + sep_len
-    } else {
-      IterContinue
-    }
-  })
+  self.view().split(separator).map(View::to_string)
 }
 
 ///|
 /// Replace the first old string in this string to new string.
+#deprecated("Use `str.view().replace(old, new).to_string()` instead.")
 pub fn replace(self : String, old~ : String, new~ : String) -> String {
-  let old_idx = self.index_of(old)
-  if old_idx < 0 {
-    self
-  } else {
-    self.substring(end=old_idx) +
-    new +
-    self.substring(start=old_idx + old.length())
-  }
+  self.view().replace(old~, new~).to_string()
 }
 
 ///|
 /// Replace all old string in this string to new string.
+#deprecated("Use `str.view().replace_all(old, new).to_string()` instead.")
 pub fn replace_all(self : String, old~ : String, new~ : String) -> String {
-  let buf = StringBuilder::new()
-  let len = self.length()
-  let old_len = old.length()
-  if old_len == 0 {
-    buf.write_string(new)
-    self
-    .iter()
-    .each(fn(c) {
-      buf.write_char(c)
-      buf.write_string(new)
-    })
-  } else {
-    let mut start = 0
-    while start < len {
-      let end = self.index_of(old, from=start)
-      if end < 0 {
-        buf.write_string(self.substring(start~))
-        break
-      }
-      buf.write_string(self.substring(start~, end~))
-      buf.write_string(new)
-      start = end + old_len
-    }
-  }
-  buf.to_string()
+  self.view().replace_all(old~, new~).to_string()
 }
 
 ///|
 /// Converts this string to lowercase.
+#deprecated("Use `str.view().to_lower().to_string()` instead.")
 pub fn to_lower(self : String) -> String {
-  // TODO: deal with non-ascii characters
-  let buf = StringBuilder::new(size_hint=self.length())
-  for c in self {
-    if c >= 'A' && c <= 'Z' {
-      buf.write_char(Char::from_int(c.to_int() + 32))
-    } else {
-      buf.write_char(c)
-    }
-  }
-  buf.to_string()
+  self.view().to_lower().to_string()
 }
 
 ///|
 /// Converts this string to uppercase.
+#deprecated("Use `str.view().to_upper().to_string()` instead.")
 pub fn to_upper(self : String) -> String {
-  // TODO: deal with non-ascii characters
-  let buf = StringBuilder::new(size_hint=self.length())
-  for c in self {
-    if c >= 'a' && c <= 'z' {
-      buf.write_char(Char::from_int(c.to_int() - 32))
-    } else {
-      buf.write_char(c)
-    }
-  }
-  buf.to_string()
+  self.view().to_upper().to_string()
 }
 
 ///|
 /// Reverse string
 /// It respects Unicode characters and surrogate pairs but not grapheme clusters.
 /// TODO: make it an intrinsic function
+#deprecated("Use `str.view().rev().to_string()` instead.")
 pub fn rev(self : String) -> String {
-  let buf = StringBuilder::new(size_hint=self.length())
-  for c in self.rev_iter() {
-    buf.write_char(c)
-  }
-  buf.to_string()
+  self.view().rev().to_string()
 }
 
 ///|
 /// Repeats the string `n` times.
+#deprecated("Use `str.view().repeat(n).to_string()` instead.")
 pub fn repeat(self : String, n : Int) -> String {
-  if n <= 0 {
-    return ""
-  }
-  if n == 1 {
-    return self
-  }
-  let len = self.length()
-  let buf = StringBuilder::new(size_hint=len * n)
-  for _ in 0..<n {
-    buf.write_string(self)
-  }
-  buf.to_string()
+  self.view().repeat(n).to_string()
 }
 
 ///|
@@ -638,22 +438,13 @@ pub fn repeat(self : String, n : Int) -> String {
 /// ```
 /// assert_eq!("2".pad_start(3, '0'), "002")
 /// ```
+#deprecated("Use `str.view().pad_start(total_width, padding_char).to_string()` instead.")
 pub fn pad_start(
   self : String,
   total_width : Int,
   padding_char : Char
 ) -> String {
-  let len = self.length()
-  if len >= total_width {
-    self
-  } else {
-    let buf = StringBuilder::new(size_hint=total_width)
-    for i in 0..<(total_width - len) {
-      buf.write_char(padding_char)
-    }
-    buf.write_string(self)
-    buf.to_string()
-  }
+  self.view().pad_start(total_width, padding_char).to_string()
 }
 
 ///|
@@ -665,18 +456,9 @@ pub fn pad_start(
 /// ```
 /// assert_eq!("2".pad_end(3, 'x'), "2xx")
 /// ```
+#deprecated("Use `str.view().pad_end(total_width, padding_char).to_string()` instead.")
 pub fn pad_end(self : String, total_width : Int, padding_char : Char) -> String {
-  let len = self.length()
-  if len >= total_width {
-    self
-  } else {
-    let buf = StringBuilder::new(size_hint=total_width)
-    buf.write_string(self)
-    for i in 0..<(total_width - len) {
-      buf.write_char(padding_char)
-    }
-    buf.to_string()
-  }
+  self.view().pad_end(total_width, padding_char).to_string()
 }
 
 ///|

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -3,18 +3,25 @@ package "moonbitlang/core/string"
 // Values
 fn concat(Array[String], separator~ : String = ..) -> String
 
+#deprecated
 fn contains(String, String) -> Bool
 
+#deprecated
 fn contains_char(String, Char) -> Bool
 
+#deprecated
 fn default() -> String
 
+#deprecated
 fn ends_with(String, String) -> Bool
 
+#deprecated
 fn fold[A](String, init~ : A, (A, Char) -> A) -> A
 
+#deprecated
 fn from_array(Array[Char]) -> String
 
+#deprecated
 fn from_iter(Iter[Char]) -> String
 
 #deprecated
@@ -23,16 +30,22 @@ fn index_at(String, Int, start~ : StringIndex = ..) -> StringIndex?
 #deprecated
 fn index_at_rev(String, Int, end? : StringIndex) -> StringIndex?
 
+#deprecated
 fn index_of(String, String, from~ : Int = ..) -> Int
 
+#deprecated
 fn is_blank(String) -> Bool
 
+#deprecated
 fn is_empty(String) -> Bool
 
+#deprecated
 fn iter(String) -> Iter[Char]
 
+#deprecated
 fn iter2(String) -> Iter2[Int, Char]
 
+#deprecated
 fn last_index_of(String, String, from~ : Int = ..) -> Int
 
 #deprecated
@@ -41,43 +54,61 @@ fn length_eq(StringView, Int) -> Bool
 #deprecated
 fn length_ge(StringView, Int) -> Bool
 
+#deprecated
 fn pad_end(String, Int, Char) -> String
 
+#deprecated
 fn pad_start(String, Int, Char) -> String
 
+#deprecated
 fn repeat(String, Int) -> String
 
+#deprecated
 fn replace(String, old~ : String, new~ : String) -> String
 
+#deprecated
 fn replace_all(String, old~ : String, new~ : String) -> String
 
+#deprecated
 fn rev(String) -> String
 
+#deprecated
 fn rev_fold[A](String, init~ : A, (A, Char) -> A) -> A
 
 #deprecated
 fn rev_get(StringView, Int) -> Char
 
+#deprecated
 fn rev_iter(String) -> Iter[Char]
 
+#deprecated
 fn split(String, String) -> Iter[String]
 
+#deprecated
 fn starts_with(String, String) -> Bool
 
+#deprecated
 fn to_array(String) -> Array[Char]
 
+#deprecated
 fn to_bytes(String) -> Bytes
 
+#deprecated
 fn to_lower(String) -> String
 
+#deprecated
 fn to_upper(String) -> String
 
+#deprecated
 fn trim(String, String) -> String
 
+#deprecated
 fn trim_end(String, String) -> String
 
+#deprecated
 fn trim_space(String) -> String
 
+#deprecated
 fn trim_start(String, String) -> String
 
 // Types and methods
@@ -92,6 +123,16 @@ impl StringView {
   char_length_eq(Self, Int) -> Bool
   char_length_ge(Self, Int) -> Bool
   charcode_at(Self, Int) -> Int
+  contains(Self, Self) -> Bool
+  contains_char(Self, Char) -> Bool
+  find(Self, Self) -> Int?
+  fold[A](Self, init~ : A, (A, Char) -> A) -> A
+  from_array(Array[Char]) -> Self
+  from_iter(Iter[Char]) -> Self
+  has_prefix(Self, Self) -> Bool
+  has_suffix(Self, Self) -> Bool
+  is_blank(Self) -> Bool
+  is_empty(Self) -> Bool
   iter(Self) -> Iter[Char]
   #deprecated
   length(Self) -> Int
@@ -99,16 +140,35 @@ impl StringView {
   length_eq(Self, Int) -> Bool
   #deprecated
   length_ge(Self, Int) -> Bool
+  make(Int, Char) -> Self
   offset_of_nth_char(Self, Int) -> Int?
   #deprecated
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
   #deprecated
   op_get(Self, Int) -> Char
+  pad_end(Self, Int, Char) -> Self
+  pad_start(Self, Int, Char) -> Self
+  repeat(Self, Int) -> Self
+  replace(Self, old~ : Self, new~ : Self) -> Self
+  replace_all(Self, old~ : Self, new~ : Self) -> Self
+  rev(Self) -> Self
+  rev_fold[A](Self, init~ : A, (A, Char) -> A) -> A
   #deprecated
   rev_get(Self, Int) -> Char
   rev_iter(Self) -> Iter[Char]
+  rfind(Self, Self) -> Int?
+  split(Self, Self) -> Iter[Self]
+  to_lower(Self) -> Self
+  to_upper(Self) -> Self
+  trim(Self, Self) -> Self
+  trim_left(Self, Self) -> Self
+  trim_right(Self, Self) -> Self
+  trim_space(Self) -> Self
+  unsafe_charcode_at(Self, Int) -> Int
+  view(Self, start_offset~ : Int = .., end_offset~ : Int = ..) -> Self
 }
 impl Compare for StringView
+impl Default for StringView
 impl Eq for StringView
 impl Show for StringView
 
@@ -118,21 +178,28 @@ impl String {
   char_length_ge(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
   #deprecated
   concat(Array[String], separator~ : String = ..) -> String
+  #deprecated
   contains(String, String) -> Bool
   contains_char(String, Char) -> Bool
+  #deprecated
   ends_with(String, String) -> Bool
+  find(String, StringView) -> Int?
   fold[A](String, init~ : A, (A, Char) -> A) -> A
   from_array(Array[Char]) -> String
   from_iter(Iter[Char]) -> String
+  has_prefix(String, StringView) -> Bool
+  has_suffix(String, StringView) -> Bool
   #deprecated
   index_at(String, Int, start~ : StringIndex = ..) -> StringIndex?
   #deprecated
   index_at_rev(String, Int, end? : StringIndex) -> StringIndex?
+  #deprecated
   index_of(String, String, from~ : Int = ..) -> Int
   is_blank(String) -> Bool
   is_empty(String) -> Bool
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
+  #deprecated
   last_index_of(String, String, from~ : Int = ..) -> Int
   #deprecated
   length_eq(String, Int) -> Bool
@@ -141,25 +208,44 @@ impl String {
   offset_of_nth_char(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int?
   #deprecated
   op_as_view(String, start~ : Int = .., end? : Int) -> StringView
+  #deprecated
   pad_end(String, Int, Char) -> String
+  #deprecated
   pad_start(String, Int, Char) -> String
+  #deprecated
   repeat(String, Int) -> String
+  #deprecated
   replace(String, old~ : String, new~ : String) -> String
+  #deprecated
   replace_all(String, old~ : String, new~ : String) -> String
+  #deprecated
   rev(String) -> String
   rev_fold[A](String, init~ : A, (A, Char) -> A) -> A
   #deprecated
   rev_get(String, Int) -> Char
   rev_iter(String) -> Iter[Char]
+  rfind(String, StringView) -> Int?
+  #deprecated
   split(String, String) -> Iter[String]
+  #deprecated
   starts_with(String, String) -> Bool
+  #deprecated
   to_array(String) -> Array[Char]
+  #deprecated
   to_bytes(String) -> Bytes
+  #deprecated
   to_lower(String) -> String
+  #deprecated
   to_upper(String) -> String
+  #deprecated
   trim(String, String) -> String
+  #deprecated
   trim_end(String, String) -> String
+  trim_left(String, StringView) -> StringView
+  trim_right(String, StringView) -> StringView
+  #deprecated
   trim_space(String) -> String
+  #deprecated
   trim_start(String, String) -> String
   view(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> StringView
 }

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -74,6 +74,25 @@ pub fn String::view(
 }
 
 ///|
+/// Returns a new view of the string with the given start and end offsets.
+pub fn View::view(
+  self : View,
+  start_offset~ : Int = 0,
+  end_offset~ : Int = self.len()
+) -> View {
+  guard start_offset >= 0 &&
+    start_offset <= end_offset &&
+    end_offset <= self.len() else {
+    abort("Invalid index for View")
+  }
+  {
+    str: self.str,
+    start: self.start + start_offset,
+    end: self.start + end_offset,
+  }
+}
+
+///|
 /// Returns the UTF-16 index of the i-th (zero-indexed) Unicode character of
 /// the view. If i is negative, it returns the index of the (n + i)-th character
 /// where n is the total number of Unicode characters in the view.
@@ -91,14 +110,29 @@ pub fn View::offset_of_nth_char(self : View, i : Int) -> Int? {
 }
 
 ///|
+/// Returns the Unicode character at the given index.
+/// 
+/// This method has O(n) complexity.
 pub fn View::char_at(self : View, index : Int) -> Char {
   guard index >= 0 && index < self.len() else { abort("Index out of bounds") }
   self.str.unsafe_char_at(self.start + index)
 }
 
 ///|
+/// Returns the charcode(code unit) at the given index.
+/// 
+/// This method has O(1) complexity.
 pub fn View::charcode_at(self : View, index : Int) -> Int {
   guard index >= 0 && index < self.len() else { abort("Index out of bounds") }
+  self.str.unsafe_charcode_at(self.start + index)
+}
+
+///|
+/// Returns the charcode(code unit) at the given index without checking if the
+/// index is within bounds.
+/// 
+/// This method has O(1) complexity.
+pub fn View::unsafe_charcode_at(self : View, index : Int) -> Int {
   self.str.unsafe_charcode_at(self.start + index)
 }
 
@@ -231,4 +265,28 @@ pub impl Compare for View with compare(self, other) {
 
   }
   0
+}
+
+///|
+/// The empty view of a string
+pub impl Default for View with default() {
+  ""
+}
+
+///|
+/// Convert char array to string view.
+pub fn View::from_array(chars : Array[Char]) -> View {
+  String::from_array(chars)
+}
+
+///|
+/// Convert char iterator to string view.
+pub fn View::from_iter(iter : Iter[Char]) -> View {
+  String::from_iter(iter)
+}
+
+///|
+/// Create a new string by repeating the given character `value` `length` times.
+pub fn View::make(length : Int, value : Char) -> View {
+  String::make(length, value)
 }


### PR DESCRIPTION
This PR significantly refactors the string package by using the View type whenever possible. The other packages should follow this as well. Currently there might performance regression caused by converting between String and View, but eventually we expect View to be used ubiquitously and String is only used for FFI boundaries. 

We will try to smooth the migration by providing implicit conversion from String to View when the expected type is View. However, method invocations cannot benefit from this conversion so all the methods will have two copies, one for String and the other for View.

There are four kinds of APIs changes:

* Both name and type are changed. Old API deprecated, new API added for both View and String. 
    * `s.ends_with(substr: String) -> Bool` -> `s.has_suffix(substr: View) -> Bool`
    * `s.starts_with(substr: String) -> Bool` -> `s.has_prefix(substr: View) -> Bool`
    * `s.index_of(substr: String, from~: Int) -> Int` -> `s.find(substr: View) -> Option[Int]`. We cannot use the word `index` here because we call it `offset` for utf16 index
    *  `s.last_index_of(substr: String, from~: Int) -> Int` -> `s.rfind(substr: View) -> Option[Int]`
    * `s.trim_end(charset: String) -> String` -> `s.trim_right(charset: View) -> View`
    * `s.trim_start(charset: String) -> String` -> `s.trim_left(charset: View) -> View`
 

* Only type is changed. I added the new APIs with correct type as methods to View. The original methods associated to String are deprecated, and once the deprecated methods are removed I will add back the methods to String.
    * `s.contains(substr: String) -> Bool` -> `s.contains(substr: View) -> Bool`
    * `s.pad_end(n: Int, c: Char) -> String` -> `s.pad_end(n: Int, c: Char) -> View`, and same for `pad_start`
    * `s.repeat(n: Int) -> String` -> `s.repeat(n: Int) -> View`
    * `s.rev() -> String` -> `s.rev() -> View`
    * `s.replace(old~: String, new~: String) -> String` -> `s.replace(old~: View, new~: View) -> View`
    * `s.replace_all(old~: String, new~: String) -> String` -> `s.replace_all(old~: View, new~: View) -> View`
    * `s.split(sep: String) -> Iter[String]` -> `s.split(sep: View) -> Iter[View]`
    * `s.to_lower() -> String` -> `s.to_lower() -> View`, and same for `to_upper`
    * `s.trim(charset: String) -> String` -> `s.trim(charset: View) -> View`
    * `s.trim_space() -> String` -> `s.trim_space() -> View`

* Both name and type are are kept. I added the API to View type, and deprecated the usage of methods as regular function calls.
    * `s.contains_char(c: Char) -> Bool`
    * `default() -> String/View`, `from_array(arr: Array[Char]) -> String/View`, `from_iter(iter: Iter[Char]) -> String/View`
    * `s.fold` and `s.rev_fold`
    * `s.is_empty()` and `s.is_blank()`
    * `s.iter()`, `s.iter2()`, `s.rev_iter()`

* Deprecated:
    * `s.to_bytes()`. I think it needs a better name like `to_underlying_bytes()`. Currently, user can use `Bytes::of_string(s)` instead.
    * `s.to_array()`. Should use `s.iter().collect()` instead.