### PR TITLE
prepare for migration of source location to relative path

### DIFF
--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -45,6 +45,78 @@ pub impl Show for SourceLoc with output(self, logger) {
 }
 
 ///|
+priv enum SourceLocRepr {
+  Legacy(String)
+  New(
+    pkg~ : StringView,
+    filename~ : StringView,
+    start_line~ : StringView,
+    start_column~ : StringView,
+    end_line~ : StringView,
+    end_column~ : StringView
+  )
+}
+
+///|
+fn SourceLocRepr::parse(repr : String) -> SourceLocRepr {
+  fn parse_loc(view : StringView) -> (StringView, StringView)? {
+    guard view.find(":") is Some(i) else { None }
+    guard i > 0 && i + 1 < view.length() else { None }
+    Some((view.view(end_offset=i), view.view(start_offset=i + 1)))
+  }
+  // extract package name
+  guard repr is ['@', .. rest] else { Legacy(repr) }
+  guard rest.find(":") is Some(pkg_end) else { Legacy(repr) }
+  let pkg = rest.view(start_offset=0, end_offset=pkg_end)
+
+  // extract end location in reverse
+  guard rest.rev_find("-") is Some(start_loc_end) else { Legacy(repr) }
+  guard start_loc_end + 1 < rest.length()
+  let end_loc = rest.view(start_offset=start_loc_end + 1)
+  guard parse_loc(end_loc) is Some((end_line, end_column)) else { Legacy(repr) }
+  let rest = rest.view(end_offset=start_loc_end)
+
+  // extract start location
+  guard rest.rev_find(":") is Some(start_line_end) &&
+    rest.view(end_offset=start_line_end).rev_find(":") is Some(filename_end) else {
+    Legacy(repr)
+  }
+  guard filename_end + 1 < rest.length()
+  let start_loc = rest.view(start_offset=filename_end + 1)
+  guard parse_loc(start_loc) is Some((start_line, start_column)) else {
+    Legacy(repr)
+  }
+
+  // everything else remaining is treated as filename
+  guard filename_end > pkg_end + 1 else { Legacy(repr) }
+  let filename = rest.view(start_offset=pkg_end + 1, end_offset=filename_end)
+  New(pkg~, filename~, start_line~, start_column~, end_line~, end_column~)
+}
+
+///|
+fn SourceLocRepr::to_json_string(self : SourceLocRepr) -> String {
+  match self {
+    Legacy(repr) => repr.escape()
+    New(pkg~, filename~, start_line~, start_column~, end_line~, end_column~) =>
+      StringBuilder::new()
+      ..write_string("{\"pkg\":\"\{pkg}\"")
+      ..write_string(",\"filename\":")
+      ..write_object(filename)
+      ..write_string(",\"start_line\":\{start_line}")
+      ..write_string(",\"start_column\":\{start_column}")
+      ..write_string(",\"end_line\":\{end_line}")
+      ..write_string(",\"end_column\":\{end_column}}")
+      .to_string()
+  }
+}
+
+///|
+/// Convert a source location to a JSON string
+pub fn SourceLoc::to_json_string(self : SourceLoc) -> String {
+  SourceLocRepr::parse(self.to_string()).to_json_string()
+}
+
+///|
 /// Represents a type for storing argument locations in source code. It is an
 /// array of optional source locations, where each element corresponds to an
 /// argument's location in the source code. Used internally by the compiler for
