### PR TITLE
fix: add bound check for array

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -58,14 +58,14 @@ pub fn[T] Array::from_fixed_array(arr : FixedArray[T]) -> Array[T] {
 ///   let arr = Array::make(3, 42)
 ///   inspect(arr, content="[42, 42, 42]")
 /// ```
-/// 
+///
 /// WARNING: A common pitfall is creating with the same initial value, for example:
 /// ```moonbit
 ///   let two_dimension_array = Array::make(10, Array::make(10, 0))
 ///   two_dimension_array[0][5] = 10
 ///   assert_eq(two_dimension_array[5][5], 10)
 /// ```
-/// This is because all the cells reference to the same object (the Array[Int] in this case). 
+/// This is because all the cells reference to the same object (the Array[Int] in this case).
 /// One should use makei() instead which creates an object for each index.
 pub fn[T] Array::make(len : Int, elem : T) -> Array[T] {
   let arr = Array::make_uninit(len)
@@ -1379,7 +1379,8 @@ pub fn[T] Array::extract_if(self : Array[T], f : (T) -> Bool) -> Array[T] {
 /// Parameters:
 ///
 /// * `array` : The array to be divided into chunks.
-/// * `size` : The size of each chunk. Must be a positive integer.
+/// * `size` : The size of each chunk. Must be a positive integer, otherwise it will panic.
+///
 ///
 /// Returns an array of arrays, where each inner array is a chunk containing
 /// elements from the original array. If the length of the original array is not
@@ -1396,6 +1397,7 @@ pub fn[T] Array::extract_if(self : Array[T], f : (T) -> Bool) -> Array[T] {
 ///   inspect(arr.chunks(3), content="[]")
 /// ```
 pub fn[T] Array::chunks(self : Array[T], size : Int) -> Array[Array[T]] {
+  guard size > 0
   let chunks = []
   let mut i = 0
   while i < self.length() {
@@ -1458,7 +1460,7 @@ pub fn[T] Array::chunk_by(
 /// Parameters:
 ///
 /// * `array` : The array to be processed with sliding windows.
-/// * `size` : The window length. Must be a positive integer.
+/// * `size` : The window length. Must be a positive integer, otherwise it will panic.
 ///
 /// Returns an array of slices, where each inner slice is a contiguous subslice
 /// of the original array. Windows are produced with a step size of 1. If the
@@ -1476,6 +1478,7 @@ pub fn[T] Array::chunk_by(
 ///   inspect(arr.windows(3), content="[]")
 /// ```
 pub fn[T] Array::windows(self : Array[T], size : Int) -> Array[ArrayView[T]] {
+  guard size > 0
   let len = self.length() - size + 1
   if len < 1 {
     return []
@@ -1642,7 +1645,7 @@ pub fn[A] Array::unsafe_pop_back(self : Array[A]) -> Unit {
 ///|
 /// Truncates the array in-place to the specified length.
 ///
-/// If `len` is greater than or equal to the current array length, 
+/// If `len` is greater than or equal to the current array length,
 /// the function does nothing. If `len` is 0, the array is cleared.
 /// Otherwise, removes elements from the end until the array reaches the given length.
 ///
@@ -1651,7 +1654,7 @@ pub fn[A] Array::unsafe_pop_back(self : Array[A]) -> Unit {
 /// * `self` : The target array (modified in-place).
 /// * `len` : The new desired length (must be non-negative).
 ///
-/// Important: 
+/// Important:
 ///   - If `len` is negative, the function does nothing.
 ///   - If `len` exceeds current length, the array remains unchanged.
 ///

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -446,6 +446,13 @@ test "array_chunks" {
 }
 
 ///|
+test "panic_array_chunks_by_zero" {
+  let arr = [1, 2, 3, 4, 5]
+  let _ = arr.chunks(0)
+
+}
+
+///|
 test "array_chunks_by" {
   let v = [1, 1, 2, 3, 2, 3, 2, 3, 4]
   inspect(
@@ -463,6 +470,13 @@ test "array_windows" {
   inspect(windows, content="[[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]")
   let windows = arr.windows(1)
   inspect(windows, content="[[1], [2], [3], [4], [5], [6]]")
+}
+
+///|
+test "panic_array_windows_by_zero" {
+  let arr = [1, 2, 3, 4, 5]
+  let _ = arr.windows(0)
+
 }
 
 ///|


### PR DESCRIPTION
This PR introduces stricter input validation for array chunking and windowing methods in `builtin/array.mbt`, ensuring that the `size` parameter must be a positive integer.