### PR TITLE
fix(strconv): adjust the logic for validating base

### DIFF
--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -32,33 +32,30 @@ fn check_and_consume_base(
   view : @string.StringView,
   base : Int
 ) -> (Int, @string.StringView, Bool)!StrConvError {
-  match view {
-    ['0', 'x' | 'X', .. rest] => {
-      guard base is (0 | 16) else { base_err!() }
-      (16, rest, true)
+  // if the base is not given, we need to determine it from the prefix
+  if base == 0 {
+    match view {
+      ['0', 'x' | 'X', .. rest] => (16, rest, true)
+      ['0', 'o' | 'O', .. rest] => (8, rest, true)
+      ['0', 'b' | 'B', .. rest] => (2, rest, true)
+      _ => (10, view, false)
     }
-    ['0', 'o' | 'O', .. rest] => {
-      guard base is (0 | 8) else { base_err!() }
-      (8, rest, true)
+  } else {
+    // if the base is given, we need to check whether the prefix is consistent with it
+    match view {
+      ['0', 'x' | 'X', .. rest] if base == 16 => (16, rest, true)
+      ['0', 'o' | 'O', .. rest] if base == 8 => (8, rest, true)
+      ['0', 'b' | 'B', .. rest] if base == 2 => (2, rest, true)
+      _ => if base is (2..=36) { (base, view, false) } else { base_err!() }
     }
-    ['0', 'b' | 'B', .. rest] => {
-      guard base is (0 | 2) else { base_err!() }
-      (2, rest, true)
-    }
-    rest =>
-      match base {
-        0 => (10, rest, false)
-        2..=36 => (base, rest, false)
-        _ => base_err!()
-      }
   }
 }
 
 ///|
 test {
-  inspect!(parse_int64?("0b01", base=3), content="Err(invalid base)")
-  inspect!(parse_int64?("0x01", base=3), content="Err(invalid base)")
-  inspect!(parse_int64?("0o01", base=3), content="Err(invalid base)")
+  inspect!(parse_int64?("0b01", base=3), content="Err(invalid syntax)")
+  inspect!(parse_int64?("0x01", base=3), content="Err(invalid syntax)")
+  inspect!(parse_int64?("0o01", base=3), content="Err(invalid syntax)")
 }
 
 ///|

--- a/strconv/int_test.mbt
+++ b/strconv/int_test.mbt
@@ -136,19 +136,25 @@ test "edge cases" {
 
 ///|
 test "more edge cases" {
-  inspect!(@strconv.parse_int64?("0b01", base=16), content="Err(invalid base)")
-  inspect!(@strconv.parse_int64?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int64?("0b01", base=16), content="Ok(2817)")
+  inspect!(
+    @strconv.parse_int64?("0o01", base=16),
+    content="Err(invalid syntax)",
+  )
   inspect!(@strconv.parse_int64?("0x01", base=16), content="Ok(1)")
-  inspect!(@strconv.parse_int?("0b01", base=16), content="Err(invalid base)")
-  inspect!(@strconv.parse_int?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0b01", base=16), content="Ok(2817)")
+  inspect!(@strconv.parse_int?("0o01", base=16), content="Err(invalid syntax)")
   inspect!(@strconv.parse_int?("0x01", base=16), content="Ok(1)")
-  inspect!(@strconv.parse_uint?("0b01", base=16), content="Err(invalid base)")
-  inspect!(@strconv.parse_uint?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint?("0b01", base=16), content="Ok(2817)")
+  inspect!(@strconv.parse_uint?("0o01", base=16), content="Err(invalid syntax)")
   inspect!(@strconv.parse_uint?("0x01", base=16), content="Ok(1)")
-  inspect!(@strconv.parse_uint64?("0b01", base=16), content="Err(invalid base)")
-  inspect!(@strconv.parse_uint64?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint64?("0b01", base=16), content="Ok(2817)")
+  inspect!(
+    @strconv.parse_uint64?("0o01", base=16),
+    content="Err(invalid syntax)",
+  )
   inspect!(@strconv.parse_uint64?("0x01", base=16), content="Ok(1)")
-  inspect!(@strconv.parse_int?("0b01", base=10), content="Err(invalid base)")
-  inspect!(@strconv.parse_int?("0o01", base=10), content="Err(invalid base)")
-  inspect!(@strconv.parse_int?("0x01", base=10), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0b01", base=10), content="Err(invalid syntax)")
+  inspect!(@strconv.parse_int?("0o01", base=10), content="Err(invalid syntax)")
+  inspect!(@strconv.parse_int?("0x01", base=10), content="Err(invalid syntax)")
 }

--- a/strconv/int_test.mbt
+++ b/strconv/int_test.mbt
@@ -133,3 +133,22 @@ test "edge cases" {
   // Underscore is allowed between the prefix and the first digit
   inspect!(@strconv.parse_int64?("0x_DEADBEEF"), content="Ok(3735928559)")
 }
+
+///|
+test "more edge cases" {
+  inspect!(@strconv.parse_int64?("0b01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int64?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int64?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_int?("0b01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_uint?("0b01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_uint64?("0b01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint64?("0o01", base=16), content="Err(invalid base)")
+  inspect!(@strconv.parse_uint64?("0x01", base=16), content="Ok(1)")
+  inspect!(@strconv.parse_int?("0b01", base=10), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0o01", base=10), content="Err(invalid base)")
+  inspect!(@strconv.parse_int?("0x01", base=10), content="Err(invalid base)")
+}


### PR DESCRIPTION
Fixes #2006 

This PR simplifies the logic:
- if base is not defined, detect the base with prefix
- otherwise, remove prefix for 2/8/16-based if there were one

Thus this breaks some exisiting behaviour. For example:

`0x01` with `base=3` was considered `bad base` because `0x` does not match `3`. Now it is considered `bad syntax` because `x` exceeds the character set allowed for base `3`.