### PR TITLE
Apply arrow functions and range loops

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1556,5 +1556,5 @@ pub fn[A] get(self : T[A], index : Int) -> A? {
 /// * For multiple matches, returns the leftmost matching position
 /// * Returns an insertion point that maintains the sort order when no match is found
 pub fn[A : Compare] binary_search(self : T[A], value : A) -> Result[Int, Int] {
-  self.binary_search_by(fn(x) { x.compare(value) })
+  self.binary_search_by(x => x.compare(value))
 }

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -657,7 +657,7 @@ test "test_from_vec" {
 
 ///|
 test "test_from_array" {
-  fn test_fn(n : Int) -> Unit raise {
+  let test_fn : (Int) -> Unit raise = (n : Int) => {
     let array : FixedArray[Int] = FixedArray::make(n, 0)
     for index in 0..<n {
       array[index] = index
@@ -668,7 +668,6 @@ test "test_from_array" {
     }
     assert_eq(deq.length(), array.length())
   }
-
   test_fn(0)
   test_fn(1)
   test_fn(2)
@@ -1054,27 +1053,27 @@ test "binary_search_by on multiple elements deque" {
   let dq = @deque.of([1, 3, 5, 7, 9])
 
   // Find the element that exists (the first one)
-  let found_first = dq.binary_search_by(fn(x) { x.compare(1) })
+  let found_first = dq.binary_search_by(x => x.compare(1))
   inspect(found_first, content="Ok(0)")
 
   // Find the element that exists (middle)
-  let found_middle = dq.binary_search_by(fn(x) { x.compare(5) })
+  let found_middle = dq.binary_search_by(x => x.compare(5))
   inspect(found_middle, content="Ok(2)")
 
   // Find the last element that exists
-  let found_last = dq.binary_search_by(fn(x) { x.compare(9) })
+  let found_last = dq.binary_search_by(x => x.compare(9))
   inspect(found_last, content="Ok(4)")
 
   // Find non-existent elements (less than all)
-  let not_found_less = dq.binary_search_by(fn(x) { x.compare(0) })
+  let not_found_less = dq.binary_search_by(x => x.compare(0))
   inspect(not_found_less, content="Err(0)")
 
   //Find the non-existent element (middle position)
-  let not_found_middle = dq.binary_search_by(fn(x) { x.compare(4) })
+  let not_found_middle = dq.binary_search_by(x => x.compare(4))
   inspect(not_found_middle, content="Err(2)")
 
   // Find non-existent elements (greater than all)
-  let not_found_greater = dq.binary_search_by(fn(x) { x.compare(10) })
+  let not_found_greater = dq.binary_search_by(x => x.compare(10))
   inspect(not_found_greater, content="Err(5)")
 }
 

--- a/double/internal/ryu/ryu.mbt
+++ b/double/internal/ryu/ryu.mbt
@@ -18,7 +18,7 @@
 ///|
 fn string_from_bytes(bytes : FixedArray[Byte], from : Int, to : Int) -> String {
   let buf = StringBuilder::new(size_hint=bytes.length())
-  for i = from; i < to; i = i + 1 {
+  for i in from..<to {
     buf.write_char(bytes[i].to_char())
   }
   buf.to_string()
@@ -563,7 +563,7 @@ fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
         output /= 10
       }
       index += olength
-      for i = olength; i < exp + 1; i = i + 1 {
+      for i in olength..<(exp + 1) {
         result[index] = b'0'
         index += 1
       }

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -564,7 +564,7 @@ fn[A] redis_plan(t : FixedArray[Tree[A]]) -> (FixedArray[Int], Int) {
       remaining_nodes = remaining_nodes + node_counts[i + 1] - min_size
       i += 1
     }
-    for j = i; j < new_len - 1; j = j + 1 {
+    for j in i..<(new_len - 1) {
       node_counts[j] = node_counts[j + 1]
     }
     new_len -= 1


### PR DESCRIPTION
## Summary
- modernize loops in ryu and tree modules
- use arrow functions in deque binary search helpers
- convert helper function in deque tests to arrow style

## Testing
- `moon info`
- `moon fmt`
- `moon check`
- `moon test`

------
https://chatgpt.com/codex/tasks/task_e_6863f34efa288320ae584416aa837012