### PR TITLE
Add UInt/UInt64 comparison/equality helpers and validate sign-only from_string

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -135,6 +135,32 @@ pub fn BigInt::equal_int64(self : BigInt, other : Int64) -> Bool {
 }
 
 ///|
+/// Tests whether a `BigInt` value is equal to a `UInt` value.
+///
+/// This is a convenience helper mirroring `equal_int`/`equal_int64` and avoids
+/// forcing callers to construct a temporary `BigInt` manually.
+pub fn BigInt::equal_uint(self : BigInt, other : UInt) -> Bool {
+  if is_neg(self) || self.bit_length() > 32 {
+    false
+  } else {
+    self.to_uint() == other
+  }
+}
+
+///|
+/// Tests whether a `BigInt` value is equal to a `UInt64` value.
+///
+/// This is a convenience helper mirroring `equal_int`/`equal_int64` and avoids
+/// forcing callers to construct a temporary `BigInt` manually.
+pub fn BigInt::equal_uint64(self : BigInt, other : UInt64) -> Bool {
+  if is_neg(self) || self.bit_length() > 64 {
+    false
+  } else {
+    self.to_uint64() == other
+  }
+}
+
+///|
 /// Compares a `BigInt` with an `Int` and returns their relative order.
 ///
 /// Parameters:
@@ -197,6 +223,30 @@ pub fn BigInt::compare_int64(self : BigInt, other : Int64) -> Int {
   }
   let self = self.to_int64()
   Int64::compare(self, other)
+}
+
+///|
+/// Compares a `BigInt` with a `UInt` and returns their relative order.
+pub fn BigInt::compare_uint(self : BigInt, other : UInt) -> Int {
+  if is_neg(self) {
+    -1
+  } else if self.bit_length() > 32 {
+    1
+  } else {
+    UInt::compare(self.to_uint(), other)
+  }
+}
+
+///|
+/// Compares a `BigInt` with a `UInt64` and returns their relative order.
+pub fn BigInt::compare_uint64(self : BigInt, other : UInt64) -> Int {
+  if is_neg(self) {
+    -1
+  } else if self.bit_length() > 64 {
+    1
+  } else {
+    UInt64::compare(self.to_uint64(), other)
+  }
 }
 
 ///|

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -58,6 +58,9 @@ pub fn BigInt::from_string(str : String, radix? : Int = 10) -> BigInt {
   if radix != 10 {
     return BigInt::from_string_radix(str, radix)
   }
+  if str == "-" {
+    abort("invalid character")
+  }
   BigInt::js_from_string(str)
 }
 

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1221,6 +1221,9 @@ fn BigInt::from_string_dec(input : String) -> BigInt {
     abort("empty string")
   }
   let sign : Sign = if input.unsafe_get(0) == '-' { Negative } else { Positive }
