### PR TITLE
refactor: migrate rand and arbitrary

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -311,15 +311,6 @@ pub fn[A, B] zip_to_iter2(self : Array[A], other : Array[B]) -> Iter2[A, B] {
 }
 
 ///|
-pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Array[X] with arbitrary(
-  size,
-  rs
-) {
-  let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
-  Array::makei(len, fn(x) { X::arbitrary(x, rs) })
-}
-
-///|
 /// Join an array of strings using the provided `separator`.
 ///
 /// Parameters:

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -1240,12 +1240,3 @@ test "FixedArray::join" {
   let fixed_array_empty : FixedArray[String] = []
   inspect(fixed_array_empty.join(","), content="")
 }
-
-///|
-pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for FixedArray[X] with arbitrary(
-  size,
-  rs
-) {
-  let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
-  FixedArray::makei(len, fn(x) { X::arbitrary(x, rs) })
-}

--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -2,15 +2,14 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/bytes",
-    "moonbitlang/core/string",
-    "moonbitlang/core/quickcheck",
-    "moonbitlang/core/quickcheck/splitmix"
+    "moonbitlang/core/string"
   ],
   "test-import": [
     "moonbitlang/core/char",
     "moonbitlang/core/test",
     "moonbitlang/core/random",
-    "moonbitlang/core/json"
+    "moonbitlang/core/json",
+    "moonbitlang/core/quickcheck"
   ],
   "targets": {
     "array_js.mbt": ["js"],

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -486,11 +486,3 @@ pub impl[A : Hash] Hash for View[A] with hash_combine(self, hasher) {
     hasher.combine(e)
   }
 }
-
-///|
-pub impl[A : @quickcheck.Arbitrary] @quickcheck.Arbitrary for View[A] with arbitrary(
-  size,
-  rs
-) {
-  Array::arbitrary(size, rs)[:]
-}

--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -52,15 +52,6 @@ pub impl @json.FromJson for BigInt with from_json(json, path) {
 }
 
 ///|
-pub impl @quickcheck.Arbitrary for BigInt with arbitrary(size, rs) {
-  if size == 0 {
-    0
-  } else {
-    rs.next_int64() |> BigInt::from_int64
-  }
-}
-
-///|
 /// Tests equality between a `BigInt` and an `Int` value.
 ///
 /// This function performs a safe comparison by first checking if the `BigInt`

--- a/bigint/moon.pkg.json
+++ b/bigint/moon.pkg.json
@@ -4,8 +4,6 @@
     "moonbitlang/core/char",
     "moonbitlang/core/uint",
     "moonbitlang/core/json",
