### PR TITLE
perf(builtin,test): assert/fail accept StringView msg

### DIFF
--- a/builtin/assert.mbt
+++ b/builtin/assert.mbt
@@ -122,9 +122,9 @@ pub fn[T : Eq + Show] assert_not_eq(
 /// ```
 #callsite(autofill(loc))
 #coverage.skip
-pub fn assert_true(x : Bool, msg? : String, loc~ : SourceLoc) -> Unit raise {
+pub fn assert_true(x : Bool, msg? : StringView, loc~ : SourceLoc) -> Unit raise {
   if !x {
-    let fail_msg = match msg {
+    let fail_msg : StringView = match msg {
       Some(msg) => msg
       None => "`\{x}` is not true"
     }
@@ -155,9 +155,13 @@ pub fn assert_true(x : Bool, msg? : String, loc~ : SourceLoc) -> Unit raise {
 /// ```
 #callsite(autofill(loc))
 #coverage.skip
-pub fn assert_false(x : Bool, msg? : String, loc~ : SourceLoc) -> Unit raise {
+pub fn assert_false(
+  x : Bool,
+  msg? : StringView,
+  loc~ : SourceLoc,
+) -> Unit raise {
   if x {
-    let fail_msg = match msg {
+    let fail_msg : StringView = match msg {
       Some(msg) => msg
       None => "`\{x}` is not false"
     }

--- a/builtin/failure.mbt
+++ b/builtin/failure.mbt
@@ -54,6 +54,6 @@ pub(all) suberror Failure {
 /// Throws an error of type `Failure` with a message that includes both the
 /// source location and the provided error message.
 #callsite(autofill(loc))
-pub fn[T] fail(msg : String, loc~ : SourceLoc) -> T raise Failure {
+pub fn[T] fail(msg : StringView, loc~ : SourceLoc) -> T raise Failure {
   raise Failure("\{loc} FAILED: \{msg}")
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -9,19 +9,19 @@ pub fn[T] abort(String) -> T
 pub fn[T : Eq + Show] assert_eq(T, T, msg? : String, loc~ : SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
-pub fn assert_false(Bool, msg? : String, loc~ : SourceLoc) -> Unit raise
+pub fn assert_false(Bool, msg? : StringView, loc~ : SourceLoc) -> Unit raise
 
 #deprecated
 #callsite(autofill(loc))
 pub fn[T : Eq + Show] assert_not_eq(T, T, msg? : String, loc~ : SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
-pub fn assert_true(Bool, msg? : String, loc~ : SourceLoc) -> Unit raise
+pub fn assert_true(Bool, msg? : StringView, loc~ : SourceLoc) -> Unit raise
 
 pub fn debug_assert(() -> Bool) -> Unit
 
 #callsite(autofill(loc))
-pub fn[T] fail(String, loc~ : SourceLoc) -> T raise Failure
+pub fn[T] fail(StringView, loc~ : SourceLoc) -> T raise Failure
 
 pub fn[T] ignore(T) -> Unit
 

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -18,13 +18,13 @@ pub fn[T] abort(String) -> T
 pub fn[T : @builtin.Eq + @builtin.Show] assert_eq(T, T, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
-pub fn assert_false(Bool, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
+pub fn assert_false(Bool, msg? : StringView, loc~ : @builtin.SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
 pub fn[T : @builtin.Eq + @builtin.Show] assert_not_eq(T, T, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
-pub fn assert_true(Bool, msg? : String, loc~ : @builtin.SourceLoc) -> Unit raise
+pub fn assert_true(Bool, msg? : StringView, loc~ : @builtin.SourceLoc) -> Unit raise
 
 pub fn[T : @debug.Debug] debug(T) -> Unit
 
@@ -38,7 +38,7 @@ pub fn debug_inspect(&@debug.Debug, content? : String, loc~ : @builtin.SourceLoc
 pub fn[T : @debug.Debug] dump(T, name? : String, loc~ : @builtin.SourceLoc) -> T
 
 #callsite(autofill(loc))
-pub fn[T] fail(String, loc~ : @builtin.SourceLoc) -> T raise @builtin.Failure
+pub fn[T] fail(StringView, loc~ : @builtin.SourceLoc) -> T raise @builtin.Failure
 
 pub fn[T] ignore(T) -> Unit
 

--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -19,7 +19,7 @@ pub fn[T : @debug.Debug] assert_not_same_object(T, T, loc~ : SourceLoc) -> Unit 
 pub fn[T : @debug.Debug] assert_same_object(T, T, loc~ : SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
-pub fn[T] fail(String, loc~ : SourceLoc) -> T raise
+pub fn[T] fail(StringView, loc~ : SourceLoc) -> T raise
 
 #alias(is_not, deprecated)
 #deprecated

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -154,7 +154,7 @@ pub fn[T : Debug] assert_not_same_object(
 ///  
 /// Produces an error message similar to @builtin.fail.
 #callsite(autofill(loc))
-pub fn[T] fail(msg : String, loc~ : SourceLoc) -> T raise {
+pub fn[T] fail(msg : StringView, loc~ : SourceLoc) -> T raise {
   @builtin.fail(msg, loc~)
 }
 


### PR DESCRIPTION
## Summary

Expand \`fail\`, \`assert_true\`, \`assert_false\`, and \`@test.fail\` to accept \`StringView\` for the \`msg\` parameter. Every one of these read-only uses the message as part of a format-string that produces a \`Failure\` error — no reason to demand ownership.

| API | Before | After |
|---|---|---|
| \`fail\` | \`msg : String\` | \`msg : StringView\` |
| \`assert_true\` | \`msg? : String\` | \`msg? : StringView\` |
| \`assert_false\` | \`msg? : String\` | \`msg? : StringView\` |
| \`@test.fail\` | \`msg : String\` | \`msg : StringView\` |

## Expanding mbti change

Every existing caller still compiles — \`String\` values and string literals coerce to \`StringView\` at argument passing.

## Test plan
- [x] \`moon test --target all\` — 6333 wasm / 6333 wasm-gc / 6291 js / 6245 native all pass

Continues the view-safe expansion theme: #3459, #3460, #3461 (merged), #3462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
