### PR TITLE
refactor(immut/map): unify lookup to get

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -48,7 +48,7 @@ pub fn singleton[K, V](key : K, value : V) -> T[K, V] {
 ///|
 /// Check if the map contains a key.
 pub fn contains[K : Eq + Hash, V](self : T[K, V], key : K) -> Bool {
-  match self.lookup(key) {
+  match self.get(key) {
     Some(_) => true
     None => false
   }
@@ -56,15 +56,15 @@ pub fn contains[K : Eq + Hash, V](self : T[K, V], key : K) -> Bool {
 
 ///|
 /// Lookup a key from a hash map
-#deprecated("Use `lookup()` instead")
+#deprecated("Use `get()` instead")
 #coverage.skip
 pub fn find[K : Eq + Hash, V](self : T[K, V], key : K) -> V? {
-  self.lookup(key)
+  self.get(key)
 }
 
 ///|
 /// Lookup a key from a hash map
-pub fn lookup[K : Eq + Hash, V](self : T[K, V], key : K) -> V? {
+pub fn get[K : Eq + Hash, V](self : T[K, V], key : K) -> V? {
   loop self, key.hash() {
     Empty, _ => None
     Leaf(key1, value), _ => if key == key1 { Some(value) } else { None }
@@ -85,7 +85,7 @@ pub fn lookup[K : Eq + Hash, V](self : T[K, V], key : K) -> V? {
 
 ///|
 pub fn op_get[K : Eq + Hash, V](self : T[K, V], key : K) -> V? {
-  self.lookup(key)
+  self.get(key)
 }
 
 ///|
@@ -326,7 +326,7 @@ pub fn union[K : Eq + Hash, V](self : T[K, V], other : T[K, V]) -> T[K, V] {
     (Leaf(k, v), _) =>
       // right-hand side element is prioritized
       // like Clojure's merge
-      match other.lookup(k) {
+      match other.get(k) {
         Some(_) => other
         None => other.add(k, v)
       }
@@ -434,7 +434,7 @@ pub fn of[K : Eq + Hash, V](arr : FixedArray[(K, V)]) -> T[K, V] {
 pub impl[K : Eq + Hash, V : Eq] Eq for T[K, V] with op_equal(self, other) {
   guard self.size() == other.size() else { return false }
   for kv in self {
-    guard other.lookup(kv.0) is Some(v) && v == kv.1 else { return false }
+    guard other.get(kv.0) is Some(v) && v == kv.1 else { return false }
 
   }
   true

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -28,19 +28,19 @@ test "HAMT" {
     i, map => continue i + 1, map.add(i, i)
   }
   for i in 0..<100 {
-    assert_eq!((i, map.lookup(i)), (i, Some(i)))
+    assert_eq!((i, map.get(i)), (i, Some(i)))
   }
-  inspect!((100, map.lookup(100)), content="(100, None)")
+  inspect!((100, map.get(100)), content="(100, None)")
   let map = map.add(100, 100)
-  inspect!((100, map.lookup(100)), content="(100, Some(100))")
+  inspect!((100, map.get(100)), content="(100, Some(100))")
   // test for replacement
   let map = loop 0, map {
     100, map => map
     i, map => continue i + 2, map.add(i, i + 1)
   }
   for i = 0; i < 100; i = i + 2 {
-    assert_eq!((i, map.lookup(i)), (i, Some(i + 1)))
-    assert_eq!((i + 1, map.lookup(i + 1)), (i + 1, Some(i + 1)))
+    assert_eq!((i, map.get(i)), (i, Some(i + 1)))
+    assert_eq!((i + 1, map.get(i + 1)), (i + 1, Some(i + 1)))
   }
 }
 
@@ -51,15 +51,15 @@ test "HAMT::remove" {
     i, map => continue i + 1, map.add(i, i)
   }
   for i in 0..<100 {
-    assert_eq!((i, map.lookup(i)), (i, Some(i)))
+    assert_eq!((i, map.get(i)), (i, Some(i)))
   }
   let map = loop 0, map {
     100, map => map.remove(100) // test for removing non-existing element
     i, map => continue i + 2, map.remove(i)
   }
   for i = 0; i < 100; i = i + 2 {
-    assert_eq!(map.lookup(i), None)
-    assert_eq!(map.lookup(i + 1), Some(i + 1))
+    assert_eq!(map.get(i), None)
+    assert_eq!(map.get(i + 1), Some(i + 1))
   }
 }
 
@@ -114,24 +114,24 @@ test "HAMT::to_string" {
 test "HAMT::from_array" {
   let map = @hashmap.of([(1, "1"), (2, "2"), (42, "42")])
   inspect!(
-    (1, map.lookup(1)),
+    (1, map.get(1)),
     content=
       #|(1, Some("1"))
     ,
   )
   inspect!(
-    (2, map.lookup(2)),
+    (2, map.get(2)),
     content=
       #|(2, Some("2"))
     ,
   )
   inspect!(
-    (42, map.lookup(42)),
+    (42, map.get(42)),
     content=
       #|(42, Some("42"))
     ,
   )
-  inspect!((43, map.lookup(43)), content="(43, None)")
+  inspect!((43, map.get(43)), content="(43, None)")
 }
 
 ///|
@@ -309,9 +309,9 @@ test "filter with all elements matching" {
 test "filter with no elements matching" {
   let map = @hashmap.of([(1, 1), (2, 2), (3, 3)])
   let filtered = map.filter(fn(v) { v > 10 })
-  assert_eq!(filtered.lookup(1), None)
-  assert_eq!(filtered.lookup(2), None)
-  assert_eq!(filtered.lookup(3), None)
+  assert_eq!(filtered.get(1), None)
+  assert_eq!(filtered.get(2), None)
+  assert_eq!(filtered.get(3), None)
   assert_eq!(filtered.size(), 0)
 }
 
@@ -319,8 +319,8 @@ test "filter with no elements matching" {
 test "filter with collision" {
   let map = @hashmap.of([(1, 10), (2, 20)]).add(1, 30)
   let filtered = map.filter(fn(v) { v == 30 })
-  assert_eq!(filtered.lookup(1), Some(30))
-  assert_eq!(filtered.lookup(2), None)
+  assert_eq!(filtered.get(1), Some(30))
+  assert_eq!(filtered.get(2), None)
 }
 
 ///|
@@ -332,9 +332,9 @@ test "filter with branch nodes" {
   let filtered = map.filter(fn(v) { v % 20 == 0 })
   for i = 0; i < 10; i = i + 1 {
     if i * 10 % 20 == 0 {
-      assert_eq!(filtered.lookup(i), Some(i * 10))
+      assert_eq!(filtered.get(i), Some(i * 10))
     } else {
-      assert_eq!(filtered.lookup(i), None)
+      assert_eq!(filtered.get(i), None)
     }
   }
 }
@@ -359,9 +359,9 @@ test "HAMT::fold" {
 test "HAMT::map" {
   let map = @hashmap.of([(1, 10), (2, 20)])
   let mapped = map.map(fn(v) { v * 2 })
-  assert_eq!(mapped.lookup(1), Some(20))
-  assert_eq!(mapped.lookup(2), Some(40))
-  assert_eq!(mapped.lookup(3), None)
+  assert_eq!(mapped.get(1), Some(20))
+  assert_eq!(mapped.get(2), Some(40))
+  assert_eq!(mapped.get(3), None)
 }
 
 ///|
@@ -369,14 +369,14 @@ test "HAMT::map with overflow" {
   let max = 2147483647 // Int.max_value
   let map = @hashmap.of([(1, max)])
   let mapped = map.map(fn(v) { v + 1 })
-  assert_eq!(mapped.lookup(1), Some(-2147483648))
+  assert_eq!(mapped.get(1), Some(-2147483648))
 }
 
 ///|
 test "HAMT::map_with_key" {
   let map = @hashmap.of([(1, 10), (2, 20)])
   let mapped = map.map_with_key(fn(k, v) { "\{k}:\{v}" })
-  assert_eq!(mapped.lookup(1), Some("1:10"))
-  assert_eq!(mapped.lookup(2), Some("2:20"))
-  assert_eq!(mapped.lookup(3), None)
+  assert_eq!(mapped.get(1), Some("1:10"))
+  assert_eq!(mapped.get(2), Some("2:20"))
+  assert_eq!(mapped.get(3), None)
 }

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -26,13 +26,13 @@ fn from_array[K : Eq + Hash, V](Array[(K, V)]) -> T[K, V]
 
 fn from_iter[K : Eq + Hash, V](Iter[(K, V)]) -> T[K, V]
 
+fn get[K : Eq + Hash, V](T[K, V], K) -> V?
+
 fn iter[K, V](T[K, V]) -> Iter[(K, V)]
 
 fn iter2[K, V](T[K, V]) -> Iter2[K, V]
 
 fn keys[K, V](T[K, V]) -> Iter[K]
-
-fn lookup[K : Eq + Hash, V](T[K, V], K) -> V?
 
 fn map[K : Eq + Hash, V, A](T[K, V], (V) -> A) -> T[K, A]
 
@@ -66,10 +66,10 @@ impl T {
   find[K : Eq + Hash, V](Self[K, V], K) -> V?
   fold[K, V, A](Self[K, V], init~ : A, (A, V) -> A) -> A
   fold_with_key[K, V, A](Self[K, V], (A, K, V) -> A, init~ : A) -> A
+  get[K : Eq + Hash, V](Self[K, V], K) -> V?
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
   keys[K, V](Self[K, V]) -> Iter[K]
-  lookup[K : Eq + Hash, V](Self[K, V], K) -> V?
   map[K : Eq + Hash, V, A](Self[K, V], (V) -> A) -> Self[K, A]
   map_with_key[K : Eq + Hash, V, A](Self[K, V], (K, V) -> A) -> Self[K, A]
   op_get[K : Eq + Hash, V](Self[K, V], K) -> V?

--- a/immut/sorted_map/README.mbt.md
+++ b/immut/sorted_map/README.mbt.md
@@ -36,7 +36,7 @@ You can use `add()` to add a key-value pair to the map and create a new map. Or 
 test {
   let map : @sorted_map.T[String,Int] = @sorted_map.new()
   let map = map.add("a", 1)
-  assert_eq!(map.lookup("a"), Some(1))
+  assert_eq!(map.get("a"), Some(1))
 }
 ```
 
@@ -48,7 +48,7 @@ You can use `remove()` to remove a key-value pair from the map.
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
   let map = map.remove("a")
-  assert_eq!(map.lookup("a"), None)
+  assert_eq!(map.get("a"), None)
 }
 ```
 

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -21,9 +21,9 @@ test "lookup" {
     (2, "two"),
     (0, "zero"),
   ])
-  assert_eq!(m.lookup(8), Some("eight"))
-  assert_eq!(m.lookup(2), Some("two"))
-  assert_eq!(m.lookup(4), None)
+  assert_eq!(m.get(8), Some("eight"))
+  assert_eq!(m.get(2), Some("two"))
+  assert_eq!(m.get(4), None)
 }
 
 ///|

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -32,6 +32,8 @@ fn from_iter[K : Compare, V](Iter[(K, V)]) -> T[K, V]
 
 fn from_json[V : @json.FromJson](Json) -> T[String, V]!@json.JsonDecodeError
 
+fn get[K : Compare, V](T[K, V], K) -> V?
+
 #deprecated
 fn insert[K : Compare, V](T[K, V], K, V) -> T[K, V]
 
@@ -43,6 +45,7 @@ fn iter2[K, V](T[K, V]) -> Iter2[K, V]
 
 fn keys[K, V](T[K, V]) -> Array[K]
 
+#deprecated
 fn lookup[K : Compare, V](T[K, V], K) -> V?
 
 fn map[K, X, Y](T[K, X], (X) -> Y) -> T[K, Y]
@@ -86,12 +89,14 @@ impl T {
   from_iter[K : Compare, V](Iter[(K, V)]) -> Self[K, V]
   #deprecated
   from_json[V : @json.FromJson](Json) -> Self[String, V]!@json.JsonDecodeError
+  get[K : Compare, V](Self[K, V], K) -> V?
   #deprecated
   insert[K : Compare, V](Self[K, V], K, V) -> Self[K, V]
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
   keys[K, V](Self[K, V]) -> Array[K]
+  #deprecated
   lookup[K : Compare, V](Self[K, V], K) -> V?
   map[K, X, Y](Self[K, X], (X) -> Y) -> Self[K, Y]
   map_with_key[K, X, Y](Self[K, X], (K, X) -> Y) -> Self[K, Y]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -72,7 +72,16 @@ fn make_tree[K, V](key : K, value : V, l : T[K, V], r : T[K, V]) -> T[K, V] {
 ///|
 /// Get the value associated with a key.
 /// O(log n).
+#deprecated("Use `get` instead")
+#coverage.skip
 pub fn lookup[K : Compare, V](self : T[K, V], key : K) -> V? {
+  self.get(key)
+}
+
+///|
+/// Get the value associated with a key.
+/// O(log n).
+pub fn get[K : Compare, V](self : T[K, V], key : K) -> V? {
   loop self {
     Empty => None
     Tree(k, value~, l, r, ..) => {
@@ -90,7 +99,7 @@ pub fn lookup[K : Compare, V](self : T[K, V], key : K) -> V? {
 
 ///|
 pub fn op_get[K : Compare, V](self : T[K, V], key : K) -> V? {
-  self.lookup(key)
+  self.get(key)
 }
 
 ///|


### PR DESCRIPTION
We will unify the APIs to: 
- `get` : return `V?`
- `op_get` : return `V` directly

The `lookup` of `immut/hashmap` was just introduced so there's no need for deprecation phase.