### PR TITLE
refactor: add new stack safe list implementation

### DIFF
--- a/list/list.mbt
+++ b/list/list.mbt
@@ -414,14 +414,11 @@ pub fn fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
 ///
 /// # Example
 /// ```
-/// let r = @list.of([1, 2, 3, 4, 5]).rev_fold(fn(x, acc) { x + acc }, init=0)
+/// let r = @list.of([1, 2, 3, 4, 5]).rev_fold(fn(acc, x) { x + acc }, init=0)
 /// assert_eq!(r, 15)
 /// ```
-pub fn rev_fold[A, B](self : T[A], init~ : B, f : (A, B) -> B) -> B {
-  match self {
-    Nil => init
-    Cons(head, tail~) => f(head, tail.rev_fold(f, init~))
-  }
+pub fn rev_fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
+  self.rev().fold(init~, fn(b, a) { f(b, a) })
 }
 
 ///|
@@ -439,15 +436,12 @@ pub fn foldi[A, B](self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
 
 ///|
 /// Fold the list from right with index.
-pub fn rev_foldi[A, B](self : T[A], init~ : B, f : (Int, A, B) -> B) -> B {
-  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B, acc : B) -> B {
-    match xs {
-      Nil => acc
-      Cons(x, tail=xs) => f(i, x, go(xs, i + 1, f, acc))
-    }
-  }
-
-  go(self, 0, f, init)
+/// 
+/// The index parameter corresponds to the order of traversal, 
+/// starting from 0 for the first element visited,
+/// i.e. the last element of the list would have index 0 as it's first visited.
+pub fn rev_foldi[A, B](self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
+  self.rev().foldi(init~, fn(i, b, a) { f(i, b, a) })
 }
 
 ///|
@@ -958,17 +952,11 @@ pub fn scan_left[A, E](self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
 /// # Example
 /// ```
 /// let ls = @list.of([1, 2, 3, 4, 5])
-/// let r = ls.scan_right(fn(x, acc) { acc + x }, init=0)
+/// let r = ls.scan_right(fn(acc, x) { acc + x }, init=0)
 /// assert_eq!(r, @list.of([15, 14, 12, 9, 5, 0]))
 /// ```
-pub fn scan_right[A, B](self : T[A], f : (A, B) -> B, init~ : B) -> T[B] {
-  match self {
-    Nil => Cons(init, tail=Nil)
-    Cons(x, tail=xs) => {
-      let qs = xs.scan_right(f, init~)
-      Cons(f(x, qs.unsafe_head()), tail=qs)
-    }
-  }
+pub fn scan_right[A, B](self : T[A], f : (B, A) -> B, init~ : B) -> T[B] {
+  self.rev().scan_left(f, init~).rev()
 }
 
 ///|
@@ -1083,10 +1071,10 @@ pub fn remove[A : Eq](self : T[A], elem : A) -> T[A] {
           if x == elem {
             // warning: sharing
             dest.tail = xs
-      } else {
+          } else {
             dest.tail = Cons(x, tail=Nil)
             continue dest.tail, xs
-      }
+          }
         Nil, _ => panic()
       }
       dest

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -14,19 +14,25 @@
 
 ///|
 /// Creates an empty list
-pub fn nil[A]() -> T[A] {
-  Nil
+pub fn new[A]() -> T[A] {
+  Empty
+}
+
+///|
+/// Creates an empty list
+pub fn empty[A]() -> T[A] {
+  Empty
 }
 
 ///|
 /// Prepend an element to the list and create a new list.
-pub fn cons[A](head : A, tail : T[A]) -> T[A] {
-  Cons(head, tail~)
+pub fn construct[A](head : A, tail : T[A]) -> T[A] {
+  More(head, tail~)
 }
 
 ///|
-pub fn add[A](self : T[A], head : A) -> T[A] {
-  Cons(head, tail=self)
+pub fn prepend[A](self : T[A], head : A) -> T[A] {
+  More(head, tail=self)
 }
 
 ///|
@@ -55,8 +61,8 @@ pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) 
   guard json is Array(arr) else {
     raise @json.JsonDecodeError((path, "@list.from_json: expected array"))
   }
-  for i = arr.length() - 1, list = Nil; i >= 0; {
-    continue i - 1, list.add(A::from_json!(arr[i], path))
+  for i = arr.length() - 1, list = Empty; i >= 0; {
+    continue i - 1, list.prepend(A::from_json!(arr[i], path))
   } else {
     list
   }
@@ -77,8 +83,8 @@ pub fn from_json[A : @json.FromJson](json : Json) -> T[A]!@json.JsonDecodeError 
 /// assert_eq!(ls, @list.from_array([1, 2, 3, 4, 5]))
 /// ```
 pub fn from_array[A](arr : Array[A]) -> T[A] {
-  for i = arr.length() - 1, list = Nil; i >= 0; {
-    continue i - 1, Cons(arr[i], tail=list)
+  for i = arr.length() - 1, list = Empty; i >= 0; {
+    continue i - 1, More(arr[i], tail=list)
   } else {
     list
   }
@@ -88,8 +94,8 @@ pub fn from_array[A](arr : Array[A]) -> T[A] {
 /// Get the length of the list.
 pub fn length[A](self : T[A]) -> Int {
   loop self, 0 {
-    Nil, len => len
-    Cons(_, tail=rest), acc => continue rest, acc + 1
+    Empty, len => len
+    More(_, tail=rest), acc => continue rest, acc + 1
   }
 }
 
@@ -105,8 +111,8 @@ pub fn length[A](self : T[A]) -> Int {
 /// ```
 pub fn each[A](self : T[A], f : (A) -> Unit) -> Unit {
   loop self {
-    Nil => ()
-    Cons(head, tail~) => {
+    Empty => ()
+    More(head, tail~) => {
       f(head)
       continue tail
     }
@@ -125,8 +131,8 @@ pub fn each[A](self : T[A], f : (A) -> Unit) -> Unit {
 /// ```
 pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
   loop self, 0 {
-    Nil, _ => ()
-    Cons(x, tail=xs), i => {
+    Empty, _ => ()
+    More(x, tail=xs), i => {
       f(i, x)
       continue xs, i + 1
     }
@@ -143,17 +149,17 @@ pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
 /// ```
 pub fn map[A, B](self : T[A], f : (A) -> B) -> T[B] {
   match self {
-    Nil => Nil
-    Cons(hd, tail~) => {
-      let dest = Cons(f(hd), tail=Nil)
+    Empty => Empty
+    More(hd, tail~) => {
+      let dest = More(f(hd), tail=Empty)
       loop dest, tail {
-        _, Nil => ()
-        Cons(_) as dest, Cons(hd, tail~) => {
-          dest.tail = Cons(f(hd), tail=Nil)
+        _, Empty => ()
+        More(_) as dest, More(hd, tail~) => {
+          dest.tail = More(f(hd), tail=Empty)
           continue dest.tail, tail
         }
         // unreachable
-        Nil, _ => panic()
+        Empty, _ => panic()
       }
       dest
     }
@@ -164,17 +170,17 @@ pub fn map[A, B](self : T[A], f : (A) -> B) -> T[B] {
 /// Maps the list with index.
 pub fn mapi[A, B](self : T[A], f : (Int, A) -> B) -> T[B] {
   match self {
-    Nil => Nil
-    Cons(hd, tail~) => {
-      let dest = Cons(f(0, hd), tail=Nil)
+    Empty => Empty
+    More(hd, tail~) => {
+      let dest = More(f(0, hd), tail=Empty)
       loop 1, dest, tail {
-        _, _, Nil => ()
-        i, Cons(_) as dest, Cons(hd, tail~) => {
-          dest.tail = Cons(f(i, hd), tail=Nil)
+        _, _, Empty => ()
+        i, More(_) as dest, More(hd, tail~) => {
+          dest.tail = More(f(i, hd), tail=Empty)
           continue i + 1, dest.tail, tail
         }
         // unreachable
-        _, Nil, _ => panic()
+        _, Empty, _ => panic()
       }
       dest
     }
@@ -191,9 +197,9 @@ pub fn mapi[A, B](self : T[A], f : (Int, A) -> B) -> T[B] {
 /// assert_eq!(@list.of([1, 2, 3, 4, 5]).rev_map(fn(x) { x * 2 }), @list.of([10, 8, 6, 4, 2]))
 /// ```
 pub fn rev_map[A, B](self : T[A], f : (A) -> B) -> T[B] {
-  loop Nil, self {
-    acc, Nil => acc
-    acc, Cons(x, tail=xs) => continue Cons(f(x), tail=acc), xs
+  loop Empty, self {
+    acc, Empty => acc
+    acc, More(x, tail=xs) => continue More(f(x), tail=acc), xs
   }
 }
 
@@ -201,12 +207,12 @@ pub fn rev_map[A, B](self : T[A], f : (A) -> B) -> T[B] {
 /// Convert list to array.
 pub fn to_array[A](self : T[A]) -> Array[A] {
   match self {
-    Nil => []
-    Cons(x, tail=xs) => {
+    Empty => []
+    More(x, tail=xs) => {
       let arr = [x]
       loop xs {
-        Nil => ()
-        Cons(x, tail=xs) => {
+        Empty => ()
+        More(x, tail=xs) => {
           arr.push(x)
           continue xs
         }
@@ -226,22 +232,22 @@ pub fn to_array[A](self : T[A]) -> Array[A] {
 /// ```
 pub fn filter[A](self : T[A], f : (A) -> Bool) -> T[A] {
   loop self {
-    Nil => Nil
-    Cons(head, tail~) =>
+    Empty => Empty
+    More(head, tail~) =>
       if not(f(head)) {
         continue tail
       } else {
-        let dest = Cons(head, tail=Nil)
+        let dest = More(head, tail=Empty)
         loop dest, tail {
-          _, Nil => ()
-          Cons(_) as dest, Cons(hd, tail~) =>
+          _, Empty => ()
+          More(_) as dest, More(hd, tail~) =>
             if f(hd) {
-              dest.tail = Cons(hd, tail=Nil)
+              dest.tail = More(hd, tail=Empty)
               continue dest.tail, tail
             } else {
               continue dest, tail
             }
-          Nil, _ =>
+          Empty, _ =>
             // unreachable
             panic()
         }
@@ -254,8 +260,8 @@ pub fn filter[A](self : T[A], f : (A) -> Bool) -> T[A] {
 /// Test if all elements of the list satisfy the predicate.
 pub fn all[A](self : T[A], f : (A) -> Bool) -> Bool {
   loop self {
-    Nil => true
-    Cons(head, tail~) => if f(head) { continue tail } else { false }
+    Empty => true
+    More(head, tail~) => if f(head) { continue tail } else { false }
   }
 }
 
@@ -263,8 +269,8 @@ pub fn all[A](self : T[A], f : (A) -> Bool) -> Bool {
 /// Test if any element of the list satisfies the predicate.
 pub fn any[A](self : T[A], f : (A) -> Bool) -> Bool {
   match self {
-    Nil => false
-    Cons(head, tail~) =>
+    Empty => false
+    More(head, tail~) =>
       // this is tail recursive
       f(head) || any(tail, f)
   }
@@ -280,8 +286,8 @@ pub fn any[A](self : T[A], f : (A) -> Bool) -> Bool {
 /// ```
 pub fn tail[A](self : T[A]) -> T[A] {
   match self {
-    Nil => Nil
-    Cons(_, tail~) => tail
+    Empty => Empty
+    More(_, tail~) => tail
   }
 }
 
@@ -290,8 +296,8 @@ pub fn tail[A](self : T[A]) -> T[A] {
 /// @alert unsafe "Panic if the list is empty"
 pub fn unsafe_head[A](self : T[A]) -> A {
   match self {
-    Nil => abort("head of empty list")
-    Cons(head, tail=_) => head
+    Empty => abort("head of empty list")
+    More(head, tail=_) => head
   }
 }
 
@@ -305,8 +311,8 @@ pub fn unsafe_head[A](self : T[A]) -> A {
 /// ```
 pub fn head[A](self : T[A]) -> A? {
   match self {
-    Nil => None
-    Cons(head, tail=_) => Some(head)
+    Empty => None
+    More(head, tail=_) => Some(head)
   }
 }
 
@@ -314,9 +320,9 @@ pub fn head[A](self : T[A]) -> A? {
 /// @alert unsafe "Panic if the list is empty"
 pub fn unsafe_last[A](self : T[A]) -> A {
   loop self {
-    Nil => abort("last of empty list")
-    Cons(head, tail=Nil) => head
-    Cons(_, tail~) => continue tail
+    Empty => abort("last of empty list")
+    More(head, tail=Empty) => head
+    More(_, tail~) => continue tail
   }
 }
 
@@ -330,9 +336,9 @@ pub fn unsafe_last[A](self : T[A]) -> A {
 /// ```
 pub fn last[A](self : T[A]) -> A? {
   loop self {
-    Nil => None
-    Cons(head, tail=Nil) => Some(head)
-    Cons(_, tail~) => continue tail
+    Empty => None
+    More(head, tail=Empty) => Some(head)
+    More(_, tail~) => continue tail
   }
 }
 
@@ -347,18 +353,18 @@ pub fn last[A](self : T[A]) -> A? {
 /// ```
 pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
   match self {
-    Nil => other
-    Cons(hd, tail=Nil) => Cons(hd, tail=other)
-    Cons(hd, tail~) => {
-      let dest = Cons(hd, tail=Nil)
+    Empty => other
+    More(hd, tail=Empty) => More(hd, tail=other)
+    More(hd, tail~) => {
+      let dest = More(hd, tail=Empty)
       loop dest, tail {
-        Cons(_) as dest, Nil => dest.tail = other
-        Cons(_) as dest, Cons(head, tail~) => {
-          dest.tail = Cons(head, tail=Nil)
+        More(_) as dest, Empty => dest.tail = other
+        More(_) as dest, More(head, tail~) => {
+          dest.tail = More(head, tail=Empty)
           continue dest.tail, tail
         }
         // unreachable
-        Nil, _ => panic()
+        Empty, _ => panic()
       }
       dest
     }
@@ -376,8 +382,8 @@ pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
 /// ```
 pub fn rev_concat[A](self : T[A], other : T[A]) -> T[A] {
   loop self, other {
-    Nil, other => other
-    Cons(head, tail~), other => continue tail, Cons(head, tail=other)
+    Empty, other => other
+    More(head, tail~), other => continue tail, More(head, tail=other)
   }
 }
 
@@ -390,7 +396,7 @@ pub fn rev_concat[A](self : T[A], other : T[A]) -> T[A] {
 /// assert_eq!(@list.of([1, 2, 3, 4, 5]).rev(), @list.of([5, 4, 3, 2, 1]))
 /// ```
 pub fn rev[A](self : T[A]) -> T[A] {
-  self.rev_concat(Nil)
+  self.rev_concat(Empty)
 }
 
 ///|
@@ -404,8 +410,8 @@ pub fn rev[A](self : T[A]) -> T[A] {
 /// ```
 pub fn fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
   match self {
-    Nil => init
-    Cons(head, tail~) => tail.fold(f, init=f(init, head))
+    Empty => init
+    More(head, tail~) => tail.fold(f, init=f(init, head))
   }
 }
 
@@ -426,8 +432,8 @@ pub fn rev_fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
 pub fn foldi[A, B](self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
   fn go(xs : T[A], i : Int, f : (Int, B, A) -> B, acc : B) -> B {
     match xs {
-      Nil => acc
-      Cons(x, tail=xs) => go(xs, i + 1, f, f(i, acc, x))
+      Empty => acc
+      More(x, tail=xs) => go(xs, i + 1, f, f(i, acc, x))
     }
   }
 
@@ -455,11 +461,11 @@ pub fn rev_foldi[A, B](self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
 /// assert_eq!(r, @list.from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]))
 /// ```
 pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)] {
-  let res = loop self, other, Nil {
-    Nil, _, acc => break acc
-    _, Nil, acc => break acc
-    Cons(x, tail=xs), Cons(y, tail=ys), acc =>
-      continue xs, ys, Cons((x, y), tail=acc)
+  let res = loop self, other, Empty {
+    Empty, _, acc => break acc
+    _, Empty, acc => break acc
+    More(x, tail=xs), More(y, tail=ys), acc =>
+      continue xs, ys, More((x, y), tail=acc)
   }
   res.reverse_inplace()
 }
@@ -478,34 +484,34 @@ pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)] {
 /// ```
 pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
   loop self {
-    Nil => Nil
-    Cons(head, tail~) =>
+    Empty => Empty
+    More(head, tail~) =>
       match f(head) {
         // continue until we have at least one element
-        Nil => continue tail
-        Cons(hd, tail=tl) => {
-          let dest = Cons(hd, tail=Nil)
+        Empty => continue tail
+        More(hd, tail=tl) => {
+          let dest = More(hd, tail=Empty)
           // copy all the elements of `f(head)` first
           let dest1 = loop dest, tl {
-            dest, Nil => dest
-            Cons(_) as dest, Cons(hd, tail~) => {
-              dest.tail = Cons(hd, tail=Nil)
+            dest, Empty => dest
+            More(_) as dest, More(hd, tail~) => {
+              dest.tail = More(hd, tail=Empty)
               continue dest.tail, tail
             }
-            Nil, _ => panic()
+            Empty, _ => panic()
           }
           // continue looping on the `tail` of `self`
           loop_over_tail~: loop dest1, tail {
-            _, Nil => ()
-            Cons(_) as dest, Cons(t_hd, tail=Nil) => dest.tail = f(t_hd)
-            dest, Cons(t_hd, tail=t_tl) =>
+            _, Empty => ()
+            More(_) as dest, More(t_hd, tail=Empty) => dest.tail = f(t_hd)
+            dest, More(t_hd, tail=t_tl) =>
               loop dest, f(t_hd) {
-                dest, Nil => continue loop_over_tail~ dest, t_tl
-                Cons(_) as dest, Cons(hd, tail~) => {
-                  dest.tail = Cons(hd, tail=Nil)
+                dest, Empty => continue loop_over_tail~ dest, t_tl
+                More(_) as dest, More(hd, tail~) => {
+                  dest.tail = More(hd, tail=Empty)
                   continue dest.tail, tail
                 }
-                Nil, _ => panic()
+                Empty, _ => panic()
               }
           }
           dest
@@ -526,23 +532,23 @@ pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
 /// ```
 pub fn filter_map[A, B](self : T[A], f : (A) -> B?) -> T[B] {
   loop self {
-    Nil => Nil
-    Cons(hd, tail~) =>
+    Empty => Empty
+    More(hd, tail~) =>
       match f(hd) {
         None => continue tail
         Some(head) => {
-          let dest = Cons(head, tail=Nil)
+          let dest = More(head, tail=Empty)
           loop dest, tail {
-            _, Nil => ()
-            Cons(_) as dest, Cons(hd, tail~) =>
+            _, Empty => ()
+            More(_) as dest, More(hd, tail~) =>
               match f(hd) {
                 None => continue dest, tail
                 Some(head) => {
-                  dest.tail = Cons(head, tail=Nil)
+                  dest.tail = More(head, tail=Empty)
                   continue dest.tail, tail
                 }
               }
-            Nil, _ => panic()
+            Empty, _ => panic()
           }
           dest
         }
@@ -554,9 +560,9 @@ pub fn filter_map[A, B](self : T[A], f : (A) -> B?) -> T[B] {
 /// @alert unsafe "Panic if the index is out of bounds"
 pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
   loop self, n {
-    Nil, _ => abort("nth: index out of bounds")
-    Cons(head, tail=_), 0 => head
-    Cons(_, tail~), n => continue tail, n - 1
+    Empty, _ => abort("nth: index out of bounds")
+    More(head, tail=_), 0 => head
+    More(_, tail~), n => continue tail, n - 1
   }
 }
 
@@ -564,9 +570,9 @@ pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
 /// Get nth element of the list or None if the index is out of bounds
 pub fn nth[A](self : T[A], n : Int) -> A? {
   loop self, n {
-    Nil, _ => None
-    Cons(head, tail=_), 0 => Some(head)
-    Cons(_, tail~), n => continue tail, n - 1
+    Empty, _ => None
+    More(head, tail=_), 0 => Some(head)
+    More(_, tail~), n => continue tail, n - 1
   }
 }
 
@@ -579,8 +585,8 @@ pub fn nth[A](self : T[A], n : Int) -> A? {
 /// assert_eq!(@list.repeat(5, 1), @list.from_array([1, 1, 1, 1, 1]))
 /// ```
 pub fn repeat[A](n : Int, x : A) -> T[A] {
-  loop Nil, n {
-    acc, n => if n <= 0 { acc } else { continue Cons(x, tail=acc), n - 1 }
+  loop Empty, n {
+    acc, n => if n <= 0 { acc } else { continue More(x, tail=acc), n - 1 }
   }
 }
 
@@ -595,19 +601,19 @@ pub fn repeat[A](n : Int, x : A) -> T[A] {
 /// ```
 pub fn intersperse[A](self : T[A], separator : A) -> T[A] {
   match self {
-    Nil => Nil
-    Cons(head, tail=Nil) => Cons(head, tail=Nil)
-    Cons(head, tail~) => {
-      let dest = Cons(head, tail=Nil)
+    Empty => Empty
+    More(head, tail=Empty) => More(head, tail=Empty)
+    More(head, tail~) => {
+      let dest = More(head, tail=Empty)
       loop dest, tail {
-        _, Nil => ()
-        Cons(_) as dest, Cons(hd, tail=tl) => {
-          let new_tail = Cons(hd, tail=Nil)
-          dest.tail = Cons(separator, tail=new_tail)
+        _, Empty => ()
+        More(_) as dest, More(hd, tail=tl) => {
+          let new_tail = More(hd, tail=Empty)
+          dest.tail = More(separator, tail=new_tail)
           continue new_tail, tl
         }
         // unreachable
-        Nil, _ => panic()
+        Empty, _ => panic()
       }
       dest
     }
@@ -617,7 +623,7 @@ pub fn intersperse[A](self : T[A], separator : A) -> T[A] {
 ///|
 /// Check if the list is empty.
 pub fn is_empty[A](self : T[A]) -> Bool {
-  self is Nil
+  self is Empty
 }
 
 ///|
@@ -631,14 +637,14 @@ pub fn is_empty[A](self : T[A]) -> Bool {
 /// assert_eq!(b, @list.from_array([2, 4, 6]))
 /// ```
 pub fn unzip[A, B](self : T[(A, B)]) -> (T[A], T[B]) {
-  let mut xs = Nil
-  let mut ys = Nil
+  let mut xs = Empty
+  let mut ys = Empty
   // implemented with loop to avoid stack overflow
   loop self.rev() {
-    Nil => break (xs, ys)
-    Cons((x, y), tail~) => {
-      xs = Cons(x, tail=xs)
-      ys = Cons(y, tail=ys)
+    Empty => break (xs, ys)
+    More((x, y), tail~) => {
+      xs = More(x, tail=xs)
+      ys = More(y, tail=ys)
       continue tail
     }
   }
@@ -655,34 +661,34 @@ pub fn unzip[A, B](self : T[(A, B)]) -> (T[A], T[B]) {
 /// ```
 pub fn flatten[A](self : T[T[A]]) -> T[A] {
   loop self {
-    Nil => Nil
-    Cons(head, tail~) =>
+    Empty => Empty
+    More(head, tail~) =>
       match head {
         // continue until we have at least one element
-        Nil => continue tail
-        Cons(hd, tail=tl) => {
-          let dest = Cons(hd, tail=Nil)
+        Empty => continue tail
+        More(hd, tail=tl) => {
+          let dest = More(hd, tail=Empty)
           // copy all the elements of `head` first
           let dest1 = loop dest, tl {
-            dest, Nil => dest
-            Cons(_) as dest, Cons(hd, tail~) => {
-              dest.tail = Cons(hd, tail=Nil)
+            dest, Empty => dest
+            More(_) as dest, More(hd, tail~) => {
+              dest.tail = More(hd, tail=Empty)
               continue dest.tail, tail
             }
-            Nil, _ => panic()
+            Empty, _ => panic()
           }
           // continue looping on the `tail` of `self`
           loop_over_tail~: loop dest1, tail {
-            _, Nil => ()
-            Cons(_) as dest, Cons(t_hd, tail=Nil) => dest.tail = t_hd
-            dest, Cons(t_hd, tail=t_tl) =>
+            _, Empty => ()
+            More(_) as dest, More(t_hd, tail=Empty) => dest.tail = t_hd
+            dest, More(t_hd, tail=t_tl) =>
               loop dest, t_hd {
-                dest, Nil => continue loop_over_tail~ dest, t_tl
-                Cons(_) as dest, Cons(hd, tail~) => {
-                  dest.tail = Cons(hd, tail=Nil)
+                dest, Empty => continue loop_over_tail~ dest, t_tl
+                More(_) as dest, More(hd, tail~) => {
+                  dest.tail = More(hd, tail=Empty)
                   continue dest.tail, tail
                 }
-                Nil, _ => panic()
+                Empty, _ => panic()
               }
           }
           dest
@@ -695,11 +701,11 @@ pub fn flatten[A](self : T[T[A]]) -> T[A] {
 /// @alert unsafe "Panic if the list is empty"
 pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
   match self {
-    Nil => abort("maximum: empty list")
-    Cons(head, tail~) =>
+    Empty => abort("maximum: empty list")
+    More(head, tail~) =>
       loop tail, head {
-        Nil, curr_max => curr_max
-        Cons(item, tail~), curr_max =>
+        Empty, curr_max => curr_max
+        More(item, tail~), curr_max =>
           continue tail, if item > curr_max { item } else { curr_max }
       }
   }
@@ -710,11 +716,11 @@ pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
 /// Returns None if the list is empty.
 pub fn maximum[A : Compare](self : T[A]) -> A? {
   match self {
-    Nil => None
-    Cons(head, tail~) =>
+    Empty => None
+    More(head, tail~) =>
       loop tail, head {
-        Nil, curr_max => Some(curr_max)
-        Cons(item, tail~), curr_max =>
+        Empty, curr_max => Some(curr_max)
+        More(item, tail~), curr_max =>
           continue tail, if item > curr_max { item } else { curr_max }
       }
   }
@@ -724,11 +730,11 @@ pub fn maximum[A : Compare](self : T[A]) -> A? {
 /// @alert unsafe "Panic if the list is empty"
 pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
   match self {
-    Nil => abort("maximum: empty list")
-    Cons(head, tail~) =>
+    Empty => abort("maximum: empty list")
+    More(head, tail~) =>
       loop tail, head {
-        Nil, curr_min => curr_min
-        Cons(item, tail~), curr_min =>
+        Empty, curr_min => curr_min
+        More(item, tail~), curr_min =>
           continue tail, if item < curr_min { item } else { curr_min }
       }
   }
@@ -738,11 +744,11 @@ pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
 /// Get minimum element of the list.
 pub fn minimum[A : Compare](self : T[A]) -> A? {
   match self {
-    Nil => None
-    Cons(head, tail~) =>
+    Empty => None
+    More(head, tail~) =>
       loop tail, head {
-        Nil, curr_min => Some(curr_min)
-        Cons(item, tail~), curr_min =>
+        Empty, curr_min => Some(curr_min)
+        More(item, tail~), curr_min =>
           continue tail, if item < curr_min { item } else { curr_min }
       }
   }
@@ -759,11 +765,11 @@ pub fn minimum[A : Compare](self : T[A]) -> A? {
 /// ```
 pub fn sort[A : Compare](self : T[A]) -> T[A] {
   match self {
-    Nil => Nil
-    Cons(x, tail=xs) => {
+    Empty => Empty
+    More(x, tail=xs) => {
       let smaller = filter(xs, fn(y) { y < x })
       let greater = filter(xs, fn(y) { y >= x })
-      concat(sort(smaller), Cons(x, tail=sort(greater)))
+      concat(sort(smaller), More(x, tail=sort(greater)))
     }
   }
 }
@@ -780,8 +786,8 @@ pub impl[A] Add for T[A] with op_add(self, other) {
 /// Check if the list contains the value.
 pub fn contains[A : Eq](self : T[A], value : A) -> Bool {
   loop self {
-    Nil => false
-    Cons(x, tail=xs) => if x == value { true } else { continue xs }
+    Empty => false
+    More(x, tail=xs) => if x == value { true } else { continue xs }
   }
 }
 
@@ -796,16 +802,16 @@ pub fn contains[A : Eq](self : T[A], value : A) -> Bool {
 /// ```
 pub fn unfold[A, S](f : (S) -> (A, S)?, init~ : S) -> T[A] {
   match f(init) {
-    None => Nil
+    None => Empty
     Some((element, new_state)) => {
-      let dest = Cons(element, tail=Nil)
+      let dest = More(element, tail=Empty)
       loop dest, f(new_state) {
         _, None => ()
-        Cons(_) as dest, Some((element, new_state)) => {
-          dest.tail = Cons(element, tail=Nil)
+        More(_) as dest, Some((element, new_state)) => {
+          dest.tail = More(element, tail=Empty)
           continue dest.tail, f(new_state)
         }
-        Nil, _ => panic()
+        Empty, _ => panic()
       }
       dest
     }
@@ -825,20 +831,20 @@ pub fn unfold[A, S](f : (S) -> (A, S)?, init~ : S) -> T[A] {
 /// ```
 pub fn take[A](self : T[A], n : Int) -> T[A] {
   if n <= 0 {
-    Nil
+    Empty
   } else {
     match self {
-      Nil => Nil
-      Cons(head, tail~) => {
-        let dest = Cons(head, tail=Nil)
+      Empty => Empty
+      More(head, tail~) => {
+        let dest = More(head, tail=Empty)
         loop dest, tail, n - 1 {
-          _, Nil, _ => ()
+          _, Empty, _ => ()
           _, _, 0 => ()
-          Cons(_) as dest, Cons(x, tail=xs), n => {
-            dest.tail = Cons(x, tail=Nil)
+          More(_) as dest, More(x, tail=xs), n => {
+            dest.tail = More(x, tail=Empty)
             continue dest.tail, xs, n - 1
           }
-          Nil, _, _ => panic()
+          Empty, _, _ => panic()
         }
         dest
       }
@@ -859,9 +865,9 @@ pub fn take[A](self : T[A], n : Int) -> T[A] {
 /// ```
 pub fn drop[A](self : T[A], n : Int) -> T[A] {
   fn go {
-    _, Nil => Nil
-    1, Cons(_, tail=xs) => xs
-    n, Cons(_, tail=xs) => go(n - 1, xs)
+    _, Empty => Empty
+    1, More(_, tail=xs) => xs
+    n, More(_, tail=xs) => go(n - 1, xs)
   }
 
   if n <= 0 {
@@ -883,22 +889,22 @@ pub fn drop[A](self : T[A], n : Int) -> T[A] {
 /// ```
 pub fn take_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
   match self {
-    Nil => Nil
-    Cons(head, tail~) =>
+    Empty => Empty
+    More(head, tail~) =>
       if p(head) {
-        let dest = Cons(head, tail=Nil)
+        let dest = More(head, tail=Empty)
         loop dest, tail {
-          _, Nil => ()
-          Cons(_) as dest, Cons(x, tail=xs) if p(x) => {
-            dest.tail = Cons(x, tail=Nil)
+          _, Empty => ()
+          More(_) as dest, More(x, tail=xs) if p(x) => {
+            dest.tail = More(x, tail=Empty)
             continue dest.tail, xs
           }
-          Cons(_), _ => ()
-          Nil, _ => panic()
+          More(_), _ => ()
+          Empty, _ => panic()
         }
         dest
       } else {
-        Nil
+        Empty
       }
   }
 }
@@ -915,8 +921,8 @@ pub fn take_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
 /// ```
 pub fn drop_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
   loop self {
-    Nil => Nil
-    Cons(x, tail=xs) => if p(x) { continue xs } else { Cons(x, tail=xs) }
+    Empty => Empty
+    More(x, tail=xs) => if p(x) { continue xs } else { More(x, tail=xs) }
   }
 }
 
@@ -931,12 +937,12 @@ pub fn drop_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
 /// assert_eq!(r, @list.of([0, 1, 3, 6, 10, 15]))
 /// ```
 pub fn scan_left[A, E](self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
-  let dest = Cons(init, tail=Nil)
+  let dest = More(init, tail=Empty)
   loop dest, self, init {
-    _, Nil, _ => ()
-    Nil, _, _ => panic()
-    Cons(_) as dest, Cons(x, tail=xs), acc => {
-      dest.tail = Cons(f(acc, x), tail=Nil)
+    _, Empty, _ => ()
+    Empty, _, _ => panic()
+    More(_) as dest, More(x, tail=xs), acc => {
+      dest.tail = More(f(acc, x), tail=Empty)
       continue dest.tail, xs, f(acc, x)
     }
   }
@@ -969,8 +975,8 @@ pub fn scan_right[A, B](self : T[A], f : (B, A) -> B, init~ : B) -> T[B] {
 /// ```
 pub fn lookup[A : Eq, B](self : T[(A, B)], v : A) -> B? {
   loop self {
-    Nil => None
-    Cons((x, y), tail=xs) => if x == v { Some(y) } else { continue xs }
+    Empty => None
+    More((x, y), tail=xs) => if x == v { Some(y) } else { continue xs }
   }
 }
 
@@ -985,8 +991,8 @@ pub fn lookup[A : Eq, B](self : T[(A, B)], v : A) -> B? {
 /// ```
 pub fn find[A](self : T[A], f : (A) -> Bool) -> A? {
   loop self {
-    Nil => None
-    Cons(element, tail=list) =>
+    Empty => None
+    More(element, tail=list) =>
       if f(element) {
         Some(element)
       } else {
@@ -1008,8 +1014,8 @@ pub fn findi[A](self : T[A], f : (A, Int) -> Bool) -> A? {
   loop self, 0 {
     list, index =>
       match list {
-        Nil => None
-        Cons(element, tail=list) =>
+        Empty => None
+        More(element, tail=list) =>
           if f(element, index) {
             Some(element)
           } else {
@@ -1029,19 +1035,19 @@ pub fn findi[A](self : T[A], f : (A, Int) -> Bool) -> A? {
 /// ```
 pub fn remove_at[A](self : T[A], index : Int) -> T[A] {
   match (index, self) {
-    (_, Nil) => Nil
+    (_, Empty) => Empty
     (_..<0, _) => self
-    (0, Cons(_, tail~)) => tail
-    (n, Cons(head, tail~)) => {
-      let dest = Cons(head, tail=Nil)
+    (0, More(_, tail~)) => tail
+    (n, More(head, tail~)) => {
+      let dest = More(head, tail=Empty)
       loop dest, tail, n - 1 {
-        _, Nil, _ => ()
-        Cons(_) as dest, Cons(_, tail~), 0 => dest.tail = tail
-        Cons(_) as dest, Cons(x, tail=xs), n => {
-          dest.tail = Cons(x, tail=Nil)
+        _, Empty, _ => ()
+        More(_) as dest, More(_, tail~), 0 => dest.tail = tail
+        More(_) as dest, More(x, tail=xs), n => {
+          dest.tail = More(x, tail=Empty)
           continue dest.tail, xs, n - 1
         }
-        Nil, _, _ => panic()
+        Empty, _, _ => panic()
       }
       dest
     }
@@ -1058,20 +1064,20 @@ pub fn remove_at[A](self : T[A], index : Int) -> T[A] {
 /// ```
 pub fn remove[A : Eq](self : T[A], elem : A) -> T[A] {
   match self {
-    Nil => Nil
-    Cons(head, tail~) if head == elem => tail
-    Cons(head, tail~) => {
-      let dest = Cons(head, tail~)
+    Empty => Empty
+    More(head, tail~) if head == elem => tail
+    More(head, tail~) => {
+      let dest = More(head, tail~)
       loop dest, tail {
-        _, Nil => ()
-        Cons(_) as dest, Cons(x, tail=xs) =>
+        _, Empty => ()
+        More(_) as dest, More(x, tail=xs) =>
           if x == elem {
             dest.tail = xs
           } else {
-            dest.tail = Cons(x, tail=Nil)
+            dest.tail = More(x, tail=Empty)
             continue dest.tail, xs
           }
-        Nil, _ => panic()
+        Empty, _ => panic()
       }
       dest
     }
@@ -1088,9 +1094,9 @@ pub fn remove[A : Eq](self : T[A], elem : A) -> T[A] {
 /// ```
 pub fn is_prefix[A : Eq](self : T[A], prefix : T[A]) -> Bool {
   loop self, prefix {
-    _, Nil => true
-    Nil, Cons(_) => false
-    Cons(h1, tail=t1), Cons(h2, tail=t2) =>
+    _, Empty => true
+    Empty, More(_) => false
+    More(h1, tail=t1), More(h2, tail=t2) =>
       if h1 == h2 {
         continue t1, t2
       } else {
@@ -1130,21 +1136,21 @@ pub fn intercalate[A](self : T[T[A]], sep : T[A]) -> T[A] {
 
 ///|
 pub impl[X] Default for T[X] with default() {
-  Nil
+  Empty
 }
 
 ///|
 /// The empty list
 pub fn default[X]() -> T[X] {
-  Nil
+  Empty
 }
 
 ///|
 pub fn iter[A](self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
     loop self {
-      Nil => IterContinue
-      Cons(head, tail~) => {
+      Empty => IterContinue
+      More(head, tail~) => {
         if yield_(head) == IterEnd {
           break IterEnd
         }
@@ -1158,8 +1164,8 @@ pub fn iter[A](self : T[A]) -> Iter[A] {
 pub fn iter2[A](self : T[A]) -> Iter2[Int, A] {
   Iter2::new(fn(yield_) {
     loop self, 0 {
-      Nil, _ => IterEnd
-      Cons(head, tail~), i => {
+      Empty, _ => IterEnd
+      More(head, tail~), i => {
         if yield_(i, head) == IterEnd {
           break IterEnd
         }
@@ -1173,18 +1179,18 @@ pub fn iter2[A](self : T[A]) -> Iter2[Int, A] {
 /// Convert the iterator into a list. Preserves order of elements.
 /// If the order of elements is not important, use `from_iter_rev` instead.
 pub fn from_iter[A](iter : Iter[A]) -> T[A] {
-  iter.fold(init=Nil, fn(acc, e) { Cons(e, tail=acc) }).reverse_inplace()
+  iter.fold(init=Empty, fn(acc, e) { More(e, tail=acc) }).reverse_inplace()
 }
 
 ///|
 pub fn from_iter_rev[A](iter : Iter[A]) -> T[A] {
-  iter.fold(init=Nil, fn(acc, e) { Cons(e, tail=acc) })
+  iter.fold(init=Empty, fn(acc, e) { More(e, tail=acc) })
 }
 
 ///|
 pub fn of[A](arr : FixedArray[A]) -> T[A] {
-  for i = arr.length() - 1, list = Nil; i >= 0; {
-    continue i - 1, Cons(arr[i], tail=list)
+  for i = arr.length() - 1, list = Empty; i >= 0; {
+    continue i - 1, More(arr[i], tail=list)
   } else {
     list
   }
@@ -1200,7 +1206,7 @@ pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[X] with arbitrar
 
 ///|
 pub fn singleton[A](x : A) -> T[A] {
-  Cons(x, tail=Nil)
+  More(x, tail=Empty)
 }
 
 ///|
@@ -1213,11 +1219,11 @@ pub impl[A : Hash] Hash for T[A] with hash_combine(self, hasher) {
 ///|
 fn reverse_inplace[A](self : T[A]) -> T[A] {
   match self {
-    Nil | Cons(_, tail=Nil) => self
-    Cons(head, tail~) =>
-      loop Cons(head, tail=Nil), tail {
-        result, Nil => result
-        result, Cons(_, tail=xs) as new_result => {
+    Empty | More(_, tail=Empty) => self
+    More(head, tail~) =>
+      loop More(head, tail=Empty), tail {
+        result, Empty => result
+        result, More(_, tail=xs) as new_result => {
           new_result.tail = result
           continue new_result, xs
         }

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -500,6 +500,7 @@ pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
           // continue looping on the `tail` of `self`
           loop_over_tail~: loop dest1, tail {
             _, Nil => ()
+            Cons(_) as dest, Cons(t_hd, tail=Nil) => dest.tail = f(t_hd)
             dest, Cons(t_hd, tail=t_tl) =>
               loop dest, f(t_hd) {
                 dest, Nil => continue loop_over_tail~ dest, t_tl
@@ -676,6 +677,7 @@ pub fn flatten[A](self : T[T[A]]) -> T[A] {
           // continue looping on the `tail` of `self`
           loop_over_tail~: loop dest1, tail {
             _, Nil => ()
+            Cons(_) as dest, Cons(t_hd, tail=Nil) => dest.tail = t_hd
             dest, Cons(t_hd, tail=t_tl) =>
               loop dest, t_hd {
                 dest, Nil => continue loop_over_tail~ dest, t_tl
@@ -956,7 +958,7 @@ pub fn scan_left[A, E](self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
 /// assert_eq!(r, @list.of([15, 14, 12, 9, 5, 0]))
 /// ```
 pub fn scan_right[A, B](self : T[A], f : (B, A) -> B, init~ : B) -> T[B] {
-  self.rev().scan_left(f, init~).rev()
+  self.rev().scan_left(f, init~).reverse_inplace()
 }
 
 ///|
@@ -1037,9 +1039,7 @@ pub fn remove_at[A](self : T[A], index : Int) -> T[A] {
       let dest = Cons(head, tail=Nil)
       loop dest, tail, n - 1 {
         _, Nil, _ => ()
-        Cons(_) as dest, Cons(_, tail~), 0 =>
-          // warning: sharing
-          dest.tail = tail
+        Cons(_) as dest, Cons(_, tail~), 0 => dest.tail = tail
         Cons(_) as dest, Cons(x, tail=xs), n => {
           dest.tail = Cons(x, tail=Nil)
           continue dest.tail, xs, n - 1
@@ -1069,7 +1069,6 @@ pub fn remove[A : Eq](self : T[A], elem : A) -> T[A] {
         _, Nil => ()
         Cons(_) as dest, Cons(x, tail=xs) =>
           if x == elem {
-            // warning: sharing
             dest.tail = xs
           } else {
             dest.tail = Cons(x, tail=Nil)
@@ -1175,10 +1174,9 @@ pub fn iter2[A](self : T[A]) -> Iter2[Int, A] {
 
 ///|
 /// Convert the iterator into a list. Preserves order of elements.
-/// This function is tail-recursive, but consumes 2*n memory. 
 /// If the order of elements is not important, use `from_iter_rev` instead.
 pub fn from_iter[A](iter : Iter[A]) -> T[A] {
-  iter.fold(init=Nil, fn(acc, e) { Cons(e, tail=acc) }).rev()
+  iter.fold(init=Nil, fn(acc, e) { Cons(e, tail=acc) }).reverse_inplace()
 }
 
 ///|
@@ -1212,5 +1210,20 @@ pub fn singleton[A](x : A) -> T[A] {
 pub impl[A : Hash] Hash for T[A] with hash_combine(self, hasher) {
   for e in self {
     hasher.combine(e)
+  }
+}
+
+///|
+fn reverse_inplace[A](self : T[A]) -> T[A] {
+  match self {
+    Nil | Cons(_, tail=Nil) => self
+    Cons(head, tail~) =>
+      loop Cons(head, tail=Nil), tail {
+        result, Nil => result
+        result, Cons(_, tail=xs) as new_result => {
+          new_result.tail = result
+          continue new_result, xs
+        }
+      }
   }
 }

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1,0 +1,1044 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Creates an empty list
+pub fn nil[A]() -> T[A] {
+  Nil
+}
+
+///|
+/// Prepend an element to the list and create a new list.
+pub fn cons[A](head : A, tail : T[A]) -> T[A] {
+  Cons(head, tail~)
+}
+
+///|
+pub fn add[A](self : T[A], head : A) -> T[A] {
+  Cons(head, tail=self)
+}
+
+///|
+pub impl[A : Show] Show for T[A] with output(xs, logger) {
+  logger.write_iter(xs.iter(), prefix="@list.of([", suffix="])")
+}
+
+///|
+pub impl[A : ToJson] ToJson for T[A] with to_json(self) {
+  let capacity = self.length()
+  guard capacity != 0 else { return [] }
+  let jsons = Array::new(capacity~)
+  for a in self {
+    jsons.push(a.to_json())
+  }
+  Array(jsons)
+}
+
+///|
+pub fn to_json[A : ToJson](self : T[A]) -> Json {
+  ToJson::to_json(self)
+}
+
+///|
+pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) {
+  guard json is Array(arr) else {
+    raise @json.JsonDecodeError((path, "@immut/list.from_json: expected array"))
+  }
+  for i = arr.length() - 1, list = Nil; i >= 0; {
+    continue i - 1, list.add(A::from_json!(arr[i], path))
+  } else {
+    list
+  }
+}
+
+///|
+pub fn from_json[A : @json.FromJson](json : Json) -> T[A]!@json.JsonDecodeError {
+  @json.from_json!(json)
+}
+
+///|
+/// Convert array to list.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.of([1, 2, 3, 4, 5])
+/// assert_eq!(ls, @list.from_array([1, 2, 3, 4, 5]))
+/// ```
+pub fn from_array[A](arr : Array[A]) -> T[A] {
+  for i = arr.length() - 1, list = Nil; i >= 0; {
+    continue i - 1, Cons(arr[i], tail=list)
+  } else {
+    list
+  }
+}
+
+///|
+/// Get the length of the list.
+pub fn length[A](self : T[A]) -> Int {
+  loop self, 0 {
+    Nil, len => len
+    Cons(_, tail=rest), acc => continue rest, acc + 1
+  }
+}
+
+///|
+/// Iterates over the list.
+///
+/// # Example
+///
+/// ```
+/// let arr = []
+/// @list.of([1, 2, 3, 4, 5]).each(fn(x) { arr.push(x) })
+/// assert_eq!(arr, [1, 2, 3, 4, 5])
+/// ```
+pub fn each[A](self : T[A], f : (A) -> Unit) -> Unit {
+  loop self {
+    Nil => ()
+    Cons(head, tail~) => {
+      f(head)
+      continue tail
+    }
+  }
+}
+
+///|
+/// Iterates over the list with index.
+///
+/// # Example
+///
+/// ```
+/// let arr = []
+/// @list.of([1, 2, 3, 4, 5]).eachi(fn(i, x) { arr.push("(\{i},\{x})") })
+/// assert_eq!(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
+/// ```
+pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
+  loop self, 0 {
+    Nil, _ => ()
+    Cons(x, tail=xs), i => {
+      f(i, x)
+      continue xs, i + 1
+    }
+  }
+}
+
+///|
+/// Maps the list.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).map(fn(x){ x * 2}), @list.of([2, 4, 6, 8, 10]))
+/// ```
+pub fn map[A, B](self : T[A], f : (A) -> B) -> T[B] {
+  match self {
+    Nil => Nil
+    Cons(head, tail~) => Cons(f(head), tail=map(tail, f))
+  }
+}
+
+///|
+/// Maps the list with index.
+pub fn mapi[A, B](self : T[A], f : (Int, A) -> B) -> T[B] {
+  fn go(xs : T[A], i : Int, f : (Int, A) -> B) -> T[B] {
+    match xs {
+      Nil => Nil
+      Cons(x, tail=xs) => Cons(f(i, x), tail=go(xs, i + 1, f))
+    }
+  }
+
+  go(self, 0, f)
+}
+
+///|
+/// Maps the list and reverses the result.
+///
+/// `list.rev_map(f)` is equivalent to `list.map(f).rev()` but more efficient.
+///
+/// # Example
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).rev_map(fn(x) { x * 2 }), @list.of([10, 8, 6, 4, 2]))
+/// ```
+pub fn rev_map[A, B](self : T[A], f : (A) -> B) -> T[B] {
+  loop Nil, self {
+    acc, Nil => acc
+    acc, Cons(x, tail=xs) => continue Cons(f(x), tail=acc), xs
+  }
+}
+
+///|
+/// Convert list to array.
+pub fn to_array[A](self : T[A]) -> Array[A] {
+  match self {
+    Nil => []
+    Cons(x, tail=xs) => {
+      let arr = [x]
+      loop xs {
+        Nil => ()
+        Cons(x, tail=xs) => {
+          arr.push(x)
+          continue xs
+        }
+      }
+      arr
+    }
+  }
+}
+
+///|
+/// Filter the list.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).filter(fn(x){ x % 2 == 0}), @list.of([2, 4]))
+/// ```
+pub fn filter[A](self : T[A], f : (A) -> Bool) -> T[A] {
+  match self {
+    Nil => Nil
+    Cons(head, tail~) =>
+      if f(head) {
+        Cons(head, tail=filter(tail, f))
+      } else {
+        filter(tail, f)
+      }
+  }
+}
+
+///|
+/// Test if all elements of the list satisfy the predicate.
+pub fn all[A](self : T[A], f : (A) -> Bool) -> Bool {
+  loop self {
+    Nil => true
+    Cons(head, tail~) => if f(head) { continue tail } else { false }
+  }
+}
+
+///|
+/// Test if any element of the list satisfies the predicate.
+pub fn any[A](self : T[A], f : (A) -> Bool) -> Bool {
+  match self {
+    Nil => false
+    Cons(head, tail~) => f(head) || any(tail, f)
+  }
+}
+
+///|
+/// Tail of the list.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).tail(), @list.of([2, 3, 4, 5]))
+/// ```
+pub fn tail[A](self : T[A]) -> T[A] {
+  match self {
+    Nil => Nil
+    Cons(_, tail~) => tail
+  }
+}
+
+///|
+/// Get first element of the list.
+/// @alert unsafe "Panic if the list is empty"
+pub fn unsafe_head[A](self : T[A]) -> A {
+  match self {
+    Nil => abort("head of empty list")
+    Cons(head, tail=_) => head
+  }
+}
+
+///|
+/// Get first element of the list.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).head(), Some(1))
+/// ```
+pub fn head[A](self : T[A]) -> A? {
+  match self {
+    Nil => None
+    Cons(head, tail=_) => Some(head)
+  }
+}
+
+///|
+/// @alert unsafe "Panic if the list is empty"
+pub fn unsafe_last[A](self : T[A]) -> A {
+  loop self {
+    Nil => abort("last of empty list")
+    Cons(head, tail=Nil) => head
+    Cons(_, tail~) => continue tail
+  }
+}
+
+///|
+/// Last element of the list.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).last(), Some(5))
+/// ```
+pub fn last[A](self : T[A]) -> A? {
+  loop self {
+    Nil => None
+    Cons(head, tail=Nil) => Some(head)
+    Cons(_, tail~) => continue tail
+  }
+}
+
+///|
+/// Concatenate two lists.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.of([1, 2, 3, 4, 5]).concat(@list.of([6, 7, 8, 9, 10]))
+/// assert_eq!(ls, @list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+/// ```
+pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
+  match self {
+    Nil => other
+    Cons(head, tail~) => Cons(head, tail=concat(tail, other))
+  }
+}
+
+///|
+/// Reverse the first list and concatenate it with the second.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.of([1, 2, 3, 4, 5]).rev_concat(@list.of([6, 7, 8, 9, 10]))
+/// assert_eq!(ls, @list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10]))
+/// ```
+pub fn rev_concat[A](self : T[A], other : T[A]) -> T[A] {
+  loop self, other {
+    Nil, other => other
+    Cons(head, tail~), other => continue tail, Cons(head, tail=other)
+  }
+}
+
+///|
+/// Reverse the list.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).rev(), @list.of([5, 4, 3, 2, 1]))
+/// ```
+pub fn rev[A](self : T[A]) -> T[A] {
+  self.rev_concat(Nil)
+}
+
+///|
+/// Fold the list from left.
+///
+/// # Example
+///
+/// ```
+/// let r = @list.of([1, 2, 3, 4, 5]).fold(init=0, fn(acc, x) { acc + x })
+/// assert_eq!(r, 15)
+/// ```
+pub fn fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
+  match self {
+    Nil => init
+    Cons(head, tail~) => tail.fold(f, init=f(init, head))
+  }
+}
+
+///|
+/// Fold the list from right.
+///
+/// # Example
+/// ```
+/// let r = @list.of([1, 2, 3, 4, 5]).rev_fold(fn(x, acc) { x + acc }, init=0)
+/// assert_eq!(r, 15)
+/// ```
+pub fn rev_fold[A, B](self : T[A], init~ : B, f : (A, B) -> B) -> B {
+  match self {
+    Nil => init
+    Cons(head, tail~) => f(head, tail.rev_fold(f, init~))
+  }
+}
+
+///|
+/// Fold the list from left with index.
+pub fn foldi[A, B](self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
+  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B, acc : B) -> B {
+    match xs {
+      Nil => acc
+      Cons(x, tail=xs) => go(xs, i + 1, f, f(i, acc, x))
+    }
+  }
+
+  go(self, 0, f, init)
+}
+
+///|
+/// Fold the list from right with index.
+pub fn rev_foldi[A, B](self : T[A], init~ : B, f : (Int, A, B) -> B) -> B {
+  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B, acc : B) -> B {
+    match xs {
+      Nil => acc
+      Cons(x, tail=xs) => f(i, x, go(xs, i + 1, f, acc))
+    }
+  }
+
+  go(self, 0, f, init)
+}
+
+///|
+/// Zip two lists.
+/// If the lists have different lengths, it will return None.
+///
+/// # Example
+///
+/// ```
+/// let r = @list.zip(@list.of([1, 2, 3, 4, 5]), @list.of([6, 7, 8, 9, 10]))
+/// assert_eq!(r, Some(@list.from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)])))
+/// ```
+pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)]? {
+  let mut acc = Nil
+  let res = loop self, other {
+    Nil, Nil => break Some(acc)
+    Cons(x, tail=xs), Cons(y, tail=ys) => {
+      acc = Cons((x, y), tail=acc)
+      continue xs, ys
+    }
+    _, _ => break None
+  }
+  res.map(T::rev)
+}
+
+///|
+/// map over the list and concat all results.
+///
+/// `flat_map(f, ls)` equal to `ls.map(f).fold(Nil, fn(acc, x) { acc.concat(x) })))`
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.from_array([1, 2, 3])
+/// let r = ls.flat_map(fn(x) { @list.from_array([x, x * 2]) })
+/// assert_eq!(r, @list.from_array([1, 2, 2, 4, 3, 6]))
+/// ```
+pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
+  match self {
+    Nil => Nil
+    Cons(head, tail~) => concat(f(head), flat_map(tail, f))
+  }
+}
+
+///|
+/// Map over the list and keep all `value`s for which the mapped result is `Some(value)`.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.of([4, 2, 2, 6, 3, 1])
+/// let r = ls.filter_map(fn(x) { if (x >= 3) { Some(x) } else { None } })
+/// assert_eq!(r, @list.of([4, 6, 3]))
+/// ```
+pub fn filter_map[A, B](self : T[A], f : (A) -> B?) -> T[B] {
+  loop Nil, self {
+    acc, Nil => acc.rev()
+    acc, Cons(x, tail=xs) =>
+      match f(x) {
+        Some(v) => continue acc.add(v), xs
+        None => continue acc, xs
+      }
+  }
+}
+
+///|
+/// @alert unsafe "Panic if the index is out of bounds"
+pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
+  loop self, n {
+    Nil, _ => abort("nth: index out of bounds")
+    Cons(head, tail=_), 0 => head
+    Cons(_, tail~), n => continue tail, n - 1
+  }
+}
+
+///|
+#deprecated("Use `unsafe_nth` instead")
+#coverage.skip
+pub fn nth_exn[A](self : T[A], n : Int) -> A {
+  unsafe_nth(self, n)
+}
+
+///|
+/// Get nth element of the list or None if the index is out of bounds
+pub fn nth[A](self : T[A], n : Int) -> A? {
+  loop self, n {
+    Nil, _ => None
+    Cons(head, tail=_), 0 => Some(head)
+    Cons(_, tail~), n => continue tail, n - 1
+  }
+}
+
+///|
+/// Create a list of length n with the given value
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.repeat(5, 1), @list.from_array([1, 1, 1, 1, 1]))
+/// ```
+pub fn repeat[A](n : Int, x : A) -> T[A] {
+  if n == 0 {
+    Nil
+  } else {
+    Cons(x, tail=repeat(n - 1, x))
+  }
+}
+
+///|
+/// Insert separator to the list.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.intersperse(@list.from_array(["1", "2", "3", "4", "5"]), "|")
+/// assert_eq!(ls, @list.from_array(["1", "|", "2", "|", "3", "|", "4", "|", "5"]))
+/// ```
+pub fn intersperse[A](self : T[A], separator : A) -> T[A] {
+  match self {
+    Nil => Nil
+    Cons(head, tail=Nil) => Cons(head, tail=Nil)
+    Cons(head, tail~) =>
+      Cons(head, tail=Cons(separator, tail=intersperse(tail, separator)))
+  }
+}
+
+///|
+/// Check if the list is empty.
+pub fn is_empty[A](self : T[A]) -> Bool {
+  self is Nil
+}
+
+///|
+/// Unzip two lists.
+///
+/// # Example
+///
+/// ```
+/// let (a,b) = @list.unzip(@list.from_array([(1,2),(3,4),(5,6)]))
+/// assert_eq!(a, @list.from_array([1, 3, 5]))
+/// assert_eq!(b, @list.from_array([2, 4, 6]))
+/// ```
+pub fn unzip[A, B](self : T[(A, B)]) -> (T[A], T[B]) {
+  let mut xs = Nil
+  let mut ys = Nil
+  // implemented with loop to avoid stack overflow
+  loop self.rev() {
+    Nil => break (xs, ys)
+    Cons((x, y), tail~) => {
+      xs = Cons(x, tail=xs)
+      ys = Cons(y, tail=ys)
+      continue tail
+    }
+  }
+}
+
+///|
+/// flatten a list of lists.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.flatten(@list.from_array([@list.from_array([1,2,3]), @list.from_array([4,5,6]), @list.from_array([7,8,9])]))
+/// assert_eq!(ls, @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+/// ```
+pub fn flatten[A](self : T[T[A]]) -> T[A] {
+  match self {
+    Nil => Nil
+    Cons(head, tail~) => concat(head, flatten(tail))
+  }
+}
+
+///|
+/// @alert unsafe "Panic if the list is empty"
+pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
+  match self {
+    Nil => abort("maximum: empty list")
+    Cons(x, tail=Nil) => x
+    Cons(x, tail=xs) => {
+      let y = unsafe_maximum(xs)
+      if x > y {
+        x
+      } else {
+        y
+      }
+    }
+  }
+}
+
+///|
+/// Get maximum element of the list.
+/// Returns None if the list is empty.
+pub fn maximum[A : Compare](self : T[A]) -> A? {
+  match self {
+    Nil => None
+    Cons(x, tail=Nil) => Some(x)
+    Cons(x, tail=xs) =>
+      match maximum(xs) {
+        None => Some(x)
+        Some(y) => Some(if x > y { x } else { y })
+      }
+  }
+}
+
+///|
+/// @alert unsafe "Panic if the list is empty"
+pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
+  match self {
+    Nil => abort("minimum: empty list")
+    Cons(x, tail=Nil) => x
+    Cons(x, tail=xs) => {
+      let y = unsafe_minimum(xs)
+      if x < y {
+        x
+      } else {
+        y
+      }
+    }
+  }
+}
+
+///|
+/// Get minimum element of the list.
+pub fn minimum[A : Compare](self : T[A]) -> A? {
+  match self {
+    Nil => None
+    Cons(x, tail=Nil) => Some(x)
+    Cons(x, tail=xs) =>
+      match minimum(xs) {
+        None => Some(x)
+        Some(y) => Some(if x < y { x } else { y })
+      }
+  }
+}
+
+///|
+/// Sort the list in ascending order.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.sort(@list.from_array([1,123,52,3,6,0,-6,-76]))
+/// assert_eq!(ls, @list.from_array([-76, -6, 0, 1, 3, 6, 52, 123]))
+/// ```
+pub fn sort[A : Compare](self : T[A]) -> T[A] {
+  match self {
+    Nil => Nil
+    Cons(x, tail=xs) => {
+      let smaller = filter(xs, fn(y) { y < x })
+      let greater = filter(xs, fn(y) { y >= x })
+      concat(sort(smaller), Cons(x, tail=sort(greater)))
+    }
+  }
+}
+
+///|
+/// Concatenate two lists.
+///
+/// `a + b` equal to `a.concat(b)`
+pub impl[A] Add for T[A] with op_add(self, other) {
+  self.concat(other)
+}
+
+///|
+/// Check if the list contains the value.
+pub fn contains[A : Eq](self : T[A], value : A) -> Bool {
+  loop self {
+    Nil => false
+    Cons(x, tail=xs) => if x == value { true } else { continue xs }
+  }
+}
+
+///|
+/// Produces a collection iteratively.
+///
+/// # Example
+///
+/// ```
+/// let r = @list.unfold(init=0, fn { i => if i == 3 { None } else { Some((i, i + 1)) } })
+/// assert_eq!(r, @list.from_array([0, 1, 2]))
+/// ```
+pub fn unfold[A, S](f : (S) -> (A, S)?, init~ : S) -> T[A] {
+  match f(init) {
+    Some((element, new_state)) => Cons(element, tail=unfold(init=new_state, f))
+    None => Nil
+  }
+}
+
+///|
+/// Take first n elements of the list.
+/// If the list is shorter than n, return the whole list.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.of([1, 2, 3, 4, 5])
+/// let r = ls.take(3)
+/// assert_eq!(r, @list.of([1, 2, 3]))
+/// ```
+pub fn take[A](self : T[A], n : Int) -> T[A] {
+  fn go {
+    _, Nil => Nil
+    1, Cons(x, tail=_) => Cons(x, tail=Nil)
+    n, Cons(x, tail=xs) => Cons(x, tail=go(n - 1, xs))
+  }
+
+  if n <= 0 {
+    Nil
+  } else {
+    go(n, self)
+  }
+}
+
+///|
+/// Drop first n elements of the list.
+/// If the list is shorter than n, return an empty list.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.of([1, 2, 3, 4, 5])
+/// let r = ls.drop(3)
+/// assert_eq!(r, @list.of([4, 5]))
+/// ```
+pub fn drop[A](self : T[A], n : Int) -> T[A] {
+  fn go {
+    _, Nil => Nil
+    1, Cons(_, tail=xs) => xs
+    n, Cons(_, tail=xs) => go(n - 1, xs)
+  }
+
+  if n <= 0 {
+    self
+  } else {
+    go(n, self)
+  }
+}
+
+///|
+/// Take the longest prefix of a list of elements that satisfies a given predicate.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.from_array([1, 2, 3, 4])
+/// let r = ls.take_while(fn(x) { x < 3 })
+/// assert_eq!(r, @list.of([1, 2]))
+/// ```
+pub fn take_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
+  match self {
+    Nil => Nil
+    Cons(x, tail=xs) => if p(x) { Cons(x, tail=xs.take_while(p)) } else { Nil }
+  }
+}
+
+///|
+/// Drop the longest prefix of a list of elements that satisfies a given predicate.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.from_array([1, 2, 3, 4])
+/// let r = ls.drop_while(fn(x) { x < 3 })
+/// assert_eq!(r, @list.of([3, 4]))
+/// ```
+pub fn drop_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
+  loop self {
+    Nil => Nil
+    Cons(x, tail=xs) => if p(x) { continue xs } else { Cons(x, tail=xs) }
+  }
+}
+
+///|
+/// Fold a list and return a list of successive reduced values from the left
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.of([1, 2, 3, 4, 5])
+/// let r = ls.scan_left(fn(acc, x) { acc + x }, init=0)
+/// assert_eq!(r, @list.of([0, 1, 3, 6, 10, 15]))
+/// ```
+pub fn scan_left[A, E](self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
+  Cons(
+    init,
+    tail=match self {
+      Nil => Nil
+      Cons(x, tail=xs) => xs.scan_left(f, init=f(init, x))
+    },
+  )
+}
+
+///|
+/// Fold a list and return a list of successive reduced values from the right
+///
+/// Note that the order of parameters on the accumulating function are reversed.
+///
+/// # Example
+/// ```
+/// let ls = @list.of([1, 2, 3, 4, 5])
+/// let r = ls.scan_right(fn(x, acc) { acc + x }, init=0)
+/// assert_eq!(r, @list.of([15, 14, 12, 9, 5, 0]))
+/// ```
+pub fn scan_right[A, B](self : T[A], f : (A, B) -> B, init~ : B) -> T[B] {
+  match self {
+    Nil => Cons(init, tail=Nil)
+    Cons(x, tail=xs) => {
+      let qs = xs.scan_right(f, init~)
+      Cons(f(x, qs.unsafe_head()), tail=qs)
+    }
+  }
+}
+
+///|
+/// Looks up a key in an association list.
+///
+/// # Example
+///
+/// ```
+/// let ls = @list.from_array([(1, "a"), (2, "b"), (3, "c")])
+/// assert_eq!(ls.lookup(3), Some("c"))
+/// ```
+pub fn lookup[A : Eq, B](self : T[(A, B)], v : A) -> B? {
+  loop self {
+    Nil => None
+    Cons((x, y), tail=xs) => if x == v { Some(y) } else { continue xs }
+  }
+}
+
+///|
+/// Find the first element in the list that satisfies f.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 3, 5, 8]).find(fn(element) -> Bool { element % 2 == 0}), Some(8))
+/// assert_eq!(@list.of([1, 3, 5]).find(fn(element) -> Bool { element % 2 == 0}), None)
+/// ```
+pub fn find[A](self : T[A], f : (A) -> Bool) -> A? {
+  loop self {
+    Nil => None
+    Cons(element, tail=list) =>
+      if f(element) {
+        Some(element)
+      } else {
+        continue list
+      }
+  }
+}
+
+///|
+/// Find the first element in the list that satisfies f and passes the index as an argument.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 3, 5, 8]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), Some(8))
+/// assert_eq!(@list.of([1, 3, 8, 5]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), None)
+/// ```
+pub fn findi[A](self : T[A], f : (A, Int) -> Bool) -> A? {
+  loop self, 0 {
+    list, index =>
+      match list {
+        Nil => None
+        Cons(element, tail=list) =>
+          if f(element, index) {
+            Some(element)
+          } else {
+            continue list, index + 1
+          }
+      }
+  }
+}
+
+///|
+/// Removes the element at the specified index in the list.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).remove_at(2), @list.of([1, 2, 4, 5]))
+/// ```
+pub fn remove_at[A](self : T[A], index : Int) -> T[A] {
+  match (index, self) {
+    (0, Cons(_, tail~)) => tail
+    (_, Cons(head, tail~)) => Cons(head, tail=remove_at(tail, index - 1))
+    (_, Nil) => Nil
+    // abort("remove_at: index out of bounds")
+  }
+}
+
+///|
+/// Removes the first occurrence of the specified element from the list, if it is present.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).remove(3), @list.of([1, 2, 4, 5]))
+/// ```
+pub fn remove[A : Eq](self : T[A], elem : A) -> T[A] {
+  match self {
+    Nil => Nil
+    Cons(head, tail~) =>
+      if head == elem {
+        tail
+      } else {
+        Cons(head, tail=remove(tail, elem))
+      }
+  }
+}
+
+///|
+/// Returns true if list starts with prefix.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([1, 2, 3])), true)
+/// ```
+pub fn is_prefix[A : Eq](self : T[A], prefix : T[A]) -> Bool {
+  loop self, prefix {
+    _, Nil => true
+    Nil, Cons(_) => false
+    Cons(h1, tail=t1), Cons(h2, tail=t2) =>
+      if h1 == h2 {
+        continue t1, t2
+      } else {
+        false
+      }
+  }
+}
+
+///|
+/// Returns true if list ends with suffix.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(@list.of([1, 2, 3, 4, 5]).is_suffix(@list.of([3, 4, 5])), true)
+/// ```
+pub fn is_suffix[A : Eq](self : T[A], suffix : T[A]) -> Bool {
+  self.rev().is_prefix(suffix.rev())
+}
+
+///|
+/// Similar to intersperse but with a list of values.
+///
+/// # Example
+/// ```
+/// let ls = @list.of([
+///    @list.of([1, 2, 3]),
+///    @list.of([4, 5, 6]),
+///    @list.of([7, 8, 9]),
+/// ])
+/// let r = ls.intercalate(@list.of([0]))
+/// assert_eq!(r, @list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]))
+/// ```
+pub fn intercalate[A](self : T[T[A]], sep : T[A]) -> T[A] {
+  self.intersperse(sep).flatten()
+}
+
+///|
+pub impl[X] Default for T[X] with default() {
+  Nil
+}
+
+///|
+/// The empty list
+pub fn default[X]() -> T[X] {
+  Nil
+}
+
+///|
+pub fn iter[A](self : T[A]) -> Iter[A] {
+  Iter::new(fn(yield_) {
+    loop self {
+      Nil => IterContinue
+      Cons(head, tail~) => {
+        if yield_(head) == IterEnd {
+          break IterEnd
+        }
+        continue tail
+      }
+    }
+  })
+}
+
+///|
+pub fn iter2[A](self : T[A]) -> Iter2[Int, A] {
+  Iter2::new(fn(yield_) {
+    loop self, 0 {
+      Nil, _ => IterEnd
+      Cons(head, tail~), i => {
+        if yield_(i, head) == IterEnd {
+          break IterEnd
+        }
+        continue tail, i + 1
+      }
+    }
+  })
+}
+
+///|
+/// Convert the iterator into a list. Preserves order of elements.
+/// This function is tail-recursive, but consumes 2*n memory. 
+/// If the order of elements is not important, use `from_iter_rev` instead.
+pub fn from_iter[A](iter : Iter[A]) -> T[A] {
+  iter.fold(init=Nil, fn(acc, e) { Cons(e, tail=acc) }).rev()
+}
+
+///|
+pub fn from_iter_rev[A](iter : Iter[A]) -> T[A] {
+  iter.fold(init=Nil, fn(acc, e) { Cons(e, tail=acc) })
+}
+
+///|
+pub fn of[A](arr : FixedArray[A]) -> T[A] {
+  for i = arr.length() - 1, list = Nil; i >= 0; {
+    continue i - 1, Cons(arr[i], tail=list)
+  } else {
+    list
+  }
+}
+
+///|
+pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[X] with arbitrary(
+  size,
+  rs
+) {
+  @quickcheck.Arbitrary::arbitrary(size, rs) |> from_array
+}
+
+///|
+pub fn singleton[A](x : A) -> T[A] {
+  Cons(x, tail=Nil)
+}
+
+///|
+pub impl[A : Hash] Hash for T[A] with hash_combine(self, hasher) {
+  for e in self {
+    hasher.combine(e)
+  }
+}

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -144,21 +144,41 @@ pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
 pub fn map[A, B](self : T[A], f : (A) -> B) -> T[B] {
   match self {
     Nil => Nil
-    Cons(head, tail~) => Cons(f(head), tail=map(tail, f))
+    Cons(hd, tail~) => {
+      let dest = Cons(f(hd), tail=Nil)
+      loop dest, tail {
+        _, Nil => ()
+        Cons(_) as dest, Cons(hd, tail~) => {
+          dest.tail = Cons(f(hd), tail=Nil)
+          continue dest.tail, tail
+        }
+        // unreachable
+        Nil, _ => panic()
+      }
+      dest
+    }
   }
 }
 
 ///|
 /// Maps the list with index.
 pub fn mapi[A, B](self : T[A], f : (Int, A) -> B) -> T[B] {
-  fn go(xs : T[A], i : Int, f : (Int, A) -> B) -> T[B] {
-    match xs {
-      Nil => Nil
-      Cons(x, tail=xs) => Cons(f(i, x), tail=go(xs, i + 1, f))
+  match self {
+    Nil => Nil
+    Cons(hd, tail~) => {
+      let dest = Cons(f(0, hd), tail=Nil)
+      loop 1, dest, tail {
+        _, _, Nil => ()
+        i, Cons(_) as dest, Cons(hd, tail~) => {
+          dest.tail = Cons(f(i, hd), tail=Nil)
+          continue i + 1, dest.tail, tail
+        }
+        // unreachable
+        _, Nil, _ => panic()
+      }
+      dest
     }
   }
-
-  go(self, 0, f)
 }
 
 ///|
@@ -205,13 +225,27 @@ pub fn to_array[A](self : T[A]) -> Array[A] {
 /// assert_eq!(@list.of([1, 2, 3, 4, 5]).filter(fn(x){ x % 2 == 0}), @list.of([2, 4]))
 /// ```
 pub fn filter[A](self : T[A], f : (A) -> Bool) -> T[A] {
-  match self {
+  loop self {
     Nil => Nil
     Cons(head, tail~) =>
-      if f(head) {
-        Cons(head, tail=filter(tail, f))
+      if not(f(head)) {
+        continue tail
       } else {
-        filter(tail, f)
+        let dest = Cons(head, tail=Nil)
+        loop dest, tail {
+          _, Nil => ()
+          Cons(_) as dest, Cons(hd, tail~) =>
+            if f(hd) {
+              dest.tail = Cons(hd, tail=Nil)
+              continue dest.tail, tail
+            } else {
+              continue dest, tail
+            }
+          Nil, _ =>
+            // unreachable
+            panic()
+        }
+        dest
       }
   }
 }
@@ -230,7 +264,9 @@ pub fn all[A](self : T[A], f : (A) -> Bool) -> Bool {
 pub fn any[A](self : T[A], f : (A) -> Bool) -> Bool {
   match self {
     Nil => false
-    Cons(head, tail~) => f(head) || any(tail, f)
+    Cons(head, tail~) =>
+      // this is tail recursive
+      f(head) || any(tail, f)
   }
 }
 
@@ -312,7 +348,20 @@ pub fn last[A](self : T[A]) -> A? {
 pub fn concat[A](self : T[A], other : T[A]) -> T[A] {
   match self {
     Nil => other
-    Cons(head, tail~) => Cons(head, tail=concat(tail, other))
+    Cons(hd, tail=Nil) => Cons(hd, tail=other)
+    Cons(hd, tail~) => {
+      let dest = Cons(hd, tail=Nil)
+      loop dest, tail {
+        Cons(_) as dest, Nil => dest.tail = other
+        Cons(_) as dest, Cons(head, tail~) => {
+          dest.tail = Cons(head, tail=Nil)
+          continue dest.tail, tail
+        }
+        // unreachable
+        Nil, _ => panic()
+      }
+      dest
+    }
   }
 }
 
@@ -437,9 +486,39 @@ pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)]? {
 /// assert_eq!(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// ```
 pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
-  match self {
+  loop self {
     Nil => Nil
-    Cons(head, tail~) => concat(f(head), flat_map(tail, f))
+    Cons(head, tail~) =>
+      match f(head) {
+        // continue until we have at least one element
+        Nil => continue tail
+        Cons(hd, tail=tl) => {
+          let dest = Cons(hd, tail=Nil)
+          // copy all the elements of `f(head)` first
+          let dest1 = loop dest, tl {
+            dest, Nil => dest
+            Cons(_) as dest, Cons(hd, tail~) => {
+              dest.tail = Cons(hd, tail=Nil)
+              continue dest.tail, tail
+            }
+            Nil, _ => panic()
+          }
+          // continue looping on the `tail` of `self`
+          loop_over_tail~: loop dest1, tail {
+            _, Nil => ()
+            dest, Cons(t_hd, tail=t_tl) =>
+              loop dest, f(t_hd) {
+                dest, Nil => continue loop_over_tail~ dest, t_tl
+                Cons(_) as dest, Cons(hd, tail~) => {
+                  dest.tail = Cons(hd, tail=Nil)
+                  continue dest.tail, tail
+                }
+                Nil, _ => panic()
+              }
+          }
+          dest
+        }
+      }
   }
 }
 
@@ -454,12 +533,27 @@ pub fn flat_map[A, B](self : T[A], f : (A) -> T[B]) -> T[B] {
 /// assert_eq!(r, @list.of([4, 6, 3]))
 /// ```
 pub fn filter_map[A, B](self : T[A], f : (A) -> B?) -> T[B] {
-  loop Nil, self {
-    acc, Nil => acc.rev()
-    acc, Cons(x, tail=xs) =>
-      match f(x) {
-        Some(v) => continue acc.add(v), xs
-        None => continue acc, xs
+  loop self {
+    Nil => Nil
+    Cons(hd, tail~) =>
+      match f(hd) {
+        None => continue tail
+        Some(head) => {
+          let dest = Cons(head, tail=Nil)
+          loop dest, tail {
+            _, Nil => ()
+            Cons(_) as dest, Cons(hd, tail~) =>
+              match f(hd) {
+                None => continue dest, tail
+                Some(head) => {
+                  dest.tail = Cons(head, tail=Nil)
+                  continue dest.tail, tail
+                }
+              }
+            Nil, _ => panic()
+          }
+          dest
+        }
       }
   }
 }
@@ -472,13 +566,6 @@ pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
     Cons(head, tail=_), 0 => head
     Cons(_, tail~), n => continue tail, n - 1
   }
-}
-
-///|
-#deprecated("Use `unsafe_nth` instead")
-#coverage.skip
-pub fn nth_exn[A](self : T[A], n : Int) -> A {
-  unsafe_nth(self, n)
 }
 
 ///|
@@ -500,10 +587,8 @@ pub fn nth[A](self : T[A], n : Int) -> A? {
 /// assert_eq!(@list.repeat(5, 1), @list.from_array([1, 1, 1, 1, 1]))
 /// ```
 pub fn repeat[A](n : Int, x : A) -> T[A] {
-  if n == 0 {
-    Nil
-  } else {
-    Cons(x, tail=repeat(n - 1, x))
+  loop Nil, n {
+    acc, n => if n <= 0 { acc } else { continue Cons(x, tail=acc), n - 1 }
   }
 }
 
@@ -520,8 +605,20 @@ pub fn intersperse[A](self : T[A], separator : A) -> T[A] {
   match self {
     Nil => Nil
     Cons(head, tail=Nil) => Cons(head, tail=Nil)
-    Cons(head, tail~) =>
-      Cons(head, tail=Cons(separator, tail=intersperse(tail, separator)))
+    Cons(head, tail~) => {
+      let dest = Cons(head, tail=Nil)
+      loop dest, tail {
+        _, Nil => ()
+        Cons(_) as dest, Cons(hd, tail=tl) => {
+          let new_tail = Cons(hd, tail=Nil)
+          dest.tail = Cons(separator, tail=new_tail)
+          continue new_tail, tl
+        }
+        // unreachable
+        Nil, _ => panic()
+      }
+      dest
+    }
   }
 }
 
@@ -565,9 +662,39 @@ pub fn unzip[A, B](self : T[(A, B)]) -> (T[A], T[B]) {
 /// assert_eq!(ls, @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
 /// ```
 pub fn flatten[A](self : T[T[A]]) -> T[A] {
-  match self {
+  loop self {
     Nil => Nil
-    Cons(head, tail~) => concat(head, flatten(tail))
+    Cons(head, tail~) =>
+      match head {
+        // continue until we have at least one element
+        Nil => continue tail
+        Cons(hd, tail=tl) => {
+          let dest = Cons(hd, tail=Nil)
+          // copy all the elements of `head` first
+          let dest1 = loop dest, tl {
+            dest, Nil => dest
+            Cons(_) as dest, Cons(hd, tail~) => {
+              dest.tail = Cons(hd, tail=Nil)
+              continue dest.tail, tail
+            }
+            Nil, _ => panic()
+          }
+          // continue looping on the `tail` of `self`
+          loop_over_tail~: loop dest1, tail {
+            _, Nil => ()
+            dest, Cons(t_hd, tail=t_tl) =>
+              loop dest, t_hd {
+                dest, Nil => continue loop_over_tail~ dest, t_tl
+                Cons(_) as dest, Cons(hd, tail~) => {
+                  dest.tail = Cons(hd, tail=Nil)
+                  continue dest.tail, tail
+                }
+                Nil, _ => panic()
+              }
+          }
+          dest
+        }
+      }
   }
 }
 
@@ -576,15 +703,12 @@ pub fn flatten[A](self : T[T[A]]) -> T[A] {
 pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
   match self {
     Nil => abort("maximum: empty list")
-    Cons(x, tail=Nil) => x
-    Cons(x, tail=xs) => {
-      let y = unsafe_maximum(xs)
-      if x > y {
-        x
-      } else {
-        y
+    Cons(head, tail~) =>
+      loop tail, head {
+        Nil, curr_max => curr_max
+        Cons(item, tail~), curr_max =>
+          continue tail, if item > curr_max { item } else { curr_max }
       }
-    }
   }
 }
 
@@ -594,11 +718,11 @@ pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
 pub fn maximum[A : Compare](self : T[A]) -> A? {
   match self {
     Nil => None
-    Cons(x, tail=Nil) => Some(x)
-    Cons(x, tail=xs) =>
-      match maximum(xs) {
-        None => Some(x)
-        Some(y) => Some(if x > y { x } else { y })
+    Cons(head, tail~) =>
+      loop tail, head {
+        Nil, curr_max => Some(curr_max)
+        Cons(item, tail~), curr_max =>
+          continue tail, if item > curr_max { item } else { curr_max }
       }
   }
 }
@@ -607,16 +731,13 @@ pub fn maximum[A : Compare](self : T[A]) -> A? {
 /// @alert unsafe "Panic if the list is empty"
 pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
   match self {
-    Nil => abort("minimum: empty list")
-    Cons(x, tail=Nil) => x
-    Cons(x, tail=xs) => {
-      let y = unsafe_minimum(xs)
-      if x < y {
-        x
-      } else {
-        y
+    Nil => abort("maximum: empty list")
+    Cons(head, tail~) =>
+      loop tail, head {
+        Nil, curr_min => curr_min
+        Cons(item, tail~), curr_min =>
+          continue tail, if item < curr_min { item } else { curr_min }
       }
-    }
   }
 }
 
@@ -625,11 +746,11 @@ pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
 pub fn minimum[A : Compare](self : T[A]) -> A? {
   match self {
     Nil => None
-    Cons(x, tail=Nil) => Some(x)
-    Cons(x, tail=xs) =>
-      match minimum(xs) {
-        None => Some(x)
-        Some(y) => Some(if x < y { x } else { y })
+    Cons(head, tail~) =>
+      loop tail, head {
+        Nil, curr_min => Some(curr_min)
+        Cons(item, tail~), curr_min =>
+          continue tail, if item < curr_min { item } else { curr_min }
       }
   }
 }
@@ -682,8 +803,19 @@ pub fn contains[A : Eq](self : T[A], value : A) -> Bool {
 /// ```
 pub fn unfold[A, S](f : (S) -> (A, S)?, init~ : S) -> T[A] {
   match f(init) {
-    Some((element, new_state)) => Cons(element, tail=unfold(init=new_state, f))
     None => Nil
+    Some((element, new_state)) => {
+      let dest = Cons(element, tail=Nil)
+      loop dest, f(new_state) {
+        _, None => ()
+        Cons(_) as dest, Some((element, new_state)) => {
+          dest.tail = Cons(element, tail=Nil)
+          continue dest.tail, f(new_state)
+        }
+        Nil, _ => panic()
+      }
+      dest
+    }
   }
 }
 
@@ -699,16 +831,25 @@ pub fn unfold[A, S](f : (S) -> (A, S)?, init~ : S) -> T[A] {
 /// assert_eq!(r, @list.of([1, 2, 3]))
 /// ```
 pub fn take[A](self : T[A], n : Int) -> T[A] {
-  fn go {
-    _, Nil => Nil
-    1, Cons(x, tail=_) => Cons(x, tail=Nil)
-    n, Cons(x, tail=xs) => Cons(x, tail=go(n - 1, xs))
-  }
-
   if n <= 0 {
     Nil
   } else {
-    go(n, self)
+    match self {
+      Nil => Nil
+      Cons(head, tail~) => {
+        let dest = Cons(head, tail=Nil)
+        loop dest, tail, n - 1 {
+          _, Nil, _ => ()
+          _, _, 0 => ()
+          Cons(_) as dest, Cons(x, tail=xs), n => {
+            dest.tail = Cons(x, tail=Nil)
+            continue dest.tail, xs, n - 1
+          }
+          Nil, _, _ => panic()
+        }
+        dest
+      }
+    }
   }
 }
 
@@ -750,7 +891,22 @@ pub fn drop[A](self : T[A], n : Int) -> T[A] {
 pub fn take_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
   match self {
     Nil => Nil
-    Cons(x, tail=xs) => if p(x) { Cons(x, tail=xs.take_while(p)) } else { Nil }
+    Cons(head, tail~) =>
+      if p(head) {
+        let dest = Cons(head, tail=Nil)
+        loop dest, tail {
+          _, Nil => ()
+          Cons(_) as dest, Cons(x, tail=xs) if p(x) => {
+            dest.tail = Cons(x, tail=Nil)
+            continue dest.tail, xs
+          }
+          Cons(_), _ => ()
+          Nil, _ => panic()
+        }
+        dest
+      } else {
+        Nil
+      }
   }
 }
 
@@ -782,13 +938,16 @@ pub fn drop_while[A](self : T[A], p : (A) -> Bool) -> T[A] {
 /// assert_eq!(r, @list.of([0, 1, 3, 6, 10, 15]))
 /// ```
 pub fn scan_left[A, E](self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
-  Cons(
-    init,
-    tail=match self {
-      Nil => Nil
-      Cons(x, tail=xs) => xs.scan_left(f, init=f(init, x))
-    },
-  )
+  let dest = Cons(init, tail=Nil)
+  loop dest, self, init {
+    _, Nil, _ => ()
+    Nil, _, _ => panic()
+    Cons(_) as dest, Cons(x, tail=xs), acc => {
+      dest.tail = Cons(f(acc, x), tail=Nil)
+      continue dest.tail, xs, f(acc, x)
+    }
+  }
+  dest
 }
 
 ///|
@@ -883,10 +1042,24 @@ pub fn findi[A](self : T[A], f : (A, Int) -> Bool) -> A? {
 /// ```
 pub fn remove_at[A](self : T[A], index : Int) -> T[A] {
   match (index, self) {
-    (0, Cons(_, tail~)) => tail
-    (_, Cons(head, tail~)) => Cons(head, tail=remove_at(tail, index - 1))
     (_, Nil) => Nil
-    // abort("remove_at: index out of bounds")
+    (_..<0, _) => self
+    (0, Cons(_, tail~)) => tail
+    (n, Cons(head, tail~)) => {
+      let dest = Cons(head, tail=Nil)
+      loop dest, tail, n - 1 {
+        _, Nil, _ => ()
+        Cons(_) as dest, Cons(_, tail~), 0 =>
+          // warning: sharing
+          dest.tail = tail
+        Cons(_) as dest, Cons(x, tail=xs), n => {
+          dest.tail = Cons(x, tail=Nil)
+          continue dest.tail, xs, n - 1
+        }
+        Nil, _, _ => panic()
+      }
+      dest
+    }
   }
 }
 
@@ -901,12 +1074,23 @@ pub fn remove_at[A](self : T[A], index : Int) -> T[A] {
 pub fn remove[A : Eq](self : T[A], elem : A) -> T[A] {
   match self {
     Nil => Nil
-    Cons(head, tail~) =>
-      if head == elem {
-        tail
+    Cons(head, tail~) if head == elem => tail
+    Cons(head, tail~) => {
+      let dest = Cons(head, tail~)
+      loop dest, tail {
+        _, Nil => ()
+        Cons(_) as dest, Cons(x, tail=xs) =>
+          if x == elem {
+            // warning: sharing
+            dest.tail = xs
       } else {
-        Cons(head, tail=remove(tail, elem))
+            dest.tail = Cons(x, tail=Nil)
+            continue dest.tail, xs
       }
+        Nil, _ => panic()
+      }
+      dest
+    }
   }
 }
 

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -42,7 +42,7 @@ pub impl[A : ToJson] ToJson for T[A] with to_json(self) {
   for a in self {
     jsons.push(a.to_json())
   }
-  Array(jsons)
+  Json::array(jsons)
 }
 
 ///|
@@ -53,7 +53,7 @@ pub fn to_json[A : ToJson](self : T[A]) -> Json {
 ///|
 pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) {
   guard json is Array(arr) else {
-    raise @json.JsonDecodeError((path, "@immut/list.from_json: expected array"))
+    raise @json.JsonDecodeError((path, "@list.from_json: expected array"))
   }
   for i = arr.length() - 1, list = Nil; i >= 0; {
     continue i - 1, list.add(A::from_json!(arr[i], path))

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -418,7 +418,7 @@ pub fn fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
 /// assert_eq!(r, 15)
 /// ```
 pub fn rev_fold[A, B](self : T[A], init~ : B, f : (B, A) -> B) -> B {
-  self.rev().fold(init~, fn(b, a) { f(b, a) })
+  self.rev().fold(init~, f)
 }
 
 ///|
@@ -446,25 +446,22 @@ pub fn rev_foldi[A, B](self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
 
 ///|
 /// Zip two lists.
-/// If the lists have different lengths, it will return None.
+/// If the lists have different lengths, it will return a list with shorter length.
 ///
 /// # Example
 ///
-/// ```
+/// ```moonbit
 /// let r = @list.zip(@list.of([1, 2, 3, 4, 5]), @list.of([6, 7, 8, 9, 10]))
-/// assert_eq!(r, Some(@list.from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)])))
+/// assert_eq!(r, @list.from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]))
 /// ```
-pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)]? {
-  let mut acc = Nil
-  let res = loop self, other {
-    Nil, Nil => break Some(acc)
-    Cons(x, tail=xs), Cons(y, tail=ys) => {
-      acc = Cons((x, y), tail=acc)
-      continue xs, ys
-    }
-    _, _ => break None
+pub fn zip[A, B](self : T[A], other : T[B]) -> T[(A, B)] {
+  let res = loop self, other, Nil {
+    Nil, _, acc => break acc
+    _, Nil, acc => break acc
+    Cons(x, tail=xs), Cons(y, tail=ys), acc =>
+      continue xs, ys, Cons((x, y), tail=acc)
   }
-  res.map(T::rev)
+  res.reverse_inplace()
 }
 
 ///|

--- a/list/list.mbti
+++ b/list/list.mbti
@@ -1,0 +1,215 @@
+package "moonbitlang/core/list"
+
+import(
+  "moonbitlang/core/json"
+  "moonbitlang/core/quickcheck"
+)
+
+// Values
+fn add[A](T[A], A) -> T[A]
+
+fn all[A](T[A], (A) -> Bool) -> Bool
+
+fn any[A](T[A], (A) -> Bool) -> Bool
+
+fn concat[A](T[A], T[A]) -> T[A]
+
+fn cons[A](A, T[A]) -> T[A]
+
+fn contains[A : Eq](T[A], A) -> Bool
+
+fn default[X]() -> T[X]
+
+fn drop[A](T[A], Int) -> T[A]
+
+fn drop_while[A](T[A], (A) -> Bool) -> T[A]
+
+fn each[A](T[A], (A) -> Unit) -> Unit
+
+fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
+
+fn filter[A](T[A], (A) -> Bool) -> T[A]
+
+fn filter_map[A, B](T[A], (A) -> B?) -> T[B]
+
+fn find[A](T[A], (A) -> Bool) -> A?
+
+fn findi[A](T[A], (A, Int) -> Bool) -> A?
+
+fn flat_map[A, B](T[A], (A) -> T[B]) -> T[B]
+
+fn flatten[A](T[T[A]]) -> T[A]
+
+fn fold[A, B](T[A], init~ : B, (B, A) -> B) -> B
+
+fn foldi[A, B](T[A], init~ : B, (Int, B, A) -> B) -> B
+
+fn from_array[A](Array[A]) -> T[A]
+
+fn from_iter[A](Iter[A]) -> T[A]
+
+fn from_iter_rev[A](Iter[A]) -> T[A]
+
+fn from_json[A : @json.FromJson](Json) -> T[A]!@json.JsonDecodeError
+
+fn head[A](T[A]) -> A?
+
+fn intercalate[A](T[T[A]], T[A]) -> T[A]
+
+fn intersperse[A](T[A], A) -> T[A]
+
+fn is_empty[A](T[A]) -> Bool
+
+fn is_prefix[A : Eq](T[A], T[A]) -> Bool
+
+fn is_suffix[A : Eq](T[A], T[A]) -> Bool
+
+fn iter[A](T[A]) -> Iter[A]
+
+fn iter2[A](T[A]) -> Iter2[Int, A]
+
+fn last[A](T[A]) -> A?
+
+fn length[A](T[A]) -> Int
+
+fn lookup[A : Eq, B](T[(A, B)], A) -> B?
+
+fn map[A, B](T[A], (A) -> B) -> T[B]
+
+fn mapi[A, B](T[A], (Int, A) -> B) -> T[B]
+
+fn maximum[A : Compare](T[A]) -> A?
+
+fn minimum[A : Compare](T[A]) -> A?
+
+fn nil[A]() -> T[A]
+
+fn nth[A](T[A], Int) -> A?
+
+fn of[A](FixedArray[A]) -> T[A]
+
+fn remove[A : Eq](T[A], A) -> T[A]
+
+fn remove_at[A](T[A], Int) -> T[A]
+
+fn repeat[A](Int, A) -> T[A]
+
+fn rev[A](T[A]) -> T[A]
+
+fn rev_concat[A](T[A], T[A]) -> T[A]
+
+fn rev_fold[A, B](T[A], init~ : B, (B, A) -> B) -> B
+
+fn rev_foldi[A, B](T[A], init~ : B, (Int, B, A) -> B) -> B
+
+fn rev_map[A, B](T[A], (A) -> B) -> T[B]
+
+fn scan_left[A, E](T[A], (E, A) -> E, init~ : E) -> T[E]
+
+fn scan_right[A, B](T[A], (B, A) -> B, init~ : B) -> T[B]
+
+fn singleton[A](A) -> T[A]
+
+fn sort[A : Compare](T[A]) -> T[A]
+
+fn tail[A](T[A]) -> T[A]
+
+fn take[A](T[A], Int) -> T[A]
+
+fn take_while[A](T[A], (A) -> Bool) -> T[A]
+
+fn to_array[A](T[A]) -> Array[A]
+
+fn to_json[A : ToJson](T[A]) -> Json
+
+fn unfold[A, S]((S) -> (A, S)?, init~ : S) -> T[A]
+
+fn unsafe_head[A](T[A]) -> A
+
+fn unsafe_last[A](T[A]) -> A
+
+fn unsafe_maximum[A : Compare](T[A]) -> A
+
+fn unsafe_minimum[A : Compare](T[A]) -> A
+
+fn unsafe_nth[A](T[A], Int) -> A
+
+fn unzip[A, B](T[(A, B)]) -> (T[A], T[B])
+
+fn zip[A, B](T[A], T[B]) -> T[(A, B)]?
+
+// Types and methods
+pub enum T[A] {
+  Nil
+  Cons(A, mut tail~ : T[A])
+}
+impl T {
+  add[A](Self[A], A) -> Self[A]
+  all[A](Self[A], (A) -> Bool) -> Bool
+  any[A](Self[A], (A) -> Bool) -> Bool
+  concat[A](Self[A], Self[A]) -> Self[A]
+  contains[A : Eq](Self[A], A) -> Bool
+  drop[A](Self[A], Int) -> Self[A]
+  drop_while[A](Self[A], (A) -> Bool) -> Self[A]
+  each[A](Self[A], (A) -> Unit) -> Unit
+  eachi[A](Self[A], (Int, A) -> Unit) -> Unit
+  filter[A](Self[A], (A) -> Bool) -> Self[A]
+  filter_map[A, B](Self[A], (A) -> B?) -> Self[B]
+  find[A](Self[A], (A) -> Bool) -> A?
+  findi[A](Self[A], (A, Int) -> Bool) -> A?
+  flat_map[A, B](Self[A], (A) -> Self[B]) -> Self[B]
+  flatten[A](Self[Self[A]]) -> Self[A]
+  fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
+  foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
+  head[A](Self[A]) -> A?
+  intercalate[A](Self[Self[A]], Self[A]) -> Self[A]
+  intersperse[A](Self[A], A) -> Self[A]
+  is_empty[A](Self[A]) -> Bool
+  is_prefix[A : Eq](Self[A], Self[A]) -> Bool
+  is_suffix[A : Eq](Self[A], Self[A]) -> Bool
+  iter[A](Self[A]) -> Iter[A]
+  iter2[A](Self[A]) -> Iter2[Int, A]
+  last[A](Self[A]) -> A?
+  length[A](Self[A]) -> Int
+  lookup[A : Eq, B](Self[(A, B)], A) -> B?
+  map[A, B](Self[A], (A) -> B) -> Self[B]
+  mapi[A, B](Self[A], (Int, A) -> B) -> Self[B]
+  maximum[A : Compare](Self[A]) -> A?
+  minimum[A : Compare](Self[A]) -> A?
+  nth[A](Self[A], Int) -> A?
+  remove[A : Eq](Self[A], A) -> Self[A]
+  remove_at[A](Self[A], Int) -> Self[A]
+  rev[A](Self[A]) -> Self[A]
+  rev_concat[A](Self[A], Self[A]) -> Self[A]
+  rev_fold[A, B](Self[A], init~ : B, (B, A) -> B) -> B
+  rev_foldi[A, B](Self[A], init~ : B, (Int, B, A) -> B) -> B
+  rev_map[A, B](Self[A], (A) -> B) -> Self[B]
+  scan_left[A, E](Self[A], (E, A) -> E, init~ : E) -> Self[E]
+  scan_right[A, B](Self[A], (B, A) -> B, init~ : B) -> Self[B]
+  sort[A : Compare](Self[A]) -> Self[A]
+  tail[A](Self[A]) -> Self[A]
+  take[A](Self[A], Int) -> Self[A]
+  take_while[A](Self[A], (A) -> Bool) -> Self[A]
+  to_array[A](Self[A]) -> Array[A]
+  to_json[A : ToJson](Self[A]) -> Json
+  unsafe_head[A](Self[A]) -> A
+  unsafe_last[A](Self[A]) -> A
+  unsafe_maximum[A : Compare](Self[A]) -> A
+  unsafe_minimum[A : Compare](Self[A]) -> A
+  unsafe_nth[A](Self[A], Int) -> A
+  unzip[A, B](Self[(A, B)]) -> (Self[A], Self[B])
+  zip[A, B](Self[A], Self[B]) -> Self[(A, B)]?
+}
+impl[A] Add for T[A]
+impl[X] Default for T[X]
+impl[A : Eq] Eq for T[A]
+impl[A : Hash] Hash for T[A]
+impl[A : Show] Show for T[A]
+impl[A : ToJson] ToJson for T[A]
+impl[A : @json.FromJson] @json.FromJson for T[A]
+impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[X]
+
+// Type aliases
+
+// Traits
+

--- a/list/list.mbti
+++ b/list/list.mbti
@@ -6,15 +6,13 @@ import(
 )
 
 // Values
-fn add[A](T[A], A) -> T[A]
-
 fn all[A](T[A], (A) -> Bool) -> Bool
 
 fn any[A](T[A], (A) -> Bool) -> Bool
 
 fn concat[A](T[A], T[A]) -> T[A]
 
-fn cons[A](A, T[A]) -> T[A]
+fn construct[A](A, T[A]) -> T[A]
 
 fn contains[A : Eq](T[A], A) -> Bool
 
@@ -27,6 +25,8 @@ fn drop_while[A](T[A], (A) -> Bool) -> T[A]
 fn each[A](T[A], (A) -> Unit) -> Unit
 
 fn eachi[A](T[A], (Int, A) -> Unit) -> Unit
+
+fn empty[A]() -> T[A]
 
 fn filter[A](T[A], (A) -> Bool) -> T[A]
 
@@ -82,11 +82,13 @@ fn maximum[A : Compare](T[A]) -> A?
 
 fn minimum[A : Compare](T[A]) -> A?
 
-fn nil[A]() -> T[A]
+fn new[A]() -> T[A]
 
 fn nth[A](T[A], Int) -> A?
 
 fn of[A](FixedArray[A]) -> T[A]
+
+fn prepend[A](T[A], A) -> T[A]
 
 fn remove[A : Eq](T[A], A) -> T[A]
 
@@ -136,15 +138,14 @@ fn unsafe_nth[A](T[A], Int) -> A
 
 fn unzip[A, B](T[(A, B)]) -> (T[A], T[B])
 
-fn zip[A, B](T[A], T[B]) -> T[(A, B)]?
+fn zip[A, B](T[A], T[B]) -> T[(A, B)]
 
 // Types and methods
 pub enum T[A] {
-  Nil
-  Cons(A, mut tail~ : T[A])
+  Empty
+  More(A, mut tail~ : T[A])
 }
 impl T {
-  add[A](Self[A], A) -> Self[A]
   all[A](Self[A], (A) -> Bool) -> Bool
   any[A](Self[A], (A) -> Bool) -> Bool
   concat[A](Self[A], Self[A]) -> Self[A]
@@ -177,6 +178,7 @@ impl T {
   maximum[A : Compare](Self[A]) -> A?
   minimum[A : Compare](Self[A]) -> A?
   nth[A](Self[A], Int) -> A?
+  prepend[A](Self[A], A) -> Self[A]
   remove[A : Eq](Self[A], A) -> Self[A]
   remove_at[A](Self[A], Int) -> Self[A]
   rev[A](Self[A]) -> Self[A]
@@ -198,7 +200,7 @@ impl T {
   unsafe_minimum[A : Compare](Self[A]) -> A
   unsafe_nth[A](Self[A], Int) -> A
   unzip[A, B](Self[(A, B)]) -> (Self[A], Self[B])
-  zip[A, B](Self[A], Self[B]) -> Self[(A, B)]?
+  zip[A, B](Self[A], Self[B]) -> Self[(A, B)]
 }
 impl[A] Add for T[A]
 impl[X] Default for T[X]

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -181,8 +181,8 @@ test "fold" {
 test "rev_fold" {
   let ls = @list.of(["1", "2", "3", "4", "5"])
   let el : @list.T[String] = @list.Nil
-  inspect!(ls.rev_fold(fn(x, acc) { x + acc }, init=""), content="12345")
-  inspect!(el.rev_fold(fn(x, acc) { x + acc }, init="init"), content="init")
+  inspect!(ls.rev_fold(fn(acc, x) { x + acc }, init=""), content="12345")
+  inspect!(el.rev_fold(fn(acc, x) { x + acc }, init="init"), content="init")
 }
 
 ///|
@@ -197,8 +197,8 @@ test "foldi" {
 test "rev_foldi" {
   let ls = @list.of([1, 2, 3, 4, 5])
   let el : @list.T[Int] = @list.Nil
-  inspect!(ls.rev_foldi(fn(i, x, acc) { x * i + acc }, init=0), content="40")
-  inspect!(el.rev_foldi(fn(i, x, acc) { x * i + acc }, init=0), content="0")
+  inspect!(ls.rev_foldi(fn(i, acc, x) { x * i + acc }, init=0), content="20")
+  inspect!(el.rev_foldi(fn(i, acc, x) { x * i + acc }, init=0), content="0")
 }
 
 ///|
@@ -384,9 +384,9 @@ test "scan_left" {
 
 ///|
 test "scan_right" {
-  let el = @list.Nil.scan_right(fn(x, acc) { x + acc }, init=0)
-  let ls = @list.of([1, 2, 3, 4]).scan_right(fn(x, acc) { x + acc }, init=0)
-  let ls2 = @list.of([1, 2, 3, 4]).scan_right(fn(x, acc) { x - acc }, init=100)
+  let el = @list.Nil.scan_right(fn(acc, x) { x + acc }, init=0)
+  let ls = @list.of([1, 2, 3, 4]).scan_right(fn(acc, x) { x + acc }, init=0)
+  let ls2 = @list.of([1, 2, 3, 4]).scan_right(fn(acc, x) { x - acc }, init=100)
   inspect!(el, content="@list.of([0])")
   inspect!(ls, content="@list.of([10, 9, 7, 4, 0])")
   inspect!(ls2, content="@list.of([98, -97, 99, -96, 100])")

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -1,0 +1,684 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "from_array" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let el : @list.T[Int] = @list.Nil
+  inspect!(ls, content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(el, content="@list.of([])")
+}
+
+///|
+test "length" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  @json.inspect!(ls.length(), content=5)
+  @json.inspect!(@list.singleton(11), content=[11])
+}
+
+///|
+test "iter" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let mut failed = false
+  for i, x in ls {
+    if x != i + 1 {
+      failed = true
+    }
+  }
+  inspect!(failed, content="false")
+}
+
+///|
+test "iteri" {
+  let mut v = 0
+  let mut failed = false
+  let ls = @list.of([1, 2, 3, 4, 5])
+  for i, x in ls {
+    if x != i + 1 || i != v {
+      failed = true
+    }
+    v = v + 1
+  }
+  inspect!(failed, content="false")
+}
+
+///|
+test "map" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs : @list.T[Int] = @list.Nil
+  inspect!(ls.map(fn(x) { x * 2 }), content="@list.of([2, 4, 6, 8, 10])")
+  inspect!(rs.map(fn(x) { x * 2 }), content="@list.of([])")
+}
+
+///|
+test "mapi" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let el : @list.T[Int] = @list.Nil
+  inspect!(ls.mapi(fn(i, x) { i * x }), content="@list.of([0, 2, 6, 12, 20])")
+  inspect!(el.mapi(fn(i, x) { i * x }), content="@list.of([])")
+}
+
+///|
+test "rev_map" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs : @list.T[Int] = @list.Nil
+  inspect!(ls.rev_map(fn(x) { x * 2 }), content="@list.of([10, 8, 6, 4, 2])")
+  inspect!(rs.rev_map(fn(x) { x * 2 }), content="@list.of([])")
+}
+
+///|
+test "to_array" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  let empty : @list.T[Int] = @list.Nil
+  let array = @list.to_array(list)
+  let earray = @list.to_array(empty)
+  inspect!(array, content="[1, 2, 3, 4, 5]")
+  inspect!(earray, content="[]")
+}
+
+///|
+test "filter" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs : @list.T[Int] = @list.Nil
+  inspect!(ls.filter(fn(x) { x % 2 == 0 }), content="@list.of([2, 4])")
+  inspect!(rs.filter(fn(x) { x % 2 == 0 }), content="@list.of([])")
+}
+
+///|
+test "all" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.all(fn(x) { x > 0 }), content="true")
+  inspect!(ls.all(fn(x) { x > 1 }), content="false")
+}
+
+///|
+test "any" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.any(fn(x) { x > 4 }), content="true")
+  inspect!(ls.any(fn(x) { x > 5 }), content="false")
+}
+
+///|
+test "tail" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let el : @list.T[Int] = @list.Nil
+  inspect!(ls.tail(), content="@list.of([2, 3, 4, 5])")
+  inspect!(el.tail(), content="@list.of([])")
+}
+
+///|
+test "head_exn" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.head(), content="Some(1)")
+}
+
+///|
+test "head" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let el : @list.T[Int] = @list.of([])
+  inspect!(ls.head(), content="Some(1)")
+  inspect!(el.head(), content="None")
+}
+
+///|
+test "last" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.last(), content="Some(5)")
+}
+
+///|
+test "concat" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs = @list.of([6, 7, 8, 9, 10])
+  inspect!(ls.concat(@list.Nil), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(
+    (@list.Nil : @list.T[Int]).concat(rs),
+    content="@list.of([6, 7, 8, 9, 10])",
+  )
+  inspect!(ls.concat(rs), content="@list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
+}
+
+///|
+test "rev_concat" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs = @list.of([6, 7, 8, 9, 10])
+  inspect!(@list.Nil.rev_concat(ls), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(rs.rev_concat(@list.Nil), content="@list.of([10, 9, 8, 7, 6])")
+  inspect!(
+    ls.rev_concat(rs),
+    content="@list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10])",
+  )
+}
+
+///|
+test "rev" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs = @list.of([5, 4, 3, 2, 1])
+  inspect!(rs.rev(), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(ls.rev().rev(), content="@list.of([1, 2, 3, 4, 5])")
+}
+
+///|
+test "fold" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let el : @list.T[Int] = @list.Nil
+  inspect!(el.fold(fn(acc, x) { acc + x }, init=0), content="0")
+  inspect!(ls.fold(fn(acc, x) { acc + x }, init=0), content="15")
+}
+
+///|
+test "rev_fold" {
+  let ls = @list.of(["1", "2", "3", "4", "5"])
+  let el : @list.T[String] = @list.Nil
+  inspect!(ls.rev_fold(fn(x, acc) { x + acc }, init=""), content="12345")
+  inspect!(el.rev_fold(fn(x, acc) { x + acc }, init="init"), content="init")
+}
+
+///|
+test "foldi" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let el : @list.T[Int] = @list.Nil
+  inspect!(ls.foldi(fn(i, acc, x) { acc + i * x }, init=0), content="40")
+  inspect!(el.foldi(fn(i, acc, x) { acc + i * x }, init=0), content="0")
+}
+
+///|
+test "rev_foldi" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let el : @list.T[Int] = @list.Nil
+  inspect!(ls.rev_foldi(fn(i, x, acc) { x * i + acc }, init=0), content="40")
+  inspect!(el.rev_foldi(fn(i, x, acc) { x * i + acc }, init=0), content="0")
+}
+
+///|
+test "zip" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  let rs = @list.of([6, 7, 8, 9, 10])
+  inspect!(
+    ls.zip(rs),
+    content="Some(@list.of([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]))",
+  )
+}
+
+///|
+test "flat_map" {
+  let ls = @list.of([1, 2, 3])
+  let rs : @list.T[Int] = @list.Nil
+  inspect!(rs.flat_map(fn(x) { @list.of([x, x * 2]) }), content="@list.of([])")
+  inspect!(
+    ls.flat_map(fn(x) { @list.of([x, x * 2]) }),
+    content="@list.of([1, 2, 2, 4, 3, 6])",
+  )
+}
+
+///|
+test "filter_map" {
+  let ls = @list.of([4, 2, 2, 6, 3, 1])
+  let rs : @list.T[Int] = @list.Nil
+  inspect!(
+    ls.filter_map(fn(x) { if x >= 3 { Some(x) } else { None } }),
+    content="@list.of([4, 6, 3])",
+  )
+  inspect!(
+    rs.filter_map(fn(x) { if x >= 3 { Some(x) } else { None } }),
+    content="@list.of([])",
+  )
+}
+
+///|
+test "nth" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.nth(0), content="Some(1)")
+  inspect!(ls.nth(1), content="Some(2)")
+}
+
+///|
+test "nth" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.nth(0), content="Some(1)")
+  inspect!(ls.nth(20), content="None")
+}
+
+///|
+test "repeat" {
+  inspect!(@list.repeat(5, 1), content="@list.of([1, 1, 1, 1, 1])")
+  inspect!(@list.repeat(0, 10), content="@list.of([])")
+}
+
+///|
+test "intersperse" {
+  let ls = @list.of(["1", "2", "3", "4", "5"])
+  let el : @list.T[String] = Nil
+  inspect!(
+    ls.intersperse("|"),
+    content=
+      #|@list.of(["1", "|", "2", "|", "3", "|", "4", "|", "5"])
+    ,
+  )
+  inspect!(el.intersperse("|"), content="@list.of([])")
+}
+
+///|
+test "is_empty" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.is_empty(), content="false")
+  inspect!((@list.Nil : @list.T[Unit]).is_empty(), content="true")
+}
+
+///|
+test "unzip" {
+  let ls = @list.of([(1, 2), (3, 4), (5, 6)])
+  let (a, b) = @list.unzip(ls)
+  inspect!(a, content="@list.of([1, 3, 5])")
+  inspect!(b, content="@list.of([2, 4, 6])")
+}
+
+///|
+test "flatten" {
+  let ls = @list.of([
+    @list.of([1, 2, 3]),
+    @list.of([4, 5, 6]),
+    @list.of([7, 8, 9]),
+  ])
+  let el : @list.T[@list.T[Int]] = @list.Nil
+  inspect!(ls.flatten(), content="@list.of([1, 2, 3, 4, 5, 6, 7, 8, 9])")
+  inspect!(el.flatten(), content="@list.of([])")
+}
+
+///|
+test "maximum" {
+  let ls = @list.of([1, 123, 52, 3, 6, 0, -6, -76])
+  inspect!(ls.maximum(), content="Some(123)")
+}
+
+///|
+test "minimum" {
+  let ls = @list.of([1, 123, 52, 3, 6, 0, -6, -76])
+  inspect!(ls.minimum(), content="Some(-76)")
+}
+
+///|
+test "sort" {
+  let ls = @list.of([1, 123, 52, 3, 6, 0, -6, -76])
+  let el : @list.T[Int] = @list.Nil
+  inspect!(el.sort(), content="@list.of([])")
+  inspect!(ls.sort(), content="@list.of([-76, -6, 0, 1, 3, 6, 52, 123])")
+}
+
+///|
+test "contain" {
+  let ls = @list.of([1, 2, 3])
+  inspect!(ls.contains(1), content="true")
+  inspect!(ls.contains(2), content="true")
+  inspect!(ls.contains(3), content="true")
+  inspect!(ls.contains(0), content="false")
+  inspect!(ls.contains(4), content="false")
+}
+
+///|
+test "unfold" {
+  let ls = @list.unfold(init=0, fn {
+    i => if i == 3 { None } else { Some((i, i + 1)) }
+  })
+  inspect!(ls, content="@list.of([0, 1, 2])")
+}
+
+///|
+test "take" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.take(3), content="@list.of([1, 2, 3])")
+  inspect!(ls.take(-1), content="@list.of([])")
+  inspect!(ls.take(7), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(ls.take(0), content="@list.of([])")
+  inspect!(ls.take(5), content="@list.of([1, 2, 3, 4, 5])")
+}
+
+///|
+test "drop" {
+  let ls = @list.of([1, 2, 3, 4, 5]).drop(3)
+  let el : @list.T[Int] = @list.Nil
+  inspect!(ls, content="@list.of([4, 5])")
+  inspect!(ls.drop(-10), content="@list.of([4, 5])")
+  inspect!(ls.drop(10), content="@list.of([])")
+  inspect!(ls.drop(2), content="@list.of([])")
+  inspect!(ls.drop(0), content="@list.of([4, 5])")
+  inspect!(el.drop(0), content="@list.of([])")
+}
+
+///|
+test "take_while" {
+  let ls = @list.take_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
+  let el : @list.T[Int] = @list.take_while(@list.Nil, fn(_e) { true })
+  inspect!(ls, content="@list.of([0, 1, 2])")
+  inspect!(el, content="@list.of([])")
+}
+
+///|
+test "drop_while" {
+  let ls = @list.drop_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
+  let el : @list.T[Int] = @list.drop_while(@list.Nil, fn(_e) { true })
+  inspect!(ls, content="@list.of([3, 4])")
+  inspect!(el, content="@list.of([])")
+}
+
+///|
+test "scan_left" {
+  let el = @list.Nil.scan_left(fn(acc, x) { acc + x }, init=0)
+  let ls = @list.of([1, 2, 3, 4, 5]).scan_left(fn(acc, x) { acc + x }, init=0)
+  let ls2 = @list.of([1, 2, 3, 4]).scan_left(fn(acc, x) { acc - x }, init=100)
+  inspect!(el, content="@list.of([0])")
+  inspect!(ls, content="@list.of([0, 1, 3, 6, 10, 15])")
+  inspect!(ls2, content="@list.of([100, 99, 97, 94, 90])")
+}
+
+///|
+test "scan_right" {
+  let el = @list.Nil.scan_right(fn(x, acc) { x + acc }, init=0)
+  let ls = @list.of([1, 2, 3, 4]).scan_right(fn(x, acc) { x + acc }, init=0)
+  let ls2 = @list.of([1, 2, 3, 4]).scan_right(fn(x, acc) { x - acc }, init=100)
+  inspect!(el, content="@list.of([0])")
+  inspect!(ls, content="@list.of([10, 9, 7, 4, 0])")
+  inspect!(ls2, content="@list.of([98, -97, 99, -96, 100])")
+}
+
+///|
+test "lookup" {
+  let ls = @list.of([(1, "a"), (2, "b"), (3, "c")])
+  let el : @list.T[(Int, Int)] = @list.Nil
+  inspect!(el.lookup(1), content="None")
+  inspect!(
+    ls.lookup(3),
+    content=
+      #|Some("c")
+    ,
+  )
+  inspect!(ls.lookup(4), content="None")
+}
+
+///|
+test "find" {
+  inspect!(
+    @list.of([1, 3, 5, 8]).find(fn(element) -> Bool { element % 2 == 0 }),
+    content="Some(8)",
+  )
+  inspect!(
+    @list.of([1, 3, 5, 7]).find(fn(element) -> Bool { element % 2 == 0 }),
+    content="None",
+  )
+  inspect!(
+    (@list.Nil : @list.T[Int]).find(fn(element) -> Bool { element % 2 == 0 }),
+    content="None",
+  )
+}
+
+///|
+test "findi" {
+  inspect!(
+    @list.of([1, 3, 5, 8]).findi(fn(element, i) -> Bool {
+      element % 2 == 0 && i == 3
+    }),
+    content="Some(8)",
+  )
+  inspect!(
+    @list.of([1, 3, 8, 5]).findi(fn(element, i) -> Bool {
+      element % 2 == 0 && i == 3
+    }),
+    content="None",
+  )
+  inspect!(
+    (@list.Nil : @list.T[Int]).findi(fn(element, i) -> Bool {
+      element % 2 == 0 && i == 3
+    }),
+    content="None",
+  )
+}
+
+///|
+test "remove_at" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(ls.remove_at(2), content="@list.of([1, 2, 4, 5])")
+  inspect!(ls.remove_at(0), content="@list.of([2, 3, 4, 5])")
+  inspect!(
+    @list.of(["a", "b", "c", "d", "e"]).remove_at(2),
+    content=
+      #|@list.of(["a", "b", "d", "e"])
+    ,
+  )
+  inspect!(
+    @list.of(["a", "b", "c", "d", "e"]).remove_at(5),
+    content=
+      #|@list.of(["a", "b", "c", "d", "e"])
+    ,
+  )
+}
+
+///|
+test "remove" {
+  inspect!(
+    @list.of([1, 2, 3, 4, 5]).remove(3),
+    content="@list.of([1, 2, 4, 5])",
+  )
+  inspect!(
+    @list.of(["a", "b", "c", "d", "e"]).remove("c"),
+    content=
+      #|@list.of(["a", "b", "d", "e"])
+    ,
+  )
+  inspect!(
+    @list.of(["a", "b", "c", "d", "e"]).remove("f"),
+    content=
+      #|@list.of(["a", "b", "c", "d", "e"])
+    ,
+  )
+}
+
+///|
+test "is_prefix" {
+  inspect!(
+    @list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([1, 2, 3])),
+    content="true",
+  )
+  inspect!(
+    @list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([3, 2, 3])),
+    content="false",
+  )
+  inspect!(@list.Nil.is_prefix(@list.of([1, 2, 3])), content="false")
+}
+
+///|
+test "equal" {
+  inspect!(@list.of([1, 2, 3]) == @list.of([1, 2, 3]), content="true")
+  inspect!(@list.of([1, 2, 3]) == @list.of([1, 3, 3]), content="false")
+  inspect!(@list.Nil == @list.of([1]), content="false")
+}
+
+///|
+test "is_suffix" {
+  inspect!(
+    @list.of([1, 2, 3, 4, 5]).is_suffix(@list.of([3, 4, 5])),
+    content="true",
+  )
+  inspect!(
+    @list.of([1, 2, 3, 4, 5]).is_suffix(@list.of([3, 4, 6])),
+    content="false",
+  )
+}
+
+///|
+test "intercalate" {
+  let ls = @list.of([
+    @list.of([1, 2, 3]),
+    @list.of([4, 5, 6]),
+    @list.of([7, 8, 9]),
+  ])
+  let el : @list.T[@list.T[Int]] = @list.Nil
+  inspect!(
+    ls.intercalate(@list.of([0])),
+    content="@list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9])",
+  )
+  inspect!(el.intersperse(@list.of([1])), content="@list.of([])")
+}
+
+///|
+test "default" {
+  let ls : @list.T[Int] = @list.default()
+  inspect!(ls, content="@list.of([])")
+}
+
+///|
+test "iter" {
+  let ls = @list.of([1, 2, 3, 4, 5])
+  inspect!(
+    ls.iter().map(fn(x) { x + 1 }).fold(fn(a, b) { a + b }, init=0),
+    content="20",
+  )
+}
+
+///|
+test "List::output with non-empty list" {
+  let buf = StringBuilder::new(size_hint=100)
+  let list = @list.of([1, 2, 3, 4, 5])
+  Show::output(list, buf)
+  inspect!(buf, content="@list.of([1, 2, 3, 4, 5])")
+}
+
+///|
+test "List::output with empty list" {
+  let buf = StringBuilder::new(size_hint=100)
+  let list : @list.T[Int] = @list.Nil
+  Show::output(list, buf)
+  inspect!(buf, content="@list.of([])")
+}
+
+///|
+test "List::to_json with non-empty list" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  @json.inspect!(ToJson::to_json(list), content=[1, 2, 3, 4, 5])
+}
+
+///|
+test "List::to_json with empty list" {
+  let list : @list.T[Int] = Nil
+  @json.inspect!(ToJson::to_json(list), content=[])
+}
+
+///|
+test "List::from_json" {
+  for xs in (@quickcheck.samples(20) : Array[@list.T[Int]]) {
+    assert_eq!(xs, @json.from_json!(xs.to_json()))
+  }
+}
+
+///|
+test "List::head_exn with non-empty list" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  let head = @list.head(list)
+  assert_eq!(head, Some(1))
+}
+
+///|
+test "List::last with non-empty list" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  let last = @list.last(list)
+  assert_eq!(last, Some(5))
+}
+
+///|
+test "List::zip with lists of equal length" {
+  let list1 = @list.of([1, 2, 3])
+  let list2 = @list.of(["a", "b", "c"])
+  let zipped = list1.zip(list2)
+  let expected = Some(@list.of([(1, "a"), (2, "b"), (3, "c")]))
+  assert_eq!(zipped, expected)
+}
+
+///|
+test "@list.zip with empty list" {
+  inspect!(@list.of([1]).zip((@list.Nil : @list.T[Int])), content="None")
+}
+
+///|
+test "List::nth_exn with valid index" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  let nth = @list.nth(list, 2)
+  assert_eq!(nth, Some(3))
+}
+
+///|
+test "List::maximum with non-empty list" {
+  let list = @list.of([1, 3, 5, 2, 4])
+  let max = @list.maximum(list)
+  assert_eq!(max, Some(5))
+}
+
+///|
+test "@list.maximum with empty list" {
+  inspect!((@list.Nil : @list.T[Int]).maximum(), content="None")
+}
+
+///|
+test "List::minimum with non-empty list" {
+  let list = @list.of([1, 3, 5, 2, 4])
+  let min = @list.minimum(list)
+  assert_eq!(min, Some(1))
+}
+
+///|
+test "@list.minimum with empty list" {
+  (@list.Nil : @list.T[Int]).minimum() |> ignore
+}
+
+///|
+test "op_add" {
+  inspect!(@list.of([1]) + @list.of([]), content="@list.of([1])")
+  inspect!(@list.of([]) + @list.of([1]), content="@list.of([1])")
+  inspect!(@list.of([1]) + @list.of([1]), content="@list.of([1, 1])")
+  inspect!(
+    (@list.Nil : @list.T[Int]) + (@list.Nil : @list.T[Int]),
+    content="@list.of([])",
+  )
+}
+
+///|
+test "from_iter multiple elements iter" {
+  inspect!(@list.from_iter([1, 2, 3].iter()), content="@list.of([1, 2, 3])")
+}
+
+///|
+test "from_iter_rev multiple elements iter" {
+  inspect!(@list.from_iter_rev([1, 2, 3].iter()), content="@list.of([3, 2, 1])")
+}
+
+///|
+test "from_iter single element iter" {
+  inspect!(@list.from_iter([1].iter()), content="@list.of([1])")
+}
+
+///|
+test "from_iter empty iter" {
+  let pq : @list.T[Int] = @list.from_iter(Iter::empty())
+  inspect!(pq, content="@list.of([])")
+}
+
+///|
+test "hash" {
+  let l1 = @list.of([1, 2, 3, 4, 5])
+  let l2 = @list.of([1, 2, 3, 4, 5])
+  inspect!(l1.hash() == l2.hash(), content="true")
+  let l3 = @list.of([5, 4, 3, 2, 1])
+  inspect!(l1.hash() == l3.hash(), content="false")
+  let l4 : @list.T[Int] = @list.of([])
+  inspect!(l1.hash() == l4.hash(), content="false")
+  inspect!(l4.hash() == l4.hash(), content="true")
+}

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test "from_array" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(ls, content="@list.of([1, 2, 3, 4, 5])")
   inspect!(el, content="@list.of([])")
 }
@@ -56,7 +56,7 @@ test "iteri" {
 ///|
 test "map" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let rs : @list.T[Int] = @list.Nil
+  let rs : @list.T[Int] = @list.nil()
   inspect!(ls.map(fn(x) { x * 2 }), content="@list.of([2, 4, 6, 8, 10])")
   inspect!(rs.map(fn(x) { x * 2 }), content="@list.of([])")
 }
@@ -64,7 +64,7 @@ test "map" {
 ///|
 test "mapi" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(ls.mapi(fn(i, x) { i * x }), content="@list.of([0, 2, 6, 12, 20])")
   inspect!(el.mapi(fn(i, x) { i * x }), content="@list.of([])")
 }
@@ -72,7 +72,7 @@ test "mapi" {
 ///|
 test "rev_map" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let rs : @list.T[Int] = @list.Nil
+  let rs : @list.T[Int] = @list.nil()
   inspect!(ls.rev_map(fn(x) { x * 2 }), content="@list.of([10, 8, 6, 4, 2])")
   inspect!(rs.rev_map(fn(x) { x * 2 }), content="@list.of([])")
 }
@@ -80,7 +80,7 @@ test "rev_map" {
 ///|
 test "to_array" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let empty : @list.T[Int] = @list.Nil
+  let empty : @list.T[Int] = @list.nil()
   let array = @list.to_array(list)
   let earray = @list.to_array(empty)
   inspect!(array, content="[1, 2, 3, 4, 5]")
@@ -90,7 +90,7 @@ test "to_array" {
 ///|
 test "filter" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let rs : @list.T[Int] = @list.Nil
+  let rs : @list.T[Int] = @list.nil()
   inspect!(ls.filter(fn(x) { x % 2 == 0 }), content="@list.of([2, 4])")
   inspect!(rs.filter(fn(x) { x % 2 == 0 }), content="@list.of([])")
 }
@@ -112,7 +112,7 @@ test "any" {
 ///|
 test "tail" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(ls.tail(), content="@list.of([2, 3, 4, 5])")
   inspect!(el.tail(), content="@list.of([])")
 }
@@ -141,9 +141,9 @@ test "last" {
 test "concat" {
   let ls = @list.of([1, 2, 3, 4, 5])
   let rs = @list.of([6, 7, 8, 9, 10])
-  inspect!(ls.concat(@list.Nil), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(ls.concat(@list.nil()), content="@list.of([1, 2, 3, 4, 5])")
   inspect!(
-    (@list.Nil : @list.T[Int]).concat(rs),
+    (@list.nil() : @list.T[Int]).concat(rs),
     content="@list.of([6, 7, 8, 9, 10])",
   )
   inspect!(ls.concat(rs), content="@list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
@@ -153,8 +153,8 @@ test "concat" {
 test "rev_concat" {
   let ls = @list.of([1, 2, 3, 4, 5])
   let rs = @list.of([6, 7, 8, 9, 10])
-  inspect!(@list.Nil.rev_concat(ls), content="@list.of([1, 2, 3, 4, 5])")
-  inspect!(rs.rev_concat(@list.Nil), content="@list.of([10, 9, 8, 7, 6])")
+  inspect!(@list.nil().rev_concat(ls), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(rs.rev_concat(@list.nil()), content="@list.of([10, 9, 8, 7, 6])")
   inspect!(
     ls.rev_concat(rs),
     content="@list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10])",
@@ -172,7 +172,7 @@ test "rev" {
 ///|
 test "fold" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(el.fold(fn(acc, x) { acc + x }, init=0), content="0")
   inspect!(ls.fold(fn(acc, x) { acc + x }, init=0), content="15")
 }
@@ -180,7 +180,7 @@ test "fold" {
 ///|
 test "rev_fold" {
   let ls = @list.of(["1", "2", "3", "4", "5"])
-  let el : @list.T[String] = @list.Nil
+  let el : @list.T[String] = @list.nil()
   inspect!(ls.rev_fold(fn(acc, x) { x + acc }, init=""), content="12345")
   inspect!(el.rev_fold(fn(acc, x) { x + acc }, init="init"), content="init")
 }
@@ -188,7 +188,7 @@ test "rev_fold" {
 ///|
 test "foldi" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(ls.foldi(fn(i, acc, x) { acc + i * x }, init=0), content="40")
   inspect!(el.foldi(fn(i, acc, x) { acc + i * x }, init=0), content="0")
 }
@@ -196,7 +196,7 @@ test "foldi" {
 ///|
 test "rev_foldi" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(ls.rev_foldi(fn(i, acc, x) { x * i + acc }, init=0), content="20")
   inspect!(el.rev_foldi(fn(i, acc, x) { x * i + acc }, init=0), content="0")
 }
@@ -214,7 +214,7 @@ test "zip" {
 ///|
 test "flat_map" {
   let ls = @list.of([1, 2, 3])
-  let rs : @list.T[Int] = @list.Nil
+  let rs : @list.T[Int] = @list.nil()
   inspect!(rs.flat_map(fn(x) { @list.of([x, x * 2]) }), content="@list.of([])")
   inspect!(
     ls.flat_map(fn(x) { @list.of([x, x * 2]) }),
@@ -225,7 +225,7 @@ test "flat_map" {
 ///|
 test "filter_map" {
   let ls = @list.of([4, 2, 2, 6, 3, 1])
-  let rs : @list.T[Int] = @list.Nil
+  let rs : @list.T[Int] = @list.nil()
   inspect!(
     ls.filter_map(fn(x) { if x >= 3 { Some(x) } else { None } }),
     content="@list.of([4, 6, 3])",
@@ -259,7 +259,7 @@ test "repeat" {
 ///|
 test "intersperse" {
   let ls = @list.of(["1", "2", "3", "4", "5"])
-  let el : @list.T[String] = Nil
+  let el : @list.T[String] = nil()
   inspect!(
     ls.intersperse("|"),
     content=
@@ -273,7 +273,7 @@ test "intersperse" {
 test "is_empty" {
   let ls = @list.of([1, 2, 3, 4, 5])
   inspect!(ls.is_empty(), content="false")
-  inspect!((@list.Nil : @list.T[Unit]).is_empty(), content="true")
+  inspect!((@list.nil() : @list.T[Unit]).is_empty(), content="true")
 }
 
 ///|
@@ -291,7 +291,7 @@ test "flatten" {
     @list.of([4, 5, 6]),
     @list.of([7, 8, 9]),
   ])
-  let el : @list.T[@list.T[Int]] = @list.Nil
+  let el : @list.T[@list.T[Int]] = @list.nil()
   inspect!(ls.flatten(), content="@list.of([1, 2, 3, 4, 5, 6, 7, 8, 9])")
   inspect!(el.flatten(), content="@list.of([])")
 }
@@ -311,7 +311,7 @@ test "minimum" {
 ///|
 test "sort" {
   let ls = @list.of([1, 123, 52, 3, 6, 0, -6, -76])
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(el.sort(), content="@list.of([])")
   inspect!(ls.sort(), content="@list.of([-76, -6, 0, 1, 3, 6, 52, 123])")
 }
@@ -347,7 +347,7 @@ test "take" {
 ///|
 test "drop" {
   let ls = @list.of([1, 2, 3, 4, 5]).drop(3)
-  let el : @list.T[Int] = @list.Nil
+  let el : @list.T[Int] = @list.nil()
   inspect!(ls, content="@list.of([4, 5])")
   inspect!(ls.drop(-10), content="@list.of([4, 5])")
   inspect!(ls.drop(10), content="@list.of([])")
@@ -359,7 +359,7 @@ test "drop" {
 ///|
 test "take_while" {
   let ls = @list.take_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.take_while(@list.Nil, fn(_e) { true })
+  let el : @list.T[Int] = @list.take_while(@list.nil(), fn(_e) { true })
   inspect!(ls, content="@list.of([0, 1, 2])")
   inspect!(el, content="@list.of([])")
 }
@@ -367,14 +367,14 @@ test "take_while" {
 ///|
 test "drop_while" {
   let ls = @list.drop_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.drop_while(@list.Nil, fn(_e) { true })
+  let el : @list.T[Int] = @list.drop_while(@list.nil(), fn(_e) { true })
   inspect!(ls, content="@list.of([3, 4])")
   inspect!(el, content="@list.of([])")
 }
 
 ///|
 test "scan_left" {
-  let el = @list.Nil.scan_left(fn(acc, x) { acc + x }, init=0)
+  let el = @list.nil().scan_left(fn(acc, x) { acc + x }, init=0)
   let ls = @list.of([1, 2, 3, 4, 5]).scan_left(fn(acc, x) { acc + x }, init=0)
   let ls2 = @list.of([1, 2, 3, 4]).scan_left(fn(acc, x) { acc - x }, init=100)
   inspect!(el, content="@list.of([0])")
@@ -384,7 +384,7 @@ test "scan_left" {
 
 ///|
 test "scan_right" {
-  let el = @list.Nil.scan_right(fn(acc, x) { x + acc }, init=0)
+  let el = @list.nil().scan_right(fn(acc, x) { x + acc }, init=0)
   let ls = @list.of([1, 2, 3, 4]).scan_right(fn(acc, x) { x + acc }, init=0)
   let ls2 = @list.of([1, 2, 3, 4]).scan_right(fn(acc, x) { x - acc }, init=100)
   inspect!(el, content="@list.of([0])")
@@ -395,7 +395,7 @@ test "scan_right" {
 ///|
 test "lookup" {
   let ls = @list.of([(1, "a"), (2, "b"), (3, "c")])
-  let el : @list.T[(Int, Int)] = @list.Nil
+  let el : @list.T[(Int, Int)] = @list.nil()
   inspect!(el.lookup(1), content="None")
   inspect!(
     ls.lookup(3),
@@ -417,7 +417,7 @@ test "find" {
     content="None",
   )
   inspect!(
-    (@list.Nil : @list.T[Int]).find(fn(element) -> Bool { element % 2 == 0 }),
+    (@list.nil() : @list.T[Int]).find(fn(element) -> Bool { element % 2 == 0 }),
     content="None",
   )
 }
@@ -437,7 +437,7 @@ test "findi" {
     content="None",
   )
   inspect!(
-    (@list.Nil : @list.T[Int]).findi(fn(element, i) -> Bool {
+    (@list.nil() : @list.T[Int]).findi(fn(element, i) -> Bool {
       element % 2 == 0 && i == 3
     }),
     content="None",
@@ -493,14 +493,14 @@ test "is_prefix" {
     @list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([3, 2, 3])),
     content="false",
   )
-  inspect!(@list.Nil.is_prefix(@list.of([1, 2, 3])), content="false")
+  inspect!(@list.nil().is_prefix(@list.of([1, 2, 3])), content="false")
 }
 
 ///|
 test "equal" {
   inspect!(@list.of([1, 2, 3]) == @list.of([1, 2, 3]), content="true")
   inspect!(@list.of([1, 2, 3]) == @list.of([1, 3, 3]), content="false")
-  inspect!(@list.Nil == @list.of([1]), content="false")
+  inspect!(@list.nil() == @list.of([1]), content="false")
 }
 
 ///|
@@ -522,7 +522,7 @@ test "intercalate" {
     @list.of([4, 5, 6]),
     @list.of([7, 8, 9]),
   ])
-  let el : @list.T[@list.T[Int]] = @list.Nil
+  let el : @list.T[@list.T[Int]] = @list.nil()
   inspect!(
     ls.intercalate(@list.of([0])),
     content="@list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9])",
@@ -556,7 +556,7 @@ test "List::output with non-empty list" {
 ///|
 test "List::output with empty list" {
   let buf = StringBuilder::new(size_hint=100)
-  let list : @list.T[Int] = @list.Nil
+  let list : @list.T[Int] = @list.nil()
   Show::output(list, buf)
   inspect!(buf, content="@list.of([])")
 }
@@ -569,7 +569,7 @@ test "List::to_json with non-empty list" {
 
 ///|
 test "List::to_json with empty list" {
-  let list : @list.T[Int] = Nil
+  let list : @list.T[Int] = nil()
   @json.inspect!(ToJson::to_json(list), content=[])
 }
 
@@ -605,7 +605,7 @@ test "List::zip with lists of equal length" {
 
 ///|
 test "@list.zip with empty list" {
-  inspect!(@list.of([1]).zip((@list.Nil : @list.T[Int])), content="None")
+  inspect!(@list.of([1]).zip((@list.nil() : @list.T[Int])), content="None")
 }
 
 ///|
@@ -624,7 +624,7 @@ test "List::maximum with non-empty list" {
 
 ///|
 test "@list.maximum with empty list" {
-  inspect!((@list.Nil : @list.T[Int]).maximum(), content="None")
+  inspect!((@list.nil() : @list.T[Int]).maximum(), content="None")
 }
 
 ///|
@@ -636,7 +636,7 @@ test "List::minimum with non-empty list" {
 
 ///|
 test "@list.minimum with empty list" {
-  (@list.Nil : @list.T[Int]).minimum() |> ignore
+  (@list.nil() : @list.T[Int]).minimum() |> ignore
 }
 
 ///|
@@ -645,7 +645,7 @@ test "op_add" {
   inspect!(@list.of([]) + @list.of([1]), content="@list.of([1])")
   inspect!(@list.of([1]) + @list.of([1]), content="@list.of([1, 1])")
   inspect!(
-    (@list.Nil : @list.T[Int]) + (@list.Nil : @list.T[Int]),
+    (@list.nil() : @list.T[Int]) + (@list.nil() : @list.T[Int]),
     content="@list.of([])",
   )
 }

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test "from_array" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(ls, content="@list.of([1, 2, 3, 4, 5])")
   inspect!(el, content="@list.of([])")
 }
@@ -56,7 +56,7 @@ test "iteri" {
 ///|
 test "map" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let rs : @list.T[Int] = @list.nil()
+  let rs : @list.T[Int] = @list.empty()
   inspect!(ls.map(fn(x) { x * 2 }), content="@list.of([2, 4, 6, 8, 10])")
   inspect!(rs.map(fn(x) { x * 2 }), content="@list.of([])")
 }
@@ -64,7 +64,7 @@ test "map" {
 ///|
 test "mapi" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(ls.mapi(fn(i, x) { i * x }), content="@list.of([0, 2, 6, 12, 20])")
   inspect!(el.mapi(fn(i, x) { i * x }), content="@list.of([])")
 }
@@ -72,7 +72,7 @@ test "mapi" {
 ///|
 test "rev_map" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let rs : @list.T[Int] = @list.nil()
+  let rs : @list.T[Int] = @list.empty()
   inspect!(ls.rev_map(fn(x) { x * 2 }), content="@list.of([10, 8, 6, 4, 2])")
   inspect!(rs.rev_map(fn(x) { x * 2 }), content="@list.of([])")
 }
@@ -80,7 +80,7 @@ test "rev_map" {
 ///|
 test "to_array" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let empty : @list.T[Int] = @list.nil()
+  let empty : @list.T[Int] = @list.empty()
   let array = @list.to_array(list)
   let earray = @list.to_array(empty)
   inspect!(array, content="[1, 2, 3, 4, 5]")
@@ -90,7 +90,7 @@ test "to_array" {
 ///|
 test "filter" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let rs : @list.T[Int] = @list.nil()
+  let rs : @list.T[Int] = @list.empty()
   inspect!(ls.filter(fn(x) { x % 2 == 0 }), content="@list.of([2, 4])")
   inspect!(rs.filter(fn(x) { x % 2 == 0 }), content="@list.of([])")
 }
@@ -112,7 +112,7 @@ test "any" {
 ///|
 test "tail" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(ls.tail(), content="@list.of([2, 3, 4, 5])")
   inspect!(el.tail(), content="@list.of([])")
 }
@@ -141,9 +141,9 @@ test "last" {
 test "concat" {
   let ls = @list.of([1, 2, 3, 4, 5])
   let rs = @list.of([6, 7, 8, 9, 10])
-  inspect!(ls.concat(@list.nil()), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(ls.concat(@list.empty()), content="@list.of([1, 2, 3, 4, 5])")
   inspect!(
-    (@list.nil() : @list.T[Int]).concat(rs),
+    (@list.empty() : @list.T[Int]).concat(rs),
     content="@list.of([6, 7, 8, 9, 10])",
   )
   inspect!(ls.concat(rs), content="@list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])")
@@ -153,8 +153,8 @@ test "concat" {
 test "rev_concat" {
   let ls = @list.of([1, 2, 3, 4, 5])
   let rs = @list.of([6, 7, 8, 9, 10])
-  inspect!(@list.nil().rev_concat(ls), content="@list.of([1, 2, 3, 4, 5])")
-  inspect!(rs.rev_concat(@list.nil()), content="@list.of([10, 9, 8, 7, 6])")
+  inspect!(@list.empty().rev_concat(ls), content="@list.of([1, 2, 3, 4, 5])")
+  inspect!(rs.rev_concat(@list.empty()), content="@list.of([10, 9, 8, 7, 6])")
   inspect!(
     ls.rev_concat(rs),
     content="@list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10])",
@@ -172,7 +172,7 @@ test "rev" {
 ///|
 test "fold" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(el.fold(fn(acc, x) { acc + x }, init=0), content="0")
   inspect!(ls.fold(fn(acc, x) { acc + x }, init=0), content="15")
 }
@@ -180,7 +180,7 @@ test "fold" {
 ///|
 test "rev_fold" {
   let ls = @list.of(["1", "2", "3", "4", "5"])
-  let el : @list.T[String] = @list.nil()
+  let el : @list.T[String] = @list.empty()
   inspect!(ls.rev_fold(fn(acc, x) { x + acc }, init=""), content="12345")
   inspect!(el.rev_fold(fn(acc, x) { x + acc }, init="init"), content="init")
 }
@@ -188,7 +188,7 @@ test "rev_fold" {
 ///|
 test "foldi" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(ls.foldi(fn(i, acc, x) { acc + i * x }, init=0), content="40")
   inspect!(el.foldi(fn(i, acc, x) { acc + i * x }, init=0), content="0")
 }
@@ -196,7 +196,7 @@ test "foldi" {
 ///|
 test "rev_foldi" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(ls.rev_foldi(fn(i, acc, x) { x * i + acc }, init=0), content="20")
   inspect!(el.rev_foldi(fn(i, acc, x) { x * i + acc }, init=0), content="0")
 }
@@ -214,7 +214,7 @@ test "zip" {
 ///|
 test "flat_map" {
   let ls = @list.of([1, 2, 3])
-  let rs : @list.T[Int] = @list.nil()
+  let rs : @list.T[Int] = @list.empty()
   inspect!(rs.flat_map(fn(x) { @list.of([x, x * 2]) }), content="@list.of([])")
   inspect!(
     ls.flat_map(fn(x) { @list.of([x, x * 2]) }),
@@ -225,7 +225,7 @@ test "flat_map" {
 ///|
 test "filter_map" {
   let ls = @list.of([4, 2, 2, 6, 3, 1])
-  let rs : @list.T[Int] = @list.nil()
+  let rs : @list.T[Int] = @list.empty()
   inspect!(
     ls.filter_map(fn(x) { if x >= 3 { Some(x) } else { None } }),
     content="@list.of([4, 6, 3])",
@@ -259,7 +259,7 @@ test "repeat" {
 ///|
 test "intersperse" {
   let ls = @list.of(["1", "2", "3", "4", "5"])
-  let el : @list.T[String] = nil()
+  let el : @list.T[String] = empty()
   inspect!(
     ls.intersperse("|"),
     content=
@@ -273,7 +273,7 @@ test "intersperse" {
 test "is_empty" {
   let ls = @list.of([1, 2, 3, 4, 5])
   inspect!(ls.is_empty(), content="false")
-  inspect!((@list.nil() : @list.T[Unit]).is_empty(), content="true")
+  inspect!((@list.empty() : @list.T[Unit]).is_empty(), content="true")
 }
 
 ///|
@@ -291,7 +291,7 @@ test "flatten" {
     @list.of([4, 5, 6]),
     @list.of([7, 8, 9]),
   ])
-  let el : @list.T[@list.T[Int]] = @list.nil()
+  let el : @list.T[@list.T[Int]] = @list.empty()
   inspect!(ls.flatten(), content="@list.of([1, 2, 3, 4, 5, 6, 7, 8, 9])")
   inspect!(el.flatten(), content="@list.of([])")
 }
@@ -311,7 +311,7 @@ test "minimum" {
 ///|
 test "sort" {
   let ls = @list.of([1, 123, 52, 3, 6, 0, -6, -76])
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(el.sort(), content="@list.of([])")
   inspect!(ls.sort(), content="@list.of([-76, -6, 0, 1, 3, 6, 52, 123])")
 }
@@ -347,7 +347,7 @@ test "take" {
 ///|
 test "drop" {
   let ls = @list.of([1, 2, 3, 4, 5]).drop(3)
-  let el : @list.T[Int] = @list.nil()
+  let el : @list.T[Int] = @list.empty()
   inspect!(ls, content="@list.of([4, 5])")
   inspect!(ls.drop(-10), content="@list.of([4, 5])")
   inspect!(ls.drop(10), content="@list.of([])")
@@ -359,7 +359,7 @@ test "drop" {
 ///|
 test "take_while" {
   let ls = @list.take_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.take_while(@list.nil(), fn(_e) { true })
+  let el : @list.T[Int] = @list.take_while(@list.empty(), fn(_e) { true })
   inspect!(ls, content="@list.of([0, 1, 2])")
   inspect!(el, content="@list.of([])")
 }
@@ -367,14 +367,14 @@ test "take_while" {
 ///|
 test "drop_while" {
   let ls = @list.drop_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.drop_while(@list.nil(), fn(_e) { true })
+  let el : @list.T[Int] = @list.drop_while(@list.empty(), fn(_e) { true })
   inspect!(ls, content="@list.of([3, 4])")
   inspect!(el, content="@list.of([])")
 }
 
 ///|
 test "scan_left" {
-  let el = @list.nil().scan_left(fn(acc, x) { acc + x }, init=0)
+  let el = @list.empty().scan_left(fn(acc, x) { acc + x }, init=0)
   let ls = @list.of([1, 2, 3, 4, 5]).scan_left(fn(acc, x) { acc + x }, init=0)
   let ls2 = @list.of([1, 2, 3, 4]).scan_left(fn(acc, x) { acc - x }, init=100)
   inspect!(el, content="@list.of([0])")
@@ -384,7 +384,7 @@ test "scan_left" {
 
 ///|
 test "scan_right" {
-  let el = @list.nil().scan_right(fn(acc, x) { x + acc }, init=0)
+  let el = @list.empty().scan_right(fn(acc, x) { x + acc }, init=0)
   let ls = @list.of([1, 2, 3, 4]).scan_right(fn(acc, x) { x + acc }, init=0)
   let ls2 = @list.of([1, 2, 3, 4]).scan_right(fn(acc, x) { x - acc }, init=100)
   inspect!(el, content="@list.of([0])")
@@ -395,7 +395,7 @@ test "scan_right" {
 ///|
 test "lookup" {
   let ls = @list.of([(1, "a"), (2, "b"), (3, "c")])
-  let el : @list.T[(Int, Int)] = @list.nil()
+  let el : @list.T[(Int, Int)] = @list.empty()
   inspect!(el.lookup(1), content="None")
   inspect!(
     ls.lookup(3),
@@ -417,7 +417,7 @@ test "find" {
     content="None",
   )
   inspect!(
-    (@list.nil() : @list.T[Int]).find(fn(element) -> Bool { element % 2 == 0 }),
+    (@list.empty() : @list.T[Int]).find(fn(element) -> Bool { element % 2 == 0 }),
     content="None",
   )
 }
@@ -437,7 +437,7 @@ test "findi" {
     content="None",
   )
   inspect!(
-    (@list.nil() : @list.T[Int]).findi(fn(element, i) -> Bool {
+    (@list.empty() : @list.T[Int]).findi(fn(element, i) -> Bool {
       element % 2 == 0 && i == 3
     }),
     content="None",
@@ -493,14 +493,14 @@ test "is_prefix" {
     @list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([3, 2, 3])),
     content="false",
   )
-  inspect!(@list.nil().is_prefix(@list.of([1, 2, 3])), content="false")
+  inspect!(@list.empty().is_prefix(@list.of([1, 2, 3])), content="false")
 }
 
 ///|
 test "equal" {
   inspect!(@list.of([1, 2, 3]) == @list.of([1, 2, 3]), content="true")
   inspect!(@list.of([1, 2, 3]) == @list.of([1, 3, 3]), content="false")
-  inspect!(@list.nil() == @list.of([1]), content="false")
+  inspect!(@list.empty() == @list.of([1]), content="false")
 }
 
 ///|
@@ -522,7 +522,7 @@ test "intercalate" {
     @list.of([4, 5, 6]),
     @list.of([7, 8, 9]),
   ])
-  let el : @list.T[@list.T[Int]] = @list.nil()
+  let el : @list.T[@list.T[Int]] = @list.empty()
   inspect!(
     ls.intercalate(@list.of([0])),
     content="@list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9])",
@@ -556,7 +556,7 @@ test "List::output with non-empty list" {
 ///|
 test "List::output with empty list" {
   let buf = StringBuilder::new(size_hint=100)
-  let list : @list.T[Int] = @list.nil()
+  let list : @list.T[Int] = @list.empty()
   Show::output(list, buf)
   inspect!(buf, content="@list.of([])")
 }
@@ -569,7 +569,7 @@ test "List::to_json with non-empty list" {
 
 ///|
 test "List::to_json with empty list" {
-  let list : @list.T[Int] = nil()
+  let list : @list.T[Int] = empty()
   @json.inspect!(ToJson::to_json(list), content=[])
 }
 
@@ -605,7 +605,10 @@ test "List::zip with lists of equal length" {
 
 ///|
 test "@list.zip with empty list" {
-  inspect!(@list.of([1]).zip((@list.nil() : @list.T[Int])), content="@list.of([])")
+  inspect!(
+    @list.of([1]).zip((@list.empty() : @list.T[Int])),
+    content="@list.of([])",
+  )
 }
 
 ///|
@@ -624,7 +627,7 @@ test "List::maximum with non-empty list" {
 
 ///|
 test "@list.maximum with empty list" {
-  inspect!((@list.nil() : @list.T[Int]).maximum(), content="None")
+  inspect!((@list.empty() : @list.T[Int]).maximum(), content="None")
 }
 
 ///|
@@ -636,7 +639,7 @@ test "List::minimum with non-empty list" {
 
 ///|
 test "@list.minimum with empty list" {
-  (@list.nil() : @list.T[Int]).minimum() |> ignore
+  (@list.empty() : @list.T[Int]).minimum() |> ignore
 }
 
 ///|
@@ -645,7 +648,7 @@ test "op_add" {
   inspect!(@list.of([]) + @list.of([1]), content="@list.of([1])")
   inspect!(@list.of([1]) + @list.of([1]), content="@list.of([1, 1])")
   inspect!(
-    (@list.nil() : @list.T[Int]) + (@list.nil() : @list.T[Int]),
+    (@list.empty() : @list.T[Int]) + (@list.empty() : @list.T[Int]),
     content="@list.of([])",
   )
 }

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -207,7 +207,7 @@ test "zip" {
   let rs = @list.of([6, 7, 8, 9, 10])
   inspect!(
     ls.zip(rs),
-    content="Some(@list.of([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]))",
+    content="@list.of([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)])",
   )
 }
 
@@ -599,13 +599,13 @@ test "List::zip with lists of equal length" {
   let list1 = @list.of([1, 2, 3])
   let list2 = @list.of(["a", "b", "c"])
   let zipped = list1.zip(list2)
-  let expected = Some(@list.of([(1, "a"), (2, "b"), (3, "c")]))
+  let expected = @list.of([(1, "a"), (2, "b"), (3, "c")])
   assert_eq!(zipped, expected)
 }
 
 ///|
 test "@list.zip with empty list" {
-  inspect!(@list.of([1]).zip((@list.nil() : @list.T[Int])), content="None")
+  inspect!(@list.of([1]).zip((@list.nil() : @list.T[Int])), content="@list.of([])")
 }
 
 ///|

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -682,3 +682,14 @@ test "hash" {
   inspect!(l1.hash() == l4.hash(), content="false")
   inspect!(l4.hash() == l4.hash(), content="true")
 }
+
+///|
+test "immutability" {
+  let l1 = @list.of([1, 2])
+  let l2 = @list.of([l1, l1, l1, l1]).flatten()
+  inspect!(l2, content="@list.of([1, 2, 1, 2, 1, 2, 1, 2])")
+  inspect!(l1, content="@list.of([1, 2])")
+  let l3 = l1.flat_map(fn(_) { l1 })
+  inspect!(l3, content="@list.of([1, 2, 1, 2])")
+  inspect!(l1, content="@list.of([1, 2])")
+}

--- a/list/moon.pkg.json
+++ b/list/moon.pkg.json
@@ -6,9 +6,7 @@
     "moonbitlang/core/json",
     "moonbitlang/core/option"
   ],
-  "test-import": [
-    "moonbitlang/core/prelude"
-  ],
+  "test-import": [],
   "targets": {
     "panic_test.mbt": [
       "not",

--- a/list/moon.pkg.json
+++ b/list/moon.pkg.json
@@ -1,0 +1,18 @@
+{
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/array",
+    "moonbitlang/core/quickcheck",
+    "moonbitlang/core/json",
+    "moonbitlang/core/option"
+  ],
+  "test-import": [
+    "moonbitlang/core/prelude"
+  ],
+  "targets": {
+    "panic_test.mbt": [
+      "not",
+      "native"
+    ]
+  }
+}

--- a/list/moon.pkg.json
+++ b/list/moon.pkg.json
@@ -3,8 +3,7 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/json",
-    "moonbitlang/core/option"
+    "moonbitlang/core/json"
   ],
   "test-import": [],
   "targets": {

--- a/list/panic_test.mbt
+++ b/list/panic_test.mbt
@@ -14,25 +14,25 @@
 
 ///|
 test "last None" {
-  assert_eq!(@list.nil().last(), (None : Unit?))
+  assert_eq!(@list.empty().last(), (None : Unit?))
 }
 
 ///|
 test "panic nth_exn" {
-  @list.nil().unsafe_nth(0)
+  @list.empty().unsafe_nth(0)
 }
 
 ///|
 test "panic @list.exn with empty list" {
-  @list.nil().unsafe_head()
+  @list.empty().unsafe_head()
 }
 
 ///|
 test "panic @list.unsafe_maximum with empty list" {
-  inspect!((@list.nil() : @list.T[Int]).unsafe_maximum())
+  inspect!((@list.empty() : @list.T[Int]).unsafe_maximum())
 }
 
 ///|
 test "panic @list.unsafe_minimum with empty list" {
-  inspect!((@list.nil() : @list.T[Int]).unsafe_minimum())
+  inspect!((@list.empty() : @list.T[Int]).unsafe_minimum())
 }

--- a/list/panic_test.mbt
+++ b/list/panic_test.mbt
@@ -14,25 +14,25 @@
 
 ///|
 test "last None" {
-  assert_eq!(@list.Nil.last(), (None : Unit?))
+  assert_eq!(@list.nil().last(), (None : Unit?))
 }
 
 ///|
 test "panic nth_exn" {
-  @list.Nil.unsafe_nth(0)
+  @list.nil().unsafe_nth(0)
 }
 
 ///|
 test "panic @list.exn with empty list" {
-  @list.Nil.unsafe_head()
+  @list.nil().unsafe_head()
 }
 
 ///|
 test "panic @list.unsafe_maximum with empty list" {
-  inspect!((@list.Nil : @list.T[Int]).unsafe_maximum())
+  inspect!((@list.nil() : @list.T[Int]).unsafe_maximum())
 }
 
 ///|
 test "panic @list.unsafe_minimum with empty list" {
-  inspect!((@list.Nil : @list.T[Int]).unsafe_minimum())
+  inspect!((@list.nil() : @list.T[Int]).unsafe_minimum())
 }

--- a/list/panic_test.mbt
+++ b/list/panic_test.mbt
@@ -1,0 +1,38 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "last None" {
+  assert_eq!(@list.Nil.last(), (None : Unit?))
+}
+
+///|
+test "panic nth_exn" {
+  @list.Nil.unsafe_nth(0)
+}
+
+///|
+test "panic @list.exn with empty list" {
+  @list.Nil.unsafe_head()
+}
+
+///|
+test "panic @list.unsafe_maximum with empty list" {
+  inspect!((@list.Nil : @list.T[Int]).unsafe_maximum())
+}
+
+///|
+test "panic @list.unsafe_minimum with empty list" {
+  inspect!((@list.Nil : @list.T[Int]).unsafe_minimum())
+}

--- a/list/types.mbt
+++ b/list/types.mbt
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 ///|
-pub(all) enum T[A] {
+pub enum T[A] {
   Nil
   Cons(A, mut tail~ : T[A])
 } derive(Eq)

--- a/list/types.mbt
+++ b/list/types.mbt
@@ -1,0 +1,20 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+///|
+pub(all) enum T[A] {
+  Nil
+  Cons(A, mut tail~ : T[A])
+} derive(Eq)

--- a/list/types.mbt
+++ b/list/types.mbt
@@ -14,6 +14,6 @@
 
 ///|
 pub enum T[A] {
-  Nil
-  Cons(A, mut tail~ : T[A])
+  Empty
+  More(A, mut tail~ : T[A])
 } derive(Eq)

--- a/string/moon.pkg.json
+++ b/string/moon.pkg.json
@@ -1,6 +1,6 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/char"],
-  "test-import": ["moonbitlang/core/immut/list", "moonbitlang/core/json"],
+  "test-import": ["moonbitlang/core/list", "moonbitlang/core/json"],
   "targets": {
     "panic_test.mbt": ["not", "native"]
   }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -563,11 +563,11 @@ test "String::fold" {
   let s = "this is a long string"
   inspect!(s.fold(init=0, fn(acc, c) { acc + c.to_int() }), content="1980")
   inspect!(
-    s.fold(init=@list.Nil, @list.add) |> @list.rev(),
+    s.fold(init=@list.nil(), @list.add) |> @list.rev(),
     content="@list.of(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
   inspect!(
-    s.rev_fold(init=@list.Nil, @list.add),
+    s.rev_fold(init=@list.nil(), @list.add),
     content="@list.of(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
 }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -563,11 +563,11 @@ test "String::fold" {
   let s = "this is a long string"
   inspect!(s.fold(init=0, fn(acc, c) { acc + c.to_int() }), content="1980")
   inspect!(
-    s.fold(init=@list.nil(), @list.add) |> @list.rev(),
+    s.fold(init=@list.empty(), @list.prepend) |> @list.rev(),
     content="@list.of(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
   inspect!(
-    s.rev_fold(init=@list.nil(), @list.add),
+    s.rev_fold(init=@list.empty(), @list.prepend),
     content="@list.of(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
 }


### PR DESCRIPTION
Reference : #1941 

This PR rewrites the `immut/list` in a stack safe manner by using 'tail modulo constructor' pattern.

Notice that this introduces a few **breaking changes** compared to `immut/list`'s original implementation for API consistency with other packages:

- the argument ordering of the high order function parameter of `rev_foldi` `rev_fold` `scan_right` is changed so that the accumulator always come before the visited argument: `(i, accumulator, element) -> result` or `(accumulator, element) -> result`
- the semantic of the index of `rev_foldi` is changed: it used to be the index of the visited element in the list, and now it is the index of the visiting order.