### PR TITLE
migrate syntax change

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -85,8 +85,8 @@ pub fnalias Array::push_iter
 /// ```
 pub fn[T] Array::makei(
   length : Int,
-  value : (Int) -> T?Error
-) -> Array[T]?Error {
+  value : (Int) -> T raise?
+) -> Array[T] raise? {
   if length <= 0 {
     []
   } else {
@@ -158,7 +158,10 @@ pub fn[T] shuffle(self : Array[T], rand~ : (Int) -> Int) -> Array[T] {
 /// 
 /// # Returns
 /// 
-pub fn[A, B] filter_map(self : Array[A], f : (A) -> B??Error) -> Array[B]?Error {
+pub fn[A, B] filter_map(
+  self : Array[A],
+  f : (A) -> B? raise?
+) -> Array[B] raise? {
   let result = []
   for x in self {
     if f(x) is Some(x) {
@@ -277,8 +280,8 @@ pub fn[T1, T2] unzip(self : Array[(T1, T2)]) -> (Array[T1], Array[T2]) {
 pub fn[A, B, C] zip_with(
   l : Array[A],
   r : Array[B],
-  merge : (A, B) -> C?Error
-) -> Array[C]?Error {
+  merge : (A, B) -> C raise?
+) -> Array[C] raise? {
   let length = if l.length() < r.length() { l.length() } else { r.length() }
   let arr = Array::new(capacity=length)
   for i = 0; i < length; i = i + 1 {

--- a/array/array.mbti
+++ b/array/array.mbti
@@ -9,7 +9,7 @@ import(
 // Values
 fn[T] copy(Array[T]) -> Array[T]
 
-fn[A, B] filter_map(Array[A], (A) -> B??Error) -> Array[B]?Error
+fn[A, B] filter_map(Array[A], (A) -> B? raise?) -> Array[B] raise?
 
 fn join(Array[String], @string.StringView) -> String
 
@@ -34,32 +34,32 @@ fn[A, B] zip(Array[A], Array[B]) -> Array[(A, B)]
 
 fn[A, B] zip_to_iter2(Array[A], Array[B]) -> Iter2[A, B]
 
-fn[A, B, C] zip_with(Array[A], Array[B], (A, B) -> C?Error) -> Array[C]?Error
+fn[A, B, C] zip_with(Array[A], Array[B], (A, B) -> C raise?) -> Array[C] raise?
 
 // Types and methods
-fn[T] FixedArray::all(Self[T], (T) -> Bool?Error) -> Bool?Error
-fn[T] FixedArray::any(Self[T], (T) -> Bool?Error) -> Bool?Error
+fn[T] FixedArray::all(Self[T], (T) -> Bool raise?) -> Bool raise?
+fn[T] FixedArray::any(Self[T], (T) -> Bool raise?) -> Bool raise?
 fn FixedArray::blit_from_bytesview(Self[Byte], Int, @bytes.View) -> Unit
 fn[T : Eq] FixedArray::contains(Self[T], T) -> Bool
 fn[T] FixedArray::copy(Self[T]) -> Self[T]
-fn[T] FixedArray::each(Self[T], (T) -> Unit?Error) -> Unit?Error
-fn[T] FixedArray::eachi(Self[T], (Int, T) -> Unit?Error) -> Unit?Error
+fn[T] FixedArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
+fn[T] FixedArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 fn[T : Eq] FixedArray::ends_with(Self[T], Self[T]) -> Bool
-fn[A, B] FixedArray::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
-fn[A, B] FixedArray::foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[A, B] FixedArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
+fn[A, B] FixedArray::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 fn[T] FixedArray::from_array(Array[T]) -> Self[T]
 fn[T] FixedArray::from_iter(Iter[T]) -> Self[T]
 fn[T : Compare] FixedArray::is_sorted(Self[T]) -> Bool
 fn FixedArray::join(Self[String], @string.StringView) -> String
 fn[A] FixedArray::last(Self[A]) -> A?
-fn[T] FixedArray::makei(Int, (Int) -> T?Error) -> Self[T]?Error
-fn[T, U] FixedArray::map(Self[T], (T) -> U?Error) -> Self[U]?Error
-fn[T, U] FixedArray::mapi(Self[T], (Int, T) -> U?Error) -> Self[U]?Error
+fn[T] FixedArray::makei(Int, (Int) -> T raise?) -> Self[T] raise?
+fn[T, U] FixedArray::map(Self[T], (T) -> U raise?) -> Self[U] raise?
+fn[T, U] FixedArray::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?
 fn[T] FixedArray::rev(Self[T]) -> Self[T]
-fn[T] FixedArray::rev_each(Self[T], (T) -> Unit?Error) -> Unit?Error
-fn[T] FixedArray::rev_eachi(Self[T], (Int, T) -> Unit?Error) -> Unit?Error
-fn[A, B] FixedArray::rev_fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
-fn[A, B] FixedArray::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[T] FixedArray::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
+fn[T] FixedArray::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
+fn[A, B] FixedArray::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
+fn[A, B] FixedArray::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 fn[T] FixedArray::rev_inplace(Self[T]) -> Unit
 fn[T : Eq] FixedArray::search(Self[T], T) -> Int?
 fn[T : Compare] FixedArray::sort(Self[T]) -> Unit
@@ -75,11 +75,11 @@ impl[T : Hash] Hash for FixedArray[T]
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for FixedArray[X]
 
 fn[T] Array::copy(Self[T]) -> Self[T]
-fn[A, B] Array::filter_map(Self[A], (A) -> B??Error) -> Self[B]?Error
+fn[A, B] Array::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 fn[T] Array::from_iter(Iter[T]) -> Self[T]
 fn Array::join(Self[String], @string.StringView) -> String
 fn[A] Array::last(Self[A]) -> A?
-fn[T] Array::makei(Int, (Int) -> T?Error) -> Self[T]?Error
+fn[T] Array::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 fn[T] Array::push_iter(Self[T], Iter[T]) -> Unit
 fn[T] Array::shuffle(Self[T], rand~ : (Int) -> Int) -> Self[T]
 fn[T] Array::shuffle_in_place(Self[T], rand~ : (Int) -> Int) -> Unit
@@ -91,23 +91,23 @@ fn[A, B] Array::zip(Self[A], Self[B]) -> Self[(A, B)]
 fn[A, B] Array::zip_to_iter2(Self[A], Self[B]) -> Iter2[A, B]
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Array[X]
 
-fn[T] ArrayView::all(Self[T], (T) -> Bool?Error) -> Bool?Error
-fn[T] ArrayView::any(Self[T], (T) -> Bool?Error) -> Bool?Error
+fn[T] ArrayView::all(Self[T], (T) -> Bool raise?) -> Bool raise?
+fn[T] ArrayView::any(Self[T], (T) -> Bool raise?) -> Bool raise?
 fn[T : Eq] ArrayView::contains(Self[T], T) -> Bool
-fn[T] ArrayView::each(Self[T], (T) -> Unit?Error) -> Unit?Error
-fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit?Error) -> Unit?Error
-fn[T] ArrayView::filter(Self[T], (T) -> Bool?Error) -> Array[T]?Error
-fn[A, B] ArrayView::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
-fn[A, B] ArrayView::foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[T] ArrayView::each(Self[T], (T) -> Unit raise?) -> Unit raise?
+fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
+fn[T] ArrayView::filter(Self[T], (T) -> Bool raise?) -> Array[T] raise?
+fn[A, B] ArrayView::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
+fn[A, B] ArrayView::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 fn[A] ArrayView::iter(Self[A]) -> Iter[A]
 fn[A] ArrayView::iter2(Self[A]) -> Iter2[Int, A]
 fn ArrayView::join(Self[String], @string.StringView) -> String
-fn[T, U] ArrayView::map(Self[T], (T) -> U?Error) -> Array[U]?Error
-fn[T] ArrayView::map_inplace(Self[T], (T) -> T?Error) -> Unit?Error
-fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U?Error) -> Array[U]?Error
-fn[T] ArrayView::mapi_inplace(Self[T], (Int, T) -> T?Error) -> Unit?Error
-fn[A, B] ArrayView::rev_fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
-fn[A, B] ArrayView::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
+fn[T] ArrayView::map_inplace(Self[T], (T) -> T raise?) -> Unit raise?
+fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?
+fn[T] ArrayView::mapi_inplace(Self[T], (Int, T) -> T raise?) -> Unit raise?
+fn[A, B] ArrayView::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
+fn[A, B] ArrayView::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 fn[T] ArrayView::rev_inplace(Self[T]) -> Unit
 fn[T] ArrayView::to_array(Self[T]) -> Array[T]
 impl[T : Compare] Compare for ArrayView[T]

--- a/array/array_js.mbt
+++ b/array/array_js.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-priv extern type JSArray
+priv type JSArray
 
 ///|
 fn[T] JSArray::ofAnyArray(array : Array[T]) -> JSArray = "%identity"

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -29,8 +29,8 @@
 /// ```
 pub fn[T] FixedArray::each(
   self : FixedArray[T],
-  f : (T) -> Unit?Error
-) -> Unit?Error {
+  f : (T) -> Unit raise?
+) -> Unit raise? {
   for v in self {
     f(v)
   }
@@ -83,8 +83,8 @@ test "each" {
 /// ```
 pub fn[T] FixedArray::eachi(
   self : FixedArray[T],
-  f : (Int, T) -> Unit?Error
-) -> Unit?Error {
+  f : (Int, T) -> Unit raise?
+) -> Unit raise? {
   for i, v in self {
     f(i, v)
   }
@@ -135,8 +135,8 @@ test "eachi" {
 /// ```
 pub fn[T] FixedArray::rev_each(
   self : FixedArray[T],
-  f : (T) -> Unit?Error
-) -> Unit?Error {
+  f : (T) -> Unit raise?
+) -> Unit raise? {
   for i = self.length() - 1; i >= 0; i = i - 1 {
     f(self[i])
   }
@@ -189,8 +189,8 @@ test "rev_each" {
 /// ```
 pub fn[T] FixedArray::rev_eachi(
   self : FixedArray[T],
-  f : (Int, T) -> Unit?Error
-) -> Unit?Error {
+  f : (Int, T) -> Unit raise?
+) -> Unit raise? {
   let len = self.length()
   for i in 0..<len {
     f(i, self[len - i - 1])
@@ -245,8 +245,8 @@ test "rev_eachi" {
 /// ```
 pub fn[T, U] FixedArray::map(
   self : FixedArray[T],
-  f : (T) -> U?Error
-) -> FixedArray[U]?Error {
+  f : (T) -> U raise?
+) -> FixedArray[U] raise? {
   if self.length() == 0 {
     return []
   }
@@ -280,8 +280,8 @@ test "map" {
 /// ```
 pub fn[T, U] FixedArray::mapi(
   self : FixedArray[T],
-  f : (Int, T) -> U?Error
-) -> FixedArray[U]?Error {
+  f : (Int, T) -> U raise?
+) -> FixedArray[U] raise? {
   if self.length() == 0 {
     return []
   }
@@ -328,8 +328,8 @@ test "mapi" {
 /// ```
 pub fn[T] FixedArray::makei(
   length : Int,
-  value : (Int) -> T?Error
-) -> FixedArray[T]?Error {
+  value : (Int) -> T raise?
+) -> FixedArray[T] raise? {
   if length <= 0 {
     []
   } else {
@@ -395,8 +395,8 @@ test "from_array" {
 pub fn[A, B] FixedArray::fold(
   self : FixedArray[A],
   init~ : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   for i = 0, acc = init; i < self.length(); {
     continue i + 1, f(acc, self[i])
   } else {
@@ -427,8 +427,8 @@ test "fold" {
 pub fn[A, B] FixedArray::rev_fold(
   self : FixedArray[A],
   init~ : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   for i = self.length() - 1, acc = init; i >= 0; {
     continue i - 1, f(acc, self[i])
   } else {
@@ -461,8 +461,8 @@ test "rev_fold" {
 pub fn[A, B] FixedArray::foldi(
   self : FixedArray[A],
   init~ : B,
-  f : (Int, B, A) -> B?Error
-) -> B?Error {
+  f : (Int, B, A) -> B raise?
+) -> B raise? {
   for i = 0, acc = init; i < self.length(); {
     continue i + 1, f(i, acc, self[i])
   } else {
@@ -496,8 +496,8 @@ test "fold_lefti" {
 pub fn[A, B] FixedArray::rev_foldi(
   self : FixedArray[A],
   init~ : B,
-  f : (Int, B, A) -> B?Error
-) -> B?Error {
+  f : (Int, B, A) -> B raise?
+) -> B raise? {
   let len = self.length()
   for i = len - 1, acc = init; i >= 0; {
     continue i - 1, f(len - i - 1, acc, self[i])
@@ -680,8 +680,8 @@ test "swap" {
 /// ```
 pub fn[T] FixedArray::all(
   self : FixedArray[T],
-  f : (T) -> Bool?Error
-) -> Bool?Error {
+  f : (T) -> Bool raise?
+) -> Bool raise? {
   for i in 0..<self.length() {
     if not(f(self[i])) {
       return false
@@ -719,8 +719,8 @@ test "all" {
 /// ```
 pub fn[T] FixedArray::any(
   self : FixedArray[T],
-  f : (T) -> Bool?Error
-) -> Bool?Error {
+  f : (T) -> Bool raise?
+) -> Bool raise? {
   for i in 0..<self.length() {
     if f(self[i]) {
       return true

--- a/array/fixedarray_sort.mbt
+++ b/array/fixedarray_sort.mbt
@@ -436,7 +436,7 @@ fn[T : Compare] fixed_sift_down(arr : FixedArraySlice[T], index : Int) -> Unit {
 }
 
 ///|
-fn fixed_test_sort(f : (FixedArray[Int]) -> Unit) -> Unit! {
+fn fixed_test_sort(f : (FixedArray[Int]) -> Unit) -> Unit raise {
   let arr : FixedArray[_] = [5, 4, 3, 2, 1]
   f(arr)
   assert_eq(arr, [1, 2, 3, 4, 5])

--- a/array/sort.mbt
+++ b/array/sort.mbt
@@ -229,7 +229,7 @@ fn[T : Compare] sift_down(arr : ArrayView[T], index : Int) -> Unit {
 }
 
 ///|
-fn test_sort(f : (Array[Int]) -> Unit) -> Unit! {
+fn test_sort(f : (Array[Int]) -> Unit) -> Unit raise {
   let arr = [5, 4, 3, 2, 1]
   f(arr)
   assert_eq(arr, [1, 2, 3, 4, 5])

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -69,7 +69,7 @@ pub fn[T] View::rev_inplace(self : View[T]) -> Unit {
 ///   inspect(sum, content="6")
 /// }
 /// ```
-pub fn[T] View::each(self : View[T], f : (T) -> Unit?Error) -> Unit?Error {
+pub fn[T] View::each(self : View[T], f : (T) -> Unit raise?) -> Unit raise? {
   for v in self {
     f(v)
   }
@@ -86,7 +86,10 @@ pub fn[T] View::each(self : View[T], f : (T) -> Unit?Error) -> Unit?Error {
 /// v.eachi(fn (i, x) { sum = sum + x + i })
 /// assert_eq(sum, 15)
 /// ```
-pub fn[T] View::eachi(self : View[T], f : (Int, T) -> Unit?Error) -> Unit?Error {
+pub fn[T] View::eachi(
+  self : View[T],
+  f : (Int, T) -> Unit raise?
+) -> Unit raise? {
   for i, v in self {
     f(i, v)
   }
@@ -102,7 +105,7 @@ pub fn[T] View::eachi(self : View[T], f : (Int, T) -> Unit?Error) -> Unit?Error 
 /// assert_false(v[:].all(fn(elem) { elem % 2 == 0 }))
 /// assert_true(v[1:4].all(fn(elem) { elem % 2 == 0 }))
 /// ```
-pub fn[T] View::all(self : View[T], f : (T) -> Bool?Error) -> Bool?Error {
+pub fn[T] View::all(self : View[T], f : (T) -> Bool raise?) -> Bool raise? {
   for v in self {
     if not(f(v)) {
       return false
@@ -121,7 +124,7 @@ pub fn[T] View::all(self : View[T], f : (T) -> Bool?Error) -> Bool?Error {
 /// assert_true(v.any(fn(ele) { ele < 6 }))
 /// assert_false(v.any(fn(ele) { ele < 1 }))
 /// ```
-pub fn[T] View::any(self : View[T], f : (T) -> Bool?Error) -> Bool?Error {
+pub fn[T] View::any(self : View[T], f : (T) -> Bool raise?) -> Bool raise? {
   for v in self {
     if f(v) {
       return true
@@ -232,8 +235,8 @@ pub fn[A] View::iter2(self : View[A]) -> Iter2[Int, A] {
 pub fn[A, B] View::fold(
   self : View[A],
   init~ : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   for i = 0, acc = init; i < self.length(); {
     continue i + 1, f(acc, self[i])
   } else {
@@ -252,8 +255,8 @@ pub fn[A, B] View::fold(
 pub fn[A, B] View::rev_fold(
   self : View[A],
   init~ : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   for i = self.length() - 1, acc = init; i >= 0; {
     continue i - 1, f(acc, self[i])
   } else {
@@ -272,8 +275,8 @@ pub fn[A, B] View::rev_fold(
 pub fn[A, B] View::foldi(
   self : View[A],
   init~ : B,
-  f : (Int, B, A) -> B?Error
-) -> B?Error {
+  f : (Int, B, A) -> B raise?
+) -> B raise? {
   for i = 0, acc = init; i < self.length(); {
     continue i + 1, f(i, acc, self[i])
   } else {
@@ -292,8 +295,8 @@ pub fn[A, B] View::foldi(
 pub fn[A, B] View::rev_foldi(
   self : View[A],
   init~ : B,
-  f : (Int, B, A) -> B?Error
-) -> B?Error {
+  f : (Int, B, A) -> B raise?
+) -> B raise? {
   let len = self.length()
   for i = len - 1, acc = init; i >= 0; {
     continue i - 1, f(len - i - 1, acc, self[i])
@@ -311,7 +314,7 @@ pub fn[A, B] View::rev_foldi(
 /// let v2 = v[1:].map(fn (x) {x + 1})
 /// assert_eq(v2, [5, 6])
 /// ```
-pub fn[T, U] View::map(self : View[T], f : (T) -> U?Error) -> Array[U]?Error {
+pub fn[T, U] View::map(self : View[T], f : (T) -> U raise?) -> Array[U] raise? {
   if self.length() == 0 {
     return []
   }
@@ -327,7 +330,7 @@ pub fn[T, U] View::map(self : View[T], f : (T) -> U?Error) -> Array[U]?Error {
 /// v[1:].map_inplace(fn (x) {x + 1})
 /// assert_eq(v, [3, 5, 6])
 /// ```
-pub fn[T] View::map_inplace(self : View[T], f : (T) -> T?Error) -> Unit?Error {
+pub fn[T] View::map_inplace(self : View[T], f : (T) -> T raise?) -> Unit raise? {
   for i, v in self {
     self[i] = f(v)
   }
@@ -344,8 +347,8 @@ pub fn[T] View::map_inplace(self : View[T], f : (T) -> T?Error) -> Unit?Error {
 /// ```
 pub fn[T, U] View::mapi(
   self : View[T],
-  f : (Int, T) -> U?Error
-) -> Array[U]?Error {
+  f : (Int, T) -> U raise?
+) -> Array[U] raise? {
   if self.length() == 0 {
     return []
   }
@@ -363,8 +366,8 @@ pub fn[T, U] View::mapi(
 /// ```
 pub fn[T] View::mapi_inplace(
   self : View[T],
-  f : (Int, T) -> T?Error
-) -> Unit?Error {
+  f : (Int, T) -> T raise?
+) -> Unit raise? {
   for i, v in self {
     self[i] = f(i, v)
   }
@@ -379,7 +382,10 @@ pub fn[T] View::mapi_inplace(
 /// let v = arr[2:].filter(fn (x) { x % 2 == 0 })
 /// assert_eq(v, [4, 6])
 /// ```
-pub fn[T] View::filter(self : View[T], f : (T) -> Bool?Error) -> Array[T]?Error {
+pub fn[T] View::filter(
+  self : View[T],
+  f : (T) -> Bool raise?
+) -> Array[T] raise? {
   let arr = []
   for v in self {
     if f(v) {

--- a/bench/monotonic_clock_js.mbt
+++ b/bench/monotonic_clock_js.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-extern type Timestamp
+type Timestamp
 
 ///|
 pub extern "js" fn monotonic_clock_start() -> Timestamp =

--- a/bench/monotonic_clock_native.mbt
+++ b/bench/monotonic_clock_native.mbt
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 ///|
-extern type Timestamp
+#external
+type Timestamp
 
 ///|
 pub extern "C" fn monotonic_clock_start() -> Timestamp = "moonbit_monotonic_clock_start"

--- a/bench/monotonic_clock_wasm.mbt
+++ b/bench/monotonic_clock_wasm.mbt
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 ///|
-extern type Timestamp
+#external
+type Timestamp
 
 ///|
 fn instant_elapsed_as_secs_f64(x : Timestamp) -> Double = "__moonbit_time_unstable" "instant_elapsed_as_secs_f64"

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-extern type BigInt
+type BigInt
 
 ///|
 pub fn BigInt::from_string(str : String) -> BigInt {

--- a/bigint/bigint_js_wbtest.mbt
+++ b/bigint/bigint_js_wbtest.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn check_invariant(_a : BigInt) -> Unit! {
+fn check_invariant(_a : BigInt) -> Unit raise {
   assert_true(true)
 }
 

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -49,7 +49,7 @@ test "debug_string" {
 }
 
 ///|
-fn check_invariant(a : BigInt) -> Unit! {
+fn check_invariant(a : BigInt) -> Unit raise {
   guard a.len > 0 else { fail("invariant len > 0 is broken: len = \{a.len}") }
   for i in 0..<a.len {
     guard a.limbs[i].to_uint64() < radix else {

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -409,7 +409,7 @@ pub fn[T] Array::append(self : Array[T], other : Array[T]) -> Unit {
 /// }
 /// ```
 #locals(f)
-pub fn[T] Array::each(self : Array[T], f : (T) -> Unit?Error) -> Unit?Error {
+pub fn[T] Array::each(self : Array[T], f : (T) -> Unit raise?) -> Unit raise? {
   for v in self {
     f(v)
   }
@@ -456,8 +456,8 @@ pub fn[T] Array::rev_each(self : Array[T], f : (T) -> Unit) -> Unit {
 #locals(f)
 pub fn[T] Array::rev_eachi(
   self : Array[T],
-  f : (Int, T) -> Unit?Error
-) -> Unit?Error {
+  f : (Int, T) -> Unit raise?
+) -> Unit raise? {
   let len = self.length()
   for i in 0..<len {
     f(i, self[len - i - 1])
@@ -479,8 +479,8 @@ pub fn[T] Array::rev_eachi(
 #locals(f)
 pub fn[T] Array::eachi(
   self : Array[T],
-  f : (Int, T) -> Unit?Error
-) -> Unit?Error {
+  f : (Int, T) -> Unit raise?
+) -> Unit raise? {
   for i, v in self {
     f(i, v)
   }
@@ -515,7 +515,10 @@ pub fn[T] Array::clear(self : Array[T]) -> Unit {
 /// }
 /// ```
 #locals(f)
-pub fn[T, U] Array::map(self : Array[T], f : (T) -> U?Error) -> Array[U]?Error {
+pub fn[T, U] Array::map(
+  self : Array[T],
+  f : (T) -> U raise?
+) -> Array[U] raise? {
   let arr = Array::make_uninit(self.length())
   for i, v in self {
     arr.unsafe_set(i, f(v))
@@ -535,7 +538,10 @@ pub fn[T, U] Array::map(self : Array[T], f : (T) -> U?Error) -> Array[U]?Error {
 /// }
 /// ```
 #locals(f)
-pub fn[T] Array::map_inplace(self : Array[T], f : (T) -> T?Error) -> Unit?Error {
+pub fn[T] Array::map_inplace(
+  self : Array[T],
+  f : (T) -> T raise?
+) -> Unit raise? {
   for i, v in self {
     self[i] = f(v)
   }
@@ -555,8 +561,8 @@ pub fn[T] Array::map_inplace(self : Array[T], f : (T) -> T?Error) -> Unit?Error 
 #locals(f)
 pub fn[T, U] Array::mapi(
   self : Array[T],
-  f : (Int, T) -> U?Error
-) -> Array[U]?Error {
+  f : (Int, T) -> U raise?
+) -> Array[U] raise? {
   if self.length() == 0 {
     return []
   }
@@ -581,8 +587,8 @@ pub fn[T, U] Array::mapi(
 #locals(f)
 pub fn[T] Array::mapi_inplace(
   self : Array[T],
-  f : (Int, T) -> T?Error
-) -> Unit?Error {
+  f : (Int, T) -> T raise?
+) -> Unit raise? {
   for i, v in self {
     self[i] = f(i, v)
   }
@@ -613,8 +619,8 @@ pub fn[T] Array::mapi_inplace(
 #locals(f)
 pub fn[T] Array::filter(
   self : Array[T],
-  f : (T) -> Bool?Error
-) -> Array[T]?Error {
+  f : (T) -> Bool raise?
+) -> Array[T] raise? {
   let arr = []
   for v in self {
     if f(v) {
@@ -1246,7 +1252,7 @@ pub fn[T] Array::swap(self : Array[T], i : Int, j : Int) -> Unit {
 /// ```
 /// TODO: perf could be improved
 #locals(f)
-pub fn[T] Array::retain(self : Array[T], f : (T) -> Bool?Error) -> Unit?Error {
+pub fn[T] Array::retain(self : Array[T], f : (T) -> Bool raise?) -> Unit raise? {
   for i = 0, j = 0; i < self.length(); {
     if f(self.unsafe_get(i)) {
       self.unsafe_set(j, self.unsafe_get(i))
@@ -1359,8 +1365,8 @@ pub fn[T] Array::repeat(self : Array[T], times : Int) -> Array[T] {
 pub fn[A, B] Array::fold(
   self : Array[A],
   init~ : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   for i = 0, acc = init; i < self.length(); {
     continue i + 1, f(acc, self[i])
   } else {
@@ -1381,8 +1387,8 @@ pub fn[A, B] Array::fold(
 pub fn[A, B] Array::rev_fold(
   self : Array[A],
   init~ : B,
-  f : (B, A) -> B?Error
-) -> B?Error {
+  f : (B, A) -> B raise?
+) -> B raise? {
   for i = self.length() - 1, acc = init; i >= 0; {
     continue i - 1, f(acc, self[i])
   } else {
@@ -1403,8 +1409,8 @@ pub fn[A, B] Array::rev_fold(
 pub fn[A, B] Array::foldi(
   self : Array[A],
   init~ : B,
-  f : (Int, B, A) -> B?Error
-) -> B?Error {
+  f : (Int, B, A) -> B raise?
+) -> B raise? {
   for i = 0, acc = init; i < self.length(); {
     continue i + 1, f(i, acc, self[i])
   } else {
@@ -1425,8 +1431,8 @@ pub fn[A, B] Array::foldi(
 pub fn[A, B] Array::rev_foldi(
   self : Array[A],
   init~ : B,
-  f : (Int, B, A) -> B?Error
-) -> B?Error {
+  f : (Int, B, A) -> B raise?
+) -> B raise? {
   let len = self.length()
   for i = len - 1, acc = init; i >= 0; {
     continue i - 1, f(len - i - 1, acc, self[i])
@@ -1448,9 +1454,9 @@ pub fn[A, B] Array::rev_foldi(
 #coverage.skip
 pub fn[T, U] Array::fold_left(
   self : Array[T],
-  f : (U, T) -> U?Error,
+  f : (U, T) -> U raise?,
   init~ : U
-) -> U?Error {
+) -> U raise? {
   self.fold(init~, f)
 }
 
@@ -1467,9 +1473,9 @@ pub fn[T, U] Array::fold_left(
 #coverage.skip
 pub fn[T, U] Array::fold_right(
   self : Array[T],
-  f : (U, T) -> U?Error,
+  f : (U, T) -> U raise?,
   init~ : U
-) -> U?Error {
+) -> U raise? {
   self.rev_fold(init~, f)
 }
 
@@ -1486,9 +1492,9 @@ pub fn[T, U] Array::fold_right(
 #coverage.skip
 pub fn[T, U] Array::fold_lefti(
   self : Array[T],
-  f : (Int, U, T) -> U?Error,
+  f : (Int, U, T) -> U raise?,
   init~ : U
-) -> U?Error {
+) -> U raise? {
   self.foldi(init~, f)
 }
 
@@ -1505,9 +1511,9 @@ pub fn[T, U] Array::fold_lefti(
 #coverage.skip
 pub fn[T, U] Array::fold_righti(
   self : Array[T],
-  f : (Int, U, T) -> U?Error,
+  f : (Int, U, T) -> U raise?,
   init~ : U
-) -> U?Error {
+) -> U raise? {
   self.rev_foldi(init~, f)
 }
 
@@ -1670,8 +1676,8 @@ pub fn[T] Array::chunks(self : Array[T], size : Int) -> Array[Array[T]] {
 #locals(pred)
 pub fn[T] Array::chunk_by(
   self : Array[T],
-  pred : (T, T) -> Bool?Error
-) -> Array[Array[T]]?Error {
+  pred : (T, T) -> Bool raise?
+) -> Array[Array[T]] raise? {
   let chunks = []
   let mut i = 0
   while i < self.length() {
@@ -1757,8 +1763,8 @@ pub fn[T] Array::windows(self : Array[T], size : Int) -> Array[ArrayView[T]] {
 #locals(pred)
 pub fn[T] Array::split(
   self : Array[T],
-  pred : (T) -> Bool?Error
-) -> Array[Array[T]]?Error {
+  pred : (T) -> Bool raise?
+) -> Array[Array[T]] raise? {
   let chunks = []
   let mut i = 0
   while i < self.length() {

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -691,7 +691,8 @@ test "each with error callback 2" {
         fail("Error at 2")
       }
       sum += x
-    }) catch {
+    })
+  catch {
     Failure(_) => {
       inspect(sum, content="1")
       assert_true(true)
@@ -725,7 +726,8 @@ test "eachi with error callback 2" {
         fail("Error at 2")
       }
       sum += x + i
-    }) catch {
+    })
+  catch {
     Failure(_) => {
       inspect(sum, content="1")
       assert_true(true)
@@ -762,7 +764,8 @@ test "map with error callback 2" {
         fail("Error at 2")
       }
       x + 1
-    }) catch {
+    })
+  catch {
     Failure(_) => assert_true(true)
   } else {
     _ => assert_true(false)
@@ -796,7 +799,8 @@ test "mapi with error callback 2" {
         raise Failure("Error at 2")
       }
       x + i
-    }) catch {
+    })
+  catch {
     Failure(_) => assert_true(true)
   } else {
     _ => assert_true(false)
@@ -830,7 +834,8 @@ test "filter with error callback 2" {
         raise Failure("Error at 2")
       }
       x % 2 == 0
-    }) catch {
+    })
+  catch {
     Failure(_) => assert_true(true)
   } else {
     _ => assert_true(false)
@@ -864,7 +869,8 @@ test "map_inplace with error callback 2" {
         raise Failure("Error at 2")
       }
       x + 1
-    }) catch {
+    })
+  catch {
     Failure(_) => assert_true(true)
   } else {
     _ => assert_true(false)

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -17,7 +17,8 @@
 // generic type parameters of extern ffi
 
 ///|
-priv extern type JSValue
+#external
+priv type JSValue
 
 ///|
 fn[T] JSValue::ofAny(array : T) -> JSValue = "%identity"
@@ -26,7 +27,8 @@ fn[T] JSValue::ofAny(array : T) -> JSValue = "%identity"
 fn[T] JSValue::toAny(self : JSValue) -> T = "%identity"
 
 ///|
-priv extern type JSArray
+#external
+priv type JSArray
 
 ///|
 fn[T] JSArray::ofAnyArray(array : Array[T]) -> JSArray = "%identity"
@@ -68,7 +70,8 @@ extern "js" fn JSArray::splice1(
 ///|
 /// An `Array` is a collection of values that supports random access and can
 /// grow in size.
-extern type Array[T]
+#external
+type Array[T]
 
 ///|
 fn[T] Array::make_uninit(len : Int) -> Array[T] = "%fixedarray.make_uninit"

--- a/builtin/assert.mbt
+++ b/builtin/assert.mbt
@@ -47,7 +47,11 @@ fn[T : Show] debug_string(t : T) -> String {
 /// }
 /// ```
 #coverage.skip
-pub fn[T : Eq + Show] assert_eq(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
+pub fn[T : Eq + Show] assert_eq(
+  a : T,
+  b : T,
+  loc~ : SourceLoc = _
+) -> Unit raise {
   if a != b {
     fail("`\{a} != \{b}`", loc~)
   }
@@ -84,7 +88,7 @@ pub fn[T : Eq + Show] assert_not_eq(
   a : T,
   b : T,
   loc~ : SourceLoc = _
-) -> Unit! {
+) -> Unit raise {
   if not(a != b) {
     let a = debug_string(a)
     let b = debug_string(b)
@@ -117,7 +121,7 @@ pub fn[T : Eq + Show] assert_not_eq(
 /// }
 /// ```
 #coverage.skip
-pub fn assert_true(x : Bool, loc~ : SourceLoc = _) -> Unit! {
+pub fn assert_true(x : Bool, loc~ : SourceLoc = _) -> Unit raise {
   if not(x) {
     fail("`\{x}` is not true", loc~)
   }
@@ -149,7 +153,7 @@ pub fn assert_true(x : Bool, loc~ : SourceLoc = _) -> Unit! {
 /// }
 /// ```
 #coverage.skip
-pub fn assert_false(x : Bool, loc~ : SourceLoc = _) -> Unit! {
+pub fn assert_false(x : Bool, loc~ : SourceLoc = _) -> Unit raise {
   if x {
     let x = debug_string(x)
     fail("`\{x}` is not false", loc~)

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -21,7 +21,7 @@
 /// opaque. Users cannot construct values of this type directly; they are
 /// automatically created by the compiler when needed.
 /// TODO: can not make a dummy loc
-pub(all) extern type SourceLoc
+pub(all) type SourceLoc
 
 ///|
 /// Converts a source location to its string representation.

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -3,22 +3,22 @@ package "moonbitlang/core/builtin"
 // Values
 fn[T] abort(String) -> T
 
-fn[T : Eq + Show] assert_eq(T, T, loc~ : SourceLoc = _) -> Unit!
+fn[T : Eq + Show] assert_eq(T, T, loc~ : SourceLoc = _) -> Unit raise
 
-fn assert_false(Bool, loc~ : SourceLoc = _) -> Unit!
+fn assert_false(Bool, loc~ : SourceLoc = _) -> Unit raise
 
-fn[T : Eq + Show] assert_not_eq(T, T, loc~ : SourceLoc = _) -> Unit!
+fn[T : Eq + Show] assert_not_eq(T, T, loc~ : SourceLoc = _) -> Unit raise
 
-fn assert_true(Bool, loc~ : SourceLoc = _) -> Unit!
+fn assert_true(Bool, loc~ : SourceLoc = _) -> Unit raise
 
 #deprecated
 fn[T] dump(T, name? : String, loc~ : SourceLoc = _) -> T
 
-fn[T] fail(String, loc~ : SourceLoc = _) -> T!Failure
+fn[T] fail(String, loc~ : SourceLoc = _) -> T raise Failure
 
 fn[T] ignore(T) -> Unit
 
-fn inspect(&Show, content~ : String = .., loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit!InspectError
+fn inspect(&Show, content~ : String = .., loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise InspectError
 
 fn not(Bool) -> Bool
 
@@ -51,30 +51,30 @@ fn[T : Compare] Array::binary_search(Self[T], T) -> Result[Int, Int]
 fn[T] Array::binary_search_by(Self[T], (T) -> Int) -> Result[Int, Int]
 fn[A] Array::blit_to(Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit
 fn[T] Array::capacity(Self[T]) -> Int
-fn[T] Array::chunk_by(Self[T], (T, T) -> Bool?Error) -> Self[Self[T]]?Error
+fn[T] Array::chunk_by(Self[T], (T, T) -> Bool raise?) -> Self[Self[T]] raise?
 fn[T] Array::chunks(Self[T], Int) -> Self[Self[T]]
 fn[T] Array::clear(Self[T]) -> Unit
 fn[T : Eq] Array::contains(Self[T], T) -> Bool
 fn[T : Eq] Array::dedup(Self[T]) -> Unit
 fn[T] Array::drain(Self[T], Int, Int) -> Self[T]
-fn[T] Array::each(Self[T], (T) -> Unit?Error) -> Unit?Error
-fn[T] Array::eachi(Self[T], (Int, T) -> Unit?Error) -> Unit?Error
+fn[T] Array::each(Self[T], (T) -> Unit raise?) -> Unit raise?
+fn[T] Array::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 fn[T : Eq] Array::ends_with(Self[T], Self[T]) -> Bool
 fn[T] Array::extract_if(Self[T], (T) -> Bool) -> Self[T]
-fn[T] Array::filter(Self[T], (T) -> Bool?Error) -> Self[T]?Error
+fn[T] Array::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
 #deprecated
 fn[T] Array::find_index(Self[T], (T) -> Bool) -> Int?
 fn[T] Array::flatten(Self[Self[T]]) -> Self[T]
-fn[A, B] Array::fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
+fn[A, B] Array::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 #deprecated
-fn[T, U] Array::fold_left(Self[T], (U, T) -> U?Error, init~ : U) -> U?Error
+fn[T, U] Array::fold_left(Self[T], (U, T) -> U raise?, init~ : U) -> U raise?
 #deprecated
-fn[T, U] Array::fold_lefti(Self[T], (Int, U, T) -> U?Error, init~ : U) -> U?Error
+fn[T, U] Array::fold_lefti(Self[T], (Int, U, T) -> U raise?, init~ : U) -> U raise?
 #deprecated
-fn[T, U] Array::fold_right(Self[T], (U, T) -> U?Error, init~ : U) -> U?Error
+fn[T, U] Array::fold_right(Self[T], (U, T) -> U raise?, init~ : U) -> U raise?
 #deprecated
-fn[T, U] Array::fold_righti(Self[T], (Int, U, T) -> U?Error, init~ : U) -> U?Error
-fn[A, B] Array::foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[T, U] Array::fold_righti(Self[T], (Int, U, T) -> U raise?, init~ : U) -> U raise?
+fn[A, B] Array::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 fn[T] Array::from_fixed_array(FixedArray[T]) -> Self[T]
 fn[T] Array::get(Self[T], Int) -> T?
 fn[T] Array::insert(Self[T], Int, T) -> Unit
@@ -84,10 +84,10 @@ fn[T] Array::iter(Self[T]) -> Iter[T]
 fn[A] Array::iter2(Self[A]) -> Iter2[Int, A]
 fn[T] Array::length(Self[T]) -> Int
 fn[T] Array::make(Int, T) -> Self[T]
-fn[T, U] Array::map(Self[T], (T) -> U?Error) -> Self[U]?Error
-fn[T] Array::map_inplace(Self[T], (T) -> T?Error) -> Unit?Error
-fn[T, U] Array::mapi(Self[T], (Int, T) -> U?Error) -> Self[U]?Error
-fn[T] Array::mapi_inplace(Self[T], (Int, T) -> T?Error) -> Unit?Error
+fn[T, U] Array::map(Self[T], (T) -> U raise?) -> Self[U] raise?
+fn[T] Array::map_inplace(Self[T], (T) -> T raise?) -> Unit raise?
+fn[T, U] Array::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?
+fn[T] Array::mapi_inplace(Self[T], (Int, T) -> T raise?) -> Unit raise?
 fn[T] Array::new(capacity~ : Int = ..) -> Self[T]
 fn[T] Array::op_as_view(Self[T], start~ : Int = .., end? : Int) -> ArrayView[T]
 fn[T] Array::op_get(Self[T], Int) -> T
@@ -100,18 +100,18 @@ fn[T] Array::remove(Self[T], Int) -> T
 fn[T] Array::repeat(Self[T], Int) -> Self[T]
 fn[T] Array::reserve_capacity(Self[T], Int) -> Unit
 fn[T] Array::resize(Self[T], Int, T) -> Unit
-fn[T] Array::retain(Self[T], (T) -> Bool?Error) -> Unit?Error
+fn[T] Array::retain(Self[T], (T) -> Bool raise?) -> Unit raise?
 fn[T] Array::rev(Self[T]) -> Self[T]
 fn[T] Array::rev_each(Self[T], (T) -> Unit) -> Unit
-fn[T] Array::rev_eachi(Self[T], (Int, T) -> Unit?Error) -> Unit?Error
-fn[A, B] Array::rev_fold(Self[A], init~ : B, (B, A) -> B?Error) -> B?Error
-fn[A, B] Array::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B?Error) -> B?Error
+fn[T] Array::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
+fn[A, B] Array::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
+fn[A, B] Array::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 fn[T] Array::rev_inplace(Self[T]) -> Unit
 fn[T] Array::rev_iter(Self[T]) -> Iter[T]
 fn[T : Eq] Array::search(Self[T], T) -> Int?
 fn[T] Array::search_by(Self[T], (T) -> Bool) -> Int?
 fn[T] Array::shrink_to_fit(Self[T]) -> Unit
-fn[T] Array::split(Self[T], (T) -> Bool?Error) -> Self[Self[T]]?Error
+fn[T] Array::split(Self[T], (T) -> Bool raise?) -> Self[Self[T]] raise?
 fn[T] Array::split_at(Self[T], Int) -> (Self[T], Self[T])
 fn[T : Eq] Array::starts_with(Self[T], Self[T]) -> Bool
 fn[T : Eq] Array::strip_prefix(Self[T], Self[T]) -> Self[T]?
@@ -255,8 +255,8 @@ fn[K, V] Map::capacity(Self[K, V]) -> Int
 fn[K, V] Map::clear(Self[K, V]) -> Unit
 fn[K : Hash + Eq, V] Map::contains(Self[K, V], K) -> Bool
 fn[K : Hash + Eq, V : Eq] Map::contains_kv(Self[K, V], K, V) -> Bool
-fn[K, V] Map::each(Self[K, V], (K, V) -> Unit?Error) -> Unit?Error
-fn[K, V] Map::eachi(Self[K, V], (Int, K, V) -> Unit?Error) -> Unit?Error
+fn[K, V] Map::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
+fn[K, V] Map::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
 fn[K : Hash + Eq, V] Map::from_array(Array[(K, V)]) -> Self[K, V]
 fn[K : Hash + Eq, V] Map::from_iter(Iter[(K, V)]) -> Self[K, V]
 fn[K : Hash + Eq, V] Map::get(Self[K, V], K) -> V?
@@ -512,7 +512,7 @@ fn[X : Show] Option::to_string(X?) -> String
 fn[X] Option::unwrap(X?) -> X
 
 fn[T : Compare] FixedArray::binary_search(Self[T], T) -> Result[Int, Int]
-fn[T] FixedArray::binary_search_by(Self[T], (T) -> Int?Error) -> Result[Int, Int]?Error
+fn[T] FixedArray::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
 fn FixedArray::blit_from_bytes(Self[Byte], Int, Bytes, Int, Int) -> Unit
 fn FixedArray::blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
 fn[A] FixedArray::blit_to(Self[A], Self[A], len~ : Int, src_offset~ : Int = .., dst_offset~ : Int = ..) -> Unit

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -140,9 +140,9 @@ fn[T] ArrayView::swap(Self[T], Int, Int) -> Unit
 fn[T] ArrayView::unsafe_get(Self[T], Int) -> T
 impl[X : ToJson] ToJson for ArrayView[X]
 
-pub(all) type! BenchError String
+pub(all) suberror BenchError String
 
-pub(all) type! Failure String
+pub(all) suberror Failure String
 impl Show for Failure
 
 type Hasher
@@ -162,7 +162,7 @@ fn Hasher::combine_unit(Self) -> Unit
 fn Hasher::finalize(Self) -> Int
 fn Hasher::new(seed~ : Int = ..) -> Self
 
-pub(all) type! InspectError String
+pub(all) suberror InspectError String
 
 type Iter[T]
 fn[T] Iter::all(Self[T], (T) -> Bool) -> Bool
@@ -281,7 +281,7 @@ impl[K : Hash + Eq, V : Eq] Eq for Map[K, V]
 impl[K : Show, V : Show] Show for Map[K, V]
 impl[K : Show, V : ToJson] ToJson for Map[K, V]
 
-pub(all) type! SnapshotError String
+pub(all) suberror SnapshotError String
 
 pub(all) extern type SourceLoc
 fn SourceLoc::to_string(Self) -> String

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -488,14 +488,14 @@ fn Double::until(Double, Double, step~ : Double = .., inclusive~ : Bool = ..) ->
 #deprecated
 fn Double::upto(Double, Double, inclusive~ : Bool = ..) -> Iter[Double]
 
-fn String::char_length(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int
+fn String::char_length(String, start_offset~ : Int = .., end_offset? : Int) -> Int
 fn String::charcode_at(String, Int) -> Int
 #deprecated
 fn String::charcode_length(String) -> Int
 #deprecated
 fn String::codepoint_at(String, Int) -> Char
 #deprecated
-fn String::codepoint_length(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int
+fn String::codepoint_length(String, start_offset~ : Int = .., end_offset? : Int) -> Int
 fn String::escape(String) -> String
 #deprecated
 fn String::get(String, Int) -> Char
@@ -541,7 +541,7 @@ fn Bytes::new(Int) -> Bytes
 #deprecated
 fn Bytes::of_string(String) -> Bytes
 fn Bytes::op_get(Bytes, Int) -> Byte
-fn Bytes::to_unchecked_string(Bytes, offset~ : Int = .., length~ : Int = ..) -> String
+fn Bytes::to_unchecked_string(Bytes, offset~ : Int = .., length? : Int) -> String
 fn Bytes::unsafe_get(Bytes, Int) -> Byte
 
 fn[T : Show] Logger::write_iter(&Self, Iter[T], prefix~ : String = .., suffix~ : String = .., sep~ : String = .., trailing~ : Bool = ..) -> Unit

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -283,7 +283,7 @@ impl[K : Show, V : ToJson] ToJson for Map[K, V]
 
 pub(all) suberror SnapshotError String
 
-pub(all) extern type SourceLoc
+pub(all) type SourceLoc
 fn SourceLoc::to_string(Self) -> String
 impl Show for SourceLoc
 

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -93,9 +93,10 @@ fn unsafe_sub_string(
 pub fn Bytes::to_unchecked_string(
   self : Bytes,
   offset~ : Int = 0,
-  length~ : Int = self.length() - offset
+  length? : Int
 ) -> String {
   let len = self.length()
+  let length = if length is Some(l) { l } else { len - offset }
   guard offset >= 0 && length >= 0 && offset + length <= len
   unsafe_sub_string(self, offset, length)
 }

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -197,7 +197,7 @@ pub fn inspect(
   content~ : String = "",
   loc~ : SourceLoc = _,
   args_loc~ : ArgsLoc = _
-) -> Unit!InspectError {
+) -> Unit raise InspectError {
   let actual = obj.to_string()
   if actual != content {
     let loc = loc.to_string().escape()

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -66,7 +66,7 @@ pub fn[T] dump(t : T, name? : String, loc~ : SourceLoc = _) -> T {
 ///   inspect(x, content="42") // Raises InspectError with detailed failure message
 /// }
 /// ```
-pub(all) type! InspectError String
+pub(all) suberror InspectError String
 
 ///|
 fn base64_encode(data : FixedArray[Byte]) -> String {
@@ -229,10 +229,10 @@ pub fn inspect(
 ///   }
 /// }
 /// ```
-pub(all) type! SnapshotError String
+pub(all) suberror SnapshotError String
 
 ///|
-pub(all) type! BenchError String
+pub(all) suberror BenchError String
 
 ///|
 test "panic error case of inspect" {

--- a/builtin/existensial_test.mbt
+++ b/builtin/existensial_test.mbt
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 ///|
-type! StringError String
+suberror StringError String
 
 ///|
-type! IntError Int
+suberror IntError Int
 
 ///|
 test {

--- a/builtin/failure.mbt
+++ b/builtin/failure.mbt
@@ -33,7 +33,7 @@
 ///   }
 /// }
 /// ```
-pub(all) type! Failure String
+pub(all) suberror Failure String
 
 ///|
 /// Raises a `Failure` error with a given message and source location.

--- a/builtin/failure.mbt
+++ b/builtin/failure.mbt
@@ -57,6 +57,6 @@ pub(all) suberror Failure String
 ///   fail("Something went wrong")
 /// }
 /// ```
-pub fn[T] fail(msg : String, loc~ : SourceLoc = _) -> T!Failure {
+pub fn[T] fail(msg : String, loc~ : SourceLoc = _) -> T raise Failure {
   raise Failure("FAILED: \{loc} \{msg}")
 }

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -277,8 +277,8 @@ pub fn[T : Compare] FixedArray::binary_search(
 #locals(cmp)
 pub fn[T] FixedArray::binary_search_by(
   self : FixedArray[T],
-  cmp : (T) -> Int?Error
-) -> Result[Int, Int]?Error {
+  cmp : (T) -> Int raise?
+) -> Result[Int, Int] raise? {
   let len = self.length()
   for i = 0, j = len; i < j; {
     let h = i + (j - i) / 2

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1828,7 +1828,7 @@ pub fn String::to_string(self : String) -> String = "%string_to_string"
 
 ///|
 // For internal use only
-priv extern type UnsafeMaybeUninit[_]
+priv type UnsafeMaybeUninit[_]
 
 ///|
 /// Converts a byte value to a 32-bit signed integer. The resulting integer will

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -447,8 +447,8 @@ pub fn[K, V] Map::is_empty(self : Map[K, V]) -> Bool {
 #locals(f)
 pub fn[K, V] Map::each(
   self : Map[K, V],
-  f : (K, V) -> Unit?Error
-) -> Unit?Error {
+  f : (K, V) -> Unit raise?
+) -> Unit raise? {
   loop self.head {
     Some({ key, value, next, .. }) => {
       f(key, value)
@@ -463,8 +463,8 @@ pub fn[K, V] Map::each(
 #locals(f)
 pub fn[K, V] Map::eachi(
   self : Map[K, V],
-  f : (Int, K, V) -> Unit?Error
-) -> Unit?Error {
+  f : (Int, K, V) -> Unit raise?
+) -> Unit raise? {
   loop (0, self.head) {
     (i, Some({ key, value, next, .. })) => {
       f(i, key, value)

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -165,8 +165,9 @@ pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
 pub fn String::char_length(
   self : String,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Int {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -194,9 +195,9 @@ pub fn String::char_length(
 pub fn String::codepoint_length(
   self : String,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Int {
-  self.char_length(start_offset~, end_offset~)
+  self.char_length(start_offset~, end_offset?)
 }
 
 ///|

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -657,7 +657,7 @@ test "test_from_vec" {
 
 ///|
 test "test_from_array" {
-  fn test_fn!(n : Int) -> Unit {
+  fn test_fn(n : Int) -> Unit raise {
     let array : FixedArray[Int] = FixedArray::make(n, 0)
     for index in 0..<n {
       array[index] = index
@@ -704,7 +704,7 @@ test "test_clone_from" {
 test "deque guard iter coverage improvement" {
   let dq = @deque.new(capacity=15)
   // Use push_front only
-  fn test_n_via_push_front(n : Int) -> Unit! {
+  fn test_n_via_push_front(n : Int) -> Unit raise {
     for i in 0..=n {
       dq.push_front(i)
     }
@@ -761,7 +761,7 @@ test "deque guard iter after push_front and push_back" {
 test "deque guard iter2 coverage improvement" {
   let dq = @deque.new(capacity=15)
   // Use push_front only
-  fn test_n_via_push_front(n : Int) -> Unit! {
+  fn test_n_via_push_front(n : Int) -> Unit raise {
     for i in 0..=n {
       dq.push_front(i)
     }
@@ -849,7 +849,7 @@ test "deque retain" {
   @json.inspect(dq.as_views(), content=[[2, 4], []])
 
   // Test split case (head_len < len)
-  fn dq!() {
+  fn dq() raise {
     // Push and pop to create a wrap-around situation
     let dq = @deque.of([1, 2, 3, 4, 5, 6])
     dq
@@ -893,7 +893,7 @@ test "deque retain_map" {
   @json.inspect(dq.as_views(), content=[[3, 5], []])
 
   // Test split case (head_len < len)
-  fn dq!() {
+  fn dq() raise {
     // Push and pop to create a wrap-around situation
     let dq = @deque.of([1, 2, 3, 4, 5, 6])
     dq

--- a/double/cbrt_test.mbt
+++ b/double/cbrt_test.mbt
@@ -37,7 +37,7 @@ test "cbrt" {
     17.95802978703349, 18.947593347990452, 19.927655294373867, 20.02047902332293,
     20.9048606324266, 21.72014665034662,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }

--- a/double/exp_test.mbt
+++ b/double/exp_test.mbt
@@ -69,7 +69,7 @@ test "expm1" {
     289.03453439173467, 879.0687241078031, 2669.443920676805, 7330.973539155995,
     19340.338973747792, 58687.55427461758,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }

--- a/double/hyperbolic_test.mbt
+++ b/double/hyperbolic_test.mbt
@@ -88,7 +88,7 @@ test "hyperbolic" {
     -0.0007649998507676599, -0.0006539999067579279, -0.0005429999466323373, -0.000431999973126146,
     -0.00032099998897461345, -0.00020999999691300006, -0.00010899999956832366, -0.00009869999967949839,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }
@@ -130,7 +130,7 @@ test "asinh" {
     6.538633835534552, 6.817350253294403, 7.0350756937495404, 7.213621564277984,
     7.363926577179187, 7.484503781189334, 7.496907985311977, 7.5884758208251615,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }
@@ -162,7 +162,7 @@ test "acosh" {
     6.538629651005136, 6.817347856913533, 7.035074143357386, 7.213620479456226, 7.363925774013791,
     7.4845031501260895, 7.496907369711817, 7.588475308242551,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }
@@ -200,7 +200,7 @@ test "atanh" {
     0.05676087889558879, 0.06790417606372265, 0.07906433728155227, 0.09034500538583387,
     0.10154761647863907, 0.11277568726185497,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }

--- a/double/hypot_test.mbt
+++ b/double/hypot_test.mbt
@@ -34,7 +34,7 @@ test "hypot" {
     6.876772498781678, 11.113955191559844, 10.178899744078432, 9.280086206496145,
     8.429116205154607, 7.6419892698171195,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }

--- a/double/log_test.mbt
+++ b/double/log_test.mbt
@@ -73,7 +73,7 @@ test "ln_1p" {
     -0.41551544396166584, -0.5978370007556204, -0.8209805520698303, -1.1086626245216111,
     -1.5141277326297757, -2.207274913189721, -2.302585092994046, -3.912023005428145,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_true(ulp <= 1)
   }

--- a/double/trig_test.mbt
+++ b/double/trig_test.mbt
@@ -83,7 +83,7 @@ test "trigonometric functions" {
     7.306955375206259, -1.500312072006621, -0.5518927161160188, 0.7803809841437486,
     7.606099243270125,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_eq(ulp <= 1, true)
   }
@@ -143,7 +143,7 @@ test "Inverse trigonometric functions" {
     2.319923687347004, 2.4848742888410893, 2.6747638630382777, 3.031993295758154,
     1.6945620578879512,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_eq(ulp <= 1, true)
   }
@@ -185,7 +185,7 @@ test "atan" {
     1.5707963186948966, -1.570796319430718, -1.5707963240010128, -1.5707963095310986,
     -1.5707962006068632, -1.5707952453419127, -1.570755809814455, -1.5705827077279444,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_eq(ulp <= 1, true)
   }
@@ -223,7 +223,7 @@ test "atan2" {
     1.4487689576369092, 1.2363766288700382, 1.0509901103283912, 0.8978026526840324,
     0.7853981633974483,
   ]
-  fn high_accuracy_test(expect : Double, actual : Double) -> Unit!Error {
+  fn high_accuracy_test(expect : Double, actual : Double) -> Unit raise Error {
     let ulp = (expect.reinterpret_as_int64() - actual.reinterpret_as_int64()).abs()
     assert_eq(ulp <= 1, true)
   }

--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 ///|
-priv extern type XStringReadHandle
+#external
+priv type XStringReadHandle
 
 ///|
-priv extern type XExternString
+#external
+priv type XExternString
 
 ///|
 fn begin_read_string(s : XExternString) -> XStringReadHandle = "__moonbit_fs_unstable" "begin_read_string"
@@ -45,10 +47,12 @@ fn string_from_extern(e : XExternString) -> String {
 }
 
 ///|
-priv extern type XStringArrayReadHandle
+#external
+priv type XStringArrayReadHandle
 
 ///|
-priv extern type XExternStringArray
+#external
+priv type XExternStringArray
 
 ///|
 fn begin_read_string_array(sa : XExternStringArray) -> XStringArrayReadHandle = "__moonbit_fs_unstable" "begin_read_string_array"

--- a/error/error_test.mbt
+++ b/error/error_test.mbt
@@ -58,14 +58,14 @@ fn[A, E : Error] protect(
 ) -> A raise E {
   try work() catch {
     e => {
-      try finally() catch {
+      finally() catch {
         _ => ()
       }
       raise e
     }
   } else {
     x => {
-      try finally() catch {
+      finally() catch {
         _ => ()
       }
       x

--- a/error/error_test.mbt
+++ b/error/error_test.mbt
@@ -17,7 +17,7 @@ suberror IntError Int
 
 ///|
 test "show error" {
-  fn f(b : Bool) -> String! {
+  fn f(b : Bool) -> String raise {
     if b {
       "ok"
     } else {
@@ -52,7 +52,10 @@ test "show error" {
 /// The design choice is that `finally` should be allowed to throw or not
 /// If it does throw, which error should be raised?
 /// here `protect` raise the `work` error
-fn[A, E : Error] protect(finally~ : () -> Unit?Error, work : () -> A!E) -> A!E {
+fn[A, E : Error] protect(
+  finally~ : () -> Unit raise?,
+  work : () -> A raise E
+) -> A raise E {
   try work() catch {
     e => {
       try finally() catch {
@@ -76,7 +79,7 @@ fn[A, E : Error] protect(finally~ : () -> Unit?Error, work : () -> A!E) -> A!E {
 /// However, due to the error comes from multiple sources,
 /// it is hard to track which error is the original one
 /// in the type system
-fn[A] protect2(finally~ : () -> Unit?Error, work : () -> A!) -> A! {
+fn[A] protect2(finally~ : () -> Unit raise?, work : () -> A raise) -> A raise {
   try work() catch {
     e => {
       finally()

--- a/error/error_test.mbt
+++ b/error/error_test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-type! IntError Int
+suberror IntError Int
 
 ///|
 test "show error" {
@@ -159,10 +159,10 @@ test "protect2 & finally raise error" {
 }
 
 ///|
-type! ErrWithToJson Int derive(ToJson)
+suberror ErrWithToJson Int derive(ToJson)
 
 ///|
-type! ErrWithoutToJson Int
+suberror ErrWithoutToJson Int
 
 ///|
 test "error to json" {

--- a/immut/array/array_mix_wbtest.mbt
+++ b/immut/array/array_mix_wbtest.mbt
@@ -21,7 +21,7 @@ test "random property tests" {
 }
 
 ///|
-fn run_test(seed : UInt64, rep : Int, max_lvl : Int) -> Unit! {
+fn run_test(seed : UInt64, rep : Int, max_lvl : Int) -> Unit raise {
   let rng = Random({ val: seed })
   let rs = random_test_gen(rng, rep, max_lvl)
   execute_array_test(rs)

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -76,7 +76,7 @@ fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
 /// 2. set
 /// 
 /// The `rs` array is a sequence of operations to be executed.
-fn execute_array_test(rs : Array[Op]) -> Unit! {
+fn execute_array_test(rs : Array[Op]) -> Unit raise {
   let mut t = new()
   let a : Array[Int] = []
   for op in rs {
@@ -120,7 +120,7 @@ fn branching_factor_power(a : Int) -> Int {
 /// Use this function to check if the array and the @immut/array are equal.
 /// If we `inspect` the array, it will raise an error if the arrays are too long.
 /// I guess that's because it exceeds the heap limit of the VM.
-fn check_array_eq(a : Array[Int], t : T[Int]) -> Unit! {
+fn check_array_eq(a : Array[Int], t : T[Int]) -> Unit raise {
   assert_eq(a.length(), t.size)
   let len = t.size
   for i in 0..<len {

--- a/immut/list/deprecated.mbt
+++ b/immut/list/deprecated.mbt
@@ -17,7 +17,7 @@
 #coverage.skip
 pub fn[A : @json.FromJson] T::from_json(
   json : Json
-) -> T[A]!@json.JsonDecodeError {
+) -> T[A] raise @json.JsonDecodeError {
   @json.from_json(json)
 }
 

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -51,7 +51,9 @@ pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) 
 }
 
 ///|
-pub fn[A : @json.FromJson] from_json(json : Json) -> T[A]!@json.JsonDecodeError {
+pub fn[A : @json.FromJson] from_json(
+  json : Json
+) -> T[A] raise @json.JsonDecodeError {
   @json.from_json(json)
 }
 

--- a/immut/list/list.mbti
+++ b/immut/list/list.mbti
@@ -66,7 +66,7 @@ fn[A] from_iter(Iter[A]) -> T[A]
 
 fn[A] from_iter_rev(Iter[A]) -> T[A]
 
-fn[A : @json.FromJson] from_json(Json) -> T[A]!@json.JsonDecodeError
+fn[A : @json.FromJson] from_json(Json) -> T[A] raise @json.JsonDecodeError
 
 fn[A] head(T[A]) -> A?
 
@@ -202,7 +202,7 @@ fn[A] T::from_array(Array[A]) -> Self[A]
 #deprecated
 fn[A] T::from_iter(Iter[A]) -> Self[A]
 #deprecated
-fn[A : @json.FromJson] T::from_json(Json) -> Self[A]!@json.JsonDecodeError
+fn[A : @json.FromJson] T::from_json(Json) -> Self[A] raise @json.JsonDecodeError
 fn[A] T::head(Self[A]) -> A?
 #deprecated
 fn[A] T::head_exn(Self[A]) -> A

--- a/immut/sorted_map/deprecated.mbt
+++ b/immut/sorted_map/deprecated.mbt
@@ -62,6 +62,6 @@ pub fn[K : Compare, V] T::of(array : FixedArray[(K, V)]) -> T[K, V] {
 #coverage.skip
 pub fn[V : @json.FromJson] T::from_json(
   json : Json
-) -> T[String, V]!@json.JsonDecodeError {
+) -> T[String, V] raise @json.JsonDecodeError {
   @json.from_json(json)
 }

--- a/immut/sorted_map/sorted_map.mbti
+++ b/immut/sorted_map/sorted_map.mbti
@@ -31,7 +31,7 @@ fn[K : Compare, V] from_array(Array[(K, V)]) -> T[K, V]
 
 fn[K : Compare, V] from_iter(Iter[(K, V)]) -> T[K, V]
 
-fn[V : @json.FromJson] from_json(Json) -> T[String, V]!@json.JsonDecodeError
+fn[V : @json.FromJson] from_json(Json) -> T[String, V] raise @json.JsonDecodeError
 
 fn[K : Compare, V] get(T[K, V], K) -> V?
 
@@ -92,7 +92,7 @@ fn[K : Compare, V] T::from_array(Array[(K, V)]) -> Self[K, V]
 #deprecated
 fn[K : Compare, V] T::from_iter(Iter[(K, V)]) -> Self[K, V]
 #deprecated
-fn[V : @json.FromJson] T::from_json(Json) -> Self[String, V]!@json.JsonDecodeError
+fn[V : @json.FromJson] T::from_json(Json) -> Self[String, V] raise @json.JsonDecodeError
 fn[K : Compare, V] T::get(Self[K, V], K) -> V?
 #deprecated
 fn[K : Compare, V] T::insert(Self[K, V], K, V) -> Self[K, V]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -304,6 +304,6 @@ pub fn[K : Show, V : ToJson] to_json(self : T[K, V]) -> Json {
 ///|
 pub fn[V : @json.FromJson] from_json(
   json : Json
-) -> T[String, V]!@json.JsonDecodeError {
+) -> T[String, V] raise @json.JsonDecodeError {
   @json.from_json(json)
 }

--- a/immut/sorted_set/deprecated.mbt
+++ b/immut/sorted_set/deprecated.mbt
@@ -38,7 +38,7 @@ pub fn[A : Compare] T::from_array(array : Array[A]) -> T[A] {
 #coverage.skip
 pub fn[A : @json.FromJson + Compare] T::from_json(
   json : Json
-) -> T[A]!@json.JsonDecodeError {
+) -> T[A] raise @json.JsonDecodeError {
   @json.from_json(json)
 }
 

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -609,7 +609,7 @@ pub impl[A : @json.FromJson + Compare] @json.FromJson for T[A] with from_json(
 ///|
 pub fn[A : @json.FromJson + Compare] from_json(
   json : Json
-) -> T[A]!@json.JsonDecodeError {
+) -> T[A] raise @json.JsonDecodeError {
   @json.from_json(json)
 }
 

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -31,7 +31,7 @@ fn[A : Compare] from_array(Array[A]) -> T[A]
 
 fn[A : Compare] from_iter(Iter[A]) -> T[A]
 
-fn[A : @json.FromJson + Compare] from_json(Json) -> T[A]!@json.JsonDecodeError
+fn[A : @json.FromJson + Compare] from_json(Json) -> T[A] raise @json.JsonDecodeError
 
 #deprecated
 fn[A : Compare] inter(T[A], T[A]) -> T[A]
@@ -94,7 +94,7 @@ fn[A : Compare] T::from_array(Array[A]) -> Self[A]
 #deprecated
 fn[A : Compare] T::from_iter(Iter[A]) -> Self[A]
 #deprecated
-fn[A : @json.FromJson + Compare] T::from_json(Json) -> Self[A]!@json.JsonDecodeError
+fn[A : @json.FromJson + Compare] T::from_json(Json) -> Self[A] raise @json.JsonDecodeError
 #deprecated
 fn[A : Compare] T::inter(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::intersection(Self[A], Self[A]) -> Self[A]

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -58,7 +58,7 @@ pub impl FromJson for Int64 with from_json(json, path) {
       path, "Int64::from_json: expected number in string representation",
     )
   }
-  try @strconv.parse_int64(str) catch {
+  @strconv.parse_int64(str) catch {
     error => decode_error(path, "Int64::from_json: parsing failure \{error}")
   }
 }
@@ -78,7 +78,7 @@ pub impl FromJson for UInt64 with from_json(json, path) {
       path, "UInt64::from_json: expected number in string representation",
     )
   }
-  try @strconv.parse_uint64(str) catch {
+  @strconv.parse_uint64(str) catch {
     error => decode_error(path, "UInt64::from_json: parsing failure \{error}")
   }
 }

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -18,19 +18,19 @@ pub(all) suberror JsonDecodeError (JsonPath, String) derive(Eq, Show, ToJson)
 ///|
 /// Trait for types that can be converted from `Json`
 pub(open) trait FromJson {
-  from_json(Json, JsonPath) -> Self!JsonDecodeError
+  from_json(Json, JsonPath) -> Self raise JsonDecodeError
 }
 
 ///|
 pub fn[T : FromJson] from_json(
   json : Json,
   path~ : JsonPath = Root
-) -> T!JsonDecodeError {
+) -> T raise JsonDecodeError {
   FromJson::from_json(json, path)
 }
 
 ///|
-fn[T] decode_error(path : JsonPath, msg : String) -> T!JsonDecodeError {
+fn[T] decode_error(path : JsonPath, msg : String) -> T raise JsonDecodeError {
   raise JsonDecodeError((path, msg))
 }
 

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub(all) type! JsonDecodeError (JsonPath, String) derive(Eq, Show, ToJson)
+pub(all) suberror JsonDecodeError (JsonPath, String) derive(Eq, Show, ToJson)
 
 ///|
 /// Trait for types that can be converted from `Json`

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -19,7 +19,7 @@ fn temp() -> Unit {
 }
 
 ///|
-typealias TestX = Map[String, Int]
+typealias Map[String, Int] as TestX
 
 ///|
 test {

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -210,7 +210,7 @@ pub fn inspect(
   content? : Json,
   loc~ : SourceLoc = _,
   args_loc~ : ArgsLoc = _
-) -> Unit!InspectError {
+) -> Unit raise InspectError {
   let loc = loc.to_string().escape()
   let args_loc = args_loc.to_json().escape()
   let actual = obj.to_json().stringify(escape_slash=false)

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -21,13 +21,13 @@ fn as_object(Json) -> Map[String, Json]?
 
 fn as_string(Json) -> String?
 
-fn[T : FromJson] from_json(Json, path~ : JsonPath = ..) -> T!JsonDecodeError
+fn[T : FromJson] from_json(Json, path~ : JsonPath = ..) -> T raise JsonDecodeError
 
-fn inspect(&ToJson, content? : Json, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit!InspectError
+fn inspect(&ToJson, content? : Json, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise InspectError
 
 fn item(Json, Int) -> Json?
 
-fn parse(String) -> Json!ParseError
+fn parse(String) -> Json raise ParseError
 
 fn stringify(Json, escape_slash~ : Bool = .., indent~ : Int = ..) -> String
 
@@ -82,7 +82,7 @@ pub typealias JsonValue = Json
 
 // Traits
 pub(open) trait FromJson {
-  from_json(Json, JsonPath) -> Self!JsonDecodeError
+  from_json(Json, JsonPath) -> Self raise JsonDecodeError
 }
 impl FromJson for Unit
 impl FromJson for Bool

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -36,7 +36,7 @@ fn valid(String) -> Bool
 fn value(Json, String) -> Json?
 
 // Types and methods
-pub(all) type! JsonDecodeError (JsonPath, String)
+pub(all) suberror JsonDecodeError (JsonPath, String)
 impl Eq for JsonDecodeError
 impl Show for JsonDecodeError
 impl ToJson for JsonDecodeError
@@ -48,7 +48,7 @@ impl Eq for JsonPath
 impl Show for JsonPath
 impl ToJson for JsonPath
 
-pub(all) type! ParseError {
+pub(all) suberror ParseError {
   InvalidChar(Position, Char)
   InvalidEof
   InvalidNumber(Position, String)

--- a/json/json_encode_decode_test.mbt
+++ b/json/json_encode_decode_test.mbt
@@ -40,7 +40,7 @@ suberror DecodeError {
 } derive(Eq, Show)
 
 ///|
-fn of_json(jv : Json) -> AllThree!DecodeError {
+fn of_json(jv : Json) -> AllThree raise DecodeError {
   match jv {
     {
       "ints": Array(ints),

--- a/json/json_encode_decode_test.mbt
+++ b/json/json_encode_decode_test.mbt
@@ -35,7 +35,7 @@ fn to_json(self : AllThree) -> Json {
 }
 
 ///|
-type! DecodeError {
+suberror DecodeError {
   DecodeError(String)
 } derive(Eq, Show)
 

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -38,12 +38,12 @@ test "get as bool" {
 }
 
 ///|
-fn _check!(x : String) -> Json {
+fn _check(x : String) -> Json raise {
   @json.parse(x)
 }
 
 ///|
-fn _check2!(x : String) -> Json!@json.ParseError {
+fn _check2(x : String) -> Json raise @json.ParseError {
   @json.parse(x)
 }
 

--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -28,7 +28,7 @@ let non_ascii_whitespace : CharClass = CharClass::of([
 fn ParseContext::lex_value(
   ctx : ParseContext,
   allow_rbracket~ : Bool
-) -> Token!ParseError {
+) -> Token raise ParseError {
   for {
     match ctx.read_char() {
       Some('\t' | ' ' | '\n' | '\r') => continue

--- a/json/lex_misc.mbt
+++ b/json/lex_misc.mbt
@@ -43,7 +43,10 @@ const SURROGATE_HIGH_CHAR = 0xDFFF
 /// `ctx.expect_char(c)` check the current context is c,
 /// if it is, consume the character and return `()`,
 /// otherwise raise an error, when it is an error, the position is unspecified.
-fn ParseContext::expect_char(ctx : ParseContext, c : Char) -> Unit!ParseError {
+fn ParseContext::expect_char(
+  ctx : ParseContext,
+  c : Char
+) -> Unit raise ParseError {
   guard ctx.offset < ctx.end_offset else { raise InvalidEof }
   let c1 = ctx.input.unsafe_charcode_at(ctx.offset)
   ctx.offset += 1
@@ -77,7 +80,7 @@ fn ParseContext::expect_char(ctx : ParseContext, c : Char) -> Unit!ParseError {
 fn ParseContext::expect_ascii_char(
   ctx : ParseContext,
   c : Byte
-) -> Unit!ParseError {
+) -> Unit raise ParseError {
   guard ctx.offset < ctx.end_offset else { raise InvalidEof }
   let c1 = ctx.input.unsafe_charcode_at(ctx.offset)
   ctx.offset += 1
@@ -126,7 +129,9 @@ fn ParseContext::lex_skip_whitespace(ctx : ParseContext) -> Unit {
 }
 
 ///|
-fn ParseContext::lex_after_array_value(ctx : ParseContext) -> Token!ParseError {
+fn ParseContext::lex_after_array_value(
+  ctx : ParseContext
+) -> Token raise ParseError {
   ctx.lex_skip_whitespace()
   match ctx.read_char() {
     Some(']') => RBracket
@@ -137,7 +142,9 @@ fn ParseContext::lex_after_array_value(ctx : ParseContext) -> Token!ParseError {
 }
 
 ///|
-fn ParseContext::lex_after_property_name(ctx : ParseContext) -> Unit!ParseError {
+fn ParseContext::lex_after_property_name(
+  ctx : ParseContext
+) -> Unit raise ParseError {
   ctx.lex_skip_whitespace()
   match ctx.read_char() {
     Some(':') => ()
@@ -147,7 +154,9 @@ fn ParseContext::lex_after_property_name(ctx : ParseContext) -> Unit!ParseError 
 }
 
 ///|
-fn ParseContext::lex_after_object_value(ctx : ParseContext) -> Token!ParseError {
+fn ParseContext::lex_after_object_value(
+  ctx : ParseContext
+) -> Token raise ParseError {
   ctx.lex_skip_whitespace()
   match ctx.read_char() {
     Some('}') => RBrace
@@ -160,7 +169,9 @@ fn ParseContext::lex_after_object_value(ctx : ParseContext) -> Token!ParseError 
 ///|
 /// In the context of `{`, try to lex token `}` or a property name,
 /// otherwise raise an error.
-fn ParseContext::lex_property_name(ctx : ParseContext) -> Token!ParseError {
+fn ParseContext::lex_property_name(
+  ctx : ParseContext
+) -> Token raise ParseError {
   ctx.lex_skip_whitespace()
   match ctx.read_char() {
     Some('}') => RBrace
@@ -177,7 +188,9 @@ fn ParseContext::lex_property_name(ctx : ParseContext) -> Token!ParseError {
 /// In the context of `{ ...,` try to lex a property name,
 /// otherwise raise an error.
 /// since it is in comma context, `}` is not allowed.
-fn ParseContext::lex_property_name2(ctx : ParseContext) -> Token!ParseError {
+fn ParseContext::lex_property_name2(
+  ctx : ParseContext
+) -> Token raise ParseError {
   ctx.lex_skip_whitespace()
   match ctx.read_char() {
     Some('"') => {

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -16,7 +16,7 @@
 fn ParseContext::lex_decimal_integer(
   ctx : ParseContext,
   start~ : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   for {
     match ctx.read_char() {
       Some('.') => return ctx.lex_decimal_point(start~)
@@ -37,7 +37,7 @@ fn ParseContext::lex_decimal_integer(
 fn ParseContext::lex_decimal_point(
   ctx : ParseContext,
   start~ : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   match ctx.read_char() {
     Some(c) =>
       if c >= '0' && c <= '9' {
@@ -53,7 +53,7 @@ fn ParseContext::lex_decimal_point(
 fn ParseContext::lex_decimal_fraction(
   ctx : ParseContext,
   start~ : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   for {
     match ctx.read_char() {
       Some('e' | 'E') => return ctx.lex_decimal_exponent(start~)
@@ -73,7 +73,7 @@ fn ParseContext::lex_decimal_fraction(
 fn ParseContext::lex_decimal_exponent(
   ctx : ParseContext,
   start~ : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   match ctx.read_char() {
     Some('+') | Some('-') => return ctx.lex_decimal_exponent_sign(start~)
     Some(c) => {
@@ -91,7 +91,7 @@ fn ParseContext::lex_decimal_exponent(
 fn ParseContext::lex_decimal_exponent_sign(
   ctx : ParseContext,
   start~ : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   match ctx.read_char() {
     Some(c) => {
       if c >= '0' && c <= '9' {
@@ -108,7 +108,7 @@ fn ParseContext::lex_decimal_exponent_sign(
 fn ParseContext::lex_decimal_exponent_integer(
   ctx : ParseContext,
   start~ : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   for {
     match ctx.read_char() {
       Some(c) => {
@@ -127,7 +127,7 @@ fn ParseContext::lex_decimal_exponent_integer(
 fn ParseContext::lex_zero(
   ctx : ParseContext,
   start~ : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   match ctx.read_char() {
     Some('.') => ctx.lex_decimal_point(start~)
     Some('e' | 'E') => ctx.lex_decimal_exponent(start~)
@@ -148,7 +148,7 @@ fn ParseContext::lex_number_end(
   ctx : ParseContext,
   start : Int,
   end : Int
-) -> Double!ParseError {
+) -> Double raise ParseError {
   let s = ctx.input.substring(start~, end~)
   try @strconv.parse_double(s) catch {
     _ => raise InvalidNumber(offset_to_position(ctx.input, start), s)

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -150,7 +150,7 @@ fn ParseContext::lex_number_end(
   end : Int
 ) -> Double raise ParseError {
   let s = ctx.input.substring(start~, end~)
-  try @strconv.parse_double(s) catch {
+  @strconv.parse_double(s) catch {
     _ => raise InvalidNumber(offset_to_position(ctx.input, start), s)
   }
 }

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn ParseContext::lex_string(ctx : ParseContext) -> String!ParseError {
+fn ParseContext::lex_string(ctx : ParseContext) -> String raise ParseError {
   let buf = StringBuilder::new()
   let mut start = ctx.offset
   fn flush(end : Int) {
@@ -62,7 +62,10 @@ fn ParseContext::lex_string(ctx : ParseContext) -> String!ParseError {
 }
 
 ///|
-fn ParseContext::lex_hex_digits(ctx : ParseContext, n : Int) -> Int!ParseError {
+fn ParseContext::lex_hex_digits(
+  ctx : ParseContext,
+  n : Int
+) -> Int raise ParseError {
   let mut r = 0
   for i in 0..<n {
     match ctx.read_char() {

--- a/json/parse.mbt
+++ b/json/parse.mbt
@@ -23,7 +23,7 @@ pub fn valid(input : String) -> Bool {
 }
 
 ///|
-pub fn parse(input : String) -> JsonValue!ParseError {
+pub fn parse(input : String) -> JsonValue raise ParseError {
   let ctx = ParseContext::make(input)
   let val = ctx.parse_value()
   ctx.lex_skip_whitespace()
@@ -35,7 +35,7 @@ pub fn parse(input : String) -> JsonValue!ParseError {
 }
 
 ///|
-fn ParseContext::parse_value(ctx : ParseContext) -> JsonValue!ParseError {
+fn ParseContext::parse_value(ctx : ParseContext) -> JsonValue raise ParseError {
   let tok = ctx.lex_value(allow_rbracket=false)
   ctx.parse_value2(tok)
 }
@@ -44,7 +44,7 @@ fn ParseContext::parse_value(ctx : ParseContext) -> JsonValue!ParseError {
 fn ParseContext::parse_value2(
   ctx : ParseContext,
   tok : Token
-) -> JsonValue!ParseError {
+) -> JsonValue raise ParseError {
   match tok {
     Null => Json::null()
     True => Json::boolean(true)
@@ -58,7 +58,7 @@ fn ParseContext::parse_value2(
 }
 
 ///|
-fn ParseContext::parse_object(ctx : ParseContext) -> JsonValue!ParseError {
+fn ParseContext::parse_object(ctx : ParseContext) -> JsonValue raise ParseError {
   let map = Map::new()
   loop ctx.lex_property_name() {
     RBrace => Json::object(map)
@@ -76,7 +76,7 @@ fn ParseContext::parse_object(ctx : ParseContext) -> JsonValue!ParseError {
 }
 
 ///|
-fn ParseContext::parse_array(ctx : ParseContext) -> JsonValue!ParseError {
+fn ParseContext::parse_array(ctx : ParseContext) -> JsonValue raise ParseError {
   let vec = []
   loop ctx.lex_value(allow_rbracket=true) {
     RBracket => Json::array(vec)

--- a/json/parse_test.mbt
+++ b/json/parse_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn test_parse(input : String, loc~ : SourceLoc = _) -> Json raise Error {
-  try @json.parse(input) catch {
+  @json.parse(input) catch {
     err => fail("Parse failed, \{loc}, \{err}")
   }
 }

--- a/json/parse_test.mbt
+++ b/json/parse_test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn test_parse(input : String, loc~ : SourceLoc = _) -> Json!Error {
+fn test_parse(input : String, loc~ : SourceLoc = _) -> Json raise Error {
   try @json.parse(input) catch {
     err => fail("Parse failed, \{loc}, \{err}")
   }

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -23,7 +23,7 @@ pub(all) struct Position {
 } derive(Eq, ToJson)
 
 ///|
-pub(all) type! ParseError {
+pub(all) suberror ParseError {
   InvalidChar(Position, Char)
   InvalidEof
   InvalidNumber(Position, String)

--- a/json/utils.mbt
+++ b/json/utils.mbt
@@ -31,7 +31,7 @@ fn offset_to_position(input : String, offset : Int) -> Position {
 fn[T] ParseContext::invalid_char(
   ctx : ParseContext,
   shift~ : Int = 0
-) -> T!ParseError {
+) -> T raise ParseError {
   let offset = ctx.offset + shift
   // FIXME: this should check the surrogate pair
   raise InvalidChar(

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -74,7 +74,9 @@ pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) 
 }
 
 ///|
-pub fn[A : @json.FromJson] from_json(json : Json) -> T[A]!@json.JsonDecodeError {
+pub fn[A : @json.FromJson] from_json(
+  json : Json
+) -> T[A] raise @json.JsonDecodeError {
   @json.from_json(json)
 }
 

--- a/list/list.mbti
+++ b/list/list.mbti
@@ -54,7 +54,7 @@ fn[A] from_iter(Iter[A]) -> T[A]
 
 fn[A] from_iter_rev(Iter[A]) -> T[A]
 
-fn[A : @json.FromJson] from_json(Json) -> T[A]!@json.JsonDecodeError
+fn[A : @json.FromJson] from_json(Json) -> T[A] raise @json.JsonDecodeError
 
 fn[A] head(T[A]) -> A?
 

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -401,7 +401,7 @@ test "iter" {
 }
 
 ///|
-pub fn[T, Err : Error] or_error(self : T?, err : Err) -> T!Err {
+pub fn[T, Err : Error] or_error(self : T?, err : Err) -> T raise Err {
   match self {
     Some(v) => v
     None => raise err

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -411,13 +411,13 @@ pub fn[T, Err : Error] or_error(self : T?, err : Err) -> T raise Err {
 ///|
 test "or error" {
   assert_eq(
-    try (None : String?).or_error(Failure("This is serious")) catch {
+    (None : String?).or_error(Failure("This is serious")) catch {
       Failure(err) => err
     },
     "This is serious",
   )
   assert_eq(
-    try Some("This is ok").or_error(Failure("This is serious")) catch {
+    Some("This is ok").or_error(Failure("This is serious")) catch {
       Failure(err) => err
     },
     "This is ok",

--- a/option/option.mbti
+++ b/option/option.mbti
@@ -29,7 +29,7 @@ fn[T : Default] or_default(T?) -> T
 
 fn[T] or_else(T?, () -> T) -> T
 
-fn[T, Err : Error] or_error(T?, Err) -> T!Err
+fn[T, Err : Error] or_error(T?, Err) -> T raise Err
 
 fn[T] some(T) -> T?
 
@@ -49,7 +49,7 @@ fn[T, U] Option::map_or_else(T?, () -> U, (T) -> U) -> U
 fn[T] Option::or(T?, T) -> T
 fn[T : Default] Option::or_default(T?) -> T
 fn[T] Option::or_else(T?, () -> T) -> T
-fn[T, Err : Error] Option::or_error(T?, Err) -> T!Err
+fn[T, Err : Error] Option::or_error(T?, Err) -> T raise Err
 impl[X : Compare] Compare for X?
 impl[X] Default for X?
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for X?

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -7,22 +7,22 @@ import(
 // Values
 fn[T] abort(String) -> T
 
-fn[T : @builtin.Eq + @builtin.Show] assert_eq(T, T, loc~ : @builtin.SourceLoc = _) -> Unit!
+fn[T : @builtin.Eq + @builtin.Show] assert_eq(T, T, loc~ : @builtin.SourceLoc = _) -> Unit raise
 
-fn assert_false(Bool, loc~ : @builtin.SourceLoc = _) -> Unit!
+fn assert_false(Bool, loc~ : @builtin.SourceLoc = _) -> Unit raise
 
-fn[T : @builtin.Eq + @builtin.Show] assert_not_eq(T, T, loc~ : @builtin.SourceLoc = _) -> Unit!
+fn[T : @builtin.Eq + @builtin.Show] assert_not_eq(T, T, loc~ : @builtin.SourceLoc = _) -> Unit raise
 
-fn assert_true(Bool, loc~ : @builtin.SourceLoc = _) -> Unit!
+fn assert_true(Bool, loc~ : @builtin.SourceLoc = _) -> Unit raise
 
 #deprecated
 fn[T] dump(T, name? : String, loc~ : @builtin.SourceLoc = _) -> T
 
-fn[T] fail(String, loc~ : @builtin.SourceLoc = _) -> T!@builtin.Failure
+fn[T] fail(String, loc~ : @builtin.SourceLoc = _) -> T raise @builtin.Failure
 
 fn[T] ignore(T) -> Unit
 
-fn inspect(&@builtin.Show, content~ : String = .., loc~ : @builtin.SourceLoc = _, args_loc~ : @builtin.ArgsLoc = _) -> Unit!@builtin.InspectError
+fn inspect(&@builtin.Show, content~ : String = .., loc~ : @builtin.SourceLoc = _, args_loc~ : @builtin.ArgsLoc = _) -> Unit raise @builtin.InspectError
 
 fn not(Bool) -> Bool
 

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -148,12 +148,12 @@ pub fn to_double(self : T) -> Double {
 }
 
 ///|
-fn[T] nan_error() -> T!RationalError {
+fn[T] nan_error() -> T raise RationalError {
   raise RationalError("Rational::from_double: cannot convert NaN")
 }
 
 ///|
-fn[T] overflow_error() -> T!RationalError {
+fn[T] overflow_error() -> T raise RationalError {
   raise RationalError("Rational::from_double: overflow")
 }
 
@@ -179,7 +179,7 @@ pub impl Eq for RationalError with op_equal(
 
 ///|
 /// Returns the approximate rational value of a double.
-pub fn from_double(value : Double) -> T!RationalError {
+pub fn from_double(value : Double) -> T raise RationalError {
   // continued fraction algorithm
   // Ported from https://github.com/rust-num/num
   if value.is_nan() {

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -158,7 +158,7 @@ fn[T] overflow_error() -> T!RationalError {
 }
 
 ///|
-pub(all) type! RationalError String
+pub(all) suberror RationalError String
 
 ///|
 pub impl Show for RationalError with output(self, logger) {

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -9,7 +9,7 @@ fn floor(T) -> Int64
 
 fn fract(T) -> T
 
-fn from_double(Double) -> T!RationalError
+fn from_double(Double) -> T raise RationalError
 
 fn is_integer(T) -> Bool
 

--- a/rational/rational.mbti
+++ b/rational/rational.mbti
@@ -24,7 +24,7 @@ fn to_double(T) -> Double
 fn trunc(T) -> Int64
 
 // Types and methods
-pub(all) type! RationalError String
+pub(all) suberror RationalError String
 impl Eq for RationalError
 impl Show for RationalError
 

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -398,7 +398,8 @@ pub fn[T, E : Error] unwrap_or_error(self : Result[T, E]) -> T raise E {
 test "unwrap exn" {
   (try
     (Err(Failure("This is serious")) : Result[Unit, Failure]).unwrap_or_error()
-    |> Ok catch {
+    |> Ok
+  catch {
     Failure(msg) => Err(msg)
   })
   |> inspect(

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -387,7 +387,7 @@ test "show" {
 }
 
 ///|
-pub fn[T, E : Error] unwrap_or_error(self : Result[T, E]) -> T!E {
+pub fn[T, E : Error] unwrap_or_error(self : Result[T, E]) -> T raise E {
   match self {
     Ok(x) => x
     Err(e) => raise e
@@ -411,7 +411,7 @@ test "unwrap exn" {
 ///|
 #deprecated("use try? instead")
 #coverage.skip
-pub fn[T, E : Error] wrap0(f~ : () -> T!E) -> Result[T, E] {
+pub fn[T, E : Error] wrap0(f~ : () -> T raise E) -> Result[T, E] {
   try f() |> Ok catch {
     e => Err(e)
   }
@@ -420,7 +420,7 @@ pub fn[T, E : Error] wrap0(f~ : () -> T!E) -> Result[T, E] {
 ///|
 #deprecated("use try? instead")
 #coverage.skip
-pub fn[T, A, E : Error] wrap1(f~ : (A) -> T!E, a : A) -> Result[T, E] {
+pub fn[T, A, E : Error] wrap1(f~ : (A) -> T raise E, a : A) -> Result[T, E] {
   try f(a) |> Ok catch {
     e => Err(e)
   }
@@ -430,7 +430,7 @@ pub fn[T, A, E : Error] wrap1(f~ : (A) -> T!E, a : A) -> Result[T, E] {
 #deprecated("use try? instead")
 #coverage.skip
 pub fn[T, A, B, E : Error] wrap2(
-  f~ : (A, B) -> T!E,
+  f~ : (A, B) -> T raise E,
   a : A,
   b : B
 ) -> Result[T, E] {

--- a/result/result.mbti
+++ b/result/result.mbti
@@ -33,16 +33,16 @@ fn[T, E] unwrap(Result[T, E]) -> T
 
 fn[T, E] unwrap_err(Result[T, E]) -> E
 
-fn[T, E : Error] unwrap_or_error(Result[T, E]) -> T!E
+fn[T, E : Error] unwrap_or_error(Result[T, E]) -> T raise E
 
 #deprecated
-fn[T, E : Error] wrap0(f~ : () -> T!E) -> Result[T, E]
+fn[T, E : Error] wrap0(f~ : () -> T raise E) -> Result[T, E]
 
 #deprecated
-fn[T, A, E : Error] wrap1(f~ : (A) -> T!E, A) -> Result[T, E]
+fn[T, A, E : Error] wrap1(f~ : (A) -> T raise E, A) -> Result[T, E]
 
 #deprecated
-fn[T, A, B, E : Error] wrap2(f~ : (A, B) -> T!E, A, B) -> Result[T, E]
+fn[T, A, B, E : Error] wrap2(f~ : (A, B) -> T raise E, A, B) -> Result[T, E]
 
 // Types and methods
 fn[T, E, U] Result::bind(Self[T, E], (T) -> Self[U, E]) -> Self[U, E]
@@ -57,7 +57,7 @@ fn[T, E] Result::or_else(Self[T, E], () -> T) -> T
 fn[T, E] Result::to_option(Self[T, E]) -> T?
 fn[T, E] Result::unwrap(Self[T, E]) -> T
 fn[T, E] Result::unwrap_err(Self[T, E]) -> E
-fn[T, E : Error] Result::unwrap_or_error(Self[T, E]) -> T!E
+fn[T, E : Error] Result::unwrap_or_error(Self[T, E]) -> T raise E
 impl[T : Compare, E : Compare] Compare for Result[T, E]
 impl[T : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Result[T, E]
 

--- a/result/result_test.mbt
+++ b/result/result_test.mbt
@@ -28,7 +28,7 @@ test "bind with Err" {
 
 ///|
 test "wrap0 with error" {
-  let f = fn() -> Int!Failure { raise Failure("error") }
+  let f = fn() -> Int raise Failure { raise Failure("error") }
   let result = try? f()
   inspect(
     result,
@@ -40,7 +40,7 @@ test "wrap0 with error" {
 
 ///|
 test "wrap2 with error result" {
-  let f = fn(_, _) -> Unit!Failure { raise Failure("error") }
+  let f = fn(_, _) -> Unit raise Failure { raise Failure("error") }
   let r = try? f(1, 2)
   inspect(
     r,

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -355,7 +355,7 @@ pub fn[K] is_empty(self : Set[K]) -> Bool {
 
 ///|
 /// Iterate over all keys of the set in the order of insertion.
-pub fn[K] each(self : Set[K], f : (K) -> Unit?Error) -> Unit?Error {
+pub fn[K] each(self : Set[K], f : (K) -> Unit raise?) -> Unit raise? {
   loop self.head {
     Some({ key, idx, .. }) => {
       f(key)
@@ -367,7 +367,7 @@ pub fn[K] each(self : Set[K], f : (K) -> Unit?Error) -> Unit?Error {
 
 ///|
 /// Iterate over all keys of the set in the order of insertion, with index.
-pub fn[K] eachi(self : Set[K], f : (Int, K) -> Unit?Error) -> Unit?Error {
+pub fn[K] eachi(self : Set[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
   loop (0, self.head) {
     (i, Some({ key, idx, .. })) => {
       f(i, key)

--- a/set/set.mbti
+++ b/set/set.mbti
@@ -13,9 +13,9 @@ fn[K : Hash + Eq] contains(Set[K], K) -> Bool
 
 fn[K : Hash + Eq] difference(Set[K], Set[K]) -> Set[K]
 
-fn[K] each(Set[K], (K) -> Unit?Error) -> Unit?Error
+fn[K] each(Set[K], (K) -> Unit raise?) -> Unit raise?
 
-fn[K] eachi(Set[K], (Int, K) -> Unit?Error) -> Unit?Error
+fn[K] eachi(Set[K], (Int, K) -> Unit raise?) -> Unit raise?
 
 #deprecated
 fn[K : Hash + Eq] insert(Set[K], K) -> Unit
@@ -46,8 +46,8 @@ fn[K] Set::capacity(Self[K]) -> Int
 fn[K] Set::clear(Self[K]) -> Unit
 fn[K : Hash + Eq] Set::contains(Self[K], K) -> Bool
 fn[K : Hash + Eq] Set::difference(Self[K], Self[K]) -> Self[K]
-fn[K] Set::each(Self[K], (K) -> Unit?Error) -> Unit?Error
-fn[K] Set::eachi(Self[K], (Int, K) -> Unit?Error) -> Unit?Error
+fn[K] Set::each(Self[K], (K) -> Unit raise?) -> Unit raise?
+fn[K] Set::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
 fn[K : Hash + Eq] Set::from_array(Array[K]) -> Self[K]
 fn[K : Hash + Eq] Set::from_iter(Iter[K]) -> Self[K]
 #deprecated

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -123,8 +123,8 @@ pub fn[K, V] clear(self : T[K, V]) -> Unit {
 
 ///|
 /// Iterates the map.
-pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit?Error) -> Unit?Error {
-  fn dfs(root : Node[K, V]?) -> Unit?Error {
+pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit raise?) -> Unit raise? {
+  fn dfs(root : Node[K, V]?) -> Unit raise? {
     if root is Some(root) {
       dfs(root.left)
       f(root.key, root.value)
@@ -137,7 +137,10 @@ pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit?Error) -> Unit?Error {
 
 ///|
 /// Iterates the map with index.
-pub fn[K, V] eachi(self : T[K, V], f : (Int, K, V) -> Unit?Error) -> Unit?Error {
+pub fn[K, V] eachi(
+  self : T[K, V],
+  f : (Int, K, V) -> Unit raise?
+) -> Unit raise? {
   let mut i = 0
   self.each(fn(k, v) {
     f(i, k, v)

--- a/sorted_map/sorted_map.mbti
+++ b/sorted_map/sorted_map.mbti
@@ -11,9 +11,9 @@ fn[K, V] clear(T[K, V]) -> Unit
 
 fn[K : Compare, V] contains(T[K, V], K) -> Bool
 
-fn[K, V] each(T[K, V], (K, V) -> Unit?Error) -> Unit?Error
+fn[K, V] each(T[K, V], (K, V) -> Unit raise?) -> Unit raise?
 
-fn[K, V] eachi(T[K, V], (Int, K, V) -> Unit?Error) -> Unit?Error
+fn[K, V] eachi(T[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
 
 fn[K : Compare, V] from_array(Array[(K, V)]) -> T[K, V]
 
@@ -54,8 +54,8 @@ type T[K, V]
 fn[K : Compare, V] T::add(Self[K, V], K, V) -> Unit
 fn[K, V] T::clear(Self[K, V]) -> Unit
 fn[K : Compare, V] T::contains(Self[K, V], K) -> Bool
-fn[K, V] T::each(Self[K, V], (K, V) -> Unit?Error) -> Unit?Error
-fn[K, V] T::eachi(Self[K, V], (Int, K, V) -> Unit?Error) -> Unit?Error
+fn[K, V] T::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
+fn[K, V] T::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
 fn[K : Compare, V] T::get(Self[K, V], K) -> V?
 fn[K, V] T::is_empty(Self[K, V]) -> Bool
 fn[K, V] T::iter(Self[K, V]) -> Iter[(K, V)]

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -365,8 +365,8 @@ pub fn[V : Compare] size(self : T[V]) -> Int {
 
 ///|
 /// Iterates the set.
-pub fn[V] each(self : T[V], f : (V) -> Unit?Error) -> Unit?Error {
-  fn dfs(root : Node[V]?) -> Unit?Error {
+pub fn[V] each(self : T[V], f : (V) -> Unit raise?) -> Unit raise? {
+  fn dfs(root : Node[V]?) -> Unit raise? {
     if root is Some(root) {
       dfs(root.left)
       f(root.value)
@@ -379,7 +379,7 @@ pub fn[V] each(self : T[V], f : (V) -> Unit?Error) -> Unit?Error {
 
 ///|
 /// Iterates the set with index.
-pub fn[V] eachi(self : T[V], f : (Int, V) -> Unit?Error) -> Unit?Error {
+pub fn[V] eachi(self : T[V], f : (Int, V) -> Unit raise?) -> Unit raise? {
   let mut i = 0
   self.each(fn(v) {
     f(i, v)

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -21,9 +21,9 @@ fn[V : Compare] difference(T[V], T[V]) -> T[V]
 
 fn[V : Compare] disjoint(T[V], T[V]) -> Bool
 
-fn[V] each(T[V], (V) -> Unit?Error) -> Unit?Error
+fn[V] each(T[V], (V) -> Unit raise?) -> Unit raise?
 
-fn[V] eachi(T[V], (Int, V) -> Unit?Error) -> Unit?Error
+fn[V] eachi(T[V], (Int, V) -> Unit raise?) -> Unit raise?
 
 fn[V : Compare] from_array(Array[V]) -> T[V]
 
@@ -70,8 +70,8 @@ fn[V] T::deep_clone(Self[V]) -> Self[V]
 fn[V : Compare] T::diff(Self[V], Self[V]) -> Self[V]
 fn[V : Compare] T::difference(Self[V], Self[V]) -> Self[V]
 fn[V : Compare] T::disjoint(Self[V], Self[V]) -> Bool
-fn[V] T::each(Self[V], (V) -> Unit?Error) -> Unit?Error
-fn[V] T::eachi(Self[V], (Int, V) -> Unit?Error) -> Unit?Error
+fn[V] T::each(Self[V], (V) -> Unit raise?) -> Unit raise?
+fn[V] T::eachi(Self[V], (Int, V) -> Unit raise?) -> Unit raise?
 #deprecated
 fn[V : Compare] T::from_iter(Iter[V]) -> Self[V]
 #deprecated

--- a/strconv/bool.mbt
+++ b/strconv/bool.mbt
@@ -14,7 +14,7 @@
 
 ///|
 /// Parse a string and return the represented boolean value or an error.
-pub fn parse_bool(str : String) -> Bool!StrConvError {
+pub fn parse_bool(str : String) -> Bool raise StrConvError {
   match str {
     "1" | "t" | "T" | "true" | "TRUE" | "True" => true
     "0" | "f" | "F" | "false" | "FALSE" | "False" => false

--- a/strconv/bool.mbt
+++ b/strconv/bool.mbt
@@ -43,7 +43,7 @@ test "parse_bool" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_bool(t.0)) catch {
+      Result::Ok(parse_bool(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -74,17 +74,17 @@ fn Decimal::from_int64_priv(v : Int64) -> Decimal {
 
 ///|
 #deprecated("use `@strconv.parse_double` instead")
-pub fn parse_decimal(str : String) -> Decimal!StrConvError {
+pub fn parse_decimal(str : String) -> Decimal raise StrConvError {
   parse_decimal_from_view(str.view())
 }
 
 ///|
-fn parse_decimal_priv(str : String) -> Decimal!StrConvError {
+fn parse_decimal_priv(str : String) -> Decimal raise StrConvError {
   parse_decimal_from_view(str.view())
 }
 
 ///|
-fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
+fn parse_decimal_from_view(str : @string.View) -> Decimal raise StrConvError {
   let d = Decimal::new_priv()
   let mut has_dp = false
   let mut has_digits = false
@@ -162,19 +162,19 @@ fn parse_decimal_from_view(str : @string.View) -> Decimal!StrConvError {
 
 ///|
 #deprecated("use `@strconv.parse_double` instead")
-pub fn Decimal::parse_decimal(str : String) -> Decimal!StrConvError {
+pub fn Decimal::parse_decimal(str : String) -> Decimal raise StrConvError {
   parse_decimal_from_view(str.view())
 }
 
 ///|
 /// Convert the decimal to Double.
 #deprecated("use `@strconv.parse_double` instead to avoid using this method.")
-pub fn to_double(self : Decimal) -> Double!StrConvError {
+pub fn to_double(self : Decimal) -> Double raise StrConvError {
   self.to_double_priv()
 }
 
 ///|
-fn to_double_priv(self : Decimal) -> Double!StrConvError {
+fn to_double_priv(self : Decimal) -> Double raise StrConvError {
   let mut exponent = 0
   let mut mantissa = 0L
   // check the underflow and overflow

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -635,13 +635,9 @@ test "from_int64" {
 ///|
 test "parse_decimal" {
   let s = "0.0000000000000000000000000000007888609052210118054117285652827862296732064351090230047702789306640625"
-  let hpd = try parse_decimal_priv(s) catch {
-    _ => panic()
-  }
+  let hpd = parse_decimal_priv(s) catch { _ => panic() }
   assert_eq(hpd.to_string(), s)
-  let hpd = try parse_decimal_priv("1.0e-10") catch {
-    _ => panic()
-  }
+  let hpd = parse_decimal_priv("1.0e-10") catch { _ => panic() }
   assert_eq(hpd.to_string(), "0.0000000001")
 }
 

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -67,7 +67,7 @@ let max_mantissa_fast_path : UInt64 = 2UL << mantissa_explicit_bits
 ///
 /// An exponent value exp scales the mantissa (significand) by 10^exp.
 /// For example, "1.23e2" represents 1.23 × 10² = 123.
-pub fn parse_double(str : String) -> Double!StrConvError {
+pub fn parse_double(str : String) -> Double raise StrConvError {
   if str.length() == 0 {
     syntax_err()
   }

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -276,7 +276,7 @@ test "parse_double" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_double(t.0)) catch {
+      Result::Ok(parse_double(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,
@@ -286,44 +286,19 @@ test "parse_double" {
 
 ///|
 test "parse_double_inf" {
+  assert_eq(parse_double("inf") catch { _ => panic() }, @double.infinity)
+  assert_eq(parse_double("+Inf") catch { _ => panic() }, @double.infinity)
+  assert_eq(parse_double("-Inf") catch { _ => panic() }, @double.neg_infinity)
+  assert_eq(parse_double("+Infinity") catch { _ => panic() }, @double.infinity)
   assert_eq(
-    try parse_double("inf") catch {
-      _ => panic()
-    },
-    @double.infinity,
-  )
-  assert_eq(
-    try parse_double("+Inf") catch {
-      _ => panic()
-    },
-    @double.infinity,
-  )
-  assert_eq(
-    try parse_double("-Inf") catch {
+    parse_double("-Infinity") catch {
       _ => panic()
     },
     @double.neg_infinity,
   )
+  assert_eq(parse_double("+INFINITY") catch { _ => panic() }, @double.infinity)
   assert_eq(
-    try parse_double("+Infinity") catch {
-      _ => panic()
-    },
-    @double.infinity,
-  )
-  assert_eq(
-    try parse_double("-Infinity") catch {
-      _ => panic()
-    },
-    @double.neg_infinity,
-  )
-  assert_eq(
-    try parse_double("+INFINITY") catch {
-      _ => panic()
-    },
-    @double.infinity,
-  )
-  assert_eq(
-    try parse_double("-INFINITY") catch {
+    parse_double("-INFINITY") catch {
       _ => panic()
     },
     @double.neg_infinity,
@@ -332,16 +307,10 @@ test "parse_double_inf" {
 
 ///|
 test "parse_double_nan" {
-  let nan = try parse_double("nan") catch {
-    _ => panic()
-  }
+  let nan = parse_double("nan") catch { _ => panic() }
   assert_true(nan.is_nan())
-  let nan = try parse_double("NaN") catch {
-    _ => panic()
-  }
+  let nan = parse_double("NaN") catch { _ => panic() }
   assert_true(nan.is_nan())
-  let nan = try parse_double("NAN") catch {
-    _ => panic()
-  }
+  let nan = parse_double("NAN") catch { _ => panic() }
   assert_true(nan.is_nan())
 }

--- a/strconv/double_test.mbt
+++ b/strconv/double_test.mbt
@@ -17,7 +17,7 @@ test "try_fast_path overflow when shift is too large" {
   // When the shift (exponent - max_exponent_fast_path) is too large,
   // the multiplication of mantissa with int_pow10[shift] will overflow,
   // triggering line 130
-  let result = try @strconv.parse_double("9007199254740992e30") catch {
+  let result = @strconv.parse_double("9007199254740992e30") catch {
     _ => panic()
   }
   // The function successfully falls back to slow path
@@ -28,7 +28,7 @@ test "try_fast_path overflow when shift is too large" {
 test "try_fast_path overflow when mantissa is too large" {
   // When the mantissa after shifting is larger than max_mantissa_fast_path,
   // line 133 will be triggered
-  let result = try @strconv.parse_double("9007199254740992e23") catch {
+  let result = @strconv.parse_double("9007199254740992e23") catch {
     _ => panic()
   }
   // The function successfully falls back to slow path

--- a/strconv/errors.mbt
+++ b/strconv/errors.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub(all) type! StrConvError String
+pub(all) suberror StrConvError String
 
 ///|
 pub impl Show for StrConvError with output(self, logger) {

--- a/strconv/errors.mbt
+++ b/strconv/errors.mbt
@@ -32,16 +32,16 @@ let syntax_err_str = "invalid syntax"
 let base_err_str = "invalid base"
 
 ///|
-fn[T] range_err() -> T!StrConvError {
+fn[T] range_err() -> T raise StrConvError {
   raise StrConvError(range_err_str)
 }
 
 ///|
-fn[T] syntax_err() -> T!StrConvError {
+fn[T] syntax_err() -> T raise StrConvError {
   raise StrConvError(syntax_err_str)
 }
 
 ///|
-fn[T] base_err() -> T!StrConvError {
+fn[T] base_err() -> T raise StrConvError {
   raise StrConvError(base_err_str)
 }

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -31,7 +31,7 @@ const INT64_MAX = 0x7fffffffffffffffL
 fn check_and_consume_base(
   view : @string.View,
   base : Int
-) -> (Int, @string.View, Bool)!StrConvError {
+) -> (Int, @string.View, Bool) raise StrConvError {
   // if the base is not given, we need to determine it from the prefix
   if base == 0 {
     match view {
@@ -80,7 +80,7 @@ test {
 /// inspect(parse_int64("zz", base=36), content="1295")
 /// ```
 /// 
-pub fn parse_int64(str : String, base~ : Int = 0) -> Int64!StrConvError {
+pub fn parse_int64(str : String, base~ : Int = 0) -> Int64 raise StrConvError {
   guard str != "" else { syntax_err() }
   let (neg, rest) = match str.view() {
     ['+', .. rest] => (false, rest)
@@ -132,7 +132,7 @@ pub fn parse_int64(str : String, base~ : Int = 0) -> Int64!StrConvError {
 ///|
 /// Parse a string in the given base (0, 2 to 36), return a Int number or an error.
 /// If the `~base` argument is 0, the base will be inferred by the prefix.
-pub fn parse_int(str : String, base~ : Int = 0) -> Int!StrConvError {
+pub fn parse_int(str : String, base~ : Int = 0) -> Int raise StrConvError {
   let n = parse_int64(str, base~)
   if n < INT_MIN.to_int64() || n > INT_MAX.to_int64() {
     range_err()

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -279,7 +279,7 @@ test "parse_int64" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_int64(t.0)) catch {
+      Result::Ok(parse_int64(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,
@@ -397,7 +397,7 @@ test "parse_int64_base" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_int64(t.0, base=t.1)) catch {
+      Result::Ok(parse_int64(t.0, base=t.1)) catch {
         StrConvError(err) => Err(err)
       },
       t.2,
@@ -437,7 +437,7 @@ test "parse_int" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_int(t.0)) catch {
+      Result::Ok(parse_int(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,

--- a/strconv/strconv.mbti
+++ b/strconv/strconv.mbti
@@ -1,28 +1,28 @@
 package "moonbitlang/core/strconv"
 
 // Values
-fn[A : FromStr] parse(String) -> A!StrConvError
+fn[A : FromStr] parse(String) -> A raise StrConvError
 
-fn parse_bool(String) -> Bool!StrConvError
+fn parse_bool(String) -> Bool raise StrConvError
 
 #deprecated
-fn parse_decimal(String) -> Decimal!StrConvError
+fn parse_decimal(String) -> Decimal raise StrConvError
 
-fn parse_double(String) -> Double!StrConvError
+fn parse_double(String) -> Double raise StrConvError
 
-fn parse_int(String, base~ : Int = ..) -> Int!StrConvError
+fn parse_int(String, base~ : Int = ..) -> Int raise StrConvError
 
-fn parse_int64(String, base~ : Int = ..) -> Int64!StrConvError
+fn parse_int64(String, base~ : Int = ..) -> Int64 raise StrConvError
 
-fn parse_uint(String, base~ : Int = ..) -> UInt!StrConvError
+fn parse_uint(String, base~ : Int = ..) -> UInt raise StrConvError
 
-fn parse_uint64(String, base~ : Int = ..) -> UInt64!StrConvError
+fn parse_uint64(String, base~ : Int = ..) -> UInt64 raise StrConvError
 
 #deprecated
 fn shift(Decimal, Int) -> Unit
 
 #deprecated
-fn to_double(Decimal) -> Double!StrConvError
+fn to_double(Decimal) -> Double raise StrConvError
 
 // Types and methods
 type Decimal
@@ -31,11 +31,11 @@ fn Decimal::from_int64(Int64) -> Self
 #deprecated
 fn Decimal::new() -> Self
 #deprecated
-fn Decimal::parse_decimal(String) -> Self!StrConvError
+fn Decimal::parse_decimal(String) -> Self raise StrConvError
 #deprecated
 fn Decimal::shift(Self, Int) -> Unit
 #deprecated
-fn Decimal::to_double(Self) -> Double!StrConvError
+fn Decimal::to_double(Self) -> Double raise StrConvError
 impl Show for Decimal
 
 pub(all) suberror StrConvError String
@@ -45,7 +45,7 @@ impl Show for StrConvError
 
 // Traits
 pub(open) trait FromStr {
-  from_string(String) -> Self!StrConvError
+  from_string(String) -> Self raise StrConvError
 }
 impl FromStr for Bool
 impl FromStr for Int

--- a/strconv/strconv.mbti
+++ b/strconv/strconv.mbti
@@ -38,7 +38,7 @@ fn Decimal::shift(Self, Int) -> Unit
 fn Decimal::to_double(Self) -> Double!StrConvError
 impl Show for Decimal
 
-pub(all) type! StrConvError String
+pub(all) suberror StrConvError String
 impl Show for StrConvError
 
 // Type aliases

--- a/strconv/traits.mbt
+++ b/strconv/traits.mbt
@@ -20,7 +20,7 @@
 
 ///|
 pub(open) trait FromStr {
-  from_string(String) -> Self!StrConvError
+  from_string(String) -> Self raise StrConvError
 }
 
 ///|
@@ -54,7 +54,7 @@ pub impl FromStr for Double with from_string(str) {
 }
 
 ///|
-pub fn[A : FromStr] parse(str : String) -> A!StrConvError {
+pub fn[A : FromStr] parse(str : String) -> A raise StrConvError {
   A::from_string(str)
 }
 

--- a/strconv/traits.mbt
+++ b/strconv/traits.mbt
@@ -60,28 +60,16 @@ pub fn[A : FromStr] parse(str : String) -> A raise StrConvError {
 
 ///|
 test "parse" {
-  let b : Bool = try parse("true") catch {
-    _ => panic()
-  }
+  let b : Bool = parse("true") catch { _ => panic() }
   assert_eq(b, true)
-  let i : Int = try parse("12345") catch {
-    _ => panic()
-  }
+  let i : Int = parse("12345") catch { _ => panic() }
   assert_eq(i, 12345)
-  let i64 : Int64 = try parse("9223372036854775807") catch {
-    _ => panic()
-  }
+  let i64 : Int64 = parse("9223372036854775807") catch { _ => panic() }
   assert_eq(i64, 9223372036854775807L)
-  let ui : UInt = try parse("4294967295") catch {
-    _ => panic()
-  }
+  let ui : UInt = parse("4294967295") catch { _ => panic() }
   assert_eq(ui, 4294967295)
-  let ui64 : UInt64 = try parse("18446744073709551615") catch {
-    _ => panic()
-  }
+  let ui64 : UInt64 = parse("18446744073709551615") catch { _ => panic() }
   assert_eq(ui64, 18446744073709551615UL)
-  let d : Double = try parse("1234.56789") catch {
-    _ => panic()
-  }
+  let d : Double = parse("1234.56789") catch { _ => panic() }
   assert_eq(d, 1234.56789)
 }

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -39,7 +39,7 @@ const UINT64_MAX : UInt64 = 0xffffffffffffffffUL
 /// inspect(parse_uint64("zz", base=36), content="1295")
 /// ```
 /// 
-pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
+pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64 raise StrConvError {
   guard str != "" else { syntax_err() }
   if str is ['+' | '-', ..] {
     syntax_err()
@@ -85,7 +85,7 @@ pub fn parse_uint64(str : String, base~ : Int = 0) -> UInt64!StrConvError {
 ///|
 /// Parse a string in the given base (0, 2 to 36), return an UInt number or an error.
 /// If the `~base` argument is 0, the base will be inferred by the prefix.
-pub fn parse_uint(str : String, base~ : Int = 0) -> UInt!StrConvError {
+pub fn parse_uint(str : String, base~ : Int = 0) -> UInt raise StrConvError {
   let n = parse_uint64(str, base~)
   if n > UINT_MAX.to_uint64() {
     range_err()

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -117,7 +117,7 @@ test "parse_uint64" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_uint64(t.0)) catch {
+      Result::Ok(parse_uint64(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,
@@ -215,7 +215,7 @@ test "parse_uint64_base" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_uint64(t.0, base=t.1)) catch {
+      Result::Ok(parse_uint64(t.0, base=t.1)) catch {
         StrConvError(err) => Err(err)
       },
       t.2,
@@ -250,7 +250,7 @@ test "parse_uint" {
   for i in 0..<tests.length() {
     let t = tests[i]
     assert_eq(
-      try Result::Ok(parse_uint(t.0)) catch {
+      Result::Ok(parse_uint(t.0)) catch {
         StrConvError(err) => Err(err)
       },
       t.1,

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -278,11 +278,8 @@ pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
 ///|
 /// Returns the last index of the sub string.
 #deprecated("Use `s.rev_find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
-pub fn last_index_of(
-  self : String,
-  str : String,
-  from~ : Int = self.length()
-) -> Int {
+pub fn last_index_of(self : String, str : String, from? : Int) -> Int {
+  let from = if from is Some(f) { f } else { self.length() }
   if from >= self.length() {
     if self.rev_find(str.view()) is Some(idx) {
       idx
@@ -390,8 +387,9 @@ pub fn String::offset_of_nth_char(
   self : String,
   i : Int,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Int? {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   if i >= 0 {
     // forward case
     self.offset_of_nth_char_forward(i, start_offset~, end_offset~)
@@ -420,8 +418,9 @@ pub fn String::char_length_eq(
   self : String,
   len : Int,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Bool {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   for index = start_offset, count = 0
       index < end_offset && count < len
       index = index + 1, count = count + 1 {
@@ -447,8 +446,9 @@ pub fn String::char_length_ge(
   self : String,
   len : Int,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> Bool {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   for index = start_offset, count = 0
       index < end_offset && count < len
       index = index + 1, count = count + 1 {

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -39,7 +39,7 @@ fn iter(String) -> Iter[Char]
 fn iter2(String) -> Iter2[Int, Char]
 
 #deprecated
-fn last_index_of(String, String, from~ : Int = ..) -> Int
+fn last_index_of(String, String, from? : Int) -> Int
 
 fn length(StringView) -> Int
 
@@ -93,7 +93,7 @@ fn StringView::char_length(Self) -> Int
 fn StringView::char_length_eq(Self, Int) -> Bool
 fn StringView::char_length_ge(Self, Int) -> Bool
 fn StringView::charcode_at(Self, Int) -> Int
-fn StringView::charcodes(Self, start~ : Int = .., end~ : Int = ..) -> Self
+fn StringView::charcodes(Self, start~ : Int = .., end? : Int) -> Self
 fn StringView::contains(Self, Self) -> Bool
 fn StringView::contains_char(Self, Char) -> Bool
 fn StringView::data(Self) -> String
@@ -132,7 +132,7 @@ fn StringView::trim_end(Self, Self) -> Self
 fn StringView::trim_space(Self) -> Self
 fn StringView::trim_start(Self, Self) -> Self
 fn StringView::unsafe_charcode_at(Self, Int) -> Int
-fn StringView::view(Self, start_offset~ : Int = .., end_offset~ : Int = ..) -> Self
+fn StringView::view(Self, start_offset~ : Int = .., end_offset? : Int) -> Self
 impl Compare for StringView
 impl Default for StringView
 impl Eq for StringView
@@ -141,9 +141,9 @@ impl Show for StringView
 impl ToJson for StringView
 
 fn String::char_at(String, Int) -> Char
-fn String::char_length_eq(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
-fn String::char_length_ge(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Bool
-fn String::charcodes(String, start~ : Int = .., end~ : Int = ..) -> StringView
+fn String::char_length_eq(String, Int, start_offset~ : Int = .., end_offset? : Int) -> Bool
+fn String::char_length_ge(String, Int, start_offset~ : Int = .., end_offset? : Int) -> Bool
+fn String::charcodes(String, start~ : Int = .., end? : Int) -> StringView
 #deprecated
 fn String::concat(Array[String], separator~ : String = ..) -> String
 fn String::contains(String, StringView) -> Bool
@@ -168,8 +168,8 @@ fn String::is_empty(String) -> Bool
 fn String::iter(String) -> Iter[Char]
 fn String::iter2(String) -> Iter2[Int, Char]
 #deprecated
-fn String::last_index_of(String, String, from~ : Int = ..) -> Int
-fn String::offset_of_nth_char(String, Int, start_offset~ : Int = .., end_offset~ : Int = ..) -> Int?
+fn String::last_index_of(String, String, from? : Int) -> Int
+fn String::offset_of_nth_char(String, Int, start_offset~ : Int = .., end_offset? : Int) -> Int?
 #deprecated
 fn String::op_as_view(String, start~ : Int = .., end? : Int) -> StringView
 fn String::pad_end(String, Int, Char) -> String
@@ -192,7 +192,7 @@ fn String::trim(String, StringView) -> StringView
 fn String::trim_end(String, StringView) -> StringView
 fn String::trim_space(String) -> StringView
 fn String::trim_start(String, StringView) -> StringView
-fn String::view(String, start_offset~ : Int = .., end_offset~ : Int = ..) -> StringView
+fn String::view(String, start_offset~ : Int = .., end_offset? : Int) -> StringView
 impl Compare for String
 impl Default for String
 

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -100,8 +100,9 @@ pub fn length(self : View) -> Int {
 pub fn String::view(
   self : String,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> View {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -115,8 +116,9 @@ pub fn String::view(
 pub fn View::view(
   self : View,
   start_offset~ : Int = 0,
-  end_offset~ : Int = self.length()
+  end_offset? : Int
 ) -> View {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -149,12 +151,8 @@ pub fn View::view(
 /// ```
 /// 
 /// This method has O(1) complexity.
-pub fn String::charcodes(
-  self : String,
-  start~ : Int = 0,
-  end~ : Int = self.length()
-) -> View {
-  self.view(start_offset=start, end_offset=end)
+pub fn String::charcodes(self : String, start~ : Int = 0, end? : Int) -> View {
+  self.view(start_offset=start, end_offset?=end)
 }
 
 ///|
@@ -175,12 +173,8 @@ pub fn String::charcodes(
 /// It allows you to create a sub-view of an existing view with the specified character range.
 /// 
 /// This method has O(1) complexity.
-pub fn View::charcodes(
-  self : View,
-  start~ : Int = 0,
-  end~ : Int = self.length()
-) -> View {
-  self.view(start_offset=start, end_offset=end)
+pub fn View::charcodes(self : View, start~ : Int = 0, end? : Int) -> View {
+  self.view(start_offset=start, end_offset?=end)
 }
 
 ///|

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -22,7 +22,7 @@ fn[T : Show] debug_string(t : T) -> String {
 ///|
 #deprecated("Use built-in `assert_eq` instead")
 #coverage.skip
-pub fn[T : Show + Eq] eq(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
+pub fn[T : Show + Eq] eq(a : T, b : T, loc~ : SourceLoc = _) -> Unit raise {
   if a != b {
     let a = debug_string(a)
     let b = debug_string(b)
@@ -33,7 +33,7 @@ pub fn[T : Show + Eq] eq(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 ///|
 #deprecated("Use built-in `assert_not_eq` instead")
 #coverage.skip
-pub fn[T : Show + Eq] ne(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
+pub fn[T : Show + Eq] ne(a : T, b : T, loc~ : SourceLoc = _) -> Unit raise {
   if not(a != b) {
     let a = debug_string(a)
     let b = debug_string(b)
@@ -44,7 +44,7 @@ pub fn[T : Show + Eq] ne(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 ///|
 #deprecated("Use built-in `assert_true` instead")
 #coverage.skip
-pub fn is_true(x : Bool, loc~ : SourceLoc = _) -> Unit! {
+pub fn is_true(x : Bool, loc~ : SourceLoc = _) -> Unit raise {
   if not(x) {
     let x = debug_string(x)
     fail("`\{x}` is not true", loc~)
@@ -54,7 +54,7 @@ pub fn is_true(x : Bool, loc~ : SourceLoc = _) -> Unit! {
 ///|
 #deprecated("Use built-in `assert_false` instead")
 #coverage.skip
-pub fn is_false(x : Bool, loc~ : SourceLoc = _) -> Unit! {
+pub fn is_false(x : Bool, loc~ : SourceLoc = _) -> Unit raise {
   if x {
     let x = debug_string(x)
     fail("`\{x}` is not false", loc~)
@@ -77,7 +77,7 @@ pub fn is_false(x : Bool, loc~ : SourceLoc = _) -> Unit! {
 /// @test.same_object(a, a)
 /// @test.is_not(a, b)
 /// ```
-pub fn[T : Show] same_object(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
+pub fn[T : Show] same_object(a : T, b : T, loc~ : SourceLoc = _) -> Unit raise {
   if not(physical_equal(a, b)) {
     let a = debug_string(a)
     let b = debug_string(b)
@@ -101,7 +101,7 @@ pub fn[T : Show] same_object(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 /// @test.is_not(a, b)
 /// @test.same_object(a, a)
 /// ```
-pub fn[T : Show] is_not(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
+pub fn[T : Show] is_not(a : T, b : T, loc~ : SourceLoc = _) -> Unit raise {
   if physical_equal(a, b) {
     let a = debug_string(a)
     let b = debug_string(b)
@@ -113,7 +113,7 @@ pub fn[T : Show] is_not(a : T, b : T, loc~ : SourceLoc = _) -> Unit! {
 /// Expected to be used in test blocks, don't catch this error.
 ///  
 /// Produces an error message similar to @builtin.fail.
-pub fn[T] fail(msg : String, loc~ : SourceLoc = _) -> T! {
+pub fn[T] fail(msg : String, loc~ : SourceLoc = _) -> T raise {
   @builtin.fail(msg, loc~)
 }
 
@@ -151,7 +151,7 @@ pub fn snapshot(
   filename~ : String,
   loc~ : SourceLoc = _,
   args_loc~ : ArgsLoc = _
-) -> Unit!SnapshotError {
+) -> Unit raise SnapshotError {
   let loc = loc.to_string().escape()
   let args_loc = args_loc.to_json().escape()
   let actual = self.buffer.to_string().escape()
@@ -164,7 +164,11 @@ pub fn snapshot(
 
 ///|
 #deprecated("Use `@bench.single_bench` instead")
-pub fn bench(self : T, f : () -> Unit, count~ : UInt = 10) -> Unit!BenchError {
+pub fn bench(
+  self : T,
+  f : () -> Unit,
+  count~ : UInt = 10
+) -> Unit raise BenchError {
   ignore(self)
   let summary = @bench.single_bench(f, count~)
   raise BenchError("@BENCH \{summary.to_json().stringify()}\n")

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -2,29 +2,29 @@ package "moonbitlang/core/test"
 
 // Values
 #deprecated
-fn bench(T, () -> Unit, count~ : UInt = ..) -> Unit!BenchError
+fn bench(T, () -> Unit, count~ : UInt = ..) -> Unit raise BenchError
 
 #deprecated
-fn[T : Show + Eq] eq(T, T, loc~ : SourceLoc = _) -> Unit!
+fn[T : Show + Eq] eq(T, T, loc~ : SourceLoc = _) -> Unit raise
 
-fn[T] fail(String, loc~ : SourceLoc = _) -> T!
-
-#deprecated
-fn is_false(Bool, loc~ : SourceLoc = _) -> Unit!
-
-fn[T : Show] is_not(T, T, loc~ : SourceLoc = _) -> Unit!
+fn[T] fail(String, loc~ : SourceLoc = _) -> T raise
 
 #deprecated
-fn is_true(Bool, loc~ : SourceLoc = _) -> Unit!
+fn is_false(Bool, loc~ : SourceLoc = _) -> Unit raise
+
+fn[T : Show] is_not(T, T, loc~ : SourceLoc = _) -> Unit raise
 
 #deprecated
-fn[T : Show + Eq] ne(T, T, loc~ : SourceLoc = _) -> Unit!
+fn is_true(Bool, loc~ : SourceLoc = _) -> Unit raise
+
+#deprecated
+fn[T : Show + Eq] ne(T, T, loc~ : SourceLoc = _) -> Unit raise
 
 fn new(String) -> T
 
-fn[T : Show] same_object(T, T, loc~ : SourceLoc = _) -> Unit!
+fn[T : Show] same_object(T, T, loc~ : SourceLoc = _) -> Unit raise
 
-fn snapshot(T, filename~ : String, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit!SnapshotError
+fn snapshot(T, filename~ : String, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise SnapshotError
 
 fn write(T, &Show) -> Unit
 
@@ -36,8 +36,8 @@ pub(all) struct T {
   buffer : StringBuilder
 }
 #deprecated
-fn T::bench(Self, () -> Unit, count~ : UInt = ..) -> Unit!BenchError
-fn T::snapshot(Self, filename~ : String, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit!SnapshotError
+fn T::bench(Self, () -> Unit, count~ : UInt = ..) -> Unit raise BenchError
+fn T::snapshot(Self, filename~ : String, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise SnapshotError
 fn T::write(Self, &Show) -> Unit
 fn T::writeln(Self, &Show) -> Unit
 


### PR DESCRIPTION
We are making some syntax changes before beta release, this PR migrates core:

- `!` is replaced by `raise`, for example `(..) -> T!Error` will become `(..) -> T raise Error`, `-> T?Error` is replaced by `-> T raise?`
- `type!` is replaced by a new keyword `suberror`
- Since `extern type` have very different semantic in different backends, we decided to deprecate this syntax and use an attribute `#external` instead. This gives more flexibility for future adjustment, if some backend demand richer FFI type declaration
- Currently, default value of optional argument can depend on previous arguments. But this feature is incompatible with virtual package, because we cannot tell the dependencies of an optional argument's default value from `.mbti` interface. So we decided to deprecate complex default value that depend on previous arguments. This kind of default value can be replaced by `label? : T` and a `match` on `label` inside function body, so there is no loss in expressiveness
- `typealias A = B` is deprecated and replaced by `typealias B as A`, similarly for `traitalias`. This simplifies MoonBit's syntax without loss of expresiveness
- `loop` with multiple parameters is deprecated. Users can alternatively use `loop` with a single tuple parameter. MoonBit compiler is capable to optimize away the tuple, so there will be no loss in performance. This change makes `match` and `loop` more consistent
- `try` can now be omitted when catching error in a simple expression, e.g. `f() catch { _ => panic() }`. This syntax is inspired by Zig