### PR TITLE
Add encoding/ascii package with encode/decode and tests

### DIFF
--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -1,0 +1,54 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub suberror Malformed {
+  Malformed(BytesView)
+}
+
+///|
+/// Decodes an ASCII byte array into a string.
+///
+/// Raises `Malformed` if any byte is outside the ASCII range.
+pub fn decode(bytes : BytesView) -> String raise Malformed {
+  let t : FixedArray[Byte] = FixedArray::make(bytes.length() * 2, 0)
+  let tlen = loop (0, bytes) {
+    (tlen, []) => tlen
+    (tlen, [0..=0x7F as b, .. rest]) => {
+      t.unsafe_set(tlen, b)
+      continue (tlen + 2, rest)
+    }
+    (_, _ as bytes) => raise Malformed(bytes)
+  }
+  t.unsafe_reinterpret_as_bytes().to_unchecked_string(offset=0, length=tlen)
+}
+
+///|
+/// Decodes ASCII bytes into a string, replacing non-ASCII bytes with U+FFFD.
+pub fn decode_lossy(bytes : BytesView) -> String {
+  let t : FixedArray[Byte] = FixedArray::make(bytes.length() * 2, 0)
+  let tlen = loop (0, bytes) {
+    (tlen, []) => tlen
+    (tlen, [0..=0x7F as b, .. rest]) => {
+      t.unsafe_set(tlen, b)
+      continue (tlen + 2, rest)
+    }
+    (tlen, [_, .. rest]) => {
+      t.unsafe_set(tlen, 0xFD)
+      t.unsafe_set(tlen + 1, 0xFF)
+      continue (tlen + 2, rest)
+    }
+  }
+  t.unsafe_reinterpret_as_bytes().to_unchecked_string(offset=0, length=tlen)
+}

--- a/encoding/ascii/decode_test.mbt
+++ b/encoding/ascii/decode_test.mbt
@@ -1,0 +1,42 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "decoding ASCII bytes" {
+  let text = b"MoonBit"
+  inspect(@ascii.decode(text), content="MoonBit")
+}
+
+///|
+test "decoding ASCII invalid bytes" {
+  let bytes = b"ok\xffmore"
+  try {
+    let _ = @ascii.decode(bytes)
+    panic()
+  } catch {
+    Malformed(e) =>
+      inspect(
+        e,
+        content=(
+          #|b"\xffmore"
+        ),
+      )
+  }
+}
+
+///|
+test "decode_lossy replaces invalid bytes" {
+  let bytes = b"ok\xffmore"
+  inspect(@ascii.decode_lossy(bytes), content="ok�more")
+}

--- a/encoding/ascii/encode.mbt
+++ b/encoding/ascii/encode.mbt
@@ -1,0 +1,30 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Encodes a string into an ASCII byte array.
+///
+/// Panics if the string contains any non-ASCII code units.
+pub fn encode(str : StringView) -> Bytes {
+  let length = str.length()
+  let arr = FixedArray::make(length, b'\x00')
+  for i in 0..<length {
+    let code_unit = str.code_unit_at(i)
+    if code_unit > 0x7F {
+      panic()
+    }
+    arr[i] = code_unit.to_byte()
+  }
+  arr.unsafe_reinterpret_as_bytes()
+}

--- a/encoding/ascii/encode_test.mbt
+++ b/encoding/ascii/encode_test.mbt
@@ -1,0 +1,25 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "encode" {
+  let s = "Hello, ASCII!"
+  let encoded = @ascii.encode(s)
+  inspect(
+    encoded,
+    content=(
+      #|b"Hello, ASCII!"
+    ),
+  )
+}

--- a/encoding/ascii/moon.pkg
+++ b/encoding/ascii/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "moonbitlang/core/builtin",
+}

--- a/encoding/ascii/pkg.generated.mbti
+++ b/encoding/ascii/pkg.generated.mbti
@@ -1,0 +1,21 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/encoding/ascii"
+
+// Values
+pub fn decode(BytesView) -> String raise Malformed
+
+pub fn decode_lossy(BytesView) -> String
+
+pub fn encode(StringView) -> Bytes
+
+// Errors
+pub suberror Malformed {
+  Malformed(BytesView)
+}
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
### Motivation

- Provide a small `encoding/ascii` package to encode/decode ASCII data with an API consistent with the existing `encoding/utf8` and `encoding/utf16` packages.
- Offer both strict and lossy decoding behavior and document the expected semantics for invalid bytes.

### Description

- Added new package `encoding/ascii` with the files `encode.mbt`, `decode.mbt`, `encode_test.mbt`, `decode_test.mbt`, `moon.pkg`, and generated `pkg.generated.mbti`.
- Implemented `pub fn encode(StringView) -> Bytes` which panics on non-ASCII code units and `pub fn decode(BytesView) -> String raise Malformed` which raises `Malformed(BytesView)` on invalid bytes.
- Implemented `pub fn decode_lossy(BytesView) -> String` which replaces non-ASCII bytes with U+FFFD (replacement character) to match the lossy behavior of the UTF encoders/decoders.
- Added concise documentation comments in the new files and updated the package interface via `moon info`.

### Testing

- Ran `moon info` to regenerate package interfaces and it completed successfully.
- Ran `moon fmt` to format sources and it completed successfully.
- Ran `moon test` and the full test suite completed successfully with `Total tests: 5618, passed: 5618, failed: 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fee252aa08320a8f6df990498351f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
