### PR TITLE
add contains_kv API to prepare more efficient pattern match compilation

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -304,6 +304,7 @@ impl Map {
   capacity[K, V](Self[K, V]) -> Int
   clear[K, V](Self[K, V]) -> Unit
   contains[K : Hash + Eq, V](Self[K, V], K) -> Bool
+  contains_kv[K : Hash + Eq, V : Eq](Self[K, V], K, V) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
   from_array[K : Hash + Eq, V](Array[(K, V)]) -> Self[K, V]

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -249,9 +249,59 @@ pub fn Map::get_or_init[K : Hash + Eq, V](
 ///|
 /// Check if the hash map contains a key.
 pub fn Map::contains[K : Hash + Eq, V](self : Map[K, V], key : K) -> Bool {
-  match self.get(key) {
-    Some(_) => true
-    None => false
+  // inline Map::get to avoid boxing
+  let hash = key.hash()
+  for i = 0, idx = hash & self.capacity_mask {
+    guard self.entries[idx] is Some(entry) else { break false }
+    if entry.hash == hash && entry.key == key {
+      break true
+    }
+    if i > entry.psl {
+      break false
+    }
+    continue i + 1, (idx + 1) & self.capacity_mask
+  }
+}
+
+///|
+/// Checks if a map contains a specific key-value pair.
+///
+/// Parameters:
+///
+/// * `map` : A map of type `Map[K, V]` to search in.
+/// * `key` : The key to look up in the map.
+/// * `value` : The value to be compared with the value associated with the key.
+///
+/// Returns `true` if the map contains the specified key and its associated value
+/// equals the given value, `false` otherwise.
+///
+/// Example:
+///
+/// ```moonbit
+/// ///|
+/// test "Map::contains_kv" {
+///   let map = { "a": 1, "b": 2 }
+///   inspect!(map.contains_kv("a", 1), content="true")
+///   inspect!(map.contains_kv("a", 2), content="false")
+///   inspect!(map.contains_kv("c", 3), content="false")
+/// }
+/// ```
+pub fn Map::contains_kv[K : Hash + Eq, V : Eq](
+  self : Map[K, V],
+  key : K,
+  value : V
+) -> Bool {
+  // inline Map::get to avoid boxing
+  let hash = key.hash()
+  for i = 0, idx = hash & self.capacity_mask {
+    guard self.entries[idx] is Some(entry) else { break false }
+    if entry.hash == hash && entry.key == key && entry.value == value {
+      break true
+    }
+    if i > entry.psl {
+      break false
+    }
+    continue i + 1, (idx + 1) & self.capacity_mask
   }
 }
 

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -577,10 +577,8 @@ pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with op_equal(
 ) -> Bool {
   guard self.size == that.size else { return false }
   for k, v in self {
-    match that.get(k) {
-      None => break false
-      Some(v_) => if v_ != v { break false }
-    }
+    guard that.contains_kv(k, v) else { return false }
+
   } else {
     true
   }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -168,18 +168,14 @@ pub fn Map::op_set[K : Hash + Eq, V](
 pub fn Map::get[K : Hash + Eq, V](self : Map[K, V], key : K) -> V? {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
-      Some(entry) => {
-        if entry.hash == hash && entry.key == key {
-          break Some(entry.value)
-        }
-        if i > entry.psl {
-          break None
-        }
-        continue i + 1, (idx + 1) & self.capacity_mask
-      }
-      None => break None
+    guard self.entries[idx] is Some(entry) else { break None }
+    if entry.hash == hash && entry.key == key {
+      break Some(entry.value)
     }
+    if i > entry.psl {
+      break None
+    }
+    continue i + 1, (idx + 1) & self.capacity_mask
   }
 }
 

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -278,7 +278,7 @@ pub fn Map::contains[K : Hash + Eq, V](self : Map[K, V], key : K) -> Bool {
 /// Example:
 ///
 /// ```moonbit
-/// ///|
+/// 
 /// test "Map::contains_kv" {
 ///   let map = { "a": 1, "b": 2 }
 ///   inspect!(map.contains_kv("a", 1), content="true")

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -47,3 +47,16 @@ test "Map:: iter2" {
   v.each(fn(k, v) { res = res + k + v.to_string() })
   inspect!(res, content="a1b2c3")
 }
+
+///|
+test "map::contains_kv" {
+  let map = { "a": 1, "b": 2, "c": 3 }
+  // contains_kv will be used in the pattern matching
+  // to avoid boxing
+  inspect!(map.contains_kv("a", 1), content="true")
+  inspect!(map.contains_kv("a", 2), content="false")
+  guard map is { "a": 1, "b": 2, "c": 3 } else {
+    fail!("map is not { \"a\": 1, \"b\": 2, \"c\": 3 }")
+  }
+
+}

--- a/sorted_map/README.mbt.md
+++ b/sorted_map/README.mbt.md
@@ -79,10 +79,7 @@ Safe access with error handling:
 test {
   let map = @sorted_map.from_array([(1, "one"), (2, "two")])
   let key = 3
-  match map.get(key) {
-    Some(value) => println("Found: \{value}")
-    None => println("Key {key} not found")
-  }
+  inspect!(map.get(key), content="None")
 }
 ```
 
@@ -264,14 +261,13 @@ When working with keys that might not exist, prefer using pattern matching for s
 fn get_score(scores : @sorted_map.T[Int, Int], student_id : Int) -> Int {
   match scores.get(student_id) {
     Some(score) => score
-    None => {
-      println(
-        "Student ID " +
-        student_id.to_string() +
-        " does not exist, returning default score",
-      )
+    None =>
+      // println(
+      //   "Student ID " +
+      //   student_id.to_string() +
+      //   " does not exist, returning default score",
+      // )
       0 // Default score
-    }
   }
 }
 


### PR DESCRIPTION
- **refactor(linked_hash_map): replace match with guard for entry retrieval**
- **update(sorted_map): enhance README with error handling examples and improve key access explanations**
- **feat(linked_hash_map): add `contains_kv` method to check for key-value pairs and improve `contains` implementation**
