### PR TITLE
Resolve push_iter conflict

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -50,11 +50,15 @@ pub fn[T] Array::from_iter(iter : Iter[T]) -> Array[T] {
 ///   assert_eq(u, [1, 2, 3, 4, 5, 6])
 /// }
 /// ```
-pub fn[T] push_iter(self : Array[T], iter : Iter[T]) -> Unit {
+pub fn[T] Array::push_iter(self : Self[T], iter : Iter[T]) -> Unit {
   for x in iter {
     self.push(x)
   }
 }
+
+///|
+#deprecated("use method call")
+pub fnalias Array::push_iter
 
 ///|
 /// Creates a new array of the specified length, where each element is

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -15,6 +15,7 @@ fn join(Array[String], @string.StringView) -> String
 
 fn[A] last(Array[A]) -> A?
 
+#deprecated
 fn[T] push_iter(Array[T], Iter[T]) -> Unit
 
 fn[T] shuffle(Array[T], rand~ : (Int) -> Int) -> Array[T]


### PR DESCRIPTION
## Summary
- convert `push_iter` into a method on `Array`
- add a deprecated alias for the old function

## Testing
- `moon fmt`
- `moon info`


------
https://chatgpt.com/codex/tasks/task_e_6849491b009c8320bbee298e7355d1e4