### PR TITLE
feat(deque): add filter and filter_map method

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1661,3 +1661,68 @@ pub fn[A] T::rev(self : T[A]) -> T[A] {
   // Create new deque with reversed elements
   T::{ buf: new_buf, len, head: 0, tail: if len == 0 { 0 } else { len - 1 } }
 }
+
+///|
+/// Creates a new deque containing all elements from the input deque that satisfy
+/// the given predicate function.
+///
+/// Parameters:
+///
+/// * `self` : The deque to filter.
+/// * `f` : A function that takes an element and returns a boolean
+/// indicating whether the element should be included in the result.
+///
+/// Returns a new deque containing only the elements for which the predicate
+/// function returns `true`. The relative order of the elements is preserved.
+///
+/// Example:
+///
+/// ```moonbit
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   let evens = dq.filter((x) => { x % 2 == 0 })
+///   inspect(evens, content="@deque.of([2, 4])")
+/// ```
+pub fn[A] filter(self : T[A], f : (A) -> Bool raise?) -> T[A] raise? {
+  let result = new(capacity=self.capacity())
+  for v in self {
+    if f(v) {
+      result.push_back(v)
+    }
+  }
+  result
+}
+
+///| Reverses the order of elements in the deque in place, modifying the original
+/// deque.
+///
+/// Parameters:
+///
+/// * `self` : The deque to be reversed.
+///
+/// Example:
+///
+/// ```moonbit
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   
+///   // Keep even numbers and convert them to strings
+///   let result = dq.filter_map(fn(x) {
+///     if x % 2 == 0 {
+///       Some(x.to_string())
+///     } else {
+///       None
+///     }
+///   })
+///   
+///   inspect(result, content="@deque.of([\"2\", \"4\"])")
+/// ```
+///
+pub fn[A, B] filter_map(self : T[A], f : (A) -> B? raise?) -> T[B] raise? {
+  let result = new(capacity=self.capacity())
+  for x in self {
+    match f(x) {
+      Some(y) => result.push_back(y)
+      None => continue
+    }
+  }
+  result
+}

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -27,6 +27,8 @@ fn[A] T::copy(Self[A]) -> Self[A]
 fn[A] T::drain(Self[A], start~ : Int, len? : Int) -> Self[A]
 fn[A] T::each(Self[A], (A) -> Unit) -> Unit
 fn[A] T::eachi(Self[A], (Int, A) -> Unit) -> Unit
+fn[A] T::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
+fn[A, B] T::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 #deprecated
 fn[A] T::filter_map_inplace(Self[A], (A) -> A?) -> Unit
 fn[A] T::flatten(Self[Self[A]]) -> Self[A]

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -1259,3 +1259,101 @@ test "rev" {
   let dq3_reversed = dq3.rev()
   @json.inspect(dq3_reversed.as_views(), content=[[6, 5, 4, 3], []])
 }
+
+///|
+test "filter_map basic" {
+  let dq = @deque.of([1, 2, 3, 4, 5])
+
+  // Keep even numbers and convert to strings
+  let result = dq.filter_map(fn(x) {
+    if x % 2 == 0 {
+      Some(x.to_string())
+    } else {
+      None
+    }
+  })
+  inspect(result, content="@deque.of([\"2\", \"4\"])")
+}
+
+///| Test filter_map with all elements filtered out
+test "filter_map empty result" {
+  let dq = @deque.of([1, 3, 5])
+  let result = dq.filter_map(fn(x) {
+    if x % 2 == 0 {
+      Some(x.to_string())
+    } else {
+      None
+    }
+  })
+  inspect(result.length(), content="0")
+  inspect(result.capacity(), content="3")
+}
+
+///| Test filter_map with error propagation
+test "filter_map error propagation" {
+  let dq = @deque.of([1, 2, 3])
+  let v = try? dq.filter_map(fn(x) {
+      if x == 2 {
+        raise Failure("Error at 2")
+      }
+      Some(x * 2)
+    })
+  inspect(
+    v,
+    content=(
+      #|Err(Failure("Error at 2"))
+    ),
+  )
+}
+
+///| Basic filter test
+test "filter basic" {
+  let dq = @deque.of([1, 2, 3, 4, 5])
+  let evens = dq.filter(fn(x) { x % 2 == 0 })
+  inspect(evens, content="@deque.of([2, 4])")
+  inspect(evens.capacity(), content="5") // Should retain original capacity
+}
+
+///| Test filter with empty result
+test "filter empty result" {
+  let dq = @deque.of([1, 3, 5])
+  let result = dq.filter(fn(x) { x % 2 == 0 })
+  inspect(result.length(), content="0")
+  inspect(result.is_empty(), content="true")
+}
+
+///| Test filter with error propagation
+test "filter error propagation" {
+  let dq = @deque.of([1, 2, 3])
+  try
+    dq.filter(fn(x) {
+      if x == 2 {
+        raise Failure("Error at 2")
+      }
+      x % 2 == 0
+    })
+  catch {
+    Failure(msg) => inspect(msg, content="Error at 2")
+  } noraise {
+    _ => assert_true(false)
+  }
+}
+
+///| Test filter preserves order
+test "filter order preservation" {
+  let dq = @deque.of([3, 1, 4, 1, 5, 9, 2])
+  let odds = dq.filter(fn(x) { x % 2 != 0 })
+  inspect(odds, content="@deque.of([3, 1, 1, 5, 9])")
+}
+
+///| Test filter with large deque
+test "filter large deque" {
+  let dq = @deque.new(capacity=100)
+  for i in 1..=100 {
+    dq.push_back(i)
+  }
+  let multiples_of_7 = dq.filter(fn(x) { x % 7 == 0 })
+  inspect(multiples_of_7.length(), content="14") // 100/7 ≈ 14
+  inspect(multiples_of_7.front(), content="Some(7)")
+  inspect(multiples_of_7.back(), content="Some(98)")
+}


### PR DESCRIPTION
## Description
Implements `deque.filter` to select elements based on a predicate function:
- Preserves original element order
- Time complexity: O(n)
- Space complexity: O(k) (k = number of filtered elements)
