### PR TITLE
Fix BigInt::to_uint for negative values

### DIFF
--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,4 @@
+{
+  "database": "beads.db",
+  "jsonl_export": "beads.left.jsonl"
+}

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1720,8 +1720,15 @@ pub fn BigInt::to_int(self : BigInt) -> Int {
 /// }
 /// ```
 pub fn BigInt::to_uint(self : BigInt) -> UInt {
-  let value = if self.sign == Negative { (1N << 32) + self } else { self }
-  value.limbs[0]
+  let low_limb = self.limbs[0]
+  if self.sign == Negative {
+    // For negative numbers, return (2^32 - low_limb) mod 2^32
+    // This computes the two's complement representation
+    // Equivalent to: 2^32 - low_limb = (2^32 - 1 - low_limb) + 1
+    4294967295U - low_limb + 1U
+  } else {
+    low_limb
+  }
 }
 
 ///|

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -158,3 +158,22 @@ test {
     content="{limbs : [2, 2147483648, 0], sign : Negative, len : 2 }",
   ) // Int64.min_value - 2
 }
+
+///|
+test "BigInt::to_uint negative values modulo 2^32" {
+  // Test that to_uint correctly handles negative values modulo 2^32
+  // -1N should map to 2^32 - 1 = 4294967295
+  inspect((-1N).to_uint(), content="4294967295")
+
+  // -(2^32 + 1) should map to 2^32 - 1 = 4294967295 (mod 2^32)
+  let large_neg = -(1N << 32) - 1N
+  inspect(large_neg.to_uint(), content="4294967295") // Should be 4294967295, not 1
+
+  // -(2^32) should map to 0
+  let neg_2_32 = -(1N << 32)
+  inspect(neg_2_32.to_uint(), content="0")
+
+  // -(2^32 + 42) should map to 2^32 - 42 = 4294967254
+  let neg_2_32_plus_42 = -(1N << 32) - 42N
+  inspect(neg_2_32_plus_42.to_uint(), content="4294967254")
+}

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -1,11 +1,11 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/bigint"
 
-import(
-  "moonbitlang/core/json"
-  "moonbitlang/core/quickcheck"
-  "moonbitlang/core/quickcheck/splitmix"
-)
+import {
+  "moonbitlang/core/json",
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/splitmix",
+}
 
 // Values
 


### PR DESCRIPTION
Fixes issue core-5ts: BigInt::to_uint incorrectly handled negative values outside [-2^32, -1] range.

### Changes
- Changed from adding `2^32` once to computing two's complement: `(4294967295U - low_limb) + 1U`
- This correctly handles all negative values, not just those in [-2^32, -1]

### Tests
Added tests for: -1N, -(2^32+1)N, -(2^32)N, -(2^32+42)N