### PR TITLE
perf(buffer): unify Buffer::write_bytes with write_bytesview

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -133,12 +133,12 @@ pub fn new(size_hint? : Int = 0) -> Buffer {
 
 ///|
 /// Create a buffer from a bytes.
-pub fn from_bytes(bytes : Bytes) -> Buffer {
+pub fn from_bytes(bytes : BytesView) -> Buffer {
   let val_len = bytes.length()
   let buf = new(size_hint=val_len)
   // inline write_bytes, skip grow_if_necessary check
   // SAFETY: known bytes size
-  buf.data.blit_from_bytes(0, bytes, 0, val_len)
+  buf.data.blit_from_bytes(0, bytes.data(), bytes.start_offset(), val_len)
   buf.len = val_len
   buf
 }
@@ -737,11 +737,8 @@ pub fn Buffer::write_object(self : Buffer, value : &Show) -> Unit {
 ///   )
 /// }
 /// ```
-pub fn Buffer::write_bytes(self : Buffer, value : Bytes) -> Unit {
-  let val_len = value.length()
-  self.grow_if_necessary(self.len + val_len)
-  self.data.blit_from_bytes(self.len, value, 0, val_len)
-  self.len += val_len
+pub fn Buffer::write_bytes(self : Buffer, value : BytesView) -> Unit {
+  self.write_bytesview(value)
 }
 
 ///|

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 // Values
 pub fn from_array(ArrayView[Byte]) -> Buffer
 
-pub fn from_bytes(Bytes) -> Buffer
+pub fn from_bytes(BytesView) -> Buffer
 
 pub fn from_iter(Iter[Byte]) -> Buffer
 
@@ -28,7 +28,7 @@ pub fn Buffer::to_bytes(Self) -> Bytes
 pub fn Buffer::to_repr(Self) -> @debug.Repr
 pub fn Buffer::view(Self) -> ArrayView[Byte]
 pub fn Buffer::write_byte(Self, Byte) -> Unit
-pub fn Buffer::write_bytes(Self, Bytes) -> Unit
+pub fn Buffer::write_bytes(Self, BytesView) -> Unit
 pub fn Buffer::write_bytesview(Self, BytesView) -> Unit
 pub fn Buffer::write_char_utf16be(Self, Char) -> Unit
 pub fn Buffer::write_char_utf16le(Self, Char) -> Unit


### PR DESCRIPTION
## Summary

\`Buffer::write_bytes(value : Bytes)\` and \`Buffer::write_bytesview(value : BytesView)\` had identical semantics — blit the argument's bytes into the buffer — implemented as two parallel blit loops. Expand \`write_bytes\` to \`BytesView\` and have it delegate to \`write_bytesview\`. Do the same for \`from_bytes\`.

| API | Before | After |
|---|---|---|
| \`Buffer::write_bytes\` | \`Bytes\` | \`BytesView\` (delegates to \`write_bytesview\`) |
| \`Buffer::write_bytesview\` | \`BytesView\` | unchanged |
| \`from_bytes\` (module-level) | \`Bytes\` | \`BytesView\` |

## Expanding mbti change

Every existing \`Bytes\` caller still compiles — \`Bytes\` coerces to \`BytesView\` at argument passing.

## Follow-up

\`write_bytesview\` stays as-is. Once downstream callers migrate to just \`write_bytes\`, it can be deprecated in a future PR — not bundled here to keep the diff small.

Continues the view-safe expansion theme (#3459, #3460, #3461).

## Test plan
- [x] \`moon test --target all\` — 6333 wasm / 6333 wasm-gc / 6291 js / 6245 native all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)