### PR TITLE
fix(char): use Char::unsafe_from_int and deprecated Char::from_int

### DIFF
--- a/builtin/bigint_nonjs.mbt
+++ b/builtin/bigint_nonjs.mbt
@@ -1190,11 +1190,11 @@ pub fn BigInt::to_hex(self : BigInt, uppercase~ : Bool = true) -> String {
       let y = x % 16
       x /= 16
       tmp = (if y < 10 {
-          Char::from_int(y.reinterpret_as_int() + 48).to_string()
+          Char::unsafe_from_int(y.reinterpret_as_int() + 48).to_string()
         } else if uppercase {
-          Char::from_int(y.reinterpret_as_int() + 55).to_string()
+          Char::unsafe_from_int(y.reinterpret_as_int() + 55).to_string()
         } else {
-          Char::from_int(y.reinterpret_as_int() + 87).to_string()
+          Char::unsafe_from_int(y.reinterpret_as_int() + 87).to_string()
         }) +
         tmp
     }

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -381,9 +381,11 @@ impl Byte {
 }
 
 impl Char {
+  #deprecated
   from_int(Int) -> Char
   to_int(Char) -> Int
   to_uint(Char) -> UInt
+  unsafe_from_int(Int) -> Char
 }
 
 impl Int {

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -235,7 +235,7 @@ pub fn Bytes::copy(self : Bytes) -> Bytes {
 /// 
 /// test "panic FixedArray::set_utf8_char/invalid_char" {
 ///   let buf = FixedArray::make(4, b'\x00')
-///   ignore(buf.set_utf8_char(0, Char::from_int(0x110000))) // Invalid Unicode code point
+///   ignore(buf.set_utf8_char(0, Char::unsafe_from_int(0x110000))) // Invalid Unicode code point
 /// }
 /// ```
 pub fn FixedArray::set_utf8_char(

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -201,7 +201,7 @@ test "blit_from_bytesview basic case" {
 test "panic FixedArray::set_utf8_char/invalid_code_point" {
   let buf = FixedArray::make(4, b'\x00')
   // Creating a character with code point greater than 0x10FFFF (1114111)
-  let invalid_char = Char::from_int(0x110001)
+  let invalid_char = Char::unsafe_from_int(0x110001)
   // This should trigger the "Char out of range" panic
   let _ = buf.set_utf8_char(0, invalid_char)
 
@@ -225,7 +225,7 @@ test "set_utf16be_char with surrogate pairs" {
 ///|
 test "panic set_utf16be_char with out of range code point" {
   let buf = FixedArray::make(4, b'\x00')
-  ignore(buf.set_utf16be_char(0, Char::from_int(0x110000)))
+  ignore(buf.set_utf16be_char(0, Char::unsafe_from_int(0x110000)))
 }
 
 ///|

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -82,17 +82,17 @@ fn base64_encode(data : FixedArray[Byte]) -> String {
     let x1 = base64[((b0 & 0x03) << 4) | ((b1 & 0xF0) >> 4)]
     let x2 = base64[((b1 & 0x0F) << 2) | ((b2 & 0xC0) >> 6)]
     let x3 = base64[b2 & 0x3F]
-    buf.write_char(Char::from_int(x0.to_int()))
-    buf.write_char(Char::from_int(x1.to_int()))
-    buf.write_char(Char::from_int(x2.to_int()))
-    buf.write_char(Char::from_int(x3.to_int()))
+    buf.write_char(Char::unsafe_from_int(x0.to_int()))
+    buf.write_char(Char::unsafe_from_int(x1.to_int()))
+    buf.write_char(Char::unsafe_from_int(x2.to_int()))
+    buf.write_char(Char::unsafe_from_int(x3.to_int()))
   }
   if rem == 1 {
     let b0 = data[len - 1].to_int()
     let x0 = base64[(b0 & 0xFC) >> 2]
     let x1 = base64[(b0 & 0x03) << 4]
-    buf.write_char(Char::from_int(x0.to_int()))
-    buf.write_char(Char::from_int(x1.to_int()))
+    buf.write_char(Char::unsafe_from_int(x0.to_int()))
+    buf.write_char(Char::unsafe_from_int(x1.to_int()))
     buf.write_char('=')
     buf.write_char('=')
   } else if rem == 2 {
@@ -101,9 +101,9 @@ fn base64_encode(data : FixedArray[Byte]) -> String {
     let x0 = base64[(b0 & 0xFC) >> 2]
     let x1 = base64[((b0 & 0x03) << 4) | ((b1 & 0xF0) >> 4)]
     let x2 = base64[(b1 & 0x0F) << 2]
-    buf.write_char(Char::from_int(x0.to_int()))
-    buf.write_char(Char::from_int(x1.to_int()))
-    buf.write_char(Char::from_int(x2.to_int()))
+    buf.write_char(Char::unsafe_from_int(x0.to_int()))
+    buf.write_char(Char::unsafe_from_int(x1.to_int()))
+    buf.write_char(Char::unsafe_from_int(x2.to_int()))
     buf.write_char('=')
   }
   buf.to_string()

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1232,8 +1232,32 @@ pub fn Char::to_uint(self : Char) -> UInt {
 }
 
 ///|
-///
+#deprecated("use Char::unsafe_from_int instead")
 pub fn Char::from_int(val : Int) -> Char = "%char_from_int"
+
+///|
+/// Converts an integer to a character. This function is unsafe because it does not
+/// validate whether the input integer represents a valid Unicode code point.
+///
+/// Parameters:
+///
+/// * `val` : The integer value to convert to a character.
+///
+/// Returns a character corresponding to the Unicode code point represented by the
+/// integer value.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "Char::unsafe_from_int" {
+///   inspect!(Char::unsafe_from_int(65), content="'A'") // ASCII 'A'
+///   inspect!(Char::unsafe_from_int(12354), content="'あ'") // Japanese hiragana 'あ'
+/// }
+/// ```
+///
+/// Warning: This function should be used with caution. If the integer value does not
+/// represent a valid Unicode code point, the behavior is undefined.
+pub fn Char::unsafe_from_int(val : Int) -> Char = "%char_from_int"
 
 ///|
 /// Compares two characters for equality.

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -231,7 +231,7 @@ test "map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = StringBuilder::new(size_hint=0)
   iter
-  .map(fn { x => Char::from_int(x.to_int() + 1) })
+  .map(fn { x => Char::unsafe_from_int(x.to_int() + 1) })
   .each(fn { x => exb.write_char(x) })
   inspect!(exb, content="23456")
 }
@@ -273,7 +273,7 @@ test "flat_map2" {
 ///|
 test "fold" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let result = Char::from_int(
+  let result = Char::unsafe_from_int(
     iter.fold(fn { acc, x => acc + x.to_int() }, init=0) / 5,
   )
   assert_eq!(result, '3')

--- a/builtin/output.mbt
+++ b/builtin/output.mbt
@@ -32,7 +32,7 @@ fn Int64::output(self : Int64, logger : &Logger, radix~ : Int = 10) -> Unit {
       write_digits(num2)
     }
     logger.write_char(
-      Char::from_int(ALPHABET.charcode_at(abs(num % radix).to_int())),
+      Char::unsafe_from_int(ALPHABET.charcode_at(abs(num % radix).to_int())),
     )
   }
 
@@ -57,7 +57,9 @@ fn Int::output(self : Int, logger : &Logger, radix~ : Int = 10) -> Unit {
     if num2 != 0 {
       write_digits(num2)
     }
-    logger.write_char(Char::from_int(ALPHABET.charcode_at(abs(num % radix))))
+    logger.write_char(
+      Char::unsafe_from_int(ALPHABET.charcode_at(abs(num % radix))),
+    )
   }
 
   write_digits(abs(self))
@@ -72,7 +74,9 @@ fn UInt::output(self : UInt, logger : &Logger, radix~ : Int = 10) -> Unit {
       write_digits(num2)
     }
     logger.write_char(
-      Char::from_int(ALPHABET.charcode_at((num % radix).reinterpret_as_int())),
+      Char::unsafe_from_int(
+        ALPHABET.charcode_at((num % radix).reinterpret_as_int()),
+      ),
     )
   }
 
@@ -88,7 +92,7 @@ fn UInt64::output(self : UInt64, logger : &Logger, radix~ : Int = 10) -> Unit {
       write_digits(num2)
     }
     logger.write_char(
-      Char::from_int(ALPHABET.charcode_at((num % radix).to_int())),
+      Char::unsafe_from_int(ALPHABET.charcode_at((num % radix).to_int())),
     )
   }
 

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -295,14 +295,14 @@ test "panic blit_from_string with invalid str_offset + length" {
 ///|
 test "panic set_utf16le_char with invalid code point" {
   let arr = FixedArray::makei(10, fn { _ => b'\x00' })
-  let char = Char::from_int(0x110000)
+  let char = Char::unsafe_from_int(0x110000)
   arr.set_utf16le_char(0, char) |> ignore
 }
 
 ///|
 test "panic set_utf16be_char with invalid code point" {
   let arr = FixedArray::makei(10, fn { _ => b'\x00' })
-  let char = Char::from_int(0x110000)
+  let char = Char::unsafe_from_int(0x110000)
   arr.set_utf16le_char(0, char) |> ignore
 }
 

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -64,9 +64,9 @@ pub impl Show for UInt16 with output(self, logger) {
 ///|
 fn to_hex_digit(i : Int) -> Char {
   if i < 10 {
-    Char::from_int(i + '0')
+    Char::unsafe_from_int(i + '0')
   } else {
-    Char::from_int(i + 'a' - 10)
+    Char::unsafe_from_int(i + 'a' - 10)
   }
 }
 
@@ -107,7 +107,7 @@ pub impl Show for String with output(self, logger) {
     match self.unsafe_charcode_at(i) {
       '"' | '\\' as c => {
         flush_segment(i)
-        logger..write_char('\\').write_char(Char::from_int(c))
+        logger..write_char('\\').write_char(Char::unsafe_from_int(c))
       }
       '\n' => {
         flush_segment(i)
@@ -214,9 +214,9 @@ pub impl Show for Char with to_string(self : Char) -> String {
 pub impl Show for Char with output(self, logger) {
   fn to_hex_digit(i : Int) -> Char {
     if i < 10 {
-      Char::from_int('0'.to_int() + i)
+      Char::unsafe_from_int('0'.to_int() + i)
     } else {
-      Char::from_int('a'.to_int() + (i - 10))
+      Char::unsafe_from_int('a'.to_int() + (i - 10))
     }
   }
 

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -58,7 +58,9 @@ fn is_trailing_surrogate(c : Int) -> Bool {
 
 ///|
 fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
-  Char::from_int((leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000)
+  Char::unsafe_from_int(
+    (leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000,
+  )
 }
 
 ///|
@@ -126,7 +128,7 @@ pub fn String::codepoint_at(self : String, index : Int) -> Char {
         abort("invalid surrogate pair")
       }
     } else {
-      Char::from_int(c1)
+      Char::unsafe_from_int(c1)
     }
   }
 }
@@ -139,7 +141,7 @@ pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
     let c2 = self.unsafe_charcode_at(index + 1)
     code_point_of_surrogate_pair(c1, c2)
   } else {
-    Char::from_int(c1)
+    Char::unsafe_from_int(c1)
   }
 }
 

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -127,7 +127,7 @@ test "String::make with zero length" {
 test "panic codepoint_length with invalid surrogate pair" {
   // Create a string with a leading surrogate (0xD800) followed by an invalid trailing surrogate
   let s = String::from_array([
-      Char::from_int(0xD800), // leading surrogate
+      Char::unsafe_from_int(0xD800), // leading surrogate
       'a',
     ], // invalid trailing surrogate
   )

--- a/bytes/bytes_pattern_test.mbt
+++ b/bytes/bytes_pattern_test.mbt
@@ -31,14 +31,14 @@ pub fn decode_utf8(bytes : Bytes) -> String {
   loop bytes[:] {
     // 1-byte sequence (ASCII): 0xxxxxxx
     [0x00..=0x7F as b, .. next] => {
-      buf.write_char(Char::from_int(b.to_int()))
+      buf.write_char(Char::unsafe_from_int(b.to_int()))
       continue next
     }
 
     // 2-byte sequence: 110xxxxx 10xxxxxx
     [0xC0..=0xDF as b1, 0x80..=0xBF as b2, .. next] => {
       let code_point = ((b1.to_int() & 0x1F) << 6) | (b2.to_int() & 0x3F)
-      buf.write_char(Char::from_int(code_point))
+      buf.write_char(Char::unsafe_from_int(code_point))
       continue next
     }
 
@@ -47,7 +47,7 @@ pub fn decode_utf8(bytes : Bytes) -> String {
       let code_point = ((b1.to_int() & 0x0F) << 12) |
         ((b2.to_int() & 0x3F) << 6) |
         (b3.to_int() & 0x3F)
-      buf.write_char(Char::from_int(code_point))
+      buf.write_char(Char::unsafe_from_int(code_point))
       continue next
     }
 
@@ -67,10 +67,10 @@ pub fn decode_utf8(bytes : Bytes) -> String {
       // Handle surrogate pairs for code points above 0xFFFF
       if code_point > 0xFFFF {
         let adjusted = code_point - 0x10000
-        buf.write_char(Char::from_int((adjusted >> 10) + 0xD800)) // High surrogate
-        buf.write_char(Char::from_int((adjusted & 0x3FF) + 0xDC00)) // Low surrogate
+        buf.write_char(Char::unsafe_from_int((adjusted >> 10) + 0xD800)) // High surrogate
+        buf.write_char(Char::unsafe_from_int((adjusted & 0x3FF) + 0xDC00)) // Low surrogate
       } else {
-        buf.write_char(Char::from_int(code_point))
+        buf.write_char(Char::unsafe_from_int(code_point))
       }
       continue next
     }

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -554,9 +554,9 @@ pub fn View::to_double_le(self : View) -> Double {
 pub impl Show for View with output(self, logger) {
   fn to_hex_digit(i : Int) -> Char {
     if i < 10 {
-      Char::from_int('0'.to_int() + i)
+      Char::unsafe_from_int('0'.to_int() + i)
     } else {
-      Char::from_int('a'.to_int() + (i - 10))
+      Char::unsafe_from_int('a'.to_int() + (i - 10))
     }
   }
 

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -33,7 +33,7 @@ test "show output" {
   assert_eq!(repr('\r'), "'\\r'")
   assert_eq!(repr('\b'), "'\\b'")
   assert_eq!(repr('\t'), "'\\t'")
-  assert_eq!(repr(Char::from_int(0)), "'\\x00'")
+  assert_eq!(repr(Char::unsafe_from_int(0)), "'\\x00'")
 }
 
 ///|

--- a/double/internal/ryu/ryu.mbt
+++ b/double/internal/ryu/ryu.mbt
@@ -19,7 +19,7 @@
 fn string_from_bytes(bytes : FixedArray[Byte], from : Int, to : Int) -> String {
   let buf = StringBuilder::new(size_hint=bytes.length())
   for i = from; i < to; i = i + 1 {
-    buf.write_char(Char::from_int(bytes[i].to_int()))
+    buf.write_char(Char::unsafe_from_int(bytes[i].to_int()))
   }
   buf.to_string()
 }

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -36,14 +36,14 @@ fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
     if c == 0 {
       break
     } else if c < 0x80 {
-      res.write_char(Char::from_int(c))
+      res.write_char(Char::unsafe_from_int(c))
       i += 1
     } else if c < 0xE0 {
       if i + 1 >= len {
         break
       }
       c = ((c & 0x1F) << 6) | (bytes[i + 1].to_int() & 0x3F)
-      res.write_char(Char::from_int(c))
+      res.write_char(Char::unsafe_from_int(c))
       i += 2
     } else if c < 0xF0 {
       if i + 2 >= len {
@@ -52,7 +52,7 @@ fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
       c = ((c & 0x0F) << 12) |
         ((bytes[i + 1].to_int() & 0x3F) << 6) |
         (bytes[i + 2].to_int() & 0x3F)
-      res.write_char(Char::from_int(c))
+      res.write_char(Char::unsafe_from_int(c))
       i += 3
     } else {
       if i + 3 >= len {
@@ -63,8 +63,8 @@ fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
         ((bytes[i + 2].to_int() & 0x3F) << 6) |
         (bytes[i + 3].to_int() & 0x3F)
       c -= 0x10000
-      res.write_char(Char::from_int((c >> 10) + 0xD800))
-      res.write_char(Char::from_int((c & 0x3FF) + 0xDC00))
+      res.write_char(Char::unsafe_from_int((c >> 10) + 0xD800))
+      res.write_char(Char::unsafe_from_int((c & 0x3FF) + 0xDC00))
       i += 4
     }
   }

--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -37,7 +37,7 @@ fn string_from_extern(e : XExternString) -> String {
     if ch == -1 {
       break
     } else {
-      buf.write_char(Char::from_int(ch))
+      buf.write_char(Char::unsafe_from_int(ch))
     }
   }
   finish_read_string(handle)

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -110,13 +110,13 @@ pub impl FromJson for Char with from_json(json, path) {
   }
   let len = a.length()
   if len == 1 {
-    a.unsafe_charcode_at(0) |> Char::from_int
+    a.unsafe_charcode_at(0) |> Char::unsafe_from_int
   } else if len == 2 {
     let c1 = a.unsafe_charcode_at(0)
     let c2 = a.unsafe_charcode_at(1)
     if c1 >= 0xD800 && c1 <= 0xDBFF && c2 >= 0xDC00 && c2 <= 0xDFFF {
       let c3 = (c1 << 10) + c2 - 0x35fdc00
-      Char::from_int(c3)
+      Char::unsafe_from_int(c3)
     } else {
       decode_error!(path, "Char::from_json: invalid surrogate pair")
     }

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -160,9 +160,9 @@ pub fn stringify(
 fn escape(str : String, escape_slash~ : Bool) -> String {
   fn to_hex_digit(i : Int) -> Char {
     if i < 10 {
-      Char::from_int('0'.to_int() + i)
+      Char::unsafe_from_int('0'.to_int() + i)
     } else {
-      Char::from_int('a'.to_int() + (i - 10))
+      Char::unsafe_from_int('a'.to_int() + (i - 10))
     }
   }
 

--- a/json/lex_misc.mbt
+++ b/json/lex_misc.mbt
@@ -23,11 +23,11 @@ fn ParseContext::read_char(ctx : ParseContext) -> Char? {
         if c2 >= 0xDC00 && c2 <= 0xDFFF {
           ctx.offset += 1
           let c3 = (c1 << 10) + c2 - 0x35fdc00
-          return Some(Char::from_int(c3))
+          return Some(Char::unsafe_from_int(c3))
         }
       }
     }
-    Some(Char::from_int(c1))
+    Some(Char::unsafe_from_int(c1))
   } else {
     None
   }
@@ -103,10 +103,10 @@ test "expect_char with surrogate pair" {
   // "\uD83D\uDE00" // todo: shall we allow this?
   let ctx = ParseContext::make("a\uD83D\uDE00bc\uD83D\uDE00c")
   ctx.expect_char!('a')
-  ctx.expect_char!(Char::from_int(0x1F600))
+  ctx.expect_char!(Char::unsafe_from_int(0x1F600))
   ctx.expect_char!('b')
   ctx.expect_char!('c')
-  ctx.expect_char!(Char::from_int(0x1F600))
+  ctx.expect_char!(Char::unsafe_from_int(0x1F600))
   ctx.expect_char!('c')
   inspect!(
     ctx.expect_char?('d').to_string(),

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -42,7 +42,7 @@ fn ParseContext::lex_string(ctx : ParseContext) -> String!ParseError {
           Some('/') => buf.write_char('/')
           Some('u') => {
             let c = ctx.lex_hex_digits!(4)
-            buf.write_char(Char::from_int(c))
+            buf.write_char(Char::unsafe_from_int(c))
           }
           Some(_) => ctx.invalid_char!(shift=-1)
           None => raise InvalidEof

--- a/json/utils.mbt
+++ b/json/utils.mbt
@@ -36,6 +36,6 @@ fn ParseContext::invalid_char[T](
   // FIXME: this should check the surrogate pair
   raise InvalidChar(
     offset_to_position(ctx.input, offset),
-    ctx.input.unsafe_charcode_at(offset) |> Char::from_int,
+    ctx.input.unsafe_charcode_at(offset) |> Char::unsafe_from_int,
   )
 }

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -95,7 +95,7 @@ pub impl Arbitrary for Double with arbitrary(_, rs) {
 ///|
 pub impl Arbitrary for Char with arbitrary(_, rs) {
   // Choose only ASCII characters
-  rs.next_uint() % 128 |> UInt::reinterpret_as_int |> Char::from_int
+  rs.next_uint() % 128 |> UInt::reinterpret_as_int |> Char::unsafe_from_int
 }
 
 ///|

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -80,7 +80,7 @@ fn step_1_unchecked(self : StringSlice) -> StringSlice {
 ///|
 /// Unsafe: make sure index is in bounds
 fn op_get(self : StringSlice, index : Int) -> Char {
-  self.string.unsafe_charcode_at(self.start + index) |> Char::from_int
+  self.string.unsafe_charcode_at(self.start + index) |> Char::unsafe_from_int
 }
 
 ///|
@@ -106,7 +106,7 @@ fn StringSlice::to_string(self : StringSlice) -> String {
 fn prefix_eq_ignore_case(self : StringSlice, s2 : String) -> Bool {
   for i = 0; i < s2.length() && i < self.length(); i = i + 1 {
     let c1 = self[i]
-    let c2 = s2.unsafe_charcode_at(i) |> Char::from_int
+    let c2 = s2.unsafe_charcode_at(i) |> Char::unsafe_from_int
     if lower(c1) != lower(c2) {
       return false
     }
@@ -117,7 +117,7 @@ fn prefix_eq_ignore_case(self : StringSlice, s2 : String) -> Bool {
 ///|
 fn lower(c : Char) -> Char {
   if 'A' <= c && c <= 'Z' {
-    Char::from_int(c.to_int() + 'a'.to_int() - 'A'.to_int())
+    Char::unsafe_from_int(c.to_int() + 'a'.to_int() - 'A'.to_int())
   } else {
     c
   }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -163,7 +163,9 @@ pub fn iter(self : String) -> Iter[Char] {
         }
       }
       //TODO: handle garbage input
-      guard yield_(Char::from_int(c1)) is IterContinue else { break IterEnd }
+      guard yield_(Char::unsafe_from_int(c1)) is IterContinue else {
+        break IterEnd
+      }
 
     } else {
       IterContinue
@@ -186,7 +188,9 @@ pub fn iter2(self : String) -> Iter2[Int, Char] {
         }
       }
       //TODO: handle garbage input
-      guard yield_(n, Char::from_int(c1)) is IterContinue else { break IterEnd }
+      guard yield_(n, Char::unsafe_from_int(c1)) is IterContinue else {
+        break IterEnd
+      }
 
     } else {
       IterContinue
@@ -254,7 +258,9 @@ pub fn rev_iter(self : String) -> Iter[Char] {
         }
       }
       // TODO: handle garbage input
-      guard yield_(Char::from_int(c1)) is IterContinue else { break IterEnd }
+      guard yield_(Char::unsafe_from_int(c1)) is IterContinue else {
+        break IterEnd
+      }
 
     } else {
       IterContinue
@@ -301,7 +307,11 @@ pub fn trim_start(self : String, trim_set : String) -> String {
         }
       }
     }
-    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
+    if not(
+        trim_set.contains_char(
+          Char::unsafe_from_int(self.unsafe_charcode_at(i)),
+        ),
+      ) {
       return self.substring(start=i)
     }
   } else {
@@ -327,7 +337,11 @@ pub fn trim_end(self : String, trim_set : String) -> String {
         }
       }
     }
-    if not(trim_set.contains_char(Char::from_int(self.unsafe_charcode_at(i)))) {
+    if not(
+        trim_set.contains_char(
+          Char::unsafe_from_int(self.unsafe_charcode_at(i)),
+        ),
+      ) {
       return self.substring(end=i + 1)
     }
   } else {
@@ -514,7 +528,7 @@ pub fn to_lower(self : String) -> String {
   let buf = StringBuilder::new(size_hint=self.length())
   for c in self {
     if c >= 'A' && c <= 'Z' {
-      buf.write_char(Char::from_int(c.to_int() + 32))
+      buf.write_char(Char::unsafe_from_int(c.to_int() + 32))
     } else {
       buf.write_char(c)
     }
@@ -529,7 +543,7 @@ pub fn to_upper(self : String) -> String {
   let buf = StringBuilder::new(size_hint=self.length())
   for c in self {
     if c >= 'a' && c <= 'z' {
-      buf.write_char(Char::from_int(c.to_int() - 32))
+      buf.write_char(Char::unsafe_from_int(c.to_int() - 32))
     } else {
       buf.write_char(c)
     }

--- a/string/utils.mbt
+++ b/string/utils.mbt
@@ -48,7 +48,9 @@ test "is_trailing_surrogate" {
 
 ///|
 fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
-  Char::from_int((leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000)
+  Char::unsafe_from_int(
+    (leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000,
+  )
 }
 
 ///|

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -195,7 +195,9 @@ pub fn View::iter(self : View) -> Iter[Char] {
           continue index + 2
         }
       }
-      guard yield_(Char::from_int(c1)) is IterContinue else { break IterEnd }
+      guard yield_(Char::unsafe_from_int(c1)) is IterContinue else {
+        break IterEnd
+      }
 
     } else {
       IterContinue
@@ -217,7 +219,9 @@ pub fn View::iter2(self : View) -> Iter2[Int, Char] {
           continue index + 2, n + 1
         }
       }
-      guard yield_(n, Char::from_int(c1)) is IterContinue else { break IterEnd }
+      guard yield_(n, Char::unsafe_from_int(c1)) is IterContinue else {
+        break IterEnd
+      }
 
     } else {
       IterContinue
@@ -239,7 +243,9 @@ pub fn View::rev_iter(self : View) -> Iter[Char] {
           continue index - 2
         }
       }
-      guard yield_(Char::from_int(c1)) is IterContinue else { break IterEnd }
+      guard yield_(Char::unsafe_from_int(c1)) is IterContinue else {
+        break IterEnd
+      }
 
     } else {
       IterContinue

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -423,7 +423,7 @@ test "panic_view_op_as_view_invalid_end_index" {
 test "panic length_eq should panic on invalid surrogate pair" {
   // Create a string with an invalid surrogate pair:
   // 0xD800 is a leading surrogate, but followed by a non-trailing surrogate character 'A'
-  let str = String::from_array([Char::from_int(0xD800), 'A'])
+  let str = String::from_array([Char::unsafe_from_int(0xD800), 'A'])
   let view = str[:]
   // This will trigger abort("invalid surrogate pair") in length_eq
   ignore(view.char_length_eq(1))
@@ -432,8 +432,8 @@ test "panic length_eq should panic on invalid surrogate pair" {
 ///|
 test "panic_length_ge invalid surrogate pair" {
   let invalid_surrogate_pair = String::from_array([
-    Char::from_int(0xD800), // Leading surrogate
-    Char::from_int(0x0041), // Invalid trailing surrogate (just a regular 'A')
+    Char::unsafe_from_int(0xD800), // Leading surrogate
+    Char::unsafe_from_int(0x0041), // Invalid trailing surrogate (just a regular 'A')
   ])
   let view = invalid_surrogate_pair[:]
   // This should abort with "invalid surrogate pair"


### PR DESCRIPTION
This PR deprecated `Char::from_int` and replaced it with `Char::unsafe_from_int`. Eventually we should change `Char::from_int` to `(Int) -> Option[Char]` after the grace period.