### PR TITLE
add `find` and `rev_find` API for bytes

### DIFF
--- a/bytes/bytes.mbti
+++ b/bytes/bytes.mbti
@@ -17,11 +17,13 @@ fn of(FixedArray[Byte]) -> Bytes
 // Types and methods
 type View
 fn View::data(Self) -> Bytes
+fn View::find(Self, Self) -> Int?
 fn View::get(Self, Int) -> Byte?
 fn View::iter(Self) -> Iter[Byte]
 fn View::length(Self) -> Int
 fn View::op_as_view(Self, start? : Int, end? : Int) -> Self
 fn View::op_get(Self, Int) -> Byte
+fn View::rev_find(Self, Self) -> Int?
 fn View::start_offset(Self) -> Int
 fn View::to_bytes(Self) -> Bytes
 fn View::to_double_be(Self) -> Double
@@ -41,6 +43,7 @@ impl Compare for View
 impl Eq for View
 impl Show for View
 
+fn Bytes::find(Bytes, View) -> Int?
 fn Bytes::from_array(Array[Byte]) -> Bytes
 fn Bytes::from_fixedarray(FixedArray[Byte], len? : Int) -> Bytes
 fn Bytes::from_iter(Iter[Byte]) -> Bytes
@@ -49,6 +52,7 @@ fn Bytes::iter(Bytes) -> Iter[Byte]
 fn Bytes::iter2(Bytes) -> Iter2[Int, Byte]
 fn Bytes::of(FixedArray[Byte]) -> Bytes
 fn Bytes::op_as_view(Bytes, start? : Int, end? : Int) -> View
+fn Bytes::rev_find(Bytes, View) -> Int?
 fn Bytes::to_array(Bytes) -> Array[Byte]
 fn Bytes::to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
 impl Add for Bytes

--- a/bytes/find_test.mbt
+++ b/bytes/find_test.mbt
@@ -1,0 +1,43 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "find" {
+  inspect(b"hello".find("o"), content="Some(4)")
+  inspect(b"hello".find("l"), content="Some(2)")
+  inspect(b"hello".find("hello"), content="Some(0)")
+  inspect(b"hello".find("h"), content="Some(0)")
+  inspect(b"hello".find(""), content="Some(0)")
+  inspect(b"hello".find("world"), content="None")
+  inspect(b"".find(""), content="Some(0)")
+  inspect(b"".find("a"), content="None")
+  inspect(b"hello hello".find("hello"), content="Some(0)")
+  inspect(b"aaa".find("aa"), content="Some(0)")
+  inspect(b"aabaabaaa".find("aaa"), content="Some(6)")
+}
+
+///|
+test "rev_find" {
+  inspect(b"hello".rev_find("o"), content="Some(4)")
+  inspect(b"hello".rev_find("l"), content="Some(3)")
+  inspect(b"hello".rev_find("hello"), content="Some(0)")
+  inspect(b"hello".rev_find("h"), content="Some(0)")
+  inspect(b"hello".rev_find(""), content="Some(5)")
+  inspect(b"hello".rev_find("world"), content="None")
+  inspect(b"".rev_find(""), content="Some(0)")
+  inspect(b"".rev_find("a"), content="None")
+  inspect(b"hello hello".rev_find("hello"), content="Some(6)")
+  inspect(b"aaa".rev_find("aa"), content="Some(1)")
+  inspect(b"aabaaabaa".find("aaa"), content="Some(3)")
+}

--- a/bytes/methods.mbt
+++ b/bytes/methods.mbt
@@ -1,0 +1,63 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Returns the offset of the first occurrence of the given
+/// bytes substring. If the substring is not found, `None` is returned.
+pub fn View::find(target : View, pattern : View) -> Int? {
+  // TODO: more efficient algorithm
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  for i in 0..=(target_len - pattern_len) {
+    for j in 0..<pattern_len {
+      guard target.unsafe_get(i + j) == pattern.unsafe_get(j) else { break }
+    } else {
+      return Some(i)
+    }
+  } else {
+    None
+  }
+}
+
+///|
+/// Returns the offset of the first occurrence of the given
+/// bytes substring. If the substring is not found, `None` is returned.
+pub fn Bytes::find(target : Bytes, pattern : View) -> Int? {
+  target[:].find(pattern)
+}
+
+///|
+/// Returns the offset of the last occurrence of the given
+/// bytes substring. If the substring is not found, `None` is returned.
+pub fn View::rev_find(target : View, pattern : View) -> Int? {
+  // TODO: more efficient algorithm
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  for i = target_len - pattern_len; i >= 0; i = i - 1 {
+    for j in 0..<pattern_len {
+      guard target.unsafe_get(i + j) == pattern.unsafe_get(j) else { break }
+    } else {
+      return Some(i)
+    }
+  } else {
+    None
+  }
+}
+
+///|
+/// Returns the offset of the last occurrence of the given
+/// bytes substring. If the substring is not found, `None` is returned.
+pub fn Bytes::rev_find(target : Bytes, pattern : View) -> Int? {
+  target[:].rev_find(pattern)
+}


### PR DESCRIPTION
This PR adds `find` and `rev_find` API for `Bytes` and `@bytes.View`, similar to `String::find` and `String::rev_find`. These API are useful for parsing protocols such as HTTP, where headers etc. are separated by special ASCII sub bytes, such as `\r\n`.

Currently the implementation just uses brute-force searching. In the future we should migrate to a faster algorithm.