### PR TITLE
bigint: add unsigned comparison and equality helpers

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -135,6 +135,24 @@ pub fn BigInt::equal_int64(self : BigInt, other : Int64) -> Bool {
 }
 
 ///|
+/// Tests whether a `BigInt` value is equal to a `UInt` value.
+///
+/// This is a convenience helper mirroring `equal_int`/`equal_int64` and avoids
+/// forcing callers to construct a temporary `BigInt` manually.
+pub fn BigInt::equal_uint(self : BigInt, other : UInt) -> Bool {
+  self == BigInt::from_uint(other)
+}
+
+///|
+/// Tests whether a `BigInt` value is equal to a `UInt64` value.
+///
+/// This is a convenience helper mirroring `equal_int`/`equal_int64` and avoids
+/// forcing callers to construct a temporary `BigInt` manually.
+pub fn BigInt::equal_uint64(self : BigInt, other : UInt64) -> Bool {
+  self == BigInt::from_uint64(other)
+}
+
+///|
 /// Compares a `BigInt` with an `Int` and returns their relative order.
 ///
 /// Parameters:
@@ -197,6 +215,18 @@ pub fn BigInt::compare_int64(self : BigInt, other : Int64) -> Int {
   }
   let self = self.to_int64()
   Int64::compare(self, other)
+}
+
+///|
+/// Compares a `BigInt` with a `UInt` and returns their relative order.
+pub fn BigInt::compare_uint(self : BigInt, other : UInt) -> Int {
+  self.compare(BigInt::from_uint(other))
+}
+
+///|
+/// Compares a `BigInt` with a `UInt64` and returns their relative order.
+pub fn BigInt::compare_uint64(self : BigInt, other : UInt64) -> Int {
+  self.compare(BigInt::from_uint64(other))
 }
 
 ///|

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -933,6 +933,22 @@ test "equal_int64" {
 }
 
 ///|
+test "equal_uint and equal_uint64" {
+  assert_true(@bigint.BigInt::equal_uint(0N, 0U))
+  assert_true(@bigint.BigInt::equal_uint(42N, 42U))
+  assert_true(@bigint.BigInt::equal_uint(4294967295N, 4294967295U))
+  assert_false(@bigint.BigInt::equal_uint(-1N, 4294967295U))
+  assert_false(@bigint.BigInt::equal_uint(4294967296N, 0U))
+
+  assert_true(@bigint.BigInt::equal_uint64(0N, 0UL))
+  assert_true(
+    @bigint.BigInt::equal_uint64(18446744073709551615N, 18446744073709551615UL),
+  )
+  assert_false(@bigint.BigInt::equal_uint64(-1N, 18446744073709551615UL))
+  assert_false(@bigint.BigInt::equal_uint64(18446744073709551616N, 0UL))
+}
+
+///|
 test "compare_int" {
   // Test with zero
   assert_eq(@bigint.BigInt::compare_int(0N, 0), 0)
@@ -1098,6 +1114,24 @@ test "compare_int64" {
   assert_eq(@bigint.BigInt::compare_int64(neg_val_32bit, -4294967296L), 0)
   assert_eq(@bigint.BigInt::compare_int64(neg_val_32bit, -4294967295L), -1)
   assert_eq(@bigint.BigInt::compare_int64(neg_val_32bit, -4294967297L), 1)
+}
+
+///|
+test "compare_uint and compare_uint64" {
+  assert_eq(@bigint.BigInt::compare_uint(0N, 0U), 0)
+  assert_eq(@bigint.BigInt::compare_uint(1N, 0U), 1)
+  assert_eq(@bigint.BigInt::compare_uint(-1N, 0U), -1)
+  assert_eq(@bigint.BigInt::compare_uint(4294967296N, 4294967295U), 1)
+
+  assert_eq(@bigint.BigInt::compare_uint64(0N, 0UL), 0)
+  assert_eq(@bigint.BigInt::compare_uint64(1N, 0UL), 1)
+  assert_eq(@bigint.BigInt::compare_uint64(-1N, 0UL), -1)
+  assert_eq(
+    @bigint.BigInt::compare_uint64(
+      18446744073709551616N, 18446744073709551615UL,
+    ),
+    1,
+  )
 }
 
 ///|

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -18,9 +18,13 @@ pub fn BigInt::asr(Self, Int) -> Self
 pub fn BigInt::bit_length(Self) -> Int
 pub fn BigInt::compare_int(Self, Int) -> Int
 pub fn BigInt::compare_int64(Self, Int64) -> Int
+pub fn BigInt::compare_uint(Self, UInt) -> Int
+pub fn BigInt::compare_uint64(Self, UInt64) -> Int
 pub fn BigInt::ctz(Self) -> Int
 pub fn BigInt::equal_int(Self, Int) -> Bool
 pub fn BigInt::equal_int64(Self, Int64) -> Bool
+pub fn BigInt::equal_uint(Self, UInt) -> Bool
+pub fn BigInt::equal_uint64(Self, UInt64) -> Bool
 #deprecated
 pub fn BigInt::from_hex(String) -> Self
 pub fn BigInt::from_int(Int) -> Self


### PR DESCRIPTION
### Motivation
- The `BigInt` API exposed helpers for signed types (`Int`, `Int64`) but lacked analogous helpers for unsigned types, making some call sites awkward.
- Provide convenient, consistent helpers so callers don't need to construct temporary `BigInt` values to compare/equality-check against `UInt`/`UInt64`.

### Description
- Added `pub fn BigInt::equal_uint(self : BigInt, other : UInt) -> Bool` and `pub fn BigInt::equal_uint64(self : BigInt, other : UInt64) -> Bool` as equality helpers.
- Added `pub fn BigInt::compare_uint(self : BigInt, other : UInt) -> Int` and `pub fn BigInt::compare_uint64(self : BigInt, other : UInt64) -> Int` as comparison helpers.
- Added focused tests in `bigint_test.mbt` covering zero, boundary values, negative-vs-unsigned cases, and overflow-adjacent scenarios for the new helpers.
- Regenerated the package interface (`bigint/pkg.generated.mbti`) and formatted sources.

### Testing
- Ran `moon fmt` which completed successfully.
- Ran `moon info` which updated the generated interface successfully.
- Ran `moon test bigint` and observed: `Total tests: 147, passed: 147, failed: 0`.
- Ran `moon check bigint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1781439708320b584a6e65310f321)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
