### PR TITLE
feat: add Debug impl for Set, SortedSet, SortedMap

### DIFF
--- a/set/debug.mbt
+++ b/set/debug.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+using @debug {trait Debug, type Repr}
+
+///|
+pub impl[K : Debug] Debug for Set[K] with to_repr(self) {
+  Repr::opaque_("Set", Repr::array(self.to_array().map(x => @debug.to_repr(x))))
+}
+
+///|
+test "Debug for Set" {
+  let s : Set[Int] = from_array([1, 2, 3])
+  @debug.debug_inspect(s, content="<Set: [1, 2, 3]>")
+}

--- a/set/moon.pkg
+++ b/set/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
   "moonbitlang/core/int",
 }
 

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/set"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 
 // Errors
@@ -50,6 +54,7 @@ pub impl[K : Hash + Eq] Eq for Set[K]
 pub impl[K : Show] Show for Set[K]
 pub impl[K : Hash + Eq] Sub for Set[K]
 pub impl[X : ToJson] ToJson for Set[X]
+pub impl[K : @debug.Debug] @debug.Debug for Set[K]
 
 // Type aliases
 

--- a/sorted_map/debug.mbt
+++ b/sorted_map/debug.mbt
@@ -1,0 +1,37 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+using @debug {trait Debug, type Repr}
+
+///|
+pub impl[K : Debug, V : Debug] Debug for SortedMap[K, V] with to_repr(self) {
+  Repr::opaque_(
+    "SortedMap",
+    Repr::map(
+      self.to_array().map(kv => (@debug.to_repr(kv.0), @debug.to_repr(kv.1))),
+    ),
+  )
+}
+
+///|
+test "Debug for SortedMap" {
+  let sm : SortedMap[Int, String] = from_array([(1, "a"), (2, "b")])
+  @debug.debug_inspect(
+    sm,
+    content=(
+      #|<SortedMap: { 1: "a", 2: "b" }>
+    ),
+  )
+}

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/core/sorted_map"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/splitmix",
@@ -60,6 +61,7 @@ pub impl[K, V] Default for SortedMap[K, V]
 pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V]
 pub impl[K : Show, V : Show] Show for SortedMap[K, V]
 pub impl[K : Show, V : ToJson] ToJson for SortedMap[K, V]
+pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for SortedMap[K, V]
 pub impl[V : @json.FromJson] @json.FromJson for SortedMap[String, V]
 pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for SortedMap[K, V]
 

--- a/sorted_set/debug.mbt
+++ b/sorted_set/debug.mbt
@@ -1,0 +1,30 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+using @debug {trait Debug, type Repr}
+
+///|
+pub impl[V : Debug] Debug for SortedSet[V] with to_repr(self) {
+  Repr::opaque_(
+    "SortedSet",
+    Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+  )
+}
+
+///|
+test "Debug for SortedSet" {
+  let ss : SortedSet[Int] = from_array([3, 1, 2])
+  @debug.debug_inspect(ss, content="<SortedSet: [1, 2, 3]>")
+}

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
   "moonbitlang/core/option",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",

--- a/sorted_set/pkg.generated.mbti
+++ b/sorted_set/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/core/sorted_set"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/splitmix",
 }
@@ -51,6 +52,7 @@ pub fn[V : Compare] SortedSet::union(Self[V], Self[V]) -> Self[V]
 pub impl[K] Default for SortedSet[K]
 pub impl[V : Eq] Eq for SortedSet[V]
 pub impl[V : Show] Show for SortedSet[V]
+pub impl[V : @debug.Debug] @debug.Debug for SortedSet[V]
 pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for SortedSet[X]
 
 // Type aliases


### PR DESCRIPTION
## Summary
These collection types had `Show` but no `Debug`. Without `Debug`, downstream structs that contain them can't `derive(@debug.Debug)` — they have to hand-write impls. (cmark_html's `State.ids` and cmark's `CloserIndex` already work around this gap.)

Adds `Debug` impls following the existing pattern used by `@hashset.HashSet`, `@immut/sorted_set.SortedSet`, and `@immut/sorted_map.SortedMap`:

```
<Set: [...]>
<SortedSet: [...]>
<SortedMap: { k: v, ... }>
```

## Test plan
- [x] `moon fmt`, `moon info`
- [x] `moon test -p moonbitlang/core/set` — 63/63 pass
- [x] `moon test -p moonbitlang/core/sorted_set` — 54/54 pass
- [x] `moon test -p moonbitlang/core/sorted_map` — 81/81 pass
- [x] Each new `debug.mbt` includes a smoke test that runs `@debug.debug_inspect` on a populated collection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
