### PR TITLE
add  method for ArrayView

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -95,6 +95,34 @@ pub fn[T] ArrayView::at(self : ArrayView[T], index : Int) -> T {
 }
 
 ///|
+/// Retrieves an element from the array view at the specified index.
+///
+/// Parameters:
+///
+/// * `self` : The array view to retrieve the element from.
+/// * `index` : The position in the array view from which to retrieve the
+/// element.
+///
+/// Returns `Some(element)` if the index is within bounds, or `None` if the index
+/// is out of bounds.
+///
+/// Example:
+///
+/// ```mbt test
+/// let arr = [1, 2, 3, 4, 5]
+/// let view = arr[1:4]
+/// inspect(view.get(0), content="Some(2)")
+/// inspect(view.get(1), content="Some(3)")
+/// inspect(view.get(2), content="Some(4)")
+/// inspect(view.get(5), content="None")
+/// ```
+pub fn[T] ArrayView::get(self : ArrayView[T], index : Int) -> T? {
+  let len = self.length()
+  guard index >= 0 && index < len else { None }
+  Some(self.buf()[self.start() + index])
+}
+
+///|
 /// Retrieves an element from the array view at the specified index without
 /// performing bounds checking.
 ///

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -161,6 +161,7 @@ type ArrayView[T]
 #alias("_[_]")
 pub fn[T] ArrayView::at(Self[T], Int) -> T
 pub fn[A] ArrayView::blit_to(Self[A], Array[A], dst_offset? : Int) -> Unit
+pub fn[T] ArrayView::get(Self[T], Int) -> T?
 pub fn[T : Compare] ArrayView::is_sorted(Self[T]) -> Bool
 pub fn[A] ArrayView::iter(Self[A]) -> Iter[A]
 pub fn[X] ArrayView::iterator(Self[X]) -> Iterator[X]


### PR DESCRIPTION
We have Array::get to retrieve an element from an array safely, but we do not have ArrayView::get to do the same thing.

This PR is for solving this problem.