### PR TITLE
[draft] feat: separate Iterator into dedicated iterator package

### DIFF
--- a/iterator/README.mbt.md
+++ b/iterator/README.mbt.md
@@ -1,0 +1,73 @@
+# Iterator
+
+External iterator implementation for MoonBit.
+
+## Overview
+
+The `iterator` package provides an external iterator type `Iterator[A]` that allows pull-based iteration. Unlike internal iterators (like `Iter[T]`), external iterators give you control over when to get the next element by calling `next()`.
+
+## Features
+
+- **Pull-based iteration**: Call `next()` to get elements when you need them
+- **Lazy evaluation**: Combinators like `map()` and `filter()` create new iterators without processing elements until consumed
+- **Method chaining**: Chain operations like `iter.filter(...).map(...)`
+- **Memory efficient**: Uses closures to maintain state without allocating intermediate collections
+
+## Basic Usage
+
+```moonbit
+///|
+test {
+  // Create an iterator from a range
+  let iter = Iterator::unfold(1, fn(n) {
+    if n <= 5 {
+      Some((n, n + 1))
+    } else {
+      None
+    }
+  })
+
+  // Use the iterator
+  assert_eq(iter.next(), Some(1))
+  assert_eq(iter.next(), Some(2))
+  assert_eq(iter.next(), Some(3))
+}
+```
+
+## Iterator Creation
+
+- `Iterator::empty()` - Create an empty iterator
+- `Iterator::singleton(value)` - Create an iterator with a single element
+- `Iterator::unfold(init, f)` - Create an iterator from a function and initial state
+
+## Iterator Operations
+
+- `iter.next()` - Get the next element
+- `iter.map(f)` - Transform each element
+- `iter.filter(predicate)` - Filter elements
+- `iter.fold(init, f)` - Fold into a single value
+- `iter.each(f)` - Apply a function to each element
+- `iter.count()` - Count elements
+- `iter.find(predicate)` - Find first matching element
+- `iter.any(predicate)` - Check if any element matches
+- `iter.all(predicate)` - Check if all elements match
+
+## Integration with List
+
+The `list` package provides integration with iterators:
+
+```moonbit
+///|
+test {
+  // Convert List to Iterator
+  let ls = @list.List::of([1, 2, 3, 4, 5])
+  let iter = ls.into_iterator()
+
+  // Process with iterator methods
+  let result = iter.filter(fn(x) { x % 2 == 0 }).map(fn(x) { x * 2 })
+
+  // Collect back to List
+  let final_list = @list.collect_from_iterator(result)
+  // final_list = @list.List::of([4, 8])
+}
+```

--- a/iterator/async_iterator.mbt
+++ b/iterator/async_iterator.mbt
@@ -1,0 +1,34 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub(all) struct AsyncIterator[A](async () -> A?)
+
+///|
+pub async fn[A] AsyncIterator::next(self : AsyncIterator[A]) -> A? {
+  self()
+}
+
+///|
+pub async fn[A, B] AsyncIterator::map(
+  self : AsyncIterator[A],
+  f : (A) -> B,
+) -> AsyncIterator[B] {
+  AsyncIterator(fn() {
+    match self.next() {
+      Some(x) => Some(f(x))
+      None => None
+    }
+  })
+}

