### PR TITLE
refactor: Preallocate UTF-8 encoding output

### DIFF
--- a/encoding/utf8/encode.mbt
+++ b/encoding/utf8/encode.mbt
@@ -13,17 +13,83 @@
 // limitations under the License.
 
 ///|
-const U_BOM : Char = '\u{FEFF}'
+const UTF8_BOM_0 : Byte = b'\xEF'
+
+///|
+const UTF8_BOM_1 : Byte = b'\xBB'
+
+///|
+const UTF8_BOM_2 : Byte = b'\xBF'
 
 ///|
 /// Encodes a string into a UTF-8 byte array.
 /// 
-/// Panics if the string contains any invalid char (out of 0..=10FFFF)
+/// Panics if the string contains an invalid surrogate pair.
 pub fn encode(str : StringView, bom? : Bool = false) -> Bytes {
-  let buffer = @buffer.new(size_hint=str.length() * 4)
-  if bom is true {
-    buffer.write_char_utf8(U_BOM)
+  let length = str.length()
+  let utf8_length = for i = 0, utf8_length = 0; i < length; {
+    let code = str.unsafe_get(i)
+    if code < 0x80 {
+      continue i + 1, utf8_length + 1
+    } else if code < 0x800 {
+      continue i + 1, utf8_length + 2
+    } else if code.is_leading_surrogate() &&
+      i + 1 < length &&
+      str.unsafe_get(i + 1).is_trailing_surrogate() {
+      continue i + 2, utf8_length + 4
+    } else if code.is_surrogate() {
+      abort("invalid surrogate pair")
+    } else {
+      continue i + 1, utf8_length + 3
+    }
+  } nobreak {
+    if bom {
+      3 + utf8_length
+    } else {
+      utf8_length
+    }
   }
-  buffer.write_string_utf8(str)
-  buffer.to_bytes()
+
+  let arr = FixedArray::make(utf8_length, b'\x00')
+  for i = 0, offset = (if bom {
+          arr[0] = UTF8_BOM_0
+          arr[1] = UTF8_BOM_1
+          arr[2] = UTF8_BOM_2
+          3
+        } else {
+          0
+        }); i < length; {
+    let code_unit = str.unsafe_get(i)
+    let code = code_unit.to_int()
+    if code < 0x80 {
+      arr[offset] = code.to_byte()
+      continue i + 1, offset + 1
+    } else if code < 0x800 {
+      arr[offset] = (0xC0 + (code >> 6)).to_byte()
+      arr[offset + 1] = (0x80 + (code & 0x3F)).to_byte()
+      continue i + 1, offset + 2
+    } else if code_unit.is_leading_surrogate() && i + 1 < length {
+      let trailing = str.unsafe_get(i + 1)
+      if trailing.is_trailing_surrogate() {
+        let code = ((code - 0xD800) << 10) +
+          (trailing.to_int() - 0xDC00) +
+          0x10000
+        arr[offset] = (0xF0 + (code >> 18)).to_byte()
+        arr[offset + 1] = (0x80 + ((code >> 12) & 0x3F)).to_byte()
+        arr[offset + 2] = (0x80 + ((code >> 6) & 0x3F)).to_byte()
+        arr[offset + 3] = (0x80 + (code & 0x3F)).to_byte()
+        continue i + 2, offset + 4
+      } else {
+        abort("invalid surrogate pair")
+      }
+    } else if code_unit.is_surrogate() {
+      abort("invalid surrogate pair")
+    } else {
+      arr[offset] = (0xE0 + (code >> 12)).to_byte()
+      arr[offset + 1] = (0x80 + ((code >> 6) & 0x3F)).to_byte()
+      arr[offset + 2] = (0x80 + (code & 0x3F)).to_byte()
+      continue i + 1, offset + 3
+    }
+  }
+  arr.unsafe_reinterpret_as_bytes()
 }

--- a/encoding/utf8/encode_test.mbt
+++ b/encoding/utf8/encode_test.mbt
@@ -30,3 +30,36 @@ test "encode" {
     ),
   )
 }
+
+///|
+fn encode_via_buffer(str : StringView, bom : Bool) -> Bytes {
+  let buffer = @buffer.new(size_hint=str.length() * 4)
+  if bom {
+    buffer.write_char_utf8('\u{FEFF}')
+  }
+  buffer.write_string_utf8(str)
+  buffer.to_bytes()
+}
+
+///|
+test "encode matches previous buffer implementation" {
+  let sample = "abc你好👀"
+  assert_eq(@utf8.encode(sample), encode_via_buffer(sample, false))
+  assert_eq(@utf8.encode(sample, bom=true), encode_via_buffer(sample, true))
+
+  let view = "zabc你好👀w"[1:8]
+  assert_eq(@utf8.encode(view), encode_via_buffer(view, false))
+  assert_eq(@utf8.encode(view, bom=true), encode_via_buffer(view, true))
+}
+
+///|
+test "panic encode with invalid leading surrogate" {
+  let invalid = String::from_array([(0xD800).unsafe_to_char(), 'A'])
+  ignore(@utf8.encode(invalid))
+}
+
+///|
+test "panic encode with dangling trailing surrogate" {
+  let invalid = String::from_array(['A', (0xDC00).unsafe_to_char()])
+  ignore(@utf8.encode(invalid))
+}

--- a/encoding/utf8/moon.pkg
+++ b/encoding/utf8/moon.pkg
@@ -1,4 +1,7 @@
 import {
-  "moonbitlang/core/buffer",
   "moonbitlang/core/builtin",
 }
+
+import {
+  "moonbitlang/core/buffer",
+} for "test"


### PR DESCRIPTION
## Summary
- replace `@encoding/utf8.encode`'s buffer-based implementation with a two-pass encoder that sizes the UTF-8 output first and writes directly into one `FixedArray[Byte]`
- validate surrogate structure during encoding so malformed UTF-16 input aborts instead of being silently encoded
- add regression tests for valid encoding behavior and malformed surrogate panic cases

## Why
The previous implementation encoded through `Buffer::write_string_utf8`, which iterated by code point and paid repeated grow checks on the hot path. This change keeps the work at the UTF-16 code-unit level, does one preallocation, and then writes bytes directly.

## Impact
- improves UTF-16 -> UTF-8 encoding throughput
- preserves BOM behavior and existing output for valid inputs
- now rejects invalid surrogate pairs explicitly

## Validation
- `moon test encoding/utf8/encode_test.mbt --target all`
- `moon check encoding/utf8 --target all`
- `moon fmt`
- `moon info encoding/utf8`
- `moon bench -p tmp/utf8_encode_bench --target native --release`
- `moon bench -p tmp/utf8_encode_bench --target js --release`
- `moon bench -p tmp/utf8_encode_bench --target wasm --release`
- `moon bench -p tmp/utf8_encode_bench --target wasm-gc --release`

## Notes
The temporary `tmp/utf8_encode_bench` package used for measurement was removed before commit.