+  if sign == Negative && len == 1 {
+    abort("invalid character")
+  }
   let mut b_len = (
       unchecked_double_to_int(len.to_double() / decimal_ratio) +
       1 +

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -933,6 +933,22 @@ test "equal_int64" {
 }
 
 ///|
+test "equal_uint and equal_uint64" {
+  assert_true(@bigint.BigInt::equal_uint(0N, 0U))
+  assert_true(@bigint.BigInt::equal_uint(42N, 42U))
+  assert_true(@bigint.BigInt::equal_uint(4294967295N, 4294967295U))
+  assert_false(@bigint.BigInt::equal_uint(-1N, 4294967295U))
+  assert_false(@bigint.BigInt::equal_uint(4294967296N, 0U))
+
+  assert_true(@bigint.BigInt::equal_uint64(0N, 0UL))
+  assert_true(
+    @bigint.BigInt::equal_uint64(18446744073709551615N, 18446744073709551615UL),
+  )
+  assert_false(@bigint.BigInt::equal_uint64(-1N, 18446744073709551615UL))
+  assert_false(@bigint.BigInt::equal_uint64(18446744073709551616N, 0UL))
+}
+
+///|
 test "compare_int" {
   // Test with zero
   assert_eq(@bigint.BigInt::compare_int(0N, 0), 0)
@@ -1098,6 +1114,30 @@ test "compare_int64" {
   assert_eq(@bigint.BigInt::compare_int64(neg_val_32bit, -4294967296L), 0)
   assert_eq(@bigint.BigInt::compare_int64(neg_val_32bit, -4294967295L), -1)
   assert_eq(@bigint.BigInt::compare_int64(neg_val_32bit, -4294967297L), 1)
+}
+
+///|
+test "compare_uint and compare_uint64" {
+  assert_eq(@bigint.BigInt::compare_uint(0N, 0U), 0)
+  assert_eq(@bigint.BigInt::compare_uint(1N, 0U), 1)
+  assert_eq(@bigint.BigInt::compare_uint(-1N, 0U), -1)
+  assert_eq(@bigint.BigInt::compare_uint(4294967296N, 4294967295U), 1)
+
+  assert_eq(@bigint.BigInt::compare_uint64(0N, 0UL), 0)
+  assert_eq(@bigint.BigInt::compare_uint64(1N, 0UL), 1)
+  assert_eq(@bigint.BigInt::compare_uint64(-1N, 0UL), -1)
+  assert_eq(
+    @bigint.BigInt::compare_uint64(
+      18446744073709551615N, 18446744073709551615UL,
+    ),
+    0,
+  )
+  assert_eq(
+    @bigint.BigInt::compare_uint64(
+      18446744073709551616N, 18446744073709551615UL,
+    ),
+    1,
+  )
 }
 
 ///|

--- a/bigint/panic_test.mbt
+++ b/bigint/panic_test.mbt
@@ -44,6 +44,11 @@ test "panic from_string empty" {
 }
 
 ///|
+test "panic from_string sign only" {
+  @bigint.BigInt::from_string("-") |> ignore
+}
+
+///|
 test "panic from_string invalid character" {
   @bigint.BigInt::from_string("12a") |> ignore
 }

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -18,9 +18,13 @@ pub fn BigInt::asr(Self, Int) -> Self
 pub fn BigInt::bit_length(Self) -> Int
 pub fn BigInt::compare_int(Self, Int) -> Int
 pub fn BigInt::compare_int64(Self, Int64) -> Int
+pub fn BigInt::compare_uint(Self, UInt) -> Int
+pub fn BigInt::compare_uint64(Self, UInt64) -> Int
 pub fn BigInt::ctz(Self) -> Int
 pub fn BigInt::equal_int(Self, Int) -> Bool
 pub fn BigInt::equal_int64(Self, Int64) -> Bool
+pub fn BigInt::equal_uint(Self, UInt) -> Bool
+pub fn BigInt::equal_uint64(Self, UInt64) -> Bool
 #deprecated
 pub fn BigInt::from_hex(String) -> Self
 pub fn BigInt::from_int(Int) -> Self


### PR DESCRIPTION
### Motivation

- Provide convenience helpers for comparing and testing equality between `BigInt` and unsigned integer types to mirror existing `Int`/`Int64` helpers.
- Prevent an invalid input case where `BigInt::from_string("-")` would be accepted, by treating a lone sign as an invalid character.

### Description

- Add `BigInt::equal_uint` and `BigInt::equal_uint64` that return `false` for negative values or when the value's `bit_length()` exceeds the target width and otherwise compare via `to_uint()`/`to_uint64()`.
- Add `BigInt::compare_uint` and `BigInt::compare_uint64` that return `-1` for negative `BigInt`, `1` when `bit_length()` exceeds the target width, and otherwise delegate to `UInt::compare`/`UInt64::compare` on converted values.
- Validate the sign-only input in decimal `from_string` implementations by aborting for `"-"` in the JS path and for sign-only input in the non-JS decimal parser, and add a panic test for that case.
- Update tests and generated package metadata (`pkg.generated.mbti`) to include and exercise the new APIs and validation.

### Testing

- Added unit tests `equal_uint and equal_uint64` and `compare_uint and compare_uint64` which run as part of the `BigInt` test suite and confirm expected equality and ordering behavior; these tests passed.
- Added panic test `panic from_string sign only` to assert `BigInt::from_string("-")` aborts; this test passed.
- Ran the package test suite with `mbt check` and all bigint-related tests including the new cases succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1781439708320b584a6e65310f321)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
