### PR TITLE
hongbo/align rust option

### DIFF
--- a/option/README.mbt.md
+++ b/option/README.mbt.md
@@ -51,7 +51,7 @@ A safer alternative to `unwrap` is the `or` method, which returns the value if i
 ```moonbit
 test {
   let none: Int? = None
-  let value = none.or(0) // 0
+  let value = none.unwrap_or(0) // 0
   assert_eq(value, 0)
 }
 ```
@@ -60,8 +60,8 @@ There is also the `or_else` method, which returns the value if it is `Some`, oth
 
 ```moonbit
 test {
-  let none: Int? = None
-  let value = none.or_else(() => { 0 }) // 0
+  let none : Int? = None
+  let value = none.unwrap_or_else(() => 0) // 0
   assert_eq(value, 0)
 }
 ```
@@ -72,8 +72,8 @@ You can transform the value of an `Option` using the `map` method. It applies th
 
 ```moonbit
 test {
-  let some: Int? = Some(42)
-  let new_some = some.map((value: Int) => { value + 1 }) // Some(43)
+  let some : Int? = Some(42)
+  let new_some = some.map((value : Int) => value + 1) // Some(43)
   assert_eq(new_some, Some(43))
 }
 ```

--- a/option/deprecated.mbt
+++ b/option/deprecated.mbt
@@ -39,3 +39,30 @@ pub fn[T] empty() -> T? {
 pub fn[T] some(value : T) -> T? {
   Some(value)
 }
+
+///|
+#deprecated("use unwrap_or instead")
+pub fn[T] Option::or(self : T?, default : T) -> T {
+  match self {
+    None => default
+    Some(t) => t
+  }
+}
+
+///|
+#deprecated("use unwrap_or_else instead")
+pub fn[T] Option::or_else(self : T?, default : () -> T) -> T {
+  match self {
+    None => default()
+    Some(t) => t
+  }
+}
+
+///|
+#deprecated("use unwrap_or_default instead")
+pub fn[T : Default] Option::or_default(self : T?) -> T {
+  match self {
+    None => T::default()
+    Some(t) => t
+  }
+}

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -194,7 +194,7 @@ test "filter" {
 
 ///|
 /// Return the contained `Some` value or the provided default.
-pub fn[T] or(self : T?, default : T) -> T {
+pub fn[T] Option::unwrap_or(self : T?, default : T) -> T {
   match self {
     None => default
     Some(t) => t
@@ -202,17 +202,17 @@ pub fn[T] or(self : T?, default : T) -> T {
 }
 
 ///|
-test "or" {
+test "unwrap_or" {
   let x = Option::Some(3)
-  assert_eq(x.or(5), 3)
-  assert_eq((None : Int?).or(5), 5)
+  assert_eq(x.unwrap_or(5), 3)
+  assert_eq((None : Int?).unwrap_or(5), 5)
 }
 
 ///|
 /// Return the contained `Some` value or the provided default.
 ///
 /// Default is lazily evaluated
-pub fn[T] or_else(self : T?, default : () -> T) -> T {
+pub fn[T] Option::unwrap_or_else(self : T?, default : () -> T) -> T {
   match self {
     None => default()
     Some(t) => t
@@ -222,13 +222,13 @@ pub fn[T] or_else(self : T?, default : () -> T) -> T {
 ///|
 test "or else" {
   let x = Option::Some(3)
-  assert_eq(x.or_else(() => 5), 3)
-  assert_eq((None : Int?).or_else(() => 5), 5)
+  assert_eq(x.unwrap_or_else(() => 5), 3)
+  assert_eq(None.unwrap_or_else(() => 5), 5)
 }
 
 ///|
 /// Return the contained `Some` value or the result of the `T::default()`.
-pub fn[T : Default] or_default(self : T?) -> T {
+pub fn[T : Default] Option::unwrap_or_default(self : T?) -> T {
   match self {
     None => T::default()
     Some(t) => t
@@ -238,8 +238,8 @@ pub fn[T : Default] or_default(self : T?) -> T {
 ///|
 test "or default" {
   let x = Option::Some(3)
-  assert_eq(x.or_default(), 3)
-  assert_eq((None : Int?).or_default(), 0)
+  assert_eq(x.unwrap_or_default(), 3)
+  assert_eq((None : Int?).unwrap_or_default(), 0)
 }
 
 ///|

--- a/option/option.mbti
+++ b/option/option.mbti
@@ -26,10 +26,16 @@ fn[T] Option::iter(T?) -> Iter[T]
 fn[T, U] Option::map(T?, (T) -> U) -> U?
 fn[T, U] Option::map_or(T?, U, (T) -> U) -> U
 fn[T, U] Option::map_or_else(T?, () -> U, (T) -> U) -> U
+#deprecated
 fn[T] Option::or(T?, T) -> T
+#deprecated
 fn[T : Default] Option::or_default(T?) -> T
+#deprecated
 fn[T] Option::or_else(T?, () -> T) -> T
 fn[T, Err : Error] Option::or_error(T?, Err) -> T raise Err
+fn[T] Option::unwrap_or(T?, T) -> T
+fn[T : Default] Option::unwrap_or_default(T?) -> T
+fn[T] Option::unwrap_or_else(T?, () -> T) -> T
 impl[X : Compare] Compare for X?
 impl[X] Default for X?
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for X?

--- a/option/option_test.mbt
+++ b/option/option_test.mbt
@@ -38,8 +38,8 @@ test "Option::default should return None for Bool" {
 
 ///|
 fn test_option_arg(x? : Int, y? : Int) -> Int {
-  let x = x.or(3)
-  let y = y.or(4)
+  let x = x.unwrap_or(3)
+  let y = y.unwrap_or(4)
   x + y
 }
 


### PR DESCRIPTION
- **deprecate tiny wrappers**
- **Align option api with Rust option crate https://doc.rust-lang.org/std/option/**
