### PR TITLE
perf(bigint,random): accept BytesView for octet/seed inputs

### DIFF
--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -169,7 +169,7 @@ extern "js" fn hex2(b : Byte) -> String =
   #|(x) => x.toString(16).padStart(2, '0')
 
 ///|
-pub fn BigInt::from_octets(octets : Bytes, signum? : Int = 1) -> BigInt {
+pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
   if signum < 0 {
     return -1N * BigInt::from_octets(octets, signum=1)
   }

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1433,7 +1433,7 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
 ///   inspect(negative, content="-66051")
 /// }
 /// ```
-pub fn BigInt::from_octets(input : Bytes, signum? : Int = 1) -> BigInt {
+pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
   let len = input.length() // number of bytes
   if signum == 0 {
     return zero

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -30,7 +30,7 @@ pub fn BigInt::equal_uint64(Self, UInt64) -> Bool
 pub fn BigInt::from_hex(String) -> Self
 pub fn BigInt::from_int(Int) -> Self
 pub fn BigInt::from_int64(Int64) -> Self
-pub fn BigInt::from_octets(Bytes, signum? : Int) -> Self
+pub fn BigInt::from_octets(BytesView, signum? : Int) -> Self
 pub fn BigInt::from_string(String, radix? : Int) -> Self
 pub fn BigInt::from_uint(UInt) -> Self
 pub fn BigInt::from_uint64(UInt64) -> Self

--- a/random/internal/random_source/pkg.generated.mbti
+++ b/random/internal/random_source/pkg.generated.mbti
@@ -7,7 +7,7 @@ package "moonbitlang/core/random/internal/random_source"
 
 // Types and methods
 type ChaCha8
-pub fn ChaCha8::new(Bytes) -> Self
+pub fn ChaCha8::new(BytesView) -> Self
 pub fn ChaCha8::next(Self) -> UInt64?
 pub fn ChaCha8::refill(Self) -> Unit
 

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -25,7 +25,7 @@ struct ChaCha8 {
 
 ///|
 /// [seed] must be 32 bytes long.
-pub fn ChaCha8::new(seed : Bytes) -> ChaCha8 {
+pub fn ChaCha8::new(seed : BytesView) -> ChaCha8 {
   let seed = FixedArray::makei(SEED_CHUNK_NUM * 2, i => {
     match seed[i * 4:] {
       [u32le(x), ..] => x


### PR DESCRIPTION
## Summary

Continues the view-safe expansion theme from #3459 (\`Iter::join\`) and #3460 (\`Hasher::combine_{string,bytes}\`). Two more public APIs that only *read* their byte argument:

| Method | Before | After |
|---|---|---|
| \`BigInt::from_octets\` (non-js) | \`input : Bytes\` | \`input : BytesView\` |
| \`BigInt::from_octets\` (js) | \`octets : Bytes\` | \`octets : BytesView\` |
| \`ChaCha8::new\` | \`seed : Bytes\` | \`seed : BytesView\` |

Callers who already have a \`BytesView\` (slice into a larger buffer, view handed back from an encoder, etc.) can now pass it directly without \`to_owned()\`.

## Expanding mbti change

Every existing \`Bytes\` caller still compiles — \`Bytes\` coerces to \`BytesView\` at argument passing. No deprecation needed.

## Test plan
- [x] \`moon test --target all\` — 6333 wasm / 6333 wasm-gc / 6291 js / 6245 native all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
