### PR TITLE
remove unused alert and internal attribute

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -153,7 +153,6 @@ pub fn Array::unsafe_get[T](self : Array[T], idx : Int) -> T {
 /// }
 /// ```
 ///
-#internal(unsafe, "Panic if index is out of bounds")
 #intrinsic("%array.get")
 pub fn Array::op_get[T](self : Array[T], index : Int) -> T {
   let len = self.length()
@@ -222,7 +221,6 @@ fn Array::unsafe_set[T](self : Array[T], idx : Int, val : T) -> Unit {
 /// }
 /// ```
 ///
-#internal(unsafe, "Panic if index is out of bounds.")
 #intrinsic("%array.set")
 pub fn Array::op_set[T](self : Array[T], index : Int, value : T) -> Unit {
   let len = self.length()
@@ -721,6 +719,7 @@ pub fn Array::rev[T](self : Array[T]) -> Array[T] {
 
 ///|
 /// Split the array into two at the given index.
+/// This function will panic if the index is out of bounds.
 ///
 /// # Example
 /// ```
@@ -730,7 +729,6 @@ pub fn Array::rev[T](self : Array[T]) -> Array[T] {
 /// assert_eq!(v2, [4, 5])
 /// ```
 /// TODO: perf could be optimized
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::split_at[T](self : Array[T], index : Int) -> (Array[T], Array[T]) {
   if index < 0 || index > self.length() {
     let len = self.length()
@@ -1149,8 +1147,8 @@ pub fn Array::binary_search_by[T](
 /// * `index1` : The index of the first element to be swapped.
 /// * `index2` : The index of the second element to be swapped.
 ///
-/// Throws an error if either index is negative or greater than or equal to the
-/// length of the array.
+/// This function will panic if either index is negative or greater than or equal to
+/// the length of the array.
 ///
 /// Example:
 ///
@@ -1166,7 +1164,6 @@ pub fn Array::binary_search_by[T](
 ///   ignore(arr.swap(0, 3)) // Index out of bounds
 /// }
 /// ```
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::swap[T](self : Array[T], i : Int, j : Int) -> Unit {
   if i >= self.length() || j >= self.length() || i < 0 || j < 0 {
     let len = self.length()
@@ -1260,7 +1257,6 @@ pub fn Array::retain[T](self : Array[T], f : (T) -> Bool) -> Unit {
 /// }
 /// ```
 ///
-#internal(unsafe, "Panic if new length is negative.")
 pub fn Array::resize[T](self : Array[T], new_len : Int, f : T) -> Unit {
   if new_len < 0 {
     abort("negative new length")

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -222,6 +222,8 @@ pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
 /// Remove an element from the array at a given index.
 ///
 /// Removes and returns the element at position index within the array, shifting all elements after it to the left.
+/// 
+/// This function will panic if the index is out of bounds.
 ///
 /// # Example
 /// ```
@@ -230,7 +232,6 @@ pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
 /// assert_eq!(vv, 4)
 /// assert_eq!(v, [3, 5])
 /// ```
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::remove[T](self : Array[T], index : Int) -> T {
   guard index >= 0 && index < self.length() else {
     abort(
@@ -246,13 +247,14 @@ pub fn Array::remove[T](self : Array[T], index : Int) -> T {
 /// Removes the specified range from the array and returns it.
 ///
 /// This functions returns a array range from `begin` to `end` `[begin, end)`
+/// 
+/// This function will panic if the index is out of bounds.
 ///
 /// # Example
 /// ```
 /// let v = [3, 4, 5]
 /// let vv = v.drain(1, 2) // vv = [4], v = [3, 5]
 /// ```
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
   guard begin >= 0 && end <= self.length() && begin <= end else {
     abort(
@@ -264,12 +266,13 @@ pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
 
 ///|
 /// Inserts an element at a given index within the array.
+/// 
+/// This function will panic if the index is out of bounds.
 ///
 /// # Example
 /// ```
 /// [3, 4, 5].insert(1, 6)
 /// ```
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
   guard index >= 0 && index <= self.length() else {
     abort(
@@ -287,7 +290,6 @@ pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
 /// difference, and the values in the new slots are left uninitilized.
 ///  If `new_len` is less than `len`, it will panic
 ///
-#internal(unsafe, "Panic if new length is negative.")
 fn Array::unsafe_grow_to_length[T](self : Array[T], new_len : Int) -> Unit {
   guard new_len >= self.length()
   JSArray::ofAnyArray(self).set_length(new_len)

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -323,9 +323,10 @@ pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
 }
 
 ///|
-/// Remove an element from the array at a given index.
-///
-/// Removes and returns the element at position index within the array, shifting all elements after it to the left.
+/// Removes and returns the element at position index within the array, 
+/// shifting all elements after it to the left.
+/// 
+/// This function will panic if the index is out of bounds.
 ///
 /// # Example
 /// ```
@@ -333,7 +334,6 @@ pub fn Array::unsafe_pop[T](self : Array[T]) -> T {
 /// assert_eq!(v.remove(1), 4)
 /// assert_eq!(v, [3, 5])
 /// ```
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::remove[T](self : Array[T], index : Int) -> T {
   guard index >= 0 && index < self.length() else {
     abort(
@@ -356,6 +356,8 @@ pub fn Array::remove[T](self : Array[T], index : Int) -> T {
 /// Removes the specified range from the array and returns it.
 ///
 /// This functions returns a array range from `begin` to `end` `[begin, end)`
+/// 
+/// This function will panic if the index is out of bounds.
 ///
 /// # Example
 /// ```
@@ -364,7 +366,6 @@ pub fn Array::remove[T](self : Array[T], index : Int) -> T {
 /// assert_eq!(vv, [4])
 /// assert_eq!(v, [3, 5])
 /// ```
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
   guard begin >= 0 && end <= self.length() && begin <= end
   let num = end - begin
@@ -383,12 +384,12 @@ pub fn Array::drain[T](self : Array[T], begin : Int, end : Int) -> Array[T] {
 
 ///|
 /// Inserts an element at a given index within the array.
+/// This function will panic if the index is out of bounds.
 ///
 /// # Example
 /// ```
 /// [3, 4, 5].insert(1, 6)
 /// ```
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
   guard index >= 0 && index <= self.length() else {
     abort(
@@ -417,7 +418,6 @@ pub fn Array::insert[T](self : Array[T], index : Int, value : T) -> Unit {
 /// difference, and the values in the new slots are left uninitialized.
 ///  If `new_len` is less than `len`, it will panic
 ///
-#internal(unsafe, "Panic if new length is negative.")
 fn Array::unsafe_grow_to_length[T](self : Array[T], new_len : Int) -> Unit {
   guard new_len >= self.length()
   let new_buf = UninitializedArray::make(new_len)

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -23,7 +23,7 @@
 /// assert_eq!(view[0], 2)
 /// assert_eq!(view.length(), 3)
 /// ```
-#internal(deprecated, "use @array.View instead")
+#deprecated("use @array.View instead")
 struct ArrayView[T] {
   buf : UninitializedArray[T]
   start : Int
@@ -154,7 +154,6 @@ pub fn ArrayView::unsafe_get[T](self : ArrayView[T], index : Int) -> T {
 /// }
 /// ```
 ///
-#internal(unsafe, "Panic if index is out of bounds.")
 pub fn ArrayView::op_set[T](
   self : ArrayView[T],
   index : Int,
@@ -196,7 +195,6 @@ pub fn ArrayView::op_set[T](
 /// }
 /// ```
 ///
-#internal(unsafe, "Panic if index is out of bounds")
 pub fn ArrayView::swap[T](self : ArrayView[T], i : Int, j : Int) -> Unit {
   guard i >= 0 && i < self.len && j >= 0 && j < self.len else {
     abort(

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -274,7 +274,8 @@ pub fn FixedArray::set_utf8_char(
 ///|
 /// Fill UTF16LE encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
-#internal(unsafe, "Panic if the [value] is out of range")
+/// 
+/// This function will panic if the `value` is out of range.
 pub fn FixedArray::set_utf16le_char(
   self : FixedArray[Byte],
   offset : Int,
@@ -302,7 +303,8 @@ pub fn FixedArray::set_utf16le_char(
 ///|
 /// Fill UTF16BE encoded char `value` into byte sequence `self`, starting at `offset`.
 /// It return the length of bytes has been written.
-#internal(unsafe, "Panic if the [value] is out of range")
+/// 
+/// This function will panic if the `value` is out of range.
 pub fn FixedArray::set_utf16be_char(
   self : FixedArray[Byte],
   offset : Int,

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1603,7 +1603,6 @@ pub fn FixedArray::get[T](self : FixedArray[T], idx : Int) -> T = "%fixedarray.g
 /// }
 /// ```
 ///
-#internal(unsafe, "Panic if index is out of bounds.")
 #intrinsic("%fixedarray.set")
 pub fn FixedArray::op_set[T](self : FixedArray[T], idx : Int, val : T) -> Unit = "%fixedarray.set"
 
@@ -1752,7 +1751,6 @@ pub fn String::charcode_length(self : String) -> Int = "%string_length"
 /// }
 /// ```
 ///
-#internal(unsafe, "Panic if index is out of bounds")
 pub fn String::op_get(self : String, idx : Int) -> Char = "%string_get"
 
 ///|

--- a/builtin/json_test.mbt
+++ b/builtin/json_test.mbt
@@ -51,14 +51,6 @@ test "to_json on empty fixed array" {
 }
 
 ///|
-test "test empty array view to json" {
-  let arr : Array[Int] = []
-  let view : ArrayView[Int] = arr[:]
-  let json = @builtin.ArrayView::to_json(view)
-  inspect!(json, content="Array([])")
-}
-
-///|
 test "test map with string values" {
   let m : Map[String, Int] = {}
   inspect!(m.to_json(), content="Object({})")

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -104,7 +104,6 @@ pub fn Map::from_array[K : Hash + Eq, V](arr : Array[(K, V)]) -> Map[K, V] {
 
 ///|
 /// Set a key-value pair into the hash map.
-#internal(unsafe, "Panic if the hash map is full.")
 pub fn Map::set[K : Hash + Eq, V](self : Map[K, V], key : K, value : V) -> Unit {
   if self.size >= self.growAt {
     self.grow()

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -31,7 +31,8 @@ pub fn Option::to_string[X : Show](self : X?) -> String {
 
 ///|
 /// Extract the value in `Some`.
-#internal(unsafe, "Panic if input is `None`.")
+/// 
+/// If the value is `None`, it throws a panic.
 pub fn Option::unwrap[X](self : X?) -> X {
   match self {
     None => panic()

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -63,6 +63,8 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 
 ///|
 /// Returns the UTF-16 code unit at the given index.
+/// 
+/// This function will panic if the index is out of bounds.
 ///
 /// # Examples
 ///
@@ -73,9 +75,6 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 /// inspect!(s.charcode_at(6), content="56611"); // Second surrogate of 🤣
 /// ```
 ///
-/// # Panics
-///
-#internal(unsafe, "Panics if the index is out of bounds.")
 pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 
 ///|

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -155,7 +155,7 @@ pub fn View::get(self : View, index : Int) -> Byte? {
 /// }
 /// ```
 ///
-/// @alert unsafe "Panic if index is out of bounds"
+#internal(unsafe, "Panic if index is out of bounds")
 pub fn View::unsafe_get(self : View, index : Int) -> Byte {
   self.bytes()[self.start() + index]
 }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -309,7 +309,7 @@ pub fn push_back[A](self : T[A], value : A) -> Unit {
 /// dv.unsafe_pop_front()
 /// assert_eq!(dv.front(), Some(2))
 /// ```
-/// @alert unsafe "Panic if the deque is empty."
+#internal(unsafe, "Panic if the deque is empty.")
 pub fn unsafe_pop_front[A](self : T[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
@@ -364,7 +364,7 @@ pub fn pop_front_exn[A](self : T[A]) -> Unit {
 /// dv.unsafe_pop_back()
 /// assert_eq!(dv.back(), Some(4))
 /// ```
-/// @alert unsafe "Panic if the deque is empty."
+#internal(unsafe, "Panic if the deque is empty.")
 pub fn unsafe_pop_back[A](self : T[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
@@ -484,7 +484,6 @@ pub fn pop_back[A](self : T[A]) -> A? {
 /// let dv = @deque.of([1, 2, 3, 4, 5])
 /// assert_eq!(dv[2], 3)
 /// ```
-/// @alert unsafe "Panic if the index is out of bounds."
 pub fn op_get[A](self : T[A], index : Int) -> A {
   if index < 0 || index >= self.len {
     let len = self.len
@@ -510,7 +509,6 @@ pub fn op_get[A](self : T[A], index : Int) -> A {
 /// dv[2] = 1
 /// assert_eq!(dv[2], 1)
 /// ```
-/// @alert unsafe "Panic if the index is out of bounds."
 pub fn op_set[A](self : T[A], index : Int, value : A) -> Unit {
   if index < 0 || index >= self.len {
     let len = self.len
@@ -551,7 +549,7 @@ pub fn op_set[A](self : T[A], index : Int, value : A) -> Unit {
 ///   inspect!(v2.length(), content="0")
 /// }
 /// ```
-pub fn T::as_views[A](self : T[A]) -> (ArrayView[A], ArrayView[A]) {
+pub fn T::as_views[A](self : T[A]) -> (@array.View[A], @array.View[A]) {
   guard self.len != 0 else { ([][:], [][:]) }
   let { buf, head, len, .. } = self
   let cap = buf.length()

--- a/deque/moon.pkg.json
+++ b/deque/moon.pkg.json
@@ -1,12 +1,10 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/json"
+    "moonbitlang/core/json",
+    "moonbitlang/core/array"
   ],
   "targets": {
     "panic_test.mbt": ["not", "native", "llvm"]
-  },
-  "test-import": [
-    "moonbitlang/core/array"
-  ]
+  }
 }

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -119,8 +119,6 @@ pub fn from_array[K : Hash + Eq, V](arr : Array[(K, V)]) -> T[K, V] {
 ///   inspect!(map.get("key"), content="Some(24)")
 /// }
 /// ```
-///
-/// @alert unsafe "Panic if the hash map is full."
 pub fn set[K : Hash + Eq, V](self : T[K, V], key : K, value : V) -> Unit {
   self.set_with_hash(key, value, key.hash())
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -44,7 +44,6 @@ pub fn of[K : Hash + Eq](arr : FixedArray[K]) -> T[K] {
 
 ///|
 /// Insert a key into hash set.
-/// @alert unsafe "Panic if the hash set is full."
 #deprecated("Use `add` instead.")
 #coverage.skip
 pub fn insert[K : Hash + Eq](self : T[K], key : K) -> Unit {
@@ -175,7 +174,6 @@ pub fn clear[K](self : T[K]) -> Unit {
 
 ///|
 /// Union of two hash sets.
-/// @alert unsafe "Panic if the hash set is full."
 pub fn union[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
   let m = new()
   self.each(fn(k) { m.add(k) })
@@ -242,7 +240,6 @@ pub impl[K : Hash + Eq] BitAnd for T[K] with land(self, other) {
 
 ///|
 /// Union of two hash sets.
-/// @alert unsafe "Panic if the hash set is full."
 pub impl[K : Hash + Eq] BitOr for T[K] with lor(self, other) {
   self.union(other)
 }

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -434,7 +434,10 @@ pub impl[A : Compare] Compare for T[A] with compare(self, other) {
 //-----------------------------------------------------------------------------
 
 ///|
-fn from_leaves[A](leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
+fn from_leaves[A](
+  leaves : @core/array.View[FixedArray[A]],
+  cap : Int
+) -> Tree[A] {
   if cap == branching_factor {
     Leaf(leaves[0])
   } else if leaves.length() <= branching_factor {

--- a/immut/array/moon.pkg.json
+++ b/immut/array/moon.pkg.json
@@ -4,7 +4,7 @@
     "moonbitlang/core/quickcheck",
     {
       "path": "moonbitlang/core/array",
-      "alias": "_core/array"
+      "alias": "core/array"
     }
   ],
   "targets": {

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -239,7 +239,7 @@ pub fn tail[A](self : T[A]) -> T[A] {
 
 ///|
 /// Get first element of the list.
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_head[A](self : T[A]) -> A {
   match self {
     Nil => abort("head of empty list")
@@ -270,7 +270,7 @@ pub fn head[A](self : T[A]) -> A? {
 }
 
 ///|
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_last[A](self : T[A]) -> A {
   loop self {
     Nil => abort("last of empty list")
@@ -546,7 +546,7 @@ pub fn filter_map[A, B](self : T[A], f : (A) -> B?) -> T[B] {
 }
 
 ///|
-/// @alert unsafe "Panic if the index is out of bounds"
+#internal(unsafe, "Panic if the index is out of bounds")
 pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
   loop self, n {
     Nil, _ => abort("nth: index out of bounds")
@@ -653,7 +653,7 @@ pub fn flatten[A](self : T[T[A]]) -> T[A] {
 }
 
 ///|
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
   match self {
     Nil => abort("maximum: empty list")
@@ -685,7 +685,7 @@ pub fn maximum[A : Compare](self : T[A]) -> A? {
 }
 
 ///|
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
   match self {
     Nil => abort("minimum: empty list")

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -167,13 +167,13 @@ fn change_and_down[A : Compare](self : Node[A], value : A) -> Node[A] {
 ///|
 /// Pops the first value from the immutable priority queue.
 ///
-/// @alert unsafe "Panics if the queue is empty."
 /// # Example
 /// ```
 /// let queue = @priority_queue.of([1, 2, 3, 4])
 /// let first = queue.unsafe_pop()
 /// assert_eq!(first, @priority_queue.of([1, 2, 3]))
 /// ```
+#internal(unsafe, "Panics if the queue is empty.")
 pub fn unsafe_pop[A : Compare](self : T[A]) -> T[A] {
   match self.node {
     Empty => abort("Priority queue is empty!")

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -64,14 +64,14 @@ pub fn to_array[A : Compare](self : T[A]) -> Array[A] {
 }
 
 ///|
-/// Remove the smallest value,
+/// Remove the smallest value.
+/// This function will panic if the set is empty.
 ///
 /// # Example
 ///
 /// ```
 /// assert_eq!(@sorted_set.of([3, 4, 5]).remove_min(), @sorted_set.of([4, 5]))
 /// ```
-/// @alert unsafe "Panic if the ImmutableSet is empty."
 pub fn remove_min[A : Compare](self : T[A]) -> T[A] {
   match self {
     Empty => abort("remove_min: empty ImmutableSet")
@@ -154,13 +154,13 @@ pub fn remove[A : Compare](self : T[A], value : A) -> T[A] {
 
 ///|
 /// Returns the smallest value in the sorted_set.
+/// This function will panic if the set is empty.
 ///
 /// # Example
 ///
 /// ```
 /// assert_eq!(@sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).min(), 1)
 /// ```
-/// @alert unsafe "Panic if the sorted_set is empty."
 pub fn min[A : Compare](self : T[A]) -> A {
   match self {
     Empty => abort("min: there are no values in sorted_set.")
@@ -185,13 +185,13 @@ pub fn min_option[A : Compare](self : T[A]) -> A? {
 
 ///|
 /// Returns the largest value in the sorted_set.
+/// This function will panic if the set is empty.
 ///
 /// # Example
 ///
 /// ```
 /// assert_eq!(@sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).max(), 9)
 /// ```
-/// @alert unsafe "Panic if the sorted_set is empty."
 pub fn max[A : Compare](self : T[A]) -> A {
   match self {
     Empty => abort("max: there are no values in ImmutableSet.")

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -292,7 +292,7 @@ pub fn tail[A](self : T[A]) -> T[A] {
 
 ///|
 /// Get first element of the list.
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_head[A](self : T[A]) -> A {
   match self {
     Empty => abort("head of empty list")
@@ -316,7 +316,7 @@ pub fn head[A](self : T[A]) -> A? {
 }
 
 ///|
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_last[A](self : T[A]) -> A {
   loop self {
     Empty => abort("last of empty list")
@@ -556,7 +556,7 @@ pub fn filter_map[A, B](self : T[A], f : (A) -> B?) -> T[B] {
 }
 
 ///|
-/// @alert unsafe "Panic if the index is out of bounds"
+#internal(unsafe, "Panic if the index is out of bounds")
 pub fn unsafe_nth[A](self : T[A], n : Int) -> A {
   loop self, n {
     Empty, _ => abort("nth: index out of bounds")
@@ -703,7 +703,7 @@ pub fn flatten[A](self : T[T[A]]) -> T[A] {
 }
 
 ///|
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_maximum[A : Compare](self : T[A]) -> A {
   match self {
     Empty => abort("maximum: empty list")
@@ -732,7 +732,7 @@ pub fn maximum[A : Compare](self : T[A]) -> A? {
 }
 
 ///|
-/// @alert unsafe "Panic if the list is empty"
+#internal(unsafe, "Panic if the list is empty")
 pub fn unsafe_minimum[A : Compare](self : T[A]) -> A {
   match self {
     Empty => abort("maximum: empty list")

--- a/prelude/moon.pkg.json
+++ b/prelude/moon.pkg.json
@@ -1,6 +1,7 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/set"
+    "moonbitlang/core/set",
+    "moonbitlang/core/array"
   ]
 }

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 ///|
+#deprecated("Use `@array.View` instead")
+pub typealias ArrayView[A] = @array.View[A]
+
+///|
 pub typealias @builtin.(
   ArgsLoc,
   Array,
-  ArrayView,
   UninitializedArray,
   BigInt,
   Failure,

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -45,7 +45,7 @@ pub typealias ArgsLoc = @builtin.ArgsLoc
 
 pub typealias Array[T] = @builtin.Array[T]
 
-pub typealias ArrayView[T] = @builtin.ArrayView[T]
+pub typealias ArrayView[A] = @builtin.ArrayView[A]
 
 pub typealias BigInt = @builtin.BigInt
 

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -156,7 +156,7 @@ pub fn length[A](self : T[A]) -> Int {
 /// queue.unsafe_pop()
 /// assert_eq!(queue.length(), 3)
 /// ```
-/// @alert unsafe "Panic if the queue is empty."
+#internal(unsafe, "Panic if the queue is empty.")
 pub fn unsafe_pop[A : Compare](self : T[A]) -> Unit {
   self.top = match self.top {
     Nil => abort("The PriorityQueue is empty!")

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -126,7 +126,7 @@ pub fn push[A](self : T[A], x : A) -> Unit {
 /// let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
 /// assert_eq!(queue.unsafe_peek(), 1)
 /// ```
-/// @alert unsafe "Panics if the queue is empty."
+#internal(unsafe, "Panics if the queue is empty.")
 pub fn unsafe_peek[A](self : T[A]) -> A {
   match self.first {
     None => abort("Queue is empty")
@@ -164,7 +164,7 @@ pub fn peek[A](self : T[A]) -> A? {
 /// let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
 /// assert_eq!(queue.unsafe_pop(), 1)
 /// ```
-/// @alert unsafe "Panics if the queue is empty."
+#internal(unsafe, "Panics if the queue is empty.")
 pub fn unsafe_pop[A](self : T[A]) -> A {
   match self.first {
     None => abort("Queue is empty")

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -20,7 +20,8 @@ struct Rand {
 
 ///|
 /// Create a new random number generator with [seed].
-#internal(unsafe, "Panic if seed is not 32 bytes long")
+/// 
+/// The seed must be 32 bytes long.
 pub fn new(seed~ : Bytes = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ123456") -> Rand {
   if seed.length() != 32 {
     abort("seed must be 32 bytes long")
@@ -232,7 +233,7 @@ test "umul128: handles zero correctly" {
 
 ///|
 /// [shuffle] shuffles the first n elements of an array using the Fisher-Yates shuffle algorithm.
-/// @alert unsafe "Panics if limit is negative"
+/// The limit should not be negative.
 ///
 /// # Example
 /// ```

--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -148,6 +148,7 @@ pub fn length_ge(self : View, len : Int) -> Bool {
 
 ///|
 /// Returns the character at the given index from the end of the string.
+/// This function will panic if the index is out of bounds.
 ///
 /// # Examples
 ///
@@ -156,10 +157,6 @@ pub fn length_ge(self : View, len : Int) -> Bool {
 /// inspect!(s.rev_get(0), content="🤣")
 /// inspect!(s.rev_get(4), content="l")
 /// ```
-///
-/// # Panics
-///
-/// @alert unsafe "Panics if the index is out of bounds."
 #deprecated("use String::rev_iter().nth(index).unwrap() instead")
 pub fn String::rev_get(self : String, index : Int) -> Char {
   guard index >= 0


### PR DESCRIPTION
- Remove unused alert and internal attributes

  Note that any member with the `#internal` attribute will emit warnings for the user (in another module).

- fix deprecated annotations

There are some changes in `@prelude` package. @Guest0x0 