### PR TITLE
perf(sorted_map/set): use tail call and reduce closure allocation in `iter`

### DIFF
--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -223,38 +223,38 @@ pub fn from_array[K : Compare, V](array : Array[(K, V)]) -> T[K, V] {
 ///|
 pub fn iter[K, V](self : T[K, V]) -> Iter[(K, V)] {
   Iter::new(fn(yield_) {
-    match self {
+    fn go {
       Empty => IterContinue
       Tree(k, value~, l, r, ..) =>
-        if l.iter().run(yield_) == IterEnd {
+        if go(l) is IterEnd {
           IterEnd
-        } else if yield_((k, value)) == IterEnd {
-          IterEnd
-        } else if r.iter().run(yield_) == IterEnd {
+        } else if yield_((k, value)) is IterEnd {
           IterEnd
         } else {
-          IterContinue
+          go(r)
         }
     }
+
+    go(self)
   })
 }
 
 ///|
 pub fn iter2[K, V](self : T[K, V]) -> Iter2[K, V] {
   Iter2::new(fn(yield_) {
-    match self {
+    fn go {
       Empty => IterContinue
       Tree(k, value~, l, r, ..) =>
-        if l.iter2().run(yield_) == IterEnd {
+        if go(l) is IterEnd {
           IterEnd
-        } else if yield_(k, value) == IterEnd {
-          IterEnd
-        } else if r.iter2().run(yield_) == IterEnd {
+        } else if yield_(k, value) is IterEnd {
           IterEnd
         } else {
-          IterContinue
+          go(r)
         }
     }
+
+    go(self)
   })
 }
 

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -19,19 +19,19 @@
 ///|
 pub fn iter[A](self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
-    match self {
+    fn go {
       Empty => IterContinue
       Node(left~, right~, value~, ..) =>
-        if left.iter().run(yield_) == IterEnd {
-          return IterEnd
-        } else if yield_(value) == IterEnd {
-          return IterEnd
-        } else if right.iter().run(yield_) == IterEnd {
-          return IterEnd
+        if go(left) is IterEnd {
+          IterEnd
+        } else if yield_(value) is IterEnd {
+          IterEnd
         } else {
-          return IterContinue
+          go(right)
         }
     }
+
+    go(self)
   })
 }
 

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -226,46 +226,31 @@ pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickc
   @quickcheck.Arbitrary::arbitrary(size, rs) |> from_iter
 }
 
-///|Returns a new array of key-value pairs that are within the specified range [low, high).
-pub fn range[K : Compare, V](self : T[K, V], low : K, high : K) -> Iter2[K, V] {
-  range_aux(self.root, low, high)
-}
-
 ///|Returns a new array of key-value pairs that are within the specified range [low, high].
-fn range_aux[K : Compare, V](
-  node : Node[K, V]?,
-  low : K,
-  high : K
-) -> Iter2[K, V] {
+pub fn range[K : Compare, V](self : T[K, V], low : K, high : K) -> Iter2[K, V] {
   Iter2::new(fn(yield_) {
-    match node {
-      None => IterContinue
-      Some(node) => {
-        let cmp_key_low = node.key.compare(low)
-        let cmp_key_high = node.key.compare(high)
-        if cmp_key_low > 0 {
-          // we should go left
-          guard range_aux(node.left, low, high).run(yield_) is IterContinue else {
-            return IterEnd
+    fn go(x : Node[K, V]?) {
+      match x {
+        None => IterContinue
+        Some({ left, right, key, value, .. }) => {
+          let cmp_key_low = key.compare(low)
+          let cmp_key_high = key.compare(high)
+          if cmp_key_low > 0 && go(left) is IterEnd {
+            IterEnd
+          } else if cmp_key_low >= 0 &&
+            cmp_key_high <= 0 &&
+            yield_(key, value) is IterEnd {
+            IterEnd
+          } else if cmp_key_high < 0 {
+            go(right)
+          } else {
+            IterContinue
           }
-
         }
-        if cmp_key_low >= 0 && cmp_key_high <= 0 {
-          // we should yield this node
-          guard yield_(node.key, node.value) is IterContinue else {
-            return IterEnd
-          }
-
-        }
-        if cmp_key_high < 0 {
-          guard range_aux(node.right, low, high).run(yield_) is IterContinue else {
-            return IterEnd
-          }
-
-        }
-        IterContinue
       }
     }
+
+    go(self.root)
   })
 }
 

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -171,49 +171,43 @@ pub fn to_array[K, V](self : T[K, V]) -> Array[(K, V)] {
 
 ///|
 pub fn iter[K, V](self : T[K, V]) -> Iter[(K, V)] {
-  iter_aux(self.root)
-}
-
-///|
-fn iter_aux[K, V](node : Node[K, V]?) -> Iter[(K, V)] {
   Iter::new(fn(yield_) {
-    match node {
-      None => IterContinue
-      Some(node) =>
-        if iter_aux(node.left).run(yield_) == IterEnd {
-          return IterEnd
-        } else if yield_((node.key, node.value)) == IterEnd {
-          return IterEnd
-        } else if iter_aux(node.right).run(yield_) == IterEnd {
-          return IterEnd
-        } else {
-          IterContinue
-        }
+    fn go(x : Node[K, V]?) {
+      match x {
+        None => IterContinue
+        Some({ left, right, key, value, .. }) =>
+          if go(left) is IterEnd {
+            IterEnd
+          } else if yield_((key, value)) is IterEnd {
+            IterEnd
+          } else {
+            go(right)
+          }
+      }
     }
+
+    go(self.root)
   })
 }
 
 ///|
 pub fn iter2[K, V](self : T[K, V]) -> Iter2[K, V] {
-  iter_aux2(self.root)
-}
-
-///|
-fn iter_aux2[K, V](node : Node[K, V]?) -> Iter2[K, V] {
   Iter2::new(fn(yield_) {
-    match node {
-      None => IterContinue
-      Some(node) =>
-        if iter_aux2(node.left).run(yield_) == IterEnd {
-          return IterEnd
-        } else if yield_(node.key, node.value) == IterEnd {
-          return IterEnd
-        } else if iter_aux2(node.right).run(yield_) == IterEnd {
-          return IterEnd
-        } else {
-          IterContinue
-        }
+    fn go(x : Node[K, V]?) {
+      match x {
+        None => IterContinue
+        Some({ left, right, key, value, .. }) =>
+          if go(left) is IterEnd {
+            IterEnd
+          } else if yield_(key, value) is IterEnd {
+            IterEnd
+          } else {
+            go(right)
+          }
+      }
     }
+
+    go(self.root)
   })
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -433,22 +433,6 @@ pub fn iter[V](self : T[V]) -> Iter[V] {
 }
 
 ///|
-fn Node::iter[A](self : Node[A]) -> Iter[A] {
-  Iter::new(fn(yield_) {
-    if self.left is Some(l) {
-      guard l.iter().run(yield_) is IterContinue else { return IterEnd }
-
-    }
-    guard yield_(self.value) is IterContinue else { return IterEnd }
-    if self.right is Some(r) {
-      guard r.iter().run(yield_) is IterContinue else { return IterEnd }
-
-    }
-    IterContinue
-  })
-}
-
-///|
 pub fn from_iter[V : Compare](iter : Iter[V]) -> T[V] {
   let s = new()
   iter.each(fn(e) { s.add(e) })
@@ -458,10 +442,7 @@ pub fn from_iter[V : Compare](iter : Iter[V]) -> T[V] {
 ///|
 /// Converts the set to string.
 pub impl[V : Show] Show for T[V] with output(self, logger) {
-  match self.root {
-    None => logger.write_string("@sorted_set.of([])")
-    Some(node) => Show::output(node, logger)
-  }
+  logger.write_iter(self.iter(), prefix="@sorted_set.of([", suffix="])")
 }
 
 ///|
@@ -474,7 +455,8 @@ pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X] wit
 
 ///|
 impl[T : Show] Show for Node[T] with output(self, logger) {
-  logger.write_iter(self.iter(), prefix="@sorted_set.of([", suffix="])")
+  let x = { root: Some(self), size: 0 } // Hack for test
+  logger.write_iter(x.iter())
 }
 
 ///|
@@ -767,17 +749,17 @@ test "union" {
 ///|
 test "split" {
   let (l, r) = split(from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 5)
-  inspect!(l, content="Some(@sorted_set.of([1, 2, 3, 4]))")
-  inspect!(r, content="Some(@sorted_set.of([6, 7, 8, 9]))")
+  inspect!(l, content="Some([1, 2, 3, 4])")
+  inspect!(r, content="Some([6, 7, 8, 9])")
   let (l, r) = split(from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 0)
   inspect!(l, content="None")
-  inspect!(r, content="Some(@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9]))")
+  inspect!(r, content="Some([1, 2, 3, 4, 5, 6, 7, 8, 9])")
   let (l, r) = split(from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 10)
-  inspect!(l, content="Some(@sorted_set.of([1, 2, 3, 4, 5, 6, 7, 8, 9]))")
+  inspect!(l, content="Some([1, 2, 3, 4, 5, 6, 7, 8, 9])")
   inspect!(r, content="None")
   let (l, r) = split(from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).root, 4)
-  inspect!(l, content="Some(@sorted_set.of([1, 2, 3]))")
-  inspect!(r, content="Some(@sorted_set.of([5, 6, 7, 8, 9]))")
+  inspect!(l, content="Some([1, 2, 3])")
+  inspect!(r, content="Some([5, 6, 7, 8, 9])")
   let (l, r) = split(from_array([]).root, 7)
   inspect!(l, content="None")
   inspect!(r, content="None")
@@ -794,11 +776,11 @@ test "split" {
   )
   inspect!(
     l,
-    content="Some(@sorted_set.of([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]))",
+    content="Some([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49])",
   )
   inspect!(
     r,
-    content="Some(@sorted_set.of([51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]))",
+    content="Some([51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100])",
   )
 }
 
@@ -808,29 +790,20 @@ test "join" {
   let r = from_array([27, 28, 40, 35, 33])
   inspect!(
     join(l.root, 26, r.root),
-    content="@sorted_set.of([1, 6, 8, 11, 13, 15, 17, 25, 26, 27, 28, 33, 35, 40])",
+    content="[1, 6, 8, 11, 13, 15, 17, 25, 26, 27, 28, 33, 35, 40]",
   )
   let l = from_array([3, 2, 5, 1, 4])
   let r = from_array([7])
-  inspect!(
-    join(l.root, 6, r.root),
-    content="@sorted_set.of([1, 2, 3, 4, 5, 6, 7])",
-  )
+  inspect!(join(l.root, 6, r.root), content="[1, 2, 3, 4, 5, 6, 7]")
   let l = from_array([3, 2, 5, 1, 4])
   let r = from_array([])
-  inspect!(
-    join(l.root, 6, r.root),
-    content="@sorted_set.of([1, 2, 3, 4, 5, 6])",
-  )
+  inspect!(join(l.root, 6, r.root), content="[1, 2, 3, 4, 5, 6]")
   let l = from_array([])
   let r = from_array([])
-  inspect!(join(l.root, 6, r.root), content="@sorted_set.of([6])")
+  inspect!(join(l.root, 6, r.root), content="[6]")
   let l = from_array([])
   let r = from_array([7, 8, 9, 10, 11, 12])
-  inspect!(
-    join(l.root, 6, r.root),
-    content="@sorted_set.of([6, 7, 8, 9, 10, 11, 12])",
-  )
+  inspect!(join(l.root, 6, r.root), content="[6, 7, 8, 9, 10, 11, 12]")
 }
 
 ///|

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -414,10 +414,21 @@ pub fn to_array[V](self : T[V]) -> Array[V] {
 /// Returns a iterator.
 pub fn iter[V](self : T[V]) -> Iter[V] {
   Iter::new(fn(yield_) {
-    match self.root {
-      None => IterContinue
-      Some(root) => root.iter().run(yield_)
+    fn go(x : Node[V]?) {
+      match x {
+        None => IterContinue
+        Some({ left, right, value, .. }) =>
+          if go(left) is IterEnd {
+            IterEnd
+          } else if yield_(value) is IterEnd {
+            IterEnd
+          } else {
+            go(right)
+          }
+      }
     }
+
+    go(self.root)
   })
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -461,36 +461,29 @@ impl[T : Show] Show for Node[T] with output(self, logger) {
 
 ///|
 pub fn range[V : Compare](self : T[V], low : V, high : V) -> Iter[V] {
-  range_aux(self.root, low, high)
-}
-
-///|
-fn range_aux[V : Compare](root : Node[V]?, low : V, high : V) -> Iter[V] {
   Iter::new(fn(yield_) {
-    match root {
-      None => IterContinue
-      Some(node) => {
-        let cmp_key_low = node.value.compare(low)
-        let cmp_key_high = node.value.compare(high)
-        if cmp_key_low > 0 {
-          guard range_aux(node.left, low, high).run(yield_) is IterContinue else {
-            return IterEnd
+    fn go(x : Node[V]?) {
+      match x {
+        None => IterContinue
+        Some({ left, right, value, .. }) => {
+          let cmp_key_low = value.compare(low)
+          let cmp_key_high = value.compare(high)
+          if cmp_key_low > 0 && go(left) is IterEnd {
+            IterEnd
+          } else if cmp_key_low >= 0 &&
+            cmp_key_high <= 0 &&
+            yield_(value) is IterEnd {
+            IterEnd
+          } else if cmp_key_high < 0 {
+            go(right)
+          } else {
+            IterContinue
           }
-
         }
-        if cmp_key_low >= 0 && cmp_key_high <= 0 {
-          guard yield_(node.value) is IterContinue else { return IterEnd }
-
-        }
-        if cmp_key_high < 0 {
-          guard range_aux(node.right, low, high).run(yield_) is IterContinue else {
-            return IterEnd
-          }
-
-        }
-        IterContinue
       }
     }
+
+    go(self.root)
   })
 }
 


### PR DESCRIPTION
## bench

```moonbit
test (b : @bench.T) {
  let a : @sorted_set.T[Int] = @quickcheck.samples(1000).last().unwrap()
  fn old() {
    b.keep(a.iter().count())
  }

  fn new() {
    b.keep(a.iter_new().count())
  }

  b.bench(name="old", old)
  b.bench(name="new", new)
}
```

---

in `sorted_set`:

```
// bench moonbitlang/core/mytest/1.mbt::0
// name time (mean ± σ)         range (min … max)
// old   19.39 µs ±   1.62 µs    17.67 µs …  22.35 µs  in 10 ×   5262 runs
// new    9.70 µs ±   0.91 µs     8.48 µs …  11.02 µs  in 10 ×  10418 runs
// Total tests: 1, passed: 1, failed: 0. [wasm]
// bench moonbitlang/core/mytest/1.mbt::0
// name time (mean ± σ)         range (min … max)
// old   10.85 µs ±   0.61 µs     9.86 µs …  11.94 µs  in 10 ×  10485 runs
// new    5.26 µs ±   0.51 µs     4.32 µs …   6.02 µs  in 10 ×  21438 runs
// Total tests: 1, passed: 1, failed: 0. [js]
// bench moonbitlang/core/mytest/1.mbt::0
// name time (mean ± σ)         range (min … max)
// old    4.54 µs ±   0.21 µs     4.10 µs …   4.78 µs  in 10 ×  19873 runs
// new    2.01 µs ±   0.33 µs     1.59 µs …   2.54 µs  in 10 ×  64080 runs
// Total tests: 1, passed: 1, failed: 0. [wasm-gc]
```

---

in `immut/sorted_set`:

```
bench moonbitlang/core/mytest/1.mbt::0
name time (mean ± σ)         range (min … max)
old    8.75 µs ±   0.76 µs     7.61 µs …   9.88 µs  in 10 ×  12855 runs
new    2.62 µs ±   0.28 µs     2.31 µs …   3.09 µs  in 10 ×  32289 runs
Total tests: 1, passed: 1, failed: 0. [wasm-gc]
bench moonbitlang/core/mytest/1.mbt::0
name time (mean ± σ)         range (min … max)
old   17.24 µs ±   1.61 µs    14.46 µs …  18.94 µs  in 10 ×   7324 runs
new    5.70 µs ±   1.01 µs     4.49 µs …   7.48 µs  in 10 ×  18107 runs
Total tests: 1, passed: 1, failed: 0. [js]
bench moonbitlang/core/mytest/1.mbt::0
name time (mean ± σ)         range (min … max)
old   35.73 µs ±   4.30 µs    30.17 µs …  42.06 µs  in 10 ×   2590 runs
new   11.49 µs ±   0.76 µs    10.48 µs …  12.50 µs  in 10 ×   8856 runs
Total tests: 1, passed: 1, failed: 0. [wasm]
```