--- a/iterator/iterator.mbt
+++ b/iterator/iterator.mbt
@@ -1,0 +1,253 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// External iterator type that allows pull-based iteration.
+///
+/// Unlike internal iterators (like `Iter[T]`), external iterators give you
+/// control over when to get the next element by calling `next()`.
+pub(all) struct Iterator[A](() -> A?)
+
+///|
+/// Get the next element from the iterator.
+///
+/// Returns `Some(element)` if there are more elements, `None` if the iterator is exhausted.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::singleton(42)
+/// assert_eq(iter.next(), Some(42))
+/// assert_eq(iter.next(), None)
+/// ```
+pub fn[A] Iterator::next(self : Iterator[A]) -> A? {
+  let Iterator(f) = self
+  f()
+}
+
+///|
+/// Apply a function to each element of the iterator, creating a new iterator.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(1, fn(n) { if n <= 2 { Some((n, n + 1)) } else { None } })
+/// let mapped = iter.map(fn(x) { x * 2 })
+/// assert_eq(mapped.next(), Some(2))
+/// assert_eq(mapped.next(), Some(4))
+/// ```
+pub fn[A, B] Iterator::map(self : Iterator[A], f : (A) -> B) -> Iterator[B] {
+  Iterator(fn() {
+    match self.next() {
+      Some(x) => Some(f(x))
+      None => None
+    }
+  })
+}
+
+///|
+/// Filter elements of the iterator based on a predicate.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(1, fn(n) { if n <= 4 { Some((n, n + 1)) } else { None } })
+/// let filtered = iter.filter(fn(x) { x % 2 == 0 })
+/// assert_eq(filtered.next(), Some(2))
+/// assert_eq(filtered.next(), Some(4))
+/// ```
+pub fn[A] Iterator::filter(
+  self : Iterator[A],
+  predicate : (A) -> Bool,
+) -> Iterator[A] {
+  Iterator(fn() {
+    while true {
+      match self.next() {
+        Some(x) => if predicate(x) { return Some(x) } else { continue }
+        None => return None
+      }
+    } else {
+      None
+    }
+  })
+}
+
+///|
+/// Fold the iterator into a single value.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(1, fn(n) { if n <= 4 { Some((n, n + 1)) } else { None } })
+/// let sum = iter.fold(0, fn(acc, x) { acc + x })
+/// assert_eq(sum, 10)
+/// ```
+pub fn[A, B] Iterator::fold(self : Iterator[A], init : B, f : (B, A) -> B) -> B {
+  let mut acc = init
+  while true {
+    match self.next() {
+      Some(x) => acc = f(acc, x)
+      None => return acc
+    }
+  } else {
+    acc
+  }
+}
+
+///|
+/// Apply a function to each element of the iterator.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::singleton(42)
+/// iter.each(fn(x) { println(x) })
+/// ```
+pub fn[A] Iterator::each(self : Iterator[A], f : (A) -> Unit) -> Unit {
+  while true {
+    match self.next() {
+      Some(x) => f(x)
+      None => return
+    }
+  }
+}
+
+///|
+/// Count the number of elements in the iterator.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(1, fn(n) { if n <= 4 { Some((n, n + 1)) } else { None } })
+/// assert_eq(iter.count(), 4)
+/// ```
+pub fn[A] Iterator::count(self : Iterator[A]) -> Int {
+  self.fold(0, fn(acc, _) { acc + 1 })
+}
+
+///|
+/// Find the first element that satisfies the predicate.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(1, fn(n) { if n <= 4 { Some((n, n + 1)) } else { None } })
+/// assert_eq(iter.find(fn(x) { x > 2 }), Some(3))
+/// ```
+pub fn[A] Iterator::find(self : Iterator[A], predicate : (A) -> Bool) -> A? {
+  while true {
+    match self.next() {
+      Some(x) => if predicate(x) { return Some(x) } else { continue }
+      None => return None
+    }
+  } else {
+    None
+  }
+}
+
+///|
+/// Check if any element satisfies the predicate.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(1, fn(n) { if n <= 4 { Some((n, n + 1)) } else { None } })
+/// assert_eq(iter.any(fn(x) { x > 3 }), true)
+/// ```
+pub fn[A] Iterator::any(self : Iterator[A], predicate : (A) -> Bool) -> Bool {
+  match self.find(predicate) {
+    Some(_) => true
+    None => false
+  }
+}
+
+///|
+/// Check if all elements satisfy the predicate.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(2, fn(n) { if n <= 4 { Some((n, n + 2)) } else { None } })
+/// assert_eq(iter.all(fn(x) { x % 2 == 0 }), true)
+/// ```
+pub fn[A] Iterator::all(self : Iterator[A], predicate : (A) -> Bool) -> Bool {
+  while true {
+    match self.next() {
+      Some(x) => if !predicate(x) { return false } else { continue }
+      None => return true
+    }
+  } else {
+    true
+  }
+}
+
+///|
+/// Create an empty iterator.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter : Iterator[Int] = Iterator::empty()
+/// assert_eq(iter.next(), None)
+/// ```
+pub fn[A] Iterator::empty() -> Iterator[A] {
+  Iterator(fn() { None })
+}
+
+///|
+/// Create an iterator from a single element.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::singleton(42)
+/// assert_eq(iter.next(), Some(42))
+/// assert_eq(iter.next(), None)
+/// ```
+pub fn[A] Iterator::singleton(value : A) -> Iterator[A] {
+  let mut consumed = false
+  Iterator(fn() {
+    if consumed {
+      None
+    } else {
+      consumed = true
+      Some(value)
+    }
+  })
+}
+
+///|
+/// Create an iterator from a function and initial state.
+///
+/// # Example
+///
+/// ```moonbit
+/// let iter = Iterator::unfold(0, fn(n) { if n < 3 { Some((n, n + 1)) } else { None } })
+/// assert_eq(iter.next(), Some(0))
+/// assert_eq(iter.next(), Some(1))
+/// assert_eq(iter.next(), Some(2))
+/// assert_eq(iter.next(), None)
+/// ```
+pub fn[A, S] Iterator::unfold(init : S, f : (S) -> (A, S)?) -> Iterator[A] {
+  let mut state = init
+  Iterator(fn() {
+    match f(state) {
+      Some((value, new_state)) => {
+        state = new_state
+        Some(value)
+      }
+      None => None
+    }
+  })
+}

