### PR TITLE
identifer unbound

### DIFF
--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -265,8 +265,8 @@ fn sum(xs : ArrayView[Int]) -> Int {
 
 ///|
 // TODO: fix(upstream) later
-// #cfg(false)
-// test "FixedArray::sub - sum" {
-//   let arr = FixedArray::makei(10, i => i * i)
-//   inspect(sum(arr), content="385")
-// }
+#cfg(false)
+test "FixedArray::sub - sum" {
+  let arr = FixedArray::makei(10, i => i * i)
+  inspect(sum(arr), content="385")
+}


### PR DESCRIPTION
```
Error: [4021]
      ╭─[ in/__generated_driver_for_blackbox_test.mbt:2210:10 ]
      │
 2210 │     27: (__test_666978656461727261795f746573742e6d6274_27, ["FixedArray::sub - sum"]),
      │          ────────────────────────┬───────────────────────  
      │                                  ╰───────────────────────── The value identifier __test_666978656461727261795f746573742e6d6274_27 is unbound.
──────╯
```

