### PR TITLE
feat(deque): implement extract_if method

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1661,3 +1661,62 @@ pub fn[A] T::rev(self : T[A]) -> T[A] {
   // Create new deque with reversed elements
   T::{ buf: new_buf, len, head: 0, tail: if len == 0 { 0 } else { len - 1 } }
 }
+
+///|
+/// Extracts elements from a deque that satisfy a given predicate function. The
+/// extracted elements are removed from the original deque and returned as a new
+/// deque. The relative order of the extracted elements is preserved.
+///
+/// Parameters:
+///
+/// * `self` : The deque to extract elements from (will be modified).
+/// * `f` : A predicate function that:
+///   - Takes an element of type `A`
+///   - Returns `true` to extract the element, `false` to leave it
+///
+/// Returns a new deque containing all extracted elements in their original order.
+///
+/// Implementation notes:
+/// - Uses O(n) time and O(k) extra space (where k = number of extracted elements)
+/// - Preserves deque's ring buffer structure during extraction
+/// - Maintains correct head/tail pointers after modification
+///
+/// Example:
+///
+/// ```moonbit
+///   let dq = @deque.of([1, 2, 3, 4, 5])
+///   let extracted = dq.extract_if((x) => { x % 2 == 0 })
+///   inspect(extracted, content="@deque.of([2, 4])")
+///   inspect(dq, content="@deque.of([1, 3, 5])")
+/// ```
+pub fn[A] extract_if(self : T[A], f : (A) -> Bool) -> T[A] {
+  let result = new()
+  let mut processed = 0
+  let mut write_pos = self.head
+  while processed < self.len {
+    let read_pos = (self.head + processed) % self.buf.length()
+    let element = self.buf[read_pos]
+    if f(element) {
+      result.push_back(element)
+      set_null(self.buf, read_pos)
+    } else {
+      if write_pos != read_pos {
+        self.buf[write_pos] = element
+        set_null(self.buf, read_pos)
+      }
+      write_pos = (write_pos + 1) % self.buf.length()
+    }
+    processed += 1
+  }
+  self.len = if write_pos >= self.head {
+    write_pos - self.head
+  } else {
+    self.buf.length() - self.head + write_pos
+  }
+  self.tail = if self.len > 0 {
+    (write_pos - 1 + self.buf.length()) % self.buf.length()
+  } else {
+    0
+  }
+  result
+}

--- a/deque/deque.mbti
+++ b/deque/deque.mbti
@@ -27,6 +27,7 @@ fn[A] T::copy(Self[A]) -> Self[A]
 fn[A] T::drain(Self[A], start~ : Int, len? : Int) -> Self[A]
 fn[A] T::each(Self[A], (A) -> Unit) -> Unit
 fn[A] T::eachi(Self[A], (Int, A) -> Unit) -> Unit
+fn[A] T::extract_if(Self[A], (A) -> Bool) -> Self[A]
 #deprecated
 fn[A] T::filter_map_inplace(Self[A], (A) -> A?) -> Unit
 fn[A] T::flatten(Self[Self[A]]) -> Self[A]

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -1259,3 +1259,73 @@ test "rev" {
   let dq3_reversed = dq3.rev()
   @json.inspect(dq3_reversed.as_views(), content=[[6, 5, 4, 3], []])
 }
+
+///|
+/// Test suite for deque.extract_if
+///
+
+///| Basic functionality test
+test "extract_if basic" {
+  let dq = @deque.of([1, 2, 3, 4, 5])
+  let extracted = dq.extract_if(fn(x) { x % 2 == 0 })
+
+  // Verify extracted elements
+  inspect(extracted, content="@deque.of([2, 4])")
+  // Verify remaining elements
+  inspect(dq, content="@deque.of([1, 3, 5])")
+  // Verify lengths
+  inspect(extracted.length(), content="2")
+  inspect(dq.length(), content="3")
+}
+
+///| Test with no elements extracted
+test "extract_if empty result" {
+  let dq = @deque.of([1, 3, 5])
+  let extracted = dq.extract_if(fn(x) { x % 2 == 0 })
+  inspect(extracted.is_empty(), content="true")
+  inspect(dq.length(), content="0")
+}
+
+///| Test with all elements extracted
+test "extract_if all elements" {
+  let dq = @deque.of([2, 4, 6])
+  let extracted = dq.extract_if(fn(x) { x % 2 == 0 })
+  inspect(extracted.length(), content="3")
+  inspect(dq.is_empty(), content="true")
+}
+
+///| Test with circular buffer wrap-around
+test "extract_if with wrap-around" {
+  // Create deque that forces buffer wrap
+  let dq = @deque.new(capacity=3)
+  dq.push_back(1)
+  dq.push_back(2)
+  dq.push_back(3)
+  dq.pop_front() |> ignore
+  let extracted = dq.extract_if(fn(x) { x >= 2 })
+  inspect(extracted, content="@deque.of([2, 3])")
+}
+
+///| Test order preservation
+test "extract_if order preservation" {
+  let dq = @deque.of([3, 1, 4, 1, 5, 9])
+  let extracted = dq.extract_if(fn(x) { x % 2 != 0 })
+  inspect(extracted, content="@deque.of([3, 1, 1, 5, 9])")
+  inspect(dq, content="@deque.of([4])")
+}
+
+///| Test with large deque
+test "extract_if large deque" {
+  let dq = @deque.new(capacity=100)
+  for i in 1..=100 {
+    dq.push_back(i)
+  }
+  let extracted = dq.extract_if(fn(x) { x % 7 == 0 })
+
+  // Should extract 14 elements (100/7 ≈ 14)
+  inspect(extracted.length(), content="14")
+  inspect(dq.length(), content="86")
+  // Verify first/last extracted
+  inspect(extracted.front(), content="Some(7)")
+  inspect(extracted.back(), content="Some(98)")
+}


### PR DESCRIPTION
## Feature Description
Implements a new `extract_if` method for deques that:
- Extracts elements matching a predicate from the original deque
- Modifies the original deque in-place
- Preserves original element order
- Handles circular buffer edge cases correctly

## Implementation
1. **Circular Buffer Handling**: