### PR TITLE
refactor: use functional for-loop state variables in fold_digits

### DIFF
--- a/strconv/string_view.mbt
+++ b/strconv/string_view.mbt
@@ -20,17 +20,14 @@ fn[T] StringView::fold_digits(
   init : T,
   f : (Int, T) -> T,
 ) -> (Self, T, Int) {
-  let mut ret = init
-  let mut len = 0
-  let mut str = self
-  while str is [ch, .. rest] {
+  for str = self, ret = init, len = 0; str is [ch, .. rest]; {
     if ch is ('0'..='9') {
-      len += 1
-      ret = f(ch.to_int() - '0', ret)
+      continue rest, f(ch.to_int() - '0', ret), len + 1
     } else if ch != '_' {
-      break
+      break (str, ret, len)
     }
-    str = rest
+    continue rest, ret, len
+  } nobreak {
+    (str, ret, len)
   }
-  (str, ret, len)
 }


### PR DESCRIPTION
## Summary
- Convert `StringView::fold_digits` from `while`+`let mut` pattern to functional for-loop state variables
- Uses `for str = self, ret = init, len = 0; str is [ch, .. rest]; {` with `continue` and `nobreak`

## Test plan
- [ ] CI passes (existing tests cover `fold_digits` via strconv parsing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
