### PR TITLE
feat(iter): add mapi

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -243,6 +243,7 @@ impl Iter {
   #deprecated
   map_option[A, B](Self[A], (A) -> B?) -> Self[B]
   map_while[A, B](Self[A], (A) -> B?) -> Self[B]
+  mapi[T, R](Self[T], (Int, T) -> R) -> Self[R]
   maximum[T : Compare](Self[T]) -> T?
   minimum[T : Compare](Self[T]) -> T?
   new[T](((T) -> IterResult) -> IterResult) -> Self[T]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -416,6 +416,36 @@ pub fn Iter::map[T, R](self : Iter[T], f : (T) -> R) -> Iter[R] {
 }
 
 ///|
+/// Transforms the elements of the iterator using a mapping function.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the elements in the iterator.
+/// - `R`: The type of the transformed elements.
+///
+/// # Arguments
+///
+/// * `self` - The input iterator.
+/// * `f` - The mapping function that transforms each element of the iterator with index.
+///
+/// # Returns
+///
+/// A new iterator that contains the transformed elements.
+pub fn Iter::mapi[T, R](self : Iter[T], f : (Int, T) -> R) -> Iter[R] {
+  fn {
+    yield_ => {
+      let mut i = -1
+      self.run(fn {
+        a => {
+          i = i + 1
+          yield_(f(i, a))
+        }
+      })
+    }
+  }
+}
+
+///|
 /// Transforms the elements of the iterator using a mapping function that returns an `Option`.
 /// The elements for which the function returns `None` are filtered out.
 pub fn Iter::filter_map[A, B](self : Iter[A], f : (A) -> B?) -> Iter[B] {

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -237,6 +237,16 @@ test "map" {
 }
 
 ///|
+test "mapi" {
+  let iter = test_from_array(['1', '2', '3', '4', '5'])
+  let exb = StringBuilder::new(size_hint=0)
+  iter
+  .mapi(fn { i, x => (i + x.to_int()).to_char().unwrap() })
+  .each(fn { x => exb.write_char(x) })
+  inspect!(exb, content="13579")
+}
+
+///|
 test "filter_map" {
   let arr = [1, 2, 3, 4, 5]
   let r1 = arr


### PR DESCRIPTION
Related #1866

Note that we may want a labelled argument `offset` or something similar in the future to avoid computing the addition every time.