### PR TITLE
feat(encoding/ascii): derive Debug for Malformed

### DIFF
--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -16,7 +16,7 @@
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)
-}
+} derive(@debug.Debug)
 
 ///|
 fn unsafe_fixedarray_uint16_to_string(buffer : FixedArray[UInt16]) -> String = "%string.unsafe_from_uint16_fixedarray"

--- a/encoding/ascii/decode_test.mbt
+++ b/encoding/ascii/decode_test.mbt
@@ -40,3 +40,14 @@ test "decode_lossy replaces invalid bytes" {
   let bytes = b"ok\xffmore"
   inspect(@ascii.decode_lossy(bytes), content="ok�more")
 }
+
+///|
+test "Debug for Malformed" {
+  let bytes = b"\xff"
+  try {
+    let _ = @ascii.decode(bytes)
+    panic()
+  } catch {
+    err => @debug.debug_inspect(err, content="Malformed(<BytesView: [0xff]>)")
+  }
+}

--- a/encoding/ascii/moon.pkg
+++ b/encoding/ascii/moon.pkg
@@ -1,3 +1,4 @@
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
 }

--- a/encoding/ascii/pkg.generated.mbti
+++ b/encoding/ascii/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/encoding/ascii"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn decode(BytesView) -> String raise Malformed
 
@@ -11,7 +15,7 @@ pub fn encode(StringView) -> Bytes
 // Errors
 pub suberror Malformed {
   Malformed(BytesView)
-}
+} derive(@debug.Debug)
 
 // Types and methods
 


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive to `encoding/ascii::Malformed` so the suberror can be inspected with `@debug.debug_inspect` alongside the existing `Show` impl.
- First in a series filling in Debug impls for every public type in core (audit found 35 missing — one PR per package for easy review).

## Test plan
- [x] `moon test -p moonbitlang/core/encoding/ascii` passes on all 4 targets (wasm, wasm-gc, js, native)
- [x] New test `Debug for Malformed` snapshots the rendered Repr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
