### PR TITLE
feat(immut/vector): add filter rev and contains

### DIFF
--- a/immut/vector/pkg.generated.mbti
+++ b/immut/vector/pkg.generated.mbti
@@ -16,12 +16,14 @@ type Vector[A]
 #alias("_[_]")
 pub fn[A] Vector::at(Self[A], Int) -> A
 pub fn[A] Vector::concat(Self[A], Self[A]) -> Self[A]
+pub fn[A : Eq] Vector::contains(Self[A], A) -> Bool
 #alias(clone, deprecated)
 #deprecated
 pub fn[A] Vector::copy(Self[A]) -> Self[A]
 pub fn[A] Vector::drop(Self[A], Int) -> Self[A]
 pub fn[A] Vector::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 pub fn[A] Vector::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
+pub fn[A] Vector::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 #alias(fold_left, deprecated)
 pub fn[A, B] Vector::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 #alias(of, deprecated)
@@ -47,6 +49,7 @@ pub fn[A] Vector::new() -> Self[A]
 pub fn[A] Vector::peek(Self[A]) -> A?
 pub fn[A] Vector::pop(Self[A]) -> Self[A]?
 pub fn[A] Vector::push(Self[A], A) -> Self[A]
+pub fn[A] Vector::rev(Self[A]) -> Self[A]
 #alias(fold_right, deprecated)
 pub fn[A, B] Vector::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A] Vector::set(Self[A], Int, A) -> Self[A]

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -608,7 +608,13 @@ pub fn[A] Vector::filter(
 /// }
 /// ```
 pub fn[A] Vector::rev(self : Vector[A]) -> Vector[A] {
-  self.rev_fold(init=new(), (vec, value) => vec.push(value))
+  if self.size == 0 {
+    new()
+  } else {
+    let arr = Array::make(self.size, self[0])
+    self.eachi((i, value) => arr[self.size - 1 - i] = value)
+    from_array(arr)
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -247,6 +247,22 @@ pub fn[A] Vector::peek(self : Vector[A]) -> A? {
   }
 }
 
+///|
+/// Returns `true` if the vector contains the given value.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let v = @vector.from_array([1, 2, 3, 4, 5])
+///   inspect(v.contains(3), content="true")
+///   inspect(v.contains(6), content="false")
+/// }
+/// ```
+pub fn[A : Eq] Vector::contains(self : Vector[A], value : A) -> Bool {
+  // TODO: optimize this to scan the tree and tail directly instead of going through `iter`.
+  self.iter().contains(value)
+}
+
 //-----------------------------------------------------------------------------
 // Modifier
 //-----------------------------------------------------------------------------
@@ -560,6 +576,39 @@ pub fn[A, B] Vector::map(
   f : (A) -> B raise?,
 ) -> Vector[B] raise? {
   make_t(self.tree.map(f), self.tail.map(f), self.size, self.shift)
+}
+
+///|
+/// Creates a new vector containing only the elements that satisfy the predicate.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let v = @vector.from_array([1, 2, 3, 4, 5])
+///   assert_eq(v.filter(x => x % 2 == 0), @vector.from_array([2, 4]))
+/// }
+/// ```
+pub fn[A] Vector::filter(
+  self : Vector[A],
+  f : (A) -> Bool raise?,
+) -> Vector[A] raise? {
+  let arr : Array[A] = []
+  self.each(value => if f(value) { arr.push(value) })
+  from_array(arr)
+}
+
+///|
+/// Returns a new vector with the elements in reverse order.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let v = @vector.from_array([1, 2, 3, 4, 5])
+///   assert_eq(v.rev(), @vector.from_array([5, 4, 3, 2, 1]))
+/// }
+/// ```
+pub fn[A] Vector::rev(self : Vector[A]) -> Vector[A] {
+  self.rev_fold(init=new(), (vec, value) => vec.push(value))
 }
 
 //-----------------------------------------------------------------------------

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -592,7 +592,7 @@ pub fn[A] Vector::filter(
   self : Vector[A],
   f : (A) -> Bool raise?,
 ) -> Vector[A] raise? {
-  let arr : Array[A] = []
+  let arr : Array[A] = Array::new(capacity=self.size)
   self.each(value => if f(value) { arr.push(value) })
   from_array(arr)
 }

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -211,6 +211,41 @@ test "map" {
 }
 
 ///|
+test "filter" {
+  let values = @vector.from_iter((0).until(40))
+  inspect(
+    values.filter(x => x % 7 == 0),
+    content="@immut/vector.from_array([0, 7, 14, 21, 28, 35])",
+  )
+  inspect(values.filter(_ => false), content="@immut/vector.from_array([])")
+}
+
+///|
+test "rev" {
+  let values = @vector.from_iter((0).until(40))
+  inspect(
+    values.rev(),
+    content=(
+      #|@immut/vector.from_array([39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
+    ),
+  )
+  inspect(
+    (@vector.new() : @vector.Vector[Int]).rev(),
+    content="@immut/vector.from_array([])",
+  )
+}
+
+///|
+test "contains" {
+  let values = @vector.from_iter((0).until(40))
+  inspect(values.contains(0), content="true")
+  inspect(values.contains(31), content="true")
+  inspect(values.contains(39), content="true")
+  inspect(values.contains(40), content="false")
+  inspect((@vector.new() : @vector.Vector[Int]).contains(1), content="false")
+}
+
+///|
 test "new" {
   let v = @vector.make(5, 1)
   let v2 = @vector.make(33, 10)


### PR DESCRIPTION
## Summary
- add `Vector::contains`, `Vector::filter`, and `Vector::rev`
- add blackbox coverage for the new vector methods, including empty and multi-leaf cases
- regenerate `immut/vector/pkg.generated.mbti`

## Notes
- `contains` currently delegates to `iter().contains(...)`
- leave a TODO in the implementation to optimize it later without going through `iter`

## Testing
- moon fmt
- moon info
- moon test immut/vector
- moon check

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
