### PR TITLE
chore(float): remove deprecated Float::upto

### DIFF
--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -411,36 +411,6 @@ pub impl Mod for Float with mod(self : Float, other : Float) -> Float {
 
 ///|
 /// Creates an iterator that iterates over a range of Float with default step 1.0 .
-///
-/// # Arguments
-///
-/// * `start` - The starting value of the range (inclusive).
-/// * `end` - The ending value of the range (exclusive).
-/// * `inclusive` - Whether the ending value is inclusive (default false).
-///
-/// # Returns
-///
-/// Returns an iterator that iterates over the range of Float from `start` to `end - 1`.
-#deprecated("Use `..<` in for loop or `until` method instead")
-#coverage.skip
-pub fn Float::upto(
-  self : Float,
-  end : Float,
-  inclusive? : Bool = false,
-) -> Iter[Float] {
-  let mut i = self
-  Iter::new(() => {
-    guard i < end || (inclusive && i == end) else { None }
-    let result = i
-    if i != end {
-      i += 1
-    }
-    Some(result)
-  })
-}
-
-///|
-/// Creates an iterator that iterates over a range of Float with default step 1.0 .
 /// To grow the range downward, set the `step` parameter to a negative value.
 ///
 /// # Arguments

--- a/float/pkg.generated.mbti
+++ b/float/pkg.generated.mbti
@@ -59,8 +59,6 @@ pub fn Float::to_le_bytes(Float) -> Bytes
 #as_free_fn
 pub fn Float::trunc(Float) -> Float
 pub fn Float::until(Float, Float, step? : Float, inclusive? : Bool) -> Iter[Float]
-#deprecated
-pub fn Float::upto(Float, Float, inclusive? : Bool) -> Iter[Float]
 pub impl Add for Float
 pub impl Compare for Float
 pub impl Default for Float


### PR DESCRIPTION
## Summary
Removes `Float::upto`, which has been `#deprecated` with message *"Use `..<` in for loop or `until` method instead"* and is unused inside core itself.

## Diff
Only `Float::upto` is removed; all other API in the `float` package is unchanged.

```
$ diff <(git show origin/main:float/pkg.generated.mbti) float/pkg.generated.mbti
< #deprecated
< pub fn Float::upto(Float, Float, inclusive? : Bool) -> Iter[Float]
```

## Test plan
- [x] `moon test` — 6364/6364 pass.
- [x] `moon check` — no new warnings.
- [x] No remaining `Float::upto` references inside the workspace (verified via grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
