### PR TITLE
refactor: make show implement one of the methods

### DIFF
--- a/argparse/arg_group.mbt
+++ b/argparse/arg_group.mbt
@@ -21,17 +21,27 @@ pub struct ArgGroup {
   priv args : Array[String]
   priv requires : Array[String]
   priv conflicts_with : Array[String]
-
-  /// Create an argument group.
-  fn new(
-    name : StringView,
-    required? : Bool,
-    multiple? : Bool,
-    args? : ArrayView[String],
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-  ) -> ArgGroup
 } derive(@debug.Debug)
+
+///|
+/// Create an argument group.
+pub fn ArgGroup::ArgGroup(
+  name : StringView,
+  required? : Bool = false,
+  multiple? : Bool = true,
+  args? : ArrayView[String] = [],
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+) -> ArgGroup {
+  {
+    name: name.to_owned(),
+    required,
+    multiple,
+    args: args.to_owned(),
+    requires: requires.to_owned(),
+    conflicts_with: conflicts_with.to_owned(),
+  }
+}
 
 ///|
 /// Create an argument group.

--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -80,23 +80,43 @@ priv enum ArgInfo {
 /// Declarative flag constructor wrapper.
 pub struct FlagArg {
   priv arg : Arg
-
-  /// Create a flag argument.
-  fn new(
-    name : StringView,
-    short? : Char,
-    long? : StringView,
-    about? : StringView,
-    action? : FlagAction,
-    env? : StringView,
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-    required? : Bool,
-    global? : Bool,
-    negatable? : Bool,
-    hidden? : Bool,
-  ) -> FlagArg
 } derive(@debug.Debug)
+
+///|
+/// Create a flag argument.
+pub fn FlagArg::FlagArg(
+  name : StringView,
+  short? : Char,
+  long? : StringView = name,
+  about? : StringView,
+  action? : FlagAction = SetTrue,
+  env? : StringView,
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+  required? : Bool = false,
+  global? : Bool = false,
+  negatable? : Bool = false,
+  hidden? : Bool = false,
+) -> FlagArg {
+  let name = name.to_owned()
+  let long = if long == "" { None } else { Some(long.to_owned()) }
+  let about = about.map(v => v.to_owned())
+  let env = env.map(v => v.to_owned())
+  {
+    arg: {
+      name,
+      about,
+      env,
+      global,
+      hidden,
+      requires: requires.to_owned(),
+      conflicts_with: conflicts_with.to_owned(),
+      required,
+      info: FlagInfo(short~, long~, action~, negatable~),
+      multiple: false,
+    },
+  }
+}
 
 ///|
 /// Create a flag argument.
@@ -148,25 +168,51 @@ pub fn FlagArg::new(
 /// Named `OptionArg` to avoid shadowing the built-in `Option` type.
 pub struct OptionArg {
   priv arg : Arg
-
-  /// Create an option argument.
-  // FIXME(upstram) rename does not work here
-  fn new(
-    name : StringView,
-    short? : Char,
-    long? : StringView,
-    about? : StringView,
-    action? : OptionAction,
-    env? : StringView,
-    default_values? : ArrayView[String],
-    allow_hyphen_values? : Bool,
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-    required? : Bool,
-    global? : Bool,
-    hidden? : Bool,
-  ) -> OptionArg
 } derive(@debug.Debug)
+
+///|
+/// Create an option argument.
+// FIXME(upstram) rename does not work here
+pub fn OptionArg::OptionArg(
+  name : StringView,
+  short? : Char,
+  long? : StringView = name,
+  about? : StringView,
+  action? : OptionAction = Set,
+  env? : StringView,
+  default_values? : ArrayView[String],
+  allow_hyphen_values? : Bool = false,
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+  required? : Bool = false,
+  global? : Bool = false,
+  hidden? : Bool = false,
+) -> OptionArg {
+  let name = name.to_owned()
+  let long = if long == "" { None } else { Some(long.to_owned()) }
+  let about = about.map(v => v.to_owned())
+  let env = env.map(v => v.to_owned())
+  {
+    arg: {
+      name,
+      about,
+      env,
+      requires: requires.to_owned(),
+      conflicts_with: conflicts_with.to_owned(),
+      required,
+      global,
+      hidden,
+      info: OptionInfo(
+        short~,
+        long~,
+        action~,
+        default_values=default_values.map(values => values.to_owned()),
+        allow_hyphen_values~,
+      ),
+      multiple: action is Append,
+    },
+  }
+}
 
 ///|
 /// Create an option argument.
@@ -224,21 +270,44 @@ pub fn OptionArg::new(
 /// Declarative positional constructor wrapper.
 pub struct PositionArg {
   priv arg : Arg
-
-  /// Create a positional argument.
-  fn new(
-    name : StringView,
-    about? : StringView,
-    env? : StringView,
-    default_values? : ArrayView[String],
-    num_args? : ValueRange,
-    allow_hyphen_values? : Bool,
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-    global? : Bool,
-    hidden? : Bool,
-  ) -> PositionArg
 } derive(@debug.Debug)
+
+///|
+/// Create a positional argument.
+pub fn PositionArg::PositionArg(
+  name : StringView,
+  about? : StringView,
+  env? : StringView,
+  default_values? : ArrayView[String],
+  num_args? : ValueRange,
+  allow_hyphen_values? : Bool = false,
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+  global? : Bool = false,
+  hidden? : Bool = false,
+) -> PositionArg {
+  let name = name.to_owned()
+  let about = about.map(v => v.to_owned())
+  let env = env.map(v => v.to_owned())
+  {
+    arg: {
+      name,
+      about,
+      env,
+      requires: requires.to_owned(),
+      conflicts_with: conflicts_with.to_owned(),
+      required: false,
+      global,
+      hidden,
+      info: PositionalInfo(
+        num_args~,
+        default_values=default_values.map(values => values.to_owned()),
+        allow_hyphen_values~,
+      ),
+      multiple: range_allows_multiple(num_args),
+    },
+  }
+}
 
 ///|
 /// Create a positional argument.

--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -28,25 +28,50 @@ pub struct Command {
   priv subcommand_required : Bool
   priv hidden : Bool
   priv mut build_error : ArgBuildError?
-
-  /// Create a declarative command specification.
-  fn new(
-    name : StringView,
-    flags? : ArrayView[FlagArg],
-    options? : ArrayView[OptionArg],
-    positionals? : ArrayView[PositionArg],
-    subcommands? : ArrayView[Command],
-    about? : StringView,
-    version? : StringView,
-    disable_help_flag? : Bool,
-    disable_version_flag? : Bool,
-    disable_help_subcommand? : Bool,
-    arg_required_else_help? : Bool,
-    subcommand_required? : Bool,
-    hidden? : Bool,
-    groups? : ArrayView[ArgGroup],
-  ) -> Command
 } derive(@debug.Debug)
+
+///|
+/// Create a declarative command specification.
+pub fn Command::Command(
+  name : StringView,
+  flags? : ArrayView[FlagArg] = [],
+  options? : ArrayView[OptionArg] = [],
+  positionals? : ArrayView[PositionArg] = [],
+  subcommands? : ArrayView[Command] = [],
+  about? : StringView,
+  version? : StringView,
+  disable_help_flag? : Bool = false,
+  disable_version_flag? : Bool = false,
+  disable_help_subcommand? : Bool = false,
+  arg_required_else_help? : Bool = false,
+  subcommand_required? : Bool = false,
+  hidden? : Bool = false,
+  groups? : ArrayView[ArgGroup] = [],
+) -> Command {
+  let (parsed_args, arg_error) = collect_args(flags, options, positionals)
+  let groups = groups.to_owned()
+  let cmd = Command::{
+    name: name.to_owned(),
+    args: parsed_args,
+    groups,
+    subcommands: subcommands.to_owned(),
+    about: about.map(v => v.to_owned()),
+    version: version.map(v => v.to_owned()),
+    disable_help_flag,
+    disable_version_flag,
+    disable_help_subcommand,
+    arg_required_else_help,
+    subcommand_required,
+    hidden,
+    build_error: arg_error,
+  }
+  if cmd.build_error is None {
+    validate_command(cmd, parsed_args, groups, []) catch {
+      err => cmd.build_error = Some(err)
+    }
+  }
+  cmd
+}
 
 ///|
 /// Create a declarative command specification.

--- a/argparse/error.mbt
+++ b/argparse/error.mbt
@@ -30,6 +30,32 @@ impl Show for ArgError with output(self : ArgError, logger) {
 }
 
 ///|
+impl @debug.Debug for ArgError with to_repr(self) {
+  match self {
+    Message(msg) => @debug.Repr::literal(msg)
+  }
+}
+
+///|
+test "ArgError debug keeps display text" {
+  let err : Error = ArgError::Message(
+    (
+      $|error: unexpected argument '--bad' found
+      $|
+      $|Usage: demo [options]
+    ),
+  )
+  inspect(
+    err.to_string(),
+    content=(
+      #|error: unexpected argument '--bad' found
+      #|
+      #|Usage: demo [options]
+    ),
+  )
+}
+
+///|
 /// Internal parse error variants used while parsing.
 priv suberror ArgParseError {
   UnknownArgument(String, String?)

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -12,16 +12,14 @@ import {
 // Types and methods
 pub struct ArgGroup {
   // private fields
-
-  fn new(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> ArgGroup
 } derive(@debug.Debug)
+pub fn ArgGroup::ArgGroup(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
 pub fn ArgGroup::new(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
 
 pub struct Command {
   // private fields
-
-  fn new(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Command], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Command
 } derive(@debug.Debug)
+pub fn Command::Command(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Self], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Self
 pub fn Command::new(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Self], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Self
 #as_free_fn
 pub fn Command::parse(Self, argv? : ArrayView[String], env? : Map[String, String]) -> Matches raise
@@ -37,9 +35,8 @@ pub(all) enum FlagAction {
 
 pub struct FlagArg {
   // private fields
-
-  fn new(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> FlagArg
 } derive(@debug.Debug)
+pub fn FlagArg::FlagArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
 pub fn FlagArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
 
 pub struct Matches {
@@ -58,23 +55,20 @@ pub(all) enum OptionAction {
 
 pub struct OptionArg {
   // private fields
-
-  fn new(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> OptionArg
 } derive(@debug.Debug)
+pub fn OptionArg::OptionArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
 pub fn OptionArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
 
 pub struct PositionArg {
   // private fields
-
-  fn new(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> PositionArg
 } derive(@debug.Debug)
+pub fn PositionArg::PositionArg(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
 pub fn PositionArg::new(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
 
 pub struct ValueRange {
   // private fields
-
-  fn new(lower? : Int, upper? : Int) -> ValueRange
 } derive(Eq, Show, @debug.Debug)
+pub fn ValueRange::ValueRange(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::new(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::single() -> Self
 

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -18,10 +18,13 @@
 pub struct ValueRange {
   priv lower : Int
   priv upper : Int?
-
-  /// Create a value-count range.
-  fn new(lower? : Int, upper? : Int) -> ValueRange
 } derive(Eq, Show, @debug.Debug)
+
+///|
+/// Create a value-count range.
+pub fn ValueRange::ValueRange(lower? : Int = 0, upper? : Int) -> ValueRange {
+  { lower, upper }
+}
 
 ///|
 /// Exact single-value range (`1..1`).

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -1313,8 +1313,9 @@ pub impl Shl for UInt
 pub impl Shl for UInt16
 pub impl Shl for UInt64
 
+#must_implement_one(output, to_string)
 pub(open) trait Show {
-  output(Self, &Logger) -> Unit
+  output(Self, &Logger) -> Unit = _
   to_string(Self) -> String = _
 }
 pub impl Show for Unit

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -121,18 +121,25 @@ impl Logger with write_char(self, value) {
 
 ///|
 /// Trait for types that can be converted to `String`
+#must_implement_one(output, to_string)
 pub(open) trait Show {
   // `output` is used for composition of aggregate structure.
   // `output` writes a string representation of `self` to a logger.
   // `output` should produce a valid MoonBit-syntax representation if possible.
   // For example, `Show::output` for `String` should be quoted
-  output(Self, &Logger) -> Unit
+  output(Self, &Logger) -> Unit = _
   // `to_string` should be used by end users of `Show`,
   // for printing, interpolation, etc. only, and should not be used for composition.
   // By default `to_string` is implemented using `output` and a buffer,
   // but some types, such as `String`, may override `to_string`,
   // for different (unescaped) behavior when interpolated/printed directly
   to_string(Self) -> String = _
+}
+
+///|
+/// Default implementation for `Show::output`, uses `Show::to_string`.
+impl Show with output(self, logger) {
+  logger.write_string(self.to_string())
 }
 
 ///|

--- a/cmp/cmp.mbt
+++ b/cmp/cmp.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// A newtype wrapper that reverses the comparison order of the wrapped value.
 ///
 /// `Reverse[T]` is useful when you need to reverse the natural ordering of a type.

--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(StringView)

--- a/encoding/utf16/types.mbt
+++ b/encoding/utf16/types.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Type `Endian` used by this package APIs.
 pub(all) enum Endian {
   Little

--- a/encoding/utf8/decode.mbt
+++ b/encoding/utf8/decode.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/internal/regex_engine/shared_types/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/pkg.generated.mbti
@@ -38,9 +38,8 @@ pub struct Profile {
   word : @rechar_set.RecharSet
   word_symbolize_splits : ReadOnlyArray[@rechar_set.RecharSet]
   category : (Int) -> Category
-
-  fn new(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Profile
 }
+pub fn Profile::Profile(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Self
 pub fn Profile::new(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Self
 
 pub(all) enum QuantifierMode {

--- a/internal/regex_engine/shared_types/profile.mbt
+++ b/internal/regex_engine/shared_types/profile.mbt
@@ -21,13 +21,18 @@ pub struct Profile {
   word : RecharSet
   word_symbolize_splits : ReadOnlyArray[RecharSet]
   category : (Rechar) -> Category
+}
 
-  fn new(
-    valid~ : RecharSet,
-    word~ : RecharSet,
-    word_symbolize_splits? : ReadOnlyArray[RecharSet],
-    category~ : (Rechar) -> Category,
-  ) -> Profile
+///|
+pub fn Profile::Profile(
+  valid~ : RecharSet,
+  word~ : RecharSet,
+  word_symbolize_splits? : ReadOnlyArray[RecharSet] = [word],
+  category~ : (Rechar) -> Category,
+) -> Profile {
+  guard valid.first_interval() is Some((lb, _)) else { panic() }
+  guard valid.last_interval() is Some((_, ub)) else { panic() }
+  Profile::{ lb, ub, valid, word, word_symbolize_splits, category }
 }
 
 ///|

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `JsonDecodeError`.
 #warnings("-deprecated_syntax")
 pub(all) suberror JsonDecodeError {

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -123,9 +123,12 @@ priv enum WriteFrame {
 /// Only applies to object properties, not array elements.
 pub struct Replacer {
   priv f : (String, Json) -> Json?
-
-  fn new(f : (String, Json) -> Json?) -> Replacer
 } derive(@debug.Debug)
+
+///|
+pub fn Replacer::Replacer(f : (String, Json) -> Json?) -> Replacer {
+  { f, }
+}
 
 ///|
 /// Create a new Replacer with a custom function.

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -45,9 +45,8 @@ pub(all) struct Position {
 
 pub struct Replacer {
   // private fields
-
-  fn new((String, Json) -> Json?) -> Replacer
 } derive(@debug.Debug)
+pub fn Replacer::Replacer((String, Json) -> Json?) -> Self
 pub fn Replacer::exclude(ArrayView[StringView]) -> Self
 pub fn Replacer::keep(ArrayView[StringView]) -> Self
 pub fn Replacer::new((String, Json) -> Json?) -> Self

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 #warnings("-deprecated_syntax")
 struct RandomState {
   mut seed : UInt64

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -15,9 +15,8 @@ pub fn[T] new(T) -> Ref[T]
 // Types and methods
 pub(all) struct Ref[T] {
   mut val : T
-
-  fn[T] new(T) -> Ref[T]
 }
+pub fn[T] Ref::Ref(T) -> Self[T]
 pub fn[T, R] Ref::map(Self[T], (T) -> R raise?) -> Self[R] raise?
 pub fn[T] Ref::new(T) -> Self[T]
 pub fn[T, R] Ref::protect(Self[T], T, () -> R raise?) -> R raise?

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -25,8 +25,11 @@
 /// ```
 pub(all) struct Ref[T] {
   mut val : T
+}
 
-  fn[T] new(value : T) -> Ref[T]
+///|
+pub fn[T] Ref::Ref(value : T) -> Ref[T] {
+  { val: value }
 }
 
 ///|

--- a/strconv/errors.mbt
+++ b/strconv/errors.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `StrConvError`.
 #deprecated("use `@string` parsing APIs instead", skip_current_package=true)
 pub(all) suberror StrConvError {

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -31,9 +31,8 @@ pub fn MatchResult::named_group(Self, String) -> StringView?
 
 pub struct Regex {
   // private fields
-
-  fn new(StringView) -> Regex raise
 }
+pub fn Regex::Regex(StringView) -> Self raise
 pub fn Regex::capture(Self, String) -> Self
 pub fn Regex::execute(Self, StringView, last_index? : Int) -> MatchResult?
 pub fn Regex::find(Self, StringView) -> Iter[MatchResult]

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -17,8 +17,16 @@
 pub struct Regex {
   priv pat : @re.Pattern
   priv mut re : @re.Regex?
+}
 
-  fn new(pattern : StringView) -> Regex raise
+///|
+pub fn Regex::Regex(pattern : StringView) -> Regex raise {
+  let pat = @regex_parser.parse(
+    profile=re_profile_unicode,
+    pattern,
+    mode=String,
+  )
+  { pat, re: None }
 }
 
 ///|

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
+using @debug {trait Debug}
 
 ///|
 fn[T : Show] debug_string(t : T) -> String {


### PR DESCRIPTION
We are going to change the behavior of `Show` so that it is purely for displaying. So there will not be special handling for `String` or `Char` any more. As a result, the `output` and `to_string` would behave the same. Thus people only need to implement one of the methods.

This PR also migrates some of the builtin types' implementations to `to_string`, because use `output` would forcefully upcast `StringBuider` to `&Logger`, which will increase code in some cases.