### PR TITLE
Fix BigInt JSON parse errors

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -52,8 +52,36 @@ pub impl @json.FromJson for BigInt with from_json(json, path) {
       (path, "BigInt::from_json: expected number in string representation"),
     )
   }
-  // TODO: Capture parse failure
+  BigInt::validate_json_decimal(s, path)
   BigInt::from_string(s)
+}
+
+///|
+fn BigInt::validate_json_decimal(
+  s : String,
+  path : @json.JsonPath,
+) -> Unit raise @json.JsonDecodeError {
+  let len = s.length()
+  let parse_error = @json.JsonDecodeError(
+    (path, "BigInt::from_json: parsing failure invalid syntax"),
+  )
+  if len == 0 {
+    raise parse_error
+  }
+  let start = if s.unsafe_get(0) == '-' {
+    if len == 1 {
+      raise parse_error
+    }
+    1
+  } else {
+    0
+  }
+  for i in start..<len {
+    let digit = s.unsafe_get(i).to_int() - '0'.to_int()
+    if digit < 0 || digit > 9 {
+      raise parse_error
+    }
+  }
 }
 
 ///|

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -67,6 +67,35 @@ test "to_octets pads larger length" {
 }
 
 ///|
+test "from_json invalid decimal string returns decode error" {
+  let empty : Result[@bigint.BigInt, _] = try? @json.from_json(Json::string(""))
+  inspect(
+    empty,
+    content=(
+      #|Err(JsonDecodeError((, "BigInt::from_json: parsing failure invalid syntax")))
+    ),
+  )
+  let sign_only : Result[@bigint.BigInt, _] = try? @json.from_json(
+    Json::string("-"),
+  )
+  inspect(
+    sign_only,
+    content=(
+      #|Err(JsonDecodeError((, "BigInt::from_json: parsing failure invalid syntax")))
+    ),
+  )
+  let invalid_digit : Result[@bigint.BigInt, _] = try? @json.from_json(
+    Json::string("12a"),
+  )
+  inspect(
+    invalid_digit,
+    content=(
+      #|Err(JsonDecodeError((, "BigInt::from_json: parsing failure invalid syntax")))
+    ),
+  )
+}
+
+///|
 test "add" {
   let a = @bigint.BigInt::from_int64(123456789012345678L)
   let b = @bigint.BigInt::from_int64(987654321098765432L)


### PR DESCRIPTION
## Summary
- Validate `BigInt` JSON decimal strings before calling the aborting parser
- Return `JsonDecodeError` for malformed string payloads instead of aborting
- Add bigint package tests for empty, sign-only, and non-digit JSON strings

## Tests
- `moon fmt bigint`
- `moon info bigint`
- `moon test bigint`
- `moon test json`
- `moon check`
- `moon test`