### PR TITLE
hongbo/continue types renaming

### DIFF
--- a/deque/README.mbt.md
+++ b/deque/README.mbt.md
@@ -10,7 +10,7 @@ You can create a deque manually via the `new()` or construct it using the `of()`
 
 ```moonbit
 test {
-    let _dv : @deque.T[Int] = @deque.new()
+    let _dv : @deque.Deque[Int] = @deque.new()
     let _dv = @deque.of([1, 2, 3, 4, 5])
 }
 ```
@@ -19,7 +19,7 @@ If you want to set the length at creation time to minimize expansion consumption
 
 ```moonbit
 test {
-    let _dv: @deque.T[Int] = @deque.new(capacity=10)
+    let _dv: @deque.Deque[Int] = @deque.new(capacity=10)
 }
 ```
 
@@ -38,7 +38,7 @@ Similarly, you can use the `is_empty` to determine whether the queue is empty.
 
 ```moonbit
 test {
-   let dv : @deque.T[Int] = @deque.new()
+   let dv : @deque.Deque[Int] = @deque.new()
    assert_eq(dv.is_empty(), true)
 }
 ```

--- a/deque/deprecated.mbt
+++ b/deque/deprecated.mbt
@@ -15,20 +15,20 @@
 ///|
 #deprecated("Use `unsafe_pop_front` instead")
 #coverage.skip
