### PR TITLE
refactor(bench): rename bench handle type and expose Bench::new

### DIFF
--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -52,7 +52,7 @@ fn iter_count(name? : String, inner : () -> Unit, count : UInt) -> Summary {
 ///|
 /// Run a benchmark in batch mode
 pub fn bench(
-  self : T,
+  self : Bench,
   name? : String,
   f : () -> Unit,
   count? : UInt = 10,
@@ -80,7 +80,7 @@ pub fn single_bench(
 ///|
 /// Keep a value to prevent the optimizer from removing 
 /// the calculation that produces it.
-pub fn[Any] keep(self : T, value : Any) -> Unit {
+pub fn[Any] keep(self : Bench, value : Any) -> Unit {
   let trait_object : &OpaqueValue = value
   self._storage = trait_object
 }
@@ -89,7 +89,7 @@ pub fn[Any] keep(self : T, value : Any) -> Unit {
 /// Returns a JSON array string containing all collected benchmark summaries.
 /// This helper is mainly used internally for tests and diagnostics.
 #coverage.skip
-pub fn dump_summaries(self : T) -> String {
+pub fn dump_summaries(self : Bench) -> String {
   "[\{self.buffer.to_string()}]"
 }
 

--- a/bench/pkg.generated.mbti
+++ b/bench/pkg.generated.mbti
@@ -6,24 +6,25 @@ fn monotonic_clock_end(Timestamp) -> Double
 
 fn monotonic_clock_start() -> Timestamp
 
-fn new() -> T
-
 fn single_bench(name? : String, () -> Unit, count? : UInt) -> Summary
 
 // Errors
 
 // Types and methods
+type Bench
+fn Bench::bench(Self, name? : String, () -> Unit, count? : UInt) -> Unit
+fn Bench::dump_summaries(Self) -> String
+fn[Any] Bench::keep(Self, Any) -> Unit
+#as_free_fn
+fn Bench::new() -> Self
+
 type Summary
 impl ToJson for Summary
-
-type T
-fn T::bench(Self, name? : String, () -> Unit, count? : UInt) -> Unit
-fn T::dump_summaries(Self) -> String
-fn[Any] T::keep(Self, Any) -> Unit
 
 type Timestamp
 
 // Type aliases
+pub typealias Bench as T
 
 // Traits
 

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -16,14 +16,18 @@
 priv trait OpaqueValue {}
 
 ///|
-struct T {
+struct Bench {
   buffer : StringBuilder
   summaries : Array[Summary]
   mut _storage : &OpaqueValue
 }
 
 ///|
-pub fn new() -> T {
+pub typealias Bench as T
+
+///|
+#as_free_fn
+pub fn Bench::new() -> Bench {
   let buffer = StringBuilder::new()
   let summaries = Array::new()
   { buffer, summaries, _storage: () }


### PR DESCRIPTION
## Summary
- rename the internal bench struct from `T` to `Bench` for clarity
- publish a `typealias Bench as T` so existing code keeps compiling
- expose the constructor as `Bench::new` with `#as_free_fn` for ergonomic usage
- update generated interface and method receivers to use the new type name

## Testing
- `moon check` (run automatically during commit)