### PR TITLE
feat(builtin): add Char::escape and refactor String::escape

### DIFF
--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -444,51 +444,38 @@ fn char_to_string(char : Char) -> String {
 }
 
 ///|
-/// Show implementation for Char that produces a human-readable representation
-/// of characters suitable for debugging and display purposes.
-/// 
-/// The output format follows Rust/C-style character literal syntax with single quotes.
-/// 
-/// ## Format Rules
-/// 
-/// 1. **Wrapper**: All characters are wrapped in single quotes: `'c'`
-/// 
-/// 2. **Special escape sequences**: Common control characters use backslash escapes:
-///    - `\'` for single quote (U+0027)
-///    - `\\` for backslash (U+005C)
-///    - `\n` for line feed (U+000A)
-///    - `\r` for carriage return (U+000D)
-///    - `\b` for backspace (U+0008)
-///    - `\t` for horizontal tab (U+0009)
-/// 
-/// 3. **ASCII printable range**: Characters from space (U+0020) to tilde (U+007E)
-///    are displayed as-is: `'A'`, `'5'`, `'@'`
-/// 
-/// 4. **Unicode escape sequences**: Non-printable characters use `\u{...}` format
-///    with minimal hex digits (no leading zeros)
-/// 
-/// ## When Char::to_hex is Called
-/// 
-/// The `Char::to_hex` function is called for characters that:
-/// - Are not in the ASCII printable range (U+0020 to U+007E)
-/// - Are not one of the special escape sequences
-/// - Fail the `is_printable()` check (control chars, format chars, private use, etc.)
-/// 
-/// For such characters, `Char::to_hex` converts the entire Unicode code point
-/// to its minimal hexadecimal string representation.
-/// 
-/// ## Examples
-/// 
-/// - ASCII printable: `'A'` displays as `'A'`
-/// - Special escape: `'\n'` displays as `'\n'`  
-/// - Non-printable: `'\u{0}'` displays as `'\u{0}'`
-/// - Emoji: `'\u{1F600}'` displays as `'\u{1f600}'`
-pub impl Show for Char with output(self, logger) {
+/// Returns the escaped representation of a character.
+///
+/// When `quote` is true (default), the result is wrapped in single quotes
+/// like a MoonBit character literal.
+///
+/// Escape rules:
+/// - Single quote and backslash are backslash-escaped: `\'`, `\\`
+/// - Common control characters use named escapes: `\n`, `\r`, `\b`, `\t`
+/// - ASCII printable characters (U+0020 to U+007E) are displayed as-is
+/// - Printable Unicode characters outside ASCII are displayed as-is
+/// - Non-printable characters use `\u{hex}` format
+///
+/// ```mbt check
+/// test {
+///   inspect('a'.escape(), content="'a'")
+///   inspect('a'.escape(quote=false), content="a")
+///   inspect('\n'.escape(), content="'\\n'")
+///   inspect('\n'.escape(quote=false), content="\\n")
+/// }
+/// ```
+pub fn Char::escape(self : Char, quote? : Bool = true) -> String {
+  let buf = StringBuilder::new()
+  self.escape_to(buf, quote~)
+  buf.to_string()
+}
 
-  // Start with opening single quote
-  logger.write_char('\'')
+///|
+fn Char::escape_to(self : Char, logger : &Logger, quote? : Bool = true) -> Unit {
+  if quote {
+    logger.write_char('\'')
+  }
   match self {
-    // Handle characters that need special escape sequences
     '\'' | '\\' => {
       logger.write_char('\\')
       logger.write_char(self)
@@ -497,26 +484,24 @@ pub impl Show for Char with output(self, logger) {
     '\r' => logger.write_string("\\r")
     '\b' => logger.write_string("\\b")
     '\t' => logger.write_string("\\t")
-
-    // ASCII printable characters (space through tilde): display as-is
     ' '..='~' => logger.write_char(self)
-
-    // All other characters: check if they're printable
     _ =>
       if !self.is_printable() {
-        // Non-printable characters get Unicode escape sequences: \u{...}
         logger.write_string("\\u{")
         logger.write_string(self.to_hex())
         logger.write_char('}')
       } else {
-        // Printable Unicode characters outside ASCII range: display as-is
-        // Examples: emoji, accented letters, CJK characters, etc.
         logger.write_char(self)
       }
   }
+  if quote {
+    logger.write_char('\'')
+  }
+}
 
-  // End with closing single quote
-  logger.write_char('\'')
+///|
+pub impl Show for Char with output(self, logger) {
+  self.escape_to(logger)
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -471,6 +471,7 @@ pub fn Byte::to_uint(Byte) -> UInt
 pub fn Byte::to_uint16(Byte) -> UInt16
 pub fn Byte::to_uint64(Byte) -> UInt64
 
+pub fn Char::escape(Char, quote? : Bool) -> String
 #deprecated
 pub fn Char::from_int(Int) -> Char
 pub fn Char::is_ascii(Char) -> Bool
@@ -691,7 +692,7 @@ pub fn String::char_length_ge(String, Int, start_offset? : Int, end_offset? : In
 pub fn String::contains(String, StringView) -> Bool
 pub fn String::contains_any(String, chars~ : StringView) -> Bool
 pub fn String::contains_char(String, Char) -> Bool
-pub fn String::escape(String) -> String
+pub fn String::escape(String, quote? : Bool) -> String
 pub fn String::find(String, StringView) -> Int?
 pub fn String::find_by(String, (Char) -> Bool) -> Int?
 pub fn[A] String::fold(String, init~ : A, (A, Char) -> A raise?) -> A raise?

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -85,23 +85,46 @@ test "to_hex_digit" {
 }
 
 ///|
-pub impl Show for String with output(self, logger) {
-  logger.write_char('"')
+/// Returns the escaped representation of a string.
+///
+/// When `quote` is true (default), the result is wrapped in double quotes
+/// like a MoonBit string literal.
+///
+/// Escape rules:
+/// - Double quote and backslash are backslash-escaped: `\"`, `\\`
+/// - Common control characters use named escapes: `\n`, `\r`, `\b`, `\t`
+/// - Other control characters (< U+0020) use `\u{hex}` format
+/// - All other characters are displayed as-is
+///
+/// ```mbt check
+/// test {
+///   inspect("Hello \n".escape(), content="\"Hello \\n\"")
+///   inspect("Hello \n".escape(quote=false), content="Hello \\n")
+/// }
+/// ```
+pub fn String::escape(self : String, quote? : Bool = true) -> String {
+  let buf = StringBuilder::new()
+  self.escape_to(buf, quote~)
+  buf.to_string()
+}
+
+///|
+fn String::escape_to(
+  self : String,
+  logger : &Logger,
+  quote? : Bool = true,
+) -> Unit {
+  if quote {
+    logger.write_char('"')
+  }
+  let len = self.length()
   fn flush_segment(seg : Int, i : Int) {
     if i > seg {
       logger.write_substring(self, seg, i - seg)
     }
   }
-  // The loop keeps two pieces of state:
-  //   i   : the current scanning position
-  //   seg : the beginning index of the current "plain" segment that has
-  //         no escaping requirements. Whenever we meet a character that
-  //         needs escaping, we flush the segment [seg, i) and reset seg.
-  let len = self.length()
   for i = 0, seg = 0 {
     if i >= len {
-      // If we reached the end of the string, flush any remaining segment
-      // and break out of the loop.
       flush_segment(seg, i)
       break
     }
@@ -111,7 +134,6 @@ pub impl Show for String with output(self, logger) {
         flush_segment(seg, i)
         logger.write_char('\\')
         logger.write_char(c.unsafe_to_char())
-        // Advance both pointers: continue with next index, new segment starts after current char
         continue i + 1, i + 1
       }
       '\n' => {
@@ -136,55 +158,42 @@ pub impl Show for String with output(self, logger) {
       }
       code =>
         if code < ' ' {
-          // has to be ascii
           flush_segment(seg, i)
           logger.write_string("\\u{")
           logger.write_string(code.to_byte().to_hex())
           logger.write_char('}')
           continue i + 1, i + 1
         } else {
-          // Normal character, keep scanning; only advance index.
           continue i + 1, seg
         }
     }
   }
-  logger.write_char('"')
+  if quote {
+    logger.write_char('"')
+  }
+}
+
+///|
+pub impl Show for String with output(self, logger) {
+  self.escape_to(logger)
 }
 
 ///|
 /// This is different from `Show::output`,
-/// here it returns the original string without escaping. 
+/// here it returns the original string without escaping.
 /// The rationale is in string interpolation,
 /// we want to show the original string, not the escaped one.
 /// # Examples
-/// 
+///
 /// ```mbt check
 /// test {
 ///   let str = "Hello \n"
 ///   inspect(str.to_string(), content="Hello \n")
-///   inspect(str.escape(), content="\"Hello \\n\"")
+///   inspect(str.escape(quote=true), content="\"Hello \\n\"")
 /// }
 /// ```
 pub impl Show for String with to_string(self) {
   self
-}
-
-///|
-/// Returns a valid MoonBit string literal representation of a string,
-/// add quotes and escape special characters.
-/// # Examples
-/// 
-/// ```mbt check
-/// test {
-///   let str = "Hello \n"
-///   inspect(str.to_string(), content="Hello \n")
-///   inspect(str.escape(), content="\"Hello \\n\"")
-/// }
-/// ```
-pub fn String::escape(self : String) -> String {
-  let buf = StringBuilder::new()
-  Show::output(self, buf)
-  buf.to_string()
 }
 
 ///|

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -855,3 +855,52 @@ test "Show for Char special cases" {
   '\u{1F}'.output(ctrl_1f_buf)
   inspect(ctrl_1f_buf.to_string(), content="'\\u{1f}'")
 }
+
+///|
+test "Char::escape" {
+  // ASCII printable
+  inspect('a'.escape(), content="'a'")
+  inspect('a'.escape(quote=false), content="a")
+  inspect('Z'.escape(), content="'Z'")
+  inspect(' '.escape(), content="' '")
+  inspect('~'.escape(), content="'~'")
+  // Special escape sequences
+  inspect('\''.escape(), content="'\\''")
+  inspect('\\'.escape(), content="'\\\\'")
+  inspect('\n'.escape(), content="'\\n'")
+  inspect('\n'.escape(quote=false), content="\\n")
+  inspect('\r'.escape(), content="'\\r'")
+  inspect('\b'.escape(), content="'\\b'")
+  inspect('\t'.escape(), content="'\\t'")
+  // Non-printable control characters
+  inspect('\u{0}'.escape(), content="'\\u{00}'")
+  inspect('\u{01}'.escape(), content="'\\u{01}'")
+  inspect('\u{1F}'.escape(), content="'\\u{1f}'")
+  // Printable Unicode (displayed as-is)
+  inspect('中'.escape(), content="'中'")
+  inspect('中'.escape(quote=false), content="中")
+}
+
+///|
+test "String::escape" {
+  // Basic string
+  inspect("hello".escape(), content="\"hello\"")
+  inspect("hello".escape(quote=false), content="hello")
+  // Special escape sequences
+  inspect("a\nb".escape(), content="\"a\\nb\"")
+  inspect("a\nb".escape(quote=false), content="a\\nb")
+  inspect("a\rb".escape(), content="\"a\\rb\"")
+  inspect("a\tb".escape(), content="\"a\\tb\"")
+  inspect("a\bb".escape(), content="\"a\\bb\"")
+  // Quote and backslash escaping
+  inspect("a\"b".escape(), content="\"a\\\"b\"")
+  inspect("a\\b".escape(), content="\"a\\\\b\"")
+  // Control characters
+  inspect("a\u{01}b".escape(), content="\"a\\u{01}b\"")
+  // Empty string
+  inspect("".escape(), content="\"\"")
+  inspect("".escape(quote=false), content="")
+  // Unicode (displayed as-is)
+  inspect("你好".escape(), content="\"你好\"")
+  inspect("你好".escape(quote=false), content="你好")
+}


### PR DESCRIPTION
## Summary
- Add `Char::escape(quote~ : Bool = true)` for escaping characters with optional single-quote wrapping
- Extend `String::escape` with a `quote~ : Bool = true` parameter for optional double-quote wrapping
- Both delegate to internal `escape_to` helpers that write directly to `&Logger`, so `Show::output` avoids intermediate `String` allocation
- Add comprehensive tests for both `Char::escape` and `String::escape`

## Test plan
- [x] `moon test -p builtin` passes (2706/2706)
- [x] `moon check` passes
- [x] `moon fmt` and `moon info` run clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
