### PR TITLE
fix(linked_hash_map/set): from_array, of

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -70,10 +70,10 @@ pub fn[K, V] Map::new(capacity? : Int = 8) -> Map[K, V] {
 pub fn[K : Hash + Eq, V] Map::from_array(arr : Array[(K, V)]) -> Map[K, V] {
   let length = arr.length()
   let mut capacity = length.next_power_of_two()
-  if length >= calc_grow_threshold(capacity) {
+  if length > calc_grow_threshold(capacity) {
     capacity *= 2
   }
-  let m = Map::new(capacity=arr.length())
+  let m = Map::new(capacity~)
   arr.each(e => m.set(e.0, e.1))
   m
 }
@@ -630,10 +630,10 @@ pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with equal(
 pub fn[K : Hash + Eq, V] Map::of(arr : FixedArray[(K, V)]) -> Map[K, V] {
   let length = arr.length()
   let mut capacity = length.next_power_of_two()
-  if length >= calc_grow_threshold(capacity) {
+  if length > calc_grow_threshold(capacity) {
     capacity *= 2
   }
-  let m = Map::new(capacity=length)
+  let m = Map::new(capacity~)
   // arr.iter((e) => { m.set(e.0, e.1) })
   for i in 0..<length {
     let e = arr[i]

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -72,7 +72,7 @@ pub fn[K] Set::new(capacity? : Int = 8) -> Set[K] {
 pub fn[K : Hash + Eq] Set::from_array(arr : Array[K]) -> Set[K] {
   let length = arr.length()
   let mut capacity = length.next_power_of_two()
-  if length >= calc_grow_threshold(capacity) {
+  if length > calc_grow_threshold(capacity) {
     capacity *= 2
   }
   let m = Set::new(capacity~)
@@ -464,7 +464,7 @@ pub impl[K : Hash + Eq] Eq for Set[K] with equal(self, other) {
 pub fn[K : Hash + Eq] Set::of(arr : FixedArray[K]) -> Set[K] {
   let length = arr.length()
   let mut capacity = length.next_power_of_two()
-  if length >= calc_grow_threshold(capacity) {
+  if length > calc_grow_threshold(capacity) {
     capacity *= 2
   }
   let m = Set::new(capacity~)


### PR DESCRIPTION
Fix bug in #2728.

Here, two bugs canceled each other out, which is why they weren't detected in the last test.

One bug is that the `capacity` was calculated but never actually used.  

The other bug is that the condition for `capacity *= 2` was incorrect. It should follow the precondition of `add`: `!(self.size > self.grow_at)`, not the condition checked in the `if` statement at the beginning of `add`: `self.size >= self.grow_at`.