### PR TITLE
refactor: use functional for-loop state variables to reduce mut usage

### DIFF
--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -106,13 +106,12 @@ fn is_negative_number(arg : String) -> Bool {
     return false
   }
   guard arg.get_char(0) is Some('-') else { return false }
-  let mut i = 1
-  while i < arg.length() {
+  for i = 1; i < arg.length(); {
     let ch = arg.get_char(i).unwrap()
     if ch < '0' || ch > '9' {
       return false
     }
-    i = i + ch.utf16_len()
+    continue i + ch.utf16_len()
   }
   true
 }

--- a/argparse/parser_values.mbt
+++ b/argparse/parser_values.mbt
@@ -81,13 +81,11 @@ fn positional_min_required(arg : Arg) -> Int {
 
 ///|
 fn remaining_positional_min(positionals : Array[Arg], start : Int) -> Int {
-  let mut total = 0
-  let mut idx = start
-  while idx < positionals.length() {
-    total = total + positional_min_required(positionals[idx])
-    idx = idx + 1
+  for idx = start, total = 0; idx < positionals.length(); {
+    continue idx + 1, total + positional_min_required(positionals[idx])
+  } nobreak {
+    total
   }
-  total
 }
 
 ///|

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1403,12 +1403,14 @@ pub fn[T : Eq] Array::dedup(self : Array[T]) -> Unit {
   if self.is_empty() {
     return
   }
-  let mut w = 1
-  for i in 1..<self.length() {
+  let w = for i in 1..<self.length(); w = 1 {
     if self[i] != self[w - 1] {
       self[w] = self[i]
-      w = w + 1
+      continue w + 1
     }
+    continue w
+  } nobreak {
+    w
   }
   self.unsafe_truncate_to_length(w)
 }
@@ -1528,12 +1530,14 @@ pub fn[T] Array::chunk_by(
   if self.is_empty() {
     return chunks
   }
-  let mut start = 0
-  for i in 1..<self.length() {
+  let start = for i in 1..<self.length(); start = 0 {
     if !pred(self[i - 1], self[i]) {
       chunks.push(self[start:i])
-      start = i
+      continue i
     }
+    continue start
+  } nobreak {
+    start
   }
   chunks.push(self[start:self.length()])
   chunks
@@ -1628,15 +1632,16 @@ pub fn[T] Array::split(
   pred : (T) -> Bool raise?,
 ) -> Array[Array[T]] raise? {
   let chunks = []
-  let mut i = 0
-  while i < self.length() {
+  for i = 0; i < self.length(); {
     let chunk = []
-    while i < self.length() && !pred(self[i]) {
+    let i = for i = i; i < self.length() && !pred(self[i]); {
       chunk.push(self[i])
-      i = i + 1
+      continue i + 1
+    } nobreak {
+      i
     }
     chunks.push(chunk)
-    i = i + 1
+    continue i + 1
   }
   chunks
 }

--- a/builtin/array_sort_by_impl.mbt
+++ b/builtin/array_sort_by_impl.mbt
@@ -19,13 +19,8 @@ fn[T] fixed_quick_sort_by(
   pred : T?,
   limit : Int,
 ) -> Unit {
-  let mut limit = limit
-  let mut arr = arr
-  let mut pred = pred
-  let mut was_partitioned = true
-  let mut balanced = true
   let bubble_sort_len = 16
-  while true {
+  for limit = limit, arr = arr, pred = pred, was_partitioned = true, balanced = true {
     let len = arr.length()
     if len <= bubble_sort_len {
       if len >= 2 {
@@ -47,21 +42,19 @@ fn[T] fixed_quick_sort_by(
       }
     }
     let (pivot, partitioned) = fixed_partition_by(arr, cmp, pivot_index)
-    was_partitioned = partitioned
-    balanced = minimum(pivot, len - pivot) >= len / 8
-    if !balanced {
-      limit -= 1
-    }
-    if pred is Some(pred) {
+    let was_partitioned = partitioned
+    let balanced = minimum(pivot, len - pivot) >= len / 8
+    let limit = if !balanced { limit - 1 } else { limit }
+    if pred is Some(p) {
       // pred is less than all elements in arr
       // If pivot equals to pred, then we can skip all elements that are equal to pred.
-      if cmp(pred, arr[pivot]) == 0 {
-        let mut i = pivot
-        while i < len && cmp(pred, arr[i]) == 0 {
-          i = i + 1
+      if cmp(p, arr[pivot]) == 0 {
+        let i = for i = pivot; i < len && cmp(p, arr[i]) == 0; {
+          continue i + 1
+        } nobreak {
+          i
         }
-        arr = arr.slice(i, len)
-        continue
+        continue limit, arr.slice(i, len), pred, was_partitioned, balanced
       }
     }
     let left = arr.slice(0, pivot)
@@ -69,11 +62,10 @@ fn[T] fixed_quick_sort_by(
     // Reduce the stack depth by only call quick_sort on the smaller partition.
     if left.length() < right.length() {
       fixed_quick_sort_by(left, cmp, pred, limit)
-      pred = Some(arr[pivot])
-      arr = right
+      continue limit, right, Some(arr[pivot]), was_partitioned, balanced
     } else {
       fixed_quick_sort_by(right, cmp, Some(arr[pivot]), limit)
-      arr = left
+      continue limit, left, pred, was_partitioned, balanced
     }
   }
 }
@@ -90,10 +82,11 @@ fn[T] fixed_try_bubble_sort_by(
 ) -> Bool {
   let max_tries = 8
   for i in 1..<arr.length(); tries = 0 {
-    let mut sorted = true
-    for j = i; j > 0 && cmp(arr[j - 1], arr[j]) > 0; j = j - 1 {
-      sorted = false
+    let sorted = for j = i, sorted = true; j > 0 && cmp(arr[j - 1], arr[j]) > 0; {
       arr.swap(j, j - 1)
+      continue j - 1, false
+    } nobreak {
+      sorted
     }
     if !sorted {
       let tries = tries + 1
@@ -221,19 +214,18 @@ fn[T] fixed_sift_down_by(
   index : Int,
   cmp : (T, T) -> Int,
 ) -> Unit {
-  let mut index = index
   let len = arr.length()
-  let mut child = index * 2 + 1
-  while child < len {
-    if child + 1 < len && cmp(arr[child], arr[child + 1]) < 0 {
-      child = child + 1
+  for index = index, child = index * 2 + 1; child < len; {
+    let child = if child + 1 < len && cmp(arr[child], arr[child + 1]) < 0 {
+      child + 1
+    } else {
+      child
     }
     if cmp(arr[index], arr[child]) >= 0 {
       return
     }
     arr.swap(index, child)
-    index = child
-    child = index * 2 + 1
+    continue child, child * 2 + 1
   }
 }
 

--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -38,20 +38,17 @@ fn[T : Compare] timsort(arr : MutArrayView[T]) -> Unit {
     MutArrayView::insertion_sort(arr)
     return
   }
-  let mut end = 0
-  let mut start = 0
   let runs : Array[TimSortRun] = []
-  while end < len {
+  for start = 0, end = 0; end < len; {
     let (streak_end, was_reversed) = find_streak(arr.mut_view(start~))
-    end += streak_end
+    let end = end + streak_end
     if was_reversed {
       arr.mut_view(start~, end~).rev_in_place()
     }
     // Insert some more elements into the run if it's too short. Insertion sort is faster than
     // merge sort on short sequences, so this significantly improves performance.
-    end = provide_sorted_batch(arr, start, end)
+    let end = provide_sorted_batch(arr, start, end)
     runs.push({ start, len: end - start })
-    start = end
     while true {
       guard collapse(runs, len) is Some(r) else { break }
       let left = runs[r]
@@ -60,6 +57,7 @@ fn[T : Compare] timsort(arr : MutArrayView[T]) -> Unit {
       runs[r + 1] = { start: left.start, len: left.len + right.len }
       runs.remove(r) |> ignore
     }
+    continue end, end
   }
 }
 
@@ -238,13 +236,8 @@ fn[T : Compare] fixed_quick_sort(
   pred : T?,
   limit : Int,
 ) -> Unit {
-  let mut limit = limit
-  let mut arr = arr
-  let mut pred = pred
-  let mut was_partitioned = true
-  let mut balanced = true
   let bubble_sort_len = 16
-  while true {
+  for limit = limit, arr = arr, pred = pred, was_partitioned = true, balanced = true {
     let len = arr.length()
     if len <= bubble_sort_len {
       if len >= 2 {
@@ -266,21 +259,19 @@ fn[T : Compare] fixed_quick_sort(
       }
     }
     let (pivot, partitioned) = fixed_partition(arr, pivot_index)
-    was_partitioned = partitioned
-    balanced = minimum(pivot, len - pivot) >= len / 8
-    if !balanced {
-      limit -= 1
-    }
-    if pred is Some(pred) {
+    let was_partitioned = partitioned
+    let balanced = minimum(pivot, len - pivot) >= len / 8
+    let limit = if !balanced { limit - 1 } else { limit }
+    if pred is Some(p) {
       // pred is less than all elements in arr
       // If pivot equals to pred, then we can skip all elements that are equal to pred.
-      if pred == arr[pivot] {
-        let mut i = pivot
-        while i < len && pred == arr[i] {
-          i = i + 1
+      if p == arr[pivot] {
+        let i = for i = pivot; i < len && p == arr[i]; {
+          continue i + 1
+        } nobreak {
+          i
         }
-        arr = arr.slice(i, len)
-        continue
+        continue limit, arr.slice(i, len), pred, was_partitioned, balanced
       }
     }
     let left = arr.slice(0, pivot)
@@ -288,11 +279,10 @@ fn[T : Compare] fixed_quick_sort(
     // Reduce the stack depth by only call fixed_quick_sort on the smaller fixed_partition.
     if left.length() < right.length() {
       fixed_quick_sort(left, pred, limit)
-      pred = Some(arr[pivot])
-      arr = right
+      continue limit, right, Some(arr[pivot]), was_partitioned, balanced
     } else {
       fixed_quick_sort(right, Some(arr[pivot]), limit)
-      arr = left
+      continue limit, left, pred, was_partitioned, balanced
     }
   }
 }
@@ -315,10 +305,11 @@ fn fixed_get_limit(len : Int) -> Int {
 fn[T : Compare] fixed_try_bubble_sort(arr : MutArrayView[T]) -> Bool {
   let max_tries = 8
   for i in 1..<arr.length(); tries = 0 {
-    let mut sorted = true
-    for j = i; j > 0 && arr[j - 1] > arr[j]; j = j - 1 {
-      sorted = false
+    let sorted = for j = i, sorted = true; j > 0 && arr[j - 1] > arr[j]; {
       arr.swap(j, j - 1)
+      continue j - 1, false
+    } nobreak {
+      sorted
     }
     if !sorted {
       let tries = tries + 1
@@ -438,19 +429,18 @@ fn[T : Compare] fixed_heap_sort(arr : MutArrayView[T]) -> Unit {
 
 ///|
 fn[T : Compare] fixed_sift_down(arr : MutArrayView[T], index : Int) -> Unit {
-  let mut index = index
   let len = arr.length()
-  let mut child = index * 2 + 1
-  while child < len {
-    if child + 1 < len && arr[child] < arr[child + 1] {
-      child = child + 1
+  for index = index, child = index * 2 + 1; child < len; {
+    let child = if child + 1 < len && arr[child] < arr[child + 1] {
+      child + 1
+    } else {
+      child
     }
     if arr[index] >= arr[child] {
       return
     }
     arr.swap(index, child)
-    index = child
-    child = index * 2 + 1
+    continue child, child * 2 + 1
   }
 }
 

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -354,17 +354,15 @@ pub fn Hasher::combine_byte(self : Hasher, value : Byte) -> Unit {
 /// }
 /// ```
 pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
-  let mut remain = value.length()
-  let mut cur = 0
-  while remain >= 4 {
+  let (cur, remain) = for cur = 0, remain = value.length(); remain >= 4; {
     self.consume4(endian32(value, cur))
-    cur += 4
-    remain -= 4
+    continue cur + 4, remain - 4
+  } nobreak {
+    (cur, remain)
   }
-  while remain >= 1 {
+  for cur = cur, remain = remain; remain >= 1; {
     self.consume1(value[cur])
-    cur += 1
-    remain -= 1
+    continue cur + 1, remain - 1
   }
 }
 
@@ -653,22 +651,20 @@ pub impl[T : Hash, E : Hash] Hash for Result[T, E] with hash_combine(
 
 ///|
 pub impl Hash for BytesView with hash_combine(self : BytesView, hasher : Hasher) {
-  let mut start = self.start()
   let data = self.bytes()
-  let mut rest = self.len()
-  while rest >= 4 {
+  let (start, rest) = for start = self.start(), rest = self.len(); rest >= 4; {
     let result = for i in 0..<=3; result = (0 : UInt) {
       continue result | (data.unsafe_get(i + start).to_uint() << (8 * i))
     } nobreak {
       result
     }
     hasher.combine_uint(result)
-    rest -= 4
-    start += 4
+    continue start + 4, rest - 4
+  } nobreak {
+    (start, rest)
   }
-  while rest >= 1 {
+  for start = start, rest = rest; rest >= 1; {
     hasher.combine_byte(data.unsafe_get(start))
-    rest -= 1
-    start += 1
+    continue start + 1, rest - 1
   }
 }

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -35,23 +35,19 @@ fn brute_force_find(haystack : StringView, needle : StringView) -> Int? {
   guard haystack_len >= needle_len else { return None }
   let needle_first = needle.unsafe_get(0)
   let forward_len = haystack_len - needle_len
-  let mut i = 0
-  while i <= forward_len {
-    // Skip positions where first charcode doesn't match
-    while i <= forward_len && haystack.unsafe_get(i) != needle_first {
-      i += 1
+  for i = 0; i <= forward_len; {
+    if haystack.unsafe_get(i) != needle_first {
+      continue i + 1
     }
-    if i <= forward_len {
-      // Check remaining charcodes for full match
-      for j in 1..<needle_len {
-        if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
-          break
-        }
-      } nobreak {
-        return Some(i)
+    // Check remaining charcodes for full match
+    for j in 1..<needle_len {
+      if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
+        break
       }
-      i += 1
+    } nobreak {
+      return Some(i)
     }
+    continue i + 1
   }
   None
 }
@@ -185,23 +181,19 @@ fn brute_force_rev_find(haystack : StringView, needle : StringView) -> Int? {
   guard needle_len > 0 else { return Some(haystack_len) }
   guard haystack_len >= needle_len else { return None }
   let needle_first = needle.unsafe_get(0)
-  let mut i = haystack_len - needle_len
-  while i >= 0 {
-    // Skip positions where first charcode doesn't match
-    while i >= 0 && haystack.unsafe_get(i) != needle_first {
-      i -= 1
+  for i = haystack_len - needle_len; i >= 0; {
+    if haystack.unsafe_get(i) != needle_first {
+      continue i - 1
     }
-    if i >= 0 {
-      // Check remaining charcodes for full match
-      for j in 1..<needle_len {
-        if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
-          break
-        }
-      } nobreak {
-        return Some(i)
+    // Check remaining charcodes for full match
+    for j in 1..<needle_len {
+      if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
+        break
       }
-      i -= 1
+    } nobreak {
+      return Some(i)
     }
+    continue i - 1
   }
   None
 }
@@ -607,15 +599,14 @@ pub fn StringView::contains_char(self : StringView, c : Char) -> Bool {
     let high = 0xD800 + (adj >> 10)
     let low = 0xDC00 + (adj & 0x3FF)
     // Search surrogate pair
-    let mut i = 0
-    while i < len - 1 {
+    for i = 0; i < len - 1; {
       if self.unsafe_get(i).to_int() == high {
-        i += 1
-        if self.unsafe_get(i).to_int() == low {
+        if self.unsafe_get(i + 1).to_int() == low {
           return true
         }
+        continue i + 2
       }
-      i += 1
+      continue i + 1
     }
   }
   false

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1348,29 +1348,29 @@ pub fn[A] Deque::retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self
   let cap = buf.length()
-  let mut idx = head
-  let mut kept_len = 0
   let (front, back) = self.as_views()
-  for cur in front {
+  let (idx, kept_len) = for cur in front; idx = head, kept_len = 0 {
     if f(cur) is Some(v) {
       buf[idx] = v
-      idx += 1
-      kept_len += 1
+      continue idx + 1, kept_len + 1
     }
+    continue idx, kept_len
+  } nobreak {
+    (idx, kept_len)
   }
   if back.length() == 0 {
     self.truncate(kept_len)
     return
   }
-  for cur in back {
-    if idx == cap {
-      idx = 0
-    }
+  let kept_len = for cur in back; idx = idx, kept_len = kept_len {
+    let idx = if idx == cap { 0 } else { idx }
     if f(cur) is Some(v) {
       buf[idx] = v
-      idx += 1
-      kept_len += 1
+      continue idx + 1, kept_len + 1
     }
+    continue idx, kept_len
+  } nobreak {
+    kept_len
   }
   self.truncate(kept_len)
 }
@@ -1405,29 +1405,29 @@ pub fn[A] Deque::retain(self : Deque[A], f : (A) -> Bool) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self
   let cap = buf.length()
-  let mut idx = head
-  let mut kept_len = 0
   let (front, back) = self.as_views()
-  for cur in front {
+  let (idx, kept_len) = for cur in front; idx = head, kept_len = 0 {
     if f(cur) {
       buf[idx] = cur
-      idx += 1
-      kept_len += 1
+      continue idx + 1, kept_len + 1
     }
+    continue idx, kept_len
+  } nobreak {
+    (idx, kept_len)
   }
   if back.length() == 0 {
     self.truncate(kept_len)
     return
   }
-  for cur in back {
-    if idx == cap {
-      idx = 0
-    }
+  let kept_len = for cur in back; idx = idx, kept_len = kept_len {
+    let idx = if idx == cap { 0 } else { idx }
     if f(cur) {
       buf[idx] = cur
-      idx += 1
-      kept_len += 1
+      continue idx + 1, kept_len + 1
     }
+    continue idx, kept_len
+  } nobreak {
+    kept_len
   }
   self.truncate(kept_len)
 }
@@ -1755,17 +1755,19 @@ pub impl[A : @json.FromJson] @json.FromJson for Deque[A] with from_json(
 pub fn[A] Deque::chunks(self : Deque[A], size : Int) -> Deque[Deque[A]] {
   guard size > 0
   let chunks = from_array([])
-  let mut i = 0
-  while i < self.length() {
+  for i = 0; i < self.length(); {
     let chunk = Deque::new(capacity=size)
-    for _ in 0..<size {
+    let i = for _ in 0..<size; i = i {
       if i >= self.length() {
-        break
+        break i
       }
       chunk.push_back(self[i])
-      i = i + 1
+      continue i + 1
+    } nobreak {
+      i
     }
     chunks.push_back(chunk)
+    continue i
   }
   chunks
 }
@@ -1809,16 +1811,17 @@ pub fn[A] Deque::chunk_by(
   pred : (A, A) -> Bool raise?,
 ) -> Deque[Deque[A]] raise? {
   let chunks = from_array([])
-  let mut i = 0
-  while i < self.length() {
+  for i = 0; i < self.length(); {
     let chunk = from_array([])
     chunk.push_back(self[i])
-    i = i + 1
-    while i < self.length() && pred(self[i - 1], self[i]) {
+    let i = for i = i + 1; i < self.length() && pred(self[i - 1], self[i]); {
       chunk.push_back(self[i])
-      i = i + 1
+      continue i + 1
+    } nobreak {
+      i
     }
     chunks.push_back(chunk)
+    continue i
   }
   chunks
 }
@@ -2276,14 +2279,11 @@ pub impl[A : Compare] Compare for Deque[A] with compare(self, other) {
 pub fn[A] Deque::rev_in_place(self : Deque[A]) -> Unit {
   guard self.len > 0 else { return }
   let cap = self.buf.length()
-  let mut left = self.head
-  let mut right = self.tail_index()
-  for _ in 0..<(self.len / 2) {
+  for _ in 0..<(self.len / 2); left = self.head, right = self.tail_index() {
     let temp = self.buf[left]
     self.buf[left] = self.buf[right]
     self.buf[right] = temp
-    left = (left + 1) % cap
-    right = (right - 1 + cap) % cap
+    continue (left + 1) % cap, (right - 1 + cap) % cap
   }
 }
 

--- a/string/regex_methods.mbt
+++ b/string/regex_methods.mbt
@@ -51,24 +51,27 @@ pub fn Regex::replace_by(
   limit? : Int,
 ) -> StringView {
   let buf = StringBuilder::new()
-  let mut copy_index = 0
-  let mut search_index = 0
-  let mut replaced = 0
-  while search_index <= str.length() {
+  let copy_index = for copy_index = 0, search_index = 0, replaced = 0; search_index <=
+                      str.length(); {
     if limit is Some(limit) && replaced >= limit {
-      break
+      break copy_index
     }
     match regex.execute(str, last_index=search_index) {
-      None => break
+      None => break copy_index
       Some(m) => {
-        guard m.result.group(0) is Some((start, end)) else { break }
+        guard m.result.group(0) is Some((start, end)) else { break copy_index }
         buf.write_stringview(str[copy_index:start])
         buf.write_stringview(replacer(m))
-        copy_index = end
-        search_index = if start == end { str.next_char_index(end) } else { end }
-        replaced += 1
+        let search_index = if start == end {
+          str.next_char_index(end)
+        } else {
+          end
+        }
+        continue end, search_index, replaced + 1
       }
     }
+  } nobreak {
+    copy_index
   }
   buf.write_stringview(str[copy_index:])
   buf.to_string()[:]


### PR DESCRIPTION
## Summary

Convert `let mut` + loop patterns to functional for-loop state variables across 9 files, using the `for i in range; state = init` and `for state = init; cond;` syntax:

- **builtin/array**: `dedup`, `chunk_by`, `split`
- **builtin/array_sort_impl**: `timsort` (run detection), `fixed_quick_sort` (eliminates 5 `let mut`), `fixed_try_bubble_sort`, `fixed_sift_down`
- **builtin/array_sort_by_impl**: mirror changes for comparison-function variants
- **builtin/hasher**: `combine_bytes`, `BytesView::hash_combine`
- **builtin/string_methods**: `brute_force_find`/`brute_force_rev_find` (simplified nested while to single for), `contains_char` surrogate pair search
- **deque**: `chunks`, `chunk_by`, `retain`, `retain_map`, `rev_in_place`
- **string/regex_methods**: `Regex::replace_by`
- **argparse**: `remaining_positional_min`, `is_negative_number`

Net -26 lines. All 5946 tests pass.

## Test plan
- [x] `moon test` — 5946/5946 passed
- [x] `codex review --uncommitted` — no correctness issues found
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
