### PR TITLE
refactor: set seed for hash-dos

### DIFF
--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -72,30 +72,51 @@ struct Hasher {
 ///   inspect(h1.finalize() != h2.finalize(), content="true") // Different seeds produce different hashes
 /// }
 /// ```
-pub fn Hasher::new(seed? : Int = seed) -> Hasher {
+pub fn Hasher::new(seed? : Int = get_hash_seed()) -> Hasher {
   { acc: seed.reinterpret_as_uint() + GPRIME5 }
 }
 
 ///|
-#cfg(not(target="js"))
-let seed : Int = 0
+let global_hash_seed : Ref[Int] = { val: 0 }
 
 ///|
-#cfg(target="js")
-let seed : Int = random_seed()
+let hash_seed_counter : Ref[UInt64] = { val: 0UL }
 
 ///|
-#cfg(target="js")
-extern "js" fn random_seed() -> Int =
-  #|() => {
-  #|  if (globalThis.crypto?.getRandomValues) {
-  #|    const array = new Uint32Array(1);
-  #|    globalThis.crypto.getRandomValues(array);
-  #|    return array[0] | 0; // Convert to signed 32
-  #|  } else {
-  #|    return Math.floor(Math.random() * 0x100000000) | 0; // Fallback to Math.random
-  #|  }
-  #|}
+fn get_hash_seed() -> Int {
+  global_hash_seed.val
+}
+
+///|
+pub fn set_hash_seed(seed : Int) -> Unit {
+  global_hash_seed.val = seed
+  hash_seed_counter.val = 0UL
+}
+
+///|
+fn next_hash_seed() -> Int {
+  hash_seed_counter.val += 1UL
+  let state = splitmix64(
+    global_hash_seed.val.reinterpret_as_uint().to_uint64() +
+    hash_seed_counter.val,
+  )
+  (state ^ (state >> 32)).to_uint().reinterpret_as_int()
+}
+
+///|
+fn[T : Hash] hash_with_seed(value : T, seed : Int) -> Int {
+  let hasher = Hasher::new(seed~)
+  hasher.combine(value)
+  hasher.finalize()
+}
+
+///|
+fn splitmix64(state : UInt64) -> UInt64 {
+  let mut z = state + 0x9E3779B97F4A7C15UL
+  z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL
+  z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL
+  z ^ (z >> 31)
+}
 
 ///|
 /// Combines a hashable value with the current state of the hasher. This is

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -264,3 +264,16 @@ test "hash_combine for UInt" {
   Hash::hash_combine(value, hasher)
   inspect(hasher.finalize(), content="1161967057")
 }
+
+///|
+test "set_hash_seed changes default Hash::hash seed" {
+  set_hash_seed(0)
+  let h0 = Hash::hash("moonbit")
+  set_hash_seed(2026)
+  let h1 = Hash::hash("moonbit")
+  let hasher = Hasher::new(seed=2026)
+  hasher.combine("moonbit")
+  inspect(h0 == h1, content="false")
+  inspect(h1 == hasher.finalize(), content="true")
+  set_hash_seed(0)
+}

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -44,6 +44,7 @@ struct Map[K, V] {
   mut capacity : Int // current capacity
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx
   mut grow_at : Int // threshold that triggers grow
+  mut hash_seed : Int
   mut head : Entry[K, V]? // head of linked list
   mut tail : Int // tail of linked list
 }
@@ -61,6 +62,7 @@ pub fn[K, V] Map::new(capacity? : Int = 8) -> Map[K, V] {
     capacity,
     capacity_mask: capacity - 1,
     grow_at: calc_grow_threshold(capacity),
+    hash_seed: next_hash_seed(),
     entries: FixedArray::make(capacity, None),
     head: None,
     tail: -1,
@@ -106,7 +108,12 @@ pub fn[K : Hash + Eq, V] Map::from_array(arr : ArrayView[(K, V)]) -> Map[K, V] {
 /// ```
 #alias("_[_]=_")
 pub fn[K : Hash + Eq, V] Map::set(self : Map[K, V], key : K, value : V) -> Unit {
-  self.set_with_hash(key, value, key.hash())
+  self.set_with_hash(key, value, self.key_hash(key))
+}
+
+///|
+fn[K : Hash, V] Map::key_hash(self : Map[K, V], key : K) -> Int {
+  hash_with_seed(key, self.hash_seed)
 }
 
 ///|
@@ -214,7 +221,7 @@ fn[K, V] Map::set_entry(
 /// }
 /// ```
 pub fn[K : Hash + Eq, V] Map::get(self : Map[K, V], key : K) -> V? {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && entry.key == key {
@@ -230,7 +237,7 @@ pub fn[K : Hash + Eq, V] Map::get(self : Map[K, V], key : K) -> V? {
 ///|
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] Map::at(self : Map[K, V], key : K) -> V {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry)
     if entry.hash == hash && entry.key == key {
@@ -269,7 +276,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_default(
   key : K,
   default : V,
 ) -> V {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
       Some(entry) => {
@@ -293,7 +300,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
   key : K,
   default : () -> V,
 ) -> V {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
     match self.entries[idx] {
@@ -338,7 +345,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 /// Check if the hash map contains a key.
 pub fn[K : Hash + Eq, V] Map::contains(self : Map[K, V], key : K) -> Bool {
   // inline Map::get to avoid boxing
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
@@ -379,7 +386,7 @@ pub fn[K : Hash + Eq, V : Eq] Map::contains_kv(
   value : V,
 ) -> Bool {
   // inline Map::get to avoid boxing
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key && entry.value == value {
@@ -414,7 +421,7 @@ pub fn[K : Hash + Eq, V : Eq] Map::contains_kv(
 /// }
 /// ```
 pub fn[K : Hash + Eq, V] Map::remove(self : Map[K, V], key : K) -> Unit {
-  self.remove_with_hash(key, key.hash())
+  self.remove_with_hash(key, self.key_hash(key))
 }
 
 ///|
@@ -492,6 +499,29 @@ fn[K : Eq, V] Map::grow(self : Map[K, V]) -> Unit {
   loop old_head {
     Some({ next, key, value, hash, .. }) => {
       self.set_with_hash(key, value, hash)
+      continue next
+    }
+    None => break
+  }
+}
+
+///|
+pub fn[K : Hash + Eq, V] Map::rehash_with_seed(
+  self : Map[K, V],
+  seed : Int,
+) -> Unit {
+  if self.hash_seed == seed {
+    return
+  }
+  let old_head = self.head
+  self.entries = FixedArray::make(self.capacity, None)
+  self.size = 0
+  self.head = None
+  self.tail = -1
+  self.hash_seed = seed
+  loop old_head {
+    Some({ next, key, value, .. }) => {
+      self.set_with_hash(key, value, self.key_hash(key))
       continue next
     }
     None => break
@@ -656,7 +686,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with equal(
   guard self.size == that.size else { return false }
   for k, v in self {
     guard that.contains_kv(k, v) else { return false }
-  } else {
+  } nobreak {
     true
   }
 }
@@ -702,6 +732,7 @@ pub fn[K, V, V2] Map::map(self : Map[K, V], f : (K, V) -> V2) -> Map[K, V2] {
     size: self.size,
     capacity_mask: self.capacity_mask,
     grow_at: self.grow_at,
+    hash_seed: self.hash_seed,
     head: None,
     tail: self.tail,
   }
@@ -734,6 +765,7 @@ pub fn[K, V] Map::copy(self : Map[K, V]) -> Map[K, V] {
     size: self.size,
     capacity_mask: self.capacity_mask,
     grow_at: self.grow_at,
+    hash_seed: self.hash_seed,
     head: None,
     tail: self.tail,
   }
@@ -781,7 +813,10 @@ pub fn[K, V] Map::copy(self : Map[K, V]) -> Map[K, V] {
 ///   @json.json_inspect(merged, content={ "a": 1, "b": 3, "c": 4 })
 /// }
 /// ```
-pub fn[K : Eq, V] Map::merge(self : Map[K, V], other : Map[K, V]) -> Map[K, V] {
+pub fn[K : Hash + Eq, V] Map::merge(
+  self : Map[K, V],
+  other : Map[K, V],
+) -> Map[K, V] {
   let result = self.copy()
   result.merge_in_place(other)
   result
@@ -811,7 +846,7 @@ pub fn[K : Eq, V] Map::merge(self : Map[K, V], other : Map[K, V]) -> Map[K, V] {
 ///   @json.json_inspect(map1, content={ "a": 1, "b": 3, "c": 4 })
 /// }
 /// ```
-pub fn[K : Eq, V] Map::merge_in_place(
+pub fn[K : Hash + Eq, V] Map::merge_in_place(
   self : Map[K, V],
   other : Map[K, V],
 ) -> Unit {
@@ -819,8 +854,8 @@ pub fn[K : Eq, V] Map::merge_in_place(
     return
   }
   loop other.head {
-    Some({ key, value, next, hash, .. }) => {
-      self.set_with_hash(key, value, hash)
+    Some({ key, value, next, .. }) => {
+      self.set_with_hash(key, value, self.key_hash(key))
       continue next
     }
     None => break
@@ -945,7 +980,7 @@ pub fn[K : Hash + Eq, V] Map::update(
   key : K,
   f : (V?) -> V?,
 ) -> Unit {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
     match self.entries[idx] {
@@ -1051,7 +1086,7 @@ fn BytesView::equal_to_bytes(self : Self, other : Bytes) -> Bool {
 /// }
 /// ```
 pub fn[V] Map::get_from_bytes(map : Self[Bytes, V], key : BytesView) -> V? {
-  let hash = key.hash()
+  let hash = hash_with_seed(key, map.hash_seed)
   for i = 0, idx = hash & map.capacity_mask {
     guard map.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_bytes(entry.key) {
@@ -1088,7 +1123,7 @@ pub fn[V] Map::get_from_bytes(map : Self[Bytes, V], key : BytesView) -> V? {
 /// }
 /// ```
 pub fn[V] Map::get_from_string(map : Self[String, V], key : StringView) -> V? {
-  let hash = key.hash()
+  let hash = hash_with_seed(key, map.hash_seed)
   for i = 0, idx = hash & map.capacity_mask {
     guard map.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_string(entry.key) {

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -661,3 +661,20 @@ test "Map::set updating existing key should not grow" {
     assert_eq(map.get(i.to_string()), Some(i * 10))
   }
 }
+
+///|
+test "Map merge and rehash across different seeds" {
+  set_hash_seed(1)
+  let map1 : Map[String, Int] = {}
+  map1.set("a", 1)
+  set_hash_seed(2)
+  let map2 : Map[String, Int] = {}
+  map2.set("b", 2)
+  map1.merge_in_place(map2)
+  inspect(map1.get("a"), content="Some(1)")
+  inspect(map1.get("b"), content="Some(2)")
+  map1.rehash_with_seed(999)
+  inspect(map1.get("a"), content="Some(1)")
+  inspect(map1.get("b"), content="Some(2)")
+  set_hash_seed(0)
+}

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -546,7 +546,7 @@ test "remove_entry_head" {
   assert_eq(head.prev, -1)
   assert_true(head.next is None)
   assert_eq(head.psl, 0)
-  assert_eq(head.hash, (2).hash())
+  assert_eq(head.hash, map.key_hash(2))
   assert_eq(head.key, 2)
   assert_eq(head.value, 2)
 }
@@ -564,7 +564,7 @@ test "remove_entry_tail" {
   assert_eq(tail.prev, -1)
   assert_true(tail.next is None)
   assert_eq(tail.psl, 0)
-  assert_eq(tail.hash, (1).hash())
+  assert_eq(tail.hash, map.key_hash(1))
   assert_eq(tail.key, 1)
   assert_eq(tail.value, 1)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -43,6 +43,8 @@ pub fn[T : Show] println(T) -> Unit
 
 pub fn[T : Show] repr(T) -> String
 
+pub fn set_hash_seed(Int) -> Unit
+
 // Errors
 pub(all) suberror BenchError {
   BenchError(String)
@@ -377,10 +379,11 @@ pub fn[K, V] Map::keys(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 pub fn[K, V] Map::length(Self[K, V]) -> Int
 pub fn[K, V, V2] Map::map(Self[K, V], (K, V) -> V2) -> Self[K, V2]
-pub fn[K : Eq, V] Map::merge(Self[K, V], Self[K, V]) -> Self[K, V]
-pub fn[K : Eq, V] Map::merge_in_place(Self[K, V], Self[K, V]) -> Unit
+pub fn[K : Hash + Eq, V] Map::merge(Self[K, V], Self[K, V]) -> Self[K, V]
+pub fn[K : Hash + Eq, V] Map::merge_in_place(Self[K, V], Self[K, V]) -> Unit
 pub fn[K, V] Map::new(capacity? : Int) -> Self[K, V]
 pub fn[K : Hash + Eq, V] Map::of(FixedArray[(K, V)]) -> Self[K, V]
+pub fn[K : Hash + Eq, V] Map::rehash_with_seed(Self[K, V], Int) -> Unit
 pub fn[K : Hash + Eq, V] Map::remove(Self[K, V], K) -> Unit
 pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit
 #alias("_[_]=_")

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -42,7 +42,19 @@ pub fn[K, V] HashMap::new(capacity? : Int = 8) -> HashMap[K, V] {
     capacity,
     entries: FixedArray::make(capacity, None),
     capacity_mask: capacity - 1,
+    hash_seed: next_hash_seed(),
   }
+}
+
+///|
+let hash_seed_counter : Ref[UInt64] = { val: 0UL }
+
+///|
+fn next_hash_seed() -> Int {
+  hash_seed_counter.val += 1UL
+  let h = Hasher::new()
+  h.combine_uint64(hash_seed_counter.val)
+  h.finalize()
 }
 
 ///|
@@ -106,7 +118,14 @@ pub fn[K : Hash + Eq, V] HashMap::set(
   key : K,
   value : V,
 ) -> Unit {
-  self.set_with_hash(key, value, key.hash())
+  self.set_with_hash(key, value, self.key_hash(key))
+}
+
+///|
+fn[K : Hash, V] HashMap::key_hash(self : HashMap[K, V], key : K) -> Int {
+  let h = Hasher::new(seed=self.hash_seed)
+  h.combine(key)
+  h.finalize()
 }
 
 ///|
@@ -204,7 +223,7 @@ fn[K, V] HashMap::push_away(
 /// ```
 pub fn[K : Hash + Eq, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
   // self.get_with_hash(key, key.hash())
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && entry.key == key {
@@ -237,7 +256,7 @@ pub fn[K : Hash + Eq, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
 /// ```
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry)
     if entry.hash == hash && entry.key == key {
@@ -278,7 +297,7 @@ pub fn[K : Hash + Eq, V] HashMap::get_or_init(
   key : K,
   init : () -> V,
 ) -> V {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
     match self.entries[idx] {
@@ -340,7 +359,7 @@ pub fn[K : Hash + Eq, V] HashMap::get_or_default(
   key : K,
   default : V,
 ) -> V {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break default }
     if entry.hash == hash && entry.key == key {
@@ -376,7 +395,7 @@ pub fn[K : Hash + Eq, V] HashMap::contains(
   self : HashMap[K, V],
   key : K,
 ) -> Bool {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { return false }
     if entry.hash == hash && entry.key == key {
@@ -418,7 +437,7 @@ pub fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(
   key : K,
   value : V,
 ) -> Bool {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { return false }
     if entry.hash == hash && entry.key == key && entry.value == value {
@@ -453,7 +472,7 @@ pub fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(
 /// }
 /// ```
 pub fn[K : Hash + Eq, V] HashMap::remove(self : HashMap[K, V], key : K) -> Unit {
-  self.remove_with_hash(key, key.hash())
+  self.remove_with_hash(key, self.key_hash(key))
 }
 
 ///|
@@ -504,6 +523,25 @@ fn[K : Eq, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
   for i in 0..<old_entries.length() {
     if old_entries[i] is Some({ key, value, hash, .. }) {
       self.set_with_hash(key, value, hash)
+    }
+  }
+}
+
+///|
+pub fn[K : Hash + Eq, V] HashMap::rehash_with_seed(
+  self : HashMap[K, V],
+  seed : Int,
+) -> Unit {
+  if self.hash_seed == seed {
+    return
+  }
+  let old_entries = self.entries
+  self.entries = FixedArray::make(self.capacity, None)
+  self.size = 0
+  self.hash_seed = seed
+  for i in 0..<old_entries.length() {
+    if old_entries[i] is Some({ key, value, .. }) {
+      self.set_with_hash(key, value, self.key_hash(key))
     }
   }
 }
@@ -577,6 +615,7 @@ pub fn[K, V, V2] HashMap::map(
     entries: FixedArray::make(self.capacity, None),
     size: self.size,
     capacity_mask: self.capacity_mask,
+    hash_seed: self.hash_seed,
   }
   if self.size == 0 {
     return other
@@ -597,6 +636,7 @@ pub fn[K, V] HashMap::copy(self : HashMap[K, V]) -> HashMap[K, V] {
     entries: FixedArray::make(self.capacity, None),
     size: self.size,
     capacity_mask: self.capacity_mask,
+    hash_seed: self.hash_seed,
   }
   if self.size == 0 {
     return other
@@ -635,7 +675,7 @@ pub fn[K, V] HashMap::copy(self : HashMap[K, V]) -> HashMap[K, V] {
 ///   @json.json_inspect(merged, content=[["a", 1], ["b", 3], ["c", 4]])
 /// }
 /// ```
-pub fn[K : Eq, V] HashMap::merge(
+pub fn[K : Hash + Eq, V] HashMap::merge(
   self : HashMap[K, V],
   other : HashMap[K, V],
 ) -> HashMap[K, V] {
@@ -668,7 +708,7 @@ pub fn[K : Eq, V] HashMap::merge(
 ///   @json.json_inspect(merged, content=[["a", 1], ["b", 3], ["c", 4]])
 /// }
 /// ```
-pub fn[K : Eq, V] HashMap::merge_in_place(
+pub fn[K : Hash + Eq, V] HashMap::merge_in_place(
   self : HashMap[K, V],
   other : HashMap[K, V],
 ) -> Unit {
@@ -676,8 +716,8 @@ pub fn[K : Eq, V] HashMap::merge_in_place(
     return
   }
   for entry in other.entries {
-    if entry is Some({ key, value, hash, .. }) {
-      self.set_with_hash(key, value, hash)
+    if entry is Some({ key, value, .. }) {
+      self.set_with_hash(key, value, self.key_hash(key))
     }
   }
 }

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -553,3 +553,20 @@ test "hashmap default" {
   let map : @hashmap.HashMap[Int, Int] = Default::default()
   inspect(map.length(), content="0")
 }
+
+///|
+test "hashmap merge and rehash across different seeds" {
+  @builtin.set_hash_seed(11)
+  let map1 : @hashmap.HashMap[String, Int] = @hashmap.new()
+  map1.set("x", 1)
+  @builtin.set_hash_seed(22)
+  let map2 : @hashmap.HashMap[String, Int] = @hashmap.new()
+  map2.set("y", 2)
+  map1.merge_in_place(map2)
+  inspect(map1.get("x"), content="Some(1)")
+  inspect(map1.get("y"), content="Some(2)")
+  map1.rehash_with_seed(333)
+  inspect(map1.get("x"), content="Some(1)")
+  inspect(map1.get("y"), content="Some(2)")
+  @builtin.set_hash_seed(0)
+}

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -42,10 +42,11 @@ pub fn[K, V] HashMap::keys(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 pub fn[K, V] HashMap::length(Self[K, V]) -> Int
 pub fn[K, V, V2] HashMap::map(Self[K, V], (K, V) -> V2) -> Self[K, V2]
-pub fn[K : Eq, V] HashMap::merge(Self[K, V], Self[K, V]) -> Self[K, V]
-pub fn[K : Eq, V] HashMap::merge_in_place(Self[K, V], Self[K, V]) -> Unit
+pub fn[K : Hash + Eq, V] HashMap::merge(Self[K, V], Self[K, V]) -> Self[K, V]
+pub fn[K : Hash + Eq, V] HashMap::merge_in_place(Self[K, V], Self[K, V]) -> Unit
 #as_free_fn
 pub fn[K, V] HashMap::new(capacity? : Int) -> Self[K, V]
+pub fn[K : Hash + Eq, V] HashMap::rehash_with_seed(Self[K, V], Int) -> Unit
 pub fn[K : Hash + Eq, V] HashMap::remove(Self[K, V], K) -> Unit
 pub fn[K, V] HashMap::retain(Self[K, V], (K, V) -> Bool) -> Unit
 #alias("_[_]=_")

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -45,6 +45,7 @@ struct HashMap[K, V] {
   mut entries : FixedArray[Entry[K, V]?]
   mut capacity : Int
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx
+  mut hash_seed : Int
   // size of field `entries`, it is redundant but useful for performance
   // so we don't need do `self.entries.length()` every time
   mut size : Int // active key-value pairs count
@@ -59,7 +60,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V] with equal(
   guard self.size == that.size else { return false }
   for k, v in self {
     guard that.contains_kv(k, v) else { return false }
-  } else {
+  } nobreak {
     true
   }
 }

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -21,7 +21,7 @@ fn[K : Show, V : Show] HashMap::_debug_entries(self : HashMap[K, V]) -> String {
       Some({ psl, key, value, .. }) =>
         continue s + "(\{psl},\{key},\{value})", i + 1
     }
-  } else {
+  } nobreak {
     s
   }
 }
@@ -82,7 +82,7 @@ pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
       if entry is Some({ key, value, .. }) {
         return Some((key, value))
       }
-    } else {
+    } nobreak {
       None
     }
   })
@@ -171,7 +171,7 @@ pub fn[K, V] HashMap::to_array(self : HashMap[K, V]) -> Array[(K, V)] {
       break Array::make(self.size, (key, value))
     }
     i += 1
-  } else {
+  } nobreak {
     []
   }
   if !res.is_empty() {
@@ -390,7 +390,7 @@ pub fn[K, V] HashMap::keys(self : HashMap[K, V]) -> Iter[K] {
     if entry is Some({ key, .. }) {
       break Some(key)
     }
-  } else {
+  } nobreak {
     None
   })
   iter.iter()
@@ -426,7 +426,7 @@ pub fn[K, V] HashMap::values(self : HashMap[K, V]) -> Iter[V] {
     if entry is Some({ value, .. }) {
       break Some(value)
     }
-  } else {
+  } nobreak {
     None
   })
   iter.iter()
@@ -479,6 +479,7 @@ test "retain" {
   let hashmap : HashMap[String, Int] = {
     capacity: 8,
     capacity_mask: 7,
+    hash_seed: 0,
     size: 4,
     entries: [
       Some({ psl: 2, hash: 448974246, key: "c", value: 3 }),

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -18,6 +18,17 @@
 let default_init_capacity = 8
 
 ///|
+let hash_seed_counter : Ref[UInt64] = { val: 0UL }
+
+///|
+fn next_hash_seed() -> Int {
+  hash_seed_counter.val += 1UL
+  let h = Hasher::new()
+  h.combine_uint64(hash_seed_counter.val)
+  h.finalize()
+}
+
+///|
 /// Create new hash set.
 #as_free_fn
 pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
@@ -27,6 +38,7 @@ pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
     capacity,
     capacity_mask: capacity - 1,
     grow_at: calc_grow_threshold(capacity),
+    hash_seed: next_hash_seed(),
     entries: FixedArray::make(capacity, None),
   }
 }
@@ -63,7 +75,14 @@ pub fn[K : Hash + Eq] HashSet::from_array(arr : ArrayView[K]) -> HashSet[K] {
 /// ```
 #alias(insert, deprecated)
 pub fn[K : Hash + Eq] HashSet::add(self : HashSet[K], key : K) -> Unit {
-  self.add_with_hash(key, key.hash())
+  self.add_with_hash(key, self.key_hash(key))
+}
+
+///|
+fn[K : Hash] HashSet::key_hash(self : HashSet[K], key : K) -> Int {
+  let h = Hasher::new(seed=self.hash_seed)
+  h.combine(key)
+  h.finalize()
 }
 
 ///|
@@ -136,7 +155,7 @@ fn[K] HashSet::set_entry(
 /// Check if the hash set contains a key.
 pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
@@ -171,7 +190,7 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
 /// }
 /// ```
 pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
-  let hash = key.hash()
+  let hash = self.key_hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break }
     if entry.hash == hash && entry.key == key {
@@ -219,6 +238,25 @@ fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
   for i in 0..<old_entries.length() {
     if old_entries[i] is Some({ key, hash, .. }) {
       self.add_with_hash(key, hash)
+    }
+  }
+}
+
+///|
+pub fn[K : Hash + Eq] HashSet::rehash_with_seed(
+  self : HashSet[K],
+  seed : Int,
+) -> Unit {
+  if self.hash_seed == seed {
+    return
+  }
+  let old_entries = self.entries
+  self.entries = FixedArray::make(self.capacity, None)
+  self.size = 0
+  self.hash_seed = seed
+  for i in 0..<old_entries.length() {
+    if old_entries[i] is Some({ key, .. }) {
+      self.add_with_hash(key, self.key_hash(key))
     }
   }
 }
@@ -299,7 +337,7 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
       if entry is Some({ key, .. }) {
         return Some(key)
       }
-    } else {
+    } nobreak {
       None
     }
   })
@@ -644,6 +682,7 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
     size: self.size,
     capacity_mask: self.capacity_mask,
     grow_at: self.grow_at,
+    hash_seed: self.hash_seed,
   }
   for i in 0..<self.capacity {
     other.entries[i] = self.entries[i]

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -421,3 +421,15 @@ test "@hashset.to_array/multiple" {
   arr.sort()
   inspect(arr.to_string(), content="[1, 2, 3, 4]")
 }
+
+///|
+test "hashset rehash_with_seed keeps entries" {
+  @builtin.set_hash_seed(7)
+  let set : @hashset.HashSet[String] = @hashset.new()
+  set.add("a")
+  set.add("b")
+  set.rehash_with_seed(123)
+  inspect(set.contains("a"), content="true")
+  inspect(set.contains("b"), content="true")
+  @builtin.set_hash_seed(0)
+}

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -42,6 +42,7 @@ pub fn[K] HashSet::iter(Self[K]) -> Iter[K]
 pub fn[K] HashSet::length(Self[K]) -> Int
 #as_free_fn
 pub fn[K] HashSet::new(capacity? : Int) -> Self[K]
+pub fn[K : Hash + Eq] HashSet::rehash_with_seed(Self[K], Int) -> Unit
 pub fn[K : Hash + Eq] HashSet::remove(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] HashSet::remove_and_check(Self[K], K) -> Bool
 pub fn[K : Hash + Eq] HashSet::symmetric_difference(Self[K], Self[K]) -> Self[K]

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -44,4 +44,5 @@ struct HashSet[K] {
   mut capacity : Int // current capacity
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx
   mut grow_at : Int // threshold that triggers grow
+  mut hash_seed : Int
 }


### PR DESCRIPTION
A possible solution for hashdos : use per-table seed and a public hash seed setter and let the user (ideally web framework developer) handle this using proper FFI.