### PR TITLE
use regular method call to implement ToJson for Error

### DIFF
--- a/error/error.mbt
+++ b/error/error.mbt
@@ -37,4 +37,9 @@ pub impl Show for Error with output(self, logger) {
 }
 
 ///|
-pub impl ToJson for Error with to_json(self) = "%error.to_json"
+fn Error::to_json(self : Error) -> Json = "%error.to_json"
+
+///|
+pub impl ToJson for Error with to_json(self) {
+  self.to_json()
+}


### PR DESCRIPTION
Using primitive directly triggers some compiler bugs. The compiler bug will be fixed. This PR just makes it robust to avoid other surprising behaviors caused by primitives.