### PR TITLE
feat(string): add code_unit_at method

### DIFF
--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1555,6 +1555,12 @@ pub fn String::length(self : String) -> Int = "%string_length"
 pub fn String::at(self : String, idx : Int) -> Int = "%string_get"
 
 ///|
+/// Returns the UTF-16 code unit at the given index.
+/// 
+/// This method has O(1) complexity.
+pub fn String::code_unit_at(self : String, idx : Int) -> UInt16 = "%string_get"
+
+///|
 /// Returns the UTF-16 code unit at a given position in the string without
 /// performing bounds checking. This is a low-level function that provides direct
 /// access to the internal representation of the string.

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -650,6 +650,7 @@ fn String::at(String, Int) -> Int
 fn String::char_length(String, start_offset? : Int, end_offset? : Int) -> Int
 fn String::char_length_eq(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
 fn String::char_length_ge(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
+fn String::code_unit_at(String, Int) -> UInt16
 #deprecated
 fn String::codepoint_at(String, Int) -> Char
 fn String::contains(String, StringView) -> Bool

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -121,3 +121,13 @@ test "String::suffixes" {
     .collect()
   @json.inspect(empty_suffixes_with_empty, content=[""])
 }
+
+///|
+test "code_unit_at" {
+  let s = "Hello, 世界!😀"
+  inspect(s.code_unit_at(0), content="72") // 'H'
+  inspect(s.code_unit_at(7), content="19990") // '世'
+  inspect(s.code_unit_at(8), content="30028") // '界'
+  inspect(s.code_unit_at(10), content="55357") // High surrogate of '😀'
+  inspect(s.code_unit_at(11), content="56832") // Low surrogate of '😀'
+}


### PR DESCRIPTION
Added `String::code_unit_at` that returns `UInt16`. Next step is to deprecated current string index accessing for nightly channel and see the consequences next week.