### PR TITLE
feat(builtin): add ArrayView chunks / chunk_by / windows

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -547,6 +547,100 @@ pub fn[T] ArrayView::suffixes(
 }
 
 ///|
+/// Split the array view into contiguous sub-views of length `size`. The last
+/// sub-view may be shorter if the view length is not a multiple of `size`. The
+/// returned sub-views share the original backing array — no elements are
+/// copied.
+///
+/// Panics if `size <= 0`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v = [1, 2, 3, 4, 5, 6, 7][:]
+///   inspect(v.chunks(3), content="[[1, 2, 3], [4, 5, 6], [7]]")
+/// }
+/// ```
+pub fn[T] ArrayView::chunks(
+  self : ArrayView[T],
+  size : Int,
+) -> Array[ArrayView[T]] {
+  guard size > 0
+  let len = self.length()
+  if len == 0 {
+    return []
+  }
+  let num_chunks = (len + size - 1) / size
+  Array::makei(num_chunks, i => {
+    let start = i * size
+    let end = Int::min(start + size, len)
+    self[start:end]
+  })
+}
+
+///|
+/// Groups consecutive elements of the view into chunks where adjacent
+/// elements satisfy the given predicate. Each returned sub-view shares the
+/// original backing array.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v = [1, 1, 2, 2, 2, 3, 1][:]
+///   inspect(v.chunk_by((a, b) => a == b), content="[[1, 1], [2, 2, 2], [3], [1]]")
+/// }
+/// ```
+pub fn[T] ArrayView::chunk_by(
+  self : ArrayView[T],
+  pred : (T, T) -> Bool raise?,
+) -> Array[ArrayView[T]] raise? {
+  let chunks = []
+  if self.is_empty() {
+    return chunks
+  }
+  let start = for i in 1..<self.length(); start = 0 {
+    if !pred(self.unsafe_get(i - 1), self.unsafe_get(i)) {
+      chunks.push(self[start:i])
+      continue i
+    }
+    continue start
+  } nobreak {
+    start
+  }
+  chunks.push(self[start:self.length()])
+  chunks
+}
+
+///|
+/// Return all contiguous sub-views of the given `size`, stepping by one
+/// element. Returns an empty array if `size` exceeds the view length. Each
+/// returned sub-view shares the original backing array.
+///
+/// Panics if `size <= 0`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v = [1, 2, 3, 4, 5][:]
+///   inspect(v.windows(3), content="[[1, 2, 3], [2, 3, 4], [3, 4, 5]]")
+/// }
+/// ```
+pub fn[T] ArrayView::windows(
+  self : ArrayView[T],
+  size : Int,
+) -> Array[ArrayView[T]] {
+  guard size > 0
+  let len = self.length() - size + 1
+  if len < 1 {
+    return []
+  }
+  Array::makei(len, i => self[i:i + size])
+}
+
+///|
 /// Returns an iterator that yields each element of the array view in sequence
 /// from start to end.
 ///

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -807,3 +807,110 @@ test "ArrayView::filter_map does not mutate source" {
   let _ = v.filter_map(x => Some(x + 100))
   inspect(arr, content="[1, 2, 3, 4]")
 }
