### PR TITLE
refactor(builtin): Array::starts_with/ends_with take ArrayView

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -874,7 +874,10 @@ pub fn[T : Eq] Array::contains(self : Array[T], value : T) -> Bool {
 ///   inspect(arr.starts_with([1, 2, 3, 4, 5, 6]), content="false")
 /// }
 /// ```
-pub fn[T : Eq] Array::starts_with(self : Array[T], prefix : Array[T]) -> Bool {
+pub fn[T : Eq] Array::starts_with(
+  self : Array[T],
+  prefix : ArrayView[T],
+) -> Bool {
   self[:].starts_with(prefix)
 }
 
@@ -901,7 +904,7 @@ pub fn[T : Eq] Array::starts_with(self : Array[T], prefix : Array[T]) -> Bool {
 ///   inspect(arr.ends_with([1]), content="false")
 /// }
 /// ```
-pub fn[T : Eq] Array::ends_with(self : Array[T], suffix : Array[T]) -> Bool {
+pub fn[T : Eq] Array::ends_with(self : Array[T], suffix : ArrayView[T]) -> Bool {
   self[:].ends_with(suffix)
 }
 

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -91,7 +91,7 @@ pub fn[T : Eq] Array::dedup(Self[T]) -> Unit
 pub fn[T] Array::drain(Self[T], Int, Int) -> Self[T]
 pub fn[T] Array::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] Array::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
-pub fn[T : Eq] Array::ends_with(Self[T], Self[T]) -> Bool
+pub fn[T : Eq] Array::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T] Array::extract_if(Self[T], (T) -> Bool) -> Self[T]
 pub fn[A] Array::fill(Self[A], A, start? : Int, end? : Int) -> Unit
 pub fn[T] Array::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
@@ -159,7 +159,7 @@ pub fn[T : Compare] Array::sort(Self[T]) -> Unit
 pub fn[T] Array::sort_by(Self[T], (T, T) -> Int) -> Unit
 pub fn[T, K : Compare] Array::sort_by_key(Self[T], (T) -> K) -> Unit
 pub fn[T] Array::split(Self[T], (T) -> Bool raise?) -> Self[Self[T]] raise?
-pub fn[T : Eq] Array::starts_with(Self[T], Self[T]) -> Bool
+pub fn[T : Eq] Array::starts_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] Array::strip_prefix(Self[T], ArrayView[T]) -> ArrayView[T]?
 pub fn[T : Eq] Array::strip_suffix(Self[T], ArrayView[T]) -> ArrayView[T]?
 pub fn[T] Array::suffixes(Self[T], include_empty? : Bool) -> Iter[ArrayView[T]]


### PR DESCRIPTION
## Summary
- Mirror the recently-merged `strip_prefix`/`strip_suffix` migration: `Array::starts_with` and `Array::ends_with` now take `ArrayView[T]` instead of `Array[T]`.
- Symmetric with the `String` API (`String::starts_with` takes `StringView`) and with `Array::strip_prefix`/`Array::strip_suffix`.
- Existing callers that pass an array literal (`arr.starts_with([1, 2])`) are unaffected — the literal is inferred as an `ArrayView`.

## Test plan
- [x] `moon fmt`, `moon info`
- [x] `moon test -p moonbitlang/core/builtin` — 2812/2812 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
