### PR TITLE
Fix bigint division loop bug and remove missing_doc warn

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -579,11 +579,11 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   let a = FixedArray::make(a_len + 1, 0UL)
   for i in 0..<a_len {
     a[i] = dividend.limbs[i].to_uint64()
-  } nobreak {
-    if dividend.limbs.length() > i {
-      a[i] = dividend.limbs[i].to_uint64()
-    }
   }
+  if dividend.limbs.length() > a_len {
+    a[a_len] = dividend.limbs[a_len].to_uint64()
+  }
+
   // invariant : divisor.limbs.last() >= radix / 2
   // if b[b_len - 1] < radix / 2 {
   //   panic()
@@ -594,7 +594,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   let v2 = b[b_len - 2]
   let q = FixedArray::make(a_len - b_len, 0U)
   // D2 - D7 loop through m to 0
-  for i = q.length() - 1; i >= 0; i = i - 1 {
+  for i in q.length()>..0 {
     let u0 = a[i + b_len]
     let u1 = a[i + b_len - 1]
     let u2 = a[i + b_len - 2]

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -5,5 +5,5 @@
   "repository": "https://github.com/moonbitlang/core",
   "license": "Apache-2.0",
   "keywords": ["core","standard library"],
-  "warn-list": "+test_unqualified_package+missing_doc"  
+  "warn-list": "+test_unqualified_package"  
 }


### PR DESCRIPTION
## Summary
- Fix a bug in `bigint/bigint_nonjs.mbt` division: the loop that copies dividend limbs incorrectly used the loop variable `i` after the loop ended; replaced with `a_len` to correctly access the overflow limb
- Modernize C-style `for` loop to idiomatic MoonBit range syntax (`for i in q.length()>..0`)
- Remove `+missing_doc` from `warn-list` in `moon.mod.json` since the test driver does not support it

## Test plan
- [ ] CI passes (moon check, moon test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
