### PR TITLE
deprecate IterResult and Iter2::run

### DIFF
--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -1228,6 +1228,7 @@ test "zip_to_iter2" {
 }
 
 ///|
+#warnings("-deprecated")
 test "zip_to_iter2 early termination" {
   // This test should trigger the uncovered line 301: break IterEnd
   // We create an iterator that terminates early when it encounters a specific value

--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -16,15 +16,7 @@
 /// Control signal used by deprecated iterator callbacks.
 ///
 /// `IterContinue` keeps iteration running, `IterEnd` stops it.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   inspect(IterResult::IterContinue == IterResult::IterContinue, content="true")
-///   inspect(IterResult::IterEnd == IterResult::IterContinue, content="false")
-/// }
-/// ```
+#deprecated
 pub(all) enum IterResult {
   IterEnd // false
   IterContinue // true

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -38,6 +38,7 @@ pub fn[X] Iter::next(self : Iter[X]) -> X? {
 /// Function `run`.
 #locals(f)
 #deprecated("write a loop instead.")
+#warnings("-deprecated")
 pub fn[X] Iter::run(self : Iter[X], f : (X) -> IterResult) -> IterResult {
   while self.next() is Some(x) {
     guard f(x) is IterContinue else { break IterEnd }
@@ -52,6 +53,7 @@ pub fn[X] Iter::run(self : Iter[X], f : (X) -> IterResult) -> IterResult {
 /// Deprecated: prefer explicit loops.
 /// Function `just_run`.
 #deprecated("write a loop instead.")
+#warnings("-deprecated")
 pub fn[X] Iter::just_run(self : Iter[X], f : (X) -> IterResult) -> Unit {
   while self.next() is Some(x) {
     if f(x) is IterEnd {
@@ -912,6 +914,8 @@ pub impl[X : Show, Y : Show] Show for Iter2[X, Y] with output(self, logger) {
 
 ///|
 /// Consume pairs while callback returns `IterContinue`.
+#warnings("-deprecated")
+#deprecated("write a loop instead.")
 pub fn[X, Y] Iter2::run(
   self : Iter2[X, Y],
   f : (X, Y) -> IterResult,

--- a/builtin/iterator_test.mbt
+++ b/builtin/iterator_test.mbt
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 ///|
+#warnings("-deprecated")
 test "Iter2::run empty iterator" {
   let iter : Iter2[Unit, Unit] = Iter2::new(() => None)
   let result = iter.run((_, _) => IterContinue)

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -19,6 +19,7 @@ pub using @set {type Set}
 pub using @bigint {type BigInt}
 
 ///|
+#warnings("-deprecated")
 pub using @builtin {
   abort,
   assert_eq,


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
