### PR TITLE
refactor(show): add explicit to_string for primitives

### DIFF
--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -45,6 +45,11 @@ pub impl Show for SourceLoc with output(self, logger) {
 }
 
 ///|
+pub impl Show for SourceLoc with to_string(self) {
+  self.repr()
+}
+
+///|
 priv struct SourceLocRepr {
   filename : StringView
   start_line : StringView

--- a/builtin/double.mbt
+++ b/builtin/double.mbt
@@ -295,6 +295,11 @@ pub impl Show for Double with output(self, logger) {
 }
 
 ///|
+pub impl Show for Double with to_string(self) {
+  Double::to_string(self)
+}
+
+///|
 /// Determines whether two floating-point numbers are approximately equal within
 /// specified tolerances.
 /// The implementation follows the algorithm described in PEP 485 for Python's

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -18,11 +18,21 @@ pub impl Show for Unit with output(_self, logger) {
 }
 
 ///|
+pub impl Show for Unit with to_string(_self) {
+  "()"
+}
+
+///|
 pub impl Show for Bool with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+///|
+pub impl Show for Bool with to_string(self) {
   if self {
-    logger.write_string("true")
+    "true"
   } else {
-    logger.write_string("false")
+    "false"
   }
 }
 
@@ -32,8 +42,18 @@ pub impl Show for Int with output(self, logger) {
 }
 
 ///|
+pub impl Show for Int with to_string(self) {
+  Int::to_string(self)
+}
+
+///|
 pub impl Show for Int64 with output(self, logger) {
   logger.write_string(self.to_string())
+}
+
+///|
+pub impl Show for Int64 with to_string(self) {
+  Int64::to_string(self)
 }
 
 ///|
@@ -42,8 +62,18 @@ pub impl Show for UInt with output(self, logger) {
 }
 
 ///|
+pub impl Show for UInt with to_string(self) {
+  UInt::to_string(self)
+}
+
+///|
 pub impl Show for UInt64 with output(self, logger) {
   logger.write_string(self.to_string())
+}
+
+///|
+pub impl Show for UInt64 with to_string(self) {
+  UInt64::to_string(self)
 }
 
 ///|
@@ -52,8 +82,18 @@ pub impl Show for Byte with output(self, logger) {
 }
 
 ///|
+pub impl Show for Byte with to_string(self) {
+  Byte::to_string(self)
+}
+
+///|
 pub impl Show for UInt16 with output(self, logger) {
   logger.write_string(self.to_string())
+}
+
+///|
+pub impl Show for UInt16 with to_string(self) {
+  UInt16::to_string(self)
 }
 
 ///|

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -30,7 +30,12 @@
 /// }
 /// ```
 pub impl Show for Float with output(self, logger) {
-  logger.write_string(self.to_double().to_string())
+  logger.write_string(self.to_string())
+}
+
+///|
+pub impl Show for Float with to_string(self) {
+  self.to_double().to_string()
 }
 
 ///|

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -131,6 +131,11 @@ pub impl Show for Int16 with output(self, logger) {
 }
 
 ///|
+pub impl Show for Int16 with to_string(self) {
+  Int16::to_string(self)
+}
+
+///|
 /// reinterpret as an unsigned integer with binary complement
 pub fn Int16::reinterpret_as_uint16(self : Int16) -> UInt16 {
   self.to_int().to_uint16()


### PR DESCRIPTION
## Summary
- add explicit `Show::to_string` implementations for primitive/basic types while keeping explicit `output` impls
- cover `Unit`, `Bool`, `Int`, `UInt`, `Int64`, `UInt64`, `Byte`, `UInt16`, `Double`, `Float`, and `Int16`
- keep `Show` itself unchanged in this PR

## Reasoning

The current default implementation will go through the process of creating a new `&Logger`, which is `StringBuilder`, and then call `&Logger::output` followed by `StringBuilder::to_string`. However, this is redundant for the primitive types, since they already compute the content. With such change, we don't get the performance / code size penalty when we are just interpolating these types.

## Validation
- `moon test builtin`
- `moon test float`
- `moon test int16`
- `moon info`
- `moon fmt`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
