### PR TITLE
fix: delay removal of @string.View

### DIFF
--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/string"
 
+import(
+  "moonbitlang/core/builtin"
+)
+
 // Values
 fn default() -> String
 
@@ -124,6 +128,7 @@ fn StringView::trim_space(Self) -> Self
 fn StringView::trim_start(Self, chars~ : Self) -> Self
 
 // Type aliases
+pub using @builtin {type StringView as View}
 
 // Traits
 pub trait ToStringView {

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -269,3 +269,6 @@ pub fn StringView::offset_of_nth_char(self : StringView, i : Int) -> Int? {
     None
   }
 }
+
+///|
+pub type View = StringView


### PR DESCRIPTION
There are a few packages that haven't migrated to StringView. We'll migrate them asap. In the mean time, we delay the removal of `@string.View`