### PR TITLE
fix(bigint): fix modpow normalization for modulus=1 and negative bases

### DIFF
--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -327,7 +327,7 @@ extern "js" fn BigInt::modpow_ffi(
   #|(x, y, z) => {
   #|  if (z === 1n) return 0n;
   #|  let result = 1n;
-  #|  x = x % z;
+  #|  x = ((x % z) + z) % z;
   #|  while (y > 0n) {
   #|    if (y & 1n) {
   #|       result = (result * x) % z;

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1388,8 +1388,8 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
     }
     Some(modulus) => {
       guard !(modulus.is_zero() || modulus.sign == Negative)
-      let mut result = 1N
-      let mut base = self
+      let mut result = 1N % modulus
+      let mut base = (self % modulus + modulus) % modulus
       let mut exp = exp
       while exp > 0 {
         if exp % 2 == 1 {

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1293,3 +1293,21 @@ test "BigInt bit_length negative multi-limb power of two" {
   let neg_2_64 = @bigint.BigInt::from_string("-18446744073709551616")
   inspect(neg_2_64.bit_length(), content="64")
 }
+
+///|
+test "BigInt modpow modulus=1 returns 0" {
+  // 2^0 mod 1 should be 0, not 1
+  inspect(2N.pow(0N, modulus=1N), content="0")
+}
+
+///|
+test "BigInt modpow sanity check" {
+  // 3^4 = 81, 81 mod 10 = 1
+  inspect(3N.pow(4N, modulus=10N), content="1")
+}
+
+///|
+test "BigInt modpow negative base normalization" {
+  // (-3)^3 = -27, -27 mod 10 = 3 (canonical non-negative)
+  inspect((-3N).pow(3N, modulus=10N), content="3")
+}


### PR DESCRIPTION
## Summary
- Fix modular exponentiation (`pow` with `modulus`) returning wrong results in two cases:
- **modulus=1:** `2.pow(0, modulus=1)` returned `1` instead of `0` because result was initialized to `1N` instead of `1N % modulus`
- **Negative bases:** Base was not normalized into `[0, modulus)` before the loop, so negative bases produced non-canonical results

Split from #3338 (one bug per PR).

## Test plan
- [x] `2.pow(0, modulus=1)` should be `0`
- [x] `3.pow(4, modulus=10)` should be `1` (sanity: 81 mod 10)
- [x] `(-3).pow(3, modulus=10)` should be `3` (negative base normalization)
- [x] All 152 bigint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
