### PR TITLE
Rename `elems` to `values` in immut/sorted_map and hash_map

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -348,8 +348,15 @@ pub fn[K, V] keys(self : T[K, V]) -> Iter[K] {
 
 ///|
 /// Returns all values of the map
-pub fn[K, V] elems(self : T[K, V]) -> Iter[V] {
+pub fn[K, V] values(self : T[K, V]) -> Iter[V] {
   self.iter().map(fn { (_, v) => v })
+}
+
+///|
+#deprecated("Use `values` instead")
+#coverage.skip
+pub fn[K, V] elems(self : T[K, V]) -> Iter[V] {
+  self.values()
 }
 
 ///|

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -73,12 +73,12 @@ test "keys" {
 }
 
 ///|
-test "HAMT::elems" {
+test "HAMT::values" {
   let m = @hashmap.of([(1, "one"), (2, "two")])
-  let elems = m.elems()
-  assert_eq(elems.contains("one"), true)
-  assert_eq(elems.contains("two"), true)
-  assert_eq(elems.contains("three"), false)
+  let values = m.values()
+  assert_eq(values.contains("one"), true)
+  assert_eq(values.contains("two"), true)
+  assert_eq(values.contains("three"), false)
 }
 
 ///|

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -11,6 +11,7 @@ fn[K : Eq + Hash, V] contains(T[K, V], K) -> Bool
 
 fn[K, V] each(T[K, V], (K, V) -> Unit) -> Unit
 
+#deprecated
 fn[K, V] elems(T[K, V]) -> Iter[V]
 
 fn[K : Eq + Hash, V] filter(T[K, V], (V) -> Bool) -> T[K, V]
@@ -55,12 +56,15 @@ fn[K, V] to_array(T[K, V]) -> Array[(K, V)]
 
 fn[K : Eq + Hash, V] union(T[K, V], T[K, V]) -> T[K, V]
 
+fn[K, V] values(T[K, V]) -> Iter[V]
+
 // Types and methods
 type T[K, V]
 impl T {
   add[K : Eq + Hash, V](Self[K, V], K, V) -> Self[K, V]
   contains[K : Eq + Hash, V](Self[K, V], K) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
+  #deprecated
   elems[K, V](Self[K, V]) -> Iter[V]
   filter[K : Eq + Hash, V](Self[K, V], (V) -> Bool) -> Self[K, V]
   #deprecated
@@ -79,6 +83,7 @@ impl T {
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
   union[K : Eq + Hash, V](Self[K, V], Self[K, V]) -> Self[K, V]
+  values[K, V](Self[K, V]) -> Iter[V]
 }
 impl[K : Eq + Hash, V : Eq] Eq for T[K, V]
 impl[K : Hash, V : Hash] Hash for T[K, V]

--- a/immut/sorted_map/README.mbt.md
+++ b/immut/sorted_map/README.mbt.md
@@ -23,7 +23,7 @@ Also, you can construct it from an array using `of()` or `from_array()`.
 ```moonbit
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
-  assert_eq(map.elems(), [1, 2, 3])
+  assert_eq(map.values().collect(), [1, 2, 3])
   assert_eq(map.keys(), ["a", "b", "c"])
 }
 ```
@@ -106,9 +106,9 @@ Use `map()` or `map_with_key()` to map a function over all values.
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
   let map = map.map(fn(v) { v + 1 })
-  assert_eq(map.elems(), [2, 3, 4])
+  assert_eq(map.values().collect(), [2, 3, 4])
   let map = map.map_with_key(fn(_k, v) { v + 1 })
-  assert_eq(map.elems(), [3, 4, 5])
+  assert_eq(map.values().collect(), [3, 4, 5])
 }
 ```
 
@@ -130,23 +130,23 @@ Use `filter()` or `filter_with_key()` to filter all keys/values that satisfy the
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
   let map = map.filter(fn (v) { v > 1 })
-  assert_eq(map.elems(), [2, 3])
+  assert_eq(map.values().collect(), [2, 3])
   assert_eq(map.keys(), ["b", "c"])
   let map = map.filter_with_key(fn (k, v) { k > "a" && v > 1 })
-  assert_eq(map.elems(), [2, 3])
+  assert_eq(map.values().collect(), [2, 3])
   assert_eq(map.keys(), ["b", "c"])
 }
 ```
 
 ## Conversion
 
-Use `elems()` to get all values in ascending order of their keys.
+Use `values()` to get all values in ascending order of their keys.
 
 ```moonbit
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
-  let elems = map.elems() // [1, 2, 3]
-  assert_eq(elems, [1, 2, 3])
+  let values = map.values()
+  assert_eq(values.collect(), [1, 2, 3])
 }
 ```
 

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -113,9 +113,9 @@ test "keys" {
 }
 
 ///|
-test "elems" {
+test "values" {
   let m = @sorted_map.of([(1, "one"), (2, "two"), (3, "three")])
-  assert_eq(m.elems(), ["one", "two", "three"])
+  assert_eq(m.values().collect(), ["one", "two", "three"])
 }
 
 ///|

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -14,6 +14,7 @@ fn[K, V] each(T[K, V], (K, V) -> Unit) -> Unit
 
 fn[K, V] eachi(T[K, V], (Int, K, V) -> Unit) -> Unit
 
+#deprecated
 fn[K, V] elems(T[K, V]) -> Array[V]
 
 fn[K : Compare, V] filter(T[K, V], (V) -> Bool) -> T[K, V]
@@ -69,6 +70,8 @@ fn[K, V] to_array(T[K, V]) -> Array[(K, V)]
 
 fn[K : Show, V : ToJson] to_json(T[K, V]) -> Json
 
+fn[K, V] values(T[K, V]) -> Iter[V]
+
 // Types and methods
 type T[K, V]
 impl T {
@@ -76,6 +79,7 @@ impl T {
   contains[K : Compare, V](Self[K, V], K) -> Bool
   each[K, V](Self[K, V], (K, V) -> Unit) -> Unit
   eachi[K, V](Self[K, V], (Int, K, V) -> Unit) -> Unit
+  #deprecated
   elems[K, V](Self[K, V]) -> Array[V]
   #deprecated
   empty[K, V]() -> Self[K, V]
@@ -113,6 +117,7 @@ impl T {
   size[K, V](Self[K, V]) -> Int
   to_array[K, V](Self[K, V]) -> Array[(K, V)]
   to_json[K : Show, V : ToJson](Self[K, V]) -> Json
+  values[K, V](Self[K, V]) -> Iter[V]
 }
 impl[K : Compare, V : Compare] Compare for T[K, V]
 impl[K, V] Default for T[K, V]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -271,8 +271,15 @@ pub fn[K, V] keys(self : T[K, V]) -> Array[K] {
 
 ///|
 /// Return all elements of the map in the ascending order of their keys.
+pub fn[K, V] values(self : T[K, V]) -> Iter[V] {
+  self.iter().map(fn { (_, v) => v })
+}
+
+///|
+#deprecated("Use `values` instead")
+#coverage.skip
 pub fn[K, V] elems(self : T[K, V]) -> Array[V] {
-  self.iter().map(fn { (_, v) => v }).collect()
+  self.values().collect()
 }
 
 ///|


### PR DESCRIPTION
+ Rename `elems()` to `values()` for consistency with `Map`.  
+ `(key, value)` pairs are called elements, but the second item is specifically called value
+ Other languages (e.g., Rust/JS/Python) also use `values()`

​​Note:​​
This PR is based on #2123 - If you want to merge this, please merge #2123 first