### PR TITLE
feat(builtin): add unsafe_read uint helpers for FixedArray[Byte] and ArrayView[Byte]

### DIFF
--- a/builtin/bytes_unsafe.mbt
+++ b/builtin/bytes_unsafe.mbt
@@ -208,6 +208,138 @@ pub fn FixedArray::unsafe_write_uint16_be(
   }
 }
 
+///|
+/// **UNSAFE**: Reads a UInt64 from the FixedArray[Byte] in little-endian byte order.
+///
+/// ⚠️ **Warning: This function is unsafe and can cause undefined behavior!**
+///
+/// # Safety
+/// - **No bounds checking**: This function does not verify that `index + 7 < bytes.length()`
+/// - **Buffer overrun risk**: Reading beyond the array boundary may access invalid memory
+/// - **Responsibility**: Caller must ensure sufficient bytes are available
+#intrinsic("%bytes.unsafe_read_uint64_le")
+#doc(hidden)
+pub fn FixedArray::unsafe_read_uint64_le(
+  bytes : FixedArray[Byte],
+  index : Int,
+) -> UInt64 {
+  for i in 0..<=7; result = (0 : UInt64) {
+    continue result | (bytes.unsafe_get(i + index).to_uint64() << (8 * i))
+  } nobreak {
+    result
+  }
+}
+
+///|
+/// **UNSAFE**: Reads a UInt64 from the FixedArray[Byte] in big-endian byte order.
+///
+/// ⚠️ **Warning: This function is unsafe and can cause undefined behavior!**
+///
+/// # Safety
+/// - **No bounds checking**: This function does not verify that `index + 7 < bytes.length()`
+/// - **Buffer overrun risk**: Reading beyond the array boundary may access invalid memory
+/// - **Responsibility**: Caller must ensure sufficient bytes are available
+#intrinsic("%bytes.unsafe_read_uint64_be")
+#doc(hidden)
+pub fn FixedArray::unsafe_read_uint64_be(
+  bytes : FixedArray[Byte],
+  index : Int,
+) -> UInt64 {
+  for i in 0..<=7; result = (0 : UInt64) {
+    continue result | (bytes.unsafe_get(i + index).to_uint64() << (8 * (7 - i)))
+  } nobreak {
+    result
+  }
+}
+
+///|
+/// **UNSAFE**: Reads a UInt32 from the FixedArray[Byte] in little-endian byte order.
+///
+/// ⚠️ **Warning: This function is unsafe and can cause undefined behavior!**
+///
+/// # Safety
+/// - **No bounds checking**: This function does not verify that `index + 3 < bytes.length()`
+/// - **Buffer overrun risk**: Reading beyond the array boundary may access invalid memory
+/// - **Responsibility**: Caller must ensure sufficient bytes are available
+#intrinsic("%bytes.unsafe_read_uint32_le")
+#doc(hidden)
+pub fn FixedArray::unsafe_read_uint32_le(
+  bytes : FixedArray[Byte],
+  index : Int,
+) -> UInt {
+  for i in 0..<=3; result = (0 : UInt) {
+    continue result | (bytes.unsafe_get(i + index).to_uint() << (8 * i))
+  } nobreak {
+    result
+  }
+}
+
+///|
+/// **UNSAFE**: Reads a UInt32 from the FixedArray[Byte] in big-endian byte order.
+///
+/// ⚠️ **Warning: This function is unsafe and can cause undefined behavior!**
+///
+/// # Safety
+/// - **No bounds checking**: This function does not verify that `index + 3 < bytes.length()`
+/// - **Buffer overrun risk**: Reading beyond the array boundary may access invalid memory
+/// - **Responsibility**: Caller must ensure sufficient bytes are available
+#intrinsic("%bytes.unsafe_read_uint32_be")
+#doc(hidden)
+pub fn FixedArray::unsafe_read_uint32_be(
+  bytes : FixedArray[Byte],
+  index : Int,
+) -> UInt {
+  for i in 0..<=3; result = (0 : UInt) {
+    continue result | (bytes.unsafe_get(i + index).to_uint() << (8 * (3 - i)))
+  } nobreak {
+    result
+  }
+}
+
+///|
+/// **UNSAFE**: Reads a UInt16 from the FixedArray[Byte] in little-endian byte order.
+///
+/// ⚠️ **Warning: This function is unsafe and can cause undefined behavior!**
+///
+/// # Safety
+/// - **No bounds checking**: This function does not verify that `index + 1 < bytes.length()`
+/// - **Buffer overrun risk**: Reading beyond the array boundary may access invalid memory
+/// - **Responsibility**: Caller must ensure sufficient bytes are available
+#intrinsic("%bytes.unsafe_read_uint16_le")
+#doc(hidden)
+pub fn FixedArray::unsafe_read_uint16_le(
+  bytes : FixedArray[Byte],
+  index : Int,
+) -> UInt16 {
+  for i in 0..<=1; result = (0 : UInt16) {
+    continue result | (bytes.unsafe_get(i + index).to_uint16() << (8 * i))
+  } nobreak {
+    result
+  }
+}
+
+///|
+/// **UNSAFE**: Reads a UInt16 from the FixedArray[Byte] in big-endian byte order.
+///
+/// ⚠️ **Warning: This function is unsafe and can cause undefined behavior!**
+///
+/// # Safety
+/// - **No bounds checking**: This function does not verify that `index + 1 < bytes.length()`
+/// - **Buffer overrun risk**: Reading beyond the array boundary may access invalid memory
+/// - **Responsibility**: Caller must ensure sufficient bytes are available
+#intrinsic("%bytes.unsafe_read_uint16_be")
+#doc(hidden)
+pub fn FixedArray::unsafe_read_uint16_be(
+  bytes : FixedArray[Byte],
+  index : Int,
+) -> UInt16 {
+  for i in 0..<=1; result = (0 : UInt16) {
+    continue result | (bytes.unsafe_get(i + index).to_uint16() << (8 * (1 - i)))
+  } nobreak {
+    result
+  }
+}
+
 // #endregion
 // #region Bytes
 
