### PR TITLE
update mbti

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -4,22 +4,29 @@ package "moonbitlang/core/builtin"
 // Values
 fn[T] abort(String) -> T
 
-fn[T : Eq + Show] assert_eq(T, T, msg? : String, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn[T : Eq + Show] assert_eq(T, T, msg? : String, loc~ : SourceLoc) -> Unit raise
 
-fn assert_false(Bool, msg? : String, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn assert_false(Bool, msg? : String, loc~ : SourceLoc) -> Unit raise
 
-fn[T : Eq + Show] assert_not_eq(T, T, msg? : String, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn[T : Eq + Show] assert_not_eq(T, T, msg? : String, loc~ : SourceLoc) -> Unit raise
 
-fn assert_true(Bool, msg? : String, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn assert_true(Bool, msg? : String, loc~ : SourceLoc) -> Unit raise
 
 #deprecated
-fn[T] dump(T, name? : String, loc~ : SourceLoc = _) -> T
+#callsite(autofill(loc))
+fn[T] dump(T, name? : String, loc~ : SourceLoc) -> T
 
-fn[T] fail(String, loc~ : SourceLoc = _) -> T raise Failure
+#callsite(autofill(loc))
+fn[T] fail(String, loc~ : SourceLoc) -> T raise Failure
 
 fn[T] ignore(T) -> Unit
 
-fn inspect(&Show, content? : String, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise InspectError
+#callsite(autofill(args_loc, loc))
+fn inspect(&Show, content? : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise InspectError
 
 fn not(Bool) -> Bool
 

--- a/json/json.mbti
+++ b/json/json.mbti
@@ -8,7 +8,8 @@ import(
 // Values
 fn[T : FromJson] from_json(Json, path? : JsonPath) -> T raise JsonDecodeError
 
-fn inspect(&ToJson, content? : Json, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise InspectError
+#callsite(autofill(args_loc, loc))
+fn inspect(&ToJson, content? : Json, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise InspectError
 
 fn parse(String) -> Json raise ParseError
 

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -8,22 +8,29 @@ import(
 // Values
 fn[T] abort(String) -> T
 
-fn[T : @builtin.Eq + @builtin.Show] assert_eq(T, T, msg? : String, loc~ : @builtin.SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn[T : @builtin.Eq + @builtin.Show] assert_eq(T, T, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
 
-fn assert_false(Bool, msg? : String, loc~ : @builtin.SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn assert_false(Bool, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
 
-fn[T : @builtin.Eq + @builtin.Show] assert_not_eq(T, T, msg? : String, loc~ : @builtin.SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn[T : @builtin.Eq + @builtin.Show] assert_not_eq(T, T, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
 
-fn assert_true(Bool, msg? : String, loc~ : @builtin.SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn assert_true(Bool, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
 
 #deprecated
-fn[T] dump(T, name? : String, loc~ : @builtin.SourceLoc = _) -> T
+#callsite(autofill(loc))
+fn[T] dump(T, name? : String, loc~ : @builtin.SourceLoc) -> T
 
-fn[T] fail(String, loc~ : @builtin.SourceLoc = _) -> T raise @builtin.Failure
+#callsite(autofill(loc))
+fn[T] fail(String, loc~ : @builtin.SourceLoc) -> T raise @builtin.Failure
 
 fn[T] ignore(T) -> Unit
 
-fn inspect(&@builtin.Show, content? : String, loc~ : @builtin.SourceLoc = _, args_loc~ : @builtin.ArgsLoc = _) -> Unit raise @builtin.InspectError
+#callsite(autofill(args_loc, loc))
+fn inspect(&@builtin.Show, content? : String, loc~ : @builtin.SourceLoc, args_loc~ : @builtin.ArgsLoc) -> Unit raise @builtin.InspectError
 
 fn not(Bool) -> Bool
 

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -3,24 +3,31 @@ package "moonbitlang/core/test"
 
 // Values
 #deprecated
-fn[T : Show + Eq] eq(T, T, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn[T : Show + Eq] eq(T, T, loc~ : SourceLoc) -> Unit raise
 
-fn[T] fail(String, loc~ : SourceLoc = _) -> T raise
-
-#deprecated
-fn is_false(Bool, loc~ : SourceLoc = _) -> Unit raise
-
-fn[T : Show] is_not(T, T, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn[T] fail(String, loc~ : SourceLoc) -> T raise
 
 #deprecated
-fn is_true(Bool, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn is_false(Bool, loc~ : SourceLoc) -> Unit raise
+
+#callsite(autofill(loc))
+fn[T : Show] is_not(T, T, loc~ : SourceLoc) -> Unit raise
 
 #deprecated
-fn[T : Show + Eq] ne(T, T, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn is_true(Bool, loc~ : SourceLoc) -> Unit raise
+
+#deprecated
+#callsite(autofill(loc))
+fn[T : Show + Eq] ne(T, T, loc~ : SourceLoc) -> Unit raise
 
 fn new(String) -> T
 
-fn[T : Show] same_object(T, T, loc~ : SourceLoc = _) -> Unit raise
+#callsite(autofill(loc))
+fn[T : Show] same_object(T, T, loc~ : SourceLoc) -> Unit raise
 
 // Errors
 
@@ -31,7 +38,8 @@ pub(all) struct T {
 }
 #deprecated
 fn T::bench(Self, () -> Unit, count? : UInt) -> Unit raise BenchError
-fn T::snapshot(Self, filename~ : String, loc~ : SourceLoc = _, args_loc~ : ArgsLoc = _) -> Unit raise SnapshotError
+#callsite(autofill(args_loc, loc))
+fn T::snapshot(Self, filename~ : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise SnapshotError
 fn T::write(Self, &Show) -> Unit
 fn T::writeln(Self, &Show) -> Unit
 


### PR DESCRIPTION
update mbti format from the latest compiler release. The main change is the format for auto fill parameters, their format in `.mbti` changes from old `label~ : Type = _` style to new `#callsite(autofill(label))` style