### PR TITLE
refactor: deprecate `@string.concat`

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -302,5 +302,27 @@ pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Array[X] with arbi
 
 ///|
 pub fn join(self : Array[String], separator : String) -> String {
-  @string.concat(self, separator~)
+  match self {
+    [] => ""
+    [hd, .. tl] => {
+      let mut size_hint = hd.length()
+      for s in tl {
+        size_hint += s.length() + separator.length()
+      }
+      size_hint = size_hint << 1
+      let buf = StringBuilder::new(size_hint~)
+      buf.write_string(hd)
+      if separator == "" {
+        for s in tl {
+          buf.write_string(s)
+        }
+      } else {
+        for s in tl {
+          buf.write_string(separator)
+          buf.write_string(s)
+        }
+      }
+      buf.to_string()
+    }
+  }
 }

--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -716,8 +716,7 @@ test "Array[String]::join" {
   inspect(["a", "b", "c"].join(","), content="a,b,c")
   inspect(["a", "b", "c"].join(""), content="abc")
   inspect(["a", "b", "c"].join(" "), content="a b c")
-  inspect(["a", "b", "c"].join(" "), content="a b c")
-  inspect(["a", "b", "c"].join(" "), content="a b c")
-  inspect(["a", "b", "c"].join(" "), content="a b c")
-  inspect(["a", "b", "c"].join(" "), content="a b c")
+  inspect!(["123", "456"].join(""), content="123456")
+  inspect!(["aaa", "bbb", "ccc"].join(" "), content="aaa bbb ccc")
+  inspect!([].join(" "))
 }

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -60,6 +60,7 @@ pub fn from_iter(iter : Iter[Char]) -> String {
 /// let s = @string.concat(["a", "b", "c"], separator=",")
 /// assert_eq!(s, "a,b,c")
 /// ```
+#deprecated("Use `Array::join` instead.")
 pub fn concat(strings : Array[String], separator~ : String = "") -> String {
   match strings {
     [] => ""

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -1,6 +1,7 @@
 package "moonbitlang/core/string"
 
 // Values
+#deprecated
 fn concat(Array[String], separator~ : String = ..) -> String
 
 fn contains(String, StringView) -> Bool

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -23,16 +23,6 @@ test "String::from_iter" {
 }
 
 ///|
-test "String::concat" {
-  inspect(@string.concat(["123", "456"]), content="123456")
-  inspect(
-    @string.concat(["aaa", "bbb", "ccc"], separator=" "),
-    content="aaa bbb ccc",
-  )
-  inspect(@string.concat([], separator=" "), content="")
-}
-
-///|
 test "default" {
   inspect(@string.default())
 }


### PR DESCRIPTION
Closes #1864 