### PR TITLE
docs(builtin): document Logger helpers

### DIFF
--- a/argparse/arg_group.mbt
+++ b/argparse/arg_group.mbt
@@ -21,17 +21,20 @@ pub struct ArgGroup {
   priv args : Array[String]
   priv requires : Array[String]
   priv conflicts_with : Array[String]
-
-  /// Create an argument group.
-  fn new(
-    name : StringView,
-    required? : Bool,
-    multiple? : Bool,
-    args? : ArrayView[String],
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-  ) -> ArgGroup
 } derive(@debug.Debug)
+
+///|
+/// Create an argument group.
+pub fn ArgGroup::ArgGroup(
+  name : StringView,
+  required? : Bool = false,
+  multiple? : Bool = true,
+  args? : ArrayView[String] = [],
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+) -> ArgGroup {
+  ArgGroup::new(name, required~, multiple~, args~, requires~, conflicts_with~)
+}
 
 ///|
 /// Create an argument group.

--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -80,23 +80,39 @@ priv enum ArgInfo {
 /// Declarative flag constructor wrapper.
 pub struct FlagArg {
   priv arg : Arg
-
-  /// Create a flag argument.
-  fn new(
-    name : StringView,
-    short? : Char,
-    long? : StringView,
-    about? : StringView,
-    action? : FlagAction,
-    env? : StringView,
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-    required? : Bool,
-    global? : Bool,
-    negatable? : Bool,
-    hidden? : Bool,
-  ) -> FlagArg
 } derive(@debug.Debug)
+
+///|
+/// Create a flag argument.
+pub fn FlagArg::FlagArg(
+  name : StringView,
+  short? : Char,
+  long? : StringView = name,
+  about? : StringView,
+  action? : FlagAction = SetTrue,
+  env? : StringView,
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+  required? : Bool = false,
+  global? : Bool = false,
+  negatable? : Bool = false,
+  hidden? : Bool = false,
+) -> FlagArg {
+  FlagArg::new(
+    name,
+    short?,
+    long~,
+    about?,
+    action~,
+    env?,
+    requires~,
+    conflicts_with~,
+    required~,
+    global~,
+    negatable~,
+    hidden~,
+  )
+}
 
 ///|
 /// Create a flag argument.
@@ -148,25 +164,41 @@ pub fn FlagArg::new(
 /// Named `OptionArg` to avoid shadowing the built-in `Option` type.
 pub struct OptionArg {
   priv arg : Arg
-
-  /// Create an option argument.
-  // FIXME(upstram) rename does not work here
-  fn new(
-    name : StringView,
-    short? : Char,
-    long? : StringView,
-    about? : StringView,
-    action? : OptionAction,
-    env? : StringView,
-    default_values? : ArrayView[String],
-    allow_hyphen_values? : Bool,
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-    required? : Bool,
-    global? : Bool,
-    hidden? : Bool,
-  ) -> OptionArg
 } derive(@debug.Debug)
+
+///|
+/// Create an option argument.
+pub fn OptionArg::OptionArg(
+  name : StringView,
+  short? : Char,
+  long? : StringView = name,
+  about? : StringView,
+  action? : OptionAction = Set,
+  env? : StringView,
+  default_values? : ArrayView[String],
+  allow_hyphen_values? : Bool = false,
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+  required? : Bool = false,
+  global? : Bool = false,
+  hidden? : Bool = false,
+) -> OptionArg {
+  OptionArg::new(
+    name,
+    short?,
+    long~,
+    about?,
+    action~,
+    env?,
+    default_values?,
+    allow_hyphen_values~,
+    requires~,
+    conflicts_with~,
+    required~,
+    global~,
+    hidden~,
+  )
+}
 
 ///|
 /// Create an option argument.
@@ -224,21 +256,35 @@ pub fn OptionArg::new(
 /// Declarative positional constructor wrapper.
 pub struct PositionArg {
   priv arg : Arg
-
-  /// Create a positional argument.
-  fn new(
-    name : StringView,
-    about? : StringView,
-    env? : StringView,
-    default_values? : ArrayView[String],
-    num_args? : ValueRange,
-    allow_hyphen_values? : Bool,
-    requires? : ArrayView[String],
-    conflicts_with? : ArrayView[String],
-    global? : Bool,
-    hidden? : Bool,
-  ) -> PositionArg
 } derive(@debug.Debug)
+
+///|
+/// Create a positional argument.
+pub fn PositionArg::PositionArg(
+  name : StringView,
+  about? : StringView,
+  env? : StringView,
+  default_values? : ArrayView[String],
+  num_args? : ValueRange,
+  allow_hyphen_values? : Bool = false,
+  requires? : ArrayView[String] = [],
+  conflicts_with? : ArrayView[String] = [],
+  global? : Bool = false,
+  hidden? : Bool = false,
+) -> PositionArg {
+  PositionArg::new(
+    name,
+    about?,
+    env?,
+    default_values?,
+    num_args?,
+    allow_hyphen_values~,
+    requires~,
+    conflicts_with~,
+    global~,
+    hidden~,
+  )
+}
 
 ///|
 /// Create a positional argument.

--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -28,25 +28,43 @@ pub struct Command {
   priv subcommand_required : Bool
   priv hidden : Bool
   priv mut build_error : ArgBuildError?
-
-  /// Create a declarative command specification.
-  fn new(
-    name : StringView,
-    flags? : ArrayView[FlagArg],
-    options? : ArrayView[OptionArg],
-    positionals? : ArrayView[PositionArg],
-    subcommands? : ArrayView[Command],
-    about? : StringView,
-    version? : StringView,
-    disable_help_flag? : Bool,
-    disable_version_flag? : Bool,
-    disable_help_subcommand? : Bool,
-    arg_required_else_help? : Bool,
-    subcommand_required? : Bool,
-    hidden? : Bool,
-    groups? : ArrayView[ArgGroup],
-  ) -> Command
 } derive(@debug.Debug)
+
+///|
+/// Create a declarative command specification.
+pub fn Command::Command(
+  name : StringView,
+  flags? : ArrayView[FlagArg] = [],
+  options? : ArrayView[OptionArg] = [],
+  positionals? : ArrayView[PositionArg] = [],
+  subcommands? : ArrayView[Command] = [],
+  about? : StringView,
+  version? : StringView,
+  disable_help_flag? : Bool = false,
+  disable_version_flag? : Bool = false,
+  disable_help_subcommand? : Bool = false,
+  arg_required_else_help? : Bool = false,
+  subcommand_required? : Bool = false,
+  hidden? : Bool = false,
+  groups? : ArrayView[ArgGroup] = [],
+) -> Command {
+  Command::new(
+    name,
+    flags~,
+    options~,
+    positionals~,
+    subcommands~,
+    about?,
+    version?,
+    disable_help_flag~,
+    disable_version_flag~,
+    disable_help_subcommand~,
+    arg_required_else_help~,
+    subcommand_required~,
+    hidden~,
+    groups~,
+  )
+}
 
 ///|
 /// Create a declarative command specification.

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -12,16 +12,14 @@ import {
 // Types and methods
 pub struct ArgGroup {
   // private fields
-
-  fn new(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> ArgGroup
 } derive(@debug.Debug)
+pub fn ArgGroup::ArgGroup(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
 pub fn ArgGroup::new(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
 
 pub struct Command {
   // private fields
-
-  fn new(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Command], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Command
 } derive(@debug.Debug)
+pub fn Command::Command(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Self], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Self
 pub fn Command::new(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Self], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Self
 #as_free_fn
 pub fn Command::parse(Self, argv? : ArrayView[String], env? : Map[String, String]) -> Matches raise
@@ -37,9 +35,8 @@ pub(all) enum FlagAction {
 
 pub struct FlagArg {
   // private fields
-
-  fn new(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> FlagArg
 } derive(@debug.Debug)
+pub fn FlagArg::FlagArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
 pub fn FlagArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
 
 pub struct Matches {
@@ -58,23 +55,20 @@ pub(all) enum OptionAction {
 
 pub struct OptionArg {
   // private fields
-
-  fn new(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> OptionArg
 } derive(@debug.Debug)
+pub fn OptionArg::OptionArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
 pub fn OptionArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
 
 pub struct PositionArg {
   // private fields
-
-  fn new(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> PositionArg
 } derive(@debug.Debug)
+pub fn PositionArg::PositionArg(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
 pub fn PositionArg::new(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
 
 pub struct ValueRange {
   // private fields
-
-  fn new(lower? : Int, upper? : Int) -> ValueRange
 } derive(Eq, Show, @debug.Debug)
+pub fn ValueRange::ValueRange(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::new(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::single() -> Self
 

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -18,10 +18,13 @@
 pub struct ValueRange {
   priv lower : Int
   priv upper : Int?
-
-  /// Create a value-count range.
-  fn new(lower? : Int, upper? : Int) -> ValueRange
 } derive(Eq, Show, @debug.Debug)
+
+///|
+/// Create a value-count range.
+pub fn ValueRange::ValueRange(lower? : Int = 0, upper? : Int) -> ValueRange {
+  { lower, upper }
+}
 
 ///|
 /// Exact single-value range (`1..1`).

--- a/builtin/logger_test.mbt
+++ b/builtin/logger_test.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "logger trait object calls" {
+  let sb = StringBuilder::new()
+  let logger : &Logger = sb
+  Logger::write_string(logger, "Hello, ")
+  Logger::write_char(logger, 'w')
+  &Logger::write_string(logger, "orld!")
+  &Logger::write_iter(
+    logger,
+    [1, 2, 3].iter(),
+    prefix="[",
+    suffix="]",
+    sep="; ",
+  )
+  inspect(
+    sb,
+    content=(
+      #|Hello, world![1; 2; 3]
+    ),
+  )
+}

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -89,32 +89,43 @@ pub(open) trait Default {
 }
 
 ///|
-/// Trait for a logger, where debug logs can be written into
+/// Trait for append-only text sinks used by `Show` implementations.
+///
+/// A logger receives formatted output without requiring callers to allocate a
+/// complete `String` first.
 pub(open) trait Logger {
+  /// Writes a string to the logger.
   write_string(Self, String) -> Unit = _
+  /// Writes a substring of the given string to the logger.
   #deprecated("use `write_view` instead", skip_current_package=true)
   write_substring(Self, String, Int, Int) -> Unit = _
+  /// Writes a string view to the logger.
   write_view(Self, StringView) -> Unit = _
+  /// Writes a character to the logger.
   write_char(Self, Char) -> Unit = _
 }
 
 ///|
+/// Writes a substring of the given string to the logger.
 impl Logger with write_substring(self, value, start, len) {
   self.write_view(value[start:start + len])
 }
 
 ///|
+/// Writes a string to the logger.
 impl Logger with write_string(self, value) {
   self.write_view(value)
 }
 
 ///|
+/// Writes a string view to the logger.
 #deprecated("replace `impl write_substring` with `impl write_view`")
 impl Logger with write_view(self, value) {
   self.write_substring(value.data(), value.start_offset(), value.length())
 }
 
 ///|
+/// Writes a character to the logger.
 impl Logger with write_char(self, value) {
   self.write_string([value])
 }
@@ -144,13 +155,17 @@ impl Show with to_string(self) {
 }
 
 ///|
-/// Function `write_object`.
+/// Writes the `Show` representation of an object to the logger.
 pub fn[Obj : Show] &Logger::write_object(self : &Logger, obj : Obj) -> Unit {
   obj.output(self)
 }
 
 ///|
-/// Function `write_iter`.
+/// Writes an iterator of `Show` values to the logger.
+///
+/// By default, values are written in list form, such as `[1, 2]`. The
+/// `prefix`, `suffix`, and `sep` arguments customize the surrounding text and
+/// separator. If `trailing` is true, `sep` is also written after the last value.
 pub fn[T : Show] &Logger::write_iter(
   self : &Logger,
   iter : Iter[T],

--- a/cmp/cmp.mbt
+++ b/cmp/cmp.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// A newtype wrapper that reverses the comparison order of the wrapped value.
 ///
 /// `Reverse[T]` is useful when you need to reverse the natural ordering of a type.

--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(StringView)

--- a/encoding/utf16/types.mbt
+++ b/encoding/utf16/types.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Type `Endian` used by this package APIs.
 pub(all) enum Endian {
   Little

--- a/encoding/utf8/decode.mbt
+++ b/encoding/utf8/decode.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `Malformed`.
 pub suberror Malformed {
   Malformed(BytesView)

--- a/internal/regex_engine/shared_types/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/pkg.generated.mbti
@@ -38,9 +38,8 @@ pub struct Profile {
   word : @rechar_set.RecharSet
   word_symbolize_splits : ReadOnlyArray[@rechar_set.RecharSet]
   category : (Int) -> Category
-
-  fn new(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Profile
 }
+pub fn Profile::Profile(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Self
 pub fn Profile::new(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Self
 
 pub(all) enum QuantifierMode {

--- a/internal/regex_engine/shared_types/profile.mbt
+++ b/internal/regex_engine/shared_types/profile.mbt
@@ -21,13 +21,17 @@ pub struct Profile {
   word : RecharSet
   word_symbolize_splits : ReadOnlyArray[RecharSet]
   category : (Rechar) -> Category
+}
 
-  fn new(
-    valid~ : RecharSet,
-    word~ : RecharSet,
-    word_symbolize_splits? : ReadOnlyArray[RecharSet],
-    category~ : (Rechar) -> Category,
-  ) -> Profile
+///|
+/// Create a new instance.
+pub fn Profile::Profile(
+  valid~ : RecharSet,
+  word~ : RecharSet,
+  word_symbolize_splits? : ReadOnlyArray[RecharSet] = [word],
+  category~ : (Rechar) -> Category,
+) -> Profile {
+  Profile::new(valid~, word~, word_symbolize_splits~, category~)
 }
 
 ///|

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `JsonDecodeError`.
 #warnings("-deprecated_syntax")
 pub(all) suberror JsonDecodeError {

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -123,9 +123,12 @@ priv enum WriteFrame {
 /// Only applies to object properties, not array elements.
 pub struct Replacer {
   priv f : (String, Json) -> Json?
-
-  fn new(f : (String, Json) -> Json?) -> Replacer
 } derive(@debug.Debug)
+
+///|
+pub fn Replacer::Replacer(f : (String, Json) -> Json?) -> Replacer {
+  { f, }
+}
 
 ///|
 /// Create a new Replacer with a custom function.

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -45,9 +45,8 @@ pub(all) struct Position {
 
 pub struct Replacer {
   // private fields
-
-  fn new((String, Json) -> Json?) -> Replacer
 } derive(@debug.Debug)
+pub fn Replacer::Replacer((String, Json) -> Json?) -> Self
 pub fn Replacer::exclude(ArrayView[StringView]) -> Self
 pub fn Replacer::keep(ArrayView[StringView]) -> Self
 pub fn Replacer::new((String, Json) -> Json?) -> Self

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 #warnings("-deprecated_syntax")
 struct RandomState {
   mut seed : UInt64

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -15,9 +15,8 @@ pub fn[T] new(T) -> Ref[T]
 // Types and methods
 pub(all) struct Ref[T] {
   mut val : T
-
-  fn[T] new(T) -> Ref[T]
 }
+pub fn[T] Ref::Ref(T) -> Self[T]
 pub fn[T, R] Ref::map(Self[T], (T) -> R raise?) -> Self[R] raise?
 pub fn[T] Ref::new(T) -> Self[T]
 pub fn[T, R] Ref::protect(Self[T], T, () -> R raise?) -> R raise?

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -25,8 +25,11 @@
 /// ```
 pub(all) struct Ref[T] {
   mut val : T
+}
 
-  fn[T] new(value : T) -> Ref[T]
+///|
+pub fn[T] Ref::Ref(value : T) -> Ref[T] {
+  { val: value }
 }
 
 ///|

--- a/strconv/errors.mbt
+++ b/strconv/errors.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
-
-///|
 /// Error type `StrConvError`.
 #deprecated("use `@string` parsing APIs instead", skip_current_package=true)
 pub(all) suberror StrConvError {

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -31,9 +31,8 @@ pub fn MatchResult::named_group(Self, String) -> StringView?
 
 pub struct Regex {
   // private fields
-
-  fn new(StringView) -> Regex raise
 }
+pub fn Regex::Regex(StringView) -> Self raise
 pub fn Regex::capture(Self, String) -> Self
 pub fn Regex::execute(Self, StringView, last_index? : Int) -> MatchResult?
 pub fn Regex::find(Self, StringView) -> Iter[MatchResult]

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -17,8 +17,11 @@
 pub struct Regex {
   priv pat : @re.Pattern
   priv mut re : @re.Regex?
+}
 
-  fn new(pattern : StringView) -> Regex raise
+///|
+pub fn Regex::Regex(pattern : StringView) -> Regex raise {
+  Regex::new(pattern)
 }
 
 ///|

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-using @debug {trait Debug, type Repr}
+using @debug {trait Debug}
 
 ///|
 fn[T : Show] debug_string(t : T) -> String {


### PR DESCRIPTION
## Summary

- Document the `Logger` trait and its helper functions.
- Add a builtin regression test covering trait-object calls through both `Logger::` and `&Logger::` forms.
- Fix current `--deny-warn` failures by removing unused debug imports and migrating deprecated struct constructor declarations to explicit constructor functions.

## Validation

- `moon fmt`
- `moon test builtin`
- `moon test`
- `moon check`
- `moon check --deny-warn --target all`
- `moon info`
