### PR TITLE
feat(collection): add remaining array constructors

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -168,14 +168,15 @@ test "add_empty" {
 /// ```mbt check
 /// test {
 ///   let arr = [1, 2, 3, 4, 5]
-///   let dq = @deque.from_array(arr)
+///   let dq = @deque.Deque(arr)
 ///   inspect(dq, content="@deque.from_array([1, 2, 3, 4, 5])")
 /// }
 /// ```
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[A] Deque::from_array(arr : ArrayView[A]) -> Deque[A] {
+pub fn[A] Deque::Deque(arr : ArrayView[A]) -> Deque[A] {
   let len = arr.length()
   let buf = UninitializedArray::make(len)
   for i, x in arr {

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -42,6 +42,14 @@ test "contains" {
 }
 
 ///|
+test "Deque constructor" {
+  let dv = @deque.Deque([3, 4, 5])
+  assert_eq(dv.length(), 3)
+  assert_eq(dv[0], 3)
+  assert_eq(dv[2], 5)
+}
+
+///|
 test "reserve_capacity" {
   let dv = @deque.from_array([1, 2, 3, 4, 5])
   dv.pop_front() |> ignore() // 2, 3, 4, 5

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -12,7 +12,14 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type Deque[A]
+pub struct Deque[A] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[A] Deque::Deque(ArrayView[A]) -> Self[A]
 pub fn[A] Deque::append(Self[A], Self[A]) -> Unit
 pub fn[A] Deque::as_views(Self[A]) -> (ArrayView[A], ArrayView[A])
 #alias("_[_]")
@@ -34,10 +41,6 @@ pub fn[A] Deque::eachi(Self[A], (Int, A) -> Unit) -> Unit
 pub fn[A] Deque::extract_if(Self[A], (A) -> Bool) -> Self[A]
 pub fn[A] Deque::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A] Deque::flatten(Self[Self[A]]) -> Self[A]
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[A] Deque::from_array(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -13,11 +13,14 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type PriorityQueue[A]
+pub struct PriorityQueue[A] {
+  // private fields
+}
+#alias(from_array)
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[A : Compare] PriorityQueue::from_array(ArrayView[A]) -> Self[A]
+#as_free_fn(from_array)
+pub fn[A : Compare] PriorityQueue::PriorityQueue(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -33,14 +33,15 @@ pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue = @priority_queue.from_array([1, 2, 3, 4, 5])
+///   let queue = @priority_queue.PriorityQueue([1, 2, 3, 4, 5])
 ///   inspect(queue.length(), content="5")
 /// }
 /// ```
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[A : Compare] PriorityQueue::from_array(
+pub fn[A : Compare] PriorityQueue::PriorityQueue(
   array : ArrayView[A],
 ) -> PriorityQueue[A] {
   for x in array; pq = (new() : PriorityQueue[A]) {

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -25,6 +25,13 @@ test "from_array" {
 }
 
 ///|
+test "PriorityQueue constructor" {
+  let queue = @priority_queue.PriorityQueue([1, 6, 3, 4, 5])
+  debug_inspect(queue.peek(), content="Some(6)")
+  inspect(queue.length(), content="5")
+}
+
+///|
 test "to_array" {
   let v = @priority_queue.from_array([1, 2, 3, 4])
   inspect(v.to_array(), content="[4, 3, 2, 1]")

--- a/immut/vector/pkg.generated.mbti
+++ b/immut/vector/pkg.generated.mbti
@@ -13,7 +13,14 @@ import {
 // Errors
 
 // Types and methods
-type Vector[A]
+pub struct Vector[A] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[A] Vector::Vector(ArrayView[A]) -> Self[A]
 #alias("_[_]")
 pub fn[A] Vector::at(Self[A], Int) -> A
 pub fn[A] Vector::concat(Self[A], Self[A]) -> Self[A]
@@ -27,10 +34,6 @@ pub fn[A] Vector::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
 pub fn[A] Vector::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 #alias(fold_left, deprecated)
 pub fn[A, B] Vector::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[A] Vector::from_array(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -90,14 +90,15 @@ pub fn[A] Vector::makei(len : Int, f : (Int) -> A raise?) -> Vector[A] raise? {
 /// # Example
 /// ```mbt check
 /// test {
-///   let v = @vector.from_array([1, 2, 3])
+///   let v = @vector.Vector([1, 2, 3])
 ///   assert_eq(v, @vector.from_array([1, 2, 3]))
 /// }
 /// ```
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[A] Vector::from_array(arr : ArrayView[A]) -> Vector[A] {
+pub fn[A] Vector::Vector(arr : ArrayView[A]) -> Vector[A] {
   Vector::makei(arr.length(), i => arr[i])
 }
 

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -169,6 +169,12 @@ test "from_array" {
 }
 
 ///|
+test "Vector constructor" {
+  let v = @vector.Vector([1, 1, 4, 5, 1, 4])
+  inspect(v, content="@immut/vector.from_array([1, 1, 4, 5, 1, 4])")
+}
+
+///|
 test "iteri" {
   let v : @vector.Vector[Int] = @vector.new()
   v.eachi((_i, _e) => abort("never reach"))

--- a/priority_queue/pkg.generated.mbti
+++ b/priority_queue/pkg.generated.mbti
@@ -13,14 +13,17 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type PriorityQueue[A]
+pub struct PriorityQueue[A] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[A : Compare] PriorityQueue::PriorityQueue(ArrayView[A]) -> Self[A]
 pub fn[A] PriorityQueue::clear(Self[A]) -> Unit
 #alias(clone, deprecated)
 pub fn[A] PriorityQueue::copy(Self[A]) -> Self[A]
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[A : Compare] PriorityQueue::from_array(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -33,14 +33,15 @@ pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue = @priority_queue.from_array([1, 2, 3, 4, 5])
+///   let queue = @priority_queue.PriorityQueue([1, 2, 3, 4, 5])
 ///   assert_eq(queue.length(), 5)
 /// }
 /// ```
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[A : Compare] PriorityQueue::from_array(
+pub fn[A : Compare] PriorityQueue::PriorityQueue(
   arr : ArrayView[A],
 ) -> PriorityQueue[A] {
   guard arr is [a0, ..] else { return new() }

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -33,6 +33,13 @@ test "from_array" {
 }
 
 ///|
+test "PriorityQueue constructor" {
+  let pq = @priority_queue.PriorityQueue([1, 3, 6, 4, 5])
+  debug_inspect(pq.peek(), content="Some(6)")
+  assert_eq(pq.length(), 5)
+}
+
+///|
 test "from_fixed_array" {
   let pq = @priority_queue.from_array([1, 2, 3, 4, 5])
   @test.assert_eq(pq.peek(), Some(5))

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -13,17 +13,20 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type Queue[A]
+pub struct Queue[A] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[A] Queue::Queue(ArrayView[A]) -> Self[A]
 pub fn[A] Queue::clear(Self[A]) -> Unit
 #alias(clone, deprecated)
 pub fn[A] Queue::copy(Self[A]) -> Self[A]
 pub fn[A] Queue::each(Self[A], (A) -> Unit) -> Unit
 pub fn[A] Queue::eachi(Self[A], (Int, A) -> Unit) -> Unit
 pub fn[A, B] Queue::fold(Self[A], init~ : B, (B, A) -> B) -> B
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[A] Queue::from_array(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -34,14 +34,15 @@ pub fn[A] Queue::new() -> Queue[A] {
 /// ```mbt check
 /// test {
 ///   let array = Array::makei(3, idx => idx + 1)
-///   let queue : @queue.Queue[Int] = @queue.from_array(array)
+///   let queue : @queue.Queue[Int] = @queue.Queue(array)
 ///   @test.assert_eq(queue.length(), 3)
 /// }
 /// ```
-#as_free_fn
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[A] Queue::from_array(arr : ArrayView[A]) -> Queue[A] {
+pub fn[A] Queue::Queue(arr : ArrayView[A]) -> Queue[A] {
   guard arr.length() > 0 else { return new() }
   let length = arr.length()
   let last = { content: arr[length - 1], next: None }

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -58,6 +58,15 @@ test "from_array_1" {
 }
 
 ///|
+test "Queue constructor" {
+  let queue = @queue.Queue([1, 2, 3])
+  assert_eq(queue.length(), 3)
+  assert_eq(queue.unsafe_pop(), 1)
+  assert_eq(queue.unsafe_pop(), 2)
+  assert_eq(queue.unsafe_pop(), 3)
+}
+
+///|
 test "from_array_2" {
   let q : @queue.Queue[Int] = @queue.from_array([])
   inspect(q, content="@queue.from_array([])")

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -33,10 +33,19 @@ pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
 
 ///|
 /// Creates a sorted map from an array of key-value pairs.
-#as_free_fn
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let map = @sorted_map.SortedMap([(1, "one"), (2, "two")])
+///   assert_true(map.get(1) == Some("one"))
+/// }
+/// ```
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[K : Compare, V] SortedMap::from_array(
+pub fn[K : Compare, V] SortedMap::SortedMap(
   entries : ArrayView[(K, V)],
 ) -> SortedMap[K, V] {
   let map = { root: None, size: 0 }

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -37,6 +37,13 @@ test "remove on empty map" {
 }
 
 ///|
+test "SortedMap constructor" {
+  let map = @sorted_map.SortedMap([(3, "c"), (2, "b"), (1, "a")])
+  assert_eq(map.length(), 3)
+  debug_inspect(map.get(1), content="Some(\"a\")")
+}
+
+///|
 test "get" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
   debug_inspect(map.get(1), content="Some(\"a\")")

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -14,7 +14,14 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type SortedMap[K, V]
+pub struct SortedMap[K, V] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[K : Compare, V] SortedMap::SortedMap(ArrayView[(K, V)]) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Compare, V] SortedMap::at(Self[K, V], K) -> V
 pub fn[K, V] SortedMap::clear(Self[K, V]) -> Unit
@@ -23,10 +30,6 @@ pub fn[K : Compare, V] SortedMap::contains(Self[K, V], K) -> Bool
 pub fn[K, V] SortedMap::copy(Self[K, V]) -> Self[K, V]
 pub fn[K, V] SortedMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[K : Compare, V] SortedMap::from_array(ArrayView[(K, V)]) -> Self[K, V]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/sorted_set/pkg.generated.mbti
+++ b/sorted_set/pkg.generated.mbti
@@ -13,7 +13,14 @@ import {
 
 // Types and methods
 #alias(T, deprecated)
-type SortedSet[V]
+pub struct SortedSet[V] {
+  // private fields
+}
+#alias(from_array)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array)
+pub fn[V : Compare] SortedSet::SortedSet(ArrayView[V]) -> Self[V]
 pub fn[V : Compare] SortedSet::add(Self[V], V) -> Unit
 pub fn[V : Compare] SortedSet::contains(Self[V], V) -> Bool
 #alias(clone, deprecated)
@@ -24,10 +31,6 @@ pub fn[V : Compare] SortedSet::difference(Self[V], Self[V]) -> Self[V]
 pub fn[V : Compare] SortedSet::disjoint(Self[V], Self[V]) -> Bool
 pub fn[V] SortedSet::each(Self[V], (V) -> Unit raise?) -> Unit raise?
 pub fn[V] SortedSet::eachi(Self[V], (Int, V) -> Unit raise?) -> Unit raise?
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[V : Compare] SortedSet::from_array(ArrayView[V]) -> Self[V]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -30,10 +30,19 @@ pub fn[V] SortedSet::singleton(value : V) -> SortedSet[V] {
 
 ///|
 /// Initialize a set from an array.
-#as_free_fn
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let set = @sorted_set.SortedSet([3, 1, 2])
+///   assert_eq(set.length(), 3)
+/// }
+/// ```
+#alias(from_array)
+#as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[V : Compare] SortedSet::from_array(array : ArrayView[V]) -> SortedSet[V] {
+pub fn[V : Compare] SortedSet::SortedSet(array : ArrayView[V]) -> SortedSet[V] {
   let set = new()
   for x in array {
     set.add(x)

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -26,6 +26,12 @@ test "default" {
 }
 
 ///|
+test "SortedSet constructor" {
+  let set = @sorted_set.SortedSet([3, 1, 2])
+  assert_eq(set.to_array(), [1, 2, 3])
+}
+
+///|
 test "arbitrary samples" {
   let samples = (@quickcheck.samples(3) : Array[@sorted_set.SortedSet[Int]])
   inspect(samples.length(), content="3")


### PR DESCRIPTION
## Summary
- Add type-style array constructors for `Queue`, `Deque`, mutable `PriorityQueue`, immutable `PriorityQueue`, `Vector`, mutable `SortedSet`, and mutable `SortedMap`.
- Keep the existing `from_array` method/free-function names as aliases, along with the deprecated `of` aliases.
- Add focused constructor tests, update public docs/examples, and regenerate generated interfaces.

## Review Notes
- GitHub-visible Devin feedback on the prior constructor PRs (#3501, #3502, #3503) reports no issues and has no inline review threads. The Devin app-only “2 additional findings” are not exposed in GitHub comments/threads from this session.
- This sweep excludes APIs that cannot use type-style constructors in the current language shape: enum-backed `List`, immutable sorted collections, and tuple-struct immutable hash collections. It also excludes mutable `HashMap`, which is already covered by #3503.
- `moon info` now renders the involved struct types as `pub struct ... { // private fields }` so the type-style constructors are visible while fields remain private.

## Validation
- `moon test queue deque priority_queue sorted_set sorted_map immut/vector immut/priority_queue`
- `moon check queue deque priority_queue sorted_set sorted_map immut/vector immut/priority_queue`
- `moon fmt && moon info`
- `moon test`
- `moon check --deny-warn --target all`
- `moon ide doc '@queue.Queue::from_array'`
- `moon ide doc '@deque.Deque::from_array'`
- `moon ide doc '@priority_queue.PriorityQueue::from_array'`
- `moon ide doc '@sorted_set.SortedSet::from_array'`
- `moon ide doc '@sorted_map.SortedMap::from_array'`
- `moon ide doc '@vector.Vector::from_array'`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
