### PR TITLE
fix: add missing return for timsort shortcut

### DIFF
--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -36,6 +36,7 @@ fn[T : Compare] timsort(arr : MutArrayView[T]) -> Unit {
   let len = arr.length()
   if len <= max_insertion {
     MutArrayView::insertion_sort(arr)
+    return
   }
   let mut end = 0
   let mut start = 0


### PR DESCRIPTION
Found this when I was playing with AI agent on the loop invariants and reasoning