### PR TITLE
feat(collection): add set and map constructors

### DIFF
--- a/builtin/LinkedHashMap.mbt.md
+++ b/builtin/LinkedHashMap.mbt.md
@@ -8,13 +8,14 @@ A mutable linked hash map based on a Robin Hood hash table, links all entry node
 
 ### Create
 
-You can create an empty map using `new()` or construct it using `from_array()`.
+You can create an empty map using `new()` or construct it from entries using `Map([...])`.
 
 ```mbt check 
 ///|
 test {
   let _map1 : Map[String, Int] = {}
   let _map2 = { "one": 1, "two": 2, "three": 3, "four": 4, "five": 5 }
+  let _map3 = Map([("one", 1), ("two", 2), ("three", 3)])
 }
 ```
 

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -68,8 +68,9 @@ pub fn[K, V] Map::new(capacity? : Int = 8) -> Map[K, V] {
 }
 
 ///|
-/// Create a hash map from array.
-pub fn[K : Hash + Eq, V] Map::from_array(arr : ArrayView[(K, V)]) -> Map[K, V] {
+/// Create a hash map from an array.
+#alias(from_array)
+pub fn[K : Hash + Eq, V] Map::Map(arr : ArrayView[(K, V)]) -> Map[K, V] {
   let length = arr.length()
   let mut capacity = length.next_power_of_two()
   if length > calc_grow_threshold(capacity) {

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -65,6 +65,16 @@ test "Map::of" {
 }
 
 ///|
+test "Map constructor" {
+  let map = Map([("a", 1), ("b", 2), ("c", 3)])
+  inspect(map, content="{\"a\": 1, \"b\": 2, \"c\": 3}")
+  inspect(map.length(), content="3")
+  debug_inspect(map.get("a"), content="Some(1)")
+  debug_inspect(map.get("b"), content="Some(2)")
+  debug_inspect(map.get("c"), content="Some(3)")
+}
+
+///|
 test "Map::from_iter" {
   let iter = [("a", 1), ("b", 2), ("c", 3)].iter()
   let map = Map::from_iter(iter)

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -356,7 +356,11 @@ pub fn Json::string(String) -> Self
 pub impl Default for Json
 pub impl Eq for Json
 
-type Map[K, V]
+pub struct Map[K, V] {
+  // private fields
+}
+#alias(from_array)
+pub fn[K : Hash + Eq, V] Map::Map(ArrayView[(K, V)]) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] Map::at(Self[K, V], K) -> V
 pub fn[K, V] Map::capacity(Self[K, V]) -> Int
@@ -367,7 +371,6 @@ pub fn[K : Hash + Eq, V : Eq] Map::contains_kv(Self[K, V], K, V) -> Bool
 pub fn[K, V] Map::copy(Self[K, V]) -> Self[K, V]
 pub fn[K, V] Map::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] Map::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
-pub fn[K : Hash + Eq, V] Map::from_array(ArrayView[(K, V)]) -> Self[K, V]
 #alias(from_iterator, deprecated)
 pub fn[K : Hash + Eq, V] Map::from_iter(Iter[(K, V)]) -> Self[K, V]
 pub fn[K : Hash + Eq, V] Map::get(Self[K, V], K) -> V?

--- a/prelude/README.mbt.md
+++ b/prelude/README.mbt.md
@@ -20,6 +20,15 @@ Core types available in every MoonBit program:
 - `Failure`, `InspectError`, `SnapshotError` — error types
 - `SourceLoc`, `ArgsLoc` — source location info
 
+```mbt check
+///|
+test "Set constructor from prelude" {
+  let set = Set([1, 2, 3, 4])
+  inspect(set.length(), content="4")
+  inspect(set.contains(3), content="true")
+}
+```
+
 ## Re-exported Traits
 
 - `Eq`, `Compare`, `Hash` — equality, ordering, hashing

--- a/set/README.mbt.md
+++ b/set/README.mbt.md
@@ -19,11 +19,11 @@ test "creating sets" {
   inspect(set_with_capacity.capacity(), content="16")
 
   // From array
-  let from_array = @set.Set::from_array([1, 2, 3, 2, 1]) // Duplicates are removed
+  let from_array = @set.Set([1, 2, 3, 2, 1]) // Duplicates are removed
   inspect(from_array.length(), content="3")
 
   // From fixed array
-  let from_fixed = @set.Set::from_array([10, 20, 30])
+  let from_fixed = @set.Set([10, 20, 30])
   inspect(from_fixed.length(), content="3")
 
   // From iterator
@@ -79,8 +79,8 @@ Perform mathematical set operations:
 ```mbt check
 ///|
 test "set operations" {
-  let set1 = @set.Set::from_array([1, 2, 3, 4])
-  let set2 = @set.Set::from_array([3, 4, 5, 6])
+  let set1 = @set.Set([1, 2, 3, 4])
+  let set2 = @set.Set([3, 4, 5, 6])
 
   // Union (all elements from both sets)
   let union_set = set1.union(set2)
@@ -127,9 +127,9 @@ Test relationships between sets:
 ```mbt check
 ///|
 test "set relationships" {
-  let small_set = @set.Set::from_array([1, 2])
-  let large_set = @set.Set::from_array([1, 2, 3, 4])
-  let disjoint_set = @set.Set::from_array([5, 6, 7])
+  let small_set = @set.Set([1, 2])
+  let large_set = @set.Set([1, 2, 3, 4])
+  let disjoint_set = @set.Set([5, 6, 7])
 
   // Subset testing
   inspect(small_set.is_subset(large_set), content="true")
@@ -144,8 +144,8 @@ test "set relationships" {
   inspect(small_set.is_disjoint(large_set), content="false")
 
   // Equal sets
-  let set1 = @set.Set::from_array([1, 2, 3])
-  let set2 = @set.Set::from_array([3, 2, 1]) // Order doesn't matter
+  let set1 = @set.Set([1, 2, 3])
+  let set2 = @set.Set([3, 2, 1]) // Order doesn't matter
   inspect(set1 == set2, content="true")
 }
 ```
@@ -157,7 +157,7 @@ Iterate over sets and convert to other types:
 ```mbt check
 ///|
 test "iteration and conversion" {
-  let set = @set.Set::from_array(["first", "second", "third"])
+  let set = @set.Set(["first", "second", "third"])
 
   // Convert to array (maintains insertion order)
   let array = set.to_array()
@@ -191,7 +191,7 @@ Clear and modify existing sets:
 ```mbt check
 ///|
 test "modifying sets" {
-  let set = @set.Set::from_array([10, 20, 30, 40, 50])
+  let set = @set.Set([10, 20, 30, 40, 50])
   inspect(set.length(), content="5")
 
   // Clear all elements
@@ -214,14 +214,14 @@ Sets can be serialized to JSON as arrays:
 ```mbt check
 ///|
 test "json serialization" {
-  let set = @set.Set::from_array([1, 2, 3])
+  let set = @set.Set([1, 2, 3])
   let json = set.to_json()
 
   // JSON representation is an array
   inspect(json, content="Array([Number(1), Number(2), Number(3)])")
 
   // String set
-  let string_set = @set.Set::from_array(["a", "b", "c"])
+  let string_set = @set.Set(["a", "b", "c"])
   let string_json = string_set.to_json()
   inspect(
     string_json,
@@ -238,20 +238,20 @@ Sets work with any type that implements `Hash` and `Eq`:
 ///|
 test "different types" {
   // Integer set
-  let int_set = @set.Set::from_array([1, 2, 3, 4, 5])
+  let int_set = @set.Set([1, 2, 3, 4, 5])
   inspect(int_set.contains(3), content="true")
 
   // String set
-  let string_set = @set.Set::from_array(["hello", "world", "moonbit"])
+  let string_set = @set.Set(["hello", "world", "moonbit"])
   inspect(string_set.contains("world"), content="true")
 
   // Note: Char and Bool types don't implement Hash in this version
   // So we use Int codes for demonstration
-  let char_codes = @set.Set::from_array([97, 98, 99]) // ASCII codes for 'a', 'b', 'c'
+  let char_codes = @set.Set([97, 98, 99]) // ASCII codes for 'a', 'b', 'c'
   inspect(char_codes.contains(98), content="true") // 'b' = 98
 
   // Integer set representing boolean values
-  let bool_codes = @set.Set::from_array([1, 0, 1]) // 1=true, 0=false
+  let bool_codes = @set.Set([1, 0, 1]) // 1=true, 0=false
   inspect(bool_codes.length(), content="2") // Only 1 and 0
 }
 ```

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -30,7 +30,7 @@ priv struct Entry[K] {
 ///
 /// ```mbt check
 /// test {
-///   let set = @set.Set::from_array(["three", "eight", "one"])
+///   let set = @set.Set(["three", "eight", "one"])
 ///   assert_eq(set.contains("two"), false)
 ///   assert_eq(set.contains("three"), true)
 ///   set.add("three") // no effect since it already exists
@@ -70,10 +70,11 @@ pub fn[K] Set::new(capacity? : Int = 8) -> Set[K] {
 
 ///|
 /// Creates a hash set containing all elements from the given array, preserving insertion order.
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[K : Hash + Eq] Set::from_array(arr : ArrayView[K]) -> Set[K] {
+pub fn[K : Hash + Eq] Set::Set(arr : ArrayView[K]) -> Set[K] {
   let length = arr.length()
   let mut capacity = length.next_power_of_two()
   if length > calc_grow_threshold(capacity) {
@@ -251,7 +252,7 @@ pub fn[K : Hash + Eq] Set::contains(self : Set[K], key : K) -> Bool {
 ///
 /// ```mbt check
 /// test {
-///   let set = @set.Set::from_array(["a", "b"])
+///   let set = @set.Set(["a", "b"])
 ///   set.remove("a")
 ///   inspect(set.contains("a"), content="false")
 ///   inspect(set.length(), content="1")
@@ -289,7 +290,7 @@ pub fn[K : Hash + Eq] Set::remove(self : Set[K], key : K) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let set = @set.Set::from_array(["a", "b"])
+///   let set = @set.Set(["a", "b"])
 ///   inspect(set.remove_and_check("a"), content="true") // Successfully removed
 ///   inspect(set.remove_and_check("a"), content="false") // Already removed
 ///   inspect(set.length(), content="1")

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -82,7 +82,7 @@ test "add remove" {
 
 ///|
 test "of" {
-  let m = @set.Set::from_array(["a", "b", "c"])
+  let m = @set.Set(["a", "b", "c"])
   assert_true(m.contains("a"))
   assert_true(m.contains("b"))
   assert_true(m.contains("c"))
@@ -92,7 +92,7 @@ test "of" {
 ///|
 test "from_array" {
   let arr = ["a", "b", "c"]
-  let m = @set.Set::from_array(arr)
+  let m = @set.Set(arr)
   assert_true(m.contains("a"))
   assert_true(m.contains("b"))
   assert_true(m.contains("c"))
@@ -119,15 +119,15 @@ test "is_empty" {
 
 ///|
 test "is_disjoint prefers shorter iteration" {
-  let m1 = @set.Set::from_array([1, 2, 3, 4])
-  let m2 = @set.Set::from_array([5])
+  let m1 = @set.Set([1, 2, 3, 4])
+  let m2 = @set.Set([5])
   inspect(m1.is_disjoint(m2), content="true")
 }
 
 ///|
 test "is_disjoint detects overlap in else branch" {
-  let m1 = @set.Set::from_array([1, 2, 3, 4])
-  let m2 = @set.Set::from_array([4])
+  let m1 = @set.Set([1, 2, 3, 4])
+  let m2 = @set.Set([4])
   inspect(m1.is_disjoint(m2), content="false")
 }
 
@@ -142,7 +142,7 @@ test "remove stops on shorter probe" {
 
 ///|
 test "each" {
-  let m = @set.Set::from_array(["a", "b", "c"])
+  let m = @set.Set(["a", "b", "c"])
   let mut sum = ""
   m.each(k => sum += k)
   inspect(sum, content="abc")
@@ -151,7 +151,7 @@ test "each" {
 ///|
 test "iter" {
   let buf = StringBuilder::new(size_hint=20)
-  let map = @set.Set::from_array(["a", "b", "c"])
+  let map = @set.Set(["a", "b", "c"])
   map.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[a][b][c]")
   buf.reset()
@@ -161,7 +161,7 @@ test "iter" {
 
 ///|
 test "iteri" {
-  let m = @set.Set::from_array(["1", "2", "3"])
+  let m = @set.Set(["1", "2", "3"])
   let mut s = ""
   let mut sum = 0
   m.eachi((i, k) => {
@@ -174,8 +174,8 @@ test "iteri" {
 
 ///|
 test "union" {
-  let m1 = @set.Set::from_array(["a", "b", "c"])
-  let m2 = @set.Set::from_array(["b", "c", "d"])
+  let m1 = @set.Set(["a", "b", "c"])
+  let m2 = @set.Set(["b", "c", "d"])
   let m = m1.union(m2)
   assert_eq(m.length(), 4)
   assert_true(m.contains("a"))
@@ -186,8 +186,8 @@ test "union" {
 
 ///|
 test "intersection" {
-  let m1 = @set.Set::from_array(["a", "b", "c"])
-  let m2 = @set.Set::from_array(["b", "c", "d"])
+  let m1 = @set.Set(["a", "b", "c"])
+  let m2 = @set.Set(["b", "c", "d"])
   let m = m1.intersection(m2)
   assert_eq(m.length(), 2)
   assert_false(m.contains("a"))
@@ -198,8 +198,8 @@ test "intersection" {
 
 ///|
 test "difference" {
-  let m1 = @set.Set::from_array(["a", "b", "c"])
-  let m2 = @set.Set::from_array(["b", "c", "d"])
+  let m1 = @set.Set(["a", "b", "c"])
+  let m2 = @set.Set(["b", "c", "d"])
   let m = m1.difference(m2)
   assert_eq(m.length(), 1)
   assert_true(m.contains("a"))
@@ -210,8 +210,8 @@ test "difference" {
 
 ///|
 test "symmetric_difference" {
-  let m1 = @set.Set::from_array(["a", "b", "c"])
-  let m2 = @set.Set::from_array(["b", "c", "d"])
+  let m1 = @set.Set(["a", "b", "c"])
+  let m2 = @set.Set(["b", "c", "d"])
   let m = m1.symmetric_difference(m2)
   assert_eq(m.length(), 2)
   assert_true(m.contains("a"))
@@ -470,18 +470,18 @@ test "trigger grow" {
 
 ///|
 test "is_disjoint" {
-  let set1 = @set.Set::from_array(["a", "b"])
-  let set2 = @set.Set::from_array(["c", "d"])
-  let set3 = @set.Set::from_array(["b", "c"])
+  let set1 = @set.Set(["a", "b"])
+  let set2 = @set.Set(["c", "d"])
+  let set3 = @set.Set(["b", "c"])
   inspect(set1.is_disjoint(set2), content="true")
   inspect(set1.is_disjoint(set3), content="false")
 }
 
 ///|
 test "is_subset" {
-  let set1 = @set.Set::from_array(["a", "b"])
-  let set2 = @set.Set::from_array(["a", "b", "c"])
-  let set3 = @set.Set::from_array(["a", "d"])
+  let set1 = @set.Set(["a", "b"])
+  let set2 = @set.Set(["a", "b", "c"])
+  let set3 = @set.Set(["a", "d"])
   inspect(set1.is_subset(set2), content="true")
   inspect(set1.is_subset(set3), content="false")
   inspect(set2.is_subset(set1), content="false")
@@ -489,9 +489,9 @@ test "is_subset" {
 
 ///|
 test "is_superset" {
-  let set1 = @set.Set::from_array(["a", "b", "c"])
-  let set2 = @set.Set::from_array(["a", "b"])
-  let set3 = @set.Set::from_array(["a", "d"])
+  let set1 = @set.Set(["a", "b", "c"])
+  let set2 = @set.Set(["a", "b"])
+  let set3 = @set.Set(["a", "d"])
   inspect(set1.is_superset(set2), content="true")
   inspect(set1.is_superset(set3), content="false")
   inspect(set2.is_superset(set1), content="false")
@@ -499,8 +499,8 @@ test "is_superset" {
 
 ///|
 test "bitwise_operations" {
-  let set1 = @set.Set::from_array(["a", "b", "c"])
-  let set2 = @set.Set::from_array(["b", "c", "d"])
+  let set1 = @set.Set(["a", "b", "c"])
+  let set2 = @set.Set(["b", "c", "d"])
 
   // Intersection (&)
   let intersection = set1 & set2

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -10,7 +10,14 @@ import {
 // Errors
 
 // Types and methods
-type Set[K]
+pub struct Set[K] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[K : Hash + Eq] Set::Set(ArrayView[K]) -> Self[K]
 #alias(insert, deprecated)
 pub fn[K : Hash + Eq] Set::add(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] Set::add_and_check(Self[K], K) -> Bool
@@ -22,10 +29,6 @@ pub fn[K] Set::copy(Self[K]) -> Self[K]
 pub fn[K : Hash + Eq] Set::difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] Set::each(Self[K], (K) -> Unit raise?) -> Unit raise?
 pub fn[K] Set::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[K : Hash + Eq] Set::from_array(ArrayView[K]) -> Self[K]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn


### PR DESCRIPTION
## Summary
- Add type-style `Set([...])` construction with `Set::from_array` kept as an alias and `@set.from_array` preserved as a free-function alias.
- Add type-style `Map([...])` construction with `Map::from_array` kept as an alias.
- Migrate Set docs/tests, add Map constructor coverage, and add a prelude checked example for bare `Set([1, 2, 3, 4])`.
- Regenerate generated interfaces.

## Review Notes
- No blocking findings from the local review pass.
- `prelude` already re-exported `Set` via `pub using @set {type Set}`; the new checked example verifies the constructor is available through that re-export.
- `moon info` now renders `Set` and `Map` as `pub struct ... { // private fields }` in the generated interfaces so the type-style constructors are visible; fields remain private.

## Validation
- `moon test set`
- `moon test prelude`
- `moon test builtin --filter 'Map constructor'`
- `moon check set builtin`
- `moon fmt && moon info`
- `moon test`
- `moon check --deny-warn --target all`
- `moon ide doc 'Set::from_array'`
- `moon ide doc 'Map::from_array'`
- `moon ide doc '@set.from_array'`
- `git diff --check`