### PR TITLE
chore(random_source)

### DIFF
--- a/random/internal/random_source/moon.pkg.json
+++ b/random/internal/random_source/moon.pkg.json
@@ -1,3 +1,7 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/array"]
+  "import": [
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/array",
+    "moonbitlang/core/bytes"
+  ]
 }

--- a/random/internal/random_source/random_source.mbti
+++ b/random/internal/random_source/random_source.mbti
@@ -11,7 +11,7 @@ pub(all) struct ChaCha8 {
   mut c : UInt
 }
 fn ChaCha8::new(Bytes) -> Self
-fn ChaCha8::next(Self) -> (UInt64, Bool)
+fn ChaCha8::next(Self) -> UInt64?
 fn ChaCha8::refill(Self) -> Unit
 
 // Type aliases

--- a/random/internal/random_source/random_source.mbti
+++ b/random/internal/random_source/random_source.mbti
@@ -4,19 +4,15 @@ package "moonbitlang/core/random/internal/random_source"
 
 // Types and methods
 pub(all) struct ChaCha8 {
-  state : State
-}
-fn ChaCha8::new(Bytes) -> Self
-
-pub(all) struct State {
   mut buffer : FixedArray[UInt64]
   mut seed : FixedArray[UInt64]
   mut i : UInt
   mut n : UInt
   mut c : UInt
 }
