### PR TITLE
feat: add a method to return a random boolean value

### DIFF
--- a/random/random.mbt
+++ b/random/random.mbt
@@ -189,6 +189,12 @@ pub fn Rand::float(self : Rand) -> Float {
 }
 
 ///|
+/// [boolean] returns a random boolean value (true or false).
+pub fn Rand::boolean(self : Rand) -> Bool {
+  self.int(limit=2) == 0
+}
+
+///|
 /// Generates a random positive `BigInt` with a specified number of bits.
 ///
 /// Parameters:

--- a/random/random_test.mbt
+++ b/random/random_test.mbt
@@ -82,3 +82,9 @@ test "bench random" (b : @bench.T) {
 
   })
 }
+
+///|
+test "boolean" {
+  let result = @random.Rand::new()
+  inspect(result.boolean(), content="false")
+}


### PR DESCRIPTION
- Implements a new method to generate a random boolean (true or false).
- The value is determined by generating a random integer in the range [0, 2), and returning true if the result is 0, and false otherwise.