### PR TITLE
feat(bytes): add missing methods to Bytes for API consistency with By…

### DIFF
--- a/bytes/bitstring.mbt
+++ b/bytes/bitstring.mbt
@@ -454,3 +454,61 @@ pub fn Bytes::unsafe_extract_bytesview(
 ) -> BytesView {
   bs[:].unsafe_extract_bytesview(offset, len)
 }
+
+///|
+/// Extract a single bit as a signed integer.
+#internal(experimental, "subject to breaking change without notice")
+pub fn Bytes::unsafe_extract_bit_signed(
+  bs : Bytes,
+  offset : Int,
+  len : Int,
+) -> Int {
+  bs[:].unsafe_extract_bit_signed(offset, len)
+}
+
+///|
+/// Extract [2..8] bits as a signed integer.
+#internal(experimental, "subject to breaking change without notice")
+pub fn Bytes::unsafe_extract_byte_signed(
+  bs : Bytes,
+  offset : Int,
+  len : Int,
+) -> Int {
+  bs[:].unsafe_extract_byte_signed(offset, len)
+}
+
+///|
+/// Extract [9..32] bits as a signed integer in little-endian byte order.
+#internal(experimental, "subject to breaking change without notice")
+pub fn Bytes::unsafe_extract_int_le(bs : Bytes, offset : Int, len : Int) -> Int {
+  bs[:].unsafe_extract_int_le(offset, len)
+}
+
+///|
+/// Extract [9..32] bits as a signed integer in big-endian byte order.
+#internal(experimental, "subject to breaking change without notice")
+pub fn Bytes::unsafe_extract_int_be(bs : Bytes, offset : Int, len : Int) -> Int {
+  bs[:].unsafe_extract_int_be(offset, len)
+}
+
+///|
+/// Extract [33..64] bits as a signed integer in little-endian byte order.
+#internal(experimental, "subject to breaking change without notice")
+pub fn Bytes::unsafe_extract_int64_le(
+  bs : Bytes,
+  offset : Int,
+  len : Int,
+) -> Int64 {
+  bs[:].unsafe_extract_int64_le(offset, len)
+}
+
+///|
+/// Extract [33..64] bits as a signed integer in big-endian byte order.
+#internal(experimental, "subject to breaking change without notice")
+pub fn Bytes::unsafe_extract_int64_be(
+  bs : Bytes,
+  offset : Int,
+  len : Int,
+) -> Int64 {
+  bs[:].unsafe_extract_int64_be(offset, len)
+}

--- a/bytes/methods.mbt
+++ b/bytes/methods.mbt
@@ -61,3 +61,83 @@ pub fn BytesView::rev_find(target : BytesView, pattern : BytesView) -> Int? {
 pub fn Bytes::rev_find(target : Bytes, pattern : BytesView) -> Int? {
   target[:].rev_find(pattern)
 }
+
+///|
+/// Converts 4 bytes to a 32-bit unsigned integer using big-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_uint_be(self : Bytes) -> UInt {
+  self[:].to_uint_be()
+}
+
+///|
+/// Converts 4 bytes to a 32-bit unsigned integer using little-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_uint_le(self : Bytes) -> UInt {
+  self[:].to_uint_le()
+}
+
+///|
+/// Converts 8 bytes to a 64-bit unsigned integer using big-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_uint64_be(self : Bytes) -> UInt64 {
+  self[:].to_uint64_be()
+}
+
+///|
+/// Converts 8 bytes to a 64-bit unsigned integer using little-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_uint64_le(self : Bytes) -> UInt64 {
+  self[:].to_uint64_le()
+}
+
+///|
+/// Converts 4 bytes to a 32-bit signed integer using big-endian byte order.
+pub fn Bytes::to_int_be(self : Bytes) -> Int {
+  self[:].to_int_be()
+}
+
+///|
+/// Converts 4 bytes to a 32-bit signed integer using little-endian byte order.
+pub fn Bytes::to_int_le(self : Bytes) -> Int {
+  self[:].to_int_le()
+}
+
+///|
+/// Converts 8 bytes to a 64-bit signed integer using big-endian byte order.
+pub fn Bytes::to_int64_be(self : Bytes) -> Int64 {
+  self[:].to_int64_be()
+}
+
+///|
+/// Converts 8 bytes to a 64-bit signed integer using little-endian byte order.
+pub fn Bytes::to_int64_le(self : Bytes) -> Int64 {
+  self[:].to_int64_le()
+}
+
+///|
+/// Converts 4 bytes to a 32-bit floating-point number using big-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_float_be(self : Bytes) -> Float {
+  self[:].to_float_be()
+}
+
+///|
+/// Converts 4 bytes to a 32-bit floating-point number using little-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_float_le(self : Bytes) -> Float {
+  self[:].to_float_le()
+}
+
+///|
+/// Converts 8 bytes to a 64-bit floating-point number using big-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_double_be(self : Bytes) -> Double {
+  self[:].to_double_be()
+}
+
+///|
+/// Converts 8 bytes to a 64-bit floating-point number using little-endian byte order.
+#deprecated(skip_current_package=false, "Use bits pattern directly")
+pub fn Bytes::to_double_le(self : Bytes) -> Double {
+  self[:].to_double_le()
+}

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -33,11 +33,37 @@ fn Bytes::rev_find(Bytes, BytesView) -> Int?
 #alias("_[_:_]")
 fn Bytes::sub(Bytes, start? : Int, end? : Int) -> BytesView
 fn Bytes::to_array(Bytes) -> Array[Byte]
