### PR TITLE
deprecate repr in favor of to_repr as free function

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -40,6 +40,7 @@ pub fn[T] physical_equal(T, T) -> Bool
 
 pub fn[T : Show] println(T) -> Unit
 
+#deprecated
 pub fn[T : Show] repr(T) -> String
 
 // Errors

--- a/builtin/repr_test.mbt
+++ b/builtin/repr_test.mbt
@@ -14,14 +14,14 @@
 
 ///|
 test "repr" {
-  inspect(repr(1), content="1")
-  inspect(repr("x"), content="\"x\"")
-  inspect(repr(true), content="true")
-  inspect(repr(false), content="false")
-  inspect(repr(1.0), content="1")
-  inspect(repr('a'), content="'a'")
+  inspect(to_repr(1), content="1")
+  inspect(to_repr("x"), content="\"x\"")
+  inspect(to_repr(true), content="true")
+  inspect(to_repr(false), content="false")
+  inspect(to_repr(1.0), content="1")
+  inspect(to_repr('a'), content="'a'")
   inspect(
-    repr((1, "x", '\n', ['a'])),
+    to_repr((1, "x", '\n', ['a'])),
     content=(
       #|(1, "x", '\n', ['a'])
     ),

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -793,16 +793,16 @@ test "char show hex digits" {
   // inspect('\x01', content="\x01")
   // FIXME: inspect('\x0b') will not work with update test
   // inspect('\x0b', content="\x0b")
-  inspect('\u{01}' |> repr, content="'\\u{01}'")
-  inspect('\u{0b}' |> repr, content="'\\u{0b}'")
+  inspect('\u{01}' |> to_repr, content="'\\u{01}'")
+  inspect('\u{0b}' |> to_repr, content="'\\u{0b}'")
 }
 
 ///|
 test "char show hex digits extended" {
-  inspect('\u{0605}' |> repr, content="'\\u{0605}'")
-  inspect('\u{FDD0}' |> repr, content="'\\u{fdd0}'")
-  inspect('\u{1FFFE}' |> repr, content="'\\u{01fffe}'")
-  inspect('\u{10FFFE}' |> repr, content="'\\u{10fffe}'")
+  inspect('\u{0605}' |> to_repr, content="'\\u{0605}'")
+  inspect('\u{FDD0}' |> to_repr, content="'\\u{fdd0}'")
+  inspect('\u{1FFFE}' |> to_repr, content="'\\u{01fffe}'")
+  inspect('\u{10FFFE}' |> to_repr, content="'\\u{10fffe}'")
 }
 
 ///|

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -180,6 +180,7 @@ pub fn[T : Show] &Logger::write_iter(
 
 ///|
 /// Function `repr`.
+#deprecated("use `to_repr` for debugging representation")
 pub fn[T : Show] repr(t : T) -> String {
   let logger = StringBuilder::new()
   t.output(logger)

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -15,6 +15,7 @@
 ///|
 /// Trait for types that can be converted to human-readable debugging info.
 pub(open) trait Debug {
+  #as_free_fn
   to_repr(Self) -> Repr
 }
 

--- a/debug/debug_test.mbt
+++ b/debug/debug_test.mbt
@@ -579,3 +579,14 @@ test "assert_eq for arrays" {
     ),
   )
 }
+
+///|
+test "repr" {
+  let v = "3"
+  inspect(
+    "hello \{Debug::to_repr(v)}",
+    content=(
+      #|hello "3"
+    ),
+  )
+}

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -34,11 +34,13 @@ pub fn[T : Debug] to_string(T) -> String
 
 // Types and methods
 type Repr
+pub impl Show for Repr
 
 // Type aliases
 
 // Traits
 pub(open) trait Debug {
+  #as_free_fn
   to_repr(Self) -> Repr
 }
 pub impl Debug for Unit

--- a/debug/pretty_print.mbt
+++ b/debug/pretty_print.mbt
@@ -143,14 +143,14 @@ fn pretty_print_repr_go(label : Repr, children : Array[Content]) -> Content {
     }
     DoubleLit(x) => {
       let needs_parens = 1.0 / x < 0.0
-      leaf(x, needs_parens~)
+      leaf(x.to_string(), needs_parens~)
     }
     FloatLit(x) => {
       let needs_parens : Bool = (1.0 : Float) / x < (0.0 : Float)
-      leaf(x, needs_parens~)
+      leaf(x.to_string(), needs_parens~)
     }
-    BoolLit(x) => leaf(x)
-    CharLit(x) => leaf(x)
+    BoolLit(x) => leaf(x.to_string())
+    CharLit(x) => leaf(x.escape())
     StringLit(x) => no_parens(verbatim(quote_string_literal(x)))
     Tuple(_) => comma_seq("(", ")", children.map(x => x.no_wrap()))
     Enum(name, _) =>
@@ -276,6 +276,11 @@ pub fn render(r : Repr, max_depth? : Int) -> String {
   let threshold = default_threshold
   let info = prune_repr_info(max_depth, r)
   print_content(render_repr(threshold, info).no_wrap())
+}
+
+///|
+pub impl Show for Repr with output(self, logger) {
+  logger.write_string(render(self))
 }
 
 ///|

--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -59,8 +59,8 @@ fn content_parens(size : Int, lines : Array[String]) -> ContentParens {
 
 ///|
 /// Render any `Show` value as a leaf content node.
-fn[T : Show] leaf(x : T, needs_parens? : Bool = false) -> Content {
-  { size: 1, lines: [repr(x)], needs_parens }
+fn leaf(x : String, needs_parens? : Bool = false) -> Content {
+  { size: 1, lines: [x], needs_parens }
 }
 
 ///|

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -34,7 +34,7 @@ pub impl Show for ParseError with output(self, logger) {
   match self {
     InvalidChar({ line, column }, c) => {
       logger.write_string("Invalid character ")
-      logger.write_string(repr(c))
+      logger.write_string(c.escape())
       logger.write_string(" at line ")
       logger.write_object(line)
       logger.write_string(", column ")

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -60,6 +60,7 @@ pub fn[T] physical_equal(T, T) -> Bool
 
 pub fn[T : @builtin.Show] println(T) -> Unit
 
+#deprecated
 pub fn[T : @builtin.Show] repr(T) -> String
 
 #deprecated
@@ -67,6 +68,8 @@ pub fn[T] tap(T, (T) -> Unit raise) -> T raise
 
 #deprecated
 pub fn[T, R] then(T, (T) -> R raise?) -> R raise?
+
+pub fn[Self : @debug.Debug] to_repr(Self) -> @debug.Repr
 
 // Errors
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -32,7 +32,6 @@ pub using @builtin {
   panic,
   physical_equal,
   println,
-  repr,
   trait Eq,
   trait Compare,
   trait Hash,
@@ -74,12 +73,17 @@ pub using @builtin {
 pub using @builtin {not}
 
 ///|
+#deprecated("use `to_repr` for debugging representation")
+#warnings("-deprecated")
+pub using @builtin {repr}
+
+///|
 #deprecated
 #warnings("-deprecated")
 pub using @builtin {type IterResult}
 
 ///|
-pub using @debug {debug, type Repr, trait Debug, debug_inspect}
+pub using @debug {debug, type Repr, trait Debug, debug_inspect, to_repr}
 
 ///|
 #deprecated("for debugging only, not for production")

--- a/string/string_unicode_test.mbt
+++ b/string/string_unicode_test.mbt
@@ -27,7 +27,7 @@ test {
   )
   let v = "\u{00AD}Hello, \u{2060}世界\t\n!\u{1D173}"
   inspect(
-    repr(v),
+    to_repr(v),
     content=(
       #|"­Hello, ⁠世界\t\n!𝅳"
     ),


### PR DESCRIPTION
## Summary
- Add `#as_free_fn` to `Debug::to_repr` trait method, making `to_repr(x)` available as a free function
- Export `to_repr` in prelude for global availability
- Deprecate `repr` with message pointing to `to_repr`
- Add `Show for Repr` so `Repr` values work with `inspect` and string interpolation
- Simplify `leaf` in debug printer to take `String` directly instead of generic `T : Show`
- Replace deprecated `repr(c)` with `c.escape()` in `json/types.mbt`
- Update all tests to use `to_repr` instead of `repr`

## Test plan
- [x] `moon check` passes
- [x] `moon test` passes for all affected packages (builtin, debug, json, string, prelude): 3170/3170
- [x] `moon fmt` and `moon info` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
