### PR TITLE
remove usage of `f!(..)` and `f?(..)`

### DIFF
--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -727,249 +727,237 @@ test "to_uint64" {
 
 ///|
 test "equal_int" {
-  assert_true!(BigInt::equal_int(1N, 1))
-  assert_true!(BigInt::equal_int(-1N, -1))
-  assert_false!(BigInt::equal_int(1N, -1))
-  assert_false!(BigInt::equal_int(-1N, 1))
-  assert_true!(BigInt::equal_int(0N, 0))
-  assert_false!(BigInt::equal_int(0N, 1))
-  assert_false!(BigInt::equal_int(1N, 0))
+  assert_true(BigInt::equal_int(1N, 1))
+  assert_true(BigInt::equal_int(-1N, -1))
+  assert_false(BigInt::equal_int(1N, -1))
+  assert_false(BigInt::equal_int(-1N, 1))
+  assert_true(BigInt::equal_int(0N, 0))
+  assert_false(BigInt::equal_int(0N, 1))
+  assert_false(BigInt::equal_int(1N, 0))
 
   // Test with max/min int values
-  assert_true!(BigInt::equal_int(2147483647N, 2147483647))
-  assert_true!(BigInt::equal_int(-2147483648N, -2147483648))
-  assert_false!(BigInt::equal_int(2147483647N, -2147483648))
-  assert_false!(BigInt::equal_int(-2147483648N, 2147483647))
+  assert_true(BigInt::equal_int(2147483647N, 2147483647))
+  assert_true(BigInt::equal_int(-2147483648N, -2147483648))
+  assert_false(BigInt::equal_int(2147483647N, -2147483648))
+  assert_false(BigInt::equal_int(-2147483648N, 2147483647))
 
   // Test with large BigInt that doesn't fit in int
   let large = 2N.pow(32)
-  assert_false!(BigInt::equal_int(large, 0))
-  assert_false!(BigInt::equal_int(large, 1))
-  assert_false!(BigInt::equal_int(large, -1))
+  assert_false(BigInt::equal_int(large, 0))
+  assert_false(BigInt::equal_int(large, 1))
+  assert_false(BigInt::equal_int(large, -1))
 
   // Test with negative large BigInt
   let neg_large = -2N.pow(32)
-  assert_false!(BigInt::equal_int(neg_large, 0))
-  assert_false!(BigInt::equal_int(neg_large, 1))
-  assert_false!(BigInt::equal_int(neg_large, -1))
+  assert_false(BigInt::equal_int(neg_large, 0))
+  assert_false(BigInt::equal_int(neg_large, 1))
+  assert_false(BigInt::equal_int(neg_large, -1))
 }
 
 ///|
 test "equal_int64" {
-  assert_true!(BigInt::equal_int64(1N, 1L))
-  assert_true!(BigInt::equal_int64(-1N, -1L))
-  assert_false!(BigInt::equal_int64(1N, -1L))
-  assert_false!(BigInt::equal_int64(-1N, 1L))
-  assert_true!(BigInt::equal_int64(0N, 0L))
-  assert_false!(BigInt::equal_int64(0N, 1L))
-  assert_false!(BigInt::equal_int64(1N, 0L))
+  assert_true(BigInt::equal_int64(1N, 1L))
+  assert_true(BigInt::equal_int64(-1N, -1L))
+  assert_false(BigInt::equal_int64(1N, -1L))
+  assert_false(BigInt::equal_int64(-1N, 1L))
+  assert_true(BigInt::equal_int64(0N, 0L))
+  assert_false(BigInt::equal_int64(0N, 1L))
+  assert_false(BigInt::equal_int64(1N, 0L))
 
   // Test with max/min int64 values
-  assert_true!(BigInt::equal_int64(9223372036854775807N, 9223372036854775807L))
-  assert_true!(
-    BigInt::equal_int64(-9223372036854775808N, -9223372036854775808L),
-  )
-  assert_false!(
-    BigInt::equal_int64(9223372036854775807N, -9223372036854775808L),
-  )
-  assert_false!(
-    BigInt::equal_int64(-9223372036854775808N, 9223372036854775807L),
-  )
+  assert_true(BigInt::equal_int64(9223372036854775807N, 9223372036854775807L))
+  assert_true(BigInt::equal_int64(-9223372036854775808N, -9223372036854775808L))
+  assert_false(BigInt::equal_int64(9223372036854775807N, -9223372036854775808L))
+  assert_false(BigInt::equal_int64(-9223372036854775808N, 9223372036854775807L))
 
   // Test with large values that fit in int64
-  assert_true!(BigInt::equal_int64(1234567890123456789N, 1234567890123456789L))
-  assert_true!(
-    BigInt::equal_int64(-1234567890123456789N, -1234567890123456789L),
-  )
-  assert_false!(
-    BigInt::equal_int64(1234567890123456789N, -1234567890123456789L),
-  )
-  assert_false!(
-    BigInt::equal_int64(-1234567890123456789N, 1234567890123456789L),
-  )
+  assert_true(BigInt::equal_int64(1234567890123456789N, 1234567890123456789L))
+  assert_true(BigInt::equal_int64(-1234567890123456789N, -1234567890123456789L))
+  assert_false(BigInt::equal_int64(1234567890123456789N, -1234567890123456789L))
+  assert_false(BigInt::equal_int64(-1234567890123456789N, 1234567890123456789L))
 
   // Test with BigInt that doesn't fit in int64
   let large = 2N.pow(64)
-  assert_false!(BigInt::equal_int64(large, 0L))
-  assert_false!(BigInt::equal_int64(large, 1L))
-  assert_false!(BigInt::equal_int64(large, -1L))
-  assert_false!(BigInt::equal_int64(large, 9223372036854775807L))
-  assert_false!(BigInt::equal_int64(large, -9223372036854775808L))
+  assert_false(BigInt::equal_int64(large, 0L))
+  assert_false(BigInt::equal_int64(large, 1L))
+  assert_false(BigInt::equal_int64(large, -1L))
+  assert_false(BigInt::equal_int64(large, 9223372036854775807L))
+  assert_false(BigInt::equal_int64(large, -9223372036854775808L))
 
   // Test with negative large BigInt that doesn't fit in int64
   let neg_large = -2N.pow(64)
-  assert_false!(BigInt::equal_int64(neg_large, 0L))
-  assert_false!(BigInt::equal_int64(neg_large, 1L))
-  assert_false!(BigInt::equal_int64(neg_large, -1L))
-  assert_false!(BigInt::equal_int64(neg_large, 9223372036854775807L))
-  assert_false!(BigInt::equal_int64(neg_large, -9223372036854775808L))
+  assert_false(BigInt::equal_int64(neg_large, 0L))
+  assert_false(BigInt::equal_int64(neg_large, 1L))
+  assert_false(BigInt::equal_int64(neg_large, -1L))
+  assert_false(BigInt::equal_int64(neg_large, 9223372036854775807L))
+  assert_false(BigInt::equal_int64(neg_large, -9223372036854775808L))
 
   // Test edge cases around int64 boundaries
   let max_plus_one = 9223372036854775808N // 2^63
   let min_minus_one = -9223372036854775809N // -2^63 - 1
-  assert_false!(BigInt::equal_int64(max_plus_one, 9223372036854775807L))
-  assert_false!(BigInt::equal_int64(min_minus_one, -9223372036854775808L))
+  assert_false(BigInt::equal_int64(max_plus_one, 9223372036854775807L))
+  assert_false(BigInt::equal_int64(min_minus_one, -9223372036854775808L))
 
   // Test with powers of 2
-  assert_true!(BigInt::equal_int64(2N.pow(32), 4294967296L))
-  assert_true!(BigInt::equal_int64(2N.pow(62), 4611686018427387904L))
-  assert_false!(BigInt::equal_int64(2N.pow(63), 9223372036854775807L)) // This would overflow
+  assert_true(BigInt::equal_int64(2N.pow(32), 4294967296L))
+  assert_true(BigInt::equal_int64(2N.pow(62), 4611686018427387904L))
+  assert_false(BigInt::equal_int64(2N.pow(63), 9223372036854775807L)) // This would overflow
 }
 
 ///|
 test "compare_int" {
   // Test with zero
-  assert_eq!(BigInt::compare_int(0N, 0), 0)
-  assert_eq!(BigInt::compare_int(0N, 1), -1)
-  assert_eq!(BigInt::compare_int(0N, -1), 1)
+  assert_eq(BigInt::compare_int(0N, 0), 0)
+  assert_eq(BigInt::compare_int(0N, 1), -1)
+  assert_eq(BigInt::compare_int(0N, -1), 1)
 
   // Test with positive values
-  assert_eq!(BigInt::compare_int(1N, 1), 0)
-  assert_eq!(BigInt::compare_int(1N, 0), 1)
-  assert_eq!(BigInt::compare_int(1N, 2), -1)
-  assert_eq!(BigInt::compare_int(42N, 42), 0)
-  assert_eq!(BigInt::compare_int(100N, 50), 1)
-  assert_eq!(BigInt::compare_int(25N, 100), -1)
+  assert_eq(BigInt::compare_int(1N, 1), 0)
+  assert_eq(BigInt::compare_int(1N, 0), 1)
+  assert_eq(BigInt::compare_int(1N, 2), -1)
+  assert_eq(BigInt::compare_int(42N, 42), 0)
+  assert_eq(BigInt::compare_int(100N, 50), 1)
+  assert_eq(BigInt::compare_int(25N, 100), -1)
 
   // Test with negative values
-  assert_eq!(BigInt::compare_int(-1N, -1), 0)
-  assert_eq!(BigInt::compare_int(-1N, 0), -1)
-  assert_eq!(BigInt::compare_int(-1N, 1), -1)
-  assert_eq!(BigInt::compare_int(-42N, -42), 0)
-  assert_eq!(BigInt::compare_int(-25N, -100), 1)
-  assert_eq!(BigInt::compare_int(-100N, -50), -1)
+  assert_eq(BigInt::compare_int(-1N, -1), 0)
+  assert_eq(BigInt::compare_int(-1N, 0), -1)
+  assert_eq(BigInt::compare_int(-1N, 1), -1)
+  assert_eq(BigInt::compare_int(-42N, -42), 0)
+  assert_eq(BigInt::compare_int(-25N, -100), 1)
+  assert_eq(BigInt::compare_int(-100N, -50), -1)
 
   // Test with mixed signs
-  assert_eq!(BigInt::compare_int(1N, -1), 1)
-  assert_eq!(BigInt::compare_int(-1N, 1), -1)
-  assert_eq!(BigInt::compare_int(100N, -50), 1)
-  assert_eq!(BigInt::compare_int(-100N, 50), -1)
+  assert_eq(BigInt::compare_int(1N, -1), 1)
+  assert_eq(BigInt::compare_int(-1N, 1), -1)
+  assert_eq(BigInt::compare_int(100N, -50), 1)
+  assert_eq(BigInt::compare_int(-100N, 50), -1)
 
   // Test with Int boundary values
-  assert_eq!(BigInt::compare_int(2147483647N, 2147483647), 0) // Int.max_value
-  assert_eq!(BigInt::compare_int(-2147483648N, -2147483648), 0) // Int.min_value
-  assert_eq!(BigInt::compare_int(2147483647N, 2147483646), 1)
-  assert_eq!(BigInt::compare_int(2147483646N, 2147483647), -1)
-  assert_eq!(BigInt::compare_int(-2147483648N, -2147483647), -1)
-  assert_eq!(BigInt::compare_int(-2147483647N, -2147483648), 1)
+  assert_eq(BigInt::compare_int(2147483647N, 2147483647), 0) // Int.max_value
+  assert_eq(BigInt::compare_int(-2147483648N, -2147483648), 0) // Int.min_value
+  assert_eq(BigInt::compare_int(2147483647N, 2147483646), 1)
+  assert_eq(BigInt::compare_int(2147483646N, 2147483647), -1)
+  assert_eq(BigInt::compare_int(-2147483648N, -2147483647), -1)
+  assert_eq(BigInt::compare_int(-2147483647N, -2147483648), 1)
 
   // Test with BigInt that doesn't fit in Int
   let large = 2147483648N // Int.max_value + 1
-  assert_eq!(BigInt::compare_int(large, 2147483647), 1)
-  assert_eq!(BigInt::compare_int(large, -2147483648), 1)
-  assert_eq!(BigInt::compare_int(large, 0), 1)
+  assert_eq(BigInt::compare_int(large, 2147483647), 1)
+  assert_eq(BigInt::compare_int(large, -2147483648), 1)
+  assert_eq(BigInt::compare_int(large, 0), 1)
   let neg_large = -2147483649N // Int.min_value - 1
-  assert_eq!(BigInt::compare_int(neg_large, -2147483648), -1)
-  assert_eq!(BigInt::compare_int(neg_large, 2147483647), -1)
-  assert_eq!(BigInt::compare_int(neg_large, 0), -1)
+  assert_eq(BigInt::compare_int(neg_large, -2147483648), -1)
+  assert_eq(BigInt::compare_int(neg_large, 2147483647), -1)
+  assert_eq(BigInt::compare_int(neg_large, 0), -1)
 
   // Test with very large BigInt values
   let very_large = BigInt::from_string("123456789012345678901234567890")
-  assert_eq!(BigInt::compare_int(very_large, 2147483647), 1)
-  assert_eq!(BigInt::compare_int(very_large, -2147483648), 1)
-  assert_eq!(BigInt::compare_int(very_large, 0), 1)
+  assert_eq(BigInt::compare_int(very_large, 2147483647), 1)
+  assert_eq(BigInt::compare_int(very_large, -2147483648), 1)
+  assert_eq(BigInt::compare_int(very_large, 0), 1)
   let very_neg_large = BigInt::from_string("-123456789012345678901234567890")
-  assert_eq!(BigInt::compare_int(very_neg_large, 2147483647), -1)
-  assert_eq!(BigInt::compare_int(very_neg_large, -2147483648), -1)
-  assert_eq!(BigInt::compare_int(very_neg_large, 0), -1)
+  assert_eq(BigInt::compare_int(very_neg_large, 2147483647), -1)
+  assert_eq(BigInt::compare_int(very_neg_large, -2147483648), -1)
+  assert_eq(BigInt::compare_int(very_neg_large, 0), -1)
 
   // Test with powers of 2
-  assert_eq!(BigInt::compare_int(2N.pow(10), 1024), 0)
-  assert_eq!(BigInt::compare_int(2N.pow(20), 1048576), 0)
-  assert_eq!(BigInt::compare_int(2N.pow(30), 1073741824), 0)
-  assert_eq!(BigInt::compare_int(2N.pow(31), 2147483647), 1) // 2^31 > Int.max_value
+  assert_eq(BigInt::compare_int(2N.pow(10), 1024), 0)
+  assert_eq(BigInt::compare_int(2N.pow(20), 1048576), 0)
+  assert_eq(BigInt::compare_int(2N.pow(30), 1073741824), 0)
+  assert_eq(BigInt::compare_int(2N.pow(31), 2147483647), 1) // 2^31 > Int.max_value
 }
 
 ///|
 test "compare_int64" {
   // Test with zero
-  assert_eq!(BigInt::compare_int64(0N, 0L), 0)
-  assert_eq!(BigInt::compare_int64(0N, 1L), -1)
-  assert_eq!(BigInt::compare_int64(0N, -1L), 1)
+  assert_eq(BigInt::compare_int64(0N, 0L), 0)
+  assert_eq(BigInt::compare_int64(0N, 1L), -1)
+  assert_eq(BigInt::compare_int64(0N, -1L), 1)
 
   // Test with positive values
-  assert_eq!(BigInt::compare_int64(1N, 1L), 0)
-  assert_eq!(BigInt::compare_int64(42N, 42L), 0)
-  assert_eq!(BigInt::compare_int64(100N, 50L), 1)
-  assert_eq!(BigInt::compare_int64(25N, 100L), -1)
+  assert_eq(BigInt::compare_int64(1N, 1L), 0)
+  assert_eq(BigInt::compare_int64(42N, 42L), 0)
+  assert_eq(BigInt::compare_int64(100N, 50L), 1)
+  assert_eq(BigInt::compare_int64(25N, 100L), -1)
 
   // Test with negative values
-  assert_eq!(BigInt::compare_int64(-1N, -1L), 0)
-  assert_eq!(BigInt::compare_int64(-1N, 0L), -1)
-  assert_eq!(BigInt::compare_int64(-1N, 1L), -1)
-  assert_eq!(BigInt::compare_int64(-42N, -42L), 0)
-  assert_eq!(BigInt::compare_int64(-25N, -100L), 1)
-  assert_eq!(BigInt::compare_int64(-100N, -50L), -1)
+  assert_eq(BigInt::compare_int64(-1N, -1L), 0)
+  assert_eq(BigInt::compare_int64(-1N, 0L), -1)
+  assert_eq(BigInt::compare_int64(-1N, 1L), -1)
+  assert_eq(BigInt::compare_int64(-42N, -42L), 0)
+  assert_eq(BigInt::compare_int64(-25N, -100L), 1)
+  assert_eq(BigInt::compare_int64(-100N, -50L), -1)
 
   // Test with mixed signs
-  assert_eq!(BigInt::compare_int64(1N, -1L), 1)
-  assert_eq!(BigInt::compare_int64(-1N, 1L), -1)
-  assert_eq!(BigInt::compare_int64(100N, -50L), 1)
-  assert_eq!(BigInt::compare_int64(-100N, 50L), -1)
+  assert_eq(BigInt::compare_int64(1N, -1L), 1)
+  assert_eq(BigInt::compare_int64(-1N, 1L), -1)
+  assert_eq(BigInt::compare_int64(100N, -50L), 1)
+  assert_eq(BigInt::compare_int64(-100N, 50L), -1)
 
   // Test with Int64 boundary values
-  assert_eq!(
+  assert_eq(
     BigInt::compare_int64(9223372036854775807N, 9223372036854775807L),
     0,
   ) // Int64.max_value
-  assert_eq!(
+  assert_eq(
     BigInt::compare_int64(-9223372036854775808N, -9223372036854775808L),
     0,
   ) // Int64.min_value
-  assert_eq!(
+  assert_eq(
     BigInt::compare_int64(9223372036854775807N, 9223372036854775806L),
     1,
   )
-  assert_eq!(
+  assert_eq(
     BigInt::compare_int64(9223372036854775806N, 9223372036854775807L),
     -1,
   )
-  assert_eq!(
+  assert_eq(
     BigInt::compare_int64(-9223372036854775808N, -9223372036854775807L),
     -1,
   )
-  assert_eq!(
+  assert_eq(
     BigInt::compare_int64(-9223372036854775807N, -9223372036854775808L),
     1,
   )
 
   // Test with BigInt that doesn't fit in Int64
   let large = BigInt::from_string("9223372036854775808") // Int64.max_value + 1
-  assert_eq!(BigInt::compare_int64(large, 9223372036854775807L), 1)
-  assert_eq!(BigInt::compare_int64(large, -9223372036854775808L), 1)
-  assert_eq!(BigInt::compare_int64(large, 0L), 1)
+  assert_eq(BigInt::compare_int64(large, 9223372036854775807L), 1)
+  assert_eq(BigInt::compare_int64(large, -9223372036854775808L), 1)
+  assert_eq(BigInt::compare_int64(large, 0L), 1)
   let neg_large = BigInt::from_string("-9223372036854775809") // Int64.min_value - 1
-  assert_eq!(BigInt::compare_int64(neg_large, -9223372036854775808L), -1)
-  assert_eq!(BigInt::compare_int64(neg_large, 9223372036854775807L), -1)
-  assert_eq!(BigInt::compare_int64(neg_large, 0L), -1)
+  assert_eq(BigInt::compare_int64(neg_large, -9223372036854775808L), -1)
+  assert_eq(BigInt::compare_int64(neg_large, 9223372036854775807L), -1)
+  assert_eq(BigInt::compare_int64(neg_large, 0L), -1)
 
   // Test with very large BigInt values
   let very_large = BigInt::from_string("123456789012345678901234567890")
-  assert_eq!(BigInt::compare_int64(very_large, 9223372036854775807L), 1)
-  assert_eq!(BigInt::compare_int64(very_large, -9223372036854775808L), 1)
-  assert_eq!(BigInt::compare_int64(very_large, 0L), 1)
+  assert_eq(BigInt::compare_int64(very_large, 9223372036854775807L), 1)
+  assert_eq(BigInt::compare_int64(very_large, -9223372036854775808L), 1)
+  assert_eq(BigInt::compare_int64(very_large, 0L), 1)
   let very_neg_large = BigInt::from_string("-123456789012345678901234567890")
-  assert_eq!(BigInt::compare_int64(very_neg_large, 9223372036854775807L), -1)
-  assert_eq!(BigInt::compare_int64(very_neg_large, -9223372036854775808L), -1)
-  assert_eq!(BigInt::compare_int64(very_neg_large, 0L), -1)
+  assert_eq(BigInt::compare_int64(very_neg_large, 9223372036854775807L), -1)
+  assert_eq(BigInt::compare_int64(very_neg_large, -9223372036854775808L), -1)
+  assert_eq(BigInt::compare_int64(very_neg_large, 0L), -1)
 
   // Test with powers of 2
-  assert_eq!(BigInt::compare_int64(2N.pow(10), 1024L), 0)
-  assert_eq!(BigInt::compare_int64(2N.pow(20), 1048576L), 0)
-  assert_eq!(BigInt::compare_int64(2N.pow(30), 1073741824L), 0)
-  assert_eq!(BigInt::compare_int64(2N.pow(40), 1099511627776L), 0)
-  assert_eq!(BigInt::compare_int64(2N.pow(50), 1125899906842624L), 0)
-  assert_eq!(BigInt::compare_int64(2N.pow(60), 1152921504606846976L), 0)
-  assert_eq!(BigInt::compare_int64(2N.pow(62), 4611686018427387904L), 0)
-  assert_eq!(BigInt::compare_int64(2N.pow(63), 9223372036854775807L), 1) // 2^63 > Int64.max_value
+  assert_eq(BigInt::compare_int64(2N.pow(10), 1024L), 0)
+  assert_eq(BigInt::compare_int64(2N.pow(20), 1048576L), 0)
+  assert_eq(BigInt::compare_int64(2N.pow(30), 1073741824L), 0)
+  assert_eq(BigInt::compare_int64(2N.pow(40), 1099511627776L), 0)
+  assert_eq(BigInt::compare_int64(2N.pow(50), 1125899906842624L), 0)
+  assert_eq(BigInt::compare_int64(2N.pow(60), 1152921504606846976L), 0)
+  assert_eq(BigInt::compare_int64(2N.pow(62), 4611686018427387904L), 0)
+  assert_eq(BigInt::compare_int64(2N.pow(63), 9223372036854775807L), 1) // 2^63 > Int64.max_value
 
   // Test with values around 32-bit boundaries (to ensure 64-bit handling)
   let val_32bit = 4294967296N // 2^32
-  assert_eq!(BigInt::compare_int64(val_32bit, 4294967296L), 0)
-  assert_eq!(BigInt::compare_int64(val_32bit, 4294967295L), 1)
-  assert_eq!(BigInt::compare_int64(val_32bit, 4294967297L), -1)
+  assert_eq(BigInt::compare_int64(val_32bit, 4294967296L), 0)
+  assert_eq(BigInt::compare_int64(val_32bit, 4294967295L), 1)
+  assert_eq(BigInt::compare_int64(val_32bit, 4294967297L), -1)
   let neg_val_32bit = -4294967296N // -2^32
-  assert_eq!(BigInt::compare_int64(neg_val_32bit, -4294967296L), 0)
-  assert_eq!(BigInt::compare_int64(neg_val_32bit, -4294967295L), -1)
-  assert_eq!(BigInt::compare_int64(neg_val_32bit, -4294967297L), 1)
+  assert_eq(BigInt::compare_int64(neg_val_32bit, -4294967296L), 0)
+  assert_eq(BigInt::compare_int64(neg_val_32bit, -4294967295L), -1)
+  assert_eq(BigInt::compare_int64(neg_val_32bit, -4294967297L), 1)
 }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -502,11 +502,11 @@ test "chunks_by" {
 test "array_windows" {
   let arr = [1, 2, 3, 4, 5, 6]
   let windows = arr.windows(11)
-  inspect!(windows, content="[]")
+  inspect(windows, content="[]")
   let windows = arr.windows(5)
-  inspect!(windows, content="[[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]")
+  inspect(windows, content="[[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]")
   let windows = arr.windows(1)
-  inspect!(windows, content="[[1], [2], [3], [4], [5], [6]]")
+  inspect(windows, content="[[1], [2], [3], [4], [5], [6]]")
 }
 
 ///|

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -269,18 +269,18 @@ test "compare" {
 ///|
 test "@array.get/normal" {
   let arr = @array.of([1, 2, 3, 4, 5])
-  inspect!(arr.get(2), content="Some(3)")
+  inspect(arr.get(2), content="Some(3)")
 }
 
 ///|
 test "@array.get/first" {
   let arr = @array.of([42])
-  inspect!(arr.get(0), content="Some(42)")
+  inspect(arr.get(0), content="Some(42)")
 }
 
 ///|
 test "@array.get/out_of_bounds" {
   let arr = @array.of([1, 2, 3])
-  inspect!(arr.get(-1), content="None")
-  inspect!(arr.get(3), content="None")
+  inspect(arr.get(-1), content="None")
+  inspect(arr.get(3), content="None")
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -584,8 +584,8 @@ test "HAMT::union leaf to non-overlapping map" {
 test "HAMT::intersection with empty" {
   let m1 = @hashmap.of([(1, 1)])
   let m2 = @hashmap.new()
-  assert_eq!(m1.intersection(m2).size(), 0)
-  assert_eq!(m2.intersection(m1).size(), 0)
+  assert_eq(m1.intersection(m2).size(), 0)
+  assert_eq(m2.intersection(m1).size(), 0)
 }
 
 ///|
@@ -593,9 +593,9 @@ test "HAMT::intersection with leaf" {
   let m1 = @hashmap.of([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(2, 2)
   let m3 = @hashmap.singleton(3, 3)
-  assert_eq!(m1.intersection(m2).get(2), Some(2))
-  assert_eq!(m1.intersection(m3).get(3), None)
-  assert_eq!(m2.intersection(m1).get(2), Some(2))
+  assert_eq(m1.intersection(m2).get(2), Some(2))
+  assert_eq(m1.intersection(m3).get(3), None)
+  assert_eq(m2.intersection(m1).get(2), Some(2))
 }
 
 ///|
@@ -603,18 +603,18 @@ test "HAMT::intersection with branch" {
   let m1 = @hashmap.of([(1, 1), (2, 2), (3, 3)])
   let m2 = @hashmap.of([(2, 2), (3, 30), (4, 4)])
   let inter = m1.intersection(m2)
-  assert_eq!(inter.get(1), None)
-  assert_eq!(inter.get(2), Some(2))
-  assert_eq!(inter.get(3), Some(3))
-  assert_eq!(inter.get(4), None)
+  assert_eq(inter.get(1), None)
+  assert_eq(inter.get(2), Some(2))
+  assert_eq(inter.get(3), Some(3))
+  assert_eq(inter.get(4), None)
 }
 
 ///|
 test "HAMT::intersection_with with empty" {
   let m1 = @hashmap.of([(1, 1)])
   let m2 = @hashmap.new()
-  assert_eq!(m1.intersection_with(m2, fn(_k, v1, v2) { v1 + v2 }).size(), 0)
-  assert_eq!(m2.intersection_with(m1, fn(_k, v1, v2) { v1 + v2 }).size(), 0)
+  assert_eq(m1.intersection_with(m2, fn(_k, v1, v2) { v1 + v2 }).size(), 0)
+  assert_eq(m2.intersection_with(m1, fn(_k, v1, v2) { v1 + v2 }).size(), 0)
 }
 
 ///|
@@ -622,12 +622,12 @@ test "HAMT::intersection_with with leaf" {
   let m1 = @hashmap.of([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(2, 20)
   let m3 = @hashmap.singleton(3, 30)
-  assert_eq!(
+  assert_eq(
     m1.intersection_with(m2, fn(_k, v1, v2) { v1 + v2 }).get(2),
     Some(22),
   )
-  assert_eq!(m1.intersection_with(m3, fn(_k, v1, v2) { v1 + v2 }).get(3), None)
-  assert_eq!(
+  assert_eq(m1.intersection_with(m3, fn(_k, v1, v2) { v1 + v2 }).get(3), None)
+  assert_eq(
     m2.intersection_with(m1, fn(_k, v1, v2) { v1 + v2 }).get(2),
     Some(22),
   )
@@ -638,18 +638,18 @@ test "HAMT::intersection_with with branch" {
   let m1 = @hashmap.of([(1, 1), (2, 2), (3, 3)])
   let m2 = @hashmap.of([(2, 20), (3, 30), (4, 4)])
   let inter = m1.intersection_with(m2, fn(_k, v1, v2) { v1 * v2 })
-  assert_eq!(inter.get(1), None)
-  assert_eq!(inter.get(2), Some(40))
-  assert_eq!(inter.get(3), Some(90))
-  assert_eq!(inter.get(4), None)
+  assert_eq(inter.get(1), None)
+  assert_eq(inter.get(2), Some(40))
+  assert_eq(inter.get(3), Some(90))
+  assert_eq(inter.get(4), None)
 }
 
 ///|
 test "HAMT::difference with empty" {
   let m1 = @hashmap.of([(1, 1)])
   let m2 = @hashmap.new()
-  assert_eq!(m1.difference(m2), m1)
-  assert_eq!(m2.difference(m1).size(), 0)
+  assert_eq(m1.difference(m2), m1)
+  assert_eq(m2.difference(m1).size(), 0)
 }
 
 ///|
@@ -657,9 +657,9 @@ test "HAMT::difference with leaf" {
   let m1 = @hashmap.of([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(2, 2)
   let m3 = @hashmap.singleton(3, 3)
-  assert_eq!(m1.difference(m2).get(2), None)
-  assert_eq!(m1.difference(m3).get(1), Some(1))
-  assert_eq!(m2.difference(m1).size(), 0)
+  assert_eq(m1.difference(m2).get(2), None)
+  assert_eq(m1.difference(m3).get(1), Some(1))
+  assert_eq(m2.difference(m1).size(), 0)
 }
 
 ///|
@@ -667,10 +667,10 @@ test "HAMT::difference with branch" {
   let m1 = @hashmap.of([(1, 1), (2, 2), (3, 3)])
   let m2 = @hashmap.of([(2, 2), (3, 30), (4, 4)])
   let diff = m1.difference(m2)
-  assert_eq!(diff.get(1), Some(1))
-  assert_eq!(diff.get(2), None)
-  assert_eq!(diff.get(3), None)
-  assert_eq!(diff.get(4), None)
+  assert_eq(diff.get(1), Some(1))
+  assert_eq(diff.get(2), None)
+  assert_eq(diff.get(3), None)
+  assert_eq(diff.get(4), None)
 }
 
 ///|

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -223,7 +223,7 @@ test "@hashset.intersection with overlapping sets" {
   let set1 = @hashset.of([1, 2, 3, 4])
   let set2 = @hashset.of([3, 4, 5, 6])
   let result = set1.intersection(set2)
-  inspect!(result, content="@immut/hashset.of([3, 4])")
+  inspect(result, content="@immut/hashset.of([3, 4])")
 }
 
 ///|
@@ -231,7 +231,7 @@ test "@hashset.intersection with disjoint sets" {
   let set1 = @hashset.of([1, 2])
   let set2 = @hashset.of([3, 4])
   let result = set1.intersection(set2)
-  inspect!(result.is_empty(), content="true")
+  inspect(result.is_empty(), content="true")
 }
 
 ///|
@@ -239,7 +239,7 @@ test "@hashset.intersection with one empty set" {
   let set1 = @hashset.of([1, 2, 3])
   let set2 = @hashset.new()
   let result = set1.intersection(set2)
-  inspect!(result.is_empty(), content="true")
+  inspect(result.is_empty(), content="true")
 }
 
 ///|
@@ -247,7 +247,7 @@ test "@hashset.intersection with identical sets" {
   let set1 = @hashset.of([1, 2, 3])
   let set2 = @hashset.of([1, 2, 3])
   let result = set1.intersection(set2)
-  inspect!(result == set1, content="true")
+  inspect(result == set1, content="true")
 }
 
 ///|
@@ -255,5 +255,5 @@ test "@hashset.intersection with subset" {
   let set1 = @hashset.of([1, 2, 3, 4])
   let set2 = @hashset.of([2, 3])
   let result = set1.intersection(set2)
-  inspect!(result == @hashset.of([2, 3]), content="true")
+  inspect(result == @hashset.of([2, 3]), content="true")
 }

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -58,7 +58,7 @@ pub impl FromJson for Int64 with from_json(json, path) {
       path, "Int64::from_json: expected number in string representation",
     )
   }
-  try @strconv.parse_int64!(str) catch {
+  try @strconv.parse_int64(str) catch {
     error => decode_error(path, "Int64::from_json: parsing failure \{error}")
   }
 }
@@ -78,7 +78,7 @@ pub impl FromJson for UInt64 with from_json(json, path) {
       path, "UInt64::from_json: expected number in string representation",
     )
   }
-  try @strconv.parse_uint64!(str) catch {
+  try @strconv.parse_uint64(str) catch {
     error => decode_error(path, "UInt64::from_json: parsing failure \{error}")
   }
 }

--- a/json/parse.mbt
+++ b/json/parse.mbt
@@ -37,7 +37,7 @@ pub fn parse(input : String) -> JsonValue!ParseError {
 ///|
 fn ParseContext::parse_value(ctx : ParseContext) -> JsonValue!ParseError {
   let tok = ctx.lex_value(allow_rbracket=false)
-  ctx.parse_value2!(tok)
+  ctx.parse_value2(tok)
 }
 
 ///|
@@ -66,7 +66,7 @@ fn ParseContext::parse_object(ctx : ParseContext) -> JsonValue!ParseError {
       ctx.lex_after_property_name()
       map[name] = ctx.parse_value()
       match ctx.lex_after_object_value() {
-        Comma => continue ctx.lex_property_name2!()
+        Comma => continue ctx.lex_property_name2()
         RBrace => Json::object(map)
         _ => abort("unreachable")
       }
@@ -81,7 +81,7 @@ fn ParseContext::parse_array(ctx : ParseContext) -> JsonValue!ParseError {
   loop ctx.lex_value(allow_rbracket=true) {
     RBracket => Json::array(vec)
     tok => {
-      vec.push(ctx.parse_value2!(tok))
+      vec.push(ctx.parse_value2(tok))
       let tok2 = ctx.lex_after_array_value()
       match tok2 {
         Comma => continue ctx.lex_value(allow_rbracket=false)

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -820,8 +820,8 @@ test "list manual grouping implementation" {
   // Check our manual implementation
   inspect(evens, content="@list.of([2, 4, 6, 8])")
   inspect(odds, content="@list.of([1, 3, 5, 7, 9])")
-  assert_eq!(evens.length(), 4)
-  assert_eq!(odds.length(), 5)
+  assert_eq(evens.length(), 4)
+  assert_eq(odds.length(), 5)
 }
 
 ///|
@@ -834,10 +834,10 @@ test "equality" {
   let l5 = @list.of([1, 2, 3, 4])
 
   // Test equality
-  assert_eq!(l1, l2)
-  assert_not_eq!(l1, l3)
-  assert_not_eq!(l1, l4)
-  assert_not_eq!(l1, l5)
+  assert_eq(l1, l2)
+  assert_not_eq(l1, l3)
+  assert_not_eq(l1, l4)
+  assert_not_eq(l1, l5)
 }
 
 ///|
@@ -861,9 +861,9 @@ test "advanced folding operations" {
     init=list.head().unwrap(),
   )
   let product = list.fold(fn(acc, x) { acc * x }, init=1)
-  assert_eq!(sum, 150)
-  assert_eq!(max, 50)
-  assert_eq!(product, 12000000)
+  assert_eq(sum, 150)
+  assert_eq(max, 50)
+  assert_eq(product, 12000000)
 }
 
 ///|
@@ -976,17 +976,17 @@ test "complex list recursion safety" {
   })
 
   // Verify operations on large list work correctly without stack overflow
-  assert_eq!(large.length(), 10000)
-  assert_eq!(large.nth(9999), Some(9999))
-  assert_eq!(large.last(), Some(9999))
+  assert_eq(large.length(), 10000)
+  assert_eq(large.nth(9999), Some(9999))
+  assert_eq(large.last(), Some(9999))
 
   // Test operations that traverse the entire list
   let sum = large.fold(fn(acc, x) { acc + x }, init=0)
-  assert_eq!(sum, 49995000) // Sum of numbers 0 to 9999
+  assert_eq(sum, 49995000) // Sum of numbers 0 to 9999
 
   // Test filter on large list
   let filtered = large.filter(fn(x) { x % 1000 == 0 })
-  assert_eq!(filtered.length(), 10)
+  assert_eq(filtered.length(), 10)
 }
 
 ///|
@@ -994,25 +994,25 @@ test "is_prefix and is_suffix complex cases" {
   let l = @list.of([1, 2, 3, 4, 5])
 
   // Test is_prefix with various scenarios
-  assert_true!(l.is_prefix(@list.of([1])))
-  assert_true!(l.is_prefix(@list.of([1, 2])))
-  assert_true!(l.is_prefix(@list.of([1, 2, 3])))
-  assert_false!(l.is_prefix(@list.of([2, 3])))
-  assert_false!(l.is_prefix(@list.of([0, 1, 2])))
+  assert_true(l.is_prefix(@list.of([1])))
+  assert_true(l.is_prefix(@list.of([1, 2])))
+  assert_true(l.is_prefix(@list.of([1, 2, 3])))
+  assert_false(l.is_prefix(@list.of([2, 3])))
+  assert_false(l.is_prefix(@list.of([0, 1, 2])))
 
   // Test is_suffix with various scenarios
-  assert_true!(l.is_suffix(@list.of([5])))
-  assert_true!(l.is_suffix(@list.of([4, 5])))
-  assert_true!(l.is_suffix(@list.of([3, 4, 5])))
-  assert_false!(l.is_suffix(@list.of([2, 5])))
-  assert_false!(l.is_suffix(@list.of([3, 4, 6])))
+  assert_true(l.is_suffix(@list.of([5])))
+  assert_true(l.is_suffix(@list.of([4, 5])))
+  assert_true(l.is_suffix(@list.of([3, 4, 5])))
+  assert_false(l.is_suffix(@list.of([2, 5])))
+  assert_false(l.is_suffix(@list.of([3, 4, 6])))
 
   // Test with empty list
   let empty : @list.T[Int] = @list.empty()
-  assert_true!(empty.is_prefix(@list.of([])))
-  assert_true!(empty.is_suffix(@list.of([])))
-  assert_true!(l.is_prefix(@list.of([])))
-  assert_true!(l.is_suffix(@list.of([])))
+  assert_true(empty.is_prefix(@list.of([])))
+  assert_true(empty.is_suffix(@list.of([])))
+  assert_true(l.is_prefix(@list.of([])))
+  assert_true(l.is_suffix(@list.of([])))
 }
 
 ///|

--- a/math/pow_test.mbt
+++ b/math/pow_test.mbt
@@ -152,14 +152,14 @@ test "pow with standard functions" {
   let x_flt : Float = 2.0
   let expected_exp_flt : Float = 7.3890562
   let actual_pow_flt = powf(e_flt, x_flt)
-  assert_true!((actual_pow_flt - expected_exp_flt).abs() < 0.01)
+  assert_true((actual_pow_flt - expected_exp_flt).abs() < 0.01)
 
   // Test sqrt(x) vs. pow(x, 0.5)
   let values_flt : Array[Float] = [4.0, 9.0, 16.0, 25.0]
   for value in values_flt {
     let expected_sqrt_flt = value.sqrt()
     let actual_pow_flt = powf(value, 0.5)
-    assert_true!((actual_pow_flt - expected_sqrt_flt).abs() < 0.01)
+    assert_true((actual_pow_flt - expected_sqrt_flt).abs() < 0.01)
   }
 
   // Test pow(x, y) * pow(x, z) = pow(x, y + z)
@@ -168,12 +168,12 @@ test "pow with standard functions" {
   let z_test_flt : Float = 4.0
   let left_val_flt = powf(x_test_flt, y_test_flt) * powf(x_test_flt, z_test_flt)
   let right_val_flt = powf(x_test_flt, y_test_flt + z_test_flt)
-  assert_true!((left_val_flt - right_val_flt).abs() < 0.01)
+  assert_true((left_val_flt - right_val_flt).abs() < 0.01)
 
   // Test pow(x, y)^z = pow(x, y*z)
   let left_test_flt = powf(powf(x_test_flt, y_test_flt), z_test_flt)
   let right_test_flt = powf(x_test_flt, y_test_flt * z_test_flt)
-  assert_true!((left_test_flt - right_test_flt).abs() < 0.01)
+  assert_true((left_test_flt - right_test_flt).abs() < 0.01)
 }
 
 ///|

--- a/math/trigonometric_test.mbt
+++ b/math/trigonometric_test.mbt
@@ -294,7 +294,7 @@ test "tanf function comprehensive" {
   let pi_2 = pi / 2.0
   let close_to_singularity = pi_2 - 0.01
   let result = @math.tanf(close_to_singularity)
-  assert_true!(result > 0.0)
+  assert_true(result > 0.0)
 
   // Testing extreme values
   assert_true(@math.tanf(10.0).is_close(0.6483607888221741))

--- a/strconv/additional_coverage_test.mbt
+++ b/strconv/additional_coverage_test.mbt
@@ -15,13 +15,13 @@
 ///|
 test "parse_uint64 overflow check" {
   let largest_uint64 = "18446744073709551615" // Maximum UInt64 value
-  let result = @strconv.parse_uint64!(largest_uint64)
+  let result = @strconv.parse_uint64(largest_uint64)
   inspect(result, content="18446744073709551615")
 
   // Test overflow with very large value
   try {
     let overflow_val = "18446744073709551616" // One more than max UInt64
-    let _ = @strconv.parse_uint64!(overflow_val)
+    let _ = @strconv.parse_uint64(overflow_val)
     fail("Expected range error for overflow value")
   } catch {
     @strconv.StrConvError(err) => assert_eq(err, "value out of range")
@@ -31,7 +31,7 @@ test "parse_uint64 overflow check" {
   // Test overflow with large base 16 value
   try {
     let overflow_hex = "ffffffffffffffff1" // Larger than max UInt64 in hex
-    let _ = @strconv.parse_uint64!(overflow_hex, base=16)
+    let _ = @strconv.parse_uint64(overflow_hex, base=16)
     fail("Expected range error for overflow hex value")
   } catch {
     @strconv.StrConvError(err) => assert_eq(err, "value out of range")

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -53,9 +53,9 @@ fn check_and_consume_base(
 
 ///|
 test {
-  inspect(parse_int64?("0b01", base=3), content="Err(invalid syntax)")
-  inspect(parse_int64?("0x01", base=3), content="Err(invalid syntax)")
-  inspect(parse_int64?("0o01", base=3), content="Err(invalid syntax)")
+  inspect(try? parse_int64("0b01", base=3), content="Err(invalid syntax)")
+  inspect(try? parse_int64("0x01", base=3), content="Err(invalid syntax)")
+  inspect(try? parse_int64("0o01", base=3), content="Err(invalid syntax)")
 }
 
 ///|
@@ -133,7 +133,7 @@ pub fn parse_int64(str : String, base~ : Int = 0) -> Int64!StrConvError {
 /// Parse a string in the given base (0, 2 to 36), return a Int number or an error.
 /// If the `~base` argument is 0, the base will be inferred by the prefix.
 pub fn parse_int(str : String, base~ : Int = 0) -> Int!StrConvError {
-  let n = parse_int64!(str, base~)
+  let n = parse_int64(str, base~)
   if n < INT_MIN.to_int64() || n > INT_MAX.to_int64() {
     range_err()
   }
@@ -279,7 +279,7 @@ test "parse_int64" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_int64!(t.0)) catch {
+      try Result::Ok(parse_int64(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,
@@ -397,7 +397,7 @@ test "parse_int64_base" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_int64!(t.0, base=t.1)) catch {
+      try Result::Ok(parse_int64(t.0, base=t.1)) catch {
         StrConvError(err) => Err(err)
       },
       t.2,

--- a/strconv/int_test.mbt
+++ b/strconv/int_test.mbt
@@ -20,7 +20,7 @@ let base_err = "invalid base"
 
 ///|
 fn parse_as_result(s : String, base~ : Int) -> Result[Int64, String] {
-  try @strconv.parse_int64!(s, base~) |> Ok catch {
+  try @strconv.parse_int64(s, base~) |> Ok catch {
     StrConvError(err) => Err(err)
   }
 }
@@ -57,69 +57,69 @@ test "parse_int64_uncovered_lines" {
 ///|
 test "@strconv.parse_int64/base_parsing" {
   // Test different bases
-  inspect(@strconv.parse_int64!("1010", base=2), content="10")
-  inspect(@strconv.parse_int64!("777", base=8), content="511")
-  inspect(@strconv.parse_int64!("ff", base=16), content="255")
+  inspect(@strconv.parse_int64("1010", base=2), content="10")
+  inspect(@strconv.parse_int64("777", base=8), content="511")
+  inspect(@strconv.parse_int64("ff", base=16), content="255")
   // Test auto-detection of base
-  inspect(@strconv.parse_int64!("0xFF"), content="255")
-  inspect(@strconv.parse_int64!("0b1010"), content="10")
-  inspect(@strconv.parse_int64!("0o777"), content="511")
+  inspect(@strconv.parse_int64("0xFF"), content="255")
+  inspect(@strconv.parse_int64("0b1010"), content="10")
+  inspect(@strconv.parse_int64("0o777"), content="511")
 }
 
 ///|
 test "panic @strconv.parse_int64/invalid_input" {
   // Empty string
-  ignore(@strconv.parse_int64!(""))
+  ignore(@strconv.parse_int64(""))
   // Invalid characters for given base
-  ignore(@strconv.parse_int64!("2", base=2))
+  ignore(@strconv.parse_int64("2", base=2))
   // Invalid base
-  ignore(@strconv.parse_int64!("123", base=37))
+  ignore(@strconv.parse_int64("123", base=37))
 }
 
 ///|
 test "@strconv.parse_int64/boundary_values" {
   // Test minimum and maximum values
   inspect(
-    @strconv.parse_int64!("-9223372036854775808"),
+    @strconv.parse_int64("-9223372036854775808"),
     content="-9223372036854775808",
   )
   inspect(
-    @strconv.parse_int64!("9223372036854775807"),
+    @strconv.parse_int64("9223372036854775807"),
     content="9223372036854775807",
   )
   // Test with underscores
   inspect(
-    @strconv.parse_int64!("922_3372_0368_5477_5807"),
+    @strconv.parse_int64("922_3372_0368_5477_5807"),
     content="9223372036854775807",
   )
   // Test with different sign prefixes
-  inspect(@strconv.parse_int64!("+42"), content="42")
-  inspect(@strconv.parse_int64!("-42"), content="-42")
+  inspect(@strconv.parse_int64("+42"), content="42")
+  inspect(@strconv.parse_int64("-42"), content="-42")
 }
 
 ///|
 test "@moonbitlang/core/strconv.parse_int64/base10" {
-  inspect(@moonbitlang/core/strconv.parse_int64!("12345"), content="12345")
-  inspect(@moonbitlang/core/strconv.parse_int64!("-12345"), content="-12345")
-  inspect(@moonbitlang/core/strconv.parse_int64!("0"), content="0")
-  inspect(@moonbitlang/core/strconv.parse_int64!("-0"), content="0")
+  inspect(@moonbitlang/core/strconv.parse_int64("12345"), content="12345")
+  inspect(@moonbitlang/core/strconv.parse_int64("-12345"), content="-12345")
+  inspect(@moonbitlang/core/strconv.parse_int64("0"), content="0")
+  inspect(@moonbitlang/core/strconv.parse_int64("-0"), content="0")
 }
 
 ///|
 test "@moonbitlang/core/strconv.parse_int64/boundary_cases" {
   inspect(
-    @moonbitlang/core/strconv.parse_int64!("9223372036854775807"),
+    @moonbitlang/core/strconv.parse_int64("9223372036854775807"),
     content="9223372036854775807",
   )
   inspect(
-    @moonbitlang/core/strconv.parse_int64!("-9223372036854775808"),
+    @moonbitlang/core/strconv.parse_int64("-9223372036854775808"),
     content="-9223372036854775808",
   )
 }
 
 ///|
 test "panic @moonbitlang/core/strconv.parse_int64/invalid_base" {
-  ignore(@moonbitlang/core/strconv.parse_int64!("12345x"))
+  ignore(@moonbitlang/core/strconv.parse_int64("12345x"))
 }
 
 ///|

--- a/strconv/traits.mbt
+++ b/strconv/traits.mbt
@@ -35,7 +35,7 @@ pub impl FromStr for Int with from_string(str) {
 
 ///|
 pub impl FromStr for Int64 with from_string(str) {
-  parse_int64!(str)
+  parse_int64(str)
 }
 
 ///|
@@ -45,7 +45,7 @@ pub impl FromStr for UInt with from_string(str) {
 
 ///|
 pub impl FromStr for UInt64 with from_string(str) {
-  parse_uint64!(str)
+  parse_uint64(str)
 }
 
 ///|

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -86,7 +86,7 @@ pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
 /// Parse a string in the given base (0, 2 to 36), return an UInt number or an error.
 /// If the `~base` argument is 0, the base will be inferred by the prefix.
 pub fn parse_uint(str : String, base~ : Int = 0) -> UInt!StrConvError {
-  let n = parse_uint64!(str, base~)
+  let n = parse_uint64(str, base~)
   if n > UINT_MAX.to_uint64() {
     range_err()
   }
@@ -117,7 +117,7 @@ test "parse_uint64" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_uint64!(t.0)) catch {
+      try Result::Ok(parse_uint64(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,
@@ -215,7 +215,7 @@ test "parse_uint64_base" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_uint64!(t.0, base=t.1)) catch {
+      try Result::Ok(parse_uint64(t.0, base=t.1)) catch {
         StrConvError(err) => Err(err)
       },
       t.2,
@@ -260,6 +260,6 @@ test "parse_uint" {
 
 ///|
 test "parse_uint64 uppercase hex and invalid base" {
-  inspect(parse_uint64?("ABCD", base=16), content="Ok(43981)")
-  inspect(parse_uint64?("1234", base=37), content="Err(invalid base)")
+  inspect(try? parse_uint64("ABCD", base=16), content="Ok(43981)")
+  inspect(try? parse_uint64("1234", base=37), content="Err(invalid base)")
 }

--- a/strconv/uint_test.mbt
+++ b/strconv/uint_test.mbt
@@ -15,80 +15,89 @@
 ///|
 test "@strconv.parse_uint64/base_handling" {
   // Different bases with valid input
-  inspect(@strconv.parse_uint64?("FF", base=16), content="Ok(255)")
-  inspect(@strconv.parse_uint64?("0xFF"), content="Ok(255)")
-  inspect(@strconv.parse_uint64?("377", base=8), content="Ok(255)")
-  inspect(@strconv.parse_uint64?("0o377"), content="Ok(255)")
-  inspect(@strconv.parse_uint64?("11111111", base=2), content="Ok(255)")
-  inspect(@strconv.parse_uint64?("0b11111111"), content="Ok(255)")
+  inspect(try? @strconv.parse_uint64("FF", base=16), content="Ok(255)")
+  inspect(try? @strconv.parse_uint64("0xFF"), content="Ok(255)")
+  inspect(try? @strconv.parse_uint64("377", base=8), content="Ok(255)")
+  inspect(try? @strconv.parse_uint64("0o377"), content="Ok(255)")
+  inspect(try? @strconv.parse_uint64("11111111", base=2), content="Ok(255)")
+  inspect(try? @strconv.parse_uint64("0b11111111"), content="Ok(255)")
 }
 
 ///|
 test "@strconv.parse_uint64/underscore" {
   // Valid underscore placements
-  inspect(@strconv.parse_uint64?("1_000_000"), content="Ok(1000000)")
-  inspect(@strconv.parse_uint64?("0xff_ff_ff"), content="Ok(16777215)")
+  inspect(try? @strconv.parse_uint64("1_000_000"), content="Ok(1000000)")
+  inspect(try? @strconv.parse_uint64("0xff_ff_ff"), content="Ok(16777215)")
   // Invalid underscore placements
-  inspect(@strconv.parse_uint64?("_123"), content="Err(invalid syntax)")
-  inspect(@strconv.parse_uint64?("123_"), content="Err(invalid syntax)")
-  inspect(@strconv.parse_uint64?("1__23"), content="Err(invalid syntax)")
+  inspect(try? @strconv.parse_uint64("_123"), content="Err(invalid syntax)")
+  inspect(try? @strconv.parse_uint64("123_"), content="Err(invalid syntax)")
+  inspect(try? @strconv.parse_uint64("1__23"), content="Err(invalid syntax)")
 }
 
 ///|
 test "panic @strconv.parse_uint64/errors" {
   // Empty string
-  ignore(@strconv.parse_uint64!(""))
+  ignore(@strconv.parse_uint64(""))
   // Invalid base
-  ignore(@strconv.parse_uint64!("123", base=37))
+  ignore(@strconv.parse_uint64("123", base=37))
   // Signs not allowed
-  ignore(@strconv.parse_uint64!("+123"))
-  ignore(@strconv.parse_uint64!("-123"))
+  ignore(@strconv.parse_uint64("+123"))
+  ignore(@strconv.parse_uint64("-123"))
   // Range error (overflow)
-  ignore(@strconv.parse_uint64!("18446744073709551616"))
+  ignore(@strconv.parse_uint64("18446744073709551616"))
 }
 
 ///|
 test "@strconv.parse_uint64/hex_and_edge_cases" {
   // Valid hexadecimal numbers with 0x/0X prefix
-  inspect(@strconv.parse_uint64?("0xDEADBEEF"), content="Ok(3735928559)")
-  inspect(@strconv.parse_uint64?("0XDEADBEEF"), content="Ok(3735928559)")
+  inspect(try? @strconv.parse_uint64("0xDEADBEEF"), content="Ok(3735928559)")
+  inspect(try? @strconv.parse_uint64("0XDEADBEEF"), content="Ok(3735928559)")
 
   // Valid hexadecimal numbers without prefix when base=16 is specified
-  inspect(@strconv.parse_uint64?("deadbeef", base=16), content="Ok(3735928559)")
-
-  // Valid hexadecimal numbers with allowed underscore placements
-  inspect(@strconv.parse_uint64?("0xDEAD_BEEF"), content="Ok(3735928559)")
   inspect(
-    @strconv.parse_uint64?("dead_beef", base=16),
+    try? @strconv.parse_uint64("deadbeef", base=16),
     content="Ok(3735928559)",
   )
-  inspect(@strconv.parse_uint64?("0x1_2345"), content="Ok(74565)")
+
+  // Valid hexadecimal numbers with allowed underscore placements
+  inspect(try? @strconv.parse_uint64("0xDEAD_BEEF"), content="Ok(3735928559)")
+  inspect(
+    try? @strconv.parse_uint64("dead_beef", base=16),
+    content="Ok(3735928559)",
+  )
+  inspect(try? @strconv.parse_uint64("0x1_2345"), content="Ok(74565)")
 
   // Edge case: zero value
-  inspect(@strconv.parse_uint64?("0x0"), content="Ok(0)")
-  inspect(@strconv.parse_uint64?("0x00"), content="Ok(0)")
+  inspect(try? @strconv.parse_uint64("0x0"), content="Ok(0)")
+  inspect(try? @strconv.parse_uint64("0x00"), content="Ok(0)")
 
   // Edge case: maximum valid uint64 value (all bits set)
   inspect(
-    @strconv.parse_uint64?("0xFFFFFFFFFFFFFFFF"),
+    try? @strconv.parse_uint64("0xFFFFFFFFFFFFFFFF"),
     content="Ok(18446744073709551615)",
   )
-  inspect(@strconv.parse_uint64?("0xDEADBEEF_"), content="Err(invalid syntax)")
   inspect(
-    @strconv.parse_uint64?("0xDE__AD_BEEF"),
+    try? @strconv.parse_uint64("0xDEADBEEF_"),
+    content="Err(invalid syntax)",
+  )
+  inspect(
+    try? @strconv.parse_uint64("0xDE__AD_BEEF"),
     content="Err(invalid syntax)",
   )
 
   // Invalid hex digit (G is not a valid base-16 digit)
-  inspect(@strconv.parse_uint64?("0xDEADBEG"), content="Err(invalid syntax)")
+  inspect(
+    try? @strconv.parse_uint64("0xDEADBEG"),
+    content="Err(invalid syntax)",
+  )
 }
 
 ///|
 test "edge cases" {
   // Invalid: Missing digits after hex prefix
-  inspect(@strconv.parse_uint64?("0x"), content="Err(invalid syntax)")
-  inspect(@strconv.parse_uint64?("0x_"), content="Err(invalid syntax)")
+  inspect(try? @strconv.parse_uint64("0x"), content="Err(invalid syntax)")
+  inspect(try? @strconv.parse_uint64("0x_"), content="Err(invalid syntax)")
 
   // Underscore is allowed between the prefix and the first digit
-  inspect(@strconv.parse_uint64?("0x_DEADBEEF"), content="Ok(3735928559)")
+  inspect(try? @strconv.parse_uint64("0x_DEADBEEF"), content="Ok(3735928559)")
 }

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -69,14 +69,14 @@ test "stringview rev_get" {
 test "stringview data" {
   let str = "Hello🤣🤣🤣"
   let view = str.view(start_offset=1, end_offset=7)
-  inspect!(view.data(), content="Hello🤣🤣🤣")
+  inspect(view.data(), content="Hello🤣🤣🤣")
 }
 
 ///|
 test "stringview start_offset" {
   let str = "Hello🤣🤣🤣"
   let view = str.view(start_offset=1, end_offset=7)
-  inspect!(view.start_offset(), content="1")
+  inspect(view.start_offset(), content="1")
 }
 
 ///|

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -114,7 +114,7 @@ pub fn[T : Show] is_not(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 ///  
 /// Produces an error message similar to @builtin.fail.
 pub fn[T] fail(msg : String, loc~ : SourceLoc = _) -> T! {
-  @builtin.fail!(msg, loc~)
+  @builtin.fail(msg, loc~)
 }
 
 ///|


### PR DESCRIPTION
We plan to deprecate `f!(..)` and `f?(..)` shortly:

- `!` can now be omitted when calling function with side effect, and the MoonBit LSP server will render these functions as underlined/italic via semantic highlighting. So `!` is no longer necessary
- `f?(..)` can be replaced by `try?`, which is a more general construct

This PR removes usage of `f!(..)` and `f?(..)` in core