### PR TITLE
Modernize closures with arrow functions

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -294,7 +294,7 @@ pub fn[A, B, C] zip_with(
 ///   inspect(arr1.zip_to_iter2(arr2).to_array(), content="[(1, 'a'), (2, 'b'), (3, 'c')]")
 /// ```
 pub fn[A, B] zip_to_iter2(self : Array[A], other : Array[B]) -> Iter2[A, B] {
-  Iter2::new(fn(yield_) {
+  Iter2::new(yield_ => {
     let length = if self.length() < other.length() {
       self.length()
     } else {

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -178,7 +178,7 @@ pub fn[T : Eq] View::contains(self : View[T], value : T) -> Bool {
 ///   inspect(sum, content="5")
 /// ```
 pub fn[A] View::iter(self : View[A]) -> Iter[A] {
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     for v in self {
       guard yield_(v) is IterContinue else { break IterEnd }
     } else {
@@ -205,7 +205,7 @@ pub fn[A] View::iter(self : View[A]) -> Iter[A] {
 ///   inspect(sum_keys, content="1")
 /// ```
 pub fn[A] View::iter2(self : View[A]) -> Iter2[Int, A] {
-  Iter2::new(fn(yield_) {
+  Iter2::new(yield_ => {
     for i, v in self {
       guard yield_(i, v) is IterContinue else { break IterEnd }
     } else {

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -178,12 +178,10 @@ pub fn[T : Eq] View::contains(self : View[T], value : T) -> Bool {
 ///   inspect(sum, content="5")
 /// ```
 pub fn[A] View::iter(self : View[A]) -> Iter[A] {
-  Iter::new(yield_ => {
-    for v in self {
-      guard yield_(v) is IterContinue else { break IterEnd }
-    } else {
-      IterContinue
-    }
+  Iter::new(yield_ => for v in self {
+    guard yield_(v) is IterContinue else { break IterEnd }
+  } else {
+    IterContinue
   })
 }
 
@@ -205,12 +203,10 @@ pub fn[A] View::iter(self : View[A]) -> Iter[A] {
 ///   inspect(sum_keys, content="1")
 /// ```
 pub fn[A] View::iter2(self : View[A]) -> Iter2[Int, A] {
-  Iter2::new(yield_ => {
-    for i, v in self {
-      guard yield_(i, v) is IterContinue else { break IterEnd }
-    } else {
-      IterContinue
-    }
+  Iter2::new(yield_ => for i, v in self {
+    guard yield_(i, v) is IterContinue else { break IterEnd }
+  } else {
+    IterContinue
   })
 }
 

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1171,30 +1171,26 @@ pub fn[X] default() -> T[X] {
 
 ///|
 pub fn[A] iter(self : T[A]) -> Iter[A] {
-  Iter::new(fn(yield_) {
-    loop self {
-      Empty => IterContinue
-      More(head, tail~) => {
-        if yield_(head) == IterEnd {
-          break IterEnd
-        }
-        continue tail
+  Iter::new(yield_ => loop self {
+    Empty => IterContinue
+    More(head, tail~) => {
+      if yield_(head) == IterEnd {
+        break IterEnd
       }
+      continue tail
     }
   })
 }
 
 ///|
 pub fn[A] iter2(self : T[A]) -> Iter2[Int, A] {
-  Iter2::new(fn(yield_) {
-    loop (self, 0) {
-      (Empty, _) => IterEnd
-      (More(head, tail~), i) => {
-        if yield_(i, head) == IterEnd {
-          break IterEnd
-        }
-        continue (tail, i + 1)
+  Iter2::new(yield_ => loop (self, 0) {
+    (Empty, _) => IterEnd
+    (More(head, tail~), i) => {
+      if yield_(i, head) == IterEnd {
+        break IterEnd
       }
+      continue (tail, i + 1)
     }
   })
 }

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -112,14 +112,12 @@ pub impl Arbitrary for String with arbitrary(size, rs) {
 ///|
 pub impl[X : Arbitrary] Arbitrary for Iter[X] with arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
-  Iter::new(yield_ => {
-    for i in 0..<len {
-      if yield_(X::arbitrary(i, rs)) == IterEnd {
-        break IterEnd
-      }
-    } else {
-      IterContinue
+  Iter::new(yield_ => for i in 0..<len {
+    if yield_(X::arbitrary(i, rs)) == IterEnd {
+      break IterEnd
     }
+  } else {
+    IterContinue
   })
 }
 

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -112,7 +112,7 @@ pub impl Arbitrary for String with arbitrary(size, rs) {
 ///|
 pub impl[X : Arbitrary] Arbitrary for Iter[X] with arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     for i in 0..<len {
       if yield_(X::arbitrary(i, rs)) == IterEnd {
         break IterEnd

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -132,7 +132,7 @@ pub fn[K, V] eachi(
   f : (Int, K, V) -> Unit raise?
 ) -> Unit raise? {
   let mut i = 0
-  self.each(fn(k, v) {
+  self.each((k, v) => {
     f(i, k, v)
     i = i + 1
   })
@@ -142,7 +142,7 @@ pub fn[K, V] eachi(
 /// Returns all keys in the map.
 pub fn[K, V] keys(self : T[K, V]) -> Array[K] {
   let keys = Array::new(capacity=self.size)
-  self.each(fn(k, _v) { keys.push(k) })
+  self.each((k, _v) => keys.push(k))
   keys
 }
 
@@ -150,7 +150,7 @@ pub fn[K, V] keys(self : T[K, V]) -> Array[K] {
 /// Returns all values in the map.
 pub fn[K, V] values(self : T[K, V]) -> Array[V] {
   let values = Array::new(capacity=self.size)
-  self.each(fn(_k, v) { values.push(v) })
+  self.each((_k, v) => values.push(v))
   values
 }
 
@@ -158,13 +158,13 @@ pub fn[K, V] values(self : T[K, V]) -> Array[V] {
 /// Converts the map to an array.
 pub fn[K, V] to_array(self : T[K, V]) -> Array[(K, V)] {
   let arr = Array::new(capacity=self.size)
-  self.each(fn(k, v) { arr.push((k, v)) })
+  self.each((k, v) => arr.push((k, v)))
   arr
 }
 
 ///|
 pub fn[K, V] iter(self : T[K, V]) -> Iter[(K, V)] {
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
         None => IterContinue
@@ -185,7 +185,7 @@ pub fn[K, V] iter(self : T[K, V]) -> Iter[(K, V)] {
 
 ///|
 pub fn[K, V] iter2(self : T[K, V]) -> Iter2[K, V] {
-  Iter2::new(fn(yield_) {
+  Iter2::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
         None => IterContinue
@@ -207,7 +207,7 @@ pub fn[K, V] iter2(self : T[K, V]) -> Iter2[K, V] {
 ///|
 pub fn[K : Compare, V] from_iter(iter : Iter[(K, V)]) -> T[K, V] {
   let m = new()
-  iter.each(fn(e) { m[e.0] = e.1 })
+  iter.each(e => m[e.0] = e.1)
   m
 }
 
@@ -221,7 +221,7 @@ pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickc
 
 ///|Returns a new array of key-value pairs that are within the specified range [low, high].
 pub fn[K : Compare, V] range(self : T[K, V], low : K, high : K) -> Iter2[K, V] {
-  Iter2::new(fn(yield_) {
+  Iter2::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
         None => IterContinue

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -684,9 +684,9 @@ test "rev" {
 pub fn View::split(self : View, sep : View) -> Iter[View] {
   let sep_len = sep.length()
   if sep_len == 0 {
-    return self.iter().map(fn(c) { c.to_string().view() })
+    return self.iter().map(c => c.to_string().view())
   }
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     let mut view = self
     while view.find(sep) is Some(end) {
       guard yield_(view.view(end_offset=end)) is IterContinue else {

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -120,7 +120,7 @@ pub fn to_array(self : String) -> Array[Char] {
 ///   assert_eq(s.length(), 15); // Utf16 code units
 /// ```
 pub fn iter(self : String) -> Iter[Char] {
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     let len = self.length()
     for index in 0..<len {
       let c1 = self.unsafe_charcode_at(index)
@@ -191,7 +191,7 @@ pub fn iter2(self : String) -> Iter2[Int, Char] {
 ///   assert_eq(reversed, ['!', 'd', 'l', 'r', 'o', 'W', ' ', ',', 'o', 'l', 'l', 'e', 'H'])
 /// ```
 pub fn rev_iter(self : String) -> Iter[Char] {
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     let len = self.length()
     for index = len - 1; index >= 0; index = index - 1 {
       let c1 = self.unsafe_charcode_at(index)

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -249,7 +249,7 @@ pub impl Show for StringView with to_string(self) {
 ///|
 /// Returns an iterator over the Unicode characters in the string view.
 pub fn View::iter(self : View) -> Iter[Char] {
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     for index in self.start..<self.end {
       let c1 = self.str.unsafe_charcode_at(index)
       if is_leading_surrogate(c1) && index + 1 < self.end {
@@ -269,7 +269,7 @@ pub fn View::iter(self : View) -> Iter[Char] {
 
 ///|
 pub fn View::iter2(self : View) -> Iter2[Int, Char] {
-  Iter2::new(fn(yield_) {
+  Iter2::new(yield_ => {
     let len = self.length()
     for index = 0, n = 0; index < len; index = index + 1, n = n + 1 {
       let c1 = self.str.unsafe_charcode_at(self.start + index)
@@ -293,7 +293,7 @@ pub fn View::iter2(self : View) -> Iter2[Int, Char] {
 ///|
 /// Returns an iterator over the Unicode characters in the string view in reverse order.
 pub fn View::rev_iter(self : View) -> Iter[Char] {
-  Iter::new(fn(yield_) {
+  Iter::new(yield_ => {
     for index = self.end - 1; index >= self.start; index = index - 1 {
       let c1 = self.str.unsafe_charcode_at(index)
       if is_trailing_surrogate(c1) && index - 1 >= 0 {

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -249,21 +249,19 @@ pub impl Show for StringView with to_string(self) {
 ///|
 /// Returns an iterator over the Unicode characters in the string view.
 pub fn View::iter(self : View) -> Iter[Char] {
-  Iter::new(yield_ => {
-    for index in self.start..<self.end {
-      let c1 = self.str.unsafe_charcode_at(index)
-      if is_leading_surrogate(c1) && index + 1 < self.end {
-        let c2 = self.str.unsafe_charcode_at(index + 1)
-        if is_trailing_surrogate(c2) {
-          let c = code_point_of_surrogate_pair(c1, c2)
-          guard yield_(c) is IterContinue else { break IterEnd }
-          continue index + 2
-        }
+  Iter::new(yield_ => for index in self.start..<self.end {
+    let c1 = self.str.unsafe_charcode_at(index)
+    if is_leading_surrogate(c1) && index + 1 < self.end {
+      let c2 = self.str.unsafe_charcode_at(index + 1)
+      if is_trailing_surrogate(c2) {
+        let c = code_point_of_surrogate_pair(c1, c2)
+        guard yield_(c) is IterContinue else { break IterEnd }
+        continue index + 2
       }
-      guard yield_(c1.unsafe_to_char()) is IterContinue else { break IterEnd }
-    } else {
-      IterContinue
     }
+    guard yield_(c1.unsafe_to_char()) is IterContinue else { break IterEnd }
+  } else {
+    IterContinue
   })
 }
 
@@ -293,21 +291,21 @@ pub fn View::iter2(self : View) -> Iter2[Int, Char] {
 ///|
 /// Returns an iterator over the Unicode characters in the string view in reverse order.
 pub fn View::rev_iter(self : View) -> Iter[Char] {
-  Iter::new(yield_ => {
-    for index = self.end - 1; index >= self.start; index = index - 1 {
-      let c1 = self.str.unsafe_charcode_at(index)
-      if is_trailing_surrogate(c1) && index - 1 >= 0 {
-        let c2 = self.str.unsafe_charcode_at(index - 1)
-        if is_leading_surrogate(c2) {
-          let c = code_point_of_surrogate_pair(c2, c1)
-          guard yield_(c) is IterContinue else { break IterEnd }
-          continue index - 2
-        }
+  Iter::new(yield_ => for index = self.end - 1
+                          index >= self.start
+                          index = index - 1 {
+    let c1 = self.str.unsafe_charcode_at(index)
+    if is_trailing_surrogate(c1) && index - 1 >= 0 {
+      let c2 = self.str.unsafe_charcode_at(index - 1)
+      if is_leading_surrogate(c2) {
+        let c = code_point_of_surrogate_pair(c2, c1)
+        guard yield_(c) is IterContinue else { break IterEnd }
+        continue index - 2
       }
-      guard yield_(c1.unsafe_to_char()) is IterContinue else { break IterEnd }
-    } else {
-      IterContinue
     }
+    guard yield_(c1.unsafe_to_char()) is IterContinue else { break IterEnd }
+  } else {
+    IterContinue
   })
 }
 


### PR DESCRIPTION
## Summary
- use arrow functions in several iterator helpers across core
- update string split to use arrow syntax

## Testing
- `moon info`
- `moon test`
- `moon check`


------
https://chatgpt.com/codex/tasks/task_e_685ab299a6dc8320b0bc97b76683fcfc