### PR TITLE
use list comprehension in more ToJson impls

### DIFF
--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -75,7 +75,9 @@ pub impl[X : Show] Show for Iter[X] with output(self, logger) {
 
 ///|
 pub impl[X : ToJson] ToJson for Iter[X] with to_json(self) {
-  Json::array(self.map(x => x.to_json()).collect())
+  [
+    for x in self => x
+  ]
 }
 
 ///|

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1675,7 +1675,9 @@ pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
 /// ```
 ///
 pub impl[A : ToJson] ToJson for Deque[A] with to_json(self : Deque[A]) -> Json {
-  Json::array([ for x in self => x.to_json() ])
+  [
+    for x in self => x
+  ]
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -672,13 +672,7 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      res.push(key.to_json())
-    }
-  }
-  Json::array(res)
+  [ for key in self => key ]
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -672,7 +672,9 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
-  [ for key in self => key ]
+  [
+    for key in self => key
+  ]
 }
 
 ///|

--- a/immut/priority_queue/types.mbt
+++ b/immut/priority_queue/types.mbt
@@ -30,5 +30,5 @@ priv enum Node[A] {
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(
   self : PriorityQueue[A],
 ) {
-  Json::array([ for item in self => item.to_json() ])
+  [ for item in self => item ]
 }

--- a/immut/priority_queue/types.mbt
+++ b/immut/priority_queue/types.mbt
@@ -30,5 +30,7 @@ priv enum Node[A] {
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(
   self : PriorityQueue[A],
 ) {
-  [ for item in self => item ]
+  [
+    for item in self => item
+  ]
 }

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -791,7 +791,7 @@ pub impl[A : Show] Show for SortedSet[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for SortedSet[A] with to_json(self) {
-  Json::array([ for a in self => a.to_json() ])
+  [ for a in self => a.to_json() ]
 }
 
 ///|

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -791,7 +791,9 @@ pub impl[A : Show] Show for SortedSet[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for SortedSet[A] with to_json(self) {
-  [ for a in self => a.to_json() ]
+  [
+    for a in self => a.to_json()
+  ]
 }
 
 ///|

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -666,7 +666,9 @@ pub impl[A : Show] Show for Vector[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for Vector[A] with to_json(self) {
-  Json::array([ for value in self => value.to_json() ])
+  [
+    for value in self => value
+  ]
 }
 
 ///|

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -79,7 +79,7 @@ test "to_array empty" {
 ///|
 test "to_json" {
   let v = @vector.from_iter((0).until(40))
-  let expected = Json::array(Array::makei(40, i => i.to_json()))
+  let expected : Json = [ for i in 0..<40 => i ]
   @json.json_inspect(v, content=expected)
   let empty : @vector.Vector[Int] = @vector.new()
   @json.json_inspect(empty, content=[])

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -94,7 +94,9 @@ pub impl[A : Show] Show for List[A] with output(xs, logger) {
 /// ToJson implementation for List.
 /// Converts a list to a JSON array.
 pub impl[A : ToJson] ToJson for List[A] with to_json(self) {
-  [ for a in self => a ]
+  [
+    for a in self => a
+  ]
 }
 
 ///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -94,13 +94,7 @@ pub impl[A : Show] Show for List[A] with output(xs, logger) {
 /// ToJson implementation for List.
 /// Converts a list to a JSON array.
 pub impl[A : ToJson] ToJson for List[A] with to_json(self) {
-  let capacity = self.length()
-  guard capacity != 0 else { return [] }
-  let jsons = Array::new(capacity~)
-  for a in self {
-    jsons.push(a.to_json())
-  }
-  Json::array(jsons)
+  [ for a in self => a ]
 }
 
 ///|

--- a/priority_queue/moon.pkg
+++ b/priority_queue/moon.pkg
@@ -9,6 +9,7 @@ import {
 import {
   "moonbitlang/core/random",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/json",
 } for "test"
 
 options(

--- a/priority_queue/moon.pkg
+++ b/priority_queue/moon.pkg
@@ -4,7 +4,6 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/splitmix",
-  "moonbitlang/core/json",
 }
 
 import {

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -142,7 +142,9 @@ pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
 
 ///|
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(self) {
-  Json::array([ for x in self => x.to_json() ])
+  [
+    for x in self => x
+  ]
 }
 
 ///|

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -594,7 +594,9 @@ pub fn[K : Hash + Eq] Set::intersection(
 
 ///|
 pub impl[X : ToJson] ToJson for Set[X] with to_json(self) {
-  [ for v in self => v ]
+  [
+    for v in self => v
+  ]
 }
 
 ///|

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -594,11 +594,7 @@ pub fn[K : Hash + Eq] Set::intersection(
 
 ///|
 pub impl[X : ToJson] ToJson for Set[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for v in self {
-    res.push(v.to_json())
-  }
-  Json::array(res)
+  [ for v in self => v ]
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Simplify `ToJson` implementations across `hashset`, `list`, `set`, `deque`, `priority_queue`, `immut/priority_queue`, and `immut/sorted_set` to use list comprehension syntax
- Update `immut/vector` test to use list comprehension
- Follow-up to #3450

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