-    "moonbitlang/core/quickcheck",
-    "moonbitlang/core/quickcheck/splitmix",
     "moonbitlang/core/string"
   ],
   "targets": {

--- a/option/moon.pkg.json
+++ b/option/moon.pkg.json
@@ -2,7 +2,7 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/quickcheck/splitmix"
+    "moonbitlang/core/random"
   ],
   "targets": {
     "panic_test.mbt": ["not", "native", "llvm"]

--- a/priority_queue/moon.pkg.json
+++ b/priority_queue/moon.pkg.json
@@ -3,7 +3,7 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/quickcheck/splitmix"
+    "moonbitlang/core/random"
   ],
   "test-import": ["moonbitlang/core/random"],
   "targets": {

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -18,7 +18,7 @@ pub(open) trait Arbitrary {
   // `arbitrary` function takes a random number generator and a number that 
   // determines the size of the generated value as arguments, and returns a
   // randomly generated value of certain type.
-  arbitrary(Int, @splitmix.RandomState) -> Self
+  arbitrary(Int, &@random.Source) -> Self
 }
 
 ///|
@@ -124,13 +124,38 @@ pub impl[X : Arbitrary] Arbitrary for Iter[X] with arbitrary(size, rs) {
 }
 
 ///|
-pub fn[T : Arbitrary] gen(size? : Int, state? : @splitmix.RandomState) -> T {
+pub impl[X : Arbitrary] Arbitrary for Array[X] with arbitrary(size, rs) {
+  let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
+  Array::makei(len, fn(x) { X::arbitrary(x, rs) })
+}
+
+///|
+pub impl[X : Arbitrary] Arbitrary for FixedArray[X] with arbitrary(size, rs) {
+  let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
+  FixedArray::makei(len, fn(x) { X::arbitrary(x, rs) })
+}
+
+///|
+pub impl[A : Arbitrary] Arbitrary for @array.View[A] with arbitrary(size, rs) {
+  (Arbitrary::arbitrary(size, rs) : Array[A])[:]
+}
+
+///|
+pub impl Arbitrary for @bigint.BigInt with arbitrary(size, rs) {
+  let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
+  rs.next_bigint(len)
+}
+
+///|
+pub fn[T : Arbitrary] gen(size? : Int, state? : &@random.Source) -> T {
   let size = match size {
     None => 0
     Some(x) => x
   }
   let state = match state {
-    None => @splitmix.RandomState::default()
+    None => {
+      @splitmix.RandomState::default() as &@random.Source
+    }
     Some(x) => x
   }
   Arbitrary::arbitrary(size, state)

--- a/quickcheck/moon.pkg.json
+++ b/quickcheck/moon.pkg.json
@@ -1,12 +1,13 @@
 {
   "import": [
     "moonbitlang/core/quickcheck/splitmix",
+    "moonbitlang/core/array",
     "moonbitlang/core/builtin",
-    "moonbitlang/core/char"
+    "moonbitlang/core/char",
+    "moonbitlang/core/random",
+    "moonbitlang/core/bigint"
   ],
   "test-import": [
-    "moonbitlang/core/array",
-    "moonbitlang/core/bigint",
     "moonbitlang/core/float",
     "moonbitlang/core/double",
     "moonbitlang/core/tuple"

--- a/quickcheck/splitmix/moon.pkg.json
+++ b/quickcheck/splitmix/moon.pkg.json
@@ -1,3 +1,6 @@
 {
-  "import": ["moonbitlang/core/builtin"]
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/random"
+  ]
 }

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -19,6 +19,13 @@ struct RandomState {
 } derive(Show, Default)
 
 ///|
+pub impl @random.Source for RandomState with next(self) {
+  let { seed, gamma } = self
+  self.seed = seed + gamma
+  mix64(self.seed)
+}
+
+///|
 let golden_gamma : UInt64 = 0x9e3779b97f4a7c15
 
 ///|

--- a/random/source.mbt
+++ b/random/source.mbt
@@ -1,0 +1,51 @@
+///|
+pub fn next_uint64(self : &Source) -> UInt64 {
+  Rand(self).uint64()
+}
+
+///|
+pub fn next_uint(self : &Source) -> UInt {
+  Rand(self).uint()
+}
+
+///|
+pub fn next_int64(self : &Source) -> Int64 {
+  Rand(self).uint64().reinterpret_as_int64()
+}
+
+///|
+pub fn next_two_uint(self : &Source) -> (UInt, UInt) {
+  let u1 = Rand(self).uint()
+  let u2 = Rand(self).uint()
+  (u1, u2)
+}
+
+///|
+pub fn next_int(self : &Source) -> Int {
+  Rand(self).uint().reinterpret_as_int()
+}
+
+///|
+pub fn next_positive_int(self : &Source) -> Int {
+  Rand(self).int()
+}
+
+///|
+pub fn next_float(self : &Source) -> Float {
+  Rand(self).float()
+}
+
+///|
+pub fn next_double(self : &Source) -> Double {
+  Rand(self).double()
+}
+
+///|
+pub fn next_bigint(self : &Source, bits : Int) -> @bigint.BigInt {
+  Rand(self).bigint(bits)
+}
+
+///|
+pub fn split(self : &Source) -> &Source {
+  self
+}

--- a/tuple/moon.pkg.json
+++ b/tuple/moon.pkg.json
@@ -2,7 +2,7 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/quickcheck/splitmix"
+    "moonbitlang/core/random"
   ],
   "test-import": [
     "moonbitlang/core/char"


### PR DESCRIPTION
**Goal**

Make `Arbitrary` accept general generators

**Blocking issue**

Currently the `Arbitrary` uses `@splitmix.RandomState`

1. All its methods need to be provided by the successor (`&Source` or `Rand`). 
2. The import of package `@random` must be added.
3. There's the `split` method that is used and can not be replaced, resulting in
4. The behavior would be different, breaking all the expectation tests.