### PR TITLE
feat(encoding/utf8): derive Debug for Malformed

### DIFF
--- a/encoding/utf8/decode.mbt
+++ b/encoding/utf8/decode.mbt
@@ -16,7 +16,7 @@
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)
-}
+} derive(@debug.Debug)
 
 ///|
 /// Decode input bytes/text into structured output.

--- a/encoding/utf8/decode.mbt
+++ b/encoding/utf8/decode.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/encoding/utf8/decode_test.mbt
+++ b/encoding/utf8/decode_test.mbt
@@ -106,3 +106,13 @@ test "decode_lossy with bom" {
   inspect(@utf8.decode_lossy(text), content="﻿abc")
   inspect(@utf8.decode_lossy(text, ignore_bom=true), content="abc")
 }
+
+///|
+test "Debug for Malformed" {
+  try {
+    let _ = @utf8.decode(b"\xff")
+    panic()
+  } catch {
+    err => @debug.debug_inspect(err, content="Malformed(<BytesView: [0xff]>)")
+  }
+}

--- a/encoding/utf8/moon.pkg
+++ b/encoding/utf8/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
 }
 
 import {

--- a/encoding/utf8/pkg.generated.mbti
+++ b/encoding/utf8/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/encoding/utf8"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn decode(BytesView, ignore_bom? : Bool) -> String raise Malformed
 
@@ -11,7 +15,7 @@ pub fn encode(StringView, bom? : Bool) -> Bytes
 // Errors
 pub suberror Malformed {
   Malformed(BytesView)
-}
+} derive(@debug.Debug)
 
 // Types and methods
 


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive to `encoding/utf8::Malformed` suberror.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/encoding/utf8` passes on all 4 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
