### PR TITLE
feat(string): add Debug for Regex

### DIFF
--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -34,7 +34,6 @@ pub struct Regex {
 
   fn new(StringView) -> Regex raise
 }
-pub impl @debug.Debug for Regex
 pub fn Regex::capture(Self, String) -> Self
 pub fn Regex::execute(Self, StringView, last_index? : Int) -> MatchResult?
 pub fn Regex::find(Self, StringView) -> Iter[MatchResult]
@@ -46,6 +45,7 @@ pub fn Regex::string(StringView) -> Self
 pub fn Regex::unsafe_from_string(StringView) -> Self
 pub impl Add for Regex
 pub impl BitOr for Regex
+pub impl @debug.Debug for Regex
 
 // Type aliases
 #deprecated

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub struct Regex {
 
   fn new(StringView) -> Regex raise
 }
+pub impl @debug.Debug for Regex
 pub fn Regex::capture(Self, String) -> Self
 pub fn Regex::execute(Self, StringView, last_index? : Int) -> MatchResult?
 pub fn Regex::find(Self, StringView) -> Iter[MatchResult]

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -28,6 +28,11 @@ const MAX_REPEAT_QUANTIFIER = 256
 using @debug {trait Debug, type Repr}
 
 ///|
+pub impl Debug for Regex with to_repr(self) {
+  Repr::opaque_("Regex", @debug.to_repr(self.pat))
+}
+
+///|
 /// Result of one successful match produced by `Regex::execute`.
 struct MatchResult {
   input : StringView


### PR DESCRIPTION
## Summary
- Adds manual `@debug.Debug` impl for `Regex` that renders the wrapped `Pattern`.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/string` passes (258 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
