### PR TITLE
misc: deprecate`@test.bench`

### DIFF
--- a/test/test.mbt
+++ b/test/test.mbt
@@ -143,6 +143,7 @@ pub fn snapshot(
 }
 
 ///|
+#deprecated("Use `@bench.single_bench` instead")
 pub fn bench(self : T, f : () -> Unit, count~ : UInt = 10) -> Unit!BenchError {
   ignore(self)
   let summary = @bench.single_bench(f, count~)

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -1,6 +1,7 @@
 package "moonbitlang/core/test"
 
 // Values
+#deprecated
 fn bench(T, () -> Unit, count~ : UInt = ..) -> Unit!BenchError
 
 #deprecated
@@ -34,6 +35,7 @@ pub(all) struct T {
   name : String
   buffer : StringBuilder
 }
+#deprecated
 fn T::bench(Self, () -> Unit, count~ : UInt = ..) -> Unit!BenchError
 fn T::snapshot(Self, filename~ : String, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit!SnapshotError
 fn T::write(Self, &Show) -> Unit


### PR DESCRIPTION
It is defined for the initial benchmark utility. Later, we migrated to using `@bench.T` and forgot to remove this function.
We shall deprecate it first.