### PR TITLE
refactor: start api migrations

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -167,15 +167,26 @@ fn[K : Eq, V] add_with_path(
 
 ///|
 /// Filter values that satisfy the predicate
+#deprecated("Use `filter_with_key` instead. `filter` will accept `(K, V) -> Bool` in the future.")
+#coverage.skip
 pub fn[K, V] filter(
   self : T[K, V],
   pred : (V) -> Bool raise?,
 ) -> T[K, V] raise? {
+  self.filter_with_key((_, v) => pred(v))
+}
+
+///|
+/// Filter entries that satisfy the predicate
+pub fn[K, V] filter_with_key(
+  self : T[K, V],
+  pred : (K, V) -> Bool raise?,
+) -> T[K, V] raise? {
   fn go(node) raise? {
     match node {
       Leaf(key1, value1, bucket) => {
-        let new_bucket = bucket.filter(kv => pred(kv.1))
-        if pred(value1) {
+        let new_bucket = bucket.filter(kv => pred(kv.0, kv.1))
+        if pred(key1, value1) {
           Some(Leaf(key1, value1, new_bucket))
         } else {
           match new_bucket {
@@ -184,7 +195,12 @@ pub fn[K, V] filter(
           }
         }
       }
-      Flat(_, value1, _) => if pred(value1) { Some(node) } else { None }
+      Flat(key1, value1, _) =>
+        if pred(key1, value1) {
+          Some(node)
+        } else {
+          None
+        }
       Branch(children) =>
         match children.filter(go) {
           None => None
@@ -201,6 +217,7 @@ pub fn[K, V] filter(
 
 ///|
 /// Fold the values in the map
+#deprecated("Use `fold_with_key` instead. `fold` will accept `(A, K, V) -> A` in the future.")
 pub fn[K, V, A] fold(
   self : T[K, V],
   init~ : A,
@@ -236,6 +253,8 @@ pub fn[K, V, A] fold_with_key(
 
 ///|
 /// Maps over the values in the map
+#deprecated("Use `map_with_key` instead. `map` will accept `(K, V) -> A` in the future.")
+#coverage.skip
 pub fn[K, V, A] map(self : T[K, V], f : (V) -> A raise?) -> T[K, A] raise? {
   self.map_with_key((_k, v) => f(v))
 }
@@ -616,15 +635,9 @@ pub fn[K, V] keys(self : T[K, V]) -> Iter[K] {
 
 ///|
 /// Returns all values of the map
+#alias(elems, deprecated="Use `values` instead")
 pub fn[K, V] values(self : T[K, V]) -> Iter[V] {
   self.iter().map(p => p.1)
-}
-
-///|
-#deprecated("Use `values` instead")
-#coverage.skip
-pub fn[K, V] elems(self : T[K, V]) -> Iter[V] {
-  self.values()
 }
 
 ///|

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -290,7 +290,7 @@ test "HAMT::contains" {
 ///|
 test "filter with simple predicate" {
   let map = @hashmap.of([(1, 1), (2, 2), (3, 3), (4, 4)])
-  let only_even = map.filter(v => v % 2 == 0)
+  let only_even = map.filter_with_key((_, v) => v % 2 == 0)
   inspect(only_even.contains(1), content="false")
   inspect(only_even.contains(2), content="true")
   inspect(only_even.contains(3), content="false")
@@ -300,7 +300,7 @@ test "filter with simple predicate" {
 ///|
 test "filter with all elements matching" {
   let map = @hashmap.of([(1, 1), (2, 2)])
-  let filtered = map.filter(v => v > 0)
+  let filtered = map.filter_with_key((_, v) => v > 0)
   inspect(filtered.contains(1), content="true")
   inspect(filtered.contains(2), content="true")
 }
@@ -308,7 +308,7 @@ test "filter with all elements matching" {
 ///|
 test "filter with no elements matching" {
   let map = @hashmap.of([(1, 1), (2, 2), (3, 3)])
-  let filtered = map.filter(v => v > 10)
+  let filtered = map.filter_with_key((_, v) => v > 10)
   assert_eq(filtered.get(1), None)
   assert_eq(filtered.get(2), None)
   assert_eq(filtered.get(3), None)
@@ -318,7 +318,7 @@ test "filter with no elements matching" {
 ///|
 test "filter with collision" {
   let map = @hashmap.of([(1, 10), (2, 20)]).add(1, 30)
-  let filtered = map.filter(v => v == 30)
+  let filtered = map.filter_with_key((_, v) => v == 30)
   assert_eq(filtered.get(1), Some(30))
   assert_eq(filtered.get(2), None)
 }
@@ -329,7 +329,7 @@ test "filter with branch nodes" {
     (10, map) => map
     (i, map) => continue (i + 1, map.add(i, i * 10))
   }
-  let filtered = map.filter(v => v % 20 == 0)
+  let filtered = map.filter_with_key((_, v) => v % 20 == 0)
   for i in 0..<10 {
     if i * 10 % 20 == 0 {
       assert_eq(filtered.get(i), Some(i * 10))
@@ -351,14 +351,14 @@ test "HAMT::fold_with_key" {
 ///|
 test "HAMT::fold" {
   let map = @hashmap.of([(1, 10), (2, 20), (3, 30)])
-  let result = map.fold(init=0, (acc, v) => acc + v)
+  let result = map.fold_with_key(init=0, (acc, _, v) => acc + v)
   inspect(result, content="60")
 }
 
 ///|
 test "HAMT::map" {
   let map = @hashmap.of([(1, 10), (2, 20)])
-  let mapped = map.map(v => v * 2)
+  let mapped = map.map_with_key((_, v) => v * 2)
   assert_eq(mapped.get(1), Some(20))
   assert_eq(mapped.get(2), Some(40))
   assert_eq(mapped.get(3), None)
@@ -368,7 +368,7 @@ test "HAMT::map" {
 test "HAMT::map with overflow" {
   let max = 2147483647 // Int.max_value
   let map = @hashmap.of([(1, max)])
-  let mapped = map.map(v => v + 1)
+  let mapped = map.map_with_key((_, v) => v + 1)
   assert_eq(mapped.get(1), Some(-2147483648))
 }
 
@@ -458,21 +458,21 @@ test "add_with_hash collision" {
 ///|
 test "empty filtering" {
   let map : @hashmap.T[Int, Int] = @hashmap.of([])
-  let _filtered = map.filter(v => v > 2)
+  let _filtered = map.filter_with_key((_, v) => v > 2)
   inspect(map.size(), content="0")
 }
 
 ///|
 test "filter with collision - all removed" {
   let map = @hashmap.of([(MyString("a"), 1), (MyString("b"), 2)])
-  let filtered = map.filter(v => v > 2)
+  let filtered = map.filter_with_key((_, v) => v > 2)
   inspect(filtered.size(), content="0")
 }
 
 ///|
 test "filter with collision - one left" {
   let map = @hashmap.of([(MyString("a"), 1), (MyString("b"), 2)])
-  let filtered = map.filter(v => v == 1)
+  let filtered = map.filter_with_key((_, v) => v == 1)
   inspect(filtered.size(), content="1")
 }
 
@@ -483,7 +483,7 @@ test "filter with collision - more than one left" {
     (MyString("b"), 2),
     (MyString("c"), 3),
   ])
-  let filtered = map.filter(v => v > 1)
+  let filtered = map.filter_with_key((_, v) => v > 1)
   inspect(filtered.size(), content="2")
 }
 

--- a/immut/hashmap/pkg.generated.mbti
+++ b/immut/hashmap/pkg.generated.mbti
@@ -25,10 +25,11 @@ fn[K : Eq + Hash, V] T::contains(Self[K, V], K) -> Bool
 fn[K : Eq, V] T::difference(Self[K, V], Self[K, V]) -> Self[K, V]
 fn[K, V] T::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 #deprecated
-fn[K, V] T::elems(Self[K, V]) -> Iter[V]
 fn[K, V] T::filter(Self[K, V], (V) -> Bool raise?) -> Self[K, V] raise?
+fn[K, V] T::filter_with_key(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
 #deprecated
 fn[K : Eq + Hash, V] T::find(Self[K, V], K) -> V?
+#deprecated
 fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A raise?) -> A raise?
 fn[K, V, A] T::fold_with_key(Self[K, V], init~ : A, (A, K, V) -> A raise?) -> A raise?
 fn[K : Eq + Hash, V] T::get(Self[K, V], K) -> V?
@@ -37,6 +38,7 @@ fn[K : Eq, V] T::intersection_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?
 fn[K, V] T::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] T::iter2(Self[K, V]) -> Iter2[K, V]
 fn[K, V] T::keys(Self[K, V]) -> Iter[K]
+#deprecated
 fn[K, V, A] T::map(Self[K, V], (V) -> A raise?) -> Self[K, A] raise?
 fn[K, V, A] T::map_with_key(Self[K, V], (K, V) -> A raise?) -> Self[K, A] raise?
 #deprecated
@@ -46,6 +48,7 @@ fn[K, V] T::size(Self[K, V]) -> Int
 fn[K, V] T::to_array(Self[K, V]) -> Array[(K, V)]
 fn[K : Eq, V] T::union(Self[K, V], Self[K, V]) -> Self[K, V]
 fn[K : Eq, V] T::union_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?) -> Self[K, V] raise?
+#alias(elems, deprecated)
 fn[K, V] T::values(Self[K, V]) -> Iter[V]
 impl[K : Eq, V : Eq] Eq for T[K, V]
 impl[K : Hash, V : Hash] Hash for T[K, V]

--- a/immut/sorted_map/README.mbt.md
+++ b/immut/sorted_map/README.mbt.md
@@ -1,4 +1,3 @@
-
 # Immutable Map
 
 An immutable tree map based on size balanced tree.
@@ -7,7 +6,8 @@ An immutable tree map based on size balanced tree.
 
 ## Create
 
-You can create an empty map using `new()` or construct it with a single key-value pair using `singleton()`.
+You can create an empty map using `new()` or construct it with a single
+key-value pair using `singleton()`.
 
 ```moonbit
 test {
@@ -30,7 +30,8 @@ test {
 
 ## Insert & Lookup
 
-You can use `add()` to add a key-value pair to the map and create a new map. Or use `lookup()` to get the value associated with a key.
+You can use `add()` to add a key-value pair to the map and create a new map. Or
+use `lookup()` to get the value associated with a key.
 
 ```moonbit
 test {
@@ -100,36 +101,42 @@ test {
 }
 ```
 
-Use `map()` or `map_with_key()` to map a function over all values.
+Use `map_with_key()` to map a function over all values.
 
 ```moonbit
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
-  let map = map.map((v) => { v + 1 })
+  let map = map.map_with_key((_, v) => { v + 1 })
   assert_eq(map.values().collect(), [2, 3, 4])
   let map = map.map_with_key((_k, v) => { v + 1 })
   assert_eq(map.values().collect(), [3, 4, 5])
 }
 ```
 
-Use `fold()` or `foldl_with_key()` to fold the values in the map. The default order of fold is Pre-order.
-Similarly, you can use `foldr_with_key()` to do a Post-order fold.
+Use `foldl_with_key()` to fold the values in the map. The default order of fold
+is Pre-order. Similarly, you can use `rev_fold()` to do a Post-order fold.
 
 ```moonbit
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
-  assert_eq(map.fold((acc, v) => { acc + v }, init=0), 6) // 6
-  assert_eq(map.foldl_with_key((acc, k, v) => { acc + k + v.to_string() }, init=""), "a1b2c3") // "a1b2c3"
-  assert_eq(map.foldr_with_key((acc, k, v) => { acc + k + v.to_string() }, init=""), "c3b2a1") // "c3b2a1"
+  assert_eq(map.foldl_with_key((acc, _, v) => acc + v, init=0), 6) // 6
+  assert_eq(
+    map.foldl_with_key((acc, k, v) => acc + k + v.to_string(), init=""),
+    "a1b2c3",
+  ) // "a1b2c3"
+  assert_eq(
+    map.rev_fold((acc, k, v) => acc + k + v.to_string(), init=""),
+    "c3b2a1",
+  ) // "c3b2a1"
 }
 ```
 
-Use `filter()` or `filter_with_key()` to filter all keys/values that satisfy the predicate.
+Use `filter_with_key()` to filter all keys/values that satisfy the predicate.
 
 ```moonbit
 test {
   let map = @sorted_map.of([("a", 1), ("b", 2), ("c", 3)])
-  let map = map.filter((v) => { v > 1 })
+  let map = map.filter_with_key((_, v) => { v > 1 })
   assert_eq(map.values().collect(), [2, 3])
   assert_eq(map.keys_as_iter().collect(), ["b", "c"])
   let map = map.filter_with_key((k, v) => { k > "a" && v > 1 })
@@ -159,4 +166,3 @@ test {
   assert_eq(keys.collect(), ["a", "b", "c"])
 }
 ```
-

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -93,6 +93,8 @@ pub fn[K : Compare, V] remove(self : T[K, V], key : K) -> T[K, V] {
 
 ///|
 /// Filter values that satisfy the predicate
+#deprecated("Use `filter_with_key` instead. `filter` will accept `(K, V) -> Bool` in the future.")
+#coverage.skip
 pub fn[K : Compare, V] filter(
   self : T[K, V],
   pred : (V) -> Bool raise?,

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -79,7 +79,7 @@ test "iteri" {
 ///|
 test "fold" {
   let m = @sorted_map.of([("a", 1), ("b", 2), ("c", 3), ("d", 4), ("e", 5)])
-  assert_eq(m.fold((acc, v) => acc + v, init=0), 15)
+  assert_eq(m.foldl_with_key((acc, _, v) => acc + v, init=0), 15)
 }
 
 ///|

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -31,11 +31,12 @@ fn[K, V] T::eachi(Self[K, V], (Int, K, V) -> Unit) -> Unit
 fn[K, V] T::elems(Self[K, V]) -> Array[V]
 #deprecated
 fn[K, V] T::empty() -> Self[K, V]
+#deprecated
 fn[K : Compare, V] T::filter(Self[K, V], (V) -> Bool raise?) -> Self[K, V] raise?
 fn[K : Compare, V] T::filter_with_key(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
+#deprecated
 fn[K, V, A] T::fold(Self[K, V], init~ : A, (A, V) -> A) -> A
 fn[K, V, A] T::foldl_with_key(Self[K, V], (A, K, V) -> A, init~ : A) -> A
-fn[K, V, A] T::foldr_with_key(Self[K, V], (A, K, V) -> A, init~ : A) -> A
 #deprecated
 fn[K : Compare, V] T::from_array(Array[(K, V)]) -> Self[K, V]
 #deprecated
@@ -53,6 +54,7 @@ fn[K, V] T::keys(Self[K, V]) -> Array[K]
 fn[K, V] T::keys_as_iter(Self[K, V]) -> Iter[K]
 #deprecated
 fn[K : Compare, V] T::lookup(Self[K, V], K) -> V?
+#deprecated
 fn[K, X, Y] T::map(Self[K, X], (X) -> Y) -> Self[K, Y]
 fn[K, X, Y] T::map_with_key(Self[K, X], (K, X) -> Y) -> Self[K, Y]
 #deprecated
@@ -61,6 +63,8 @@ fn[K, V] T::new() -> Self[K, V]
 fn[K : Compare, V] T::of(FixedArray[(K, V)]) -> Self[K, V]
 fn[K : Compare, V] T::op_get(Self[K, V], K) -> V
 fn[K : Compare, V] T::remove(Self[K, V], K) -> Self[K, V]
+#alias(foldr_with_key)
+fn[K, V, A] T::rev_fold(Self[K, V], (A, K, V) -> A, init~ : A) -> A
 #deprecated
 fn[K, V] T::singleton(K, V) -> Self[K, V]
 fn[K, V] T::size(Self[K, V]) -> Int

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -150,6 +150,8 @@ pub fn[K, V] eachi(self : T[K, V], f : (Int, K, V) -> Unit) -> Unit {
 
 ///|
 /// Ts over the values in the map.
+#deprecated("Use `map_with_key` instead. `map` will accept `(K, X) -> Y` in the future.")
+#coverage.skip
 pub fn[K, X, Y] map(self : T[K, X], f : (X) -> Y) -> T[K, Y] {
   match self {
     Empty => Empty
@@ -171,6 +173,7 @@ pub fn[K, X, Y] map_with_key(self : T[K, X], f : (K, X) -> Y) -> T[K, Y] {
 ///|
 /// Fold the values in the map.
 /// O(n).
+#deprecated("Use `foldl_with_key` instead. `fold` will accept `(A, K, V) -> A` in the future.")
 pub fn[K, V, A] fold(self : T[K, V], init~ : A, f : (A, V) -> A) -> A {
   self.foldl_with_key((acc, _k, v) => f(acc, v), init~)
 }
@@ -178,11 +181,8 @@ pub fn[K, V, A] fold(self : T[K, V], init~ : A, f : (A, V) -> A) -> A {
 ///|
 /// Post-order fold.
 /// O(n).
-pub fn[K, V, A] foldr_with_key(
-  self : T[K, V],
-  f : (A, K, V) -> A,
-  init~ : A,
-) -> A {
+#alias(foldr_with_key)
+pub fn[K, V, A] rev_fold(self : T[K, V], f : (A, K, V) -> A, init~ : A) -> A {
   fn go(m : T[K, V], acc) {
     match m {
       Empty => acc


### PR DESCRIPTION
The first commit add deprecation warnings for immutable maps. This start a migration phase and they would have the same APIs as the mutable ones after the migration.

The rest of the APIs adjust the constructor APIs, allowing the existence of `T::from_array`, which might be more intuitive to use when trying to define new instances.