### PR TITLE
perf(deque): drop separator.to_owned() in Deque::join

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1655,8 +1655,17 @@ pub fn[A] Deque::to_array(self : Deque[A]) -> Array[A] {
 /// }
 /// ```
 pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
-  let str = separator.to_owned()
-  self.iter().join(str)
+  let buf = StringBuilder::new()
+  let mut first = true
+  for s in self {
+    if first {
+      first = false
+    } else {
+      buf.write_view(separator)
+    }
+    buf.write_string(s)
+  }
+  buf.to_string()
 }
 
 ///|


### PR DESCRIPTION
## Summary

\`Deque::join(separator : StringView)\` was materializing the separator into an owned \`String\` just to feed it to \`Iter::join\`, which takes \`String\`. Inline the loop with \`StringBuilder\` and use \`write_view\` for the separator instead.

## Allocation impact

| Target | Before | After |
|---|---|---|
| wasm / wasm-gc / native | 1 allocation for \`separator.to_owned()\`, then N×\`write_string\` blits into the FixedArray buffer | 0 allocation for separator — \`write_view\` blits the source range directly |
| js | 1 allocation for \`separator.to_owned()\` + N concat-steps | N \`write_view\` calls (currently allocate per-call on js) — no worse than before, and the upfront \`to_owned\` is gone |

## Why this was easy to find

\`rg '\\.to_owned\\(\\)' deque/\` turned up exactly one site. The call was feeding \`Iter::join\`, which takes a \`String\` — so the \`to_owned\` was required *only because of that downstream signature*. Inlining the loop lets us use \`write_view\` directly, which accepts \`StringView\`.

## No public API change

\`Deque::join\`'s signature is unchanged; \`deque/pkg.generated.mbti\` untouched.

## Test plan
- [x] \`moon test --target all\` — 6333 wasm / 6333 wasm-gc / 6291 js / 6245 native all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
