### PR TITLE
refactor: deprecate mutable operations in ArrayView and update documentation

### DIFF
--- a/array/README.mbt.md
+++ b/array/README.mbt.md
@@ -94,10 +94,6 @@ test "array views" {
   // Map view to new array
   let doubled = view.map(x => x * 2)
   inspect(doubled, content="[4, 6, 8]")
-
-  // Modify view in-place
-  view.map_inplace(x => x + 1)
-  inspect(arr, content="[1, 3, 4, 5, 5]")
 }
 ```
 

--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -85,6 +85,7 @@ fn[A] ArrayView::iter(Self[A]) -> Iter[A]
 fn[A] ArrayView::iter2(Self[A]) -> Iter2[Int, A]
 fn[A : @string.ToStringView] ArrayView::join(Self[A], @string.View) -> String
 fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
+#deprecated
 fn[T] ArrayView::map_inplace(Self[T], (T) -> T raise?) -> Unit raise?
 fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?
 fn[T] ArrayView::mapi_inplace(Self[T], (Int, T) -> T raise?) -> Unit raise?

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -310,12 +310,7 @@ pub fn[T, U] View::map(self : View[T], f : (T) -> U raise?) -> Array[U] raise? {
 ///|
 /// Maps a function over the elements of the array view in place.
 ///
-/// # Example
-/// ```mbt
-///   let v = [3, 4, 5]
-///   v[1:].map_inplace((x) => {x + 1})
-///   assert_eq(v, [3, 5, 6])
-/// ```
+#deprecated("ArrayView will be immutable, use Array if you need mutation")
 pub fn[T] View::map_inplace(self : View[T], f : (T) -> T raise?) -> Unit raise? {
   for i, v in self {
     self[i] = f(v)

--- a/array/view_test.mbt
+++ b/array/view_test.mbt
@@ -154,16 +154,6 @@ test "arrayview_map" {
 }
 
 ///|
-test "arrayview_map_inplace" {
-  let arr = [1, 2, 3]
-  arr[1:].map_inplace(x => x * 2)
-  inspect(arr.length(), content="3")
-  inspect(arr[0], content="1")
-  inspect(arr[1], content="4")
-  inspect(arr[2], content="6")
-}
-
-///|
 test "arrayview_mapi" {
   let arr = [1, 2, 3]
   let mapped = arr[1:].mapi((i, x) => i + x)

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -131,15 +131,8 @@ pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
 /// Throws a panic if `index` is negative or greater than or equal to the length
 /// of the array view.
 ///
-/// Example:
 ///
-/// ```moonbit
-///   let arr = [1, 2, 3, 4, 5]
-///   let view = arr[1:4] // view contains [2, 3, 4]
-///   view.op_set(1, 42)
-///   inspect(arr, content="[1, 2, 42, 4, 5]")
-/// ```
-///
+#deprecated("ArrayView will be immutable, use array if you need mutation")
 pub fn[T] ArrayView::op_set(
   self : ArrayView[T],
   index : Int,

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -29,14 +29,6 @@ test "op_get" {
 }
 
 ///|
-test "op_set" {
-  let v = [1, 2, 3][:]
-  inspect(v[1], content="2")
-  v[1] = 4
-  inspect(v[1], content="4")
-}
-
-///|
 test "swap" {
   let v = [1, 2, 3][:]
   inspect(v[1], content="2")

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -108,11 +108,6 @@ test "panic array_as_view_get_index_error" {
 }
 
 ///|
-test "panic array_as_view_set_index_error" {
-  [1, 2, 3][:][5] = 0
-}
-
-///|
 test "panic array_as_view_swap_index_error" {
   [1, 2, 3][:].swap(1, 9)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -161,6 +161,7 @@ fn[T] ArrayView::blit_to(Self[T], Self[T]) -> Unit
 fn[T] ArrayView::length(Self[T]) -> Int
 fn[T] ArrayView::op_as_view(Self[T], start? : Int, end? : Int) -> Self[T]
 fn[T] ArrayView::op_get(Self[T], Int) -> T
+#deprecated
 fn[T] ArrayView::op_set(Self[T], Int, T) -> Unit
 fn[T] ArrayView::swap(Self[T], Int, Int) -> Unit
 fn[T] ArrayView::unsafe_get(Self[T], Int) -> T


### PR DESCRIPTION
cc @Yu-zh 

