### PR TITLE
perf(builtin): expand Hasher::combine_{string,bytes} to accept views

### DIFF
--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -353,7 +353,7 @@ pub fn Hasher::combine_byte(self : Hasher, value : Byte) -> Unit {
 ///   inspect(hasher.finalize(), content="-686861102")
 /// }
 /// ```
-pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
+pub fn Hasher::combine_bytes(self : Hasher, value : BytesView) -> Unit {
   let (cur, remain) = for cur = 0, remain = value.length(); remain >= 4; {
     self.consume4(endian32(value, cur))
     continue cur + 4, remain - 4
@@ -384,7 +384,7 @@ pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
 ///   inspect(hasher.finalize(), content="-655549713")
 /// }
 /// ```
-pub fn Hasher::combine_string(self : Hasher, value : String) -> Unit {
+pub fn Hasher::combine_string(self : Hasher, value : StringView) -> Unit {
   for i in 0..<value.length() {
     self.combine_uint(value.unsafe_get(i).to_int().reinterpret_as_uint())
   }
@@ -463,7 +463,7 @@ fn rotl(x : UInt, r : Int) -> UInt {
 }
 
 ///|
-fn endian32(input : Bytes, cur : Int) -> UInt {
+fn endian32(input : BytesView, cur : Int) -> UInt {
   input[cur + 0].to_uint() |
   (
     (input[cur + 1].to_uint() << 8) |
@@ -502,10 +502,7 @@ pub impl Hash for StringView with hash_combine(
   self : StringView,
   hasher : Hasher,
 ) -> Unit {
-  let str = self.str()
-  for i in self.start()..<self.end() {
-    hasher.combine_uint(str.unsafe_get(i).to_int().reinterpret_as_uint())
-  }
+  hasher.combine_string(self)
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -246,14 +246,14 @@ type Hasher
 pub fn[T : Hash] Hasher::combine(Self, T) -> Unit
 pub fn Hasher::combine_bool(Self, Bool) -> Unit
 pub fn Hasher::combine_byte(Self, Byte) -> Unit
-pub fn Hasher::combine_bytes(Self, Bytes) -> Unit
+pub fn Hasher::combine_bytes(Self, BytesView) -> Unit
 pub fn Hasher::combine_char(Self, Char) -> Unit
 pub fn Hasher::combine_double(Self, Double) -> Unit
 #deprecated
 pub fn Hasher::combine_float(Self, Float) -> Unit
 pub fn Hasher::combine_int(Self, Int) -> Unit
 pub fn Hasher::combine_int64(Self, Int64) -> Unit
-pub fn Hasher::combine_string(Self, String) -> Unit
+pub fn Hasher::combine_string(Self, StringView) -> Unit
 pub fn Hasher::combine_uint(Self, UInt) -> Unit
 pub fn Hasher::combine_uint64(Self, UInt64) -> Unit
 pub fn Hasher::combine_unit(Self) -> Unit


### PR DESCRIPTION
## Summary

Follow-on to #3459. The same argument — \`StringView\` / \`BytesView\` are views over immutable data, so substituting them for the owned types at read-only API boundaries is always safe — applies to the \`Hasher\` helpers:

| Method | Before | After |
|---|---|---|
| \`Hasher::combine_string\` | \`value : String\` | \`value : StringView\` |
| \`Hasher::combine_bytes\` | \`value : Bytes\` | \`value : BytesView\` |

Internal private helper \`endian32\` is similarly expanded so the \`combine_bytes\` chain compiles.

Expanding mbti change: every existing caller keeps working (\`String\` / \`Bytes\` values and literals coerce to their view types at argument passing).

## Cleanup dividend

With \`combine_string\` now accepting \`StringView\`, the \`Hash for StringView\` impl collapses from a 9-line manual loop to a one-liner. The two were doing the same thing — iterate UTF-16 code units and call \`combine_uint\` on each — just in different code.

\`Hash for BytesView\` is *not* simplified the same way: its 4-byte-packing loop uses \`combine_uint\` / \`combine_byte\`, while \`combine_bytes\` uses the lower-level \`consume4\` / \`consume1\`. Delegating would change observable hash values for every existing \`Bytes\` consumer — not acceptable. Left as-is.

## Test plan
- [x] \`moon test --target all\` — 6333 wasm / 6333 wasm-gc / 6291 js / 6245 native all pass. (The BytesView-algorithm concern above was caught by the existing \`bytes/bytes_test.mbt\` hash test during development.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
