### PR TITLE
feat(encoding/utf16): derive Debug for Malformed and Endian

### DIFF
--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -16,7 +16,7 @@
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)
-}
+} derive(@debug.Debug)
 
 ///|
 /// The Unicode Replacement Character, which is used to replace invalid or unrecognized sequences during lossy decoding.

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/encoding/utf16/decode_test.mbt
+++ b/encoding/utf16/decode_test.mbt
@@ -181,3 +181,21 @@ test "decode_lossy with surrogate pairs" {
   let result = @utf16.decode_lossy(invalid_surr)
   assert_true(result.length() > 0)
 }
+
+///|
+test "Debug for Endian" {
+  @debug.debug_inspect(@utf16.Endian::Little, content="Little")
+  @debug.debug_inspect(@utf16.Endian::Big, content="Big")
+}
+
+///|
+test "Debug for Malformed" {
+  let unpaired = b"\x00\xd8"
+  try {
+    let _ = @utf16.decode(unpaired)
+    panic()
+  } catch {
+    err =>
+      @debug.debug_inspect(err, content="Malformed(<BytesView: [0x00, 0xd8]>)")
+  }
+}

--- a/encoding/utf16/moon.pkg
+++ b/encoding/utf16/moon.pkg
@@ -1,3 +1,4 @@
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
 }

--- a/encoding/utf16/pkg.generated.mbti
+++ b/encoding/utf16/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/encoding/utf16"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn decode(BytesView, ignore_bom? : Bool, endianness? : Endian) -> String raise Malformed
 
@@ -11,13 +15,13 @@ pub fn encode(StringView, bom? : Bool, endianness? : Endian) -> Bytes
 // Errors
 pub suberror Malformed {
   Malformed(BytesView)
-}
+} derive(@debug.Debug)
 
 // Types and methods
 pub(all) enum Endian {
   Little
   Big
-}
+} derive(@debug.Debug)
 
 // Type aliases
 

--- a/encoding/utf16/types.mbt
+++ b/encoding/utf16/types.mbt
@@ -17,4 +17,4 @@
 pub(all) enum Endian {
   Little
   Big
-}
+} derive(@debug.Debug)

--- a/encoding/utf16/types.mbt
+++ b/encoding/utf16/types.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Type `Endian` used by this package APIs.
 pub(all) enum Endian {
   Little


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive to `encoding/utf16::Malformed` suberror and `encoding/utf16::Endian` enum.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/encoding/utf16` passes on all 4 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
