### PR TITLE
refactor: migrate suberror declarations to new block syntax

### DIFF
--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -56,7 +56,9 @@ pub fn[T : Show] println(input : T) -> Unit {
 ///   inspect(x, content="42") // Raises InspectError with detailed failure message
 /// }
 /// ```
-pub(all) suberror InspectError String
+pub(all) suberror InspectError {
+  InspectError(String)
+}
 
 ///|
 fn base64_encode(data : FixedArray[Byte]) -> String {
@@ -220,10 +222,14 @@ pub fn inspect(
 ///   }
 /// }
 /// ```
-pub(all) suberror SnapshotError String
+pub(all) suberror SnapshotError {
+  SnapshotError(String)
+}
 
 ///|
-pub(all) suberror BenchError String
+pub(all) suberror BenchError {
+  BenchError(String)
+}
 
 ///|
 test "panic error case of inspect" {

--- a/builtin/existensial_test.mbt
+++ b/builtin/existensial_test.mbt
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 ///|
-suberror StringError String
+suberror StringError {
+  StringError(String)
+}
 
 ///|
-suberror IntError Int
+suberror IntError {
+  IntError(Int)
+}
 
 ///|
 test {

--- a/builtin/failure.mbt
+++ b/builtin/failure.mbt
@@ -34,7 +34,9 @@
 ///   @json.inspect(err, content=["Failure", "Test assertion failed"])
 /// }
 /// ```
-pub(all) suberror Failure String derive(ToJson, Show)
+pub(all) suberror Failure {
+  Failure(String)
+} derive(ToJson, Show)
 
 ///|
 /// Raises a `Failure` error with a given message and source location.

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -44,7 +44,9 @@ pub fn[T : Show] println(T) -> Unit
 pub fn[T : Show] repr(T) -> String
 
 // Errors
-pub(all) suberror BenchError String
+pub(all) suberror BenchError {
+  BenchError(String)
+}
 
 pub suberror CreatingViewError {
   IndexOutOfBounds
@@ -52,13 +54,19 @@ pub suberror CreatingViewError {
 }
 pub impl Show for CreatingViewError
 
-pub(all) suberror Failure String
+pub(all) suberror Failure {
+  Failure(String)
+}
 pub impl Show for Failure
 pub impl ToJson for Failure
 
-pub(all) suberror InspectError String
+pub(all) suberror InspectError {
+  InspectError(String)
+}
 
-pub(all) suberror SnapshotError String
+pub(all) suberror SnapshotError {
+  SnapshotError(String)
+}
 
 // Types and methods
 pub(all) struct ArgsLoc(Array[SourceLoc?])

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 ///|
-pub suberror Malformed BytesView
+pub suberror Malformed {
+  Malformed(BytesView)
+}
 
 ///|
 /// The Unicode Replacement Character, which is used to replace invalid or unrecognized sequences during lossy decoding.

--- a/encoding/utf16/pkg.generated.mbti
+++ b/encoding/utf16/pkg.generated.mbti
@@ -9,7 +9,9 @@ pub fn decode_lossy(BytesView, ignore_bom? : Bool, endianness? : Endian) -> Stri
 pub fn encode(StringView, bom? : Bool, endianness? : Endian) -> Bytes
 
 // Errors
-pub suberror Malformed BytesView
+pub suberror Malformed {
+  Malformed(BytesView)
+}
 
 // Types and methods
 pub(all) enum Endian {

--- a/encoding/utf8/decode.mbt
+++ b/encoding/utf8/decode.mbt
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 ///|
-pub suberror Malformed BytesView
+pub suberror Malformed {
+  Malformed(BytesView)
+}
 
 ///|
 pub fn decode(

--- a/encoding/utf8/pkg.generated.mbti
+++ b/encoding/utf8/pkg.generated.mbti
@@ -9,7 +9,9 @@ pub fn decode_lossy(BytesView, ignore_bom? : Bool) -> String
 pub fn encode(StringView, bom? : Bool) -> Bytes
 
 // Errors
-pub suberror Malformed BytesView
+pub suberror Malformed {
+  Malformed(BytesView)
+}
 
 // Types and methods
 

--- a/error/README.mbt.md
+++ b/error/README.mbt.md
@@ -33,10 +33,14 @@ Define custom error types using `suberror`:
 
 ```mbt check
 ///|
-suberror ValidationError String
+suberror ValidationError {
+  ValidationError(String)
+}
 
 ///|
-suberror NetworkError String
+suberror NetworkError {
+  NetworkError(String)
+}
 
 ///|
 test "custom errors" {
@@ -78,7 +82,9 @@ The error package provides `Show` and `ToJson` implementations:
 
 ```mbt check
 ///|
-suberror MyError Int derive(ToJson)
+suberror MyError {
+  MyError(Int)
+} derive(ToJson)
 
 ///|
 test "error display and json" {
@@ -100,10 +106,14 @@ Handle errors at different levels of your application:
 
 ```mbt check
 ///|
-suberror ParseError String
+suberror ParseError {
+  ParseError(String)
+}
 
 ///|
-suberror FileError String
+suberror FileError {
+  FileError(String)
+}
 
 ///|
 test "error propagation" {
@@ -140,7 +150,9 @@ Use `protect` functions for resource cleanup:
 
 ```mbt check
 ///|
-suberror ResourceError String
+suberror ResourceError {
+  ResourceError(String)
+}
 
 ///|
 test "resource management" {
@@ -172,10 +184,14 @@ Combine multiple error-producing operations:
 
 ```mbt check
 ///|
-suberror ConfigError String
+suberror ConfigError {
+  ConfigError(String)
+}
 
 ///|
-suberror DatabaseError String
+suberror DatabaseError {
+  DatabaseError(String)
+}
 
 ///|
 test "error composition" {

--- a/error/error_test.mbt
+++ b/error/error_test.mbt
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 ///|
-suberror IntError Int
+suberror IntError {
+  IntError(Int)
+}
 
 ///|
 test "show error" {
@@ -148,10 +150,14 @@ test "protect2 & finally raise error" {
 }
 
 ///|
-suberror ErrWithToJson Int derive(ToJson)
+suberror ErrWithToJson {
+  ErrWithToJson(Int)
+} derive(ToJson)
 
 ///|
-suberror ErrWithoutToJson Int
+suberror ErrWithoutToJson {
+  ErrWithoutToJson(Int)
+}
 
 ///|
 test "error to json" {

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 ///|
-pub(all) suberror JsonDecodeError (JsonPath, String) derive(Eq, Show, ToJson)
+pub(all) suberror JsonDecodeError {
+  JsonDecodeError((JsonPath, String))
+} derive(Eq, Show, ToJson)
 
 ///|
 /// Trait for types that can be converted from `Json`

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -13,7 +13,9 @@ pub fn parse(StringView, max_nesting_depth? : Int) -> Json raise ParseError
 pub fn valid(StringView) -> Bool
 
 // Errors
-pub(all) suberror JsonDecodeError (JsonPath, String)
+pub(all) suberror JsonDecodeError {
+  JsonDecodeError((JsonPath, String))
+}
 pub impl Eq for JsonDecodeError
 pub impl Show for JsonDecodeError
 pub impl ToJson for JsonDecodeError

--- a/strconv/errors.mbt
+++ b/strconv/errors.mbt
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 ///|
-pub(all) suberror StrConvError String
+pub(all) suberror StrConvError {
+  StrConvError(String)
+}
 
 ///|
 pub impl Show for StrConvError with output(self, logger) {

--- a/strconv/pkg.generated.mbti
+++ b/strconv/pkg.generated.mbti
@@ -21,7 +21,9 @@ pub fn parse_uint(StringView, base? : Int) -> UInt raise StrConvError
 pub fn parse_uint64(StringView, base? : Int) -> UInt64 raise StrConvError
 
 // Errors
-pub(all) suberror StrConvError String
+pub(all) suberror StrConvError {
+  StrConvError(String)
+}
 pub impl Show for StrConvError
 
 // Types and methods


### PR DESCRIPTION
## Summary
Migrates all suberror error type declarations from the deprecated syntax to the new block-style syntax.

## Changes
- **Old syntax**: `suberror ErrorName Type`
- **New syntax**: `suberror ErrorName { ErrorName(Type) }`

## Affected Packages
- `builtin`: InspectError, SnapshotError, BenchError, Failure
- `encoding/utf16`: Malformed
- `encoding/utf8`: Malformed
- `error`: Updated test examples
- `json`: JsonDecodeError
- `strconv`: StrConvError

## Testing
- Updated documentation in `error/README.mbt.md` with new syntax examples
- Ran `moon info` to update all `.mbti` interface files
- Ran `moon fmt` to format code consistently
- All interface files updated correctly with no unexpected changes

## Notes
- This is a purely syntactic refactoring with no behavioral changes
- The compiler was already warning about deprecated syntax
- Existing compiler ICE in builtin tests is pre-existing and unrelated to this change