### PR TITLE
feat(coverage): add Debug for CoverageCounter

### DIFF
--- a/coverage/debug.mbt
+++ b/coverage/debug.mbt
@@ -1,0 +1,22 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+using @debug {trait Debug, type Repr}
+
+///|
+pub impl Debug for CoverageCounter with to_repr(self) {
+  let CoverageCounter(arr) = self
+  Repr::opaque_("CoverageCounter", @debug.to_repr(arr))
+}

--- a/coverage/moon.pkg
+++ b/coverage/moon.pkg
@@ -1,3 +1,4 @@
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
 }

--- a/coverage/pkg.generated.mbti
+++ b/coverage/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/coverage"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn end() -> Unit
 
@@ -13,6 +17,7 @@ type CoverageCounter
 pub fn CoverageCounter::incr(Self, Int) -> Unit
 pub fn CoverageCounter::new(Int) -> Self
 pub impl Show for CoverageCounter
+pub impl @debug.Debug for CoverageCounter
 
 // Type aliases
 


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` impl for `CoverageCounter`, delegating to the wrapped `FixedArray[UInt]`.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/coverage` passes (14 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
