### PR TITLE
feat(Array): add retain_map for in-place filter+map operations

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1682,7 +1682,10 @@ pub fn[A] Array::truncate(self : Array[A], len : Int) -> Unit {
 /// })
 /// // arr is now [4, 8]
 /// ```
-pub fn[A] Array::retain_map(self : Array[A], f : (A) -> A?) -> Unit {
+pub fn[A] Array::retain_map(
+  self : Array[A],
+  f : (A) -> A? raise?
+) -> Unit raise? {
   if self.is_empty() {
     return
   }
@@ -1699,6 +1702,5 @@ pub fn[A] Array::retain_map(self : Array[A], f : (A) -> A?) -> Unit {
       None => ()
     }
   }
-  let _ = self.unsafe_truncate_to_length(write_idx)
-
+  self.unsafe_truncate_to_length(write_idx)
 }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1680,7 +1680,7 @@ pub fn[A] Array::truncate(self : Array[A], len : Int) -> Unit {
 ///     None
 ///   }
 /// })
-/// // arr is now [4, 8]
+/// inspect(arr,content = "[4, 8]")
 /// ```
 pub fn[A] Array::retain_map(
   self : Array[A],

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1690,15 +1690,15 @@ pub fn[A] Array::retain_map(self : Array[A], f : (A) -> A?) -> Unit {
   let len = self.length()
   let mut write_idx = 0
   for read_idx in 0..<len {
-    match f(buf[read_idx]) {
+    let val = buf[read_idx]
+    match f(val) {
       Some(new_val) => {
-        if write_idx != read_idx {
-          buf[write_idx] = new_val
-        }
+        buf[write_idx] = new_val
         write_idx += 1
       }
       None => ()
     }
   }
-  self.unsafe_truncate_to_length(write_idx)
+  let _ = self.unsafe_truncate_to_length(write_idx)
+
 }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1666,3 +1666,39 @@ pub fn[A] Array::truncate(self : Array[A], len : Int) -> Unit {
   guard len >= 0 && len < self.length() else { return }
   self.unsafe_truncate_to_length(len)
 }
+
+///|
+/// In-place filter and map for Array
+///
+/// # Example
+/// ```moonbit
+/// let arr = [1, 2, 3, 4, 5]
+/// arr.retain_map(fn(x) {
+///   if x % 2 == 0 {
+///     Some(x * 2)
+///   } else {
+///     None
+///   }
+/// })
+/// // arr is now [4, 8]
+/// ```
+pub fn[A] Array::retain_map(self : Array[A], f : (A) -> A?) -> Unit {
+  if self.is_empty() {
+    return
+  }
+  let buf = self.buffer()
+  let len = self.length()
+  let mut write_idx = 0
+  for read_idx in 0..<len {
+    match f(buf[read_idx]) {
+      Some(new_val) => {
+        if write_idx != read_idx {
+          buf[write_idx] = new_val
+        }
+        write_idx += 1
+      }
+      None => ()
+    }
+  }
+  self.unsafe_truncate_to_length(write_idx)
+}

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1682,10 +1682,7 @@ pub fn[A] Array::truncate(self : Array[A], len : Int) -> Unit {
 /// })
 /// inspect(arr,content = "[4, 8]")
 /// ```
-pub fn[A] Array::retain_map(
-  self : Array[A],
-  f : (A) -> A? raise?
-) -> Unit raise? {
+pub fn[A] Array::retain_map(self : Array[A], f : (A) -> A?) -> Unit {
   if self.is_empty() {
     return
   }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -810,3 +810,10 @@ test "mapi_inplace with error callback" {
     ),
   )
 }
+
+///|
+test "retain_map" {
+  let arr = [2, 3, 4]
+  arr.retain_map(x => if x < 4 { Some(x + 1) } else { None })
+  inspect(arr, content="[3, 4]")
+}

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -102,7 +102,7 @@ fn[T] Array::repeat(Self[T], Int) -> Self[T]
 fn[T] Array::reserve_capacity(Self[T], Int) -> Unit
 fn[T] Array::resize(Self[T], Int, T) -> Unit
 fn[T] Array::retain(Self[T], (T) -> Bool raise?) -> Unit raise?
-fn[A] Array::retain_map(Self[A], (A) -> A?) -> Unit
+fn[A] Array::retain_map(Self[A], (A) -> A? raise?) -> Unit raise?
 fn[T] Array::rev(Self[T]) -> Self[T]
 fn[T] Array::rev_each(Self[T], (T) -> Unit) -> Unit
 fn[T] Array::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -102,6 +102,7 @@ fn[T] Array::repeat(Self[T], Int) -> Self[T]
 fn[T] Array::reserve_capacity(Self[T], Int) -> Unit
 fn[T] Array::resize(Self[T], Int, T) -> Unit
 fn[T] Array::retain(Self[T], (T) -> Bool raise?) -> Unit raise?
+fn[A] Array::retain_map(Self[A], (A) -> A?) -> Unit
 fn[T] Array::rev(Self[T]) -> Self[T]
 fn[T] Array::rev_each(Self[T], (T) -> Unit) -> Unit
 fn[T] Array::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -102,7 +102,7 @@ fn[T] Array::repeat(Self[T], Int) -> Self[T]
 fn[T] Array::reserve_capacity(Self[T], Int) -> Unit
 fn[T] Array::resize(Self[T], Int, T) -> Unit
 fn[T] Array::retain(Self[T], (T) -> Bool raise?) -> Unit raise?
-fn[A] Array::retain_map(Self[A], (A) -> A? raise?) -> Unit raise?
+fn[A] Array::retain_map(Self[A], (A) -> A?) -> Unit
 fn[T] Array::rev(Self[T]) -> Self[T]
 fn[T] Array::rev_each(Self[T], (T) -> Unit) -> Unit
 fn[T] Array::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?


### PR DESCRIPTION
### Changes Proposed

- Adds new `retain_map` method to `Array` type
- Combines filtering and mapping in a single in-place operation
- Matches behavior of similar functions in other languages (Rust's `retain_mut`, Swift's `removeAll(where:)` with mapping)