### PR TITLE
Increase string and map test coverage

### DIFF
--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -249,3 +249,45 @@ test "range" {
   }
   inspect(buf, content="[2b][3c][4d]")
 }
+
+///|
+// Additional tests for iterator early exits and default
+
+test "iter early break" {
+  let map = @sorted_map.from_array([(1, "a"), (2, "b"), (3, "c")])
+  inspect(
+    map.iter().take(1).to_array(),
+    content=(
+      #|[(1, "a")]
+    ),
+  )
+}
+
+///|
+test "iter2 early break" {
+  let map = @sorted_map.from_array([(1, "a"), (2, "b"), (3, "c")])
+  inspect(
+    map.iter2().iter().take(1).to_array(),
+    content=(
+      #|[(1, "a")]
+    ),
+  )
+}
+
+///|
+test "range early break" {
+  let map = @sorted_map.from_array([(1, "a"), (2, "b"), (3, "c")])
+  let r = map.range(1, 3)
+  inspect(
+    r.iter().take(1).to_array(),
+    content=(
+      #|[(1, "a")]
+    ),
+  )
+}
+
+///|
+test "default impl" {
+  let map : @sorted_map.T[Int, String] = Default::default()
+  inspect(map.size(), content="0")
+}

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -64,3 +64,38 @@ test "panic String::char_at with out of bounds offset" {
   let last = s.char_at(len - 1)
   inspect(last, content="'o'")
 }
+
+///|
+// Tests for deprecated String utilities
+
+test "String::concat deprecated" {
+  let result = String::concat(["a", "b", "c"], separator=",")
+  inspect(result, content="a,b,c")
+  inspect(String::concat([], separator=","), content="")
+  inspect(String::concat(["x"], separator="-"), content="x")
+}
+
+///|
+test "index_of deprecated" {
+  inspect("banana".index_of("na", from=0), content="2")
+  inspect("banana".index_of("na", from=3), content="4")
+  inspect("banana".index_of("xyz", from=0), content="-1")
+  inspect("abc".index_of("", from=0), content="0")
+  inspect("abc".index_of("", from=10), content="3")
+}
+
+///|
+test "last_index_of deprecated" {
+  inspect("banana".last_index_of("na"), content="4")
+  inspect("banana".last_index_of("na", from=4), content="2")
+  inspect("banana".last_index_of("xyz"), content="-1")
+  inspect("abc".last_index_of("", from=-1), content="3")
+}
+
+///|
+test "starts_with and ends_with deprecated" {
+  inspect("hello".starts_with("he"), content="true")
+  inspect("hello".starts_with("lo"), content="false")
+  inspect("hello".ends_with("lo"), content="true")
+  inspect("hello".ends_with("he"), content="false")
+}


### PR DESCRIPTION
## Summary
- add tests for deprecated string helpers
- add tests exercising early breaks in sorted_map iteration

## Testing
- `moon test`
- `moon coverage analyze`


------
https://chatgpt.com/codex/tasks/task_e_6876089ca2908320a9ae2821c59b5472