### PR TITLE
feat: add size_hint for Iter::collect

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -175,7 +175,7 @@ impl Iter {
   all[T](Self[T], (T) -> Bool) -> Bool
   any[T](Self[T], (T) -> Bool) -> Bool
   append[T](Self[T], T) -> Self[T]
-  collect[T](Self[T]) -> Array[T]
+  collect[T](Self[T], size_hint~ : Int = ..) -> Array[T]
   concat[T](Self[T], Self[T]) -> Self[T]
   contains[A : Eq](Self[A], A) -> Bool
   count[T](Self[T]) -> Int
@@ -215,7 +215,7 @@ impl Iter {
   take[T](Self[T], Int) -> Self[T]
   take_while[T](Self[T], (T) -> Bool) -> Self[T]
   tap[T](Self[T], (T) -> Unit) -> Self[T]
-  to_array[T](Self[T]) -> Array[T]
+  to_array[T](Self[T], size_hint~ : Int = ..) -> Array[T]
 }
 impl[T] Add for Iter[T]
 impl[T : Show] Show for Iter[T]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -805,8 +805,8 @@ pub impl[T] Add for Iter[T] with op_add(self, other) {
 
 ///|
 /// Collects the elements of the iterator into an array.
-pub fn Iter::to_array[T](self : Iter[T]) -> Array[T] {
-  let result = []
+pub fn Iter::to_array[T](self : Iter[T], size_hint~ : Int = 0) -> Array[T] {
+  let result = Array::new(capacity=size_hint)
   for e in self {
     result.push(e)
   }
@@ -815,10 +815,8 @@ pub fn Iter::to_array[T](self : Iter[T]) -> Array[T] {
 
 ///|
 /// Collects the elements of the iterator into an array.
-pub fn Iter::collect[T](self : Iter[T]) -> Array[T] {
-  let result = []
-  self.each(fn(e) { result.push(e) })
-  result
+pub fn Iter::collect[T](self : Iter[T], size_hint~ : Int = 0) -> Array[T] {
+  self.to_array(size_hint~)
 }
 
 ///|


### PR DESCRIPTION
The internal iterator doesn't know the number of elements, and it makes sense to add size_hint as a default parameter