### PR TITLE
perf(arrayview): use `for` in `to_array`

### DIFF
--- a/array/view.mbt
+++ b/array/view.mbt
@@ -358,7 +358,9 @@ pub fn View::to_array[T](self : View[T]) -> Array[T] {
     []
   } else {
     let arr = Array::make(len, self[0])
-    self.iter().eachi(fn(i, v) { arr[i] = v })
+    for i, v in self {
+      arr[i] = v
+    }
     arr
   }
 }


### PR DESCRIPTION
## bench

```moonbit
test (b : @bench.T) {
  let a = (1).until(1000).to_array()[:]
  fn old() {
    b.keep(a.to_array())
  }

  fn new() {
    b.keep(a.to_array2())
  }

  b.bench(name="old", old)
  b.bench(name="new", new)
}
```

run `moon bench -p moonbitlang/core/mytest -f 1.mbt -i 0 --target all`:

```
name time (mean ± σ)         range (min … max) 
old   11.39 µs ±   1.31 µs     9.63 µs …  13.55 µs  in 10 ×   8578 runs
new    6.70 µs ±   0.71 µs     6.02 µs …   7.73 µs  in 10 ×  11768 runs
Total tests: 1, passed: 1, failed: 0. [js]
bench moonbitlang/core/mytest/1.mbt::0
name time (mean ± σ)         range (min … max) 
old    6.40 µs ±   1.16 µs     4.99 µs …   7.96 µs  in 10 ×  19649 runs
new    1.90 µs ±   0.18 µs     1.68 µs …   2.25 µs  in 10 ×  49227 runs
Total tests: 1, passed: 1, failed: 0. [wasm-gc]
bench moonbitlang/core/mytest/1.mbt::0
name time (mean ± σ)         range (min … max) 
old   43.55 µs ±   3.60 µs    39.06 µs …  48.14 µs  in 10 ×   2638 runs
new   29.46 µs ±   1.89 µs    27.27 µs …  32.09 µs  in 10 ×   3537 runs
Total tests: 1, passed: 1, failed: 0. [wasm]
```