### PR TITLE
Add missing unwrap methods to Result type for API alignment with Option

### DIFF
--- a/result/pkg.generated.mbti
+++ b/result/pkg.generated.mbti
@@ -30,6 +30,9 @@ fn[T, E] Result::or_else(Self[T, E], () -> T) -> T
 fn[T, E] Result::to_option(Self[T, E]) -> T?
 fn[T, E] Result::unwrap(Self[T, E]) -> T
 fn[T, E] Result::unwrap_err(Self[T, E]) -> E
+fn[T, E] Result::unwrap_or(Self[T, E], T) -> T
+fn[T : Default, E] Result::unwrap_or_default(Self[T, E]) -> T
+fn[T, E] Result::unwrap_or_else(Self[T, E], () -> T raise?) -> T raise?
 fn[T, E : Error] Result::unwrap_or_error(Self[T, E]) -> T raise E
 impl[T : Compare, E : Compare] Compare for Result[T, E]
 impl[T : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Result[T, E]

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -294,6 +294,62 @@ test "show" {
 }
 
 ///|
+/// Return the contained `Ok` value or the provided default.
+pub fn[T, E] Result::unwrap_or(self : Result[T, E], default : T) -> T {
+  match self {
+    Ok(value) => value
+    Err(_) => default
+  }
+}
+
+///|
+test "unwrap_or" {
+  let x : Result[Int, String] = Ok(3)
+  let y : Result[Int, String] = Err("error")
+  assert_eq(x.unwrap_or(5), 3)
+  assert_eq(y.unwrap_or(5), 5)
+}
+
+///|
+/// Return the contained `Ok` value or the provided default.
+///
+/// Default is lazily evaluated
+pub fn[T, E] Result::unwrap_or_else(
+  self : Result[T, E],
+  default : () -> T raise?,
+) -> T raise? {
+  match self {
+    Ok(value) => value
+    Err(_) => default()
+  }
+}
+
+///|
+test "unwrap_or_else" {
+  let x : Result[Int, String] = Ok(3)
+  let y : Result[Int, String] = Err("error")
+  assert_eq(x.unwrap_or_else(() => 5), 3)
+  assert_eq(y.unwrap_or_else(() => 5), 5)
+}
+
+///|
+/// Return the contained `Ok` value or the result of the `T::default()`.
+pub fn[T : Default, E] Result::unwrap_or_default(self : Result[T, E]) -> T {
+  match self {
+    Ok(value) => value
+    Err(_) => T::default()
+  }
+}
+
+///|
+test "unwrap_or_default" {
+  let x : Result[Int, String] = Ok(3)
+  let y : Result[Int, String] = Err("error")
+  assert_eq(x.unwrap_or_default(), 3)
+  assert_eq(y.unwrap_or_default(), 0)
+}
+
+///|
 pub fn[T, E : Error] unwrap_or_error(self : Result[T, E]) -> T raise E {
   match self {
     Ok(x) => x


### PR DESCRIPTION
**Problem:** The `Result` type was missing three helper functions that exist in `Option`, creating an inconsistency in the API:

* unwrap_or
* unwrap_or_else
* unwrap_or_default

**Solution:** This PR adds the three missing methods to align the `Result` API with `Option`:

* fn[T,E] Result::unwrap_or(Result[T,E], T) -> T - Returns the contained Ok value or the provided default
* fn[T,E] Result::unwrap_or_else(Result[T,E], () -> T raise?) -> T raise? - Returns the contained Ok value or calls the provided closure (lazily evaluated)
* fn[T : Default,E] Result::unwrap_or_default(Result[T,E]) -> T - Returns the contained Ok value or T::default()

**Justification:** Since `Option[T]` and `Result[T, Unit]` are equivalent, having consistent APIs between these types improves developer experience and maintains API coherence.

**Testing:** All three methods include comprehensive unit tests covering both Ok and Err cases.

close: #2681 