### PR TITLE
Refactor byte conversion methods and tests for Int and UInt types

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -101,31 +101,6 @@ pub fn Buffer::is_empty(self : Buffer) -> Bool {
 }
 
 ///|
-/// Returns a copy of the buffer's content as a sequence of bytes.
-///
-/// Parameters:
-///
-/// * `buffer` : The buffer to read from.
-///
-/// Returns a `Bytes` object containing all bytes written to the buffer.
-///
-/// Example:
-///
-/// ```moonbit
-/// let buf = @buffer.new()
-/// buf.write_string("Test")
-/// inspect(
-///   buf.contents(),
-///   content=(
-///     #|b"T\x00e\x00s\x00t\x00"
-///   ),
-/// )
-/// ```
-pub fn Buffer::contents(self : Buffer) -> Bytes {
-  Bytes::from_array(self.data[0:self.len])
-}
-
-///|
 /// Creates a new extensible buffer with specified initial capacity. If the
 /// initial capacity is less than 1, the buffer will be initialized with capacity
 /// 1.
@@ -1014,10 +989,16 @@ pub fn Buffer::reset(self : Buffer) -> Unit {
 ///   let buf = @buffer.new()
 ///   buf.write_string("Test")
 ///   let bytes = buf.to_bytes()
-///   inspect(bytes.length(), content="8")
+///   inspect(bytes.length(), content="8") //utf16
 /// ```
+#alias(contents)
 pub fn Buffer::to_bytes(self : Buffer) -> Bytes {
   Bytes::from_array(self.data[0:self.len])
+}
+
+///|
+pub fn Buffer::view(self : Buffer) -> ArrayView[Byte] {
+  self.data[0:self.len]
 }
 
 ///|

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -15,11 +15,12 @@ fn new(size_hint? : Int) -> Buffer
 // Types and methods
 #alias(T, deprecated)
 type Buffer
-fn Buffer::contents(Self) -> Bytes
 fn Buffer::is_empty(Self) -> Bool
 fn Buffer::length(Self) -> Int
 fn Buffer::reset(Self) -> Unit
+#alias(contents)
 fn Buffer::to_bytes(Self) -> Bytes
+fn Buffer::view(Self) -> ArrayView[Byte]
 fn Buffer::write_byte(Self, Byte) -> Unit
 fn Buffer::write_bytes(Self, Bytes) -> Unit
 fn Buffer::write_bytesview(Self, BytesView) -> Unit

--- a/bytes/bitstring_test.mbt
+++ b/bytes/bitstring_test.mbt
@@ -158,342 +158,352 @@ test "extract_byte - bit patterns and edge cases" {
 // ============================================================================
 
 ///|
+fn UInt::to_be_bytes_local(self : UInt) -> Bytes {
+  [
+    (self >> 24).to_byte(),
+    (self >> 16).to_byte(),
+    (self >> 8).to_byte(),
+    self.to_byte(),
+  ]
+}
+
+///|
 test "extract_uint_le" {
   let s = b"\xA5\xB6\xC7\xD8"[:]
   inspect(
-    s.unsafe_extract_uint_le(0, 9).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 9).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x01\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 10).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 10).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x02\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 11).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 11).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x05\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 12).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 12).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x0b\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 13).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 13).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x16\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 14).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 14).to_be_bytes_local(),
     content=(
       #|b"\x00\x00-\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 15).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 15).to_be_bytes_local(),
     content=(
       #|b"\x00\x00[\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 16).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 16).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 17).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 17).to_be_bytes_local(),
     content=(
       #|b"\x00\x01\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 18).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 18).to_be_bytes_local(),
     content=(
       #|b"\x00\x03\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 19).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 19).to_be_bytes_local(),
     content=(
       #|b"\x00\x06\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 20).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 20).to_be_bytes_local(),
     content=(
       #|b"\x00\x0c\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 21).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 21).to_be_bytes_local(),
     content=(
       #|b"\x00\x18\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 22).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 22).to_be_bytes_local(),
     content=(
       #|b"\x001\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 23).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 23).to_be_bytes_local(),
     content=(
       #|b"\x00c\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 24).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 24).to_be_bytes_local(),
     content=(
       #|b"\x00\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 25).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 25).to_be_bytes_local(),
     content=(
       #|b"\x01\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 26).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 26).to_be_bytes_local(),
     content=(
       #|b"\x03\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 27).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 27).to_be_bytes_local(),
     content=(
       #|b"\x06\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 28).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 28).to_be_bytes_local(),
     content=(
       #|b"\x0d\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 29).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 29).to_be_bytes_local(),
     content=(
       #|b"\x1b\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 30).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 30).to_be_bytes_local(),
     content=(
       #|b"6\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 31).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 31).to_be_bytes_local(),
     content=(
       #|b"l\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(0, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 32).to_be_bytes_local(),
     content=(
       #|b"\xd8\xc7\xb6\xa5"
     ),
   )
   let s = b"\xA5\xB6\xC7\xD8\xA5\xB6\xC7\xD8"[:]
   inspect(
-    s.unsafe_extract_uint_le(1, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(1, 32).to_be_bytes_local(),
     content=(
       #|b"\xb1\x8fmK"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(2, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(2, 32).to_be_bytes_local(),
     content=(
       #|b"b\x1f\xdb\x96"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(3, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(3, 32).to_be_bytes_local(),
     content=(
       #|b"\xc5>\xb6-"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(4, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(4, 32).to_be_bytes_local(),
     content=(
       #|b"\x8a}l["
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(5, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(5, 32).to_be_bytes_local(),
     content=(
       #|b"\x14\xfb\xd8\xb6"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(6, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(6, 32).to_be_bytes_local(),
     content=(
       #|b")\xf6\xb1m"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(7, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(7, 32).to_be_bytes_local(),
     content=(
       #|b"R\xecc\xdb"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(8, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(8, 32).to_be_bytes_local(),
     content=(
       #|b"\xa5\xd8\xc7\xb6"
     ),
   )
   let s = b"\xA5\xB6\xC7\xD8"[:]
   inspect(
-    s.unsafe_extract_uint_le(0, 32).to_be_bytes(),
+    s.unsafe_extract_uint_le(0, 32).to_be_bytes_local(),
     content=(
       #|b"\xd8\xc7\xb6\xa5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(1, 31).to_be_bytes(),
+    s.unsafe_extract_uint_le(1, 31).to_be_bytes_local(),
     content=(
       #|b"X\x8fmK"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(2, 30).to_be_bytes(),
+    s.unsafe_extract_uint_le(2, 30).to_be_bytes_local(),
     content=(
       #|b"\x18\x1f\xdb\x96"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(3, 29).to_be_bytes(),
+    s.unsafe_extract_uint_le(3, 29).to_be_bytes_local(),
     content=(
       #|b"\x18>\xb6-"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(4, 28).to_be_bytes(),
+    s.unsafe_extract_uint_le(4, 28).to_be_bytes_local(),
     content=(
       #|b"\x08}l["
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(5, 27).to_be_bytes(),
+    s.unsafe_extract_uint_le(5, 27).to_be_bytes_local(),
     content=(
       #|b"\x00\xfb\xd8\xb6"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(6, 26).to_be_bytes(),
+    s.unsafe_extract_uint_le(6, 26).to_be_bytes_local(),
     content=(
       #|b"\x00\xf6\xb1m"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(7, 25).to_be_bytes(),
+    s.unsafe_extract_uint_le(7, 25).to_be_bytes_local(),
     content=(
       #|b"\x00\xecc\xdb"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(8, 24).to_be_bytes(),
+    s.unsafe_extract_uint_le(8, 24).to_be_bytes_local(),
     content=(
       #|b"\x00\xd8\xc7\xb6"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(9, 23).to_be_bytes(),
+    s.unsafe_extract_uint_le(9, 23).to_be_bytes_local(),
     content=(
       #|b"\x00X\x8fm"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(10, 22).to_be_bytes(),
+    s.unsafe_extract_uint_le(10, 22).to_be_bytes_local(),
     content=(
       #|b"\x00\x18\x1f\xdb"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(11, 21).to_be_bytes(),
+    s.unsafe_extract_uint_le(11, 21).to_be_bytes_local(),
     content=(
       #|b"\x00\x18>\xb6"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(12, 20).to_be_bytes(),
+    s.unsafe_extract_uint_le(12, 20).to_be_bytes_local(),
     content=(
       #|b"\x00\x08}l"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(13, 19).to_be_bytes(),
+    s.unsafe_extract_uint_le(13, 19).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\xfb\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(14, 18).to_be_bytes(),
+    s.unsafe_extract_uint_le(14, 18).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\xf6\xb1"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(15, 17).to_be_bytes(),
+    s.unsafe_extract_uint_le(15, 17).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\xecc"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(16, 16).to_be_bytes(),
+    s.unsafe_extract_uint_le(16, 16).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\xd8\xc7"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(17, 15).to_be_bytes(),
+    s.unsafe_extract_uint_le(17, 15).to_be_bytes_local(),
     content=(
       #|b"\x00\x00X\x8f"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(18, 14).to_be_bytes(),
+    s.unsafe_extract_uint_le(18, 14).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x18\x1f"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(19, 13).to_be_bytes(),
+    s.unsafe_extract_uint_le(19, 13).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x18>"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(20, 12).to_be_bytes(),
+    s.unsafe_extract_uint_le(20, 12).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x08}"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(21, 11).to_be_bytes(),
+    s.unsafe_extract_uint_le(21, 11).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x00\xfb"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(22, 10).to_be_bytes(),
+    s.unsafe_extract_uint_le(22, 10).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x00\xf6"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_le(23, 9).to_be_bytes(),
+    s.unsafe_extract_uint_le(23, 9).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x00\xec"
     ),
@@ -518,339 +528,339 @@ test "extract_int_le_path_consistent" {
 test "extract_int_be" {
   let s = b"\xA5\xB6\xC7\xD8"[:]
   inspect(
-    (s.unsafe_extract_uint_be(0, 9) << 23).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 9) << 23).to_be_bytes_local(),
     content=(
       #|b"\xa5\x80\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 10) << 22).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 10) << 22).to_be_bytes_local(),
     content=(
       #|b"\xa5\x80\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 11) << 21).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 11) << 21).to_be_bytes_local(),
     content=(
       #|b"\xa5\xa0\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 12) << 20).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 12) << 20).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb0\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 13) << 19).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 13) << 19).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb0\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 14) << 18).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 14) << 18).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb4\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 15) << 17).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 15) << 17).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 16) << 16).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 16) << 16).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\x00\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 17) << 15).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 17) << 15).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\x80\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 18) << 14).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 18) << 14).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc0\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 19) << 13).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 19) << 13).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc0\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 20) << 12).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 20) << 12).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc0\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 21) << 11).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 21) << 11).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc0\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 22) << 10).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 22) << 10).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc4\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 23) << 9).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 23) << 9).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc6\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 24) << 8).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 24) << 8).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\x00"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 25) << 7).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 25) << 7).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\x80"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 26) << 6).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 26) << 6).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xc0"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 27) << 5).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 27) << 5).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xc0"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 28) << 4).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 28) << 4).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xd0"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 29) << 3).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 29) << 3).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xd8"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 30) << 2).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 30) << 2).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xd8"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 31) << 1).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 31) << 1).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xd8"
     ),
   )
   inspect(
-    (s.unsafe_extract_uint_be(0, 32) << 0).to_be_bytes(),
+    (s.unsafe_extract_uint_be(0, 32) << 0).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xd8"
     ),
   )
   let s = b"\xA5\xB6\xC7\xD8\xA5\xB6\xC7\xD8"[:]
   inspect(
-    s.unsafe_extract_uint_be(1, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(1, 32).to_be_bytes_local(),
     content=(
       #|b"Km\x8f\xb1"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(2, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(2, 32).to_be_bytes_local(),
     content=(
       #|b"\x96\xdb\x1fb"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(3, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(3, 32).to_be_bytes_local(),
     content=(
       #|b"-\xb6>\xc5"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(4, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(4, 32).to_be_bytes_local(),
     content=(
       #|b"[l}\x8a"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(5, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(5, 32).to_be_bytes_local(),
     content=(
       #|b"\xb6\xd8\xfb\x14"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(6, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(6, 32).to_be_bytes_local(),
     content=(
       #|b"m\xb1\xf6)"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(7, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(7, 32).to_be_bytes_local(),
     content=(
       #|b"\xdbc\xecR"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(8, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(8, 32).to_be_bytes_local(),
     content=(
       #|b"\xb6\xc7\xd8\xa5"
     ),
   )
   let s = b"\xA5\xB6\xC7\xD8"[:]
   inspect(
-    s.unsafe_extract_uint_be(0, 32).to_be_bytes(),
+    s.unsafe_extract_uint_be(0, 32).to_be_bytes_local(),
     content=(
       #|b"\xa5\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(1, 31).to_be_bytes(),
+    s.unsafe_extract_uint_be(1, 31).to_be_bytes_local(),
     content=(
       #|b"%\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(2, 30).to_be_bytes(),
+    s.unsafe_extract_uint_be(2, 30).to_be_bytes_local(),
     content=(
       #|b"%\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(3, 29).to_be_bytes(),
+    s.unsafe_extract_uint_be(3, 29).to_be_bytes_local(),
     content=(
       #|b"\x05\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(4, 28).to_be_bytes(),
+    s.unsafe_extract_uint_be(4, 28).to_be_bytes_local(),
     content=(
       #|b"\x05\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(5, 27).to_be_bytes(),
+    s.unsafe_extract_uint_be(5, 27).to_be_bytes_local(),
     content=(
       #|b"\x05\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(6, 26).to_be_bytes(),
+    s.unsafe_extract_uint_be(6, 26).to_be_bytes_local(),
     content=(
       #|b"\x01\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(7, 25).to_be_bytes(),
+    s.unsafe_extract_uint_be(7, 25).to_be_bytes_local(),
     content=(
       #|b"\x01\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(8, 24).to_be_bytes(),
+    s.unsafe_extract_uint_be(8, 24).to_be_bytes_local(),
     content=(
       #|b"\x00\xb6\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(9, 23).to_be_bytes(),
+    s.unsafe_extract_uint_be(9, 23).to_be_bytes_local(),
     content=(
       #|b"\x006\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(10, 22).to_be_bytes(),
+    s.unsafe_extract_uint_be(10, 22).to_be_bytes_local(),
     content=(
       #|b"\x006\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(11, 21).to_be_bytes(),
+    s.unsafe_extract_uint_be(11, 21).to_be_bytes_local(),
     content=(
       #|b"\x00\x16\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(12, 20).to_be_bytes(),
+    s.unsafe_extract_uint_be(12, 20).to_be_bytes_local(),
     content=(
       #|b"\x00\x06\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(13, 19).to_be_bytes(),
+    s.unsafe_extract_uint_be(13, 19).to_be_bytes_local(),
     content=(
       #|b"\x00\x06\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(14, 18).to_be_bytes(),
+    s.unsafe_extract_uint_be(14, 18).to_be_bytes_local(),
     content=(
       #|b"\x00\x02\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(15, 17).to_be_bytes(),
+    s.unsafe_extract_uint_be(15, 17).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(16, 16).to_be_bytes(),
+    s.unsafe_extract_uint_be(16, 16).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\xc7\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(17, 15).to_be_bytes(),
+    s.unsafe_extract_uint_be(17, 15).to_be_bytes_local(),
     content=(
       #|b"\x00\x00G\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(18, 14).to_be_bytes(),
+    s.unsafe_extract_uint_be(18, 14).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x07\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(19, 13).to_be_bytes(),
+    s.unsafe_extract_uint_be(19, 13).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x07\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(20, 12).to_be_bytes(),
+    s.unsafe_extract_uint_be(20, 12).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x07\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(21, 11).to_be_bytes(),
+    s.unsafe_extract_uint_be(21, 11).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x07\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(22, 10).to_be_bytes(),
+    s.unsafe_extract_uint_be(22, 10).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x03\xd8"
     ),
   )
   inspect(
-    s.unsafe_extract_uint_be(23, 9).to_be_bytes(),
+    s.unsafe_extract_uint_be(23, 9).to_be_bytes_local(),
     content=(
       #|b"\x00\x00\x01\xd8"
     ),
@@ -1758,11 +1768,15 @@ test "integration - complex bit manipulations" {
   inspect(byte_val, content="60") // 6 bits starting from bit 6
 
   // For int and int64 values, shift to make them more readable
+  let shifted_int = int_val << (32 - 20)
   inspect(
-    (int_val << (32 - 20)).to_le_bytes(),
-    content=(
-      #|b"\x00\xe0\x1d/"
-    ),
+    [
+      shifted_int.to_byte(),
+      (shifted_int >> 8).to_byte(),
+      (shifted_int >> 16).to_byte(),
+      (shifted_int >> 24).to_byte(),
+    ],
+    content="[b'\\x00', b'\\xE0', b'\\x1D', b'\\x2F']",
   )
   inspect(
     (int64_val << (64 - 40)).to_le_bytes(),
@@ -1824,7 +1838,7 @@ test "integration - pattern verification" {
   // Check that pattern is maintained in larger extractions
   let int_val = view.unsafe_extract_uint_be(0, 16)
   inspect(
-    int_val.to_be_bytes(),
+    int_val.to_be_bytes_local(),
     content=(
       #|b"\x00\x00U\xaa"
     ),

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -89,7 +89,13 @@ pub impl Hash for Float with hash_combine(self, hasher) {
 /// )
 /// ```
 pub fn Float::to_be_bytes(self : Float) -> Bytes {
-  self.reinterpret_as_uint().to_be_bytes()
+  let uint = self.reinterpret_as_uint()
+  [
+    (uint >> 24).to_byte(),
+    (uint >> 16).to_byte(),
+    (uint >> 8).to_byte(),
+    uint.to_byte(),
+  ]
 }
 
 ///|
@@ -111,7 +117,13 @@ pub fn Float::to_be_bytes(self : Float) -> Bytes {
 ///   inspect(bytes.length(), content="4")
 /// ```
 pub fn Float::to_le_bytes(self : Float) -> Bytes {
-  self.reinterpret_as_uint().to_le_bytes()
+  let uint = self.reinterpret_as_uint()
+  [
+    uint.to_byte(),
+    (uint >> 8).to_byte(),
+    (uint >> 16).to_byte(),
+    (uint >> 24).to_byte(),
+  ]
 }
 
 ///|

--- a/int/README.mbt.md
+++ b/int/README.mbt.md
@@ -29,7 +29,9 @@ test "byte conversions" {
   let num = 258 // 0x0102 in hex
 
   // Big-endian conversion (most significant byte first)
-  let be_bytes = num.to_be_bytes()
+  let buf = @buffer.new()
+  buf.write_int_be(num)
+  let be_bytes = buf.contents()
   inspect(
     be_bytes.to_string(),
     content=(
@@ -38,7 +40,9 @@ test "byte conversions" {
   )
 
   // Little-endian conversion (least significant byte first)
-  let le_bytes = num.to_le_bytes()
+  buf.reset() // reset the position of the buffer
+  buf.write_int_le(num)
+  let le_bytes = buf.contents()
   inspect(
     le_bytes.to_string(),
     content=(
@@ -61,8 +65,12 @@ test "method syntax" {
   inspect(n.abs(), content="42")
 
   // Byte conversions using method syntax
-  let be = n.to_be_bytes()
-  let le = n.to_le_bytes()
+  let buf = @buffer.new()
+  buf.write_int_be(n)
+  let be = buf.contents()
+  buf.reset()
+  buf.write_int_le(n)
+  let le = buf.contents()
   inspect(
     be.to_string(),
     content=(

--- a/int/int.mbt
+++ b/int/int.mbt
@@ -47,12 +47,28 @@ pub fn Int::abs(self : Int) -> Int {
 
 ///|
 /// Converts the Int to a Bytes in big-endian byte order.
+#deprecated(skip_current_package=false)
+#doc(hidden)
 pub fn Int::to_be_bytes(self : Int) -> Bytes {
-  self.reinterpret_as_uint().to_be_bytes()
+  let self = self.reinterpret_as_uint()
+  [
+    (self >> 24).to_byte(),
+    (self >> 16).to_byte(),
+    (self >> 8).to_byte(),
+    self.to_byte(),
+  ]
 }
 
 ///|
 /// Converts the Int to a Bytes in little-endian byte order.
+#deprecated(skip_current_package=false)
+#doc(hidden)
 pub fn Int::to_le_bytes(self : Int) -> Bytes {
-  self.reinterpret_as_uint().to_le_bytes()
+  let self = self.reinterpret_as_uint()
+  [
+    self.to_byte(),
+    (self >> 8).to_byte(),
+    (self >> 16).to_byte(),
+    (self >> 24).to_byte(),
+  ]
 }

--- a/int/int_test.mbt
+++ b/int/int_test.mbt
@@ -58,7 +58,9 @@ test "abs function coverage" {
 
 ///|
 test "to_le_bytes" {
-  let bytes = (0x12345678).to_le_bytes()
+  let buffer = @buffer.new()
+  buffer.write_int_le(0x12345678)
+  let bytes = buffer.contents()
   inspect(
     bytes,
     content=(
@@ -69,7 +71,9 @@ test "to_le_bytes" {
 
 ///|
 test "to_be_bytes" {
-  let bytes = (0x12345678).to_be_bytes()
+  let buffer = @buffer.new()
+  buffer.write_int_be(0x12345678)
+  let bytes = buffer.contents()
   inspect(
     bytes,
     content=(

--- a/int/moon.pkg.json
+++ b/int/moon.pkg.json
@@ -1,4 +1,7 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/uint"],
-  "test-import": ["moonbitlang/core/bytes"]
+  "test-import": [
+    "moonbitlang/core/bytes",
+    "moonbitlang/core/buffer"
+  ]
 }

--- a/int/pkg.generated.mbti
+++ b/int/pkg.generated.mbti
@@ -11,8 +11,6 @@ let min_value : Int
 // Types and methods
 #as_free_fn
 fn Int::abs(Int) -> Int
-fn Int::to_be_bytes(Int) -> Bytes
-fn Int::to_le_bytes(Int) -> Bytes
 
 // Type aliases
 

--- a/uint/README.mbt.md
+++ b/uint/README.mbt.md
@@ -18,35 +18,6 @@ test "uint basics" {
 }
 ```
 
-## Byte Representation
-
-`UInt` can be converted to bytes in both big-endian and little-endian formats:
-
-```moonbit
-///|
-test "uint byte conversion" {
-  let num = 258U // 0x00000102 in hex
-
-  // Big-endian bytes (most significant byte first)
-  let be_bytes = num.to_be_bytes()
-  inspect(
-    be_bytes,
-    content=(
-      #|b"\x00\x00\x01\x02"
-    ),
-  )
-
-  // Little-endian bytes (least significant byte first)
-  let le_bytes = num.to_le_bytes()
-  inspect(
-    le_bytes,
-    content=(
-      #|b"\x02\x01\x00\x00"
-    ),
-  )
-}
-```
-
 ## Converting to Other Number Types
 
 `UInt` can be converted to `Int64` when you need to work with signed 64-bit integers:
@@ -70,17 +41,5 @@ test "uint methods" {
 
   // Using method syntax
   inspect(num.to_int64(), content="1000")
-  inspect(
-    num.to_be_bytes(),
-    content=(
-      #|b"\x00\x00\x03\xe8"
-    ),
-  )
-  inspect(
-    num.to_le_bytes(),
-    content=(
-      #|b"\xe8\x03\x00\x00"
-    ),
-  )
 }
 ```

--- a/uint/moon.pkg.json
+++ b/uint/moon.pkg.json
@@ -1,4 +1,4 @@
 {
   "import": ["moonbitlang/core/builtin"],
-  "test-import": ["moonbitlang/core/bytes"]
+  "test-import": ["moonbitlang/core/bytes", "moonbitlang/core/buffer"]
 }

--- a/uint/pkg.generated.mbti
+++ b/uint/pkg.generated.mbti
@@ -11,9 +11,7 @@ let min_value : UInt
 // Errors
 
 // Types and methods
-fn UInt::to_be_bytes(UInt) -> Bytes
 fn UInt::to_int64(UInt) -> Int64
-fn UInt::to_le_bytes(UInt) -> Bytes
 impl Default for UInt
 
 // Type aliases

--- a/uint/uint.mbt
+++ b/uint/uint.mbt
@@ -36,6 +36,8 @@ pub fn default() -> UInt {
 
 ///|
 /// Converts the UInt to a Bytes in big-endian byte order.
+#deprecated(skip_current_package=false)
+#doc(hidden)
 pub fn UInt::to_be_bytes(self : UInt) -> Bytes {
   [
     (self >> 24).to_byte(),
@@ -47,6 +49,8 @@ pub fn UInt::to_be_bytes(self : UInt) -> Bytes {
 
 ///|
 /// Converts the UInt to a Bytes in little-endian byte order.
+#deprecated(skip_current_package=false)
+#doc(hidden)
 pub fn UInt::to_le_bytes(self : UInt) -> Bytes {
   [
     self.to_byte(),

--- a/uint/uint_test.mbt
+++ b/uint/uint_test.mbt
@@ -64,7 +64,10 @@ test "default" {
 ///|
 test "to_le_bytes" {
   let x : UInt = 0x12345678U
-  let bytes = x.to_le_bytes()
+  // let bytes = x.to_le_bytes()
+  let buf = @buffer.new()
+  buf.write_uint_le(x)
+  let bytes = buf.to_bytes()
   inspect(bytes[0].to_int(), content="120") // 0x78
   inspect(bytes[1].to_int(), content="86") // 0x56
   inspect(bytes[2].to_int(), content="52") // 0x34
@@ -74,10 +77,4 @@ test "to_le_bytes" {
 ///|
 test "test UInt::default" {
   inspect(UInt::default(), content="0")
-}
-
-///|
-test "to_be_bytes" {
-  let n = 4294967295U // maximum UInt value
-  inspect(n.to_be_bytes(), content="b\"\\xff\\xff\\xff\\xff\"")
 }


### PR DESCRIPTION
- Removed deprecated `contents` method from Buffer and replaced it with `to_bytes` and `view` methods.
- Updated `to_bytes` methods in Buffer, Float, Int, and UInt to use local byte conversion functions instead of relying on reinterpretation.
- Modified tests for Int and UInt to utilize Buffer for byte conversions, ensuring consistency and clarity.
- Cleaned up README documentation for UInt, removing unnecessary byte conversion examples.
- Updated package dependencies in `moon.pkg.json` for Int and UInt to include Buffer.
