### PR TITLE
builtin: add Iter::zip/combine with docs and tests

### DIFF
--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -360,6 +360,37 @@ test "concat" {
 }
 
 ///|
+test "zip" {
+  let numbers = (1).until(6)
+  let letters = ["a", "b", "c"].iter()
+  inspect(
+    numbers.zip(letters).collect(),
+    content="[(1, \"a\"), (2, \"b\"), (3, \"c\")]",
+  )
+}
+
+///|
+test "zip alias combine" {
+  let numbers = (1).until(4)
+  let letters = ["x", "y", "z", "w"].iter()
+  inspect(
+    numbers.combine(letters).collect(),
+    content="[(1, \"x\"), (2, \"y\"), (3, \"z\")]",
+  )
+}
+
+///|
+test "zip short-circuits when either side ends" {
+  let lhs_evaluated = []
+  let rhs_evaluated = []
+  let lhs = (1).until(10).tap(x => lhs_evaluated.push(x))
+  let rhs = [10, 20].iter().tap(x => rhs_evaluated.push(x))
+  inspect(lhs.zip(rhs).collect(), content="[(1, 10), (2, 20)]")
+  inspect(lhs_evaluated, content="[1, 2, 3]")
+  inspect(rhs_evaluated, content="[10, 20]")
+}
+
+///|
 test "collect" {
   let arr = ['1', '2', '3', '4', '5']
   let iter = arr.iter()

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -664,6 +664,50 @@ pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
 }
 
 ///|
+/// Combines two iterators element-wise into an iterator of pairs.
+///
+/// The resulting iterator stops as soon as either input iterator is exhausted.
+///
+/// # Type Parameters
+///
+/// - `X`: The element type of `self`.
+/// - `Y`: The element type of `other`.
+///
+/// # Arguments
+///
+/// * `self` - The first input iterator.
+/// * `other` - The second input iterator.
+///
+/// # Returns
+///
+/// Returns a new iterator yielding tuples `(x, y)` where `x` comes from `self`
+/// and `y` comes from `other`.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let numbers = (1).until(5)
+///   let letters = ["a", "b", "c"].iter()
+///   inspect(
+///     numbers.zip(letters).collect(),
+///     content="[(1, \"a\"), (2, \"b\"), (3, \"c\")]",
+///   )
+/// }
+/// ```
+///
+/// # Note
+/// The old iterators `self` and `other` must not be used again after calling `zip`.
+#alias(combine)
+pub fn[X, Y] Iter::zip(self : Iter[X], other : Iter[Y]) -> Iter[(X, Y)] {
+  fn() {
+    guard self.next() is Some(x) else { None }
+    guard other.next() is Some(y) else { None }
+    Some((x, y))
+  }
+}
+
+///|
 pub impl[T] Add for Iter[T] with add(self, other) {
   self.concat(other)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -301,6 +301,8 @@ pub fn[X] Iter::to_array(Self[X]) -> Array[X]
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[X] Iter::view(Self[X], start? : Int, end? : Int) -> Self[X]
+#alias(combine)
+pub fn[X, Y] Iter::zip(Self[X], Self[Y]) -> Self[(X, Y)]
 pub impl[T] Add for Iter[T]
 pub impl[X : Show] Show for Iter[X]
 pub impl[X : ToJson] ToJson for Iter[X]


### PR DESCRIPTION
### Motivation
- Provide an element-wise zipping operation for external `Iter` to address feature request for `zip/combine` (issue #3280). 
- Offer an alias `combine` for ergonomics and backwards compatibility with requested naming.

### Description
- Add `pub fn[X, Y] Iter::zip(self : Iter[X], other : Iter[Y]) -> Iter[(X, Y)]` that yields `(x, y)` pairs and stops when either input is exhausted, with full API documentation and a usage example in `builtin/iterator.mbt`.
- Add `#alias(combine)` so `Iter::combine` is available as an alias for `zip`.
- Add unit tests covering basic `zip` behavior, the `combine` alias, and short-circuit semantics (including evaluation-order checks) in `builtin/iter_test.mbt`.
- Update the generated package interface `builtin/pkg.generated.mbti` to expose `Iter::zip` and the `combine` alias.

### Testing
- Ran `moon fmt` which completed successfully.
- Ran `moon info` to refresh generated interfaces which completed successfully.
- Ran the full test suite with `moon test`, where `Total tests: 5951, passed: 5951, failed: 0`.
- Ran `moon check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6c98518b88320a0adabb694e832aa)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