@@ -529,6 +661,78 @@ pub fn BytesView::unsafe_read_uint16_be(
   index : Int,
 ) -> UInt16 {
   bytes.bytes().unsafe_read_uint16_be(bytes.start() + index)
+}
+
+// #endregion
+// #region ArrayView
+// Note: ArrayView[Byte] is treated as immutable here — only read methods are
+// provided (no write counterparts). Each method forwards to the corresponding
+// FixedArray[Byte] read, re-using the `%bytes.unsafe_read_*` intrinsic via
+// a zero-cost reinterpretation of the underlying buffer.
+
+///|
+fn buffer_to_fixedarray(
+  buf : UninitializedArray[Byte],
+) -> FixedArray[Byte] = "%identity"
+
+///|
+/// **UNSAFE**: Reads a UInt64 from the ArrayView[Byte] in little-endian byte order.
+#doc(hidden)
+pub fn ArrayView::unsafe_read_uint64_le(
+  bytes : ArrayView[Byte],
+  index : Int,
+) -> UInt64 {
+  buffer_to_fixedarray(bytes.buf()).unsafe_read_uint64_le(bytes.start() + index)
+}
+
+///|
+/// **UNSAFE**: Reads a UInt64 from the ArrayView[Byte] in big-endian byte order.
+#doc(hidden)
+pub fn ArrayView::unsafe_read_uint64_be(
+  bytes : ArrayView[Byte],
+  index : Int,
+) -> UInt64 {
+  buffer_to_fixedarray(bytes.buf()).unsafe_read_uint64_be(bytes.start() + index)
+}
+
+///|
+/// **UNSAFE**: Reads a UInt32 from the ArrayView[Byte] in little-endian byte order.
+#doc(hidden)
+pub fn ArrayView::unsafe_read_uint32_le(
+  bytes : ArrayView[Byte],
+  index : Int,
+) -> UInt {
+  buffer_to_fixedarray(bytes.buf()).unsafe_read_uint32_le(bytes.start() + index)
+}
+
+///|
+/// **UNSAFE**: Reads a UInt32 from the ArrayView[Byte] in big-endian byte order.
+#doc(hidden)
+pub fn ArrayView::unsafe_read_uint32_be(
+  bytes : ArrayView[Byte],
+  index : Int,
+) -> UInt {
+  buffer_to_fixedarray(bytes.buf()).unsafe_read_uint32_be(bytes.start() + index)
+}
+
+///|
+/// **UNSAFE**: Reads a UInt16 from the ArrayView[Byte] in little-endian byte order.
+#doc(hidden)
+pub fn ArrayView::unsafe_read_uint16_le(
+  bytes : ArrayView[Byte],
+  index : Int,
+) -> UInt16 {
+  buffer_to_fixedarray(bytes.buf()).unsafe_read_uint16_le(bytes.start() + index)
+}
+
+///|
+/// **UNSAFE**: Reads a UInt16 from the ArrayView[Byte] in big-endian byte order.
+#doc(hidden)
+pub fn ArrayView::unsafe_read_uint16_be(
+  bytes : ArrayView[Byte],
+  index : Int,
+) -> UInt16 {
+  buffer_to_fixedarray(bytes.buf()).unsafe_read_uint16_be(bytes.start() + index)
 }
 
 // #endregion

