### PR TITLE
Fix utf16be panic test calling wrong method

### DIFF
--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -17,7 +17,7 @@ import {
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
   "moonbitlang/core/random",
-  "moonbitlang/core/math",
+  "moonbitlang/core/math", // FIXME: IDE false alarm unused package
   "moonbitlang/core/buffer",
 } for "test"
 

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -227,7 +227,7 @@ test "panic set_utf16le_char with invalid code point" {
 test "panic set_utf16be_char with invalid code point" {
   let arr = FixedArray::makei(10, _ => b'\x00')
   let char = (0x110000).unsafe_to_char()
-  arr.set_utf16le_char(0, char) |> ignore
+  arr.set_utf16be_char(0, char) |> ignore
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Fix bug in `builtin/panic_test.mbt`: the test "panic set_utf16be_char with invalid code point" was incorrectly calling `set_utf16le_char` instead of `set_utf16be_char`
- Annotate unused `math` import in `builtin/moon.pkg` as IDE false alarm

## Test plan
- [x] `moon check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
