### PR TITLE
refactor(builtin): FixedArray/ReadOnlyArray::starts_with/ends_with take ArrayView

### DIFF
--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1088,7 +1088,7 @@ test "contains" {
 /// ```
 pub fn[T : Eq] FixedArray::starts_with(
   self : FixedArray[T],
-  prefix : FixedArray[T],
+  prefix : ArrayView[T],
 ) -> Bool {
   self[:].starts_with(prefix)
 }
@@ -1130,7 +1130,7 @@ test "starts_with" {
 /// ```
 pub fn[T : Eq] FixedArray::ends_with(
   self : FixedArray[T],
-  suffix : FixedArray[T],
+  suffix : ArrayView[T],
 ) -> Bool {
   self[:].ends_with(suffix)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -834,7 +834,7 @@ pub fn[T : Eq] FixedArray::contains(Self[T], T) -> Bool
 pub fn[T] FixedArray::copy(Self[T]) -> Self[T]
 pub fn[T] FixedArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] FixedArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
-pub fn[T : Eq] FixedArray::ends_with(Self[T], Self[T]) -> Bool
+pub fn[T : Eq] FixedArray::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T] FixedArray::fill(Self[T], T, start? : Int, end? : Int) -> Unit
 pub fn[A, B] FixedArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] FixedArray::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
@@ -875,7 +875,7 @@ pub fn[T : Compare] FixedArray::sort(Self[T]) -> Unit
 pub fn[T] FixedArray::sort_by(Self[T], (T, T) -> Int) -> Unit
 pub fn[T, K : Compare] FixedArray::sort_by_key(Self[T], (T) -> K) -> Unit
 pub fn[T : Compare] FixedArray::stable_sort(Self[T]) -> Unit
-pub fn[T : Eq] FixedArray::starts_with(Self[T], Self[T]) -> Bool
+pub fn[T : Eq] FixedArray::starts_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T] FixedArray::swap(Self[T], Int, Int) -> Unit
 pub fn[A] FixedArray::unsafe_blit(Self[A], Int, Self[A], Int, Int) -> Unit
 pub fn FixedArray::unsafe_write_uint16_be(Self[Byte], Int, UInt16) -> Unit
@@ -899,7 +899,7 @@ pub fn[T] ReadOnlyArray::binary_search_by(Self[T], (T) -> Int raise?) -> Result[
 pub fn[T : Eq] ReadOnlyArray::contains(Self[T], T) -> Bool
 pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
-pub fn[T : Eq] ReadOnlyArray::ends_with(Self[T], Self[T]) -> Bool
+pub fn[T : Eq] ReadOnlyArray::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[A, B] ReadOnlyArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ReadOnlyArray::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 pub fn[T] ReadOnlyArray::from_array(ArrayView[T]) -> Self[T]
@@ -924,7 +924,7 @@ pub fn[T] ReadOnlyArray::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit rai
 pub fn[A, B] ReadOnlyArray::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ReadOnlyArray::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 pub fn[T : Eq] ReadOnlyArray::search(Self[T], T) -> Int?
-pub fn[T : Eq] ReadOnlyArray::starts_with(Self[T], Self[T]) -> Bool
+pub fn[T : Eq] ReadOnlyArray::starts_with(Self[T], ArrayView[T]) -> Bool
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[T] ReadOnlyArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -453,17 +453,14 @@ pub fn[T : Compare] ReadOnlyArray::is_sorted(self : ReadOnlyArray[T]) -> Bool {
 /// ```mbt check
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
-///   let prefix : ReadOnlyArray[Int] = [1, 2]
-///   inspect(arr.starts_with(prefix), content="true")
+///   inspect(arr.starts_with([1, 2][:]), content="true")
 /// }
 /// ```
 pub fn[T : Eq] ReadOnlyArray::starts_with(
   self : ReadOnlyArray[T],
-  prefix : ReadOnlyArray[T],
+  prefix : ArrayView[T],
 ) -> Bool {
-  self
-  .unsafe_reinterpret_to_fixed_array()
-  .starts_with(prefix.unsafe_reinterpret_to_fixed_array())
+  self[:].starts_with(prefix)
 }
 
 ///|
@@ -473,17 +470,14 @@ pub fn[T : Eq] ReadOnlyArray::starts_with(
 /// ```mbt check
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
-///   let suffix : ReadOnlyArray[Int] = [4, 5]
-///   inspect(arr.ends_with(suffix), content="true")
+///   inspect(arr.ends_with([4, 5][:]), content="true")
 /// }
 /// ```
 pub fn[T : Eq] ReadOnlyArray::ends_with(
   self : ReadOnlyArray[T],
-  suffix : ReadOnlyArray[T],
+  suffix : ArrayView[T],
 ) -> Bool {
-  self
-  .unsafe_reinterpret_to_fixed_array()
-  .ends_with(suffix.unsafe_reinterpret_to_fixed_array())
+  self[:].ends_with(suffix)
 }
 
 ///|


### PR DESCRIPTION
## Summary
Mirrors the recently-merged `Array::starts_with`/`ends_with` migration (#3470). Both `FixedArray` and `ReadOnlyArray` slice to `ArrayView[T]`, so making the prefix/suffix parameter an `ArrayView[T]` keeps the API symmetric with `Array`, `String`, and `Bytes`.

Existing callers that pass an array literal (`arr.starts_with([1, 2])`) continue to work — the literal is inferred as an `ArrayView`.

## Test plan
- [x] `moon fmt`, `moon info`
- [x] `moon test -p moonbitlang/core/builtin` — 2812/2812 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
