### PR TITLE
feat: add `Char::length` method and rename `Char::utf16_len`

### DIFF
--- a/char/char.mbt
+++ b/char/char.mbt
@@ -512,6 +512,7 @@ pub impl ToJson for Char with to_json(self : Char) -> Json {
 /// inspect('🌟'.utf16_len(), content="2")
 /// ```
 ///
+#deprecated("Use `Char::length` instead.")
 pub fn Char::utf16_len(self : Self) -> Int {
   let code = self.to_int()
   if code <= 0xFFFF {
@@ -519,6 +520,42 @@ pub fn Char::utf16_len(self : Self) -> Int {
   } else {
     2
   }
+}
+
+///|
+/// Returns the number of UTF-16 code units (1 or 2) needed to represent this
+/// character.
+/// Note surrogate pairs are counted as 2, it should not happen in general since
+/// surrogate pair is Int instead of Char.
+/// Example:
+///
+/// ```moonbit
+/// inspect('A'.length(), content="1")
+/// inspect('🌟'.length(), content="2")
+/// ```
+///
+pub fn Char::length(self : Self) -> Int {
+  let code = self.to_int()
+  if code <= 0xFFFF {
+    1
+  } else {
+    2
+  }
+}
+
+///|
+/// Returns the character length, which is always 1.
+///
+/// This function is provided for consistency with `String::char_length`.
+///
+/// Example:
+///
+/// ```moonbit
+/// inspect('A'.char_length(), content="1")
+/// inspect('🌟'.char_length(), content="1")
+/// ```
+pub fn Char::char_length(_self : Self) -> Int {
+  1
 }
 
 ///|

--- a/char/pkg.generated.mbti
+++ b/char/pkg.generated.mbti
@@ -6,6 +6,7 @@ package "moonbitlang/core/char"
 // Errors
 
 // Types and methods
+fn Char::char_length(Char) -> Int
 fn Char::hash(Char) -> Int // from trait `Hash`
 fn Char::hash_combine(Char, Hasher) -> Unit // from trait `Hash`
 fn Char::is_ascii(Char) -> Bool
@@ -25,11 +26,13 @@ fn Char::is_digit(Char, UInt) -> Bool
 fn Char::is_numeric(Char) -> Bool
 fn Char::is_printable(Char) -> Bool
 fn Char::is_whitespace(Char) -> Bool
+fn Char::length(Char) -> Int
 fn Char::output(Char, &Logger) -> Unit // from trait `Show`
 fn Char::to_ascii_lowercase(Char) -> Char
 fn Char::to_ascii_uppercase(Char) -> Char
 fn Char::to_json(Char) -> Json // from trait `ToJson`
 fn Char::to_string(Char) -> String // from trait `Show`
+#deprecated
 fn Char::utf16_len(Char) -> Int
 impl Hash for Char
 impl Show for Char

--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -90,7 +90,7 @@ fn ParseContext::lex_value(
         if c > '\u{7f}' && non_ascii_whitespace.contains(c) {
           continue
         }
-        let shift = -c.utf16_len()
+        let shift = -c.length()
         ctx.invalid_char(shift~)
       }
       None => raise InvalidEof


### PR DESCRIPTION
Based on #2856.
Renaming `Char::utf16_len` to `Char::length` will no longer cause confusion when using `String::length` and `Char::length`.And the `Char::char_length` will always return `1`.