### PR TITLE
Add UInt16::reinterpret_as_int16 method

### DIFF
--- a/uint16/uint16.mbt
+++ b/uint16/uint16.mbt
@@ -102,3 +102,9 @@ pub fn UInt16::to_uint(self : UInt16) -> UInt {
 pub fn UInt16::to_uint64(self : UInt16) -> UInt64 {
   self.to_int().to_uint64()
 }
+
+///|
+/// reinterpret as an unsigned integer with binary complement
+pub fn UInt16::reinterpret_as_int16(self : UInt16) -> Int16 {
+  self.to_int().to_int16()
+}

--- a/uint16/uint16_test.mbt
+++ b/uint16/uint16_test.mbt
@@ -371,3 +371,14 @@ test "UInt16::hash_combine" {
 test "UInt16::default" {
   inspect(UInt16::default(), content="0")
 }
+
+///|
+test "UInt16::reinterpret_as_int16" {
+  inspect(UInt16::reinterpret_as_int16(0), content="0")
+  inspect(UInt16::reinterpret_as_int16(1), content="1")
+  inspect(UInt16::reinterpret_as_int16(32768), content="-32768")
+  inspect(UInt16::reinterpret_as_int16(65535), content="-1")
+  inspect(UInt16::reinterpret_as_int16(65534), content="-2")
+  inspect(UInt16::reinterpret_as_int16(12345), content="12345")
+  inspect(UInt16::reinterpret_as_int16(54321), content="-11215")
+}


### PR DESCRIPTION
This PR adds the `UInt16::reinterpret_as_int16` method to convert UInt16 to Int16 using two's complement representation.

## Changes
- Adds `UInt16::reinterpret_as_int16` method that mirrors the existing `Int16::reinterpret_as_uint16` for symmetry
- Adds comprehensive tests covering edge cases including 0, 1, max values, and typical conversions
- This enables a consistent pattern where `write_int16_le` can delegate to `write_uint16_le` in buffer operations (similar to how 32-bit and 64-bit functions work)

## Context
This change was made as part of investigating whether `write_uint16_le` and `write_int16_le` are exactly the same. They write the same bit pattern (two's complement), and having the reinterpret method allows for code reuse and consistency with the existing patterns in the codebase.

## Testing
- Added tests for various edge cases
- All existing tests pass
- Pre-commit hooks (moon fmt, moon check) passed successfully