### PR TITLE
refactor string and stringview methods

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -504,8 +504,6 @@ fn String::codepoint_at(String, Int) -> Char
 #deprecated
 fn String::codepoint_length(String, start_offset~ : Int = .., end_offset? : Int) -> Int
 fn String::escape(String) -> String
-#deprecated
-fn String::get(String, Int) -> Char
 fn String::length(String) -> Int
 fn String::make(Int, Char) -> String
 fn String::op_get(String, Int) -> Int

--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -508,8 +508,7 @@ fn String::escape(String) -> String
 fn String::get(String, Int) -> Char
 fn String::length(String) -> Int
 fn String::make(Int, Char) -> String
-#deprecated
-fn String::op_get(String, Int) -> Char
+fn String::op_get(String, Int) -> Int
 fn String::substring(String, start~ : Int = .., end? : Int) -> String
 fn String::to_string(String) -> String
 fn String::unsafe_char_at(String, Int) -> Char

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1528,8 +1528,15 @@ pub fn String::length(self : String) -> Int = "%string_length"
 pub fn String::charcode_length(self : String) -> Int = "%string_length"
 
 ///|
-#deprecated("use `String::charcode_at` and `Int::to_char` instead")
-pub fn String::op_get(self : String, idx : Int) -> Char = "%string_get"
+/// Returns the UTF-16 code unit at the given index.
+///
+/// Parameters:
+///
+/// * `string` : The string to access.
+/// * `index` : The position in the string from which to retrieve the code unit.
+///
+/// This method has O(1) complexity.
+pub fn String::op_get(self : String, idx : Int) -> Int = "%string_get"
 
 ///|
 /// Retrieves the character at the specified index in a string.

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1539,29 +1539,6 @@ pub fn String::charcode_length(self : String) -> Int = "%string_length"
 pub fn String::op_get(self : String, idx : Int) -> Int = "%string_get"
 
 ///|
-/// Retrieves the character at the specified index in a string.
-///
-/// Parameters:
-///
-/// * `string` : The string to access.
-/// * `index` : The position in the string from which to retrieve the character.
-///
-/// Returns a Unicode character at the specified position in the string.
-///
-/// Throws a runtime error if the index is negative or greater than or equal to
-/// the length of the string.
-///
-/// Example:
-///
-/// ```moonbit
-///   let s = "Hello, 世界"
-///   inspect(s.charcode_at(0), content="72")
-///   inspect(s.char_at(7), content="世")
-/// ```
-#deprecated("use `charcode_at` instead")
-pub fn String::get(self : String, idx : Int) -> Char = "%string_get"
-
-///|
 /// Returns the UTF-16 code unit at a given position in the string without
 /// performing bounds checking. This is a low-level function that provides direct
 /// access to the internal representation of the string.

--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -19,40 +19,6 @@ pub fn String::concat(self : Array[String], separator~ : String = "") -> String 
 }
 
 ///|
