### PR TITLE
refactor(result): use unwrap_or/unwrap_or_else as primary methods with or/or_else aliases

### DIFF
--- a/result/pkg.generated.mbti
+++ b/result/pkg.generated.mbti
@@ -26,13 +26,13 @@ pub fn[T, E] Result::is_err(Self[T, E]) -> Bool
 pub fn[T, E] Result::is_ok(Self[T, E]) -> Bool
 pub fn[T, E, U] Result::map(Self[T, E], (T) -> U) -> Self[U, E]
 pub fn[T, E, F] Result::map_err(Self[T, E], (E) -> F) -> Self[T, F]
-pub fn[T, E] Result::or(Self[T, E], T) -> T
-pub fn[T, E] Result::or_else(Self[T, E], () -> T) -> T
 pub fn[T, E] Result::to_option(Self[T, E]) -> T?
 pub fn[T, E] Result::unwrap(Self[T, E]) -> T
 pub fn[T, E] Result::unwrap_err(Self[T, E]) -> E
+#alias(or)
 pub fn[T, E] Result::unwrap_or(Self[T, E], T) -> T
 pub fn[T : Default, E] Result::unwrap_or_default(Self[T, E]) -> T
+#alias(or_else)
 pub fn[T, E] Result::unwrap_or_else(Self[T, E], () -> T raise?) -> T raise?
 pub fn[T, E : Error] Result::unwrap_or_error(Self[T, E]) -> T raise E
 pub impl[T : Compare, E : Compare] Compare for Result[T, E]

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -70,16 +70,18 @@ test "map_err" {
 }
 
 ///|
-/// Return the inner `Ok` value, if it exists, otherwise return the provided default.
+/// Return the contained `Ok` value or the provided default.
 ///
 /// # Example
 ///
 /// ```mbt
-///   let x: Result[Int, String] = Ok(6)
-///   let y = x.or(0)
-///   assert_eq(y, 6)
+///   let x: Result[Int, String] = Ok(3)
+///   let y: Result[Int, String] = Err("error")
+///   assert_eq(x.unwrap_or(5), 3)
+///   assert_eq(y.unwrap_or(5), 5)
 /// ```
-pub fn[T, E] Result::or(self : Result[T, E], default : T) -> T {
+#alias(or)
+pub fn[T, E] Result::unwrap_or(self : Result[T, E], default : T) -> T {
   match self {
     Ok(value) => value
     Err(_) => default
@@ -87,27 +89,31 @@ pub fn[T, E] Result::or(self : Result[T, E], default : T) -> T {
 }
 
 ///|
-test "or" {
-  let x : Result[Int, String] = Ok(6)
+test "unwrap_or" {
+  let x : Result[Int, String] = Ok(3)
   let y : Result[Int, String] = Err("error")
-  let z = x.or(0)
-  let w = y.or(0)
-  assert_eq(z, 6)
-  assert_eq(w, 0)
+  assert_eq(x.unwrap_or(5), 3)
+  assert_eq(y.unwrap_or(5), 5)
 }
 
 ///|
-/// Return the inner `Ok` value, if it exists, otherwise return the provided default.
+/// Return the contained `Ok` value or the provided default.
 ///
 /// Default is lazily evaluated.
+///
 /// # Example
 ///
 /// ```mbt
-///   let x: Result[Int, String] = Ok(6)
-///   let y = x.or_else(() => { 0 })
-///   assert_eq(y, 6)
+///   let x: Result[Int, String] = Ok(3)
+///   let y: Result[Int, String] = Err("error")
+///   assert_eq(x.unwrap_or_else(() => 5), 3)
+///   assert_eq(y.unwrap_or_else(() => 5), 5)
 /// ```
-pub fn[T, E] Result::or_else(self : Result[T, E], default : () -> T) -> T {
+#alias(or_else)
+pub fn[T, E] Result::unwrap_or_else(
+  self : Result[T, E],
+  default : () -> T raise?,
+) -> T raise? {
   match self {
     Ok(value) => value
     Err(_) => default()
@@ -115,13 +121,11 @@ pub fn[T, E] Result::or_else(self : Result[T, E], default : () -> T) -> T {
 }
 
 ///|
-test "or_else" {
-  let x : Result[Int, String] = Ok(6)
+test "unwrap_or_else" {
+  let x : Result[Int, String] = Ok(3)
   let y : Result[Int, String] = Err("error")
-  let z = x.or_else(() => 0)
-  let w = y.or_else(() => 0)
-  assert_eq(z, 6)
-  assert_eq(w, 0)
+  assert_eq(x.unwrap_or_else(() => 5), 3)
+  assert_eq(y.unwrap_or_else(() => 5), 5)
 }
 
 ///|
@@ -285,45 +289,6 @@ test "show" {
       #|Err("world")
     ),
   )
-}
-
-///|
-/// Return the contained `Ok` value or the provided default.
-pub fn[T, E] Result::unwrap_or(self : Result[T, E], default : T) -> T {
-  match self {
-    Ok(value) => value
-    Err(_) => default
-  }
-}
-
-///|
-test "unwrap_or" {
-  let x : Result[Int, String] = Ok(3)
-  let y : Result[Int, String] = Err("error")
-  assert_eq(x.unwrap_or(5), 3)
-  assert_eq(y.unwrap_or(5), 5)
-}
-
-///|
-/// Return the contained `Ok` value or the provided default.
-///
-/// Default is lazily evaluated
-pub fn[T, E] Result::unwrap_or_else(
-  self : Result[T, E],
-  default : () -> T raise?,
-) -> T raise? {
-  match self {
-    Ok(value) => value
-    Err(_) => default()
-  }
-}
-
-///|
-test "unwrap_or_else" {
-  let x : Result[Int, String] = Ok(3)
-  let y : Result[Int, String] = Err("error")
-  assert_eq(x.unwrap_or_else(() => 5), 3)
-  assert_eq(y.unwrap_or_else(() => 5), 5)
 }
 
 ///|


### PR DESCRIPTION
## Summary

This PR refactors the Result API to use more standard Rust-like naming conventions while maintaining backward compatibility.

## Changes

- Replace `Result::or` with `Result::unwrap_or`, adding `#alias(or)` for backward compatibility
- Replace `Result::or_else` with `Result::unwrap_or_else`, adding `#alias(or_else)`
- Both method names remain available to users through the alias mechanism

## Benefits

- Aligns the API with standard Rust naming conventions
- Makes the codebase more familiar to developers from Rust ecosystem
- Maintains full backward compatibility
- Primary method names are more descriptive and self-documenting

## Testing

✅ All tests pass: 5306 tests across all targets (wasm, wasm-gc, js)
✅ Type checking passes
✅ Interface file correctly reflects the aliases