### PR TITLE
Add extra char show coverage

### DIFF
--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -248,6 +248,14 @@ test "char show hex digits" {
 }
 
 ///|
+test "char show hex digits extended" {
+  inspect((0x605).unsafe_to_char() |> repr, content="'\\u{605}'")
+  inspect((0xFDD0).unsafe_to_char() |> repr, content="'\\u{fdd0}'")
+  inspect((0x1FFFE).unsafe_to_char() |> repr, content="'\\u{1fffe}'")
+  inspect((0x10FFFE).unsafe_to_char() |> repr, content="'\\u{10fffe}'")
+}
+
+///|
 test "char_special" {
   inspect('\r', content="\r")
   inspect('\b', content="\u{8}")


### PR DESCRIPTION
## Summary
- expand `char show hex digits` tests to cover longer escape cases
- run `moon info`, `moon fmt`, `moon check`, and `moon test`

## Testing
- `moon fmt builtin/show_test.mbt`
- `moon info`
- `moon check`
- `moon test > /tmp/moon_test.log && tail -n 20 /tmp/moon_test.log`


------
https://chatgpt.com/codex/tasks/task_e_6875dc69ca508320ad07b4ef156c4834