### PR TITLE
feat: add lexical_compare for Array, ArrayView, FixedArray, and Bytes

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -2038,3 +2038,34 @@ pub fn[A : ToStringView] Array::join(
 ) -> String {
   self[:].join(separator)
 }
+
+///|
+/// Performs a lexicographical comparison of two arrays.
+///
+/// This method compares the arrays element by element until a difference is
+/// found or one array is exhausted. Unlike the `Compare` trait implementation
+/// which uses shortlex order (shorter arrays come first), this method compares
+/// based purely on element values until a difference is found.
+///
+/// # Returns
+///
+/// - A negative integer if `self` is lexicographically less than `other`
+/// - Zero if `self` is lexicographically equal to `other`
+/// - A positive integer if `self` is lexicographically greater than `other`
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   inspect([1, 2].lexical_compare([1, 2, 3]), content="-1")
+///   inspect([1, 2, 3].lexical_compare([1, 2]), content="1")
+///   inspect([1, 2, 3].lexical_compare([1, 2, 3]), content="0")
+///   inspect([1, 2, 3].lexical_compare([1, 2, 4]), content="-1")
+/// }
+/// ```
+pub fn[T : Compare] Array::lexical_compare(
+  self : Array[T],
+  other : Array[T],
+) -> Int {
+  self[:].lexical_compare(other[:])
+}

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -366,6 +366,28 @@ test "array_ends_with" {
 }
 
 ///|
+test "lexical_compare" {
+  // Test equal arrays
+  inspect([1, 2, 3].lexical_compare([1, 2, 3]), content="0")
+  inspect(([] : Array[Int]).lexical_compare([]), content="0")
+
+  // Test shorter is less when prefix matches
+  inspect([1, 2].lexical_compare([1, 2, 3]), content="-1")
+  inspect([1, 2, 3].lexical_compare([1, 2]), content="1")
+  inspect(([] : Array[Int]).lexical_compare([1]), content="-1")
+  inspect([1].lexical_compare([]), content="1")
+
+  // Test element-wise comparison
+  inspect([1, 2, 3].lexical_compare([1, 2, 4]), content="-1")
+  inspect([1, 2, 4].lexical_compare([1, 2, 3]), content="1")
+
+  // Elements are compared before considering length
+  // [1, 3] > [1, 2, 9] because 3 > 2 at position 1
+  inspect([1, 3].lexical_compare([1, 2, 9]), content="1")
+  inspect([1, 2, 9].lexical_compare([1, 3]), content="-1")
+}
+
+///|
 test "array_strip_prefix" {
   let arr = [1, 2, 3]
   assert_eq(arr.strip_prefix([1, 2]), Some([3]))

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -957,6 +957,46 @@ pub fn[A : ToStringView] ArrayView::join(
   }
 }
 
+///|
+/// Performs a lexicographical comparison of two array views.
+///
+/// This method compares the array views element by element until a difference
+/// is found or one view is exhausted. Unlike the `Compare` trait implementation
+/// which uses shortlex order (shorter views come first), this method compares
+/// based purely on element values until a difference is found.
+///
+/// # Returns
+///
+/// - A negative integer if `self` is lexicographically less than `other`
+/// - Zero if `self` is lexicographically equal to `other`
+/// - A positive integer if `self` is lexicographically greater than `other`
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   inspect([1, 2][:].lexical_compare([1, 2, 3][:]), content="-1")
+///   inspect([1, 2, 3][:].lexical_compare([1, 2][:]), content="1")
+///   inspect([1, 2, 3][:].lexical_compare([1, 2, 3][:]), content="0")
+///   inspect([1, 2, 3][:].lexical_compare([1, 2, 4][:]), content="-1")
+/// }
+/// ```
+pub fn[T : Compare] ArrayView::lexical_compare(
+  self : ArrayView[T],
+  other : ArrayView[T],
+) -> Int {
+  let self_len = self.length()
+  let other_len = other.length()
+  let min_len = if self_len < other_len { self_len } else { other_len }
+  for i in 0..<min_len {
+    let cmp = self.unsafe_get(i).compare(other.unsafe_get(i))
+    if cmp != 0 {
+      return cmp
+    }
+  }
+  self_len.compare(other_len)
+}
+
 // #endregion
 
 // #region trait impls

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -297,6 +297,36 @@ test "compare" {
 }
 
 ///|
