### PR TITLE
refactor: deprecated unused bencherror

### DIFF
--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -224,21 +224,7 @@ pub(all) suberror SnapshotError {
 }
 
 ///|
-/// Error type for benchmark snapshot helpers.
-///
-/// This is used by benchmark-related testing utilities to signal validation
-/// failures.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let err : BenchError = BenchError("benchmark output mismatch")
-///   match err {
-///     BenchError(msg) => inspect(msg, content="benchmark output mismatch")
-///   }
-/// }
-/// ```
+#deprecated
 pub(all) suberror BenchError {
   BenchError(String)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -40,6 +40,7 @@ pub fn[T : Show] println(T) -> Unit
 pub fn[T : Show] repr(T) -> String
 
 // Errors
+#deprecated
 pub(all) suberror BenchError {
   BenchError(String)
 }


### PR DESCRIPTION
This type is not used actually
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
