### PR TITLE
[codex] Deprecate Set and Map new constructors

### DIFF
--- a/argparse/parser_globals_merge.mbt
+++ b/argparse/parser_globals_merge.mbt
@@ -205,7 +205,7 @@ fn seed_child_globals_from_parent(
   child_local_non_globals : @set.Set[String],
 ) -> Matches {
   let seed = new_matches_parse_state()
-  let seen : @set.Set[String] = @set.new()
+  let seen : @set.Set[String] = Set([])
   for arg in globals {
     let name = arg.name
     if child_local_non_globals.contains(name) || !seen.add_and_check(name) {
@@ -313,7 +313,7 @@ fn propagate_globals_to_child(
   }
   match child.parsed_subcommand {
     Some((sub_name, sub_m)) => {
-      propagate_globals_to_child(parent, sub_m, globals, @set.new())
+      propagate_globals_to_child(parent, sub_m, globals, Set([]))
       child.parsed_subcommand = Some((sub_name, sub_m))
     }
     None => ()

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -23,13 +23,13 @@ priv struct ValidationCtx {
 
 ///|
 fn ValidationCtx::new(
-  inherited_global_names? : @set.Set[String] = @set.new(),
+  inherited_global_names? : @set.Set[String] = Set([]),
 ) -> ValidationCtx {
   {
     inherited_global_names: inherited_global_names.copy(),
-    seen_names: @set.new(),
-    seen_long: @set.new(),
-    seen_short: @set.new(),
+    seen_names: Set([]),
+    seen_long: Set([]),
+    seen_short: Set([]),
     args: [],
   }
 }
@@ -349,8 +349,8 @@ fn validate_group_defs(
   args : Array[Arg],
   groups : Array[ArgGroup],
 ) -> Unit raise ArgBuildError {
-  let seen : @set.Set[String] = @set.new()
-  let arg_seen : @set.Set[String] = @set.new()
+  let seen : @set.Set[String] = Set([])
+  let arg_seen : @set.Set[String] = Set([])
   for arg in args {
     arg_seen.add(arg.name)
   }
@@ -391,7 +391,7 @@ fn validate_group_refs(
   if groups.length() == 0 {
     return
   }
-  let arg_index : @set.Set[String] = @set.new()
+  let arg_index : @set.Set[String] = Set([])
   for arg in args {
     arg_index.add(arg.name)
   }
@@ -436,7 +436,7 @@ fn validate_subcommand_defs(subs : Array[Command]) -> Unit raise ArgBuildError {
   if subs.length() == 0 {
     return
   }
-  let seen : @set.Set[String] = @set.new()
+  let seen : @set.Set[String] = Set([])
   for sub in subs {
     if !seen.add_and_check(sub.name) {
       raise Unsupported("duplicate subcommand: \{sub.name}")
@@ -493,8 +493,8 @@ fn validate_groups(
     return
   }
   let group_presence : Map[String, Int] = {}
-  let group_seen : @set.Set[String] = @set.new()
-  let arg_seen : @set.Set[String] = @set.new()
+  let group_seen : @set.Set[String] = Set([])
+  let arg_seen : @set.Set[String] = Set([])
   for group in groups {
     group_seen.add(group.name)
   }

--- a/builtin/LinkedHashMap.mbt.md
+++ b/builtin/LinkedHashMap.mbt.md
@@ -8,7 +8,7 @@ A mutable linked hash map based on a Robin Hood hash table, links all entry node
 
 ### Create
 
-You can create an empty map using `new()` or construct it from entries using `Map([...])`.
+You can create an empty map using `Map([])` or construct it from entries using `Map([...])`.
 
 ```mbt check 
 ///|

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -54,6 +54,17 @@ pub fn Bytes::copy(self : Bytes) -> Bytes {
 }
 
 ///|
+/// Create a hash map.
+/// The capacity of the map will be the smallest power of 2 that is
+/// greater than or equal to the provided [capacity].
+///
+/// Deprecated: use `Map([], capacity=...)` instead.
+#deprecated("Use `Map([], capacity=...)` instead")
+pub fn[K, V] Map::new(capacity? : Int = default_init_capacity) -> Map[K, V] {
+  new_map(capacity)
+}
+
+///|
 /// positions.
 ///
 /// Parameters:

--- a/builtin/iter2_test.mbt
+++ b/builtin/iter2_test.mbt
@@ -23,7 +23,7 @@ test "iter2_to_iter" {
 
 ///|
 test "iter2 identity function should return its input" {
-  let m : @builtin.Map[String, Int] = @builtin.Map::new()
+  let m : @builtin.Map[String, Int] = @builtin.Map([])
   m.set("x", 1)
   m.set("y", 2)
   let iter2 = m.iter2()

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -276,7 +276,7 @@ pub impl[X : ToJson] ToJson for ArrayView[X] with to_json(self) {
 
 ///|
 pub impl[K : Show, V : ToJson] ToJson for Map[K, V] with to_json(self) {
-  let object = Map::new(capacity=self.capacity)
+  let object = Map([], capacity=self.capacity)
   for k, v in self {
     object[k.to_string()] = v.to_json()
   }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -51,10 +51,10 @@ struct Map[K, V] {
 // Implementations
 
 ///|
-/// Create a hash map.
-/// The capacity of the map will be the smallest power of 2 that is
-/// greater than or equal to the provided [capacity].
-pub fn[K, V] Map::new(capacity? : Int = 8) -> Map[K, V] {
+let default_init_capacity = 8
+
+///|
+fn[K, V] new_map(capacity : Int) -> Map[K, V] {
   let capacity = capacity.next_power_of_two()
   {
     size: 0,
@@ -68,15 +68,34 @@ pub fn[K, V] Map::new(capacity? : Int = 8) -> Map[K, V] {
 }
 
 ///|
-/// Create a hash map from an array.
-#alias(from_array)
-pub fn[K : Hash + Eq, V] Map::Map(arr : ArrayView[(K, V)]) -> Map[K, V] {
-  let length = arr.length()
+fn capacity_for_length(length : Int) -> Int {
   let mut capacity = length.next_power_of_two()
   if length > calc_grow_threshold(capacity) {
     capacity *= 2
   }
-  let m = Map::new(capacity~)
+  capacity
+}
+
+///|
+/// Create a hash map from an array.
+/// The optional `capacity` is treated as a minimum initial capacity and will be
+/// rounded up to the smallest power of 2 that can hold the requested capacity.
+#alias(from_array)
+pub fn[K : Hash + Eq, V] Map::Map(
+  arr : ArrayView[(K, V)],
+  capacity? : Int,
+) -> Map[K, V] {
+  let length = arr.length()
+  let capacity = match capacity {
+    Some(capacity) => capacity.max(capacity_for_length(length))
+    None =>
+      if length == 0 {
+        default_init_capacity
+      } else {
+        capacity_for_length(length)
+      }
+  }
+  let m = new_map(capacity)
   for e in arr {
     m.set(e.0, e.1)
   }
@@ -98,7 +117,7 @@ pub fn[K : Hash + Eq, V] Map::Map(arr : ArrayView[(K, V)]) -> Map[K, V] {
 ///
 /// ```mbt check
 /// test {
-///   let map : Map[String, Int] = Map::new()
+///   let map : Map[String, Int] = Map([])
 ///   map.set("key", 42)
 ///   debug_inspect(map.get("key"), content="Some(42)")
 ///   map.set("key", 24) // update existing key
@@ -685,11 +704,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with equal(
 /// Function `of`.
 pub fn[K : Hash + Eq, V] Map::of(arr : FixedArray[(K, V)]) -> Map[K, V] {
   let length = arr.length()
-  let mut capacity = length.next_power_of_two()
-  if length > calc_grow_threshold(capacity) {
-    capacity *= 2
-  }
-  let m = Map::new(capacity~)
+  let m = new_map(capacity_for_length(length))
   // arr.iter((e) => { m.set(e.0, e.1) })
   for i in 0..<length {
     let e = arr[i]
@@ -711,7 +726,7 @@ pub fn[K : Hash + Eq, V] Map::from_iter(iter : Iter[(K, V)]) -> Map[K, V] {
 
 ///|
 pub impl[K, V] Default for Map[K, V] with default() {
-  Map::new()
+  new_map(default_init_capacity)
 }
 
 ///|

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -257,7 +257,7 @@ test "Map::update" {
   inspect(empty_map.length(), content="1")
 
   // Test adding to empty map
-  let empty_map : Map[String, Int] = Map::new(capacity=1)
+  let empty_map : Map[String, Int] = Map([], capacity=1)
   empty_map.update("a", _ => Some(1))
   empty_map.update("b", _ => Some(2))
   empty_map.update("c", _ => Some(3))
@@ -355,7 +355,7 @@ test "Map::retain - filter by both key and value" {
 
 ///|
 test "Map::retain - large map performance" {
-  let map : Map[String, Int] = Map::new()
+  let map : Map[String, Int] = Map([])
   for i in 0..<1000 {
     map.set("key" + i.to_string(), i)
   }
@@ -444,7 +444,7 @@ test "Map::retain - edge case with all elements removed then re-added" {
 
 ///|
 test "Map::retain - with hash collisions simulation" {
-  let map : Map[String, Int] = Map::new()
+  let map : Map[String, Int] = Map([])
   // Create keys that might have similar hash values
   let keys = ["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa"]
   for i, k in keys {
@@ -550,7 +550,7 @@ test "Map::merge" {
 
 ///|
 test "Map::merge empty maps" {
-  let map1 : Map[String, Int] = Map::new()
+  let map1 : Map[String, Int] = Map([])
   let map2 : Map[String, Int] = { "a": 1, "b": 2 }
   let merged1 = map1.merge(map2)
   inspect(merged1.length(), content="2")
@@ -577,7 +577,7 @@ test "Map::merge_in_place" {
 
 ///|
 test "Map::merge_in_place empty maps" {
-  let map1 : Map[String, Int] = Map::new()
+  let map1 : Map[String, Int] = Map([])
   let map2 : Map[String, Int] = { "a": 1, "b": 2 }
   map1.merge_in_place(map2)
   inspect(map1.length(), content="2")

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -28,8 +28,8 @@ impl Hash for MyString with hash_combine(self, hasher) {
 }
 
 ///|
-test "new" {
-  let m : Map[String, Int] = Map::new()
+test "empty constructor" {
+  let m : Map[String, Int] = Map([])
   assert_eq(m.size, 0)
   assert_eq(m.capacity, 8)
   assert_true(m.head is None)
@@ -40,8 +40,24 @@ test "new" {
 }
 
 ///|
+test "constructor capacity" {
+  let empty : Map[String, Int] = Map([], capacity=16)
+  assert_eq(empty.capacity, 16)
+  assert_eq(empty.length(), 0)
+  let below_length = Map([("a", 1), ("b", 2), ("c", 3)], capacity=2)
+  assert_eq(below_length.capacity, 4)
+  assert_eq(below_length.length(), 3)
+  let above_length = Map([("a", 1), ("b", 2), ("c", 3)], capacity=16)
+  assert_eq(above_length.capacity, 16)
+  inspect(
+    above_length.to_array(),
+    content="[(\"a\", 1), (\"b\", 2), (\"c\", 3)]",
+  )
+}
+
+///|
 test "set" {
-  let m : Map[MyString, Int] = Map::new()
+  let m : Map[MyString, Int] = Map([])
   m.set("a", 1)
   m.set("b", 1)
   m.set("bc", 2)
@@ -58,7 +74,7 @@ test "set" {
 
 ///|
 test "get" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -73,7 +89,7 @@ test "get" {
 
 ///|
 test "at" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   assert_eq(m["a"], 1)
@@ -82,7 +98,7 @@ test "at" {
 
 ///|
 test "get_or_default" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -94,7 +110,7 @@ test "get_or_default" {
 
 ///|
 test "get_or_init" {
-  let m : Map[String, Array[Int]] = Map::new()
+  let m : Map[String, Array[Int]] = Map([])
   m.get_or_init("a", () => Array::new()).push(1)
   m.get_or_init("b", () => Array::new()).push(2)
   m.get_or_init("a", () => Array::new()).push(3)
@@ -105,7 +121,7 @@ test "get_or_init" {
 
 ///|
 test "get_or_init on push_back" {
-  let m : Map[MyString, Array[Int]] = Map::new(capacity=4)
+  let m : Map[MyString, Array[Int]] = Map([], capacity=4)
   inspect(m.grow_at, content="3")
   m.set("x", Array::new())
   m.set("xx", Array::new())
@@ -116,7 +132,7 @@ test "get_or_init on push_back" {
 
 ///|
 test "get_or_init full" {
-  let m = Map::new(capacity=2)
+  let m = Map([], capacity=2)
   m.get_or_init("a", () => 0) |> ignore
   m.get_or_init("b", () => 0) |> ignore
   m.get_or_init("c", () => 0) |> ignore
@@ -125,7 +141,7 @@ test "get_or_init full" {
 
 ///|
 test "Map::set" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m["a"] = 1
   m["b"] = 2
   assert_true(m.get("a") == Some(1))
@@ -134,7 +150,7 @@ test "Map::set" {
 
 ///|
 test "panic get" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m["c"] |> ignore
@@ -142,7 +158,7 @@ test "panic get" {
 
 ///|
 test "set_update" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   assert_true(m.get("a") == Some(1))
@@ -152,7 +168,7 @@ test "set_update" {
 
 ///|
 test "contains" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   assert_eq(m.contains("a"), true)
   assert_eq(m.contains("b"), false)
@@ -168,7 +184,7 @@ test "from_array" {
 
 ///|
 test "length" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   assert_eq(m.length(), 0)
   m.set("a", 1)
   assert_eq(m.length(), 1)
@@ -176,7 +192,7 @@ test "length" {
 
 ///|
 test "size" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   assert_eq(m.size, 0)
   m.set("a", 1)
   assert_eq(m.size, 1)
@@ -184,7 +200,7 @@ test "size" {
 
 ///|
 test "is_empty" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   assert_eq(m.is_empty(), true)
   m.set("a", 1)
   assert_eq(m.is_empty(), false)
@@ -230,7 +246,7 @@ test "clear" {
 
 ///|
 test "grow" {
-  let m : Map[MyString, Int] = Map::new()
+  let m : Map[MyString, Int] = Map([])
   m.set("C", 1)
   m.set("Go", 2)
   m.set("C++", 3)
@@ -348,7 +364,7 @@ test "to_array" {
       #|[(1, "one"), (2, "two"), (3, "three")]
     ),
   )
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -368,7 +384,7 @@ test "set_existing_key" {
 
 ///|
 test "get_nonexistent_key" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -377,7 +393,7 @@ test "get_nonexistent_key" {
 
 ///|
 test "get_or_default_existing_key" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -386,7 +402,7 @@ test "get_or_default_existing_key" {
 
 ///|
 test "get_or_default_nonexistent_key" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -395,7 +411,7 @@ test "get_or_default_nonexistent_key" {
 
 ///|
 test "remove_existing_key" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -406,7 +422,7 @@ test "remove_existing_key" {
 
 ///|
 test "remove_nonexistent_key" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -416,7 +432,7 @@ test "remove_nonexistent_key" {
 
 ///|
 test "contains_existing_key" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -425,7 +441,7 @@ test "contains_existing_key" {
 
 ///|
 test "contains_nonexistent_key" {
-  let m : Map[String, Int] = Map::new()
+  let m : Map[String, Int] = Map([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -434,7 +450,7 @@ test "contains_nonexistent_key" {
 
 ///|
 test "equal_1" {
-  let m1 : Map[String, Int] = Map::new()
+  let m1 : Map[String, Int] = Map([])
   m1.set("a", 1)
   m1.set("b", 2)
   m1.set("c", 3)
@@ -477,7 +493,7 @@ test "to_string" {
 
 ///|
 test "hash collision" {
-  let m : Map[MyString, Int] = Map::new()
+  let m : Map[MyString, Int] = Map([])
   m.set("a", 1)
   m.set("ab", 2)
   m.set("abc", 3)
@@ -486,7 +502,7 @@ test "hash collision" {
 
 ///|
 test "remove" {
-  let m : Map[MyString, Int] = Map::new()
+  let m : Map[MyString, Int] = Map([])
   m.set("a", 1)
   m.set("ab", 2)
   m.set("bc", 2)
@@ -508,7 +524,7 @@ test "remove" {
 
 ///|
 test "remove_unexist_key" {
-  let m : Map[MyString, Int] = Map::new()
+  let m : Map[MyString, Int] = Map([])
   m.set("a", 1)
   m.set("ab", 2)
   m.set("abc", 3)
@@ -519,7 +535,7 @@ test "remove_unexist_key" {
 
 ///|
 test "insert_entry_panic" {
-  let map = Map::new(capacity=1)
+  let map = Map([], capacity=1)
   map.set(1, 1)
   // This should trigger the panic in insert_entry
   map.set(2, 2)
@@ -527,7 +543,7 @@ test "insert_entry_panic" {
 
 ///|
 test "get_entry_none" {
-  let map = Map::new(capacity=1)
+  let map = Map([], capacity=1)
   map.set(1, 1)
   // This should return None as the key 2 is not in the map
   let result = map.get(2)
@@ -536,7 +552,7 @@ test "get_entry_none" {
 
 ///|
 test "remove_entry_head" {
-  let map = Map::new(capacity=2)
+  let map = Map([], capacity=2)
   map.set(1, 1)
   map.set(2, 2)
   map.remove(1)
@@ -553,7 +569,7 @@ test "remove_entry_head" {
 
 ///|
 test "remove_entry_tail" {
-  let map = Map::new(capacity=2)
+  let map = Map([], capacity=2)
   map.set(1, 1)
   map.set(2, 2)
   map.remove(2)
@@ -571,8 +587,8 @@ test "remove_entry_tail" {
 
 ///|
 test "equal_size_mismatch" {
-  let map1 = Map::new(capacity=1)
-  let map2 = Map::new(capacity=2)
+  let map1 = Map([], capacity=1)
+  let map2 = Map([], capacity=2)
   map1.set(1, 1)
   map2.set(1, 1)
   map2.set(2, 2)
@@ -582,8 +598,8 @@ test "equal_size_mismatch" {
 
 ///|
 test "equal_key_value_mismatch" {
-  let map1 = Map::new(capacity=2)
-  let map2 = Map::new(capacity=2)
+  let map1 = Map([], capacity=2)
+  let map2 = Map([], capacity=2)
   map1.set(1, 1)
   map1.set(2, 2)
   map2.set(1, 1)

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -360,7 +360,7 @@ pub struct Map[K, V] {
   // private fields
 }
 #alias(from_array)
-pub fn[K : Hash + Eq, V] Map::Map(ArrayView[(K, V)]) -> Self[K, V]
+pub fn[K : Hash + Eq, V] Map::Map(ArrayView[(K, V)], capacity? : Int) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] Map::at(Self[K, V], K) -> V
 pub fn[K, V] Map::capacity(Self[K, V]) -> Int
@@ -389,6 +389,7 @@ pub fn[K, V] Map::length(Self[K, V]) -> Int
 pub fn[K, V, V2] Map::map(Self[K, V], (K, V) -> V2) -> Self[K, V2]
 pub fn[K : Eq, V] Map::merge(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K : Eq, V] Map::merge_in_place(Self[K, V], Self[K, V]) -> Unit
+#deprecated
 pub fn[K, V] Map::new(capacity? : Int) -> Self[K, V]
 pub fn[K : Hash + Eq, V] Map::of(FixedArray[(K, V)]) -> Self[K, V]
 pub fn[K : Hash + Eq, V] Map::remove(Self[K, V], K) -> Unit

--- a/hashmap/json.mbt
+++ b/hashmap/json.mbt
@@ -14,7 +14,7 @@
 
 ///|
 pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V] with to_json(self) {
-  let object = Map::new(capacity=self.capacity)
+  let object = Map([], capacity=self.capacity)
   for k, v in self {
     object[k.to_string()] = v.to_json()
   }

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -81,8 +81,8 @@ pub impl[K : Show, V : Show] Show for SortedMap[K, V] with output(self, logger) 
 ///|
 pub impl[K : Show, V : ToJson] ToJson for SortedMap[K, V] with to_json(self) {
   let capacity = self.length()
-  guard capacity != 0 else { return Json::object(Map::new()) }
-  let jsons = Map::new(capacity~)
+  guard capacity != 0 else { return Json::object(Map([])) }
+  let jsons = Map([], capacity~)
   self.each((k, v) => jsons[k.to_string()] = v.to_json())
   Json::object(jsons)
 }

--- a/json/json_traverse_test.mbt
+++ b/json/json_traverse_test.mbt
@@ -32,7 +32,7 @@
 //       let m1 = m.remove_key("loc");
 
 //       // 2) prune children, dropping empties
-//       let m2 = Map::new();
+//       let m2 = Map([]);
 //       for (k, child) in m1 {
 //         match prune_loc(child) {
 //           Some(c2) => m2.insert(k, c2),
@@ -60,7 +60,7 @@ fn Json::prune_loc(self : Json) -> Json? {
     }
     Object(obj) => {
       // 1) create a new map without "loc" key
-      let new_obj = Map::new()
+      let new_obj = Map([])
 
       // 2) iterate through all keys except "loc"
       for key, value in obj {
@@ -128,7 +128,7 @@ test "prune_loc - arrays" {
 ///|
 test "prune_loc - objects without loc" {
   // Empty object
-  debug_inspect(Json::object(Map::new()).prune_loc(), content="None")
+  debug_inspect(Json::object(Map([])).prune_loc(), content="None")
 
   // Object with no "loc" key
   let obj1 : Json = { "name": Json::string("John"), "age": Json::number(30.0) }

--- a/json/parse.mbt
+++ b/json/parse.mbt
@@ -69,7 +69,7 @@ fn ParseContext::parse_object(ctx : ParseContext) -> Json raise ParseError {
     raise DepthLimitExceeded
   }
   ctx.remaining_available_depth -= 1
-  let map = Map::new()
+  let map = Map([])
   for x = ctx.lex_property_name() {
     match x {
       RBrace => {

--- a/set/README.mbt.md
+++ b/set/README.mbt.md
@@ -10,12 +10,12 @@ There are several ways to create sets:
 ///|
 test "creating sets" {
   // Empty set
-  let empty_set : @set.Set[Int] = @set.Set::new()
+  let empty_set : @set.Set[Int] = @set.Set([])
   inspect(empty_set.length(), content="0")
   inspect(empty_set.is_empty(), content="true")
 
   // Set with initial capacity
-  let set_with_capacity : @set.Set[Int] = @set.Set::new(capacity=16)
+  let set_with_capacity : @set.Set[Int] = @set.Set([], capacity=16)
   inspect(set_with_capacity.capacity(), content="16")
 
   // From array
@@ -39,7 +39,7 @@ Add, remove, and check membership:
 ```mbt check
 ///|
 test "basic operations" {
-  let set = @set.Set::new()
+  let set = @set.Set([])
 
   // Adding elements
   set.add("apple")
@@ -264,7 +264,7 @@ Demonstrate efficient operations:
 ///|
 test "performance examples" {
   // Large set operations
-  let large_set = @set.Set::new(capacity=1000)
+  let large_set = @set.Set([], capacity=1000)
 
   // Add many elements
   for i in 0..<100 {
@@ -277,7 +277,7 @@ test "performance examples" {
   inspect(large_set.contains(150), content="false")
 
   // Efficient set operations on large sets
-  let another_set = @set.Set::new()
+  let another_set = @set.Set([])
   for i in 50..<150 {
     another_set.add(i)
   }
@@ -306,7 +306,7 @@ Sets are particularly useful for:
 
 ## Best Practices
 
-1. **Pre-size when possible**: Use `@set.Set::new(capacity=n)` if you know the approximate size
+1. **Pre-size when possible**: Use `@set.Set([], capacity=n)` if you know the approximate size
 2. **Use appropriate types**: Ensure your key type has good `Hash` and `Eq` implementations
 3. **Prefer set operations**: Use built-in union, intersection, etc. instead of manual loops
 4. **Check return values**: Use `add_and_check` and `remove_and_check` when you need to know if the operation succeeded

--- a/set/deprecated.mbt
+++ b/set/deprecated.mbt
@@ -11,3 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+///|
+/// Creates an empty insertion-ordered hash set with an optional initial capacity.
+///
+/// Deprecated: use `Set([], capacity=...)` instead.
+#deprecated("Use `Set([], capacity=...)` instead")
+#as_free_fn(deprecated="Use `Set([], capacity=...)` instead")
+pub fn[K] Set::new(capacity? : Int = default_init_capacity) -> Set[K] {
+  new_set(capacity)
+}

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -51,11 +51,10 @@ struct Set[K] {
 // Implementations
 
 ///|
-/// Creates an empty insertion-ordered hash set with an optional initial capacity.
-/// The capacity will be rounded up to the smallest power of 2 that is
-/// greater than or equal to the provided `capacity`.
-#as_free_fn
-pub fn[K] Set::new(capacity? : Int = 8) -> Set[K] {
+let default_init_capacity = 8
+
+///|
+fn[K] new_set(capacity : Int) -> Set[K] {
   let capacity = capacity.next_power_of_two()
   {
     size: 0,
@@ -69,18 +68,34 @@ pub fn[K] Set::new(capacity? : Int = 8) -> Set[K] {
 }
 
 ///|
-/// Creates a hash set containing all elements from the given array, preserving insertion order.
-#alias(from_array)
-#as_free_fn(from_array)
-#alias(of, deprecated="Use from_array instead")
-#as_free_fn(of, deprecated="Use from_array instead")
-pub fn[K : Hash + Eq] Set::Set(arr : ArrayView[K]) -> Set[K] {
-  let length = arr.length()
+fn capacity_for_length(length : Int) -> Int {
   let mut capacity = length.next_power_of_two()
   if length > calc_grow_threshold(capacity) {
     capacity *= 2
   }
-  let m = Set::new(capacity~)
+  capacity
+}
+
+///|
+/// Creates a hash set containing all elements from the given array, preserving insertion order.
+/// The optional `capacity` is treated as a minimum initial capacity and will be
+/// rounded up to the smallest power of 2 that can hold the requested capacity.
+#alias(from_array)
+#as_free_fn(from_array)
+#alias(of, deprecated="Use from_array instead")
+#as_free_fn(of, deprecated="Use from_array instead")
+pub fn[K : Hash + Eq] Set::Set(arr : ArrayView[K], capacity? : Int) -> Set[K] {
+  let length = arr.length()
+  let capacity = match capacity {
+    Some(capacity) => capacity.max(capacity_for_length(length))
+    None =>
+      if length == 0 {
+        default_init_capacity
+      } else {
+        capacity_for_length(length)
+      }
+  }
+  let m = new_set(capacity)
   // arr.each(e => m.add(e))
   // FIXME:(upstream)
   // ArrayView::each depends on array package
@@ -104,7 +119,7 @@ pub fn[K : Hash + Eq] Set::Set(arr : ArrayView[K]) -> Set[K] {
 ///
 /// ```mbt check
 /// test {
-///   let set : @set.Set[String] = @set.Set::new()
+///   let set : @set.Set[String] = @set.Set([])
 ///   set.add("key")
 ///   inspect(set.contains("key"), content="true")
 ///   set.add("key") // no effect since it already exists
@@ -187,7 +202,7 @@ fn[K] Set::set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let set : @set.Set[String] = @set.Set::new()
+///   let set : @set.Set[String] = @set.Set([])
 ///   inspect(set.add_and_check("key"), content="true") // First insertion
 ///   inspect(set.add_and_check("key"), content="false") // Already exists
 ///   inspect(set.length(), content="1")
@@ -505,7 +520,7 @@ pub impl[K : Hash + Eq] Eq for Set[K] with equal(self, other) {
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 pub fn[K : Hash + Eq] Set::from_iter(iter : Iter[K]) -> Set[K] {
-  let m = Set::new()
+  let m = new_set(default_init_capacity)
   while iter.next() is Some(e) {
     m.add(e)
   }
@@ -514,7 +529,7 @@ pub fn[K : Hash + Eq] Set::from_iter(iter : Iter[K]) -> Set[K] {
 
 ///|
 pub impl[K] Default for Set[K] with default() {
-  Set::new()
+  new_set(default_init_capacity)
 }
 
 ///|
@@ -555,7 +570,7 @@ pub fn[K] Set::copy(self : Set[K]) -> Set[K] {
 ///|
 /// Returns a new set containing elements in `self` that are not in `other`.
 pub fn[K : Hash + Eq] Set::difference(self : Set[K], other : Set[K]) -> Set[K] {
-  let m = Set::new()
+  let m = new_set(default_init_capacity)
   self.each(k => if !other.contains(k) { m.add(k) })
   m
 }
@@ -566,7 +581,7 @@ pub fn[K : Hash + Eq] Set::symmetric_difference(
   self : Set[K],
   other : Set[K],
 ) -> Set[K] {
-  let m = Set::new()
+  let m = new_set(default_init_capacity)
   self.each(k => if !other.contains(k) { m.add(k) })
   other.each(k => if !self.contains(k) { m.add(k) })
   m
@@ -575,7 +590,7 @@ pub fn[K : Hash + Eq] Set::symmetric_difference(
 ///|
 /// Returns a new set containing all elements from both sets.
 pub fn[K : Hash + Eq] Set::union(self : Set[K], other : Set[K]) -> Set[K] {
-  let m = Set::new()
+  let m = new_set(default_init_capacity)
   self.each(k => m.add(k))
   other.each(k => m.add(k))
   m
@@ -587,7 +602,7 @@ pub fn[K : Hash + Eq] Set::intersection(
   self : Set[K],
   other : Set[K],
 ) -> Set[K] {
-  let m = Set::new()
+  let m = new_set(default_init_capacity)
   self.each(k => if other.contains(k) { m.add(k) })
   m
 }

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -32,10 +32,23 @@ impl Hash for Key with hash(self) {
 }
 
 ///|
-test "new" {
-  let m : @set.Set[Int] = @set.Set::new()
+test "empty constructor" {
+  let m : @set.Set[Int] = @set.Set([])
   assert_eq(m.capacity(), default_init_capacity)
   assert_eq(m.length(), 0)
+}
+
+///|
+test "constructor capacity" {
+  let empty : @set.Set[Int] = @set.Set([], capacity=16)
+  assert_eq(empty.capacity(), 16)
+  assert_eq(empty.length(), 0)
+  let below_length = @set.Set([1, 2, 3], capacity=2)
+  assert_eq(below_length.capacity(), 4)
+  assert_eq(below_length.length(), 3)
+  let above_length = @set.Set([1, 2, 3], capacity=16)
+  assert_eq(above_length.capacity(), 16)
+  inspect(above_length.to_array(), content="[1, 2, 3]")
 }
 
 ///|
@@ -46,14 +59,14 @@ test "default" {
 
 ///|
 test "copy empty" {
-  let m : @set.Set[Int] = @set.Set::new()
+  let m : @set.Set[Int] = @set.Set([])
   let copied = m.copy()
   inspect(copied.length(), content="0")
 }
 
 ///|
 test "insert" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   m.add("a")
   m.add("b")
   m.add("c")
@@ -65,7 +78,7 @@ test "insert" {
 
 ///|
 test "add remove" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   m.add("a")
   m.add("b")
   m.add("c")
@@ -101,7 +114,7 @@ test "from_array" {
 
 ///|
 test "size" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   assert_eq(m.length(), 0)
   m.add("a")
   assert_eq(m.length(), 1)
@@ -109,7 +122,7 @@ test "size" {
 
 ///|
 test "is_empty" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   assert_eq(m.is_empty(), true)
   m.add("a")
   assert_eq(m.is_empty(), false)
@@ -133,7 +146,7 @@ test "is_disjoint detects overlap in else branch" {
 
 ///|
 test "remove stops on shorter probe" {
-  let set : @set.Set[Key] = @set.Set::new()
+  let set : @set.Set[Key] = @set.Set([])
   set.add({ id: 1, hash_value: 0 })
   set.add({ id: 2, hash_value: 1 })
   set.remove({ id: 3, hash_value: 0 })
@@ -222,7 +235,7 @@ test "symmetric_difference" {
 
 ///|
 test "insert_and_grow" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   for i in 0..<10 {
     m.add(i.to_string())
   }
@@ -244,7 +257,7 @@ test "array unique via Set" {
 
 ///|
 test "remove_and_shift_back" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   m.add("a")
   m.add("b")
   m.add("c")
@@ -258,7 +271,7 @@ test "remove_and_shift_back" {
 
 ///|
 test "capacity_and_size" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   assert_eq(m.capacity(), default_init_capacity)
   assert_eq(m.length(), 0)
   m.add("a")
@@ -267,7 +280,7 @@ test "capacity_and_size" {
 
 ///|
 test "clear_and_reinsert" {
-  let m = @set.Set::new()
+  let m = @set.Set([])
   m.add("a")
   m.add("b")
   m.clear()
@@ -295,7 +308,7 @@ test "from_iter empty iter" {
 
 ///|
 test "remove item causes break when psl < i" {
-  let set = @set.Set::new()
+  let set = @set.Set([])
   set.add(1)
   set.add(11) // This goes to a different bucket due to hash collision
   set.remove(21) // Key doesn't exist, will cause psl < i and break
@@ -304,12 +317,12 @@ test "remove item causes break when psl < i" {
 
 ///|
 test "to_array_empty" {
-  inspect((@set.Set::new() : @set.Set[Int]).to_array(), content="[]")
+  inspect((@set.Set([]) : @set.Set[Int]).to_array(), content="[]")
 }
 
 ///|
 test "to_array_non_empty" {
-  let set = @set.Set::new()
+  let set = @set.Set([])
   set.add(1)
   set.add(2)
   set.add(3)
@@ -318,44 +331,44 @@ test "to_array_non_empty" {
 
 ///|
 test "equal: different size" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add(1)
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   inspect(set1 == set2, content="false")
 }
 
 ///|
 test "equal: different keys" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add(1)
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   set2.add(2)
   inspect(set1 == set2, content="false")
 }
 
 ///|
 test "equal: same sets" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add(1)
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   set2.add(1)
   inspect(set1 == set2, content="true")
 }
 
 ///|
 test "equal: empty sets" {
-  let set1 : @set.Set[Int] = @set.Set::new()
-  let set2 : @set.Set[Int] = @set.Set::new()
+  let set1 : @set.Set[Int] = @set.Set([])
+  let set2 : @set.Set[Int] = @set.Set([])
   inspect(set1 == set2, content="true")
 }
 
 ///|
 test "equal: same elements different order" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add(1)
   set1.add(2)
   set1.add(3)
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   set2.add(3)
   set2.add(2)
   set2.add(1)
@@ -364,11 +377,11 @@ test "equal: same elements different order" {
 
 ///|
 test "equal: subset" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add(1)
   set1.add(2)
   set1.add(3)
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   set2.add(1)
   set2.add(2)
   inspect(set1 == set2, content="false")
@@ -377,8 +390,8 @@ test "equal: subset" {
 
 ///|
 test "equal: large sets" {
-  let set1 = @set.Set::new()
-  let set2 = @set.Set::new()
+  let set1 = @set.Set([])
+  let set2 = @set.Set([])
   for i in 0..<100 {
     set1.add(i)
     set2.add(i)
@@ -388,8 +401,8 @@ test "equal: large sets" {
 
 ///|
 test "equal: large sets with one difference" {
-  let set1 = @set.Set::new()
-  let set2 = @set.Set::new()
+  let set1 = @set.Set([])
+  let set2 = @set.Set([])
   for i in 0..<100 {
     set1.add(i)
     if i != 50 {
@@ -403,11 +416,11 @@ test "equal: large sets with one difference" {
 
 ///|
 test "equal: after removal" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add(1)
   set1.add(2)
   set1.add(3)
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   set2.add(1)
   set2.add(2)
   set2.add(3)
@@ -419,11 +432,11 @@ test "equal: after removal" {
 
 ///|
 test "equal: after clear" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add(1)
   set1.add(2)
   set1.add(3)
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   inspect(set1 == set2, content="false")
   set1.clear()
   inspect(set1 == set2, content="true")
@@ -431,11 +444,11 @@ test "equal: after clear" {
 
 ///|
 test "equal: with string elements" {
-  let set1 = @set.Set::new()
+  let set1 = @set.Set([])
   set1.add("apple")
   set1.add("banana")
   set1.add("cherry")
-  let set2 = @set.Set::new()
+  let set2 = @set.Set([])
   set2.add("apple")
   set2.add("banana")
   set2.add("cherry")
@@ -446,7 +459,7 @@ test "equal: with string elements" {
 
 ///|
 test "equal: reflexivity" {
-  let set = @set.Set::new()
+  let set = @set.Set([])
   set.add(1)
   set.add(2)
   set.add(3)
@@ -456,12 +469,12 @@ test "equal: reflexivity" {
 ///|
 test "remove_and_check when key not found in empty slot" {
   // Try to remove from empty set
-  inspect(@set.Set::new().remove_and_check(1), content="false")
+  inspect(@set.Set([]).remove_and_check(1), content="false")
 }
 
 ///|
 test "trigger grow" {
-  let set = @set.Set::new(capacity=2)
+  let set = @set.Set([], capacity=2)
   for i in 0..<10 {
     assert_true(set.add_and_check(i))
   }

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -17,7 +17,7 @@ pub struct Set[K] {
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
-pub fn[K : Hash + Eq] Set::Set(ArrayView[K]) -> Self[K]
+pub fn[K : Hash + Eq] Set::Set(ArrayView[K], capacity? : Int) -> Self[K]
 #alias(insert, deprecated)
 pub fn[K : Hash + Eq] Set::add(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] Set::add_and_check(Self[K], K) -> Bool
@@ -42,7 +42,8 @@ pub fn[K : Hash + Eq] Set::is_superset(Self[K], Self[K]) -> Bool
 pub fn[K] Set::iter(Self[K]) -> Iter[K]
 #alias(size, deprecated)
 pub fn[K] Set::length(Self[K]) -> Int
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[K] Set::new(capacity? : Int) -> Self[K]
 pub fn[K : Hash + Eq] Set::remove(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] Set::remove_and_check(Self[K], K) -> Bool

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -68,8 +68,8 @@ pub impl[K : Show, V : Show] Show for SortedMap[K, V] with output(self, logger) 
 ///|
 pub impl[K : Show, V : ToJson] ToJson for SortedMap[K, V] with to_json(self) {
   let capacity = self.length()
-  guard capacity != 0 else { return Json::object(Map::new()) }
-  let jsons = Map::new(capacity~)
+  guard capacity != 0 else { return Json::object(Map([])) }
+  let jsons = Map([], capacity~)
   self.each((k, v) => jsons[k.to_string()] = v.to_json())
   Json::object(jsons)
 }


### PR DESCRIPTION
## Summary

- Add `capacity?` to `Set::Set` and `Map::Map`, so `Set([], capacity=n)` and `Map([], capacity=n)` can replace the old empty constructors.
- Move `Set::new` and `Map::new` to deprecated definitions that forward to private helpers.
- Update internal call sites, docs, tests, and generated interfaces to prefer `Set([])` / `Map([])`.

## Constructor inventory

Checked with `moon ide doc '*::new'`. The direct same-shape candidates are the mutable hash collections with array constructors and `capacity?` on `new`; this PR handles the requested `Set` and `Map` changes and leaves wider collection API cleanup for follow-up.

## Validation

- `moon test builtin && moon test set && moon test argparse && moon test json && moon test sorted_map && moon test immut/sorted_map && moon test hashmap`
- `moon info && moon fmt`
- `moon check && moon test`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
