### PR TITLE
fix(list): deprecate @list.tail

### DIFF
--- a/list/README.mbt.md
+++ b/list/README.mbt.md
@@ -114,7 +114,7 @@ Get the list without its first element.
 ```moonbit
 test {
   let list = @list.of([1, 2, 3, 4, 5])
-  assert_eq(list.tail(), @list.of([2, 3, 4, 5]))
+  assert_eq(list.unsafe_tail(), @list.of([2, 3, 4, 5]))
 }
 ```
 

--- a/list/deprecated.mbt
+++ b/list/deprecated.mbt
@@ -30,3 +30,10 @@ pub fn[A, B] rev_foldi(self : T[A], init~ : B, f : (Int, B, A) -> B) -> B {
 }
 
 ///|
+#deprecated("use `unsafe_tail` instead")
+pub fn[A] tail(self : T[A]) -> T[A] {
+  match self {
+    Empty => Empty
+    More(_, tail~) => tail
+  }
+}

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -283,27 +283,20 @@ pub fn[A] any(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
 }
 
 ///|
-/// Tail of the list.
-///
-/// # Example
-///
-/// ```mbt
-///   assert_eq(@list.of([1, 2, 3, 4, 5]).tail(), @list.of([2, 3, 4, 5]))
-/// ```
-pub fn[A] tail(self : T[A]) -> T[A] {
-  match self {
-    Empty => Empty
-    More(_, tail~) => tail
-  }
-}
-
-///|
 /// Get first element of the list.
 #internal(unsafe, "Panic if the list is empty")
 pub fn[A] unsafe_head(self : T[A]) -> A {
   match self {
     Empty => abort("head of empty list")
     More(head, tail=_) => head
+  }
+}
+
+///|
+pub fn[A] unsafe_tail(self : T[A]) -> T[A] {
+  match self {
+    Empty => abort("tail of empty list")
+    More(_, tail~) => tail
   }
 }
 

--- a/list/list.mbti
+++ b/list/list.mbti
@@ -86,6 +86,7 @@ fn[A, B] T::rev_map(Self[A], (A) -> B raise?) -> Self[B] raise?
 fn[A, E] T::scan_left(Self[A], (E, A) -> E raise?, init~ : E) -> Self[E] raise?
 fn[A, B] T::scan_right(Self[A], (B, A) -> B raise?, init~ : B) -> Self[B] raise?
 fn[A : Compare] T::sort(Self[A]) -> Self[A]
+#deprecated
 fn[A] T::tail(Self[A]) -> Self[A]
 fn[A] T::take(Self[A], Int) -> Self[A]
 fn[A] T::take_while(Self[A], (A) -> Bool raise?) -> Self[A] raise?
@@ -96,6 +97,7 @@ fn[A] T::unsafe_last(Self[A]) -> A
 fn[A : Compare] T::unsafe_maximum(Self[A]) -> A
 fn[A : Compare] T::unsafe_minimum(Self[A]) -> A
 fn[A] T::unsafe_nth(Self[A], Int) -> A
+fn[A] T::unsafe_tail(Self[A]) -> Self[A]
 fn[A, B] T::unzip(Self[(A, B)]) -> (Self[A], Self[B])
 fn[A, B] T::zip(Self[A], Self[B]) -> Self[(A, B)]
 impl[A] Add for T[A]

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -115,11 +115,15 @@ test "any" {
 }
 
 ///|
-test "tail" {
+test "unsafe_tail" {
   let ls = @list.of([1, 2, 3, 4, 5])
-  let el : @list.T[Int] = @list.empty()
-  inspect(ls.tail(), content="@list.of([2, 3, 4, 5])")
-  inspect(el.tail(), content="@list.of([])")
+  inspect(ls.unsafe_tail(), content="@list.of([2, 3, 4, 5])")
+}
+
+///|
+test "panic unsafe_tail" {
+  let ls : @list.T[Int] = @list.empty()
+  inspect(ls.unsafe_tail())
 }
 
 ///|


### PR DESCRIPTION
we need to align type signature with `@list.head`

**current API**

```moonbit
pub fn[A] tail(self : T[A]) -> T[A]
```

**expected API**

```moonbit
pub fn[A] tail(self : T[A]) -> T[A]?
```