### PR TITLE
refactor(argparse): use for-comprehension in required_option_usage

### DIFF
--- a/argparse/argparse_blackbox_test.mbt
+++ b/argparse/argparse_blackbox_test.mbt
@@ -2234,6 +2234,42 @@ test "subcommand help puts required options in usage" {
 }
 
 ///|
+test "required_option_usage covers option/flag/hidden/short-only" {
+  let cmd = @argparse.Command(
+    "demo",
+    flags=[
+      FlagArg("verbose", short='v', long="verbose", required=true),
+      FlagArg("secret", short='s', long="secret", required=true, hidden=true),
+    ],
+    options=[
+      OptionArg("mode", long="mode", required=true),
+      OptionArg("tag", short='t', long="", required=true),
+      OptionArg("optional", long="optional"),
+    ],
+    positionals=[
+      PositionArg("required_pos", num_args=@argparse.ValueRange::single()),
+    ],
+  )
+  let help = cmd.render_help()
+  assert_true(
+    help.has_prefix(
+      "Usage: demo --verbose --mode <mode> -t <tag> [options] <required_pos>",
+    ),
+  )
+}
+
+///|
+test "required_option_usage returns empty when nothing required" {
+  let cmd = @argparse.Command(
+    "demo",
+    flags=[FlagArg("verbose", short='v', long="verbose")],
+    options=[OptionArg("mode", long="mode")],
+  )
+  let help = cmd.render_help()
+  assert_true(help.has_prefix("Usage: demo [options]"))
+}
+
+///|
 test "required and env-fed ranged values validate after parsing" {
   let required_cmd = @argparse.Command("demo", options=[
     OptionArg("input", long="input", required=true),

--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -98,19 +98,12 @@ fn has_options(cmd : Command) -> Bool {
 
 ///|
 fn required_option_usage(cmd : Command) -> String {
-  let parts = Array::new(capacity=cmd.args.length())
-  for arg in cmd.args {
-    if arg.hidden || !is_required_arg(arg) {
-      continue
-    }
-    if arg.info is PositionalInfo(_) {
-      continue
-    }
-    if required_option_token(arg) is Some(token) {
-      parts.push(token)
-    }
-  }
-  parts.join(" ")
+  [
+    for arg in cmd.args if !(arg.hidden ||
+    !is_required_arg(arg) ||
+    arg.info is PositionalInfo(_)) &&
+    required_option_token(arg) is Some(token) => token
+  ].join(" ")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Convert the imperative accumulator loop in `required_option_usage` to an array comprehension that filters and maps in one expression.
- Add two focused tests covering required options with long/short/hidden combinations and the no-required-options path.

## Test plan
- [x] \`moon check argparse\` passes
- [x] \`moon test -p argparse\` passes (223 tests)
- [x] \`moon fmt --check\` passes (verified via \`codex review\`)
- [x] Snapshot test \`subcommand help puts required options in usage\` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
