### PR TITLE
perf: only grow HashMap/Map when actually inserting new entries

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -116,27 +116,42 @@ fn[K : Eq, V] Map::set_with_hash(
   value : V,
   hash : Int,
 ) -> Unit {
-  if self.size >= self.grow_at {
-    self.grow()
-  }
-  let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
+  // Only grow when actually inserting a new entry, not when updating existing
+  for psl = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
-      None => break (idx, psl)
+      None => {
+        // Need to insert new entry - check if grow is needed first
+        if self.size >= self.grow_at {
+          self.grow()
+          // Restart search with new capacity_mask
+          continue 0, hash & self.capacity_mask
+        }
+        let entry = { prev: self.tail, next: None, psl, key, value, hash }
+        self.add_entry_to_tail(idx, entry)
+        return
+      }
       Some(curr_entry) => {
         if curr_entry.hash == hash && curr_entry.key == key {
+          // Key exists - just update value, no grow needed
           curr_entry.value = value
           return
         }
         if psl > curr_entry.psl {
+          // Need to insert and push away - check if grow is needed first
+          if self.size >= self.grow_at {
+            self.grow()
+            // Restart search with new capacity_mask
+            continue 0, hash & self.capacity_mask
+          }
           self.push_away(idx, curr_entry)
-          break (idx, psl)
+          let entry = { prev: self.tail, next: None, psl, key, value, hash }
+          self.add_entry_to_tail(idx, entry)
+          return
         }
         continue psl + 1, (idx + 1) & self.capacity_mask
       }
     }
   }
-  let entry = { prev: self.tail, next: None, psl, key, value, hash }
-  self.add_entry_to_tail(idx, entry)
 }
 
 ///|

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -640,3 +640,24 @@ test "Map::merge_in_place self should not grow" {
     assert_eq(map.get(i.to_string()), Some(i))
   }
 }
+
+///|
+test "Map::set updating existing key should not grow" {
+  let map : Map[String, Int] = {}
+  // Add 6 entries to reach the growth threshold (default capacity 8, grow_at 6)
+  for i in 0..<6 {
+    map.set(i.to_string(), i)
+  }
+  assert_eq(map.capacity(), 8)
+  assert_eq(map.length(), 6)
+  // Update existing keys - should NOT trigger grow
+  for i in 0..<6 {
+    map.set(i.to_string(), i * 10)
+  }
+  assert_eq(map.capacity(), 8) // Should still be 8, not 16
+  assert_eq(map.length(), 6)
+  // Verify values were updated
+  for i in 0..<6 {
+    assert_eq(map.get(i.to_string()), Some(i * 10))
+  }
+}

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -116,28 +116,44 @@ fn[K : Eq, V] HashMap::set_with_hash(
   value : V,
   hash : Int,
 ) -> Unit {
-  if self.size >= self.capacity / 2 {
-    self.grow()
-  }
-  let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
+  // Only grow when actually inserting a new entry, not when updating existing
+  for psl = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
-      None => break (idx, psl)
+      None => {
+        // Need to insert new entry - check if grow is needed first
+        if self.size >= self.capacity / 2 {
+          self.grow()
+          // Restart search with new capacity_mask
+          continue 0, hash & self.capacity_mask
+        }
+        let entry = { psl, key, value, hash }
+        self.entries[idx] = Some(entry)
+        self.size += 1
+        return
+      }
       Some(curr_entry) => {
         if curr_entry.hash == hash && curr_entry.key == key {
+          // Key exists - just update value, no grow needed
           curr_entry.value = value
           return
         }
         if psl > curr_entry.psl {
+          // Need to insert and push away - check if grow is needed first
+          if self.size >= self.capacity / 2 {
+            self.grow()
+            // Restart search with new capacity_mask
+            continue 0, hash & self.capacity_mask
+          }
           self.push_away(idx, curr_entry)
-          break (idx, psl)
+          let entry = { psl, key, value, hash }
+          self.entries[idx] = Some(entry)
+          self.size += 1
+          return
         }
         continue psl + 1, (idx + 1) & self.capacity_mask
       }
     }
   }
-  let entry = { psl, key, value, hash }
-  self.entries[idx] = Some(entry)
-  self.size += 1
 }
 
 ///|

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -493,6 +493,27 @@ test "@hashmap.merge_in_place self-aliasing should be no-op" {
 }
 
 ///|
+test "@hashmap.set updating existing key should not grow" {
+  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+  // Fill to exactly at grow threshold: capacity=8, size=4
+  for i in 0..<4 {
+    map.set(i.to_string(), i)
+  }
+  assert_eq(map.capacity(), 8)
+  assert_eq(map.length(), 4)
+  // Update existing keys - should NOT trigger grow
+  for i in 0..<4 {
+    map.set(i.to_string(), i * 10)
+  }
+  assert_eq(map.capacity(), 8) // Should still be 8, not 16
+  assert_eq(map.length(), 4)
+  // Verify values were updated
+  for i in 0..<4 {
+    assert_eq(map.get(i.to_string()), Some(i * 10))
+  }
+}
+
+///|
 priv struct Key(Int, Int) derive(Eq)
 
 ///|


### PR DESCRIPTION
## Summary

Optimize `set_with_hash` for both `HashMap` and `Map` to only grow when actually inserting new entries, not when updating existing keys.

## Problem

The previous implementation checked the grow threshold **before** looking up the key:

```moonbit
fn set_with_hash(...) {
  if size >= threshold { grow() }  // ❌ Check BEFORE key lookup
  // search for key...
  // if found: update value (no size change!)
  // if not found: insert, size += 1
}
```

This meant updating an existing key could trigger an unnecessary O(n) rehash operation.

## Solution

Move the grow check to happen **only** when we need to insert a new entry:

```moonbit
fn set_with_hash(...) {
  for ... {
    match entries[idx] {
      None => {
        if size >= threshold { grow(); continue 0, hash & new_mask }  // Restart
        // insert new entry
      }
      Some(entry) if key matches => {
        entry.value = value  // ✅ No grow check needed for updates
        return
      }
      Some(entry) if need push_away => {
        if size >= threshold { grow(); continue 0, hash & new_mask }  // Restart
        // insert and push away
      }
    }
  }
}
```

## Benefits

- Avoid unnecessary O(n) rehash when updating existing keys
- Better performance in update-heavy workloads  
- Makes `merge_in_place(self)` even more efficient (combined with the physical_equal check from PR #3163)

## Test plan

- [x] Added test `@hashmap.set updating existing key should not grow`
- [x] Added test `Map::set updating existing key should not grow`
- [x] All existing hashmap and builtin tests pass (111 + 2591 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)