### PR TITLE
fix(queue): handle self-transfer as no-op

### DIFF
--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -313,6 +313,7 @@ pub fn[A] Queue::copy(self : Queue[A]) -> Queue[A] {
 /// Transfers all elements from one queue to another.
 ///
 /// Adds all of the elements of source to the end of destination, then clears source.
+/// If source and destination are the same queue, this is a no-op.
 ///
 /// # Example
 /// ```mbt check
@@ -323,6 +324,9 @@ pub fn[A] Queue::copy(self : Queue[A]) -> Queue[A] {
 /// }
 /// ```
 pub fn[A] Queue::transfer(self : Queue[A], dst : Queue[A]) -> Unit {
+  if physical_equal(self, dst) {
+    return // no-op for self-transfer
+  }
   if self.length > 0 {
     match dst.last {
       None => {

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -241,3 +241,20 @@ test "queue arbitrary" {
   )
   inspect(samples[15], content="@queue.from_array([])")
 }
+
+///|
+test "transfer_self" {
+  // Test self-transfer: q.transfer(q) should be a no-op
+  let q : @queue.Queue[Int] = @queue.from_array([1, 2, 3])
+  q.transfer(q)
+  // After self-transfer, queue should remain unchanged
+  inspect(q, content="@queue.from_array([1, 2, 3])")
+}
+
+///|
+test "transfer_self_empty" {
+  // Test self-transfer on empty queue
+  let q : @queue.Queue[Int] = @queue.new()
+  q.transfer(q)
+  inspect(q, content="@queue.from_array([])")
+}

--- a/queue/types.mbt
+++ b/queue/types.mbt
@@ -18,13 +18,22 @@ priv struct Cons[A] {
   mut next : Cons[A]?
 } derive(Eq)
 
-// Invariant:
-// - length == 0 <=> first is None && last is None
-
 ///|
+/// A FIFO queue backed by a singly linked list of `Cons` cells.
+///
+/// Layout:
+/// - `first` points to the head cell (front of the queue).
+/// - `last` points to the tail cell (back of the queue) and its `next` is None.
+/// - When empty, `first` and `last` are None and `length` is 0.
+///
+/// We keep both `first` and `last` so `pop` and `push` are O(1) without
+/// scanning the list.
 #alias(T, deprecated)
 struct Queue[A] {
+  /// Number of elements in the queue.
   mut length : Int
+  /// Head cell (front) for O(1) peek/pop.
   mut first : Cons[A]?
+  /// Tail cell (back) for O(1) push/append.
   mut last : Cons[A]?
 }


### PR DESCRIPTION
## Summary

- Fixed `Queue::transfer(q, q)` which previously caused the queue to become empty
- Added `physical_equal` check to make self-transfer a no-op (elements already in destination)
- Added test cases for self-transfer on both non-empty and empty queues
- Improved Queue struct documentation explaining the layout and O(1) guarantees

## Problem

When calling `q.transfer(q)` on a non-empty queue, the queue incorrectly became empty because:
1. `last.next = self.first` created a cycle in the linked list
2. `self.clear()` cleared both `self` and `dst` (same object)

Other languages (OCaml, Java, C++) treat this as undefined behavior, but for a safe language like MoonBit, a no-op is the cleanest semantic.

## Test plan

- [x] Added `transfer_self` test - verifies non-empty queue remains unchanged after self-transfer
- [x] Added `transfer_self_empty` test - verifies empty queue remains empty after self-transfer
- [x] All existing queue tests pass (`moon test queue` - 64/64 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)