### PR TITLE
refactor: convert more array-building loops to for-comprehensions

### DIFF
--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -14,13 +14,9 @@
 
 ///|
 fn positional_args(args : Array[Arg]) -> Array[Arg] {
-  let ordered = []
-  for arg in args {
-    if arg.info is PositionalInfo(_) {
-      ordered.push(arg)
-    }
-  }
-  ordered
+  [
+    for arg in args if arg.info is PositionalInfo(_) => arg
+  ]
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -314,13 +314,9 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
 ///|
 /// Converts the hash set to an array.
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
-  let arr = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      arr.push(key)
-    }
-  }
-  arr
+  [
+    for entry in self.entries if entry is Some({ key, .. }) => key
+  ]
 }
 
 ///|

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -791,11 +791,7 @@ pub impl[A : Show] Show for SortedSet[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for SortedSet[A] with to_json(self) {
-  let capacity = self.iter().count()
-  guard capacity != 0 else { return Json::array([]) }
-  let jsons = Array::new(capacity~)
-  self.each(a => jsons.push(a.to_json()))
-  Json::array(jsons)
+  Json::array([ for a in self => a.to_json() ])
 }
 
 ///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -94,13 +94,7 @@ pub impl[A : Show] Show for List[A] with output(xs, logger) {
 /// ToJson implementation for List.
 /// Converts a list to a JSON array.
 pub impl[A : ToJson] ToJson for List[A] with to_json(self) {
-  let capacity = self.length()
-  guard capacity != 0 else { return [] }
-  let jsons = Array::new(capacity~)
-  for a in self {
-    jsons.push(a.to_json())
-  }
-  Json::array(jsons)
+  Json::array([ for a in self => a.to_json() ])
 }
 
 ///|

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -17,9 +17,9 @@
 #deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
 #coverage.skip
 pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
-  let keys = Array::new(capacity=self.size)
-  self.each((k, _v) => keys.push(k))
-  keys
+  [
+    for k, _ in self => k
+  ]
 }
 
 ///|
@@ -27,7 +27,7 @@ pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
 #deprecated("Use `values_as_iter` instead. `values` will return `Iter[V]` instead of `Array[V]` in the future.")
 #coverage.skip
 pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Array[V] {
-  let values = Array::new(capacity=self.size)
-  self.each((_k, v) => values.push(v))
-  values
+  [
+    for _, v in self => v
+  ]
 }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -269,9 +269,9 @@ pub fn[K, V] SortedMap::values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
 ///|
 /// Returns an array of all key-value pairs in ascending key order.
 pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
-  let arr = Array::new(capacity=self.size)
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [
+    for kv in self => kv
+  ]
 }
 
 ///|


### PR DESCRIPTION
## Summary
Fourth in the series (after #3444, #3445, #3446). Aggressive sweep targeting sites where the comprehension form is clearly more concise, even when it drops an explicit \`capacity\` pre-alloc hint:

- \`argparse/parser_positionals.mbt\`: \`positional_args\`
- \`hashset/hashset.mbt\`: \`HashSet::to_array\` (previously kept out of #3446 to preserve capacity hint — now included)
- \`immut/sorted_set/immutable_set.mbt\`: \`ToJson\` impl
- \`list/list.mbt\`: \`ToJson\` impl
- \`sorted_map/deprecated.mbt\`: \`keys\`, \`values\` (uses two-binding \`for k, _ in self\` / \`for _, v in self\`)
- \`sorted_map/map.mbt\`: \`SortedMap::to_array\`

### Discovered limitation
Array comprehensions reject calling functions that can raise (\"calling function with error is not allowed inside list comprehension\"). This blocks conversion of \`Array::filter\`, \`Array::filter_map\`, \`ArrayView::filter\`, \`ArrayView::filter_map\`, etc., which take \`(T) -> Bool raise?\` predicates. Those are left untouched.

## Test plan
- [x] \`moon check\` clean
- [x] \`moon test -p argparse -p list -p hashset -p sorted_map -p immut/sorted_set\` passes (916 tests)
- [x] \`moon fmt --check\` clean
- [x] \`codex review --uncommitted\` confirms behavior-preserving

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