-pub fn[A] pop_front_exn(self : T[A]) -> Unit {
+pub fn[A] pop_front_exn(self : Deque[A]) -> Unit {
   self.unsafe_pop_front()
 }
 
 ///|
 #deprecated("Use `unsafe_pop_back` instead")
 #coverage.skip
-pub fn[A] pop_back_exn(self : T[A]) -> Unit {
+pub fn[A] pop_back_exn(self : Deque[A]) -> Unit {
   self.unsafe_pop_back()
 }
 
 ///|
 #deprecated("Use `@deque.retain_map` instead")
-pub fn[A] filter_map_inplace(self : T[A], f : (A) -> A?) -> Unit {
+pub fn[A] filter_map_inplace(self : Deque[A], f : (A) -> A?) -> Unit {
   self.retain_map(f)
 }
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -29,16 +29,16 @@ fn[T] set_null(buffer : UninitializedArray[T], index : Int) = "%fixedarray.set_n
 ///# Example
 ///
 /// ```moonbit
-///   let dq : @deque.T[Int] = @deque.new()
+///   let dq : @deque.Deque[Int] = @deque.new()
 ///   inspect(dq.length(), content="0")
 ///   inspect(dq.capacity(), content="0")
 ///
-///   let dq : @deque.T[Int] = @deque.new(capacity=10)
+///   let dq : @deque.Deque[Int] = @deque.new(capacity=10)
 ///   inspect(dq.length(), content="0")
 ///   inspect(dq.capacity(), content="10")
 /// ```
-pub fn[A] new(capacity? : Int = 0) -> T[A] {
-  T::{ buf: UninitializedArray::make(capacity), len: 0, head: 0, tail: 0 }
+pub fn[A] new(capacity? : Int = 0) -> Deque[A] {
+  Deque::{ buf: UninitializedArray::make(capacity), len: 0, head: 0, tail: 0 }
 }
 
 ///|
@@ -58,7 +58,7 @@ pub fn[A] new(capacity? : Int = 0) -> T[A] {
 ///   inspect(dq, content="@deque.of([1, 2, 3])")
 /// ```
 ///
-pub impl[A : Show] Show for T[A] with output(self, logger) {
+pub impl[A : Show] Show for Deque[A] with output(self, logger) {
   logger.write_iter(self.iter(), prefix="@deque.of([", suffix="])")
 }
 
@@ -79,8 +79,8 @@ pub impl[A : Show] Show for T[A] with output(self, logger) {
 ///   let dq = @deque.from_array(arr)
 ///   inspect(dq, content="@deque.of([1, 2, 3, 4, 5])")
 /// ```
-pub fn[A] from_array(arr : Array[A]) -> T[A] {
-  let deq = T::{
+pub fn[A] from_array(arr : Array[A]) -> Deque[A] {
+  let deq = Deque::{
     buf: UninitializedArray::make(arr.length()),
     len: arr.length(),
     head: 0,
@@ -111,9 +111,9 @@ pub fn[A] from_array(arr : Array[A]) -> T[A] {
 ///   let copied = dq.copy()
 ///   inspect(copied, content="@deque.of([1, 2, 3, 4, 5])")
 /// ```
-pub fn[A] copy(self : T[A]) -> T[A] {
+pub fn[A] copy(self : Deque[A]) -> Deque[A] {
   let len = self.len
-  let deq = T::{
+  let deq = Deque::{
     buf: UninitializedArray::make(len),
     len,
     head: 0,
@@ -146,7 +146,7 @@ pub fn[A] copy(self : T[A]) -> T[A] {
 /// v1.append(v2)
 /// inspect(v1, content="@deque.of([1, 2, 3])")
 /// ```
-pub fn[A] append(self : T[A], other : T[A]) -> Unit {
+pub fn[A] append(self : Deque[A], other : Deque[A]) -> Unit {
   guard other.len != 0 else { return }
   let space = if self.buf.length() != 0 {
     (self.head - self.tail - 1 + self.buf.length()) % self.buf.length()
@@ -189,8 +189,8 @@ pub fn[A] append(self : T[A], other : T[A]) -> Unit {
 ///   let dq = @deque.of([1, 2, 3])
 ///   inspect(dq, content="@deque.of([1, 2, 3])")
 /// ```
-pub fn[A] of(arr : FixedArray[A]) -> T[A] {
-  let deq = T::{
+pub fn[A] of(arr : FixedArray[A]) -> Deque[A] {
+  let deq = Deque::{
     buf: UninitializedArray::make(arr.length()),
     len: arr.length(),
     head: 0,
@@ -219,7 +219,7 @@ pub fn[A] of(arr : FixedArray[A]) -> T[A] {
 ///   dq.push_back(4)
 ///   inspect(dq.length(), content="4")
 /// ```
-pub fn[A] length(self : T[A]) -> Int {
+pub fn[A] length(self : Deque[A]) -> Int {
   self.len
 }
 
@@ -241,13 +241,13 @@ pub fn[A] length(self : T[A]) -> Int {
 ///   dq.push_back(2)
 ///   inspect(dq.capacity(), content="10")
 /// ```
-pub fn[A] capacity(self : T[A]) -> Int {
+pub fn[A] capacity(self : Deque[A]) -> Int {
   self.buf.length()
 }
 
 ///|
 /// Reallocate the deque with a new capacity.
-fn[A] realloc(self : T[A]) -> Unit {
+fn[A] realloc(self : Deque[A]) -> Unit {
   let old_cap = self.len
   let new_cap = if old_cap == 0 { 8 } else { old_cap * 2 }
   let new_buf = UninitializedArray::make(new_cap)
@@ -283,7 +283,7 @@ fn[A] realloc(self : T[A]) -> Unit {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.front(), Some(1))
 /// ```
-pub fn[A] front(self : T[A]) -> A? {
+pub fn[A] front(self : Deque[A]) -> A? {
   if self.len == 0 {
     None
   } else {
@@ -299,7 +299,7 @@ pub fn[A] front(self : T[A]) -> A? {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.back(), Some(5))
 /// ```
-pub fn[A] back(self : T[A]) -> A? {
+pub fn[A] back(self : Deque[A]) -> A? {
   if self.len == 0 {
     None
   } else {
@@ -318,7 +318,7 @@ pub fn[A] back(self : T[A]) -> A? {
 ///   dv.push_front(0)
 ///   assert_eq(dv.front(), Some(0))
 /// ```
-pub fn[A] push_front(self : T[A], value : A) -> Unit {
+pub fn[A] push_front(self : Deque[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
   }
@@ -340,7 +340,7 @@ pub fn[A] push_front(self : T[A], value : A) -> Unit {
 ///   dv.push_back(6)
 ///   assert_eq(dv.back(), Some(6))
 /// ```
-pub fn[A] push_back(self : T[A], value : A) -> Unit {
+pub fn[A] push_back(self : Deque[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
   }
@@ -361,7 +361,7 @@ pub fn[A] push_back(self : T[A], value : A) -> Unit {
 ///   assert_eq(dv.front(), Some(2))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
-pub fn[A] unsafe_pop_front(self : T[A]) -> Unit {
+pub fn[A] unsafe_pop_front(self : Deque[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
     1 => {
@@ -409,7 +409,7 @@ pub fn[A] unsafe_pop_front(self : T[A]) -> Unit {
 ///   assert_eq(dv.back(), Some(4))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
-pub fn[A] unsafe_pop_back(self : T[A]) -> Unit {
+pub fn[A] unsafe_pop_back(self : Deque[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
     1 => {
@@ -457,7 +457,7 @@ pub fn[A] unsafe_pop_back(self : T[A]) -> Unit {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.pop_front(), Some(1))
 /// ```
-pub fn[A] pop_front(self : T[A]) -> A? {
+pub fn[A] pop_front(self : Deque[A]) -> A? {
   match self.len {
     0 => None
     1 => {
@@ -488,7 +488,7 @@ pub fn[A] pop_front(self : T[A]) -> A? {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.pop_back(), Some(5))
 /// ```
-pub fn[A] pop_back(self : T[A]) -> A? {
+pub fn[A] pop_back(self : Deque[A]) -> A? {
   match self.len {
     0 => None
     1 => {
@@ -521,7 +521,7 @@ pub fn[A] pop_back(self : T[A]) -> A? {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   inspect(dv[2], content="3")
 /// ```
-pub fn[A] op_get(self : T[A], index : Int) -> A {
+pub fn[A] op_get(self : Deque[A], index : Int) -> A {
   if index < 0 || index >= self.len {
     let len = self.len
     abort(
@@ -546,7 +546,7 @@ pub fn[A] op_get(self : T[A], index : Int) -> A {
 ///   dv[2] = 1
 ///   inspect(dv[2], content="1")
 /// ```
-pub fn[A] op_set(self : T[A], index : Int, value : A) -> Unit {
+pub fn[A] op_set(self : Deque[A], index : Int, value : A) -> Unit {
   if index < 0 || index >= self.len {
     let len = self.len
     abort(
@@ -584,7 +584,7 @@ pub fn[A] op_set(self : T[A], index : Int, value : A) -> Unit {
 ///   inspect(v1.length(), content="5")
 ///   inspect(v2.length(), content="0")
 /// ```
-pub fn[A] T::as_views(self : T[A]) -> (@array.View[A], @array.View[A]) {
+pub fn[A] Deque::as_views(self : Deque[A]) -> (@array.View[A], @array.View[A]) {
   guard self.len != 0 else { ([][:], [][:]) }
   let { buf, head, len, .. } = self
   let cap = buf.length()
@@ -616,7 +616,7 @@ pub fn[A] T::as_views(self : T[A]) -> (@array.View[A], @array.View[A]) {
 ///   inspect(dq1 == dq2, content="true")
 ///   inspect(dq1 == dq3, content="false")
 /// ```
-pub impl[A : Eq] Eq for T[A] with op_equal(self, other) {
+pub impl[A : Eq] Eq for Deque[A] with op_equal(self, other) {
   if self.len != other.len {
     return false
   }
@@ -638,7 +638,7 @@ pub impl[A : Eq] Eq for T[A] with op_equal(self, other) {
 ///   dv.each((x) => {sum = sum + x})
 ///   inspect(sum, content="15")
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
+pub fn[A] each(self : Deque[A], f : (A) -> Unit) -> Unit {
   for v in self {
     f(v)
   }
@@ -654,7 +654,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
 ///   dv.eachi((i, _x) => {idx_sum = idx_sum + i})
 ///   inspect(idx_sum, content="10")
 /// ```
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self {
     f(i, v)
   }
@@ -670,7 +670,7 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 ///   dv.rev_each((x) => {sum = sum + x})
 ///   inspect(sum, content="15")
 /// ```
-pub fn[A] rev_each(self : T[A], f : (A) -> Unit) -> Unit {
+pub fn[A] rev_each(self : Deque[A], f : (A) -> Unit) -> Unit {
   for v in self.rev_iter() {
     f(v)
   }
@@ -686,7 +686,7 @@ pub fn[A] rev_each(self : T[A], f : (A) -> Unit) -> Unit {
 ///   dv.rev_eachi((i, _x) => {idx_sum = idx_sum + i})
 ///   inspect(idx_sum, content="10")
 /// ```
-pub fn[A] rev_eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] rev_eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self.rev_iter2() {
     f(i, v)
   }
@@ -703,7 +703,7 @@ pub fn[A] rev_eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 ///   dv.clear()
 ///   inspect(dv.length(), content="0")
 /// ```
-pub fn[A] clear(self : T[A]) -> Unit {
+pub fn[A] clear(self : Deque[A]) -> Unit {
   let { head, buf, len, .. } = self
   let cap = buf.length()
   let head_len = cap - head
@@ -733,7 +733,7 @@ pub fn[A] clear(self : T[A]) -> Unit {
 ///   let dv2 = dv.map((x) => {x + 1})
 ///   assert_eq(dv2, @deque.of([4, 5, 6]))
 /// ```
-pub fn[A, U] map(self : T[A], f : (A) -> U) -> T[U] {
+pub fn[A, U] map(self : Deque[A], f : (A) -> U) -> Deque[U] {
   if self.len == 0 {
     new()
   } else {
@@ -742,7 +742,7 @@ pub fn[A, U] map(self : T[A], f : (A) -> U) -> T[U] {
       let idx = (self.head + i) % self.len
       buf[i] = f(self.buf[idx])
     }
-    T::{ buf, len: self.len, head: 0, tail: self.len - 1 }
+    Deque::{ buf, len: self.len, head: 0, tail: self.len - 1 }
   }
 }
 
@@ -755,7 +755,7 @@ pub fn[A, U] map(self : T[A], f : (A) -> U) -> T[U] {
 ///   let dv2 = dv.mapi((i, x) => {x + i}) // @deque.of([3, 5, 7])
 ///   assert_eq(dv2, @deque.of([3, 5, 7]))
 /// ```
-pub fn[A, U] mapi(self : T[A], f : (Int, A) -> U) -> T[U] {
+pub fn[A, U] mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
   if self.len == 0 {
     new()
   } else {
@@ -764,7 +764,7 @@ pub fn[A, U] mapi(self : T[A], f : (Int, A) -> U) -> T[U] {
       let idx = (self.head + i) % self.len
       buf[i] = f(i, self.buf[idx])
     }
-    T::{ buf, len: self.len, head: 0, tail: self.len - 1 }
+    Deque::{ buf, len: self.len, head: 0, tail: self.len - 1 }
   }
 }
 
@@ -778,7 +778,7 @@ pub fn[A, U] mapi(self : T[A], f : (Int, A) -> U) -> T[U] {
 ///   dv.push_back(1)
 ///   inspect(dv.is_empty(), content="false")
 /// ```
-pub fn[A] is_empty(self : T[A]) -> Bool {
+pub fn[A] is_empty(self : Deque[A]) -> Bool {
   self.len == 0
 }
 
@@ -800,7 +800,7 @@ pub fn[A] is_empty(self : T[A]) -> Bool {
 ///   inspect(dq.search(2), content="Some(1)")
 ///   inspect(dq.search(4), content="None")
 /// ```
-pub fn[A : Eq] search(self : T[A], value : A) -> Int? {
+pub fn[A : Eq] search(self : Deque[A], value : A) -> Int? {
   for i in 0..<self.len {
     let idx = (self.head + i) % self.len
     if self.buf[idx] == value {
@@ -828,7 +828,7 @@ pub fn[A : Eq] search(self : T[A], value : A) -> Int? {
 ///   inspect(dq.contains(3), content="true")
 ///   inspect(dq.contains(6), content="false")
 /// ```
-pub fn[A : Eq] contains(self : T[A], value : A) -> Bool {
+pub fn[A : Eq] contains(self : Deque[A], value : A) -> Bool {
   self.iter().contains(value)
 }
 
@@ -843,7 +843,7 @@ pub fn[A : Eq] contains(self : T[A], value : A) -> Bool {
 ///   dv.reserve_capacity(10)
 ///   inspect(dv.capacity(), content="10")
 /// ```
-pub fn[A] reserve_capacity(self : T[A], capacity : Int) -> Unit {
+pub fn[A] reserve_capacity(self : Deque[A], capacity : Int) -> Unit {
   if self.capacity() >= capacity {
     return
   }
@@ -873,7 +873,7 @@ pub fn[A] reserve_capacity(self : T[A], capacity : Int) -> Unit {
 ///   dv.shrink_to_fit()
 ///   inspect(dv.capacity(), content="3")
 /// ```
-pub fn[A] shrink_to_fit(self : T[A]) -> Unit {
+pub fn[A] shrink_to_fit(self : Deque[A]) -> Unit {
   if self.capacity() <= self.length() {
     return
   }
@@ -906,7 +906,7 @@ pub fn[A] shrink_to_fit(self : T[A]) -> Unit {
 ///   dq.truncate(3)
 ///   inspect(dq, content="@deque.of([1, 2, 3])")
 /// ```
-pub fn[A] truncate(self : T[A], len : Int) -> Unit {
+pub fn[A] truncate(self : Deque[A], len : Int) -> Unit {
   guard len >= 0 && len < self.len else { return }
   if len == 0 {
     self.clear()
@@ -957,7 +957,7 @@ pub fn[A] truncate(self : T[A], len : Int) -> Unit {
 ///   dq.retain_map((x) => { if x % 2 == 0 { Some(x * 2) } else { None } })
 ///   inspect(dq, content="@deque.of([4, 8])")
 /// ```
-pub fn[A] retain_map(self : T[A], f : (A) -> A?) -> Unit {
+pub fn[A] retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self
   let cap = buf.length()
@@ -1014,7 +1014,7 @@ pub fn[A] retain_map(self : T[A], f : (A) -> A?) -> Unit {
 ///   dq.retain((x) => { x % 2 == 0 })
 ///   inspect(dq, content="@deque.of([2, 4])")
 /// ```
-pub fn[A] retain(self : T[A], f : (A) -> Bool) -> Unit {
+pub fn[A] retain(self : Deque[A], f : (A) -> Bool) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self
   let cap = buf.length()
@@ -1065,7 +1065,7 @@ pub fn[A] retain(self : T[A], f : (A) -> Bool) -> Unit {
 ///   dq.iter().each((x) => { sum = sum + x })
 ///   inspect(sum, content="15")
 /// ```
-pub fn[A] iter(self : T[A]) -> Iter[A] {
+pub fn[A] iter(self : Deque[A]) -> Iter[A] {
   Iter::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1107,7 +1107,7 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
 ///   dq.iter2().each((i, x) => { sum = sum + i * x })
 ///   inspect(sum, content="80") // 0*10 + 1*20 + 2*30 = 80
 /// ```
-pub fn[A] iter2(self : T[A]) -> Iter2[Int, A] {
+pub fn[A] iter2(self : Deque[A]) -> Iter2[Int, A] {
   Iter2::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1151,7 +1151,7 @@ pub fn[A] iter2(self : T[A]) -> Iter2[Int, A] {
 ///   dq.rev_iter().each((x) => { sum = sum * 10 + x })
 ///   inspect(sum, content="321")
 /// ```
-pub fn[A] rev_iter(self : T[A]) -> Iter[A] {
+pub fn[A] rev_iter(self : Deque[A]) -> Iter[A] {
   Iter::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1193,7 +1193,7 @@ pub fn[A] rev_iter(self : T[A]) -> Iter[A] {
 ///   dq.rev_iter2().each((i, x) => { s = s + "\{i}:\{x} " })
 ///   inspect(s, content="0:3 1:2 2:1 ")
 /// ```
-pub fn[A] rev_iter2(self : T[A]) -> Iter2[Int, A] {
+pub fn[A] rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
   Iter2::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1236,7 +1236,7 @@ pub fn[A] rev_iter2(self : T[A]) -> Iter2[Int, A] {
 ///   let dq = @deque.from_iter(arr.iter())
 ///   inspect(dq, content="@deque.of([1, 2, 3, 4, 5])")
 /// ```
-pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
+pub fn[A] from_iter(iter : Iter[A]) -> Deque[A] {
   let dq = new()
   iter.each(e => dq.push_back(e))
   dq
@@ -1260,7 +1260,7 @@ pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
 ///   inspect(arr, content="[1, 2, 3, 4, 5]")
 /// ```
 ///
-pub fn[A] to_array(self : T[A]) -> Array[A] {
+pub fn[A] to_array(self : Deque[A]) -> Array[A] {
   let len = self.length()
   if len == 0 {
     []
@@ -1297,7 +1297,7 @@ pub fn[A] to_array(self : T[A]) -> Array[A] {
 ///   let s2 = deque.join(",")
 ///   inspect(s2, content="a,b,c")
 /// ```
-pub fn T::join(self : T[String], separator : @string.View) -> String {
+pub fn Deque::join(self : Deque[String], separator : @string.View) -> String {
   let str = separator.to_string()
   self.iter().join(str)
 }
@@ -1317,7 +1317,7 @@ pub fn T::join(self : T[String], separator : @string.View) -> String {
 ///   inspect(json, content="Array([Number(1), Number(2), Number(3)])")
 /// ```
 ///
-pub impl[A : ToJson] ToJson for T[A] with to_json(self : T[A]) -> Json {
+pub impl[A : ToJson] ToJson for Deque[A] with to_json(self : Deque[A]) -> Json {
   let res = Array::make(self.length(), null)
   for i, x in self {
     res[i] = x.to_json()
@@ -1344,11 +1344,14 @@ pub impl[A : ToJson] ToJson for T[A] with to_json(self : T[A]) -> Json {
 ///
 /// ```moonbit
 ///   let json = @json.parse("[1, 2, 3]")
-///   let dq : @deque.T[Int] = @json.from_json(json)
+///   let dq : @deque.Deque[Int] = @json.from_json(json)
 ///   inspect(dq, content="@deque.of([1, 2, 3])")
 /// ```
 ///
-pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) {
+pub impl[A : @json.FromJson] @json.FromJson for Deque[A] with from_json(
+  json,
+  path,
+) {
   guard json is Array(arr) else {
     raise @json.JsonDecodeError((path, "Deque::from_json: expected array"))
   }
@@ -1384,12 +1387,12 @@ pub impl[A : @json.FromJson] @json.FromJson for T[A] with from_json(json, path) 
 ///   let deque_test = deque.flatten()
 ///   inspect(deque_test, content="@deque.of([1, 2, 3, 4, 5, 6, 7, 8])")
 /// ```
-pub fn[A] T::flatten(self : T[T[A]]) -> T[A] {
+pub fn[A] Deque::flatten(self : Deque[Deque[A]]) -> Deque[A] {
   let mut len = 0
   for deque in self {
     len += deque.length()
   }
-  let target = T::{
+  let target = Deque::{
     buf: UninitializedArray::make(len),
     len,
     head: 0,
@@ -1429,7 +1432,7 @@ pub fn[A] T::flatten(self : T[T[A]]) -> T[A] {
 /// inspect(deque_test, content="@deque.of([3, 4, 5, 6])")
 /// inspect(deque, content="@deque.of([1, 2, 7, 8, 9])")
 /// ```
-pub fn[A] T::drain(self : T[A], start~ : Int, len? : Int) -> T[A] {
+pub fn[A] Deque::drain(self : Deque[A], start~ : Int, len? : Int) -> Deque[A] {
   let len = match len {
     Some(l) => if l > self.len { self.len } else { l }
     None => self.len - start
@@ -1437,7 +1440,7 @@ pub fn[A] T::drain(self : T[A], start~ : Int, len? : Int) -> T[A] {
   if len == 0 {
     return new()
   }
-  let deque = T::{
+  let deque = Deque::{
     buf: UninitializedArray::make(len),
     len,
     head: 0,
@@ -1523,7 +1526,10 @@ pub fn[A] T::drain(self : T[A], start~ : Int, len? : Int) -> T[A] {
 /// * Handles the deque's ring buffer structure internally
 /// * For empty deques, returns `Err(0)`
 #locals(cmp)
-pub fn[A] binary_search_by(self : T[A], cmp : (A) -> Int) -> Result[Int, Int] {
+pub fn[A] binary_search_by(
+  self : Deque[A],
+  cmp : (A) -> Int,
+) -> Result[Int, Int] {
   let len = self.len
 
   // Functional loop with two evolving bounds `i` (inclusive) and `j` (exclusive).
@@ -1554,7 +1560,7 @@ pub fn[A] binary_search_by(self : T[A], cmp : (A) -> Int) -> Result[Int, Int] {
 
 ///|
 /// Safe element access with bounds checking
-pub fn[A] get(self : T[A], index : Int) -> A? {
+pub fn[A] get(self : Deque[A], index : Int) -> A? {
   if index >= 0 && index < self.len {
     let physical_index = (self.head + index) % self.buf.length()
     Some(self.buf[physical_index])
@@ -1591,7 +1597,10 @@ pub fn[A] get(self : T[A], index : Int) -> A? {
 /// * Assumes the deque is sorted in ascending order
 /// * For multiple matches, returns the leftmost matching position
 /// * Returns an insertion point that maintains the sort order when no match is found
-pub fn[A : Compare] binary_search(self : T[A], value : A) -> Result[Int, Int] {
+pub fn[A : Compare] binary_search(
+  self : Deque[A],
+  value : A,
+) -> Result[Int, Int] {
   self.binary_search_by(x => x.compare(value))
 }
 
@@ -1625,7 +1634,7 @@ pub fn[A : Compare] binary_search(self : T[A], value : A) -> Result[Int, Int] {
 ///   inspect(dq1.compare(dq3), content="1") // dq1 > dq3 (longer)
 ///   inspect(dq1.compare(dq1), content="0") // dq1 = dq1
 /// ```
-pub impl[A : Compare] Compare for T[A] with compare(self, other) {
+pub impl[A : Compare] Compare for Deque[A] with compare(self, other) {
   let len_self = self.length()
   let len_other = other.length()
   let cmp = len_self.compare(len_other)
@@ -1652,11 +1661,11 @@ pub impl[A : Compare] Compare for T[A] with compare(self, other) {
 ///   dq.rev_inplace()
 ///   inspect(dq, content="@deque.of([5, 4, 3, 2, 1])")
 ///
-///   let dq : @deque.T[Int] = @deque.new()
+///   let dq : @deque.Deque[Int] = @deque.new()
 ///   dq.rev_inplace()
 ///   inspect(dq, content="@deque.of([])")
 /// ```
-pub fn[A] T::rev_inplace(self : T[A]) -> Unit {
+pub fn[A] Deque::rev_inplace(self : Deque[A]) -> Unit {
   guard self.len > 0 else { return }
   let cap = self.buf.length()
   let mut left = self.head
@@ -1687,7 +1696,7 @@ pub fn[A] T::rev_inplace(self : T[A]) -> Unit {
 ///   inspect(dq.rev(), content="@deque.of([5, 4, 3, 2, 1])")
 ///   inspect(dq, content="@deque.of([1, 2, 3, 4, 5])") // original deque unchanged
 /// ```
-pub fn[A] T::rev(self : T[A]) -> T[A] {
+pub fn[A] Deque::rev(self : Deque[A]) -> Deque[A] {
   let len = self.len
   let new_buf = UninitializedArray::make(len)
   // Copy elements in reverse order
@@ -1696,7 +1705,16 @@ pub fn[A] T::rev(self : T[A]) -> T[A] {
     new_buf[i] = self.buf[src_idx]
   }
   // Create new deque with reversed elements
-  T::{ buf: new_buf, len, head: 0, tail: if len == 0 { 0 } else { len - 1 } }
+  Deque::{
+    buf: new_buf,
+    len,
+    head: 0,
+    tail: if len == 0 {
+      0
+    } else {
+      len - 1
+    },
+  }
 }
 
 ///|
@@ -1708,7 +1726,10 @@ pub fn[A] T::rev(self : T[A]) -> T[A] {
 ///
 /// # Note
 /// This function handles the circular buffer nature of the deque internally.
-pub fn[A] T::shuffle_in_place(self : T[A], rand~ : (Int) -> Int) -> Unit {
+pub fn[A] Deque::shuffle_in_place(
+  self : Deque[A],
+  rand~ : (Int) -> Int,
+) -> Unit {
   let n = self.len
   let buf_length = self.buf.length()
   for i = n - 1; i > 0; i = i - 1 {
@@ -1731,7 +1752,7 @@ pub fn[A] T::shuffle_in_place(self : T[A], rand~ : (Int) -> Int) -> Unit {
 /// To use this function, you need to provide a rand function, which takes an integer as its upper bound
 /// and returns an integer.
 /// *rand n* is expected to return a uniformly distributed integer between 0 and n - 1
-pub fn[A] shuffle(self : T[A], rand~ : (Int) -> Int) -> T[A] {
+pub fn[A] shuffle(self : Deque[A], rand~ : (Int) -> Int) -> Deque[A] {
   // Create a copy of the original deque
   let new_deque = self.copy()
   // Shuffle the copy in place

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -221,7 +221,7 @@ test "from_array" {
 
 ///|
 test "copy" {
-  inspect((@deque.new() : @deque.T[Int]).copy(), content="@deque.of([])")
+  inspect((@deque.new() : @deque.Deque[Int]).copy(), content="@deque.of([])")
   let deq = @deque.of([1, 2, 3])
   let deq1 = deq.copy()
   deq1[0] = 111
@@ -316,20 +316,20 @@ test "front_and_back" {
   let dv = @deque.of([1, 2, 3, 4, 5])
   assert_eq(dv.back(), Some(5))
   assert_eq(dv.front(), Some(1))
-  let dv : @deque.T[Int] = @deque.new()
+  let dv : @deque.Deque[Int] = @deque.new()
   assert_eq(dv.back(), None)
   assert_eq(dv.front(), None)
 }
 
 ///|
 test "new_with_capacity" {
-  let d : @deque.T[Int] = @deque.new(capacity=0)
+  let d : @deque.Deque[Int] = @deque.new(capacity=0)
   inspect(d.capacity(), content="0")
 }
 
 ///|
 test "new_with_capacity_non_zero" {
-  let d : @deque.T[Int] = @deque.new(capacity=10)
+  let d : @deque.Deque[Int] = @deque.new(capacity=10)
   inspect(d.capacity(), content="10")
 }
 
@@ -401,7 +401,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let dq : @deque.T[Int] = @deque.from_iter(Iter::empty())
+  let dq : @deque.Deque[Int] = @deque.from_iter(Iter::empty())
   inspect(dq, content="@deque.of([])")
 }
 
@@ -550,7 +550,7 @@ test "deque push_back when empty" {
 ///|
 test "deque as_views" {
   // Test empty deque
-  let dq1 : @deque.T[Int] = @deque.new()
+  let dq1 : @deque.Deque[Int] = @deque.new()
   @json.inspect(dq1.as_views(), content=[[], []])
 
   // Test contiguous case (head_len >= len)
@@ -586,7 +586,7 @@ test "test_get" {
 
 ///|
 test "test_reserve_capacity" {
-  let tester : @deque.T[Int] = @deque.new(capacity=1)
+  let tester : @deque.Deque[Int] = @deque.new(capacity=1)
   inspect(tester.capacity(), content="1")
   tester.reserve_capacity(2)
   inspect(tester.capacity(), content="2")
@@ -792,7 +792,7 @@ test "deque guard iter2 coverage improvement" {
 ///|
 test "deque truncate" {
   // Empty deque
-  let dq : @deque.T[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.new()
   dq.truncate(3)
   @json.inspect(dq, content=[])
 
@@ -838,7 +838,7 @@ test "deque retain" {
   let is_even = x => x % 2 == 0
 
   // Empty deque
-  let dq : @deque.T[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.new()
   dq.retain(is_even)
   @json.inspect(dq, content=[])
 
@@ -876,7 +876,7 @@ test "deque retain_map" {
   let inc_if_even = inc_if(is_even)
 
   // Empty deque
-  let dq : @deque.T[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.new()
   dq.retain_map(inc_if_even)
   @json.inspect(dq, content=[])
 
@@ -920,7 +920,7 @@ test "deque retain_map" {
 
 ///|
 test "@deque.to_array/empty" {
-  let dq : @deque.T[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.new()
   let arr = dq.to_array()
   @json.inspect(arr, content=[])
 }
@@ -997,11 +997,14 @@ test "rev_iter2 when wrapped around" {
 
 ///|
 test "flatten with empty deque" {
-  let dq : @deque.T[@deque.T[Int]] = @deque.of([])
+  let dq : @deque.Deque[@deque.Deque[Int]] = @deque.of([])
   inspect(dq.flatten(), content="@deque.of([])")
-  let dq : @deque.T[@deque.T[Int]] = @deque.of([@deque.of([]), @deque.of([])])
+  let dq : @deque.Deque[@deque.Deque[Int]] = @deque.of([
+    @deque.of([]),
+    @deque.of([]),
+  ])
   inspect(dq.flatten(), content="@deque.of([])")
-  let dq : @deque.T[@deque.T[Int]] = @deque.of([
+  let dq : @deque.Deque[@deque.Deque[Int]] = @deque.of([
     @deque.of([1, 2, 3]),
     @deque.of([]),
     @deque.of([4, 5, 6]),
@@ -1201,7 +1204,7 @@ test "rev_inplace" {
   assert_eq(dq, @deque.of([3, 4]))
 
   // Test with empty deque
-  let empty : @deque.T[Int] = @deque.new()
+  let empty : @deque.Deque[Int] = @deque.new()
   empty.rev_inplace()
   assert_eq(empty, @deque.of([]))
 
@@ -1238,7 +1241,7 @@ test "rev" {
   assert_eq(reversed_back, @deque.of([3, 4, 5]))
 
   // Test with empty deque
-  let empty : @deque.T[Int] = @deque.new()
+  let empty : @deque.Deque[Int] = @deque.new()
   let empty_reversed = empty.rev()
   assert_eq(empty, @deque.of([]))
   assert_eq(empty_reversed, @deque.of([]))
@@ -1290,7 +1293,7 @@ test "shuffle maintains elements with deterministic rand" {
   }
 
   // Shuffle in place
-  @deque.T::shuffle_in_place(dq, rand~)
+  @deque.Deque::shuffle_in_place(dq, rand~)
 
   // Verify properties of shuffle:
   assert_eq(dq.length(), original.length())
@@ -1298,7 +1301,7 @@ test "shuffle maintains elements with deterministic rand" {
   assert_true(dq != original)
 
   // Test non-in-place version
-  let shuffled = @deque.T::shuffle(original, rand~)
+  let shuffled = @deque.Deque::shuffle(original, rand~)
   assert_eq(shuffled.length(), original.length())
   assert_eq(shuffled.to_array().sort(), original.to_array().sort())
   assert_true(shuffled != original)
@@ -1436,7 +1439,7 @@ test "append_growth_strategy" {
 /// Test large append to trigger buffer reallocation
 test "append_large_realloc" {
   let d1 = @deque.of([1])
-  let d2 : @deque.T[Int] = @deque.of([])
+  let d2 : @deque.Deque[Int] = @deque.of([])
   for i = 0; i < 1000; i = i + 1 {
     d2.push_back(i)
   }

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -7,76 +7,77 @@ import(
 )
 
 // Values
-fn[A] from_array(Array[A]) -> T[A]
+fn[A] from_array(Array[A]) -> Deque[A]
 
-fn[A] from_iter(Iter[A]) -> T[A]
+fn[A] from_iter(Iter[A]) -> Deque[A]
 
-fn[A] new(capacity? : Int) -> T[A]
+fn[A] new(capacity? : Int) -> Deque[A]
 
-fn[A] of(FixedArray[A]) -> T[A]
+fn[A] of(FixedArray[A]) -> Deque[A]
 
 // Errors
 
 // Types and methods
-type T[A]
-fn[A] T::append(Self[A], Self[A]) -> Unit
-fn[A] T::as_views(Self[A]) -> (ArrayView[A], ArrayView[A])
-fn[A] T::back(Self[A]) -> A?
-fn[A : Compare] T::binary_search(Self[A], A) -> Result[Int, Int]
-fn[A] T::binary_search_by(Self[A], (A) -> Int) -> Result[Int, Int]
-fn[A] T::capacity(Self[A]) -> Int
-fn[A] T::clear(Self[A]) -> Unit
-fn[A : Eq] T::contains(Self[A], A) -> Bool
-fn[A] T::copy(Self[A]) -> Self[A]
-fn[A] T::drain(Self[A], start~ : Int, len? : Int) -> Self[A]
-fn[A] T::each(Self[A], (A) -> Unit) -> Unit
-fn[A] T::eachi(Self[A], (Int, A) -> Unit) -> Unit
+type Deque[A]
+fn[A] Deque::append(Self[A], Self[A]) -> Unit
+fn[A] Deque::as_views(Self[A]) -> (ArrayView[A], ArrayView[A])
+fn[A] Deque::back(Self[A]) -> A?
+fn[A : Compare] Deque::binary_search(Self[A], A) -> Result[Int, Int]
+fn[A] Deque::binary_search_by(Self[A], (A) -> Int) -> Result[Int, Int]
+fn[A] Deque::capacity(Self[A]) -> Int
+fn[A] Deque::clear(Self[A]) -> Unit
+fn[A : Eq] Deque::contains(Self[A], A) -> Bool
+fn[A] Deque::copy(Self[A]) -> Self[A]
+fn[A] Deque::drain(Self[A], start~ : Int, len? : Int) -> Self[A]
+fn[A] Deque::each(Self[A], (A) -> Unit) -> Unit
+fn[A] Deque::eachi(Self[A], (Int, A) -> Unit) -> Unit
 #deprecated
-fn[A] T::filter_map_inplace(Self[A], (A) -> A?) -> Unit
-fn[A] T::flatten(Self[Self[A]]) -> Self[A]
-fn[A] T::front(Self[A]) -> A?
-fn[A] T::get(Self[A], Int) -> A?
-fn[A] T::is_empty(Self[A]) -> Bool
-fn[A] T::iter(Self[A]) -> Iter[A]
-fn[A] T::iter2(Self[A]) -> Iter2[Int, A]
-fn T::join(Self[String], @string.View) -> String
-fn[A] T::length(Self[A]) -> Int
-fn[A, U] T::map(Self[A], (A) -> U) -> Self[U]
-fn[A, U] T::mapi(Self[A], (Int, A) -> U) -> Self[U]
-fn[A] T::op_get(Self[A], Int) -> A
-fn[A] T::op_set(Self[A], Int, A) -> Unit
-fn[A] T::pop_back(Self[A]) -> A?
+fn[A] Deque::filter_map_inplace(Self[A], (A) -> A?) -> Unit
+fn[A] Deque::flatten(Self[Self[A]]) -> Self[A]
+fn[A] Deque::front(Self[A]) -> A?
+fn[A] Deque::get(Self[A], Int) -> A?
+fn[A] Deque::is_empty(Self[A]) -> Bool
+fn[A] Deque::iter(Self[A]) -> Iter[A]
+fn[A] Deque::iter2(Self[A]) -> Iter2[Int, A]
+fn Deque::join(Self[String], @string.View) -> String
+fn[A] Deque::length(Self[A]) -> Int
+fn[A, U] Deque::map(Self[A], (A) -> U) -> Self[U]
+fn[A, U] Deque::mapi(Self[A], (Int, A) -> U) -> Self[U]
+fn[A] Deque::op_get(Self[A], Int) -> A
+fn[A] Deque::op_set(Self[A], Int, A) -> Unit
+fn[A] Deque::pop_back(Self[A]) -> A?
 #deprecated
-fn[A] T::pop_back_exn(Self[A]) -> Unit
-fn[A] T::pop_front(Self[A]) -> A?
+fn[A] Deque::pop_back_exn(Self[A]) -> Unit
+fn[A] Deque::pop_front(Self[A]) -> A?
 #deprecated
-fn[A] T::pop_front_exn(Self[A]) -> Unit
-fn[A] T::push_back(Self[A], A) -> Unit
-fn[A] T::push_front(Self[A], A) -> Unit
-fn[A] T::reserve_capacity(Self[A], Int) -> Unit
-fn[A] T::retain(Self[A], (A) -> Bool) -> Unit
-fn[A] T::retain_map(Self[A], (A) -> A?) -> Unit
-fn[A] T::rev(Self[A]) -> Self[A]
-fn[A] T::rev_each(Self[A], (A) -> Unit) -> Unit
-fn[A] T::rev_eachi(Self[A], (Int, A) -> Unit) -> Unit
-fn[A] T::rev_inplace(Self[A]) -> Unit
-fn[A] T::rev_iter(Self[A]) -> Iter[A]
-fn[A] T::rev_iter2(Self[A]) -> Iter2[Int, A]
-fn[A : Eq] T::search(Self[A], A) -> Int?
-fn[A] T::shrink_to_fit(Self[A]) -> Unit
-fn[A] T::shuffle(Self[A], rand~ : (Int) -> Int) -> Self[A]
-fn[A] T::shuffle_in_place(Self[A], rand~ : (Int) -> Int) -> Unit
-fn[A] T::to_array(Self[A]) -> Array[A]
-fn[A] T::truncate(Self[A], Int) -> Unit
-fn[A] T::unsafe_pop_back(Self[A]) -> Unit
-fn[A] T::unsafe_pop_front(Self[A]) -> Unit
-impl[A : Compare] Compare for T[A]
-impl[A : Eq] Eq for T[A]
-impl[A : Show] Show for T[A]
-impl[A : ToJson] ToJson for T[A]
-impl[A : @json.FromJson] @json.FromJson for T[A]
+fn[A] Deque::pop_front_exn(Self[A]) -> Unit
+fn[A] Deque::push_back(Self[A], A) -> Unit
+fn[A] Deque::push_front(Self[A], A) -> Unit
+fn[A] Deque::reserve_capacity(Self[A], Int) -> Unit
+fn[A] Deque::retain(Self[A], (A) -> Bool) -> Unit
+fn[A] Deque::retain_map(Self[A], (A) -> A?) -> Unit
+fn[A] Deque::rev(Self[A]) -> Self[A]
+fn[A] Deque::rev_each(Self[A], (A) -> Unit) -> Unit
+fn[A] Deque::rev_eachi(Self[A], (Int, A) -> Unit) -> Unit
+fn[A] Deque::rev_inplace(Self[A]) -> Unit
+fn[A] Deque::rev_iter(Self[A]) -> Iter[A]
+fn[A] Deque::rev_iter2(Self[A]) -> Iter2[Int, A]
+fn[A : Eq] Deque::search(Self[A], A) -> Int?
+fn[A] Deque::shrink_to_fit(Self[A]) -> Unit
+fn[A] Deque::shuffle(Self[A], rand~ : (Int) -> Int) -> Self[A]
+fn[A] Deque::shuffle_in_place(Self[A], rand~ : (Int) -> Int) -> Unit
+fn[A] Deque::to_array(Self[A]) -> Array[A]
+fn[A] Deque::truncate(Self[A], Int) -> Unit
+fn[A] Deque::unsafe_pop_back(Self[A]) -> Unit
+fn[A] Deque::unsafe_pop_front(Self[A]) -> Unit
+impl[A : Compare] Compare for Deque[A]
+impl[A : Eq] Eq for Deque[A]
+impl[A : Show] Show for Deque[A]
+impl[A : ToJson] ToJson for Deque[A]
+impl[A : @json.FromJson] @json.FromJson for Deque[A]
 
 // Type aliases
+pub typealias Deque as T
 
 // Traits
 

--- a/deque/types.mbt
+++ b/deque/types.mbt
@@ -15,9 +15,13 @@
 // head and tail point to non-empty slots. When the buffer is empty, head and tail points to the same slot.
 
 ///|
-struct T[A] {
+struct Deque[A] {
   mut buf : UninitializedArray[A]
   mut len : Int
   mut head : Int
   mut tail : Int
 }
+
+///|
+#deprecated("Use `Deque` instead of `T`")
+pub typealias Deque as T

--- a/hashmap/README.mbt.md
+++ b/hashmap/README.mbt.md
@@ -10,7 +10,7 @@ You can create an empty map using `new()` or construct it using `from_array()`.
 
 ```moonbit
 test {
-  let _map2 : @hashmap.T[String, Int] = @hashmap.new()
+  let _map2 : @hashmap.HashMap[String, Int] = @hashmap.new()
 }
 ```
 
@@ -20,7 +20,7 @@ You can use `set()` to add a key-value pair to the map, and use `get()` to get a
 
 ```moonbit
 test {
-  let map : @hashmap.T[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
   map.set("a", 1)
   assert_eq(map.get("a"), Some(1))
   assert_eq(map.get_or_default("a", 0), 1)
@@ -70,7 +70,7 @@ Similarly, you can use `is_empty()` to check whether the map is empty.
 
 ```moonbit
 test {
-    let map: @hashmap.T[String, Int] = @hashmap.new()
+    let map: @hashmap.HashMap[String, Int] = @hashmap.new()
     assert_eq(map.is_empty(), true)
 }
 ```

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -28,11 +28,11 @@
 /// Example:
 ///
 /// ```moonbit
-///   let map : @hashmap.T[String, Int] = @hashmap.new(capacity=16)
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.new(capacity=16)
 ///   inspect(map.capacity(), content="16")
 ///   inspect(map.is_empty(), content="true")
 /// ```
-pub fn[K, V] new(capacity? : Int = 8) -> T[K, V] {
+pub fn[K, V] new(capacity? : Int = 8) -> HashMap[K, V] {
   let capacity = capacity.next_power_of_two()
   {
     size: 0,
@@ -62,7 +62,7 @@ pub fn[K, V] new(capacity? : Int = 8) -> T[K, V] {
 ///   inspect(map.get(1), content="Some(\"ONE\")")
 ///   inspect(map.get(2), content="Some(\"two\")")
 /// ```
-pub fn[K : Hash + Eq, V] from_array(arr : Array[(K, V)]) -> T[K, V] {
+pub fn[K : Hash + Eq, V] from_array(arr : Array[(K, V)]) -> HashMap[K, V] {
   let m = new(capacity=arr.length())
   arr.each(e => m.set(e.0, e.1))
   m
@@ -82,19 +82,19 @@ pub fn[K : Hash + Eq, V] from_array(arr : Array[(K, V)]) -> T[K, V] {
 /// Example:
 ///
 /// ```moonbit
-///   let map : @hashmap.T[String, Int] = @hashmap.new()
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.new()
 ///   map.set("key", 42)
 ///   inspect(map.get("key"), content="Some(42)")
 ///   map.set("key", 24) // update existing key
 ///   inspect(map.get("key"), content="Some(24)")
 /// ```
-pub fn[K : Hash + Eq, V] set(self : T[K, V], key : K, value : V) -> Unit {
+pub fn[K : Hash + Eq, V] set(self : HashMap[K, V], key : K, value : V) -> Unit {
   self.set_with_hash(key, value, key.hash())
 }
 
 ///|
 fn[K : Eq, V] set_with_hash(
-  self : T[K, V],
+  self : HashMap[K, V],
   key : K,
   value : V,
   hash : Int,
@@ -124,7 +124,11 @@ fn[K : Eq, V] set_with_hash(
 }
 
 ///|
-fn[K, V] T::push_away(self : T[K, V], idx : Int, entry : Entry[K, V]) -> Unit {
+fn[K, V] HashMap::push_away(
+  self : HashMap[K, V],
+  idx : Int,
+  entry : Entry[K, V],
+) -> Unit {
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
     match self.entries[idx] {
       None => {
@@ -162,11 +166,15 @@ fn[K, V] T::push_away(self : T[K, V], idx : Int, entry : Entry[K, V]) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let map : @hashmap.T[String, Int] = @hashmap.new()
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.new()
 ///   map["key"] = 42
 ///   inspect(map.get("key"), content="Some(42)")
 /// ```
-pub fn[K : Hash + Eq, V] op_set(self : T[K, V], key : K, value : V) -> Unit {
+pub fn[K : Hash + Eq, V] op_set(
+  self : HashMap[K, V],
+  key : K,
+  value : V,
+) -> Unit {
   self.set(key, value)
 }
 
@@ -187,7 +195,7 @@ pub fn[K : Hash + Eq, V] op_set(self : T[K, V], key : K, value : V) -> Unit {
 ///   inspect(map.get("key"), content="Some(42)")
 ///   inspect(map.get("nonexistent"), content="None")
 /// ```
-pub fn[K : Hash + Eq, V] get(self : T[K, V], key : K) -> V? {
+pub fn[K : Hash + Eq, V] get(self : HashMap[K, V], key : K) -> V? {
   // self.get_with_hash(key, key.hash())
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
@@ -218,7 +226,7 @@ pub fn[K : Hash + Eq, V] get(self : T[K, V], key : K) -> V? {
 ///   let map = @hashmap.of([("key", 42)])
 ///   inspect(map["key"], content="42")
 /// ```
-pub fn[K : Hash + Eq, V] op_get(self : T[K, V], key : K) -> V {
+pub fn[K : Hash + Eq, V] op_get(self : HashMap[K, V], key : K) -> V {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry)
@@ -248,13 +256,13 @@ pub fn[K : Hash + Eq, V] op_get(self : T[K, V], key : K) -> V {
 /// Example:
 ///
 /// ```moonbit
-///   let map : @hashmap.T[String, Int] = @hashmap.new()
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.new()
 ///   let value = map.get_or_init("key", () => { 42 })
 ///   inspect(value, content="42")
 ///   inspect(map.get("key"), content="Some(42)")
 /// ```
 pub fn[K : Hash + Eq, V] get_or_init(
-  self : T[K, V],
+  self : HashMap[K, V],
   key : K,
   init : () -> V,
 ) -> V {
@@ -314,7 +322,7 @@ pub fn[K : Hash + Eq, V] get_or_init(
 ///   inspect(map.get_or_default("c", 0), content="0")
 /// ```
 pub fn[K : Hash + Eq, V] get_or_default(
-  self : T[K, V],
+  self : HashMap[K, V],
   key : K,
   default : V,
 ) -> V {
@@ -348,7 +356,7 @@ pub fn[K : Hash + Eq, V] get_or_default(
 ///   inspect(map.contains("a"), content="true")
 ///   inspect(map.contains("c"), content="false")
 /// ```
-pub fn[K : Hash + Eq, V] contains(self : T[K, V], key : K) -> Bool {
+pub fn[K : Hash + Eq, V] contains(self : HashMap[K, V], key : K) -> Bool {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { return false }
@@ -367,7 +375,7 @@ pub fn[K : Hash + Eq, V] contains(self : T[K, V], key : K) -> Bool {
 ///
 /// Parameters:
 ///
-/// * `map` : A map of type `@hashmap.T[K, V]` to search in.
+/// * `map` : A map of type `@hashmap.HashMap[K, V]` to search in.
 /// * `key` : The key to look up in the map.
 /// * `value` : The value to be compared with the value associated with the key.
 ///
@@ -385,7 +393,7 @@ pub fn[K : Hash + Eq, V] contains(self : T[K, V], key : K) -> Bool {
 ///   inspect(map.contains_kv("c", 3), content="false")
 /// ```
 pub fn[K : Hash + Eq, V : Eq] contains_kv(
-  self : T[K, V],
+  self : HashMap[K, V],
   key : K,
   value : V,
 ) -> Bool {
@@ -421,12 +429,16 @@ pub fn[K : Hash + Eq, V : Eq] contains_kv(
 ///   inspect(map.get("a"), content="None")
 ///   inspect(map.size(), content="1")
 /// ```
-pub fn[K : Hash + Eq, V] remove(self : T[K, V], key : K) -> Unit {
+pub fn[K : Hash + Eq, V] remove(self : HashMap[K, V], key : K) -> Unit {
   self.remove_with_hash(key, key.hash())
 }
 
 ///|
-fn[K : Eq, V] remove_with_hash(self : T[K, V], key : K, hash : Int) -> Unit {
+fn[K : Eq, V] remove_with_hash(
+  self : HashMap[K, V],
+  key : K,
+  hash : Int,
+) -> Unit {
   for i = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
       Some(entry) => {
@@ -446,7 +458,7 @@ fn[K : Eq, V] remove_with_hash(self : T[K, V], key : K, hash : Int) -> Unit {
 }
 
 ///|
-fn[K, V] shift_back(self : T[K, V], idx : Int) -> Unit {
+fn[K, V] shift_back(self : HashMap[K, V], idx : Int) -> Unit {
   let next = (idx + 1) & self.capacity_mask
   match self.entries[next] {
     None | Some({ psl: 0, .. }) => self.entries[idx] = None
@@ -459,7 +471,7 @@ fn[K, V] shift_back(self : T[K, V], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq, V] grow(self : T[K, V]) -> Unit {
+fn[K : Eq, V] grow(self : HashMap[K, V]) -> Unit {
   let old_entries = self.entries
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)
@@ -492,7 +504,7 @@ fn[K : Eq, V] grow(self : T[K, V]) -> Unit {
 ///   inspect(map.get(1), content="Some(\"one\")")
 ///   inspect(map.get(2), content="Some(\"two\")")
 /// ```
-pub fn[K : Eq + Hash, V] of(arr : FixedArray[(K, V)]) -> T[K, V] {
+pub fn[K : Eq + Hash, V] of(arr : FixedArray[(K, V)]) -> HashMap[K, V] {
   let m = new(capacity=arr.length())
   arr.each(e => m.set(e.0, e.1))
   m
@@ -520,10 +532,10 @@ test "of" {
 /// Example:
 ///
 /// ```moonbit
-///   let samples : Array[@hashmap.T[Int, String]] = @quickcheck.samples(5)
+///   let samples : Array[@hashmap.HashMap[Int, String]] = @quickcheck.samples(5)
 ///   inspect(samples.length(), content="5")
 /// ```
-pub impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[
+pub impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for HashMap[
   K,
   V,
 ] with arbitrary(size, rs) {
@@ -536,14 +548,17 @@ pub impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quic
 }
 
 ///|
-pub impl[K, V] Default for T[K, V] with default() {
+pub impl[K, V] Default for HashMap[K, V] with default() {
   new()
 }
 
 ///|
 /// Applies a function to each key-value pair in the map and 
 /// returns a new map with the results, using the original keys.
-pub fn[K, V, V2] T::map(self : T[K, V], f : (K, V) -> V2) -> T[K, V2] {
+pub fn[K, V, V2] HashMap::map(
+  self : HashMap[K, V],
+  f : (K, V) -> V2,
+) -> HashMap[K, V2] {
   let other = {
     capacity: self.capacity,
     entries: FixedArray::make(self.capacity, None),
@@ -563,7 +578,7 @@ pub fn[K, V, V2] T::map(self : T[K, V], f : (K, V) -> V2) -> T[K, V2] {
 
 ///|
 /// Copy the map, creating a new map with the same key-value pairs.
-pub fn[K, V] T::copy(self : T[K, V]) -> T[K, V] {
+pub fn[K, V] HashMap::copy(self : HashMap[K, V]) -> HashMap[K, V] {
   let other = {
     capacity: self.capacity,
     entries: FixedArray::make(self.capacity, None),
@@ -605,7 +620,7 @@ impl Show for MyString with output(self, logger) {
 
 ///|
 test "arbitrary" {
-  let samples : Array[T[String, Int]] = @quickcheck.samples(20)
+  let samples : Array[HashMap[String, Int]] = @quickcheck.samples(20)
   inspect(
     samples[5:10],
     content=(
@@ -622,7 +637,7 @@ test "arbitrary" {
 
 ///|
 test "set" {
-  let m : T[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new()
   m.set("a", 1)
   m.set("b", 1)
   m.set("bc", 2)
@@ -639,7 +654,7 @@ test "set" {
 
 ///|
 test "remove" {
-  let m : T[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new()
   m.set("a", 1)
   m.set("ab", 2)
   m.set("bc", 2)
@@ -656,7 +671,7 @@ test "remove" {
 
 ///|
 test "remove_unexist_key" {
-  let m : T[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new()
   m.set("a", 1)
   m.set("ab", 2)
   m.set("abc", 3)
@@ -667,7 +682,7 @@ test "remove_unexist_key" {
 
 ///|
 test "clear" {
-  let m : T[MyString, Int] = of([("a", 1), ("b", 2), ("c", 3)])
+  let m : HashMap[MyString, Int] = of([("a", 1), ("b", 2), ("c", 3)])
   m.clear()
   inspect(m.size(), content="0")
   inspect(m.capacity(), content="8")
@@ -678,7 +693,7 @@ test "clear" {
 
 ///|
 test "grow" {
-  let m : T[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new()
   m.set("C", 1)
   m.set("Go", 2)
   m.set("C++", 3)
@@ -703,7 +718,7 @@ test "grow" {
 
 ///|
 test "get_or_init" {
-  let m : T[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new()
   inspect(m.get_or_init("a", () => 1), content="1")
   inspect(m.get("a"), content="Some(1)")
   inspect(m.get_or_init("a", () => 2), content="1")

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "new" {
-  let m : @hashmap.T[Int, Int] = @hashmap.new()
+  let m : @hashmap.HashMap[Int, Int] = @hashmap.new()
   inspect(m.capacity(), content="8")
   inspect(m.size(), content="0")
 }
@@ -48,7 +48,7 @@ test "get_or_default" {
 
 ///|
 test "get_or_init" {
-  let m : @hashmap.T[String, Array[Int]] = @hashmap.new()
+  let m : @hashmap.HashMap[String, Array[Int]] = @hashmap.new()
   m.get_or_init("a", () => Array::new()).push(1)
   m.get_or_init("b", () => Array::new()).push(2)
   m.get_or_init("a", () => Array::new()).push(3)
@@ -340,13 +340,13 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let map : @hashmap.T[Int, Int] = @hashmap.from_iter(Iter::empty())
+  let map : @hashmap.HashMap[Int, Int] = @hashmap.from_iter(Iter::empty())
   inspect(map, content="HashMap::of([])")
 }
 
 ///|
 test "@hashmap.contains/empty" {
-  let map : @hashmap.T[Int, String] = @hashmap.new()
+  let map : @hashmap.HashMap[Int, String] = @hashmap.new()
   inspect(map.contains(42), content="false")
 }
 
@@ -415,7 +415,7 @@ test "@hashmap.map" {
       #|HashMap::of([("e", "e20"), ("a", "a1"), ("b", "b2"), ("d", "d10")])
     ),
   )
-  let v : @hashmap.T[String, String] = @hashmap.new().map((k, v) => k + v)
+  let v : @hashmap.HashMap[String, String] = @hashmap.new().map((k, v) => k + v)
   inspect(v, content="HashMap::of([])")
 }
 
@@ -439,6 +439,6 @@ test "@hashmap.copy" {
       #|HashMap::of([("e", 20), ("a", 1), ("b", 2), ("d", 10)])
     ),
   )
-  let copy : @hashmap.T[String, String] = @hashmap.new().copy()
+  let copy : @hashmap.HashMap[String, String] = @hashmap.new().copy()
   inspect(copy, content="HashMap::of([])")
 }

--- a/hashmap/json.mbt
+++ b/hashmap/json.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-pub impl[K : Show, V : ToJson] ToJson for T[K, V] with to_json(self) {
+pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V] with to_json(self) {
   let object = Map::new(capacity=self.capacity)
   for k, v in self {
     object[k.to_string()] = v.to_json()

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -6,48 +6,49 @@ import(
 )
 
 // Values
-fn[K : Hash + Eq, V] from_array(Array[(K, V)]) -> T[K, V]
+fn[K : Hash + Eq, V] from_array(Array[(K, V)]) -> HashMap[K, V]
 
-fn[K : Hash + Eq, V] from_iter(Iter[(K, V)]) -> T[K, V]
+fn[K : Hash + Eq, V] from_iter(Iter[(K, V)]) -> HashMap[K, V]
 
-fn[K, V] new(capacity? : Int) -> T[K, V]
+fn[K, V] new(capacity? : Int) -> HashMap[K, V]
 
-fn[K : Eq + Hash, V] of(FixedArray[(K, V)]) -> T[K, V]
+fn[K : Eq + Hash, V] of(FixedArray[(K, V)]) -> HashMap[K, V]
 
 // Errors
 
 // Types and methods
-type T[K, V]
-fn[K, V] T::capacity(Self[K, V]) -> Int
-fn[K, V] T::clear(Self[K, V]) -> Unit
-fn[K : Hash + Eq, V] T::contains(Self[K, V], K) -> Bool
-fn[K : Hash + Eq, V : Eq] T::contains_kv(Self[K, V], K, V) -> Bool
-fn[K, V] T::copy(Self[K, V]) -> Self[K, V]
-fn[K, V] T::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
-fn[K, V] T::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
-fn[K : Hash + Eq, V] T::get(Self[K, V], K) -> V?
-fn[K : Hash + Eq, V] T::get_or_default(Self[K, V], K, V) -> V
-fn[K : Hash + Eq, V] T::get_or_init(Self[K, V], K, () -> V) -> V
-fn[K, V] T::is_empty(Self[K, V]) -> Bool
-fn[K, V] T::iter(Self[K, V]) -> Iter[(K, V)]
-fn[K, V] T::iter2(Self[K, V]) -> Iter2[K, V]
-fn[K, V] T::keys(Self[K, V]) -> Iter[K]
-fn[K, V, V2] T::map(Self[K, V], (K, V) -> V2) -> Self[K, V2]
-fn[K : Hash + Eq, V] T::op_get(Self[K, V], K) -> V
-fn[K : Hash + Eq, V] T::op_set(Self[K, V], K, V) -> Unit
-fn[K : Hash + Eq, V] T::remove(Self[K, V], K) -> Unit
-fn[K, V] T::retain(Self[K, V], (K, V) -> Bool) -> Unit
-fn[K : Hash + Eq, V] T::set(Self[K, V], K, V) -> Unit
-fn[K, V] T::size(Self[K, V]) -> Int
-fn[K, V] T::to_array(Self[K, V]) -> Array[(K, V)]
-fn[K, V] T::values(Self[K, V]) -> Iter[V]
-impl[K, V] Default for T[K, V]
-impl[K : Hash + Eq, V : Eq] Eq for T[K, V]
-impl[K : Show, V : Show] Show for T[K, V]
-impl[K : Show, V : ToJson] ToJson for T[K, V]
-impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[K, V]
+type HashMap[K, V]
+fn[K, V] HashMap::capacity(Self[K, V]) -> Int
+fn[K, V] HashMap::clear(Self[K, V]) -> Unit
+fn[K : Hash + Eq, V] HashMap::contains(Self[K, V], K) -> Bool
+fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(Self[K, V], K, V) -> Bool
+fn[K, V] HashMap::copy(Self[K, V]) -> Self[K, V]
+fn[K, V] HashMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
+fn[K, V] HashMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
+fn[K : Hash + Eq, V] HashMap::get(Self[K, V], K) -> V?
+fn[K : Hash + Eq, V] HashMap::get_or_default(Self[K, V], K, V) -> V
+fn[K : Hash + Eq, V] HashMap::get_or_init(Self[K, V], K, () -> V) -> V
+fn[K, V] HashMap::is_empty(Self[K, V]) -> Bool
+fn[K, V] HashMap::iter(Self[K, V]) -> Iter[(K, V)]
+fn[K, V] HashMap::iter2(Self[K, V]) -> Iter2[K, V]
+fn[K, V] HashMap::keys(Self[K, V]) -> Iter[K]
+fn[K, V, V2] HashMap::map(Self[K, V], (K, V) -> V2) -> Self[K, V2]
+fn[K : Hash + Eq, V] HashMap::op_get(Self[K, V], K) -> V
+fn[K : Hash + Eq, V] HashMap::op_set(Self[K, V], K, V) -> Unit
+fn[K : Hash + Eq, V] HashMap::remove(Self[K, V], K) -> Unit
+fn[K, V] HashMap::retain(Self[K, V], (K, V) -> Bool) -> Unit
+fn[K : Hash + Eq, V] HashMap::set(Self[K, V], K, V) -> Unit
+fn[K, V] HashMap::size(Self[K, V]) -> Int
+fn[K, V] HashMap::to_array(Self[K, V]) -> Array[(K, V)]
+fn[K, V] HashMap::values(Self[K, V]) -> Iter[V]
+impl[K, V] Default for HashMap[K, V]
+impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V]
+impl[K : Show, V : Show] Show for HashMap[K, V]
+impl[K : Show, V : ToJson] ToJson for HashMap[K, V]
+impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for HashMap[K, V]
 
 // Type aliases
+pub typealias HashMap as T
 
 // Traits
 

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -38,7 +38,7 @@ priv struct Entry[K, V] {
 ///   map.set(3, "updated")
 ///   assert_eq(map.get(3), Some("updated"))
 /// ```
-struct T[K, V] {
+struct HashMap[K, V] {
   mut entries : FixedArray[Entry[K, V]?]
   mut capacity : Int
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx
@@ -49,9 +49,9 @@ struct T[K, V] {
 }
 
 ///|
-pub impl[K : Hash + Eq, V : Eq] Eq for T[K, V] with op_equal(
-  self : T[K, V],
-  that : T[K, V],
+pub impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V] with op_equal(
+  self : HashMap[K, V],
+  that : HashMap[K, V],
 ) -> Bool {
   guard self.size == that.size else { return false }
   for k, v in self {
@@ -60,3 +60,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for T[K, V] with op_equal(
     true
   }
 }
+
+///|
+#deprecated("Use `HashMap` instead of `T`")
+pub typealias HashMap as T

--- a/hashmap/types_test.mbt
+++ b/hashmap/types_test.mbt
@@ -30,8 +30,8 @@ test "HashMap equality - same content different order" {
 
 ///|
 test "HashMap equality - empty maps" {
-  let map1 : @hashmap.T[Int, String] = @hashmap.new()
-  let map2 : @hashmap.T[Int, String] = @hashmap.new()
+  let map1 : @hashmap.HashMap[Int, String] = @hashmap.new()
+  let map2 : @hashmap.HashMap[Int, String] = @hashmap.new()
   assert_eq(map1, map2)
   assert_true(map1 == map2)
 }
@@ -62,7 +62,7 @@ test "HashMap equality - same size different values" {
 
 ///|
 test "HashMap equality - one empty one non-empty" {
-  let empty_map : @hashmap.T[Int, String] = @hashmap.new()
+  let empty_map : @hashmap.HashMap[Int, String] = @hashmap.new()
   let non_empty_map = @hashmap.of([(1, "one")])
   assert_false(empty_map == non_empty_map)
   assert_false(non_empty_map == empty_map)

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn[K : Show, V : Show] debug_entries(self : T[K, V]) -> String {
+fn[K : Show, V : Show] debug_entries(self : HashMap[K, V]) -> String {
   for s = "", i = 0; i < self.entries.length(); {
     let s = if i > 0 { s + "," } else { s }
     match self.entries[i] {
@@ -43,7 +43,7 @@ fn[K : Show, V : Show] debug_entries(self : T[K, V]) -> String {
 ///   inspect(map.size(), content="0")
 ///   inspect(map.get("a"), content="None")
 /// ```
-pub fn[K, V] clear(self : T[K, V]) -> Unit {
+pub fn[K, V] clear(self : HashMap[K, V]) -> Unit {
   self.entries.fill(None)
   self.size = 0
 }
@@ -67,7 +67,7 @@ pub fn[K, V] clear(self : T[K, V]) -> Unit {
 ///   inspect(pairs.contains((1, "one")), content="true")
 ///   inspect(pairs.contains((2, "two")), content="true")
 /// ```
-pub fn[K, V] iter(self : T[K, V]) -> Iter[(K, V)] {
+pub fn[K, V] iter(self : HashMap[K, V]) -> Iter[(K, V)] {
   Iter::new(yield_ => for entry in self.entries {
     if entry is Some({ key, value, .. }) {
       guard yield_((key, value)) is IterContinue else { break IterEnd }
@@ -97,7 +97,7 @@ pub fn[K, V] iter(self : T[K, V]) -> Iter[(K, V)] {
 ///   map.iter2().each((k, _) => { sum = sum + k })
 ///   inspect(sum, content="3")
 /// ```
-pub fn[K, V] iter2(self : T[K, V]) -> Iter2[K, V] {
+pub fn[K, V] iter2(self : HashMap[K, V]) -> Iter2[K, V] {
   Iter2::new(yield_ => for entry in self.entries {
     if entry is Some({ key, value, .. }) {
       guard yield_(key, value) is IterContinue else { break IterEnd }
@@ -136,7 +136,7 @@ pub fn[K, V] iter2(self : T[K, V]) -> Iter2[K, V] {
 ///   inspect(map.get(1), content="Some(\"one\")")
 ///   inspect(map.get(2), content="Some(\"two\")")
 /// ```
-pub fn[K : Hash + Eq, V] from_iter(iter : Iter[(K, V)]) -> T[K, V] {
+pub fn[K : Hash + Eq, V] from_iter(iter : Iter[(K, V)]) -> HashMap[K, V] {
   let m = new()
   iter.each(e => m[e.0] = e.1)
   m
@@ -164,7 +164,7 @@ pub fn[K : Hash + Eq, V] from_iter(iter : Iter[(K, V)]) -> T[K, V] {
 ///     ),
 ///   )
 /// ```
-pub fn[K, V] to_array(self : T[K, V]) -> Array[(K, V)] {
+pub fn[K, V] to_array(self : HashMap[K, V]) -> Array[(K, V)] {
   let mut i = 0
   let res = while i < self.capacity {
     if self.entries[i] is Some({ key, value, .. }) {
@@ -203,7 +203,7 @@ pub fn[K, V] to_array(self : T[K, V]) -> Array[(K, V)] {
 ///   let map = @hashmap.of([("a", 1), ("b", 2), ("c", 3)])
 ///   inspect(map.size(), content="3")
 /// ```
-pub fn[K, V] size(self : T[K, V]) -> Int {
+pub fn[K, V] size(self : HashMap[K, V]) -> Int {
   self.size
 }
 
@@ -222,10 +222,10 @@ pub fn[K, V] size(self : T[K, V]) -> Int {
 /// Example:
 ///
 /// ```moonbit
-///   let map : @hashmap.T[Int, String] = @hashmap.new(capacity=16)
+///   let map : @hashmap.HashMap[Int, String] = @hashmap.new(capacity=16)
 ///   inspect(map.capacity(), content="16")
 /// ```
-pub fn[K, V] capacity(self : T[K, V]) -> Int {
+pub fn[K, V] capacity(self : HashMap[K, V]) -> Int {
   self.capacity
 }
 
@@ -242,12 +242,12 @@ pub fn[K, V] capacity(self : T[K, V]) -> Int {
 /// Example:
 ///
 /// ```moonbit
-///   let map : @hashmap.T[String, Int] = @hashmap.new()
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.new()
 ///   inspect(map.is_empty(), content="true")
 ///   map.set("key", 42)
 ///   inspect(map.is_empty(), content="false")
 /// ```
-pub fn[K, V] is_empty(self : T[K, V]) -> Bool {
+pub fn[K, V] is_empty(self : HashMap[K, V]) -> Bool {
   self.size == 0
 }
 
@@ -270,7 +270,10 @@ pub fn[K, V] is_empty(self : T[K, V]) -> Bool {
 ///   inspect(result, content="2:two,1:one,")
 /// ```
 #locals(f)
-pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit raise?) -> Unit raise? {
+pub fn[K, V] each(
+  self : HashMap[K, V],
+  f : (K, V) -> Unit raise?,
+) -> Unit raise? {
   for i in 0..<self.capacity {
     if self.entries[i] is Some({ key, value, .. }) {
       f(key, value)
@@ -302,7 +305,7 @@ pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit raise?) -> Unit raise? {
 /// ```
 #locals(f)
 pub fn[K, V] eachi(
-  self : T[K, V],
+  self : HashMap[K, V],
   f : (Int, K, V) -> Unit raise?,
 ) -> Unit raise? {
   for i = 0, idx = 0; i < self.capacity; {
@@ -335,7 +338,7 @@ pub fn[K, V] eachi(
 ///     ),
 /// )
 /// ```
-pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
+pub impl[K : Show, V : Show] Show for HashMap[K, V] with output(self, logger) {
   logger.write_string("HashMap::of([")
   self.eachi((i, k, v) => {
     if i > 0 {
@@ -371,7 +374,7 @@ pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
 ///   inspect(keys.contains(2), content="true")
 ///   inspect(keys.contains(3), content="true")
 /// ```
-pub fn[K, V] T::keys(self : T[K, V]) -> Iter[K] {
+pub fn[K, V] HashMap::keys(self : HashMap[K, V]) -> Iter[K] {
   Iter::new(yield_ => for entry in self.entries {
     if entry is Some({ key, .. }) {
       guard yield_(key) is IterContinue else { break IterEnd }
@@ -401,7 +404,7 @@ pub fn[K, V] T::keys(self : T[K, V]) -> Iter[K] {
 ///   inspect(values.contains(2), content="true")
 ///   inspect(values.contains(3), content="true")
 /// ```
-pub fn[K, V] T::values(self : T[K, V]) -> Iter[V] {
+pub fn[K, V] HashMap::values(self : HashMap[K, V]) -> Iter[V] {
   Iter::new(yield_ => for entry in self.entries {
     if entry is Some({ value, .. }) {
       guard yield_(value) is IterContinue else { break IterEnd }
@@ -434,7 +437,7 @@ pub fn[K, V] T::values(self : T[K, V]) -> Iter[V] {
 ///   inspect(map.get("d"), content="Some(4)")
 /// ```
 #locals(f)
-pub fn[K, V] retain(self : T[K, V], f : (K, V) -> Bool) -> Unit {
+pub fn[K, V] retain(self : HashMap[K, V], f : (K, V) -> Bool) -> Unit {
   let last = self.capacity - 1
   while self.entries[last] is Some(entry) && !f(entry.key, entry.value) {
     self.shift_back(last)

--- a/hashmap/utils_test.mbt
+++ b/hashmap/utils_test.mbt
@@ -62,7 +62,7 @@ test "T::retain - remove all" {
 
 ///|
 test "T::retain - empty map" {
-  let map : @hashmap.T[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
   map.retain((_k, _v) => true)
   inspect(map.size(), content="0")
   inspect(map.is_empty(), content="true")

--- a/hashset/README.mbt.md
+++ b/hashset/README.mbt.md
@@ -11,7 +11,7 @@ You can create an empty set using `new()` or construct it using `from_array()`.
 ```moonbit
 test {
   let _set1 = @hashset.of([1, 2, 3, 4, 5])
-  let _set2 : @hashset.T[String] = @hashset.new()
+  let _set2 : @hashset.HashSet[String] = @hashset.new()
 }
 ```
 
@@ -21,7 +21,7 @@ You can use `insert()` to add a key to the set, and `contains()` to check whethe
 
 ```moonbit
 test {
-  let set : @hashset.T[String] = @hashset.new()
+  let set : @hashset.HashSet[String] = @hashset.new()
   set.add("a")
   assert_eq(set.contains("a"), true)
 }
@@ -55,7 +55,7 @@ Similarly, you can use `is_empty()` to check whether the set is empty.
 
 ```moonbit
 test {
-  let set : @hashset.T[Int] = @hashset.new()
+  let set : @hashset.HashSet[Int] = @hashset.new()
   assert_eq(set.is_empty(), true)
 }
 ```
@@ -94,7 +94,7 @@ You can use `union()`, `intersection()`, `difference()` and `symmetric_differenc
 test {
   let m1 = @hashset.of(["a", "b", "c"])
   let m2 = @hashset.of(["b", "c", "d"])
-  fn to_sorted_array(set : @hashset.T[String]) {
+  fn to_sorted_array(set : @hashset.HashSet[String]) {
     let arr = set.to_array()
     arr.sort()
     arr

--- a/hashset/deprecated.mbt
+++ b/hashset/deprecated.mbt
@@ -15,6 +15,6 @@
 ///|
 #deprecated("Use `add` instead.")
 #coverage.skip
-pub fn[K : Hash + Eq] insert(self : T[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] insert(self : HashSet[K], key : K) -> Unit {
   self.add(key)
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -19,7 +19,7 @@ let default_init_capacity = 8
 
 ///|
 /// Create new hash set.
-pub fn[K] T::new(capacity? : Int = default_init_capacity) -> T[K] {
+pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
   {
     size: 0,
     capacity,
@@ -31,14 +31,14 @@ pub fn[K] T::new(capacity? : Int = default_init_capacity) -> T[K] {
 
 ///|
 /// Create new hash set from array.
-pub fn[K : Hash + Eq] T::from_array(arr : Array[K]) -> T[K] {
+pub fn[K : Hash + Eq] HashSet::from_array(arr : Array[K]) -> HashSet[K] {
   let m = new()
   arr.each(e => m.add(e))
   m
 }
 
 ///|
-pub fn[K : Hash + Eq] T::of(arr : FixedArray[K]) -> T[K] {
+pub fn[K : Hash + Eq] HashSet::of(arr : FixedArray[K]) -> HashSet[K] {
   let m = new()
   arr.each(e => m.add(e))
   m
@@ -55,18 +55,18 @@ pub fn[K : Hash + Eq] T::of(arr : FixedArray[K]) -> T[K] {
 /// Example:
 ///
 /// ```moonbit
-///   let set : @hashset.T[String] = @hashset.new()
+///   let set : @hashset.HashSet[String] = @hashset.new()
 ///   set.add("key")
 ///   inspect(set.contains("key"), content="true")
 ///   set.add("key") // no effect since it already exists
 ///   inspect(set.size(), content="1")
 /// ```
-pub fn[K : Hash + Eq] add(self : T[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] add(self : HashSet[K], key : K) -> Unit {
   self.add_with_hash(key, key.hash())
 }
 
 ///|
-fn[K : Eq] add_with_hash(self : T[K], key : K, hash : Int) -> Unit {
+fn[K : Eq] add_with_hash(self : HashSet[K], key : K, hash : Int) -> Unit {
   if self.size >= self.grow_at {
     self.grow()
   }
@@ -91,7 +91,7 @@ fn[K : Eq] add_with_hash(self : T[K], key : K, hash : Int) -> Unit {
 }
 
 ///|
-fn[K] push_away(self : T[K], idx : Int, entry : Entry[K]) -> Unit {
+fn[K] push_away(self : HashSet[K], idx : Int, entry : Entry[K]) -> Unit {
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
     match self.entries[idx] {
       None => {
@@ -115,13 +115,13 @@ fn[K] push_away(self : T[K], idx : Int, entry : Entry[K]) -> Unit {
 
 ///|
 #inline
-fn[K] set_entry(self : T[K], entry : Entry[K], new_idx : Int) -> Unit {
+fn[K] set_entry(self : HashSet[K], entry : Entry[K], new_idx : Int) -> Unit {
   self.entries[new_idx] = Some(entry)
 }
 
 ///|
 /// Check if the hash set contains a key.
-pub fn[K : Hash + Eq] contains(self : T[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = key.hash()
   for i = 0, idx = abs(hash) & self.capacity_mask {
@@ -155,7 +155,7 @@ pub fn[K : Hash + Eq] contains(self : T[K], key : K) -> Bool {
 ///   inspect(set.contains("a"), content="false")
 ///   inspect(set.size(), content="1")
 /// ```
-pub fn[K : Hash + Eq] remove(self : T[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] remove(self : HashSet[K], key : K) -> Unit {
   let hash = key.hash()
   for i = 0, idx = abs(hash) & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break }
@@ -172,7 +172,7 @@ pub fn[K : Hash + Eq] remove(self : T[K], key : K) -> Unit {
 }
 
 ///|
-fn[K] shift_back(self : T[K], idx : Int) -> Unit {
+fn[K] shift_back(self : HashSet[K], idx : Int) -> Unit {
   let next = (idx + 1) & self.capacity_mask
   match self.entries[next] {
     None | Some({ psl: 0, .. }) => self.entries[idx] = None
@@ -185,7 +185,7 @@ fn[K] shift_back(self : T[K], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq] grow(self : T[K]) -> Unit {
+fn[K : Eq] grow(self : HashSet[K]) -> Unit {
   // handle zero capacity
   if self.capacity == 0 {
     self.capacity = default_init_capacity
@@ -211,32 +211,32 @@ fn[K : Eq] grow(self : T[K]) -> Unit {
 // Utils
 
 ///|
-pub impl[K : Show] Show for T[K] with output(self, logger) {
+pub impl[K : Show] Show for HashSet[K] with output(self, logger) {
   logger.write_iter(self.iter(), prefix="@hashset.of([", suffix="])")
 }
 
 ///|
 /// Get the number of keys in the set.
-pub fn[K] size(self : T[K]) -> Int {
+pub fn[K] size(self : HashSet[K]) -> Int {
   self.size
 }
 
 ///|
 /// Get the capacity of the set.
-pub fn[K] capacity(self : T[K]) -> Int {
+pub fn[K] capacity(self : HashSet[K]) -> Int {
   self.capacity
 }
 
 ///|
 /// Check if the hash set is empty.
-pub fn[K] is_empty(self : T[K]) -> Bool {
+pub fn[K] is_empty(self : HashSet[K]) -> Bool {
   self.size == 0
 }
 
 ///|
 /// Iterate over all keys of the set.
 #locals(f)
-pub fn[K] each(self : T[K], f : (K) -> Unit raise?) -> Unit raise? {
+pub fn[K] each(self : HashSet[K], f : (K) -> Unit raise?) -> Unit raise? {
   for entry in self.entries {
     if entry is Some({ key, .. }) {
       f(key)
@@ -247,7 +247,7 @@ pub fn[K] each(self : T[K], f : (K) -> Unit raise?) -> Unit raise? {
 ///|
 /// Iterate over all keys of the set, with index.
 #locals(f)
-pub fn[K] eachi(self : T[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
+pub fn[K] eachi(self : HashSet[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
   let mut idx = 0
   for i in 0..<self.capacity {
     if self.entries[i] is Some({ key, .. }) {
@@ -259,14 +259,14 @@ pub fn[K] eachi(self : T[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
 
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
-pub fn[K] clear(self : T[K]) -> Unit {
+pub fn[K] clear(self : HashSet[K]) -> Unit {
   self.entries.fill(None)
   self.size = 0
 }
 
 ///|
 /// Returns the iterator of the hash set.
-pub fn[K] iter(self : T[K]) -> Iter[K] {
+pub fn[K] iter(self : HashSet[K]) -> Iter[K] {
   Iter::new(yield_ => for entry in self.entries {
     if entry is Some({ key, .. }) {
       guard yield_(key) is IterContinue else { break IterEnd }
@@ -278,7 +278,7 @@ pub fn[K] iter(self : T[K]) -> Iter[K] {
 
 ///|
 /// Converts the hash set to an array.
-pub fn[K] to_array(self : T[K]) -> Array[K] {
+pub fn[K] to_array(self : HashSet[K]) -> Array[K] {
   let arr = Array::new(capacity=self.size)
   for entry in self.entries {
     if entry is Some({ key, .. }) {
@@ -289,7 +289,7 @@ pub fn[K] to_array(self : T[K]) -> Array[K] {
 }
 
 ///|
-pub fn[K : Hash + Eq] T::from_iter(iter : Iter[K]) -> T[K] {
+pub fn[K : Hash + Eq] HashSet::from_iter(iter : Iter[K]) -> HashSet[K] {
   let s = new()
   iter.each(e => s.add(e))
   s
@@ -297,7 +297,10 @@ pub fn[K : Hash + Eq] T::from_iter(iter : Iter[K]) -> T[K] {
 
 ///|
 /// Union of two hash sets.
-pub fn[K : Hash + Eq] union(self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] union(
+  self : HashSet[K],
+  other : HashSet[K],
+) -> HashSet[K] {
   let m = new()
   self.each(k => m.add(k))
   other.each(k => m.add(k))
@@ -306,7 +309,10 @@ pub fn[K : Hash + Eq] union(self : T[K], other : T[K]) -> T[K] {
 
 ///|
 /// Intersection of two hash sets.
-pub fn[K : Hash + Eq] intersection(self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] intersection(
+  self : HashSet[K],
+  other : HashSet[K],
+) -> HashSet[K] {
   let m = new()
   self.each(k => if other.contains(k) { m.add(k) })
   m
@@ -314,7 +320,10 @@ pub fn[K : Hash + Eq] intersection(self : T[K], other : T[K]) -> T[K] {
 
 ///|
 /// Difference of two hash sets.
-pub fn[K : Hash + Eq] difference(self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] difference(
+  self : HashSet[K],
+  other : HashSet[K],
+) -> HashSet[K] {
   let m = new()
   self.each(k => if !other.contains(k) { m.add(k) })
   m
@@ -322,7 +331,10 @@ pub fn[K : Hash + Eq] difference(self : T[K], other : T[K]) -> T[K] {
 
 ///|
 /// Symmetric difference of two hash sets.
-pub fn[K : Hash + Eq] symmetric_difference(self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] symmetric_difference(
+  self : HashSet[K],
+  other : HashSet[K],
+) -> HashSet[K] {
   let m = new()
   self.each(k => if !other.contains(k) { m.add(k) })
   other.each(k => if !self.contains(k) { m.add(k) })
@@ -331,7 +343,10 @@ pub fn[K : Hash + Eq] symmetric_difference(self : T[K], other : T[K]) -> T[K] {
 
 ///|
 /// Check if two sets have no common elements.
-pub fn[K : Hash + Eq] is_disjoint(self : T[K], other : T[K]) -> Bool {
+pub fn[K : Hash + Eq] is_disjoint(
+  self : HashSet[K],
+  other : HashSet[K],
+) -> Bool {
   if self.size() <= other.size() {
     self.iter().all(k => !other.contains(k))
   } else {
@@ -341,7 +356,7 @@ pub fn[K : Hash + Eq] is_disjoint(self : T[K], other : T[K]) -> Bool {
 
 ///|
 /// Check if the current set is a subset of another set.
-pub fn[K : Hash + Eq] is_subset(self : T[K], other : T[K]) -> Bool {
+pub fn[K : Hash + Eq] is_subset(self : HashSet[K], other : HashSet[K]) -> Bool {
   if self.size() <= other.size() {
     self.iter().all(k => other.contains(k))
   } else {
@@ -351,39 +366,41 @@ pub fn[K : Hash + Eq] is_subset(self : T[K], other : T[K]) -> Bool {
 
 ///|
 /// Check if the current set is a superset of another set.
-pub fn[K : Hash + Eq] is_superset(self : T[K], other : T[K]) -> Bool {
+pub fn[K : Hash + Eq] is_superset(
+  self : HashSet[K],
+  other : HashSet[K],
+) -> Bool {
   other.is_subset(self)
 }
 
 ///|
 /// Intersection of two hash sets.
-pub impl[K : Hash + Eq] BitAnd for T[K] with land(self, other) {
+pub impl[K : Hash + Eq] BitAnd for HashSet[K] with land(self, other) {
   self.intersection(other)
 }
 
 ///|
 /// Union of two hash sets.
-pub impl[K : Hash + Eq] BitOr for T[K] with lor(self, other) {
+pub impl[K : Hash + Eq] BitOr for HashSet[K] with lor(self, other) {
   self.union(other)
 }
 
 ///|
 /// Symmetric difference of two hash sets.
-pub impl[K : Hash + Eq] BitXOr for T[K] with lxor(self, other) {
+pub impl[K : Hash + Eq] BitXOr for HashSet[K] with lxor(self, other) {
   self.symmetric_difference(other)
 }
 
 ///|
 /// Difference of two hash sets.
-pub impl[K : Hash + Eq] Sub for T[K] with op_sub(self, other) {
+pub impl[K : Hash + Eq] Sub for HashSet[K] with op_sub(self, other) {
   self.difference(other)
 }
 
 ///|
-pub impl[X : @quickcheck.Arbitrary + Eq + Hash] @quickcheck.Arbitrary for T[X] with arbitrary(
-  size,
-  rs,
-) {
+pub impl[X : @quickcheck.Arbitrary + Eq + Hash] @quickcheck.Arbitrary for HashSet[
+  X,
+] with arbitrary(size, rs) {
   @quickcheck.Arbitrary::arbitrary(size, rs) |> from_iter
 }
 
@@ -402,7 +419,7 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 }
 
 ///|
-fn[K : Show] debug_entries(self : T[K]) -> String {
+fn[K : Show] debug_entries(self : HashSet[K]) -> String {
   let mut s = ""
   for i in 0..<self.entries.length() {
     if i > 0 {
@@ -439,7 +456,7 @@ impl Show for MyString with output(self, logger) {
 
 ///|
 test "set" {
-  let m : T[MyString] = new()
+  let m : HashSet[MyString] = new()
   m.add("a")
   m.add("b")
   m.add("bc")
@@ -456,7 +473,7 @@ test "set" {
 
 ///|
 test "remove" {
-  let m : T[MyString] = new()
+  let m : HashSet[MyString] = new()
   fn i(s) {
     MyString::MyString(s)
   }
@@ -477,7 +494,7 @@ test "remove" {
 
 ///|
 test "remove_unexist_key" {
-  let m : T[MyString] = new()
+  let m : HashSet[MyString] = new()
   fn i(s) {
     MyString::MyString(s)
   }
@@ -492,7 +509,7 @@ test "remove_unexist_key" {
 
 ///|
 test "grow" {
-  let m : T[MyString] = new()
+  let m : HashSet[MyString] = new()
   fn i(s) {
     MyString::MyString(s)
   }
@@ -521,7 +538,7 @@ test "grow" {
 
 ///|
 test "clear" {
-  let m : T[MyString] = new()
+  let m : HashSet[MyString] = new()
   m.clear()
   inspect(m.size(), content="0")
   inspect(m.capacity(), content="8")
@@ -544,12 +561,12 @@ test "clear" {
 /// Example:
 ///
 /// ```moonbit
-///   let set : @hashset.T[String] = @hashset.new()
+///   let set : @hashset.HashSet[String] = @hashset.new()
 ///   inspect(set.add_and_check("key"), content="true")  // First insertion
 ///   inspect(set.add_and_check("key"), content="false") // Already exists
 ///   inspect(set.size(), content="1")
 /// ```
-pub fn[K : Hash + Eq] add_and_check(self : T[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] add_and_check(self : HashSet[K], key : K) -> Bool {
   let old_size = self.size
   self.add(key)
   self.size > old_size
@@ -574,7 +591,7 @@ pub fn[K : Hash + Eq] add_and_check(self : T[K], key : K) -> Bool {
 ///   inspect(set.remove_and_check("a"), content="false") // Already removed
 ///   inspect(set.size(), content="1")
 /// ```
-pub fn[K : Hash + Eq] remove_and_check(self : T[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] remove_and_check(self : HashSet[K], key : K) -> Bool {
   let old_size = self.size
   self.remove(key)
   self.size < old_size
@@ -582,7 +599,7 @@ pub fn[K : Hash + Eq] remove_and_check(self : T[K], key : K) -> Bool {
 
 ///|
 /// Copy the set, creating a new set with the same keys.
-pub fn[K] copy(self : T[K]) -> T[K] {
+pub fn[K] copy(self : HashSet[K]) -> HashSet[K] {
   let other = {
     capacity: self.capacity,
     entries: FixedArray::make(self.capacity, None),
@@ -598,7 +615,7 @@ pub fn[K] copy(self : T[K]) -> T[K] {
 
 ///|
 /// ToJson implementation for hashset
-pub impl[X : ToJson] ToJson for T[X] with to_json(self) {
+pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
   let res = Array::new(capacity=self.size)
   for entry in self.entries {
     if entry is Some({ key, .. }) {
@@ -610,9 +627,9 @@ pub impl[X : ToJson] ToJson for T[X] with to_json(self) {
 
 ///|
 /// Default implementation for hashset
-pub impl[K] Default for T[K] with default() {
+pub impl[K] Default for HashSet[K] with default() {
   new()
 }
 
 ///|
-pub fnalias T::(new, from_array, from_iter, of)
+pub fnalias HashSet::(new, from_array, from_iter, of)

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -17,7 +17,7 @@ let default_init_capacity = 8
 
 ///|
 test "new_with_capacity_then_add " {
-  let set : @hashset.T[(String, String)] = @hashset.new(capacity=20)
+  let set : @hashset.HashSet[(String, String)] = @hashset.new(capacity=20)
   set.add(("None", "Hash"))
   inspect(
     set,
@@ -37,7 +37,7 @@ test "to_array" {
 
 ///|
 test "add_and_check" {
-  let set : @hashset.T[String] = @hashset.new()
+  let set : @hashset.HashSet[String] = @hashset.new()
   inspect(set.add_and_check("key"), content="true") // First insertion
   inspect(set.add_and_check("key"), content="false") // Already exists
   inspect(set.size(), content="1")
@@ -73,7 +73,7 @@ test "to_json" {
 
 ///|
 test "new" {
-  let m : @hashset.T[Int] = @hashset.new()
+  let m : @hashset.HashSet[Int] = @hashset.new()
   assert_eq(m.capacity(), default_init_capacity)
   inspect(m.size(), content="0")
 }
@@ -390,13 +390,13 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let map : @hashset.T[Int] = @hashset.from_iter(Iter::empty())
+  let map : @hashset.HashSet[Int] = @hashset.from_iter(Iter::empty())
   inspect(map, content="@hashset.of([])")
 }
 
 ///|
 test "hashset arbitrary" {
-  let samples : Array[@hashset.T[Int]] = @quickcheck.samples(20)
+  let samples : Array[@hashset.HashSet[Int]] = @quickcheck.samples(20)
   inspect(
     samples[5:10],
     content="[@hashset.of([]), @hashset.of([]), @hashset.of([0]), @hashset.of([0]), @hashset.of([0, 3, 1, 2])]",
@@ -409,7 +409,7 @@ test "hashset arbitrary" {
 
 ///|
 test "@hashset.to_array/empty" {
-  let set : @hashset.T[Int] = @hashset.new()
+  let set : @hashset.HashSet[Int] = @hashset.new()
   inspect(set.to_array(), content="[]")
 }
 

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -10,48 +10,49 @@ import(
 // Errors
 
 // Types and methods
-type T[K]
-fn[K : Hash + Eq] T::add(Self[K], K) -> Unit
-fn[K : Hash + Eq] T::add_and_check(Self[K], K) -> Bool
-fn[K] T::capacity(Self[K]) -> Int
-fn[K] T::clear(Self[K]) -> Unit
-fn[K : Hash + Eq] T::contains(Self[K], K) -> Bool
-fn[K] T::copy(Self[K]) -> Self[K]
-fn[K : Hash + Eq] T::difference(Self[K], Self[K]) -> Self[K]
-fn[K] T::each(Self[K], (K) -> Unit raise?) -> Unit raise?
-fn[K] T::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
-fn[K : Hash + Eq] T::from_array(Array[K]) -> Self[K]
-fnalias T::from_array
-fn[K : Hash + Eq] T::from_iter(Iter[K]) -> Self[K]
-fnalias T::from_iter
+type HashSet[K]
+fn[K : Hash + Eq] HashSet::add(Self[K], K) -> Unit
+fn[K : Hash + Eq] HashSet::add_and_check(Self[K], K) -> Bool
+fn[K] HashSet::capacity(Self[K]) -> Int
+fn[K] HashSet::clear(Self[K]) -> Unit
+fn[K : Hash + Eq] HashSet::contains(Self[K], K) -> Bool
+fn[K] HashSet::copy(Self[K]) -> Self[K]
+fn[K : Hash + Eq] HashSet::difference(Self[K], Self[K]) -> Self[K]
+fn[K] HashSet::each(Self[K], (K) -> Unit raise?) -> Unit raise?
+fn[K] HashSet::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
+fn[K : Hash + Eq] HashSet::from_array(Array[K]) -> Self[K]
+fnalias HashSet::from_array
+fn[K : Hash + Eq] HashSet::from_iter(Iter[K]) -> Self[K]
+fnalias HashSet::from_iter
 #deprecated
-fn[K : Hash + Eq] T::insert(Self[K], K) -> Unit
-fn[K : Hash + Eq] T::intersection(Self[K], Self[K]) -> Self[K]
-fn[K : Hash + Eq] T::is_disjoint(Self[K], Self[K]) -> Bool
-fn[K] T::is_empty(Self[K]) -> Bool
-fn[K : Hash + Eq] T::is_subset(Self[K], Self[K]) -> Bool
-fn[K : Hash + Eq] T::is_superset(Self[K], Self[K]) -> Bool
-fn[K] T::iter(Self[K]) -> Iter[K]
-fn[K] T::new(capacity? : Int) -> Self[K]
-fnalias T::new
-fn[K : Hash + Eq] T::of(FixedArray[K]) -> Self[K]
-fnalias T::of
-fn[K : Hash + Eq] T::remove(Self[K], K) -> Unit
-fn[K : Hash + Eq] T::remove_and_check(Self[K], K) -> Bool
-fn[K] T::size(Self[K]) -> Int
-fn[K : Hash + Eq] T::symmetric_difference(Self[K], Self[K]) -> Self[K]
-fn[K] T::to_array(Self[K]) -> Array[K]
-fn[K : Hash + Eq] T::union(Self[K], Self[K]) -> Self[K]
-impl[K : Hash + Eq] BitAnd for T[K]
-impl[K : Hash + Eq] BitOr for T[K]
-impl[K : Hash + Eq] BitXOr for T[K]
-impl[K] Default for T[K]
-impl[K : Show] Show for T[K]
-impl[K : Hash + Eq] Sub for T[K]
-impl[X : ToJson] ToJson for T[X]
-impl[X : @quickcheck.Arbitrary + Eq + Hash] @quickcheck.Arbitrary for T[X]
+fn[K : Hash + Eq] HashSet::insert(Self[K], K) -> Unit
+fn[K : Hash + Eq] HashSet::intersection(Self[K], Self[K]) -> Self[K]
+fn[K : Hash + Eq] HashSet::is_disjoint(Self[K], Self[K]) -> Bool
+fn[K] HashSet::is_empty(Self[K]) -> Bool
+fn[K : Hash + Eq] HashSet::is_subset(Self[K], Self[K]) -> Bool
+fn[K : Hash + Eq] HashSet::is_superset(Self[K], Self[K]) -> Bool
+fn[K] HashSet::iter(Self[K]) -> Iter[K]
+fn[K] HashSet::new(capacity? : Int) -> Self[K]
+fnalias HashSet::new
+fn[K : Hash + Eq] HashSet::of(FixedArray[K]) -> Self[K]
+fnalias HashSet::of
+fn[K : Hash + Eq] HashSet::remove(Self[K], K) -> Unit
+fn[K : Hash + Eq] HashSet::remove_and_check(Self[K], K) -> Bool
+fn[K] HashSet::size(Self[K]) -> Int
+fn[K : Hash + Eq] HashSet::symmetric_difference(Self[K], Self[K]) -> Self[K]
+fn[K] HashSet::to_array(Self[K]) -> Array[K]
+fn[K : Hash + Eq] HashSet::union(Self[K], Self[K]) -> Self[K]
+impl[K : Hash + Eq] BitAnd for HashSet[K]
+impl[K : Hash + Eq] BitOr for HashSet[K]
+impl[K : Hash + Eq] BitXOr for HashSet[K]
+impl[K] Default for HashSet[K]
+impl[K : Show] Show for HashSet[K]
+impl[K : Hash + Eq] Sub for HashSet[K]
+impl[X : ToJson] ToJson for HashSet[X]
+impl[X : @quickcheck.Arbitrary + Eq + Hash] @quickcheck.Arbitrary for HashSet[X]
 
 // Type aliases
+pub typealias HashSet as T
 
 // Traits
 

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -35,10 +35,14 @@ priv struct Entry[K] {
 ///   set.add((4, "four"))
 ///   assert_eq(set.contains((4, "four")), true)
 /// ```
-struct T[K] {
+struct HashSet[K] {
   mut entries : FixedArray[Entry[K]?]
   mut size : Int // active key count
   mut capacity : Int // current capacity
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx
   mut grow_at : Int // threshold that triggers grow
 }
+
+///|
+#deprecated("Use `HashSet` instead of `T`")
+pub typealias HashSet as T

--- a/queue/README.mbt.md
+++ b/queue/README.mbt.md
@@ -8,7 +8,7 @@ Queue is a first in first out (FIFO) data structure, allowing to process their e
 You can create a queue manually by using the `new` or construct it using the `from_array`.
 ```moonbit
 test {
-    let _queue : @queue.T[Int] = @queue.new()
+    let _queue : @queue.Queue[Int] = @queue.new()
     let _queue1 = @queue.of([1,2,3])
 }
 ```
@@ -86,8 +86,8 @@ test {
 Transfer the elements from one queue to another using the `transfer` method.
 ```moonbit
 test {
-    let dst : @queue.T[Int] = @queue.new()
-    let src : @queue.T[Int] = @queue.of([5, 6, 7, 8])
+    let dst : @queue.Queue[Int] = @queue.new()
+    let src : @queue.Queue[Int] = @queue.of([5, 6, 7, 8])
     src.transfer(dst)
 }
 ```

--- a/queue/deprecated.mbt
+++ b/queue/deprecated.mbt
@@ -15,13 +15,13 @@
 ///|
 #deprecated("Use `unsafe_peek` instead")
 #coverage.skip
-pub fn[A] peek_exn(self : T[A]) -> A {
+pub fn[A] peek_exn(self : Queue[A]) -> A {
   self.unsafe_peek()
 }
 
 ///|
 #deprecated("Use `unsafe_pop` instead")
 #coverage.skip
-pub fn[A] pop_exn(self : T[A]) -> A {
+pub fn[A] pop_exn(self : Queue[A]) -> A {
   self.unsafe_pop()
 }

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -6,40 +6,41 @@ import(
 )
 
 // Values
-fn[A] from_array(Array[A]) -> T[A]
+fn[A] from_array(Array[A]) -> Queue[A]
 
-fn[A] from_iter(Iter[A]) -> T[A]
+fn[A] from_iter(Iter[A]) -> Queue[A]
 
-fn[A] new() -> T[A]
+fn[A] new() -> Queue[A]
 
-fn[A] of(FixedArray[A]) -> T[A]
+fn[A] of(FixedArray[A]) -> Queue[A]
 
 // Errors
 
 // Types and methods
-type T[A]
-fn[A] T::clear(Self[A]) -> Unit
-fn[A] T::copy(Self[A]) -> Self[A]
-fn[A] T::each(Self[A], (A) -> Unit) -> Unit
-fn[A] T::eachi(Self[A], (Int, A) -> Unit) -> Unit
-fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B) -> B
-fn[A] T::is_empty(Self[A]) -> Bool
-fn[A] T::iter(Self[A]) -> Iter[A]
-fn[A] T::length(Self[A]) -> Int
-fn[A] T::peek(Self[A]) -> A?
+type Queue[A]
+fn[A] Queue::clear(Self[A]) -> Unit
+fn[A] Queue::copy(Self[A]) -> Self[A]
+fn[A] Queue::each(Self[A], (A) -> Unit) -> Unit
+fn[A] Queue::eachi(Self[A], (Int, A) -> Unit) -> Unit
+fn[A, B] Queue::fold(Self[A], init~ : B, (B, A) -> B) -> B
+fn[A] Queue::is_empty(Self[A]) -> Bool
+fn[A] Queue::iter(Self[A]) -> Iter[A]
+fn[A] Queue::length(Self[A]) -> Int
+fn[A] Queue::peek(Self[A]) -> A?
 #deprecated
-fn[A] T::peek_exn(Self[A]) -> A
-fn[A] T::pop(Self[A]) -> A?
+fn[A] Queue::peek_exn(Self[A]) -> A
+fn[A] Queue::pop(Self[A]) -> A?
 #deprecated
-fn[A] T::pop_exn(Self[A]) -> A
-fn[A] T::push(Self[A], A) -> Unit
-fn[A] T::transfer(Self[A], Self[A]) -> Unit
-fn[A] T::unsafe_peek(Self[A]) -> A
-fn[A] T::unsafe_pop(Self[A]) -> A
-impl[A : Show] Show for T[A]
-impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[X]
+fn[A] Queue::pop_exn(Self[A]) -> A
+fn[A] Queue::push(Self[A], A) -> Unit
+fn[A] Queue::transfer(Self[A], Self[A]) -> Unit
+fn[A] Queue::unsafe_peek(Self[A]) -> A
+fn[A] Queue::unsafe_pop(Self[A]) -> A
+impl[A : Show] Show for Queue[A]
+impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Queue[X]
 
 // Type aliases
+pub typealias Queue as T
 
 // Traits
 

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -17,10 +17,10 @@
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.new()
 ///   assert_eq(queue.length(), 0)
 /// ```
-pub fn[A] new() -> T[A] {
+pub fn[A] new() -> Queue[A] {
   { length: 0, first: None, last: None }
 }
 
@@ -30,10 +30,10 @@ pub fn[A] new() -> T[A] {
 /// # Example
 /// ```mbt
 ///   let array = Array::makei(3, (idx) => { idx + 1 })
-///   let queue : @queue.T[Int] = @queue.from_array(array)
+///   let queue : @queue.Queue[Int] = @queue.from_array(array)
 ///   assert_eq(queue.length(), 3)
 /// ```
-pub fn[A] from_array(arr : Array[A]) -> T[A] {
+pub fn[A] from_array(arr : Array[A]) -> Queue[A] {
   guard arr.length() > 0 else { return new() }
   let length = arr.length()
   let last = { content: arr[length - 1], next: None }
@@ -46,13 +46,13 @@ pub fn[A] from_array(arr : Array[A]) -> T[A] {
 }
 
 ///|
-pub impl[A : Show] Show for T[A] with output(self, logger) {
+pub impl[A : Show] Show for Queue[A] with output(self, logger) {
   logger.write_iter(self.iter(), prefix="@queue.of([", suffix="])")
 }
 
 ///|
 /// Tests if two queues are equal.
-impl[A : Eq] Eq for T[A] with op_equal(self, other) {
+impl[A : Eq] Eq for Queue[A] with op_equal(self, other) {
   self.length == other.length && self.first == other.first
 }
 
@@ -61,10 +61,10 @@ impl[A : Eq] Eq for T[A] with op_equal(self, other) {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   queue.clear()
 /// ```
-pub fn[A] clear(self : T[A]) -> Unit {
+pub fn[A] clear(self : Queue[A]) -> Unit {
   self.length = 0
   self.first = None
   self.last = None
@@ -75,10 +75,10 @@ pub fn[A] clear(self : T[A]) -> Unit {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.new()
 ///   assert_eq(queue.length(), 0)
 /// ```
-pub fn[A] length(self : T[A]) -> Int {
+pub fn[A] length(self : Queue[A]) -> Int {
   self.length
 }
 
@@ -87,10 +87,10 @@ pub fn[A] length(self : T[A]) -> Int {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.new()
 ///   assert_true(queue.is_empty())
 /// ```
-pub fn[A] is_empty(self : T[A]) -> Bool {
+pub fn[A] is_empty(self : Queue[A]) -> Bool {
   self.length == 0
 }
 
@@ -99,10 +99,10 @@ pub fn[A] is_empty(self : T[A]) -> Bool {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.new()
 ///   queue.push(1)
 /// ```
-pub fn[A] push(self : T[A], x : A) -> Unit {
+pub fn[A] push(self : Queue[A], x : A) -> Unit {
   let cell = Some({ content: x, next: None })
   match self.last {
     None => {
@@ -123,11 +123,11 @@ pub fn[A] push(self : T[A], x : A) -> Unit {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.unsafe_peek(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
-pub fn[A] unsafe_peek(self : T[A]) -> A {
+pub fn[A] unsafe_peek(self : Queue[A]) -> A {
   match self.first {
     None => abort("Queue is empty")
     Some(first) => first.content
@@ -139,10 +139,10 @@ pub fn[A] unsafe_peek(self : T[A]) -> A {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.peek(), Some(1))
 /// ```
-pub fn[A] peek(self : T[A]) -> A? {
+pub fn[A] peek(self : Queue[A]) -> A? {
   match self.first {
     None => None
     Some(first) => Some(first.content)
@@ -154,11 +154,11 @@ pub fn[A] peek(self : T[A]) -> A? {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.unsafe_pop(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
-pub fn[A] unsafe_pop(self : T[A]) -> A {
+pub fn[A] unsafe_pop(self : Queue[A]) -> A {
   match self.first {
     None => abort("Queue is empty")
     Some({ content, next: None }) => {
@@ -178,10 +178,10 @@ pub fn[A] unsafe_pop(self : T[A]) -> A {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.pop(), Some(1))
 /// ```
-pub fn[A] pop(self : T[A]) -> A? {
+pub fn[A] pop(self : Queue[A]) -> A? {
   match self.first {
     None => None
     Some({ content, next: None }) => {
@@ -201,11 +201,11 @@ pub fn[A] pop(self : T[A]) -> A? {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   let mut sum = 0
 ///   queue.each((x) => { sum = sum + x })
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
+pub fn[A] each(self : Queue[A], f : (A) -> Unit) -> Unit {
   loop self.first {
     Some({ content, next }) => {
       f(content)
@@ -220,11 +220,11 @@ pub fn[A] each(self : T[A], f : (A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   let mut sum = 0
 ///   queue.eachi((x, i) => { sum = sum + x * i })
 /// ```
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
   loop (self.first, 0) {
     (Some({ content, next }), index) => {
       f(index, content)
@@ -239,11 +239,11 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit) -> Unit {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.new()
 ///   let sum = queue.fold(init=0, (acc, x) => { acc + x })
 ///   assert_eq(sum, 0)
 /// ```
-pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
+pub fn[A, B] fold(self : Queue[A], init~ : B, f : (B, A) -> B) -> B {
   loop (self.first, init) {
     (None, acc) => acc
     (Some({ content, next }), acc) => continue (next, f(acc, content))
@@ -255,11 +255,11 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B) -> B {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
-///   let queue2 : @queue.T[Int] = queue.copy()
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
+///   let queue2 : @queue.Queue[Int] = queue.copy()
 ///   assert_eq(queue2.length(), 4)
 /// ```
-pub fn[A] copy(self : T[A]) -> T[A] {
+pub fn[A] copy(self : Queue[A]) -> Queue[A] {
   guard self.first is Some({ content, next }) else { return new() }
   let first = { content, next: None }
   let last = loop (first, next) {
@@ -280,11 +280,11 @@ pub fn[A] copy(self : T[A]) -> T[A] {
 ///
 /// # Example
 /// ```mbt
-///   let dst : @queue.T[Int] = @queue.new()
-///   let src : @queue.T[Int] = @queue.of([5, 6, 7, 8])
+///   let dst : @queue.Queue[Int] = @queue.new()
+///   let src : @queue.Queue[Int] = @queue.of([5, 6, 7, 8])
 ///   src.transfer(dst)
 /// ```
-pub fn[A] transfer(self : T[A], dst : T[A]) -> Unit {
+pub fn[A] transfer(self : Queue[A], dst : Queue[A]) -> Unit {
   if self.length > 0 {
     match dst.last {
       None => {
@@ -308,11 +308,11 @@ pub fn[A] transfer(self : T[A], dst : T[A]) -> Unit {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([5, 6, 7, 8])
+///   let queue : @queue.Queue[Int] = @queue.of([5, 6, 7, 8])
 ///   let sum = queue.iter().fold((x, y) => { x + y }, init=0)
 ///   assert_eq(sum, 26)
 /// ```
-pub fn[A] iter(self : T[A]) -> Iter[A] {
+pub fn[A] iter(self : Queue[A]) -> Iter[A] {
   Iter::new(yield_ => loop self.first {
     Some({ content, next }) => {
       if yield_(content) == IterEnd {
@@ -329,10 +329,10 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.from_iter(Iter::empty())
+///   let queue : @queue.Queue[Int] = @queue.from_iter(Iter::empty())
 ///   assert_eq(queue.length(), 0)
 /// ```
-pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
+pub fn[A] from_iter(iter : Iter[A]) -> Queue[A] {
   let q = new()
   iter.each(e => q.push(e))
   q
@@ -343,10 +343,10 @@ pub fn[A] from_iter(iter : Iter[A]) -> T[A] {
 ///
 /// # Example
 /// ```mbt
-///   let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.length(), 4)
 /// ```
-pub fn[A] of(arr : FixedArray[A]) -> T[A] {
+pub fn[A] of(arr : FixedArray[A]) -> Queue[A] {
   guard arr.length() > 0 else { return new() }
   let length = arr.length()
   let last = { content: arr[length - 1], next: None }
@@ -390,7 +390,7 @@ test "op_equal" {
 
 ///|
 test "push" {
-  let queue : T[Int] = new()
+  let queue : Queue[Int] = new()
   queue.push(1)
   queue.push(2)
   queue.push(3)
@@ -401,8 +401,8 @@ test "push" {
 
 ///|
 test "copy" {
-  let queue : T[Int] = of([1, 2, 3, 4])
-  let queue2 : T[Int] = queue.copy()
+  let queue : Queue[Int] = of([1, 2, 3, 4])
+  let queue2 : Queue[Int] = queue.copy()
   assert_eq(queue2.length(), 4)
   assert_eq(queue2, of([1, 2, 3, 4]))
   assert_eq(queue.length(), 4)
@@ -411,8 +411,8 @@ test "copy" {
 
 ///|
 test "transfer" {
-  let queue : T[Int] = of([1, 2, 3, 4])
-  let queue2 : T[Int] = of([5, 6, 7, 8])
+  let queue : Queue[Int] = of([1, 2, 3, 4])
+  let queue2 : Queue[Int] = of([5, 6, 7, 8])
   queue.transfer(queue2)
   assert_eq(queue.length(), 0)
   assert_eq(queue2.length(), 8)
@@ -425,7 +425,7 @@ test "cell_equal" {
 }
 
 ///|
-pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[X] with arbitrary(
+pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Queue[X] with arbitrary(
   size,
   rs,
 ) {

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "new" {
-  let queue : @queue.T[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.new()
   assert_eq(queue.length(), 0)
 }
 
@@ -33,7 +33,7 @@ test "from_fixed_array_1" {
 
 ///|
 test "from_fixed_array_2" {
-  let q : @queue.T[Int] = @queue.of([])
+  let q : @queue.Queue[Int] = @queue.of([])
   inspect(q, content="@queue.of([])")
 }
 
@@ -52,18 +52,18 @@ test "from_array_1" {
 
 ///|
 test "from_array_2" {
-  let q : @queue.T[Int] = @queue.from_array([])
+  let q : @queue.Queue[Int] = @queue.from_array([])
   inspect(q, content="@queue.of([])")
   let array = Array::makei(3, idx => idx + 1)
-  let q : @queue.T[Int] = @queue.from_array(array)
+  let q : @queue.Queue[Int] = @queue.from_array(array)
   inspect(q, content="@queue.of([1, 2, 3])")
-  let q : @queue.T[Int] = @queue.from_array(Array::new(capacity=10))
+  let q : @queue.Queue[Int] = @queue.from_array(Array::new(capacity=10))
   inspect(q, content="@queue.of([])")
 }
 
 ///|
 test "to_string" {
-  let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+  let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
   inspect(queue, content="@queue.of([1, 2, 3, 4])")
   queue.push(11)
   inspect(queue, content="@queue.of([1, 2, 3, 4, 11])")
@@ -73,7 +73,7 @@ test "to_string" {
 
 ///|
 test "clear" {
-  let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+  let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
   assert_eq(queue.length(), 4)
   queue.clear()
   assert_eq(queue.length(), 0)
@@ -81,7 +81,7 @@ test "clear" {
 
 ///|
 test "is_empty" {
-  let queue : @queue.T[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.new()
   assert_true(queue.is_empty())
   queue.push(1)
   queue.push(2)
@@ -92,7 +92,7 @@ test "is_empty" {
 
 ///|
 test "unsafe_peek" {
-  let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+  let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
   assert_eq(queue.unsafe_peek(), 1)
   assert_eq(queue.length(), 4)
   assert_eq(queue.unsafe_pop(), 1)
@@ -102,7 +102,7 @@ test "unsafe_peek" {
 
 ///|
 test "peek" {
-  let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+  let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
   assert_eq(queue.peek(), Some(1))
   queue.clear()
   assert_eq(queue.peek(), None)
@@ -110,7 +110,7 @@ test "peek" {
 
 ///|
 test "unsafe_pop" {
-  let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+  let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
   assert_eq(queue.unsafe_pop(), 1)
   assert_eq(queue.unsafe_pop(), 2)
   assert_eq(queue.unsafe_pop(), 3)
@@ -120,7 +120,7 @@ test "unsafe_pop" {
 
 ///|
 test "pop" {
-  let queue : @queue.T[Int] = @queue.of([1, 2, 3, 4])
+  let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
   assert_eq(queue.pop(), Some(1))
   assert_eq(queue.pop(), Some(2))
   assert_eq(queue.pop(), Some(3))
@@ -130,7 +130,7 @@ test "pop" {
 
 ///|
 test "iter" {
-  let queue : @queue.T[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.new()
   let mut sum = 0
   queue.each(x => sum = sum + x)
   assert_eq(sum, 0)
@@ -142,7 +142,7 @@ test "iter" {
 
 ///|
 test "iteri" {
-  let queue : @queue.T[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.new()
   let mut sum = 0
   queue.eachi((x, i) => sum = sum + x * i)
   assert_eq(sum, 0)
@@ -154,7 +154,7 @@ test "iteri" {
 
 ///|
 test "fold" {
-  let queue : @queue.T[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.new()
   let sum = queue.fold(init=0, (acc, x) => acc + x)
   assert_eq(sum, 0)
   @queue.of([1, 2, 3, 4]).transfer(queue)
@@ -170,7 +170,7 @@ test "fold" {
 
 ///|
 test "length" {
-  let empty : @queue.T[Unit] = @queue.of([])
+  let empty : @queue.Queue[Unit] = @queue.of([])
   inspect(empty.length(), content="0")
   inspect(@queue.of([1, 2, 3]).length(), content="3")
 }
@@ -193,21 +193,21 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @queue.T[Int] = @queue.from_iter(Iter::empty())
+  let pq : @queue.Queue[Int] = @queue.from_iter(Iter::empty())
   inspect(pq, content="@queue.of([])")
 }
 
 ///|
 test "to_string" {
-  let queue : @queue.T[Int] = @queue.from_array([])
+  let queue : @queue.Queue[Int] = @queue.from_array([])
   assert_eq(queue.to_string(), "@queue.of([])")
-  let queue : @queue.T[Int] = @queue.from_array([9, 8, 7, 5])
+  let queue : @queue.Queue[Int] = @queue.from_array([9, 8, 7, 5])
   assert_eq(queue.to_string(), "@queue.of([9, 8, 7, 5])")
 }
 
 ///|
 test "queue arbitrary" {
-  let samples : Array[@queue.T[Int]] = @quickcheck.samples(20)
+  let samples : Array[@queue.Queue[Int]] = @quickcheck.samples(20)
   inspect(
     samples[1:5],
     content="[@queue.of([]), @queue.of([]), @queue.of([0]), @queue.of([0])]",

--- a/queue/types.mbt
+++ b/queue/types.mbt
@@ -22,8 +22,12 @@ priv struct Cons[A] {
 // - length == 0 <=> first is None && last is None
 
 ///|
-struct T[A] {
+struct Queue[A] {
   mut length : Int
   mut first : Cons[A]?
   mut last : Cons[A]?
 }
+
+///|
+#deprecated("use `Queue` instead of `T`")
+pub typealias Queue as T


### PR DESCRIPTION
- **refactor(hashmap): rename type T to HashMap and update function signatures for consistency**
- **refactor(priority_queue): rename type T to PriorityQueue and update function signatures for consistency**
- **refactor(sorted_set): rename type T to SortedSet and update function signatures for consistency**
- **refactor(deque): rename type T to Deque and update function signatures for consistency**
- **refactor(hashmap): rename type T to HashMap and update function signatures for consistency**
- **refactor(hashset): rename type T to HashSet and update function signatures for consistency**
- **refactor(queue): rename type T to Queue and update function signatures for consistency**
