### PR TITLE
remove use of local impl as method

### DIFF
--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -60,7 +60,7 @@ pub impl Arbitrary for Bytes with arbitrary(size, rs) {
     Bytes::new(0)
   } else {
     let sz = rs.next_positive_int() % size
-    Bytes::makei(sz, fn(_) { Byte::arbitrary(size, rs) })
+    Bytes::makei(sz, fn(_) { Arbitrary::arbitrary(size, rs) })
   }
 }
 
@@ -103,7 +103,8 @@ pub impl Arbitrary for String with arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
   let mut s = ""
   for i in 0..<len {
-    s = s + Char::arbitrary(i, rs).to_string()
+    let c : Char = Arbitrary::arbitrary(i, rs)
+    s = s + c.to_string()
   }
   s
 }


### PR DESCRIPTION
MoonBit currently allows calling `impl` of foreign type with dot syntax/`TypeName::`, but only inside current package. This behavior was added to allow locally extend dot syntax of foreign type, but is not refactor safe (if upstream add a method of the same name, behavior of downstream code will silently change), so we decided to deprecate and remove this feature in the future.

This PR removes usage of this behavior in core. 