### PR TITLE
feat(builtin): add ArrayView::rev

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1257,6 +1257,30 @@ pub fn[T : Compare] ArrayView::lexical_compare(
   self_len.compare(other_len)
 }
 
+///|
+/// Reverses the elements of the array view, returning a freshly allocated
+/// array containing the elements in reverse order. The original view is not
+/// modified.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v = [1, 2, 3, 4, 5][1:4]
+///   inspect(v.rev(), content="[4, 3, 2]")
+///   // The view itself is unchanged.
+///   inspect(v, content="[2, 3, 4]")
+/// }
+/// ```
+pub fn[T] ArrayView::rev(self : ArrayView[T]) -> Array[T] {
+  let len = self.length()
+  let arr = Array::make_uninit(len)
+  for i in 0..<len {
+    arr.unsafe_set(i, self.unsafe_get(len - i - 1))
+  }
+  arr
+}
+
 // #endregion
 
 // #region trait impls

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -693,3 +693,61 @@ test "ArrayView::search_by matches first element" {
   let v = [1, 2, 3][:]
   inspect(v.search_by(_ => true), content="Some(0)")
 }
+
+///|
+test "ArrayView::rev basic" {
+  inspect([1, 2, 3, 4, 5][:].rev(), content="[5, 4, 3, 2, 1]")
+}
+
+///|
+test "ArrayView::rev sliced view" {
+  let v = [1, 2, 3, 4, 5][1:4]
+  inspect(v.rev(), content="[4, 3, 2]")
+}
+
+///|
+test "ArrayView::rev empty" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  inspect(v.rev(), content="[]")
+  assert_true(v.rev().is_empty())
+}
+
+///|
+test "ArrayView::rev singleton" {
+  inspect([42][:].rev(), content="[42]")
+}
+
+///|
+test "ArrayView::rev does not mutate source" {
+  let arr = [1, 2, 3, 4]
+  let v = arr[1:3]
+  let _ = v.rev()
+  inspect(arr, content="[1, 2, 3, 4]")
+  inspect(v, content="[2, 3]")
+}
+
+///|
+test "ArrayView::rev result is independent" {
+  let arr = [1, 2, 3, 4]
+  let v = arr[:]
+  let r = v.rev()
+  arr[0] = 99
+  inspect(r, content="[4, 3, 2, 1]")
+}
+
+///|
+test "ArrayView::rev twice is identity" {
+  let v = [1, 2, 3, 4, 5][1:4]
+  inspect(v.rev()[:].rev(), content="[2, 3, 4]")
+}
+
+///|
+test "ArrayView::rev matches Array::rev" {
+  let arr = [1, 2, 3, 4, 5]
+  let view_rev = arr[:].rev()
+  let array_rev = arr.rev()
+  assert_eq(view_rev.length(), array_rev.length())
+  for i in 0..<view_rev.length() {
+    assert_eq(view_rev[i], array_rev[i])
+  }
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -213,6 +213,7 @@ pub fn[T] ArrayView::length(Self[T]) -> Int
 pub fn[T : Compare] ArrayView::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
 pub fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?
+pub fn[T] ArrayView::rev(Self[T]) -> Array[T]
 pub fn[T] ArrayView::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[A, B] ArrayView::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?


### PR DESCRIPTION
## Summary
- Mirror `Array::rev` on `ArrayView`, returning a freshly allocated `Array[T]` with elements in reverse order.
- Source view is unchanged.

## Test plan
- [x] `moon fmt`, `moon check`, `moon info`
- [x] `moon test -p moonbitlang/core/builtin` — 2742/2742 pass
- [x] New tests: basic, sliced view, empty, singleton, source non-mutation, result independence after source mutation, `rev`-twice identity, parity with `Array::rev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
