### PR TITLE
[codex] replace derived Show impls and deprecate weak Show cases

### DIFF
--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -27,6 +27,10 @@ pub(all) enum FlagAction {
 } derive(Eq)
 
 ///|
+#deprecated("FlagAction is parser configuration metadata; pattern match on the value instead of stringifying it.", skip_current_package=true)
+pub impl Show for FlagAction
+
+///|
 pub impl Show for FlagAction with output(self, logger) {
   match self {
     SetTrue => logger.write_string("SetTrue")
@@ -46,6 +50,10 @@ pub(all) enum OptionAction {
   Set
   Append
 } derive(Eq)
+
+///|
+#deprecated("OptionAction is parser configuration metadata; pattern match on the value instead of stringifying it.", skip_current_package=true)
+pub impl Show for OptionAction
 
 ///|
 pub impl Show for OptionAction with output(self, logger) {

--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -18,25 +18,42 @@
 /// - `SetTrue` / `SetFalse` set a boolean value.
 /// - `Count` increments `Matches.flag_counts`.
 /// - `Help` / `Version` display output and exit successfully when triggered.
-#warnings("-deprecated_syntax")
 pub(all) enum FlagAction {
   SetTrue
   SetFalse
   Count
   Help
   Version
-} derive(Eq, Show)
+} derive(Eq)
+
+///|
+pub impl Show for FlagAction with output(self, logger) {
+  match self {
+    SetTrue => logger.write_string("SetTrue")
+    SetFalse => logger.write_string("SetFalse")
+    Count => logger.write_string("Count")
+    Help => logger.write_string("Help")
+    Version => logger.write_string("Version")
+  }
+}
 
 ///|
 /// Behavior for option args.
 ///
 /// - `Set` keeps the last provided value.
 /// - `Append` keeps all provided values in order.
-#warnings("-deprecated_syntax")
 pub(all) enum OptionAction {
   Set
   Append
-} derive(Eq, Show)
+} derive(Eq)
+
+///|
+pub impl Show for OptionAction with output(self, logger) {
+  match self {
+    Set => logger.write_string("Set")
+    Append => logger.write_string("Append")
+  }
+}
 
 ///|
 /// Unified argument model used by the parser internals.

--- a/argparse/matches.mbt
+++ b/argparse/matches.mbt
@@ -17,12 +17,20 @@ using @debug {trait Debug, type Repr}
 
 ///|
 /// Where a value/flag came from.
-#warnings("-deprecated_syntax")
 pub enum ValueSource {
   Argv
   Env
   Default
-} derive(Eq, Show, Debug)
+} derive(Eq, Debug)
+
+///|
+pub impl Show for ValueSource with output(self, logger) {
+  match self {
+    Argv => logger.write_string("Argv")
+    Env => logger.write_string("Env")
+    Default => logger.write_string("Default")
+  }
+}
 
 ///|
 /// Parse results for declarative commands.

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -33,7 +33,8 @@ pub(all) enum FlagAction {
   Count
   Help
   Version
-} derive(Eq, Show)
+} derive(Eq)
+pub impl Show for FlagAction
 
 pub struct FlagArg {
   // private fields
@@ -54,7 +55,8 @@ pub struct Matches {
 pub(all) enum OptionAction {
   Set
   Append
-} derive(Eq, Show)
+} derive(Eq)
+pub impl Show for OptionAction
 
 pub struct OptionArg {
   // private fields
@@ -74,15 +76,17 @@ pub struct ValueRange {
   // private fields
 
   fn new(lower? : Int, upper? : Int) -> ValueRange
-} derive(Eq, Show)
+} derive(Eq)
 pub fn ValueRange::new(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::single() -> Self
+pub impl Show for ValueRange
 
 pub enum ValueSource {
   Argv
   Env
   Default
-} derive(Eq, Show, @debug.Debug)
+} derive(Eq, @debug.Debug)
+pub impl Show for ValueSource
 
 // Type aliases
 

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub(all) enum FlagAction {
   Help
   Version
 } derive(Eq)
+#deprecated
 pub impl Show for FlagAction
 
 pub struct FlagArg {
@@ -56,6 +57,7 @@ pub(all) enum OptionAction {
   Set
   Append
 } derive(Eq)
+#deprecated
 pub impl Show for OptionAction
 
 pub struct OptionArg {

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -14,14 +14,29 @@
 
 ///|
 /// Number-of-values constraint for an argument.
-#warnings("-deprecated_syntax-deprecated")
 pub struct ValueRange {
   priv lower : Int
   priv upper : Int?
 
   /// Create a value-count range.
   fn new(lower? : Int, upper? : Int) -> ValueRange
-} derive(Eq, Show)
+} derive(Eq)
+
+///|
+pub impl Show for ValueRange with output(self, logger) {
+  logger.write_string("{lower: ")
+  logger.write_object(self.lower)
+  logger.write_string(", upper: ")
+  match self.upper {
+    None => logger.write_string("None")
+    Some(upper) => {
+      logger.write_string("Some(")
+      logger.write_object(upper)
+      logger.write_string(")")
+    }
+  }
+  logger.write_string("}")
+}
 
 ///|
 /// Exact single-value range (`1..1`).

--- a/builtin/failure.mbt
+++ b/builtin/failure.mbt
@@ -34,10 +34,20 @@
 ///   @json.json_inspect(err, content=["Failure", "Test assertion failed"])
 /// }
 /// ```
-#warnings("-deprecated_syntax")
 pub(all) suberror Failure {
   Failure(String)
-} derive(ToJson, Show)
+} derive(ToJson)
+
+///|
+pub impl Show for Failure with output(self, logger) {
+  match self {
+    Failure(message) => {
+      logger.write_string("Failure(")
+      logger.write_object(message)
+      logger.write_string(")")
+    }
+  }
+}
 
 ///|
 /// Raises a `Failure` error with a given message and source location.

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -52,7 +52,8 @@ pub(all) suberror BenchError {
 
 pub(all) suberror Failure {
   Failure(String)
-} derive(Show, ToJson)
+} derive(ToJson)
+pub impl Show for Failure
 
 pub(all) suberror InspectError {
   InspectError(String)

--- a/cmp/cmp.mbt
+++ b/cmp/cmp.mbt
@@ -34,8 +34,14 @@ using @debug {trait Debug, type Repr}
 ///   inspect(a.to_string(), content="Reverse(1)") // Shows wrapped value
 /// }
 /// ```
-#warnings("-deprecated_syntax")
-pub(all) struct Reverse[T](T) derive(Eq, Show, Hash, @debug.Debug)
+pub(all) struct Reverse[T](T) derive(Eq, Hash, @debug.Debug)
+
+///|
+pub impl[T : Show] Show for Reverse[T] with output(self, logger) {
+  logger.write_string("Reverse(")
+  logger.write_object(self.0)
+  logger.write_string(")")
+}
 
 ///|
 pub impl[T : Compare] Compare for Reverse[T] with compare(a, b) {

--- a/cmp/pkg.generated.mbti
+++ b/cmp/pkg.generated.mbti
@@ -21,8 +21,9 @@ pub fn[T, K : Compare] minmax_by_key(T, T, (T) -> K) -> (T, T)
 // Errors
 
 // Types and methods
-pub(all) struct Reverse[T](T) derive(Eq, Hash, Show, @debug.Debug)
+pub(all) struct Reverse[T](T) derive(Eq, Hash, @debug.Debug)
 pub impl[T : Compare] Compare for Reverse[T]
+pub impl[T : Show] Show for Reverse[T]
 
 // Type aliases
 

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
 priv struct Entry[K, V] {
   mut psl : Int
   hash : Int

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
 priv struct Entry[K] {
   mut psl : Int
   hash : Int

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -17,10 +17,20 @@ using @debug {trait Debug, type Repr}
 
 ///|
 /// Error type `JsonDecodeError`.
-#warnings("-deprecated_syntax")
 pub(all) suberror JsonDecodeError {
   JsonDecodeError((JsonPath, String))
-} derive(Eq, Show, ToJson, @debug.Debug)
+} derive(Eq, ToJson, @debug.Debug)
+
+///|
+pub impl Show for JsonDecodeError with output(self, logger) {
+  match self {
+    JsonDecodeError(details) => {
+      logger.write_string("JsonDecodeError(")
+      logger.write_object(details)
+      logger.write_string(")")
+    }
+  }
+}
 
 ///|
 /// Trait for types that can be converted from `Json`

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -20,7 +20,8 @@ pub fn valid(StringView) -> Bool
 // Errors
 pub(all) suberror JsonDecodeError {
   JsonDecodeError((JsonPath, String))
-} derive(Eq, Show, ToJson, @debug.Debug)
+} derive(Eq, ToJson, @debug.Debug)
+pub impl Show for JsonDecodeError
 
 pub(all) suberror ParseError {
   InvalidChar(Position, Char)

--- a/quickcheck/splitmix/README.mbt.md
+++ b/quickcheck/splitmix/README.mbt.md
@@ -11,15 +11,14 @@ Create and initialize random number generators:
 test "random state creation" {
   // Create with default seed
   let rng1 = @splitmix.new()
-  inspect(rng1.to_string().length() > 0, content="true")
+  inspect(rng1.next_uint().to_string().length() > 0, content="true")
 
   // Create with specific seed
   let rng2 = @splitmix.new(seed=12345UL)
-  inspect(rng2.to_string().length() > 0, content="true")
 
   // Clone existing state
   let rng3 = rng2.clone()
-  inspect(rng3.to_string().length() > 0, content="true")
+  inspect(rng2.next_uint() == rng3.next_uint(), content="true")
 }
 ```
 

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -7,7 +7,7 @@ pub fn new(seed? : UInt64) -> RandomState
 // Errors
 
 // Types and methods
-type RandomState derive(Show)
+type RandomState
 pub fn RandomState::clone(Self) -> Self
 #deprecated
 pub fn RandomState::new(seed? : UInt64) -> Self
@@ -22,6 +22,7 @@ pub fn RandomState::next_uint(Self) -> UInt
 pub fn RandomState::next_uint64(Self) -> UInt64
 pub fn RandomState::split(Self) -> Self
 pub impl Default for RandomState
+pub impl Show for RandomState
 
 // Type aliases
 

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub fn RandomState::next_uint(Self) -> UInt
 pub fn RandomState::next_uint64(Self) -> UInt64
 pub fn RandomState::split(Self) -> Self
 pub impl Default for RandomState
+#deprecated
 pub impl Show for RandomState
 
 // Type aliases

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -19,6 +19,10 @@ struct RandomState {
 }
 
 ///|
+#deprecated("RandomState is generator state; use generated values instead of formatting the state.", skip_current_package=true)
+pub impl Show for RandomState
+
+///|
 pub impl Show for RandomState with output(self, logger) {
   logger.write_string("{seed: ")
   logger.write_object(self.seed)

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -13,11 +13,19 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
 struct RandomState {
   mut seed : UInt64
   gamma : UInt64
-} derive(Show)
+}
+
+///|
+pub impl Show for RandomState with output(self, logger) {
+  logger.write_string("{seed: ")
+  logger.write_object(self.seed)
+  logger.write_string(", gamma: ")
+  logger.write_object(self.gamma)
+  logger.write_string("}")
+}
 
 ///|
 let golden_gamma : UInt64 = 0x9e3779b97f4a7c15


### PR DESCRIPTION
## Summary

This PR removes live `derive(Show)` usage from the affected core packages and replaces each one with an explicit standalone `impl Show`.

It also removes the `#warnings("-deprecated_syntax")` suppressions that were masking those definitions, regenerates the affected `.mbti` files, and deprecates the new `Show` impls whose output should not be treated as stable API.

## What Changed

- replaced live source `derive(Show)` definitions with explicit `impl Show`
- removed deprecated-syntax warning suppressions from the touched source files
- deprecated `Show` for `RandomState`, `FlagAction`, and `OptionAction`
- kept `Show` non-deprecated for intentional string forms such as `Failure`, `JsonDecodeError`, `Reverse`, `ValueRange`, and `ValueSource`
- updated the `quickcheck/splitmix` README to stop demonstrating `RandomState::to_string()`
- regenerated affected `pkg.generated.mbti` files

## Why

The repo still had a small set of `derive(Show)` sites that depended on deprecated syntax, and some of those sites were shielded by local warning suppressions.

Converting them to explicit impls makes the behavior visible in ordinary source, removes reliance on deprecated syntax, and exposes any remaining issues directly. The follow-up deprecations keep weak or incidental string representations from becoming encouraged public API.

## Impact

- the deprecated-syntax suppressions in the touched files are gone
- the exported API now shows standalone `impl Show` entries instead of `derive(Show)` in generated interfaces
- callers that stringify `RandomState`, `FlagAction`, or `OptionAction` will now see deprecation metadata

## Validation

- `moon info`
- `moon fmt`
- `moon check`
- `moon test argparse json builtin cmp quickcheck/splitmix`
- `moon test argparse quickcheck/splitmix`
