### PR TITLE
Add `data` and `start_offset` methods for `StringView`

### DIFF
--- a/string/string.mbti
+++ b/string/string.mbti
@@ -7,6 +7,8 @@ fn contains(String, StringView) -> Bool
 
 fn contains_char(String, Char) -> Bool
 
+fn data(StringView) -> String
+
 fn default() -> String
 
 #deprecated
@@ -58,6 +60,8 @@ fn rev_iter(String) -> Iter[Char]
 
 fn split(String, StringView) -> Iter[StringView]
 
+fn start_offset(StringView) -> Int
+
 #deprecated
 fn starts_with(String, String) -> Bool
 
@@ -92,6 +96,7 @@ impl StringView {
   charcodes(Self, start~ : Int = .., end~ : Int = ..) -> Self
   contains(Self, Self) -> Bool
   contains_char(Self, Char) -> Bool
+  data(Self) -> String
   find(Self, Self) -> Int?
   find_by(Self, (Char) -> Bool) -> Int?
   fold[A](Self, init~ : A, (A, Char) -> A) -> A
@@ -119,6 +124,7 @@ impl StringView {
   rev_fold[A](Self, init~ : A, (A, Char) -> A) -> A
   rev_iter(Self) -> Iter[Char]
   split(Self, Self) -> Iter[Self]
+  start_offset(Self) -> Int
   to_lower(Self) -> Self
   to_upper(Self) -> Self
   trim(Self, Self) -> Self

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -58,6 +58,19 @@ pub fn View::op_get(self : View, index : Int) -> Int {
 }
 
 ///|
+/// Returns the original string that is being viewed.
+pub fn data(self : View) -> String {
+  self.str
+}
+
+///|
+/// Returns the starting offset (in UTF-16 code units) of this view into its
+/// underlying string.
+pub fn start_offset(self : View) -> Int {
+  self.start
+}
+
+///|
 /// Returns the length of the view.
 /// 
 /// This method counts the charcodes(code unit) in the view and has O(1) complexity.

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -66,6 +66,20 @@ test "stringview rev_get" {
 }
 
 ///|
+test "stringview data" {
+  let str = "Hello🤣🤣🤣"
+  let view = str.view(start_offset=1, end_offset=7)
+  inspect!(view.data(), content="Hello🤣🤣🤣")
+}
+
+///|
+test "stringview start_offset" {
+  let str = "Hello🤣🤣🤣"
+  let view = str.view(start_offset=1, end_offset=7)
+  inspect!(view.start_offset(), content="1")
+}
+
+///|
 test "stringview length" {
   let str = "Hello🤣🤣🤣"
   let view = str.view(start_offset=1, end_offset=7)


### PR DESCRIPTION
The `StringView` currently lacks methods to obtain raw data and starting offset, which hinders seamless switching between `StringView` and `String`.

Here is an example:

- Original:
```moonbit
///|
pub type Oid

///|
extern "C" fn oid_from_string_ffi(
  str : String,
  oid_buf : FixedArray[Oid?],
  err_buf : FixedArray[GitErrorMeta?]
) -> Unit = "oid_from_string_ffi"

///|
pub fn Oid::from_string(str : String) -> Oid!GitError {
  let oid_buf : FixedArray[Oid?] = [None]
  let err_buf : FixedArray[GitErrorMeta?] = [None]
  oid_from_string_ffi(str, oid_buf, err_buf)
  match (oid_buf, err_buf) {
    ([Some(oid)], [None]) => oid
    ([None], [Some(err)]) => raise GitError(err)
    _ => abort("unreachable")
  }
}
```
- After adding:
```moonbit
///|
pub type Oid

///|
extern "C" fn oid_from_string_ffi(
  str : String,
  start_offset : Int,
  length : Int,
  oid_buf : FixedArray[Oid?],
  err_buf : FixedArray[GitErrorMeta?]
) -> Unit = "oid_from_string_ffi"

///|
pub fn Oid::from_string(str : @string.StringView) -> Oid!GitError {
  let oid_buf : FixedArray[Oid?] = [None]
  let err_buf : FixedArray[GitErrorMeta?] = [None]
  oid_from_string_ffi(
    str.data(),
    str.start_offset(),
    str.length(),
    oid_buf,
    err_buf,
  )
  match (oid_buf, err_buf) {
    ([Some(oid)], [None]) => oid
    ([None], [Some(err)]) => raise GitError(err)
    _ => abort("unreachable")
  }
}
```