### PR TITLE
fix(iter): remove intrinsic on Iter::fold

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -110,7 +110,6 @@ pub fn[T] Iter::eachi(
 /// # Returns
 ///
 /// Returns the final accumulator value after folding all elements of the iterator.
-#intrinsic("%iter.reduce")
 #locals(f)
 pub fn[T, B] Iter::fold(
   self : Iter[T],


### PR DESCRIPTION
With error polymorphism involved, the intrinsic on `Iter::fold` no longer matches the behavior, and will cause ICE in the compiler.

This PR fixes: https://github.com/moonbitlang/moonbit-docs/issues/1035