### PR TITLE
hongbo/trait name migrations

### DIFF
--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -1047,7 +1047,7 @@ pub impl[T : Compare] Compare for FixedArray[T] with compare(self, other) {
 ///   let arr2 : FixedArray[Int] = [4, 5, 6]
 ///   inspect(arr1 + arr2, content="[1, 2, 3, 4, 5, 6]")
 /// ```
-pub impl[T] Add for FixedArray[T] with op_add(self, other) {
+pub impl[T] Add for FixedArray[T] with add(self, other) {
   let slen = self.length()
   let nlen = other.length()
   FixedArray::makei(slen + nlen, i => if i < slen {

--- a/array/fixedarray.mbt
+++ b/array/fixedarray.mbt
@@ -944,7 +944,7 @@ test "ends_with" {
 ///   inspect(arr1 == arr2, content="true")
 ///   inspect(arr1 == arr3, content="false")
 /// ```
-pub impl[T : Eq] Eq for FixedArray[T] with op_equal(
+pub impl[T : Eq] Eq for FixedArray[T] with equal(
   self : FixedArray[T],
   that : FixedArray[T],
 ) -> Bool {

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -458,7 +458,7 @@ pub impl[X : Show] Show for View[X] with output(self, logger) {
 }
 
 ///|
-pub impl[T : Eq] Eq for View[T] with op_equal(self, other) -> Bool {
+pub impl[T : Eq] Eq for View[T] with equal(self, other) -> Bool {
   if self.length() != other.length() {
     return false
   }

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -129,7 +129,7 @@ extern "js" fn BigInt::equal(self : BigInt, other : BigInt) -> Bool =
   #|(x, y) => x === y
 
 ///|
-pub impl Eq for BigInt with op_equal(self, other) {
+pub impl Eq for BigInt with equal(self, other) {
   self.equal(other)
 }
 

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -158,7 +158,7 @@ extern "js" fn BigInt::op_neg_ffi(self : BigInt) -> BigInt =
   #|(x) => -x
 
 ///|
-pub impl Neg for BigInt with op_neg(self) {
+pub impl Neg for BigInt with neg(self) {
   self.op_neg_ffi()
 }
 
@@ -167,7 +167,7 @@ extern "js" fn BigInt::op_add_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x + y
 
 ///|
-pub impl Add for BigInt with op_add(self, other) {
+pub impl Add for BigInt with add(self, other) {
   self.op_add_ffi(other)
 }
 
@@ -176,7 +176,7 @@ extern "js" fn BigInt::op_sub_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x - y
 
 ///|
-pub impl Sub for BigInt with op_sub(self, other) {
+pub impl Sub for BigInt with sub(self, other) {
   self.op_sub_ffi(other)
 }
 
@@ -185,7 +185,7 @@ extern "js" fn BigInt::op_mul_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x * y
 
 ///|
-pub impl Mul for BigInt with op_mul(self, other) {
+pub impl Mul for BigInt with mul(self, other) {
   self.op_mul_ffi(other)
 }
 
@@ -194,7 +194,7 @@ extern "js" fn BigInt::op_div_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x / y
 
 ///|
-pub impl Div for BigInt with op_div(self, other) {
+pub impl Div for BigInt with div(self, other) {
   self.op_div_ffi(other)
 }
 
@@ -203,7 +203,7 @@ extern "js" fn BigInt::op_mod_ffi(self : BigInt, other : BigInt) -> BigInt =
   #|(x, y) => x % y
 
 ///|
-pub impl Mod for BigInt with op_mod(self, other) {
+pub impl Mod for BigInt with mod(self, other) {
   self.op_mod_ffi(other)
 }
 
@@ -256,7 +256,7 @@ extern "js" fn BigInt::to_byte(self : BigInt) -> Byte =
   #|(x) => Number(BigInt.asUintN(8, x)) | 0
 
 ///|
-pub impl Shl for BigInt with op_shl(self : BigInt, n : Int) -> BigInt {
+pub impl Shl for BigInt with shl(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
   }

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -844,7 +844,7 @@ pub impl Compare for BigInt with compare(self, other) {
 ///   inspect(a == b, content="true")
 ///   inspect(a == c, content="false")
 /// ```
-pub impl Eq for BigInt with op_equal(self, other) {
+pub impl Eq for BigInt with equal(self, other) {
   if self.sign != other.sign || self.len != other.len {
     return false
   }

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -198,7 +198,7 @@ pub fn BigInt::from_uint64(n : UInt64) -> BigInt {
 ///   inspect(-(-42N), content="42")
 ///   inspect(-0N, content="0")
 /// ```
-pub impl Neg for BigInt with op_neg(self : BigInt) -> BigInt {
+pub impl Neg for BigInt with neg(self : BigInt) -> BigInt {
   if self.is_zero() {
     return zero
   }
@@ -225,7 +225,7 @@ pub impl Neg for BigInt with op_neg(self : BigInt) -> BigInt {
 ///   inspect(a + b, content="9223372036854775808") // Beyond Int64 range
 ///   inspect(-a + -b, content="-9223372036854775808")
 /// ```
-pub impl Add for BigInt with op_add(self : BigInt, other : BigInt) -> BigInt {
+pub impl Add for BigInt with add(self : BigInt, other : BigInt) -> BigInt {
   if self.sign == Negative {
     if other.sign == Negative {
       return -(-other + -self)
@@ -271,7 +271,7 @@ pub impl Add for BigInt with op_add(self : BigInt, other : BigInt) -> BigInt {
 ///   inspect(a - b, content="2469135690246913569")
 ///   inspect(-a - b, content="-22222222112222222211")
 /// ```
-pub impl Sub for BigInt with op_sub(self : BigInt, other : BigInt) -> BigInt {
+pub impl Sub for BigInt with sub(self : BigInt, other : BigInt) -> BigInt {
   // first make sure self and other > 0
   if self.sign == Negative {
     if other.sign == Negative {
@@ -337,7 +337,7 @@ pub impl Sub for BigInt with op_sub(self : BigInt, other : BigInt) -> BigInt {
 ///   inspect(a * b, content="-1219326311370217952237463801111263526900")
 ///   inspect(a * 0N, content="0")
 /// ```
-pub impl Mul for BigInt with op_mul(self : BigInt, other : BigInt) -> BigInt {
+pub impl Mul for BigInt with mul(self : BigInt, other : BigInt) -> BigInt {
   if self.is_zero() || other.is_zero() {
     return zero
   }
@@ -436,7 +436,7 @@ fn BigInt::split(self : BigInt, half : Int) -> (BigInt, BigInt) {
 ///   inspect(a / -b, content="-5")
 ///   inspect(-a / -b, content="5")
 /// ```
-pub impl Div for BigInt with op_div(self : BigInt, other : BigInt) -> BigInt {
+pub impl Div for BigInt with div(self : BigInt, other : BigInt) -> BigInt {
   if other is 0 {
     abort("division by zero")
   }
@@ -477,7 +477,7 @@ pub impl Div for BigInt with op_div(self : BigInt, other : BigInt) -> BigInt {
 ///   let d = -5N
 ///   inspect(c % d, content="-2")
 /// ```
-pub impl Mod for BigInt with op_mod(self : BigInt, other : BigInt) -> BigInt {
+pub impl Mod for BigInt with mod(self : BigInt, other : BigInt) -> BigInt {
   if other == zero {
     abort("division by zero")
   }
@@ -657,7 +657,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
 ///   let y = -5N
 ///   inspect(y << 2, content="-20")
 /// ```
-pub impl Shl for BigInt with op_shl(self : BigInt, n : Int) -> BigInt {
+pub impl Shl for BigInt with shl(self : BigInt, n : Int) -> BigInt {
   if n < 0 {
     abort("negative shift count")
   }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -257,7 +257,7 @@ pub fn[T] Array::op_set(self : Array[T], index : Int, value : T) -> Unit {
 ///   inspect(arr1 == arr2, content="true")
 ///   inspect(arr1 == arr3, content="false")
 /// ```
-pub impl[T : Eq] Eq for Array[T] with op_equal(self, other) {
+pub impl[T : Eq] Eq for Array[T] with equal(self, other) {
   let self_len = self.length()
   let other_len = other.length()
   guard self_len == other_len else { return false }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -336,7 +336,7 @@ pub impl[T : Compare] Compare for Array[T] with compare(self, other) {
 ///   let b = [4, 5]
 ///   inspect(a + b, content="[1, 2, 3, 4, 5]")
 /// ```
-pub impl[T] Add for Array[T] with op_add(self, other) {
+pub impl[T] Add for Array[T] with add(self, other) {
   let result = Array::make_uninit(self.length() + other.length())
   UninitializedArray::unsafe_blit(
     result.buffer(),

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -38,6 +38,12 @@ pub impl Mul for Byte with mul(self : Byte, that : Byte) -> Byte {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Mul for Byte with op_mul(self : Byte, that : Byte) -> Byte {
+  (self.to_int() * that.to_int()).to_byte()
+}
+
+///|
 /// Performs division operation between two bytes by converting them to integers,
 /// performing the division, and converting the result back to a byte.
 ///
@@ -60,7 +66,19 @@ pub impl Div for Byte with div(self : Byte, that : Byte) -> Byte {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Div for Byte with op_div(self : Byte, that : Byte) -> Byte {
+  (self.to_int() / that.to_int()).to_byte()
+}
+
+///|
 pub impl Mod for Byte with mod(self : Byte, that : Byte) -> Byte {
+  (self.to_int() % that.to_int()).to_byte()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Mod for Byte with op_mod(self : Byte, that : Byte) -> Byte {
   (self.to_int() % that.to_int()).to_byte()
 }
 
@@ -78,6 +96,12 @@ pub impl Eq for Byte with equal(self : Byte, that : Byte) -> Bool {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Eq for Byte with op_equal(self : Byte, that : Byte) -> Bool {
+  self.to_int() == that.to_int()
+}
+
+///|
 /// Adds two `Byte` values together and returns the result as a `Byte`.
 ///
 /// Parameters:
@@ -87,6 +111,12 @@ pub impl Eq for Byte with equal(self : Byte, that : Byte) -> Bool {
 ///
 /// Returns the sum of `byte1` and `byte2` as a `Byte`.
 pub impl Add for Byte with add(self : Byte, that : Byte) -> Byte {
+  (self.to_int() + that.to_int()).to_byte()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Add for Byte with op_add(self : Byte, that : Byte) -> Byte {
   (self.to_int() + that.to_int()).to_byte()
 }
 
@@ -101,6 +131,12 @@ pub impl Add for Byte with add(self : Byte, that : Byte) -> Byte {
 ///
 /// Returns the result of the subtraction as a byte.
 pub impl Sub for Byte with sub(self : Byte, that : Byte) -> Byte {
+  (self.to_int() - that.to_int()).to_byte()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Sub for Byte with op_sub(self : Byte, that : Byte) -> Byte {
   (self.to_int() - that.to_int()).to_byte()
 }
 

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -33,7 +33,7 @@
 ///   let c = b'\xFF'
 ///   inspect(c * c, content="b'\\x01'") // 255 * 255 = 65025, truncated to 1
 /// ```
-pub impl Mul for Byte with op_mul(self : Byte, that : Byte) -> Byte {
+pub impl Mul for Byte with mul(self : Byte, that : Byte) -> Byte {
   (self.to_int() * that.to_int()).to_byte()
 }
 
@@ -55,12 +55,12 @@ pub impl Mul for Byte with op_mul(self : Byte, that : Byte) -> Byte {
 ///   let b = b'\x03' // 3
 ///   inspect(a / b, content="b'\\x55'") // 255 / 3 = 85 (0x55)
 /// ```
-pub impl Div for Byte with op_div(self : Byte, that : Byte) -> Byte {
+pub impl Div for Byte with div(self : Byte, that : Byte) -> Byte {
   (self.to_int() / that.to_int()).to_byte()
 }
 
 ///|
-pub impl Mod for Byte with op_mod(self : Byte, that : Byte) -> Byte {
+pub impl Mod for Byte with mod(self : Byte, that : Byte) -> Byte {
   (self.to_int() % that.to_int()).to_byte()
 }
 
@@ -86,7 +86,7 @@ pub impl Eq for Byte with op_equal(self : Byte, that : Byte) -> Bool {
 /// - `byte2` : The second `Byte` value to be added.
 ///
 /// Returns the sum of `byte1` and `byte2` as a `Byte`.
-pub impl Add for Byte with op_add(self : Byte, that : Byte) -> Byte {
+pub impl Add for Byte with add(self : Byte, that : Byte) -> Byte {
   (self.to_int() + that.to_int()).to_byte()
 }
 
@@ -100,7 +100,7 @@ pub impl Add for Byte with op_add(self : Byte, that : Byte) -> Byte {
 /// - `that` : The byte to subtract from the first byte.
 ///
 /// Returns the result of the subtraction as a byte.
-pub impl Sub for Byte with op_sub(self : Byte, that : Byte) -> Byte {
+pub impl Sub for Byte with sub(self : Byte, that : Byte) -> Byte {
   (self.to_int() - that.to_int()).to_byte()
 }
 
@@ -288,7 +288,7 @@ pub fn Byte::to_uint(self : Byte) -> UInt {
 ///   the left.
 ///
 /// Returns the resulting `Byte` value after the shift operation.
-pub impl Shl for Byte with op_shl(self : Byte, count : Int) -> Byte {
+pub impl Shl for Byte with shl(self : Byte, count : Int) -> Byte {
   (self.to_int() << count).to_byte()
 }
 

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -73,7 +73,7 @@ pub impl Mod for Byte with mod(self : Byte, that : Byte) -> Byte {
 /// - `that` : The second `Byte` value to compare.
 ///
 /// Returns `true` if the two `Byte` values are equal, otherwise `false`.
-pub impl Eq for Byte with op_equal(self : Byte, that : Byte) -> Bool {
+pub impl Eq for Byte with equal(self : Byte, that : Byte) -> Bool {
   self.to_int() == that.to_int()
 }
 

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -304,7 +304,7 @@ pub fn FixedArray::set_utf16be_char(
 ///   inspect(bytes1 == bytes2, content="true")
 ///   inspect(bytes1 == bytes3, content="false")
 /// ```
-pub impl Eq for Bytes with op_equal(self : Bytes, other : Bytes) -> Bool {
+pub impl Eq for Bytes with equal(self : Bytes, other : Bytes) -> Bool {
   if self.length() != other.length() {
     false
   } else {

--- a/builtin/int64_js.mbt
+++ b/builtin/int64_js.mbt
@@ -479,7 +479,7 @@ pub fn Int64::popcnt(self : Int64) -> Int {
 }
 
 ///|
-pub impl Eq for Int64 with op_equal(self : Int64, other : Int64) -> Bool {
+pub impl Eq for Int64 with equal(self : Int64, other : Int64) -> Bool {
   MyInt64::from_int64(self) == MyInt64::from_int64(other)
 }
 
@@ -650,7 +650,7 @@ pub impl Compare for UInt64 with compare(self : UInt64, other : UInt64) -> Int {
 }
 
 ///|
-pub impl Eq for UInt64 with op_equal(self : UInt64, other : UInt64) -> Bool {
+pub impl Eq for UInt64 with equal(self : UInt64, other : UInt64) -> Bool {
   MyInt64::from_uint64(self).op_equal(MyInt64::from_uint64(other))
 }
 

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -32,7 +32,7 @@
 ///   inspect(--42L, content="42")
 ///   inspect(-9223372036854775808L, content="-9223372036854775808") // negating min value
 /// ```
-pub impl Neg for Int64 with op_neg(self : Int64) -> Int64 = "%i64_neg"
+pub impl Neg for Int64 with neg(self : Int64) -> Int64 = "%i64_neg"
 
 ///|
 /// Adds two 64-bit integers together. Performs overflow checking and wrapping
@@ -53,7 +53,7 @@ pub impl Neg for Int64 with op_neg(self : Int64) -> Int64 = "%i64_neg"
 ///   inspect(a + b, content="-9223372036854775808") // Wraps around to minimum value
 ///   inspect(42L + -42L, content="0")
 /// ```
-pub impl Add for Int64 with op_add(self, other) = "%i64_add"
+pub impl Add for Int64 with add(self, other) = "%i64_add"
 
 ///|
 /// Performs subtraction between two 64-bit integers.
@@ -75,7 +75,7 @@ pub impl Add for Int64 with op_add(self, other) = "%i64_add"
 ///   let d = 1L
 ///   inspect(c - d, content="9223372036854775807")
 /// ```
-pub impl Sub for Int64 with op_sub(self, other) = "%i64_sub"
+pub impl Sub for Int64 with sub(self, other) = "%i64_sub"
 
 ///|
 /// Multiplies two 64-bit integers.
@@ -98,7 +98,7 @@ pub impl Sub for Int64 with op_sub(self, other) = "%i64_sub"
 ///   let c = -42L
 ///   inspect(c * b, content="-4200")
 /// ```
-pub impl Mul for Int64 with op_mul(self, other) = "%i64_mul"
+pub impl Mul for Int64 with mul(self, other) = "%i64_mul"
 
 ///|
 /// Performs integer division between two 64-bit integers. Truncates the result
@@ -123,7 +123,7 @@ pub impl Mul for Int64 with op_mul(self, other) = "%i64_mul"
 ///   let d = 5L
 ///   inspect(c / d, content="-8")
 /// ```
-pub impl Div for Int64 with op_div(self, other) = "%i64_div"
+pub impl Div for Int64 with div(self, other) = "%i64_div"
 
 ///|
 /// Calculates the remainder of the division between two 64-bit integers. The
@@ -146,7 +146,7 @@ pub impl Div for Int64 with op_div(self, other) = "%i64_div"
 ///   inspect(-7L % 3L, content="-1")
 ///   inspect(7L % -3L, content="1")
 /// ```
-pub impl Mod for Int64 with op_mod(self, other) = "%i64_mod"
+pub impl Mod for Int64 with mod(self, other) = "%i64_mod"
 
 ///|
 /// Performs a bitwise NOT operation on a 64-bit integer. Each bit in the input
@@ -377,7 +377,7 @@ pub fn Int64::shr(self : Int64, other : Int) -> Int64 = "%i64_shr"
 ///   let m = -4L
 ///   inspect(m << 2, content="-16") // -4 shifted left by 2 positions becomes -16
 /// ```
-pub impl Shl for Int64 with op_shl(self, other) = "%i64_shl"
+pub impl Shl for Int64 with shl(self, other) = "%i64_shl"
 
 ///|
 /// Performs arithmetic right shift operation on a 64-bit integer value by a
@@ -1083,7 +1083,7 @@ pub fn UInt64::to_double(self : UInt64) -> Double = "%u64.to_f64"
 ///   let max = 18446744073709551615UL
 ///   inspect(max + 1UL, content="0")
 /// ```
-pub impl Add for UInt64 with op_add(self, other) = "%u64.add"
+pub impl Add for UInt64 with add(self, other) = "%u64.add"
 
 ///|
 /// Performs subtraction between two unsigned 64-bit integers. When the result
@@ -1107,7 +1107,7 @@ pub impl Add for UInt64 with op_add(self, other) = "%u64.add"
 ///   let d = 5UL
 ///   inspect(c - d, content="18446744073709551614") // wraps around to 2^64 - 2
 /// ```
-pub impl Sub for UInt64 with op_sub(self, other) = "%u64.sub"
+pub impl Sub for UInt64 with sub(self, other) = "%u64.sub"
 
 ///|
 /// Performs multiplication between two unsigned 64-bit integers.
@@ -1131,7 +1131,7 @@ pub impl Sub for UInt64 with op_sub(self, other) = "%u64.sub"
 ///   let max = 18446744073709551615UL
 ///   inspect(max * 2UL, content="18446744073709551614") // Wraps around to max - 1
 /// ```
-pub impl Mul for UInt64 with op_mul(self, other) = "%u64.mul"
+pub impl Mul for UInt64 with mul(self, other) = "%u64.mul"
 
 ///|
 /// Performs division operation between two unsigned 64-bit integers.
@@ -1152,7 +1152,7 @@ pub impl Mul for UInt64 with op_mul(self, other) = "%u64.mul"
 ///   let b = 20UL
 ///   inspect(a / b, content="5") // Using infix operator
 /// ```
-pub impl Div for UInt64 with op_div(self, other) = "%u64.div"
+pub impl Div for UInt64 with div(self, other) = "%u64.div"
 
 ///|
 /// Calculates the remainder of dividing one unsigned 64-bit integer by another.
@@ -1174,7 +1174,7 @@ pub impl Div for UInt64 with op_div(self, other) = "%u64.div"
 ///   inspect(a % b, content="2") // 17 divided by 5 gives quotient 3 and remainder 2
 ///   inspect(7UL % 4UL, content="3")
 /// ```
-pub impl Mod for UInt64 with op_mod(self, other) = "%u64.mod"
+pub impl Mod for UInt64 with mod(self, other) = "%u64.mod"
 
 ///|
 /// Compares two unsigned 64-bit integers and determines their relative order.
@@ -1419,7 +1419,7 @@ pub fn UInt64::lsr(self : UInt64, shift : Int) -> UInt64 = "%u64.shr"
 ///   inspect(x << 3, content="8") // 1 shifted left by 3 positions becomes 8
 ///   inspect(x << 63, content="9223372036854775808") // 1 shifted left by 63 positions
 /// ```
-pub impl Shl for UInt64 with op_shl(self, shift) = "%u64.shl"
+pub impl Shl for UInt64 with shl(self, shift) = "%u64.shl"
 
 ///|
 /// Performs a logical right shift operation on a 64-bit unsigned integer by a

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -486,7 +486,7 @@ pub fn Int64::popcnt(self : Int64) -> Int = "%i64_popcnt"
 ///   inspect(a == b, content="true")
 ///   inspect(a == c, content="false")
 /// ```
-pub impl Eq for Int64 with op_equal(self : Int64, other : Int64) -> Bool = "%i64_eq"
+pub impl Eq for Int64 with equal(self : Int64, other : Int64) -> Bool = "%i64_eq"
 
 ///|
 /// Compares two 64-bit integers and returns their relative order.
@@ -1220,7 +1220,7 @@ pub impl Compare for UInt64 with compare(self, other) = "%u64.compare"
 ///   inspect(a == b, content="true")
 ///   inspect(a == c, content="false")
 /// ```
-pub impl Eq for UInt64 with op_equal(self : UInt64, other : UInt64) -> Bool = "%u64.eq"
+pub impl Eq for UInt64 with equal(self : UInt64, other : UInt64) -> Bool = "%u64.eq"
 
 ///|
 /// Performs a bitwise AND operation between two unsigned 64-bit integers.

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -195,7 +195,7 @@ pub impl Default for Bool with default() = "%bool_default"
 ///   inspect(42, content="42")
 ///   inspect(--2147483647, content="2147483647") // negating near min value
 /// ```
-pub impl Neg for Int with op_neg(self) = "%i32_neg"
+pub impl Neg for Int with neg(self) = "%i32_neg"
 
 ///|
 /// Adds two 32-bit signed integers. Performs two's complement arithmetic, which
@@ -217,7 +217,7 @@ pub impl Neg for Int with op_neg(self) = "%i32_neg"
 ///   inspect(42 + 1, content="43")
 ///   inspect(2147483647 + 1, content="-2147483648") // Overflow wraps around to minimum value
 /// ```
-pub impl Add for Int with op_add(self, other) = "%i32_add"
+pub impl Add for Int with add(self, other) = "%i32_add"
 
 ///|
 /// Performs subtraction between two 32-bit integers, following standard two's
@@ -240,7 +240,7 @@ pub impl Add for Int with op_add(self, other) = "%i32_add"
 ///   let max = 2147483647 // Int maximum value
 ///   inspect(max - -1, content="-2147483648") // Overflow case
 /// ```
-pub impl Sub for Int with op_sub(self, other) = "%i32_sub"
+pub impl Sub for Int with sub(self, other) = "%i32_sub"
 
 ///|
 /// Multiplies two 32-bit integers. This is the implementation of the `*`
@@ -262,7 +262,7 @@ pub impl Sub for Int with op_sub(self, other) = "%i32_sub"
 ///   let max = 2147483647 // Int.max_value
 ///   inspect(max * 2, content="-2") // Overflow wraps around
 /// ```
-pub impl Mul for Int with op_mul(self, other) = "%i32_mul"
+pub impl Mul for Int with mul(self, other) = "%i32_mul"
 
 ///|
 /// Performs integer division between two 32-bit integers. The result is
@@ -285,7 +285,7 @@ pub impl Mul for Int with op_mul(self, other) = "%i32_mul"
 ///   inspect(-10 / 3, content="-3")
 ///   inspect(10 / -3, content="-3")
 /// ```
-pub impl Div for Int with op_div(self, other) = "%i32_div"
+pub impl Div for Int with div(self, other) = "%i32_div"
 
 ///|
 /// Calculates the remainder of dividing one integer by another. The result
@@ -307,7 +307,7 @@ pub impl Div for Int with op_div(self, other) = "%i32_div"
 ///   inspect(-7 % 3, content="-1")
 ///   inspect(7 % -3, content="1")
 /// ```
-pub impl Mod for Int with op_mod(self, other) = "%i32_mod"
+pub impl Mod for Int with mod(self, other) = "%i32_mod"
 
 ///|
 /// Performs a bitwise NOT operation on a 32-bit integer. Flips each bit in the
@@ -416,7 +416,7 @@ pub fn Int::lxor(self : Int, other : Int) -> Int = "%i32_lxor"
 ///   let y = -4
 ///   inspect(y << 2, content="-16") // Binary: 100 -> 10000
 /// ```
-pub impl Shl for Int with op_shl(self, other) = "%i32_shl"
+pub impl Shl for Int with shl(self, other) = "%i32_shl"
 
 ///|
 /// Performs an arithmetic right shift operation on an integer value. Shifts the
@@ -822,7 +822,7 @@ pub fn Int::to_uint64(self : Int) -> UInt64 {
 ///   inspect(--42.0, content="42")
 ///   inspect(-(0.0 / 0.0), content="NaN") // Negating NaN returns NaN
 /// ```
-pub impl Neg for Double with op_neg(self) = "%f64_neg"
+pub impl Neg for Double with neg(self) = "%f64_neg"
 
 ///|
 /// Adds two double-precision floating-point numbers together following IEEE 754
@@ -846,7 +846,7 @@ pub impl Neg for Double with op_neg(self) = "%f64_neg"
 ///   inspect(2.5 + 3.7, content="6.2")
 ///   inspect(1.0 / 0.0 + -1.0 / 0.0, content="NaN") // Infinity + -Infinity = NaN
 /// ```
-pub impl Add for Double with op_add(self, other) = "%f64_add"
+pub impl Add for Double with add(self, other) = "%f64_add"
 
 ///|
 /// Performs subtraction between two double-precision floating-point numbers.
@@ -867,7 +867,7 @@ pub impl Add for Double with op_add(self, other) = "%f64_add"
 ///   inspect(a - b, content="2")
 ///   inspect(0.0 / 0.0 - 1.0, content="NaN") // NaN - anything = NaN
 /// ```
-pub impl Sub for Double with op_sub(self, other) = "%f64_sub"
+pub impl Sub for Double with sub(self, other) = "%f64_sub"
 
 ///|
 /// Multiplies two double-precision floating-point numbers. This is the
@@ -895,7 +895,7 @@ pub impl Sub for Double with op_sub(self, other) = "%f64_sub"
 ///   let nan = 0.0 / 0.0 // NaN
 ///   inspect(nan * 1.0, content="NaN")
 /// ```
-pub impl Mul for Double with op_mul(self, other) = "%f64_mul"
+pub impl Mul for Double with mul(self, other) = "%f64_mul"
 
 ///|
 /// Performs division between two double-precision floating-point numbers.
@@ -923,7 +923,7 @@ pub impl Mul for Double with op_mul(self, other) = "%f64_mul"
 ///   inspect(-6.0 / 2.0, content="-3")
 ///   inspect(1.0 / 0.0, content="Infinity")
 /// ```
-pub impl Div for Double with op_div(self, other) = "%f64_div"
+pub impl Div for Double with div(self, other) = "%f64_div"
 
 ///|
 /// Calculates the square root of a double-precision floating-point number. For
@@ -1584,7 +1584,7 @@ pub fn String::unsafe_charcode_at(self : String, idx : Int) -> Int = "%string.un
 ///   inspect(hello + world, content="Hello World!")
 ///   inspect("" + "abc", content="abc") // concatenating with empty string
 /// ```
-pub impl Add for String with op_add(self, other) = "%string_add"
+pub impl Add for String with add(self, other) = "%string_add"
 
 ///|
 /// Tests whether two strings are equal by comparing their characters.
@@ -1742,7 +1742,7 @@ pub fn UInt::to_int(self : UInt) -> Int = "%u32.to_i32_reinterpret"
 ///   let max = 4294967295U // UInt::max_value
 ///   inspect(max + 1U, content="0")
 /// ```
-pub impl Add for UInt with op_add(self, other) = "%u32.add"
+pub impl Add for UInt with add(self, other) = "%u32.add"
 
 ///|
 /// Performs subtraction between two unsigned 32-bit integers. When the result
@@ -1768,7 +1768,7 @@ pub impl Add for UInt with op_add(self, other) = "%u32.add"
 ///   let d = 5U
 ///   inspect(c - d, content="4294967294") // wraps around to 2^32 - 2
 /// ```
-pub impl Sub for UInt with op_sub(self, other) = "%u32.sub"
+pub impl Sub for UInt with sub(self, other) = "%u32.sub"
 
 ///|
 /// Performs multiplication between two unsigned 32-bit integers. The result
@@ -1792,7 +1792,7 @@ pub impl Sub for UInt with op_sub(self, other) = "%u32.sub"
 ///   let max = 4294967295U
 ///   inspect(max * 2U, content="4294967294") // Wraps around to max * 2 % 2^32
 /// ```
-pub impl Mul for UInt with op_mul(self, other) = "%u32.mul"
+pub impl Mul for UInt with mul(self, other) = "%u32.mul"
 
 ///|
 /// Performs division between two unsigned 32-bit integers. The operation follows
@@ -1813,7 +1813,7 @@ pub impl Mul for UInt with op_mul(self, other) = "%u32.mul"
 ///   let b = 5U
 ///   inspect(a / b, content="8") // Using infix operator
 /// ```
-pub impl Div for UInt with op_div(self, other) = "%u32.div"
+pub impl Div for UInt with div(self, other) = "%u32.div"
 
 ///|
 /// Calculates the remainder of dividing one unsigned integer by another.
@@ -1835,7 +1835,7 @@ pub impl Div for UInt with op_div(self, other) = "%u32.div"
 ///   inspect(a % b, content="2") // 17 divided by 5 gives quotient 3 and remainder 2
 ///   inspect(7U % 4U, content="3")
 /// ```
-pub impl Mod for UInt with op_mod(self, other) = "%u32.mod"
+pub impl Mod for UInt with mod(self, other) = "%u32.mod"
 
 ///|
 /// Compares two unsigned 32-bit integers for equality.
@@ -2109,7 +2109,7 @@ pub fn UInt::shr(self : UInt, shift : Int) -> UInt = "%u32.shr"
 ///   let y = 0xFFFFFFFFU
 ///   inspect(y << 16, content="4294901760") // All bits after position 16 are discarded
 /// ```
-pub impl Shl for UInt with op_shl(self, shift) = "%u32.shl"
+pub impl Shl for UInt with shl(self, shift) = "%u32.shl"
 
 ///|
 /// Performs a logical right shift operation on an unsigned 32-bit integer. The
@@ -2295,7 +2295,7 @@ pub fn UInt::to_double(self : UInt) -> Double = "%u32.to_f64"
 ///   let zero = 0.0.to_float()
 ///   inspect((-zero).to_double(), content="0")
 /// ```
-pub impl Neg for Float with op_neg(self) = "%f32.neg"
+pub impl Neg for Float with neg(self) = "%f32.neg"
 
 ///|
 /// Performs addition between two single-precision floating-point numbers.
@@ -2317,7 +2317,7 @@ pub impl Neg for Float with op_neg(self) = "%f32.neg"
 ///   let sum = a + b
 ///   inspect(sum.to_double(), content="6")
 /// ```
-pub impl Add for Float with op_add(self, other) = "%f32.add"
+pub impl Add for Float with add(self, other) = "%f32.add"
 
 ///|
 /// Performs subtraction between two single-precision floating-point numbers.
@@ -2338,7 +2338,7 @@ pub impl Add for Float with op_add(self, other) = "%f32.add"
 ///   let result = x - y
 ///   inspect(result.to_double(), content="2.140000104904175")
 /// ```
-pub impl Sub for Float with op_sub(self, other) = "%f32.sub"
+pub impl Sub for Float with sub(self, other) = "%f32.sub"
 
 ///|
 /// Performs multiplication between two single-precision floating-point numbers
@@ -2361,7 +2361,7 @@ pub impl Sub for Float with op_sub(self, other) = "%f32.sub"
 ///   let z = x * y
 ///   inspect(z.to_double(), content="6")
 /// ```
-pub impl Mul for Float with op_mul(self, other) = "%f32.mul"
+pub impl Mul for Float with mul(self, other) = "%f32.mul"
 
 ///|
 /// Performs division between two 32-bit floating-point numbers according to IEEE
@@ -2388,7 +2388,7 @@ pub impl Mul for Float with op_mul(self, other) = "%f32.mul"
 ///   inspect(result, content="3")
 ///   inspect((0.0.to_float() / 0.0.to_float()).to_double(), content="NaN")
 /// ```
-pub impl Div for Float with op_div(self, other) = "%f32.div"
+pub impl Div for Float with div(self, other) = "%f32.div"
 
 ///|
 /// Calculates the square root of a floating-point number. For non-negative

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -102,7 +102,7 @@ pub fn not(x : Bool) -> Bool = "%bool_not"
 ///   inspect(true == false, content="false")
 ///   inspect(false == false, content="true")
 /// ```
-pub impl Eq for Bool with op_equal(self : Bool, other : Bool) -> Bool = "%bool_eq"
+pub impl Eq for Bool with equal(self : Bool, other : Bool) -> Bool = "%bool_eq"
 
 ///|
 /// Compares two boolean values and returns their relative order. This is a
@@ -635,7 +635,7 @@ pub fn Int::popcnt(self : Int) -> Int = "%i32_popcnt"
 ///   inspect(42 == 42, content="true")
 ///   inspect(42 == -42, content="false")
 /// ```
-pub impl Eq for Int with op_equal(self : Int, other : Int) -> Bool = "%i32_eq"
+pub impl Eq for Int with equal(self : Int, other : Int) -> Bool = "%i32_eq"
 
 ///|
 /// Compares two integers and returns their relative order.
@@ -971,7 +971,7 @@ pub fn Double::sqrt(self : Double) -> Double = "%f64_sqrt"
 ///   let nan = 0.0 / 0.0 // NaN
 ///   inspect(nan == nan, content="false") // Note: NaN equals itself in MoonBit
 /// ```
-pub impl Eq for Double with op_equal(self : Double, other : Double) -> Bool = "%f64_eq"
+pub impl Eq for Double with equal(self : Double, other : Double) -> Bool = "%f64_eq"
 
 ///|
 /// Tests for inequality between two double-precision floating-point numbers.
@@ -1128,7 +1128,7 @@ pub fn Char::from_int(val : Int) -> Char = "%char_from_int"
 ///   inspect(a == b, content="true")
 ///   inspect(a == c, content="false")
 /// ```
-pub impl Eq for Char with op_equal(self : Char, other : Char) -> Bool = "%char_eq"
+pub impl Eq for Char with equal(self : Char, other : Char) -> Bool = "%char_eq"
 
 ///|
 /// Compares two characters based on their Unicode code points. Returns a
@@ -1606,7 +1606,7 @@ pub impl Add for String with add(self, other) = "%string_add"
 ///   inspect(str1 == str2, content="true")
 ///   inspect(str1 == str3, content="false")
 /// ```
-pub impl Eq for String with op_equal(self : String, other : String) -> Bool = "%string_eq"
+pub impl Eq for String with equal(self : String, other : String) -> Bool = "%string_eq"
 
 ///|
 /// Returns the string itself without any modifications. This method is primarily
@@ -1856,7 +1856,7 @@ pub impl Mod for UInt with mod(self, other) = "%u32.mod"
 ///   inspect(a == b, content="true")
 ///   inspect(a == c, content="false")
 /// ```
-pub impl Eq for UInt with op_equal(self : UInt, other : UInt) -> Bool = "%u32.eq"
+pub impl Eq for UInt with equal(self : UInt, other : UInt) -> Bool = "%u32.eq"
 
 ///|
 /// Checks if two unsigned 32-bit integers are not equal.
@@ -2440,7 +2440,7 @@ pub fn Float::sqrt(self : Float) -> Float = "%f32.sqrt"
 ///   inspect(x == y, content="true")
 ///   inspect(z == z, content="false") // NaN is not equal to itself
 /// ```
-pub impl Eq for Float with op_equal(self : Float, other : Float) -> Bool = "%f32.eq"
+pub impl Eq for Float with equal(self : Float, other : Float) -> Bool = "%f32.eq"
 
 ///|
 /// Tests if two single-precision floating-point numbers are not equal. This

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -771,7 +771,7 @@ pub fn[T] Iter::concat(self : Iter[T], other : Iter[T]) -> Iter[T] {
 }
 
 ///|
-pub impl[T] Add for Iter[T] with op_add(self, other) {
+pub impl[T] Add for Iter[T] with add(self, other) {
   Iter::concat(self, other)
 }
 

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -24,7 +24,7 @@ pub enum Json {
 }
 
 ///|
-pub impl Eq for Json with op_equal(a, b) {
+pub impl Eq for Json with equal(a, b) {
   match (a, b) {
     (Null, Null) => true
     (True, True) => true

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -635,7 +635,7 @@ pub fn[K, V] Map::to_array(self : Map[K, V]) -> Array[(K, V)] {
 }
 
 ///|
-pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with op_equal(
+pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with equal(
   self : Map[K, V],
   that : Map[K, V],
 ) -> Bool {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -915,6 +915,6 @@ fn[K : Show, V : Show] Map::debug_entries(self : Map[K, V]) -> String {
 }
 
 ///|
-impl[K : Eq, V] Eq for Entry[K, V] with op_equal(self, other) {
+impl[K : Eq, V] Eq for Entry[K, V] with equal(self, other) {
   self.hash == other.hash && self.key == other.key
 }

--- a/builtin/operators.mbt
+++ b/builtin/operators.mbt
@@ -15,37 +15,43 @@
 ///|
 /// types implementing this trait can use the `+` operator
 pub(open) trait Add {
-  op_add(Self, Self) -> Self
+  add(Self, Self) -> Self = _
+  op_add(Self, Self) -> Self = _
 }
 
 ///|
 /// types implementing this trait can use the `-` operator
 pub(open) trait Sub {
-  op_sub(Self, Self) -> Self
+  sub(Self, Self) -> Self = _
+  op_sub(Self, Self) -> Self = _
 }
 
 ///|
 /// types implementing this trait can use the `*` operator
 pub(open) trait Mul {
-  op_mul(Self, Self) -> Self
+  mul(Self, Self) -> Self = _
+  op_mul(Self, Self) -> Self = _
 }
 
 ///|
 /// types implementing this trait can use the `/` operator
 pub(open) trait Div {
-  op_div(Self, Self) -> Self
+  div(Self, Self) -> Self = _
+  op_div(Self, Self) -> Self = _
 }
 
 ///|
 /// types implementing this trait can use the unary `-` operator
 pub(open) trait Neg {
-  op_neg(Self) -> Self
+  neg(Self) -> Self = _
+  op_neg(Self) -> Self = _
 }
 
 ///|
 /// types implementing this trait can use the `%` operator
 pub(open) trait Mod {
-  op_mod(Self, Self) -> Self
+  mod(Self, Self) -> Self = _
+  op_mod(Self, Self) -> Self = _
 }
 
 ///|
@@ -69,7 +75,8 @@ pub(open) trait BitXOr {
 ///|
 /// types implementing this trait can use the `<<` operator
 pub(open) trait Shl {
-  op_shl(Self, Int) -> Self
+  shl(Self, Int) -> Self = _
+  op_shl(Self, Int) -> Self = _
 }
 
 ///|
@@ -77,6 +84,83 @@ pub(open) trait Shl {
 pub(open) trait Shr {
   shr(Self, Int) -> Self = _
   op_shr(Self, Int) -> Self = _
+}
+
+///|
+#deprecated("replace `impl op_add` with `impl add`")
+impl Add with add(self, other) {
+  Add::op_add(self, other)
+}
+
+///|
+impl Add with op_add(self, other) {
+  Add::add(self, other)
+}
+
+///|
+#deprecated("replace `impl op_sub` with `impl sub`")
+impl Sub with sub(self, other) {
+  Sub::op_sub(self, other)
+}
+
+///|
+impl Sub with op_sub(self, other) {
+  Sub::sub(self, other)
+}
+
+///|
+#deprecated("replace `impl op_mul` with `impl mul`")
+impl Mul with mul(self, other) {
+  Mul::op_mul(self, other)
+}
+
+///|
+impl Mul with op_mul(self, other) {
+  Mul::mul(self, other)
+}
+
+///|
+#deprecated("replace `impl op_div` with `impl div`")
+impl Div with div(self, other) {
+  Div::op_div(self, other)
+}
+
+///|
+impl Div with op_div(self, other) {
+  Div::div(self, other)
+}
+
+///|
+#deprecated("replace `impl op_neg` with `impl neg`")
+impl Neg with neg(self) {
+  Neg::op_neg(self)
+}
+
+///|
+impl Neg with op_neg(self) {
+  Neg::neg(self)
+}
+
+///|
+#deprecated("replace `impl op_mod` with `impl mod`")
+impl Mod with mod(self, other) {
+  Mod::op_mod(self, other)
+}
+
+///|
+impl Mod with op_mod(self, other) {
+  Mod::mod(self, other)
+}
+
+///|
+#deprecated("replace `impl op_shl` with `impl shl`")
+impl Shl with shl(self, i) {
+  Shl::op_shl(self, i)
+}
+
+///|
+impl Shl with op_shl(self, i) {
+  Shl::shl(self, i)
 }
 
 ///|

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub impl[X : Eq] Eq for X? with op_equal(self, other) {
+pub impl[X : Eq] Eq for X? with equal(self, other) {
   match (self, other) {
     (None, None) => true
     (Some(x), Some(y)) => x == y

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -581,7 +581,8 @@ fn[Obj : Show] Logger::write_object(&Self, Obj) -> Unit
 
 // Traits
 pub(open) trait Add {
-  op_add(Self, Self) -> Self
+  add(Self, Self) -> Self = _
+  op_add(Self, Self) -> Self = _
 }
 impl Add for Byte
 impl Add for Int
@@ -655,7 +656,8 @@ impl Default for Double
 impl[X] Default for FixedArray[X]
 
 pub(open) trait Div {
-  op_div(Self, Self) -> Self
+  div(Self, Self) -> Self = _
+  op_div(Self, Self) -> Self = _
 }
 impl Div for Byte
 impl Div for Int
@@ -723,7 +725,8 @@ pub(open) trait Logger {
 }
 
 pub(open) trait Mod {
-  op_mod(Self, Self) -> Self
+  mod(Self, Self) -> Self = _
+  op_mod(Self, Self) -> Self = _
 }
 impl Mod for Byte
 impl Mod for Int
@@ -732,7 +735,8 @@ impl Mod for UInt
 impl Mod for UInt64
 
 pub(open) trait Mul {
-  op_mul(Self, Self) -> Self
+  mul(Self, Self) -> Self = _
+  op_mul(Self, Self) -> Self = _
 }
 impl Mul for Byte
 impl Mul for Int
@@ -743,7 +747,8 @@ impl Mul for Float
 impl Mul for Double
 
 pub(open) trait Neg {
-  op_neg(Self) -> Self
+  neg(Self) -> Self = _
+  op_neg(Self) -> Self = _
 }
 impl Neg for Int
 impl Neg for Int64
@@ -751,7 +756,8 @@ impl Neg for Float
 impl Neg for Double
 
 pub(open) trait Shl {
-  op_shl(Self, Int) -> Self
+  shl(Self, Int) -> Self = _
+  op_shl(Self, Int) -> Self = _
 }
 impl Shl for Byte
 impl Shl for Int
@@ -805,7 +811,8 @@ impl Shr for UInt
 impl Shr for UInt64
 
 pub(open) trait Sub {
-  op_sub(Self, Self) -> Self
+  sub(Self, Self) -> Self = _
+  op_sub(Self, Self) -> Self = _
 }
 impl Sub for Byte
 impl Sub for Int

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -668,7 +668,8 @@ impl Div for Float
 impl Div for Double
 
 pub(open) trait Eq {
-  op_equal(Self, Self) -> Bool
+  equal(Self, Self) -> Bool = _
+  op_equal(Self, Self) -> Bool = _
 }
 impl Eq for Unit
 impl Eq for Bool

--- a/builtin/result.mbt
+++ b/builtin/result.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub impl[T : Eq, E : Eq] Eq for Result[T, E] with op_equal(self, other) {
+pub impl[T : Eq, E : Eq] Eq for Result[T, E] with equal(self, other) {
   match (self, other) {
     (Ok(x), Ok(y)) => x == y
     (Err(x), Err(y)) => x == y

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -15,7 +15,8 @@
 ///|
 /// Trait for types whose elements can test for equality
 pub(open) trait Eq {
-  op_equal(Self, Self) -> Bool
+  equal(Self, Self) -> Bool = _
+  op_equal(Self, Self) -> Bool = _
 }
 
 ///|
@@ -135,4 +136,15 @@ pub fn[T : Show] repr(t : T) -> String {
   let logger = StringBuilder::new()
   t.output(logger)
   logger.to_string()
+}
+
+///|
+#deprecated("replace `impl op_equal` with `impl equal`")
+impl Eq with equal(self, other) {
+  Eq::op_equal(self, other)
+}
+
+///|
+impl Eq with op_equal(self, other) {
+  Eq::equal(self, other)
 }

--- a/builtin/tuple_eq.mbt
+++ b/builtin/tuple_eq.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub impl[T0 : Eq, T1 : Eq] Eq for (T0, T1) with op_equal(
+pub impl[T0 : Eq, T1 : Eq] Eq for (T0, T1) with equal(
   self : (T0, T1),
   other : (T0, T1),
 ) -> Bool {
@@ -21,7 +21,7 @@ pub impl[T0 : Eq, T1 : Eq] Eq for (T0, T1) with op_equal(
 }
 
 ///|
-pub impl[T0 : Eq, T1 : Eq, T2 : Eq] Eq for (T0, T1, T2) with op_equal(
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq] Eq for (T0, T1, T2) with equal(
   self : (T0, T1, T2),
   other : (T0, T1, T2),
 ) -> Bool {
@@ -29,7 +29,7 @@ pub impl[T0 : Eq, T1 : Eq, T2 : Eq] Eq for (T0, T1, T2) with op_equal(
 }
 
 ///|
-pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq] Eq for (T0, T1, T2, T3) with op_equal(
+pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq] Eq for (T0, T1, T2, T3) with equal(
   self : (T0, T1, T2, T3),
   other : (T0, T1, T2, T3),
 ) -> Bool {
@@ -46,7 +46,7 @@ pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq] Eq for (
   T2,
   T3,
   T4,
-) with op_equal(self : (T0, T1, T2, T3, T4), other : (T0, T1, T2, T3, T4)) -> Bool {
+) with equal(self : (T0, T1, T2, T3, T4), other : (T0, T1, T2, T3, T4)) -> Bool {
   self.0 == other.0 &&
   self.1 == other.1 &&
   self.2 == other.2 &&
@@ -62,10 +62,7 @@ pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq] Eq for (
   T3,
   T4,
   T5,
-) with op_equal(
-  self : (T0, T1, T2, T3, T4, T5),
-  other : (T0, T1, T2, T3, T4, T5),
-) -> Bool {
+) with equal(self : (T0, T1, T2, T3, T4, T5), other : (T0, T1, T2, T3, T4, T5)) -> Bool {
   self.0 == other.0 &&
   self.1 == other.1 &&
   self.2 == other.2 &&
@@ -83,7 +80,7 @@ pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq] Eq for (
   T4,
   T5,
   T6,
-) with op_equal(
+) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6),
   other : (T0, T1, T2, T3, T4, T5, T6),
 ) -> Bool {
@@ -106,7 +103,7 @@ pub impl[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq]
   T5,
   T6,
   T7,
-) with op_equal(
+) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7),
   other : (T0, T1, T2, T3, T4, T5, T6, T7),
 ) -> Bool {
@@ -131,7 +128,7 @@ pub impl[
   T6 : Eq,
   T7 : Eq,
   T8 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8),
 ) -> Bool {
@@ -158,7 +155,7 @@ pub impl[
   T7 : Eq,
   T8 : Eq,
   T9 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9),
 ) -> Bool {
@@ -187,7 +184,7 @@ pub impl[
   T8 : Eq,
   T9 : Eq,
   T10 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
 ) -> Bool {
@@ -218,7 +215,7 @@ pub impl[
   T9 : Eq,
   T10 : Eq,
   T11 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
 ) -> Bool {
@@ -251,7 +248,7 @@ pub impl[
   T10 : Eq,
   T11 : Eq,
   T12 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12),
 ) -> Bool {
@@ -286,7 +283,7 @@ pub impl[
   T11 : Eq,
   T12 : Eq,
   T13 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13),
 ) -> Bool {
@@ -323,7 +320,7 @@ pub impl[
   T12 : Eq,
   T13 : Eq,
   T14 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14),
 ) -> Bool {
@@ -362,7 +359,7 @@ pub impl[
   T13 : Eq,
   T14 : Eq,
   T15 : Eq,
-] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) with op_equal(
+] Eq for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) with equal(
   self : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15),
   other : (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15),
 ) -> Bool {

--- a/builtin/unit.mbt
+++ b/builtin/unit.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub impl Eq for Unit with op_equal(self : Unit, _other : Unit) -> Bool {
+pub impl Eq for Unit with equal(self : Unit, _other : Unit) -> Bool {
   let _ = self
   true
 }

--- a/builtin/unit.mbt
+++ b/builtin/unit.mbt
@@ -17,3 +17,10 @@ pub impl Eq for Unit with equal(self : Unit, _other : Unit) -> Bool {
   let _ = self
   true
 }
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Eq for Unit with op_equal(self : Unit, _other : Unit) -> Bool {
+  let _ = self
+  true
+}

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -316,7 +316,7 @@ fn unsafe_to_bytes(array : FixedArray[Byte]) -> Bytes = "%identity"
 /// * `self` : The first bytes sequence.
 /// * `other` : The second bytes sequence.
 /// TODO: marked as intrinsic, inline if it is constant
-pub impl Add for Bytes with op_add(self : Bytes, other : Bytes) -> Bytes {
+pub impl Add for Bytes with add(self : Bytes, other : Bytes) -> Bytes {
   let len_self = self.length()
   let len_other = other.length()
   let rv : FixedArray[Byte] = FixedArray::make(len_self + len_other, 0)

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -564,7 +564,7 @@ pub impl Show for View with output(self, logger) {
 ///   inspect(bytes[0:3] == bytes[2:5], content="false")
 ///   inspect(bytes[0:4] == bytes[3:6], content="false")
 /// ```
-pub impl Eq for View with op_equal(self, other) -> Bool {
+pub impl Eq for View with equal(self, other) -> Bool {
   guard self.length() == other.length() else { return false }
   for i in 0..<self.length() {
     guard self.unsafe_get(i) == other.unsafe_get(i) else { return false }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -616,7 +616,7 @@ pub fn[A] Deque::as_views(self : Deque[A]) -> (@array.View[A], @array.View[A]) {
 ///   inspect(dq1 == dq2, content="true")
 ///   inspect(dq1 == dq3, content="false")
 /// ```
-pub impl[A : Eq] Eq for Deque[A] with op_equal(self, other) {
+pub impl[A : Eq] Eq for Deque[A] with equal(self, other) {
   if self.len != other.len {
     return false
   }

--- a/double/mod_js.mbt
+++ b/double/mod_js.mbt
@@ -38,6 +38,6 @@ extern "js" fn mod_ffi(self : Double, other : Double) -> Double =
   #| (a, b) => (a % b)
 
 ///|
-pub impl Mod for Double with op_mod(self, other) {
+pub impl Mod for Double with mod(self, other) {
   self.mod_ffi(other)
 }

--- a/double/mod_nonjs.mbt
+++ b/double/mod_nonjs.mbt
@@ -34,7 +34,7 @@
 ///   inspect(5.0.op_mod(@double.not_a_number), content="NaN")
 ///   inspect(@double.infinity.op_mod(3.0), content="NaN")
 /// ```
-pub impl Mod for Double with op_mod(self : Double, other : Double) -> Double {
+pub impl Mod for Double with mod(self : Double, other : Double) -> Double {
   let x = self
   let y = other
   let mut uint64_x = x.reinterpret_as_uint64()

--- a/float/mod.mbt
+++ b/float/mod.mbt
@@ -28,6 +28,6 @@
 ///   inspect((5.7 : Float).op_mod(2.0), content="1.6999998092651367")
 ///   inspect((-5.7 : Float).op_mod(2.0), content="-1.6999998092651367")
 /// ```
-pub impl Mod for Float with op_mod(self : Float, other : Float) -> Float {
+pub impl Mod for Float with mod(self : Float, other : Float) -> Float {
   (self.to_double() % other.to_double()).to_float()
 }

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -49,7 +49,7 @@ struct HashMap[K, V] {
 }
 
 ///|
-pub impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V] with op_equal(
+pub impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V] with equal(
   self : HashMap[K, V],
   that : HashMap[K, V],
 ) -> Bool {

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -393,7 +393,7 @@ pub impl[K : Hash + Eq] BitXOr for HashSet[K] with lxor(self, other) {
 
 ///|
 /// Difference of two hash sets.
-pub impl[K : Hash + Eq] Sub for HashSet[K] with op_sub(self, other) {
+pub impl[K : Hash + Eq] Sub for HashSet[K] with sub(self, other) {
   self.difference(other)
 }
 

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -271,7 +271,7 @@ pub fn[A] concat(self : T[A], other : T[A]) -> T[A] {
 
 ///|
 /// Concat two arrays.
-pub impl[A] Add for T[A] with op_add(self, other) {
+pub impl[A] Add for T[A] with add(self, other) {
   self.concat(other)
 }
 

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -405,7 +405,7 @@ pub impl[A : Hash] Hash for T[A] with hash_combine(self, hasher) {
 }
 
 ///|
-pub impl[A : Eq] Eq for T[A] with op_equal(self, other) {
+pub impl[A : Eq] Eq for T[A] with equal(self, other) {
   self.size == other.size && self.tree == other.tree
 }
 

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -734,7 +734,7 @@ pub fn[K : Eq + Hash, V] of(arr : FixedArray[(K, V)]) -> HashMap[K, V] {
 }
 
 ///|
-impl[K : Eq, V : Eq] Eq for Node[K, V] with op_equal(self, other) {
+impl[K : Eq, V : Eq] Eq for Node[K, V] with equal(self, other) {
   match (self, other) {
     (Flat(key1, value1, path1), Flat(key2, value2, path2)) =>
       path1 == path2 && key1 == key2 && value1 == value2

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -438,7 +438,7 @@ impl Hash for MyString with hash_combine(_self, hasher) {
 }
 
 ///|
-impl Eq for MyString with op_equal(self, other) {
+impl Eq for MyString with equal(self, other) {
   self.0 == other.0
 }
 

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -381,7 +381,7 @@ pub impl[A : Hash] Hash for HashSet[A] with hash_combine(self, hasher) {
 }
 
 ///|
-impl[A : Eq] Eq for Node[A] with op_equal(self, other) {
+impl[A : Eq] Eq for Node[A] with equal(self, other) {
   match (self, other) {
     (Leaf(x, xs), Leaf(y, ys)) =>
       xs.length() == ys.length() &&

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -255,7 +255,7 @@ impl Hash for MyString with hash_combine(_self, hasher) {
 }
 
 ///|
-impl Eq for MyString with op_equal(self, other) {
+impl Eq for MyString with equal(self, other) {
   self.0 == other.0
 }
 

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -794,7 +794,7 @@ pub fn[A : Compare] sort(self : T[A]) -> T[A] {
 /// Concatenate two lists.
 ///
 /// `a + b` equal to `a.concat(b)`
-pub impl[A] Add for T[A] with op_add(self, other) {
+pub impl[A] Add for T[A] with add(self, other) {
   self.concat(other)
 }
 

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -294,7 +294,7 @@ pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for Priority
 }
 
 ///|
-pub impl[A : Compare] Eq for PriorityQueue[A] with op_equal(self, other) {
+pub impl[A : Compare] Eq for PriorityQueue[A] with equal(self, other) {
   self.length() == other.length() && self.to_array() == other.to_array()
 }
 

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -18,7 +18,7 @@ pub impl[K, V] Default for SortedMap[K, V] with default() {
 }
 
 ///|
-pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V] with op_equal(self, other) -> Bool {
+pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V] with equal(self, other) -> Bool {
   let iter = InorderIterator::new(self)
   let iter1 = InorderIterator::new(other)
   loop (iter.next(), iter1.next()) {

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -54,7 +54,7 @@ test {
 }
 
 ///|
-pub impl[A : Eq] Eq for SortedSet[A] with op_equal(self, other) -> Bool {
+pub impl[A : Eq] Eq for SortedSet[A] with equal(self, other) -> Bool {
   // There's no `Iter::zip` (https://github.com/moonbitlang/core/issues/994#issuecomment-2350935193),
   // so we have to use the manual implementation below:
   let iter = InorderIterator::new(self)

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -310,7 +310,7 @@ pub fn[A : Compare] union(
 /// ```mbt
 ///   assert_eq(@sorted_set.of([3, 4, 5]) + (@sorted_set.of([4, 5, 6])), @sorted_set.of([3, 4, 5, 6]))
 /// ```
-pub impl[A : Compare] Add for SortedSet[A] with op_add(self, other) {
+pub impl[A : Compare] Add for SortedSet[A] with add(self, other) {
   return self.union(other)
 }
 

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -24,7 +24,19 @@ pub impl Add for Int16 with add(self : Int16, that : Int16) -> Int16 {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Add for Int16 with op_add(self : Int16, that : Int16) -> Int16 {
+  (self.to_int() + that.to_int()).to_int16()
+}
+
+///|
 pub impl Sub for Int16 with sub(self : Int16, that : Int16) -> Int16 {
+  (self.to_int() - that.to_int()).to_int16()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Sub for Int16 with op_sub(self : Int16, that : Int16) -> Int16 {
   (self.to_int() - that.to_int()).to_int16()
 }
 
@@ -34,7 +46,19 @@ pub impl Mul for Int16 with mul(self : Int16, that : Int16) -> Int16 {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Mul for Int16 with op_mul(self : Int16, that : Int16) -> Int16 {
+  (self.to_int() * that.to_int()).to_int16()
+}
+
+///|
 pub impl Div for Int16 with div(self : Int16, that : Int16) -> Int16 {
+  (self.to_int() / that.to_int()).to_int16()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Div for Int16 with op_div(self : Int16, that : Int16) -> Int16 {
   (self.to_int() / that.to_int()).to_int16()
 }
 
@@ -44,7 +68,19 @@ pub impl Mod for Int16 with mod(self : Int16, that : Int16) -> Int16 {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Mod for Int16 with op_mod(self : Int16, that : Int16) -> Int16 {
+  (self.to_int() % that.to_int()).to_int16()
+}
+
+///|
 pub impl Eq for Int16 with equal(self, that) {
+  self.to_int() == that.to_int()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Eq for Int16 with op_equal(self, that) {
   self.to_int() == that.to_int()
 }
 

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -19,27 +19,27 @@ pub let max_value : Int16 = 32767
 pub let min_value : Int16 = -32768
 
 ///|
-pub impl Add for Int16 with op_add(self : Int16, that : Int16) -> Int16 {
+pub impl Add for Int16 with add(self : Int16, that : Int16) -> Int16 {
   (self.to_int() + that.to_int()).to_int16()
 }
 
 ///|
-pub impl Sub for Int16 with op_sub(self : Int16, that : Int16) -> Int16 {
+pub impl Sub for Int16 with sub(self : Int16, that : Int16) -> Int16 {
   (self.to_int() - that.to_int()).to_int16()
 }
 
 ///|
-pub impl Mul for Int16 with op_mul(self : Int16, that : Int16) -> Int16 {
+pub impl Mul for Int16 with mul(self : Int16, that : Int16) -> Int16 {
   (self.to_int() * that.to_int()).to_int16()
 }
 
 ///|
-pub impl Div for Int16 with op_div(self : Int16, that : Int16) -> Int16 {
+pub impl Div for Int16 with div(self : Int16, that : Int16) -> Int16 {
   (self.to_int() / that.to_int()).to_int16()
 }
 
 ///|
-pub impl Mod for Int16 with op_mod(self : Int16, that : Int16) -> Int16 {
+pub impl Mod for Int16 with mod(self : Int16, that : Int16) -> Int16 {
   (self.to_int() % that.to_int()).to_int16()
 }
 
@@ -64,7 +64,7 @@ pub impl Hash for Int16 with hash_combine(self, hasher) {
 }
 
 ///|
-pub impl Shl for Int16 with op_shl(self : Int16, that : Int) -> Int16 {
+pub impl Shl for Int16 with shl(self : Int16, that : Int) -> Int16 {
   (self.to_int() << that).to_int16()
 }
 
@@ -89,7 +89,7 @@ pub impl BitXOr for Int16 with lxor(self : Int16, that : Int16) -> Int16 {
 }
 
 ///|
-pub impl Neg for Int16 with op_neg(self : Int16) -> Int16 {
+pub impl Neg for Int16 with neg(self : Int16) -> Int16 {
   (-self.to_int()).to_int16()
 }
 

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -44,7 +44,7 @@ pub impl Mod for Int16 with mod(self : Int16, that : Int16) -> Int16 {
 }
 
 ///|
-pub impl Eq for Int16 with op_equal(self, that) {
+pub impl Eq for Int16 with equal(self, that) {
   self.to_int() == that.to_int()
 }
 

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1038,7 +1038,7 @@ pub fn[A : Compare] sort(self : List[A]) -> List[A] {
 /// let result = a + b
 /// assert_eq(result, @list.of([1, 2, 3, 4, 5, 6]))
 /// ```
-pub impl[A] Add for List[A] with op_add(self, other) {
+pub impl[A] Add for List[A] with add(self, other) {
   self.concat(other)
 }
 

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -52,7 +52,7 @@ pub impl[A : Show] Show for Queue[A] with output(self, logger) {
 
 ///|
 /// Tests if two queues are equal.
-impl[A : Eq] Eq for Queue[A] with op_equal(self, other) {
+impl[A : Eq] Eq for Queue[A] with equal(self, other) {
   self.length == other.length && self.first == other.first
 }
 

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -209,7 +209,7 @@ pub fn T::abs(self : T) -> T {
 /// Returns `true` if the two rational numbers are equal, `false` otherwise.
 ///
 #coverage.skip
-pub impl Eq for T with op_equal(self : T, other : T) -> Bool {
+pub impl Eq for T with equal(self : T, other : T) -> Bool {
   self.numerator * other.denominator == other.numerator * self.denominator
 }
 
@@ -283,7 +283,7 @@ pub(all) suberror RationalError String derive(Show, ToJson(style="flat"))
 /// `false` otherwise.
 ///
 #coverage.skip
-pub impl Eq for RationalError with op_equal(
+pub impl Eq for RationalError with equal(
   self : RationalError,
   other : RationalError,
 ) -> Bool {

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -81,7 +81,7 @@ fn new_unchecked(numerator : Int64, denominator : Int64) -> T {
 /// NOTE: we don't check overflow here, to align with the `op_add` of `Int64`.
 /// TODO: add a `checked_add` method.
 #coverage.skip
-pub impl Add for T with op_add(self : T, other : T) -> T {
+pub impl Add for T with add(self : T, other : T) -> T {
   new_unchecked(
     self.numerator * other.denominator + other.numerator * self.denominator,
     self.denominator * other.denominator,
@@ -99,7 +99,7 @@ pub impl Add for T with op_add(self : T, other : T) -> T {
 /// Returns the difference of the two rational numbers.
 ///
 #coverage.skip
-pub impl Sub for T with op_sub(self : T, other : T) -> T {
+pub impl Sub for T with sub(self : T, other : T) -> T {
   new_unchecked(
     self.numerator * other.denominator - other.numerator * self.denominator,
     self.denominator * other.denominator,
@@ -117,7 +117,7 @@ pub impl Sub for T with op_sub(self : T, other : T) -> T {
 /// Returns the product of the two rational numbers.
 ///
 #coverage.skip
-pub impl Mul for T with op_mul(self : T, other : T) -> T {
+pub impl Mul for T with mul(self : T, other : T) -> T {
   new_unchecked(
     self.numerator * other.numerator,
     self.denominator * other.denominator,
@@ -135,7 +135,7 @@ pub impl Mul for T with op_mul(self : T, other : T) -> T {
 /// Returns the quotient of the division as a rational number.
 ///
 #coverage.skip
-pub impl Div for T with op_div(self : T, other : T) -> T {
+pub impl Div for T with div(self : T, other : T) -> T {
   if other.numerator < 0L {
     new_unchecked(
       self.numerator * -other.denominator,

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -605,7 +605,7 @@ pub impl[K : Hash + Eq] BitXOr for Set[K] with lxor(self, other) {
 
 ///|
 /// Difference of two hash sets.
-pub impl[K : Hash + Eq] Sub for Set[K] with op_sub(self, other) {
+pub impl[K : Hash + Eq] Sub for Set[K] with sub(self, other) {
   self.difference(other)
 }
 

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -438,7 +438,7 @@ pub fn[K] to_array(self : Set[K]) -> Array[K] {
 }
 
 ///|
-pub impl[K : Hash + Eq] Eq for Set[K] with op_equal(self, other) {
+pub impl[K : Hash + Eq] Eq for Set[K] with equal(self, other) {
   guard self.size == other.size else { return false }
   for k in self {
     guard other.contains(k) else { return false }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -22,7 +22,7 @@ pub fn[K : Compare, V] op_set(
 }
 
 ///|
-pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V] with op_equal(self, other) {
+pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V] with equal(self, other) {
   self.to_array() == other.to_array()
 }
 

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -18,7 +18,7 @@ fn[K, V] new_node(key : K, value : V) -> Node[K, V] {
 }
 
 ///|
-impl[K : Eq, V] Eq for Node[K, V] with op_equal(self, other) {
+impl[K : Eq, V] Eq for Node[K, V] with equal(self, other) {
   self.key == other.key
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -318,7 +318,7 @@ pub fn[V : Compare] disjoint(self : SortedSet[V], src : SortedSet[V]) -> Bool {
 // General collection operations
 
 ///|
-pub impl[V : Eq] Eq for SortedSet[V] with op_equal(self, other) {
+pub impl[V : Eq] Eq for SortedSet[V] with equal(self, other) {
   self.to_array() == other.to_array()
 }
 

--- a/sorted_set/utils.mbt
+++ b/sorted_set/utils.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-impl[V : Eq] Eq for Node[V] with op_equal(self, other) {
+impl[V : Eq] Eq for Node[V] with equal(self, other) {
   self.value == other.value
 }
 

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -323,7 +323,7 @@ pub fn View::rev_iter(self : View) -> Iter[Char] {
 ///|
 /// Compares two views for equality. Returns true only if both views
 /// have the same length and contain identical characters in the same order.
-pub impl Eq for View with op_equal(self, other) {
+pub impl Eq for View with equal(self, other) {
   let len = self.length()
   guard len == other.length() else { return false }
   if physical_equal(self.str(), other.str()) && self.start() == other.start() {

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -561,6 +561,6 @@ pub fn View::op_as_view(
 }
 
 ///|
-pub impl Add for View with op_add(self, other) {
+pub impl Add for View with add(self, other) {
   [..self, ..other]
 }

--- a/uint16/uint16.mbt
+++ b/uint16/uint16.mbt
@@ -24,7 +24,19 @@ pub impl Add for UInt16 with add(self : UInt16, that : UInt16) -> UInt16 {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Add for UInt16 with op_add(self : UInt16, that : UInt16) -> UInt16 {
+  (self.to_int() + that.to_int()).to_uint16()
+}
+
+///|
 pub impl Sub for UInt16 with sub(self : UInt16, that : UInt16) -> UInt16 {
+  (self.to_int() - that.to_int()).to_uint16()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Sub for UInt16 with op_sub(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() - that.to_int()).to_uint16()
 }
 
@@ -34,7 +46,19 @@ pub impl Mul for UInt16 with mul(self : UInt16, that : UInt16) -> UInt16 {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Mul for UInt16 with op_mul(self : UInt16, that : UInt16) -> UInt16 {
+  (self.to_int() * that.to_int()).to_uint16()
+}
+
+///|
 pub impl Div for UInt16 with div(self : UInt16, that : UInt16) -> UInt16 {
+  (self.to_int() / that.to_int()).to_uint16()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Div for UInt16 with op_div(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() / that.to_int()).to_uint16()
 }
 
@@ -44,7 +68,19 @@ pub impl Mod for UInt16 with mod(self : UInt16, that : UInt16) -> UInt16 {
 }
 
 ///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Mod for UInt16 with op_mod(self : UInt16, that : UInt16) -> UInt16 {
+  (self.to_int() % that.to_int()).to_uint16()
+}
+
+///|
 pub impl Eq for UInt16 with equal(self, that) {
+  self.to_int() == that.to_int()
+}
+
+///|
+// TODO: remove this after we migrate compiler to new names
+pub impl Eq for UInt16 with op_equal(self, that) {
   self.to_int() == that.to_int()
 }
 

--- a/uint16/uint16.mbt
+++ b/uint16/uint16.mbt
@@ -44,7 +44,7 @@ pub impl Mod for UInt16 with mod(self : UInt16, that : UInt16) -> UInt16 {
 }
 
 ///|
-pub impl Eq for UInt16 with op_equal(self, that) {
+pub impl Eq for UInt16 with equal(self, that) {
   self.to_int() == that.to_int()
 }
 

--- a/uint16/uint16.mbt
+++ b/uint16/uint16.mbt
@@ -19,27 +19,27 @@ pub let max_value : UInt16 = 65535
 pub let min_value : UInt16 = 0
 
 ///|
-pub impl Add for UInt16 with op_add(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Add for UInt16 with add(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() + that.to_int()).to_uint16()
 }
 
 ///|
-pub impl Sub for UInt16 with op_sub(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Sub for UInt16 with sub(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() - that.to_int()).to_uint16()
 }
 
 ///|
-pub impl Mul for UInt16 with op_mul(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Mul for UInt16 with mul(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() * that.to_int()).to_uint16()
 }
 
 ///|
-pub impl Div for UInt16 with op_div(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Div for UInt16 with div(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() / that.to_int()).to_uint16()
 }
 
 ///|
-pub impl Mod for UInt16 with op_mod(self : UInt16, that : UInt16) -> UInt16 {
+pub impl Mod for UInt16 with mod(self : UInt16, that : UInt16) -> UInt16 {
   (self.to_int() % that.to_int()).to_uint16()
 }
 
@@ -64,7 +64,7 @@ pub impl Hash for UInt16 with hash_combine(self, hasher) {
 }
 
 ///|
-pub impl Shl for UInt16 with op_shl(self : UInt16, that : Int) -> UInt16 {
+pub impl Shl for UInt16 with shl(self : UInt16, that : Int) -> UInt16 {
   (self.to_int() << that).to_uint16()
 }
 


### PR DESCRIPTION
- **add duplicated names for migration**
- **fix all warnings**
- **update mi file**

```
Error: Moonc.Basic_hash_string.Key_not_found("$@moonbitlang/core/builtin.Add::Int16::op_add")
```
The compiler may hard coded Int16::op_add operator etc