### PR TITLE
feat: add intrinsic annotation

### DIFF
--- a/array/unsafe_bytes.mbt
+++ b/array/unsafe_bytes.mbt
@@ -34,7 +34,7 @@
 /// - `bytes[index+1]` ← bits 8-15
 /// - ...
 /// - `bytes[index+7]` ← bits 56-63 (most significant)
-// #intrinsic("%bytes.unsafe_write_uint64_le")
+#intrinsic("%bytes.unsafe_write_uint64_le")
 pub fn FixedArray::unsafe_write_uint64_le(
   bytes : FixedArray[Byte],
   index : Int,
@@ -67,7 +67,7 @@ pub fn FixedArray::unsafe_write_uint64_le(
 /// - `bytes[index+1]` ← bits 48-55
 /// - ...
 /// - `bytes[index+7]` ← bits 0-7 (least significant)
-// #intrinsic("%bytes.unsafe_write_uint64_be")
+#intrinsic("%bytes.unsafe_write_uint64_be")
 pub fn FixedArray::unsafe_write_uint64_be(
   bytes : FixedArray[Byte],
   index : Int,
@@ -100,7 +100,7 @@ pub fn FixedArray::unsafe_write_uint64_be(
 /// - `bytes[index+1]` ← bits 8-15
 /// - `bytes[index+2]` ← bits 16-23
 /// - `bytes[index+3]` ← bits 24-31 (most significant)
-// #intrinsic("%bytes.unsafe_write_uint32_le")
+#intrinsic("%bytes.unsafe_write_uint32_le")
 pub fn FixedArray::unsafe_write_uint32_le(
   bytes : FixedArray[Byte],
   index : Int,
@@ -133,7 +133,7 @@ pub fn FixedArray::unsafe_write_uint32_le(
 /// - `bytes[index+1]` ← bits 16-23
 /// - `bytes[index+2]` ← bits 8-15
 /// - `bytes[index+3]` ← bits 0-7 (least significant)
-// #intrinsic("%bytes.unsafe_write_uint32_be")
+#intrinsic("%bytes.unsafe_write_uint32_be")
 pub fn FixedArray::unsafe_write_uint32_be(
   bytes : FixedArray[Byte],
   index : Int,
@@ -164,7 +164,7 @@ pub fn FixedArray::unsafe_write_uint32_be(
 /// Writes 2 bytes starting at `index` in little-endian order:
 /// - `bytes[index]` ← bits 0-7 (least significant)
 /// - `bytes[index+1]` ← bits 8-15 (most significant)
-// #intrinsic("%bytes.unsafe_write_uint16_le")
+#intrinsic("%bytes.unsafe_write_uint16_le")
 pub fn FixedArray::unsafe_write_uint16_le(
   bytes : FixedArray[Byte],
   index : Int,
@@ -195,7 +195,7 @@ pub fn FixedArray::unsafe_write_uint16_le(
 /// Writes 2 bytes starting at `index` in big-endian order:
 /// - `bytes[index]` ← bits 8-15 (most significant)
 /// - `bytes[index+1]` ← bits 0-7 (least significant)
-// #intrinsic("%bytes.unsafe_write_uint16_be")
+#intrinsic("%bytes.unsafe_write_uint16_be")
 pub fn FixedArray::unsafe_write_uint16_be(
   bytes : FixedArray[Byte],
   index : Int,

--- a/bytes/unsafe_bytes.mbt
+++ b/bytes/unsafe_bytes.mbt
@@ -151,7 +151,7 @@ pub fn Bytes::unsafe_read_uint32_be(bytes : Bytes, index : Int) -> UInt {
 /// Reads 2 bytes starting at `index` and interprets them as a UInt16 in little-endian order:
 /// - `bytes[index]` → bits 0-7 (least significant)
 /// - `bytes[index+1]` → bits 8-15 (most significant)
-// #intrinsic("%bytes.unsafe_read_uint16_le")
+#intrinsic("%bytes.unsafe_read_uint16_le")
 pub fn Bytes::unsafe_read_uint16_le(bytes : Bytes, index : Int) -> UInt16 {
   let mut result : UInt16 = 0
   for i in 0..=1 {
@@ -179,7 +179,7 @@ pub fn Bytes::unsafe_read_uint16_le(bytes : Bytes, index : Int) -> UInt16 {
 /// Reads 2 bytes starting at `index` and interprets them as a UInt16 in big-endian order:
 /// - `bytes[index]` → bits 8-15 (most significant)
 /// - `bytes[index+1]` → bits 0-7 (least significant)
-// #intrinsic("%bytes.unsafe_read_uint16_be")
+#intrinsic("%bytes.unsafe_read_uint16_be")
 pub fn Bytes::unsafe_read_uint16_be(bytes : Bytes, index : Int) -> UInt16 {
   let mut result : UInt16 = 0
   for i in 0..=1 {


### PR DESCRIPTION
Add intrinsic annotation to `unsafe_{read|write}_uint{16|32|64}_{be|le}`. These intrinsics will optimize the code to one read/write instruction if possible.