### PR TITLE
refactor: apply for-comprehension to more array-building loops

### DIFF
--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -161,16 +161,13 @@ fn group_usage_expr(
     if group.name != name {
       continue
     }
-    let members = []
-    for member_name in group.args {
-      if args.search_by(arg => arg.name == member_name) is Some(idx) {
-        let item = args[idx]
-        if item.hidden {
-          continue
-        }
-        members.push(arg_usage_token_for_group(item))
-      }
-    }
+    let members = [
+      for member_name in group.args if args.search_by(arg => {
+        arg.name == member_name
+      })
+      is Some(idx) &&
+      !args[idx].hidden => arg_usage_token_for_group(args[idx])
+    ]
     if members.length() == 0 {
       return None
     }

--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -98,10 +98,7 @@ fn resolve_help_target(
 
 ///|
 fn split_long(arg : String) -> (String, String?) {
-  let parts = []
-  for part in arg.split("=") {
-    parts.push(part.to_string())
-  }
+  let parts = [ for part in arg.split("=") => part.to_string() ]
   if parts.length() <= 1 {
     let name = match parts[0].strip_prefix("--") {
       Some(view) => view.to_string()

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -17,12 +17,9 @@ fn get_cli_args_ffi() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
 
 ///|
 fn get_cli_args_internal() -> Array[String] {
-  let tmp = get_cli_args_ffi()
-  let res = Array::new(capacity=tmp.length())
-  for t in tmp {
-    res.push(utf8_bytes_to_mbt_string(t))
-  }
-  res
+  [
+    for t in get_cli_args_ffi() => utf8_bytes_to_mbt_string(t)
+  ]
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -672,13 +672,11 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      res.push(key.to_json())
-    }
-  }
-  Json::array(res)
+  Json::array(
+    [
+      for entry in self.entries if entry is Some({ key, .. }) => key.to_json()
+    ],
+  )
 }
 
 ///|

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -594,11 +594,7 @@ pub fn[K : Hash + Eq] Set::intersection(
 
 ///|
 pub impl[X : ToJson] ToJson for Set[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for v in self {
-    res.push(v.to_json())
-  }
-  Json::array(res)
+  Json::array([ for v in self => v.to_json() ])
 }
 
 ///|


### PR DESCRIPTION
## Summary
Third in the series (after #3444 and #3445). Converts five more imperative push-loops to for-comprehensions:

- \`argparse/parser.mbt\`: \`group_usage_expr\` (uses \`is Some(idx)\` binding)
- \`argparse/parser_lookup.mbt\`: \`split_long\`
- \`env/env_native.mbt\`: \`get_cli_args_internal\`
- \`hashset/hashset.mbt\`: \`ToJson\` impl (uses \`is Some({ key, .. })\` binding)
- \`set/linked_hash_set.mbt\`: \`ToJson\` impl

Skipped sites:
- \`HashSet::to_array\` — hot-path, keeps explicit \`capacity=self.size\` hint.
- \`parser_globals_merge\` two-loop concat — needs spread/extend, not a clean comprehension.
- \`positional_usage\`, \`option_entries\`, \`arg_display\` — branching pushes; not idiomatic to unify.

## Test plan
- [x] \`moon check\` clean
- [x] \`moon test -p argparse -p env -p hashset -p set\` passes (700 tests)
- [x] \`moon fmt --check\` clean
- [x] \`codex review --uncommitted\` confirms behavior-preserving across wasm/wasm-gc/js/native targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
