### PR TITLE
Make trim functions accept optional chars parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ changelog should follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - **BREAKING**: `String::at` and `StringView::at` now return `UInt16` instead of `Int` and are the primary methods for accessing UTF-16 code units
 - **BREAKING**: `String::code_unit_at` and `StringView::code_unit_at` are now aliases for `at` instead of being separate methods
+- `String::trim`, `String::trim_start`, `String::trim_end` and their `StringView` counterparts now accept optional `chars` parameter with default whitespace characters
 
 #### Deprecated
 
 - `String::charcode_at` (previously named `at`) is now deprecated, use `String::at` which returns `UInt16`
+- `String::trim_space` and `StringView::trim_space` are now deprecated, use `trim()` with default whitespace characters instead
 
 #### Removed
 

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -746,15 +746,13 @@ pub fn String::to_lower(String) -> String
 pub fn String::to_string(String) -> String
 pub fn String::to_upper(String) -> String
 #label_migration(chars, alias=char_set)
-#label_migration(chars, allow_positional=true)
-pub fn String::trim(String, chars~ : StringView) -> StringView
+pub fn String::trim(String, chars? : StringView) -> StringView
 #label_migration(chars, alias=char_set)
-#label_migration(chars, allow_positional=true)
-pub fn String::trim_end(String, chars~ : StringView) -> StringView
+pub fn String::trim_end(String, chars? : StringView) -> StringView
+#deprecated
 pub fn String::trim_space(String) -> StringView
 #label_migration(chars, alias=char_set)
-#label_migration(chars, allow_positional=true)
-pub fn String::trim_start(String, chars~ : StringView) -> StringView
+pub fn String::trim_start(String, chars? : StringView) -> StringView
 #deprecated
 pub fn String::unsafe_char_at(String, Int) -> Char
 pub fn String::unsafe_substring(String, start~ : Int, end~ : Int) -> String
@@ -1010,11 +1008,10 @@ pub fn StringView::to_bytes(Self) -> Bytes
 pub fn StringView::to_lower(Self) -> Self
 pub fn StringView::to_upper(Self) -> Self
 #label_migration(chars, alias=char_set)
-#label_migration(chars, allow_positional=true)
-pub fn StringView::trim(Self, chars~ : Self) -> Self
+pub fn StringView::trim(Self, chars? : Self) -> Self
 #label_migration(chars, alias=char_set)
