### PR TITLE
add signed extraction for single bit

### DIFF
--- a/array/bitstring.mbt
+++ b/array/bitstring.mbt
@@ -49,6 +49,24 @@ pub fn ArrayView::unsafe_extract_bit(
 }
 
 ///|
+/// Extract a single bit.
+#internal(experimental, "subject to breaking change without notice")
+pub fn ArrayView::unsafe_extract_bit_signed(
+  bs : ArrayView[Byte],
+  offset : Int,
+  _len : Int,
+) -> Int {
+  let byte_index = offset >> 3
+  let bit_mask = (1 << (7 - (offset & 7))).to_byte()
+  // TODO: branchless for performance
+  if (bs.unsafe_get(byte_index) & bit_mask) != 0 {
+    -1
+  } else {
+    0
+  }
+}
+
+///|
 /// Extract [2..8] bits.
 #internal(experimental, "subject to breaking change without notice")
 pub fn ArrayView::unsafe_extract_byte(

--- a/array/bitstring_test.mbt
+++ b/array/bitstring_test.mbt
@@ -454,6 +454,20 @@ test "FixedArray extract view" {
 }
 
 ///|
+test "extract bit signed" {
+  let bytes : ArrayView[Byte] = [0xAA]
+  let view = bytes[:]
+  inspect(view.unsafe_extract_bit_signed(0, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(1, 1), content="0")
+  inspect(view.unsafe_extract_bit_signed(2, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(3, 1), content="0")
+  inspect(view.unsafe_extract_bit_signed(4, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(5, 1), content="0")
+  inspect(view.unsafe_extract_bit_signed(6, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(7, 1), content="0")
+}
+
+///|
 test "extract byte signed" {
   let bs1 : BytesView = b"\x7F\xFF\x80\x00\xAA\x55"
   let bs2 : ArrayView[Byte] = [0x7F, 0xFF, 0x80, 0x00, 0xAA, 0x55]

--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -153,6 +153,7 @@ fn[X] ArrayView::rev_iterator(Self[X]) -> Iterator[X]
 fn[T] ArrayView::start_offset(Self[T]) -> Int
 fn[T] ArrayView::to_array(Self[T]) -> Array[T]
 fn ArrayView::unsafe_extract_bit(Self[Byte], Int, Int) -> UInt
+fn ArrayView::unsafe_extract_bit_signed(Self[Byte], Int, Int) -> Int
 fn ArrayView::unsafe_extract_byte(Self[Byte], Int, Int) -> UInt
 fn ArrayView::unsafe_extract_byte_signed(Self[Byte], Int, Int) -> Int
 fn ArrayView::unsafe_extract_bytesview(Self[Byte], Int, Int) -> Self[Byte]

--- a/bytes/bitstring.mbt
+++ b/bytes/bitstring.mbt
@@ -49,6 +49,24 @@ pub fn BytesView::unsafe_extract_bit(
 }
 
 ///|
+/// Extract a single bit.
+#internal(experimental, "subject to breaking change without notice")
+pub fn BytesView::unsafe_extract_bit_signed(
+  bs : BytesView,
+  offset : Int,
+  _len : Int,
+) -> Int {
+  let byte_index = offset >> 3
+  let bit_mask = (1 << (7 - (offset & 7))).to_byte()
+  // TODO: branchless for performance
+  if (bs.unsafe_get(byte_index) & bit_mask) != 0 {
+    -1
+  } else {
+    0
+  }
+}
+
+///|
 /// Extract [2..8] bits.
 #internal(experimental, "subject to breaking change without notice")
 pub fn BytesView::unsafe_extract_byte(

--- a/bytes/bitstring_test.mbt
+++ b/bytes/bitstring_test.mbt
@@ -1865,6 +1865,20 @@ test "misc" {
 // ============================================================================
 
 ///|
+test "extract_bit_signed - basic functionality" {
+  let bytes = b"\xAA"
+  let view = bytes[:]
+  inspect(view.unsafe_extract_bit_signed(0, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(1, 1), content="0")
+  inspect(view.unsafe_extract_bit_signed(2, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(3, 1), content="0")
+  inspect(view.unsafe_extract_bit_signed(4, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(5, 1), content="0")
+  inspect(view.unsafe_extract_bit_signed(6, 1), content="-1")
+  inspect(view.unsafe_extract_bit_signed(7, 1), content="0")
+}
+
+///|
 test "extract_byte_signed - basic positive and negative values" {
   // Test with a mix of positive and negative values
   let bytes = b"\x7F\xFF\x80\x00\xAA\x55"

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -79,6 +79,7 @@ fn BytesView::to_uint64_le(Self) -> UInt64
 fn BytesView::to_uint_be(Self) -> UInt
 fn BytesView::to_uint_le(Self) -> UInt
 fn BytesView::unsafe_extract_bit(Self, Int, Int) -> UInt
+fn BytesView::unsafe_extract_bit_signed(Self, Int, Int) -> Int
 fn BytesView::unsafe_extract_byte(Self, Int, Int) -> UInt
 fn BytesView::unsafe_extract_byte_signed(Self, Int, Int) -> Int
 fn BytesView::unsafe_extract_bytesview(Self, Int, Int) -> Self


### PR DESCRIPTION
In #2882, I forgot to add signed extraction for the 1-bit case. In such case, if the bit is not 0, it return -1.