### PR TITLE
remove `any_to_string` and its usage

### DIFF
--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -16,9 +16,6 @@
 fn println_mono(s : String) -> Unit = "%println"
 
 ///|
-fn[T] any_to_string(any : T) -> String = "%any.to_string"
-
-///|
 /// Prints any value that implements the `Show` trait to the standard output,
 /// followed by a newline.
 ///

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -86,31 +86,6 @@ pub fn Byte::lsr(self : Byte, count : Int) -> Byte {
 }
 
 ///|
-/// Prints and returns the value of a given expression for quick and dirty debugging.
-/// This could also be useful to print some logs to trace the progress.
-/// For example, you can put `dump(())` in each line, the execution will print the line number
-/// when it reaches that line.
-#callsite(autofill(loc))
-#deprecated("This function is for debugging only and should not be used in production", skip_current_package=true)
-pub fn[T] dump(t : T, name? : String, loc~ : SourceLoc) -> T {
-  let name = match name {
-    Some(name) => name
-    None => ""
-  }
-  println("dump(\{name}@\{loc}) = \{any_to_string(t)}")
-  t
-}
-
-///|
-test "dump" {
-  let x = 42
-  if false {
-    dump(()) // never reached here
-    assert_eq(dump(x) + x, 84)
-  }
-}
-
-///|
 /// Returns the Unicode code point at the given index without bounds checking.
 #deprecated("Use `s.get_char(i).unwrap()` instead", skip_current_package=true)
 pub fn String::unsafe_char_at(self : String, index : Int) -> Char {

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -17,10 +17,6 @@ pub fn[T : Eq + Show] assert_not_eq(T, T, msg? : String, loc~ : SourceLoc) -> Un
 #callsite(autofill(loc))
 pub fn assert_true(Bool, msg? : String, loc~ : SourceLoc) -> Unit raise
 
-#deprecated
-#callsite(autofill(loc))
-pub fn[T] dump(T, name? : String, loc~ : SourceLoc) -> T
-
 #callsite(autofill(loc))
 pub fn[T] fail(String, loc~ : SourceLoc) -> T raise Failure
 

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -1401,3 +1401,28 @@ test "Debug for hash-based collections" {
   let immut_hs = @immut_hashset.from_array([3])
   debug_inspect(immut_hs, content="<HashSet: [3]>")
 }
+
+///|
+/// Prints and returns the value of a given expression for quick and dirty debugging.
+/// This could also be useful to print some logs to trace the progress.
+/// For example, you can put `dump(())` in each line, the execution will print the line number
+/// when it reaches that line.
+#callsite(autofill(loc))
+#deprecated("This function is for debugging only and should not be used in production", skip_current_package=true)
+pub fn[T : Debug] dump(t : T, name? : String, loc~ : SourceLoc) -> T {
+  let name = match name {
+    Some(name) => name
+    None => ""
+  }
+  println("dump(\{name}@\{loc}) = \{to_string(t)}")
+  t
+}
+
+///|
+test "dump" {
+  let x = 42
+  if false {
+    dump(()) // never reached here
+    assert_eq(dump(x) + x, 84)
+  }
+}

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -21,6 +21,10 @@ pub fn[T : Debug] debug(T) -> Unit
 #callsite(autofill(args_loc, loc))
 pub fn debug_inspect(&Debug, content? : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise InspectError
 
+#deprecated
+#callsite(autofill(loc))
+pub fn[T : Debug] dump(T, name? : String, loc~ : SourceLoc) -> T
+
 pub fn render(Repr, max_depth? : Int) -> String
 
 pub fn[T : Debug] to_string(T) -> String

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -33,7 +33,7 @@ pub fn debug_inspect(&@debug.Debug, content? : String, loc~ : @builtin.SourceLoc
 
 #deprecated
 #callsite(autofill(loc))
-pub fn[T] dump(T, name? : String, loc~ : @builtin.SourceLoc) -> T
+pub fn[T : @debug.Debug] dump(T, name? : String, loc~ : @builtin.SourceLoc) -> T
 
 #callsite(autofill(loc))
 pub fn[T] fail(String, loc~ : @builtin.SourceLoc) -> T raise @builtin.Failure

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -73,6 +73,11 @@ pub using @builtin {
 pub using @debug {debug, type Repr, trait Debug, debug_inspect}
 
 ///|
+#deprecated("for debugging only, not for production")
+#warnings("-deprecated")
+pub using @debug {dump}
+
+///|
 pub using @string {type Regex}
 
 ///|
@@ -130,18 +135,6 @@ pub let null : Json = @builtin.null
 
 ///|
 pub using @json {trait FromJson, json_inspect}
-
-///|
-/// Prints and returns the value of a given expression for quick and dirty debugging.
-/// This could also be useful to print some logs to trace the progress.
-/// For example, you can put `dump(())` in each line, the execution will print the line number
-/// when it reaches that line.
-#callsite(autofill(loc))
-#deprecated("This function is for debugging only and should not be used in production")
-#warnings("-deprecated")
-pub fn[T] dump(t : T, name? : String, loc~ : SourceLoc) -> T {
-  @builtin.dump(t, name?, loc~)
-}
 
 ///|
 /// Type `Iterator`.


### PR DESCRIPTION
This PR removes the usage of the magic primitive `%any.to_string`. The only public API that uses it is `dump`, which has been deprecated for a while. So this PR also removed `dump`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
