### PR TITLE
Add test for `Iter::iter2` functionality

### DIFF
--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -812,8 +812,7 @@ test "Iter::iter2" {
   for i, x in iter.iter2() {
     assert_eq(i, x)
   }
-  // TODO: fix this in the next release
-  // for i, x in iter {
-  //   assert_eq(i, x)
-  // }
+  for i, x in iter {
+    assert_eq(i, x)
+  }
 }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -805,3 +805,15 @@ test "iter2" {
     assert_eq(i, x)
   }
 }
+
+///|
+test "Iter::iter2" {
+  let iter = [0, 1, 2].iter()
+  for i, x in iter.iter2() {
+    assert_eq(i, x)
+  }
+  // TODO: fix this in the next release
+  // for i, x in iter {
+  //   assert_eq(i, x)
+  // }
+}


### PR DESCRIPTION
- Introduced a new test case for the `iter2` method in the `iter_test.mbt` file to validate its behavior.
- Included assertions to check that the indices and values match during iteration.
- Added a TODO comment to address a known issue in the next release.
