### PR TITLE
Refactor buffer growth

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -43,14 +43,12 @@ struct T {
 ///|
 /// Expand the buffer size if capacity smaller than required space.
 fn grow_if_necessary(self : T, required : Int) -> Unit {
-  // TODO: get rid of mut
-  let mut enough_space = self.data.length()
-  if enough_space <= 0 {
-    enough_space = 1
-  }
-  // double the enough_space until it larger than required
-  while enough_space < required {
-    enough_space = enough_space * 2
+  let start = if self.data.length() <= 0 { 1 } else { self.data.length() }
+  let enough_space = for space = start {
+    if space >= required {
+      break space
+    }
+    continue space * 2
   }
   if enough_space != self.data.length() {
     let new_data = FixedArray::make(enough_space, Byte::default())

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -284,7 +284,6 @@ pub fn[K : Hash + Eq, V] op_get(self : T[K, V], key : K) -> V? {
 ///   inspect(map.get("key"), content="Some(42)")
 /// }
 /// ```
-/// TODO: improve performance to avoid calling `get_with_hash` twice
 pub fn[K : Hash + Eq, V] get_or_init(
   self : T[K, V],
   key : K,


### PR DESCRIPTION
## Summary
- refactor buffer growth logic to remove mut variable
- drop outdated todo in hashmap

## Testing
- `moon fmt`
- `moon check`
- `moon test`
- `moon bundle`
- `moon info`


------
https://chatgpt.com/codex/tasks/task_e_6849580f44b08320adc09f7a73a0c325