### PR TITLE
test: expand black-box coverage probes

### DIFF
--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -18,3 +18,10 @@ test "zip_with" {
   let right = [10, 20]
   inspect(@array.zip_with(left, right, (a, b) => a + b), content="[11, 22]")
 }
+
+///|
+test "zip_with left shorter" {
+  let left = [1, 2]
+  let right = [10, 20, 30]
+  inspect(@array.zip_with(left, right, (a, b) => a + b), content="[11, 22]")
+}

--- a/bench/bench_test.mbt
+++ b/bench/bench_test.mbt
@@ -34,3 +34,30 @@ test "bench buffer writes with multiple samples" {
   bench.bench(() => ignore(2 + 2), name="second", count=1)
   inspect(bench.dump_summaries().contains(","), content="true")
 }
+
+///|
+fn busy_wait_us(target_us : Double) -> Unit {
+  let start = @bench.monotonic_clock_start()
+  let mut elapsed = 0.0
+  while elapsed < target_us {
+    elapsed = @bench.monotonic_clock_end(start)
+  }
+}
+
+///|
+test "bench slow samples clamp batch size and winsorize" {
+  let mut calls = 0
+  let summary = @bench.single_bench(
+    () => {
+      let is_slow = calls % 2 == 0
+      calls = calls + 1
+      if is_slow {
+        busy_wait_us(120000.0)
+      }
+    },
+    count=4,
+  )
+  let json = ToJson::to_json(summary).stringify()
+  inspect(json.contains("\"batch_size\""), content="true")
+  inspect(json.contains("\"runs\""), content="true")
+}

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -42,6 +42,12 @@ test "bit_length zero" {
 }
 
 ///|
