### PR TITLE
feat(immut/vector): add singleton

### DIFF
--- a/immut/vector/pkg.generated.mbti
+++ b/immut/vector/pkg.generated.mbti
@@ -50,6 +50,8 @@ pub fn[A] Vector::push(Self[A], A) -> Self[A]
 #alias(fold_right, deprecated)
 pub fn[A, B] Vector::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A] Vector::set(Self[A], Int, A) -> Self[A]
+#as_free_fn
+pub fn[A] Vector::singleton(A) -> Self[A]
 pub fn[A] Vector::slice(Self[A], Int, Int) -> Self[A]
 pub fn[A] Vector::split(Self[A], Int) -> (Self[A], Self[A])
 pub fn[A] Vector::take(Self[A], Int) -> Self[A]

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -24,6 +24,22 @@ pub fn[A] Vector::new() -> Vector[A] {
 }
 
 ///|
+/// Create a vector with a single element.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let v = @vector.singleton(42)
+///   assert_eq(v, @vector.from_array([42]))
+///   assert_eq(v.length(), 1)
+/// }
+/// ```
+#as_free_fn
+pub fn[A] Vector::singleton(value : A) -> Vector[A] {
+  make_t(Tree::empty(), [value], 1, 0)
+}
+
+///|
 /// Create a persistent vector with a given length and value.
 #as_free_fn
 pub fn[A] Vector::make(len : Int, value : A) -> Vector[A] {

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -49,6 +49,13 @@ test "to_string" {
 }
 
 ///|
+test "singleton" {
+  let v = @vector.singleton(7)
+  inspect(v, content="@immut/vector.from_array([7])")
+  inspect(v.length(), content="1")
+}
+
+///|
 test "make with full leaf" {
   let v = @vector.make(32, 7)
   inspect(v.length(), content="32")


### PR DESCRIPTION
## Summary
- add `Vector::singleton` as a free function constructor for one-element vectors
- add a blackbox test covering the new constructor
- regenerate `immut/vector/pkg.generated.mbti`

## Testing
- moon info
- moon fmt
- moon test immut/vector
- moon check
- moon test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
