### PR TITLE
remove unused string/bytes in deps

### DIFF
--- a/bigint/moon.pkg.json
+++ b/bigint/moon.pkg.json
@@ -6,8 +6,6 @@
     "moonbitlang/core/json",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/quickcheck/splitmix",
-    "moonbitlang/core/string",
-    "moonbitlang/core/bytes",
     "moonbitlang/core/int16",
     "moonbitlang/core/uint16"
   ],

--- a/buffer/moon.pkg.json
+++ b/buffer/moon.pkg.json
@@ -1,9 +1,7 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/bytes",
     "moonbitlang/core/array",
-    "moonbitlang/core/string",
     "moonbitlang/core/float",
     "moonbitlang/core/int16",
     "moonbitlang/core/uint16"

--- a/builtin/moon.pkg.json
+++ b/builtin/moon.pkg.json
@@ -4,8 +4,6 @@
   ],
   "test-import": [
     "moonbitlang/core/char",
-    "moonbitlang/core/string",
-    "moonbitlang/core/bytes",
     "moonbitlang/core/int",
     "moonbitlang/core/double",
     "moonbitlang/core/uint64",

--- a/debug/moon.pkg.json
+++ b/debug/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/string",
     "moonbitlang/core/double",
     "moonbitlang/core/float",
     "moonbitlang/core/list",

--- a/deque/moon.pkg.json
+++ b/deque/moon.pkg.json
@@ -2,8 +2,7 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/json",
-    "moonbitlang/core/array",
-    "moonbitlang/core/string"
+    "moonbitlang/core/array"
   ],
   "targets": {
     "panic_test.mbt": ["not", "native", "llvm"]

--- a/double/moon.pkg.json
+++ b/double/moon.pkg.json
@@ -5,7 +5,6 @@
     "moonbitlang/core/double/internal/ryu"
   ],
   "test-import": [
-    "moonbitlang/core/bytes",
     "moonbitlang/core/buffer",
     "moonbitlang/core/math"
   ],

--- a/encoding/utf16/moon.pkg.json
+++ b/encoding/utf16/moon.pkg.json
@@ -1,7 +1,5 @@
 {
   "import": [
-    "moonbitlang/core/builtin",
-    "moonbitlang/core/string",
-    "moonbitlang/core/bytes"
+    "moonbitlang/core/builtin"
   ]
 }

--- a/encoding/utf8/moon.pkg.json
+++ b/encoding/utf8/moon.pkg.json
@@ -1,8 +1,6 @@
 {
   "import": [
     "moonbitlang/core/buffer",
-    "moonbitlang/core/string",
-    "moonbitlang/core/bytes",
     "moonbitlang/core/builtin"
   ]
 }

--- a/float/moon.pkg.json
+++ b/float/moon.pkg.json
@@ -7,5 +7,5 @@
     "to_int.mbt": ["not", "wasm", "wasm-gc"],
     "to_int_wasm.mbt": ["wasm", "wasm-gc"]
   },
-  "test-import": ["moonbitlang/core/bytes", "moonbitlang/core/math"]
+  "test-import": ["moonbitlang/core/math"]
 }

--- a/hashmap/moon.pkg.json
+++ b/hashmap/moon.pkg.json
@@ -7,5 +7,5 @@
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/int"
   ],
-  "test-import": ["moonbitlang/core/string", "moonbitlang/core/json"]
+  "test-import": ["moonbitlang/core/json"]
 }

--- a/hashset/moon.pkg.json
+++ b/hashset/moon.pkg.json
@@ -6,7 +6,6 @@
     "moonbitlang/core/quickcheck"
   ],
   "test-import": [
-    "moonbitlang/core/string",
     "moonbitlang/core/int",
     "moonbitlang/core/json"
   ]

--- a/immut/hashmap/moon.pkg.json
+++ b/immut/hashmap/moon.pkg.json
@@ -10,7 +10,6 @@
   ],
   "test-import": [
     "moonbitlang/core/int",
-    "moonbitlang/core/string",
     "moonbitlang/core/option"
   ]
 }

--- a/immut/hashset/moon.pkg.json
+++ b/immut/hashset/moon.pkg.json
@@ -7,5 +7,5 @@
     "moonbitlang/core/immut/internal/path",
     "moonbitlang/core/list"
   ],
-  "test-import": ["moonbitlang/core/string", "moonbitlang/core/int"]
+  "test-import": ["moonbitlang/core/int"]
 }

--- a/immut/sorted_map/moon.pkg.json
+++ b/immut/sorted_map/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/tuple",
-    "moonbitlang/core/string",
     "moonbitlang/core/array",
     "moonbitlang/core/quickcheck",
     "moonbitlang/core/json"

--- a/int/moon.pkg.json
+++ b/int/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/uint"],
   "test-import": [
-    "moonbitlang/core/bytes",
     "moonbitlang/core/buffer"
   ]
 }

--- a/int64/moon.pkg.json
+++ b/int64/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": ["moonbitlang/core/builtin", "moonbitlang/core/uint64", "moonbitlang/core/int16"],
   "test-import": [
-    "moonbitlang/core/bytes",
     "moonbitlang/core/buffer"
   ]
 }

--- a/json/moon.pkg.json
+++ b/json/moon.pkg.json
@@ -5,7 +5,6 @@
     "moonbitlang/core/char",
     "moonbitlang/core/double",
     "moonbitlang/core/float",
