### PR TITLE
Improve json conversion and stringify behavior

### DIFF
--- a/json/deprecated.mbt
+++ b/json/deprecated.mbt
@@ -11,3 +11,76 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+///|
+/// Try to get this element as a Null
+#deprecated("Suggestion: `if json is Null { Some(()) } else { None }`")
+pub fn Json::as_null(self : Json) -> Unit? {
+  guard self is Null else { return None }
+  Some(())
+}
+
+///|
+/// Try to get this element as a Boolean
+#deprecated("Suggestion: `if json is True { Some(true) } else if json is False { Some(false) } else { None }`")
+pub fn Json::as_bool(self : Json) -> Bool? {
+  match self {
+    True => Some(true)
+    False => Some(false)
+    _ => None
+  }
+}
+
+///|
+/// Try to get this element as a Number
+#deprecated("Suggestion: `if json is Number(n) { Some(n) } else { None }`")
+pub fn Json::as_number(self : Json) -> Double? {
+  guard self is Number(n, ..) else { return None }
+  Some(n)
+}
+
+///|
+/// Try to get this element as a String
+#deprecated("Suggestion: `if json is String(s) { Some(s) } else { None }`")
+pub fn Json::as_string(self : Json) -> String? {
+  guard self is String(s) else { return None }
+  Some(s)
+}
+
+///|
+/// Try to get this element as an Array
+#deprecated("Suggestion: `if json is Array(array) { Some(array) } else { None }`")
+pub fn Json::as_array(self : Json) -> Array[Json]? {
+  guard self is Array(arr) else { return None }
+  Some(arr)
+}
+
+///|
+/// Try to get this element as a Json Array and get the element at the `index` as a Json Value
+#deprecated("Suggestion: `if json is Array(array) { array.get(index) } else { None }`")
+pub fn Json::item(self : Json, index : Int) -> Json? {
+  if self is Array(arr) {
+    arr.get(index)
+  } else {
+    None
+  }
+}
+
+///|
+/// Try to get this element as an Object
+#deprecated
+pub fn Json::as_object(self : Json) -> Map[String, Json]? {
+  guard self is Object(obj) else { return None }
+  Some(obj)
+}
+
+///|
+/// Try to get this element as a Json Object and get the element with the `key` as a Json Value
+#deprecated("Suggestion: `if json is Object(obj) { obj.get(key) } else { None }`")
+pub fn Json::value(self : Json, key : String) -> Json? {
+  if self is Object(obj) {
+    obj.get(key)
+  } else {
+    None
+  }
+}

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -24,6 +24,8 @@ pub(open) trait FromJson {
 }
 
 ///|