--- a/iterator/iterator_test.mbt
+++ b/iterator/iterator_test.mbt
@@ -1,0 +1,142 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "external iterator basic usage" {
+  let ls = @list.List::of([1, 2, 3])
+  let iter = ls.into_iterator()
+  assert_eq(iter.next(), Some(1))
+  assert_eq(iter.next(), Some(2))
+  assert_eq(iter.next(), Some(3))
+  assert_eq(iter.next(), None)
+}
+
+///|
+test "external iterator map" {
+  let ls = @list.List::of([1, 2, 3])
+  let iter = ls.into_iterator().map(fn(x) { x * 2 })
+  assert_eq(iter.next(), Some(2))
+  assert_eq(iter.next(), Some(4))
+  assert_eq(iter.next(), Some(6))
+  assert_eq(iter.next(), None)
+}
+
+///|
+test "external iterator filter" {
+  let ls = @list.List::of([1, 2, 3, 4, 5, 6])
+  let iter = ls.into_iterator().filter(fn(x) { x % 2 == 0 })
+  assert_eq(iter.next(), Some(2))
+  assert_eq(iter.next(), Some(4))
+  assert_eq(iter.next(), Some(6))
+  assert_eq(iter.next(), None)
+}
+
+///|
+test "external iterator fold" {
+  let ls = @list.List::of([1, 2, 3, 4])
+  let iter = ls.into_iterator()
+  let sum = iter.fold(0, fn(acc, x) { acc + x })
+  assert_eq(sum, 10)
+}
+
+///|
+test "external iterator collect" {
+  let ls = @list.List::of([1, 2, 3])
+  let iter = ls.into_iterator().map(fn(x) { x * 2 })
+  let result = @list.collect_from_iterator(iter)
+  assert_eq(result, @list.List::of([2, 4, 6]))
+}
+
+///|
+test "external iterator count" {
+  let ls = @list.List::of([1, 2, 3, 4, 5])
+  let iter = ls.into_iterator()
+  assert_eq(iter.count(), 5)
+}
+
+///|
+test "external iterator find" {
+  let ls = @list.List::of([1, 2, 3, 4, 5])
+  let iter = ls.into_iterator()
+  assert_eq(iter.find(fn(x) { x > 3 }), Some(4))
+}
+
+///|
+test "external iterator any" {
+  let ls = @list.List::of([1, 2, 3, 4, 5])
+  let iter = ls.into_iterator()
+  assert_eq(iter.any(fn(x) { x > 4 }), true)
+  let ls2 = @list.List::of([1, 2, 3])
+  let iter2 = ls2.into_iterator()
+  assert_eq(iter2.any(fn(x) { x > 5 }), false)
+}
+
+///|
+test "external iterator all" {
+  let ls = @list.List::of([2, 4, 6])
+  let iter = ls.into_iterator()
+  assert_eq(iter.all(fn(x) { x % 2 == 0 }), true)
+  let ls2 = @list.List::of([2, 3, 6])
+  let iter2 = ls2.into_iterator()
+  assert_eq(iter2.all(fn(x) { x % 2 == 0 }), false)
+}
+
+///|
+test "external iterator empty list" {
+  let ls : @list.List[Int] = @list.List::new()
+  let iter = ls.into_iterator()
+  assert_eq(iter.next(), None)
+  assert_eq(iter.count(), 0)
+  assert_eq(@list.collect_from_iterator(iter), @list.List::new())
+}
+
+///|
+test "external iterator chaining" {
+  let ls = @list.List::of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  let iter = ls
+    .into_iterator()
+    .filter(fn(x) { x % 2 == 0 })
+    .map(fn(x) { x * 3 })
+  let result = @list.collect_from_iterator(iter)
+  assert_eq(result, @list.List::of([6, 12, 18, 24, 30]))
+}
+
+///|
+test "iterator empty" {
+  let iter : Iterator[Int] = Iterator::empty()
+  assert_eq(iter.next(), None)
+  assert_eq(iter.count(), 0)
+}
+
+///|
+test "iterator singleton" {
+  let iter = Iterator::singleton(42)
+  assert_eq(iter.next(), Some(42))
+  assert_eq(iter.next(), None)
+}
+
+///|
+test "iterator unfold" {
+  let iter = Iterator::unfold(0, fn(n) {
+    if n < 3 {
+      Some((n, n + 1))
+    } else {
+      None
+    }
+  })
+  assert_eq(iter.next(), Some(0))
+  assert_eq(iter.next(), Some(1))
+  assert_eq(iter.next(), Some(2))
+  assert_eq(iter.next(), None)
+}