-#label_migration(chars, allow_positional=true)
-pub fn StringView::trim_end(Self, chars~ : Self) -> Self
+pub fn StringView::trim_end(Self, chars? : Self) -> Self
+#deprecated
 pub fn StringView::trim_space(Self) -> Self
 #label_migration(chars, alias=char_set)
 #label_migration(chars, allow_positional=true)

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -649,9 +649,11 @@ pub fn StringView::trim_start(
 ///|
 /// Returns the view of the string without the leading characters that are in
 /// the given string.
-#label_migration(chars, allow_positional=true)
 #label_migration(chars, alias=char_set)
-pub fn String::trim_start(self : String, chars~ : StringView) -> StringView {
+pub fn String::trim_start(
+  self : String,
+  chars? : StringView = "\t\n\r ",
+) -> StringView {
   self[:].trim_start(chars~)
 }
 
@@ -674,11 +676,10 @@ test "trim_start" {
 ///|
 /// Returns the view of the string without the trailing characters that are in
 /// the given string.
-#label_migration(chars, allow_positional=true)
 #label_migration(chars, alias=char_set)
 pub fn StringView::trim_end(
   self : StringView,
-  chars~ : StringView,
+  chars? : StringView = "\t\n\r ",
 ) -> StringView {
   loop self {
     [] as v => v
@@ -691,9 +692,11 @@ pub fn StringView::trim_end(
 /// the given string.
 // TODO(upstream): label_migration warning does not apply to the current package
 // TODO: make chars optional with default value of whitespace characters
-#label_migration(chars, allow_positional=true)
 #label_migration(chars, alias=char_set)
-pub fn String::trim_end(self : String, chars~ : StringView) -> StringView {
+pub fn String::trim_end(
+  self : String,
+  chars? : StringView = "\t\n\r ",
+) -> StringView {
   self[:].trim_end(chars~)
 }
 
@@ -715,18 +718,22 @@ test "trim_end" {
 ///|
 /// Returns the view of the string without the leading and trailing characters
 /// that are in the given string.
-#label_migration(chars, allow_positional=true)
 #label_migration(chars, alias=char_set)
-pub fn StringView::trim(self : StringView, chars~ : StringView) -> StringView {
+pub fn StringView::trim(
+  self : StringView,
+  chars? : StringView = "\t\n\r ",
+) -> StringView {
   self.trim_start(chars~).trim_end(chars~)
 }
 
 ///|
 /// Returns the view of the string without the leading and trailing characters
 /// that are in the given string.
-#label_migration(chars, allow_positional=true)
 #label_migration(chars, alias=char_set)
-pub fn String::trim(self : String, chars~ : StringView) -> StringView {
+pub fn String::trim(
+  self : String,
+  chars? : StringView = "\t\n\r ",
+) -> StringView {
   self[:].trim(chars~)
 }
 
@@ -751,28 +758,30 @@ test "trim" {
 
 ///|
 /// Returns the view of the string without the leading and trailing spaces.
+#deprecated("Use `trim` with default whitespace characters instead")
 pub fn StringView::trim_space(self : StringView) -> StringView {
-  self.trim(chars=" \n\r\t")
+  self.trim()
 }
 
 ///|
 /// Returns the view of the string without the leading and trailing spaces.
+#deprecated("Use `trim` with default whitespace characters instead")
 pub fn String::trim_space(self : String) -> StringView {
-  self[:].trim_space()
+  self.trim()
 }
 
 ///|
-test "trim_space" {
-  inspect("hello".trim_space(), content="hello")
-  inspect("  hello  ".trim_space(), content="hello")
-  inspect("hello  ".trim_space(), content="hello")
-  inspect("  hello".trim_space(), content="hello")
-  inspect("\t\nhello\r\n".trim_space(), content="hello")
-  inspect("  hello world  ".trim_space(), content="hello world")
-  inspect("  ".trim_space(), content="")
-  inspect("\n\r\t".trim_space(), content="")
-  inspect("".trim_space(), content="")
-  inspect("  hello\nworld\t".trim_space(), content="hello\nworld")
+test "trim whitespace for string" {
+  inspect("hello".trim(), content="hello")
+  inspect("  hello  ".trim(), content="hello")
+  inspect("hello  ".trim(), content="hello")
+  inspect("  hello".trim(), content="hello")
+  inspect("\t\nhello\r\n".trim(), content="hello")
+  inspect("  hello world  ".trim(), content="hello world")
+  inspect("  ".trim(), content="")
+  inspect("\n\r\t".trim(), content="")
+  inspect("".trim(), content="")
+  inspect("  hello\nworld\t".trim(), content="hello\nworld")
 }
 
 ///|
@@ -807,7 +816,7 @@ test "is_empty" {
 ///|
 /// Returns true if this string is blank.
 pub fn StringView::is_blank(self : StringView) -> Bool {
-  self.trim_space().is_empty()
+  self.trim().is_empty()
 }
 
 ///|

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -372,19 +372,19 @@ test "trim" {
 }
 
 ///|
-test "trim_space" {
-  inspect(" abc ".trim_space(), content="abc")
-  inspect("abc ".trim_space(), content="abc")
-  inspect(" abc".trim_space(), content="abc")
-  inspect("\nabc\n".trim_space(), content="abc")
-  inspect("\tabc\t".trim_space(), content="abc")
-  inspect("\rabc\r".trim_space(), content="abc")
-  inspect("abc".trim_space(), content="abc")
-  inspect("".trim_space(), content="")
-  inspect("  ".trim_space(), content="")
-  inspect("\n\n".trim_space(), content="")
-  inspect("\t\t".trim_space(), content="")
-  inspect("\r\r".trim_space(), content="")
+test "trim whitespace" {
+  inspect(" abc ".trim(), content="abc")
+  inspect("abc ".trim(), content="abc")
+  inspect(" abc".trim(), content="abc")
+  inspect("\nabc\n".trim(), content="abc")
+  inspect("\tabc\t".trim(), content="abc")
+  inspect("\rabc\r".trim(), content="abc")
+  inspect("abc".trim(), content="abc")
+  inspect("".trim(), content="")
+  inspect("  ".trim(), content="")
+  inspect("\n\n".trim(), content="")
+  inspect("\t\t".trim(), content="")
+  inspect("\r\r".trim(), content="")
 }
 
 ///|


### PR DESCRIPTION
This PR improves the  family of functions by making the  parameter optional with a default value of common whitespace characters.

## Changes

- Changed `String::trim`, `trim_start`, `trim_end` to accept optional `chars` parameter with default whitespace (`"\t\n\r "`)
- Changed `StringView::trim`, `trim_start`, `trim_end` to accept optional `chars` parameter with default whitespace
- Deprecated `String::trim_space` and `StringView::trim_space` in favor of `trim()` with defaults
- Updated tests to use `trim()` instead of `trim_space()`
- Updated CHANGELOG.md with breaking changes and deprecations

## Benefits

- More ergonomic API - users can call `string.trim()` instead of `string.trim(chars=" \t\n\r")`
- Backward compatible - existing code using named parameter `chars~` will continue to work
- Consistent with other string operations that have sensible defaults
- `trim_space` is deprecated but still available for smooth migration

## Migration

Old code:
```moonbit
let s = "  hello  ".trim_space()
```

New code:
```moonbit
let s = "  hello  ".trim()
```