### PR TITLE
deque: align head/tail for empty constructors

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -133,7 +133,8 @@ pub impl[A] Add for Deque[A] with add(self, other) {
   for i, x in other {
     buf[i + self.len] = x
   }
-  Deque::{ buf, len, head: 0, tail: len - 1 }
+  let tail = if len == 0 { 0 } else { len - 1 }
+  Deque::{ buf, len, head: 0, tail }
 }
 
 ///|
@@ -164,7 +165,8 @@ pub fn[A] Deque::from_array(arr : ArrayView[A]) -> Deque[A] {
   for i, x in arr {
     buf[i] = x
   }
-  Deque::{ buf, len, head: 0, tail: len - 1 }
+  let tail = if len == 0 { 0 } else { len - 1 }
+  Deque::{ buf, len, head: 0, tail }
 }
 
 ///|
@@ -194,7 +196,8 @@ pub fn[A] Deque::copy(self : Deque[A]) -> Deque[A] {
   for i, x in self {
     buf[i] = x
   }
-  Deque::{ buf, len, head: 0, tail: len - 1 }
+  let tail = if len == 0 { 0 } else { len - 1 }
+  Deque::{ buf, len, head: 0, tail }
 }
 
 ///|
@@ -1981,12 +1984,8 @@ pub fn[A] Deque::flatten(self : Deque[Deque[A]]) -> Deque[A] {
   for deque in self {
     len += deque.length()
   }
-  let target = Deque::{
-    buf: UninitializedArray::make(len),
-    len,
-    head: 0,
-    tail: len - 1,
-  }
+  let tail = if len == 0 { 0 } else { len - 1 }
+  let target = Deque::{ buf: UninitializedArray::make(len), len, head: 0, tail }
   let mut i = 0
   for deque in self {
     let (front, back) = deque.as_views()

--- a/deque/deque_wbtest.mbt
+++ b/deque/deque_wbtest.mbt
@@ -25,6 +25,24 @@ test "unsafe_pop_front after many push_front" {
 }
 
 ///|
+test "empty constructors keep head and tail aligned" {
+  let empty : Deque[Int] = from_array([])
+  assert_eq(empty.len, 0)
+  assert_eq(empty.head, empty.tail)
+  let copied = empty.copy()
+  assert_eq(copied.len, 0)
+  assert_eq(copied.head, copied.tail)
+  let added = empty + from_array([])
+  assert_eq(added.len, 0)
+  assert_eq(added.head, added.tail)
+  let empty_inner : Deque[Int] = from_array([])
+  let nested : Deque[Deque[Int]] = from_array([empty_inner, empty_inner])
+  let flattened = nested.flatten()
+  assert_eq(flattened.len, 0)
+  assert_eq(flattened.head, flattened.tail)
+}
+
+///|
 test "truncate zero" {
   let dq = from_array([1, 2, 3])
   dq.truncate(0)


### PR DESCRIPTION
Single-commit fix for review.

Commit: 242550ba