### PR TITLE
fix: docs in Array::blit_to

### DIFF
--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -137,7 +137,7 @@ pub fn Array::unsafe_blit_fixed[A](
 /// * `len` is negative
 /// * `src_offset` is negative
 /// * `dst_offset` is negative
-/// * `dst_offset + len` exceeds the length of destination array
+/// * `dst_offset` exceeds the length of destination array
 /// * `src_offset + len` exceeds the length of source array
 pub fn Array::blit_to[A](
   self : Array[A],


### PR DESCRIPTION
if `dst_offset + len > dst.length()`, dest array can automatically grow.

Warning: if `dst_offset > dst_length()`, use `unsafe_grow_to_length` would create uninitialized element.