### PR TITLE
fix logic bug in `.range` of sorted set/map

### DIFF
--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -314,15 +314,15 @@ pub fn[K : Compare, V] SortedMap::range(
       Some({ left, key, value, right, height: _ }) => {
         let cmp_key_low = key.compare(low)
         let cmp_key_high = key.compare(high)
-        if cmp_key_high > 0 {
-          // `value > high`, the left subtree and the value itself
+        if cmp_key_low < 0 {
+          // `key > low`, the left subtree and the value itself
           // should not be visited
           continue right
-        } else if cmp_key_low < 0 {
-          // `value < low`, the right subtree and the value itself
+        } else if cmp_key_high > 0 {
+          // `key > right`, the right subtree and the value itself
           // should not be visited
           continue left
-          // `low <= value <= high`,
+          // `low <= key <= high`,
           // the value itself falls in the range,
           // and both the left and right sub tree need to be visited
         } else if left is None {

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -268,12 +268,24 @@ test "range" {
     (4, "d"),
     (5, "e"),
   ])
-  let result = map.range(2, 4)
-  let buf = StringBuilder::new()
-  for k, v in result {
-    buf.write_string("[\{k}\{v}]")
-  }
-  inspect(buf, content="[2b][3c][4d]")
+  inspect(
+    map.range(2, 4),
+    content=(
+      #|[(2, "b"), (3, "c"), (4, "d")]
+    ),
+  )
+  inspect(
+    map.range(1, 1),
+    content=(
+      #|[(1, "a")]
+    ),
+  )
+  inspect(
+    map.range(5, 5),
+    content=(
+      #|[(5, "e")]
+    ),
+  )
 }
 
 ///|

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -490,12 +490,12 @@ pub fn[V : Compare] SortedSet::range(
     Some({ value, left, right, height: _ }) => {
       let cmp_key_low = value.compare(low)
       let cmp_key_high = value.compare(high)
-      if cmp_key_high > 0 {
-        // `value > high`, the left subtree and the value itself
+      if cmp_key_low < 0 {
+        // `key < low`, the left subtree and the value itself
         // should not be visited
         continue right
-      } else if cmp_key_low < 0 {
-        // `value < low`, the right subtree and the value itself
+      } else if cmp_key_high > 0 {
+        // `key > high`, the right subtree and the value itself
         // should not be visited
         continue left
         // `low <= value <= high`,

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -328,8 +328,9 @@ test "from_iterator empty iter" {
 ///|
 test "range" {
   let set = @sorted_set.from_array([1, 2, 3, 4, 5])
-  let result = set.range(2, 4)
-  inspect(result, content="[2, 3, 4]")
+  inspect(set.range(2, 4), content="[2, 3, 4]")
+  inspect(set.range(1, 1), content="[1]")
+  inspect(set.range(5, 5), content="[5]")
 }
 
 ///|


### PR DESCRIPTION
The external iterator version of `@sorted_set.SortedSet::range` and `@sorted_map.SortedMap::range` has logical bug, as correctly pointed out by Copilot in #3050. But there two API has only very minimal test, so the bug is not spotted. This PR fixes the bug and add a little more tests to the two `range` methods.