### PR TITLE
fix: normalize zero result in grade_school_mul to single-limb zero

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -368,7 +368,7 @@ fn BigInt::grade_school_mul(self : BigInt, other : BigInt) -> BigInt {
       carry = product / radix
     }
   }
-  if limbs[self_len + other_len - 1] == 0 {
+  while len > 1 && limbs[len - 1] == 0 {
     len -= 1
   }
   { limbs, sign: Positive, len }
@@ -1844,4 +1844,14 @@ test "limb length" {
 ///|
 fn BigInt::limbs(self : Self) -> Iter[UInt] {
   self.limbs.iter().take(self.len)
+}
+
+///|
+test "algorithm_edge_cases" {
+  // Test with zero
+  let zero = 0N
+  let large = BigInt::from_string("123456789012345678901234567890")
+  assert_true(zero.grade_school_mul(large) == zero)
+  assert_true(zero.karatsuba_mul(large) == zero)
+  assert_true(zero * large == zero)
 }


### PR DESCRIPTION
## Reason

`BigInt::grade_school_mul` returned a non-normalized zero when the product was zero: it only trimmed at most one leading zero limb, potentially leaving extra leading zero limbs. This violates the BigInt invariants (zero must be represented as a single limb with value 0), causing direct calls to `grade_school_mul` to compare unequal to the canonical `zero`.

Relevant invariant and failing behavior:
```mbt
// Invariants:
// - len > 0
// - forall 0 <= i < len. 0 <= limbs[i] < radix
// - (exists 0 <= i < len. limbs[i] > 0) => limbs[len-1] > 0
// - (forall 0 <= i < len. limbs[i] == 0) => limbs[0] == 0 and len == 1
// - forall len <= i < limbs.length(). limbs[i] == 0
struct BigInt {
  limbs : FixedArray[UInt]
  sign : Sign
  len : Int
}
```

## What I changed

Normalize zero results in `grade_school_mul` by trimming all leading zero limbs, keeping at least one limb:
```mbt
fn BigInt::grade_school_mul(self : BigInt, other : BigInt) -> BigInt {
  let self_len = self.len
  let other_len = other.len
  let mut len = self_len + other_len
  let limbs = FixedArray::make(len, 0U)
  for i in 0..<self_len {
    let mut carry = 0UL
    for j = 0; j < other_len || carry != 0; j = j + 1 {
      let product = limbs[i + j].to_uint64() +
        self.limbs[i].to_uint64() *
        (if j < other_len { other.limbs[j].to_uint64() } else { 0 }) +
        carry
      limbs[i + j] = (product % radix).to_uint()
      carry = product / radix
    }
  }
  // NOTE HERE
  while len > 1 && limbs[len - 1] == 0 {
    len -= 1
  }
  { limbs, sign: Positive, len }
}
```

## Why `assert_true(zero * large == zero)` passed while `assert_true(zero.grade_school_mul(large) == zero)` failed

The `Mul` implementation short-circuits on zero before choosing an algorithm, returning the canonical `zero` directly:
```mbt
pub impl Mul for BigInt with mul(self : BigInt, other : BigInt) -> BigInt {
  // NOTE HERE
  if self.is_zero() || other.is_zero() {
    return zero
  }
  let ret = if self.len < karatsuba_threshold || other.len < karatsuba_threshold {
    self.grade_school_mul(other)
  } else {
    self.karatsuba_mul(other)
  }
  { ..ret, sign: if self.sign == other.sign { Positive } else { Negative } }
}
```