### PR TITLE
feat(bench): add Debug for Bench, Summary, Timestamp

### DIFF
--- a/bench/bench_test.mbt
+++ b/bench/bench_test.mbt
@@ -34,3 +34,11 @@ test "bench buffer writes with multiple samples" {
   bench.bench(() => ignore(2 + 2), name="second", count=1)
   inspect(bench.dump_summaries().contains(","), content="true")
 }
+
+///|
+test "Debug for Bench and Timestamp" {
+  let bench = @bench.Bench::new()
+  @debug.debug_inspect(bench, content="<Bench: []>")
+  let ts = @bench.monotonic_clock_start()
+  @debug.debug_inspect(ts, content="<Timestamp: ...>")
+}

--- a/bench/debug.mbt
+++ b/bench/debug.mbt
@@ -1,0 +1,29 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+using @debug {trait Debug, type Repr}
+
+///|
+pub impl Debug for Bench with to_repr(self) {
+  Repr::opaque_(
+    "Bench",
+    Repr::array(self.summaries.map(s => @debug.to_repr(s))),
+  )
+}
+
+///|
+pub impl Debug for Timestamp with to_repr(_) {
+  Repr::opaque_("Timestamp", Repr::omitted())
+}

--- a/bench/moon.pkg
+++ b/bench/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/core/json",
   "moonbitlang/core/ref",
   "moonbitlang/core/test",
+  "moonbitlang/core/debug",
 }
 
 options(

--- a/bench/pkg.generated.mbti
+++ b/bench/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/bench"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn monotonic_clock_end(Timestamp) -> Double
 
@@ -18,10 +22,12 @@ pub fn Bench::dump_summaries(Self) -> String
 pub fn[Any] Bench::keep(Self, Any) -> Unit
 #as_free_fn
 pub fn Bench::new() -> Self
+pub impl @debug.Debug for Bench
 
-type Summary derive(ToJson)
+type Summary derive(ToJson, @debug.Debug)
 
 type Timestamp
+pub impl @debug.Debug for Timestamp
 
 // Type aliases
 

--- a/bench/stats.mbt
+++ b/bench/stats.mbt
@@ -32,7 +32,7 @@ struct Summary {
   iqr : Double
   batch_size : Int
   runs : Int
-} derive(ToJson)
+} derive(ToJson, @debug.Debug)
 
 ///|
 fn Summary::new(

--- a/bench/stats.mbt
+++ b/bench/stats.mbt
@@ -16,9 +16,6 @@
 // Please refer to https://github.com/rust-lang/rust/blob/a19472a93e2eecce1477011fa9f7ec49b45ca164/library/test/src/stats.rs
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 struct Summary {
   name : String?
   sum : Double

--- a/bench/stats.mbt
+++ b/bench/stats.mbt
@@ -16,6 +16,9 @@
 // Please refer to https://github.com/rust-lang/rust/blob/a19472a93e2eecce1477011fa9f7ec49b45ca164/library/test/src/stats.rs
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 struct Summary {
   name : String?
   sum : Double


### PR DESCRIPTION
## Summary
- `Summary` derives `@debug.Debug`.
- `Bench` and `Timestamp` get manual `Debug` impls in a new `debug.mbt` (Bench has a trait-object field; Timestamp is platform-opaque).
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/bench` passes on all 4 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
