### PR TITLE
feat(builtin): add ArrayView::search_by

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -842,6 +842,32 @@ pub fn[T : Eq] ArrayView::search(self : ArrayView[T], value : T) -> Int? {
 }
 
 ///|
+/// Searches for the first element in the view that satisfies the predicate
+/// `f` and returns its (view-relative) index, or `None` if no element matches.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let view = [1, 2, 3, 4, 5][1:]
+///   inspect(view.search_by(x => x > 3), content="Some(2)")
+///   inspect(view.search_by(x => x > 99), content="None")
+/// }
+/// ```
+pub fn[T] ArrayView::search_by(
+  self : ArrayView[T],
+  f : (T) -> Bool raise?,
+) -> Int? raise? {
+  for i, v in self {
+    if f(v) {
+      break Some(i)
+    }
+  } nobreak {
+    None
+  }
+}
+
+///|
 /// Checks if the array view starts with the given prefix.
 ///
 /// # Example

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -656,3 +656,40 @@ test "ArrayView::rev_eachi empty" {
   v.rev_eachi((i, x) => out.push((i, x)))
   inspect(out, content="[]")
 }
+
+///|
+test "ArrayView::search_by basic" {
+  let v = [1, 2, 3, 4, 5][:]
+  inspect(v.search_by(x => x > 3), content="Some(3)")
+}
+
+///|
+test "ArrayView::search_by no match" {
+  let v = [1, 2, 3][:]
+  inspect(v.search_by(x => x > 99), content="None")
+}
+
+///|
+test "ArrayView::search_by empty" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  inspect(v.search_by(_ => true), content="None")
+}
+
+///|
+test "ArrayView::search_by returns first match" {
+  let v = [1, 2, 3, 2, 4][:]
+  inspect(v.search_by(x => x == 2), content="Some(1)")
+}
+
+///|
+test "ArrayView::search_by index is view-relative" {
+  let v = [10, 20, 30, 40, 50][2:5]
+  // Looking for 40, which is at view-index 1 (absolute index 3).
+  inspect(v.search_by(x => x == 40), content="Some(1)")
+}
+
+///|
+test "ArrayView::search_by matches first element" {
+  let v = [1, 2, 3][:]
+  inspect(v.search_by(_ => true), content="Some(0)")
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -220,6 +220,7 @@ pub fn[A, B] ArrayView::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -
 #alias(rev_iterator, deprecated)
 pub fn[X] ArrayView::rev_iter(Self[X]) -> Iter[X]
 pub fn[T : Eq] ArrayView::search(Self[T], T) -> Int?
+pub fn[T] ArrayView::search_by(Self[T], (T) -> Bool raise?) -> Int? raise?
 pub fn[T] ArrayView::start_offset(Self[T]) -> Int
 pub fn[T : Eq] ArrayView::starts_with(Self[T], Self[T]) -> Bool
 pub fn[T] ArrayView::suffixes(Self[T], include_empty? : Bool) -> Iter[Self[T]]


### PR DESCRIPTION
## Summary
- Mirror `Array::search_by` on `ArrayView`, returning the view-relative index of the first element satisfying the predicate.
- Complements the existing Eq-based `ArrayView::search`.

## Test plan
- [x] `moon fmt`, `moon check`, `moon info`
- [x] `moon test -p moonbitlang/core/builtin` — 2740/2740 pass
- [x] New tests: basic, no-match, empty view, first-match stop, view-relative index on sliced view, match-first-element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
