### PR TITLE
Modernize for loops

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -214,7 +214,7 @@ pub fn[A, B] zip(self : Array[A], other : Array[B]) -> Array[(A, B)] {
     other.length()
   }
   let arr = Array::new(capacity=length)
-  for i = 0; i < length; i = i + 1 {
+  for i in 0..<length {
     arr.push((self[i], other[i]))
   } else {
     return arr
@@ -268,7 +268,7 @@ pub fn[A, B, C] zip_with(
 ) -> Array[C] raise? {
   let length = if l.length() < r.length() { l.length() } else { r.length() }
   let arr = Array::new(capacity=length)
-  for i = 0; i < length; i = i + 1 {
+  for i in 0..<length {
     arr.push(merge(l[i], r[i]))
   } else {
     return arr
@@ -300,7 +300,7 @@ pub fn[A, B] zip_to_iter2(self : Array[A], other : Array[B]) -> Iter2[A, B] {
     } else {
       other.length()
     }
-    for i = 0; i < length; i = i + 1 {
+    for i in 0..<length {
       if yield_(self[i], other[i]) == IterEnd {
         break IterEnd
       }

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -1173,17 +1173,17 @@ pub fn FixedArray::join(
   }
   let first = self[0]
   let mut size_hint = first.length()
-  for i = 1; i < len; i = i + 1 {
+  for i in 1..<len {
     size_hint += separator.length() + self[i].length()
   }
   let string = StringBuilder::new(size_hint~)
   if separator.is_empty() {
-    for i = 0; i < len; i = i + 1 {
+    for i in 0..<len {
       string.write_string(self[i])
     }
   } else {
     string.write_string(self[0])
-    for i = 1; i < len; i = i + 1 {
+    for i in 1..<len {
       string.write_substring(
         separator.data(),
         separator.start_offset(),

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1196,7 +1196,8 @@ pub fn[T] Array::resize(self : Array[T], new_len : Int, f : T) -> Unit {
   if new_len < self.length() {
     self.unsafe_truncate_to_length(new_len)
   } else {
-    for i = self.length(); i < new_len; i = i + 1 {
+    let len = self.length()
+    for _ in len..<new_len {
       self.push(f)
     }
   }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -209,11 +209,11 @@ fn[A] realloc(self : T[A]) -> Unit {
       }
     } else {
       let mut j = 0
-      for i = self.head; i < self.buf.length(); i = i + 1 {
+      for i in self.head..<self.buf.length() {
         new_buf[j] = self.buf[i]
         j += 1
       }
-      for i = 0; i <= self.tail; i = i + 1 {
+      for i in 0..=self.tail {
         new_buf[j] = self.buf[i]
         j += 1
       }

--- a/math/prime.mbt
+++ b/math/prime.mbt
@@ -264,7 +264,7 @@ fn trial_divisions(n : @bigint.BigInt) -> Bool {
     2048..=4096 => 1024
     _ => 2048
   }
-  for i = 1; i < td; i = i + 1 {
+  for i in 1..<td {
     if n % small_primes[i] == 0 {
       return n == small_primes[i]
     }
@@ -291,7 +291,7 @@ fn miller_rabin_test(
   // (step 3) 
   let w3_len = w3.bit_length()
   // (step 4)
-  next~: for i = 0; i < iters; i = i + 1 {
+  next~: for i in 0..<iters {
     // (step 4.1) obtain a random BigInt b where 1 < b < w-1
     let rand_b = for {
       let x = rand.bigint(w3_len)
@@ -307,7 +307,7 @@ fn miller_rabin_test(
       continue next~
     }
     // (step 4.5)
-    for j = 1; j < a; j = j + 1 {
+    for j in 1..<a {
       // (step 4.5.1) z = z^2 mod w
       z = z.pow(2, modulus=w)
       // (step 4.5.2)

--- a/strconv/string_slice.mbt
+++ b/strconv/string_slice.mbt
@@ -95,7 +95,12 @@ fn is_empty(self : StringSlice) -> Bool {
 
 ///|
 fn prefix_eq_ignore_case(self : StringSlice, s2 : String) -> Bool {
-  for i = 0; i < s2.length() && i < self.length(); i = i + 1 {
+  let end = if s2.length() < self.length() {
+    s2.length()
+  } else {
+    self.length()
+  }
+  for i in 0..<end {
     let c1 = self[i]
     let c2 = s2.unsafe_charcode_at(i).unsafe_to_char()
     if lower(c1) != lower(c2) {


### PR DESCRIPTION
## Summary
- modernize traditional for loops to range-based loops
- update bytes prefix equality check
- resize uses range loop for push

## Testing
- `moon fmt`
- `moon info`
- `moon check`
- `moon test`

------
https://chatgpt.com/codex/tasks/task_e_685dd97e00a083208e751d2f19e4ba7a