-fn index_at_(self : String, offset_by : Int, start~ : Int = 0) -> Int? {
-  if self.offset_of_nth_char(offset_by, start_offset=start) is Some(index) {
-    Some(index)
-  } else if offset_by == self.char_length(start_offset=start) {
-    Some(self.length())
-  } else {
-    None
-  }
-}
-
-///|
-fn index_at_rev_(self : String, offset_by : Int, end? : Int) -> Int? {
-  match end {
-    Some(end) =>
-      if offset_by == 0 {
-        Some(end)
-      } else if self.offset_of_nth_char(-offset_by, end_offset=end)
-        is Some(index) {
-        Some(index)
-      } else {
-        None
-      }
-    None =>
-      if offset_by == 0 {
-        Some(self.length())
-      } else if self.offset_of_nth_char(-offset_by) is Some(index) {
-        Some(index)
-      } else {
-        None
-      }
-  }
-}
-
-///|
 #deprecated("Use `Array::join` instead.")
 pub fn concat(strings : Array[String], separator~ : String = "") -> String {
   match strings {

--- a/string/deprecated.mbt
+++ b/string/deprecated.mbt
@@ -53,59 +53,6 @@ fn index_at_rev_(self : String, offset_by : Int, end? : Int) -> Int? {
 }
 
 ///|
-#deprecated("use str.charcodes(start = str.offset_of_nth_char(i).unwrap(), end = str.offset_of_nth_char(j).unwrap()) to replace str[i:j]")
-#coverage.skip
-pub fn String::op_as_view(self : String, start~ : Int = 0, end? : Int) -> View {
-  let str_len = self.length()
-  let start = if start >= 0 {
-    self.index_at_(start, start=0).unwrap()
-  } else {
-    self.index_at_rev_(-start, end=str_len).unwrap()
-  }
-  let end = match end {
-    Some(end) =>
-      if end >= 0 {
-        self.index_at_(end, start=0).unwrap()
-      } else {
-        self.index_at_rev_(-end, end=str_len).unwrap()
-      }
-    None => str_len
-  }
-  guard start >= 0 && start <= end && end <= str_len else {
-    abort("Invalid index for View")
-  }
-  { str: self, start, end }
-}
-
-///|
-#deprecated("use view.charcodes(start = view.offset_of_nth_char(i).unwrap(), end = view.offset_of_nth_char(j).unwrap()) to replace view[i:j]")
-#coverage.skip
-pub fn View::op_as_view(self : View, start~ : Int = 0, end? : Int) -> View {
-  let start = if start >= 0 {
-    self.str.index_at_(start, start=self.start).unwrap()
-  } else {
-    self.str.index_at_rev_(-start, end=self.end).unwrap()
-  }
-  let end = match end {
-    Some(end) =>
-      if end >= 0 {
-        self.str.index_at_(end, start=self.start).unwrap()
-      } else {
-        self.str.index_at_rev_(-end, end=self.end).unwrap()
-      }
-    None => self.end
-  }
-  guard start >= self.start &&
-    start <= self.end &&
-    end >= self.start &&
-    end <= self.end &&
-    start <= end else {
-    abort("Invalid index for View")
-  }
-  { str: self.str, start, end }
-}
-
-///|
 #deprecated("Use `Array::join` instead.")
 pub fn concat(strings : Array[String], separator~ : String = "") -> String {
   match strings {

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -1102,3 +1102,125 @@ test "rev_fold" {
     111 + 108 + 108 + 101 + 104,
   )
 }
+
+///|
+/// Returns the UTF-16 code unit at the given index. Returns `None` if the index
+/// is out of bounds.
+pub fn String::get(self : String, idx : Int) -> Int? {
+  guard idx >= 0 && idx < self.length() else { return None }
+  Some(self.unsafe_charcode_at(idx))
+}
+
+///|
+/// Returns the UTF-16 code unit at the given index. Returns `None` if the index
+/// is out of bounds.
+pub fn View::get(self : View, idx : Int) -> Int? {
+  guard idx >= 0 && idx < self.length() else { return None }
+  Some(self.unsafe_charcode_at(idx))
+}
+
+///|
+test "String::get supports emoji (surrogate pair)" {
+  let s = "hello"
+  inspect(s.get(0), content="Some(104)")
+  inspect(s.get(4), content="Some(111)")
+  inspect(s.get(5), content="None")
+  inspect(s.get(-1), content="None")
+  let s = "a🤣b"
+  inspect(s.get(0), content="Some(97)")
+  inspect(s.get(1), content="Some(55358)")
+  inspect(s.get(2), content="Some(56611)")
+  inspect(s.get(3), content="Some(98)")
+  inspect(s.get(4), content="None")
+}
+
+///|
+test "View::get basic cases" {
+  let v = "hello"[1:-1]
+  inspect(v.get(0), content="Some(101)")
+  inspect(v.get(2), content="Some(108)")
+  inspect(v.get(3), content="None")
+  inspect(v.get(-1), content="None")
+  let v = "ab🤣cd"[1:-1]
+  inspect(v.get(0), content="Some(98)")
+  inspect(v.get(1), content="Some(55358)")
+  inspect(v.get(2), content="Some(56611)")
+}
+
+///|
+/// Returns the character at the given index. Returns `None` if the index is out
+/// of bounds or the index splits a surrogate pair.
+pub fn String::get_char(self : String, idx : Int) -> Char? {
+  guard idx >= 0 && idx < self.length() else { return None }
+  let c = self.unsafe_charcode_at(idx)
+  if is_leading_surrogate(c) {
+    guard idx + 1 < self.length() else { return None }
+    let next = self.unsafe_charcode_at(idx + 1)
+    if is_trailing_surrogate(next) {
+      Some(code_point_of_surrogate_pair(c, next))
+    } else {
+      None
+    }
+  } else if is_trailing_surrogate(c) {
+    None
+  } else {
+    Some(c.unsafe_to_char())
+  }
+}
+
+///|
+/// Returns the character at the given index. Returns `None` if the index is out
+/// of bounds or the index splits a surrogate pair.
+pub fn View::get_char(self : View, idx : Int) -> Char? {
+  guard idx >= 0 && idx < self.length() else { return None }
+  let c = self.unsafe_charcode_at(idx)
+  if is_leading_surrogate(c) {
+    guard idx + 1 < self.length() else { return None }
+    let next = self.unsafe_charcode_at(idx + 1)
+    if is_trailing_surrogate(next) {
+      Some(code_point_of_surrogate_pair(c, next))
+    } else {
+      None
+    }
+  } else if is_trailing_surrogate(c) {
+    None
+  } else {
+    Some(c.unsafe_to_char())
+  }
+}
+
+///|
+test "String::get_char basic cases" {
+  // Basic ASCII characters
+  let s = "hello"
+  inspect(s.get_char(0), content="Some('h')")
+  inspect(s.get_char(1), content="Some('e')")
+  inspect(s.get_char(4), content="Some('o')")
+  inspect(s.get_char(5), content="None")
+  inspect(s.get_char(-1), content="None")
+
+  // Contains emoji (surrogate pair)
+  let s = "a🤣b"
+  inspect(s.get_char(0), content="Some('a')")
+  inspect(s.get_char(1), content="Some('🤣')")
+  inspect(s.get_char(2), content="None") // Second half of surrogate pair is not a valid char
+  inspect(s.get_char(3), content="Some('b')")
+  inspect(s.get_char(4), content="None")
+}
+
+///|
+test "View::get_char basic cases" {
+  let s = "a🤣b"
+  let v = s[0:-1]
+  inspect(v.get_char(0), content="Some('a')")
+  inspect(v.get_char(1), content="Some('🤣')")
+  inspect(v.get_char(2), content="None")
+  inspect(v.get_char(3), content="None")
+  inspect(v.get_char(4), content="None")
+
+  // Test substring view
+  let v2 = s[1:3] // Only contains the emoji surrogate pair
+  inspect(v2.get_char(0), content="Some('🤣')")
+  inspect(v2.get_char(1), content="None")
+  inspect(v2.get_char(2), content="None")
+}

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -32,6 +32,8 @@ fn StringView::find_by(Self, (Char) -> Bool) -> Int?
 fn[A] StringView::fold(Self, init~ : A, (A, Char) -> A) -> A
 fn StringView::from_array(Array[Char]) -> Self
 fn StringView::from_iter(Iter[Char]) -> Self
+fn StringView::get(Self, Int) -> Int?
+fn StringView::get_char(Self, Int) -> Char?
 fn StringView::has_prefix(Self, Self) -> Bool
 fn StringView::has_suffix(Self, Self) -> Bool
 fn StringView::is_blank(Self) -> Bool
@@ -84,6 +86,8 @@ fn String::find_by(String, (Char) -> Bool) -> Int?
 fn[A] String::fold(String, init~ : A, (A, Char) -> A) -> A
 fn String::from_array(Array[Char]) -> String
 fn String::from_iter(Iter[Char]) -> String
+fn String::get(String, Int) -> Int?
+fn String::get_char(String, Int) -> Char?
 fn String::has_prefix(String, StringView) -> Bool
 fn String::has_suffix(String, StringView) -> Bool
 #deprecated

--- a/string/string.mbti
+++ b/string/string.mbti
@@ -11,6 +11,12 @@ fn from_array(Array[Char]) -> String
 fn from_iter(Iter[Char]) -> String
 
 // Types and methods
+pub suberror CreatingViewError {
+  IndexOutOfBounds
+  InvalidIndex
+}
+impl Show for CreatingViewError
+
 type StringView
 fn StringView::char_at(Self, Int) -> Char
 fn StringView::char_length(Self) -> Int
@@ -35,8 +41,7 @@ fn StringView::iter2(Self) -> Iter2[Int, Char]
 fn StringView::length(Self) -> Int
 fn StringView::make(Int, Char) -> Self
 fn StringView::offset_of_nth_char(Self, Int) -> Int?
-#deprecated
-fn StringView::op_as_view(Self, start~ : Int = .., end? : Int) -> Self
+fn StringView::op_as_view(Self, start~ : Int = .., end? : Int) -> Self raise CreatingViewError
 fn StringView::op_get(Self, Int) -> Int
 fn StringView::pad_end(Self, Int, Char) -> String
 fn StringView::pad_start(Self, Int, Char) -> String
@@ -90,8 +95,7 @@ fn String::iter2(String) -> Iter2[Int, Char]
 #deprecated
 fn String::last_index_of(String, String, from? : Int) -> Int
 fn String::offset_of_nth_char(String, Int, start_offset~ : Int = .., end_offset? : Int) -> Int?
-#deprecated
-fn String::op_as_view(String, start~ : Int = .., end? : Int) -> StringView
+fn String::op_as_view(String, start~ : Int = .., end? : Int) -> StringView raise CreatingViewError
 fn String::pad_end(String, Int, Char) -> String
 fn String::pad_start(String, Int, Char) -> String
 fn String::repeat(String, Int) -> String

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -388,3 +388,151 @@ pub impl Hash for View with hash_combine(self : View, hasher : Hasher) -> Unit {
     hasher.combine_uint(self.unsafe_charcode_at(i).reinterpret_as_uint())
   }
 }
+
+///|
+pub suberror CreatingViewError {
+  IndexOutOfBounds
+  InvalidIndex
+} derive(Show)
+
+///|
+/// Creates a view of a string with proper UTF-16 boundary validation.
+/// 
+/// # Parameters
+/// 
+/// - `start` : Starting UTF-16 code unit index (default: 0)
+///   - If positive: counts from the beginning of the string
+///   - If negative: counts from the end of the string (e.g., -1 means last position)
+/// - `end` : Ending UTF-16 code unit index (optional)
+///   - If `None`: extends to the end of the string
+///   - If positive: counts from the beginning of the string
+///   - If negative: counts from the end of the string
+/// 
+/// # Returns
+/// 
+/// - A `View` representing the specified substring range
+/// 
+/// # Errors
+/// 
+/// - `IndexOutOfBounds` : If start or end indices are out of valid range
+/// - `InvalidIndex` : If start or end position would split a UTF-16 surrogate pair
+/// 
+/// This prevents creating views that would split surrogate pairs, which would
+/// result in invalid Unicode characters.
+/// 
+/// # Performance
+/// 
+/// This function has O(1) complexity as it only performs boundary checks
+/// without scanning the string content.
+/// 
+/// # Examples
+/// 
+/// ```mbt
+///   let str = "Hello🤣World"
+///   let view1 = try? str[0:5]
+///   inspect(view1, content=(
+///   #|Ok("Hello")
+/// ))
+///   let view2 = try? str[-5:]
+///   inspect(view2, content=(
+///   #|Ok("World")
+/// ))
+///   let view3 = try? str[:6]
+///   inspect(view3, content="Err(InvalidIndex)")
+/// ```
+pub fn String::op_as_view(
+  self : String,
+  start~ : Int = 0,
+  end? : Int
+) -> View raise CreatingViewError {
+  let len = self.length()
+  let end = match end {
+    None => len
+    Some(end) => if end < 0 { len + end } else { end }
+  }
+  let start = if start < 0 { len + start } else { start }
+  guard start >= 0 && start <= end && end <= len else { raise IndexOutOfBounds }
+  if start < len && is_trailing_surrogate(self.unsafe_charcode_at(start)) {
+    raise InvalidIndex
+  }
+  if end < len && is_trailing_surrogate(self.unsafe_charcode_at(end)) {
+    raise InvalidIndex
+  }
+  { str: self, start, end }
+}
+
+///|
+/// Creates a subview of an existing view with proper UTF-16 boundary validation.
+/// 
+/// # Parameters
+/// 
+/// - `start` : Starting UTF-16 code unit index relative to this view (default: 0)
+///   - If positive: counts from the beginning of this view
+///   - If negative: counts from the end of this view
+/// - `end` : Ending UTF-16 code unit index relative to this view (optional)
+///   - If `None`: extends to the end of this view
+///   - If positive: counts from the beginning of this view
+///   - If negative: counts from the end of this view
+/// 
+/// # Returns
+/// 
+/// - A `View` representing the specified subrange of this view
+/// 
+/// # Errors
+/// 
+/// - `IndexOutOfBounds` : If start or end indices are out of this view's range
+/// - `InvalidIndex` : If start or end position would split a UTF-16 surrogate pair
+/// 
+/// This prevents creating views that would split surrogate pairs, which would
+/// result in invalid Unicode characters.
+/// 
+/// # Performance
+/// 
+/// This function has O(1) complexity as it only performs boundary checks
+/// without scanning the string content.
+/// 
+/// # Examples
+/// 
+/// ```mbt
+///   let str = "Hello🤣World"[1:-1] // "ello🤣Worl"
+///   let view1 = try? str[0:6]
+///   inspect(view1, content=(
+///   #|Ok("ello🤣")
+/// ))
+///   let view2 = try? str[-2:]
+///   inspect(view2, content=(
+///   #|Ok("rl")
+/// ))
+///   let view3 = try? str[:5]
+///   inspect(view3, content=("Err(InvalidIndex)"))
+/// ```
+pub fn View::op_as_view(
+  self : View,
+  start~ : Int = 0,
+  end? : Int
+) -> View raise CreatingViewError {
+  let str_len = self.str.length()
+
+  // Calculate absolute positions in the original string
+  let abs_end = match end {
+    None => self.end
+    Some(end) => if end < 0 { self.end + end } else { self.start + end }
+  }
+  let abs_start = if start < 0 { self.end + start } else { self.start + start }
+
+  // Validate bounds against the original string
+  guard abs_start >= self.start && abs_start <= abs_end && abs_end <= self.end else {
+    raise IndexOutOfBounds
+  }
+
+  // Check for surrogate pair boundaries
+  if abs_start < str_len &&
+    is_trailing_surrogate(self.str.unsafe_charcode_at(abs_start)) {
+    raise InvalidIndex
+  }
+  if abs_end < str_len &&
+    is_trailing_surrogate(self.str.unsafe_charcode_at(abs_end)) {
+    raise InvalidIndex
+  }
+  { str: self.str, start: abs_start, end: abs_end }
+}

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -705,3 +705,285 @@ test "View::split take" {
     ),
   )
 }
