### PR TITLE
Modernize C-style descending for loops to `for i in a>..b`

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -413,7 +413,7 @@ fn BigInt::split(self : BigInt, half : Int) -> (BigInt, BigInt) {
   if self.len <= half {
     return ({ ..self, sign: Positive }, zero)
   }
-  let lower_len = for i = half - 1; i > 0; i = i - 1 {
+  let lower_len = for i in half>..1 {
     if self.limbs[i] > 0 {
       break i + 1
     }
@@ -536,7 +536,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
     let a = ret.limbs
     let x = number.to_uint64()
     let mut y = 0UL
-    for i = self.len - 1; i >= 0; i = i - 1 {
+    for i in self.len>..0 {
       y = y << radix_bit_len
       y += a[i].to_uint64()
       a[i] = ((y / x) & radix_mask).to_uint()
@@ -761,7 +761,7 @@ pub impl Shr for BigInt with shr(self : BigInt, n : Int) -> BigInt {
     let new_limbs = FixedArray::make(new_len, 0U)
     let a = self.limbs
     let mut carry = 0UL
-    for i = self.len - 1; i >= lz; i = i - 1 {
+    for i in self.len>..lz {
       let x = a[i].to_uint64()
       new_limbs[i - lz] = ((x >> r) | carry).to_uint()
       carry = (x << (radix_bit_len - r)) % radix
@@ -841,7 +841,7 @@ pub impl Compare for BigInt with compare(self, other) {
       other_len - self_len
     }
   }
-  for i = self_len - 1; i >= 0; i = i - 1 {
+  for i in self_len>..0 {
     if self.limbs[i] != other.limbs[i] {
       return if self.sign == Positive {
         self.limbs[i].compare(other.limbs[i])
@@ -937,7 +937,7 @@ pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
   let s = if self.sign == Negative { "-" } else { "" }
   let v = Array::make(decimal_len, 0L)
   let mut v_idx = 0
-  for i = self.len - 1; i >= 0; i = i - 1 {
+  for i in self.len>..0 {
     let mut x = self.limbs[i].to_int64()
     for j in 0..<v_idx {
       let y = (v[j] << radix_bit_len) | x
@@ -1048,7 +1048,7 @@ fn BigInt::to_string_radix(self : BigInt, radix : Int) -> String {
       if is_negative {
         builder.write_char('-')
       }
-      for i = digits.length() - 1; i >= 0; i = i - 1 {
+      for i in digits.length()>..0 {
         builder.write_char(digits[i])
       }
       builder.to_string()
@@ -1069,7 +1069,7 @@ fn BigInt::to_string_radix_pow2(self : BigInt, shift : Int) -> String {
     builder.write_char('-')
   }
   let mask = (1UL << shift) - 1UL
-  for pos = digit_len - 1; pos >= 0; pos = pos - 1 {
+  for pos in digit_len>..0 {
     let bit_index = pos * shift
     let limb_index = bit_index / radix_bit_len
     let offset = bit_index % radix_bit_len
@@ -1154,7 +1154,7 @@ fn BigInt::from_string_radix_pow2(
   let b_len = (total_bits + radix_bit_len - 1) / radix_bit_len
   let limbs = FixedArray::make(b_len, 0U)
   let mut bit_pos = 0
-  for i = len - 1; i >= first; i = i - 1 {
+  for i in len>..first {
     let digit = digit_from_char(input.unsafe_get(i).to_int())
     if digit < 0 || digit >= radix {
       abort("invalid character")
@@ -1837,7 +1837,7 @@ pub fn BigInt::to_uint64(self : BigInt) -> UInt64 {
   let len = 64 / radix_bit_len
   let len = if value.len < len { value.len } else { len }
   let mut result = 0UL
-  for i = len - 1; i >= 0; i = i - 1 {
+  for i in len>..0 {
     result = result << radix_bit_len
     result = result | (value.limbs[i].to_uint64() & radix_mask)
   }

--- a/bigint/deprecated.mbt
+++ b/bigint/deprecated.mbt
@@ -82,7 +82,7 @@ pub fn BigInt::to_hex(self : BigInt, uppercase? : Bool = true) -> String {
   } else {
     StringBuilder::new(size_hint=self.len * digits_per_limb)
   }
-  for i = self.len - 1; i >= 0; i = i - 1 { // TODO: reverse iteration would be a bit faster.
+  for i in self.len>..0 {
     // split the limb into 4-bit chunks
     let mut x = self.limbs[i]
     let digits = FixedArray::make(digits_per_limb, '0')

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1872,7 +1872,7 @@ pub fn[T] Array::shuffle_in_place(
   rand~ : (Int) -> Int,
 ) -> Unit {
   let n = self.length()
-  for i = n - 1; i > 0; i = i - 1 {
+  for i in n>..1 {
     let j = rand(i + 1) % (i + 1)
     // for safety, perf is not a concern here
     // TODO: maybe return an error later

--- a/builtin/array_sort_by_impl.mbt
+++ b/builtin/array_sort_by_impl.mbt
@@ -198,10 +198,10 @@ fn[T] fixed_choose_pivot_by(
 ///|
 fn[T] fixed_heap_sort_by(arr : MutArrayView[T], cmp : (T, T) -> Int) -> Unit {
   let len = arr.length()
-  for i = len / 2 - 1; i >= 0; i = i - 1 {
+  for i in (len / 2)>..0 {
     fixed_sift_down_by(arr, i, cmp)
   }
-  for i = len - 1; i > 0; i = i - 1 {
+  for i in len>..1 {
     arr.swap(0, i)
     fixed_sift_down_by(arr.slice(0, i), 0, cmp)
   }

--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -421,10 +421,10 @@ fn[T : Compare] fixed_choose_pivot(arr : MutArrayView[T]) -> (Int, Bool) {
 ///|
 fn[T : Compare] fixed_heap_sort(arr : MutArrayView[T]) -> Unit {
   let len = arr.length()
-  for i = len / 2 - 1; i >= 0; i = i - 1 {
+  for i in (len / 2)>..0 {
     fixed_sift_down(arr, i)
   }
-  for i = len - 1; i > 0; i = i - 1 {
+  for i in len>..1 {
     arr.swap(0, i)
     fixed_sift_down(arr.slice(0, i), 0)
   }

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -368,7 +368,7 @@ pub fn[T] FixedArray::rev_each(
   self : FixedArray[T],
   f : (T) -> Unit raise?,
 ) -> Unit raise? {
-  for i = self.length() - 1; i >= 0; i = i - 1 {
+  for i in self.length()>..0 {
     f(self[i])
   }
 }

--- a/builtin/fixedarray_block.mbt
+++ b/builtin/fixedarray_block.mbt
@@ -49,7 +49,7 @@ pub fn[A] FixedArray::unsafe_blit(
       dst[dst_offset + i] = src[src_offset + i]
     }
   } else {
-    for i = len - 1; i >= 0; i = i - 1 {
+    for i in len>..0 {
       dst[dst_offset + i] = src[src_offset + i]
     }
   }
@@ -67,7 +67,7 @@ fn[T] UninitializedArray::unsafe_blit_fixed(
   src_offset : Int,
   len : Int,
 ) -> Unit {
-  for i = len - 1; i >= 0; i = i - 1 {
+  for i in len>..0 {
     dst[dst_offset + i] = src[src_offset + i]
   }
 }

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -218,7 +218,7 @@ fn boyer_moore_horspool_rev_find(
   guard needle_len > 0 else { return Some(haystack_len) }
   guard haystack_len >= needle_len else { return None }
   let skip_table = FixedArray::make(1 << 8, needle_len)
-  for i = needle_len - 1; i > 0; i = i - 1 {
+  for i in needle_len>..1 {
     skip_table[needle.unsafe_get(i).to_int() & 0xFF] = i
   }
   for i = haystack_len - needle_len

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -290,7 +290,7 @@ pub fn[A] Deque::blit_to(
       dst.len = new_len
     }
     // Copy in reverse order
-    for i = len - 1; i >= 0; i = i - 1 {
+    for i in len>..0 {
       let dst_idx = (dst.head + dst_offset + i) % dst.buf.length()
       let src_idx = (self.head + src_offset + i) % self.buf.length()
       dst.buf[dst_idx] = self.buf[src_idx]
@@ -464,7 +464,7 @@ pub fn[A] Deque::remove(self : Deque[A], index : Int) -> A {
   if index < self.len / 2 {
     // Shift front elements right
     let new_head = (self.head + 1) % cap
-    for i = index - 1; i >= 0; i = i - 1 {
+    for i in index>..0 {
       let to = (self.head + i + 1) % cap
       let from = (self.head + i) % cap
       self.buf[to] = self.buf[from]
@@ -2331,7 +2331,7 @@ pub fn[A] Deque::shuffle_in_place(
 ) -> Unit {
   let n = self.len
   let buf_length = self.buf.length()
-  for i = n - 1; i > 0; i = i - 1 {
+  for i in n>..1 {
     let j = rand(i + 1)
     // Calculate circular buffer positions
     let i_pos = (self.head + i) % buf_length

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -315,7 +315,7 @@ pub fn Rand::shuffle(
   if limit < 0 {
     abort("Rand::shuffle: invalid argument limit")
   }
-  for i = limit - 1; i > 0; i = i - 1 {
+  for i in limit>..1 {
     let j = self.int(limit=i + 1)
     swap(i, j)
   }

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -305,7 +305,7 @@ fn Decimal::assign(self : Decimal, v : Int64) -> Unit {
 
   // reverse the buf
   self.digits_num = 0
-  for i = n - 1; i >= 0; i = i - 1 {
+  for i in n>..0 {
     self.digits[self.digits_num] = buf[i]
     self.digits_num += 1
   }


### PR DESCRIPTION
## Summary
- Replace C-style descending `for` loops (`for i = n - 1; i >= 0; i = i - 1`) with idiomatic MoonBit reverse range syntax (`for i in n>..0`) across 11 files
- Covers `bigint`, `builtin`, `deque`, `strconv`, and `random` packages
- Two loops intentionally left unconverted where the start value isn't in `n - 1` form (`bytes_find.mbt`, `array_sort_impl.mbt`)

## Test plan
- [x] `moon check` passes
- [x] All affected package tests pass locally (bigint, builtin, deque, strconv, random)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
