### PR TITLE
fix: resolve json parse int/uint overflow issue

### DIFF
--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -54,6 +54,12 @@ pub impl FromJson for Int with from_json(json, path) {
     n != @double.neg_infinity else {
     decode_error(path, "Int::from_json: expected number")
   }
+  // Range check before conversion to avoid silent wrap/truncation
+  let max_ok = 2147483647.0
+  let min_ok = -2147483648.0
+  if n > max_ok || n < min_ok {
+    decode_error(path, "Int::from_json: overflow")
+  }
   n.to_int()
 }
 
@@ -75,6 +81,11 @@ pub impl FromJson for UInt with from_json(json, path) {
     n != @double.infinity &&
     n != @double.neg_infinity else {
     decode_error(path, "UInt::from_json: expected number")
+  }
+  // Range check before conversion to avoid silent wrap/truncation
+  let max_ok = 4294967295.0
+  if n < 0.0 || n > max_ok {
+    decode_error(path, "UInt::from_json: overflow")
   }
   n.to_uint()
 }

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -419,12 +419,51 @@ test "uint roundtrip" {
 
 ///|
 test "uint" {
+  // valid max
   let v : UInt = @json.from_json(Json::number(4294967295))
   inspect(v, content="4294967295")
-  let v : UInt = @json.from_json(Json::number(-1))
-  inspect(v, content="0")
-  let v : UInt = @json.from_json(Json::number(4294967296))
-  inspect(v, content="4294967295")
+  // negative should error
+  let neg_res : Result[UInt, _] = try? @json.from_json(Json::number(-1))
+  inspect(
+    neg_res,
+    content="Err(JsonDecodeError(($, \"UInt::from_json: overflow\")))",
+  )
+  // overflow should error
+  let ovf_res : Result[UInt, _] = try? @json.from_json(Json::number(4294967296))
+  inspect(
+    ovf_res,
+    content="Err(JsonDecodeError(($, \"UInt::from_json: overflow\")))",
+  )
+}
+
+///|
+test "Int from_json overflow should error" {
+  let json = @json.parse("2147483648") // INT_MAX + 1 for 32-bit
+  let res : Result[Int, _] = try? @json.from_json(json)
+  match res {
+    Ok(v) => fail("BUG: Int overflow not detected, decoded as \{v}")
+    Err(_) => ()
+  }
+}
+
+///|
+test "Int from_json negative overflow should error" {
+  let json = @json.parse("-2147483649") // INT_MIN - 1 for 32-bit
+  let res : Result[Int, _] = try? @json.from_json(json)
+  match res {
+    Ok(v) => fail("BUG: Int negative overflow not detected, decoded as \{v}")
+    Err(_) => ()
+  }
+}
+
+///|
+test "UInt from_json overflow should error" {
+  let json = @json.parse("4294967296") // UINT_MAX + 1 for 32-bit
+  let res : Result[UInt, _] = try? @json.from_json(json)
+  match res {
+    Ok(v) => fail("BUG: UInt overflow not detected, decoded as \{v}")
+    Err(_) => ()
+  }
 }
 
 ///|


### PR DESCRIPTION
 In current main branch, decoding JSON numbers outside the 32‑bit bounds silently truncated:

- Int: values > INT_MAX became INT_MAX, < INT_MIN became INT_MIN
- UInt: negatives became 0, > UINT_MAX became UINT_MAX

This could hide data corruption and make overflow undetectable. 

**Behavioral Difference (Breaking):**
- Code relying on previous clamping / wrap semantics will now receive JsonDecodeError.
- Negative JSON numbers for UInt now produce overflow (not “expected number”) to distinguish representation vs range errors.

**Rationale**
Fail‑fast on invalid data is safer and matches typical JSON decoding expectations in other ecosystems (Rust serde, Go encoding/json, etc.).