### PR TITLE
refactor: remove deprecated type aliases and hide deprecated functions from docs

### DIFF
--- a/bytes/README.mbt.md
+++ b/bytes/README.mbt.md
@@ -30,7 +30,7 @@ test "bytes creation" {
   )
 
   // Create empty bytes
-  let empty = @bytes.default()
+  let empty = Bytes::default()
   inspect(
     empty,
     content=(

--- a/bytes/alias.mbt
+++ b/bytes/alias.mbt
@@ -13,32 +13,16 @@
 // limitations under the License.
 
 ///|
-/// A `BytesView` represents a view into a section of a `Bytes` without copying the data.
-///
-/// # Example
-/// 
-/// ```mbt check
-/// test {
-///   let bs = b"\x00\x01\x02\x03\x04\x05"
-///   let bv = bs[1:4]
-///   inspect(bv.length(), content="3")
-///   assert_eq(bv[0], b'\x01')
-///   assert_eq(bv[1], b'\x02')
-///   assert_eq(bv[2], b'\x03')
-/// }
-/// ```
-#builtin.valtype
-#deprecated("Use `BytesView` instead")
-pub type View = BytesView
-
-///|
 /// same as `Bytes::default`
+#deprecated("Use `Bytes::default` instead")
+#doc(hidden)
 pub fn default() -> Bytes {
   b""
 }
 
 ///|
 #deprecated("Use `Bytes::from_array` instead")
+#doc(hidden)
 pub fn from_fixedarray(arr : FixedArray[Byte], len? : Int) -> Bytes {
   Bytes::from_array(arr[:len.unwrap_or(arr.length())])
 }
@@ -46,18 +30,21 @@ pub fn from_fixedarray(arr : FixedArray[Byte], len? : Int) -> Bytes {
 ///|
 #deprecated("Use `Bytes::from_iter` instead")
 #alias(from_iterator, deprecated="Use `Bytes::from_iter` instead")
+#doc(hidden)
 pub fn from_iter(iter : Iter[Byte]) -> Bytes {
   Bytes::from_iter(iter)
 }
 
 ///|
 #deprecated("Use `Bytes::from_array` instead")
+#doc(hidden)
 pub fn of(arr : ArrayView[Byte]) -> Bytes {
   Bytes::from_array(arr)
 }
 
 ///|
 #deprecated("Use `Bytes::from_array` instead")
+#doc(hidden)
 pub fn from_array(arr : ArrayView[Byte]) -> Bytes {
   Bytes::from_array(arr)
 }

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -1,25 +1,7 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/bytes"
 
-import(
-  "moonbitlang/core/builtin"
-)
-
 // Values
-pub fn default() -> Bytes
-
-#deprecated
-pub fn from_array(ArrayView[Byte]) -> Bytes
-
-#deprecated
-pub fn from_fixedarray(FixedArray[Byte], len? : Int) -> Bytes
-
-#alias(from_iterator, deprecated)
-#deprecated
-pub fn from_iter(Iter[Byte]) -> Bytes
-
-#deprecated
-pub fn of(ArrayView[Byte]) -> Bytes
 
 // Errors
 
@@ -35,8 +17,6 @@ pub fn MatchResult::group(Self, Int) -> BytesView?
 pub fn MatchResult::named_group(Self, String) -> BytesView?
 
 // Type aliases
-#deprecated
-pub using @builtin {type BytesView as View}
 
 // Traits
 

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -6,16 +6,6 @@ import(
 )
 
 // Values
-pub fn default() -> String
-
-#deprecated
-pub fn from_array(ArrayView[Char]) -> String
-
-#deprecated
-pub fn from_iter(Iter[Char]) -> String
-
-#deprecated
-pub fn from_iterator(Iter[Char]) -> String
 
 // Errors
 
@@ -31,9 +21,6 @@ type Regex
 pub fn Regex::execute(Self, StringView, lastIndex? : Int) -> MatchResult?
 
 // Type aliases
-#deprecated
-pub using @builtin {type StringView as View}
-
 pub using @builtin {trait ToStringView}
 
 // Traits

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -26,6 +26,7 @@
 ///
 /// For efficiency considerations, it's recommended to use `Buffer` instead.
 #deprecated
+#doc(hidden)
 pub fn from_array(chars : ArrayView[Char]) -> String {
   String::from_array(chars)
 }
@@ -33,6 +34,7 @@ pub fn from_array(chars : ArrayView[Char]) -> String {
 ///|
 /// Convert char iterator to string,
 #deprecated
+#doc(hidden)
 pub fn from_iter(iter : Iter[Char]) -> String {
   String::from_iter(iter)
 }
@@ -40,12 +42,15 @@ pub fn from_iter(iter : Iter[Char]) -> String {
 ///|
 /// Convert char iterator to string,
 #deprecated
+#doc(hidden)
 pub fn from_iterator(iter : Iter[Char]) -> String {
   String::from_iter(iter)
 }
 
 ///|
 /// same as `String::default`
+#deprecated("Use `String::default` instead")
+#doc(hidden)
 pub fn default() -> String {
   ""
 }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -780,5 +780,5 @@ test "guard const" {
 
 ///|
 test "string default" {
-  inspect(@string.default(), content="")
+  inspect(String::default(), content="")
 }

--- a/string/view.mbt
+++ b/string/view.mbt
@@ -13,8 +13,4 @@
 // limitations under the License.
 
 ///|
-#deprecated("Use `StringView` instead")
-pub type View = StringView
-
-///|
 pub using @builtin {trait ToStringView}


### PR DESCRIPTION
## Summary
- Remove `View` type aliases from `bytes` and `string` packages (they were deprecated in favor of `BytesView` and `StringView`)
- Add `#doc(hidden)` to deprecated functions to hide them from generated documentation
- Update README example and test to use new syntax (`Bytes::default()`, `String::default()`)

## Test plan
- [x] `moon fmt && moon check` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)