### PR TITLE
fix(argparse): handle llvm as well

### DIFF
--- a/argparse/runtime_exit_native.mbt
+++ b/argparse/runtime_exit_native.mbt
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 ///|
-#cfg(target="native")
+#cfg(any(target="native", target="llvm"))
 extern "c" fn runtime_native_exit(code : Int) = "exit"
 
 ///|
-#cfg(target="native")
+#cfg(any(target="native", target="llvm"))
 fn runtime_exit_success() -> Unit {
   runtime_native_exit(0)
 }


### PR DESCRIPTION
Core didn't have nightly CI, so the llvm support was missed and failed the nightly distribution. This is a quick fix @myfreess 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
