### PR TITLE
perf: BytesView pattern matching for hash + benchmarks

### DIFF
--- a/bench/hash_bench_test.mbt
+++ b/bench/hash_bench_test.mbt
@@ -1,0 +1,38 @@
+///|
+test "bench Hash for Bytes (small)" (it : @bench.T) {
+  let data = Bytes::make(16, 0xAB)
+  it.bench(fn() { it.keep(Hash::hash(data)) })
+}
+
+///|
+test "bench Hash for Bytes (medium)" (it : @bench.T) {
+  let data = Bytes::make(256, 0xAB)
+  it.bench(fn() { it.keep(Hash::hash(data)) })
+}
+
+///|
+test "bench Hash for Bytes (large)" (it : @bench.T) {
+  let data = Bytes::make(4096, 0xAB)
+  it.bench(fn() { it.keep(Hash::hash(data)) })
+}
+
+///|
+test "bench Hash for BytesView (small)" (it : @bench.T) {
+  let data = Bytes::make(16, 0xAB)
+  let view = data.view()
+  it.bench(fn() { it.keep(Hash::hash(view)) })
+}
+
+///|
+test "bench Hash for BytesView (medium)" (it : @bench.T) {
+  let data = Bytes::make(256, 0xAB)
+  let view = data.view()
+  it.bench(fn() { it.keep(Hash::hash(view)) })
+}
+
+///|
+test "bench Hash for BytesView (large)" (it : @bench.T) {
+  let data = Bytes::make(4096, 0xAB)
+  let view = data.view()
+  it.bench(fn() { it.keep(Hash::hash(view)) })
+}

