### PR TITLE
fix(bigint): fix modpow normalization, right shift, and bit_length bugs

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -812,11 +812,21 @@ pub impl Shr for BigInt with shr(self : BigInt, n : Int) -> BigInt {
     if new_len > 1 && new_limbs[new_len - 1] == 0 {
       new_len -= 1
     }
-    if self.sign == Negative && (carry & (1UL << r)) != carry {
-      { limbs: new_limbs, sign: self.sign, len: new_len } - 1
-    } else {
-      { limbs: new_limbs, sign: self.sign, len: new_len }
+    if self.sign == Negative {
+      let mut has_remainder = carry != 0UL
+      if !has_remainder {
+        for i in 0..<lz {
+          if self.limbs[i] != 0 {
+            has_remainder = true
+            break
+          }
+        }
+      }
+      if has_remainder {
+        return { limbs: new_limbs, sign: self.sign, len: new_len } - 1
+      }
     }
+    { limbs: new_limbs, sign: self.sign, len: new_len }
   }
 }
 

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -788,7 +788,17 @@ pub impl Shr for BigInt with shr(self : BigInt, n : Int) -> BigInt {
   if r == 0 {
     let new_limbs = FixedArray::make(new_len, 0U)
     new_limbs.unsafe_blit(0, self.limbs, lz, new_len)
-    { limbs: new_limbs, sign: self.sign, len: new_len }
+    let result = { limbs: new_limbs, sign: self.sign, len: new_len }
+    // For negative numbers with floor division semantics, check if any
+    // dropped low limbs were non-zero and round toward negative infinity
+    if self.sign == Negative {
+      for i in 0..<lz {
+        if self.limbs[i] != 0 {
+          return result - 1
+        }
+      }
+    }
+    result
   } else {
     let new_limbs = FixedArray::make(new_len, 0U)
     let a = self.limbs
@@ -1370,8 +1380,8 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
     }
     Some(modulus) => {
       guard !(modulus.is_zero() || modulus.sign == Negative)
-      let mut result = 1N
-      let mut base = self
+      let mut result = 1N % modulus
+      let mut base = (self % modulus + modulus) % modulus
       let mut exp = exp
       while exp > 0 {
         if exp % 2 == 1 {
@@ -1908,15 +1918,13 @@ pub fn BigInt::bit_length(self : BigInt) -> Int {
   let mut bit_length = (self.len - 1) * radix_bit_len +
     (radix_bit_len - self.limbs[self.len - 1].clz())
   if self.sign == Negative {
-    // check if this number is a power of two
-    let mut pow2 = self.limbs[0].popcnt() == 1
-    for i in 1..<self.len {
-      if !pow2 {
-        break
-      }
-      pow2 = self.limbs[i] == 0
+    // Check if the magnitude is a power of two (exactly one bit set
+    // across all limbs). For example, -2^32 has limbs [0, 1].
+    let mut total_bits = 0
+    for i in 0..<self.len {
+      total_bits += self.limbs[i].popcnt()
     }
-    if pow2 {
+    if total_bits == 1 {
       bit_length -= 1
     }
   }

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -419,6 +419,10 @@ test "shr" {
     @bigint.BigInt::from_int64(0b1111_1111L) >> 44,
     @bigint.BigInt::from_int64(0),
   )
+  // dropped limbs bug: -(2^33+1) >> 33 should be -2
+  assert_eq(-8589934593N >> 33, -2N)
+  // carry condition bug: -65537 >> 16 should be -2
+  assert_eq(-65537N >> 16, -2N)
 }
 
 ///|

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1271,3 +1271,38 @@ test "BigInt bit_length negative multi-limb" {
 test "BigInt bit_length zero" {
   inspect(@bigint.BigInt::from_int(0).bit_length(), content="0")
 }
+
+///|
+test "BigInt bit_length negative multi-limb power of two" {
+  // -2^32 has limbs [0, 1] - bit_length should be 32, not 33
+  let neg = @bigint.BigInt::from_string("-4294967296")
+  inspect(neg.bit_length(), content="32")
+  // -2^64 has limbs [0, 0, 1] - bit_length should be 64
+  let neg2 = @bigint.BigInt::from_string("-18446744073709551616")
+  inspect(neg2.bit_length(), content="64")
+}
+
+///|
+test "BigInt right shift negative exact multiple of 32" {
+  // (-4294967297) >> 32 should be -2 (floor division), not -1
+  // -4294967297 = -(2^32 + 1), so >>32 should give -2
+  let neg = @bigint.BigInt::from_string("-4294967297")
+  inspect((neg >> 32).to_string(), content="-2")
+  // -4294967296 = -(2^32), so >>32 should give -1
+  let neg2 = @bigint.BigInt::from_string("-4294967296")
+  inspect((neg2 >> 32).to_string(), content="-1")
+}
+
+///|
+test "BigInt modular exponentiation edge cases" {
+  // 2^0 mod 1 should be 0
+  let base = @bigint.BigInt::from_int(2)
+  let zero = @bigint.BigInt::from_int(0)
+  let one = @bigint.BigInt::from_int(1)
+  inspect(base.pow(zero, modulus=one).to_string(), content="0")
+  // 3^4 mod 10 should be 1
+  let three = @bigint.BigInt::from_int(3)
+  let four = @bigint.BigInt::from_int(4)
+  let ten = @bigint.BigInt::from_int(10)
+  inspect(three.pow(four, modulus=ten).to_string(), content="1")
+}


### PR DESCRIPTION
## Summary
Three correctness fixes for the non-JS BigInt backend:

1. **Modular exponentiation** (pow with modulus): Initialize result as `1%modulus` (not `1`) so `modulus=1` returns `0`. Normalize base into `[0, modulus)` before the loop so negative bases produce canonical non-negative results.

2. **Arithmetic right shift** (>>): When shift amount is an exact multiple of 32 (`r==0`), the code was not checking if any dropped low limbs were non-zero. For negative numbers, floor division requires rounding toward negative infinity, so `(-2^32-1)>>32` should be `-2`, not `-1`.

3. **bit_length** for negative multi-limb powers of two: The power-of-two check started with `limbs[0].popcnt()==1`, which fails for numbers like `-2^32` where limb 0 is 0 and limb 1 is 1. Fixed to count total set bits across all limbs.

## Test plan
- [x] Added regression tests for all three bugs
- [x] `moon test` passes (151 bigint tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
