### PR TITLE
fix(deque): handle overlapping self-blit in blit_to

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -249,13 +249,38 @@ pub fn[A] Deque::blit_to(
     dst.tail = dst.len - 1
   }
   let dst_len = dst.len
-  for i = 0; i < len; i = i + 1 {
-    let dst_idx = (dst.head + dst_offset + i) % dst.buf.length()
-    let src_idx = (self.head + src_offset + i) % self.buf.length()
-    dst.buf[dst_idx] = self.buf[src_idx]
-    if dst_offset + i >= dst_len {
-      dst.tail = (dst.tail + 1) % dst.buf.length()
-      dst.len += 1
+  // Check for overlapping self-blit requiring reverse copy:
+  // When src and dst are the same object, src_offset < dst_offset, and regions overlap,
+  // we must copy in reverse order to avoid overwriting source before reading.
+  let needs_reverse = physical_equal(self, dst) &&
+    src_offset < dst_offset &&
+    src_offset + len > dst_offset
+  if needs_reverse {
+    // First, extend the deque length if writing beyond current length
+    let new_len = if dst_offset + len > dst_len {
+      dst_offset + len
+    } else {
+      dst_len
+    }
+    if new_len > dst_len {
+      dst.tail = (dst.head + new_len - 1) % dst.buf.length()
+      dst.len = new_len
+    }
+    // Copy in reverse order
+    for i = len - 1; i >= 0; i = i - 1 {
+      let dst_idx = (dst.head + dst_offset + i) % dst.buf.length()
+      let src_idx = (self.head + src_offset + i) % self.buf.length()
+      dst.buf[dst_idx] = self.buf[src_idx]
+    }
+  } else {
+    for i = 0; i < len; i = i + 1 {
+      let dst_idx = (dst.head + dst_offset + i) % dst.buf.length()
+      let src_idx = (self.head + src_offset + i) % self.buf.length()
+      dst.buf[dst_idx] = self.buf[src_idx]
+      if dst_offset + i >= dst_len {
+        dst.tail = (dst.tail + 1) % dst.buf.length()
+        dst.len += 1
+      }
     }
   }
 }

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -1759,11 +1759,22 @@ test "blit_to_self" {
 test "blit_to_self_overlap" {
   // Case 1: src_offset < dst_offset with overlap
   // Copy [2,3,4] (indices 1,2,3) to positions 2,3,4
-  // Expected: [1, 2, 2, 3, 4] (not [1, 2, 2, 2, 2] which is the buggy result)
+  // Expected: [1, 2, 2, 3, 4]
   let d = @deque.from_array([1, 2, 3, 4, 5])
   d.blit_to(d, len=3, src_offset=1, dst_offset=2)
-  // BUG: Currently produces [1, 2, 2, 2, 2] instead of [1, 2, 2, 3, 4]
-  inspect(d.to_array(), content="[1, 2, 2, 2, 2]")
+  inspect(d.to_array(), content="[1, 2, 2, 3, 4]")
+
+  // Case 2: dst_offset < src_offset with overlap (forward copy is safe)
+  // Copy [3,4,5] (indices 2,3,4) to positions 0,1,2
+  // Expected: [3, 4, 5, 4, 5]
+  let d2 = @deque.from_array([1, 2, 3, 4, 5])
+  d2.blit_to(d2, len=3, src_offset=2, dst_offset=0)
+  inspect(d2.to_array(), content="[3, 4, 5, 4, 5]")
+
+  // Case 3: No overlap (src and dst regions don't intersect)
+  let d3 = @deque.from_array([1, 2, 3, 4, 5])
+  d3.blit_to(d3, len=2, src_offset=0, dst_offset=3)
+  inspect(d3.to_array(), content="[1, 2, 3, 1, 2]")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Fixed `Deque::blit_to` to correctly handle overlapping regions when blitting a deque to itself
- Added comprehensive test cases for self-blit scenarios

## Problem

When calling `d.blit_to(d, ...)` with overlapping regions where `src_offset < dst_offset`, the source elements were being overwritten before being read:

```
d = [1, 2, 3, 4, 5]
d.blit_to(d, len=3, src_offset=1, dst_offset=2)

Before fix: [1, 2, 2, 2, 2]  # Wrong - source overwritten during forward copy
After fix:  [1, 2, 2, 3, 4]  # Correct - copied in reverse order
```

## Solution

Added detection for overlapping self-blit using `physical_equal(self, dst)` and copy in reverse order when `src_offset < dst_offset` and regions overlap. This is similar to how `memmove` handles overlapping memory regions in C.

## Test plan

- [x] Added `blit_to_self_overlap` test with 3 cases:
  - Case 1: `src_offset < dst_offset` with overlap (requires reverse copy)
  - Case 2: `dst_offset < src_offset` with overlap (forward copy is safe)
  - Case 3: No overlap (regions don't intersect)
- [x] All 226 deque tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)