### PR TITLE
chore: fix byte literal deprecation warnings

### DIFF
--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -556,7 +556,7 @@ pub fn BytesView::to_double_le(self : BytesView) -> Double {
 pub impl Show for BytesView with output(self, logger) {
   logger.write_string("b\"")
   for byte in self {
-    if byte is (' '..='~') && byte != '"' && byte != '\\' {
+    if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
       logger.write_char(byte.to_char())
     } else {
       logger.write_string("\\x")
@@ -718,7 +718,7 @@ pub fn BytesView::to_bytes(self : BytesView) -> Bytes {
 pub impl ToJson for BytesView with to_json(self) -> Json {
   let sb = StringBuilder::new()
   for byte in self {
-    if byte is (' '..='~') && byte != '"' && byte != '\\' {
+    if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
       sb.write_char(byte.to_char())
     } else {
       sb.write_string("\\x")

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -109,9 +109,9 @@ pub impl Show for UInt16 with to_string(self) {
 pub fn Byte::to_hex(b : Byte) -> String {
   fn to_hex_digit(i : Byte) -> Char {
     if i < 10 {
-      (i + '0').to_char()
+      (i + b'0').to_char()
     } else {
-      (i + 'a' - 10).to_char()
+      (i + b'a' - 10).to_char()
     }
   }
 

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 ///|
-const HELLO : Bytes = "你好"
+const HELLO : Bytes = b"你好"
 
 ///|
 test "bytes literal" {
   inspect("ABC", content="ABC")
-  let b : Bytes = "你好"
+  let b : Bytes = b"你好"
   inspect(
-    b + "utf8" + HELLO,
+    b + b"utf8" + HELLO,
     content=(
       #|b"\xe4\xbd\xa0\xe5\xa5\xbdutf8\xe4\xbd\xa0\xe5\xa5\xbd"
     ),
@@ -242,12 +242,12 @@ test "panic Fixed::blit_from_bytesview 2" {
 
 ///|
 test "bytes pattern match" {
-  let bytes : Bytes = "Hello, world!你好"
+  let bytes : Bytes = b"Hello, world!你好"
   guard bytes is [.. b"Hello", ..] else { fail("") }
-  guard bytes is [.. _x, .. "你好"] && _x is [.. "Hello, world!", ..] else {
+  guard bytes is [.. _x, .. b"你好"] && _x is [.. b"Hello, world!", ..] else {
     fail("")
   }
-  guard bytes is [.., .. "你好"] else { fail("") }
+  guard bytes is [.., .. b"你好"] else { fail("") }
   // CR: ZYU: it's weird this works but below does not work
   // guard bytes is [.. _ , .. "你好"] else { fail("") }
 }

--- a/bytes/feature_pipe_test.mbt
+++ b/bytes/feature_pipe_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "feature pipe" {
-  let b : Bytes = "hello"
+  let b : Bytes = b"hello"
   let mut u = Bytes::new(b.length())
   let v = b
     |> x => {

--- a/bytes/find_test.mbt
+++ b/bytes/find_test.mbt
@@ -14,32 +14,32 @@
 
 ///|
 test "find" {
-  inspect(b"hello".find("o"), content="Some(4)")
-  inspect(b"hello".find("l"), content="Some(2)")
-  inspect(b"hello".find("hello"), content="Some(0)")
-  inspect(b"hello".find("h"), content="Some(0)")
-  inspect(b"hello".find(""), content="Some(0)")
-  inspect(b"hello".find("world"), content="None")
-  inspect(b"".find(""), content="Some(0)")
-  inspect(b"".find("a"), content="None")
-  inspect(b"hello hello".find("hello"), content="Some(0)")
-  inspect(b"aaa".find("aa"), content="Some(0)")
-  inspect(b"aabaabaaa".find("aaa"), content="Some(6)")
+  inspect(b"hello".find(b"o"), content="Some(4)")
+  inspect(b"hello".find(b"l"), content="Some(2)")
+  inspect(b"hello".find(b"hello"), content="Some(0)")
+  inspect(b"hello".find(b"h"), content="Some(0)")
+  inspect(b"hello".find(b""), content="Some(0)")
+  inspect(b"hello".find(b"world"), content="None")
+  inspect(b"".find(b""), content="Some(0)")
+  inspect(b"".find(b"a"), content="None")
+  inspect(b"hello hello".find(b"hello"), content="Some(0)")
+  inspect(b"aaa".find(b"aa"), content="Some(0)")
+  inspect(b"aabaabaaa".find(b"aaa"), content="Some(6)")
 }
 
 ///|
 test "rev_find" {
-  inspect(b"hello".rev_find("o"), content="Some(4)")
-  inspect(b"hello".rev_find("l"), content="Some(3)")
-  inspect(b"hello".rev_find("hello"), content="Some(0)")
-  inspect(b"hello".rev_find("h"), content="Some(0)")
-  inspect(b"hello".rev_find(""), content="Some(5)")
-  inspect(b"hello".rev_find("world"), content="None")
-  inspect(b"".rev_find(""), content="Some(0)")
-  inspect(b"".rev_find("a"), content="None")
-  inspect(b"hello hello".rev_find("hello"), content="Some(6)")
-  inspect(b"aaa".rev_find("aa"), content="Some(1)")
-  inspect(b"aabaaabaa".find("aaa"), content="Some(3)")
+  inspect(b"hello".rev_find(b"o"), content="Some(4)")
+  inspect(b"hello".rev_find(b"l"), content="Some(3)")
+  inspect(b"hello".rev_find(b"hello"), content="Some(0)")
+  inspect(b"hello".rev_find(b"h"), content="Some(0)")
+  inspect(b"hello".rev_find(b""), content="Some(5)")
+  inspect(b"hello".rev_find(b"world"), content="None")
+  inspect(b"".rev_find(b""), content="Some(0)")
+  inspect(b"".rev_find(b"a"), content="None")
+  inspect(b"hello hello".rev_find(b"hello"), content="Some(6)")
+  inspect(b"aaa".rev_find(b"aa"), content="Some(1)")
+  inspect(b"aabaaabaa".find(b"aaa"), content="Some(3)")
 }
 
 ///|

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -529,8 +529,8 @@ test "View::to_bytes" {
 
 ///|
 test "impl Hash for View" {
-  let b0 : Bytes = "12345678"
-  let b1 : Bytes = "56781234"
+  let b0 : Bytes = b"12345678"
+  let b1 : Bytes = b"56781234"
   assert_eq(b0[0:4].hash(), b1[4:8].hash())
   assert_eq(b0[4:8].hash(), b1[0:4].hash())
   assert_not_eq(b0[0:4].hash(), b1[0:4].hash())

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -31,9 +31,9 @@ pub fn decode(
   endianness? : Endian = Little,
 ) -> String raise Malformed {
   let bytes = if ignore_bom {
-    if endianness is Little && bytes is [.. "\xff\xfe", .. rest] {
+    if endianness is Little && bytes is [.. b"\xff\xfe", .. rest] {
       rest
-    } else if endianness is Big && bytes is [.. "\xfe\xff", .. rest] {
+    } else if endianness is Big && bytes is [.. b"\xfe\xff", .. rest] {
       rest
     } else {
       bytes
@@ -115,9 +115,9 @@ pub fn decode_lossy(
   endianness? : Endian = Little,
 ) -> String {
   let bytes = if ignore_bom {
-    if endianness is Little && bytes is [.. "\xff\xfe", .. rest] {
+    if endianness is Little && bytes is [.. b"\xff\xfe", .. rest] {
       rest
-    } else if endianness is Big && bytes is [.. "\xfe\xff", .. rest] {
+    } else if endianness is Big && bytes is [.. b"\xfe\xff", .. rest] {
       rest
     } else {
       bytes

--- a/encoding/utf8/decode.mbt
+++ b/encoding/utf8/decode.mbt
@@ -24,7 +24,7 @@ pub fn decode(
   bytes : BytesView,
   ignore_bom? : Bool = false,
 ) -> String raise Malformed {
-  let bytes = if ignore_bom && bytes is [.. "\xef\xbb\xbf", .. rest] {
+  let bytes = if ignore_bom && bytes is [.. b"\xef\xbb\xbf", .. rest] {
     rest
   } else {
     bytes
@@ -130,7 +130,7 @@ pub fn decode(
 /// - https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G66453
 /// - https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-5/#G40630
 pub fn decode_lossy(bytes : BytesView, ignore_bom? : Bool = false) -> String {
-  let bytes = if ignore_bom && bytes is [.. "\xef\xbb\xbf", .. rest] {
+  let bytes = if ignore_bom && bytes is [.. b"\xef\xbb\xbf", .. rest] {
     rest
   } else {
     bytes

--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -28,22 +28,22 @@ fn ParseContext::lex_value(
         ctx.invalid_char(shift=-1)
       }
     Some('n') => {
-      ctx.expect_ascii_char('u')
-      ctx.expect_ascii_char('l')
-      ctx.expect_ascii_char('l')
+      ctx.expect_ascii_char(b'u')
+      ctx.expect_ascii_char(b'l')
+      ctx.expect_ascii_char(b'l')
       return Null
     }
     Some('t') => {
-      ctx.expect_ascii_char('r')
-      ctx.expect_ascii_char('u')
-      ctx.expect_ascii_char('e')
+      ctx.expect_ascii_char(b'r')
+      ctx.expect_ascii_char(b'u')
+      ctx.expect_ascii_char(b'e')
       return True
     }
     Some('f') => {
-      ctx.expect_ascii_char('a')
-      ctx.expect_ascii_char('l')
-      ctx.expect_ascii_char('s')
-      ctx.expect_ascii_char('e')
+      ctx.expect_ascii_char(b'a')
+      ctx.expect_ascii_char(b'l')
+      ctx.expect_ascii_char(b's')
+      ctx.expect_ascii_char(b'e')
       return False
     }
     Some('-') =>


### PR DESCRIPTION
## Summary
- Replace deprecated char-as-Byte literal overloading with `b'x'` form
- Replace deprecated string-as-Bytes literal overloading with `b"..."` form
- Resolves all 58 `Warning (deprecated)` warnings from `moon check`

Files touched: `builtin/bytesview.mbt`, `builtin/show.mbt`, `bytes/{bytes,feature_pipe,find,view}_test.mbt`, `encoding/utf8/decode.mbt`, `encoding/utf16/decode.mbt`, `json/lex_main.mbt`.

## Test plan
- [x] `moon check` — deprecation warnings down from 58 to 0
- [x] `moon test` — 6319/6319 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
