### PR TITLE
feat: improve array zip_to_iter2 to be fault tolerant

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -275,12 +275,12 @@ pub fn zip_with[A, B, C](
 /// }
 /// ```
 pub fn zip_to_iter2[A, B](self : Array[A], other : Array[B]) -> Iter2[A, B] {
-  let length = if self.length() < other.length() {
-    self.length()
-  } else {
-    other.length()
-  }
   Iter2::new(fn(yield_) {
+    let length = if self.length() < other.length() {
+      self.length()
+    } else {
+      other.length()
+    }
     for i = 0; i < length; i = i + 1 {
       if yield_(self[i], other[i]) == IterEnd {
         break IterEnd

--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -687,6 +687,19 @@ test "zip_to_iter2" {
 }
 
 ///|
+test "zip_to_iter2 current behavior" {
+  // Only for recording what can be done, but not what should be done
+  let arr = [1, 2, 3]
+  let arr2 = ['a', 'b', 'c']
+  let iter = arr.zip_to_iter2(arr2)
+  arr.push(4)
+  arr2.push('d')
+  inspect!(iter.to_array(), content="[(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')]")
+  arr.clear()
+  inspect!(iter.to_array(), content="[]")
+}
+
+///|
 test "arbitrary" {
   let arr : Array[Array[Int]] = @quickcheck.samples(20)
   inspect!(arr[5:9], content="[[], [], [0], [0, 0]]")


### PR DESCRIPTION
Based on the comment: https://github.com/moonbitlang/core/commit/0783012aa805c255788bfa2b38fe196d7edb8ef1#r156454436

Notice that this changes the behavior when the user modifies the Array after creating the zip.