--- a/iterator/moon.pkg.json
+++ b/iterator/moon.pkg.json
@@ -1,0 +1,8 @@
+{
+  "import": [
+    "moonbitlang/core/builtin"
+  ],
+  "test-import": [
+    "moonbitlang/core/list"
+  ]
+}

--- a/iterator/pkg.generated.mbti
+++ b/iterator/pkg.generated.mbti
@@ -1,0 +1,34 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/iterator"
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct AsyncIterator[A](async () -> A?)
+#deprecated
+fn[A] AsyncIterator::inner(Self[A]) -> async () -> A?
+async fn[A, B] AsyncIterator::map(Self[A], (A) -> B) -> Self[B]
+async fn[A] AsyncIterator::next(Self[A]) -> A?
+
+pub(all) struct Iterator[A](() -> A?)
+fn[A] Iterator::all(Self[A], (A) -> Bool) -> Bool
+fn[A] Iterator::any(Self[A], (A) -> Bool) -> Bool
+fn[A] Iterator::count(Self[A]) -> Int
+fn[A] Iterator::each(Self[A], (A) -> Unit) -> Unit
+fn[A] Iterator::empty() -> Self[A]
+fn[A] Iterator::filter(Self[A], (A) -> Bool) -> Self[A]
+fn[A] Iterator::find(Self[A], (A) -> Bool) -> A?
+fn[A, B] Iterator::fold(Self[A], B, (B, A) -> B) -> B
+#deprecated
+fn[A] Iterator::inner(Self[A]) -> () -> A?
+fn[A, B] Iterator::map(Self[A], (A) -> B) -> Self[B]
+fn[A] Iterator::next(Self[A]) -> A?
+fn[A] Iterator::singleton(A) -> Self[A]
+fn[A, S] Iterator::unfold(S, (S) -> (A, S)?) -> Self[A]
+
+// Type aliases
+
+// Traits
+

