### PR TITLE
Move deprecated blocks in string package

### DIFF
--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -138,3 +138,111 @@ pub fn View::op_as_view(self : View, start~ : Int = 0, end? : Int) -> View {
   }
   { str: self.str, start, end }
 }
+
+///|
+#deprecated("Use `Array::join` instead.")
+pub fn concat(strings : Array[String], separator~ : String = "") -> String {
+  match strings {
+    [] => ""
+    [hd, .. tl] => {
+      let mut size_hint = hd.length()
+      for s in tl {
+        size_hint += s.length() + separator.length()
+      }
+      size_hint = size_hint << 1
+      let buf = StringBuilder::new(size_hint~)
+      buf.write_string(hd)
+      if separator == "" {
+        for s in tl {
+          buf.write_string(s)
+        }
+      } else {
+        for s in tl {
+          buf.write_string(separator)
+          buf.write_string(s)
+        }
+      }
+      buf.to_string()
+    }
+  }
+}
+
+///|
+#deprecated("Use `s.find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
+pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
+  if from <= 0 {
+    if self.find(str.view()) is Some(idx) {
+      idx
+    } else {
+      -1
+    }
+  } else if from > self.length() {
+    if str.length() == 0 {
+      self.length()
+    } else {
+      -1
+    }
+  } else if self.view(start_offset=from).find(str.view()) is Some(idx) {
+    idx + from
+  } else {
+    -1
+  }
+}
+
+///|
+/// Returns the last index of the sub string.
+#deprecated("Use `s.rev_find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
+pub fn last_index_of(self : String, str : String, from? : Int) -> Int {
+  let from = if from is Some(f) { f } else { self.length() }
+  if from >= self.length() {
+    if self.rev_find(str.view()) is Some(idx) {
+      idx
+    } else {
+      -1
+    }
+  } else if from < 0 {
+    if str.length() == 0 {
+      self.length()
+    } else {
+      -1
+    }
+  } else if self.view(end_offset=from).rev_find(str.view()) is Some(idx) {
+    idx
+  } else {
+    -1
+  }
+}
+
+///|
+/// Returns true if this string starts with a sub string.
+#deprecated("Use `s.has_prefix(str)` instead.")
+pub fn starts_with(self : String, str : String) -> Bool {
+  self.has_prefix(str.view())
+}
+
+///|
+/// Returns true if this string ends with a sub string.
+#deprecated("Use `s.has_suffix(str)` instead.")
+pub fn ends_with(self : String, str : String) -> Bool {
+  self.has_suffix(str.view())
+}
+
+///| 
+/// A `StringView` represents a view of a String that maintains proper Unicode
+/// character boundaries. It allows safe access to a substring while handling 
+/// multi-byte characters correctly.
+#deprecated("use @string.View instead")
+#builtin.valtype
+struct StringView {
+  // # Fields
+  //
+  // - `str`: The source String being viewed
+  // - `start`: Starting UTF-16 code unit index into the string
+  // - `end`: Ending UTF-16 code unit index into the string (not included)
+  //
+  // `len` is not included because it will make the operation of `op_as_view`
+  // has complexity O(n) where n is the length of the code points in the view.
+  str : String
+  start : Int
+  end : Int
+}

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -52,34 +52,6 @@ pub fn from_iter(iter : Iter[Char]) -> String {
 }
 
 ///|
-#deprecated("Use `Array::join` instead.")
-pub fn concat(strings : Array[String], separator~ : String = "") -> String {
-  match strings {
-    [] => ""
-    [hd, .. tl] => {
-      let mut size_hint = hd.length()
-      for s in tl {
-        size_hint += s.length() + separator.length()
-      }
-      size_hint = size_hint << 1
-      let buf = StringBuilder::new(size_hint~)
-      buf.write_string(hd)
-      if separator == "" {
-        for s in tl {
-          buf.write_string(s)
-        }
-      } else {
-        for s in tl {
-          buf.write_string(separator)
-          buf.write_string(s)
-        }
-      }
-      buf.to_string()
-    }
-  }
-}
-
-///|
 /// Strings are ordered lexicographically by their charcodes(code unit). This 
 /// orders Unicode characters based on their positions in the code charts. This is
 /// not necessarily the same as "alphabetical" order, which varies by language
@@ -240,66 +212,9 @@ pub fn rev_iter(self : String) -> Iter[Char] {
 }
 
 ///|
-#deprecated("Use `s.find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
-pub fn index_of(self : String, str : String, from~ : Int = 0) -> Int {
-  if from <= 0 {
-    if self.find(str.view()) is Some(idx) {
-      idx
-    } else {
-      -1
-    }
-  } else if from > self.length() {
-    if str.length() == 0 {
-      self.length()
-    } else {
-      -1
-    }
-  } else if self.view(start_offset=from).find(str.view()) is Some(idx) {
-    idx + from
-  } else {
-    -1
-  }
-}
-
-///|
 /// Returns the last index of the sub string.
-#deprecated("Use `s.rev_find(substr)` instead. If the optional argument `from` is not 0, take view from the string first. Please do not use an invalid `from` argument.")
-pub fn last_index_of(self : String, str : String, from? : Int) -> Int {
-  let from = if from is Some(f) { f } else { self.length() }
-  if from >= self.length() {
-    if self.rev_find(str.view()) is Some(idx) {
-      idx
-    } else {
-      -1
-    }
-  } else if from < 0 {
-    if str.length() == 0 {
-      self.length()
-    } else {
-      -1
-    }
-  } else if self.view(end_offset=from).rev_find(str.view()) is Some(idx) {
-    idx
-  } else {
-    -1
-  }
-}
-
-///|
 /// Returns true if this string starts with a sub string.
-#deprecated("Use `s.has_prefix(str)` instead.")
-pub fn starts_with(self : String, str : String) -> Bool {
-  self.has_prefix(str.view())
-}
-
-///|
 /// Returns true if this string ends with a sub string.
-#deprecated("Use `s.has_suffix(str)` instead.")
-pub fn ends_with(self : String, str : String) -> Bool {
-  self.has_suffix(str.view())
-}
-
-///|
 /// Returns the index of the n-th (zero-indexed) character within the range [start, end).
 fn String::offset_of_nth_char_forward(
   self : String,

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -12,25 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-///| 
-/// A `StringView` represents a view of a String that maintains proper Unicode
-/// character boundaries. It allows safe access to a substring while handling 
-/// multi-byte characters correctly.
-#deprecated("use @string.View instead")
-#builtin.valtype
-struct StringView {
-  // # Fields
-  //
-  // - `str`: The source String being viewed
-  // - `start`: Starting UTF-16 code unit index into the string
-  // - `end`: Ending UTF-16 code unit index into the string (not included)
-  //
-  // `len` is not included because it will make the operation of `op_as_view`
-  // has complexity O(n) where n is the length of the code points in the view.
-  str : String
-  start : Int
-  end : Int
-}
 
 ///|
 /// A `@string.View` represents a view of a String that maintains proper Unicode


### PR DESCRIPTION
## Summary
- consolidate deprecated string functions in `deprecated.mbt`
- remove deprecated blocks from `string.mbt` and `view.mbt`

## Testing
- `moon test`
- `moon info`
- `moon check`


------
https://chatgpt.com/codex/tasks/task_e_685963c08e6c83208721f1364ce6039a