### PR TITLE
add proper attribute to view types

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -24,6 +24,7 @@
 /// assert_eq!(view.length(), 3)
 /// ```
 #deprecated("use @array.View instead")
+#builtin.valtype
 struct ArrayView[T] {
   buf : UninitializedArray[T]
   start : Int

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -29,9 +29,9 @@ const INT64_MAX = 0x7fffffffffffffffL
 /// and consume the prefix.
 /// The boolean flag `allow_underscore` is used to check validity of underscores.
 fn check_and_consume_base(
-  view : @string.StringView,
+  view : @string.View,
   base : Int
-) -> (Int, @string.StringView, Bool)!StrConvError {
+) -> (Int, @string.View, Bool)!StrConvError {
   // if the base is not given, we need to determine it from the prefix
   if base == 0 {
     match view {

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -16,7 +16,8 @@
 /// A `StringView` represents a view of a String that maintains proper Unicode
 /// character boundaries. It allows safe access to a substring while handling 
 /// multi-byte characters correctly.
-/// alert deprecated "use @string.View instead"
+#deprecated("use @string.View instead")
+#builtin.valtype
 struct StringView {
   // # Fields
   //


### PR DESCRIPTION
* Added #builtin.valtype mainly for documentation purpose
* Deprecated `@string.StringView` in favor of `@string.View`