### PR TITLE
fix(string): abort on negative repeat count and guard against overflow

### DIFF
--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -972,13 +972,20 @@ test "pad_end" {
 
 ///|
 /// Returns a new string with `self` repeated `n` times.
+///
+/// Aborts if `n` is negative. When `n` is `0`, returns the empty string.
 pub fn StringView::repeat(self : StringView, n : Int) -> StringView {
   match n {
-    _..=0 => ""
+    _..<0 => abort("negative repeat count")
+    0 => ""
     1 => self
     _ => {
       let len = self.length()
-      let buf = StringBuilder::new(size_hint=len * n)
+      let total = len * n
+      guard len == 0 || total / n == len else {
+        abort("repeat result too large")
+      }
+      let buf = StringBuilder::new(size_hint=total)
       let str = self.to_owned()
       for _ in 0..<n {
         buf.write_string(str)
@@ -990,13 +997,20 @@ pub fn StringView::repeat(self : StringView, n : Int) -> StringView {
 
 ///|
 /// Returns a new string with `self` repeated `n` times.
+///
+/// Aborts if `n` is negative. When `n` is `0`, returns the empty string.
 pub fn String::repeat(self : String, n : Int) -> String {
   match n {
-    _..=0 => ""
+    _..<0 => abort("negative repeat count")
+    0 => ""
     1 => self
     _ => {
       let len = self.length()
-      let buf = StringBuilder::new(size_hint=len * n)
+      let total = len * n
+      guard len == 0 || total / n == len else {
+        abort("repeat result too large")
+      }
+      let buf = StringBuilder::new(size_hint=total)
       let str = self.to_string()
       for _ in 0..<n {
         buf.write_string(str)
@@ -1027,8 +1041,17 @@ test "repeat" {
 
   // Edge cases
   inspect("abc".repeat(0), content="")
-  inspect("abc".repeat(-5), content="")
   inspect("abc".repeat(1), content="abc")
+}
+
+///|
+test "panic string repeat negative" {
+  let _ = "abc".repeat(-5)
+}
+
+///|
+test "panic string view repeat negative" {
+  let _ = "hello"[1:].repeat(-1)
 }
 
 ///|

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -202,11 +202,11 @@ test "String::rev_find partial mismatch" {
 }
 
 ///|
-test "StringView repeat non-positive" {
+test "panic StringView repeat negative" {
   let view = "hi"[:]
   let mut n = 1
   n -= view.length()
-  inspect(view.repeat(n), content="")
+  let _ = view.repeat(n)
 }
 
 ///|

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -679,7 +679,11 @@ test "StringView::replace" {
 test "StringView::repeat" {
   inspect("ab"[:].repeat(1), content="ab")
   inspect("ab"[:].repeat(0), content="")
-  inspect("ab"[:].repeat(-2), content="")
+}
+
+///|
+test "panic StringView::repeat negative" {
+  let _ = "ab"[:].repeat(-2)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- `String::repeat(-5)` and `StringView::repeat(-5)` previously matched `_..=0 => ""` and silently returned an empty string for any non-positive `n`. Now negative `n` aborts with `"negative repeat count"`.
- Adds the same multiplicative-overflow guard already present in `Bytes::repeat` (`guard total / n == len`) so a wrap-around aborts cleanly with `"repeat result too large"`.
- `n == 0` still returns the empty string (unchanged).
- Two existing tests that asserted the old silent-empty behavior on negative `n` (in `builtin/string_test.mbt` and `string/view_test.mbt`) are converted to `panic` tests.

Part of the split-up of #3505 for easier review. Refs #3498.

Sibling PRs:
- array: hongbo/3498-array
- bytes: hongbo/3498-bytes
- list: hongbo/3498-list

## Test plan

- [x] `moon test -p moonbitlang/core/builtin --target native` — 2773 pass
- [x] `moon test -p moonbitlang/core/string --target native` — 259 pass
- [x] New `panic` tests added for `String::repeat`, `StringView::repeat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
