### PR TITLE
Refactor and deprecate various types and functions across multiple modules

### DIFF
--- a/array/view.mbt
+++ b/array/view.mbt
@@ -25,7 +25,7 @@
 /// inspect(view.length(), content="3")
 /// ```
 #deprecated
-pub typealias ArrayView as View
+pub type View[T] = ArrayView[T]
 
 ///|
 /// Iterates over each element in the array view and applies a function to it.

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -16,14 +16,12 @@
 priv trait OpaqueValue {}
 
 ///|
+#alias(T)
 struct Bench {
   buffer : StringBuilder
   summaries : Array[Summary]
   mut _storage : &OpaqueValue
 }
-
-///|
-pub typealias Bench as T
 
 ///|
 #as_free_fn

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -35,6 +35,7 @@
 ///     ),
 ///   )
 /// ```
+#alias(T, deprecated)
 struct Buffer {
   mut data : FixedArray[Byte]
   mut len : Int

--- a/buffer/deprecated.mbt
+++ b/buffer/deprecated.mbt
@@ -11,8 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-/// Extensible buffer.
-#deprecated("Use type `Buffer` instead")
-pub typealias Buffer as T

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -27,7 +27,7 @@
 /// ```
 #builtin.valtype
 #deprecated("Use `BytesView` instead")
-pub typealias BytesView as View
+pub type View = BytesView
 
 ///|
 fn BytesView::bytes(self : BytesView) -> Bytes = "%bytesview.bytes"

--- a/deque/deprecated.mbt
+++ b/deque/deprecated.mbt
@@ -31,9 +31,3 @@ pub fn[A] Deque::pop_back_exn(self : Deque[A]) -> Unit {
 pub fn[A] Deque::filter_map_inplace(self : Deque[A], f : (A) -> A?) -> Unit {
   self.retain_map(f)
 }
-
-///|
-#deprecated("Use `Deque` instead of `T`")
-pub typealias Deque as T
-
-///|

--- a/deque/types.mbt
+++ b/deque/types.mbt
@@ -15,6 +15,7 @@
 // head and tail point to non-empty slots. When the buffer is empty, head and tail points to the same slot.
 
 ///|
+#alias(T, deprecated)
 struct Deque[A] {
   mut buf : UninitializedArray[A]
   mut len : Int

--- a/hashmap/deprecated.mbt
+++ b/hashmap/deprecated.mbt
@@ -11,7 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `HashMap` instead of `T`")
-pub typealias HashMap as T

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -38,6 +38,7 @@ priv struct Entry[K, V] {
 ///   map.set(3, "updated")
 ///   assert_eq(map.get(3), Some("updated"))
 /// ```
+#alias(T, deprecated)
 struct HashMap[K, V] {
   mut entries : FixedArray[Entry[K, V]?]
   mut capacity : Int

--- a/hashset/deprecated.mbt
+++ b/hashset/deprecated.mbt
@@ -18,7 +18,3 @@
 pub fn[K : Hash + Eq] HashSet::insert(self : HashSet[K], key : K) -> Unit {
   self.add(key)
 }
-
-///|
-#deprecated("Use `HashSet` instead of `T`")
-pub typealias HashSet as T

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -35,6 +35,7 @@ priv struct Entry[K] {
 ///   set.add((4, "four"))
 ///   assert_eq(set.contains((4, "four")), true)
 /// ```
+#alias(T, deprecated)
 struct HashSet[K] {
   mut entries : FixedArray[Entry[K]?]
   mut size : Int // active key count

--- a/immut/hashmap/deprecated.mbt
+++ b/immut/hashmap/deprecated.mbt
@@ -44,7 +44,3 @@ pub fn[K, V, A] HashMap::map(
 ) -> HashMap[K, A] raise? {
   self.map_with_key((_k, v) => f(v))
 }
-
-///|
-#deprecated("Use `HashMap` instead of `T`")
-pub typealias HashMap as T

--- a/immut/hashmap/types.mbt
+++ b/immut/hashmap/types.mbt
@@ -25,4 +25,5 @@ priv enum Node[K, V] {
 }
 
 ///|
+#alias(T, deprecated)
 struct HashMap[K, V](Node[K, V]?) derive(Eq)

--- a/immut/hashset/deprecated.mbt
+++ b/immut/hashset/deprecated.mbt
@@ -11,7 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `Set` instead of `T`")
-pub typealias HashSet as T

--- a/immut/hashset/types.mbt
+++ b/immut/hashset/types.mbt
@@ -25,4 +25,5 @@ priv enum Node[A] {
 }
 
 ///|
+#alias(T, deprecated)
 struct HashSet[A](Node[A]?) derive(Eq)

--- a/immut/priority_queue/deprecated.mbt
+++ b/immut/priority_queue/deprecated.mbt
@@ -20,7 +20,3 @@ pub fn[A : Compare] PriorityQueue::pop_exn(
 ) -> PriorityQueue[A] {
   self.unsafe_pop()
 }
-
-///|
-#deprecated("Use `PriorityQueue` instead of `T`")
-pub typealias PriorityQueue as T

--- a/immut/priority_queue/types.mbt
+++ b/immut/priority_queue/types.mbt
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 ///|
+#alias(T, deprecated)
 struct PriorityQueue[A] {
   node : Node[A]
   size : Int

--- a/immut/sorted_map/deprecated.mbt
+++ b/immut/sorted_map/deprecated.mbt
@@ -81,7 +81,3 @@ pub fn[K, V] SortedMap::filter(
 ) -> SortedMap[K, V] raise? {
   self.filter_with_key((_, v) => pred(v))
 }
-
-///|
-#deprecated("Use `SortedMap` instead of `T`")
-pub typealias SortedMap as T

--- a/immut/sorted_map/types.mbt
+++ b/immut/sorted_map/types.mbt
@@ -32,6 +32,7 @@
 ///   assert_eq(map3.get(3), None)
 ///   assert_eq(map3.get(2), Some("updated"))
 /// ```
+#alias(T, deprecated)
 enum SortedMap[K, V] {
   Empty
   Tree(K, value~ : V, size~ : Int, SortedMap[K, V], SortedMap[K, V])

--- a/immut/sorted_set/deprecated.mbt
+++ b/immut/sorted_set/deprecated.mbt
@@ -37,7 +37,3 @@ pub fn[A : Compare] SortedSet::diff(
 ) -> SortedSet[A] {
   self.difference(other)
 }
-
-///|
-#deprecated("Use `SortedSet` instead of `T`")
-pub typealias SortedSet as T

--- a/immut/sorted_set/types.mbt
+++ b/immut/sorted_set/types.mbt
@@ -18,6 +18,7 @@
 
 ///|
 /// ImmutableSets are represented by balanced binary trees (the heights of the children differ by at most 2).
+#alias(T, deprecated)
 enum SortedSet[A] {
   Empty
   Node(left~ : SortedSet[A], right~ : SortedSet[A], size~ : Int, value~ : A)

--- a/json/deprecated.mbt
+++ b/json/deprecated.mbt
@@ -11,7 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Definition of json is moved to builtin package, use `Json` instead")
-pub typealias Json as JsonValue

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -1,10 +1,6 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/json"
 
-import(
-  "moonbitlang/core/builtin"
-)
-
 // Values
 fn[T : FromJson] from_json(Json, path? : JsonPath) -> T raise JsonDecodeError
 
@@ -66,7 +62,6 @@ impl Show for Json
 impl ToJson for Json
 
 // Type aliases
-pub using @builtin {type Json as JsonValue}
 
 // Traits
 pub(open) trait FromJson {

--- a/list/deprecated.mbt
+++ b/list/deprecated.mbt
@@ -41,7 +41,3 @@ pub fn[A] List::tail(self : List[A]) -> List[A] {
     More(_, tail~) => tail
   }
 }
-
-///|
-#deprecated("Use List instead of T")
-pub typealias List as T

--- a/list/types.mbt
+++ b/list/types.mbt
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 ///|
+#alias(T, deprecated)
 pub enum List[A] {
   Empty
   More(A, mut tail~ : List[A])

--- a/queue/deprecated.mbt
+++ b/queue/deprecated.mbt
@@ -25,7 +25,3 @@ pub fn[A] Queue::peek_exn(self : Queue[A]) -> A {
 pub fn[A] Queue::pop_exn(self : Queue[A]) -> A {
   self.unsafe_pop()
 }
-
-///|
-#deprecated("use `Queue` instead of `T`")
-pub typealias Queue as T

--- a/queue/types.mbt
+++ b/queue/types.mbt
@@ -22,6 +22,7 @@ priv struct Cons[A] {
 // - length == 0 <=> first is None && last is None
 
 ///|
+#alias(T, deprecated)
 struct Queue[A] {
   mut length : Int
   mut first : Cons[A]?

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -29,7 +29,3 @@ pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Array[V] {
   self.each(fn(_k, v) { values.push(v) })
   values
 }
-
-///|
-#deprecated("Use `SortedMap` instead of `T`")
-pub typealias SortedMap as T

--- a/sorted_map/types.mbt
+++ b/sorted_map/types.mbt
@@ -22,6 +22,7 @@ priv struct Node[K, V] {
 }
 
 ///|
+#alias(T, deprecated)
 struct SortedMap[K, V] {
   mut root : Node[K, V]?
   mut size : Int

--- a/sorted_set/deprecated.mbt
+++ b/sorted_set/deprecated.mbt
@@ -46,7 +46,3 @@ pub fn[V : Compare] SortedSet::intersect(
 ) -> SortedSet[V] {
   self.intersection(src)
 }
-
-///|
-#deprecated("Use `SortedSet` instead of `T`")
-pub typealias SortedSet as T

--- a/sorted_set/types.mbt
+++ b/sorted_set/types.mbt
@@ -17,6 +17,7 @@
 // All operations over sets are purely applicative (no side-effects).
 
 ///|
+#alias(T, deprecated)
 struct SortedSet[V] {
   mut root : Node[V]?
   mut size : Int

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -1,10 +1,6 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/string"
 
-import(
-  "moonbitlang/core/builtin"
-)
-
 // Values
 fn default() -> String
 
@@ -145,7 +141,6 @@ impl Show for StringView
 impl ToJson for StringView
 
 // Type aliases
-pub using @builtin {type StringView as View}
 
 // Traits
 pub trait ToStringView {

--- a/string/regex/internal/regexp/internal/vm/impl_wbtest.mbt
+++ b/string/regex/internal/regexp/internal/vm/impl_wbtest.mbt
@@ -51,7 +51,7 @@ test "lazy capture" {
 }
 
 ///|
-test "priority" (t : @test.T) {
+test "priority" (t : @test.Test) {
   // (a.*)(b.*)(c.*)
   let instructions = [
     Save(0),

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -13,14 +13,6 @@
 // limitations under the License.
 
 ///|
-/// `StringView` represents a view of a String that maintains proper Unicode
-/// character boundaries. It allows safe access to a substring while handling 
-/// multi-byte characters correctly.
-#builtin.valtype
-#deprecated("Use `StringView` instead")
-pub typealias StringView as View
-
-///|
 /// Returns the source string being viewed.
 fn StringView::str(self : StringView) -> String = "%stringview.str"
 

--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -15,7 +15,7 @@ fn[T : Show] same_object(T, T, loc~ : SourceLoc) -> Unit raise
 // Errors
 
 // Types and methods
-#alias(T)
+#alias(T, deprecated)
 type Test
 fn Test::name(Self) -> String
 #as_free_fn

--- a/test/types.mbt
+++ b/test/types.mbt
@@ -13,14 +13,11 @@
 // limitations under the License.
 
 ///|
+#alias(T, deprecated)
 struct Test {
   name : String
   buffer : StringBuilder
 }
-
-///|
-// TODO: deprecate it in the future
-pub typealias Test as T
 
 ///|
 #as_free_fn


### PR DESCRIPTION
- Updated `json` module:
  - Removed deprecated typealias for `Json`.
  - Adjusted `pkg.generated.mbti` to reflect changes in the `builtin` package.

- Updated `list` module:
  - Deprecated `List::tail` in favor of `unsafe_tail`.
  - Removed deprecated typealias for `List`.

- Updated `queue` module:
  - Deprecated `Queue::peek_exn` and `Queue::pop_exn` in favor of `unsafe_peek` and `unsafe_pop`.
  - Removed deprecated typealias for `Queue`.

- Updated `sorted_map` module:
  - Deprecated `SortedMap::keys` and `SortedMap::values` in favor of `keys_as_iter` and `values_as_iter`.
  - Removed deprecated typealias for `SortedMap`.

- Updated `sorted_set` module:
  - Deprecated `SortedSet::intersect` in favor of `intersection`.
  - Removed deprecated typealias for `SortedSet`.

- Updated `string` module:
  - Removed deprecated typealias for `StringView`.
  - Adjusted `pkg.generated.mbti` to reflect changes in the `builtin` package.

- Updated `test` module:
  - Removed deprecated typealias for `Test`.
  - Added deprecation alias for `is_not`.

- Updated `types` in various modules to include deprecation aliases for better clarity and future-proofing.
