### PR TITLE
perf(argparse): thread ArrayView[String] through subcommand dispatch

### DIFF
--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -77,10 +77,10 @@ fn raise_context_help(
 }
 
 ///|
-fn default_argv() -> Array[String] {
+fn default_argv() -> ArrayView[String] {
   let args = @env.args()
   if args.length() > 1 {
-    args[1:].to_owned()
+    args[1:]
   } else {
     []
   }
@@ -546,7 +546,7 @@ fn parse_command_impl(
       if positional_arg_found {
         raise_subcommand_conflict("help")
       }
-      let rest = argv[i + 1:].to_owned()
+      let rest = argv[i + 1:]
       let (target, target_globals, target_path) = resolve_help_target(
         cmd, rest, builtin_help_short, builtin_help_long, inherited_globals, command_path,
       )
@@ -557,7 +557,7 @@ fn parse_command_impl(
       if positional_arg_found {
         raise_subcommand_conflict(sub.name)
       }
-      let rest = argv[i + 1:].to_owned()
+      let rest = argv[i + 1:]
       let sub_path = if command_path == "" {
         sub.name
       } else {

--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -58,7 +58,7 @@ fn collect_non_global_names(args : Array[Arg]) -> @set.Set[String] {
 ///|
 fn resolve_help_target(
   cmd : Command,
-  argv : Array[String],
+  argv : ArrayView[String],
   builtin_help_short : Bool,
   builtin_help_long : Bool,
   inherited_globals : Array[Arg],
@@ -110,7 +110,7 @@ fn split_long(arg : String) -> (StringView, String?) {
       Some(view) => view
       None => parts[0]
     }
-    let value = parts[1:].to_owned().join("=")
+    let value = parts[1:].join("=")
     (name, Some(value))
   }
 }


### PR DESCRIPTION
## Summary

Four \`.to_owned()\` calls in the argparse parser hot path were eagerly materializing an \`Array[String]\` from what downstream consumers already accept as \`ArrayView[String]\`:

| Location | Before | After |
|---|---|---|
| \`parser.mbt::default_argv\` | returns \`Array[String]\` via \`args[1:].to_owned()\` | returns \`ArrayView[String]\` — \`Command::parse.argv?\` already takes \`ArrayView\` |
| \`parser.mbt:549\` (help dispatch) | \`argv[i+1:].to_owned()\` | \`argv[i+1:]\` — \`resolve_help_target\` now takes \`ArrayView\` |
| \`parser.mbt:560\` (subcommand dispatch) | \`argv[i+1:].to_owned()\` | \`argv[i+1:]\` — \`parse_command\` already takes \`ArrayView\` |
| \`parser_lookup.mbt:113\` (\`split_long\`) | \`parts[1:].to_owned().join("=")\` | \`parts[1:].join("=")\` — \`.join\` works on \`ArrayView[StringView]\` |

Each call saves one \`Array\` allocation per invocation. Nested subcommand dispatch takes several of these per parse.

## Why this was easy to find

\`rg '\\.to_owned\\(\\)' argparse/\` turned up 34 sites. Most (in \`arg_spec.mbt\` / \`arg_group.mbt\` / \`command.mbt\`) are genuinely structural — \`Arg\` struct fields are \`String\` / \`Array[String]\`, so the owned-copy is required. The four sites fixed here were the ones where downstream already accepted views; they were just over-materializing.

## No public API change

\`default_argv\` and \`resolve_help_target\` are private \`fn\`s. \`parse_command\` already declared \`argv : ArrayView[String]\`. \`argparse/pkg.generated.mbti\` untouched.

## Test plan
- [x] \`moon test --target all\` — 6333 wasm / 6333 wasm-gc / 6291 js / 6245 native all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
