### PR TITLE
fix(buffer): prevent integer overflow in grow_if_necessary

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -49,7 +49,9 @@ fn Buffer::grow_if_necessary(self : Buffer, required : Int) -> Unit {
     if space >= required {
       break space
     }
-    if space > 1073741823 { // Int max / 2, prevent overflow
+    // Guard against integer overflow: when space > Int max / 2 (1073741823),
+    // doubling would exceed 32-bit Int range. Fall back to exact allocation.
+    if space > 1073741823 {
       break required
     }
     continue space * 2

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -49,6 +49,9 @@ fn Buffer::grow_if_necessary(self : Buffer, required : Int) -> Unit {
     if space >= required {
       break space
     }
+    if space > 1073741823 { // Int max / 2, prevent overflow
+      break required
+    }
     continue space * 2
   }
   if enough_space != self.data.length() {


### PR DESCRIPTION
## Summary

The `Buffer::grow_if_necessary` doubles the capacity in a loop until it meets the required size. When the current capacity exceeds `Int.max_value / 2` (~1 billion), `space * 2` overflows to a negative value, causing either an infinite loop or a panic when allocating with a negative size.

### Fix
Add a guard: when `space > 1073741823` (Int max / 2), fall back to allocating exactly the required size instead of doubling.

## Test plan
- [x] All 96 buffer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
