### PR TITLE
refactor: update inner access to use zero-indexing for buffer references

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -88,7 +88,7 @@ pub fn[T] Array::make(len : Int, elem : T) -> Array[T] {
 /// NOTE: The capacity of an array may not be consistent across different backends
 /// and/or different versions of the MoonBit compiler/core.
 pub fn[T] Array::capacity(self : Array[T]) -> Int {
-  self.buffer().inner().length()
+  self.buffer().0.length()
 }
 
 ///|

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -52,9 +52,9 @@ pub fn[A] Array::unsafe_blit(
   len : Int,
 ) -> Unit {
   FixedArray::unsafe_blit(
-    dst.buffer().inner(),
+    dst.buffer().0,
     dst_offset,
-    src.buffer().inner(),
+    src.buffer().0,
     src_offset,
     len,
   )

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -126,7 +126,7 @@ fn[T] Array::buffer(self : Array[T]) -> UninitializedArray[T] {
 fn[T] Array::resize_buffer(self : Array[T], new_capacity : Int) -> Unit {
   let new_buf = UninitializedArray::make(new_capacity)
   let old_buf = self.buf
-  let old_cap = old_buf.inner().length()
+  let old_cap = old_buf.0.length()
   let copy_len = if old_cap < new_capacity { old_cap } else { new_capacity }
   UninitializedArray::unsafe_blit(new_buf, 0, old_buf, 0, copy_len)
   self.buf = new_buf
@@ -177,7 +177,7 @@ test "Array::resize_buffer" {
   arr.push(1)
   arr.push(2)
   arr.resize_buffer(4)
-  assert_eq(arr.buffer().inner().length() >= 4, true)
+  assert_eq(arr.buffer().0.length() >= 4, true)
   arr.push(3)
   arr.push(4)
   assert_eq(arr.length(), 4)
@@ -244,7 +244,7 @@ pub fn[T] Array::shrink_to_fit(self : Array[T]) -> Unit {
 ///   v.push(3)
 /// ```
 pub fn[T] Array::push(self : Array[T], value : T) -> Unit {
-  if self.length() == self.buffer().inner().length() {
+  if self.length() == self.buffer().0.length() {
     self.realloc()
   }
   let length = self.length()
@@ -376,7 +376,7 @@ pub fn[T] Array::insert(self : Array[T], index : Int, value : T) -> Unit {
       "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
     )
   }
-  if self.length() == self.buffer().inner().length() {
+  if self.length() == self.buffer().0.length() {
     self.realloc()
   }
   UninitializedArray::unsafe_blit(

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -106,7 +106,7 @@ pub fn[T] UninitializedArray::unsafe_blit(
   src_offset : Int,
   len : Int,
 ) -> Unit {
-  FixedArray::unsafe_blit(dst.inner(), dst_offset, src.inner(), src_offset, len)
+  FixedArray::unsafe_blit(dst.0, dst_offset, src.0, src_offset, len)
 }
 
 ///|

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -106,8 +106,8 @@ pub fn end() -> Unit {
   let sbuf = StringBuffer::StringBuffer([])
   coverage_log(counters.val, sbuf)
   let line_buf = StringBuilder::new()
-  for i in 0..<sbuf.inner().length() {
-    let str = sbuf.inner()[i]
+  for i in 0..<sbuf.0.length() {
+    let str = sbuf.0[i]
     let mut start = 0
     for j in 0..<str.length() {
       if str.unsafe_charcode_at(j) == '\n' {

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -492,13 +492,13 @@ impl Hash for MyString with hash(self) {
 ///|
 #coverage.skip
 impl Hash for MyString with hash_combine(self, hasher) {
-  hasher.combine_string(self.inner())
+  hasher.combine_string(self.0)
 }
 
 ///|
 #coverage.skip
 impl Show for MyString with output(self, logger) {
-  logger.write_string(self.inner())
+  logger.write_string(self.0)
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -55,7 +55,7 @@ pub fn[K : Eq + Hash, V] find(self : T[K, V], key : K) -> V? {
 ///|
 /// Lookup a key from a hash map
 pub fn[K : Eq + Hash, V] get(self : T[K, V], key : K) -> V? {
-  match self.inner() {
+  match self.0 {
     None => None
     Some(node) => node.get_with_path(key, @path.of(key))
   }
@@ -193,7 +193,7 @@ pub fn[K, V] filter(
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => None
     Some(node) => go(node)
   }
@@ -228,7 +228,7 @@ pub fn[K, V, A] fold_with_key(
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => init
     Some(node) => go(init, node)
   }
@@ -255,7 +255,7 @@ pub fn[K, V, A] map_with_key(
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => None
     Some(node) => Some(go(node))
   }
@@ -266,7 +266,7 @@ pub fn[K, V, A] map_with_key(
 ///
 /// If a pair with the same key already exists, the old one is replaced
 pub fn[K : Eq + Hash, V] add(self : T[K, V], key : K, value : V) -> T[K, V] {
-  match self.inner() {
+  match self.0 {
     None => Some(Flat(key, value, @path.of(key)))
     Some(node) => Some(node.add_with_path(key, value, @path.of(key)))
   }
@@ -275,7 +275,7 @@ pub fn[K : Eq + Hash, V] add(self : T[K, V], key : K, value : V) -> T[K, V] {
 ///|
 /// Remove an element from a map
 pub fn[K : Eq + Hash, V] remove(self : T[K, V], key : K) -> T[K, V] {
-  match self.inner() {
+  match self.0 {
     None => None
     Some(node) => node.remove_with_path(key, @path.of(key))
   }
@@ -351,7 +351,7 @@ pub fn[K, V] size(self : T[K, V]) -> Int {
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => 0
     Some(node) => node_size(node)
   }
@@ -382,7 +382,7 @@ pub fn[K : Eq, V] T::union(self : T[K, V], other : T[K, V]) -> T[K, V] {
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, x) | (x, None) => x
     (Some(a), Some(b)) => Some(go(a, b))
   }
@@ -422,7 +422,7 @@ pub fn[K : Eq, V] T::union_with(
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, x) | (x, None) => x
     (Some(a), Some(b)) => Some(go(a, b))
   }
@@ -483,7 +483,7 @@ pub fn[K : Eq, V] T::intersection(self : T[K, V], other : T[K, V]) -> T[K, V] {
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, _) | (_, None) => None
     (Some(a), Some(b)) => go(a, b)
   }
@@ -524,7 +524,7 @@ pub fn[K : Eq, V] T::intersection_with(
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, _) | (_, None) => None
     (Some(a), Some(b)) => go(a, b)
   }
@@ -581,7 +581,7 @@ pub fn[K : Eq, V] T::difference(self : T[K, V], other : T[K, V]) -> T[K, V] {
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, _) => None
     (_, None) => self
     (Some(a), Some(b)) => go(a, b)
@@ -602,7 +602,7 @@ pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit raise?) -> Unit raise? {
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => ()
     Some(node) => go(node)
   }
@@ -638,7 +638,7 @@ pub fn[K, V] iter(self : T[K, V]) -> Iter[(K, V)] {
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => Iter::empty()
     Some(node) => go(node)
   }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -390,7 +390,7 @@ test "HAMT::map_with_key leaf" {
 ///|
 test "HAMT::map_with_key collision" {
   let map = @hashmap.of([(MyString("a"), 1), (MyString("b"), 2)]) // Collision
-  let mapped = map.map_with_key((k, v) => k.inner() + ":" + v.to_string())
+  let mapped = map.map_with_key((k, v) => k.0 + ":" + v.to_string())
   assert_eq(mapped.get(MyString("a")), Some("a:1"))
   assert_eq(mapped.get(MyString("b")), Some("b:2"))
   assert_eq(mapped.get(MyString("c")), None)
@@ -427,7 +427,7 @@ impl Hash for MyString with hash_combine(_self, hasher) {
 
 ///|
 impl Eq for MyString with op_equal(self, other) {
-  self.inner() == other.inner()
+  self.0 == other.0
 }
 
 ///|

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -35,7 +35,7 @@ pub fn[A] new() -> T[A] {
 ///|
 /// Lookup a value from the hash set
 pub fn[A : Eq + Hash] contains(self : T[A], key : A) -> Bool {
-  self.inner() is Some(node) && node.contains(key, @path.of(key))
+  self.0 is Some(node) && node.contains(key, @path.of(key))
 }
 
 ///|
@@ -109,7 +109,7 @@ fn[A : Eq] add_with_path(self : Node[A], key : A, path : Path) -> Node[A] {
 ///|
 /// Add a key to the hashset.
 pub fn[A : Eq + Hash] add(self : T[A], key : A) -> T[A] {
-  match self.inner() {
+  match self.0 {
     None => Some(Flat(key, @path.of(key)))
     Some(node) => Some(node.add_with_path(key, @path.of(key)))
   }
@@ -118,7 +118,7 @@ pub fn[A : Eq + Hash] add(self : T[A], key : A) -> T[A] {
 ///|
 /// Remove an element from a set
 pub fn[A : Eq + Hash] remove(self : T[A], key : A) -> T[A] {
-  match self.inner() {
+  match self.0 {
     None => None
     Some(node) => node.remove_with_path(key, @path.of(key))
   }
@@ -184,7 +184,7 @@ pub fn[A] size(self : T[A]) -> Int {
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => 0
     Some(node) => node_size(node)
   }
@@ -211,7 +211,7 @@ pub fn[K : Eq] T::union(self : T[K], other : T[K]) -> T[K] {
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, x) | (x, None) => x
     (Some(a), Some(b)) => Some(go(a, b))
   }
@@ -247,7 +247,7 @@ pub fn[K : Eq] T::intersection(self : T[K], other : T[K]) -> T[K] {
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, _) | (_, None) => None
     (Some(a), Some(b)) => go(a, b)
   }
@@ -284,7 +284,7 @@ pub fn[K : Eq] T::difference(self : T[K], other : T[K]) -> T[K] {
     }
   }
 
-  match (self.inner(), other.inner()) {
+  match (self.0, other.0) {
     (None, _) => None
     (_, None) => self
     (Some(a), Some(b)) => go(a, b)
@@ -294,7 +294,7 @@ pub fn[K : Eq] T::difference(self : T[K], other : T[K]) -> T[K] {
 ///|
 /// Returns true if the hash set is empty.
 pub fn[A] is_empty(self : T[A]) -> Bool {
-  self.inner() is None
+  self.0 is None
 }
 
 ///|
@@ -311,7 +311,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => ()
     Some(node) => go(node)
   }
@@ -328,7 +328,7 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
     }
   }
 
-  match self.inner() {
+  match self.0 {
     None => Iter::empty()
     Some(node) => go(node)
   }

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -256,17 +256,17 @@ impl Hash for MyString with hash_combine(_self, hasher) {
 
 ///|
 impl Eq for MyString with op_equal(self, other) {
-  self.inner() == other.inner()
+  self.0 == other.0
 }
 
 ///|
 impl Show for MyString with to_string(self) {
-  self.inner()
+  self.0
 }
 
 ///|
 impl Show for MyString with output(self, logger) {
-  logger.write_string(self.inner())
+  logger.write_string(self.0)
 }
 
 ///|

--- a/immut/internal/sparse_array/bitset.mbt
+++ b/immut/internal/sparse_array/bitset.mbt
@@ -22,40 +22,40 @@ let empty_bitset : Bitset = Bitset(0)
 ///|
 /// Check if the given index is present in the bitset.
 pub fn Bitset::has(self : Bitset, idx : Int) -> Bool {
-  (self.inner() & (1U << idx)) != 0
+  (self.0 & (1U << idx)) != 0
 }
 
 ///|
 /// Get the index of the bit in the bitset.
 pub fn Bitset::index_of(self : Bitset, idx : Int) -> Int {
-  (self.inner() & ((1U << idx) - 1)).popcnt()
+  (self.0 & ((1U << idx) - 1)).popcnt()
 }
 
 ///|
 pub fn Bitset::first_idx(self : Bitset) -> Int {
-  self.inner().ctz()
+  self.0.ctz()
 }
 
 ///|
 pub fn Bitset::union(self : Bitset, other : Bitset) -> Bitset {
-  Bitset(self.inner() | other.inner())
+  Bitset(self.0 | other.0)
 }
 
 ///|
 pub fn Bitset::intersection(self : Bitset, other : Bitset) -> Bitset {
-  Bitset(self.inner() & other.inner())
+  Bitset(self.0 & other.0)
 }
 
 ///|
 /// Add a new index to the bitset.
 pub fn Bitset::add(self : Bitset, idx : Int) -> Bitset {
-  Bitset(self.inner() | (1U << idx))
+  Bitset(self.0 | (1U << idx))
 }
 
 ///|
 /// Remove an index from the bitset.
 pub fn Bitset::remove(self : Bitset, idx : Int) -> Bitset {
-  Bitset(self.inner() ^ (1U << idx))
+  Bitset(self.0 ^ (1U << idx))
 }
 
 ///|

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -91,12 +91,12 @@ fn path(size : Int) -> Path {
 
 ///|
 fn is_left(self : Path) -> Bool {
-  (self.inner() & 1) == 0
+  (self.0 & 1) == 0
 }
 
 ///|
 fn next(self : Path) -> Path {
-  Path(self.inner() >> 1)
+  Path(self.0 >> 1)
 }
 
 ///|


### PR DESCRIPTION
- Changed access from `inner()` to `0` for buffer references in multiple files, ensuring consistency in how buffers are accessed.
- This update improves clarity and aligns with the new conventions for accessing buffer data.
