### PR TITLE
feat(argparse): derive Debug for public types

### DIFF
--- a/argparse/arg_group.mbt
+++ b/argparse/arg_group.mbt
@@ -31,7 +31,7 @@ pub struct ArgGroup {
     requires? : ArrayView[String],
     conflicts_with? : ArrayView[String],
   ) -> ArgGroup
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create an argument group.

--- a/argparse/arg_group.mbt
+++ b/argparse/arg_group.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Declarative argument group constructor.
 pub struct ArgGroup {
   priv name : String

--- a/argparse/arg_group.mbt
+++ b/argparse/arg_group.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Declarative argument group constructor.
 pub struct ArgGroup {
   priv name : String

--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -25,7 +25,7 @@ pub(all) enum FlagAction {
   Count
   Help
   Version
-} derive(Eq, Show)
+} derive(Eq, Show, @debug.Debug)
 
 ///|
 /// Behavior for option args.
@@ -36,7 +36,7 @@ pub(all) enum FlagAction {
 pub(all) enum OptionAction {
   Set
   Append
-} derive(Eq, Show)
+} derive(Eq, Show, @debug.Debug)
 
 ///|
 /// Unified argument model used by the parser internals.
@@ -52,7 +52,7 @@ priv struct Arg {
   hidden : Bool
   info : ArgInfo
   multiple : Bool
-}
+} derive(@debug.Debug)
 
 ///|
 priv enum ArgInfo {
@@ -74,7 +74,7 @@ priv enum ArgInfo {
     default_values~ : Array[String]?,
     allow_hyphen_values~ : Bool
   )
-}
+} derive(@debug.Debug)
 
 ///|
 /// Declarative flag constructor wrapper.
@@ -96,7 +96,7 @@ pub struct FlagArg {
     negatable? : Bool,
     hidden? : Bool,
   ) -> FlagArg
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create a flag argument.
@@ -166,7 +166,7 @@ pub struct OptionArg {
     global? : Bool,
     hidden? : Bool,
   ) -> OptionArg
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create an option argument.
@@ -238,7 +238,7 @@ pub struct PositionArg {
     global? : Bool,
     hidden? : Bool,
   ) -> PositionArg
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create a positional argument.

--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Behavior for flag args.
 ///
 /// - `SetTrue` / `SetFalse` set a boolean value.

--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Behavior for flag args.
 ///
 /// - `SetTrue` / `SetFalse` set a boolean value.

--- a/argparse/argparse_blackbox_test.mbt
+++ b/argparse/argparse_blackbox_test.mbt
@@ -3072,3 +3072,11 @@ test "positional range 0..1 renders as single optional value" {
     ),
   )
 }
+
+///|
+test "Debug for argparse enums" {
+  @debug.debug_inspect(@argparse.FlagAction::SetTrue, content="SetTrue")
+  @debug.debug_inspect(@argparse.FlagAction::Count, content="Count")
+  @debug.debug_inspect(@argparse.OptionAction::Set, content="Set")
+  @debug.debug_inspect(@argparse.OptionAction::Append, content="Append")
+}

--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -46,7 +46,7 @@ pub struct Command {
     hidden? : Bool,
     groups? : ArrayView[ArgGroup],
   ) -> Command
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create a declarative command specification.

--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Declarative command specification.
 pub struct Command {
   priv name : String

--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Declarative command specification.
 pub struct Command {
   priv name : String

--- a/argparse/error.mbt
+++ b/argparse/error.mbt
@@ -87,7 +87,7 @@ fn ArgParseError::arg_parse_error_message(self : ArgParseError) -> String {
 /// Internal build errors raised while validating command definitions.
 priv suberror ArgBuildError {
   Unsupported(String)
-}
+} derive(@debug.Debug)
 
 ///|
 /// Internal control-flow event for displaying help.

--- a/argparse/error.mbt
+++ b/argparse/error.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Internal error surface used by argparse.
 ///
 /// `Message` is display-ready text intended for end users.

--- a/argparse/error.mbt
+++ b/argparse/error.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Internal error surface used by argparse.
 ///
 /// `Message` is display-ready text intended for end users.

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -14,14 +14,14 @@ pub struct ArgGroup {
   // private fields
 
   fn new(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> ArgGroup
-}
+} derive(@debug.Debug)
 pub fn ArgGroup::new(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
 
 pub struct Command {
   // private fields
 
   fn new(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Command], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Command
-}
+} derive(@debug.Debug)
 pub fn Command::new(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Self], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Self
 #as_free_fn
 pub fn Command::parse(Self, argv? : ArrayView[String], env? : Map[String, String]) -> Matches raise
@@ -33,13 +33,13 @@ pub(all) enum FlagAction {
   Count
   Help
   Version
-} derive(Eq, Show)
+} derive(Eq, Show, @debug.Debug)
 
 pub struct FlagArg {
   // private fields
 
   fn new(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> FlagArg
-}
+} derive(@debug.Debug)
 pub fn FlagArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
 
 pub struct Matches {
@@ -54,27 +54,27 @@ pub struct Matches {
 pub(all) enum OptionAction {
   Set
   Append
-} derive(Eq, Show)
+} derive(Eq, Show, @debug.Debug)
 
 pub struct OptionArg {
   // private fields
 
   fn new(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> OptionArg
-}
+} derive(@debug.Debug)
 pub fn OptionArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
 
 pub struct PositionArg {
   // private fields
 
   fn new(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> PositionArg
-}
+} derive(@debug.Debug)
 pub fn PositionArg::new(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
 
 pub struct ValueRange {
   // private fields
 
   fn new(lower? : Int, upper? : Int) -> ValueRange
-} derive(Eq, Show)
+} derive(Eq, Show, @debug.Debug)
 pub fn ValueRange::new(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::single() -> Self
 

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -21,7 +21,7 @@ pub struct ValueRange {
 
   /// Create a value-count range.
   fn new(lower? : Int, upper? : Int) -> ValueRange
-} derive(Eq, Show)
+} derive(Eq, Show, @debug.Debug)
 
 ///|
 /// Exact single-value range (`1..1`).

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Number-of-values constraint for an argument.
 #warnings("-deprecated_syntax-deprecated")
 pub struct ValueRange {

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Number-of-values constraint for an argument.
 #warnings("-deprecated_syntax-deprecated")
 pub struct ValueRange {


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive for the public types `ArgGroup`, `Command`, `FlagAction`, `FlagArg`, `OptionAction`, `OptionArg`, `PositionArg`, `ValueRange`.
- Internal `Arg`, `ArgInfo`, `ArgBuildError` also gain Debug so the public struct derives cascade.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/argparse` passes on all 4 targets (129 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
