### PR TITLE
feat(encoding/base64): derive Debug for Malformed

### DIFF
--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(StringView)

--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -16,7 +16,7 @@
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(StringView)
-}
+} derive(@debug.Debug)
 
 ///|
 const WRITESPACE = -3

--- a/encoding/base64/decode_test.mbt
+++ b/encoding/base64/decode_test.mbt
@@ -73,6 +73,22 @@ test "decode malformed" {
 }
 
 ///|
+test "Debug for Malformed" {
+  try {
+    let _ = @base64.decode("Zh==")
+    panic()
+  } catch {
+    err =>
+      @debug.debug_inspect(
+        err,
+        content=(
+          #|Malformed(<StringView: "Zh==">)
+        ),
+      )
+  }
+}
+
+///|
 test "decode lossy" {
   inspect(
     @base64.decode_lossy("Zm9v$$$"),

--- a/encoding/base64/moon.pkg
+++ b/encoding/base64/moon.pkg
@@ -1,4 +1,5 @@
 import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
 }

--- a/encoding/base64/pkg.generated.mbti
+++ b/encoding/base64/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/encoding/base64"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn decode(StringView, ignore_whitespace? : Bool) -> Bytes raise Malformed
 
@@ -11,7 +15,7 @@ pub fn encode(BytesView, padding? : Bool) -> String
 // Errors
 pub suberror Malformed {
   Malformed(StringView)
-}
+} derive(@debug.Debug)
 
 // Types and methods
 


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive to `encoding/base64::Malformed` suberror.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/encoding/base64` passes on all 4 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