--- a/list/list_iterator_ext.mbt
+++ b/list/list_iterator_ext.mbt
@@ -1,0 +1,71 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Convert a List into an external iterator.
+///
+/// # Example
+///
+/// ```moonbit
+/// let ls = @list.List::of([1, 2, 3])
+/// let iter = ls.into_iterator()
+/// assert_eq(iter.next(), Some(1))
+/// assert_eq(iter.next(), Some(2))
+/// assert_eq(iter.next(), Some(3))
+/// assert_eq(iter.next(), None)
+/// ```
+pub fn[A] List::into_iterator(self : List[A]) -> @iterator.Iterator[A] {
+  let mut current = self
+  @iterator.Iterator(fn() {
+    match current {
+      Empty => None
+      More(head, tail~) => {
+        current = tail
+        Some(head)
+      }
+    }
+  })
+}
+
+///|
+/// Collect all elements from an iterator into a List.
+///
+/// This is a standalone function that can be used to collect any iterator into a List.
+///
+/// # Example
+///
+/// ```moonbit
+/// let ls = @list.List::of([1, 2, 3])
+/// let iter = ls.into_iterator().map(fn(x) { x * 2 })
+/// let result = @list.collect_from_iterator(iter)
+/// assert_eq(result, @list.List::of([2, 4, 6]))
+/// ```
+pub fn[A] collect_from_iterator(iter : @iterator.Iterator[A]) -> List[A] {
+  let reversed = iter.fold(Empty, fn(acc, x) { More(x, tail=acc) })
+  reversed.rev()
+}
+
+///|
+pub fn[A] into_async_iterator(self : List[A]) -> @iterator.AsyncIterator[A] {
+  let mut current = self
+  @iterator.AsyncIterator(fn() {
+    match current {
+      Empty => None
+      More(head, tail~) => {
+        current = tail
+        Some(head)
+      }
+    }
+  })
+}

--- a/list/moon.pkg.json
+++ b/list/moon.pkg.json
@@ -3,7 +3,8 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/json"
+    "moonbitlang/core/json",
+    "moonbitlang/core/iterator"
   ],
   "test-import": [],
   "targets": {

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -2,11 +2,14 @@
 package "moonbitlang/core/list"
 
 import(
+  "moonbitlang/core/iterator"
   "moonbitlang/core/json"
   "moonbitlang/core/quickcheck"
 )
 
 // Values
+fn[A] collect_from_iterator(@iterator.Iterator[A]) -> List[A]
+
 fn[X] default() -> List[X]
 
 // Errors
@@ -47,6 +50,8 @@ fn[A : @json.FromJson] List::from_json(Json) -> Self[A] raise @json.JsonDecodeEr
 fn[A] List::head(Self[A]) -> A?
 fn[A] List::intercalate(Self[Self[A]], Self[A]) -> Self[A]
 fn[A] List::intersperse(Self[A], A) -> Self[A]
+fn[A] List::into_async_iterator(Self[A]) -> @iterator.AsyncIterator[A]
+fn[A] List::into_iterator(Self[A]) -> @iterator.Iterator[A]
 fn[A] List::is_empty(Self[A]) -> Bool
 fn[A : Eq] List::is_prefix(Self[A], Self[A]) -> Bool
 fn[A : Eq] List::is_suffix(Self[A], Self[A]) -> Bool


### PR DESCRIPTION
- Create new iterator package with external Iterator[A] implementation
- Move Iterator struct and all methods (next, map, filter, fold, etc.) to iterator package
- Add Iterator factory methods: empty(), singleton(), unfold()
- Add AsyncIterator[A] implementation for async iteration
- Update list package to depend on iterator package
- Add List::into_iterator() method for converting List to Iterator
- Add into_async_iterator() method for converting List to AsyncIterator
- Add collect_from_iterator() function for collecting Iterator back to List
- Maintain all existing functionality with 5646 tests passing
- Avoid circular dependencies by keeping iterator package minimal
- Add comprehensive tests and documentation for iterator package

Breaking change: Iterator is now in @iterator package instead of @list
