### PR TITLE
deprecate

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -192,6 +192,7 @@ impl Iter {
   flat_map[T, R](Self[T], (T) -> Self[R]) -> Self[R]
   flatten[T](Self[Self[T]]) -> Self[T]
   fold[T, B](Self[T], init~ : B, (B, T) -> B) -> B
+  #deprecated
   group_by[T, K : Eq + Hash](Self[T], (T) -> K) -> Map[K, Array[T]]
   head[A](Self[A]) -> A?
   intersperse[A](Self[A], A) -> Self[A]

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -1024,6 +1024,7 @@ pub fn[T : Compare] Iter::minimum(self : Iter[T]) -> T? {
 ///   assert_eq(result.get(2), Some([2, 2, 2]))
 ///   assert_eq(result.get(3), Some([3]))
 /// }
+#deprecated
 pub fn[T, K : Eq + Hash] Iter::group_by(
   self : Iter[T],
   f : (T) -> K


### PR DESCRIPTION
@juliano  we are working on spin off Map to a separate package, this could potentially trigger a cyclic dependency between iter and map, we may add it back if no cyclic deps found, this would be temporarily removed for safety.

cc @Guest0x0 