### PR TITLE
Modernize loops and closures

### DIFF
--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -330,7 +330,7 @@ test "filter with branch nodes" {
     (i, map) => continue (i + 1, map.add(i, i * 10))
   }
   let filtered = map.filter(v => v % 20 == 0)
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     if i * 10 % 20 == 0 {
       assert_eq(filtered.get(i), Some(i * 10))
     } else {
@@ -403,7 +403,7 @@ test "HAMT::map_with_key branch" {
     (i, map) => continue (i + 1, map.add(i, i * 10))
   } // Branch
   let mapped = map.map_with_key((k, v) => k * 100 + v)
-  for i = 0; i < 10; i = i + 1 {
+  for i in 0..<10 {
     assert_eq(mapped.get(i), Some(i * 100 + i * 10))
   }
   assert_eq(mapped.get(100), None)

--- a/result/result_test.mbt
+++ b/result/result_test.mbt
@@ -22,13 +22,13 @@ test "Result unwrap should return Ok value" {
 ///|
 test "bind with Err" {
   let x : Result[Int, String] = Err("error")
-  let y = x.bind(fn(v : Int) { Ok(v * 7) })
+  let y = x.bind(v => Ok(v * 7))
   assert_eq(y, Err("error"))
 }
 
 ///|
 test "wrap0 with error" {
-  let f = fn() -> Int raise Failure { raise Failure("error") }
+  let f : () -> Int raise Failure = () => raise Failure("error")
   let result = try? f()
   inspect(
     result,
@@ -40,7 +40,7 @@ test "wrap0 with error" {
 
 ///|
 test "wrap2 with error result" {
-  let f = fn(_, _) -> Unit raise Failure { raise Failure("error") }
+  let f : (Int, Int) -> Unit raise Failure = (_, _) => raise Failure("error")
   let r = try? f(1, 2)
   inspect(
     r,

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -203,11 +203,11 @@ test "mix_everything" {
     set7,
     content="@sorted_set.from_array([1, 2, 4, 5, 6, 7, 8, 12, 13, 14, 22, 33])",
   )
-  for i = 1; i <= 5; i = i + 1 {
+  for i in 1..=5 {
     set7.remove(i)
   }
   inspect(set7, content="@sorted_set.from_array([6, 7, 8, 12, 13, 14, 22, 33])")
-  for i = 6; i <= 33; i = i + 1 {
+  for i in 6..=33 {
     set7.remove(i)
   }
   let set = @sorted_set.from_array([


### PR DESCRIPTION
## Summary
- modernize loops in HAMT and sorted set tests using range syntax
- rewrite closure tests with arrow functions

## Testing
- `moon info`
- `moon fmt`
- `moon check`
- `moon test`

------
https://chatgpt.com/codex/tasks/task_e_68613250549883208aad2a88e9512ed0