### PR TITLE
perf: inline funcs

### DIFF
--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -56,7 +56,8 @@ pub fn[A : Compare] to_array(self : T[A]) -> Array[A] {
   }
 
   go(self.node)
-  arr.sort_by((x, y) => y.compare(x))
+  arr.sort()
+  arr.rev_inplace()
   arr
 }
 

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -43,19 +43,18 @@ pub fn[A : Compare] from_array(array : Array[A]) -> T[A] {
 ///|
 pub fn[A : Compare] to_array(self : T[A]) -> Array[A] {
   let arr : Array[A] = []
-  fn go(x : Node[A]) {
-    match x {
-      Empty => return
+  let stack : Array[Node[A]] = [self.node]
+  while stack.pop() is Some(node) {
+    match node {
+      Empty => ()
       Leaf(a) => arr.push(a)
       Branch(a, left=l, right=r) => {
         arr.push(a)
-        go(l)
-        go(r)
+        stack.push(l)
+        stack.push(r)
       }
     }
   }
-
-  go(self.node)
   arr.sort()
   arr.rev_inplace()
   arr

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -74,18 +74,17 @@ pub fn[A] copy(self : T[A]) -> T[A] {
 ///|
 pub fn[A : Compare] to_array(self : T[A]) -> Array[A] {
   let arr = Array::new(capacity=self.len)
-  fn go(x : Node[A]) {
-    match x {
-      Cons(_) as x => {
-        arr.push(x.content)
-        go(x.sibling)
-        go(x.child)
-      }
+  let stack : Array[Node[A]] = [self.top]
+  while stack.pop() is Some(node) {
+    match node {
       Nil => ()
+      Cons(content~, sibling~, child~) => {
+        arr.push(content)
+        stack.push(sibling)
+        stack.push(child)
+      }
     }
   }
-
-  go(self.top)
   arr.sort()
   arr.rev_inplace()
   arr

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -86,7 +86,8 @@ pub fn[A : Compare] to_array(self : T[A]) -> Array[A] {
   }
 
   go(self.top)
-  arr.sort_by((x, y) => y.compare(x))
+  arr.sort()
+  arr.rev_inplace()
   arr
 }
 


### PR DESCRIPTION
This PR
1. Inline `binary_search` for `deque` for better performance
2. Use `sort` then `rev_inplace` for `@priority_queue.to_array` for better performance (both immutable version and mutable version)
3. Use a stack to avoid overflow for `@priority_queue.to_array` (both immutable version and mutable version)

Bench: 

```moonbit
///|
test (bench : @bench.T) {
  let queue : T[Int] = @quickcheck.samples(10000) |> from_array
  bench.bench(name="to_array", fn() { bench.keep(queue.to_array()) })
  bench.bench(name="to_array_new", fn() { bench.keep(queue.to_array_new()) })
}
```

Result:

```
bench username/hello/lib/hello.mbt::0
name         time (mean ± σ)         range (min … max) 
to_array        2.35 ms ±   7.29 µs     2.34 ms …   2.36 ms  in 10 ×     43 runs
to_array_new    1.88 ms ±   4.74 µs     1.87 ms …   1.89 ms  in 10 ×     53 runs
Total tests: 1, passed: 1, failed: 0. [wasm]
bench username/hello/lib/hello.mbt::0
name         time (mean ± σ)         range (min … max) 
to_array        1.03 ms ±   6.95 µs     1.02 ms …   1.04 ms  in 10 ×     95 runs
to_array_new  834.08 µs ±   2.84 µs   830.28 µs … 838.90 µs  in 10 ×    120 runs
Total tests: 1, passed: 1, failed: 0. [wasm-gc]
bench username/hello/lib/hello.mbt::0
name         time (mean ± σ)         range (min … max) 
to_array        2.41 ms ±  34.78 µs     2.38 ms …   2.49 ms  in 10 ×     42 runs
to_array_new    2.33 ms ±   9.73 µs     2.32 ms …   2.34 ms  in 10 ×     43 runs
Total tests: 1, passed: 1, failed: 0. [js]
bench username/hello/lib/hello.mbt::0
name         time (mean ± σ)         range (min … max) 
to_array        1.43 ms ±   2.88 µs     1.43 ms …   1.43 ms  in 10 ×     70 runs
to_array_new    1.37 ms ±   3.73 µs     1.37 ms …   1.38 ms  in 10 ×     73 runs
Total tests: 1, passed: 1, failed: 0. [native]
```