### PR TITLE
Increase coverage with additional tests

### DIFF
--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -192,3 +192,13 @@ test "bench - monotonic clock functionality" {
   // Elapsed time should be non-negative
   inspect(elapsed >= 0.0, content="true")
 }
+
+///|
+test "bench - keep stores value" {
+  let b = new()
+  assert_eq(b.summaries.length(), 0)
+  b.keep(123)
+  assert_eq(b.summaries.length(), 0)
+  b.keep(456)
+  assert_eq(b.summaries.length(), 0)
+}

--- a/bench/stats.mbt
+++ b/bench/stats.mbt
@@ -229,3 +229,19 @@ test {
     "runs": 8,
   })
 }
+
+///|
+test "std_dev_pct zero mean" {
+  assert_eq(std_dev_pct(mean=0.0, std_dev=5.0), 0.0)
+}
+
+///|
+test "median_abs_dev_pct zero median" {
+  assert_eq(median_abs_dev_pct(median=0.0, median_abs_dev=3.0), 0.0)
+}
+
+///|
+test "percentile edge cases" {
+  assert_eq(percentile(sorted_data=[42.0], pct=50.0), 42.0)
+  assert_eq(percentile(sorted_data=[1.0, 2.0, 3.0], pct=100.0), 3.0)
+}

--- a/builtin/to_string.mbt
+++ b/builtin/to_string.mbt
@@ -159,6 +159,8 @@ test "to_string with radix" {
     1.0.reinterpret_as_uint64().to_string(radix=16),
     content="3ff0000000000000",
   )
+  inspect(0b101L.to_string(radix=2), content="101")
+  inspect(0o17L.to_string(radix=8), content="17")
 
   // UInt64
   inspect(0UL.to_string(radix=16), content="0")

--- a/bytes/xxhash.mbt
+++ b/bytes/xxhash.mbt
@@ -147,3 +147,11 @@ fn h16bytes(input : Bytes, cur : Int, len : Int, seed : Int) -> Int {
     seed - gPRIME1,
   )
 }
+
+///|
+test "Bytes hash_combine" {
+  let data : Bytes = [1, 2, 3, 4]
+  let hasher = Hasher::new()
+  data.hash_combine(hasher)
+  assert_true(hasher.finalize() != 0)
+}


### PR DESCRIPTION
## Summary
- add bench.keep test to ensure stored values are handled
- cover edge cases in statistics helpers
- exercise Int64 `to_string` with binary and octal radix
- test bytes hashing integration

## Testing
- `moon info`
- `moon fmt`
- `moon check`
- `moon test`

------
https://chatgpt.com/codex/tasks/task_e_68726f3becc08320ae946cc91a9f5614