### PR TITLE
make using regex test compatible with future `String` support

### DIFF
--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -248,7 +248,7 @@ test "Bytes::get out of bounds" {
 
 ///|
 test "using regex" {
-  match "hell123o" using regex {
+  match b"hell123o" using regex {
     ["hell[0-9]+" as x, .. rest] => {
       guard x is "hell123" && rest is "o" else { fail("Regex match failed") }
     }


### PR DESCRIPTION
The bleeding version of `match .. using regex` now supports matching `String` directly, so if the matched object is a string literal, the semantic will change from matching `Bytes` to matching `String`. If `moonbitlang/core/string` is not imported (this can only happen in core itself, most users should not worry about this), the compiler will crash. This PR migrate tests to use `b"..."` literal, so that they are compatible with future support for matching `String` with regex.