### PR TITLE
refactor: deprecate some operators

### DIFF
--- a/builtin/op.mbt
+++ b/builtin/op.mbt
@@ -14,24 +14,32 @@
 
 ///|
 #coverage.skip
+#deprecated
+#doc(hidden)
 pub fn[T : Compare] op_lt(self_ : T, other : T) -> Bool {
   Compare::op_lt(self_, other)
 }
 
 ///|
 #coverage.skip
+#deprecated
+#doc(hidden)
 pub fn[T : Compare] op_gt(self_ : T, other : T) -> Bool {
   Compare::op_gt(self_, other)
 }
 
 ///|
 #coverage.skip
+#deprecated
+#doc(hidden)
 pub fn[T : Compare] op_le(self_ : T, other : T) -> Bool {
   Compare::op_le(self_, other)
 }
 
 ///|
 #coverage.skip
+#deprecated
+#doc(hidden)
 pub fn[T : Compare] op_ge(self_ : T, other : T) -> Bool {
   Compare::op_ge(self_, other)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -32,14 +32,6 @@ fn not(Bool) -> Bool
 
 let null : Json
 
-fn[T : Compare] op_ge(T, T) -> Bool
-
-fn[T : Compare] op_gt(T, T) -> Bool
-
-fn[T : Compare] op_le(T, T) -> Bool
-
-fn[T : Compare] op_lt(T, T) -> Bool
-
 fn[T : Eq] op_notequal(T, T) -> Bool
 
 fn[T] panic() -> T


### PR DESCRIPTION
The operators are now resolved to `Compare::xxx`

Note : The `op_notequal` has not been migrated yet.