### PR TITLE
feat(json): derive Debug for ParseError, Position, Replacer

### DIFF
--- a/json/json.mbt
+++ b/json/json.mbt
@@ -125,7 +125,7 @@ pub struct Replacer {
   priv f : (String, Json) -> Json?
 
   fn new(f : (String, Json) -> Json?) -> Replacer
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create a new Replacer with a custom function.

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Try to get this element as a Null
 #deprecated("Suggestion: `if json is Null { Some(()) } else { None }`")
 pub fn Json::as_null(self : Json) -> Unit? {

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Try to get this element as a Null
 #deprecated("Suggestion: `if json is Null { Some(()) } else { None }`")
 pub fn Json::as_null(self : Json) -> Unit? {

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -28,7 +28,7 @@ pub(all) suberror ParseError {
   InvalidNumber(Position, String)
   InvalidIdentEscape(Position)
   DepthLimitExceeded
-} derive(Eq, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub impl Show for ParseError
 
 // Types and methods
@@ -41,13 +41,13 @@ pub impl ToJson for JsonPath
 pub(all) struct Position {
   line : Int
   column : Int
-} derive(Eq, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 
 pub struct Replacer {
   // private fields
 
   fn new((String, Json) -> Json?) -> Replacer
-}
+} derive(@debug.Debug)
 pub fn Replacer::exclude(ArrayView[StringView]) -> Self
 pub fn Replacer::keep(ArrayView[StringView]) -> Self
 pub fn Replacer::new((String, Json) -> Json?) -> Self

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -17,7 +17,7 @@
 pub(all) struct Position {
   line : Int // 1-based
   column : Int // 0-based
-} derive(Eq, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 
 ///|
 /// Error type `ParseError`.
@@ -27,7 +27,7 @@ pub(all) suberror ParseError {
   InvalidNumber(Position, String)
   InvalidIdentEscape(Position)
   DepthLimitExceeded
-} derive(Eq, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 
 ///|
 pub impl Show for ParseError with output(self, logger) {

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Type `Position` used by this package APIs.
 pub(all) struct Position {
   line : Int // 1-based

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Type `Position` used by this package APIs.
 pub(all) struct Position {
   line : Int // 1-based

--- a/json/types_test.mbt
+++ b/json/types_test.mbt
@@ -41,3 +41,33 @@ test "ParseError::to_string coverage" {
     "Invalid escape sequence in identifier at line 1, column 0",
   )
 }
+
+///|
+test "Debug for Position" {
+  let pos : @json.Position = { line: 3, column: 7 }
+  @debug.debug_inspect(
+    pos,
+    content=(
+      #|{ line: 3, column: 7 }
+    ),
+  )
+}
+
+///|
+test "Debug for ParseError" {
+  @debug.debug_inspect(
+    (@json.ParseError::InvalidEof : @json.ParseError),
+    content="InvalidEof",
+  )
+}
+
+///|
+test "Debug for Replacer" {
+  let r = @json.Replacer::new(fn(_, v) { Some(v) })
+  @debug.debug_inspect(
+    r,
+    content=(
+      #|{ f: <function: ...> }
+    ),
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive to `ParseError`, `Position`, `Replacer`.
- Replacer's closure field renders as `<function: ...>` via the default Debug derive (no `ignore=` needed).
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/json` passes on all 4 targets (170 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
