### PR TITLE
fix unused `derive`

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -40,7 +40,7 @@ struct BigInt {
 priv enum Sign {
   Positive
   Negative
-} derive(Show, Eq)
+} derive(Eq)
 
 // Hyper Params
 

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -23,6 +23,14 @@ impl Show for MyBigInt with output(self, logger) {
 }
 
 ///|
+impl Show for Sign with output(self, logger) {
+  match self {
+    Positive => logger.write_string("Positive")
+    Negative => logger.write_string("Negative")
+  }
+}
+
+///|
 test "debug_string" {
   let buf = StringBuilder::new()
   let v : Array[MyBigInt] = [0, 1, 2, 3, 4, -0, -1, -2, -3]

--- a/json/internal_types.mbt
+++ b/json/internal_types.mbt
@@ -63,4 +63,4 @@ priv enum Token {
   RBracket
   Comma
   // Colon
-} derive(Eq, Show)
+}

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -236,7 +236,7 @@ test "bigint" {
 priv struct UInt128 {
   mut hi : UInt64
   mut lo : UInt64
-} derive(Eq)
+}
 
 ///|
 let gUInt128 : UInt128 = { hi: 0UL, lo: 0UL }

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -20,7 +20,7 @@ priv struct SEntry[K] {
   mut psl : Int
   hash : Int
   key : K
-} derive(Show)
+}
 
 ///|
 impl[K : Eq] Eq for SEntry[K] with op_equal(self, other) {


### PR DESCRIPTION
This PR removes some unused `derive`, using the to-be-released unused warning support for trait implementations. One problematic case is `derive` implementations that are only used in whitebox tests, they will be reported as unused. There are two workaround to this:

- turn the `derive` into a manual implementation in `_wbtest.mbt`
- add a inline test for the `derive`