@@ -73,7 +145,7 @@ pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
     let item = self[i]
     match item {
       None => buf.write_string("null")
-      Some(loc) => loc.to_string() |> Show::output(buf)
+      Some(loc) => buf.write_string(loc.to_json_string())
     }
   }
   buf.write_char(']')

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -183,7 +183,7 @@ pub fn inspect(
 ) -> Unit raise InspectError {
   let actual = obj.to_string()
   if actual != content {
-    let loc = loc.to_string().escape()
+    let loc = loc.to_json_string()
     let args_loc = args_loc.to_json().escape()
     let expect_escaped = content.escape()
     let actual_escaped = actual.escape()

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -406,6 +406,7 @@ pub impl[A : Hash] Hash for MutArrayView[A]
 pub impl[X : Show] Show for MutArrayView[X]
 
 pub(all) type SourceLoc
+pub fn SourceLoc::to_json_string(Self) -> String
 pub fn SourceLoc::to_string(Self) -> String
 pub impl Show for SourceLoc
 

--- a/builtin/source_loc_wbtest.mbt
+++ b/builtin/source_loc_wbtest.mbt
@@ -1,0 +1,59 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "SourceLocRepr::parse" {
+  inspect(
+    SourceLocRepr::parse("file.mbt:1:1-2:2").to_json_string(),
+    content=(
+      #|"file.mbt:1:1-2:2"
+    ),
+  )
+  inspect(
+    SourceLocRepr::parse("/path/to/file.mbt:1:1-2:2").to_json_string(),
+    content=(
+      #|"/path/to/file.mbt:1:1-2:2"
+    ),
+  )
+  inspect(
+    SourceLocRepr::parse("/中文路径/中文文件.mbt:1:1-2:2").to_json_string(),
+    content=(
+      #|"/中文路径/中文文件.mbt:1:1-2:2"
+    ),
+  )
+  inspect(
+    SourceLocRepr::parse("@pkg:file.mbt:1:1-2:2").to_json_string(),
+    content=(
+      #|{"pkg":"pkg","filename":"file.mbt","start_line":1,"start_column":1,"end_line":2,"end_column":2}
+    ),
+  )
+  inspect(
+    SourceLocRepr::parse("@path/to/pkg:/path/to/file.mbt:1:1-2:2").to_json_string(),
+    content=(
+      #|{"pkg":"path/to/pkg","filename":"/path/to/file.mbt","start_line":1,"start_column":1,"end_line":2,"end_column":2}
+    ),
+  )
+  inspect(
+    SourceLocRepr::parse("@path/to/pkg:/中文路径/中文文件.mbt:1:1-2:2").to_json_string(),
+    content=(
+      #|{"pkg":"path/to/pkg","filename":"/中文路径/中文文件.mbt","start_line":1,"start_column":1,"end_line":2,"end_column":2}
+    ),
+  )
+  inspect(
+    SourceLocRepr::parse("@file.mbt:1:1-2:2").to_json_string(),
+    content=(
+      #|"@file.mbt:1:1-2:2"
+    ),
+  )
+}

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -457,7 +457,7 @@ pub fn inspect(
   loc~ : SourceLoc,
   args_loc~ : ArgsLoc,
 ) -> Unit raise InspectError {
-  let loc = loc.to_string().escape()
+  let loc = loc.to_json_string()
   let args_loc = args_loc.to_json().escape()
   let actual = obj.to_json().stringify(escape_slash=false)
   let want = match content {

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -113,7 +113,7 @@ pub fn Test::snapshot(
   loc~ : SourceLoc,
   args_loc~ : ArgsLoc,
 ) -> Unit raise SnapshotError {
-  let loc = loc.to_string().escape()
+  let loc = loc.to_json_string()
   let args_loc = args_loc.to_json().escape()
   let actual = self.buffer.to_string().escape()
   let expect = filename.escape()


### PR DESCRIPTION
We intend to migrate `SourceLoc` to relative path (package name + file name relative to package root) in the near future, this enables:

- snapshot `SourceLoc` in tests
- relocatable `.core` binary

However, this migration requires change in both `moonc`, `moon` and `moonbitlang/core`. This PR:

- let `moonbitlang/core` handle both the old representation `<filename>:<line>:<col>-<line>:<col>` and the new representation `@<pkg>:<filename>:<line>:<col>-<line>:<col>`
- for testing related API such as `inspect`, the output format depends on the format of the source location:
    - if the source location is in old format, the output is the same as before, just output the source location string as-is
    - if the source location is in new format, it is parsed, and the output would be a more structured JSON
    
    this way, `moon` can easily handle both formats during the migration period