### PR TITLE
fix: import `@bench` when using tests with arguments

### DIFF
--- a/double/moon.pkg.json
+++ b/double/moon.pkg.json
@@ -29,6 +29,7 @@
     "hypot_nonjs.mbt" : ["not", "js"]
   },
   "test-import": [
-    "moonbitlang/core/test"
+    "moonbitlang/core/test",
+    "moonbitlang/core/bench"
   ]
 }

--- a/double/moon.pkg.json
+++ b/double/moon.pkg.json
@@ -31,5 +31,6 @@
   "test-import": [
     "moonbitlang/core/test",
     "moonbitlang/core/bench"
-  ]
+  ],
+  "warn-list": "-29"
 }


### PR DESCRIPTION
For tests in the core, coders shall explicitly import the packages used in the test driver, except for `@builtin`.

The driver for tests with arguments used `@test`, which has been imported. Since `moon` introduced the benchmark mechanism in the same driver, an additional `@bench` import is required.

It's also required to allow warning `29` (unused package) as only newer `moon` will actually use this package in its driver.

This is related to https://github.com/moonbitlang/moon/pull/751.

This PR should be merged immediately before next pre-release to minimalize the duration of disabling PR unused package warnings ~~broken stable CI~~. Only after this PR merged, can PR https://github.com/moonbitlang/moon/pull/751 pass its own CI and then been merged. Merge https://github.com/moonbitlang/moon/pull/751 first means to break all its CI and core's bleeding CI, which is not preferrable.

