### PR TITLE
feat: iterate SortedMap and SortedSet in reverse order

### DIFF
--- a/immut/sorted_map/README.mbt.md
+++ b/immut/sorted_map/README.mbt.md
@@ -181,3 +181,27 @@ test {
   assert_eq(keys.collect(), ["a", "b", "c"])
 }
 ```
+
+### Reverse Iteration
+
+Use `rev_keys()` to get all keys in descending order.
+
+```mbt check
+///|
+test {
+  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let keys = map.rev_keys().collect()
+  assert_eq(keys, ["c", "b", "a"])
+}
+```
+
+Use `rev_values()` to get all values in descending order of their keys.
+
+```mbt check
+///|
+test {
+  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let values = map.rev_values().collect()
+  assert_eq(values, [3, 2, 1])
+}
+```

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -61,6 +61,8 @@ pub fn[K, V] SortedMap::new() -> Self[K, V]
 pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Self[K, V]
 #alias(foldr_with_key)
 pub fn[K, V, A] SortedMap::rev_fold(Self[K, V], (A, K, V) -> A, init~ : A) -> A
+pub fn[K, V] SortedMap::rev_keys(Self[K, V]) -> Iterator[K]
+pub fn[K, V] SortedMap::rev_values(Self[K, V]) -> Iterator[V]
 #as_free_fn
 pub fn[K, V] SortedMap::singleton(K, V) -> Self[K, V]
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -297,6 +297,70 @@ pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Iter[V] {
 }
 
 ///|
+/// Return all keys of the map in descending order.
+///
+/// # Example
+///
+/// ```mbt
+///   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+///   let keys = map.rev_keys().collect()
+///   assert_eq(keys, ["c", "b", "a"])
+/// ```
+pub fn[K, V] SortedMap::rev_keys(self : SortedMap[K, V]) -> Iterator[K] {
+  let mut curr_node = self
+  let parents = []
+  Iterator::new(fn() {
+    loop curr_node {
+      Tree(k, l, Empty, ..) => {
+        curr_node = l
+        Some(k)
+      }
+      Tree(k, l, r, ..) => {
+        parents.push((k, l))
+        continue r
+      }
+      Empty if parents.pop() is Some((k, l)) => {
+        curr_node = l
+        Some(k)
+      }
+      Empty => None
+    }
+  })
+}
+
+///|
+/// Return all values of the map in descending order of their keys.
+///
+/// # Example
+///
+/// ```mbt
+///   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+///   let values = map.rev_values().collect()
+///   assert_eq(values, [3, 2, 1])
+/// ```
+pub fn[K, V] SortedMap::rev_values(self : SortedMap[K, V]) -> Iterator[V] {
+  let mut curr_node = self
+  let parents = []
+  Iterator::new(fn() {
+    loop curr_node {
+      Tree(_k, value~, l, Empty, ..) => {
+        curr_node = l
+        Some(value)
+      }
+      Tree(_k, value~, l, r, ..) => {
+        parents.push((value, l))
+        continue r
+      }
+      Empty if parents.pop() is Some((v, l)) => {
+        curr_node = l
+        Some(v)
+      }
+      Empty => None
+    }
+  })
+}
+
+///|
 pub fn[K : Show, V : ToJson] SortedMap::to_json(self : SortedMap[K, V]) -> Json {
   ToJson::to_json(self)
 }

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -210,6 +210,121 @@ test "iter2" {
 }
 
 ///|
