### PR TITLE
improve `contains_char`

### DIFF
--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -236,7 +236,37 @@ test "contains" {
 ///|
 /// Returns true if this string contains the given character.
 pub fn View::contains_char(self : View, c : Char) -> Bool {
-  self.iter().any(fn(ch) { ch == c })
+  let len = self.length()
+  // Check empty
+  guard len > 0 else { return false }
+  let c = c.to_int()
+  if c <= 0xFFFF {
+    // Search BMP
+    for i in 0..<len {
+      if self.unsafe_charcode_at(i) == c {
+        return true
+      }
+    }
+  } else {
+    // Check insufficient
+    guard len >= 2 else { return false }
+    // Calc surrogate pair
+    let adj = c - 0x10000
+    let high = 0xD800 + (adj >> 10)
+    let low = 0xDC00 + (adj & 0x3FF)
+    // Search surrogate pair
+    let mut i = 0
+    while i < len - 1 {
+      if self.unsafe_charcode_at(i) == high {
+        i += 1
+        if self.unsafe_charcode_at(i) == low {
+          return true
+        }
+      }
+      i += 1
+    }
+  }
+  false
 }
 
 ///|


### PR DESCRIPTION
### Bench code
```moonbit
///|
test (it : @bench.T) {
  let str = String::make(10000, 'a') + "b" + "😀"
  it.bench(name="contains_char_v1/bmp", fn() {
    it.keep(contains_char_v1(str, 'b'))
  })
  it.bench(name="contains_char_v2/bmp", fn() {
    it.keep(contains_char_v2(str, 'b'))
  })
  it.bench(name="contains_char_v1/surrogate", fn() {
    it.keep(contains_char_v1(str, '😀'))
  })
  it.bench(name="contains_char_v2/surrogate", fn() {
    it.keep(contains_char_v2(str, '😀'))
  })
}

///|
pub fn contains_char_v1(haystack : @string.View, needle : Char) -> Bool {
  haystack.iter().any(fn(ch) { ch == needle })
}

///|
pub fn contains_char_v2(haystack : @string.View, needle : Char) -> Bool {
  let len = haystack.length()
  // Empty
  if len == 0 {
    return false
  }
  let needle = needle.to_int()
  if needle <= 0xFFFF {
    // Search BMP
    for i in 0..<len {
      if haystack.unsafe_charcode_at(i) == needle {
        return true
      }
    }
  } else {
    // Insufficient
    if len < 2 {
      return false
    }
    // Calc surrogate pair
    let adj = needle - 0x10000
    let high = 0xD800 + (adj >> 10)
    let low = 0xDC00 + (adj & 0x3FF)
    // Search surrogate pair
    let mut i = 0
    while i < len - 1 {
      if haystack.unsafe_charcode_at(i) == high {
        i += 1
        if haystack.unsafe_charcode_at(i) == low {
          return true
        }
      }
      i += 1
    }
  }
  false
}
```
### Bench result (release mode)
- native
```txt
# set -gx MOON_CC "gcc -O2"
name                       time (mean ± σ)         range (min … max) 
contains_char_v1/bmp         51.13 µs ±   0.30 µs    50.69 µs …  51.55 µs  in 10 ×   1925 runs
contains_char_v2/bmp          3.03 µs ±   0.10 µs     2.87 µs …   3.15 µs  in 10 ×  35682 runs
contains_char_v1/surrogate   53.85 µs ±   3.67 µs    51.36 µs …  62.45 µs  in 10 ×   1951 runs
contains_char_v2/surrogate    3.21 µs ±   0.34 µs     2.90 µs …   3.79 µs  in 10 ×  27754 runs

# set -gx MOON_CC "gcc -O3 -march=native -funroll-loops"
name                       time (mean ± σ)         range (min … max) 
contains_char_v1/bmp         51.94 µs ±   0.51 µs    51.32 µs …  52.77 µs  in 10 ×   1925 runs
contains_char_v2/bmp          2.03 µs ±   0.01 µs     2.02 µs …   2.04 µs  in 10 ×  49541 runs
contains_char_v1/surrogate   52.77 µs ±   1.60 µs    51.56 µs …  56.15 µs  in 10 ×   1902 runs
contains_char_v2/surrogate    2.88 µs ±   0.06 µs     2.80 µs …   2.98 µs  in 10 ×  34145 runs
```
- wasm-gc
```txt
name                       time (mean ± σ)         range (min … max) 
contains_char_v1/bmp         33.50 µs ±   4.76 µs    28.71 µs …  42.91 µs  in 10 ×   3612 runs
contains_char_v2/bmp          6.76 µs ±   0.85 µs     5.64 µs …   8.79 µs  in 10 ×  15648 runs
contains_char_v1/surrogate   34.95 µs ±   3.63 µs    29.66 µs …  39.73 µs  in 10 ×   2391 runs
contains_char_v2/surrogate    6.60 µs ±   0.91 µs     5.50 µs …   7.96 µs  in 10 ×  12528 runs
```
- wasm
```txt
name                       time (mean ± σ)         range (min … max) 
contains_char_v1/bmp        177.46 µs ±  13.09 µs   162.01 µs … 199.95 µs  in 10 ×    388 runs
contains_char_v2/bmp          9.01 µs ±   0.90 µs     7.63 µs …   9.86 µs  in 10 ×  10856 runs
contains_char_v1/surrogate  132.04 µs ±   1.68 µs   129.57 µs … 134.68 µs  in 10 ×    773 runs
contains_char_v2/surrogate   27.40 µs ±   0.37 µs    26.71 µs …  27.77 µs  in 10 ×   3688 runs
```
- js
```txt
name                       time (mean ± σ)         range (min … max) 
contains_char_v1/bmp         19.25 µs ±   0.11 µs    19.12 µs …  19.41 µs  in 10 ×   5023 runs
contains_char_v2/bmp          8.45 µs ±   0.35 µs     8.18 µs …   9.21 µs  in 10 ×  11781 runs
contains_char_v1/surrogate   19.92 µs ±   0.51 µs    19.28 µs …  20.79 µs  in 10 ×   5107 runs
contains_char_v2/surrogate   12.09 µs ±   0.42 µs    11.59 µs …  12.98 µs  in 10 ×   7933 runs
```