### PR TITLE
remove unused trait bound

### DIFF
--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -209,7 +209,7 @@ pub fn[K : Hash + Eq, V] get(self : T[K, V], key : K) -> V? {
 }
 
 ///|
-fn[K : Hash + Eq, V] get_with_hash(self : T[K, V], key : K, hash : Int) -> V? {
+fn[K : Eq, V] get_with_hash(self : T[K, V], key : K, hash : Int) -> V? {
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && entry.key == key {
@@ -411,7 +411,7 @@ pub fn[K : Hash + Eq, V] remove(self : T[K, V], key : K) -> Unit {
 }
 
 ///|
-fn[K : Hash, V] shift_back(self : T[K, V], start_index : Int) -> Unit {
+fn[K, V] shift_back(self : T[K, V], start_index : Int) -> Unit {
   for prev = start_index, curr = (start_index + 1) & self.capacity_mask {
     match self.entries[curr] {
       Some({ psl, hash, key, value }) => {

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -278,7 +278,7 @@ pub impl[X : @quickcheck.Arbitrary + Eq + Hash] @quickcheck.Arbitrary for T[X] w
 }
 
 ///|
-fn[K : Hash] shift_back(self : T[K], start_index : Int) -> Unit {
+fn[K] shift_back(self : T[K], start_index : Int) -> Unit {
   for i = 0, prev = start_index, curr = self.next_index(start_index)
       i < self.entries.length()
       i = i + 1, prev = curr, curr = self.next_index(curr) {
@@ -319,7 +319,7 @@ fn[K : Hash + Eq] grow(self : T[K]) -> Unit {
 }
 
 ///|
-fn[K : Hash] index(self : T[K], hash : Int) -> Int {
+fn[K] index(self : T[K], hash : Int) -> Int {
   abs(hash) & (self.capacity - 1)
 }
 
@@ -333,7 +333,7 @@ fn abs(n : Int) -> Int {
 }
 
 ///|
-fn[K : Hash] next_index(self : T[K], index : Int) -> Int {
+fn[K] next_index(self : T[K], index : Int) -> Int {
   (index + 1) & (self.capacity - 1)
 }
 

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -20,7 +20,7 @@
 ///   let queue = @priority_queue.new()
 ///   assert_eq(queue.push(1).length(), 1)
 /// ```
-pub fn[A : Compare] new() -> T[A] {
+pub fn[A] new() -> T[A] {
   { node: Empty, size: 0 }
 }
 

--- a/immut/priority_queue/priority_queue.mbti
+++ b/immut/priority_queue/priority_queue.mbti
@@ -7,7 +7,7 @@ import(
 // Values
 fn[A : Compare] from_array(Array[A]) -> T[A]
 
-fn[A : Compare] new() -> T[A]
+fn[A] new() -> T[A]
 
 fn[A : Compare] of(FixedArray[A]) -> T[A]
 

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -130,12 +130,7 @@ pub fn[K, V] to_array(self : T[K, V]) -> Array[(K, V)] {
 let ratio = 5
 
 ///|
-fn[K : Compare, V] balance(
-  key : K,
-  value : V,
-  l : T[K, V],
-  r : T[K, V]
-) -> T[K, V] {
+fn[K, V] balance(key : K, value : V, l : T[K, V], r : T[K, V]) -> T[K, V] {
   //       1                   2
   //      / \                 / \
   //     x   2       --->    1   z

--- a/immut/sorted_set/deprecated.mbt
+++ b/immut/sorted_set/deprecated.mbt
@@ -22,7 +22,7 @@ pub fn[A] T::new() -> T[A] {
 ///|
 #deprecated("use `immut/sorted_set.singleton` instead")
 #coverage.skip
-pub fn[A : Compare] T::singleton(value : A) -> T[A] {
+pub fn[A] T::singleton(value : A) -> T[A] {
   singleton(value)
 }
 

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -29,7 +29,7 @@ pub impl[A] Default for T[A] with default() {
 
 ///|
 /// Returns the one-value ImmutableSet containing only `value`.
-pub fn[A : Compare] singleton(value : A) -> T[A] {
+pub fn[A] singleton(value : A) -> T[A] {
   Node(left=Empty, value~, right=Empty, size=1)
 }
 
@@ -45,7 +45,7 @@ pub fn[A : Compare] from_array(array : Array[A]) -> T[A] {
 
 ///|
 /// Convert ImmutableSet[T] to Array[T], the result must be ordered.
-pub fn[A : Compare] to_array(self : T[A]) -> Array[A] {
+pub fn[A] to_array(self : T[A]) -> Array[A] {
   let arr = []
   fn aux(set : T[A]) {
     match set {
@@ -247,7 +247,7 @@ pub fn[A : Compare] split(self : T[A], divide : A) -> (T[A], Bool, T[A]) {
 
 ///|
 /// Returns true if sorted_set is empty
-pub fn[A : Compare] is_empty(self : T[A]) -> Bool {
+pub fn[A] is_empty(self : T[A]) -> Bool {
   self is Empty
 }
 
@@ -638,7 +638,7 @@ priv enum SplitBis[A] {
 }
 
 ///|
-impl[T : Show] Show for SplitBis[T] with output(self, logger) {
+impl[T] Show for SplitBis[T] with output(self, logger) {
   match self {
     Found => logger.write_string("Found")
     NotFound(_) => logger.write_string("NotFound")
@@ -672,7 +672,7 @@ fn[A : Compare] split_bis(self : T[A], value : A) -> SplitBis[A] {
 
 ///|
 /// Get the height of set.
-pub fn[A : Compare] size(self : T[A]) -> Int {
+pub fn[A] size(self : T[A]) -> Int {
   match self {
     Empty => 0
     Node(size~, ..) => size
@@ -681,13 +681,13 @@ pub fn[A : Compare] size(self : T[A]) -> Int {
 
 ///|
 /// Creates a new node.
-fn[A : Compare] create(left : T[A], value : A, right : T[A]) -> T[A] {
+fn[A] create(left : T[A], value : A, right : T[A]) -> T[A] {
   Node(left~, right~, value~, size=left.size() + right.size() + 1)
 }
 
 ///|
 /// Same as create, but performs one step of rebalancing if necessary.
-fn[A : Compare] balance(left : T[A], value : A, right : T[A]) -> T[A] {
+fn[A] balance(left : T[A], value : A, right : T[A]) -> T[A] {
   let left_size = left.size()
   let right_size = right.size()
   if left_size + right_size < 2 {

--- a/immut/sorted_set/sorted_set.mbti
+++ b/immut/sorted_set/sorted_set.mbti
@@ -16,7 +16,7 @@ fn[A] new() -> T[A]
 
 fn[A : Compare] of(FixedArray[A]) -> T[A]
 
-fn[A : Compare] singleton(A) -> T[A]
+fn[A] singleton(A) -> T[A]
 
 // Types and methods
 type T[A]
@@ -40,7 +40,7 @@ fn[A : @json.FromJson + Compare] T::from_json(Json) -> Self[A] raise @json.JsonD
 #deprecated
 fn[A : Compare] T::inter(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] T::intersection(Self[A], Self[A]) -> Self[A]
-fn[A : Compare] T::is_empty(Self[A]) -> Bool
+fn[A] T::is_empty(Self[A]) -> Bool
 fn[A] T::iter(Self[A]) -> Iter[A]
 fn[A : Compare, B : Compare] T::map(Self[A], (A) -> B raise?) -> Self[B] raise?
 fn[A : Compare] T::max(Self[A]) -> A
@@ -54,12 +54,12 @@ fn[A : Compare] T::of(FixedArray[A]) -> Self[A]
 fn[A : Compare] T::remove(Self[A], A) -> Self[A]
 fn[A : Compare] T::remove_min(Self[A]) -> Self[A]
 #deprecated
-fn[A : Compare] T::singleton(A) -> Self[A]
-fn[A : Compare] T::size(Self[A]) -> Int
+fn[A] T::singleton(A) -> Self[A]
+fn[A] T::size(Self[A]) -> Int
 fn[A : Compare] T::split(Self[A], A) -> (Self[A], Bool, Self[A])
 fn[A : Compare] T::subset(Self[A], Self[A]) -> Bool
 fn[A : Compare] T::symmetric_difference(Self[A], Self[A]) -> Self[A]
-fn[A : Compare] T::to_array(Self[A]) -> Array[A]
+fn[A] T::to_array(Self[A]) -> Array[A]
 fn[A : ToJson] T::to_json(Self[A]) -> Json
 fn[A : Compare] T::union(Self[A], Self[A]) -> Self[A]
 impl[A : Compare] Add for T[A]

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -225,7 +225,7 @@ pub fn[K : Hash + Eq] remove_and_check(self : Set[K], key : K) -> Bool {
 }
 
 ///|
-fn[K : Eq] add_entry_to_tail(self : Set[K], entry : SEntry[K]) -> Unit {
+fn[K] add_entry_to_tail(self : Set[K], entry : SEntry[K]) -> Unit {
   match self.tail {
     None => {
       self.head = Some(entry)
@@ -264,7 +264,7 @@ fn[K : Eq] remove_entry(self : Set[K], entry : SEntry[K]) -> Unit {
 }
 
 ///|
-fn[K : Hash] shift_back(self : Set[K], start_index : Int) -> Unit {
+fn[K] shift_back(self : Set[K], start_index : Int) -> Unit {
   for prev = start_index, curr = (start_index + 1) & self.capacity_mask {
     match (self.entries[curr], self.list[curr]) {
       (Some(entry), currNode) => {

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -286,7 +286,7 @@ fn[K, V] height_ge(x1 : Node[K, V]?, x2 : Node[K, V]?) -> Bool {
 }
 
 ///|
-fn[K : Compare, V] balance(root : Node[K, V]) -> Node[K, V] {
+fn[K, V] balance(root : Node[K, V]) -> Node[K, V] {
   let (l, r) = (root.left, root.right)
   let (hl, hr) = (height(l), height(r))
   let new_root = if hl > hr + 1 {
@@ -311,7 +311,7 @@ fn[K : Compare, V] balance(root : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
-fn[K : Compare, V] rotate_l(n : Node[K, V]) -> Node[K, V] {
+fn[K, V] rotate_l(n : Node[K, V]) -> Node[K, V] {
   let r = n.right.unwrap()
   n.right = r.left
   r.left = Some(n)
@@ -321,7 +321,7 @@ fn[K : Compare, V] rotate_l(n : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
-fn[K : Compare, V] rotate_r(n : Node[K, V]) -> Node[K, V] {
+fn[K, V] rotate_r(n : Node[K, V]) -> Node[K, V] {
   let l = n.left.unwrap()
   n.left = l.right
   l.right = Some(n)
@@ -331,7 +331,7 @@ fn[K : Compare, V] rotate_r(n : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
-fn[K : Compare, V] rotate_lr(n : Node[K, V]) -> Node[K, V] {
+fn[K, V] rotate_lr(n : Node[K, V]) -> Node[K, V] {
   let l = n.left.unwrap()
   let v = rotate_l(l)
   n.left = Some(v)
@@ -339,7 +339,7 @@ fn[K : Compare, V] rotate_lr(n : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
-fn[K : Compare, V] rotate_rl(n : Node[K, V]) -> Node[K, V] {
+fn[K, V] rotate_rl(n : Node[K, V]) -> Node[K, V] {
   let r = n.right.unwrap()
   let v = rotate_r(r)
   n.right = Some(v)

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -22,7 +22,7 @@ pub fn[V] new() -> T[V] {
 
 ///|
 /// Returns the one-value set containing only `value`.
-pub fn[V : Compare] singleton(value : V) -> T[V] {
+pub fn[V] singleton(value : V) -> T[V] {
   { root: Some({ value, left: None, right: None, height: 1 }), size: 1 }
 }
 
@@ -306,19 +306,19 @@ pub fn[V : Compare] disjoint(self : T[V], src : T[V]) -> Bool {
 // General collection operations
 
 ///|
-pub impl[V : Compare] Eq for T[V] with op_equal(self, other) {
+pub impl[V : Eq] Eq for T[V] with op_equal(self, other) {
   self.to_array() == other.to_array()
 }
 
 ///|
 /// Returns if the set is empty.
-pub fn[V : Compare] is_empty(self : T[V]) -> Bool {
+pub fn[V] is_empty(self : T[V]) -> Bool {
   self.root is None
 }
 
 ///|
 /// Returns the number of elements in the set.
-pub fn[V : Compare] size(self : T[V]) -> Int {
+pub fn[V] size(self : T[V]) -> Int {
   self.size
 }
 
@@ -484,7 +484,7 @@ fn[V] height_ge(x1 : Node[V]?, x2 : Node[V]?) -> Bool {
 }
 
 ///|
-fn[V : Compare] balance(root : Node[V]) -> Node[V] {
+fn[V] balance(root : Node[V]) -> Node[V] {
   let (l, r) = (root.left, root.right)
   let (hl, hr) = (height(l), height(r))
   let new_root = if hl > hr + 1 {
@@ -509,7 +509,7 @@ fn[V : Compare] balance(root : Node[V]) -> Node[V] {
 }
 
 ///|
-fn[V : Compare] rotate_l(n : Node[V]) -> Node[V] {
+fn[V] rotate_l(n : Node[V]) -> Node[V] {
   let r = n.right.unwrap()
   n.right = r.left
   r.left = Some(n)
@@ -519,7 +519,7 @@ fn[V : Compare] rotate_l(n : Node[V]) -> Node[V] {
 }
 
 ///|
-fn[V : Compare] rotate_r(n : Node[V]) -> Node[V] {
+fn[V] rotate_r(n : Node[V]) -> Node[V] {
   let l = n.left.unwrap()
   n.left = l.right
   l.right = Some(n)
@@ -529,7 +529,7 @@ fn[V : Compare] rotate_r(n : Node[V]) -> Node[V] {
 }
 
 ///|
-fn[V : Compare] rotate_lr(n : Node[V]) -> Node[V] {
+fn[V] rotate_lr(n : Node[V]) -> Node[V] {
   let l = n.left.unwrap()
   let v = rotate_l(l)
   n.left = Some(v)
@@ -537,7 +537,7 @@ fn[V : Compare] rotate_lr(n : Node[V]) -> Node[V] {
 }
 
 ///|
-fn[V : Compare] rotate_rl(n : Node[V]) -> Node[V] {
+fn[V] rotate_rl(n : Node[V]) -> Node[V] {
   let r = n.right.unwrap()
   let v = rotate_r(r)
   n.right = Some(v)

--- a/sorted_set/sorted_set.mbti
+++ b/sorted_set/sorted_set.mbti
@@ -14,7 +14,7 @@ fn[V] new() -> T[V]
 #deprecated
 fn[V : Compare] of(Array[V]) -> T[V]
 
-fn[V : Compare] singleton(V) -> T[V]
+fn[V] singleton(V) -> T[V]
 
 // Types and methods
 type T[V]
@@ -34,17 +34,17 @@ fn[V : Compare] T::from_iter(Iter[V]) -> Self[V]
 #deprecated
 fn[V : Compare] T::intersect(Self[V], Self[V]) -> Self[V]
 fn[V : Compare] T::intersection(Self[V], Self[V]) -> Self[V]
-fn[V : Compare] T::is_empty(Self[V]) -> Bool
+fn[V] T::is_empty(Self[V]) -> Bool
 fn[V] T::iter(Self[V]) -> Iter[V]
 fn[V : Compare] T::range(Self[V], V, V) -> Iter[V]
 fn[V : Compare] T::remove(Self[V], V) -> Unit
-fn[V : Compare] T::size(Self[V]) -> Int
+fn[V] T::size(Self[V]) -> Int
 fn[V : Compare] T::subset(Self[V], Self[V]) -> Bool
 fn[V : Compare] T::symmetric_difference(Self[V], Self[V]) -> Self[V]
 fn[V] T::to_array(Self[V]) -> Array[V]
 fn[V : Compare] T::union(Self[V], Self[V]) -> Self[V]
 impl[K] Default for T[K]
-impl[V : Compare] Eq for T[V]
+impl[V : Eq] Eq for T[V]
 impl[V : Show] Show for T[V]
 impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for T[X]
 


### PR DESCRIPTION
This PR removes unused trait bound in core, using unused warning for trait bounds, which is currently under development in MoonBit compiler.