### PR TITLE
fix(bigint): fix right shift floor division for negative numbers

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -788,7 +788,15 @@ pub impl Shr for BigInt with shr(self : BigInt, n : Int) -> BigInt {
   if r == 0 {
     let new_limbs = FixedArray::make(new_len, 0U)
     new_limbs.unsafe_blit(0, self.limbs, lz, new_len)
-    { limbs: new_limbs, sign: self.sign, len: new_len }
+    let result = { limbs: new_limbs, sign: self.sign, len: new_len }
+    if self.sign == Negative {
+      for i in 0..<lz {
+        if self.limbs[i] != 0 {
+          return result - 1
+        }
+      }
+    }
+    result
   } else {
     let new_limbs = FixedArray::make(new_len, 0U)
     let a = self.limbs
@@ -802,11 +810,21 @@ pub impl Shr for BigInt with shr(self : BigInt, n : Int) -> BigInt {
     if new_len > 1 && new_limbs[new_len - 1] == 0 {
       new_len -= 1
     }
-    if self.sign == Negative && (carry & (1UL << r)) != carry {
-      { limbs: new_limbs, sign: self.sign, len: new_len } - 1
-    } else {
-      { limbs: new_limbs, sign: self.sign, len: new_len }
+    if self.sign == Negative {
+      let mut has_remainder = carry != 0UL
+      if !has_remainder {
+        for i in 0..<lz {
+          if self.limbs[i] != 0 {
+            has_remainder = true
+            break
+          }
+        }
+      }
+      if has_remainder {
+        return { limbs: new_limbs, sign: self.sign, len: new_len } - 1
+      }
     }
+    { limbs: new_limbs, sign: self.sign, len: new_len }
   }
 }
 

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -422,6 +422,18 @@ test "shr" {
 }
 
 ///|
+test "shr_negative_floor_division" {
+  // -(2^32 + 1) >> 32 should be -2 (floor division)
+  assert_eq((-4294967297N) >> 32, -2N)
+  // -(2^32) >> 32 should be -1 (exact division)
+  assert_eq((-4294967296N) >> 32, -1N)
+  // -(2^33 + 1) >> 33 should be -2
+  assert_eq(-8589934593N >> 33, -2N)
+  // -(2^16 + 1) >> 16 should be -2
+  assert_eq(-65537N >> 16, -2N)
+}
+
+///|
 test "decimal_string" {
   let a = @bigint.BigInt::from_string("0")
   inspect(a.to_string(), content="0")

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -424,9 +424,9 @@ test "shr" {
 ///|
 test "shr_negative_floor_division" {
   // -(2^32 + 1) >> 32 should be -2 (floor division)
-  assert_eq((-4294967297N) >> 32, -2N)
+  assert_eq(-4294967297N >> 32, -2N)
   // -(2^32) >> 32 should be -1 (exact division)
-  assert_eq((-4294967296N) >> 32, -1N)
+  assert_eq(-4294967296N >> 32, -1N)
   // -(2^33 + 1) >> 33 should be -2
   assert_eq(-8589934593N >> 33, -2N)
   // -(2^16 + 1) >> 16 should be -2


### PR DESCRIPTION
## Summary
- Fix arithmetic right shift (`>>`) producing wrong results for negative numbers when shift amount is an exact multiple of 32
- **r==0 path:** Was not checking if any dropped low limbs were non-zero, so `-(2^32+1) >> 32` returned `-1` instead of `-2`
- **r!=0 path:** The carry condition `(carry & (1UL << r)) != carry` was incorrect; replaced with proper remainder + dropped limb check

Split from #3338 (one bug per PR).

## Test plan
- [x] `(-4294967297) >> 32` should be `-2` (floor division of -(2^32+1))
- [x] `(-4294967296) >> 32` should be `-1` (exact: -(2^32))
- [x] `-8589934593 >> 33` should be `-2`
- [x] `-65537 >> 16` should be `-2`
- [x] All 150 bigint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
