### PR TITLE
uint16 overflow check

### DIFF
--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -66,7 +66,7 @@ test "Show for UInt16" {
   inspect!((65535 : UInt16).to_string(radix=8), content="177777")
   inspect!((65533 : UInt16), content="65533")
   // TODO:
-  // inspect!((65536 : UInt16), content="65536")
+  inspect!((65536 : UInt16), content="65536")
   // 65536 is overflow for uint16
 }
 


### PR DESCRIPTION
there are two things wrong:
- literal overflow check missed
- overflow behavior inconsistent between different backends, the native backend wrap to 0 seems to be reasonable