### PR TITLE
deprecate `String::get` and `StringView::get`

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -663,6 +663,7 @@ pub fn[A] String::fold(String, init~ : A, (A, Char) -> A) -> A
 pub fn String::from_array(ArrayView[Char]) -> String
 pub fn String::from_iter(Iter[Char]) -> String
 pub fn String::from_iterator(Iterator[Char]) -> String
+#deprecated
 pub fn String::get(String, Int) -> Int?
 pub fn String::get_char(String, Int) -> Char?
 #alias(starts_with, deprecated)
@@ -863,6 +864,7 @@ pub fn[A] StringView::fold(Self, init~ : A, (A, Char) -> A) -> A
 pub fn StringView::from_array(ArrayView[Char]) -> Self
 pub fn StringView::from_iter(Iter[Char]) -> Self
 pub fn StringView::from_iterator(Iterator[Char]) -> Self
+#deprecated
 pub fn StringView::get(Self, Int) -> Int?
 pub fn StringView::get_char(Self, Int) -> Char?
 #alias(starts_with, deprecated)

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1545,6 +1545,7 @@ test "rev_fold" {
 ///|
 /// Returns the UTF-16 code unit at the given index. Returns `None` if the index
 /// is out of bounds.
+#deprecated("The return type is about to change to `UInt16?` in a future release. Please check boundaries manually and use `String::code_unit_at` instead.", skip_current_package=true)
 pub fn String::get(self : String, idx : Int) -> Int? {
   guard idx >= 0 && idx < self.length() else { return None }
   Some(self.unsafe_charcode_at(idx))
@@ -1553,6 +1554,7 @@ pub fn String::get(self : String, idx : Int) -> Int? {
 ///|
 /// Returns the UTF-16 code unit at the given index. Returns `None` if the index
 /// is out of bounds.
+#deprecated("The return type is about to change to `UInt16?` in a future release. Please check boundaries manually and use `StringView::code_unit_at` instead.", skip_current_package=true)
 pub fn StringView::get(self : StringView, idx : Int) -> Int? {
   guard idx >= 0 && idx < self.length() else { return None }
   Some(self.unsafe_charcode_at(idx))


### PR DESCRIPTION
Because their return type is about to change to `UInt16?`