### PR TITLE
simplify error handling in parse tests

### DIFF
--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -578,10 +578,8 @@ test "from_int64" {
 ///|
 test "parse_decimal" {
   let s = "0.0000000000000000000000000000007888609052210118054117285652827862296732064351090230047702789306640625"
-  let hpd = parse_decimal_priv(s) catch { _ => panic() }
-  assert_eq(hpd.to_string(), s)
-  let hpd = parse_decimal_priv("1.0e-10") catch { _ => panic() }
-  assert_eq(hpd.to_string(), "0.0000000001")
+  assert_eq(parse_decimal_priv(s).to_string(), s)
+  assert_eq(parse_decimal_priv("1.0e-10").to_string(), "0.0000000001")
 }
 
 ///|

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -286,31 +286,18 @@ test "parse_double" {
 
 ///|
 test "parse_double_inf" {
-  assert_eq(parse_double("inf") catch { _ => panic() }, @double.infinity)
-  assert_eq(parse_double("+Inf") catch { _ => panic() }, @double.infinity)
-  assert_eq(parse_double("-Inf") catch { _ => panic() }, @double.neg_infinity)
-  assert_eq(parse_double("+Infinity") catch { _ => panic() }, @double.infinity)
-  assert_eq(
-    parse_double("-Infinity") catch {
-      _ => panic()
-    },
-    @double.neg_infinity,
-  )
-  assert_eq(parse_double("+INFINITY") catch { _ => panic() }, @double.infinity)
-  assert_eq(
-    parse_double("-INFINITY") catch {
-      _ => panic()
-    },
-    @double.neg_infinity,
-  )
+  assert_eq(parse_double("inf"), @double.infinity)
+  assert_eq(parse_double("+Inf"), @double.infinity)
+  assert_eq(parse_double("-Inf"), @double.neg_infinity)
+  assert_eq(parse_double("+Infinity"), @double.infinity)
+  assert_eq(parse_double("-Infinity"), @double.neg_infinity)
+  assert_eq(parse_double("+INFINITY"), @double.infinity)
+  assert_eq(parse_double("-INFINITY"), @double.neg_infinity)
 }
 
 ///|
 test "parse_double_nan" {
-  let nan = parse_double("nan") catch { _ => panic() }
-  assert_true(nan.is_nan())
-  let nan = parse_double("NaN") catch { _ => panic() }
-  assert_true(nan.is_nan())
-  let nan = parse_double("NAN") catch { _ => panic() }
-  assert_true(nan.is_nan())
+  assert_true(parse_double("nan").is_nan())
+  assert_true(parse_double("NaN").is_nan())
+  assert_true(parse_double("NAN").is_nan())
 }

--- a/strconv/double_test.mbt
+++ b/strconv/double_test.mbt
@@ -17,9 +17,7 @@ test "try_fast_path overflow when shift is too large" {
   // When the shift (exponent - max_exponent_fast_path) is too large,
   // the multiplication of mantissa with int_pow10[shift] will overflow,
   // triggering line 130
-  let result = @strconv.parse_double("9007199254740992e30") catch {
-    _ => panic()
-  }
+  let result = @strconv.parse_double("9007199254740992e30")
   // The function successfully falls back to slow path
   inspect(result, content="9.007199254740992e+45")
 }
@@ -28,9 +26,7 @@ test "try_fast_path overflow when shift is too large" {
 test "try_fast_path overflow when mantissa is too large" {
   // When the mantissa after shifting is larger than max_mantissa_fast_path,
   // line 133 will be triggered
-  let result = @strconv.parse_double("9007199254740992e23") catch {
-    _ => panic()
-  }
+  let result = @strconv.parse_double("9007199254740992e23")
   // The function successfully falls back to slow path
   inspect(result, content="9.007199254740991e+38")
 }

--- a/strconv/traits.mbt
+++ b/strconv/traits.mbt
@@ -60,16 +60,16 @@ pub fn[A : FromStr] parse(str : String) -> A raise StrConvError {
 
 ///|
 test "parse" {
-  let b : Bool = parse("true") catch { _ => panic() }
+  let b : Bool = parse("true")
   assert_eq(b, true)
-  let i : Int = parse("12345") catch { _ => panic() }
+  let i : Int = parse("12345")
   assert_eq(i, 12345)
-  let i64 : Int64 = parse("9223372036854775807") catch { _ => panic() }
+  let i64 : Int64 = parse("9223372036854775807")
   assert_eq(i64, 9223372036854775807L)
-  let ui : UInt = parse("4294967295") catch { _ => panic() }
+  let ui : UInt = parse("4294967295")
   assert_eq(ui, 4294967295)
-  let ui64 : UInt64 = parse("18446744073709551615") catch { _ => panic() }
+  let ui64 : UInt64 = parse("18446744073709551615")
   assert_eq(ui64, 18446744073709551615UL)
-  let d : Double = parse("1234.56789") catch { _ => panic() }
+  let d : Double = parse("1234.56789")
   assert_eq(d, 1234.56789)
 }


### PR DESCRIPTION
Replace
```mbt
test {
  try exp catch { _ => panic() }
}
```
to
```mbt
test {
  exp
}