### PR TITLE
Add blackbox test for `Array::get_view` and fix `get_view` examples

### DIFF
--- a/array/array_test.mbt
+++ b/array/array_test.mbt
@@ -18,3 +18,15 @@ test "zip_with" {
   let right = [10, 20]
   inspect(@array.zip_with(left, right, (a, b) => a + b), content="[11, 22]")
 }
+
+///|
+test "get_view" {
+  let arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
+  let start = 16
+  let end = 18
+  inspect(arr.get_view(start~), content="Some([16, 17, 18])")
+  let start = 20
+  inspect(arr.get_view(start~), content="None")
+  let start = 16
+  inspect(arr.get_view(start~, end~), content="Some([16, 17])")
+}

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -255,6 +255,48 @@ pub fn[T] Array::view(
 }
 
 ///|
+/// Creates a view of a portion of the array, returning `None` when indices are
+/// invalid.
+///
+/// Parameters:
+///
+/// * `array` : The array to create a view from.
+/// * `start` : The starting index of the view (inclusive). Defaults to 0.
+/// * `end` : The ending index of the view (exclusive). If not provided, defaults
+/// to the length of the array.
+///
+/// Returns `Some(ArrayView)` that provides a window into the specified portion
+/// of the array, or `None` when the indices are invalid.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let arr = [1, 2, 3, 4, 5]
+///   let start = 1
+///   let end = 4
+///   inspect(arr.get_view(start~, end~), content="Some([2, 3, 4])")
+///   let start = 3
+///   let end = 10
+///   inspect(arr.get_view(start~, end~), content="None")
+/// }
+/// ```
+pub fn[T] Array::get_view(
+  self : Array[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T]? {
+  let len = self.length()
+  let end = match end {
+    None => len
+    Some(end) => if end < 0 { len + end } else { end }
+  }
+  let start = if start < 0 { len + start } else { start }
+  guard start >= 0 && start <= end && end <= len else { None }
+  Some(ArrayView::make(self.buffer(), start, end - start))
+}
+
+///|
 /// Creates a new view into a portion of the array view.
 ///
 /// Parameters:
@@ -302,6 +344,50 @@ pub fn[T] ArrayView::view(
     abort("View index out of bounds")
   }
   ArrayView::make(self.buf(), self.start() + start, end - start)
+}
+
+///|
+/// Creates a new view into a portion of the array view, returning `None` when
+/// indices are invalid.
+///
+/// Parameters:
+///
+/// * `self` : The array view to create a new view from.
+/// * `start` : The starting index in the current view (inclusive). Defaults to
+/// 0.
+/// * `end` : The ending index in the current view (exclusive). Defaults to the
+/// length of the current view.
+///
+/// Returns `Some(ArrayView)` that provides a window into the specified portion
+/// of the original array view, or `None` when the indices are invalid.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let arr = [1, 2, 3, 4, 5]
+///   let view = arr[1:4] // view = [2, 3, 4]
+///   let start = 1
+///   let end = 2
+///   inspect(view.get_view(start~, end~), content="Some([3])")
+///   let start = 4
+///   let end = 5
+///   inspect(view.get_view(start~, end~), content="None")
+/// }
+/// ```
+pub fn[T] ArrayView::get_view(
+  self : ArrayView[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T]? {
+  let len = self.length()
+  let end = match end {
+    None => len
+    Some(end) => if end < 0 { len + end } else { end }
+  }
+  let start = if start < 0 { len + start } else { start }
+  guard start >= 0 && start <= end && end <= len else { None }
+  Some(ArrayView::make(self.buf(), self.start() + start, end - start))
 }
 
 ///|
@@ -357,6 +443,54 @@ pub fn[T] FixedArray::view(
     unsafe_cast_fixedarray_to_uninitializedarray(self),
     start,
     end - start,
+  )
+}
+
+///|
+/// Creates a new `ArrayView` from a `FixedArray`, returning `None` when indices
+/// are invalid.
+///
+/// Parameters:
+///
+/// * `self` : The fixed array to create a new view from.
+/// * `start` : The starting index in the array (inclusive). Defaults to 0.
+/// * `end` : The ending index in the array (exclusive). Defaults to the
+/// length of the array.
+///
+/// Returns `Some(ArrayView)` that provides a window into the specified portion
+/// of the original fixed array, or `None` when the indices are invalid.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let arr : FixedArray[Int] = [1, 2, 3, 4, 5]
+///   let start = 1
+///   let end = 4
+///   inspect(arr.get_view(start~, end~), content="Some([2, 3, 4])")
+///   let start = 2
+///   let end = 10
+///   inspect(arr.get_view(start~, end~), content="None")
+/// }
+/// ```
+pub fn[T] FixedArray::get_view(
+  self : FixedArray[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T]? {
+  let len = self.length()
+  let end = match end {
+    None => len
+    Some(end) => if end < 0 { len + end } else { end }
+  }
+  let start = if start < 0 { len + start } else { start }
+  guard start >= 0 && start <= end && end <= len else { None }
+  Some(
+    ArrayView::make(
+      unsafe_cast_fixedarray_to_uninitializedarray(self),
+      start,
+      end - start,
+    ),
   )
 }
 

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -112,6 +112,7 @@ pub fn[T] Array::from_fixed_array(FixedArray[T]) -> Self[T]
 #alias(from_iterator, deprecated)
 pub fn[T] Array::from_iter(Iter[T]) -> Self[T]
 pub fn[T] Array::get(Self[T], Int) -> T?
+pub fn[T] Array::get_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]?
 pub fn[T] Array::insert(Self[T], Int, T) -> Unit
 pub fn[T] Array::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] Array::is_sorted(Self[T]) -> Bool
