### PR TITLE
refactor(json): convert Replacer to named struct with new constructor

### DIFF
--- a/json/json.mbt
+++ b/json/json.mbt
@@ -121,7 +121,11 @@ priv enum WriteFrame {
 /// - `None` to exclude the property from the output
 /// 
 /// Only applies to object properties, not array elements.
-struct Replacer((String, Json) -> Json?)
+pub struct Replacer {
+  priv f : (String, Json) -> Json?
+
+  fn new(f : (String, Json) -> Json?) -> Replacer
+}
 
 ///|
 /// Create a new Replacer with a custom function.
@@ -150,7 +154,7 @@ struct Replacer((String, Json) -> Json?)
 /// }
 /// ```
 pub fn Replacer::new(f : (String, Json) -> Json?) -> Replacer {
-  Replacer(f)
+  { f, }
 }
 
 ///|
@@ -172,15 +176,15 @@ pub fn Replacer::new(f : (String, Json) -> Json?) -> Replacer {
 /// }
 /// ```
 pub fn Replacer::keep(array : ArrayView[StringView]) -> Replacer {
-  Replacer((idx, value) => if array.contains(idx) { Some(value) } else { None })
+  { f: fn(idx, value) { if array.contains(idx) { Some(value) } else { None } } }
 }
 
 ///|
 /// Create a Replacer that excludes the specified property keys.
 /// All other properties will be included in the output.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```mbt check
 /// test {
 ///   let replacer = @json.Replacer::exclude(["password", "secret", "private"])
@@ -194,7 +198,7 @@ pub fn Replacer::keep(array : ArrayView[StringView]) -> Replacer {
 /// }
 /// ```
 pub fn Replacer::exclude(array : ArrayView[StringView]) -> Replacer {
-  Replacer((idx, value) => if array.contains(idx) { None } else { Some(value) })
+  { f: fn(idx, value) { if array.contains(idx) { None } else { Some(value) } } }
 }
 
 ///|
@@ -344,7 +348,7 @@ pub fn Json::stringify(
             Some((k, v)) => {
               let mut v2 = v
               if replacer is Some(replacer) {
-                if replacer(k, v) is Some(v) {
+                if (replacer.f)(k, v) is Some(v) {
                   v2 = v
                 } else {
                   continue None
@@ -459,7 +463,7 @@ pub fn Json::transform(self : Self, replacer : Replacer) -> Json {
       .iter()
       .filter_map(pair => {
         let (k, v) = pair
-        if replacer(k, v) is Some(v2) {
+        if (replacer.f)(k, v) is Some(v2) {
           Some((k, v2.transform(replacer)))
         } else {
           None

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -150,16 +150,16 @@ test "stringify with replacer" {
       #|{"a":1,"c":3}
     ),
   )
-  // custom logic
-  let replacer = @json.Replacer::new((idx, value) => {
-    match idx {
-      "b" => None
-      "d" => None
-      _ => Some(value)
-    }
-  })
   inspect(
-    json.stringify(replacer~),
+    json.stringify(
+      replacer=Replacer((idx, value) => {
+        if idx is ("b" | "d") {
+          None
+        } else {
+          Some(value)
+        }
+      }),
+    ),
     content=(
       #|{"a":1,"c":3}
     ),
@@ -189,15 +189,15 @@ test "stringify with replace recursively" {
       #|{"a":1,"c":[{"a":4},{"a":6}]}
     ),
   )
-  // custom logic
-  let replacer = @json.Replacer::new((idx, value) => {
-    match idx {
-      "b" => None
-      _ => Some(value)
-    }
-  })
   inspect(
-    json.stringify(replacer~),
+    json.stringify(
+      replacer=Replacer((idx, value) => {
+        match idx {
+          "b" => None
+          _ => Some(value)
+        }
+      }),
+    ),
     content=(
       #|{"a":1,"c":[{"a":4},{"a":6}]}
     ),
@@ -542,7 +542,7 @@ test "transformer" {
   // custom function
   let json : Json = { "a": 1.0, "b": { "c": 2.0, "d": [3.0, 4.0] } }
   let newjson = json.transform(
-    @json.Replacer::new((_, value) => {
+    Replacer((_, value) => {
       match value {
         Number(n, ..) => Some(Json::number(n * 10))
         other => Some(other)
@@ -564,7 +564,7 @@ test "transformer" {
 test "transformer with array" {
   let json : Json = [1.0, { "a": 2.0 }, [3.0, 4.0]]
   let newjson = json.transform(
-    @json.Replacer::new((_, value) => {
+    Replacer((_, value) => {
       match value {
         Number(n, ..) => Some(Json::number(n + 1))
         other => Some(other)

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -47,7 +47,11 @@ pub(all) struct Position {
 pub impl Eq for Position
 pub impl ToJson for Position
 
-type Replacer
+pub struct Replacer {
+  // private fields
+
+  fn new((String, Json) -> Json?) -> Replacer
+}
 pub fn Replacer::exclude(ArrayView[StringView]) -> Self
 pub fn Replacer::keep(ArrayView[StringView]) -> Self
 pub fn Replacer::new((String, Json) -> Json?) -> Self


### PR DESCRIPTION
## Summary
- Convert `Replacer` from an opaque tuple type to a `pub struct` with a private `f` field and a `fn new` constructor declared in the struct body
- Update internal call sites to use `(replacer.f)(k, v)` field access
- Update tests to use the new `Replacer(...)` constructor syntax (desugars to `Replacer::new(...)`)
- Regenerate `pkg.generated.mbti`

## Test plan
- [x] `moon test -p moonbitlang/core/json` passes (162/162)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