+test "lexical_compare" {
+  // Test equal arrays
+  inspect([1, 2, 3][:].lexical_compare([1, 2, 3][:]), content="0")
+  inspect(
+    ([] : Array[Int])[0:0].lexical_compare(([] : Array[Int])[0:0]),
+    content="0",
+  )
+
+  // Test shorter is less when prefix matches
+  inspect([1, 2][:].lexical_compare([1, 2, 3][:]), content="-1")
+  inspect([1, 2, 3][:].lexical_compare([1, 2][:]), content="1")
+  inspect(([] : Array[Int])[0:0].lexical_compare([1][:]), content="-1")
+  inspect([1][:].lexical_compare(([] : Array[Int])[0:0]), content="1")
+
+  // Test element-wise comparison (differs from shortlex)
+  inspect([1, 2, 3][:].lexical_compare([1, 2, 4][:]), content="-1")
+  inspect([1, 2, 4][:].lexical_compare([1, 2, 3][:]), content="1")
+
+  // Key difference from Compare trait: lexical compares elements first, not length
+  // Compare trait: [1, 2, 0].compare([1, 2]) == 1 (longer is greater by shortlex)
+  // lexical_compare: [1, 2, 0].lexical_compare([1, 2]) == 1 (longer is greater since prefix matches)
+  inspect([1, 2, 0][:].lexical_compare([1, 2][:]), content="1")
+
+  // Elements are compared before considering length
+  // [1, 3] > [1, 2, 9] because 3 > 2 at position 1
+  inspect([1, 3][:].lexical_compare([1, 2, 9][:]), content="1")
+  inspect([1, 2, 9][:].lexical_compare([1, 3][:]), content="-1")
+}
+
+///|
 test "iter" {
   let array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   @json.json_inspect(array[:].iter().to_array(), content=[

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -800,3 +800,31 @@ pub fn Bytes::repeat(self : Self, count : Int) -> Bytes {
   }
   unsafe_to_bytes(arr)
 }
+
+///|
+/// Performs a lexicographical comparison of two byte sequences.
+///
+/// This method compares the sequences byte by byte until a difference is found
+/// or one sequence is exhausted. Unlike the `Compare` trait implementation which
+/// uses shortlex order (shorter sequences come first), this method compares based
+/// purely on byte values until a difference is found.
+///
+/// # Returns
+///
+/// - A negative integer if `self` is lexicographically less than `other`
+/// - Zero if `self` is lexicographically equal to `other`
+/// - A positive integer if `self` is lexicographically greater than `other`
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   inspect(b"\x01\x02".lexical_compare(b"\x01\x02\x03"), content="-1")
+///   inspect(b"\x01\x02\x03".lexical_compare(b"\x01\x02"), content="1")
+///   inspect(b"\x01\x02\x03".lexical_compare(b"\x01\x02\x03"), content="0")
+///   inspect(b"\x01\x02\x03".lexical_compare(b"\x01\x02\x04"), content="-1")
+/// }
+/// ```
+pub fn Bytes::lexical_compare(self : Bytes, other : Bytes) -> Int {
+  self[:].lexical_compare(other[:])
+}

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -334,6 +334,53 @@ test "@builtin.Bytes::compare/empty" {
 }
 
 ///|
+test "Bytes::lexical_compare/basic" {
+  // Test equal sequences
+  inspect(b"\x01\x02\x03".lexical_compare(b"\x01\x02\x03"), content="0")
+  inspect(b"".lexical_compare(b""), content="0")
+
+  // Test shorter is less when prefix matches
+  inspect(b"\x01\x02".lexical_compare(b"\x01\x02\x03"), content="-1")
+  inspect(b"\x01\x02\x03".lexical_compare(b"\x01\x02"), content="1")
+  inspect(b"".lexical_compare(b"\x00"), content="-1")
+  inspect(b"\x00".lexical_compare(b""), content="1")
+
+  // Test element-wise comparison
+  inspect(b"\x01\x02\x03".lexical_compare(b"\x01\x02\x04"), content="-1")
+  inspect(b"\x01\x02\x04".lexical_compare(b"\x01\x02\x03"), content="1")
+
+  // Elements are compared before considering length
+  // b"\x01\x03" > b"\x01\x02\x09" because 0x03 > 0x02 at position 1
+  inspect(b"\x01\x03".lexical_compare(b"\x01\x02\x09"), content="1")
+  inspect(b"\x01\x02\x09".lexical_compare(b"\x01\x03"), content="-1")
+}
+
+///|
+test "BytesView::lexical_compare/basic" {
+  let bytes = b"\x01\x02\x03\x04\x05"
+
+  // Test equal views
+  inspect(bytes[0:3].lexical_compare(bytes[0:3]), content="0")
+  inspect(bytes[0:0].lexical_compare(bytes[5:5]), content="0") // both empty
+
+  // Test shorter is less when prefix matches
+  inspect(bytes[0:2].lexical_compare(bytes[0:3]), content="-1")
+  inspect(bytes[0:3].lexical_compare(bytes[0:2]), content="1")
+
+  // Test element-wise comparison
+  let a = b"\x01\x02\x03"
+  let b = b"\x01\x02\x04"
+  inspect(a[:].lexical_compare(b[:]), content="-1")
+  inspect(b[:].lexical_compare(a[:]), content="1")
+
+  // Elements are compared before considering length
+  let short_higher = b"\x01\x03"
+  let long_lower = b"\x01\x02\x09"
+  inspect(short_higher[:].lexical_compare(long_lower[:]), content="1")
+  inspect(long_lower[:].lexical_compare(short_higher[:]), content="-1")
+}
+
+///|
 test "Bytes find and rev_find" {
   let target = b"abcabc"
   let pattern = b"abc"

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -570,6 +570,43 @@ pub impl Compare for BytesView with compare(self, other) -> Int {
 }
 
 ///|
+/// Performs a lexicographical comparison of two byte views.
+///
+/// This method compares the views byte by byte until a difference is found
+/// or one view is exhausted. Unlike the `Compare` trait implementation which
+/// uses shortlex order (shorter views come first), this method compares based
+/// purely on byte values until a difference is found.
+///
+/// # Returns
+///
+/// - A negative integer if `self` is lexicographically less than `other`
+/// - Zero if `self` is lexicographically equal to `other`
+/// - A positive integer if `self` is lexicographically greater than `other`
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   inspect(b"\x01\x02"[:].lexical_compare(b"\x01\x02\x03"[:]), content="-1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02"[:]), content="1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x03"[:]), content="0")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x04"[:]), content="-1")
+/// }
+/// ```
+pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
+  let self_len = self.length()
+  let other_len = other.length()
+  let min_len = if self_len < other_len { self_len } else { other_len }
+  for i in 0..<min_len {
+    let cmp = self.unsafe_get(i).compare(other.unsafe_get(i))
+    if cmp != 0 {
+      return cmp
+    }
+  }
+  self_len.compare(other_len)
+}
+
+///|
 /// Retrieves the underlying `Bytes` from a `View`.
 pub fn BytesView::data(self : BytesView) -> Bytes {
   self.bytes()

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1559,3 +1559,38 @@ pub fn[T] FixedArray::copy(self : FixedArray[T]) -> FixedArray[T] {
 pub fn[T] FixedArray::copy(self : FixedArray[T]) -> FixedArray[T] {
   JSArray::ofAnyFixedArray(self).copy().toAnyFixedArray()
 }
+
+///|
+/// Performs a lexicographical comparison of two fixed arrays.
+///
+/// This method compares the arrays element by element until a difference is
+/// found or one array is exhausted. Unlike the `Compare` trait implementation
+/// which uses shortlex order (shorter arrays come first), this method compares
+/// based purely on element values until a difference is found.
+///
+/// # Returns
+///
+/// - A negative integer if `self` is lexicographically less than `other`
+/// - Zero if `self` is lexicographically equal to `other`
+/// - A positive integer if `self` is lexicographically greater than `other`
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let a : FixedArray[Int] = [1, 2]
+///   let b : FixedArray[Int] = [1, 2, 3]
+///   inspect(a.lexical_compare(b), content="-1")
+///   inspect(b.lexical_compare(a), content="1")
+///   let c : FixedArray[Int] = [1, 2, 3]
+///   inspect(b.lexical_compare(c), content="0")
+///   let d : FixedArray[Int] = [1, 2, 4]
+///   inspect(b.lexical_compare(d), content="-1")
+/// }
+/// ```
+pub fn[T : Compare] FixedArray::lexical_compare(
+  self : FixedArray[T],
+  other : FixedArray[T],
+) -> Int {
+  self[:].lexical_compare(other[:])
+}

--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -36,6 +36,37 @@ test "compare" {
 }
 
 ///|
+test "lexical_compare" {
+  // Test equal arrays
+  let arr1 : FixedArray[Int] = [1, 2, 3]
+  let arr2 : FixedArray[Int] = [1, 2, 3]
+  inspect(arr1.lexical_compare(arr2), content="0")
+  let empty1 : FixedArray[Int] = []
+  let empty2 : FixedArray[Int] = []
+  inspect(empty1.lexical_compare(empty2), content="0")
+
+  // Test shorter is less when prefix matches
+  let short : FixedArray[Int] = [1, 2]
+  let long : FixedArray[Int] = [1, 2, 3]
+  inspect(short.lexical_compare(long), content="-1")
+  inspect(long.lexical_compare(short), content="1")
+  let one : FixedArray[Int] = [1]
+  inspect(empty1.lexical_compare(one), content="-1")
+  inspect(one.lexical_compare(empty1), content="1")
+
+  // Test element-wise comparison
+  let arr3 : FixedArray[Int] = [1, 2, 4]
+  inspect(arr1.lexical_compare(arr3), content="-1")
+  inspect(arr3.lexical_compare(arr1), content="1")
+
+  // Elements are compared before considering length
+  let a : FixedArray[Int] = [1, 3]
+  let b : FixedArray[Int] = [1, 2, 9]
+  inspect(a.lexical_compare(b), content="1")
+  inspect(b.lexical_compare(a), content="-1")
+}
+
+///|
 test "is_empty" {
   let arr : FixedArray[Int] = []
   assert_true(arr.is_empty())

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -122,6 +122,7 @@ pub fn[A] Array::iter2(Self[A]) -> Iter2[Int, A]
 pub fn[A : ToStringView] Array::join(Self[A], StringView) -> String
 pub fn[A] Array::last(Self[A]) -> A?
 pub fn[T] Array::length(Self[T]) -> Int
+pub fn[T : Compare] Array::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T] Array::make(Int, T) -> Self[T]
 pub fn[T] Array::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 pub fn[T, U] Array::map(Self[T], (T) -> U raise?) -> Self[U] raise?
@@ -214,6 +215,7 @@ pub fn[X] ArrayView::iter2(Self[X]) -> Iter2[Int, X]
 pub fn[A : ToStringView] ArrayView::join(Self[A], StringView) -> String
 pub fn[T] ArrayView::last(Self[T]) -> T?
 pub fn[T] ArrayView::length(Self[T]) -> Int
+pub fn[T : Compare] ArrayView::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
 pub fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?
 pub fn[A, B] ArrayView::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
@@ -793,6 +795,7 @@ pub fn[X] FixedArray::iter2(Self[X]) -> Iter2[Int, X]
 pub fn FixedArray::join(Self[String], StringView) -> String
 pub fn[A] FixedArray::last(Self[A]) -> A?
 pub fn[T] FixedArray::length(Self[T]) -> Int
+pub fn[T : Compare] FixedArray::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T] FixedArray::make(Int, T) -> Self[T]
 pub fn[T] FixedArray::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 pub fn[T, U] FixedArray::map(Self[T], (T) -> U raise?) -> Self[U] raise?
@@ -883,6 +886,7 @@ pub fn Bytes::iter(Bytes) -> Iter[Byte]
 #alias(iterator2, deprecated)
 pub fn Bytes::iter2(Bytes) -> Iter2[Int, Byte]
 pub fn Bytes::length(Bytes) -> Int
+pub fn Bytes::lexical_compare(Bytes, Bytes) -> Int
 pub fn Bytes::make(Int, Byte) -> Bytes
 pub fn Bytes::makei(Int, (Int) -> Byte raise?) -> Bytes raise?
 pub fn Bytes::new(Int) -> Bytes
@@ -907,6 +911,7 @@ pub fn BytesView::iter(Self) -> Iter[Byte]
 #alias(iterator2, deprecated)
 pub fn BytesView::iter2(Self) -> Iter2[Int, Byte]
 pub fn BytesView::length(Self) -> Int
+pub fn BytesView::lexical_compare(Self, Self) -> Int
 pub fn BytesView::rev_find(Self, Self) -> Int?
 pub fn BytesView::start_offset(Self) -> Int
 #alias("_[_:_]")


### PR DESCRIPTION
## Summary

- Add `lexical_compare` method to `Array`, `ArrayView`, `FixedArray`, `Bytes`, and `BytesView` types
- Unlike the `Compare` trait which uses shortlex order (comparing lengths first), `lexical_compare` compares elements first and only uses length as a tiebreaker when all compared elements match
- Similar to the existing `String::lexical_compare` method

## Test plan

- [x] Added comprehensive tests for all new methods
- [x] `moon fmt` passes
- [x] `moon test` passes (5509 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3175">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
