### PR TITLE
refactor: make hash random

### DIFF
--- a/array/view_test.mbt
+++ b/array/view_test.mbt
@@ -195,8 +195,14 @@ test "arrayview_arbitrary" {
 ///|
 test "arrayview_hash" {
   let arr : Array[@array.View[Int]] = @quickcheck.samples(20)
-  inspect(arr[5:9].hash(), content="-966877954")
-  inspect(arr[10:15].hash(), content="-951019668")
+  inspect(
+    Hasher::new(seed=0)..combine(arr[5:9]).finalize(),
+    content="-966877954",
+  )
+  inspect(
+    Hasher::new(seed=0)..combine(arr[10:15]).finalize(),
+    content="-951019668",
+  )
 }
 
 ///|

--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -221,7 +221,7 @@ test "can_convert_to_int64" {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   let big = 12345N
 ///   hasher.combine(big)
 ///   inspect(hasher.finalize(), content="890579181")

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1015,38 +1015,46 @@ test "compare_int64" {
 ///|
 test "@bigint.BigInt::hash" {
   // Test zero
-  inspect(0N.hash(), content="-813420232")
+  inspect(Hasher::new(seed=0)..combine(0N).finalize(), content="-813420232")
   assert_eq(0N.hash(), (-0N).hash())
 
   // Positive and negative of same magnitude should have different hashes
   assert_not_eq(1N.hash(), (-1N).hash())
 
   // Test small positive numbers
-  inspect(42N.hash(), content="2103260413")
+  inspect(Hasher::new(seed=0)..combine(42N).finalize(), content="2103260413")
 
   // Test small negative numbers
-  inspect((-42N).hash(), content="-504604139")
+  inspect(Hasher::new(seed=0)..combine(-42N).finalize(), content="-504604139")
 
   // Test larger numbers
   let large = 123456789N
-  assert_not_eq(large.hash(), (-large).hash())
+  inspect(Hasher::new(seed=0)..combine(large).finalize(), content="275171670")
+  inspect(
+    Hasher::new(seed=0)..combine(-large).finalize(),
+    content="-200902609",
+  )
 
   // Test very large numbers (multi-limb)
   let very_large = 12345678901234567890123456789N
-  inspect(very_large.hash(), content="2115080653")
-  inspect((-very_large).hash(), content="-1781872667")
-  assert_not_eq(very_large.hash(), (-very_large).hash())
+  inspect(
+    Hasher::new(seed=0)..combine(very_large).finalize(),
+    content="2115080653",
+  )
+  inspect(
+    Hasher::new(seed=0)..combine(-very_large).finalize(),
+    content="-1781872667",
+  )
 
   // Test that equal BigInts have equal hashes
   let a = 987654321098765432N
   let b = @bigint.BigInt::from_string("00987654321098765432")
-  inspect(a.hash(), content="-1950963429")
-  assert_eq(a.hash(), b.hash())
+  inspect(Hasher::new(seed=0)..combine(a).finalize(), content="-1950963429")
+  inspect(Hasher::new(seed=0)..combine(b).finalize(), content="-1950963429")
 
   // Test that different BigInts have different hashes (usually)
   let c = a + 1N
-  inspect(c.hash(), content="-959383658")
-  assert_not_eq(a.hash(), c.hash())
+  inspect(Hasher::new(seed=0)..combine(c).finalize(), content="-959383658")
 }
 
 ///|

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -193,7 +193,7 @@ pub impl Hash for Byte with hash(self) {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_byte(b'\xFF')
 ///   inspect(hasher.finalize(), content="1955036104")
 /// ```

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -39,7 +39,7 @@ const GPRIME5 : UInt = 0x165667B1
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_int(42)
 ///   hasher.combine_string("hello")
 ///   inspect(hasher.finalize(), content="860601284")
@@ -61,7 +61,7 @@ struct Hasher {
 /// Example:
 ///
 /// ```moonbit
-///   let h1 = Hasher::new() // Create a hasher with default seed
+///   let h1 = Hasher::new(seed=0) // Create a hasher with default seed
 ///   let h2 = Hasher::new(seed=42) // Create a hasher with custom seed
 ///   let x = 123
 ///   h1.combine(x)
@@ -106,7 +106,7 @@ extern "js" fn random_seed() -> Int =
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine(42)
 ///   hasher.combine("hello")
 ///   inspect(hasher.finalize(), content="860601284")
@@ -126,7 +126,7 @@ pub fn[T : Hash] Hasher::combine(self : Hasher, value : T) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_unit()
 ///   inspect(hasher.finalize(), content="148298089")
 /// ```
@@ -147,7 +147,7 @@ pub fn Hasher::combine_unit(self : Hasher) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_bool(true)
 ///   inspect(hasher.finalize(), content="-205818221")
 /// ```
@@ -168,7 +168,7 @@ pub fn Hasher::combine_bool(self : Hasher, value : Bool) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_int(42)
 ///   inspect(hasher.finalize(), content="1161967057")
 /// ```
@@ -190,7 +190,7 @@ pub fn Hasher::combine_int(self : Hasher, value : Int) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_int64(42L)
 ///   inspect(hasher.finalize(), content="-1962516083")
 /// ```
@@ -213,7 +213,7 @@ pub fn Hasher::combine_int64(self : Hasher, value : Int64) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_uint(42U)
 ///   inspect(hasher.finalize(), content="1161967057")
 /// ```
@@ -235,7 +235,7 @@ pub fn Hasher::combine_uint(self : Hasher, value : UInt) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_uint64(42UL)
 ///   inspect(hasher.finalize(), content="-1962516083")
 /// ```
@@ -257,7 +257,7 @@ pub fn Hasher::combine_uint64(self : Hasher, value : UInt64) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_double(3.14)
 ///   inspect(hasher.finalize(), content="-428265677")
 /// ```
@@ -279,7 +279,7 @@ pub fn Hasher::combine_double(self : Hasher, value : Double) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_float(3.14)
 ///   inspect(hasher.finalize(), content="635116317") // Hash of the bits of 3.14
 /// ```
@@ -298,7 +298,7 @@ pub fn Hasher::combine_float(self : Hasher, value : Float) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_byte(b'\xFF')
 ///   inspect(hasher.finalize(), content="1955036104")
 /// ```
@@ -319,7 +319,7 @@ pub fn Hasher::combine_byte(self : Hasher, value : Byte) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_bytes(b"\xFF\x00\xFF\x00")
 ///   inspect(hasher.finalize(), content="-686861102")
 /// ```
@@ -350,7 +350,7 @@ pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_string("hello")
 ///   inspect(hasher.finalize(), content="-655549713")
 /// ```
@@ -373,7 +373,7 @@ pub fn Hasher::combine_string(self : Hasher, value : String) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_char('A')
 ///   inspect(hasher.finalize(), content="-1625495534")
 /// ```
@@ -394,7 +394,7 @@ pub fn Hasher::combine_char(self : Hasher, value : Char) -> Unit {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_byte(b'\xFF')
 ///   inspect(hasher.finalize(), content="1955036104")
 /// ```
@@ -508,7 +508,7 @@ pub impl Hash for Int with hash(self) {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_int(42)
 ///   inspect(hasher.finalize(), content="1161967057")
 /// ```
@@ -530,7 +530,7 @@ pub impl Hash for Int with hash_combine(self, hasher) {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_uint(42U)
 ///   inspect(hasher.finalize(), content="1161967057")
 /// ```
@@ -550,7 +550,7 @@ pub impl Hash for UInt with hash_combine(self, hasher) {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine_uint64(42UL)
 ///   inspect(hasher.finalize(), content="-1962516083")
 /// ```
@@ -570,12 +570,12 @@ pub impl Hash for UInt64 with hash_combine(self, hasher) {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   let some_value : Int? = Some(42)
 ///   let none_value : Int? = None
 ///   hasher.combine(some_value)
 ///   inspect(hasher.finalize(), content="2103260413")
-///   let hasher2 = Hasher::new()
+///   let hasher2 = Hasher::new(seed=0)
 ///   hasher2.combine(none_value)
 ///   inspect(hasher2.finalize(), content="148298089")
 /// ```
@@ -598,12 +598,12 @@ pub impl[X : Hash] Hash for X? with hash_combine(self, hasher) {
 /// Example:
 ///
 /// ```moonbit
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   let ok_result : Result[Int, String] = Ok(42)
 ///   let err_result : Result[Int, String] = Err("error")
 ///   hasher.combine(ok_result)
 ///   inspect(hasher.finalize(), content="-1948635851")
-///   let hasher = Hasher::new()
+///   let hasher = Hasher::new(seed=0)
 ///   hasher.combine(err_result)
 ///   inspect(hasher.finalize(), content="1953766574")
 /// ```

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -68,9 +68,30 @@ struct Hasher {
 ///   h2.combine(x)
 ///   inspect(h1.finalize() != h2.finalize(), content="true") // Different seeds produce different hashes
 /// ```
-pub fn Hasher::new(seed? : Int = 0) -> Hasher {
+pub fn Hasher::new(seed? : Int = seed) -> Hasher {
   { acc: seed.reinterpret_as_uint() + GPRIME5 }
 }
+
+///|
+#cfg(not(target="js"))
+let seed : Int = 0
+
+///|
+#cfg(target="js")
+let seed : Int = random_seed()
+
+///|
+#cfg(target="js")
+extern "js" fn random_seed() -> Int =
+  #|() => {
+  #|  if (crypto?.getRandomValues) {
+  #|    const array = new Uint32Array(1);
+  #|    crypto.getRandomValues(array);
+  #|    return array[0] | 0; // Convert to signed 32
+  #|  } else {
+  #|    return Math.floor(Math.random() * 0x100000000) | 0; // Fallback to Math.random
+  #|  }
+  #|}
 
 ///|
 /// Combines a hashable value with the current state of the hasher. This is

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test "combine int" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_int(v)
     hasher.finalize()
   }
@@ -32,7 +32,7 @@ test "combine int" {
 ///|
 test "combine char" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_char(v)
     hasher.finalize()
   }
@@ -42,7 +42,7 @@ test "combine char" {
 ///|
 test "combine int64" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_int64(v)
     hasher.finalize()
   }
@@ -59,7 +59,7 @@ test "combine int64" {
 ///|
 test "combine uint" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_uint(v)
     hasher.finalize()
   }
@@ -75,7 +75,7 @@ test "combine uint" {
 ///|
 test "combine uint64" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_uint64(v)
     hasher.finalize()
   }
@@ -91,7 +91,7 @@ test "combine uint64" {
 ///|
 test "combine double" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_double(v)
     hasher.finalize()
   }
@@ -106,7 +106,7 @@ test "combine double" {
 ///|
 test "combine float" {
   let hash = (v : Float) => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_float(v)
     hasher.finalize()
   }
@@ -121,7 +121,7 @@ test "combine float" {
 ///|
 test "combine string" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_string(v)
     hasher.finalize()
   }
@@ -141,7 +141,7 @@ test "combine string" {
 ///|
 test "combine bytes" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_bytes(v)
     hasher.finalize()
   }
@@ -165,7 +165,7 @@ test "combine bytes" {
 ///|
 test "combine byte" {
   let hash = v => {
-    let hasher = Hasher::new()
+    let hasher = Hasher::new(seed=0)
     hasher.combine_byte(v)
     hasher.finalize()
   }
@@ -179,7 +179,7 @@ test "combine byte" {
 
 ///|
 test "combine all" {
-  let hasher = Hasher::new()
+  let hasher = Hasher::new(seed=0)
   hasher
   ..combine_int(1)
   ..combine_int64(2147483648)
@@ -194,10 +194,10 @@ test "combine all" {
 
 ///|
 test "combine_unit" {
-  let hasher = @builtin.Hasher::new()
+  let hasher = @builtin.Hasher::new(seed=0)
   hasher.combine_unit()
   let hash = hasher.finalize()
-  let hasher2 = @builtin.Hasher::new()
+  let hasher2 = @builtin.Hasher::new(seed=0)
   hasher2.combine_int(0)
   let hash2 = hasher2.finalize()
   inspect(hash == hash2, content="true")
@@ -205,17 +205,17 @@ test "combine_unit" {
 
 ///|
 test "combine_bool" {
-  let hasher = @builtin.Hasher::new()
+  let hasher = @builtin.Hasher::new(seed=0)
   hasher.combine_bool(true)
   let hash1 = hasher.finalize()
-  let hasher2 = @builtin.Hasher::new()
+  let hasher2 = @builtin.Hasher::new(seed=0)
   hasher2.combine_int(1)
   let hash2 = hasher2.finalize()
   assert_eq(hash1, hash2)
-  let hasher3 = @builtin.Hasher::new()
+  let hasher3 = @builtin.Hasher::new(seed=0)
   hasher3.combine_bool(false)
   let hash3 = hasher3.finalize()
-  let hasher4 = @builtin.Hasher::new()
+  let hasher4 = @builtin.Hasher::new(seed=0)
   hasher4.combine_int(0)
   let hash4 = hasher4.finalize()
   assert_eq(hash3, hash4)
@@ -224,7 +224,7 @@ test "combine_bool" {
 ///|
 test "Result::hash_combine Ok case" {
   // Test the Ok case
-  let hasher = Hasher::new()
+  let hasher = Hasher::new(seed=0)
   let ok_result : Result[Int, String] = Ok(42)
   hasher.combine(ok_result)
   inspect(hasher.finalize(), content="-1948635851")
@@ -232,7 +232,7 @@ test "Result::hash_combine Ok case" {
 
 ///|
 test "Result::hash_combine Err case" {
-  let hasher = Hasher::new()
+  let hasher = Hasher::new(seed=0)
   let err_result : Result[Int, String] = Err("error")
   hasher.combine(err_result)
   inspect(hasher.finalize(), content="1953766574")
@@ -240,11 +240,11 @@ test "Result::hash_combine Err case" {
 
 ///|
 test "option hash" {
-  let hasher = @builtin.Hasher::new()
+  let hasher = @builtin.Hasher::new(seed=0)
   let some_val : Int? = Some(42)
   hasher.combine(some_val)
   inspect(hasher.finalize(), content="2103260413")
-  let hasher2 = @builtin.Hasher::new()
+  let hasher2 = @builtin.Hasher::new(seed=0)
   let none_val : Int? = None
   hasher2.combine(none_val)
   inspect(hasher2.finalize(), content="148298089")
@@ -252,7 +252,7 @@ test "option hash" {
 
 ///|
 test "UInt64::hash_combine test" {
-  let hasher = @builtin.Hasher::new()
+  let hasher = @builtin.Hasher::new(seed=0)
   let value = 42UL
   @builtin.Hash::hash_combine(value, hasher)
   inspect(hasher.finalize(), content="-1962516083")
@@ -260,7 +260,7 @@ test "UInt64::hash_combine test" {
 
 ///|
 test "hash_combine for UInt" {
-  let hasher = Hasher::new()
+  let hasher = Hasher::new(seed=0)
   let value : UInt = 42U
   Hash::hash_combine(value, hasher)
   inspect(hasher.finalize(), content="1161967057")

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -100,7 +100,7 @@ pub fn[K : Hash + Eq, V] Map::from_array(arr : Array[(K, V)]) -> Map[K, V] {
 /// ```
 #alias("_[_]=_")
 pub fn[K : Hash + Eq, V] Map::set(self : Map[K, V], key : K, value : V) -> Unit {
-  self.set_with_hash(key, value, key.hash())
+  self.set_with_hash(key, value, Hasher::new()..combine(key).finalize())
 }
 
 ///|
@@ -191,7 +191,7 @@ fn[K, V] Map::set_entry(
 ///   inspect(map.get("nonexistent"), content="None")
 /// ```
 pub fn[K : Hash + Eq, V] Map::get(self : Map[K, V], key : K) -> V? {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && entry.key == key {
@@ -207,7 +207,7 @@ pub fn[K : Hash + Eq, V] Map::get(self : Map[K, V], key : K) -> V? {
 ///|
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] Map::at(self : Map[K, V], key : K) -> V {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry)
     if entry.hash == hash && entry.key == key {
@@ -244,7 +244,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_default(
   key : K,
   default : V,
 ) -> V {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
       Some(entry) => {
@@ -268,7 +268,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
   key : K,
   default : () -> V,
 ) -> V {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
     match self.entries[idx] {
@@ -313,7 +313,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 /// Check if the hash map contains a key.
 pub fn[K : Hash + Eq, V] Map::contains(self : Map[K, V], key : K) -> Bool {
   // inline Map::get to avoid boxing
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
@@ -353,7 +353,7 @@ pub fn[K : Hash + Eq, V : Eq] Map::contains_kv(
   value : V,
 ) -> Bool {
   // inline Map::get to avoid boxing
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key && entry.value == value {
@@ -386,7 +386,7 @@ pub fn[K : Hash + Eq, V : Eq] Map::contains_kv(
 ///   inspect(map.length(), content="1")
 /// ```
 pub fn[K : Hash + Eq, V] Map::remove(self : Map[K, V], key : K) -> Unit {
-  self.remove_with_hash(key, key.hash())
+  self.remove_with_hash(key, Hasher::new()..combine(key).finalize())
 }
 
 ///|
@@ -824,7 +824,7 @@ pub fn[K : Hash + Eq, V] Map::update(
   key : K,
   f : (V?) -> V?,
 ) -> Unit {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
     match self.entries[idx] {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -51,10 +51,10 @@ test "set" {
   m.set("c", 1)
   m.set("d", 1)
   assert_eq(m.size, 7)
-  assert_eq(
-    m.debug_entries(),
-    "_,(0,a,1),(1,b,1),(2,c,1),(3,d,1),(3,bc,2),(4,cd,2),(4,abc,3),_,_,_,_,_,_,_,_",
-  )
+  // assert_eq(
+  //   m._debug_entries(),
+  //   "_,(0,a,1),(1,b,1),(2,c,1),(3,d,1),(3,bc,2),(4,cd,2),(4,abc,3),_,_,_,_,_,_,_,_",
+  // )
 }
 
 ///|
@@ -101,9 +101,9 @@ test "get_or_init on push_back" {
   inspect(m.grow_at, content="3")
   m.set("x", Array::new())
   m.set("xx", Array::new())
-  inspect(m.debug_entries(), content="_,(0,x,[]),(0,xx,[]),_")
+  // inspect(m._debug_entries(), content="_,(0,x,[]),(0,xx,[]),_")
   m.get_or_init("a", () => Array::new()).push(1)
-  inspect(m.debug_entries(), content="_,(0,x,[]),(1,a,[1]),(1,xx,[])")
+  // inspect(m._debug_entries(), content="_,(0,x,[]),(1,a,[1]),(1,xx,[])")
 }
 
 ///|
@@ -240,10 +240,10 @@ test "grow" {
   m.set("Rescript", 8)
   assert_eq(m.length(), 10)
   assert_eq(m.capacity(), 16)
-  assert_eq(
-    m.debug_entries(),
-    "_,(0,C,1),(0,Go,2),(0,C++,3),(0,Java,4),(0,Scala,5),(1,Julia,5),(2,Cobol,5),(2,Python,6),(2,Haskell,7),(2,Rescript,8),_,_,_,_,_",
-  )
+  // assert_eq(
+  //   m._debug_entries(),
+  //   "_,(0,C,1),(0,Go,2),(0,C++,3),(0,Java,4),(0,Scala,5),(1,Julia,5),(2,Cobol,5),(2,Python,6),(2,Haskell,7),(2,Rescript,8),_,_,_,_,_",
+  // )
 }
 
 ///|
@@ -769,12 +769,15 @@ test "remove" {
   m.set("abcdef", 6)
   m.remove("ab")
   assert_eq(m.length(), 5)
-  assert_eq(
-    m.debug_entries(),
-    "_,(0,a,1),(0,bc,2),(1,cd,2),(1,abc,3),_,(0,abcdef,6),_",
-  )
+  // assert_eq(
+  //   m._debug_entries(),
+  //   "_,(0,a,1),(0,bc,2),(1,cd,2),(1,abc,3),_,(0,abcdef,6),_",
+  // )
   m.remove("abc")
-  assert_eq(m.debug_entries(), "_,(0,a,1),(0,bc,2),(1,cd,2),_,_,(0,abcdef,6),_")
+  // assert_eq(
+  //   m._debug_entries(),
+  //   "_,(0,a,1),(0,bc,2),(1,cd,2),_,_,(0,abcdef,6),_",
+  // )
 }
 
 ///|
@@ -785,7 +788,7 @@ test "remove_unexist_key" {
   m.set("abc", 3)
   m.remove("d")
   assert_eq(m.length(), 3)
-  assert_eq(m.debug_entries(), "_,(0,a,1),(0,ab,2),(0,abc,3),_,_,_,_")
+  // assert_eq(m._debug_entries(), "_,(0,a,1),(0,ab,2),(0,abc,3),_,_,_,_")
 }
 
 ///|
@@ -910,7 +913,7 @@ test "equal_key_value_mismatch" {
 }
 
 ///|
-fn[K : Show, V : Show] Map::debug_entries(self : Map[K, V]) -> String {
+fn[K : Show, V : Show] Map::_debug_entries(self : Map[K, V]) -> String {
   let buf = StringBuilder::new()
   for i in 0..<self.entries.length() {
     if i > 0 {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -28,12 +28,6 @@ impl Hash for MyString with hash_combine(self, hasher) {
 }
 
 ///|
-impl Show for MyString with output(self, logger) {
-  let MyString(s) = self
-  logger.write_string(s)
-}
-
-///|
 test "new" {
   let m : Map[Int, Int] = Map::new()
   assert_eq(m.capacity, 8)
@@ -820,7 +814,7 @@ test "remove_entry_head" {
   assert_eq(head.prev, -1)
   assert_true(head.next is None)
   assert_eq(head.psl, 0)
-  assert_eq(head.hash, (2).hash())
+  assert_eq(head.hash, Hasher::new()..combine(2).finalize())
   assert_eq(head.key, 2)
   assert_eq(head.value, 2)
 }
@@ -838,7 +832,7 @@ test "remove_entry_tail" {
   assert_eq(tail.prev, -1)
   assert_true(tail.next is None)
   assert_eq(tail.psl, 0)
-  assert_eq(tail.hash, (1).hash())
+  assert_eq(tail.hash, Hasher::new()..combine(1).finalize())
   assert_eq(tail.key, 1)
   assert_eq(tail.value, 1)
 }

--- a/float/float_test.mbt
+++ b/float/float_test.mbt
@@ -71,7 +71,7 @@ test "Hash" {
     a : Float
   } derive(Hash)
   let a = A::{ a: 1.0 }
-  inspect(a.hash(), content="1986884538")
+  inspect(Hasher::new(seed=0)..combine(a).finalize(), content="1986884538")
   inspect(a.a.hash(), content="749479517")
   inspect((2.0 : Float).hash(), content="-1861484393")
 }

--- a/hashmap/README.mbt.md
+++ b/hashmap/README.mbt.md
@@ -42,7 +42,7 @@ You can use `remove()` to remove a key-value pair.
 test {
   let map = @hashmap.of([("a", 1), ("b", 2), ("c", 3)])
   map.remove("a") |> ignore
-  assert_eq(map.to_array(), [("c", 3), ("b", 2)])
+  assert_false(map.contains("a"))
 }
 ```
 

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -602,20 +602,72 @@ impl Show for MyString with output(self, logger) {
 }
 
 ///|
+fn[K : Hash + Eq, V : Eq] verify_content(
+  map : HashMap[K, V],
+  expected : Array[(K, V)],
+) -> Unit raise {
+  for entry in expected {
+    let (k, v) = entry
+    assert_true(map.contains_kv(k, v))
+  }
+  assert_eq(map.length(), expected.length())
+}
+
+///|
 test "arbitrary" {
   let samples : Array[HashMap[String, Int]] = @quickcheck.samples(20)
-  inspect(
-    samples[5:10],
-    content=(
-      #|[HashMap::of([]), HashMap::of([]), HashMap::of([("", 0)]), HashMap::of([("", 0)]), HashMap::of([("", 0)])]
-    ),
-  )
-  inspect(
-    samples[11:15],
-    content=(
-      #|[HashMap::of([("Q", 1), ("", 0), ("\u{1e}", 0)]), HashMap::of([("", 0)]), HashMap::of([("F:", 0), ("A&", 2), ("v\b", 0), ("", 0), ("#", 0)]), HashMap::of([("p(", -2), ("^\u{1e}", 3), ("2x", 1), ("", 3)])]
-    ),
-  )
+  let data = [
+    [],
+    [],
+    [],
+    [("", 0)],
+    [("", 0)],
+    [],
+    [],
+    [("", 0)],
+    [("", 0)],
+    [("", 0)],
+    [("}\u{11}e", -1), ("", 0), ("0f", -1), ("k", -2)],
+    [("Q", 1), ("", 0), ("\u{1e}", 0)],
+    [("", 0)],
+    [("F:", 0), ("A&", 2), ("v\b", 0), ("", 0), ("#", 0)],
+    [("p(", -2), ("^\u{1e}", 3), ("2x", 1), ("", 3)],
+    [("A", -3), ("", 0), ("/w", 0), ("lD", 0), ("jlF0", 3)],
+    [
+      ("zd", 2),
+      ("[z\r]j", 4),
+      ("\u{1d}r", -3),
+      ("", 0),
+      ("p=61s\u{14}", -7),
+      ("t|,7X4\"\u{14}", -10),
+      ("HeH\b\u{15}d", 1),
+      ("LC\u{19}", 1),
+      ("\u{0b}", 0),
+      ("\n", 0),
+      ("3", -9),
+      ("v", -1),
+    ],
+    [
+      ("", -1),
+      ("&\b", -4),
+      ("ob%>j\bD?xboR5", 0),
+      (";:B", -3),
+      ("`", 1),
+      ("OwQCP+@", -1),
+      ("O]k", -3),
+      ("\n^", -3),
+      ("U_-*\u{1c}x\u{18}", -11),
+      ("shU^\u{1d}hd8\u{1d}", 0),
+      ("!\u{1b}63p", 3),
+      ("q", 1),
+      ("R@", 4),
+    ],
+    [("", -4), ("v", -2), (")xh", 1), ("C\u{10}\u{0e}", -3), ("|", 0)],
+    [("", 1), ("b", -1)],
+  ]
+  for i in 0..<samples.length() {
+    verify_content(samples[i], data[i])
+  }
 }
 
 ///|

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -98,7 +98,7 @@ pub fn[K : Hash + Eq, V] HashMap::set(
   key : K,
   value : V,
 ) -> Unit {
-  self.set_with_hash(key, value, key.hash())
+  self.set_with_hash(key, value, Hasher::new()..combine(key).finalize())
 }
 
 ///|
@@ -178,7 +178,7 @@ fn[K, V] HashMap::push_away(
 /// ```
 pub fn[K : Hash + Eq, V] get(self : HashMap[K, V], key : K) -> V? {
   // self.get_with_hash(key, key.hash())
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && entry.key == key {
@@ -209,7 +209,7 @@ pub fn[K : Hash + Eq, V] get(self : HashMap[K, V], key : K) -> V? {
 /// ```
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry)
     if entry.hash == hash && entry.key == key {
@@ -248,7 +248,7 @@ pub fn[K : Hash + Eq, V] get_or_init(
   key : K,
   init : () -> V,
 ) -> V {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
     match self.entries[idx] {
@@ -308,7 +308,7 @@ pub fn[K : Hash + Eq, V] get_or_default(
   key : K,
   default : V,
 ) -> V {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break default }
     if entry.hash == hash && entry.key == key {
@@ -339,7 +339,7 @@ pub fn[K : Hash + Eq, V] get_or_default(
 ///   inspect(map.contains("c"), content="false")
 /// ```
 pub fn[K : Hash + Eq, V] contains(self : HashMap[K, V], key : K) -> Bool {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { return false }
     if entry.hash == hash && entry.key == key {
@@ -379,7 +379,7 @@ pub fn[K : Hash + Eq, V : Eq] contains_kv(
   key : K,
   value : V,
 ) -> Bool {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { return false }
     if entry.hash == hash && entry.key == key && entry.value == value {
@@ -412,7 +412,7 @@ pub fn[K : Hash + Eq, V : Eq] contains_kv(
 ///   inspect(map.length(), content="1")
 /// ```
 pub fn[K : Hash + Eq, V] remove(self : HashMap[K, V], key : K) -> Unit {
-  self.remove_with_hash(key, key.hash())
+  self.remove_with_hash(key, Hasher::new()..combine(key).finalize())
 }
 
 ///|

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -629,10 +629,10 @@ test "set" {
   m.set("c", 1)
   m.set("d", 1)
   inspect(m.length(), content="7")
-  inspect(
-    m.debug_entries(),
-    content="_,(0,a,1),(1,b,1),(2,c,1),(3,d,1),(3,bc,2),(4,cd,2),(4,abc,3),_,_,_,_,_,_,_,_",
-  )
+  // inspect(
+  //   m._debug_entries(),
+  //   content="_,(0,a,1),(1,b,1),(2,c,1),(3,d,1),(3,bc,2),(4,cd,2),(4,abc,3),_,_,_,_,_,_,_,_",
+  // )
 }
 
 ///|
@@ -646,10 +646,10 @@ test "remove" {
   m.set("abcdef", 6)
   m.remove("ab")
   inspect(m.length(), content="5")
-  inspect(
-    m.debug_entries(),
-    content="_,(0,a,1),(0,bc,2),(1,cd,2),(1,abc,3),_,(0,abcdef,6),_,_,_,_,_,_,_,_,_",
-  )
+  // inspect(
+  //   m._debug_entries(),
+  //   content="_,(0,a,1),(0,bc,2),(1,cd,2),(1,abc,3),_,(0,abcdef,6),_,_,_,_,_,_,_,_,_",
+  // )
 }
 
 ///|
@@ -660,7 +660,7 @@ test "remove_unexist_key" {
   m.set("abc", 3)
   m.remove("d")
   inspect(m.length(), content="3")
-  inspect(m.debug_entries(), content="_,(0,a,1),(0,ab,2),(0,abc,3),_,_,_,_")
+  // inspect(m._debug_entries(), content="_,(0,a,1),(0,ab,2),(0,abc,3),_,_,_,_")
 }
 
 ///|
@@ -693,10 +693,21 @@ test "grow" {
   m.set("Rescript", 8)
   inspect(m.length(), content="10")
   inspect(m.capacity(), content="32")
-  inspect(
-    m.debug_entries(),
-    content="_,(0,C,1),(0,Go,2),(0,C++,3),(0,Java,4),(0,Scala,5),(1,Julia,5),(2,Cobol,5),(2,Python,6),(2,Haskell,7),(2,Rescript,8),_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_",
-  )
+  inspect(m.get("C"), content="Some(1)")
+  inspect(m.get("Go"), content="Some(2)")
+  inspect(m.get("C++"), content="Some(3)")
+  inspect(m.get("Java"), content="Some(4)")
+  inspect(m.get("Scala"), content="Some(5)")
+  inspect(m.get("Julia"), content="Some(5)")
+  inspect(m.get("Cobol"), content="Some(5)")
+  inspect(m.get("Python"), content="Some(6)")
+  inspect(m.get("Haskell"), content="Some(7)")
+  inspect(m.get("Rescript"), content="Some(8)")
+  // Only for debugging
+  // inspect(
+  //   m._debug_entries(),
+  //   content="_,(0,C,1),(0,Go,2),(0,C++,3),(0,Java,4),(0,Scala,5),(1,Julia,5),(2,Cobol,5),(2,Python,6),(2,Haskell,7),(2,Rescript,8),_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_",
+  // )
 }
 
 ///|

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -159,43 +159,39 @@ test "iteri" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
   let map = @hashmap.of([(1, "one"), (2, "two"), (3, "three")])
-  map
-  .iter()
-  .each(e => {
-    let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
-  })
-  inspect(buf, content="[2-two][1-one][3-three]")
-  buf.reset()
-  map
-  .iter()
-  .take(2)
-  .each(e => {
-    let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
-  })
-  inspect(buf, content="[2-two][1-one]")
+  let array = map.iter().collect()
+  array.sort()
+  inspect(
+    array,
+    content=(
+      #|[(1, "one"), (2, "two"), (3, "three")]
+    ),
+  )
 }
 
 ///|
 test "iter2" {
-  let buf = StringBuilder::new(size_hint=20)
   let map = @hashmap.of([(1, "one"), (2, "two"), (3, "three")])
-  for k, v in map {
-    buf.write_string("[\{k}-\{v}]")
-  }
-  inspect(buf, content="[2-two][1-one][3-three]")
+  let array = map.iter2().to_array()
+  array.sort()
+  inspect(
+    array,
+    content=(
+      #|[(1, "one"), (2, "two"), (3, "three")]
+    ),
+  )
 }
 
 ///|
 test "to_array" {
   let map = @hashmap.of([(1, "one"), (2, "two"), (3, "three")])
+  let array = map.to_array()
+  array.sort()
   inspect(
-    map.to_array(),
+    array,
     content=(
-      #|[(2, "two"), (1, "one"), (3, "three")]
+      #|[(1, "one"), (2, "two"), (3, "three")]
     ),
   )
 }
@@ -327,10 +323,11 @@ test "get_nonexistent_key_with_psl" {
 
 ///|
 test "from_iter multiple elements iter" {
-  inspect(
-    @hashmap.from_iter([(1, 1), (2, 2), (3, 3)].iter()),
-    content="HashMap::of([(2, 2), (1, 1), (3, 3)])",
-  )
+  let map = @hashmap.from_iter([(1, 1), (2, 2), (3, 3)].iter())
+  guard map is { 1: 1, 2: 2, 3: 3, .. } else {
+    fail("Map is not expected: \{map}")
+  }
+  inspect(map.length(), content="3")
 }
 
 ///|
@@ -370,14 +367,22 @@ test "@hashmap.contains/after_operations" {
 
 ///|
 test "@hashmap.from_array" {
-  let map = @hashmap.from_array([("a", 1), ("b", 2), ("c", 3)])
-  @json.inspect(map, content={ "a": 1, "c": 3, "b": 2 })
+  let array = [("a", 1), ("b", 2), ("c", 3)]
+  let map = @hashmap.from_array(array)
+  for k, v in map {
+    assert_eq(map.get(k), Some(v))
+  }
+  assert_eq(map.length(), array.length())
 }
 
 ///|
 test "@hashmap.from_array with int key" {
-  let map = @hashmap.from_array([(1, "one"), (2, "two"), (3, "three")])
-  @json.inspect(map, content={ "2": "two", "1": "one", "3": "three" })
+  let array = [(1, "one"), (2, "two"), (3, "three")]
+  let map = @hashmap.from_array(array)
+  for k, v in map {
+    assert_eq(map.get(k), Some(v))
+  }
+  assert_eq(map.length(), array.length())
 }
 
 ///|

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -404,22 +404,12 @@ test "@hashmap.eq" {
 test "@hashmap.map" {
   let map = @hashmap.of([("a", 1), ("b", 2), ("c", 3)])
   let v = map.map((k, v) => k + v.to_string())
-  inspect(
-    v,
-    content=(
-      #|HashMap::of([("a", "a1"), ("c", "c3"), ("b", "b2")])
-    ),
-  )
+  verify_content(v, [("a", "a1"), ("b", "b2"), ("c", "c3")])
   map["d"] = 10
   map["e"] = 20
   map.remove("c")
   let v = map.map((k, v) => k + v.to_string())
-  inspect(
-    v,
-    content=(
-      #|HashMap::of([("e", "e20"), ("a", "a1"), ("b", "b2"), ("d", "d10")])
-    ),
-  )
+  verify_content(v, [("a", "a1"), ("b", "b2"), ("d", "d10"), ("e", "e20")])
   let v : @hashmap.HashMap[String, String] = @hashmap.new().map((k, v) => k + v)
   inspect(v, content="HashMap::of([])")
 }
@@ -428,22 +418,27 @@ test "@hashmap.map" {
 test "@hashmap.copy" {
   let map = @hashmap.of([("a", 1), ("b", 2), ("c", 3)])
   let copy = map.copy()
-  inspect(
-    copy,
-    content=(
-      #|HashMap::of([("a", 1), ("c", 3), ("b", 2)])
-    ),
-  )
+  verify_content(copy, [("a", 1), ("b", 2), ("c", 3)])
   map["d"] = 10
   map["e"] = 20
   map.remove("c")
   let copy = map.copy()
-  inspect(
-    copy,
-    content=(
-      #|HashMap::of([("e", 20), ("a", 1), ("b", 2), ("d", 10)])
-    ),
-  )
+  verify_content(copy, [("e", 20), ("a", 1), ("b", 2), ("d", 10)])
   let copy : @hashmap.HashMap[String, String] = @hashmap.new().copy()
   inspect(copy, content="HashMap::of([])")
+}
+
+///|
+fn[K : Hash + Eq + Show, V : Eq + Show] verify_content(
+  map : @hashmap.HashMap[K, V],
+  expected : Array[(K, V)],
+) -> Unit raise {
+  for entry in expected {
+    let (k, v) = entry
+    assert_true(
+      map.contains_kv(k, v),
+      msg="Key \{k} with value \{v} not found in map \{map}",
+    )
+  }
+  assert_eq(map.length(), expected.length())
 }

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -7,5 +7,5 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/int"
   ],
-  "test-import": ["moonbitlang/core/string", "moonbitlang/core/json"]
+  "test-import": ["moonbitlang/core/string"]
 }

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -160,10 +160,11 @@ pub fn[K : Hash + Eq, V] HashMap::from_iter(
 /// ```moonbit
 ///   let map = @hashmap.of([(1, "one"), (2, "two")])
 ///   let arr = map.to_array()
+///   arr.sort()
 ///   inspect(
 ///     arr, 
 ///     content=(
-///       #|[(2, "two"), (1, "one")]
+///       #|[(1, "one"), (2, "two")]
 ///     ),
 ///   )
 /// ```
@@ -269,9 +270,12 @@ pub fn[K, V] is_empty(self : HashMap[K, V]) -> Bool {
 ///
 /// ```moonbit
 ///   let map = @hashmap.of([(1, "one"), (2, "two")])
-///   let mut result = ""
-///   map.each((k, v) => { result = result + "\{k}:\{v}," })
-///   inspect(result, content="2:two,1:one,")
+///   let array = []
+///   map.each((k, v) => { array.push((k, v)) })
+///   array.sort()
+///   inspect(array, content=(
+///   #|[(1, "one"), (2, "two")]
+/// ))
 /// ```
 #locals(f)
 pub fn[K, V] each(
@@ -289,6 +293,8 @@ pub fn[K, V] each(
 /// Iterates over all key-value pairs in the map with their index, applying the
 /// given function to each element. The index starts from 0 and only counts
 /// non-empty entries.
+/// 
+/// Notice that the order of iteration is not guaranteed.
 ///
 /// Parameters:
 ///
@@ -298,14 +304,6 @@ pub fn[K, V] each(
 ///  * The key of the current entry
 ///  * The value of the current entry
 ///
-/// Example:
-///
-/// ```moonbit
-///   let map = @hashmap.of([("a", 1), ("b", 2), ("c", 3)])
-///   let mut result = 0
-///   map.eachi((i, k, _) => { if k == "b" { result = i } })
-///   // "b" is at index 1
-///   inspect(result, content="2")
 /// ```
 #locals(f)
 pub fn[K, V] eachi(
@@ -325,6 +323,8 @@ pub fn[K, V] eachi(
 
 ///|
 /// Provides string representation for hash maps.
+/// 
+/// Notice that the order of key-value pairs in the output string is not guaranteed
 ///
 /// Parameters:
 ///
@@ -335,12 +335,8 @@ pub fn[K, V] eachi(
 ///
 /// ```moonbit
 ///   let map = @hashmap.of([(1, "one"), (2, "two")])
-///   inspect(
-///     map, 
-///     content=(
-///       #|HashMap::of([(2, "two"), (1, "one")])
-///     ),
-/// )
+///   let array = map.to_array()
+///   assert_eq(map.to_string(), "HashMap::of(\{array})")
 /// ```
 pub impl[K : Show, V : Show] Show for HashMap[K, V] with output(self, logger) {
   logger.write_string("HashMap::of([")

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn[K : Show, V : Show] debug_entries(self : HashMap[K, V]) -> String {
+fn[K : Show, V : Show] _debug_entries(self : HashMap[K, V]) -> String {
   for s = "", i = 0; i < self.entries.length(); {
     let s = if i > 0 { s + "," } else { s }
     match self.entries[i] {

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -424,7 +424,7 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 }
 
 ///|
-fn[K : Show] debug_entries(self : HashSet[K]) -> String {
+fn[K : Show] _debug_entries(self : HashSet[K]) -> String {
   let mut s = ""
   for i in 0..<self.entries.length() {
     if i > 0 {
@@ -470,10 +470,10 @@ test "set" {
   m.add("c")
   m.add("d")
   inspect(m.size, content="7")
-  assert_eq(
-    m.debug_entries(),
-    "_,(0,a),(1,b),(2,c),(3,d),(3,bc),(4,cd),(4,abc),_,_,_,_,_,_,_,_",
-  )
+  // assert_eq(
+  //   m._debug_entries(),
+  //   "_,(0,a),(1,b),(2,c),(3,d),(3,bc),(4,cd),(4,abc),_,_,_,_,_,_,_,_",
+  // )
 }
 
 ///|
@@ -491,10 +491,10 @@ test "remove" {
   m.add("abcdef" |> i)
   m.remove("ab" |> i)
   inspect(m.length(), content="5")
-  inspect(
-    m.debug_entries(),
-    content="_,(0,a),(0,bc),(1,cd),(1,abc),_,(0,abcdef),_",
-  )
+  // inspect(
+  //   m._debug_entries(),
+  //   content="_,(0,a),(0,bc),(1,cd),(1,abc),_,(0,abcdef),_",
+  // )
 }
 
 ///|
@@ -509,7 +509,7 @@ test "remove_unexist_key" {
   m.add("abc" |> i)
   m.remove("d" |> i)
   inspect(m.length(), content="3")
-  inspect(m.debug_entries(), content="_,(0,a),(0,ab),(0,abc),_,_,_,_")
+  // inspect(m._debug_entries(), content="_,(0,a),(0,ab),(0,abc),_,_,_,_")
 }
 
 ///|
@@ -535,10 +535,10 @@ test "grow" {
   m.add("Rescript" |> i)
   inspect(m.size, content="10")
   inspect(m.capacity, content="16")
-  assert_eq(
-    m.debug_entries(),
-    "_,(0,C),(0,Go),(0,C++),(0,Java),(0,Scala),(1,Julia),(2,Cobol),(2,Python),(2,Haskell),(2,Rescript),_,_,_,_,_",
-  )
+  // assert_eq(
+  //   m._debug_entries(),
+  //   "_,(0,C),(0,Go),(0,C++),(0,Java),(0,Scala),(1,Julia),(2,Cobol),(2,Python),(2,Haskell),(2,Rescript),_,_,_,_,_",
+  // )
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -65,7 +65,7 @@ pub fn[K : Hash + Eq] HashSet::of(arr : FixedArray[K]) -> HashSet[K] {
 ///   inspect(set.length(), content="1")
 /// ```
 pub fn[K : Hash + Eq] add(self : HashSet[K], key : K) -> Unit {
-  self.add_with_hash(key, key.hash())
+  self.add_with_hash(key, Hasher::new()..combine(key).finalize())
 }
 
 ///|
@@ -126,7 +126,7 @@ fn[K] set_entry(self : HashSet[K], entry : Entry[K], new_idx : Int) -> Unit {
 /// Check if the hash set contains a key.
 pub fn[K : Hash + Eq] contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = abs(hash) & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
@@ -159,7 +159,7 @@ pub fn[K : Hash + Eq] contains(self : HashSet[K], key : K) -> Bool {
 ///   inspect(set.length(), content="1")
 /// ```
 pub fn[K : Hash + Eq] remove(self : HashSet[K], key : K) -> Unit {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = abs(hash) & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break }
     if entry.hash == hash && entry.key == key {

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -397,14 +397,31 @@ test "from_iter empty iter" {
 ///|
 test "hashset arbitrary" {
   let samples : Array[@hashset.HashSet[Int]] = @quickcheck.samples(20)
-  inspect(
-    samples[5:10],
-    content="[@hashset.of([]), @hashset.of([]), @hashset.of([0]), @hashset.of([0]), @hashset.of([0, 3, 1, 2])]",
-  )
-  inspect(
-    samples[11:15],
-    content="[@hashset.of([0, -2, -1]), @hashset.of([0, 4, -5, -2, 8]), @hashset.of([2, 0, -1]), @hashset.of([0])]",
-  )
+  let cases = [
+    @hashset.of([]),
+    @hashset.of([]),
+    @hashset.of([]),
+    @hashset.of([0]),
+    @hashset.of([0]),
+    @hashset.of([]),
+    @hashset.of([]),
+    @hashset.of([0]),
+    @hashset.of([0]),
+    @hashset.of([0, 3, 1, 2]),
+    @hashset.of([0, 1, -2]),
+    @hashset.of([-2, 0, -1]),
+    @hashset.of([-5, 0, 8, 4, -2]),
+    @hashset.of([0, 2, -1]),
+    @hashset.of([0]),
+    @hashset.of([]),
+    @hashset.of([-2, 0, -3, -1]),
+    @hashset.of([-1, 0, 3, 1, -6, 2]),
+    @hashset.of([0]),
+    @hashset.of([-5, -1, 6, 0, 2, -2]),
+  ]
+  for i = 0; i < 20; i = i + 1 {
+    assert_true(samples[i].symmetric_difference(cases[i]).is_empty())
+  }
 }
 
 ///|
@@ -427,5 +444,5 @@ test "@hashset.to_array/multiple" {
   set.add(2)
   set.add(3)
   set.add(4)
-  inspect(set.to_array(), content="[3, 4, 1, 2]")
+  inspect(set.to_array()..sort().to_string(), content="[1, 2, 3, 4]")
 }

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -67,8 +67,14 @@ test "copy" {
 
 ///|
 test "to_json" {
+  let data = [1, 2, 3]
   let set = @hashset.of([1, 2, 3])
-  @json.inspect(set, content=[3, 1, 2])
+  let json = set.to_json()
+  guard json is Array(array) else { fail("Expected JSON array") }
+  for item in data {
+    assert_true(array.contains(item.to_json()))
+  }
+  assert_eq(array.length(), 3)
 }
 
 ///|
@@ -119,22 +125,32 @@ test "is_empty" {
 
 ///|
 test "iter" {
-  let m = @hashset.of(["a", "b", "c"])
-  let mut sum = ""
-  m.each(k => sum += k)
-  inspect(sum, content="cab")
+  let m = @hashset.of(["a", "b", "c"]).iter().collect()
+  m.sort()
+  inspect(
+    m,
+    content=(
+      #|["a", "b", "c"]
+    ),
+  )
 }
 
 ///|
 test "iteri" {
   let m = @hashset.of(["1", "2", "3"])
-  let mut s = ""
+  let s = []
   let mut sum = 0
   m.eachi((i, k) => {
-    s += k
     sum += i
+    s.push(k)
   })
-  inspect(s, content="231")
+  s.sort()
+  inspect(
+    s,
+    content=(
+      #|["1", "2", "3"]
+    ),
+  )
   inspect(sum, content="3")
 }
 
@@ -266,13 +282,11 @@ test "sub" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
-  let map = @hashset.of(["a", "b", "c"])
-  map.iter().each(e => buf.write_string("[\{e}]"))
-  inspect(buf, content="[c][a][b]")
-  buf.reset()
-  map.iter().take(2).each(e => buf.write_string("[\{e}]"))
-  inspect(buf, content="[c][a]")
+  let array = @hashset.of(["a", "b", "c"]).iter().collect()
+  array.sort()
+  inspect(array, content=(
+    #|["a", "b", "c"]
+  ))
 }
 
 ///|
@@ -377,10 +391,9 @@ test "clear_and_reinsert" {
 
 ///|
 test "from_iter multiple elements iter" {
-  inspect(
-    @hashset.from_iter([1, 2, 3].iter()),
-    content="@hashset.of([3, 1, 2])",
-  )
+  let array = @hashset.from_iter([1, 2, 3].iter()).to_array()
+  array.sort()
+  inspect(array, content="[1, 2, 3]")
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -725,5 +725,8 @@ pub impl[K : Hash, V : Hash] Hash for HashMap[K, V] with hash_combine(
   self,
   hasher,
 ) {
-  hasher.combine(self.fold_with_key(init=0, (acc, k, v) => acc ^ Hasher::new()..combine((k, v)).finalize()))
+  hasher.combine(
+    self.fold_with_key(init=0, (acc, k, v) => acc ^
+      Hasher::new()..combine((k, v)).finalize()),
+  )
 }

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -725,5 +725,5 @@ pub impl[K : Hash, V : Hash] Hash for HashMap[K, V] with hash_combine(
   self,
   hasher,
 ) {
-  hasher.combine(self.fold_with_key(init=0, (acc, k, v) => acc ^ (k, v).hash()))
+  hasher.combine(self.fold_with_key(init=0, (acc, k, v) => acc ^ Hasher::new()..combine((k, v)).finalize()))
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -101,17 +101,27 @@ test "HAMT::values" {
 ///|
 test "HAMT::iter" {
   let data = @hashmap.of([(0, "a"), (2, "b"), (3, "d"), (5, "e"), (11111, "f")])
-  let mut s = ""
-  data.iter().each(p => s += " \{p.0},\{p.1}")
-  inspect(s, content=" 0,a 5,e 3,d 11111,f 2,b")
+  let array = data.iter().collect()
+  array.sort()
+  inspect(
+    array,
+    content=(
+      #|[(0, "a"), (2, "b"), (3, "d"), (5, "e"), (11111, "f")]
+    ),
+  )
 }
 
 ///|
 test "HAMT::iter2" {
   let data = @hashmap.of([(0, "a"), (2, "b"), (3, "d"), (5, "e"), (11111, "f")])
-  let mut s = ""
-  data.iter2().each((k, v) => s += " \{k},\{v}")
-  inspect(s, content=" 0,a 5,e 3,d 11111,f 2,b")
+  let array = data.iter2().to_array()
+  array.sort()
+  inspect(
+    array,
+    content=(
+      #|[(0, "a"), (2, "b"), (3, "d"), (5, "e"), (11111, "f")]
+    ),
+  )
 }
 
 ///|
@@ -121,10 +131,8 @@ test "HAMT::to_string" {
     .add(3, 3)
     .add(0x0f_ff_ff_ff, 0x0f_ff_ff_ff)
     .add(42, 42)
-  inspect(
-    map,
-    content="@immut/hashmap.of([(3, 3), (42, 42), (1, 1), (268435455, 268435455)])",
-  )
+  let array = map.to_array()
+  assert_eq(map.to_string(), "@immut/hashmap.of(\{array})")
 }
 
 ///|
@@ -163,10 +171,11 @@ test "to_array" {
 
 ///|
 test "from_iter multiple elements iter" {
-  inspect(
-    @hashmap.from_iter([(1, 1), (2, 2), (3, 3)].iter()),
-    content="@immut/hashmap.of([(3, 3), (2, 2), (1, 1)])",
-  )
+  let map = @hashmap.from_iter([(1, 1), (2, 2), (3, 3)].iter())
+  guard map is { 1: 1, 2: 2, 3: 3, .. } else {
+    fail("Map is not as expected: \{map}")
+  }
+  inspect(map.length(), content="3")
 }
 
 ///|

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -382,7 +382,9 @@ pub fn[A : Eq + Hash] HashSet::of(arr : FixedArray[A]) -> HashSet[A] {
 
 ///|
 pub impl[A : Hash] Hash for HashSet[A] with hash_combine(self, hasher) {
-  hasher.combine(self.iter().fold(init=0, (x, y) => x ^ y.hash()))
+  hasher.combine(
+    self.iter().fold(init=0, (x, y) => x ^ Hasher::new()..combine(y).finalize()),
+  )
 }
 
 ///|

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -68,9 +68,11 @@ test "@hashset.remove" {
 ///|
 test "@hashset.iter" {
   let data = @hashset.of(["a", "b", "d", "e", "f"])
-  let mut s = ""
-  data.iter().each(k => s += " \{k}")
-  inspect(s, content=" e f b a d")
+  let array = data.iter().collect()
+  array.sort()
+  inspect(array, content=(
+    #|["a", "b", "d", "e", "f"]
+  ))
 }
 
 ///|

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -13,6 +13,17 @@
 // limitations under the License.
 
 ///|
+fn[T : Hash + Eq] verify_content(
+  set : @hashset.HashSet[T],
+  expected : Array[T],
+) -> Unit raise {
+  for item in expected {
+    assert_true(set.contains(item))
+  }
+  assert_true(set.length() == expected.length())
+}
+
+///|
 test "Set" {
   let map = loop (0, @hashset.new()) {
     (100, map) => map
@@ -65,7 +76,8 @@ test "@hashset.iter" {
 ///|
 test "@hashset.to_string" {
   let set = @hashset.new().add(1).add(3).add(0x0f_ff_ff_ff).add(42)
-  inspect(set, content="@immut/hashset.of([3, 42, 1, 268435455])")
+  let content = set.iter().collect()
+  assert_eq(set.to_string(), "@immut/hashset.of(\{content})")
 }
 
 ///|
@@ -127,10 +139,9 @@ test "@hashset.iter" {
 
 ///|
 test "from_iter multiple elements iter" {
-  inspect(
-    @hashset.from_iter([1, 2, 3].iter()),
-    content="@immut/hashset.of([3, 2, 1])",
-  )
+  let data = [1, 2, 3]
+  let set = @hashset.from_iter(data.iter())
+  verify_content(set, data)
 }
 
 ///|
@@ -178,8 +189,9 @@ test "remove non-existent key from leaf" {
 
 ///|
 test "from_array - non-empty array" {
-  let set = @hashset.from_array([1, 2, 3])
-  inspect(set, content="@immut/hashset.of([3, 2, 1])")
+  let data = [1, 2, 3]
+  let set = @hashset.from_array(data)
+  verify_content(set, data)
 }
 
 ///|
@@ -327,12 +339,12 @@ test "@hashset.difference patch" {
   let set3 = @hashset.of([])
   let set4 = @hashset.of([1, 2, 3, 4, 5, 6])
   let leaf = @hashset.of([1])
-  inspect(set1.difference(set2), content="@immut/hashset.of([2, 1])")
-  inspect(set1.difference(set3), content="@immut/hashset.of([3, 2, 4, 1])")
-  inspect(set3.difference(set1), content="@immut/hashset.of([])")
-  inspect(set2.difference(set4), content="@immut/hashset.of([])")
-  inspect(leaf.difference(set1), content="@immut/hashset.of([])")
-  inspect(set1.difference(leaf), content="@immut/hashset.of([3, 2, 4])")
+  verify_content(set1.difference(set2), [1, 2])
+  verify_content(set1.difference(set3), [1, 2, 3, 4])
+  verify_content(set3.difference(set1), [])
+  verify_content(set2.difference(set4), [])
+  verify_content(leaf.difference(set1), [])
+  verify_content(set1.difference(leaf), [2, 3, 4])
 }
 
 ///|
@@ -343,13 +355,13 @@ test "@hashset.intersection patch" {
   let set4 = @hashset.of([1, 2, 3, 4, 5, 6])
   let set5 = @hashset.of([7, 8, 9, 10])
   let leaf = @hashset.of([1])
-  inspect(set1.intersection(set2), content="@immut/hashset.of([3, 4])")
-  inspect(set1.intersection(set3), content="@immut/hashset.of([])")
-  inspect(set3.intersection(set1), content="@immut/hashset.of([])")
-  inspect(set2.intersection(set4), content="@immut/hashset.of([5, 3, 6, 4])")
-  inspect(leaf.intersection(set1), content="@immut/hashset.of([1])")
-  inspect(set1.intersection(leaf), content="@immut/hashset.of([1])")
-  inspect(set5.intersection(set1), content="@immut/hashset.of([])")
+  verify_content(set1.intersection(set2), [3, 4])
+  verify_content(set1.intersection(set3), [])
+  verify_content(set3.intersection(set1), [])
+  verify_content(set2.intersection(set4), [3, 4, 5, 6])
+  verify_content(leaf.intersection(set1), [1])
+  verify_content(set1.intersection(leaf), [1])
+  verify_content(set5.intersection(set1), [])
 }
 
 ///|

--- a/immut/internal/path/path.mbt
+++ b/immut/internal/path/path.mbt
@@ -41,7 +41,7 @@ const HEAD_TAG : UInt = 0xffffffffU << (SEGMENT_LENGTH * SEGMENT_NUM)
 /// Creates a Path using the lowest (SEGMENT_LENGTH * SEGMENT_NUM)
 /// bits of the key's hash.
 pub fn[A : Hash] of(key : A) -> Path {
-  key.hash().reinterpret_as_uint() | HEAD_TAG
+  Hasher::new()..combine(key).finalize().reinterpret_as_uint() | HEAD_TAG
 }
 
 ///|

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -98,7 +98,7 @@ pub fn[K : Hash + Eq] Set::from_array(arr : Array[K]) -> Set[K] {
 ///   inspect(set.length(), content="1")
 /// ```
 pub fn[K : Hash + Eq] add(self : Set[K], key : K) -> Unit {
-  self.add_with_hash(key, key.hash())
+  self.add_with_hash(key, Hasher::new()..combine(key).finalize())
 }
 
 ///|
@@ -180,7 +180,7 @@ pub fn[K : Hash + Eq] add_and_check(self : Set[K], key : K) -> Bool {
   if self.size >= self.grow_at {
     self.grow()
   }
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   let (idx, psl, added) = for psl = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
       None => break (idx, psl, true)
@@ -207,7 +207,7 @@ pub fn[K : Hash + Eq] add_and_check(self : Set[K], key : K) -> Bool {
 /// Check if the hash set contains a key.
 pub fn[K : Hash + Eq] Set::contains(self : Set[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
@@ -240,7 +240,7 @@ pub fn[K : Hash + Eq] Set::contains(self : Set[K], key : K) -> Bool {
 ///   inspect(set.length(), content="1")
 /// ```
 pub fn[K : Hash + Eq] remove(self : Set[K], key : K) -> Unit {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break }
     if entry.hash == hash && entry.key == key {
@@ -276,7 +276,7 @@ pub fn[K : Hash + Eq] remove(self : Set[K], key : K) -> Unit {
 ///   inspect(set.length(), content="1")
 /// ```
 pub fn[K : Hash + Eq] remove_and_check(self : Set[K], key : K) -> Bool {
-  let hash = key.hash()
+  let hash = Hasher::new()..combine(key).finalize()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {

--- a/uint16/uint16_test.mbt
+++ b/uint16/uint16_test.mbt
@@ -361,7 +361,7 @@ test "UInt16::to_uint64" {
 
 ///|
 test "UInt16::hash_combine" {
-  let hasher = @builtin.Hasher::new()
+  let hasher = @builtin.Hasher::new(seed=0)
   let value : UInt16 = 42
   value.hash_combine(hasher)
   inspect(hasher.finalize(), content="1161967057")

--- a/uint64/README.mbt.md
+++ b/uint64/README.mbt.md
@@ -137,7 +137,7 @@ test "UInt64 default value" {
 
   // Hash support is available via .hash()
   let value : UInt64 = 42UL
-  inspect(value.hash(), content="-1962516083")
+  inspect(Hasher::new(seed=0)..combine(value).finalize(), content="-1962516083")
 }
 ```
 


### PR DESCRIPTION
This PR makes the hash seed random on JavaScript backend, and cleanup the relevant tests.

This PR is broken into two steps:

1. Migrate `key.hash()` to `Hasher::new()..combine(key).finalize()`. This is to make sure that the hash values are computed based on the hash combine with a seed, which is fixed at this stage. The tests based on the specific hash values are cleaned up.
2. Make the `seed` in `Hasher::new()` random for JS backend. It will use `crypto.getRandomValue` if possible, and fallback to `Math.random`. The tests based on the fixed hash computations are cleaned up.