### PR TITLE
fix: explicitly impl bitwise operators for `Int` and `UInt`

### DIFF
--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -348,7 +348,7 @@ pub fn Int::lnot(self : Int) -> Int = "%i32_lnot"
 ///   let y = 0xAA // 10101010
 ///   inspect(x & y, content="160") // 10100000 = 160
 /// ```
-pub fn Int::land(self : Int, other : Int) -> Int = "%i32_land"
+pub impl BitAnd for Int with land(self : Int, other : Int) -> Int = "%i32_land"
 
 ///|
 /// Performs a bitwise OR operation between two 32-bit integers. For each bit
@@ -370,7 +370,7 @@ pub fn Int::land(self : Int, other : Int) -> Int = "%i32_land"
 ///   let y = 0x0F0F // 0000_1111_0000_1111
 ///   inspect(x | y, content="65535") // 1111_1111_1111_1111 = 65535
 /// ```
-pub fn Int::lor(self : Int, other : Int) -> Int = "%i32_lor"
+pub impl BitOr for Int with lor(self : Int, other : Int) -> Int = "%i32_lor"
 
 ///|
 /// Performs a bitwise XOR operation between two integers.
@@ -391,7 +391,7 @@ pub fn Int::lor(self : Int, other : Int) -> Int = "%i32_lor"
 ///   inspect(x ^ y, content="65535") // 1111_1111_1111_1111
 ///   inspect(x ^ x, content="0") // XOR with self gives 0
 /// ```
-pub fn Int::lxor(self : Int, other : Int) -> Int = "%i32_lxor"
+pub impl BitXOr for Int with lxor(self : Int, other : Int) -> Int = "%i32_lxor"
 
 ///|
 /// Performs a left shift operation on a 32-bit integer. Shifts each bit in the
@@ -1901,7 +1901,7 @@ pub impl Compare for UInt with compare(self, other) = "%u32.compare"
 ///   let b = 0xFF00U // 1111_1111_0000_0000
 ///   inspect(a & b, content="61440") // 1111_0000_0000_0000 = 61440
 /// ```
-pub fn UInt::land(self : UInt, other : UInt) -> UInt = "%u32.bitand"
+pub impl BitAnd for UInt with land(self : UInt, other : UInt) -> UInt = "%u32.bitand"
 
 ///|
 /// Performs a bitwise OR operation between two unsigned 32-bit integers. For
@@ -1922,7 +1922,7 @@ pub fn UInt::land(self : UInt, other : UInt) -> UInt = "%u32.bitand"
 ///   let b = 0x0F0FU // Binary: 0000_1111_0000_1111
 ///   inspect(a | b, content="65535") // Binary: 1111_1111_1111_1111
 /// ```
-pub fn UInt::lor(self : UInt, other : UInt) -> UInt = "%u32.bitor"
+pub impl BitOr for UInt with lor(self : UInt, other : UInt) -> UInt = "%u32.bitor"
 
 ///|
 /// Performs a bitwise XOR (exclusive OR) operation between two unsigned 32-bit
@@ -1943,7 +1943,7 @@ pub fn UInt::lor(self : UInt, other : UInt) -> UInt = "%u32.bitor"
 ///   let b = 0x0F0FU // Binary: 0000_1111_0000_1111
 ///   inspect(a ^ b, content="61455") // Binary: 1111_0000_0000_1111
 /// ```
-pub fn UInt::lxor(self : UInt, other : UInt) -> UInt = "%u32.bitxor"
+pub impl BitXOr for UInt with lxor(self : UInt, other : UInt) -> UInt = "%u32.bitxor"
 
 ///|
 /// Performs a bitwise NOT operation on an unsigned 32-bit integer. Flips all

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -368,14 +368,11 @@ fn Int::is_non_pos(Int) -> Bool
 fn Int::is_pos(Int) -> Bool
 fn Int::is_surrogate(Int) -> Bool
 fn Int::is_trailing_surrogate(Int) -> Bool
-fn Int::land(Int, Int) -> Int
 fn Int::lnot(Int) -> Int
-fn Int::lor(Int, Int) -> Int
 #deprecated
 fn Int::lsl(Int, Int) -> Int
 #deprecated
 fn Int::lsr(Int, Int) -> Int
-fn Int::lxor(Int, Int) -> Int
 fn Int::max(Int, Int) -> Int
 fn Int::min(Int, Int) -> Int
 fn Int::next_power_of_two(Int) -> Int
@@ -438,14 +435,11 @@ fn Int64::upto(Int64, Int64, inclusive? : Bool) -> Iter[Int64]
 
 fn UInt::clz(UInt) -> Int
 fn UInt::ctz(UInt) -> Int
-fn UInt::land(UInt, UInt) -> UInt
 fn UInt::lnot(UInt) -> UInt
-fn UInt::lor(UInt, UInt) -> UInt
 #deprecated
 fn UInt::lsl(UInt, Int) -> UInt
 #deprecated
 fn UInt::lsr(UInt, Int) -> UInt
-fn UInt::lxor(UInt, UInt) -> UInt
 fn UInt::op_neq(UInt, UInt) -> Bool
 fn UInt::popcnt(UInt) -> Int
 fn UInt::reinterpret_as_float(UInt) -> Float
@@ -606,21 +600,27 @@ pub(open) trait BitAnd {
   land(Self, Self) -> Self
 }
 impl BitAnd for Byte
+impl BitAnd for Int
 impl BitAnd for Int64
+impl BitAnd for UInt
 impl BitAnd for UInt64
 
 pub(open) trait BitOr {
   lor(Self, Self) -> Self
 }
 impl BitOr for Byte
+impl BitOr for Int
 impl BitOr for Int64
+impl BitOr for UInt
 impl BitOr for UInt64
 
 pub(open) trait BitXOr {
   lxor(Self, Self) -> Self
 }
 impl BitXOr for Byte
+impl BitXOr for Int
 impl BitXOr for Int64
+impl BitXOr for UInt
 impl BitXOr for UInt64
 
 pub(open) trait Compare : Eq {


### PR DESCRIPTION
Before patching, the last line below will fail to compile, with the error ``Type UInt does not implement trait BitXOr: no `impl` is defined (E4018)``

```moonbit
fn[T: BitXOr] foo(x : T, y : T) -> T {
  x ^ y
}

test {
  let x: UInt = 1
  let y: UInt = 2
  inspect(x ^ y, content="3")
  inspect(foo(x, y), content="3")
}
```

Given that `Int` and `UInt` already implement other arithmetic operators explicitly, e.g., `pub impl Add for Int with add(self, other) = "%i32_add"`, I propose also implementing the bitwise operators.