+/// Decode a Json value into a concrete type that implements `FromJson`.
+/// The `path` parameter is used to annotate errors with a JSON Pointer location.
 pub fn[T : FromJson] from_json(
   json : Json,
   path? : JsonPath = Root,
@@ -52,6 +54,9 @@ pub impl FromJson for Int with from_json(json, path) {
     n != @double.neg_infinity else {
     decode_error(path, "Int::from_json: expected number")
   }
+  if n != n.trunc() {
+    decode_error(path, "Int::from_json: expected integer")
+  }
   // Range check before conversion to avoid silent wrap/truncation
   let max_ok = 2147483647.0
   let min_ok = -2147483648.0
@@ -79,6 +84,9 @@ pub impl FromJson for UInt with from_json(json, path) {
     n != @double.infinity &&
     n != @double.neg_infinity else {
     decode_error(path, "UInt::from_json: expected number")
+  }
+  if n != n.trunc() {
+    decode_error(path, "UInt::from_json: expected integer")
   }
   // Range check before conversion to avoid silent wrap/truncation
   let max_ok = 4294967295.0

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -408,6 +408,17 @@ test "int roundtrip" {
 }
 
 ///|
+test "int from_json rejects fractional numbers" {
+  let res : Result[Int, _] = try? @json.from_json(Json::number(1.5))
+  inspect(
+    res,
+    content=(
+      #|Err(JsonDecodeError((, "Int::from_json: expected integer")))
+    ),
+  )
+}
+
+///|
 test "uint roundtrip" {
   let u = 123U.to_json()
   let v : UInt = @json.from_json(u)
@@ -415,6 +426,17 @@ test "uint roundtrip" {
   let u = 4294967295U.to_json()
   let v : UInt = @json.from_json(u)
   inspect(v, content="4294967295")
+}
+
+///|
+test "uint from_json rejects fractional numbers" {
+  let res : Result[UInt, _] = try? @json.from_json(Json::number(3.14))
+  inspect(
+    res,
+    content=(
+      #|Err(JsonDecodeError((, "UInt::from_json: expected integer")))
+    ),
+  )
 }
 
 ///|

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -13,79 +13,6 @@
 // limitations under the License.
 
 ///|
-/// Try to get this element as a Null
-#deprecated("Suggestion: `if json is Null { Some(()) } else { None }`")
-pub fn Json::as_null(self : Json) -> Unit? {
-  guard self is Null else { return None }
-  Some(())
-}
-
-///|
-/// Try to get this element as a Boolean
-#deprecated("Suggestion: `if json is True { Some(true) } else if json is False { Some(false) } else { None }`")
-pub fn Json::as_bool(self : Json) -> Bool? {
-  match self {
-    True => Some(true)
-    False => Some(false)
-    _ => None
-  }
-}
-
-///|
-/// Try to get this element as a Number
-#deprecated("Suggestion: `if json is Number(n) { Some(n) } else { None }`")
-pub fn Json::as_number(self : Json) -> Double? {
-  guard self is Number(n, ..) else { return None }
-  Some(n)
-}
-
-///|
-/// Try to get this element as a String
-#deprecated("Suggestion: `if json is String(s) { Some(s) } else { None }`")
-pub fn Json::as_string(self : Json) -> String? {
-  guard self is String(s) else { return None }
-  Some(s)
-}
-
-///|
-/// Try to get this element as an Array
-#deprecated("Suggestion: `if json is Array(array) { Some(array) } else { None }`")
-pub fn Json::as_array(self : Json) -> Array[Json]? {
-  guard self is Array(arr) else { return None }
-  Some(arr)
-}
-
-///|
-/// Try to get this element as a Json Array and get the element at the `index` as a Json Value
-#deprecated("Suggestion: `if json is Array(array) { array.get(index) } else { None }`")
-pub fn Json::item(self : Json, index : Int) -> Json? {
-  if self is Array(arr) {
-    arr.get(index)
-  } else {
-    None
-  }
-}
-
-///|
-/// Try to get this element as an Object
-#deprecated
-pub fn Json::as_object(self : Json) -> Map[String, Json]? {
-  guard self is Object(obj) else { return None }
-  Some(obj)
-}
-
-///|
-/// Try to get this element as a Json Object and get the element with the `key` as a Json Value
-#deprecated("Suggestion: `if json is Object(obj) { obj.get(key) } else { None }`")
-pub fn Json::value(self : Json, key : String) -> Json? {
-  if self is Object(obj) {
-    obj.get(key)
-  } else {
-    None
-  }
-}
-
-///|
 fn indent_str(level : Int, indent : Int) -> String {
   if indent == 0 {
     ""
@@ -284,7 +211,6 @@ pub fn Json::stringify(
           } else {
             depth += 1
             buf.write_char('{')
-            buf.write_string(indent_str(depth, indent))
             // After child value printed, we resume from this frame
             stack.push(WriteFrame::Object(members.iter(), first=true))
           }
@@ -344,7 +270,9 @@ pub fn Json::stringify(
                   continue None
                 }
               }
-              if !first {
+              if first {
+                buf.write_string(indent_str(depth, indent))
+              } else {
                 buf.write_char(',')
                 buf.write_string(indent_str(depth, indent))
               }
@@ -361,7 +289,9 @@ pub fn Json::stringify(
             None => {
               depth -= 1
               ignore(stack.pop())
-              buf.write_string(indent_str(depth, indent))
+              if !first {
+                buf.write_string(indent_str(depth, indent))
+              }
               buf.write_char('}')
               continue None
             }
@@ -373,8 +303,31 @@ pub fn Json::stringify(
 
 ///|
 fn escape(str : String, escape_slash~ : Bool) -> String {
+  let mut needs_escape = false
+  for c in str.iter() {
+    match c {
+      '"' | '\\' | '\n' | '\r' | '\b' | '\t' => {
+        needs_escape = true
+        break
+      }
+      '/' if escape_slash => {
+        needs_escape = true
+        break
+      }
+      _ => {
+        let code = c.to_int()
+        if code == 0x0C || code < ' ' {
+          needs_escape = true
+          break
+        }
+      }
+    }
+  }
+  if !needs_escape {
+    return str
+  }
   let buf = StringBuilder::new(size_hint=str.length())
-  for c in str {
+  for c in str.iter() {
     match c {
       '"' => buf.write_string("\\\"")
       '\\' => buf.write_string("\\\\")

--- a/json/json_path.mbt
+++ b/json/json_path.mbt
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 ///|
+/// A JSON Pointer path (RFC 6901) used to locate values in a JSON document.
+/// This is primarily used in decode errors to indicate where a failure occurred.
 enum JsonPath {
   Root
   Key(JsonPath, mut key~ : String)
@@ -20,11 +22,13 @@ enum JsonPath {
 } derive(Eq)
 
 ///|
+/// Append an array index segment to the current JSON path.
 pub fn JsonPath::add_index(self : JsonPath, index : Int) -> JsonPath {
   Index(self, index~)
 }
 
 ///|
+/// Append an object key segment to the current JSON path.
 pub fn JsonPath::add_key(self : JsonPath, key : String) -> JsonPath {
   Key(self, key~)
 }

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -162,6 +162,9 @@ test "stringify with replacer" {
       #|{"a":1,"c":3}
     ),
   )
+  // keep none with indentation should still be compact
+  let replacer = @json.Replacer::keep([])
+  inspect(json.stringify(indent=2, replacer~), content="{}")
 }
 
 ///|


### PR DESCRIPTION
### Motivation
- Consolidate deprecated Json helpers into a dedicated module for API clarity and consistency.
- Prevent surprising conversions by rejecting fractional numbers when decoding `Int`/`UInt`.
- Fix `stringify`/`escape` behavior to avoid unwanted indentation/newlines and improve common-case performance for unescaped strings.
- Add missing documentation for `JsonPath` helper APIs to improve discoverability.

### Description
- Moved legacy accessors (`Json::as_*`, `Json::item`, `Json::value`) out of the main module into `json/deprecated.mbt` and left deprecation hints in place.
- Tightened `from_json` implementations for `Int` and `UInt` to reject fractional numbers by checking `n == n.trunc()` and added corresponding tests in `json/from_json_test.mbt` that assert fractional values fail with an `expected integer` error.
- Adjusted `Json::stringify` to not emit a leading indent for objects until the first property is written and to avoid emitting a trailing indent for empty objects when a replacer filtered out members, fixing compact output when `Replacer::keep([])` is used.
- Added a fast-path to `escape` that returns the original string when no characters require escaping to avoid extra allocation/work in the common case.
- Added brief doc comments for `JsonPath` and its `add_index`/`add_key` helpers and added a unit test verifying replacer + indentation behavior in `json/json_test.mbt`.

### Testing
- Ran `moon info` to update package metadata and ensure interfaces are consistent, which completed successfully.
- Ran `moon fmt` to format changes, which completed successfully.
- Ran the full test suite with `moon test`, and all tests passed: `Total tests: 5632, passed: 5632, failed: 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882074090c8320b817245d2cfb808f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
