### PR TITLE
Add Error Polymorphism to High-Order Functions in `@immut` Modules

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -175,15 +175,15 @@ fn[A : Eq] Iter::contains(Self[A], A) -> Bool
 fn[T] Iter::count(Self[T]) -> Int
 fn[T] Iter::drop(Self[T], Int) -> Self[T]
 fn[T] Iter::drop_while(Self[T], (T) -> Bool) -> Self[T]
-fn[T] Iter::each(Self[T], (T) -> Unit?Error) -> Unit?Error
-fn[T] Iter::eachi(Self[T], (Int, T) -> Unit?Error) -> Unit?Error
+fn[T] Iter::each(Self[T], (T) -> Unit raise?) -> Unit raise?
+fn[T] Iter::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 fn[T] Iter::empty() -> Self[T]
 fn[T] Iter::filter(Self[T], (T) -> Bool) -> Self[T]
 fn[A, B] Iter::filter_map(Self[A], (A) -> B?) -> Self[B]
 fn[T] Iter::find_first(Self[T], (T) -> Bool) -> T?
 fn[T, R] Iter::flat_map(Self[T], (T) -> Self[R]) -> Self[R]
 fn[T] Iter::flatten(Self[Self[T]]) -> Self[T]
-fn[T, B] Iter::fold(Self[T], init~ : B, (B, T) -> B?Error) -> B?Error
+fn[T, B] Iter::fold(Self[T], init~ : B, (B, T) -> B raise?) -> B raise?
 #deprecated
 fn[T, K : Eq + Hash] Iter::group_by(Self[T], (T) -> K) -> Map[K, Array[T]]
 fn[A] Iter::head(Self[A]) -> A?

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -175,15 +175,15 @@ fn[A : Eq] Iter::contains(Self[A], A) -> Bool
 fn[T] Iter::count(Self[T]) -> Int
 fn[T] Iter::drop(Self[T], Int) -> Self[T]
 fn[T] Iter::drop_while(Self[T], (T) -> Bool) -> Self[T]
-fn[T] Iter::each(Self[T], (T) -> Unit) -> Unit
-fn[T] Iter::eachi(Self[T], (Int, T) -> Unit) -> Unit
+fn[T] Iter::each(Self[T], (T) -> Unit?Error) -> Unit?Error
+fn[T] Iter::eachi(Self[T], (Int, T) -> Unit?Error) -> Unit?Error
 fn[T] Iter::empty() -> Self[T]
 fn[T] Iter::filter(Self[T], (T) -> Bool) -> Self[T]
 fn[A, B] Iter::filter_map(Self[A], (A) -> B?) -> Self[B]
 fn[T] Iter::find_first(Self[T], (T) -> Bool) -> T?
 fn[T, R] Iter::flat_map(Self[T], (T) -> Self[R]) -> Self[R]
 fn[T] Iter::flatten(Self[Self[T]]) -> Self[T]
