### PR TITLE
Group deprecated blocks

### DIFF
--- a/deque/deprecated.mbt
+++ b/deque/deprecated.mbt
@@ -1,0 +1,35 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `unsafe_pop_front` instead")
+#coverage.skip
+pub fn[A] pop_front_exn(self : T[A]) -> Unit {
+  self.unsafe_pop_front()
+}
+
+///|
+#deprecated("Use `unsafe_pop_back` instead")
+#coverage.skip
+pub fn[A] pop_back_exn(self : T[A]) -> Unit {
+  self.unsafe_pop_back()
+}
+
+///|
+#deprecated("Use `@deque.retain_map` instead")
+pub fn[A] filter_map_inplace(self : T[A], f : (A) -> A?) -> Unit {
+  self.retain_map(f)
+}
+
+///|

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -349,11 +349,6 @@ pub fn[A] unsafe_pop_front(self : T[A]) -> Unit {
 ///   inspect(dq, content="@deque.of([2, 3])")
 /// ```
 ///
-#deprecated("Use `unsafe_pop_front` instead")
-#coverage.skip
-pub fn[A] pop_front_exn(self : T[A]) -> Unit {
-  self.unsafe_pop_front()
-}
 
 ///|
 /// Removes a back element from a deque.
@@ -404,11 +399,6 @@ pub fn[A] unsafe_pop_back(self : T[A]) -> Unit {
 ///   inspect(dq, content="@deque.of([1, 2])")
 /// ```
 ///
-#deprecated("Use `unsafe_pop_back` instead")
-#coverage.skip
-pub fn[A] pop_back_exn(self : T[A]) -> Unit {
-  self.unsafe_pop_back()
-}
 
 ///|
 /// Removes a front element from a deque and returns it, or `None` if it is empty.
@@ -953,10 +943,6 @@ pub fn[A] retain_map(self : T[A], f : (A) -> A?) -> Unit {
 /// deque to retain only elements for which the provided function returns `Some`,
 /// and updates those elements with the values inside the `Some` variant.
 ///
-#deprecated("Use `@deque.retain_map` instead")
-pub fn[A] filter_map_inplace(self : T[A], f : (A) -> A?) -> Unit {
-  self.retain_map(f)
-}
 
 ///|
 /// Filters elements in-place by retaining only the elements that satisfy the

--- a/double/deprecated.mbt
+++ b/double/deprecated.mbt
@@ -1,0 +1,65 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// [DEPRECATED] Returns a "not-a-number" (NaN) value.
+///
+/// This function is deprecated. Use `@double.not_a_number` instead.
+///
+/// Returns a double-precision floating-point NaN value.
+///
+/// Example:
+///
+/// ```moonbit
+///   let nan = @double.not_a_number
+///   inspect(nan.is_nan(), content="true")
+/// ```
+#deprecated("Use `@double.not_a_number` instead")
+#coverage.skip
+pub fn Double::nan() -> Double {
+  not_a_number
+}
+
+///|
+/// Returns positive infinity if sign >= 0, negative infinity if sign < 0.
+#deprecated("Use `@double.infinity` and `@double.neg_infinity` instead")
+#coverage.skip
+pub fn Double::inf(sign : Int) -> Double {
+  if sign >= 0 {
+    infinity
+  } else {
+    neg_infinity
+  }
+}
+
+///|
+/// Returns the smallest positive normal value of a double-precision
+/// floating-point number.
+///
+/// Returns a `Double` value that represents the smallest positive normal number
+/// that can be represented by a double-precision floating-point number
+/// (approximately 2.2250738585072014e-308).
+///
+/// Example:
+///
+/// ```moonbit
+///   inspect(@double.min_positive, content="2.2250738585072014e-308")
+/// ```
+#deprecated("Use `@double.min_positive` instead")
+#coverage.skip
+pub fn Double::min_normal() -> Double {
+  min_positive
+}
+
+///|

--- a/double/double.mbt
+++ b/double/double.mbt
@@ -91,60 +91,7 @@ pub fn signum(self : Double) -> Double {
   }
 }
 
-///|
-/// \[DEPRECATED] Returns a "not-a-number" (NaN) value.
-///
-/// This function is deprecated. Use `@double.not_a_number` instead.
-///
-/// Returns a double-precision floating-point NaN value.
-///
-/// Example:
-///
-/// ```moonbit
-///   let nan = @double.not_a_number
-///   inspect(nan.is_nan(), content="true")
-/// ```
-///
-#deprecated("Use `@double.not_a_number` instead")
-#coverage.skip
-pub fn Double::nan() -> Double {
-  not_a_number
-}
-
-///|
-/// Returns positive infinity if sign >= 0, negative infinity if sign < 0.
-#deprecated("Use `@double.infinity` and `@double.neg_infinity` instead")
-#coverage.skip
-pub fn Double::inf(sign : Int) -> Double {
-  if sign >= 0 {
-    infinity
-  } else {
-    neg_infinity
-  }
-}
-
-///|
-/// Returns the smallest positive normal value of a double-precision
-/// floating-point number.
-///
-/// Returns a `Double` value that represents the smallest positive normal number
-/// that can be represented by a double-precision floating-point number
-/// (approximately 2.2250738585072014e-308).
-///
-/// Example:
-///
-/// ```moonbit
-///   inspect(@double.min_positive, content="2.2250738585072014e-308")
-/// ```
-///
-#deprecated("Use `@double.min_positive` instead")
-#coverage.skip
-pub fn Double::min_normal() -> Double {
-  min_positive
-}
-
-///|
-/// Checks whether a double-precision floating-point number represents a "Not a
+///| Checks whether a double-precision floating-point number represents a "Not a
 /// Number" (NaN) value.
 ///
 /// Parameters:

--- a/list/deprecated.mbt
+++ b/list/deprecated.mbt
@@ -1,0 +1,32 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("use `_.to_array().rev_fold(...)` instead")
+pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
+  let xs = self.to_array()
+  let mut acc = init
+  for x in xs.rev_iter() {
+    acc = f(acc, x)
+  }
+  acc
+}
+
+///|
+#deprecated("use `_.rev().foldi(...)` instead")
+pub fn[A, B] rev_foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
+  self.rev().foldi(init~, fn(i, b, a) { f(i, b, a) })
+}
+
+///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -422,17 +422,6 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 }
 
 ///|
