### PR TITLE
refactor: remove op methods from traits

### DIFF
--- a/builtin/operators.mbt
+++ b/builtin/operators.mbt
@@ -15,49 +15,37 @@
 ///|
 /// types implementing this trait can use the `+` operator
 pub(open) trait Add {
-  add(Self, Self) -> Self = _
-  #deprecated("use `add` instead", skip_current_package=true)
-  op_add(Self, Self) -> Self = _
+  add(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `-` operator
 pub(open) trait Sub {
-  sub(Self, Self) -> Self = _
-  #deprecated("use `sub` instead", skip_current_package=true)
-  op_sub(Self, Self) -> Self = _
+  sub(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `*` operator
 pub(open) trait Mul {
-  mul(Self, Self) -> Self = _
-  #deprecated("use `mul` instead", skip_current_package=true)
-  op_mul(Self, Self) -> Self = _
+  mul(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `/` operator
 pub(open) trait Div {
-  div(Self, Self) -> Self = _
-  #deprecated("use `div` instead", skip_current_package=true)
-  op_div(Self, Self) -> Self = _
+  div(Self, Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the unary `-` operator
 pub(open) trait Neg {
-  neg(Self) -> Self = _
-  #deprecated("use `neg` instead", skip_current_package=true)
-  op_neg(Self) -> Self = _
+  neg(Self) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `%` operator
 pub(open) trait Mod {
-  mod(Self, Self) -> Self = _
-  #deprecated("use `mod` instead", skip_current_package=true)
-  op_mod(Self, Self) -> Self = _
+  mod(Self, Self) -> Self
 }
 
 ///|
@@ -81,103 +69,11 @@ pub(open) trait BitXOr {
 ///|
 /// types implementing this trait can use the `<<` operator
 pub(open) trait Shl {
-  shl(Self, Int) -> Self = _
-  #deprecated("use `shl` instead", skip_current_package=true)
-  op_shl(Self, Int) -> Self = _
+  shl(Self, Int) -> Self
 }
 
 ///|
 /// types implementing this trait can use the `>>` operator
 pub(open) trait Shr {
-  shr(Self, Int) -> Self = _
-  #deprecated("use `shr` instead", skip_current_package=true)
-  op_shr(Self, Int) -> Self = _
-}
-
-///|
-#deprecated("replace `impl op_add` with `impl add`")
-impl Add with add(self, other) {
-  Add::op_add(self, other)
-}
-
-///|
-impl Add with op_add(self, other) {
-  Add::add(self, other)
-}
-
-///|
-#deprecated("replace `impl op_sub` with `impl sub`")
-impl Sub with sub(self, other) {
-  Sub::op_sub(self, other)
-}
-
-///|
-impl Sub with op_sub(self, other) {
-  Sub::sub(self, other)
-}
-
-///|
-#deprecated("replace `impl op_mul` with `impl mul`")
-impl Mul with mul(self, other) {
-  Mul::op_mul(self, other)
-}
-
-///|
-impl Mul with op_mul(self, other) {
-  Mul::mul(self, other)
-}
-
-///|
-#deprecated("replace `impl op_div` with `impl div`")
-impl Div with div(self, other) {
-  Div::op_div(self, other)
-}
-
-///|
-impl Div with op_div(self, other) {
-  Div::div(self, other)
-}
-
-///|
-#deprecated("replace `impl op_neg` with `impl neg`")
-impl Neg with neg(self) {
-  Neg::op_neg(self)
-}
-
-///|
-impl Neg with op_neg(self) {
-  Neg::neg(self)
-}
-
-///|
-#deprecated("replace `impl op_mod` with `impl mod`")
-impl Mod with mod(self, other) {
-  Mod::op_mod(self, other)
-}
-
-///|
-impl Mod with op_mod(self, other) {
-  Mod::mod(self, other)
-}
-
-///|
-#deprecated("replace `impl op_shl` with `impl shl`")
-impl Shl with shl(self, i) {
-  Shl::op_shl(self, i)
-}
-
-///|
-impl Shl with op_shl(self, i) {
-  Shl::shl(self, i)
-}
-
-///|
-#deprecated("replace `impl op_shr` with `impl shr`")
-impl Shr with shr(self, i) {
-  Shr::op_shr(self, i)
-}
-
-///|
-impl Shr with op_shr(self, i) {
-  Shr::shr(self, i)
+  shr(Self, Int) -> Self
 }

--- a/builtin/operators_test.mbt
+++ b/builtin/operators_test.mbt
@@ -63,7 +63,7 @@ impl Shr for Num with shr(self, i) {
 }
 
 ///|
-test "deprecated operator helpers" {
+test "operator trait methods on builtin types" {
   inspect(Add::add(1, 2), content="3")
   inspect(Sub::sub(5, 3), content="2")
   inspect(Mul::mul(2, 3), content="6")
@@ -75,14 +75,13 @@ test "deprecated operator helpers" {
 }
 
 ///|
-#warnings("-deprecated")
-test "deprecated operator defaults" {
-  inspect(Add::op_add(num(8), num(3)).value, content="11")
-  inspect(Sub::op_sub(num(8), num(3)).value, content="5")
-  inspect(Mul::op_mul(num(4), num(3)).value, content="12")
-  inspect(Div::op_div(num(9), num(3)).value, content="3")
-  inspect(Mod::op_mod(num(10), num(3)).value, content="1")
-  inspect(Neg::op_neg(num(4)).value, content="-4")
-  inspect(Shl::op_shl(num(1), 4).value, content="16")
-  inspect(Shr::op_shr(num(16), 2).value, content="4")
+test "operator trait methods on custom types" {
+  inspect(Add::add(num(8), num(3)).value, content="11")
+  inspect(Sub::sub(num(8), num(3)).value, content="5")
+  inspect(Mul::mul(num(4), num(3)).value, content="12")
+  inspect(Div::div(num(9), num(3)).value, content="3")
+  inspect(Mod::mod(num(10), num(3)).value, content="1")
+  inspect(Neg::neg(num(4)).value, content="-4")
+  inspect(Shl::shl(num(1), 4).value, content="16")
+  inspect(Shr::shr(num(16), 2).value, content="4")
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -1059,9 +1059,7 @@ pub fn StringView::view(Self, start_offset? : Int, end_offset? : Int) -> Self
 
 // Traits
 pub(open) trait Add {
-  add(Self, Self) -> Self = _
-  #deprecated
-  op_add(Self, Self) -> Self = _
+  add(Self, Self) -> Self
 }
 pub impl Add for Byte
 pub impl Add for Int
@@ -1166,9 +1164,7 @@ pub impl Default for Bytes
 pub impl Default for StringView
 
 pub(open) trait Div {
-  div(Self, Self) -> Self = _
-  #deprecated
-  op_div(Self, Self) -> Self = _
+  div(Self, Self) -> Self
 }
 pub impl Div for Byte
 pub impl Div for Int
@@ -1179,9 +1175,7 @@ pub impl Div for UInt64
 pub impl Div for Double
 
 pub(open) trait Eq {
-  equal(Self, Self) -> Bool = _
-  #deprecated
-  op_equal(Self, Self) -> Bool = _
+  equal(Self, Self) -> Bool
   not_equal(Self, Self) -> Bool = _
 }
 pub impl Eq for Unit
@@ -1258,9 +1252,7 @@ pub fn[T : Show] &Logger::write_iter(Self, Iter[T], prefix? : String, suffix? : 
 pub fn[Obj : Show] &Logger::write_object(Self, Obj) -> Unit
 
 pub(open) trait Mod {
-  mod(Self, Self) -> Self = _
-  #deprecated
-  op_mod(Self, Self) -> Self = _
+  mod(Self, Self) -> Self
 }
 pub impl Mod for Byte
 pub impl Mod for Int
@@ -1271,9 +1263,7 @@ pub impl Mod for UInt64
 pub impl Mod for Double
 
 pub(open) trait Mul {
-  mul(Self, Self) -> Self = _
-  #deprecated
-  op_mul(Self, Self) -> Self = _
+  mul(Self, Self) -> Self
 }
 pub impl Mul for Byte
 pub impl Mul for Int
@@ -1284,18 +1274,14 @@ pub impl Mul for UInt64
 pub impl Mul for Double
 
 pub(open) trait Neg {
-  neg(Self) -> Self = _
-  #deprecated
-  op_neg(Self) -> Self = _
+  neg(Self) -> Self
 }
 pub impl Neg for Int
 pub impl Neg for Int64
 pub impl Neg for Double
 
 pub(open) trait Shl {
-  shl(Self, Int) -> Self = _
-  #deprecated
-  op_shl(Self, Int) -> Self = _
+  shl(Self, Int) -> Self
 }
 pub impl Shl for Byte
 pub impl Shl for Int
@@ -1343,9 +1329,7 @@ pub impl Show for BytesView
 pub impl Show for StringView
 
 pub(open) trait Shr {
-  shr(Self, Int) -> Self = _
-  #deprecated
-  op_shr(Self, Int) -> Self = _
+  shr(Self, Int) -> Self
 }
 pub impl Shr for Byte
 pub impl Shr for Int
@@ -1355,9 +1339,7 @@ pub impl Shr for UInt16
 pub impl Shr for UInt64
 
 pub(open) trait Sub {
-  sub(Self, Self) -> Self = _
-  #deprecated
-  op_sub(Self, Self) -> Self = _
+  sub(Self, Self) -> Self
 }
 pub impl Sub for Byte
 pub impl Sub for Int

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -15,9 +15,7 @@
 ///|
 /// Trait for types whose elements can test for equality
 pub(open) trait Eq {
-  equal(Self, Self) -> Bool = _
-  #deprecated("use `equal` instead", skip_current_package=true)
-  op_equal(Self, Self) -> Bool = _
+  equal(Self, Self) -> Bool
   not_equal(Self, Self) -> Bool = _
 }
 
@@ -185,15 +183,4 @@ pub fn[T : Show] repr(t : T) -> String {
   let logger = StringBuilder::new()
   t.output(logger)
   logger.to_string()
-}
-
-///|
-#deprecated("replace `impl op_equal` with `impl equal`")
-impl Eq with equal(self, other) {
-  Eq::op_equal(self, other)
-}
-
-///|
-impl Eq with op_equal(self, other) {
-  Eq::equal(self, other)
 }

--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -74,11 +74,10 @@ test "Eq helpers" {
 }
 
 ///|
-#warnings("-deprecated")
-test "Eq op_equal default" {
+test "Eq::equal on custom impl" {
   let a = Wrapper::{ value: 1 }
   let b = Wrapper::{ value: 2 }
-  inspect(Eq::op_equal(a, b), content="false")
+  inspect(Eq::equal(a, b), content="false")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- remove deprecated `op_xxx` members from operator traits and `Eq`
- keep `Compare::op_lt`, `op_le`, `op_gt`, and `op_ge` unchanged
- update builtin tests and regenerate `builtin/pkg.generated.mbti`

## Why
These deprecated `op_xxx` members were still part of the public trait surface even though the canonical trait methods are the non-`op_` names.

## Impact
This narrows the trait API to the canonical method names for arithmetic, shift, and equality traits while preserving the comparison helpers that should remain on `Compare`.

## Validation
- `moon check`
- `moon test builtin`
- `moon info`
- `moon fmt`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
