### PR TITLE
doc: fix leaked local function

### DIFF
--- a/double/README.mbt.md
+++ b/double/README.mbt.md
@@ -87,7 +87,6 @@ test "binary representation" {
       #|b"?\xf0\x00\x00\x00\x00\x00\x00"
     ),
   )
-
   buffer.reset()
   buffer.write_double_le(num)
   inspect(


### PR DESCRIPTION
@bobzhang Currently the documents are considered as `block box test`, so they may accidentally leak helper functions from the blackbox tests. Should we do anything?