### PR TITLE
feat(stringview): add length method to View

### DIFF
--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -135,12 +135,6 @@ pub fn View::op_as_view(self : View, start~ : Int = 0, end? : Int) -> View {
 }
 
 ///|
-#deprecated("use View::char_length instead")
-pub fn View::length(self : View) -> Int {
-  self.char_length()
-}
-
-///|
 #deprecated("use View::char_length_eq instead")
 pub fn length_eq(self : View, len : Int) -> Bool {
   self.char_length_eq(len)

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -16,8 +16,8 @@
 /// Returns the offset (charcode index) of the first occurrence of the given
 /// substring. If the substring is not found, it returns None.
 pub fn View::find(self : View, str : View) -> Int? {
-  let len = self.len()
-  let sub_len = str.len()
+  let len = self.length()
+  let sub_len = str.length()
   // Handle empty substring case
   guard sub_len > 0 else { return Some(0) }
   // If substring is longer than string, it can't be found
@@ -72,8 +72,8 @@ test "find" {
 /// Returns the offset of the last occurrence of the given substring. If the
 /// substring is not found, it returns None.
 pub fn View::rev_find(self : View, str : View) -> Int? {
-  let len = self.len()
-  let sub_len = str.len()
+  let len = self.length()
+  let sub_len = str.length()
   guard sub_len > 0 else { return Some(len) }
   guard sub_len <= len else { return None }
   let min_idx = sub_len - 1
@@ -123,7 +123,7 @@ test "rev_find" {
 ///| 
 /// Returns true if the given substring is suffix of this string.
 pub fn View::has_suffix(self : View, str : View) -> Bool {
-  self.rev_find(str) is Some(i) && i == self.len() - str.len()
+  self.rev_find(str) is Some(i) && i == self.length() - str.length()
 }
 
 ///|
@@ -337,7 +337,7 @@ test "trim_space" {
 ///|
 /// Returns true if this string is empty.
 pub fn View::is_empty(self : View) -> Bool {
-  self.len() == 0
+  self.length() == 0
 }
 
 ///|
@@ -502,7 +502,7 @@ pub fn View::repeat(self : View, n : Int) -> String {
     _..=0 => ""
     1 => self.to_string()
     _ => {
-      let len = self.len()
+      let len = self.length()
       let buf = StringBuilder::new(size_hint=len * n)
       let str = self.to_string()
       for _ in 0..<n {
@@ -548,7 +548,7 @@ test "repeat" {
 /// Returns a new string with the characters in reverse order. It respects
 /// Unicode characters and surrogate pairs but not grapheme clusters.
 pub fn View::rev(self : View) -> String {
-  let buf = StringBuilder::new(size_hint=self.len())
+  let buf = StringBuilder::new(size_hint=self.length())
   for c in self.rev_iter() {
     buf.write_char(c)
   }
@@ -580,7 +580,7 @@ test "rev" {
 /// If the separator is empty, the returned iterator will contain all the
 /// characters in the string as single elements.
 pub fn View::split(self : View, sep : View) -> Iter[View] {
-  let sep_len = sep.len()
+  let sep_len = sep.length()
   if sep_len == 0 {
     return self.iter().map(fn(c) { c.to_string().view() })
   }
@@ -654,7 +654,7 @@ pub fn View::replace(self : View, old~ : View, new~ : View) -> String {
       [
         ..self.view(end_offset=end),
         ..new,
-        ..self.view(start_offset=end + old.len()),
+        ..self.view(start_offset=end + old.length()),
       ]
     None => self.to_string()
   }
@@ -687,9 +687,9 @@ test "replace" {
 /// character in the string, so `new` is inserted at the beginning of the string
 /// and after each character.
 pub fn View::replace_all(self : View, old~ : View, new~ : View) -> String {
-  let buf = StringBuilder::new(size_hint=self.len())
-  let len = self.len()
-  let old_len = old.len()
+  let len = self.length()
+  let buf = StringBuilder::new(size_hint=len)
+  let old_len = old.length()
   // todo: improve performance
   if old_len == 0 {
     buf.write_string(new.to_string())
@@ -749,7 +749,7 @@ test "replace_all" {
 /// Converts this string to lowercase.
 pub fn View::to_lower(self : View) -> String {
   // TODO: deal with non-ascii characters
-  let buf = StringBuilder::new(size_hint=self.len())
+  let buf = StringBuilder::new(size_hint=self.length())
   for c in self {
     if c is ('A'..='Z') {
       // 'A' is 65 in ASCII, 'a' is 97, the difference is 32
@@ -778,7 +778,7 @@ test "to_lower" {
 /// Converts this string to uppercase.
 pub fn View::to_upper(self : View) -> String {
   // TODO: deal with non-ascii characters
-  let buf = StringBuilder::new(size_hint=self.len())
+  let buf = StringBuilder::new(size_hint=self.length())
   for c in self {
     if c >= 'a' && c <= 'z' {
       buf.write_char(Char::from_int(c.to_int() - 32))

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -38,6 +38,8 @@ fn iter2(String) -> Iter2[Int, Char]
 #deprecated
 fn last_index_of(String, String, from~ : Int = ..) -> Int
 
+fn length(StringView) -> Int
+
 #deprecated
 fn length_eq(StringView, Int) -> Bool
 
@@ -107,7 +109,6 @@ impl StringView {
   is_empty(Self) -> Bool
   iter(Self) -> Iter[Char]
   iter2(Self) -> Iter2[Int, Char]
-  #deprecated
   length(Self) -> Int
   #deprecated
   length_eq(Self, Int) -> Bool

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -38,7 +38,10 @@ struct StringView {
 pub typealias View = StringView
 
 ///|
-fn len(self : View) -> Int {
+/// Returns the length of the view.
+/// 
+/// This method counts the charcodes(code unit) in the view and has O(1) complexity.
+pub fn length(self : View) -> Int {
   self.end - self.start
 }
 
@@ -78,11 +81,11 @@ pub fn String::view(
 pub fn View::view(
   self : View,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.len()
+  end_offset~ : Int = self.length()
 ) -> View {
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
-    end_offset <= self.len() else {
+    end_offset <= self.length() else {
     abort("Invalid index for View")
   }
   {
@@ -114,7 +117,9 @@ pub fn View::offset_of_nth_char(self : View, i : Int) -> Int? {
 /// 
 /// This method has O(n) complexity.
 pub fn View::char_at(self : View, index : Int) -> Char {
-  guard index >= 0 && index < self.len() else { abort("Index out of bounds") }
+  guard index >= 0 && index < self.length() else {
+    abort("Index out of bounds")
+  }
   self.str.unsafe_char_at(self.start + index)
 }
 
@@ -123,7 +128,9 @@ pub fn View::char_at(self : View, index : Int) -> Char {
 /// 
 /// This method has O(1) complexity.
 pub fn View::charcode_at(self : View, index : Int) -> Int {
-  guard index >= 0 && index < self.len() else { abort("Index out of bounds") }
+  guard index >= 0 && index < self.length() else {
+    abort("Index out of bounds")
+  }
   self.str.unsafe_charcode_at(self.start + index)
 }
 
@@ -206,7 +213,7 @@ pub fn View::iter(self : View) -> Iter[Char] {
 ///|
 pub fn View::iter2(self : View) -> Iter2[Int, Char] {
   Iter2::new(fn(yield_) {
-    let len = self.len()
+    let len = self.length()
     for index = 0, n = 0; index < len; index = index + 1, n = n + 1 {
       let c1 = self.str.unsafe_charcode_at(self.start + index)
       if is_leading_surrogate(c1) && index + 1 < len {
@@ -251,8 +258,8 @@ pub fn View::rev_iter(self : View) -> Iter[Char] {
 /// Compares two views for equality. Returns true only if both views
 /// have the same length and contain identical characters in the same order.
 pub impl Eq for View with op_equal(self, other) {
-  let len = self.len()
-  guard len == other.len() else { return false }
+  let len = self.length()
+  guard len == other.length() else { return false }
   if physical_equal(self.str, other.str) && self.start == other.start {
     return true
   }
@@ -272,8 +279,8 @@ pub impl Eq for View with op_equal(self, other) {
 /// not necessarily the same as "alphabetical" order, which varies by language
 /// and locale.
 pub impl Compare for View with compare(self, other) {
-  let self_len = self.len()
-  let other_len = other.len()
+  let self_len = self.length()
+  let other_len = other.length()
   let cmp = self_len.compare(other_len)
   guard cmp == 0 else { return cmp }
   if physical_equal(self.str, other.str) && self.start == other.start {

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -95,7 +95,7 @@ test "stringview rev_get" {
 test "stringview length" {
   let str = "Hello🤣🤣🤣"
   let view = str[1:6]
-  inspect!(view.length(), content="5")
+  inspect!(view.length(), content="6")
 }
 
 ///|


### PR DESCRIPTION
This PR changes the `View::length()` method to count the number of charcodes. `View::length()` has been deprecated for over a few weeks so I just changed it.