### PR TITLE
internal: skip inconsistent test case

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -451,7 +451,9 @@ fn BigInt::split(self : BigInt, half : Int) -> (BigInt, BigInt) {
 ///   inspect(a / -b, content="-5")
 ///   inspect(-a / -b, content="5")
 /// }
-///
+/// ```
+/// 
+/// ```skip
 /// test "panic BigInt::op_div/division_by_zero" {
 ///   let a = BigInt::from_string("100")
 ///   let b = BigInt::from_string("0")

--- a/builtin/double_to_int.mbt
+++ b/builtin/double_to_int.mbt
@@ -31,7 +31,7 @@
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::to_int/normal" {
 ///   inspect(42.0.to_int(), content="42")
 ///   inspect((-42.5).to_int(), content="-42")

--- a/builtin/double_to_int64_native.mbt
+++ b/builtin/double_to_int64_native.mbt
@@ -34,7 +34,7 @@ fn Double::to_unchecked_int64(self : Double) -> Int64 = "%f64_to_i64"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::to_int64" {
 ///   inspect(42.0.to_int64(), content="42")
 ///   inspect((-42.5).to_int64(), content="-42")
@@ -77,7 +77,7 @@ fn Double::to_unchecked_uint64(self : Double) -> UInt64 = "%f64_to_i64"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::to_int64" {
 ///   inspect(42.0.to_int64(), content="42")
 ///   inspect((-42.5).to_int64(), content="-42")

--- a/builtin/double_to_int_wasm.mbt
+++ b/builtin/double_to_int_wasm.mbt
@@ -31,7 +31,7 @@
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::to_int/normal" {
 ///   inspect(42.0.to_int(), content="42")
 ///   inspect((-42.5).to_int(), content="-42")

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -132,7 +132,9 @@ pub impl Mul for Int64 with op_mul(self, other) = "%i64_mul"
 ///   let d = 5L
 ///   inspect(c / d, content="-8")
 /// }
-///
+/// ```
+/// 
+/// ```skip
 /// test "panic Int64::op_div/division_by_zero" {
 ///   let a = 42L
 ///   ignore(a / 0L) // Division by zero
@@ -1264,7 +1266,9 @@ pub impl Mul for UInt64 with op_mul(self, other) = "%u64.mul"
 ///   let b = 20UL
 ///   inspect(a / b, content="5") // Using infix operator
 /// }
-///
+/// ```
+/// 
+/// ```skip
 /// test "panic UInt64::op_div/division_by_zero" {
 ///   let a = 42UL
 ///   ignore(a / 0UL) // Throws runtime error: division by zero

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -984,7 +984,7 @@ pub fn Double::reinterpret_as_uint64(self : Double) -> UInt64 = "%f64_to_i64_rei
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::convert_uint64" {
 ///   let n = 12345678901234567890UL
 ///   inspect(Double::convert_uint64(n), content="12345678901234567000")
@@ -1155,7 +1155,7 @@ pub fn UInt64::to_int(self : UInt64) -> Int = "%u64.to_i32"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "UInt64::to_double" {
 ///   let n = 12345678901234567890UL
 ///   inspect(n.to_double(), content="12345678901234567000") // Note the slight precision loss

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -897,7 +897,7 @@ pub fn Int::to_uint64(self : Int) -> UInt64 {
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::op_neg" {
 ///   inspect(-42.0, content="-42")
 ///   inspect(--42.0, content="42")
@@ -924,7 +924,7 @@ pub impl Neg for Double with op_neg(self) = "%f64_neg"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::op_add" {
 ///   inspect(2.5 + 3.7, content="6.2")
 ///   inspect(1.0 / 0.0 + -1.0 / 0.0, content="NaN") // Infinity + -Infinity = NaN
@@ -945,7 +945,7 @@ pub impl Add for Double with op_add(self, other) = "%f64_add"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::op_sub" {
 ///   let a = 5.0
 ///   let b = 3.0
@@ -975,7 +975,7 @@ pub impl Sub for Double with op_sub(self, other) = "%f64_sub"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::op_mul" {
 ///   inspect(2.5 * 2.0, content="5")
 ///   inspect(-2.0 * 3.0, content="-6")
@@ -1006,7 +1006,7 @@ pub impl Mul for Double with op_mul(self, other) = "%f64_mul"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::op_div" {
 ///   inspect(6.0 / 2.0, content="3")
 ///   inspect(-6.0 / 2.0, content="-3")
@@ -1054,7 +1054,7 @@ pub fn Double::sqrt(self : Double) -> Double = "%f64_sqrt"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::op_equal" {
 ///   let a = 3.14
 ///   let b = 3.14
@@ -1082,7 +1082,7 @@ pub impl Eq for Double with op_equal(self : Double, other : Double) -> Bool = "%
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Double::op_neq" {
 ///   inspect(1.0 != 2.0, content="true")
 ///   inspect(1.0 != 1.0, content="false")
@@ -2664,7 +2664,7 @@ pub impl Mul for Float with op_mul(self, other) = "%f32.mul"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Float::op_div" {
 ///   let a = 6.0.to_float()
 ///   let b = 2.0.to_float()
@@ -2720,7 +2720,7 @@ pub fn Float::sqrt(self : Float) -> Float = "%f32.sqrt"
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Float::op_equal" {
 ///   let x = 3.14
 ///   let y = 3.14
@@ -2746,7 +2746,7 @@ pub impl Eq for Float with op_equal(self : Float, other : Float) -> Bool = "%f32
 ///
 /// Example:
 ///
-/// ```moonbit
+/// ```skip
 /// test "Float::op_neq" {
 ///   let x = 1.0.to_float()
 ///   let y = 2.0.to_float()


### PR DESCRIPTION
Skip some of the doc tests that behavior inconsistently across backends / OS, notably native backend on Windows.