### PR TITLE
Revert "refactor: move `ref` out of builtin"

### DIFF
--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -373,12 +373,12 @@ test "FixedArray::arbitrary" {
 
 ///|
 test "FixedArray::makei" {
-  let empty = FixedArray::makei(0, _i => @ref.Ref::{ val: 3 })
+  let empty = FixedArray::makei(0, _i => Ref::{ val: 3 })
   inspect(empty.length(), content="0")
-  let simple_arr = FixedArray::makei(1, _i => @ref.Ref::{ val: 2 })
+  let simple_arr = FixedArray::makei(1, _i => Ref::{ val: 2 })
   inspect(simple_arr.length(), content="1")
   inspect(simple_arr[0].val, content="2")
-  let arr = FixedArray::makei(2, _i => @ref.Ref::{ val: 1 })
+  let arr = FixedArray::makei(2, _i => Ref::{ val: 1 })
   inspect(arr.length(), content="2")
   @test.not_same_object(arr[0], arr[1])
   inspect(arr[0].val, content="1")

--- a/builtin/moon.pkg.json
+++ b/builtin/moon.pkg.json
@@ -19,7 +19,6 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/test",
     "moonbitlang/core/random",
-    "moonbitlang/core/ref",
     "moonbitlang/core/int16"
   ],
    "warn-list": "-test_unqualified_package",

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -707,7 +707,7 @@ test "Show for Result" {
 ///|
 test "Show for Ref" {
   inspect(
-    @ref.Ref::{ val: "abc" }.to_string(),
+    { val: "abc" }.to_string(),
     content=(
       #|{val: "abc"}
     ),

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 ///|
-struct StringBuilder {
-  mut val : String
-}
+struct StringBuilder(Ref[String])
 
 ///|
 /// Creates a new string builder with an optional initial capacity hint.

--- a/immut/array/moon.pkg.json
+++ b/immut/array/moon.pkg.json
@@ -4,9 +4,6 @@
     "moonbitlang/core/quickcheck",
     { "path": "moonbitlang/core/array", "alias": "_" }
   ],
-  "wbtest-import": [
-    "moonbitlang/core/ref"
-  ],
   "targets": {
     "panic_test.mbt": [
       "not",

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -136,7 +136,7 @@ fn random_array(n : Int) -> Array[Int] {
 }
 
 ///|
-struct Random(@ref.Ref[UInt64])
+struct Random(Ref[UInt64])
 
 ///|
 fn Random::int(self : Random, limit~ : Int) -> Int {

--- a/prelude/moon.pkg.json
+++ b/prelude/moon.pkg.json
@@ -3,8 +3,7 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/bigint",
     "moonbitlang/core/set",
-    "moonbitlang/core/json",
-    "moonbitlang/core/ref"
+    "moonbitlang/core/json"
   ],
   "warn-list": "-test_unqualified_package"
 }

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -5,7 +5,6 @@ import(
   "moonbitlang/core/bigint"
   "moonbitlang/core/builtin"
   "moonbitlang/core/json"
-  "moonbitlang/core/ref"
   "moonbitlang/core/set"
 )
 
@@ -87,8 +86,6 @@ pub using @builtin {type Json}
 pub using @builtin {type Map}
 
 pub using @builtin {type MutArrayView}
-
-pub using @ref {type Ref}
 
 pub using @set {type Set}
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -133,6 +133,3 @@ pub let null : Json = @builtin.null
 
 ///|
 pub using @json {trait FromJson}
-
-///|
-pub using @ref {type Ref}

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -12,9 +12,6 @@ pub fn[T] new(T) -> Ref[T]
 // Errors
 
 // Types and methods
-pub(all) struct Ref[T] {
-  mut val : T
-}
 pub fn[T, R] Ref::map(Self[T], (T) -> R raise?) -> Self[R] raise?
 pub fn[T] Ref::new(T) -> Self[T]
 pub fn[T, R] Ref::protect(Self[T], T, () -> R raise?) -> R raise?

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -13,11 +13,6 @@
 // limitations under the License.
 
 ///|
-pub(all) struct Ref[T] {
-  mut val : T
-}
-
-///|
 pub impl[X : Show] Show for Ref[X] with output(self, logger) {
   logger..write_string("{val: ")..write_object(self.val)..write_string("}")
 }

--- a/ref/ref_test.mbt
+++ b/ref/ref_test.mbt
@@ -82,7 +82,7 @@ test "update with identity function" {
 
 ///|
 test "Ref::new with string" {
-  let r = @ref.Ref::new("hello")
+  let r = Ref::new("hello")
   inspect(r, content="{val: \"hello\"}")
 }
 


### PR DESCRIPTION
Currently, the `Ref` type is defined in the compiler for faster compilation. So it cannot be directly moved to `moonbitlang/core/ref`. To perform this movement, we need to first deprecate `{ val: xxx }` (creation `Ref` via struct literal without type annotation), otherwise user code will receive a hard break.

This PR temporarily reverts #3070. We may restart #3070 later when things get ready.