### PR TITLE
fix(bigint): fix bit_length for negative multi-limb powers of two

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1909,14 +1909,11 @@ pub fn BigInt::bit_length(self : BigInt) -> Int {
     (radix_bit_len - self.limbs[self.len - 1].clz())
   if self.sign == Negative {
     // check if this number is a power of two
-    let mut pow2 = self.limbs[0].popcnt() == 1
-    for i in 1..<self.len {
-      if !pow2 {
-        break
-      }
-      pow2 = self.limbs[i] == 0
+    let mut total_bits = 0
+    for i in 0..<self.len {
+      total_bits += self.limbs[i].popcnt()
     }
-    if pow2 {
+    if total_bits == 1 {
       bit_length -= 1
     }
   }

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1271,3 +1271,13 @@ test "BigInt bit_length negative multi-limb" {
 test "BigInt bit_length zero" {
   inspect(@bigint.BigInt::from_int(0).bit_length(), content="0")
 }
+
+///|
+test "BigInt bit_length negative multi-limb power of two" {
+  // -2^32 has limbs [0, 1], bit_length should be 32 not 33
+  let neg_2_32 = @bigint.BigInt::from_string("-4294967296")
+  inspect(neg_2_32.bit_length(), content="32")
+  // -2^64 has limbs [0, 0, 1], bit_length should be 64
+  let neg_2_64 = @bigint.BigInt::from_string("-18446744073709551616")
+  inspect(neg_2_64.bit_length(), content="64")
+}


### PR DESCRIPTION
## Summary
- Fix `bit_length` returning incorrect results for negative multi-limb powers of two (e.g. `-2^32`)
- The power-of-two check started with `limbs[0].popcnt()==1`, which fails for numbers like `-2^32` where limb 0 is 0 and limb 1 is 1
- Fixed to count total set bits across all limbs — exactly 1 set bit means power of two

Split from #3338 (one bug per PR).

## Test plan
- [x] Added regression test: `-2^32` (limbs `[0, 1]`) → `bit_length` should be 32
- [x] Added regression test: `-2^64` (limbs `[0, 0, 1]`) → `bit_length` should be 64
- [x] All 150 bigint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
