### PR TITLE
refactor: deprecated Iter::apend and Iter::prepend

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -175,6 +175,7 @@ type Iter[T]
 impl Iter {
   all[T](Self[T], (T) -> Bool) -> Bool
   any[T](Self[T], (T) -> Bool) -> Bool
+  #deprecated
   append[T](Self[T], T) -> Self[T]
   collect[T](Self[T]) -> Array[T]
   concat[T](Self[T], Self[T]) -> Self[T]
@@ -209,6 +210,7 @@ impl Iter {
   nth[T](Self[T], Int) -> T?
   op_as_view[A](Self[A], start~ : Int = .., end? : Int) -> Self[A]
   peek[T](Self[T]) -> T?
+  #deprecated
   prepend[T](Self[T], T) -> Self[T]
   repeat[T](T) -> Self[T]
   run[T](Self[T], (T) -> IterResult) -> IterResult

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -737,6 +737,7 @@ pub fn[T] Iter::peek(self : Iter[T]) -> T? {
 /// # Returns
 ///
 /// Returns a new iterator with the element `a` prepended to the original iterator.
+#deprecated("Use `self + [a].iter()` or `self + Iter::singleton(a)` instead")
 pub fn[T] Iter::prepend(self : Iter[T], a : T) -> Iter[T] {
   fn(yield_) {
     if yield_(a) == IterContinue {
@@ -762,6 +763,7 @@ pub fn[T] Iter::prepend(self : Iter[T], a : T) -> Iter[T] {
 /// # Returns
 ///
 /// Returns a new iterator with the element `a` appended to the original iterator.
+#deprecated("Use `[a].iter() + self` or `Iter::singleton(a) + self` instead")
 pub fn[T] Iter::append(self : Iter[T], a : T) -> Iter[T] {
   fn(yield_) {
     if self.run(yield_) == IterContinue {

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -312,22 +312,6 @@ test "tap" {
 }
 
 ///|
-test "prepend" {
-  let iter = test_from_array(['0', '1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
-  iter.prepend('X').each(fn { x => exb.write_char(x) })
-  inspect(exb, content="X012345")
-}
-
-///|
-test "append" {
-  let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
-  iter.append('6').each(fn { x => exb.write_char(x) })
-  inspect(exb, content="123456")
-}
-
-///|
 test "concat" {
   let iter1 = test_from_array(['1', '2', '3'])
   let iter2 = test_from_array(['4', '5', '6'])
@@ -665,20 +649,6 @@ test "@builtin.Iter::minimum" {
   // Test with empty sequence
   let empty : Iter[Int] = Iter::empty()
   inspect(empty.minimum(), content="None")
-}
-
-///|
-test "Iter::prepend with early termination" {
-  let iter = [1, 2, 3].iter()
-  let result = iter.prepend(0).take(1).collect()
-  inspect(result, content="[0]")
-}
-
-///|
-test "Iter::append with early termination" {
-  let iter = [1, 2, 3].iter()
-  let result = iter.take(2).append(4).take(2).collect()
-  inspect(result, content="[1, 2]")
 }
 
 ///|


### PR DESCRIPTION
Closes #1511