### PR TITLE
feat: make tap/then functions polymorphic over error types

### DIFF
--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -46,9 +46,9 @@ fn[T : @builtin.Show] println(T) -> Unit
 
 fn[T : @builtin.Show] repr(T) -> String
 
-fn[T] tap(T, (T) -> Unit) -> T
+fn[T] tap(T, (T) -> Unit raise) -> T raise
 
-fn[T, R] then(T, (T) -> R) -> R
+fn[T, R] then(T, (T) -> R raise?) -> R raise?
 
 // Errors
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -86,11 +86,9 @@ pub using @builtin {
 /// let val : Ref[Int] = { val : 1 }
 /// let x : Int = 5
 /// assert_eq(x |> tap(n => val.val += n), 5)
-/// // This is not allowed
-/// // x |> (val.val += _)
 /// assert_eq(val.val, 6)
 /// ```
-pub fn[T] tap(value : T, f : (T) -> Unit) -> T {
+pub fn[T] tap(value : T, f : (T) -> Unit raise) -> T raise {
   f(value)
   value
 }
@@ -109,11 +107,13 @@ pub fn[T] tap(value : T, f : (T) -> Unit) -> T {
 /// ```moonbit
 /// let x = 5
 /// let result = x |> then(n => n * 2)
-/// // This is not allowed
-/// // x |> (_ * 2)
 /// assert_eq(result, 10)
 /// ```
-pub fn[T, R] then(value : T, f : (T) -> R) -> R {
+/// 
+/// ```moonbit skip
+/// x |> then(x => fail(x.to_string()))
+/// ```
+pub fn[T, R] then(value : T, f : (T) -> R raise?) -> R raise? {
   f(value)
 }
 


### PR DESCRIPTION
Make `x |> then(x => may_fail(x + 1))` possible.