### PR TITLE
Add abort panic test

### DIFF
--- a/abort/moon.pkg.json
+++ b/abort/moon.pkg.json
@@ -1,5 +1,8 @@
 {
   "virtual": {
     "has-default": true
+  },
+  "targets": {
+    "panic_test.mbt": ["not", "native", "llvm"]
   }
 }

--- a/abort/panic_test.mbt
+++ b/abort/panic_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "panic abort" {
+  abort("should panic")
+}


### PR DESCRIPTION
## Summary
- add a new panic test for the `abort` module
- run `moon info`, `moon fmt`, `moon check` and `moon test`

## Testing
- `moon info`
- `moon fmt`
- `moon check`
- `moon test`


------
https://chatgpt.com/codex/tasks/task_e_687305da00ac8320a1905ef604f34364