### PR TITLE
perf(debug): avoid per-element allocation in compact_lines

### DIFF
--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -152,39 +152,38 @@ fn compact_lines(lines : Array[String]) -> Array[String] {
       // Special-case bracket/brace blocks: "[ ... ]" and "{ ... }"
       // produced by `bracket_seq_lines`.
       if (first == "[" && last == "]") || (first == "{" && last == "}") {
-        let parts : Array[String] = []
+        let parts : Array[StringView] = []
         for m in middle {
-          let t = m.trim().to_owned()
+          let t = m.trim()
           if t != "" {
             parts.push(t)
           }
         }
         let joined0 = parts.join(" ")
-        let joined = match joined0.strip_suffix(",") {
-          Some(sv) => sv.to_owned()
-          None => joined0
+        let joined : StringView = match joined0.strip_suffix(",") {
+          Some(sv) => sv
+          None => joined0[:]
         }
 
         // Match expected style:
         // - arrays: [a, b]
         // - records/maps: { field: value, field: value }
         if first == "{" {
-          let inner0 = joined
-          let inner1 = match inner0.strip_prefix(" ") {
-            Some(sv) => sv.to_owned()
-            None => inner0
+          let s1 = match joined.strip_prefix(" ") {
+            Some(sv) => sv
+            None => joined
           }
-          let inner = match inner1.strip_suffix(" ") {
-            Some(sv) => sv.to_owned()
-            None => inner1
+          let inner = match s1.strip_suffix(" ") {
+            Some(sv) => sv
+            None => s1
           }
           if inner == "" {
             ["{}"]
           } else {
-            ["{ " + inner + " }"]
+            ["{ \{inner} }"]
           }
         } else {
-          ["[" + joined + "]"]
+          ["[\{joined}]"]
         }
         // Special-case parenthesized call-like blocks produced by `comma_seq_lines`:
         //
@@ -201,19 +200,19 @@ fn compact_lines(lines : Array[String]) -> Array[String] {
         // Enum(a, b)
         // ```
       } else if first.has_suffix("(") && last == ")" {
-        let parts : Array[String] = []
+        let parts : Array[StringView] = []
         for m in middle {
           let t = m.trim()
           if t != "" {
-            parts.push(t.to_owned())
+            parts.push(t)
           }
         }
         let joined0 = parts.join(" ")
-        let joined = match joined0.strip_suffix(",") {
-          Some(sv) => sv.to_owned()
-          None => joined0
+        let joined : StringView = match joined0.strip_suffix(",") {
+          Some(sv) => sv
+          None => joined0[:]
         }
-        [first + joined + last]
+        ["\{first}\{joined}\{last}"]
       } else {
         let parts : Array[StringView] = [first]
         for m in middle {
@@ -286,11 +285,11 @@ fn bracket_seq_lines(
           [] => [open + close]
           [x] =>
             if open == "{" && close == "}" {
-              let inner = x.trim().to_owned()
+              let inner = x.trim()
               if inner == "" {
                 ["{}"]
               } else {
-                ["{ " + inner + " }"]
+                ["{ \{inner} }"]
               }
             } else {
               [open + x + close]


### PR DESCRIPTION
## Summary

\`compact_lines\` in \`debug/printer.mbt\` was doing \`N + ~5\` allocations per call (N = middle elements in a bracket/brace/paren group): one \`to_owned\` per trimmed element, one per strip_prefix/strip_suffix, one per final concat. Since \`compact_lines\` is called recursively on every debug print, those compound.

This PR keeps substrings as \`StringView\` until the final \`join\` / string interpolation, so each branch produces a constant **~2 allocations** regardless of N.

## Why this was easy to find

\`rg '\\.to_owned\\(\\)' debug/printer.mbt\` returned exactly 7 candidate sites. All 7 turned out to be removable because downstream operations (\`Array[StringView].join\`, string-literal interpolation \`"[\\{view}]"\`) accept views natively. That was the whole point of the recent rename: turn "audit for unnecessary allocations" into a tractable grep.

## No public API change

\`compact_lines\` is a private \`fn\`; signatures and \`debug/pkg.generated.mbti\` are untouched.

## Test plan
- [x] \`moon test --target all\` — 6333 wasm / 6333 wasm-gc / 6291 js / 6245 native all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)