### PR TITLE
feat: add min/max built-in function

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -594,6 +594,8 @@ impl BitXOr for UInt64
 
 pub(open) trait Compare : Eq {
   compare(Self, Self) -> Int
+  max(Self, Self) -> Self = _
+  min(Self, Self) -> Self = _
 }
 impl Compare for Bool
 impl Compare for Byte

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -20,13 +20,34 @@ pub(open) trait Eq {
 
 ///|
 /// Trait for types whose elements are ordered
-///
-/// The return value of [compare] is:
-/// - zero, if the two arguments are equal
-/// - negative, if the first argument is smaller
-/// - positive, if the first argument is greater
 pub(open) trait Compare: Eq {
+  // Compares two values and returns an integer indicating their order.
+  // - zero, if the two arguments are equal
+  // - negative, if the first argument is smaller
+  // - positive, if the first argument is greater
   compare(Self, Self) -> Int
+  // Compares and returns the maximum of two values.
+  max(Self, Self) -> Self = _
+  // Compares and returns the minimum of two values.
+  min(Self, Self) -> Self = _
+}
+
+///|
+impl Compare with max(self, other) {
+  if self > other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+impl Compare with min(self, other) {
+  if self < other {
+    self
+  } else {
+    other
+  }
 }
 
 ///|

--- a/cmp/cmp_test.mbt
+++ b/cmp/cmp_test.mbt
@@ -118,3 +118,11 @@ test "maximum and minimum with negative numbers" {
   assert_eq(@cmp.maximum(0, -1), 0)
   assert_eq(@cmp.minimum(0, -1), -1)
 }
+
+///|
+test "max and min fn" {
+  let v1 = 1
+  let v2 = 2
+  assert_eq(v1.max(2), v2)
+  assert_eq(v1.min(1), v1)
+}


### PR DESCRIPTION
This pull request introduces enhancements to the Compare trait by adding new methods for determining the maximum and minimum of two values.

Similar helper functions are commonly found in other modern programming languages, [rust](https://doc.rust-lang.org/std/cmp/trait.Ord.html#method.min) for example.

These methods serve as convenient and expressive shortcuts in everyday code, eliminating the need for verbose conditional logic like if-else or ternary expressions just to pick the smaller or larger of two values. They also improve readability and maintainability, especially when used in chains, comparisons, or when embedded in more complex expressions.