+test "bit_length default" {
+  let zero = @bigint.BigInt::default()
+  inspect(zero.bit_length(), content="0")
+}
+
+///|
 test "add" {
   let a = @bigint.BigInt::from_int64(123456789012345678L)
   let b = @bigint.BigInt::from_int64(987654321098765432L)

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -218,6 +218,33 @@ test "array_sort_by_pred_skip_duplicates" {
 }
 
 ///|
+struct HeapSortProbe {
+  value : Int
+}
+
+///|
+impl Eq for HeapSortProbe with equal(_self, _other) -> Bool {
+  false
+}
+
+///|
+impl Compare for HeapSortProbe with compare(_self, _other) -> Int {
+  1
+}
+
+///|
+test "array_sort heap fallback" {
+  // Force unbalanced partitions to exercise the heap sort fallback.
+  let arr : FixedArray[HeapSortProbe] = FixedArray::make(64, { value: 0 })
+  for i in 0..<arr.length() {
+    arr[i] = { value: i }
+  }
+  arr.sort()
+  assert_eq(arr.length(), 64)
+  ignore(arr[0].value)
+}
+
+///|
 test "array_each" {
   let arr = [1, 2, 3]
   let mut sum = 0

--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -83,6 +83,15 @@ test "FixedArray::iter2 with empty array" {
 }
 
 ///|
+#cfg(target="js")
+test "FixedArray::copy on js" {
+  let arr : FixedArray[Int] = [1, 2, 3]
+  let copied = arr.copy()
+  inspect(copied, content="[1, 2, 3]")
+  inspect(physical_equal(arr, copied), content="false")
+}
+
+///|
 test "FixedArray::iter2 with single element" {
   let arr = FixedArray::make(1, 42)
   let pairs : Array[(Int, Int)] = []

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -119,6 +119,14 @@ test "combine float" {
 }
 
 ///|
+#cfg(target="js")
+test "hasher default seed on js" {
+  let hasher = Hasher::new()
+  hasher.combine_int(1)
+  inspect(hasher.finalize().to_string().length() > 0, content="true")
+}
+
+///|
 test "combine string" {
   let hash = v => {
     let hasher = Hasher::new(seed=0)

--- a/builtin/to_string_test.mbt
+++ b/builtin/to_string_test.mbt
@@ -121,6 +121,15 @@ test "to_string runtime zero paths" {
 }
 
 ///|
+#cfg(target="js")
+test "to_string js wrappers" {
+  inspect((255).to_string(radix=16), content="ff")
+  inspect(255U.to_string(radix=16), content="ff")
+  inspect(255L.to_string(radix=16), content="ff")
+  inspect(255UL.to_string(radix=16), content="ff")
+}
+
+///|
 test "panic UInt64::to_string invalid radix" {
   let arr = Array::new()
   arr.push(1)

--- a/coverage/coverage_gaps.md
+++ b/coverage/coverage_gaps.md
@@ -1,0 +1,85 @@
+# Coverage gaps (black-box only)
+
+This note documents remaining uncovered lines after the black-box test pass and
+why they are currently out of reach.
+
+Last coverage run (wasm-gc):
+- `moon coverage analyze -- -f summary`
+
+## JS coverage blocked (compiler ICE)
+Attempting JS coverage currently crashes the compiler:
+- Command: `moon test --target js --enable-coverage`
+- moonc: v0.6.37+0b3e4ae80
+- Error: assertion failure in `moonc.ml` during link-core
+
+This blocks coverage of JS-only code paths listed below.
+
+## Target-specific or host-dependent
+- JS-only functions or externs (blocked by JS ICE):
+  - `builtin/fixedarray.mbt:1633` `FixedArray::copy` (#cfg target=js)
+  - `builtin/hasher.mbt:85` `seed` via `random_seed()` (#cfg target=js)
+  - `float/methods.mbt:886,927` JS conversions (#cfg target=js)
+  - `int16/int16.mbt:213,219` JS conversions (#cfg target=js)
+  - `builtin/to_string.mbt:339,353,699,717` JS wrappers (#cfg target=js)
+- WASM host dependent:
+  - `env/env_wasm.mbt:102` `current_dir_internal` returns `None` only if the
+    host returns an empty string; not controllable from tests.
+
+## Invariant / defensive branches (unreachable by design)
+- `bigint/bigint_nonjs.mbt:1816` `len == 0` guard; BigInt invariants keep
+  `len > 0` for public values.
+- `encoding/utf16/decode.mbt:53,78,133,161` `ch > 0x10FFFF` is impossible for
+  valid surrogate pairs; the guard is defensive.
+- `builtin/to_string.mbt:204,216,436,448` `hex_count*`/`radix_count*` zero paths
+  are bypassed by early return in `to_string` when value is zero.
+- `string/regex/internal/regexp/internal/unicode/case_folding.mbt:27` odd-length
+  DATA guard should be unreachable (data is even-length).
+- `json/parse.mbt:61,86,89,114` `abort("unreachable")` arms in parser token
+  state machine.
+- `string/regex/internal/regexp/internal/vm/impl.mbt:201` panic for unexpected
+  instruction; unreachable under valid compilation.
+
+## Private helpers (not callable from black-box tests)
+- `hashmap/utils.mbt:17-25` `_debug_entries` is private.
+- `hashset/hashset.mbt:462-493` `_debug_entries` and `MyString` helpers are
+  private to the package.
+- `immut/array/tree.mbt` internal `abort` branches and helper paths.
+- `immut/array/tree_utils.mbt` internal helpers.
+- `immut/hashmap/HAMT.mbt` internal mutation paths.
+- `immut/hashset/HAMT.mbt` internal mutation paths.
+- `immut/priority_queue/priority_queue.mbt` internal rebalance paths.
+- `immut/sorted_set/immutable_set.mbt` internal balancing paths.
+
+## Algorithmic edge cases not hit by current black-box inputs
+These are reachable in principle, but require very specific input patterns that
+are hard to trigger without white-box hooks or dedicated generators:
+- `builtin/array_sort_impl.mbt:253` heap sort fallback when quicksort limit
+  reaches zero.
+- `builtin/linked_hash_map.mbt:1004,1011,1021,1024` view comparison branches
+  not hit by current `Map::get_from_string/get_from_bytes` cases.
+- `builtin/string_methods.mbt:1215,1265` defensive break on final segment in
+  `replace_all` loops.
+- `double/internal/ryu/ryu.mbt:229,255,435` carry/rounding branches.
+- `double/scalbn.mbt:17,20,23,26,29,32,35,38,42,43` extreme exponent scaling.
+- `math/log_double_nonjs.mbt:256,264,266` edge-case log branches.
+- `math/pow.mbt:229,231` subnormal base handling in float pow.
+- `math/pow_double_nonjs.mbt:330,332` subnormal base handling in double pow.
+- `math/prime.mbt:287,323` rare primality branches.
+- `math/trig_double_nonjs.mbt:433,461,512,582,635,640,663,664,665,666,689,714,
+  721,722,725,755,759,762,780,783,790,798,802,806,811,870,915,919,921,925`
+  specialized rounding and edge-case paths.
+- `quickcheck/splitmix/random.mbt:86-87` `next_positive_int` special cases for
+  `-2147483648` and `0` need specific RNG states.
+- `sorted_set/set.mbt:223,238,239,240,248` join/rotation variants.
+- `strconv/decimal.mbt:282,359,360,483,484,497,498,506` rounding/truncation
+  paths that require crafted decimal inputs.
+- `list/list.mbt:242,279,376,555,722,735,777,878,929,967,980,1194,1258,1319,
+  1370,1543,1578,1801` specialized list edge cases.
+- `string/regex/internal/regexp/internal/parse/parse.mbt:495,583,624,625`
+  parser error branches for specific invalid regex patterns.
+
+## Follow-ups
+- Once JS coverage works again, re-run `moon test --target js --enable-coverage`
+  to cover JS-only branches.
+- For the algorithmic edge cases, consider targeted property tests or
+  generated inputs if white-box tests are allowed in the future.

--- a/coverage/coverage_gaps.md
+++ b/coverage/coverage_gaps.md
@@ -54,17 +54,20 @@ This blocks coverage of JS-only code paths listed below.
 These are reachable in principle, but require very specific input patterns that
 are hard to trigger without white-box hooks or dedicated generators:
 - `builtin/array_sort_impl.mbt:253` heap sort fallback when quicksort limit
-  reaches zero.
+  reaches zero. Attempted a degenerate `Compare` ordering in
+  `builtin/array_test.mbt`, but the fallback is still not observed.
 - `builtin/linked_hash_map.mbt:1004,1011,1021,1024` view comparison branches
   not hit by current `Map::get_from_string/get_from_bytes` cases.
 - `builtin/string_methods.mbt:1215,1265` defensive break on final segment in
   `replace_all` loops.
 - `double/internal/ryu/ryu.mbt:229,255,435` carry/rounding branches.
 - `double/scalbn.mbt:17,20,23,26,29,32,35,38,42,43` extreme exponent scaling.
-- `math/log_double_nonjs.mbt:256,264,266` edge-case log branches.
+- `math/log_double_nonjs.mbt:256,264,266` `ln_1p` edge-case branches; crafted
+  inputs still miss the `hu == 0` fast-paths due to early-return guards.
 - `math/pow.mbt:229,231` subnormal base handling in float pow.
 - `math/pow_double_nonjs.mbt:330,332` subnormal base handling in double pow.
-- `math/prime.mbt:287,323` rare primality branches.
+- `math/prime.mbt:287,323` rare primality branches. Tried a deterministic
+  `Rand` with `128017` and base `54`; still no hit on the `z == 1` branch.
 - `math/trig_double_nonjs.mbt:433,461,512,582,635,640,663,664,665,666,689,714,
   721,722,725,755,759,762,780,783,790,798,802,806,811,870,915,919,921,925`
   specialized rounding and edge-case paths.
@@ -76,7 +79,8 @@ are hard to trigger without white-box hooks or dedicated generators:
 - `list/list.mbt:242,279,376,555,722,735,777,878,929,967,980,1194,1258,1319,
   1370,1543,1578,1801` specialized list edge cases.
 - `string/regex/internal/regexp/internal/parse/parse.mbt:495,583,624,625`
-  parser error branches for specific invalid regex patterns.
+  parser error branches for specific invalid regex patterns. Added char-class
+  escape coverage tests; `\f`/range-end escapes still report uncovered here.
 
 ## Follow-ups
 - Once JS coverage works again, re-run `moon test --target js --enable-coverage`

--- a/coverage/coverage_gaps.md
+++ b/coverage/coverage_gaps.md
@@ -64,8 +64,11 @@ are hard to trigger without white-box hooks or dedicated generators:
 - `double/scalbn.mbt:17,20,23,26,29,32,35,38,42,43` extreme exponent scaling.
 - `math/log_double_nonjs.mbt:256,264,266` `ln_1p` edge-case branches; crafted
   inputs still miss the `hu == 0` fast-paths due to early-return guards.
-- `math/pow.mbt:229,231` subnormal base handling in float pow.
+- `math/pow.mbt:229,231` subnormal base handling in float pow. Tried
+  `Float::reinterpret_from_int(1)` with exponent `3.0`, but wasm-gc still
+  bypasses the subnormal branch (likely subnormal flush-to-zero).
 - `math/pow_double_nonjs.mbt:330,332` subnormal base handling in double pow.
+  Tried `1UL.reinterpret_as_double()` with exponent `3.0`, still no hit.
 - `math/prime.mbt:287,323` rare primality branches. Tried a deterministic
   `Rand` with `128017` and base `54`; still no hit on the `z == 1` branch.
 - `math/trig_double_nonjs.mbt:433,461,512,582,635,640,663,664,665,666,689,714,
@@ -79,8 +82,9 @@ are hard to trigger without white-box hooks or dedicated generators:
 - `list/list.mbt:242,279,376,555,722,735,777,878,929,967,980,1194,1258,1319,
   1370,1543,1578,1801` specialized list edge cases.
 - `string/regex/internal/regexp/internal/parse/parse.mbt:495,583,624,625`
-  parser error branches for specific invalid regex patterns. Added char-class
-  escape coverage tests; `\f`/range-end escapes still report uncovered here.
+  parser error branches for specific invalid regex patterns. Built runtime
+  patterns with `\f`/`\v` and escaped range endpoints, but these lines still
+  report uncovered.
 
 ## Follow-ups
 - Once JS coverage works again, re-run `moon test --target js --enable-coverage`

--- a/double/double_test.mbt
+++ b/double/double_test.mbt
@@ -176,3 +176,14 @@ test "Double::is_neg_inf" {
 test "min equal to neg max" {
   assert_true(min_value == -max_value)
 }
+
+///|
+
+///|
+#warnings("-deprecated")
+test "pow extreme exponents" {
+  let big = 2.0.pow(4000.0)
+  inspect(big.is_pos_inf(), content="true")
+  let small = 2.0.pow(-4000.0)
+  inspect(small == 0.0, content="true")
+}

--- a/float/float_test.mbt
+++ b/float/float_test.mbt
@@ -80,6 +80,13 @@ test "Hash" {
 }
 
 ///|
+#cfg(target="js")
+test "Float::from_int64 and from_uint64 on js" {
+  inspect(Float::from_uint64(42UL), content="42")
+  inspect(Float::from_int64(-42L), content="-42")
+}
+
+///|
 test "Float::is_inf/special_values" {
   inspect(@float.infinity.is_inf(), content="true")
   inspect(@float.neg_infinity.is_inf(), content="true")

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -504,3 +504,12 @@ test "Int16 int64 conversions" {
   let back = Int16::from_int64(as64)
   inspect(back.to_int(), content="123")
 }
+
+///|
+#cfg(target="js")
+test "Int16 int64 conversions on js" {
+  inspect(Int16::from_int64(42), content="42")
+  inspect(Int16::from_int64(-42), content="-42")
+  inspect(Int16::to_int64(123), content="123")
+  inspect(Int16::to_int64(-123), content="-123")
+}

--- a/math/log_test.mbt
+++ b/math/log_test.mbt
@@ -98,6 +98,17 @@ test "ln" {
 }
 
 ///|
+test "ln mantissa edge cases" {
+  assert_eq(@math.ln(1.0), 0.0)
+  let near_one = 0x3ff0000000000001UL.reinterpret_as_double()
+  let res_one = @math.ln(near_one)
+  assert_true((res_one - 2.220446049250313e-16).abs() < 1.0e-20)
+  let near_two = 0x4000000000000001UL.reinterpret_as_double()
+  let res_two = @math.ln(near_two)
+  assert_true((res_two - 0.6931471805599453).abs() < 1.0e-12)
+}
+
+///|
 test "lnf subnormal input" {
   let sub = Float::reinterpret_from_uint(1U)
   let res = @math.lnf(sub)
@@ -121,6 +132,17 @@ test "ln_1p small and large values" {
   let large_res = @math.ln_1p(large)
   assert_true(!large_res.is_nan())
   assert_true(large_res > 0.0)
+}
+
+///|
+test "ln_1p mantissa edge cases" {
+  let step = 2.98023223876953125e-8
+  let res_step = @math.ln_1p(step)
+  assert_true((res_step - step).abs() < 1.0e-12)
+  let near_two = 1.0 + step
+  let res_near_two = @math.ln_1p(near_two)
+  assert_true((res_near_two - 0.6931471805599453).abs() < 1.0e-7)
+  assert_true((@math.ln_1p(1.0) - 0.6931471805599453).abs() < 1.0e-15)
 }
 
 ///|

--- a/math/pow_test.mbt
+++ b/math/pow_test.mbt
@@ -1224,13 +1224,13 @@ test "scalbnf exponent clamp" {
 ///|
 test "powf subnormal base" {
   let subnormal = Float::reinterpret_from_int(1)
-  let result = @math.powf(subnormal, 2.0)
-  assert_true(result >= 0.0)
+  let result = @math.powf(subnormal, 3.0)
+  assert_true(result == 0.0)
 }
 
 ///|
 test "pow subnormal double base" {
   let subnormal = 1UL.reinterpret_as_double()
-  let result = @math.pow(subnormal, 2.0)
-  assert_true(result >= 0.0)
+  let result = @math.pow(subnormal, 3.0)
+  assert_true(result == 0.0)
 }

--- a/math/pow_test.mbt
+++ b/math/pow_test.mbt
@@ -1220,3 +1220,17 @@ test "scalbnf exponent clamp" {
   assert_true(@math.scalbnf(1.0, 500).is_pos_inf())
   inspect(@math.scalbnf(1.0, -500), content="0")
 }
+
+///|
+test "powf subnormal base" {
+  let subnormal = Float::reinterpret_from_int(1)
+  let result = @math.powf(subnormal, 2.0)
+  assert_true(result >= 0.0)
+}
+
+///|
+test "pow subnormal double base" {
+  let subnormal = 1UL.reinterpret_as_double()
+  let result = @math.pow(subnormal, 2.0)
+  assert_true(result >= 0.0)
+}

--- a/math/prime_test.mbt
+++ b/math/prime_test.mbt
@@ -82,6 +82,33 @@ test "@math.is_probable_prime" {
 }
 
 ///|
+struct SeqSource {
+  values : Array[UInt64]
+  mut idx : Int
+}
+
+///|
+impl @random.Source for SeqSource with next(self) -> UInt64 {
+  let idx = self.idx
+  self.idx += 1
+  if idx < self.values.length() {
+    self.values[idx]
+  } else {
+    0UL
+  }
+}
+
+///|
+test "miller rabin detects z == 1 branch" {
+  let gen_check : SeqSource = { values: [0UL, 0UL, 52UL], idx: 0 }
+  let rand_check = @random.Rand::new(generator=gen_check as &@random.Source)
+  inspect(rand_check.bigint(17), content="52")
+  let gen : SeqSource = { values: [0UL, 0UL, 52UL], idx: 0 }
+  let rand = @random.Rand::new(generator=gen as &@random.Source)
+  assert_false(@math.is_probable_prime(128017N, rand, iters=1))
+}
+
+///|
 test "@math.probable_prime" {
   let rand = @random.Rand::new()
   inspect(

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -81,3 +81,15 @@ test "get_char invalid surrogate pair" {
   let v = s[:]
   inspect(v.get_char(0), content="None")
 }
+
+///|
+test "replace_all on view with matches" {
+  let view = "foo bar foo".view()
+  inspect(view.replace_all(old="foo", new="baz"), content="baz bar baz")
+}
+
+///|
+test "replace_all on string with matches" {
+  let s = "foo foo"
+  inspect(s.replace_all(old="foo", new="x"), content="x x")
+}

--- a/string/regex/regex_test.mbt
+++ b/string/regex/regex_test.mbt
@@ -24,3 +24,24 @@ test "escape form feed" {
   let regex = @regex.compile("\\f")
   inspect(regex.execute("\u{c}") is Some(_), content="true")
 }
+
+///|
+test "char class escape form feed and vertical tab" {
+  let regex = @regex.compile("[\\f\\v]")
+  assert_true(regex.execute("\u{c}") is Some(_))
+  assert_true(regex.execute("\u{b}") is Some(_))
+}
+
+///|
+test "char class range escape endpoints" {
+  let range_v = @regex.compile("[\\t-\\v]")
+  assert_true(range_v.execute("\u{b}") is Some(_))
+  let range_f = @regex.compile("[\\v-\\f]")
+  assert_true(range_f.execute("\u{c}") is Some(_))
+}
+
+///|
+test "compile trailing backslash" {
+  let result = try? @regex.compile("\\")
+  assert_true(result is Err(_))
+}

--- a/string/regex/regex_test.mbt
+++ b/string/regex/regex_test.mbt
@@ -21,27 +21,56 @@ test "named group missing" {
 
 ///|
 test "escape form feed" {
-  let regex = @regex.compile("\\f")
+  let chars = Array::make(2, 'x')
+  chars[0] = '\\'
+  chars[1] = 'f'
+  let regex = @regex.compile(String::from_array(chars))
   inspect(regex.execute("\u{c}") is Some(_), content="true")
 }
 
 ///|
 test "char class escape form feed and vertical tab" {
-  let regex = @regex.compile("[\\f\\v]")
+  let chars = Array::make(6, 'x')
+  chars[0] = '['
+  chars[1] = '\\'
+  chars[2] = 'f'
+  chars[3] = '\\'
+  chars[4] = 'v'
+  chars[5] = ']'
+  let pattern = String::from_array(chars)
+  let regex = @regex.compile(pattern)
   assert_true(regex.execute("\u{c}") is Some(_))
   assert_true(regex.execute("\u{b}") is Some(_))
 }
 
 ///|
 test "char class range escape endpoints" {
-  let range_v = @regex.compile("[\\t-\\v]")
+  let chars_v = Array::make(7, 'x')
+  chars_v[0] = '['
+  chars_v[1] = '\\'
+  chars_v[2] = 't'
+  chars_v[3] = '-'
+  chars_v[4] = '\\'
+  chars_v[5] = 'v'
+  chars_v[6] = ']'
+  let range_v = @regex.compile(String::from_array(chars_v))
   assert_true(range_v.execute("\u{b}") is Some(_))
-  let range_f = @regex.compile("[\\v-\\f]")
+  let chars_f = Array::make(7, 'x')
+  chars_f[0] = '['
+  chars_f[1] = '\\'
+  chars_f[2] = 'v'
+  chars_f[3] = '-'
+  chars_f[4] = '\\'
+  chars_f[5] = 'f'
+  chars_f[6] = ']'
+  let range_f = @regex.compile(String::from_array(chars_f))
   assert_true(range_f.execute("\u{c}") is Some(_))
 }
 
 ///|
 test "compile trailing backslash" {
-  let result = try? @regex.compile("\\")
+  let chars = Array::make(1, 'x')
+  chars[0] = '\\'
+  let result = try? @regex.compile(String::from_array(chars))
   assert_true(result is Err(_))
 }


### PR DESCRIPTION
## Summary
- add black-box coverage tests across core packages
- add JS-only tests for wrappers/conversions (blocked by JS coverage ICE)
- document remaining coverage gaps and target constraints in coverage/coverage_gaps.md

## Coverage
- wasm-gc: `moon coverage analyze -- -f summary`
- js: `moon test --target js --enable-coverage` (moonc v0.6.37+0b3e4ae80 ICE)

## Notes
- remaining uncovered lines are categorized in `coverage/coverage_gaps.md`
