### PR TITLE
fix(builtin): Iter#take take one more element from iter

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -548,7 +548,7 @@ pub fn[T] Iter::take(self : Iter[T], n : Int) -> Iter[T] {
     let mut r = IterContinue
     self.just_run(a => {
       i = i + 1
-      guard yield_(a) == IterContinue else {
+      guard yield_(a) is IterContinue else {
         r = IterEnd
         return IterEnd
       }

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -545,16 +545,14 @@ pub fn[T] Iter::take(self : Iter[T], n : Int) -> Iter[T] {
     //
     let mut i = 0
     let mut r = IterContinue
-    self.just_run(a => if i < n {
-      if yield_(a) == IterContinue {
-        i = i + 1
-        IterContinue
-      } else {
+    self.just_run(a => {
+      i = i + 1
+      guard yield_(a) == IterContinue else {
         r = IterEnd
-        IterEnd
+        return IterEnd
       }
-    } else {
-      IterEnd
+      guard i < n else { return IterEnd }
+      IterContinue
     })
     r
   }

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -543,6 +543,7 @@ pub fn[T] Iter::take(self : Iter[T], n : Int) -> Iter[T] {
     // even if seq has less than 10 elements
     // but `for x in [..take(10,seq), next ] { break }` would stop
     //
+    guard n > 0 else { return IterContinue }
     let mut i = 0
     let mut r = IterContinue
     self.just_run(a => {

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -536,7 +536,7 @@ pub fn[T] Iter::tap(self : Iter[T], f : (T) -> Unit) -> Iter[T] {
 /// # Returns
 ///
 /// A new iterator that contains the first `n` elements.
-#intrinsic("%iter.take")
+// #intrinsic("%iter.take")
 pub fn[T] Iter::take(self : Iter[T], n : Int) -> Iter[T] {
   yield_ => {
     // [..take(10,seq), next] would continue

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -54,7 +54,7 @@ test "take" {
   let evaluated = []
   let collected = (1).until(20).tap(evaluated.push(_)).take(10).collect()
   inspect(collected, content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]")
-  inspect(evaluated, content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]")
+  inspect(evaluated, content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]")
   // take with concat
   let evaluated2 = []
   let collected2a = (1).until(20).tap(i => evaluated2.push("a\{i}")).take(5)
@@ -64,7 +64,8 @@ test "take" {
   inspect(
     evaluated2,
     content=(
-      #|["a1", "a2", "a3", "a4", "a5", "a6", "b1", "b2", "b3", "b4", "b5", "b6"]
+      #|["a1", "a2", "a3", "a4", "a5", "b1", "b2", "b3", "b4", "b5"]
+
     ),
   )
   // take 0 with concat
@@ -72,11 +73,12 @@ test "take" {
   let collected3a = (1).until(20).tap(i => evaluated3.push("a\{i}")).take(0)
   let collected3b = (1).until(20).tap(i => evaluated3.push("b\{i}")).take(5)
   let collected3 = collected3a.concat(collected3b).collect()
-  inspect(collected3, content="[1, 2, 3, 4, 5]")
+  inspect(collected3, content="[1, 1, 2, 3, 4, 5]")
   inspect(
     evaluated3,
     content=(
-      #|["a1", "b1", "b2", "b3", "b4", "b5", "b6"]
+      #|["a1", "b1", "b2", "b3", "b4", "b5"]
+
     ),
   )
 }

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -73,9 +73,12 @@ test "take" {
   let collected3b = (1).until(20).tap(i => evaluated3.push("b\{i}")).take(5)
   let collected3 = collected3a.concat(collected3b).collect()
   inspect(collected3, content="[1, 2, 3, 4, 5]")
-  inspect(evaluated3, content=(
-    #|["b1", "b2", "b3", "b4", "b5"]
-  ))
+  inspect(
+    evaluated3,
+    content=(
+      #|["b1", "b2", "b3", "b4", "b5"]
+    ),
+  )
 }
 
 ///|

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -65,7 +65,6 @@ test "take" {
     evaluated2,
     content=(
       #|["a1", "a2", "a3", "a4", "a5", "b1", "b2", "b3", "b4", "b5"]
-
     ),
   )
   // take 0 with concat
@@ -73,14 +72,10 @@ test "take" {
   let collected3a = (1).until(20).tap(i => evaluated3.push("a\{i}")).take(0)
   let collected3b = (1).until(20).tap(i => evaluated3.push("b\{i}")).take(5)
   let collected3 = collected3a.concat(collected3b).collect()
-  inspect(collected3, content="[1, 1, 2, 3, 4, 5]")
-  inspect(
-    evaluated3,
-    content=(
-      #|["a1", "b1", "b2", "b3", "b4", "b5"]
-
-    ),
-  )
+  inspect(collected3, content="[1, 2, 3, 4, 5]")
+  inspect(evaluated3, content=(
+    #|["b1", "b2", "b3", "b4", "b5"]
+  ))
 }
 
 ///|

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -50,6 +50,35 @@ test "take" {
   let exb = StringBuilder::new(size_hint=0)
   iter.take(3).each(x => exb.write_char(x))
   inspect(exb, content="123")
+  // normal take
+  let evaluated = []
+  let collected = (1).until(20).tap(evaluated.push(_)).take(10).collect()
+  inspect(collected, content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]")
+  inspect(evaluated, content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]")
+  // take with concat
+  let evaluated2 = []
+  let collected2a = (1).until(20).tap(i => evaluated2.push("a\{i}")).take(5)
+  let collected2b = (1).until(20).tap(i => evaluated2.push("b\{i}")).take(5)
+  let collected2 = collected2a.concat(collected2b).collect()
+  inspect(collected2, content="[1, 2, 3, 4, 5, 1, 2, 3, 4, 5]")
+  inspect(
+    evaluated2,
+    content=(
+      #|["a1", "a2", "a3", "a4", "a5", "a6", "b1", "b2", "b3", "b4", "b5", "b6"]
+    ),
+  )
+  // take 0 with concat
+  let evaluated3 = []
+  let collected3a = (1).until(20).tap(i => evaluated3.push("a\{i}")).take(0)
+  let collected3b = (1).until(20).tap(i => evaluated3.push("b\{i}")).take(5)
+  let collected3 = collected3a.concat(collected3b).collect()
+  inspect(collected3, content="[1, 2, 3, 4, 5]")
+  inspect(
+    evaluated3,
+    content=(
+      #|["a1", "b1", "b2", "b3", "b4", "b5", "b6"]
+    ),
+  )
 }
 
 ///|


### PR DESCRIPTION
# Description
In the current implementation, `Iter#take` take an extra element out of the iter. This may lead to extra overhead, expensive resource initialization or race condition in state-shared iterators.

# Reproduction
```moonbit
fn[T] Iter::take_fix(self : Iter[T], n : Int) -> Iter[T] {
  Iter::new(yield_ => {
    // [..take(10,seq), next] would continue
    // even if seq has less than 10 elements
    // but `for x in [..take(10,seq), next ] { break }` would stop
    //
    let mut i = 0
    let mut r = IterContinue
    self.just_run(a => {
      i = i + 1
      guard yield_(a) == IterContinue else { 
        r = IterEnd
        return IterEnd 
      }
      guard i < n else { return IterEnd }
      IterContinue
    })
    r
  })
}

///|
test "hot take" {
  struct s {
    mut i : Int
  }
  let s = s::{ i: 0 }
  let iter = Iter::new(c => while s.i < 5 {
    s.i = s.i + 1
    guard c(s.i) is IterContinue else { return IterEnd }
  } else {
    IterEnd
  })
  println("take by for loop")
  for tk2 in iter {
    println(tk2)
    for take1 in iter {
      println(take1)
      break;
    }
    for take1 in iter {
      println(take1)
      break;
    }
    break;
  }

  s.i = 0;
  println("take 1:")
  for tk2 in iter {
    println(tk2)
    println(iter.take(1).to_array())
    println(iter.take(1).to_array())
    break;
  }

  s.i = 0;
  println("take 1 fix:")
  for tk2 in iter {
    println(tk2)
    println(iter.take_fix(1).to_array())
    println(iter.take_fix(1).to_array())
    break;
  }
  ///|
  let iter = ['1', '2', '3', '4', '5'].iter()
  let exb = StringBuilder::new(size_hint=0)
  iter.take(3).each(x => exb.write_char(x))
  inspect(exb, content="123")
}
```

Output:
```
take by for loop
1
2
3
take 1:
1
[2]
[4]
take 1 fix:
1
[2]
[3]
Total tests: 1, passed: 1, failed: 0.
```