### PR TITLE
perf(sorted_set): O(n+m) difference, intersection, symmetric_difference

### DIFF
--- a/sorted_set/invariant_wbtest.mbt
+++ b/sorted_set/invariant_wbtest.mbt
@@ -1,0 +1,210 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Whitebox structural-invariant tests for the mutable AVL tree behind
+// `SortedSet`, focused on the split/join based set operations
+// (`difference`, `intersection`, `symmetric_difference`, `union`).
+// Blackbox tests can only observe symptoms (wrong membership, wrong
+// iteration order); these tests recursively verify the internal invariants
+// of every node in every operation result, so latent corruption (a stale
+// cached height, an unbalanced subtree that merely degrades performance,
+// a size counter that drifted, a node shared with an input tree) is caught
+// directly.
+//
+// Invariants checked (see `check_invariants`):
+//  1. BST order with full min/max bounds propagation (checking only the
+//     immediate children would miss violations deeper in the tree).
+//  2. AVL balance: |height(left) - height(right)| <= 1 at every node.
+//  3. Cached height: the stored `height` field equals the recomputed
+//     true height (leaf = 1).
+//  4. The set-level `size` field equals the actual node count.
+
+///|
+/// Recursively checks one node. `lower`/`upper` are exclusive bounds
+/// inherited from ancestors. Returns (recomputed_height, node_count).
+fn check_node(
+  node : Node[Int]?,
+  lower : Int?,
+  upper : Int?,
+) -> (Int, Int) raise {
+  match node {
+    None => (0, 0)
+    Some(n) => {
+      if lower is Some(lo) && n.value <= lo {
+        fail("BST order violated: value \{n.value} <= lower bound \{lo}")
+      }
+      if upper is Some(hi) && n.value >= hi {
+        fail("BST order violated: value \{n.value} >= upper bound \{hi}")
+      }
+      let (lh, lc) = check_node(n.left, lower, Some(n.value))
+      let (rh, rc) = check_node(n.right, Some(n.value), upper)
+      let true_height = 1 + max(lh, rh)
+      if n.height != true_height {
+        fail(
+          "stale cached height at value \{n.value}: stored \{n.height}, actual \{true_height}",
+        )
+      }
+      let bal = lh - rh
+      if bal > 1 || bal < -1 {
+        fail(
+          "AVL balance violated at value \{n.value}: left height \{lh}, right height \{rh}",
+        )
+      }
+      (true_height, lc + rc + 1)
+    }
+  }
+}
+
+///|
+/// Verifies every structural invariant of the whole set.
+fn check_invariants(set : SortedSet[Int]) -> Unit raise {
+  let (_, count) = check_node(set.root, None, None)
+  if count != set.size {
+    fail(
+      "size field out of sync: stored \{set.size}, actual node count \{count}",
+    )
+  }
+}
+
+///|
+/// Minimal deterministic splitmix64 PRNG so the whitebox test needs no
+/// extra package imports (importing `quickcheck` here would pull in a
+/// package that itself depends on `sorted_set`).
+priv struct Rand {
+  mut state : UInt64
+}
+
+///|
+fn Rand::next(self : Rand) -> UInt64 {
+  self.state += 0x9E3779B97F4A7C15UL
+  let mut z = self.state
+  z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL
+  z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL
+  z ^ (z >> 31)
+}
+
+///|
+/// Uniform-ish integer in [0, limit).
+fn Rand::below(self : Rand, limit : Int) -> Int {
+  (self.next() & 0x7FFFFFFFUL).to_int() % limit
+}
+
+///|
+/// Builds two random sets over `key_space`, runs the four set operations,
+/// and checks that every result satisfies the structural invariants and has
+/// the size the array model predicts, that the inputs are left intact, and
+/// that the results stay valid under further mutation.
+fn set_ops_scenario(
+  seed : UInt64,
+  size_a : Int,
+  size_b : Int,
+  key_space : Int,
+) -> Unit raise {
+  let rng = Rand::{ state: seed }
+  let a : SortedSet[Int] = new_sorted_set()
+  let b : SortedSet[Int] = new_sorted_set()
+  for _ in 0..<size_a {
+    a.add(rng.below(key_space))
+  }
+  for _ in 0..<size_b {
+    b.add(rng.below(key_space))
+  }
+  check_invariants(a)
+  check_invariants(b)
+  let a0 = a.to_array()
+  let b0 = b.to_array()
+  let mut shared = 0
+  for x in a0 {
+    if b.contains(x) {
+      shared += 1
+    }
+  }
+  let d = a.difference(b)
+  let i = a.intersection(b)
+  let s = a.symmetric_difference(b)
+  let u = a.union(b)
+  for result in [d, i, s, u] {
+    check_invariants(result)
+  }
+  @test.assert_eq(d.length(), a0.length() - shared)
+  @test.assert_eq(i.length(), shared)
+  @test.assert_eq(s.length(), a0.length() + b0.length() - 2 * shared)
+  @test.assert_eq(u.length(), a0.length() + b0.length() - shared)
+  // the inputs are untouched, structurally and in content
+  check_invariants(a)
+  check_invariants(b)
+  @test.assert_eq(a.to_array(), a0)
+  @test.assert_eq(b.to_array(), b0)
+  // the results stay valid trees under further mutation, and mutating them
+  // never leaks into the inputs (they would if nodes were shared)
+  for result in [d, i, s, u] {
+    for _ in 0..<20 {
+      result.add(rng.below(key_space))
+      result.remove(rng.below(key_space))
+      check_invariants(result)
+    }
+  }
+  @test.assert_eq(a.to_array(), a0)
+  @test.assert_eq(b.to_array(), b0)
+}
+
+///|
+test "set operations keep invariants (heavy overlap)" {
+  for seed in 1..<=5 {
+    set_ops_scenario(seed.to_uint64() * 0x9E3779B9UL, 120, 120, 60)
+  }
+}
+
+///|
+test "set operations keep invariants (sparse overlap, deeper trees)" {
+  for seed in 1..<=3 {
+    set_ops_scenario(0xDEADBEEFUL + seed.to_uint64(), 200, 150, 5000)
+  }
+}
+
+///|
+test "set operations keep invariants (asymmetric sizes)" {
+  for seed in 1..<=3 {
+    set_ops_scenario(0xC0FFEEUL + seed.to_uint64(), 300, 7, 400)
+    set_ops_scenario(0xF00DUL + seed.to_uint64(), 7, 300, 400)
+  }
+}
+
+///|
+test "set operations with self and empty keep invariants" {
+  let rng = Rand::{ state: 77UL }
+  let a : SortedSet[Int] = new_sorted_set()
+  for _ in 0..<150 {
+    a.add(rng.below(500))
+  }
+  let empty : SortedSet[Int] = new_sorted_set()
+  for
+    result in [
+      a.difference(a),
+      a.intersection(a),
+      a.symmetric_difference(a),
+      a.difference(empty),
+      empty.difference(a),
+      a.intersection(empty),
+      a.symmetric_difference(empty),
+      empty.symmetric_difference(a),
+    ] {
+    check_invariants(result)
+  }
+  @test.assert_eq(a.difference(a).length(), 0)
+  @test.assert_eq(a.intersection(a).to_array(), a.to_array())
+  @test.assert_eq(a.symmetric_difference(a).length(), 0)
+  check_invariants(a)
+  check_invariants(empty)
+}

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -10,3 +10,7 @@ import {
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"
+
+import {
+  "moonbitlang/core/test",
+} for "wbtest"

--- a/sorted_set/quickcheck_test.mbt
+++ b/sorted_set/quickcheck_test.mbt
@@ -27,6 +27,123 @@ test "quickcheck: iteration is sorted and duplicate-free" {
 }
 
 ///|
+test "quickcheck: difference matches the filter model" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let a = @sorted_set.from_array(xs)
+    let b = @sorted_set.from_array(ys)
+    let d = a.difference(b)
+    let expected = a.to_array().filter(x => !b.contains(x))
+    d.to_array() == expected && d.length() == expected.length()
+  })
+}
+
+///|
+test "quickcheck: intersection matches the filter model" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let a = @sorted_set.from_array(xs)
+    let b = @sorted_set.from_array(ys)
+    let i = a.intersection(b)
+    let expected = a.to_array().filter(x => b.contains(x))
+    i.to_array() == expected && i.length() == expected.length()
+  })
+}
+
+///|
+test "quickcheck: symmetric_difference matches the filter model" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let a = @sorted_set.from_array(xs)
+    let b = @sorted_set.from_array(ys)
+    let s = a.symmetric_difference(b)
+    let expected = a.to_array().filter(x => !b.contains(x))
+    expected.append(b.to_array().filter(y => !a.contains(y)))
+    expected.sort()
+    s.to_array() == expected && s.length() == expected.length()
+  })
+}
+
+///|
+test "quickcheck: set algebra laws relate the operations" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let a = @sorted_set.from_array(xs)
+    let b = @sorted_set.from_array(ys)
+    let a_minus_b = a.difference(b)
+    let b_minus_a = b.difference(a)
+    let both = a.intersection(b)
+    let sym = a.symmetric_difference(b)
+    a_minus_b.length() + both.length() == a.length() &&
+    b_minus_a.length() + both.length() == b.length() &&
+    sym.length() == a_minus_b.length() + b_minus_a.length() &&
+    sym == a_minus_b.union(b_minus_a) &&
+    a.union(b) == sym.union(both) &&
+    a_minus_b.union(both) == a
+  })
+}
+
+///|
+test "quickcheck: operations with self and empty are identities" {
+  @quickcheck.check((xs : Array[Int]) => {
+    let a = @sorted_set.from_array(xs)
+    let empty : @sorted_set.SortedSet[Int] = @sorted_set.from_array([])
+    a.difference(a).is_empty() &&
+    a.intersection(a) == a &&
+    a.symmetric_difference(a).is_empty() &&
+    a.difference(empty) == a &&
+    empty.difference(a).is_empty() &&
+    a.intersection(empty).is_empty() &&
+    a.symmetric_difference(empty) == a &&
+    empty.symmetric_difference(a) == a
+  })
+}
+
+///|
+test "quickcheck: results do not share nodes with the inputs" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let a = @sorted_set.from_array(xs)
+    let b = @sorted_set.from_array(ys)
+    let a0 = a.to_array()
+    let b0 = b.to_array()
+    let d = a.difference(b)
+    let i = a.intersection(b)
+    let s = a.symmetric_difference(b)
+    let d0 = d.to_array()
+    let i0 = i.to_array()
+    let s0 = s.to_array()
+    // mutating the inputs must not disturb the results
+    for y in ys {
+      a.add(y)
+    }
+    for x in xs {
+      b.remove(x)
+    }
+    guard d.to_array() == d0 && i.to_array() == i0 && s.to_array() == s0 else {
+      return false
+    }
+    // mutating the results must not disturb (fresh copies of) the inputs
+    let a2 = @sorted_set.from_array(xs)
+    let b2 = @sorted_set.from_array(ys)
+    for
+      result in [
+        a2.difference(b2),
+        a2.intersection(b2),
+        a2.symmetric_difference(b2),
+      ] {
+      for y in ys {
+        result.add(y)
+      }
+      for x in xs {
+        result.remove(x)
+      }
+    }
+    a2.to_array() == a0 && b2.to_array() == b0
+  })
+}
+
+///|
 test "quickcheck: set operations obey membership laws" {
   @quickcheck.check((input : (Array[Int], Array[Int])) => {
     let (xs, ys) = input

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -207,6 +207,54 @@ fn[V : Compare] split(root : Node[V]?, value : V) -> (Node[V]?, Node[V]?) {
 }
 
 ///|
+/// Splits a tree by a value, returning (left, found, right).
+fn[V : Compare] split_member(
+  root : Node[V]?,
+  value : V,
+) -> (Node[V]?, Bool, Node[V]?) {
+  match root {
+    None => (None, false, None)
+    Some(node) => {
+      let comp = value.compare(node.value)
+      if comp == 0 {
+        (node.left, true, node.right)
+      } else if comp < 0 {
+        let (l, found, r) = split_member(node.left, value)
+        (l, found, Some(join(r, node.value, node.right)))
+      } else {
+        let (l, found, r) = split_member(node.right, value)
+        (Some(join(node.left, node.value, l)), found, r)
+      }
+    }
+  }
+}
+
+///|
+/// Concatenates two trees where all elements in left < all elements in right.
+fn[V] concat(left : Node[V]?, right : Node[V]?) -> Node[V]? {
+  match (left, right) {
+    (None, _) => right
+    (_, None) => left
+    (Some(_), Some(r)) => {
+      let (min_val, rest) = remove_min(r)
+      Some(join(left, min_val, rest))
+    }
+  }
+}
+
+///|
+/// Removes the minimum value from a tree, returning it and the remaining tree.
+fn[V] remove_min(node : Node[V]) -> (V, Node[V]?) {
+  match node.left {
+    None => (node.value, node.right)
+    Some(left) => {
+      let (min_val, new_left) = remove_min(left)
+      (min_val, Some(join(new_left, node.value, node.right)))
+    }
+  }
+}
+
+///|
 #owned(left, value, right)
 fn[V] join(left : Node[V]?, value : V, right : Node[V]?) -> Node[V] {
   let (hl, hr) = (height(left), height(right))
@@ -278,9 +326,34 @@ pub fn[V : Compare] SortedSet::difference(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
-  let ret = new_sorted_set()
-  self.each(x => if !src.contains(x) { ret.add(x) })
-  ret
+  match (self.root, src.root) {
+    (None, _) => new_sorted_set()
+    (_, None) => { root: copy_tree(self.root), size: self.size }
+    (Some(_), Some(_)) => {
+      // `found_count` ends up as the number of elements shared by both sets:
+      // `aux` takes every node of `a` as a split pivot, except in subtrees
+      // whose matching `b` fragment is empty and therefore shares no elements.
+      let mut found_count = 0
+      fn aux(a : Node[V]?, b : Node[V]?) -> Node[V]? {
+        match (a, b) {
+          (None, _) => None
+          (_, None) => a
+          (Some({ value: va, left: la, right: ra, .. }), _) => {
+            let (lb, found, rb) = split_member(b, va)
+            if found {
+              found_count += 1
+              concat(aux(la, lb), aux(ra, rb))
+            } else {
+              Some(join(aux(la, lb), va, aux(ra, rb)))
+            }
+          }
+        }
+      }
+
+      let t = aux(copy_tree(self.root), copy_tree(src.root))
+      { root: t, size: self.size - found_count }
+    }
+  }
 }
 
 ///|
@@ -315,10 +388,26 @@ pub fn[V : Compare] SortedSet::symmetric_difference(
   self : SortedSet[V],
   other : SortedSet[V],
 ) -> SortedSet[V] {
-  // TODO: Optimize this function to avoid creating two intermediate sets.
-  let set1 = self.difference(other)
-  let set2 = other.difference(self)
-  set1.union(set2)
+  // See `difference` for why `found_count` counts each shared element once.
+  let mut found_count = 0
+  fn aux(a : Node[V]?, b : Node[V]?) -> Node[V]? {
+    match (a, b) {
+      (None, _) => b
+      (_, None) => a
+      (Some({ value: va, left: la, right: ra, .. }), _) => {
+        let (lb, found, rb) = split_member(b, va)
+        if found {
+          found_count += 1
+          concat(aux(la, lb), aux(ra, rb))
+        } else {
+          Some(join(aux(la, lb), va, aux(ra, rb)))
+        }
+      }
+    }
+  }
+
+  let t = aux(copy_tree(self.root), copy_tree(other.root))
+  { root: t, size: self.size + other.size - 2 * found_count }
 }
 
 ///|
@@ -328,9 +417,31 @@ pub fn[V : Compare] SortedSet::intersection(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
-  let ret = new_sorted_set()
-  self.each(x => if src.contains(x) { ret.add(x) })
-  ret
+  match (self.root, src.root) {
+    (None, _) | (_, None) => new_sorted_set()
+    (Some(_), Some(_)) => {
+      // See `difference` for why `found_count` counts each shared element
+      // once.
+      let mut found_count = 0
+      fn aux(a : Node[V]?, b : Node[V]?) -> Node[V]? {
+        match (a, b) {
+          (None, _) | (_, None) => None
+          (Some({ value: va, left: la, right: ra, .. }), _) => {
+            let (lb, found, rb) = split_member(b, va)
+            if found {
+              found_count += 1
+              Some(join(aux(la, lb), va, aux(ra, rb)))
+            } else {
+              concat(aux(la, lb), aux(ra, rb))
+            }
+          }
+        }
+      }
+
+      let t = aux(copy_tree(self.root), copy_tree(src.root))
+      { root: t, size: found_count }
+    }
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

Replace O(n·log m) set operations with split-based divide-and-conquer, matching the approach used in `immut/sorted_set`.

### Before
```moonbit
// O(n * log m) — iterates self, calls contains on src for each element
self.each(x => if !src.contains(x) { ret.add(x) })
```

### After
```moonbit
// split-based recursive merge on private copies of both trees
fn aux(a, b) {
  match (a, b) {
    (Some({ value: va, left: la, right: ra, .. }), _) => {
      let (lb, found, rb) = split_member(b, va)
      // recursively process left and right subtrees
    }
  }
}
```

The split/join merge is O(m·log(n/m + 1)) ⊆ O(n + m); the upfront `copy_tree` of both operands is Θ(n + m), so each operation is O(n + m) overall. For two 100K-element sets this is roughly 17x less work than the old O(n·log m) loops.

### Changes
- Add `split_member` — like `split` but also returns whether the pivot was found
- Add `concat` — joins two trees where all left elements < all right elements
- Add `remove_min` — helper for `concat`
- Rewrite `difference`, `intersection`, `symmetric_difference` using the split-based approach
- Result sizes are derived arithmetically from the number of shared elements discovered during the merge (each shared element is found exactly once as a split pivot), so no separate counting traversal of the result is needed
- Empty operands short-circuit before any tree is copied, mirroring `union`
- Remove the TODO comment about symmetric_difference optimization

### Update (2026-08-19 rebase)
Rebased onto current `main` (conflicts with the `#owned` annotations and the `new()` → `new_sorted_set()` rename resolved), and split into two commits:

1. **perf** — the rewrite above, now with the arithmetic size derivation and empty-operand fast paths.
2. **test** — new blackbox QuickCheck properties (filter-model equivalence for content/order/size, algebra laws, self/empty identities, result/input independence) and a new whitebox `invariant_wbtest.mbt` (mirroring `sorted_map`'s) that recursively verifies BST bounds, AVL balance, cached heights, and the `size` field of every operation result. All new tests are mutation-verified: a size-formula mutation fails 9 tests, a balance-only mutation fails exactly the 3 whitebox scenario tests (blackbox tests are provably blind to it), and skipping one `copy_tree` fails 6 tests including the dedicated no-sharing property.

## Test plan
- [x] Full repo `moon test`: 7454/7454 pass
- [x] `sorted_set`: 67/67 on wasm-gc, native, and js
- [x] `moon check --warn-list +unnecessary_annotation` clean, `moon fmt` applied
- [x] `moon info`: no public API change (`pkg.generated.mbti` untouched)
- [x] Reviewed by Codex CLI (2 rounds, reasoning `xhigh`); round-1 blocking issue fixed, round-2 sign-off — see review comment below

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
