### PR TITLE
chore(tuple): deprecate `map_xxx` for tuple

### DIFF
--- a/tuple/README.mbt.md
+++ b/tuple/README.mbt.md
@@ -31,26 +31,14 @@ test {
 
 ## Transformation
 
-You can transform the tuple using the `map_fst` and `map_snd` method, which will apply the function to the first and second element of the tuple respectively.
+You can transform the tuple using the matrix functions combined with `then`.
 
 ```moonbit  
 test {
     let tuple = (1, 2)
-    let _tuple2 = @tuple.map_fst(fn(x) { x + 1 }, tuple) // tuple2 = (2, 2)
-    let _tuple3 = @tuple.map_snd(fn(x) { x + 1 }, tuple) // tuple3 = (1, 3)
-}
-```
-
-Or you can use the `map_both` method to apply the function to both elements of the tuple.
-
-```moonbit
-test {
-    let tuple = (1, 2)
-    let _mapped = @tuple.map_both(
-        fn(x : Int) -> Int { x + 1 },
-        fn(x : Int) -> Int { x - 1 },
-        tuple
-    ) // mapped = (2, 1)
+    let _tuple2 = (fn { (x, y) => (x + 1, y) })(tuple) // tuple2 = (2, 2)
+    let _tuple3 = tuple |> then(fn { (x, y) => (x, y + 1) }) // tuple3 = (1, 3)
+    let _mapped = tuple |> then(fn(pair) { (pair.0 + 1, pair.1 - 1) }) // _mapped = 2, 1
 }
 ```
 

--- a/tuple/tuple.mbt
+++ b/tuple/tuple.mbt
@@ -59,6 +59,7 @@ pub fn snd[T, U](tuple : (T, U)) -> U {
 /// let mapped = @tuple.map_fst(fn(x : Int) -> Int { x + 1 }, tuple)
 /// assert_eq!(mapped, (2, 2))
 /// ```
+#deprecated("use `tuple |> then(fn { (a, b) => (f(a), b) })` instead")
 pub fn map_fst[T, U, V](f : (T) -> U, tuple : (T, V)) -> (U, V) {
   (f(tuple.0), tuple.1)
 }
@@ -72,6 +73,7 @@ pub fn map_fst[T, U, V](f : (T) -> U, tuple : (T, V)) -> (U, V) {
 /// let mapped = @tuple.map_snd(fn(x : Int) -> Int { x + 1 }, tuple)
 /// assert_eq!(mapped, (1, 3))
 /// ```
+#deprecated("use `tuple |> then(fn { (a, b) => (a, f(b)) })` instead")
 pub fn map_snd[T, U, V](f : (T) -> U, tuple : (V, T)) -> (V, U) {
   (tuple.0, f(tuple.1))
 }
@@ -85,6 +87,7 @@ pub fn map_snd[T, U, V](f : (T) -> U, tuple : (V, T)) -> (V, U) {
 /// let mapped = @tuple.map_both(fn(x : Int) -> Int { x + 1 }, fn(x : Int) -> Int { x - 1 }, tuple)
 /// assert_eq!(mapped, (2, 1))
 /// ```
+#deprecated("use `tuple |> then(fn { (a, b) => (f(a), g(b)) })` instead")
 pub fn map_both[T, U, V, W](
   f : (T) -> U,
   g : (V) -> W,

--- a/tuple/tuple.mbti
+++ b/tuple/tuple.mbti
@@ -9,10 +9,13 @@ fn curry[T, U, V]((T, U) -> V) -> (T) -> (U) -> V
 
 fn fst[T, U]((T, U)) -> T
 
+#deprecated
 fn map_both[T, U, V, W]((T) -> U, (V) -> W, (T, V)) -> (U, W)
 
+#deprecated
 fn map_fst[T, U, V]((T) -> U, (T, V)) -> (U, V)
 
+#deprecated
 fn map_snd[T, U, V]((T) -> U, (V, T)) -> (V, U)
 
 fn pair[T, U](T, U) -> (T, U)


### PR DESCRIPTION
Closes #1787

The reason for deprecation is:

1. it can be replaced with matrix functions
2. the order of parameters is not nature

We may or may not add back the version where the parameters are swapped.