-fn[T, B] Iter::fold(Self[T], init~ : B, (B, T) -> B) -> B
+fn[T, B] Iter::fold(Self[T], init~ : B, (B, T) -> B?Error) -> B?Error
 #deprecated
 fn[T, K : Eq + Hash] Iter::group_by(Self[T], (T) -> K) -> Map[K, Array[T]]
 fn[A] Iter::head(Self[A]) -> A?

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -53,7 +53,7 @@ pub impl[T : Show] Show for Iter[T] with output(self, logger) {
 /// - `f`: A function that takes an element of type `T` and returns `Unit`. This function is applied to each element of the iterator.
 /// TODO: change the intrinsic to match the function name
 #intrinsic("%iter.iter")
-pub fn[T] Iter::each(self : Iter[T], f : (T) -> Unit) -> Unit {
+pub fn[T] Iter::each(self : Iter[T], f : (T) -> Unit?Error) -> Unit?Error {
   for a in self {
     f(a)
   }
@@ -82,7 +82,7 @@ pub fn[T] Iter::all(self : Iter[T], f : (T) -> Bool) -> Bool {
 /// - `self`: The iterator to consume.
 /// - `f`: A function that takes an index of type `Int` and an element of type `T` and returns `Unit`. This function is applied to each element of the iterator.
 /// TODO: Add intrinsic
-pub fn[T] Iter::eachi(self : Iter[T], f : (Int, T) -> Unit) -> Unit {
+pub fn[T] Iter::eachi(self : Iter[T], f : (Int, T) -> Unit?Error) -> Unit?Error {
   let mut i = 0
   for a in self {
     f(i, a)
@@ -109,7 +109,11 @@ pub fn[T] Iter::eachi(self : Iter[T], f : (Int, T) -> Unit) -> Unit {
 /// Returns the final accumulator value after folding all elements of the iterator.
 #intrinsic("%iter.reduce")
 #locals(f)
-pub fn[T, B] Iter::fold(self : Iter[T], init~ : B, f : (B, T) -> B) -> B {
+pub fn[T, B] Iter::fold(
+  self : Iter[T],
+  init~ : B,
+  f : (B, T) -> B?Error
+) -> B?Error {
   let mut acc = init
   for a in self {
     acc = f(acc, a)

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -53,7 +53,7 @@ pub impl[T : Show] Show for Iter[T] with output(self, logger) {
 /// - `f`: A function that takes an element of type `T` and returns `Unit`. This function is applied to each element of the iterator.
 /// TODO: change the intrinsic to match the function name
 #intrinsic("%iter.iter")
-pub fn[T] Iter::each(self : Iter[T], f : (T) -> Unit?Error) -> Unit?Error {
+pub fn[T] Iter::each(self : Iter[T], f : (T) -> Unit raise?) -> Unit raise? {
   for a in self {
     f(a)
   }
@@ -82,7 +82,10 @@ pub fn[T] Iter::all(self : Iter[T], f : (T) -> Bool) -> Bool {
 /// - `self`: The iterator to consume.
 /// - `f`: A function that takes an index of type `Int` and an element of type `T` and returns `Unit`. This function is applied to each element of the iterator.
 /// TODO: Add intrinsic
-pub fn[T] Iter::eachi(self : Iter[T], f : (Int, T) -> Unit?Error) -> Unit?Error {
+pub fn[T] Iter::eachi(
+  self : Iter[T],
+  f : (Int, T) -> Unit raise?
+) -> Unit raise? {
   let mut i = 0
   for a in self {
     f(i, a)
@@ -112,8 +115,8 @@ pub fn[T] Iter::eachi(self : Iter[T], f : (Int, T) -> Unit?Error) -> Unit?Error 
 pub fn[T, B] Iter::fold(
   self : Iter[T],
   init~ : B,
-  f : (B, T) -> B?Error
-) -> B?Error {
+  f : (B, T) -> B raise?
+) -> B raise? {
   let mut acc = init
   for a in self {
     acc = f(acc, a)

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -52,7 +52,6 @@ pub impl[T : Show] Show for Iter[T] with output(self, logger) {
 /// - `self`: The iterator to consume.
 /// - `f`: A function that takes an element of type `T` and returns `Unit`. This function is applied to each element of the iterator.
 /// TODO: change the intrinsic to match the function name
-#intrinsic("%iter.iter")
 pub fn[T] Iter::each(self : Iter[T], f : (T) -> Unit raise?) -> Unit raise? {
   for a in self {
     f(a)

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -45,7 +45,7 @@ pub fn[A] make(len : Int, value : A) -> T[A] {
 
 ///|
 /// Create a persistent array with a given length and a function to generate values.
-pub fn[A] makei(len : Int, f : (Int) -> A) -> T[A] {
+pub fn[A] makei(len : Int, f : (Int) -> A?Error) -> T[A]?Error {
   let quot = len / branching_factor
   let rem = len % branching_factor
   let leaves = if rem == 0 {
@@ -310,7 +310,7 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
+pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
   self.tree.each(f)
 }
 
@@ -326,7 +326,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
 ///   assert_eq(arr, [0, 2, 6, 12, 20])
 /// }
 /// ```
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit?Error) -> Unit?Error {
   self.tree.eachi(f, self.shift, 0)
 }
 
@@ -340,7 +340,7 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 ///   assert_eq(v.fold(fn(a, b) { a + b }, init=0), 15)
 /// }
 /// ```
-pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
+pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
   self.tree.fold(init, f)
 }
 
@@ -354,7 +354,7 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 ///   assert_eq(v.rev_fold(fn(a, b) { a + b }, init=0), 15)
 /// }
 /// ```
-pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
+pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
   self.tree.rev_fold(init, f)
 }
 
@@ -370,7 +370,7 @@ pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 /// ```
 #deprecated("Use `fold` instead")
 #coverage.skip
-pub fn[A] fold_left(self : T[A], f : (A, A) -> A, init~ : A) -> A {
+pub fn[A] fold_left(self : T[A], f : (A, A) -> A?Error, init~ : A) -> A?Error {
   self.fold(init~, f)
 }
 
@@ -386,7 +386,7 @@ pub fn[A] fold_left(self : T[A], f : (A, A) -> A, init~ : A) -> A {
 /// ```
 #deprecated("Use `rev_fold` instead")
 #coverage.skip
-pub fn[A] fold_right(self : T[A], f : (A, A) -> A, init~ : A) -> A {
+pub fn[A] fold_right(self : T[A], f : (A, A) -> A?Error, init~ : A) -> A?Error {
   self.rev_fold(init~, f)
 }
 
@@ -400,7 +400,7 @@ pub fn[A] fold_right(self : T[A], f : (A, A) -> A, init~ : A) -> A {
 ///   assert_eq(v.map(fn(e) { e * 2 }), @array.of([2, 4, 6, 8, 10]))
 /// }
 /// ```
-pub fn[A, B] map(self : T[A], f : (A) -> B) -> T[B] {
+pub fn[A, B] map(self : T[A], f : (A) -> B?Error) -> T[B]?Error {
   { tree: self.tree.map(f), size: self.size, shift: self.shift }
 }
 

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -45,7 +45,7 @@ pub fn[A] make(len : Int, value : A) -> T[A] {
 
 ///|
 /// Create a persistent array with a given length and a function to generate values.
-pub fn[A] makei(len : Int, f : (Int) -> A?Error) -> T[A]?Error {
+pub fn[A] makei(len : Int, f : (Int) -> A raise?) -> T[A] raise? {
   let quot = len / branching_factor
   let rem = len % branching_factor
   let leaves = if rem == 0 {
@@ -310,7 +310,7 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
+pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
   self.tree.each(f)
 }
 
@@ -326,7 +326,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
 ///   assert_eq(arr, [0, 2, 6, 12, 20])
 /// }
 /// ```
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit?Error) -> Unit?Error {
+pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
   self.tree.eachi(f, self.shift, 0)
 }
 
@@ -340,7 +340,7 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit?Error) -> Unit?Error {
 ///   assert_eq(v.fold(fn(a, b) { a + b }, init=0), 15)
 /// }
 /// ```
-pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
+pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B raise?) -> B raise? {
   self.tree.fold(init, f)
 }
 
@@ -354,7 +354,11 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
 ///   assert_eq(v.rev_fold(fn(a, b) { a + b }, init=0), 15)
 /// }
 /// ```
-pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
+pub fn[A, B] rev_fold(
+  self : T[A],
+  init~ : B,
+  f : (B, A) -> B raise?
+) -> B raise? {
   self.tree.rev_fold(init, f)
 }
 
@@ -370,7 +374,7 @@ pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error 
 /// ```
 #deprecated("Use `fold` instead")
 #coverage.skip
-pub fn[A] fold_left(self : T[A], f : (A, A) -> A?Error, init~ : A) -> A?Error {
+pub fn[A] fold_left(self : T[A], f : (A, A) -> A raise?, init~ : A) -> A raise? {
   self.fold(init~, f)
 }
 
@@ -386,7 +390,11 @@ pub fn[A] fold_left(self : T[A], f : (A, A) -> A?Error, init~ : A) -> A?Error {
 /// ```
 #deprecated("Use `rev_fold` instead")
 #coverage.skip
-pub fn[A] fold_right(self : T[A], f : (A, A) -> A?Error, init~ : A) -> A?Error {
+pub fn[A] fold_right(
+  self : T[A],
+  f : (A, A) -> A raise?,
+  init~ : A
+) -> A raise? {
   self.rev_fold(init~, f)
 }
 
@@ -400,7 +408,7 @@ pub fn[A] fold_right(self : T[A], f : (A, A) -> A?Error, init~ : A) -> A?Error {
 ///   assert_eq(v.map(fn(e) { e * 2 }), @array.of([2, 4, 6, 8, 10]))
 /// }
 /// ```
-pub fn[A, B] map(self : T[A], f : (A) -> B?Error) -> T[B]?Error {
+pub fn[A, B] map(self : T[A], f : (A) -> B raise?) -> T[B] raise? {
   { tree: self.tree.map(f), size: self.size, shift: self.shift }
 }
 

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -10,17 +10,17 @@ fn[A] concat(T[A], T[A]) -> T[A]
 #deprecated
 fn[A] copy(T[A]) -> T[A]
 
-fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
+fn[A] each(T[A], (A) -> Unit raise?) -> Unit raise?
 
-fn[A] eachi(T[A], (Int, A) -> Unit?Error) -> Unit?Error
+fn[A] eachi(T[A], (Int, A) -> Unit raise?) -> Unit raise?
 
-fn[A, B] fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
-
-#deprecated
-fn[A] fold_left(T[A], (A, A) -> A?Error, init~ : A) -> A?Error
+fn[A, B] fold(T[A], init~ : B, (B, A) -> B raise?) -> B raise?
 
 #deprecated
-fn[A] fold_right(T[A], (A, A) -> A?Error, init~ : A) -> A?Error
+fn[A] fold_left(T[A], (A, A) -> A raise?, init~ : A) -> A raise?
+
+#deprecated
+fn[A] fold_right(T[A], (A, A) -> A raise?, init~ : A) -> A raise?
 
 fn[A] from_array(Array[A]) -> T[A]
 
@@ -36,9 +36,9 @@ fn[A] length(T[A]) -> Int
 
 fn[A] make(Int, A) -> T[A]
 
-fn[A] makei(Int, (Int) -> A?Error) -> T[A]?Error
+fn[A] makei(Int, (Int) -> A raise?) -> T[A] raise?
 
-fn[A, B] map(T[A], (A) -> B?Error) -> T[B]?Error
+fn[A, B] map(T[A], (A) -> B raise?) -> T[B] raise?
 
 fn[A] new() -> T[A]
 
@@ -48,7 +48,7 @@ fn[A] op_get(T[A], Int) -> A
 
 fn[A] push(T[A], A) -> T[A]
 
-fn[A, B] rev_fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A, B] rev_fold(T[A], init~ : B, (B, A) -> B raise?) -> B raise?
 
 fn[A] set(T[A], Int, A) -> T[A]
 
@@ -59,13 +59,13 @@ type T[A]
 fn[A] T::concat(Self[A], Self[A]) -> Self[A]
 #deprecated
 fn[A] T::copy(Self[A]) -> Self[A]
-fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
-fn[A] T::eachi(Self[A], (Int, A) -> Unit?Error) -> Unit?Error
-fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A] T::each(Self[A], (A) -> Unit raise?) -> Unit raise?
+fn[A] T::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
+fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 #deprecated
-fn[A] T::fold_left(Self[A], (A, A) -> A?Error, init~ : A) -> A?Error
+fn[A] T::fold_left(Self[A], (A, A) -> A raise?, init~ : A) -> A raise?
 #deprecated
-fn[A] T::fold_right(Self[A], (A, A) -> A?Error, init~ : A) -> A?Error
+fn[A] T::fold_right(Self[A], (A, A) -> A raise?, init~ : A) -> A raise?
 #deprecated
 fn[A] T::from_array(Array[A]) -> Self[A]
 #deprecated
@@ -78,14 +78,14 @@ fn[A] T::length(Self[A]) -> Int
 fn[A] T::make(Int, A) -> Self[A]
 #deprecated
 fn[A] T::makei(Int, (Int) -> A) -> Self[A]
-fn[A, B] T::map(Self[A], (A) -> B?Error) -> Self[B]?Error
+fn[A, B] T::map(Self[A], (A) -> B raise?) -> Self[B] raise?
 #deprecated
 fn[A] T::new() -> Self[A]
 #deprecated
 fn[A] T::of(FixedArray[A]) -> Self[A]
 fn[A] T::op_get(Self[A], Int) -> A
 fn[A] T::push(Self[A], A) -> Self[A]
-fn[A, B] T::rev_fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A, B] T::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 fn[A] T::set(Self[A], Int, A) -> Self[A]
 fn[A] T::to_array(Self[A]) -> Array[A]
 impl[A] Add for T[A]

--- a/immut/array/array.mbti
+++ b/immut/array/array.mbti
@@ -10,17 +10,17 @@ fn[A] concat(T[A], T[A]) -> T[A]
 #deprecated
 fn[A] copy(T[A]) -> T[A]
 
-fn[A] each(T[A], (A) -> Unit) -> Unit
+fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
 
-fn[A] eachi(T[A], (Int, A) -> Unit) -> Unit
+fn[A] eachi(T[A], (Int, A) -> Unit?Error) -> Unit?Error
 
-fn[A, B] fold(T[A], init~ : B, (B, A) -> B) -> B
-
-#deprecated
-fn[A] fold_left(T[A], (A, A) -> A, init~ : A) -> A
+fn[A, B] fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
 
 #deprecated
-fn[A] fold_right(T[A], (A, A) -> A, init~ : A) -> A
+fn[A] fold_left(T[A], (A, A) -> A?Error, init~ : A) -> A?Error
+
+#deprecated
+fn[A] fold_right(T[A], (A, A) -> A?Error, init~ : A) -> A?Error
 
 fn[A] from_array(Array[A]) -> T[A]
 
@@ -36,9 +36,9 @@ fn[A] length(T[A]) -> Int
 
 fn[A] make(Int, A) -> T[A]
 
-fn[A] makei(Int, (Int) -> A) -> T[A]
+fn[A] makei(Int, (Int) -> A?Error) -> T[A]?Error
 
-fn[A, B] map(T[A], (A) -> B) -> T[B]
+fn[A, B] map(T[A], (A) -> B?Error) -> T[B]?Error
 
 fn[A] new() -> T[A]
 
@@ -48,7 +48,7 @@ fn[A] op_get(T[A], Int) -> A
 
 fn[A] push(T[A], A) -> T[A]
 
-fn[A, B] rev_fold(T[A], init~ : B, (B, A) -> B) -> B
+fn[A, B] rev_fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
 
 fn[A] set(T[A], Int, A) -> T[A]
 
@@ -59,13 +59,13 @@ type T[A]
 fn[A] T::concat(Self[A], Self[A]) -> Self[A]
 #deprecated
 fn[A] T::copy(Self[A]) -> Self[A]
-fn[A] T::each(Self[A], (A) -> Unit) -> Unit
-fn[A] T::eachi(Self[A], (Int, A) -> Unit) -> Unit
-fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B) -> B
+fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
+fn[A] T::eachi(Self[A], (Int, A) -> Unit?Error) -> Unit?Error
+fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
 #deprecated
-fn[A] T::fold_left(Self[A], (A, A) -> A, init~ : A) -> A
+fn[A] T::fold_left(Self[A], (A, A) -> A?Error, init~ : A) -> A?Error
 #deprecated
-fn[A] T::fold_right(Self[A], (A, A) -> A, init~ : A) -> A
+fn[A] T::fold_right(Self[A], (A, A) -> A?Error, init~ : A) -> A?Error
 #deprecated
 fn[A] T::from_array(Array[A]) -> Self[A]
 #deprecated
@@ -78,14 +78,14 @@ fn[A] T::length(Self[A]) -> Int
 fn[A] T::make(Int, A) -> Self[A]
 #deprecated
 fn[A] T::makei(Int, (Int) -> A) -> Self[A]
-fn[A, B] T::map(Self[A], (A) -> B) -> Self[B]
+fn[A, B] T::map(Self[A], (A) -> B?Error) -> Self[B]?Error
 #deprecated
 fn[A] T::new() -> Self[A]
 #deprecated
 fn[A] T::of(FixedArray[A]) -> Self[A]
 fn[A] T::op_get(Self[A], Int) -> A
 fn[A] T::push(Self[A], A) -> Self[A]
-fn[A, B] T::rev_fold(Self[A], init~ : B, (B, A) -> B) -> B
+fn[A, B] T::rev_fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
 fn[A] T::set(Self[A], Int, A) -> Self[A]
 fn[A] T::to_array(Self[A]) -> Array[A]
 impl[A] Add for T[A]

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -272,7 +272,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
 
 ///|
 /// For each element in the tree, apply the function `f`.
-fn[A] Tree::each(self : Tree[A], f : (A) -> Unit?Error) -> Unit?Error {
+fn[A] Tree::each(self : Tree[A], f : (A) -> Unit raise?) -> Unit raise? {
   match self {
     Empty => ()
     Leaf(l) => l.each(f)
@@ -300,10 +300,10 @@ fn[A] Tree::iter(self : Tree[A]) -> Iter[A] {
 /// For each element in the tree, apply the function `f` with the index of the element.
 fn[A] Tree::eachi(
   self : Tree[A],
-  f : (Int, A) -> Unit?Error,
+  f : (Int, A) -> Unit raise?,
   shift : Int,
   start : Int
-) -> Unit?Error {
+) -> Unit raise? {
   match self {
     Empty => ()
     Leaf(l) =>
@@ -331,7 +331,11 @@ fn[A] Tree::eachi(
 
 ///|
 /// Fold the tree.
-fn[A, B] Tree::fold(self : Tree[A], acc : B, f : (B, A) -> B?Error) -> B?Error {
+fn[A, B] Tree::fold(
+  self : Tree[A],
+  acc : B,
+  f : (B, A) -> B raise?
+) -> B raise? {
   match self {
     Empty => acc
     Leaf(l) => l.fold(f, init=acc)
@@ -344,8 +348,8 @@ fn[A, B] Tree::fold(self : Tree[A], acc : B, f : (B, A) -> B?Error) -> B?Error {
 fn[A, B] Tree::rev_fold(
   self : Tree[A],
   acc : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   match self {
     Empty => acc
     Leaf(l) => l.rev_fold(f, init=acc)
@@ -355,7 +359,7 @@ fn[A, B] Tree::rev_fold(
 
 ///|
 /// Map the tree.
-fn[A, B] Tree::map(self : Tree[A], f : (A) -> B?Error) -> Tree[B]?Error {
+fn[A, B] Tree::map(self : Tree[A], f : (A) -> B raise?) -> Tree[B] raise? {
   match self {
     Empty => Empty
     Leaf(l) => Leaf(l.map(f))

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -272,7 +272,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
 
 ///|
 /// For each element in the tree, apply the function `f`.
-fn[A] Tree::each(self : Tree[A], f : (A) -> Unit) -> Unit {
+fn[A] Tree::each(self : Tree[A], f : (A) -> Unit?Error) -> Unit?Error {
   match self {
     Empty => ()
     Leaf(l) => l.each(f)
@@ -300,10 +300,10 @@ fn[A] Tree::iter(self : Tree[A]) -> Iter[A] {
 /// For each element in the tree, apply the function `f` with the index of the element.
 fn[A] Tree::eachi(
   self : Tree[A],
-  f : (Int, A) -> Unit,
+  f : (Int, A) -> Unit?Error,
   shift : Int,
   start : Int
-) -> Unit {
+) -> Unit?Error {
   match self {
     Empty => ()
     Leaf(l) =>
@@ -331,7 +331,7 @@ fn[A] Tree::eachi(
 
 ///|
 /// Fold the tree.
-fn[A, B] Tree::fold(self : Tree[A], acc : B, f : (B, A) -> B) -> B {
+fn[A, B] Tree::fold(self : Tree[A], acc : B, f : (B, A) -> B?Error) -> B?Error {
   match self {
     Empty => acc
     Leaf(l) => l.fold(f, init=acc)
@@ -341,7 +341,11 @@ fn[A, B] Tree::fold(self : Tree[A], acc : B, f : (B, A) -> B) -> B {
 
 ///|
 /// Fold the tree in reverse order.
-fn[A, B] Tree::rev_fold(self : Tree[A], acc : B, f : (B, A) -> B) -> B {
+fn[A, B] Tree::rev_fold(
+  self : Tree[A],
+  acc : B,
+  f : (B, A) -> B?Error
+) -> B?Error {
   match self {
     Empty => acc
     Leaf(l) => l.rev_fold(f, init=acc)
@@ -351,7 +355,7 @@ fn[A, B] Tree::rev_fold(self : Tree[A], acc : B, f : (B, A) -> B) -> B {
 
 ///|
 /// Map the tree.
-fn[A, B] Tree::map(self : Tree[A], f : (A) -> B) -> Tree[B] {
+fn[A, B] Tree::map(self : Tree[A], f : (A) -> B?Error) -> Tree[B]?Error {
   match self {
     Empty => Empty
     Leaf(l) => Leaf(l.map(f))

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -154,8 +154,8 @@ fn[K : Eq, V] add_with_hash(
 /// Filter values that satisfy the predicate
 pub fn[K : Eq + Hash, V] filter(
   self : T[K, V],
-  pred : (V) -> Bool?Error
-) -> T[K, V]?Error {
+  pred : (V) -> Bool raise?
+) -> T[K, V] raise? {
   match self {
     Empty => Empty
     Leaf(k, v) => if pred(v) { Leaf(k, v) } else { Empty }
@@ -184,8 +184,8 @@ pub fn[K : Eq + Hash, V] filter(
 pub fn[K, V, A] fold(
   self : T[K, V],
   init~ : A,
-  f : (A, V) -> A?Error
-) -> A?Error {
+  f : (A, V) -> A raise?
+) -> A raise? {
   self.fold_with_key(fn(acc, _k, v) { f(acc, v) }, init~)
 }
 
@@ -197,8 +197,8 @@ pub fn[K, V, A] fold(
 pub fn[K, V, A] fold_with_key(
   self : T[K, V],
   init~ : A,
-  f : (A, K, V) -> A?Error
-) -> A?Error {
+  f : (A, K, V) -> A raise?
+) -> A raise? {
   loop (@list.singleton((self, 0)), init) {
     (Empty, acc) => acc
     (More((node, index), tail~), acc) =>
@@ -221,8 +221,8 @@ pub fn[K, V, A] fold_with_key(
 /// Maps over the values in the map
 pub fn[K : Eq + Hash, V, A] map(
   self : T[K, V],
-  f : (V) -> A?Error
-) -> T[K, A]?Error {
+  f : (V) -> A raise?
+) -> T[K, A] raise? {
   self.map_with_key(fn(_k, v) { f(v) })
 }
 
@@ -230,9 +230,9 @@ pub fn[K : Eq + Hash, V, A] map(
 /// Maps over the key-value pairs in the map
 pub fn[K : Eq + Hash, V, A] map_with_key(
   self : T[K, V],
-  f : (K, V) -> A?Error
-) -> T[K, A]?Error {
-  fn go(m : T[K, V]) -> T[K, A]?Error {
+  f : (K, V) -> A raise?
+) -> T[K, A] raise? {
+  fn go(m : T[K, V]) -> T[K, A] raise? {
     match m {
       Empty => Empty
       Leaf(k, v) => Leaf(k, f(k, v))
@@ -346,8 +346,8 @@ pub fn[K : Eq + Hash, V] T::union(self : T[K, V], other : T[K, V]) -> T[K, V] {
 pub fn[K : Eq + Hash, V] T::union_with(
   self : T[K, V],
   other : T[K, V],
-  f : (K, V, V) -> V?Error
-) -> T[K, V]?Error {
+  f : (K, V, V) -> V raise?
+) -> T[K, V] raise? {
   match (self, other) {
     (_, Empty) => self
     (Empty, _) => other
@@ -414,8 +414,8 @@ pub fn[K : Eq + Hash, V] T::intersection(
 pub fn[K : Eq + Hash, V] T::intersection_with(
   self : T[K, V],
   other : T[K, V],
-  f : (K, V, V) -> V?Error
-) -> T[K, V]?Error {
+  f : (K, V, V) -> V raise?
+) -> T[K, V] raise? {
   match (self, other) {
     (_, Empty) => Empty
     (Empty, _) => Empty
@@ -473,7 +473,7 @@ pub fn[K : Eq + Hash, V] T::difference(
 
 ///|
 /// Iterate through the elements in a hash map
-pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit?Error) -> Unit?Error {
+pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit raise?) -> Unit raise? {
   match self {
     Empty => ()
     Leaf(k, v) => f(k, v)

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -152,7 +152,10 @@ fn[K : Eq, V] add_with_hash(
 
 ///|
 /// Filter values that satisfy the predicate
-pub fn[K : Eq + Hash, V] filter(self : T[K, V], pred : (V) -> Bool) -> T[K, V] {
+pub fn[K : Eq + Hash, V] filter(
+  self : T[K, V],
+  pred : (V) -> Bool?Error
+) -> T[K, V]?Error {
   match self {
     Empty => Empty
     Leaf(k, v) => if pred(v) { Leaf(k, v) } else { Empty }
@@ -178,7 +181,11 @@ pub fn[K : Eq + Hash, V] filter(self : T[K, V], pred : (V) -> Bool) -> T[K, V] {
 
 ///|
 /// Fold the values in the map
-pub fn[K, V, A] fold(self : T[K, V], init~ : A, f : (A, V) -> A) -> A {
+pub fn[K, V, A] fold(
+  self : T[K, V],
+  init~ : A,
+  f : (A, V) -> A?Error
+) -> A?Error {
   self.fold_with_key(fn(acc, _k, v) { f(acc, v) }, init~)
 }
 
@@ -190,8 +197,8 @@ pub fn[K, V, A] fold(self : T[K, V], init~ : A, f : (A, V) -> A) -> A {
 pub fn[K, V, A] fold_with_key(
   self : T[K, V],
   init~ : A,
-  f : (A, K, V) -> A
-) -> A {
+  f : (A, K, V) -> A?Error
+) -> A?Error {
   loop (@list.singleton((self, 0)), init) {
     (Empty, acc) => acc
     (More((node, index), tail~), acc) =>
@@ -212,7 +219,10 @@ pub fn[K, V, A] fold_with_key(
 
 ///|
 /// Maps over the values in the map
-pub fn[K : Eq + Hash, V, A] map(self : T[K, V], f : (V) -> A) -> T[K, A] {
+pub fn[K : Eq + Hash, V, A] map(
+  self : T[K, V],
+  f : (V) -> A?Error
+) -> T[K, A]?Error {
   self.map_with_key(fn(_k, v) { f(v) })
 }
 
@@ -220,9 +230,9 @@ pub fn[K : Eq + Hash, V, A] map(self : T[K, V], f : (V) -> A) -> T[K, A] {
 /// Maps over the key-value pairs in the map
 pub fn[K : Eq + Hash, V, A] map_with_key(
   self : T[K, V],
-  f : (K, V) -> A
-) -> T[K, A] {
-  fn go(m : T[K, V]) {
+  f : (K, V) -> A?Error
+) -> T[K, A]?Error {
+  fn go(m : T[K, V]) -> T[K, A]?Error {
     match m {
       Empty => Empty
       Leaf(k, v) => Leaf(k, f(k, v))
@@ -336,8 +346,8 @@ pub fn[K : Eq + Hash, V] T::union(self : T[K, V], other : T[K, V]) -> T[K, V] {
 pub fn[K : Eq + Hash, V] T::union_with(
   self : T[K, V],
   other : T[K, V],
-  f : (K, V, V) -> V
-) -> T[K, V] {
+  f : (K, V, V) -> V?Error
+) -> T[K, V]?Error {
   match (self, other) {
     (_, Empty) => self
     (Empty, _) => other
@@ -404,8 +414,8 @@ pub fn[K : Eq + Hash, V] T::intersection(
 pub fn[K : Eq + Hash, V] T::intersection_with(
   self : T[K, V],
   other : T[K, V],
-  f : (K, V, V) -> V
-) -> T[K, V] {
+  f : (K, V, V) -> V?Error
+) -> T[K, V]?Error {
   match (self, other) {
     (_, Empty) => Empty
     (Empty, _) => Empty
@@ -463,7 +473,7 @@ pub fn[K : Eq + Hash, V] T::difference(
 
 ///|
 /// Iterate through the elements in a hash map
-pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit) -> Unit {
+pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit?Error) -> Unit?Error {
   match self {
     Empty => ()
     Leaf(k, v) => f(k, v)

--- a/immut/hashmap/bucket.mbt
+++ b/immut/hashmap/bucket.mbt
@@ -78,7 +78,10 @@ fn[K, V] Bucket::size(self : Bucket[K, V]) -> Int {
 
 ///|
 /// Iterate through elements of a bucket
-fn[K, V] Bucket::each(self : Bucket[K, V], f : (K, V) -> Unit) -> Unit {
+fn[K, V] Bucket::each(
+  self : Bucket[K, V],
+  f : (K, V) -> Unit?Error
+) -> Unit?Error {
   loop self {
     JustOne(k, v) => f(k, v)
     More(k, v, rest) => {
@@ -89,7 +92,10 @@ fn[K, V] Bucket::each(self : Bucket[K, V], f : (K, V) -> Unit) -> Unit {
 }
 
 ///|
-fn[K, V] Bucket::filter(self : Bucket[K, V], f : (V) -> Bool) -> Bucket[K, V]? {
+fn[K, V] Bucket::filter(
+  self : Bucket[K, V],
+  f : (V) -> Bool?Error
+) -> Bucket[K, V]??Error {
   match self {
     JustOne(k, v) => if f(v) { Some(JustOne(k, v)) } else { None }
     More(k, v, rest) => {
@@ -191,9 +197,9 @@ test "Bucket::iter" {
 ///
 fn[K, V, A] Bucket::foldl_with_key(
   self : Bucket[K, V],
-  f : (A, K, V) -> A,
+  f : (A, K, V) -> A?Error,
   init~ : A
-) -> A {
+) -> A?Error {
   match self {
     JustOne(k, v) => f(init, k, v)
     More(k, v, rest) => rest.foldl_with_key(init=f(init, k, v), f)
@@ -210,8 +216,8 @@ test "foldl_with_key" {
 ///|
 fn[K, V, A] Bucket::map_with_key(
   self : Bucket[K, V],
-  f : (K, V) -> A
-) -> Bucket[K, A] {
+  f : (K, V) -> A?Error
+) -> Bucket[K, A]?Error {
   match self {
     JustOne(k, v) => JustOne(k, f(k, v))
     More(k, v, rest) => More(k, f(k, v), rest.map_with_key(f))
@@ -228,7 +234,10 @@ test "Bucket::map_with_key" {
 }
 
 ///|
-fn[K, V, A] Bucket::map(self : Bucket[K, V], f : (V) -> A) -> Bucket[K, A] {
+fn[K, V, A] Bucket::map(
+  self : Bucket[K, V],
+  f : (V) -> A?Error
+) -> Bucket[K, A]?Error {
   self.map_with_key(fn(_k, v) { f(v) })
 }
 

--- a/immut/hashmap/bucket.mbt
+++ b/immut/hashmap/bucket.mbt
@@ -80,8 +80,8 @@ fn[K, V] Bucket::size(self : Bucket[K, V]) -> Int {
 /// Iterate through elements of a bucket
 fn[K, V] Bucket::each(
   self : Bucket[K, V],
-  f : (K, V) -> Unit?Error
-) -> Unit?Error {
+  f : (K, V) -> Unit raise?
+) -> Unit raise? {
   loop self {
     JustOne(k, v) => f(k, v)
     More(k, v, rest) => {
@@ -94,8 +94,8 @@ fn[K, V] Bucket::each(
 ///|
 fn[K, V] Bucket::filter(
   self : Bucket[K, V],
-  f : (V) -> Bool?Error
-) -> Bucket[K, V]??Error {
+  f : (V) -> Bool raise?
+) -> Bucket[K, V]? raise? {
   match self {
     JustOne(k, v) => if f(v) { Some(JustOne(k, v)) } else { None }
     More(k, v, rest) => {
@@ -197,9 +197,9 @@ test "Bucket::iter" {
 ///
 fn[K, V, A] Bucket::foldl_with_key(
   self : Bucket[K, V],
-  f : (A, K, V) -> A?Error,
+  f : (A, K, V) -> A raise?,
   init~ : A
-) -> A?Error {
+) -> A raise? {
   match self {
     JustOne(k, v) => f(init, k, v)
     More(k, v, rest) => rest.foldl_with_key(init=f(init, k, v), f)
@@ -216,8 +216,8 @@ test "foldl_with_key" {
 ///|
 fn[K, V, A] Bucket::map_with_key(
   self : Bucket[K, V],
-  f : (K, V) -> A?Error
-) -> Bucket[K, A]?Error {
+  f : (K, V) -> A raise?
+) -> Bucket[K, A] raise? {
   match self {
     JustOne(k, v) => JustOne(k, f(k, v))
     More(k, v, rest) => More(k, f(k, v), rest.map_with_key(f))
@@ -236,8 +236,8 @@ test "Bucket::map_with_key" {
 ///|
 fn[K, V, A] Bucket::map(
   self : Bucket[K, V],
-  f : (V) -> A?Error
-) -> Bucket[K, A]?Error {
+  f : (V) -> A raise?
+) -> Bucket[K, A] raise? {
   self.map_with_key(fn(_k, v) { f(v) })
 }
 

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -9,19 +9,19 @@ fn[K : Eq + Hash, V] add(T[K, V], K, V) -> T[K, V]
 
 fn[K : Eq + Hash, V] contains(T[K, V], K) -> Bool
 
-fn[K, V] each(T[K, V], (K, V) -> Unit) -> Unit
+fn[K, V] each(T[K, V], (K, V) -> Unit?Error) -> Unit?Error
 
 #deprecated
 fn[K, V] elems(T[K, V]) -> Iter[V]
 
-fn[K : Eq + Hash, V] filter(T[K, V], (V) -> Bool) -> T[K, V]
+fn[K : Eq + Hash, V] filter(T[K, V], (V) -> Bool?Error) -> T[K, V]?Error
 
 #deprecated
 fn[K : Eq + Hash, V] find(T[K, V], K) -> V?
 
-fn[K, V, A] fold(T[K, V], init~ : A, (A, V) -> A) -> A
+fn[K, V, A] fold(T[K, V], init~ : A, (A, V) -> A?Error) -> A?Error
 
-fn[K, V, A] fold_with_key(T[K, V], init~ : A, (A, K, V) -> A) -> A
+fn[K, V, A] fold_with_key(T[K, V], init~ : A, (A, K, V) -> A?Error) -> A?Error
 
 fn[K : Eq + Hash, V] from_array(Array[(K, V)]) -> T[K, V]
 
@@ -35,9 +35,9 @@ fn[K, V] iter2(T[K, V]) -> Iter2[K, V]
 
 fn[K, V] keys(T[K, V]) -> Iter[K]
 
-fn[K : Eq + Hash, V, A] map(T[K, V], (V) -> A) -> T[K, A]
+fn[K : Eq + Hash, V, A] map(T[K, V], (V) -> A?Error) -> T[K, A]?Error
 
-fn[K : Eq + Hash, V, A] map_with_key(T[K, V], (K, V) -> A) -> T[K, A]
+fn[K : Eq + Hash, V, A] map_with_key(T[K, V], (K, V) -> A?Error) -> T[K, A]?Error
 
 fn[K, V] new() -> T[K, V]
 
@@ -61,29 +61,29 @@ type T[K, V]
 fn[K : Eq + Hash, V] T::add(Self[K, V], K, V) -> Self[K, V]
 fn[K : Eq + Hash, V] T::contains(Self[K, V], K) -> Bool
 fn[K : Eq + Hash, V] T::difference(Self[K, V], Self[K, V]) -> Self[K, V]
-fn[K, V] T::each(Self[K, V], (K, V) -> Unit) -> Unit
+fn[K, V] T::each(Self[K, V], (K, V) -> Unit?Error) -> Unit?Error
 #deprecated
 fn[K, V] T::elems(Self[K, V]) -> Iter[V]
-fn[K : Eq + Hash, V] T::filter(Self[K, V], (V) -> Bool) -> Self[K, V]
+fn[K : Eq + Hash, V] T::filter(Self[K, V], (V) -> Bool?Error) -> Self[K, V]?Error
 #deprecated
 fn[K : Eq + Hash, V] T::find(Self[K, V], K) -> V?
-fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A) -> A
-fn[K, V, A] T::fold_with_key(Self[K, V], init~ : A, (A, K, V) -> A) -> A
+fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A?Error) -> A?Error
+fn[K, V, A] T::fold_with_key(Self[K, V], init~ : A, (A, K, V) -> A?Error) -> A?Error
 fn[K : Eq + Hash, V] T::get(Self[K, V], K) -> V?
 fn[K : Eq + Hash, V] T::intersection(Self[K, V], Self[K, V]) -> Self[K, V]
-fn[K : Eq + Hash, V] T::intersection_with(Self[K, V], Self[K, V], (K, V, V) -> V) -> Self[K, V]
+fn[K : Eq + Hash, V] T::intersection_with(Self[K, V], Self[K, V], (K, V, V) -> V?Error) -> Self[K, V]?Error
 fn[K, V] T::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] T::iter2(Self[K, V]) -> Iter2[K, V]
 fn[K, V] T::keys(Self[K, V]) -> Iter[K]
-fn[K : Eq + Hash, V, A] T::map(Self[K, V], (V) -> A) -> Self[K, A]
-fn[K : Eq + Hash, V, A] T::map_with_key(Self[K, V], (K, V) -> A) -> Self[K, A]
+fn[K : Eq + Hash, V, A] T::map(Self[K, V], (V) -> A?Error) -> Self[K, A]?Error
+fn[K : Eq + Hash, V, A] T::map_with_key(Self[K, V], (K, V) -> A?Error) -> Self[K, A]?Error
 #deprecated
 fn[K : Eq + Hash, V] T::op_get(Self[K, V], K) -> V?
 fn[K : Eq + Hash, V] T::remove(Self[K, V], K) -> Self[K, V]
 fn[K, V] T::size(Self[K, V]) -> Int
 fn[K, V] T::to_array(Self[K, V]) -> Array[(K, V)]
 fn[K : Eq + Hash, V] T::union(Self[K, V], Self[K, V]) -> Self[K, V]
-fn[K : Eq + Hash, V] T::union_with(Self[K, V], Self[K, V], (K, V, V) -> V) -> Self[K, V]
+fn[K : Eq + Hash, V] T::union_with(Self[K, V], Self[K, V], (K, V, V) -> V?Error) -> Self[K, V]?Error
 fn[K, V] T::values(Self[K, V]) -> Iter[V]
 impl[K : Eq + Hash, V : Eq] Eq for T[K, V]
 impl[K : Hash, V : Hash] Hash for T[K, V]

--- a/immut/hashmap/hashmap.mbti
+++ b/immut/hashmap/hashmap.mbti
@@ -9,19 +9,19 @@ fn[K : Eq + Hash, V] add(T[K, V], K, V) -> T[K, V]
 
 fn[K : Eq + Hash, V] contains(T[K, V], K) -> Bool
 
-fn[K, V] each(T[K, V], (K, V) -> Unit?Error) -> Unit?Error
+fn[K, V] each(T[K, V], (K, V) -> Unit raise?) -> Unit raise?
 
 #deprecated
 fn[K, V] elems(T[K, V]) -> Iter[V]
 
-fn[K : Eq + Hash, V] filter(T[K, V], (V) -> Bool?Error) -> T[K, V]?Error
+fn[K : Eq + Hash, V] filter(T[K, V], (V) -> Bool raise?) -> T[K, V] raise?
 
 #deprecated
 fn[K : Eq + Hash, V] find(T[K, V], K) -> V?
 
-fn[K, V, A] fold(T[K, V], init~ : A, (A, V) -> A?Error) -> A?Error
+fn[K, V, A] fold(T[K, V], init~ : A, (A, V) -> A raise?) -> A raise?
 
-fn[K, V, A] fold_with_key(T[K, V], init~ : A, (A, K, V) -> A?Error) -> A?Error
+fn[K, V, A] fold_with_key(T[K, V], init~ : A, (A, K, V) -> A raise?) -> A raise?
 
 fn[K : Eq + Hash, V] from_array(Array[(K, V)]) -> T[K, V]
 
@@ -35,9 +35,9 @@ fn[K, V] iter2(T[K, V]) -> Iter2[K, V]
 
 fn[K, V] keys(T[K, V]) -> Iter[K]
 
-fn[K : Eq + Hash, V, A] map(T[K, V], (V) -> A?Error) -> T[K, A]?Error
+fn[K : Eq + Hash, V, A] map(T[K, V], (V) -> A raise?) -> T[K, A] raise?
 
-fn[K : Eq + Hash, V, A] map_with_key(T[K, V], (K, V) -> A?Error) -> T[K, A]?Error
+fn[K : Eq + Hash, V, A] map_with_key(T[K, V], (K, V) -> A raise?) -> T[K, A] raise?
 
 fn[K, V] new() -> T[K, V]
 
@@ -61,29 +61,29 @@ type T[K, V]
 fn[K : Eq + Hash, V] T::add(Self[K, V], K, V) -> Self[K, V]
 fn[K : Eq + Hash, V] T::contains(Self[K, V], K) -> Bool
 fn[K : Eq + Hash, V] T::difference(Self[K, V], Self[K, V]) -> Self[K, V]
-fn[K, V] T::each(Self[K, V], (K, V) -> Unit?Error) -> Unit?Error
+fn[K, V] T::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 #deprecated
 fn[K, V] T::elems(Self[K, V]) -> Iter[V]
-fn[K : Eq + Hash, V] T::filter(Self[K, V], (V) -> Bool?Error) -> Self[K, V]?Error
+fn[K : Eq + Hash, V] T::filter(Self[K, V], (V) -> Bool raise?) -> Self[K, V] raise?
 #deprecated
 fn[K : Eq + Hash, V] T::find(Self[K, V], K) -> V?
-fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A?Error) -> A?Error
-fn[K, V, A] T::fold_with_key(Self[K, V], init~ : A, (A, K, V) -> A?Error) -> A?Error
+fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A raise?) -> A raise?
+fn[K, V, A] T::fold_with_key(Self[K, V], init~ : A, (A, K, V) -> A raise?) -> A raise?
 fn[K : Eq + Hash, V] T::get(Self[K, V], K) -> V?
 fn[K : Eq + Hash, V] T::intersection(Self[K, V], Self[K, V]) -> Self[K, V]
-fn[K : Eq + Hash, V] T::intersection_with(Self[K, V], Self[K, V], (K, V, V) -> V?Error) -> Self[K, V]?Error
+fn[K : Eq + Hash, V] T::intersection_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?) -> Self[K, V] raise?
 fn[K, V] T::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] T::iter2(Self[K, V]) -> Iter2[K, V]
 fn[K, V] T::keys(Self[K, V]) -> Iter[K]
-fn[K : Eq + Hash, V, A] T::map(Self[K, V], (V) -> A?Error) -> Self[K, A]?Error
-fn[K : Eq + Hash, V, A] T::map_with_key(Self[K, V], (K, V) -> A?Error) -> Self[K, A]?Error
+fn[K : Eq + Hash, V, A] T::map(Self[K, V], (V) -> A raise?) -> Self[K, A] raise?
+fn[K : Eq + Hash, V, A] T::map_with_key(Self[K, V], (K, V) -> A raise?) -> Self[K, A] raise?
 #deprecated
 fn[K : Eq + Hash, V] T::op_get(Self[K, V], K) -> V?
 fn[K : Eq + Hash, V] T::remove(Self[K, V], K) -> Self[K, V]
 fn[K, V] T::size(Self[K, V]) -> Int
 fn[K, V] T::to_array(Self[K, V]) -> Array[(K, V)]
 fn[K : Eq + Hash, V] T::union(Self[K, V], Self[K, V]) -> Self[K, V]
-fn[K : Eq + Hash, V] T::union_with(Self[K, V], Self[K, V], (K, V, V) -> V?Error) -> Self[K, V]?Error
+fn[K : Eq + Hash, V] T::union_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?) -> Self[K, V] raise?
 fn[K, V] T::values(Self[K, V]) -> Iter[V]
 impl[K : Eq + Hash, V : Eq] Eq for T[K, V]
 impl[K : Hash, V : Hash] Hash for T[K, V]

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -252,7 +252,7 @@ pub fn[A] is_empty(self : T[A]) -> Bool {
 
 ///|
 /// Iterate through the elements in a hash set
-pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
+pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
   match self {
     Empty => ()
     Leaf(k) => f(k)

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -252,7 +252,7 @@ pub fn[A] is_empty(self : T[A]) -> Bool {
 
 ///|
 /// Iterate through the elements in a hash set
-pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
+pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
   match self {
     Empty => ()
     Leaf(k) => f(k)

--- a/immut/hashset/bucket.mbt
+++ b/immut/hashset/bucket.mbt
@@ -64,7 +64,7 @@ fn[T] Bucket::size(self : Bucket[T]) -> Int {
 
 ///|
 /// Iterate through elements of a bucket
-fn[T] Bucket::each(self : Bucket[T], f : (T) -> Unit) -> Unit {
+fn[T] Bucket::each(self : Bucket[T], f : (T) -> Unit?Error) -> Unit?Error {
   loop self {
     JustOne(k) => f(k)
     More(k, rest) => {

--- a/immut/hashset/bucket.mbt
+++ b/immut/hashset/bucket.mbt
@@ -64,7 +64,7 @@ fn[T] Bucket::size(self : Bucket[T]) -> Int {
 
 ///|
 /// Iterate through elements of a bucket
-fn[T] Bucket::each(self : Bucket[T], f : (T) -> Unit?Error) -> Unit?Error {
+fn[T] Bucket::each(self : Bucket[T], f : (T) -> Unit raise?) -> Unit raise? {
   loop self {
     JustOne(k) => f(k)
     More(k, rest) => {

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -9,7 +9,7 @@ fn[A : Eq + Hash] add(T[A], A) -> T[A]
 
 fn[A : Eq + Hash] contains(T[A], A) -> Bool
 
-fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
+fn[A] each(T[A], (A) -> Unit raise?) -> Unit raise?
 
 fn[A : Eq + Hash] from_array(Array[A]) -> T[A]
 
@@ -32,7 +32,7 @@ type T[A]
 fn[A : Eq + Hash] T::add(Self[A], A) -> Self[A]
 fn[A : Eq + Hash] T::contains(Self[A], A) -> Bool
 fn[K : Eq + Hash] T::difference(Self[K], Self[K]) -> Self[K]
-fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
+fn[A] T::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 fn[K : Eq + Hash] T::intersection(Self[K], Self[K]) -> Self[K]
 fn[A] T::is_empty(Self[A]) -> Bool
 fn[A] T::iter(Self[A]) -> Iter[A]

--- a/immut/hashset/hashset.mbti
+++ b/immut/hashset/hashset.mbti
@@ -9,7 +9,7 @@ fn[A : Eq + Hash] add(T[A], A) -> T[A]
 
 fn[A : Eq + Hash] contains(T[A], A) -> Bool
 
-fn[A] each(T[A], (A) -> Unit) -> Unit
+fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
 
 fn[A : Eq + Hash] from_array(Array[A]) -> T[A]
 
@@ -32,7 +32,7 @@ type T[A]
 fn[A : Eq + Hash] T::add(Self[A], A) -> Self[A]
 fn[A : Eq + Hash] T::contains(Self[A], A) -> Bool
 fn[K : Eq + Hash] T::difference(Self[K], Self[K]) -> Self[K]
-fn[A] T::each(Self[A], (A) -> Unit) -> Unit
+fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
 fn[K : Eq + Hash] T::intersection(Self[K], Self[K]) -> Self[K]
 fn[A] T::is_empty(Self[A]) -> Bool
 fn[A] T::iter(Self[A]) -> Iter[A]

--- a/immut/internal/sparse_array/sparse_array.mbt
+++ b/immut/internal/sparse_array/sparse_array.mbt
@@ -73,8 +73,8 @@ pub fn[X] add(self : SparseArray[X], idx : Int, value : X) -> SparseArray[X] {
 pub fn[X] SparseArray::union(
   self : SparseArray[X],
   other : SparseArray[X],
-  union : (X, X) -> X
-) -> SparseArray[X] {
+  union : (X, X) -> X?Error
+) -> SparseArray[X]?Error {
   let un = self.elem_info.union(other.elem_info)
   let diff = self.elem_info.difference(other.elem_info)
   let new_len = un.size()
@@ -109,8 +109,8 @@ pub fn[X] SparseArray::union(
 pub fn[X] SparseArray::intersection(
   self : SparseArray[X],
   other : SparseArray[X],
-  f : (X, X) -> X
-) -> SparseArray[X] {
+  f : (X, X) -> X?Error
+) -> SparseArray[X]?Error {
   let inter = self.elem_info.intersection(other.elem_info)
   let new_len = inter.size()
   if new_len == 0 {
@@ -176,7 +176,7 @@ pub fn[X] size(self : SparseArray[X]) -> Int {
 /// `each(self: SparseArray[X], f: (X) -> Unit) -> Unit`
 ///
 /// Iterate through elements in a sparse array
-pub fn[X] each(self : SparseArray[X], f : (X) -> Unit) -> Unit {
+pub fn[X] each(self : SparseArray[X], f : (X) -> Unit?Error) -> Unit?Error {
   for i in 0..<self.elem_info.size() {
     f(self.data[i])
   }

--- a/immut/internal/sparse_array/sparse_array.mbt
+++ b/immut/internal/sparse_array/sparse_array.mbt
@@ -73,8 +73,8 @@ pub fn[X] add(self : SparseArray[X], idx : Int, value : X) -> SparseArray[X] {
 pub fn[X] SparseArray::union(
   self : SparseArray[X],
   other : SparseArray[X],
-  union : (X, X) -> X?Error
-) -> SparseArray[X]?Error {
+  union : (X, X) -> X raise?
+) -> SparseArray[X] raise? {
   let un = self.elem_info.union(other.elem_info)
   let diff = self.elem_info.difference(other.elem_info)
   let new_len = un.size()
@@ -109,8 +109,8 @@ pub fn[X] SparseArray::union(
 pub fn[X] SparseArray::intersection(
   self : SparseArray[X],
   other : SparseArray[X],
-  f : (X, X) -> X?Error
-) -> SparseArray[X]?Error {
+  f : (X, X) -> X raise?
+) -> SparseArray[X] raise? {
   let inter = self.elem_info.intersection(other.elem_info)
   let new_len = inter.size()
   if new_len == 0 {
@@ -176,7 +176,7 @@ pub fn[X] size(self : SparseArray[X]) -> Int {
 /// `each(self: SparseArray[X], f: (X) -> Unit) -> Unit`
 ///
 /// Iterate through elements in a sparse array
-pub fn[X] each(self : SparseArray[X], f : (X) -> Unit?Error) -> Unit?Error {
+pub fn[X] each(self : SparseArray[X], f : (X) -> Unit raise?) -> Unit raise? {
   for i in 0..<self.elem_info.size() {
     f(self.data[i])
   }

--- a/immut/internal/sparse_array/sparse_array.mbti
+++ b/immut/internal/sparse_array/sparse_array.mbti
@@ -3,7 +3,7 @@ package "moonbitlang/core/immut/internal/sparse_array"
 // Values
 fn[X] add(SparseArray[X], Int, X) -> SparseArray[X]
 
-fn[X] each(SparseArray[X], (X) -> Unit?Error) -> Unit?Error
+fn[X] each(SparseArray[X], (X) -> Unit raise?) -> Unit raise?
 
 fn[X] empty() -> SparseArray[X]
 
@@ -36,13 +36,13 @@ pub(all) struct SparseArray[X] {
 }
 fn[X] SparseArray::add(Self[X], Int, X) -> Self[X]
 fn[X] SparseArray::difference(Self[X], Self[X]) -> Self[X]
-fn[X] SparseArray::each(Self[X], (X) -> Unit?Error) -> Unit?Error
+fn[X] SparseArray::each(Self[X], (X) -> Unit raise?) -> Unit raise?
 fn[X] SparseArray::has(Self[X], Int) -> Bool
-fn[X] SparseArray::intersection(Self[X], Self[X], (X, X) -> X?Error) -> Self[X]?Error
+fn[X] SparseArray::intersection(Self[X], Self[X], (X, X) -> X raise?) -> Self[X] raise?
 fn[X] SparseArray::op_get(Self[X], Int) -> X?
 fn[X] SparseArray::replace(Self[X], Int, X) -> Self[X]
 fn[X] SparseArray::size(Self[X]) -> Int
-fn[X] SparseArray::union(Self[X], Self[X], (X, X) -> X?Error) -> Self[X]?Error
+fn[X] SparseArray::union(Self[X], Self[X], (X, X) -> X raise?) -> Self[X] raise?
 impl[X : Eq] Eq for SparseArray[X]
 
 // Type aliases

--- a/immut/internal/sparse_array/sparse_array.mbti
+++ b/immut/internal/sparse_array/sparse_array.mbti
@@ -3,7 +3,7 @@ package "moonbitlang/core/immut/internal/sparse_array"
 // Values
 fn[X] add(SparseArray[X], Int, X) -> SparseArray[X]
 
-fn[X] each(SparseArray[X], (X) -> Unit) -> Unit
+fn[X] each(SparseArray[X], (X) -> Unit?Error) -> Unit?Error
 
 fn[X] empty() -> SparseArray[X]
 
@@ -36,13 +36,13 @@ pub(all) struct SparseArray[X] {
 }
 fn[X] SparseArray::add(Self[X], Int, X) -> Self[X]
 fn[X] SparseArray::difference(Self[X], Self[X]) -> Self[X]
-fn[X] SparseArray::each(Self[X], (X) -> Unit) -> Unit
+fn[X] SparseArray::each(Self[X], (X) -> Unit?Error) -> Unit?Error
 fn[X] SparseArray::has(Self[X], Int) -> Bool
-fn[X] SparseArray::intersection(Self[X], Self[X], (X, X) -> X) -> Self[X]
+fn[X] SparseArray::intersection(Self[X], Self[X], (X, X) -> X?Error) -> Self[X]?Error
 fn[X] SparseArray::op_get(Self[X], Int) -> X?
 fn[X] SparseArray::replace(Self[X], Int, X) -> Self[X]
 fn[X] SparseArray::size(Self[X]) -> Int
-fn[X] SparseArray::union(Self[X], Self[X], (X, X) -> X) -> Self[X]
+fn[X] SparseArray::union(Self[X], Self[X], (X, X) -> X?Error) -> Self[X]?Error
 impl[X : Eq] Eq for SparseArray[X]
 
 // Type aliases

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -97,7 +97,7 @@ pub fn[A] length(self : T[A]) -> Int {
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
+pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
   loop self {
     Nil => ()
     Cons(head, tail) => {
@@ -119,7 +119,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
 ///   assert_eq(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
 /// }
 /// ```
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit?Error) -> Unit?Error {
+pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
   loop (self, 0) {
     (Nil, _) => ()
     (Cons(x, xs), i) => {
@@ -148,8 +148,8 @@ pub fn[A, B] map(self : T[A], f : (A) -> B) -> T[B] {
 
 ///|
 /// Maps the list with index.
-pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B?Error) -> T[B]?Error {
-  fn go(xs : T[A], i : Int, f : (Int, A) -> B?Error) -> T[B]?Error {
+pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B raise?) -> T[B] raise? {
+  fn go(xs : T[A], i : Int, f : (Int, A) -> B raise?) -> T[B] raise? {
     match xs {
       Nil => Nil
       Cons(x, xs) => Cons(f(i, x), go(xs, i + 1, f))
@@ -170,7 +170,7 @@ pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B?Error) -> T[B]?Error {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).rev_map(fn(x) { x * 2 }), @list.of([10, 8, 6, 4, 2]))
 /// }
 /// ```
-pub fn[A, B] rev_map(self : T[A], f : (A) -> B?Error) -> T[B]?Error {
+pub fn[A, B] rev_map(self : T[A], f : (A) -> B raise?) -> T[B] raise? {
   loop (Nil, self) {
     (acc, Nil) => acc
     (acc, Cons(x, xs)) => continue (Cons(f(x), acc), xs)
@@ -206,7 +206,7 @@ pub fn[A] to_array(self : T[A]) -> Array[A] {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).filter(fn(x){ x % 2 == 0}), @list.of([2, 4]))
 /// }
 /// ```
-pub fn[A] filter(self : T[A], f : (A) -> Bool?Error) -> T[A]?Error {
+pub fn[A] filter(self : T[A], f : (A) -> Bool raise?) -> T[A] raise? {
   match self {
     Nil => Nil
     Cons(head, tail) =>
@@ -220,7 +220,7 @@ pub fn[A] filter(self : T[A], f : (A) -> Bool?Error) -> T[A]?Error {
 
 ///|
 /// Test if all elements of the list satisfy the predicate.
-pub fn[A] all(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
+pub fn[A] all(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
   loop self {
     Nil => true
     Cons(head, tail) => if f(head) { continue tail } else { false }
@@ -229,7 +229,7 @@ pub fn[A] all(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
 
 ///|
 /// Test if any element of the list satisfies the predicate.
-pub fn[A] any(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
+pub fn[A] any(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
   match self {
     Nil => false
     Cons(head, tail) => f(head) || tail.any(f)
@@ -376,7 +376,7 @@ pub fn[A] rev(self : T[A]) -> T[A] {
 ///   assert_eq(r, 15)
 /// }
 /// ```
-pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
+pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B raise?) -> B raise? {
   match self {
     Nil => init
     Cons(head, tail) => tail.fold(f, init=f(init, head))
@@ -393,7 +393,11 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
 ///   assert_eq(r, 15)
 /// }
 /// ```
-pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (A, B) -> B?Error) -> B?Error {
+pub fn[A, B] rev_fold(
+  self : T[A],
+  init~ : B,
+  f : (A, B) -> B raise?
+) -> B raise? {
   let xs = self.to_array()
   let mut acc = init
   for x in xs.rev_iter() {
@@ -417,9 +421,9 @@ pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (A, B) -> B?Error) -> B?Error 
 #coverage.skip
 pub fn[A, B] fold_left(
   self : T[A],
-  f : (B, A) -> B?Error,
+  f : (B, A) -> B raise?,
   init~ : B
-) -> B?Error {
+) -> B raise? {
   self.fold(init~, f)
 }
 
@@ -428,9 +432,9 @@ pub fn[A, B] fold_left(
 #coverage.skip
 pub fn[A, B] fold_right(
   self : T[A],
-  f : (A, B) -> B?Error,
+  f : (A, B) -> B raise?,
   init~ : B
-) -> B?Error {
+) -> B raise? {
   match self {
     Nil => init
     Cons(head, tail) => f(head, tail.rev_fold(f, init~))
@@ -442,9 +446,9 @@ pub fn[A, B] fold_right(
 pub fn[A, B] foldi(
   self : T[A],
   init~ : B,
-  f : (Int, B, A) -> B?Error
-) -> B?Error {
-  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B?Error, acc : B) -> B?Error {
+  f : (Int, B, A) -> B raise?
+) -> B raise? {
+  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B raise?, acc : B) -> B raise? {
     match xs {
       Nil => acc
       Cons(x, xs) => go(xs, i + 1, f, f(i, acc, x))
@@ -459,9 +463,9 @@ pub fn[A, B] foldi(
 pub fn[A, B] rev_foldi(
   self : T[A],
   init~ : B,
-  f : (Int, A, B) -> B?Error
-) -> B?Error {
-  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B?Error, acc : B) -> B?Error {
+  f : (Int, A, B) -> B raise?
+) -> B raise? {
+  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B raise?, acc : B) -> B raise? {
     match xs {
       Nil => acc
       Cons(x, xs) => f(i, x, go(xs, i + 1, f, acc))
@@ -477,10 +481,10 @@ pub fn[A, B] rev_foldi(
 #coverage.skip
 pub fn[A, B] fold_lefti(
   self : T[A],
-  f : (Int, B, A) -> B?Error,
+  f : (Int, B, A) -> B raise?,
   init~ : B
-) -> B?Error {
-  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B?Error, acc : B) -> B?Error {
+) -> B raise? {
+  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B raise?, acc : B) -> B raise? {
     match xs {
       Nil => acc
       Cons(x, xs) => go(xs, i + 1, f, f(i, acc, x))
@@ -496,10 +500,10 @@ pub fn[A, B] fold_lefti(
 #coverage.skip
 pub fn[A, B] fold_righti(
   self : T[A],
-  f : (Int, A, B) -> B?Error,
+  f : (Int, A, B) -> B raise?,
   init~ : B
-) -> B?Error {
-  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B?Error, acc : B) -> B?Error {
+) -> B raise? {
+  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B raise?, acc : B) -> B raise? {
     match xs {
       Nil => acc
       Cons(x, xs) => f(i, x, go(xs, i + 1, f, acc))
@@ -568,7 +572,7 @@ pub fn[A, B] concat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
 ///   assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// }
 /// ```
-pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B]?Error) -> T[B]?Error {
+pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B] raise?) -> T[B] raise? {
   match self {
     Nil => Nil
     Cons(head, tail) => f(head).concat(tail.flat_map(f))
@@ -825,7 +829,7 @@ pub fn[A : Eq] contains(self : T[A], value : A) -> Bool {
 ///   assert_eq(r, @list.from_array([0, 1, 2]))
 /// }
 /// ```
-pub fn[A, S] unfold(f : (S) -> (A, S)??Error, init~ : S) -> T[A]?Error {
+pub fn[A, S] unfold(f : (S) -> (A, S)? raise?, init~ : S) -> T[A] raise? {
   match f(init) {
     Some((element, new_state)) => Cons(element, unfold(init=new_state, f))
     None => Nil
@@ -917,7 +921,7 @@ pub fn[A] take_while(self : T[A], p : (A) -> Bool) -> T[A] {
 ///   assert_eq(r, @list.of([3, 4]))
 /// }
 /// ```
-pub fn[A] drop_while(self : T[A], p : (A) -> Bool?Error) -> T[A]?Error {
+pub fn[A] drop_while(self : T[A], p : (A) -> Bool raise?) -> T[A] raise? {
   loop self {
     Nil => Nil
     Cons(x, xs) => if p(x) { continue xs } else { Cons(x, xs) }
@@ -938,9 +942,9 @@ pub fn[A] drop_while(self : T[A], p : (A) -> Bool?Error) -> T[A]?Error {
 /// ```
 pub fn[A, E] scan_left(
   self : T[A],
-  f : (E, A) -> E?Error,
+  f : (E, A) -> E raise?,
   init~ : E
-) -> T[E]?Error {
+) -> T[E] raise? {
   Cons(
     init,
     match self {
@@ -965,9 +969,9 @@ pub fn[A, E] scan_left(
 /// ```
 pub fn[A, B] scan_right(
   self : T[A],
-  f : (A, B) -> B?Error,
+  f : (A, B) -> B raise?,
   init~ : B
-) -> T[B]?Error {
+) -> T[B] raise? {
   match self {
     Nil => Cons(init, Nil)
     Cons(x, xs) => {
@@ -1006,7 +1010,7 @@ pub fn[A : Eq, B] lookup(self : T[(A, B)], v : A) -> B? {
 ///   assert_eq(@list.of([1, 3, 5]).find(fn(element) -> Bool { element % 2 == 0}), None)
 /// }
 /// ```
-pub fn[A] find(self : T[A], f : (A) -> Bool?Error) -> A??Error {
+pub fn[A] find(self : T[A], f : (A) -> Bool raise?) -> A? raise? {
   loop self {
     Nil => None
     Cons(element, list) =>
@@ -1029,7 +1033,7 @@ pub fn[A] find(self : T[A], f : (A) -> Bool?Error) -> A??Error {
 ///   assert_eq(@list.of([1, 3, 8, 5]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), None)
 /// }
 /// ```
-pub fn[A] findi(self : T[A], f : (A, Int) -> Bool?Error) -> A??Error {
+pub fn[A] findi(self : T[A], f : (A, Int) -> Bool raise?) -> A? raise? {
   loop (self, 0) {
     (list, index) =>
       match list {

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -97,7 +97,7 @@ pub fn[A] length(self : T[A]) -> Int {
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
+pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
   loop self {
     Nil => ()
     Cons(head, tail) => {
@@ -119,7 +119,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
 ///   assert_eq(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
 /// }
 /// ```
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit?Error) -> Unit?Error {
   loop (self, 0) {
     (Nil, _) => ()
     (Cons(x, xs), i) => {
@@ -148,8 +148,8 @@ pub fn[A, B] map(self : T[A], f : (A) -> B) -> T[B] {
 
 ///|
 /// Maps the list with index.
-pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B) -> T[B] {
-  fn go(xs : T[A], i : Int, f : (Int, A) -> B) -> T[B] {
+pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B?Error) -> T[B]?Error {
+  fn go(xs : T[A], i : Int, f : (Int, A) -> B?Error) -> T[B]?Error {
     match xs {
       Nil => Nil
       Cons(x, xs) => Cons(f(i, x), go(xs, i + 1, f))
@@ -170,7 +170,7 @@ pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B) -> T[B] {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).rev_map(fn(x) { x * 2 }), @list.of([10, 8, 6, 4, 2]))
 /// }
 /// ```
-pub fn[A, B] rev_map(self : T[A], f : (A) -> B) -> T[B] {
+pub fn[A, B] rev_map(self : T[A], f : (A) -> B?Error) -> T[B]?Error {
   loop (Nil, self) {
     (acc, Nil) => acc
     (acc, Cons(x, xs)) => continue (Cons(f(x), acc), xs)
@@ -206,7 +206,7 @@ pub fn[A] to_array(self : T[A]) -> Array[A] {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).filter(fn(x){ x % 2 == 0}), @list.of([2, 4]))
 /// }
 /// ```
-pub fn[A] filter(self : T[A], f : (A) -> Bool) -> T[A] {
+pub fn[A] filter(self : T[A], f : (A) -> Bool?Error) -> T[A]?Error {
   match self {
     Nil => Nil
     Cons(head, tail) =>
@@ -220,7 +220,7 @@ pub fn[A] filter(self : T[A], f : (A) -> Bool) -> T[A] {
 
 ///|
 /// Test if all elements of the list satisfy the predicate.
-pub fn[A] all(self : T[A], f : (A) -> Bool) -> Bool {
+pub fn[A] all(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
   loop self {
     Nil => true
     Cons(head, tail) => if f(head) { continue tail } else { false }
@@ -229,7 +229,7 @@ pub fn[A] all(self : T[A], f : (A) -> Bool) -> Bool {
 
 ///|
 /// Test if any element of the list satisfies the predicate.
-pub fn[A] any(self : T[A], f : (A) -> Bool) -> Bool {
+pub fn[A] any(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
   match self {
     Nil => false
     Cons(head, tail) => f(head) || tail.any(f)
@@ -376,7 +376,7 @@ pub fn[A] rev(self : T[A]) -> T[A] {
 ///   assert_eq(r, 15)
 /// }
 /// ```
-pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
+pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B?Error) -> B?Error {
   match self {
     Nil => init
     Cons(head, tail) => tail.fold(f, init=f(init, head))
@@ -393,7 +393,7 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 ///   assert_eq(r, 15)
 /// }
 /// ```
-pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (A, B) -> B) -> B {
+pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (A, B) -> B?Error) -> B?Error {
   let xs = self.to_array()
   let mut acc = init
   for x in xs.rev_iter() {
@@ -415,14 +415,22 @@ pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (A, B) -> B) -> B {
 /// ```
 #deprecated("Use `fold` instead")
 #coverage.skip
-pub fn[A, B] fold_left(self : T[A], f : (B, A) -> B, init~ : B) -> B {
+pub fn[A, B] fold_left(
+  self : T[A],
+  f : (B, A) -> B?Error,
+  init~ : B
+) -> B?Error {
   self.fold(init~, f)
 }
 
 ///|
 #deprecated("Use `rev_fold` instead")
 #coverage.skip
-pub fn[A, B] fold_right(self : T[A], f : (A, B) -> B, init~ : B) -> B {
+pub fn[A, B] fold_right(
+  self : T[A],
+  f : (A, B) -> B?Error,
+  init~ : B
+) -> B?Error {
   match self {
     Nil => init
     Cons(head, tail) => f(head, tail.rev_fold(f, init~))
@@ -431,8 +439,12 @@ pub fn[A, B] fold_right(self : T[A], f : (A, B) -> B, init~ : B) -> B {
 
 ///|
 /// Fold the list from left with index.
-pub fn[A, B] foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
-  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B, acc : B) -> B {
+pub fn[A, B] foldi(
+  self : T[A],
+  init~ : B,
+  f : (Int, B, A) -> B?Error
+) -> B?Error {
+  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B?Error, acc : B) -> B?Error {
     match xs {
       Nil => acc
       Cons(x, xs) => go(xs, i + 1, f, f(i, acc, x))
@@ -444,8 +456,12 @@ pub fn[A, B] foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
 
 ///|
 /// Fold the list from right with index.
-pub fn[A, B] rev_foldi(self : T[A], init~ : B, f : (Int, A, B) -> B) -> B {
-  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B, acc : B) -> B {
+pub fn[A, B] rev_foldi(
+  self : T[A],
+  init~ : B,
+  f : (Int, A, B) -> B?Error
+) -> B?Error {
+  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B?Error, acc : B) -> B?Error {
     match xs {
       Nil => acc
       Cons(x, xs) => f(i, x, go(xs, i + 1, f, acc))
@@ -459,8 +475,12 @@ pub fn[A, B] rev_foldi(self : T[A], init~ : B, f : (Int, A, B) -> B) -> B {
 /// Fold the list from left with index.
 #deprecated("Use `foldi` instead")
 #coverage.skip
-pub fn[A, B] fold_lefti(self : T[A], f : (Int, B, A) -> B, init~ : B) -> B {
-  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B, acc : B) -> B {
+pub fn[A, B] fold_lefti(
+  self : T[A],
+  f : (Int, B, A) -> B?Error,
+  init~ : B
+) -> B?Error {
+  fn go(xs : T[A], i : Int, f : (Int, B, A) -> B?Error, acc : B) -> B?Error {
     match xs {
       Nil => acc
       Cons(x, xs) => go(xs, i + 1, f, f(i, acc, x))
@@ -474,8 +494,12 @@ pub fn[A, B] fold_lefti(self : T[A], f : (Int, B, A) -> B, init~ : B) -> B {
 /// Fold the list from right with index.
 #deprecated("Use `rev_foldi` instead")
 #coverage.skip
-pub fn[A, B] fold_righti(self : T[A], f : (Int, A, B) -> B, init~ : B) -> B {
-  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B, acc : B) -> B {
+pub fn[A, B] fold_righti(
+  self : T[A],
+  f : (Int, A, B) -> B?Error,
+  init~ : B
+) -> B?Error {
+  fn go(xs : T[A], i : Int, f : (Int, A, B) -> B?Error, acc : B) -> B?Error {
     match xs {
       Nil => acc
       Cons(x, xs) => f(i, x, go(xs, i + 1, f, acc))
@@ -544,7 +568,7 @@ pub fn[A, B] concat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
 ///   assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// }
 /// ```
-pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
+pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B]?Error) -> T[B]?Error {
   match self {
     Nil => Nil
     Cons(head, tail) => f(head).concat(tail.flat_map(f))
@@ -801,7 +825,7 @@ pub fn[A : Eq] contains(self : T[A], value : A) -> Bool {
 ///   assert_eq(r, @list.from_array([0, 1, 2]))
 /// }
 /// ```
-pub fn[A, S] unfold(f : (S) -> (A, S)?, init~ : S) -> T[A] {
+pub fn[A, S] unfold(f : (S) -> (A, S)??Error, init~ : S) -> T[A]?Error {
   match f(init) {
     Some((element, new_state)) => Cons(element, unfold(init=new_state, f))
     None => Nil
@@ -893,7 +917,7 @@ pub fn[A] take_while(self : T[A], p : (A) -> Bool) -> T[A] {
 ///   assert_eq(r, @list.of([3, 4]))
 /// }
 /// ```
-pub fn[A] drop_while(self : T[A], p : (A) -> Bool) -> T[A] {
+pub fn[A] drop_while(self : T[A], p : (A) -> Bool?Error) -> T[A]?Error {
   loop self {
     Nil => Nil
     Cons(x, xs) => if p(x) { continue xs } else { Cons(x, xs) }
@@ -912,7 +936,11 @@ pub fn[A] drop_while(self : T[A], p : (A) -> Bool) -> T[A] {
 ///   assert_eq(r, @list.of([0, 1, 3, 6, 10, 15]))
 /// }
 /// ```
-pub fn[A, E] scan_left(self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
+pub fn[A, E] scan_left(
+  self : T[A],
+  f : (E, A) -> E?Error,
+  init~ : E
+) -> T[E]?Error {
   Cons(
     init,
     match self {
@@ -935,7 +963,11 @@ pub fn[A, E] scan_left(self : T[A], f : (E, A) -> E, init~ : E) -> T[E] {
 ///   assert_eq(r, @list.of([15, 14, 12, 9, 5, 0]))
 /// }
 /// ```
-pub fn[A, B] scan_right(self : T[A], f : (A, B) -> B, init~ : B) -> T[B] {
+pub fn[A, B] scan_right(
+  self : T[A],
+  f : (A, B) -> B?Error,
+  init~ : B
+) -> T[B]?Error {
   match self {
     Nil => Cons(init, Nil)
     Cons(x, xs) => {
@@ -974,7 +1006,7 @@ pub fn[A : Eq, B] lookup(self : T[(A, B)], v : A) -> B? {
 ///   assert_eq(@list.of([1, 3, 5]).find(fn(element) -> Bool { element % 2 == 0}), None)
 /// }
 /// ```
-pub fn[A] find(self : T[A], f : (A) -> Bool) -> A? {
+pub fn[A] find(self : T[A], f : (A) -> Bool?Error) -> A??Error {
   loop self {
     Nil => None
     Cons(element, list) =>
@@ -997,7 +1029,7 @@ pub fn[A] find(self : T[A], f : (A) -> Bool) -> A? {
 ///   assert_eq(@list.of([1, 3, 8, 5]).findi(fn(element, index) -> Bool { (element % 2 == 0) && (index == 3) }), None)
 /// }
 /// ```
-pub fn[A] findi(self : T[A], f : (A, Int) -> Bool) -> A? {
+pub fn[A] findi(self : T[A], f : (A, Int) -> Bool?Error) -> A??Error {
   loop (self, 0) {
     (list, index) =>
       match list {

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -8,9 +8,9 @@ import(
 // Values
 fn[A] add(T[A], A) -> T[A]
 
-fn[A] all(T[A], (A) -> Bool?Error) -> Bool?Error
+fn[A] all(T[A], (A) -> Bool raise?) -> Bool raise?
 
-fn[A] any(T[A], (A) -> Bool?Error) -> Bool?Error
+fn[A] any(T[A], (A) -> Bool raise?) -> Bool raise?
 
 fn[A] concat(T[A], T[A]) -> T[A]
 
@@ -23,42 +23,42 @@ fn[X] default() -> T[X]
 
 fn[A] drop(T[A], Int) -> T[A]
 
-fn[A] drop_while(T[A], (A) -> Bool?Error) -> T[A]?Error
+fn[A] drop_while(T[A], (A) -> Bool raise?) -> T[A] raise?
 
-fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
+fn[A] each(T[A], (A) -> Unit raise?) -> Unit raise?
 
-fn[A] eachi(T[A], (Int, A) -> Unit?Error) -> Unit?Error
+fn[A] eachi(T[A], (Int, A) -> Unit raise?) -> Unit raise?
 
 #deprecated
 fn[A : Eq] equal(T[A], T[A]) -> Bool
 
-fn[A] filter(T[A], (A) -> Bool?Error) -> T[A]?Error
+fn[A] filter(T[A], (A) -> Bool raise?) -> T[A] raise?
 
-fn[A, B] filter_map(T[A], (A) -> B??Error) -> T[B]?Error
+fn[A, B] filter_map(T[A], (A) -> B?) -> T[B]
 
-fn[A] find(T[A], (A) -> Bool?Error) -> A??Error
+fn[A] find(T[A], (A) -> Bool raise?) -> A? raise?
 
-fn[A] findi(T[A], (A, Int) -> Bool?Error) -> A??Error
+fn[A] findi(T[A], (A, Int) -> Bool raise?) -> A? raise?
 
-fn[A, B] flat_map(T[A], (A) -> T[B]?Error) -> T[B]?Error
+fn[A, B] flat_map(T[A], (A) -> T[B] raise?) -> T[B] raise?
 
 fn[A] flatten(T[T[A]]) -> T[A]
 
-fn[A, B] fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A, B] fold(T[A], init~ : B, (B, A) -> B raise?) -> B raise?
 
 #deprecated
-fn[A, B] fold_left(T[A], (B, A) -> B?Error, init~ : B) -> B?Error
+fn[A, B] fold_left(T[A], (B, A) -> B raise?, init~ : B) -> B raise?
 
 #deprecated
-fn[A, B] fold_lefti(T[A], (Int, B, A) -> B?Error, init~ : B) -> B?Error
+fn[A, B] fold_lefti(T[A], (Int, B, A) -> B raise?, init~ : B) -> B raise?
 
 #deprecated
-fn[A, B] fold_right(T[A], (A, B) -> B?Error, init~ : B) -> B?Error
+fn[A, B] fold_right(T[A], (A, B) -> B raise?, init~ : B) -> B raise?
 
 #deprecated
-fn[A, B] fold_righti(T[A], (Int, A, B) -> B?Error, init~ : B) -> B?Error
+fn[A, B] fold_righti(T[A], (Int, A, B) -> B raise?, init~ : B) -> B raise?
 
-fn[A, B] foldi(T[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[A, B] foldi(T[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 
 fn[A] from_array(Array[A]) -> T[A]
 
@@ -96,9 +96,9 @@ fn[A] length(T[A]) -> Int
 
 fn[A : Eq, B] lookup(T[(A, B)], A) -> B?
 
-fn[A, B] map(T[A], (A) -> B?Error) -> T[B]?Error
+fn[A, B] map(T[A], (A) -> B) -> T[B]
 
-fn[A, B] mapi(T[A], (Int, A) -> B?Error) -> T[B]?Error
+fn[A, B] mapi(T[A], (Int, A) -> B raise?) -> T[B] raise?
 
 fn[A : Compare] maximum(T[A]) -> A?
 
@@ -121,15 +121,15 @@ fn[A] rev(T[A]) -> T[A]
 
 fn[A] rev_concat(T[A], T[A]) -> T[A]
 
-fn[A, B] rev_fold(T[A], init~ : B, (A, B) -> B?Error) -> B?Error
+fn[A, B] rev_fold(T[A], init~ : B, (A, B) -> B raise?) -> B raise?
 
-fn[A, B] rev_foldi(T[A], init~ : B, (Int, A, B) -> B?Error) -> B?Error
+fn[A, B] rev_foldi(T[A], init~ : B, (Int, A, B) -> B raise?) -> B raise?
 
-fn[A, B] rev_map(T[A], (A) -> B?Error) -> T[B]?Error
+fn[A, B] rev_map(T[A], (A) -> B raise?) -> T[B] raise?
 
-fn[A, E] scan_left(T[A], (E, A) -> E?Error, init~ : E) -> T[E]?Error
+fn[A, E] scan_left(T[A], (E, A) -> E raise?, init~ : E) -> T[E] raise?
 
-fn[A, B] scan_right(T[A], (A, B) -> B?Error, init~ : B) -> T[B]?Error
+fn[A, B] scan_right(T[A], (A, B) -> B raise?, init~ : B) -> T[B] raise?
 
 fn[A] singleton(A) -> T[A]
 
@@ -145,7 +145,7 @@ fn[A] to_array(T[A]) -> Array[A]
 
 fn[A : ToJson] to_json(T[A]) -> Json
 
-fn[A, S] unfold((S) -> (A, S)??Error, init~ : S) -> T[A]?Error
+fn[A, S] unfold((S) -> (A, S)? raise?, init~ : S) -> T[A] raise?
 
 fn[A] unsafe_head(T[A]) -> A
 
@@ -167,8 +167,8 @@ pub(all) enum T[A] {
   Cons(A, T[A])
 }
 fn[A] T::add(Self[A], A) -> Self[A]
-fn[A] T::all(Self[A], (A) -> Bool?Error) -> Bool?Error
-fn[A] T::any(Self[A], (A) -> Bool?Error) -> Bool?Error
+fn[A] T::all(Self[A], (A) -> Bool raise?) -> Bool raise?
+fn[A] T::any(Self[A], (A) -> Bool raise?) -> Bool raise?
 fn[A] T::concat(Self[A], Self[A]) -> Self[A]
 #deprecated
 fn[A, B] T::concat_map(Self[A], (A) -> Self[B]) -> Self[B]
@@ -176,27 +176,27 @@ fn[A : Eq] T::contains(Self[A], A) -> Bool
 #deprecated
 fn[X] T::default() -> Self[X]
 fn[A] T::drop(Self[A], Int) -> Self[A]
-fn[A] T::drop_while(Self[A], (A) -> Bool?Error) -> Self[A]?Error
-fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
-fn[A] T::eachi(Self[A], (Int, A) -> Unit?Error) -> Unit?Error
+fn[A] T::drop_while(Self[A], (A) -> Bool raise?) -> Self[A] raise?
+fn[A] T::each(Self[A], (A) -> Unit raise?) -> Unit raise?
+fn[A] T::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
 #deprecated
 fn[A : Eq] T::equal(Self[A], Self[A]) -> Bool
-fn[A] T::filter(Self[A], (A) -> Bool?Error) -> Self[A]?Error
-fn[A, B] T::filter_map(Self[A], (A) -> B??Error) -> Self[B]?Error
-fn[A] T::find(Self[A], (A) -> Bool?Error) -> A??Error
-fn[A] T::findi(Self[A], (A, Int) -> Bool?Error) -> A??Error
-fn[A, B] T::flat_map(Self[A], (A) -> Self[B]?Error) -> Self[B]?Error
+fn[A] T::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
+fn[A, B] T::filter_map(Self[A], (A) -> B?) -> Self[B]
+fn[A] T::find(Self[A], (A) -> Bool raise?) -> A? raise?
+fn[A] T::findi(Self[A], (A, Int) -> Bool raise?) -> A? raise?
+fn[A, B] T::flat_map(Self[A], (A) -> Self[B] raise?) -> Self[B] raise?
 fn[A] T::flatten(Self[Self[A]]) -> Self[A]
-fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 #deprecated
-fn[A, B] T::fold_left(Self[A], (B, A) -> B?Error, init~ : B) -> B?Error
+fn[A, B] T::fold_left(Self[A], (B, A) -> B raise?, init~ : B) -> B raise?
 #deprecated
-fn[A, B] T::fold_lefti(Self[A], (Int, B, A) -> B?Error, init~ : B) -> B?Error
+fn[A, B] T::fold_lefti(Self[A], (Int, B, A) -> B raise?, init~ : B) -> B raise?
 #deprecated
-fn[A, B] T::fold_right(Self[A], (A, B) -> B?Error, init~ : B) -> B?Error
+fn[A, B] T::fold_right(Self[A], (A, B) -> B raise?, init~ : B) -> B raise?
 #deprecated
-fn[A, B] T::fold_righti(Self[A], (Int, A, B) -> B?Error, init~ : B) -> B?Error
-fn[A, B] T::foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[A, B] T::fold_righti(Self[A], (Int, A, B) -> B raise?, init~ : B) -> B raise?
+fn[A, B] T::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 #deprecated
 fn[A] T::from_array(Array[A]) -> Self[A]
 #deprecated
@@ -218,8 +218,8 @@ fn[A] T::iter2(Self[A]) -> Iter2[Int, A]
 fn[A] T::last(Self[A]) -> A?
 fn[A] T::length(Self[A]) -> Int
 fn[A : Eq, B] T::lookup(Self[(A, B)], A) -> B?
-fn[A, B] T::map(Self[A], (A) -> B?Error) -> Self[B]?Error
-fn[A, B] T::mapi(Self[A], (Int, A) -> B?Error) -> Self[B]?Error
+fn[A, B] T::map(Self[A], (A) -> B) -> Self[B]
+fn[A, B] T::mapi(Self[A], (Int, A) -> B raise?) -> Self[B] raise?
 fn[A : Compare] T::maximum(Self[A]) -> A?
 fn[A : Compare] T::minimum(Self[A]) -> A?
 fn[A] T::nth(Self[A], Int) -> A?
@@ -231,11 +231,11 @@ fn[A : Eq] T::remove(Self[A], A) -> Self[A]
 fn[A] T::remove_at(Self[A], Int) -> Self[A]
 fn[A] T::rev(Self[A]) -> Self[A]
 fn[A] T::rev_concat(Self[A], Self[A]) -> Self[A]
-fn[A, B] T::rev_fold(Self[A], init~ : B, (A, B) -> B?Error) -> B?Error
-fn[A, B] T::rev_foldi(Self[A], init~ : B, (Int, A, B) -> B?Error) -> B?Error
-fn[A, B] T::rev_map(Self[A], (A) -> B?Error) -> Self[B]?Error
-fn[A, E] T::scan_left(Self[A], (E, A) -> E?Error, init~ : E) -> Self[E]?Error
-fn[A, B] T::scan_right(Self[A], (A, B) -> B?Error, init~ : B) -> Self[B]?Error
+fn[A, B] T::rev_fold(Self[A], init~ : B, (A, B) -> B raise?) -> B raise?
+fn[A, B] T::rev_foldi(Self[A], init~ : B, (Int, A, B) -> B raise?) -> B raise?
+fn[A, B] T::rev_map(Self[A], (A) -> B raise?) -> Self[B] raise?
+fn[A, E] T::scan_left(Self[A], (E, A) -> E raise?, init~ : E) -> Self[E] raise?
+fn[A, B] T::scan_right(Self[A], (A, B) -> B raise?, init~ : B) -> Self[B] raise?
 fn[A : Compare] T::sort(Self[A]) -> Self[A]
 fn[A] T::tail(Self[A]) -> Self[A]
 fn[A] T::take(Self[A], Int) -> Self[A]

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -8,9 +8,9 @@ import(
 // Values
 fn[A] add(T[A], A) -> T[A]
 
-fn[A] all(T[A], (A) -> Bool) -> Bool
+fn[A] all(T[A], (A) -> Bool?Error) -> Bool?Error
 
-fn[A] any(T[A], (A) -> Bool) -> Bool
+fn[A] any(T[A], (A) -> Bool?Error) -> Bool?Error
 
 fn[A] concat(T[A], T[A]) -> T[A]
 
@@ -23,42 +23,42 @@ fn[X] default() -> T[X]
 
 fn[A] drop(T[A], Int) -> T[A]
 
-fn[A] drop_while(T[A], (A) -> Bool) -> T[A]
+fn[A] drop_while(T[A], (A) -> Bool?Error) -> T[A]?Error
 
-fn[A] each(T[A], (A) -> Unit) -> Unit
+fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
 
-fn[A] eachi(T[A], (Int, A) -> Unit) -> Unit
+fn[A] eachi(T[A], (Int, A) -> Unit?Error) -> Unit?Error
 
 #deprecated
 fn[A : Eq] equal(T[A], T[A]) -> Bool
 
-fn[A] filter(T[A], (A) -> Bool) -> T[A]
+fn[A] filter(T[A], (A) -> Bool?Error) -> T[A]?Error
 
-fn[A, B] filter_map(T[A], (A) -> B?) -> T[B]
+fn[A, B] filter_map(T[A], (A) -> B??Error) -> T[B]?Error
 
-fn[A] find(T[A], (A) -> Bool) -> A?
+fn[A] find(T[A], (A) -> Bool?Error) -> A??Error
 
-fn[A] findi(T[A], (A, Int) -> Bool) -> A?
+fn[A] findi(T[A], (A, Int) -> Bool?Error) -> A??Error
 
-fn[A, B] flat_map(T[A], (A) -> T[B]) -> T[B]
+fn[A, B] flat_map(T[A], (A) -> T[B]?Error) -> T[B]?Error
 
 fn[A] flatten(T[T[A]]) -> T[A]
 
-fn[A, B] fold(T[A], init~ : B, (B, A) -> B) -> B
+fn[A, B] fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
 
 #deprecated
-fn[A, B] fold_left(T[A], (B, A) -> B, init~ : B) -> B
+fn[A, B] fold_left(T[A], (B, A) -> B?Error, init~ : B) -> B?Error
 
 #deprecated
-fn[A, B] fold_lefti(T[A], (Int, B, A) -> B, init~ : B) -> B
+fn[A, B] fold_lefti(T[A], (Int, B, A) -> B?Error, init~ : B) -> B?Error
 
 #deprecated
-fn[A, B] fold_right(T[A], (A, B) -> B, init~ : B) -> B
+fn[A, B] fold_right(T[A], (A, B) -> B?Error, init~ : B) -> B?Error
 
 #deprecated
-fn[A, B] fold_righti(T[A], (Int, A, B) -> B, init~ : B) -> B
+fn[A, B] fold_righti(T[A], (Int, A, B) -> B?Error, init~ : B) -> B?Error
 
-fn[A, B] foldi(T[A], init~ : B, (Int, B, A) -> B) -> B
+fn[A, B] foldi(T[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
 
 fn[A] from_array(Array[A]) -> T[A]
 
@@ -96,9 +96,9 @@ fn[A] length(T[A]) -> Int
 
 fn[A : Eq, B] lookup(T[(A, B)], A) -> B?
 
-fn[A, B] map(T[A], (A) -> B) -> T[B]
+fn[A, B] map(T[A], (A) -> B?Error) -> T[B]?Error
 
-fn[A, B] mapi(T[A], (Int, A) -> B) -> T[B]
+fn[A, B] mapi(T[A], (Int, A) -> B?Error) -> T[B]?Error
 
 fn[A : Compare] maximum(T[A]) -> A?
 
@@ -121,15 +121,15 @@ fn[A] rev(T[A]) -> T[A]
 
 fn[A] rev_concat(T[A], T[A]) -> T[A]
 
-fn[A, B] rev_fold(T[A], init~ : B, (A, B) -> B) -> B
+fn[A, B] rev_fold(T[A], init~ : B, (A, B) -> B?Error) -> B?Error
 
-fn[A, B] rev_foldi(T[A], init~ : B, (Int, A, B) -> B) -> B
+fn[A, B] rev_foldi(T[A], init~ : B, (Int, A, B) -> B?Error) -> B?Error
 
-fn[A, B] rev_map(T[A], (A) -> B) -> T[B]
+fn[A, B] rev_map(T[A], (A) -> B?Error) -> T[B]?Error
 
-fn[A, E] scan_left(T[A], (E, A) -> E, init~ : E) -> T[E]
+fn[A, E] scan_left(T[A], (E, A) -> E?Error, init~ : E) -> T[E]?Error
 
-fn[A, B] scan_right(T[A], (A, B) -> B, init~ : B) -> T[B]
+fn[A, B] scan_right(T[A], (A, B) -> B?Error, init~ : B) -> T[B]?Error
 
 fn[A] singleton(A) -> T[A]
 
@@ -145,7 +145,7 @@ fn[A] to_array(T[A]) -> Array[A]
 
 fn[A : ToJson] to_json(T[A]) -> Json
 
-fn[A, S] unfold((S) -> (A, S)?, init~ : S) -> T[A]
+fn[A, S] unfold((S) -> (A, S)??Error, init~ : S) -> T[A]?Error
 
 fn[A] unsafe_head(T[A]) -> A
 
@@ -167,8 +167,8 @@ pub(all) enum T[A] {
   Cons(A, T[A])
 }
 fn[A] T::add(Self[A], A) -> Self[A]
-fn[A] T::all(Self[A], (A) -> Bool) -> Bool
-fn[A] T::any(Self[A], (A) -> Bool) -> Bool
+fn[A] T::all(Self[A], (A) -> Bool?Error) -> Bool?Error
+fn[A] T::any(Self[A], (A) -> Bool?Error) -> Bool?Error
 fn[A] T::concat(Self[A], Self[A]) -> Self[A]
 #deprecated
 fn[A, B] T::concat_map(Self[A], (A) -> Self[B]) -> Self[B]
@@ -176,27 +176,27 @@ fn[A : Eq] T::contains(Self[A], A) -> Bool
 #deprecated
 fn[X] T::default() -> Self[X]
 fn[A] T::drop(Self[A], Int) -> Self[A]
-fn[A] T::drop_while(Self[A], (A) -> Bool) -> Self[A]
-fn[A] T::each(Self[A], (A) -> Unit) -> Unit
-fn[A] T::eachi(Self[A], (Int, A) -> Unit) -> Unit
+fn[A] T::drop_while(Self[A], (A) -> Bool?Error) -> Self[A]?Error
+fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
+fn[A] T::eachi(Self[A], (Int, A) -> Unit?Error) -> Unit?Error
 #deprecated
 fn[A : Eq] T::equal(Self[A], Self[A]) -> Bool
-fn[A] T::filter(Self[A], (A) -> Bool) -> Self[A]
-fn[A, B] T::filter_map(Self[A], (A) -> B?) -> Self[B]
-fn[A] T::find(Self[A], (A) -> Bool) -> A?
-fn[A] T::findi(Self[A], (A, Int) -> Bool) -> A?
-fn[A, B] T::flat_map(Self[A], (A) -> Self[B]) -> Self[B]
+fn[A] T::filter(Self[A], (A) -> Bool?Error) -> Self[A]?Error
+fn[A, B] T::filter_map(Self[A], (A) -> B??Error) -> Self[B]?Error
+fn[A] T::find(Self[A], (A) -> Bool?Error) -> A??Error
+fn[A] T::findi(Self[A], (A, Int) -> Bool?Error) -> A??Error
+fn[A, B] T::flat_map(Self[A], (A) -> Self[B]?Error) -> Self[B]?Error
 fn[A] T::flatten(Self[Self[A]]) -> Self[A]
-fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B) -> B
+fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
 #deprecated
-fn[A, B] T::fold_left(Self[A], (B, A) -> B, init~ : B) -> B
+fn[A, B] T::fold_left(Self[A], (B, A) -> B?Error, init~ : B) -> B?Error
 #deprecated
-fn[A, B] T::fold_lefti(Self[A], (Int, B, A) -> B, init~ : B) -> B
+fn[A, B] T::fold_lefti(Self[A], (Int, B, A) -> B?Error, init~ : B) -> B?Error
 #deprecated
-fn[A, B] T::fold_right(Self[A], (A, B) -> B, init~ : B) -> B
+fn[A, B] T::fold_right(Self[A], (A, B) -> B?Error, init~ : B) -> B?Error
 #deprecated
-fn[A, B] T::fold_righti(Self[A], (Int, A, B) -> B, init~ : B) -> B
-fn[A, B] T::foldi(Self[A], init~ : B, (Int, B, A) -> B) -> B
+fn[A, B] T::fold_righti(Self[A], (Int, A, B) -> B?Error, init~ : B) -> B?Error
+fn[A, B] T::foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
 #deprecated
 fn[A] T::from_array(Array[A]) -> Self[A]
 #deprecated
@@ -218,8 +218,8 @@ fn[A] T::iter2(Self[A]) -> Iter2[Int, A]
 fn[A] T::last(Self[A]) -> A?
 fn[A] T::length(Self[A]) -> Int
 fn[A : Eq, B] T::lookup(Self[(A, B)], A) -> B?
-fn[A, B] T::map(Self[A], (A) -> B) -> Self[B]
-fn[A, B] T::mapi(Self[A], (Int, A) -> B) -> Self[B]
+fn[A, B] T::map(Self[A], (A) -> B?Error) -> Self[B]?Error
+fn[A, B] T::mapi(Self[A], (Int, A) -> B?Error) -> Self[B]?Error
 fn[A : Compare] T::maximum(Self[A]) -> A?
 fn[A : Compare] T::minimum(Self[A]) -> A?
 fn[A] T::nth(Self[A], Int) -> A?
@@ -231,11 +231,11 @@ fn[A : Eq] T::remove(Self[A], A) -> Self[A]
 fn[A] T::remove_at(Self[A], Int) -> Self[A]
 fn[A] T::rev(Self[A]) -> Self[A]
 fn[A] T::rev_concat(Self[A], Self[A]) -> Self[A]
-fn[A, B] T::rev_fold(Self[A], init~ : B, (A, B) -> B) -> B
-fn[A, B] T::rev_foldi(Self[A], init~ : B, (Int, A, B) -> B) -> B
-fn[A, B] T::rev_map(Self[A], (A) -> B) -> Self[B]
-fn[A, E] T::scan_left(Self[A], (E, A) -> E, init~ : E) -> Self[E]
-fn[A, B] T::scan_right(Self[A], (A, B) -> B, init~ : B) -> Self[B]
+fn[A, B] T::rev_fold(Self[A], init~ : B, (A, B) -> B?Error) -> B?Error
+fn[A, B] T::rev_foldi(Self[A], init~ : B, (Int, A, B) -> B?Error) -> B?Error
+fn[A, B] T::rev_map(Self[A], (A) -> B?Error) -> Self[B]?Error
+fn[A, E] T::scan_left(Self[A], (E, A) -> E?Error, init~ : E) -> Self[E]?Error
+fn[A, B] T::scan_right(Self[A], (A, B) -> B?Error, init~ : B) -> Self[B]?Error
 fn[A : Compare] T::sort(Self[A]) -> Self[A]
 fn[A] T::tail(Self[A]) -> Self[A]
 fn[A] T::take(Self[A], Int) -> Self[A]

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -93,7 +93,10 @@ pub fn[K : Compare, V] remove(self : T[K, V], key : K) -> T[K, V] {
 
 ///|
 /// Filter values that satisfy the predicate
-pub fn[K : Compare, V] filter(self : T[K, V], pred : (V) -> Bool) -> T[K, V] {
+pub fn[K : Compare, V] filter(
+  self : T[K, V],
+  pred : (V) -> Bool?Error
+) -> T[K, V]?Error {
   self.filter_with_key(fn(_k, v) { pred(v) })
 }
 
@@ -101,8 +104,8 @@ pub fn[K : Compare, V] filter(self : T[K, V], pred : (V) -> Bool) -> T[K, V] {
 /// Filter key-value pairs that satisfy the predicate
 pub fn[K : Compare, V] filter_with_key(
   self : T[K, V],
-  pred : (K, V) -> Bool
-) -> T[K, V] {
+  pred : (K, V) -> Bool?Error
+) -> T[K, V]?Error {
   match self {
     Empty => Empty
     Tree(k, value=v, l, r, ..) =>

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -95,8 +95,8 @@ pub fn[K : Compare, V] remove(self : T[K, V], key : K) -> T[K, V] {
 /// Filter values that satisfy the predicate
 pub fn[K : Compare, V] filter(
   self : T[K, V],
-  pred : (V) -> Bool?Error
-) -> T[K, V]?Error {
+  pred : (V) -> Bool raise?
+) -> T[K, V] raise? {
   self.filter_with_key(fn(_k, v) { pred(v) })
 }
 
@@ -104,8 +104,8 @@ pub fn[K : Compare, V] filter(
 /// Filter key-value pairs that satisfy the predicate
 pub fn[K : Compare, V] filter_with_key(
   self : T[K, V],
-  pred : (K, V) -> Bool?Error
-) -> T[K, V]?Error {
+  pred : (K, V) -> Bool raise?
+) -> T[K, V] raise? {
   match self {
     Empty => Empty
     Tree(k, value=v, l, r, ..) =>

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -17,9 +17,9 @@ fn[K, V] eachi(T[K, V], (Int, K, V) -> Unit) -> Unit
 #deprecated
 fn[K, V] elems(T[K, V]) -> Array[V]
 
-fn[K : Compare, V] filter(T[K, V], (V) -> Bool) -> T[K, V]
+fn[K : Compare, V] filter(T[K, V], (V) -> Bool?Error) -> T[K, V]?Error
 
-fn[K : Compare, V] filter_with_key(T[K, V], (K, V) -> Bool) -> T[K, V]
+fn[K : Compare, V] filter_with_key(T[K, V], (K, V) -> Bool?Error) -> T[K, V]?Error
 
 fn[K, V, A] fold(T[K, V], init~ : A, (A, V) -> A) -> A
 
@@ -82,8 +82,8 @@ fn[K, V] T::eachi(Self[K, V], (Int, K, V) -> Unit) -> Unit
 fn[K, V] T::elems(Self[K, V]) -> Array[V]
 #deprecated
 fn[K, V] T::empty() -> Self[K, V]
-fn[K : Compare, V] T::filter(Self[K, V], (V) -> Bool) -> Self[K, V]
-fn[K : Compare, V] T::filter_with_key(Self[K, V], (K, V) -> Bool) -> Self[K, V]
+fn[K : Compare, V] T::filter(Self[K, V], (V) -> Bool?Error) -> Self[K, V]?Error
+fn[K : Compare, V] T::filter_with_key(Self[K, V], (K, V) -> Bool?Error) -> Self[K, V]?Error
 fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A) -> A
 fn[K, V, A] T::foldl_with_key(Self[K, V], (A, K, V) -> A, init~ : A) -> A
 fn[K, V, A] T::foldr_with_key(Self[K, V], (A, K, V) -> A, init~ : A) -> A

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -17,9 +17,9 @@ fn[K, V] eachi(T[K, V], (Int, K, V) -> Unit) -> Unit
 #deprecated
 fn[K, V] elems(T[K, V]) -> Array[V]
 
-fn[K : Compare, V] filter(T[K, V], (V) -> Bool?Error) -> T[K, V]?Error
+fn[K : Compare, V] filter(T[K, V], (V) -> Bool raise?) -> T[K, V] raise?
 
-fn[K : Compare, V] filter_with_key(T[K, V], (K, V) -> Bool?Error) -> T[K, V]?Error
+fn[K : Compare, V] filter_with_key(T[K, V], (K, V) -> Bool raise?) -> T[K, V] raise?
 
 fn[K, V, A] fold(T[K, V], init~ : A, (A, V) -> A) -> A
 
@@ -82,8 +82,8 @@ fn[K, V] T::eachi(Self[K, V], (Int, K, V) -> Unit) -> Unit
 fn[K, V] T::elems(Self[K, V]) -> Array[V]
 #deprecated
 fn[K, V] T::empty() -> Self[K, V]
-fn[K : Compare, V] T::filter(Self[K, V], (V) -> Bool?Error) -> Self[K, V]?Error
-fn[K : Compare, V] T::filter_with_key(Self[K, V], (K, V) -> Bool?Error) -> Self[K, V]?Error
+fn[K : Compare, V] T::filter(Self[K, V], (V) -> Bool raise?) -> Self[K, V] raise?
+fn[K : Compare, V] T::filter_with_key(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
 fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A) -> A
 fn[K, V, A] T::foldl_with_key(Self[K, V], (A, K, V) -> A, init~ : A) -> A
 fn[K, V, A] T::foldr_with_key(Self[K, V], (A, K, V) -> A, init~ : A) -> A

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -496,7 +496,7 @@ pub fn[A : Compare] disjoint(self : T[A], other : T[A]) -> Bool {
 ///   assert_eq(arr, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 /// }
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
+pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
   match self {
     Empty => ()
     Node(left~, value~, right~, ..) => {
@@ -520,8 +520,8 @@ pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
 pub fn[A : Compare, B] fold(
   self : T[A],
   init~ : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   match self {
     Empty => init
     Node(left~, value~, right~, ..) =>
@@ -541,8 +541,8 @@ pub fn[A : Compare, B] fold(
 /// ```
 pub fn[A : Compare, B : Compare] map(
   self : T[A],
-  f : (A) -> B?Error
-) -> T[B]?Error {
+  f : (A) -> B raise?
+) -> T[B] raise? {
   match self {
     Empty => Empty
     Node(left~, value~, right~, ..) =>
@@ -560,7 +560,7 @@ pub fn[A : Compare, B : Compare] map(
 ///   assert_eq(@sorted_set.of([2, 4, 6]).all(fn(v) { v % 2 == 0}), true)
 /// }
 /// ```
-pub fn[A : Compare] all(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
+pub fn[A : Compare] all(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
   match self {
     Empty => true
     Node(left~, value~, right~, ..) => f(value) && left.all(f) && right.all(f)
@@ -577,7 +577,7 @@ pub fn[A : Compare] all(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
 ///   assert_eq(@sorted_set.of([1, 4, 3]).any(fn(v) { v % 2 == 0}), true)
 /// }
 /// ```
-pub fn[A : Compare] any(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
+pub fn[A : Compare] any(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
   match self {
     Empty => false
     Node(left~, value~, right~, ..) => f(value) || left.any(f) || right.any(f)
@@ -594,7 +594,7 @@ pub fn[A : Compare] any(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
 ///   assert_eq(@sorted_set.of([1, 2, 3, 4, 5, 6]).filter(fn(v) { v % 2 == 0}), @sorted_set.of([2, 4, 6]))
 /// }
 /// ```
-pub fn[A : Compare] filter(self : T[A], f : (A) -> Bool?Error) -> T[A]?Error {
+pub fn[A : Compare] filter(self : T[A], f : (A) -> Bool raise?) -> T[A] raise? {
   match self {
     Empty => Empty
     Node(left~, value~, right~, ..) => {

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -496,7 +496,7 @@ pub fn[A : Compare] disjoint(self : T[A], other : T[A]) -> Bool {
 ///   assert_eq(arr, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 /// }
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
+pub fn[A] each(self : T[A], f : (A) -> Unit?Error) -> Unit?Error {
   match self {
     Empty => ()
     Node(left~, value~, right~, ..) => {
@@ -517,7 +517,11 @@ pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
 ///   assert_eq(@sorted_set.of([1, 2, 3, 4, 5]).fold(init=0, fn(acc, x) { acc + x }), 15)
 /// }
 /// ```
-pub fn[A : Compare, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
+pub fn[A : Compare, B] fold(
+  self : T[A],
+  init~ : B,
+  f : (B, A) -> B?Error
+) -> B?Error {
   match self {
     Empty => init
     Node(left~, value~, right~, ..) =>
@@ -535,7 +539,10 @@ pub fn[A : Compare, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 ///   assert_eq(@sorted_set.of([1, 2, 3]).map(fn(x){ x * 2}), @sorted_set.of([2, 4, 6]))
 /// }
 /// ```
-pub fn[A : Compare, B : Compare] map(self : T[A], f : (A) -> B) -> T[B] {
+pub fn[A : Compare, B : Compare] map(
+  self : T[A],
+  f : (A) -> B?Error
+) -> T[B]?Error {
   match self {
     Empty => Empty
     Node(left~, value~, right~, ..) =>
@@ -553,7 +560,7 @@ pub fn[A : Compare, B : Compare] map(self : T[A], f : (A) -> B) -> T[B] {
 ///   assert_eq(@sorted_set.of([2, 4, 6]).all(fn(v) { v % 2 == 0}), true)
 /// }
 /// ```
-pub fn[A : Compare] all(self : T[A], f : (A) -> Bool) -> Bool {
+pub fn[A : Compare] all(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
   match self {
     Empty => true
     Node(left~, value~, right~, ..) => f(value) && left.all(f) && right.all(f)
@@ -570,7 +577,7 @@ pub fn[A : Compare] all(self : T[A], f : (A) -> Bool) -> Bool {
 ///   assert_eq(@sorted_set.of([1, 4, 3]).any(fn(v) { v % 2 == 0}), true)
 /// }
 /// ```
-pub fn[A : Compare] any(self : T[A], f : (A) -> Bool) -> Bool {
+pub fn[A : Compare] any(self : T[A], f : (A) -> Bool?Error) -> Bool?Error {
   match self {
     Empty => false
     Node(left~, value~, right~, ..) => f(value) || left.any(f) || right.any(f)
@@ -587,7 +594,7 @@ pub fn[A : Compare] any(self : T[A], f : (A) -> Bool) -> Bool {
 ///   assert_eq(@sorted_set.of([1, 2, 3, 4, 5, 6]).filter(fn(v) { v % 2 == 0}), @sorted_set.of([2, 4, 6]))
 /// }
 /// ```
-pub fn[A : Compare] filter(self : T[A], f : (A) -> Bool) -> T[A] {
+pub fn[A : Compare] filter(self : T[A], f : (A) -> Bool?Error) -> T[A]?Error {
   match self {
     Empty => Empty
     Node(left~, value~, right~, ..) => {

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -8,9 +8,9 @@ import(
 // Values
 fn[A : Compare] add(T[A], A) -> T[A]
 
-fn[A : Compare] all(T[A], (A) -> Bool) -> Bool
+fn[A : Compare] all(T[A], (A) -> Bool?Error) -> Bool?Error
 
-fn[A : Compare] any(T[A], (A) -> Bool) -> Bool
+fn[A : Compare] any(T[A], (A) -> Bool?Error) -> Bool?Error
 
 fn[A : Compare] contains(T[A], A) -> Bool
 
@@ -21,11 +21,11 @@ fn[A : Compare] difference(T[A], T[A]) -> T[A]
 
 fn[A : Compare] disjoint(T[A], T[A]) -> Bool
 
-fn[A] each(T[A], (A) -> Unit) -> Unit
+fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
 
-fn[A : Compare] filter(T[A], (A) -> Bool) -> T[A]
+fn[A : Compare] filter(T[A], (A) -> Bool?Error) -> T[A]?Error
 
-fn[A : Compare, B] fold(T[A], init~ : B, (B, A) -> B) -> B
+fn[A : Compare, B] fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
 
 fn[A : Compare] from_array(Array[A]) -> T[A]
 
@@ -42,7 +42,7 @@ fn[A : Compare] is_empty(T[A]) -> Bool
 
 fn[A] iter(T[A]) -> Iter[A]
 
-fn[A : Compare, B : Compare] map(T[A], (A) -> B) -> T[B]
+fn[A : Compare, B : Compare] map(T[A], (A) -> B?Error) -> T[B]?Error
 
 fn[A : Compare] max(T[A]) -> A
 
@@ -79,16 +79,16 @@ fn[A : Compare] union(T[A], T[A]) -> T[A]
 // Types and methods
 type T[A]
 fn[A : Compare] T::add(Self[A], A) -> Self[A]
-fn[A : Compare] T::all(Self[A], (A) -> Bool) -> Bool
-fn[A : Compare] T::any(Self[A], (A) -> Bool) -> Bool
+fn[A : Compare] T::all(Self[A], (A) -> Bool?Error) -> Bool?Error
+fn[A : Compare] T::any(Self[A], (A) -> Bool?Error) -> Bool?Error
 fn[A : Compare] T::contains(Self[A], A) -> Bool
 #deprecated
 fn[A : Compare] T::diff(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::difference(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::disjoint(Self[A], Self[A]) -> Bool
-fn[A] T::each(Self[A], (A) -> Unit) -> Unit
-fn[A : Compare] T::filter(Self[A], (A) -> Bool) -> Self[A]
-fn[A : Compare, B] T::fold(Self[A], init~ : B, (B, A) -> B) -> B
+fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
+fn[A : Compare] T::filter(Self[A], (A) -> Bool?Error) -> Self[A]?Error
+fn[A : Compare, B] T::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
 #deprecated
 fn[A : Compare] T::from_array(Array[A]) -> Self[A]
 #deprecated
@@ -100,7 +100,7 @@ fn[A : Compare] T::inter(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::intersection(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::is_empty(Self[A]) -> Bool
 fn[A] T::iter(Self[A]) -> Iter[A]
-fn[A : Compare, B : Compare] T::map(Self[A], (A) -> B) -> Self[B]
+fn[A : Compare, B : Compare] T::map(Self[A], (A) -> B?Error) -> Self[B]?Error
 fn[A : Compare] T::max(Self[A]) -> A
 fn[A : Compare] T::max_option(Self[A]) -> A?
 fn[A : Compare] T::min(Self[A]) -> A

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -8,9 +8,9 @@ import(
 // Values
 fn[A : Compare] add(T[A], A) -> T[A]
 
-fn[A : Compare] all(T[A], (A) -> Bool?Error) -> Bool?Error
+fn[A : Compare] all(T[A], (A) -> Bool raise?) -> Bool raise?
 
-fn[A : Compare] any(T[A], (A) -> Bool?Error) -> Bool?Error
+fn[A : Compare] any(T[A], (A) -> Bool raise?) -> Bool raise?
 
 fn[A : Compare] contains(T[A], A) -> Bool
 
@@ -21,11 +21,11 @@ fn[A : Compare] difference(T[A], T[A]) -> T[A]
 
 fn[A : Compare] disjoint(T[A], T[A]) -> Bool
 
-fn[A] each(T[A], (A) -> Unit?Error) -> Unit?Error
+fn[A] each(T[A], (A) -> Unit raise?) -> Unit raise?
 
-fn[A : Compare] filter(T[A], (A) -> Bool?Error) -> T[A]?Error
+fn[A : Compare] filter(T[A], (A) -> Bool raise?) -> T[A] raise?
 
-fn[A : Compare, B] fold(T[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A : Compare, B] fold(T[A], init~ : B, (B, A) -> B raise?) -> B raise?
 
 fn[A : Compare] from_array(Array[A]) -> T[A]
 
@@ -42,7 +42,7 @@ fn[A : Compare] is_empty(T[A]) -> Bool
 
 fn[A] iter(T[A]) -> Iter[A]
 
-fn[A : Compare, B : Compare] map(T[A], (A) -> B?Error) -> T[B]?Error
+fn[A : Compare, B : Compare] map(T[A], (A) -> B raise?) -> T[B] raise?
 
 fn[A : Compare] max(T[A]) -> A
 
@@ -79,16 +79,16 @@ fn[A : Compare] union(T[A], T[A]) -> T[A]
 // Types and methods
 type T[A]
 fn[A : Compare] T::add(Self[A], A) -> Self[A]
-fn[A : Compare] T::all(Self[A], (A) -> Bool?Error) -> Bool?Error
-fn[A : Compare] T::any(Self[A], (A) -> Bool?Error) -> Bool?Error
+fn[A : Compare] T::all(Self[A], (A) -> Bool raise?) -> Bool raise?
+fn[A : Compare] T::any(Self[A], (A) -> Bool raise?) -> Bool raise?
 fn[A : Compare] T::contains(Self[A], A) -> Bool
 #deprecated
 fn[A : Compare] T::diff(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::difference(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::disjoint(Self[A], Self[A]) -> Bool
-fn[A] T::each(Self[A], (A) -> Unit?Error) -> Unit?Error
-fn[A : Compare] T::filter(Self[A], (A) -> Bool?Error) -> Self[A]?Error
-fn[A : Compare, B] T::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A] T::each(Self[A], (A) -> Unit raise?) -> Unit raise?
+fn[A : Compare] T::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
+fn[A : Compare, B] T::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 #deprecated
 fn[A : Compare] T::from_array(Array[A]) -> Self[A]
 #deprecated
@@ -100,7 +100,7 @@ fn[A : Compare] T::inter(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::intersection(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::is_empty(Self[A]) -> Bool
 fn[A] T::iter(Self[A]) -> Iter[A]
-fn[A : Compare, B : Compare] T::map(Self[A], (A) -> B?Error) -> Self[B]?Error
+fn[A : Compare, B : Compare] T::map(Self[A], (A) -> B raise?) -> Self[B] raise?
 fn[A : Compare] T::max(Self[A]) -> A
 fn[A : Compare] T::max_option(Self[A]) -> A?
 fn[A : Compare] T::min(Self[A]) -> A


### PR DESCRIPTION
## Summary

This PR enhances error handling across various functions in the codebase, allowing for proper error propagation in higher-order functions.

## Details

### Affected Functions

- **Immutable Array**
  - `each`
  - `eachi`
  - `makei`
  - `fold`
  - `fold_left` and `fold_right`
  - `rev_fold`
  - `map`

- **Immutable HashMap**
  - `each`
  - `filter`
  - `fold` and `fold_with_key`
  - `intersection_with`
  - `map` and `map_with_key`
  - `union_with` (updated to propagate errors from merging function)

- **Immutable HashSet**
  - `each`
 
- **Legacy Immutable List**
  - `all`
  - `any`
  - `drop_while`
  - `each` and `eachi`
  - `filter`
  - `find` and `findi`
  - `flat_map`
  - `fold` and `foldi` and `rev_fold` and `rev_foldi`
  - `fold_left` and `fold_lefti`
  - `fold_right` and `fold_righti`
  - `mapi` and `rev_map`
  - `scan_left` and `scan_right`
  - `unfold`

- **Immutable Sorted Map**
  - `filter` and `filter_with_key`

- **Immutable SortedSet**
  - `all`
  - `any`
  - `each`
  - `filter`
  - `fold`
  - `map`

- **Built-in Iteration**
  - `Iter::each`
  - `Iter::eachi`
  - `Iter::fold`

These updates ensure a more robust and consistent approach to error handling across multiple modules, including array operations, immutable data structures, and iteration utilities.