### PR TITLE
feat(bigint): add compare_int and compare_int64

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -33,3 +33,73 @@ pub impl @quickcheck.Arbitrary for BigInt with arbitrary(size, rs) {
     rs.next_int64() |> BigInt::from_int64
   }
 }
+
+///|
+/// Test equality between a `BigInt` and an `Int`.
+pub fn BigInt::equal_int(self : BigInt, other : Int) -> Bool {
+  can_convert_to_int(self) && self.to_int() == other
+}
+
+///|
+/// Test equality between a `BigInt` and an `Int64`.
+pub fn BigInt::equal_int64(self : BigInt, other : Int64) -> Bool {
+  can_convert_to_int64(self) && self.to_int64() == other
+}
+
+///|
+/// Compare a `BigInt` with an `Int`.
+pub fn BigInt::compare_int(self : BigInt, other : Int) -> Int {
+  guard can_convert_to_int(self) else {
+    return if is_neg(self) { -1 } else { 1 }
+  }
+  let self = self.to_int()
+  Int::compare(self, other)
+}
+
+///|
+/// Compare a `BigInt` with an `Int64`.
+pub fn BigInt::compare_int64(self : BigInt, other : Int64) -> Int {
+  guard can_convert_to_int64(self) else {
+    return if is_neg(self) { -1 } else { 1 }
+  }
+  let self = self.to_int64()
+  Int64::compare(self, other)
+}
+
+///|
+test "can_convert_to_int" {
+  assert_true(can_convert_to_int(0N))
+  assert_true(can_convert_to_int(1N))
+  assert_true(can_convert_to_int(-1N))
+  assert_true(can_convert_to_int(2147483647N)) // Int.max_value
+  assert_true(can_convert_to_int(-2147483648N)) // Int.min_value
+  assert_false(can_convert_to_int(2147483648N)) // Int.max_value + 1
+  assert_false(can_convert_to_int(-2147483649N)) // Int.min_value - 1
+  assert_false(can_convert_to_int(4294967295N)) // 2^32 - 1
+  assert_false(can_convert_to_int(-4294967295N)) // -(2^32 - 1)
+  assert_false(can_convert_to_int(4294967296N)) // 2^32
+  assert_false(can_convert_to_int(-4294967296N)) // -2^32
+}
+
+///|
+test "can_convert_to_int64" {
+  assert_true(can_convert_to_int64(0N))
+  assert_true(can_convert_to_int64(1N))
+  assert_true(can_convert_to_int64(-1N))
+  assert_true(can_convert_to_int64(2147483647N)) // Int.max_value
+  assert_true(can_convert_to_int64(-2147483648N)) // Int.min_value
+  assert_true(can_convert_to_int64(2147483648N)) // Int.max_value + 1
+  assert_true(can_convert_to_int64(-2147483649N)) // Int.min_value - 1
+  assert_true(can_convert_to_int64(4294967295N)) // 2^32 - 1
+  assert_true(can_convert_to_int64(-4294967295N)) // -(2^32 - 1)
+  assert_true(can_convert_to_int64(4294967296N)) // 2^32
+  assert_true(can_convert_to_int64(-4294967296N)) // -2^32
+  assert_true(can_convert_to_int64(9223372036854775807N)) // Int64.max_value
+  assert_true(can_convert_to_int64(-9223372036854775808N)) // Int64.min_value
+  assert_false(can_convert_to_int64(9223372036854775808N)) // Int64.max_value + 1
+  assert_false(can_convert_to_int64(-9223372036854775809N)) // Int64.min_value - 1
+  assert_false(can_convert_to_int64(18446744073709551615N)) // 2^64 - 1
+  assert_false(can_convert_to_int64(-18446744073709551615N)) // -(2^64 - 1)
+  assert_false(can_convert_to_int64(18446744073709551616N)) // 2^64
+  assert_false(can_convert_to_int64(-18446744073709551616N)) // -2^64
+}

