### PR TITLE
feat(iter): add iter2

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -188,6 +188,7 @@ fn[T, K : Eq + Hash] Iter::group_by(Self[T], (T) -> K) -> Map[K, Array[T]]
 fn[A] Iter::head(Self[A]) -> A?
 fn[A] Iter::intersperse(Self[A], A) -> Self[A]
 fn[T] Iter::iter(Self[T]) -> Self[T]
+fn[T] Iter::iter2(Self[T]) -> Iter2[Int, T]
 fn Iter::join(Self[String], String) -> String
 fn[T] Iter::just_run(Self[T], (T) -> IterResult) -> Unit
 fn[A] Iter::last(Self[A]) -> A?

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -1039,3 +1039,17 @@ pub fn[T, K : Eq + Hash] Iter::group_by(
   }
   result
 }
+
+///|
+/// Returns an iterator that iterates over the index and the element of the iterator.
+pub fn[T] Iter::iter2(self : Iter[T]) -> Iter2[Int, T] {
+  fn {
+    yield_ => {
+      let mut index = -1
+      self.run(fn(i) {
+        index += 1
+        yield_(index, i)
+      })
+    }
+  }
+}

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -793,3 +793,15 @@ test "group_by with complex objects" {
   let groups = grouped.values().map(fn(a) { a.map(fn(p) { p.name }) }).collect()
   assert_eq(groups, [["Alice", "Bob"], ["Charlie", "Eve"], ["Dave"]])
 }
+
+///|
+test "iter2" {
+  let iter : Iter[Int] = [].iter()
+  for _, _ in iter.iter2() {
+    assert_true(false)
+  }
+  let iter = [0, 1, 2].iter()
+  for i, x in iter.iter2() {
+    assert_eq(i, x)
+  }
+}


### PR DESCRIPTION
Closes #1319 

The naming is chosen as such because:

- we have `mapi` `eachi` where the `i` signifies the fact that an index is added as parameter
- we can't write `for i, v in [].iter()` anyway, so there's no ambiguity.

Update: we will use `iter2` to return `Iter2[Int, T]` to align with existing behaviors. As of `Iter[(K, V)]`, users can just use a pattern matching `let (k, v) = elem`.