### PR TITLE
fix incorrect return type for some `iterator2` methods

### DIFF
--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -896,9 +896,13 @@ pub fn[X, Y] Iterator2::new(f : () -> (X, Y)?) -> Iterator2[X, Y] {
 }
 
 ///|
-#alias(iterator2)
 pub fn[X, Y] Iterator2::iterator(self : Iterator2[X, Y]) -> Iterator[(X, Y)] {
   self.0
+}
+
+///|
+pub fn[X, Y] Iterator2::iterator2(self : Iterator2[X, Y]) -> Iterator2[X, Y] {
+  self
 }
 
 ///|

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -566,7 +566,6 @@ pub fn[K, V] Map::iter(self : Map[K, V]) -> Iter[(K, V)] {
 
 ///|
 /// Returns the iterator of the hash map, provide elements in the order of insertion.
-#alias(iterator2)
 pub fn[K, V] Map::iterator(self : Map[K, V]) -> Iterator[(K, V)] {
   let mut curr_entry = self.head
   Iterator::new(fn() {
@@ -578,6 +577,11 @@ pub fn[K, V] Map::iterator(self : Map[K, V]) -> Iterator[(K, V)] {
       None => None
     }
   })
+}
+
+///|
+pub fn[K, V] Map::iterator2(self : Map[K, V]) -> Iterator2[K, V] {
+  self.iterator()
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -346,8 +346,8 @@ impl[X : ToJson] ToJson for Iterator[X]
 pub(all) struct Iterator2[X, Y](Iterator[(X, Y)])
 #deprecated
 fn[X, Y] Iterator2::inner(Self[X, Y]) -> Iterator[(X, Y)]
-#alias(iterator2)
 fn[X, Y] Iterator2::iterator(Self[X, Y]) -> Iterator[(X, Y)]
+fn[X, Y] Iterator2::iterator2(Self[X, Y]) -> Self[X, Y]
 fn[X, Y] Iterator2::new(() -> (X, Y)?) -> Self[X, Y]
 fn[X, Y] Iterator2::next(Self[X, Y]) -> (X, Y)?
 fn[X : Show, Y : Show] Iterator2::output(Self[X, Y], &Logger) -> Unit // from trait `Show`
@@ -397,8 +397,8 @@ fn[K : Hash + Eq, V] Map::get_or_init(Self[K, V], K, () -> V) -> V
 fn[K, V] Map::is_empty(Self[K, V]) -> Bool
 fn[K, V] Map::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] Map::iter2(Self[K, V]) -> Iter2[K, V]
-#alias(iterator2)
 fn[K, V] Map::iterator(Self[K, V]) -> Iterator[(K, V)]
+fn[K, V] Map::iterator2(Self[K, V]) -> Iterator2[K, V]
 fn[K, V] Map::keys(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 fn[K, V] Map::length(Self[K, V]) -> Int

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -36,8 +36,8 @@ fn[K : Hash + Eq, V] HashMap::get_or_init(Self[K, V], K, () -> V) -> V
 fn[K, V] HashMap::is_empty(Self[K, V]) -> Bool
 fn[K, V] HashMap::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] HashMap::iter2(Self[K, V]) -> Iter2[K, V]
-#alias(iterator2)
 fn[K, V] HashMap::iterator(Self[K, V]) -> Iterator[(K, V)]
+fn[K, V] HashMap::iterator2(Self[K, V]) -> Iterator2[K, V]
 fn[K, V] HashMap::keys(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 fn[K, V] HashMap::length(Self[K, V]) -> Int

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -96,7 +96,6 @@ pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
 ///   inspect(pairs.contains((1, "one")), content="true")
 ///   inspect(pairs.contains((2, "two")), content="true")
 /// ```
-#alias(iterator2)
 pub fn[K, V] HashMap::iterator(self : HashMap[K, V]) -> Iterator[(K, V)] {
   let mut i = 0
   let len = self.entries.length()
@@ -111,6 +110,20 @@ pub fn[K, V] HashMap::iterator(self : HashMap[K, V]) -> Iterator[(K, V)] {
       None
     }
   })
+}
+
+///|
+/// Returns an iterator over the key-value pairs in the map.
+///
+/// Parameters:
+///
+/// * `map` : The hash map to iterate over.
+///
+/// Returns an iterator that yields tuples of `(key, value)` for each entry in
+/// the map, in unspecified order.
+/// This is mainly used for `for _, _ in ..` loops.
+pub fn[K, V] HashMap::iterator2(self : HashMap[K, V]) -> Iterator2[K, V] {
+  self.iterator()
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -648,7 +648,6 @@ pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
 
 ///|
 /// Converted to Iterator
-#alias(iterator2)
 pub fn[K, V] HashMap::iterator(self : HashMap[K, V]) -> Iterator[(K, V)] {
   enum CurrNode {
     Tree(Node[K, V])
@@ -690,6 +689,12 @@ pub fn[K, V] HashMap::iterator(self : HashMap[K, V]) -> Iterator[(K, V)] {
       Bucket(Empty) | Tree(Branch(_)) => None
     }
   })
+}
+
+///|
+/// Convert to `Iterator2`
+pub fn[K, V] HashMap::iterator2(self : HashMap[K, V]) -> Iterator2[K, V] {
+  self.iterator()
 }
 
 ///|

