### PR TITLE
Optimize Json stringify frame reuse

### DIFF
--- a/json/json.mbt
+++ b/json/json.mbt
@@ -99,8 +99,8 @@ fn indent_str(level : Int, indent : Int) -> String {
 ///|
 /// Internal stack frame used by iterative stringify to avoid recursion
 priv enum WriteFrame {
-  Array(Array[Json], Int, Int) // (arr, index, depth)
-  Object(Iterator[(String, Json)], Bool, Int) // (kvs, first, depth)
+  Array(Array[Json], mut i~ : Int, Int) // (arr, index, depth)
+  Object(Iterator[(String, Json)], mut first~ : Bool, Int) // (kvs, first, depth)
 }
 
 ///|
@@ -127,7 +127,9 @@ pub fn Json::stringify(
             buf.write_char('{')
             buf.write_string(indent_str(depth + 1, indent))
             // After child value printed, we resume from this frame
-            stack.push(WriteFrame::Object(members.iterator(), true, depth))
+            stack.push(
+              WriteFrame::Object(members.iterator(), first=true, depth),
+            )
             continue (None, depth)
           }
         Array(arr) =>
@@ -137,7 +139,7 @@ pub fn Json::stringify(
           } else {
             buf.write_char('[')
             buf.write_string(indent_str(depth + 1, indent))
-            stack.push(WriteFrame::Array(arr, 0, depth))
+            stack.push(WriteFrame::Array(arr, i=0, depth))
             continue (None, depth)
           }
         String(s) => {
@@ -169,50 +171,48 @@ pub fn Json::stringify(
       }
     (None, _) =>
       // No current node to write; try to resume a pending container
-      match stack.pop() {
-        Some(frame) =>
-          match frame {
-            WriteFrame::Array(arr, i, depth) =>
-              if i < arr.length() {
-                if i > 0 {
-                  buf.write_char(',')
-                  buf.write_string(indent_str(depth + 1, indent))
-                }
-                // Resume this array after the child is printed
-                stack.push(WriteFrame::Array(arr, i + 1, depth))
-                continue (Some(arr[i]), depth + 1)
-              } else {
-                buf.write_string(indent_str(depth, indent))
-                buf.write_char(']')
-                continue (None, depth)
-              }
-            WriteFrame::Object(iterator, first, depth) =>
-              match iterator.next() {
-                Some((k, v)) => {
-                  if !first {
-                    buf.write_char(',')
-                    buf.write_string(indent_str(depth + 1, indent))
-                  }
-                  buf
-                  ..write_char('\"')
-                  ..write_string(escape(k, escape_slash~))
-                  ..write_char('\"')
-                  ..write_char(':')
-                  if indent > 0 {
-                    buf.write_char(' ')
-                  }
-                  // Resume this object after the child is printed
-                  stack.push(WriteFrame::Object(iterator, false, depth))
-                  continue (Some(v), depth + 1)
-                }
-                None => {
-                  buf.write_string(indent_str(depth, indent))
-                  buf.write_char('}')
-                  continue (None, depth)
-                }
-              }
+      match stack {
+        [] => break
+        [.., WriteFrame::Array(arr, i~, depth) as frame] =>
+          if i < arr.length() {
+            if i > 0 {
+              buf.write_char(',')
+              buf.write_string(indent_str(depth + 1, indent))
+            }
+            let element = arr[i]
+            frame.i = i + 1
+            continue (Some(element), depth + 1)
+          } else {
+            ignore(stack.pop())
+            buf.write_string(indent_str(depth, indent))
+            buf.write_char(']')
+            continue (None, depth)
           }
-        None => break
+        [.., WriteFrame::Object(iterator, first~, depth) as frame] =>
+          match iterator.next() {
+            Some((k, v)) => {
+              if !first {
+                buf.write_char(',')
+                buf.write_string(indent_str(depth + 1, indent))
+              }
+              buf
+              ..write_char('\"')
+              ..write_string(escape(k, escape_slash~))
+              ..write_char('\"')
+              ..write_char(':')
+              if indent > 0 {
+                buf.write_char(' ')
+              }
+              frame.first = false
+              continue (Some(v), depth + 1)
+            }
+            None => {
+              ignore(stack.pop())
+              buf.write_string(indent_str(depth, indent))
+              buf.write_char('}')
+              continue (None, depth)
+            }
+          }
       }
   }
   buf.to_string()


### PR DESCRIPTION
## Summary
- reuse the active WriteFrame when resuming Json::stringify iteration
- avoid extra pop/push churn while preserving existing formatting behavior

## Testing
- moon test
