### PR TITLE
fix(builtin): uint16 aligned fastpath returns UInt, not UInt16

### DIFF
--- a/builtin/bitstring.mbt
+++ b/builtin/bitstring.mbt
@@ -1077,11 +1077,11 @@ pub fn ArrayView::unsafe_extract_byte_signed_aligned(
 pub fn ArrayView::unsafe_extract_uint16_le_aligned(
   bs : ArrayView[Byte],
   byte_offset : Int,
-) -> UInt16 {
+) -> UInt {
   fixedarray_read_uint16_le(
     buffer_to_fixedarray(bs.buf()),
     bs.start() + byte_offset,
-  )
+  ).to_uint()
 }
 
 ///|
@@ -1090,11 +1090,11 @@ pub fn ArrayView::unsafe_extract_uint16_le_aligned(
 pub fn ArrayView::unsafe_extract_uint16_be_aligned(
   bs : ArrayView[Byte],
   byte_offset : Int,
-) -> UInt16 {
+) -> UInt {
   fixedarray_read_uint16_be(
     buffer_to_fixedarray(bs.buf()),
     bs.start() + byte_offset,
-  )
+  ).to_uint()
 }
 
 ///|
@@ -1104,7 +1104,7 @@ pub fn ArrayView::unsafe_extract_int16_le_aligned(
   bs : ArrayView[Byte],
   byte_offset : Int,
 ) -> Int {
-  bs.unsafe_extract_uint16_le_aligned(byte_offset).to_uint().extend_sign(16)
+  bs.unsafe_extract_uint16_le_aligned(byte_offset).extend_sign(16)
 }
 
 ///|
@@ -1114,7 +1114,7 @@ pub fn ArrayView::unsafe_extract_int16_be_aligned(
   bs : ArrayView[Byte],
   byte_offset : Int,
 ) -> Int {
-  bs.unsafe_extract_uint16_be_aligned(byte_offset).to_uint().extend_sign(16)
+  bs.unsafe_extract_uint16_be_aligned(byte_offset).extend_sign(16)
 }
 
 ///|
