### PR TITLE
fix constructor as function

### DIFF
--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -256,7 +256,7 @@ test "filter_map" {
   inspect!(r1, content="[3, 4, 5]")
   let r2 : Array[Unit] = arr.iter().filter_map(fn(_x) { None }).collect()
   inspect!(r2, content="[]")
-  let r3 : Array[Unit] = [].iter().filter_map(Option::Some).collect()
+  let r3 : Array[Unit] = [].iter().filter_map(Option::Some(_)).collect()
   inspect!(r3, content="[]")
 }
 

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -922,7 +922,7 @@ test "deque retain_map" {
     [8, 9],
     [],
   ])
-  @json.inspect!(dq!()..retain_map(Option::Some).as_views(), content=[
+  @json.inspect!(dq!()..retain_map(Option::Some(_)).as_views(), content=[
     [4, 5, 6],
     [7, 8],
   ])


### PR DESCRIPTION
We plan to deprecate the behavior of using constructor with payload as function directly, in favor of the partial application syntax. Reasons:

- if we allow constructor as function, there will be an inconsistency between constructor with payload (function) and constructor without payload (constants)
- if we forbid constructor as function, code readers can visually tell whether a constructor is constant directly
- constructors allow type-directed resolution, allowing constructor as function makes this part of typing logic complicated
- for cases where constructors are indeed used as first class function directly, the partial application syntax provides a good alternative

This PR removes usage of constructor as first class function directly in core, to adapt the upcoming compiler update.