### PR TITLE
feat: align MutArrayView, Bytes, and BytesView APIs

### DIFF
--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -368,7 +368,8 @@ pub fn[T] FixedArray::mut_view(
 /// * `end` : The ending index in the array (exclusive). Defaults to the
 /// length of the array.
 #alias("_[_:_]")
-pub fn[T] MutArrayView::sub(
+#alias(sub, deprecated="Use _[_:_] instead")
+pub fn[T] MutArrayView::view(
   self : MutArrayView[T],
   start? : Int = 0,
   end? : Int,

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -409,11 +409,12 @@ pub fn[T] MutArrayView::sort_by(Self[T], (T, T) -> Int) -> Unit
 pub fn[T, K : Compare] MutArrayView::sort_by_key(Self[T], (T) -> K) -> Unit
 pub fn[T : Compare] MutArrayView::stable_sort(Self[T]) -> Unit
 pub fn[T] MutArrayView::start_offset(Self[T]) -> Int
-#alias("_[_:_]")
-pub fn[T] MutArrayView::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] MutArrayView::to_array(Self[T]) -> Array[T]
 pub fn[T] MutArrayView::unsafe_get(Self[T], Int) -> T
 pub fn[T] MutArrayView::unsafe_set(Self[T], Int, T) -> Unit
+#alias("_[_:_]")
+#alias(sub, deprecated)
+pub fn[T] MutArrayView::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub impl[T : Compare] Compare for MutArrayView[T]
 pub impl[T : Eq] Eq for MutArrayView[T]
 pub impl[A : Hash] Hash for MutArrayView[A]


### PR DESCRIPTION
## Summary
- Rename `MutArrayView::sub` to `view` with deprecation alias (consistent with Array, ArrayView, FixedArray, ReadOnlyArray)
- Add `MutArrayView::is_empty`, `start_offset`, and `to_array` helpers
- Add `Bytes::is_empty` and `BytesView::is_empty`

This aligns the APIs across view types as discussed in #3068.

## Test plan
- [x] Added tests for `MutArrayView::is_empty`, `start_offset`, `to_array`
- [x] Added tests for `Bytes::is_empty` and `BytesView::is_empty`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
