### PR TITLE
Improve string package coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 moonbit-coverage-*.txt
 _coverage
 bisect.coverage
+*.log
 
 .DS_Store
 .ai/

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -50,3 +50,34 @@ test "String::offset_of_nth_char_forward with special case" {
   let result2 = s.offset_of_nth_char(5) // Beyond last character
   inspect(result2, content="None")
 }
+
+///|
+test "View::pad_start and pad_end no padding" {
+  let v = "abc"[1:3] // "bc"
+  inspect(v.pad_start(2, 'x'), content="bc")
+  inspect(v.pad_end(2, 'y'), content="bc")
+}
+
+///|
+test "View::compare identical" {
+  let str = "abcdef"
+  let v = str.view(start_offset=2, end_offset=4)
+  inspect(v.compare(v), content="0")
+}
+
+///|
+test "View::default and hash" {
+  let v : View = View::default()
+  inspect(v, content="")
+  let v1 = "abc".view()
+  let v2 = "abc".view()
+  assert_eq(v1.hash(), v2.hash())
+}
+
+///|
+test "get_char invalid surrogate pair" {
+  let s = String::from_array([(0xD800).unsafe_to_char(), 'A'])
+  inspect(s.get_char(0), content="None")
+  let v = s[:]
+  inspect(v.get_char(0), content="None")
+}

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -85,6 +85,18 @@ fn boyer_moore_horspool_find(haystack : View, needle : View) -> Int? {
 }
 
 ///|
+test "boyer_moore_horspool_find edge cases" {
+  inspect(boyer_moore_horspool_find("abc"[:], ""[:]), content="Some(0)")
+  inspect(boyer_moore_horspool_find("ab"[:], "abcd"[:]), content="None")
+}
+
+///|
+test "boyer_moore_horspool_rev_find edge cases" {
+  inspect(boyer_moore_horspool_rev_find("abc"[:], ""[:]), content="Some(3)")
+  inspect(boyer_moore_horspool_rev_find("ab"[:], "abcd"[:]), content="None")
+}
+
+///|
 /// Returns the offset of the first occurrence of the given substring. If the
 /// substring is not found, it returns None.
 pub fn String::find(self : String, str : View) -> Int? {


### PR DESCRIPTION
## Summary
- add more tests to cover View padding, compare, default, hashing, and surrogate handling
- add whitebox tests for internal search helpers

## Testing
- `moon info`
- `moon fmt`
- `moon check`
- `moon test --update`
- `moon coverage analyze -p string`

------
https://chatgpt.com/codex/tasks/task_e_68888317bc188320841fc3e76a06c866