### PR TITLE
fix invalid constructor expression

### DIFF
--- a/string/regex_profile.mbt
+++ b/string/regex_profile.mbt
@@ -19,7 +19,7 @@ let word_set : @re.RecharSet = @re.RecharSet::char_range('a', 'z') +
   @re.RecharSet::char('_')
 
 ///|
-let re_profile_unicode : @re.Profile = @re.Profile(
+let re_profile_unicode : @re.Profile = Profile(
   valid=@re.RecharSet::char_range(0, 0x10FFFF) -
     @re.RecharSet::char_range(0xD800, 0xDFFF),
   word=word_set,
@@ -33,7 +33,7 @@ let re_profile_unicode : @re.Profile = @re.Profile(
 )
 
 ///|
-let re_profile_utf16 : @re.Profile = @re.Profile(
+let re_profile_utf16 : @re.Profile = Profile(
   valid=@re.RecharSet::char_range(0, 0xFFFF),
   word=re_profile_unicode.word,
   word_symbolize_splits=[


### PR DESCRIPTION
Currently, tuple struct constructor/struct constructor cannot be accessed via `using` alias (we plan to support it in the future, but currently there is no support for this). However, due to a compiler bug, some constructor expressions that should be invalid may accidentally pass the type checker. This PR fixes code in core that accidentally relies on the bug.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
