### PR TITLE
feat(builtin): add ArrayView::filter_map

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1146,6 +1146,34 @@ pub fn[T] ArrayView::filter(
 }
 
 ///|
+/// Apply a function to each element of the view, keeping only the `Some`
+/// results. Returns a freshly allocated `Array`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v = [1, 2, 3, 4, 5][1:4]
+///   inspect(
+///     v.filter_map(x => if x % 2 == 0 { Some(x * 10) } else { None }),
+///     content="[20, 40]",
+///   )
+/// }
+/// ```
+pub fn[A, B] ArrayView::filter_map(
+  self : ArrayView[A],
+  f : (A) -> B? raise?,
+) -> Array[B] raise? {
+  let result = []
+  for x in self {
+    if f(x) is Some(x) {
+      result.push(x)
+    }
+  }
+  result
+}
+
+///|
 /// Copy the view elements to a new array
 ///
 /// # Example

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -751,3 +751,59 @@ test "ArrayView::rev matches Array::rev" {
     assert_eq(view_rev[i], array_rev[i])
   }
 }
+
+///|
+test "ArrayView::filter_map basic" {
+  let v = [1, 2, 3, 4, 5][:]
+  let r = v.filter_map(x => if x % 2 == 0 { Some(x * 10) } else { None })
+  inspect(r, content="[20, 40]")
+}
+
+///|
+test "ArrayView::filter_map sliced view" {
+  let v = [1, 2, 3, 4, 5, 6][1:5]
+  let r = v.filter_map(x => if x > 2 { Some(x) } else { None })
+  inspect(r, content="[3, 4, 5]")
+}
+
+///|
+test "ArrayView::filter_map empty view" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  let r = v.filter_map(x => Some(x))
+  inspect(r, content="[]")
+  assert_true(r.is_empty())
+}
+
+///|
+test "ArrayView::filter_map all none" {
+  let v = [1, 2, 3][:]
+  let r : Array[Int] = v.filter_map(_ => None)
+  inspect(r, content="[]")
+}
+
+///|
+test "ArrayView::filter_map all some (type change)" {
+  let v = [1, 2, 3][:]
+  let r = v.filter_map(x => Some(x.to_string()))
+  inspect(
+    r,
+    content=(
+      #|["1", "2", "3"]
+    ),
+  )
+}
+
+///|
+test "ArrayView::filter_map preserves order" {
+  let v = [5, 1, 4, 2, 3][:]
+  let r = v.filter_map(x => if x >= 3 { Some(x * 2) } else { None })
+  inspect(r, content="[10, 8, 6]")
+}
+
+///|
+test "ArrayView::filter_map does not mutate source" {
+  let arr = [1, 2, 3, 4]
+  let v = arr[:]
+  let _ = v.filter_map(x => Some(x + 100))
+  inspect(arr, content="[1, 2, 3, 4]")
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -197,6 +197,7 @@ pub fn[T] ArrayView::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ArrayView::ends_with(Self[T], Self[T]) -> Bool
 pub fn[T] ArrayView::filter(Self[T], (T) -> Bool raise?) -> Array[T] raise?
+pub fn[A, B] ArrayView::filter_map(Self[A], (A) -> B? raise?) -> Array[B] raise?
 pub fn[A, B] ArrayView::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ArrayView::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 pub fn[T] ArrayView::get(Self[T], Int) -> T?


### PR DESCRIPTION
## Summary
- Mirror `Array::filter_map` on `ArrayView`, applying `A -> B?` and collecting the `Some` results into a fresh `Array[B]`.
- Complements the existing `ArrayView::filter` and `ArrayView::map`.

## Test plan
- [x] `moon fmt`, `moon check`, `moon info`
- [x] `moon test -p moonbitlang/core/builtin` — 2741/2741 pass
- [x] New tests: basic, sliced view, empty view, all-None, type-changing all-Some, order preservation, source non-mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
