### PR TITLE
refactor: migrate is_leading_surrogate/is_trailing_surrogate to Int methods

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -340,10 +340,12 @@ fn Int::asr(Int, Int) -> Int
 fn Int::clamp(Int, min~ : Int, max~ : Int) -> Int
 fn Int::clz(Int) -> Int
 fn Int::ctz(Int) -> Int
+fn Int::is_leading_surrogate(Int) -> Bool
 fn Int::is_neg(Int) -> Bool
 fn Int::is_non_neg(Int) -> Bool
 fn Int::is_non_pos(Int) -> Bool
 fn Int::is_pos(Int) -> Bool
+fn Int::is_trailing_surrogate(Int) -> Bool
 fn Int::land(Int, Int) -> Int
 fn Int::lnot(Int) -> Int
 fn Int::lor(Int, Int) -> Int

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -434,9 +434,9 @@ pub fn String::codepoint_at(self : String, index : Int) -> Char {
       char_count < charcode_len && utf16_offset < index
       char_count = char_count + 1, utf16_offset = utf16_offset + 1 {
     let c1 = self.unsafe_charcode_at(char_count)
-    if is_leading_surrogate(c1) && char_count + 1 < charcode_len {
+    if c1.is_leading_surrogate() && char_count + 1 < charcode_len {
       let c2 = self.unsafe_charcode_at(char_count + 1)
-      if is_trailing_surrogate(c2) {
+      if c2.is_trailing_surrogate() {
         continue char_count + 2, utf16_offset + 1
       } else {
         abort("invalid surrogate pair")
@@ -447,9 +447,9 @@ pub fn String::codepoint_at(self : String, index : Int) -> Char {
       abort("index out of bounds")
     }
     let c1 = self.unsafe_charcode_at(char_count)
-    if is_leading_surrogate(c1) && char_count + 1 < charcode_len {
+    if c1.is_leading_surrogate() && char_count + 1 < charcode_len {
       let c2 = self.unsafe_charcode_at(char_count + 1)
-      if is_trailing_surrogate(c2) {
+      if c2.is_trailing_surrogate() {
         code_point_of_surrogate_pair(c1, c2)
       } else {
         abort("invalid surrogate pair")
@@ -481,7 +481,7 @@ pub fn String::charcode_at(self : String, index : Int) -> Int {
 #deprecated("Use `s.get_char(i).unwrap()` instead")
 pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
   let c1 = self.unsafe_charcode_at(index)
-  if is_leading_surrogate(c1) {
+  if c1.is_leading_surrogate() {
     let c2 = self.unsafe_charcode_at(index + 1)
     code_point_of_surrogate_pair(c1, c2)
   } else {

--- a/builtin/int.mbt
+++ b/builtin/int.mbt
@@ -94,3 +94,33 @@ pub fn Int::clamp(self : Int, min~ : Int, max~ : Int) -> Int {
     self
   }
 }
+
+///|
+/// Checks if the integer value represents a UTF-16 leading surrogate.
+/// Leading surrogates are in the range 0xD800 to 0xDBFF.
+///
+/// Example:
+/// ```moonbit
+///   inspect((0xD800).is_leading_surrogate(), content="true")
+///   inspect((0xDBFF).is_leading_surrogate(), content="true")
+///   inspect((0xDC00).is_leading_surrogate(), content="false")
+///   inspect((0x41).is_leading_surrogate(), content="false") // 'A'
+/// ```
+pub fn Int::is_leading_surrogate(self : Int) -> Bool {
+  0xD800 <= self && self <= 0xDBFF
+}
+
+///|
+/// Checks if the integer value represents a UTF-16 trailing surrogate.
+/// Trailing surrogates are in the range 0xDC00 to 0xDFFF.
+///
+/// Example:
+/// ```moonbit
+///   inspect((0xDC00).is_trailing_surrogate(), content="true")
+///   inspect((0xDFFF).is_trailing_surrogate(), content="true")
+///   inspect((0xD800).is_trailing_surrogate(), content="false")
+///   inspect((0x41).is_trailing_surrogate(), content="false") // 'A'
+/// ```
+pub fn Int::is_trailing_surrogate(self : Int) -> Bool {
+  0xDC00 <= self && self <= 0xDFFF
+}

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -35,16 +35,6 @@ pub fn String::make(length : Int, value : Char) -> String {
 }
 
 ///|
-fn is_leading_surrogate(c : Int) -> Bool {
-  c is (0xD800..=0xDBFF)
-}
-
-///|
-fn is_trailing_surrogate(c : Int) -> Bool {
-  c is (0xDC00..=0xDFFF)
-}
-
-///|
 fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
   ((leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000).unsafe_to_char()
 }
@@ -78,9 +68,9 @@ pub fn String::char_length(
       utf16_index < end_offset
       utf16_index = utf16_index + 1, char_count = char_count + 1 {
     let c1 = self.unsafe_charcode_at(utf16_index)
-    if is_leading_surrogate(c1) && utf16_index + 1 < end_offset {
+    if c1.is_leading_surrogate() && utf16_index + 1 < end_offset {
       let c2 = self.unsafe_charcode_at(utf16_index + 1)
-      if is_trailing_surrogate(c2) {
+      if c2.is_trailing_surrogate() {
         continue utf16_index + 2, char_count + 1
       } else {
         abort("invalid surrogate pair")

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -1329,15 +1329,15 @@ test "View::get basic cases" {
 pub fn String::get_char(self : String, idx : Int) -> Char? {
   guard idx >= 0 && idx < self.length() else { return None }
   let c = self.unsafe_charcode_at(idx)
-  if is_leading_surrogate(c) {
+  if c.is_leading_surrogate() {
     guard idx + 1 < self.length() else { return None }
     let next = self.unsafe_charcode_at(idx + 1)
-    if is_trailing_surrogate(next) {
+    if next.is_trailing_surrogate() {
       Some(code_point_of_surrogate_pair(c, next))
     } else {
       None
     }
-  } else if is_trailing_surrogate(c) {
+  } else if c.is_trailing_surrogate() {
     None
   } else {
     Some(c.unsafe_to_char())
@@ -1350,15 +1350,15 @@ pub fn String::get_char(self : String, idx : Int) -> Char? {
 pub fn View::get_char(self : View, idx : Int) -> Char? {
   guard idx >= 0 && idx < self.length() else { return None }
   let c = self.unsafe_charcode_at(idx)
-  if is_leading_surrogate(c) {
+  if c.is_leading_surrogate() {
     guard idx + 1 < self.length() else { return None }
     let next = self.unsafe_charcode_at(idx + 1)
-    if is_trailing_surrogate(next) {
+    if next.is_trailing_surrogate() {
       Some(code_point_of_surrogate_pair(c, next))
     } else {
       None
     }
-  } else if is_trailing_surrogate(c) {
+  } else if c.is_trailing_surrogate() {
     None
   } else {
     Some(c.unsafe_to_char())

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -124,9 +124,9 @@ pub fn iter(self : String) -> Iter[Char] {
     let len = self.length()
     for index in 0..<len {
       let c1 = self.unsafe_charcode_at(index)
-      if is_leading_surrogate(c1) && index + 1 < len {
+      if c1.is_leading_surrogate() && index + 1 < len {
         let c2 = self.unsafe_charcode_at(index + 1)
-        if is_trailing_surrogate(c2) {
+        if c2.is_trailing_surrogate() {
           let c = code_point_of_surrogate_pair(c1, c2)
           guard yield_(c) is IterContinue else { break IterEnd }
           continue index + 2
@@ -146,9 +146,9 @@ pub fn iter2(self : String) -> Iter2[Int, Char] {
     let len = self.length()
     for index = 0, n = 0; index < len; index = index + 1, n = n + 1 {
       let c1 = self.unsafe_charcode_at(index)
-      if is_leading_surrogate(c1) && index + 1 < len {
+      if c1.is_leading_surrogate() && index + 1 < len {
         let c2 = self.unsafe_charcode_at(index + 1)
-        if is_trailing_surrogate(c2) {
+        if c2.is_trailing_surrogate() {
           let c = code_point_of_surrogate_pair(c1, c2)
           guard yield_(n, c) is IterContinue else { break IterEnd }
           continue index + 2, n + 1
@@ -195,9 +195,9 @@ pub fn rev_iter(self : String) -> Iter[Char] {
     let len = self.length()
     for index = len - 1; index >= 0; index = index - 1 {
       let c1 = self.unsafe_charcode_at(index)
-      if is_trailing_surrogate(c1) && index - 1 >= 0 {
+      if c1.is_trailing_surrogate() && index - 1 >= 0 {
         let c2 = self.unsafe_charcode_at(index - 1)
-        if is_leading_surrogate(c2) {
+        if c2.is_leading_surrogate() {
           let c = code_point_of_surrogate_pair(c2, c1)
           guard yield_(c) is IterContinue else { break IterEnd }
           continue index - 2
@@ -227,7 +227,7 @@ fn String::offset_of_nth_char_forward(
   while utf16_offset < end_offset && char_count < n {
     let c = self.unsafe_charcode_at(utf16_offset)
     // check if this is a surrogate pair
-    if is_leading_surrogate(c) {
+    if c.is_leading_surrogate() {
       utf16_offset = utf16_offset + 2
     } else {
       utf16_offset = utf16_offset + 1
@@ -260,7 +260,7 @@ fn String::offset_of_nth_char_backward(
   // Invariant: utf16_offset always points to the previous character
   while utf16_offset - 1 >= start_offset && char_count < n {
     let c = self.unsafe_charcode_at(utf16_offset - 1)
-    if is_trailing_surrogate(c) {
+    if c.is_trailing_surrogate() {
       utf16_offset = utf16_offset - 2
     } else {
       utf16_offset = utf16_offset - 1
@@ -312,9 +312,9 @@ pub fn String::char_length_eq(
       index < end_offset && count < len
       index = index + 1, count = count + 1 {
     let c1 = self.unsafe_charcode_at(index)
-    if is_leading_surrogate(c1) && index + 1 < end_offset {
+    if c1.is_leading_surrogate() && index + 1 < end_offset {
       let c2 = self.unsafe_charcode_at(index + 1)
-      if is_trailing_surrogate(c2) {
+      if c2.is_trailing_surrogate() {
         continue index + 2, count + 1
       } else {
         abort("invalid surrogate pair")
@@ -340,9 +340,9 @@ pub fn String::char_length_ge(
       index < end_offset && count < len
       index = index + 1, count = count + 1 {
     let c1 = self.unsafe_charcode_at(index)
-    if is_leading_surrogate(c1) && index + 1 < end_offset {
+    if c1.is_leading_surrogate() && index + 1 < end_offset {
       let c2 = self.unsafe_charcode_at(index + 1)
-      if is_trailing_surrogate(c2) {
+      if c2.is_trailing_surrogate() {
         continue index + 2, count + 1
       } else {
         abort("invalid surrogate pair")

--- a/string/utils.mbt
+++ b/string/utils.mbt
@@ -13,40 +13,6 @@
 // limitations under the License.
 
 ///|
-let min_leading_surrogate = 0xD800
-
-///|
-let max_leading_surrogate = 0xDBFF
-
-///|
-let min_trailing_surrogate = 0xDC00
-
-///|
-let max_trailing_surrogate = 0xDFFF
-
-///|
-fn is_leading_surrogate(c : Int) -> Bool {
-  min_leading_surrogate <= c && c <= max_leading_surrogate
-}
-
-///|
-test "is_leading_surrogate" {
-  inspect(is_leading_surrogate("🤣".charcode_at(0)), content="true")
-  inspect(is_leading_surrogate("🤣".charcode_at(1)), content="false")
-}
-
-///|
-fn is_trailing_surrogate(c : Int) -> Bool {
-  min_trailing_surrogate <= c && c <= max_trailing_surrogate
-}
-
-///|
-test "is_trailing_surrogate" {
-  inspect(is_trailing_surrogate("🤣".charcode_at(0)), content="false")
-  inspect(is_trailing_surrogate("🤣".charcode_at(1)), content="true")
-}
-
-///|
 fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
   ((leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000).unsafe_to_char()
 }
@@ -57,4 +23,16 @@ test "code_point_of_surrogate_pair" {
   let leading = s.charcode_at(0)
   let trailing = s.charcode_at(1)
   inspect(code_point_of_surrogate_pair(leading, trailing), content="😀")
+}
+
+///|
+test "is_leading_surrogate" {
+  inspect("🤣".charcode_at(0).is_leading_surrogate(), content="true")
+  inspect("🤣".charcode_at(1).is_leading_surrogate(), content="false")
+}
+
+///|
+test "is_trailing_surrogate" {
+  inspect("🤣".charcode_at(0).is_trailing_surrogate(), content="false")
+  inspect("🤣".charcode_at(1).is_trailing_surrogate(), content="true")
 }

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -248,9 +248,9 @@ pub impl Show for StringView with to_string(self) {
 pub fn View::iter(self : View) -> Iter[Char] {
   Iter::new(yield_ => for index in self.start()..<self.end() {
     let c1 = self.str().unsafe_charcode_at(index)
-    if is_leading_surrogate(c1) && index + 1 < self.end() {
+    if c1.is_leading_surrogate() && index + 1 < self.end() {
       let c2 = self.str().unsafe_charcode_at(index + 1)
-      if is_trailing_surrogate(c2) {
+      if c2.is_trailing_surrogate() {
         let c = code_point_of_surrogate_pair(c1, c2)
         guard yield_(c) is IterContinue else { break IterEnd }
         continue index + 2
@@ -268,9 +268,9 @@ pub fn View::iter2(self : View) -> Iter2[Int, Char] {
     let len = self.length()
     for index = 0, n = 0; index < len; index = index + 1, n = n + 1 {
       let c1 = self.str().unsafe_charcode_at(self.start() + index)
-      if is_leading_surrogate(c1) && index + 1 < len {
+      if c1.is_leading_surrogate() && index + 1 < len {
         let c2 = self.str().unsafe_charcode_at(self.start() + index + 1)
-        if is_trailing_surrogate(c2) {
+        if c2.is_trailing_surrogate() {
           let c = code_point_of_surrogate_pair(c1, c2)
           guard yield_(n, c) is IterContinue else { break IterEnd }
           continue index + 2, n + 1
@@ -292,9 +292,9 @@ pub fn View::rev_iter(self : View) -> Iter[Char] {
                           index >= self.start()
                           index = index - 1 {
     let c1 = self.str().unsafe_charcode_at(index)
-    if is_trailing_surrogate(c1) && index - 1 >= 0 {
+    if c1.is_trailing_surrogate() && index - 1 >= 0 {
       let c2 = self.str().unsafe_charcode_at(index - 1)
-      if is_leading_surrogate(c2) {
+      if c2.is_leading_surrogate() {
         let c = code_point_of_surrogate_pair(c2, c1)
         guard yield_(c) is IterContinue else { break IterEnd }
         continue index - 2
@@ -456,10 +456,10 @@ pub fn String::op_as_view(
   }
   let start = if start < 0 { len + start } else { start }
   guard start >= 0 && start <= end && end <= len else { raise IndexOutOfBounds }
-  if start < len && is_trailing_surrogate(self.unsafe_charcode_at(start)) {
+  if start < len && self.unsafe_charcode_at(start).is_trailing_surrogate() {
     raise InvalidIndex
   }
-  if end < len && is_trailing_surrogate(self.unsafe_charcode_at(end)) {
+  if end < len && self.unsafe_charcode_at(end).is_trailing_surrogate() {
     raise InvalidIndex
   }
   View::make_view(self, start, end)
@@ -537,11 +537,11 @@ pub fn View::op_as_view(
 
   // Check for surrogate pair boundaries
   if abs_start < str_len &&
-    is_trailing_surrogate(self.str().unsafe_charcode_at(abs_start)) {
+    self.str().unsafe_charcode_at(abs_start).is_trailing_surrogate() {
     raise InvalidIndex
   }
   if abs_end < str_len &&
-    is_trailing_surrogate(self.str().unsafe_charcode_at(abs_end)) {
+    self.str().unsafe_charcode_at(abs_end).is_trailing_surrogate() {
     raise InvalidIndex
   }
   View::make_view(self.str(), abs_start, abs_end)


### PR DESCRIPTION
- Add Int::is_leading_surrogate() and Int::is_trailing_surrogate() methods
- Replace all function calls with method calls throughout the codebase
- Remove duplicate function definitions from builtin/string.mbt and string/utils.mbt
- Clean up unused surrogate range constants

This provides a more consistent API by making these UTF-16 surrogate checks
available as methods on the Int type itself.
