### PR TITLE
improve `Show` impl for `SourceLoc`

### DIFF
--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -32,16 +32,16 @@ pub(all) type SourceLoc
 /// file path, line number, and column number.
 ///
 /// Returns a string representation of the source location, typically in the
-/// format "file:line:column".
+/// format "@package:file:start_line:start_column-end_line:end_column".
 ///
 /// Note: This function is primarily used internally by the compiler for error
 /// reporting and debugging purposes. Source locations are automatically created
 /// by the compiler when needed.
-pub fn SourceLoc::to_string(self : Self) -> String = "%loc_to_string"
+fn SourceLoc::repr(self : Self) -> String = "%loc_to_string"
 
 ///|
 pub impl Show for SourceLoc with output(self, logger) {
-  logger.write_string(self.to_string())
+  SourceLocRepr::parse(self.repr()).output(logger)
 }
 
 ///|
@@ -55,6 +55,42 @@ priv enum SourceLocRepr {
     end_line~ : StringView,
     end_column~ : StringView
   )
+}
+
+///|
+impl Show for SourceLocRepr with output(self, logger) {
+  match self {
+    Legacy(repr) => logger.write_string(repr)
+    New(pkg~, filename~, start_line~, start_column~, end_line~, end_column~) => {
+      let (module_name, package_name) = {
+        guard pkg.find("/") is Some(first_slash) else { (pkg, None) }
+        guard pkg.view(start_offset=first_slash + 1).find("/")
+          is Some(second_slash) else {
+          (pkg, None)
+        }
+        let module_name_end = first_slash + 1 + second_slash
+        (
+          pkg.view(end_offset=module_name_end),
+          Some(pkg.view(start_offset=module_name_end + 1)),
+        )
+      }
+      if package_name is Some(pkg_name) {
+        logger..write_view(pkg_name)..write_char('/')
+      }
+      logger
+      ..write_view(filename)
+      ..write_char(':')
+      ..write_view(start_line)
+      ..write_char(':')
+      ..write_view(start_column)
+      ..write_char('-')
+      ..write_view(end_line)
+      ..write_char(':')
+      ..write_view(end_column)
+      ..write_char('@')
+      ..write_view(module_name)
+    }
+  }
 }
 
 ///|
@@ -113,7 +149,7 @@ fn SourceLocRepr::to_json_string(self : SourceLocRepr) -> String {
 ///|
 /// Convert a source location to a JSON string
 pub fn SourceLoc::to_json_string(self : SourceLoc) -> String {
-  SourceLocRepr::parse(self.to_string()).to_json_string()
+  SourceLocRepr::parse(self.repr()).to_json_string()
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -444,7 +444,6 @@ pub impl[X : Show] Show for MutArrayView[X]
 
 pub(all) type SourceLoc
 pub fn SourceLoc::to_json_string(Self) -> String
-pub fn SourceLoc::to_string(Self) -> String
 pub impl Show for SourceLoc
 
 type StringBuilder

--- a/builtin/source_loc_wbtest.mbt
+++ b/builtin/source_loc_wbtest.mbt
@@ -57,3 +57,35 @@ test "SourceLocRepr::parse" {
     ),
   )
 }
+
+///|
+test "SourceLocRepr::to_string" {
+  // legacy format
+  inspect(
+    SourceLocRepr::parse("file.mbt:1:1-2:2").to_string(),
+    content="file.mbt:1:1-2:2",
+  )
+  inspect(
+    SourceLocRepr::parse("中文路径/中文文件.mbt:1:1-2:2").to_string(),
+    content="中文路径/中文文件.mbt:1:1-2:2",
+  )
+  // new format
+  inspect(
+    SourceLocRepr::parse(
+      "@moonbitlang/core/builtin:source_loc_wbtest.mbt:1:1-2:2",
+    ),
+    content="builtin/source_loc_wbtest.mbt:1:1-2:2@moonbitlang/core",
+  )
+  inspect(
+    SourceLocRepr::parse("@module/root:file.mbt:1:1-2:2"),
+    content="file.mbt:1:1-2:2@module/root",
+  )
+  inspect(
+    SourceLocRepr::parse("@module/root/internal/package:file.mbt:1:1-2:2"),
+    content="internal/package/file.mbt:1:1-2:2@module/root",
+  )
+  inspect(
+    SourceLocRepr::parse("@bad_module_name:file.mbt:1:1-2:2"),
+    content="file.mbt:1:1-2:2@bad_module_name",
+  )
+}


### PR DESCRIPTION
Previously, the `Show` implementation of `SourceLoc` displays something like:
```
@monbitlang/core/builtin:autoloc.mbt:1:1-2:2
```
One problem with this format is: tools like VSCode will recognize the whole `@package_path:file.mbt` as a file name, so users cannot jump to the corresponding location by clicking on test diff.

This PR tweaks the format to:
```
builtin/autoloc.mbt:1:1-2:2@moonbitlang/core
```
The package full path is split into the module part (i.e. content before the second slash) and package part (everything else), the package path is combined with the file name, and the module part is moved to the end. This way, the file name part (`builtin/autoloc.mbt`) is a valid file path relative to module root directory in a typical MoonBit project, and users can jump to the location by clicking.

Note that the change in this PR only affects the `Show` implementation of `SourceLoc`. Interaction with `moon` (via `inspect`, for example) is not affected.