--- a/bench/hash_bench_test.mbt
+++ b/bench/hash_bench_test.mbt
@@ -1,3 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 ///|
 test "bench Hash for Bytes (small)" (it : @bench.T) {
   let data = Bytes::make(16, 0xAB)

--- a/bench/hash_bench_test.mbt
+++ b/bench/hash_bench_test.mbt
@@ -50,3 +50,33 @@ test "bench Hash for BytesView (large)" (it : @bench.T) {
   let view = data.view()
   it.bench(fn() { it.keep(Hash::hash(view)) })
 }
+
+///|
+test "bench Hasher::combine_bytes (small)" (it : @bench.T) {
+  let data = Bytes::make(16, 0xAB)
+  it.bench(fn() {
+    let hasher = Hasher(seed=0)
+    hasher.combine_bytes(data)
+    it.keep(hasher.finalize())
+  })
+}
+
+///|
+test "bench Hasher::combine_bytes (medium)" (it : @bench.T) {
+  let data = Bytes::make(256, 0xAB)
+  it.bench(fn() {
+    let hasher = Hasher(seed=0)
+    hasher.combine_bytes(data)
+    it.keep(hasher.finalize())
+  })
+}
+
+///|
+test "bench Hasher::combine_bytes (large)" (it : @bench.T) {
+  let data = Bytes::make(4096, 0xAB)
+  it.bench(fn() {
+    let hasher = Hasher(seed=0)
+    hasher.combine_bytes(data)
+    it.keep(hasher.finalize())
+  })
+}

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -354,15 +354,22 @@ pub fn Hasher::combine_byte(self : Hasher, value : Byte) -> Unit {
 /// }
 /// ```
 pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
-  let (cur, remain) = for cur = 0, remain = value.length(); remain >= 4; {
-    self.consume4(endian32(value, cur))
-    continue cur + 4, remain - 4
-  } nobreak {
-    (cur, remain)
-  }
-  for cur = cur, remain = remain; remain >= 1; {
-    self.consume1(value[cur])
-    continue cur + 1, remain - 1
+  for data = value.view() {
+    if data is [u32le(x), .. rest] {
+      self.consume4(x)
+      continue rest
+    } else {
+      if data is [b0, .. data] {
+        self.consume1(b0)
+        if data is [b1, .. data] {
+          self.consume1(b1)
+          if data is [b2, ..] {
+            self.consume1(b2)
+          }
+        }
+      }
+      break
+    }
   }
 }
 
@@ -460,16 +467,6 @@ fn Hasher::consume1(self : Hasher, input : Byte) -> Unit {
 ///|
 fn rotl(x : UInt, r : Int) -> UInt {
   (x << r) | (x >> (32 - r))
-}
-
-///|
-fn endian32(input : Bytes, cur : Int) -> UInt {
-  input[cur + 0].to_uint() |
-  (
-    (input[cur + 1].to_uint() << 8) |
-    (input[cur + 2].to_uint() << 16) |
-    (input[cur + 3].to_uint() << 24)
-  )
 }
 
 ///|
@@ -651,20 +648,22 @@ pub impl[T : Hash, E : Hash] Hash for Result[T, E] with hash_combine(
 
 ///|
 pub impl Hash for BytesView with hash_combine(self : BytesView, hasher : Hasher) {
-  let data = self.bytes()
-  let (start, rest) = for start = self.start(), rest = self.len(); rest >= 4; {
-    let result = for i in 0..<=3; result = (0 : UInt) {
-      continue result | (data.unsafe_get(i + start).to_uint() << (8 * i))
-    } nobreak {
-      result
+  for data = self {
+    if data is [u32le(x), .. rest] {
+      hasher.combine_uint(x)
+      continue rest
+    } else {
+      // only 0-3 bytes left
+      if data is [b0, .. data] {
+        hasher.combine_byte(b0)
+        if data is [b1, .. data] {
+          hasher.combine_byte(b1)
+          if data is [b2, ..] {
+            hasher.combine_byte(b2)
+          }
+        }
+      }
+      break
     }
-    hasher.combine_uint(result)
-    continue start + 4, rest - 4
-  } nobreak {
-    (start, rest)
-  }
-  for start = start, rest = rest; rest >= 1; {
-    hasher.combine_byte(data.unsafe_get(start))
-    continue start + 1, rest - 1
   }
 }

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -358,15 +358,22 @@ pub fn Hasher::combine_byte(self : Hasher, value : Byte) -> Unit {
 /// }
 /// ```
 pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
-  let (cur, remain) = for cur = 0, remain = value.length(); remain >= 4; {
-    self.consume4(endian32(value, cur))
-    continue cur + 4, remain - 4
-  } nobreak {
-    (cur, remain)
-  }
-  for cur = cur, remain = remain; remain >= 1; {
-    self.consume1(value[cur])
-    continue cur + 1, remain - 1
+  for data = value.view() {
+    if data is [u32le(x), .. rest] {
+      self.consume4(x)
+      continue rest
+    } else {
+      if data is [b0, .. data] {
+        self.consume1(b0)
+        if data is [b1, .. data] {
+          self.consume1(b1)
+          if data is [b2, ..] {
+            self.consume1(b2)
+          }
+        }
+      }
+      break
+    }
   }
 }
 
@@ -474,16 +481,6 @@ fn Hasher::consume1(self : Hasher, input : Byte) -> Unit {
 ///|
 fn rotl(x : UInt, r : Int) -> UInt {
   (x << r) | (x >> (32 - r))
-}
-
-///|
-fn endian32(input : Bytes, cur : Int) -> UInt {
-  input[cur + 0].to_uint() |
-  (
-    (input[cur + 1].to_uint() << 8) |
-    (input[cur + 2].to_uint() << 16) |
-    (input[cur + 3].to_uint() << 24)
-  )
 }
 
 ///|
@@ -735,20 +732,22 @@ pub impl Hash for BytesView with fn hash_combine(
   self : BytesView,
   hasher : Hasher,
 ) {
-  let data = self.bytes()
-  let (start, rest) = for start = self.start(), rest = self.len(); rest >= 4; {
-    let result = for i in 0..<=3; result = (0 : UInt) {
-      continue result | (data.unsafe_get(i + start).to_uint() << (8 * i))
-    } nobreak {
-      result
+  for data = self {
+    if data is [u32le(x), .. rest] {
+      hasher.combine_uint(x)
+      continue rest
+    } else {
+      // only 0-3 bytes left
+      if data is [b0, .. data] {
+        hasher.combine_byte(b0)
+        if data is [b1, .. data] {
+          hasher.combine_byte(b1)
+          if data is [b2, ..] {
+            hasher.combine_byte(b2)
+          }
+        }
+      }
+      break
     }
-    hasher.combine_uint(result)
-    continue start + 4, rest - 4
-  } nobreak {
-    (start, rest)
-  }
-  for start = start, rest = rest; rest >= 1; {
-    hasher.combine_byte(data.unsafe_get(start))
-    continue start + 1, rest - 1
   }
 }


### PR DESCRIPTION
## Summary

- Rewrites `Hasher::combine_bytes` and `Hash for BytesView` to use the `[u32le(x), .. rest]` view pattern instead of manual index arithmetic with `endian32`
- Removes the now-unused `endian32` helper
- Adds hash benchmarks for `Bytes`, `BytesView`, and `Hasher::combine_bytes` at 16B / 256B / 4KB

## Benchmark results

Re-measured on 2026-08-19, rebased onto main **after #4097 landed**. That rebase changes the conclusion, so the earlier numbers in this thread are superseded:

- The ~3x regression this PR was originally filed under is long gone.
- The wasm-gc `combine_bytes` regression I reported before #4097 (+22% to +36%) **is also gone** — that regression was the un-unrolled `unsafe_read_uint32_le` fallback, which #4097 fixed.
- wasm-gc `BytesView` has additionally flipped from neutral to a 12–18% win, because this PR routes through the now-unrolled helper while the code it replaces kept its own per-byte shift loop.

**Every row on every backend is now a win or parity.**

Method: A/B between the bench-only commit (benchmarks, old hasher) and the branch head, same benchmark file, `moon bench --release`, 3 runs per backend. Figures are means.

### native

| benchmark | main | this PR | Δ |
|---|---|---|---|
| Bytes 16B | 7.53 ns | 7.57 ns | +0.5% |
| Bytes 256B | 108.1 ns | 108.0 ns | 0.0% |
| Bytes 4KB | 2.343 µs | 2.350 µs | +0.3% |
| BytesView 16B | 14.35 ns | 12.89 ns | **−10.2%** |
| BytesView 256B | 132.1 ns | 109.6 ns | **−17.1%** |
| BytesView 4KB | 2.457 µs | 2.340 µs | −4.8% |
| `combine_bytes` 16B | 16.00 ns | 13.43 ns | **−16.1%** |
| `combine_bytes` 256B | 124.8 ns | 98.7 ns | **−20.9%** |
| `combine_bytes` 4KB | 2.150 µs | 2.047 µs | −4.8% |

### wasm-gc

| benchmark | main | this PR | Δ |
|---|---|---|---|
| Bytes 16B | 13.90 ns | 14.07 ns | +1.2% |
| Bytes 256B | 150.2 ns | 149.4 ns | −0.6% |
| Bytes 4KB | 2.477 µs | 2.490 µs | +0.5% |
| BytesView 16B | 22.30 ns | 19.57 ns | **−12.2%** |
| BytesView 256B | 190.9 ns | 157.3 ns | **−17.6%** |
| BytesView 4KB | 2.837 µs | 2.483 µs | **−12.5%** |
| `combine_bytes` 16B | 17.56 ns | 16.88 ns | −3.9% |
| `combine_bytes` 256B | 135.2 ns | 136.5 ns | +1.0% |
| `combine_bytes` 4KB | 2.157 µs | 2.213 µs | +2.6% |

The three `combine_bytes` rows were +21.8% / +35.9% / +29.2% when measured before #4097. They are now within the ±2–4% run-to-run spread.

### js

| benchmark | main | this PR | Δ |
|---|---|---|---|
| Bytes 16B | 12.23 ns | 11.99 ns | −2.0% |
| Bytes 256B | 152.2 ns | 157.1 ns | +3.2% |
| Bytes 4KB | 2.487 µs | 2.523 µs | +1.4% |
| BytesView 16B | 15.07 ns | 14.65 ns | −2.8% |
| BytesView 256B | 144.3 ns | 143.8 ns | −0.4% |
| BytesView 4KB | 2.493 µs | 2.473 µs | −0.8% |
| `combine_bytes` 16B | 19.02 ns | 19.16 ns | +0.7% |
| `combine_bytes` 256B | 162.2 ns | 133.2 ns | −17.9% (see note) |
| `combine_bytes` 4KB | 2.280 µs | 2.193 µs | −3.8% |

Note on the js `combine_bytes` 256B row: the baseline was unstable (173.5 / 150.4 / 162.8 ns across runs, with σ up to 29.6 ns *within* a run) while this PR's side was tight (132.9 / 132.8 / 133.7). The direction is solid — every baseline sample exceeds every PR sample — but treat the −17.9% as approximate.

### Reading the numbers

Run-to-run spread is roughly ±2–4%, so every row under that should be read as unchanged.

The `Hash::hash(Bytes)` rows mean **different things on different backends**, which is worth stating precisely:

- On **native and wasm-gc** they are a true control. `Hash for Bytes with fn hash` (`builtin/bytes.mbt:828`) is a specialized accumulator guarded by `#cfg(not(target="js"))`, it overrides the defaulted `hash`, and this PR does not touch it. Those rows should be flat, and are.
- On **js** that override is `#cfg`'d out, so the default `Hash::hash` (`builtin/traits.mbt:79`) calls `hash_combine`, and `Bytes::hash_combine` delegates through `self[:]` (`builtin/bytes.mbt:819`) into the changed `BytesView` implementation. **The js `Bytes` rows therefore exercise changed code** — read them as a second, wrapper-inclusive measurement of the `BytesView` path, not as a control.

One methodological caveat: the `combine_bytes` cases construct and finalize a `Hasher` inside the timed closure. That is paid identically on both sides so the A/B is fair, but its fixed cost dilutes the ratio at 16B. Hoisting the hasher would change the workload being measured, so it is left in.

The two changed methods differ because their *old* code differed. `combine_bytes` gave up the hand-written `endian32`; `Hash for BytesView` gave up a per-byte `for i in 0..<=3` shift loop. Both now share one unrolled `unsafe_read_uint32_le`, which is why the wasm-gc `BytesView` row improved on rebase without this PR changing.

## Test plan

- [x] `moon test` passes on all three backends — native 7370, wasm-gc 7454, js 7398
- [x] `moon fmt`, `moon check`, `moon info` clean; no `.mbti` change (`endian32` was private and the impl signature is unchanged)
- [x] Benchmarks run on native, wasm-gc and js
- [x] Codex CLI reviewed hash-value equivalence: modeled old/new consumption traces matched across 156,849 length-and-offset cases, including the 0–3 byte tail and non-zero-offset views. `builtin/hasher.mbt` and the benchmark file are byte-identical to the reviewed revision — the rebase was conflict-free and changed nothing under review.

## Note on file placement

`bench/hash_bench_test.mbt` sits inside the `@bench` library package, whereas core's convention puts bench files beside the code they measure (`builtin/bytes_unsafe_bench_test.mbt` and friends). Main also already carries `builtin/bytes_hash_bench_test.mbt` covering `Hash::hash(Bytes)` at n=32/8192. Happy to move this into `builtin/` if preferred.

Signed-off-by: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
