### PR TITLE
remove unused trait bound

### DIFF
--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -127,7 +127,7 @@ pub fn[A : Compare] pop(self : PriorityQueue[A]) -> PriorityQueue[A]? {
 }
 
 ///|
-fn[A : Compare] remove_last_leaf(self : Node[A], path : Path) -> (A, Node[A]) {
+fn[A] remove_last_leaf(self : Node[A], path : Path) -> (A, Node[A]) {
   match self {
     Empty => abort("Priority queue is empty!")
     Leaf(a) => (a, Empty)


### PR DESCRIPTION
Remove more unused trait bound. The nightly version of the compiler can now detect unused trait bound in single-recursive function, the unused trait bound in this PR is detected using that enhanced unused warning.