-    "moonbitlang/core/string",
     "moonbitlang/core/strconv",
     "moonbitlang/core/option",
     "moonbitlang/core/buffer"
@@ -13,7 +12,6 @@
   "test-import": [
     "moonbitlang/core/result",
     "moonbitlang/core/unit",
-    "moonbitlang/core/bigint",
-    "moonbitlang/core/bytes"
+    "moonbitlang/core/bigint"
   ]
 }

--- a/quickcheck/moon.pkg.json
+++ b/quickcheck/moon.pkg.json
@@ -9,8 +9,7 @@
     "moonbitlang/core/bigint",
     "moonbitlang/core/float",
     "moonbitlang/core/double",
-    "moonbitlang/core/tuple",
-    "moonbitlang/core/bytes"
+    "moonbitlang/core/tuple"
 
   ]
 }

--- a/random/internal/random_source/moon.pkg.json
+++ b/random/internal/random_source/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/core/builtin",
-    "moonbitlang/core/array",
-    "moonbitlang/core/bytes"
+    "moonbitlang/core/array"
   ]
 }

--- a/sorted_map/moon.pkg.json
+++ b/sorted_map/moon.pkg.json
@@ -4,8 +4,7 @@
     "moonbitlang/core/option",
     "moonbitlang/core/tuple",
     "moonbitlang/core/quickcheck",
-    "moonbitlang/core/json",
-    "moonbitlang/core/string"
+    "moonbitlang/core/json"
   ],
   "test-import": ["moonbitlang/core/array"]
 }

--- a/strconv/moon.pkg.json
+++ b/strconv/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/core/builtin",
     "moonbitlang/core/double",
     "moonbitlang/core/uint64",
-    "moonbitlang/core/string",
     "moonbitlang/core/char",
     "moonbitlang/core/array"
   ]

--- a/string/regex/internal/regexp/internal/ast/moon.pkg.json
+++ b/string/regex/internal/regexp/internal/ast/moon.pkg.json
@@ -4,7 +4,6 @@
     { "path": "moonbitlang/core/string/regex/internal/regexp/internal/unicode", "alias": "unicode" },
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/string",
     "moonbitlang/core/int",
     "moonbitlang/core/char"
   ],

--- a/string/regex/internal/regexp/internal/parse/moon.pkg.json
+++ b/string/regex/internal/regexp/internal/parse/moon.pkg.json
@@ -5,7 +5,6 @@
     "moonbitlang/core/string/regex/internal/regexp/internal/unicode",
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/string",
     "moonbitlang/core/int",
     "moonbitlang/core/char",
     "moonbitlang/core/set"

--- a/string/regex/internal/regexp/internal/unicode/moon.pkg.json
+++ b/string/regex/internal/regexp/internal/unicode/moon.pkg.json
@@ -2,7 +2,6 @@
   "import": [
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/string", 
     "moonbitlang/core/int",
     "moonbitlang/core/char"
   ]

--- a/string/regex/internal/regexp/internal/vm/moon.pkg.json
+++ b/string/regex/internal/regexp/internal/vm/moon.pkg.json
@@ -3,7 +3,6 @@
     { "path": "moonbitlang/core/string/regex/internal/regexp/internal/unicode", "alias": "unicode" },
     "moonbitlang/core/builtin",
     "moonbitlang/core/array",
-    "moonbitlang/core/string",
     "moonbitlang/core/int",
     "moonbitlang/core/char"
   ],

--- a/string/regex/internal/regexp/moon.pkg.json
+++ b/string/regex/internal/regexp/moon.pkg.json
@@ -4,8 +4,7 @@
     "moonbitlang/core/string/regex/internal/regexp/internal/vm",
     "moonbitlang/core/string/regex/internal/regexp/internal/ast",
     "moonbitlang/core/builtin",
-    "moonbitlang/core/array",
-    "moonbitlang/core/string"
+    "moonbitlang/core/array"
   ],
   "test-import": [
     "moonbitlang/core/option"

--- a/string/regex/moon.pkg.json
+++ b/string/regex/moon.pkg.json
@@ -5,7 +5,6 @@
   ],
   "test-import": [
     "moonbitlang/core/option",
-    "moonbitlang/core/error",
-    "moonbitlang/core/string"
+    "moonbitlang/core/error"
   ]
 }

--- a/uint/moon.pkg.json
+++ b/uint/moon.pkg.json
@@ -1,4 +1,4 @@
 {
   "import": ["moonbitlang/core/builtin"],
-  "test-import": ["moonbitlang/core/bytes", "moonbitlang/core/buffer"]
+  "test-import": ["moonbitlang/core/buffer"]
 }

--- a/uint64/moon.pkg.json
+++ b/uint64/moon.pkg.json
@@ -1,4 +1,4 @@
 {
   "import": ["moonbitlang/core/builtin"],
-  "test-import": ["moonbitlang/core/double", "moonbitlang/core/bytes"]
+  "test-import": ["moonbitlang/core/double"]
 }


### PR DESCRIPTION
This PR removes unused `moonbitlang/core/string` and `moonbitlang/core/bytes` packages from deps. This is a major blocker for #3141 , which expect to put regex surface api directly inside `string` and `bytes` packages.

Other packages for builtin types in deps should cleanup this way as well, but there's no convenient way for now, as the unused package warning not working. /cc @peter-jerry-ye @Yu-zh 

I didn't investigate why unused package warning not working. This should raise another issue.
