### PR TITLE
feat(random): add Debug for Rand

### DIFF
--- a/random/debug.mbt
+++ b/random/debug.mbt
@@ -1,0 +1,21 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+using @debug {trait Debug, type Repr}
+
+///|
+pub impl Debug for Rand with to_repr(_) {
+  Repr::opaque_("Rand", Repr::omitted())
+}

--- a/random/moon.pkg
+++ b/random/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/core/random/internal/random_source",
   "moonbitlang/core/bigint",
   "moonbitlang/core/test",
+  "moonbitlang/core/debug",
 }
 
 import {

--- a/random/pkg.generated.mbti
+++ b/random/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/core/random"
 
 import {
   "moonbitlang/core/bigint",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -27,6 +28,7 @@ pub fn Rand::new(generator? : &Source) -> Self
 pub fn Rand::shuffle(Self, Int, (Int, Int) -> Unit) -> Unit
 pub fn Rand::uint(Self, limit? : UInt) -> UInt
 pub fn Rand::uint64(Self, limit? : UInt64) -> UInt64
+pub impl @debug.Debug for Rand
 
 // Type aliases
 


### PR DESCRIPTION
## Summary
- Adds manual `@debug.Debug` impl for `Rand` (wraps a `&Source` trait object so manual impl needed) in a new `debug.mbt`.
- Renders as `<Rand>`.

## Test plan
- [x] `moon test -p moonbitlang/core/random` passes (28 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
