### PR TITLE
move `op_lt` etc. into `Compare` to allow specialization

### DIFF
--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -43,6 +43,10 @@ fn[T, U] FixedArray::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?
 fn[T] FixedArray::op_add(Self[T], Self[T]) -> Self[T] // from trait `Add`
 #deprecated
 fn[T : Eq] FixedArray::op_equal(Self[T], Self[T]) -> Bool // from trait `Eq`
+fn[T : Compare] FixedArray::op_ge(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] FixedArray::op_gt(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] FixedArray::op_le(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] FixedArray::op_lt(Self[T], Self[T]) -> Bool // from trait `Compare`
 fn[T] FixedArray::rev(Self[T]) -> Self[T]
 fn[T] FixedArray::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 fn[T] FixedArray::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
@@ -162,6 +166,10 @@ fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
 fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?
 #deprecated
 fn[T : Eq] ArrayView::op_equal(Self[T], Self[T]) -> Bool // from trait `Eq`
+fn[T : Compare] ArrayView::op_ge(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] ArrayView::op_gt(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] ArrayView::op_le(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] ArrayView::op_lt(Self[T], Self[T]) -> Bool // from trait `Compare`
 fn[X : Show] ArrayView::output(Self[X], &Logger) -> Unit // from trait `Show`
 fn[A, B] ArrayView::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 fn[A, B] ArrayView::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -52,6 +52,10 @@ fn BigInt::op_add(Self, Self) -> Self // from trait `Add`
 fn BigInt::op_div(Self, Self) -> Self // from trait `Div`
 #deprecated
 fn BigInt::op_equal(Self, Self) -> Bool // from trait `Eq`
+fn BigInt::op_ge(Self, Self) -> Bool // from trait `Compare`
+fn BigInt::op_gt(Self, Self) -> Bool // from trait `Compare`
+fn BigInt::op_le(Self, Self) -> Bool // from trait `Compare`
+fn BigInt::op_lt(Self, Self) -> Bool // from trait `Compare`
 #deprecated
 fn BigInt::op_mod(Self, Self) -> Self // from trait `Mod`
 #deprecated

--- a/builtin/byte.mbt
+++ b/builtin/byte.mbt
@@ -122,6 +122,26 @@ pub impl Compare for Byte with compare(self : Byte, that : Byte) -> Int {
 }
 
 ///|
