### PR TITLE
Fix random negative limit handling

### DIFF
--- a/random/random.mbt
+++ b/random/random.mbt
@@ -76,6 +76,9 @@ test "next" {
 /// * `limit` - The upper bound (exclusive) of the random number to be generated (Optional).
 ///             When limit is 0, the range is [0, 2^31).
 pub fn Rand::int(self : Rand, limit? : Int = 0) -> Int {
+  if limit < 0 {
+    abort("Rand::int: invalid argument limit")
+  }
   if limit == 0 {
     // Range [0, 2^31)
     (self.next() >> 33).to_int()
@@ -92,6 +95,9 @@ pub fn Rand::int(self : Rand, limit? : Int = 0) -> Int {
 /// * `limit` - The upper bound (exclusive) of the random number to be generated (Optional).
 ///            When limit is 0, the range is [0, 2^63).
 pub fn Rand::int64(self : Rand, limit? : Int64 = 0) -> Int64 {
+  if limit < 0 {
+    abort("Rand::int64: invalid argument limit")
+  }
   if limit == 0 {
     // range [0, 2^63)
     // Create a mask that keeps the lower 63 bits

--- a/random/random_test.mbt
+++ b/random/random_test.mbt
@@ -85,6 +85,18 @@ test "panic negative limit in shuffle" {
 }
 
 ///|
+test "panic negative limit in int" {
+  let r = @random.Rand::new()
+  ignore(r.int(limit=-1))
+}
+
+///|
+test "panic negative limit in int64" {
+  let r = @random.Rand::new()
+  ignore(r.int64(limit=-1L))
+}
+
+///|
 test "uint64 modulo bias handling with large limit" {
   let r = @random.Rand::new()
   let limit = 12345678901234567890UL // Large non-power-of-2 number


### PR DESCRIPTION
## Summary
- Abort `Rand::int` and `Rand::int64` when passed a negative `limit`
- Add panic tests for negative signed integer limits

## Tests
- `moon fmt random`
- `moon info random`
- `moon test random`
- `moon check`
- `moon test`