### PR TITLE
Deprecate remaining collection new constructors

### DIFF
--- a/bytes/internal/regex_engine/regex.mbt
+++ b/bytes/internal/regex_engine/regex.mbt
@@ -48,7 +48,7 @@ fn Regex::new(
     symbol_table,
     symbol_repr,
     start_states: [],
-    state_table: @hashmap.HashMap::new(),
+    state_table: @hashmap.HashMap([]),
     states: [],
   }
 }

--- a/bytes/internal/regex_engine/symbol_map/symbol_map.mbt
+++ b/bytes/internal/regex_engine/symbol_map/symbol_map.mbt
@@ -18,7 +18,7 @@ struct SymbolMap(@sorted_set.SortedSet[@shared_types.Rechar])
 ///|
 /// Create a new instance.
 pub fn new() -> SymbolMap {
-  SymbolMap(@sorted_set.new())
+  SymbolMap(@sorted_set.SortedSet([]))
 }
 
 ///|

--- a/deque/README.mbt.md
+++ b/deque/README.mbt.md
@@ -6,12 +6,12 @@ A double-ended queue backed by a growable ring buffer. Supports O(1) amortized p
 
 ## Create
 
-Create an empty deque with `new()`, or construct one from an array or iterator.
+Create an empty deque with `Deque([])`, or construct one from an array or iterator.
 
 ```mbt check
 ///|
 test {
-  let dv : @deque.Deque[Int] = @deque.new()
+  let dv : @deque.Deque[Int] = @deque.Deque([])
   assert_eq(dv.is_empty(), true)
   let dv2 = @deque.from_array([1, 2, 3, 4, 5])
   assert_eq(dv2.length(), 5)
@@ -25,7 +25,7 @@ Pre-allocate capacity to avoid resizing:
 ```mbt check
 ///|
 test {
-  let dv : @deque.Deque[Int] = @deque.new(capacity=1024)
+  let dv : @deque.Deque[Int] = @deque.Deque([], capacity=1024)
   assert_eq(dv.capacity(), 1024)
 }
 ```

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -16,30 +16,7 @@
 fn[T] set_null(buffer : UninitializedArray[T], index : Int) = "%fixedarray.set_null"
 
 ///|
-/// Creates a new empty deque with an optional initial capacity.
-///
-/// Parameters:
-///
-/// * `capacity` : The initial capacity of the deque. If not specified, defaults
-/// to 0 and will be automatically adjusted as elements are added.
-///
-/// Returns a new empty deque of type `T[A]` where `A` is the type of elements
-/// the deque will hold.
-///
-///# Example
-///
-/// ```mbt check
-/// test {
-///   let dq : @deque.Deque[Int] = @deque.new()
-///   inspect(dq.length(), content="0")
-///   inspect(dq.capacity(), content="0")
-///   let dq : @deque.Deque[Int] = @deque.new(capacity=10)
-///   inspect(dq.length(), content="0")
-///   inspect(dq.capacity(), content="10")
-/// }
-/// ```
-#as_free_fn
-pub fn[A] Deque::new(capacity? : Int = 0) -> Deque[A] {
+fn[A] new_deque(capacity : Int) -> Deque[A] {
   Deque::{ buf: UninitializedArray::make(capacity), len: 0, head: 0 }
 }
 
@@ -146,8 +123,8 @@ pub impl[A] Add for Deque[A] with add(self, other) {
 ///|
 /// Test add (operator +) with empty deques creates valid empty deque.
 test "add_empty" {
-  let empty1 : Deque[Int] = new()
-  let empty2 : Deque[Int] = new()
+  let empty1 : Deque[Int] = new_deque(0)
+  let empty2 : Deque[Int] = new_deque(0)
   let result = empty1 + empty2
   inspect(result.len, content="0")
   inspect(result.is_empty(), content="true")
@@ -155,6 +132,7 @@ test "add_empty" {
 
 ///|
 /// Creates a new deque with elements copied from an array.
+/// The optional `capacity` is treated as a minimum initial capacity.
 ///
 /// Parameters:
 ///
@@ -176,9 +154,13 @@ test "add_empty" {
 #as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[A] Deque::Deque(arr : ArrayView[A]) -> Deque[A] {
+pub fn[A] Deque::Deque(arr : ArrayView[A], capacity? : Int) -> Deque[A] {
   let len = arr.length()
-  let buf = UninitializedArray::make(len)
+  let capacity = match capacity {
+    Some(capacity) => capacity.max(len)
+    None => len
+  }
+  let buf = UninitializedArray::make(capacity)
   for i, x in arr {
     buf[i] = x
   }
@@ -529,7 +511,7 @@ pub fn[A] Deque::length(self : Deque[A]) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let dq = @deque.new(capacity=10)
+///   let dq = @deque.Deque([], capacity=10)
 ///   dq.push_back(1)
 ///   dq.push_back(2)
 ///   inspect(dq.capacity(), content="10")
@@ -660,7 +642,7 @@ pub fn[A] Deque::unsafe_pop_front(self : Deque[A]) -> Unit {
 
 ///|
 test "unsafe_pop_front after many push_front" {
-  let dq = new()
+  let dq = new_deque(0)
   for i in 0..<10 {
     dq.push_front(i)
   }
@@ -1016,7 +998,7 @@ pub fn[A] Deque::clear(self : Deque[A]) -> Unit {
 pub fn[A, U] Deque::map(self : Deque[A], f : (A) -> U) -> Deque[U] {
   let cap = self.buf.length()
   if self.len == 0 {
-    new()
+    new_deque(0)
   } else {
     let buf : UninitializedArray[U] = UninitializedArray::make(self.len)
     for i in 0..<self.len {
@@ -1041,7 +1023,7 @@ pub fn[A, U] Deque::map(self : Deque[A], f : (A) -> U) -> Deque[U] {
 pub fn[A, U] Deque::mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
   let cap = self.buf.length()
   if self.len == 0 {
-    new()
+    new_deque(0)
   } else {
     let buf : UninitializedArray[U] = UninitializedArray::make(self.len)
     for i in 0..<self.len {
@@ -1058,7 +1040,7 @@ pub fn[A, U] Deque::mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
 /// # Example
 /// ```mbt check
 /// test {
-///   let dv = @deque.new()
+///   let dv = @deque.Deque([])
 ///   inspect(dv.is_empty(), content="true")
 ///   dv.push_back(1)
 ///   inspect(dv.is_empty(), content="false")
@@ -1244,7 +1226,7 @@ pub fn[A] Deque::reserve_capacity(self : Deque[A], capacity : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let dv = @deque.new(capacity=10)
+///   let dv = @deque.Deque([], capacity=10)
 ///   dv.push_back(1)
 ///   dv.push_back(2)
 ///   dv.push_back(3)
@@ -1590,7 +1572,7 @@ pub fn[A] Deque::rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 pub fn[A] Deque::from_iter(iter : Iter[A]) -> Deque[A] {
-  let dq = new()
+  let dq = new_deque(0)
   while iter.next() is Some(e) {
     dq.push_back(e)
   }
@@ -1754,7 +1736,7 @@ pub fn[A] Deque::chunks(self : Deque[A], size : Int) -> Deque[Deque[A]] {
   guard size > 0
   let chunks = from_array([])
   for i = 0; i < self.length(); {
-    let chunk = Deque::new(capacity=size)
+    let chunk = Deque([], capacity=size)
     let i = for _ in 0..<size; i = i {
       if i >= self.length() {
         break i
@@ -1918,7 +1900,7 @@ pub fn[A] Deque::drain(self : Deque[A], start~ : Int, len? : Int) -> Deque[A] {
     None => self.len - start
   }
   if len == 0 {
-    return new()
+    return new_deque(0)
   }
   // Prepare deque to return
   let deque = Deque::{ buf: UninitializedArray::make(len), len, head: 0 }
@@ -2021,7 +2003,7 @@ pub fn[A] Deque::drain(self : Deque[A], start~ : Int, len? : Int) -> Deque[A] {
 
 ///|
 test "weird behavior after drain" {
-  let deque = new(capacity=16)
+  let deque = new_deque(16)
   deque.push_back(1)
   deque.push_back(2)
   deque.push_back(3)
@@ -2268,7 +2250,7 @@ pub impl[A : Compare] Compare for Deque[A] with compare(self, other) {
 ///   let dq = @deque.from_array([1, 2, 3, 4, 5])
 ///   dq.rev_in_place()
 ///   inspect(dq, content="@deque.from_array([5, 4, 3, 2, 1])")
-///   let dq : @deque.Deque[Int] = @deque.new()
+///   let dq : @deque.Deque[Int] = @deque.Deque([])
 ///   dq.rev_in_place()
 ///   inspect(dq, content="@deque.from_array([])")
 /// }

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -126,22 +126,22 @@ test "iter" {
 ///|
 test "reserve and push" {
   // capacity > 0, len = 0
-  let a = @deque.new(capacity=2)
+  let a = @deque.Deque([], capacity=2)
   a.push_back(Option::Some(1))
   debug_inspect(a.front(), content="Some(Some(1))")
   debug_inspect(a.back(), content="Some(Some(1))")
   // capacity = 0, len = 0
-  let b = @deque.new(capacity=0)
+  let b = @deque.Deque([], capacity=0)
   b.push_back(Option::Some(1))
   debug_inspect(b.front(), content="Some(Some(1))")
   debug_inspect(b.back(), content="Some(Some(1))")
   // capacity > 0, len = 0
-  let c = @deque.new(capacity=2)
+  let c = @deque.Deque([], capacity=2)
   c.push_front(Option::Some(1))
   debug_inspect(c.front(), content="Some(Some(1))")
   debug_inspect(c.back(), content="Some(Some(1))")
   // capacity = 0, len = 0
-  let d = @deque.new(capacity=0)
+  let d = @deque.Deque([], capacity=0)
   d.push_front(Option::Some(1))
   debug_inspect(d.front(), content="Some(Some(1))")
   debug_inspect(d.back(), content="Some(Some(1))")
@@ -272,7 +272,7 @@ test "from_json rejects non-array" {
 ///|
 test "copy" {
   inspect(
-    (@deque.new() : @deque.Deque[Int]).copy(),
+    (@deque.Deque([]) : @deque.Deque[Int]).copy(),
     content="@deque.from_array([])",
   )
   let deq = @deque.from_array([1, 2, 3])
@@ -364,7 +364,7 @@ test "push_and_pop" {
 
 ///|
 test "is_empty" {
-  let dv = @deque.new()
+  let dv = @deque.Deque([])
   assert_true(dv.is_empty())
   dv.push_back(3)
   assert_false(dv.is_empty())
@@ -383,20 +383,20 @@ test "front_and_back" {
   let dv = @deque.from_array([1, 2, 3, 4, 5])
   assert_eq(dv.back(), Some(5))
   assert_eq(dv.front(), Some(1))
-  let dv : @deque.Deque[Int] = @deque.new()
+  let dv : @deque.Deque[Int] = @deque.Deque([])
   assert_eq(dv.back(), None)
   assert_eq(dv.front(), None)
 }
 
 ///|
 test "new_with_capacity" {
-  let d : @deque.Deque[Int] = @deque.new(capacity=0)
+  let d : @deque.Deque[Int] = @deque.Deque([], capacity=0)
   inspect(d.capacity(), content="0")
 }
 
 ///|
 test "new_with_capacity_non_zero" {
-  let d : @deque.Deque[Int] = @deque.new(capacity=10)
+  let d : @deque.Deque[Int] = @deque.Deque([], capacity=10)
   inspect(d.capacity(), content="10")
 }
 
@@ -422,11 +422,11 @@ test "realloc" {
 
 ///|
 test "push_realloc" {
-  let dv = @deque.new()
+  let dv = @deque.Deque([])
   dv.push_front(1)
   assert_eq(dv.pop_front(), Some(1))
   assert_true(dv.capacity() > 0)
-  let dv = @deque.new()
+  let dv = @deque.Deque([])
   dv.push_back(1)
   assert_eq(dv.pop_back(), Some(1))
   assert_true(dv.capacity() > 0)
@@ -435,22 +435,22 @@ test "push_realloc" {
 ///|
 test "reserve_and_push" {
   // capacity > 0, len = 0
-  let a = @deque.new(capacity=2)
+  let a = @deque.Deque([], capacity=2)
   a.push_back(Some(1))
   debug_inspect(a.front(), content="Some(Some(1))")
   debug_inspect(a.back(), content="Some(Some(1))")
   // capacity = 0, len = 0
-  let b = @deque.new(capacity=0)
+  let b = @deque.Deque([], capacity=0)
   b.push_back(Some(1))
   debug_inspect(b.front(), content="Some(Some(1))")
   debug_inspect(b.back(), content="Some(Some(1))")
   // capacity > 0, len = 0
-  let c = @deque.new(capacity=2)
+  let c = @deque.Deque([], capacity=2)
   c.push_front(Some(1))
   debug_inspect(c.front(), content="Some(Some(1))")
   debug_inspect(c.back(), content="Some(Some(1))")
   // capacity = 0, len = 0
-  let d = @deque.new(capacity=0)
+  let d = @deque.Deque([], capacity=0)
   d.push_front(Some(1))
   debug_inspect(d.front(), content="Some(Some(1))")
   debug_inspect(d.back(), content="Some(Some(1))")
@@ -486,7 +486,7 @@ test "from_array with single element" {
 
 ///|
 test "unsafe_pop_front after many push_front" {
-  let dq = @deque.new()
+  let dq = @deque.Deque([])
   // First fill some elements to create a buffer with some capacity
   for i in 0..<10 {
     dq.push_front(i)
@@ -504,7 +504,7 @@ test "unsafe_pop_front after many push_front" {
 
 ///|
 test "unsafe_pop_back when tail needs to wrap around" {
-  let dq = @deque.new(capacity=2)
+  let dq = @deque.Deque([], capacity=2)
   dq.push_back(1) // tail = 0
   dq.push_back(2) // tail = 1
   dq.unsafe_pop_front() // head = 1
@@ -515,7 +515,7 @@ test "unsafe_pop_back when tail needs to wrap around" {
 
 ///|
 test "deque Deque::set wrapping case" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   // Add elements until the deque wraps around
   dq.push_back(1) // head=0, tail=0
   dq.push_back(2) // head=0, tail=1
@@ -533,7 +533,7 @@ test "deque Deque::set wrapping case" {
 
 ///|
 test "iter when tail needs to wrap around" {
-  let dq = @deque.new(capacity=2)
+  let dq = @deque.Deque([], capacity=2)
   dq.push_back(1) // tail = 0
   dq.push_back(2) // tail = 1
   dq.unsafe_pop_front() // head = 1
@@ -545,7 +545,7 @@ test "iter when tail needs to wrap around" {
 
 ///|
 test "iter2 when tail needs to wrap around" {
-  let dq = @deque.new(capacity=2)
+  let dq = @deque.Deque([], capacity=2)
   dq.push_back(1) // tail = 0
   dq.push_back(2) // tail = 1
   dq.unsafe_pop_front() // head = 1
@@ -555,7 +555,7 @@ test "iter2 when tail needs to wrap around" {
 
 ///|
 test "rev_iter when head needs to wrap around" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(1)
   dq.unsafe_pop_front()
   dq.push_back(2)
@@ -568,7 +568,7 @@ test "rev_iter when head needs to wrap around" {
 
 ///|
 test "rev_iter2 when head needs to wrap around" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(1)
   dq.unsafe_pop_front()
   dq.push_back(2)
@@ -620,7 +620,7 @@ test "deque push_back when empty" {
 ///|
 test "deque as_views" {
   // Test empty deque
-  let dq1 : @deque.Deque[Int] = @deque.new()
+  let dq1 : @deque.Deque[Int] = @deque.Deque([])
   @json.json_inspect(dq1.as_views(), content=[[], []])
 
   // Test contiguous case (head_len >= len)
@@ -640,7 +640,7 @@ test "deque as_views" {
 
 ///|
 test "test_get" {
-  let tester = @deque.new()
+  let tester = @deque.Deque([])
   tester.push_back(1)
   tester.push_back(2)
   tester.push_back(35)
@@ -656,7 +656,7 @@ test "test_get" {
 
 ///|
 test "test_reserve_capacity" {
-  let tester : @deque.Deque[Int] = @deque.new(capacity=1)
+  let tester : @deque.Deque[Int] = @deque.Deque([], capacity=1)
   inspect(tester.capacity(), content="1")
   tester.reserve_capacity(2)
   inspect(tester.capacity(), content="2")
@@ -680,7 +680,7 @@ test "test_reserve_capacity" {
 
 ///|
 test "test_contains" {
-  let tester = @deque.new()
+  let tester = @deque.Deque([])
   tester.push_back(1)
   tester.push_back(2)
   tester.push_back(3)
@@ -697,7 +697,7 @@ test "test_contains" {
 
 ///|
 test "test_shrink_to_fit" {
-  let tester = @deque.new(capacity=15)
+  let tester = @deque.Deque([], capacity=15)
   let cap = tester.capacity()
   tester.reserve_capacity(63)
   let max_cap = tester.capacity()
@@ -782,7 +782,7 @@ test "test_clone_from" {
 
 ///|
 test "deque guard iter coverage improvement" {
-  let dq = @deque.new(capacity=15)
+  let dq = @deque.Deque([], capacity=15)
   // Use push_front only
   fn test_n_via_push_front(n : Int) -> Unit raise {
     for i in 0..<=n {
@@ -816,7 +816,7 @@ test "deque guard iter coverage improvement" {
 
 ///|
 test "deque guard iter after push_front and push_back" {
-  let dq = @deque.new(capacity=15)
+  let dq = @deque.Deque([], capacity=15)
   for i in 0..<15 {
     dq.push_back(i)
   }
@@ -840,7 +840,7 @@ test "deque guard iter after push_front and push_back" {
 
 ///|
 test "deque guard iter2 coverage improvement" {
-  let dq = @deque.new(capacity=15)
+  let dq = @deque.Deque([], capacity=15)
   // Use push_front only
   fn test_n_via_push_front(n : Int) -> Unit raise {
     for i in 0..<=n {
@@ -875,7 +875,7 @@ test "deque guard iter2 coverage improvement" {
 ///|
 test "deque truncate" {
   // Empty deque
-  let dq : @deque.Deque[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.Deque([])
   dq.truncate(3)
   @json.json_inspect(dq, content=[])
 
@@ -920,7 +920,7 @@ test "deque retain" {
   let is_even = x => x % 2 == 0
 
   // Empty deque
-  let dq : @deque.Deque[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.Deque([])
   dq.retain(is_even)
   @json.json_inspect(dq, content=[])
 
@@ -987,7 +987,7 @@ test "deque retain" {
 
 ///|
 test "deque retain clears full wrapped deque" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(1)
   dq.push_back(2)
   dq.push_back(3)
@@ -1007,7 +1007,7 @@ test "deque retain_map" {
   let inc_if_even = inc_if(is_even)
 
   // Empty deque
-  let dq : @deque.Deque[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.Deque([])
   dq.retain_map(inc_if_even)
   @json.json_inspect(dq, content=[])
 
@@ -1066,7 +1066,7 @@ test "deque retain_map" {
 
 ///|
 test "deque retain_map clears full wrapped deque" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(1)
   dq.push_back(2)
   dq.push_back(3)
@@ -1081,7 +1081,7 @@ test "deque retain_map clears full wrapped deque" {
 
 ///|
 test "@deque.to_array/empty" {
-  let dq : @deque.Deque[Int] = @deque.new()
+  let dq : @deque.Deque[Int] = @deque.Deque([])
   let arr = dq.to_array()
   @json.json_inspect(arr, content=[])
 }
@@ -1096,7 +1096,7 @@ test "@deque.to_array/basic" {
 ///|
 test "@deque.to_array/wrapped_around" {
   // Create a deque that will wrap around its internal buffer
-  let dq = @deque.new(capacity=3)
+  let dq = @deque.Deque([], capacity=3)
   dq.push_back(1)
   dq.push_back(2)
   dq.push_back(3)
@@ -1326,7 +1326,7 @@ test "binary_search when wrapped around" {
 
 ///|
 test "binary_search on wrapped deque with first/mid/last checks" {
-  let dq = @deque.new(capacity=10)
+  let dq = @deque.Deque([], capacity=10)
   for i in 1..<=9 {
     dq.push_back(i)
   }
@@ -1347,7 +1347,7 @@ test "binary_search on wrapped deque with first/mid/last checks" {
 
 ///|
 test "binary_search with minimal wrap around" {
-  let dq = @deque.new(capacity=2)
+  let dq = @deque.Deque([], capacity=2)
   dq.push_back(1)
   dq.push_back(2)
   dq.unsafe_pop_front()
@@ -1360,7 +1360,7 @@ test "binary_search with minimal wrap around" {
 
 ///|
 test "binary_search with edge wrap around" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(1)
   dq.push_back(3)
   dq.push_back(5)
@@ -1379,7 +1379,7 @@ test "binary_search with edge wrap around" {
 ///|
 /// Test binary search with wrap-around buffer
 test "deque_binary_search_wrap_around" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(1)
   dq.push_back(3)
   dq.push_back(5)
@@ -1447,7 +1447,7 @@ test "rev_inplace" {
   assert_eq(dq, @deque.from_array([3, 4]))
 
   // Test with empty deque
-  let empty : @deque.Deque[Int] = @deque.new()
+  let empty : @deque.Deque[Int] = @deque.Deque([])
   empty.rev_in_place()
   assert_eq(empty, @deque.from_array([]))
 
@@ -1484,7 +1484,7 @@ test "rev" {
   assert_eq(reversed_back, @deque.from_array([3, 4, 5]))
 
   // Test with empty deque
-  let empty : @deque.Deque[Int] = @deque.new()
+  let empty : @deque.Deque[Int] = @deque.Deque([])
   let empty_reversed = empty.rev()
   assert_eq(empty, @deque.from_array([]))
   assert_eq(empty_reversed, @deque.from_array([]))
@@ -1552,7 +1552,7 @@ test "shuffle maintains elements with deterministic rand" {
 
 ///|
 test "deque map/mapi/search with wrapped head should keep logical order" {
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(1)
   dq.push_back(2)
   dq.push_back(3)
@@ -1578,7 +1578,7 @@ test "deque map/mapi/search with wrapped head should keep logical order" {
 ///|
 test "deque map/mapi/search wrapped unfull buffer" {
   // map
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(0)
   dq.push_back(1)
   dq.push_front(-1)
@@ -1587,7 +1587,7 @@ test "deque map/mapi/search wrapped unfull buffer" {
   inspect(mapped, content="@deque.from_array([-10, 0, 10])")
 
   // mapi
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(0)
   dq.push_back(1)
   dq.push_front(-1)
@@ -1596,7 +1596,7 @@ test "deque map/mapi/search wrapped unfull buffer" {
   inspect(mapped, content="@deque.from_array([-1, 10, 21])")
 
   // search
-  let dq = @deque.new(capacity=4)
+  let dq = @deque.Deque([], capacity=4)
   dq.push_back(0)
   dq.push_back(1)
   dq.push_front(-1)
@@ -2183,7 +2183,7 @@ test "extract_if_folded" {
 
 ///|
 test "flatten reads uninitialized memory" {
-  let inner_deque_with_slack = @deque.new(capacity=10)
+  let inner_deque_with_slack = @deque.Deque([], capacity=10)
   inner_deque_with_slack.push_back(1)
   inner_deque_with_slack.push_back(2)
   let outer_deque = @deque.from_array([inner_deque_with_slack])
@@ -2196,7 +2196,7 @@ test "flatten reads uninitialized memory" {
 test "Deque::append/self_alias" {
   // Test appending deque to itself - this should double the deque
   // Using small capacity to force reallocation during append
-  let dq = @deque.new(capacity=3)
+  let dq = @deque.Deque([], capacity=3)
   dq.push_back(1)
   dq.push_back(2)
   dq.push_back(3)

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -19,7 +19,7 @@ pub struct Deque[A] {
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
-pub fn[A] Deque::Deque(ArrayView[A]) -> Self[A]
+pub fn[A] Deque::Deque(ArrayView[A], capacity? : Int) -> Self[A]
 pub fn[A] Deque::append(Self[A], Self[A]) -> Unit
 pub fn[A] Deque::as_views(Self[A]) -> (ArrayView[A], ArrayView[A])
 #alias("_[_]")
@@ -57,7 +57,8 @@ pub fn Deque::join(Self[String], StringView) -> String
 pub fn[A] Deque::length(Self[A]) -> Int
 pub fn[A, U] Deque::map(Self[A], (A) -> U) -> Self[U]
 pub fn[A, U] Deque::mapi(Self[A], (Int, A) -> U) -> Self[U]
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[A] Deque::new(capacity? : Int) -> Self[A]
 pub fn[A] Deque::pop_back(Self[A]) -> A?
 pub fn[A] Deque::pop_front(Self[A]) -> A?

--- a/hashmap/README.mbt.md
+++ b/hashmap/README.mbt.md
@@ -6,13 +6,13 @@ A mutable hash map based on a Robin Hood hash table.
 
 ## Create
 
-You can create an empty map using `new()` or construct it from entries using `HashMap([...])`.
+You can create an empty map using `HashMap([])` or construct it from entries using `HashMap([...])`.
 
 ```mbt check
 ///|
 test {
   let _map1 = @hashmap.HashMap([("a", 1), ("b", 2)])
-  let _map2 : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let _map2 : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
 }
 ```
 
@@ -23,7 +23,7 @@ You can use `set()` to add a key-value pair to the map, and use `get()` to get a
 ```mbt check
 ///|
 test {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   map.set("a", 1)
   assert_eq(map.get("a"), Some(1))
   assert_eq(map.get_or_default("a", 0), 1)
@@ -77,7 +77,7 @@ Similarly, you can use `is_empty()` to check whether the map is empty.
 ```mbt check
 ///|
 test {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   assert_eq(map.is_empty(), true)
 }
 ```
@@ -129,7 +129,7 @@ Use `get_or_init()` to get a value or initialize it if missing:
 ```mbt check
 ///|
 test {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   let val = map.get_or_init("key", () => 42)
   assert_eq(val, 42)
   assert_eq(map.get("key"), Some(42))

--- a/hashmap/deprecated.mbt
+++ b/hashmap/deprecated.mbt
@@ -11,3 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+///|
+/// Creates a new empty hash map with the specified initial capacity. The actual
+/// capacity will be rounded up to the next power of 2 that is greater than or
+/// equal to the requested capacity.
+///
+/// Deprecated: use `HashMap([], capacity=...)` instead.
+#deprecated("Use `HashMap([], capacity=...)` instead")
+#as_free_fn(deprecated="Use `HashMap([], capacity=...)` instead")
+pub fn[K, V] HashMap::new(
+  capacity? : Int = default_init_capacity,
+) -> HashMap[K, V] {
+  new_hashmap(capacity)
+}

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -13,29 +13,10 @@
 // limitations under the License.
 
 ///|
-/// Creates a new empty hash map with the specified initial capacity. The actual
-/// capacity will be rounded up to the next power of 2 that is greater than or
-/// equal to the requested capacity, with a minimum of 8.
-///
-/// Parameters:
-///
-/// * `capacity` : The desired minimum capacity of the hash map. Must be a
-/// non-negative integer. Defaults to 8 if not specified.
-///
-/// Returns a new empty hash map of type `T[K, V]`, where `K` is the key type and
-/// `V` is the value type.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.new(capacity=16)
-///   inspect(map.capacity(), content="16")
-///   inspect(map.is_empty(), content="true")
-/// }
-/// ```
-#as_free_fn
-pub fn[K, V] HashMap::new(capacity? : Int = 8) -> HashMap[K, V] {
+let default_init_capacity = 8
+
+///|
+fn[K, V] new_hashmap(capacity : Int) -> HashMap[K, V] {
   let capacity = capacity.next_power_of_two()
   {
     size: 0,
@@ -46,8 +27,15 @@ pub fn[K, V] HashMap::new(capacity? : Int = 8) -> HashMap[K, V] {
 }
 
 ///|
+fn capacity_for_length(length : Int) -> Int {
+  (length * 2).next_power_of_two()
+}
+
+///|
 /// Creates a new hash map from an array of key-value pairs. Pairs with duplicate
 /// keys will keep the latest value, overwriting the previous ones.
+/// The optional `capacity` is treated as a minimum initial capacity and will be
+/// rounded up to the smallest power of 2 that can hold the requested capacity.
 ///
 /// Parameters:
 ///
@@ -73,8 +61,19 @@ pub fn[K, V] HashMap::new(capacity? : Int = 8) -> HashMap[K, V] {
 #as_free_fn(of, deprecated="Use from_array instead")
 pub fn[K : Hash + Eq, V] HashMap::HashMap(
   arr : ArrayView[(K, V)],
+  capacity? : Int,
 ) -> HashMap[K, V] {
-  let m = new(capacity=arr.length() * 2)
+  let length = arr.length()
+  let capacity = match capacity {
+    Some(capacity) => capacity.max(capacity_for_length(length))
+    None =>
+      if length == 0 {
+        default_init_capacity
+      } else {
+        capacity_for_length(length)
+      }
+  }
+  let m = new_hashmap(capacity)
   arr.each(e => m.set(e.0, e.1))
   m
 }
@@ -94,7 +93,7 @@ pub fn[K : Hash + Eq, V] HashMap::HashMap(
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
 ///   map.set("key", 42)
 ///   debug_inspect(map.get("key"), content="Some(42)")
 ///   map.set("key", 24) // update existing key
@@ -268,7 +267,7 @@ pub fn[K : Hash + Eq, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
 ///   let value = map.get_or_init("key", () => 42)
 ///   inspect(value, content="42")
 ///   debug_inspect(map.get("key"), content="Some(42)")
@@ -406,7 +405,7 @@ pub fn[K : Hash + Eq, V] HashMap::contains(
 ///
 /// ```mbt check
 /// test {
-///   let map = @hashmap.new()
+///   let map = @hashmap.HashMap([])
 ///   map.set("a", 1)
 ///   map.set("b", 2)
 ///   inspect(map.contains_kv("a", 1), content="true")
@@ -558,7 +557,7 @@ pub impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quic
   K,
   V,
 ] with arbitrary(size, rs) {
-  let m = new()
+  let m = new_hashmap(default_init_capacity)
   (@quickcheck.Arbitrary::arbitrary(size, rs) : Iter[(K, V)]).each(kv => {
     m.set(kv.0, kv.1)
   })
@@ -567,7 +566,7 @@ pub impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quic
 
 ///|
 pub impl[K, V] Default for HashMap[K, V] with default() {
-  new()
+  new_hashmap(default_init_capacity)
 }
 
 ///|
@@ -775,7 +774,7 @@ test "arbitrary" {
 
 ///|
 test "set" {
-  let m : HashMap[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new_hashmap(default_init_capacity)
   m.set("a", 1)
   m.set("b", 1)
   m.set("bc", 2)
@@ -792,7 +791,7 @@ test "set" {
 
 ///|
 test "remove" {
-  let m : HashMap[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new_hashmap(default_init_capacity)
   m.set("a", 1)
   m.set("ab", 2)
   m.set("bc", 2)
@@ -809,7 +808,7 @@ test "remove" {
 
 ///|
 test "remove_unexist_key" {
-  let m : HashMap[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new_hashmap(default_init_capacity)
   m.set("a", 1)
   m.set("ab", 2)
   m.set("abc", 3)
@@ -831,7 +830,7 @@ test "clear" {
 
 ///|
 test "grow" {
-  let m : HashMap[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new_hashmap(default_init_capacity)
   m.set("C", 1)
   m.set("Go", 2)
   m.set("C++", 3)
@@ -867,7 +866,7 @@ test "grow" {
 
 ///|
 test "_[_]" {
-  let m : HashMap[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new_hashmap(default_init_capacity)
   m.set("a", 1)
   m.set("b", 1)
   m.set("cc", 2)
@@ -879,7 +878,7 @@ test "_[_]" {
 
 ///|
 test "get_or_init" {
-  let m : HashMap[MyString, Int] = new()
+  let m : HashMap[MyString, Int] = new_hashmap(default_init_capacity)
   inspect(m.get_or_init("a", () => 1), content="1")
   @debug.debug_inspect(m.get("a"), content="Some(1)")
   inspect(m.get_or_init("a", () => 2), content="1")

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -14,14 +14,14 @@
 
 ///|
 test "new" {
-  let m : @hashmap.HashMap[Int, Int] = @hashmap.new()
+  let m : @hashmap.HashMap[Int, Int] = @hashmap.HashMap([])
   inspect(m.capacity(), content="8")
   inspect(m.length(), content="0")
 }
 
 ///|
 test "get" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -36,7 +36,7 @@ test "get" {
 
 ///|
 test "_[_]" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   assert_eq(m["a"], 1)
@@ -45,7 +45,7 @@ test "_[_]" {
 
 ///|
 test "get_or_default" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -57,7 +57,7 @@ test "get_or_default" {
 
 ///|
 test "get_or_init" {
-  let m : @hashmap.HashMap[String, Array[Int]] = @hashmap.new()
+  let m : @hashmap.HashMap[String, Array[Int]] = @hashmap.HashMap([])
   m.get_or_init("a", () => Array::new()).push(1)
   m.get_or_init("b", () => Array::new()).push(2)
   m.get_or_init("a", () => Array::new()).push(3)
@@ -68,7 +68,7 @@ test "get_or_init" {
 
 ///|
 test "get_or_init full" {
-  let m = @hashmap.new(capacity=2)
+  let m = @hashmap.HashMap([], capacity=2)
   m.get_or_init("a", () => 0) |> ignore
   m.get_or_init("b", () => 0) |> ignore
   m.get_or_init("c", () => 0) |> ignore
@@ -77,7 +77,7 @@ test "get_or_init full" {
 
 ///|
 test "_[_]=_" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m["a"] = 1
   m["b"] = 2
   assert_eq(m.get("a"), Some(1))
@@ -86,7 +86,7 @@ test "_[_]=_" {
 
 ///|
 test "panic get" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   m["c"] |> ignore
@@ -94,7 +94,7 @@ test "panic get" {
 
 ///|
 test "set_update" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   assert_eq(m.get("a"), Some(1))
@@ -104,7 +104,7 @@ test "set_update" {
 
 ///|
 test "contains" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   inspect(m.contains("a"), content="true")
   inspect(m.contains("b"), content="false")
@@ -120,7 +120,7 @@ test "from_array" {
 
 ///|
 test "size" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   inspect(m.length(), content="0")
   m.set("a", 1)
   inspect(m.length(), content="1")
@@ -128,7 +128,7 @@ test "size" {
 
 ///|
 test "is_empty" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   inspect(m.is_empty(), content="true")
   m.set("a", 1)
   inspect(m.is_empty(), content="false")
@@ -211,13 +211,13 @@ test "to_array" {
 
 ///|
 test "to_array empty" {
-  let map : @hashmap.HashMap[Int, String] = @hashmap.new()
+  let map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
   inspect(map.to_array(), content="[]")
 }
 
 ///|
 test "get_nonexistent_key" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   debug_inspect(m.get("c"), content="None")
@@ -225,7 +225,7 @@ test "get_nonexistent_key" {
 
 ///|
 test "remove_nonexistent_key" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   m.remove("c")
@@ -234,7 +234,7 @@ test "remove_nonexistent_key" {
 
 ///|
 test "get_nonexistent_key_with_psl" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   m.set("a", 1)
   m.set("b", 2)
   m.set("c", 3)
@@ -314,7 +314,7 @@ test "from_iter empty iter" {
 
 ///|
 test "@hashmap.contains/empty" {
-  let map : @hashmap.HashMap[Int, String] = @hashmap.new()
+  let map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
   inspect(map.contains(42), content="false")
 }
 
@@ -389,7 +389,9 @@ test "@hashmap.map" {
   map.remove("c")
   let v = map.map((k, v) => k + v.to_string())
   verify_content(v, [("a", "a1"), ("b", "b2"), ("d", "d10"), ("e", "e20")])
-  let v : @hashmap.HashMap[String, String] = @hashmap.new().map((k, v) => k + v)
+  let v : @hashmap.HashMap[String, String] = @hashmap.HashMap([]).map((k, v) => {
+    k + v
+  })
   inspect(v, content="HashMap::from_array([])")
 }
 
@@ -403,7 +405,7 @@ test "@hashmap.copy" {
   map.remove("c")
   let copy = map.copy()
   verify_content(copy, [("e", 20), ("a", 1), ("b", 2), ("d", 10)])
-  let copy : @hashmap.HashMap[String, String] = @hashmap.new().copy()
+  let copy : @hashmap.HashMap[String, String] = @hashmap.HashMap([]).copy()
   inspect(copy, content="HashMap::from_array([])")
 }
 
@@ -445,7 +447,7 @@ test "@hashmap.merge" {
 
 ///|
 test "@hashmap.merge empty maps" {
-  let map1 : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map1 : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   let map2 = @hashmap.from_array([("a", 1), ("b", 2)])
   let merged1 = map1.merge(map2)
   verify_content(merged1, [("a", 1), ("b", 2)])
@@ -470,7 +472,7 @@ test "@hashmap.merge_in_place" {
 
 ///|
 test "@hashmap.merge_in_place empty maps" {
-  let map1 : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map1 : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   let map2 = @hashmap.from_array([("a", 1), ("b", 2)])
   map1.merge_in_place(map2)
   verify_content(map1, [("a", 1), ("b", 2)])
@@ -480,7 +482,7 @@ test "@hashmap.merge_in_place empty maps" {
 
 ///|
 test "@hashmap.merge_in_place self-aliasing should be no-op" {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   // With 4 elements: capacity=8, size=4
   // The grow condition is size >= capacity/2, i.e., 4 >= 4
   // Without fix, merge_in_place(map) calls set_with_hash which triggers grow()
@@ -502,7 +504,7 @@ test "@hashmap.merge_in_place self-aliasing should be no-op" {
 
 ///|
 test "@hashmap.set updating existing key should not grow" {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   // Fill to exactly at grow threshold: capacity=8, size=4
   for i in 0..<4 {
     map.set(i.to_string(), i)
@@ -538,7 +540,7 @@ impl Hash for Key with hash_combine(self, hasher) {
 
 ///|
 test "hashmap collision probe paths" {
-  let map : @hashmap.HashMap[Key, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[Key, Int] = @hashmap.HashMap([])
   let k0 = Key::Key(0, 0)
   let k1 = Key::Key(1, 1)
   map.set(k0, 10)
@@ -549,7 +551,7 @@ test "hashmap collision probe paths" {
 
 ///|
 test "hashmap get_or_init push_away" {
-  let map : @hashmap.HashMap[Key, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[Key, Int] = @hashmap.HashMap([])
   map.set(Key::Key(1, 1), 10)
   map.set(Key::Key(2, 2), 20)
   inspect(map.get_or_init(Key::Key(3, 1), () => 30), content="30")

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub struct HashMap[K, V] {
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
-pub fn[K : Hash + Eq, V] HashMap::HashMap(ArrayView[(K, V)]) -> Self[K, V]
+pub fn[K : Hash + Eq, V] HashMap::HashMap(ArrayView[(K, V)], capacity? : Int) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] HashMap::at(Self[K, V], K) -> V
 pub fn[K, V] HashMap::capacity(Self[K, V]) -> Int
@@ -49,7 +49,8 @@ pub fn[K, V] HashMap::length(Self[K, V]) -> Int
 pub fn[K, V, V2] HashMap::map(Self[K, V], (K, V) -> V2) -> Self[K, V2]
 pub fn[K : Eq, V] HashMap::merge(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K : Eq, V] HashMap::merge_in_place(Self[K, V], Self[K, V]) -> Unit
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[K, V] HashMap::new(capacity? : Int) -> Self[K, V]
 pub fn[K : Hash + Eq, V] HashMap::remove(Self[K, V], K) -> Unit
 pub fn[K, V] HashMap::retain(Self[K, V], (K, V) -> Bool) -> Unit

--- a/hashmap/types_test.mbt
+++ b/hashmap/types_test.mbt
@@ -30,8 +30,8 @@ test "HashMap equality - same content different order" {
 
 ///|
 test "HashMap equality - empty maps" {
-  let map1 : @hashmap.HashMap[Int, String] = @hashmap.new()
-  let map2 : @hashmap.HashMap[Int, String] = @hashmap.new()
+  let map1 : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
+  let map2 : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
   assert_eq(map1, map2)
   assert_true(map1 == map2)
 }
@@ -62,7 +62,7 @@ test "HashMap equality - same size different values" {
 
 ///|
 test "HashMap equality - one empty one non-empty" {
-  let empty_map : @hashmap.HashMap[Int, String] = @hashmap.new()
+  let empty_map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
   let non_empty_map = @hashmap.from_array([(1, "one")])
   assert_false(empty_map == non_empty_map)
   assert_false(non_empty_map == empty_map)

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -131,7 +131,7 @@ pub fn[K, V] HashMap::iter2(self : HashMap[K, V]) -> Iter2[K, V] {
 pub fn[K : Hash + Eq, V] HashMap::from_iter(
   iter : Iter[(K, V)],
 ) -> HashMap[K, V] {
-  let m = new()
+  let m = new_hashmap(default_init_capacity)
   while iter.next() is Some((k, v)) {
     m[k] = v
   }
@@ -225,7 +225,7 @@ pub fn[K, V] HashMap::length(self : HashMap[K, V]) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[Int, String] = @hashmap.new(capacity=16)
+///   let map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([], capacity=16)
 ///   inspect(map.capacity(), content="16")
 /// }
 /// ```
@@ -247,7 +247,7 @@ pub fn[K, V] HashMap::capacity(self : HashMap[K, V]) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+///   let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
 ///   inspect(map.is_empty(), content="true")
 ///   map.set("key", 42)
 ///   inspect(map.is_empty(), content="false")

--- a/hashmap/utils_test.mbt
+++ b/hashmap/utils_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "capacity" {
-  let m = @hashmap.new()
+  let m = @hashmap.HashMap([])
   inspect(m.capacity(), content="8")
   m.set("a", 1)
   m.set("b", 2)
@@ -68,7 +68,7 @@ test "T::retain - remove all" {
 
 ///|
 test "T::retain - empty map" {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.new()
+  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
   map.retain((_k, _v) => true)
   inspect(map.length(), content="0")
   inspect(map.is_empty(), content="true")
@@ -125,7 +125,7 @@ test "T::retain - single element map" {
 
 ///|
 test "T::retain - large map with complex predicate" {
-  let map = @hashmap.new()
+  let map = @hashmap.HashMap([])
   for i = 0; i < 100; i = i + 1 {
     map.set("key" + i.to_string(), i)
   }
@@ -144,7 +144,7 @@ test "T::retain - large map with complex predicate" {
 ///|
 test "T::retain - with collisions" {
   // Create keys that likely hash to same buckets
-  let map = @hashmap.new()
+  let map = @hashmap.HashMap([])
   let keys = ["a", "aa", "aaa", "aaaa", "aaaaa"]
   for i = 0; i < keys.length(); i = i + 1 {
     map.set(keys[i], i)

--- a/hashset/README.mbt.md
+++ b/hashset/README.mbt.md
@@ -6,13 +6,13 @@ A mutable hash set based on a Robin Hood hash table.
 
 ## Create
 
-You can create an empty set using `new()` or construct it from entries using `HashSet([...])`.
+You can create an empty set using `HashSet([])` or construct it from entries using `HashSet([...])`.
 
 ```mbt check
 ///|
 test {
   let _set1 = @hashset.HashSet([1, 2, 3, 4, 5])
-  let _set2 : @hashset.HashSet[String] = @hashset.new()
+  let _set2 : @hashset.HashSet[String] = @hashset.HashSet([])
 }
 ```
 
@@ -23,7 +23,7 @@ You can use `insert()` to add a key to the set, and `contains()` to check whethe
 ```mbt check
 ///|
 test {
-  let set : @hashset.HashSet[String] = @hashset.new()
+  let set : @hashset.HashSet[String] = @hashset.HashSet([])
   set.add("a")
   assert_eq(set.contains("a"), true)
 }
@@ -60,7 +60,7 @@ Similarly, you can use `is_empty()` to check whether the set is empty.
 ```mbt check
 ///|
 test {
-  let set : @hashset.HashSet[Int] = @hashset.new()
+  let set : @hashset.HashSet[Int] = @hashset.HashSet([])
   assert_eq(set.is_empty(), true)
 }
 ```

--- a/hashset/deprecated.mbt
+++ b/hashset/deprecated.mbt
@@ -11,3 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+///|
+/// Creates an empty hash set with an optional initial capacity.
+///
+/// Deprecated: use `HashSet([], capacity=...)` instead.
+#deprecated("Use `HashSet([], capacity=...)` instead")
+#as_free_fn(deprecated="Use `HashSet([], capacity=...)` instead")
+pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
+  new_hashset(capacity)
+}

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -18,9 +18,7 @@
 let default_init_capacity = 8
 
 ///|
-/// Creates an empty hash set with an optional initial capacity.
-#as_free_fn
-pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
+fn[K] new_hashset(capacity : Int) -> HashSet[K] {
   let capacity = capacity.next_power_of_two()
   {
     size: 0,
@@ -32,13 +30,32 @@ pub fn[K] HashSet::new(capacity? : Int = default_init_capacity) -> HashSet[K] {
 }
 
 ///|
+fn capacity_for_length(length : Int) -> Int {
+  let mut capacity = length.next_power_of_two()
+  if length > calc_grow_threshold(capacity) {
+    capacity *= 2
+  }
+  capacity
+}
+
+///|
 /// Creates a hash set containing all elements from the given array.
+/// The optional `capacity` is treated as a minimum initial capacity and will be
+/// rounded up to the smallest power of 2 that can hold the requested capacity.
 #alias(from_array)
 #as_free_fn(from_array)
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
-pub fn[K : Hash + Eq] HashSet::HashSet(arr : ArrayView[K]) -> HashSet[K] {
-  let m = new()
+pub fn[K : Hash + Eq] HashSet::HashSet(
+  arr : ArrayView[K],
+  capacity? : Int,
+) -> HashSet[K] {
+  let length = arr.length()
+  let capacity = match capacity {
+    Some(capacity) => capacity.max(capacity_for_length(length))
+    None => default_init_capacity.max(capacity_for_length(length))
+  }
+  let m = new_hashset(capacity)
   arr.each(e => m.add(e))
   m
 }
@@ -55,7 +72,7 @@ pub fn[K : Hash + Eq] HashSet::HashSet(arr : ArrayView[K]) -> HashSet[K] {
 ///
 /// ```mbt check
 /// test {
-///   let set : @hashset.HashSet[String] = @hashset.new()
+///   let set : @hashset.HashSet[String] = @hashset.HashSet([])
 ///   set.add("key")
 ///   inspect(set.contains("key"), content="true")
 ///   set.add("key") // no effect since it already exists
@@ -330,7 +347,7 @@ pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 pub fn[K : Hash + Eq] HashSet::from_iter(iter : Iter[K]) -> HashSet[K] {
-  let s = new()
+  let s = new_hashset(default_init_capacity)
   while iter.next() is Some(e) {
     s.add(e)
   }
@@ -343,7 +360,7 @@ pub fn[K : Hash + Eq] HashSet::union(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
-  let m = new()
+  let m = new_hashset(default_init_capacity)
   self.each(k => m.add(k))
   other.each(k => m.add(k))
   m
@@ -355,7 +372,7 @@ pub fn[K : Hash + Eq] HashSet::intersection(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
-  let m = new()
+  let m = new_hashset(default_init_capacity)
   self.each(k => if other.contains(k) { m.add(k) })
   m
 }
@@ -366,7 +383,7 @@ pub fn[K : Hash + Eq] HashSet::difference(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
-  let m = new()
+  let m = new_hashset(default_init_capacity)
   self.each(k => if !other.contains(k) { m.add(k) })
   m
 }
@@ -377,7 +394,7 @@ pub fn[K : Hash + Eq] HashSet::symmetric_difference(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
-  let m = new()
+  let m = new_hashset(default_init_capacity)
   self.each(k => if !other.contains(k) { m.add(k) })
   other.each(k => if !self.contains(k) { m.add(k) })
   m
@@ -502,7 +519,7 @@ impl Hash for MyString with hash_combine(self, hasher) {
 
 ///|
 test "set" {
-  let m : HashSet[MyString] = new()
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
   m.add("a")
   m.add("b")
   m.add("bc")
@@ -519,7 +536,7 @@ test "set" {
 
 ///|
 test "remove" {
-  let m : HashSet[MyString] = new()
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
   fn i(s) {
     MyString::MyString(s)
   }
@@ -540,7 +557,7 @@ test "remove" {
 
 ///|
 test "remove_unexist_key" {
-  let m : HashSet[MyString] = new()
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
   fn i(s) {
     MyString::MyString(s)
   }
@@ -555,7 +572,7 @@ test "remove_unexist_key" {
 
 ///|
 test "grow" {
-  let m : HashSet[MyString] = new()
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
   fn i(s) {
     MyString::MyString(s)
   }
@@ -584,7 +601,7 @@ test "grow" {
 
 ///|
 test "clear" {
-  let m : HashSet[MyString] = new()
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
@@ -608,7 +625,7 @@ test "clear" {
 ///
 /// ```mbt check
 /// test {
-///   let set : @hashset.HashSet[String] = @hashset.new()
+///   let set : @hashset.HashSet[String] = @hashset.HashSet([])
 ///   inspect(set.add_and_check("key"), content="true") // First insertion
 ///   inspect(set.add_and_check("key"), content="false") // Already exists
 ///   inspect(set.length(), content="1")
@@ -685,7 +702,7 @@ pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
 ///|
 /// Default implementation for hashset
 pub impl[K] Default for HashSet[K] with default() {
-  new()
+  new_hashset(default_init_capacity)
 }
 
 ///|

--- a/hashset/hashset_coverage_test.mbt
+++ b/hashset/hashset_coverage_test.mbt
@@ -14,8 +14,8 @@
 
 ///|
 test "is_disjoint with different sizes" {
-  let set1 = @hashset.new()
-  let set2 = @hashset.new()
+  let set1 = @hashset.HashSet([])
+  let set2 = @hashset.HashSet([])
 
   // Add fewer elements to set1
   set1.add(1)
@@ -33,8 +33,8 @@ test "is_disjoint with different sizes" {
 
 ///|
 test "is_disjoint with overlap" {
-  let set1 = @hashset.new()
-  let set2 = @hashset.new()
+  let set1 = @hashset.HashSet([])
+  let set2 = @hashset.HashSet([])
   set1.add(1)
   set1.add(2)
   set2.add(2)
@@ -46,8 +46,8 @@ test "is_disjoint with overlap" {
 
 ///|
 test "is_subset with different sizes" {
-  let subset = @hashset.new()
-  let superset = @hashset.new()
+  let subset = @hashset.HashSet([])
+  let superset = @hashset.HashSet([])
   subset.add(1)
   subset.add(2)
   superset.add(1)
@@ -61,7 +61,7 @@ test "is_subset with different sizes" {
 
 ///|
 test "contains with probe sequence length comparison" {
-  let set = @hashset.new()
+  let set = @hashset.HashSet([])
 
   // Create a scenario that might trigger PSL comparison
   // Add multiple elements to create collisions and probe sequences
@@ -77,7 +77,7 @@ test "contains with probe sequence length comparison" {
 ///|
 test "large set operations" {
   // Create a large enough set to test growth scenarios
-  let set = @hashset.new()
+  let set = @hashset.HashSet([])
 
   // Add many elements to trigger multiple grows
   for i in 0..<1000 {

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -17,7 +17,10 @@ let default_init_capacity = 8
 
 ///|
 test "new_with_capacity_then_add " {
-  let set : @hashset.HashSet[(String, String)] = @hashset.new(capacity=20)
+  let set : @hashset.HashSet[(String, String)] = @hashset.HashSet(
+    [],
+    capacity=20,
+  )
   set.add(("None", "Hash"))
   inspect(
     set,
@@ -37,7 +40,7 @@ test "to_array" {
 
 ///|
 test "add_and_check" {
-  let set : @hashset.HashSet[String] = @hashset.new()
+  let set : @hashset.HashSet[String] = @hashset.HashSet([])
   inspect(set.add_and_check("key"), content="true") // First insertion
   inspect(set.add_and_check("key"), content="false") // Already exists
   inspect(set.length(), content="1")
@@ -79,14 +82,14 @@ test "to_json" {
 
 ///|
 test "new" {
-  let m : @hashset.HashSet[Int] = @hashset.new()
+  let m : @hashset.HashSet[Int] = @hashset.HashSet([])
   assert_eq(m.capacity(), default_init_capacity)
   inspect(m.length(), content="0")
 }
 
 ///|
 test "new with zero capacity grows on insert" {
-  let m : @hashset.HashSet[Int] = @hashset.new(capacity=0)
+  let m : @hashset.HashSet[Int] = @hashset.HashSet([], capacity=0)
   m.add(1)
   assert_true(m.contains(1))
   assert_true(m.capacity() > 0)
@@ -100,7 +103,7 @@ test "default" {
 
 ///|
 test "insert" {
-  let m = @hashset.new()
+  let m = @hashset.HashSet([])
   m.add("a")
   m.add("b")
   m.add("c")
@@ -140,7 +143,7 @@ test "HashSet constructor" {
 
 ///|
 test "size" {
-  let m = @hashset.new()
+  let m = @hashset.HashSet([])
   inspect(m.length(), content="0")
   m.add("a")
   inspect(m.length(), content="1")
@@ -148,7 +151,7 @@ test "size" {
 
 ///|
 test "is_empty" {
-  let m = @hashset.new()
+  let m = @hashset.HashSet([])
   inspect(m.is_empty(), content="true")
   m.add("a")
   inspect(m.is_empty(), content="false")
@@ -315,7 +318,7 @@ test "sub" {
 
 ///|
 test "insert_and_grow" {
-  let m = @hashset.new()
+  let m = @hashset.HashSet([])
   for i in 0..<10 {
     m.add(i.to_string())
   }
@@ -325,7 +328,7 @@ test "insert_and_grow" {
 
 ///|
 test "remove_and_shift_back" {
-  let m = @hashset.new()
+  let m = @hashset.HashSet([])
   m.add("a")
   m.add("b")
   m.add("c")
@@ -339,7 +342,7 @@ test "remove_and_shift_back" {
 
 ///|
 test "capacity_and_size" {
-  let m = @hashset.new()
+  let m = @hashset.HashSet([])
   assert_eq(m.capacity(), default_init_capacity)
   inspect(m.length(), content="0")
   m.add("a")
@@ -348,7 +351,7 @@ test "capacity_and_size" {
 
 ///|
 test "clear_and_reinsert" {
-  let m = @hashset.new()
+  let m = @hashset.HashSet([])
   m.add("a")
   m.add("b")
   m.clear()
@@ -408,20 +411,20 @@ test "hashset arbitrary" {
 
 ///|
 test "@hashset.to_array/empty" {
-  let set : @hashset.HashSet[Int] = @hashset.new()
+  let set : @hashset.HashSet[Int] = @hashset.HashSet([])
   inspect(set.to_array(), content="[]")
 }
 
 ///|
 test "@hashset.to_array/single" {
-  let set = @hashset.new()
+  let set = @hashset.HashSet([])
   set.add(42)
   inspect(set.to_array(), content="[42]")
 }
 
 ///|
 test "@hashset.to_array/multiple" {
-  let set = @hashset.new()
+  let set = @hashset.HashSet([])
   set.add(1)
   set.add(2)
   set.add(3)
@@ -461,7 +464,7 @@ test "retain/none_removed" {
 
 ///|
 test "retain/empty_set" {
-  let set : @hashset.HashSet[Int] = @hashset.new()
+  let set : @hashset.HashSet[Int] = @hashset.HashSet([])
   set.retain(_x => true)
   assert_eq(set.length(), 0)
 }

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub struct HashSet[K] {
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
-pub fn[K : Hash + Eq] HashSet::HashSet(ArrayView[K]) -> Self[K]
+pub fn[K : Hash + Eq] HashSet::HashSet(ArrayView[K], capacity? : Int) -> Self[K]
 #alias(insert, deprecated)
 pub fn[K : Hash + Eq] HashSet::add(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] HashSet::add_and_check(Self[K], K) -> Bool
@@ -45,7 +45,8 @@ pub fn[K : Hash + Eq] HashSet::is_superset(Self[K], Self[K]) -> Bool
 pub fn[K] HashSet::iter(Self[K]) -> Iter[K]
 #alias(size, deprecated)
 pub fn[K] HashSet::length(Self[K]) -> Int
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[K] HashSet::new(capacity? : Int) -> Self[K]
 pub fn[K : Hash + Eq] HashSet::remove(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] HashSet::remove_and_check(Self[K], K) -> Bool

--- a/immut/priority_queue/README.mbt.md
+++ b/immut/priority_queue/README.mbt.md
@@ -6,12 +6,13 @@ A priority queue is a data structure capable of maintaining maximum/minimum valu
 
 ## Create
 
-You can use `new()` or `of()` to create an immutable priority queue.
+You can use `PriorityQueue([])` or `of()` to create an immutable priority queue.
 
 ```mbt check
 ///|
 test {
-  let _queue1 : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let _queue1 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
+  )
   let _queue2 = @priority_queue.from_array([1, 2, 3])
 }
 ```
@@ -25,7 +26,7 @@ You can use the `length` to get the length of the immutable priority queue.
 ```mbt check
 ///|
 test {
-  let pq = @priority_queue.new()
+  let pq = @priority_queue.PriorityQueue([])
   assert_eq(pq.length(), 0)
   assert_eq(pq.push(1).length(), 1)
 }
@@ -36,7 +37,7 @@ You can use the `is_empty` to determine whether the immutable priority queue is 
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
   assert_eq(pq.is_empty(), true)
 }
 ```
@@ -61,7 +62,7 @@ You can use `push()` to add elements to the immutable priority queue and get a n
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
   @test.assert_eq(pq.push(1).peek(), Some(1))
 }
 ```

--- a/immut/priority_queue/deprecated.mbt
+++ b/immut/priority_queue/deprecated.mbt
@@ -11,3 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+///|
+/// Creates a new empty immutable priority queue.
+///
+/// Deprecated: use `PriorityQueue([])` instead.
+#deprecated("Use `PriorityQueue([])` instead")
+#as_free_fn(deprecated="Use `PriorityQueue([])` instead")
+pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
+  new_priority_queue()
+}

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -29,7 +29,8 @@ pub fn[A] PriorityQueue::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
 pub fn[A : Compare] PriorityQueue::iter(Self[A]) -> Iter[A]
 pub fn[A] PriorityQueue::length(Self[A]) -> Int
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[A] PriorityQueue::new() -> Self[A]
 pub fn[A] PriorityQueue::peek(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::pop(Self[A]) -> Self[A]?

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -13,17 +13,7 @@
 // limitations under the License.
 
 ///|
-/// Creates a new empty immutable priority queue.
-///
-/// # Example
-/// ```mbt check
-/// test {
-///   let queue = @priority_queue.new()
-///   assert_eq(queue.push(1).length(), 1)
-/// }
-/// ```
-#as_free_fn
-pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
+fn[A] new_priority_queue() -> PriorityQueue[A] {
   { node: Empty, size: 0 }
 }
 
@@ -44,7 +34,7 @@ pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
 pub fn[A : Compare] PriorityQueue::PriorityQueue(
   array : ArrayView[A],
 ) -> PriorityQueue[A] {
-  for x in array; pq = (new() : PriorityQueue[A]) {
+  for x in array; pq = (new_priority_queue() : PriorityQueue[A]) {
     continue pq.push(x)
   } nobreak {
     pq
@@ -89,7 +79,7 @@ pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
 pub fn[A : Compare] PriorityQueue::from_iter(
   iter : Iter[A],
 ) -> PriorityQueue[A] {
-  iter.fold(init=new(), (s, e) => s.push(e))
+  iter.fold(init=new_priority_queue(), (s, e) => s.push(e))
 }
 
 ///|
@@ -217,7 +207,7 @@ pub fn[A : Compare] PriorityQueue::unsafe_pop(
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue = @priority_queue.new()
+///   let queue = @priority_queue.PriorityQueue([])
 ///   assert_eq(queue.push(1).length(), 1)
 /// }
 /// ```
@@ -277,7 +267,7 @@ pub fn[A] PriorityQueue::peek(self : PriorityQueue[A]) -> A? {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue = @priority_queue.new()
+///   let queue = @priority_queue.PriorityQueue([])
 ///   inspect(queue.is_empty(), content="true")
 ///   assert_eq(queue.push(1).is_empty(), false)
 /// }
@@ -292,7 +282,7 @@ pub fn[A] PriorityQueue::is_empty(self : PriorityQueue[A]) -> Bool {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue = @priority_queue.new()
+///   let queue = @priority_queue.PriorityQueue([])
 ///   inspect(queue.length(), content="0")
 ///   assert_eq(queue.push(1).length(), 1)
 /// }

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -37,7 +37,7 @@ test "to_array" {
   inspect(v.to_array(), content="[4, 3, 2, 1]")
   inspect(v.push(0).to_array(), content="[4, 3, 2, 1, 0]")
   inspect(
-    (@priority_queue.new() : @priority_queue.PriorityQueue[Int]).to_array(),
+    (@priority_queue.PriorityQueue([]) : @priority_queue.PriorityQueue[Int]).to_array(),
     content="[]",
   )
 }
@@ -112,14 +112,14 @@ test "push" {
 
 ///|
 test "peek" {
-  let queue = @priority_queue.new()
+  let queue = @priority_queue.PriorityQueue([])
   debug_inspect(queue.peek(), content="None")
   debug_inspect(queue.push(1).peek(), content="Some(1)")
 }
 
 ///|
 test "is_empty" {
-  let queue = @priority_queue.new()
+  let queue = @priority_queue.PriorityQueue([])
   inspect(queue.is_empty(), content="true")
   inspect(queue.push(1).is_empty(), content="false")
 }
@@ -163,7 +163,7 @@ test "hash" {
   inspect(pq1.hash() == pq2.hash(), content="true")
   let pq3 = @priority_queue.from_array([5, 4, 3, 2, 1])
   inspect(pq1.hash() == pq3.hash(), content="true")
-  let pq4 : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let pq4 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
   inspect(pq1.hash() == pq4.hash(), content="false")
   inspect(pq4.hash() == pq4.hash(), content="true")
   let pq5 = @priority_queue.from_array([1, 2, 3, 4, 6])
@@ -178,7 +178,7 @@ test "equal" {
   inspect(pq1 == pq2, content="true")
   let pq3 = @priority_queue.from_array([5, 4, 3, 2, 1])
   inspect(pq1 == pq3, content="true")
-  let pq4 : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let pq4 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
   inspect(pq1 == pq4, content="false")
   let pq5 = @priority_queue.from_array([1, 2, 3])
   inspect(pq1 == pq5, content="false")
@@ -195,7 +195,7 @@ test "complex" {
   arr.shuffle_in_place(rand~)
   let pq = for
     i in 0..<=1000
-    pq = (@priority_queue.new() : @priority_queue.PriorityQueue[Int]) {
+    pq = (@priority_queue.PriorityQueue([]) : @priority_queue.PriorityQueue[Int]) {
     continue pq.push(arr[i])
   } nobreak {
     pq
@@ -216,7 +216,8 @@ test "compare" {
   let pq1 = @priority_queue.from_array([1, 2, 3])
   let pq2 = @priority_queue.from_array([1, 2, 4])
   let pq3 = @priority_queue.from_array([1, 2])
-  let empty : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let empty : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
+  )
   inspect(pq1.compare(pq2), content="-1")
   inspect(pq1.compare(pq3), content="1")
   inspect(pq3.compare(pq1), content="-1")

--- a/internal/regex_engine/automata/thread_set.mbt
+++ b/internal/regex_engine/automata/thread_set.mbt
@@ -218,7 +218,7 @@ fn ThreadSet::split_at_first_match(self : ThreadSet) -> (ThreadSet, ThreadSet) {
 
 ///|
 fn ThreadSet::remove_duplicates(self : ThreadSet, next : Expr) -> ThreadSet {
-  let seen = @hashset.HashSet::new()
+  let seen = @hashset.HashSet([])
   for thread in self; result = ts_empty {
     match thread {
       End(_) => break result + ts_one(thread)

--- a/priority_queue/README.mbt.md
+++ b/priority_queue/README.mbt.md
@@ -6,12 +6,13 @@ A priority queue is a data structure capable of maintaining maximum/minimum valu
 
 ## Create
 
-You can use `new()` or `of()` to create a priority queue.
+You can use `PriorityQueue([])` or `of()` to create a priority queue.
 
 ```mbt check
 ///|
 test {
-  let queue1 : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let queue1 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
+  )
   let queue2 = @priority_queue.from_array([1, 2, 3])
   @json.json_inspect(queue1, content=[])
   @json.json_inspect(queue2, content=[3, 2, 1])
@@ -57,7 +58,7 @@ Similarly, you can use the `is_empty` to determine whether the priority queue is
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
   assert_eq(pq.is_empty(), true)
 }
 ```
@@ -81,7 +82,7 @@ You can use `push()` to add elements to the priority queue.
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
   pq.push(1)
   pq.push(2)
   @test.assert_eq(pq.peek(), Some(2))

--- a/priority_queue/deprecated.mbt
+++ b/priority_queue/deprecated.mbt
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 ///|
-/// Creates a new empty deque with an optional initial capacity.
+/// Creates a new empty priority queue.
 ///
-/// Deprecated: use `Deque([], capacity=...)` instead.
-#deprecated("Use `Deque([], capacity=...)` instead")
-#as_free_fn(deprecated="Use `Deque([], capacity=...)` instead")
-pub fn[A] Deque::new(capacity? : Int = 0) -> Deque[A] {
-  new_deque(capacity)
+/// Deprecated: use `PriorityQueue([])` instead.
+#deprecated("Use `PriorityQueue([])` instead")
+#as_free_fn(deprecated="Use `PriorityQueue([])` instead")
+pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
+  new_priority_queue()
 }

--- a/priority_queue/pkg.generated.mbti
+++ b/priority_queue/pkg.generated.mbti
@@ -32,7 +32,8 @@ pub fn[A] PriorityQueue::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
 pub fn[A : Compare] PriorityQueue::iter(Self[A]) -> Iter[A]
 pub fn[A] PriorityQueue::length(Self[A]) -> Int
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[A] PriorityQueue::new() -> Self[A]
 pub fn[A] PriorityQueue::peek(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::pop(Self[A]) -> A?

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -13,17 +13,7 @@
 // limitations under the License.
 
 ///|
-/// Creates a new empty priority queue.
-///
-/// # Example
-/// ```mbt check
-/// test {
-///   let queue : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
-///   assert_eq(queue.length(), 0)
-/// }
-/// ```
-#as_free_fn
-pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
+fn[A] new_priority_queue() -> PriorityQueue[A] {
   { len: 0, top: None }
 }
 
@@ -44,7 +34,7 @@ pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
 pub fn[A : Compare] PriorityQueue::PriorityQueue(
   arr : ArrayView[A],
 ) -> PriorityQueue[A] {
-  guard arr is [a0, ..] else { return new() }
+  guard arr is [a0, ..] else { return new_priority_queue() }
   let len = arr.length()
   for i = 1, acc = { content: a0, sibling: None, child: None } {
     if i < len {
@@ -154,7 +144,7 @@ pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(self) {
 pub fn[K : Compare] PriorityQueue::from_iter(
   iter : Iter[K],
 ) -> PriorityQueue[K] {
-  let s = new()
+  let s = new_priority_queue()
   while iter.next() is Some(e) {
     s.push(e)
   }
@@ -254,7 +244,7 @@ pub fn[A : Compare] PriorityQueue::pop(self : PriorityQueue[A]) -> A? {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue = @priority_queue.new()
+///   let queue = @priority_queue.PriorityQueue([])
 ///   queue.push(1)
 ///   assert_eq(queue.length(), 1)
 /// }
@@ -311,7 +301,8 @@ pub fn[A] PriorityQueue::clear(self : PriorityQueue[A]) -> Unit {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+///   let queue : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
+///   )
 ///   assert_eq(queue.is_empty(), true)
 /// }
 /// ```
@@ -333,7 +324,7 @@ pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for Priority
   X,
 ] with arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
-  guard len > 0 else { return new() }
+  guard len > 0 else { return new_priority_queue() }
   for i = 1, acc = { content: X::arbitrary(0, rs), sibling: None, child: None } {
     if i < len {
       continue i + 1,
@@ -359,5 +350,5 @@ test "priority queue arbitrary" {
 
 ///|
 pub impl[K] Default for PriorityQueue[K] with default() {
-  new()
+  new_priority_queue()
 }

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -14,7 +14,8 @@
 
 ///|
 test "new" {
-  let queue : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let queue : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
+  )
   @test.assert_eq(queue.length(), 0)
 }
 
@@ -79,7 +80,7 @@ test "iter" {
 
 ///|
 test "length" {
-  let pq = @priority_queue.new()
+  let pq = @priority_queue.PriorityQueue([])
   @test.assert_eq(pq.length(), 0)
   pq.push(1)
   @test.assert_eq(pq.length(), 1)
@@ -122,7 +123,7 @@ test "pop" {
 
 ///|
 test "pop empty" {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.new()
+  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
   debug_inspect(pq.pop(), content="None")
 }
 
@@ -190,7 +191,7 @@ test "complex" {
   }
   let arr = (0).until(1000, inclusive=true).collect()
   arr.shuffle_in_place(rand~)
-  let pq = @priority_queue.new()
+  let pq = @priority_queue.PriorityQueue([])
   for i in 0..<=1000 {
     pq.push(arr[i])
   }
@@ -204,7 +205,7 @@ test "complex" {
 
 ///|
 test "priority queue large data" {
-  let pq = @priority_queue.new()
+  let pq = @priority_queue.PriorityQueue([])
   for i in 0..<=10000000 {
     pq.push(-i)
   }
@@ -220,7 +221,7 @@ test "priority queue large data" {
 test "copy large monotonic queue" {
   // Monotonic inserts create deep sibling chains in pairing heaps.
   // This verifies copy() doesn't overflow the stack on large inputs.
-  let pq = @priority_queue.new()
+  let pq = @priority_queue.PriorityQueue([])
   for i in 0..<10000 {
     pq.push(i)
   }

--- a/queue/README.mbt.md
+++ b/queue/README.mbt.md
@@ -9,7 +9,7 @@ You can create a queue manually by using the `new` or construct it using the `fr
 ```mbt check
 ///|
 test {
-  let _queue : @queue.Queue[Int] = @queue.new()
+  let _queue : @queue.Queue[Int] = @queue.Queue([])
   let _queue1 = @queue.from_array([1, 2, 3])
 }
 ```
@@ -39,7 +39,7 @@ You can add elements to the queue using the `push` method and remove them using 
 ```mbt check
 ///|
 test {
-  let queue = @queue.new()
+  let queue = @queue.Queue([])
   queue.push(1)
   queue.push(2)
   assert_eq(queue.pop(), Some(1))

--- a/queue/deprecated.mbt
+++ b/queue/deprecated.mbt
@@ -11,3 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+///|
+/// Creates a new empty queue.
+///
+/// Deprecated: use `Queue([])` instead.
+#deprecated("Use `Queue([])` instead")
+#as_free_fn(deprecated="Use `Queue([])` instead")
+pub fn[A] Queue::new() -> Queue[A] {
+  new_queue()
+}

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -35,7 +35,8 @@ pub fn[A] Queue::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
 pub fn[A] Queue::iter(Self[A]) -> Iter[A]
 pub fn[A] Queue::length(Self[A]) -> Int
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[A] Queue::new() -> Self[A]
 pub fn[A] Queue::peek(Self[A]) -> A?
 pub fn[A] Queue::pop(Self[A]) -> A?

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -13,17 +13,7 @@
 // limitations under the License.
 
 ///|
-/// Creates a new empty queue.
-///
-/// # Example
-/// ```mbt check
-/// test {
-///   let queue : @queue.Queue[Int] = @queue.new()
-///   @test.assert_eq(queue.length(), 0)
-/// }
-/// ```
-#as_free_fn
-pub fn[A] Queue::new() -> Queue[A] {
+fn[A] new_queue() -> Queue[A] {
   { length: 0, first: None, last: None }
 }
 
@@ -43,7 +33,7 @@ pub fn[A] Queue::new() -> Queue[A] {
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
 pub fn[A] Queue::Queue(arr : ArrayView[A]) -> Queue[A] {
-  guard arr.length() > 0 else { return new() }
+  guard arr.length() > 0 else { return new_queue() }
   let length = arr.length()
   let last = { content: arr[length - 1], next: None }
   let first = for i = length - 2, x = last; i >= 0; {
@@ -87,7 +77,7 @@ pub fn[A] Queue::clear(self : Queue[A]) -> Unit {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.Queue([])
 ///   @test.assert_eq(queue.length(), 0)
 /// }
 /// ```
@@ -101,7 +91,7 @@ pub fn[A] Queue::length(self : Queue[A]) -> Int {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.Queue([])
 ///   assert_true(queue.is_empty())
 /// }
 /// ```
@@ -115,7 +105,7 @@ pub fn[A] Queue::is_empty(self : Queue[A]) -> Bool {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.Queue([])
 ///   queue.push(1)
 /// }
 /// ```
@@ -274,7 +264,7 @@ pub fn[A] Queue::eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.new()
+///   let queue : @queue.Queue[Int] = @queue.Queue([])
 ///   let sum = queue.fold(init=0, (acc, x) => acc + x)
 ///   @test.assert_eq(sum, 0)
 /// }
@@ -301,7 +291,7 @@ pub fn[A, B] Queue::fold(self : Queue[A], init~ : B, f : (B, A) -> B) -> B {
 /// ```
 #alias(clone, deprecated)
 pub fn[A] Queue::copy(self : Queue[A]) -> Queue[A] {
-  guard self.first is Some({ content, next }) else { return new() }
+  guard self.first is Some({ content, next }) else { return new_queue() }
   let first = { content, next: None }
   let last = for pre = first, n = next {
     match (pre, n) {
@@ -325,7 +315,7 @@ pub fn[A] Queue::copy(self : Queue[A]) -> Queue[A] {
 /// # Example
 /// ```mbt check
 /// test {
-///   let dst : @queue.Queue[Int] = @queue.new()
+///   let dst : @queue.Queue[Int] = @queue.Queue([])
 ///   let src : @queue.Queue[Int] = @queue.from_array([5, 6, 7, 8])
 ///   src.transfer(dst)
 /// }
@@ -391,7 +381,7 @@ pub fn[A] Queue::iter(self : Queue[A]) -> Iter[A] {
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 pub fn[A] Queue::from_iter(iter : Iter[A]) -> Queue[A] {
-  let q = new()
+  let q = new_queue()
   while iter.next() is Some(e) {
     q.push(e)
   }
@@ -430,7 +420,7 @@ test "equal" {
 
 ///|
 test "push" {
-  let queue : Queue[Int] = new()
+  let queue : Queue[Int] = new_queue()
   queue.push(1)
   queue.push(2)
   queue.push(3)

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -14,13 +14,13 @@
 
 ///|
 test "new" {
-  let queue : @queue.Queue[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.Queue([])
   assert_eq(queue.length(), 0)
 }
 
 ///|
 test "copy empty" {
-  let queue : @queue.Queue[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.Queue([])
   let copied = queue.copy()
   inspect(copied.length(), content="0")
 }
@@ -101,7 +101,7 @@ test "clear" {
 
 ///|
 test "is_empty" {
-  let queue : @queue.Queue[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.Queue([])
   assert_true(queue.is_empty())
   queue.push(1)
   queue.push(2)
@@ -150,7 +150,7 @@ test "pop" {
 
 ///|
 test "each" {
-  let queue : @queue.Queue[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.Queue([])
   let mut sum = 0
   queue.each(x => sum = sum + x)
   assert_eq(sum, 0)
@@ -168,7 +168,7 @@ test "iter_fold" {
 
 ///|
 test "iteri" {
-  let queue : @queue.Queue[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.Queue([])
   let mut sum = 0
   queue.eachi((i, x) => sum = sum + i * x)
   assert_eq(sum, 0)
@@ -180,7 +180,7 @@ test "iteri" {
 
 ///|
 test "fold" {
-  let queue : @queue.Queue[Int] = @queue.new()
+  let queue : @queue.Queue[Int] = @queue.Queue([])
   let sum = queue.fold(init=0, (acc, x) => acc + x)
   assert_eq(sum, 0)
   @queue.from_array([1, 2, 3, 4]).transfer(queue)
@@ -248,7 +248,7 @@ test "transfer_self" {
 ///|
 test "transfer_self_empty" {
   // Test self-transfer on empty queue
-  let q : @queue.Queue[Int] = @queue.new()
+  let q : @queue.Queue[Int] = @queue.Queue([])
   q.transfer(q)
   inspect(q, content="@queue.from_array([])")
 }

--- a/sorted_map/README.mbt.md
+++ b/sorted_map/README.mbt.md
@@ -24,7 +24,7 @@ You can create an empty SortedMap or a SortedMap from other containers.
 ```mbt check
 ///|
 test {
-  let _map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let _map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   let _map2 = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
 }
 ```
@@ -47,7 +47,7 @@ You can also use the convenient subscript syntax to add or update values:
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.new()
+  let map = @sorted_map.SortedMap([])
   map[1] = "one"
   map[2] = "two"
   assert_eq(map.length(), 2)
@@ -143,7 +143,7 @@ Check if the map is empty.
 ```mbt check
 ///|
 test {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   assert_eq(map.is_empty(), true)
 }
 ```

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -13,6 +13,16 @@
 // limitations under the License.
 
 ///|
+/// Creates an empty sorted map.
+///
+/// Deprecated: use `SortedMap([])` instead.
+#deprecated("Use `SortedMap([])` instead")
+#as_free_fn(deprecated="Use `SortedMap([])` instead")
+pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
+  new_sorted_map()
+}
+
+///|
 /// Return an iterator of keys.
 #deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
 #coverage.skip

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -25,9 +25,7 @@ pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V] with equal(self, other) {
 }
 
 ///|
-/// Creates an empty sorted map.
-#as_free_fn
-pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
+fn[K, V] new_sorted_map() -> SortedMap[K, V] {
   { root: None, size: 0 }
 }
 
@@ -48,7 +46,7 @@ pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
 pub fn[K : Compare, V] SortedMap::SortedMap(
   entries : ArrayView[(K, V)],
 ) -> SortedMap[K, V] {
-  let map = { root: None, size: 0 }
+  let map = new_sorted_map()
   for e in entries {
     map.set(e.0, e.1)
   }
@@ -59,7 +57,7 @@ pub fn[K : Compare, V] SortedMap::SortedMap(
 /// FIXME: (remove this line will break formatter)
 /// ```mbt check
 /// test {
-///   let map = @sorted_map.new()
+///   let map = @sorted_map.SortedMap([])
 ///   map.set(1, "a")
 ///   map.set(2, "b")
 ///   map.set(2, "c") // updates value for key 2
@@ -321,7 +319,7 @@ pub fn[K, V] SortedMap::iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
 pub fn[K : Compare, V] SortedMap::from_iter(
   iter : Iter[(K, V)],
 ) -> SortedMap[K, V] {
-  let m = new()
+  let m = new_sorted_map()
   while iter.next() is Some((k, v)) {
     m[k] = v
   }
@@ -658,7 +656,7 @@ fn[K : Compare, V] delete_node(
 
 ///|
 test "new" {
-  let map : SortedMap[Int, String] = new()
+  let map : SortedMap[Int, String] = new_sorted_map()
   inspect(map.debug_tree(), content="_")
   inspect(map.length(), content="0")
 }
@@ -672,7 +670,7 @@ test "of" {
 
 ///|
 test "add1" {
-  let map = new()
+  let map = new_sorted_map()
   map.set(6, "a")
   map.set(5, "b")
   map.set(4, "c")
@@ -688,7 +686,7 @@ test "add1" {
 
 ///|
 test "add2" {
-  let map = new()
+  let map = new_sorted_map()
   map.set(1, "a")
   map.set(2, "b")
   map.set(3, "c")
@@ -704,7 +702,7 @@ test "add2" {
 
 ///|
 test "add3" {
-  let map = new()
+  let map = new_sorted_map()
   map.set(4, "a")
   map.set(1, "b")
   map.set(3, "c")
@@ -717,7 +715,7 @@ test "add3" {
 
 ///|
 test "add4" {
-  let map = new()
+  let map = new_sorted_map()
   map.set(1, "a")
   map.set(4, "b")
   map.set(2, "c")
@@ -793,7 +791,7 @@ test "remove" {
 
 ///|
 test "_[_]=_" {
-  let map = new()
+  let map = new_sorted_map()
   map[1] = "a"
   map[2] = "b"
   map[3] = "c"
@@ -840,5 +838,5 @@ test "copy" {
 
 ///|
 pub impl[K, V] Default for SortedMap[K, V] with default() {
-  new()
+  new_sorted_map()
 }

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -31,7 +31,7 @@ test "remove3" {
 
 ///|
 test "remove on empty map" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   map.remove(1)
   inspect(map.length(), content="0")
 }
@@ -95,7 +95,7 @@ test "equal" {
 
 ///|
 test "is_empty" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   inspect(map.is_empty(), content="true")
   map[1] = "a"
   inspect(map.is_empty(), content="false")
@@ -264,7 +264,7 @@ test "to_json with non-empty map" {
 
 ///|
 test "to_json with empty map" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   @json.json_inspect(map.to_json(), content={})
 }
 
@@ -314,7 +314,7 @@ test "@sorted_map.merge" {
 
 ///|
 test "@sorted_map.merge empty maps" {
-  let map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   let map2 = @sorted_map.from_array([(1, "a"), (2, "b")])
   let merged1 = map1.merge(map2)
   inspect(merged1.to_array(), content="[(1, \"a\"), (2, \"b\")]")
@@ -339,7 +339,7 @@ test "@sorted_map.merge_in_place" {
 
 ///|
 test "@sorted_map.merge_in_place empty maps" {
-  let map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   let map2 = @sorted_map.from_array([(1, "a"), (2, "b")])
   map1.merge_in_place(map2)
   inspect(map1.to_array(), content="[(1, \"a\"), (2, \"b\")]")
@@ -416,7 +416,7 @@ test "range with out-of-bounds keys" {
 
 ///|
 test "range on empty map" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
+  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
   inspect(map.range(1, 5), content="[]")
 }
 

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -49,7 +49,8 @@ pub fn[K, V] SortedMap::keys_as_iter(Self[K, V]) -> Iter[K]
 pub fn[K, V] SortedMap::length(Self[K, V]) -> Int
 pub fn[K : Compare, V] SortedMap::merge(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K : Compare, V] SortedMap::merge_in_place(Self[K, V], Self[K, V]) -> Unit
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[K, V] SortedMap::new() -> Self[K, V]
 pub fn[K : Compare, V] SortedMap::range(Self[K, V], K, K) -> Iter2[K, V]
 pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -84,7 +84,7 @@ pub impl[V : @json.FromJson] @json.FromJson for SortedMap[String, V] with from_j
       (path, "@sorted_map.from_json: expected object"),
     )
   }
-  let map = new()
+  let map = new_sorted_map()
   for k, v in obj {
     map.set(k, V::from_json(v, path.add_key(k)))
   }

--- a/sorted_set/README.mbt.md
+++ b/sorted_set/README.mbt.md
@@ -11,7 +11,7 @@ You can create an empty SortedSet or a SortedSet from other containers.
 ```mbt check
 ///|
 test {
-  let _set1 : @sorted_set.SortedSet[Int] = @sorted_set.new()
+  let _set1 : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
   let _set2 = @sorted_set.singleton(1)
   let _set3 = @sorted_set.from_array([1])
 }
@@ -79,7 +79,7 @@ Whether the set is empty.
 ```mbt check
 ///|
 test {
-  let set : @sorted_set.SortedSet[Int] = @sorted_set.new()
+  let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
   assert_eq(set.is_empty(), true)
 }
 ```

--- a/sorted_set/deprecated.mbt
+++ b/sorted_set/deprecated.mbt
@@ -11,3 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+///|
+/// Construct an empty set.
+///
+/// Deprecated: use `SortedSet([])` instead.
+#deprecated("Use `SortedSet([])` instead")
+#as_free_fn(deprecated="Use `SortedSet([])` instead")
+pub fn[V] SortedSet::new() -> SortedSet[V] {
+  new_sorted_set()
+}

--- a/sorted_set/pkg.generated.mbti
+++ b/sorted_set/pkg.generated.mbti
@@ -42,7 +42,8 @@ pub fn[V] SortedSet::is_empty(Self[V]) -> Bool
 pub fn[V] SortedSet::iter(Self[V]) -> Iter[V]
 #alias(size, deprecated)
 pub fn[V] SortedSet::length(Self[V]) -> Int
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[V] SortedSet::new() -> Self[V]
 pub fn[V : Compare] SortedSet::range(Self[V], V, V) -> Iter[V]
 pub fn[V : Compare] SortedSet::remove(Self[V], V) -> Unit

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -15,9 +15,7 @@
 /// Constructions
 
 ///|
-/// Construct an empty set.
-#as_free_fn
-pub fn[V] SortedSet::new() -> SortedSet[V] {
+fn[V] new_sorted_set() -> SortedSet[V] {
   { root: None, size: 0 }
 }
 
@@ -43,7 +41,7 @@ pub fn[V] SortedSet::singleton(value : V) -> SortedSet[V] {
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
 pub fn[V : Compare] SortedSet::SortedSet(array : ArrayView[V]) -> SortedSet[V] {
-  let set = new()
+  let set = new_sorted_set()
   for x in array {
     set.add(x)
   }
@@ -59,7 +57,7 @@ pub fn[V : Compare] SortedSet::SortedSet(array : ArrayView[V]) -> SortedSet[V] {
 #alias(clone, deprecated)
 pub fn[V] SortedSet::copy(self : SortedSet[V]) -> SortedSet[V] {
   match self.root {
-    None => new()
+    None => new_sorted_set()
     Some(_) => { root: copy_tree(self.root), size: self.size }
   }
 }
@@ -181,7 +179,7 @@ pub fn[V : Compare] SortedSet::union(
     }
     (Some(_), None) => { root: copy_tree(self.root), size: self.size }
     (None, Some(_)) => { root: copy_tree(src.root), size: src.size }
-    (None, None) => new()
+    (None, None) => new_sorted_set()
   }
 }
 
@@ -273,7 +271,7 @@ pub fn[V : Compare] SortedSet::difference(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
-  let ret = new()
+  let ret = new_sorted_set()
   self.each(x => if !src.contains(x) { ret.add(x) })
   ret
 }
@@ -318,7 +316,7 @@ pub fn[V : Compare] SortedSet::intersection(
   self : SortedSet[V],
   src : SortedSet[V],
 ) -> SortedSet[V] {
-  let ret = new()
+  let ret = new_sorted_set()
   self.each(x => if src.contains(x) { ret.add(x) })
   ret
 }
@@ -454,7 +452,7 @@ pub fn[V] SortedSet::iter(self : SortedSet[V]) -> Iter[V] {
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 pub fn[V : Compare] SortedSet::from_iter(iter : Iter[V]) -> SortedSet[V] {
-  let s = new()
+  let s = new_sorted_set()
   while iter.next() is Some(e) {
     s.add(e)
   }
@@ -719,8 +717,8 @@ test "union" {
   inspect(set3.debug_tree(), content="([2]2,([1]1,_,_),([1]3,_,_))")
 
   // Test 4: Union of two empty sets
-  let set1 : SortedSet[Int] = new()
-  let set2 = new()
+  let set1 : SortedSet[Int] = new_sorted_set()
+  let set2 = new_sorted_set()
   let set3 = set1.union(set2)
   inspect(set3, content="@sorted_set.from_array([])")
   inspect(set3.debug_tree(), content="_")
@@ -840,7 +838,7 @@ test "join" {
 
 ///|
 test "add to empty set" {
-  let set = new()
+  let set = new_sorted_set()
   set.add(1)
   @test.assert_eq(set.contains(1), true)
   inspect(set.debug_tree(), content="([1]1,_,_)")
@@ -848,7 +846,7 @@ test "add to empty set" {
 
 ///|
 test "add to non-empty set" {
-  let set = new()
+  let set = new_sorted_set()
   set.add(1)
   set.add(2)
   @test.assert_eq(set.contains(1), true)
@@ -858,7 +856,7 @@ test "add to non-empty set" {
 
 ///|
 test "add duplicate value" {
-  let set = new()
+  let set = new_sorted_set()
   set.add(1)
   set.add(1)
   @test.assert_eq(set.contains(1), true)
@@ -868,7 +866,7 @@ test "add duplicate value" {
 
 ///|
 test "add multiple values" {
-  let set = new()
+  let set = new_sorted_set()
   set.add(1)
   set.add(2)
   set.add(3)
@@ -1063,5 +1061,5 @@ test "add_and_remove" {
 
 ///|
 pub impl[K] Default for SortedSet[K] with default() {
-  new()
+  new_sorted_set()
 }

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "remove on empty set" {
-  let set : @sorted_set.SortedSet[Int] = @sorted_set.new()
+  let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
   set.remove(0)
   inspect(set.length(), content="0")
 }
@@ -93,7 +93,7 @@ test "each" {
   let result = StringBuilder::new(size_hint=10)
   set.each(x => result.write_string(x.to_string()))
   inspect(result.to_string(), content="123456789")
-  let set : @sorted_set.SortedSet[Int] = @sorted_set.new()
+  let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
   set.each(_x => abort("Impossible to reach"))
 }
 
@@ -328,8 +328,8 @@ test "@sorted_set.symmetric_difference/basic" {
 ///|
 test "@sorted_set.symmetric_difference/empty" {
   // Test with empty sets
-  let empty1 = @sorted_set.new()
-  let empty2 = @sorted_set.new()
+  let empty1 = @sorted_set.SortedSet([])
+  let empty2 = @sorted_set.SortedSet([])
   let result1 = empty1.symmetric_difference(empty2)
   inspect(result1, content="@sorted_set.from_array([])")
 

--- a/string/internal/regex_engine/regex.mbt
+++ b/string/internal/regex_engine/regex.mbt
@@ -53,7 +53,7 @@ fn Regex::new(
     symbol_table,
     symbol_repr,
     start_states: [],
-    state_table: @hashmap.HashMap::new(),
+    state_table: @hashmap.HashMap([]),
     transition_table: [],
     final_table: [],
     states: [],

--- a/string/internal/regex_engine/symbol_map/symbol_map.mbt
+++ b/string/internal/regex_engine/symbol_map/symbol_map.mbt
@@ -18,7 +18,7 @@ struct SymbolMap(@sorted_set.SortedSet[Rechar])
 ///|
 /// Create a new instance.
 pub fn new() -> SymbolMap {
-  SymbolMap(@sorted_set.new())
+  SymbolMap(@sorted_set.SortedSet([]))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Add `capacity?` to `HashMap::HashMap`, `HashSet::HashSet`, and `Deque::Deque` so empty constructors with capacity can be written as `Type([], capacity=...)`.
- Move `new` constructors for `HashMap`, `HashSet`, `Deque`, `Queue`, mutable and immutable `PriorityQueue`, `SortedMap`, and `SortedSet` into `deprecated.mbt` with replacement guidance.
- Update docs, tests, and internal call sites to use the direct `Type([])` constructor form.

## Notes

`moon ide doc '*::new'` no longer shows these collection constructors in the non-deprecated inventory. Remaining `new` APIs are builders, domain constructors, or collections without the same `Type([])` constructor pattern.

## Validation

- `moon test hashmap hashset deque queue priority_queue immut/priority_queue sorted_map sorted_set string/internal/regex_engine bytes/internal/regex_engine internal/regex_engine`
- `moon info && moon fmt`
- `moon check && moon test`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/core/pull/3512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
