### PR TITLE
fix: replace deprecated hashmap methods with their new names

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -166,7 +166,8 @@ fn[K : Eq, V] Node::add_with_path(
 
 ///|
 /// Filter entries that satisfy the predicate
-pub fn[K, V] HashMap::filter_with_key(
+#alias(filter_with_key, deprecated)
+pub fn[K, V] HashMap::filter(
   self : HashMap[K, V],
   pred : (K, V) -> Bool raise?,
 ) -> HashMap[K, V] raise? {
@@ -208,7 +209,8 @@ pub fn[K, V] HashMap::filter_with_key(
 /// TODO: can not mark `f` as `#locals(f)` because 
 /// it will be shadowed by the `f` in the `@list.T::fold` function
 /// TO make it more useful in the future, we may need propagate
-pub fn[K, V, A] HashMap::fold_with_key(
+#alias(fold_with_key, deprecated)
+pub fn[K, V, A] HashMap::fold(
   self : HashMap[K, V],
   init~ : A,
   f : (A, K, V) -> A raise?,
@@ -230,7 +232,8 @@ pub fn[K, V, A] HashMap::fold_with_key(
 
 ///|
 /// Maps over the key-value pairs in the map
-pub fn[K, V, A] HashMap::map_with_key(
+#alias(map_with_key, deprecated)
+pub fn[K, V, A] HashMap::map(
   self : HashMap[K, V],
   f : (K, V) -> A raise?,
 ) -> HashMap[K, A] raise? {
@@ -785,7 +788,7 @@ pub impl[K : Hash, V : Hash] Hash for HashMap[K, V] with hash_combine(
   hasher,
 ) {
   hasher.combine(
-    self.fold_with_key(init=0, (acc, k, v) => acc ^
+    self.fold(init=0, (acc, k, v) => acc ^
       Hasher::new()..combine((k, v)).finalize()),
   )
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -352,7 +352,7 @@ test "HAMT::contains" {
 ///|
 test "filter with simple predicate" {
   let map = @hashmap.from_array([(1, 1), (2, 2), (3, 3), (4, 4)])
-  let only_even = map.filter_with_key((_, v) => v % 2 == 0)
+  let only_even = map.filter((_, v) => v % 2 == 0)
   inspect(only_even.contains(1), content="false")
   inspect(only_even.contains(2), content="true")
   inspect(only_even.contains(3), content="false")
@@ -362,7 +362,7 @@ test "filter with simple predicate" {
 ///|
 test "filter with all elements matching" {
   let map = @hashmap.from_array([(1, 1), (2, 2)])
-  let filtered = map.filter_with_key((_, v) => v > 0)
+  let filtered = map.filter((_, v) => v > 0)
   inspect(filtered.contains(1), content="true")
   inspect(filtered.contains(2), content="true")
 }
@@ -370,7 +370,7 @@ test "filter with all elements matching" {
 ///|
 test "filter with no elements matching" {
   let map = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let filtered = map.filter_with_key((_, v) => v > 10)
+  let filtered = map.filter((_, v) => v > 10)
   assert_eq(filtered.get(1), None)
   assert_eq(filtered.get(2), None)
   assert_eq(filtered.get(3), None)
@@ -380,7 +380,7 @@ test "filter with no elements matching" {
 ///|
 test "filter with collision" {
   let map = @hashmap.from_array([(1, 10), (2, 20)]).add(1, 30)
-  let filtered = map.filter_with_key((_, v) => v == 30)
+  let filtered = map.filter((_, v) => v == 30)
   assert_eq(filtered.get(1), Some(30))
   assert_eq(filtered.get(2), None)
 }
@@ -391,7 +391,7 @@ test "filter with branch nodes" {
     (10, map) => map
     (i, map) => continue (i + 1, map.add(i, i * 10))
   }
-  let filtered = map.filter_with_key((_, v) => v % 20 == 0)
+  let filtered = map.filter((_, v) => v % 20 == 0)
   for i in 0..<10 {
     if i * 10 % 20 == 0 {
       assert_eq(filtered.get(i), Some(i * 10))
@@ -404,7 +404,7 @@ test "filter with branch nodes" {
 ///|
 test "HAMT::fold_with_key" {
   let map = @hashmap.from_array([(1, "a"), (2, "b")])
-  let result = map.fold_with_key(init="", (acc, k, v) => acc + "\{k}:\{v}, ")
+  let result = map.fold(init="", (acc, k, v) => acc + "\{k}:\{v}, ")
   // order of elements is not guaranteed, so we check for substrings
   inspect(result.contains("1:a"), content="true")
   inspect(result.contains("2:b"), content="true")
@@ -413,14 +413,14 @@ test "HAMT::fold_with_key" {
 ///|
 test "HAMT::fold" {
   let map = @hashmap.from_array([(1, 10), (2, 20), (3, 30)])
-  let result = map.fold_with_key(init=0, (acc, _, v) => acc + v)
+  let result = map.fold(init=0, (acc, _, v) => acc + v)
   inspect(result, content="60")
 }
 
 ///|
 test "HAMT::map" {
   let map = @hashmap.from_array([(1, 10), (2, 20)])
-  let mapped = map.map_with_key((_, v) => v * 2)
+  let mapped = map.map((_, v) => v * 2)
   assert_eq(mapped.get(1), Some(20))
   assert_eq(mapped.get(2), Some(40))
   assert_eq(mapped.get(3), None)
@@ -430,21 +430,21 @@ test "HAMT::map" {
 test "HAMT::map with overflow" {
   let max = 2147483647 // Int.max_value
   let map = @hashmap.from_array([(1, max)])
-  let mapped = map.map_with_key((_, v) => v + 1)
+  let mapped = map.map((_, v) => v + 1)
   assert_eq(mapped.get(1), Some(-2147483648))
 }
 
 ///|
 test "HAMT::map_with_key empty" {
   let map : @hashmap.HashMap[Int, Int] = @hashmap.new()
-  let mapped = map.map_with_key((_k, v) => v)
+  let mapped = map.map((_k, v) => v)
   inspect(mapped.length(), content="0")
 }
 
 ///|
 test "HAMT::map_with_key leaf" {
   let map = @hashmap.singleton(42, 100) // Leaf
-  let mapped = map.map_with_key((k, v) => k + v)
+  let mapped = map.map((k, v) => k + v)
   assert_eq(mapped.get(42), Some(142))
   inspect(mapped.length(), content="1")
 }
@@ -452,7 +452,7 @@ test "HAMT::map_with_key leaf" {
 ///|
 test "HAMT::map_with_key collision" {
   let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)]) // Collision
-  let mapped = map.map_with_key((k, v) => k.0 + ":" + v.to_string())
+  let mapped = map.map((k, v) => k.0 + ":" + v.to_string())
   assert_eq(mapped.get(MyString("a")), Some("a:1"))
   assert_eq(mapped.get(MyString("b")), Some("b:2"))
   assert_eq(mapped.get(MyString("c")), None)
@@ -464,7 +464,7 @@ test "HAMT::map_with_key branch" {
     (10, map) => map
     (i, map) => continue (i + 1, map.add(i, i * 10))
   } // Branch
-  let mapped = map.map_with_key((k, v) => k * 100 + v)
+  let mapped = map.map((k, v) => k * 100 + v)
   for i in 0..<10 {
     assert_eq(mapped.get(i), Some(i * 100 + i * 10))
   }
@@ -513,21 +513,21 @@ test "add_with_hash collision" {
 ///|
 test "empty filtering" {
   let map : @hashmap.HashMap[Int, Int] = @hashmap.from_array([])
-  let _filtered = map.filter_with_key((_, v) => v > 2)
+  let _filtered = map.filter((_, v) => v > 2)
   inspect(map.length(), content="0")
 }
 
 ///|
 test "filter with collision - all removed" {
   let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let filtered = map.filter_with_key((_, v) => v > 2)
+  let filtered = map.filter((_, v) => v > 2)
   inspect(filtered.length(), content="0")
 }
 
 ///|
 test "filter with collision - one left" {
   let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let filtered = map.filter_with_key((_, v) => v == 1)
+  let filtered = map.filter((_, v) => v == 1)
   inspect(filtered.length(), content="1")
 }
 
@@ -538,21 +538,21 @@ test "filter with collision - more than one left" {
     (MyString("b"), 2),
     (MyString("c"), 3),
   ])
-  let filtered = map.filter_with_key((_, v) => v > 1)
+  let filtered = map.filter((_, v) => v > 1)
   inspect(filtered.length(), content="2")
 }
 
 ///|
 test "HAMT::fold_with_key on empty" {
   let map : @hashmap.HashMap[Int, Int] = @hashmap.new()
-  let result = map.fold_with_key(init=0, (acc, _k, _v) => acc + 1)
+  let result = map.fold(init=0, (acc, _k, _v) => acc + 1)
   inspect(result, content="0")
 }
 
 ///|
 test "HAMT::fold_with_key on collision" {
   let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let result = map.fold_with_key(init=0, (acc, _k, v) => acc + v)
+  let result = map.fold(init=0, (acc, _k, v) => acc + v)
   inspect(result, content="3")
 }
 

--- a/immut/hashmap/deprecated.mbt
+++ b/immut/hashmap/deprecated.mbt
@@ -11,36 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-/// Filter values that satisfy the predicate
-#deprecated("Use `filter_with_key` instead. `filter` will accept `(K, V) -> Bool` in the future.", skip_current_package=false)
-#coverage.skip
-pub fn[K, V] HashMap::filter(
-  self : HashMap[K, V],
-  pred : (V) -> Bool raise?,
-) -> HashMap[K, V] raise? {
-  self.filter_with_key((_, v) => pred(v))
-}
-
-///|
-/// Fold the values in the map
-#deprecated("Use `fold_with_key` instead. `fold` will accept `(A, K, V) -> A` in the future.", skip_current_package=false)
-pub fn[K, V, A] HashMap::fold(
-  self : HashMap[K, V],
-  init~ : A,
-  f : (A, V) -> A raise?,
-) -> A raise? {
-  self.fold_with_key((acc, _k, v) => f(acc, v), init~)
-}
-
-///|
-/// Maps over the values in the map
-#deprecated("Use `map_with_key` instead. `map` will accept `(K, V) -> A` in the future.", skip_current_package=false)
-#coverage.skip
-pub fn[K, V, A] HashMap::map(
-  self : HashMap[K, V],
-  f : (V) -> A raise?,
-) -> HashMap[K, A] raise? {
-  self.map_with_key((_k, v) => f(v))
-}

--- a/immut/hashmap/pkg.generated.mbti
+++ b/immut/hashmap/pkg.generated.mbti
@@ -19,12 +19,10 @@ fn[K : Eq + Hash, V] HashMap::at(Self[K, V], K) -> V
 fn[K : Eq + Hash, V] HashMap::contains(Self[K, V], K) -> Bool
 fn[K : Eq, V] HashMap::difference(Self[K, V], Self[K, V]) -> Self[K, V]
 fn[K, V] HashMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
-#deprecated
-fn[K, V] HashMap::filter(Self[K, V], (V) -> Bool raise?) -> Self[K, V] raise?
-fn[K, V] HashMap::filter_with_key(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
-#deprecated
-fn[K, V, A] HashMap::fold(Self[K, V], init~ : A, (A, V) -> A raise?) -> A raise?
-fn[K, V, A] HashMap::fold_with_key(Self[K, V], init~ : A, (A, K, V) -> A raise?) -> A raise?
+#alias(filter_with_key, deprecated)
+fn[K, V] HashMap::filter(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
+#alias(fold_with_key, deprecated)
+fn[K, V, A] HashMap::fold(Self[K, V], init~ : A, (A, K, V) -> A raise?) -> A raise?
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn
@@ -44,9 +42,8 @@ fn[K, V] HashMap::iterator2(Self[K, V]) -> Iterator2[K, V]
 fn[K, V] HashMap::keys(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 fn[K, V] HashMap::length(Self[K, V]) -> Int
-#deprecated
-fn[K, V, A] HashMap::map(Self[K, V], (V) -> A raise?) -> Self[K, A] raise?
-fn[K, V, A] HashMap::map_with_key(Self[K, V], (K, V) -> A raise?) -> Self[K, A] raise?
+#alias(map_with_key, deprecated)
+fn[K, V, A] HashMap::map(Self[K, V], (K, V) -> A raise?) -> Self[K, A] raise?
 #as_free_fn
 fn[K, V] HashMap::new() -> Self[K, V]
 fn[K : Eq + Hash, V] HashMap::remove(Self[K, V], K) -> Self[K, V]


### PR DESCRIPTION
- Replace filter_with_key with filter (17 occurrences)
- Replace fold_with_key with fold (4 occurrences)
- Replace map_with_key with map (6 occurrences)

All deprecated method calls in HAMT.mbt and HAMT_test.mbt have been updated to use the new non-deprecated method names.
