### PR TITLE
feat(test): derive Debug for Test

### DIFF
--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -34,7 +34,7 @@ pub fn[T : Show] same_object(T, T, loc~ : SourceLoc) -> Unit raise
 
 // Types and methods
 #alias(T, deprecated)
-type Test
+type Test derive(@debug.Debug)
 pub fn Test::name(Self) -> String
 #as_free_fn
 pub fn Test::new(String) -> Self

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug}
+using @debug {trait Debug, type Repr}
 
 ///|
 fn[T : Show] debug_string(t : T) -> String {

--- a/test/types.mbt
+++ b/test/types.mbt
@@ -17,7 +17,7 @@
 struct Test {
   name : String
   buffer : StringBuilder
-}
+} derive(@debug.Debug)
 
 ///|
 /// Create a new instance.


### PR DESCRIPTION
## Summary
- Adds `@debug.Debug` derive for `Test`.
- Part of an audit filling in Debug impls for every public type in core.

## Test plan
- [x] `moon test -p moonbitlang/core/test` passes (25 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