+pub impl Compare for Byte with op_lt(x, y) {
+  x.to_int() < y.to_int()
+}
+
+///|
+pub impl Compare for Byte with op_le(x, y) {
+  x.to_int() <= y.to_int()
+}
+
+///|
+pub impl Compare for Byte with op_gt(x, y) {
+  x.to_int() > y.to_int()
+}
+
+///|
+pub impl Compare for Byte with op_ge(x, y) {
+  x.to_int() >= y.to_int()
+}
+
+///|
 fn alphabet(x : Int) -> String {
   match x {
     0 => "0"

--- a/builtin/int64_nonjs.mbt
+++ b/builtin/int64_nonjs.mbt
@@ -516,6 +516,18 @@ pub impl Eq for Int64 with equal(self : Int64, other : Int64) -> Bool = "%i64_eq
 pub impl Compare for Int64 with compare(self, other) = "%i64_compare"
 
 ///|
+pub impl Compare for Int64 with op_lt(x, y) = "%i64.lt"
+
+///|
+pub impl Compare for Int64 with op_le(x, y) = "%i64.le"
+
+///|
+pub impl Compare for Int64 with op_gt(x, y) = "%i64.gt"
+
+///|
+pub impl Compare for Int64 with op_ge(x, y) = "%i64.ge"
+
+///|
 /// Returns the default value for `Int64` type, which is zero (0L).
 ///
 /// Returns a 64-bit signed integer with value 0.
@@ -1222,6 +1234,18 @@ pub impl Mod for UInt64 with mod(self, other) = "%u64.mod"
 ///   inspect(a.compare(a), content="0") // 42 = 42
 /// ```
 pub impl Compare for UInt64 with compare(self, other) = "%u64.compare"
+
+///|
+pub impl Compare for UInt64 with op_lt(x, y) = "%u64.lt"
+
+///|
+pub impl Compare for UInt64 with op_le(x, y) = "%u64.le"
+
+///|
+pub impl Compare for UInt64 with op_gt(x, y) = "%u64.gt"
+
+///|
+pub impl Compare for UInt64 with op_ge(x, y) = "%u64.ge"
 
 ///|
 /// Compares two unsigned 64-bit integers for equality.

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -663,6 +663,18 @@ pub impl Eq for Int with equal(self : Int, other : Int) -> Bool = "%i32_eq"
 pub impl Compare for Int with compare(self, other) = "%i32_compare"
 
 ///|
+pub impl Compare for Int with op_lt(x, y) = "%i32.lt"
+
+///|
+pub impl Compare for Int with op_le(x, y) = "%i32.le"
+
+///|
+pub impl Compare for Int with op_gt(x, y) = "%i32.gt"
+
+///|
+pub impl Compare for Int with op_ge(x, y) = "%i32.ge"
+
+///|
 pub fn Int::is_pos(self : Int) -> Bool = "%i32_is_pos"
 
 ///|
@@ -1026,6 +1038,18 @@ pub fn Double::op_neq(self : Double, other : Double) -> Bool = "%f64_ne"
 pub impl Compare for Double with compare(self, other) = "%f64_compare"
 
 ///|
+pub impl Compare for Double with op_lt(x, y) = "%f64.lt"
+
+///|
+pub impl Compare for Double with op_le(x, y) = "%f64.le"
+
+///|
+pub impl Compare for Double with op_gt(x, y) = "%f64.gt"
+
+///|
+pub impl Compare for Double with op_ge(x, y) = "%f64.ge"
+
+///|
 /// Returns the default value for double-precision floating-point numbers (0.0).
 ///
 /// Returns a `Double` value initialized to 0.0.
@@ -1155,6 +1179,18 @@ pub impl Eq for Char with equal(self : Char, other : Char) -> Bool = "%char_eq"
 ///   inspect('a'.compare('a'), content="0")
 /// ```
 pub impl Compare for Char with compare(self, other) = "%char_compare"
+
+///|
+pub impl Compare for Char with op_lt(x, y) = "%i32.lt"
+
+///|
+pub impl Compare for Char with op_le(x, y) = "%i32.le"
+
+///|
+pub impl Compare for Char with op_gt(x, y) = "%i32.gt"
+
+///|
+pub impl Compare for Char with op_ge(x, y) = "%i32.ge"
 
 ///|
 /// Returns the default value for the `Char` type, which is the null character
@@ -1882,6 +1918,18 @@ pub fn UInt::op_neq(self : UInt, other : UInt) -> Bool = "%u32.ne"
 pub impl Compare for UInt with compare(self, other) = "%u32.compare"
 
 ///|
+pub impl Compare for UInt with op_lt(x, y) = "%u32.lt"
+
+///|
+pub impl Compare for UInt with op_le(x, y) = "%u32.le"
+
+///|
+pub impl Compare for UInt with op_gt(x, y) = "%u32.gt"
+
+///|
+pub impl Compare for UInt with op_ge(x, y) = "%u32.ge"
+
+///|
 /// Performs a bitwise AND operation between two unsigned 32-bit integers. For
 /// each bit position, the result is 1 if the bits at that position in both
 /// operands are 1, and 0 otherwise.
@@ -2469,6 +2517,18 @@ pub fn Float::op_neq(self : Float, other : Float) -> Bool = "%f32.ne"
 ///   inspect(a.compare(a), content="0") // 3.14 = 3.14
 /// ```
 pub impl Compare for Float with compare(self, other) = "%f32.compare"
+
+///|
+pub impl Compare for Float with op_lt(x, y) = "%f32.lt"
+
+///|
+pub impl Compare for Float with op_le(x, y) = "%f32.le"
+
+///|
+pub impl Compare for Float with op_gt(x, y) = "%f32.gt"
+
+///|
+pub impl Compare for Float with op_ge(x, y) = "%f32.ge"
 
 ///|
 /// Converts a 32-bit floating-point number to a double-precision (64-bit)

--- a/builtin/op.mbt
+++ b/builtin/op.mbt
@@ -15,25 +15,25 @@
 ///|
 #coverage.skip
 pub fn[T : Compare] op_lt(self_ : T, other : T) -> Bool {
-  self_.compare(other).is_neg()
+  Compare::op_lt(self_, other)
 }
 
 ///|
 #coverage.skip
 pub fn[T : Compare] op_gt(self_ : T, other : T) -> Bool {
-  self_.compare(other).is_pos()
+  Compare::op_gt(self_, other)
 }
 
 ///|
 #coverage.skip
 pub fn[T : Compare] op_le(self_ : T, other : T) -> Bool {
-  self_.compare(other).is_non_pos()
+  Compare::op_le(self_, other)
 }
 
 ///|
 #coverage.skip
 pub fn[T : Compare] op_ge(self_ : T, other : T) -> Bool {
-  self_.compare(other).is_non_neg()
+  Compare::op_ge(self_, other)
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -123,6 +123,10 @@ fn[T] Array::new(capacity? : Int) -> Self[T]
 fn[T] Array::op_add(Self[T], Self[T]) -> Self[T] // from trait `Add`
 #deprecated
 fn[T : Eq] Array::op_equal(Self[T], Self[T]) -> Bool // from trait `Eq`
+fn[T : Compare] Array::op_ge(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] Array::op_gt(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] Array::op_le(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] Array::op_lt(Self[T], Self[T]) -> Bool // from trait `Compare`
 fn[X : Show] Array::output(Self[X], &Logger) -> Unit // from trait `Show`
 fn[T] Array::pop(Self[T]) -> T?
 fn[T] Array::push(Self[T], T) -> Unit
@@ -452,6 +456,10 @@ fn Bool::equal(Bool, Bool) -> Bool // from trait `Eq`
 fn Bool::op_compare(Bool, Bool) -> Int
 #deprecated
 fn Bool::op_equal(Bool, Bool) -> Bool // from trait `Eq`
+fn Bool::op_ge(Bool, Bool) -> Bool // from trait `Compare`
+fn Bool::op_gt(Bool, Bool) -> Bool // from trait `Compare`
+fn Bool::op_le(Bool, Bool) -> Bool // from trait `Compare`
+fn Bool::op_lt(Bool, Bool) -> Bool // from trait `Compare`
 fn Bool::output(Bool, &Logger) -> Unit // from trait `Show`
 fn Bool::to_json(Bool) -> Json // from trait `ToJson`
 fn Bool::to_string(Bool) -> String // from trait `Show`
@@ -479,6 +487,10 @@ fn Byte::op_add(Byte, Byte) -> Byte // from trait `Add`
 fn Byte::op_div(Byte, Byte) -> Byte // from trait `Div`
 #deprecated
 fn Byte::op_equal(Byte, Byte) -> Bool // from trait `Eq`
+fn Byte::op_ge(Byte, Byte) -> Bool // from trait `Compare`
+fn Byte::op_gt(Byte, Byte) -> Bool // from trait `Compare`
+fn Byte::op_le(Byte, Byte) -> Bool // from trait `Compare`
+fn Byte::op_lt(Byte, Byte) -> Bool // from trait `Compare`
 #deprecated
 fn Byte::op_mod(Byte, Byte) -> Byte // from trait `Mod`
 #deprecated
@@ -512,6 +524,10 @@ fn Char::equal(Char, Char) -> Bool // from trait `Eq`
 fn Char::from_int(Int) -> Char
 #deprecated
 fn Char::op_equal(Char, Char) -> Bool // from trait `Eq`
+fn Char::op_ge(Char, Char) -> Bool // from trait `Compare`
+fn Char::op_gt(Char, Char) -> Bool // from trait `Compare`
+fn Char::op_le(Char, Char) -> Bool // from trait `Compare`
+fn Char::op_lt(Char, Char) -> Bool // from trait `Compare`
 fn Char::to_int(Char) -> Int
 fn Char::to_uint(Char) -> UInt
 
@@ -554,6 +570,10 @@ fn Int::op_add(Int, Int) -> Int // from trait `Add`
 fn Int::op_div(Int, Int) -> Int // from trait `Div`
 #deprecated
 fn Int::op_equal(Int, Int) -> Bool // from trait `Eq`
+fn Int::op_ge(Int, Int) -> Bool // from trait `Compare`
+fn Int::op_gt(Int, Int) -> Bool // from trait `Compare`
+fn Int::op_le(Int, Int) -> Bool // from trait `Compare`
+fn Int::op_lt(Int, Int) -> Bool // from trait `Compare`
 #deprecated
 fn Int::op_mod(Int, Int) -> Int // from trait `Mod`
 #deprecated
@@ -624,6 +644,10 @@ fn Int64::op_add(Int64, Int64) -> Int64 // from trait `Add`
 fn Int64::op_div(Int64, Int64) -> Int64 // from trait `Div`
 #deprecated
 fn Int64::op_equal(Int64, Int64) -> Bool // from trait `Eq`
+fn Int64::op_ge(Int64, Int64) -> Bool // from trait `Compare`
+fn Int64::op_gt(Int64, Int64) -> Bool // from trait `Compare`
+fn Int64::op_le(Int64, Int64) -> Bool // from trait `Compare`
+fn Int64::op_lt(Int64, Int64) -> Bool // from trait `Compare`
 #deprecated
 fn Int64::op_mod(Int64, Int64) -> Int64 // from trait `Mod`
 #deprecated
@@ -683,6 +707,10 @@ fn UInt::op_add(UInt, UInt) -> UInt // from trait `Add`
 fn UInt::op_div(UInt, UInt) -> UInt // from trait `Div`
 #deprecated
 fn UInt::op_equal(UInt, UInt) -> Bool // from trait `Eq`
+fn UInt::op_ge(UInt, UInt) -> Bool // from trait `Compare`
+fn UInt::op_gt(UInt, UInt) -> Bool // from trait `Compare`
+fn UInt::op_le(UInt, UInt) -> Bool // from trait `Compare`
+fn UInt::op_lt(UInt, UInt) -> Bool // from trait `Compare`
 #deprecated
 fn UInt::op_mod(UInt, UInt) -> UInt // from trait `Mod`
 #deprecated
@@ -748,6 +776,10 @@ fn UInt64::op_add(UInt64, UInt64) -> UInt64 // from trait `Add`
 fn UInt64::op_div(UInt64, UInt64) -> UInt64 // from trait `Div`
 #deprecated
 fn UInt64::op_equal(UInt64, UInt64) -> Bool // from trait `Eq`
+fn UInt64::op_ge(UInt64, UInt64) -> Bool // from trait `Compare`
+fn UInt64::op_gt(UInt64, UInt64) -> Bool // from trait `Compare`
+fn UInt64::op_le(UInt64, UInt64) -> Bool // from trait `Compare`
+fn UInt64::op_lt(UInt64, UInt64) -> Bool // from trait `Compare`
 #deprecated
 fn UInt64::op_mod(UInt64, UInt64) -> UInt64 // from trait `Mod`
 #deprecated
@@ -793,6 +825,10 @@ fn Float::op_add(Float, Float) -> Float // from trait `Add`
 fn Float::op_div(Float, Float) -> Float // from trait `Div`
 #deprecated
 fn Float::op_equal(Float, Float) -> Bool // from trait `Eq`
+fn Float::op_ge(Float, Float) -> Bool // from trait `Compare`
+fn Float::op_gt(Float, Float) -> Bool // from trait `Compare`
+fn Float::op_le(Float, Float) -> Bool // from trait `Compare`
+fn Float::op_lt(Float, Float) -> Bool // from trait `Compare`
 #deprecated
 fn Float::op_mul(Float, Float) -> Float // from trait `Mul`
 #deprecated
@@ -825,6 +861,10 @@ fn Double::op_add(Double, Double) -> Double // from trait `Add`
 fn Double::op_div(Double, Double) -> Double // from trait `Div`
 #deprecated
 fn Double::op_equal(Double, Double) -> Bool // from trait `Eq`
+fn Double::op_ge(Double, Double) -> Bool // from trait `Compare`
+fn Double::op_gt(Double, Double) -> Bool // from trait `Compare`
+fn Double::op_le(Double, Double) -> Bool // from trait `Compare`
+fn Double::op_lt(Double, Double) -> Bool // from trait `Compare`
 #deprecated
 fn Double::op_mul(Double, Double) -> Double // from trait `Mul`
 #deprecated
@@ -941,6 +981,10 @@ fn Bytes::new(Int) -> Bytes
 fn Bytes::of_string(String) -> Bytes
 #deprecated
 fn Bytes::op_equal(Bytes, Bytes) -> Bool // from trait `Eq`
+fn Bytes::op_ge(Bytes, Bytes) -> Bool // from trait `Compare`
+fn Bytes::op_gt(Bytes, Bytes) -> Bool // from trait `Compare`
+fn Bytes::op_le(Bytes, Bytes) -> Bool // from trait `Compare`
+fn Bytes::op_lt(Bytes, Bytes) -> Bool // from trait `Compare`
 fn Bytes::to_unchecked_string(Bytes, offset? : Int, length? : Int) -> String
 fn Bytes::unsafe_get(Bytes, Int) -> Byte
 
@@ -953,6 +997,10 @@ fn[A : Hash, B : Hash] Tuple(2)::hash((A, B)) -> Int // from trait `Hash`
 fn[A : Hash, B : Hash] Tuple(2)::hash_combine((A, B), Hasher) -> Unit // from trait `Hash`
 #deprecated
 fn[T0 : Eq, T1 : Eq] Tuple(2)::op_equal((T0, T1), (T0, T1)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare] Tuple(2)::op_ge((T0, T1), (T0, T1)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare] Tuple(2)::op_gt((T0, T1), (T0, T1)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare] Tuple(2)::op_le((T0, T1), (T0, T1)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare] Tuple(2)::op_lt((T0, T1), (T0, T1)) -> Bool // from trait `Compare`
 fn[A : Show, B : Show] Tuple(2)::output((A, B), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson] Tuple(2)::to_json((A, B)) -> Json // from trait `ToJson`
 fn[A : Show, B : Show] Tuple(2)::to_string((A, B)) -> String // from trait `Show`
@@ -963,6 +1011,10 @@ fn[A : Hash, B : Hash, C : Hash] Tuple(3)::hash((A, B, C)) -> Int // from trait 
 fn[A : Hash, B : Hash, C : Hash] Tuple(3)::hash_combine((A, B, C), Hasher) -> Unit // from trait `Hash`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq] Tuple(3)::op_equal((T0, T1, T2), (T0, T1, T2)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_ge((T0, T1, T2), (T0, T1, T2)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_gt((T0, T1, T2), (T0, T1, T2)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_le((T0, T1, T2), (T0, T1, T2)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_lt((T0, T1, T2), (T0, T1, T2)) -> Bool // from trait `Compare`
 fn[A : Show, B : Show, C : Show] Tuple(3)::output((A, B, C), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson] Tuple(3)::to_json((A, B, C)) -> Json // from trait `ToJson`
 fn[A : Show, B : Show, C : Show] Tuple(3)::to_string((A, B, C)) -> String // from trait `Show`
@@ -973,6 +1025,10 @@ fn[A : Hash, B : Hash, C : Hash, D : Hash] Tuple(4)::hash((A, B, C, D)) -> Int /
 fn[A : Hash, B : Hash, C : Hash, D : Hash] Tuple(4)::hash_combine((A, B, C, D), Hasher) -> Unit // from trait `Hash`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq] Tuple(4)::op_equal((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_ge((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_gt((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_le((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_lt((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool // from trait `Compare`
 fn[A : Show, B : Show, C : Show, D : Show] Tuple(4)::output((A, B, C, D), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson] Tuple(4)::to_json((A, B, C, D)) -> Json // from trait `ToJson`
 fn[A : Show, B : Show, C : Show, D : Show] Tuple(4)::to_string((A, B, C, D)) -> String // from trait `Show`
@@ -983,6 +1039,10 @@ fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash] Tuple(5)::hash((A, B, C, D,
 fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash] Tuple(5)::hash_combine((A, B, C, D, E), Hasher) -> Unit // from trait `Hash`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq] Tuple(5)::op_equal((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_ge((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_gt((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_le((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_lt((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool // from trait `Compare`
 fn[A : Show, B : Show, C : Show, D : Show, E : Show] Tuple(5)::output((A, B, C, D, E), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson] Tuple(5)::to_json((A, B, C, D, E)) -> Json // from trait `ToJson`
 fn[A : Show, B : Show, C : Show, D : Show, E : Show] Tuple(5)::to_string((A, B, C, D, E)) -> String // from trait `Show`
@@ -993,6 +1053,10 @@ fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash] Tuple(6)::hash((A
 fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash] Tuple(6)::hash_combine((A, B, C, D, E, F), Hasher) -> Unit // from trait `Hash`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq] Tuple(6)::op_equal((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_ge((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_gt((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_le((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_lt((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool // from trait `Compare`
 fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Tuple(6)::output((A, B, C, D, E, F), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson] Tuple(6)::to_json((A, B, C, D, E, F)) -> Json // from trait `ToJson`
 fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Tuple(6)::to_string((A, B, C, D, E, F)) -> String // from trait `Show`
@@ -1003,6 +1067,10 @@ fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] Tuple(7
 fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] Tuple(7)::hash_combine((A, B, C, D, E, F, G), Hasher) -> Unit // from trait `Hash`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq] Tuple(7)::op_equal((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_ge((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_gt((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_le((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_lt((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool // from trait `Compare`
 fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show] Tuple(7)::output((A, B, C, D, E, F, G), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson] Tuple(7)::to_json((A, B, C, D, E, F, G)) -> Json // from trait `ToJson`
 fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show] Tuple(7)::to_string((A, B, C, D, E, F, G)) -> String // from trait `Show`
