### PR TITLE
Fix int64 random mask

### DIFF
--- a/random/README.mbt.md
+++ b/random/README.mbt.md
@@ -16,7 +16,7 @@ test {
   assert_eq(r.double(), 0.3318940049218405)
   assert_eq(r.int(limit=10), 0)
   assert_eq(r.uint(), 311122750)
-  assert_eq(r.int64(), -9223372036854775808)
+  assert_eq(r.int64(), 2043189202271773519)
   assert_eq(r.int64(limit=10), 8)
   assert_eq(r.uint64(), 3951155890335085418)
   let a = [1, 2, 3, 4, 5]

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -102,8 +102,8 @@ pub fn int(self : Rand, limit~ : Int = 0) -> Int {
 pub fn int64(self : Rand, limit~ : Int64 = 0) -> Int64 {
   if limit == 0 {
     // range [0, 2^63)
-    // Create a mask that has all bits set to 1 except the highest bit
-    let mask : UInt64 = 1UL << 63
+    // Create a mask that keeps the lower 63 bits
+    let mask : UInt64 = (1UL << 63) - 1UL
     return (self.next() & mask).reinterpret_as_int64()
   } else {
     self.uint64(limit=limit.reinterpret_as_uint64()).reinterpret_as_int64()

--- a/random/random_test.mbt
+++ b/random/random_test.mbt
@@ -22,7 +22,7 @@ test "prng" {
   assert_eq(r.double(), 0.3318940049218405)
   assert_eq(r.int(limit=10), 0)
   assert_eq(r.uint(), 311122750)
-  assert_eq(r.int64(), -9223372036854775808)
+  assert_eq(r.int64(), 2043189202271773519)
   assert_eq(r.int64(limit=10), 8)
   assert_eq(r.uint64(), 3951155890335085418)
   let a = [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary
- update mask for `Rand.int64`
- adjust expected `int64` output in README
- update `random_test.mbt` accordingly

## Testing
- `moon clean`
- `moon test`

------
https://chatgpt.com/codex/tasks/task_e_6849493e451c832094e278729b3ed52d