### PR TITLE
Optimize loops by caching length

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -717,10 +717,11 @@ pub fn[T : Compare] Array::is_sorted(self : Array[T]) -> Bool {
 /// }
 /// ```
 pub fn[T] Array::rev_inplace(self : Array[T]) -> Unit {
-  for i in 0..<(self.length() / 2) {
+  let len = self.length()
+  for i in 0..<(len / 2) {
     let temp = self.unsafe_get(i)
-    self.unsafe_set(i, self.unsafe_get(self.length() - i - 1))
-    self.unsafe_set(self.length() - i - 1, temp)
+    self.unsafe_set(i, self.unsafe_get(len - i - 1))
+    self.unsafe_set(len - i - 1, temp)
   }
 }
 
@@ -744,9 +745,10 @@ pub fn[T] Array::rev_inplace(self : Array[T]) -> Unit {
 /// }
 /// ```
 pub fn[T] Array::rev(self : Array[T]) -> Array[T] {
-  let arr = Array::make_uninit(self.length())
-  for i in 0..<self.length() {
-    arr.unsafe_set(i, self.unsafe_get(self.length() - i - 1))
+  let len = self.length()
+  let arr = Array::make_uninit(len)
+  for i in 0..<len {
+    arr.unsafe_set(i, self.unsafe_get(len - i - 1))
   }
   arr
 }

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -199,8 +199,9 @@ pub fn of(arr : FixedArray[Byte]) -> Bytes {
 /// }
 /// ```
 pub fn to_array(self : Bytes) -> Array[Byte] {
-  let rv = Array::make(self.length(), b'0')
-  for i in 0..<self.length() {
+  let len = self.length()
+  let rv = Array::make(len, b'0')
+  for i in 0..<len {
     rv[i] = self[i]
   }
   rv
@@ -330,15 +331,14 @@ fn unsafe_to_bytes(array : FixedArray[Byte]) -> Bytes = "%identity"
 /// * `other` : The second bytes sequence.
 /// TODO: marked as intrinsic, inline if it is constant
 pub impl Add for Bytes with op_add(self : Bytes, other : Bytes) -> Bytes {
-  let rv : FixedArray[Byte] = FixedArray::make(
-    self.length() + other.length(),
-    0,
-  )
-  for i in 0..<self.length() {
+  let len_self = self.length()
+  let len_other = other.length()
+  let rv : FixedArray[Byte] = FixedArray::make(len_self + len_other, 0)
+  for i in 0..<len_self {
     rv[i] = self[i]
   }
-  for i in 0..<other.length() {
-    rv[self.length() + i] = other[i]
+  for i in 0..<len_other {
+    rv[len_self + i] = other[i]
   }
   unsafe_to_bytes(rv)
 }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1286,11 +1286,12 @@ pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
 
 ///|
 pub fn[A] to_array(self : T[A]) -> Array[A] {
-  if self.length() == 0 {
+  let len = self.length()
+  if len == 0 {
     []
   } else {
-    let xs = Array::make(self.length(), self[0])
-    for i in 0..<self.length() {
+    let xs = Array::make(len, self[0])
+    for i in 0..<len {
       xs[i] = self[i]
     }
     xs


### PR DESCRIPTION
## Summary
- optimize loops in `Bytes::to_array` and `Bytes` addition
- reduce `length()` calls in array reversal functions
- cache size in `Deque::to_array`

## Testing
- `moon fmt`
- `moon info`
- `moon check --verbose`
- `moon test`

------
https://chatgpt.com/codex/tasks/task_e_684ae1d2a7d483209a8fab3f9a02c07b