### PR TITLE
hongbo/factor out ref

### DIFF
--- a/array/moon.pkg.json
+++ b/array/moon.pkg.json
@@ -10,7 +10,8 @@
     "moonbitlang/core/char",
     "moonbitlang/core/test",
     "moonbitlang/core/random",
-    "moonbitlang/core/json"
+    "moonbitlang/core/json",
+    "moonbitlang/core/ref"
   ],
   "targets": {
     "array_js.mbt": ["js"],

--- a/builtin/moon.pkg.json
+++ b/builtin/moon.pkg.json
@@ -13,7 +13,8 @@
     "moonbitlang/core/int64",
     "moonbitlang/core/uint",
     "moonbitlang/core/json",
-    "moonbitlang/core/bigint"
+    "moonbitlang/core/bigint",
+    "moonbitlang/core/ref"
   ],
   "alert-list": "-test_import_all",
   "targets": {

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -689,7 +689,6 @@ fn Bytes::unsafe_get(Bytes, Int) -> Byte
 
 
 
-
 #alias("_[_]")
 fn StringView::at(Self, Int) -> Int
 fn StringView::char_length(Self) -> Int
@@ -944,7 +943,6 @@ impl Show for String
 impl[X : Show] Show for X?
 impl[T : Show, E : Show] Show for Result[T, E]
 impl[X : Show] Show for FixedArray[X]
-impl[X : Show] Show for Ref[X]
 impl[A : Show, B : Show] Show for (A, B)
 impl[A : Show, B : Show, C : Show] Show for (A, B, C)
 impl[A : Show, B : Show, C : Show, D : Show] Show for (A, B, C, D)

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -197,11 +197,6 @@ pub impl[T : Show, E : Show] Show for Result[T, E] with output(self, logger) {
 }
 
 ///|
-pub impl[X : Show] Show for Ref[X] with output(self, logger) {
-  logger..write_string("{val: ")..write_object(self.val)..write_string("}")
-}
-
-///|
 pub impl[X : Show] Show for FixedArray[X] with output(self, logger) {
   logger.write_iter(self.iter())
 }

--- a/ref/moon.pkg.json
+++ b/ref/moon.pkg.json
@@ -1,3 +1,4 @@
 {
-  "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"]
+  "import": ["moonbitlang/core/builtin", "moonbitlang/core/quickcheck"],
+  "test-import": []
 }

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -18,6 +18,7 @@ fn[T, R] Ref::protect(Self[T], T, () -> R raise?) -> R raise?
 #as_free_fn
 fn[T] Ref::swap(Self[T], Self[T]) -> Unit
 fn[T] Ref::update(Self[T], (T) -> T raise?) -> Unit raise?
+impl[X : Show] Show for Ref[X]
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Ref[X]
 
 // Type aliases

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 ///|
+pub impl[X : Show] Show for Ref[X] with output(self, logger) {
+  logger..write_string("{val: ")..write_object(self.val)..write_string("}")
+}
+
+///|
 /// create a reference from value
 pub fn[T] Ref::new(x : T) -> Ref[T] {
   { val: x }

--- a/ref/ref_test.mbt
+++ b/ref/ref_test.mbt
@@ -27,6 +27,7 @@ test "protect" {
   x.protect(2, () => r = x.val)
   assert_eq(r, 2)
   assert_eq(x.val, 1)
+  inspect(x, content="{val: 1}")
 }
 
 ///|


### PR DESCRIPTION
- **refactor(option): replace flatten method with bind in tests and documentation**
- **1. move Ref outside builtin 2. todo downgrade Ref to user defined type(no magic in compiler)**
