### PR TITLE
perf(hashset): fix from_array capacity and make shift_back iterative

### DIFF
--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -37,7 +37,12 @@ pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
 pub fn[K : Hash + Eq] HashSet::from_array(arr : ArrayView[K]) -> HashSet[K] {
-  let m = new(capacity=arr.length() * 2)
+  let length = arr.length()
+  let mut capacity = length.next_power_of_two()
+  if length >= calc_grow_threshold(capacity) {
+    capacity = capacity * 2
+  }
+  let m = new(capacity~)
   arr.each(e => m.add(e))
   m
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -37,7 +37,7 @@ pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
 pub fn[K : Hash + Eq] HashSet::from_array(arr : ArrayView[K]) -> HashSet[K] {
-  let m = new()
+  let m = new(capacity=arr.length() * 2)
   arr.each(e => m.add(e))
   m
 }


### PR DESCRIPTION
## Summary
- **from_array**: pre-allocate with `capacity=arr.length()*2` instead of default capacity 8, avoiding multiple grow operations during construction.
- **shift_back**: convert from recursive to iterative loop to prevent stack overflow at high load factors.

## Test plan
- [x] `moon test -p moonbitlang/core/hashset` — all 65 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