@@ -1011,6 +1079,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq] Tuple(8)::equal((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq] Tuple(8)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_le((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show] Tuple(8)::output((T0, T1, T2, T3, T4, T5, T6, T7), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson] Tuple(8)::to_json((A, B, C, D, E, F, G, H)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show] Tuple(8)::to_string((T0, T1, T2, T3, T4, T5, T6, T7)) -> String // from trait `Show`
@@ -1019,6 +1091,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq] Tuple(9)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq] Tuple(9)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show] Tuple(9)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson] Tuple(9)::to_json((A, B, C, D, E, F, G, H, I)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show] Tuple(9)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> String // from trait `Show`
@@ -1027,6 +1103,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq] Tuple(10)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq] Tuple(10)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show] Tuple(10)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson] Tuple(10)::to_json((A, B, C, D, E, F, G, H, I, J)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show] Tuple(10)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> String // from trait `Show`
@@ -1035,6 +1115,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq] Tuple(11)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq] Tuple(11)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show] Tuple(11)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson] Tuple(11)::to_json((A, B, C, D, E, F, G, H, I, J, K)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show] Tuple(11)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> String // from trait `Show`
@@ -1043,6 +1127,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq] Tuple(12)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq] Tuple(12)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show] Tuple(12)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson] Tuple(12)::to_json((A, B, C, D, E, F, G, H, I, J, K, L)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show] Tuple(12)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> String // from trait `Show`
@@ -1051,6 +1139,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq] Tuple(13)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq] Tuple(13)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show] Tuple(13)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson] Tuple(13)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show] Tuple(13)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> String // from trait `Show`
@@ -1059,6 +1151,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq] Tuple(14)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq] Tuple(14)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show] Tuple(14)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson] Tuple(14)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show] Tuple(14)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> String // from trait `Show`
@@ -1067,6 +1163,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq] Tuple(15)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq] Tuple(15)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show] Tuple(15)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson, O : ToJson] Tuple(15)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show] Tuple(15)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> String // from trait `Show`
@@ -1075,6 +1175,10 @@ fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Co
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq] Tuple(16)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool // from trait `Eq`
 #deprecated
 fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq] Tuple(16)::op_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool // from trait `Eq`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool // from trait `Compare`
+fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool // from trait `Compare`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show] Tuple(16)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), &Logger) -> Unit // from trait `Show`
 fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson, O : ToJson, P : ToJson] Tuple(16)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)) -> Json // from trait `ToJson`
 fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show] Tuple(16)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> String // from trait `Show`
@@ -1125,6 +1229,10 @@ impl BitXOr for UInt64
 
 pub(open) trait Compare : Eq {
   compare(Self, Self) -> Int
+  op_lt(Self, Self) -> Bool = _
+  op_gt(Self, Self) -> Bool = _
+  op_le(Self, Self) -> Bool = _
+  op_ge(Self, Self) -> Bool = _
 }
 impl Compare for Bool
 impl Compare for Byte

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -29,6 +29,30 @@ pub(open) trait Eq {
 /// - positive, if the first argument is greater
 pub(open) trait Compare: Eq {
   compare(Self, Self) -> Int
+  op_lt(Self, Self) -> Bool = _
+  op_gt(Self, Self) -> Bool = _
+  op_le(Self, Self) -> Bool = _
+  op_ge(Self, Self) -> Bool = _
+}
+
+///|
+impl Compare with op_lt(x, y) {
+  x.compare(y).is_neg()
+}
+
+///|
+impl Compare with op_gt(x, y) {
+  x.compare(y).is_pos()
+}
+
+///|
+impl Compare with op_le(x, y) {
+  x.compare(y).is_non_pos()
+}
+
+///|
+impl Compare with op_ge(x, y) {
+  x.compare(y).is_non_neg()
 }
 
 ///|

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -66,6 +66,10 @@ fn BytesView::iterator2(Self) -> Iterator[(Int, Byte)]
 fn BytesView::length(Self) -> Int
 #deprecated
 fn BytesView::op_equal(Self, Self) -> Bool // from trait `Eq`
+fn BytesView::op_ge(Self, Self) -> Bool // from trait `Compare`
+fn BytesView::op_gt(Self, Self) -> Bool // from trait `Compare`
+fn BytesView::op_le(Self, Self) -> Bool // from trait `Compare`
+fn BytesView::op_lt(Self, Self) -> Bool // from trait `Compare`
 fn BytesView::output(Self, &Logger) -> Unit // from trait `Show`
 fn BytesView::rev_find(Self, Self) -> Int?
 fn BytesView::start_offset(Self) -> Int

--- a/cmp/pkg.generated.mbti
+++ b/cmp/pkg.generated.mbti
@@ -26,6 +26,10 @@ fn[T : Hash] Reverse::hash_combine(Self[T], Hasher) -> Unit // from trait `Hash`
 fn[T] Reverse::inner(Self[T]) -> T
 #deprecated
 fn[T : Eq] Reverse::op_equal(Self[T], Self[T]) -> Bool // from trait `Eq`
+fn[T : Compare] Reverse::op_ge(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] Reverse::op_gt(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] Reverse::op_le(Self[T], Self[T]) -> Bool // from trait `Compare`
+fn[T : Compare] Reverse::op_lt(Self[T], Self[T]) -> Bool // from trait `Compare`
 fn[T : Show] Reverse::output(Self[T], &Logger) -> Unit // from trait `Show`
 fn[T : Show] Reverse::to_string(Self[T]) -> String // from trait `Show`
 impl[T : Compare] Compare for Reverse[T]

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -65,6 +65,10 @@ fn[A] Deque::of(FixedArray[A]) -> Self[A]
 fn[A] Deque::op_add(Self[A], Self[A]) -> Self[A] // from trait `Add`
 #deprecated
 fn[A : Eq] Deque::op_equal(Self[A], Self[A]) -> Bool // from trait `Eq`
+fn[A : Compare] Deque::op_ge(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] Deque::op_gt(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] Deque::op_le(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] Deque::op_lt(Self[A], Self[A]) -> Bool // from trait `Compare`
 fn[A : Show] Deque::output(Self[A], &Logger) -> Unit // from trait `Show`
 fn[A] Deque::pop_back(Self[A]) -> A?
 #deprecated

--- a/immut/array/pkg.generated.mbti
+++ b/immut/array/pkg.generated.mbti
@@ -54,6 +54,10 @@ fn[A] T::of(FixedArray[A]) -> Self[A]
 fn[A] T::op_add(Self[A], Self[A]) -> Self[A] // from trait `Add`
 #deprecated
 fn[A : Eq] T::op_equal(Self[A], Self[A]) -> Bool // from trait `Eq`
+fn[A : Compare] T::op_ge(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] T::op_gt(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] T::op_le(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] T::op_lt(Self[A], Self[A]) -> Bool // from trait `Compare`
 fn[A : Show] T::output(Self[A], &Logger) -> Unit // from trait `Show`
 fn[A] T::push(Self[A], A) -> Self[A]
 fn[A, B] T::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?

--- a/immut/list/pkg.generated.mbti
+++ b/immut/list/pkg.generated.mbti
@@ -144,6 +144,10 @@ fn[A] T::of(FixedArray[A]) -> Self[A]
 fn[A] T::op_add(Self[A], Self[A]) -> Self[A] // from trait `Add`
 #deprecated
 fn[A : Eq] T::op_equal(Self[A], Self[A]) -> Bool // from trait `Eq`
+fn[A : Compare] T::op_ge(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] T::op_gt(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] T::op_le(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] T::op_lt(Self[A], Self[A]) -> Bool // from trait `Compare`
 fn[A : Show] T::output(Self[A], &Logger) -> Unit // from trait `Show`
 #deprecated
 fn[A : Eq] T::remove(Self[A], A) -> Self[A]

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -33,6 +33,10 @@ fn[A] PriorityQueue::new() -> Self[A]
 fn[A : Compare] PriorityQueue::of(FixedArray[A]) -> Self[A]
 #deprecated
 fn[A : Compare] PriorityQueue::op_equal(Self[A], Self[A]) -> Bool // from trait `Eq`
+fn[A : Compare] PriorityQueue::op_ge(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] PriorityQueue::op_gt(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] PriorityQueue::op_le(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] PriorityQueue::op_lt(Self[A], Self[A]) -> Bool // from trait `Compare`
 fn[A : Show + Compare] PriorityQueue::output(Self[A], &Logger) -> Unit // from trait `Show`
 fn[A] PriorityQueue::peek(Self[A]) -> A?
 fn[A : Compare] PriorityQueue::pop(Self[A]) -> Self[A]?

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -66,6 +66,10 @@ fn[K, V] SortedMap::new() -> Self[K, V]
 fn[K : Compare, V] SortedMap::of(FixedArray[(K, V)]) -> Self[K, V]
 #deprecated
 fn[K : Eq, V : Eq] SortedMap::op_equal(Self[K, V], Self[K, V]) -> Bool // from trait `Eq`
+fn[K : Compare, V : Compare] SortedMap::op_ge(Self[K, V], Self[K, V]) -> Bool // from trait `Compare`
+fn[K : Compare, V : Compare] SortedMap::op_gt(Self[K, V], Self[K, V]) -> Bool // from trait `Compare`
+fn[K : Compare, V : Compare] SortedMap::op_le(Self[K, V], Self[K, V]) -> Bool // from trait `Compare`
+fn[K : Compare, V : Compare] SortedMap::op_lt(Self[K, V], Self[K, V]) -> Bool // from trait `Compare`
 fn[K : Show, V : Show] SortedMap::output(Self[K, V], &Logger) -> Unit // from trait `Show`
 fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Self[K, V]
 #alias(foldr_with_key)

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -59,6 +59,10 @@ fn[A : Compare] SortedSet::of(FixedArray[A]) -> Self[A]
 fn[A : Compare] SortedSet::op_add(Self[A], Self[A]) -> Self[A] // from trait `Add`
 #deprecated
 fn[A : Eq] SortedSet::op_equal(Self[A], Self[A]) -> Bool // from trait `Eq`
+fn[A : Compare] SortedSet::op_ge(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] SortedSet::op_gt(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] SortedSet::op_le(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] SortedSet::op_lt(Self[A], Self[A]) -> Bool // from trait `Compare`
 fn[A : Show] SortedSet::output(Self[A], &Logger) -> Unit // from trait `Show`
 fn[A : Compare] SortedSet::remove(Self[A], A) -> Self[A]
 fn[A] SortedSet::remove_min(Self[A]) -> Self[A]

--- a/int16/pkg.generated.mbti
+++ b/int16/pkg.generated.mbti
@@ -29,6 +29,10 @@ fn Int16::op_add(Int16, Int16) -> Int16 // from trait `Add`
 fn Int16::op_div(Int16, Int16) -> Int16 // from trait `Div`
 #deprecated
 fn Int16::op_equal(Int16, Int16) -> Bool // from trait `Eq`
+fn Int16::op_ge(Int16, Int16) -> Bool // from trait `Compare`
+fn Int16::op_gt(Int16, Int16) -> Bool // from trait `Compare`
+fn Int16::op_le(Int16, Int16) -> Bool // from trait `Compare`
+fn Int16::op_lt(Int16, Int16) -> Bool // from trait `Compare`
 #deprecated
 fn Int16::op_mod(Int16, Int16) -> Int16 // from trait `Mod`
 #deprecated

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -83,6 +83,10 @@ fn[A] List::of(FixedArray[A]) -> Self[A]
 fn[A] List::op_add(Self[A], Self[A]) -> Self[A] // from trait `Add`
 #deprecated
 fn[A : Eq] List::op_equal(Self[A], Self[A]) -> Bool // from trait `Eq`
+fn[A : Compare] List::op_ge(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] List::op_gt(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] List::op_le(Self[A], Self[A]) -> Bool // from trait `Compare`
+fn[A : Compare] List::op_lt(Self[A], Self[A]) -> Bool // from trait `Compare`
 fn[A : Show] List::output(Self[A], &Logger) -> Unit // from trait `Show`
 #alias(add)
 fn[A] List::prepend(Self[A], A) -> Self[A]

--- a/option/pkg.generated.mbti
+++ b/option/pkg.generated.mbti
@@ -38,6 +38,10 @@ fn[T] Option::iterator(T?) -> Iterator[T]
 fn[T, U] Option::map(T?, (T) -> U raise?) -> U? raise?
 fn[T, U] Option::map_or(T?, U, (T) -> U raise?) -> U raise?
 fn[T, U] Option::map_or_else(T?, () -> U raise?, (T) -> U raise?) -> U raise?
+fn[X : Compare] Option::op_ge(X?, X?) -> Bool // from trait `Compare`
+fn[X : Compare] Option::op_gt(X?, X?) -> Bool // from trait `Compare`
+fn[X : Compare] Option::op_le(X?, X?) -> Bool // from trait `Compare`
+fn[X : Compare] Option::op_lt(X?, X?) -> Bool // from trait `Compare`
 #deprecated
 fn[T] Option::or(T?, T) -> T
 #deprecated

--- a/rational/pkg.generated.mbti
+++ b/rational/pkg.generated.mbti
@@ -55,6 +55,10 @@ fn T::op_add(Self, Self) -> Self // from trait `Add`
 fn T::op_div(Self, Self) -> Self // from trait `Div`
 #deprecated
 fn T::op_equal(Self, Self) -> Bool // from trait `Eq`
+fn T::op_ge(Self, Self) -> Bool // from trait `Compare`
+fn T::op_gt(Self, Self) -> Bool // from trait `Compare`
+fn T::op_le(Self, Self) -> Bool // from trait `Compare`
+fn T::op_lt(Self, Self) -> Bool // from trait `Compare`
 #deprecated
 fn T::op_mul(Self, Self) -> Self // from trait `Mul`
 #deprecated

--- a/result/pkg.generated.mbti
+++ b/result/pkg.generated.mbti
@@ -28,6 +28,10 @@ fn[T, E] Result::is_err(Self[T, E]) -> Bool
 fn[T, E] Result::is_ok(Self[T, E]) -> Bool
 fn[T, E, U] Result::map(Self[T, E], (T) -> U) -> Self[U, E]
 fn[T, E, F] Result::map_err(Self[T, E], (E) -> F) -> Self[T, F]
+fn[T : Compare, E : Compare] Result::op_ge(Self[T, E], Self[T, E]) -> Bool // from trait `Compare`
+fn[T : Compare, E : Compare] Result::op_gt(Self[T, E], Self[T, E]) -> Bool // from trait `Compare`
+fn[T : Compare, E : Compare] Result::op_le(Self[T, E], Self[T, E]) -> Bool // from trait `Compare`
+fn[T : Compare, E : Compare] Result::op_lt(Self[T, E], Self[T, E]) -> Bool // from trait `Compare`
 fn[T, E] Result::or(Self[T, E], T) -> T
 fn[T, E] Result::or_else(Self[T, E], () -> T) -> T
 fn[T, E] Result::to_option(Self[T, E]) -> T?

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -44,6 +44,10 @@ fn String::iterator(String) -> Iterator[Char]
 fn String::iterator2(String) -> Iterator[(Int, Char)]
 fn String::lexical_compare(String, String) -> Int
 fn String::offset_of_nth_char(String, Int, start_offset? : Int, end_offset? : Int) -> Int?
+fn String::op_ge(String, String) -> Bool // from trait `Compare`
+fn String::op_gt(String, String) -> Bool // from trait `Compare`
+fn String::op_le(String, String) -> Bool // from trait `Compare`
+fn String::op_lt(String, String) -> Bool // from trait `Compare`
 fn String::pad_end(String, Int, Char) -> String
 fn String::pad_start(String, Int, Char) -> String
 fn String::repeat(String, Int) -> String
@@ -117,6 +121,10 @@ fn StringView::offset_of_nth_char(Self, Int) -> Int?
 fn StringView::op_add(Self, Self) -> Self // from trait `Add`
 #deprecated
 fn StringView::op_equal(Self, Self) -> Bool // from trait `Eq`
+fn StringView::op_ge(Self, Self) -> Bool // from trait `Compare`
+fn StringView::op_gt(Self, Self) -> Bool // from trait `Compare`
+fn StringView::op_le(Self, Self) -> Bool // from trait `Compare`
+fn StringView::op_lt(Self, Self) -> Bool // from trait `Compare`
 fn StringView::output(Self, &Logger) -> Unit // from trait `Show`
 fn StringView::pad_end(Self, Int, Char) -> String
 fn StringView::pad_start(Self, Int, Char) -> String

--- a/uint16/pkg.generated.mbti
+++ b/uint16/pkg.generated.mbti
@@ -30,6 +30,10 @@ fn UInt16::op_add(UInt16, UInt16) -> UInt16 // from trait `Add`
 fn UInt16::op_div(UInt16, UInt16) -> UInt16 // from trait `Div`
 #deprecated
 fn UInt16::op_equal(UInt16, UInt16) -> Bool // from trait `Eq`
+fn UInt16::op_ge(UInt16, UInt16) -> Bool // from trait `Compare`
+fn UInt16::op_gt(UInt16, UInt16) -> Bool // from trait `Compare`
+fn UInt16::op_le(UInt16, UInt16) -> Bool // from trait `Compare`
+fn UInt16::op_lt(UInt16, UInt16) -> Bool // from trait `Compare`
 #deprecated
 fn UInt16::op_mod(UInt16, UInt16) -> UInt16 // from trait `Mod`
 #deprecated

--- a/unit/pkg.generated.mbti
+++ b/unit/pkg.generated.mbti
@@ -11,6 +11,10 @@ fn Unit::compare(Unit, Unit) -> Int // from trait `Compare`
 fn Unit::default() -> Unit // from trait `Default`
 fn Unit::hash(Unit) -> Int // from trait `Hash`
 fn Unit::hash_combine(Unit, Hasher) -> Unit // from trait `Hash`
+fn Unit::op_ge(Unit, Unit) -> Bool // from trait `Compare`
+fn Unit::op_gt(Unit, Unit) -> Bool // from trait `Compare`
+fn Unit::op_le(Unit, Unit) -> Bool // from trait `Compare`
+fn Unit::op_lt(Unit, Unit) -> Bool // from trait `Compare`
 fn Unit::to_string(Unit) -> String
 impl Compare for Unit
 impl Default for Unit


### PR DESCRIPTION
This PR refactors the `Compare` trait and comparison operators `<`/`>`/`<=`/`>=`. Previously, the `Compare` trait only contains `compare`, and the four comparison operators are implemented via toplevel polymorphic functions. In this PR, the four comparison operators are added to the `Compare` trait directly (with default implementation). This allows users to specialize them (for example, use more efficient primitives for builtin type/new type of builtin types).

The old toplevel functions `fn op_lt` etc. are still kept for compatibility purpose. After the MoonBit compiler migrates to `Compare::op_lt` etc. for operator resolution, we can turn `fn op_lt` etc. into a deprecated `#as_free_fn` on `Compare::op_lt`.