### PR TITLE
refactor(builtin): share Int/Int64/Double until via a private helper

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -43,27 +43,7 @@ pub fn Int::until(
   step? : Int = 1,
   inclusive? : Bool = false,
 ) -> Iter[Int] {
-  if step == 0 {
-    return Iter::empty()
-  }
-  let mut i = self
-  let mut done = false
-  () => {
-    guard !done else { None }
-    guard (step > 0 && i < end) ||
-      (step < 0 && i > end) ||
-      (inclusive && i == end) else {
-      None
-    }
-    let value = i
-    let next = i + step
-    if (step > 0 && next >= i) || (step < 0 && next <= i) {
-      i = next
-    } else {
-      done = true
-    }
-    Some(value)
-  }
+  until_impl(self, end, step, inclusive)
 }
 
 ///|
@@ -86,27 +66,7 @@ pub fn Int64::until(
   step? : Int64 = 1L,
   inclusive? : Bool = false,
 ) -> Iter[Int64] {
-  if step == 0 {
-    return Iter::empty()
-  }
-  let mut i = self
-  let mut done = false
-  () => {
-    guard !done else { None }
-    guard (step > 0 && i < end) ||
-      (step < 0 && i > end) ||
-      (inclusive && i == end) else {
-      None
-    }
-    let value = i
-    let next = i + step
-    if (step > 0 && next >= i) || (step < 0 && next <= i) {
-      i = next
-    } else {
-      done = true
-    }
-    Some(value)
-  }
+  until_impl(self, end, step, inclusive)
 }
 
 ///|
@@ -129,25 +89,5 @@ pub fn Double::until(
   step? : Double = 1.0,
   inclusive? : Bool = false,
 ) -> Iter[Double] {
-  if step == 0.0 {
-    return Iter::empty()
-  }
-  let mut i = self
-  let mut done = false
-  () => {
-    guard !done else { None }
-    guard (step > 0.0 && i < end) ||
-      (step < 0.0 && i > end) ||
-      (inclusive && i == end) else {
-      None
-    }
-    let value = i
-    let next = i + step
-    if (step > 0.0 && next >= i) || (step < 0.0 && next <= i) {
-      i = next
-    } else {
-      done = true
-    }
-    Some(value)
-  }
+  until_impl(self, end, step, inclusive)
 }

--- a/builtin/range.mbt
+++ b/builtin/range.mbt
@@ -1,0 +1,47 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Shared body for `Int::until`, `Int64::until`, and `Double::until`.
+/// `Default::default()` is taken to be the additive identity (zero) of
+/// `T`, which is true for the built-in numeric types this is used with.
+fn[T : Add + Compare + Default] until_impl(
+  start : T,
+  end : T,
+  step : T,
+  inclusive : Bool,
+) -> Iter[T] {
+  let zero = T::default()
+  if step == zero {
+    return Iter::empty()
+  }
+  let mut i = start
+  let mut done = false
+  Iter::new(() => {
+    guard !done else { None }
+    guard (step > zero && i < end) ||
+      (step < zero && i > end) ||
+      (inclusive && i == end) else {
+      None
+    }
+    let value = i
+    let next = i + step
+    if (step > zero && next >= i) || (step < zero && next <= i) {
+      i = next
+    } else {
+      done = true
+    }
+    Some(value)
+  })
+}


### PR DESCRIPTION
## Summary
- Extracts the three near-identical loop bodies of `Int::until`, `Int64::until`, and `Double::until` into a single private generic helper `until_impl[T : Add + Compare + Default]` in `builtin/range.mbt`.
- The three public functions become one-line delegates.
- **Public API is unchanged** — no new traits, no new functions exported. `git diff origin/main builtin/pkg.generated.mbti` is empty.

## Why
Three copies of the same loop, with the only differences being the literal numeric type. Sharing them via a small generic helper keeps each per-type wrapper focused on its signature and lets us evolve the loop in one place.

## Semantics
Byte-for-byte identical to the previous behavior, including:
- Zero-step yields an empty iterator.
- Negative step descends.
- `inclusive=true` includes `end`.
- The overflow corner case `(MAX_VALUE - 1).until(MAX_VALUE, inclusive=true)` yields `[MAX-1, MAX]` and terminates without wrapping — covered by existing tests at `builtin/iter_test.mbt:421-438` for both `Int` and `Int64`.

## Test plan
- [x] `moon test` — 6364/6364 pass.
- [x] `moon check` — no new warnings.
- [x] `diff <(git show origin/main:builtin/pkg.generated.mbti) builtin/pkg.generated.mbti` — empty.

## Diff size
2 files changed, 50 insertions(+), 63 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)