### PR TITLE
Revert "chore: deprecate substring"

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -509,7 +509,6 @@ fn String::length(String) -> Int
 fn String::make(Int, Char) -> String
 #deprecated
 fn String::op_get(String, Int) -> Char
-#deprecated
 fn String::substring(String, start~ : Int = .., end? : Int) -> String
 fn String::to_string(String) -> String
 fn String::unsafe_char_at(String, Int) -> Char

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -311,3 +311,23 @@ test "panic" {
   let _ : Int = Option::None.unwrap()
 
 }
+
+///|
+test "panic substring_start_index_error" {
+  "test".substring(start=-1, end=0) |> ignore
+}
+
+///|
+test "panic substring_end_index_error" {
+  "test".substring(start=0, end=-1) |> ignore
+}
+
+///|
+test "panic substring_start_end_index_error" {
+  "test".substring(start=1, end=0) |> ignore
+}
+
+///|
+test "panic substring_length_index_error" {
+  "test".substring(start=0, end=5) |> ignore
+}

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -141,7 +141,30 @@ fn unsafe_substring(str : String, start : Int, end : Int) -> String {
 }
 
 ///|
-#deprecated("Use `string.charcodes(start~, end~).to_string()` instead")
+/// Returns a new string containing characters from the original string starting
+/// at `start` index up to (but not including) `end` index.
+///
+/// Parameters:
+///
+/// * `string` : The source string from which to extract the substring.
+/// * `start` : The starting index of the substring (inclusive). Defaults to 0.
+/// * `end` : The ending index of the substring (exclusive). Defaults to the
+/// length of the string.
+///
+/// Returns a new string containing the specified substring.
+///
+/// Example:
+///
+/// ```moonbit
+///   let s = "Hello world"
+///   inspect(s.substring(start=0, end=5), content="Hello")
+///   inspect(s.substring(start=6, end=11), content="world")
+///   inspect(s.substring(), content="Hello world")
+///
+///   let s = "test"
+///   inspect(s.substring(start=2, end=2), content="")
+///   inspect("".substring(), content="")
+/// ```
 pub fn String::substring(self : String, start~ : Int = 0, end? : Int) -> String {
   let len = self.length()
   let end = match end {

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -41,6 +41,14 @@ test "String::escape" {
 }
 
 ///|
+test "substring" {
+  assert_eq("abc".substring(), "abc")
+  assert_eq("abc".substring(start=1), "bc")
+  assert_eq("abc".substring(end=2), "ab")
+  assert_eq("abc".substring(start=1, end=2), "b")
+}
+
+///|
 test "panic codepoint_at1" {
   let str = "Hello🤣🤣🤣"
   let _ = str.iter().nth(8).unwrap()

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -149,7 +149,7 @@ fn ParseContext::lex_number_end(
   start : Int,
   end : Int
 ) -> Double raise ParseError {
-  let s = ctx.input.charcodes(start~, end~).to_string()
+  let s = ctx.input.substring(start~, end~)
   @strconv.parse_double(s) catch {
     _ => raise InvalidNumber(offset_to_position(ctx.input, start), s)
   }

--- a/string/panic_test.mbt
+++ b/string/panic_test.mbt
@@ -1,0 +1,33 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "panic substring_start_index_error" {
+  "test".substring(start=-1, end=0) |> ignore
+}
+
+///|
+test "panic substring_end_index_error" {
+  "test".substring(start=0, end=-1) |> ignore
+}
+
+///|
+test "panic substring_start_end_index_error" {
+  "test".substring(start=1, end=0) |> ignore
+}
+
+///|
+test "panic substring_length_index_error" {
+  "test".substring(start=0, end=5) |> ignore
+}


### PR DESCRIPTION
This reverts commit c100ab95024bc956d3dfb83aadc6fb4f5f141c63.

The native backend test template relies on substring. Replacing it with charcodes will cause dependency on package string.