### PR TITLE
fix: replace deprecated byte conversion functions with bit patterns

### DIFF
--- a/bytes/README.mbt.md
+++ b/bytes/README.mbt.md
@@ -114,7 +114,8 @@ test "numeric interpretation" {
   ])
   let int64_view = int64_bytes[:]
   inspect(int64_view.to_int64_be(), content="66")
-  inspect(int64_view.to_uint64_le(), content="4755801206503243776")
+  guard int64_view is [u64le(x), ..]
+  inspect(x, content="4755801206503243776")
 }
 ```
 

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -69,18 +69,26 @@ fn BytesView::start_offset(Self) -> Int
 fn BytesView::sub(Self, start? : Int, end? : Int) -> Self
 fn BytesView::to_array(Self) -> Array[Byte]
 fn BytesView::to_bytes(Self) -> Bytes
+#deprecated
 fn BytesView::to_double_be(Self) -> Double
+#deprecated
 fn BytesView::to_double_le(Self) -> Double
 fn BytesView::to_fixedarray(Self) -> FixedArray[Byte]
+#deprecated
 fn BytesView::to_float_be(Self) -> Float
+#deprecated
 fn BytesView::to_float_le(Self) -> Float
 fn BytesView::to_int64_be(Self) -> Int64
 fn BytesView::to_int64_le(Self) -> Int64
 fn BytesView::to_int_be(Self) -> Int
 fn BytesView::to_int_le(Self) -> Int
+#deprecated
 fn BytesView::to_uint64_be(Self) -> UInt64
+#deprecated
 fn BytesView::to_uint64_le(Self) -> UInt64
+#deprecated
 fn BytesView::to_uint_be(Self) -> UInt
+#deprecated
 fn BytesView::to_uint_le(Self) -> UInt
 fn BytesView::unsafe_extract_bit(Self, Int, Int) -> UInt
 fn BytesView::unsafe_extract_bit_signed(Self, Int, Int) -> Int

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -281,9 +281,11 @@ pub fn BytesView::iterator2(self : BytesView) -> Iterator2[Int, Byte] {
 /// Example:
 ///
 /// ```moonbit
-///   let bytes = b"\x12\x34\x56\x78"[:]
-///   inspect(bytes.to_uint_be(), content="305419896") // 0x12345678
+///   let bytes = b"\x12\x34\x56\x78"
+///   guard bytes is [u32be(x),..]
+///   inspect(x, content="305419896") // 0x12345678
 /// ```
+#deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_uint_be(self : BytesView) -> UInt {
   (self[0].to_uint() << 24) +
   (self[1].to_uint() << 16) +
