### PR TITLE
Add decimal package

### DIFF
--- a/decimal/README.mbt.md
+++ b/decimal/README.mbt.md
@@ -1,0 +1,84 @@
+# Decimal
+
+`Decimal` provides arbitrary-precision finite decimal arithmetic. Values are
+stored canonically as an integer coefficient and a base-10 exponent, so
+`1.50`, `1.5`, and `1.500e0` compare and hash as the same value.
+
+## Creating Values
+
+```mbt check
+///|
+test "create decimals" {
+  let a = @decimal.Decimal::from_string("123.4500")
+  inspect(a, content="123.45")
+
+  let b = @decimal.Decimal::from_bigint(
+    @bigint.BigInt::from_string("12345"),
+    exponent=-2,
+  )
+  inspect(b, content="123.45")
+
+  inspect(a == b, content="true")
+}
+```
+
+## Arithmetic
+
+```mbt check
+///|
+test "decimal arithmetic" {
+  let subtotal = @decimal.Decimal::from_string("19.99")
+  let tax = @decimal.Decimal::from_string("1.65")
+  inspect(subtotal + tax, content="21.64")
+
+  let quantity = @decimal.Decimal::from_int(3)
+  inspect(subtotal * quantity, content="59.97")
+}
+```
+
+## Rounding And Division
+
+There is intentionally no `/` operator for `Decimal`. Division can either be
+exact or require an explicit scale and rounding mode.
+
+Rounded results are still canonical values. The requested scale controls the
+rounding position, but `to_string` does not keep trailing zeros added by that
+rounding step.
+
+```mbt check
+///|
+test "decimal division" {
+  inspect(
+    @decimal.Decimal::from_string("1").div_exact(
+      @decimal.Decimal::from_string("4"),
+    ),
+    content="0.25",
+  )
+
+  inspect(
+    @decimal.Decimal::from_string("1").div_round(
+      @decimal.Decimal::from_string("3"),
+      scale=2,
+      mode=@decimal.HalfEven,
+    ),
+    content="0.33",
+  )
+}
+```
+
+## JSON
+
+Decimals are encoded as JSON strings to preserve precision across JSON parsers
+that represent numbers as IEEE 754 doubles.
+
+```mbt check
+///|
+test "decimal json" {
+  let value = @decimal.Decimal::from_string("12345678901234567890.125")
+  let json = value.to_json()
+  inspect(json, content="String(\"12345678901234567890.125\")")
+
+  let decoded : @decimal.Decimal = @json.from_json(json)
+  inspect(decoded == value, content="true")
+}
+```

--- a/decimal/arithmetic.mbt
+++ b/decimal/arithmetic.mbt
@@ -1,0 +1,70 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn align_coefficients(
+  a : Decimal,
+  b : Decimal,
+) -> (@bigint.BigInt, @bigint.BigInt, Int) {
+  if a.exponent == b.exponent {
+    (a.coefficient, b.coefficient, a.exponent)
+  } else if a.exponent < b.exponent {
+    let factor = pow10(sub_exponents(b.exponent, a.exponent))
+    (a.coefficient, b.coefficient * factor, a.exponent)
+  } else {
+    let factor = pow10(sub_exponents(a.exponent, b.exponent))
+    (a.coefficient * factor, b.coefficient, b.exponent)
+  }
+}
+
+///|
+pub impl Add for Decimal with add(self, other) {
+  let (a, b, exponent) = align_coefficients(self, other)
+  make_decimal(a + b, exponent)
+}
+
+///|
+pub impl Sub for Decimal with sub(self, other) {
+  let (a, b, exponent) = align_coefficients(self, other)
+  make_decimal(a - b, exponent)
+}
+
+///|
+pub impl Mul for Decimal with mul(self, other) {
+  make_decimal(
+    self.coefficient * other.coefficient,
+    add_exponents(self.exponent, other.exponent),
+  )
+}
+
+///|
+pub impl Neg for Decimal with neg(self) {
+  { coefficient: -self.coefficient, exponent: self.exponent }
+}
+
+///|
+/// Converts a decimal to `BigInt` if it has no fractional part.
+pub fn Decimal::to_bigint_exact(
+  self : Decimal,
+) -> @bigint.BigInt raise DecimalError {
+  if self.exponent >= 0 {
+    self.coefficient * pow10(self.exponent)
+  } else {
+    let divisor = pow10(exponent_from_int64(-self.exponent.to_int64()))
+    guard self.coefficient % divisor == zero_bigint else {
+      raise InexactConversion
+    }
+    self.coefficient / divisor
+  }
+}

