### PR TITLE
feat: add Int::is_surrogate() method and apply it in char module

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -345,6 +345,7 @@ fn Int::is_neg(Int) -> Bool
 fn Int::is_non_neg(Int) -> Bool
 fn Int::is_non_pos(Int) -> Bool
 fn Int::is_pos(Int) -> Bool
+fn Int::is_surrogate(Int) -> Bool
 fn Int::is_trailing_surrogate(Int) -> Bool
 fn Int::land(Int, Int) -> Int
 fn Int::lnot(Int) -> Int

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -416,9 +416,9 @@ pub fn[T] dump(t : T, name? : String, loc~ : SourceLoc = _) -> T {
 /// # Examples
 ///
 /// ```mbt
-///   let s = "Hello🤣";
-///   inspect(s.iter().nth(0).unwrap(), content="H");
-///   inspect(s.iter().nth(5).unwrap(), content="🤣"); // Returns full emoji character
+/// let s = "Hello🤣"
+/// inspect(s.get_char(0).unwrap(), content="H")
+/// inspect(s.get_char(5).unwrap(), content="🤣")
 /// ```
 ///
 /// # Panics

--- a/builtin/int.mbt
+++ b/builtin/int.mbt
@@ -101,10 +101,10 @@ pub fn Int::clamp(self : Int, min~ : Int, max~ : Int) -> Int {
 ///
 /// Example:
 /// ```moonbit
-///   inspect((0xD800).is_leading_surrogate(), content="true")
-///   inspect((0xDBFF).is_leading_surrogate(), content="true")
-///   inspect((0xDC00).is_leading_surrogate(), content="false")
-///   inspect((0x41).is_leading_surrogate(), content="false") // 'A'
+/// inspect((0xD800).is_leading_surrogate(), content="true")
+/// inspect((0xDBFF).is_leading_surrogate(), content="true")
+/// inspect((0xDC00).is_leading_surrogate(), content="false")
+/// inspect((0x41).is_leading_surrogate(), content="false") // 'A'
 /// ```
 pub fn Int::is_leading_surrogate(self : Int) -> Bool {
   0xD800 <= self && self <= 0xDBFF
@@ -123,4 +123,20 @@ pub fn Int::is_leading_surrogate(self : Int) -> Bool {
 /// ```
 pub fn Int::is_trailing_surrogate(self : Int) -> Bool {
   0xDC00 <= self && self <= 0xDFFF
+}
+
+///|
+/// Checks if the integer value represents any UTF-16 surrogate (leading or trailing).
+/// Surrogates are in the range 0xD800 to 0xDFFF.
+///
+/// Example:
+/// ```moonbit
+///   inspect((0xD800).is_surrogate(), content="true")  // leading surrogate
+///   inspect((0xDC00).is_surrogate(), content="true")  // trailing surrogate
+///   inspect((0xDFFF).is_surrogate(), content="true")  // trailing surrogate
+///   inspect((0x41).is_surrogate(), content="false")   // 'A'
+///   inspect((0x1F600).is_surrogate(), content="false") // 😀 emoji codepoint
+/// ```
+pub fn Int::is_surrogate(self : Int) -> Bool {
+  0xD800 <= self && self <= 0xDFFF
 }

--- a/char/char.mbt
+++ b/char/char.mbt
@@ -337,7 +337,7 @@ pub fn Char::is_printable(self : Self) -> Bool {
     return false
   }
   // Surrogate (Cs)
-  if self >= 0xD800 && self <= 0xDFFF {
+  if self.is_surrogate() {
     return false
   }
 

--- a/string/utils.mbt
+++ b/string/utils.mbt
@@ -36,3 +36,14 @@ test "is_trailing_surrogate" {
   inspect("🤣".charcode_at(0).is_trailing_surrogate(), content="false")
   inspect("🤣".charcode_at(1).is_trailing_surrogate(), content="true")
 }
+
+///|
+test "is_surrogate" {
+  inspect((0xD800).is_surrogate(), content="true")  // Leading surrogate
+  inspect((0xDBFF).is_surrogate(), content="true")  // Leading surrogate
+  inspect((0xDC00).is_surrogate(), content="true")  // Trailing surrogate
+  inspect((0xDFFF).is_surrogate(), content="true")  // Trailing surrogate
+  inspect((0xD7FF).is_surrogate(), content="false") // Just before surrogates
+  inspect((0xE000).is_surrogate(), content="false") // Just after surrogates
+  inspect((0x41).is_surrogate(), content="false")   // Regular ASCII 'A'
+}


### PR DESCRIPTION
- Add Int::is_surrogate() method to check if an integer is any UTF-16 surrogate
- Apply the new method in Char::is_printable() for cleaner surrogate checking
- Add comprehensive tests for the new method
