### PR TITLE
feat(stringview): add contains method

### DIFF
--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -207,6 +207,33 @@ test "has_prefix" {
 }
 
 ///|
+/// Returns true if this string contains the given substring.
+pub fn View::contains(self : View, str : View) -> Bool {
+  self.find(str) is Some(_)
+}
+
+///|
+/// Returns true if this string contains the given substring.
+pub fn contains(self : String, str : View) -> Bool {
+  self[:].contains(str)
+}
+
+///|
+test "contains" {
+  inspect!("hello".contains("o"), content="true")
+  inspect!("hello".contains("l"), content="true")
+  inspect!("hello".contains("hello"), content="true")
+  inspect!("hello".contains("h"), content="true")
+  inspect!("hello".contains(""), content="true")
+  inspect!("hello".contains("world"), content="false")
+  inspect!("".contains(""), content="true")
+  inspect!("".contains("a"), content="false")
+  inspect!("hello hello".contains("hello"), content="true")
+  inspect!("aaa".contains("aa"), content="true")
+  inspect!("😀😀".contains("😀"), content="true")
+}
+
+///|
 /// Returns true if this string contains the given character.
 pub fn View::contains_char(self : View, c : Char) -> Bool {
   self.iter().any(fn(ch) { ch == c })

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -292,12 +292,6 @@ pub fn last_index_of(
 }
 
 ///|
-/// Returns true if this string contains given sub string.
-pub fn contains(self : String, str : String) -> Bool {
-  self.find(str.view()) is Some(_)
-}
-
-///|
 /// Returns true if this string starts with a sub string.
 #deprecated("Use `s.has_prefix(str)` instead.")
 pub fn starts_with(self : String, str : String) -> Bool {

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -3,7 +3,7 @@ package "moonbitlang/core/string"
 // Values
 fn concat(Array[String], separator~ : String = ..) -> String
 
-fn contains(String, String) -> Bool
+fn contains(String, StringView) -> Bool
 
 fn contains_char(String, Char) -> Bool
 
@@ -98,6 +98,7 @@ impl StringView {
   char_length_eq(Self, Int) -> Bool
   char_length_ge(Self, Int) -> Bool
   charcode_at(Self, Int) -> Int
+  contains(Self, Self) -> Bool
   contains_char(Self, Char) -> Bool
   find(Self, Self) -> Int?
   find_by(Self, (Char) -> Bool) -> Int?
@@ -154,7 +155,7 @@ impl String {
   char_length_ge(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
   #deprecated
   concat(Array[String], separator~ : String = ..) -> String
-  contains(String, String) -> Bool
+  contains(String, StringView) -> Bool
   contains_char(String, Char) -> Bool
   #deprecated
   ends_with(String, String) -> Bool


### PR DESCRIPTION
I missed the `contains` function when migrate String's APIs to use the `View` type for parameters. This PR changes the parameter's type of `contains` to `View` and add this method for `View`.