### PR TITLE
feat(quickcheck/splitmix): derive Debug for RandomState

### DIFF
--- a/quickcheck/splitmix/moon.pkg
+++ b/quickcheck/splitmix/moon.pkg
@@ -2,4 +2,5 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/float",
   "moonbitlang/core/test",
+  "moonbitlang/core/debug",
 }

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -1,13 +1,17 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/core/quickcheck/splitmix"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn new(seed? : UInt64) -> RandomState
 
 // Errors
 
 // Types and methods
-type RandomState derive(Show)
+type RandomState derive(Show, @debug.Debug)
 pub fn RandomState::clone(Self) -> Self
 #deprecated
 pub fn RandomState::new(seed? : UInt64) -> Self

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 ///|
+using @debug {trait Debug, type Repr}
+
+///|
 #warnings("-deprecated_syntax")
 struct RandomState {
   mut seed : UInt64
   gamma : UInt64
-} derive(Show)
+} derive(Show, @debug.Debug)
 
 ///|
 let golden_gamma : UInt64 = 0x9e3779b97f4a7c15


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive for `RandomState`.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/quickcheck/splitmix` passes (13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
