### PR TITLE
refactor: using deprecation alias

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -448,20 +448,12 @@ pub fn[T, R] Iter::mapi(self : Iter[T], f : (Int, T) -> R) -> Iter[R] {
 ///|
 /// Transforms the elements of the iterator using a mapping function that returns an `Option`.
 /// The elements for which the function returns `None` are filtered out.
+#alias(map_option, deprecated)
 pub fn[A, B] Iter::filter_map(self : Iter[A], f : (A) -> B?) -> Iter[B] {
   yield_ => self.run(a => match f(a) {
     Some(b) => yield_(b)
     None => IterContinue
   })
-}
-
-///|
-/// Transforms the elements of the iterator using a mapping function that returns an `Option`.
-/// The elements for which the function returns `None` are filtered out.
-///
-#deprecated("Use `Iter::filter_map` instead", skip_current_package=false)
-pub fn[A, B] Iter::map_option(self : Iter[A], f : (A) -> B?) -> Iter[B] {
-  self.filter_map(f)
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -199,6 +199,7 @@ fn[T] Iter::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 fn[T] Iter::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 fn[T] Iter::empty() -> Self[T]
 fn[T] Iter::filter(Self[T], (T) -> Bool) -> Self[T]
+#alias(map_option, deprecated)
 fn[A, B] Iter::filter_map(Self[A], (A) -> B?) -> Self[B]
 fn[T] Iter::find_first(Self[T], (T) -> Bool) -> T?
 fn[T, R] Iter::flat_map(Self[T], (T) -> Self[R]) -> Self[R]
@@ -214,8 +215,6 @@ fn Iter::join(Self[String], String) -> String
 fn[T] Iter::just_run(Self[T], (T) -> IterResult) -> Unit
 fn[A] Iter::last(Self[A]) -> A?
 fn[T, R] Iter::map(Self[T], (T) -> R) -> Self[R]
-#deprecated
-fn[A, B] Iter::map_option(Self[A], (A) -> B?) -> Self[B]
 fn[A, B] Iter::map_while(Self[A], (A) -> B?) -> Self[B]
 fn[T, R] Iter::mapi(Self[T], (Int, T) -> R) -> Self[R]
 fn[T : Compare] Iter::maximum(Self[T]) -> T?

--- a/deque/deprecated.mbt
+++ b/deque/deprecated.mbt
@@ -11,23 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `unsafe_pop_front` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A] Deque::pop_front_exn(self : Deque[A]) -> Unit {
-  self.unsafe_pop_front()
-}
-
-///|
-#deprecated("Use `unsafe_pop_back` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A] Deque::pop_back_exn(self : Deque[A]) -> Unit {
-  self.unsafe_pop_back()
-}
-
-///|
-#deprecated("Use `@deque.retain_map` instead", skip_current_package=false)
-pub fn[A] Deque::filter_map_inplace(self : Deque[A], f : (A) -> A?) -> Unit {
-  self.retain_map(f)
-}

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -579,6 +579,7 @@ pub fn[A] Deque::push_back(self : Deque[A], value : A) -> Unit {
 ///   assert_eq(dv.front(), Some(2))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
+#alias(pop_front_exn, deprecated)
 pub fn[A] Deque::unsafe_pop_front(self : Deque[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
@@ -627,6 +628,7 @@ pub fn[A] Deque::unsafe_pop_front(self : Deque[A]) -> Unit {
 ///   assert_eq(dv.back(), Some(4))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
+#alias(pop_back_exn, deprecated)
 pub fn[A] Deque::unsafe_pop_back(self : Deque[A]) -> Unit {
   match self.len {
     0 => abort("The deque is empty!")
@@ -1262,6 +1264,7 @@ pub fn[A] Deque::truncate(self : Deque[A], len : Int) -> Unit {
 ///   dq.retain_map((x) => { if x % 2 == 0 { Some(x * 2) } else { None } })
 ///   inspect(dq, content="@deque.from_array([4, 8])")
 /// ```
+#alias(filter_map_inplace, deprecated)
 pub fn[A] Deque::retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -31,8 +31,6 @@ fn[A] Deque::each(Self[A], (A) -> Unit) -> Unit
 fn[A] Deque::eachi(Self[A], (Int, A) -> Unit) -> Unit
 fn[A] Deque::extract_if(Self[A], (A) -> Bool) -> Self[A]
 fn[A] Deque::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
-#deprecated
-fn[A] Deque::filter_map_inplace(Self[A], (A) -> A?) -> Unit
 fn[A] Deque::flatten(Self[Self[A]]) -> Self[A]
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
@@ -57,16 +55,13 @@ fn[A, U] Deque::mapi(Self[A], (Int, A) -> U) -> Self[U]
 #as_free_fn
 fn[A] Deque::new(capacity? : Int) -> Self[A]
 fn[A] Deque::pop_back(Self[A]) -> A?
-#deprecated
-fn[A] Deque::pop_back_exn(Self[A]) -> Unit
 fn[A] Deque::pop_front(Self[A]) -> A?
-#deprecated
-fn[A] Deque::pop_front_exn(Self[A]) -> Unit
 fn[A] Deque::push_back(Self[A], A) -> Unit
 fn[A] Deque::push_front(Self[A], A) -> Unit
 fn[A] Deque::remove(Self[A], Int) -> A
 fn[A] Deque::reserve_capacity(Self[A], Int) -> Unit
 fn[A] Deque::retain(Self[A], (A) -> Bool) -> Unit
+#alias(filter_map_inplace, deprecated)
 fn[A] Deque::retain_map(Self[A], (A) -> A?) -> Unit
 fn[A] Deque::rev(Self[A]) -> Self[A]
 fn[A] Deque::rev_each(Self[A], (A) -> Unit) -> Unit
@@ -84,7 +79,9 @@ fn[A] Deque::shuffle(Self[A], rand~ : (Int) -> Int) -> Self[A]
 fn[A] Deque::shuffle_in_place(Self[A], rand~ : (Int) -> Int) -> Unit
 fn[A] Deque::to_array(Self[A]) -> Array[A]
 fn[A] Deque::truncate(Self[A], Int) -> Unit
+#alias(pop_back_exn, deprecated)
 fn[A] Deque::unsafe_pop_back(Self[A]) -> Unit
+#alias(pop_front_exn, deprecated)
 fn[A] Deque::unsafe_pop_front(Self[A]) -> Unit
 impl[A] Add for Deque[A]
 impl[A : Compare] Compare for Deque[A]

--- a/hashset/deprecated.mbt
+++ b/hashset/deprecated.mbt
@@ -11,10 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `add` instead.", skip_current_package=false)
-#coverage.skip
-pub fn[K : Hash + Eq] HashSet::insert(self : HashSet[K], key : K) -> Unit {
-  self.add(key)
-}

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -59,6 +59,7 @@ pub fn[K : Hash + Eq] HashSet::from_array(arr : ArrayView[K]) -> HashSet[K] {
 ///   set.add("key") // no effect since it already exists
 ///   inspect(set.length(), content="1")
 /// ```
+#alias(insert, deprecated)
 pub fn[K : Hash + Eq] HashSet::add(self : HashSet[K], key : K) -> Unit {
   self.add_with_hash(key, key.hash())
 }

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -13,6 +13,7 @@ import(
 // Types and methods
 #alias(T, deprecated)
 type HashSet[K]
+#alias(insert, deprecated)
 fn[K : Hash + Eq] HashSet::add(Self[K], K) -> Unit
 fn[K : Hash + Eq] HashSet::add_and_check(Self[K], K) -> Bool
 fn[K] HashSet::capacity(Self[K]) -> Int
@@ -30,8 +31,6 @@ fn[K : Hash + Eq] HashSet::from_array(ArrayView[K]) -> Self[K]
 fn[K : Hash + Eq] HashSet::from_iter(Iter[K]) -> Self[K]
 #as_free_fn
 fn[K : Hash + Eq] HashSet::from_iterator(Iterator[K]) -> Self[K]
-#deprecated
-fn[K : Hash + Eq] HashSet::insert(Self[K], K) -> Unit
 fn[K : Hash + Eq] HashSet::intersection(Self[K], Self[K]) -> Self[K]
 fn[K : Hash + Eq] HashSet::is_disjoint(Self[K], Self[K]) -> Bool
 fn[K] HashSet::is_empty(Self[K]) -> Bool

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -335,6 +335,7 @@ pub fn[A] T::eachi(self : T[A], f : (Int, A) -> Unit raise?) -> Unit raise? {
 ///   let v = @array.from_array([1, 2, 3, 4, 5])
 ///   assert_eq(v.fold((a, b) => { a + b }, init=0), 15)
 /// ```
+#alias(fold_left, deprecated)
 pub fn[A, B] T::fold(
   self : T[A],
   init~ : B,
@@ -351,6 +352,7 @@ pub fn[A, B] T::fold(
 ///   let v = @array.from_array([1, 2, 3, 4, 5])
 ///   assert_eq(v.rev_fold((a, b) => { a + b }, init=0), 15)
 /// ```
+#alias(fold_right, deprecated)
 pub fn[A, B] T::rev_fold(
   self : T[A],
   init~ : B,

--- a/immut/array/deprecated.mbt
+++ b/immut/array/deprecated.mbt
@@ -37,39 +37,3 @@ pub fn[A] T::copy(self : T[A]) -> T[A] {
 
   { tree: copy(self.tree), size: self.size, shift: self.shift }
 }
-
-///|
-/// Fold the array from left to right.
-///
-/// # Example
-/// ```mbt
-///   let v = @array.from_array([1, 2, 3, 4, 5])
-///   assert_eq(v.fold((a, b) => { a + b }, init=0), 15)
-/// ```
-#deprecated("Use `fold` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A] T::fold_left(
-  self : T[A],
-  f : (A, A) -> A raise?,
-  init~ : A,
-) -> A raise? {
-  self.fold(init~, f)
-}
-
-///|
-/// Fold the array from right to left.
-///
-/// # Example
-/// ```mbt
-///   let v = @array.from_array([1, 2, 3, 4, 5])
-///   assert_eq(v.rev_fold((a, b) => { a + b }, init=0), 15)
-/// ```
-#deprecated("Use `rev_fold` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A] T::fold_right(
-  self : T[A],
-  f : (A, A) -> A raise?,
-  init~ : A,
-) -> A raise? {
-  self.rev_fold(init~, f)
-}

--- a/immut/array/pkg.generated.mbti
+++ b/immut/array/pkg.generated.mbti
@@ -19,11 +19,8 @@ fn[A] T::concat(Self[A], Self[A]) -> Self[A]
 fn[A] T::copy(Self[A]) -> Self[A]
 fn[A] T::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 fn[A] T::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
+#alias(fold_left, deprecated)
 fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
-#deprecated
-fn[A] T::fold_left(Self[A], (A, A) -> A raise?, init~ : A) -> A raise?
-#deprecated
-fn[A] T::fold_right(Self[A], (A, A) -> A raise?, init~ : A) -> A raise?
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn
@@ -45,6 +42,7 @@ fn[A, B] T::map(Self[A], (A) -> B raise?) -> Self[B] raise?
 #as_free_fn
 fn[A] T::new() -> Self[A]
 fn[A] T::push(Self[A], A) -> Self[A]
+#alias(fold_right, deprecated)
 fn[A, B] T::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 fn[A] T::set(Self[A], Int, A) -> Self[A]
 fn[A] T::to_array(Self[A]) -> Array[A]

--- a/immut/priority_queue/deprecated.mbt
+++ b/immut/priority_queue/deprecated.mbt
@@ -11,12 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `unsafe_pop` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A : Compare] PriorityQueue::pop_exn(
-  self : PriorityQueue[A],
-) -> PriorityQueue[A] {
-  self.unsafe_pop()
-}

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -29,10 +29,9 @@ fn[A] PriorityQueue::length(Self[A]) -> Int
 fn[A] PriorityQueue::new() -> Self[A]
 fn[A] PriorityQueue::peek(Self[A]) -> A?
 fn[A : Compare] PriorityQueue::pop(Self[A]) -> Self[A]?
-#deprecated
-fn[A : Compare] PriorityQueue::pop_exn(Self[A]) -> Self[A]
 fn[A : Compare] PriorityQueue::push(Self[A], A) -> Self[A]
 fn[A : Compare] PriorityQueue::to_array(Self[A]) -> Array[A]
+#alias(pop_exn, deprecated)
 fn[A : Compare] PriorityQueue::unsafe_pop(Self[A]) -> Self[A]
 impl[A : Compare] Compare for PriorityQueue[A]
 impl[A : Compare] Eq for PriorityQueue[A]

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -201,6 +201,7 @@ fn[A : Compare] Node::change_and_down(self : Node[A], value : A) -> Node[A] {
 ///   assert_eq(first, @priority_queue.from_array([1, 2, 3]))
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
+#alias(pop_exn, deprecated)
 pub fn[A : Compare] PriorityQueue::unsafe_pop(
   self : PriorityQueue[A],
 ) -> PriorityQueue[A] {

--- a/immut/sorted_map/deprecated.mbt
+++ b/immut/sorted_map/deprecated.mbt
@@ -13,23 +13,6 @@
 // limitations under the License.
 
 ///|
-/// Create an empty map.
-#deprecated("Use `new()` instead", skip_current_package=false)
-#coverage.skip
-pub fn[K, V] SortedMap::empty() -> SortedMap[K, V] {
-  Empty
-}
-
-///|
-/// Get the value associated with a key.
-/// O(log n).
-#deprecated("Use `get` instead", skip_current_package=false)
-#coverage.skip
-pub fn[K : Compare, V] SortedMap::lookup(self : SortedMap[K, V], key : K) -> V? {
-  self.get(key)
-}
-
-///|
 /// Ts over the values in the map.
 #deprecated("Use `map_with_key` instead. `map` will accept `(K, X) -> Y` in the future.", skip_current_package=false)
 #coverage.skip

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -24,8 +24,6 @@ fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit) -> Unit
 #deprecated
 fn[K, V] SortedMap::elems(Self[K, V]) -> Array[V]
 #deprecated
-fn[K, V] SortedMap::empty() -> Self[K, V]
-#deprecated
 fn[K, V] SortedMap::filter(Self[K, V], (V) -> Bool raise?) -> Self[K, V] raise?
 fn[K, V] SortedMap::filter_with_key(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
 #deprecated
@@ -41,6 +39,7 @@ fn[K : Compare, V] SortedMap::from_iter(Iter[(K, V)]) -> Self[K, V]
 fn[K : Compare, V] SortedMap::from_iterator(Iterator[(K, V)]) -> Self[K, V]
 #as_free_fn
 fn[V : @json.FromJson] SortedMap::from_json(Json) -> Self[String, V] raise @json.JsonDecodeError
+#alias(lookup, deprecated)
 fn[K : Compare, V] SortedMap::get(Self[K, V], K) -> V?
 fn[K, V] SortedMap::is_empty(Self[K, V]) -> Bool
 fn[K, V] SortedMap::iter(Self[K, V]) -> Iter[(K, V)]
@@ -53,10 +52,9 @@ fn[K, V] SortedMap::keys_as_iter(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 fn[K, V] SortedMap::length(Self[K, V]) -> Int
 #deprecated
-fn[K : Compare, V] SortedMap::lookup(Self[K, V], K) -> V?
-#deprecated
 fn[K, X, Y] SortedMap::map(Self[K, X], (X) -> Y) -> Self[K, Y]
 fn[K, X, Y] SortedMap::map_with_key(Self[K, X], (K, X) -> Y) -> Self[K, Y]
+#alias(empty, deprecated)
 #as_free_fn
 fn[K, V] SortedMap::new() -> Self[K, V]
 fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Self[K, V]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -15,6 +15,7 @@
 ///|
 /// Create an empty map.
 #as_free_fn
+#alias(empty, deprecated)
 pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
   Empty
 }
@@ -77,6 +78,7 @@ fn[K, V] make_tree(
 ///|
 /// Get the value associated with a key.
 /// O(log n).
+#alias(lookup, deprecated)
 pub fn[K : Compare, V] SortedMap::get(self : SortedMap[K, V], key : K) -> V? {
   loop self {
     Empty => None

--- a/immut/sorted_set/deprecated.mbt
+++ b/immut/sorted_set/deprecated.mbt
@@ -11,29 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `intersection` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A : Compare] SortedSet::inter(
-  self : SortedSet[A],
-  other : SortedSet[A],
-) -> SortedSet[A] {
-  self.intersection(other)
-}
-
-///|
-/// Returns the difference of two sets.
-///
-/// # Example
-/// ```mbt
-///   assert_eq(@sorted_set.from_array([1, 2, 3]).difference(@sorted_set.from_array([4, 5, 1])), @sorted_set.from_array([2, 3]))
-/// ```
-#deprecated("Use `difference` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A : Compare] SortedSet::diff(
-  self : SortedSet[A],
-  other : SortedSet[A],
-) -> SortedSet[A] {
-  self.difference(other)
-}

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -333,6 +333,7 @@ pub impl[A : Compare] Add for SortedSet[A] with add(self, other) {
 /// ```mbt
 ///   assert_eq(@sorted_set.from_array([3, 4, 5]).intersection(@sorted_set.from_array([4, 5, 6])), @sorted_set.from_array([4, 5]))
 /// ```
+#alias(inter, deprecated)
 pub fn[A : Compare] SortedSet::intersection(
   self : SortedSet[A],
   other : SortedSet[A],
@@ -355,6 +356,7 @@ pub fn[A : Compare] SortedSet::intersection(
 /// ```mbt
 ///   assert_eq(@sorted_set.from_array([1, 2, 3]).difference(@sorted_set.from_array([4, 5, 1])), @sorted_set.from_array([2, 3]))
 /// ```
+#alias(diff, deprecated)
 pub fn[A : Compare] SortedSet::difference(
   self : SortedSet[A],
   other : SortedSet[A],

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -18,8 +18,7 @@ fn[A : Compare] SortedSet::add(Self[A], A) -> Self[A]
 fn[A] SortedSet::all(Self[A], (A) -> Bool raise?) -> Bool raise?
 fn[A] SortedSet::any(Self[A], (A) -> Bool raise?) -> Bool raise?
 fn[A : Compare] SortedSet::contains(Self[A], A) -> Bool
-#deprecated
-fn[A : Compare] SortedSet::diff(Self[A], Self[A]) -> Self[A]
+#alias(diff, deprecated)
 fn[A : Compare] SortedSet::difference(Self[A], Self[A]) -> Self[A]
 fn[A : Compare] SortedSet::disjoint(Self[A], Self[A]) -> Bool
 fn[A] SortedSet::each(Self[A], (A) -> Unit raise?) -> Unit raise?
@@ -35,8 +34,7 @@ fn[A : Compare] SortedSet::from_iter(Iter[A]) -> Self[A]
 fn[A : Compare] SortedSet::from_iterator(Iterator[A]) -> Self[A]
 #as_free_fn
 fn[A : @json.FromJson + Compare] SortedSet::from_json(Json) -> Self[A] raise @json.JsonDecodeError
-#deprecated
-fn[A : Compare] SortedSet::inter(Self[A], Self[A]) -> Self[A]
+#alias(inter, deprecated)
 fn[A : Compare] SortedSet::intersection(Self[A], Self[A]) -> Self[A]
 fn[A] SortedSet::is_empty(Self[A]) -> Bool
 fn[A] SortedSet::iter(Self[A]) -> Iter[A]

--- a/option/deprecated.mbt
+++ b/option/deprecated.mbt
@@ -45,33 +45,6 @@ pub fn[T] some(value : T) -> T? {
 }
 
 ///|
-#deprecated("use unwrap_or instead", skip_current_package=false)
-pub fn[T] Option::or(self : T?, default : T) -> T {
-  match self {
-    None => default
-    Some(t) => t
-  }
-}
-
-///|
-#deprecated("use unwrap_or_else instead", skip_current_package=false)
-pub fn[T] Option::or_else(self : T?, default : () -> T) -> T {
-  match self {
-    None => default()
-    Some(t) => t
-  }
-}
-
-///|
-#deprecated("use unwrap_or_default instead", skip_current_package=false)
-pub fn[T : Default] Option::or_default(self : T?) -> T {
-  match self {
-    None => T::default()
-    Some(t) => t
-  }
-}
-
-///|
 /// Checks if the option contains a value.
 #deprecated("use `x is Some(_)` instead", skip_current_package=false)
 pub fn[T] Option::is_some(self : T?) -> Bool {

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -202,6 +202,7 @@ test "filter" {
 
 ///|
 /// Return the contained `Some` value or the provided default.
+#alias(or, deprecated)
 pub fn[T] Option::unwrap_or(self : T?, default : T) -> T {
   match self {
     None => default
@@ -220,6 +221,7 @@ test "unwrap_or" {
 /// Return the contained `Some` value or the provided default.
 ///
 /// Default is lazily evaluated
+#alias(or_else, deprecated)
 pub fn[T] Option::unwrap_or_else(
   self : T?,
   default : () -> T raise?,
@@ -239,6 +241,7 @@ test "or else" {
 
 ///|
 /// Return the contained `Some` value or the result of the `T::default()`.
+#alias(or_default, deprecated)
 pub fn[T : Default] Option::unwrap_or_default(self : T?) -> T {
   match self {
     None => T::default()

--- a/option/pkg.generated.mbti
+++ b/option/pkg.generated.mbti
@@ -35,15 +35,12 @@ fn[T] Option::iterator(T?) -> Iterator[T]
 fn[T, U] Option::map(T?, (T) -> U raise?) -> U? raise?
 fn[T, U] Option::map_or(T?, U, (T) -> U raise?) -> U raise?
 fn[T, U] Option::map_or_else(T?, () -> U raise?, (T) -> U raise?) -> U raise?
-#deprecated
-fn[T] Option::or(T?, T) -> T
-#deprecated
-fn[T : Default] Option::or_default(T?) -> T
-#deprecated
-fn[T] Option::or_else(T?, () -> T) -> T
 fn[T, Err : Error] Option::or_error(T?, Err) -> T raise Err
+#alias(or, deprecated)
 fn[T] Option::unwrap_or(T?, T) -> T
+#alias(or_default, deprecated)
 fn[T : Default] Option::unwrap_or_default(T?) -> T
+#alias(or_else, deprecated)
 fn[T] Option::unwrap_or_else(T?, () -> T raise?) -> T raise?
 impl[X : Compare] Compare for X?
 impl[X] Default for X?

--- a/queue/deprecated.mbt
+++ b/queue/deprecated.mbt
@@ -11,17 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `unsafe_peek` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A] Queue::peek_exn(self : Queue[A]) -> A {
-  self.unsafe_peek()
-}
-
-///|
-#deprecated("Use `unsafe_pop` instead", skip_current_package=false)
-#coverage.skip
-pub fn[A] Queue::pop_exn(self : Queue[A]) -> A {
-  self.unsafe_pop()
-}

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -33,14 +33,12 @@ fn[A] Queue::length(Self[A]) -> Int
 #as_free_fn
 fn[A] Queue::new() -> Self[A]
 fn[A] Queue::peek(Self[A]) -> A?
-#deprecated
-fn[A] Queue::peek_exn(Self[A]) -> A
 fn[A] Queue::pop(Self[A]) -> A?
-#deprecated
-fn[A] Queue::pop_exn(Self[A]) -> A
 fn[A] Queue::push(Self[A], A) -> Unit
 fn[A] Queue::transfer(Self[A], Self[A]) -> Unit
+#alias(peek_exn, deprecated)
 fn[A] Queue::unsafe_peek(Self[A]) -> A
+#alias(pop_exn, deprecated)
 fn[A] Queue::unsafe_pop(Self[A]) -> A
 impl[A : Show] Show for Queue[A]
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Queue[X]

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -131,6 +131,7 @@ pub fn[A] Queue::push(self : Queue[A], x : A) -> Unit {
 ///   assert_eq(queue.unsafe_peek(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
+#alias(peek_exn, deprecated)
 pub fn[A] Queue::unsafe_peek(self : Queue[A]) -> A {
   match self.first {
     None => abort("Queue is empty")
@@ -162,6 +163,7 @@ pub fn[A] Queue::peek(self : Queue[A]) -> A? {
 ///   assert_eq(queue.unsafe_pop(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
+#alias(pop_exn, deprecated)
 pub fn[A] Queue::unsafe_pop(self : Queue[A]) -> A {
   match self.first {
     None => abort("Queue is empty")

--- a/set/deprecated.mbt
+++ b/set/deprecated.mbt
@@ -11,10 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-#deprecated("Use `add` instead.", skip_current_package=false)
-#coverage.skip
-pub fn[K : Hash + Eq] Set::insert(self : Set[K], key : K) -> Unit {
-  self.add(key)
-}

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -106,6 +106,7 @@ pub fn[K : Hash + Eq] Set::from_array(arr : ArrayView[K]) -> Set[K] {
 ///   set.add("key") // no effect since it already exists
 ///   inspect(set.length(), content="1")
 /// ```
+#alias(insert, deprecated)
 pub fn[K : Hash + Eq] Set::add(self : Set[K], key : K) -> Unit {
   self.add_with_hash(key, key.hash())
 }

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -7,6 +7,7 @@ package "moonbitlang/core/set"
 
 // Types and methods
 type Set[K]
+#alias(insert, deprecated)
 fn[K : Hash + Eq] Set::add(Self[K], K) -> Unit
 fn[K : Hash + Eq] Set::add_and_check(Self[K], K) -> Bool
 fn[K] Set::capacity(Self[K]) -> Int
@@ -24,8 +25,6 @@ fn[K : Hash + Eq] Set::from_array(ArrayView[K]) -> Self[K]
 fn[K : Hash + Eq] Set::from_iter(Iter[K]) -> Self[K]
 #as_free_fn
 fn[K : Hash + Eq] Set::from_iterator(Iterator[K]) -> Self[K]
-#deprecated
-fn[K : Hash + Eq] Set::insert(Self[K], K) -> Unit
 fn[K : Hash + Eq] Set::intersection(Self[K], Self[K]) -> Self[K]
 fn[K : Hash + Eq] Set::is_disjoint(Self[K], Self[K]) -> Bool
 fn[K] Set::is_empty(Self[K]) -> Bool

--- a/sorted_set/deprecated.mbt
+++ b/sorted_set/deprecated.mbt
@@ -11,38 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-/// It is just copying the tree structure, not the values.
-/// It requires a Clone trait on T, which we don't have yet.
-///
-#deprecated("Use `copy` instead", skip_current_package=false)
-#coverage.skip
-pub fn[V] SortedSet::deep_clone(self : SortedSet[V]) -> SortedSet[V] {
-  self.copy()
-}
-
-///|
-/// Returns the difference of two sets.
-///
-#deprecated("Use `difference` instead", skip_current_package=false)
-#coverage.skip
-pub fn[V : Compare] SortedSet::diff(
-  self : SortedSet[V],
-  src : SortedSet[V],
-) -> SortedSet[V] {
-  let ret = new()
-  self.each(x => if !src.contains(x) { ret.add(x) })
-  ret
-}
-
-///|
-/// Returns the intersection of two sets.
-#deprecated("Use `intersection` instead", skip_current_package=false)
-#coverage.skip
-pub fn[V : Compare] SortedSet::intersect(
-  self : SortedSet[V],
-  src : SortedSet[V],
-) -> SortedSet[V] {
-  self.intersection(src)
-}

--- a/sorted_set/pkg.generated.mbti
+++ b/sorted_set/pkg.generated.mbti
@@ -15,11 +15,9 @@ import(
 type SortedSet[V]
 fn[V : Compare] SortedSet::add(Self[V], V) -> Unit
 fn[V : Compare] SortedSet::contains(Self[V], V) -> Bool
+#alias(deep_clone, deprecated)
 fn[V] SortedSet::copy(Self[V]) -> Self[V]
-#deprecated
-fn[V] SortedSet::deep_clone(Self[V]) -> Self[V]
-#deprecated
-fn[V : Compare] SortedSet::diff(Self[V], Self[V]) -> Self[V]
+#alias(diff, deprecated)
 fn[V : Compare] SortedSet::difference(Self[V], Self[V]) -> Self[V]
 fn[V : Compare] SortedSet::disjoint(Self[V], Self[V]) -> Bool
 fn[V] SortedSet::each(Self[V], (V) -> Unit raise?) -> Unit raise?
@@ -32,8 +30,7 @@ fn[V : Compare] SortedSet::from_array(ArrayView[V]) -> Self[V]
 fn[V : Compare] SortedSet::from_iter(Iter[V]) -> Self[V]
 #as_free_fn
 fn[V : Compare] SortedSet::from_iterator(Iterator[V]) -> Self[V]
-#deprecated
-fn[V : Compare] SortedSet::intersect(Self[V], Self[V]) -> Self[V]
+#alias(intersect, deprecated)
 fn[V : Compare] SortedSet::intersection(Self[V], Self[V]) -> Self[V]
 fn[V] SortedSet::is_empty(Self[V]) -> Bool
 fn[V] SortedSet::iter(Self[V]) -> Iter[V]

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -46,6 +46,7 @@ pub fn[V : Compare] SortedSet::from_array(array : ArrayView[V]) -> SortedSet[V] 
 /// 
 /// It is just copying the tree structure, not the values.
 /// 
+#alias(deep_clone, deprecated)
 pub fn[V] SortedSet::copy(self : SortedSet[V]) -> SortedSet[V] {
   match self.root {
     None => new()
@@ -253,6 +254,7 @@ fn[V] join_right(l : Node[V]?, v : V, r : Node[V]?) -> Node[V] {
 
 ///|
 /// Returns the difference of two sets.
+#alias(diff, deprecated)
 pub fn[V : Compare] SortedSet::difference(
   self : SortedSet[V],
   src : SortedSet[V],
@@ -295,6 +297,7 @@ pub fn[V : Compare] SortedSet::symmetric_difference(
 
 ///|
 /// Returns the intersection of two sets.
+#alias(intersect, deprecated)
 pub fn[V : Compare] SortedSet::intersection(
   self : SortedSet[V],
   src : SortedSet[V],


### PR DESCRIPTION
This PR removes all methods that were deprecated due to renaming and adds the `#alias(name, deprecated)` annotation to their corresponding methods.