### PR TITLE
fix: blit_from_string bound check bug

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -122,7 +122,7 @@ pub fn FixedArray::blit_from_string(
 ) -> Unit {
   let s1 = bytes_offset
   let s2 = str_offset
-  let e1 = bytes_offset + length - 1
+  let e1 = bytes_offset + length * 2 - 1
   let e2 = str_offset + length - 1
   let len1 = self.length()
   let len2 = str.length()


### PR DESCRIPTION
The boundary check in `FixedArray::blit_from_string` was incorrect, it allowed operations that would later cause array bounds violations. However, I haven't found how to create a unit test that can verify the guard condition: a guard statement without a return value will panic the whole program, but unit tests don't seem to have a way to assert what the panic is.