### PR TITLE
style: remove unnecessary [:] view conversions

### DIFF
--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -628,7 +628,7 @@ test "to_string radix 16" {
 test "pow" {
   let x = 2N.pow(5664N).to_string(radix=16)
   assert_eq(x.get_char(0).unwrap(), '1')
-  assert_eq(x[1:], String::make(5664 / 4, '0')[:])
+  assert_eq(x[1:], String::make(5664 / 4, '0'))
 }
 
 ///|

--- a/buffer/README.mbt.md
+++ b/buffer/README.mbt.md
@@ -23,7 +23,7 @@ Create from existing data:
 test {
   let buf = @buffer.from_bytes(b"hello")
   assert_eq(buf.length(), 5)
-  let buf2 = @buffer.from_array([b'a', b'b', b'c'][:])
+  let buf2 = @buffer.from_array([b'a', b'b', b'c'])
   assert_eq(buf2.length(), 3)
   let buf3 = @buffer.from_iter(b"hi".iter())
   assert_eq(buf3.length(), 2)
@@ -129,7 +129,7 @@ test {
   // UTF-8
   let buf = @buffer.new()
   buf.write_char_utf8('A')
-  buf.write_string_utf8("BC"[:])
+  buf.write_string_utf8("BC")
   inspect(buf.to_bytes(), content="b\"ABC\"")
   // UTF-16 little-endian
   let buf2 = @buffer.new()
@@ -137,7 +137,7 @@ test {
   inspect(buf2.to_bytes(), content="b\"A\\x00\"")
   // UTF-16 big-endian
   let buf3 = @buffer.new()
-  buf3.write_string_utf16be("AB"[:])
+  buf3.write_string_utf16be("AB")
   inspect(buf3.to_bytes(), content="b\"\\x00A\\x00B\"")
 }
 ```

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -875,7 +875,7 @@ pub fn[T : Eq] Array::contains(self : Array[T], value : T) -> Bool {
 /// }
 /// ```
 pub fn[T : Eq] Array::starts_with(self : Array[T], prefix : Array[T]) -> Bool {
-  self[:].starts_with(prefix[:])
+  self[:].starts_with(prefix)
 }
 
 ///|
@@ -902,7 +902,7 @@ pub fn[T : Eq] Array::starts_with(self : Array[T], prefix : Array[T]) -> Bool {
 /// }
 /// ```
 pub fn[T : Eq] Array::ends_with(self : Array[T], suffix : Array[T]) -> Bool {
-  self[:].ends_with(suffix[:])
+  self[:].ends_with(suffix)
 }
 
 ///|
@@ -2122,5 +2122,5 @@ pub fn[T : Compare] Array::lexical_compare(
   self : Array[T],
   other : Array[T],
 ) -> Int {
-  self[:].lexical_compare(other[:])
+  self[:].lexical_compare(other)
 }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -1361,7 +1361,7 @@ test "Array::append/self_alias" {
   arr.push(1)
   arr.push(2)
   arr.push(3)
-  arr.append(arr[:])
+  arr.append(arr)
   inspect(arr, content="[1, 2, 3, 1, 2, 3]")
 }
 

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -968,8 +968,8 @@ pub fn[T] ArrayView::search_by(
 /// ```mbt check
 /// test {
 ///   let view = [1, 2, 3, 4, 5][:]
-///   inspect(view.starts_with([1, 2][:]), content="true")
-///   inspect(view.starts_with([2, 3][:]), content="false")
+///   inspect(view.starts_with([1, 2]), content="true")
+///   inspect(view.starts_with([2, 3]), content="false")
 /// }
 /// ```
 pub fn[T : Eq] ArrayView::starts_with(
@@ -995,8 +995,8 @@ pub fn[T : Eq] ArrayView::starts_with(
 /// ```mbt check
 /// test {
 ///   let view = [1, 2, 3, 4, 5][:]
-///   inspect(view.ends_with([4, 5][:]), content="true")
-///   inspect(view.ends_with([3, 4][:]), content="false")
+///   inspect(view.ends_with([4, 5]), content="true")
+///   inspect(view.ends_with([3, 4]), content="false")
 /// }
 /// ```
 pub fn[T : Eq] ArrayView::ends_with(
@@ -1357,10 +1357,10 @@ pub fn[A : ToStringView] ArrayView::join(
 ///
 /// ```mbt check
 /// test {
-///   inspect([1, 2][:].lexical_compare([1, 2, 3][:]), content="-1")
-///   inspect([1, 2, 3][:].lexical_compare([1, 2][:]), content="1")
-///   inspect([1, 2, 3][:].lexical_compare([1, 2, 3][:]), content="0")
-///   inspect([1, 2, 3][:].lexical_compare([1, 2, 4][:]), content="-1")
+///   inspect([1, 2][:].lexical_compare([1, 2, 3]), content="-1")
+///   inspect([1, 2, 3][:].lexical_compare([1, 2]), content="1")
+///   inspect([1, 2, 3][:].lexical_compare([1, 2, 3]), content="0")
+///   inspect([1, 2, 3][:].lexical_compare([1, 2, 4]), content="-1")
 /// }
 /// ```
 pub fn[T : Compare] ArrayView::lexical_compare(
@@ -1483,7 +1483,7 @@ pub impl[T] Add for ArrayView[T] with add(self, other) {
     other.start(),
     len_other,
   )
-  result[:]
+  result
 }
 
 // #endregion

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -280,41 +280,41 @@ test "equal" {
 
 ///|
 test "compare" {
-  assert_eq([1, 2, 4][:].compare([1, 2, 3][:]), 1)
-  assert_eq([-1, 2, 4][:].compare([1, 2, 4][:]), -1)
-  assert_eq([1, 2, 3][:].compare([1, 2, 3][:]), 0)
-  assert_eq([1, 2, 0][:].compare([1, 2][:]), 1)
-  assert_eq([1, 2][:].compare([1, 2, 0][:]), -1)
+  assert_eq([1, 2, 4][:].compare([1, 2, 3]), 1)
+  assert_eq([-1, 2, 4][:].compare([1, 2, 4]), -1)
+  assert_eq([1, 2, 3][:].compare([1, 2, 3]), 0)
+  assert_eq([1, 2, 0][:].compare([1, 2]), 1)
+  assert_eq([1, 2][:].compare([1, 2, 0]), -1)
 }
 
 ///|
 test "lexical_compare" {
   // Test equal arrays
-  inspect([1, 2, 3][:].lexical_compare([1, 2, 3][:]), content="0")
+  inspect([1, 2, 3][:].lexical_compare([1, 2, 3]), content="0")
   inspect(
     ([] : Array[Int])[0:0].lexical_compare(([] : Array[Int])[0:0]),
     content="0",
   )
 
   // Test shorter is less when prefix matches
-  inspect([1, 2][:].lexical_compare([1, 2, 3][:]), content="-1")
-  inspect([1, 2, 3][:].lexical_compare([1, 2][:]), content="1")
-  inspect(([] : Array[Int])[0:0].lexical_compare([1][:]), content="-1")
+  inspect([1, 2][:].lexical_compare([1, 2, 3]), content="-1")
+  inspect([1, 2, 3][:].lexical_compare([1, 2]), content="1")
+  inspect(([] : Array[Int])[0:0].lexical_compare([1]), content="-1")
   inspect([1][:].lexical_compare(([] : Array[Int])[0:0]), content="1")
 
   // Test element-wise comparison (differs from shortlex)
-  inspect([1, 2, 3][:].lexical_compare([1, 2, 4][:]), content="-1")
-  inspect([1, 2, 4][:].lexical_compare([1, 2, 3][:]), content="1")
+  inspect([1, 2, 3][:].lexical_compare([1, 2, 4]), content="-1")
+  inspect([1, 2, 4][:].lexical_compare([1, 2, 3]), content="1")
 
   // Key difference from Compare trait: lexical compares elements first, not length
   // Compare trait: [1, 2, 0].compare([1, 2]) == 1 (longer is greater by shortlex)
   // lexical_compare: [1, 2, 0].lexical_compare([1, 2]) == 1 (longer is greater since prefix matches)
-  inspect([1, 2, 0][:].lexical_compare([1, 2][:]), content="1")
+  inspect([1, 2, 0][:].lexical_compare([1, 2]), content="1")
 
   // Elements are compared before considering length
   // [1, 3] > [1, 2, 9] because 3 > 2 at position 1
-  inspect([1, 3][:].lexical_compare([1, 2, 9][:]), content="1")
-  inspect([1, 2, 9][:].lexical_compare([1, 3][:]), content="-1")
+  inspect([1, 3][:].lexical_compare([1, 2, 9]), content="1")
+  inspect([1, 2, 9][:].lexical_compare([1, 3]), content="-1")
 }
 
 ///|
@@ -554,7 +554,7 @@ test "ArrayView::op_add result is independent of source mutation" {
 test "ArrayView::op_add full slice equals Array Add" {
   let a = [1, 2, 3]
   let b = [4, 5, 6]
-  let view_sum = a[:] + b[:]
+  let view_sum = a[:] + b
   let array_sum = a + b
   assert_eq(view_sum.length(), array_sum.length())
   for i in 0..<view_sum.length() {
@@ -593,7 +593,7 @@ test "ArrayView::op_add large" {
   let n = 100
   let a = Array::makei(n, i => i)
   let b = Array::makei(n, i => i + n)
-  let result = a[:] + b[:]
+  let result = a[:] + b
   assert_eq(result.length(), 2 * n)
   for i in 0..<(2 * n) {
     assert_eq(result[i], i)

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -861,5 +861,5 @@ pub fn Bytes::repeat(self : Self, count : Int) -> Bytes {
 /// }
 /// ```
 pub fn Bytes::lexical_compare(self : Bytes, other : Bytes) -> Int {
-  self[:].lexical_compare(other[:])
+  self[:].lexical_compare(other)
 }

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -369,54 +369,54 @@ test "BytesView::lexical_compare/basic" {
   // Test element-wise comparison
   let a = b"\x01\x02\x03"
   let b = b"\x01\x02\x04"
-  inspect(a[:].lexical_compare(b[:]), content="-1")
-  inspect(b[:].lexical_compare(a[:]), content="1")
+  inspect(a[:].lexical_compare(b), content="-1")
+  inspect(b[:].lexical_compare(a), content="1")
 
   // Elements are compared before considering length
   let short_higher = b"\x01\x03"
   let long_lower = b"\x01\x02\x09"
-  inspect(short_higher[:].lexical_compare(long_lower[:]), content="1")
-  inspect(long_lower[:].lexical_compare(short_higher[:]), content="-1")
+  inspect(short_higher[:].lexical_compare(long_lower), content="1")
+  inspect(long_lower[:].lexical_compare(short_higher), content="-1")
 }
 
 ///|
 test "Bytes find and rev_find" {
   let target = b"abcabc"
   let pattern = b"abc"
-  inspect(target.find(pattern[:]), content="Some(0)")
-  inspect(target.rev_find(pattern[:]), content="Some(3)")
-  inspect(target.find(b"zzz"[:]), content="None")
-  inspect(target[:].find(b"bca"[:]), content="Some(1)")
-  inspect(target[:].rev_find(b"bca"[:]), content="Some(1)")
+  inspect(target.find(pattern), content="Some(0)")
+  inspect(target.rev_find(pattern), content="Some(3)")
+  inspect(target.find(b"zzz"), content="None")
+  inspect(target[:].find(b"bca"), content="Some(1)")
+  inspect(target[:].rev_find(b"bca"), content="Some(1)")
 }
 
 ///|
 test "Bytes has_prefix/has_suffix/chop" {
   let bytes = b"hello"
-  inspect(bytes.has_prefix(b"h"[:]), content="true")
-  inspect(bytes.has_prefix(b"he"[:]), content="true")
-  inspect(bytes.has_prefix(b""[:]), content="true")
-  inspect(bytes.has_prefix(b"hello"[:]), content="true")
-  inspect(bytes.has_prefix(b"world"[:]), content="false")
-  inspect(bytes.has_suffix(b"o"[:]), content="true")
-  inspect(bytes.has_suffix(b"lo"[:]), content="true")
-  inspect(bytes.has_suffix(b""[:]), content="true")
-  inspect(bytes.has_suffix(b"hello"[:]), content="true")
-  inspect(bytes.has_suffix(b"hel"[:]), content="false")
+  inspect(bytes.has_prefix(b"h"), content="true")
+  inspect(bytes.has_prefix(b"he"), content="true")
+  inspect(bytes.has_prefix(b""), content="true")
+  inspect(bytes.has_prefix(b"hello"), content="true")
+  inspect(bytes.has_prefix(b"world"), content="false")
+  inspect(bytes.has_suffix(b"o"), content="true")
+  inspect(bytes.has_suffix(b"lo"), content="true")
+  inspect(bytes.has_suffix(b""), content="true")
+  inspect(bytes.has_suffix(b"hello"), content="true")
+  inspect(bytes.has_suffix(b"hel"), content="false")
   let view = bytes[1:4]
-  inspect(view.has_prefix(b"ell"[:]), content="true")
-  inspect(view.has_suffix(b"ell"[:]), content="true")
-  inspect(view.has_prefix(b"el"[:]), content="true")
-  inspect(view.has_suffix(b"ll"[:]), content="true")
-  inspect(view.has_prefix(b"ll"[:]), content="false")
-  inspect(view.chop_prefix(b"el"[:]), content="Some(b\"l\")")
-  inspect(view.chop_suffix(b"ll"[:]), content="Some(b\"e\")")
-  inspect(view.chop_prefix(b""[:]), content="Some(b\"ell\")")
-  inspect(view.chop_suffix(b""[:]), content="Some(b\"ell\")")
-  inspect(bytes.chop_prefix(b"he"[:]), content="Some(b\"llo\")")
-  inspect(bytes.chop_suffix(b"lo"[:]), content="Some(b\"hel\")")
-  inspect(bytes.chop_prefix(b"zz"[:]), content="None")
-  inspect(bytes.chop_suffix(b"zz"[:]), content="None")
+  inspect(view.has_prefix(b"ell"), content="true")
+  inspect(view.has_suffix(b"ell"), content="true")
+  inspect(view.has_prefix(b"el"), content="true")
+  inspect(view.has_suffix(b"ll"), content="true")
+  inspect(view.has_prefix(b"ll"), content="false")
+  inspect(view.chop_prefix(b"el"), content="Some(b\"l\")")
+  inspect(view.chop_suffix(b"ll"), content="Some(b\"e\")")
+  inspect(view.chop_prefix(b""), content="Some(b\"ell\")")
+  inspect(view.chop_suffix(b""), content="Some(b\"ell\")")
+  inspect(bytes.chop_prefix(b"he"), content="Some(b\"llo\")")
+  inspect(bytes.chop_suffix(b"lo"), content="Some(b\"hel\")")
+  inspect(bytes.chop_prefix(b"zz"), content="None")
+  inspect(bytes.chop_suffix(b"zz"), content="None")
 }
 
 ///|

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -619,7 +619,7 @@ pub impl Show for BytesView with output(self, logger) {
 
 ///|
 pub impl Show for Bytes with output(self, logger) {
-  BytesView::output(self[:], logger)
+  BytesView::output(self, logger)
 }
 
 ///|
@@ -710,10 +710,10 @@ pub impl Compare for BytesView with compare(self, other) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   inspect(b"\x01\x02"[:].lexical_compare(b"\x01\x02\x03"[:]), content="-1")
-///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02"[:]), content="1")
-///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x03"[:]), content="0")
-///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x04"[:]), content="-1")
+///   inspect(b"\x01\x02"[:].lexical_compare(b"\x01\x02\x03"), content="-1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02"), content="1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x03"), content="0")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x04"), content="-1")
 /// }
 /// ```
 pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
@@ -785,5 +785,5 @@ pub impl ToJson for BytesView with to_json(self) -> Json {
 /// Printable ASCII characters (from space to tilde, excluding '"' and '\') are output as-is.
 /// All other bytes are represented as \xHH, where HH is the two-digit hexadecimal value of the byte.
 pub impl ToJson for Bytes with to_json(self : Bytes) -> Json {
-  BytesView::to_json(self[:])
+  BytesView::to_json(self)
 }

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1090,7 +1090,7 @@ pub fn[T : Eq] FixedArray::starts_with(
   self : FixedArray[T],
   prefix : FixedArray[T],
 ) -> Bool {
-  self[:].starts_with(prefix[:])
+  self[:].starts_with(prefix)
 }
 
 ///|
@@ -1132,7 +1132,7 @@ pub fn[T : Eq] FixedArray::ends_with(
   self : FixedArray[T],
   suffix : FixedArray[T],
 ) -> Bool {
-  self[:].ends_with(suffix[:])
+  self[:].ends_with(suffix)
 }
 
 ///|
@@ -1621,5 +1621,5 @@ pub fn[T : Compare] FixedArray::lexical_compare(
   self : FixedArray[T],
   other : FixedArray[T],
 ) -> Int {
-  self[:].lexical_compare(other[:])
+  self[:].lexical_compare(other)
 }

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -79,13 +79,13 @@ test "Map::from_iter" {
 ///|
 test "Map::get_from_view" {
   let string_map : Map[String, Int] = { "alpha": 1, "beta": 2 }
-  inspect(Map::get_from_string(string_map, "alp"[:]), content="None")
-  inspect(Map::get_from_string(string_map, "alphx"[:]), content="None")
-  inspect(Map::get_from_string(string_map, "alpha"[:]), content="Some(1)")
+  inspect(Map::get_from_string(string_map, "alp"), content="None")
+  inspect(Map::get_from_string(string_map, "alphx"), content="None")
+  inspect(Map::get_from_string(string_map, "alpha"), content="Some(1)")
   let bytes_map : Map[Bytes, Int] = { b"abc": 10, b"xyz": 20 }
-  inspect(Map::get_from_bytes(bytes_map, b"ab"[:]), content="None")
-  inspect(Map::get_from_bytes(bytes_map, b"abd"[:]), content="None")
-  inspect(Map::get_from_bytes(bytes_map, b"abc"[:]), content="Some(10)")
+  inspect(Map::get_from_bytes(bytes_map, b"ab"), content="None")
+  inspect(Map::get_from_bytes(bytes_map, b"abd"), content="None")
+  inspect(Map::get_from_bytes(bytes_map, b"abc"), content="Some(10)")
 }
 
 ///|

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -451,12 +451,12 @@ pub impl[X : Show] Show for MutArrayView[X] with output(self, logger) {
 
 ///|
 pub impl[T : Eq] Eq for MutArrayView[T] with equal(self, other) -> Bool {
-  self[:] == other[:]
+  self[:] == other
 }
 
 ///|
 pub impl[T : Compare] Compare for MutArrayView[T] with compare(self, other) -> Int {
-  self[:].compare(other[:])
+  self[:].compare(other)
 }
 
 ///|

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -493,7 +493,7 @@ pub fn String::char_length_ge(
 /// UTF-16 code units, not Unicode code points. Surrogate pairs (used for characters
 /// outside the Basic Multilingual Plane) are compared as individual code units.
 pub fn String::lexical_compare(self : String, other : String) -> Int {
-  self[:].lexical_compare(other[:])
+  self[:].lexical_compare(other)
 }
 
 ///|
@@ -530,7 +530,7 @@ pub fn String::lexical_compare(self : String, other : String) -> Int {
 /// }
 /// ```
 pub fn String::compare_ignore_ascii_case(self : String, other : String) -> Int {
-  self[:].compare_ignore_ascii_case(other[:])
+  self[:].compare_ignore_ascii_case(other)
 }
 
 ///|
@@ -558,7 +558,7 @@ pub fn String::compare_ignore_ascii_case(self : String, other : String) -> Int {
 /// }
 /// ```
 pub fn String::equal_ignore_ascii_case(self : String, other : String) -> Bool {
-  self[:].equal_ignore_ascii_case(other[:])
+  self[:].equal_ignore_ascii_case(other)
 }
 
 ///|

--- a/builtin/string_like.mbt
+++ b/builtin/string_like.mbt
@@ -22,7 +22,7 @@ pub trait ToStringView {
 
 ///|
 pub impl ToStringView for String with to_string_view(self) -> StringView {
-  self[:]
+  self
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -86,14 +86,14 @@ fn boyer_moore_horspool_find(
 
 ///|
 test "boyer_moore_horspool_find edge cases" {
-  inspect(boyer_moore_horspool_find("abc"[:], ""[:]), content="Some(0)")
-  inspect(boyer_moore_horspool_find("ab"[:], "abcd"[:]), content="None")
+  inspect(boyer_moore_horspool_find("abc", ""), content="Some(0)")
+  inspect(boyer_moore_horspool_find("ab", "abcd"), content="None")
 }
 
 ///|
 test "boyer_moore_horspool_rev_find edge cases" {
-  inspect(boyer_moore_horspool_rev_find("abc"[:], ""[:]), content="Some(3)")
-  inspect(boyer_moore_horspool_rev_find("ab"[:], "abcd"[:]), content="None")
+  inspect(boyer_moore_horspool_rev_find("abc", ""), content="Some(3)")
+  inspect(boyer_moore_horspool_rev_find("ab", "abcd"), content="None")
 }
 
 ///|

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -84,7 +84,7 @@ test "StringView core operations" {
   let make_view = StringView::make(3, 'a')
   inspect(make_view.to_string(), content="aaa")
   inspect(StringView::default(), content="")
-  inspect(("hi"[:] + "!"[:]).to_string(), content="hi!")
+  inspect(("hi"[:] + "!").to_string(), content="hi!")
   inspect(view.offset_of_nth_char(1), content="Some(1)")
   inspect(view.offset_of_nth_char(3), content="None")
 }
@@ -157,7 +157,7 @@ test "panic String::view invalid range" {
 test "StringView iter2 and eq length mismatch" {
   let view = "abc"[:]
   inspect(view.iter2().to_string(), content="[(0, 'a'), (1, 'b'), (2, 'c')]")
-  inspect(view == "ab"[:], content="false")
+  inspect(view == "ab", content="false")
 }
 
 ///|

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -105,7 +105,7 @@ impl Logger with write_substring(self, value, start, len) {
 
 ///|
 impl Logger with write_string(self, value) {
-  self.write_view(value[:])
+  self.write_view(value)
 }
 
 ///|

--- a/bytes/README.mbt.md
+++ b/bytes/README.mbt.md
@@ -165,10 +165,10 @@ You can check for prefixes and suffixes or remove them when present:
 ///|
 test "bytes prefix/suffix" {
   let bytes = b"hello"
-  inspect(bytes.has_prefix(b"he"[:]), content="true")
-  inspect(bytes.has_suffix(b"lo"[:]), content="true")
-  inspect(bytes.chop_prefix(b"he"[:]), content="Some(b\"llo\")")
-  inspect(bytes.chop_suffix(b"lo"[:]), content="Some(b\"hel\")")
-  inspect(bytes.chop_prefix(b"zz"[:]), content="None")
+  inspect(bytes.has_prefix(b"he"), content="true")
+  inspect(bytes.has_suffix(b"lo"), content="true")
+  inspect(bytes.chop_prefix(b"he"), content="Some(b\"llo\")")
+  inspect(bytes.chop_suffix(b"lo"), content="Some(b\"hel\")")
+  inspect(bytes.chop_prefix(b"zz"), content="None")
 }
 ```

--- a/bytes/bitstring_pcap_test.mbt
+++ b/bytes/bitstring_pcap_test.mbt
@@ -114,7 +114,7 @@ fn pcap_ipv4_test(ipv4 : BytesView) -> Unit raise {
 
 ///|
 test "pcap_test" {
-  inspect(try? pcap_test(data[:]), content="Ok(())")
+  inspect(try? pcap_test(data), content="Ok(())")
 }
 
 ///|

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -113,14 +113,14 @@ pub impl[T : Debug] Debug for ArrayView[T] with to_repr(self) {
 ///|
 pub impl[T : Debug] Debug for FixedArray[T] with to_repr(self) {
   // `FixedArray` can be viewed as `ArrayView` via slicing.
-  let view : ArrayView[T] = self[:]
+  let view : ArrayView[T] = self
   Repr::opaque_("FixedArray", Repr::array(view.map(x => to_repr(x))))
 }
 
 ///|
 pub impl[T : Debug] Debug for ReadOnlyArray[T] with to_repr(self) {
   // `ReadOnlyArray` can be viewed as `ArrayView` via slicing.
-  let view : ArrayView[T] = self[:]
+  let view : ArrayView[T] = self
   Repr::opaque_("ReadOnlyArray", Repr::array(view.map(x => to_repr(x))))
 }
 
@@ -284,9 +284,9 @@ test "core builtin Debug implementations" {
   debug_inspect((1.0 : Float), content="1")
   let b : Bytes = b"ab"
   debug_inspect(b, content="<Bytes: [0x61, 0x62]>")
-  let bv : BytesView = b[:]
+  let bv : BytesView = b
   debug_inspect(bv, content="<BytesView: [0x61, 0x62]>")
-  let sv : StringView = "abc"[:]
+  let sv : StringView = "abc"
   debug_inspect(
     sv,
     content=(

--- a/deque/README.mbt.md
+++ b/deque/README.mbt.md
@@ -306,7 +306,7 @@ test {
   ])
   inspect(nested.flatten(), content="@deque.from_array([1, 2, 3, 4])")
   let words = @deque.from_array(["hello", "world"])
-  inspect(words.join(", "[:]), content="hello, world")
+  inspect(words.join(", "), content="hello, world")
 }
 ```
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -851,12 +851,12 @@ pub fn[A] Deque::set(self : Deque[A], index : Int, value : A) -> Unit {
 /// }
 /// ```
 pub fn[A] Deque::as_views(self : Deque[A]) -> (ArrayView[A], ArrayView[A]) {
-  guard self.len != 0 else { ([][:], [][:]) }
+  guard self.len != 0 else { ([], []) }
   let { buf, head, len } = self
   let cap = buf.length()
   let head_len = cap - head
   if head_len >= len {
-    (buf[head:head + len], [][:])
+    (buf[head:head + len], [])
   } else {
     (buf[head:cap], buf[:len - head_len])
   }

--- a/encoding/ascii/README.mbt.md
+++ b/encoding/ascii/README.mbt.md
@@ -9,7 +9,7 @@ Use `encode` to convert a string to ASCII bytes. Panics if the string contains n
 ```mbt check
 ///|
 test "encode" {
-  let bytes = @ascii.encode("hello"[:])
+  let bytes = @ascii.encode("hello")
   inspect(bytes, content="b\"hello\"")
 }
 ```
@@ -22,7 +22,7 @@ Use `decode` to convert ASCII bytes back to a string. Raises `Malformed` if any 
 ///|
 test "decode" {
   let bytes : Bytes = b"\x68\x65\x6C\x6C\x6F"
-  let s = @ascii.decode(bytes[:])
+  let s = @ascii.decode(bytes)
   inspect(s, content="hello")
 }
 ```
@@ -35,7 +35,7 @@ Use `decode_lossy` to decode bytes that may contain invalid ASCII, replacing inv
 ///|
 test "decode_lossy" {
   let bytes : Bytes = b"\x68\x80\x6F"
-  let s = @ascii.decode_lossy(bytes[:])
+  let s = @ascii.decode_lossy(bytes)
   inspect(s, content="h\u{FFFD}o")
 }
 ```

--- a/encoding/base64/README.mbt.md
+++ b/encoding/base64/README.mbt.md
@@ -10,7 +10,7 @@ Use `encode` to convert bytes to a Base64 string. Padding with `=` is enabled by
 ///|
 test "encode" {
   let bytes : Bytes = b"Hello"
-  inspect(@base64.encode(bytes[:]), content="SGVsbG8=")
+  inspect(@base64.encode(bytes), content="SGVsbG8=")
 }
 ```
 
@@ -20,7 +20,7 @@ Disable padding by setting `padding=false`:
 ///|
 test "encode_no_padding" {
   let bytes : Bytes = b"Hello"
-  inspect(@base64.encode(bytes[:], padding=false), content="SGVsbG8")
+  inspect(@base64.encode(bytes, padding=false), content="SGVsbG8")
 }
 ```
 
@@ -31,7 +31,7 @@ Use `decode` to convert a Base64 string back to bytes. Both padded and unpadded 
 ```mbt check
 ///|
 test "decode" {
-  let bytes = @base64.decode("SGVsbG8="[:])
+  let bytes = @base64.decode("SGVsbG8=")
   inspect(bytes, content="b\"Hello\"")
 }
 ```
@@ -41,7 +41,7 @@ Set `ignore_whitespace=true` to skip ASCII whitespace in the input:
 ```mbt check
 ///|
 test "decode_ignore_whitespace" {
-  let bytes = @base64.decode("SGVs bG8="[:], ignore_whitespace=true)
+  let bytes = @base64.decode("SGVs bG8=", ignore_whitespace=true)
   inspect(bytes, content="b\"Hello\"")
 }
 ```
@@ -53,7 +53,7 @@ Use `decode_lossy` to decode Base64 while skipping invalid characters instead of
 ```mbt check
 ///|
 test "decode_lossy" {
-  let bytes = @base64.decode_lossy("SGVsbG8="[:])
+  let bytes = @base64.decode_lossy("SGVsbG8=")
   inspect(bytes, content="b\"Hello\"")
 }
 ```

--- a/encoding/utf16/README.mbt.md
+++ b/encoding/utf16/README.mbt.md
@@ -9,7 +9,7 @@ Use `encode` to convert a string to UTF-16 bytes. Default endianness is little-e
 ```mbt check
 ///|
 test "encode" {
-  let bytes = @utf16.encode("hi"[:])
+  let bytes = @utf16.encode("hi")
   inspect(bytes, content="b\"h\\x00i\\x00\"")
 }
 ```
@@ -19,7 +19,7 @@ Use `endianness` to specify byte order and `bom=true` to prepend a Byte Order Ma
 ```mbt check
 ///|
 test "encode_big_endian_with_bom" {
-  let bytes = @utf16.encode("hi"[:], endianness=Big, bom=true)
+  let bytes = @utf16.encode("hi", endianness=Big, bom=true)
   inspect(bytes, content="b\"\\xfe\\xff\\x00h\\x00i\"")
 }
 ```
@@ -32,7 +32,7 @@ Use `decode` to convert UTF-16 bytes back to a string. Raises `Malformed` on inv
 ///|
 test "decode" {
   let bytes : Bytes = b"\x68\x00\x69\x00"
-  let s = @utf16.decode(bytes[:])
+  let s = @utf16.decode(bytes)
   inspect(s, content="hi")
 }
 ```
@@ -43,7 +43,7 @@ Set `ignore_bom=true` to strip a leading BOM, or use `endianness` to specify the
 ///|
 test "decode_big_endian" {
   let bytes : Bytes = b"\x00\x68\x00\x69"
-  let s = @utf16.decode(bytes[:], endianness=Big)
+  let s = @utf16.decode(bytes, endianness=Big)
   inspect(s, content="hi")
 }
 ```
@@ -56,7 +56,7 @@ Use `decode_lossy` to decode bytes that may contain invalid UTF-16, replacing in
 ///|
 test "decode_lossy" {
   let bytes : Bytes = b"\x00\xD8\x68\x00"
-  let s = @utf16.decode_lossy(bytes[:])
+  let s = @utf16.decode_lossy(bytes)
   inspect(s, content="\u{FFFD}h")
 }
 ```

--- a/encoding/utf8/README.mbt.md
+++ b/encoding/utf8/README.mbt.md
@@ -9,7 +9,7 @@ Use `encode` to convert a string to UTF-8 bytes. Set `bom=true` to prepend the U
 ```mbt check
 ///|
 test "encode" {
-  let bytes = @utf8.encode("hi"[:])
+  let bytes = @utf8.encode("hi")
   inspect(bytes, content="b\"hi\"")
 }
 ```
@@ -17,7 +17,7 @@ test "encode" {
 ```mbt check
 ///|
 test "encode_with_bom" {
-  let bytes = @utf8.encode("hi"[:], bom=true)
+  let bytes = @utf8.encode("hi", bom=true)
   inspect(bytes, content="b\"\\xef\\xbb\\xbfhi\"")
 }
 ```
@@ -30,7 +30,7 @@ Use `decode` to convert UTF-8 bytes back to a string. Raises `Malformed` on inva
 ///|
 test "decode" {
   let bytes : Bytes = b"\x68\x69"
-  let s = @utf8.decode(bytes[:])
+  let s = @utf8.decode(bytes)
   inspect(s, content="hi")
 }
 ```
@@ -43,7 +43,7 @@ Use `decode_lossy` to decode bytes that may contain invalid UTF-8, replacing inv
 ///|
 test "decode_lossy" {
   let bytes : Bytes = b"\x68\x80\x69"
-  let s = @utf8.decode_lossy(bytes[:])
+  let s = @utf8.decode_lossy(bytes)
   inspect(s, content="h\u{FFFD}i")
 }
 ```

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -43,7 +43,7 @@ pub fn[A] T::make(len : Int, value : A) -> T[A] {
   }
   let size = len
   let (shift, cap) = shift_cap_of_size(size)
-  let tree = if size == 0 { Empty } else { from_leaves(leaves[:], cap) }
+  let tree = if size == 0 { Empty } else { from_leaves(leaves, cap) }
   { shift, tree, size }
 }
 
@@ -70,7 +70,7 @@ pub fn[A] T::makei(len : Int, f : (Int) -> A raise?) -> T[A] raise? {
   }
   let size = len
   let (shift, cap) = shift_cap_of_size(size)
-  let tree = if size == 0 { Empty } else { from_leaves(leaves[:], cap) }
+  let tree = if size == 0 { Empty } else { from_leaves(leaves, cap) }
   { shift, tree, size }
 }
 
@@ -124,7 +124,7 @@ pub fn[A] T::from_iter(iter : Iter[A]) -> T[A] {
   }
   let size = leaves.fold(init=0, (acc, xs) => acc + xs.length())
   let (shift, cap) = shift_cap_of_size(size)
-  let tree = if size == 0 { Empty } else { from_leaves(leaves[:], cap) }
+  let tree = if size == 0 { Empty } else { from_leaves(leaves, cap) }
   { shift, tree, size }
 }
 

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -486,7 +486,7 @@ test "range with early termination" {
 ///|
 test "range on large dataset" {
   let arr = Array::makei(100, fn(i) { (i, "val\{i}") })
-  let map = @sorted_map.from_array(arr[:])
+  let map = @sorted_map.from_array(arr)
   let count = for _, _ in map.range(low=25, high=75); count = 0 {
     continue count + 1
   } nobreak {

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -806,7 +806,7 @@ test "range with early termination" {
 ///|
 test "range on large dataset" {
   let arr = Array::makei(100, fn(i) { i })
-  let set = @sorted_set.from_array(arr[:])
+  let set = @sorted_set.from_array(arr)
   let count = for _ in set.range(low=25, high=75); count = 0 {
     continue count + 1
   } nobreak {

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -55,7 +55,7 @@ pub fn[A] Vector::make(len : Int, value : A) -> Vector[A] {
       FixedArray::make(branching_factor, value),
     )
     let (shift, cap) = shift_cap_of_size(tree_len)
-    (from_leaves(leaves[:], cap), shift)
+    (from_leaves(leaves, cap), shift)
   }
   make_t(tree, tail, len, shift)
 }
@@ -79,7 +79,7 @@ pub fn[A] Vector::makei(len : Int, f : (Int) -> A raise?) -> Vector[A] raise? {
       })
     }
     let (shift, cap) = shift_cap_of_size(tree_len)
-    (from_leaves(leaves[:], cap), shift)
+    (from_leaves(leaves, cap), shift)
   }
   make_t(tree, tail, len, shift)
 }
@@ -143,7 +143,7 @@ pub fn[A] Vector::from_iter(iter : Iter[A]) -> Vector[A] {
     (Tree::empty(), 0)
   } else {
     let (shift, cap) = shift_cap_of_size(tree_len)
-    (from_leaves(leaves[:], cap), shift)
+    (from_leaves(leaves, cap), shift)
   }
   make_t(tree, tail, tree_len + tail.length(), shift)
 }

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -147,7 +147,7 @@ pub impl FromJson for StringView with from_json(json, path) {
   guard json is String(a) else {
     decode_error(path, "View::from_json: expected string")
   }
-  a[:]
+  a
 }
 
 ///|

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -166,7 +166,7 @@ pub impl[X : Arbitrary] Arbitrary for FixedArray[X] with arbitrary(size, rs) {
 pub impl[A : Arbitrary] Arbitrary for ArrayView[A] with arbitrary(size, rs) {
   let arr : Array[A] = Arbitrary::arbitrary(size, rs)
   // Note can not use Array::arbitrary
-  arr[:]
+  arr
 }
 
 ///|

--- a/strconv/README.mbt.md
+++ b/strconv/README.mbt.md
@@ -12,9 +12,9 @@ Parse integers in various bases:
 ///|
 #warnings("-deprecated")
 test "parse_int" {
-  inspect(@strconv.parse_int("42"[:]), content="42")
-  inspect(@strconv.parse_int("101"[:], base=2), content="5")
-  inspect(@strconv.parse_int("ff"[:], base=16), content="255")
+  inspect(@strconv.parse_int("42"), content="42")
+  inspect(@strconv.parse_int("101", base=2), content="5")
+  inspect(@strconv.parse_int("ff", base=16), content="255")
 }
 ```
 
@@ -25,12 +25,12 @@ Parse 64-bit integers and unsigned integers:
 #warnings("-deprecated")
 test "parse_int64_uint" {
   inspect(
-    @strconv.parse_int64("9223372036854775807"[:]),
+    @strconv.parse_int64("9223372036854775807"),
     content="9223372036854775807",
   )
-  inspect(@strconv.parse_uint("42"[:]), content="42")
+  inspect(@strconv.parse_uint("42"), content="42")
   inspect(
-    @strconv.parse_uint64("18446744073709551615"[:]),
+    @strconv.parse_uint64("18446744073709551615"),
     content="18446744073709551615",
   )
 }
@@ -42,8 +42,8 @@ test "parse_int64_uint" {
 ///|
 #warnings("-deprecated")
 test "parse_other" {
-  inspect(@strconv.parse_bool("true"[:]), content="true")
-  inspect(@strconv.parse_double("3.14"[:]), content="3.14")
+  inspect(@strconv.parse_bool("true"), content="true")
+  inspect(@strconv.parse_double("3.14"), content="3.14")
 }
 ```
 
@@ -56,11 +56,11 @@ Use `@string.from_str` in new code.
 ///|
 #warnings("-deprecated")
 test "from_str" {
-  let i : Int = @strconv.from_str("123"[:])
+  let i : Int = @strconv.from_str("123")
   inspect(i, content="123")
-  let b : Bool = @strconv.from_str("false"[:])
+  let b : Bool = @strconv.from_str("false")
   inspect(b, content="false")
-  let d : Double = @strconv.from_str("2.718"[:])
+  let d : Double = @strconv.from_str("2.718")
   inspect(d, content="2.718")
 }
 ```
@@ -77,7 +77,7 @@ Use the `@string` versions in new code.
 ///|
 #warnings("-deprecated")
 test "error_handling" {
-  let result : Result[Int, _] = try? @strconv.parse_int("abc"[:])
+  let result : Result[Int, _] = try? @strconv.parse_int("abc")
   inspect(result is Err(_), content="true")
 }
 ```

--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -220,23 +220,23 @@ Parse primitive types from strings. All parsing functions raise on invalid input
 ///|
 test "parse numbers" {
   // integers (decimal by default)
-  inspect(@string.parse_int("42"[:]), content="42")
-  inspect(@string.parse_int("-17"[:]), content="-17")
+  inspect(@string.parse_int("42"), content="42")
+  inspect(@string.parse_int("-17"), content="-17")
   // explicit base
-  inspect(@string.parse_int("ff"[:], base=16), content="255")
-  inspect(@string.parse_int("101"[:], base=2), content="5")
+  inspect(@string.parse_int("ff", base=16), content="255")
+  inspect(@string.parse_int("101", base=2), content="5")
   // unsigned
-  inspect(@string.parse_uint("42"[:]), content="42")
+  inspect(@string.parse_uint("42"), content="42")
   // 64-bit
-  inspect(@string.parse_int64("9999999999"[:]), content="9999999999")
+  inspect(@string.parse_int64("9999999999"), content="9999999999")
   inspect(
-    @string.parse_uint64("18446744073709551615"[:]),
+    @string.parse_uint64("18446744073709551615"),
     content="18446744073709551615",
   )
   // double
-  inspect(@string.parse_double("3.14"[:]), content="3.14")
+  inspect(@string.parse_double("3.14"), content="3.14")
   // bool
-  inspect(@string.parse_bool("true"[:]), content="true")
+  inspect(@string.parse_bool("true"), content="true")
 }
 ```
 
@@ -297,14 +297,14 @@ Build complex patterns programmatically with `Regex::string()`, `Regex::repeat()
 ///|
 test "regex combinators" {
   // match "abc" literally
-  let abc = @string.Regex::string("abc"[:])
+  let abc = @string.Regex::string("abc")
   inspect(abc.execute("xabcy") is Some(_), content="true")
   // repeat: match 2 to 4 digits
   let digits = @string.Regex("[[:digit:]]").repeat(min=2, max=4)
   guard digits.execute("a12345") is Some(m) else { fail("no match") }
   inspect(m.content(), content="1234") // greedy: takes max
   // alternation with |
-  let either = @string.Regex::string("cat"[:]) | @string.Regex::string("dog"[:])
+  let either = @string.Regex::string("cat") | @string.Regex::string("dog")
   inspect(either.execute("I have a dog") is Some(_), content="true")
 }
 ```

--- a/string/internal/regex_engine/regex_engine_test.mbt
+++ b/string/internal/regex_engine/regex_engine_test.mbt
@@ -36,7 +36,7 @@ test "abc" {
     @regex_engine.char(@regex_engine.RecharSet::char('c')),
   ])
   let re = @regex_engine.compile(profile~, pat)
-  guard re.execute("abc"[:], 0) is Some(result) else { fail("Expected match") }
+  guard re.execute("abc", 0) is Some(result) else { fail("Expected match") }
   assert_eq(result.group(0), Some((0, 3)))
   assert_eq(result.group(1), None)
 }
@@ -48,17 +48,17 @@ test "anchored start-of-input mismatch" {
     @regex_engine.char(@regex_engine.RecharSet::char('a')),
   ])
   let re = @regex_engine.compile(profile~, pat)
-  assert_true(re.execute("b"[:], 0) is None)
+  assert_true(re.execute("b", 0) is None)
 }
 
 ///|
 test "execute with last_index and cached transitions/start-state" {
   let pat = @regex_engine.char(@regex_engine.RecharSet::char('a'))
   let re = @regex_engine.compile(profile~, pat)
-  guard re.execute("ba"[:], 1) is Some(mr) else { fail("Expected match") }
+  guard re.execute("ba", 1) is Some(mr) else { fail("Expected match") }
   assert_eq(mr.group(0), Some((1, 2)))
   // second run hits cached start state + transition
-  guard re.execute("ba"[:], 1) is Some(mr2) else { fail("Expected match") }
+  guard re.execute("ba", 1) is Some(mr2) else { fail("Expected match") }
   assert_eq(mr2.group(0), Some((1, 2)))
 }
 
@@ -66,9 +66,9 @@ test "execute with last_index and cached transitions/start-state" {
 test "execute with last_index and cached failure transitions" {
   let pat = @regex_engine.char(@regex_engine.RecharSet::char('a'))
   let re = @regex_engine.compile(profile~, pat)
-  assert_true(re.execute("bb"[:], 1) is None)
+  assert_true(re.execute("bb", 1) is None)
   // second run hits cached start state + failed transition
-  assert_true(re.execute("bb"[:], 1) is None)
+  assert_true(re.execute("bb", 1) is None)
 }
 
 ///|
@@ -84,10 +84,10 @@ test "nested stars execute repeatedly" {
     @regex_engine.start_of_input, outer, @regex_engine.end_of_input,
   ])
   let re = @regex_engine.compile(profile~, pat)
-  guard re.execute("aaa"[:], 0) is Some(mr1) else { fail("Expected match") }
+  guard re.execute("aaa", 0) is Some(mr1) else { fail("Expected match") }
   assert_eq(mr1.group(0), Some((0, 3)))
   // Repeat the same execution path to exercise cached transitions.
-  guard re.execute("aaa"[:], 0) is Some(mr2) else { fail("Expected match") }
+  guard re.execute("aaa", 0) is Some(mr2) else { fail("Expected match") }
   assert_eq(mr2.group(0), Some((0, 3)))
 }
 
@@ -98,7 +98,7 @@ test "alternation compiles and matches" {
     @regex_engine.char(@regex_engine.RecharSet::char('b')),
   ])
   let re = @regex_engine.compile(profile~, pat)
-  guard re.execute("b"[:], 0) is Some(mr) else { fail("Expected match") }
+  guard re.execute("b", 0) is Some(mr) else { fail("Expected match") }
   assert_eq(mr.group(0), Some((0, 1)))
 }
 
@@ -112,7 +112,7 @@ test "finite quantifiers greedy vs non-greedy compile" {
   })
   let pat1 = @regex_engine.seq([greedy, a])
   let re1 = @regex_engine.compile(profile~, pat1)
-  guard re1.execute("aa"[:], 0) is Some(_mr) else { fail("Expected match") }
+  guard re1.execute("aa", 0) is Some(_mr) else { fail("Expected match") }
   let nongreedy = @regex_engine.quantifier(a, {
     min: 0,
     max: Some(2),
@@ -120,7 +120,7 @@ test "finite quantifiers greedy vs non-greedy compile" {
   })
   let pat2 = @regex_engine.seq([nongreedy, a])
   let re2 = @regex_engine.compile(profile~, pat2)
-  guard re2.execute("aa"[:], 0) is Some(_mr) else { fail("Expected match") }
+  guard re2.execute("aa", 0) is Some(_mr) else { fail("Expected match") }
 }
 
 ///|
@@ -141,10 +141,10 @@ test "nested sequence vs flattened sequence preserve effective-tail preference" 
   ])
   let nested_re = @regex_engine.compile(profile~, nested_pat)
   let flat_re = @regex_engine.compile(profile~, flat_pat)
-  guard nested_re.execute("abc. "[:], 0) is Some(nested_match) else {
+  guard nested_re.execute("abc. ", 0) is Some(nested_match) else {
     fail("Expected nested match")
   }
-  guard flat_re.execute("abc. "[:], 0) is Some(flat_match) else {
+  guard flat_re.execute("abc. ", 0) is Some(flat_match) else {
     fail("Expected flattened match")
   }
   assert_eq(nested_match.group(0), Some((0, 5)))
@@ -158,13 +158,13 @@ test "epsilon in sequences (translate eps optimizations)" {
     @regex_engine.start_of_input, a, @regex_engine.end_of_input, @regex_engine.epsilon,
   ])
   let re1 = @regex_engine.compile(profile~, pat1)
-  guard re1.execute("a"[:], 0) is Some(mr1) else { fail("Expected match") }
+  guard re1.execute("a", 0) is Some(mr1) else { fail("Expected match") }
   assert_eq(mr1.group(0), Some((0, 1)))
   let pat2 = @regex_engine.seq([
     @regex_engine.start_of_input, @regex_engine.epsilon, a, @regex_engine.end_of_input,
   ])
   let re2 = @regex_engine.compile(profile~, pat2)
-  guard re2.execute("a"[:], 0) is Some(mr2) else { fail("Expected match") }
+  guard re2.execute("a", 0) is Some(mr2) else { fail("Expected match") }
   assert_eq(mr2.group(0), Some((0, 1)))
 }
 
@@ -175,13 +175,13 @@ test "line assertions" {
   // StartOfLine should match after newline.
   let pat1 = @regex_engine.seq([@regex_engine.start_of_line, a])
   let re1 = @regex_engine.compile(profile~, pat1)
-  guard re1.execute("\na"[:], 0) is Some(mr1) else { fail("Expected match") }
+  guard re1.execute("\na", 0) is Some(mr1) else { fail("Expected match") }
   assert_eq(mr1.group(0), Some((1, 2)))
 
   // EndOfLine is a lookahead (needs next-cat check).
   let pat2 = @regex_engine.seq([a, @regex_engine.end_of_line])
   let re2 = @regex_engine.compile(profile~, pat2)
-  guard re2.execute("a\n"[:], 0) is Some(mr2) else { fail("Expected match") }
+  guard re2.execute("a\n", 0) is Some(mr2) else { fail("Expected match") }
   assert_eq(mr2.group(0), Some((0, 1)))
 }
 
@@ -191,16 +191,16 @@ test "word boundary assertions" {
   let b = @regex_engine.char(@regex_engine.RecharSet::char('b'))
   let pat1 = @regex_engine.seq([@regex_engine.start_of_word, a])
   let re1 = @regex_engine.compile(profile~, pat1)
-  guard re1.execute("a"[:], 0) is Some(mr1) else { fail("Expected match") }
+  guard re1.execute("a", 0) is Some(mr1) else { fail("Expected match") }
   assert_eq(mr1.group(0), Some((0, 1)))
   let pat2 = @regex_engine.seq([a, @regex_engine.end_of_word])
   let re2 = @regex_engine.compile(profile~, pat2)
-  guard re2.execute("a!"[:], 0) is Some(mr2) else { fail("Expected match") }
+  guard re2.execute("a!", 0) is Some(mr2) else { fail("Expected match") }
   assert_eq(mr2.group(0), Some((0, 1)))
-  assert_true(re2.execute("ab"[:], 0) is None)
+  assert_true(re2.execute("ab", 0) is None)
   let pat3 = @regex_engine.seq([a, @regex_engine.not_word_boundary, b])
   let re3 = @regex_engine.compile(profile~, pat3)
-  guard re3.execute("ab"[:], 0) is Some(mr3) else { fail("Expected match") }
+  guard re3.execute("ab", 0) is Some(mr3) else { fail("Expected match") }
   assert_eq(mr3.group(0), Some((0, 2)))
 }
 
@@ -213,7 +213,7 @@ test "quantifier min > 0 uses iter step" {
     @regex_engine.end_of_input,
   ])
   let re = @regex_engine.compile(profile~, pat)
-  guard re.execute("aa"[:], 0) is Some(mr) else { fail("Expected match") }
+  guard re.execute("aa", 0) is Some(mr) else { fail("Expected match") }
   assert_eq(mr.group(0), Some((0, 2)))
 }
 
@@ -231,7 +231,7 @@ test "preference node triggers enforce_pref(First, k)" {
     @regex_engine.end_of_input,
   ])
   let re = @regex_engine.compile(profile~, pat)
-  guard re.execute("ab"[:], 0) is Some(mr) else { fail("Expected match") }
+  guard re.execute("ab", 0) is Some(mr) else { fail("Expected match") }
   assert_eq(mr.group(0), Some((0, 2)))
 }
 

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -91,7 +91,7 @@ pub fn Regex::internal_compile_pattern(pat : Pattern) -> Regex {
 #internal(internal, "not intended for public use")
 #doc(hidden)
 pub fn Regex::internal_from_string(pat : String) -> Regex {
-  try! Regex::new(pat[:])
+  try! Regex::new(pat)
 }
 
 ///|

--- a/string/regex_methods.mbt
+++ b/string/regex_methods.mbt
@@ -87,7 +87,7 @@ pub fn Regex::replace_by(
     None => str
     Some(b) => {
       b.write_stringview(str[copy_index:])
-      b.to_string()[:]
+      b.to_string()
     }
   }
 }


### PR DESCRIPTION
## Summary
- Strip redundant `expr[:]` at 188 sites across 37 files where the expected type already triggers auto view conversion
- Unblocks pre-release CI (`unnecessary_view_op` is promoted to error under `--deny-warn`)

Self-recursive delegating wrappers (e.g. `Array::starts_with(self, prefix)` calling `self[:].starts_with(prefix)`) keep the `self[:]` conversion so they land on the view method.

## Test plan
- [x] `moon check --deny-warn` — 0 warnings, 0 errors
- [x] `moon check --target native --deny-warn` — clean
- [x] `moon test` — 6319/6319 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
