### PR TITLE
Update documentation tests across various modules

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -446,10 +446,12 @@ pub fn[T] Array::rev_each(self : Array[T], f : (T) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// let mut sum = 0
-/// v.rev_eachi(fn(i, x) { sum = sum + x + i })
-/// assert_eq(sum, 15)
+/// test "Array::rev_eachi" {
+///   let v = [3, 4, 5]
+///   let mut sum = 0
+///   v.rev_eachi(fn(i, x) { sum = sum + x + i })
+///   assert_eq(sum, 15)
+/// }
 /// ```
 #locals(f)
 pub fn[T] Array::rev_eachi(self : Array[T], f : (Int, T) -> Unit) -> Unit {
@@ -488,9 +490,11 @@ pub fn[T] Array::eachi(
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// v.clear()
-/// assert_eq(v.length(), 0)
+/// test "Array::clear" {
+///   let v = [3, 4, 5]
+///   v.clear()
+///   assert_eq(v.length(), 0)
+/// }
 /// ```
 pub fn[T] Array::clear(self : Array[T]) -> Unit {
   self.unsafe_truncate_to_length(0)
@@ -501,9 +505,11 @@ pub fn[T] Array::clear(self : Array[T]) -> Unit {
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// let v2 = v.map(fn (x) {x + 1})
-/// assert_eq(v2, [4, 5, 6])
+/// test "Array::map" {
+///   let v = [3, 4, 5]
+///   let v2 = v.map(fn (x) {x + 1})
+///   assert_eq(v2, [4, 5, 6])
+/// }
 /// ```
 #locals(f)
 pub fn[T, U] Array::map(self : Array[T], f : (T) -> U?Error) -> Array[U]?Error {
@@ -519,9 +525,11 @@ pub fn[T, U] Array::map(self : Array[T], f : (T) -> U?Error) -> Array[U]?Error {
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// v.map_inplace(fn (x) {x + 1})
-/// assert_eq(v, [4, 5, 6])
+/// test "Array::map_inplace" {
+///   let v = [3, 4, 5]
+///   v.map_inplace(fn (x) {x + 1})
+///   assert_eq(v, [4, 5, 6])
+/// }
 /// ```
 #locals(f)
 pub fn[T] Array::map_inplace(self : Array[T], f : (T) -> T?Error) -> Unit?Error {
@@ -535,9 +543,11 @@ pub fn[T] Array::map_inplace(self : Array[T], f : (T) -> T?Error) -> Unit?Error 
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// let v2 = v.mapi(fn (i, x) {x + i})
-/// assert_eq(v2, [3, 5, 7])
+/// test "Array::mapi" {
+///   let v = [3, 4, 5]
+///   let v2 = v.mapi(fn (i, x) {x + i})
+///   assert_eq(v2, [3, 5, 7])
+/// }
 /// ```
 #locals(f)
 pub fn[T, U] Array::mapi(
@@ -559,9 +569,11 @@ pub fn[T, U] Array::mapi(
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// v.mapi_inplace(fn (i, x) {x + i})
-/// assert_eq(v, [3, 5, 7])
+/// test "Array::mapi_inplace" {
+///   let v = [3, 4, 5]
+///   v.mapi_inplace(fn (i, x) {x + i})
+///   assert_eq(v, [3, 5, 7])
+/// }
 /// ```
 #locals(f)
 pub fn[T] Array::mapi_inplace(
@@ -736,10 +748,12 @@ pub fn[T] Array::rev(self : Array[T]) -> Array[T] {
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// let (v1, v2) = v.split_at(1)
-/// assert_eq(v1, [3])
-/// assert_eq(v2, [4, 5])
+/// test "Array::split_at" {
+///   let v = [3, 4, 5]
+///   let (v1, v2) = v.split_at(1)
+///   assert_eq(v1, [3])
+///   assert_eq(v2, [4, 5])
+/// }
 /// ```
 /// TODO: perf could be optimized
 pub fn[T] Array::split_at(self : Array[T], index : Int) -> (Array[T], Array[T]) {
@@ -924,9 +938,11 @@ pub fn[T : Eq] Array::strip_prefix(
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// let v2 = v.strip_suffix([5])
-/// assert_eq(v2, Some([3, 4]))
+/// test "Array::strip_suffix" {
+///   let v = [3, 4, 5]
+///   let v2 = v.strip_suffix([5])
+///   assert_eq(v2, Some([3, 4]))
+/// }
 /// ```
 pub fn[T : Eq] Array::strip_suffix(
   self : Array[T],
@@ -1008,10 +1024,12 @@ pub fn[T] Array::find_index(self : Array[T], f : (T) -> Bool) -> Int? {
 /// # Example
 ///
 /// ```
-/// let v = [1, 2, 3, 4, 5]
-/// match v.search_by(fn(x) { x == 3 }) {
-///   Some(index) => assert_eq(index, 2) // 2
-///   None => println("Not found")
+/// test "Array::search_by" {
+///   let v = [1, 2, 3, 4, 5]
+///   match v.search_by(fn(x) { x == 3 }) {
+///     Some(index) => assert_eq(index, 2) // 2
+///     None => println("Not found")
+///   }
 /// }
 /// ```
 #locals(f)
@@ -1030,9 +1048,11 @@ pub fn[T] Array::search_by(self : Array[T], f : (T) -> Bool) -> Int? {
 ///
 /// # Example
 /// ```
-/// let v = [3, 4, 5]
-/// let result = v.binary_search(3)
-/// assert_eq(result, Ok(0)) // The element 3 is found at index 0
+/// test "Array::binary_search" {
+///   let v = [3, 4, 5]
+///   let result = v.binary_search(3)
+///   assert_eq(result, Ok(0)) // The element 3 is found at index 0
+/// }
 /// ```
 ///
 /// # Arguments

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -104,9 +104,11 @@ pub impl[X] Default for FixedArray[X] with default() {
 ///
 /// # Example
 /// ```
-/// let fa : FixedArray[Int] = [0, 0, 0, 0, 0]
-/// fa.fill(3)
-/// assert_eq(fa[0], 3)
+/// test "FixedArray::fill" {
+///   let fa : FixedArray[Int] = [0, 0, 0, 0, 0]
+///   fa.fill(3)
+///   assert_eq(fa[0], 3)
+/// }
 /// ```
 pub fn[T] FixedArray::fill(self : FixedArray[T], value : T) -> Unit {
   for i in 0..<self.length() {
@@ -143,9 +145,11 @@ pub fn[T] FixedArray::is_empty(self : FixedArray[T]) -> Bool {
 ///
 /// # Example
 /// ```
-/// let v : FixedArray[Int] = [3, 4, 5]
-/// let result = v.binary_search(3)
-/// assert_eq(result, Ok(0)) // The element 3 is found at index 0
+/// test "FixedArray::binary_search" {
+///   let v : FixedArray[Int] = [3, 4, 5]
+///   let result = v.binary_search(3)
+///   assert_eq(result, Ok(0)) // The element 3 is found at index 0
+/// }
 /// ```
 ///
 /// # Arguments

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -69,10 +69,12 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 /// # Examples
 ///
 /// ```
-/// let s = "Hello🤣";
-/// inspect(s.charcode_at(0), content="72");
-/// inspect(s.charcode_at(5), content="55358"); // First surrogate of 🤣
-/// inspect(s.charcode_at(6), content="56611"); // Second surrogate of 🤣
+/// test "String::charcode_at" {
+///   let s = "Hello🤣";
+///   inspect(s.charcode_at(0), content="72");
+///   inspect(s.charcode_at(5), content="55358"); // First surrogate of 🤣
+///   inspect(s.charcode_at(6), content="56611"); // Second surrogate of 🤣
+/// }
 /// ```
 ///
 pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
@@ -86,9 +88,11 @@ pub fn String::charcode_at(self : String, index : Int) -> Int = "%string_get"
 /// # Examples
 ///
 /// ```
-/// let s = "Hello🤣";
-/// inspect(s.codepoint_at(0), content="H");
-/// inspect(s.codepoint_at(5), content="🤣"); // Returns full emoji character
+/// test "String::codepoint_at" {
+///   let s = "Hello🤣";
+///   inspect(s.codepoint_at(0), content="H");
+///   inspect(s.codepoint_at(5), content="🤣"); // Returns full emoji character
+/// }
 /// ```
 ///
 /// # Panics
@@ -152,9 +156,11 @@ pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
 /// # Examples
 ///
 /// ```
-/// let s = "Hello🤣";
-/// inspect(s.char_length(), content = "6"); // 6 actual characters
-/// inspect(s.length(), content = "7");  // 5 ASCII chars + 2 surrogate pairs
+/// test "String::char_length" {
+///   let s = "Hello🤣";
+///   inspect(s.char_length(), content = "6"); // 6 actual characters
+///   inspect(s.length(), content = "7");  // 5 ASCII chars + 2 surrogate pairs
+/// }
 /// ```
 pub fn String::char_length(
   self : String,

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -229,8 +229,10 @@ fn[A] realloc(self : T[A]) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// assert_eq(dv.front(), Some(1))
+/// test "Deque::front" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   assert_eq(dv.front(), Some(1))
+/// }
 /// ```
 pub fn[A] front(self : T[A]) -> A? {
   if self.len == 0 {
@@ -245,8 +247,10 @@ pub fn[A] front(self : T[A]) -> A? {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// assert_eq(dv.back(), Some(5))
+/// test "Deque::back" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   assert_eq(dv.back(), Some(5))
+/// }
 /// ```
 pub fn[A] back(self : T[A]) -> A? {
   if self.len == 0 {
@@ -263,9 +267,11 @@ pub fn[A] back(self : T[A]) -> A? {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// dv.push_front(0)
-/// assert_eq(dv.front(), Some(0))
+/// test "Deque::push_front" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   dv.push_front(0)
+///   assert_eq(dv.front(), Some(0))
+/// }
 /// ```
 pub fn[A] push_front(self : T[A], value : A) -> Unit {
   if self.len == self.buf.length() {
@@ -285,9 +291,11 @@ pub fn[A] push_front(self : T[A], value : A) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// dv.push_back(6)
-/// assert_eq(dv.back(), Some(6))
+/// test "Deque::push_back" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   dv.push_back(6)
+///   assert_eq(dv.back(), Some(6))
+/// }
 /// ```
 pub fn[A] push_back(self : T[A], value : A) -> Unit {
   if self.len == self.buf.length() {
@@ -305,9 +313,11 @@ pub fn[A] push_back(self : T[A], value : A) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// dv.unsafe_pop_front()
-/// assert_eq(dv.front(), Some(2))
+/// test "Deque::unsafe_pop_front" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   dv.unsafe_pop_front()
+///   assert_eq(dv.front(), Some(2))
+/// }
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
 pub fn[A] unsafe_pop_front(self : T[A]) -> Unit {
@@ -360,9 +370,11 @@ pub fn[A] pop_front_exn(self : T[A]) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// dv.unsafe_pop_back()
-/// assert_eq(dv.back(), Some(4))
+/// test "Deque::unsafe_pop_back" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   dv.unsafe_pop_back()
+///   assert_eq(dv.back(), Some(4))
+/// }
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
 pub fn[A] unsafe_pop_back(self : T[A]) -> Unit {
@@ -417,8 +429,10 @@ pub fn[A] pop_back_exn(self : T[A]) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// assert_eq(dv.pop_front(), Some(1))
+/// test "Deque::pop_front" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   assert_eq(dv.pop_front(), Some(1))
+/// }
 /// ```
 pub fn[A] pop_front(self : T[A]) -> A? {
   match self.len {
@@ -448,8 +462,10 @@ pub fn[A] pop_front(self : T[A]) -> A? {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// assert_eq(dv.pop_back(), Some(5))
+/// test "Deque::pop_back" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   assert_eq(dv.pop_back(), Some(5))
+/// }
 /// ```
 pub fn[A] pop_back(self : T[A]) -> A? {
   match self.len {
@@ -477,12 +493,14 @@ pub fn[A] pop_back(self : T[A]) -> A? {
 ///|
 /// Retrieves the element at the specified index from the deque.
 ///
-/// If you try to access an index which isn’t in the Deque, it will panic.
+/// If you try to access an index which isn't in the Deque, it will panic.
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// assert_eq(dv[2], 3)
+/// test "Deque::op_get" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   assert_eq(dv[2], 3)
+/// }
 /// ```
 pub fn[A] op_get(self : T[A], index : Int) -> A {
   if index < 0 || index >= self.len {
@@ -501,13 +519,15 @@ pub fn[A] op_get(self : T[A], index : Int) -> A {
 ///|
 /// Sets the value of the element at the specified index.
 ///
-/// If you try to access an index which isn’t in the Deque, it will panic.
+/// If you try to access an index which isn't in the Deque, it will panic.
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// dv[2] = 1
-/// assert_eq(dv[2], 1)
+/// test "Deque::op_set" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   dv[2] = 1
+///   assert_eq(dv[2], 1)
+/// }
 /// ```
 pub fn[A] op_set(self : T[A], index : Int, value : A) -> Unit {
   if index < 0 || index >= self.len {
@@ -600,10 +620,12 @@ pub impl[A : Eq] Eq for T[A] with op_equal(self, other) {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// let mut sum = 0
-/// dv.each(fn (x) {sum = sum + x})
-/// assert_eq(sum, 15)
+/// test "Deque::each" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   let mut sum = 0
+///   dv.each(fn (x) {sum = sum + x})
+///   assert_eq(sum, 15)
+/// }
 /// ```
 pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
   for v in self {
@@ -616,10 +638,12 @@ pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// let mut idx_sum = 0
-/// dv.eachi(fn (i, _x) {idx_sum = idx_sum + i})
-/// assert_eq(idx_sum, 10)
+/// test "Deque::eachi" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   let mut idx_sum = 0
+///   dv.eachi(fn (i, _x) {idx_sum = idx_sum + i})
+///   assert_eq(idx_sum, 10)
+/// }
 /// ```
 pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self {
@@ -632,10 +656,12 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// let mut sum = 0
-/// dv.rev_each(fn (x) {sum = sum + x})
-/// assert_eq(sum, 15)
+/// test "Deque::rev_each" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   let mut sum = 0
+///   dv.rev_each(fn (x) {sum = sum + x})
+///   assert_eq(sum, 15)
+/// }
 /// ```
 pub fn[A] rev_each(self : T[A], f : (A) -> Unit) -> Unit {
   for v in self.rev_iter() {
@@ -648,10 +674,12 @@ pub fn[A] rev_each(self : T[A], f : (A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// let mut idx_sum = 0
-/// dv.rev_eachi(fn (i, _x) {idx_sum = idx_sum + i})
-/// assert_eq(idx_sum, 10)
+/// test "Deque::rev_eachi" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   let mut idx_sum = 0
+///   dv.rev_eachi(fn (i, _x) {idx_sum = idx_sum + i})
+///   assert_eq(idx_sum, 10)
+/// }
 /// ```
 pub fn[A] rev_eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self.rev_iter2() {
@@ -666,9 +694,11 @@ pub fn[A] rev_eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([1, 2, 3, 4, 5])
-/// dv.clear()
-/// assert_eq(dv.length(), 0)
+/// test "Deque::clear" {
+///   let dv = @deque.of([1, 2, 3, 4, 5])
+///   dv.clear()
+///   assert_eq(dv.length(), 0)
+/// }
 /// ```
 pub fn[A] clear(self : T[A]) -> Unit {
   let { head, buf, len, .. } = self
@@ -696,9 +726,11 @@ pub fn[A] clear(self : T[A]) -> Unit {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([3, 4, 5])
-/// let dv2 = dv.map(fn (x) {x + 1})
-/// assert_eq(dv2, @deque.of([4, 5, 6]))
+/// test "Deque::map" {
+///   let dv = @deque.of([3, 4, 5])
+///   let dv2 = dv.map(fn (x) {x + 1})
+///   assert_eq(dv2, @deque.of([4, 5, 6]))
+/// }
 /// ```
 pub fn[A, U] map(self : T[A], f : (A) -> U) -> T[U] {
   if self.len == 0 {
@@ -717,9 +749,11 @@ pub fn[A, U] map(self : T[A], f : (A) -> U) -> T[U] {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.of([3, 4, 5])
-/// let dv2 = dv.mapi(fn (i, x) {x + i}) // @deque.of([3, 5, 7])
-/// assert_eq(dv2, @deque.of([3, 5, 7]))
+/// test "Deque::mapi" {
+///   let dv = @deque.of([3, 4, 5])
+///   let dv2 = dv.mapi(fn (i, x) {x + i}) // @deque.of([3, 5, 7])
+///   assert_eq(dv2, @deque.of([3, 5, 7]))
+/// }
 /// ```
 pub fn[A, U] mapi(self : T[A], f : (Int, A) -> U) -> T[U] {
   if self.len == 0 {
@@ -738,10 +772,12 @@ pub fn[A, U] mapi(self : T[A], f : (Int, A) -> U) -> T[U] {
 ///
 /// # Example
 /// ```
-/// let dv = @deque.new()
-/// assert_eq(dv.is_empty(), true)
-/// dv.push_back(1)
-/// assert_eq(dv.is_empty(), false)
+/// test "Deque::is_empty" {
+///   let dv = @deque.new()
+///   assert_eq(dv.is_empty(), true)
+///   dv.push_back(1)
+///   assert_eq(dv.is_empty(), false)
+/// }
 /// ```
 pub fn[A] is_empty(self : T[A]) -> Bool {
   self.len == 0

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -84,8 +84,10 @@ pub fn[A : @json.FromJson] from_json(json : Json) -> T[A]!@json.JsonDecodeError 
 /// # Example
 ///
 /// ```
-/// let ls = @list.of([1, 2, 3, 4, 5])
-/// assert_eq(ls, @list.from_array([1, 2, 3, 4, 5]))
+/// test "from_array" {
+///   let ls = @list.of([1, 2, 3, 4, 5])
+///   assert_eq(ls, @list.from_array([1, 2, 3, 4, 5]))
+/// }
 /// ```
 pub fn[A] from_array(arr : Array[A]) -> T[A] {
   for i = arr.length() - 1, list = Empty; i >= 0; {
@@ -110,9 +112,11 @@ pub fn[A] length(self : T[A]) -> Int {
 /// # Example
 ///
 /// ```
-/// let arr = []
-/// @list.of([1, 2, 3, 4, 5]).each(fn(x) { arr.push(x) })
-/// assert_eq(arr, [1, 2, 3, 4, 5])
+/// test "each" {
+///   let arr = []
+///   @list.of([1, 2, 3, 4, 5]).each(fn(x) { arr.push(x) })
+///   assert_eq(arr, [1, 2, 3, 4, 5])
+/// }
 /// ```
 #locals(f)
 pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
@@ -153,7 +157,9 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 2, 3, 4, 5]).map(fn(x){ x * 2}), @list.of([2, 4, 6, 8, 10]))
+/// test "map" {
+///   assert_eq(@list.of([1, 2, 3, 4, 5]).map(fn(x){ x * 2}), @list.of([2, 4, 6, 8, 10]))
+/// }
 /// ```
 pub fn[A, B] map(self : T[A], f : (A) -> B) -> T[B] {
   match self {
@@ -202,7 +208,9 @@ pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B) -> T[B] {
 ///
 /// # Example
 /// ```
-/// assert_eq(@list.of([1, 2, 3, 4, 5]).rev_map(fn(x) { x * 2 }), @list.of([10, 8, 6, 4, 2]))
+/// test "rev_map" {
+///   assert_eq(@list.of([1, 2, 3, 4, 5]).rev_map(fn(x) { x * 2 }), @list.of([10, 8, 6, 4, 2]))
+/// }
 /// ```
 pub fn[A, B] rev_map(self : T[A], f : (A) -> B) -> T[B] {
   loop Empty, self {
@@ -236,7 +244,9 @@ pub fn[A] to_array(self : T[A]) -> Array[A] {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 2, 3, 4, 5]).filter(fn(x){ x % 2 == 0}), @list.of([2, 4]))
+/// test "filter" {
+///   assert_eq(@list.of([1, 2, 3, 4, 5]).filter(fn(x){ x % 2 == 0}), @list.of([2, 4]))
+/// }
 /// ```
 pub fn[A] filter(self : T[A], f : (A) -> Bool) -> T[A] {
   loop self {
@@ -426,8 +436,10 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 ///
 /// # Example
 /// ```
-/// let r = @list.of([1, 2, 3, 4, 5]).rev_fold(fn(acc, x) { x + acc }, init=0)
-/// assert_eq(r, 15)
+/// test "rev_fold" {
+///   let r = @list.of([1, 2, 3, 4, 5]).rev_fold(fn(acc, x) { x + acc }, init=0)
+///   assert_eq(r, 15)
+/// }
 /// ```
 pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
   let xs = self.to_array()
@@ -489,9 +501,11 @@ pub fn[A, B] zip(self : T[A], other : T[B]) -> T[(A, B)] {
 /// # Example
 ///
 /// ```
-/// let ls = @list.from_array([1, 2, 3])
-/// let r = ls.flat_map(fn(x) { @list.from_array([x, x * 2]) })
-/// assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
+/// test "flat_map" {
+///   let ls = @list.from_array([1, 2, 3])
+///   let r = ls.flat_map(fn(x) { @list.from_array([x, x * 2]) })
+///   assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
+/// }
 /// ```
 pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
   loop self {
@@ -537,9 +551,11 @@ pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
 /// # Example
 ///
 /// ```
-/// let ls = @list.of([4, 2, 2, 6, 3, 1])
-/// let r = ls.filter_map(fn(x) { if (x >= 3) { Some(x) } else { None } })
-/// assert_eq(r, @list.of([4, 6, 3]))
+/// test "filter_map" {
+///   let ls = @list.of([4, 2, 2, 6, 3, 1])
+///   let r = ls.filter_map(fn(x) { if (x >= 3) { Some(x) } else { None } })
+///   assert_eq(r, @list.of([4, 6, 3]))
+/// }
 /// ```
 pub fn[A, B] filter_map(self : T[A], f : (A) -> B?) -> T[B] {
   loop self {
@@ -593,7 +609,9 @@ pub fn[A] nth(self : T[A], n : Int) -> A? {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.repeat(5, 1), @list.from_array([1, 1, 1, 1, 1]))
+/// test "repeat" {
+///   assert_eq(@list.repeat(5, 1), @list.from_array([1, 1, 1, 1, 1]))
+/// }
 /// ```
 pub fn[A] repeat(n : Int, x : A) -> T[A] {
   loop Empty, n {
@@ -976,9 +994,11 @@ pub fn[A, E] scan_left(self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
 ///
 /// # Example
 /// ```
-/// let ls = @list.of([1, 2, 3, 4, 5])
-/// let r = ls.scan_right(fn(acc, x) { acc + x }, init=0)
-/// assert_eq(r, @list.of([15, 14, 12, 9, 5, 0]))
+/// test "List::scan_right" {
+///   let ls = @list.of([1, 2, 3, 4, 5])
+///   let r = ls.scan_right(fn(acc, x) { acc + x }, init=0)
+///   assert_eq(r, @list.of([15, 14, 12, 9, 5, 0]))
+/// }
 /// ```
 pub fn[A, B] scan_right(self : T[A], f : (B, A) -> B, init~ : B) -> T[B] {
   self.rev().scan_left(f, init~).reverse_inplace()
@@ -990,8 +1010,10 @@ pub fn[A, B] scan_right(self : T[A], f : (B, A) -> B, init~ : B) -> T[B] {
 /// # Example
 ///
 /// ```
-/// let ls = @list.from_array([(1, "a"), (2, "b"), (3, "c")])
-/// assert_eq(ls.lookup(3), Some("c"))
+/// test "lookup" {
+///   let ls = @list.from_array([(1, "a"), (2, "b"), (3, "c")])
+///   assert_eq(ls.lookup(3), Some("c"))
+/// }
 /// ```
 pub fn[A : Eq, B] lookup(self : T[(A, B)], v : A) -> B? {
   loop self {
@@ -1006,8 +1028,10 @@ pub fn[A : Eq, B] lookup(self : T[(A, B)], v : A) -> B? {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 3, 5, 8]).find(fn(element) -> Bool { element % 2 == 0}), Some(8))
-/// assert_eq(@list.of([1, 3, 5]).find(fn(element) -> Bool { element % 2 == 0}), None)
+/// test "find" {
+///   assert_eq(@list.of([1, 3, 5, 8]).find(fn(element) -> Bool { element % 2 == 0}), Some(8))
+///   assert_eq(@list.of([1, 3, 5]).find(fn(element) -> Bool { element % 2 == 0}), None)
+/// }
 /// ```
 pub fn[A] find(self : T[A], f : (A) -> Bool) -> A? {
   loop self {
@@ -1027,8 +1051,10 @@ pub fn[A] find(self : T[A], f : (A) -> Bool) -> A? {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 3, 5, 8]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), Some(8))
-/// assert_eq(@list.of([1, 3, 8, 5]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), None)
+/// test "findi" {
+///   assert_eq(@list.of([1, 3, 5, 8]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), Some(8))
+///   assert_eq(@list.of([1, 3, 8, 5]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), None)
+/// }
 /// ```
 pub fn[A] findi(self : T[A], f : (A, Int) -> Bool) -> A? {
   loop self, 0 {
@@ -1051,7 +1077,9 @@ pub fn[A] findi(self : T[A], f : (A, Int) -> Bool) -> A? {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 2, 3, 4, 5]).remove_at(2), @list.of([1, 2, 4, 5]))
+/// test "remove_at" {
+///   assert_eq(@list.of([1, 2, 3, 4, 5]).remove_at(2), @list.of([1, 2, 4, 5]))
+/// }
 /// ```
 pub fn[A] remove_at(self : T[A], index : Int) -> T[A] {
   match (index, self) {
@@ -1080,7 +1108,9 @@ pub fn[A] remove_at(self : T[A], index : Int) -> T[A] {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 2, 3, 4, 5]).remove(3), @list.of([1, 2, 4, 5]))
+/// test "remove" {
+///   assert_eq(@list.of([1, 2, 3, 4, 5]).remove(3), @list.of([1, 2, 4, 5]))
+/// }
 /// ```
 pub fn[A : Eq] remove(self : T[A], elem : A) -> T[A] {
   match self {
@@ -1110,7 +1140,9 @@ pub fn[A : Eq] remove(self : T[A], elem : A) -> T[A] {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([1, 2, 3])), true)
+/// test "is_prefix" {
+///   assert_eq(@list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([1, 2, 3])), true)
+/// }
 /// ```
 pub fn[A : Eq] is_prefix(self : T[A], prefix : T[A]) -> Bool {
   loop self, prefix {
@@ -1131,7 +1163,9 @@ pub fn[A : Eq] is_prefix(self : T[A], prefix : T[A]) -> Bool {
 /// # Example
 ///
 /// ```
-/// assert_eq(@list.of([1, 2, 3, 4, 5]).is_suffix(@list.of([3, 4, 5])), true)
+/// test "is_suffix" {
+///   assert_eq(@list.of([1, 2, 3, 4, 5]).is_suffix(@list.of([3, 4, 5])), true)
+/// }
 /// ```
 pub fn[A : Eq] is_suffix(self : T[A], suffix : T[A]) -> Bool {
   self.rev().is_prefix(suffix.rev())
@@ -1142,13 +1176,15 @@ pub fn[A : Eq] is_suffix(self : T[A], suffix : T[A]) -> Bool {
 ///
 /// # Example
 /// ```
-/// let ls = @list.of([
-///    @list.of([1, 2, 3]),
-///    @list.of([4, 5, 6]),
-///    @list.of([7, 8, 9]),
-/// ])
-/// let r = ls.intercalate(@list.of([0]))
-/// assert_eq(r, @list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]))
+/// test "intercalate" {
+///   let ls = @list.of([
+///      @list.of([1, 2, 3]),
+///      @list.of([4, 5, 6]),
+///      @list.of([7, 8, 9]),
+///   ])
+///   let r = ls.intercalate(@list.of([0]))
+///   assert_eq(r, @list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]))
+/// }
 /// ```
 pub fn[A] intercalate(self : T[T[A]], sep : T[A]) -> T[A] {
   self.intersperse(sep).flatten()

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -27,8 +27,10 @@
 /// # Example
 ///
 /// ```
-/// let result = @option.when(true, fn(){ "Hello, World!" })
-/// assert_eq(result, Some("Hello, World!"))
+/// test "when_example" {
+///   let result = @option.when(true, fn(){ "Hello, World!" })
+///   assert_eq(result, Some("Hello, World!"))
+/// }
 /// ```
 pub fn[T] when(condition : Bool, value : () -> T) -> T? {
   if condition {
@@ -104,11 +106,13 @@ test "some" {
 /// # Example
 ///
 /// ```
-/// let a = Some(5)
-/// assert_eq(a.map(fn(x){ x * 2 }), Some(10))
+/// test "map_example" {
+///   let a = Some(5)
+///   assert_eq(a.map(fn(x){ x * 2 }), Some(10))
 ///
-/// let b = None
-/// assert_eq(b.map(fn(x){ x * 2 }), None)
+///   let b = None
+///   assert_eq(b.map(fn(x){ x * 2 }), None)
+/// }
 /// ```
 pub fn[T, U] map(self : T?, f : (T) -> U) -> U? {
   match self {
@@ -132,8 +136,10 @@ test "map" {
 /// # Example
 ///
 /// ```
-/// let a = Some(5)
-/// assert_eq(a.map_or(3, fn(x){ x * 2 }), 10)
+/// test "map_or_example" {
+///   let a = Some(5)
+///   assert_eq(a.map_or(3, fn(x){ x * 2 }), 10)
+/// }
 /// ```
 pub fn[T, U] map_or(self : T?, default : U, f : (T) -> U) -> U {
   match self {
@@ -156,8 +162,10 @@ test "map_or" {
 /// # Example
 ///
 /// ```
-/// let a = Some(5)
-/// assert_eq(a.map_or_else(fn(){ 3 }, fn(x){ x * 2 }), 10)
+/// test "map_or_else_example" {
+///   let a = Some(5)
+///   assert_eq(a.map_or_else(fn(){ 3 }, fn(x){ x * 2 }), 10)
+/// }
 /// ```
 pub fn[T, U] map_or_else(self : T?, default : () -> U, f : (T) -> U) -> U {
   match self {
@@ -181,12 +189,14 @@ test "map_or_else" {
 /// # Example
 ///
 /// ```
-/// let a = Option::Some(5)
-/// let r1 = a.bind(fn(x){ Some(x * 2) })
-/// assert_eq(r1, Some(10))
-/// let b : Option[Int] = None
-/// let r2 = b.bind(fn(x){ Some(x * 2) })
-/// assert_eq(r2, None)
+/// test "bind_example" {
+///   let a = Option::Some(5)
+///   let r1 = a.bind(fn(x){ Some(x * 2) })
+///   assert_eq(r1, Some(10))
+///   let b : Option[Int] = None
+///   let r2 = b.bind(fn(x){ Some(x * 2) })
+///   assert_eq(r2, None)
+/// }
 /// ```
 pub fn[T, U] bind(self : T?, f : (T) -> U?) -> U? {
   match self {
@@ -211,10 +221,12 @@ test "bind" {
 /// # Example
 ///
 /// ```
-/// let a = Some(Some(42));
-/// assert_eq(@option.flatten(a), Some(42))
-/// let b : Int?? = Some(None)
-/// assert_eq(@option.flatten(b), None)
+/// test "flatten_example" {
+///   let a = Some(Some(42));
+///   assert_eq(@option.flatten(a), Some(42))
+///   let b : Int?? = Some(None)
+///   assert_eq(@option.flatten(b), None)
+/// }
 /// ```
 pub fn[T] flatten(self : T??) -> T? {
   match self {
@@ -253,9 +265,11 @@ test "is_empty" {
 ///
 /// # Example
 /// ```
-/// let x = Some(3)
-/// assert_eq(x.filter(fn(x){ x > 5 }), None)
-/// assert_eq(x.filter(fn(x){ x < 5 }), Some(3))
+/// test "Option::filter_example" {
+///   let x = Some(3)
+///   assert_eq(x.filter(fn(x){ x > 5 }), None)
+///   assert_eq(x.filter(fn(x){ x < 5 }), Some(3))
+/// }
 /// ```
 pub fn[T] filter(self : T?, f : (T) -> Bool) -> T? {
   match self {

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -235,9 +235,11 @@ pub fn[A] pop(self : T[A]) -> A? {
 ///
 /// # Example
 /// ```
-/// let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
-/// let mut sum = 0
-/// queue.each(fn(x) { sum = sum + x })
+/// test "each" {
+///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let mut sum = 0
+///   queue.each(fn(x) { sum = sum + x })
+/// }
 /// ```
 pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
   loop self.first {
@@ -254,9 +256,11 @@ pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
-/// let mut sum = 0
-/// queue.eachi(fn(x, i) { sum = sum + x * i })
+/// test "eachi" {
+///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let mut sum = 0
+///   queue.eachi(fn(x, i) { sum = sum + x * i })
+/// }
 /// ```
 pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
   loop self.first, 0 {
@@ -273,9 +277,11 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```
-/// let queue : @queue.T[Int] = @queue.new()
-/// let sum = queue.fold(init=0, fn(acc, x) { acc + x })
-/// assert_eq(sum, 0)
+/// test "fold" {
+///   let queue : @queue.T[Int] = @queue.new()
+///   let sum = queue.fold(init=0, fn(acc, x) { acc + x })
+///   assert_eq(sum, 0)
+/// }
 /// ```
 pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
   loop self.first, init {
@@ -289,9 +295,11 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 ///
 /// # Example
 /// ```
-/// let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
-/// let queue2 : @queue.T[Int] = queue.copy()
-/// assert_eq(queue2.length(), 4)
+/// test "copy" {
+///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue2 : @queue.T[Int] = queue.copy()
+///   assert_eq(queue2.length(), 4)
+/// }
 /// ```
 pub fn[A] copy(self : T[A]) -> T[A] {
   guard self.first is Some({ content, next }) else { return new() }
@@ -314,9 +322,11 @@ pub fn[A] copy(self : T[A]) -> T[A] {
 ///
 /// # Example
 /// ```
-/// let dst : @queue.T[Int] = @queue.new()
-/// let src : @queue.T[Int] = @queue.of([5, 6, 7, 8])
-/// src.transfer(dst)
+/// test "transfer" {
+///   let dst : @queue.T[Int] = @queue.new()
+///   let src : @queue.T[Int] = @queue.of([5, 6, 7, 8])
+///   src.transfer(dst)
+/// }
 /// ```
 pub fn[A] transfer(self : T[A], dst : T[A]) -> Unit {
   if self.length > 0 {
@@ -342,9 +352,11 @@ pub fn[A] transfer(self : T[A], dst : T[A]) -> Unit {
 ///
 /// # Example
 /// ```
-/// let queue : @queue.T[Int] = @queue.of([5, 6, 7, 8])
-/// let sum = queue.iter().fold(fn(x, y) { x + y }, init=0)
-/// assert_eq(sum, 26)
+/// test "iter" {
+///   let queue : @queue.T[Int] = @queue.of([5, 6, 7, 8])
+///   let sum = queue.iter().fold(fn(x, y) { x + y }, init=0)
+///   assert_eq(sum, 26)
+/// }
 /// ```
 pub fn[A] iter(self : T[A]) -> Iter[A] {
   Iter::new(fn(yield_) {
@@ -365,8 +377,10 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
 ///
 /// # Example
 /// ```
-/// let queue : @queue.T[Int] = @queue.from_iter(Iter::empty())
-/// assert_eq(queue.length(), 0)
+/// test "from_iter" {
+///   let queue : @queue.T[Int] = @queue.from_iter(Iter::empty())
+///   assert_eq(queue.length(), 0)
+/// }
 /// ```
 pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
   let q = new()
@@ -379,8 +393,10 @@ pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
 ///
 /// # Example
 /// ```
-/// let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
-/// assert_eq(queue.length(), 4)
+/// test "of" {
+///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   assert_eq(queue.length(), 4)
+/// }
 /// ```
 pub fn[A] of(arr : FixedArray[A]) -> T[A] {
   guard arr.length() > 0 else { return new() }

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -302,16 +302,18 @@ test "umul128: handles zero correctly" {
 ///
 /// # Example
 /// ```
-/// let r = @random.new()
-/// let a = [1, 2, 3, 4, 5]
-/// r.shuffle(
-///   a.length(),
-///   fn(i : Int, j : Int) {
-///     let t = a[i]
-///     a[i] = a[j]
-///     a[j] = t
-///   },
-/// )
+/// test "shuffle example" {
+///   let r = @random.new()
+///   let a = [1, 2, 3, 4, 5]
+///   r.shuffle(
+///     a.length(),
+///     fn(i : Int, j : Int) {
+///       let t = a[i]
+///       a[i] = a[j]
+///       a[j] = t
+///     },
+///   )
+/// }
 /// ```
 pub fn shuffle(self : Rand, limit : Int, swap : (Int, Int) -> Unit) -> Unit {
   if limit < 0 {

--- a/tuple/tuple.mbt
+++ b/tuple/tuple.mbt
@@ -17,8 +17,10 @@
 ///
 /// # Example
 /// ```
-/// let tuple = @tuple.pair(1, 2)
-/// assert_eq(tuple, (1, 2))
+/// test "Tuple::pair" {
+///   let tuple = @tuple.pair(1, 2)
+///   assert_eq(tuple, (1, 2))
+/// }
 /// ```
 pub fn[T, U] pair(x : T, y : U) -> (T, U) {
   (x, y)
@@ -29,9 +31,11 @@ pub fn[T, U] pair(x : T, y : U) -> (T, U) {
 ///
 /// # Example
 /// ```
-/// let tuple = (1, 2)
-/// let x = @tuple.fst(tuple)
-/// assert_eq(x, 1)
+/// test "Tuple::fst" {
+///   let tuple = (1, 2)
+///   let x = @tuple.fst(tuple)
+///   assert_eq(x, 1)
+/// }
 /// ```
 pub fn[T, U] fst(tuple : (T, U)) -> T {
   tuple.0
@@ -42,9 +46,11 @@ pub fn[T, U] fst(tuple : (T, U)) -> T {
 ///
 /// # Example
 /// ```
-/// let tuple = (1, 2)
-/// let y = @tuple.snd(tuple)
-/// assert_eq(y, 2)
+/// test "Tuple::snd" {
+///   let tuple = (1, 2)
+///   let y = @tuple.snd(tuple)
+///   assert_eq(y, 2)
+/// }
 /// ```
 pub fn[T, U] snd(tuple : (T, U)) -> U {
   tuple.1
@@ -55,9 +61,11 @@ pub fn[T, U] snd(tuple : (T, U)) -> U {
 ///
 /// # Example
 /// ```
-/// let tuple = (1, 2)
-/// let mapped = @tuple.map_fst(fn(x : Int) -> Int { x + 1 }, tuple)
-/// assert_eq(mapped, (2, 2))
+/// test "Tuple::map_fst" {
+///   let tuple = (1, 2)
+///   let mapped = @tuple.map_fst(fn(x : Int) -> Int { x + 1 }, tuple)
+///   assert_eq(mapped, (2, 2))
+/// }
 /// ```
 #deprecated("use `tuple |> then(fn { (a, b) => (f(a), b) })` instead")
 pub fn[T, U, V] map_fst(f : (T) -> U, tuple : (T, V)) -> (U, V) {
@@ -69,9 +77,11 @@ pub fn[T, U, V] map_fst(f : (T) -> U, tuple : (T, V)) -> (U, V) {
 ///
 /// # Example
 /// ```
-/// let tuple = (1, 2)
-/// let mapped = @tuple.map_snd(fn(x : Int) -> Int { x + 1 }, tuple)
-/// assert_eq(mapped, (1, 3))
+/// test "Tuple::map_snd" {
+///   let tuple = (1, 2)
+///   let mapped = @tuple.map_snd(fn(x : Int) -> Int { x + 1 }, tuple)
+///   assert_eq(mapped, (1, 3))
+/// }
 /// ```
 #deprecated("use `tuple |> then(fn { (a, b) => (a, f(b)) })` instead")
 pub fn[T, U, V] map_snd(f : (T) -> U, tuple : (V, T)) -> (V, U) {
@@ -83,9 +93,11 @@ pub fn[T, U, V] map_snd(f : (T) -> U, tuple : (V, T)) -> (V, U) {
 ///
 /// # Example
 /// ```
-/// let tuple = (1, 2)
-/// let mapped = @tuple.map_both(fn(x : Int) -> Int { x + 1 }, fn(x : Int) -> Int { x - 1 }, tuple)
-/// assert_eq(mapped, (2, 1))
+/// test "Tuple::map_both" {
+///   let tuple = (1, 2)
+///   let mapped = @tuple.map_both(fn(x : Int) -> Int { x + 1 }, fn(x : Int) -> Int { x - 1 }, tuple)
+///   assert_eq(mapped, (2, 1))
+/// }
 /// ```
 #deprecated("use `tuple |> then(fn { (a, b) => (f(a), g(b)) })` instead")
 pub fn[T, U, V, W] map_both(
@@ -101,9 +113,11 @@ pub fn[T, U, V, W] map_both(
 ///
 /// # Example
 /// ```
-/// let tuple = (1, 2)
-/// let swapped = @tuple.swap(tuple)
-/// assert_eq(swapped, (2, 1))
+/// test "Tuple::swap" {
+///   let tuple = (1, 2)
+///   let swapped = @tuple.swap(tuple)
+///   assert_eq(swapped, (2, 1))
+/// }
 /// ```
 pub fn[T, U] swap(tuple : (T, U)) -> (U, T) {
   (tuple.1, tuple.0)
@@ -114,9 +128,11 @@ pub fn[T, U] swap(tuple : (T, U)) -> (U, T) {
 ///
 /// # Example
 /// ```
-/// let add = fn(x : Int, y : Int) -> Int { x + y }
-/// let curried_add = @tuple.curry(add)
-/// assert_eq(curried_add(1)(2), 3)
+/// test "Tuple::curry" {
+///   let add = fn(x : Int, y : Int) -> Int { x + y }
+///   let curried_add = @tuple.curry(add)
+///   assert_eq(curried_add(1)(2), 3)
+/// }
 /// ```
 pub fn[T, U, V] curry(f : (T, U) -> V) -> (T) -> (U) -> V {
   fn(x : T) { fn(y : U) -> V { f(x, y) } }
@@ -127,9 +143,11 @@ pub fn[T, U, V] curry(f : (T, U) -> V) -> (T) -> (U) -> V {
 ///
 /// # Example
 /// ```
-/// let add = fn(x : Int) -> (Int) -> Int { fn(y : Int) -> Int { x + y } }
-/// let uncurried_add = @tuple.uncurry(add)
-/// assert_eq(uncurried_add(1, 2), 3)
+/// test "Tuple::uncurry" {
+///   let add = fn(x : Int) -> (Int) -> Int { fn(y : Int) -> Int { x + y } }
+///   let uncurried_add = @tuple.uncurry(add)
+///   assert_eq(uncurried_add(1, 2), 3)
+/// }
 /// ```
 pub fn[T, U, V] uncurry(f : (T) -> (U) -> V) -> (T, U) -> V {
   fn(x : T, y : U) { f(x)(y) }


### PR DESCRIPTION
- Added test blocks for documentation examples in the `array`, `fixedarray`, `string`, `deque`, `list`, `option`, `queue`, `random`, and `tuple` modules to ensure examples are validated.
- Improved clarity and consistency in documentation by including tests for functions like `rev_each`, `fill`, `charcode_at`, `front`, `from_array`, `when`, `shuffle`, and others.
- Ensured that all new tests reflect the expected behavior and outputs as described in the documentation.
