### PR TITLE
refactor: remove function not

### DIFF
--- a/array/view.mbt
+++ b/array/view.mbt
@@ -24,7 +24,7 @@
 /// assert_eq(view[0], 2)
 /// assert_eq(view.length(), 3)
 /// ```
-pub typealias View[T] = ArrayView[T]
+pub typealias ArrayView as View
 
 ///|
 /// Reverses the elements in the array view in place.

--- a/array/view_test.mbt
+++ b/array/view_test.mbt
@@ -204,7 +204,7 @@ test "arrayview_to_array" {
 
 ///|
 test "arrayview_arbitrary" {
-  let arr : Array[ArrayView[Int]] = @quickcheck.samples(20)
+  let arr : Array[View[Int]] = @quickcheck.samples(20)
   inspect(arr[5:9], content="[[], [], [0], [0, 0]]")
   inspect(
     arr[10:15],
@@ -214,7 +214,7 @@ test "arrayview_arbitrary" {
 
 ///|
 test "arrayview_hash" {
-  let arr : Array[ArrayView[Int]] = @quickcheck.samples(20)
+  let arr : Array[View[Int]] = @quickcheck.samples(20)
   inspect(arr[5:9].hash(), content="-966877954")
   inspect(arr[10:15].hash(), content="-951019668")
 }

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///| Extensible buffer.
-#deprecated("Use type `T` instead")
-pub(all) typealias Buffer = T
+// #deprecated("Use type `T` instead")
+pub(all) typealias T as Buffer
 
 ///|
 /// Extensible buffer.

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -20,8 +20,6 @@ fn[T] ignore(T) -> Unit
 
 fn inspect(&Show, content~ : String = .., loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit!InspectError
 
-fn not(Bool) -> Bool
-
 fn[T : Compare] op_ge(T, T) -> Bool
 
 fn[T : Compare] op_gt(T, T) -> Bool

--- a/builtin/byte_test.mbt
+++ b/builtin/byte_test.mbt
@@ -41,11 +41,11 @@ test "byte_op_equal" {
   let b2 = b'\x0F'
   let b3 = b'\xFF'
   assert_true(b1.op_equal(b1))
-  assert_true(b1.op_equal(b2) |> not)
-  assert_true(b2.op_equal(b1) |> not)
+  assert_true(not(b1.op_equal(b2)))
+  assert_true(not(b2.op_equal(b1)))
   assert_true(b2.op_equal(b2))
-  assert_true(b2.op_equal(b3) |> not)
-  assert_true(b3.op_equal(b2) |> not)
+  assert_true(not(b2.op_equal(b3)))
+  assert_true(not(b3.op_equal(b2)))
   assert_true(b3.op_equal(b3))
 }
 

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -67,28 +67,6 @@ pub fnalias @abort.abort
 ///|
 pub fn[T] panic() -> T = "%panic"
 
-// Bool primitive ops
-
-///|
-/// Performs logical negation on a boolean value.
-///
-/// Parameters:
-///
-/// * `value` : The boolean value to negate.
-///
-/// Returns the logical NOT of the input value: `true` if the input is `false`,
-/// and `false` if the input is `true`.
-///
-/// Example:
-///
-/// ```moonbit
-/// test "not" {
-///   inspect(not(true), content="false")
-///   inspect(not(false), content="true")
-/// }
-/// ```
-pub fn not(x : Bool) -> Bool = "%bool_not"
-
 ///|
 /// Compares two boolean values for equality.
 ///

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///|
-#deprecated("Definition of json is moved to builtin package, use `Json` instead")
-pub(all) typealias JsonValue = Json
+// #deprecated("Definition of json is moved to builtin package, use `Json` instead")
+pub(all) typealias Json as JsonValue
 
 ///|
 pub(all) struct Position {

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -75,7 +75,6 @@ pub fnalias @builtin.(
   panic,
   physical_equal,
   println,
-  not,
   repr,
   dump
 )

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///|
-#deprecated("Use `@array.View` instead")
-pub typealias ArrayView[A] = @array.View[A]
+// #deprecated("Use `@array.View` instead")
+pub typealias @array.View as ArrayView
 
 ///|
 pub typealias @builtin.(

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -45,7 +45,7 @@ pub typealias ArgsLoc = @builtin.ArgsLoc
 
 pub typealias Array[T] = @builtin.Array[T]
 
-pub typealias ArrayView[A] = @builtin.ArrayView[A]
+pub typealias ArrayView[T] = @builtin.ArrayView[T]
 
 pub typealias BigInt = @moonbitlang/core/bigint.BigInt
 

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -24,8 +24,6 @@ fn[T] ignore(T) -> Unit
 
 fn inspect(&@builtin.Show, content~ : String = .., loc~ : @builtin.SourceLoc = _, args_loc~ : @builtin.ArgsLoc = _) -> Unit!@builtin.InspectError
 
-fn not(Bool) -> Bool
-
 fn[T] panic() -> T
 
 fn[T] physical_equal(T, T) -> Bool

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -36,7 +36,7 @@ struct StringView {
 /// A `@string.View` represents a view of a String that maintains proper Unicode
 /// character boundaries. It allows safe access to a substring while handling 
 /// multi-byte characters correctly.
-pub typealias View = StringView
+pub typealias StringView as View
 
 ///| 
 /// Returns the charcode(UTF-16 code unit) at the given index.


### PR DESCRIPTION
We will introduce the `not expr` syntax to replace the `not()` function