### PR TITLE
fix: simplify write_iter

### DIFF
--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -163,15 +163,10 @@ pub fn[T : Show] &Logger::write_iter(
       self.write_object(x)
       self.write_string(sep)
     }
-  } else {
-    // trailing is false
-    let mut first = true
+  } else if iter.next() is Some(x) {
+    self.write_object(x)
     for x in iter {
-      if first {
-        first = false
-      } else {
-        self.write_string(sep)
-      }
+      self.write_string(sep)
       self.write_object(x)
     }
   }


### PR DESCRIPTION
When using an external iterator, it is not necessary to check whether it is the first iteration in the loop each time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3179">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