-fn State::next(Self) -> (UInt64, Bool)
-fn State::refill(Self) -> Unit
+fn ChaCha8::new(Bytes) -> Self
+fn ChaCha8::next(Self) -> (UInt64, Bool)
+fn ChaCha8::refill(Self) -> Unit
 
 // Type aliases
 

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -14,18 +14,6 @@
 
 ///|
 pub(all) struct ChaCha8 {
-  state : State
-}
-
-///|
-pub fn ChaCha8::new(seed : Bytes) -> ChaCha8 {
-  let c = { state: State::new() }
-  c.state.init(seed)
-  c
-}
-
-///|
-pub(all) struct State {
   /// length = 32
   mut buffer : FixedArray[UInt64]
   /// length = 4
@@ -36,14 +24,16 @@ pub(all) struct State {
 }
 
 ///|
-fn State::new() -> State {
-  {
+pub fn ChaCha8::new(seed : Bytes) -> ChaCha8 {
+  let c = {
     buffer: FixedArray::make(32, 0UL),
     seed: FixedArray::make(4, 0UL),
     i: 0U,
     n: 0U,
     c: 0U,
   }
+  c.init(seed)
+  c
 }
 
 ///|
@@ -59,7 +49,7 @@ let chunk = 32U
 let chacha_reseed = 4
 
 ///|
-pub fn State::next(self : State) -> (UInt64, Bool) {
+pub fn ChaCha8::next(self : ChaCha8) -> (UInt64, Bool) {
   let i = self.i
   if i >= self.n {
     return (0, false)
@@ -88,7 +78,7 @@ test "bytes_to_uint64" {
 
 ///|
 /// [seed] must be 32 bytes long.
-fn State::init(self : State, seed : Bytes) -> Unit {
+fn ChaCha8::init(self : ChaCha8, seed : Bytes) -> Unit {
   let seed0 = FixedArray::make(8, Byte::default())
   let seed1 = FixedArray::make(8, Byte::default())
   let seed2 = FixedArray::make(8, Byte::default())
@@ -108,7 +98,7 @@ fn State::init(self : State, seed : Bytes) -> Unit {
 }
 
 ///|
-fn State::init64(self : State, seed : FixedArray[UInt64]) -> Unit {
+fn ChaCha8::init64(self : ChaCha8, seed : FixedArray[UInt64]) -> Unit {
   self.seed = seed
   // convert FixedArray[UInt64] size=[32] to FixedArray[FixedArray[UInt]] size=[16][4]
   let buffer = FixedArray::makei(16, fn(_i) { FixedArray::make(4, 0U) })
@@ -138,7 +128,7 @@ fn State::init64(self : State, seed : FixedArray[UInt64]) -> Unit {
 }
 
 ///|
-pub fn State::refill(self : State) -> Unit {
+pub fn ChaCha8::refill(self : ChaCha8) -> Unit {
   self.c = self.c + ctr_inc
   if self.c == ctr_max {
     // reseed
@@ -356,11 +346,9 @@ fn setup(
 
 ///|
 test "output" {
-  let s = State::new()
-  let seed = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"
+  let s = ChaCha8::new(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
   let res = Array::new(capacity=372)
-  s.init(seed)
-  fn uint64(s : State) -> UInt64 {
+  fn uint64(s : ChaCha8) -> UInt64 {
     for {
       let x = s.next()
       if x.1 {

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -59,41 +59,9 @@ pub fn ChaCha8::next(self : ChaCha8) -> UInt64? {
 }
 
 ///|
-fn bytes_to_uint64(b : FixedArray[Byte]) -> UInt64 {
-  let mut result = 0UL
-  for i in 0..<8 {
-    result = result | (b[i].to_int64().reinterpret_as_uint64() << (i * 8))
-  }
-  result
-}
-
-///|
-test "bytes_to_uint64" {
-  let bytes = FixedArray::make(8, Byte::default())
-  for i in 0..<2 {
-    bytes[i] = i.to_byte()
-  }
-  inspect(bytes_to_uint64(bytes), content="256")
-}
-
-///|
 /// [seed] must be 32 bytes long.
 fn ChaCha8::init(self : ChaCha8, seed : Bytes) -> Unit {
-  let seed0 = FixedArray::make(8, Byte::default())
-  let seed1 = FixedArray::make(8, Byte::default())
-  let seed2 = FixedArray::make(8, Byte::default())
-  let seed3 = FixedArray::make(8, Byte::default())
-  for i in 0..<8 {
-    seed0[i] = seed[i]
-    seed1[i] = seed[8 + i]
-    seed2[i] = seed[16 + i]
-    seed3[i] = seed[24 + i]
-  }
-  let arr = FixedArray::make(4, 0UL)
-  arr[0] = bytes_to_uint64(seed0)
-  arr[1] = bytes_to_uint64(seed1)
-  arr[2] = bytes_to_uint64(seed2)
-  arr[3] = bytes_to_uint64(seed3)
+  let arr = FixedArray::makei(4, i => seed[i * 8:i * 8 + 8].to_uint64_le())
   self.init64(arr)
 }
 

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -49,13 +49,13 @@ let chunk = 32U
 let chacha_reseed = 4
 
 ///|
-pub fn ChaCha8::next(self : ChaCha8) -> (UInt64, Bool) {
+pub fn ChaCha8::next(self : ChaCha8) -> UInt64? {
   let i = self.i
   if i >= self.n {
-    return (0, false)
+    return None
   }
   self.i = i + 1
-  (self.buffer[i.reinterpret_as_int() & 31], true)
+  Some(self.buffer[i.reinterpret_as_int() & 31])
 }
 
 ///|
@@ -350,9 +350,8 @@ test "output" {
   let res = Array::new(capacity=372)
   fn uint64(s : ChaCha8) -> UInt64 {
     for {
-      let x = s.next()
-      if x.1 {
-        return x.0
+      if s.next() is Some(x) {
+        return x
       }
       s.refill()
     }

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -26,8 +26,10 @@ pub fn ChaCha8::new(seed : Bytes) -> ChaCha8 {
 
 ///|
 pub(all) struct State {
-  mut buffer : FixedArray[UInt64] // size=[32]
-  mut seed : FixedArray[UInt64] // size=[4]
+  /// length = 32
+  mut buffer : FixedArray[UInt64]
+  /// length = 4
+  mut seed : FixedArray[UInt64]
   mut i : UInt
   mut n : UInt
   mut c : UInt
@@ -45,16 +47,16 @@ fn State::new() -> State {
 }
 
 ///|
-let ctrInc = 4U
+let ctr_inc = 4U
 
 ///|
-let ctrMax = 16U
+let ctr_max = 16U
 
 ///|
 let chunk = 32U
 
 ///|
-let chachaReseed = 4
+let chacha_reseed = 4
 
 ///|
 pub fn State::next(self : State) -> (UInt64, Bool) {
@@ -67,7 +69,7 @@ pub fn State::next(self : State) -> (UInt64, Bool) {
 }
 
 ///|
-fn bytesToUInt64(b : FixedArray[Byte]) -> UInt64 {
+fn bytes_to_uint64(b : FixedArray[Byte]) -> UInt64 {
   let mut result = 0UL
   for i in 0..<8 {
     result = result | (b[i].to_int64().reinterpret_as_uint64() << (i * 8))
@@ -76,12 +78,12 @@ fn bytesToUInt64(b : FixedArray[Byte]) -> UInt64 {
 }
 
 ///|
-test "bytesToUInt64" {
+test "bytes_to_uint64" {
   let bytes = FixedArray::make(8, Byte::default())
   for i in 0..<2 {
     bytes[i] = i.to_byte()
   }
-  inspect(bytesToUInt64(bytes), content="256")
+  inspect(bytes_to_uint64(bytes), content="256")
 }
 
 ///|
@@ -98,10 +100,10 @@ fn State::init(self : State, seed : Bytes) -> Unit {
     seed3[i] = seed[24 + i]
   }
   let arr = FixedArray::make(4, 0UL)
-  arr[0] = bytesToUInt64(seed0)
-  arr[1] = bytesToUInt64(seed1)
-  arr[2] = bytesToUInt64(seed2)
-  arr[3] = bytesToUInt64(seed3)
+  arr[0] = bytes_to_uint64(seed0)
+  arr[1] = bytes_to_uint64(seed1)
+  arr[2] = bytes_to_uint64(seed2)
+  arr[3] = bytes_to_uint64(seed3)
   self.init64(arr)
 }
 
@@ -137,14 +139,13 @@ fn State::init64(self : State, seed : FixedArray[UInt64]) -> Unit {
 
 ///|
 pub fn State::refill(self : State) -> Unit {
-  self.c = self.c + ctrInc
-  if self.c == ctrMax {
+  self.c = self.c + ctr_inc
+  if self.c == ctr_max {
     // reseed
     let len = self.buffer.length()
-    self.seed[0] = self.buffer[len - chachaReseed + 0]
-    self.seed[1] = self.buffer[len - chachaReseed + 1]
-    self.seed[2] = self.buffer[len - chachaReseed + 2]
-    self.seed[3] = self.buffer[len - chachaReseed + 3]
+    for i in 0..<chacha_reseed {
+      self.seed[i] = self.buffer[len - chacha_reseed + i]
+    }
     self.c = 0
   }
   // convert FixedArray[UInt64] size=[32] to FixedArray[FixedArray[UInt]] size=[16][4]
@@ -169,9 +170,10 @@ pub fn State::refill(self : State) -> Unit {
     }
   }
   self.i = 0
-  self.n = self.buffer.length().reinterpret_as_uint()
-  if self.c == ctrMax - ctrInc {
-    self.n = (self.buffer.length() - chachaReseed).reinterpret_as_uint()
+  self.n = if self.c == ctr_max - ctr_inc {
+    (self.buffer.length() - chacha_reseed).reinterpret_as_uint()
+  } else {
+    self.buffer.length().reinterpret_as_uint()
   }
 }
 
@@ -265,14 +267,14 @@ fn chacha_block(
     buf[1][i] = b1
     buf[2][i] = b2
     buf[3][i] = b3
-    buf[4][i] = buf[4][i] + b4
-    buf[5][i] = buf[5][i] + b5
-    buf[6][i] = buf[6][i] + b6
-    buf[7][i] = buf[7][i] + b7
-    buf[8][i] = buf[8][i] + b8
-    buf[9][i] = buf[9][i] + b9
-    buf[10][i] = buf[10][i] + b10
-    buf[11][i] = buf[11][i] + b11
+    buf[4][i] += b4
+    buf[5][i] += b5
+    buf[6][i] += b6
+    buf[7][i] += b7
+    buf[8][i] += b8
+    buf[9][i] += b9
+    buf[10][i] += b10
+    buf[11][i] += b11
     buf[12][i] = b12
     buf[13][i] = b13
     buf[14][i] = b14

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -26,9 +26,8 @@ pub(open) trait Source {
 ///|
 impl Source for @random_source.ChaCha8 with next(self : @random_source.ChaCha8) -> UInt64 {
   for {
-    let x = self.next()
-    if x.1 {
-      return x.0
+    if self.next() is Some(x) {
+      return x
     }
     self.refill()
   }

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -26,11 +26,11 @@ pub(open) trait Source {
 ///|
 impl Source for @random_source.ChaCha8 with next(self : @random_source.ChaCha8) -> UInt64 {
   for {
-    let x = self.state.next()
+    let x = self.next()
     if x.1 {
       return x.0
     }
-    self.state.refill()
+    self.refill()
   }
 }
 


### PR DESCRIPTION
This PR is part of #2333

1. Flatten the structural. Remove `struct ChaCha8 { state : State }` and rename `State` to `ChaCha8`.
2. Improve api in ChaCha8::next. Return an `UInt64?` instead of `(UInt64, Bool)`.
3. Simplify.