### PR TITLE
perf(sorted_set): O(n+m) co-iteration for set operations

### DIFF
--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -262,7 +262,30 @@ pub fn[V : Compare] SortedSet::difference(
   src : SortedSet[V],
 ) -> SortedSet[V] {
   let ret = new()
-  self.each(x => if !src.contains(x) { ret.add(x) })
+  let it1 = self.iter()
+  let it2 = src.iter()
+  let mut a = it1.next()
+  let mut b = it2.next()
+  while a is Some(va) {
+    match b {
+      None => {
+        ret.add(va)
+        a = it1.next()
+      }
+      Some(vb) => {
+        let c = va.compare(vb)
+        if c < 0 {
+          ret.add(va)
+          a = it1.next()
+        } else if c > 0 {
+          b = it2.next()
+        } else {
+          a = it1.next()
+          b = it2.next()
+        }
+      }
+    }
+  }
   ret
 }
 
@@ -293,10 +316,38 @@ pub fn[V : Compare] SortedSet::symmetric_difference(
   self : SortedSet[V],
   other : SortedSet[V],
 ) -> SortedSet[V] {
-  // TODO: Optimize this function to avoid creating two intermediate sets.
-  let set1 = self.difference(other)
-  let set2 = other.difference(self)
-  set1.union(set2)
+  let ret = new()
+  let it1 = self.iter()
+  let it2 = other.iter()
+  let mut a = it1.next()
+  let mut b = it2.next()
+  while true {
+    match (a, b) {
+      (Some(va), Some(vb)) => {
+        let c = va.compare(vb)
+        if c < 0 {
+          ret.add(va)
+          a = it1.next()
+        } else if c > 0 {
+          ret.add(vb)
+          b = it2.next()
+        } else {
+          a = it1.next()
+          b = it2.next()
+        }
+      }
+      (Some(va), None) => {
+        ret.add(va)
+        a = it1.next()
+      }
+      (None, Some(vb)) => {
+        ret.add(vb)
+        b = it2.next()
+      }
+      (None, None) => break
+    }
+  }
+  ret
 }
 
 ///|
@@ -307,7 +358,22 @@ pub fn[V : Compare] SortedSet::intersection(
   src : SortedSet[V],
 ) -> SortedSet[V] {
   let ret = new()
-  self.each(x => if src.contains(x) { ret.add(x) })
+  let it1 = self.iter()
+  let it2 = src.iter()
+  let mut a = it1.next()
+  let mut b = it2.next()
+  while a is Some(va) && b is Some(vb) {
+    let c = va.compare(vb)
+    if c < 0 {
+      a = it1.next()
+    } else if c > 0 {
+      b = it2.next()
+    } else {
+      ret.add(va)
+      a = it1.next()
+      b = it2.next()
+    }
+  }
   ret
 }
 
@@ -317,7 +383,27 @@ pub fn[V : Compare] SortedSet::subset(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> Bool {
-  self.iter().all(x => src.contains(x))
+  let it1 = self.iter()
+  let it2 = src.iter()
+  let mut a = it1.next()
+  let mut b = it2.next()
+  while a is Some(va) {
+    match b {
+      None => return false
+      Some(vb) => {
+        let c = va.compare(vb)
+        if c < 0 {
+          return false
+        } else if c > 0 {
+          b = it2.next()
+        } else {
+          a = it1.next()
+          b = it2.next()
+        }
+      }
+    }
+  }
+  true
 }
 
 ///|
@@ -326,7 +412,21 @@ pub fn[V : Compare] SortedSet::disjoint(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> Bool {
-  self.iter().all(x => !src.contains(x))
+  let it1 = self.iter()
+  let it2 = src.iter()
+  let mut a = it1.next()
+  let mut b = it2.next()
+  while a is Some(va) && b is Some(vb) {
+    let c = va.compare(vb)
+    if c < 0 {
+      a = it1.next()
+    } else if c > 0 {
+      b = it2.next()
+    } else {
+      return false
+    }
+  }
+  true
 }
 
 // General collection operations


### PR DESCRIPTION
## Summary

Replace O(n*log m) implementations of `subset`, `disjoint`, `intersection`, `difference`, and `symmetric_difference` with O(n+m) co-iteration over both sorted iterators.

### Before

Each operation iterated `self` and called `contains()` on `src` for each element — O(log m) per lookup, O(n*log m) total:

```moonbit
pub fn subset(self, src) -> Bool {
  self.iter().all(x => src.contains(x))  // O(n * log m)
}
pub fn intersection(self, src) -> SortedSet {
  let ret = new()
  self.each(x => if src.contains(x) { ret.add(x) })  // O(n * log m)
  ret
}
```

`symmetric_difference` was even worse — it created two intermediate sets via `difference()` then called `union()` (with a TODO acknowledging this).

### After

Co-iterate both sorted iterators in lockstep using `compare()`, advancing the smaller side — O(n+m) total, zero allocations on the input sets:

```moonbit
pub fn subset(self, src) -> Bool {
  let it1 = self.iter()
  let it2 = src.iter()
  // advance in lockstep, O(n+m)
}
```

### Complexity comparison

| Operation | Before | After |
|---|---|---|
| `subset` | O(n·log m) | O(n+m) |
| `disjoint` | O(n·log m) | O(n+m) |
| `intersection` | O(n·log m) | O(n+m) |
| `difference` | O(n·log m) | O(n+m) |
| `symmetric_difference` | O(n·log m + m·log n + n+m) | O(n+m) |

### Codex review

> I did not find a correctness issue in the co-iteration logic. The iterator advancement rules for `subset`, `disjoint`, `intersection`, `difference`, and `symmetric_difference` match the expected merge-style behavior on two sorted unique streams, and `moon test sorted_set` passes after the change.

## Test plan
- [x] All 48 sorted_set tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
