### PR TITLE
Support bitstring operation for FixedArray[Byte]

### DIFF
--- a/array/bitstring.mbt
+++ b/array/bitstring.mbt
@@ -366,3 +366,73 @@ pub fn Array::unsafe_extract_bytesview(
 ) -> ArrayView[Byte] {
   bs[:].unsafe_extract_bytesview(offset, len)
 }
+
+///|
+#internal(experimental, "subject to breaking change without notice")
+pub fn FixedArray::unsafe_extract_bit(
+  bs : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt {
+  bs[:].unsafe_extract_bit(offset, len)
+}
+
+///|
+#internal(experimental, "subject to breaking change without notice")
+pub fn FixedArray::unsafe_extract_byte(
+  bs : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt {
+  bs[:].unsafe_extract_byte(offset, len)
+}
+
+///|
+#internal(experimental, "subject to breaking change without notice")
+pub fn FixedArray::unsafe_extract_uint_le(
+  bs : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt {
+  bs[:].unsafe_extract_uint_le(offset, len)
+}
+
+///|
+#internal(experimental, "subject to breaking change without notice")
+pub fn FixedArray::unsafe_extract_uint_be(
+  bs : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt {
+  bs[:].unsafe_extract_uint_be(offset, len)
+}
+
+///|
+#internal(experimental, "subject to breaking change without notice")
+pub fn FixedArray::unsafe_extract_uint64_le(
+  bs : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt64 {
+  bs[:].unsafe_extract_uint64_le(offset, len)
+}
+
+///|
+#internal(experimental, "subject to breaking change without notice")
+pub fn FixedArray::unsafe_extract_uint64_be(
+  bs : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt64 {
+  bs[:].unsafe_extract_uint64_be(offset, len)
+}
+
+///|
+#internal(experimental, "subject to breaking change without notice")
+pub fn FixedArray::unsafe_extract_bytesview(
+  bs : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> ArrayView[Byte] {
+  bs[:].unsafe_extract_bytesview(offset, len)
+}

--- a/array/bitstring_test.mbt
+++ b/array/bitstring_test.mbt
@@ -166,3 +166,297 @@ test "extract view" {
     }
   }
 }
+
+///|
+test "FixedArray extract bit" {
+  let bs1 = b"\x89\xab\xcd\xef"
+  let bs2 : Array[Byte] = bs1.to_array()
+  let bs3 : FixedArray[Byte] = FixedArray::from_array(bs2)
+  
+  for i in 0..=(bs1.length() * 8 - 1) {
+    assert_eq(bs3.unsafe_extract_bit(i, 1), bs2.unsafe_extract_bit(i, 1))
+    assert_eq(bs3.unsafe_extract_bit(i, 1), bs1.unsafe_extract_bit(i, 1))
+  }
+}
+
+///|
+test "FixedArray extract byte" {
+  let bs1 = b"\x89\xab\xcd\xef"
+  let bs2 : Array[Byte] = bs1.to_array()
+  let bs3 : FixedArray[Byte] = FixedArray::from_array(bs2)
+  
+  for i in 0..=(bs1.length() * 8 - 8) {
+    assert_eq(bs3.unsafe_extract_byte(i, 2), bs2.unsafe_extract_byte(i, 2))
+    assert_eq(bs3.unsafe_extract_byte(i, 3), bs2.unsafe_extract_byte(i, 3))
+    assert_eq(bs3.unsafe_extract_byte(i, 4), bs2.unsafe_extract_byte(i, 4))
+    assert_eq(bs3.unsafe_extract_byte(i, 5), bs2.unsafe_extract_byte(i, 5))
+    assert_eq(bs3.unsafe_extract_byte(i, 8), bs2.unsafe_extract_byte(i, 8))
+    
+    assert_eq(bs3.unsafe_extract_byte(i, 2), bs1.unsafe_extract_byte(i, 2))
+    assert_eq(bs3.unsafe_extract_byte(i, 3), bs1.unsafe_extract_byte(i, 3))
+    assert_eq(bs3.unsafe_extract_byte(i, 4), bs1.unsafe_extract_byte(i, 4))
+    assert_eq(bs3.unsafe_extract_byte(i, 5), bs1.unsafe_extract_byte(i, 5))
+    assert_eq(bs3.unsafe_extract_byte(i, 8), bs1.unsafe_extract_byte(i, 8))
+  }
+}
+
+///|
+test "FixedArray extract int32" {
+  let bs1 = b"\x89\xab\xcd\xef\x01\x23\x45\x67"
+  let bs2 : Array[Byte] = bs1.to_array()
+  let bs3 : FixedArray[Byte] = FixedArray::from_array(bs2)
+  
+  for i in 0..=(bs1.length() * 8 - 32) {
+    // Test big-endian extraction
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 9),
+      bs2.unsafe_extract_uint_be(i, 9),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 12),
+      bs2.unsafe_extract_uint_be(i, 12),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 16),
+      bs2.unsafe_extract_uint_be(i, 16),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 23),
+      bs2.unsafe_extract_uint_be(i, 23),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 24),
+      bs2.unsafe_extract_uint_be(i, 24),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 32),
+      bs2.unsafe_extract_uint_be(i, 32),
+    )
+    
+    // Test little-endian extraction
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 9),
+      bs2.unsafe_extract_uint_le(i, 9),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 12),
+      bs2.unsafe_extract_uint_le(i, 12),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 16),
+      bs2.unsafe_extract_uint_le(i, 16),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 23),
+      bs2.unsafe_extract_uint_le(i, 23),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 24),
+      bs2.unsafe_extract_uint_le(i, 24),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 32),
+      bs2.unsafe_extract_uint_le(i, 32),
+    )
+    
+    // Also test against BytesView
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 9),
+      bs1.unsafe_extract_uint_be(i, 9),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 12),
+      bs1.unsafe_extract_uint_be(i, 12),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 16),
+      bs1.unsafe_extract_uint_be(i, 16),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 23),
+      bs1.unsafe_extract_uint_be(i, 23),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 24),
+      bs1.unsafe_extract_uint_be(i, 24),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_be(i, 32),
+      bs1.unsafe_extract_uint_be(i, 32),
+    )
+    
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 9),
+      bs1.unsafe_extract_uint_le(i, 9),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 12),
+      bs1.unsafe_extract_uint_le(i, 12),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 16),
+      bs1.unsafe_extract_uint_le(i, 16),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 23),
+      bs1.unsafe_extract_uint_le(i, 23),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 24),
+      bs1.unsafe_extract_uint_le(i, 24),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint_le(i, 32),
+      bs1.unsafe_extract_uint_le(i, 32),
+    )
+  }
+}
+
+///|
+test "FixedArray extract int64" {
+  let bs1 = b"\x89\xab\xcd\xef\x01\x23\x45\x67\x01\x23\x45\x67\x89\xab\xcd\xef"
+  let bs2 : Array[Byte] = bs1.to_array()
+  let bs3 : FixedArray[Byte] = FixedArray::from_array(bs2)
+  
+  for i in 0..=(bs1.length() * 8 - 64) {
+    // Test big-endian extraction
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 33),
+      bs2.unsafe_extract_uint64_be(i, 33),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 40),
+      bs2.unsafe_extract_uint64_be(i, 40),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 45),
+      bs2.unsafe_extract_uint64_be(i, 45),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 48),
+      bs2.unsafe_extract_uint64_be(i, 48),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 56),
+      bs2.unsafe_extract_uint64_be(i, 56),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 64),
+      bs2.unsafe_extract_uint64_be(i, 64),
+    )
+    
+    // Test little-endian extraction
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 33),
+      bs2.unsafe_extract_uint64_le(i, 33),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 40),
+      bs2.unsafe_extract_uint64_le(i, 40),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 45),
+      bs2.unsafe_extract_uint64_le(i, 45),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 48),
+      bs2.unsafe_extract_uint64_le(i, 48),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 56),
+      bs2.unsafe_extract_uint64_le(i, 56),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 64),
+      bs2.unsafe_extract_uint64_le(i, 64),
+    )
+    
+    // Also test against BytesView
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 33),
+      bs1.unsafe_extract_uint64_be(i, 33),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 40),
+      bs1.unsafe_extract_uint64_be(i, 40),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 45),
+      bs1.unsafe_extract_uint64_be(i, 45),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 48),
+      bs1.unsafe_extract_uint64_be(i, 48),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 56),
+      bs1.unsafe_extract_uint64_be(i, 56),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_be(i, 64),
+      bs1.unsafe_extract_uint64_be(i, 64),
+    )
+    
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 33),
+      bs1.unsafe_extract_uint64_le(i, 33),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 40),
+      bs1.unsafe_extract_uint64_le(i, 40),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 45),
+      bs1.unsafe_extract_uint64_le(i, 45),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 48),
+      bs1.unsafe_extract_uint64_le(i, 48),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 56),
+      bs1.unsafe_extract_uint64_le(i, 56),
+    )
+    assert_eq(
+      bs3.unsafe_extract_uint64_le(i, 64),
+      bs1.unsafe_extract_uint64_le(i, 64),
+    )
+  }
+}
+
+///|
+test "FixedArray extract view" {
+  let bs1 = b"\x89\xab\xcd\xef"
+  let bs2 : Array[Byte] = bs1.to_array()
+  let bs3 : FixedArray[Byte] = FixedArray::from_array(bs2)
+  
+  fn equal(a : ArrayView[Byte], b : ArrayView[Byte]) raise {
+    assert_eq(a.length(), b.length())
+    for i in 0..<a.length() {
+      assert_eq(a[i], b[i])
+    }
+  }
+  
+  fn equal_with_bytes(a : ArrayView[Byte], b : BytesView) raise {
+    assert_eq(a.length(), b.length())
+    for i in 0..<a.length() {
+      assert_eq(a[i], b[i])
+    }
+  }
+
+  for i in 0..=bs1.length() {
+    for j in 0..=(bs1.length() - i) {
+      // Test FixedArray vs Array
+      equal(
+        bs3.unsafe_extract_bytesview(i * 8, j * 8),
+        bs2.unsafe_extract_bytesview(i * 8, j * 8),
+      )
+      
+      // Test FixedArray vs BytesView
+      equal_with_bytes(
+        bs3.unsafe_extract_bytesview(i * 8, j * 8),
+        bs1.unsafe_extract_bytesview(i * 8, j * 8),
+      )
+    }
+  }
+}

