### PR TITLE
Fix typo in deque panic message

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -524,7 +524,7 @@ pub fn[A] op_get(self : T[A], index : Int) -> A {
   if index < 0 || index >= self.len {
     let len = self.len
     abort(
-      "index out of bounds: Ahe len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
     )
   }
   if self.head + index < self.buf.length() {
@@ -551,7 +551,7 @@ pub fn[A] op_set(self : T[A], index : Int, value : A) -> Unit {
   if index < 0 || index >= self.len {
     let len = self.len
     abort(
-      "index out of bounds: Ahe len is from 0 to \{len} but the index is \{index}",
+      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
     )
   }
   if self.head + index < self.buf.length() {


### PR DESCRIPTION
## Summary
- fix typo in deque bounds checking message

## Testing
- `moon test --target all` *(fails: `moon` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684944e6a0f883209bd4225be4a37d11