### PR TITLE
fom_json flat trigger warnings

### DIFF
--- a/json/from_to_json_test.mbt
+++ b/json/from_to_json_test.mbt
@@ -28,7 +28,7 @@ test {
   inspect(
     ej.stringify(),
     content=(
-      #|{"$tag":"Add","0":{"$tag":"Val","0":"x"},"1":{"$tag":"Val","0":"y"}}
+      #|["Add",["Val","x"],["Val","y"]]
     ),
   )
   let e0 : Expr = @json.from_json(ej)

--- a/json/from_to_json_test.mbt
+++ b/json/from_to_json_test.mbt
@@ -19,7 +19,7 @@ enum Expr {
   Mul(Expr, Expr)
   Div(Expr, Expr)
   Val(String)
-} derive(ToJson(style="legacy"), FromJson(style="legacy"), Show, Eq)
+} derive(ToJson(style="flat"), FromJson(style="flat"), Show, Eq)
 
 ///|
 test {


### PR DESCRIPTION
```
Error: [0011] Error (warning): Partial match, some hints:
True
Null
False
error: failed when checking
```