### PR TITLE
Add clamp and lerp methods for Float and Double

### DIFF
--- a/builtin/double.mbt
+++ b/builtin/double.mbt
@@ -104,12 +104,12 @@ pub fn Double::clamp(self : Double, min~ : Double, max~ : Double) -> Double {
 ///
 /// ```mbt check
 /// test {
-///   inspect(0.0.lerp(10.0, 0.25), content="2.5")
-///   inspect(5.0.lerp(15.0, 0.0), content="5")
-///   inspect(5.0.lerp(15.0, 1.0), content="15")
+///   inspect(0.0.lerp(target=10.0, t=0.25), content="2.5")
+///   inspect(5.0.lerp(target=15.0, t=0.0), content="5")
+///   inspect(5.0.lerp(target=15.0, t=1.0), content="15")
 /// }
 /// ```
-pub fn Double::lerp(self : Double, target : Double, t : Double) -> Double {
+pub fn Double::lerp(self : Double, target~ : Double, t~ : Double) -> Double {
   self + (target - self) * t
 }
 

--- a/builtin/double_test.mbt
+++ b/builtin/double_test.mbt
@@ -69,9 +69,9 @@ test "panic Double::clamp with invalid range" {
 
 ///|
 test "Double::lerp" {
-  inspect(0.0.lerp(10.0, 0.25), content="2.5")
-  inspect(5.0.lerp(15.0, 0.0), content="5")
-  inspect(5.0.lerp(15.0, 1.0), content="15")
+  inspect(0.0.lerp(target=10.0, t=0.25), content="2.5")
+  inspect(5.0.lerp(target=15.0, t=0.0), content="5")
+  inspect(5.0.lerp(target=15.0, t=1.0), content="15")
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -646,7 +646,7 @@ pub fn Double::is_inf(Double) -> Bool
 pub fn Double::is_nan(Double) -> Bool
 pub fn Double::is_neg_inf(Double) -> Bool
 pub fn Double::is_pos_inf(Double) -> Bool
-pub fn Double::lerp(Double, Double, Double) -> Double
+pub fn Double::lerp(Double, target~ : Double, t~ : Double) -> Double
 #deprecated
 pub fn Double::pow(Double, Double) -> Double
 #deprecated

--- a/float/float_test.mbt
+++ b/float/float_test.mbt
@@ -178,9 +178,9 @@ test "panic Float::clamp with invalid range" {
 
 ///|
 test "Float::lerp" {
-  inspect((0.0 : Float).lerp(10.0, 0.25), content="2.5")
-  inspect((5.0 : Float).lerp(15.0, 0.0), content="5")
-  inspect((5.0 : Float).lerp(15.0, 1.0), content="15")
+  inspect((0.0 : Float).lerp(target=10.0, t=0.25), content="2.5")
+  inspect((5.0 : Float).lerp(target=15.0, t=0.0), content="5")
+  inspect((5.0 : Float).lerp(target=15.0, t=1.0), content="15")
 }
 
 ///|

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -273,12 +273,12 @@ pub fn Float::clamp(self : Float, min~ : Float, max~ : Float) -> Float {
 ///
 /// ```mbt check
 /// test {
-///   inspect((0.0 : Float).lerp(10.0, 0.25), content="2.5")
-///   inspect((5.0 : Float).lerp(15.0, 0.0), content="5")
-///   inspect((5.0 : Float).lerp(15.0, 1.0), content="15")
+///   inspect((0.0 : Float).lerp(target=10.0, t=0.25), content="2.5")
+///   inspect((5.0 : Float).lerp(target=15.0, t=0.0), content="5")
+///   inspect((5.0 : Float).lerp(target=15.0, t=1.0), content="15")
 /// }
 /// ```
-pub fn Float::lerp(self : Float, target : Float, t : Float) -> Float {
+pub fn Float::lerp(self : Float, target~ : Float, t~ : Float) -> Float {
   self + (target - self) * t
 }
 

--- a/float/pkg.generated.mbti
+++ b/float/pkg.generated.mbti
@@ -38,7 +38,7 @@ pub fn Float::is_inf(Float) -> Bool
 pub fn Float::is_nan(Float) -> Bool
 pub fn Float::is_neg_inf(Float) -> Bool
 pub fn Float::is_pos_inf(Float) -> Bool
-pub fn Float::lerp(Float, Float, Float) -> Float
+pub fn Float::lerp(Float, target~ : Float, t~ : Float) -> Float
 #as_free_fn(deprecated)
 #deprecated
 pub fn Float::pow(Float, Float) -> Float


### PR DESCRIPTION
### Motivation

- Provide common numeric utilities `clamp` and `lerp` for floating types so callers no longer need to reimplement these frequently-used operations for graphics/animation and general numeric code.
- Keep `Float` and `Double` APIs consistent with other numeric types that already provide `clamp`-style helpers.

### Description

- Added `pub fn Float::clamp(self : Float, min~ : Float, max~ : Float) -> Float` and `pub fn Float::lerp(self : Float, target : Float, t : Float) -> Float` in `float/methods.mbt`, with docs and examples and a `guard min <= max` to validate the range.
- Added `pub fn Double::clamp(self : Double, min~ : Double, max~ : Double) -> Double` and `pub fn Double::lerp(self : Double, target : Double, t : Double) -> Double` in `builtin/double.mbt`, matching Float semantics.
- Added tests covering normal behavior and invalid-range panic cases: `float/float_test.mbt` and `builtin/double_test.mbt` include `clamp` and `lerp` checks and `ignore(...)` cases for the `guard` violation.
- Regenerated package interfaces so the new methods are exported (`float/pkg.generated.mbti` and `builtin/pkg.generated.mbti`).

### Testing

- Ran `moon info && moon fmt` successfully to update interfaces and format sources.
- Ran `moon test` and observed `Total tests: 5781, passed: 5781, failed: 0` indicating all tests passed.
- Ran `moon check` which completed with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a541c30e288320b57bfd43e9017056)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