@@ -1239,8 +1239,8 @@ pub fn BytesView::unsafe_extract_byte_signed_aligned(
 pub fn BytesView::unsafe_extract_uint16_le_aligned(
   bs : BytesView,
   byte_offset : Int,
-) -> UInt16 {
-  bs.unsafe_read_uint16_le(byte_offset)
+) -> UInt {
+  bs.unsafe_read_uint16_le(byte_offset).to_uint()
 }
 
 ///|
@@ -1249,8 +1249,8 @@ pub fn BytesView::unsafe_extract_uint16_le_aligned(
 pub fn BytesView::unsafe_extract_uint16_be_aligned(
   bs : BytesView,
   byte_offset : Int,
-) -> UInt16 {
-  bs.unsafe_read_uint16_be(byte_offset)
+) -> UInt {
+  bs.unsafe_read_uint16_be(byte_offset).to_uint()
 }
 
 ///|
@@ -1260,7 +1260,7 @@ pub fn BytesView::unsafe_extract_int16_le_aligned(
   bs : BytesView,
   byte_offset : Int,
 ) -> Int {
-  bs.unsafe_read_uint16_le(byte_offset).to_uint().extend_sign(16)
+  bs.unsafe_extract_uint16_le_aligned(byte_offset).extend_sign(16)
 }
 
 ///|
@@ -1270,7 +1270,7 @@ pub fn BytesView::unsafe_extract_int16_be_aligned(
   bs : BytesView,
   byte_offset : Int,
 ) -> Int {
-  bs.unsafe_read_uint16_be(byte_offset).to_uint().extend_sign(16)
+  bs.unsafe_extract_uint16_be_aligned(byte_offset).extend_sign(16)
 }
 
 ///|

--- a/builtin/bitstring_test.mbt
+++ b/builtin/bitstring_test.mbt
@@ -819,10 +819,10 @@ test "aligned fastpath known values" {
   inspect(bview.unsafe_extract_uint_be_aligned(0), content="16909060") // 0x01020304
   inspect(aview.unsafe_extract_uint_le_aligned(0), content="67305985")
   inspect(aview.unsafe_extract_uint_be_aligned(0), content="16909060")
-  inspect(bview.unsafe_extract_uint16_le_aligned(0).to_int(), content="513") // 0x0201
-  inspect(bview.unsafe_extract_uint16_be_aligned(0).to_int(), content="258") // 0x0102
-  inspect(aview.unsafe_extract_uint16_le_aligned(0).to_int(), content="513")
-  inspect(aview.unsafe_extract_uint16_be_aligned(0).to_int(), content="258")
+  inspect(bview.unsafe_extract_uint16_le_aligned(0).reinterpret_as_int(), content="513") // 0x0201
+  inspect(bview.unsafe_extract_uint16_be_aligned(0).reinterpret_as_int(), content="258") // 0x0102
+  inspect(aview.unsafe_extract_uint16_le_aligned(0).reinterpret_as_int(), content="513")
+  inspect(aview.unsafe_extract_uint16_be_aligned(0).reinterpret_as_int(), content="258")
   inspect(
     bview.unsafe_extract_uint64_le_aligned(0) == 0x0807060504030201UL,
     content="true",

--- a/builtin/bitstring_test.mbt
+++ b/builtin/bitstring_test.mbt
@@ -704,19 +704,19 @@ test "aligned fastpath cross-check" {
   // uint16 (2 bytes)
   for b in 0..<=(bytes.length() - 2) {
     assert_eq(
-      aview.unsafe_extract_uint16_le_aligned(b).to_uint(),
+      aview.unsafe_extract_uint16_le_aligned(b),
       aview.unsafe_extract_uint_le(b * 8, 16),
     )
     assert_eq(
-      aview.unsafe_extract_uint16_be_aligned(b).to_uint(),
+      aview.unsafe_extract_uint16_be_aligned(b),
       aview.unsafe_extract_uint_be(b * 8, 16),
     )
     assert_eq(
-      bview.unsafe_extract_uint16_le_aligned(b).to_uint(),
+      bview.unsafe_extract_uint16_le_aligned(b),
       bview.unsafe_extract_uint_le(b * 8, 16),
     )
     assert_eq(
-      bview.unsafe_extract_uint16_be_aligned(b).to_uint(),
+      bview.unsafe_extract_uint16_be_aligned(b),
       bview.unsafe_extract_uint_be(b * 8, 16),
     )
     assert_eq(

--- a/builtin/bitstring_test.mbt
+++ b/builtin/bitstring_test.mbt
@@ -819,10 +819,22 @@ test "aligned fastpath known values" {
   inspect(bview.unsafe_extract_uint_be_aligned(0), content="16909060") // 0x01020304
   inspect(aview.unsafe_extract_uint_le_aligned(0), content="67305985")
   inspect(aview.unsafe_extract_uint_be_aligned(0), content="16909060")
-  inspect(bview.unsafe_extract_uint16_le_aligned(0).reinterpret_as_int(), content="513") // 0x0201
-  inspect(bview.unsafe_extract_uint16_be_aligned(0).reinterpret_as_int(), content="258") // 0x0102
-  inspect(aview.unsafe_extract_uint16_le_aligned(0).reinterpret_as_int(), content="513")
-  inspect(aview.unsafe_extract_uint16_be_aligned(0).reinterpret_as_int(), content="258")
+  inspect(
+    bview.unsafe_extract_uint16_le_aligned(0).reinterpret_as_int(),
+    content="513",
+  ) // 0x0201
+  inspect(
+    bview.unsafe_extract_uint16_be_aligned(0).reinterpret_as_int(),
+    content="258",
+  ) // 0x0102
+  inspect(
+    aview.unsafe_extract_uint16_le_aligned(0).reinterpret_as_int(),
+    content="513",
+  )
+  inspect(
+    aview.unsafe_extract_uint16_be_aligned(0).reinterpret_as_int(),
+    content="258",
+  )
   inspect(
     bview.unsafe_extract_uint64_le_aligned(0) == 0x0807060504030201UL,
     content="true",


### PR DESCRIPTION
## Summary
Fixes a follow-up to #3455: the 16-bit aligned fastpaths should return `UInt`, not `UInt16`, so they match the convention used by the existing `unsafe_extract_uint_le/be` and don't force every caller to widen. The signed (`_int16_*_aligned`) variants were already returning `Int`, so no change there — but their bodies can now drop the `.to_uint()` hop since their unsigned counterparts return `UInt` directly.

Changed:
- `ArrayView[Byte]::unsafe_extract_uint16_{le,be}_aligned` → `UInt`
- `BytesView::unsafe_extract_uint16_{le,be}_aligned` → `UInt`
- `_int16_{le,be}_aligned` bodies simplified (no more `.to_uint()`)
- Cross-check test calls drop the now-unnecessary `.to_uint()`

## Test plan
- [x] `moon test -p builtin -f bitstring_test.mbt` passes on wasm, wasm-gc, js, native (26/26 per backend)
- [x] `moon check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
