### PR TITLE
feat(bytes): add Debug for BytesRegex and MatchResult

### DIFF
--- a/bytes/debug.mbt
+++ b/bytes/debug.mbt
@@ -1,0 +1,26 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+using @debug {trait Debug, type Repr}
+
+///|
+pub impl Debug for BytesRegex with to_repr(_) {
+  Repr::opaque_("BytesRegex", Repr::omitted())
+}
+
+///|
+pub impl Debug for MatchResult with to_repr(self) {
+  Repr::opaque_("MatchResult", @debug.to_repr(self.content()))
+}

--- a/bytes/moon.pkg
+++ b/bytes/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/bytes/internal/regex_engine" @re,
+  "moonbitlang/core/debug",
 }
 
 import {

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/core/bytes"
 
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -12,6 +13,7 @@ import {
 // Types and methods
 type BytesRegex
 pub fn BytesRegex::execute(Self, BytesView, last_index? : Int) -> MatchResult?
+pub impl @debug.Debug for BytesRegex
 
 type MatchResult
 pub fn MatchResult::after(Self) -> BytesView
@@ -19,6 +21,7 @@ pub fn MatchResult::before(Self) -> BytesView
 pub fn MatchResult::content(Self) -> BytesView
 pub fn MatchResult::group(Self, Int) -> BytesView?
 pub fn MatchResult::named_group(Self, String) -> BytesView?
+pub impl @debug.Debug for MatchResult
 
 // Type aliases
 #deprecated


### PR DESCRIPTION
## Summary
- Adds manual `@debug.Debug` impls for `BytesRegex` and `MatchResult` (both opaque/wrapper public types) in a new `debug.mbt`.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon check --target all` passes
- [x] `moon test -p moonbitlang/core/bytes` passes (134 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
