### PR TITLE
doc: Update comments

### DIFF
--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -90,7 +90,7 @@ pub fnalias @builtin.(
 /// ```mbt
 /// let val : Ref[Int] = { val : 1 }
 /// let x : Int = 5
-/// assert_eq(x |> tap((n) => { val.val += n }), 5)
+/// assert_eq(x |> tap(n => val.val += n), 5)
 /// // This is not allowed
 /// // x |> (val.val += _)
 /// assert_eq(val.val, 6)
@@ -113,7 +113,7 @@ pub fn[T] tap(value : T, f : (T) -> Unit) -> T {
 /// # Examples
 /// ```moonbit
 /// let x = 5
-/// let result = x |> then((n) => { n * 2 })
+/// let result = x |> then(n => n * 2)
 /// // This is not allowed
 /// // x |> (_ * 2)
 /// assert_eq(result, 10)


### PR DESCRIPTION
This PR updates comments for two built-in functions in `prelude.mbt`: `tap` and `then`. 

changes: Update the arrow function style to latest concise syntax. Since pipeline can only pass one value, the parenthesis can be omitted in this case.
