### PR TITLE
use list comprehension in ToJson impls

### DIFF
--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -75,7 +75,9 @@ pub impl[X : Show] Show for Iter[X] with output(self, logger) {
 
 ///|
 pub impl[X : ToJson] ToJson for Iter[X] with to_json(self) {
-  Json::array(self.map(x => x.to_json()).collect())
+  [
+    for x in self => x
+  ]
 }
 
 ///|

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -666,7 +666,9 @@ pub impl[A : Show] Show for Vector[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for Vector[A] with to_json(self) {
-  Json::array([ for value in self => value.to_json() ])
+  [
+    for value in self => value
+  ]
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Simplify `ToJson` implementation for `Iter` to use list comprehension instead of `Json::array` + `map` + `collect`
- Simplify `ToJson` implementation for `Vector` to use list comprehension without explicit `Json::array` wrapper and `.to_json()` call

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
