### PR TITLE
fix alias of deprecated stuff in `@prelude`

### DIFF
--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -87,6 +87,12 @@ pub using @builtin {type Iter2}
 
 pub using @builtin {type IterResult}
 
+#deprecated
+pub using @builtin {type Iter as Iterator}
+
+#deprecated
+pub using @builtin {type Iter2 as Iterator2}
+
 pub using @builtin {type Json}
 
 pub using @builtin {type Map}

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -33,7 +33,6 @@ pub using @builtin {
   println,
   not,
   repr,
-  dump,
   trait Eq,
   trait Compare,
   trait Hash,
@@ -60,9 +59,7 @@ pub using @builtin {
   type Failure,
   type Hasher,
   type Iter,
-  type Iterator,
   type Iter2,
-  type Iterator2,
   type IterResult,
   type Json,
   type Map,
@@ -137,3 +134,23 @@ pub let null : Json = @builtin.null
 
 ///|
 pub using @json {trait FromJson, json_inspect}
+
+///|
+/// Prints and returns the value of a given expression for quick and dirty debugging.
+/// This could also be useful to print some logs to trace the progress.
+/// For example, you can put `dump(())` in each line, the execution will print the line number
+/// when it reaches that line.
+#callsite(autofill(loc))
+#deprecated("This function is for debugging only and should not be used in production")
+#warnings("-deprecated")
+pub fn[T] dump(t : T, name? : String, loc~ : SourceLoc) -> T {
+  @builtin.dump(t, name?, loc~)
+}
+
+///|
+#deprecated("The name `Iterator` is deprecated, use `Iter` instead. Note that if you have defined `iterator()` method to support `for .. in` loop, you should also rename `iterator()` to `iter()`. See https://github.com/moonbitlang/core/pull/3127 for more details.")
+pub type Iterator[X] = Iter[X]
+
+///|
+#deprecated("The name `Iterator2` is deprecated, use `Iter2` instead. Note that if you have defined `iterator2()` method to support `for .. in` loop, you should also rename `iterator2()` to `iter2()`. See https://github.com/moonbitlang/core/pull/3127 for more details.")
+pub type Iterator2[X, Y] = Iter2[X, Y]


### PR DESCRIPTION
Currently, the behavior of `using` on deprecated stuff is:

- the `#deprecated` attribute is inherited by the new alias
- `using` itself never report a deprecation warning

but this behavior is not desirable. It is not intuitive, and may lead to warning that cannot be fixed for downstream of `pub using`. Current behavior also forbids deprecating the alias generated by `using` only, which is useful for `pub using`. So we plan to change the behavior of `using` on deprecated stuff to:

- the `#deprecated` attribute is not inherited by the new alias in `using`
- `using` itself will show a deprecation warning when the alias target is deprecated
- `using` itself can be annotated with `#deprecated`, which will deprecate the alias and only the alias

This PR prepares `moonbitlang/core` for this semantic change by temporarily avoid `using` for deprecated stuff in `@prelude`, so that we won't run into invalid state when the MoonBit compiler is performing the migration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3174">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
