### PR TITLE
Add BytesView constructors and unchecked string conversion

### DIFF
--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -626,6 +626,31 @@ pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
 }
 
 ///|
+/// Creates a new bytes view from a byte array.
+///
+/// Parameters:
+///
+/// * `array` : An array of bytes to be converted.
+///
+/// Returns a bytes view containing the same bytes as the input array.
+pub fn BytesView::from_array(arr : ArrayView[Byte]) -> BytesView {
+  Bytes::from_array(arr)[:]
+}
+
+///|
+/// Creates a new bytes view from an iterator of bytes.
+///
+/// Parameters:
+///
+/// * `iterator` : An iterator that yields bytes.
+///
+/// Returns a bytes view containing all the bytes from the iterator.
+#alias(from_iterator, deprecated)
+pub fn BytesView::from_iter(iter : Iter[Byte]) -> BytesView {
+  Bytes::from_iter(iter)[:]
+}
+
+///|
 /// Retrieves the underlying `Bytes` from a `View`.
 pub fn BytesView::data(self : BytesView) -> Bytes {
   self.bytes()
@@ -646,6 +671,24 @@ pub fn BytesView::to_bytes(self : BytesView) -> Bytes {
   let bytes = FixedArray::make(self.length(), (0 : Byte))
   bytes.blit_from_bytes(0, self.bytes(), self.start_offset(), self.length())
   unsafe_to_bytes(bytes)
+}
+
+///|
+/// Return an unchecked string, containing the subsequence of `self` that starts at
+/// `offset` and has length `length`. Both `offset` and `length`
+/// are indexed by byte.
+///
+/// Note this function does not validate the encoding of the byte sequence,
+/// it simply copy the bytes into a new String.
+pub fn BytesView::to_unchecked_string(
+  self : BytesView,
+  offset? : Int = 0,
+  length? : Int,
+) -> String {
+  let len = self.length()
+  let length = if length is Some(l) { l } else { len - offset }
+  guard offset >= 0 && length >= 0 && offset + length <= len
+  self.data().to_unchecked_string(offset=self.start_offset() + offset, length~)
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -944,6 +944,9 @@ pub fn BytesView::chop_prefix(Self, Self) -> Self?
 pub fn BytesView::chop_suffix(Self, Self) -> Self?
 pub fn BytesView::data(Self) -> Bytes
 pub fn BytesView::find(Self, Self) -> Int?
+pub fn BytesView::from_array(ArrayView[Byte]) -> Self
+#alias(from_iterator, deprecated)
+pub fn BytesView::from_iter(Iter[Byte]) -> Self
 pub fn BytesView::get(Self, Int) -> Byte?
 pub fn BytesView::has_prefix(Self, Self) -> Bool
 pub fn BytesView::has_suffix(Self, Self) -> Bool
@@ -959,6 +962,7 @@ pub fn BytesView::start_offset(Self) -> Int
 pub fn BytesView::to_array(Self) -> Array[Byte]
 pub fn BytesView::to_bytes(Self) -> Bytes
 pub fn BytesView::to_fixedarray(Self) -> FixedArray[Byte]
+pub fn BytesView::to_unchecked_string(Self, offset? : Int, length? : Int) -> String
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn BytesView::view(Self, start? : Int, end? : Int) -> Self


### PR DESCRIPTION
### Motivation
- Align `BytesView` API with `Bytes` by providing constructors and the unchecked string helper that mirror `Bytes` counterparts.
- Expose the new `BytesView` helpers in the builtins interface so external code can use them without workarounds.

### Description
- Added `BytesView::from_array(ArrayView[Byte]) -> BytesView` to construct a view from an array by delegating to `Bytes::from_array(... )[:]`.
- Added `BytesView::from_iter(Iter[Byte]) -> BytesView` (declared with `#alias(from_iterator, deprecated)`) to construct a view from an iterator by delegating to `Bytes::from_iter(... )[:]`.
- Added `BytesView::to_unchecked_string(self, offset? : Int, length? : Int) -> String` which delegates to `Bytes::to_unchecked_string` using the view start offset and validates bounds.
- Regenerated the builtin package interface (`pkg.generated.mbti`) so the new `BytesView` APIs are published.

### Testing
- Ran `moon info` which completed successfully and updated the generated interface without errors.
- Ran `moon fmt` which completed successfully and formatted the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a1eb0ab88320a5f133166c5dfb1b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
