### PR TITLE
remove usage of deprecated local alias

### DIFF
--- a/builtin/output.mbt
+++ b/builtin/output.mbt
@@ -31,9 +31,7 @@ fn Int64::output(self : Int64, logger : &Logger, radix? : Int = 10) -> Unit {
     if num2 != 0L {
       write_digits(num2)
     }
-    logger.write_char(
-      ALPHABET.charcode_at(abs(num % radix).to_int()).unsafe_to_char(),
-    )
+    logger.write_char(ALPHABET.at(abs(num % radix).to_int()).unsafe_to_char())
   }
 
   write_digits(abs(self))
@@ -72,7 +70,7 @@ fn UInt::output(self : UInt, logger : &Logger, radix? : Int = 10) -> Unit {
       write_digits(num2)
     }
     logger.write_char(
-      ALPHABET.charcode_at((num % radix).reinterpret_as_int()).unsafe_to_char(),
+      ALPHABET.at((num % radix).reinterpret_as_int()).unsafe_to_char(),
     )
   }
 
@@ -87,9 +85,7 @@ fn UInt64::output(self : UInt64, logger : &Logger, radix? : Int = 10) -> Unit {
     if num2 != 0UL {
       write_digits(num2)
     }
-    logger.write_char(
-      ALPHABET.charcode_at((num % radix).to_int()).unsafe_to_char(),
-    )
+    logger.write_char(ALPHABET.at((num % radix).to_int()).unsafe_to_char())
   }
 
   write_digits(self)

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -19,7 +19,7 @@ pub impl[K, V] Default for SortedMap[K, V] with default() {
 
 ///|
 pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V] with equal(self, other) -> Bool {
-  guard self.size() == other.size() else { return false }
+  guard self.length() == other.length() else { return false }
   let iter = self.iterator()
   let iter1 = other.iterator()
   while iter.next() is Some(a) && iter1.next() is Some(b) {
@@ -34,7 +34,9 @@ pub impl[K : Compare, V : Compare] Compare for SortedMap[K, V] with compare(
   self,
   other,
 ) -> Int {
-  guard self.size() == other.size() else { return self.size() - other.size() }
+  guard self.length() == other.length() else {
+    return self.length() - other.length()
+  }
   let iter = self.iterator()
   let iter1 = other.iterator()
   while iter.next() is Some(a) && iter1.next() is Some(b) {

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -83,7 +83,7 @@ test {
 pub impl[A : Eq] Eq for SortedSet[A] with equal(self, other) -> Bool {
   // There's no `Iter::zip` (https://github.com/moonbitlang/core/issues/994#issuecomment-2350935193),
   // so we have to use the manual implementation below:
-  guard self.size() == other.size() else { return false }
+  guard self.length() == other.length() else { return false }
   let iter = self.iterator()
   let iter1 = other.iterator()
   while iter.next() is Some(a) && iter1.next() is Some(b) {
@@ -95,8 +95,8 @@ pub impl[A : Eq] Eq for SortedSet[A] with equal(self, other) -> Bool {
 
 ///|
 pub impl[A : Compare] Compare for SortedSet[A] with compare(self, other) -> Int {
-  let my_size = self.size()
-  let other_size = other.size()
+  let my_size = self.length()
+  let other_size = other.length()
   guard my_size == other_size else { return my_size - other_size }
   let iter = self.iterator()
   let iter1 = other.iterator()

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -41,7 +41,7 @@ pub fn[K : Compare, V] SortedMap::from_array(
 ) -> SortedMap[K, V] {
   let map = { root: None, size: 0 }
   for e in entries {
-    map.add(e.0, e.1)
+    map.set(e.0, e.1)
   }
   map
 }
@@ -541,12 +541,12 @@ test "of" {
 ///|
 test "add1" {
   let map = new()
-  map.add(6, "a")
-  map.add(5, "b")
-  map.add(4, "c")
-  map.add(3, "d")
-  map.add(2, "e")
-  map.add(1, "f")
+  map.set(6, "a")
+  map.set(5, "b")
+  map.set(4, "c")
+  map.set(3, "d")
+  map.set(2, "e")
+  map.set(1, "f")
   inspect(
     map.debug_tree(),
     content="([3]3,d,([2]2,e,([1]1,f,_,_),_),([2]5,b,([1]4,c,_,_),([1]6,a,_,_)))",
@@ -557,12 +557,12 @@ test "add1" {
 ///|
 test "add2" {
   let map = new()
-  map.add(1, "a")
-  map.add(2, "b")
-  map.add(3, "c")
-  map.add(4, "d")
-  map.add(5, "e")
-  map.add(6, "f")
+  map.set(1, "a")
+  map.set(2, "b")
+  map.set(3, "c")
+  map.set(4, "d")
+  map.set(5, "e")
+  map.set(6, "f")
   inspect(
     map.debug_tree(),
     content="([3]4,d,([2]2,b,([1]1,a,_,_),([1]3,c,_,_)),([2]5,e,_,([1]6,f,_,_)))",
@@ -573,10 +573,10 @@ test "add2" {
 ///|
 test "add3" {
   let map = new()
-  map.add(4, "a")
-  map.add(1, "b")
-  map.add(3, "c")
-  map.add(2, "d")
+  map.set(4, "a")
+  map.set(1, "b")
+  map.set(3, "c")
+  map.set(2, "d")
   inspect(
     map.debug_tree(),
     content="([3]3,c,([2]1,b,_,([1]2,d,_,_)),([1]4,a,_,_))",
@@ -586,10 +586,10 @@ test "add3" {
 ///|
 test "add4" {
   let map = new()
-  map.add(1, "a")
-  map.add(4, "b")
-  map.add(2, "c")
-  map.add(3, "d")
+  map.set(1, "a")
+  map.set(4, "b")
+  map.set(2, "c")
+  map.set(3, "d")
   inspect(
     map.debug_tree(),
     content="([3]2,c,([1]1,a,_,_),([2]4,b,([1]3,d,_,_),_))",
@@ -600,7 +600,7 @@ test "add4" {
 test "add duplicate key" {
   let map = from_array([(3, "c"), (2, "b"), (1, "a")])
   inspect(map.debug_tree(), content="([2]2,b,([1]1,a,_,_),([1]3,c,_,_))")
-  map.add(1, "x")
+  map.set(1, "x")
   inspect(map.debug_tree(), content="([2]2,b,([1]1,x,_,_),([1]3,c,_,_))")
 }
 

--- a/string/utils.mbt
+++ b/string/utils.mbt
@@ -20,21 +20,21 @@ fn code_point_of_surrogate_pair(leading : Int, trailing : Int) -> Char {
 ///|
 test "code_point_of_surrogate_pair" {
   let s = "😀"
-  let leading = s.charcode_at(0)
-  let trailing = s.charcode_at(1)
+  let leading = s.at(0)
+  let trailing = s.at(1)
   inspect(code_point_of_surrogate_pair(leading, trailing), content="😀")
 }
 
 ///|
 test "is_leading_surrogate" {
-  inspect("🤣".charcode_at(0).is_leading_surrogate(), content="true")
-  inspect("🤣".charcode_at(1).is_leading_surrogate(), content="false")
+  inspect("🤣".at(0).is_leading_surrogate(), content="true")
+  inspect("🤣".at(1).is_leading_surrogate(), content="false")
 }
 
 ///|
 test "is_trailing_surrogate" {
-  inspect("🤣".charcode_at(0).is_trailing_surrogate(), content="false")
-  inspect("🤣".charcode_at(1).is_trailing_surrogate(), content="true")
+  inspect("🤣".at(0).is_trailing_surrogate(), content="false")
+  inspect("🤣".at(1).is_trailing_surrogate(), content="true")
 }
 
 ///|


### PR DESCRIPTION
Remove usage of locally deprecated alias. Previously the compiler does not report deprecation for local usage of deprecated `#alias`, but this will change in the future. This PR migrates core in advance.