### PR TITLE
fix(@json.parse): remove max_nesting_depth default parameter

### DIFF
--- a/json/parse.mbt
+++ b/json/parse.mbt
@@ -23,10 +23,15 @@ pub fn valid(input : StringView) -> Bool {
 }
 
 ///|
-/// Parse a JSON input string into a Json value, with an optional maximum nesting depth (default is 1024)
-pub fn parse(
+/// Parse a JSON input string into a Json value
+pub fn parse(input : StringView) -> Json raise ParseError {
+  parse_with_max_nesting_depth(input, 1024)
+}
+
+///|
+fn parse_with_max_nesting_depth(
   input : StringView,
-  max_nesting_depth? : Int = 1024,
+  max_nesting_depth : Int,
 ) -> Json raise ParseError {
   let ctx = ParseContext::make(input, max_nesting_depth)
   let val = ctx.parse_value()

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -7,7 +7,7 @@ pub fn[T : FromJson] from_json(Json, path? : JsonPath) -> T raise JsonDecodeErro
 #callsite(autofill(args_loc, loc))
 pub fn inspect(&ToJson, content? : Json, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise InspectError
 
-pub fn parse(StringView, max_nesting_depth? : Int) -> Json raise ParseError
+pub fn parse(StringView) -> Json raise ParseError
 
 pub fn valid(StringView) -> Bool
 


### PR DESCRIPTION
`max_nesting_depth` is OS system setting, only should be set by `moonbitlang/core`, the user should not worry about it.