### PR TITLE
Annotate intrinsic RC conventions

### DIFF
--- a/builtin/bytes_unsafe.mbt
+++ b/builtin/bytes_unsafe.mbt
@@ -36,6 +36,7 @@
 /// - `bytes[index+1]` ← bits 8-15
 /// - ...
 /// - `bytes[index+7]` ← bits 56-63 (most significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_write_uint64_le")
 pub fn FixedArray::unsafe_write_uint64_le(
   bytes : FixedArray[Byte],
@@ -69,6 +70,7 @@ pub fn FixedArray::unsafe_write_uint64_le(
 /// - `bytes[index+1]` ← bits 48-55
 /// - ...
 /// - `bytes[index+7]` ← bits 0-7 (least significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_write_uint64_be")
 pub fn FixedArray::unsafe_write_uint64_be(
   bytes : FixedArray[Byte],
@@ -102,6 +104,7 @@ pub fn FixedArray::unsafe_write_uint64_be(
 /// - `bytes[index+1]` ← bits 8-15
 /// - `bytes[index+2]` ← bits 16-23
 /// - `bytes[index+3]` ← bits 24-31 (most significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_write_uint32_le")
 pub fn FixedArray::unsafe_write_uint32_le(
   bytes : FixedArray[Byte],
@@ -135,6 +138,7 @@ pub fn FixedArray::unsafe_write_uint32_le(
 /// - `bytes[index+1]` ← bits 16-23
 /// - `bytes[index+2]` ← bits 8-15
 /// - `bytes[index+3]` ← bits 0-7 (least significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_write_uint32_be")
 pub fn FixedArray::unsafe_write_uint32_be(
   bytes : FixedArray[Byte],
@@ -166,6 +170,7 @@ pub fn FixedArray::unsafe_write_uint32_be(
 /// Writes 2 bytes starting at `index` in little-endian order:
 /// - `bytes[index]` ← bits 0-7 (least significant)
 /// - `bytes[index+1]` ← bits 8-15 (most significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_write_uint16_le")
 pub fn FixedArray::unsafe_write_uint16_le(
   bytes : FixedArray[Byte],
@@ -197,6 +202,7 @@ pub fn FixedArray::unsafe_write_uint16_le(
 /// Writes 2 bytes starting at `index` in big-endian order:
 /// - `bytes[index]` ← bits 8-15 (most significant)
 /// - `bytes[index+1]` ← bits 0-7 (least significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_write_uint16_be")
 pub fn FixedArray::unsafe_write_uint16_be(
   bytes : FixedArray[Byte],
@@ -232,6 +238,7 @@ pub fn FixedArray::unsafe_write_uint16_be(
 /// - `bytes[index+1]` → bits 8-15
 /// - ...
 /// - `bytes[index+7]` → bits 56-63 (most significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint64_le")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint64_le(bytes : Bytes, index : Int) -> UInt64 {
@@ -263,6 +270,7 @@ pub fn Bytes::unsafe_read_uint64_le(bytes : Bytes, index : Int) -> UInt64 {
 /// - `bytes[index+1]` → bits 48-55
 /// - ...
 /// - `bytes[index+7]` → bits 0-7 (least significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint64_be")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint64_be(bytes : Bytes, index : Int) -> UInt64 {
@@ -294,6 +302,7 @@ pub fn Bytes::unsafe_read_uint64_be(bytes : Bytes, index : Int) -> UInt64 {
 /// - `bytes[index+1]` → bits 8-15
 /// - `bytes[index+2]` → bits 16-23
 /// - `bytes[index+3]` → bits 24-31 (most significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint32_le")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint32_le(bytes : Bytes, index : Int) -> UInt {
@@ -325,6 +334,7 @@ pub fn Bytes::unsafe_read_uint32_le(bytes : Bytes, index : Int) -> UInt {
 /// - `bytes[index+1]` → bits 16-23
 /// - `bytes[index+2]` → bits 8-15
 /// - `bytes[index+3]` → bits 0-7 (least significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint32_be")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint32_be(bytes : Bytes, index : Int) -> UInt {
@@ -354,6 +364,7 @@ pub fn Bytes::unsafe_read_uint32_be(bytes : Bytes, index : Int) -> UInt {
 /// Reads 2 bytes starting at `index` and interprets them as a UInt16 in little-endian order:
 /// - `bytes[index]` → bits 0-7 (least significant)
 /// - `bytes[index+1]` → bits 8-15 (most significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint16_le")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint16_le(bytes : Bytes, index : Int) -> UInt16 {
@@ -383,6 +394,7 @@ pub fn Bytes::unsafe_read_uint16_le(bytes : Bytes, index : Int) -> UInt16 {
 /// Reads 2 bytes starting at `index` and interprets them as a UInt16 in big-endian order:
 /// - `bytes[index]` → bits 8-15 (most significant)
 /// - `bytes[index+1]` → bits 0-7 (least significant)
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint16_be")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint16_be(bytes : Bytes, index : Int) -> UInt16 {
@@ -545,6 +557,7 @@ pub fn BytesView::unsafe_read_uint16_be(
 fn buffer_to_fixedarray(buf : UninitializedArray[Byte]) -> FixedArray[Byte] = "%identity"
 
 ///|
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint16_le")
 fn fixedarray_read_uint16_le(bytes : FixedArray[Byte], index : Int) -> UInt16 {
   for i in 0..<=1; result = (0 : UInt16) {
@@ -555,6 +568,7 @@ fn fixedarray_read_uint16_le(bytes : FixedArray[Byte], index : Int) -> UInt16 {
 }
 
 ///|
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint16_be")
 fn fixedarray_read_uint16_be(bytes : FixedArray[Byte], index : Int) -> UInt16 {
   for i in 0..<=1; result = (0 : UInt16) {
@@ -565,6 +579,7 @@ fn fixedarray_read_uint16_be(bytes : FixedArray[Byte], index : Int) -> UInt16 {
 }
 
 ///|
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint32_le")
 fn fixedarray_read_uint32_le(bytes : FixedArray[Byte], index : Int) -> UInt {
   for i in 0..<=3; result = (0 : UInt) {
@@ -575,6 +590,7 @@ fn fixedarray_read_uint32_le(bytes : FixedArray[Byte], index : Int) -> UInt {
 }
 
 ///|
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint32_be")
 fn fixedarray_read_uint32_be(bytes : FixedArray[Byte], index : Int) -> UInt {
   for i in 0..<=3; result = (0 : UInt) {
@@ -585,6 +601,7 @@ fn fixedarray_read_uint32_be(bytes : FixedArray[Byte], index : Int) -> UInt {
 }
 
 ///|
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint64_le")
 fn fixedarray_read_uint64_le(bytes : FixedArray[Byte], index : Int) -> UInt64 {
   for i in 0..<=7; result = (0 : UInt64) {
@@ -595,6 +612,7 @@ fn fixedarray_read_uint64_le(bytes : FixedArray[Byte], index : Int) -> UInt64 {
 }
 
 ///|
+#borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint64_be")
 fn fixedarray_read_uint64_be(bytes : FixedArray[Byte], index : Int) -> UInt64 {
   for i in 0..<=7; result = (0 : UInt64) {

--- a/builtin/fixedarray_block.mbt
+++ b/builtin/fixedarray_block.mbt
@@ -35,6 +35,7 @@
 /// - `dst_offset + len > dst.length()`
 /// - `src_offset + len > src.length()`
 ///
+#owned(dst, src)
 #intrinsic("%fixedarray.copy")
 #coverage.skip
 pub fn[A] FixedArray::unsafe_blit(
@@ -58,6 +59,7 @@ pub fn[A] FixedArray::unsafe_blit(
 ///|
 /// This is the same as `unsafe_blit`, but it is used when the source array is
 /// FixedArray[T] instead of UninitializedArray[T].
+#owned(dst, src)
 #intrinsic("%fixedarray.copy")
 #coverage.skip
 fn[T] UninitializedArray::unsafe_blit_fixed(


### PR DESCRIPTION
## Summary

Annotate native intrinsic wrappers with explicit RC conventions where the convention is implemented and meaningful.

| Category | Intrinsics | Status |
|---|---|---|
| Batch read/write bytes | `%bytes.unsafe_read_uint{16,32,64}_{le,be}`, `%bytes.unsafe_write_uint{16,32,64}_{le,be}` | `#borrow(bytes)` |
| `fixedarray_copy` | `%fixedarray.copy` | `#owned(dst, src)` |
| Array/fixedarray length/get/set | array length/get/set and arrayview get/set intrinsics | Always inlined, so RC convention does not matter |
| Not implemented for native backend yet | `%fixedarray.fill`, `%string.substring` | Skipped for now |
| Not applicable / no reference parameter | `%char.to_string`, `%regex.seq`, `%regex.alt` | No annotation needed for this native RC convention work |

## Tests

- `moon check`
- `moon fmt`
- `moon test` (6388 passed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
