### PR TITLE
refactor(ref): deprecate Ref::new constructor

### DIFF
--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -707,7 +707,7 @@ test "Show for Result" {
 ///|
 test "Show for Ref" {
   inspect(
-    Ref::new("abc").to_string(),
+    Ref("abc").to_string(),
     content=(
       #|{val: "abc"}
     ),

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -16,9 +16,9 @@ pub fn[T] new(T) -> Ref[T]
 pub(all) struct Ref[T] {
   mut val : T
 }
+#alias(new, deprecated)
 pub fn[T] Ref::Ref(T) -> Self[T]
 pub fn[T, R] Ref::map(Self[T], (T) -> R raise?) -> Self[R] raise?
-pub fn[T] Ref::new(T) -> Self[T]
 pub fn[T, R] Ref::protect(Self[T], T, () -> R raise?) -> R raise?
 #as_free_fn
 pub fn[T] Ref::swap(Self[T], Self[T]) -> Unit

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -28,11 +28,6 @@ pub(all) struct Ref[T] {
 }
 
 ///|
-pub fn[T] Ref::Ref(value : T) -> Ref[T] {
-  { val: value }
-}
-
-///|
 pub impl[X : Show] Show for Ref[X] with output(self, logger) {
   logger.write_string("{val: ")
   logger.write_object(self.val)
@@ -41,7 +36,8 @@ pub impl[X : Show] Show for Ref[X] with output(self, logger) {
 
 ///|
 /// create a reference from value
-pub fn[T] Ref::new(x : T) -> Ref[T] {
+#alias(new, deprecated)
+pub fn[T] Ref::Ref(x : T) -> Ref[T] {
   { val: x }
 }
 
@@ -51,7 +47,7 @@ test "to_string" {
 }
 
 ///|
-/// same as `Ref::new`
+/// Same as the `Ref` constructor.
 pub fn[T] new(x : T) -> Ref[T] {
   { val: x }
 }


### PR DESCRIPTION
## Summary

- Move the typed ref constructor to `Ref::Ref` and keep `Ref::new` as a deprecated alias.
- Preserve the free `@ref.new` helper and refresh its docs.
- Update the builtin Show test to use constructor syntax and regenerate `ref/pkg.generated.mbti`.

## Review

No blocking findings from the local review pass.

## Validation

- `moon fmt`
- `moon test ref`
- `moon test builtin --filter 'Show for Ref'`
- `moon test`
- `moon check --deny-warn --target all`
- `moon info`
