### PR TITLE
fix: add `@test.T::name()` method

### DIFF
--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -38,6 +38,7 @@ pub(all) struct T {
 }
 #deprecated
 fn T::bench(Self, () -> Unit, count? : UInt) -> Unit raise BenchError
+fn T::name(Self) -> String
 #callsite(autofill(args_loc, loc))
 fn T::snapshot(Self, filename~ : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise SnapshotError
 fn T::write(Self, &Show) -> Unit

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -123,3 +123,7 @@ pub fn snapshot(
 }
 
 ///|
+/// Return the name of the test.
+pub fn T::name(self : Self) -> String {
+  self.name
+}


### PR DESCRIPTION
I found that `@test.T::name` is useful for snapshot testing scenarios:

```mbt
/// a local method
fn @test.T::run(self : Self) -> Unit raise {
  let input = @fs.read_from_file(base_path + self.name + ".input")
  let result = process(input)
  self.writeln(result)
  self.snapshot(self.name + ".output")
}

test "file1" (t : @test.T) { t.run() }
test "file2" (t : @test.T) { t.run() }
test "file3" (t : @test.T) { t.run() }
```

Following this pattern, it's convenient to add snapshot tests for new input files. Since `@test.T` will likely become an abstract type in the future, let's introduce a `@test.T::name()` method to keep this practice available.