### PR TITLE
feat(debug): add Debug for builtin BenchError/ArgsLoc/Hasher/IterResult/UninitializedArray

### DIFF
--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -353,6 +353,37 @@ pub impl Debug for SnapshotError with to_repr(self) {
 }
 
 ///|
+pub impl Debug for BenchError with to_repr(self) {
+  match self {
+    BenchError(msg) => Repr::ctor("BenchError", [(None, Repr::string(msg))])
+  }
+}
+
+///|
+pub impl Debug for ArgsLoc with to_repr(self) {
+  let ArgsLoc(arr) = self
+  Repr::opaque_("ArgsLoc", to_repr(arr))
+}
+
+///|
+pub impl Debug for Hasher with to_repr(_) {
+  Repr::opaque_("Hasher", Repr::omitted())
+}
+
+///|
+pub impl Debug for IterResult with to_repr(self) {
+  match self {
+    IterEnd => Repr::ctor("IterEnd", [])
+    IterContinue => Repr::ctor("IterContinue", [])
+  }
+}
+
+///|
+pub impl[T] Debug for UninitializedArray[T] with to_repr(_) {
+  Repr::opaque_("UninitializedArray", Repr::omitted())
+}
+
+///|
 test "Debug for builtin errors" {
   debug_inspect(
     InspectError::InspectError("inspect msg"),

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -353,6 +353,7 @@ pub impl Debug for SnapshotError with to_repr(self) {
 }
 
 ///|
+#warnings("-deprecated")
 pub impl Debug for BenchError with to_repr(self) {
   match self {
     BenchError(msg) => Repr::ctor("BenchError", [(None, Repr::string(msg))])
@@ -371,6 +372,7 @@ pub impl Debug for Hasher with to_repr(_) {
 }
 
 ///|
+#warnings("-deprecated")
 pub impl Debug for IterResult with to_repr(self) {
   match self {
     IterEnd => Repr::ctor("IterEnd", [])

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -50,22 +50,22 @@ pub impl[T : Debug, E : Debug] Debug for Result[T, E]
 pub impl[T : Debug] Debug for FixedArray[T]
 pub impl[T : Debug] Debug for ReadOnlyArray[T]
 pub impl Debug for Bytes
+pub impl Debug for ArgsLoc
 pub impl[T : Debug] Debug for Array[T]
 pub impl[T : Debug] Debug for ArrayView[T]
+pub impl Debug for BenchError
 pub impl Debug for Failure
+pub impl Debug for Hasher
 pub impl Debug for InspectError
 pub impl[A] Debug for Iter[A]
 pub impl[A, B] Debug for Iter2[A, B]
+pub impl Debug for IterResult
 pub impl Debug for Json
 pub impl[K : Debug, V : Debug] Debug for Map[K, V]
 pub impl[T : Debug] Debug for MutArrayView[T]
 pub impl Debug for SnapshotError
 pub impl Debug for SourceLoc
 pub impl Debug for StringBuilder
-pub impl Debug for BenchError
-pub impl Debug for ArgsLoc
-pub impl Debug for Hasher
-pub impl Debug for IterResult
 pub impl[T] Debug for UninitializedArray[T]
 pub impl[A : Debug, B : Debug] Debug for (A, B)
 pub impl[A : Debug, B : Debug, C : Debug] Debug for (A, B, C)

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -62,6 +62,11 @@ pub impl[T : Debug] Debug for MutArrayView[T]
 pub impl Debug for SnapshotError
 pub impl Debug for SourceLoc
 pub impl Debug for StringBuilder
+pub impl Debug for BenchError
+pub impl Debug for ArgsLoc
+pub impl Debug for Hasher
+pub impl Debug for IterResult
+pub impl[T] Debug for UninitializedArray[T]
 pub impl[A : Debug, B : Debug] Debug for (A, B)
 pub impl[A : Debug, B : Debug, C : Debug] Debug for (A, B, C)
 pub impl[A : Debug, B : Debug, C : Debug, D : Debug] Debug for (A, B, C, D)


### PR DESCRIPTION
## Summary
- Adds `Debug` impls in the `debug` package for builtin types `BenchError`, `ArgsLoc`, `Hasher`, `IterResult`, `UninitializedArray[T]`.
- These can't be derived/declared in `builtin` because builtin can't import debug (circular dep), so they live here alongside `Failure`/`InspectError`/`SnapshotError`.

## Test plan
- [x] `moon check --target all` passes
- [x] `moon test -p moonbitlang/core/debug` passes (57 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
