### PR TITLE
refactor(string): add `find`, `rev_find`, `has_suffix`, and `has_prefix`

### DIFF
--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -1,0 +1,178 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Returns the offset of the first occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn View::find(self : View, str : View) -> Int? {
+  let len = self.len()
+  let sub_len = str.len()
+  // Handle empty substring case
+  guard sub_len > 0 else { return Some(0) }
+  // If substring is longer than string, it can't be found
+  guard sub_len <= len else { return None }
+  let max_idx = len - sub_len
+  let first = str.unsafe_charcode_at(0)
+  let mut i = 0
+  while i <= max_idx {
+    // find first character
+    while i < len && self.unsafe_charcode_at(i) != first {
+      i += 1
+    }
+    // check the rest
+    if i <= max_idx {
+      for j in 1..<sub_len {
+        if self.unsafe_charcode_at(i + j) != str.unsafe_charcode_at(j) {
+          break
+        }
+      } else {
+        // the substring is found
+        return Some(i)
+      }
+    }
+    i += 1
+  }
+  None
+}
+
+///|
+/// Returns the offset of the first occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn String::find(self : String, str : View) -> Int? {
+  self.view().find(str)
+}
+
+///|
+test "find" {
+  // todo: remove .view() when new version is released
+  inspect!("hello".find("o".view()), content="Some(4)")
+  inspect!("hello".find("l".view()), content="Some(2)")
+  inspect!("hello".find("hello".view()), content="Some(0)")
+  inspect!("hello".find("h".view()), content="Some(0)")
+  inspect!("hello".find("".view()), content="Some(0)")
+  inspect!("hello".find("world".view()), content="None")
+  inspect!("".find("".view()), content="Some(0)")
+  inspect!("".find("a".view()), content="None")
+  inspect!("hello hello".find("hello".view()), content="Some(0)")
+  inspect!("aaa".find("aa".view()), content="Some(0)")
+  inspect!("😀😀".find("😀".view()), content="Some(0)")
+}
+
+///|
+/// Returns the offset of the last occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn View::rev_find(self : View, str : View) -> Int? {
+  let len = self.len()
+  let sub_len = str.len()
+  guard sub_len > 0 else { return Some(len) }
+  guard sub_len <= len else { return None }
+  let min_idx = sub_len - 1
+  let last = str.unsafe_charcode_at(sub_len - 1)
+  let mut i = len - 1
+  while i >= min_idx {
+    while i >= 0 && self.unsafe_charcode_at(i) != last {
+      i -= 1
+    }
+    if i >= min_idx {
+      for j in 1..<sub_len {
+        if self.unsafe_charcode_at(i - j) !=
+          str.unsafe_charcode_at(sub_len - 1 - j) {
+          break
+        }
+      } else {
+        return Some(i - sub_len + 1)
+      }
+    }
+    i -= 1
+  }
+  None
+}
+
+///|
+/// Returns the offset of the last occurrence of the given substring. If the
+/// substring is not found, it returns None.
+pub fn String::rev_find(self : String, str : View) -> Int? {
+  self.view().rev_find(str)
+}
+
+///|
+test "rev_find" {
+  // todo: remove .view() when new version is released
+  inspect!("hello".rev_find("o".view()), content="Some(4)")
+  inspect!("hello".rev_find("l".view()), content="Some(3)")
+  inspect!("hello".rev_find("hello".view()), content="Some(0)")
+  inspect!("hello".rev_find("h".view()), content="Some(0)")
+  inspect!("hello".rev_find("".view()), content="Some(5)")
+  inspect!("hello".rev_find("world".view()), content="None")
+  inspect!("".rev_find("".view()), content="Some(0)")
+  inspect!("".rev_find("a".view()), content="None")
+  inspect!("hello hello".rev_find("hello".view()), content="Some(6)")
+  inspect!("aaa".rev_find("aa".view()), content="Some(1)")
+  inspect!("😀😀".rev_find("😀".view()), content="Some(2)")
+}
+
+///| 
+/// Returns true if the given substring is suffix of this string.
+pub fn View::has_suffix(self : View, str : View) -> Bool {
+  self.rev_find(str) is Some(i) && i == self.len() - str.len()
+}
+
+///|
+/// Returns true if the given substring is suffix of this string.
+pub fn String::has_suffix(self : String, str : View) -> Bool {
+  self.view().has_suffix(str)
+}
+
+///|
+test "has_suffix" {
+  // todo: remove .view() when new version is released
+  inspect!("hello".has_suffix("lo".view()), content="true")
+  inspect!("hello".has_suffix("hello".view()), content="true")
+  inspect!("hello".has_suffix("".view()), content="true")
+  inspect!("hello".has_suffix("world".view()), content="false")
+  inspect!("hello".has_suffix("hel".view()), content="false")
+  inspect!("".has_suffix("".view()), content="true")
+  inspect!("".has_suffix("a".view()), content="false")
+  inspect!("hello world".has_suffix("world".view()), content="true")
+  inspect!("😀😀".has_suffix("😀".view()), content="true")
+  inspect!("😀😀".has_suffix("😀😀".view()), content="true")
+}
+
+///|
+/// Returns true if this string starts with the given substring.
+pub fn View::has_prefix(self : View, str : View) -> Bool {
+  self.find(str) is Some(i) && i == 0
+}
+
+///|
+/// Returns true if this string starts with the given substring.
+pub fn String::has_prefix(self : String, str : View) -> Bool {
+  self.view().has_prefix(str)
+}
+
+///|
+test "has_prefix" {
+  // todo: remove .view() when new version is released
+  inspect!("hello".has_prefix("h".view()), content="true")
+  inspect!("hello".has_prefix("he".view()), content="true")
+  inspect!("hello".has_prefix("".view()), content="true")
+  inspect!("hello".has_prefix("world".view()), content="false")
+  inspect!("hello".has_prefix("lo".view()), content="false")
+  inspect!("".has_prefix("".view()), content="true")
+  inspect!("".has_prefix("a".view()), content="false")
+  inspect!("😀hello".has_prefix("😀".view()), content="true")
+  inspect!("😀😃hello".has_prefix("😀😃".view()), content="true")
+  inspect!("😀hello".has_prefix("😃".view()), content="false")
+  inspect!("hello😀".has_prefix("😀".view()), content="false")
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -348,131 +348,72 @@ pub fn is_blank(self : String) -> Bool {
 }
 
 ///|
-/// Returns the first index of the sub string.
+#deprecated("Use `s.find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
 pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
-  let len = self.length()
-  let sub_len = str.length()
-
-  // Handle empty substring case
-  if sub_len == 0 {
-    // Return 0 for empty string in empty string
-    if len == 0 {
-      return 0
+  if from <= 0 {
+    if self.find(str.view()) is Some(idx) {
+      idx
+    } else {
+      -1
     }
-    // Bound from within valid range and return it
-    return if from < 0 { 0 } else if from >= len { len } else { from }
-  }
-
-  // If substring is longer than string, it can't be found
-  if sub_len > len {
-    return -1
-  }
-
-  // Bound the starting position
-  let from = if from < 0 { 0 } else if from >= len { len - 1 } else { from }
-  let max_idx = len - sub_len
-  let first = str.unsafe_charcode_at(0)
-  let mut i = from
-  while i <= max_idx {
-    // find first character
-    while i < len && self.unsafe_charcode_at(i) != first {
-      i += 1
+  } else if from > self.length() {
+    if str.length() == 0 {
+      self.length()
+    } else {
+      -1
     }
-    // check the rest
-    if i <= max_idx {
-      for j in 1..<sub_len {
-        if self.unsafe_charcode_at(i + j) != str.unsafe_charcode_at(j) {
-          break
-        }
-      } else {
-        // the substring is found
-        return i
-      }
-    }
-    i += 1
+  } else if self.view(start_offset=from).find(str.view()) is Some(idx) {
+    idx + from
+  } else {
+    -1
   }
-  -1
 }
 
 ///|
 /// Returns the last index of the sub string.
+#deprecated("Use `s.rev_find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
 pub fn last_index_of(
   self : String,
   str : String,
   from~ : Int = self.length()
 ) -> Int {
-  let from = if from < 0 {
-    0
-  } else if from > self.length() {
-    self.length()
-  } else {
-    from
-  }
-  let len = self.length()
-  let sub_len = str.length()
-  if sub_len == 0 {
-    return from
-  }
-  if len < sub_len {
-    return -1
-  }
-  let min = sub_len - 1
-  let last = str.unsafe_charcode_at(sub_len - 1)
-  let mut i = from - 1
-  while i >= 0 {
-    // find last character
-    while i >= min && self.unsafe_charcode_at(i) != last {
-      i -= 1
-    }
-    if i < min {
-      return -1
-    }
-    let mut j = i - 1
-    let mut k = sub_len - 2
-    let start = i - sub_len
-    let found = while j > start {
-      if self.unsafe_charcode_at(j) != str.unsafe_charcode_at(k) {
-        break false
-      }
-      j -= 1
-      k -= 1
+  if from >= self.length() {
+    if self.rev_find(str.view()) is Some(idx) {
+      idx
     } else {
-      true
+      -1
     }
-    if found {
-      return start + 1
+  } else if from < 0 {
+    if str.length() == 0 {
+      self.length()
+    } else {
+      -1
     }
-    i -= 1
+  } else if self.view(end_offset=from).rev_find(str.view()) is Some(idx) {
+    idx
+  } else {
+    -1
   }
-  -1
 }
 
 ///|
 /// Returns true if this string contains given sub string.
 pub fn contains(self : String, str : String) -> Bool {
-  self.index_of(str) >= 0
+  self.find(str.view()) is Some(_)
 }
 
 ///|
 /// Returns true if this string starts with a sub string.
+#deprecated("Use `s.has_prefix(str)` instead.")
 pub fn starts_with(self : String, str : String) -> Bool {
-  if str.length() > self.length() {
-    false
-  } else {
-    self.index_of(str) == 0
-  }
+  self.has_prefix(str.view())
 }
 
 ///|
 /// Returns true if this string ends with a sub string.
+#deprecated("Use `s.has_suffix(str)` instead.")
 pub fn ends_with(self : String, str : String) -> Bool {
-  let len = self.length()
-  let sub_len = str.length()
-  if sub_len > len {
-    false
-  } else {
-    self.last_index_of(str) == len - sub_len
-  }
+  self.has_suffix(str.view())
 }
 
 ///|
@@ -510,13 +451,13 @@ pub fn split(self : String, separator : String) -> Iter[String] {
   Iter::new(fn(yield_) {
     let mut start = 0
     while start < len {
-      let end = self.index_of(separator, from=start)
-      if end < 0 {
+      guard self.view(start_offset=start).find(separator.view()) is Some(end) else {
         if yield_(self.substring(start~)) == IterEnd {
           break IterEnd
         }
         break IterContinue
       }
+      let end = start + end
       if yield_(self.substring(start~, end~)) == IterEnd {
         break IterEnd
       }
@@ -530,14 +471,10 @@ pub fn split(self : String, separator : String) -> Iter[String] {
 ///|
 /// Replace the first old string in this string to new string.
 pub fn replace(self : String, old~ : String, new~ : String) -> String {
-  let old_idx = self.index_of(old)
-  if old_idx < 0 {
-    self
-  } else {
-    self.substring(end=old_idx) +
-    new +
-    self.substring(start=old_idx + old.length())
-  }
+  guard self.find(old.view()) is Some(old_idx) else { self }
+  self.substring(end=old_idx) +
+  new +
+  self.substring(start=old_idx + old.length())
 }
 
 ///|
@@ -557,11 +494,11 @@ pub fn replace_all(self : String, old~ : String, new~ : String) -> String {
   } else {
     let mut start = 0
     while start < len {
-      let end = self.index_of(old, from=start)
-      if end < 0 {
+      guard self.view(start_offset=start).find(old.view()) is Some(end) else {
         buf.write_string(self.substring(start~))
         break
       }
+      let end = start + end
       buf.write_string(self.substring(start~, end~))
       buf.write_string(new)
       start = end + old_len

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -9,6 +9,7 @@ fn contains_char(String, Char) -> Bool
 
 fn default() -> String
 
+#deprecated
 fn ends_with(String, String) -> Bool
 
 fn fold[A](String, init~ : A, (A, Char) -> A) -> A
@@ -23,6 +24,7 @@ fn index_at(String, Int, start~ : StringIndex = ..) -> StringIndex?
 #deprecated
 fn index_at_rev(String, Int, end? : StringIndex) -> StringIndex?
 
+#deprecated
 fn index_of(String, String, from~ : Int = ..) -> Int
 
 fn is_blank(String) -> Bool
@@ -33,6 +35,7 @@ fn iter(String) -> Iter[Char]
 
 fn iter2(String) -> Iter2[Int, Char]
 
+#deprecated
 fn last_index_of(String, String, from~ : Int = ..) -> Int
 
 #deprecated
@@ -62,6 +65,7 @@ fn rev_iter(String) -> Iter[Char]
 
 fn split(String, String) -> Iter[String]
 
+#deprecated
 fn starts_with(String, String) -> Bool
 
 fn to_array(String) -> Array[Char]
@@ -92,6 +96,9 @@ impl StringView {
   char_length_eq(Self, Int) -> Bool
   char_length_ge(Self, Int) -> Bool
   charcode_at(Self, Int) -> Int
+  find(Self, Self) -> Int?
+  has_prefix(Self, Self) -> Bool
+  has_suffix(Self, Self) -> Bool
   iter(Self) -> Iter[Char]
   #deprecated
   length(Self) -> Int
@@ -104,9 +111,11 @@ impl StringView {
   op_as_view(Self, start~ : Int = .., end? : Int) -> Self
   #deprecated
   op_get(Self, Int) -> Char
+  rev_find(Self, Self) -> Int?
   #deprecated
   rev_get(Self, Int) -> Char
   rev_iter(Self) -> Iter[Char]
+  unsafe_charcode_at(Self, Int) -> Int
 }
 impl Compare for StringView
 impl Eq for StringView
@@ -120,19 +129,25 @@ impl String {
   concat(Array[String], separator~ : String = ..) -> String
   contains(String, String) -> Bool
   contains_char(String, Char) -> Bool
+  #deprecated
   ends_with(String, String) -> Bool
+  find(String, StringView) -> Int?
   fold[A](String, init~ : A, (A, Char) -> A) -> A
   from_array(Array[Char]) -> String
   from_iter(Iter[Char]) -> String
+  has_prefix(String, StringView) -> Bool
+  has_suffix(String, StringView) -> Bool
   #deprecated
   index_at(String, Int, start~ : StringIndex = ..) -> StringIndex?
   #deprecated
   index_at_rev(String, Int, end? : StringIndex) -> StringIndex?
+  #deprecated
   index_of(String, String, from~ : Int = ..) -> Int
   is_blank(String) -> Bool
   is_empty(String) -> Bool
   iter(String) -> Iter[Char]
   iter2(String) -> Iter2[Int, Char]
+  #deprecated
   last_index_of(String, String, from~ : Int = ..) -> Int
   #deprecated
   length_eq(String, Int) -> Bool
@@ -147,11 +162,13 @@ impl String {
   replace(String, old~ : String, new~ : String) -> String
   replace_all(String, old~ : String, new~ : String) -> String
   rev(String) -> String
+  rev_find(String, StringView) -> Int?
   rev_fold[A](String, init~ : A, (A, Char) -> A) -> A
   #deprecated
   rev_get(String, Int) -> Char
   rev_iter(String) -> Iter[Char]
   split(String, String) -> Iter[String]
+  #deprecated
   starts_with(String, String) -> Bool
   to_array(String) -> Array[Char]
   to_bytes(String) -> Bytes

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -102,6 +102,15 @@ pub fn View::charcode_at(self : View, index : Int) -> Int {
   self.str.unsafe_charcode_at(self.start + index)
 }
 
+///|
+/// Returns the charcode(code unit) at the given index without checking if the
+/// index is within bounds.
+/// 
+/// This method has O(1) complexity.
+pub fn View::unsafe_charcode_at(self : View, index : Int) -> Int {
+  self.str.unsafe_charcode_at(self.start + index)
+}
+
 ///| 
 /// Returns the number of Unicode characters in this view.
 /// 


### PR DESCRIPTION
This PR deprecates: `index_of`, `last_index_of`, `starts_with`, and `ends_with`. Replace them with `find`, `rev_find`, `has_prefix`, `has_suffix`.

Rationale:

* The word "index" is ambiguous since it could refer to either Utf16 index or char index, so it is inappropriate to use it in the API names. `find` and `rev_find` returns the Utf16 index.
* `s.starts_with("abc")` is unclear whether "abc" is used as a prefix substring or a char set. So it is renamed to `has_prefix` for clarity. 