@@ -207,6 +208,7 @@ pub fn[T] ArrayView::filter(Self[T], (T) -> Bool raise?) -> Array[T] raise?
 pub fn[A, B] ArrayView::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ArrayView::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 pub fn[T] ArrayView::get(Self[T], Int) -> T?
+pub fn[T] ArrayView::get_view(Self[T], start? : Int, end? : Int) -> Self[T]?
 pub fn[T] ArrayView::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] ArrayView::is_sorted(Self[T]) -> Bool
 #alias(iterator, deprecated)
@@ -810,6 +812,7 @@ pub fn[T] FixedArray::from_array(ArrayView[T]) -> Self[T]
 #alias(from_iterator, deprecated)
 pub fn[T] FixedArray::from_iter(Iter[T]) -> Self[T]
 pub fn[T] FixedArray::get(Self[T], Int) -> T?
+pub fn[T] FixedArray::get_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]?
 pub fn[T] FixedArray::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] FixedArray::is_sorted(Self[T]) -> Bool
 #alias(iterator, deprecated)
@@ -873,6 +876,7 @@ pub fn[T] ReadOnlyArray::from_array(ArrayView[T]) -> Self[T]
 #alias(from_iterator, deprecated)
 pub fn[T] ReadOnlyArray::from_iter(Iter[T]) -> Self[T]
 pub fn[T] ReadOnlyArray::get(Self[T], Int) -> T?
+pub fn[T] ReadOnlyArray::get_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]?
 pub fn[T] ReadOnlyArray::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] ReadOnlyArray::is_sorted(Self[T]) -> Bool
 #alias(iterator, deprecated)

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -576,6 +576,33 @@ pub fn[T] ReadOnlyArray::view(
 }
 
 ///|
+/// Creates a view of a subarray, returning `None` when indices are invalid.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+///   let start = 1
+///   let end = 4
+///   inspect(arr.get_view(start~, end~), content="Some([2, 3, 4])")
+///   let start = 4
+///   let end = 10
+///   inspect(arr.get_view(start~, end~), content="None")
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::get_view(
+  self : ReadOnlyArray[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T]? {
+  let fixed = self.unsafe_reinterpret_to_fixed_array()
+  match end {
+    None => fixed.get_view(start~)
+    Some(end) => fixed.get_view(start~, end~)
+  }
+}
+
+///|
 /// Joins string elements with a separator.
 ///
 /// # Example


### PR DESCRIPTION
### Motivation

- Provide a safe, non-panicking `get_view` API and ensure examples/tests use the correct labeled optional-argument syntax so callers can safely request sub-views (including out-of-range checks).

### Description

- Implemented optional `get_view` helpers for `Array`, `ArrayView`, `FixedArray`, and `ReadOnlyArray` that return `ArrayView[T]?` on invalid bounds (files: `builtin/arrayview.mbt`, `builtin/readonlyarray.mbt`).
- Added a blackbox test `test "get_view"` in `array/array_test.mbt` that exercises `arr.get_view(start~)`, `arr.get_view(start~, end~)` and an out-of-bounds case to validate behavior when selecting `arr.get_view(16)` / `arr.get_view(20)` / `arr.get_view(16, 18)`.
- Updated documentation examples in `builtin/arrayview.mbt` and `builtin/readonlyarray.mbt` to use labeled optional-argument invocation (e.g. `start~`, `end~`) and to use local `start`/`end` variables in examples so doctests parse correctly.
- Regenerated package interface entries so the new `get_view` APIs are exported (`builtin/pkg.generated.mbti`).

### Testing

- Ran `moon info && moon fmt` and it completed successfully.
- Ran `moon test array` and the array package tests passed (`Total tests: 10, passed: 10, failed: 0`).
- Ran full `moon test` and the entire test suite passed (`Total tests: 5609, passed: 5609, failed: 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb8c3dec08320b190d8f6e8baa0b8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3191">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
