### PR TITLE
remove use of old type alias syntax

### DIFF
--- a/array/view.mbt
+++ b/array/view.mbt
@@ -24,7 +24,7 @@
 /// assert_eq(view[0], 2)
 /// assert_eq(view.length(), 3)
 /// ```
-pub typealias View[T] = ArrayView[T]
+pub typealias ArrayView as View
 
 ///|
 /// Reverses the elements in the array view in place.

--- a/array/view_test.mbt
+++ b/array/view_test.mbt
@@ -204,7 +204,7 @@ test "arrayview_to_array" {
 
 ///|
 test "arrayview_arbitrary" {
-  let arr : Array[ArrayView[Int]] = @quickcheck.samples(20)
+  let arr : Array[View[Int]] = @quickcheck.samples(20)
   inspect(arr[5:9], content="[[], [], [0], [0, 0]]")
   inspect(
     arr[10:15],
@@ -214,7 +214,7 @@ test "arrayview_arbitrary" {
 
 ///|
 test "arrayview_hash" {
-  let arr : Array[ArrayView[Int]] = @quickcheck.samples(20)
+  let arr : Array[View[Int]] = @quickcheck.samples(20)
   inspect(arr[5:9].hash(), content="-966877954")
   inspect(arr[10:15].hash(), content="-951019668")
 }

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///| Extensible buffer.
-#deprecated("Use type `T` instead")
-pub(all) typealias Buffer = T
+// #deprecated("Use type `T` instead")
+pub(all) typealias T as Buffer
 
 ///|
 /// Extensible buffer.

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///|
-#deprecated("Definition of json is moved to builtin package, use `Json` instead")
-pub(all) typealias JsonValue = Json
+// #deprecated("Definition of json is moved to builtin package, use `Json` instead")
+pub(all) typealias Json as JsonValue
 
 ///|
 pub(all) struct Position {

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///|
-#deprecated("Use `@array.View` instead")
-pub typealias ArrayView[A] = @array.View[A]
+// #deprecated("Use `@array.View` instead")
+pub typealias @array.View as ArrayView
 
 ///|
 pub typealias @builtin.(

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -45,7 +45,7 @@ pub typealias ArgsLoc = @builtin.ArgsLoc
 
 pub typealias Array[T] = @builtin.Array[T]
 
-pub typealias ArrayView[A] = @builtin.ArrayView[A]
+pub typealias ArrayView[T] = @builtin.ArrayView[T]
 
 pub typealias BigInt = @moonbitlang/core/bigint.BigInt
 

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -36,7 +36,7 @@ struct StringView {
 /// A `@string.View` represents a view of a String that maintains proper Unicode
 /// character boundaries. It allows safe access to a substring while handling 
 /// multi-byte characters correctly.
-pub typealias View = StringView
+pub typealias StringView as View
 
 ///| 
 /// Returns the charcode(UTF-16 code unit) at the given index.


### PR DESCRIPTION
We intend to deprecate the `typealias XX = YY` and `traitalias XX = YY` syntax, to make the language more uniform, and the various forms of alias (`typealias`/`traitalias`/`fnalias`) more consistent. This PR migrates core and remove usage of the old syntax.

Deprecating type alias is currently unsupported, however due to a compiler bug, the unused attribute warning is currently not reported for `typealias XX = YY`. But the warning will be correctly emitted for `typealias YY as XX`, so this PR need to temporarily comment out the deprecation attributes on type alias.