### PR TITLE
add Debug impls for Error and builtin error types

### DIFF
--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -1426,3 +1426,62 @@ test "dump" {
     assert_eq(dump(x) + x, 84)
   }
 }
+
+///|
+fn error_to_repr(e : Error) -> Repr = "%error.to_repr"
+
+///|
+pub impl Debug for Error with to_repr(self) {
+  error_to_repr(self)
+}
+
+///|
+pub impl Debug for InspectError with to_repr(self) {
+  match self {
+    InspectError(msg) => Repr::ctor("InspectError", [(None, Repr::string(msg))])
+  }
+}
+
+///|
+pub impl Debug for Failure with to_repr(self) {
+  match self {
+    Failure(msg) => Repr::ctor("Failure", [(None, Repr::string(msg))])
+  }
+}
+
+///|
+pub impl Debug for SnapshotError with to_repr(self) {
+  match self {
+    SnapshotError(msg) =>
+      Repr::ctor("SnapshotError", [(None, Repr::string(msg))])
+  }
+}
+
+///|
+test "Debug for Error" {
+  fn fail_with_error() -> Unit raise {
+    raise InspectError::InspectError("test error")
+  }
+
+  let result : Result[Unit, Error] = try? fail_with_error()
+  match result {
+    Err(e) => debug_inspect(e, content="InspectError(\"test error\")")
+    Ok(_) => fail("expected error")
+  }
+}
+
+///|
+test "Debug for builtin errors" {
+  debug_inspect(
+    InspectError::InspectError("inspect msg"),
+    content="InspectError(\"inspect msg\")",
+  )
+  debug_inspect(
+    Failure::Failure("failure msg"),
+    content="Failure(\"failure msg\")",
+  )
+  debug_inspect(
+    SnapshotError::SnapshotError("snapshot msg"),
+    content="SnapshotError(\"snapshot msg\")",
+  )
+}

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -59,13 +59,17 @@ pub impl[T : Debug, E : Debug] Debug for Result[T, E]
 pub impl[T : Debug] Debug for FixedArray[T]
 pub impl[T : Debug] Debug for ReadOnlyArray[T]
 pub impl Debug for Bytes
+pub impl Debug for Error
 pub impl Debug for @buffer.Buffer
 pub impl[T : Debug] Debug for Array[T]
 pub impl[T : Debug] Debug for ArrayView[T]
+pub impl Debug for Failure
+pub impl Debug for InspectError
 pub impl[A] Debug for Iter[A]
 pub impl[A, B] Debug for Iter2[A, B]
 pub impl[K : Debug, V : Debug] Debug for Map[K, V]
 pub impl[T : Debug] Debug for MutArrayView[T]
+pub impl Debug for SnapshotError
 pub impl Debug for SourceLoc
 pub impl Debug for StringBuilder
 pub impl[A : Debug] Debug for @deque.Deque[A]


### PR DESCRIPTION
## Summary
- Implement `Debug for Error` using the `%error.to_repr` intrinsic
- Add structured `Debug` impls for `InspectError`, `Failure`, and `SnapshotError` that produce readable output like `Failure("msg")` instead of opaque representations
- Add tests for all new impls

## Test plan
- [x] `moon test -p moonbitlang/core/debug -f "debug.mbt"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
