### PR TITLE
Add coverage for array sort duplicates and iterator sub

### DIFF
--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -186,6 +186,38 @@ test "array_sort_by_all_equal" {
 }
 
 ///|
+test "array_sort_pred_skip_duplicates" {
+  let arr = Array::make(32, 5)
+  arr[0] = 1
+  arr[1] = 2
+  arr[2] = 3
+  arr[3] = 4
+  arr[8] = 9
+  arr[16] = 5
+  arr[24] = 1
+  arr.sort()
+  assert_true(arr.is_sorted())
+  assert_eq(arr[0], 1)
+  assert_eq(arr[31], 9)
+}
+
+///|
+test "array_sort_by_pred_skip_duplicates" {
+  let arr = Array::make(32, 5)
+  arr[0] = 4
+  arr[1] = 3
+  arr[2] = 2
+  arr[3] = 1
+  arr[8] = 9
+  arr[16] = 5
+  arr[24] = 1
+  arr.sort_by((a, b) => a.compare(b))
+  assert_true(arr.is_sorted())
+  assert_eq(arr[0], 1)
+  assert_eq(arr[31], 9)
+}
+
+///|
 test "array_each" {
   let arr = [1, 2, 3]
   let mut sum = 0

--- a/builtin/iterator_test.mbt
+++ b/builtin/iterator_test.mbt
@@ -669,6 +669,7 @@ test "Iterator::sub variants" {
     [1, 2, 3, 4].iterator().sub(start=1, end=3).collect(),
     content="[2, 3]",
   )
+  inspect([1, 2, 3].iterator().sub(start=2, end=2).collect(), content="[]")
   inspect([1, 2, 3].iterator().sub(start=1, end=0).collect(), content="[]")
 }
 


### PR DESCRIPTION
## Summary
- exercise quick sort duplicate-skip path via public Array::sort and Array::sort_by
- add iterator sub(start=end) coverage case
- reduce uncovered lines (185→177)

## Testing
- moon fmt
- moon check
- moon test
- moon clean
- moon test --enable-coverage
- moon coverage analyze