### PR TITLE
Add basic stack data structure

### DIFF
--- a/stack/README.mbt.md
+++ b/stack/README.mbt.md
@@ -1,0 +1,12 @@
+# Stack
+
+`stack` provides a simple last in first out (LIFO) data structure.
+
+```moonbit
+test {
+  let s : @stack.T[Int] = @stack.new()
+  s.push(1)
+  s.push(2)
+  inspect(s.pop(), content="Some(2)")
+}
+```

--- a/stack/moon.pkg.json
+++ b/stack/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/array", "moonbitlang/core/quickcheck"]
+}

--- a/stack/stack.mbt
+++ b/stack/stack.mbt
@@ -1,0 +1,137 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Creates a new empty stack.
+///
+/// # Example
+/// ```
+/// test "new_stack_example" {
+///   let stack : @stack.T[Int] = @stack.new()
+///   assert_eq(stack.length(), 0)
+/// }
+/// ```
+pub fn[A] new() -> T[A] {
+  { data: [] }
+}
+
+///|
+/// Creates a new stack from an array.
+///
+/// # Example
+/// ```
+/// test "from_array_example" {
+///   let stack : @stack.T[Int] = @stack.from_array([1,2,3])
+///   assert_eq(stack.length(), 3)
+/// }
+/// ```
+pub fn[A] from_array(arr : Array[A]) -> T[A] {
+  { data: arr }
+}
+
+///|
+/// Creates a new stack from a fixed array.
+pub fn[A] of(arr : FixedArray[A]) -> T[A] {
+  from_array(Array::from_fixed_array(arr))
+}
+
+///|
+pub impl[A : Show] Show for T[A] with output(self, logger) {
+  logger.write_iter(self.iter(), prefix="@stack.of([", suffix="])")
+}
+
+///|
+/// Pushes a value onto the stack.
+pub fn[A] push(self : T[A], x : A) -> Unit {
+  self.data.push(x)
+}
+
+///|
+/// Pops the top value from the stack, panicking if empty.
+#internal(unsafe, "Panics if the stack is empty.")
+pub fn[A] unsafe_pop(self : T[A]) -> A {
+  self.data.unsafe_pop()
+}
+
+///|
+/// Pops the top value from the stack.
+pub fn[A] pop(self : T[A]) -> A? {
+  self.data.pop()
+}
+
+///|
+/// Peeks the top value of the stack, panicking if empty.
+#internal(unsafe, "Panics if the stack is empty.")
+pub fn[A] unsafe_peek(self : T[A]) -> A {
+  match self.data.last() {
+    Some(v) => v
+    None => abort("Stack is empty")
+  }
+}
+
+///|
+/// Peeks the top value of the stack.
+pub fn[A] peek(self : T[A]) -> A? {
+  self.data.last()
+}
+
+///|
+/// Returns the number of elements in the stack.
+pub fn[A] length(self : T[A]) -> Int {
+  self.data.length()
+}
+
+///|
+/// Returns true if the stack contains no elements.
+pub fn[A] is_empty(self : T[A]) -> Bool {
+  self.data.is_empty()
+}
+
+///|
+/// Removes all elements from the stack.
+pub fn[A] clear(self : T[A]) -> Unit {
+  self.data.clear()
+}
+
+///|
+/// Creates an iterator from the stack (top to bottom).
+pub fn[A] iter(self : T[A]) -> Iter[A] {
+  Iter::new(fn(yield_) {
+    for i = self.data.length() - 1; i >= 0; {
+      if yield_(self.data[i]) == IterEnd {
+        break IterEnd
+      } else {
+        continue i - 1
+      }
+    } else {
+      IterContinue
+    }
+  })
+}
+
+///|
+/// Creates a stack from an iterator.
+pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
+  let s = new()
+  iter.each(fn(e) { s.push(e) })
+  s
+}
+
+///|
+pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[X] with arbitrary(
+  size,
+  rs,
+) {
+  @quickcheck.Arbitrary::arbitrary(size, rs) |> from_iter
+}

--- a/stack/stack.mbti
+++ b/stack/stack.mbti
@@ -1,0 +1,52 @@
+package "moonbitlang/core/stack"
+
+import(
+  "moonbitlang/core/quickcheck"
+)
+
+// Values
+fn[A] clear(T[A]) -> Unit
+
+fn[A] from_array(Array[A]) -> T[A]
+
+fn[A] from_iter(Iter[A]) -> T[A]
+
+fn[A] is_empty(T[A]) -> Bool
+
+fn[A] iter(T[A]) -> Iter[A]
+
+fn[A] length(T[A]) -> Int
+
+fn[A] new() -> T[A]
+
+fn[A] of(FixedArray[A]) -> T[A]
+
+fn[A] peek(T[A]) -> A?
+
+fn[A] pop(T[A]) -> A?
+
+fn[A] push(T[A], A) -> Unit
+
+fn[A] unsafe_peek(T[A]) -> A
+
+fn[A] unsafe_pop(T[A]) -> A
+
+// Types and methods
+type T[A]
+fn[A] T::clear(Self[A]) -> Unit
+fn[A] T::is_empty(Self[A]) -> Bool
+fn[A] T::iter(Self[A]) -> Iter[A]
+fn[A] T::length(Self[A]) -> Int
+fn[A] T::peek(Self[A]) -> A?
+fn[A] T::pop(Self[A]) -> A?
+fn[A] T::push(Self[A], A) -> Unit
+fn[A] T::unsafe_peek(Self[A]) -> A
+fn[A] T::unsafe_pop(Self[A]) -> A
+impl[A : Eq] Eq for T[A]
+impl[A : Show] Show for T[A]
+impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[X]
+
+// Type aliases
+
+// Traits
+

--- a/stack/stack_test.mbt
+++ b/stack/stack_test.mbt
@@ -1,0 +1,45 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "new" {
+  let s : @stack.T[Int] = @stack.new()
+  assert_true(s.is_empty())
+}
+
+///|
+test "push_pop" {
+  let s : @stack.T[Int] = @stack.new()
+  s.push(1)
+  s.push(2)
+  assert_eq(s.length(), 2)
+  assert_eq(s.unsafe_pop(), 2)
+  assert_eq(s.pop(), Some(1))
+  assert_true(s.is_empty())
+}
+
+///|
+test "peek" {
+  let s = @stack.of([1,2,3])
+  assert_eq(s.peek(), Some(3))
+  assert_eq(s.unsafe_peek(), 3)
+  s.clear()
+  assert_eq(s.peek(), None)
+}
+
+///|
+test "iter" {
+  let s = @stack.of([1,2,3])
+  inspect(s.iter().fold(fn(a,b){a+b}, init=0), content="6")
+}

--- a/stack/types.mbt
+++ b/stack/types.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+struct T[A] {
+  data : Array[A]
+} derive(Eq)


### PR DESCRIPTION
## Summary
- add new `stack` package implemented with an internal `Array`
- include helper functions like `push`, `pop`, `peek`, `iter`, etc.
- provide README example and tests

## Testing
- `moon info`
- `moon check`
- `moon test`
- `moon bundle`
- `moon info`

------
https://chatgpt.com/codex/tasks/task_e_68499345106c83209b3c6992c9ad9b2c