### PR TITLE
fix(splitmix): remove derived Default for RandomState

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -48,12 +48,11 @@ QuickCheck provides `Arbitrary` implementations for all basic MoonBit types:
 test "builtin types" {
   // Basic types
   let v : (Bool, Char, Byte) = @quickcheck.gen()
-  inspect(v, content="(true, '#', b'\\x12')")
+  inspect(v, content="(false, '\\u{02}', b'\\x4D')")
   // Numeric types
   let v : (Int, Int64, UInt, UInt64, Float, Double, BigInt) = @quickcheck.gen()
-  inspect(v, content="(0, 0, 0, 0, 0.1430625319480896, 0.33098446695254635, 0)")
+  inspect(v, content="(0, 0, 0, 0, 0.23986786603927612, 0.7917029935679342, 0)")
   // Collections
-
   let v : (String, Bytes, Iter[Int]) = @quickcheck.gen()
   inspect(
     v,

--- a/quickcheck/arbitrary_test.mbt
+++ b/quickcheck/arbitrary_test.mbt
@@ -23,13 +23,13 @@ test {
   let state = @splitmix.RandomState::default()
   let size = 10
   let v : H = @quickcheck.gen(state~, size~)
-  inspect(v, content="{x: 0, y: 0}")
+  inspect(v, content="{x: 6, y: 4}")
   let state = state.split()
   let v : H = @quickcheck.gen(state~, size~)
-  inspect(v, content="{x: -1, y: -2}")
+  inspect(v, content="{x: 1, y: -6}")
   let state = state.split()
   let v : H = @quickcheck.gen(state~, size~)
-  inspect(v, content="{x: 7, y: 2}")
+  inspect(v, content="{x: -9, y: 1}")
 }
 
 ///|
@@ -78,7 +78,8 @@ test "arbitrary float" {
 ///|
 test "arbitrary_iter_break" {
   let rs = @splitmix.RandomState::default()
-  let iter : Iter[Int] = @quickcheck.gen(size=3, state=rs)
+  let iter : Iter[Int] = @quickcheck.gen(size=4, state=rs)
+  // An Iter with a length greater than 0 is required here
   let mut i = 0
   match
     iter.run(_ => {
@@ -98,7 +99,7 @@ test "arbitrary gen bytes" {
   inspect(
     bytes,
     content=(
-      #|b"\xec\xa9a\xbcQ. \x8b"
+      #|b"\xcb"
     ),
   )
 }

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -16,7 +16,7 @@
 struct RandomState {
   mut seed : UInt64
   gamma : UInt64
-} derive(Show, Default)
+} derive(Show)
 
 ///|
 let golden_gamma : UInt64 = 0x9e3779b97f4a7c15
@@ -145,4 +145,16 @@ fn mix_gamma(z0 : UInt64) -> UInt64 {
   } else {
     z1 ^ 0xaaaaaaaaaaaaaaaa
   }
+}
+
+///|
+pub impl Default for RandomState with default() {
+  new()
+}
+
+///|
+test "non-zero default" {
+  let rs = RandomState::default()
+  assert_not_eq(rs.seed, 0)
+  assert_not_eq(rs.gamma, 0)
 }


### PR DESCRIPTION
- It would generate zero `seed` and `gamma`, which affects randomness