--- a/decimal/arithmetic.mbt
+++ b/decimal/arithmetic.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+/// Aligns two values to a common exponent so their coefficients can be
+/// added or compared. The smaller-exponent operand keeps its coefficient;
+/// the other is multiplied by `10^(exponent_diff)`.
 fn align_coefficients(
   a : Decimal,
   b : Decimal,
@@ -29,18 +32,32 @@ fn align_coefficients(
 }
 
 ///|
+/// Exact addition: `self + other`.
+///
+/// Always exact; result is canonicalized. Note that pairs of values with
+/// vastly different exponents will materialize a large `BigInt` factor of
+/// ten during alignment, so the operation can be expensive (but never
+/// imprecise).
 pub impl Add for Decimal with add(self, other) {
   let (a, b, exponent) = align_coefficients(self, other)
   make_decimal(a + b, exponent)
 }
 
 ///|
+/// Exact subtraction: `self - other`.
+///
+/// Same exactness/cost characteristics as `Add`.
 pub impl Sub for Decimal with sub(self, other) {
   let (a, b, exponent) = align_coefficients(self, other)
   make_decimal(a - b, exponent)
 }
 
 ///|
+/// Exact multiplication: `self * other`.
+///
+/// Coefficients multiply; exponents add. Result is canonicalized.
+///
+/// **Aborts** if the sum of exponents would overflow `Int`.
 pub impl Mul for Decimal with mul(self, other) {
   make_decimal(
     self.coefficient * other.coefficient,
@@ -49,12 +66,46 @@ pub impl Mul for Decimal with mul(self, other) {
 }
 
 ///|
+/// Unary negation: `-self`. Always exact, no allocation of a fresh
+/// coefficient is required when the value is already negative because
+/// `BigInt::neg` handles both signs uniformly.
 pub impl Neg for Decimal with neg(self) {
   { coefficient: -self.coefficient, exponent: self.exponent }
 }
 
 ///|
-/// Converts a decimal to `BigInt` if it has no fractional part.
+/// Converts a decimal to `BigInt` if and only if it has no fractional
+/// part.
+///
+/// # Errors
+///
+/// Raises `InexactConversion` when:
+/// - The value has a non-zero fractional part (e.g. `12.01`).
+/// - The exponent is so far below zero that the would-be divisor cannot
+///   even be constructed without overflowing `Int` (only happens for
+///   pathological inputs near `Int::min_value`).
+///
+/// For lossy / rounded conversion, prefer `round(scale=0)` followed by
+/// this method, or use `div_round` to control the rounding mode.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   inspect(
+///     @decimal.Decimal::from_string("1200").to_bigint_exact(),
+///     content="1200",
+///   )
+///   inspect(
+///     @decimal.Decimal::from_string("12.00").to_bigint_exact(),
+///     content="12",
+///   )
+///   inspect(
+///     try? @decimal.Decimal::from_string("12.01").to_bigint_exact(),
+///     content="Err(InexactConversion)",
+///   )
+/// }
+/// ```
 pub fn Decimal::to_bigint_exact(
   self : Decimal,
 ) -> @bigint.BigInt raise DecimalError {

--- a/decimal/arithmetic.mbt
+++ b/decimal/arithmetic.mbt
@@ -61,7 +61,9 @@ pub fn Decimal::to_bigint_exact(
   if self.exponent >= 0 {
     self.coefficient * pow10(self.exponent)
   } else {
-    let divisor = pow10(exponent_from_int64(-self.exponent.to_int64()))
+    let negative_exponent = -self.exponent.to_int64()
+    guard negative_exponent <= max_exponent64 else { raise InexactConversion }
+    let divisor = pow10(negative_exponent.to_int())
     guard self.coefficient % divisor == zero_bigint else {
       raise InexactConversion
     }

--- a/decimal/constructors.mbt
+++ b/decimal/constructors.mbt
@@ -13,11 +13,35 @@
 // limitations under the License.
 
 ///|
-/// Creates a decimal from a coefficient and base-10 exponent.
+/// Builds a decimal from a coefficient and a base-10 exponent.
 ///
-/// The resulting value is `coefficient * 10^exponent`. The result is
-/// canonicalized, so trailing zeros may be moved from the coefficient into the
-/// exponent.
+/// The resulting value equals `coefficient * 10^exponent` and is
+/// canonicalized: trailing factors of ten in `coefficient` are folded into
+/// `exponent`. So `from_bigint(BigInt::from_int(12_500), exponent=-2)` and
+/// `from_bigint(BigInt::from_int(125), exponent=-1)` produce the same
+/// `Decimal` (`125`).
+///
+/// **Aborts** if canonicalizing would push `exponent` past `Int::max_value`.
+/// In practice this only happens when `coefficient` already has many trailing
+/// zeros and `exponent` is very close to the upper limit.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   let n = @decimal.Decimal::from_bigint(
+///     @bigint.BigInt::from_int(12345),
+///     exponent=-2,
+///   )
+///   inspect(n, content="123.45")
+///   // Trailing zeros in the coefficient are absorbed by the exponent.
+///   let m = @decimal.Decimal::from_bigint(
+///     @bigint.BigInt::from_int(12300),
+///     exponent=-2,
+///   )
+///   inspect(m, content="123")
+/// }
+/// ```
 pub fn Decimal::from_bigint(
   coefficient : @bigint.BigInt,
   exponent? : Int = 0,
@@ -26,49 +50,80 @@ pub fn Decimal::from_bigint(
 }
 
 ///|
-/// Creates a decimal from an `Int`.
+/// Builds a decimal from an `Int`. Equivalent to
+/// `Decimal::from_bigint(BigInt::from_int(value))`.
 pub fn Decimal::from_int(value : Int) -> Decimal {
   make_decimal(@bigint.BigInt::from_int(value), 0)
 }
 
 ///|
-/// Creates a decimal from an `Int64`.
+/// Builds a decimal from an `Int64`.
 pub fn Decimal::from_int64(value : Int64) -> Decimal {
   make_decimal(@bigint.BigInt::from_int64(value), 0)
 }
 
 ///|
-/// Creates a decimal from a `UInt`.
+/// Builds a decimal from an unsigned `UInt`.
 pub fn Decimal::from_uint(value : UInt) -> Decimal {
   make_decimal(@bigint.BigInt::from_uint(value), 0)
 }
 
 ///|
-/// Creates a decimal from a `UInt64`.
+/// Builds a decimal from an unsigned `UInt64`.
 pub fn Decimal::from_uint64(value : UInt64) -> Decimal {
   make_decimal(@bigint.BigInt::from_uint64(value), 0)
 }
 
 ///|
 /// Returns the canonical coefficient.
+///
+/// Because the value is canonical, `coefficient()` never has a trailing
+/// factor of ten (except when the value is exactly zero, where the
+/// coefficient is `0`). Combined with `exponent()` this is a complete view
+/// of the underlying representation.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   inspect(@decimal.Decimal::from_string("12.300").coefficient(), content="123")
+///   inspect(@decimal.Decimal::from_int(0).coefficient(), content="0")
+/// }
+/// ```
 pub fn Decimal::coefficient(self : Decimal) -> @bigint.BigInt {
   self.coefficient
 }
 
 ///|
 /// Returns the canonical base-10 exponent.
+///
+/// For a value `c * 10^e`, this is `e`. Zero always has exponent `0`.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   inspect(@decimal.Decimal::from_string("12.300").exponent(), content="-1")
+///   inspect(@decimal.Decimal::from_string("1200").exponent(), content="2")
+///   inspect(@decimal.Decimal::from_int(0).exponent(), content="0")
+/// }
+/// ```
 pub fn Decimal::exponent(self : Decimal) -> Int {
   self.exponent
 }
 
 ///|
-/// Tests whether the decimal value is zero.
+/// Tests whether the decimal value is exactly zero.
+///
+/// Equivalent to `self == Decimal::from_int(0)` but does not allocate.
 pub fn Decimal::is_zero(self : Decimal) -> Bool {
   self.coefficient.is_zero()
 }
 
 ///|
-/// Returns the absolute value.
+/// Returns the absolute value `|self|`.
+///
+/// For non-negative values this returns `self` unchanged (no allocation).
 pub fn Decimal::abs(self : Decimal) -> Decimal {
   if self.coefficient < zero_bigint {
     { coefficient: -self.coefficient, exponent: self.exponent }
@@ -78,7 +133,7 @@ pub fn Decimal::abs(self : Decimal) -> Decimal {
 }
 
 ///|
-/// Returns the default decimal value, zero.
+/// The default `Decimal` value is zero.
 pub impl Default for Decimal with default() {
   { coefficient: zero_bigint, exponent: 0 }
 }

--- a/decimal/constructors.mbt
+++ b/decimal/constructors.mbt
@@ -1,0 +1,84 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Creates a decimal from a coefficient and base-10 exponent.
+///
+/// The resulting value is `coefficient * 10^exponent`. The result is
+/// canonicalized, so trailing zeros may be moved from the coefficient into the
+/// exponent.
+pub fn Decimal::from_bigint(
+  coefficient : @bigint.BigInt,
+  exponent? : Int = 0,
+) -> Decimal {
+  make_decimal(coefficient, exponent)
+}
+
+///|
+/// Creates a decimal from an `Int`.
+pub fn Decimal::from_int(value : Int) -> Decimal {
+  make_decimal(@bigint.BigInt::from_int(value), 0)
+}
+
+///|
+/// Creates a decimal from an `Int64`.
+pub fn Decimal::from_int64(value : Int64) -> Decimal {
+  make_decimal(@bigint.BigInt::from_int64(value), 0)
+}
+
+///|
+/// Creates a decimal from a `UInt`.
+pub fn Decimal::from_uint(value : UInt) -> Decimal {
+  make_decimal(@bigint.BigInt::from_uint(value), 0)
+}
+
+///|
+/// Creates a decimal from a `UInt64`.
+pub fn Decimal::from_uint64(value : UInt64) -> Decimal {
+  make_decimal(@bigint.BigInt::from_uint64(value), 0)
+}
+
+///|
+/// Returns the canonical coefficient.
+pub fn Decimal::coefficient(self : Decimal) -> @bigint.BigInt {
+  self.coefficient
+}
+
+///|
+/// Returns the canonical base-10 exponent.
+pub fn Decimal::exponent(self : Decimal) -> Int {
+  self.exponent
+}
+
+///|
+/// Tests whether the decimal value is zero.
+pub fn Decimal::is_zero(self : Decimal) -> Bool {
+  self.coefficient.is_zero()
+}
+
+///|
+/// Returns the absolute value.
+pub fn Decimal::abs(self : Decimal) -> Decimal {
+  if self.coefficient < zero_bigint {
+    { coefficient: -self.coefficient, exponent: self.exponent }
+  } else {
+    self
+  }
+}
+
+///|
+/// Returns the default decimal value, zero.
+pub impl Default for Decimal with default() {
+  { coefficient: zero_bigint, exponent: 0 }
+}

--- a/decimal/decimal_test.mbt
+++ b/decimal/decimal_test.mbt
@@ -164,6 +164,19 @@ test "division" {
     content="-1",
   )
   inspect(dec("1").div_round(dec("4"), scale=4), content="0.25")
+  inspect(dec("1e-2147483648").div_round(dec("1"), scale=0), content="0")
+  inspect(
+    dec("1e-2147483648").div_round(dec("1"), scale=0, mode=AwayFromZero),
+    content="1",
+  )
+  inspect(
+    dec("-1e-2147483648").div_round(
+      dec("1"),
+      scale=0,
+      mode=TowardNegativeInfinity,
+    ),
+    content="-1",
+  )
   inspect(
     try? dec("1").div_round(dec("0"), scale=2),
     content="Err(DivisionByZero)",
@@ -175,6 +188,10 @@ test "exact bigint conversion" {
   inspect(dec("1200").to_bigint_exact(), content="1200")
   inspect(dec("12.00").to_bigint_exact(), content="12")
   inspect(try? dec("12.01").to_bigint_exact(), content="Err(InexactConversion)")
+  inspect(
+    try? dec("1e-2147483648").to_bigint_exact(),
+    content="Err(InexactConversion)",
+  )
 }
 
 ///|

--- a/decimal/decimal_test.mbt
+++ b/decimal/decimal_test.mbt
@@ -215,8 +215,11 @@ test "json conversion" {
 }
 
 ///|
-test "panic decimal round scale out of range" {
-  dec("1").round(scale=-2147483648) |> ignore
+test "round scale out of range raises" {
+  inspect(
+    try? dec("1").round(scale=-2147483648),
+    content="Err(ExponentOutOfRange)",
+  )
 }
 
 ///|
@@ -226,4 +229,59 @@ test "panic decimal exponent overflow in constructor" {
     exponent=2147483647,
   )
   |> ignore
+}
+
+///|
+test "compare extreme exponents does not abort" {
+  let huge = dec("1e2147483647")
+  let tiny = dec("1e-2147483648")
+  inspect(huge.compare(tiny), content="1")
+  inspect(tiny.compare(huge), content="-1")
+  inspect(huge.compare(huge), content="0")
+  // Same sign, magnitudes that decide via the fast path.
+  inspect(dec("9e10").compare(dec("1e1")), content="1")
+  inspect(dec("1e1").compare(dec("9e10")), content="-1")
+  // Magnitudes overlap → precise scaled comparison.
+  inspect(dec("0.5").compare(dec("0.50000001")), content="-1")
+  // Negative vs positive across extremes.
+  inspect(dec("-1e2147483647").compare(dec("1e-2147483648")), content="-1")
+}
+
+///|
+test "div_round survives extreme shifts" {
+  let huge = dec("1e2147483647")
+  let tiny = dec("1e-2147483648")
+  // tiny / huge is far below half a unit → rounds toward zero by default.
+  inspect(tiny.div_round(huge, scale=0), content="0")
+  inspect(tiny.div_round(huge, scale=0, mode=AwayFromZero), content="1")
+  inspect(
+    tiny.div_round(huge, scale=0, mode=TowardNegativeInfinity),
+    content="0",
+  )
+  inspect(
+    (-tiny).div_round(huge, scale=0, mode=TowardNegativeInfinity),
+    content="-1",
+  )
+  // Extreme scale is reported as a typed error rather than aborting.
+  inspect(
+    try? dec("1").div_round(dec("1"), scale=-2147483648),
+    content="Err(ExponentOutOfRange)",
+  )
+}
+
+///|
+test "parse rejects underscore adjacent to dot" {
+  inspect(
+    try? @decimal.Decimal::from_string("1._2"),
+    content="Err(InvalidSyntax(\"1._2\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("._5"),
+    content="Err(InvalidSyntax(\"._5\"))",
+  )
+  // Already covered: underscore right before the dot.
+  inspect(
+    try? @decimal.Decimal::from_string("1_.2"),
+    content="Err(InvalidSyntax(\"1_.2\"))",
+  )
 }

--- a/decimal/decimal_test.mbt
+++ b/decimal/decimal_test.mbt
@@ -1,0 +1,212 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn dec(s : StringView) -> @decimal.Decimal raise @decimal.DecimalError {
+  @decimal.Decimal::from_string(s)
+}
+
+///|
+test "parse and canonical formatting" {
+  inspect(dec("0"), content="0")
+  inspect(dec("-0.000"), content="0")
+  inspect(dec("+00123.4500"), content="123.45")
+  inspect(dec(".123"), content="0.123")
+  inspect(dec("123."), content="123")
+  inspect(dec("1e-3"), content="0.001")
+  inspect(dec("1_23.45_00e+1_2"), content="123450000000000")
+  inspect(dec("1e-2147483648").exponent(), content="-2147483648")
+  inspect(
+    dec("999999999999999999999999999999999999.000"),
+    content="999999999999999999999999999999999999",
+  )
+}
+
+///|
+test "parse invalid syntax" {
+  inspect(
+    try? @decimal.Decimal::from_string(""),
+    content="Err(InvalidSyntax(\"\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("."),
+    content="Err(InvalidSyntax(\".\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("-"),
+    content="Err(InvalidSyntax(\"-\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("_1"),
+    content="Err(InvalidSyntax(\"_1\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("1__2"),
+    content="Err(InvalidSyntax(\"1__2\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("1_.2"),
+    content="Err(InvalidSyntax(\"1_.2\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("1.2_e3"),
+    content="Err(InvalidSyntax(\"1.2_e3\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("1e+_2"),
+    content="Err(InvalidSyntax(\"1e+_2\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("1e2147483648"),
+    content="Err(InvalidSyntax(\"1e2147483648\"))",
+  )
+  inspect(
+    try? @decimal.Decimal::from_string("10e2147483647"),
+    content="Err(InvalidSyntax(\"10e2147483647\"))",
+  )
+}
+
+///|
+test "constructors and accessors canonicalize" {
+  let n = @decimal.Decimal::from_bigint(
+    @bigint.BigInt::from_string("1234500"),
+    exponent=-4,
+  )
+  inspect(n, content="123.45")
+  inspect(n.coefficient(), content="12345")
+  inspect(n.exponent(), content="-2")
+  inspect(@decimal.Decimal::from_int(-42), content="-42")
+  inspect(@decimal.Decimal::from_int64(1234567890123L), content="1234567890123")
+  inspect(@decimal.Decimal::from_uint(42U), content="42")
+  inspect(@decimal.Decimal::from_uint64(42UL), content="42")
+  inspect(@decimal.Decimal::default().is_zero(), content="true")
+  inspect(dec("-12.5").abs(), content="12.5")
+}
+
+///|
+test "arithmetic" {
+  inspect(dec("1.2") + dec("3.45"), content="4.65")
+  inspect(dec("3.45") - dec("1.2"), content="2.25")
+  inspect(dec("-3.45") + dec("1.20"), content="-2.25")
+  inspect(dec("12.5") * dec("-0.2"), content="-2.5")
+  inspect(-dec("12.500"), content="-12.5")
+  inspect(
+    dec("1000000000000000000000000.01") + dec("0.09"),
+    content="1000000000000000000000000.1",
+  )
+}
+
+///|
+test "equality compare and hash use canonical value" {
+  let a = dec("1.50")
+  let b = dec("1.5")
+  let c = dec("1.500e0")
+  inspect(a == b, content="true")
+  inspect(b == c, content="true")
+  inspect(a.compare(dec("1.49")), content="1")
+  inspect(a.compare(dec("1.50")), content="0")
+  inspect(a.compare(dec("1.51")), content="-1")
+  inspect(Hash::hash(a) == Hash::hash(b), content="true")
+}
+
+///|
+test "rounding modes" {
+  inspect(dec("2.5").round(scale=0, mode=HalfEven), content="2")
+  inspect(dec("3.5").round(scale=0, mode=HalfEven), content="4")
+  inspect(dec("-2.5").round(scale=0, mode=HalfEven), content="-2")
+  inspect(dec("2.5").round(scale=0, mode=HalfTowardZero), content="2")
+  inspect(dec("-2.5").round(scale=0, mode=HalfTowardZero), content="-2")
+  inspect(dec("2.5").round(scale=0, mode=HalfAwayFromZero), content="3")
+  inspect(dec("-2.5").round(scale=0, mode=HalfAwayFromZero), content="-3")
+  inspect(dec("2.1").round(scale=0, mode=AwayFromZero), content="3")
+  inspect(dec("-2.1").round(scale=0, mode=AwayFromZero), content="-3")
+  inspect(dec("2.9").round(scale=0, mode=TowardZero), content="2")
+  inspect(dec("-2.9").round(scale=0, mode=TowardZero), content="-2")
+  inspect(dec("2.1").round(scale=0, mode=TowardPositiveInfinity), content="3")
+  inspect(dec("-2.1").round(scale=0, mode=TowardPositiveInfinity), content="-2")
+  inspect(dec("2.1").round(scale=0, mode=TowardNegativeInfinity), content="2")
+  inspect(dec("-2.1").round(scale=0, mode=TowardNegativeInfinity), content="-3")
+  inspect(dec("12.345").round(scale=2, mode=HalfEven), content="12.34")
+  inspect(dec("12.355").round(scale=2, mode=HalfEven), content="12.36")
+  inspect(dec("1.005").round(scale=2, mode=HalfEven), content="1")
+  inspect(dec("149").round(scale=-1, mode=HalfEven), content="150")
+  inspect(dec("145").round(scale=-1, mode=HalfEven), content="140")
+}
+
+///|
+test "division" {
+  inspect(dec("1").div_exact(dec("2")), content="0.5")
+  inspect(dec("1.5").div_exact(dec("0.25")), content="6")
+  inspect(dec("-1").div_exact(dec("8")), content="-0.125")
+  inspect(
+    try? dec("1").div_exact(dec("3")),
+    content="Err(NonTerminatingDivision)",
+  )
+  inspect(try? dec("1").div_exact(dec("0")), content="Err(DivisionByZero)")
+  inspect(dec("1").div_round(dec("3"), scale=2), content="0.33")
+  inspect(
+    dec("2").div_round(dec("3"), scale=0, mode=HalfAwayFromZero),
+    content="1",
+  )
+  inspect(
+    dec("-2").div_round(dec("3"), scale=0, mode=HalfAwayFromZero),
+    content="-1",
+  )
+  inspect(dec("1").div_round(dec("4"), scale=4), content="0.25")
+  inspect(
+    try? dec("1").div_round(dec("0"), scale=2),
+    content="Err(DivisionByZero)",
+  )
+}
+
+///|
+test "exact bigint conversion" {
+  inspect(dec("1200").to_bigint_exact(), content="1200")
+  inspect(dec("12.00").to_bigint_exact(), content="12")
+  inspect(try? dec("12.01").to_bigint_exact(), content="Err(InexactConversion)")
+}
+
+///|
+test "json conversion" {
+  let value = dec("12345678901234567890.125")
+  inspect(value.to_json(), content="String(\"12345678901234567890.125\")")
+  let decoded : @decimal.Decimal = @json.from_json(value.to_json())
+  inspect(decoded, content="12345678901234567890.125")
+  inspect(
+    try? (@json.from_json(Json::number(1.5)) : @decimal.Decimal),
+    content=(
+      #|Err(JsonDecodeError((, "Decimal::from_json: expected decimal in string representation")))
+    ),
+  )
+  inspect(
+    try? (@json.from_json(Json::string("not-decimal")) : @decimal.Decimal),
+    content=(
+      #|Err(JsonDecodeError((, "Decimal::from_json: invalid decimal string")))
+    ),
+  )
+}
+
+///|
+test "panic decimal round scale out of range" {
+  dec("1").round(scale=-2147483648) |> ignore
+}
+
+///|
+test "panic decimal exponent overflow in constructor" {
+  @decimal.Decimal::from_bigint(
+    @bigint.BigInt::from_int(10),
+    exponent=2147483647,
+  )
+  |> ignore
+}

--- a/decimal/division.mbt
+++ b/decimal/division.mbt
@@ -128,27 +128,40 @@ pub fn Decimal::div_round(
   mode? : RoundingMode = HalfEven,
 ) -> Decimal raise DecimalError {
   guard !other.coefficient.is_zero() else { raise DivisionByZero }
-  let target_exponent = scale_to_exponent(scale)
-  let shift = sub_exponents(
-    sub_exponents(self.exponent, other.exponent),
-    target_exponent,
-  )
-  let (numerator, denominator) = if shift >= 0 {
-    (self.coefficient * pow10(shift), other.coefficient)
+  // Compute the result exponent and scaling shift in Int64 so we never
+  // round-trip through `Int` until we actually need to materialize a
+  // canonical exponent or call `pow10`.
+  let target_exponent_i64 = -scale.to_int64()
+  guard target_exponent_i64 >= min_exponent64 &&
+    target_exponent_i64 <= max_exponent64 else {
+    raise ExponentOutOfRange
+  }
+  let target_exponent = target_exponent_i64.to_int()
+  let shift_i64 = self.exponent.to_int64() -
+    other.exponent.to_int64() -
+    target_exponent_i64
+  if shift_i64 >= 0L {
+    // Multiply numerator by 10^shift. If the shift exceeds Int range we
+    // would need to construct an infeasibly large `BigInt`; bail.
+    guard shift_i64 <= max_exponent64 else { raise ExponentOutOfRange }
+    let numerator = self.coefficient * pow10(shift_i64.to_int())
+    let denominator = other.coefficient
+    make_decimal(rounded_ratio(numerator, denominator, mode), target_exponent)
   } else {
-    let negative_shift = -shift.to_int64()
-    if negative_shift > max_exponent64 {
-      // Pathological case: `shift == Int::min_value` and the exact value
-      // is below half of one target unit. Rounding therefore depends only
-      // on direction; we can settle the result without materializing the
-      // (infeasibly large) divisor.
+    let neg_shift = -shift_i64
+    if neg_shift > max_exponent64 {
+      // The exact value is more than `max_exponent64` decimal places
+      // below the target scale, so the magnitude is strictly below
+      // half of one unit. Rounding therefore depends only on the
+      // sign of the ratio and the rounding mode; we settle the result
+      // without materializing the (infeasibly large) divisor.
       return make_decimal(
         rounded_ratio_below_half(self.coefficient, other.coefficient, mode),
         target_exponent,
       )
     }
-    (self.coefficient, other.coefficient * pow10(negative_shift.to_int()))
+    let numerator = self.coefficient
+    let denominator = other.coefficient * pow10(neg_shift.to_int())
+    make_decimal(rounded_ratio(numerator, denominator, mode), target_exponent)
   }
-  let quotient = rounded_ratio(numerator, denominator, mode)
-  make_decimal(quotient, target_exponent)
 }

--- a/decimal/division.mbt
+++ b/decimal/division.mbt
@@ -1,0 +1,83 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Divides two decimals exactly.
+///
+/// Raises `NonTerminatingDivision` when the exact result is not a finite
+/// decimal, for example `1 / 3`.
+pub fn Decimal::div_exact(
+  self : Decimal,
+  other : Decimal,
+) -> Decimal raise DecimalError {
+  guard !other.coefficient.is_zero() else { raise DivisionByZero }
+  let mut numerator = self.coefficient
+  let mut denominator = other.coefficient
+  if denominator < zero_bigint {
+    numerator = -numerator
+    denominator = -denominator
+  }
+  let gcd = bigint_gcd(numerator, denominator)
+  numerator = numerator / gcd
+  denominator = denominator / gcd
+
+  let mut twos = 0
+  while denominator % two_bigint == zero_bigint {
+    denominator = denominator / two_bigint
+    twos += 1
+  }
+  let mut fives = 0
+  while denominator % five_bigint == zero_bigint {
+    denominator = denominator / five_bigint
+    fives += 1
+  }
+  guard denominator == one_bigint else { raise NonTerminatingDivision }
+
+  let scale = if twos > fives { twos } else { fives }
+  let coefficient = numerator *
+    pow_bigint(two_bigint, scale - twos) *
+    pow_bigint(five_bigint, scale - fives)
+  make_decimal(
+    coefficient,
+    sub_exponents(sub_exponents(self.exponent, other.exponent), scale),
+  )
+}
+
+///|
+/// Divides two decimals and rounds to the requested scale. Results remain
+/// canonical, so trailing zeros introduced by rounding are not preserved in
+/// `to_string`.
+pub fn Decimal::div_round(
+  self : Decimal,
+  other : Decimal,
+  scale~ : Int,
+  mode? : RoundingMode = HalfEven,
+) -> Decimal raise DecimalError {
+  guard !other.coefficient.is_zero() else { raise DivisionByZero }
+  let target_exponent = scale_to_exponent(scale)
+  let shift = sub_exponents(
+    sub_exponents(self.exponent, other.exponent),
+    target_exponent,
+  )
+  let (numerator, denominator) = if shift >= 0 {
+    (self.coefficient * pow10(shift), other.coefficient)
+  } else {
+    (
+      self.coefficient,
+      other.coefficient * pow10(exponent_from_int64(-shift.to_int64())),
+    )
+  }
+  let quotient = rounded_ratio(numerator, denominator, mode)
+  make_decimal(quotient, target_exponent)
+}

--- a/decimal/division.mbt
+++ b/decimal/division.mbt
@@ -13,10 +13,39 @@
 // limitations under the License.
 
 ///|
-/// Divides two decimals exactly.
+/// Exact division: `self / other`.
 ///
-/// Raises `NonTerminatingDivision` when the exact result is not a finite
-/// decimal, for example `1 / 3`.
+/// Computes the exact rational result and represents it as a canonical
+/// decimal — but only if the result *is* a finite decimal. A rational
+/// number `p/q` (in lowest terms) is a finite decimal iff `q` has no prime
+/// factors other than 2 and 5. So `1/2 = 0.5` and `1/8 = 0.125` work, but
+/// `1/3` and `1/7` do not.
+///
+/// # Errors
+///
+/// - `DivisionByZero` if `other` is zero.
+/// - `NonTerminatingDivision` if the exact result cannot be represented as
+///   a finite decimal. Use `div_round` instead to obtain a rounded
+///   approximation with an explicit scale.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   let dec = @decimal.Decimal::from_string
+///   inspect(dec("1").div_exact(dec("2")), content="0.5")
+///   inspect(dec("1.5").div_exact(dec("0.25")), content="6")
+///   inspect(
+///     try? dec("1").div_exact(dec("3")),
+///     content="Err(NonTerminatingDivision)",
+///   )
+///   inspect(try? dec("1").div_exact(dec("0")), content="Err(DivisionByZero)")
+/// }
+/// ```
+///
+/// There is intentionally no `/` operator for `Decimal` — division must be
+/// either exact (this method) or rounded with an explicit scale
+/// (`div_round`).
 pub fn Decimal::div_exact(
   self : Decimal,
   other : Decimal,
@@ -31,7 +60,6 @@ pub fn Decimal::div_exact(
   let gcd = bigint_gcd(numerator, denominator)
   numerator = numerator / gcd
   denominator = denominator / gcd
-
   let mut twos = 0
   while denominator % two_bigint == zero_bigint {
     denominator = denominator / two_bigint
@@ -43,7 +71,6 @@ pub fn Decimal::div_exact(
     fives += 1
   }
   guard denominator == one_bigint else { raise NonTerminatingDivision }
-
   let scale = if twos > fives { twos } else { fives }
   let coefficient = numerator *
     pow_bigint(two_bigint, scale - twos) *
@@ -55,9 +82,45 @@ pub fn Decimal::div_exact(
 }
 
 ///|
-/// Divides two decimals and rounds to the requested scale. Results remain
-/// canonical, so trailing zeros introduced by rounding are not preserved in
-/// `to_string`.
+/// Rounded division: `self / other`, rounded to `scale` digits after the
+/// decimal point using `mode`.
+///
+/// `scale` is the number of digits *after* the decimal point. Positive
+/// `scale` rounds to a fractional position; `scale=0` rounds to an integer;
+/// negative `scale` rounds to a position to the left of the decimal point
+/// (e.g. `scale=-2` rounds to the nearest hundred).
+///
+/// `mode` defaults to `HalfEven` (banker's rounding). See `RoundingMode`
+/// for all seven modes and their tie-breaking behavior.
+///
+/// The result is canonicalized: trailing zeros introduced by rounding are
+/// not preserved by `to_string`. So `dec("1").div_round(dec("2"),
+/// scale=2)` is `"0.5"`, not `"0.50"`. If you need a fixed-scale string,
+/// pad after `to_string` or format from the canonical representation.
+///
+/// # Errors
+///
+/// - `DivisionByZero` if `other` is zero.
+///
+/// Unlike `div_exact`, this never raises `NonTerminatingDivision` — that
+/// is exactly what `scale` lets you avoid.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   let dec = @decimal.Decimal::from_string
+///   inspect(dec("1").div_round(dec("3"), scale=2), content="0.33")
+///   inspect(
+///     dec("2").div_round(dec("3"), scale=0, mode=@decimal.HalfAwayFromZero),
+///     content="1",
+///   )
+///   inspect(
+///     try? dec("1").div_round(dec("0"), scale=2),
+///     content="Err(DivisionByZero)",
+///   )
+/// }
+/// ```
 pub fn Decimal::div_round(
   self : Decimal,
   other : Decimal,
@@ -75,8 +138,10 @@ pub fn Decimal::div_round(
   } else {
     let negative_shift = -shift.to_int64()
     if negative_shift > max_exponent64 {
-      // This only happens for `shift == Int::min_value`; the scaled value is
-      // below half of one target unit, so rounding depends only on direction.
+      // Pathological case: `shift == Int::min_value` and the exact value
+      // is below half of one target unit. Rounding therefore depends only
+      // on direction; we can settle the result without materializing the
+      // (infeasibly large) divisor.
       return make_decimal(
         rounded_ratio_below_half(self.coefficient, other.coefficient, mode),
         target_exponent,

--- a/decimal/division.mbt
+++ b/decimal/division.mbt
@@ -73,10 +73,16 @@ pub fn Decimal::div_round(
   let (numerator, denominator) = if shift >= 0 {
     (self.coefficient * pow10(shift), other.coefficient)
   } else {
-    (
-      self.coefficient,
-      other.coefficient * pow10(exponent_from_int64(-shift.to_int64())),
-    )
+    let negative_shift = -shift.to_int64()
+    if negative_shift > max_exponent64 {
+      // This only happens for `shift == Int::min_value`; the scaled value is
+      // below half of one target unit, so rounding depends only on direction.
+      return make_decimal(
+        rounded_ratio_below_half(self.coefficient, other.coefficient, mode),
+        target_exponent,
+      )
+    }
+    (self.coefficient, other.coefficient * pow10(negative_shift.to_int()))
   }
   let quotient = rounded_ratio(numerator, denominator, mode)
   make_decimal(quotient, target_exponent)

--- a/decimal/format.mbt
+++ b/decimal/format.mbt
@@ -1,0 +1,57 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Converts a decimal to its canonical non-exponential decimal representation.
+pub fn Decimal::to_string(self : Decimal) -> String {
+  if self.coefficient.is_zero() {
+    return "0"
+  }
+  let negative = self.coefficient < zero_bigint
+  let digits = bigint_abs(self.coefficient).to_string()
+  let builder = StringBuilder::new(size_hint=digits.length() + 8)
+  if negative {
+    builder.write_char('-')
+  }
+  if self.exponent >= 0 {
+    builder.write_string(digits)
+    for _ in 0..<self.exponent {
+      builder.write_char('0')
+    }
+  } else {
+    let point = digits.length().to_int64() + self.exponent.to_int64()
+    if point > 0L {
+      let point = exponent_from_int64(point)
+      for i in 0..<point {
+        builder.write_char(digits.unsafe_get(i).unsafe_to_char())
+      }
+      builder.write_char('.')
+      for i in point..<digits.length() {
+        builder.write_char(digits.unsafe_get(i).unsafe_to_char())
+      }
+    } else {
+      builder.write_string("0.")
+      for _ in 0..<exponent_from_int64(-point) {
+        builder.write_char('0')
+      }
+      builder.write_string(digits)
+    }
+  }
+  builder.to_string()
+}
+
+///|
+pub impl Show for Decimal with output(self, logger) {
+  logger.write_string(self.to_string())
+}

--- a/decimal/format.mbt
+++ b/decimal/format.mbt
@@ -13,7 +13,23 @@
 // limitations under the License.
 
 ///|
-/// Converts a decimal to its canonical non-exponential decimal representation.
+/// Renders the decimal in plain (non-scientific) form.
+///
+/// The output reflects the canonical representation, so trailing zeros
+/// after the decimal point are **not** preserved. For example:
+///
+/// ```text
+/// from_string("1.500")    -> "1.5"
+/// from_string("12.300")   -> "12.3"
+/// from_string("1e3")      -> "1000"
+/// from_string("1e-3")     -> "0.001"
+/// from_int(0)             -> "0"
+/// ```
+///
+/// Round-tripping through `from_string`/`to_string` always yields the
+/// canonical form. If you need a fixed-scale string (e.g. always two
+/// fractional digits for currency display), pad the canonical form
+/// yourself or build a formatter on top.
 pub fn Decimal::to_string(self : Decimal) -> String {
   if self.coefficient.is_zero() {
     return "0"
@@ -52,6 +68,7 @@ pub fn Decimal::to_string(self : Decimal) -> String {
 }
 
 ///|
+/// `Show` produces the same canonical form as `to_string`.
 pub impl Show for Decimal with output(self, logger) {
   logger.write_string(self.to_string())
 }

--- a/decimal/moon.pkg
+++ b/decimal/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "moonbitlang/core/builtin",
+  "moonbitlang/core/bigint",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}

--- a/decimal/parse.mbt
+++ b/decimal/parse.mbt
@@ -71,6 +71,7 @@ pub fn Decimal::from_string(input : StringView) -> Decimal raise DecimalError {
   let mut has_digit = false
   let mut dot_seen = false
   let mut after_underscore = false
+  let mut after_dot = false
   let mut frac_digits = 0
   let mut has_exponent = false
   let mut scanning = true
@@ -81,24 +82,30 @@ pub fn Decimal::from_string(input : StringView) -> Decimal raise DecimalError {
         digits.write_char(ch)
         has_digit = true
         after_underscore = false
+        after_dot = false
         if dot_seen {
           frac_digits += 1
         }
         rest = tail
       }
       ['_', .. tail] => {
-        guard has_digit && !after_underscore else { invalid_syntax(input) }
+        guard has_digit && !after_underscore && !after_dot else {
+          invalid_syntax(input)
+        }
         after_underscore = true
+        after_dot = false
         rest = tail
       }
       ['.', .. tail] => {
         guard !dot_seen && !after_underscore else { invalid_syntax(input) }
         dot_seen = true
+        after_dot = true
         rest = tail
       }
       ['e' | 'E', .. tail] => {
         guard has_digit && !after_underscore else { invalid_syntax(input) }
         has_exponent = true
+        after_dot = false
         rest = tail
         scanning = false
       }

--- a/decimal/parse.mbt
+++ b/decimal/parse.mbt
@@ -13,10 +13,48 @@
 // limitations under the License.
 
 ///|
-/// Parses a decimal string.
+/// Parses a decimal literal.
 ///
-/// Accepted forms include an optional sign, decimal point, scientific exponent,
-/// and underscores between digits.
+/// Accepts the standard textual form of a decimal number with these
+/// extensions:
+///
+/// - **Optional sign**: `+` or `-` at the front.
+/// - **Decimal point**: `.` may appear zero or one time. Either side may be
+///   empty (`".5"` and `"5."` both parse), but at least one digit must
+///   appear in total.
+/// - **Scientific exponent**: `e` or `E` followed by an optional sign and a
+///   digit sequence. The exponent must fit in the canonical exponent range
+///   (roughly ±2³¹ after combining with the position of the decimal point).
+/// - **Underscores**: between digits, as visual separators (`"1_000_000"`).
+///   Not allowed at the start or end of a digit run, adjacent to the
+///   decimal point, between the sign and the first digit, or doubled
+///   (`"1__2"`).
+///
+/// Whitespace is **not** accepted; trim it before parsing if needed.
+///
+/// The result is canonicalized (`"1.500"` and `"1.5"` parse to the same
+/// value).
+///
+/// # Errors
+///
+/// Raises `InvalidSyntax(input)` for any unparseable input, including
+/// empty strings, lone signs or dots, malformed exponents, and exponents
+/// that would push the canonical representation beyond the supported
+/// range.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   inspect(@decimal.Decimal::from_string("123.45"), content="123.45")
+///   inspect(@decimal.Decimal::from_string("-0.000"), content="0")
+///   inspect(@decimal.Decimal::from_string("1e-3"), content="0.001")
+///   inspect(
+///     @decimal.Decimal::from_string("1_23.45_00e+1_2"),
+///     content="123450000000000",
+///   )
+/// }
+/// ```
 pub fn Decimal::from_string(input : StringView) -> Decimal raise DecimalError {
   guard !input.is_empty() else { invalid_syntax(input) }
   let mut rest = input
@@ -29,7 +67,6 @@ pub fn Decimal::from_string(input : StringView) -> Decimal raise DecimalError {
     ['+', .. tail] => rest = tail
     _ => ()
   }
-
   let digits = StringBuilder::new()
   let mut has_digit = false
   let mut dot_seen = false
@@ -69,7 +106,6 @@ pub fn Decimal::from_string(input : StringView) -> Decimal raise DecimalError {
     }
   }
   guard has_digit && !after_underscore else { invalid_syntax(input) }
-
   let mut scientific_exponent = 0L
   if has_exponent {
     let mut exponent_negative = false
@@ -113,7 +149,6 @@ pub fn Decimal::from_string(input : StringView) -> Decimal raise DecimalError {
     }
   }
   guard rest is [] else { invalid_syntax(input) }
-
   let total_exponent = scientific_exponent - frac_digits.to_int64()
   guard total_exponent >= min_exponent64 && total_exponent <= max_exponent64 else {
     invalid_syntax(input)

--- a/decimal/parse.mbt
+++ b/decimal/parse.mbt
@@ -1,0 +1,124 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Parses a decimal string.
+///
+/// Accepted forms include an optional sign, decimal point, scientific exponent,
+/// and underscores between digits.
+pub fn Decimal::from_string(input : StringView) -> Decimal raise DecimalError {
+  guard !input.is_empty() else { invalid_syntax(input) }
+  let mut rest = input
+  let mut negative = false
+  match rest {
+    ['-', .. tail] => {
+      negative = true
+      rest = tail
+    }
+    ['+', .. tail] => rest = tail
+    _ => ()
+  }
+
+  let digits = StringBuilder::new()
+  let mut has_digit = false
+  let mut dot_seen = false
+  let mut after_underscore = false
+  let mut frac_digits = 0
+  let mut has_exponent = false
+  let mut scanning = true
+  while scanning {
+    match rest {
+      [] => scanning = false
+      ['0'..='9' as ch, .. tail] => {
+        digits.write_char(ch)
+        has_digit = true
+        after_underscore = false
+        if dot_seen {
+          frac_digits += 1
+        }
+        rest = tail
+      }
+      ['_', .. tail] => {
+        guard has_digit && !after_underscore else { invalid_syntax(input) }
+        after_underscore = true
+        rest = tail
+      }
+      ['.', .. tail] => {
+        guard !dot_seen && !after_underscore else { invalid_syntax(input) }
+        dot_seen = true
+        rest = tail
+      }
+      ['e' | 'E', .. tail] => {
+        guard has_digit && !after_underscore else { invalid_syntax(input) }
+        has_exponent = true
+        rest = tail
+        scanning = false
+      }
+      _ => invalid_syntax(input)
+    }
+  }
+  guard has_digit && !after_underscore else { invalid_syntax(input) }
+
+  let mut scientific_exponent = 0L
+  if has_exponent {
+    let mut exponent_negative = false
+    match rest {
+      ['-', .. tail] => {
+        exponent_negative = true
+        rest = tail
+      }
+      ['+', .. tail] => rest = tail
+      _ => ()
+    }
+    let mut has_exponent_digit = false
+    let mut after_exponent_underscore = false
+    while rest is [ch, .. tail] {
+      match ch {
+        '0'..='9' => {
+          has_exponent_digit = true
+          after_exponent_underscore = false
+          scientific_exponent = scientific_exponent * 10L +
+            (ch.to_int() - '0'.to_int()).to_int64()
+          guard scientific_exponent <= -min_exponent64 else {
+            invalid_syntax(input)
+          }
+          rest = tail
+        }
+        '_' => {
+          guard has_exponent_digit && !after_exponent_underscore else {
+            invalid_syntax(input)
+          }
+          after_exponent_underscore = true
+          rest = tail
+        }
+        _ => invalid_syntax(input)
+      }
+    }
+    guard has_exponent_digit && !after_exponent_underscore else {
+      invalid_syntax(input)
+    }
+    if exponent_negative {
+      scientific_exponent = -scientific_exponent
+    }
+  }
+  guard rest is [] else { invalid_syntax(input) }
+
+  let total_exponent = scientific_exponent - frac_digits.to_int64()
+  guard total_exponent >= min_exponent64 && total_exponent <= max_exponent64 else {
+    invalid_syntax(input)
+  }
+  let coefficient = @bigint.BigInt::from_string(digits.to_string())
+  let coefficient = if negative { -coefficient } else { coefficient }
+  make_decimal_from_string(coefficient, total_exponent, input)
+}

--- a/decimal/pkg.generated.mbti
+++ b/decimal/pkg.generated.mbti
@@ -1,0 +1,64 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/decimal"
+
+import {
+  "moonbitlang/core/bigint",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+pub(all) suberror DecimalError {
+  InvalidSyntax(String)
+  DivisionByZero
+  NonTerminatingDivision
+  InexactConversion
+} derive(Eq, ToJson, @debug.Debug)
+pub impl Show for DecimalError
+
+// Types and methods
+type Decimal derive(@debug.Debug)
+pub fn Decimal::abs(Self) -> Self
+pub fn Decimal::coefficient(Self) -> @bigint.BigInt
+pub fn Decimal::div_exact(Self, Self) -> Self raise DecimalError
+pub fn Decimal::div_round(Self, Self, scale~ : Int, mode? : RoundingMode) -> Self raise DecimalError
+pub fn Decimal::exponent(Self) -> Int
+pub fn Decimal::from_bigint(@bigint.BigInt, exponent? : Int) -> Self
+pub fn Decimal::from_int(Int) -> Self
+pub fn Decimal::from_int64(Int64) -> Self
+pub fn Decimal::from_string(StringView) -> Self raise DecimalError
+pub fn Decimal::from_uint(UInt) -> Self
+pub fn Decimal::from_uint64(UInt64) -> Self
+pub fn Decimal::is_zero(Self) -> Bool
+pub fn Decimal::round(Self, scale~ : Int, mode? : RoundingMode) -> Self
+pub fn Decimal::to_bigint_exact(Self) -> @bigint.BigInt raise DecimalError
+pub fn Decimal::to_string(Self) -> String
+pub impl Add for Decimal
+pub impl Compare for Decimal
+pub impl Default for Decimal
+pub impl Eq for Decimal
+pub impl Hash for Decimal
+pub impl Mul for Decimal
+pub impl Neg for Decimal
+pub impl Show for Decimal
+pub impl Sub for Decimal
+pub impl ToJson for Decimal
+pub impl @json.FromJson for Decimal
+
+pub(all) enum RoundingMode {
+  TowardZero
+  AwayFromZero
+  TowardNegativeInfinity
+  TowardPositiveInfinity
+  HalfTowardZero
+  HalfAwayFromZero
+  HalfEven
+} derive(Eq, @debug.Debug)
+pub impl Show for RoundingMode
+
+// Type aliases
+
+// Traits
+

--- a/decimal/pkg.generated.mbti
+++ b/decimal/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub(all) suberror DecimalError {
   DivisionByZero
   NonTerminatingDivision
   InexactConversion
+  ExponentOutOfRange
 } derive(Eq, ToJson, @debug.Debug)
 pub impl Show for DecimalError
 
@@ -32,7 +33,7 @@ pub fn Decimal::from_string(StringView) -> Self raise DecimalError
 pub fn Decimal::from_uint(UInt) -> Self
 pub fn Decimal::from_uint64(UInt64) -> Self
 pub fn Decimal::is_zero(Self) -> Bool
-pub fn Decimal::round(Self, scale~ : Int, mode? : RoundingMode) -> Self
+pub fn Decimal::round(Self, scale~ : Int, mode? : RoundingMode) -> Self raise DecimalError
 pub fn Decimal::to_bigint_exact(Self) -> @bigint.BigInt raise DecimalError
 pub fn Decimal::to_string(Self) -> String
 pub impl Add for Decimal

--- a/decimal/rounding.mbt
+++ b/decimal/rounding.mbt
@@ -123,8 +123,10 @@ fn rounded_ratio_below_half(
 /// `mode` defaults to `HalfEven` (banker's rounding). See `RoundingMode`
 /// for the full list of modes and their tie-breaking semantics.
 ///
-/// **Aborts** when `scale` is `Int::min_value` (the would-be exponent
-/// `-scale` overflows `Int`).
+/// Raises `ExponentOutOfRange` when `scale` is `Int::min_value` (the
+/// would-be exponent `-scale` overflows `Int`) or when the gap between
+/// `self`'s exponent and the target scale is too wide to materialize a
+/// `pow10` divisor.
 ///
 /// The result is canonicalized: trailing zeros introduced by rounding
 /// are not preserved by `to_string`. To get a fixed-scale string, format
@@ -150,12 +152,19 @@ pub fn Decimal::round(
   self : Decimal,
   scale~ : Int,
   mode? : RoundingMode = HalfEven,
-) -> Decimal {
-  let target_exponent = scale_to_exponent(scale)
+) -> Decimal raise DecimalError {
+  let target_exponent_i64 = -scale.to_int64()
+  guard target_exponent_i64 >= min_exponent64 &&
+    target_exponent_i64 <= max_exponent64 else {
+    raise ExponentOutOfRange
+  }
+  let target_exponent = target_exponent_i64.to_int()
   if self.exponent >= target_exponent {
     return self
   }
-  let divisor = pow10(sub_exponents(target_exponent, self.exponent))
+  let diff_i64 = target_exponent_i64 - self.exponent.to_int64()
+  guard diff_i64 <= max_exponent64 else { raise ExponentOutOfRange }
+  let divisor = pow10(diff_i64.to_int())
   let quotient = rounded_ratio(self.coefficient, divisor, mode)
   make_decimal(quotient, target_exponent)
 }

--- a/decimal/rounding.mbt
+++ b/decimal/rounding.mbt
@@ -1,0 +1,91 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn round_quotient(
+  quotient : @bigint.BigInt,
+  remainder : @bigint.BigInt,
+  divisor : @bigint.BigInt,
+  negative : Bool,
+  mode : RoundingMode,
+) -> @bigint.BigInt {
+  if remainder.is_zero() {
+    return quotient
+  }
+  let abs_remainder = bigint_abs(remainder)
+  let half_cmp = (abs_remainder * two_bigint).compare(divisor)
+  let increment = match mode {
+    TowardZero => false
+    AwayFromZero => true
+    TowardPositiveInfinity => !negative
+    TowardNegativeInfinity => negative
+    HalfTowardZero => half_cmp > 0
+    HalfAwayFromZero => half_cmp >= 0
+    HalfEven =>
+      half_cmp > 0 ||
+      (half_cmp == 0 && bigint_abs(quotient) % two_bigint != zero_bigint)
+  }
+  if increment {
+    if negative {
+      quotient - one_bigint
+    } else {
+      quotient + one_bigint
+    }
+  } else {
+    quotient
+  }
+}
+
+///|
+fn rounded_ratio(
+  numerator : @bigint.BigInt,
+  denominator : @bigint.BigInt,
+  mode : RoundingMode,
+) -> @bigint.BigInt {
+  let mut numerator = numerator
+  let mut denominator = denominator
+  if denominator < zero_bigint {
+    numerator = -numerator
+    denominator = -denominator
+  }
+  let quotient = numerator / denominator
+  let remainder = numerator % denominator
+  round_quotient(
+    quotient,
+    remainder,
+    denominator,
+    numerator < zero_bigint,
+    mode,
+  )
+}
+
+///|
+/// Rounds to the requested number of digits after the decimal point.
+///
+/// Negative scales round to positions left of the decimal point. Results remain
+/// canonical, so trailing zeros introduced by rounding are not preserved in
+/// `to_string`.
+pub fn Decimal::round(
+  self : Decimal,
+  scale~ : Int,
+  mode? : RoundingMode = HalfEven,
+) -> Decimal {
+  let target_exponent = scale_to_exponent(scale)
+  if self.exponent >= target_exponent {
+    return self
+  }
+  let divisor = pow10(sub_exponents(target_exponent, self.exponent))
+  let quotient = rounded_ratio(self.coefficient, divisor, mode)
+  make_decimal(quotient, target_exponent)
+}

--- a/decimal/rounding.mbt
+++ b/decimal/rounding.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+/// Rounds `quotient` (the integer-divided result) up or down by one
+/// according to the relation between the absolute remainder and half of
+/// the divisor. Used by both `Decimal::round` and `Decimal::div_round`.
 fn round_quotient(
   quotient : @bigint.BigInt,
   remainder : @bigint.BigInt,
@@ -48,6 +51,7 @@ fn round_quotient(
 }
 
 ///|
+/// Computes `numerator / denominator` rounded to an integer per `mode`.
 fn rounded_ratio(
   numerator : @bigint.BigInt,
   denominator : @bigint.BigInt,
@@ -71,6 +75,10 @@ fn rounded_ratio(
 }
 
 ///|
+/// Round-to-integer for the specific case where the exact value is known
+/// to lie strictly below half of a unit (i.e. `|num/den| < 0.5`). Used by
+/// `div_round` for the pathological `shift == Int::min_value` path where
+/// constructing the full divisor is not feasible.
 fn rounded_ratio_below_half(
   numerator : @bigint.BigInt,
   denominator : @bigint.BigInt,
@@ -89,6 +97,7 @@ fn rounded_ratio_below_half(
     AwayFromZero => true
     TowardPositiveInfinity => !negative
     TowardNegativeInfinity => negative
+    // All half-modes round exact values below half toward zero.
     HalfTowardZero | HalfAwayFromZero | HalfEven => false
   }
   if increment {
@@ -103,11 +112,40 @@ fn rounded_ratio_below_half(
 }
 
 ///|
-/// Rounds to the requested number of digits after the decimal point.
+/// Rounds the decimal to the requested scale.
 ///
-/// Negative scales round to positions left of the decimal point. Results remain
-/// canonical, so trailing zeros introduced by rounding are not preserved in
-/// `to_string`.
+/// `scale` is the number of digits *after* the decimal point. Positive
+/// `scale` rounds to a fractional position; `scale=0` rounds to the
+/// nearest integer; negative `scale` rounds to a position to the left of
+/// the decimal point (`scale=-1` rounds to the nearest ten, `scale=-2`
+/// to the nearest hundred, etc.).
+///
+/// `mode` defaults to `HalfEven` (banker's rounding). See `RoundingMode`
+/// for the full list of modes and their tie-breaking semantics.
+///
+/// **Aborts** when `scale` is `Int::min_value` (the would-be exponent
+/// `-scale` overflows `Int`).
+///
+/// The result is canonicalized: trailing zeros introduced by rounding
+/// are not preserved by `to_string`. To get a fixed-scale string, format
+/// from the canonical representation.
+///
+/// # Examples
+///
+/// ```mbt nocheck
+/// test {
+///   let dec = @decimal.Decimal::from_string
+///   // HalfEven (banker's rounding) breaks ties toward the even digit.
+///   inspect(dec("2.5").round(scale=0), content="2")
+///   inspect(dec("3.5").round(scale=0), content="4")
+///   inspect(dec("-2.5").round(scale=0), content="-2")
+///   // Negative scales round above the decimal point.
+///   inspect(dec("149").round(scale=-1), content="150")
+///   inspect(dec("145").round(scale=-1), content="140")
+///   // Toward-zero is plain truncation (no ties).
+///   inspect(dec("-2.9").round(scale=0, mode=@decimal.TowardZero), content="-2")
+/// }
+/// ```
 pub fn Decimal::round(
   self : Decimal,
   scale~ : Int,

--- a/decimal/rounding.mbt
+++ b/decimal/rounding.mbt
@@ -71,6 +71,38 @@ fn rounded_ratio(
 }
 
 ///|
+fn rounded_ratio_below_half(
+  numerator : @bigint.BigInt,
+  denominator : @bigint.BigInt,
+  mode : RoundingMode,
+) -> @bigint.BigInt {
+  if numerator.is_zero() {
+    return zero_bigint
+  }
+  let negative = if numerator < zero_bigint {
+    denominator > zero_bigint
+  } else {
+    denominator < zero_bigint
+  }
+  let increment = match mode {
+    TowardZero => false
+    AwayFromZero => true
+    TowardPositiveInfinity => !negative
+    TowardNegativeInfinity => negative
+    HalfTowardZero | HalfAwayFromZero | HalfEven => false
+  }
+  if increment {
+    if negative {
+      -one_bigint
+    } else {
+      one_bigint
+    }
+  } else {
+    zero_bigint
+  }
+}
+
+///|
 /// Rounds to the requested number of digits after the decimal point.
 ///
 /// Negative scales round to positions left of the decimal point. Results remain

--- a/decimal/traits.mbt
+++ b/decimal/traits.mbt
@@ -23,11 +23,73 @@ pub impl Eq for Decimal with equal(self, other) {
 
 ///|
 /// Total ordering by numeric value. Sign, magnitude, and fractional part
-/// are all respected. Compares by aligning to a common exponent and
-/// comparing coefficients.
+/// are all respected.
+///
+/// Two values with the same exponent are compared by coefficient. When
+/// exponents differ, a fast magnitude check decides the order without
+/// scaling whenever the values' decimal magnitudes are clearly apart;
+/// otherwise the smaller-exponent operand's coefficient is multiplied
+/// by `10^(exponent_diff)` and the coefficients are compared directly.
+///
+/// The fast path is what keeps `compare` from aborting on inputs like
+/// `dec("1e2147483647").compare(dec("1e-2147483648"))`: the exponent
+/// difference there overflows `Int` and would blow up if the function
+/// tried to scale before checking magnitudes.
 pub impl Compare for Decimal with compare(self, other) {
-  let (a, b, _) = align_coefficients(self, other)
-  a.compare(b)
+  // Identical canonical → equal.
+  if self.exponent == other.exponent {
+    return self.coefficient.compare(other.coefficient)
+  }
+  // Zero vs zero / zero vs non-zero.
+  let self_zero = self.coefficient.is_zero()
+  let other_zero = other.coefficient.is_zero()
+  if self_zero && other_zero {
+    return 0
+  }
+  if self_zero {
+    return -other.coefficient.compare(zero_bigint)
+  }
+  if other_zero {
+    return self.coefficient.compare(zero_bigint)
+  }
+  // Sign decides when signs differ.
+  let self_sign = if self.coefficient < zero_bigint { -1 } else { 1 }
+  let other_sign = if other.coefficient < zero_bigint { -1 } else { 1 }
+  if self_sign != other_sign {
+    return self_sign
+  }
+  // Both non-zero, same sign. Bracket each value's decimal magnitude
+  // (position of the most-significant digit relative to the decimal
+  // point) using the BigInt bit length. log10(2) ≈ 0.301, so:
+  //   digits_lower(bits) = floor(bits / 4) + 1   (slight underestimate)
+  //   digits_upper(bits) = floor(bits / 3) + 1   (slight overestimate)
+  // magnitude = digits + exponent.  All math in Int64 to dodge the Int
+  // range that triggered the original bug.
+  let self_bits = bigint_abs(self.coefficient).bit_length().to_int64()
+  let other_bits = bigint_abs(other.coefficient).bit_length().to_int64()
+  let self_e = self.exponent.to_int64()
+  let other_e = other.exponent.to_int64()
+  let self_mag_low = self_bits / 4L + 1L + self_e
+  let self_mag_high = self_bits / 3L + 1L + self_e
+  let other_mag_low = other_bits / 4L + 1L + other_e
+  let other_mag_high = other_bits / 3L + 1L + other_e
+  if self_mag_low > other_mag_high {
+    return self_sign
+  }
+  if other_mag_low > self_mag_high {
+    return -self_sign
+  }
+  // Magnitudes overlap: the exponent difference is bounded by the
+  // narrower of the two bit-length brackets, so it fits in Int and
+  // pow10 is feasible.
+  let diff = self_e - other_e
+  if diff > 0L {
+    let scaled = self.coefficient * pow10(diff.to_int())
+    scaled.compare(other.coefficient)
+  } else {
+    let scaled = other.coefficient * pow10((-diff).to_int())
+    self.coefficient.compare(scaled)
+  }
 }
 
 ///|

--- a/decimal/traits.mbt
+++ b/decimal/traits.mbt
@@ -13,28 +13,46 @@
 // limitations under the License.
 
 ///|
+/// Two `Decimal` values are equal iff they have the same canonical
+/// `(coefficient, exponent)`. Because all public constructors
+/// canonicalize, this is also semantic equality: `1.5`, `1.50`, and
+/// `1.500e0` are all `==`.
 pub impl Eq for Decimal with equal(self, other) {
   self.coefficient == other.coefficient && self.exponent == other.exponent
 }
 
 ///|
+/// Total ordering by numeric value. Sign, magnitude, and fractional part
+/// are all respected. Compares by aligning to a common exponent and
+/// comparing coefficients.
 pub impl Compare for Decimal with compare(self, other) {
   let (a, b, _) = align_coefficients(self, other)
   a.compare(b)
 }
 
 ///|
+/// Hash uses the canonical `(coefficient, exponent)`. Equal values hash
+/// equal (canonicalization guarantees a unique representation).
 pub impl Hash for Decimal with hash_combine(self, hasher) {
   hasher.combine(self.coefficient)
   hasher.combine(self.exponent)
 }
 
 ///|
+/// JSON encoding is the canonical decimal string. Encoding as a string
+/// (rather than a JSON number) preserves precision across JSON
+/// implementations that represent numbers as IEEE 754 doubles.
 pub impl ToJson for Decimal with to_json(self : Decimal) -> Json {
   Json::string(self.to_string())
 }
 
 ///|
+/// JSON decoding accepts a string. Numeric JSON is rejected on purpose:
+/// JSON numbers have no defined precision, and silently coercing them
+/// would defeat the point of using `Decimal`.
+///
+/// Raises `JsonDecodeError` if the JSON value is not a string, or if the
+/// string is not a valid decimal literal (per `Decimal::from_string`).
 pub impl @json.FromJson for Decimal with from_json(json, path) {
   guard json is String(s) else {
     raise @json.JsonDecodeError(

--- a/decimal/traits.mbt
+++ b/decimal/traits.mbt
@@ -1,0 +1,50 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub impl Eq for Decimal with equal(self, other) {
+  self.coefficient == other.coefficient && self.exponent == other.exponent
+}
+
+///|
+pub impl Compare for Decimal with compare(self, other) {
+  let (a, b, _) = align_coefficients(self, other)
+  a.compare(b)
+}
+
+///|
+pub impl Hash for Decimal with hash_combine(self, hasher) {
+  hasher.combine(self.coefficient)
+  hasher.combine(self.exponent)
+}
+
+///|
+pub impl ToJson for Decimal with to_json(self : Decimal) -> Json {
+  Json::string(self.to_string())
+}
+
+///|
+pub impl @json.FromJson for Decimal with from_json(json, path) {
+  guard json is String(s) else {
+    raise @json.JsonDecodeError(
+      (path, "Decimal::from_json: expected decimal in string representation"),
+    )
+  }
+  Decimal::from_string(s) catch {
+    _ =>
+      raise @json.JsonDecodeError(
+        (path, "Decimal::from_json: invalid decimal string"),
+      )
+  }
+}

--- a/decimal/types.mbt
+++ b/decimal/types.mbt
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 ///|
-/// Errors raised by `Decimal` parsing, exact conversion, and division.
+/// Errors raised by `Decimal` parsing, exact conversion, division, and
+/// scale-bound operations.
 ///
 /// - `InvalidSyntax(input)` — `Decimal::from_string` could not interpret the
 ///   string. The captured `input` is the original text that failed to parse.
@@ -26,11 +27,18 @@
 /// - `InexactConversion` — `Decimal::to_bigint_exact` was called on a value
 ///   with a fractional part, or with an exponent so far below zero that even
 ///   the divisor cannot be constructed.
+/// - `ExponentOutOfRange` — an operation would produce a canonical exponent
+///   outside the supported range (`Int::min_value..=Int::max_value`).
+///   Triggered by extreme inputs to `div_round` (e.g. `scale=Int::min_value`)
+///   or by `round` with a `scale` whose corresponding exponent does not fit
+///   in `Int`. Internal helpers used by the trait operators still abort on
+///   the same condition because trait method signatures cannot raise.
 pub(all) suberror DecimalError {
   InvalidSyntax(String)
   DivisionByZero
   NonTerminatingDivision
   InexactConversion
+  ExponentOutOfRange
 } derive(Eq, ToJson, @debug.Debug)
 
 ///|
@@ -44,6 +52,7 @@ pub impl Show for DecimalError with output(self, logger) {
     DivisionByZero => logger.write_string("DivisionByZero")
     NonTerminatingDivision => logger.write_string("NonTerminatingDivision")
     InexactConversion => logger.write_string("InexactConversion")
+    ExponentOutOfRange => logger.write_string("ExponentOutOfRange")
   }
 }
 
@@ -158,11 +167,6 @@ fn add_exponents(a : Int, b : Int) -> Int {
 ///|
 fn sub_exponents(a : Int, b : Int) -> Int {
   exponent_from_int64(a.to_int64() - b.to_int64())
-}
-
-///|
-fn scale_to_exponent(scale : Int) -> Int {
-  exponent_from_int64(-scale.to_int64())
 }
 
 ///|

--- a/decimal/types.mbt
+++ b/decimal/types.mbt
@@ -13,7 +13,19 @@
 // limitations under the License.
 
 ///|
-/// Error type for decimal parsing, exact conversion, and division.
+/// Errors raised by `Decimal` parsing, exact conversion, and division.
+///
+/// - `InvalidSyntax(input)` — `Decimal::from_string` could not interpret the
+///   string. The captured `input` is the original text that failed to parse.
+/// - `DivisionByZero` — `Decimal::div_exact` or `Decimal::div_round` was
+///   called with a divisor that is exactly zero.
+/// - `NonTerminatingDivision` — `Decimal::div_exact` produced a result whose
+///   denominator (after simplifying through GCD) has prime factors other than
+///   2 and 5, so it cannot be represented as a finite decimal. Use
+///   `Decimal::div_round` to obtain a rounded result instead.
+/// - `InexactConversion` — `Decimal::to_bigint_exact` was called on a value
+///   with a fractional part, or with an exponent so far below zero that even
+///   the divisor cannot be constructed.
 pub(all) suberror DecimalError {
   InvalidSyntax(String)
   DivisionByZero
@@ -38,8 +50,26 @@ pub impl Show for DecimalError with output(self, logger) {
 ///|
 /// Rounding modes used by `Decimal::round` and `Decimal::div_round`.
 ///
-/// The names are directional to avoid the common ambiguity around "up" and
-/// "down" for negative values.
+/// Modes split into two families:
+///
+/// **Directional modes** — apply when the value is not exactly on a midpoint:
+/// - `TowardZero`              — truncate toward zero (drop fractional part).
+/// - `AwayFromZero`            — round to the value with greater magnitude.
+/// - `TowardNegativeInfinity`  — floor (toward `-∞`).
+/// - `TowardPositiveInfinity`  — ceiling (toward `+∞`).
+///
+/// **Half modes** — only differ from the directional modes when the value lies
+/// exactly halfway between two representable results:
+/// - `HalfTowardZero`          — break ties toward zero. ("round half down".)
+/// - `HalfAwayFromZero`        — break ties away from zero. ("round half up".)
+/// - `HalfEven`                — break ties toward the nearest even digit.
+///                               This is *banker's rounding*, the IEEE 754
+///                               default; minimizes statistical bias.
+///
+/// The directional names are deliberate: "up" and "down" are ambiguous for
+/// negative values, so we name the destination instead.
+///
+/// Default for `Decimal::round` and `Decimal::div_round` is `HalfEven`.
 pub(all) enum RoundingMode {
   TowardZero
   AwayFromZero
@@ -68,9 +98,24 @@ pub impl Show for RoundingMode with output(self, logger) {
 ///|
 /// Arbitrary-precision finite decimal value.
 ///
-/// A value is represented as `coefficient * 10^exponent`. All public
-/// constructors keep the representation canonical by removing trailing decimal
-/// zeros from the coefficient. Zero is always represented as `0 * 10^0`.
+/// Internally a value is `coefficient * 10^exponent`, where `coefficient` is
+/// a `BigInt` and `exponent` is an `Int`. All public constructors keep the
+/// representation **canonical**:
+///
+/// - Zero is always `0 * 10^0`.
+/// - Non-zero values have no trailing decimal zeros — any factor of ten is
+///   moved out of the coefficient and into the exponent.
+///
+/// Canonicalization means `1.5`, `1.50`, and `1.500e0` are all the same
+/// `Decimal` value: they compare equal, hash to the same bucket, and round-
+/// trip through `to_string` as `"1.5"`. If you need a fixed-scale string
+/// representation (e.g. always two fractional digits for currency), use
+/// `to_string` together with `round(scale=...)` and post-process — or pad
+/// at the formatter, since the underlying value is canonical.
+///
+/// `Decimal` is **finite only**: there is no `NaN`, no `±Infinity`, and no
+/// signed zero. Operations that would produce a non-finite result (such as
+/// dividing by zero) raise a `DecimalError` instead.
 struct Decimal {
   coefficient : @bigint.BigInt
   exponent : Int

--- a/decimal/types.mbt
+++ b/decimal/types.mbt
@@ -1,0 +1,197 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Error type for decimal parsing, exact conversion, and division.
+pub(all) suberror DecimalError {
+  InvalidSyntax(String)
+  DivisionByZero
+  NonTerminatingDivision
+  InexactConversion
+} derive(Eq, ToJson, @debug.Debug)
+
+///|
+pub impl Show for DecimalError with output(self, logger) {
+  match self {
+    InvalidSyntax(input) => {
+      logger.write_string("InvalidSyntax(")
+      Show::output(input, logger)
+      logger.write_char(')')
+    }
+    DivisionByZero => logger.write_string("DivisionByZero")
+    NonTerminatingDivision => logger.write_string("NonTerminatingDivision")
+    InexactConversion => logger.write_string("InexactConversion")
+  }
+}
+
+///|
+/// Rounding modes used by `Decimal::round` and `Decimal::div_round`.
+///
+/// The names are directional to avoid the common ambiguity around "up" and
+/// "down" for negative values.
+pub(all) enum RoundingMode {
+  TowardZero
+  AwayFromZero
+  TowardNegativeInfinity
+  TowardPositiveInfinity
+  HalfTowardZero
+  HalfAwayFromZero
+  HalfEven
+} derive(Eq, @debug.Debug)
+
+///|
+pub impl Show for RoundingMode with output(self, logger) {
+  logger.write_string(
+    match self {
+      TowardZero => "TowardZero"
+      AwayFromZero => "AwayFromZero"
+      TowardNegativeInfinity => "TowardNegativeInfinity"
+      TowardPositiveInfinity => "TowardPositiveInfinity"
+      HalfTowardZero => "HalfTowardZero"
+      HalfAwayFromZero => "HalfAwayFromZero"
+      HalfEven => "HalfEven"
+    },
+  )
+}
+
+///|
+/// Arbitrary-precision finite decimal value.
+///
+/// A value is represented as `coefficient * 10^exponent`. All public
+/// constructors keep the representation canonical by removing trailing decimal
+/// zeros from the coefficient. Zero is always represented as `0 * 10^0`.
+struct Decimal {
+  coefficient : @bigint.BigInt
+  exponent : Int
+} derive(@debug.Debug)
+
+///|
+let zero_bigint : @bigint.BigInt = @bigint.BigInt::from_int(0)
+
+///|
+let one_bigint : @bigint.BigInt = @bigint.BigInt::from_int(1)
+
+///|
+let two_bigint : @bigint.BigInt = @bigint.BigInt::from_int(2)
+
+///|
+let five_bigint : @bigint.BigInt = @bigint.BigInt::from_int(5)
+
+///|
+let ten_bigint : @bigint.BigInt = @bigint.BigInt::from_int(10)
+
+///|
+let max_exponent64 = 2147483647L
+
+///|
+let min_exponent64 = -2147483648L
+
+///|
+fn exponent_from_int64(exponent : Int64) -> Int {
+  guard exponent >= min_exponent64 && exponent <= max_exponent64 else {
+    abort("Decimal exponent out of range")
+  }
+  exponent.to_int()
+}
+
+///|
+fn add_exponents(a : Int, b : Int) -> Int {
+  exponent_from_int64(a.to_int64() + b.to_int64())
+}
+
+///|
+fn sub_exponents(a : Int, b : Int) -> Int {
+  exponent_from_int64(a.to_int64() - b.to_int64())
+}
+
+///|
+fn scale_to_exponent(scale : Int) -> Int {
+  exponent_from_int64(-scale.to_int64())
+}
+
+///|
+fn bigint_abs(value : @bigint.BigInt) -> @bigint.BigInt {
+  if value < zero_bigint {
+    -value
+  } else {
+    value
+  }
+}
+
+///|
+fn bigint_gcd(a : @bigint.BigInt, b : @bigint.BigInt) -> @bigint.BigInt {
+  let mut x = bigint_abs(a)
+  let mut y = bigint_abs(b)
+  while !y.is_zero() {
+    let r = x % y
+    x = y
+    y = r
+  }
+  x
+}
+
+///|
+fn pow_bigint(base : @bigint.BigInt, exponent : Int) -> @bigint.BigInt {
+  guard exponent >= 0 else { abort("negative exponent") }
+  base.pow(@bigint.BigInt::from_int(exponent))
+}
+
+///|
+fn pow10(exponent : Int) -> @bigint.BigInt {
+  pow_bigint(ten_bigint, exponent)
+}
+
+///|
+fn make_decimal(coefficient : @bigint.BigInt, exponent : Int) -> Decimal {
+  if coefficient.is_zero() {
+    return { coefficient: zero_bigint, exponent: 0 }
+  }
+  let mut coefficient = coefficient
+  let mut exponent = exponent.to_int64()
+  while coefficient % ten_bigint == zero_bigint {
+    coefficient = coefficient / ten_bigint
+    exponent += 1L
+    guard exponent <= max_exponent64 else {
+      abort("Decimal exponent out of range")
+    }
+  }
+  { coefficient, exponent: exponent.to_int() }
+}
+
+///|
+fn make_decimal_from_string(
+  coefficient : @bigint.BigInt,
+  exponent : Int64,
+  input : StringView,
+) -> Decimal raise DecimalError {
+  guard exponent >= min_exponent64 && exponent <= max_exponent64 else {
+    invalid_syntax(input)
+  }
+  if coefficient.is_zero() {
+    return { coefficient: zero_bigint, exponent: 0 }
+  }
+  let mut coefficient = coefficient
+  let mut exponent = exponent
+  while coefficient % ten_bigint == zero_bigint {
+    coefficient = coefficient / ten_bigint
+    exponent += 1L
+    guard exponent <= max_exponent64 else { invalid_syntax(input) }
+  }
+  { coefficient, exponent: exponent.to_int() }
+}
+
+///|
+fn[T] invalid_syntax(input : StringView) -> T raise DecimalError {
+  raise InvalidSyntax(input.to_owned())
+}


### PR DESCRIPTION
## Summary
- Add a new `moonbitlang/core/decimal` package backed by `@bigint.BigInt`.
- Store decimals canonically as `coefficient * 10^exponent`, including canonical zero and value-consistent `Eq`/`Hash`.
- Add parsing/formatting, arithmetic, explicit rounding, exact/rounded division, exact BigInt conversion, and JSON string encoding/decoding.
- Omit `/` intentionally; division requires exactness or an explicit rounding scale/mode.

## Claude CLI feedback incorporated
- Replaced the original linear private power loop with `BigInt::pow` and made negative powers fail loudly.
- Added checked Int64 exponent arithmetic for scale conversion, arithmetic exponent math, formatting, and division shifts.
- Documented that rounded results remain canonical, so requested scale does not preserve display trailing zeros.
- Simplified JSON decode failures for invalid decimal strings to avoid leaking lossy `Show` output.
- Removed the warning suppression around `suberror` usage.

## Validation
- `moon fmt`
- `moon info`
- `moon check decimal` (passes; existing unrelated warnings only)
- `moon test decimal` (15 passed)
- `moon check --target all` (passes; existing unrelated warnings only)
- `moon test` (6403 passed)