### PR TITLE
refactor: use internal attribute for safety messages

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -142,7 +142,7 @@ pub fn Array::unsafe_get[T](self : Array[T], idx : Int) -> T {
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds"
+#internal(unsafe, "Panic if index is out of bounds")
 #intrinsic("%array.get")
 pub fn Array::op_get[T](self : Array[T], index : Int) -> T {
   let len = self.length()
@@ -211,7 +211,7 @@ fn Array::unsafe_set[T](self : Array[T], idx : Int, val : T) -> Unit {
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 #intrinsic("%array.set")
 pub fn Array::op_set[T](self : Array[T], index : Int, value : T) -> Unit {
   let len = self.length()
@@ -710,7 +710,7 @@ pub fn Array::rev[T](self : Array[T]) -> Array[T] {
 /// assert_eq!(v2, [4, 5])
 /// ```
 /// TODO: perf could be optimized
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::split_at[T](self : Array[T], index : Int) -> (Array[T], Array[T]) {
   if index < 0 || index > self.length() {
     let len = self.length()
@@ -1144,7 +1144,7 @@ pub fn Array::binary_search_by[T](
 ///   ignore(arr.swap(0, 3)) // Index out of bounds
 /// }
 /// ```
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::swap[T](self : Array[T], i : Int, j : Int) -> Unit {
   if i >= self.length() || j >= self.length() || i < 0 || j < 0 {
     let len = self.length()
@@ -1237,7 +1237,7 @@ pub fn Array::retain[T](self : Array[T], f : (T) -> Bool) -> Unit {
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if new length is negative."
+#internal(unsafe, "Panic if new length is negative.")
 pub fn Array::resize[T](self : Array[T], new_len : Int, f : T) -> Unit {
   if new_len < 0 {
     abort("negative new length")

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -45,7 +45,7 @@
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if the indices or length are out of bounds"
+#internal(unsafe, "Panic if the indices or length are out of bounds")
 pub fn Array::unsafe_blit[A](
   dst : Array[A],
   dst_offset : Int,

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -213,7 +213,7 @@ pub fn Array::pop_exn[T](self : Array[T]) -> T {
 /// **NOTE** This method will not cause a panic, but it may result in undefined
 /// behavior on the JavaScript platform. Use with caution.
 ///
-/// @alert unsafe "Panic if the array is empty."
+#internal(unsafe, "Panic if the array is empty.")
 pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
   JSArray::ofAnyArray(self).pop().toAny()
 }
@@ -230,7 +230,7 @@ pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
 /// assert_eq!(vv, 4)
 /// assert_eq!(v, [3, 5])
 /// ```
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::remove[T](self : Array[T], index : Int) -> T {
   guard index >= 0 && index < self.length() else {
     abort(
@@ -252,7 +252,7 @@ pub fn Array::remove[T](self : Array[T], index : Int) -> T {
 /// let v = [3, 4, 5]
 /// let vv = v.drain(1, 2) // vv = [4], v = [3, 5]
 /// ```
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
   guard begin >= 0 && end <= self.length() && begin <= end else {
     abort(
@@ -269,7 +269,7 @@ pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
 /// ```
 /// [3, 4, 5].insert(1, 6)
 /// ```
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
   guard index >= 0 && index <= self.length() else {
     abort(
@@ -287,7 +287,7 @@ pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
 /// difference, and the values in the new slots are left uninitilized.
 ///  If `new_len` is less than `len`, it will panic
 ///
-/// @alert unsafe "Panic if new length is negative."
+#internal(unsafe, "Panic if new length is negative.")
 fn Array::unsafe_grow_to_length[T](self : Array[T], new_len : Int) -> Unit {
   guard new_len >= self.length()
   JSArray::ofAnyArray(self).set_length(new_len)

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -311,7 +311,7 @@ pub fn Array::pop_exn[T](self : Array[T]) -> T {
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if the array is empty."
+#internal(unsafe, "Panic if the array is empty.")
 pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
   let len = self.length()
   guard len != 0
@@ -333,7 +333,7 @@ pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
 /// assert_eq!(v.remove(1), 4)
 /// assert_eq!(v, [3, 5])
 /// ```
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::remove[T](self : Array[T], index : Int) -> T {
   guard index >= 0 && index < self.length() else {
     abort(
@@ -364,7 +364,7 @@ pub fn Array::remove[T](self : Array[T], index : Int) -> T {
 /// assert_eq!(vv, [4])
 /// assert_eq!(v, [3, 5])
 /// ```
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
   guard begin >= 0 && end <= self.length() && begin <= end
   let num = end - begin
@@ -388,7 +388,7 @@ pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
 /// ```
 /// [3, 4, 5].insert(1, 6)
 /// ```
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
   guard index >= 0 && index <= self.length() else {
     abort(
@@ -417,7 +417,7 @@ pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
 /// difference, and the values in the new slots are left uninitialized.
 ///  If `new_len` is less than `len`, it will panic
 ///
-/// @alert unsafe "Panic if new length is negative."
+#internal(unsafe, "Panic if new length is negative.")
 fn Array::unsafe_grow_to_length[T](self : Array[T], new_len : Int) -> Unit {
   guard new_len >= self.length()
   let new_buf = UninitializedArray::make(new_len)

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -23,7 +23,7 @@
 /// assert_eq!(view[0], 2)
 /// assert_eq!(view.length(), 3)
 /// ```
-/// @alert deprecated "use @array.View instead"
+#internal(deprecated, "use @array.View instead")
 struct ArrayView[T] {
   buf : UninitializedArray[T]
   start : Int
@@ -120,7 +120,7 @@ pub fn ArrayView::op_get[T](self : ArrayView[T], index : Int) -> T {
 /// ```
 ///
 #intrinsic("%arrayview.unsafe_get")
-/// @alert unsafe "Panic if index is out of bounds"
+#internal(unsafe, "Panic if index is out of bounds")
 pub fn ArrayView::unsafe_get[T](self : ArrayView[T], index : Int) -> T {
   self.buf[self.start + index]
 }
@@ -154,7 +154,7 @@ pub fn ArrayView::unsafe_get[T](self : ArrayView[T], index : Int) -> T {
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn ArrayView::op_set[T](
   self : ArrayView[T],
   index : Int,
@@ -196,7 +196,7 @@ pub fn ArrayView::op_set[T](
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds"
+#internal(unsafe, "Panic if index is out of bounds")
 pub fn ArrayView::swap[T](self : ArrayView[T], i : Int, j : Int) -> Unit {
   guard i >= 0 && i < self.len && j >= 0 && j < self.len else {
     abort(

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -133,7 +133,7 @@ impl[T : Hash] Hash for Array[T]
 impl[X : Show] Show for Array[X]
 impl[X : ToJson] ToJson for Array[X]
 
-type ArrayView[T] //deprecated
+type ArrayView[T]
 impl ArrayView {
   length[T](Self[T]) -> Int
   op_as_view[T](Self[T], start~ : Int = .., end? : Int) -> Self[T]

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -274,7 +274,7 @@ pub fn FixedArray::set_utf8_char(
 ///|
 /// Fill UTF16LE encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
-/// @alert unsafe "Panic if the [value] is out of range"
+#internal(unsafe, "Panic if the [value] is out of range")
 pub fn FixedArray::set_utf16le_char(
   self : FixedArray[Byte],
   offset : Int,
@@ -302,7 +302,7 @@ pub fn FixedArray::set_utf16le_char(
 ///|
 /// Fill UTF16BE encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
-/// @alert unsafe "Panic if the [value] is out of range"
+#internal(unsafe, "Panic if the [value] is out of range")
 pub fn FixedArray::set_utf16be_char(
   self : FixedArray[Byte],
   offset : Int,

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1363,7 +1363,7 @@ pub fn Bytes::op_get(self : Bytes, idx : Int) -> Byte = "%bytes_get"
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds"
+#internal(unsafe, "Panic if index is out of bounds")
 pub fn Bytes::unsafe_get(self : Bytes, idx : Int) -> Byte = "%bytes_get"
 
 ///|
@@ -1565,7 +1565,7 @@ pub fn FixedArray::op_get[T](self : FixedArray[T], idx : Int) -> T = "%fixedarra
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds"
+#internal(unsafe, "Panic if index is out of bounds")
 pub fn FixedArray::unsafe_get[T](self : FixedArray[T], idx : Int) -> T = "%fixedarray.unsafe_get"
 
 ///|
@@ -1625,7 +1625,7 @@ pub fn FixedArray::get[T](self : FixedArray[T], idx : Int) -> T = "%fixedarray.g
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 #intrinsic("%fixedarray.set")
 pub fn FixedArray::op_set[T](self : FixedArray[T], idx : Int, val : T) -> Unit = "%fixedarray.set"
 
@@ -1763,7 +1763,7 @@ pub fn String::charcode_length(self : String) -> Int = "%string_length"
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds"
+#internal(unsafe, "Panic if index is out of bounds")
 pub fn String::op_get(self : String, idx : Int) -> Char = "%string_get"
 
 ///|
@@ -1820,7 +1820,7 @@ pub fn String::get(self : String, idx : Int) -> Char = "%string_get"
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds."
+#internal(unsafe, "Panic if index is out of bounds.")
 pub fn String::unsafe_charcode_at(self : String, idx : Int) -> Int = "%string.unsafe_get"
 
 ///|

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -104,7 +104,7 @@ pub fn Map::from_array[K : Hash + Eq, V](arr : Array[(K, V)]) -> Map[K, V] {
 
 ///|
 /// Set a key-value pair into the hash map.
-/// @alert unsafe "Panic if the hash map is full."
+#internal(unsafe, "Panic if the hash map is full.")
 pub fn Map::set[K : Hash + Eq, V](self : Map[K, V], key : K, value : V) -> Unit {
   if self.size >= self.growAt {
     self.grow()

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -31,7 +31,7 @@ pub fn Option::to_string[X : Show](self : X?) -> String {
 
 ///|
 /// Extract the value in `Some`.
-/// @alert unsafe "Panic if input is `None`."
+#internal(unsafe, "Panic if input is `None`.")
 pub fn Option::unwrap[X](self : X?) -> X {
   match self {
     None => panic()

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -203,12 +203,15 @@ pub impl[X : Show] Show for Array[X] with output(self, logger) {
   logger.write_iter(self.iter())
 }
 
-///|
-/// Convert Char to String
-// TODO: support attributes for impl
-// #intrinsic("%char.to_string")
+///| Convert Char to String
 pub impl Show for Char with to_string(self : Char) -> String {
-  [self]
+  char_to_string(self)
+}
+
+///| TODO: support attributes for impl
+#intrinsic("%char.to_string")
+fn char_to_string(char : Char) -> String {
+  [char]
 }
 
 ///|

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -205,7 +205,8 @@ pub impl[X : Show] Show for Array[X] with output(self, logger) {
 
 ///|
 /// Convert Char to String
-/// @intrinsic %char.to_string
+// TODO: support attributes for impl
+// #intrinsic("%char.to_string")
 pub impl Show for Char with to_string(self : Char) -> String {
   [self]
 }

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -75,7 +75,7 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 ///
 /// # Panics
 ///
-/// @alert unsafe "Panics if the index is out of bounds."
+#internal(unsafe, "Panics if the index is out of bounds.")
 pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 
 ///|


### PR DESCRIPTION
remove all  `@alert` pragmas, use `#internal` attribute instead