### PR TITLE
feat(hashset): add array constructor

### DIFF
--- a/hashset/README.mbt.md
+++ b/hashset/README.mbt.md
@@ -6,12 +6,12 @@ A mutable hash set based on a Robin Hood hash table.
 
 ## Create
 
-You can create an empty set using `new()` or construct it using `from_array()`.
+You can create an empty set using `new()` or construct it from entries using `HashSet([...])`.
 
 ```mbt check
 ///|
 test {
-  let _set1 = @hashset.from_array([1, 2, 3, 4, 5])
+  let _set1 = @hashset.HashSet([1, 2, 3, 4, 5])
   let _set2 : @hashset.HashSet[String] = @hashset.new()
 }
 ```
@@ -197,4 +197,3 @@ test {
   assert_eq(small.is_disjoint(big), false)
 }
 ```
-

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -33,10 +33,11 @@ pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
 
 ///|
 /// Creates a hash set containing all elements from the given array.
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[K : Hash + Eq] HashSet::from_array(arr : ArrayView[K]) -> HashSet[K] {
+pub fn[K : Hash + Eq] HashSet::HashSet(arr : ArrayView[K]) -> HashSet[K] {
   let m = new()
   arr.each(e => m.add(e))
   m

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -130,6 +130,15 @@ test "from_array" {
 }
 
 ///|
+test "HashSet constructor" {
+  let m = @hashset.HashSet(["a", "b", "c"])
+  assert_true(m.contains("a"))
+  assert_true(m.contains("b"))
+  assert_true(m.contains("c"))
+  assert_false(m.contains("d"))
+}
+
+///|
 test "size" {
   let m = @hashset.new()
   inspect(m.length(), content="0")

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -13,7 +13,14 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type HashSet[K]
+pub struct HashSet[K] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[K : Hash + Eq] HashSet::HashSet(ArrayView[K]) -> Self[K]
 #alias(insert, deprecated)
 pub fn[K : Hash + Eq] HashSet::add(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] HashSet::add_and_check(Self[K], K) -> Bool
@@ -25,10 +32,6 @@ pub fn[K] HashSet::copy(Self[K]) -> Self[K]
 pub fn[K : Hash + Eq] HashSet::difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] HashSet::each(Self[K], (K) -> Unit raise?) -> Unit raise?
 pub fn[K] HashSet::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[K : Hash + Eq] HashSet::from_array(ArrayView[K]) -> Self[K]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -33,7 +33,7 @@ priv struct Entry[K] {
 ///
 /// ```mbt check
 /// test {
-///   let set = @hashset.from_array([(3, "three"), (8, "eight"), (1, "one")])
+///   let set = @hashset.HashSet([(3, "three"), (8, "eight"), (1, "one")])
 ///   set.add((4, "four"))
 ///   assert_eq(set.contains((4, "four")), true)
 /// }


### PR DESCRIPTION
## Summary
- Add type-style `HashSet([...])` construction for array-view inputs.
- Keep `HashSet::from_array` and `@hashset.from_array` as aliases for compatibility, along with the existing deprecated `of` aliases.
- Update the HashSet creation docs and add focused constructor test coverage.

## Review Notes
- No blocking findings from the local review pass.
- I kept this separate PR scoped to the mutable `hashset` package; immutable hashset and other collection packages are unchanged.
- `moon info` now renders `HashSet` as `pub struct ... { // private fields }` in the generated interface so the type-style constructor is visible; fields remain private.

## Validation
- `moon test hashset`
- `moon check hashset`
- `moon fmt && moon info`
- `moon test`
- `moon check --deny-warn --target all`
- `moon ide doc '@hashset.HashSet::HashSet'`
- `moon ide doc '@hashset.HashSet::from_array'`
- `moon ide doc '@hashset.from_array'`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
