### PR TITLE
fix(list): abort on negative repeat count

### DIFF
--- a/list/list.mbt
+++ b/list/list.mbt
@@ -882,7 +882,9 @@ pub fn[A] List::nth(self : List[A], n : Int) -> A? {
 }
 
 ///|
-/// Create a list of length n with the given value
+/// Create a list of length n with the given value.
+///
+/// Aborts if `n` is negative. When `n` is `0`, returns the empty list.
 ///
 /// # Example
 ///
@@ -893,6 +895,9 @@ pub fn[A] List::nth(self : List[A], n : Int) -> A? {
 /// ```
 #as_free_fn
 pub fn[A] List::repeat(n : Int, x : A) -> List[A] {
+  if n < 0 {
+    abort("negative repeat count")
+  }
   for acc = Empty, i = n {
     match (acc, i) {
       (acc, n) =>

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -307,6 +307,11 @@ test "repeat" {
 }
 
 ///|
+test "panic List::repeat negative" {
+  let _ = @list.repeat(-1, 0)
+}
+
+///|
 test "intersperse" {
   let ls = @list.from_array(["1", "2", "3", "4", "5"])
   let el : @list.List[String] = @list.empty()


### PR DESCRIPTION
## Summary

- `@list.repeat(-1, x)` previously treated negative `n` as `0` and silently returned `Empty`. Now aborts with `"negative repeat count"`.
- `n == 0` still returns the empty list (unchanged).

Rounds out the same treatment applied across the `*::repeat` family. Part of the split-up of #3505 for easier review. Refs #3498.

Sibling PRs:
- array: hongbo/3498-array
- string + StringView: hongbo/3498-string
- bytes: hongbo/3498-bytes

## Test plan

- [x] `moon test -p moonbitlang/core/list --target native` — 202 pass
- [x] New `panic List::repeat negative` test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
