### PR TITLE
refactor(random): use value type for performance

### DIFF
--- a/random/moon.pkg.json
+++ b/random/moon.pkg.json
@@ -5,5 +5,8 @@
     "moonbitlang/core/random/internal/random_source",
     "moonbitlang/core/bigint"
   ],
-  "test-import": ["moonbitlang/core/float"]
+  "test-import": [
+    "moonbitlang/core/float",
+    "moonbitlang/core/bench"
+  ]
 }

--- a/random/random_test.mbt
+++ b/random/random_test.mbt
@@ -73,3 +73,12 @@ test "uint64 modulo bias handling with large limit" {
   let result = r.uint64(limit~)
   inspect(result < limit, content="true")
 }
+
+///|
+test "bench random" (b : @bench.T) {
+  let r = @random.Rand::new()
+  b.bench(() => for i in 0..<1000000 {
+    let _ = r.uint64(limit=10000000000000000000UL)
+
+  })
+}


### PR DESCRIPTION
Before:
```
bench moonbitlang/core/random/random_test.mbt::bench random
time (mean ± σ)         range (min … max) 
 129.01 ms ± 362.74 µs   128.63 ms … 129.75 ms  in 10 ×      1 runs
```

After:
```
bench moonbitlang/core/random/random_test.mbt::bench random
time (mean ± σ)         range (min … max) 
  67.28 ms ± 381.11 µs    66.52 ms …  67.72 ms  in 10 ×      2 runs
```