+#deprecated
+fn Bytes::to_double_be(Bytes) -> Double
+#deprecated
+fn Bytes::to_double_le(Bytes) -> Double
 #label_migration(len, fill=false)
 fn Bytes::to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
+#deprecated
+fn Bytes::to_float_be(Bytes) -> Float
+#deprecated
+fn Bytes::to_float_le(Bytes) -> Float
+fn Bytes::to_int64_be(Bytes) -> Int64
+fn Bytes::to_int64_le(Bytes) -> Int64
+fn Bytes::to_int_be(Bytes) -> Int
+fn Bytes::to_int_le(Bytes) -> Int
+#deprecated
+fn Bytes::to_uint64_be(Bytes) -> UInt64
+#deprecated
+fn Bytes::to_uint64_le(Bytes) -> UInt64
+#deprecated
+fn Bytes::to_uint_be(Bytes) -> UInt
+#deprecated
+fn Bytes::to_uint_le(Bytes) -> UInt
 fn Bytes::unsafe_extract_bit(Bytes, Int, Int) -> UInt
+fn Bytes::unsafe_extract_bit_signed(Bytes, Int, Int) -> Int
 fn Bytes::unsafe_extract_byte(Bytes, Int, Int) -> UInt
+fn Bytes::unsafe_extract_byte_signed(Bytes, Int, Int) -> Int
 fn Bytes::unsafe_extract_bytesview(Bytes, Int, Int) -> BytesView
+fn Bytes::unsafe_extract_int64_be(Bytes, Int, Int) -> Int64
+fn Bytes::unsafe_extract_int64_le(Bytes, Int, Int) -> Int64
+fn Bytes::unsafe_extract_int_be(Bytes, Int, Int) -> Int
+fn Bytes::unsafe_extract_int_le(Bytes, Int, Int) -> Int
 fn Bytes::unsafe_extract_uint64_be(Bytes, Int, Int) -> UInt64
 fn Bytes::unsafe_extract_uint64_le(Bytes, Int, Int) -> UInt64
 fn Bytes::unsafe_extract_uint_be(Bytes, Int, Int) -> UInt
@@ -60,6 +86,7 @@ fn BytesView::data(Self) -> Bytes
 fn BytesView::find(Self, Self) -> Int?
 fn BytesView::get(Self, Int) -> Byte?
 fn BytesView::iter(Self) -> Iter[Byte]
+fn BytesView::iter2(Self) -> Iter2[Int, Byte]
 fn BytesView::iterator(Self) -> Iterator[Byte]
 fn BytesView::iterator2(Self) -> Iterator2[Int, Byte]
 fn BytesView::length(Self) -> Int

--- a/bytes/view.mbt
+++ b/bytes/view.mbt
@@ -219,6 +219,28 @@ pub fn BytesView::iter(self : BytesView) -> Iter[Byte] {
 }
 
 ///|
+/// Creates an iterator that yields tuples of index and byte,
+/// indices start from 0.
+/// 
+/// # Example
+/// 
+/// ```mbt
+///   let bv = b"\x00\x01\x02\x03\x04\x05"[:]
+///   let mut sum = 0
+///   bv.iter2().each((i, x) => { sum = sum + i + x.to_int() })
+///   inspect(sum, content="30")
+/// ```
+pub fn BytesView::iter2(self : BytesView) -> Iter2[Int, Byte] {
+  Iter2::new(yield_ => for i in 0..<self.length() {
+    if yield_(i, self[i]) is IterEnd {
+      break IterEnd
+    }
+  } else {
+    IterContinue
+  })
+}
+
+///|
 /// Returns an iterator over the `View`.
 /// 
 /// # Example


### PR DESCRIPTION
…tesView

- Add iter2() to BytesView for indexed iteration
- Add signed extraction methods to Bytes:
  * unsafe_extract_bit_signed
  * unsafe_extract_byte_signed
  * unsafe_extract_int_be/le
  * unsafe_extract_int64_be/le
- Add numeric conversion methods to Bytes:
  * to_int_be/le, to_int64_be/le
  * to_uint_be/le, to_uint64_be/le (deprecated)
  * to_float_be/le, to_double_be/le (deprecated)

All new Bytes methods delegate to BytesView via bs[:] for consistency. All tests pass (173/173).