### PR TITLE
remove usage of complex default value

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -488,14 +488,14 @@ fn Double::until(Double, Double, step~ : Double = .., inclusive~ : Bool = ..) ->
 #deprecated
 fn Double::upto(Double, Double, inclusive~ : Bool = ..) -> Iter[Double]
 
-fn String::char_length(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int
+fn String::char_length(String, start_offset~ : Int = .., end_offset? : Int) -> Int
 fn String::charcode_at(String, Int) -> Int
 #deprecated
 fn String::charcode_length(String) -> Int
 #deprecated
 fn String::codepoint_at(String, Int) -> Char
 #deprecated
-fn String::codepoint_length(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int
+fn String::codepoint_length(String, start_offset~ : Int = .., end_offset? : Int) -> Int
 fn String::escape(String) -> String
 #deprecated
 fn String::get(String, Int) -> Char
@@ -541,7 +541,7 @@ fn Bytes::new(Int) -> Bytes
 #deprecated
 fn Bytes::of_string(String) -> Bytes
 fn Bytes::op_get(Bytes, Int) -> Byte
-fn Bytes::to_unchecked_string(Bytes, offset~ : Int = .., length~ : Int = ..) -> String
+fn Bytes::to_unchecked_string(Bytes, offset~ : Int = .., length? : Int) -> String
 fn Bytes::unsafe_get(Bytes, Int) -> Byte
 
 fn[T : Show] Logger::write_iter(&Self, Iter[T], prefix~ : String = .., suffix~ : String = .., sep~ : String = .., trailing~ : Bool = ..) -> Unit

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -93,9 +93,10 @@ fn unsafe_sub_string(
 pub fn Bytes::to_unchecked_string(
   self : Bytes,
   offset~ : Int = 0,
-  length~ : Int = self.length() - offset
+  length? : Int
 ) -> String {
   let len = self.length()
+  let length = if length is Some(l) { l } else { len - offset }
   guard offset >= 0 && length >= 0 && offset + length <= len
   unsafe_sub_string(self, offset, length)
 }

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -165,8 +165,9 @@ pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
 pub fn String::char_length(
   self : String,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Int {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -194,9 +195,9 @@ pub fn String::char_length(
 pub fn String::codepoint_length(
   self : String,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Int {
-  self.char_length(start_offset~, end_offset~)
+  self.char_length(start_offset~, end_offset?)
 }
 
 ///|

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -278,11 +278,8 @@ pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
 ///|
 /// Returns the last index of the sub string.
 #deprecated("Use `s.rev_find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
-pub fn last_index_of(
-  self : String,
-  str : String,
-  from~ : Int = self.length()
-) -> Int {
+pub fn last_index_of(self : String, str : String, from? : Int) -> Int {
+  let from = if from is Some(f) { f } else { self.length() }
   if from >= self.length() {
     if self.rev_find(str.view()) is Some(idx) {
       idx
@@ -390,8 +387,9 @@ pub fn String::offset_of_nth_char(
   self : String,
   i : Int,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Int? {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   if i >= 0 {
     // forward case
     self.offset_of_nth_char_forward(i, start_offset~, end_offset~)
@@ -420,8 +418,9 @@ pub fn String::char_length_eq(
   self : String,
   len : Int,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Bool {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   for index = start_offset, count = 0
       index < end_offset && count < len
       index = index + 1, count = count + 1 {
@@ -447,8 +446,9 @@ pub fn String::char_length_ge(
   self : String,
   len : Int,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Bool {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   for index = start_offset, count = 0
       index < end_offset && count < len
       index = index + 1, count = count + 1 {

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -39,7 +39,7 @@ fn iter(String) -> Iter[Char]
 fn iter2(String) -> Iter2[Int, Char]
 
 #deprecated
-fn last_index_of(String, String, from~ : Int = ..) -> Int
+fn last_index_of(String, String, from? : Int) -> Int
 
 fn length(StringView) -> Int
 
@@ -93,7 +93,7 @@ fn StringView::char_length(Self) -> Int
 fn StringView::char_length_eq(Self, Int) -> Bool
 fn StringView::char_length_ge(Self, Int) -> Bool
 fn StringView::charcode_at(Self, Int) -> Int
-fn StringView::charcodes(Self, start~ : Int = .., end~ : Int = ..) -> Self
+fn StringView::charcodes(Self, start~ : Int = .., end? : Int) -> Self
 fn StringView::contains(Self, Self) -> Bool
 fn StringView::contains_char(Self, Char) -> Bool
 fn StringView::data(Self) -> String
@@ -132,7 +132,7 @@ fn StringView::trim_end(Self, Self) -> Self
 fn StringView::trim_space(Self) -> Self
 fn StringView::trim_start(Self, Self) -> Self
 fn StringView::unsafe_charcode_at(Self, Int) -> Int
-fn StringView::view(Self, start_offset~ : Int = .., end_offset~ : Int = ..) -> Self
+fn StringView::view(Self, start_offset~ : Int = .., end_offset? : Int) -> Self
 impl Compare for StringView
 impl Default for StringView
 impl Eq for StringView
@@ -141,9 +141,9 @@ impl Show for StringView
 impl ToJson for StringView
 
 fn String::char_at(String, Int) -> Char
-fn String::char_length_eq(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
-fn String::char_length_ge(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
-fn String::charcodes(String, start~ : Int = .., end~ : Int = ..) -> StringView
+fn String::char_length_eq(String, Int, start_offset~ : Int = .., end_offset? : Int) -> Bool
+fn String::char_length_ge(String, Int, start_offset~ : Int = .., end_offset? : Int) -> Bool
+fn String::charcodes(String, start~ : Int = .., end? : Int) -> StringView
 #deprecated
 fn String::concat(Array[String], separator~ : String = ..) -> String
 fn String::contains(String, StringView) -> Bool
@@ -168,8 +168,8 @@ fn String::is_empty(String) -> Bool
 fn String::iter(String) -> Iter[Char]
 fn String::iter2(String) -> Iter2[Int, Char]
 #deprecated
-fn String::last_index_of(String, String, from~ : Int = ..) -> Int
-fn String::offset_of_nth_char(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int?
+fn String::last_index_of(String, String, from? : Int) -> Int
+fn String::offset_of_nth_char(String, Int, start_offset~ : Int = .., end_offset? : Int) -> Int?
 #deprecated
 fn String::op_as_view(String, start~ : Int = .., end? : Int) -> StringView
 fn String::pad_end(String, Int, Char) -> String
@@ -192,7 +192,7 @@ fn String::trim(String, StringView) -> StringView
 fn String::trim_end(String, StringView) -> StringView
 fn String::trim_space(String) -> StringView
 fn String::trim_start(String, StringView) -> StringView
-fn String::view(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> StringView
+fn String::view(String, start_offset~ : Int = .., end_offset? : Int) -> StringView
 impl Compare for String
 impl Default for String
 

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -100,8 +100,9 @@ pub fn length(self : View) -> Int {
 pub fn String::view(
   self : String,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> View {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -115,8 +116,9 @@ pub fn String::view(
 pub fn View::view(
   self : View,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> View {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -149,12 +151,8 @@ pub fn View::view(
 /// ```
 /// 
 /// This method has O(1) complexity.
-pub fn String::charcodes(
-  self : String,
-  start~ : Int = 0,
-  end~ : Int = self.length()
-) -> View {
-  self.view(start_offset=start, end_offset=end)
+pub fn String::charcodes(self : String, start~ : Int = 0, end? : Int) -> View {
+  self.view(start_offset=start, end_offset?=end)
 }
 
 ///|
@@ -175,12 +173,8 @@ pub fn String::charcodes(
 /// It allows you to create a sub-view of an existing view with the specified character range.
 /// 
 /// This method has O(1) complexity.
-pub fn View::charcodes(
-  self : View,
-  start~ : Int = 0,
-  end~ : Int = self.length()
-) -> View {
-  self.view(start_offset=start, end_offset=end)
+pub fn View::charcodes(self : View, start~ : Int = 0, end? : Int) -> View {
+  self.view(start_offset=start, end_offset?=end)
 }
 
 ///|


### PR DESCRIPTION
Currently, MoonBit allows default value of optional arguments to depend on previous parameters. However, this feature is in conflict with the virtual package feature, as we cannot tell the dependency of a default value from its `.mbti` signature. Meanwhile, the other kind of optional argument, `label? : T`, is expressive enough to cover all usage of complex default value (just pattern match `label : T?` in function body), and with MoonBit's unboxing optimization on option type, `label? : T` has little performance overhead. So we decided to deprecate complex default values that depends on previous parameters, this PR migrates core.

Note that simple cases where the default value does not depend on anything are still supported for convenience.