### PR TITLE
remove usage of method as function

### DIFF
--- a/bool/README.mbt.md
+++ b/bool/README.mbt.md
@@ -8,10 +8,6 @@ The package allows converting boolean values to various integer types. `true` is
 
 ```moonbit
 test "bool to integer conversions" {
-  // Direct function calls
-  inspect(@bool.to_int(true), content="1")
-  inspect(@bool.to_int(false), content="0")
-
   // Method syntax
   inspect(true.to_int(), content="1")
   inspect(false.to_int(), content="0")

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -132,8 +132,8 @@ pub impl Compare for Byte with compare(self : Byte, that : Byte) -> Int {
 }
 
 ///|
-fn alphabet(self : Int) -> String {
-  match self {
+fn alphabet(x : Int) -> String {
+  match x {
     0 => "0"
     1 => "1"
     2 => "2"

--- a/byte/README.mbt.md
+++ b/byte/README.mbt.md
@@ -22,7 +22,7 @@ test "byte conversion" {
   let byte = b'A'
   inspect(byte.to_uint64(), content="65")
   let byte = b' '
-  inspect(@byte.to_uint64(byte), content="32")
+  inspect(byte.to_uint64(), content="32")
 }
 ```
 

--- a/byte/byte_test.mbt
+++ b/byte/byte_test.mbt
@@ -30,25 +30,25 @@ test "int to byte" {
 
 ///|
 test "grouped test for boundary cases" {
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x00'), content="0")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\xFF'), content="255")
+  inspect(b'\x00'.to_uint64(), content="0")
+  inspect(b'\xFF'.to_uint64(), content="255")
 }
 
 ///|
 test "grouped test for random cases" {
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x10'), content="16")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x2A'), content="42")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x7F'), content="127")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x80'), content="128")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\xAA'), content="170")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x55'), content="85")
+  inspect(b'\x10'.to_uint64(), content="16")
+  inspect(b'\x2A'.to_uint64(), content="42")
+  inspect(b'\x7F'.to_uint64(), content="127")
+  inspect(b'\x80'.to_uint64(), content="128")
+  inspect(b'\xAA'.to_uint64(), content="170")
+  inspect(b'\x55'.to_uint64(), content="85")
 }
 
 ///|
 test "additional random cases" {
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x3C'), content="60")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x64'), content="100")
-  inspect(@moonbitlang/core/byte.to_uint64(b'\x99'), content="153")
+  inspect(b'\x3C'.to_uint64(), content="60")
+  inspect(b'\x64'.to_uint64(), content="100")
+  inspect(b'\x99'.to_uint64(), content="153")
 }
 
 ///|

--- a/char/README.mbt.md
+++ b/char/README.mbt.md
@@ -9,18 +9,18 @@ Functions for determining if a character belongs to various ASCII categories.
 ```moonbit
 test "ascii classification" {
   // Basic ASCII checks
-  inspect(@char.is_ascii('A'), content="true")
-  inspect(@char.is_ascii('λ'), content="false")
+  inspect('A'.is_ascii(), content="true")
+  inspect('λ'.is_ascii(), content="false")
 
   // Letter classification
-  inspect(@char.is_ascii_alphabetic('Z'), content="true")
-  inspect(@char.is_ascii_alphabetic('1'), content="false")
+  inspect('Z'.is_ascii_alphabetic(), content="true")
+  inspect('1'.is_ascii_alphabetic(), content="false")
 
   // Case classification
-  inspect(@char.is_ascii_uppercase('A'), content="true")
-  inspect(@char.is_ascii_uppercase('a'), content="false")
-  inspect(@char.is_ascii_lowercase('a'), content="true")
-  inspect(@char.is_ascii_lowercase('A'), content="false")
+  inspect('A'.is_ascii_uppercase(), content="true")
+  inspect('a'.is_ascii_uppercase(), content="false")
+  inspect('a'.is_ascii_lowercase(), content="true")
+  inspect('A'.is_ascii_lowercase(), content="false")
 }
 ```
 
@@ -31,24 +31,24 @@ Functions for identifying digits in different number bases.
 ```moonbit
 test "number classification" {
   // Decimal digits
-  inspect(@char.is_ascii_digit('5'), content="true")
-  inspect(@char.is_ascii_digit('x'), content="false")
+  inspect('5'.is_ascii_digit(), content="true")
+  inspect('x'.is_ascii_digit(), content="false")
 
   // Hexadecimal digits
-  inspect(@char.is_ascii_hexdigit('F'), content="true")
-  inspect(@char.is_ascii_hexdigit('G'), content="false")
+  inspect('F'.is_ascii_hexdigit(), content="true")
+  inspect('G'.is_ascii_hexdigit(), content="false")
 
   // Octal digits
-  inspect(@char.is_ascii_octdigit('7'), content="true")
-  inspect(@char.is_ascii_octdigit('8'), content="false")
+  inspect('7'.is_ascii_octdigit(), content="true")
+  inspect('8'.is_ascii_octdigit(), content="false")
 
   // Custom base digits
-  inspect(@char.is_digit('5', 6U), content="true")
-  inspect(@char.is_digit('6', 6U), content="false")
+  inspect('5'.is_digit(6U), content="true")
+  inspect('6'.is_digit(6U), content="false")
 
   // General numeric characters
-  inspect(@char.is_numeric('1'), content="true")
-  inspect(@char.is_numeric('A'), content="false")
+  inspect('1'.is_numeric(), content="true")
+  inspect('A'.is_numeric(), content="false")
 }
 ```
 
