### PR TITLE
fix(strconv): allow "0b" to be parsed as digits when base is 16

### DIFF
--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -41,10 +41,15 @@ fn check_and_consume_base(
       guard base is (0 | 8) else { base_err!() }
       (8, rest, true)
     }
-    ['0', 'b' | 'B', .. rest] => {
-      guard base is (0 | 2) else { base_err!() }
-      (2, rest, true)
-    }
+    ['0', 'b' | 'B', .. rest] =>
+      if base is (0 | 2) {
+        (2, rest, true)
+      } else if base is 16 {
+        // 'b' is a legitimate hex digit
+        (16, view, false)
+      } else {
+        base_err!()
+      }
     rest =>
       match base {
         0 => (10, rest, false)

--- a/strconv/int_test.mbt
+++ b/strconv/int_test.mbt
@@ -133,3 +133,22 @@ test "edge cases" {
   // Underscore is allowed between the prefix and the first digit
   inspect!(@strconv.parse_int64?("0x_DEADBEEF"), content="Ok(3735928559)")
 }
+
+///|
+test "more edge cases" {
+  inspect!(@strconv.parse_int64?("0b01", base=16), content="Ok(2817)")
+  inspect!(@strconv.parse_int64?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int64?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_int?("0b01", base=16), content="Ok(2817)")
+  inspect!(@strconv.parse_int?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_uint?("0b01", base=16), content="Ok(2817)")
+  inspect!(@strconv.parse_uint?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_uint64?("0b01", base=16), content="Ok(2817)")
+  inspect!(@strconv.parse_uint64?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint64?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_int?("0b01", base=10), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0o01", base=10), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0x01", base=10), content="Err(invalid base)")
+}


### PR DESCRIPTION
fix #2006 