--- a/builtin/bytes_unsafe.mbt
+++ b/builtin/bytes_unsafe.mbt
@@ -671,9 +671,7 @@ pub fn BytesView::unsafe_read_uint16_be(
 // a zero-cost reinterpretation of the underlying buffer.
 
 ///|
-fn buffer_to_fixedarray(
-  buf : UninitializedArray[Byte],
-) -> FixedArray[Byte] = "%identity"
+fn buffer_to_fixedarray(buf : UninitializedArray[Byte]) -> FixedArray[Byte] = "%identity"
 
 ///|
 /// **UNSAFE**: Reads a UInt64 from the ArrayView[Byte] in little-endian byte order.

--- a/builtin/bytes_unsafe_test.mbt
+++ b/builtin/bytes_unsafe_test.mbt
@@ -323,3 +323,100 @@ test "unsafe_read_uint16 and view reads" {
   inspect(view.unsafe_read_uint16_le(6).to_int(), content="2055")
   inspect(view.unsafe_read_uint16_be(6).to_int(), content="1800")
 }
+
+///|
+test "FixedArray[Byte]::unsafe_read_uint64" {
+  let arr : FixedArray[Byte] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+  ]
+  inspect(arr.unsafe_read_uint64_le(0) == 0x0807060504030201UL, content="true")
+  inspect(arr.unsafe_read_uint64_be(0) == 0x0102030405060708UL, content="true")
+}
+
+///|
+test "FixedArray[Byte]::unsafe_read_uint32" {
+  let arr : FixedArray[Byte] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
+  inspect(arr.unsafe_read_uint32_le(0) == 0x04030201U, content="true")
+  inspect(arr.unsafe_read_uint32_be(0) == 0x01020304U, content="true")
+  inspect(arr.unsafe_read_uint32_le(2) == 0x06050403U, content="true")
+}
+
+///|
+test "FixedArray[Byte]::unsafe_read_uint16" {
+  let arr : FixedArray[Byte] = [0x01, 0x02, 0x03, 0x04]
+  inspect(arr.unsafe_read_uint16_le(0).to_int(), content="513") // 0x0201
+  inspect(arr.unsafe_read_uint16_be(0).to_int(), content="258") // 0x0102
+  inspect(arr.unsafe_read_uint16_le(2).to_int(), content="1027") // 0x0403
+}
+
+///|
+test "ArrayView[Byte]::unsafe_read_uint64 basic functionality" {
+  let arr : Array[Byte] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+  ]
+  let view = arr[0:8]
+  inspect(
+    view.unsafe_read_uint64_le(0) == 0x0807060504030201UL,
+    content="true",
+  )
+  inspect(
+    view.unsafe_read_uint64_be(0) == 0x0102030405060708UL,
+    content="true",
+  )
+}
+
+///|
+test "ArrayView[Byte]::unsafe_read_uint32 basic functionality" {
+  let arr : Array[Byte] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
+  let view = arr[0:6]
+  inspect(view.unsafe_read_uint32_le(0) == 0x04030201U, content="true")
+  inspect(view.unsafe_read_uint32_be(0) == 0x01020304U, content="true")
+  // offset within view
+  inspect(view.unsafe_read_uint32_le(2) == 0x06050403U, content="true")
+  inspect(view.unsafe_read_uint32_be(2) == 0x03040506U, content="true")
+}
+
+///|
+test "ArrayView[Byte]::unsafe_read_uint16 basic functionality" {
+  let arr : Array[Byte] = [0x01, 0x02, 0x03, 0x04]
+  let view = arr[0:4]
+  inspect(view.unsafe_read_uint16_le(0).to_int(), content="513") // 0x0201
+  inspect(view.unsafe_read_uint16_be(0).to_int(), content="258") // 0x0102
+  inspect(view.unsafe_read_uint16_le(2).to_int(), content="1027") // 0x0403
+  inspect(view.unsafe_read_uint16_be(2).to_int(), content="772") // 0x0304
+}
+
+///|
+test "ArrayView[Byte]::unsafe_read with non-zero view start" {
+  // view that starts partway into the underlying array
+  let arr : Array[Byte] = [
+    0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+  ]
+  let view = arr[2:10]
+  inspect(
+    view.unsafe_read_uint64_le(0) == 0x0807060504030201UL,
+    content="true",
+  )
+  inspect(view.unsafe_read_uint32_be(0) == 0x01020304U, content="true")
+  inspect(view.unsafe_read_uint16_le(6).to_int(), content="2055") // 0x0807
+}
+
+///|
+test "ArrayView[Byte]::unsafe_read edge values" {
+  let zeros : Array[Byte] = [0, 0, 0, 0, 0, 0, 0, 0]
+  let zview = zeros[0:8]
+  inspect(zview.unsafe_read_uint64_le(0) == 0UL, content="true")
+  inspect(zview.unsafe_read_uint64_be(0) == 0UL, content="true")
+  let ones : Array[Byte] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+  let oview = ones[0:8]
+  inspect(
+    oview.unsafe_read_uint64_le(0) == 0xFFFFFFFFFFFFFFFFUL,
+    content="true",
+  )
+  inspect(
+    oview.unsafe_read_uint64_be(0) == 0xFFFFFFFFFFFFFFFFUL,
+    content="true",
+  )
+  inspect(oview.unsafe_read_uint32_le(0) == 0xFFFFFFFFU, content="true")
+  inspect(oview.unsafe_read_uint16_le(0).to_int(), content="65535")
+}

