### PR TITLE
feat(strconv): derive Debug for StrConvError and Decimal

### DIFF
--- a/strconv/deprecated.mbt
+++ b/strconv/deprecated.mbt
@@ -26,7 +26,7 @@ struct Decimal {
   mut decimal_point : Int
   mut negative : Bool
   mut truncated : Bool
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create a zero decimal.

--- a/strconv/deprecated.mbt
+++ b/strconv/deprecated.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// High Precision Decimal structure for "Simple Decimal Conversion" algorithm.
 /// Developed by Ken. Thompson, Russ Cox, Robert Griesemer, Nigel Tao.
 ///

--- a/strconv/deprecated.mbt
+++ b/strconv/deprecated.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// High Precision Decimal structure for "Simple Decimal Conversion" algorithm.
 /// Developed by Ken. Thompson, Russ Cox, Robert Griesemer, Nigel Tao.
 ///

--- a/strconv/errors.mbt
+++ b/strconv/errors.mbt
@@ -17,7 +17,7 @@
 #deprecated("use `@string` parsing APIs instead", skip_current_package=true)
 pub(all) suberror StrConvError {
   StrConvError(String)
-}
+} derive(@debug.Debug)
 
 ///|
 pub impl Show for StrConvError with output(self, logger) {

--- a/strconv/errors.mbt
+++ b/strconv/errors.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 /// Error type `StrConvError`.
 #deprecated("use `@string` parsing APIs instead", skip_current_package=true)
 pub(all) suberror StrConvError {

--- a/strconv/int_test.mbt
+++ b/strconv/int_test.mbt
@@ -269,3 +269,14 @@ test "parse_int" {
     assert_eq(parse_int_as_result(t.0), t.1)
   }
 }
+
+///|
+test "Debug for StrConvError" {
+  let err : @strconv.StrConvError = StrConvError("invalid syntax")
+  @debug.debug_inspect(
+    err,
+    content=(
+      #|StrConvError("invalid syntax")
+    ),
+  )
+}

--- a/strconv/moon.pkg
+++ b/strconv/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/core/uint64",
   "moonbitlang/core/char",
   "moonbitlang/core/array",
+  "moonbitlang/core/debug",
 }
 
 warnings = "-deprecated"

--- a/strconv/pkg.generated.mbti
+++ b/strconv/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/strconv"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 #deprecated
 pub fn[A : FromStr] parse(StringView) -> A raise StrConvError
@@ -30,12 +34,12 @@ pub fn parse_uint64(StringView, base? : Int) -> UInt64 raise StrConvError
 #deprecated
 pub(all) suberror StrConvError {
   StrConvError(String)
-}
+} derive(@debug.Debug)
 pub impl Show for StrConvError
 
 // Types and methods
 #deprecated
-type Decimal
+type Decimal derive(@debug.Debug)
 #deprecated
 pub fn Decimal::from_int64(Int64) -> Self
 #deprecated


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive to `StrConvError` suberror and `Decimal` struct.
- Both are deprecated already; adding Debug just completes the audit.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/strconv` passes (60 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
