### PR TITLE
feat: parse number for uint64/int64/bigint

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -45,13 +45,27 @@ pub impl ToJson for BigInt with to_json(self : BigInt) -> Json {
 
 ///|
 pub impl @json.FromJson for BigInt with from_json(json, path) {
-  guard json is String(s) else {
-    raise @json.JsonDecodeError(
-      (path, "BigInt::from_json: expected number in string representation"),
-    )
+  match json {
+    Number(n, repr~) =>
+      if n != @double.infinity && n != @double.neg_infinity {
+        if n < 0 {
+          BigInt::from_int64(n.to_int64())
+        } else {
+          BigInt::from_uint64(n.to_uint64())
+        }
+      } else {
+        raise @json.JsonDecodeError(
+          (path, "BigInt::from_json: invalid number representation \{repr}"),
+        )
+      }
+    String(s) => BigInt::from_string(s)
+    _ =>
+      raise @json.JsonDecodeError(
+        (
+          path, "BigInt::from_json: expected number in number or string representation",
+        ),
+      )
   }
-  // TODO: Capture parse failure
-  BigInt::from_string(s)
 }
 
 ///|

--- a/bigint/moon.pkg.json
+++ b/bigint/moon.pkg.json
@@ -6,7 +6,8 @@
     "moonbitlang/core/json",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix",
-    "moonbitlang/core/string"
+    "moonbitlang/core/string",
+    "moonbitlang/core/double"
   ],
   "targets": {
     "bigint_js.mbt": ["js"],

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -55,13 +55,30 @@ pub impl FromJson for Int with from_json(json, path) {
 
 ///|
 pub impl FromJson for Int64 with from_json(json, path) {
-  guard json is String(str) else {
-    decode_error(
-      path, "Int64::from_json: expected number in string representation",
-    )
-  }
-  @strconv.parse_int64(str) catch {
-    error => decode_error(path, "Int64::from_json: parsing failure \{error}")
+  match json {
+    Number(n, repr~) =>
+      if n != @double.infinity && n != @double.neg_infinity {
+        n.to_int64()
+      } else if repr is Some(str) {
+        @strconv.parse_int64(str) catch {
+          error =>
+            decode_error(path, "Int64::from_json: parsing failure \{error}")
+        }
+      } else {
+        decode_error(
+          path,
+          "Int64::from_json: invalid number representation \{repr}",
+        )
+      }
+    String(str) =>
+      @strconv.parse_int64(str) catch {
+        error =>
+          decode_error(path, "Int64::from_json: parsing failure \{error}")
+      }
+    _ =>
+      decode_error(
+        path, "Int64::from_json: expected number in number or string representation",
+      )
   }
 }
 
@@ -77,13 +94,30 @@ pub impl FromJson for UInt with from_json(json, path) {
 
 ///|
 pub impl FromJson for UInt64 with from_json(json, path) {
-  guard json is String(str) else {
-    decode_error(
-      path, "UInt64::from_json: expected number in string representation",
-    )
-  }
-  @strconv.parse_uint64(str) catch {
-    error => decode_error(path, "UInt64::from_json: parsing failure \{error}")
+  match json {
+    Number(n, repr~) =>
+      if n != @double.infinity && n != @double.neg_infinity {
+        n.to_uint64()
+      } else if repr is Some(str) {
+        @strconv.parse_uint64(str) catch {
+          error =>
+            decode_error(path, "UInt64::from_json: parsing failure \{error}")
+        }
+      } else {
+        decode_error(
+          path,
+          "UInt64::from_json: invalid number representation \{repr}",
+        )
+      }
+    String(str) =>
+      @strconv.parse_uint64(str) catch {
+        error =>
+          decode_error(path, "UInt64::from_json: parsing failure \{error}")
+      }
+    _ =>
+      decode_error(
+        path, "UInt64::from_json: expected number in number or string representation",
+      )
   }
 }
 

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -544,10 +544,7 @@ test "Bool from_json error handling" {
 test "Int64 from_json error handling" {
   let json_number = Json::number(123)
   let result : Result[Int64, _] = try? @json.from_json(json_number)
-  inspect(
-    result,
-    content="Err(JsonDecodeError(($, \"Int64::from_json: expected number in string representation\")))",
-  )
+  inspect(result, content="Ok(123)")
   let json_invalid_string = Json::string("not a number")
   let result : Result[Int64, _] = try? @json.from_json(json_invalid_string)
   inspect(
@@ -570,15 +567,14 @@ test "UInt from_json error handling" {
 test "UInt64 from_json error handling" {
   let json_number = Json::number(123)
   let result : Result[UInt64, _] = try? @json.from_json(json_number)
-  inspect(
-    result,
-    content="Err(JsonDecodeError(($, \"UInt64::from_json: expected number in string representation\")))",
-  )
+  inspect(result, content="Ok(123)")
   let json_invalid_string = Json::string("not a number")
   let result : Result[UInt64, _] = try? @json.from_json(json_invalid_string)
   inspect(
     result,
-    content="Err(JsonDecodeError(($, \"UInt64::from_json: parsing failure invalid syntax\")))",
+    content=(
+      #|Err(JsonDecodeError(($, "UInt64::from_json: parsing failure invalid syntax")))
+    ),
   )
 }
 
@@ -628,12 +624,22 @@ test "Char from_json error handling" {
 test "BigInt from_json error handling" {
   let json_number = Json::number(123)
   let result : Result[BigInt, _] = try? @json.from_json(json_number)
+  inspect(result, content="Ok(123)")
+  let json_number = Json::number(@double.infinity)
+  let result : Result[BigInt, _] = try? @json.from_json(json_number)
   inspect(
     result,
     content=(
-      #|Err(JsonDecodeError(($, "BigInt::from_json: expected number in string representation")))
+      #|Err(JsonDecodeError(($, "BigInt::from_json: invalid number representation None")))
     ),
   )
+}
+
+///|
+test "panic BigInt from_json invalid input" {
+  let json_invalid_string = Json::string("not a number")
+  let _ : Result[BigInt, _] = try? @json.from_json(json_invalid_string)
+
 }
 
 ///|

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -542,14 +542,44 @@ test "Bool from_json error handling" {
 
 ///|
 test "Int64 from_json error handling" {
+  // Parse from valid number, which were invalid
   let json_number = Json::number(123)
   let result : Result[Int64, _] = try? @json.from_json(json_number)
   inspect(result, content="Ok(123)")
+  let json_number = Json::number(
+    @double.infinity,
+    repr=@int64.max_value.to_string(),
+  )
+  let result : Result[Int64, _] = try? @json.from_json(json_number)
+  assert_eq(result, Ok(@int64.max_value))
+  let json_number = Json::number(
+    @double.infinity,
+    repr=@int64.min_value.to_string(),
+  )
+  let result : Result[Int64, _] = try? @json.from_json(json_number)
+  assert_eq(result, Ok(@int64.min_value))
+
+  // Parse from invalid string representation
   let json_invalid_string = Json::string("not a number")
   let result : Result[Int64, _] = try? @json.from_json(json_invalid_string)
   inspect(
     result,
     content="Err(JsonDecodeError(($, \"Int64::from_json: parsing failure invalid syntax\")))",
+  )
+  let json_invalid_string = Json::number(@double.infinity, repr="not a number")
+  let result : Result[Int64, _] = try? @json.from_json(json_invalid_string)
+  inspect(
+    result,
+    content="Err(JsonDecodeError(($, \"Int64::from_json: parsing failure invalid syntax\")))",
+  )
+  // Parse from invalid number representation
+  let json_invalid_number = Json::boolean(true)
+  let result : Result[Int64, _] = try? @json.from_json(json_invalid_number)
+  inspect(
+    result,
+    content=(
+      #|Err(JsonDecodeError(($, "Int64::from_json: expected number in number or string representation")))
+    ),
   )
 }
 
@@ -565,15 +595,41 @@ test "UInt from_json error handling" {
 
 ///|
 test "UInt64 from_json error handling" {
+  // Parse from valid number, which were invalid
   let json_number = Json::number(123)
   let result : Result[UInt64, _] = try? @json.from_json(json_number)
   inspect(result, content="Ok(123)")
+  let json_number = Json::number(
+    @double.infinity,
+    repr=@uint64.max_value.to_string(),
+  )
+  let result : Result[UInt64, _] = try? @json.from_json(json_number)
+  assert_eq(result, Ok(@uint64.max_value))
+
+  // Parse from invalid string representation
   let json_invalid_string = Json::string("not a number")
   let result : Result[UInt64, _] = try? @json.from_json(json_invalid_string)
   inspect(
     result,
     content=(
       #|Err(JsonDecodeError(($, "UInt64::from_json: parsing failure invalid syntax")))
+    ),
+  )
+  let json_invalid_string = Json::number(@double.infinity, repr="not a number")
+  let result : Result[UInt64, _] = try? @json.from_json(json_invalid_string)
+  inspect(
+    result,
+    content=(
+      #|Err(JsonDecodeError(($, "UInt64::from_json: parsing failure invalid syntax")))
+    ),
+  )
+  // Parse from invalid number representation
+  let json_invalid_number = Json::boolean(true)
+  let result : Result[UInt64, _] = try? @json.from_json(json_invalid_number)
+  inspect(
+    result,
+    content=(
+      #|Err(JsonDecodeError(($, "UInt64::from_json: expected number in number or string representation")))
     ),
   )
 }

--- a/json/moon.pkg.json
+++ b/json/moon.pkg.json
@@ -11,6 +11,8 @@
     "moonbitlang/core/result",
     "moonbitlang/core/unit",
     "moonbitlang/core/array",
-    "moonbitlang/core/bigint"
+    "moonbitlang/core/bigint",
+    "moonbitlang/core/int64",
+    "moonbitlang/core/uint64"
   ]
 }


### PR DESCRIPTION
Now that we've changed the representation of `Number`, we can parse arbitrary length number. This PR relaxes the restriction upon the `from_int` implementation to accept numbers as well.

Notice though that the `BigInt::from_string` currently just panics if the string doesn't looks like a number. This should be adjusted in the future.