### PR TITLE
deprecate: `Result::fold`

### DIFF
--- a/result/pkg.generated.mbti
+++ b/result/pkg.generated.mbti
@@ -17,6 +17,7 @@ fn[T, E] ok(T) -> Result[T, E]
 // Types and methods
 fn[T, E, U] Result::bind(Self[T, E], (T) -> Self[U, E]) -> Self[U, E]
 fn[T, E] Result::flatten(Self[Self[T, E], E]) -> Self[T, E]
+#deprecated
 fn[T, E, V] Result::fold(Self[T, E], (T) -> V, (E) -> V) -> V
 #deprecated
 fn[T, E] Result::is_err(Self[T, E]) -> Bool

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -178,31 +178,12 @@ test "bind" {
 }
 
 ///|
-/// Folds a `Result` into a single value.
-///
-/// If the `Result` is an `Ok`, the `ok` function is applied to the value. If the `Result` is an `Err`, the `err` function is applied to the value.
-/// # Example
-///
-/// ```mbt
-///   let x = Ok(6)
-///   let y = x.fold((v : Int) => { v * 7 }, (_e : String) => { 0 })
-///   assert_eq(y, 42)
-/// ```
+#deprecated("use `match result { Ok(value) => ok(value); Err(error) => err(error) }` instead")
 pub fn[T, E, V] fold(self : Result[T, E], ok : (T) -> V, err : (E) -> V) -> V {
   match self {
     Ok(value) => ok(value)
     Err(error) => err(error)
   }
-}
-
-///|
-test "fold" {
-  let x : Result[Int, String] = Ok(6)
-  let y = x.fold((v : Int) => v * 7, (_e : String) => 0)
-  let z : Result[Int, String] = Err("error")
-  let w = z.fold((v : Int) => v * 7, (_e : String) => 0)
-  assert_eq(y, 42)
-  assert_eq(w, 0)
 }
 
 ///|


### PR DESCRIPTION
`Result::fold` is inconsistent with other `fold` function such as `Array::fold` and `Iter::fold`.

```moonbit
pub fn[T, E, V] fold(self : Result[T, E], ok : (T) -> V, err : (E) -> V) -> V
```

here is corrected MoonBit version

```moonbit
fn [A,E,B] Result::fold_(self : Result[A,E], init~ : B, f : (B,A) -> B) -> B {
  match self {
    Ok(value) => f(init, value)
    Err(_) => init
  }
}
```

Haskell `Either` instance of `Foldable` is similar to this.

here is an example usage for `Either` foldl in Haskell

```haskell
foldl (\acc x -> acc + x) 10 (Right 5)
-- Result: 15
```