### PR TITLE
feat(debug): add Debug for Repr

### DIFF
--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub fn[T : Debug] to_string(T) -> String
 // Types and methods
 type Repr
 pub impl Show for Repr
+pub impl Debug for Repr
 
 // Type aliases
 

--- a/debug/pretty_print.mbt
+++ b/debug/pretty_print.mbt
@@ -260,9 +260,9 @@ pub impl Show for Repr with output(self, logger) {
 }
 
 ///|
-/// Debug for Repr renders the same as Show.
+/// `Repr` is its own debug representation: `to_repr` is the identity.
 pub impl Debug for Repr with to_repr(self) {
-  Repr::opaque_("Repr", Repr::literal(render(self)))
+  self
 }
 
 ///|

--- a/debug/pretty_print.mbt
+++ b/debug/pretty_print.mbt
@@ -260,6 +260,12 @@ pub impl Show for Repr with output(self, logger) {
 }
 
 ///|
+/// Debug for Repr renders the same as Show.
+pub impl Debug for Repr with to_repr(self) {
+  Repr::opaque_("Repr", Repr::literal(render(self)))
+}
+
+///|
 /// Print a value in human-readable format to standard output.
 pub fn[T : Debug] debug(x : T) -> Unit {
   println(render(x.to_repr()))


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` impl for `Repr` (the type returned by `Debug::to_repr`).
- Renders as `<Repr: rendered>` via the existing `render` function.

## Test plan
- [x] `moon test -p moonbitlang/core/debug` passes (57 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
