### PR TITLE
refactor: serialize nan/inf to string

### DIFF
--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -202,12 +202,15 @@ pub impl ToJson for UInt64 with to_json(self : UInt64) -> Json {
 
 ///|
 pub impl ToJson for Double with to_json(self : Double) -> Json {
-  if self != self ||
-    self > 0x7FEFFFFFFFFFFFFFL.reinterpret_as_double() ||
-    self < 0xFFEFFFFFFFFFFFFFL.reinterpret_as_double() {
-    return Null
+  if self != self {
+    Json::string("NaN")
+  } else if self > 0x7FEFFFFFFFFFFFFFL.reinterpret_as_double() {
+    Json::string("Infinity")
+  } else if self < 0xFFEFFFFFFFFFFFFFL.reinterpret_as_double() {
+    Json::string("-Infinity")
+  } else {
+    Json::number(self)
   }
-  Json::number(self)
 }
 
 ///|

--- a/builtin/json_test.mbt
+++ b/builtin/json_test.mbt
@@ -34,7 +34,23 @@ test "UInt to_json" {
 ///|
 test "double to json with positive infinity" {
   let pos_inf = 1.0 / 0.0
-  inspect(pos_inf.to_json(), content="Null")
+  inspect(
+    pos_inf.to_json(),
+    content=(
+      #|String("Infinity")
+    ),
+  )
+}
+
+///|
+test "double to json with negative infinity" {
+  let neg_inf = -1.0 / 0.0
+  inspect(
+    neg_inf.to_json(),
+    content=(
+      #|String("-Infinity")
+    ),
+  )
 }
 
 ///|

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -93,12 +93,13 @@ pub impl FromJson for UInt64 with from_json(json, path) {
 
 ///|
 pub impl FromJson for Double with from_json(json, path) {
-  guard json is Number(n, ..) &&
-    n != @double.infinity &&
-    n != @double.neg_infinity else {
-    decode_error(path, "Double::from_json: expected number")
+  match json {
+    String("NaN") => @double.not_a_number
+    String("Infinity") => @double.infinity
+    String("-Infinity") => @double.neg_infinity
+    Number(n, ..) if n != @double.infinity && n != @double.neg_infinity => n
+    _ => decode_error(path, "Double::from_json: expected number")
   }
-  n
 }
 
 ///|

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -379,9 +379,24 @@ test "stringify number" {
   inspect(nums[7].stringify(), content="9.999999999992234e+29")
   inspect(nums[8].stringify(), content="-1.7976931348623157e+308")
   inspect(nums[9].stringify(), content="1.7976931348623157e+308")
-  inspect(nums[10].stringify(), content="null")
-  inspect(nums[11].stringify(), content="null")
-  inspect(nums[12].stringify(), content="null")
+  inspect(
+    nums[10].stringify(),
+    content=(
+      #|"NaN"
+    ),
+  )
+  inspect(
+    nums[11].stringify(),
+    content=(
+      #|"Infinity"
+    ),
+  )
+  inspect(
+    nums[12].stringify(),
+    content=(
+      #|"-Infinity"
+    ),
+  )
   let err : Array[String] = []
   for json in nums {
     let json = @json.parse(json.stringify()) catch {

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -69,9 +69,24 @@ test "UInt64::to_json" {
 ///|
 test "Double::to_json" {
   inspect(42.0.to_json(), content="Number(42)")
-  inspect(@double.not_a_number.to_json(), content="Null")
-  inspect(@double.infinity.to_json(), content="Null")
-  inspect(@double.neg_infinity.to_json(), content="Null")
+  inspect(
+    @double.not_a_number.to_json(),
+    content=(
+      #|String("NaN")
+    ),
+  )
+  inspect(
+    @double.infinity.to_json(),
+    content=(
+      #|String("Infinity")
+    ),
+  )
+  inspect(
+    @double.neg_infinity.to_json(),
+    content=(
+      #|String("-Infinity")
+    ),
+  )
 }
 
 ///|


### PR DESCRIPTION
Currently, `nan` `+inf` and `-inf` are converted to `null` in the `impl ToJson for Double`. While this corresponds to the behavior of JavaScript, this creates an issue when we want to use `@json.inspect` upon such values.

As a result, we are serializing them to string, which can be recovered from the corresponding `FromJson`.