### PR TITLE
remove use of implicit empty trait impl

### DIFF
--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -82,7 +82,7 @@ pub fn single_bench(
 /// Keep a value to prevent the optimizer from removing 
 /// the calculation that produces it.
 pub fn[Any] Bench::keep(self : Bench, value : Any) -> Unit {
-  let trait_object : &OpaqueValue = value
+  let trait_object : &OpaqueValue = @ref.new(value)
   self._storage = trait_object
 }
 

--- a/bench/moon.pkg
+++ b/bench/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/core/double",
   "moonbitlang/core/array",
   "moonbitlang/core/json",
+  "moonbitlang/core/ref",
 }
 
 options(

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -16,6 +16,9 @@
 priv trait OpaqueValue {}
 
 ///|
+impl[X] OpaqueValue for Ref[X]
+
+///|
 #alias(T)
 struct Bench {
   buffer : StringBuilder
@@ -42,5 +45,5 @@ struct Bench {
 pub fn Bench::new() -> Bench {
   let buffer = StringBuilder::new()
   let summaries = Array::new()
-  { buffer, summaries, _storage: () }
+  { buffer, summaries, _storage: @ref.new(()) }
 }


### PR DESCRIPTION
related: https://github.com/moonbitlang/moonbit-docs/issues/1129

We plan to remove the behavior that every type can implicitly implement an empty trait. This PR migrates `moonbitlang/core`. The usage of this feature is treating `&EmptyTrait` an an any type, and use it to extend the lifetime of an arbitrary value to prevent DCE in `moonbitlang/core/bench`. But in fact, the empty trait feature is not necessary for this purpose. This PR uses another trick to achieve the same effect:

- *explicitly* implement an empty trait for `Ref[X]` for any `X`, without requiring any trait bound on `X`
- now every type can be first converted to `Ref[X]` and then to `&EmptyTrait`. The type parameter will be erased

no implicit implementation is necessary in this alternative trick.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
