### PR TITLE
feat(int16): add integer conversion

### DIFF
--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -111,3 +111,18 @@ pub impl Default for Int16 with default() {
 pub impl ToJson for Int16 with to_json(self : Int16) -> Json {
   Json::number(self.to_int().to_double())
 }
+
+///| reinterpret as an unsigned integer with binary complement
+pub fn Int16::reinterpret_as_uint16(self : Int16) -> UInt16 {
+  self.to_int().to_uint16()
+}
+
+///| Sign extend to 32 bits and reinterpret as an unsigned integer with binary complement
+pub fn Int16::to_uint(self : Int16) -> UInt {
+  self.to_int().reinterpret_as_uint()
+}
+
+///| Sign extend to 64 bits and reinterpret as an unsigned integer with binary complement
+pub fn Int16::to_uint64(self : Int16) -> UInt64 {
+  self.to_int64().reinterpret_as_uint64()
+}

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -116,13 +116,3 @@ pub impl ToJson for Int16 with to_json(self : Int16) -> Json {
 pub fn Int16::reinterpret_as_uint16(self : Int16) -> UInt16 {
   self.to_int().to_uint16()
 }
-
-///| Sign extend to 32 bits and reinterpret as an unsigned integer with binary complement
-pub fn Int16::to_uint(self : Int16) -> UInt {
-  self.to_int().reinterpret_as_uint()
-}
-
-///| Sign extend to 64 bits and reinterpret as an unsigned integer with binary complement
-pub fn Int16::to_uint64(self : Int16) -> UInt64 {
-  self.to_int64().reinterpret_as_uint64()
-}

--- a/int16/int16.mbti
+++ b/int16/int16.mbti
@@ -8,8 +8,6 @@ let min_value : Int16
 // Types and methods
 fn Int16::abs(Int16) -> Int16
 fn Int16::reinterpret_as_uint16(Int16) -> UInt16
-fn Int16::to_uint(Int16) -> UInt
-fn Int16::to_uint64(Int16) -> UInt64
 impl Add for Int16
 impl BitAnd for Int16
 impl BitOr for Int16

--- a/int16/int16.mbti
+++ b/int16/int16.mbti
@@ -7,6 +7,9 @@ let min_value : Int16
 
 // Types and methods
 fn Int16::abs(Int16) -> Int16
+fn Int16::reinterpret_as_uint16(Int16) -> UInt16
+fn Int16::to_uint(Int16) -> UInt
+fn Int16::to_uint64(Int16) -> UInt64
 impl Add for Int16
 impl BitAnd for Int16
 impl BitOr for Int16

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -433,22 +433,3 @@ test "Int16::reinterpret_as_uint16" {
   assert_eq((0 : Int16).reinterpret_as_uint16(), (0 : UInt16))
   assert_eq((1 : Int16).reinterpret_as_uint16(), (1 : UInt16))
 }
-
-///|
-test "Int16::to_uint" {
-  inspect((-1 : Int16).to_uint(), content="4294967295")
-  inspect((-1 : Int16).to_uint().to_string(radix=16), content="ffffffff")
-  inspect((0 : Int16).to_uint(), content="0")
-  inspect((1 : Int16).to_uint(), content="1")
-}
-
-///|
-test "Int16::to_uint64" {
-  inspect((-1 : Int16).to_uint64(), content="18446744073709551615")
-  inspect(
-    (-1 : Int16).to_uint64().to_string(radix=16),
-    content="ffffffffffffffff",
-  )
-  inspect((0 : Int16).to_uint64(), content="0")
-  inspect((1 : Int16).to_uint64(), content="1")
-}

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -426,3 +426,24 @@ test "Int16::to_json" {
   inspect(Int16::to_json(32767), content="Number(32767)")
   inspect(Int16::to_json(-32768), content="Number(-32768)")
 }
+
+///|
+test "Int16::reinterpret_as_uint16" {
+  assert_eq((-1 : Int16).reinterpret_as_uint16(), @uint16.max_value)
+  assert_eq((0 : Int16).reinterpret_as_uint16(), (0 : UInt16))
+  assert_eq((1 : Int16).reinterpret_as_uint16(), (1 : UInt16))
+}
+
+///|
+test "Int16::reinterpret_as_uint64" {
+  assert_eq((-1 : Int16).to_uint(), @uint.max_value)
+  assert_eq((0 : Int16).to_uint(), (0 : UInt))
+  assert_eq((1 : Int16).to_uint(), (1 : UInt))
+}
+
+///|
+test "Int16::reinterpret_as_uint64" {
+  assert_eq((-1 : Int16).to_uint64(), @uint64.max_value)
+  assert_eq((0 : Int16).to_uint64(), (0 : UInt64))
+  assert_eq((1 : Int16).to_uint64(), (1 : UInt64))
+}

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -435,15 +435,20 @@ test "Int16::reinterpret_as_uint16" {
 }
 
 ///|
-test "Int16::reinterpret_as_uint64" {
-  assert_eq((-1 : Int16).to_uint(), @uint.max_value)
-  assert_eq((0 : Int16).to_uint(), (0 : UInt))
-  assert_eq((1 : Int16).to_uint(), (1 : UInt))
+test "Int16::to_uint" {
+  inspect((-1 : Int16).to_uint(), content="4294967295")
+  inspect((-1 : Int16).to_uint().to_string(radix=16), content="ffffffff")
+  inspect((0 : Int16).to_uint(), content="0")
+  inspect((1 : Int16).to_uint(), content="1")
 }
 
 ///|
-test "Int16::reinterpret_as_uint64" {
-  assert_eq((-1 : Int16).to_uint64(), @uint64.max_value)
-  assert_eq((0 : Int16).to_uint64(), (0 : UInt64))
-  assert_eq((1 : Int16).to_uint64(), (1 : UInt64))
+test "Int16::to_uint64" {
+  inspect((-1 : Int16).to_uint64(), content="18446744073709551615")
+  inspect(
+    (-1 : Int16).to_uint64().to_string(radix=16),
+    content="ffffffffffffffff",
+  )
+  inspect((0 : Int16).to_uint64(), content="0")
+  inspect((1 : Int16).to_uint64(), content="1")
 }

--- a/int16/moon.pkg.json
+++ b/int16/moon.pkg.json
@@ -2,5 +2,10 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/json"
+  ],
+  "test-import": [
+    "moonbitlang/core/uint16",
+    "moonbitlang/core/uint",
+    "moonbitlang/core/uint64"
   ]
 }

--- a/int16/moon.pkg.json
+++ b/int16/moon.pkg.json
@@ -1,11 +1,4 @@
 {
-  "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/json"
-  ],
-  "test-import": [
-    "moonbitlang/core/uint16",
-    "moonbitlang/core/uint",
-    "moonbitlang/core/uint64"
-  ]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/json"],
+  "test-import": ["moonbitlang/core/uint16"]
 }


### PR DESCRIPTION
This behavior is consistent with Rust's `as`, which first expands to the corresponding bit and then reinterprets it with binary complement.


https://doc.rust-lang.org/reference/expressions/operator-expr.html#numeric-cast