+
+///|
+test "ArrayView::chunks even" {
+  let v = [1, 2, 3, 4, 5, 6][:]
+  inspect(v.chunks(2), content="[[1, 2], [3, 4], [5, 6]]")
+}
+
+///|
+test "ArrayView::chunks uneven last" {
+  let v = [1, 2, 3, 4, 5, 6, 7][:]
+  inspect(v.chunks(3), content="[[1, 2, 3], [4, 5, 6], [7]]")
+}
+
+///|
+test "ArrayView::chunks size larger than view" {
+  let v = [1, 2][:]
+  inspect(v.chunks(5), content="[[1, 2]]")
+}
+
+///|
+test "ArrayView::chunks empty view" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  inspect(v.chunks(3), content="[]")
+}
+
+///|
+test "ArrayView::chunks on sliced view" {
+  let v = [0, 1, 2, 3, 4, 5, 6][1:6]
+  inspect(v.chunks(2), content="[[1, 2], [3, 4], [5]]")
+}
+
+///|
+test "ArrayView::chunks shares backing" {
+  let arr = [1, 2, 3, 4]
+  let parts = arr[:].chunks(2)
+  arr[0] = 99
+  arr[3] = 88
+  inspect(parts, content="[[99, 2], [3, 88]]")
+}
+
+///|
+test "ArrayView::chunk_by basic" {
+  let v = [1, 1, 2, 2, 2, 3, 1][:]
+  inspect(v.chunk_by((a, b) => a == b), content="[[1, 1], [2, 2, 2], [3], [1]]")
+}
+
+///|
+test "ArrayView::chunk_by empty" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  inspect(v.chunk_by((a, b) => a == b), content="[]")
+}
+
+///|
+test "ArrayView::chunk_by singleton" {
+  let v = [42][:]
+  inspect(v.chunk_by((a, b) => a == b), content="[[42]]")
+}
+
+///|
+test "ArrayView::chunk_by monotonic increasing" {
+  let v = [1, 2, 3, 1, 2, 4, 3][:]
+  inspect(v.chunk_by((a, b) => a <= b), content="[[1, 2, 3], [1, 2, 4], [3]]")
+}
+
+///|
+test "ArrayView::chunk_by on sliced view" {
+  let v = [9, 1, 1, 2, 2, 9][1:5]
+  inspect(v.chunk_by((a, b) => a == b), content="[[1, 1], [2, 2]]")
+}
+
+///|
+test "ArrayView::windows basic" {
+  let v = [1, 2, 3, 4, 5][:]
+  inspect(v.windows(3), content="[[1, 2, 3], [2, 3, 4], [3, 4, 5]]")
+}
+
+///|
+test "ArrayView::windows size equals length" {
+  let v = [1, 2, 3][:]
+  inspect(v.windows(3), content="[[1, 2, 3]]")
+}
+
+///|
+test "ArrayView::windows size larger than view" {
+  let v = [1, 2][:]
+  inspect(v.windows(5), content="[]")
+}
+
+///|
+test "ArrayView::windows empty view" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  inspect(v.windows(1), content="[]")
+}
+
+///|
+test "ArrayView::windows on sliced view" {
+  let v = [0, 1, 2, 3, 4, 5][1:5]
+  inspect(v.windows(2), content="[[1, 2], [2, 3], [3, 4]]")
+}
+
+///|
+test "ArrayView::windows shares backing" {
+  let arr = [1, 2, 3, 4]
+  let ws = arr[:].windows(2)
+  arr[1] = 99
+  inspect(ws, content="[[1, 99], [99, 3], [3, 4]]")
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -194,6 +194,8 @@ pub fn[T] ArrayView::at(Self[T], Int) -> T
 pub fn[T : Compare] ArrayView::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] ArrayView::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
 pub fn[A] ArrayView::blit_to(Self[A], Array[A], dst_offset? : Int) -> Unit
+pub fn[T] ArrayView::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[Self[T]] raise?
+pub fn[T] ArrayView::chunks(Self[T], Int) -> Array[Self[T]]
 pub fn[T : Eq] ArrayView::contains(Self[T], T) -> Bool
 pub fn[T] ArrayView::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
@@ -232,6 +234,7 @@ pub fn[T] ArrayView::to_array(Self[T]) -> Array[T]
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[T] ArrayView::view(Self[T], start? : Int, end? : Int) -> Self[T]
+pub fn[T] ArrayView::windows(Self[T], Int) -> Array[Self[T]]
 pub impl[T] Add for ArrayView[T]
 pub impl[T : Compare] Compare for ArrayView[T]
 pub impl[T : Eq] Eq for ArrayView[T]


### PR DESCRIPTION
## Summary
- Add `ArrayView::chunks`, `ArrayView::chunk_by`, and `ArrayView::windows`, mirroring the `Array` methods.
- Each returns an `Array[ArrayView[T]]` where the sub-views share the original backing array — no element copies.

## Test plan
- [x] `moon fmt`, `moon check`, `moon info`
- [x] `moon test -p moonbitlang/core/builtin` — 2753/2753 pass
- [x] `chunks`: even split, uneven last chunk, size > length, empty view, sliced view, backing-array sharing.
- [x] `chunk_by`: basic equality grouping, empty, singleton, monotonic predicate, sliced view.
- [x] `windows`: basic, size == length, size > length, empty view, sliced view, backing-array sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
