### PR TITLE
fix(regex): avoid RC cycles in regex_engine state transitions

### DIFF
--- a/internal/regex_engine/execute.mbt
+++ b/internal/regex_engine/execute.mbt
@@ -46,20 +46,21 @@ pub fn MatchResult::group(self : MatchResult, index : Int) -> (Int, Int)? {
 }
 
 ///|
-fn Regex::find_start_state(self : Regex, cat : Category) -> State {
+fn Regex::find_start_state(self : Regex, cat : Category) -> StateId {
   for i in 0..<self.start_states.length() {
-    let (cat2, state) = self.start_states[i]
+    let (cat2, state_id) = self.start_states[i]
     if cat2 == cat {
-      return state
+      return state_id
     }
   }
-  let state = find_state(
+  let state_id = find_state(
     self.state_table,
+    self.states,
     self.symbol_repr.length(),
     @automata.State::start(cat, self.expr),
   )
-  self.start_states.push((cat, state))
-  state
+  self.start_states.push((cat, state_id))
+  state_id
 }
 
 ///|
@@ -83,10 +84,11 @@ pub fn[T : Input] Regex::execute(
       prev_symbol,
     )
   }
-  let start_state = self.find_start_state(start_cat)
+  let start_state_id = self.find_start_state(start_cat)
   let positions = Positions::new()
-  let mut state = start_state
+  let mut state_id = start_state_id
   while pos < end {
+    let state = self.states[state_id]
     let ch = input.get(pos)
     let symbol = self.symbol_table.map(ch)
     // INVARIANT: The start state is never a break state.
@@ -94,8 +96,8 @@ pub fn[T : Input] Regex::execute(
     //   `/[]/`  -> `seq(shortest(char(any)), capture(empty))`
     //   `/^[]/` -> `capture(seq(start_of_input, empty))`
     // This ensures the executor can safely access state.transitions[symbol] without checking.
-    let next_state = state.transitions[symbol]
-    state = if next_state.kind is Pending {
+    let next_state_id = state.transitions[symbol]
+    state_id = if next_state_id == PENDING_STATE_ID {
       let cat = category_from_symbol(
         profile=self.profile,
         symbol_repr=self.symbol_repr,
@@ -107,16 +109,18 @@ pub fn[T : Input] Regex::execute(
         symbol,
         next_cat=cat,
       )
-      let next_state = find_state(
+      let next_state_id = find_state(
         self.state_table,
+        self.states,
         self.symbol_repr.length(),
         next_desc,
       )
-      state.transitions[symbol] = next_state
-      next_state
+      state.transitions[symbol] = next_state_id
+      next_state_id
     } else {
-      next_state
+      next_state_id
     }
+    let state = self.states[state_id]
     let slot = state.desc.slot()
     if slot.is_assigned() {
       positions.set(slot, pos)
@@ -126,6 +130,7 @@ pub fn[T : Input] Regex::execute(
     }
     pos += 1
   }
+  let state = self.states[state_id]
   let matched = match state.desc.status() {
     Failed => None
     Running => {

--- a/internal/regex_engine/regex.mbt
+++ b/internal/regex_engine/regex.mbt
@@ -20,8 +20,9 @@ struct Regex {
   groups : ReadOnlyArray[String?]
   symbol_table : &@symbol_map.Table
   symbol_repr : ReadOnlyArray[Rechar]
-  start_states : Array[(Category, State)]
-  state_table : @hashmap.HashMap[@automata.State, State]
+  start_states : Array[(Category, StateId)]
+  state_table : @hashmap.HashMap[@automata.State, StateId]
+  states : Array[State]
 }
 
 ///|
@@ -48,5 +49,6 @@ fn Regex::new(
     symbol_repr,
     start_states: [],
     state_table: @hashmap.HashMap::new(),
+    states: [],
   }
 }

--- a/internal/regex_engine/regex_engine_test.mbt
+++ b/internal/regex_engine/regex_engine_test.mbt
@@ -79,6 +79,35 @@ test "execute with lastIndex and cached transitions/start-state" {
 }
 
 ///|
+test "execute with lastIndex and cached failure transitions" {
+  let pat = @regex_engine.char(@regex_engine.RecharSet::char('a'))
+  let re = @regex_engine.compile(profile~, pat)
+  assert_true(re.execute("bb"[:], 1) is None)
+  // second run hits cached start state + failed transition
+  assert_true(re.execute("bb"[:], 1) is None)
+}
+
+///|
+test "nested stars execute repeatedly" {
+  let a = @regex_engine.char(@regex_engine.RecharSet::char('a'))
+  let inner = @regex_engine.quantifier(a, { min: 0, max: None, mode: Greedy })
+  let outer = @regex_engine.quantifier(inner, {
+    min: 0,
+    max: None,
+    mode: Greedy,
+  })
+  let pat = @regex_engine.seq([
+    @regex_engine.start_of_input, outer, @regex_engine.end_of_input,
+  ])
+  let re = @regex_engine.compile(profile~, pat)
+  guard re.execute("aaa"[:], 0) is Some(mr1) else { fail("Expected match") }
+  assert_eq(mr1.group(0), Some((0, 3)))
+  // Repeat the same execution path to exercise cached transitions.
+  guard re.execute("aaa"[:], 0) is Some(mr2) else { fail("Expected match") }
+  assert_eq(mr2.group(0), Some((0, 3)))
+}
+
+///|
 test "alternation compiles and matches" {
   let pat = @regex_engine.alt([
     @regex_engine.char(@regex_engine.RecharSet::char('a')),

--- a/internal/regex_engine/state.mbt
+++ b/internal/regex_engine/state.mbt
@@ -13,16 +13,21 @@
 // limitations under the License.
 
 ///|
+type StateId = Int
+
+///|
+const PENDING_STATE_ID : StateId = -1
+
+///|
 priv struct State {
   kind : StateKind
   desc : @automata.State
-  transitions : FixedArray[State] // indexed by symbol
+  transitions : FixedArray[StateId] // indexed by symbol
   mut final_ : @list.List[(Category, @automata.Slot, @automata.Status)]
 }
 
 ///|
 priv enum StateKind {
-  Pending
   Break
   Normal
 }
@@ -43,25 +48,22 @@ fn State::new(desc : @automata.State, num_symbols : Int) -> State {
     transitions: if is_break {
       []
     } else {
-      FixedArray::make(num_symbols, pending_state)
+      FixedArray::make(num_symbols, PENDING_STATE_ID)
     },
     final_: @list.empty(),
   }
 }
 
 ///|
-let pending_state : State = {
-  kind: Pending,
-  desc: @automata.st_dummy,
-  transitions: [],
-  final_: @list.empty(),
-}
-
-///|
 fn find_state(
-  table : @hashmap.HashMap[@automata.State, State],
+  table : @hashmap.HashMap[@automata.State, StateId],
+  states : Array[State],
   num_symbols : Int,
   desc : @automata.State,
-) -> State {
-  table.get_or_init(desc, () => State::new(desc, num_symbols))
+) -> StateId {
+  table.get_or_init(desc, () => {
+    let state_id = states.length()
+    states.push(State::new(desc, num_symbols))
+    state_id
+  })
 }


### PR DESCRIPTION
## Summary

MoonBit uses reference counting for memory management.  
In `internal/regex_engine`, `State.transitions` previously stored direct `State` references, which could form reference cycles in the state graph and make those states non-reclaimable.

This PR removes that cycle risk by changing transition edges to ID-based references.

## What Changed

- Introduced `StateId` in `regex_engine` state runtime.
- Changed `State.transitions` from `FixedArray[State]` to `FixedArray[StateId]`.
- Replaced pending-state object sentinel with a pending-state-id sentinel.
- Refactored state dedup/cache:
  - `state_table` now maps `@automata.State -> StateId`.
  - Added a central `states : Array[State]` pool in `Regex`.
  - `start_states` now stores `(Category, StateId)`.
- Updated executor flow to advance by `StateId` and resolve through the state pool.
- Added regression test: `nested stars execute repeatedly` to cover repeated execution on highly-looping patterns.

## Why This Is Safe

- This is an internal refactor of `internal/regex_engine` runtime state representation.
- Matching semantics and lazy transition caching behavior are preserved.
- Public API surface remains unchanged.

## Validation

- `moon check`
- `moon test internal/regex_engine`
- `moon test`

All tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