--- a/immut/hashmap/pkg.generated.mbti
+++ b/immut/hashmap/pkg.generated.mbti
@@ -40,8 +40,8 @@ fn[K : Eq, V] HashMap::intersection(Self[K, V], Self[K, V]) -> Self[K, V]
 fn[K : Eq, V] HashMap::intersection_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?) -> Self[K, V] raise?
 fn[K, V] HashMap::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] HashMap::iter2(Self[K, V]) -> Iter2[K, V]
-#alias(iterator2)
 fn[K, V] HashMap::iterator(Self[K, V]) -> Iterator[(K, V)]
+fn[K, V] HashMap::iterator2(Self[K, V]) -> Iterator2[K, V]
 fn[K, V] HashMap::keys(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 fn[K, V] HashMap::length(Self[K, V]) -> Int

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -48,8 +48,8 @@ fn[K : Hash, V : Hash] SortedMap::hash_combine(Self[K, V], Hasher) -> Unit // fr
 fn[K, V] SortedMap::is_empty(Self[K, V]) -> Bool
 fn[K, V] SortedMap::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] SortedMap::iter2(Self[K, V]) -> Iter2[K, V]
-#alias(iterator2)
 fn[K, V] SortedMap::iterator(Self[K, V]) -> Iterator[(K, V)]
+fn[K, V] SortedMap::iterator2(Self[K, V]) -> Iterator2[K, V]
 #deprecated
 fn[K, V] SortedMap::keys(Self[K, V]) -> Array[K]
 fn[K, V] SortedMap::keys_as_iter(Self[K, V]) -> Iter[K]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -248,7 +248,6 @@ pub fn[K, V] SortedMap::iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
 }
 
 ///|
-#alias(iterator2)
 pub fn[K, V] SortedMap::iterator(self : SortedMap[K, V]) -> Iterator[(K, V)] {
   let mut curr_node = self
   let parents = []
@@ -269,6 +268,11 @@ pub fn[K, V] SortedMap::iterator(self : SortedMap[K, V]) -> Iterator[(K, V)] {
       Empty => None
     }
   })
+}
+
+///|
+pub fn[K, V] SortedMap::iterator2(self : SortedMap[K, V]) -> Iterator2[K, V] {
+  self.iterator()
 }
 
 ///|

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -283,7 +283,6 @@ pub fn[K, V] SortedMap::iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
 }
 
 ///|
-#alias(iterator2)
 pub fn[K, V] SortedMap::iterator(self : SortedMap[K, V]) -> Iterator[(K, V)] {
   let todo_list = []
   let mut next_node = self.root
@@ -300,6 +299,11 @@ pub fn[K, V] SortedMap::iterator(self : SortedMap[K, V]) -> Iterator[(K, V)] {
       None => None
     }
   })
+}
+
+///|
+pub fn[K, V] SortedMap::iterator2(self : SortedMap[K, V]) -> Iterator2[K, V] {
+  self.iterator()
 }
 
 ///|

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -33,8 +33,8 @@ fn[K : Compare, V] SortedMap::get(Self[K, V], K) -> V?
 fn[K, V] SortedMap::is_empty(Self[K, V]) -> Bool
 fn[K, V] SortedMap::iter(Self[K, V]) -> Iter[(K, V)]
 fn[K, V] SortedMap::iter2(Self[K, V]) -> Iter2[K, V]
-#alias(iterator2)
 fn[K, V] SortedMap::iterator(Self[K, V]) -> Iterator[(K, V)]
+fn[K, V] SortedMap::iterator2(Self[K, V]) -> Iterator2[K, V]
 #deprecated
 fn[K, V] SortedMap::keys(Self[K, V]) -> Array[K]
 fn[K, V] SortedMap::keys_as_iter(Self[K, V]) -> Iter[K]


### PR DESCRIPTION
Continuation of #2859. Some `iterator2` methods still have incorrect return type, this PR fixes them. All `iterator2` methods should return `Iterator2[X, Y]` so that `for _, _ in ..` loop will work correctly in the future.