### PR TITLE
introduce null

### DIFF
--- a/builtin/builtin.mbti
+++ b/builtin/builtin.mbti
@@ -30,6 +30,8 @@ fn inspect(&Show, content? : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> U
 
 fn not(Bool) -> Bool
 
+let null : Json
+
 fn[T : Compare] op_ge(T, T) -> Bool
 
 fn[T : Compare] op_gt(T, T) -> Bool

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -41,15 +41,13 @@ pub impl Eq for Json with op_equal(a, b) {
 /// Creates a JSON null value.
 ///
 /// Returns a JSON value representing `null`.
-///
-/// Example:
-///
-/// ```moonbit
-///   inspect(Json::null(), content="Null")
-/// ```
+#deprecated("Use `null` instead")
 pub fn Json::null() -> Json {
   return Null
 }
+
+///|
+pub let null : Json = Null
 
 ///|
 /// Creates a JSON number value from a double-precision floating-point number.

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -41,7 +41,6 @@ pub impl Eq for Json with op_equal(a, b) {
 /// Creates a JSON null value.
 ///
 /// Returns a JSON value representing `null`.
-#deprecated("Use `null` instead")
 pub fn Json::null() -> Json {
   return Null
 }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1266,7 +1266,7 @@ pub fn T::join(self : T[String], separator : @string.View) -> String {
 /// ```
 ///
 pub impl[A : ToJson] ToJson for T[A] with to_json(self : T[A]) -> Json {
-  let res = Array::make(self.length(), Json::null())
+  let res = Array::make(self.length(), null)
   for i, x in self {
     res[i] = x.to_json()
   }

--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -139,7 +139,7 @@ This is particularly true for deeply-nested data structures.
 
 ```moonbit
 test "json inspection" {
-  let null = Json::null() 
+  let null = null 
 
   // Simple json values
   let json_value : Json = { "key": "value", "numbers": [1, 2, 3] }

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -366,7 +366,7 @@ test "jsonvalue" {
   let u = Json::boolean(false)
   let v : Json = @json.from_json(u)
   inspect(v, content="False")
-  let u = Json::null()
+  let u = null
   let v : Json = @json.from_json(u)
   inspect(v, content="Null")
   let u = Json::array([Json::number(1), Json::string("str")])
@@ -520,7 +520,7 @@ test "string view from json" {
 
 ///|
 test "Bool from_json error handling" {
-  let json_null = Json::null()
+  let json_null = null
   let result : Result[Bool, _] = try? @json.from_json(json_null)
   inspect(
     result,

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "get as null" {
-  inspect(Json::null().as_null(), content="Some(())")
+  inspect(null.as_null(), content="Some(())")
   inspect(Json::boolean(true).as_null(), content="None")
   inspect(Json::boolean(false).as_null(), content="None")
   inspect(Json::number(1.0).as_null(), content="None")
@@ -28,7 +28,7 @@ test "get as null" {
 
 ///|
 test "get as bool" {
-  inspect(Json::null().as_bool(), content="None")
+  inspect(null.as_bool(), content="None")
   inspect(Json::boolean(true).as_bool(), content="Some(true)")
   inspect(Json::boolean(false).as_bool(), content="Some(false)")
   inspect(Json::number(1.0).as_bool(), content="None")
@@ -49,7 +49,7 @@ fn _check2(x : String) -> Json raise @json.ParseError {
 
 ///|
 test "get as number" {
-  inspect(Json::null().as_number(), content="None")
+  inspect(null.as_number(), content="None")
   inspect(Json::boolean(false).as_number(), content="None")
   inspect(Json::boolean(true).as_number(), content="None")
   inspect(Json::number(1.0).as_number(), content="Some(1)")
@@ -68,7 +68,7 @@ test "get as number" {
 
 ///|
 test "get as string" {
-  inspect(Json::null().as_string(), content="None")
+  inspect(null.as_string(), content="None")
   inspect(Json::boolean(true).as_string(), content="None")
   inspect(Json::boolean(false).as_string(), content="None")
   inspect(Json::number(1.0).as_string(), content="None")
@@ -92,7 +92,7 @@ test "get as string" {
 
 ///|
 test "get as array" {
-  inspect(Json::null().as_array(), content="None")
+  inspect(null.as_array(), content="None")
   inspect(Json::boolean(true).as_array(), content="None")
   inspect(Json::boolean(false).as_array(), content="None")
   inspect(Json::number(1.0).as_array(), content="None")
@@ -127,7 +127,7 @@ test "get as array" {
 
 ///|
 test "get as object" {
-  inspect(Json::null().as_object().map(_.to_array()), content="None")
+  inspect(null.as_object().map(_.to_array()), content="None")
   inspect(Json::boolean(true).as_object().map(_.to_array()), content="None")
   inspect(Json::boolean(false).as_object().map(_.to_array()), content="None")
   inspect(Json::number(1.0).as_object().map(_.to_array()), content="None")
@@ -188,10 +188,10 @@ test "get as object" {
 ///|
 test "deep access" {
   let json : Json = {
-    "key": [1.0, true, Json::null(), [], { "key": "value", "value": 100.0 }],
+    "key": [1.0, true, null, [], { "key": "value", "value": 100.0 }],
     "int": 12345,
     "double": 123.45,
-    "null": Json::null(),
+    "null": null,
     "bool": false,
     "obj": {},
   }
@@ -230,10 +230,10 @@ test "deep access" {
 ///|
 test "stringify" {
   let json : Json = {
-    "key": [1.0, true, Json::null(), [], { "key": "value", "value": 100.0 }],
+    "key": [1.0, true, null, [], { "key": "value", "value": 100.0 }],
     "int": 12345,
     "double": 123.45,
-    "null": Json::null(),
+    "null": null,
     "bool": false,
     "obj": {},
   }
@@ -421,10 +421,10 @@ test "stringify number" {
 ///|
 test "stringify with indent" {
   let json : Json = {
-    "key": [1.0, true, Json::null(), [], { "key": "value", "value": 100.0 }],
+    "key": [1.0, true, null, [], { "key": "value", "value": 100.0 }],
     "int": 12345,
     "double": 123.45,
-    "null": Json::null(),
+    "null": null,
     "bool": false,
     "obj": {},
   }

--- a/json/json_traverse_test.mbt
+++ b/json/json_traverse_test.mbt
@@ -93,7 +93,7 @@ fn Json::prune_loc_test(self : Json) -> Json {
 ///|
 test "prune_loc - primitive values" {
   // Null, True, False, Number, String should be preserved as-is
-  inspect(Json::null().prune_loc(), content="Some(Null)")
+  inspect(null.prune_loc(), content="Some(Null)")
   inspect(Json::boolean(true).prune_loc(), content="Some(True)")
   inspect(Json::boolean(false).prune_loc(), content="Some(False)")
   inspect(Json::number(42.0).prune_loc(), content="Some(Number(42))")
@@ -107,7 +107,7 @@ test "prune_loc - arrays" {
 
   // Array with primitives
   let arr1 = Json::array([
-    Json::null(),
+    null,
     Json::boolean(true),
     Json::number(123.0),
     Json::string("test"),
@@ -141,7 +141,7 @@ test "prune_loc - objects with loc key" {
       "column": Json::number(5.0),
     }),
   }
-  @json.inspect(obj_only_loc.prune_loc(), content=Json::null()) // FIXME: None -> Null
+  @json.inspect(obj_only_loc.prune_loc(), content=null) // FIXME: None -> Null
 
   // Object with "loc" and other keys - "loc" should be removed
   let obj_with_loc : Json = {
@@ -172,7 +172,7 @@ test "prune_loc - nested objects" {
   }
   @json.inspect(
     nested2.prune_loc(),
-    content=Json::null(), // FIXME: None -> Null
+    content=null, // FIXME: None -> Null
   )
 }
 

--- a/json/parse.mbt
+++ b/json/parse.mbt
@@ -46,7 +46,7 @@ fn ParseContext::parse_value2(
   tok : Token,
 ) -> JsonValue raise ParseError {
   match tok {
-    Null => Json::null()
+    Null => null
     True => Json::boolean(true)
     False => Json::boolean(false)
     Number(n, repr) => Json::number(n, repr?)

--- a/json/parse_test.mbt
+++ b/json/parse_test.mbt
@@ -102,7 +102,7 @@ test "parses nested arrays" {
 ///|
 test "parses nulls" {
   let json = test_parse("null")
-  assert_eq(json, Json::null())
+  assert_eq(json, null)
 }
 //endregion
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -121,3 +121,6 @@ pub fn[T] tap(value : T, f : (T) -> Unit) -> T {
 pub fn[T, R] then(value : T, f : (T) -> R) -> R {
   f(value)
 }
+
+///|
+pub let null : Json = @builtin.null

--- a/prelude/prelude.mbti
+++ b/prelude/prelude.mbti
@@ -34,6 +34,8 @@ fn inspect(&@builtin.Show, content? : String, loc~ : @builtin.SourceLoc, args_lo
 
 fn not(Bool) -> Bool
 
+let null : @builtin.Json
+
 fn[T] panic() -> T
 
 fn[T] physical_equal(T, T) -> Bool


### PR DESCRIPTION
Note CI fails, because `derive(ToJson)` used `Json::null()` which is not really needed.

CI run `moon check --deny-warn` caught this error, while `moon check` skip this error, due to missing location, 
`moon check --render-no-loc warn` would find this location

cc @lynzrand 

As a temporary workaround, I would keep Json::null for a while