### PR TITLE
add json_path to json and more tests for list

### DIFF
--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub(all) type! JsonDecodeError (JsonPath, String) derive(Eq, Show)
+pub(all) type! JsonDecodeError (JsonPath, String) derive(Eq, Show, ToJson)
 
 ///|
 /// Trait for types that can be converted from `Json`

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -39,6 +39,7 @@ fn value(Json, String) -> Json?
 pub(all) type! JsonDecodeError (JsonPath, String)
 impl Eq for JsonDecodeError
 impl Show for JsonDecodeError
+impl ToJson for JsonDecodeError
 
 type JsonPath
 impl JsonPath {
@@ -47,6 +48,7 @@ impl JsonPath {
 }
 impl Eq for JsonPath
 impl Show for JsonPath
+impl ToJson for JsonPath
 
 pub(all) type! ParseError {
   InvalidChar(Position, Char)

--- a/json/json_path.mbt
+++ b/json/json_path.mbt
@@ -45,6 +45,11 @@ pub impl Show for JsonPath with output(self, logger) {
 }
 
 ///|
+pub impl ToJson for JsonPath with to_json(self) {
+  String(self.to_string())
+}
+
+///|
 test "show JsonPath" {
   let path = Key(Index(Root, index=0), key="foo")
   @builtin.inspect!(path, content="$[0].foo")

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -36,6 +36,11 @@ pub fn prepend[A](self : T[A], head : A) -> T[A] {
 }
 
 ///|
+pub fn add[A](self : T[A], head : A) -> T[A] {
+  More(head, tail=self)
+}
+
+///|
 pub impl[A : Show] Show for T[A] with output(xs, logger) {
   logger.write_iter(xs.iter(), prefix="@list.of([", suffix="])")
 }
@@ -126,9 +131,11 @@ pub fn each[A](self : T[A], f : (A) -> Unit) -> Unit {
 /// # Example
 ///
 /// ```
-/// let arr = []
-/// @list.of([1, 2, 3, 4, 5]).eachi(fn(i, x) { arr.push("(\{i},\{x})") })
-/// assert_eq!(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
+/// test {
+///   let arr = []
+///   @list.of([1, 2, 3, 4, 5]).eachi(fn(i, x) { arr.push("(\{i},\{x})") })
+///   assert_eq!(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
+/// }
 /// ```
 pub fn eachi[A](self : T[A], f : (Int, A) -> Unit) -> Unit {
   loop self, 0 {

--- a/list/list.mbti
+++ b/list/list.mbti
@@ -6,6 +6,8 @@ import(
 )
 
 // Values
+fn add[A](T[A], A) -> T[A]
+
 fn all[A](T[A], (A) -> Bool) -> Bool
 
 fn any[A](T[A], (A) -> Bool) -> Bool
@@ -148,6 +150,7 @@ pub enum T[A] {
   More(A, mut tail~ : T[A])
 }
 impl T {
+  add[A](Self[A], A) -> Self[A]
   all[A](Self[A], (A) -> Bool) -> Bool
   any[A](Self[A], (A) -> Bool) -> Bool
   concat[A](Self[A], Self[A]) -> Self[A]

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -594,6 +594,34 @@ test "List::from_json" {
 }
 
 ///|
+test "to_json/from_json" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  let json_expected : Json = [1, 2, 3, 4, 5]
+  @json.inspect!(list, content=json_expected)
+  let list2 : @list.T[Int] = @json.from_json!(json_expected)
+  @json.inspect!(list2, content=json_expected)
+  let v : Result[@list.T[Int], @json.JsonDecodeError] = @json.from_json?({
+    "a": 1,
+  })
+  @json.inspect!(v, content={
+    "Err": {
+      "$tag": "JsonDecodeError",
+      "0": ["$", "@list.from_json: expected array"],
+    },
+  })
+  let v2 : @list.T[Int] = @list.from_json!([1, 2, 3, 4])
+  @json.inspect!(v2, content=[1, 2, 3, 4])
+}
+
+///|
+test "eachi" {
+  let list = @list.of([1, 2, 3, 4, 5])
+  let mut acc = 0
+  list.eachi(fn(i, x) { acc += x * i })
+  assert_eq!(acc, 40)
+}
+
+///|
 test "List::head_exn with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
   let head = @list.head(list)


### PR DESCRIPTION
- **use loop with stack**
- **fix: reorder parameters in `fold_with_key` function signature for consistency**
- **add more tests coverage for list**
- **feat: implement ToJson trait for JsonDecodeError and JsonPath**
