### PR TITLE
feat(builtin): add ArrayView::rev_each and rev_eachi

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -691,6 +691,55 @@ pub fn[T] ArrayView::eachi(
 }
 
 ///|
+/// Iterates over the elements of the array view in reverse order (last to
+/// first).
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v = [1, 2, 3, 4, 5][1:4]
+///   let out = []
+///   v.rev_each(x => out.push(x))
+///   inspect(out, content="[4, 3, 2]")
+/// }
+/// ```
+pub fn[T] ArrayView::rev_each(
+  self : ArrayView[T],
+  f : (T) -> Unit raise?,
+) -> Unit raise? {
+  let len = self.length()
+  for i in 0..<len {
+    f(self.unsafe_get(len - i - 1))
+  }
+}
+
+///|
+/// Iterates over the elements of the array view in reverse order, passing the
+/// view-relative index of each element (0 for the first element yielded, the
+/// last position of the view).
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v = [10, 20, 30][:]
+///   let out = []
+///   v.rev_eachi((i, x) => out.push((i, x)))
+///   inspect(out, content="[(0, 30), (1, 20), (2, 10)]")
+/// }
+/// ```
+pub fn[T] ArrayView::rev_eachi(
+  self : ArrayView[T],
+  f : (Int, T) -> Unit raise?,
+) -> Unit raise? {
+  let len = self.length()
+  for i in 0..<len {
+    f(i, self.unsafe_get(len - i - 1))
+  }
+}
+
+///|
 /// Checks if all elements in the array view match the condition.
 /// 
 /// # Example

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -599,3 +599,60 @@ test "ArrayView::op_add large" {
     assert_eq(result[i], i)
   }
 }
+
+///|
+test "ArrayView::rev_each basic" {
+  let v = [1, 2, 3, 4, 5][:]
+  let out = []
+  v.rev_each(x => out.push(x))
+  inspect(out, content="[5, 4, 3, 2, 1]")
+}
+
+///|
+test "ArrayView::rev_each sliced view" {
+  let v = [1, 2, 3, 4, 5][1:4]
+  let out = []
+  v.rev_each(x => out.push(x))
+  inspect(out, content="[4, 3, 2]")
+}
+
+///|
+test "ArrayView::rev_each empty" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  let out = []
+  v.rev_each(x => out.push(x))
+  inspect(out, content="[]")
+}
+
+///|
+test "ArrayView::rev_each matches rev_iter order" {
+  let v = [1, 2, 3, 4, 5][1:4]
+  let a = []
+  v.rev_each(x => a.push(x))
+  let b = v.rev_iter().to_array()
+  assert_eq(a, b)
+}
+
+///|
+test "ArrayView::rev_eachi basic" {
+  let v = [10, 20, 30][:]
+  let out = []
+  v.rev_eachi((i, x) => out.push((i, x)))
+  inspect(out, content="[(0, 30), (1, 20), (2, 10)]")
+}
+
+///|
+test "ArrayView::rev_eachi sliced view index starts at 0" {
+  let v = [0, 10, 20, 30, 40][1:4]
+  let out = []
+  v.rev_eachi((i, x) => out.push((i, x)))
+  inspect(out, content="[(0, 30), (1, 20), (2, 10)]")
+}
+
+///|
+test "ArrayView::rev_eachi empty" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  let out = []
+  v.rev_eachi((i, x) => out.push((i, x)))
+  inspect(out, content="[]")
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -213,6 +213,8 @@ pub fn[T] ArrayView::length(Self[T]) -> Int
 pub fn[T : Compare] ArrayView::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
 pub fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?
+pub fn[T] ArrayView::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
+pub fn[T] ArrayView::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[A, B] ArrayView::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ArrayView::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 #alias(rev_iterator, deprecated)


### PR DESCRIPTION
## Summary
- Add `ArrayView::rev_each` and `ArrayView::rev_eachi` mirroring `Array`.
- `rev_eachi` yields view-relative indices — `0` for the first element emitted (the view's last element).

## Test plan
- [x] `moon fmt`, `moon check`, `moon info`
- [x] `moon test -p moonbitlang/core/builtin` — 2742/2742 pass
- [x] Covers: basic, sliced view, empty view, parity with `rev_iter`, `rev_eachi` basic + sliced view (verifying index starts at 0) + empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
