### PR TITLE
fix: correct termination condition for positive integer encoding

### DIFF
--- a/buffer/sleb128.mbt
+++ b/buffer/sleb128.mbt
@@ -24,7 +24,7 @@ pub impl Leb128 for Int with output(self, buffer) {
     let next_value = value >> 7 // Arithmetic right shift
     let sign_bit_set = (byte & 0x40) != 0
     let need_more = if value >= 0 {
-      next_value != 0
+      next_value != 0 || sign_bit_set
     } else {
       next_value != -1 || !sign_bit_set
     }
@@ -45,7 +45,7 @@ pub impl Leb128 for Int64 with output(self, buffer) {
     let next_value = value >> 7 // Arithmetic right shift
     let sign_bit_set = (byte & 0x40) != 0
     let need_more = if value >= 0 {
-      next_value != 0
+      next_value != 0 || sign_bit_set
     } else {
       next_value != -1 || !sign_bit_set
     }

--- a/buffer/sleb128_test.mbt
+++ b/buffer/sleb128_test.mbt
@@ -54,11 +54,11 @@ test "write_leb128 Int" {
   buffer.test_leb128(129)
   assert_eq(buffer.to_bytes(), b"\x81\x01")
   buffer.test_leb128(16383)
-  assert_eq(buffer.to_bytes(), b"\xff\x7f")
+  assert_eq(buffer.to_bytes(), b"\xff\xff\x00")
   buffer.test_leb128(16384)
   assert_eq(buffer.to_bytes(), b"\x80\x80\x01")
   buffer.test_leb128(2097151)
-  assert_eq(buffer.to_bytes(), b"\xff\xff\x7f")
+  assert_eq(buffer.to_bytes(), b"\xff\xff\xff\x00")
 }
 
 ///|
@@ -68,7 +68,7 @@ test "write_leb128 Int64" {
   assert_eq(buffer.to_bytes(), b"\x00")
   buffer.reset()
   buffer.write_leb128(127L)
-  assert_eq(buffer.to_bytes(), b"\x7f")
+  assert_eq(buffer.to_bytes(), b"\xff\x00")
   buffer.reset()
   buffer.write_leb128(128L)
   assert_eq(buffer.to_bytes(), b"\x80\x01")
@@ -77,13 +77,13 @@ test "write_leb128 Int64" {
   assert_eq(buffer.to_bytes(), b"\x81\x01")
   buffer.reset()
   buffer.write_leb128(16383L)
-  assert_eq(buffer.to_bytes(), b"\xff\x7f")
+  assert_eq(buffer.to_bytes(), b"\xff\xff\x00")
   buffer.reset()
   buffer.write_leb128(16384L)
   assert_eq(buffer.to_bytes(), b"\x80\x80\x01")
   buffer.reset()
   buffer.write_leb128(2097151L)
-  assert_eq(buffer.to_bytes(), b"\xff\xff\x7f")
+  assert_eq(buffer.to_bytes(), b"\xff\xff\xff\x00")
 }
 
 ///|


### PR DESCRIPTION
The previous termination condition was incorrect.  
If the last 7-bit block of a positive number is ≥ 64, ending the encoding immediately can cause the decoder to interpret it as a negative number.  
To prevent this, append a 0x00 byte after the last block.