### PR TITLE
export `Iterator2` in `@prelude`

### DIFF
--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -75,6 +75,8 @@ pub typealias @builtin.IterResult as IterResult
 
 pub typealias @builtin.Iterator as Iterator
 
+pub typealias @builtin.Iterator2 as Iterator2
+
 pub typealias @builtin.Json as Json
 
 pub typealias @builtin.Map as Map

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -61,6 +61,7 @@ pub using @builtin {
   type Iter,
   type Iterator,
   type Iter2,
+  type Iterator2,
   type IterResult,
   type Json,
   type Map,


### PR DESCRIPTION
so that people outside core can use the type directly