### PR TITLE
feat: `@bench.T::keep`

### DIFF
--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -87,6 +87,12 @@ pub fn keep[Any](self : T, value : Any) -> Unit {
 }
 
 ///|
+/// Suppress field never-read warning
+fn touch_storage(self : T) -> Unit {
+  self.storage |> ignore
+}
+
+///|
 /// Internal use only
 #coverage.skip
 pub fn dump_summaries(self : T) -> String {

--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -77,11 +77,13 @@ pub fn single_bench(
   iter_count(name?, f, count)
 }
 
+// NOTE: use a type parameter `Any` to avoid exposing `trait OpaqueValue` to users
 ///|
 /// Keep a value to prevent the optimizer from removing 
 /// the calculation that produces it.
-pub fn keep(self : T, value : &OpaqueValue) -> Unit {
-  self.storage = value
+pub fn keep[Any](self : T, value : Any) -> Unit {
+  let trait_object : &OpaqueValue = value
+  self.storage = trait_object
 }
 
 ///|

--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -78,6 +78,13 @@ pub fn single_bench(
 }
 
 ///|
+/// Keep a value to prevent the optimizer from removing 
+/// the calculation that produces it.
+pub fn keep(self : T, value : &OpaqueValue) -> Unit {
+  self.storage = value
+}
+
+///|
 /// Internal use only
 #coverage.skip
 pub fn dump_summaries(self : T) -> String {

--- a/bench/bench.mbti
+++ b/bench/bench.mbti
@@ -19,11 +19,7 @@ fn single_bench(name? : String, () -> Unit, count~ : UInt = ..) -> Summary
 type Summary
 impl ToJson for Summary
 
-pub(all) struct T {
-  buffer : StringBuilder
-  summaries : Array[Summary]
-  mut storage : &OpaqueValue
-}
+type T
 impl T {
   bench(Self, name? : String, () -> Unit, count~ : UInt = ..) -> Unit
   dump_summaries(Self) -> String

--- a/bench/bench.mbti
+++ b/bench/bench.mbti
@@ -5,6 +5,8 @@ fn bench(T, name? : String, () -> Unit, count~ : UInt = ..) -> Unit
 
 fn dump_summaries(T) -> String
 
+fn keep(T, &OpaqueValue) -> Unit
+
 fn monotonic_clock_end(Timestamp) -> Double
 
 fn monotonic_clock_start() -> Timestamp
@@ -20,10 +22,12 @@ impl ToJson for Summary
 pub(all) struct T {
   buffer : StringBuilder
   summaries : Array[Summary]
+  mut storage : &OpaqueValue
 }
 impl T {
   bench(Self, name? : String, () -> Unit, count~ : UInt = ..) -> Unit
   dump_summaries(Self) -> String
+  keep(Self, &OpaqueValue) -> Unit
 }
 
 type Timestamp
@@ -31,4 +35,6 @@ type Timestamp
 // Type aliases
 
 // Traits
+pub(open) trait OpaqueValue {
+}
 

--- a/bench/bench.mbti
+++ b/bench/bench.mbti
@@ -5,7 +5,7 @@ fn bench(T, name? : String, () -> Unit, count~ : UInt = ..) -> Unit
 
 fn dump_summaries(T) -> String
 
-fn keep(T, &OpaqueValue) -> Unit
+fn keep[Any](T, Any) -> Unit
 
 fn monotonic_clock_end(Timestamp) -> Double
 
@@ -27,7 +27,7 @@ pub(all) struct T {
 impl T {
   bench(Self, name? : String, () -> Unit, count~ : UInt = ..) -> Unit
   dump_summaries(Self) -> String
-  keep(Self, &OpaqueValue) -> Unit
+  keep[Any](Self, Any) -> Unit
 }
 
 type Timestamp
@@ -35,6 +35,4 @@ type Timestamp
 // Type aliases
 
 // Traits
-pub(open) trait OpaqueValue {
-}
 

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -13,15 +13,19 @@
 // limitations under the License.
 
 ///|
+pub(open) trait OpaqueValue {}
+
+///|
 #visibility(change_to="abstract")
 pub(all) struct T {
   buffer : StringBuilder
   summaries : Array[Summary]
+  mut storage : &OpaqueValue
 }
 
 ///|
 pub fn new() -> T {
   let buffer = StringBuilder::new()
   let summaries = Array::new()
-  { buffer, summaries }
+  { buffer, summaries, storage: () }
 }

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub(open) trait OpaqueValue {}
+priv trait OpaqueValue {}
 
 ///|
 #visibility(change_to="abstract")

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -16,8 +16,7 @@
 priv trait OpaqueValue {}
 
 ///|
-#visibility(change_to="abstract")
-pub(all) struct T {
+struct T {
   buffer : StringBuilder
   summaries : Array[Summary]
   mut storage : &OpaqueValue


### PR DESCRIPTION
Some optimizations may eliminate the calculation that doesn't have side effects. #1974 
A special function can be used to block such an optimization.

In other PLs or libraries,
- [`black_box`](https://doc.rust-lang.org/beta/std/hint/fn.black_box.html) in Rust,
- [`DoNotOptimize`](https://github.com/google/benchmark/blob/c19058b4e5ebab2f3cfe79c5267c28e1654e6c6a/test/donotoptimize_test.cc) in Google Benchmark
- [`runtime.Keep`](https://github.com/golang/go/issues/61179) it's a proposal for Go. Partially replaced by `runtime.KeepAlive` with a poor semantics.

Example:
from
```moonbit
test "batch_bench" (it : @bench.T) {
  it.bench(name="fast_fib", fn() { fast_fib(20) |> ignore })
  it.bench(name="native_fib", fn() { naive_fib(20) |> ignore })
}
```
to
```moonbit
test "batch_bench" (it : @bench.T) {
  it.bench(name="fast_fib", fn() { it.keep(fast_fib(20)) })
  it.bench(name="native_fib", fn() { it.keep(naive_fib(20)) })
}
```