@@ -310,8 +312,8 @@ pub fn BytesView::to_uint_be(self : BytesView) -> UInt {
 ///
 /// ```moonbit
 /// let bytes = b"\x01\x02\x03\x04"
-/// let view = bytes[:]
-/// inspect(view.to_uint_le(), content="67305985") // 0x04030201
+/// guard bytes is [u32le(x),..]
+/// inspect(x, content="67305985") // 0x04030201
 /// ```
 #deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_uint_le(self : BytesView) -> UInt {
@@ -341,9 +343,11 @@ pub fn BytesView::to_uint_le(self : BytesView) -> UInt {
 /// Example:
 ///
 /// ```moonbit
-///   let bytes = b"\x01\x23\x45\x67\x89\xAB\xCD\xEF"[:]
-///   inspect(bytes.to_uint64_be(), content="81985529216486895")
+///   let bytes = b"\x01\x23\x45\x67\x89\xAB\xCD\xEF"
+///   guard bytes is [u64be(x),..]
+///   inspect(x, content="81985529216486895")
 /// ```
+#deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_uint64_be(self : BytesView) -> UInt64 {
   (self[0].to_uint().to_uint64() << 56) +
   (self[1].to_uint().to_uint64() << 48) +
@@ -376,9 +380,11 @@ pub fn BytesView::to_uint64_be(self : BytesView) -> UInt64 {
 /// Example:
 ///
 /// ```moonbit
-///   let bytes = b"\x01\x02\x03\x04\x05\x06\x07\x08"[:]
-///   inspect(bytes.to_uint64_le(), content="578437695752307201")
+///   let bytes = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+///   guard bytes is [u64le(x),..]
+///   inspect(x, content="578437695752307201")
 /// ```
+#deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_uint64_le(self : BytesView) -> UInt64 {
   self[0].to_uint().to_uint64() +
   (self[1].to_uint().to_uint64() << 8) +
@@ -504,11 +510,12 @@ pub fn BytesView::to_int64_le(self : BytesView) -> Int64 {
 ///
 /// ```moonbit
 ///   let bytes = b"\x40\x48\xF5\xC3" // Represents 3.14 in IEEE 754 format
-///   let view = bytes[:]
-///   let float = view.to_float_be()
+///   guard bytes is [u32be(bits),..]
+///   let float = bits.reinterpret_as_float()
 ///   // Convert to double for comparison since Float doesn't implement Show
 ///   inspect(float.to_double(), content="3.140000104904175")
 /// ```
+#deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_float_be(self : BytesView) -> Float {
   self.to_uint_be().reinterpret_as_float()
 }
@@ -528,9 +535,11 @@ pub fn BytesView::to_float_be(self : BytesView) -> Float {
 ///
 /// ```moonbit
 ///   let bytes = b"\x00\x00\x80\x3F" // Represents 1.0 in little-endian IEEE-754
-///   let f = bytes[:].to_float_le()
+///   guard bytes is [u32le(bits),..]
+///   let f = bits.reinterpret_as_float()
 ///   inspect(f.to_double(), content="1")
 /// ```
+#deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_float_le(self : BytesView) -> Float {
   self.to_uint_le().reinterpret_as_float()
 }
@@ -553,9 +562,10 @@ pub fn BytesView::to_float_le(self : BytesView) -> Float {
 /// ```moonbit
 ///   // Bytes representing 1.0 in IEEE 754 double-precision format (big-endian)
 ///   let bytes = b"\x3F\xF0\x00\x00\x00\x00\x00\x00"
-///   let view = bytes[:]
-///   inspect(view.to_double_be(), content="1")
+///   guard bytes is [u64be(bits),..]
+///   inspect(bits.reinterpret_as_double(), content="1")
 /// ```
+#deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_double_be(self : BytesView) -> Double {
   self.to_uint64_be().reinterpret_as_double()
 }
@@ -576,9 +586,10 @@ pub fn BytesView::to_double_be(self : BytesView) -> Double {
 ///
 /// ```moonbit
 ///   let bytes = b"\x00\x00\x00\x00\x00\x00\xF0\x3F" // represents 1.0 in little-endian
-///   let view = bytes[:]
-///   inspect(view.to_double_le(), content="1")
+///   guard bytes is [u64le(bits),..]
+///   inspect(bits.reinterpret_as_double(), content="1")
 /// ```
+#deprecated(skip_current_package=false, "Use bits pattern directly")
 pub fn BytesView::to_double_le(self : BytesView) -> Double {
   self.to_uint64_le().reinterpret_as_double()
 }

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -354,41 +354,47 @@ test "View::get out_of_bounds" {
 ///|
 test "to_uint_be with b'\\xFF\\xFF\\xFF\\xFF'" {
   let bytes = b"\xFF\xFF\xFF\xFF"[:]
-  inspect(bytes.to_uint_be(), content="4294967295")
+  guard bytes is [u32be(x), ..]
+  inspect(x, content="4294967295")
 }
 
 ///|
 test "View::to_uint_le with non-zero bytes" {
   let bytes = b"\x01\x02\x03\x04"
-  let view = bytes[:]
-  inspect(view.to_uint_le(), content="67305985") // 67305985 = 0x04030201
+  guard bytes is [u32le(x), ..]
+  inspect(x, content="67305985") // 67305985 = 0x04030201
 }
 
 ///|
 test "panic View::to_uint_le/out_of_bounds" {
   let bytes = b"\x01\x02\x03" // Only 3 bytes
-  let view = bytes[:]
-  ignore(view.to_uint_le()) // Should panic: index out of bounds
+  match bytes {
+    [u32le(_), ..] => ()
+    _ => abort("Should not reach here")
+  }
 }
 
 ///|
 test "View::to_uint64_be/first_byte_operation" {
-  let bytes = b"\xFF\x00\x00\x00\x00\x00\x00\x00"[:] // First byte is all 1s
-  let result = bytes.to_uint64_be()
+  let bytes = b"\xFF\x00\x00\x00\x00\x00\x00\x00" // First byte is all 1s
+  guard bytes is [u64be(result), ..]
   // First byte shifted left by 56 bits should give us: 0xFF00000000000000
   inspect(result, content="18374686479671623680")
 }
 
 ///|
 test "test View::to_uint64_le with binary pattern" {
-  let bytes = b"\x01\x00\x00\x00\x00\x00\x00\x00"[:]
-  inspect(bytes.to_uint64_le(), content="1")
-  let bytes2 = b"\x00\x01\x00\x00\x00\x00\x00\x00"[:]
-  inspect(bytes2.to_uint64_le(), content="256")
+  let bytes = b"\x01\x00\x00\x00\x00\x00\x00\x00"
+  guard bytes is [u64le(x), ..]
+  inspect(x, content="1")
+  let bytes2 = b"\x00\x01\x00\x00\x00\x00\x00\x00"
+  guard bytes2 is [u64le(x2), ..]
+  inspect(x2, content="256")
 
   // Test all bytes set to non-zero values
-  let bytes3 = b"\x01\x02\x03\x04\x05\x06\x07\x08"[:]
-  inspect(bytes3.to_uint64_le(), content="578437695752307201")
+  let bytes3 = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+  guard bytes3 is [u64le(x3), ..]
+  inspect(x3, content="578437695752307201")
 }
 
 ///|
@@ -424,36 +430,40 @@ test "View::to_int64_le with mixed bytes" {
 test "panic to_float_be/short_input" {
   // Test that trying to read from a view that's too short causes a panic
   let bytes = b"\x40\x49"
-  let view = bytes[:]
-  ignore(BytesView::to_float_be(view)) // Should panic due to insufficient bytes
+  match bytes {
+    [u32be(_), ..] => ()
+    _ => abort("Should not reach here")
+  }
 }
 
 ///|
 test "View::to_float_le with different values" {
   // Test with value 0.0
   let bytes = b"\x00\x00\x00\x00"
-  let f = bytes[:].to_float_le()
+  guard bytes is [u32le(bits), ..]
+  let f = bits.reinterpret_as_float()
   inspect(f.to_double(), content="0")
 
   // Test with value -1.0
   let bytes2 = b"\x00\x00\x80\xBF"
-  let f2 = bytes2[:].to_float_le()
+  guard bytes2 is [u32le(bits2), ..]
+  let f2 = bits2.reinterpret_as_float()
   inspect(f2.to_double(), content="-1")
 }
 
 ///|
 test "View::to_double_be/zero" {
   let bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00"
-  let view = bytes[:]
-  inspect(view.to_double_be(), content="0")
+  guard bytes is [u64be(bits), ..]
+  inspect(bits.reinterpret_as_double(), content="0")
 }
 
 ///|
 test "test to_double_le with normal float" {
   // 3.14 in little-endian IEEE 754 double format
   let bytes = b"\x1F\x85\xEB\x51\xB8\x1E\x09\x40"
-  let view = bytes[:]
-  inspect(view.to_double_le(), content="3.14")
+  guard bytes is [u64le(bits), ..]
+  inspect(bits.reinterpret_as_double(), content="3.14")
 }
 
 ///|

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -26,7 +26,10 @@ struct ChaCha8 {
 ///|
 /// [seed] must be 32 bytes long.
 pub fn ChaCha8::new(seed : Bytes) -> ChaCha8 {
-  let seed = FixedArray::makei(SEED_CHUNK_NUM * 2, i => seed[i * 4:i * 4 + 4].to_uint_le())
+  let seed = FixedArray::makei(SEED_CHUNK_NUM * 2, i => match seed[i * 4:] {
+    [u32le(x), ..] => x
+    _ => abort("seed must be 32 bytes long")
+  })
   let buffer = FixedArray::make(BUFFER_CHUNK_NUM * 2, 0U)
   chacha_block(seed, buffer, 0)
   { seed, buffer, counter: 0, i: 0, n: BUFFER_CHUNK_NUM.reinterpret_as_uint() }


### PR DESCRIPTION
This PR fixes deprecation warnings by replacing deprecated byte conversion function calls with bit pattern matching.

## Changes
- Replace deprecated `to_uint_le()`, `to_uint64_be()`, `to_uint64_le()` calls with bit pattern matching (`u32le`, `u32be`, `u64le`, `u64be`)
- Update examples and tests in `bytes/view.mbt` and `bytes/view_test.mbt` to use bit patterns
- Fix deprecation warning in `random_source_chacha.mbt`
- For float/double conversions: extract bits as u32/u64 then call `reinterpret_as_float`/`reinterpret_as_double`

## Testing
- All tests pass with `moon check --deny-warn`
- Formatted with `moon fmt`
- Comprehensive test suite validated with `moon test --target all`