### PR TITLE
fix: Deque::drain should panic on invalid bounds

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1867,17 +1867,23 @@ pub fn[A] Deque::flatten(self : Deque[Deque[A]]) -> Deque[A] {
 }
 
 ///|
-/// Removes and returns elements in the specified range [begin, end) from the deque.
+/// Removes and returns elements in the specified range `[start, start + len)` from the deque.
 ///
 /// Parameters:
 ///
 /// * `self` : The target deque (modified in-place).
-/// * `start` : Start index of the range (inclusive).
-/// * `len` : Length of the range to drain.
+/// * `start` : Start index of the range (inclusive). Must be >= 0 and <= self.length().
+/// * `len` : Length of the range to drain. If not provided, drains from `start` to end.
+///   If provided, must be >= 0 and `start + len` must be <= self.length().
 ///
-/// Important:
-///   - Returns a new deque containing the drained elements.
-///   - Original deque retains elements outside [start, start + len) in original order.
+/// Returns a new deque containing the drained elements. The original deque retains
+/// elements outside `[start, start + len)` in their original order.
+///
+/// Panics if:
+/// * `start < 0`
+/// * `start > self.length()`
+/// * `len < 0` (when provided)
+/// * `start + len > self.length()` (when len is provided)
 ///
 /// Example:
 ///
@@ -1890,12 +1896,24 @@ pub fn[A] Deque::flatten(self : Deque[Deque[A]]) -> Deque[A] {
 /// }
 /// ```
 pub fn[A] Deque::drain(self : Deque[A], start~ : Int, len? : Int) -> Deque[A] {
-  // Verify parameters
-  if start >= self.len {
-    return new()
+  // Validate start
+  guard start >= 0 && start <= self.len else {
+    abort(
+      "Deque::drain: start index out of bounds (start=\{start}, deque.length()=\{self.len})",
+    )
   }
-  let max_len = self.len - start
-  let len = if len is Some(l) && l <= max_len { l } else { max_len }
+  // Calculate and validate len
+  let len = match len {
+    Some(l) => {
+      guard l >= 0 && start + l <= self.len else {
+        abort(
+          "Deque::drain: len out of bounds (start=\{start}, len=\{l}, deque.length()=\{self.len})",
+        )
+      }
+      l
+    }
+    None => self.len - start
+  }
   if len == 0 {
     return new()
   }

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -1141,19 +1141,30 @@ test "drain when wrapped around" {
 }
 
 ///|
-test "drain invalid inputs" {
-  let dq = @deque.from_array([5, 6])
-  let dq2 = dq.drain(start=100)
-  inspect(dq.as_views(), content="([5, 6], [])")
-  inspect(dq2, content="@deque.from_array([])")
-  let dq = @deque.from_array([5, 6])
-  let dq2 = dq.drain(start=1, len=100)
-  inspect(dq.as_views(), content="([5], [])")
-  inspect(dq2, content="@deque.from_array([6])")
+test "drain edge cases" {
+  // drain with len=0 should return empty and not modify original
   let dq = @deque.from_array([5, 6])
   let dq2 = dq.drain(start=1, len=0)
   inspect(dq.as_views(), content="([5, 6], [])")
   inspect(dq2, content="@deque.from_array([])")
+
+  // drain from start=length() should return empty (no elements to drain)
+  let dq = @deque.from_array([5, 6])
+  let dq2 = dq.drain(start=2)
+  inspect(dq.as_views(), content="([5, 6], [])")
+  inspect(dq2, content="@deque.from_array([])")
+
+  // drain entire deque
+  let dq = @deque.from_array([5, 6])
+  let dq2 = dq.drain(start=0)
+  inspect(dq.as_views(), content="([], [])")
+  inspect(dq2, content="@deque.from_array([5, 6])")
+
+  // drain with exact len
+  let dq = @deque.from_array([5, 6, 7])
+  let dq2 = dq.drain(start=1, len=2)
+  inspect(dq.as_views(), content="([5], [])")
+  inspect(dq2, content="@deque.from_array([6, 7])")
 }
 
 ///|

--- a/deque/panic_test.mbt
+++ b/deque/panic_test.mbt
@@ -41,3 +41,23 @@ test "panic insert out of bounds" {
 test "panic remove out of bounds" {
   @deque.from_array([1, 2, 3]).remove(3) |> ignore
 }
+
+///|
+test "panic drain with negative start" {
+  @deque.from_array([5, 6]).drain(start=-1) |> ignore
+}
+
+///|
+test "panic drain with start out of bounds" {
+  @deque.from_array([5, 6]).drain(start=100) |> ignore
+}
+
+///|
+test "panic drain with negative len" {
+  @deque.from_array([5, 6]).drain(start=0, len=-1) |> ignore
+}
+
+///|
+test "panic drain with len exceeding bounds" {
+  @deque.from_array([5, 6]).drain(start=1, len=100) |> ignore
+}


### PR DESCRIPTION
## Summary

Change `Deque::drain` to use `guard` + `abort` for invalid inputs instead of silently returning an empty deque. This makes it consistent with `Array::drain` behavior.

## Problem

The previous implementation (and PR #3080) treated invalid inputs as a no-op:
- Negative `start` → return empty deque
- Out-of-bounds `start` → return empty deque  
- Negative `len` → return empty deque

This behavior:
1. **Inconsistent** with `Array::drain` which panics on invalid bounds
2. **Hides bugs** - programmer doesn't realize they passed invalid bounds
3. **Ambiguous** - what does "invalid" mean exactly?

## Solution

Use `guard` + `abort` with clear error messages:

```moonbit
guard start >= 0 && start <= self.len else {
  abort("Deque::drain: start index out of bounds (start=\{start}, deque.length()=\{self.len})")
}
```

### Panics if:
- `start < 0`
- `start > self.length()`
- `len < 0` (when provided)
- `start + len > self.length()` (when len is provided)

### Valid edge cases (no panic):
- `start = self.length()` with no `len` → drains 0 elements
- `len = 0` → drains 0 elements

## Test plan

- [x] Added edge case tests in `deque_test.mbt`
- [x] Added panic tests in `deque/panic_test.mbt`
- [x] All 227 deque tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)