### PR TITLE
fix warnings in nightly

### DIFF
--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -52,7 +52,7 @@ test "take" {
   inspect(exb, content="123")
   // normal take
   let evaluated = []
-  let collected = (1).until(20).tap(evaluated.push(_)).take(10).collect()
+  let collected = (1).until(20).tap(x => evaluated.push(x)).take(10).collect()
   inspect(collected, content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]")
   inspect(evaluated, content="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]")
   // take with concat
@@ -281,7 +281,7 @@ test "filter_map" {
   inspect(r1, content="[3, 4, 5]")
   let r2 : Array[Unit] = arr.iter().filter_map(_x => None).collect()
   inspect(r2, content="[]")
-  let r3 : Array[Unit] = [].iter().filter_map(Option::Some(_)).collect()
+  let r3 : Array[Unit] = [].iter().filter_map(x => Some(x)).collect()
   inspect(r3, content="[]")
   // Test using next() directly to ensure the closure is executed
   let it1 = [1, 2, 3, 4, 5]

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -67,7 +67,7 @@ pub impl[X : Show] Show for Iter[X] with output(self, logger) {
 
 ///|
 pub impl[X : ToJson] ToJson for Iter[X] with to_json(self) {
-  Json::array(self.map(_.to_json()).collect())
+  Json::array(self.map(x => x.to_json()).collect())
 }
 
 ///|

--- a/builtin/option_test.mbt
+++ b/builtin/option_test.mbt
@@ -53,10 +53,10 @@ test "compare default iter" {
   let default_opt : Int? = Default::default()
   inspect(default_opt, content="None")
   let iter_values = []
-  (Some(3) : Int?).iter().each(iter_values.push(_))
+  (Some(3) : Int?).iter().each(x => iter_values.push(x))
   inspect(iter_values, content="[3]")
   let iter_empty = []
-  (None : Int?).iter().each(iter_empty.push(_))
+  (None : Int?).iter().each(x => iter_empty.push(x))
   inspect(iter_empty, content="[]")
 }
 

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1445,7 +1445,7 @@ test "View::to_lower" {
 /// Converts this string to uppercase.
 pub fn StringView::to_upper(self : StringView) -> StringView {
   // TODO: deal with non-ascii characters
-  guard self.find_by(_.is_ascii_lowercase()) is Some(idx) else { return self }
+  guard self.find_by(Char::is_ascii_lowercase) is Some(idx) else { return self }
   let buf = StringBuilder::new(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
@@ -1463,7 +1463,7 @@ pub fn StringView::to_upper(self : StringView) -> StringView {
 /// Converts this string to uppercase.
 pub fn String::to_upper(self : String) -> String {
   // TODO: deal with non-ascii characters
-  guard self.find_by(_.is_ascii_lowercase()) is Some(idx) else { return self }
+  guard self.find_by(Char::is_ascii_lowercase) is Some(idx) else { return self }
   let buf = StringBuilder::new(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())

--- a/bytes/feature_pipe_test.mbt
+++ b/bytes/feature_pipe_test.mbt
@@ -18,8 +18,8 @@ test "feature pipe" {
   let mut u = Bytes::new(b.length())
   let v = b
     |> tap(x => u = x)
-    |> _.length() // test _.length()
-    |> _.to_int64() // test _.to_int()
+    |> Bytes::length() // test _.length()
+    |> Int::to_int64() // test _.to_int()
   inspect(v, content="5")
   inspect(
     b,

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -1033,7 +1033,7 @@ test "deque retain_map" {
   @json.json_inspect(
     dq()
     |> x => {
-      x.retain_map(Option::Some(_))
+      x.retain_map(x => Some(x))
       x.as_views()
     },
     content=[[4, 5, 6], [7, 8]],

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -259,7 +259,7 @@ pub fn[K : Eq] HashSet::intersection(
       (Leaf(key1, bucket1), Leaf(key2, bucket2)) => {
         let keys1 = bucket1.add(key1)
         let keys2 = bucket2.add(key2)
-        match keys1.filter(keys2.contains(_)) {
+        match keys1.filter(k => keys2.contains(k)) {
           Empty => None
           More(head, tail~) => Some(Leaf(head, tail))
         }
@@ -434,7 +434,7 @@ impl[A : Eq] Eq for Node[A] with equal(self, other) {
       {
         let keys1 = xs.add(x)
         let keys2 = ys.add(y)
-        keys1.iter().all(keys2.contains(_))
+        keys1.iter().all(k => keys2.contains(k))
       }
     (Flat(x, pathx), Flat(y, pathy)) => pathx == pathy && x == y
     (Branch(xs), Branch(ys)) => xs == ys

--- a/json/json_encode_decode_test.mbt
+++ b/json/json_encode_decode_test.mbt
@@ -29,8 +29,8 @@ fn AllThree::to_json(self : AllThree) -> Json {
   let { ints, floats, strings } = self
   {
     "ints": ints |> array_to_json(f=x => Json::number(x.to_double())),
-    "floats": floats |> array_to_json(f=Json::number(_)),
-    "strings": strings |> array_to_json(f=Json::string(_)),
+    "floats": floats |> array_to_json(f=x => Json::number(x)),
+    "strings": strings |> array_to_json(f=s => Json::string(s)),
   }
 }
 

--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -50,12 +50,12 @@ fn ParseContext::lex_value(
       match ctx.read_char() {
         Some('0') => {
           let (n, repr) = ctx.lex_zero(start=ctx.offset - 2)
-          return Number(n, repr.map(_.to_string()))
+          return Number(n, repr.map(repr => repr.to_string()))
         }
         Some(c2) => {
           if c2 is ('1'..='9') {
             let (n, repr) = ctx.lex_decimal_integer(start=ctx.offset - 2)
-            return Number(n, repr.map(_.to_string()))
+            return Number(n, repr.map(repr => repr.to_string()))
           }
           ctx.invalid_char(shift=-1)
         }
@@ -63,11 +63,11 @@ fn ParseContext::lex_value(
       }
     Some('0') => {
       let (n, repr) = ctx.lex_zero(start=ctx.offset - 1)
-      return Number(n, repr.map(_.to_string()))
+      return Number(n, repr.map(repr => repr.to_string()))
     }
     Some('1'..='9') => {
       let (n, repr) = ctx.lex_decimal_integer(start=ctx.offset - 1)
-      return Number(n, repr.map(_.to_string()))
+      return Number(n, repr.map(repr => repr.to_string()))
     }
     Some('"') => {
       let s = ctx.lex_string()

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -23,7 +23,7 @@ test "from_array" {
 ///|
 test "pipe" {
   debug_inspect(
-    1 |> @list.List::prepend(@list.empty(), _),
+    1 |> x => { @list.List::prepend(@list.empty(), x) },
     content="<List: [1]>",
   )
 }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -579,11 +579,11 @@ test "String::fold" {
   let s = "this is a long string"
   inspect(s.fold(init=0, (acc, c) => acc + c.to_int()), content="1980")
   inspect(
-    s.fold(init=@list.empty(), _.prepend(_)).rev(),
+    s.fold(init=@list.empty(), (acc, x) => acc.prepend(x)).rev(),
     content="@list.from_array(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
   inspect(
-    s.rev_fold(init=@list.empty(), _.prepend(_)),
+    s.rev_fold(init=@list.empty(), (acc, x) => acc.prepend(x)),
     content="@list.from_array(['t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g'])",
   )
 }

--- a/unit/README.mbt.md
+++ b/unit/README.mbt.md
@@ -101,7 +101,7 @@ test "generic unit usage" {
   let items = [1, 2, 3, 4, 5]
 
   // Process for side effects only
-  items.each(fn(x) {
+  items.each(x => {
     // Side effect: processing each item
     let processed = x * 2
     assert_true(processed > 0) // Simulated processing validation


### PR DESCRIPTION
Fix compiler warnings in nightly. There are mainly two changes:

1. effect inference is deprecated for `fn`: if a `fn` may raise error or perform async operation in its body, it should be annotated with its effect. Arrow functions are not affected, so for callback functions users can just replace `fn` with arrow function to fix the warning
2. the partial application syntax is deprecated due to visual ambiguity (i.e. where's the boundary of the anonymous function)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3203">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
