### PR TITLE
refactor: simplify for-loops with direct iteration

### DIFF
--- a/argparse/parser_values.mbt
+++ b/argparse/parser_values.mbt
@@ -18,8 +18,7 @@ fn assign_positionals(
   positionals : Array[Arg],
   values : Array[String],
 ) -> Unit raise ArgParseError {
-  let cursor = for idx in 0..<positionals.length(); cursor = 0 {
-    let arg = positionals[idx]
+  let cursor = for idx, arg in positionals; cursor = 0 {
     let remaining = values.length() - cursor
     if arg.multiple {
       let (min, max) = arg_min_max(arg)

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -141,11 +141,10 @@ pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
   let buf = StringBuilder::new(size_hint=10)
   let ArgsLoc(self) = self
   buf.write_char('[')
-  for i in 0..<self.length() {
+  for i, item in self {
     if i != 0 {
       buf.write_string(", ")
     }
-    let item = self[i]
     match item {
       None => buf.write_string("null")
       Some(loc) => buf.write_string(loc.to_json_string())

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -437,8 +437,8 @@ test "Map::retain - with hash collisions simulation" {
   let map : Map[String, Int] = Map::new()
   // Create keys that might have similar hash values
   let keys = ["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa"]
-  for i in 0..<keys.length() {
-    map.set(keys[i], i + 1)
+  for i, k in keys {
+    map.set(k, i + 1)
   }
 
   // Keep only keys with odd length

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -595,11 +595,11 @@ test "equal_key_value_mismatch" {
 ///|
 fn[K : Show, V : Show] Map::_debug_entries(self : Map[K, V]) -> String {
   let buf = StringBuilder::new()
-  for i in 0..<self.entries.length() {
+  for i, entry in self.entries {
     if i > 0 {
       buf.write_char(',')
     }
-    match self.entries[i] {
+    match entry {
       None => buf.write_char('_')
       Some({ psl, key, value, .. }) =>
         buf.write_string("(\{psl},\{key},\{value})")

--- a/bytes/internal/regex_engine/symbol_map/sparse_table.mbt
+++ b/bytes/internal/regex_engine/symbol_map/sparse_table.mbt
@@ -26,19 +26,17 @@ priv struct SparseTable(ReadOnlyArray[SparseTableEntry])
 ///|
 impl Table for SparseTable with map(self, c) {
   let arr = self.0
-  let mut left = 0
-  let mut right = arr.length() - 1
-  while left <= right {
+  for left = 0, right = arr.length() - 1; left <= right; {
     let mid = left + (right - left) / 2
     let entry = arr[mid]
     if c < entry.lo {
-      right = mid - 1
+      continue left, mid - 1
     } else if c > entry.hi {
-      left = mid + 1
+      continue mid + 1, right
     } else {
-      // c is within [lo, hi]
-      return entry.symbol
+      break entry.symbol
     }
+  } nobreak {
+    panic()
   }
-  panic()
 }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -39,11 +39,11 @@ pub fn CoverageCounter::incr(self : CoverageCounter, idx : Int) -> Unit {
 pub impl Show for CoverageCounter with output(self, logger) {
   let CoverageCounter(self) = self
   logger.write_char('[')
-  for i in 0..<self.length() {
+  for i, v in self {
     if i != 0 {
       logger.write_string(", ")
     }
-    Show::output(self[i], logger)
+    Show::output(v, logger)
   }
   logger.write_char(']')
 }
@@ -111,8 +111,7 @@ pub fn end() -> Unit {
   let sbuf = StringBuffer::StringBuffer([])
   coverage_log(counters.val, sbuf)
   let line_buf = StringBuilder::new()
-  for i in 0..<sbuf.0.length() {
-    let str = sbuf.0[i]
+  for str in sbuf.0 {
     let start = for j in 0..<str.length(); start = 0 {
       if str.unsafe_get(j) == '\n' {
         line_buf.write_view(str[start:j])

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -19,8 +19,8 @@ fn get_cli_args_ffi() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
 fn get_cli_args_internal() -> Array[String] {
   let tmp = get_cli_args_ffi()
   let res = Array::new(capacity=tmp.length())
-  for i in 0..<tmp.length() {
-    res.push(utf8_bytes_to_mbt_string(tmp[i]))
+  for t in tmp {
+    res.push(utf8_bytes_to_mbt_string(t))
   }
   res
 }

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -501,8 +501,8 @@ fn[K : Eq, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
   self.capacity = new_capacity
   self.capacity_mask = new_capacity - 1
   self.size = 0
-  for i in 0..<old_entries.length() {
-    if old_entries[i] is Some({ key, value, hash, .. }) {
+  for entry in old_entries {
+    if entry is Some({ key, value, hash, .. }) {
       self.set_with_hash(key, value, hash)
     }
   }
@@ -767,8 +767,8 @@ test "arbitrary" {
     [("", -4), ("v", -2), (")xh", 1), ("C\u{10}\u{0e}", -3), ("|", 0)],
     [("", 1), ("b", -1)],
   ]
-  for i in 0..<samples.length() {
-    verify_content(samples[i], data[i])
+  for i, sample in samples {
+    verify_content(sample, data[i])
   }
 }
 
@@ -823,8 +823,8 @@ test "clear" {
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
-  for i in 0..<m.capacity() {
-    @test.same_object(m.entries[i], None)
+  for entry in m.entries {
+    @test.same_object(entry, None)
   }
 }
 

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -216,8 +216,8 @@ fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
   self.capacity_mask = self.capacity - 1
   self.grow_at = calc_grow_threshold(self.capacity)
   self.size = 0
-  for i in 0..<old_entries.length() {
-    if old_entries[i] is Some({ key, hash, .. }) {
+  for entry in old_entries {
+    if entry is Some({ key, hash, .. }) {
       self.add_with_hash(key, hash)
     }
   }
@@ -570,8 +570,8 @@ test "clear" {
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
-  for i in 0..<m.capacity() {
-    @test.same_object(m.entries[i], None)
+  for entry in m.entries {
+    @test.same_object(entry, None)
   }
 }
 

--- a/immut/array/array_wbtest.mbt
+++ b/immut/array/array_wbtest.mbt
@@ -52,8 +52,8 @@ test "mix" {
   }
   let vec = []
   v.eachi((i, _e) => vec.push(i))
-  for i in 0..<large_const {
-    assert_eq(vec[i], i)
+  for i, v in vec {
+    assert_eq(v, i)
   }
 }
 
@@ -131,8 +131,8 @@ fn gen_concat_seq(n : Int, len_gen : (Int) -> Int) -> Array[Op] {
 /// to be concatenated is given as an array.
 fn gen_concat_seq_from_len_array(len : Array[Int]) -> Array[Op] {
   let ret = []
-  for i in 0..<len.length() {
-    ret.push(Op::Concat(random_array(len[i])))
+  for l in len {
+    ret.push(Op::Concat(random_array(l)))
   }
   ret
 }

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -43,8 +43,8 @@ pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
 pub fn[A : Compare] PriorityQueue::from_array(
   array : ArrayView[A],
 ) -> PriorityQueue[A] {
-  for i in 0..<array.length(); pq = (new() : PriorityQueue[A]) {
-    continue pq.push(array[i])
+  for x in array; pq = (new() : PriorityQueue[A]) {
+    continue pq.push(x)
   } nobreak {
     pq
   }
@@ -363,8 +363,8 @@ pub impl[A : Compare] Compare for PriorityQueue[A] with compare(self, other) {
   }
   let self_arr = self.to_array()
   let other_arr = other.to_array()
-  for i in 0..<self_arr.length() {
-    let cmp = self_arr[i].compare(other_arr[i])
+  for i, x in self_arr {
+    let cmp = x.compare(other_arr[i])
     if cmp != 0 {
       return cmp
     }

--- a/math/exp_test.mbt
+++ b/math/exp_test.mbt
@@ -28,8 +28,7 @@ test "expf Test" {
     0.1271357387304306, 0.046770621091127396, 0.017205949872732162, 0, @float.infinity,
     @float.not_a_number,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.expf(x)
     let libm_res = libm_results[i]
     assert_true(
@@ -54,8 +53,7 @@ test "expm1f Test" {
     -0.8728642463684082, -0.9532293677330017, -0.9827940464019775, -1.0, @float.infinity,
     @float.not_a_number,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.expm1f(x)
     let libm_res = libm_results[i]
     assert_true(

--- a/math/hyperbolic_test.mbt
+++ b/math/hyperbolic_test.mbt
@@ -26,8 +26,7 @@ test "sinhf Test" {
     -4.126732349395752, -11.357978820800781, -30.925823211669922, -0.0625406950712204,
     -1.2740025520324707, -3.869236707687378, -10.667085647583008, -29.051111221313477,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.sinhf(x)
     let libm_res = libm_results[i]
     assert_true(
@@ -50,8 +49,7 @@ test "coshf Test" {
     11.401915550231934, 30.941986083984375, 1.0019537210464478, 1.6195933818817139,
     3.9963724613189697, 10.71385669708252, 29.068317413330078,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.coshf(x)
     let libm_res = libm_results[i]
     assert_true(
@@ -74,8 +72,7 @@ test "tanhf Test" {
     -0.996146559715271, -0.9994776248931885, -0.06241874769330025, -0.7866188287734985,
     -0.9681872129440308, -0.9956345558166504, -0.9994080662727356,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.tanhf(x)
     let libm_res = libm_results[i]
     assert_true(
@@ -99,8 +96,7 @@ test "asinhf Test" {
     -0.06245937943458557, -0.924884557723999, -1.4712419509887695, -1.8380275964736938,
     -2.1097605228424072,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.asinhf(x)
     let libm_res = libm_results[i]
     assert_true(
@@ -119,8 +115,7 @@ test "acoshf Test" {
     2.558979034423828, 2.703575849533081, 2.829735040664673, 2.941657304763794, 3.0422470569610596,
     0.6931471824645996, 1.450574517250061, 1.8472460508346558, 2.1259288787841797,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.acoshf(x)
     let libm_res = libm_results[i]
     assert_true(
@@ -143,8 +138,7 @@ test "atanhf Test" {
     1.256152868270874, 1.8317806720733643, -0.12565721571445465, -0.22891654074192047,
     -0.3372275233268738, -0.45377853512763977, -0.5832173824310303,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.atanhf(x)
     let libm_res = libm_results[i]
     assert_true(

--- a/math/log_test.mbt
+++ b/math/log_test.mbt
@@ -25,8 +25,7 @@ test "@math.lnf Test" {
     1.1786550283432007, 1.4469189643859863, @float.not_a_number, @float.not_a_number,
     @float.infinity,
   ]
-  for i in 0..<data.length() {
-    let x = data[i]
+  for i, x in data {
     let res = @math.lnf(x)
     let libm_res = libm_results[i]
     assert_true(

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -35,8 +35,8 @@ pub fn[V] SortedSet::singleton(value : V) -> SortedSet[V] {
 #as_free_fn(of, deprecated="Use from_array instead")
 pub fn[V : Compare] SortedSet::from_array(array : ArrayView[V]) -> SortedSet[V] {
   let set = new()
-  for i in 0..<array.length() {
-    set.add(array[i])
+  for x in array {
+    set.add(x)
   }
   set
 }

--- a/strconv/bool.mbt
+++ b/strconv/bool.mbt
@@ -40,8 +40,7 @@ test "parse_bool" {
     ("true", Ok(true)),
     ("True", Ok(true)),
   ]
-  for i in 0..<tests.length() {
-    let t = tests[i]
+  for t in tests {
     assert_eq(
       Result::Ok(parse_bool(t.0)) catch {
         StrConvError(err) => Err(err)

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -608,8 +608,7 @@ test "shift" {
     (195312L, 9, "99999744"),
     (1953125L, 9, "1000000000"),
   ]
-  for i in 0..<tests.length() {
-    let t = tests[i]
+  for t in tests {
     let d = Decimal::from_int64_priv(t.0)
     d.shift_priv(t.1)
     assert_eq(d.to_string(), t.2)

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -255,8 +255,7 @@ test "parse_double" {
     ("123.5e+1__2", Err(syntax_err_str)),
     ("123.5e+12_", Err(syntax_err_str)),
   ]
-  for i in 0..<tests.length() {
-    let t = tests[i]
+  for t in tests {
     assert_eq(
       Result::Ok(parse_double(t.0)) catch {
         StrConvError(err) => Err(err)

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -119,8 +119,7 @@ test "parse_uint64" {
     ("12345_", Err(syntax_err_str)),
     ("12345%", Err(syntax_err_str)),
   ]
-  for i in 0..<tests.length() {
-    let t = tests[i]
+  for t in tests {
     assert_eq(
       Result::Ok(parse_uint64(t.0)) catch {
         StrConvError(err) => Err(err)
@@ -217,8 +216,7 @@ test "parse_uint64_base" {
     ("0x+f", 0, Err(syntax_err_str)),
     ("0x-f", 0, Err(syntax_err_str)),
   ]
-  for i in 0..<tests.length() {
-    let t = tests[i]
+  for t in tests {
     assert_eq(
       Result::Ok(parse_uint64(t.0, base=t.1)) catch {
         StrConvError(err) => Err(err)
@@ -252,8 +250,7 @@ test "parse_uint" {
     ("12345_", Err(syntax_err_str)),
     ("123%45", Err(syntax_err_str)),
   ]
-  for i in 0..<tests.length() {
-    let t = tests[i]
+  for t in tests {
     assert_eq(
       Result::Ok(parse_uint(t.0)) catch {
         StrConvError(err) => Err(err)


### PR DESCRIPTION
## Summary
- Replace `for i in 0..<arr.length() { let x = arr[i] ... }` with `for i, x in arr { ... }` or `for x in arr { ... }` when the index is unused across 19 files
- Convert a while-loop binary search in `sparse_table.mbt` to a functional for-loop with state variables
- Net reduction of 20 lines

## Test plan
- [x] `moon check` passes
- [x] `moon fmt` applied
- [x] Codex review confirms correct mechanical refactor with no semantic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
