### PR TITLE
docs(tuple): recommend message is wrong

### DIFF
--- a/tuple/deprecated.mbt
+++ b/tuple/deprecated.mbt
@@ -20,35 +20,35 @@ pub fn[T, U] pair(x : T, y : U) -> (T, U) {
 }
 
 ///|
-#deprecated("use `tuple.0` instead")
+#deprecated("use `tuple => tuple.0` instead")
 #coverage.skip
 pub fn[T, U] fst(tuple : (T, U)) -> T {
   tuple.0
 }
 
 ///|
-#deprecated("use `tuple.1` instead")
+#deprecated("use `tuple => tuple.1` instead")
 #coverage.skip
 pub fn[T, U] snd(tuple : (T, U)) -> U {
   tuple.1
 }
 
 ///|
-#deprecated("use `tuple |> then(fn { (a, b) => (f(a), b) })` instead")
+#deprecated("use `tuple => (f(tuple.0), tuple.1)` instead")
 #coverage.skip
 pub fn[T, U, V] map_fst(f : (T) -> U, tuple : (T, V)) -> (U, V) {
   (f(tuple.0), tuple.1)
 }
 
 ///|
-#deprecated("use `tuple |> then(fn { (a, b) => (a, f(b)) })` instead")
+#deprecated("use `tuple => (tuple.0, f(tuple.1))` instead")
 #coverage.skip
 pub fn[T, U, V] map_snd(f : (T) -> U, tuple : (V, T)) -> (V, U) {
   (tuple.0, f(tuple.1))
 }
 
 ///|
-#deprecated("use `tuple |> then(fn { (a, b) => (f(a), g(b)) })` instead")
+#deprecated("use `tuple => (f(tuple.0), g(tuple.1))` instead")
 #coverage.skip
 pub fn[T, U, V, W] map_both(
   f : (T) -> U,


### PR DESCRIPTION
here we need `closure` rather `Fully Applied Term`

e.g. `xs.map(tuple => tuple.0)`