### PR TITLE
feat(builtin): add impl Add for ArrayView

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1226,4 +1226,43 @@ pub impl[A : Hash] Hash for ArrayView[A] with hash_combine(self, hasher) {
   }
 }
 
+///|
+/// Concatenates two array views into a new view backed by a freshly allocated
+/// array. The resulting view contains all elements from `self` followed by all
+/// elements from `other`.
+///
+/// Note: although `+` looks cheap, this allocates a new owned `Array[T]`
+/// because views cannot own data — the returned view spans the whole new
+/// array.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let a = [1, 2, 3, 4, 5][1:4]
+///   let b = [10, 20, 30][:2]
+///   inspect(a + b, content="[2, 3, 4, 10, 20]")
+/// }
+/// ```
+pub impl[T] Add for ArrayView[T] with add(self, other) {
+  let len_self = self.length()
+  let len_other = other.length()
+  let result = Array::make_uninit(len_self + len_other)
+  UninitializedArray::unsafe_blit(
+    result.buffer(),
+    0,
+    self.buf(),
+    self.start(),
+    len_self,
+  )
+  UninitializedArray::unsafe_blit(
+    result.buffer(),
+    len_self,
+    other.buf(),
+    other.start(),
+    len_other,
+  )
+  result[:]
+}
+
 // #endregion

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -482,3 +482,120 @@ test "ArrayView::iter2 empty" {
   let iter = view.iter2()
   assert_eq(iter.next(), None)
 }
+
+///|
+test "ArrayView::op_add basic" {
+  let a = [1, 2, 3][:]
+  let b = [4, 5][:]
+  inspect(a + b, content="[1, 2, 3, 4, 5]")
+}
+
+///|
+test "ArrayView::op_add sliced views" {
+  let a = [0, 1, 2, 3, 4, 5][1:4]
+  let b = [10, 20, 30, 40][1:3]
+  inspect(a + b, content="[1, 2, 3, 20, 30]")
+}
+
+///|
+test "ArrayView::op_add empty left" {
+  let a = [1, 2, 3][0:0]
+  let b = [4, 5, 6][:]
+  let result = a + b
+  inspect(result, content="[4, 5, 6]")
+  assert_eq(result.length(), 3)
+}
+
+///|
+test "ArrayView::op_add empty right" {
+  let a = [1, 2, 3][:]
+  let b = [4, 5, 6][1:1]
+  let result = a + b
+  inspect(result, content="[1, 2, 3]")
+  assert_eq(result.length(), 3)
+}
+
+///|
+test "ArrayView::op_add both empty" {
+  let a : ArrayView[Int] = [1, 2, 3][0:0]
+  let b : ArrayView[Int] = [4, 5][1:1]
+  let result = a + b
+  inspect(result, content="[]")
+  assert_eq(result.length(), 0)
+  assert_true(result.is_empty())
+}
+
+///|
+test "ArrayView::op_add does not mutate sources" {
+  let arr_a = [1, 2, 3, 4]
+  let arr_b = [5, 6, 7]
+  let a = arr_a[1:3]
+  let b = arr_b[:2]
+  let _ = a + b
+  inspect(arr_a, content="[1, 2, 3, 4]")
+  inspect(arr_b, content="[5, 6, 7]")
+  inspect(a, content="[2, 3]")
+  inspect(b, content="[5, 6]")
+}
+
+///|
+test "ArrayView::op_add result is independent of source mutation" {
+  let arr_a = [1, 2, 3, 4]
+  let arr_b = [5, 6, 7, 8]
+  let a = arr_a[1:3]
+  let b = arr_b[1:3]
+  let result = a + b
+  arr_a[1] = 99
+  arr_b[2] = 88
+  inspect(result, content="[2, 3, 6, 7]")
+}
+
+///|
+test "ArrayView::op_add full slice equals Array Add" {
+  let a = [1, 2, 3]
+  let b = [4, 5, 6]
+  let view_sum = a[:] + b[:]
+  let array_sum = a + b
+  assert_eq(view_sum.length(), array_sum.length())
+  for i in 0..<view_sum.length() {
+    assert_eq(view_sum[i], array_sum[i])
+  }
+}
+
+///|
+test "ArrayView::op_add generic string elements" {
+  let a = ["hello", "world"][:]
+  let b = ["foo"][:]
+  let expected =
+    #|["hello", "world", "foo"]
+  inspect(a + b, content=expected)
+}
+
+///|
+test "ArrayView::op_add chained" {
+  let a = [1, 2][:]
+  let b = [3, 4][:]
+  let c = [5, 6][:]
+  inspect(a + b + c, content="[1, 2, 3, 4, 5, 6]")
+}
+
+///|
+test "ArrayView::op_add tail and head slices" {
+  let v = [1, 2, 3, 4, 5, 6]
+  let head = v[:3]
+  let tail = v[3:]
+  inspect(head + tail, content="[1, 2, 3, 4, 5, 6]")
+  inspect(tail + head, content="[4, 5, 6, 1, 2, 3]")
+}
+
+///|
+test "ArrayView::op_add large" {
+  let n = 100
+  let a = Array::makei(n, i => i)
+  let b = Array::makei(n, i => i + n)
+  let result = a[:] + b[:]
+  assert_eq(result.length(), 2 * n)
+  for i in 0..<(2 * n) {
+    assert_eq(result[i], i)
+  }
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -225,6 +225,7 @@ pub fn[T] ArrayView::to_array(Self[T]) -> Array[T]
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[T] ArrayView::view(Self[T], start? : Int, end? : Int) -> Self[T]
+pub impl[T] Add for ArrayView[T]
 pub impl[T : Compare] Compare for ArrayView[T]
 pub impl[T : Eq] Eq for ArrayView[T]
 pub impl[A : Hash] Hash for ArrayView[A]


### PR DESCRIPTION
## Summary
- Add `impl Add for ArrayView[T]` mirroring `Array[T]`'s concatenation, so `view1 + view2` works analogously to `array1 + array2`.
- Establishes parity with the existing `StringView`/`String` pairing (both implement `Add`).
- The result is an `ArrayView[T]` spanning a freshly allocated backing array — views can't own data, so `+` necessarily allocates (documented in the doc comment).

## Test plan
- [x] `moon check` clean
- [x] `moon fmt`
- [x] `moon test -p moonbitlang/core/builtin` — 2733 / 2733 pass
- [x] `moon test` (full suite) — 6260 / 6260 pass
- [x] New tests cover: full-slice views, sub-slice views, empty left / right / both, source non-mutation and result independence after source mutation, parity with `Array + Array`, generic element type (`String`), chained `+`, head/tail concat, and a 200-element large case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
