### PR TITLE
feat(Byte): add count_ones method

### DIFF
--- a/byte/byte.mbt
+++ b/byte/byte.mbt
@@ -51,12 +51,12 @@ pub fn to_uint64(self : Byte) -> UInt64 {
 /// Example:
 ///
 /// ```moonbit
-/// test "count_ones" {
+/// test "popcnt" {
 ///   let b = b'\x0F'
-///   inspect!(b.count_ones(), content="4")
+///   inspect!(b.popcnt(), content="4")
 /// }
 /// ```
-pub fn count_ones(self : Byte) -> Int {
+pub fn popcnt(self : Byte) -> Int {
   let mut n = self
   n = (n & 0x55) + ((n >> 1) & 0x55)
   n = (n & 0x33) + ((n >> 2) & 0x33)

--- a/byte/byte.mbt
+++ b/byte/byte.mbt
@@ -38,3 +38,29 @@ pub let min_value : Byte = b'\x00'
 pub fn to_uint64(self : Byte) -> UInt64 {
   self.to_uint().to_uint64()
 }
+
+
+///|
+/// Counts the number of 1-bits (population count) in the byte using bitwise operations.
+///
+/// Parameters:
+///
+/// * `self` : The byte value whose 1-bits are to be counted.
+///
+/// Returns the number of 1-bits in the byte.
+///
+/// Example:
+///
+/// ```moonbit
+/// test "count_ones" {
+///   let b = b'\x0F'
+///   inspect!(b.count_ones(), content="4")
+/// }
+/// ```
+pub fn count_ones(self: Byte) -> Int {
+  let mut n = self;
+  n = (n & 0x55) + ((n >> 1) & 0x55);
+  n = (n & 0x33) + ((n >> 2) & 0x33);
+  n = (n & 0x0F) + ((n >> 4) & 0x0F);
+  n.to_int()
+}

--- a/byte/byte.mbt
+++ b/byte/byte.mbt
@@ -39,7 +39,6 @@ pub fn to_uint64(self : Byte) -> UInt64 {
   self.to_uint().to_uint64()
 }
 
-
 ///|
 /// Counts the number of 1-bits (population count) in the byte using bitwise operations.
 ///
@@ -57,10 +56,10 @@ pub fn to_uint64(self : Byte) -> UInt64 {
 ///   inspect!(b.count_ones(), content="4")
 /// }
 /// ```
-pub fn count_ones(self: Byte) -> Int {
-  let mut n = self;
-  n = (n & 0x55) + ((n >> 1) & 0x55);
-  n = (n & 0x33) + ((n >> 2) & 0x33);
-  n = (n & 0x0F) + ((n >> 4) & 0x0F);
+pub fn count_ones(self : Byte) -> Int {
+  let mut n = self
+  n = (n & 0x55) + ((n >> 1) & 0x55)
+  n = (n & 0x33) + ((n >> 2) & 0x33)
+  n = (n & 0x0F) + ((n >> 4) & 0x0F)
   n.to_int()
 }

--- a/byte/byte.mbti
+++ b/byte/byte.mbti
@@ -1,17 +1,17 @@
 package "moonbitlang/core/byte"
 
 // Values
-fn count_ones(Byte) -> Int
-
 let max_value : Byte
 
 let min_value : Byte
+
+fn popcnt(Byte) -> Int
 
 fn to_uint64(Byte) -> UInt64
 
 // Types and methods
 impl Byte {
-  count_ones(Byte) -> Int
+  popcnt(Byte) -> Int
   to_uint64(Byte) -> UInt64
 }
 

--- a/byte/byte.mbti
+++ b/byte/byte.mbti
@@ -1,6 +1,8 @@
 package "moonbitlang/core/byte"
 
 // Values
+fn count_ones(Byte) -> Int
+
 let max_value : Byte
 
 let min_value : Byte
@@ -9,6 +11,7 @@ fn to_uint64(Byte) -> UInt64
 
 // Types and methods
 impl Byte {
+  count_ones(Byte) -> Int
   to_uint64(Byte) -> UInt64
 }
 

--- a/byte/byte_test.mbt
+++ b/byte/byte_test.mbt
@@ -50,3 +50,29 @@ test "additional random cases" {
   inspect!(@moonbitlang/core/byte.to_uint64(b'\x64'), content="100")
   inspect!(@moonbitlang/core/byte.to_uint64(b'\x99'), content="153")
 }
+
+///|
+test "count_ones max_value" {
+  let b = b'\xFF'
+  inspect!(b.count_ones(), content="8")
+}
+
+///|
+test "count_ones min_value" {
+  let b = b'\x00'
+  inspect!(b.count_ones(), content="0")
+}
+
+///|
+test "count_ones random cases" {
+  inspect!(b'\x00'.count_ones(), content="0")
+  inspect!(b'\x01'.count_ones(), content="1")
+  inspect!(b'\x03'.count_ones(), content="2")
+  inspect!(b'\x05'.count_ones(), content="2")
+  inspect!(b'\x0F'.count_ones(), content="4")
+  inspect!(b'\x4F'.count_ones(), content="5")
+  inspect!(b'\x3F'.count_ones(), content="6")
+  inspect!(b'\x7F'.count_ones(), content="7")
+  inspect!(b'\x5F'.count_ones(), content="6")
+  inspect!(b'\xFF'.count_ones(), content="8")
+}

--- a/byte/byte_test.mbt
+++ b/byte/byte_test.mbt
@@ -52,27 +52,27 @@ test "additional random cases" {
 }
 
 ///|
-test "count_ones max_value" {
+test "popcnt max_value" {
   let b = b'\xFF'
-  inspect!(b.count_ones(), content="8")
+  inspect!(b.popcnt(), content="8")
 }
 
 ///|
-test "count_ones min_value" {
+test "popcnt min_value" {
   let b = b'\x00'
-  inspect!(b.count_ones(), content="0")
+  inspect!(b.popcnt(), content="0")
 }
 
 ///|
-test "count_ones random cases" {
-  inspect!(b'\x00'.count_ones(), content="0")
-  inspect!(b'\x01'.count_ones(), content="1")
-  inspect!(b'\x03'.count_ones(), content="2")
-  inspect!(b'\x05'.count_ones(), content="2")
-  inspect!(b'\x0F'.count_ones(), content="4")
-  inspect!(b'\x4F'.count_ones(), content="5")
-  inspect!(b'\x3F'.count_ones(), content="6")
-  inspect!(b'\x7F'.count_ones(), content="7")
-  inspect!(b'\x5F'.count_ones(), content="6")
-  inspect!(b'\xFF'.count_ones(), content="8")
+test "popcnt random cases" {
+  inspect!(b'\x00'.popcnt(), content="0")
+  inspect!(b'\x01'.popcnt(), content="1")
+  inspect!(b'\x03'.popcnt(), content="2")
+  inspect!(b'\x05'.popcnt(), content="2")
+  inspect!(b'\x0F'.popcnt(), content="4")
+  inspect!(b'\x4F'.popcnt(), content="5")
+  inspect!(b'\x3F'.popcnt(), content="6")
+  inspect!(b'\x7F'.popcnt(), content="7")
+  inspect!(b'\x5F'.popcnt(), content="6")
+  inspect!(b'\xFF'.popcnt(), content="8")
 }


### PR DESCRIPTION
Byte is widely used in files, protocols, and data structures. Counting the number of 1-bits in a byte is a common requirement in many scenarios where bitwise operations or bit statistics are needed, and similar functions are also available in the standard libraries of other programming languages.


[Rust count_ones](https://doc.rust-lang.org/std/primitive.u8.html#method.count_ones)
[C++ popcount](https://en.cppreference.com/w/cpp/numeric/popcount)