+
+///|
+test "String::op_as_view basic usage" {
+  let str = "Hello🤣World"
+
+  // Basic usage - positive indices
+  let view1 = str[0:5]
+  inspect(view1, content="Hello")
+
+  // Negative indexing from end
+  let view2 = str[-5:]
+  inspect(view2, content="World")
+
+  // Full string view
+  let view3 = str[:]
+  inspect(view3, content="Hello🤣World")
+
+  // Start from middle
+  let view4 = str[5:]
+  inspect(view4, content="🤣World")
+
+  // End before middle
+  let view5 = str[:5]
+  inspect(view5, content="Hello")
+}
+
+///|
+test "String::op_as_view error cases" {
+  let str = "Hello🤣World"
+
+  // InvalidIndex - splits surrogate pair
+  let view1 = try? str[:6]
+  inspect(view1, content="Err(InvalidIndex)")
+
+  // IndexOutOfBounds - beyond string length
+  let view2 = try? str[0:20]
+  inspect(view2, content="Err(IndexOutOfBounds)")
+
+  // IndexOutOfBounds - negative index too large
+  let view3 = try? str[-20:]
+  inspect(view3, content="Err(IndexOutOfBounds)")
+
+  // IndexOutOfBounds - start > end
+  let view4 = try? str[5:3]
+  inspect(view4, content="Err(IndexOutOfBounds)")
+
+  // InvalidIndex - start on trailing surrogate
+  let view5 = try? str[6:8]
+  inspect(view5, content="Err(InvalidIndex)")
+}
+
+///|
+test "String::op_as_view with surrogate pairs" {
+  let str = "Hello🤣😭😂World"
+
+  // View containing complete emoji
+  let view1 = str[5:7]
+  inspect(view1, content="🤣")
+
+  // View containing multiple emojis
+  let view2 = str[5:11]
+  inspect(view2, content="🤣😭😂")
+
+  // View from middle of emoji sequence
+  let view3 = str[7:9]
+  inspect(view3, content="😭")
+
+  // Invalid - splits first emoji
+  let view4 = try? str[5:6]
+  inspect(view4, content="Err(InvalidIndex)")
+
+  // Invalid - splits second emoji
+  let view5 = try? str[7:8]
+  inspect(view5, content="Err(InvalidIndex)")
+}
+
+///|
+test "View::op_as_view basic usage" {
+  let str = "Hello🤣World"[1:-1] // "ello🤣Worl"
+
+  // Basic subview creation
+  let view1 = str[0:6]
+  inspect(view1, content="ello🤣")
+
+  // Negative indexing within view
+  let view2 = str[-2:]
+  inspect(view2, content="rl")
+
+  // Full view
+  let view3 = str[:]
+  inspect(view3, content="ello🤣Worl")
+
+  // Start from middle
+  let view4 = str[4:]
+  inspect(view4, content="🤣Worl")
+
+  // End before middle
+  let view5 = str[:4]
+  inspect(view5, content="ello")
+}
+
+///|
+test "View::op_as_view error cases" {
+  let str = "Hello🤣World"[1:-1] // "ello🤣Worl"
+
+  // IndexOutOfBounds - beyond view range
+  let view1 = try? str[0:15]
+  inspect(view1, content="Err(IndexOutOfBounds)")
+
+  // IndexOutOfBounds - negative index too large
+  let view2 = try? str[-20:]
+  inspect(view2, content="Err(IndexOutOfBounds)")
+
+  // IndexOutOfBounds - start > end
+  let view3 = try? str[5:3]
+  inspect(view3, content="Err(IndexOutOfBounds)")
+
+  // InvalidIndex - splits surrogate pair
+  let view4 = try? str[:5]
+  inspect(view4, content="Err(InvalidIndex)")
+
+  // IndexOutOfBounds - start beyond view
+  let view5 = try? str[11:]
+  inspect(view5, content="Err(IndexOutOfBounds)")
+}
+
+///|
+test "View::op_as_view with surrogate pairs" {
+  let str = "Hello🤣😭😂World"[1:-1] // "ello🤣😭😂Worl"
+
+  // View containing complete emoji
+  let view1 = str[4:6]
+  inspect(view1, content="🤣")
+
+  // View containing multiple emojis
+  let view2 = str[4:10]
+  inspect(view2, content="🤣😭😂")
+
+  // View from middle of emoji sequence
+  let view3 = str[6:8]
+  inspect(view3, content="😭")
+
+  // Invalid - splits first emoji
+  let view4 = try? str[4:5]
+  inspect(view4, content="Err(InvalidIndex)")
+
+  // Invalid - splits second emoji
+  let view5 = try? str[6:7]
+  inspect(view5, content="Err(InvalidIndex)")
+}
+
+///|
+test "nested View::op_as_view operations" {
+  let str = "Hello🤣World"
+
+  // Create first view
+  let view1 = str[1:-1] // "ello🤣Worl"
+  inspect(view1, content="ello🤣Worl")
+
+  // Create subview from first view
+  let view2 = view1[2:6] // "lo🤣"
+  inspect(view2, content="lo🤣")
+
+  // Create subview from second view
+  let view3 = view2[2:] // "🤣"
+  inspect(view3, content="🤣")
+
+  // Create subview with negative indexing
+  let view4 = view1[-4:-1] // "Wor"
+  inspect(view4, content="Wor")
+}
+
+///|
+test "View::op_as_view edge cases" {
+  let str = "Hello🤣World"
+
+  // Empty view at start
+  let view1 = str[0:0]
+  inspect(view1, content="")
+
+  // Empty view at end
+  let view2 = str[str.length():str.length()]
+  inspect(view2, content="")
+
+  // Single character view
+  let view3 = str[0:1]
+  inspect(view3, content="H")
+
+  // Single emoji view
+  let view4 = str[5:7]
+  inspect(view4, content="🤣")
+
+  // View with only ASCII characters
+  let view5 = str[0:5]
+  inspect(view5, content="Hello")
+}
+
+///|
+test "View::op_as_view with complex Unicode" {
+  let str = "Hello🤣😭😂🌍World"
+
+  // View with multiple emojis
+  let view1 = str[5:13]
+  inspect(view1, content="🤣😭😂🌍")
+
+  // View with mixed content
+  let view2 = str[4:14]
+  inspect(view2, content="o🤣😭😂🌍W")
+
+  // View ending with emoji
+  let view3 = str[-7:]
+  inspect(view3, content="🌍World")
+
+  // View starting with emoji
+  let view4 = str[5:]
+  inspect(view4, content="🤣😭😂🌍World")
+
+  // Invalid - splits emoji
+  let view5 = try? str[5:6]
+  inspect(view5, content="Err(InvalidIndex)")
+}
+
+///|
+test "View::op_as_view performance characteristics" {
+  let str = "Hello🤣World"
+
+  // Test that operations are O(1) - multiple operations
+  let view1 = str[1:-1]
+  let view2 = view1[1:-1]
+  let view3 = view2[1:-1]
+  let view4 = view3[1:-1]
+  inspect(view4, content="o🤣W")
+
+  // Test with longer string
+  let long_str = "Hello🤣WorldHello🤣WorldHello🤣World"
+  let long_view1 = long_str[5:15]
+  let long_view2 = long_view1[2:8]
+  inspect(long_view2, content="WorldH")
+}
+
+///|
+test "View::op_as_view with empty and single character strings" {
+  let empty_str = ""
+
+  // Empty string operations
+  let view1 = empty_str[:]
+  inspect(view1, content="")
+  let view2 = empty_str[0:0]
+  inspect(view2, content="")
+
+  // Single character string
+  let single_str = "A"
+  let view3 = single_str[:]
+  inspect(view3, content="A")
+  let view4 = single_str[0:1]
+  inspect(view4, content="A")
+  let view5 = single_str[0:0]
+  inspect(view5, content="")
+}
+
+///|
+test "View::op_as_view boundary validation" {
+  let str = "Hello🤣World"
+
+  // Test boundary conditions
+  let view1 = str[0:str.length()]
+  inspect(view1, content="Hello🤣World")
+  let view2 = str[str.length():str.length()]
+  inspect(view2, content="")
+
+  // Test negative boundary conditions
+  let view3 = str[-str.length():]
+  inspect(view3, content="Hello🤣World")
+  let view4 = str[-1:]
+  inspect(view4, content="d")
+
+  // Test invalid boundaries
+  let view5 = try? str[str.length() + 1:]
+  inspect(view5, content="Err(IndexOutOfBounds)")
+  let view6 = try? str[-str.length() - 1:]
+  inspect(view6, content="Err(IndexOutOfBounds)")
+}


### PR DESCRIPTION
* Added back `op_as_view` so that the syntax `s[i:j]` can be used. The taking view method now may raise error if the given index is invalid (out of bound or splitting surrogate pair), so the use site must handle the possible errors. One exception is `s[:]`, which is specially handled by the compiler and does not need error handling.
* Changed the return value of method `op_get` from `Char` to `Int`. This is a changed planned for a few months and now landed.
* Added `get` and `get_char` methods that return `Int?` and `Char?`