### PR TITLE
refactor: rename sub to view for Array, ArrayView, FixedArray, and Re…

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -236,7 +236,8 @@ pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
 /// }
 /// ```
 #alias("_[_:_]")
-pub fn[T] Array::sub(
+#alias(sub, deprecated="Use _[_:_] instead")
+pub fn[T] Array::view(
   self : Array[T],
   start? : Int = 0,
   end? : Int,
@@ -285,7 +286,8 @@ pub fn[T] Array::sub(
 /// }
 /// ```
 #alias("_[_:_]")
-pub fn[T] ArrayView::sub(
+#alias(sub, deprecated="Use _[_:_] instead")
+pub fn[T] ArrayView::view(
   self : ArrayView[T],
   start? : Int = 0,
   end? : Int,
@@ -336,7 +338,8 @@ fn[T] unsafe_cast_fixedarray_to_uninitializedarray(
 /// }
 /// ```
 #alias("_[_:_]")
-pub fn[T] FixedArray::sub(
+#alias(sub, deprecated="Use _[_:_] instead")
+pub fn[T] FixedArray::view(
   self : FixedArray[T],
   start? : Int = 0,
   end? : Int,

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -168,8 +168,6 @@ pub fn[T] Array::split(Self[T], (T) -> Bool raise?) -> Self[Self[T]] raise?
 pub fn[T : Eq] Array::starts_with(Self[T], Self[T]) -> Bool
 pub fn[T : Eq] Array::strip_prefix(Self[T], Self[T]) -> Self[T]?
 pub fn[T : Eq] Array::strip_suffix(Self[T], Self[T]) -> Self[T]?
-#alias("_[_:_]")
-pub fn[T] Array::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] Array::suffixes(Self[T], include_empty? : Bool) -> Iter[ArrayView[T]]
 pub fn[T] Array::swap(Self[T], Int, Int) -> Unit
 pub fn[A] Array::truncate(Self[A], Int) -> Unit
@@ -177,6 +175,9 @@ pub fn[A] Array::unsafe_blit_fixed(Self[A], Int, FixedArray[A], Int, Int) -> Uni
 pub fn[T] Array::unsafe_get(Self[T], Int) -> T
 pub fn[T] Array::unsafe_set(Self[T], Int, T) -> Unit
 pub fn[T1, T2] Array::unzip(Self[(T1, T2)]) -> (Self[T1], Self[T2])
+#alias("_[_:_]")
+#alias(sub, deprecated)
+pub fn[T] Array::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] Array::windows(Self[T], Int) -> Self[ArrayView[T]]
 pub fn[A, B] Array::zip(Self[A], Self[B]) -> Self[(A, B)]
 pub fn[A, B] Array::zip_to_iter2(Self[A], Self[B]) -> Iter2[A, B]
@@ -225,10 +226,11 @@ pub fn[X] ArrayView::rev_iter(Self[X]) -> Iter[X]
 pub fn[T : Eq] ArrayView::search(Self[T], T) -> Int?
 pub fn[T] ArrayView::start_offset(Self[T]) -> Int
 pub fn[T : Eq] ArrayView::starts_with(Self[T], Self[T]) -> Bool
-#alias("_[_:_]")
-pub fn[T] ArrayView::sub(Self[T], start? : Int, end? : Int) -> Self[T]
 pub fn[T] ArrayView::suffixes(Self[T], include_empty? : Bool) -> Iter[Self[T]]
 pub fn[T] ArrayView::to_array(Self[T]) -> Array[T]
+#alias("_[_:_]")
+#alias(sub, deprecated)
+pub fn[T] ArrayView::view(Self[T], start? : Int, end? : Int) -> Self[T]
 pub impl[T : Compare] Compare for ArrayView[T]
 pub impl[T : Eq] Eq for ArrayView[T]
 pub impl[A : Hash] Hash for ArrayView[A]
@@ -819,8 +821,6 @@ pub fn[T] FixedArray::sort_by(Self[T], (T, T) -> Int) -> Unit
 pub fn[T, K : Compare] FixedArray::sort_by_key(Self[T], (T) -> K) -> Unit
 pub fn[T : Compare] FixedArray::stable_sort(Self[T]) -> Unit
 pub fn[T : Eq] FixedArray::starts_with(Self[T], Self[T]) -> Bool
-#alias("_[_:_]")
-pub fn[T] FixedArray::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] FixedArray::swap(Self[T], Int, Int) -> Unit
 pub fn[A] FixedArray::unsafe_blit(Self[A], Int, Self[A], Int, Int) -> Unit
 pub fn FixedArray::unsafe_write_uint16_be(Self[Byte], Int, UInt16) -> Unit
@@ -829,6 +829,9 @@ pub fn FixedArray::unsafe_write_uint32_be(Self[Byte], Int, UInt) -> Unit
 pub fn FixedArray::unsafe_write_uint32_le(Self[Byte], Int, UInt) -> Unit
 pub fn FixedArray::unsafe_write_uint64_be(Self[Byte], Int, UInt64) -> Unit
 pub fn FixedArray::unsafe_write_uint64_le(Self[Byte], Int, UInt64) -> Unit
+#alias("_[_:_]")
+#alias(sub, deprecated)
+pub fn[T] FixedArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 
 #alias(every)
 pub fn[T] ReadOnlyArray::all(Self[T], (T) -> Bool raise?) -> Bool raise?
@@ -867,7 +870,8 @@ pub fn[A, B] ReadOnlyArray::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise
 pub fn[T : Eq] ReadOnlyArray::search(Self[T], T) -> Int?
 pub fn[T : Eq] ReadOnlyArray::starts_with(Self[T], Self[T]) -> Bool
 #alias("_[_:_]")
-pub fn[T] ReadOnlyArray::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
+#alias(sub, deprecated)
+pub fn[T] ReadOnlyArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 
 #alias("_[_]")
 pub fn Bytes::at(Bytes, Int) -> Byte

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -557,20 +557,21 @@ pub fn[T] ReadOnlyArray::binary_search_by(
 /// ```mbt check
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
-///   let view = arr.sub(start=1, end=4)
+///   let view = arr[1:4]
 ///   inspect(view[0], content="2")
 ///   inspect(view[2], content="4")
 /// }
 /// ```
 #alias("_[_:_]")
-pub fn[T] ReadOnlyArray::sub(
+#alias(sub, deprecated="Use _[_:_] instead")
+pub fn[T] ReadOnlyArray::view(
   self : ReadOnlyArray[T],
   start? : Int = 0,
   end? : Int,
 ) -> ArrayView[T] {
   match end {
-    None => self.unsafe_reinterpret_to_fixed_array().sub(start~)
-    Some(e) => self.unsafe_reinterpret_to_fixed_array().sub(start~, end=e)
+    None => self.unsafe_reinterpret_to_fixed_array()[start:]
+    Some(e) => self.unsafe_reinterpret_to_fixed_array()[start:e]
   }
 }
 


### PR DESCRIPTION
…adOnlyArray

Encourage users to use the sugar syntax `arr[start:end]` instead of calling `.sub()` directly. The `sub` name is kept as a deprecated alias.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3176">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
