### PR TITLE
hongbo/finish types renaming

### DIFF
--- a/sorted_map/README.mbt.md
+++ b/sorted_map/README.mbt.md
@@ -23,7 +23,7 @@ You can create an empty SortedMap or a SortedMap from other containers.
 
 ```moonbit
 test {
-  let _map1 : @sorted_map.T[Int, String] = @sorted_map.new()
+  let _map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
   let _map2 = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
 
 }
@@ -133,7 +133,7 @@ Check if the map is empty.
 
 ```moonbit
 test {
-  let map : @sorted_map.T[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
   assert_eq(map.is_empty(), true)
 }
 ```
@@ -258,7 +258,7 @@ test {
 When working with keys that might not exist, prefer using pattern matching for safety:
 
 ```moonbit
-fn get_score(scores : @sorted_map.T[Int, Int], student_id : Int) -> Int {
+fn get_score(scores : @sorted_map.SortedMap[Int, Int], student_id : Int) -> Int {
   match scores.get(student_id) {
     Some(score) => score
     None =>
@@ -296,7 +296,7 @@ Key properties of the AVL tree implementation:
 
 - **@hashmap.T**: Provides O(1) average case lookups but doesn't maintain order; use when order doesn't matter
 - **@indexmap.T**: Maintains insertion order but not sorted order; use when insertion order matters
-- **@sorted_map.T**: Maintains keys in sorted order; use when you need keys to be sorted
+- **@sorted_map.SortedMap**: Maintains keys in sorted order; use when you need keys to be sorted
 
 Choose SortedMap when you need:
 - Key-value pairs sorted by key

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -14,7 +14,7 @@
 
 ///|
 #deprecated("Use @sorted_map.from_array instead")
-pub fn[K : Compare, V] of(entries : Array[(K, V)]) -> T[K, V] {
+pub fn[K : Compare, V] of(entries : Array[(K, V)]) -> SortedMap[K, V] {
   let map = { root: None, size: 0 }
   entries.each(e => map.add(e.0, e.1))
   map
@@ -23,7 +23,7 @@ pub fn[K : Compare, V] of(entries : Array[(K, V)]) -> T[K, V] {
 ///|
 #deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
 #coverage.skip
-pub fn[K, V] keys(self : T[K, V]) -> Array[K] {
+pub fn[K, V] keys(self : SortedMap[K, V]) -> Array[K] {
   let keys = Array::new(capacity=self.size)
   self.each(fn(k, _v) { keys.push(k) })
   keys
@@ -32,7 +32,7 @@ pub fn[K, V] keys(self : T[K, V]) -> Array[K] {
 ///|
 #deprecated("Use `values_as_iter` instead. `values` will return `Iter[V]` instead of `Array[V]` in the future.")
 #coverage.skip
-pub fn[K, V] values(self : T[K, V]) -> Array[V] {
+pub fn[K, V] values(self : SortedMap[K, V]) -> Array[V] {
   let values = Array::new(capacity=self.size)
   self.each(fn(_k, v) { values.push(v) })
   values

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -13,24 +13,28 @@
 // limitations under the License.
 
 ///|
-pub fn[K : Compare, V] op_set(self : T[K, V], key : K, value : V) -> Unit {
+pub fn[K : Compare, V] op_set(
+  self : SortedMap[K, V],
+  key : K,
+  value : V,
+) -> Unit {
   self.add(key, value)
 }
 
 ///|
-pub impl[K : Eq, V : Eq] Eq for T[K, V] with op_equal(self, other) {
+pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V] with op_equal(self, other) {
   self.to_array() == other.to_array()
 }
 
 ///|
 /// Returns a new sorted map.
-pub fn[K, V] new() -> T[K, V] {
+pub fn[K, V] new() -> SortedMap[K, V] {
   { root: None, size: 0 }
 }
 
 ///|
 /// Creates a sorted map from a array of key-value pairs.
-pub fn[K : Compare, V] from_array(entries : Array[(K, V)]) -> T[K, V] {
+pub fn[K : Compare, V] from_array(entries : Array[(K, V)]) -> SortedMap[K, V] {
   let map = { root: None, size: 0 }
   entries.each(e => map.add(e.0, e.1))
   map
@@ -38,7 +42,7 @@ pub fn[K : Compare, V] from_array(entries : Array[(K, V)]) -> T[K, V] {
 
 ///|
 /// Inserts a key-value pair.
-pub fn[K : Compare, V] add(self : T[K, V], key : K, value : V) -> Unit {
+pub fn[K : Compare, V] add(self : SortedMap[K, V], key : K, value : V) -> Unit {
   let (new_root, inserted) = add_node(self.root, key, value)
   if self.root != new_root {
     self.root = new_root
@@ -50,7 +54,7 @@ pub fn[K : Compare, V] add(self : T[K, V], key : K, value : V) -> Unit {
 
 ///|
 /// Removes a key-value pair.
-pub fn[K : Compare, V] remove(self : T[K, V], key : K) -> Unit {
+pub fn[K : Compare, V] remove(self : SortedMap[K, V], key : K) -> Unit {
   if self.root is Some(old_root) {
     let (new_root, deleted) = delete_node(old_root, key)
     if self.root != new_root {
@@ -64,7 +68,7 @@ pub fn[K : Compare, V] remove(self : T[K, V], key : K) -> Unit {
 
 ///|
 /// Gets a value by a key.
-pub fn[K : Compare, V] get(self : T[K, V], key : K) -> V? {
+pub fn[K : Compare, V] get(self : SortedMap[K, V], key : K) -> V? {
   loop self.root {
     Some(node) => {
       let cmp = key.compare(node.key)
@@ -82,7 +86,7 @@ pub fn[K : Compare, V] get(self : T[K, V], key : K) -> V? {
 
 ///|
 /// Gets a value by a key.
-pub fn[K : Compare, V] op_get(self : T[K, V], key : K) -> V {
+pub fn[K : Compare, V] op_get(self : SortedMap[K, V], key : K) -> V {
   loop self.root {
     Some(node) => {
       let cmp = key.compare(node.key)
@@ -100,7 +104,7 @@ pub fn[K : Compare, V] op_get(self : T[K, V], key : K) -> V {
 
 ///|
 /// Checks if map contains a key-value pair.
-pub fn[K : Compare, V] contains(self : T[K, V], key : K) -> Bool {
+pub fn[K : Compare, V] contains(self : SortedMap[K, V], key : K) -> Bool {
   match self.get(key) {
     Some(_) => true
     None => false
@@ -109,26 +113,29 @@ pub fn[K : Compare, V] contains(self : T[K, V], key : K) -> Bool {
 
 ///|
 /// Returns true if map is empty.
-pub fn[K, V] is_empty(self : T[K, V]) -> Bool {
+pub fn[K, V] is_empty(self : SortedMap[K, V]) -> Bool {
   self.size == 0
 }
 
 ///|
 /// Returns the count of key-value pairs in the map.
-pub fn[K, V] size(self : T[K, V]) -> Int {
+pub fn[K, V] size(self : SortedMap[K, V]) -> Int {
   self.size
 }
 
 ///|
 /// Clears the map.
-pub fn[K, V] clear(self : T[K, V]) -> Unit {
+pub fn[K, V] clear(self : SortedMap[K, V]) -> Unit {
   self.root = None
   self.size = 0
 }
 
 ///|
 /// Iterates the map.
-pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit raise?) -> Unit raise? {
+pub fn[K, V] each(
+  self : SortedMap[K, V],
+  f : (K, V) -> Unit raise?,
+) -> Unit raise? {
   fn dfs(root : Node[K, V]?) -> Unit raise? {
     if root is Some(root) {
       dfs(root.left)
@@ -143,7 +150,7 @@ pub fn[K, V] each(self : T[K, V], f : (K, V) -> Unit raise?) -> Unit raise? {
 ///|
 /// Iterates the map with index.
 pub fn[K, V] eachi(
-  self : T[K, V],
+  self : SortedMap[K, V],
   f : (Int, K, V) -> Unit raise?,
 ) -> Unit raise? {
   let mut i = 0
@@ -155,7 +162,7 @@ pub fn[K, V] eachi(
 
 ///|
 /// Returns all keys in the map.
-pub fn[K, V] keys_as_iter(self : T[K, V]) -> Iter[K] {
+pub fn[K, V] keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
   Iter::new(fn(yield_) {
     fn go(x : Node[K, V]?) {
       match x {
@@ -177,7 +184,7 @@ pub fn[K, V] keys_as_iter(self : T[K, V]) -> Iter[K] {
 
 ///|
 /// Returns all values in the map.
-pub fn[K, V] values_as_iter(self : T[K, V]) -> Iter[V] {
+pub fn[K, V] values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
   Iter::new(fn(yield_) {
     fn go(x : Node[K, V]?) {
       match x {
@@ -199,14 +206,14 @@ pub fn[K, V] values_as_iter(self : T[K, V]) -> Iter[V] {
 
 ///|
 /// Converts the map to an array.
-pub fn[K, V] to_array(self : T[K, V]) -> Array[(K, V)] {
+pub fn[K, V] to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
   let arr = Array::new(capacity=self.size)
   self.each((k, v) => arr.push((k, v)))
   arr
 }
 
 ///|
-pub fn[K, V] iter(self : T[K, V]) -> Iter[(K, V)] {
+pub fn[K, V] iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
   Iter::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
@@ -227,7 +234,7 @@ pub fn[K, V] iter(self : T[K, V]) -> Iter[(K, V)] {
 }
 
 ///|
-pub fn[K, V] iter2(self : T[K, V]) -> Iter2[K, V] {
+pub fn[K, V] iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
   Iter2::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
@@ -248,14 +255,14 @@ pub fn[K, V] iter2(self : T[K, V]) -> Iter2[K, V] {
 }
 
 ///|
-pub fn[K : Compare, V] from_iter(iter : Iter[(K, V)]) -> T[K, V] {
+pub fn[K : Compare, V] from_iter(iter : Iter[(K, V)]) -> SortedMap[K, V] {
   let m = new()
   iter.each(e => m[e.0] = e.1)
   m
 }
 
 ///|
-pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[
+pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for SortedMap[
   K,
   V,
 ] with arbitrary(size, rs) {
@@ -264,7 +271,11 @@ pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickc
 
 ///|
 ///Returns a new array of key-value pairs that are within the specified range [low, high].
-pub fn[K : Compare, V] range(self : T[K, V], low : K, high : K) -> Iter2[K, V] {
+pub fn[K : Compare, V] range(
+  self : SortedMap[K, V],
+  low : K,
+  high : K,
+) -> Iter2[K, V] {
   Iter2::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
@@ -456,7 +467,7 @@ fn[K : Compare, V] delete_node(
 
 ///|
 test "new" {
-  let map : T[Int, String] = new()
+  let map : SortedMap[Int, String] = new()
   inspect(map.debug_tree(), content="_")
   inspect(map.size(), content="0")
 }
@@ -607,6 +618,6 @@ test "clear" {
 }
 
 ///|
-pub impl[K, V] Default for T[K, V] with default() {
+pub impl[K, V] Default for SortedMap[K, V] with default() {
   new()
 }

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -31,7 +31,7 @@ test "remove3" {
 
 ///|
 test "remove on empty map" {
-  let map : @sorted_map.T[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
   map.remove(1)
   inspect(map.size(), content="0")
 }
@@ -98,7 +98,7 @@ test "op_equal" {
 
 ///|
 test "is_empty" {
-  let map : @sorted_map.T[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
   inspect(map.is_empty(), content="true")
   map[1] = "a"
   inspect(map.is_empty(), content="false")
@@ -189,13 +189,15 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @sorted_map.T[Int, Int] = @sorted_map.from_iter(Iter::empty())
+  let pq : @sorted_map.SortedMap[Int, Int] = @sorted_map.from_iter(
+    Iter::empty(),
+  )
   inspect(pq, content="@sorted_map.of([])")
 }
 
 ///|
 test "arbitrary" {
-  let map : Array[@sorted_map.T[Int, UInt]] = @quickcheck.samples(20)
+  let map : Array[@sorted_map.SortedMap[Int, UInt]] = @quickcheck.samples(20)
   inspect(
     map[5:10],
     content="[@sorted_map.of([]), @sorted_map.of([]), @sorted_map.of([(0, 0)]), @sorted_map.of([(0, 0)]), @sorted_map.of([(0, 0)])]",

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -6,46 +6,47 @@ import(
 )
 
 // Values
-fn[K : Compare, V] from_array(Array[(K, V)]) -> T[K, V]
+fn[K : Compare, V] from_array(Array[(K, V)]) -> SortedMap[K, V]
 
-fn[K : Compare, V] from_iter(Iter[(K, V)]) -> T[K, V]
+fn[K : Compare, V] from_iter(Iter[(K, V)]) -> SortedMap[K, V]
 
-fn[K, V] new() -> T[K, V]
+fn[K, V] new() -> SortedMap[K, V]
 
 #deprecated
-fn[K : Compare, V] of(Array[(K, V)]) -> T[K, V]
+fn[K : Compare, V] of(Array[(K, V)]) -> SortedMap[K, V]
 
 // Errors
 
 // Types and methods
-type T[K, V]
-fn[K : Compare, V] T::add(Self[K, V], K, V) -> Unit
-fn[K, V] T::clear(Self[K, V]) -> Unit
-fn[K : Compare, V] T::contains(Self[K, V], K) -> Bool
-fn[K, V] T::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
-fn[K, V] T::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
-fn[K : Compare, V] T::get(Self[K, V], K) -> V?
-fn[K, V] T::is_empty(Self[K, V]) -> Bool
-fn[K, V] T::iter(Self[K, V]) -> Iter[(K, V)]
-fn[K, V] T::iter2(Self[K, V]) -> Iter2[K, V]
+type SortedMap[K, V]
+fn[K : Compare, V] SortedMap::add(Self[K, V], K, V) -> Unit
+fn[K, V] SortedMap::clear(Self[K, V]) -> Unit
+fn[K : Compare, V] SortedMap::contains(Self[K, V], K) -> Bool
+fn[K, V] SortedMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
+fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
+fn[K : Compare, V] SortedMap::get(Self[K, V], K) -> V?
+fn[K, V] SortedMap::is_empty(Self[K, V]) -> Bool
+fn[K, V] SortedMap::iter(Self[K, V]) -> Iter[(K, V)]
+fn[K, V] SortedMap::iter2(Self[K, V]) -> Iter2[K, V]
 #deprecated
-fn[K, V] T::keys(Self[K, V]) -> Array[K]
-fn[K, V] T::keys_as_iter(Self[K, V]) -> Iter[K]
-fn[K : Compare, V] T::op_get(Self[K, V], K) -> V
-fn[K : Compare, V] T::op_set(Self[K, V], K, V) -> Unit
-fn[K : Compare, V] T::range(Self[K, V], K, K) -> Iter2[K, V]
-fn[K : Compare, V] T::remove(Self[K, V], K) -> Unit
-fn[K, V] T::size(Self[K, V]) -> Int
-fn[K, V] T::to_array(Self[K, V]) -> Array[(K, V)]
+fn[K, V] SortedMap::keys(Self[K, V]) -> Array[K]
+fn[K, V] SortedMap::keys_as_iter(Self[K, V]) -> Iter[K]
+fn[K : Compare, V] SortedMap::op_get(Self[K, V], K) -> V
+fn[K : Compare, V] SortedMap::op_set(Self[K, V], K, V) -> Unit
+fn[K : Compare, V] SortedMap::range(Self[K, V], K, K) -> Iter2[K, V]
+fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
+fn[K, V] SortedMap::size(Self[K, V]) -> Int
+fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
 #deprecated
-fn[K, V] T::values(Self[K, V]) -> Array[V]
-fn[K, V] T::values_as_iter(Self[K, V]) -> Iter[V]
-impl[K, V] Default for T[K, V]
-impl[K : Eq, V : Eq] Eq for T[K, V]
-impl[K : Show, V : Show] Show for T[K, V]
-impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for T[K, V]
+fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]
+fn[K, V] SortedMap::values_as_iter(Self[K, V]) -> Iter[V]
+impl[K, V] Default for SortedMap[K, V]
+impl[K : Eq, V : Eq] Eq for SortedMap[K, V]
+impl[K : Show, V : Show] Show for SortedMap[K, V]
+impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for SortedMap[K, V]
 
 // Type aliases
+pub typealias SortedMap as T
 
 // Traits
 

--- a/sorted_map/types.mbt
+++ b/sorted_map/types.mbt
@@ -22,7 +22,11 @@ priv struct Node[K, V] {
 }
 
 ///|
-struct T[K, V] {
+struct SortedMap[K, V] {
   mut root : Node[K, V]?
   mut size : Int
 }
+
+///|
+#deprecated("Use `SortedMap` instead of `T`")
+pub typealias SortedMap as T

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -53,7 +53,7 @@ fn[K : Show, V : Show] debug_node(self : Node[K, V]) -> String {
 }
 
 ///|
-fn[K : Show, V : Show] debug_tree(self : T[K, V]) -> String {
+fn[K : Show, V : Show] debug_tree(self : SortedMap[K, V]) -> String {
   match self.root {
     Some(root) => root.debug_node()
     None => "_"
@@ -61,6 +61,6 @@ fn[K : Show, V : Show] debug_tree(self : T[K, V]) -> String {
 }
 
 ///|
-pub impl[K : Show, V : Show] Show for T[K, V] with output(self, logger) {
+pub impl[K : Show, V : Show] Show for SortedMap[K, V] with output(self, logger) {
   logger.write_iter(self.iter(), prefix="@sorted_map.of([", suffix="])")
 }

--- a/sorted_set/types.mbt
+++ b/sorted_set/types.mbt
@@ -31,5 +31,5 @@ priv struct Node[V] {
 }
 
 ///|
-#deprecated("Use `Set` instead of `T`")
+#deprecated("Use `SortedSet` instead of `T`")
 pub typealias SortedSet as T


### PR DESCRIPTION
- **refactor(sorted_set): update deprecation message to suggest using `SortedSet` instead of `T`**
- **refactor(sorted_map): rename type T to SortedMap and update function signatures for consistency**
