### PR TITLE
refactor(array): optimize makei

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -53,42 +53,6 @@ pub fn[T] Array::push_iter(self : Self[T], iter : Iter[T]) -> Unit {
 }
 
 ///|
-/// Creates a new array of the specified length, where each element is
-/// initialized using an index-based initialization function.
-///
-/// Parameters:
-///
-/// * `length` : The length of the new array. If `length` is less than or equal
-/// to 0, returns an empty array.
-/// * `initializer` : A function that takes an index (starting from 0) and
-/// returns a value of type `T`. This function is called for each index to
-/// initialize the corresponding element.
-///
-/// Returns a new array of type `Array[T]` with the specified length, where each
-/// element is initialized using the provided function.
-///
-/// Example:
-///
-/// ```moonbit
-///   let arr = Array::makei(3, i => i * 2)
-///   inspect(arr, content="[0, 2, 4]")
-/// ```
-pub fn[T] Array::makei(
-  length : Int,
-  value : (Int) -> T raise?,
-) -> Array[T] raise? {
-  if length <= 0 {
-    []
-  } else {
-    let array = Array::make(length, value(0))
-    for i in 1..<length {
-      array[i] = value(i)
-    }
-    array
-  }
-}
-
-///|
 /// Shuffle the array using Knuth shuffle
 /// 
 /// To use this function, you need to provide a rand function, which takes an integer as it upper bound

--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -55,7 +55,6 @@ fn[A, B] Array::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 fn[T] Array::from_iter(Iter[T]) -> Self[T]
 fn[A : @string.ToStringView] Array::join(Self[A], @string.View) -> String
 fn[A] Array::last(Self[A]) -> A?
-fn[T] Array::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 fn[T] Array::push_iter(Self[T], Iter[T]) -> Unit
 fn[T] Array::shuffle(Self[T], rand~ : (Int) -> Int) -> Self[T]
 fn[T] Array::shuffle_in_place(Self[T], rand~ : (Int) -> Int) -> Unit

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -76,6 +76,43 @@ pub fn[T] Array::make(len : Int, elem : T) -> Array[T] {
 }
 
 ///|
+/// Creates a new array of the specified length, where each element is
+/// initialized using an index-based initialization function.
+///
+/// Parameters:
+///
+/// * `length` : The length of the new array. If `length` is less than or equal
+/// to 0, returns an empty array.
+/// * `initializer` : A function that takes an index (starting from 0) and
+/// returns a value of type `T`. This function is called for each index to
+/// initialize the corresponding element.
+///
+/// Returns a new array of type `Array[T]` with the specified length, where each
+/// element is initialized using the provided function.
+///
+/// Example:
+///
+/// ```moonbit
+///   let arr = Array::makei(3, i => i * 2)
+///   inspect(arr, content="[0, 2, 4]")
+/// ```
+#locals(value)
+pub fn[T] Array::makei(
+  length : Int,
+  value : (Int) -> T raise?,
+) -> Array[T] raise? {
+  if length <= 0 {
+    []
+  } else {
+    let array = Array::make_uninit(length)
+    for i in 0..<length {
+      array.unsafe_set(i, value(i))
+    }
+    array
+  }
+}
+
+///|
 /// Returns the total capacity of the array, which is the number of elements that
 /// the array can hold without requiring reallocation of its internal buffer.
 ///

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -107,6 +107,7 @@ fn[T] Array::iter(Self[T]) -> Iter[T]
 fn[A] Array::iter2(Self[A]) -> Iter2[Int, A]
 fn[T] Array::length(Self[T]) -> Int
 fn[T] Array::make(Int, T) -> Self[T]
+fn[T] Array::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 fn[T, U] Array::map(Self[T], (T) -> U raise?) -> Self[U] raise?
 fn[T] Array::map_inplace(Self[T], (T) -> T raise?) -> Unit raise?
 fn[T, U] Array::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?


### PR DESCRIPTION
This PR optimizes `makei` in two aspects:
* add `#locals` attribute so that it can be more aggressively inlined
* use `Array::make_uninit` to allocate so that one iteration can be saved for scalar element type.

Out FFT benchmark before this optimization:
<img width="741" height="363" alt="image" src="https://github.com/user-attachments/assets/0dc866bb-0333-47ce-ad51-bf974bc84e09" />


With this optimization:
<img width="736" height="358" alt="image" src="https://github.com/user-attachments/assets/57ed8be4-5b22-4875-8dd9-cfe6d30cdd3c" />
