### PR TITLE
feat(deque): Implement rev and rev_inplace method with comprehensive test cases

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1588,3 +1588,76 @@ pub impl[A : Compare] Compare for T[A] with compare(self, other) {
   }
   0
 }
+
+///|
+/// Reverses the order of elements in the deque in place, modifying the original
+/// deque.
+///
+/// Parameters:
+///
+/// * `self` : The deque to be reversed.
+///
+/// Example:
+///
+/// ```moonbit
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   dq.rev_inplace()
+///   inspect(dq, content="@deque.of([5, 4, 3, 2, 1])")
+///
+///   let dq : @deque.T[Int] = @deque.new()
+///   dq.rev_inplace()
+///   inspect(dq, content="@deque.of([])")
+/// ```
+pub fn[A] T::rev_inplace(self : T[A]) -> Unit {
+  let len = self.len
+  let cap = self.buf.length()
+  // Only swap elements if deque is not empty
+  if len > 0 {
+    // Initialize two pointers
+    let mut left = self.head
+    let mut right = self.tail
+    let mut count = 0
+    // Swap elements until we reach the middle
+    while count < len / 2 {
+      // Swap elements at left and right indices
+      let temp = self.buf[left]
+      self.buf[left] = self.buf[right]
+      self.buf[right] = temp
+      // Move pointers in opposite directions
+      left = (left + 1) % cap
+      right = (right - 1 + cap) % cap
+      count += 1
+    }
+    // No need to update head and tail as the elements are swapped in place
+    // The structure remains the same, just the order of elements is reversed
+  }
+}
+
+///|
+/// Creates a new deque with elements in reversed order.
+///
+/// Parameters:
+///
+/// * `self` : The deque to be reversed.
+///
+/// Returns a new deque containing the same elements as the input deque but in
+/// reverse order. The original deque remains unchanged.
+///
+/// Example:
+///
+/// ```moonbit
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   inspect(dq.rev(), content="@deque.of([5, 4, 3, 2, 1])")
+///   inspect(dq, content="@deque.of([1, 2, 3, 4, 5])") // original deque unchanged
+/// ```
+pub fn[A] T::rev(self : T[A]) -> T[A] {
+  let len = self.len
+  let new_buf = UninitializedArray::make(len)
+  // Copy elements in reverse order
+  for i in 0..<len {
+    let src_idx = (self.head + len - i - 1) % self.buf.length()
+    new_buf[i] = self.buf[src_idx]
+  }
+  // Create new deque with reversed elements
+  T::{ buf: new_buf, len, head: 0, tail: if len == 0 { 0 } else { len - 1 } }
+}

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -52,8 +52,10 @@ fn[A] T::push_front(Self[A], A) -> Unit
 fn[A] T::reserve_capacity(Self[A], Int) -> Unit
 fn[A] T::retain(Self[A], (A) -> Bool) -> Unit
 fn[A] T::retain_map(Self[A], (A) -> A?) -> Unit
+fn[A] T::rev(Self[A]) -> Self[A]
 fn[A] T::rev_each(Self[A], (A) -> Unit) -> Unit
 fn[A] T::rev_eachi(Self[A], (Int, A) -> Unit) -> Unit
+fn[A] T::rev_inplace(Self[A]) -> Unit
 fn[A] T::rev_iter(Self[A]) -> Iter[A]
 fn[A] T::rev_iter2(Self[A]) -> Iter2[Int, A]
 fn[A : Eq] T::search(Self[A], A) -> Int?

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -1164,3 +1164,80 @@ test "deque_compare" {
   inspect(dq3.compare(dq1), content="-1")
   inspect(dq1.compare(dq1), content="0")
 }
+
+///|
+test "rev_inplace" {
+  // Test with odd number of elements
+  let dq = @deque.of([3, 4, 5])
+  dq.rev_inplace()
+  assert_eq(dq, @deque.of([5, 4, 3]))
+  dq.rev_inplace()
+  assert_eq(dq, @deque.of([3, 4, 5]))
+
+  // Test with even number of elements
+  let dq = @deque.of([3, 4])
+  dq.rev_inplace()
+  assert_eq(dq, @deque.of([4, 3]))
+  dq.rev_inplace()
+  assert_eq(dq, @deque.of([3, 4]))
+
+  // Test with empty deque
+  let empty : @deque.T[Int] = @deque.new()
+  empty.rev_inplace()
+  assert_eq(empty, @deque.of([]))
+
+  // Additional test with more elements
+  let dq = @deque.of([1, 2, 3, 4, 5])
+  dq.rev_inplace()
+  assert_eq(dq, @deque.of([5, 4, 3, 2, 1]))
+  dq.rev_inplace()
+  assert_eq(dq, @deque.of([1, 2, 3, 4, 5]))
+
+  // Test with snapped deque (NEW)
+  let dq = @deque.of([1, 2, 3, 4])
+  let snapped = dq.copy()
+  snapped.rev_inplace()
+  assert_eq(snapped, @deque.of([4, 3, 2, 1]))
+}
+
+///|
+test "rev" {
+  // Test with basic case
+  let dq = @deque.of([3, 4, 5])
+  let reversed = dq.rev()
+  assert_eq(dq, @deque.of([3, 4, 5])) // Original unchanged
+  assert_eq(reversed, @deque.of([5, 4, 3])) // Reversed order
+
+  // Test double reversal returns to original
+  let reversed_back = reversed.rev()
+  assert_eq(reversed_back, @deque.of([3, 4, 5]))
+
+  // Test with empty deque
+  let empty : @deque.T[Int] = @deque.new()
+  let empty_reversed = empty.rev()
+  assert_eq(empty, @deque.of([]))
+  assert_eq(empty_reversed, @deque.of([]))
+
+  // Test with single element
+  let single = @deque.of([42])
+  let single_reversed = single.rev()
+  assert_eq(single, @deque.of([42]))
+  assert_eq(single_reversed, @deque.of([42]))
+
+  // Test with even number of elements
+  let even = @deque.of([1, 2, 3, 4])
+  let even_reversed = even.rev()
+  assert_eq(even, @deque.of([1, 2, 3, 4]))
+  assert_eq(even_reversed, @deque.of([4, 3, 2, 1]))
+  let original = @deque.of([1, 2, 3, 4])
+  let copied = original.copy()
+  let copied_reversed = copied.rev()
+  assert_eq(original, @deque.of([1, 2, 3, 4])) // Original unchanged
+  assert_eq(copied_reversed, @deque.of([4, 3, 2, 1])) // Copied and reversed
+
+  // Test with larger deque
+  let large = @deque.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  let large_reversed = large.rev()
+  assert_eq(large, @deque.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+  assert_eq(large_reversed, @deque.of([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]))
+}


### PR DESCRIPTION
#### Changes

- Added a non-in-place `rev` method to the `deque` module, aligning with `Array.rev` behavior
- Includes extensive test coverage for edge cases and normal usage
- Maintains consistency with `Array.rev`: returns a new instance, leaves original unchanged

#### Implementation Details

- Uses `UninitializedArray` for new buffer allocation
- Correctly handles circular buffer index calculations
- Time complexity: O(n), Space complexity: O(n)