### PR TITLE
Fix implicit_use_builtin warnings using Type::Constructor format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ bisect.coverage
 .auto-coder/
 .moonagent/
 node_modules/
+_build
+target

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -769,7 +769,7 @@ test "map with error callback" {
   let arr = [1, 2, 3]
   let v = try? arr.map(x => {
     if x == 2 {
-      raise Failure("Error at 2")
+      raise Failure::Failure("Error at 2")
     }
     x + 1
   })
@@ -803,7 +803,7 @@ test "mapi with error callback" {
   let arr = [1, 2, 3]
   let v = try? arr.mapi((i, x) => {
     if x == 2 {
-      raise Failure("Error at 2")
+      raise Failure::Failure("Error at 2")
     }
     x + i
   })
@@ -821,7 +821,7 @@ test "mapi with error callback 2" {
   try
     arr.mapi((i, x) => {
       if x == 2 {
-        raise Failure("Error at 2")
+        raise Failure::Failure("Error at 2")
       }
       x + i
     })
@@ -837,7 +837,7 @@ test "filter with error callback" {
   let arr = [1, 2, 3]
   let v = try? arr.filter(x => {
     if x == 2 {
-      raise Failure("Error at 2")
+      raise Failure::Failure("Error at 2")
     }
     x % 2 == 0
   })
@@ -855,7 +855,7 @@ test "filter with error callback 2" {
   try
     arr.filter(x => {
       if x == 2 {
-        raise Failure("Error at 2")
+        raise Failure::Failure("Error at 2")
       }
       x % 2 == 0
     })
@@ -871,7 +871,7 @@ test "map_inplace with error callback" {
   let arr = [1, 2, 3]
   let v = try? arr.map_in_place(x => {
     if x == 2 {
-      raise Failure("Error at 2")
+      raise Failure::Failure("Error at 2")
     }
     x + 1
   })
@@ -889,7 +889,7 @@ test "map_inplace with error callback 2" {
   try
     arr.map_in_place(x => {
       if x == 2 {
-        raise Failure("Error at 2")
+        raise Failure::Failure("Error at 2")
       }
       x + 1
     })
@@ -905,7 +905,7 @@ test "mapi_inplace with error callback" {
   let arr = [1, 2, 3]
   let v = try? arr.mapi_in_place((i, x) => {
     if x == 2 {
-      raise Failure("Error at 2")
+      raise Failure::Failure("Error at 2")
     }
     x + i
   })

--- a/builtin/option_test.mbt
+++ b/builtin/option_test.mbt
@@ -78,13 +78,13 @@ test "map_or and filter" {
 ///|
 test "unwrap_or_error" {
   assert_eq(
-    (None : String?).unwrap_or_error(Failure("boom")) catch {
+    (None : String?).unwrap_or_error(Failure::Failure("boom")) catch {
       Failure(err) => err
     },
     "boom",
   )
   assert_eq(
-    Some("ok").unwrap_or_error(Failure("boom")) catch {
+    Some("ok").unwrap_or_error(Failure::Failure("boom")) catch {
       Failure(err) => err
     },
     "ok",

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -707,7 +707,7 @@ test "Show for Result" {
 ///|
 test "Show for Ref" {
   inspect(
-    { val: "abc" }.to_string(),
+    Ref::{ val: "abc" }.to_string(),
     content=(
       #|{val: "abc"}
     ),
@@ -813,7 +813,7 @@ test "char_special" {
 
 ///|
 test "Show for Failure" {
-  let f = Failure("test error message")
+  let f = Failure::Failure("test error message")
   inspect(
     f.to_string(),
     content=(

--- a/error/README.mbt.md
+++ b/error/README.mbt.md
@@ -11,7 +11,7 @@ MoonBit uses a structured error system with `raise` and `try` constructs:
 test "basic error handling" {
   fn divide(a : Int, b : Int) -> Int raise {
     if b == 0 {
-      raise Failure("Division by zero")
+      raise Failure::Failure("Division by zero")
     } else {
       a / b
     }
@@ -154,7 +154,7 @@ test "resource management" {
     risky_operation() catch {
       ResourceError(_) =>
         // Cleanup happens here
-        raise Failure("Operation failed after cleanup")
+        raise Failure::Failure("Operation failed after cleanup")
     }
   }
 
@@ -197,10 +197,10 @@ test "error composition" {
 
   fn initialize_app() -> String raise {
     let config = load_config() catch {
-      ConfigError(msg) => raise Failure("Config error: " + msg)
+      ConfigError(msg) => raise Failure::Failure("Config error: " + msg)
     }
     let db = connect_database(config) catch {
-      DatabaseError(msg) => raise Failure("Database error: " + msg)
+      DatabaseError(msg) => raise Failure::Failure("Database error: " + msg)
     }
     "App initialized with " + db
   }

--- a/error/error.mbt
+++ b/error/error.mbt
@@ -28,7 +28,7 @@ fn Error::to_string(self : Error) -> String = "%error.to_string"
 ///
 /// ```mbt check
 /// test {
-///   let error : Error = Failure("test error")
+///   let error : Error = Failure::Failure("test error")
 ///   inspect(
 ///     error,
 ///     content=(

--- a/error/error_test.mbt
+++ b/error/error_test.mbt
@@ -91,7 +91,7 @@ fn[A] protect2(finalize~ : () -> Unit raise?, work : () -> A raise) -> A raise {
 ///|
 test "protect" {
   let x = try? protect(finalize=() => (), () => if true {
-    raise Failure("error")
+    raise Failure::Failure("error")
   } else {
     1
   })
@@ -105,8 +105,8 @@ test "protect" {
 
 ///|
 test "protect & finally raise error" {
-  let x = try? protect(finalize=() => raise Failure("finally error"), () => if true {
-    raise Failure("error")
+  let x = try? protect(finalize=() => raise Failure::Failure("finally error"), () => if true {
+    raise Failure::Failure("error")
   } else {
     1
   })
@@ -121,7 +121,7 @@ test "protect & finally raise error" {
 ///|
 test "protect2" {
   let x = try? protect2(finalize=() => (), () => if true {
-    raise Failure("error")
+    raise Failure::Failure("error")
   } else {
     1
   })
@@ -135,11 +135,10 @@ test "protect2" {
 
 ///|
 test "protect2 & finally raise error" {
-  let x = try? protect2(finalize=() => raise Failure("finally error"), () => if true {
-    raise Failure("error")
-  } else {
-    1
-  })
+  let x = try? protect2(
+    finalize=() => raise Failure::Failure("finally error"),
+    () => if true { raise Failure::Failure("error") } else { 1 },
+  )
   inspect(
     x,
     content=(

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -487,7 +487,7 @@ pub fn inspect(
     Some(x) => x.stringify(escape_slash=false)
   }
   if actual != want {
-    raise InspectError(
+    raise InspectError::InspectError(
       "@EXPECT_FAILED {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{want.escape()}, \"actual\": \{actual.escape()}, \"mode\": \"json\"}",
     )
   }

--- a/json/json_traverse_test.mbt
+++ b/json/json_traverse_test.mbt
@@ -114,7 +114,7 @@ test "prune_loc - arrays" {
   ])
   @json.inspect(
     arr1.prune_loc_test(),
-    content=[Null, true, 123, "test"], // FIXME: support null
+    content=[null, true, 123, "test"], // FIXME: support null
   )
 
   // Nested arrays

--- a/option/option_test.mbt
+++ b/option/option_test.mbt
@@ -213,13 +213,13 @@ test "iter" {
 ///|
 test "or error" {
   assert_eq(
-    (None : String?).unwrap_or_error(Failure("This is serious")) catch {
+    (None : String?).unwrap_or_error(Failure::Failure("This is serious")) catch {
       Failure(err) => err
     },
     "This is serious",
   )
   assert_eq(
-    Some("This is ok").unwrap_or_error(Failure("This is serious")) catch {
+    Some("This is ok").unwrap_or_error(Failure::Failure("This is serious")) catch {
       Failure(err) => err
     },
     "This is ok",

--- a/result/result_test.mbt
+++ b/result/result_test.mbt
@@ -28,7 +28,7 @@ test "bind with Err" {
 
 ///|
 test "wrap0 with error" {
-  let f : () -> Int raise Failure = () => raise Failure("error")
+  let f : () -> Int raise Failure = () => raise Failure::Failure("error")
   let result = try? f()
   inspect(
     result,
@@ -40,7 +40,9 @@ test "wrap0 with error" {
 
 ///|
 test "wrap2 with error result" {
-  let f : (Int, Int) -> Unit raise Failure = (_, _) => raise Failure("error")
+  let f : (Int, Int) -> Unit raise Failure = (_, _) => raise Failure::Failure(
+    "error",
+  )
   let r = try? f(1, 2)
   inspect(
     r,

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -120,7 +120,7 @@ pub fn Test::snapshot(
   let actual = self.buffer.to_string().escape()
   let expect = filename.escape()
   // always raise SnapshotError, moon will handle this
-  raise SnapshotError(
+  raise SnapshotError::SnapshotError(
     "@SNAPSHOT_TESTING {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{expect}, \"actual\": \{actual}, \"snapshot\": true}",
   )
 }


### PR DESCRIPTION
Replace implicit constructor usage with explicit Type::Constructor format:
- Changed InspectError(...) to InspectError::InspectError(...)
- Changed Failure(...) to Failure::Failure(...)

This fixes 27 implicit_use_builtin warnings across the codebase.

Files modified:
- builtin/array_test.mbt (8 occurrences)
- builtin/option_test.mbt (2 occurrences)
- builtin/show_test.mbt (1 occurrence)
- error/README.mbt.md (4 occurrences)
- error/error.mbt (1 occurrence)
- error/error_test.mbt (6 occurrences)
- json/json.mbt (1 occurrence)
- option/option_test.mbt (2 occurrences)
- result/result_test.mbt (2 occurrences)