+test "rev_keys returns keys in descending order" {
+  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let keys = map.rev_keys().collect()
+  inspect(keys, content="[\"c\", \"b\", \"a\"]")
+}
+
+///|
+test "rev_values returns values in descending key order" {
+  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let values = map.rev_values().collect()
+  inspect(values, content="[3, 2, 1]")
+}
+
+///|
+test "rev_keys on empty map" {
+  let map : @sorted_map.SortedMap[String, Int] = @sorted_map.new()
+  inspect(map.rev_keys().collect(), content="[]")
+}
+
+///|
+test "rev_values on empty map" {
+  let map : @sorted_map.SortedMap[String, Int] = @sorted_map.new()
+  inspect(map.rev_values().collect(), content="[]")
+}
+
+///|
+test "rev_keys on single element map" {
+  let map = @sorted_map.singleton("a", 1)
+  let keys = map.rev_keys().collect()
+  inspect(keys, content="[\"a\"]")
+}
+
+///|
+test "rev_values on single element map" {
+  let map = @sorted_map.singleton("a", 1)
+  let values = map.rev_values().collect()
+  inspect(values, content="[1]")
+}
+
+///|
+test "rev_keys early termination" {
+  let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let result = map.rev_keys().take(2).collect()
+  inspect(result, content="[3, 2]")
+}
+
+///|
+test "rev_values early termination" {
+  let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let result = map.rev_values().take(2).collect()
+  inspect(result, content="[\"three\", \"two\"]")
+}
+
+///|
+test "rev_keys is reverse of keys" {
+  let map = @sorted_map.from_array([
+    (3, "three"),
+    (8, "eight"),
+    (1, "one"),
+    (2, "two"),
+    (0, "zero"),
+  ])
+  let forward = map.keys_as_iter().collect()
+  let reverse = map.rev_keys().collect()
+  assert_eq(reverse, forward.rev())
+}
+
+///|
+test "rev_values is reverse of values" {
+  let map = @sorted_map.from_array([
+    (3, "three"),
+    (8, "eight"),
+    (1, "one"),
+    (2, "two"),
+    (0, "zero"),
+  ])
+  let forward = map.values().collect()
+  let reverse = map.rev_values().collect()
+  assert_eq(reverse, forward.rev())
+}
+
+///|
+test "rev_keys with complex tree" {
+  let map = @sorted_map.from_array([
+    (15, "15"),
+    (10, "10"),
+    (20, "20"),
+    (5, "5"),
+    (12, "12"),
+    (18, "18"),
+    (25, "25"),
+  ])
+  let keys = map.rev_keys().collect()
+  inspect(keys, content="[25, 20, 18, 15, 12, 10, 5]")
+}
+
+///|
+test "rev_values with complex tree" {
+  let map = @sorted_map.from_array([
+    (15, "15"),
+    (10, "10"),
+    (20, "20"),
+    (5, "5"),
+    (12, "12"),
+    (18, "18"),
+    (25, "25"),
+  ])
+  let values = map.rev_values().collect()
+  inspect(
+    values,
+    content="[\"25\", \"20\", \"18\", \"15\", \"12\", \"10\", \"5\"]",
+  )
+}
+
+///|
 test "from_json free function" {
   let json : Json = { "a": 1, "b": 2 }
   let map : @sorted_map.SortedMap[String, Int] = @sorted_map.from_json(json)

--- a/immut/sorted_set/README.mbt.md
+++ b/immut/sorted_set/README.mbt.md
@@ -170,6 +170,18 @@ test {
 }
 ```
 
+You can also use `rev_iterator()` to iterate in descending order.
+
+```mbt check
+///|
+test {
+  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let arr = []
+  set.rev_iterator().each(v => arr.push(v))
+  assert_eq(arr, [5, 4, 3, 2, 1])
+}
+```
+
 ## All & Any
 
 `all` and `any` can detect whether all elements in the set match or if there are elements that match.

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -22,6 +22,38 @@ pub fn[A] SortedSet::iter(self : SortedSet[A]) -> Iter[A] {
 }
 
 ///|
+/// Iterate over the elements in the set in descending order.
+///
+/// # Example
+///
+/// ```mbt
+///   let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+///   let result = set.rev_iterator().collect()
+///   assert_eq(result, [5, 4, 3, 2, 1])
+/// ```
+pub fn[A] SortedSet::rev_iterator(self : SortedSet[A]) -> Iterator[A] {
+  let mut curr_node = self
+  let parents = []
+  Iterator::new(fn() {
+    loop curr_node {
+      Node(left~, right=Empty, value~, ..) => {
+        curr_node = left
+        Some(value)
+      }
+      Node(left~, right~, value~, ..) => {
+        parents.push((value, left))
+        continue right
+      }
+      Empty if parents.pop() is Some((value, left)) => {
+        curr_node = left
+        Some(value)
+      }
+      Empty => None
+    }
+  })
+}
+
+///|
 pub fn[A] SortedSet::iterator(self : SortedSet[A]) -> Iterator[A] {
   let mut curr_node = self
   let parents = []

--- a/immut/sorted_set/generic_test.mbt
+++ b/immut/sorted_set/generic_test.mbt
@@ -78,3 +78,86 @@ test "iterator" {
   let result = set.iterator().collect()
   inspect(result, content="[1, 2, 3]")
 }
+
+///|
+test "rev_iterator returns elements in descending order" {
+  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let result = set.rev_iterator().collect()
+  inspect(result, content="[5, 4, 3, 2, 1]")
+}
+
+///|
+test "rev_iterator on empty set" {
+  let set : @sorted_set.SortedSet[Int] = @sorted_set.new()
+  let result = set.rev_iterator().collect()
+  inspect(result, content="[]")
+}
+
+///|
+test "rev_iterator on single element set" {
+  let set = @sorted_set.singleton(42)
+  let result = set.rev_iterator().collect()
+  inspect(result, content="[42]")
+}
+
+///|
+test "rev_iterator early termination" {
+  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let result = set.rev_iterator().take(3).collect()
+  inspect(result, content="[5, 4, 3]")
+}
+
+///|
+test "rev_iterator on unbalanced insertion" {
+  let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
+  let result = set.rev_iterator().collect()
+  inspect(result, content="[9, 8, 7, 6, 5, 4, 3, 2, 1]")
+}
+
+///|
+test "rev_iterator is reverse of iter" {
+  let set = @sorted_set.from_array([3, 1, 4, 1, 5, 9, 2, 6])
+  let forward = set.iter().collect()
+  let reverse = set.rev_iterator().collect()
+  assert_eq(reverse, forward.rev())
+}
+
+///|
+test "rev_iterator with early termination on right subtree" {
+  // Create a binary search tree with both left and right subtrees
+  let set = @sorted_set.new()
+    .add(2) // root
+    .add(1) // left child
+    .add(3) // right child
+
+  // Create an iterator that stops after processing the first element (from right)
+  let mut count = 0
+  for _ in set.rev_iterator() {
+    count = count + 1
+    if count == 1 {
+      break
+    }
+  }
+
+  // Verify that we stopped after processing the first element
+  inspect(count, content="1")
+}
+
+///|
+test "rev_iterator with complex tree structure" {
+  let set = @sorted_set.from_array([
+    15, 10, 20, 5, 12, 18, 25, 3, 7, 11, 14, 17, 19, 23, 27,
+  ])
+  let result = set.rev_iterator().collect()
+  inspect(
+    result,
+    content="[27, 25, 23, 20, 19, 18, 17, 15, 14, 12, 11, 10, 7, 5, 3]",
+  )
+}
+
+///|
+test "rev_iterator terminates on left" {
+  let set = @sorted_set.from_array([1, 2, 3])
+  let result = set.rev_iterator().take(2).to_array()
+  inspect(result, content="[3, 2]")
+}

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -50,6 +50,7 @@ pub fn[A] SortedSet::min_option(Self[A]) -> A?
 pub fn[A] SortedSet::new() -> Self[A]
 pub fn[A : Compare] SortedSet::remove(Self[A], A) -> Self[A]
 pub fn[A] SortedSet::remove_min(Self[A]) -> Self[A]
+pub fn[A] SortedSet::rev_iterator(Self[A]) -> Iterator[A]
 #as_free_fn
 pub fn[A] SortedSet::singleton(A) -> Self[A]
 pub fn[A : Compare] SortedSet::split(Self[A], A) -> (Self[A], Bool, Self[A])


### PR DESCRIPTION
These methods follow the pattern used by the other rev_* methods in the standard library.