### PR TITLE
doc: update comments

### DIFF
--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -988,7 +988,7 @@ test "op_equal" {
 }
 
 ///|
-/// Compares two fixed arrays lexicographically based on their elements. First
+/// Compares two fixed arrays based on shortlex order by their elements. First
 /// compares the lengths of the arrays, then compares elements pairwise until a
 /// difference is found or all elements have been compared.
 ///

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -239,7 +239,7 @@ pub impl[T : Hash] Hash for Array[T] with hash_combine(self, hasher) {
 }
 
 ///|
-/// Compares two arrays lexicographically.
+/// Compares two arrays based on shortlex order.
 ///
 /// First compares the lengths of the arrays. If they differ, returns -1 if the
 /// first array is shorter, 1 if it's longer. If the lengths are equal, compares

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -319,7 +319,7 @@ pub impl Eq for Bytes with op_equal(self : Bytes, other : Bytes) -> Bool {
 }
 
 ///|
-/// Compares two byte sequences lexicographically. First compares the lengths of
+/// Compares two byte sequences based on shortlex order. First compares the lengths of
 /// the sequences, then compares bytes pairwise until a difference is found or
 /// all bytes have been compared.
 ///

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -462,13 +462,6 @@ pub impl Hash for String with hash_combine(self, hasher) {
 ///   let y = -42
 ///   inspect(Hash::hash(y), content="1617647962")
 /// ```
-/// TODO: This implementation is **different** from the default implementation of the hash trait. 
-/// So it will be replaced with the default implementation in the future **(breaking change)**, 
-/// and users should not rely on this particular hash value
-/// ```moonbit 
-///   let x = 42
-///   assert_not_eq(Hash::hash(x),Hasher::new()..combine(x).finalize())
-/// ```
 pub impl Hash for Int with hash(self) {
   let self = self.reinterpret_as_uint()
   let mut x = self ^ (self >> 17)

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -31,6 +31,15 @@ pub(open) trait Compare: Eq {
 
 ///|
 /// Trait for types that can be hashed
+/// 
+/// The `hash` method should return a hash value for the type, which is used in hash tables and other data structures.
+/// The `hash_combine` method is used to combine the hash of the current value with another hash value,
+/// typically used to hash composite types.
+/// 
+/// When two values are equal according to the `Eq` trait, they should produce the same hash value.
+/// 
+/// The `hash` method does not need to be implemented if `hash_combine` is implemented,
+/// When implemented separately, `hash` **does not need** to produce a hash value that is consistent with `hash_combine`.
 pub(open) trait Hash {
   hash_combine(Self, Hasher) -> Unit
   hash(Self) -> Int = _

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -573,7 +573,7 @@ pub impl Eq for View with op_equal(self, other) -> Bool {
 }
 
 ///|
-/// Compares two views lexicographically. First compares the lengths of
+/// Compares two views based on shortlex order. First compares the lengths of
 /// the views, then compares bytes pairwise until a difference is found or
 /// all bytes have been compared.
 ///

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1544,7 +1544,7 @@ pub fn[A : Compare] binary_search(self : T[A], value : A) -> Result[Int, Int] {
 }
 
 ///|
-/// Compares two deques lexicographically.
+/// Compares two deques based on shortlex order.
 ///
 /// First compares the lengths of the deques. If they differ, returns -1 if the
 /// first deque is shorter, 1 if it's longer. If the lengths are equal, compares

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -415,7 +415,7 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 }
 
 ///|
-/// Compares two arrays lexicographically.
+/// Compares two arrays based on shortlex order.
 ///
 /// First compares the lengths of the arrays. If they differ, returns -1 if the
 /// first array is shorter, 1 if it's longer. If the lengths are equal, compares

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -1207,7 +1207,7 @@ pub impl[A : Hash] Hash for T[A] with hash_combine(self, hasher) {
 }
 
 ///|
-/// Compares two lists lexicographically.
+/// Compares two lists based on shortlex order.
 ///
 /// First compares elements pairwise until a difference is found.
 /// If lists have different lengths and all shared elements are equal,

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -301,7 +301,7 @@ pub impl[A : Hash + Compare] Hash for T[A] with hash_combine(self, hasher) {
 }
 
 ///|
-/// Compare two priority queues lexicographically by comparing their sorted contents.
+/// Compare two priority queues based on shortlex order by comparing their sorted contents.
 ///
 /// Parameters:
 ///

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -52,7 +52,7 @@ pub fn from_iter(iter : Iter[Char]) -> String {
 }
 
 ///|
-/// Strings are ordered lexicographically by their charcodes(code unit). This 
+/// Strings are ordered based on shortlex order by their charcodes (code units). This 
 /// orders Unicode characters based on their positions in the code charts. This is
 /// not necessarily the same as "alphabetical" order, which varies by language
 /// and locale.

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -338,7 +338,7 @@ pub impl Eq for View with op_equal(self, other) {
 }
 
 ///|
-/// Views are ordered lexicographically by their charcodes(code unit). This 
+/// Views are ordered based on shortlex order by their charcodes (code units). This 
 /// orders Unicode characters based on their positions in the code charts. This is
 /// not necessarily the same as "alphabetical" order, which varies by language
 /// and locale.


### PR DESCRIPTION
This PR updates comments for
1. Hash, making it clear that the current inconsistency between `hash` and `hash_combine` is fine. The TODO notice is removed.
2. Compare, making it clear that we are using [shortlex order](https://en.wikipedia.org/wiki/Shortlex_order) instead of pure lexicographical order.