### PR TITLE
remove `self : T` style of method declaration

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -70,7 +70,10 @@ pub fn[T] Array::push_iter(self : Self[T], iter : Iter[T]) -> Unit {
 ///   }
 ///   Array::shuffle_in_place(arr, rand=rand)
 /// ```
-pub fn[T] shuffle_in_place(self : Array[T], rand~ : (Int) -> Int) -> Unit {
+pub fn[T] Array::shuffle_in_place(
+  self : Array[T],
+  rand~ : (Int) -> Int,
+) -> Unit {
   let n = self.length()
   for i = n - 1; i > 0; i = i - 1 {
     let j = rand(i + 1) % (i + 1)
@@ -96,7 +99,7 @@ pub fn[T] shuffle_in_place(self : Array[T], rand~ : (Int) -> Int) -> Unit {
 ///   }
 ///   let _shuffled = Array::shuffle(arr, rand=rand)
 /// ```
-pub fn[T] shuffle(self : Array[T], rand~ : (Int) -> Int) -> Array[T] {
+pub fn[T] Array::shuffle(self : Array[T], rand~ : (Int) -> Int) -> Array[T] {
   let new_arr = self.copy()
   Array::shuffle_in_place(new_arr, rand~)
   new_arr
@@ -112,7 +115,7 @@ pub fn[T] shuffle(self : Array[T], rand~ : (Int) -> Int) -> Array[T] {
 ///
 /// # Returns
 ///
-pub fn[A, B] filter_map(
+pub fn[A, B] Array::filter_map(
   self : Array[A],
   f : (A) -> B? raise?,
 ) -> Array[B] raise? {
@@ -144,7 +147,7 @@ pub fn[A, B] filter_map(
 ///   let empty : Array[Int] = []
 ///   inspect(empty.last(), content="None")
 /// ```
-pub fn[A] last(self : Array[A]) -> A? {
+pub fn[A] Array::last(self : Array[A]) -> A? {
   match self {
     [] => None
     [.., last] => Some(last)
@@ -169,7 +172,7 @@ pub fn[A] last(self : Array[A]) -> A? {
 ///   let arr2 = ['a', 'b', 'c']
 ///   inspect(arr1.zip(arr2), content="[(1, 'a'), (2, 'b'), (3, 'c')]")
 /// ```
-pub fn[A, B] zip(self : Array[A], other : Array[B]) -> Array[(A, B)] {
+pub fn[A, B] Array::zip(self : Array[A], other : Array[B]) -> Array[(A, B)] {
   let length = if self.length() < other.length() {
     self.length()
   } else {
@@ -188,7 +191,7 @@ pub fn[A, B] zip(self : Array[A], other : Array[B]) -> Array[(A, B)] {
 ///   inspect(nums, content="[1, 2, 3]")
 ///   inspect(strs, content="[\"a\", \"b\", \"c\"]")
 /// ```
-pub fn[T1, T2] unzip(self : Array[(T1, T2)]) -> (Array[T1], Array[T2]) {
+pub fn[T1, T2] Array::unzip(self : Array[(T1, T2)]) -> (Array[T1], Array[T2]) {
   let arr1 : Array[T1] = Array::new(capacity=self.length())
   let arr2 : Array[T2] = Array::new(capacity=self.length())
   for pair in self {
@@ -245,7 +248,10 @@ pub fn[A, B, C] zip_with(
 ///   let arr2 = ['a', 'b', 'c']
 ///   inspect(arr1.zip_to_iter2(arr2).to_array(), content="[(1, 'a'), (2, 'b'), (3, 'c')]")
 /// ```
-pub fn[A, B] zip_to_iter2(self : Array[A], other : Array[B]) -> Iter2[A, B] {
+pub fn[A, B] Array::zip_to_iter2(
+  self : Array[A],
+  other : Array[B],
+) -> Iter2[A, B] {
   Iter2::new(yield_ => {
     let length = if self.length() < other.length() {
       self.length()

--- a/array/array_js.mbt
+++ b/array/array_js.mbt
@@ -49,6 +49,6 @@ extern "js" fn JSArray::copy(self : JSArray) -> JSArray =
 ///   inspect(copied, content="[1, 2, 3]")
 ///   inspect(physical_equal(original, copied), content="false")
 /// ```
-pub fn[T] copy(self : Array[T]) -> Array[T] {
+pub fn[T] Array::copy(self : Array[T]) -> Array[T] {
   JSArray::ofAnyArray(self).copy().toAnyArray()
 }

--- a/array/array_nonjs.mbt
+++ b/array/array_nonjs.mbt
@@ -30,7 +30,7 @@
 ///   inspect(copied, content="[1, 2, 3]")
 ///   inspect(physical_equal(original, copied), content="false")
 /// ```
-pub fn[T] copy(self : Array[T]) -> Array[T] {
+pub fn[T] Array::copy(self : Array[T]) -> Array[T] {
   let len = self.length()
   if len == 0 {
     []

--- a/array/sort.mbt
+++ b/array/sort.mbt
@@ -24,7 +24,7 @@
 ///   arr.sort()
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// ```
-pub fn[T : Compare] sort(self : Array[T]) -> Unit {
+pub fn[T : Compare] Array::sort(self : Array[T]) -> Unit {
   let len = self.length()
   self.quick_sort(start=0, end=len, None, get_limit(len))
 }

--- a/array/sort_by.mbt
+++ b/array/sort_by.mbt
@@ -24,7 +24,10 @@
 ///   arr.sort_by_key((x) => {-x})
 ///   assert_eq(arr, [5, 4, 3, 2, 1])
 /// ```
-pub fn[T, K : Compare] sort_by_key(self : Array[T], map : (T) -> K) -> Unit {
+pub fn[T, K : Compare] Array::sort_by_key(
+  self : Array[T],
+  map : (T) -> K,
+) -> Unit {
   self.quick_sort_by(
     start=0,
     end=self.length(),
@@ -46,7 +49,7 @@ pub fn[T, K : Compare] sort_by_key(self : Array[T], map : (T) -> K) -> Unit {
 ///   arr.sort_by((a, b) => { a - b })
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// ```
-pub fn[T] sort_by(self : Array[T], cmp : (T, T) -> Int) -> Unit {
+pub fn[T] Array::sort_by(self : Array[T], cmp : (T, T) -> Int) -> Unit {
   self.quick_sort_by(
     start=0,
     end=self.length(),

--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -51,7 +51,7 @@ fn iter_count(name? : String, inner : () -> Unit, count : UInt) -> Summary {
 
 ///|
 /// Run a benchmark in batch mode
-pub fn bench(
+pub fn Bench::bench(
   self : Bench,
   name? : String,
   f : () -> Unit,
@@ -80,7 +80,7 @@ pub fn single_bench(
 ///|
 /// Keep a value to prevent the optimizer from removing 
 /// the calculation that produces it.
-pub fn[Any] keep(self : Bench, value : Any) -> Unit {
+pub fn[Any] Bench::keep(self : Bench, value : Any) -> Unit {
   let trait_object : &OpaqueValue = value
   self._storage = trait_object
 }
@@ -89,7 +89,7 @@ pub fn[Any] keep(self : Bench, value : Any) -> Unit {
 /// Returns a JSON array string containing all collected benchmark summaries.
 /// This helper is mainly used internally for tests and diagnostics.
 #coverage.skip
-pub fn dump_summaries(self : Bench) -> String {
+pub fn Bench::dump_summaries(self : Bench) -> String {
   "[\{self.buffer.to_string()}]"
 }
 

--- a/bool/bool.mbt
+++ b/bool/bool.mbt
@@ -27,7 +27,7 @@
 ///   inspect(true.to_int(), content="1")
 ///   inspect(false.to_int(), content="0")
 /// ```
-pub fn to_int(self : Bool) -> Int {
+pub fn Bool::to_int(self : Bool) -> Int {
   if self {
     1
   } else {
@@ -51,7 +51,7 @@ pub fn to_int(self : Bool) -> Int {
 ///   inspect(true.to_int64(), content="1")
 ///   inspect(false.to_int64(), content="0")
 /// ```
-pub fn to_int64(self : Bool) -> Int64 {
+pub fn Bool::to_int64(self : Bool) -> Int64 {
   if self {
     1
   } else {
@@ -75,7 +75,7 @@ pub fn to_int64(self : Bool) -> Int64 {
 ///   inspect(true.to_uint(), content="1")
 ///   inspect(false.to_uint(), content="0")
 /// ```
-pub fn to_uint(self : Bool) -> UInt {
+pub fn Bool::to_uint(self : Bool) -> UInt {
   if self {
     1
   } else {
@@ -99,7 +99,7 @@ pub fn to_uint(self : Bool) -> UInt {
 ///   inspect(true.to_uint64(), content="1")
 ///   inspect(false.to_uint64(), content="0")
 /// ```
-pub fn to_uint64(self : Bool) -> UInt64 {
+pub fn Bool::to_uint64(self : Bool) -> UInt64 {
   if self {
     1
   } else {
@@ -129,7 +129,7 @@ pub impl Hash for Bool with hash_combine(self, hasher) {
 /// inspect(false.to_uint16(), content="0")
 /// ```
 ///
-pub fn to_uint16(self : Bool) -> UInt16 {
+pub fn Bool::to_uint16(self : Bool) -> UInt16 {
   if self {
     1
   } else {
@@ -154,7 +154,7 @@ pub fn to_uint16(self : Bool) -> UInt16 {
 /// inspect(false.to_int16(), content="0")
 /// ```
 ///
-pub fn to_int16(self : Bool) -> Int16 {
+pub fn Bool::to_int16(self : Bool) -> Int16 {
   if self {
     1
   } else {

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -42,7 +42,7 @@ struct Buffer {
 
 ///|
 /// Expand the buffer size if capacity smaller than required space.
-fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
+fn Buffer::grow_if_necessary(self : Buffer, required : Int) -> Unit {
   let start = if self.data.length() <= 0 { 1 } else { self.data.length() }
   let enough_space = for space = start {
     if space >= required {
@@ -73,7 +73,7 @@ fn grow_if_necessary(self : Buffer, required : Int) -> Unit {
 ///   buf.write_string("Test")
 ///   inspect(buf.length(), content="8") // each char takes 2 bytes in UTF-16
 /// ```
-pub fn length(self : Buffer) -> Int {
+pub fn Buffer::length(self : Buffer) -> Int {
   self.len
 }
 
@@ -95,7 +95,7 @@ pub fn length(self : Buffer) -> Int {
 ///   buf.write_string("test")
 ///   inspect(buf.is_empty(), content="false")
 /// ```
-pub fn is_empty(self : Buffer) -> Bool {
+pub fn Buffer::is_empty(self : Buffer) -> Bool {
   self.len == 0
 }
 
@@ -122,7 +122,7 @@ pub fn is_empty(self : Buffer) -> Bool {
 ///     ),
 ///   )
 /// ```
-pub fn contents(self : Buffer) -> Bytes {
+pub fn Buffer::contents(self : Buffer) -> Bytes {
   @bytes.from_fixedarray(self.data, len=self.len)
 }
 
@@ -252,7 +252,7 @@ pub impl Logger for Buffer with write_string(self, value) {
 ///     ),
 ///   )
 /// ```
-pub fn write_uint64_be(self : Buffer, value : UInt64) -> Unit {
+pub fn Buffer::write_uint64_be(self : Buffer, value : UInt64) -> Unit {
   self.grow_if_necessary(self.len + 8)
   let offset = self.len
   self.data[offset] = (value >> 56).to_byte()
@@ -289,7 +289,7 @@ pub fn write_uint64_be(self : Buffer, value : UInt64) -> Unit {
 ///     ),
 ///   )
 /// ```
-pub fn write_uint64_le(self : Buffer, value : UInt64) -> Unit {
+pub fn Buffer::write_uint64_le(self : Buffer, value : UInt64) -> Unit {
   self.grow_if_necessary(self.len + 8)
   let offset = self.len
   self.data[offset] = value.to_byte()
@@ -324,7 +324,7 @@ pub fn write_uint64_le(self : Buffer, value : UInt64) -> Unit {
 ///     ),
 ///   )
 /// ```
-pub fn write_int64_be(self : Buffer, value : Int64) -> Unit {
+pub fn Buffer::write_int64_be(self : Buffer, value : Int64) -> Unit {
   self.write_uint64_be(value.reinterpret_as_uint64())
 }
 
@@ -348,7 +348,7 @@ pub fn write_int64_be(self : Buffer, value : Int64) -> Unit {
 ///     ),
 ///   )
 /// ```
-pub fn write_int64_le(self : Buffer, value : Int64) -> Unit {
+pub fn Buffer::write_int64_le(self : Buffer, value : Int64) -> Unit {
   self.write_uint64_le(value.reinterpret_as_uint64())
 }
 
@@ -370,7 +370,7 @@ pub fn write_int64_le(self : Buffer, value : Int64) -> Unit {
 ///   #|b"\x124Vx"
 /// ))
 /// ```
-pub fn write_uint_be(self : Buffer, value : UInt) -> Unit {
+pub fn Buffer::write_uint_be(self : Buffer, value : UInt) -> Unit {
   self.grow_if_necessary(self.len + 4)
   let offset = self.len
   self.data[offset] = (value >> 24).to_byte()
@@ -399,7 +399,7 @@ pub fn write_uint_be(self : Buffer, value : UInt) -> Unit {
 ///   #|b"xV4\x12"
 /// ))
 /// ```
-pub fn write_uint_le(self : Buffer, value : UInt) -> Unit {
+pub fn Buffer::write_uint_le(self : Buffer, value : UInt) -> Unit {
   self.grow_if_necessary(self.len + 4)
   let offset = self.len
   self.data[offset] = value.to_byte()
@@ -427,7 +427,7 @@ pub fn write_uint_le(self : Buffer, value : UInt) -> Unit {
 ///   #|b"\x124Vx"
 /// ))
 /// ```
-pub fn write_int_be(self : Buffer, value : Int) -> Unit {
+pub fn Buffer::write_int_be(self : Buffer, value : Int) -> Unit {
   self.write_uint_be(value.reinterpret_as_uint())
 }
 
@@ -448,7 +448,7 @@ pub fn write_int_be(self : Buffer, value : Int) -> Unit {
 ///   buf.write_int_le(-1)
 ///   inspect(buf.contents(), content="b\"\\xff\\xff\\xff\\xff\"")
 /// ```
-pub fn write_int_le(self : Buffer, value : Int) -> Unit {
+pub fn Buffer::write_int_le(self : Buffer, value : Int) -> Unit {
   self.write_uint_le(value.reinterpret_as_uint())
 }
 
@@ -472,7 +472,7 @@ pub fn write_int_le(self : Buffer, value : Int) -> Unit {
 /// 
 /// ))
 /// ```
-pub fn write_uint16_be(self : Buffer, value : UInt16) -> Unit {
+pub fn Buffer::write_uint16_be(self : Buffer, value : UInt16) -> Unit {
   self.grow_if_necessary(self.len + 2)
   let offset = self.len
   self.data[offset] = (value.to_int() >> 8).to_byte()
@@ -501,7 +501,7 @@ pub fn write_uint16_be(self : Buffer, value : UInt16) -> Unit {
 /// 
 /// ))
 /// ```
-pub fn write_uint16_le(self : Buffer, value : UInt16) -> Unit {
+pub fn Buffer::write_uint16_le(self : Buffer, value : UInt16) -> Unit {
   self.grow_if_necessary(self.len + 2)
   let offset = self.len
   self.data[offset] = value.to_byte()
@@ -529,7 +529,7 @@ pub fn write_uint16_le(self : Buffer, value : UInt16) -> Unit {
 /// 
 /// ))
 /// ```
-pub fn write_int16_be(self : Buffer, value : Int16) -> Unit {
+pub fn Buffer::write_int16_be(self : Buffer, value : Int16) -> Unit {
   self.grow_if_necessary(self.len + 2)
   let offset = self.len
   self.data[offset] = (value.to_int() >> 8).to_byte()
@@ -555,7 +555,7 @@ pub fn write_int16_be(self : Buffer, value : Int16) -> Unit {
 ///   #|b"\xff\xff"
 /// ))
 /// ```
-pub fn write_int16_le(self : Buffer, value : Int16) -> Unit {
+pub fn Buffer::write_int16_le(self : Buffer, value : Int16) -> Unit {
   self.grow_if_necessary(self.len + 2)
   let offset = self.len
   self.data[offset] = value.to_byte()
@@ -581,7 +581,7 @@ pub fn write_int16_le(self : Buffer, value : Int16) -> Unit {
 ///   #|b"?\xf0\x00\x00\x00\x00\x00\x00"
 /// ))
 /// ```
-pub fn write_double_be(self : Buffer, value : Double) -> Unit {
+pub fn Buffer::write_double_be(self : Buffer, value : Double) -> Unit {
   self.write_uint64_be(value.reinterpret_as_uint64())
 }
 
@@ -606,7 +606,7 @@ pub fn write_double_be(self : Buffer, value : Double) -> Unit {
 /// ),
 ///   )
 /// ```
-pub fn write_double_le(self : Buffer, value : Double) -> Unit {
+pub fn Buffer::write_double_le(self : Buffer, value : Double) -> Unit {
   self.write_uint64_le(value.reinterpret_as_uint64())
 }
 
@@ -630,7 +630,7 @@ pub fn write_double_le(self : Buffer, value : Double) -> Unit {
 ///   #|b"@H\xf5\xc3"
 /// ))
 /// ```
-pub fn write_float_be(self : Buffer, value : Float) -> Unit {
+pub fn Buffer::write_float_be(self : Buffer, value : Float) -> Unit {
   self.write_uint_be(value.reinterpret_as_uint())
 }
 
@@ -653,7 +653,7 @@ pub fn write_float_be(self : Buffer, value : Float) -> Unit {
 ///   #|b"\xc3\xf5H@"
 /// ))
 /// ```
-pub fn write_float_le(self : Buffer, value : Float) -> Unit {
+pub fn Buffer::write_float_le(self : Buffer, value : Float) -> Unit {
   self.write_uint_le(value.reinterpret_as_uint())
 }
 
@@ -675,7 +675,7 @@ pub fn write_float_le(self : Buffer, value : Float) -> Unit {
 ///   buf.write_object(42)
 ///   inspect(buf.contents().to_unchecked_string(), content="42")
 /// ```
-pub fn write_object(self : Buffer, value : &Show) -> Unit {
+pub fn Buffer::write_object(self : Buffer, value : &Show) -> Unit {
   self.write_string(value.to_string())
 }
 
@@ -701,7 +701,7 @@ pub fn write_object(self : Buffer, value : &Show) -> Unit {
 ///     ),
 ///   )
 /// ```
-pub fn write_bytes(self : Buffer, value : Bytes) -> Unit {
+pub fn Buffer::write_bytes(self : Buffer, value : Bytes) -> Unit {
   let val_len = value.length()
   self.grow_if_necessary(self.len + val_len)
   self.data.blit_from_bytes(self.len, value, 0, val_len)
@@ -731,7 +731,7 @@ pub fn write_bytes(self : Buffer, value : Bytes) -> Unit {
 ///     ),
 ///   )
 /// ```
-pub fn write_bytesview(self : Buffer, value : BytesView) -> Unit {
+pub fn Buffer::write_bytesview(self : Buffer, value : BytesView) -> Unit {
   let val_len = value.length()
   self.grow_if_necessary(self.len + val_len)
   self.data.blit_from_bytes(
@@ -941,7 +941,7 @@ pub impl Logger for Buffer with write_char(self : Buffer, value : Char) -> Unit 
 ///   #|b"A"
 /// ))
 /// ```
-pub fn write_byte(self : Buffer, value : Byte) -> Unit {
+pub fn Buffer::write_byte(self : Buffer, value : Byte) -> Unit {
   self.grow_if_necessary(self.len + 1)
   self.data[self.len] = value
   self.len += 1
@@ -970,7 +970,7 @@ pub fn write_byte(self : Buffer, value : Byte) -> Unit {
 ///     ),
 ///   )
 /// ```
-pub fn write_iter(self : Buffer, iter : Iter[Byte]) -> Unit {
+pub fn Buffer::write_iter(self : Buffer, iter : Iter[Byte]) -> Unit {
   for byte in iter {
     self.write_byte(byte)
   }
@@ -995,7 +995,7 @@ pub fn write_iter(self : Buffer, iter : Iter[Byte]) -> Unit {
 /// inspect(buf.is_empty(), content="true")
 /// ```
 ///
-pub fn reset(self : Buffer) -> Unit {
+pub fn Buffer::reset(self : Buffer) -> Unit {
   self.len = 0
 }
 
@@ -1017,7 +1017,7 @@ pub fn reset(self : Buffer) -> Unit {
 ///   let bytes = buf.to_bytes()
 ///   inspect(bytes.length(), content="8")
 /// ```
-pub fn to_bytes(self : Buffer) -> Bytes {
+pub fn Buffer::to_bytes(self : Buffer) -> Bytes {
   @bytes.from_fixedarray(self.data, len=self.len)
 }
 

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn[T] set_null(self : UninitializedArray[T], index : Int) = "%fixedarray.set_null"
+fn[T] UninitializedArray::set_null(self : UninitializedArray[T], index : Int) = "%fixedarray.set_null"
 
 ///|
 /// An `Array` is a collection of values that supports random access and can

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -104,7 +104,7 @@ pub fn[K : Hash + Eq, V] Map::set(self : Map[K, V], key : K, value : V) -> Unit 
 }
 
 ///|
-fn[K : Eq, V] set_with_hash(
+fn[K : Eq, V] Map::set_with_hash(
   self : Map[K, V],
   key : K,
   value : V,

--- a/byte/byte.mbt
+++ b/byte/byte.mbt
@@ -33,7 +33,7 @@ pub let min_value : Byte = b'\x00'
 ///   let b = b'\xFF'
 ///   inspect(b.to_uint64(), content="255")
 /// ```
-pub fn to_uint64(self : Byte) -> UInt64 {
+pub fn Byte::to_uint64(self : Byte) -> UInt64 {
   self.to_uint().to_uint64()
 }
 
@@ -52,7 +52,7 @@ pub fn to_uint64(self : Byte) -> UInt64 {
 ///   let b = b'\x0F'
 ///   inspect(b.popcnt(), content="4")
 /// ```
-pub fn popcnt(self : Byte) -> Int {
+pub fn Byte::popcnt(self : Byte) -> Int {
   let mut n = self
   n = (n & 0x55) + ((n >> 1) & 0x55)
   n = (n & 0x33) + ((n >> 2) & 0x33)

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -109,7 +109,7 @@ pub fn Bytes::from_fixedarray(arr : FixedArray[Byte], len? : Int) -> Bytes {
 /// ```
 /// 
 /// Panics if the length is invalid
-pub fn to_fixedarray(self : Bytes, len? : Int) -> FixedArray[Byte] {
+pub fn Bytes::to_fixedarray(self : Bytes, len? : Int) -> FixedArray[Byte] {
   let len = match len {
     None => self.length()
     Some(x) => {
@@ -199,7 +199,7 @@ pub fn Bytes::of(arr : FixedArray[Byte]) -> Bytes {
 ///   let arr = bytes.to_array()
 ///   inspect(arr, content="[b'\\x68', b'\\x65', b'\\x6C', b'\\x6C', b'\\x6F']")
 /// ```
-pub fn to_array(self : Bytes) -> Array[Byte] {
+pub fn Bytes::to_array(self : Bytes) -> Array[Byte] {
   let len = self.length()
   let rv = Array::make(len, b'0')
   for i in 0..<len {
@@ -225,7 +225,7 @@ pub fn to_array(self : Bytes) -> Array[Byte] {
 ///   bytes.iter().each((b) => { sum = sum + b.to_int() })
 ///   inspect(sum, content="209") // ASCII values: 'h'(104) + 'i'(105) = 209
 /// ```
-pub fn iter(self : Bytes) -> Iter[Byte] {
+pub fn Bytes::iter(self : Bytes) -> Iter[Byte] {
   Iter::new(yield_ => for i in 0..<self.length() {
     if yield_(self[i]) is IterEnd {
       break IterEnd
@@ -248,7 +248,7 @@ pub fn iter(self : Bytes) -> Iter[Byte] {
 ///   })
 ///   inspect(buf, content="b'\\x61'b'\\x62'b'\\x63'b'\\x64'b'\\x65'")
 ///   inspect(keys, content="[0, 1, 2, 3, 4]")
-pub fn iter2(self : Bytes) -> Iter2[Int, Byte] {
+pub fn Bytes::iter2(self : Bytes) -> Iter2[Int, Byte] {
   Iter2::new(yield_ => for i in 0..<self.length() {
     if yield_(i, self[i]) is IterEnd {
       break IterEnd
@@ -300,7 +300,7 @@ pub fn default() -> Bytes {
 ///   let byte = bytes.get(3)
 ///   inspect(byte, content="None")
 /// ```
-pub fn get(self : Bytes, index : Int) -> Byte? {
+pub fn Bytes::get(self : Bytes, index : Int) -> Byte? {
   guard index >= 0 && index < self.length() else { None }
   Some(self[index])
 }

--- a/deque/deprecated.mbt
+++ b/deque/deprecated.mbt
@@ -15,20 +15,20 @@
 ///|
 #deprecated("Use `unsafe_pop_front` instead")
 #coverage.skip
-pub fn[A] pop_front_exn(self : Deque[A]) -> Unit {
+pub fn[A] Deque::pop_front_exn(self : Deque[A]) -> Unit {
   self.unsafe_pop_front()
 }
 
 ///|
 #deprecated("Use `unsafe_pop_back` instead")
 #coverage.skip
-pub fn[A] pop_back_exn(self : Deque[A]) -> Unit {
+pub fn[A] Deque::pop_back_exn(self : Deque[A]) -> Unit {
   self.unsafe_pop_back()
 }
 
 ///|
 #deprecated("Use `@deque.retain_map` instead")
-pub fn[A] filter_map_inplace(self : Deque[A], f : (A) -> A?) -> Unit {
+pub fn[A] Deque::filter_map_inplace(self : Deque[A], f : (A) -> A?) -> Unit {
   self.retain_map(f)
 }
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -175,7 +175,7 @@ pub fn[A] Deque::from_array(arr : Array[A]) -> Deque[A] {
 ///   let copied = dq.copy()
 ///   inspect(copied, content="@deque.of([1, 2, 3, 4, 5])")
 /// ```
-pub fn[A] copy(self : Deque[A]) -> Deque[A] {
+pub fn[A] Deque::copy(self : Deque[A]) -> Deque[A] {
   let len = self.len
   let buf = UninitializedArray::make(len)
   for i, x in self {
@@ -216,7 +216,7 @@ pub fn[A] copy(self : Deque[A]) -> Deque[A] {
 /// * `dst_offset` is negative
 /// * `dst_offset` exceeds the length of the destination deque
 /// * `src_offset + len` exceeds the length of the source deque
-pub fn[A] blit_to(
+pub fn[A] Deque::blit_to(
   self : Deque[A],
   dst : Deque[A],
   len~ : Int,
@@ -266,7 +266,7 @@ pub fn[A] blit_to(
 /// v1.append(v2)
 /// inspect(v1, content="@deque.of([1, 2, 3])")
 /// ```
-pub fn[A] append(self : Deque[A], other : Deque[A]) -> Unit {
+pub fn[A] Deque::append(self : Deque[A], other : Deque[A]) -> Unit {
   guard other.len != 0 else { return }
   let space = if self.buf.length() != 0 {
     (self.head - self.tail - 1 + self.buf.length()) % self.buf.length()
@@ -321,7 +321,7 @@ pub fn[A] append(self : Deque[A], other : Deque[A]) -> Unit {
 /// v3.insert(3, 5) // insert at the end
 /// inspect(v3, content="@deque.of([2, 3, 4, 5])")
 /// ```
-pub fn[A] insert(self : Deque[A], index : Int, value : A) -> Unit {
+pub fn[A] Deque::insert(self : Deque[A], index : Int, value : A) -> Unit {
   guard index >= 0 && index <= self.length() else {
     abort(
       "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
@@ -382,7 +382,7 @@ pub fn[A] insert(self : Deque[A], index : Int, value : A) -> Unit {
 /// let z = v3.remove(3) // remove from the end
 /// inspect((z, v3), content="(5, @deque.of([2, 3, 4]))")
 /// ```
-pub fn[A] remove(self : Deque[A], index : Int) -> A {
+pub fn[A] Deque::remove(self : Deque[A], index : Int) -> A {
   guard index >= 0 && index < self.length() else {
     abort(
       "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
@@ -455,7 +455,7 @@ pub fn[A] Deque::of(arr : FixedArray[A]) -> Deque[A] {
 ///   dq.push_back(4)
 ///   inspect(dq.length(), content="4")
 /// ```
-pub fn[A] length(self : Deque[A]) -> Int {
+pub fn[A] Deque::length(self : Deque[A]) -> Int {
   self.len
 }
 
@@ -477,13 +477,13 @@ pub fn[A] length(self : Deque[A]) -> Int {
 ///   dq.push_back(2)
 ///   inspect(dq.capacity(), content="10")
 /// ```
-pub fn[A] capacity(self : Deque[A]) -> Int {
+pub fn[A] Deque::capacity(self : Deque[A]) -> Int {
   self.buf.length()
 }
 
 ///|
 /// Reallocate the deque with a new capacity.
-fn[A] realloc(self : Deque[A]) -> Unit {
+fn[A] Deque::realloc(self : Deque[A]) -> Unit {
   let old_cap = self.len
   let new_cap = if old_cap == 0 { 8 } else { old_cap * 2 }
   let new_buf = UninitializedArray::make(new_cap)
@@ -519,7 +519,7 @@ fn[A] realloc(self : Deque[A]) -> Unit {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.front(), Some(1))
 /// ```
-pub fn[A] front(self : Deque[A]) -> A? {
+pub fn[A] Deque::front(self : Deque[A]) -> A? {
   if self.len == 0 {
     None
   } else {
@@ -535,7 +535,7 @@ pub fn[A] front(self : Deque[A]) -> A? {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.back(), Some(5))
 /// ```
-pub fn[A] back(self : Deque[A]) -> A? {
+pub fn[A] Deque::back(self : Deque[A]) -> A? {
   if self.len == 0 {
     None
   } else {
@@ -554,7 +554,7 @@ pub fn[A] back(self : Deque[A]) -> A? {
 ///   dv.push_front(0)
 ///   assert_eq(dv.front(), Some(0))
 /// ```
-pub fn[A] push_front(self : Deque[A], value : A) -> Unit {
+pub fn[A] Deque::push_front(self : Deque[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
   }
@@ -576,7 +576,7 @@ pub fn[A] push_front(self : Deque[A], value : A) -> Unit {
 ///   dv.push_back(6)
 ///   assert_eq(dv.back(), Some(6))
 /// ```
-pub fn[A] push_back(self : Deque[A], value : A) -> Unit {
+pub fn[A] Deque::push_back(self : Deque[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
   }
@@ -597,7 +597,7 @@ pub fn[A] push_back(self : Deque[A], value : A) -> Unit {
 ///   assert_eq(dv.front(), Some(2))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
-pub fn[A] unsafe_pop_front(self : Deque[A]) -> Unit {
+pub fn[A] Deque::unsafe_pop_front(self : Deque[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
     1 => {
@@ -645,7 +645,7 @@ pub fn[A] unsafe_pop_front(self : Deque[A]) -> Unit {
 ///   assert_eq(dv.back(), Some(4))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
-pub fn[A] unsafe_pop_back(self : Deque[A]) -> Unit {
+pub fn[A] Deque::unsafe_pop_back(self : Deque[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
     1 => {
@@ -693,7 +693,7 @@ pub fn[A] unsafe_pop_back(self : Deque[A]) -> Unit {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.pop_front(), Some(1))
 /// ```
-pub fn[A] pop_front(self : Deque[A]) -> A? {
+pub fn[A] Deque::pop_front(self : Deque[A]) -> A? {
   match self.len {
     0 => None
     1 => {
@@ -724,7 +724,7 @@ pub fn[A] pop_front(self : Deque[A]) -> A? {
 ///   let dv = @deque.of([1, 2, 3, 4, 5])
 ///   assert_eq(dv.pop_back(), Some(5))
 /// ```
-pub fn[A] pop_back(self : Deque[A]) -> A? {
+pub fn[A] Deque::pop_back(self : Deque[A]) -> A? {
   match self.len {
     0 => None
     1 => {
@@ -876,7 +876,7 @@ pub impl[A : Eq] Eq for Deque[A] with equal(self, other) {
 ///   dv.each((x) => {sum = sum + x})
 ///   inspect(sum, content="15")
 /// ```
-pub fn[A] each(self : Deque[A], f : (A) -> Unit) -> Unit {
+pub fn[A] Deque::each(self : Deque[A], f : (A) -> Unit) -> Unit {
   for v in self {
     f(v)
   }
@@ -892,7 +892,7 @@ pub fn[A] each(self : Deque[A], f : (A) -> Unit) -> Unit {
 ///   dv.eachi((i, _x) => {idx_sum = idx_sum + i})
 ///   inspect(idx_sum, content="10")
 /// ```
-pub fn[A] eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] Deque::eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self {
     f(i, v)
   }
@@ -908,7 +908,7 @@ pub fn[A] eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
 ///   dv.rev_each((x) => {sum = sum + x})
 ///   inspect(sum, content="15")
 /// ```
-pub fn[A] rev_each(self : Deque[A], f : (A) -> Unit) -> Unit {
+pub fn[A] Deque::rev_each(self : Deque[A], f : (A) -> Unit) -> Unit {
   for v in self.rev_iter() {
     f(v)
   }
@@ -924,7 +924,7 @@ pub fn[A] rev_each(self : Deque[A], f : (A) -> Unit) -> Unit {
 ///   dv.rev_eachi((i, _x) => {idx_sum = idx_sum + i})
 ///   inspect(idx_sum, content="10")
 /// ```
-pub fn[A] rev_eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] Deque::rev_eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self.rev_iter2() {
     f(i, v)
   }
@@ -941,7 +941,7 @@ pub fn[A] rev_eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
 ///   dv.clear()
 ///   inspect(dv.length(), content="0")
 /// ```
-pub fn[A] clear(self : Deque[A]) -> Unit {
+pub fn[A] Deque::clear(self : Deque[A]) -> Unit {
   let { head, buf, len, .. } = self
   let cap = buf.length()
   let head_len = cap - head
@@ -971,7 +971,7 @@ pub fn[A] clear(self : Deque[A]) -> Unit {
 ///   let dv2 = dv.map((x) => {x + 1})
 ///   assert_eq(dv2, @deque.of([4, 5, 6]))
 /// ```
-pub fn[A, U] map(self : Deque[A], f : (A) -> U) -> Deque[U] {
+pub fn[A, U] Deque::map(self : Deque[A], f : (A) -> U) -> Deque[U] {
   let cap = self.buf.length()
   if self.len == 0 {
     new()
@@ -994,7 +994,7 @@ pub fn[A, U] map(self : Deque[A], f : (A) -> U) -> Deque[U] {
 ///   let dv2 = dv.mapi((i, x) => {x + i}) // @deque.of([3, 5, 7])
 ///   assert_eq(dv2, @deque.of([3, 5, 7]))
 /// ```
-pub fn[A, U] mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
+pub fn[A, U] Deque::mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
   let cap = self.buf.length()
   if self.len == 0 {
     new()
@@ -1018,7 +1018,7 @@ pub fn[A, U] mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
 ///   dv.push_back(1)
 ///   inspect(dv.is_empty(), content="false")
 /// ```
-pub fn[A] is_empty(self : Deque[A]) -> Bool {
+pub fn[A] Deque::is_empty(self : Deque[A]) -> Bool {
   self.len == 0
 }
 
@@ -1040,7 +1040,7 @@ pub fn[A] is_empty(self : Deque[A]) -> Bool {
 ///   inspect(dq.search(2), content="Some(1)")
 ///   inspect(dq.search(4), content="None")
 /// ```
-pub fn[A : Eq] search(self : Deque[A], value : A) -> Int? {
+pub fn[A : Eq] Deque::search(self : Deque[A], value : A) -> Int? {
   let cap = self.buf.length()
   for i in 0..<self.len {
     let idx = (self.head + i) % cap
@@ -1069,7 +1069,7 @@ pub fn[A : Eq] search(self : Deque[A], value : A) -> Int? {
 ///   inspect(dq.contains(3), content="true")
 ///   inspect(dq.contains(6), content="false")
 /// ```
-pub fn[A : Eq] contains(self : Deque[A], value : A) -> Bool {
+pub fn[A : Eq] Deque::contains(self : Deque[A], value : A) -> Bool {
   self.iter().contains(value)
 }
 
@@ -1096,7 +1096,7 @@ pub fn[A : Eq] contains(self : Deque[A], value : A) -> Bool {
 /// inspect(d.to_array(), content="[1, 3, 5]")
 /// ```
 #locals(f)
-pub fn[A] extract_if(self : Deque[A], f : (A) -> Bool) -> Deque[A] {
+pub fn[A] Deque::extract_if(self : Deque[A], f : (A) -> Bool) -> Deque[A] {
   guard self.length() != 0 else { of([]) }
   let removed = of([])
   let mut write = 0
@@ -1143,7 +1143,10 @@ pub fn[A] extract_if(self : Deque[A], f : (A) -> Bool) -> Deque[A] {
 ///   inspect(evens, content="@deque.of([2, 4])")
 /// ```
 #locals(f)
-pub fn[A] filter(self : Deque[A], f : (A) -> Bool raise?) -> Deque[A] raise? {
+pub fn[A] Deque::filter(
+  self : Deque[A],
+  f : (A) -> Bool raise?,
+) -> Deque[A] raise? {
   let dq = of([])
   for v in self {
     if f(v) {
@@ -1164,7 +1167,7 @@ pub fn[A] filter(self : Deque[A], f : (A) -> Bool raise?) -> Deque[A] raise? {
 ///   dv.reserve_capacity(10)
 ///   inspect(dv.capacity(), content="10")
 /// ```
-pub fn[A] reserve_capacity(self : Deque[A], capacity : Int) -> Unit {
+pub fn[A] Deque::reserve_capacity(self : Deque[A], capacity : Int) -> Unit {
   if self.capacity() >= capacity {
     return
   }
@@ -1193,7 +1196,7 @@ pub fn[A] reserve_capacity(self : Deque[A], capacity : Int) -> Unit {
 ///   dv.shrink_to_fit()
 ///   inspect(dv.capacity(), content="3")
 /// ```
-pub fn[A] shrink_to_fit(self : Deque[A]) -> Unit {
+pub fn[A] Deque::shrink_to_fit(self : Deque[A]) -> Unit {
   if self.capacity() <= self.length() {
     return
   }
@@ -1226,7 +1229,7 @@ pub fn[A] shrink_to_fit(self : Deque[A]) -> Unit {
 ///   dq.truncate(3)
 ///   inspect(dq, content="@deque.of([1, 2, 3])")
 /// ```
-pub fn[A] truncate(self : Deque[A], len : Int) -> Unit {
+pub fn[A] Deque::truncate(self : Deque[A], len : Int) -> Unit {
   guard len >= 0 && len < self.len else { return }
   if len == 0 {
     self.clear()
@@ -1277,7 +1280,7 @@ pub fn[A] truncate(self : Deque[A], len : Int) -> Unit {
 ///   dq.retain_map((x) => { if x % 2 == 0 { Some(x * 2) } else { None } })
 ///   inspect(dq, content="@deque.of([4, 8])")
 /// ```
-pub fn[A] retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
+pub fn[A] Deque::retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self
   let cap = buf.length()
@@ -1334,7 +1337,7 @@ pub fn[A] retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
 ///   dq.retain((x) => { x % 2 == 0 })
 ///   inspect(dq, content="@deque.of([2, 4])")
 /// ```
-pub fn[A] retain(self : Deque[A], f : (A) -> Bool) -> Unit {
+pub fn[A] Deque::retain(self : Deque[A], f : (A) -> Bool) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self
   let cap = buf.length()
@@ -1385,7 +1388,7 @@ pub fn[A] retain(self : Deque[A], f : (A) -> Bool) -> Unit {
 ///   dq.iter().each((x) => { sum = sum + x })
 ///   inspect(sum, content="15")
 /// ```
-pub fn[A] iter(self : Deque[A]) -> Iter[A] {
+pub fn[A] Deque::iter(self : Deque[A]) -> Iter[A] {
   Iter::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1427,7 +1430,7 @@ pub fn[A] iter(self : Deque[A]) -> Iter[A] {
 ///   dq.iter2().each((i, x) => { sum = sum + i * x })
 ///   inspect(sum, content="80") // 0*10 + 1*20 + 2*30 = 80
 /// ```
-pub fn[A] iter2(self : Deque[A]) -> Iter2[Int, A] {
+pub fn[A] Deque::iter2(self : Deque[A]) -> Iter2[Int, A] {
   Iter2::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1471,7 +1474,7 @@ pub fn[A] iter2(self : Deque[A]) -> Iter2[Int, A] {
 ///   dq.rev_iter().each((x) => { sum = sum * 10 + x })
 ///   inspect(sum, content="321")
 /// ```
-pub fn[A] rev_iter(self : Deque[A]) -> Iter[A] {
+pub fn[A] Deque::rev_iter(self : Deque[A]) -> Iter[A] {
   Iter::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1513,7 +1516,7 @@ pub fn[A] rev_iter(self : Deque[A]) -> Iter[A] {
 ///   dq.rev_iter2().each((i, x) => { s = s + "\{i}:\{x} " })
 ///   inspect(s, content="0:3 1:2 2:1 ")
 /// ```
-pub fn[A] rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
+pub fn[A] Deque::rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
   Iter2::new(yield_ => {
     guard !self.is_empty() else { IterContinue }
     let { head, buf, len, .. } = self
@@ -1581,7 +1584,7 @@ pub fn[A] Deque::from_iter(iter : Iter[A]) -> Deque[A] {
 ///   inspect(arr, content="[1, 2, 3, 4, 5]")
 /// ```
 ///
-pub fn[A] to_array(self : Deque[A]) -> Array[A] {
+pub fn[A] Deque::to_array(self : Deque[A]) -> Array[A] {
   let len = self.length()
   if len == 0 {
     []
@@ -1715,7 +1718,7 @@ pub impl[A : @json.FromJson] @json.FromJson for Deque[A] with from_json(
 /// Panics if:
 /// 
 /// * `size` is not positive
-pub fn[A] chunks(self : Deque[A], size : Int) -> Deque[Deque[A]] {
+pub fn[A] Deque::chunks(self : Deque[A], size : Int) -> Deque[Deque[A]] {
   guard size > 0
   let chunks = of([])
   let mut i = 0
@@ -1762,7 +1765,7 @@ pub fn[A] chunks(self : Deque[A], size : Int) -> Deque[Deque[A]] {
 /// inspect(empty.chunk_by((x, y) => x <= y).to_array(), content="[]")
 /// ```
 #locals(pred)
-pub fn[A] chunk_by(
+pub fn[A] Deque::chunk_by(
   self : Deque[A],
   pred : (A, A) -> Bool raise?,
 ) -> Deque[Deque[A]] raise? {
@@ -1942,7 +1945,7 @@ pub fn[A] Deque::drain(self : Deque[A], start~ : Int, len? : Int) -> Deque[A] {
 /// * Handles the deque's ring buffer structure internally
 /// * For empty deques, returns `Err(0)`
 #locals(cmp)
-pub fn[A] binary_search_by(
+pub fn[A] Deque::binary_search_by(
   self : Deque[A],
   cmp : (A) -> Int,
 ) -> Result[Int, Int] {
@@ -1976,7 +1979,7 @@ pub fn[A] binary_search_by(
 
 ///|
 /// Safe element access with bounds checking
-pub fn[A] get(self : Deque[A], index : Int) -> A? {
+pub fn[A] Deque::get(self : Deque[A], index : Int) -> A? {
   if index >= 0 && index < self.len {
     let physical_index = (self.head + index) % self.buf.length()
     Some(self.buf[physical_index])
@@ -2013,7 +2016,7 @@ pub fn[A] get(self : Deque[A], index : Int) -> A? {
 /// * Assumes the deque is sorted in ascending order
 /// * For multiple matches, returns the leftmost matching position
 /// * Returns an insertion point that maintains the sort order when no match is found
-pub fn[A : Compare] binary_search(
+pub fn[A : Compare] Deque::binary_search(
   self : Deque[A],
   value : A,
 ) -> Result[Int, Int] {
@@ -2168,7 +2171,7 @@ pub fn[A] Deque::shuffle_in_place(
 /// To use this function, you need to provide a rand function, which takes an integer as its upper bound
 /// and returns an integer.
 /// *rand n* is expected to return a uniformly distributed integer between 0 and n - 1
-pub fn[A] shuffle(self : Deque[A], rand~ : (Int) -> Int) -> Deque[A] {
+pub fn[A] Deque::shuffle(self : Deque[A], rand~ : (Int) -> Int) -> Deque[A] {
   // Create a copy of the original deque
   let new_deque = self.copy()
   // Shuffle the copy in place

--- a/double/double.mbt
+++ b/double/double.mbt
@@ -82,7 +82,7 @@ pub fn Double::abs(self : Double) -> Double = "%f64.abs"
 /// - If the double is positive, returns 1.0.
 /// - If the double is negative, returns -1.0.
 /// - Otherwise, returns the double itself (0.0, -0.0 and NaN).
-pub fn signum(self : Double) -> Double {
+pub fn Double::signum(self : Double) -> Double {
   if self < 0.0 {
     -1.0
   } else if self > 0.0 {
@@ -109,7 +109,7 @@ pub fn signum(self : Double) -> Double {
 ///   inspect(42.0.is_nan(), content="false")
 ///   inspect((0.0 / 0.0).is_nan(), content="true")
 /// ```
-pub fn is_nan(self : Double) -> Bool {
+pub fn Double::is_nan(self : Double) -> Bool {
   // only NaNs satisfy f != f.
   self != self
 }
@@ -132,7 +132,7 @@ pub fn is_nan(self : Double) -> Bool {
 ///   inspect(@double.neg_infinity.is_inf(), content="true")
 ///   inspect(42.0.is_inf(), content="false")
 /// ```
-pub fn is_inf(self : Double) -> Bool {
+pub fn Double::is_inf(self : Double) -> Bool {
   self > max_value || self < min_value
 }
 
@@ -152,7 +152,7 @@ pub fn is_inf(self : Double) -> Bool {
 ///   inspect(@double.neg_infinity.is_pos_inf(), content="false")
 ///   inspect(42.0.is_pos_inf(), content="false")
 /// ```
-pub fn is_pos_inf(self : Double) -> Bool {
+pub fn Double::is_pos_inf(self : Double) -> Bool {
   self > max_value
 }
 
@@ -172,7 +172,7 @@ pub fn is_pos_inf(self : Double) -> Bool {
 ///   inspect(42.0.is_neg_inf(), content="false")
 ///   inspect((1.0 / 0.0).is_neg_inf(), content="false") // positive infinity
 /// ```
-pub fn is_neg_inf(self : Double) -> Bool {
+pub fn Double::is_neg_inf(self : Double) -> Bool {
   self < min_value
 }
 
@@ -263,7 +263,7 @@ pub impl Hash for Double with hash_combine(self, hasher) {
 /// ```
 ///
 #intrinsic("%f64.to_string")
-pub fn to_string(self : Double) -> String {
+pub fn Double::to_string(self : Double) -> String {
   @ryu.ryu_to_string(self)
 }
 
@@ -348,7 +348,7 @@ pub fn Double::is_close(
 ///     ),
 ///   )
 /// ```
-pub fn to_be_bytes(self : Double) -> Bytes {
+pub fn Double::to_be_bytes(self : Double) -> Bytes {
   self.reinterpret_as_uint64().to_be_bytes()
 }
 
@@ -376,6 +376,6 @@ pub fn to_be_bytes(self : Double) -> Bytes {
 ///     ),
 ///   )
 /// ```
-pub fn to_le_bytes(self : Double) -> Bytes {
+pub fn Double::to_le_bytes(self : Double) -> Bytes {
   self.reinterpret_as_uint64().to_le_bytes()
 }

--- a/double/mod_js.mbt
+++ b/double/mod_js.mbt
@@ -34,7 +34,7 @@
 ///   inspect(5.0.mod(@double.not_a_number), content="NaN")
 ///   inspect(@double.infinity.mod(3.0), content="NaN")
 /// ```
-extern "js" fn mod_ffi(self : Double, other : Double) -> Double =
+extern "js" fn Double::mod_ffi(self : Double, other : Double) -> Double =
   #| (a, b) => (a % b)
 
 ///|

--- a/double/to_uint.mbt
+++ b/double/to_uint.mbt
@@ -39,7 +39,7 @@
 ///   inspect((1.0 / 0.0).to_uint(), content="4294967295") // Infinity
 ///   inspect((-1.0 / 0.0).to_uint(), content="0") // -Infinity
 /// ```
-pub fn to_uint(self : Double) -> UInt {
+pub fn Double::to_uint(self : Double) -> UInt {
   if self != self {
     0
   } else if self >= 4294967295.0 {

--- a/double/to_uint_wasm.mbt
+++ b/double/to_uint_wasm.mbt
@@ -39,4 +39,4 @@
 /// inspect((1.0 / 0.0).to_uint(), content="4294967295") // Infinity
 /// inspect((-1.0 / 0.0).to_uint(), content="0") // -Infinity
 /// ```
-pub fn to_uint(self : Double) -> UInt = "%f64.to_u32_saturate"
+pub fn Double::to_uint(self : Double) -> UInt = "%f64.to_u32_saturate"

--- a/float/float.mbt
+++ b/float/float.mbt
@@ -206,7 +206,7 @@ pub impl Hash for Float with hash_combine(self, hasher) {
 ///     ),
 ///   )
 /// ```
-pub fn to_be_bytes(self : Float) -> Bytes {
+pub fn Float::to_be_bytes(self : Float) -> Bytes {
   self.reinterpret_as_uint().to_be_bytes()
 }
 
@@ -228,7 +228,7 @@ pub fn to_be_bytes(self : Float) -> Bytes {
 ///   let bytes = f.to_le_bytes()
 ///   inspect(bytes.length(), content="4")
 /// ```
-pub fn to_le_bytes(self : Float) -> Bytes {
+pub fn Float::to_le_bytes(self : Float) -> Bytes {
   self.reinterpret_as_uint().to_le_bytes()
 }
 
@@ -249,7 +249,7 @@ pub fn to_le_bytes(self : Float) -> Bytes {
 ///   inspect(@float.neg_infinity.is_inf(), content="true")
 ///   inspect((1.0 : Float).is_inf(), content="false")
 /// ```
-pub fn is_inf(self : Float) -> Bool {
+pub fn Float::is_inf(self : Float) -> Bool {
   self.is_pos_inf() || self.is_neg_inf()
 }
 
@@ -269,7 +269,7 @@ pub fn is_inf(self : Float) -> Bool {
 ///   inspect((1.0 : Float).is_pos_inf(), content="false")
 ///   inspect(@float.neg_infinity.is_pos_inf(), content="false")
 /// ```
-pub fn is_pos_inf(self : Float) -> Bool {
+pub fn Float::is_pos_inf(self : Float) -> Bool {
   self > max_value
 }
 
@@ -289,7 +289,7 @@ pub fn is_pos_inf(self : Float) -> Bool {
 ///   inspect((1.0 : Float).is_neg_inf(), content="false")
 ///   inspect(@float.infinity.is_neg_inf(), content="false")
 /// ```
-pub fn is_neg_inf(self : Float) -> Bool {
+pub fn Float::is_neg_inf(self : Float) -> Bool {
   self < min_value
 }
 
@@ -309,7 +309,7 @@ pub fn is_neg_inf(self : Float) -> Bool {
 ///   inspect((1.0 : Float).is_nan(), content="false")
 ///   inspect(@float.infinity.is_nan(), content="false")
 /// ```
-pub fn is_nan(self : Float) -> Bool {
+pub fn Float::is_nan(self : Float) -> Bool {
   self != self
 }
 

--- a/float/to_int.mbt
+++ b/float/to_int.mbt
@@ -38,7 +38,7 @@ fn Float::to_unchecked_int(self : Float) -> Int = "%f32.to_i32"
 ///   inspect(@float.infinity.to_int(), content="2147483647")
 ///   inspect(@float.neg_infinity.to_int(), content="-2147483648")
 /// ```
-pub fn to_int(self : Float) -> Int {
+pub fn Float::to_int(self : Float) -> Int {
   if self != self {
     0
   } else if self >= 2147483647 {

--- a/float/to_int_wasm.mbt
+++ b/float/to_int_wasm.mbt
@@ -35,4 +35,4 @@
 ///   inspect(@float.infinity.to_int(), content="2147483647")
 ///   inspect(@float.neg_infinity.to_int(), content="-2147483648")
 /// ```
-pub fn to_int(self : Float) -> Int = "%f32.to_i32_saturate"
+pub fn Float::to_int(self : Float) -> Int = "%f32.to_i32_saturate"

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -102,7 +102,7 @@ pub fn[K : Hash + Eq, V] HashMap::set(
 }
 
 ///|
-fn[K : Eq, V] set_with_hash(
+fn[K : Eq, V] HashMap::set_with_hash(
   self : HashMap[K, V],
   key : K,
   value : V,
@@ -176,7 +176,7 @@ fn[K, V] HashMap::push_away(
 ///   inspect(map.get("key"), content="Some(42)")
 ///   inspect(map.get("nonexistent"), content="None")
 /// ```
-pub fn[K : Hash + Eq, V] get(self : HashMap[K, V], key : K) -> V? {
+pub fn[K : Hash + Eq, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
   // self.get_with_hash(key, key.hash())
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
@@ -243,7 +243,7 @@ pub fn[K : Hash + Eq, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
 ///   inspect(value, content="42")
 ///   inspect(map.get("key"), content="Some(42)")
 /// ```
-pub fn[K : Hash + Eq, V] get_or_init(
+pub fn[K : Hash + Eq, V] HashMap::get_or_init(
   self : HashMap[K, V],
   key : K,
   init : () -> V,
@@ -303,7 +303,7 @@ pub fn[K : Hash + Eq, V] get_or_init(
 ///   inspect(map.get_or_default("a", 0), content="1")
 ///   inspect(map.get_or_default("c", 0), content="0")
 /// ```
-pub fn[K : Hash + Eq, V] get_or_default(
+pub fn[K : Hash + Eq, V] HashMap::get_or_default(
   self : HashMap[K, V],
   key : K,
   default : V,
@@ -338,7 +338,10 @@ pub fn[K : Hash + Eq, V] get_or_default(
 ///   inspect(map.contains("a"), content="true")
 ///   inspect(map.contains("c"), content="false")
 /// ```
-pub fn[K : Hash + Eq, V] contains(self : HashMap[K, V], key : K) -> Bool {
+pub fn[K : Hash + Eq, V] HashMap::contains(
+  self : HashMap[K, V],
+  key : K,
+) -> Bool {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { return false }
@@ -374,7 +377,7 @@ pub fn[K : Hash + Eq, V] contains(self : HashMap[K, V], key : K) -> Bool {
 ///   inspect(map.contains_kv("a", 2), content="false")
 ///   inspect(map.contains_kv("c", 3), content="false")
 /// ```
-pub fn[K : Hash + Eq, V : Eq] contains_kv(
+pub fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(
   self : HashMap[K, V],
   key : K,
   value : V,
@@ -411,12 +414,12 @@ pub fn[K : Hash + Eq, V : Eq] contains_kv(
 ///   inspect(map.get("a"), content="None")
 ///   inspect(map.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq, V] remove(self : HashMap[K, V], key : K) -> Unit {
+pub fn[K : Hash + Eq, V] HashMap::remove(self : HashMap[K, V], key : K) -> Unit {
   self.remove_with_hash(key, key.hash())
 }
 
 ///|
-fn[K : Eq, V] remove_with_hash(
+fn[K : Eq, V] HashMap::remove_with_hash(
   self : HashMap[K, V],
   key : K,
   hash : Int,
@@ -440,7 +443,7 @@ fn[K : Eq, V] remove_with_hash(
 }
 
 ///|
-fn[K, V] shift_back(self : HashMap[K, V], idx : Int) -> Unit {
+fn[K, V] HashMap::shift_back(self : HashMap[K, V], idx : Int) -> Unit {
   let next = (idx + 1) & self.capacity_mask
   match self.entries[next] {
     None | Some({ psl: 0, .. }) => self.entries[idx] = None
@@ -453,7 +456,7 @@ fn[K, V] shift_back(self : HashMap[K, V], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq, V] grow(self : HashMap[K, V]) -> Unit {
+fn[K : Eq, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
   let old_entries = self.entries
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn[K : Show, V : Show] _debug_entries(self : HashMap[K, V]) -> String {
+fn[K : Show, V : Show] HashMap::_debug_entries(self : HashMap[K, V]) -> String {
   for s = "", i = 0; i < self.entries.length(); {
     let s = if i > 0 { s + "," } else { s }
     match self.entries[i] {
@@ -43,7 +43,7 @@ fn[K : Show, V : Show] _debug_entries(self : HashMap[K, V]) -> String {
 ///   inspect(map.length(), content="0")
 ///   inspect(map.get("a"), content="None")
 /// ```
-pub fn[K, V] clear(self : HashMap[K, V]) -> Unit {
+pub fn[K, V] HashMap::clear(self : HashMap[K, V]) -> Unit {
   self.entries.fill(None)
   self.size = 0
 }
@@ -67,7 +67,7 @@ pub fn[K, V] clear(self : HashMap[K, V]) -> Unit {
 ///   inspect(pairs.contains((1, "one")), content="true")
 ///   inspect(pairs.contains((2, "two")), content="true")
 /// ```
-pub fn[K, V] iter(self : HashMap[K, V]) -> Iter[(K, V)] {
+pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
   Iter::new(yield_ => for entry in self.entries {
     if entry is Some({ key, value, .. }) {
       guard yield_((key, value)) is IterContinue else { break IterEnd }
@@ -97,7 +97,7 @@ pub fn[K, V] iter(self : HashMap[K, V]) -> Iter[(K, V)] {
 ///   map.iter2().each((k, _) => { sum = sum + k })
 ///   inspect(sum, content="3")
 /// ```
-pub fn[K, V] iter2(self : HashMap[K, V]) -> Iter2[K, V] {
+pub fn[K, V] HashMap::iter2(self : HashMap[K, V]) -> Iter2[K, V] {
   Iter2::new(yield_ => for entry in self.entries {
     if entry is Some({ key, value, .. }) {
       guard yield_(key, value) is IterContinue else { break IterEnd }
@@ -168,7 +168,7 @@ pub fn[K : Hash + Eq, V] HashMap::from_iter(
 ///     ),
 ///   )
 /// ```
-pub fn[K, V] to_array(self : HashMap[K, V]) -> Array[(K, V)] {
+pub fn[K, V] HashMap::to_array(self : HashMap[K, V]) -> Array[(K, V)] {
   let mut i = 0
   let res = while i < self.capacity {
     if self.entries[i] is Some({ key, value, .. }) {
@@ -208,7 +208,7 @@ pub fn[K, V] to_array(self : HashMap[K, V]) -> Array[(K, V)] {
 ///   inspect(map.length(), content="3")
 /// ```
 #alias(size, deprecated)
-pub fn[K, V] length(self : HashMap[K, V]) -> Int {
+pub fn[K, V] HashMap::length(self : HashMap[K, V]) -> Int {
   self.size
 }
 
@@ -230,7 +230,7 @@ pub fn[K, V] length(self : HashMap[K, V]) -> Int {
 ///   let map : @hashmap.HashMap[Int, String] = @hashmap.new(capacity=16)
 ///   inspect(map.capacity(), content="16")
 /// ```
-pub fn[K, V] capacity(self : HashMap[K, V]) -> Int {
+pub fn[K, V] HashMap::capacity(self : HashMap[K, V]) -> Int {
   self.capacity
 }
 
@@ -252,7 +252,7 @@ pub fn[K, V] capacity(self : HashMap[K, V]) -> Int {
 ///   map.set("key", 42)
 ///   inspect(map.is_empty(), content="false")
 /// ```
-pub fn[K, V] is_empty(self : HashMap[K, V]) -> Bool {
+pub fn[K, V] HashMap::is_empty(self : HashMap[K, V]) -> Bool {
   self.size == 0
 }
 
@@ -278,7 +278,7 @@ pub fn[K, V] is_empty(self : HashMap[K, V]) -> Bool {
 /// ))
 /// ```
 #locals(f)
-pub fn[K, V] each(
+pub fn[K, V] HashMap::each(
   self : HashMap[K, V],
   f : (K, V) -> Unit raise?,
 ) -> Unit raise? {
@@ -305,7 +305,7 @@ pub fn[K, V] each(
 ///  * The value of the current entry
 ///
 #locals(f)
-pub fn[K, V] eachi(
+pub fn[K, V] HashMap::eachi(
   self : HashMap[K, V],
   f : (Int, K, V) -> Unit raise?,
 ) -> Unit raise? {
@@ -436,7 +436,7 @@ pub fn[K, V] HashMap::values(self : HashMap[K, V]) -> Iter[V] {
 ///   inspect(map.get("d"), content="Some(4)")
 /// ```
 #locals(f)
-pub fn[K, V] retain(self : HashMap[K, V], f : (K, V) -> Bool) -> Unit {
+pub fn[K, V] HashMap::retain(self : HashMap[K, V], f : (K, V) -> Bool) -> Unit {
   let size = self.size
   let mut j = 0
   for i = 0; j < size; i = i + 1 {

--- a/hashset/deprecated.mbt
+++ b/hashset/deprecated.mbt
@@ -15,7 +15,7 @@
 ///|
 #deprecated("Use `add` instead.")
 #coverage.skip
-pub fn[K : Hash + Eq] insert(self : HashSet[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] HashSet::insert(self : HashSet[K], key : K) -> Unit {
   self.add(key)
 }
 

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -65,12 +65,16 @@ pub fn[K : Hash + Eq] HashSet::of(arr : FixedArray[K]) -> HashSet[K] {
 ///   set.add("key") // no effect since it already exists
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] add(self : HashSet[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] HashSet::add(self : HashSet[K], key : K) -> Unit {
   self.add_with_hash(key, key.hash())
 }
 
 ///|
-fn[K : Eq] add_with_hash(self : HashSet[K], key : K, hash : Int) -> Unit {
+fn[K : Eq] HashSet::add_with_hash(
+  self : HashSet[K],
+  key : K,
+  hash : Int,
+) -> Unit {
   if self.size >= self.grow_at {
     self.grow()
   }
@@ -95,7 +99,11 @@ fn[K : Eq] add_with_hash(self : HashSet[K], key : K, hash : Int) -> Unit {
 }
 
 ///|
-fn[K] push_away(self : HashSet[K], idx : Int, entry : Entry[K]) -> Unit {
+fn[K] HashSet::push_away(
+  self : HashSet[K],
+  idx : Int,
+  entry : Entry[K],
+) -> Unit {
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
     match self.entries[idx] {
       None => {
@@ -119,13 +127,17 @@ fn[K] push_away(self : HashSet[K], idx : Int, entry : Entry[K]) -> Unit {
 
 ///|
 #inline
-fn[K] set_entry(self : HashSet[K], entry : Entry[K], new_idx : Int) -> Unit {
+fn[K] HashSet::set_entry(
+  self : HashSet[K],
+  entry : Entry[K],
+  new_idx : Int,
+) -> Unit {
   self.entries[new_idx] = Some(entry)
 }
 
 ///|
 /// Check if the hash set contains a key.
-pub fn[K : Hash + Eq] contains(self : HashSet[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
@@ -159,7 +171,7 @@ pub fn[K : Hash + Eq] contains(self : HashSet[K], key : K) -> Bool {
 ///   inspect(set.contains("a"), content="false")
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] remove(self : HashSet[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break }
@@ -176,7 +188,7 @@ pub fn[K : Hash + Eq] remove(self : HashSet[K], key : K) -> Unit {
 }
 
 ///|
-fn[K] shift_back(self : HashSet[K], idx : Int) -> Unit {
+fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
   let next = (idx + 1) & self.capacity_mask
   match self.entries[next] {
     None | Some({ psl: 0, .. }) => self.entries[idx] = None
@@ -189,7 +201,7 @@ fn[K] shift_back(self : HashSet[K], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq] grow(self : HashSet[K]) -> Unit {
+fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
   // handle zero capacity
   if self.capacity == 0 {
     self.capacity = default_init_capacity
@@ -222,26 +234,29 @@ pub impl[K : Show] Show for HashSet[K] with output(self, logger) {
 ///|
 /// Get the number of keys in the set.
 #alias(size, deprecated)
-pub fn[K] length(self : HashSet[K]) -> Int {
+pub fn[K] HashSet::length(self : HashSet[K]) -> Int {
   self.size
 }
 
 ///|
 /// Get the capacity of the set.
-pub fn[K] capacity(self : HashSet[K]) -> Int {
+pub fn[K] HashSet::capacity(self : HashSet[K]) -> Int {
   self.capacity
 }
 
 ///|
 /// Check if the hash set is empty.
-pub fn[K] is_empty(self : HashSet[K]) -> Bool {
+pub fn[K] HashSet::is_empty(self : HashSet[K]) -> Bool {
   self.size == 0
 }
 
 ///|
 /// Iterate over all keys of the set.
 #locals(f)
-pub fn[K] each(self : HashSet[K], f : (K) -> Unit raise?) -> Unit raise? {
+pub fn[K] HashSet::each(
+  self : HashSet[K],
+  f : (K) -> Unit raise?,
+) -> Unit raise? {
   for entry in self.entries {
     if entry is Some({ key, .. }) {
       f(key)
@@ -252,7 +267,10 @@ pub fn[K] each(self : HashSet[K], f : (K) -> Unit raise?) -> Unit raise? {
 ///|
 /// Iterate over all keys of the set, with index.
 #locals(f)
-pub fn[K] eachi(self : HashSet[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
+pub fn[K] HashSet::eachi(
+  self : HashSet[K],
+  f : (Int, K) -> Unit raise?,
+) -> Unit raise? {
   let mut idx = 0
   for i in 0..<self.capacity {
     if self.entries[i] is Some({ key, .. }) {
@@ -264,14 +282,14 @@ pub fn[K] eachi(self : HashSet[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
 
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
-pub fn[K] clear(self : HashSet[K]) -> Unit {
+pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
   self.entries.fill(None)
   self.size = 0
 }
 
 ///|
 /// Returns the iterator of the hash set.
-pub fn[K] iter(self : HashSet[K]) -> Iter[K] {
+pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
   Iter::new(yield_ => for entry in self.entries {
     if entry is Some({ key, .. }) {
       guard yield_(key) is IterContinue else { break IterEnd }
@@ -283,7 +301,7 @@ pub fn[K] iter(self : HashSet[K]) -> Iter[K] {
 
 ///|
 /// Converts the hash set to an array.
-pub fn[K] to_array(self : HashSet[K]) -> Array[K] {
+pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
   let arr = Array::new(capacity=self.size)
   for entry in self.entries {
     if entry is Some({ key, .. }) {
@@ -303,7 +321,7 @@ pub fn[K : Hash + Eq] HashSet::from_iter(iter : Iter[K]) -> HashSet[K] {
 
 ///|
 /// Union of two hash sets.
-pub fn[K : Hash + Eq] union(
+pub fn[K : Hash + Eq] HashSet::union(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
@@ -315,7 +333,7 @@ pub fn[K : Hash + Eq] union(
 
 ///|
 /// Intersection of two hash sets.
-pub fn[K : Hash + Eq] intersection(
+pub fn[K : Hash + Eq] HashSet::intersection(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
@@ -326,7 +344,7 @@ pub fn[K : Hash + Eq] intersection(
 
 ///|
 /// Difference of two hash sets.
-pub fn[K : Hash + Eq] difference(
+pub fn[K : Hash + Eq] HashSet::difference(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
@@ -337,7 +355,7 @@ pub fn[K : Hash + Eq] difference(
 
 ///|
 /// Symmetric difference of two hash sets.
-pub fn[K : Hash + Eq] symmetric_difference(
+pub fn[K : Hash + Eq] HashSet::symmetric_difference(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
@@ -349,7 +367,7 @@ pub fn[K : Hash + Eq] symmetric_difference(
 
 ///|
 /// Check if two sets have no common elements.
-pub fn[K : Hash + Eq] is_disjoint(
+pub fn[K : Hash + Eq] HashSet::is_disjoint(
   self : HashSet[K],
   other : HashSet[K],
 ) -> Bool {
@@ -362,7 +380,10 @@ pub fn[K : Hash + Eq] is_disjoint(
 
 ///|
 /// Check if the current set is a subset of another set.
-pub fn[K : Hash + Eq] is_subset(self : HashSet[K], other : HashSet[K]) -> Bool {
+pub fn[K : Hash + Eq] HashSet::is_subset(
+  self : HashSet[K],
+  other : HashSet[K],
+) -> Bool {
   if self.length() <= other.length() {
     self.iter().all(k => other.contains(k))
   } else {
@@ -372,7 +393,7 @@ pub fn[K : Hash + Eq] is_subset(self : HashSet[K], other : HashSet[K]) -> Bool {
 
 ///|
 /// Check if the current set is a superset of another set.
-pub fn[K : Hash + Eq] is_superset(
+pub fn[K : Hash + Eq] HashSet::is_superset(
   self : HashSet[K],
   other : HashSet[K],
 ) -> Bool {
@@ -416,7 +437,7 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 }
 
 ///|
-fn[K : Show] _debug_entries(self : HashSet[K]) -> String {
+fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
   let mut s = ""
   for i in 0..<self.entries.length() {
     if i > 0 {
@@ -563,7 +584,10 @@ test "clear" {
 ///   inspect(set.add_and_check("key"), content="false") // Already exists
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] add_and_check(self : HashSet[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] HashSet::add_and_check(
+  self : HashSet[K],
+  key : K,
+) -> Bool {
   let old_size = self.length()
   self.add(key)
   self.length() > old_size
@@ -588,7 +612,10 @@ pub fn[K : Hash + Eq] add_and_check(self : HashSet[K], key : K) -> Bool {
 ///   inspect(set.remove_and_check("a"), content="false") // Already removed
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] remove_and_check(self : HashSet[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] HashSet::remove_and_check(
+  self : HashSet[K],
+  key : K,
+) -> Bool {
   let old_size = self.size
   self.remove(key)
   self.size < old_size
@@ -596,7 +623,7 @@ pub fn[K : Hash + Eq] remove_and_check(self : HashSet[K], key : K) -> Bool {
 
 ///|
 /// Copy the set, creating a new set with the same keys.
-pub fn[K] copy(self : HashSet[K]) -> HashSet[K] {
+pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
   let other = {
     capacity: self.capacity,
     entries: FixedArray::make(self.capacity, None),

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -126,7 +126,7 @@ pub fn[A] T::from_iter(iter : Iter[A]) -> T[A] {
 //-----------------------------------------------------------------------------
 
 ///|
-pub fn[A] to_array(self : T[A]) -> Array[A] {
+pub fn[A] T::to_array(self : T[A]) -> Array[A] {
   if self.is_empty() {
     []
   } else {
@@ -141,12 +141,12 @@ pub fn[A] to_array(self : T[A]) -> Array[A] {
 //-----------------------------------------------------------------------------
 
 ///|
-pub fn[A] is_empty(self : T[A]) -> Bool {
+pub fn[A] T::is_empty(self : T[A]) -> Bool {
   self.size == 0
 }
 
 ///|
-pub fn[A] length(self : T[A]) -> Int {
+pub fn[A] T::length(self : T[A]) -> Int {
   self.size
 }
 
@@ -193,7 +193,7 @@ pub fn[A] T::at(self : T[A], index : Int) -> A {
 ///   inspect(v.get(-1), content="None")
 ///   inspect(v.get(3), content="None")
 /// ```
-pub fn[A] get(self : T[A], index : Int) -> A? {
+pub fn[A] T::get(self : T[A], index : Int) -> A? {
   guard 0 <= index && index < self.size else { None }
   Some(self[index])
 }
@@ -210,7 +210,7 @@ pub fn[A] get(self : T[A], index : Int) -> A? {
 ///   let v = @array.of([1, 2, 3, 4, 5])
 ///   assert_eq(v.set(1, 10), @array.of([1, 10, 3, 4, 5]))
 /// ```
-pub fn[A] set(self : T[A], index : Int, value : A) -> T[A] {
+pub fn[A] T::set(self : T[A], index : Int, value : A) -> T[A] {
   {
     tree: self.tree.set(index, self.shift, value),
     size: self.size,
@@ -226,14 +226,14 @@ pub fn[A] set(self : T[A], index : Int, value : A) -> T[A] {
 ///   let v = @array.of([1, 2, 3])
 ///   assert_eq(v.push(4), @array.of([1, 2, 3, 4]))
 /// ```
-pub fn[A] push(self : T[A], value : A) -> T[A] {
+pub fn[A] T::push(self : T[A], value : A) -> T[A] {
   let (tree, shift) = self.tree.push_end(self.shift, value)
   { tree, size: self.size + 1, shift }
 }
 
 ///|
 /// Given two trees, concatenate them into a new tree.
-pub fn[A] concat(self : T[A], other : T[A]) -> T[A] {
+pub fn[A] T::concat(self : T[A], other : T[A]) -> T[A] {
   if self.is_empty() {
     return other
   }
@@ -262,7 +262,7 @@ pub impl[A] Add for T[A] with add(self, other) {
 
 ///|
 /// Return an iterator over the array.
-pub fn[A] iter(self : T[A]) -> Iter[A] {
+pub fn[A] T::iter(self : T[A]) -> Iter[A] {
   self.tree.iter()
 }
 
@@ -276,7 +276,7 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
 ///   v.each((e) => { arr.push(e) })
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// ```
-pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
+pub fn[A] T::each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
   self.tree.each(f)
 }
 
@@ -290,7 +290,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
 ///   v.eachi((i, e) => { arr.push(i * e) })
 ///   assert_eq(arr, [0, 2, 6, 12, 20])
 /// ```
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
+pub fn[A] T::eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
   self.tree.eachi(f, self.shift, 0)
 }
 
@@ -302,7 +302,11 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
 ///   let v = @array.of([1, 2, 3, 4, 5])
 ///   assert_eq(v.fold((a, b) => { a + b }, init=0), 15)
 /// ```
-pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B raise?) -> B raise? {
+pub fn[A, B] T::fold(
+  self : T[A],
+  init~ : B,
+  f : (B, A) -> B raise?,
+) -> B raise? {
   self.tree.fold(init, f)
 }
 
@@ -314,7 +318,7 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B raise?) -> B raise? {
 ///   let v = @array.of([1, 2, 3, 4, 5])
 ///   assert_eq(v.rev_fold((a, b) => { a + b }, init=0), 15)
 /// ```
-pub fn[A, B] rev_fold(
+pub fn[A, B] T::rev_fold(
   self : T[A],
   init~ : B,
   f : (B, A) -> B raise?,
@@ -330,7 +334,7 @@ pub fn[A, B] rev_fold(
 ///   let v = @array.of([1, 2, 3, 4, 5])
 ///   assert_eq(v.map((e) => { e * 2 }), @array.of([2, 4, 6, 8, 10]))
 /// ```
-pub fn[A, B] map(self : T[A], f : (A) -> B raise?) -> T[B] raise? {
+pub fn[A, B] T::map(self : T[A], f : (A) -> B raise?) -> T[B] raise? {
   { tree: self.tree.map(f), size: self.size, shift: self.shift }
 }
 

--- a/immut/array/deprecated.mbt
+++ b/immut/array/deprecated.mbt
@@ -19,7 +19,7 @@
 /// 
 #deprecated("We don't copy immutable array")
 #coverage.skip
-pub fn[A] copy(self : T[A]) -> T[A] {
+pub fn[A] T::copy(self : T[A]) -> T[A] {
   fn copy(t : Tree[A]) -> Tree[A] {
     match t {
       Leaf(l) => Leaf(l.copy())
@@ -48,7 +48,11 @@ pub fn[A] copy(self : T[A]) -> T[A] {
 /// ```
 #deprecated("Use `fold` instead")
 #coverage.skip
-pub fn[A] fold_left(self : T[A], f : (A, A) -> A raise?, init~ : A) -> A raise? {
+pub fn[A] T::fold_left(
+  self : T[A],
+  f : (A, A) -> A raise?,
+  init~ : A,
+) -> A raise? {
   self.fold(init~, f)
 }
 
@@ -62,7 +66,7 @@ pub fn[A] fold_left(self : T[A], f : (A, A) -> A raise?, init~ : A) -> A raise? 
 /// ```
 #deprecated("Use `rev_fold` instead")
 #coverage.skip
-pub fn[A] fold_right(
+pub fn[A] T::fold_right(
   self : T[A],
   f : (A, A) -> A raise?,
   init~ : A,

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -139,7 +139,7 @@ fn random_array(n : Int) -> Array[Int] {
 struct Random(Ref[UInt64])
 
 ///|
-fn int(self : Random, limit~ : Int) -> Int {
+fn Random::int(self : Random, limit~ : Int) -> Int {
   let limit = if limit == 0 { 1L << 32 } else { limit.to_int64() }
   let a = 1UL << 48
   let c = 11UL

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -42,14 +42,17 @@ pub fn[K : Hash, V] HashMap::singleton(key : K, value : V) -> HashMap[K, V] {
 
 ///|
 /// Check if the map contains a key.
-pub fn[K : Eq + Hash, V] contains(self : HashMap[K, V], key : K) -> Bool {
+pub fn[K : Eq + Hash, V] HashMap::contains(
+  self : HashMap[K, V],
+  key : K,
+) -> Bool {
   self.get(key) is Some(_)
 }
 
 ///|
 /// Lookup a key from a hash map
 #alias(find, deprecated)
-pub fn[K : Eq + Hash, V] get(self : HashMap[K, V], key : K) -> V? {
+pub fn[K : Eq + Hash, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
   match self.0 {
     None => None
     Some(node) => node.get_with_path(key, @path.of(key))
@@ -122,7 +125,7 @@ fn[K, V] join_2(
 }
 
 ///|
-fn[K : Eq, V] add_with_path(
+fn[K : Eq, V] Node::add_with_path(
   self : Node[K, V],
   key : K,
   value : V,
@@ -163,7 +166,7 @@ fn[K : Eq, V] add_with_path(
 
 ///|
 /// Filter entries that satisfy the predicate
-pub fn[K, V] filter_with_key(
+pub fn[K, V] HashMap::filter_with_key(
   self : HashMap[K, V],
   pred : (K, V) -> Bool raise?,
 ) -> HashMap[K, V] raise? {
@@ -205,7 +208,7 @@ pub fn[K, V] filter_with_key(
 /// TODO: can not mark `f` as `#locals(f)` because 
 /// it will be shadowed by the `f` in the `@list.T::fold` function
 /// TO make it more useful in the future, we may need propagate
-pub fn[K, V, A] fold_with_key(
+pub fn[K, V, A] HashMap::fold_with_key(
   self : HashMap[K, V],
   init~ : A,
   f : (A, K, V) -> A raise?,
@@ -227,7 +230,7 @@ pub fn[K, V, A] fold_with_key(
 
 ///|
 /// Maps over the key-value pairs in the map
-pub fn[K, V, A] map_with_key(
+pub fn[K, V, A] HashMap::map_with_key(
   self : HashMap[K, V],
   f : (K, V) -> A raise?,
 ) -> HashMap[K, A] raise? {
@@ -250,7 +253,7 @@ pub fn[K, V, A] map_with_key(
 /// Add a key-value pair to the hashmap.
 ///
 /// If a pair with the same key already exists, the old one is replaced
-pub fn[K : Eq + Hash, V] add(
+pub fn[K : Eq + Hash, V] HashMap::add(
   self : HashMap[K, V],
   key : K,
   value : V,
@@ -263,7 +266,10 @@ pub fn[K : Eq + Hash, V] add(
 
 ///|
 /// Remove an element from a map
-pub fn[K : Eq + Hash, V] remove(self : HashMap[K, V], key : K) -> HashMap[K, V] {
+pub fn[K : Eq + Hash, V] HashMap::remove(
+  self : HashMap[K, V],
+  key : K,
+) -> HashMap[K, V] {
   match self.0 {
     None => None
     Some(node) => node.remove_with_path(key, @path.of(key))
@@ -271,7 +277,7 @@ pub fn[K : Eq + Hash, V] remove(self : HashMap[K, V], key : K) -> HashMap[K, V] 
 }
 
 ///|
-fn[K : Eq, V] remove_with_path(
+fn[K : Eq, V] Node::remove_with_path(
   self : Node[K, V],
   key : K,
   path : Path,
@@ -327,7 +333,7 @@ fn[K : Eq, V] remove_with_path(
 ///
 /// WARNING: this operation is `O(N)` in map size
 #alias(size, deprecated)
-pub fn[K, V] length(self : HashMap[K, V]) -> Int {
+pub fn[K, V] HashMap::length(self : HashMap[K, V]) -> Int {
   fn node_size(node) {
     match node {
       Leaf(_, _, bucket) => 1 + bucket.length()
@@ -589,7 +595,7 @@ pub fn[K : Eq, V] HashMap::difference(
 
 ///|
 /// Iterate through the elements in a hash map
-pub fn[K, V] each(
+pub fn[K, V] HashMap::each(
   self : HashMap[K, V],
   f : (K, V) -> Unit raise?,
 ) -> Unit raise? {
@@ -612,20 +618,20 @@ pub fn[K, V] each(
 
 ///|
 /// Returns all keys of the map
-pub fn[K, V] keys(self : HashMap[K, V]) -> Iter[K] {
+pub fn[K, V] HashMap::keys(self : HashMap[K, V]) -> Iter[K] {
   self.iter().map(p => p.0)
 }
 
 ///|
 /// Returns all values of the map
 #alias(elems, deprecated="Use `values` instead")
-pub fn[K, V] values(self : HashMap[K, V]) -> Iter[V] {
+pub fn[K, V] HashMap::values(self : HashMap[K, V]) -> Iter[V] {
   self.iter().map(p => p.1)
 }
 
 ///|
 /// Converted to Iter
-pub fn[K, V] iter(self : HashMap[K, V]) -> Iter[(K, V)] {
+pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
   fn go(node) -> Iter[(K, V)] {
     match node {
       Leaf(k, v, bucket) => Iter::singleton((k, v)) + bucket.iter()
@@ -641,7 +647,7 @@ pub fn[K, V] iter(self : HashMap[K, V]) -> Iter[(K, V)] {
 }
 
 ///|
-pub fn[K, V] iter2(self : HashMap[K, V]) -> Iter2[K, V] {
+pub fn[K, V] HashMap::iter2(self : HashMap[K, V]) -> Iter2[K, V] {
   Iter2::new(yield_ => for kv in self {
     guard yield_(kv.0, kv.1) is IterContinue else { break IterEnd }
   } else {
@@ -678,7 +684,7 @@ pub fn[K : Eq + Hash, V] HashMap::from_array(
 
 ///|
 /// Convert to an array of key-value pairs.
-pub fn[K, V] to_array(self : HashMap[K, V]) -> Array[(K, V)] {
+pub fn[K, V] HashMap::to_array(self : HashMap[K, V]) -> Array[(K, V)] {
   let arr = Array::new(capacity=self.length())
   self.each((k, v) => arr.push((k, v)))
   arr

--- a/immut/hashmap/deprecated.mbt
+++ b/immut/hashmap/deprecated.mbt
@@ -16,7 +16,7 @@
 /// Filter values that satisfy the predicate
 #deprecated("Use `filter_with_key` instead. `filter` will accept `(K, V) -> Bool` in the future.")
 #coverage.skip
-pub fn[K, V] filter(
+pub fn[K, V] HashMap::filter(
   self : HashMap[K, V],
   pred : (V) -> Bool raise?,
 ) -> HashMap[K, V] raise? {
@@ -26,7 +26,7 @@ pub fn[K, V] filter(
 ///|
 /// Fold the values in the map
 #deprecated("Use `fold_with_key` instead. `fold` will accept `(A, K, V) -> A` in the future.")
-pub fn[K, V, A] fold(
+pub fn[K, V, A] HashMap::fold(
   self : HashMap[K, V],
   init~ : A,
   f : (A, V) -> A raise?,
@@ -38,7 +38,7 @@ pub fn[K, V, A] fold(
 /// Maps over the values in the map
 #deprecated("Use `map_with_key` instead. `map` will accept `(K, V) -> A` in the future.")
 #coverage.skip
-pub fn[K, V, A] map(
+pub fn[K, V, A] HashMap::map(
   self : HashMap[K, V],
   f : (V) -> A raise?,
 ) -> HashMap[K, A] raise? {

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -35,7 +35,7 @@ pub fn[A] HashSet::new() -> HashSet[A] {
 
 ///|
 /// Lookup a value from the hash set
-pub fn[A : Eq + Hash] contains(self : HashSet[A], key : A) -> Bool {
+pub fn[A : Eq + Hash] HashSet::contains(self : HashSet[A], key : A) -> Bool {
   self.0 is Some(node) && node.contains(key, @path.of(key))
 }
 
@@ -77,7 +77,7 @@ fn[A] join_2(key1 : A, path1 : Path, key2 : A, path2 : Path) -> Node[A] {
 }
 
 ///|
-fn[A : Eq] add_with_path(self : Node[A], key : A, path : Path) -> Node[A] {
+fn[A : Eq] Node::add_with_path(self : Node[A], key : A, path : Path) -> Node[A] {
   match self {
     Leaf(key1, bucket) =>
       if key == key1 || bucket.contains(key) {
@@ -109,7 +109,7 @@ fn[A : Eq] add_with_path(self : Node[A], key : A, path : Path) -> Node[A] {
 
 ///|
 /// Add a key to the hashset.
-pub fn[A : Eq + Hash] add(self : HashSet[A], key : A) -> HashSet[A] {
+pub fn[A : Eq + Hash] HashSet::add(self : HashSet[A], key : A) -> HashSet[A] {
   match self.0 {
     None => Some(Flat(key, @path.of(key)))
     Some(node) => Some(node.add_with_path(key, @path.of(key)))
@@ -118,7 +118,7 @@ pub fn[A : Eq + Hash] add(self : HashSet[A], key : A) -> HashSet[A] {
 
 ///|
 /// Remove an element from a set
-pub fn[A : Eq + Hash] remove(self : HashSet[A], key : A) -> HashSet[A] {
+pub fn[A : Eq + Hash] HashSet::remove(self : HashSet[A], key : A) -> HashSet[A] {
   match self.0 {
     None => None
     Some(node) => node.remove_with_path(key, @path.of(key))
@@ -126,7 +126,11 @@ pub fn[A : Eq + Hash] remove(self : HashSet[A], key : A) -> HashSet[A] {
 }
 
 ///|
-fn[A : Eq] remove_with_path(self : Node[A], key : A, path : Path) -> Node[A]? {
+fn[A : Eq] Node::remove_with_path(
+  self : Node[A],
+  key : A,
+  path : Path,
+) -> Node[A]? {
   match self {
     Leaf(key1, bucket) =>
       if key1 == key {
@@ -172,7 +176,7 @@ fn[A : Eq] remove_with_path(self : Node[A], key : A, path : Path) -> Node[A]? {
 ///
 /// WARNING: this operation is `O(N)` in set size
 #alias(size, deprecated)
-pub fn[A] length(self : HashSet[A]) -> Int {
+pub fn[A] HashSet::length(self : HashSet[A]) -> Int {
   fn node_size(node) {
     match node {
       Leaf(_, bucket) => 1 + bucket.length()
@@ -304,13 +308,16 @@ pub fn[K : Eq] HashSet::difference(
 
 ///|
 /// Returns true if the hash set is empty.
-pub fn[A] is_empty(self : HashSet[A]) -> Bool {
+pub fn[A] HashSet::is_empty(self : HashSet[A]) -> Bool {
   self.0 is None
 }
 
 ///|
 /// Iterate through the elements in a hash set
-pub fn[A] each(self : HashSet[A], f : (A) -> Unit raise?) -> Unit raise? {
+pub fn[A] HashSet::each(
+  self : HashSet[A],
+  f : (A) -> Unit raise?,
+) -> Unit raise? {
   fn go(node) raise? {
     match node {
       Leaf(k, bucket) => {
@@ -330,7 +337,7 @@ pub fn[A] each(self : HashSet[A], f : (A) -> Unit raise?) -> Unit raise? {
 
 ///|
 /// Converted to Iter
-pub fn[A] iter(self : HashSet[A]) -> Iter[A] {
+pub fn[A] HashSet::iter(self : HashSet[A]) -> Iter[A] {
   fn go(node) -> Iter[A] {
     match node {
       Leaf(k, bucket) => Iter::singleton(k) + bucket.iter()

--- a/immut/internal/sparse_array/sparse_array.mbt
+++ b/immut/internal/sparse_array/sparse_array.mbt
@@ -32,7 +32,7 @@ pub fn[X] singleton(idx : Int, value : X) -> SparseArray[X] {
 }
 
 ///|
-pub fn[X] get(self : SparseArray[X], idx : Int) -> X? {
+pub fn[X] SparseArray::get(self : SparseArray[X], idx : Int) -> X? {
   if self.elem_info.has(idx) {
     Some(self.data[self.elem_info.index_of(idx)])
   } else {
@@ -41,7 +41,7 @@ pub fn[X] get(self : SparseArray[X], idx : Int) -> X? {
 }
 
 ///|
-fn[X] unsafe_get(self : SparseArray[X], idx : Int) -> X {
+fn[X] SparseArray::unsafe_get(self : SparseArray[X], idx : Int) -> X {
   self.data[self.elem_info.index_of(idx)]
 }
 
@@ -65,7 +65,11 @@ pub fn[X] doubleton(
 ///|
 /// Add a new element into the sparse array.
 /// `idx` must be absent from `self`
-pub fn[X] add(self : SparseArray[X], idx : Int, value : X) -> SparseArray[X] {
+pub fn[X] SparseArray::add(
+  self : SparseArray[X],
+  idx : Int,
+  value : X,
+) -> SparseArray[X] {
   let old_data = self.data
   let old_len = old_data.length()
   let new_len = old_len + 1
@@ -84,7 +88,10 @@ pub fn[X] add(self : SparseArray[X], idx : Int, value : X) -> SparseArray[X] {
 ///|
 /// Removes an element at the specified index from the sparse array.
 /// `idx` must be in `self`
-pub fn[X] remove(self : SparseArray[X], idx : Int) -> SparseArray[X] {
+pub fn[X] SparseArray::remove(
+  self : SparseArray[X],
+  idx : Int,
+) -> SparseArray[X] {
   let old_data = self.data
   let old_len = old_data.length()
   let pos_of_removed_item = self.elem_info.index_of(idx)
@@ -244,7 +251,7 @@ pub fn[X] SparseArray::filter(
 // replace an existing element in the sparse array.
 
 ///|
-pub fn[X] replace(
+pub fn[X] SparseArray::replace(
   self : SparseArray[X],
   idx : Int,
   value : X,
@@ -257,13 +264,16 @@ pub fn[X] replace(
 ///|
 /// Return the size of a sparse array
 #alias(size, deprecated)
-pub fn[X] length(self : SparseArray[X]) -> Int {
+pub fn[X] SparseArray::length(self : SparseArray[X]) -> Int {
   self.data.length()
 }
 
 ///|
 /// Iterate through elements in a sparse array
-pub fn[X] each(self : SparseArray[X], f : (X) -> Unit raise?) -> Unit raise? {
+pub fn[X] SparseArray::each(
+  self : SparseArray[X],
+  f : (X) -> Unit raise?,
+) -> Unit raise? {
   for i in 0..<self.elem_info.length() {
     f(self.data[i])
   }

--- a/immut/list/deprecated.mbt
+++ b/immut/list/deprecated.mbt
@@ -31,7 +31,7 @@ pub fn[A : @json.FromJson] T::from_json(
 ///|
 #deprecated
 #coverage.skip
-pub fn[A] init_(self : T[A]) -> T[A] {
+pub fn[A] T::init_(self : T[A]) -> T[A] {
   fn aux(self) {
     match self {
       Nil => Nil
@@ -52,7 +52,7 @@ pub fn[A] init_(self : T[A]) -> T[A] {
 ///   assert_eq(@list.of([1, 2, 3]) == @list.of([1, 2, 3]), true)
 /// ```
 #deprecated("use `==` instead")
-pub fn[A : Eq] equal(self : T[A], other : T[A]) -> Bool {
+pub fn[A : Eq] T::equal(self : T[A], other : T[A]) -> Bool {
   loop (self, other) {
     (Nil, Nil) => true
     (Cons(h, t), Cons(h1, t1)) => if h == h1 { continue (t, t1) } else { false }

--- a/immut/list/dps_test.mbt
+++ b/immut/list/dps_test.mbt
@@ -20,7 +20,7 @@ pub enum L {
 
 ///|
 /// tail recursive map using dps
-pub fn map(self : L, f : (Int) -> Int) -> L {
+pub fn L::map(self : L, f : (Int) -> Int) -> L {
   match self {
     Nil => Nil
     Cons(head, tail~) => {

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -14,7 +14,7 @@
 
 ///|
 #deprecated("use `@list` instead")
-pub fn[A] add(self : T[A], head : A) -> T[A] {
+pub fn[A] T::add(self : T[A], head : A) -> T[A] {
   Cons(head, self)
 }
 
@@ -36,7 +36,7 @@ pub impl[A : ToJson] ToJson for T[A] with to_json(self) {
 
 ///|
 #deprecated("use `@list` instead")
-pub fn[A : ToJson] to_json(self : T[A]) -> Json {
+pub fn[A : ToJson] T::to_json(self : T[A]) -> Json {
   ToJson::to_json(self)
 }
 
@@ -81,7 +81,7 @@ pub fn[A] from_array(arr : Array[A]) -> T[A] {
 ///|
 /// Get the length of the list.
 #deprecated("use `@list` instead")
-pub fn[A] length(self : T[A]) -> Int {
+pub fn[A] T::length(self : T[A]) -> Int {
   loop (self, 0) {
     (Nil, len) => len
     (Cons(_, rest), acc) => continue (rest, acc + 1)
@@ -99,7 +99,7 @@ pub fn[A] length(self : T[A]) -> Int {
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
+pub fn[A] T::each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
   loop self {
     Nil => ()
     Cons(head, tail) => {
@@ -120,7 +120,7 @@ pub fn[A] each(self : T[A], f : (A) -> Unit raise?) -> Unit raise? {
 ///   assert_eq(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
+pub fn[A] T::eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
   loop (self, 0) {
     (Nil, _) => ()
     (Cons(x, xs), i) => {
@@ -139,7 +139,7 @@ pub fn[A] eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).map((x) => { x * 2}), @list.of([2, 4, 6, 8, 10]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] map(self : T[A], f : (A) -> B) -> T[B] {
+pub fn[A, B] T::map(self : T[A], f : (A) -> B) -> T[B] {
   match self {
     Nil => Nil
     Cons(head, tail) => Cons(f(head), tail.map(f))
@@ -149,7 +149,7 @@ pub fn[A, B] map(self : T[A], f : (A) -> B) -> T[B] {
 ///|
 /// Maps the list with index.
 #deprecated("use `@list` instead")
-pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B raise?) -> T[B] raise? {
+pub fn[A, B] T::mapi(self : T[A], f : (Int, A) -> B raise?) -> T[B] raise? {
   fn go(xs : T[A], i : Int, f : (Int, A) -> B raise?) -> T[B] raise? {
     match xs {
       Nil => Nil
@@ -170,7 +170,7 @@ pub fn[A, B] mapi(self : T[A], f : (Int, A) -> B raise?) -> T[B] raise? {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).rev_map((x) => { x * 2 }), @list.of([10, 8, 6, 4, 2]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] rev_map(self : T[A], f : (A) -> B raise?) -> T[B] raise? {
+pub fn[A, B] T::rev_map(self : T[A], f : (A) -> B raise?) -> T[B] raise? {
   loop (Nil, self) {
     (acc, Nil) => acc
     (acc, Cons(x, xs)) => continue (Cons(f(x), acc), xs)
@@ -180,7 +180,7 @@ pub fn[A, B] rev_map(self : T[A], f : (A) -> B raise?) -> T[B] raise? {
 ///|
 /// Convert list to array.
 #deprecated("use `@list` instead")
-pub fn[A] to_array(self : T[A]) -> Array[A] {
+pub fn[A] T::to_array(self : T[A]) -> Array[A] {
   match self {
     Nil => []
     Cons(x, xs) => {
@@ -206,7 +206,7 @@ pub fn[A] to_array(self : T[A]) -> Array[A] {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).filter((x) => { x % 2 == 0}), @list.of([2, 4]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] filter(self : T[A], f : (A) -> Bool raise?) -> T[A] raise? {
+pub fn[A] T::filter(self : T[A], f : (A) -> Bool raise?) -> T[A] raise? {
   match self {
     Nil => Nil
     Cons(head, tail) =>
@@ -221,7 +221,7 @@ pub fn[A] filter(self : T[A], f : (A) -> Bool raise?) -> T[A] raise? {
 ///|
 /// Test if all elements of the list satisfy the predicate.
 #deprecated("use `@list` instead")
-pub fn[A] all(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
+pub fn[A] T::all(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
   loop self {
     Nil => true
     Cons(head, tail) => if f(head) { continue tail } else { false }
@@ -231,7 +231,7 @@ pub fn[A] all(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
 ///|
 /// Test if any element of the list satisfies the predicate.
 #deprecated("use `@list` instead")
-pub fn[A] any(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
+pub fn[A] T::any(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
   match self {
     Nil => false
     Cons(head, tail) => f(head) || tail.any(f)
@@ -247,7 +247,7 @@ pub fn[A] any(self : T[A], f : (A) -> Bool raise?) -> Bool raise? {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).tail(), @list.of([2, 3, 4, 5]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] tail(self : T[A]) -> T[A] {
+pub fn[A] T::tail(self : T[A]) -> T[A] {
   match self {
     Nil => Nil
     Cons(_, tail) => tail
@@ -258,7 +258,7 @@ pub fn[A] tail(self : T[A]) -> T[A] {
 /// Get first element of the list.
 #internal(unsafe, "Panic if the list is empty")
 #deprecated("use `@list` instead")
-pub fn[A] unsafe_head(self : T[A]) -> A {
+pub fn[A] T::unsafe_head(self : T[A]) -> A {
   match self {
     Nil => abort("head of empty list")
     Cons(head, _) => head
@@ -268,7 +268,7 @@ pub fn[A] unsafe_head(self : T[A]) -> A {
 ///|
 #coverage.skip
 #deprecated("use `@list` instead")
-pub fn[A] head_exn(self : T[A]) -> A {
+pub fn[A] T::head_exn(self : T[A]) -> A {
   self.unsafe_head()
 }
 
@@ -281,7 +281,7 @@ pub fn[A] head_exn(self : T[A]) -> A {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).head(), Some(1))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] head(self : T[A]) -> A? {
+pub fn[A] T::head(self : T[A]) -> A? {
   match self {
     Nil => None
     Cons(head, _) => Some(head)
@@ -291,7 +291,7 @@ pub fn[A] head(self : T[A]) -> A? {
 ///|
 #internal(unsafe, "Panic if the list is empty")
 #deprecated("use `@list` instead")
-pub fn[A] unsafe_last(self : T[A]) -> A {
+pub fn[A] T::unsafe_last(self : T[A]) -> A {
   loop self {
     Nil => abort("last of empty list")
     Cons(head, Nil) => head
@@ -308,7 +308,7 @@ pub fn[A] unsafe_last(self : T[A]) -> A {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).last(), Some(5))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] last(self : T[A]) -> A? {
+pub fn[A] T::last(self : T[A]) -> A? {
   loop self {
     Nil => None
     Cons(head, Nil) => Some(head)
@@ -326,7 +326,7 @@ pub fn[A] last(self : T[A]) -> A? {
 ///   assert_eq(ls, @list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] concat(self : T[A], other : T[A]) -> T[A] {
+pub fn[A] T::concat(self : T[A], other : T[A]) -> T[A] {
   match self {
     Nil => other
     Cons(head, tail) => Cons(head, tail.concat(other))
@@ -343,7 +343,7 @@ pub fn[A] concat(self : T[A], other : T[A]) -> T[A] {
 ///   assert_eq(ls, @list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] rev_concat(self : T[A], other : T[A]) -> T[A] {
+pub fn[A] T::rev_concat(self : T[A], other : T[A]) -> T[A] {
   loop (self, other) {
     (Nil, other) => other
     (Cons(head, tail), other) => continue (tail, Cons(head, other))
@@ -359,7 +359,7 @@ pub fn[A] rev_concat(self : T[A], other : T[A]) -> T[A] {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).rev(), @list.of([5, 4, 3, 2, 1]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] rev(self : T[A]) -> T[A] {
+pub fn[A] T::rev(self : T[A]) -> T[A] {
   self.rev_concat(Nil)
 }
 
@@ -373,7 +373,11 @@ pub fn[A] rev(self : T[A]) -> T[A] {
 ///   inspect(r, content="15")
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B raise?) -> B raise? {
+pub fn[A, B] T::fold(
+  self : T[A],
+  init~ : B,
+  f : (B, A) -> B raise?,
+) -> B raise? {
   match self {
     Nil => init
     Cons(head, tail) => tail.fold(f, init=f(init, head))
@@ -389,7 +393,7 @@ pub fn[A, B] fold(self : T[A], init~ : B, f : (B, A) -> B raise?) -> B raise? {
 ///   inspect(r, content="15")
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] rev_fold(
+pub fn[A, B] T::rev_fold(
   self : T[A],
   init~ : B,
   f : (A, B) -> B raise?,
@@ -413,7 +417,7 @@ pub fn[A, B] rev_fold(
 /// ```
 #coverage.skip
 #deprecated("use `@list` instead")
-pub fn[A, B] fold_left(
+pub fn[A, B] T::fold_left(
   self : T[A],
   f : (B, A) -> B raise?,
   init~ : B,
@@ -424,7 +428,7 @@ pub fn[A, B] fold_left(
 ///|
 #coverage.skip
 #deprecated("use `@list.rev_fold` instead")
-pub fn[A, B] fold_right(
+pub fn[A, B] T::fold_right(
   self : T[A],
   f : (A, B) -> B raise?,
   init~ : B,
@@ -438,7 +442,7 @@ pub fn[A, B] fold_right(
 ///|
 /// Fold the list from left with index.
 #deprecated("use `@list` instead")
-pub fn[A, B] foldi(
+pub fn[A, B] T::foldi(
   self : T[A],
   init~ : B,
   f : (Int, B, A) -> B raise?,
@@ -456,7 +460,7 @@ pub fn[A, B] foldi(
 ///|
 /// Fold the list from right with index.
 #deprecated("use `@list` instead")
-pub fn[A, B] rev_foldi(
+pub fn[A, B] T::rev_foldi(
   self : T[A],
   init~ : B,
   f : (Int, A, B) -> B raise?,
@@ -474,7 +478,7 @@ pub fn[A, B] rev_foldi(
 ///|
 /// Fold the list from left with index.
 #deprecated("use `@list.foldi` instead")
-pub fn[A, B] fold_lefti(
+pub fn[A, B] T::fold_lefti(
   self : T[A],
   f : (Int, B, A) -> B raise?,
   init~ : B,
@@ -492,7 +496,7 @@ pub fn[A, B] fold_lefti(
 ///|
 /// Fold the list from right with index.
 #deprecated("use `@list.rev_foldi` instead")
-pub fn[A, B] fold_righti(
+pub fn[A, B] T::fold_righti(
   self : T[A],
   f : (Int, A, B) -> B raise?,
   init~ : B,
@@ -518,7 +522,7 @@ pub fn[A, B] fold_righti(
 ///   assert_eq(r, Some(@list.from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)])))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] zip(self : T[A], other : T[B]) -> T[(A, B)]? {
+pub fn[A, B] T::zip(self : T[A], other : T[B]) -> T[(A, B)]? {
   let mut acc = Nil
   let res = loop (self, other) {
     (Nil, Nil) => break Some(acc)
@@ -544,7 +548,7 @@ pub fn[A, B] zip(self : T[A], other : T[B]) -> T[(A, B)]? {
 ///   assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] concat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
+pub fn[A, B] T::concat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
   self.flat_map(f)
 }
 
@@ -561,7 +565,7 @@ pub fn[A, B] concat_map(self : T[A], f : (A) -> T[B]) -> T[B] {
 ///   assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B] raise?) -> T[B] raise? {
+pub fn[A, B] T::flat_map(self : T[A], f : (A) -> T[B] raise?) -> T[B] raise? {
   match self {
     Nil => Nil
     Cons(head, tail) => f(head).concat(tail.flat_map(f))
@@ -579,7 +583,7 @@ pub fn[A, B] flat_map(self : T[A], f : (A) -> T[B] raise?) -> T[B] raise? {
 ///   assert_eq(r, @list.of([4, 6, 3]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] filter_map(self : T[A], f : (A) -> B?) -> T[B] {
+pub fn[A, B] T::filter_map(self : T[A], f : (A) -> B?) -> T[B] {
   loop (Nil, self) {
     (acc, Nil) => acc.rev()
     (acc, Cons(x, xs)) =>
@@ -593,7 +597,7 @@ pub fn[A, B] filter_map(self : T[A], f : (A) -> B?) -> T[B] {
 ///|
 #internal(unsafe, "Panic if the index is out of bounds")
 #deprecated("use `@list` instead")
-pub fn[A] unsafe_nth(self : T[A], n : Int) -> A {
+pub fn[A] T::unsafe_nth(self : T[A], n : Int) -> A {
   loop (self, n) {
     (Nil, _) => abort("nth: index out of bounds")
     (Cons(head, _), 0) => head
@@ -603,14 +607,14 @@ pub fn[A] unsafe_nth(self : T[A], n : Int) -> A {
 
 ///|
 #deprecated("use `@list` instead")
-pub fn[A] nth_exn(self : T[A], n : Int) -> A {
+pub fn[A] T::nth_exn(self : T[A], n : Int) -> A {
   self.unsafe_nth(n)
 }
 
 ///|
 /// Get nth element of the list or None if the index is out of bounds
 #deprecated("use `@list` instead")
-pub fn[A] nth(self : T[A], n : Int) -> A? {
+pub fn[A] T::nth(self : T[A], n : Int) -> A? {
   loop (self, n) {
     (Nil, _) => None
     (Cons(head, _), 0) => Some(head)
@@ -645,7 +649,7 @@ pub fn[A] repeat(n : Int, x : A) -> T[A] {
 ///   assert_eq(ls, @list.from_array(["1", "|", "2", "|", "3", "|", "4", "|", "5"]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] intersperse(self : T[A], separator : A) -> T[A] {
+pub fn[A] T::intersperse(self : T[A], separator : A) -> T[A] {
   match self {
     Nil => Nil
     Cons(head, Nil) => Cons(head, Nil)
@@ -656,7 +660,7 @@ pub fn[A] intersperse(self : T[A], separator : A) -> T[A] {
 ///|
 /// Check if the list is empty.
 #deprecated("use `@list` instead")
-pub fn[A] is_empty(self : T[A]) -> Bool {
+pub fn[A] T::is_empty(self : T[A]) -> Bool {
   self is Nil
 }
 
@@ -671,7 +675,7 @@ pub fn[A] is_empty(self : T[A]) -> Bool {
 ///   assert_eq(b, @list.from_array([2, 4, 6]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] unzip(self : T[(A, B)]) -> (T[A], T[B]) {
+pub fn[A, B] T::unzip(self : T[(A, B)]) -> (T[A], T[B]) {
   let mut xs = Nil
   let mut ys = Nil
   // implemented with loop to avoid stack overflow
@@ -695,7 +699,7 @@ pub fn[A, B] unzip(self : T[(A, B)]) -> (T[A], T[B]) {
 ///   assert_eq(ls, @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] flatten(self : T[T[A]]) -> T[A] {
+pub fn[A] T::flatten(self : T[T[A]]) -> T[A] {
   match self {
     Nil => Nil
     Cons(head, tail) => head.concat(tail.flatten())
@@ -705,7 +709,7 @@ pub fn[A] flatten(self : T[T[A]]) -> T[A] {
 ///|
 #internal(unsafe, "Panic if the list is empty")
 #deprecated("use `@list` instead")
-pub fn[A : Compare] unsafe_maximum(self : T[A]) -> A {
+pub fn[A : Compare] T::unsafe_maximum(self : T[A]) -> A {
   match self {
     Nil => abort("maximum: empty list")
     Cons(x, Nil) => x
@@ -724,7 +728,7 @@ pub fn[A : Compare] unsafe_maximum(self : T[A]) -> A {
 /// Get maximum element of the list.
 /// Returns None if the list is empty.
 #deprecated("use `@list` instead")
-pub fn[A : Compare] maximum(self : T[A]) -> A? {
+pub fn[A : Compare] T::maximum(self : T[A]) -> A? {
   match self {
     Nil => None
     Cons(x, Nil) => Some(x)
@@ -739,7 +743,7 @@ pub fn[A : Compare] maximum(self : T[A]) -> A? {
 ///|
 #internal(unsafe, "Panic if the list is empty")
 #deprecated("use `@list` instead")
-pub fn[A : Compare] unsafe_minimum(self : T[A]) -> A {
+pub fn[A : Compare] T::unsafe_minimum(self : T[A]) -> A {
   match self {
     Nil => abort("minimum: empty list")
     Cons(x, Nil) => x
@@ -757,7 +761,7 @@ pub fn[A : Compare] unsafe_minimum(self : T[A]) -> A {
 ///|
 /// Get minimum element of the list.
 #deprecated("use `@list` instead")
-pub fn[A : Compare] minimum(self : T[A]) -> A? {
+pub fn[A : Compare] T::minimum(self : T[A]) -> A? {
   match self {
     Nil => None
     Cons(x, Nil) => Some(x)
@@ -779,7 +783,7 @@ pub fn[A : Compare] minimum(self : T[A]) -> A? {
 ///   assert_eq(ls, @list.from_array([-76, -6, 0, 1, 3, 6, 52, 123]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A : Compare] sort(self : T[A]) -> T[A] {
+pub fn[A : Compare] T::sort(self : T[A]) -> T[A] {
   match self {
     Nil => Nil
     Cons(x, xs) => {
@@ -801,7 +805,7 @@ pub impl[A] Add for T[A] with add(self, other) {
 ///|
 /// Check if the list contains the value.
 #deprecated("use `@list` instead")
-pub fn[A : Eq] contains(self : T[A], value : A) -> Bool {
+pub fn[A : Eq] T::contains(self : T[A], value : A) -> Bool {
   loop self {
     Nil => false
     Cons(x, xs) => if x == value { true } else { continue xs }
@@ -837,7 +841,7 @@ pub fn[A, S] unfold(f : (S) -> (A, S)? raise?, init~ : S) -> T[A] raise? {
 ///   assert_eq(r, @list.of([1, 2, 3]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] take(self : T[A], n : Int) -> T[A] {
+pub fn[A] T::take(self : T[A], n : Int) -> T[A] {
   fn go(n, t) {
     match (n, t) {
       (_, Nil) => Nil
@@ -865,7 +869,7 @@ pub fn[A] take(self : T[A], n : Int) -> T[A] {
 ///   assert_eq(r, @list.of([4, 5]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] drop(self : T[A], n : Int) -> T[A] {
+pub fn[A] T::drop(self : T[A], n : Int) -> T[A] {
   if n <= 0 {
     self
   } else {
@@ -888,7 +892,7 @@ pub fn[A] drop(self : T[A], n : Int) -> T[A] {
 ///   assert_eq(r, @list.of([1, 2]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] take_while(self : T[A], p : (A) -> Bool) -> T[A] {
+pub fn[A] T::take_while(self : T[A], p : (A) -> Bool) -> T[A] {
   match self {
     Nil => Nil
     Cons(x, xs) => if p(x) { Cons(x, xs.take_while(p)) } else { Nil }
@@ -906,7 +910,7 @@ pub fn[A] take_while(self : T[A], p : (A) -> Bool) -> T[A] {
 ///   assert_eq(r, @list.of([3, 4]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] drop_while(self : T[A], p : (A) -> Bool raise?) -> T[A] raise? {
+pub fn[A] T::drop_while(self : T[A], p : (A) -> Bool raise?) -> T[A] raise? {
   loop self {
     Nil => Nil
     Cons(x, xs) => if p(x) { continue xs } else { Cons(x, xs) }
@@ -924,7 +928,7 @@ pub fn[A] drop_while(self : T[A], p : (A) -> Bool raise?) -> T[A] raise? {
 ///   assert_eq(r, @list.of([0, 1, 3, 6, 10, 15]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, E] scan_left(
+pub fn[A, E] T::scan_left(
   self : T[A],
   f : (E, A) -> E raise?,
   init~ : E,
@@ -950,7 +954,7 @@ pub fn[A, E] scan_left(
 ///   assert_eq(r, @list.of([15, 14, 12, 9, 5, 0]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A, B] scan_right(
+pub fn[A, B] T::scan_right(
   self : T[A],
   f : (A, B) -> B raise?,
   init~ : B,
@@ -974,7 +978,7 @@ pub fn[A, B] scan_right(
 ///   assert_eq(ls.lookup(3), Some("c"))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A : Eq, B] lookup(self : T[(A, B)], v : A) -> B? {
+pub fn[A : Eq, B] T::lookup(self : T[(A, B)], v : A) -> B? {
   loop self {
     Nil => None
     Cons((x, y), xs) => if x == v { Some(y) } else { continue xs }
@@ -991,7 +995,7 @@ pub fn[A : Eq, B] lookup(self : T[(A, B)], v : A) -> B? {
 ///   assert_eq(@list.of([1, 3, 5]).find((element) => { element % 2 == 0}), None)
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] find(self : T[A], f : (A) -> Bool raise?) -> A? raise? {
+pub fn[A] T::find(self : T[A], f : (A) -> Bool raise?) -> A? raise? {
   loop self {
     Nil => None
     Cons(element, list) =>
@@ -1013,7 +1017,7 @@ pub fn[A] find(self : T[A], f : (A) -> Bool raise?) -> A? raise? {
 ///   assert_eq(@list.of([1, 3, 8, 5]).findi((element, index) => { (element % 2 == 0) && (index == 3) }), None)
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] findi(self : T[A], f : (A, Int) -> Bool raise?) -> A? raise? {
+pub fn[A] T::findi(self : T[A], f : (A, Int) -> Bool raise?) -> A? raise? {
   loop (self, 0) {
     (list, index) =>
       match list {
@@ -1037,7 +1041,7 @@ pub fn[A] findi(self : T[A], f : (A, Int) -> Bool raise?) -> A? raise? {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).remove_at(2), @list.of([1, 2, 4, 5]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] remove_at(self : T[A], index : Int) -> T[A] {
+pub fn[A] T::remove_at(self : T[A], index : Int) -> T[A] {
   match (index, self) {
     (0, Cons(_, tail)) => tail
     (_, Cons(head, tail)) => Cons(head, tail.remove_at(index - 1))
@@ -1055,7 +1059,7 @@ pub fn[A] remove_at(self : T[A], index : Int) -> T[A] {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).remove(3), @list.of([1, 2, 4, 5]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A : Eq] remove(self : T[A], elem : A) -> T[A] {
+pub fn[A : Eq] T::remove(self : T[A], elem : A) -> T[A] {
   match self {
     Nil => Nil
     Cons(head, tail) =>
@@ -1076,7 +1080,7 @@ pub fn[A : Eq] remove(self : T[A], elem : A) -> T[A] {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([1, 2, 3])), true)
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A : Eq] is_prefix(self : T[A], prefix : T[A]) -> Bool {
+pub fn[A : Eq] T::is_prefix(self : T[A], prefix : T[A]) -> Bool {
   loop (self, prefix) {
     (_, Nil) => true
     (Nil, Cons(_)) => false
@@ -1098,7 +1102,7 @@ pub fn[A : Eq] is_prefix(self : T[A], prefix : T[A]) -> Bool {
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).is_suffix(@list.of([3, 4, 5])), true)
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A : Eq] is_suffix(self : T[A], suffix : T[A]) -> Bool {
+pub fn[A : Eq] T::is_suffix(self : T[A], suffix : T[A]) -> Bool {
   self.rev().is_prefix(suffix.rev())
 }
 
@@ -1116,7 +1120,7 @@ pub fn[A : Eq] is_suffix(self : T[A], suffix : T[A]) -> Bool {
 ///   assert_eq(r, @list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]))
 /// ```
 #deprecated("use `@list` instead")
-pub fn[A] intercalate(self : T[T[A]], sep : T[A]) -> T[A] {
+pub fn[A] T::intercalate(self : T[T[A]], sep : T[A]) -> T[A] {
   self.intersperse(sep).flatten()
 }
 
@@ -1134,7 +1138,7 @@ pub fn[X] default() -> T[X] {
 
 ///|
 #deprecated("use `@list` instead")
-pub fn[A] iter(self : T[A]) -> Iter[A] {
+pub fn[A] T::iter(self : T[A]) -> Iter[A] {
   Iter::new(yield_ => loop self {
     Nil => IterContinue
     Cons(head, tail) => {
@@ -1148,7 +1152,7 @@ pub fn[A] iter(self : T[A]) -> Iter[A] {
 
 ///|
 #deprecated("use `@list` instead")
-pub fn[A] iter2(self : T[A]) -> Iter2[Int, A] {
+pub fn[A] T::iter2(self : T[A]) -> Iter2[Int, A] {
   Iter2::new(yield_ => loop (self, 0) {
     (Nil, _) => IterEnd
     (Cons(head, tail), i) => {

--- a/immut/priority_queue/deprecated.mbt
+++ b/immut/priority_queue/deprecated.mbt
@@ -15,7 +15,9 @@
 ///|
 #deprecated("Use `unsafe_pop` instead")
 #coverage.skip
-pub fn[A : Compare] pop_exn(self : PriorityQueue[A]) -> PriorityQueue[A] {
+pub fn[A : Compare] PriorityQueue::pop_exn(
+  self : PriorityQueue[A],
+) -> PriorityQueue[A] {
   self.unsafe_pop()
 }
 

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -45,7 +45,9 @@ pub fn[A : Compare] PriorityQueue::from_array(
 }
 
 ///|
-pub fn[A : Compare] to_array(self : PriorityQueue[A]) -> Array[A] {
+pub fn[A : Compare] PriorityQueue::to_array(
+  self : PriorityQueue[A],
+) -> Array[A] {
   let arr : Array[A] = []
   let stack : Array[Node[A]] = [self.node]
   while stack.pop() is Some(node) {
@@ -65,7 +67,7 @@ pub fn[A : Compare] to_array(self : PriorityQueue[A]) -> Array[A] {
 }
 
 ///|
-pub fn[A : Compare] iter(self : PriorityQueue[A]) -> Iter[A] {
+pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
   Iter::new(yield_ => {
     let arr = self.to_array()
     for i in 0..<arr.length() {
@@ -97,12 +99,12 @@ fn path(size : Int) -> Path {
 }
 
 ///|
-fn is_left(self : Path) -> Bool {
+fn Path::is_left(self : Path) -> Bool {
   (self.0 & 1) == 0
 }
 
 ///|
-fn next(self : Path) -> Path {
+fn Path::next(self : Path) -> Path {
   Path(self.0 >> 1)
 }
 
@@ -115,7 +117,9 @@ fn next(self : Path) -> Path {
 ///   let first = queue.pop()
 ///   assert_eq(first, Some(@priority_queue.of([1, 2, 3])))
 /// ```
-pub fn[A : Compare] pop(self : PriorityQueue[A]) -> PriorityQueue[A]? {
+pub fn[A : Compare] PriorityQueue::pop(
+  self : PriorityQueue[A],
+) -> PriorityQueue[A]? {
   match self.node {
     Empty => None
     Leaf(_) => Some({ node: Empty, size: 0 })
@@ -127,7 +131,7 @@ pub fn[A : Compare] pop(self : PriorityQueue[A]) -> PriorityQueue[A]? {
 }
 
 ///|
-fn[A] remove_last_leaf(self : Node[A], path : Path) -> (A, Node[A]) {
+fn[A] Node::remove_last_leaf(self : Node[A], path : Path) -> (A, Node[A]) {
   match self {
     Empty => abort("Priority queue is empty!")
     Leaf(a) => (a, Empty)
@@ -145,7 +149,7 @@ fn[A] remove_last_leaf(self : Node[A], path : Path) -> (A, Node[A]) {
 
 ///|
 /// require: self is not empty
-fn[A : Compare] change_and_down(self : Node[A], value : A) -> Node[A] {
+fn[A : Compare] Node::change_and_down(self : Node[A], value : A) -> Node[A] {
   match self {
     Empty => abort("unreachable")
     Leaf(_) => Leaf(value)
@@ -180,7 +184,9 @@ fn[A : Compare] change_and_down(self : Node[A], value : A) -> Node[A] {
 ///   assert_eq(first, @priority_queue.of([1, 2, 3]))
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
-pub fn[A : Compare] unsafe_pop(self : PriorityQueue[A]) -> PriorityQueue[A] {
+pub fn[A : Compare] PriorityQueue::unsafe_pop(
+  self : PriorityQueue[A],
+) -> PriorityQueue[A] {
   match self.node {
     Empty => abort("Priority queue is empty!")
     Leaf(_) => { node: Empty, size: 0 }
@@ -199,7 +205,7 @@ pub fn[A : Compare] unsafe_pop(self : PriorityQueue[A]) -> PriorityQueue[A] {
 ///   let queue = @priority_queue.new()
 ///   assert_eq(queue.push(1).length(), 1)
 /// ```
-pub fn[A : Compare] push(
+pub fn[A : Compare] PriorityQueue::push(
   self : PriorityQueue[A],
   value : A,
 ) -> PriorityQueue[A] {
@@ -239,7 +245,7 @@ fn[A : Compare] Node::push(self : Node[A], value : A, path : Path) -> Node[A] {
 ///   let queue = @priority_queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.peek(), Some(4))
 /// ```
-pub fn[A] peek(self : PriorityQueue[A]) -> A? {
+pub fn[A] PriorityQueue::peek(self : PriorityQueue[A]) -> A? {
   match self.node {
     Empty => None
     Leaf(a) => Some(a)
@@ -256,7 +262,7 @@ pub fn[A] peek(self : PriorityQueue[A]) -> A? {
 ///   inspect(queue.is_empty(), content="true")
 ///   assert_eq(queue.push(1).is_empty(), false)
 /// ```
-pub fn[A] is_empty(self : PriorityQueue[A]) -> Bool {
+pub fn[A] PriorityQueue::is_empty(self : PriorityQueue[A]) -> Bool {
   self.node is Empty
 }
 
@@ -269,7 +275,7 @@ pub fn[A] is_empty(self : PriorityQueue[A]) -> Bool {
 ///   inspect(queue.length(), content="0")
 ///   assert_eq(queue.push(1).length(), 1)
 /// ```
-pub fn[A] length(self : PriorityQueue[A]) -> Int {
+pub fn[A] PriorityQueue::length(self : PriorityQueue[A]) -> Int {
   self.size
 }
 

--- a/immut/sorted_map/deprecated.mbt
+++ b/immut/sorted_map/deprecated.mbt
@@ -25,7 +25,7 @@ pub fn[K, V] SortedMap::empty() -> SortedMap[K, V] {
 /// O(log n).
 #deprecated("Use `get` instead")
 #coverage.skip
-pub fn[K : Compare, V] lookup(self : SortedMap[K, V], key : K) -> V? {
+pub fn[K : Compare, V] SortedMap::lookup(self : SortedMap[K, V], key : K) -> V? {
   self.get(key)
 }
 
@@ -33,7 +33,10 @@ pub fn[K : Compare, V] lookup(self : SortedMap[K, V], key : K) -> V? {
 /// Ts over the values in the map.
 #deprecated("Use `map_with_key` instead. `map` will accept `(K, X) -> Y` in the future.")
 #coverage.skip
-pub fn[K, X, Y] map(self : SortedMap[K, X], f : (X) -> Y) -> SortedMap[K, Y] {
+pub fn[K, X, Y] SortedMap::map(
+  self : SortedMap[K, X],
+  f : (X) -> Y,
+) -> SortedMap[K, Y] {
   match self {
     Empty => Empty
     Tree(k, value~, size~, l, r) =>
@@ -45,7 +48,11 @@ pub fn[K, X, Y] map(self : SortedMap[K, X], f : (X) -> Y) -> SortedMap[K, Y] {
 /// Fold the values in the map.
 /// O(n).
 #deprecated("Use `foldl_with_key` instead. `fold` will accept `(A, K, V) -> A` in the future.")
-pub fn[K, V, A] fold(self : SortedMap[K, V], init~ : A, f : (A, V) -> A) -> A {
+pub fn[K, V, A] SortedMap::fold(
+  self : SortedMap[K, V],
+  init~ : A,
+  f : (A, V) -> A,
+) -> A {
   self.foldl_with_key((acc, _k, v) => f(acc, v), init~)
 }
 
@@ -53,14 +60,14 @@ pub fn[K, V, A] fold(self : SortedMap[K, V], init~ : A, f : (A, V) -> A) -> A {
 /// Return all keys of the map in ascending order.
 #deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
 #coverage.skip
-pub fn[K, V] keys(self : SortedMap[K, V]) -> Array[K] {
+pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
   self.iter().map(p => p.0).collect()
 }
 
 ///|
 #deprecated("Use `values` instead")
 #coverage.skip
-pub fn[K, V] elems(self : SortedMap[K, V]) -> Array[V] {
+pub fn[K, V] SortedMap::elems(self : SortedMap[K, V]) -> Array[V] {
   self.values().collect()
 }
 
@@ -68,7 +75,7 @@ pub fn[K, V] elems(self : SortedMap[K, V]) -> Array[V] {
 /// Filter values that satisfy the predicate
 #deprecated("Use `filter_with_key` instead. `filter` will accept `(K, V) -> Bool` in the future.")
 #coverage.skip
-pub fn[K, V] filter(
+pub fn[K, V] SortedMap::filter(
   self : SortedMap[K, V],
   pred : (V) -> Bool raise?,
 ) -> SortedMap[K, V] raise? {

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -17,7 +17,7 @@
 /// O(log n).
 ///
 #alias(insert, deprecated)
-pub fn[K : Compare, V] add(
+pub fn[K : Compare, V] SortedMap::add(
   self : SortedMap[K, V],
   key : K,
   value : V,
@@ -38,7 +38,9 @@ pub fn[K : Compare, V] add(
 }
 
 ///|
-fn[K, V] split_max(self : SortedMap[K, V]) -> (K, V, SortedMap[K, V]) {
+fn[K, V] SortedMap::split_max(
+  self : SortedMap[K, V],
+) -> (K, V, SortedMap[K, V]) {
   match self {
     Tree(k, value=v, l, Empty, ..) => (k, v, l)
     Tree(k, value=v, l, r, ..) => {
@@ -50,7 +52,9 @@ fn[K, V] split_max(self : SortedMap[K, V]) -> (K, V, SortedMap[K, V]) {
 }
 
 ///|
-fn[K, V] split_min(self : SortedMap[K, V]) -> (K, V, SortedMap[K, V]) {
+fn[K, V] SortedMap::split_min(
+  self : SortedMap[K, V],
+) -> (K, V, SortedMap[K, V]) {
   match self {
     Tree(k, value=v, Empty, r, ..) => (k, v, r)
     Tree(k, value=v, l, r, ..) => {
@@ -80,7 +84,7 @@ fn[K, V] glue(l : SortedMap[K, V], r : SortedMap[K, V]) -> SortedMap[K, V] {
 ///|
 /// Create a new map with a key-value pair removed. O(log n).
 /// If the key is not a member or map, the original map is returned.
-pub fn[K : Compare, V] remove(
+pub fn[K : Compare, V] SortedMap::remove(
   self : SortedMap[K, V],
   key : K,
 ) -> SortedMap[K, V] {
@@ -101,7 +105,7 @@ pub fn[K : Compare, V] remove(
 
 ///|
 /// Filter key-value pairs that satisfy the predicate
-pub fn[K, V] filter_with_key(
+pub fn[K, V] SortedMap::filter_with_key(
   self : SortedMap[K, V],
   pred : (K, V) -> Bool raise?,
 ) -> SortedMap[K, V] raise? {
@@ -118,7 +122,7 @@ pub fn[K, V] filter_with_key(
 
 ///|
 /// Convert to an array of key-value pairs.
-pub fn[K, V] to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
+pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
   let arr = []
   self.each((k, v) => arr.push((k, v)))
   arr

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -29,7 +29,10 @@ pub fn[K, V] SortedMap::singleton(key : K, value : V) -> SortedMap[K, V] {
 ///|
 /// Check if the map contains a key.
 /// O(log n).
-pub fn[K : Compare, V] contains(self : SortedMap[K, V], key : K) -> Bool {
+pub fn[K : Compare, V] SortedMap::contains(
+  self : SortedMap[K, V],
+  key : K,
+) -> Bool {
   loop self {
     Empty => false
     Tree(k, l, r, ..) => {
@@ -48,7 +51,7 @@ pub fn[K : Compare, V] contains(self : SortedMap[K, V], key : K) -> Bool {
 ///|
 /// Get the number of key-value pairs in the map.
 #alias(size, deprecated)
-pub fn[K, V] length(self : SortedMap[K, V]) -> Int {
+pub fn[K, V] SortedMap::length(self : SortedMap[K, V]) -> Int {
   match self {
     Empty => 0
     Tree(_) as t => t.size
@@ -56,7 +59,7 @@ pub fn[K, V] length(self : SortedMap[K, V]) -> Int {
 }
 
 ///|
-pub fn[K, V] is_empty(self : SortedMap[K, V]) -> Bool {
+pub fn[K, V] SortedMap::is_empty(self : SortedMap[K, V]) -> Bool {
   self.length() == 0
 }
 
@@ -74,7 +77,7 @@ fn[K, V] make_tree(
 ///|
 /// Get the value associated with a key.
 /// O(log n).
-pub fn[K : Compare, V] get(self : SortedMap[K, V], key : K) -> V? {
+pub fn[K : Compare, V] SortedMap::get(self : SortedMap[K, V], key : K) -> V? {
   loop self {
     Empty => None
     Tree(k, value~, l, r, ..) => {
@@ -112,7 +115,10 @@ pub fn[K : Compare, V] SortedMap::at(self : SortedMap[K, V], key : K) -> V {
 
 ///|
 /// Iterate over the key-value pairs in the map.
-pub fn[K, V] each(self : SortedMap[K, V], f : (K, V) -> Unit) -> Unit {
+pub fn[K, V] SortedMap::each(
+  self : SortedMap[K, V],
+  f : (K, V) -> Unit,
+) -> Unit {
   match self {
     Empty => ()
     Tree(k, value~, l, r, ..) => {
@@ -125,7 +131,10 @@ pub fn[K, V] each(self : SortedMap[K, V], f : (K, V) -> Unit) -> Unit {
 
 ///|
 /// Iterate over the key-value pairs with index.
-pub fn[K, V] eachi(self : SortedMap[K, V], f : (Int, K, V) -> Unit) -> Unit {
+pub fn[K, V] SortedMap::eachi(
+  self : SortedMap[K, V],
+  f : (Int, K, V) -> Unit,
+) -> Unit {
   fn do_eachi(m : SortedMap[K, V], f, i) {
     match m {
       Empty => ()
@@ -142,7 +151,7 @@ pub fn[K, V] eachi(self : SortedMap[K, V], f : (Int, K, V) -> Unit) -> Unit {
 
 ///|
 /// Maps over the key-value pairs in the map.
-pub fn[K, X, Y] map_with_key(
+pub fn[K, X, Y] SortedMap::map_with_key(
   self : SortedMap[K, X],
   f : (K, X) -> Y,
 ) -> SortedMap[K, Y] {
@@ -157,7 +166,7 @@ pub fn[K, X, Y] map_with_key(
 /// Post-order fold.
 /// O(n).
 #alias(foldr_with_key)
-pub fn[K, V, A] rev_fold(
+pub fn[K, V, A] SortedMap::rev_fold(
   self : SortedMap[K, V],
   f : (A, K, V) -> A,
   init~ : A,
@@ -175,7 +184,7 @@ pub fn[K, V, A] rev_fold(
 ///|
 /// Pre-order fold.
 /// O(n).
-pub fn[K, V, A] foldl_with_key(
+pub fn[K, V, A] SortedMap::foldl_with_key(
   self : SortedMap[K, V],
   f : (A, K, V) -> A,
   init~ : A,
@@ -191,7 +200,7 @@ pub fn[K, V, A] foldl_with_key(
 }
 
 ///|
-fn[K : Show, V : Show] debug_tree(self : SortedMap[K, V]) -> String {
+fn[K : Show, V : Show] SortedMap::debug_tree(self : SortedMap[K, V]) -> String {
   match self {
     Empty => "_"
     Tree(k, value~, l, r, ..) => {
@@ -218,7 +227,7 @@ pub fn[K : Compare, V] SortedMap::from_array(
 }
 
 ///|
-pub fn[K, V] iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
+pub fn[K, V] SortedMap::iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
   Iter::new(yield_ => {
     fn go(t) {
       match t {
@@ -239,7 +248,7 @@ pub fn[K, V] iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
 }
 
 ///|
-pub fn[K, V] iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
+pub fn[K, V] SortedMap::iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
   Iter2::new(yield_ => {
     fn go(t) {
       match t {
@@ -269,13 +278,13 @@ pub fn[K : Compare, V] SortedMap::from_iter(
 
 ///|
 /// Return all keys of the map in ascending order.
-pub fn[K, V] keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
+pub fn[K, V] SortedMap::keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
   self.iter().map(p => p.0)
 }
 
 ///|
 /// Return all elements of the map in the ascending order of their keys.
-pub fn[K, V] values(self : SortedMap[K, V]) -> Iter[V] {
+pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Iter[V] {
   self.iter().map(p => p.1)
 }
 
@@ -293,6 +302,6 @@ pub fn[K : Compare, V] SortedMap::of(
 }
 
 ///|
-pub fn[K : Show, V : ToJson] to_json(self : SortedMap[K, V]) -> Json {
+pub fn[K : Show, V : ToJson] SortedMap::to_json(self : SortedMap[K, V]) -> Json {
   ToJson::to_json(self)
 }

--- a/immut/sorted_set/deprecated.mbt
+++ b/immut/sorted_set/deprecated.mbt
@@ -15,7 +15,7 @@
 ///|
 #deprecated("Use `intersection` instead")
 #coverage.skip
-pub fn[A : Compare] inter(
+pub fn[A : Compare] SortedSet::inter(
   self : SortedSet[A],
   other : SortedSet[A],
 ) -> SortedSet[A] {
@@ -31,7 +31,7 @@ pub fn[A : Compare] inter(
 /// ```
 #deprecated("Use `difference` instead")
 #coverage.skip
-pub fn[A : Compare] diff(
+pub fn[A : Compare] SortedSet::diff(
   self : SortedSet[A],
   other : SortedSet[A],
 ) -> SortedSet[A] {

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -17,7 +17,7 @@
 // All operations over sets are purely applicative (no side-effects).
 
 ///|
-pub fn[A] iter(self : SortedSet[A]) -> Iter[A] {
+pub fn[A] SortedSet::iter(self : SortedSet[A]) -> Iter[A] {
   Iter::new(yield_ => {
     fn go(t) {
       match t {

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -49,7 +49,7 @@ pub fn[A : Compare] SortedSet::from_array(array : Array[A]) -> SortedSet[A] {
 
 ///|
 /// Convert ImmutableSet[T] to Array[T], the result must be ordered.
-pub fn[A] to_array(self : SortedSet[A]) -> Array[A] {
+pub fn[A] SortedSet::to_array(self : SortedSet[A]) -> Array[A] {
   let arr = []
   fn aux(set : SortedSet[A]) {
     match set {
@@ -76,7 +76,7 @@ pub fn[A] to_array(self : SortedSet[A]) -> Array[A] {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([3, 4, 5]).remove_min(), @sorted_set.of([4, 5]))
 /// ```
-pub fn[A] remove_min(self : SortedSet[A]) -> SortedSet[A] {
+pub fn[A] SortedSet::remove_min(self : SortedSet[A]) -> SortedSet[A] {
   match self {
     Empty => abort("remove_min: empty ImmutableSet")
     Node(left~, right~, value~, ..) =>
@@ -96,7 +96,10 @@ pub fn[A] remove_min(self : SortedSet[A]) -> SortedSet[A] {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([6, 3, 8, 1]).add(5), @sorted_set.of([1, 3, 5, 6, 8]))
 /// ```
-pub fn[A : Compare] add(self : SortedSet[A], value : A) -> SortedSet[A] {
+pub fn[A : Compare] SortedSet::add(
+  self : SortedSet[A],
+  value : A,
+) -> SortedSet[A] {
   match self {
     Empty => Node(left=Empty, value~, right=Empty, size=1)
     Node(left~, right~, value=node_value, ..) => {
@@ -130,7 +133,10 @@ pub fn[A : Compare] add(self : SortedSet[A], value : A) -> SortedSet[A] {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([3, 8, 1]).remove(8), @sorted_set.of([1, 3]))
 /// ```
-pub fn[A : Compare] remove(self : SortedSet[A], value : A) -> SortedSet[A] {
+pub fn[A : Compare] SortedSet::remove(
+  self : SortedSet[A],
+  value : A,
+) -> SortedSet[A] {
   match self {
     Empty => Empty
     Node(left~, right~, value=node_value, ..) => {
@@ -165,7 +171,7 @@ pub fn[A : Compare] remove(self : SortedSet[A], value : A) -> SortedSet[A] {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).min(), 1)
 /// ```
-pub fn[A] min(self : SortedSet[A]) -> A {
+pub fn[A] SortedSet::min(self : SortedSet[A]) -> A {
   match self {
     Empty => abort("min: there are no values in sorted_set.")
     Node(left~, value~, ..) => if left is Empty { value } else { left.min() }
@@ -175,7 +181,7 @@ pub fn[A] min(self : SortedSet[A]) -> A {
 ///|
 /// Returns the smallest value in the sorted_set.
 /// But returns None when the value does not exist.
-pub fn[A] min_option(self : SortedSet[A]) -> A? {
+pub fn[A] SortedSet::min_option(self : SortedSet[A]) -> A? {
   match self {
     Empty => None
     Node(left~, value~, ..) =>
@@ -196,7 +202,7 @@ pub fn[A] min_option(self : SortedSet[A]) -> A? {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).max(), 9)
 /// ```
-pub fn[A] max(self : SortedSet[A]) -> A {
+pub fn[A] SortedSet::max(self : SortedSet[A]) -> A {
   match self {
     Empty => abort("max: there are no values in ImmutableSet.")
     Node(right~, value~, ..) => if right is Empty { value } else { right.max() }
@@ -206,7 +212,7 @@ pub fn[A] max(self : SortedSet[A]) -> A {
 ///|
 /// Returns the largest value in the ImmutableSet.
 /// But returns None when the value does not exist.
-pub fn[A] max_option(self : SortedSet[A]) -> A? {
+pub fn[A] SortedSet::max_option(self : SortedSet[A]) -> A? {
   match self {
     Empty => None
     Node(right~, value~, ..) =>
@@ -231,7 +237,7 @@ pub fn[A] max_option(self : SortedSet[A]) -> A? {
 ///   assert_eq(left, @sorted_set.of([1, 2, 3, 4]))
 ///   assert_eq(right, @sorted_set.of([6, 7, 8, 9]))
 /// ```
-pub fn[A : Compare] split(
+pub fn[A : Compare] SortedSet::split(
   self : SortedSet[A],
   divide : A,
 ) -> (SortedSet[A], Bool, SortedSet[A]) {
@@ -254,13 +260,13 @@ pub fn[A : Compare] split(
 
 ///|
 /// Returns true if sorted_set is empty
-pub fn[A] is_empty(self : SortedSet[A]) -> Bool {
+pub fn[A] SortedSet::is_empty(self : SortedSet[A]) -> Bool {
   self is Empty
 }
 
 ///|
 /// Return true if value contain in sorted_set
-pub fn[A : Compare] contains(self : SortedSet[A], value : A) -> Bool {
+pub fn[A : Compare] SortedSet::contains(self : SortedSet[A], value : A) -> Bool {
   match self {
     Empty => false
     Node(left~, right~, value=node_value, ..) => {
@@ -279,7 +285,7 @@ pub fn[A : Compare] contains(self : SortedSet[A], value : A) -> Bool {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([3, 4, 5]).union(@sorted_set.of([4, 5, 6])), @sorted_set.of([3, 4, 5, 6]))
 /// ```
-pub fn[A : Compare] union(
+pub fn[A : Compare] SortedSet::union(
   self : SortedSet[A],
   other : SortedSet[A],
 ) -> SortedSet[A] {
@@ -325,7 +331,7 @@ pub impl[A : Compare] Add for SortedSet[A] with add(self, other) {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([3, 4, 5]).intersection(@sorted_set.of([4, 5, 6])), @sorted_set.of([4, 5]))
 /// ```
-pub fn[A : Compare] intersection(
+pub fn[A : Compare] SortedSet::intersection(
   self : SortedSet[A],
   other : SortedSet[A],
 ) -> SortedSet[A] {
@@ -347,7 +353,7 @@ pub fn[A : Compare] intersection(
 /// ```mbt
 ///   assert_eq(@sorted_set.of([1, 2, 3]).difference(@sorted_set.of([4, 5, 1])), @sorted_set.of([2, 3]))
 /// ```
-pub fn[A : Compare] difference(
+pub fn[A : Compare] SortedSet::difference(
   self : SortedSet[A],
   other : SortedSet[A],
 ) -> SortedSet[A] {
@@ -384,7 +390,7 @@ pub fn[A : Compare] difference(
 ///     content="@immut/sorted_set.of([1, 2, 5, 6])",
 ///   )
 /// ```
-pub fn[A : Compare] symmetric_difference(
+pub fn[A : Compare] SortedSet::symmetric_difference(
   self : SortedSet[A],
   other : SortedSet[A],
 ) -> SortedSet[A] {
@@ -409,7 +415,10 @@ pub fn[A : Compare] symmetric_difference(
 /// ```mbt
 ///   assert_eq(@sorted_set.of([1, 2, 3]).subset(@sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1])), true)
 /// ```
-pub fn[A : Compare] subset(self : SortedSet[A], other : SortedSet[A]) -> Bool {
+pub fn[A : Compare] SortedSet::subset(
+  self : SortedSet[A],
+  other : SortedSet[A],
+) -> Bool {
   match (self, other) {
     (Empty, _) => true
     (_, Empty) => false
@@ -439,7 +448,10 @@ pub fn[A : Compare] subset(self : SortedSet[A], other : SortedSet[A]) -> Bool {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([1, 2, 3]).disjoint(@sorted_set.of([4, 5, 6])), true)
 /// ```
-pub fn[A : Compare] disjoint(self : SortedSet[A], other : SortedSet[A]) -> Bool {
+pub fn[A : Compare] SortedSet::disjoint(
+  self : SortedSet[A],
+  other : SortedSet[A],
+) -> Bool {
   match (self, other) {
     (Empty, _) | (_, Empty) => true
     (Node(left=l1, value=v1, right=r1, ..), _) =>
@@ -464,7 +476,10 @@ pub fn[A : Compare] disjoint(self : SortedSet[A], other : SortedSet[A]) -> Bool 
 ///   @sorted_set.of([7, 2, 9, 4, 5, 6, 3, 8, 1]).each((x) => { arr.push(x) })
 ///   assert_eq(arr, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 /// ```
-pub fn[A] each(self : SortedSet[A], f : (A) -> Unit raise?) -> Unit raise? {
+pub fn[A] SortedSet::each(
+  self : SortedSet[A],
+  f : (A) -> Unit raise?,
+) -> Unit raise? {
   match self {
     Empty => ()
     Node(left~, value~, right~, ..) => {
@@ -483,7 +498,7 @@ pub fn[A] each(self : SortedSet[A], f : (A) -> Unit raise?) -> Unit raise? {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => { acc + x }), 15)
 /// ```
-pub fn[A, B] fold(
+pub fn[A, B] SortedSet::fold(
   self : SortedSet[A],
   init~ : B,
   f : (B, A) -> B raise?,
@@ -503,7 +518,7 @@ pub fn[A, B] fold(
 /// ```mbt
 ///   assert_eq(@sorted_set.of([1, 2, 3]).map((x) => { x * 2}), @sorted_set.of([2, 4, 6]))
 /// ```
-pub fn[A, B : Compare] map(
+pub fn[A, B : Compare] SortedSet::map(
   self : SortedSet[A],
   f : (A) -> B raise?,
 ) -> SortedSet[B] raise? {
@@ -522,7 +537,10 @@ pub fn[A, B : Compare] map(
 /// ```mbt
 ///   assert_eq(@sorted_set.of([2, 4, 6]).all((v) => { v % 2 == 0}), true)
 /// ```
-pub fn[A] all(self : SortedSet[A], f : (A) -> Bool raise?) -> Bool raise? {
+pub fn[A] SortedSet::all(
+  self : SortedSet[A],
+  f : (A) -> Bool raise?,
+) -> Bool raise? {
   match self {
     Empty => true
     Node(left~, value~, right~, ..) => f(value) && left.all(f) && right.all(f)
@@ -537,7 +555,10 @@ pub fn[A] all(self : SortedSet[A], f : (A) -> Bool raise?) -> Bool raise? {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([1, 4, 3]).any((v) => { v % 2 == 0}), true)
 /// ```
-pub fn[A] any(self : SortedSet[A], f : (A) -> Bool raise?) -> Bool raise? {
+pub fn[A] SortedSet::any(
+  self : SortedSet[A],
+  f : (A) -> Bool raise?,
+) -> Bool raise? {
   match self {
     Empty => false
     Node(left~, value~, right~, ..) => f(value) || left.any(f) || right.any(f)
@@ -552,7 +573,7 @@ pub fn[A] any(self : SortedSet[A], f : (A) -> Bool raise?) -> Bool raise? {
 /// ```mbt
 ///   assert_eq(@sorted_set.of([1, 2, 3, 4, 5, 6]).filter((v) => { v % 2 == 0}), @sorted_set.of([2, 4, 6]))
 /// ```
-pub fn[A] filter(
+pub fn[A] SortedSet::filter(
   self : SortedSet[A],
   f : (A) -> Bool raise?,
 ) -> SortedSet[A] raise? {
@@ -590,7 +611,7 @@ pub impl[A : ToJson] ToJson for SortedSet[A] with to_json(self) {
 }
 
 ///|
-pub fn[A : ToJson] to_json(self : SortedSet[A]) -> Json {
+pub fn[A : ToJson] SortedSet::to_json(self : SortedSet[A]) -> Json {
   ToJson::to_json(self)
 }
 
@@ -649,7 +670,10 @@ impl[T] Show for SplitBis[T] with output(self, logger) {
 ///|
 /// Same as split, but compute the left and right only if the pivot value is not in the ImmutableSet.
 /// The right is computed on demand.
-fn[A : Compare] split_bis(self : SortedSet[A], value : A) -> SplitBis[A] {
+fn[A : Compare] SortedSet::split_bis(
+  self : SortedSet[A],
+  value : A,
+) -> SplitBis[A] {
   match self {
     Empty => NotFound(Empty, () => Empty)
     Node(left~, value=node_value, right~, ..) => {
@@ -674,7 +698,7 @@ fn[A : Compare] split_bis(self : SortedSet[A], value : A) -> SplitBis[A] {
 ///|
 /// Get the height of set.
 #alias(size, deprecated)
-pub fn[A] length(self : SortedSet[A]) -> Int {
+pub fn[A] SortedSet::length(self : SortedSet[A]) -> Int {
   match self {
     Empty => 0
     Node(size~, ..) => size
@@ -736,7 +760,7 @@ fn[A] balance(
 }
 
 ///|
-fn[A] add_min_value(self : SortedSet[A], value : A) -> SortedSet[A] {
+fn[A] SortedSet::add_min_value(self : SortedSet[A], value : A) -> SortedSet[A] {
   match self {
     Empty => singleton(value)
     Node(left~, value=node_value, right~, ..) =>
@@ -745,7 +769,7 @@ fn[A] add_min_value(self : SortedSet[A], value : A) -> SortedSet[A] {
 }
 
 ///|
-fn[A] add_max_value(self : SortedSet[A], value : A) -> SortedSet[A] {
+fn[A] SortedSet::add_max_value(self : SortedSet[A], value : A) -> SortedSet[A] {
   match self {
     Empty => singleton(value)
     Node(left~, value=node_value, right~, ..) =>
@@ -794,7 +818,10 @@ fn[A : Compare] try_join(
 ///|
 /// Merge two ImmutableSet[T] into one.
 /// All values of left must precede the values of r.
-fn[A] merge(self : SortedSet[A], other : SortedSet[A]) -> SortedSet[A] {
+fn[A] SortedSet::merge(
+  self : SortedSet[A],
+  other : SortedSet[A],
+) -> SortedSet[A] {
   match (self, other) {
     (Empty, _) => other
     (_, Empty) => self
@@ -804,7 +831,10 @@ fn[A] merge(self : SortedSet[A], other : SortedSet[A]) -> SortedSet[A] {
 
 ///|
 /// Same as merge, but no assumption on the heights of self and other.
-fn[A] concat(self : SortedSet[A], other : SortedSet[A]) -> SortedSet[A] {
+fn[A] SortedSet::concat(
+  self : SortedSet[A],
+  other : SortedSet[A],
+) -> SortedSet[A] {
   match (self, other) {
     (Empty, _) => other
     (_, Empty) => self

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -47,12 +47,12 @@ pub fn Int::abs(self : Int) -> Int {
 
 ///|
 /// Converts the Int to a Bytes in big-endian byte order.
-pub fn to_be_bytes(self : Int) -> Bytes {
+pub fn Int::to_be_bytes(self : Int) -> Bytes {
   self.reinterpret_as_uint().to_be_bytes()
 }
 
 ///|
 /// Converts the Int to a Bytes in little-endian byte order.
-pub fn to_le_bytes(self : Int) -> Bytes {
+pub fn Int::to_le_bytes(self : Int) -> Bytes {
   self.reinterpret_as_uint().to_le_bytes()
 }

--- a/int64/int64.mbt
+++ b/int64/int64.mbt
@@ -69,13 +69,13 @@ pub fn Int64::abs(self : Int64) -> Int64 {
 
 ///|
 /// Converts the Int64 to a Bytes in big-endian byte order.
-pub fn to_be_bytes(self : Int64) -> Bytes {
+pub fn Int64::to_be_bytes(self : Int64) -> Bytes {
   self.reinterpret_as_uint64().to_be_bytes()
 }
 
 ///|
 /// Converts the Int64 to a Bytes in little-endian byte order.
-pub fn to_le_bytes(self : Int64) -> Bytes {
+pub fn Int64::to_le_bytes(self : Int64) -> Bytes {
   self.reinterpret_as_uint64().to_le_bytes()
 }
 

--- a/json/internal_types.mbt
+++ b/json/internal_types.mbt
@@ -42,7 +42,7 @@ fn CharClass::of(array : Array[(Char, Char)]) -> CharClass {
 }
 
 ///|
-fn contains(self : CharClass, c : Char) -> Bool {
+fn CharClass::contains(self : CharClass, c : Char) -> Bool {
   let CharClass(self) = self
   for left = 0, right = self.length(); left < right; {
     let middle = (left + right) / 2

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -14,14 +14,14 @@
 
 ///|
 /// Try to get this element as a Null
-pub fn as_null(self : Json) -> Unit? {
+pub fn Json::as_null(self : Json) -> Unit? {
   guard self is Null else { return None }
   Some(())
 }
 
 ///|
 /// Try to get this element as a Boolean
-pub fn as_bool(self : Json) -> Bool? {
+pub fn Json::as_bool(self : Json) -> Bool? {
   match self {
     True => Some(true)
     False => Some(false)
@@ -31,28 +31,28 @@ pub fn as_bool(self : Json) -> Bool? {
 
 ///|
 /// Try to get this element as a Number
-pub fn as_number(self : Json) -> Double? {
+pub fn Json::as_number(self : Json) -> Double? {
   guard self is Number(n, ..) else { return None }
   Some(n)
 }
 
 ///|
 /// Try to get this element as a String
-pub fn as_string(self : Json) -> String? {
+pub fn Json::as_string(self : Json) -> String? {
   guard self is String(s) else { return None }
   Some(s)
 }
 
 ///|
 /// Try to get this element as an Array
-pub fn as_array(self : Json) -> Array[Json]? {
+pub fn Json::as_array(self : Json) -> Array[Json]? {
   guard self is Array(arr) else { return None }
   Some(arr)
 }
 
 ///|
 /// Try to get this element as a Json Array and get the element at the `index` as a Json Value
-pub fn item(self : Json, index : Int) -> Json? {
+pub fn Json::item(self : Json, index : Int) -> Json? {
   match self.as_array() {
     Some(arr) => arr.get(index)
     None => None
@@ -61,14 +61,14 @@ pub fn item(self : Json, index : Int) -> Json? {
 
 ///|
 /// Try to get this element as an Object
-pub fn as_object(self : Json) -> Map[String, Json]? {
+pub fn Json::as_object(self : Json) -> Map[String, Json]? {
   guard self is Object(obj) else { return None }
   Some(obj)
 }
 
 ///|
 /// Try to get this element as a Json Object and get the element with the `key` as a Json Value
-pub fn value(self : Json, key : String) -> Json? {
+pub fn Json::value(self : Json, key : String) -> Json? {
   match self.as_object() {
     Some(obj) => obj.get(key)
     None => None
@@ -85,7 +85,7 @@ fn indent_str(level : Int, indent : Int) -> String {
 }
 
 ///|
-pub fn stringify(
+pub fn Json::stringify(
   self : Json,
   escape_slash? : Bool = false,
   indent? : Int = 0,

--- a/json/json_encode_decode_test.mbt
+++ b/json/json_encode_decode_test.mbt
@@ -25,7 +25,7 @@ fn[T] array_to_json(arr : Array[T], f~ : (T) -> Json) -> Json {
 }
 
 ///|
-fn to_json(self : AllThree) -> Json {
+fn AllThree::to_json(self : AllThree) -> Json {
   let { ints, floats, strings } = self
   {
     "ints": ints |> array_to_json(f=x => Json::number(x.to_double())),

--- a/json/json_path.mbt
+++ b/json/json_path.mbt
@@ -20,12 +20,12 @@ enum JsonPath {
 } derive(Eq)
 
 ///|
-pub fn add_index(self : JsonPath, index : Int) -> JsonPath {
+pub fn JsonPath::add_index(self : JsonPath, index : Int) -> JsonPath {
   Index(self, index~)
 }
 
 ///|
-pub fn add_key(self : JsonPath, key : String) -> JsonPath {
+pub fn JsonPath::add_key(self : JsonPath, key : String) -> JsonPath {
   Key(self, key~)
 }
 

--- a/list/deprecated.mbt
+++ b/list/deprecated.mbt
@@ -14,7 +14,7 @@
 
 ///|
 #deprecated("use `_.to_array().rev_fold(...)` instead")
-pub fn[A, B] rev_fold(self : List[A], init~ : B, f : (B, A) -> B) -> B {
+pub fn[A, B] List::rev_fold(self : List[A], init~ : B, f : (B, A) -> B) -> B {
   let xs = self.to_array()
   let mut acc = init
   for x in xs.rev_iter() {
@@ -25,13 +25,17 @@ pub fn[A, B] rev_fold(self : List[A], init~ : B, f : (B, A) -> B) -> B {
 
 ///|
 #deprecated("use `_.rev().foldi(...)` instead")
-pub fn[A, B] rev_foldi(self : List[A], init~ : B, f : (Int, B, A) -> B) -> B {
+pub fn[A, B] List::rev_foldi(
+  self : List[A],
+  init~ : B,
+  f : (Int, B, A) -> B,
+) -> B {
   self.rev().foldi(init~, (i, b, a) => f(i, b, a))
 }
 
 ///|
 #deprecated("use `unsafe_tail` instead")
-pub fn[A] tail(self : List[A]) -> List[A] {
+pub fn[A] List::tail(self : List[A]) -> List[A] {
   match self {
     Empty => Empty
     More(_, tail~) => tail

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -61,7 +61,7 @@ pub fn[A] List::cons(head : A, tail : List[A]) -> List[A] {
 /// assert_eq(ls, @list.of([1, 2, 3, 4]))
 /// ```
 #alias(add)
-pub fn[A] prepend(self : List[A], head : A) -> List[A] {
+pub fn[A] List::prepend(self : List[A], head : A) -> List[A] {
   More(head, tail=self)
 }
 
@@ -95,7 +95,7 @@ pub impl[A : ToJson] ToJson for List[A] with to_json(self) {
 /// let json = ls.to_json()
 /// inspect(json, content="Array([Number(1), Number(2), Number(3)])")
 /// ```
-pub fn[A : ToJson] to_json(self : List[A]) -> Json {
+pub fn[A : ToJson] List::to_json(self : List[A]) -> Json {
   ToJson::to_json(self)
 }
 
@@ -147,7 +147,7 @@ pub fn[A] List::from_array(arr : Array[A]) -> List[A] {
 
 ///|
 /// Get the length of the list.
-pub fn[A] length(self : List[A]) -> Int {
+pub fn[A] List::length(self : List[A]) -> Int {
   loop (self, 0) {
     (Empty, len) => len
     (More(_, tail=rest), acc) => continue (rest, acc + 1)
@@ -165,7 +165,7 @@ pub fn[A] length(self : List[A]) -> Int {
 /// assert_eq(arr, [1, 2, 3, 4, 5])
 /// ```
 #locals(f)
-pub fn[A] each(self : List[A], f : (A) -> Unit raise?) -> Unit raise? {
+pub fn[A] List::each(self : List[A], f : (A) -> Unit raise?) -> Unit raise? {
   loop self {
     Empty => ()
     More(head, tail~) => {
@@ -185,7 +185,10 @@ pub fn[A] each(self : List[A], f : (A) -> Unit raise?) -> Unit raise? {
 ///   @list.of([1, 2, 3, 4, 5]).eachi((i, x) => arr.push("(\{i},\{x})"))
 ///   assert_eq(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
 /// ```
-pub fn[A] eachi(self : List[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
+pub fn[A] List::eachi(
+  self : List[A],
+  f : (Int, A) -> Unit raise?,
+) -> Unit raise? {
   loop (self, 0) {
     (Empty, _) => ()
     (More(x, tail=xs), i) => {
@@ -203,7 +206,7 @@ pub fn[A] eachi(self : List[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
 /// ```mbt
 /// assert_eq(@list.of([1, 2, 3, 4, 5]).map(x => x * 2), @list.of([2, 4, 6, 8, 10]))
 /// ```
-pub fn[A, B] map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
+pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
   match self {
     Empty => Empty
     More(hd, tail~) => {
@@ -235,7 +238,10 @@ pub fn[A, B] map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
 /// let result = ls.mapi((i, x) => x + i)
 /// assert_eq(result, @list.of([10, 21, 32]))
 /// ```
-pub fn[A, B] mapi(self : List[A], f : (Int, A) -> B raise?) -> List[B] raise? {
+pub fn[A, B] List::mapi(
+  self : List[A],
+  f : (Int, A) -> B raise?,
+) -> List[B] raise? {
   match self {
     Empty => Empty
     More(hd, tail~) => {
@@ -263,7 +269,10 @@ pub fn[A, B] mapi(self : List[A], f : (Int, A) -> B raise?) -> List[B] raise? {
 /// ```mbt
 /// assert_eq(@list.of([1, 2, 3, 4, 5]).rev_map(x => x * 2), @list.of([10, 8, 6, 4, 2]))
 /// ```
-pub fn[A, B] rev_map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
+pub fn[A, B] List::rev_map(
+  self : List[A],
+  f : (A) -> B raise?,
+) -> List[B] raise? {
   loop (Empty, self) {
     (acc, Empty) => acc
     (acc, More(x, tail=xs)) => continue (More(f(x), tail=acc), xs)
@@ -282,7 +291,7 @@ pub fn[A, B] rev_map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
 /// let arr = ls.to_array()
 /// assert_eq(arr, [1, 2, 3, 4, 5])
 /// ```
-pub fn[A] to_array(self : List[A]) -> Array[A] {
+pub fn[A] List::to_array(self : List[A]) -> Array[A] {
   match self {
     Empty => []
     More(x, tail=xs) => {
@@ -307,7 +316,10 @@ pub fn[A] to_array(self : List[A]) -> Array[A] {
 /// ```mbt
 /// assert_eq(@list.of([1, 2, 3, 4, 5]).filter(x => x % 2 == 0), @list.of([2, 4]))
 /// ```
-pub fn[A] filter(self : List[A], f : (A) -> Bool raise?) -> List[A] raise? {
+pub fn[A] List::filter(
+  self : List[A],
+  f : (A) -> Bool raise?,
+) -> List[A] raise? {
   loop self {
     Empty => Empty
     More(head, tail~) =>
@@ -348,7 +360,7 @@ pub fn[A] filter(self : List[A], f : (A) -> Bool raise?) -> List[A] raise? {
 /// let ls2 = @list.of([2, 3, 6, 8])
 /// assert_eq(ls2.all(x => x % 2 == 0), false)
 /// ```
-pub fn[A] all(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
+pub fn[A] List::all(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
   loop self {
     Empty => true
     More(head, tail~) => if f(head) { continue tail } else { false }
@@ -370,7 +382,7 @@ pub fn[A] all(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
 /// let ls2 = @list.of([1, 3, 5, 7])
 /// assert_eq(ls2.any(x => x % 2 == 0), false)
 /// ```
-pub fn[A] any(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
+pub fn[A] List::any(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
   loop self {
     Empty => false
     More(head, tail~) => if f(head) { true } else { continue tail }
@@ -380,7 +392,7 @@ pub fn[A] any(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
 ///|
 /// Get first element of the list.
 #internal(unsafe, "Panic if the list is empty")
-pub fn[A] unsafe_head(self : List[A]) -> A {
+pub fn[A] List::unsafe_head(self : List[A]) -> A {
   match self {
     Empty => abort("head of empty list")
     More(head, tail=_) => head
@@ -404,7 +416,7 @@ pub fn[A] unsafe_head(self : List[A]) -> A {
 /// # Panics
 /// 
 /// Panics if the list is empty.
-pub fn[A] unsafe_tail(self : List[A]) -> List[A] {
+pub fn[A] List::unsafe_tail(self : List[A]) -> List[A] {
   match self {
     Empty => abort("tail of empty list")
     More(_, tail~) => tail
@@ -419,7 +431,7 @@ pub fn[A] unsafe_tail(self : List[A]) -> List[A] {
 /// ```mbt
 /// assert_eq(@list.of([1, 2, 3, 4, 5]).head(), Some(1))
 /// ```
-pub fn[A] head(self : List[A]) -> A? {
+pub fn[A] List::head(self : List[A]) -> A? {
   match self {
     Empty => None
     More(head, tail=_) => Some(head)
@@ -443,7 +455,7 @@ pub fn[A] head(self : List[A]) -> A? {
 /// 
 /// Panics if the list is empty.
 #internal(unsafe, "Panic if the list is empty")
-pub fn[A] unsafe_last(self : List[A]) -> A {
+pub fn[A] List::unsafe_last(self : List[A]) -> A {
   loop self {
     Empty => abort("last of empty list")
     More(head, tail=Empty) => head
@@ -459,7 +471,7 @@ pub fn[A] unsafe_last(self : List[A]) -> A {
 /// ```mbt
 /// assert_eq(@list.of([1, 2, 3, 4, 5]).last(), Some(5))
 /// ```
-pub fn[A] last(self : List[A]) -> A? {
+pub fn[A] List::last(self : List[A]) -> A? {
   loop self {
     Empty => None
     More(head, tail=Empty) => Some(head)
@@ -476,7 +488,7 @@ pub fn[A] last(self : List[A]) -> A? {
 /// let ls = @list.of([1, 2, 3, 4, 5]).concat(@list.of([6, 7, 8, 9, 10]))
 /// assert_eq(ls, @list.of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 /// ```
-pub fn[A] concat(self : List[A], other : List[A]) -> List[A] {
+pub fn[A] List::concat(self : List[A], other : List[A]) -> List[A] {
   match self {
     Empty => other
     More(hd, tail=Empty) => More(hd, tail=other)
@@ -505,7 +517,7 @@ pub fn[A] concat(self : List[A], other : List[A]) -> List[A] {
 /// let ls = @list.of([1, 2, 3, 4, 5]).rev_concat(@list.of([6, 7, 8, 9, 10]))
 /// assert_eq(ls, @list.of([5, 4, 3, 2, 1, 6, 7, 8, 9, 10]))
 /// ```
-pub fn[A] rev_concat(self : List[A], other : List[A]) -> List[A] {
+pub fn[A] List::rev_concat(self : List[A], other : List[A]) -> List[A] {
   loop (self, other) {
     (Empty, other) => other
     (More(head, tail~), other) => continue (tail, More(head, tail=other))
@@ -520,7 +532,7 @@ pub fn[A] rev_concat(self : List[A], other : List[A]) -> List[A] {
 /// ```mbt
 /// assert_eq(@list.of([1, 2, 3, 4, 5]).rev(), @list.of([5, 4, 3, 2, 1]))
 /// ```
-pub fn[A] rev(self : List[A]) -> List[A] {
+pub fn[A] List::rev(self : List[A]) -> List[A] {
   self.rev_concat(Empty)
 }
 
@@ -533,7 +545,7 @@ pub fn[A] rev(self : List[A]) -> List[A] {
 /// let r = @list.of([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => acc + x)
 /// inspect(r, content="15")
 /// ```
-pub fn[A, B] fold(
+pub fn[A, B] List::fold(
   self : List[A],
   init~ : B,
   f : (B, A) -> B raise?,
@@ -557,7 +569,7 @@ pub fn[A, B] fold(
 /// let result = ls.foldi(init=0, (i, acc, x) => acc + x * i)
 /// inspect(result, content="80") // 0*10 + 1*20 + 2*30 = 80
 /// ```
-pub fn[A, B] foldi(
+pub fn[A, B] List::foldi(
   self : List[A],
   init~ : B,
   f : (Int, B, A) -> B raise?,
@@ -615,7 +627,7 @@ pub fn[A, B] List::zip(self : List[A], other : List[B]) -> List[(A, B)] {
 /// let r = ls.flat_map(x => @list.from_array([x, x * 2]))
 /// assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// ```
-pub fn[A, B] flat_map(
+pub fn[A, B] List::flat_map(
   self : List[A],
   f : (A) -> List[B] raise?,
 ) -> List[B] raise? {
@@ -666,7 +678,10 @@ pub fn[A, B] flat_map(
 /// let r = ls.filter_map(x => if (x >= 3) { Some(x) } else { None })
 /// assert_eq(r, @list.of([4, 6, 3]))
 /// ```
-pub fn[A, B] filter_map(self : List[A], f : (A) -> B? raise?) -> List[B] raise? {
+pub fn[A, B] List::filter_map(
+  self : List[A],
+  f : (A) -> B? raise?,
+) -> List[B] raise? {
   loop self {
     Empty => Empty
     More(hd, tail~) =>
@@ -709,7 +724,7 @@ pub fn[A, B] filter_map(self : List[A], f : (A) -> B? raise?) -> List[B] raise? 
 /// 
 /// Panics if the index is out of bounds.
 #internal(unsafe, "Panic if the index is out of bounds")
-pub fn[A] unsafe_nth(self : List[A], n : Int) -> A {
+pub fn[A] List::unsafe_nth(self : List[A], n : Int) -> A {
   loop (self, n) {
     (Empty, _) => abort("nth: index out of bounds")
     (More(head, tail=_), 0) => head
@@ -730,7 +745,7 @@ pub fn[A] unsafe_nth(self : List[A], n : Int) -> A {
 /// assert_eq(ls.nth(2), Some(3))
 /// assert_eq(ls.nth(10), None)
 /// ```
-pub fn[A] nth(self : List[A], n : Int) -> A? {
+pub fn[A] List::nth(self : List[A], n : Int) -> A? {
   loop (self, n) {
     (Empty, _) => None
     (More(head, tail=_), 0) => Some(head)
@@ -762,7 +777,7 @@ pub fn[A] List::repeat(n : Int, x : A) -> List[A] {
 ///   let ls = @list.from_array(["1", "2", "3", "4", "5"]).intersperse("|")
 ///   assert_eq(ls, @list.from_array(["1", "|", "2", "|", "3", "|", "4", "|", "5"]))
 /// ```
-pub fn[A] intersperse(self : List[A], separator : A) -> List[A] {
+pub fn[A] List::intersperse(self : List[A], separator : A) -> List[A] {
   match self {
     Empty => Empty
     More(head, tail=Empty) => More(head, tail=Empty)
@@ -797,7 +812,7 @@ pub fn[A] intersperse(self : List[A], separator : A) -> List[A] {
 /// let non_empty = @list.of([1, 2, 3])
 /// assert_eq(non_empty.is_empty(), false)
 /// ```
-pub fn[A] is_empty(self : List[A]) -> Bool {
+pub fn[A] List::is_empty(self : List[A]) -> Bool {
   self is Empty
 }
 
@@ -811,7 +826,7 @@ pub fn[A] is_empty(self : List[A]) -> Bool {
 /// assert_eq(a, @list.from_array([1, 3, 5]))
 /// assert_eq(b, @list.from_array([2, 4, 6]))
 /// ```
-pub fn[A, B] unzip(self : List[(A, B)]) -> (List[A], List[B]) {
+pub fn[A, B] List::unzip(self : List[(A, B)]) -> (List[A], List[B]) {
   match self {
     Empty => (Empty, Empty)
     More((x, y), tail~) => {
@@ -840,7 +855,7 @@ pub fn[A, B] unzip(self : List[(A, B)]) -> (List[A], List[B]) {
 /// let ls = @list.from_array([@list.from_array([1,2,3]), @list.from_array([4,5,6]), @list.from_array([7,8,9])]).flatten()
 /// assert_eq(ls, @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
 /// ```
-pub fn[A] flatten(self : List[List[A]]) -> List[A] {
+pub fn[A] List::flatten(self : List[List[A]]) -> List[A] {
   loop self {
     Empty => Empty
     More(head, tail~) =>
@@ -895,7 +910,7 @@ pub fn[A] flatten(self : List[List[A]]) -> List[A] {
 /// 
 /// Panics if the list is empty.
 #internal(unsafe, "Panic if the list is empty")
-pub fn[A : Compare] unsafe_maximum(self : List[A]) -> A {
+pub fn[A : Compare] List::unsafe_maximum(self : List[A]) -> A {
   match self {
     Empty => abort("maximum: empty list")
     More(head, tail~) =>
@@ -922,7 +937,7 @@ pub fn[A : Compare] unsafe_maximum(self : List[A]) -> A {
 ///   let empty : @list.List[Int] = @list.empty()
 ///   assert_eq(empty.maximum(), None)
 /// ```
-pub fn[A : Compare] maximum(self : List[A]) -> A? {
+pub fn[A : Compare] List::maximum(self : List[A]) -> A? {
   match self {
     Empty => None
     More(head, tail~) =>
@@ -951,7 +966,7 @@ pub fn[A : Compare] maximum(self : List[A]) -> A? {
 /// 
 /// Panics if the list is empty.
 #internal(unsafe, "Panic if the list is empty")
-pub fn[A : Compare] unsafe_minimum(self : List[A]) -> A {
+pub fn[A : Compare] List::unsafe_minimum(self : List[A]) -> A {
   match self {
     Empty => abort("minimum: empty list")
     More(head, tail~) =>
@@ -978,7 +993,7 @@ pub fn[A : Compare] unsafe_minimum(self : List[A]) -> A {
 /// let empty : @list.List[Int] = @list.empty()
 /// assert_eq(empty.minimum(), None)
 /// ```
-pub fn[A : Compare] minimum(self : List[A]) -> A? {
+pub fn[A : Compare] List::minimum(self : List[A]) -> A? {
   match self {
     Empty => None
     More(head, tail~) =>
@@ -999,7 +1014,7 @@ pub fn[A : Compare] minimum(self : List[A]) -> A? {
 ///   let ls = @list.from_array([1,123,52,3,6,0,-6,-76]).sort()
 ///   assert_eq(ls, @list.from_array([-76, -6, 0, 1, 3, 6, 52, 123]))
 /// ```
-pub fn[A : Compare] sort(self : List[A]) -> List[A] {
+pub fn[A : Compare] List::sort(self : List[A]) -> List[A] {
   let arr = self.to_array()
   arr.sort()
   from_array(arr)
@@ -1036,7 +1051,7 @@ pub impl[A] Add for List[A] with add(self, other) {
 /// assert_eq(ls.contains(3), true)
 /// assert_eq(ls.contains(6), false)
 /// ```
-pub fn[A : Eq] contains(self : List[A], value : A) -> Bool {
+pub fn[A : Eq] List::contains(self : List[A], value : A) -> Bool {
   loop self {
     Empty => false
     More(x, tail=xs) => if x == value { true } else { continue xs }
@@ -1109,7 +1124,7 @@ pub fn[A, S] List::rev_unfold(
 ///   let r = ls.take(3)
 ///   assert_eq(r, @list.of([1, 2, 3]))
 /// ```
-pub fn[A] take(self : List[A], n : Int) -> List[A] {
+pub fn[A] List::take(self : List[A], n : Int) -> List[A] {
   if n <= 0 {
     Empty
   } else {
@@ -1143,7 +1158,7 @@ pub fn[A] take(self : List[A], n : Int) -> List[A] {
 ///   let r = ls.drop(3)
 ///   assert_eq(r, @list.of([4, 5]))
 /// ```
-pub fn[A] drop(self : List[A], n : Int) -> List[A] {
+pub fn[A] List::drop(self : List[A], n : Int) -> List[A] {
   if n <= 0 {
     self
   } else {
@@ -1165,7 +1180,10 @@ pub fn[A] drop(self : List[A], n : Int) -> List[A] {
 ///   let r = ls.take_while(x => x < 3)
 ///   assert_eq(r, @list.of([1, 2]))
 /// ```
-pub fn[A] take_while(self : List[A], p : (A) -> Bool raise?) -> List[A] raise? {
+pub fn[A] List::take_while(
+  self : List[A],
+  p : (A) -> Bool raise?,
+) -> List[A] raise? {
   match self {
     Empty => Empty
     More(head, tail~) =>
@@ -1197,7 +1215,10 @@ pub fn[A] take_while(self : List[A], p : (A) -> Bool raise?) -> List[A] raise? {
 ///   let r = ls.drop_while(x => x < 3)
 ///   assert_eq(r, @list.of([3, 4]))
 /// ```
-pub fn[A] drop_while(self : List[A], p : (A) -> Bool raise?) -> List[A] raise? {
+pub fn[A] List::drop_while(
+  self : List[A],
+  p : (A) -> Bool raise?,
+) -> List[A] raise? {
   loop self {
     Empty => Empty
     More(x, tail=xs) => if p(x) { continue xs } else { More(x, tail=xs) }
@@ -1214,7 +1235,7 @@ pub fn[A] drop_while(self : List[A], p : (A) -> Bool raise?) -> List[A] raise? {
 ///   let r = ls.scan_left((acc, x) => acc + x, init=0)
 ///   assert_eq(r, @list.of([0, 1, 3, 6, 10, 15]))
 /// ```
-pub fn[A, E] scan_left(
+pub fn[A, E] List::scan_left(
   self : List[A],
   f : (E, A) -> E raise?,
   init~ : E,
@@ -1242,7 +1263,7 @@ pub fn[A, E] scan_left(
 ///   let r = ls.scan_right((acc, x) => acc + x, init=0)
 ///   assert_eq(r, @list.of([15, 14, 12, 9, 5, 0]))
 /// ```
-pub fn[A, B] scan_right(
+pub fn[A, B] List::scan_right(
   self : List[A],
   f : (B, A) -> B raise?,
   init~ : B,
@@ -1259,7 +1280,7 @@ pub fn[A, B] scan_right(
 ///   let ls = @list.from_array([(1, "a"), (2, "b"), (3, "c")])
 ///   assert_eq(ls.lookup(3), Some("c"))
 /// ```
-pub fn[A : Eq, B] lookup(self : List[(A, B)], v : A) -> B? {
+pub fn[A : Eq, B] List::lookup(self : List[(A, B)], v : A) -> B? {
   loop self {
     Empty => None
     More((x, y), tail=xs) => if x == v { Some(y) } else { continue xs }
@@ -1275,7 +1296,7 @@ pub fn[A : Eq, B] lookup(self : List[(A, B)], v : A) -> B? {
 ///   assert_eq(@list.of([1, 3, 5, 8]).find(element => element % 2 == 0), Some(8))
 ///   assert_eq(@list.of([1, 3, 5]).find(element => element % 2 == 0), None)
 /// ```
-pub fn[A] find(self : List[A], f : (A) -> Bool raise?) -> A? raise? {
+pub fn[A] List::find(self : List[A], f : (A) -> Bool raise?) -> A? raise? {
   loop self {
     Empty => None
     More(element, tail=list) =>
@@ -1332,7 +1353,7 @@ pub fn[A] List::find_index(
 ///   assert_eq(@list.of([1, 3, 5, 8]).findi((element, index) => (element % 2 == 0) && (index == 3)), Some(8))
 ///   assert_eq(@list.of([1, 3, 8, 5]).findi((element, index) => (element % 2 == 0) && (index == 3)), None)
 /// ```
-pub fn[A] findi(self : List[A], f : (A, Int) -> Bool raise?) -> A? raise? {
+pub fn[A] List::findi(self : List[A], f : (A, Int) -> Bool raise?) -> A? raise? {
   loop (self, 0) {
     (list, index) =>
       match list {
@@ -1355,7 +1376,7 @@ pub fn[A] findi(self : List[A], f : (A, Int) -> Bool raise?) -> A? raise? {
 /// ```mbt
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).remove_at(2), @list.of([1, 2, 4, 5]))
 /// ```
-pub fn[A] remove_at(self : List[A], index : Int) -> List[A] {
+pub fn[A] List::remove_at(self : List[A], index : Int) -> List[A] {
   match (index, self) {
     (_, Empty) => Empty
     (_..<0, _) => self
@@ -1384,7 +1405,7 @@ pub fn[A] remove_at(self : List[A], index : Int) -> List[A] {
 /// ```mbt
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).remove(3), @list.of([1, 2, 4, 5]))
 /// ```
-pub fn[A : Eq] remove(self : List[A], elem : A) -> List[A] {
+pub fn[A : Eq] List::remove(self : List[A], elem : A) -> List[A] {
   match self {
     Empty => Empty
     More(head, tail~) if head == elem => tail
@@ -1414,7 +1435,7 @@ pub fn[A : Eq] remove(self : List[A], elem : A) -> List[A] {
 /// ```mbt
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).is_prefix(@list.of([1, 2, 3])), true)
 /// ```
-pub fn[A : Eq] is_prefix(self : List[A], prefix : List[A]) -> Bool {
+pub fn[A : Eq] List::is_prefix(self : List[A], prefix : List[A]) -> Bool {
   loop (self, prefix) {
     (_, Empty) => true
     (Empty, More(_)) => false
@@ -1435,7 +1456,7 @@ pub fn[A : Eq] is_prefix(self : List[A], prefix : List[A]) -> Bool {
 /// ```mbt
 ///   assert_eq(@list.of([1, 2, 3, 4, 5]).is_suffix(@list.of([3, 4, 5])), true)
 /// ```
-pub fn[A : Eq] is_suffix(self : List[A], suffix : List[A]) -> Bool {
+pub fn[A : Eq] List::is_suffix(self : List[A], suffix : List[A]) -> Bool {
   self.rev().is_prefix(suffix.rev())
 }
 
@@ -1456,7 +1477,7 @@ pub fn[A : Eq] is_suffix(self : List[A], suffix : List[A]) -> Bool {
 ///   let r = ls.intercalate(@list.of([0]))
 ///   assert_eq(r, @list.of([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]))
 /// ```
-pub fn[A] intercalate(self : List[List[A]], sep : List[A]) -> List[A] {
+pub fn[A] List::intercalate(self : List[List[A]], sep : List[A]) -> List[A] {
   self.intersperse(sep).flatten()
 }
 
@@ -1494,7 +1515,7 @@ pub fn[X] default() -> List[X] {
 /// let sum = iter.fold(init=0, (acc, x) => acc + x)
 /// inspect(sum, content="15")
 /// ```
-pub fn[A] iter(self : List[A]) -> Iter[A] {
+pub fn[A] List::iter(self : List[A]) -> Iter[A] {
   Iter::new(yield_ => loop self {
     Empty => IterContinue
     More(head, tail~) => {
@@ -1519,7 +1540,7 @@ pub fn[A] iter(self : List[A]) -> Iter[A] {
 /// let iter = ls.iter2()
 /// inspect(iter, content="[(0, 10), (1, 20), (2, 30)]")
 /// ```
-pub fn[A] iter2(self : List[A]) -> Iter2[Int, A] {
+pub fn[A] List::iter2(self : List[A]) -> Iter2[Int, A] {
   Iter2::new(yield_ => loop (self, 0) {
     (Empty, _) => IterEnd
     (More(head, tail~), i) => {
@@ -1649,7 +1670,7 @@ pub impl[A : Hash] Hash for List[A] with hash_combine(self, hasher) {
 /// 
 /// This is an internal helper function that efficiently reverses a list
 /// by modifying the existing structure rather than creating a completely new one.
-fn[A] reverse_inplace(self : List[A]) -> List[A] {
+fn[A] List::reverse_inplace(self : List[A]) -> List[A] {
   match self {
     Empty | More(_, tail=Empty) => self
     More(head, tail~) =>

--- a/option/deprecated.mbt
+++ b/option/deprecated.mbt
@@ -70,13 +70,13 @@ pub fn[T : Default] Option::or_default(self : T?) -> T {
 ///|
 /// Checks if the option contains a value.
 #deprecated("use `x is Some(_)` instead")
-pub fn[T] is_some(self : T?) -> Bool {
+pub fn[T] Option::is_some(self : T?) -> Bool {
   self is Some(_)
 }
 
 ///|
 /// Checks if the option is None.
 #deprecated("use `x is None` instead")
-pub fn[T] is_none(self : T?) -> Bool {
+pub fn[T] Option::is_none(self : T?) -> Bool {
   self is None
 }

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -31,7 +31,7 @@ test "some equals to Some" {
 ///   let b = None
 ///   assert_eq(b.map(x => x * 2), None)
 /// ```
-pub fn[T, U] map(self : T?, f : (T) -> U raise?) -> U? raise? {
+pub fn[T, U] Option::map(self : T?, f : (T) -> U raise?) -> U? raise? {
   match self {
     Some(t) => Some(f(t))
     None => None
@@ -56,7 +56,11 @@ test "map" {
 ///   let a = Some(5)
 ///   assert_eq(a.map_or(3, x => x * 2), 10)
 /// ```
-pub fn[T, U] map_or(self : T?, default : U, f : (T) -> U raise?) -> U raise? {
+pub fn[T, U] Option::map_or(
+  self : T?,
+  default : U,
+  f : (T) -> U raise?,
+) -> U raise? {
   match self {
     None => default
     Some(x) => f(x)
@@ -80,7 +84,7 @@ test "map_or" {
 ///   let a = Some(5)
 ///   assert_eq(a.map_or_else(() => 3, x => x * 2), 10)
 /// ```
-pub fn[T, U] map_or_else(
+pub fn[T, U] Option::map_or_else(
   self : T?,
   default : () -> U raise?,
   f : (T) -> U raise?,
@@ -113,7 +117,7 @@ test "map_or_else" {
 ///   let r2 = b.bind(x => Some(x * 2))
 ///   assert_eq(r2, None)
 /// ```
-pub fn[T, U] bind(self : T?, f : (T) -> U? raise?) -> U? raise? {
+pub fn[T, U] Option::bind(self : T?, f : (T) -> U? raise?) -> U? raise? {
   match self {
     Some(t) => f(t)
     None => None
@@ -141,7 +145,7 @@ test "bind" {
 ///   let b : Int?? = Some(None)
 ///   assert_eq(b.flatten(), None)
 /// ```
-pub fn[T] flatten(self : T??) -> T? {
+pub fn[T] Option::flatten(self : T??) -> T? {
   match self {
     Some(inner) => inner
     None => None
@@ -158,7 +162,7 @@ test "flatten" {
 
 ///|
 /// Checks if the option is empty.
-pub fn[T] is_empty(self : T?) -> Bool {
+pub fn[T] Option::is_empty(self : T?) -> Bool {
   self is None
 }
 
@@ -182,7 +186,7 @@ test "is_empty" {
 ///   assert_eq(x.filter(x => x > 5), None)
 ///   assert_eq(x.filter(x => x < 5), Some(3))
 /// ```
-pub fn[T] filter(self : T?, f : (T) -> Bool raise?) -> T? raise? {
+pub fn[T] Option::filter(self : T?, f : (T) -> Bool raise?) -> T? raise? {
   match self {
     Some(t) => if f(t) { self } else { None }
     None => None
@@ -279,7 +283,7 @@ pub impl[X] Default for X? with default() {
 }
 
 ///|
-pub fn[T] iter(self : T?) -> Iter[T] {
+pub fn[T] Option::iter(self : T?) -> Iter[T] {
   match self {
     Some(v) => Iter::singleton(v)
     None => Iter::empty()
@@ -315,7 +319,7 @@ test "iter" {
 }
 
 ///|
-pub fn[T, Err : Error] or_error(self : T?, err : Err) -> T raise Err {
+pub fn[T, Err : Error] Option::or_error(self : T?, err : Err) -> T raise Err {
   match self {
     Some(v) => v
     None => raise err

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -68,13 +68,13 @@ fn[A] copy_node(x : Node[A]?) -> Node[A]? {
 /// let queue2 = queue.copy()
 /// inspect(queue2.length(), content="4")
 /// ```
-pub fn[A] copy(self : T[A]) -> T[A] {
+pub fn[A] T::copy(self : T[A]) -> T[A] {
   let new_que : T[A] = { len: self.len, top: copy_node(self.top) }
   new_que
 }
 
 ///|
-pub fn[A : Compare] to_array(self : T[A]) -> Array[A] {
+pub fn[A : Compare] T::to_array(self : T[A]) -> Array[A] {
   let arr = Array::new(capacity=self.len)
   let stack : Array[Node[A]?] = [self.top]
   while stack.pop() is Some(node) {
@@ -93,7 +93,7 @@ pub fn[A : Compare] to_array(self : T[A]) -> Array[A] {
 }
 
 ///|
-pub fn[A : Compare] iter(self : T[A]) -> Iter[A] {
+pub fn[A : Compare] T::iter(self : T[A]) -> Iter[A] {
   Iter::new(yield_ => {
     let arr = self.to_array()
     for i in 0..<arr.length() {
@@ -159,7 +159,7 @@ fn[A : Compare] merges(x : Node[A]?) -> Node[A]? {
 }
 
 ///|
-pub fn[A] length(self : T[A]) -> Int {
+pub fn[A] T::length(self : T[A]) -> Int {
   self.len
 }
 
@@ -173,7 +173,7 @@ pub fn[A] length(self : T[A]) -> Int {
 /// inspect(queue.length(), content="3")
 /// ```
 #internal(unsafe, "Panic if the queue is empty.")
-pub fn[A : Compare] unsafe_pop(self : T[A]) -> Unit {
+pub fn[A : Compare] T::unsafe_pop(self : T[A]) -> Unit {
   self.top = match self.top {
     None => abort("The PriorityQueue is empty!")
     Some({ child, .. }) => merges(child)
@@ -191,7 +191,7 @@ pub fn[A : Compare] unsafe_pop(self : T[A]) -> Unit {
 /// inspect(first, content="Some(4)")
 /// inspect(queue.length(), content="3")
 /// ```
-pub fn[A : Compare] pop(self : T[A]) -> A? {
+pub fn[A : Compare] T::pop(self : T[A]) -> A? {
   match self.top {
     None => None
     Some({ content, child, .. }) => {
@@ -211,7 +211,7 @@ pub fn[A : Compare] pop(self : T[A]) -> A? {
 /// queue.push(1)
 /// assert_eq(queue.length(), 1)
 /// ```
-pub fn[A : Compare] push(self : T[A], value : A) -> Unit {
+pub fn[A : Compare] T::push(self : T[A], value : A) -> Unit {
   let x = { content: value, sibling: None, child: None }
   self.top = match self.top {
     None => Some(x)
@@ -229,7 +229,7 @@ pub fn[A : Compare] push(self : T[A], value : A) -> Unit {
 ///   let first = queue.peek() // Some(4)
 ///   assert_eq(first, Some(4))
 /// ```
-pub fn[A] peek(self : T[A]) -> A? {
+pub fn[A] T::peek(self : T[A]) -> A? {
   match self.top {
     None => None
     Some({ content, .. }) => Some(content)
@@ -245,7 +245,7 @@ pub fn[A] peek(self : T[A]) -> A? {
 /// queue.clear()
 /// assert_eq(queue.length(), 0)
 /// ```
-pub fn[A] clear(self : T[A]) -> Unit {
+pub fn[A] T::clear(self : T[A]) -> Unit {
   self.top = None
   self.len = 0
 }
@@ -258,7 +258,7 @@ pub fn[A] clear(self : T[A]) -> Unit {
 ///   let queue : @priority_queue.T[Int] = @priority_queue.new()
 ///   assert_eq(queue.is_empty(), true)
 /// ```
-pub fn[A] is_empty(self : T[A]) -> Bool {
+pub fn[A] T::is_empty(self : T[A]) -> Bool {
   self.len == 0
 }
 

--- a/queue/deprecated.mbt
+++ b/queue/deprecated.mbt
@@ -15,14 +15,14 @@
 ///|
 #deprecated("Use `unsafe_peek` instead")
 #coverage.skip
-pub fn[A] peek_exn(self : Queue[A]) -> A {
+pub fn[A] Queue::peek_exn(self : Queue[A]) -> A {
   self.unsafe_peek()
 }
 
 ///|
 #deprecated("Use `unsafe_pop` instead")
 #coverage.skip
-pub fn[A] pop_exn(self : Queue[A]) -> A {
+pub fn[A] Queue::pop_exn(self : Queue[A]) -> A {
   self.unsafe_pop()
 }
 

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -66,7 +66,7 @@ impl[A : Eq] Eq for Queue[A] with equal(self, other) {
 ///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   queue.clear()
 /// ```
-pub fn[A] clear(self : Queue[A]) -> Unit {
+pub fn[A] Queue::clear(self : Queue[A]) -> Unit {
   self.length = 0
   self.first = None
   self.last = None
@@ -80,7 +80,7 @@ pub fn[A] clear(self : Queue[A]) -> Unit {
 ///   let queue : @queue.Queue[Int] = @queue.new()
 ///   assert_eq(queue.length(), 0)
 /// ```
-pub fn[A] length(self : Queue[A]) -> Int {
+pub fn[A] Queue::length(self : Queue[A]) -> Int {
   self.length
 }
 
@@ -92,7 +92,7 @@ pub fn[A] length(self : Queue[A]) -> Int {
 ///   let queue : @queue.Queue[Int] = @queue.new()
 ///   assert_true(queue.is_empty())
 /// ```
-pub fn[A] is_empty(self : Queue[A]) -> Bool {
+pub fn[A] Queue::is_empty(self : Queue[A]) -> Bool {
   self.length == 0
 }
 
@@ -104,7 +104,7 @@ pub fn[A] is_empty(self : Queue[A]) -> Bool {
 ///   let queue : @queue.Queue[Int] = @queue.new()
 ///   queue.push(1)
 /// ```
-pub fn[A] push(self : Queue[A], x : A) -> Unit {
+pub fn[A] Queue::push(self : Queue[A], x : A) -> Unit {
   let cell = Some({ content: x, next: None })
   match self.last {
     None => {
@@ -129,7 +129,7 @@ pub fn[A] push(self : Queue[A], x : A) -> Unit {
 ///   assert_eq(queue.unsafe_peek(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
-pub fn[A] unsafe_peek(self : Queue[A]) -> A {
+pub fn[A] Queue::unsafe_peek(self : Queue[A]) -> A {
   match self.first {
     None => abort("Queue is empty")
     Some(first) => first.content
@@ -144,7 +144,7 @@ pub fn[A] unsafe_peek(self : Queue[A]) -> A {
 ///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.peek(), Some(1))
 /// ```
-pub fn[A] peek(self : Queue[A]) -> A? {
+pub fn[A] Queue::peek(self : Queue[A]) -> A? {
   match self.first {
     None => None
     Some(first) => Some(first.content)
@@ -160,7 +160,7 @@ pub fn[A] peek(self : Queue[A]) -> A? {
 ///   assert_eq(queue.unsafe_pop(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
-pub fn[A] unsafe_pop(self : Queue[A]) -> A {
+pub fn[A] Queue::unsafe_pop(self : Queue[A]) -> A {
   match self.first {
     None => abort("Queue is empty")
     Some({ content, next: None }) => {
@@ -183,7 +183,7 @@ pub fn[A] unsafe_pop(self : Queue[A]) -> A {
 ///   let queue : @queue.Queue[Int] = @queue.of([1, 2, 3, 4])
 ///   assert_eq(queue.pop(), Some(1))
 /// ```
-pub fn[A] pop(self : Queue[A]) -> A? {
+pub fn[A] Queue::pop(self : Queue[A]) -> A? {
   match self.first {
     None => None
     Some({ content, next: None }) => {
@@ -207,7 +207,7 @@ pub fn[A] pop(self : Queue[A]) -> A? {
 ///   let mut sum = 0
 ///   queue.each((x) => { sum = sum + x })
 /// ```
-pub fn[A] each(self : Queue[A], f : (A) -> Unit) -> Unit {
+pub fn[A] Queue::each(self : Queue[A], f : (A) -> Unit) -> Unit {
   loop self.first {
     Some({ content, next }) => {
       f(content)
@@ -226,7 +226,7 @@ pub fn[A] each(self : Queue[A], f : (A) -> Unit) -> Unit {
 ///   let mut sum = 0
 ///   queue.eachi((x, i) => { sum = sum + x * i })
 /// ```
-pub fn[A] eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
+pub fn[A] Queue::eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
   loop (self.first, 0) {
     (Some({ content, next }), index) => {
       f(index, content)
@@ -245,7 +245,7 @@ pub fn[A] eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
 ///   let sum = queue.fold(init=0, (acc, x) => { acc + x })
 ///   assert_eq(sum, 0)
 /// ```
-pub fn[A, B] fold(self : Queue[A], init~ : B, f : (B, A) -> B) -> B {
+pub fn[A, B] Queue::fold(self : Queue[A], init~ : B, f : (B, A) -> B) -> B {
   loop (self.first, init) {
     (None, acc) => acc
     (Some({ content, next }), acc) => continue (next, f(acc, content))
@@ -261,7 +261,7 @@ pub fn[A, B] fold(self : Queue[A], init~ : B, f : (B, A) -> B) -> B {
 ///   let queue2 : @queue.Queue[Int] = queue.copy()
 ///   assert_eq(queue2.length(), 4)
 /// ```
-pub fn[A] copy(self : Queue[A]) -> Queue[A] {
+pub fn[A] Queue::copy(self : Queue[A]) -> Queue[A] {
   guard self.first is Some({ content, next }) else { return new() }
   let first = { content, next: None }
   let last = loop (first, next) {
@@ -286,7 +286,7 @@ pub fn[A] copy(self : Queue[A]) -> Queue[A] {
 ///   let src : @queue.Queue[Int] = @queue.of([5, 6, 7, 8])
 ///   src.transfer(dst)
 /// ```
-pub fn[A] transfer(self : Queue[A], dst : Queue[A]) -> Unit {
+pub fn[A] Queue::transfer(self : Queue[A], dst : Queue[A]) -> Unit {
   if self.length > 0 {
     match dst.last {
       None => {
@@ -314,7 +314,7 @@ pub fn[A] transfer(self : Queue[A], dst : Queue[A]) -> Unit {
 ///   let sum = queue.iter().fold((x, y) => { x + y }, init=0)
 ///   assert_eq(sum, 26)
 /// ```
-pub fn[A] iter(self : Queue[A]) -> Iter[A] {
+pub fn[A] Queue::iter(self : Queue[A]) -> Iter[A] {
   Iter::new(yield_ => loop self.first {
     Some({ content, next }) => {
       if yield_(content) is IterEnd {

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -35,19 +35,19 @@ pub fn new(seed? : UInt64 = 37) -> RandomState {
 
 ///|
 /// Clone a RandomState.
-pub fn clone(self : RandomState) -> RandomState {
+pub fn RandomState::clone(self : RandomState) -> RandomState {
   { ..self }
 }
 
 ///|
 /// Skip the next random number.
-pub fn next(self : RandomState) -> Unit {
+pub fn RandomState::next(self : RandomState) -> Unit {
   self.next_uint64() |> ignore
 }
 
 ///|
 /// Get the next random number as a 64-bit unsigned integer.
-pub fn next_uint64(self : RandomState) -> UInt64 {
+pub fn RandomState::next_uint64(self : RandomState) -> UInt64 {
   let { seed, gamma } = self
   self.seed = seed + gamma
   mix64(self.seed)
@@ -55,32 +55,32 @@ pub fn next_uint64(self : RandomState) -> UInt64 {
 
 ///|
 /// Get the next random number as a 32-bit unsigned integer.
-pub fn next_uint(self : RandomState) -> UInt {
+pub fn RandomState::next_uint(self : RandomState) -> UInt {
   self.next_uint64().to_uint()
 }
 
 ///|
 /// Get the next random number as a 64-bit signed integer.
-pub fn next_int64(self : RandomState) -> Int64 {
+pub fn RandomState::next_int64(self : RandomState) -> Int64 {
   self.next_uint64().reinterpret_as_int64()
 }
 
 ///|
 /// Get the next two random number as 32-bit signed integers.
-pub fn next_two_uint(self : RandomState) -> (UInt, UInt) {
+pub fn RandomState::next_two_uint(self : RandomState) -> (UInt, UInt) {
   let g = self.next_uint64()
   ((g >> 32).to_uint(), g.to_uint())
 }
 
 ///|
 /// Get the next random number as a 32-bit signed integer.
-pub fn next_int(self : RandomState) -> Int {
+pub fn RandomState::next_int(self : RandomState) -> Int {
   self.next_uint().reinterpret_as_int()
 }
 
 ///|
 /// Get the next random number as a positive 32-bit signed integer.
-pub fn next_positive_int(self : RandomState) -> Int {
+pub fn RandomState::next_positive_int(self : RandomState) -> Int {
   let r = self.next_int()
   match r {
     -2147483648 => 2147483647
@@ -92,21 +92,21 @@ pub fn next_positive_int(self : RandomState) -> Int {
 
 ///|
 /// Get the next random number as a float in [0, 1]
-pub fn next_float(self : RandomState) -> Float {
+pub fn RandomState::next_float(self : RandomState) -> Float {
   let u = self.next_uint64()
   (u >> 40).to_float() * float_ulp
 }
 
 ///|
 /// Get the next random number as a double in [0, 1]
-pub fn next_double(self : RandomState) -> Double {
+pub fn RandomState::next_double(self : RandomState) -> Double {
   let u = self.next_uint64()
   (u >> 11).to_double() * double_ulp
 }
 
 ///|
 /// Generates an independent random number generator.
-pub fn split(self : RandomState) -> RandomState {
+pub fn RandomState::split(self : RandomState) -> RandomState {
   let seed1 = self.seed + self.gamma
   self.seed = seed1 + self.gamma
   { seed: mix64(seed1), gamma: mix_gamma(self.seed) }

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -55,7 +55,7 @@ pub fn Rand::new(generator? : &Source) -> Rand {
 }
 
 ///|
-fn next(self : Rand) -> UInt64 {
+fn Rand::next(self : Rand) -> UInt64 {
   let Rand(s) = self
   s.next()
 }
@@ -75,7 +75,7 @@ test "next" {
 ///
 /// * `limit` - The upper bound (exclusive) of the random number to be generated (Optional).
 ///             When limit is 0, the range is [0, 2^31).
-pub fn int(self : Rand, limit? : Int = 0) -> Int {
+pub fn Rand::int(self : Rand, limit? : Int = 0) -> Int {
   if limit == 0 {
     // Range [0, 2^31)
     (self.next() >> 33).to_int()
@@ -91,7 +91,7 @@ pub fn int(self : Rand, limit? : Int = 0) -> Int {
 ///
 /// * `limit` - The upper bound (exclusive) of the random number to be generated (Optional).
 ///            When limit is 0, the range is [0, 2^63).
-pub fn int64(self : Rand, limit? : Int64 = 0) -> Int64 {
+pub fn Rand::int64(self : Rand, limit? : Int64 = 0) -> Int64 {
   if limit == 0 {
     // range [0, 2^63)
     // Create a mask that keeps the lower 63 bits
@@ -109,7 +109,7 @@ pub fn int64(self : Rand, limit? : Int64 = 0) -> Int64 {
 ///
 /// * `limit` - The upper bound (exclusive) of the random number to be generated (Optional).
 ///            When limit is 0, the range is [0, 2^32).
-pub fn uint(self : Rand, limit? : UInt = 0) -> UInt {
+pub fn Rand::uint(self : Rand, limit? : UInt = 0) -> UInt {
   if limit == 0 {
     // Range: [0, 2^32)
     return self.next().to_uint()
@@ -135,7 +135,7 @@ test "uint" {
 ///
 /// * `limit` - The upper bound (exclusive) of the random number to be generated (Optional).
 ///           When limit is 0, the range is [0, 2^64).
-pub fn uint64(self : Rand, limit? : UInt64 = 0) -> UInt64 {
+pub fn Rand::uint64(self : Rand, limit? : UInt64 = 0) -> UInt64 {
   if limit == 0 {
     // Range: [0, 2^64)
     return self.next()
@@ -170,7 +170,7 @@ test "UInt64" {
 
 ///|
 /// [double] returns a pseudo-random 64-bit Double in the range [0.0, 1.0)
-pub fn double(self : Rand) -> Double {
+pub fn Rand::double(self : Rand) -> Double {
   Double::convert_uint64(self.next() << 11 >> 11) /
   Double::convert_uint64(1UL << 53)
 }
@@ -184,7 +184,7 @@ test "double" {
 
 ///|
 /// [float] returns a pseudo-random 32-bit Float in the range [0.0, 1.0)
-pub fn float(self : Rand) -> Float {
+pub fn Rand::float(self : Rand) -> Float {
   (self.uint() << 8 >> 8).to_float() / (1U << 24).to_float()
 }
 
@@ -203,7 +203,7 @@ pub fn float(self : Rand) -> Float {
 ///   let n = rand.bigint(8) // Generate random 8-bit number
 ///   inspect(n.bit_length() <= 8, content="true")
 /// ```
-pub fn bigint(self : Rand, bits : Int) -> @bigint.BigInt {
+pub fn Rand::bigint(self : Rand, bits : Int) -> @bigint.BigInt {
   let mod = bits % 8
   let len = if mod == 0 { bits / 8 } else { bits / 8 + 1 }
   let bytes = Bytes::makei(len, i => if i == 0 && mod != 0 {
@@ -298,7 +298,11 @@ test "umul128: handles zero correctly" {
 ///     },
 ///   )
 /// ```
-pub fn shuffle(self : Rand, limit : Int, swap : (Int, Int) -> Unit) -> Unit {
+pub fn Rand::shuffle(
+  self : Rand,
+  limit : Int,
+  swap : (Int, Int) -> Unit,
+) -> Unit {
   if limit < 0 {
     abort("Rand::shuffle: invalid argument limit")
   }

--- a/rational/rational.mbt
+++ b/rational/rational.mbt
@@ -160,7 +160,7 @@ pub impl Div for T with div(self : T, other : T) -> T {
 ///
 #deprecated("Use @rational in module moonbitlang/x instead. Note that you need to rename Rational to Rational64.")
 #coverage.skip
-pub fn reciprocal(self : T) -> T {
+pub fn T::reciprocal(self : T) -> T {
   if self.numerator < 0L {
     new_unchecked(-self.denominator, -self.numerator)
   } else {
@@ -247,7 +247,7 @@ pub impl Compare for T with compare(self : T, other : T) -> Int {
 ///
 #deprecated("Use @rational in module moonbitlang/x instead. Note that you need to rename Rational to Rational64.")
 #coverage.skip
-pub fn to_double(self : T) -> Double {
+pub fn T::to_double(self : T) -> Double {
   // TODO: complete algorithm
   self.numerator.to_double() / self.denominator.to_double()
 }
@@ -463,7 +463,7 @@ pub fn T::trunc(self : T) -> Int64 {
 ///
 #deprecated("Use @rational in module moonbitlang/x instead. Note that you need to rename Rational to Rational64.")
 #coverage.skip
-pub fn fract(self : T) -> T {
+pub fn T::fract(self : T) -> T {
   new_unchecked(self.numerator % self.denominator, self.denominator)
 }
 
@@ -522,7 +522,7 @@ pub impl @quickcheck.Arbitrary for T with arbitrary(size, rs) {
 ///
 #deprecated("Use @rational in module moonbitlang/x instead. Note that you need to rename Rational to Rational64.")
 #coverage.skip
-pub fn is_integer(self : T) -> Bool {
+pub fn T::is_integer(self : T) -> Bool {
   self.denominator == 1L
 }
 

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -37,7 +37,7 @@ pub fn[T] new(x : T) -> Ref[T] {
 /// ```mbt
 ///   assert_eq(@ref.new(1).map((a) => { a + 1 }).val, 2)
 /// ```
-pub fn[T, R] map(self : Ref[T], f : (T) -> R raise?) -> Ref[R] raise? {
+pub fn[T, R] Ref::map(self : Ref[T], f : (T) -> R raise?) -> Ref[R] raise? {
   { val: f(self.val) }
 }
 
@@ -62,7 +62,7 @@ pub fn[T, R] map(self : Ref[T], f : (T) -> R raise?) -> Ref[R] raise? {
 ///   x.protect(2, () => { x.val = 3 })
 ///   assert_eq(x.val, 1)
 /// ```
-pub fn[T, R] protect(self : Ref[T], a : T, f : () -> R raise?) -> R raise? {
+pub fn[T, R] Ref::protect(self : Ref[T], a : T, f : () -> R raise?) -> R raise? {
   let old = self.val
   self.val = a
   try f() catch {
@@ -107,7 +107,7 @@ test "swap" {
 }
 
 ///|
-pub fn[T] update(self : Ref[T], f : (T) -> T raise?) -> Unit raise? {
+pub fn[T] Ref::update(self : Ref[T], f : (T) -> T raise?) -> Unit raise? {
   self.val = f(self.val)
 }
 

--- a/result/deprecated.mbt
+++ b/result/deprecated.mbt
@@ -26,19 +26,23 @@ pub fn[T, E] err(value : E) -> Result[T, E] {
 
 ///|
 #deprecated("use `x is Ok(_)` instead")
-pub fn[T, E] is_ok(self : Result[T, E]) -> Bool {
+pub fn[T, E] Result::is_ok(self : Result[T, E]) -> Bool {
   self is Ok(_)
 }
 
 ///|
 #deprecated("use `x is Err(_)` instead")
-pub fn[T, E] is_err(self : Result[T, E]) -> Bool {
+pub fn[T, E] Result::is_err(self : Result[T, E]) -> Bool {
   self is Err(_)
 }
 
 ///|
 #deprecated("use `match result { Ok(value) => ok(value); Err(error) => err(error) }` instead")
-pub fn[T, E, V] fold(self : Result[T, E], ok : (T) -> V, err : (E) -> V) -> V {
+pub fn[T, E, V] Result::fold(
+  self : Result[T, E],
+  ok : (T) -> V,
+  err : (E) -> V,
+) -> V {
   match self {
     Ok(value) => ok(value)
     Err(error) => err(error)

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -22,7 +22,7 @@
 ///   let y = x.map((v : Int) => { v * 7 })
 ///   assert_eq(y, Ok(42))
 /// ```
-pub fn[T, E, U] map(self : Result[T, E], f : (T) -> U) -> Result[U, E] {
+pub fn[T, E, U] Result::map(self : Result[T, E], f : (T) -> U) -> Result[U, E] {
   match self {
     Ok(value) => Ok(f(value))
     Err(err) => Err(err)
@@ -49,7 +49,10 @@ test "map" {
 ///   let y = x.map_err((v : String) => { v + "!" })
 ///   assert_eq(y, Err("error!"))
 /// ```
-pub fn[T, E, F] map_err(self : Result[T, E], f : (E) -> F) -> Result[T, F] {
+pub fn[T, E, F] Result::map_err(
+  self : Result[T, E],
+  f : (E) -> F,
+) -> Result[T, F] {
   match self {
     Ok(value) => Ok(value)
     Err(err) => Err(f(err))
@@ -76,7 +79,7 @@ test "map_err" {
 ///   let y = x.or(0)
 ///   assert_eq(y, 6)
 /// ```
-pub fn[T, E] or(self : Result[T, E], default : T) -> T {
+pub fn[T, E] Result::or(self : Result[T, E], default : T) -> T {
   match self {
     Ok(value) => value
     Err(_) => default
@@ -104,7 +107,7 @@ test "or" {
 ///   let y = x.or_else(() => { 0 })
 ///   assert_eq(y, 6)
 /// ```
-pub fn[T, E] or_else(self : Result[T, E], default : () -> T) -> T {
+pub fn[T, E] Result::or_else(self : Result[T, E], default : () -> T) -> T {
   match self {
     Ok(value) => value
     Err(_) => default()
@@ -133,7 +136,7 @@ test "or_else" {
 ///   let y = x.flatten()
 ///   assert_eq(y, Ok(6))
 /// ```
-pub fn[T, E] flatten(self : Result[Result[T, E], E]) -> Result[T, E] {
+pub fn[T, E] Result::flatten(self : Result[Result[T, E], E]) -> Result[T, E] {
   match self {
     Ok(value) => value
     Err(err) => Err(err)
@@ -160,7 +163,7 @@ test "flatten" {
 ///   let y = x.bind((v : Int) => { Ok(v * 7) })
 ///   assert_eq(y, Ok(42))
 /// ```
-pub fn[T, E, U] bind(
+pub fn[T, E, U] Result::bind(
   self : Result[T, E],
   g : (T) -> Result[U, E],
 ) -> Result[U, E] {
@@ -189,7 +192,7 @@ test "bind" {
 ///   let y = x.to_option()
 ///   assert_eq(y, Some(6))
 /// ```
-pub fn[T, E] to_option(self : Result[T, E]) -> T? {
+pub fn[T, E] Result::to_option(self : Result[T, E]) -> T? {
   match self {
     Ok(value) => Some(value)
     Err(_) => None
@@ -236,7 +239,7 @@ test "compare" {
 }
 
 ///|
-pub fn[T, E] unwrap(self : Result[T, E]) -> T {
+pub fn[T, E] Result::unwrap(self : Result[T, E]) -> T {
   match self {
     Ok(x) => x
     Err(_) => abort("called `Result::unwrap()` on an `Err` value")
@@ -259,7 +262,7 @@ pub fn[T, E] unwrap(self : Result[T, E]) -> T {
 ///   let err : Result[Int, String] = Err("error message")
 ///   inspect(err.unwrap_err(), content="error message")
 /// ```
-pub fn[T, E] unwrap_err(self : Result[T, E]) -> E {
+pub fn[T, E] Result::unwrap_err(self : Result[T, E]) -> E {
   match self {
     Ok(_) => abort("called `Result::unwrap_err()` on an `Ok` value")
     Err(e) => e
@@ -341,7 +344,7 @@ test "unwrap_or_default" {
 }
 
 ///|
-pub fn[T, E : Error] unwrap_or_error(self : Result[T, E]) -> T raise E {
+pub fn[T, E : Error] Result::unwrap_or_error(self : Result[T, E]) -> T raise E {
   match self {
     Ok(x) => x
     Err(e) => raise e

--- a/set/deprecated.mbt
+++ b/set/deprecated.mbt
@@ -15,6 +15,6 @@
 ///|
 #deprecated("Use `add` instead.")
 #coverage.skip
-pub fn[K : Hash + Eq] insert(self : Set[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] Set::insert(self : Set[K], key : K) -> Unit {
   self.add(key)
 }

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -97,12 +97,12 @@ pub fn[K : Hash + Eq] Set::from_array(arr : Array[K]) -> Set[K] {
 ///   set.add("key") // no effect since it already exists
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] add(self : Set[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] Set::add(self : Set[K], key : K) -> Unit {
   self.add_with_hash(key, key.hash())
 }
 
 ///|
-fn[K : Eq] add_with_hash(self : Set[K], key : K, hash : Int) -> Unit {
+fn[K : Eq] Set::add_with_hash(self : Set[K], key : K, hash : Int) -> Unit {
   if self.size >= self.grow_at {
     self.grow()
   }
@@ -126,7 +126,7 @@ fn[K : Eq] add_with_hash(self : Set[K], key : K, hash : Int) -> Unit {
 }
 
 ///|
-fn[K] push_away(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
+fn[K] Set::push_away(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
     match self.entries[idx] {
       None => {
@@ -149,7 +149,7 @@ fn[K] push_away(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
 }
 
 ///|
-fn[K] set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
+fn[K] Set::set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
   self.entries[new_idx] = Some(entry)
   match entry.next {
     None => self.tail = new_idx
@@ -176,7 +176,7 @@ fn[K] set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
 ///   inspect(set.add_and_check("key"), content="false") // Already exists
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] add_and_check(self : Set[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] Set::add_and_check(self : Set[K], key : K) -> Bool {
   if self.size >= self.grow_at {
     self.grow()
   }
@@ -239,7 +239,7 @@ pub fn[K : Hash + Eq] Set::contains(self : Set[K], key : K) -> Bool {
 ///   inspect(set.contains("a"), content="false")
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] remove(self : Set[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] Set::remove(self : Set[K], key : K) -> Unit {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break }
@@ -275,7 +275,7 @@ pub fn[K : Hash + Eq] remove(self : Set[K], key : K) -> Unit {
 ///   inspect(set.remove_and_check("a"), content="false") // Already removed
 ///   inspect(set.length(), content="1")
 /// ```
-pub fn[K : Hash + Eq] remove_and_check(self : Set[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] Set::remove_and_check(self : Set[K], key : K) -> Bool {
   let hash = key.hash()
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
@@ -293,7 +293,11 @@ pub fn[K : Hash + Eq] remove_and_check(self : Set[K], key : K) -> Bool {
 }
 
 ///|
-fn[K] add_entry_to_tail(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
+fn[K] Set::add_entry_to_tail(
+  self : Set[K],
+  idx : Int,
+  entry : Entry[K],
+) -> Unit {
   match self.tail {
     -1 => self.head = Some(entry)
     tail => self.entries[tail].unwrap().next = Some(entry)
@@ -304,7 +308,7 @@ fn[K] add_entry_to_tail(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
 }
 
 ///|
-fn[K] remove_entry(self : Set[K], entry : Entry[K]) -> Unit {
+fn[K] Set::remove_entry(self : Set[K], entry : Entry[K]) -> Unit {
   match entry.prev {
     -1 => self.head = entry.next
     idx => self.entries[idx].unwrap().next = entry.next
@@ -316,7 +320,7 @@ fn[K] remove_entry(self : Set[K], entry : Entry[K]) -> Unit {
 }
 
 ///|
-fn[K] shift_back(self : Set[K], idx : Int) -> Unit {
+fn[K] Set::shift_back(self : Set[K], idx : Int) -> Unit {
   let next = (idx + 1) & self.capacity_mask
   match self.entries[next] {
     None | Some({ psl: 0, .. }) => self.entries[idx] = None
@@ -329,7 +333,7 @@ fn[K] shift_back(self : Set[K], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq] grow(self : Set[K]) -> Unit {
+fn[K : Eq] Set::grow(self : Set[K]) -> Unit {
   let old_head = self.head
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)
@@ -368,26 +372,26 @@ pub impl[K : Show] Show for Set[K] with output(self, logger) {
 ///|
 /// Get the number of keys in the set.
 #alias(size, deprecated)
-pub fn[K] length(self : Set[K]) -> Int {
+pub fn[K] Set::length(self : Set[K]) -> Int {
   self.size
 }
 
 ///|
 /// Get the capacity of the set.
-pub fn[K] capacity(self : Set[K]) -> Int {
+pub fn[K] Set::capacity(self : Set[K]) -> Int {
   self.capacity
 }
 
 ///|
 /// Check if the hash set is empty.
-pub fn[K] is_empty(self : Set[K]) -> Bool {
+pub fn[K] Set::is_empty(self : Set[K]) -> Bool {
   self.size == 0
 }
 
 ///|
 /// Iterate over all keys of the set in the order of insertion.
 #locals(f)
-pub fn[K] each(self : Set[K], f : (K) -> Unit raise?) -> Unit raise? {
+pub fn[K] Set::each(self : Set[K], f : (K) -> Unit raise?) -> Unit raise? {
   loop self.head {
     Some({ key, next, .. }) => {
       f(key)
@@ -400,7 +404,7 @@ pub fn[K] each(self : Set[K], f : (K) -> Unit raise?) -> Unit raise? {
 ///|
 /// Iterate over all keys of the set in the order of insertion, with index.
 #locals(f)
-pub fn[K] eachi(self : Set[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
+pub fn[K] Set::eachi(self : Set[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
   loop (0, self.head) {
     (i, Some({ key, next, .. })) => {
       f(i, key)
@@ -412,7 +416,7 @@ pub fn[K] eachi(self : Set[K], f : (Int, K) -> Unit raise?) -> Unit raise? {
 
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
-pub fn[K] clear(self : Set[K]) -> Unit {
+pub fn[K] Set::clear(self : Set[K]) -> Unit {
   self.entries.fill(None)
   self.size = 0
   self.head = None
@@ -421,7 +425,7 @@ pub fn[K] clear(self : Set[K]) -> Unit {
 
 ///|
 /// Returns the iterator of the hash set, provide elements in the order of insertion.
-pub fn[K] iter(self : Set[K]) -> Iter[K] {
+pub fn[K] Set::iter(self : Set[K]) -> Iter[K] {
   Iter::new(yield_ => loop self.head {
     Some({ key, next, .. }) => {
       guard yield_(key) is IterContinue else { break IterEnd }
@@ -433,7 +437,7 @@ pub fn[K] iter(self : Set[K]) -> Iter[K] {
 
 ///|
 /// Converts the hash set to an array.
-pub fn[K] to_array(self : Set[K]) -> Array[K] {
+pub fn[K] Set::to_array(self : Set[K]) -> Array[K] {
   let arr = Array::new(capacity=self.size)
   loop self.head {
     Some({ key, next, .. }) => {
@@ -488,7 +492,7 @@ pub impl[K] Default for Set[K] with default() {
 
 ///|
 /// Copy the set, creating a new set with the same keys and order of insertion.
-pub fn[K] copy(self : Set[K]) -> Set[K] {
+pub fn[K] Set::copy(self : Set[K]) -> Set[K] {
   // copy structure
   let other = {
     capacity: self.capacity,
@@ -518,14 +522,14 @@ pub fn[K] copy(self : Set[K]) -> Set[K] {
 }
 
 ///|
-pub fn[K : Hash + Eq] difference(self : Set[K], other : Set[K]) -> Set[K] {
+pub fn[K : Hash + Eq] Set::difference(self : Set[K], other : Set[K]) -> Set[K] {
   let m = Set::new()
   self.each(k => if !other.contains(k) { m.add(k) })
   m
 }
 
 ///|
-pub fn[K : Hash + Eq] symmetric_difference(
+pub fn[K : Hash + Eq] Set::symmetric_difference(
   self : Set[K],
   other : Set[K],
 ) -> Set[K] {
@@ -536,7 +540,7 @@ pub fn[K : Hash + Eq] symmetric_difference(
 }
 
 ///|
-pub fn[K : Hash + Eq] union(self : Set[K], other : Set[K]) -> Set[K] {
+pub fn[K : Hash + Eq] Set::union(self : Set[K], other : Set[K]) -> Set[K] {
   let m = Set::new()
   self.each(k => m.add(k))
   other.each(k => m.add(k))
@@ -544,7 +548,10 @@ pub fn[K : Hash + Eq] union(self : Set[K], other : Set[K]) -> Set[K] {
 }
 
 ///|
-pub fn[K : Hash + Eq] intersection(self : Set[K], other : Set[K]) -> Set[K] {
+pub fn[K : Hash + Eq] Set::intersection(
+  self : Set[K],
+  other : Set[K],
+) -> Set[K] {
   let m = Set::new()
   self.each(k => if other.contains(k) { m.add(k) })
   m
@@ -561,7 +568,7 @@ pub impl[X : ToJson] ToJson for Set[X] with to_json(self) {
 
 ///|
 /// Check if two sets have no common elements.
-pub fn[K : Hash + Eq] is_disjoint(self : Set[K], other : Set[K]) -> Bool {
+pub fn[K : Hash + Eq] Set::is_disjoint(self : Set[K], other : Set[K]) -> Bool {
   if self.length() <= other.length() {
     for k in self {
       if other.contains(k) {
@@ -580,7 +587,7 @@ pub fn[K : Hash + Eq] is_disjoint(self : Set[K], other : Set[K]) -> Bool {
 
 ///|
 /// Check if the current set is a subset of another set.
-pub fn[K : Hash + Eq] is_subset(self : Set[K], other : Set[K]) -> Bool {
+pub fn[K : Hash + Eq] Set::is_subset(self : Set[K], other : Set[K]) -> Bool {
   if self.length() <= other.length() {
     for k in self {
       if !other.contains(k) {
@@ -595,7 +602,7 @@ pub fn[K : Hash + Eq] is_subset(self : Set[K], other : Set[K]) -> Bool {
 
 ///|
 /// Check if the current set is a superset of another set.
-pub fn[K : Hash + Eq] is_superset(self : Set[K], other : Set[K]) -> Bool {
+pub fn[K : Hash + Eq] Set::is_superset(self : Set[K], other : Set[K]) -> Bool {
   other.is_subset(self)
 }
 

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -15,7 +15,7 @@
 ///|
 #deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
 #coverage.skip
-pub fn[K, V] keys(self : SortedMap[K, V]) -> Array[K] {
+pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
   let keys = Array::new(capacity=self.size)
   self.each(fn(k, _v) { keys.push(k) })
   keys
@@ -24,7 +24,7 @@ pub fn[K, V] keys(self : SortedMap[K, V]) -> Array[K] {
 ///|
 #deprecated("Use `values_as_iter` instead. `values` will return `Iter[V]` instead of `Array[V]` in the future.")
 #coverage.skip
-pub fn[K, V] values(self : SortedMap[K, V]) -> Array[V] {
+pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Array[V] {
   let values = Array::new(capacity=self.size)
   self.each(fn(_k, v) { values.push(v) })
   values

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -74,7 +74,10 @@ pub fn[K : Compare, V] SortedMap::set(
 
 ///|
 /// Removes a key-value pair.
-pub fn[K : Compare, V] remove(self : SortedMap[K, V], key : K) -> Unit {
+pub fn[K : Compare, V] SortedMap::remove(
+  self : SortedMap[K, V],
+  key : K,
+) -> Unit {
   if self.root is Some(old_root) {
     let (new_root, deleted) = delete_node(old_root, key)
     if self.root != new_root {
@@ -88,7 +91,7 @@ pub fn[K : Compare, V] remove(self : SortedMap[K, V], key : K) -> Unit {
 
 ///|
 /// Gets a value by a key.
-pub fn[K : Compare, V] get(self : SortedMap[K, V], key : K) -> V? {
+pub fn[K : Compare, V] SortedMap::get(self : SortedMap[K, V], key : K) -> V? {
   loop self.root {
     Some(node) => {
       let cmp = key.compare(node.key)
@@ -125,7 +128,10 @@ pub fn[K : Compare, V] SortedMap::at(self : SortedMap[K, V], key : K) -> V {
 
 ///|
 /// Checks if map contains a key-value pair.
-pub fn[K : Compare, V] contains(self : SortedMap[K, V], key : K) -> Bool {
+pub fn[K : Compare, V] SortedMap::contains(
+  self : SortedMap[K, V],
+  key : K,
+) -> Bool {
   match self.get(key) {
     Some(_) => true
     None => false
@@ -134,27 +140,27 @@ pub fn[K : Compare, V] contains(self : SortedMap[K, V], key : K) -> Bool {
 
 ///|
 /// Returns true if map is empty.
-pub fn[K, V] is_empty(self : SortedMap[K, V]) -> Bool {
+pub fn[K, V] SortedMap::is_empty(self : SortedMap[K, V]) -> Bool {
   self.size == 0
 }
 
 ///|
 /// Returns the count of key-value pairs in the map.
 #alias(size, deprecated)
-pub fn[K, V] length(self : SortedMap[K, V]) -> Int {
+pub fn[K, V] SortedMap::length(self : SortedMap[K, V]) -> Int {
   self.size
 }
 
 ///|
 /// Clears the map.
-pub fn[K, V] clear(self : SortedMap[K, V]) -> Unit {
+pub fn[K, V] SortedMap::clear(self : SortedMap[K, V]) -> Unit {
   self.root = None
   self.size = 0
 }
 
 ///|
 /// Iterates the map.
-pub fn[K, V] each(
+pub fn[K, V] SortedMap::each(
   self : SortedMap[K, V],
   f : (K, V) -> Unit raise?,
 ) -> Unit raise? {
@@ -171,7 +177,7 @@ pub fn[K, V] each(
 
 ///|
 /// Iterates the map with index.
-pub fn[K, V] eachi(
+pub fn[K, V] SortedMap::eachi(
   self : SortedMap[K, V],
   f : (Int, K, V) -> Unit raise?,
 ) -> Unit raise? {
@@ -184,7 +190,7 @@ pub fn[K, V] eachi(
 
 ///|
 /// Returns all keys in the map.
-pub fn[K, V] keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
+pub fn[K, V] SortedMap::keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
   Iter::new(fn(yield_) {
     fn go(x : Node[K, V]?) {
       match x {
@@ -206,7 +212,7 @@ pub fn[K, V] keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
 
 ///|
 /// Returns all values in the map.
-pub fn[K, V] values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
+pub fn[K, V] SortedMap::values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
   Iter::new(fn(yield_) {
     fn go(x : Node[K, V]?) {
       match x {
@@ -228,14 +234,14 @@ pub fn[K, V] values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
 
 ///|
 /// Converts the map to an array.
-pub fn[K, V] to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
+pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
   let arr = Array::new(capacity=self.size)
   self.each((k, v) => arr.push((k, v)))
   arr
 }
 
 ///|
-pub fn[K, V] iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
+pub fn[K, V] SortedMap::iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
   Iter::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
@@ -256,7 +262,7 @@ pub fn[K, V] iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
 }
 
 ///|
-pub fn[K, V] iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
+pub fn[K, V] SortedMap::iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
   Iter2::new(yield_ => {
     fn go(x : Node[K, V]?) {
       match x {
@@ -296,7 +302,7 @@ pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickc
 
 ///|
 ///Returns a new array of key-value pairs that are within the specified range [low, high].
-pub fn[K : Compare, V] range(
+pub fn[K : Compare, V] SortedMap::range(
   self : SortedMap[K, V],
   low : K,
   high : K,
@@ -349,7 +355,7 @@ fn[K, V] replace_root_with_min(
 }
 
 ///|
-fn[K, V] update_height(self : Node[K, V]) -> Unit {
+fn[K, V] Node::update_height(self : Node[K, V]) -> Unit {
   self.height = 1 + max(height(self.left), height(self.right))
 }
 

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -40,7 +40,7 @@ fn[K, V] height(node : Node[K, V]?) -> Int {
 }
 
 ///|
-fn[K : Show, V : Show] debug_node(self : Node[K, V]) -> String {
+fn[K : Show, V : Show] Node::debug_node(self : Node[K, V]) -> String {
   let l = match self.left {
     Some(left) => left.debug_node()
     None => "_"
@@ -53,7 +53,7 @@ fn[K : Show, V : Show] debug_node(self : Node[K, V]) -> String {
 }
 
 ///|
-fn[K : Show, V : Show] debug_tree(self : SortedMap[K, V]) -> String {
+fn[K : Show, V : Show] SortedMap::debug_tree(self : SortedMap[K, V]) -> String {
   match self.root {
     Some(root) => root.debug_node()
     None => "_"

--- a/sorted_set/deprecated.mbt
+++ b/sorted_set/deprecated.mbt
@@ -18,7 +18,7 @@
 ///
 #deprecated("Use `copy` instead")
 #coverage.skip
-pub fn[V] deep_clone(self : SortedSet[V]) -> SortedSet[V] {
+pub fn[V] SortedSet::deep_clone(self : SortedSet[V]) -> SortedSet[V] {
   self.copy()
 }
 
@@ -27,7 +27,7 @@ pub fn[V] deep_clone(self : SortedSet[V]) -> SortedSet[V] {
 ///
 #deprecated("Use `difference` instead")
 #coverage.skip
-pub fn[V : Compare] diff(
+pub fn[V : Compare] SortedSet::diff(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
@@ -40,7 +40,7 @@ pub fn[V : Compare] diff(
 /// Returns the intersection of two sets.
 #deprecated("Use `intersection` instead")
 #coverage.skip
-pub fn[V : Compare] intersect(
+pub fn[V : Compare] SortedSet::intersect(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -54,7 +54,7 @@ pub fn[V : Compare] SortedSet::of(array : FixedArray[V]) -> SortedSet[V] {
 /// 
 /// It is just copying the tree structure, not the values.
 /// 
-pub fn[V] copy(self : SortedSet[V]) -> SortedSet[V] {
+pub fn[V] SortedSet::copy(self : SortedSet[V]) -> SortedSet[V] {
   match self.root {
     None => new()
     Some(_) => { root: copy_tree(self.root), size: self.size }
@@ -96,7 +96,7 @@ fn[V] new_node_update_height(
 // Manipulations
 
 ///|
-pub fn[V : Compare] add(self : SortedSet[V], value : V) -> Unit {
+pub fn[V : Compare] SortedSet::add(self : SortedSet[V], value : V) -> Unit {
   let (new_root, inserted) = add_node(self.root, value)
   if self.root != new_root {
     self.root = new_root
@@ -107,7 +107,7 @@ pub fn[V : Compare] add(self : SortedSet[V], value : V) -> Unit {
 }
 
 ///|
-pub fn[V : Compare] remove(self : SortedSet[V], value : V) -> Unit {
+pub fn[V : Compare] SortedSet::remove(self : SortedSet[V], value : V) -> Unit {
   if self.root is Some(old_root) {
     let (new_root, deleted) = delete_node(old_root, value)
     if self.root != new_root {
@@ -126,7 +126,7 @@ pub fn[V : Compare] remove(self : SortedSet[V], value : V) -> Unit {
 
 ///|
 /// Return if a value is contained in the set.
-pub fn[V : Compare] contains(self : SortedSet[V], value : V) -> Bool {
+pub fn[V : Compare] SortedSet::contains(self : SortedSet[V], value : V) -> Bool {
   loop (self.root, value) {
     (None, _) => false
     (Some(node), value) => {
@@ -144,7 +144,7 @@ pub fn[V : Compare] contains(self : SortedSet[V], value : V) -> Bool {
 
 ///|
 /// Returns the union of two sets.
-pub fn[V : Compare] union(
+pub fn[V : Compare] SortedSet::union(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
@@ -261,7 +261,7 @@ fn[V] join_right(l : Node[V]?, v : V, r : Node[V]?) -> Node[V] {
 
 ///|
 /// Returns the difference of two sets.
-pub fn[V : Compare] difference(
+pub fn[V : Compare] SortedSet::difference(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
@@ -291,7 +291,7 @@ pub fn[V : Compare] difference(
 ///   let diff = set1.symmetric_difference(set2)
 ///   inspect(diff, content="@sorted_set.from_array([1, 2, 5, 6])")
 /// ```
-pub fn[V : Compare] symmetric_difference(
+pub fn[V : Compare] SortedSet::symmetric_difference(
   self : SortedSet[V],
   other : SortedSet[V],
 ) -> SortedSet[V] {
@@ -303,7 +303,7 @@ pub fn[V : Compare] symmetric_difference(
 
 ///|
 /// Returns the intersection of two sets.
-pub fn[V : Compare] intersection(
+pub fn[V : Compare] SortedSet::intersection(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
@@ -314,7 +314,10 @@ pub fn[V : Compare] intersection(
 
 ///|
 /// Returns if a set is a subset of another set.
-pub fn[V : Compare] subset(self : SortedSet[V], src : SortedSet[V]) -> Bool {
+pub fn[V : Compare] SortedSet::subset(
+  self : SortedSet[V],
+  src : SortedSet[V],
+) -> Bool {
   let mut ret = true
   self.each(x => if !src.contains(x) { ret = false })
   ret
@@ -322,7 +325,10 @@ pub fn[V : Compare] subset(self : SortedSet[V], src : SortedSet[V]) -> Bool {
 
 ///|
 /// Returns if two sets are disjoint.
-pub fn[V : Compare] disjoint(self : SortedSet[V], src : SortedSet[V]) -> Bool {
+pub fn[V : Compare] SortedSet::disjoint(
+  self : SortedSet[V],
+  src : SortedSet[V],
+) -> Bool {
   let mut ret = true
   self.each(x => if src.contains(x) { ret = false })
   ret
@@ -344,20 +350,23 @@ pub impl[V : Eq] Eq for SortedSet[V] with equal(self, other) {
 
 ///|
 /// Returns if the set is empty.
-pub fn[V] is_empty(self : SortedSet[V]) -> Bool {
+pub fn[V] SortedSet::is_empty(self : SortedSet[V]) -> Bool {
   self.root is None
 }
 
 ///|
 /// Returns the number of elements in the set.
 #alias(size, deprecated)
-pub fn[V] length(self : SortedSet[V]) -> Int {
+pub fn[V] SortedSet::length(self : SortedSet[V]) -> Int {
   self.size
 }
 
 ///|
 /// Iterates the set.
-pub fn[V] each(self : SortedSet[V], f : (V) -> Unit raise?) -> Unit raise? {
+pub fn[V] SortedSet::each(
+  self : SortedSet[V],
+  f : (V) -> Unit raise?,
+) -> Unit raise? {
   fn dfs(root : Node[V]?) -> Unit raise? {
     if root is Some(root) {
       dfs(root.left)
@@ -371,7 +380,7 @@ pub fn[V] each(self : SortedSet[V], f : (V) -> Unit raise?) -> Unit raise? {
 
 ///|
 /// Iterates the set with index.
-pub fn[V] eachi(
+pub fn[V] SortedSet::eachi(
   self : SortedSet[V],
   f : (Int, V) -> Unit raise?,
 ) -> Unit raise? {
@@ -384,7 +393,7 @@ pub fn[V] eachi(
 
 ///|
 /// Converts the set to an array.
-pub fn[V] to_array(self : SortedSet[V]) -> Array[V] {
+pub fn[V] SortedSet::to_array(self : SortedSet[V]) -> Array[V] {
   if self.size == 0 {
     []
   } else {
@@ -407,7 +416,7 @@ pub fn[V] to_array(self : SortedSet[V]) -> Array[V] {
 
 ///|
 /// Returns a iterator.
-pub fn[V] iter(self : SortedSet[V]) -> Iter[V] {
+pub fn[V] SortedSet::iter(self : SortedSet[V]) -> Iter[V] {
   Iter::new(yield_ => {
     fn go(x : Node[V]?) {
       match x {
@@ -455,7 +464,11 @@ impl[T : Show] Show for Node[T] with output(self, logger) {
 }
 
 ///|
-pub fn[V : Compare] range(self : SortedSet[V], low : V, high : V) -> Iter[V] {
+pub fn[V : Compare] SortedSet::range(
+  self : SortedSet[V],
+  low : V,
+  high : V,
+) -> Iter[V] {
   Iter::new(yield_ => {
     fn go(x : Node[V]?) {
       match x {
@@ -500,7 +513,7 @@ fn[V] replace_root_with_min(root : Node[V], node : Node[V]) -> Node[V]? {
 }
 
 ///|
-fn[V] update_height(self : Node[V]) -> Unit {
+fn[V] Node::update_height(self : Node[V]) -> Unit {
   self.height = 1 + max(height(self.left), height(self.right))
 }
 

--- a/sorted_set/utils.mbt
+++ b/sorted_set/utils.mbt
@@ -35,7 +35,7 @@ fn[V] height(node : Node[V]?) -> Int {
 }
 
 ///|
-fn[V : Show] debug_node(self : Node[V]) -> String {
+fn[V : Show] Node::debug_node(self : Node[V]) -> String {
   let l = match self.left {
     Some(left) => left.debug_node()
     None => "_"
@@ -50,7 +50,7 @@ fn[V : Show] debug_node(self : Node[V]) -> String {
 }
 
 ///|
-fn[V : Show] debug_tree(self : SortedSet[V]) -> String {
+fn[V : Show] SortedSet::debug_tree(self : SortedSet[V]) -> String {
   match self.root {
     Some(root) => root.debug_node()
     None => "_"

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -125,7 +125,7 @@ fn parse_decimal_from_view(str : StringView) -> Decimal raise StrConvError {
 }
 
 ///|
-fn to_double_priv(self : Decimal) -> Double raise StrConvError {
+fn Decimal::to_double_priv(self : Decimal) -> Double raise StrConvError {
   let mut exponent = 0
   let mut mantissa = 0L
   // check the underflow and overflow
@@ -209,7 +209,7 @@ fn to_double_priv(self : Decimal) -> Double raise StrConvError {
 }
 
 ///|
-fn shift_priv(self : Decimal, s : Int) -> Unit {
+fn Decimal::shift_priv(self : Decimal, s : Int) -> Unit {
   if self.digits_num == 0 {
     return
   }
@@ -247,7 +247,7 @@ fn assemble_bits(mantissa : Int64, exponent : Int, negative : Bool) -> Int64 {
 
 ///|
 /// Extract a rounded 64bit integer
-fn rounded_integer(self : Decimal) -> Int64 {
+fn Decimal::rounded_integer(self : Decimal) -> Int64 {
   if self.decimal_point > 20 {
     return 0xFFFFFFFFFFFFFFFFL
   }
@@ -271,7 +271,7 @@ fn rounded_integer(self : Decimal) -> Int64 {
 /// Check if truncate at d digits should round up.
 /// Typically, when rounding a decimal fraction to an integer, 7.3 rounds down to 7 and 7.6 rounds up to 8. 
 /// Rounding numbers like 7.5, half-way between two integers, will round to even.
-fn should_round_up(self : Decimal, d : Int) -> Bool {
+fn Decimal::should_round_up(self : Decimal, d : Int) -> Bool {
   if d < 0 || d >= self.digits_num {
     return false
   }
@@ -290,7 +290,7 @@ fn should_round_up(self : Decimal, d : Int) -> Bool {
 
 ///|
 /// Assign a Int64 value to decimal.
-fn assign(self : Decimal, v : Int64) -> Unit {
+fn Decimal::assign(self : Decimal, v : Int64) -> Unit {
   let buf = FixedArray::make(24, Byte::default())
 
   // write value to buf
@@ -315,7 +315,7 @@ fn assign(self : Decimal, v : Int64) -> Unit {
 
 ///|
 /// Binary shift right by s bits.
-fn right_shift(self : Decimal, s : Int) -> Unit {
+fn Decimal::right_shift(self : Decimal, s : Int) -> Unit {
   let mut read_index = 0
   let mut write_index = 0
 
@@ -438,7 +438,7 @@ let left_shift_cheats = [
 
 ///|
 /// Lookup the cheat sheet to find the new digits num.
-fn new_digits(self : Decimal, s : Int) -> Int {
+fn Decimal::new_digits(self : Decimal, s : Int) -> Int {
   let new_digits = left_shift_cheats[s].0
   let cheat_num = left_shift_cheats[s].1
   // check if the leading digits lexicographically less than cheats num.
@@ -463,7 +463,7 @@ fn new_digits(self : Decimal, s : Int) -> Int {
 
 ///|
 /// Binary shift left by s bits.
-fn left_shift(self : Decimal, s : Int) -> Unit {
+fn Decimal::left_shift(self : Decimal, s : Int) -> Unit {
   let new_digits = self.new_digits(s)
   // from right to left
   let mut read_index = self.digits_num
@@ -511,7 +511,7 @@ fn left_shift(self : Decimal, s : Int) -> Unit {
 
 ///|
 /// Trim trailing zeros.
-fn trim(self : Decimal) -> Unit {
+fn Decimal::trim(self : Decimal) -> Unit {
   while self.digits_num > 0 && self.digits[self.digits_num - 1] == 0 {
     self.digits_num -= 1
   }

--- a/strconv/deprecated.mbt
+++ b/strconv/deprecated.mbt
@@ -57,7 +57,7 @@ pub fn Decimal::parse_decimal(str : StringView) -> Decimal raise StrConvError {
 ///|
 /// Convert the decimal to Double.
 #deprecated("use `@strconv.parse_double` instead to avoid using this method.")
-pub fn to_double(self : Decimal) -> Double raise StrConvError {
+pub fn Decimal::to_double(self : Decimal) -> Double raise StrConvError {
   self.to_double_priv()
 }
 
@@ -65,6 +65,6 @@ pub fn to_double(self : Decimal) -> Double raise StrConvError {
 /// Binary shift left (s > 0) or right (s < 0).
 /// The shift count must not larger than the max_shift to avoid overflow.
 #deprecated("use `@strconv.parse_double` instead to avoid using this method.")
-pub fn shift(self : Decimal, s : Int) -> Unit {
+pub fn Decimal::shift(self : Decimal, s : Int) -> Unit {
   self.shift_priv(s)
 }

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -83,7 +83,7 @@ pub fn parse_double(str : StringView) -> Double raise StrConvError {
 }
 
 ///|
-fn is_fast_path(self : Number) -> Bool {
+fn Number::is_fast_path(self : Number) -> Bool {
   min_exponent_fast_path <= self.exponent &&
   self.exponent <= max_exponent_disguised_fast_path &&
   self.mantissa <= max_mantissa_fast_path &&
@@ -112,7 +112,7 @@ let int_pow10 : FixedArray[UInt64] = [
 ]
 
 ///|
-fn try_fast_path(self : Number) -> Double? {
+fn Number::try_fast_path(self : Number) -> Double? {
   if self.is_fast_path() {
     let mut value = if self.exponent <= max_exponent_fast_path {
       // normal fast path

--- a/string/methods.mbt
+++ b/string/methods.mbt
@@ -336,7 +336,7 @@ test "has_prefix" {
 ///   inspect("hello world".strip_suffix(" moon"), content="None")
 ///   inspect("hello".strip_suffix("hello"), content="Some(\"\")")
 /// ```
-pub fn strip_suffix(self : String, suffix : StringView) -> StringView? {
+pub fn String::strip_suffix(self : String, suffix : StringView) -> StringView? {
   if self.has_suffix(suffix) {
     Some(self.view(end_offset=self.length() - suffix.length()))
   } else {
@@ -382,7 +382,7 @@ test "strip_suffix" {
 ///   inspect("hello world".strip_prefix("hi "), content="None")
 ///   inspect("hello".strip_prefix("hello"), content="Some(\"\")")
 /// ```
-pub fn strip_prefix(self : String, prefix : StringView) -> StringView? {
+pub fn String::strip_prefix(self : String, prefix : StringView) -> StringView? {
   if self.has_prefix(prefix) {
     Some(self.view(start_offset=prefix.length()))
   } else {
@@ -536,7 +536,7 @@ pub fn StringView::contains(self : StringView, str : StringView) -> Bool {
 
 ///|
 /// Returns true if this string contains the given substring.
-pub fn contains(self : String, str : StringView) -> Bool {
+pub fn String::contains(self : String, str : StringView) -> Bool {
   self[:].contains(str)
 }
 
@@ -593,7 +593,7 @@ pub fn StringView::contains_char(self : StringView, c : Char) -> Bool {
 
 ///|
 /// Returns true if this string contains the given character.
-pub fn contains_char(self : String, c : Char) -> Bool {
+pub fn String::contains_char(self : String, c : Char) -> Bool {
   self[:].contains_char(c)
 }
 
@@ -635,7 +635,7 @@ pub fn StringView::trim_start(
 /// Returns the view of the string without the leading characters that are in
 /// the given string.
 #callsite(migration(char_set, allow_positional=true))
-pub fn trim_start(self : String, char_set~ : StringView) -> StringView {
+pub fn String::trim_start(self : String, char_set~ : StringView) -> StringView {
   self[:].trim_start(char_set~)
 }
 
@@ -678,7 +678,7 @@ pub fn StringView::trim_end(
 /// Returns the view of the string without the trailing characters that are in
 /// the given string.
 #callsite(migration(char_set, allow_positional=true))
-pub fn trim_end(self : String, char_set~ : StringView) -> StringView {
+pub fn String::trim_end(self : String, char_set~ : StringView) -> StringView {
   self[:].trim_end(char_set~)
 }
 
@@ -712,7 +712,7 @@ pub fn StringView::trim(
 /// Returns the view of the string without the leading and trailing characters
 /// that are in the given string.
 #callsite(migration(char_set, allow_positional=true))
-pub fn trim(self : String, char_set~ : StringView) -> StringView {
+pub fn String::trim(self : String, char_set~ : StringView) -> StringView {
   self[:].trim(char_set~)
 }
 
@@ -743,7 +743,7 @@ pub fn StringView::trim_space(self : StringView) -> StringView {
 
 ///|
 /// Returns the view of the string without the leading and trailing spaces.
-pub fn trim_space(self : String) -> StringView {
+pub fn String::trim_space(self : String) -> StringView {
   self[:].trim_space()
 }
 
@@ -769,7 +769,7 @@ pub fn StringView::is_empty(self : StringView) -> Bool {
 
 ///|
 /// Returns true if this string is empty.
-pub fn is_empty(self : String) -> Bool {
+pub fn String::is_empty(self : String) -> Bool {
   self == ""
 }
 
@@ -798,7 +798,7 @@ pub fn StringView::is_blank(self : StringView) -> Bool {
 
 ///|
 /// Returns true if this string is blank.
-pub fn is_blank(self : String) -> Bool {
+pub fn String::is_blank(self : String) -> Bool {
   self[:].is_blank()
 }
 
@@ -841,7 +841,7 @@ pub fn StringView::pad_start(
 /// Returns a new string with `padding_char`s prefixed to `self` if
 /// `self.char_length() < total_width`. The number of unicode characters in
 /// the returned string is `total_width` if padding is added.
-pub fn pad_start(
+pub fn String::pad_start(
   self : String,
   total_width : Int,
   padding_char : Char,
@@ -952,7 +952,7 @@ pub fn StringView::repeat(self : StringView, n : Int) -> StringView {
 
 ///|
 /// Returns a new string with `self` repeated `n` times.
-pub fn repeat(self : String, n : Int) -> String {
+pub fn String::repeat(self : String, n : Int) -> String {
   match n {
     _..=0 => ""
     1 => self
@@ -1007,7 +1007,7 @@ pub fn StringView::rev(self : StringView) -> String {
 ///|
 /// Returns a new string with the characters in reverse order. It respects
 /// Unicode characters and surrogate pairs but not grapheme clusters.
-pub fn rev(self : String) -> String {
+pub fn String::rev(self : String) -> String {
   self[:].rev()
 }
 
@@ -1058,7 +1058,7 @@ pub fn StringView::split(
 /// 
 /// If the separator is empty, the returned iterator will contain all the
 /// characters in the string as single elements.
-pub fn split(self : String, sep : StringView) -> Iter[StringView] {
+pub fn String::split(self : String, sep : StringView) -> Iter[StringView] {
   self[:].split(sep)
 }
 
@@ -1123,7 +1123,11 @@ pub fn StringView::replace(
 /// 
 /// If `old` is empty, it matches the beginning of the string, and `new` is
 /// prepended to the string.
-pub fn replace(self : String, old~ : StringView, new~ : StringView) -> String {
+pub fn String::replace(
+  self : String,
+  old~ : StringView,
+  new~ : StringView,
+) -> String {
   match self.find(old) {
     Some(end) =>
       [
@@ -1202,7 +1206,7 @@ pub fn StringView::replace_all(
 /// If `old` is empty, it matches at the beginning of the string and after each
 /// character in the string, so `new` is inserted at the beginning of the string
 /// and after each character.
-pub fn replace_all(
+pub fn String::replace_all(
   self : String,
   old~ : StringView,
   new~ : StringView,
@@ -1373,7 +1377,7 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
 
 ///|
 /// Converts this string to lowercase.
-pub fn to_lower(self : String) -> String {
+pub fn String::to_lower(self : String) -> String {
   // TODO: deal with non-ascii characters
   guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
     return self
@@ -1426,7 +1430,7 @@ pub fn StringView::to_upper(self : StringView) -> StringView {
 
 ///|
 /// Converts this string to uppercase.
-pub fn to_upper(self : String) -> String {
+pub fn String::to_upper(self : String) -> String {
   // TODO: deal with non-ascii characters
   guard self.find_by(_.is_ascii_lowercase()) is Some(idx) else { return self }
   let buf = StringBuilder::new(size_hint=self.length())
@@ -1472,7 +1476,7 @@ pub fn[A] StringView::fold(
 
 ///|
 /// Folds the characters of the string into a single value.
-pub fn[A] fold(self : String, init~ : A, f : (A, Char) -> A) -> A {
+pub fn[A] String::fold(self : String, init~ : A, f : (A, Char) -> A) -> A {
   self[:].fold(init~, f)
 }
 
@@ -1505,7 +1509,7 @@ pub fn[A] StringView::rev_fold(
 }
 
 ///|
-pub fn[A] rev_fold(self : String, init~ : A, f : (A, Char) -> A) -> A {
+pub fn[A] String::rev_fold(self : String, init~ : A, f : (A, Char) -> A) -> A {
   self[:].rev_fold(init~, f)
 }
 

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -79,7 +79,7 @@ pub fn default() -> String {
 ///|
 /// `String` holds a sequence of UTF-16 code units encoded in little endian format
 #deprecated("check @encoding/utf8.encode")
-pub fn to_bytes(self : String) -> Bytes {
+pub fn String::to_bytes(self : String) -> Bytes {
   let array = FixedArray::make(self.length() * 2, Byte::default())
   array.blit_from_string(0, self, 0, self.length())
   array |> unsafe_to_bytes
@@ -90,7 +90,7 @@ fn unsafe_to_bytes(array : FixedArray[Byte]) -> Bytes = "%identity"
 
 ///|
 /// Converts the String into an array of Chars.
-pub fn to_array(self : String) -> Array[Char] {
+pub fn String::to_array(self : String) -> Array[Char] {
   self
   .iter()
   .fold(init=Array::new(capacity=self.length()), (rv, c) => {
@@ -110,7 +110,7 @@ pub fn to_array(self : String) -> Array[Char] {
 ///   assert_eq(s.iter().count(), 14); // Unicode characters
 ///   assert_eq(s.length(), 15); // Utf16 code units
 /// ```
-pub fn iter(self : String) -> Iter[Char] {
+pub fn String::iter(self : String) -> Iter[Char] {
   Iter::new(yield_ => {
     let len = self.length()
     for index in 0..<len {
@@ -132,7 +132,7 @@ pub fn iter(self : String) -> Iter[Char] {
 }
 
 ///|
-pub fn iter2(self : String) -> Iter2[Int, Char] {
+pub fn String::iter2(self : String) -> Iter2[Int, Char] {
   Iter2::new(yield_ => {
     let len = self.length()
     for index = 0, n = 0; index < len; index = index + 1, n = n + 1 {
@@ -181,7 +181,7 @@ pub fn iter2(self : String) -> Iter2[Int, Char] {
 ///   let reversed = input.rev_iter().collect()
 ///   assert_eq(reversed, ['!', 'd', 'l', 'r', 'o', 'W', ' ', ',', 'o', 'l', 'l', 'e', 'H'])
 /// ```
-pub fn rev_iter(self : String) -> Iter[Char] {
+pub fn String::rev_iter(self : String) -> Iter[Char] {
   Iter::new(yield_ => {
     let len = self.length()
     for index = len - 1; index >= 0; index = index - 1 {

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -58,14 +58,14 @@ pub fn StringView::at(self : StringView, index : Int) -> Int {
 
 ///|
 /// Returns the original string that is being viewed.
-pub fn data(self : StringView) -> String {
+pub fn StringView::data(self : StringView) -> String {
   self.str()
 }
 
 ///|
 /// Returns the starting offset (in UTF-16 code units) of this view into its
 /// underlying string.
-pub fn start_offset(self : StringView) -> Int {
+pub fn StringView::start_offset(self : StringView) -> Int {
   self.start()
 }
 
@@ -73,7 +73,7 @@ pub fn start_offset(self : StringView) -> Int {
 /// Returns the length of the view.
 /// 
 /// This method counts the charcodes(code unit) in the view and has O(1) complexity.
-pub fn length(self : StringView) -> Int {
+pub fn StringView::length(self : StringView) -> Int {
   self.end() - self.start()
 }
 

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -83,7 +83,7 @@ pub fn[T] fail(msg : String, loc~ : SourceLoc) -> T raise {
 /// Write data to snapshot buffer, use `snapshot` to output.
 /// 
 /// See also `@test.T::writeln`
-pub fn write(self : Test, obj : &Show) -> Unit {
+pub fn Test::write(self : Test, obj : &Show) -> Unit {
   self.buffer.write_string(obj.to_string())
 }
 
@@ -91,7 +91,7 @@ pub fn write(self : Test, obj : &Show) -> Unit {
 /// Write data to snapshot buffer and newline, use `snapshot` to output.
 /// 
 /// See also `@test.T::write`
-pub fn writeln(self : Test, obj : &Show) -> Unit {
+pub fn Test::writeln(self : Test, obj : &Show) -> Unit {
   self.write(obj)
   self.buffer.write_char('\n')
 }
@@ -107,7 +107,7 @@ pub fn writeln(self : Test, obj : &Show) -> Unit {
 ///
 /// Currently it can only be used once and should be used as the last step.
 #callsite(autofill(args_loc, loc))
-pub fn snapshot(
+pub fn Test::snapshot(
   self : Test,
   filename~ : String,
   loc~ : SourceLoc,

--- a/uint/uint.mbt
+++ b/uint/uint.mbt
@@ -19,7 +19,7 @@ pub let min_value : UInt = 0U
 pub let max_value : UInt = 4294967295U
 
 ///|
-pub fn to_int64(self : UInt) -> Int64 {
+pub fn UInt::to_int64(self : UInt) -> Int64 {
   self.to_uint64().reinterpret_as_int64()
 }
 
@@ -36,7 +36,7 @@ pub fn default() -> UInt {
 
 ///|
 /// Converts the UInt to a Bytes in big-endian byte order.
-pub fn to_be_bytes(self : UInt) -> Bytes {
+pub fn UInt::to_be_bytes(self : UInt) -> Bytes {
   [
     (self >> 24).to_byte(),
     (self >> 16).to_byte(),
@@ -47,7 +47,7 @@ pub fn to_be_bytes(self : UInt) -> Bytes {
 
 ///|
 /// Converts the UInt to a Bytes in little-endian byte order.
-pub fn to_le_bytes(self : UInt) -> Bytes {
+pub fn UInt::to_le_bytes(self : UInt) -> Bytes {
   [
     self.to_byte(),
     (self >> 8).to_byte(),

--- a/uint64/uint64.mbt
+++ b/uint64/uint64.mbt
@@ -20,7 +20,7 @@ pub let max_value : UInt64 = 18446744073709551615UL
 
 ///|
 /// Converts the UInt64 to a Bytes in big-endian byte order.
-pub fn to_be_bytes(self : UInt64) -> Bytes {
+pub fn UInt64::to_be_bytes(self : UInt64) -> Bytes {
   [
     (self >> 56).to_byte(),
     (self >> 48).to_byte(),
@@ -35,7 +35,7 @@ pub fn to_be_bytes(self : UInt64) -> Bytes {
 
 ///|
 /// Converts the UInt64 to a Bytes in little-endian byte order.
-pub fn to_le_bytes(self : UInt64) -> Bytes {
+pub fn UInt64::to_le_bytes(self : UInt64) -> Bytes {
   [
     self.to_byte(),
     (self >> 8).to_byte(),


### PR DESCRIPTION
We plan to deprecate the `fn meth(self : T)` style of method declaration in the next compiler release, in favor of `fn T::meth(..)`. This PR migrates usage of `self` style method in core.