### PR TITLE
Add min/max/clamp/signum helpers for Float/Double/Int64/UInt

### DIFF
--- a/builtin/double.mbt
+++ b/builtin/double.mbt
@@ -57,6 +57,38 @@ pub fn Double::from_int(i : Int) -> Double {
 pub fn Double::abs(self : Double) -> Double = "%f64.abs"
 
 ///|
+/// Returns the minimum of two double-precision floating-point values.
+///
+/// If exactly one argument is NaN, returns the other argument.
+pub fn Double::min(self : Double, other : Double) -> Double {
+  if self.is_nan() {
+    other
+  } else if other.is_nan() {
+    self
+  } else if self < other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Returns the maximum of two double-precision floating-point values.
+///
+/// If exactly one argument is NaN, returns the other argument.
+pub fn Double::max(self : Double, other : Double) -> Double {
+  if self.is_nan() {
+    other
+  } else if other.is_nan() {
+    self
+  } else if self > other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
 /// Clamps the value between `min` and `max` (inclusive).
 ///
 /// Parameters:

--- a/builtin/double_test.mbt
+++ b/builtin/double_test.mbt
@@ -192,3 +192,21 @@ test "Double::is_neg_inf" {
 test "min equal to neg max" {
   assert_true(@double.min_value == -@double.max_value)
 }
+
+///|
+test "Double::min and Double::max" {
+  assert_eq(1.0.min(2.0), 1.0)
+  assert_eq(2.0.min(1.0), 1.0)
+  assert_eq(1.0.max(2.0), 2.0)
+  assert_eq(2.0.max(1.0), 2.0)
+}
+
+///|
+test "Double::min and Double::max with NaN" {
+  assert_eq(@double.not_a_number.min(1.0), 1.0)
+  assert_eq(1.0.min(@double.not_a_number), 1.0)
+  assert_eq(@double.not_a_number.max(1.0), 1.0)
+  assert_eq(1.0.max(@double.not_a_number), 1.0)
+  assert_true(@double.not_a_number.min(@double.not_a_number).is_nan())
+  assert_true(@double.not_a_number.max(@double.not_a_number).is_nan())
+}

--- a/builtin/int64.mbt
+++ b/builtin/int64.mbt
@@ -59,6 +59,39 @@ pub fn Int64::abs(self : Int64) -> Int64 {
 }
 
 ///|
+/// Returns the minimum of two 64-bit signed integers.
+pub fn Int64::min(self : Int64, other : Int64) -> Int64 {
+  if self < other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Returns the maximum of two 64-bit signed integers.
+pub fn Int64::max(self : Int64, other : Int64) -> Int64 {
+  if self > other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Clamps the value `self` between `min` and `max`.
+pub fn Int64::clamp(self : Int64, min~ : Int64, max~ : Int64) -> Int64 {
+  guard min <= max
+  if self < min {
+    min
+  } else if self > max {
+    max
+  } else {
+    self
+  }
+}
+
+///|
 pub impl Hash for Int64 with hash_combine(self, hasher) {
   hasher.combine_int64(self)
 }

--- a/builtin/int64_additional_test.mbt
+++ b/builtin/int64_additional_test.mbt
@@ -39,3 +39,17 @@ test "int64 conversions and defaults" {
   assert_eq(u_hi.ctz(), 32)
   assert_eq(UInt64::trunc_double(1234567.89), 1234567UL)
 }
+
+///|
+test "Int64::min, Int64::max and Int64::clamp" {
+  assert_eq(1L.min(2L), 1L)
+  assert_eq(2L.max(1L), 2L)
+  assert_eq(1L.clamp(min=0L, max=2L), 1L)
+  assert_eq((-1L).clamp(min=0L, max=2L), 0L)
+  assert_eq(3L.clamp(min=0L, max=2L), 2L)
+}
+
+///|
+test "panic Int64::clamp with invalid range" {
+  ignore(1L.clamp(min=2L, max=1L))
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -541,6 +541,7 @@ pub fn Int::until(Int, Int, step? : Int, inclusive? : Bool) -> Iter[Int]
 pub fn Int64::abs(Int64) -> Int64
 #deprecated
 pub fn Int64::asr(Int64, Int) -> Int64
+pub fn Int64::clamp(Int64, min~ : Int64, max~ : Int64) -> Int64
 pub fn Int64::clz(Int64) -> Int
 pub fn Int64::ctz(Int64) -> Int
 pub fn Int64::from_int(Int) -> Int64
@@ -549,6 +550,8 @@ pub fn Int64::lnot(Int64) -> Int64
 pub fn Int64::lsl(Int64, Int) -> Int64
 #deprecated
 pub fn Int64::lsr(Int64, Int) -> Int64
+pub fn Int64::max(Int64, Int64) -> Int64
+pub fn Int64::min(Int64, Int64) -> Int64
 pub fn Int64::popcnt(Int64) -> Int
 pub fn Int64::reinterpret_as_double(Int64) -> Double
 pub fn Int64::reinterpret_as_uint64(Int64) -> UInt64
@@ -567,6 +570,7 @@ pub fn Int64::to_uint16(Int64) -> UInt16
 pub fn Int64::to_uint64(Int64) -> UInt64
 pub fn Int64::until(Int64, Int64, step? : Int64, inclusive? : Bool) -> Iter[Int64]
 
+pub fn UInt::clamp(UInt, min~ : UInt, max~ : UInt) -> UInt
 pub fn UInt::clz(UInt) -> Int
 pub fn UInt::ctz(UInt) -> Int
 pub fn UInt::lnot(UInt) -> UInt
@@ -574,6 +578,8 @@ pub fn UInt::lnot(UInt) -> UInt
 pub fn UInt::lsl(UInt, Int) -> UInt
 #deprecated
 pub fn UInt::lsr(UInt, Int) -> UInt
+pub fn UInt::max(UInt, UInt) -> UInt
+pub fn UInt::min(UInt, UInt) -> UInt
 pub fn UInt::popcnt(UInt) -> Int
 #deprecated
 pub fn UInt::reinterpret_as_float(UInt) -> Float
@@ -647,6 +653,8 @@ pub fn Double::is_nan(Double) -> Bool
 pub fn Double::is_neg_inf(Double) -> Bool
 pub fn Double::is_pos_inf(Double) -> Bool
 pub fn Double::lerp(Double, target~ : Double, t~ : Double) -> Double
+pub fn Double::max(Double, Double) -> Double
+pub fn Double::min(Double, Double) -> Double
 #deprecated
 pub fn Double::pow(Double, Double) -> Double
 #deprecated

--- a/builtin/uint.mbt
+++ b/builtin/uint.mbt
@@ -1,0 +1,46 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Returns the minimum of two unsigned integers.
+pub fn UInt::min(self : UInt, other : UInt) -> UInt {
+  if self < other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Returns the maximum of two unsigned integers.
+pub fn UInt::max(self : UInt, other : UInt) -> UInt {
+  if self > other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Clamps the value `self` between `min` and `max`.
+pub fn UInt::clamp(self : UInt, min~ : UInt, max~ : UInt) -> UInt {
+  guard min <= max
+  if self < min {
+    min
+  } else if self > max {
+    max
+  } else {
+    self
+  }
+}

--- a/builtin/uint_test.mbt
+++ b/builtin/uint_test.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "UInt::min, UInt::max and UInt::clamp" {
+  assert_eq((1 : UInt).min(2), 1)
+  assert_eq((2 : UInt).max(1), 2)
+  assert_eq((1 : UInt).clamp(min=0, max=2), 1)
+  assert_eq((0 : UInt).clamp(min=1, max=2), 1)
+  assert_eq((3 : UInt).clamp(min=1, max=2), 2)
+}
+
+///|
+test "panic UInt::clamp with invalid range" {
+  ignore((1 : UInt).clamp(min=2, max=1))
+}

--- a/float/float_test.mbt
+++ b/float/float_test.mbt
@@ -211,3 +211,29 @@ test "Float::until with NaN step" {
   }
   inspect(values, content="[1]")
 }
+
+///|
+test "Float::min and Float::max" {
+  assert_eq((1.0 : Float).min(2.0), 1.0)
+  assert_eq((2.0 : Float).min(1.0), 1.0)
+  assert_eq((1.0 : Float).max(2.0), 2.0)
+  assert_eq((2.0 : Float).max(1.0), 2.0)
+}
+
+///|
+test "Float::min and Float::max with NaN" {
+  assert_eq(@float.not_a_number.min(1.0), 1.0)
+  assert_eq((1.0 : Float).min(@float.not_a_number), 1.0)
+  assert_eq(@float.not_a_number.max(1.0), 1.0)
+  assert_eq((1.0 : Float).max(@float.not_a_number), 1.0)
+  assert_true(@float.not_a_number.min(@float.not_a_number).is_nan())
+  assert_true(@float.not_a_number.max(@float.not_a_number).is_nan())
+}
+
+///|
+test "Float::signum" {
+  assert_eq((-2.0 : Float).signum(), -1.0)
+  assert_eq((1.0 : Float).signum(), 1.0)
+  assert_eq((0.0 : Float).signum(), 0.0)
+  assert_true(@float.not_a_number.signum().is_nan())
+}

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -226,6 +226,38 @@ pub fn Float::is_nan(self : Float) -> Bool {
 }
 
 ///|
+/// Returns the minimum of two floating-point values.
+///
+/// If exactly one argument is NaN, returns the other argument.
+pub fn Float::min(self : Float, other : Float) -> Float {
+  if self.is_nan() {
+    other
+  } else if other.is_nan() {
+    self
+  } else if self < other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Returns the maximum of two floating-point values.
+///
+/// If exactly one argument is NaN, returns the other argument.
+pub fn Float::max(self : Float, other : Float) -> Float {
+  if self.is_nan() {
+    other
+  } else if other.is_nan() {
+    self
+  } else if self > other {
+    self
+  } else {
+    other
+  }
+}
+
+///|
 /// Clamps the value between `min` and `max` (inclusive).
 ///
 /// Parameters:
@@ -280,6 +312,21 @@ pub fn Float::clamp(self : Float, min~ : Float, max~ : Float) -> Float {
 /// ```
 pub fn Float::lerp(self : Float, target~ : Float, t~ : Float) -> Float {
   self + (target - self) * t
+}
+
+///|
+/// Returns the sign of the float.
+/// - If the float is positive, returns 1.0.
+/// - If the float is negative, returns -1.0.
+/// - Otherwise, returns the float itself (0.0, -0.0 and NaN).
+pub fn Float::signum(self : Float) -> Float {
+  if self < 0.0 {
+    -1.0
+  } else if self > 0.0 {
+    1.0
+  } else {
+    self
+  }
 }
 
 ///|

--- a/float/pkg.generated.mbti
+++ b/float/pkg.generated.mbti
@@ -39,6 +39,8 @@ pub fn Float::is_nan(Float) -> Bool
 pub fn Float::is_neg_inf(Float) -> Bool
 pub fn Float::is_pos_inf(Float) -> Bool
 pub fn Float::lerp(Float, target~ : Float, t~ : Float) -> Float
+pub fn Float::max(Float, Float) -> Float
+pub fn Float::min(Float, Float) -> Float
 #as_free_fn(deprecated)
 #deprecated
 pub fn Float::pow(Float, Float) -> Float
@@ -48,6 +50,7 @@ pub fn Float::reinterpret_from_int(Int) -> Float
 pub fn Float::reinterpret_from_uint(UInt) -> Float
 #as_free_fn
 pub fn Float::round(Float) -> Float
+pub fn Float::signum(Float) -> Float
 pub fn Float::sqrt(Float) -> Float
 pub fn Float::to_be_bytes(Float) -> Bytes
 pub fn Float::to_double(Float) -> Double


### PR DESCRIPTION
### Motivation

- Numeric types lacked a consistent set of small utility methods (`min`, `max`, `clamp`, `signum`) across `Float`, `Double`, `Int64`, and `UInt`, forcing callers to hand-roll common helpers.
- Provide IEEE-style `min`/`max` semantics for floating types (when exactly one operand is `NaN`, return the non-`NaN` operand) and parity with existing `Int` APIs to simplify client code.

### Description

- Added `Float::min`, `Float::max`, and `Float::signum` to the `float` package implementing IEEE-style NaN handling and parity with `Double::signum` (`float/methods.mbt`).
- Added `Double::min` and `Double::max` with the same NaN semantics (`builtin/double.mbt`).
- Added `Int64::min`, `Int64::max`, and `Int64::clamp` (`builtin/int64.mbt`) and `UInt::min`, `UInt::max`, and `UInt::clamp` (`builtin/uint.mbt`).
- Added tests covering basic behavior, NaN cases for float/double `min`/`max`, and clamp panic cases for invalid ranges; updated generated interface files (`.mbti`) to expose the new APIs.

### Testing

- Ran `moon fmt` which completed successfully.
- Ran `moon info` and `moon check` which completed successfully and updated package interfaces.
- Ran the full test suite with `moon test` and observed all tests passed (`Total tests: 5790, passed: 5790, failed: 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a672508200832095f865637385cb95)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
