### PR TITLE
refactor: apply for-comprehension pattern across collections and argparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bisect.coverage
 node_modules/
 _build
 target
+.claude/

--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -240,25 +240,22 @@ fn builtin_option_label(
 
 ///|
 fn positional_entries(cmd : Command) -> Array[String] {
-  let display = Array::new(capacity=cmd.args.length())
-  for arg in positional_args(cmd.args) {
-    if arg.hidden {
-      continue
-    }
-    display.push((positional_display(arg), arg_doc(arg)))
-  }
-  format_entries(display)
+  format_entries(
+    [
+      for arg in positional_args(cmd.args) if !arg.hidden => {
+        (positional_display(arg), arg_doc(arg))
+      }
+    ],
+  )
 }
 
 ///|
 fn subcommand_entries(cmd : Command) -> Array[String] {
-  let display = Array::new(capacity=cmd.subcommands.length() + 1)
-  for sub in cmd.subcommands {
-    if sub.hidden {
-      continue
+  let display = [
+    for sub in cmd.subcommands if !sub.hidden => {
+      (sub.name, sub.about.unwrap_or(""))
     }
-    display.push((sub.name, sub.about.unwrap_or("")))
-  }
+  ]
   if help_subcommand_enabled(cmd) {
     display.push(("help", "Print help for the subcommand(s)."))
   }
@@ -428,16 +425,11 @@ fn group_label(group : ArgGroup) -> String {
 
 ///|
 fn group_members(cmd : Command, group : ArgGroup) -> String {
-  let members = []
-  for arg in cmd.args {
-    if arg.hidden {
-      continue
+  [
+    for arg in cmd.args if !arg.hidden && arg_in_group(arg, group) => {
+      group_member_display(arg)
     }
-    if arg_in_group(arg, group) {
-      members.push(group_member_display(arg))
-    }
-  }
-  members.join(", ")
+  ].join(", ")
 }
 
 ///|

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -161,16 +161,13 @@ fn group_usage_expr(
     if group.name != name {
       continue
     }
-    let members = []
-    for member_name in group.args {
-      if args.search_by(arg => arg.name == member_name) is Some(idx) {
-        let item = args[idx]
-        if item.hidden {
-          continue
-        }
-        members.push(arg_usage_token_for_group(item))
-      }
-    }
+    let members = [
+      for member_name in group.args if args.search_by(arg => {
+        arg.name == member_name
+      })
+      is Some(idx) &&
+      !args[idx].hidden => arg_usage_token_for_group(args[idx])
+    ]
     if members.length() == 0 {
       return None
     }

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -660,7 +660,8 @@ fn version_text_for_long_action(
   inherited_version_long : Map[String, String],
 ) -> String {
   for arg in cmd.args {
-    if arg.info is FlagInfo(long=Some(name), action=Version, ..) && name[:] == long {
+    if arg.info is FlagInfo(long=Some(name), action=Version, ..) &&
+      name[:] == long {
       return command_version(cmd)
     }
   }

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -24,7 +24,7 @@ fn raise_version(text : String) -> Unit raise DisplayVersion {
 
 ///|
 fn[T] raise_unknown_long(
-  name : String,
+  name : StringView,
   long_index : Map[String, Arg],
 ) -> T raise ArgParseError {
   let hint = suggest_long(name, long_index)
@@ -659,7 +659,7 @@ fn command_version(cmd : Command) -> String {
 ///|
 fn version_text_for_long_action(
   cmd : Command,
-  long : String,
+  long : StringView,
   inherited_version_long : Map[String, String],
 ) -> String {
   for arg in cmd.args {

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -423,11 +423,11 @@ fn parse_command_impl(
         }
         raise_version(command_version(cmd))
       }
-      match long_index.get(name) {
+      match long_index.get_from_string(name) {
         None =>
           // Support `--no-<flag>` when the underlying flag is marked `negatable`.
           if name is [.. "no-", .. target] &&
-            long_index.get(target.to_string())
+            long_index.get_from_string(target)
             is Some({ info: FlagInfo(negatable=true, action~, ..), .. } as spec) {
             if inline is Some(_) {
               raise ArgParseError::InvalidArgument(arg)
@@ -660,11 +660,11 @@ fn version_text_for_long_action(
   inherited_version_long : Map[String, String],
 ) -> String {
   for arg in cmd.args {
-    if arg.info is FlagInfo(long=Some(name), action=Version, ..) && name == long {
+    if arg.info is FlagInfo(long=Some(name), action=Version, ..) && name[:] == long {
       return command_version(cmd)
     }
   }
-  inherited_version_long.get(long).unwrap_or(command_version(cmd))
+  inherited_version_long.get_from_string(long).unwrap_or(command_version(cmd))
 }
 
 ///|

--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -97,20 +97,17 @@ fn resolve_help_target(
 }
 
 ///|
-fn split_long(arg : String) -> (String, String?) {
-  let parts = []
-  for part in arg.split("=") {
-    parts.push(part.to_string())
-  }
+fn split_long(arg : String) -> (StringView, String?) {
+  let parts = [ for part in arg.split("=") => part ]
   if parts.length() <= 1 {
     let name = match parts[0].strip_prefix("--") {
-      Some(view) => view.to_string()
+      Some(view) => view
       None => parts[0]
     }
     (name, None)
   } else {
     let name = match parts[0].strip_prefix("--") {
-      Some(view) => view.to_string()
+      Some(view) => view
       None => parts[0]
     }
     let value = parts[1:].to_array().join("=")

--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -14,13 +14,9 @@
 
 ///|
 fn positional_args(args : Array[Arg]) -> Array[Arg] {
-  let ordered = []
-  for arg in args {
-    if arg.info is PositionalInfo(_) {
-      ordered.push(arg)
-    }
-  }
-  ordered
+  [
+    for arg in args if arg.info is PositionalInfo(_) => arg
+  ]
 }
 
 ///|

--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -87,7 +87,7 @@ fn should_parse_as_positional(
   }
   if arg.has_prefix("--") {
     let (name, _) = split_long(arg)
-    return long_index.get(name) is None
+    return long_index.get_from_string(name) is None
   }
   let short = arg.get_char(1)
   match short {

--- a/argparse/parser_suggest.mbt
+++ b/argparse/parser_suggest.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-fn suggest_long(name : String, long_index : Map[String, Arg]) -> String? {
+fn suggest_long(name : StringView, long_index : Map[String, Arg]) -> String? {
   let candidates = long_index.keys().collect()
   if suggest_name(name, candidates) is Some(best) {
     Some("--\{best}")
@@ -34,7 +34,7 @@ fn suggest_short(short : Char, short_index : Map[Char, Arg]) -> String? {
 }
 
 ///|
-fn suggest_name(input : String, candidates : Array[String]) -> String? {
+fn suggest_name(input : StringView, candidates : Array[String]) -> String? {
   let max_dist = suggestion_threshold(input.length())
   for cand in candidates; best = (None : String?), best_dist = 0 {
     let dist = levenshtein(input, cand)
@@ -63,7 +63,7 @@ fn suggestion_threshold(len : Int) -> Int {
 }
 
 ///|
-fn levenshtein(a : String, b : String) -> Int {
+fn levenshtein(a : StringView, b : StringView) -> Int {
   let aa = a.to_array()
   let bb = b.to_array()
   let m = aa.length()

--- a/bytes/internal/regex_engine/translate.mbt
+++ b/bytes/internal/regex_engine/translate.mbt
@@ -39,11 +39,12 @@ fn translate(
     Sequence(exprs) => (transl_seq(tc, exprs), pref)
     Alternation(exprs) => {
       // TODO: merge sequences
-      let alts = []
-      for expr in exprs {
-        let (cr, pref2) = translate(tc, expr)
-        alts.push(enforce_pref(ctx, pref, pref2, cr))
-      }
+      let alts = [
+        for expr in exprs => {
+          let (cr, pref2) = translate(tc, expr)
+          enforce_pref(ctx, pref, pref2, cr)
+        }
+      ]
       (@automata.e_alt(ctx~, alts), pref)
     }
     Quantifier(q, expr) => {

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1675,11 +1675,7 @@ pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
 /// ```
 ///
 pub impl[A : ToJson] ToJson for Deque[A] with to_json(self : Deque[A]) -> Json {
-  let res = Array::make(self.length(), null)
-  for i, x in self {
-    res[i] = x.to_json()
-  }
-  Json::array(res)
+  Json::array([ for x in self => x.to_json() ])
 }
 
 ///|

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -17,12 +17,9 @@ fn get_cli_args_ffi() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
 
 ///|
 fn get_cli_args_internal() -> Array[String] {
-  let tmp = get_cli_args_ffi()
-  let res = Array::new(capacity=tmp.length())
-  for t in tmp {
-    res.push(utf8_bytes_to_mbt_string(t))
-  }
-  res
+  [
+    for t in get_cli_args_ffi() => utf8_bytes_to_mbt_string(t)
+  ]
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -726,9 +726,9 @@ pub fn[K : Eq + Hash, V] HashMap::from_array(
 ///|
 /// Returns an array of all key-value pairs.
 pub fn[K, V] HashMap::to_array(self : HashMap[K, V]) -> Array[(K, V)] {
-  let arr = Array::new(capacity=self.length())
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [
+    for k, v in self => (k, v)
+  ]
 }
 
 ///|

--- a/immut/priority_queue/types.mbt
+++ b/immut/priority_queue/types.mbt
@@ -30,12 +30,5 @@ priv enum Node[A] {
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(
   self : PriorityQueue[A],
 ) {
-  // note here iter requires Compare 
-  // This requires some investigation 
-  // CR: this syntax feels less intuitive
-  let output : Array[Json] = []
-  for item in self {
-    output.push(item.to_json())
-  }
-  Json::array(output)
+  Json::array([ for item in self => item.to_json() ])
 }

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -123,9 +123,9 @@ pub fn[K, V] SortedMap::filter_with_key(
 ///|
 /// Returns an array of all key-value pairs in ascending key order.
 pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
-  let arr = []
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [
+    for k, v in self => (k, v)
+  ]
 }
 
 ///|

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -791,11 +791,7 @@ pub impl[A : Show] Show for SortedSet[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for SortedSet[A] with to_json(self) {
-  let capacity = self.iter().count()
-  guard capacity != 0 else { return Json::array([]) }
-  let jsons = Array::new(capacity~)
-  self.each(a => jsons.push(a.to_json()))
-  Json::array(jsons)
+  Json::array([ for a in self => a.to_json() ])
 }
 
 ///|

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -666,11 +666,7 @@ pub impl[A : Show] Show for Vector[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for Vector[A] with to_json(self) {
-  let len = self.length()
-  guard len != 0 else { return [] }
-  let res : Array[Json] = Array::make(len, null)
-  self.eachi((i, value) => res[i] = value.to_json())
-  Json::array(res)
+  Json::array([ for value in self => value.to_json() ])
 }
 
 ///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -346,22 +346,9 @@ pub fn[A, B] List::rev_map(
 /// }
 /// ```
 pub fn[A] List::to_array(self : List[A]) -> Array[A] {
-  match self {
-    Empty => []
-    More(x, tail=xs) => {
-      let arr = [x]
-      for cur = xs {
-        match cur {
-          Empty => break
-          More(x, tail=xs) => {
-            arr.push(x)
-            continue xs
-          }
-        }
-      }
-      arr
-    }
-  }
+  [
+    for x in self => x
+  ]
 }
 
 ///|

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -142,11 +142,7 @@ pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
 
 ///|
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(self) {
-  let arr = []
-  for x in self {
-    arr.push(x.to_json())
-  }
-  Json::array(arr)
+  Json::array([ for x in self => x.to_json() ])
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Convert array-building `loop`/`for` patterns to `for ... in` comprehensions across `list`, `immut/{vector,sorted_set,sorted_map,priority_queue,hashmap}`, `priority_queue`, `deque`, `env`, `bytes/internal/regex_engine`, and `argparse`
- Use `StringView` instead of `String` in argparse render paths to avoid intermediate allocations
- Reduce allocations in argparse `help_render` and `parser`

## Test plan
- [ ] CI green on stable-check (ubuntu/macos/windows)
- [ ] CI green on stable-native-opt-test (ubuntu/macos/windows)
- [ ] misc-check / version-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
