### PR TITLE
docs: fix typos

### DIFF
--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This module implements the set data structure.
+// This package implements the set data structure.
 // The types stored in set need to implement the Compare trait.
 // All operations over sets are purely applicative (no side-effects).
 

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This module implements the set data structure.
+// This package implements the set data structure.
 // The types stored in set need to implement the Compare trait.
 // All operations over sets are purely applicative (no side-effects).
 

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This module implements the set data structure.
+// This package implements the set data structure.
 // The types stored in set need to implement the Compare trait.
 // All operations over sets are purely applicative (no side-effects).
 

--- a/immut/sorted_set/types.mbt
+++ b/immut/sorted_set/types.mbt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This module implements the set data structure.
+// This package implements the set data structure.
 // The types stored in set need to implement the Compare trait.
 // All operations over sets are purely applicative (no side-effects).
 

--- a/list/README.mbt.md
+++ b/list/README.mbt.md
@@ -1,6 +1,6 @@
 # List
 
-The `List` module provides an immutable linked list data structure with a variety of utility functions for functional programming.
+The `List` package provides an immutable linked list data structure with a variety of utility functions for functional programming.
 
 ## Table of Contents
 

--- a/sorted_set/types.mbt
+++ b/sorted_set/types.mbt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This module implements the set data structure.
+// This package implements the set data structure.
 // The types stored in set need to implement the Compare trait.
 // All operations over sets are purely applicative (no side-effects).
 


### PR DESCRIPTION
`core` is module, a module contains many packages in moonbit.