### PR TITLE
test(deque): add regression coverage for self-aliasing append and blit_to overlap

### DIFF
--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -275,6 +275,20 @@ test "copy" {
 }
 
 ///|
+test "append self keeps order" {
+  let dq = @deque.from_array([1, 2, 3])
+  dq.append(dq)
+  inspect(dq, content="@deque.from_array([1, 2, 3, 1, 2, 3])")
+}
+
+///|
+test "blit_to self overlap copies as memmove" {
+  let dq = @deque.from_array([1, 2, 3, 4, 5])
+  dq.blit_to(dq, src_offset=0, dst_offset=1, len=4)
+  inspect(dq, content="@deque.from_array([1, 1, 2, 3, 4])")
+}
+
+///|
 test "Deque::set" {
   let dv = @deque.from_array([1, 2, 3, 4, 5])
   dv[1] = 3


### PR DESCRIPTION
### Motivation
- Add lightweight regression coverage for subtle self-aliasing/overlap scenarios in `deque` to prevent future regressions and validate memmove-like semantics.

### Description
- Added two tests in `deque/deque_test.mbt`: `append self keeps order` to verify `dq.append(dq)` preserves element order and duplicates contents, and `blit_to self overlap copies as memmove` to validate overlapping self-copies behave correctly.

### Testing
- Ran `moon fmt && moon info && moon test deque && moon check deque` and all tests passed locally (Total tests: 229, passed: 229, failed: 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b174be3770832082f6c0a677762957)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
