### PR TITLE
deprecate old `op_xxx` operator names

### DIFF
--- a/builtin/operators.mbt
+++ b/builtin/operators.mbt
@@ -16,6 +16,7 @@
 /// types implementing this trait can use the `+` operator
 pub(open) trait Add {
   add(Self, Self) -> Self = _
+  #deprecated("use `add` instead")
   op_add(Self, Self) -> Self = _
 }
 
@@ -23,6 +24,7 @@ pub(open) trait Add {
 /// types implementing this trait can use the `-` operator
 pub(open) trait Sub {
   sub(Self, Self) -> Self = _
+  #deprecated("use `sub` instead")
   op_sub(Self, Self) -> Self = _
 }
 
@@ -30,6 +32,7 @@ pub(open) trait Sub {
 /// types implementing this trait can use the `*` operator
 pub(open) trait Mul {
   mul(Self, Self) -> Self = _
+  #deprecated("use `mul` instead")
   op_mul(Self, Self) -> Self = _
 }
 
@@ -37,6 +40,7 @@ pub(open) trait Mul {
 /// types implementing this trait can use the `/` operator
 pub(open) trait Div {
   div(Self, Self) -> Self = _
+  #deprecated("use `div` instead")
   op_div(Self, Self) -> Self = _
 }
 
@@ -44,6 +48,7 @@ pub(open) trait Div {
 /// types implementing this trait can use the unary `-` operator
 pub(open) trait Neg {
   neg(Self) -> Self = _
+  #deprecated("use `neg` instead")
   op_neg(Self) -> Self = _
 }
 
@@ -51,6 +56,7 @@ pub(open) trait Neg {
 /// types implementing this trait can use the `%` operator
 pub(open) trait Mod {
   mod(Self, Self) -> Self = _
+  #deprecated("use `mod` instead")
   op_mod(Self, Self) -> Self = _
 }
 
@@ -76,6 +82,7 @@ pub(open) trait BitXOr {
 /// types implementing this trait can use the `<<` operator
 pub(open) trait Shl {
   shl(Self, Int) -> Self = _
+  #deprecated("use `shl` instead")
   op_shl(Self, Int) -> Self = _
 }
 
@@ -83,6 +90,7 @@ pub(open) trait Shl {
 /// types implementing this trait can use the `>>` operator
 pub(open) trait Shr {
   shr(Self, Int) -> Self = _
+  #deprecated("use `shr` instead")
   op_shr(Self, Int) -> Self = _
 }
 

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -588,6 +588,7 @@ fn[Obj : Show] Logger::write_object(&Self, Obj) -> Unit
 // Traits
 pub(open) trait Add {
   add(Self, Self) -> Self = _
+  #deprecated
   op_add(Self, Self) -> Self = _
 }
 impl Add for Byte
@@ -669,6 +670,7 @@ impl[X] Default for FixedArray[X]
 
 pub(open) trait Div {
   div(Self, Self) -> Self = _
+  #deprecated
   op_div(Self, Self) -> Self = _
 }
 impl Div for Byte
@@ -681,6 +683,7 @@ impl Div for Double
 
 pub(open) trait Eq {
   equal(Self, Self) -> Bool = _
+  #deprecated
   op_equal(Self, Self) -> Bool = _
 }
 impl Eq for Unit
@@ -739,6 +742,7 @@ pub(open) trait Logger {
 
 pub(open) trait Mod {
   mod(Self, Self) -> Self = _
+  #deprecated
   op_mod(Self, Self) -> Self = _
 }
 impl Mod for Byte
@@ -749,6 +753,7 @@ impl Mod for UInt64
 
 pub(open) trait Mul {
   mul(Self, Self) -> Self = _
+  #deprecated
   op_mul(Self, Self) -> Self = _
 }
 impl Mul for Byte
@@ -761,6 +766,7 @@ impl Mul for Double
 
 pub(open) trait Neg {
   neg(Self) -> Self = _
+  #deprecated
   op_neg(Self) -> Self = _
 }
 impl Neg for Int
@@ -770,6 +776,7 @@ impl Neg for Double
 
 pub(open) trait Shl {
   shl(Self, Int) -> Self = _
+  #deprecated
   op_shl(Self, Int) -> Self = _
 }
 impl Shl for Byte
@@ -814,6 +821,7 @@ impl[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show
 
 pub(open) trait Shr {
   shr(Self, Int) -> Self = _
+  #deprecated
   op_shr(Self, Int) -> Self = _
 }
 impl Shr for Byte
@@ -824,6 +832,7 @@ impl Shr for UInt64
 
 pub(open) trait Sub {
   sub(Self, Self) -> Self = _
+  #deprecated
   op_sub(Self, Self) -> Self = _
 }
 impl Sub for Byte

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -16,6 +16,7 @@
 /// Trait for types whose elements can test for equality
 pub(open) trait Eq {
   equal(Self, Self) -> Bool = _
+  #deprecated("use `equal` instead")
   op_equal(Self, Self) -> Bool = _
 }
 


### PR DESCRIPTION
The compiler has already migrated from `op_xxx` to `xxx` for operator overloading, so the `op_xxx` methods of the operator traits can now be deprecated. Note that the default implementation for `add`, `sub` etc. are already deprecated, this PR deals with the rare case where `op_xxx` is called directly.