### PR TITLE
In String::make, add length overflow protection

### DIFF
--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -22,7 +22,7 @@ fn unsafe_make_string(length : Int, value : Char) -> String = "$moonbit.unsafe_m
 ///   assert_eq(String::make(5,'S'), "SSSSS")
 /// ```
 pub fn String::make(length : Int, value : Char) -> String {
-  guard length >= 0 else { abort("invalid length") }
+  guard length >= 0 && length < 536870900 else { abort("invalid length") }
   if value.to_int() <= 0xFFFF {
     unsafe_make_string(length, value)
   } else {

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -87,6 +87,11 @@ test "String::make with zero length" {
 }
 
 ///|
+test "String::make with huge length" {
+  assert_eq(String::make(536870899, 'a').length(), 536870899)
+}
+
+///|
 test "panic codepoint_length with invalid surrogate pair" {
   // Create a string with a leading surrogate (0xD800) followed by an invalid trailing surrogate
   let s = String::from_array([


### PR DESCRIPTION
In String::make, add length overflow protection to prevent creating excessively large strings, which could cause out-of-memory errors or integer overflow