-#deprecated("use `_.to_array().rev_fold(...)` instead")
-pub fn[A, B] rev_fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
-  let xs = self.to_array()
-  let mut acc = init
-  for x in xs.rev_iter() {
-    acc = f(acc, x)
-  }
-  acc
-}
-
-///|
 /// Fold the list from left with index.
 pub fn[A, B] foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
   fn go(xs : T[A], i : Int, f : (Int, B, A) -> B, acc : B) -> B {
@@ -443,17 +432,6 @@ pub fn[A, B] foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
   }
 
   go(self, 0, f, init)
-}
-
-///|
-/// Fold the list from right with index.
-/// 
-/// The index parameter corresponds to the order of traversal, 
-/// starting from 0 for the first element visited,
-/// i.e. the last element of the list would have index 0 as it's first visited.
-#deprecated("use `_.rev().foldi(...)` instead")
-pub fn[A, B] rev_foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
-  self.rev().foldi(init~, fn(i, b, a) { f(i, b, a) })
 }
 
 ///|


### PR DESCRIPTION
## Summary
- move deprecated `deque` functions into `deprecated.mbt`
- move deprecated `list` functions into `deprecated.mbt`
- move deprecated `double` functions into `deprecated.mbt`

## Testing
- `moon fmt`
- `moon info`
- `moon test`
- `moon check`


------
https://chatgpt.com/codex/tasks/task_e_6858faf57c248320aebb9138fa34cf6e