### PR TITLE
docs: `Array::push_iter`

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -47,6 +47,8 @@ pub fn[T] Array::from_iter(iter : Iter[T]) -> Array[T] {
 ///   assert_eq(u, [1, 2, 3, 4, 5, 6])
 /// ```
 pub fn[T] Array::push_iter(self : Self[T], iter : Iter[T]) -> Unit {
+  // This function used by [Array spread operator](https://docs.moonbitlang.com/en/latest/language/fundamentals.html#spread-operator)
+  // it can't be removed and deprecated
   for x in iter {
     self.push(x)
   }


### PR DESCRIPTION
moonc uses `Array::push_iter` for intrinsic implementation. Removing `Array::push_iter` causes mysterious errors in moonc.

https://github.com/illusory0x0/core.mbt/commit/54ef68d659dd4aa7bd65fc7f4259c72ed81a9608