### PR TITLE
feat(hashmap): add array constructor

### DIFF
--- a/hashmap/README.mbt.md
+++ b/hashmap/README.mbt.md
@@ -6,11 +6,12 @@ A mutable hash map based on a Robin Hood hash table.
 
 ## Create
 
-You can create an empty map using `new()` or construct it using `from_array()`.
+You can create an empty map using `new()` or construct it from entries using `HashMap([...])`.
 
 ```mbt check
 ///|
 test {
+  let _map1 = @hashmap.HashMap([("a", 1), ("b", 2)])
   let _map2 : @hashmap.HashMap[String, Int] = @hashmap.new()
 }
 ```

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -62,15 +62,16 @@ pub fn[K, V] HashMap::new(capacity? : Int = 8) -> HashMap[K, V] {
 /// ```mbt check
 /// test {
 ///   let arr = [(1, "one"), (2, "two"), (1, "ONE")]
-///   let map = @hashmap.from_array(arr)
+///   let map = @hashmap.HashMap(arr)
 ///   debug_inspect(map.get(1), content="Some(\"ONE\")")
 ///   debug_inspect(map.get(2), content="Some(\"two\")")
 /// }
 /// ```
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[K : Hash + Eq, V] HashMap::from_array(
+pub fn[K : Hash + Eq, V] HashMap::HashMap(
   arr : ArrayView[(K, V)],
 ) -> HashMap[K, V] {
   let m = new(capacity=arr.length() * 2)

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -357,6 +357,14 @@ test "@hashmap.from_array with int key" {
 }
 
 ///|
+test "@hashmap.HashMap constructor" {
+  let map = @hashmap.HashMap([("a", 1), ("b", 2), ("a", 3)])
+  assert_eq(map.length(), 2)
+  assert_eq(map.get("a"), Some(3))
+  assert_eq(map.get("b"), Some(2))
+}
+
+///|
 test "@hashmap.contains_kv" {
   let map = @hashmap.from_array([(1, "one"), (2, "two"), (3, "three")])
   inspect(map.contains_kv(1, "one"), content="true")

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -13,7 +13,14 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type HashMap[K, V]
+pub struct HashMap[K, V] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[K : Hash + Eq, V] HashMap::HashMap(ArrayView[(K, V)]) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] HashMap::at(Self[K, V], K) -> V
 pub fn[K, V] HashMap::capacity(Self[K, V]) -> Int
@@ -24,10 +31,6 @@ pub fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(Self[K, V], K, V) -> Bool
 pub fn[K, V] HashMap::copy(Self[K, V]) -> Self[K, V]
 pub fn[K, V] HashMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] HashMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[K : Hash + Eq, V] HashMap::from_array(ArrayView[(K, V)]) -> Self[K, V]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -34,7 +34,7 @@ priv struct Entry[K, V] {
 ///
 /// ```mbt check
 /// test {
-///   let map = @hashmap.from_array([(3, "three"), (8, "eight"), (1, "one")])
+///   let map = @hashmap.HashMap([(3, "three"), (8, "eight"), (1, "one")])
 ///   assert_eq(map.get(2), None)
 ///   assert_eq(map.get(3), Some("three"))
 ///   map.set(3, "updated")


### PR DESCRIPTION
## Summary
- Add type-style `HashMap([...])` construction for array-view key-value inputs.
- Keep `HashMap::from_array` and `@hashmap.from_array` as aliases for compatibility, along with the existing deprecated `of` aliases.
- Update focused HashMap docs and add constructor test coverage.

## Review Notes
- No blocking findings from the local review pass.
- I kept this separate PR scoped to the mutable `hashmap` package; immutable hashmap and other collections are unchanged.
- `moon info` now renders `HashMap` as `pub struct ... { // private fields }` in the generated interface so the type-style constructor is visible; fields remain private.

## Validation
- `moon test hashmap`
- `moon check hashmap`
- `moon fmt && moon info`
- `moon test`
- `moon check --deny-warn --target all`
- `moon ide doc '@hashmap.HashMap::HashMap'`
- `moon ide doc '@hashmap.HashMap::from_array'`
- `moon ide doc '@hashmap.from_array'`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