--- a/builtin/bytes_unsafe_test.mbt
+++ b/builtin/bytes_unsafe_test.mbt
@@ -326,9 +326,7 @@ test "unsafe_read_uint16 and view reads" {
 
 ///|
 test "FixedArray[Byte]::unsafe_read_uint64" {
-  let arr : FixedArray[Byte] = [
-    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-  ]
+  let arr : FixedArray[Byte] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
   inspect(arr.unsafe_read_uint64_le(0) == 0x0807060504030201UL, content="true")
   inspect(arr.unsafe_read_uint64_be(0) == 0x0102030405060708UL, content="true")
 }
@@ -355,14 +353,8 @@ test "ArrayView[Byte]::unsafe_read_uint64 basic functionality" {
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
   ]
   let view = arr[0:8]
-  inspect(
-    view.unsafe_read_uint64_le(0) == 0x0807060504030201UL,
-    content="true",
-  )
-  inspect(
-    view.unsafe_read_uint64_be(0) == 0x0102030405060708UL,
-    content="true",
-  )
+  inspect(view.unsafe_read_uint64_le(0) == 0x0807060504030201UL, content="true")
+  inspect(view.unsafe_read_uint64_be(0) == 0x0102030405060708UL, content="true")
 }
 
 ///|
@@ -393,10 +385,7 @@ test "ArrayView[Byte]::unsafe_read with non-zero view start" {
     0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
   ]
   let view = arr[2:10]
-  inspect(
-    view.unsafe_read_uint64_le(0) == 0x0807060504030201UL,
-    content="true",
-  )
+  inspect(view.unsafe_read_uint64_le(0) == 0x0807060504030201UL, content="true")
   inspect(view.unsafe_read_uint32_be(0) == 0x01020304U, content="true")
   inspect(view.unsafe_read_uint16_le(6).to_int(), content="2055") // 0x0807
 }


### PR DESCRIPTION
## Summary
- Adds `unsafe_read_uint{16,32,64}_{le,be}` on `FixedArray[Byte]` (6 methods), each annotated with the matching `%bytes.unsafe_read_*` intrinsic — symmetric with the pre-existing `unsafe_write_*` set.
- Adds `unsafe_read_uint{16,32,64}_{le,be}` on `ArrayView[Byte]` (6 methods). These forward to the `FixedArray[Byte]` reads via a `%identity` reinterpret of the view's backing buffer, so they pick up the intrinsic implementation transparently — same shape as the existing `BytesView -> Bytes` forwards.
- All new functions are `#doc(hidden)` (consistent with the `Bytes`/`BytesView` read siblings); no public mbti surface change.

## Test plan
- [x] `moon test -p builtin -f bytes_unsafe_test.mbt` passes on wasm, wasm-gc, js, native (22/22)
- [x] `moon check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