@@ -59,17 +59,17 @@ Functions for identifying whitespace, control characters and other special chara
 ```moonbit
 test "special characters" {
   // Whitespace characters
-  inspect(@char.is_ascii_whitespace(' '), content="true")
-  inspect(@char.is_whitespace('\n'), content="true")
+  inspect(' '.is_ascii_whitespace(), content="true")
+  inspect('\n'.is_whitespace(), content="true")
 
   // Control characters
-  inspect(@char.is_ascii_control('\u0000'), content="true")
-  inspect(@char.is_control('\u007F'), content="true")
+  inspect('\u0000'.is_ascii_control(), content="true")
+  inspect('\u007F'.is_control(), content="true")
 
   // Graphic and punctuation characters
-  inspect(@char.is_ascii_graphic('!'), content="true")
-  inspect(@char.is_ascii_graphic(' '), content="false")
-  inspect(@char.is_ascii_punctuation(','), content="true")
+  inspect('!'.is_ascii_graphic(), content="true")
+  inspect(' '.is_ascii_graphic(), content="false")
+  inspect(','.is_ascii_punctuation(), content="true")
 }
 ```
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -352,7 +352,7 @@ pub fn[A] unsafe_pop_front(self : T[A]) -> Unit {
 #deprecated("Use `unsafe_pop_front` instead")
 #coverage.skip
 pub fn[A] pop_front_exn(self : T[A]) -> Unit {
-  unsafe_pop_front(self)
+  self.unsafe_pop_front()
 }
 
 ///|
@@ -409,7 +409,7 @@ pub fn[A] unsafe_pop_back(self : T[A]) -> Unit {
 #deprecated("Use `unsafe_pop_back` instead")
 #coverage.skip
 pub fn[A] pop_back_exn(self : T[A]) -> Unit {
-  unsafe_pop_back(self)
+  self.unsafe_pop_back()
 }
 
 ///|

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -693,7 +693,7 @@ test "test_clone_from" {
         for _idx in 0..<pfu {
           u.push_front(2)
         }
-        let v = @deque.copy(u)
+        let v = u.copy()
         assert_eq!(v, u)
       }
     }

--- a/double/README.mbt.md
+++ b/double/README.mbt.md
@@ -36,8 +36,8 @@ test "basic operations" {
   inspect(@double.trunc(3.7), content="3")
 
   // Sign
-  inspect(@double.signum(-3.14), content="-1")
-  inspect(@double.signum(2.0), content="1")
+  inspect((-3.14).signum(), content="-1")
+  inspect((2.0).signum(), content="1")
 
   // Type conversion
   inspect(@double.from_int(42), content="42")
@@ -113,10 +113,10 @@ Functions for testing special floating-point values and comparing numbers:
 ```moonbit
 test "special value testing" {
   // Testing for special values
-  inspect(@double.is_nan(@double.not_a_number), content="true")
-  inspect(@double.is_inf(@double.infinity), content="true")
-  inspect(@double.is_pos_inf(@double.infinity), content="true")
-  inspect(@double.is_neg_inf(@double.neg_infinity), content="true")
+  inspect(@double.not_a_number.is_nan(), content="true")
+  inspect(@double.infinity.is_inf(), content="true")
+  inspect(@double.infinity.is_pos_inf(), content="true")
+  inspect(@double.neg_infinity.is_neg_inf(), content="true")
 
   // Approximate equality
   let relative_tolerance = 1.e-9

--- a/double/cbrt_js.mbt
+++ b/double/cbrt_js.mbt
@@ -42,4 +42,4 @@
 ///   inspect(@double.neg_infinity, content="-Infinity")
 /// }
 /// ```
-pub fn cbrt(self : Double) -> Double = "Math" "cbrt"
+pub fn Double::cbrt(self : Double) -> Double = "Math" "cbrt"

--- a/double/cbrt_nonjs.mbt
+++ b/double/cbrt_nonjs.mbt
@@ -54,7 +54,7 @@
 ///   inspect(@double.neg_infinity, content="-Infinity")
 /// }
 /// ```
-pub fn cbrt(self : Double) -> Double {
+pub fn Double::cbrt(self : Double) -> Double {
   if self.is_inf() || self.is_nan() || self == 0.0 {
     return self
   }

--- a/double/double.mbt
+++ b/double/double.mbt
@@ -78,7 +78,7 @@ pub fn from_int(i : Int) -> Double {
 ///   inspect(0.0.abs(), content="0")
 /// }
 /// ```
-pub fn abs(self : Double) -> Double = "%f64.abs"
+pub fn Double::abs(self : Double) -> Double = "%f64.abs"
 
 ///|
 /// Returns the sign of the double.
@@ -268,35 +268,35 @@ test "signum" {
 
 ///|
 test "is_nan" {
-  assert_true!(is_nan(not_a_number))
-  assert_false!(is_nan(0.0))
-  assert_false!(is_nan(12345.678))
-  assert_false!(is_nan(infinity))
-  assert_false!(is_nan(neg_infinity))
+  assert_true!(not_a_number.is_nan())
+  assert_false!(0.0.is_nan())
+  assert_false!(12345.678.is_nan())
+  assert_false!(infinity.is_nan())
+  assert_false!(neg_infinity.is_nan())
 }
 
 ///|
 test "is_inf" {
-  assert_true!(is_inf(infinity))
-  assert_true!(is_inf(neg_infinity))
-  assert_false!(is_inf(0.0))
-  assert_false!(is_inf(12345.678))
+  assert_true!(infinity.is_inf())
+  assert_true!(neg_infinity.is_inf())
+  assert_false!(0.0.is_inf())
+  assert_false!(12345.678.is_inf())
 }
 
 ///|
 test "is_pos_inf" {
-  assert_true!(is_pos_inf(infinity))
-  assert_false!(is_pos_inf(neg_infinity))
-  assert_false!(is_pos_inf(0.0))
-  assert_false!(is_pos_inf(12345.678))
+  assert_true!(infinity.is_pos_inf())
+  assert_false!(neg_infinity.is_pos_inf())
+  assert_false!(0.0.is_pos_inf())
+  assert_false!(12345.678.is_pos_inf())
 }
 
 ///|
 test "is_neg_inf" {
-  assert_false!(is_neg_inf(infinity))
-  assert_true!(is_neg_inf(neg_infinity))
-  assert_false!(is_neg_inf(0.0))
-  assert_false!(is_neg_inf(12345.678))
+  assert_false!(infinity.is_neg_inf())
+  assert_true!(neg_infinity.is_neg_inf())
+  assert_false!(0.0.is_neg_inf())
+  assert_false!(12345.678.is_neg_inf())
 }
 
 ///|
@@ -376,7 +376,7 @@ pub impl Show for Double with output(self, logger) {
 ///   inspect(infinity.is_close(infinity), content="true")
 /// }
 /// ```
-pub fn is_close(
+pub fn Double::is_close(
   self : Double,
   other : Double,
   relative_tolerance~ : Double = 1.0e-09,

--- a/double/exp_js.mbt
+++ b/double/exp_js.mbt
@@ -39,7 +39,7 @@
 ///   inspect(not_a_number.exp().is_nan(), content="true")
 /// }
 /// ```
-pub fn exp(self : Double) -> Double = "Math" "exp"
+pub fn Double::exp(self : Double) -> Double = "Math" "exp"
 
 ///|
 /// Calculates exp(x) - 1 accurately even when x is close to zero.
@@ -70,4 +70,4 @@ pub fn exp(self : Double) -> Double = "Math" "exp"
 ///   inspect(@double.neg_infinity.expm1(), content="-1")
 /// }
 /// ```
-pub fn expm1(self : Double) -> Double = "Math" "expm1"
+pub fn Double::expm1(self : Double) -> Double = "Math" "expm1"

--- a/double/exp_nonjs.mbt
+++ b/double/exp_nonjs.mbt
@@ -51,7 +51,7 @@
 ///   inspect(not_a_number.exp().is_nan(), content="true")
 /// }
 /// ```
-pub fn exp(self : Double) -> Double {
+pub fn Double::exp(self : Double) -> Double {
   fn get_high_word(x : Double) -> UInt {
     (x.reinterpret_as_uint64() >> 32).to_uint()
   }
@@ -189,7 +189,7 @@ pub fn exp(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.expm1(), content="-1")
 /// }
 /// ```
-pub fn expm1(self : Double) -> Double {
+pub fn Double::expm1(self : Double) -> Double {
   if self.is_nan() {
     return not_a_number
   }

--- a/double/hyperbolic_js.mbt
+++ b/double/hyperbolic_js.mbt
@@ -41,7 +41,7 @@
 ///   inspect(@double.neg_infinity.sinh(), content="-Infinity")
 /// }
 /// ```
-pub fn sinh(self : Double) -> Double = "Math" "sinh"
+pub fn Double::sinh(self : Double) -> Double = "Math" "sinh"
 
 ///|
 /// Calculates the hyperbolic cosine of a number.
@@ -72,7 +72,7 @@ pub fn sinh(self : Double) -> Double = "Math" "sinh"
 ///   inspect(@double.neg_infinity.cosh(), content="Infinity")
 /// }
 /// ```
-pub fn cosh(self : Double) -> Double = "Math" "cosh"
+pub fn Double::cosh(self : Double) -> Double = "Math" "cosh"
 
 ///|
 /// Calculates the hyperbolic tangent of a number.
@@ -104,7 +104,7 @@ pub fn cosh(self : Double) -> Double = "Math" "cosh"
 ///   inspect(@double.neg_infinity.tanh(), content="-1")
 /// }
 /// ```
-pub fn tanh(self : Double) -> Double = "Math" "tanh"
+pub fn Double::tanh(self : Double) -> Double = "Math" "tanh"
 
 ///|
 /// Calculates the inverse hyperbolic sine of a number.
@@ -135,7 +135,7 @@ pub fn tanh(self : Double) -> Double = "Math" "tanh"
 ///   inspect(@double.neg_infinity.asinh(), content="-Infinity")
 /// }
 /// ```
-pub fn asinh(self : Double) -> Double = "Math" "asinh"
+pub fn Double::asinh(self : Double) -> Double = "Math" "asinh"
 
 ///|
 /// Calculates the inverse hyperbolic cosine of a number.
@@ -167,7 +167,7 @@ pub fn asinh(self : Double) -> Double = "Math" "asinh"
 ///   inspect(@double.neg_infinity.acosh(), content="NaN")
 /// }
 /// ```
-pub fn acosh(self : Double) -> Double = "Math" "acosh"
+pub fn Double::acosh(self : Double) -> Double = "Math" "acosh"
 
 ///|
 /// Calculates the inverse hyperbolic tangent of a number.
@@ -200,4 +200,4 @@ pub fn acosh(self : Double) -> Double = "Math" "acosh"
 ///   inspect(@double.neg_infinity.atanh(), content="NaN")
 /// }
 /// ```
-pub fn atanh(self : Double) -> Double = "Math" "atanh"
+pub fn Double::atanh(self : Double) -> Double = "Math" "atanh"

--- a/double/hyperbolic_nonjs.mbt
+++ b/double/hyperbolic_nonjs.mbt
@@ -58,7 +58,7 @@
 ///   inspect(@double.neg_infinity.sinh(), content="-Infinity")
 /// }
 /// ```
-pub fn sinh(self : Double) -> Double {
+pub fn Double::sinh(self : Double) -> Double {
   if self.is_nan() || self.is_inf() {
     return self
   }
@@ -118,7 +118,7 @@ pub fn sinh(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.cosh(), content="Infinity")
 /// }
 /// ```
-pub fn cosh(self : Double) -> Double {
+pub fn Double::cosh(self : Double) -> Double {
   if self.is_nan() {
     return self
   }
@@ -180,7 +180,7 @@ pub fn cosh(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.tanh(), content="-1")
 /// }
 /// ```
-pub fn tanh(self : Double) -> Double {
+pub fn Double::tanh(self : Double) -> Double {
   if self.is_nan() {
     return self
   }
@@ -241,7 +241,7 @@ pub fn tanh(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.asinh(), content="-Infinity")
 /// }
 /// ```
-pub fn asinh(self : Double) -> Double {
+pub fn Double::asinh(self : Double) -> Double {
   if self.is_nan() || self.is_inf() {
     return self
   }
@@ -301,7 +301,7 @@ pub fn asinh(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.acosh(), content="NaN")
 /// }
 /// ```
-pub fn acosh(self : Double) -> Double {
+pub fn Double::acosh(self : Double) -> Double {
   let one = 1.0
   let hx = get_high_word(self).reinterpret_as_int()
   if self < 1.0 || self.is_nan() {
@@ -352,7 +352,7 @@ pub fn acosh(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.atanh(), content="NaN")
 /// }
 /// ```
-pub fn atanh(self : Double) -> Double {
+pub fn Double::atanh(self : Double) -> Double {
   let hx : Int = get_high_word(self).reinterpret_as_int()
   let ix = hx & 0x7fffffff
   if self.abs() > 1.0 {

--- a/double/hypot_js.mbt
+++ b/double/hypot_js.mbt
@@ -38,4 +38,4 @@
 ///   inspect(1.0.hypot(@double.neg_infinity), content="Infinity")
 /// }
 /// ```
-pub fn hypot(self : Double, y : Double) -> Double = "Math" "hypot"
+pub fn Double::hypot(self : Double, y : Double) -> Double = "Math" "hypot"

--- a/double/hypot_nonjs.mbt
+++ b/double/hypot_nonjs.mbt
@@ -46,7 +46,7 @@
 ///   inspect(1.0.hypot(@double.neg_infinity), content="Infinity")
 /// }
 /// ```
-pub fn hypot(self : Double, y : Double) -> Double {
+pub fn Double::hypot(self : Double, y : Double) -> Double {
   if self.is_nan() || y.is_nan() {
     return not_a_number
   }

--- a/double/log_js.mbt
+++ b/double/log_js.mbt
@@ -36,7 +36,7 @@
 ///   inspect(0.0.ln(), content="-Infinity")
 /// }
 /// ```
-pub fn ln(self : Double) -> Double = "Math" "log"
+pub fn Double::ln(self : Double) -> Double = "Math" "log"
 
 ///|
 /// Calculates the base-2 logarithm of a double-precision floating-point number.
@@ -56,7 +56,7 @@ pub fn ln(self : Double) -> Double = "Math" "log"
 ///   inspect(3.0.log2(), content="1.584962500721156")
 /// }
 /// ```
-pub fn log2(self : Double) -> Double = "Math" "log2"
+pub fn Double::log2(self : Double) -> Double = "Math" "log2"
 
 ///|
 /// Calculates the base-10 logarithm of a double-precision floating-point number.
@@ -78,7 +78,7 @@ pub fn log2(self : Double) -> Double = "Math" "log2"
 ///   inspect(100.0.log10(), content="2")
 /// }
 /// ```
-pub fn log10(self : Double) -> Double = "Math" "log10"
+pub fn Double::log10(self : Double) -> Double = "Math" "log10"
 
 ///|
 /// Calculates ln(1 + x) accurately even when x is close to zero.
@@ -109,4 +109,4 @@ pub fn log10(self : Double) -> Double = "Math" "log10"
 ///   inspect(@double.neg_infinity.ln_1p(), content="NaN")
 /// }
 /// ```
-pub fn ln_1p(self : Double) -> Double = "Math" "log1p"
+pub fn Double::ln_1p(self : Double) -> Double = "Math" "log1p"

--- a/double/log_nonjs.mbt
+++ b/double/log_nonjs.mbt
@@ -103,7 +103,7 @@ fn frexp(f : Double) -> (Double, Int) {
 ///   inspect(0.0.ln(), content="-Infinity")
 /// }
 /// ```
-pub fn ln(self : Double) -> Double {
+pub fn Double::ln(self : Double) -> Double {
   if self < 0.0 {
     return not_a_number
   } else if self.is_nan() || self.is_inf() {
@@ -145,7 +145,7 @@ pub fn ln(self : Double) -> Double {
 ///   inspect(3.0.log2(), content="1.584962500721156")
 /// }
 /// ```
-pub fn log2(self : Double) -> Double {
+pub fn Double::log2(self : Double) -> Double {
   let (f, e) = frexp(self)
   if f == 0.5 {
     return e.to_double() - 1.0
@@ -175,7 +175,7 @@ pub fn log2(self : Double) -> Double {
 ///   inspect(15.0.log10(), content="1.1760912590556813")
 /// }
 /// ```
-pub fn log10(self : Double) -> Double {
+pub fn Double::log10(self : Double) -> Double {
   if self < 0.0 {
     return not_a_number
   } else if self.is_nan() || self.is_inf() {
@@ -225,7 +225,7 @@ pub fn log10(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.ln_1p(), content="NaN")
 /// }
 /// ```
-pub fn ln_1p(self : Double) -> Double {
+pub fn Double::ln_1p(self : Double) -> Double {
   if self < -1.0 || self.is_nan() {
     return not_a_number
   }

--- a/double/math_functions.mbt
+++ b/double/math_functions.mbt
@@ -13,13 +13,33 @@
 // limitations under the License.
 
 ///|
-test "parse_inf_nan positive NaN" {
-  let result = @strconv.parse_double!("+nan")
-  inspect(result.is_nan(), content="true")
-}
-
-///|
-test "parse_inf_nan negative NaN" {
-  let result = @strconv.parse_double!("-nan")
-  inspect(result.is_nan(), content="true")
-}
+pub fnalias Double::(
+  sin,
+  cos,
+  tan,
+  asin,
+  acos,
+  atan,
+  atan2,
+  exp,
+  expm1,
+  pow,
+  ln,
+  log2,
+  log10,
+  ln_1p,
+  sinh,
+  cosh,
+  tanh,
+  asinh,
+  acosh,
+  atanh,
+  hypot,
+  cbrt,
+  is_close,
+  trunc,
+  floor,
+  ceil,
+  round,
+  abs
+)

--- a/double/mod_test.mbt
+++ b/double/mod_test.mbt
@@ -38,12 +38,12 @@ test "mod" {
   inspect(4.0e-310 % 3.0e-310, content="1e-310")
   // inf
   inspect(1.0 % @double.infinity, content="1")
-  assert_true!(@double.is_nan(@double.infinity % @double.infinity))
-  assert_true!(@double.is_nan(@double.infinity % 1))
+  assert_true((@double.infinity % @double.infinity).is_nan())
+  assert_true((@double.infinity % 1).is_nan())
   // division by zero
-  assert_true!(@double.is_nan(1.0 % 0))
-  assert_true!(@double.is_nan(1.0 % -0))
+  assert_true!((1.0 % 0).is_nan())
+  assert_true!((1.0 % -0).is_nan())
   // nan
-  assert_true!(@double.is_nan(@double.not_a_number % 1.0))
-  assert_true!(@double.is_nan(1.0 % @double.not_a_number))
+  assert_true!((@double.not_a_number % 1.0).is_nan())
+  assert_true!((1.0 % @double.not_a_number).is_nan())
 }

--- a/double/pow_js.mbt
+++ b/double/pow_js.mbt
@@ -37,4 +37,4 @@
 ///   inspect(infinity.pow(-1.0), content="0")
 /// }
 /// ```
-pub fn pow(self : Double, other : Double) -> Double = "Math" "pow"
+pub fn Double::pow(self : Double, other : Double) -> Double = "Math" "pow"

--- a/double/pow_nonjs.mbt
+++ b/double/pow_nonjs.mbt
@@ -132,7 +132,7 @@ const POW_ivln2_l = 1.92596299112661746887e-08
 ///   inspect(infinity.pow(-1.0), content="0")
 /// }
 /// ```
-pub fn pow(self : Double, other : Double) -> Double {
+pub fn Double::pow(self : Double, other : Double) -> Double {
   fn set_low_word(d : Double, v : UInt) -> Double {
     let bits : UInt64 = d.reinterpret_as_uint64()
     let bits = bits & 0xFFFF_FFFF_0000_0000

--- a/double/round.mbt
+++ b/double/round.mbt
@@ -43,7 +43,7 @@ let frac_bits = 52
 ///   inspect(0.0.trunc(), content="0")
 /// }
 /// ```
-pub fn trunc(self : Double) -> Double {
+pub fn Double::trunc(self : Double) -> Double {
   let u64 = self.reinterpret_as_uint64()
   let biased_exp = ((u64 >> frac_bits) & ((0x1UL << exp_bits) - 1)).to_int()
   if biased_exp < exp_bias {
@@ -74,7 +74,7 @@ pub fn trunc(self : Double) -> Double {
 ///   inspect(42.0.ceil(), content="42")
 /// }
 /// ```
-pub fn ceil(self : Double) -> Double {
+pub fn Double::ceil(self : Double) -> Double {
   let trunced = self.trunc()
   if self > trunced {
     return trunced + 1.0
@@ -102,7 +102,7 @@ pub fn ceil(self : Double) -> Double {
 ///   inspect(0.0.floor(), content="0")
 /// }
 /// ```
-pub fn floor(self : Double) -> Double {
+pub fn Double::floor(self : Double) -> Double {
   let trunced = self.trunc()
   if self < trunced {
     return trunced - 1.0
@@ -132,6 +132,6 @@ pub fn floor(self : Double) -> Double {
 ///   inspect((-3.5).round(), content="-3")
 /// }
 /// ```
-pub fn round(self : Double) -> Double {
+pub fn Double::round(self : Double) -> Double {
   floor(self + 0.5)
 }

--- a/double/round_js.mbt
+++ b/double/round_js.mbt
@@ -31,7 +31,7 @@
 ///   inspect(0.0.trunc(), content="0")
 /// }
 /// ```
-pub fn trunc(self : Double) -> Double = "Math" "trunc"
+pub fn Double::trunc(self : Double) -> Double = "Math" "trunc"
 
 ///|
 /// Returns the smallest integer greater than or equal to the given number.
@@ -51,7 +51,7 @@ pub fn trunc(self : Double) -> Double = "Math" "trunc"
 ///   inspect(42.0.ceil(), content="42")
 /// }
 /// ```
-pub fn ceil(self : Double) -> Double = "Math" "ceil"
+pub fn Double::ceil(self : Double) -> Double = "Math" "ceil"
 
 ///|
 /// Returns the largest integer less than or equal to the given number.
@@ -72,7 +72,7 @@ pub fn ceil(self : Double) -> Double = "Math" "ceil"
 ///   inspect(0.0.floor(), content="0")
 /// }
 /// ```
-pub fn floor(self : Double) -> Double = "Math" "floor"
+pub fn Double::floor(self : Double) -> Double = "Math" "floor"
 
 ///|
 /// Rounds a floating-point number to the nearest integer using "round half up"
@@ -95,4 +95,4 @@ pub fn floor(self : Double) -> Double = "Math" "floor"
 ///   inspect((-3.5).round(), content="-3")
 /// }
 /// ```
-pub fn round(self : Double) -> Double = "Math" "round"
+pub fn Double::round(self : Double) -> Double = "Math" "round"

--- a/double/round_wasm.mbt
+++ b/double/round_wasm.mbt
@@ -31,7 +31,7 @@
 ///   inspect(0.0.trunc(), content="0")
 /// }
 /// ```
-pub fn trunc(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.trunc (local.get $d)))"
+pub fn Double::trunc(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.trunc (local.get $d)))"
 
 ///|
 /// Returns the smallest integer greater than or equal to the given number.
@@ -51,7 +51,7 @@ pub fn trunc(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.
 ///   inspect(42.0.ceil(), content="42")
 /// }
 /// ```
-pub fn ceil(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.ceil (local.get $d)))"
+pub fn Double::ceil(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.ceil (local.get $d)))"
 
 ///|
 /// Returns the largest integer less than or equal to the given number.
@@ -72,7 +72,7 @@ pub fn ceil(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.c
 ///   inspect(0.0.floor(), content="0")
 /// }
 /// ```
-pub fn floor(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.floor (local.get $d)))"
+pub fn Double::floor(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.floor (local.get $d)))"
 
 ///|
 /// Rounds a floating-point number to the nearest integer using "round half up"
@@ -95,6 +95,6 @@ pub fn floor(self : Double) -> Double = "(func (param $d f64) (result f64) (f64.
 ///   inspect((-3.5).round(), content="-3")
 /// }
 /// ```
-pub fn round(self : Double) -> Double {
+pub fn Double::round(self : Double) -> Double {
   floor(self + 0.5)
 }

--- a/double/scalbn.mbt
+++ b/double/scalbn.mbt
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 ///|
-fn scalbn(self : Double, exp : Int) -> Double {
+fn scalbn(x : Double, exp : Int) -> Double {
   let mut n = exp
-  let mut y : Double = self
+  let mut y : Double = x
   if n > 1023 {
     y *= 0x1.0p1023
     n -= 1023

--- a/double/trig_js.mbt
+++ b/double/trig_js.mbt
@@ -36,7 +36,7 @@
 ///   inspect(@double.neg_infinity.sin(), content="NaN")
 /// }
 /// ```
-pub fn sin(self : Double) -> Double = "Math" "sin"
+pub fn Double::sin(self : Double) -> Double = "Math" "sin"
 
 ///|
 /// Calculates the cosine of a number in radians. Handles special cases and edge
@@ -62,7 +62,7 @@ pub fn sin(self : Double) -> Double = "Math" "sin"
 ///   inspect(@double.neg_infinity.cos(), content="NaN")
 /// }
 /// ```
-pub fn cos(self : Double) -> Double = "Math" "cos"
+pub fn Double::cos(self : Double) -> Double = "Math" "cos"
 
 ///|
 /// Calculates the tangent of a number in radians. Handles special cases and edge
@@ -88,7 +88,7 @@ pub fn cos(self : Double) -> Double = "Math" "cos"
 ///   inspect(@double.neg_infinity.tan(), content="NaN")
 /// }
 /// ```
-pub fn tan(self : Double) -> Double = "Math" "tan"
+pub fn Double::tan(self : Double) -> Double = "Math" "tan"
 
 ///|
 /// Calculates the arcsine of a number. Handles special cases and edge conditions
@@ -115,7 +115,7 @@ pub fn tan(self : Double) -> Double = "Math" "tan"
 ///   inspect(@double.neg_infinity.asin(), content="NaN")
 /// }
 /// ```
-pub fn asin(self : Double) -> Double = "Math" "asin"
+pub fn Double::asin(self : Double) -> Double = "Math" "asin"
 
 ///|
 /// Calculates the arccosine of a number.
@@ -142,7 +142,7 @@ pub fn asin(self : Double) -> Double = "Math" "asin"
 ///   inspect(0.0.acos(), content="1.5707963267948966")
 /// }
 /// ```
-pub fn acos(self : Double) -> Double = "Math" "acos"
+pub fn Double::acos(self : Double) -> Double = "Math" "acos"
 
 ///|
 /// Calculates the arctangent of a number.
@@ -167,7 +167,7 @@ pub fn acos(self : Double) -> Double = "Math" "acos"
 ///   inspect(@double.neg_infinity.atan(), content="-1.5707963267948966")
 /// }
 /// ```
-pub fn atan(self : Double) -> Double = "Math" "atan"
+pub fn Double::atan(self : Double) -> Double = "Math" "atan"
 
 ///|
 /// Calculates the arctangent of the quotient of two numbers.
@@ -200,4 +200,4 @@ pub fn atan(self : Double) -> Double = "Math" "atan"
 ///   inspect(neg_infinity.atan2(infinity), content="-0.7853981633974483")
 /// }
 /// ```
-pub fn atan2(self : Double, x : Double) -> Double = "Math" "atan2"
+pub fn Double::atan2(self : Double, x : Double) -> Double = "Math" "atan2"

--- a/double/trig_nonjs.mbt
+++ b/double/trig_nonjs.mbt
@@ -688,7 +688,7 @@ fn __kernal_tan(x : Double, y : Double, iy : Int) -> Double {
 ///   inspect(@double.neg_infinity.sin(), content="NaN")
 /// }
 /// ```
-pub fn sin(self : Double) -> Double {
+pub fn Double::sin(self : Double) -> Double {
   if self.is_inf() || self.is_nan() {
     return not_a_number
   }
@@ -731,7 +731,7 @@ pub fn sin(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.cos(), content="NaN")
 /// }
 /// ```
-pub fn cos(self : Double) -> Double {
+pub fn Double::cos(self : Double) -> Double {
   if self.is_inf() || self.is_nan() {
     return not_a_number
   }
@@ -774,7 +774,7 @@ pub fn cos(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.tan(), content="NaN")
 /// }
 /// ```
-pub fn tan(self : Double) -> Double {
+pub fn Double::tan(self : Double) -> Double {
   if self.is_inf() || self.is_nan() {
     return not_a_number
   }
@@ -813,7 +813,7 @@ pub fn tan(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.asin(), content="NaN")
 /// }
 /// ```
-pub fn asin(self : Double) -> Double {
+pub fn Double::asin(self : Double) -> Double {
   let huge = 1.0e+300
   let pio4_hi = 7.85398163397448278999e-01
   let pio2_hi = 1.57079632679489655800
@@ -895,7 +895,7 @@ pub fn asin(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.acos(), content="NaN")
 /// }
 /// ```
-pub fn acos(self : Double) -> Double {
+pub fn Double::acos(self : Double) -> Double {
   let one : Double = 1.0
   let pi : Double = 3.14159265358979311600
   let pio2_hi : Double = 1.57079632679489655800
@@ -975,7 +975,7 @@ pub fn acos(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.atan(), content="-1.5707963267948966")
 /// }
 /// ```
-pub fn atan(self : Double) -> Double {
+pub fn Double::atan(self : Double) -> Double {
   if self.is_nan() || self == 0.0 {
     return self
   }
@@ -1085,7 +1085,7 @@ pub fn atan(self : Double) -> Double {
 ///   inspect(@double.neg_infinity.atan2(@double.infinity), content="-0.7853981633974483")
 /// }
 /// ```
-pub fn atan2(self : Double, x : Double) -> Double {
+pub fn Double::atan2(self : Double, x : Double) -> Double {
   if x.is_nan() || self.is_nan() {
     return not_a_number
   }

--- a/float/README.mbt.md
+++ b/float/README.mbt.md
@@ -23,10 +23,10 @@ test "special float values" {
 
 test "checking special values" {
   // Testing for special values
-  inspect(@float.is_inf(@float.infinity), content="true")
-  inspect(@float.is_neg_inf(@float.neg_infinity), content="true")
-  inspect(@float.is_pos_inf(@float.infinity), content="true")
-  inspect(@float.is_nan(@float.not_a_number), content="true")
+  inspect(@float.infinity.is_inf(), content="true")
+  inspect(@float.neg_infinity.is_neg_inf(), content="true")
+  inspect(@float.infinity.is_pos_inf(), content="true")
+  inspect(@float.not_a_number.is_nan(), content="true")
 }
 ```
 
@@ -114,7 +114,7 @@ test "utility functions" {
   inspect(@float.hypot(3.0, 4.0), content="5")
 
   // Conversion to integer
-  inspect(@float.to_int(3.14), content="3")
+  inspect((3.14).to_int(), content="3")
 
   // Default value
   inspect(@float.default(), content="0")

--- a/float/cbrt.mbt
+++ b/float/cbrt.mbt
@@ -41,6 +41,6 @@
 ///  inspect(@float.neg_infinity.cbrt(), content="-Infinity")
 /// }
 /// ```
-pub fn cbrt(self : Float) -> Float {
+pub fn Float::cbrt(self : Float) -> Float {
   self.to_double().cbrt().to_float()
 }

--- a/float/exp.mbt
+++ b/float/exp.mbt
@@ -88,7 +88,7 @@ let exp2f_data : Exp2fData = {
 ///   inspect(@float.neg_infinity.exp(), content="0")
 /// }
 /// ```
-pub fn exp(self : Float) -> Float {
+pub fn Float::exp(self : Float) -> Float {
   let xd = self.to_double()
   let abstop = top12(self) & 0x7ff
   if abstop >= top12(88.0) {
@@ -149,6 +149,6 @@ pub fn exp(self : Float) -> Float {
 ///  inspect(@float.neg_infinity.expm1(), content="-1")
 /// }
 /// ```
-pub fn expm1(self : Float) -> Float {
+pub fn Float::expm1(self : Float) -> Float {
   self.to_double().expm1().to_float()
 }

--- a/float/float.mbt
+++ b/float/float.mbt
@@ -125,7 +125,7 @@ pub let min_positive : Float = (0x00800000).reinterpret_as_float()
 ///   inspect(@float.not_a_number.abs().is_nan(), content="true")
 /// }
 /// ```
-pub fn abs(self : Float) -> Float = "%f32.abs"
+pub fn Float::abs(self : Float) -> Float = "%f32.abs"
 
 ///|
 /// Converts a floating-point number to its string representation.

--- a/float/hyperbolic.mbt
+++ b/float/hyperbolic.mbt
@@ -41,7 +41,7 @@
 ///   inspect(@float.neg_infinity.sinh(), content="-Infinity")
 /// }
 /// ```
-pub fn sinh(self : Float) -> Float {
+pub fn Float::sinh(self : Float) -> Float {
   self.to_double().sinh().to_float()
 }
 
@@ -74,7 +74,7 @@ pub fn sinh(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.cosh(), content="Infinity")
 /// }
 /// ```
-pub fn cosh(self : Float) -> Float {
+pub fn Float::cosh(self : Float) -> Float {
   self.to_double().cosh().to_float()
 }
 
@@ -108,7 +108,7 @@ pub fn cosh(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.tanh(), content="-1")
 /// }
 /// ```
-pub fn tanh(self : Float) -> Float {
+pub fn Float::tanh(self : Float) -> Float {
   self.to_double().tanh().to_float()
 }
 
@@ -140,7 +140,7 @@ pub fn tanh(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.asinh(), content="-Infinity")
 /// }
 /// ```
-pub fn asinh(self : Float) -> Float {
+pub fn Float::asinh(self : Float) -> Float {
   self.to_double().asinh().to_float()
 }
 
@@ -174,7 +174,7 @@ pub fn asinh(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.acosh(), content="NaN")
 /// }
 /// ```
-pub fn acosh(self : Float) -> Float {
+pub fn Float::acosh(self : Float) -> Float {
   self.to_double().acosh().to_float()
 }
 
@@ -209,6 +209,6 @@ pub fn acosh(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.atanh(), content="NaN")
 /// }
 /// ```
-pub fn atanh(self : Float) -> Float {
+pub fn Float::atanh(self : Float) -> Float {
   self.to_double().atanh().to_float()
 }

--- a/float/hypot.mbt
+++ b/float/hypot.mbt
@@ -38,6 +38,6 @@
 ///   inspect((1.0 : Float).hypot(@float.neg_infinity), content="Infinity")
 /// }
 /// ```
-pub fn hypot(self : Float, y : Float) -> Float {
+pub fn Float::hypot(self : Float, y : Float) -> Float {
   self.to_double().hypot(y.to_double()).to_float()
 }

--- a/float/log.mbt
+++ b/float/log.mbt
@@ -72,7 +72,7 @@ let logf_data : LogfData = {
 ///   inspect((0.0 : Float).ln(), content="-Infinity")
 /// }
 /// ```
-pub fn ln(self : Float) -> Float {
+pub fn Float::ln(self : Float) -> Float {
   let mut ix : UInt = self.reinterpret_as_int().reinterpret_as_uint()
   if ix == 0x3f800000U {
     return 0.0
@@ -134,6 +134,6 @@ pub fn ln(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.ln_1p(), content="NaN")
 /// }
 /// ```
-pub fn ln_1p(self : Float) -> Float {
+pub fn Float::ln_1p(self : Float) -> Float {
   self.to_double().ln_1p().to_float()
 }

--- a/float/math_functions.mbt
+++ b/float/math_functions.mbt
@@ -13,13 +13,30 @@
 // limitations under the License.
 
 ///|
-test "parse_inf_nan positive NaN" {
-  let result = @strconv.parse_double!("+nan")
-  inspect(result.is_nan(), content="true")
-}
-
-///|
-test "parse_inf_nan negative NaN" {
-  let result = @strconv.parse_double!("-nan")
-  inspect(result.is_nan(), content="true")
-}
+pub fnalias Float::(
+  sin,
+  cos,
+  tan,
+  asin,
+  acos,
+  atan,
+  atan2,
+  exp,
+  expm1,
+  pow,
+  ln,
+  ln_1p,
+  sinh,
+  cosh,
+  tanh,
+  asinh,
+  acosh,
+  atanh,
+  hypot,
+  cbrt,
+  trunc,
+  ceil,
+  floor,
+  round,
+  abs
+)

--- a/float/pow.mbt
+++ b/float/pow.mbt
@@ -32,6 +32,6 @@
 ///   inspect((1.0 : Float).pow(-1.0), content="1")
 /// }
 /// ```
-pub fn pow(self : Float, other : Float) -> Float {
+pub fn Float::pow(self : Float, other : Float) -> Float {
   self.to_double().pow(other.to_double()).to_float()
 }

--- a/float/round.mbt
+++ b/float/round.mbt
@@ -48,7 +48,7 @@ let frac_bits = 23
 ///   inspect((0.2 : Float).trunc(), content="0.0")
 /// }
 /// ```
-pub fn trunc(self : Float) -> Float {
+pub fn Float::trunc(self : Float) -> Float {
   let u32 = self.reinterpret_as_uint()
   let biased_exp = ((u32 >> frac_bits) & ((0x1U << exp_bits) - 1)).reinterpret_as_int()
   if biased_exp < exp_bias {
@@ -80,7 +80,7 @@ pub fn trunc(self : Float) -> Float {
 ///   inspect((-1.5 : Float).ceil(), content="-1.0")
 /// }
 /// ```
-pub fn ceil(self : Float) -> Float {
+pub fn Float::ceil(self : Float) -> Float {
   let trunced = self.trunc()
   if self > trunced {
     return trunced + 1.0
@@ -109,7 +109,7 @@ pub fn ceil(self : Float) -> Float {
 ///   inspect((2.0 : Float).floor(), content="2.0")
 /// }
 /// ```
-pub fn floor(self : Float) -> Float {
+pub fn Float::floor(self : Float) -> Float {
   let trunced = self.trunc()
   if self < trunced {
     return trunced - 1.0
@@ -137,6 +137,6 @@ pub fn floor(self : Float) -> Float {
 ///   inspect((-2.5 : Float).round(), content="-2.0")
 /// }
 /// ```
-pub fn round(self : Float) -> Float {
+pub fn Float::round(self : Float) -> Float {
   floor(self + 0.5)
 }

--- a/float/round_js.mbt
+++ b/float/round_js.mbt
@@ -31,7 +31,7 @@
 ///   inspect((-3.7 : Float).trunc(), content="-3.0")
 /// }
 /// ```
-pub fn trunc(self : Float) -> Float = "Math" "trunc"
+pub fn Float::trunc(self : Float) -> Float = "Math" "trunc"
 
 ///|
 /// Returns the smallest integer greater than or equal to the given
@@ -51,7 +51,7 @@ pub fn trunc(self : Float) -> Float = "Math" "trunc"
 ///   inspect((-1.5 : Float).ceil(), content="-1.0")
 /// }
 /// ```
-pub fn ceil(self : Float) -> Float = "Math" "ceil"
+pub fn Float::ceil(self : Float) -> Float = "Math" "ceil"
 
 ///|
 /// Returns the largest integer value less than or equal to the given
@@ -72,7 +72,7 @@ pub fn ceil(self : Float) -> Float = "Math" "ceil"
 ///   inspect((-3.7 : Float).floor(), content="-4.0")
 /// }
 /// ```
-pub fn floor(self : Float) -> Float = "Math" "floor"
+pub fn Float::floor(self : Float) -> Float = "Math" "floor"
 
 ///|
 /// Rounds a floating-point number to the nearest integer, with ties rounding up
@@ -94,4 +94,4 @@ pub fn floor(self : Float) -> Float = "Math" "floor"
 ///   inspect((-1.5 : Float).round(), content="-1.0")
 /// }
 /// ```
-pub fn round(self : Float) -> Float = "Math" "round"
+pub fn Float::round(self : Float) -> Float = "Math" "round"

--- a/float/round_wasm.mbt
+++ b/float/round_wasm.mbt
@@ -35,7 +35,7 @@
 ///   inspect((0.1 : Float).trunc(), content="0")
 /// }
 /// ```
-pub fn trunc(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.trunc (local.get $f)))"
+pub fn Float::trunc(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.trunc (local.get $f)))"
 
 ///|
 /// Returns the smallest integer greater than or equal to the given
@@ -56,7 +56,7 @@ pub fn trunc(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.tr
 ///   inspect((-1.4 : Float).ceil(), content="-1")
 /// }
 /// ```
-pub fn ceil(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.ceil (local.get $f)))"
+pub fn Float::ceil(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.ceil (local.get $f)))"
 
 ///|
 /// Returns the largest integer less than or equal to the given floating-point
@@ -77,7 +77,7 @@ pub fn ceil(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.cei
 ///   inspect((-3.7 : Float).floor(), content="-4")
 /// }
 /// ```
-pub fn floor(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.floor (local.get $f)))"
+pub fn Float::floor(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.floor (local.get $f)))"
 
 ///|
 /// Rounds a floating-point number to the nearest integer value. If the
@@ -100,6 +100,6 @@ pub fn floor(self : Float) -> Float = "(func (param $f f32) (result f32) (f32.fl
 ///   inspect((-1.5 : Float).round(), content="-1")
 /// }
 /// ```
-pub fn round(self : Float) -> Float {
+pub fn Float::round(self : Float) -> Float {
   floor(self + 0.5)
 }

--- a/float/trig.mbt
+++ b/float/trig.mbt
@@ -33,7 +33,7 @@
 ///   inspect(@float.neg_infinity.sin(), content="NaN")
 /// }
 /// ```
-pub fn sin(self : Float) -> Float {
+pub fn Float::sin(self : Float) -> Float {
   self.to_double().sin().to_float()
 }
 
@@ -58,7 +58,7 @@ pub fn sin(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.cos(), content="NaN")
 /// }
 /// ```
-pub fn cos(self : Float) -> Float {
+pub fn Float::cos(self : Float) -> Float {
   self.to_double().cos().to_float()
 }
 
@@ -83,7 +83,7 @@ pub fn cos(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.tan(), content="NaN")
 /// }
 /// ```
-pub fn tan(self : Float) -> Float {
+pub fn Float::tan(self : Float) -> Float {
   self.to_double().tan().to_float()
 }
 
@@ -111,7 +111,7 @@ pub fn tan(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.asin(), content="NaN")
 /// }
 /// ```
-pub fn asin(self : Float) -> Float {
+pub fn Float::asin(self : Float) -> Float {
   self.to_double().asin().to_float()
 }
 
@@ -139,7 +139,7 @@ pub fn asin(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.acos(), content="NaN")
 /// }
 /// ```
-pub fn acos(self : Float) -> Float {
+pub fn Float::acos(self : Float) -> Float {
   self.to_double().acos().to_float()
 }
 
@@ -166,7 +166,7 @@ pub fn acos(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.atan(), content="-1.5707963705062866")
 /// }
 /// ```
-pub fn atan(self : Float) -> Float {
+pub fn Float::atan(self : Float) -> Float {
   self.to_double().atan().to_float()
 }
 
@@ -201,6 +201,6 @@ pub fn atan(self : Float) -> Float {
 ///   inspect(@float.neg_infinity.atan2(@float.infinity), content="-0.7853981852531433")
 /// }
 /// ```
-pub fn atan2(self : Float, other : Float) -> Float {
+pub fn Float::atan2(self : Float, other : Float) -> Float {
   self.to_double().atan2(other.to_double()).to_float()
 }

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -374,14 +374,14 @@ test "hashset arbitrary" {
 ///|
 test "@hashset.to_array/empty" {
   let set : @hashset.T[Int] = @hashset.new()
-  inspect(@hashset.to_array(set), content="[]")
+  inspect(set.to_array(), content="[]")
 }
 
 ///|
 test "@hashset.to_array/single" {
   let set = @hashset.new()
   set.add(42)
-  inspect(@hashset.to_array(set), content="[42]")
+  inspect(set.to_array(), content="[42]")
 }
 
 ///|
@@ -391,5 +391,5 @@ test "@hashset.to_array/multiple" {
   set.add(2)
   set.add(3)
   set.add(4)
-  inspect(@hashset.to_array(set), content="[3, 4, 1, 2]")
+  inspect(set.to_array(), content="[3, 4, 1, 2]")
 }

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -177,7 +177,7 @@ pub fn[K : Eq + Hash, V] filter(self : T[K, V], pred : (V) -> Bool) -> T[K, V] {
 ///|
 /// Fold the values in the map
 pub fn[K, V, A] fold(self : T[K, V], init~ : A, f : (A, V) -> A) -> A {
-  fold_with_key(self, fn(acc, _k, v) { f(acc, v) }, init~)
+  self.fold_with_key(fn(acc, _k, v) { f(acc, v) }, init~)
 }
 
 ///|
@@ -211,7 +211,7 @@ pub fn[K, V, A] fold_with_key(
 ///|
 /// Maps over the values in the map
 pub fn[K : Eq + Hash, V, A] map(self : T[K, V], f : (V) -> A) -> T[K, A] {
-  map_with_key(self, fn(_k, v) { f(v) })
+  self.map_with_key(fn(_k, v) { f(v) })
 }
 
 ///|

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -156,17 +156,17 @@ test "each on empty set" {
 test "from_array with empty array" {
   let empty_array : Array[Int] = []
   let set = @hashset.from_array(empty_array)
-  inspect(@hashset.is_empty(set), content="true")
+  inspect(set.is_empty(), content="true")
 }
 
 ///|
 test "from_array with non-empty array" {
   let array = [1, 2, 3]
   let set = @hashset.from_array(array)
-  inspect(@hashset.contains(set, 1), content="true")
-  inspect(@hashset.contains(set, 2), content="true")
-  inspect(@hashset.contains(set, 3), content="true")
-  inspect(@hashset.size(set), content="3")
+  inspect(set.contains(1), content="true")
+  inspect(set.contains(2), content="true")
+  inspect(set.contains(3), content="true")
+  inspect(set.size(), content="3")
 }
 
 ///|

--- a/immut/list/dps_test.mbt
+++ b/immut/list/dps_test.mbt
@@ -52,7 +52,7 @@ test "map" {
     1,
     tail=Cons(2, tail=Cons(3, tail=Cons(4, tail=Cons(5, tail=Nil)))),
   )
-  let lst : L = map(lstL, fn { x => x * 2 })
+  let lst : L = lstL.map(fn { x => x * 2 })
   inspect(
     lst,
     content="Cons(2, tail=Cons(4, tail=Cons(6, tail=Cons(8, tail=Cons(10, tail=Nil)))))",

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -132,7 +132,7 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 pub fn[A, B] map(self : T[A], f : (A) -> B) -> T[B] {
   match self {
     Nil => Nil
-    Cons(head, tail) => Cons(f(head), map(tail, f))
+    Cons(head, tail) => Cons(f(head), tail.map(f))
   }
 }
 
@@ -197,9 +197,9 @@ pub fn[A] filter(self : T[A], f : (A) -> Bool) -> T[A] {
     Nil => Nil
     Cons(head, tail) =>
       if f(head) {
-        Cons(head, filter(tail, f))
+        Cons(head, tail.filter(f))
       } else {
-        filter(tail, f)
+        tail.filter(f)
       }
   }
 }
@@ -218,7 +218,7 @@ pub fn[A] all(self : T[A], f : (A) -> Bool) -> Bool {
 pub fn[A] any(self : T[A], f : (A) -> Bool) -> Bool {
   match self {
     Nil => false
-    Cons(head, tail) => f(head) || any(tail, f)
+    Cons(head, tail) => f(head) || tail.any(f)
   }
 }
 
@@ -251,7 +251,7 @@ pub fn[A] unsafe_head(self : T[A]) -> A {
 #deprecated("Use `unsafe_head` instead")
 #coverage.skip
 pub fn[A] head_exn(self : T[A]) -> A {
-  unsafe_head(self)
+  self.unsafe_head()
 }
 
 ///|
@@ -307,7 +307,7 @@ pub fn[A] last(self : T[A]) -> A? {
 pub fn[A] concat(self : T[A], other : T[A]) -> T[A] {
   match self {
     Nil => other
-    Cons(head, tail) => Cons(head, concat(tail, other))
+    Cons(head, tail) => Cons(head, tail.concat(other))
   }
 }
 
@@ -498,7 +498,7 @@ pub fn[A, B] zip(self : T[A], other : T[B]) -> T[(A, B)]? {
 #deprecated("Use `flat_map` instead")
 #coverage.skip
 pub fn[A, B] concat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
-  flat_map(self, f)
+  self.flat_map(f)
 }
 
 ///|
@@ -516,7 +516,7 @@ pub fn[A, B] concat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
 pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
   match self {
     Nil => Nil
-    Cons(head, tail) => concat(f(head), flat_map(tail, f))
+    Cons(head, tail) => f(head).concat(tail.flat_map(f))
   }
 }
 
@@ -555,7 +555,7 @@ pub fn[A] unsafe_nth(self : T[A], n : Int) -> A {
 #deprecated("Use `unsafe_nth` instead")
 #coverage.skip
 pub fn[A] nth_exn(self : T[A], n : Int) -> A {
-  unsafe_nth(self, n)
+  self.unsafe_nth(n)
 }
 
 ///|
@@ -597,8 +597,7 @@ pub fn[A] intersperse(self : T[A], separator : A) -> T[A] {
   match self {
     Nil => Nil
     Cons(head, Nil) => Cons(head, Nil)
-    Cons(head, tail) =>
-      Cons(head, Cons(separator, intersperse(tail, separator)))
+    Cons(head, tail) => Cons(head, Cons(separator, tail.intersperse(separator)))
   }
 }
 
@@ -644,7 +643,7 @@ pub fn[A, B] unzip(self : T[(A, B)]) -> (T[A], T[B]) {
 pub fn[A] flatten(self : T[T[A]]) -> T[A] {
   match self {
     Nil => Nil
-    Cons(head, tail) => concat(head, flatten(tail))
+    Cons(head, tail) => head.concat(tail.flatten())
   }
 }
 
@@ -655,7 +654,7 @@ pub fn[A : Compare] unsafe_maximum(self : T[A]) -> A {
     Nil => abort("maximum: empty list")
     Cons(x, Nil) => x
     Cons(x, xs) => {
-      let y = unsafe_maximum(xs)
+      let y = xs.unsafe_maximum()
       if x > y {
         x
       } else {
@@ -673,7 +672,7 @@ pub fn[A : Compare] maximum(self : T[A]) -> A? {
     Nil => None
     Cons(x, Nil) => Some(x)
     Cons(x, xs) =>
-      match maximum(xs) {
+      match xs.maximum() {
         None => Some(x)
         Some(y) => Some(if x > y { x } else { y })
       }
@@ -687,7 +686,7 @@ pub fn[A : Compare] unsafe_minimum(self : T[A]) -> A {
     Nil => abort("minimum: empty list")
     Cons(x, Nil) => x
     Cons(x, xs) => {
-      let y = unsafe_minimum(xs)
+      let y = xs.unsafe_minimum()
       if x < y {
         x
       } else {
@@ -704,7 +703,7 @@ pub fn[A : Compare] minimum(self : T[A]) -> A? {
     Nil => None
     Cons(x, Nil) => Some(x)
     Cons(x, xs) =>
-      match minimum(xs) {
+      match xs.minimum() {
         None => Some(x)
         Some(y) => Some(if x < y { x } else { y })
       }
@@ -724,9 +723,9 @@ pub fn[A : Compare] sort(self : T[A]) -> T[A] {
   match self {
     Nil => Nil
     Cons(x, xs) => {
-      let smaller = filter(xs, fn(y) { y < x })
-      let greater = filter(xs, fn(y) { y >= x })
-      concat(sort(smaller), Cons(x, sort(greater)))
+      let smaller = xs.filter(fn(y) { y < x })
+      let greater = xs.filter(fn(y) { y >= x })
+      smaller.sort().concat(Cons(x, greater.sort()))
     }
   }
 }
@@ -961,7 +960,7 @@ pub fn[A] findi(self : T[A], f : (A, Int) -> Bool) -> A? {
 pub fn[A] remove_at(self : T[A], index : Int) -> T[A] {
   match (index, self) {
     (0, Cons(_, tail)) => tail
-    (_, Cons(head, tail)) => Cons(head, remove_at(tail, index - 1))
+    (_, Cons(head, tail)) => Cons(head, tail.remove_at(index - 1))
     (_, Nil) => Nil
     // abort("remove_at: index out of bounds")
   }
@@ -982,7 +981,7 @@ pub fn[A : Eq] remove(self : T[A], elem : A) -> T[A] {
       if head == elem {
         tail
       } else {
-        Cons(head, remove(tail, elem))
+        Cons(head, tail.remove(elem))
       }
   }
 }

--- a/immut/list/list_test.mbt
+++ b/immut/list/list_test.mbt
@@ -81,8 +81,8 @@ test "rev_map" {
 test "to_array" {
   let list = @list.of([1, 2, 3, 4, 5])
   let empty : @list.T[Int] = @list.Nil
-  let array = @list.to_array(list)
-  let earray = @list.to_array(empty)
+  let array = list.to_array()
+  let earray = empty.to_array()
   inspect(array, content="[1, 2, 3, 4, 5]")
   inspect(earray, content="[]")
 }
@@ -279,7 +279,7 @@ test "is_empty" {
 ///|
 test "unzip" {
   let ls = @list.of([(1, 2), (3, 4), (5, 6)])
-  let (a, b) = @list.unzip(ls)
+  let (a, b) = ls.unzip()
   inspect(a, content="@list.of([1, 3, 5])")
   inspect(b, content="@list.of([2, 4, 6])")
 }
@@ -358,16 +358,16 @@ test "drop" {
 
 ///|
 test "take_while" {
-  let ls = @list.take_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.take_while(@list.Nil, fn(_e) { true })
+  let ls = @list.of([0, 1, 2, 3, 4]).take_while(fn(x) { x < 3 })
+  let el : @list.T[Int] = @list.Nil.take_while(fn(_e) { true })
   inspect(ls, content="@list.of([0, 1, 2])")
   inspect(el, content="@list.of([])")
 }
 
 ///|
 test "drop_while" {
-  let ls = @list.drop_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.drop_while(@list.Nil, fn(_e) { true })
+  let ls = @list.of([0, 1, 2, 3, 4]).drop_while(fn(x) { x < 3 })
+  let el : @list.T[Int] = @list.Nil.drop_while(fn(_e) { true })
   inspect(ls, content="@list.of([3, 4])")
   inspect(el, content="@list.of([])")
 }
@@ -580,14 +580,14 @@ test "List::from_json" {
 ///|
 test "List::head_exn with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let head = @list.head(list)
+  let head = list.head()
   assert_eq!(head, Some(1))
 }
 
 ///|
 test "List::last with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let last = @list.last(list)
+  let last = list.last()
   assert_eq!(last, Some(5))
 }
 
@@ -608,14 +608,14 @@ test "@list.zip with empty list" {
 ///|
 test "List::nth_exn with valid index" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let nth = @list.nth(list, 2)
+  let nth = list.nth(2)
   assert_eq!(nth, Some(3))
 }
 
 ///|
 test "List::maximum with non-empty list" {
   let list = @list.of([1, 3, 5, 2, 4])
-  let max = @list.maximum(list)
+  let max = list.maximum()
   assert_eq!(max, Some(5))
 }
 
@@ -627,7 +627,7 @@ test "@list.maximum with empty list" {
 ///|
 test "List::minimum with non-empty list" {
   let list = @list.of([1, 3, 5, 2, 4])
-  let min = @list.minimum(list)
+  let min = list.minimum()
   assert_eq!(min, Some(1))
 }
 

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -189,7 +189,7 @@ pub fn[A : Compare] unsafe_pop(self : T[A]) -> T[A] {
 #deprecated("Use `unsafe_pop` instead")
 #coverage.skip
 pub fn[A : Compare] pop_exn(self : T[A]) -> T[A] {
-  unsafe_pop(self)
+  self.unsafe_pop()
 }
 
 ///|

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -37,7 +37,7 @@ fn[K : Compare, V] split_max(self : T[K, V]) -> (K, V, T[K, V]) {
   match self {
     Tree(k, value=v, l, Empty, ..) => (k, v, l)
     Tree(k, value=v, l, r, ..) => {
-      let (k1, v1, r) = split_max(r)
+      let (k1, v1, r) = r.split_max()
       (k1, v1, balance(k, v, l, r))
     }
     Empty => abort("Map::split_max error")
@@ -49,7 +49,7 @@ fn[K : Compare, V] split_min(self : T[K, V]) -> (K, V, T[K, V]) {
   match self {
     Tree(k, value=v, Empty, r, ..) => (k, v, r)
     Tree(k, value=v, l, r, ..) => {
-      let (k1, v1, l) = split_min(l)
+      let (k1, v1, l) = l.split_min()
       (k1, v1, balance(k, v, l, r))
     }
     Empty => abort("Map::split_min error")
@@ -57,16 +57,16 @@ fn[K : Compare, V] split_min(self : T[K, V]) -> (K, V, T[K, V]) {
 }
 
 ///|
-fn[K : Compare, V] glue(self : T[K, V], other : T[K, V]) -> T[K, V] {
-  match (self, other) {
+fn[K : Compare, V] glue(l : T[K, V], r : T[K, V]) -> T[K, V] {
+  match (l, r) {
     (Empty, r) => r
     (l, Empty) => l
     (l, r) =>
       if l.size() > r.size() {
-        let (k, v, l) = split_max(l)
+        let (k, v, l) = l.split_max()
         balance(k, v, l, r)
       } else {
-        let (k, v, r) = split_min(r)
+        let (k, v, r) = r.split_min()
         balance(k, v, l, r)
       }
   }
@@ -83,9 +83,9 @@ pub fn[K : Compare, V] remove(self : T[K, V], key : K) -> T[K, V] {
       if c == 0 {
         glue(l, r)
       } else if c < 0 {
-        balance(k, v, remove(l, key), r)
+        balance(k, v, l.remove(key), r)
       } else {
-        balance(k, v, l, remove(r, key))
+        balance(k, v, l, r.remove(key))
       }
     }
   }
@@ -94,7 +94,7 @@ pub fn[K : Compare, V] remove(self : T[K, V], key : K) -> T[K, V] {
 ///|
 /// Filter values that satisfy the predicate
 pub fn[K : Compare, V] filter(self : T[K, V], pred : (V) -> Bool) -> T[K, V] {
-  filter_with_key(self, fn(_k, v) { pred(v) })
+  self.filter_with_key(fn(_k, v) { pred(v) })
 }
 
 ///|
@@ -107,9 +107,9 @@ pub fn[K : Compare, V] filter_with_key(
     Empty => Empty
     Tree(k, value=v, l, r, ..) =>
       if pred(k, v) {
-        balance(k, v, filter_with_key(l, pred), filter_with_key(r, pred))
+        balance(k, v, l.filter_with_key(pred), r.filter_with_key(pred))
       } else {
-        glue(filter_with_key(l, pred), filter_with_key(r, pred))
+        glue(l.filter_with_key(pred), r.filter_with_key(pred))
       }
   }
 }
@@ -172,15 +172,15 @@ fn[K : Compare, V] balance(
     make_tree(k2, v2, make_tree(k1, v1, x, y1), make_tree(k3, v3, y2, z))
   }
 
-  let ln = size(l)
-  let rn = size(r)
+  let ln = l.size()
+  let rn = r.size()
   if ln + rn < 2 {
     make_tree(key, value, l, r)
   } else if rn > ratio * ln {
     // right is too big
     guard r is Tree(_, rl, rr, ..)
-    let rln = size(rl)
-    let rrn = size(rr)
+    let rln = rl.size()
+    let rrn = rr.size()
     if rln < rrn {
       single_l(key, value, l, r)
     } else {
@@ -189,8 +189,8 @@ fn[K : Compare, V] balance(
   } else if ln > ratio * rn {
     // left is too big
     guard l is Tree(_, ll, lr, ..)
-    let lln = size(ll)
-    let lrn = size(lr)
+    let lln = ll.size()
+    let lrn = lr.size()
     if lrn < lln {
       single_r(key, value, l, r)
     } else {
@@ -370,7 +370,7 @@ test "glue" {
     Tree(_, l, r, ..) => (l, r)
     _ => abort("unreachable")
   }
-  let m = l.glue(r)
+  let m = glue(l, r)
   assert_eq!(m.debug_tree(), "(2,two,(1,one,(0,zero,_,_),_),(8,eight,_,_))")
 }
 

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -65,7 +65,7 @@ pub fn[K, V] is_empty(self : T[K, V]) -> Bool {
 
 ///|
 fn[K, V] make_tree(key : K, value : V, l : T[K, V], r : T[K, V]) -> T[K, V] {
-  let size = size(l) + size(r) + 1
+  let size = l.size() + r.size() + 1
   Tree(key, value~, size~, l, r)
 }
 
@@ -109,9 +109,9 @@ pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit) -> Unit {
   match self {
     Empty => ()
     Tree(k, value~, l, r, ..) => {
-      each(l, f)
+      l.each(f)
       f(k, value)
-      each(r, f)
+      r.each(f)
     }
   }
 }
@@ -124,8 +124,8 @@ pub fn[K, V] eachi(self : T[K, V], f : (Int, K, V) -> Unit) -> Unit {
       Empty => ()
       Tree(k, value~, l, r, ..) => {
         do_eachi(l, f, i)
-        f(size(l) + i, k, value)
-        do_eachi(r, f, size(l) + i + 1)
+        f(l.size() + i, k, value)
+        do_eachi(r, f, l.size() + i + 1)
       }
     }
   }
@@ -139,7 +139,7 @@ pub fn[K, X, Y] map(self : T[K, X], f : (X) -> Y) -> T[K, Y] {
   match self {
     Empty => Empty
     Tree(k, value~, size~, l, r) =>
-      Tree(k, value=f(value), size~, map(l, f), map(r, f))
+      Tree(k, value=f(value), size~, l.map(f), r.map(f))
   }
 }
 
@@ -149,7 +149,7 @@ pub fn[K, X, Y] map_with_key(self : T[K, X], f : (K, X) -> Y) -> T[K, Y] {
   match self {
     Empty => Empty
     Tree(k, value~, l, r, size~) =>
-      Tree(k, value=f(k, value), size~, map_with_key(l, f), map_with_key(r, f))
+      Tree(k, value=f(k, value), size~, l.map_with_key(f), r.map_with_key(f))
   }
 }
 
@@ -157,7 +157,7 @@ pub fn[K, X, Y] map_with_key(self : T[K, X], f : (K, X) -> Y) -> T[K, Y] {
 /// Fold the values in the map.
 /// O(n).
 pub fn[K, V, A] fold(self : T[K, V], init~ : A, f : (A, V) -> A) -> A {
-  foldl_with_key(self, fn(acc, _k, v) { f(acc, v) }, init~)
+  self.foldl_with_key(fn(acc, _k, v) { f(acc, v) }, init~)
 }
 
 ///|
@@ -201,8 +201,8 @@ fn[K : Show, V : Show] debug_tree(self : T[K, V]) -> String {
   match self {
     Empty => "_"
     Tree(k, value~, l, r, ..) => {
-      let l = debug_tree(l)
-      let r = debug_tree(r)
+      let l = l.debug_tree()
+      let r = r.debug_tree()
       "(\{k},\{value},\{l},\{r})"
     }
   }

--- a/int/README.mbt.md
+++ b/int/README.mbt.md
@@ -27,7 +27,7 @@ test "byte conversions" {
   let num = 258 // 0x0102 in hex
 
   // Big-endian conversion (most significant byte first)
-  let be_bytes = @int.to_be_bytes(num)
+  let be_bytes = num.to_be_bytes()
   inspect(
     be_bytes.to_string(),
     content=
@@ -36,7 +36,7 @@ test "byte conversions" {
   )
 
   // Little-endian conversion (least significant byte first)
-  let le_bytes = @int.to_le_bytes(num)
+  let le_bytes = num.to_le_bytes()
   inspect(
     le_bytes.to_string(),
     content=

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -38,13 +38,16 @@ pub let min_value = -2147483648
 ///   inspect(@int.abs(0), content="0")
 /// }
 /// ```
-pub fn abs(self : Int) -> Int {
+pub fn Int::abs(self : Int) -> Int {
   if self < 0 {
     -self
   } else {
     self
   }
 }
+
+///|
+pub fnalias Int::abs
 
 ///| Converts the Int to a Bytes in big-endian byte order.
 pub fn to_be_bytes(self : Int) -> Bytes {

--- a/int/int_test.mbt
+++ b/int/int_test.mbt
@@ -52,7 +52,7 @@ test "abs function coverage" {
 
 ///|
 test "to_le_bytes" {
-  let bytes = @int.to_le_bytes(0x12345678)
+  let bytes = (0x12345678).to_le_bytes()
   inspect(
     bytes,
     content=
@@ -63,7 +63,7 @@ test "to_le_bytes" {
 
 ///|
 test "to_be_bytes" {
-  let bytes = @int.to_be_bytes(0x12345678)
+  let bytes = (0x12345678).to_be_bytes()
   inspect(
     bytes,
     content=

--- a/int64/README.mbt.md
+++ b/int64/README.mbt.md
@@ -28,8 +28,8 @@ The package provides functions to convert `Int64` values to their binary represe
 ```moonbit
 test "binary conversion" {
   let x = 258L // Int64 value of 258
-  let be_bytes = @int64.to_be_bytes(x)
-  let le_bytes = @int64.to_le_bytes(x)
+  let be_bytes = x.to_be_bytes()
+  let le_bytes = x.to_le_bytes()
 
   // Convert to String for inspection
   inspect(

--- a/int64/int64.mbt
+++ b/int64/int64.mbt
@@ -62,13 +62,16 @@ pub fn from_int(i : Int) -> Int64 {
 ///   inspect(0L.abs(), content="0")
 /// }
 /// ```
-pub fn abs(self : Int64) -> Int64 {
+pub fn Int64::abs(self : Int64) -> Int64 {
   if self < 0L {
     -self
   } else {
     self
   }
 }
+
+///|
+pub fnalias Int64::abs
 
 ///| Converts the Int64 to a Bytes in big-endian byte order.
 pub fn to_be_bytes(self : Int64) -> Bytes {

--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -26,7 +26,7 @@ test "parse and validate jsons" {
 
   // Pretty print with indentation
   inspect(
-    @json.stringify(json, indent=2),
+    json.stringify(indent=2),
     content=
       #|{
       #|  "key": 42

--- a/json/from_to_json_test.mbt
+++ b/json/from_to_json_test.mbt
@@ -26,7 +26,7 @@ test {
   let e = Expr::Add(Val("x"), Val("y"))
   let ej = e.to_json()
   inspect(
-    ej |> @json.stringify,
+    ej.stringify(),
     content=
       #|{"$tag":"Add","0":{"$tag":"Val","0":"x"},"1":{"$tag":"Val","0":"y"}}
     ,

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -14,34 +14,27 @@
 
 ///|
 test "get as null" {
-  inspect(Json::null() |> @json.as_null, content="Some(())")
-  inspect(Json::boolean(true) |> @json.as_null, content="None")
-  inspect(Json::boolean(false) |> @json.as_null, content="None")
-  inspect(Json::number(1.0) |> @json.as_null, content="None")
-  inspect(Json::string("Hello World") |> @json.as_null, content="None")
+  inspect(Json::null().as_null(), content="Some(())")
+  inspect(Json::boolean(true).as_null(), content="None")
+  inspect(Json::boolean(false).as_null(), content="None")
+  inspect(Json::number(1.0).as_null(), content="None")
+  inspect(Json::string("Hello World").as_null(), content="None")
+  inspect(Json::array([Json::string("Hello World")]).as_null(), content="None")
   inspect(
-    Json::array([Json::string("Hello World")]) |> @json.as_null,
-    content="None",
-  )
-  inspect(
-    Json::object({ "key": Json::string("key"), "value": Json::number(100.0) })
-    |> @json.as_null,
+    Json::object({ "key": Json::string("key"), "value": Json::number(100.0) }).as_null(),
     content="None",
   )
 }
 
 ///|
 test "get as bool" {
-  inspect(Json::null() |> @json.as_bool, content="None")
-  inspect(Json::boolean(true) |> @json.as_bool, content="Some(true)")
-  inspect(Json::boolean(false) |> @json.as_bool, content="Some(false)")
-  inspect(Json::number(1.0) |> @json.as_bool, content="None")
-  inspect(Json::string("Hello World") |> @json.as_bool, content="None")
-  inspect(
-    Json::array([Json::string("Hello World")]) |> @json.as_bool,
-    content="None",
-  )
-  inspect({ "key": "key", "value": 100.0 } |> @json.as_bool, content="None")
+  inspect(Json::null().as_bool(), content="None")
+  inspect(Json::boolean(true).as_bool(), content="Some(true)")
+  inspect(Json::boolean(false).as_bool(), content="Some(false)")
+  inspect(Json::number(1.0).as_bool(), content="None")
+  inspect(Json::string("Hello World").as_bool(), content="None")
+  inspect(Json::array([Json::string("Hello World")]).as_bool(), content="None")
+  inspect(Json::as_bool({ "key": "key", "value": 100.0 }), content="None")
 }
 
 ///|
@@ -58,119 +51,102 @@ fn check2!(x : String) -> Json!@json.ParseError {
 test "get as number" {
   let _ = check
   let _ = check2
-  inspect(Json::null() |> @json.as_number, content="None")
-  inspect(Json::boolean(false) |> @json.as_number, content="None")
-  inspect(Json::boolean(true) |> @json.as_number, content="None")
-  inspect(Json::number(1.0) |> @json.as_number, content="Some(1)")
-  inspect(Json::string("Hello World") |> @json.as_number, content="None")
+  inspect(Json::null().as_number(), content="None")
+  inspect(Json::boolean(false).as_number(), content="None")
+  inspect(Json::boolean(true).as_number(), content="None")
+  inspect(Json::number(1.0).as_number(), content="Some(1)")
+  inspect(Json::string("Hello World").as_number(), content="None")
   inspect(
-    Json::array([Json::string("Hello World")]) |> @json.as_number,
+    Json::array([Json::string("Hello World")]).as_number(),
     content="None",
   )
   inspect(
     Json::object(
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
-    )
-    |> @json.as_number,
+    ).as_number(),
     content="None",
   )
 }
 
 ///|
 test "get as string" {
-  inspect(Json::null() |> @json.as_string, content="None")
-  inspect(Json::boolean(true) |> @json.as_string, content="None")
-  inspect(Json::boolean(false) |> @json.as_string, content="None")
-  inspect(Json::number(1.0) |> @json.as_string, content="None")
+  inspect(Json::null().as_string(), content="None")
+  inspect(Json::boolean(true).as_string(), content="None")
+  inspect(Json::boolean(false).as_string(), content="None")
+  inspect(Json::number(1.0).as_string(), content="None")
   inspect(
-    Json::string("Hello World") |> @json.as_string,
+    Json::string("Hello World").as_string(),
     content=
       #|Some("Hello World")
     ,
   )
   inspect(
-    Json::array([Json::string("Hello World")]) |> @json.as_string,
+    Json::array([Json::string("Hello World")]).as_string(),
     content="None",
   )
   inspect(
     Json::object(
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
-    )
-    |> @json.as_string,
+    ).as_string(),
     content="None",
   )
 }
 
 ///|
 test "get as array" {
-  inspect(Json::null() |> @json.as_array, content="None")
-  inspect(Json::boolean(true) |> @json.as_array, content="None")
-  inspect(Json::boolean(false) |> @json.as_array, content="None")
-  inspect(Json::number(1.0) |> @json.as_array, content="None")
-  inspect(Json::string("Hello World") |> @json.as_array, content="None")
+  inspect(Json::null().as_array(), content="None")
+  inspect(Json::boolean(true).as_array(), content="None")
+  inspect(Json::boolean(false).as_array(), content="None")
+  inspect(Json::number(1.0).as_array(), content="None")
+  inspect(Json::string("Hello World").as_array(), content="None")
   inspect(
-    Json::array([Json::string("Hello World")]) |> @json.as_array,
+    Json::array([Json::string("Hello World")]).as_array(),
     content=
       #|Some([String("Hello World")])
     ,
   )
   inspect(
-    Json::array([Json::string("Hello World")]).item(0).bind(@json.as_string),
+    Json::array([Json::string("Hello World")]).item(0).bind(Json::as_string),
     content=
       #|Some("Hello World")
     ,
   )
   inspect(
-    Json::array([Json::string("Hello World")]).item(1).bind(@json.as_string),
+    Json::array([Json::string("Hello World")]).item(1).bind(Json::as_string),
     content="None",
   )
   inspect(
-    Json::array([Json::string("Hello World")]).item(0).bind(@json.as_number),
+    Json::array([Json::string("Hello World")]).item(0).bind(Json::as_number),
     content="None",
   )
   inspect(
     Json::object(
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
-    )
-    |> @json.as_array,
+    ).as_array(),
     content="None",
   )
 }
 
 ///|
 test "get as object" {
+  inspect(Json::null().as_object().map(_.to_array()), content="None")
+  inspect(Json::boolean(true).as_object().map(_.to_array()), content="None")
+  inspect(Json::boolean(false).as_object().map(_.to_array()), content="None")
+  inspect(Json::number(1.0).as_object().map(_.to_array()), content="None")
   inspect(
-    Json::null() |> @json.as_object |> @option.map(Map::to_array),
+    Json::string("Hello World").as_object().map(_.to_array()),
     content="None",
   )
   inspect(
-    Json::boolean(true) |> @json.as_object |> @option.map(Map::to_array),
-    content="None",
-  )
-  inspect(
-    Json::boolean(false) |> @json.as_object |> @option.map(Map::to_array),
-    content="None",
-  )
-  inspect(
-    Json::number(1.0) |> @json.as_object |> @option.map(Map::to_array),
-    content="None",
-  )
-  inspect(
-    Json::string("Hello World") |> @json.as_object |> @option.map(Map::to_array),
-    content="None",
-  )
-  inspect(
-    Json::array([Json::string("Hello World")])
-    |> @json.as_object
-    |> @option.map(Map::to_array),
+    Json::array([Json::string("Hello World")]).as_object().map(_.to_array()),
     content="None",
   )
   inspect(
     Json::object(
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
     )
-    |> @json.as_object
-    |> @option.map(Map::to_array),
+    .as_object()
+    .map(_.to_array()),
     content=
       #|Some([("key", String("key")), ("value", Number(100))])
     ,
@@ -180,7 +156,7 @@ test "get as object" {
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
     )
     .value("key")
-    .bind(@json.as_string),
+    .bind(_.as_string()),
     content=
       #|Some("key")
     ,
@@ -190,7 +166,7 @@ test "get as object" {
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
     )
     .value("value")
-    .bind(@json.as_number),
+    .bind(_.as_number()),
     content="Some(100)",
   )
   inspect(
@@ -198,7 +174,7 @@ test "get as object" {
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
     )
     .value("key")
-    .bind(@json.as_number),
+    .bind(_.as_number()),
     content="None",
   )
   inspect(
@@ -206,7 +182,7 @@ test "get as object" {
       Map::of([("key", Json::string("key")), ("value", Json::number(100.0))]),
     )
     .value("asdf")
-    .bind(@json.as_number),
+    .bind(_.as_number()),
     content="None",
   )
 }
@@ -221,38 +197,38 @@ test "deep access" {
     "bool": false,
     "obj": {},
   }
-  inspect(json.value("null").bind(@json.as_null), content="Some(())")
+  inspect(json.value("null").bind(Json::as_null), content="Some(())")
   inspect(
-    json.value("key").bind(fn { array => array.item(2) }).bind(@json.as_null),
+    json.value("key").bind(fn { array => array.item(2) }).bind(Json::as_null),
     content="Some(())",
   )
-  inspect(json.value("bool").bind(@json.as_bool), content="Some(false)")
+  inspect(json.value("bool").bind(Json::as_bool), content="Some(false)")
   inspect(
-    json.value("key").bind(fn { array => array.item(1) }).bind(@json.as_bool),
+    json.value("key").bind(fn { array => array.item(1) }).bind(Json::as_bool),
     content="Some(true)",
   )
   inspect(
-    json.value("key").bind(@json.as_array),
+    json.value("key").bind(Json::as_array),
     content=
       #|Some([Number(1), True, Null, Array([]), Object({"key": String("value"), "value": Number(100)})])
     ,
   )
   inspect(
-    json.value("key").bind(fn { array => array.item(3) }).bind(@json.as_array),
+    json.value("key").bind(fn { array => array.item(3) }).bind(Json::as_array),
     content="Some([])",
   )
   inspect(
     json
     .value("key")
     .bind(fn { array => array.item(4) })
-    .bind(@json.as_object)
-    .map(Map::to_array),
+    .bind(_.as_object())
+    .map(_.to_array()),
     content=
       #|Some([("key", String("value")), ("value", Number(100))])
     ,
   )
   inspect(
-    json.value("obj").bind(@json.as_object).map(Map::to_array),
+    json.value("obj").bind(_.as_object()).map(_.to_array()),
     content="Some([])",
   )
 }
@@ -371,13 +347,13 @@ test "string from and to json round trip" {
 test "escape" {
   let s = "http://example.com/"
   inspect(
-    @json.stringify(Json::string(s), escape_slash=true),
+    Json::string(s).stringify(escape_slash=true),
     content=
       #|"http:\/\/example.com\/"
     ,
   )
   inspect(
-    @json.stringify(Json::string(s)),
+    Json::string(s).stringify(),
     content=
       #|"http://example.com/"
     ,

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -206,7 +206,7 @@ test "optional field" {
     { x: None, t: Some(None) },
   ]
   inspect(
-    opt.to_json() |> @json.stringify,
+    opt.to_json().stringify(),
     content=
       #|[{"x":42,"t":[42]},{},{"t":null}]
     ,

--- a/list/README.mbt.md
+++ b/list/README.mbt.md
@@ -199,7 +199,7 @@ Flatten a list of lists.
 
 ```moonbit
 test {
-  let list = @list.flatten(@list.of([@list.of([1, 2]), @list.of([3, 4])]))
+  let list = @list.of([@list.of([1, 2]), @list.of([3, 4])]).flatten()
   assert_eq!(list, @list.of([1, 2, 3, 4]))
 }
 ```

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -784,9 +784,9 @@ pub fn[A : Compare] sort(self : T[A]) -> T[A] {
   match self {
     Empty => Empty
     More(x, tail=xs) => {
-      let smaller = filter(xs, fn(y) { y < x })
-      let greater = filter(xs, fn(y) { y >= x })
-      concat(sort(smaller), More(x, tail=sort(greater)))
+      let smaller = xs.filter(fn(y) { y < x })
+      let greater = xs.filter(fn(y) { y >= x })
+      smaller.sort().concat(More(x, tail=greater.sort()))
     }
   }
 }

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -22,7 +22,7 @@ test "from_array" {
 
 ///|
 test "pipe" {
-  inspect(1 |> @list.prepend(@list.empty(), _), content="@list.of([1])")
+  inspect(1 |> @list.T::prepend(@list.empty(), _), content="@list.of([1])")
 }
 
 ///|
@@ -86,8 +86,8 @@ test "rev_map" {
 test "to_array" {
   let list = @list.of([1, 2, 3, 4, 5])
   let empty : @list.T[Int] = @list.empty()
-  let array = @list.to_array(list)
-  let earray = @list.to_array(empty)
+  let array = list.to_array()
+  let earray = empty.to_array()
   inspect(array, content="[1, 2, 3, 4, 5]")
   inspect(earray, content="[]")
 }
@@ -284,7 +284,7 @@ test "is_empty" {
 ///|
 test "unzip" {
   let ls = @list.of([(1, 2), (3, 4), (5, 6)])
-  let (a, b) = @list.unzip(ls)
+  let (a, b) = ls.unzip()
   inspect(a, content="@list.of([1, 3, 5])")
   inspect(b, content="@list.of([2, 4, 6])")
 }
@@ -371,16 +371,16 @@ test "drop" {
 
 ///|
 test "take_while" {
-  let ls = @list.take_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.take_while(@list.empty(), fn(_e) { true })
+  let ls = @list.of([0, 1, 2, 3, 4]).take_while(fn(x) { x < 3 })
+  let el : @list.T[Int] = @list.empty().take_while(fn(_e) { true })
   inspect(ls, content="@list.of([0, 1, 2])")
   inspect(el, content="@list.of([])")
 }
 
 ///|
 test "drop_while" {
-  let ls = @list.drop_while(@list.of([0, 1, 2, 3, 4]), fn(x) { x < 3 })
-  let el : @list.T[Int] = @list.drop_while(@list.empty(), fn(_e) { true })
+  let ls = @list.of([0, 1, 2, 3, 4]).drop_while(fn(x) { x < 3 })
+  let el : @list.T[Int] = @list.empty().drop_while(fn(_e) { true })
   inspect(ls, content="@list.of([3, 4])")
   inspect(el, content="@list.of([])")
 }
@@ -621,14 +621,14 @@ test "eachi" {
 ///|
 test "List::head_exn with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let head = @list.head(list)
+  let head = list.head()
   assert_eq!(head, Some(1))
 }
 
 ///|
 test "List::last with non-empty list" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let last = @list.last(list)
+  let last = list.last()
   assert_eq!(last, Some(5))
 }
 
@@ -652,14 +652,14 @@ test "@list.zip with empty list" {
 ///|
 test "List::nth_exn with valid index" {
   let list = @list.of([1, 2, 3, 4, 5])
-  let nth = @list.nth(list, 2)
+  let nth = list.nth(2)
   assert_eq!(nth, Some(3))
 }
 
 ///|
 test "List::maximum with non-empty list" {
   let list = @list.of([1, 3, 5, 2, 4])
-  let max = @list.maximum(list)
+  let max = list.maximum()
   assert_eq!(max, Some(5))
 }
 
@@ -671,7 +671,7 @@ test "@list.maximum with empty list" {
 ///|
 test "List::minimum with non-empty list" {
   let list = @list.of([1, 3, 5, 2, 4])
-  let min = @list.minimum(list)
+  let min = list.minimum()
   assert_eq!(min, Some(1))
 }
 

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -226,9 +226,9 @@ pub fn[T] flatten(self : T??) -> T? {
 ///|
 test "flatten" {
   let a : Int?? = Some(Some(42))
-  assert_eq!(flatten(a), Some(42))
+  assert_eq!(a.flatten(), Some(42))
   let b : Int?? = Some(None)
-  assert_eq!(flatten(b), None)
+  assert_eq!(b.flatten(), None)
 }
 
 ///|

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -138,7 +138,7 @@ pub fn[A] unsafe_peek(self : T[A]) -> A {
 #deprecated("Use `unsafe_peek` instead")
 #coverage.skip
 pub fn[A] peek_exn(self : T[A]) -> A {
-  unsafe_peek(self)
+  self.unsafe_peek()
 }
 
 ///|
@@ -184,7 +184,7 @@ pub fn[A] unsafe_pop(self : T[A]) -> A {
 #deprecated("Use `unsafe_pop` instead")
 #coverage.skip
 pub fn[A] pop_exn(self : T[A]) -> A {
-  unsafe_pop(self)
+  self.unsafe_pop()
 }
 
 ///|

--- a/quickcheck/splitmix/random_test.mbt
+++ b/quickcheck/splitmix/random_test.mbt
@@ -28,7 +28,7 @@ test "next_two_uint should return two 32-bit unsigned integers" {
 ///|
 test "clone_random_state" {
   let state = @splitmix.new(seed=42UL)
-  let cloned = @splitmix.clone(state)
+  let cloned = state.clone()
 
   // Generate some values from both states to ensure they behave the same
   let orig_int = state.next_int()

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -116,13 +116,13 @@ pub fn reciprocal(self : T) -> T {
 
 ///|
 /// Returns the negation of a rational number.
-pub fn neg(self : T) -> T {
+pub fn T::neg(self : T) -> T {
   new_unchecked(-self.numerator, self.denominator)
 }
 
 ///|
 /// Returns the absolute value of a rational number.
-pub fn abs(self : T) -> T {
+pub fn T::abs(self : T) -> T {
   new_unchecked(self.numerator.abs(), self.denominator.abs())
 }
 
@@ -256,7 +256,7 @@ pub fn from_double(value : Double) -> T!RationalError {
 
 ///|
 /// Ceils a rational number towards positive infinity.
-pub fn ceil(self : T) -> Int64 {
+pub fn T::ceil(self : T) -> Int64 {
   let sign = if self.numerator < 0L { -1L } else { 1L }
   let quotient = self.numerator / self.denominator
   if self.numerator % self.denominator == 0L {
@@ -268,7 +268,7 @@ pub fn ceil(self : T) -> Int64 {
 
 ///|
 /// Floors a rational number towards negative infinity.
-pub fn floor(self : T) -> Int64 {
+pub fn T::floor(self : T) -> Int64 {
   let sign = if self.numerator < 0L { -1L } else { 1L }
   let quotient = self.numerator / self.denominator
   if self.numerator % self.denominator == 0L {
@@ -280,7 +280,7 @@ pub fn floor(self : T) -> Int64 {
 
 ///|
 /// Rounds a rational number towards zero.
-pub fn trunc(self : T) -> Int64 {
+pub fn T::trunc(self : T) -> Int64 {
   if self.numerator < 0L {
     -(-self.numerator / self.denominator)
   } else {
@@ -326,6 +326,9 @@ pub impl @quickcheck.Arbitrary for T with arbitrary(size, rs) {
 pub fn is_integer(self : T) -> Bool {
   self.denominator == 1L
 }
+
+///|
+pub fnalias T::(neg, abs, ceil, floor, trunc)
 
 ///|
 test "op_add" {
@@ -451,13 +454,13 @@ test "op_div" {
 test "reciprocal" {
   // 1/2 -> 2/1
   let a = new_unchecked(1L, 2L)
-  let b = reciprocal(a)
+  let b = a.reciprocal()
   assert_eq!(b.numerator, 2L)
   assert_eq!(b.denominator, 1L)
 
   // -1/2 -> -2/1
   let a = new_unchecked(-1L, 2L)
-  let b = reciprocal(a)
+  let b = a.reciprocal()
   assert_eq!(b.numerator, -2L)
   assert_eq!(b.denominator, 1L)
 }
@@ -568,25 +571,25 @@ test "trunc" {
 test "fract" {
   // 1/2 -> 1/2
   let a = new_unchecked(1L, 2L)
-  let b = fract(a)
+  let b = a.fract()
   assert_eq!(b.numerator, 1L)
   assert_eq!(b.denominator, 2L)
 
   // -1/2 -> -1/2
   let a = new_unchecked(-1L, 2L)
-  let b = fract(a)
+  let b = a.fract()
   assert_eq!(b.numerator, -1L)
   assert_eq!(b.denominator, 2L)
 
   // 3/2 -> 1/2
   let a = new_unchecked(3L, 2L)
-  let b = fract(a)
+  let b = a.fract()
   assert_eq!(b.numerator, 1L)
   assert_eq!(b.denominator, 2L)
 
   // -3/2 -> -1/2
   let a = new_unchecked(-3L, 2L)
-  let b = fract(a)
+  let b = a.fract()
   assert_eq!(b.numerator, -1L)
   assert_eq!(b.denominator, 2L)
 }

--- a/ref/README.mbt.md
+++ b/ref/README.mbt.md
@@ -20,7 +20,7 @@ The `update` function allows modifying the contained value using a transformatio
 ```moonbit
 test "updating refs" {
   let counter = @ref.new(0)
-  @ref.update(counter, fn(x) { x + 1 })
+  counter.update(fn(x) { x + 1 })
   inspect(counter.val, content="1")
   counter.update(fn(x) { x * 2 })
   inspect(counter.val, content="2")
@@ -34,7 +34,7 @@ The `map` function transforms a reference while preserving the reference wrapper
 ```moonbit
 test "mapping refs" {
   let num = @ref.new(10)
-  let doubled = @ref.map(num, fn(x) { x * 2 })
+  let doubled = num.map(fn(x) { x * 2 })
   inspect(doubled.val, content="20")
   let squared = num.map(fn(x) { x * x })
   inspect(squared.val, content="100")
@@ -63,7 +63,7 @@ The `protect` function temporarily sets a reference to a value and restores it a
 test "protected updates" {
   let state = @ref.new(100)
   let mut middle = 0
-  let result = @ref.protect(state, 50, fn() {
+  let result = state.protect(50, fn() {
     middle = state.val
     42
   })

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -81,11 +81,14 @@ pub fn[T, R] protect(self : Ref[T], a : T, f : () -> R) -> R {
 /// assert_eq!(x.val, 2)
 /// assert_eq!(y.val, 1)
 /// ```
-pub fn[T] swap(self : Ref[T], that : Ref[T]) -> Unit {
+pub fn[T] Ref::swap(self : Ref[T], that : Ref[T]) -> Unit {
   let tmp = self.val
   self.val = that.val
   that.val = tmp
 }
+
+///|
+pub fnalias Ref::swap
 
 ///|
 test "swap" {

--- a/ref/ref_test.mbt
+++ b/ref/ref_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test "map" {
   let x = @ref.new(1)
-  let y = @ref.map(x, fn(a) { a + 1 })
+  let y = x.map(fn(a) { a + 1 })
   assert_eq!(y.val, 2)
 }
 
@@ -24,7 +24,7 @@ test "protect" {
   let x = @ref.new(1)
   assert_eq!(x.val, 1)
   let mut r = 0
-  @ref.protect(x, 2, fn() { r = x.val })
+  x.protect(2, fn() { r = x.val })
   assert_eq!(r, 2)
   assert_eq!(x.val, 1)
 }
@@ -32,35 +32,35 @@ test "protect" {
 ///|
 test "update with increment function" {
   let a = @ref.new(1)
-  @ref.update(a, fn(x) { x + 1 })
+  a.update(fn(x) { x + 1 })
   assert_eq!(a.val, 2)
 }
 
 ///|
 test "update with decrement function" {
   let a = @ref.new(1)
-  @ref.update(a, fn(x) { x - 1 })
+  a.update(fn(x) { x - 1 })
   assert_eq!(a.val, 0)
 }
 
 ///|
 test "update with multiplication function" {
   let a = @ref.new(2)
-  @ref.update(a, fn(x) { x * 2 })
+  a.update(fn(x) { x * 2 })
   assert_eq!(a.val, 4)
 }
 
 ///|
 test "update with division function" {
   let a = @ref.new(4)
-  @ref.update(a, fn(x) { x / 2 })
+  a.update(fn(x) { x / 2 })
   assert_eq!(a.val, 2)
 }
 
 ///|
 test "update with identity function" {
   let a = @ref.new(1)
-  @ref.update(a, fn(x) { x })
+  a.update(fn(x) { x })
   assert_eq!(a.val, 1)
 }
 

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -114,8 +114,8 @@ pub fn[T, E] is_ok(self : Result[T, E]) -> Bool {
 test "is_ok" {
   let x : Result[Int, String] = Ok(6)
   let y : Result[Int, String] = Err("error")
-  assert_eq!(is_ok(x), true)
-  assert_eq!(is_ok(y), false)
+  assert_eq!(x.is_ok(), true)
+  assert_eq!(y.is_ok(), false)
 }
 
 ///|
@@ -128,8 +128,8 @@ pub fn[T, E] is_err(self : Result[T, E]) -> Bool {
 test "is_err" {
   let x : Result[Int, String] = Ok(6)
   let y : Result[Int, String] = Err("error")
-  assert_eq!(is_err(x), false)
-  assert_eq!(is_err(y), true)
+  assert_eq!(x.is_err(), false)
+  assert_eq!(y.is_err(), true)
 }
 
 ///|
@@ -181,8 +181,8 @@ pub fn[T, E] or_else(self : Result[T, E], default : () -> T) -> T {
 test "or_else" {
   let x : Result[Int, String] = Ok(6)
   let y : Result[Int, String] = Err("error")
-  let z = or_else(x, fn() { 0 })
-  let w = or_else(y, fn() { 0 })
+  let z = x.or_else(fn() { 0 })
+  let w = y.or_else(fn() { 0 })
   assert_eq!(z, 6)
   assert_eq!(w, 0)
 }
@@ -239,7 +239,7 @@ pub fn[T, E, U] bind(
 ///|
 test "bind" {
   let x : Result[Int, String] = Ok(6)
-  let y = bind(x, fn(v : Int) { Ok(v * 7) })
+  let y = x.bind(fn(v : Int) { Ok(v * 7) })
   assert_eq!(y, Ok(42))
 }
 
@@ -264,9 +264,9 @@ pub fn[T, E, V] fold(self : Result[T, E], ok : (T) -> V, err : (E) -> V) -> V {
 ///|
 test "fold" {
   let x : Result[Int, String] = Ok(6)
-  let y = fold(x, fn(v : Int) -> Int { v * 7 }, fn(_e : String) -> Int { 0 })
+  let y = x.fold(fn(v : Int) -> Int { v * 7 }, fn(_e : String) -> Int { 0 })
   let z : Result[Int, String] = Err("error")
-  let w = fold(z, fn(v : Int) -> Int { v * 7 }, fn(_e : String) -> Int { 0 })
+  let w = z.fold(fn(v : Int) -> Int { v * 7 }, fn(_e : String) -> Int { 0 })
   assert_eq!(y, 42)
   assert_eq!(w, 0)
 }
@@ -294,8 +294,8 @@ pub fn[T, E] to_option(self : Result[T, E]) -> T? {
 test "to_option" {
   let x : Result[Int, String] = Ok(6)
   let y : Result[Int, String] = Err("error")
-  let z = to_option(x)
-  let w = to_option(y)
+  let z = x.to_option()
+  let w = y.to_option()
   assert_eq!(z, Some(6))
   assert_eq!(w, None)
 }

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -53,7 +53,7 @@ pub fn[V : Compare] of(array : Array[V]) -> T[V] {
 #deprecated("Use `copy` instead")
 #coverage.skip
 pub fn[V] deep_clone(self : T[V]) -> T[V] {
-  copy(self)
+  self.copy()
 }
 
 ///|

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -92,7 +92,7 @@ pub fn parse_double(str : String) -> Double!StrConvError {
     syntax_err!()
   }
   // Clinger's fast path (How to read floating point numbers accurately)[https://doi.org/10.1145/989393.989430]
-  match try_fast_path(num) {
+  match num.try_fast_path() {
     Some(value) => value
     None => {
       // fallback to slow path

--- a/strconv/number.mbt
+++ b/strconv/number.mbt
@@ -36,7 +36,7 @@ fn to_digit(c : Char) -> Int {
 ///|
 /// Returns the remaining slice, the parsed number, and the number of digits parsed.
 fn parse_digits(s : StringSlice, x : UInt64) -> (StringSlice, UInt64, Int) {
-  fold_digits(s, x, fn(digit, acc : UInt64) {
+  s.fold_digits(x, fn(digit, acc : UInt64) {
     acc * 10UL + UInt64::extend_uint(digit.reinterpret_as_uint())
   })
 }
@@ -74,7 +74,7 @@ fn parse_scientific(s : StringSlice) -> (StringSlice, Int64)? {
     s = s.step_1_unchecked()
   }
   if s.first_is_digit() {
-    let (s, exp_num, _) = fold_digits(s, exp_num, fn(digit, exp_num : Int64) {
+    let (s, exp_num, _) = s.fold_digits(exp_num, fn(digit, exp_num : Int64) {
       if exp_num < 0x10000L {
         10L * exp_num + digit.to_int64() // no overflows here
       } else {

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -148,9 +148,9 @@ fn[T] fold_digits(
 
 ///|
 test "eq_ignore_case" {
-  assert_true!(prefix_eq_ignore_case(full_slice("nan"), "NaN"))
-  assert_true!(prefix_eq_ignore_case(full_slice("inf"), "inf"))
-  assert_true!(prefix_eq_ignore_case(full_slice("inf"), "Inf"))
+  assert_true!(full_slice("nan").prefix_eq_ignore_case("NaN"))
+  assert_true!(full_slice("inf").prefix_eq_ignore_case("inf"))
+  assert_true!(full_slice("inf").prefix_eq_ignore_case("Inf"))
 }
 
 ///|

--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -91,16 +91,16 @@ fn index_at_rev_(
 pub fn String::op_as_view(self : String, start~ : Int = 0, end? : Int) -> View {
   let str_len = self.length()
   let start = if start >= 0 {
-    index_at_(self, start, start=0).unwrap()._
+    self.index_at_(start, start=0).unwrap()._
   } else {
-    index_at_rev_(self, -start, end=str_len).unwrap()._
+    self.index_at_rev_(-start, end=str_len).unwrap()._
   }
   let end = match end {
     Some(end) =>
       if end >= 0 {
-        index_at_(self, end, start=0).unwrap()._
+        self.index_at_(end, start=0).unwrap()._
       } else {
-        index_at_rev_(self, -end, end=str_len).unwrap()._
+        self.index_at_rev_(-end, end=str_len).unwrap()._
       }
     None => str_len
   }
@@ -115,16 +115,16 @@ pub fn String::op_as_view(self : String, start~ : Int = 0, end? : Int) -> View {
 #coverage.skip
 pub fn View::op_as_view(self : View, start~ : Int = 0, end? : Int) -> View {
   let start = if start >= 0 {
-    index_at_(self.str, start, start=self.start).unwrap()._
+    self.str.index_at_(start, start=self.start).unwrap()._
   } else {
-    index_at_rev_(self.str, -start, end=self.end).unwrap()._
+    self.str.index_at_rev_(-start, end=self.end).unwrap()._
   }
   let end = match end {
     Some(end) =>
       if end >= 0 {
-        index_at_(self.str, end, start=self.start).unwrap()._
+        self.str.index_at_(end, start=self.start).unwrap()._
       } else {
-        index_at_rev_(self.str, -end, end=self.end).unwrap()._
+        self.str.index_at_rev_(-end, end=self.end).unwrap()._
       }
     None => self.end
   }

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -906,7 +906,7 @@ test "View::replace_all" {
 /// Converts this string to lowercase.
 pub fn View::to_lower(self : View) -> View {
   // TODO: deal with non-ascii characters
-  guard self.find_by(@char.is_ascii_uppercase) is Some(idx) else { return self }
+  guard self.find_by(_.is_ascii_uppercase()) is Some(idx) else { return self }
   let buf = StringBuilder::new(size_hint=self.length())
   buf.write_string(self.view(end_offset=idx).to_string())
   for c in self.view(start_offset=idx) {
@@ -924,7 +924,7 @@ pub fn View::to_lower(self : View) -> View {
 /// Converts this string to lowercase.
 pub fn to_lower(self : String) -> String {
   // TODO: deal with non-ascii characters
-  guard self.find_by(@char.is_ascii_uppercase) is Some(idx) else { return self }
+  guard self.find_by(_.is_ascii_uppercase()) is Some(idx) else { return self }
   let buf = StringBuilder::new(size_hint=self.length())
   buf.write_string(self.view(end_offset=idx).to_string())
   for c in self.view(start_offset=idx) {
@@ -956,7 +956,7 @@ test "View::to_lower" {
 /// Converts this string to uppercase.
 pub fn View::to_upper(self : View) -> View {
   // TODO: deal with non-ascii characters
-  guard self.find_by(@char.is_ascii_lowercase) is Some(idx) else { return self }
+  guard self.find_by(_.is_ascii_lowercase()) is Some(idx) else { return self }
   let buf = StringBuilder::new(size_hint=self.length())
   buf.write_string(self.view(end_offset=idx).to_string())
   for c in self.view(start_offset=idx) {
@@ -973,7 +973,7 @@ pub fn View::to_upper(self : View) -> View {
 /// Converts this string to uppercase.
 pub fn to_upper(self : String) -> String {
   // TODO: deal with non-ascii characters
-  guard self.find_by(@char.is_ascii_lowercase) is Some(idx) else { return self }
+  guard self.find_by(_.is_ascii_lowercase()) is Some(idx) else { return self }
   let buf = StringBuilder::new(size_hint=self.length())
   buf.write_string(self.view(end_offset=idx).to_string())
   for c in self.view(start_offset=idx) {

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -543,11 +543,11 @@ test "String::fold" {
   let s = "this is a long string"
   inspect(s.fold(init=0, fn(acc, c) { acc + c.to_int() }), content="1980")
   inspect(
-    s.fold(init=@list.empty(), @list.prepend) |> @list.rev(),
+    s.fold(init=@list.empty(), _.prepend(_)).rev(),
     content="@list.of(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
   inspect(
-    s.rev_fold(init=@list.empty(), @list.prepend),
+    s.rev_fold(init=@list.empty(), _.prepend(_)),
     content="@list.of(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
 }

--- a/uint/README.mbt.md
+++ b/uint/README.mbt.md
@@ -26,7 +26,7 @@ test "uint byte conversion" {
   let num = 258U // 0x00000102 in hex
 
   // Big-endian bytes (most significant byte first)
-  let be_bytes = @uint.to_be_bytes(num)
+  let be_bytes = num.to_be_bytes()
   inspect(
     be_bytes,
     content=
@@ -35,7 +35,7 @@ test "uint byte conversion" {
   )
 
   // Little-endian bytes (least significant byte first)
-  let le_bytes = @uint.to_le_bytes(num)
+  let le_bytes = num.to_le_bytes()
   inspect(
     le_bytes,
     content=
@@ -52,9 +52,9 @@ test "uint byte conversion" {
 ```moonbit
 test "uint type conversion" {
   let num = 42U
-  inspect(@uint.to_int64(num), content="42")
+  inspect(num.to_int64(), content="42")
   let large_num = 4294967295U // max value
-  inspect(@uint.to_int64(large_num), content="4294967295")
+  inspect(large_num.to_int64(), content="4294967295")
 }
 ```
 

--- a/uint/uint_test.mbt
+++ b/uint/uint_test.mbt
@@ -64,7 +64,7 @@ test "default" {
 ///|
 test "to_le_bytes" {
   let x : UInt = 0x12345678U
-  let bytes = @uint.to_le_bytes(x)
+  let bytes = x.to_le_bytes()
   inspect(bytes[0].to_int(), content="120") // 0x78
   inspect(bytes[1].to_int(), content="86") // 0x56
   inspect(bytes[2].to_int(), content="52") // 0x34
@@ -79,5 +79,5 @@ test "test UInt::default" {
 ///|
 test "to_be_bytes" {
   let n = 4294967295U // maximum UInt value
-  inspect(@uint.to_be_bytes(n), content="b\"\\xff\\xff\\xff\\xff\"")
+  inspect(n.to_be_bytes(), content="b\"\\xff\\xff\\xff\\xff\"")
 }

--- a/uint64/README.mbt.md
+++ b/uint64/README.mbt.md
@@ -100,7 +100,7 @@ UInt64 provides methods for converting to bytes in both big-endian and little-en
 ```moonbit
 test "UInt64 byte conversion" {
   // Convert to bytes in big-endian order (most significant byte first)
-  let be_bytes = @uint64.to_be_bytes(0x123456789ABCDEF0UL)
+  let be_bytes = (0x123456789ABCDEF0UL).to_be_bytes()
   inspect(
     be_bytes,
     content=
@@ -109,7 +109,7 @@ test "UInt64 byte conversion" {
   )
 
   // Convert to bytes in little-endian order (least significant byte first)
-  let le_bytes = @uint64.to_le_bytes(0x123456789ABCDEF0UL)
+  let le_bytes = (0x123456789ABCDEF0UL).to_le_bytes()
   inspect(
     le_bytes,
     content=
@@ -191,7 +191,7 @@ test "UInt64 hexadecimal literals" {
   inspect(ad.to_byte(), content="b'\\xAD'")
 
   // Convert to byte representation
-  let bytes = @uint64.to_be_bytes(value)
+  let bytes = value.to_be_bytes()
   inspect(
     bytes,
     content=

--- a/uint64/uint64.mbt
+++ b/uint64/uint64.mbt
@@ -49,19 +49,19 @@ pub fn to_le_bytes(self : UInt64) -> Bytes {
 ///|
 test "to_be_bytes" {
   inspect(
-    to_be_bytes(max_value),
+    max_value.to_be_bytes(),
     content=
       #|b"\xff\xff\xff\xff\xff\xff\xff\xff"
     ,
   )
   inspect(
-    to_be_bytes(min_value),
+    min_value.to_be_bytes(),
     content=
       #|b"\x00\x00\x00\x00\x00\x00\x00\x00"
     ,
   )
   inspect(
-    to_be_bytes(0x123456789ABCDEF0UL),
+    0x123456789ABCDEF0UL.to_be_bytes(),
     content=
       #|b"\x12\x34\x56\x78\x9a\xbc\xde\xf0"
     ,
@@ -71,19 +71,19 @@ test "to_be_bytes" {
 ///|
 test "to_le_bytes" {
   inspect(
-    to_le_bytes(max_value),
+    max_value.to_le_bytes(),
     content=
       #|b"\xff\xff\xff\xff\xff\xff\xff\xff"
     ,
   )
   inspect(
-    to_le_bytes(min_value),
+    min_value.to_le_bytes(),
     content=
       #|b"\x00\x00\x00\x00\x00\x00\x00\x00"
     ,
   )
   inspect(
-    to_le_bytes(0x123456789ABCDEF0UL),
+    0x123456789ABCDEF0UL.to_le_bytes(),
     content=
       #|b"\xf0\xde\xbc\x9a\x78\x56\x34\x12"
     ,

--- a/unit/README.mbt.md
+++ b/unit/README.mbt.md
@@ -23,7 +23,6 @@ Unit values can be converted to strings using either the standalone function or 
 test "unit string conversion" {
   let u = ()
   // Both ways produce the same result
-  inspect(@unit.to_string(u), content="()")
   inspect(u.to_string(), content="()")
 }
 ```


### PR DESCRIPTION
Previously, methods defined as `fn f(self : T, ..)` are considered **both** method and regular function. While this allows convenient ways of calling method via `@pkg.meth(..)`, it also complicates the semantic of MoonBit.

The latest release of MoonBit now supports partial dot application (`_.meth(..)`) and piping into dot application (`expr |> _.meth(..)`), which significantly reduce the need for calling methods as regular functions. So we decided to deprecate the behavior of calling methods as regular functions, to simplify the language.

This PR removes usage of calling method as regular function in core. In next week's release, we will start emitting warnings on such usage. We are also simplifying the syntax of MoonBit's method system, the simplified syntax will also be available next week.

For most cases, this PR just migrates regular function apply to dot apply. However, for math related methods (`Double::sin`, for example), people are more used to function call style `sin(..)` from math notation, compared of dot apply style `xx.sin()`. So an `fnalias` is provided for math related functions and several others, such as `Ref::swap`.