### PR TITLE
feat(prelude): export intrinsic type name

### DIFF
--- a/internal/intrinsic.mbt
+++ b/internal/intrinsic.mbt
@@ -1,0 +1,67 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub typealias Int16 as int16
+
+///|
+pub typealias Int as int
+
+///|
+pub typealias Int64 as int64
+
+///|
+pub typealias UInt16 as uint16
+
+///|
+pub typealias UInt as uint
+
+///|
+pub typealias UInt64 as uint64
+
+///|
+pub typealias Byte as byte
+
+///|
+pub typealias Float as float
+
+///|
+pub typealias Double as double
+
+///|
+pub typealias String as string
+
+///|
+pub typealias Bool as bool
+
+///|
+pub typealias Char as char
+
+///|
+pub typealias Unit as unit
+
+///|
+pub typealias Option as option
+
+///|
+pub typealias Result as result
+
+///|
+pub typealias FixedArray as fixedarray
+
+///|
+pub typealias Ref as ref_
+
+///|
+pub typealias Bytes as bytes

--- a/internal/moon.pkg.json
+++ b/internal/moon.pkg.json
@@ -1,0 +1,4 @@
+{
+  "import": ["moonbitlang/core/builtin"],
+  "warn-list": "-3"
+}

--- a/prelude/moon.pkg.json
+++ b/prelude/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/bigint",
     "moonbitlang/core/set",
-    "moonbitlang/core/array"
+    "moonbitlang/core/array",
+    "moonbitlang/core/internal"
   ]
 }

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -121,3 +121,25 @@ pub fn[T] tap(value : T, f : (T) -> Unit) -> T {
 pub fn[T, R] then(value : T, f : (T) -> R) -> R {
   f(value)
 }
+
+///|
+pub typealias @internal.(
+  int as Int,
+  int16 as Int16,
+  int64 as Int64,
+  uint as UInt,
+  uint16 as UInt16,
+  uint64 as UInt64,
+  float as Float,
+  double as Double,
+  byte as Byte,
+  bytes as Bytes,
+  ref_ as Ref,
+  fixedarray as FixedArray,
+  result as Result,
+  option as Option,
+  unit as Unit,
+  char as Char,
+  bool as Bool,
+  string as String
+)

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -49,11 +49,31 @@ pub typealias @builtin.ArrayView as ArrayView
 
 pub typealias @moonbitlang/core/bigint.BigInt as BigInt
 
+pub typealias Bool as Bool
+
+pub typealias Byte as Byte
+
+pub typealias Bytes as Bytes
+
+pub typealias Char as Char
+
+pub typealias Double as Double
+
 pub typealias @builtin.Failure as Failure
+
+pub typealias FixedArray as FixedArray
+
+pub typealias Float as Float
 
 pub typealias @builtin.Hasher as Hasher
 
 pub typealias @builtin.InspectError as InspectError
+
+pub typealias Int as Int
+
+pub typealias Int16 as Int16
+
+pub typealias Int64 as Int64
 
 pub typealias @builtin.Iter as Iter
 
@@ -65,15 +85,31 @@ pub typealias @builtin.Json as Json
 
 pub typealias @builtin.Map as Map
 
+pub typealias Option as Option
+
+pub typealias Ref as Ref
+
+pub typealias Result as Result
+
 pub typealias @moonbitlang/core/set.Set as Set
 
 pub typealias @builtin.SnapshotError as SnapshotError
 
 pub typealias @builtin.SourceLoc as SourceLoc
 
+pub typealias String as String
+
 pub typealias @builtin.StringBuilder as StringBuilder
 
+pub typealias UInt as UInt
+
+pub typealias UInt16 as UInt16
+
+pub typealias UInt64 as UInt64
+
 pub typealias @builtin.UninitializedArray as UninitializedArray
+
+pub typealias Unit as Unit
 
 pub traitalias @builtin.Add as Add
 


### PR DESCRIPTION
In order for the template for the moon test deriver to use fully qualified names.

https://github.com/moonbitlang/moon/tree/main/crates/moonbuild/template/test_driver

related issues:

https://github.com/moonbitlang/core/issues/1167

https://github.com/moonbitlang/moonbit-docs/issues/878

https://github.com/moonbitlang/moonbit-docs/issues/669

https://github.com/moonbitlang/core/issues/1899