### PR TITLE
fix(array): abort on negative repeat count and guard against overflow

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1224,7 +1224,9 @@ pub fn[T] Array::flatten(self : Array[Array[T]]) -> Array[T] {
 }
 
 ///|
-/// Create an array by repeat a given array for a given times.
+/// Create an array by repeating `self` `times` times.
+///
+/// Aborts if `times` is negative. When `times` is `0`, returns an empty array.
 ///
 /// Example:
 ///
@@ -1235,7 +1237,16 @@ pub fn[T] Array::flatten(self : Array[Array[T]]) -> Array[T] {
 /// }
 /// ```
 pub fn[T] Array::repeat(self : Array[T], times : Int) -> Array[T] {
-  let v = Array::new(capacity=self.length() * times)
+  if times < 0 {
+    abort("negative repeat count")
+  }
+  let len = self.length()
+  if times == 0 || len == 0 {
+    return []
+  }
+  let total = len * times
+  guard total / times == len else { abort("repeat result too large") }
+  let v = Array::new(capacity=total)
   for _ in 0..<times {
     v.append(self)
   }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -461,6 +461,12 @@ test "array_repeat" {
   let arr = [1, 2]
   let repeated = arr.repeat(3)
   inspect(repeated, content="[1, 2, 1, 2, 1, 2]")
+  inspect(arr.repeat(0), content="[]")
+}
+
+///|
+test "panic array_repeat negative" {
+  let _ = [1, 2].repeat(-1)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- `Array::repeat(-1)` previously raised the opaque `RuntimeError: requested new array is too large`. Now aborts with `"negative repeat count"`.
- Adds the same multiplicative-overflow guard already present in `Bytes::repeat` (`guard total / times == len`) so a wrap-around aborts cleanly with `"repeat result too large"`.
- `times == 0` still returns an empty array (unchanged).

Part of the split-up of #3505 for easier review. Refs #3498.

Sibling PRs:
- string + StringView: hongbo/3498-string
- bytes: hongbo/3498-bytes
- list: hongbo/3498-list

## Test plan

- [x] `moon test -p moonbitlang/core/builtin --target native` — 2772 pass
- [x] New `panic array_repeat negative` test in `builtin/array_test.mbt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
