### PR TITLE
refactor(map): deprecate op-get for future migration

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -320,6 +320,7 @@ impl Map {
   keys[K, V](Self[K, V]) -> Iter[K]
   new[K, V](capacity~ : Int = ..) -> Self[K, V]
   of[K : Hash + Eq, V](FixedArray[(K, V)]) -> Self[K, V]
+  #deprecated
   op_get[K : Hash + Eq, V](Self[K, V], K) -> V?
   op_set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   remove[K : Hash + Eq, V](Self[K, V], K) -> Unit

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -196,6 +196,7 @@ pub fn Map::get[K : Hash + Eq, V](self : Map[K, V], key : K) -> V? {
 }
 
 ///|
+#deprecated("Use `get` instead. `op_get` will return `V` instead of `Option[V]` in the future.")
 pub fn Map::op_get[K : Hash + Eq, V](self : Map[K, V], key : K) -> V? {
   self.get(key)
 }

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -256,6 +256,7 @@ fn get_with_hash[K : Hash + Eq, V](self : T[K, V], key : K, hash : Int) -> V? {
 ///   inspect!(map["nonexistent"], content="None")
 /// }
 /// ```
+#deprecated("Use `get` instead. `op_get` will return `V` instead of `Option[V]` in the future.")
 pub fn op_get[K : Hash + Eq, V](self : T[K, V], key : K) -> V? {
   self.get(key)
 }

--- a/hashmap/hashmap.mbti
+++ b/hashmap/hashmap.mbti
@@ -37,6 +37,7 @@ fn new[K, V](capacity~ : Int = ..) -> T[K, V]
 
 fn of[K : Eq + Hash, V](FixedArray[(K, V)]) -> T[K, V]
 
+#deprecated
 fn op_get[K : Hash + Eq, V](T[K, V], K) -> V?
 
 fn op_set[K : Hash + Eq, V](T[K, V], K, V) -> Unit
@@ -64,6 +65,7 @@ impl T {
   is_empty[K, V](Self[K, V]) -> Bool
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
+  #deprecated
   op_get[K : Hash + Eq, V](Self[K, V], K) -> V?
   op_set[K : Hash + Eq, V](Self[K, V], K, V) -> Unit
   remove[K : Hash + Eq, V](Self[K, V], K) -> Unit

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -84,6 +84,7 @@ pub fn get[K : Eq + Hash, V](self : T[K, V], key : K) -> V? {
 }
 
 ///|
+#deprecated("Use `get` instead. `op_get` will return `V` instead of `Option[V]` in the future.")
 pub fn op_get[K : Eq + Hash, V](self : T[K, V], key : K) -> V? {
   self.get(key)
 }

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -42,6 +42,7 @@ fn new[K, V]() -> T[K, V]
 
 fn of[K : Eq + Hash, V](FixedArray[(K, V)]) -> T[K, V]
 
+#deprecated
 fn op_get[K : Eq + Hash, V](T[K, V], K) -> V?
 
 fn remove[K : Eq + Hash, V](T[K, V], K) -> T[K, V]
@@ -72,6 +73,7 @@ impl T {
   keys[K, V](Self[K, V]) -> Iter[K]
   map[K : Eq + Hash, V, A](Self[K, V], (V) -> A) -> Self[K, A]
   map_with_key[K : Eq + Hash, V, A](Self[K, V], (K, V) -> A) -> Self[K, A]
+  #deprecated
   op_get[K : Eq + Hash, V](Self[K, V], K) -> V?
   remove[K : Eq + Hash, V](Self[K, V], K) -> Self[K, V]
   size[K, V](Self[K, V]) -> Int

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -56,6 +56,7 @@ fn new[K, V]() -> T[K, V]
 
 fn of[K : Compare, V](FixedArray[(K, V)]) -> T[K, V]
 
+#deprecated
 fn op_get[K : Compare, V](T[K, V], K) -> V?
 
 fn remove[K : Compare, V](T[K, V], K) -> T[K, V]
@@ -104,6 +105,7 @@ impl T {
   new[K, V]() -> Self[K, V]
   #deprecated
   of[K : Compare, V](FixedArray[(K, V)]) -> Self[K, V]
+  #deprecated
   op_get[K : Compare, V](Self[K, V], K) -> V?
   remove[K : Compare, V](Self[K, V], K) -> Self[K, V]
   #deprecated

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -98,6 +98,7 @@ pub fn get[K : Compare, V](self : T[K, V], key : K) -> V? {
 }
 
 ///|
+#deprecated("Use `get` instead. `op_get` will return `V` instead of `Option[V]` in the future.")
 pub fn op_get[K : Compare, V](self : T[K, V], key : K) -> V? {
   self.get(key)
 }

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -70,7 +70,7 @@ pub fn as_object(self : JsonValue) -> Map[String, JsonValue]? {
 /// Try to get this element as a Json Object and get the element with the `key` as a Json Value
 pub fn value(self : JsonValue, key : String) -> JsonValue? {
   match self.as_object() {
-    Some(obj) => obj[key]
+    Some(obj) => obj.get(key)
     None => None
   }
 }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -18,6 +18,7 @@ pub fn op_set[K : Compare, V](self : T[K, V], key : K, value : V) -> Unit {
 }
 
 ///|
+#deprecated("Use `get` instead. `op_get` will return `V` instead of `Option[V]` in the future.")
 pub fn op_get[K : Compare, V](self : T[K, V], key : K) -> V? {
   self.get(key)
 }

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -34,6 +34,7 @@ fn new[K, V]() -> T[K, V]
 #deprecated
 fn of[K : Compare, V](Array[(K, V)]) -> T[K, V]
 
+#deprecated
 fn op_get[K : Compare, V](T[K, V], K) -> V?
 
 fn op_set[K : Compare, V](T[K, V], K, V) -> Unit
@@ -61,6 +62,7 @@ impl T {
   iter[K, V](Self[K, V]) -> Iter[(K, V)]
   iter2[K, V](Self[K, V]) -> Iter2[K, V]
   keys[K, V](Self[K, V]) -> Array[K]
+  #deprecated
   op_get[K : Compare, V](Self[K, V], K) -> V?
   op_set[K : Compare, V](Self[K, V], K, V) -> Unit
   range[K : Compare, V](Self[K, V], K, K) -> Iter2[K, V]


### PR DESCRIPTION
In the future, we will have `op_get` return `V` instead of `V?` and `get` return `V?`.

For other functions, if there are a 'unsafe' implementation and a 'safe', the unsafe one will be named as `unsafe_xxx`. Otherwise it will just named as it is.

cc @Yoorkin the `json.mbt` emitted two same warnings