### PR TITLE
fix: add missing return for timsort shortcut

### DIFF
--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -606,10 +606,10 @@ impl Compare for CompareCounter with compare(self, other) {
 /// would cause timsort to continue processing, resulting in extra comparisons.
 test "timsort_early_return_for_small_arrays" {
   let count : Ref[Int] = { val: 0 }
-  let arr : FixedArray[CompareCounter] = FixedArray::make(
-    10,
-    { value: 0, counter: count },
-  )
+  let arr : FixedArray[CompareCounter] = FixedArray::make(10, {
+    value: 0,
+    counter: count,
+  })
   for i in 0..<10 {
     arr[i] = { value: 10 - i, counter: count }
   }


### PR DESCRIPTION
## Summary

- Add test to reveal missing return bug in timsort for small arrays
- Add missing `return` statement after `insertion_sort` for arrays with length <= 20

## Problem

In `timsort`, when the array length is <= `max_insertion` (20), it correctly calls `insertion_sort` but was missing a `return` statement. This caused timsort to unnecessarily continue processing the already-sorted array, resulting in extra comparisons.

## Test

Added `timsort_early_return_for_small_arrays` test that counts comparisons:
- **Expected (with fix):** 45 comparisons (insertion sort worst case)
- **Actual (without fix):** 54 comparisons (9 extra from `find_streak`)

## Related

This is essentially a re-implementation of #3137 with an added test case.

🤖 Generated with [Claude Code](https://claude.ai/code)