--- a/bigint/bigint.mbti
+++ b/bigint/bigint.mbti
@@ -12,7 +12,11 @@ impl BigInt {
   #deprecated
   asr(Self, Int) -> Self
   bit_length(Self) -> Int
+  compare_int(Self, Int) -> Int
+  compare_int64(Self, Int64) -> Int
   ctz(Self) -> Int
+  equal_int(Self, Int) -> Bool
+  equal_int64(Self, Int64) -> Bool
   from_hex(String) -> Self
   from_int(Int) -> Self
   from_int64(Int64) -> Self

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -454,3 +454,15 @@ pub extern "js" fn BigInt::ctz(self : BigInt) -> Int =
   #|  }
   #|  return count;
   #|}
+
+///|
+extern "js" fn can_convert_to_int(x : BigInt) -> Bool =
+  #|(x) => x >= -(2n ** 31n) && x < 2n ** 31n
+
+///|
+extern "js" fn can_convert_to_int64(x : BigInt) -> Bool =
+  #|(x) => x >= -(2n ** 63n) && x < 2n ** 63n
+
+///|
+extern "js" fn is_neg(x : BigInt) -> Bool =
+  #|(x) => x < 0n

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1913,3 +1913,45 @@ fn unchecked_double_to_int(d : Double) -> Int = "%f64_to_i32"
 
 ///|
 fn unsafe_fixedarray_to_bytes(arr : FixedArray[Byte]) -> Bytes = "%identity"
+
+///|
+fn can_convert_to_int(x : BigInt) -> Bool {
+  // bigint range from [-(2^32 - 1), 2^32 - 1] has len == 1. But here we only
+  // want bigint from [-2^31, 2^31 - 1]
+  x.len == 1 &&
+  (if x.sign == Negative {
+    x.limbs[0] <= 0x80000000
+  } else {
+    x.limbs[0] < 0x80000000
+  })
+}
+
+///|
+fn can_convert_to_int64(x : BigInt) -> Bool {
+  x.len <= 2 &&
+  (if x.sign == Negative {
+    x.limbs[1] < 0x80000000 || (x.limbs[1] == 0x80000000 && x.limbs[0] == 0)
+  } else {
+    x.limbs[1] < 0x80000000
+  })
+}
+
+///|
+fn is_neg(x : BigInt) -> Bool {
+  x.sign == Negative
+}
+
+///|
+test "limb length" {
+  inspect(0N.len, content="1")
+  inspect(1N.len, content="1")
+  inspect((-1N).len, content="1")
+  inspect(2147483647N.len, content="1") // Int.max_value
+  inspect((-2147483648N).len, content="1") // Int.min_value
+  inspect(2147483648N.len, content="1") // Int.max_value + 1
+  inspect((-2147483649N).len, content="1") // Int.min_value - 1
+  inspect(4294967295N.len, content="1") // 2^32 - 1
+  inspect((-4294967295N).len, content="1") // -(2^32 - 1)
+  inspect(4294967296N.len, content="2") // 2^32
+  inspect((-4294967296N).len, content="2") // -2^32
+}

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -142,3 +142,15 @@ test "BigInt::ctz" {
   inspect((1N << 31).ctz(), content="31")
   inspect((1N << 63).ctz(), content="63")
 }
+
+///|
+test {
+  inspect(
+    MyBigInt(-9223372036854775809N),
+    content="{limbs : [1, 2147483648, 0], sign : Negative, len : 2 }",
+  ) // Int64.min_value - 1
+  inspect(
+    MyBigInt(-9223372036854775810N),
+    content="{limbs : [2, 2147483648, 0], sign : Negative, len : 2 }",
+  ) // Int64.min_value - 2
+}

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -724,3 +724,252 @@ test "to_uint64" {
   inspect(max.to_uint64(), content="18446744073709551615")
   inspect((max + 1).to_uint64(), content="0")
 }
+
+///|
+test "equal_int" {
+  assert_true!(BigInt::equal_int(1N, 1))
+  assert_true!(BigInt::equal_int(-1N, -1))
+  assert_false!(BigInt::equal_int(1N, -1))
+  assert_false!(BigInt::equal_int(-1N, 1))
+  assert_true!(BigInt::equal_int(0N, 0))
+  assert_false!(BigInt::equal_int(0N, 1))
+  assert_false!(BigInt::equal_int(1N, 0))
+
+  // Test with max/min int values
+  assert_true!(BigInt::equal_int(2147483647N, 2147483647))
+  assert_true!(BigInt::equal_int(-2147483648N, -2147483648))
+  assert_false!(BigInt::equal_int(2147483647N, -2147483648))
+  assert_false!(BigInt::equal_int(-2147483648N, 2147483647))
+
+  // Test with large BigInt that doesn't fit in int
+  let large = 2N.pow(32)
+  assert_false!(BigInt::equal_int(large, 0))
+  assert_false!(BigInt::equal_int(large, 1))
+  assert_false!(BigInt::equal_int(large, -1))
+
+  // Test with negative large BigInt
+  let neg_large = -2N.pow(32)
+  assert_false!(BigInt::equal_int(neg_large, 0))
+  assert_false!(BigInt::equal_int(neg_large, 1))
+  assert_false!(BigInt::equal_int(neg_large, -1))
+}
+
+///|
+test "equal_int64" {
+  assert_true!(BigInt::equal_int64(1N, 1L))
+  assert_true!(BigInt::equal_int64(-1N, -1L))
+  assert_false!(BigInt::equal_int64(1N, -1L))
+  assert_false!(BigInt::equal_int64(-1N, 1L))
+  assert_true!(BigInt::equal_int64(0N, 0L))
+  assert_false!(BigInt::equal_int64(0N, 1L))
+  assert_false!(BigInt::equal_int64(1N, 0L))
+
+  // Test with max/min int64 values
+  assert_true!(BigInt::equal_int64(9223372036854775807N, 9223372036854775807L))
+  assert_true!(
+    BigInt::equal_int64(-9223372036854775808N, -9223372036854775808L),
+  )
+  assert_false!(
+    BigInt::equal_int64(9223372036854775807N, -9223372036854775808L),
+  )
+  assert_false!(
+    BigInt::equal_int64(-9223372036854775808N, 9223372036854775807L),
+  )
+
+  // Test with large values that fit in int64
+  assert_true!(BigInt::equal_int64(1234567890123456789N, 1234567890123456789L))
+  assert_true!(
+    BigInt::equal_int64(-1234567890123456789N, -1234567890123456789L),
+  )
+  assert_false!(
+    BigInt::equal_int64(1234567890123456789N, -1234567890123456789L),
+  )
+  assert_false!(
+    BigInt::equal_int64(-1234567890123456789N, 1234567890123456789L),
+  )
+
+  // Test with BigInt that doesn't fit in int64
+  let large = 2N.pow(64)
+  assert_false!(BigInt::equal_int64(large, 0L))
+  assert_false!(BigInt::equal_int64(large, 1L))
+  assert_false!(BigInt::equal_int64(large, -1L))
+  assert_false!(BigInt::equal_int64(large, 9223372036854775807L))
+  assert_false!(BigInt::equal_int64(large, -9223372036854775808L))
+
+  // Test with negative large BigInt that doesn't fit in int64
+  let neg_large = -2N.pow(64)
+  assert_false!(BigInt::equal_int64(neg_large, 0L))
+  assert_false!(BigInt::equal_int64(neg_large, 1L))
+  assert_false!(BigInt::equal_int64(neg_large, -1L))
+  assert_false!(BigInt::equal_int64(neg_large, 9223372036854775807L))
+  assert_false!(BigInt::equal_int64(neg_large, -9223372036854775808L))
+
+  // Test edge cases around int64 boundaries
+  let max_plus_one = 9223372036854775808N // 2^63
+  let min_minus_one = -9223372036854775809N // -2^63 - 1
+  assert_false!(BigInt::equal_int64(max_plus_one, 9223372036854775807L))
+  assert_false!(BigInt::equal_int64(min_minus_one, -9223372036854775808L))
+
+  // Test with powers of 2
+  assert_true!(BigInt::equal_int64(2N.pow(32), 4294967296L))
+  assert_true!(BigInt::equal_int64(2N.pow(62), 4611686018427387904L))
+  assert_false!(BigInt::equal_int64(2N.pow(63), 9223372036854775807L)) // This would overflow
+}
+
+///|
+test "compare_int" {
+  // Test with zero
+  assert_eq!(BigInt::compare_int(0N, 0), 0)
+  assert_eq!(BigInt::compare_int(0N, 1), -1)
+  assert_eq!(BigInt::compare_int(0N, -1), 1)
+
+  // Test with positive values
+  assert_eq!(BigInt::compare_int(1N, 1), 0)
+  assert_eq!(BigInt::compare_int(1N, 0), 1)
+  assert_eq!(BigInt::compare_int(1N, 2), -1)
+  assert_eq!(BigInt::compare_int(42N, 42), 0)
+  assert_eq!(BigInt::compare_int(100N, 50), 1)
+  assert_eq!(BigInt::compare_int(25N, 100), -1)
+
+  // Test with negative values
+  assert_eq!(BigInt::compare_int(-1N, -1), 0)
+  assert_eq!(BigInt::compare_int(-1N, 0), -1)
+  assert_eq!(BigInt::compare_int(-1N, 1), -1)
+  assert_eq!(BigInt::compare_int(-42N, -42), 0)
+  assert_eq!(BigInt::compare_int(-25N, -100), 1)
+  assert_eq!(BigInt::compare_int(-100N, -50), -1)
+
+  // Test with mixed signs
+  assert_eq!(BigInt::compare_int(1N, -1), 1)
+  assert_eq!(BigInt::compare_int(-1N, 1), -1)
+  assert_eq!(BigInt::compare_int(100N, -50), 1)
+  assert_eq!(BigInt::compare_int(-100N, 50), -1)
+
+  // Test with Int boundary values
+  assert_eq!(BigInt::compare_int(2147483647N, 2147483647), 0) // Int.max_value
+  assert_eq!(BigInt::compare_int(-2147483648N, -2147483648), 0) // Int.min_value
+  assert_eq!(BigInt::compare_int(2147483647N, 2147483646), 1)
+  assert_eq!(BigInt::compare_int(2147483646N, 2147483647), -1)
+  assert_eq!(BigInt::compare_int(-2147483648N, -2147483647), -1)
+  assert_eq!(BigInt::compare_int(-2147483647N, -2147483648), 1)
+
+  // Test with BigInt that doesn't fit in Int
+  let large = 2147483648N // Int.max_value + 1
+  assert_eq!(BigInt::compare_int(large, 2147483647), 1)
+  assert_eq!(BigInt::compare_int(large, -2147483648), 1)
+  assert_eq!(BigInt::compare_int(large, 0), 1)
+  let neg_large = -2147483649N // Int.min_value - 1
+  assert_eq!(BigInt::compare_int(neg_large, -2147483648), -1)
+  assert_eq!(BigInt::compare_int(neg_large, 2147483647), -1)
+  assert_eq!(BigInt::compare_int(neg_large, 0), -1)
+
+  // Test with very large BigInt values
+  let very_large = BigInt::from_string("123456789012345678901234567890")
+  assert_eq!(BigInt::compare_int(very_large, 2147483647), 1)
+  assert_eq!(BigInt::compare_int(very_large, -2147483648), 1)
+  assert_eq!(BigInt::compare_int(very_large, 0), 1)
+  let very_neg_large = BigInt::from_string("-123456789012345678901234567890")
+  assert_eq!(BigInt::compare_int(very_neg_large, 2147483647), -1)
+  assert_eq!(BigInt::compare_int(very_neg_large, -2147483648), -1)
+  assert_eq!(BigInt::compare_int(very_neg_large, 0), -1)
+
+  // Test with powers of 2
+  assert_eq!(BigInt::compare_int(2N.pow(10), 1024), 0)
+  assert_eq!(BigInt::compare_int(2N.pow(20), 1048576), 0)
+  assert_eq!(BigInt::compare_int(2N.pow(30), 1073741824), 0)
+  assert_eq!(BigInt::compare_int(2N.pow(31), 2147483647), 1) // 2^31 > Int.max_value
+}
+
+///|
+test "compare_int64" {
+  // Test with zero
+  assert_eq!(BigInt::compare_int64(0N, 0L), 0)
+  assert_eq!(BigInt::compare_int64(0N, 1L), -1)
+  assert_eq!(BigInt::compare_int64(0N, -1L), 1)
+
+  // Test with positive values
+  assert_eq!(BigInt::compare_int64(1N, 1L), 0)
+  assert_eq!(BigInt::compare_int64(42N, 42L), 0)
+  assert_eq!(BigInt::compare_int64(100N, 50L), 1)
+  assert_eq!(BigInt::compare_int64(25N, 100L), -1)
+
+  // Test with negative values
+  assert_eq!(BigInt::compare_int64(-1N, -1L), 0)
+  assert_eq!(BigInt::compare_int64(-1N, 0L), -1)
+  assert_eq!(BigInt::compare_int64(-1N, 1L), -1)
+  assert_eq!(BigInt::compare_int64(-42N, -42L), 0)
+  assert_eq!(BigInt::compare_int64(-25N, -100L), 1)
+  assert_eq!(BigInt::compare_int64(-100N, -50L), -1)
+
+  // Test with mixed signs
+  assert_eq!(BigInt::compare_int64(1N, -1L), 1)
+  assert_eq!(BigInt::compare_int64(-1N, 1L), -1)
+  assert_eq!(BigInt::compare_int64(100N, -50L), 1)
+  assert_eq!(BigInt::compare_int64(-100N, 50L), -1)
+
+  // Test with Int64 boundary values
+  assert_eq!(
+    BigInt::compare_int64(9223372036854775807N, 9223372036854775807L),
+    0,
+  ) // Int64.max_value
+  assert_eq!(
+    BigInt::compare_int64(-9223372036854775808N, -9223372036854775808L),
+    0,
+  ) // Int64.min_value
+  assert_eq!(
+    BigInt::compare_int64(9223372036854775807N, 9223372036854775806L),
+    1,
+  )
+  assert_eq!(
+    BigInt::compare_int64(9223372036854775806N, 9223372036854775807L),
+    -1,
+  )
+  assert_eq!(
+    BigInt::compare_int64(-9223372036854775808N, -9223372036854775807L),
+    -1,
+  )
+  assert_eq!(
+    BigInt::compare_int64(-9223372036854775807N, -9223372036854775808L),
+    1,
+  )
+
+  // Test with BigInt that doesn't fit in Int64
+  let large = BigInt::from_string("9223372036854775808") // Int64.max_value + 1
+  assert_eq!(BigInt::compare_int64(large, 9223372036854775807L), 1)
+  assert_eq!(BigInt::compare_int64(large, -9223372036854775808L), 1)
+  assert_eq!(BigInt::compare_int64(large, 0L), 1)
+  let neg_large = BigInt::from_string("-9223372036854775809") // Int64.min_value - 1
+  assert_eq!(BigInt::compare_int64(neg_large, -9223372036854775808L), -1)
+  assert_eq!(BigInt::compare_int64(neg_large, 9223372036854775807L), -1)
+  assert_eq!(BigInt::compare_int64(neg_large, 0L), -1)
+
+  // Test with very large BigInt values
+  let very_large = BigInt::from_string("123456789012345678901234567890")
+  assert_eq!(BigInt::compare_int64(very_large, 9223372036854775807L), 1)
+  assert_eq!(BigInt::compare_int64(very_large, -9223372036854775808L), 1)
+  assert_eq!(BigInt::compare_int64(very_large, 0L), 1)
+  let very_neg_large = BigInt::from_string("-123456789012345678901234567890")
+  assert_eq!(BigInt::compare_int64(very_neg_large, 9223372036854775807L), -1)
+  assert_eq!(BigInt::compare_int64(very_neg_large, -9223372036854775808L), -1)
+  assert_eq!(BigInt::compare_int64(very_neg_large, 0L), -1)
+
+  // Test with powers of 2
+  assert_eq!(BigInt::compare_int64(2N.pow(10), 1024L), 0)
+  assert_eq!(BigInt::compare_int64(2N.pow(20), 1048576L), 0)
+  assert_eq!(BigInt::compare_int64(2N.pow(30), 1073741824L), 0)
+  assert_eq!(BigInt::compare_int64(2N.pow(40), 1099511627776L), 0)
+  assert_eq!(BigInt::compare_int64(2N.pow(50), 1125899906842624L), 0)
+  assert_eq!(BigInt::compare_int64(2N.pow(60), 1152921504606846976L), 0)
+  assert_eq!(BigInt::compare_int64(2N.pow(62), 4611686018427387904L), 0)
+  assert_eq!(BigInt::compare_int64(2N.pow(63), 9223372036854775807L), 1) // 2^63 > Int64.max_value
+
+  // Test with values around 32-bit boundaries (to ensure 64-bit handling)
+  let val_32bit = 4294967296N // 2^32
+  assert_eq!(BigInt::compare_int64(val_32bit, 4294967296L), 0)
+  assert_eq!(BigInt::compare_int64(val_32bit, 4294967295L), 1)
+  assert_eq!(BigInt::compare_int64(val_32bit, 4294967297L), -1)
+  let neg_val_32bit = -4294967296N // -2^32
+  assert_eq!(BigInt::compare_int64(neg_val_32bit, -4294967296L), 0)
+  assert_eq!(BigInt::compare_int64(neg_val_32bit, -4294967295L), -1)
+  assert_eq!(BigInt::compare_int64(neg_val_32bit, -4294967297L), 1)
+}


### PR DESCRIPTION
This PR implements some utilities for comparing bigints with int/int64. These utilities can be used to implement more efficient pattern matching for bigint in the compiler.