### PR TITLE
fix unused loop variables

### DIFF
--- a/bench/README.mbt.md
+++ b/bench/README.mbt.md
@@ -133,7 +133,7 @@ test "string benchmarks" {
   // Benchmark string concatenation
   bencher.bench(name="string_concat", fn() {
     let mut result = ""
-    for i in 0..<5 {
+    for _ in 0..<5 {
       result = result + "x"
     }
   })
@@ -141,7 +141,7 @@ test "string benchmarks" {
   // Benchmark StringBuilder (should be faster)
   bencher.bench(name="stringbuilder", fn() {
     let builder = StringBuilder::new()
-    for i in 0..<5 {
+    for _ in 0..<5 {
       builder.write_string("x")
     }
     ignore(builder.to_string())

--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -15,7 +15,7 @@
 ///|
 fn iter_n_microseconds(inner : () -> Unit, k : Int) -> Double {
   let ts = monotonic_clock_start()
-  for i in 0..<k {
+  for _ in 0..<k {
     inner()
   }
   let diff = monotonic_clock_end(ts)

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -952,7 +952,7 @@ pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
   }
   let mut ret = ""
   for i in 0..<(v_idx - 1) {
-    for j in 0..<decimal_radix_bit_len {
+    for _ in 0..<decimal_radix_bit_len {
       let x = v[i] % 10L
       v[i] /= 10L
       ret = x.to_string() + ret

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1252,7 +1252,7 @@ pub fn[T] Array::flatten(self : Array[Array[T]]) -> Array[T] {
 /// ```
 pub fn[T] Array::repeat(self : Array[T], times : Int) -> Array[T] {
   let v = Array::new(capacity=self.length() * times)
-  for i in 0..<times {
+  for _ in 0..<times {
     v.append(self)
   }
   v

--- a/builtin/double_ryu_nonjs.mbt
+++ b/builtin/double_ryu_nonjs.mbt
@@ -612,7 +612,7 @@ fn to_chars(v : FloatingDecimal64, sign : Bool) -> String {
         output /= 10
       }
       index += olength
-      for i in olength..<(exp + 1) {
+      for _ in olength..<(exp + 1) {
         result[index] = b'0'
         index += 1
       }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -662,7 +662,7 @@ test "unsafe_pop_front after many push_front" {
   for i in 0..<10 {
     dq.push_front(i)
   }
-  for i in 0..<10 {
+  for _ in 0..<10 {
     dq.unsafe_pop_front()
   }
   assert_eq(dq.len, 0)

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -470,7 +470,7 @@ test "unsafe_pop_front after many push_front" {
     dq.push_front(i)
   }
   // Pop all elements except one
-  for i in 0..<9 {
+  for _ in 0..<9 {
     dq.unsafe_pop_front()
   }
   // Now head should be at the end of buffer

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -36,7 +36,7 @@ fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
   // Start constructing the array
   let ret = []
   let mut cur_len = 0
-  for i in 0..<times {
+  for _ in 0..<times {
     let op = rng.int(limit=op_count)
     match op {
       0 => {
@@ -110,7 +110,7 @@ fn execute_array_test(rs : Array[Op]) -> Unit raise {
 /// Compute the power of the branching factor.
 fn branching_factor_power(a : Int) -> Int {
   let mut ret = 1
-  for i in 0..<a {
+  for _ in 0..<a {
     ret *= branching_factor
   }
   ret

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -67,7 +67,7 @@ fn ParseContext::lex_hex_digits(
   n : Int,
 ) -> Int raise ParseError {
   let mut r = 0
-  for i in 0..<n {
+  for _ in 0..<n {
     match ctx.read_char() {
       Some(c) =>
         if c >= 'A' {

--- a/math/prime.mbt
+++ b/math/prime.mbt
@@ -295,7 +295,7 @@ fn miller_rabin_test(
   // (step 3) 
   let w3_len = w3.bit_length()
   // (step 4)
-  next~: for i in 0..<iters {
+  next~: for _ in 0..<iters {
     // (step 4.1) obtain a random BigInt b where 1 < b < w-1
     let rand_b = for {
       let x = rand.bigint(w3_len)
@@ -311,7 +311,7 @@ fn miller_rabin_test(
       continue next~
     }
     // (step 4.5)
-    for j in 1..<a {
+    for _ in 1..<a {
       // (step 4.5.1) z = z^2 mod w
       z = z.pow(2, modulus=w)
       // (step 4.5.2)

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -132,7 +132,7 @@ fn chacha_block(
     let mut b13 = buf[13 * 4 + i]
     let mut b14 = buf[14 * 4 + i]
     let mut b15 = buf[15 * 4 + i]
-    for round in 0..<4 {
+    for _ in 0..<4 {
       let Quadruple(tb1_0, tb1_1, tb1_2, tb1_3) = qr(Quadruple(b0, b4, b8, b12))
       b0 = tb1_0
       b4 = tb1_1
@@ -292,7 +292,7 @@ test "output" {
     }
   }
 
-  for i in 0..<372 {
+  for _ in 0..<372 {
     let x = uint64(s)
     res.push(x)
   }

--- a/random/random_test.mbt
+++ b/random/random_test.mbt
@@ -96,7 +96,7 @@ test "uint64 modulo bias handling with large limit" {
 test "bench random" (b : @bench.T) {
   let r = @random.Rand::new()
   b.bench(() => {
-    for i in 0..<1000000 {
+    for _ in 0..<1000000 {
       let _ = r.uint64(limit=10000000000000000000UL)
     }
   })

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -529,7 +529,7 @@ pub impl Show for Decimal with output(self, logger) {
   if self.decimal_point <= 0 {
     // zeros filling between the decimal point and the digits
     logger.write_string("0.")
-    for i in 0..<-self.decimal_point {
+    for _ in 0..<-self.decimal_point {
       logger.write_char('0')
     }
     for i in 0..<self.digits_num {
@@ -548,7 +548,7 @@ pub impl Show for Decimal with output(self, logger) {
     for i in 0..<self.digits_num {
       logger.write_string(self.digits[i].to_int().to_string())
     }
-    for i in 0..<(self.decimal_point - self.digits_num) {
+    for _ in 0..<(self.decimal_point - self.digits_num) {
       logger.write_char('0')
     }
   }


### PR DESCRIPTION
Due to a compiler bug, previously some unused loop variables are not caught by compiler warnings. The bug is fixed in nightly release, and this PR fixes some previously uncaught unused loop variables on `moonbitlang/core`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
