### PR TITLE
feat: add chop_prefix/chop_suffix for String and StringView

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -752,7 +752,9 @@ pub fn[A] String::rev_fold(String, init~ : A, (A, Char) -> A raise?) -> A raise?
 pub fn String::rev_iter(String) -> Iter[Char]
 pub fn String::rev_iterator(String) -> Iterator[Char]
 pub fn String::split(String, StringView) -> Iter[StringView]
+#alias(chop_prefix)
 pub fn String::strip_prefix(String, StringView) -> StringView?
+#alias(chop_suffix)
 pub fn String::strip_suffix(String, StringView) -> StringView?
 #alias("_[_:_]")
 pub fn String::sub(String, start? : Int, end? : Int) -> StringView raise CreatingViewError
@@ -1018,7 +1020,9 @@ pub fn StringView::rev_iter(Self) -> Iter[Char]
 pub fn StringView::rev_iterator(Self) -> Iterator[Char]
 pub fn StringView::split(Self, Self) -> Iter[Self]
 pub fn StringView::start_offset(Self) -> Int
+#alias(chop_prefix)
 pub fn StringView::strip_prefix(Self, Self) -> Self?
+#alias(chop_suffix)
 pub fn StringView::strip_suffix(Self, Self) -> Self?
 #alias("_[_:_]")
 pub fn StringView::sub(Self, start? : Int, end? : Int) -> Self raise CreatingViewError

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -324,13 +324,13 @@ test "has_prefix" {
 
 ///|
 /// Removes the given suffix from the string if it exists.
-/// 
+///
 /// Returns `Some(prefix)` if the string ends with the given suffix,
 /// where `prefix` is the string without the suffix.
 /// Returns `None` if the string does not end with the suffix.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```mbt check
 /// test {
 ///   inspect("hello world".strip_suffix(" world"), content="Some(\"hello\")")
@@ -338,12 +338,9 @@ test "has_prefix" {
 ///   inspect("hello".strip_suffix("hello"), content="Some(\"\")")
 /// }
 /// ```
+#alias(chop_suffix)
 pub fn String::strip_suffix(self : String, suffix : StringView) -> StringView? {
-  if self.has_suffix(suffix) {
-    Some(self.view(end_offset=self.length() - suffix.length()))
-  } else {
-    None
-  }
+  self[:].strip_suffix(suffix)
 }
 
 ///|
@@ -372,13 +369,13 @@ test "strip_suffix" {
 
 ///|
 /// Removes the given prefix from the string if it exists.
-/// 
+///
 /// Returns `Some(suffix)` if the string starts with the given prefix,
 /// where `suffix` is the string without the prefix.
 /// Returns `None` if the string does not start with the prefix.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```mbt check
 /// test {
 ///   inspect("hello world".strip_prefix("hello "), content="Some(\"world\")")
@@ -386,23 +383,20 @@ test "strip_suffix" {
 ///   inspect("hello".strip_prefix("hello"), content="Some(\"\")")
 /// }
 /// ```
+#alias(chop_prefix)
 pub fn String::strip_prefix(self : String, prefix : StringView) -> StringView? {
-  if self.has_prefix(prefix) {
-    Some(self.view(start_offset=prefix.length()))
-  } else {
-    None
-  }
+  self[:].strip_prefix(prefix)
 }
 
 ///|
 /// Removes the given prefix from the view if it exists.
-/// 
+///
 /// Returns `Some(suffix)` if the view starts with the given prefix,
 /// where `suffix` is the view without the prefix.
 /// Returns `None` if the view does not start with the prefix.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```mbt check
 /// test {
 ///   let view = "hello world"[:]
@@ -411,13 +405,14 @@ pub fn String::strip_prefix(self : String, prefix : StringView) -> StringView? {
 ///   inspect(view.strip_prefix("hello world"), content="Some(\"\")")
 /// }
 /// ```
-/// 
+#alias(chop_prefix)
 pub fn StringView::strip_prefix(
   self : StringView,
   prefix : StringView,
 ) -> StringView? {
-  if self.has_prefix(prefix) {
-    Some(self.view(start_offset=prefix.length()))
+  let prefix_len = prefix.length()
+  if self.length() >= prefix_len && self.view(end_offset=prefix_len) == prefix {
+    Some(self.view(start_offset=prefix_len))
   } else {
     None
   }
@@ -425,13 +420,13 @@ pub fn StringView::strip_prefix(
 
 ///|
 /// Removes the given suffix from the view if it exists.
-/// 
+///
 /// Returns `Some(prefix)` if the view ends with the given suffix,
 /// where `prefix` is the view without the suffix.
 /// Returns `None` if the view does not end with the suffix.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```mbt check
 /// test {
 ///   let view = "hello world"[:]
@@ -440,12 +435,16 @@ pub fn StringView::strip_prefix(
 ///   inspect(view.strip_suffix("hello world"), content="Some(\"\")")
 /// }
 /// ```
+#alias(chop_suffix)
 pub fn StringView::strip_suffix(
   self : StringView,
   suffix : StringView,
 ) -> StringView? {
-  if self.has_suffix(suffix) {
-    Some(self.view(end_offset=self.length() - suffix.length()))
+  let self_len = self.length()
+  let suffix_len = suffix.length()
+  if self_len >= suffix_len &&
+    self.view(start_offset=self_len - suffix_len) == suffix {
+    Some(self.view(end_offset=self_len - suffix_len))
   } else {
     None
   }
@@ -453,9 +452,9 @@ pub fn StringView::strip_suffix(
 
 ///|
 /// Converts the View into an array of Chars.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```mbt check
 /// test {
 ///   let view = "Hello🤣xa"[1:-1]


### PR DESCRIPTION
## Summary

- Add `#alias(chop_prefix)` to existing `strip_prefix` methods for `String` and `StringView`
- Add `#alias(chop_suffix)` to existing `strip_suffix` methods for `String` and `StringView`
- Optimize `strip_prefix`/`strip_suffix` to directly compare at expected position instead of using `has_prefix`/`has_suffix` which internally use `find`/`rev_find` to search the entire string

## Optimization Details

Before (inefficient):
```moonbit
pub fn StringView::strip_prefix(self, prefix) -> StringView? {
  if self.has_prefix(prefix) {  // has_prefix uses find() which searches entire string
    Some(self.view(start_offset=prefix.length()))
  } else {
    None
  }
}
```

After (efficient):
```moonbit
pub fn StringView::strip_prefix(self, prefix) -> StringView? {
  let prefix_len = prefix.length()
  if self.length() >= prefix_len && self.view(end_offset=prefix_len) == prefix {
    Some(self.view(start_offset=prefix_len))
  } else {
    None
  }
}
```

## Test plan
- [x] All existing tests pass
- [x] `moon check` passes
- [x] `moon test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)