### PR TITLE
add `Iterator2` wrapper for two-variable `for .. in` loop

### DIFF
--- a/array/array.mbt
+++ b/array/array.mbt
@@ -328,6 +328,6 @@ pub fn[X] Array::rev_iterator(self : Array[X]) -> Iterator[X] {
 }
 
 ///|
-pub fn[X] Array::iterator2(self : Array[X]) -> Iterator[(Int, X)] {
+pub fn[X] Array::iterator2(self : Array[X]) -> Iterator2[Int, X] {
   self[:].iterator2()
 }

--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -122,7 +122,7 @@ fn[A, B] Array::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 fn[T] Array::from_iter(Iter[T]) -> Self[T]
 fn[T] Array::from_iterator(Iterator[T]) -> Self[T]
 fn[X] Array::iterator(Self[X]) -> Iterator[X]
-fn[X] Array::iterator2(Self[X]) -> Iterator[(Int, X)]
+fn[X] Array::iterator2(Self[X]) -> Iterator2[Int, X]
 fn[A : @string.ToStringView] Array::join(Self[A], StringView) -> String
 fn[A] Array::last(Self[A]) -> A?
 fn[T] Array::push_iter(Self[T], Iter[T]) -> Unit
@@ -160,7 +160,7 @@ fn[A : Hash] ArrayView::hash_combine(Self[A], Hasher) -> Unit // from trait `Has
 fn[A] ArrayView::iter(Self[A]) -> Iter[A]
 fn[A] ArrayView::iter2(Self[A]) -> Iter2[Int, A]
 fn[X] ArrayView::iterator(Self[X]) -> Iterator[X]
-fn[X] ArrayView::iterator2(Self[X]) -> Iterator[(Int, X)]
+fn[X] ArrayView::iterator2(Self[X]) -> Iterator2[Int, X]
 fn[A : @string.ToStringView] ArrayView::join(Self[A], StringView) -> String
 fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
 fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?

--- a/array/view.mbt
+++ b/array/view.mbt
@@ -195,9 +195,9 @@ pub fn[X] ArrayView::rev_iterator(self : ArrayView[X]) -> Iterator[X] {
 }
 
 ///|
-pub fn[X] ArrayView::iterator2(self : ArrayView[X]) -> Iterator[(Int, X)] {
+pub fn[X] ArrayView::iterator2(self : ArrayView[X]) -> Iterator2[Int, X] {
   let mut i = 0
-  Iterator::new(fn() {
+  Iterator2::new(fn() {
     guard i < self.length() else { None }
     let result = Some((i, self.unsafe_get(i)))
     i += 1

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -718,9 +718,9 @@ pub fn[X] Iterator::iter2(self : Iterator[X]) -> Iter2[Int, X] {
 }
 
 ///|
-pub fn[X] Iterator::iterator2(self : Iterator[X]) -> Iterator[(Int, X)] {
+pub fn[X] Iterator::iterator2(self : Iterator[X]) -> Iterator2[Int, X] {
   let mut i = 0
-  fn() {
+  Iterator2::new(fn() {
     match self.next() {
       None => None
       Some(x) => {
@@ -729,7 +729,7 @@ pub fn[X] Iterator::iterator2(self : Iterator[X]) -> Iterator[(Int, X)] {
         result
       }
     }
-  }
+  })
 }
 
 ///|
@@ -882,4 +882,31 @@ pub fn[X : Compare] Iterator::minimum(self : Iterator[X]) -> X? {
     }
   }
   res
+}
+
+///|
+/// This type is used for `for _, _ in ..` loop
+/// (`for .. in` loop with two loop variables),
+/// and should not be used directly in general.
+pub(all) struct Iterator2[X, Y](Iterator[(X, Y)])
+
+///|
+pub fn[X, Y] Iterator2::new(f : () -> (X, Y)?) -> Iterator2[X, Y] {
+  Iterator2(Iterator::new(f))
+}
+
+///|
+#alias(iterator2)
+pub fn[X, Y] Iterator2::iterator(self : Iterator2[X, Y]) -> Iterator[(X, Y)] {
+  self.0
+}
+
+///|
+pub fn[X, Y] Iterator2::next(self : Iterator2[X, Y]) -> (X, Y)? {
+  self.0.next()
+}
+
+///|
+pub impl[X : Show, Y : Show] Show for Iterator2[X, Y] with output(self, logger) {
+  self.0.output(logger)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -308,7 +308,7 @@ fn[X] Iterator::intersperse(Self[X], X) -> Self[X]
 fn[X] Iterator::iter(Self[X]) -> Iter[X]
 fn[X] Iterator::iter2(Self[X]) -> Iter2[Int, X]
 fn[X] Iterator::iterator(Self[X]) -> Self[X]
-fn[X] Iterator::iterator2(Self[X]) -> Self[(Int, X)]
+fn[X] Iterator::iterator2(Self[X]) -> Iterator2[Int, X]
 fn Iterator::join(Self[String], String) -> String
 #deprecated
 fn[X] Iterator::just_run(Self[X], (X) -> IterResult) -> Unit
@@ -342,6 +342,17 @@ fn[X : Show] Iterator::to_string(Self[X]) -> String // from trait `Show`
 impl[T] Add for Iterator[T]
 impl[X : Show] Show for Iterator[X]
 impl[X : ToJson] ToJson for Iterator[X]
+
+pub(all) struct Iterator2[X, Y](Iterator[(X, Y)])
+#deprecated
+fn[X, Y] Iterator2::inner(Self[X, Y]) -> Iterator[(X, Y)]
+#alias(iterator2)
+fn[X, Y] Iterator2::iterator(Self[X, Y]) -> Iterator[(X, Y)]
+fn[X, Y] Iterator2::new(() -> (X, Y)?) -> Self[X, Y]
+fn[X, Y] Iterator2::next(Self[X, Y]) -> (X, Y)?
+fn[X : Show, Y : Show] Iterator2::output(Self[X, Y], &Logger) -> Unit // from trait `Show`
+fn[X : Show, Y : Show] Iterator2::to_string(Self[X, Y]) -> String // from trait `Show`
+impl[X : Show, Y : Show] Show for Iterator2[X, Y]
 
 pub enum Json {
   Null

--- a/bytes/bytes.mbt
+++ b/bytes/bytes.mbt
@@ -329,7 +329,7 @@ pub fn Bytes::iter2(self : Bytes) -> Iter2[Int, Byte] {
 ///   inspect(buf, content="b'\\x61'b'\\x62'b'\\x63'b'\\x64'b'\\x65'")
 ///   inspect(keys, content="[0, 1, 2, 3, 4]")
 /// ```
-pub fn Bytes::iterator2(self : Bytes) -> Iterator[(Int, Byte)] {
+pub fn Bytes::iterator2(self : Bytes) -> Iterator2[Int, Byte] {
   let mut i = 0
   let len = self.length()
   Iterator::new(fn() {

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -24,7 +24,7 @@ fn Bytes::hash_combine(Bytes, Hasher) -> Unit // from trait `Hash`
 fn Bytes::iter(Bytes) -> Iter[Byte]
 fn Bytes::iter2(Bytes) -> Iter2[Int, Byte]
 fn Bytes::iterator(Bytes) -> Iterator[Byte]
-fn Bytes::iterator2(Bytes) -> Iterator[(Int, Byte)]
+fn Bytes::iterator2(Bytes) -> Iterator2[Int, Byte]
 #as_free_fn
 fn Bytes::of(FixedArray[Byte]) -> Bytes
 #deprecated
@@ -62,7 +62,7 @@ fn BytesView::hash(Self) -> Int // from trait `Hash`
 fn BytesView::hash_combine(Self, Hasher) -> Unit // from trait `Hash`
 fn BytesView::iter(Self) -> Iter[Byte]
 fn BytesView::iterator(Self) -> Iterator[Byte]
-fn BytesView::iterator2(Self) -> Iterator[(Int, Byte)]
+fn BytesView::iterator2(Self) -> Iterator2[Int, Byte]
 fn BytesView::length(Self) -> Int
 #deprecated
 fn BytesView::op_equal(Self, Self) -> Bool // from trait `Eq`

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -256,10 +256,10 @@ pub fn BytesView::iterator(self : BytesView) -> Iterator[Byte] {
 ///   inspect(buf, content="b'\\x61'b'\\x62'b'\\x63'b'\\x64'b'\\x65'")
 ///   inspect(keys, content="[0, 1, 2, 3, 4]")
 /// ```
-pub fn BytesView::iterator2(self : BytesView) -> Iterator[(Int, Byte)] {
+pub fn BytesView::iterator2(self : BytesView) -> Iterator2[Int, Byte] {
   let mut i = 0
   let len = self.length()
-  Iterator::new(fn() {
+  Iterator2::new(fn() {
     guard i < len else { None }
     let result = (i, self.unsafe_get(i))
     i += 1

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -116,7 +116,7 @@ test "iterator2" {
   let bs = b"\x00\x01\x02\x03\x04\x05"
   let bv = bs[1:5]
   inspect(
-    bv.iterator2().to_array(),
+    bv.iterator2(),
     content="[(0, b'\\x01'), (1, b'\\x02'), (2, b'\\x03'), (3, b'\\x04')]",
   )
 }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1507,9 +1507,9 @@ pub fn[A] Deque::iter2(self : Deque[A]) -> Iter2[Int, A] {
 ///   }
 ///   inspect(sum, content="80") // 0*10 + 1*20 + 2*30 = 80
 /// ```
-pub fn[A] Deque::iterator2(self : Deque[A]) -> Iterator[(Int, A)] {
+pub fn[A] Deque::iterator2(self : Deque[A]) -> Iterator2[Int, A] {
   let mut index = 0
-  Iterator::new(fn() {
+  Iterator2::new(fn() {
     guard index < self.len else { None }
     let result = (index, self.buf[(self.head + index) % self.buf.length()])
     index += 1
@@ -1653,9 +1653,9 @@ pub fn[A] Deque::rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
 ///   }
 ///   inspect(s, content="0:3 1:2 2:1 ")
 /// ```
-pub fn[A] Deque::rev_iterator2(self : Deque[A]) -> Iterator[(Int, A)] {
+pub fn[A] Deque::rev_iterator2(self : Deque[A]) -> Iterator2[Int, A] {
   let mut rev_index = self.len
-  Iterator::new(fn() {
+  Iterator2::new(fn() {
     guard rev_index > 0 else { None }
     let index = self.len - rev_index
     rev_index -= 1

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -561,7 +561,7 @@ test "iterator2 when tail needs to wrap around" {
   dq.push_back(2) // tail = 1
   dq.unsafe_pop_front() // head = 1
   dq.push_back(3) // tail = 0 (wraps around)
-  inspect(dq.iterator2().to_array(), content="[(0, 2), (1, 3)]")
+  inspect(dq.iterator2(), content="[(0, 2), (1, 3)]")
 }
 
 ///|
@@ -600,10 +600,7 @@ test "rev_iterator2 when head needs to wrap around" {
   for i in 3..=6 {
     dq.push_back(i)
   }
-  inspect(
-    dq.rev_iterator2().to_array(),
-    content="[(0, 6), (1, 5), (2, 4), (3, 3)]",
-  )
+  inspect(dq.rev_iterator2(), content="[(0, 6), (1, 5), (2, 4), (3, 3)]")
 }
 
 ///|

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -52,7 +52,7 @@ fn[A] Deque::is_empty(Self[A]) -> Bool
 fn[A] Deque::iter(Self[A]) -> Iter[A]
 fn[A] Deque::iter2(Self[A]) -> Iter2[Int, A]
 fn[A] Deque::iterator(Self[A]) -> Iterator[A]
-fn[A] Deque::iterator2(Self[A]) -> Iterator[(Int, A)]
+fn[A] Deque::iterator2(Self[A]) -> Iterator2[Int, A]
 fn Deque::join(Self[String], StringView) -> String
 fn[A] Deque::length(Self[A]) -> Int
 fn[A, U] Deque::map(Self[A], (A) -> U) -> Self[U]
@@ -89,7 +89,7 @@ fn[A] Deque::rev_inplace(Self[A]) -> Unit
 fn[A] Deque::rev_iter(Self[A]) -> Iter[A]
 fn[A] Deque::rev_iter2(Self[A]) -> Iter2[Int, A]
 fn[A] Deque::rev_iterator(Self[A]) -> Iterator[A]
-fn[A] Deque::rev_iterator2(Self[A]) -> Iterator[(Int, A)]
+fn[A] Deque::rev_iterator2(Self[A]) -> Iterator2[Int, A]
 fn[A : Eq] Deque::search(Self[A], A) -> Int?
 #alias("_[_]=_")
 fn[A] Deque::set(Self[A], Int, A) -> Unit

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1591,10 +1591,10 @@ pub fn[A] List::iter2(self : List[A]) -> Iter2[Int, A] {
 /// let iter = ls.iterator2()
 /// inspect(iter, content="[(0, 10), (1, 20), (2, 30)]")
 /// ```
-pub fn[A] List::iterator2(self : List[A]) -> Iterator[(Int, A)] {
+pub fn[A] List::iterator2(self : List[A]) -> Iterator2[Int, A] {
   let mut i = 0
   let mut next = self
-  Iterator::new(fn() {
+  Iterator2::new(fn() {
     match next {
       Empty => None
       More(head, tail~) => {

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -64,7 +64,7 @@ fn[A : Eq] List::is_suffix(Self[A], Self[A]) -> Bool
 fn[A] List::iter(Self[A]) -> Iter[A]
 fn[A] List::iter2(Self[A]) -> Iter2[Int, A]
 fn[A] List::iterator(Self[A]) -> Iterator[A]
-fn[A] List::iterator2(Self[A]) -> Iterator[(Int, A)]
+fn[A] List::iterator2(Self[A]) -> Iterator2[Int, A]
 fn[A] List::last(Self[A]) -> A?
 fn[A] List::length(Self[A]) -> Int
 fn[A : Eq, B] List::lookup(Self[(A, B)], A) -> B?

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -41,7 +41,7 @@ fn String::is_empty(String) -> Bool
 fn String::iter(String) -> Iter[Char]
 fn String::iter2(String) -> Iter2[Int, Char]
 fn String::iterator(String) -> Iterator[Char]
-fn String::iterator2(String) -> Iterator[(Int, Char)]
+fn String::iterator2(String) -> Iterator2[Int, Char]
 fn String::lexical_compare(String, String) -> Int
 fn String::offset_of_nth_char(String, Int, start_offset? : Int, end_offset? : Int) -> Int?
 fn String::op_ge(String, String) -> Bool // from trait `Compare`
@@ -112,7 +112,7 @@ fn StringView::is_empty(Self) -> Bool
 fn StringView::iter(Self) -> Iter[Char]
 fn StringView::iter2(Self) -> Iter2[Int, Char]
 fn StringView::iterator(Self) -> Iterator[Char]
-fn StringView::iterator2(Self) -> Iterator[(Int, Char)]
+fn StringView::iterator2(Self) -> Iterator2[Int, Char]
 fn StringView::length(Self) -> Int
 fn StringView::lexical_compare(Self, Self) -> Int
 fn StringView::make(Int, Char) -> Self

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -196,7 +196,7 @@ pub fn String::iter2(self : String) -> Iter2[Int, Char] {
 }
 
 ///|
-pub fn String::iterator2(self : String) -> Iterator[(Int, Char)] {
+pub fn String::iterator2(self : String) -> Iterator2[Int, Char] {
   self.iterator().iterator2()
 }
 

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -294,10 +294,11 @@ test "iter2" {
 
 ///|
 test "iterator2" {
-  let mut str = ""
-  "A😊𠮷BA😊𠮷B"
-  .iterator2()
-  .each(pair => str += "\{pair.0}: \{pair.1.to_int()} \n")
+  let str = StringBuilder::new()
+  let it = "A😊𠮷BA😊𠮷B".iterator2()
+  while it.next() is Some((i, c)) {
+    str.write_string("\{i}: \{c.to_int()} \n")
+  }
   inspect(
     str,
     content=(

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -279,12 +279,12 @@ pub fn StringView::iter2(self : StringView) -> Iter2[Int, Char] {
 }
 
 ///|
-pub fn StringView::iterator2(self : StringView) -> Iterator[(Int, Char)] {
+pub fn StringView::iterator2(self : StringView) -> Iterator2[Int, Char] {
   let start = self.start()
   let end = self.end()
   let mut index = start
   let mut char_index = 0
-  Iterator::new(fn() {
+  Iterator2::new(fn() {
     guard index < end else { None }
     let c1 = self.str().unsafe_charcode_at(index)
     if c1.is_leading_surrogate() && index + 1 < self.end() {

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -649,7 +649,7 @@ test "iterator2" {
   let str = "aa😭b😂cc"
   let view = str.view(start_offset=1, end_offset=8)
   inspect(
-    view.iterator2().iter().collect(),
+    view.iterator2(),
     content="[(0, 'a'), (1, '😭'), (2, 'b'), (3, '😂'), (4, 'c')]",
   )
 }


### PR DESCRIPTION
This PR introduces a thin wrapper type:
```rust
pub(all) struct Iterator2[X, Y] (Iterator[(X, Y)])
```
This is the analog to `Iter2` of internal iterator. The type itself is not very useful, and people should use `Iterator` directly in general. However, we need a special type to identify `for .. in` loops with two loop variables.