--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -43,6 +43,13 @@ fn[T, K : Compare] FixedArray::sort_by_key(Self[T], (T) -> K) -> Unit
 fn[T : Compare] FixedArray::stable_sort(Self[T]) -> Unit
 fn[T : Eq] FixedArray::starts_with(Self[T], Self[T]) -> Bool
 fn[T] FixedArray::swap(Self[T], Int, Int) -> Unit
+fn FixedArray::unsafe_extract_bit(Self[Byte], Int, Int) -> UInt
+fn FixedArray::unsafe_extract_byte(Self[Byte], Int, Int) -> UInt
+fn FixedArray::unsafe_extract_bytesview(Self[Byte], Int, Int) -> ArrayView[Byte]
+fn FixedArray::unsafe_extract_uint64_be(Self[Byte], Int, Int) -> UInt64
+fn FixedArray::unsafe_extract_uint64_le(Self[Byte], Int, Int) -> UInt64
+fn FixedArray::unsafe_extract_uint_be(Self[Byte], Int, Int) -> UInt
+fn FixedArray::unsafe_extract_uint_le(Self[Byte], Int, Int) -> UInt
 impl[T] Add for FixedArray[T]
 impl[T : Compare] Compare for FixedArray[T]
 impl[T : Eq] Eq for FixedArray[T]


### PR DESCRIPTION
This PR adds necessary bitstring operations for FixedArray[Byte] so that in future releases, bitstring pattern can be used when the value being matched has type FixedArray[Byte].