### PR TITLE
cleanup method as function semantic in `@list`

### DIFF
--- a/list/list.mbt
+++ b/list/list.mbt
@@ -466,7 +466,7 @@ pub fn[A, B] rev_foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
 ///   let r = @list.zip(@list.of([1, 2, 3, 4, 5]), @list.of([6, 7, 8, 9, 10]))
 ///   assert_eq(r, @list.from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]))
 /// ```
-pub fn[A, B] zip(self : T[A], other : T[B]) -> T[(A, B)] {
+pub fn[A, B] T::zip(self : T[A], other : T[B]) -> T[(A, B)] {
   let res = loop (self, other, Empty) {
     (Empty, _, acc) => break acc
     (_, Empty, acc) => break acc
@@ -602,7 +602,7 @@ pub fn[A] repeat(n : Int, x : A) -> T[A] {
 /// # Example
 ///
 /// ```mbt
-///   let ls = @list.intersperse(@list.from_array(["1", "2", "3", "4", "5"]), "|")
+///   let ls = @list.from_array(["1", "2", "3", "4", "5"]).intersperse("|")
 ///   assert_eq(ls, @list.from_array(["1", "|", "2", "|", "3", "|", "4", "|", "5"]))
 /// ```
 pub fn[A] intersperse(self : T[A], separator : A) -> T[A] {
@@ -638,7 +638,7 @@ pub fn[A] is_empty(self : T[A]) -> Bool {
 /// # Example
 ///
 /// ```mbt
-///   let (a,b) = @list.unzip(@list.from_array([(1,2),(3,4),(5,6)]))
+///   let (a,b) = @list.from_array([(1,2),(3,4),(5,6)]).unzip()
 ///   assert_eq(a, @list.from_array([1, 3, 5]))
 ///   assert_eq(b, @list.from_array([2, 4, 6]))
 /// ```
@@ -668,7 +668,7 @@ pub fn[A, B] unzip(self : T[(A, B)]) -> (T[A], T[B]) {
 /// # Example
 ///
 /// ```mbt
-///   let ls = @list.flatten(@list.from_array([@list.from_array([1,2,3]), @list.from_array([4,5,6]), @list.from_array([7,8,9])]))
+///   let ls = @list.from_array([@list.from_array([1,2,3]), @list.from_array([4,5,6]), @list.from_array([7,8,9])]).flatten()
 ///   assert_eq(ls, @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
 /// ```
 pub fn[A] flatten(self : T[T[A]]) -> T[A] {
@@ -772,7 +772,7 @@ pub fn[A : Compare] minimum(self : T[A]) -> A? {
 /// # Example
 ///
 /// ```mbt
-///   let ls = @list.sort(@list.from_array([1,123,52,3,6,0,-6,-76]))
+///   let ls = @list.from_array([1,123,52,3,6,0,-6,-76]).sort()
 ///   assert_eq(ls, @list.from_array([-76, -6, 0, 1, 3, 6, 52, 123]))
 /// ```
 pub fn[A : Compare] sort(self : T[A]) -> T[A] {
@@ -1276,3 +1276,6 @@ fn[A] reverse_inplace(self : T[A]) -> T[A] {
       }
   }
 }
+
+///|
+pub fnalias T::zip

--- a/list/list.mbti
+++ b/list/list.mbti
@@ -6,45 +6,11 @@ import(
 )
 
 // Values
-fn[A] add(T[A], A) -> T[A]
-
-fn[A] all(T[A], (A) -> Bool) -> Bool
-
-fn[A] any(T[A], (A) -> Bool) -> Bool
-
-fn[A] concat(T[A], T[A]) -> T[A]
-
 fn[A] construct(A, T[A]) -> T[A]
-
-fn[A : Eq] contains(T[A], A) -> Bool
 
 fn[X] default() -> T[X]
 
-fn[A] drop(T[A], Int) -> T[A]
-
-fn[A] drop_while(T[A], (A) -> Bool) -> T[A]
-
-fn[A] each(T[A], (A) -> Unit) -> Unit
-
-fn[A] eachi(T[A], (Int, A) -> Unit) -> Unit
-
 fn[A] empty() -> T[A]
-
-fn[A] filter(T[A], (A) -> Bool) -> T[A]
-
-fn[A, B] filter_map(T[A], (A) -> B?) -> T[B]
-
-fn[A] find(T[A], (A) -> Bool) -> A?
-
-fn[A] findi(T[A], (A, Int) -> Bool) -> A?
-
-fn[A, B] flat_map(T[A], (A) -> T[B]) -> T[B]
-
-fn[A] flatten(T[T[A]]) -> T[A]
-
-fn[A, B] fold(T[A], init~ : B, (B, A) -> B) -> B
-
-fn[A, B] foldi(T[A], init~ : B, (Int, B, A) -> B) -> B
 
 fn[A] from_array(Array[A]) -> T[A]
 
@@ -54,95 +20,17 @@ fn[A] from_iter_rev(Iter[A]) -> T[A]
 
 fn[A : @json.FromJson] from_json(Json) -> T[A] raise @json.JsonDecodeError
 
-fn[A] head(T[A]) -> A?
-
-fn[A] intercalate(T[T[A]], T[A]) -> T[A]
-
-fn[A] intersperse(T[A], A) -> T[A]
-
-fn[A] is_empty(T[A]) -> Bool
-
-fn[A : Eq] is_prefix(T[A], T[A]) -> Bool
-
-fn[A : Eq] is_suffix(T[A], T[A]) -> Bool
-
-fn[A] iter(T[A]) -> Iter[A]
-
-fn[A] iter2(T[A]) -> Iter2[Int, A]
-
-fn[A] last(T[A]) -> A?
-
-fn[A] length(T[A]) -> Int
-
-fn[A : Eq, B] lookup(T[(A, B)], A) -> B?
-
-fn[A, B] map(T[A], (A) -> B) -> T[B]
-
-fn[A, B] mapi(T[A], (Int, A) -> B) -> T[B]
-
-fn[A : Compare] maximum(T[A]) -> A?
-
-fn[A : Compare] minimum(T[A]) -> A?
-
 fn[A] new() -> T[A]
-
-fn[A] nth(T[A], Int) -> A?
 
 fn[A] of(FixedArray[A]) -> T[A]
 
-fn[A] prepend(T[A], A) -> T[A]
-
-fn[A : Eq] remove(T[A], A) -> T[A]
-
-fn[A] remove_at(T[A], Int) -> T[A]
-
 fn[A] repeat(Int, A) -> T[A]
-
-fn[A] rev(T[A]) -> T[A]
-
-fn[A] rev_concat(T[A], T[A]) -> T[A]
-
-#deprecated
-fn[A, B] rev_fold(T[A], init~ : B, (B, A) -> B) -> B
-
-#deprecated
-fn[A, B] rev_foldi(T[A], init~ : B, (Int, B, A) -> B) -> B
-
-fn[A, B] rev_map(T[A], (A) -> B) -> T[B]
 
 fn[A, S] rev_unfold((S) -> (A, S)?, init~ : S) -> T[A]
 
-fn[A, E] scan_left(T[A], (E, A) -> E, init~ : E) -> T[E]
-
-fn[A, B] scan_right(T[A], (B, A) -> B, init~ : B) -> T[B]
-
 fn[A] singleton(A) -> T[A]
 
-fn[A : Compare] sort(T[A]) -> T[A]
-
-fn[A] tail(T[A]) -> T[A]
-
-fn[A] take(T[A], Int) -> T[A]
-
-fn[A] take_while(T[A], (A) -> Bool) -> T[A]
-
-fn[A] to_array(T[A]) -> Array[A]
-
-fn[A : ToJson] to_json(T[A]) -> Json
-
 fn[A, S] unfold((S) -> (A, S)?, init~ : S) -> T[A]
-
-fn[A] unsafe_head(T[A]) -> A
-
-fn[A] unsafe_last(T[A]) -> A
-
-fn[A : Compare] unsafe_maximum(T[A]) -> A
-
-fn[A : Compare] unsafe_minimum(T[A]) -> A
-
-fn[A] unsafe_nth(T[A], Int) -> A
-
-fn[A, B] unzip(T[(A, B)]) -> (T[A], T[B])
 
 fn[A, B] zip(T[A], T[B]) -> T[(A, B)]
 


### PR DESCRIPTION
This PR reverts #2224, and fix some related issue.

We have deprecated the behavior of calling methods as functions directly. Currently, the recommended API design guideline is:

- always favor method when the first parameter is `Self`
- do not provide function alternative unless necessary

For existing library, library authors need to do nothing: downstream users will receive a deprecated warning when calling methods as function, and fix these usage. There is no need to provide `fnalias` for methods, as in #2224, unless necessary (for example, for math functions `Double::sin` etc, people are used to regular function syntax due to math notation convention).

So this PR reverts #2224, remove `fnalias` for `@list.T` methods. Downstream users of `@list` will receive a deprecated warning if they use `@list.T` methods as regular functions, and it is their responsibility to fix these usage. This is not a breaking change since it's a warning, not a fatal error.

One exception is `zip`. Since `zip` is a binary operation on list, it sometimes feels more natural to write `@list.zip(xs, ys)`, so the `fnalias` for `zip` is kept in this PR.

cc @illusory0x0 @peter-jerry-ye 