### PR TITLE
fix(regex): int literal

### DIFF
--- a/internal/regex_engine/shared_types/rechar_set/rechar_set.mbt
+++ b/internal/regex_engine/shared_types/rechar_set/rechar_set.mbt
@@ -239,7 +239,7 @@ fn complement(t : Tree) -> Tree {
     }
   }
 
-  aux(-80000000, 0x7FFFFFFF, t)
+  aux(-0x80000000, 0x7FFFFFFF, t)
 }
 
 ///|


### PR DESCRIPTION
Use the correct Int minimum value 0x80000000