### PR TITLE
fix: #3155 BigInt parses “-0” as negative zero in non‑JS backend

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1044,6 +1044,7 @@ pub fn BigInt::from_string(input : String) -> BigInt {
   while b[b_len - 1] == 0 && b_len > 1 {
     b_len -= 1
   }
+  let sign = if b_len == 1 && b[0] == 0 { Positive } else { sign }
   { limbs: b, sign, len: b_len }
 }
 
@@ -1116,6 +1117,7 @@ pub fn BigInt::from_hex(input : String) -> BigInt {
   while b[b_len - 1] == 0 && b_len > 1 {
     b_len -= 1
   }
+  let sign = if b_len == 1 && b[0] == 0 { Positive } else { sign }
   { limbs: b, sign, len: b_len }
 }
 

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -495,6 +495,22 @@ test "from_hex" {
 }
 
 ///|
+test "from_string negative zero" {
+  let z = @bigint.BigInt::from_string("-0")
+  inspect(z.to_string(), content="0")
+  assert_true(z == 0N)
+  assert_eq(z.compare(0N), 0)
+}
+
+///|
+test "from_hex negative zero" {
+  let z = @bigint.BigInt::from_hex("-0")
+  inspect(z.to_string(), content="0")
+  assert_true(z == 0N)
+  assert_eq(z.compare(0N), 0)
+}
+
+///|
 test "to_hex" {
   // Check zero
   let a = @bigint.BigInt::from_hex("00")


### PR DESCRIPTION
- #3155