### PR TITLE
feat(json): expose decode_error for custom error handling

### DIFF
--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -30,7 +30,10 @@ pub fn[T : FromJson] from_json(
 }
 
 ///|
-fn[T] decode_error(path : JsonPath, msg : String) -> T raise JsonDecodeError {
+pub fn[T] decode_error(
+  path : JsonPath,
+  msg : String
+) -> T raise JsonDecodeError {
   raise JsonDecodeError((path, msg))
 }
 

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -5,6 +5,8 @@ import(
 )
 
 // Values
+fn[T] decode_error(JsonPath, String) -> T raise JsonDecodeError
+
 fn[T : FromJson] from_json(Json, path~ : JsonPath = ..) -> T raise JsonDecodeError
 
 fn inspect(&ToJson, content? : Json, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise InspectError


### PR DESCRIPTION
When users manually implement the FromJson trait, they may need to construct JsonDecodeError instances. Exposing the json library's decode_error function would help with this.

```moonbit
type NewType 
// impl @json.FromJson for NewType with from_json(json: Json, path: @json.JsonPath) -> NewType raise {
//    raise @json.JsonDecodeError((path, "JsonType::from_json: expected a string, got \{json}"))
//}

impl @json.FromJson for NewType with from_json(json: Json, path: @json.JsonPath) -> NewType raise {
    raise @json.decode_error(path, "JsonType::from_json: expected a string, got \{json}")
}

```