### PR TITLE
Export FromJson trait from prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changelog should follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 #### Added
 
+- Export `FromJson` trait from `@json` package in prelude for easier JSON deserialization
+
 #### Changed
 
 - **BREAKING**: `String::at` and `StringView::at` now return `UInt16` instead of `Int` and are the primary methods for accessing UTF-16 code units

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -726,3 +726,15 @@ test "transformer with array" {
     { "a": [{ "b": [{ "c": [{}] }] }] },
   ])
 }
+
+///|
+#warnings("-unused_trait_bound")
+fn[A : FromJson] test_json_export(x : A) -> A {
+  x
+}
+
+///|
+test {
+  let _ : Int = test_json_export(42)
+
+}

--- a/prelude/moon.pkg.json
+++ b/prelude/moon.pkg.json
@@ -2,7 +2,8 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/bigint",
-    "moonbitlang/core/set"
+    "moonbitlang/core/set",
+    "moonbitlang/core/json"
   ],
   "warn-list": "-test_unqualified_package"
 }

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbitlang/core/prelude"
 import(
   "moonbitlang/core/bigint"
   "moonbitlang/core/builtin"
+  "moonbitlang/core/json"
   "moonbitlang/core/set"
 )
 
@@ -111,6 +112,8 @@ pub using @builtin {trait Default}
 pub using @builtin {trait Div}
 
 pub using @builtin {trait Eq}
+
+pub using @json {trait FromJson}
 
 pub using @builtin {trait Hash}
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -120,3 +120,6 @@ pub fn[T, R] then(value : T, f : (T) -> R raise?) -> R raise? {
 
 ///|
 pub let null : Json = @builtin.null
+
+///|
+pub using @json {trait FromJson}


### PR DESCRIPTION
This change makes FromJson trait available in the prelude, allowing users to use FromJson trait bound without explicitly importing from @json package.

This simplifies code that uses JSON deserialization by making FromJson available by default, similar to other commonly used traits like Show, Eq, etc.

Changes:
- Export FromJson trait in prelude/prelude.mbt
- Update prelude dependencies to include @json
- Add test case for FromJson trait bound usage
- Update CHANGELOG.md