### PR TITLE
refactor: apply for-comprehension pattern across collections and argparse

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -240,25 +240,22 @@ fn builtin_option_label(
 
 ///|
 fn positional_entries(cmd : Command) -> Array[String] {
-  let display = Array::new(capacity=cmd.args.length())
-  for arg in positional_args(cmd.args) {
-    if arg.hidden {
-      continue
-    }
-    display.push((positional_display(arg), arg_doc(arg)))
-  }
-  format_entries(display)
+  format_entries(
+    [
+      for arg in positional_args(cmd.args) if !arg.hidden => {
+        (positional_display(arg), arg_doc(arg))
+      }
+    ],
+  )
 }
 
 ///|
 fn subcommand_entries(cmd : Command) -> Array[String] {
-  let display = Array::new(capacity=cmd.subcommands.length() + 1)
-  for sub in cmd.subcommands {
-    if sub.hidden {
-      continue
+  let display = [
+    for sub in cmd.subcommands if !sub.hidden => {
+      (sub.name, sub.about.unwrap_or(""))
     }
-    display.push((sub.name, sub.about.unwrap_or("")))
-  }
+  ]
   if help_subcommand_enabled(cmd) {
     display.push(("help", "Print help for the subcommand(s)."))
   }
@@ -267,7 +264,7 @@ fn subcommand_entries(cmd : Command) -> Array[String] {
 
 ///|
 fn group_entries(cmd : Command) -> Array[String] {
-  let display = Array::new(capacity=cmd.groups.length())
+  let display = []
   for group in cmd.groups {
     let members = group_members(cmd, group)
     if members == "" {
@@ -428,16 +425,11 @@ fn group_label(group : ArgGroup) -> String {
 
 ///|
 fn group_members(cmd : Command, group : ArgGroup) -> String {
-  let members = []
-  for arg in cmd.args {
-    if arg.hidden {
-      continue
+  [
+    for arg in cmd.args if !arg.hidden && arg_in_group(arg, group) => {
+      group_member_display(arg)
     }
-    if arg_in_group(arg, group) {
-      members.push(group_member_display(arg))
-    }
-  }
-  members.join(", ")
+  ].join(", ")
 }
 
 ///|

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -161,16 +161,13 @@ fn group_usage_expr(
     if group.name != name {
       continue
     }
-    let members = []
-    for member_name in group.args {
-      if args.search_by(arg => arg.name == member_name) is Some(idx) {
-        let item = args[idx]
-        if item.hidden {
-          continue
-        }
-        members.push(arg_usage_token_for_group(item))
-      }
-    }
+    let members = [
+      for member_name in group.args if args.search_by(arg => {
+        arg.name == member_name
+      })
+      is Some(idx) &&
+      !args[idx].hidden => arg_usage_token_for_group(args[idx])
+    ]
     if members.length() == 0 {
       return None
     }

--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -98,10 +98,7 @@ fn resolve_help_target(
 
 ///|
 fn split_long(arg : String) -> (String, String?) {
-  let parts = []
-  for part in arg.split("=") {
-    parts.push(part.to_string())
-  }
+  let parts = [ for part in arg.split("=") => part.to_string() ]
   if parts.length() <= 1 {
     let name = match parts[0].strip_prefix("--") {
       Some(view) => view.to_string()

--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -14,13 +14,9 @@
 
 ///|
 fn positional_args(args : Array[Arg]) -> Array[Arg] {
-  let ordered = []
-  for arg in args {
-    if arg.info is PositionalInfo(_) {
-      ordered.push(arg)
-    }
-  }
-  ordered
+  [
+    for arg in args if arg.info is PositionalInfo(_) => arg
+  ]
 }
 
 ///|

--- a/bytes/internal/regex_engine/translate.mbt
+++ b/bytes/internal/regex_engine/translate.mbt
@@ -39,11 +39,11 @@ fn translate(
     Sequence(exprs) => (transl_seq(tc, exprs), pref)
     Alternation(exprs) => {
       // TODO: merge sequences
-      let alts = []
-      for expr in exprs {
-        let (cr, pref2) = translate(tc, expr)
-        alts.push(enforce_pref(ctx, pref, pref2, cr))
-      }
+      let alts = [
+        for expr in exprs if translate(tc, expr) is (cr, pref2) => {
+          enforce_pref(ctx, pref, pref2, cr)
+        }
+      ]
       (@automata.e_alt(ctx~, alts), pref)
     }
     Quantifier(q, expr) => {

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1675,11 +1675,7 @@ pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
 /// ```
 ///
 pub impl[A : ToJson] ToJson for Deque[A] with to_json(self : Deque[A]) -> Json {
-  let res = Array::make(self.length(), null)
-  for i, x in self {
-    res[i] = x.to_json()
-  }
-  Json::array(res)
+  Json::array([ for x in self => x.to_json() ])
 }
 
 ///|

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -17,12 +17,9 @@ fn get_cli_args_ffi() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
 
 ///|
 fn get_cli_args_internal() -> Array[String] {
-  let tmp = get_cli_args_ffi()
-  let res = Array::new(capacity=tmp.length())
-  for t in tmp {
-    res.push(utf8_bytes_to_mbt_string(t))
-  }
-  res
+  [
+    for t in get_cli_args_ffi() => utf8_bytes_to_mbt_string(t)
+  ]
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -672,13 +672,11 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      res.push(key.to_json())
-    }
-  }
-  Json::array(res)
+  Json::array(
+    [
+      for entry in self.entries if entry is Some({ key, .. }) => key.to_json()
+    ],
+  )
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -314,13 +314,9 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
 ///|
 /// Converts the hash set to an array.
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
-  let arr = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      arr.push(key)
-    }
-  }
-  arr
+  [
+    for entry in self.entries if entry is Some({ key, .. }) => key
+  ]
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -726,9 +726,9 @@ pub fn[K : Eq + Hash, V] HashMap::from_array(
 ///|
 /// Returns an array of all key-value pairs.
 pub fn[K, V] HashMap::to_array(self : HashMap[K, V]) -> Array[(K, V)] {
-  let arr = Array::new(capacity=self.length())
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [
+    for k, v in self => (k, v)
+  ]
 }
 
 ///|

--- a/immut/priority_queue/types.mbt
+++ b/immut/priority_queue/types.mbt
@@ -30,12 +30,5 @@ priv enum Node[A] {
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(
   self : PriorityQueue[A],
 ) {
-  // note here iter requires Compare 
-  // This requires some investigation 
-  // CR: this syntax feels less intuitive
-  let output : Array[Json] = []
-  for item in self {
-    output.push(item.to_json())
-  }
-  Json::array(output)
+  Json::array([ for item in self => item.to_json() ])
 }

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -123,9 +123,9 @@ pub fn[K, V] SortedMap::filter_with_key(
 ///|
 /// Returns an array of all key-value pairs in ascending key order.
 pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
-  let arr = []
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [
+    for k, v in self => (k, v)
+  ]
 }
 
 ///|

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -791,11 +791,7 @@ pub impl[A : Show] Show for SortedSet[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for SortedSet[A] with to_json(self) {
-  let capacity = self.iter().count()
-  guard capacity != 0 else { return Json::array([]) }
-  let jsons = Array::new(capacity~)
-  self.each(a => jsons.push(a.to_json()))
-  Json::array(jsons)
+  Json::array([ for a in self => a.to_json() ])
 }
 
 ///|

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -666,11 +666,7 @@ pub impl[A : Show] Show for Vector[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for Vector[A] with to_json(self) {
-  let len = self.length()
-  guard len != 0 else { return [] }
-  let res : Array[Json] = Array::make(len, null)
-  self.eachi((i, value) => res[i] = value.to_json())
-  Json::array(res)
+  Json::array([ for value in self => value.to_json() ])
 }
 
 ///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -340,22 +340,9 @@ pub fn[A, B] List::rev_map(
 /// }
 /// ```
 pub fn[A] List::to_array(self : List[A]) -> Array[A] {
-  match self {
-    Empty => []
-    More(x, tail=xs) => {
-      let arr = [x]
-      for cur = xs {
-        match cur {
-          Empty => break
-          More(x, tail=xs) => {
-            arr.push(x)
-            continue xs
-          }
-        }
-      }
-      arr
-    }
-  }
+  [
+    for x in self => x
+  ]
 }
 
 ///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -94,13 +94,7 @@ pub impl[A : Show] Show for List[A] with output(xs, logger) {
 /// ToJson implementation for List.
 /// Converts a list to a JSON array.
 pub impl[A : ToJson] ToJson for List[A] with to_json(self) {
-  let capacity = self.length()
-  guard capacity != 0 else { return [] }
-  let jsons = Array::new(capacity~)
-  for a in self {
-    jsons.push(a.to_json())
-  }
-  Json::array(jsons)
+  Json::array([ for a in self => a.to_json() ])
 }
 
 ///|

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -142,11 +142,7 @@ pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
 
 ///|
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(self) {
-  let arr = []
-  for x in self {
-    arr.push(x.to_json())
-  }
-  Json::array(arr)
+  Json::array([ for x in self => x.to_json() ])
 }
 
 ///|

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -594,11 +594,7 @@ pub fn[K : Hash + Eq] Set::intersection(
 
 ///|
 pub impl[X : ToJson] ToJson for Set[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for v in self {
-    res.push(v.to_json())
-  }
-  Json::array(res)
+  Json::array([ for v in self => v.to_json() ])
 }
 
 ///|

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -17,9 +17,9 @@
 #deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
 #coverage.skip
 pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
-  let keys = Array::new(capacity=self.size)
-  self.each((k, _v) => keys.push(k))
-  keys
+  [
+    for k, _ in self => k
+  ]
 }
 
 ///|
@@ -27,7 +27,7 @@ pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
 #deprecated("Use `values_as_iter` instead. `values` will return `Iter[V]` instead of `Array[V]` in the future.")
 #coverage.skip
 pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Array[V] {
-  let values = Array::new(capacity=self.size)
-  self.each((_k, v) => values.push(v))
-  values
+  [
+    for _, v in self => v
+  ]
 }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -269,9 +269,9 @@ pub fn[K, V] SortedMap::values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
 ///|
 /// Returns an array of all key-value pairs in ascending key order.
 pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
-  let arr = Array::new(capacity=self.size)
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [
+    for kv in self => kv
+  ]
 }
 
 ///|


### PR DESCRIPTION
## Summary
Follow-up to #3444 consolidating three stacked batches (originally #3445, #3446, #3447 — superseded by this PR) plus an additional aggressive sweep of simple unconditional-map loops. Converts imperative \`let xs = []\` / \`Array::new(...)\` + \`for ... { xs.push(...) }\` patterns to MoonBit array comprehensions.

### Sites converted (18 files)

**argparse:**
- \`help_render.mbt\`: \`positional_entries\`, \`subcommand_entries\`, \`group_members\` (filter-map)
- \`parser.mbt\`: \`group_usage_expr\` (\`is Some(idx)\` binding)
- \`parser_lookup.mbt\`: \`split_long\` (simple map)
- \`parser_positionals.mbt\`: \`positional_args\` (pattern filter)

**core collections:**
- \`deque/deque.mbt\`: \`ToJson\` impl
- \`hashset/hashset.mbt\`: \`to_array\` (\`is Some({ key, .. })\` binding), \`ToJson\` impl
- \`list/list.mbt\`: \`to_array\`, \`ToJson\` impl
- \`priority_queue/priority_queue.mbt\`: \`ToJson\` impl
- \`set/linked_hash_set.mbt\`: \`ToJson\` impl
- \`sorted_map/map.mbt\`: \`to_array\`
- \`sorted_map/deprecated.mbt\`: \`keys\`, \`values\` (two-binding \`for k, _ in self\` / \`for _, v in self\`)

**immut collections:**
- \`immut/hashmap/HAMT.mbt\`: \`to_array\` (two-binding)
- \`immut/priority_queue/types.mbt\`: \`ToJson\` impl
- \`immut/sorted_map/map.mbt\`: \`to_array\` (two-binding)
- \`immut/sorted_set/immutable_set.mbt\`: \`ToJson\` impl
- \`immut/vector/vector.mbt\`: \`ToJson\` impl

**misc:**
- \`bytes/internal/regex_engine/translate.mbt\`: \`Alternation\` arm (\`is (cr, pref2)\` destructure)
- \`env/env_native.mbt\`: \`get_cli_args_internal\`

### Patterns used
- Unconditional map: \`[for x in iter => f(x)]\`
- Filter-map: \`[for x in iter if cond => f(x)]\`
- Is-pattern binding: \`[for x in iter if f(x) is Some(y) => g(y)]\`
- Two-binding for Iter2: \`[for k, v in map => (k, v)]\`

### Discovered limitation
MoonBit rejects calls to raising functions inside comprehensions:
> \`error: calling function with error is not allowed inside list comprehension\`

This blocks conversion of \`Array::filter\`, \`Array::filter_map\`, \`ArrayView::filter\`, \`ArrayView::filter_map\`, and similar functions whose predicate/mapper closures are typed \`(T) -> ... raise?\`. Those are intentionally left as imperative loops.

### Sites deliberately skipped
- \`Array::new(capacity=...)\` hot paths where the explicit capacity hint is load-bearing (\`Deque::to_array\`, \`Vector::to_array\`, \`Array::extract_if\`, \`Array::split\`).
- \`parser_globals_merge\` two-optional-loop concat — cleaner as-is.
- Closure-based \`each_intervals\` callbacks in regex symbol_map.

## Test plan
- [x] \`moon check\` clean
- [x] \`moon test\` passes all 6333 tests
- [x] \`moon fmt --check\` clean
- [x] \`codex review --uncommitted\` confirms behavior-preserving (no correctness, API, or performance regressions)

Supersedes #3445, #3446, #3447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
