### PR TITLE
chore: convert local fns to arrows

### DIFF
--- a/buffer/README.mbt.md
+++ b/buffer/README.mbt.md
@@ -137,7 +137,7 @@ test "buffer with size hint" {
   let buf = @buffer.new(size_hint=1024)
 
   // Write some data
-  for i = 0; i < 100; i = i + 1 {
+  for i in 0..<100 {
     buf.write_int_le(i)
   }
 

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -592,16 +592,13 @@ struct TestStruct {
 test "array_binary_search_by_test" {
   let arr = [{ num: 10 }, { num: 22 }, { num: 35 }, { num: 48 }]
   let mut target = { num: 22 }
-  fn cmp(val : TestStruct) {
-    if val.num < target.num {
-      -1
-    } else if val.num == target.num {
-      0
-    } else {
-      1
-    }
+  let cmp = (val : TestStruct) => if val.num < target.num {
+    -1
+  } else if val.num == target.num {
+    0
+  } else {
+    1
   }
-
   assert_eq(arr.binary_search_by(cmp), Ok(1))
   target = { num: 48 }
   assert_eq(arr.binary_search_by(cmp), Ok(3))

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -14,12 +14,11 @@
 
 ///|
 test "combine int" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_int(v)
     hasher.finalize()
   }
-
   inspect(hash(0), content="148298089")
   inspect(hash(1), content="-205818221")
   inspect(hash(2), content="527729046")
@@ -32,23 +31,21 @@ test "combine int" {
 
 ///|
 test "combine char" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_char(v)
     hasher.finalize()
   }
-
   inspect(hash('c'), content="-1500876651")
 }
 
 ///|
 test "combine int64" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_int64(v)
     hasher.finalize()
   }
-
   inspect(hash(0), content="-558656237")
   inspect(hash(1), content="149775153")
   inspect(hash(2), content="-368796614")
@@ -61,12 +58,11 @@ test "combine int64" {
 
 ///|
 test "combine uint" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_uint(v)
     hasher.finalize()
   }
-
   inspect(hash(0), content="148298089")
   inspect(hash(1), content="-205818221")
   inspect(hash(2), content="527729046")
@@ -78,12 +74,11 @@ test "combine uint" {
 
 ///|
 test "combine uint64" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_uint64(v)
     hasher.finalize()
   }
-
   inspect(hash(0), content="-558656237")
   inspect(hash(1), content="149775153")
   inspect(hash(2), content="-368796614")
@@ -95,12 +90,11 @@ test "combine uint64" {
 
 ///|
 test "combine double" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_double(v)
     hasher.finalize()
   }
-
   inspect(hash(0.0), content="-558656237")
   inspect(hash(0.1), content="1840903062")
   inspect(hash(0.2), content="-1200607554")
@@ -111,12 +105,11 @@ test "combine double" {
 
 ///|
 test "combine float" {
-  fn hash(v : Float) {
+  let hash = (v : Float) => {
     let hasher = Hasher::new()
     hasher.combine_float(v)
     hasher.finalize()
   }
-
   inspect(hash(0.0), content="148298089")
   inspect(hash(0.1), content="1101647392")
   inspect(hash(0.2), content="-352548260")
@@ -127,12 +120,11 @@ test "combine float" {
 
 ///|
 test "combine string" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_string(v)
     hasher.finalize()
   }
-
   inspect(hash(""), content="46947589")
   inspect(hash("abc"), content="-771846975")
   inspect(
@@ -148,12 +140,11 @@ test "combine string" {
 
 ///|
 test "combine bytes" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_bytes(v)
     hasher.finalize()
   }
-
   let b1 : Bytes = [
     65, 0, 66, 0, 67, 0, 68, 0, 69, 0, 70, 0, 71, 0, 72, 0, 73, 0,
   ]
@@ -173,12 +164,11 @@ test "combine bytes" {
 
 ///|
 test "combine byte" {
-  fn hash(v) {
+  let hash = v => {
     let hasher = Hasher::new()
     hasher.combine_byte(v)
     hasher.finalize()
   }
-
   inspect(hash(b'0'), content="-1971641254")
   inspect(hash(b'1'), content="1943578595")
   inspect(hash(b'2'), content="1881073354")

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1449,7 +1449,7 @@ pub fn[A] T::drain(self : T[A], start~ : Int, len? : Int) -> T[A] {
 /// let dq = @deque.of([1, 3, 5, 7, 9])
 ///
 /// 
-/// let find_3 = dq.binary_search_by(fn(x) {
+/// let find_3 = dq.binary_search_by(x => {
 ///   if x < 3 {
 ///     -1
 ///   } else if x > 3 {
@@ -1461,7 +1461,7 @@ pub fn[A] T::drain(self : T[A], start~ : Int, len? : Int) -> T[A] {
 /// inspect(find_3, content="Ok(1)")
 ///
 /// 
-/// let find_4 = dq.binary_search_by(fn(x) {
+/// let find_4 = dq.binary_search_by(x => {
 ///   if x < 4 {
 ///     -1
 ///   } else if x > 4 {

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -78,10 +78,7 @@ test "Int16::from_int64" {
 
 ///|
 test "Int16::op_add" {
-  fn add(a : Int16, b : Int16) -> Int16 {
-    a + b
-  }
-
+  let add = (a : Int16, b : Int16) => a + b
   inspect(add(1, 2), content="3")
   inspect(add(0, 0), content="0")
   inspect(add(32767, 1), content="-32768") // Overflow case
@@ -98,10 +95,7 @@ test "Int16::op_add" {
 
 ///|
 test "Int16::op_sub" {
-  fn sub(a : Int16, b : Int16) -> Int16 {
-    a - b
-  }
-
+  let sub = (a : Int16, b : Int16) => a - b
   inspect(sub(3, 2), content="1")
   inspect(sub(0, 0), content="0")
   inspect(sub(-32768, 1), content="32767") // Underflow case
@@ -118,10 +112,7 @@ test "Int16::op_sub" {
 
 ///|
 test "Int16::op_mul" {
-  fn mul(a : Int16, b : Int16) -> Int16 {
-    a * b
-  }
-
+  let mul = (a : Int16, b : Int16) => a * b
   inspect(mul(0, 0), content="0")
   inspect(mul(1, 1), content="1")
   inspect(mul(-1, -1), content="1")
@@ -140,10 +131,7 @@ test "Int16::op_mul" {
 
 ///|
 test "Int16::op_div" {
-  fn div(a : Int16, b : Int16) -> Int16 {
-    a / b
-  }
-
+  let div = (a : Int16, b : Int16) => a / b
   inspect(div(6, 2), content="3")
   inspect(div(0, 1), content="0")
   inspect(div(1, 1), content="1")
@@ -207,10 +195,7 @@ test "Int16::op_equal" {
 
 ///|
 test "Int16::op_shl" {
-  fn shl(a : Int16, b : Int) -> Int16 {
-    a << b
-  }
-
+  let shl = (a : Int16, b : Int) => a << b
   inspect(shl(0, 0), content="0")
   inspect(shl(1, 0), content="1")
   inspect(shl(1, 1), content="2")
@@ -269,10 +254,7 @@ test "Int16::op_shl" {
 
 ///|
 test "Int16::op_shr" {
-  fn shr(a : Int16, b : Int) -> Int16 {
-    a >> b
-  }
-
+  let shr = (a : Int16, b : Int) => a >> b
   inspect(shr(0, 0), content="0")
   inspect(shr(1, 0), content="1")
   inspect(shr(2, 1), content="1")
@@ -345,10 +327,7 @@ test "Int16::op_shr" {
 
 ///|
 test "Int16::lor" {
-  fn lor(a : Int16, b : Int16) -> Int16 {
-    a | b
-  }
-
+  let lor = (a : Int16, b : Int16) => a | b
   inspect(lor(0, 0), content="0")
   inspect(lor(1, 0), content="1")
   inspect(lor(0, 1), content="1")
@@ -369,10 +348,7 @@ test "Int16::lor" {
 
 ///|
 test "Int16::land" {
-  fn land(a : Int16, b : Int16) -> Int16 {
-    a & b
-  }
-
+  let land = (a : Int16, b : Int16) => a & b
   inspect(land(0, 0), content="0")
   inspect(land(1, 0), content="0")
   inspect(land(0, 1), content="0")
@@ -393,10 +369,7 @@ test "Int16::land" {
 
 ///|
 test "Int16::lxor" {
-  fn lxor(a : Int16, b : Int16) -> Int16 {
-    a ^ b
-  }
-
+  let lxor = (a : Int16, b : Int16) => a ^ b
   inspect(lxor(0, 0), content="0")
   inspect(lxor(1, 0), content="1")
   inspect(lxor(0, 1), content="1")
@@ -408,10 +381,7 @@ test "Int16::lxor" {
 
 ///|
 test "Int16::op_mod" {
-  fn mod(a : Int16, b : Int16) -> Int16 {
-    a % b
-  }
-
+  let mod = (a : Int16, b : Int16) => a % b
   inspect(mod(10, 3), content="1")
   inspect(mod(10, 2), content="0")
   inspect(mod(10, 10), content="0")
@@ -429,10 +399,7 @@ test "Int16::op_mod" {
 
 ///|
 test "Int16::op_neg" {
-  fn neg(a : Int16) -> Int16 {
-    -a
-  }
-
+  let neg = (a : Int16) => -a
   inspect(neg(10), content="-10")
   inspect(neg(-10), content="10")
   inspect(neg(0), content="0")
@@ -443,10 +410,7 @@ test "Int16::op_neg" {
 
 ///|
 test "Int16::abs" {
-  fn abs(a : Int16) -> Int16 {
-    a.abs()
-  }
-
+  let abs = (a : Int16) => a.abs()
   inspect(abs(10), content="10")
   inspect(abs(-10), content="10")
   inspect(abs(0), content="0")

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -167,11 +167,10 @@ test "pop" {
 
 ///|
 test "complex" {
-  fn rand(upper : Int) -> Int {
+  let rand = (upper : Int) => {
     let rng = @random.Rand::new()
     rng.int(limit=upper)
   }
-
   let arr = (0).until(1000, inclusive=true).collect()
   arr.shuffle_in_place(rand~)
   let pq = new()


### PR DESCRIPTION
## Summary
- modernize docs to use arrow lambdas
- convert local helper functions in tests to arrow functions

## Testing
- `moon info`
- `moon fmt`
- `moon check`
- `moon test`


------
https://chatgpt.com/codex/tasks/task_e_6863f7cd810c8320ae90c3017628aabc