### PR TITLE
Add #doc(hidden) to all #internal functions

### DIFF
--- a/array/bitstring.mbt
+++ b/array/bitstring.mbt
@@ -33,6 +33,7 @@ fn UInt64::extend_sign(self : UInt64, len : Int) -> Int64 {
 ///|
 /// Extract a single bit.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_bit(
   bs : ArrayView[Byte],
   offset : Int,
@@ -51,6 +52,7 @@ pub fn ArrayView::unsafe_extract_bit(
 ///|
 /// Extract a single bit.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_bit_signed(
   bs : ArrayView[Byte],
   offset : Int,
@@ -69,6 +71,7 @@ pub fn ArrayView::unsafe_extract_bit_signed(
 ///|
 /// Extract [2..8] bits.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_byte(
   bs : ArrayView[Byte],
   offset : Int,
@@ -106,6 +109,7 @@ pub fn ArrayView::unsafe_extract_byte(
 /// - Only reads the necessary number of bytes based on the bit length
 ///
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_uint_le(
   bs : ArrayView[Byte],
   offset : Int,
@@ -143,6 +147,7 @@ pub fn ArrayView::unsafe_extract_uint_le(
 /// - Only reads the necessary number of bytes based on the bit length
 ///
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_uint_be(
   bs : ArrayView[Byte],
   offset : Int,
@@ -187,6 +192,7 @@ pub fn ArrayView::unsafe_extract_uint_be(
 /// - For bit lengths < 33, use unsafe_extract_int_le instead
 ///
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_uint64_le(
   bs : ArrayView[Byte],
   offset : Int,
@@ -248,6 +254,7 @@ pub fn ArrayView::unsafe_extract_uint64_le(
 /// - For bit lengths < 33, use unsafe_extract_int_be instead
 ///
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_uint64_be(
   bs : ArrayView[Byte],
   offset : Int,
@@ -321,6 +328,7 @@ pub fn ArrayView::unsafe_extract_uint64_be(
 /// Extract a subview from a view. `offset` and `len` are in bits and must be
 /// aligned to bytes.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_bytesview(
   bs : ArrayView[Byte],
   offset : Int,
@@ -334,6 +342,7 @@ pub fn ArrayView::unsafe_extract_bytesview(
 ///|
 /// Extract [2..8] bits as a signed integer.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_byte_signed(
   bs : ArrayView[Byte],
   offset : Int,
@@ -346,6 +355,7 @@ pub fn ArrayView::unsafe_extract_byte_signed(
 ///|
 /// Extract [9..32] bits as a signed integer.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_int_le(
   bs : ArrayView[Byte],
   offset : Int,
@@ -358,6 +368,7 @@ pub fn ArrayView::unsafe_extract_int_le(
 ///|
 /// Extract [9..32] bits as a signed integer.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_int_be(
   bs : ArrayView[Byte],
   offset : Int,
@@ -370,6 +381,7 @@ pub fn ArrayView::unsafe_extract_int_be(
 ///|
 /// Extract [33..64] bits as a signed integer.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_int64_le(
   bs : ArrayView[Byte],
   offset : Int,
@@ -382,6 +394,7 @@ pub fn ArrayView::unsafe_extract_int64_le(
 ///|
 /// Extract [33..64] bits as a signed integer.
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn ArrayView::unsafe_extract_int64_be(
   bs : ArrayView[Byte],
   offset : Int,
@@ -396,6 +409,7 @@ pub fn ArrayView::unsafe_extract_int64_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Array::unsafe_extract_bit(
   bs : Array[Byte],
   offset : Int,
@@ -406,6 +420,7 @@ pub fn Array::unsafe_extract_bit(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Array::unsafe_extract_byte(
   bs : Array[Byte],
   offset : Int,
@@ -416,6 +431,7 @@ pub fn Array::unsafe_extract_byte(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Array::unsafe_extract_uint_le(
   bs : Array[Byte],
   offset : Int,
@@ -426,6 +442,7 @@ pub fn Array::unsafe_extract_uint_le(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Array::unsafe_extract_uint_be(
   bs : Array[Byte],
   offset : Int,
@@ -436,6 +453,7 @@ pub fn Array::unsafe_extract_uint_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Array::unsafe_extract_uint64_le(
   bs : Array[Byte],
   offset : Int,
@@ -446,6 +464,7 @@ pub fn Array::unsafe_extract_uint64_le(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Array::unsafe_extract_uint64_be(
   bs : Array[Byte],
   offset : Int,
@@ -456,6 +475,7 @@ pub fn Array::unsafe_extract_uint64_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Array::unsafe_extract_bytesview(
   bs : Array[Byte],
   offset : Int,
@@ -470,6 +490,7 @@ pub fn Array::unsafe_extract_bytesview(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn FixedArray::unsafe_extract_bit(
   bs : FixedArray[Byte],
   offset : Int,
@@ -480,6 +501,7 @@ pub fn FixedArray::unsafe_extract_bit(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn FixedArray::unsafe_extract_byte(
   bs : FixedArray[Byte],
   offset : Int,
@@ -490,6 +512,7 @@ pub fn FixedArray::unsafe_extract_byte(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn FixedArray::unsafe_extract_uint_le(
   bs : FixedArray[Byte],
   offset : Int,
@@ -500,6 +523,7 @@ pub fn FixedArray::unsafe_extract_uint_le(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn FixedArray::unsafe_extract_uint_be(
   bs : FixedArray[Byte],
   offset : Int,
@@ -510,6 +534,7 @@ pub fn FixedArray::unsafe_extract_uint_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn FixedArray::unsafe_extract_uint64_le(
   bs : FixedArray[Byte],
   offset : Int,
@@ -520,6 +545,7 @@ pub fn FixedArray::unsafe_extract_uint64_le(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn FixedArray::unsafe_extract_uint64_be(
   bs : FixedArray[Byte],
   offset : Int,
@@ -530,6 +556,7 @@ pub fn FixedArray::unsafe_extract_uint64_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn FixedArray::unsafe_extract_bytesview(
   bs : FixedArray[Byte],
   offset : Int,

--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -45,13 +45,6 @@ fn[T, K : Compare] FixedArray::sort_by_key(Self[T], (T) -> K) -> Unit
 fn[T : Compare] FixedArray::stable_sort(Self[T]) -> Unit
 fn[T : Eq] FixedArray::starts_with(Self[T], Self[T]) -> Bool
 fn[T] FixedArray::swap(Self[T], Int, Int) -> Unit
-fn FixedArray::unsafe_extract_bit(Self[Byte], Int, Int) -> UInt
-fn FixedArray::unsafe_extract_byte(Self[Byte], Int, Int) -> UInt
-fn FixedArray::unsafe_extract_bytesview(Self[Byte], Int, Int) -> ArrayView[Byte]
-fn FixedArray::unsafe_extract_uint64_be(Self[Byte], Int, Int) -> UInt64
-fn FixedArray::unsafe_extract_uint64_le(Self[Byte], Int, Int) -> UInt64
-fn FixedArray::unsafe_extract_uint_be(Self[Byte], Int, Int) -> UInt
-fn FixedArray::unsafe_extract_uint_le(Self[Byte], Int, Int) -> UInt
 fn FixedArray::unsafe_write_uint16_be(Self[Byte], Int, UInt16) -> Unit
 fn FixedArray::unsafe_write_uint16_le(Self[Byte], Int, UInt16) -> Unit
 fn FixedArray::unsafe_write_uint32_be(Self[Byte], Int, UInt) -> Unit
@@ -119,13 +112,6 @@ fn[T] Array::shuffle_in_place(Self[T], rand~ : (Int) -> Int) -> Unit
 fn[T : Compare] Array::sort(Self[T]) -> Unit
 fn[T] Array::sort_by(Self[T], (T, T) -> Int) -> Unit
 fn[T, K : Compare] Array::sort_by_key(Self[T], (T) -> K) -> Unit
-fn Array::unsafe_extract_bit(Self[Byte], Int, Int) -> UInt
-fn Array::unsafe_extract_byte(Self[Byte], Int, Int) -> UInt
-fn Array::unsafe_extract_bytesview(Self[Byte], Int, Int) -> ArrayView[Byte]
-fn Array::unsafe_extract_uint64_be(Self[Byte], Int, Int) -> UInt64
-fn Array::unsafe_extract_uint64_le(Self[Byte], Int, Int) -> UInt64
-fn Array::unsafe_extract_uint_be(Self[Byte], Int, Int) -> UInt
-fn Array::unsafe_extract_uint_le(Self[Byte], Int, Int) -> UInt
 fn[T1, T2] Array::unzip(Self[(T1, T2)]) -> (Self[T1], Self[T2])
 fn[A, B] Array::zip(Self[A], Self[B]) -> Self[(A, B)]
 fn[A, B] Array::zip_to_iter2(Self[A], Self[B]) -> Iter2[A, B]
@@ -150,19 +136,6 @@ fn[A, B] ArrayView::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B 
 fn[X] ArrayView::rev_iterator(Self[X]) -> Iterator[X]
 fn[T] ArrayView::start_offset(Self[T]) -> Int
 fn[T] ArrayView::to_array(Self[T]) -> Array[T]
-fn ArrayView::unsafe_extract_bit(Self[Byte], Int, Int) -> UInt
-fn ArrayView::unsafe_extract_bit_signed(Self[Byte], Int, Int) -> Int
-fn ArrayView::unsafe_extract_byte(Self[Byte], Int, Int) -> UInt
-fn ArrayView::unsafe_extract_byte_signed(Self[Byte], Int, Int) -> Int
-fn ArrayView::unsafe_extract_bytesview(Self[Byte], Int, Int) -> Self[Byte]
-fn ArrayView::unsafe_extract_int64_be(Self[Byte], Int, Int) -> Int64
-fn ArrayView::unsafe_extract_int64_le(Self[Byte], Int, Int) -> Int64
-fn ArrayView::unsafe_extract_int_be(Self[Byte], Int, Int) -> Int
-fn ArrayView::unsafe_extract_int_le(Self[Byte], Int, Int) -> Int
-fn ArrayView::unsafe_extract_uint64_be(Self[Byte], Int, Int) -> UInt64
-fn ArrayView::unsafe_extract_uint64_le(Self[Byte], Int, Int) -> UInt64
-fn ArrayView::unsafe_extract_uint_be(Self[Byte], Int, Int) -> UInt
-fn ArrayView::unsafe_extract_uint_le(Self[Byte], Int, Int) -> UInt
 impl[T : Compare] Compare for ArrayView[T]
 impl[T : Eq] Eq for ArrayView[T]
 impl[A : Hash] Hash for ArrayView[A]

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1689,6 +1689,7 @@ pub impl[T] Default for Array[T] with default() {
 ///   assert_eq(array.last(), Some(4))
 /// ```
 #internal(unsafe, "Panic if the array is empty on non-JS backend.")
+#doc(hidden)
 pub fn[A] Array::unsafe_pop_back(self : Array[A]) -> Unit {
   self.unsafe_pop() |> ignore
 }

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -44,6 +44,7 @@
 /// ```
 ///
 #internal(unsafe, "Panic if the indices or length are out of bounds")
+#doc(hidden)
 pub fn[A] Array::unsafe_blit(
   dst : Array[A],
   dst_offset : Int,

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -206,6 +206,7 @@ pub fn[T] Array::pop(self : Array[T]) -> T? {
 /// behavior on the JavaScript platform. Use with caution.
 ///
 #internal(unsafe, "Panic if the array is empty.")
+#doc(hidden)
 #alias(pop_exn, deprecated)
 pub fn[T] Array::unsafe_pop(self : Array[T]) -> T {
   JSArray::ofAnyArray(self).pop().toAny()

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -279,6 +279,7 @@ pub fn[T] Array::pop(self : Array[T]) -> T? {
 /// ```
 ///
 #internal(unsafe, "Panic if the array is empty.")
+#doc(hidden)
 #alias(pop_exn, deprecated)
 pub fn[T] Array::unsafe_pop(self : Array[T]) -> T {
   let len = self.length()

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -115,6 +115,7 @@ pub fn[T] ArrayView::at(self : ArrayView[T], index : Int) -> T {
 /// ```
 #intrinsic("%arrayview.unsafe_get")
 #internal(unsafe, "Panic if index is out of bounds")
+#doc(hidden)
 pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
   self.buf()[self.start() + index]
 }

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -19,6 +19,7 @@
 /// byte sequence, so any modification to the original byte sequence will be
 /// reflected in the `Bytes` object.
 #internal(unsafe, "Creating mutable Bytes")
+#doc(hidden)
 pub fn FixedArray::unsafe_reinterpret_as_bytes(
   self : FixedArray[Byte],
 ) -> Bytes = "%identity"

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1254,6 +1254,7 @@ pub fn Bytes::at(self : Bytes, idx : Int) -> Byte = "%bytes_get"
 /// ```
 ///
 #internal(unsafe, "Panic if index is out of bounds")
+#doc(hidden)
 pub fn Bytes::unsafe_get(self : Bytes, idx : Int) -> Byte = "%bytes.unsafe_get"
 
 ///|
@@ -1434,10 +1435,12 @@ pub fn[T] FixedArray::at(self : FixedArray[T], idx : Int) -> T = "%fixedarray.ge
 /// ```
 ///
 #internal(unsafe, "Panic if index is out of bounds")
+#doc(hidden)
 pub fn[T] FixedArray::unsafe_get(self : FixedArray[T], idx : Int) -> T = "%fixedarray.unsafe_get"
 
 ///|
 #internal(unsafe, "Panic if index is out of bounds")
+#doc(hidden)
 pub fn[T] FixedArray::unsafe_set(
   self : FixedArray[T],
   idx : Int,
@@ -1577,6 +1580,7 @@ pub fn String::at(self : String, idx : Int) -> Int = "%string_get"
 /// ```
 /// TODO: rename to `unsafe_get`
 #internal(unsafe, "Panic if index is out of bounds.")
+#doc(hidden)
 pub fn String::unsafe_charcode_at(self : String, idx : Int) -> Int = "%string.unsafe_get"
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -141,12 +141,8 @@ fn[T] Array::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 fn[T] Array::suffixes(Self[T], include_empty? : Bool) -> Iterator[ArrayView[T]]
 fn[T] Array::swap(Self[T], Int, Int) -> Unit
 fn[A] Array::truncate(Self[A], Int) -> Unit
-fn[A] Array::unsafe_blit(Self[A], Int, Self[A], Int, Int) -> Unit
 fn[A] Array::unsafe_blit_fixed(Self[A], Int, FixedArray[A], Int, Int) -> Unit
 fn[T] Array::unsafe_get(Self[T], Int) -> T
-#alias(pop_exn, deprecated)
-fn[T] Array::unsafe_pop(Self[T]) -> T
-fn[A] Array::unsafe_pop_back(Self[A]) -> Unit
 fn[T] Array::unsafe_set(Self[T], Int, T) -> Unit
 fn[T] Array::windows(Self[T], Int) -> Self[ArrayView[T]]
 impl[T] Add for Array[T]
@@ -164,7 +160,6 @@ fn[T] ArrayView::length(Self[T]) -> Int
 #alias("_[_:_]")
 fn[T] ArrayView::sub(Self[T], start? : Int, end? : Int) -> Self[T]
 fn[T] ArrayView::suffixes(Self[T], include_empty? : Bool) -> Iterator[Self[T]]
-fn[T] ArrayView::unsafe_get(Self[T], Int) -> T
 impl[X : ToJson] ToJson for ArrayView[X]
 
 type Hasher
@@ -397,7 +392,6 @@ fn[T] UninitializedArray::make(Int) -> Self[T]
 fn[T] UninitializedArray::set(Self[T], Int, T) -> Unit
 #alias("_[_:_]")
 fn[T] UninitializedArray::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
-fn[T] UninitializedArray::unsafe_blit(Self[T], Int, Self[T], Int, Int) -> Unit
 
 #deprecated
 fn Bool::op_compare(Bool, Bool) -> Int
@@ -615,7 +609,6 @@ fn String::suffixes(String, include_empty? : Bool) -> Iterator[StringView]
 fn String::to_string(String) -> String
 #deprecated
 fn String::unsafe_char_at(String, Int) -> Char
-fn String::unsafe_charcode_at(String, Int) -> Int
 fn String::unsafe_substring(String, start~ : Int, end~ : Int) -> String
 
 fn[T, U] Option::bind(T?, (T) -> U? raise?) -> U? raise?
@@ -666,9 +659,6 @@ fn FixedArray::set_utf8_char(Self[Byte], Int, Char) -> Int
 #alias("_[_:_]")
 fn[T] FixedArray::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 fn[A] FixedArray::unsafe_blit(Self[A], Int, Self[A], Int, Int) -> Unit
-fn[T] FixedArray::unsafe_get(Self[T], Int) -> T
-fn FixedArray::unsafe_reinterpret_as_bytes(Self[Byte]) -> Bytes
-fn[T] FixedArray::unsafe_set(Self[T], Int, T) -> Unit
 
 #alias("_[_]")
 fn Bytes::at(Bytes, Int) -> Byte
@@ -681,7 +671,6 @@ fn Bytes::new(Int) -> Bytes
 #deprecated
 fn Bytes::of_string(String) -> Bytes
 fn Bytes::to_unchecked_string(Bytes, offset? : Int, length? : Int) -> String
-fn Bytes::unsafe_get(Bytes, Int) -> Byte
 
 #alias("_[_]")
 fn StringView::at(Self, Int) -> Int

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -102,6 +102,7 @@ pub fn[A] UninitializedArray::length(self : UninitializedArray[A]) -> Int {
 
 ///|
 #internal(unsafe, "For internal use only.")
+#doc(hidden)
 pub fn[T] UninitializedArray::unsafe_blit(
   dst : UninitializedArray[T],
   dst_offset : Int,

--- a/bytes/bitstring.mbt
+++ b/bytes/bitstring.mbt
@@ -408,18 +408,21 @@ pub fn BytesView::unsafe_extract_int64_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Bytes::unsafe_extract_bit(bs : Bytes, offset : Int, len : Int) -> UInt {
   bs[:].unsafe_extract_bit(offset, len)
 }
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Bytes::unsafe_extract_byte(bs : Bytes, offset : Int, len : Int) -> UInt {
   bs[:].unsafe_extract_byte(offset, len)
 }
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Bytes::unsafe_extract_uint_le(
   bs : Bytes,
   offset : Int,
@@ -430,6 +433,7 @@ pub fn Bytes::unsafe_extract_uint_le(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Bytes::unsafe_extract_uint_be(
   bs : Bytes,
   offset : Int,
@@ -440,6 +444,7 @@ pub fn Bytes::unsafe_extract_uint_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Bytes::unsafe_extract_uint64_le(
   bs : Bytes,
   offset : Int,
@@ -450,6 +455,7 @@ pub fn Bytes::unsafe_extract_uint64_le(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Bytes::unsafe_extract_uint64_be(
   bs : Bytes,
   offset : Int,
@@ -460,6 +466,7 @@ pub fn Bytes::unsafe_extract_uint64_be(
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Bytes::unsafe_extract_bytesview(
   bs : Bytes,
   offset : Int,

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -35,13 +35,6 @@ fn Bytes::sub(Bytes, start? : Int, end? : Int) -> BytesView
 fn Bytes::to_array(Bytes) -> Array[Byte]
 #label_migration(len, fill=false)
 fn Bytes::to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
-fn Bytes::unsafe_extract_bit(Bytes, Int, Int) -> UInt
-fn Bytes::unsafe_extract_byte(Bytes, Int, Int) -> UInt
-fn Bytes::unsafe_extract_bytesview(Bytes, Int, Int) -> BytesView
-fn Bytes::unsafe_extract_uint64_be(Bytes, Int, Int) -> UInt64
-fn Bytes::unsafe_extract_uint64_le(Bytes, Int, Int) -> UInt64
-fn Bytes::unsafe_extract_uint_be(Bytes, Int, Int) -> UInt
-fn Bytes::unsafe_extract_uint_le(Bytes, Int, Int) -> UInt
 fn Bytes::unsafe_read_uint16_be(Bytes, Int) -> UInt16
 fn Bytes::unsafe_read_uint16_le(Bytes, Int) -> UInt16
 fn Bytes::unsafe_read_uint32_be(Bytes, Int) -> UInt

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -579,6 +579,7 @@ pub fn[A] Deque::push_back(self : Deque[A], value : A) -> Unit {
 ///   assert_eq(dv.front(), Some(2))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
+#doc(hidden)
 #alias(pop_front_exn, deprecated)
 pub fn[A] Deque::unsafe_pop_front(self : Deque[A]) -> Unit {
   match self.len {
@@ -628,6 +629,7 @@ pub fn[A] Deque::unsafe_pop_front(self : Deque[A]) -> Unit {
 ///   assert_eq(dv.back(), Some(4))
 /// ```
 #internal(unsafe, "Panic if the deque is empty.")
+#doc(hidden)
 #alias(pop_back_exn, deprecated)
 pub fn[A] Deque::unsafe_pop_back(self : Deque[A]) -> Unit {
   match self.len {

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -79,10 +79,6 @@ fn[A] Deque::shuffle(Self[A], rand~ : (Int) -> Int) -> Self[A]
 fn[A] Deque::shuffle_in_place(Self[A], rand~ : (Int) -> Int) -> Unit
 fn[A] Deque::to_array(Self[A]) -> Array[A]
 fn[A] Deque::truncate(Self[A], Int) -> Unit
-#alias(pop_back_exn, deprecated)
-fn[A] Deque::unsafe_pop_back(Self[A]) -> Unit
-#alias(pop_front_exn, deprecated)
-fn[A] Deque::unsafe_pop_front(Self[A]) -> Unit
 impl[A] Add for Deque[A]
 impl[A : Compare] Compare for Deque[A]
 impl[A : Eq] Eq for Deque[A]

--- a/immut/list/list.mbt
+++ b/immut/list/list.mbt
@@ -257,6 +257,7 @@ pub fn[A] T::tail(self : T[A]) -> T[A] {
 ///|
 /// Get first element of the list.
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 #deprecated("use `@list` instead", skip_current_package=false)
 pub fn[A] T::unsafe_head(self : T[A]) -> A {
   match self {
@@ -290,6 +291,7 @@ pub fn[A] T::head(self : T[A]) -> A? {
 
 ///|
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 #deprecated("use `@list` instead", skip_current_package=false)
 pub fn[A] T::unsafe_last(self : T[A]) -> A {
   loop self {
@@ -596,6 +598,7 @@ pub fn[A, B] T::filter_map(self : T[A], f : (A) -> B?) -> T[B] {
 
 ///|
 #internal(unsafe, "Panic if the index is out of bounds")
+#doc(hidden)
 #deprecated("use `@list` instead", skip_current_package=false)
 pub fn[A] T::unsafe_nth(self : T[A], n : Int) -> A {
   loop (self, n) {
@@ -708,6 +711,7 @@ pub fn[A] T::flatten(self : T[T[A]]) -> T[A] {
 
 ///|
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 #deprecated("use `@list` instead", skip_current_package=false)
 pub fn[A : Compare] T::unsafe_maximum(self : T[A]) -> A {
   match self {
@@ -742,6 +746,7 @@ pub fn[A : Compare] T::maximum(self : T[A]) -> A? {
 
 ///|
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 #deprecated("use `@list` instead", skip_current_package=false)
 pub fn[A : Compare] T::unsafe_minimum(self : T[A]) -> A {
   match self {

--- a/immut/list/pkg.generated.mbti
+++ b/immut/list/pkg.generated.mbti
@@ -168,16 +168,6 @@ fn[A] T::to_array(Self[A]) -> Array[A]
 #deprecated
 fn[A : ToJson] T::to_json(Self[A]) -> Json
 #deprecated
-fn[A] T::unsafe_head(Self[A]) -> A
-#deprecated
-fn[A] T::unsafe_last(Self[A]) -> A
-#deprecated
-fn[A : Compare] T::unsafe_maximum(Self[A]) -> A
-#deprecated
-fn[A : Compare] T::unsafe_minimum(Self[A]) -> A
-#deprecated
-fn[A] T::unsafe_nth(Self[A], Int) -> A
-#deprecated
 fn[A, B] T::unzip(Self[(A, B)]) -> (Self[A], Self[B])
 #deprecated
 fn[A, B] T::zip(Self[A], Self[B]) -> Self[(A, B)]?

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -31,8 +31,6 @@ fn[A] PriorityQueue::peek(Self[A]) -> A?
 fn[A : Compare] PriorityQueue::pop(Self[A]) -> Self[A]?
 fn[A : Compare] PriorityQueue::push(Self[A], A) -> Self[A]
 fn[A : Compare] PriorityQueue::to_array(Self[A]) -> Array[A]
-#alias(pop_exn, deprecated)
-fn[A : Compare] PriorityQueue::unsafe_pop(Self[A]) -> Self[A]
 impl[A : Compare] Compare for PriorityQueue[A]
 impl[A : Compare] Eq for PriorityQueue[A]
 impl[A : Hash + Compare] Hash for PriorityQueue[A]

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -201,6 +201,7 @@ fn[A : Compare] Node::change_and_down(self : Node[A], value : A) -> Node[A] {
 ///   assert_eq(first, @priority_queue.from_array([1, 2, 3]))
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
+#doc(hidden)
 #alias(pop_exn, deprecated)
 pub fn[A : Compare] PriorityQueue::unsafe_pop(
   self : PriorityQueue[A],

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -394,6 +394,7 @@ pub fn[A] List::any(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
 ///|
 /// Get first element of the list.
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 pub fn[A] List::unsafe_head(self : List[A]) -> A {
   match self {
     Empty => abort("head of empty list")
@@ -457,6 +458,7 @@ pub fn[A] List::head(self : List[A]) -> A? {
 /// 
 /// Panics if the list is empty.
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 pub fn[A] List::unsafe_last(self : List[A]) -> A {
   loop self {
     Empty => abort("last of empty list")
@@ -726,6 +728,7 @@ pub fn[A, B] List::filter_map(
 /// 
 /// Panics if the index is out of bounds.
 #internal(unsafe, "Panic if the index is out of bounds")
+#doc(hidden)
 pub fn[A] List::unsafe_nth(self : List[A], n : Int) -> A {
   loop (self, n) {
     (Empty, _) => abort("nth: index out of bounds")
@@ -912,6 +915,7 @@ pub fn[A] List::flatten(self : List[List[A]]) -> List[A] {
 /// 
 /// Panics if the list is empty.
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 pub fn[A : Compare] List::unsafe_maximum(self : List[A]) -> A {
   match self {
     Empty => abort("maximum: empty list")
@@ -968,6 +972,7 @@ pub fn[A : Compare] List::maximum(self : List[A]) -> A? {
 /// 
 /// Panics if the list is empty.
 #internal(unsafe, "Panic if the list is empty")
+#doc(hidden)
 pub fn[A : Compare] List::unsafe_minimum(self : List[A]) -> A {
   match self {
     Empty => abort("minimum: empty list")

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -102,11 +102,6 @@ fn[A] List::to_array(Self[A]) -> Array[A]
 fn[A : ToJson] List::to_json(Self[A]) -> Json
 #as_free_fn
 fn[A, S] List::unfold((S) -> (A, S)? raise?, init~ : S) -> Self[A] raise?
-fn[A] List::unsafe_head(Self[A]) -> A
-fn[A] List::unsafe_last(Self[A]) -> A
-fn[A : Compare] List::unsafe_maximum(Self[A]) -> A
-fn[A : Compare] List::unsafe_minimum(Self[A]) -> A
-fn[A] List::unsafe_nth(Self[A], Int) -> A
 fn[A] List::unsafe_tail(Self[A]) -> Self[A]
 fn[A, B] List::unzip(Self[(A, B)]) -> (Self[A], Self[B])
 #as_free_fn

--- a/priority_queue/pkg.generated.mbti
+++ b/priority_queue/pkg.generated.mbti
@@ -32,7 +32,6 @@ fn[A] T::peek(Self[A]) -> A?
 fn[A : Compare] T::pop(Self[A]) -> A?
 fn[A : Compare] T::push(Self[A], A) -> Unit
 fn[A : Compare] T::to_array(Self[A]) -> Array[A]
-fn[A : Compare] T::unsafe_pop(Self[A]) -> Unit
 impl[K] Default for T[K]
 impl[A : Show + Compare] Show for T[A]
 impl[A : ToJson + Compare] ToJson for T[A]

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -190,6 +190,7 @@ pub fn[A] T::length(self : T[A]) -> Int {
 /// inspect(queue.length(), content="3")
 /// ```
 #internal(unsafe, "Panic if the queue is empty.")
+#doc(hidden)
 pub fn[A : Compare] T::unsafe_pop(self : T[A]) -> Unit {
   self.top = match self.top {
     None => abort("The PriorityQueue is empty!")

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -36,10 +36,6 @@ fn[A] Queue::peek(Self[A]) -> A?
 fn[A] Queue::pop(Self[A]) -> A?
 fn[A] Queue::push(Self[A], A) -> Unit
 fn[A] Queue::transfer(Self[A], Self[A]) -> Unit
-#alias(peek_exn, deprecated)
-fn[A] Queue::unsafe_peek(Self[A]) -> A
-#alias(pop_exn, deprecated)
-fn[A] Queue::unsafe_pop(Self[A]) -> A
 impl[A : Show] Show for Queue[A]
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for Queue[X]
 

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -131,6 +131,7 @@ pub fn[A] Queue::push(self : Queue[A], x : A) -> Unit {
 ///   assert_eq(queue.unsafe_peek(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
+#doc(hidden)
 #alias(peek_exn, deprecated)
 pub fn[A] Queue::unsafe_peek(self : Queue[A]) -> A {
   match self.first {
@@ -163,6 +164,7 @@ pub fn[A] Queue::peek(self : Queue[A]) -> A? {
 ///   assert_eq(queue.unsafe_pop(), 1)
 /// ```
 #internal(unsafe, "Panics if the queue is empty.")
+#doc(hidden)
 #alias(pop_exn, deprecated)
 pub fn[A] Queue::unsafe_pop(self : Queue[A]) -> A {
   match self.first {

--- a/string/regex/pkg.generated.mbti
+++ b/string/regex/pkg.generated.mbti
@@ -2,20 +2,10 @@
 package "moonbitlang/core/string/regex"
 
 // Values
-fn compile(StringView) -> Regex raise
 
 // Errors
 
 // Types and methods
-type MatchResult
-fn MatchResult::after(Self) -> StringView
-fn MatchResult::before(Self) -> StringView
-fn MatchResult::content(Self) -> StringView
-fn MatchResult::group(Self, Int) -> StringView?
-fn MatchResult::named_group(Self, String) -> StringView?
-
-type Regex
-fn Regex::execute(Self, StringView) -> MatchResult?
 
 // Type aliases
 

--- a/string/regex/regex.mbt
+++ b/string/regex/regex.mbt
@@ -14,34 +14,40 @@
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 struct MatchResult(@regex_impl.MatchResult, @regex_impl.Regexp)
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn MatchResult::before(self : Self) -> StringView {
   self.0.before()
 }
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn MatchResult::after(self : Self) -> StringView {
   self.0.after()
 }
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn MatchResult::content(self : Self) -> StringView {
   self.0.get(0).unwrap()
 }
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn MatchResult::group(self : Self, index : Int) -> StringView? {
   self.0.get(index)
 }
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn MatchResult::named_group(self : Self, name : String) -> StringView? {
   if self.1.group_by_name(name) is Some(index) {
     self.0.get(index)
@@ -52,16 +58,19 @@ pub fn MatchResult::named_group(self : Self, name : String) -> StringView? {
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 struct Regex(@regex_impl.Regexp)
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn compile(pattern : StringView) -> Regex raise {
   @regex_impl.compile(pattern)
 }
 
 ///|
 #internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
 pub fn Regex::execute(self : Self, input : StringView) -> MatchResult? {
   match self.0.match_(input) {
     None => None


### PR DESCRIPTION
Hide all functions marked with #internal(experimental) and #internal(unsafe) from public documentation by adding #doc(hidden) attribute.

This affects:
- array/bitstring.mbt: 27 experimental bitstring extraction functions
- bytes/bitstring.mbt: 7 experimental Bytes extraction functions
- string/regex/regex.mbt: 9 experimental regex API functions
- builtin/*: 11 unsafe functions (Array, FixedArray, Bytes, etc.)
- queue, deque, list, priority_queue: unsafe pop/peek functions

The #doc(hidden) attribute ensures these internal/experimental APIs don't appear in generated documentation while keeping them accessible for internal use and testing.