### PR TITLE
Revert "perf(builtin): improve StringView::to_string performance via …

### DIFF
--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -173,12 +173,8 @@ pub impl Show for StringView with output(self, logger) {
 ///   inspect(view.to_string(), content="Hello")
 /// ```
 pub impl Show for StringView with to_string(self) {
-  if self.length() == self.str().length() {
-    // avoid memory allocation
-    self.str()
-  } else {
-    self.str().unsafe_substring(start=self.start(), end=self.end())
-  }
+  // when `self == self.str()`, `String::unsafe_substring` would return original string, which doesn't create a new copy.
+  self.str().unsafe_substring(start=self.start(), end=self.end())
 }
 
 ///|

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -30,13 +30,3 @@ test "StringView::suffixes" {
     .collect()
   @json.inspect(suffixes_no_empty, content=["a🤣b", "🤣b", "b"])
 }
-
-///|
-
-///|
-test "StringView::to_string" {
-  let str = "Hello"
-  let stvw = str.view()
-  @json.inspect(str, content="Hello")
-  @json.inspect(stvw, content="Hello")
-}


### PR DESCRIPTION
…avoid memory allocation (#2924)"

This reverts commit 42a10fd7d0f1b9c42cd4f239203b5251aebd94e1.

Doc: add internal documentation for StringView::to_string