### PR TITLE
perf(regex): avoid bounds check & expensive RC operations

### DIFF
--- a/internal/regex_engine/execute.mbt
+++ b/internal/regex_engine/execute.mbt
@@ -71,13 +71,14 @@ pub fn[T : Input] Regex::execute(
   lastIndex : Int,
 ) -> MatchResult? {
   guard lastIndex >= 0 && lastIndex <= input.length() else { panic() }
+  let { states, symbol_table, .. } = self
   let mut pos = lastIndex
   let end = input.length()
   let start_cat = if pos == 0 {
     Category::inexistant()
   } else {
     let prev = input.get(pos - 1)
-    let prev_symbol = self.symbol_table.map(prev)
+    let prev_symbol = symbol_table.map(prev)
     category_from_symbol(
       profile=self.profile,
       symbol_repr=self.symbol_repr,
@@ -88,15 +89,15 @@ pub fn[T : Input] Regex::execute(
   let positions = Positions::new()
   let mut state_id = start_state_id
   while pos < end {
-    let state = self.states[state_id]
+    let state = states.unsafe_get(state_id)
     let ch = input.get(pos)
-    let symbol = self.symbol_table.map(ch)
+    let symbol = symbol_table.map(ch)
     // INVARIANT: The start state is never a break state.
     // Empty character classes like `/[]/` are transformed during compilation:
     //   `/[]/`  -> `seq(shortest(char(any)), capture(empty))`
     //   `/^[]/` -> `capture(seq(start_of_input, empty))`
     // This ensures the executor can safely access state.transitions[symbol] without checking.
-    let next_state_id = state.transitions[symbol]
+    let next_state_id = state.transitions.unsafe_get(symbol)
     state_id = if next_state_id == PENDING_STATE_ID {
       let cat = category_from_symbol(
         profile=self.profile,
@@ -111,7 +112,7 @@ pub fn[T : Input] Regex::execute(
       )
       let next_state_id = find_state(
         self.state_table,
-        self.states,
+        states,
         self.symbol_repr.length(),
         next_desc,
       )
@@ -120,17 +121,22 @@ pub fn[T : Input] Regex::execute(
     } else {
       next_state_id
     }
-    let state = self.states[state_id]
+    let state = states.unsafe_get(state_id)
     let slot = state.desc.slot()
     if slot.is_assigned() {
-      positions.set(slot, pos)
+      // NOTE: we manually inline `Positions::set` here to avoid the overhead
+      // of callee-owned RC (reference counting) operations.
+      if slot.0 >= positions.0.length() {
+        positions.0.resize(slot.0 + 1, -1)
+      }
+      positions.0[slot.0] = pos
     }
     if state.kind is Break {
       break
     }
     pos += 1
   }
-  let state = self.states[state_id]
+  let state = states.unsafe_get(state_id)
   let matched = match state.desc.status() {
     Failed => None
     Running => {
@@ -140,7 +146,7 @@ pub fn[T : Input] Regex::execute(
         Category::inexistant()
       } else {
         let ch = input.get(pos)
-        let symbol = self.symbol_table.map(ch)
+        let symbol = symbol_table.map(ch)
         category_from_symbol(
           profile=self.profile,
           symbol_repr=self.symbol_repr,

--- a/internal/regex_engine/input.mbt
+++ b/internal/regex_engine/input.mbt
@@ -28,7 +28,7 @@ pub impl Input for BytesView with length(self) {
 
 ///|
 pub impl Input for BytesView with get(self, index) {
-  self[index].to_int()
+  self.unsafe_get(index).to_int()
 }
 
 ///|
@@ -38,5 +38,5 @@ pub impl Input for StringView with length(self) {
 
 ///|
 pub impl Input for StringView with get(self, index) {
-  self[index].to_int()
+  self.unsafe_get(index).to_int()
 }

--- a/internal/regex_engine/symbol_map/dense_table.mbt
+++ b/internal/regex_engine/symbol_map/dense_table.mbt
@@ -17,5 +17,5 @@ priv struct DenseTable(FixedArray[@shared_types.Rechar])
 
 ///|
 impl Table for DenseTable with map(self, c) {
-  self.0[c]
+  self.0.unsafe_get(c)
 }


### PR DESCRIPTION
This PR optimizes the hot path of the regex engine — the main character-by-character matching loop in Regex::execute execute.mbt:90-138.

Three kinds of overhead are removed:

Bounds checks — replaced [] with unsafe_get at every layer of the execution pipeline (state lookup, transition table, symbol map, input access). The loop invariants already guarantee valid indices.

Repeated field access — self.states and self.symbol_table are hoisted into local variables so the compiler avoids repeated struct indirection.

Reference counting — Positions::set is manually inlined in the hot loop to avoid callee-owned RC operations at the call boundary.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
