### PR TITLE
feat: add next_power_of_two fn

### DIFF
--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -13,31 +13,6 @@
 // limitations under the License.
 
 ///|
-fn power_2_above(x : Int, n : Int) -> Int {
-  for i = x {
-    if i >= n {
-      break i
-    }
-    let next = i << 1
-    if next < 0 {
-      // overflow happened
-      break i
-    }
-    continue next
-  }
-}
-
-///|
-test "power_2_above" {
-  inspect(power_2_above(1, 15), content="16")
-  inspect(power_2_above(1, 16), content="16")
-  inspect(power_2_above(1, 17), content="32")
-  inspect(power_2_above(1, 32), content="32")
-  inspect(power_2_above(128, 33), content="128")
-  inspect(power_2_above(1, 2147483647), content="1073741824")
-}
-
-///|
 /// Creates a new empty hash map with the specified initial capacity. The actual
 /// capacity will be rounded up to the next power of 2 that is greater than or
 /// equal to the requested capacity, with a minimum of 8.
@@ -58,7 +33,7 @@ test "power_2_above" {
 ///   inspect(map.is_empty(), content="true")
 /// ```
 pub fn[K, V] new(capacity~ : Int = 8) -> T[K, V] {
-  let capacity = power_2_above(8, capacity)
+  let capacity = @cmp.maximum(8, capacity).next_power_of_two()
   {
     size: 0,
     capacity,

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -33,7 +33,7 @@
 ///   inspect(map.is_empty(), content="true")
 /// ```
 pub fn[K, V] new(capacity~ : Int = 8) -> T[K, V] {
-  let capacity = @cmp.maximum(8, capacity).next_power_of_two()
+  let capacity = capacity.next_power_of_two()
   {
     size: 0,
     capacity,

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -5,7 +5,6 @@
     "moonbitlang/core/array",
     "moonbitlang/core/tuple",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/cmp",
     "moonbitlang/core/int"
   ],
   "test-import": ["moonbitlang/core/string", "moonbitlang/core/json"]

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -4,7 +4,9 @@
     "moonbitlang/core/test",
     "moonbitlang/core/array",
     "moonbitlang/core/tuple",
-    "moonbitlang/core/quickcheck"    
+    "moonbitlang/core/quickcheck",
+    "moonbitlang/core/cmp",
+    "moonbitlang/core/int"
   ],
   "test-import": ["moonbitlang/core/string", "moonbitlang/core/json"]
 }

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -59,7 +59,9 @@ pub fn to_le_bytes(self : Int) -> Bytes {
 
 ///|
 /// Returns the smallest power of two greater than or equal to `self`.
-/// This function will panic if `self` is negative or greater than `max_value / 2`.
+/// This function will panic if `self` is negative. For values greater than
+/// the largest representable power of two (2^30 = 1073741824), it returns
+/// the largest representable power of two.
 ///
 /// Example:
 /// ```moonbit
@@ -69,11 +71,17 @@ pub fn to_le_bytes(self : Int) -> Bytes {
 ///   inspect((3).next_power_of_two(), content="4")
 ///   inspect((8).next_power_of_two(), content="8")
 ///   inspect((1073741824).next_power_of_two(), content="1073741824")
+///   inspect((2000000000).next_power_of_two(), content="1073741824")
 /// ```
 pub fn next_power_of_two(self : Int) -> Int {
-  guard self >= 0 && self <= (max_value >> 1) + 1
+  guard self >= 0
   if self <= 1 {
     return 1
+  }
+  // The largest power of 2 that fits in a 32-bit signed integer is 2^30
+  let max_power_of_two = 1073741824 // 2^30
+  if self > max_power_of_two {
+    return max_power_of_two
   }
   (max_value >> ((self - 1).clz() - 1)) + 1
 }

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -56,3 +56,24 @@ pub fn to_be_bytes(self : Int) -> Bytes {
 pub fn to_le_bytes(self : Int) -> Bytes {
   self.reinterpret_as_uint().to_le_bytes()
 }
+
+///|
+/// Returns the smallest power of two greater than or equal to `self`.
+/// This function will panic if `self` is negative or greater than `max_value / 2`.
+///
+/// Example:
+/// ```moonbit
+///   inspect((0).next_power_of_two(), content="1")
+///   inspect((1).next_power_of_two(), content="1")
+///   inspect((2).next_power_of_two(), content="2")
+///   inspect((3).next_power_of_two(), content="4")
+///   inspect((8).next_power_of_two(), content="8")
+///   inspect((1073741824).next_power_of_two(), content="1073741824")
+/// ```
+pub fn next_power_of_two(self : Int) -> Int {
+  guard self >= 0 && self <= (max_value >> 1) + 1
+  if self <= 1 {
+    return 1
+  }
+  (max_value >> ((self - 1).clz() - 1)) + 1
+}

--- a/int/int.mbti
+++ b/int/int.mbti
@@ -9,6 +9,7 @@ let min_value : Int
 // Types and methods
 fn Int::abs(Int) -> Int
 fnalias Int::abs
+fn Int::next_power_of_two(Int) -> Int
 fn Int::to_be_bytes(Int) -> Bytes
 fn Int::to_le_bytes(Int) -> Bytes
 

--- a/set/grow_heuristic.mbt
+++ b/set/grow_heuristic.mbt
@@ -13,31 +13,6 @@
 // limitations under the License.
 
 ///|
-fn power_2_above(x : Int, n : Int) -> Int {
-  for i = x {
-    if i >= n {
-      break i
-    }
-    let next = i << 1
-    if next < 0 {
-      // overflow happened
-      break i
-    }
-    continue next
-  }
-}
-
-///|
-test "power_2_above" {
-  inspect(power_2_above(1, 15), content="16")
-  inspect(power_2_above(1, 16), content="16")
-  inspect(power_2_above(1, 17), content="32")
-  inspect(power_2_above(1, 32), content="32")
-  inspect(power_2_above(128, 33), content="128")
-  inspect(power_2_above(1, 2147483647), content="1073741824")
-}
-
-///|
 fn calc_grow_threshold(capacity : Int) -> Int {
   capacity * 13 / 16
 }

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -53,7 +53,7 @@ struct Set[K] {
 /// The capacity of the set will be the smallest power of 2 that is
 /// greater than or equal to the provided [capacity].
 pub fn[K] Set::new(capacity~ : Int = 8) -> Set[K] {
-  let capacity = @cmp.maximum(8, capacity).next_power_of_two()
+  let capacity = capacity.next_power_of_two()
   {
     size: 0,
     capacity,

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -53,7 +53,7 @@ struct Set[K] {
 /// The capacity of the set will be the smallest power of 2 that is
 /// greater than or equal to the provided [capacity].
 pub fn[K] Set::new(capacity~ : Int = 8) -> Set[K] {
-  let capacity = power_2_above(8, capacity)
+  let capacity = @cmp.maximum(8, capacity).next_power_of_two()
   {
     size: 0,
     capacity,

--- a/set/moon.pkg.json
+++ b/set/moon.pkg.json
@@ -1,6 +1,8 @@
 {
   "import": [
-    "moonbitlang/core/builtin"
+    "moonbitlang/core/builtin",
+    "moonbitlang/core/int",
+    "moonbitlang/core/cmp"
   ],
   "test-import": [
     "moonbitlang/core/json",

--- a/set/moon.pkg.json
+++ b/set/moon.pkg.json
@@ -1,8 +1,7 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/int",
-    "moonbitlang/core/cmp"
+    "moonbitlang/core/int"
   ],
   "test-import": [
     "moonbitlang/core/json",


### PR DESCRIPTION
This PR adds a `next_power_of_two` fn to the `Int`, which is is particularly useful in systems programming and performance-sensitive applications. Two common use cases are:
1. Memory Allocation Alignment
2. HashMap Capacity Management

This PR also removed duplicate fn `power_2_above` in the codebase by utilizing this new fn