### PR TITLE
ci: cleanup test script

### DIFF
--- a/.github/actions/test-native-release/action.yml
+++ b/.github/actions/test-native-release/action.yml
@@ -1,0 +1,21 @@
+name: "Run MoonBit Native Release Tests"
+description: "Run MoonBit tests with --target native --release"
+runs:
+  using: "composite"
+  steps:
+    - name: Set ulimit and run moon test (--release + --target native)
+      if: ${{ runner.os != 'Windows' }}
+      shell: bash
+      run: |
+        ulimit -s 8176
+        moon test --target native --release
+
+    - name: Setup MSVC
+      if: ${{ runner.os == 'Windows' }}
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Run moon test on Windows (--release + --target native)
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: |
+        moon test --target native --release

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,42 @@
+name: "Run MoonBit Tests"
+description: "Run comprehensive MoonBit tests across all targets"
+runs:
+  using: "composite"
+  steps:
+    - name: Set ulimit and run moon test
+      if: ${{ runner.os != 'Windows' }}
+      shell: bash
+      run: |
+        ulimit -s 8176
+        moon test --target all
+        moon test --release --target js,wasm,wasm-gc # native test in release mode is run in a separate job
+
+    - name: Setup MSVC
+      if: ${{ runner.os == 'Windows' }}
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Run moon test on Windows
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: |
+        moon test --target all
+        moon test --release --target js,wasm,wasm-gc # native test in release mode is run in a separate job
+
+    - name: Run moon test with JS builtin string
+      if: ${{ runner.os != 'Windows' }}
+      shell: bash
+      run: |
+        ulimit -s 8176
+        moon test --target wasm-gc
+        moon test --target wasm-gc --release
+      env:
+        MOONC_INTERNAL_PARAMS: use_js_builtin_string = 1 |
+
+    - name: Run moon test with JS builtin string
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: |
+        moon test --target wasm-gc
+        moon test --target wasm-gc --release
+      env:
+        MOONC_INTERNAL_PARAMS: use_js_builtin_string = 1 |

--- a/.github/workflows/bleeding-check.yml
+++ b/.github/workflows/bleeding-check.yml
@@ -22,33 +22,8 @@ jobs:
         with:
           version: nightly
 
-      - name: Set ulimit and run moon test
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          ulimit -s 8176
-          moon test --target all
-          moon test --release --target all
-          moon test --target native
-          moon test --release --target native
-
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Run moon test on Windows (--target all)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target all
-
-      - name: Run moon test on Windows (--release + --target all)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --release --target all
-
-      - name: Run moon test on Windows (--target native)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target native
+      - name: run tests
+        uses: ./.github/actions/test
 
       - name: Test new allocator
         run: |
@@ -96,17 +71,5 @@ jobs:
         run: |
           moon version --all
 
-      - name: Set ulimit and run moon test (--release + --target native)
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          ulimit -s 8176
-          moon test --target native --release
-
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Run moon test on Windows (--release + --target native)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target native --release
+      - name: run native release tests
+        uses: ./.github/actions/test-native-release

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -140,38 +140,8 @@ jobs:
       - name: check
         run: moon check --deny-warn
 
-      - name: Set ulimit and run moon test
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          ulimit -s 8176
-          moon test --target all
-          moon test --release --target all
-          moon test --target native
-          moon test --target native --release
-
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Run moon test on Windows (--target all)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target all
-
-      - name: Run moon test on Windows (--release + --target all)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --release --target all
-
-      - name: Run moon test on Windows (--target native)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target native
-
-      - name: Run moon test on Windows (--release + --target native)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target native --release
+      - name: run tests
+        uses: ./.github/actions/test
 
       - name: moon test --doc
         run: |
@@ -194,3 +164,26 @@ jobs:
       - name: check core size on windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: Get-ChildItem -Path ".\target" -Recurse -Filter "*.core" | ForEach-Object { "{0} ({1} bytes)" -f $_.FullName, $_.Length }
+
+  pre-release-native-opt-test:
+    needs: version-check
+    if: ${{ needs.version-check.outputs.should-skip == 'false' }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install
+        uses: ./.github/actions/setup
+        with:
+          version: pre-release
+
+      - name: check
+        run: moon check --target native --deny-warn
+
+      - name: run native release tests
+        uses: ./.github/actions/test-native-release

--- a/.github/workflows/stable-check.yml
+++ b/.github/workflows/stable-check.yml
@@ -34,33 +34,8 @@ jobs:
           moon fmt
           git diff --exit-code
 
-      - name: Set ulimit and run moon test
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          ulimit -s 8176
-          moon test --target all
-          moon test --release --target all
-          moon test --target native
-          moon test --release --target native
-
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Run moon test on Windows (--target all)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target all
-
-      - name: Run moon test on Windows (--release + --target all)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --release --target all
-
-      - name: Run moon test on Windows (--target native)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target native
+      - name: run tests
+        uses: ./.github/actions/test
 
       - name: moon bundle
         run: moon bundle --all
@@ -89,17 +64,5 @@ jobs:
       - name: check
         run: moon check --target native --deny-warn
 
-      - name: Set ulimit and run moon test (--release + --target native)
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          ulimit -s 8176
-          moon test --target native --release
-
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Run moon test on Windows (--release + --target native)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          moon test --target native --release
+      - name: run native release tests
+        uses: ./.github/actions/test-native-release


### PR DESCRIPTION
Two changes:
1. `moon test --target all` includes native backends now, so there's no need to run native backend separately
2. add CI test with `use_js_builtin_string` on
3. https://github.com/moonbitlang/core/pull/2906 introduced redundant jobs, and this PR removed them.

And a refactor:
factored out some common testing script to `actions/test/action.yml` and `actions/test-native-release/action.yml` and share them across stable/pre-release/nightly CI workflows.