### PR TITLE
feat(sorted_map): add SortedMap::update_or_init

### DIFF
--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -158,7 +158,7 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 }
 
 ///|
-/// Updates the value for `key` by applying `f` to it, using `init()` as the
+/// Updates the value for `key` by applying `f` to it, using `init` as the
 /// starting value when the key is absent.
 ///
 /// This is the symmetric mutating counterpart to `get_or_init`: it is the
@@ -169,9 +169,9 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 /// ```mbt check
 /// test {
 ///   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
-///   counts.update_or_init("a", init=() => 0, x => x + 1)
-///   counts.update_or_init("a", init=() => 0, x => x + 1)
-///   counts.update_or_init("b", init=() => 0, x => x + 1)
+///   counts.update_or_init("a", init=0, x => x + 1)
+///   counts.update_or_init("a", init=0, x => x + 1)
+///   counts.update_or_init("b", init=0, x => x + 1)
 ///   debug_inspect(counts.get("a"), content="Some(2)")
 ///   debug_inspect(counts.get("b"), content="Some(1)")
 /// }
@@ -179,12 +179,12 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 pub fn[K : Compare, V] SortedMap::update_or_init(
   self : SortedMap[K, V],
   key : K,
-  init~ : () -> V,
+  init~ : V,
   f : (V) -> V,
 ) -> Unit {
   let v = match self.get(key) {
     Some(v) => v
-    None => init()
+    None => init
   }
   self.set(key, f(v))
 }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -158,35 +158,35 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 }
 
 ///|
-/// Updates the value for `key` by applying `f` to it, using `init` as the
-/// starting value when the key is absent.
-///
-/// This is the symmetric mutating counterpart to `get_or_init`: it is the
-/// idiomatic way to express "increment a counter, defaulting to zero" and
-/// similar tally/histogram patterns without two lookups.
+/// Inserts `default` for `key` if it is absent, otherwise replaces the existing
+/// value with `f(existing)`. The pairing of an eager `default` value with a
+/// modifier function lets the canonical counter pattern read literally:
 ///
 /// # Example
 /// ```mbt check
 /// test {
 ///   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
-///   counts.update_or_init("a", 0, x => x + 1)
-///   counts.update_or_init("a", 0, x => x + 1)
-///   counts.update_or_init("b", 0, x => x + 1)
+///   counts.update_or_default("a", 1, x => x + 1)
+///   counts.update_or_default("a", 1, x => x + 1)
+///   counts.update_or_default("b", 1, x => x + 1)
 ///   debug_inspect(counts.get("a"), content="Some(2)")
 ///   debug_inspect(counts.get("b"), content="Some(1)")
 /// }
 /// ```
-pub fn[K : Compare, V] SortedMap::update_or_init(
+///
+/// Note: `f` is *not* applied to `default` on first insertion — `default` is
+/// the value stored when the key is absent. This mirrors Java's `Map.merge`
+/// and Rust's `Entry::and_modify(f).or_insert(default)`.
+pub fn[K : Compare, V] SortedMap::update_or_default(
   self : SortedMap[K, V],
   key : K,
-  init : V,
+  default : V,
   f : (V) -> V,
 ) -> Unit {
-  let v = match self.get(key) {
-    Some(v) => v
-    None => init
+  match self.get(key) {
+    Some(v) => self.set(key, f(v))
+    None => self.set(key, default)
   }
-  self.set(key, f(v))
 }
 
 ///|

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -183,9 +183,12 @@ pub fn[K : Compare, V] SortedMap::update_or_default(
   default : V,
   f : (V) -> V,
 ) -> Unit {
-  match self.get(key) {
-    Some(v) => self.set(key, f(v))
-    None => self.set(key, default)
+  let (new_root, inserted) = update_or_default_node(self.root, key, default, f)
+  if self.root != new_root {
+    self.root = new_root
+  }
+  if inserted {
+    self.size += 1
   }
 }
 
@@ -642,6 +645,34 @@ fn[K : Compare, V] add_node(
           (Some(balance(n)), inserted)
         } else {
           let (nr, inserted) = add_node(r, key, value)
+          n.right = nr
+          (Some(balance(n)), inserted)
+        }
+      }
+  }
+}
+
+///|
+fn[K : Compare, V] update_or_default_node(
+  root : Node[K, V]?,
+  key : K,
+  default : V,
+  f : (V) -> V,
+) -> (Node[K, V]?, Bool) {
+  match root {
+    None => (Some(new_node(key, default)), true)
+    Some(n) =>
+      if key == n.key {
+        n.value = f(n.value)
+        (Some(n), false)
+      } else {
+        let (l, r) = (n.left, n.right)
+        if key < n.key {
+          let (nl, inserted) = update_or_default_node(l, key, default, f)
+          n.left = nl
+          (Some(balance(n)), inserted)
+        } else {
+          let (nr, inserted) = update_or_default_node(r, key, default, f)
           n.right = nr
           (Some(balance(n)), inserted)
         }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -190,6 +190,31 @@ pub fn[K : Compare, V] SortedMap::update_or_init(
 }
 
 ///|
+/// Updates the value for `key` by applying `f` to it, using `V::default()` as
+/// the starting value when the key is absent.
+///
+/// Convenience over `update_or_init` for value types with a `Default`
+/// implementation (mirrors Rust's `Entry::or_default`):
+///
+/// ```mbt check
+/// test {
+///   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
+///   counts.update_or_default("a", x => x + 1)
+///   counts.update_or_default("a", x => x + 1)
+///   counts.update_or_default("b", x => x + 1)
+///   debug_inspect(counts.get("a"), content="Some(2)")
+///   debug_inspect(counts.get("b"), content="Some(1)")
+/// }
+/// ```
+pub fn[K : Compare, V : Default] SortedMap::update_or_default(
+  self : SortedMap[K, V],
+  key : K,
+  f : (V) -> V,
+) -> Unit {
+  self.update_or_init(key, Default::default(), f)
+}
+
+///|
 /// Returns the value for the key if present, otherwise returns `default`.
 pub fn[K : Compare, V] SortedMap::get_or_default(
   self : SortedMap[K, V],

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -158,6 +158,38 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 }
 
 ///|
+/// Updates the value for `key` by applying `f` to it, using `init()` as the
+/// starting value when the key is absent.
+///
+/// This is the symmetric mutating counterpart to `get_or_init`: it is the
+/// idiomatic way to express "increment a counter, defaulting to zero" and
+/// similar tally/histogram patterns without two lookups.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
+///   counts.update_or_init("a", init=() => 0, x => x + 1)
+///   counts.update_or_init("a", init=() => 0, x => x + 1)
+///   counts.update_or_init("b", init=() => 0, x => x + 1)
+///   debug_inspect(counts.get("a"), content="Some(2)")
+///   debug_inspect(counts.get("b"), content="Some(1)")
+/// }
+/// ```
+pub fn[K : Compare, V] SortedMap::update_or_init(
+  self : SortedMap[K, V],
+  key : K,
+  init~ : () -> V,
+  f : (V) -> V,
+) -> Unit {
+  let v = match self.get(key) {
+    Some(v) => v
+    None => init()
+  }
+  self.set(key, f(v))
+}
+
+///|
 /// Returns the value for the key if present, otherwise returns `default`.
 pub fn[K : Compare, V] SortedMap::get_or_default(
   self : SortedMap[K, V],

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -190,31 +190,6 @@ pub fn[K : Compare, V] SortedMap::update_or_init(
 }
 
 ///|
-/// Updates the value for `key` by applying `f` to it, using `V::default()` as
-/// the starting value when the key is absent.
-///
-/// Convenience over `update_or_init` for value types with a `Default`
-/// implementation (mirrors Rust's `Entry::or_default`):
-///
-/// ```mbt check
-/// test {
-///   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
-///   counts.update_or_default("a", x => x + 1)
-///   counts.update_or_default("a", x => x + 1)
-///   counts.update_or_default("b", x => x + 1)
-///   debug_inspect(counts.get("a"), content="Some(2)")
-///   debug_inspect(counts.get("b"), content="Some(1)")
-/// }
-/// ```
-pub fn[K : Compare, V : Default] SortedMap::update_or_default(
-  self : SortedMap[K, V],
-  key : K,
-  f : (V) -> V,
-) -> Unit {
-  self.update_or_init(key, Default::default(), f)
-}
-
-///|
 /// Returns the value for the key if present, otherwise returns `default`.
 pub fn[K : Compare, V] SortedMap::get_or_default(
   self : SortedMap[K, V],

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -169,9 +169,9 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 /// ```mbt check
 /// test {
 ///   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
-///   counts.update_or_init("a", init=0, x => x + 1)
-///   counts.update_or_init("a", init=0, x => x + 1)
-///   counts.update_or_init("b", init=0, x => x + 1)
+///   counts.update_or_init("a", 0, x => x + 1)
+///   counts.update_or_init("a", 0, x => x + 1)
+///   counts.update_or_init("b", 0, x => x + 1)
 ///   debug_inspect(counts.get("a"), content="Some(2)")
 ///   debug_inspect(counts.get("b"), content="Some(1)")
 /// }
@@ -179,7 +179,7 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 pub fn[K : Compare, V] SortedMap::update_or_init(
   self : SortedMap[K, V],
   key : K,
-  init~ : V,
+  init : V,
   f : (V) -> V,
 ) -> Unit {
   let v = match self.get(key) {

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -388,7 +388,7 @@ test "get_or_default returns existing value" {
 ///|
 test "update_or_init applies f to init when absent" {
   let map = @sorted_map.from_array([(1, "a"), (3, "c")])
-  map.update_or_init(2, init="b", x => x + "!")
+  map.update_or_init(2, "b", x => x + "!")
   debug_inspect(map.get(2), content="Some(\"b!\")")
   inspect(map.length(), content="3")
 }
@@ -397,7 +397,7 @@ test "update_or_init applies f to init when absent" {
 test "update_or_init updates when present" {
   let map = @sorted_map.from_array([(1, "a"), (2, "b")])
   // init is ignored when key is present; only f is applied to the existing value
-  map.update_or_init(2, init="z", x => x + "!")
+  map.update_or_init(2, "z", x => x + "!")
   debug_inspect(map.get(2), content="Some(\"b!\")")
   inspect(map.length(), content="2")
 }
@@ -406,7 +406,7 @@ test "update_or_init updates when present" {
 test "update_or_init counter pattern" {
   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
   for label in ["a", "b", "a", "c", "a", "b"] {
-    counts.update_or_init(label, init=0, x => x + 1)
+    counts.update_or_init(label, 0, x => x + 1)
   }
   inspect(
     counts.to_array(),

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -388,7 +388,7 @@ test "get_or_default returns existing value" {
 ///|
 test "update_or_init applies f to init when absent" {
   let map = @sorted_map.from_array([(1, "a"), (3, "c")])
-  map.update_or_init(2, init=() => "b", x => x + "!")
+  map.update_or_init(2, init="b", x => x + "!")
   debug_inspect(map.get(2), content="Some(\"b!\")")
   inspect(map.length(), content="3")
 }
@@ -396,17 +396,8 @@ test "update_or_init applies f to init when absent" {
 ///|
 test "update_or_init updates when present" {
   let map = @sorted_map.from_array([(1, "a"), (2, "b")])
-  let mut initialized = false
-  map.update_or_init(
-    2,
-    init=() => {
-      initialized = true
-      "z"
-    },
-    x => x + "!",
-  )
-  // init should not run when key was present
-  inspect(initialized, content="false")
+  // init is ignored when key is present; only f is applied to the existing value
+  map.update_or_init(2, init="z", x => x + "!")
   debug_inspect(map.get(2), content="Some(\"b!\")")
   inspect(map.length(), content="2")
 }
@@ -415,7 +406,7 @@ test "update_or_init updates when present" {
 test "update_or_init counter pattern" {
   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
   for label in ["a", "b", "a", "c", "a", "b"] {
-    counts.update_or_init(label, init=() => 0, x => x + 1)
+    counts.update_or_init(label, init=0, x => x + 1)
   }
   inspect(
     counts.to_array(),

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -417,6 +417,20 @@ test "update_or_init counter pattern" {
 }
 
 ///|
+test "update_or_default counter pattern" {
+  let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
+  for label in ["a", "b", "a", "c", "a", "b"] {
+    counts.update_or_default(label, x => x + 1)
+  }
+  inspect(
+    counts.to_array(),
+    content=(
+      #|[("a", 3), ("b", 2), ("c", 1)]
+    ),
+  )
+}
+
+///|
 test "range with inverted bounds returns empty" {
   let map = @sorted_map.from_array([
     (1, "a"),

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -386,27 +386,28 @@ test "get_or_default returns existing value" {
 }
 
 ///|
-test "update_or_init applies f to init when absent" {
+test "update_or_default inserts default when absent" {
   let map = @sorted_map.from_array([(1, "a"), (3, "c")])
-  map.update_or_init(2, "b", x => x + "!")
-  debug_inspect(map.get(2), content="Some(\"b!\")")
+  map.update_or_default(2, "b", x => x + "!")
+  // f is NOT applied to default on first insert
+  debug_inspect(map.get(2), content="Some(\"b\")")
   inspect(map.length(), content="3")
 }
 
 ///|
-test "update_or_init updates when present" {
+test "update_or_default applies f when present" {
   let map = @sorted_map.from_array([(1, "a"), (2, "b")])
-  // init is ignored when key is present; only f is applied to the existing value
-  map.update_or_init(2, "z", x => x + "!")
+  // default is ignored when key is present; f is applied to the existing value
+  map.update_or_default(2, "z", x => x + "!")
   debug_inspect(map.get(2), content="Some(\"b!\")")
   inspect(map.length(), content="2")
 }
 
 ///|
-test "update_or_init counter pattern" {
+test "update_or_default counter pattern" {
   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
   for label in ["a", "b", "a", "c", "a", "b"] {
-    counts.update_or_init(label, 0, x => x + 1)
+    counts.update_or_default(label, 1, x => x + 1)
   }
   inspect(
     counts.to_array(),

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -417,20 +417,6 @@ test "update_or_init counter pattern" {
 }
 
 ///|
-test "update_or_default counter pattern" {
-  let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
-  for label in ["a", "b", "a", "c", "a", "b"] {
-    counts.update_or_default(label, x => x + 1)
-  }
-  inspect(
-    counts.to_array(),
-    content=(
-      #|[("a", 3), ("b", 2), ("c", 1)]
-    ),
-  )
-}
-
-///|
 test "range with inverted bounds returns empty" {
   let map = @sorted_map.from_array([
     (1, "a"),

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -386,6 +386,46 @@ test "get_or_default returns existing value" {
 }
 
 ///|
+test "update_or_init applies f to init when absent" {
+  let map = @sorted_map.from_array([(1, "a"), (3, "c")])
+  map.update_or_init(2, init=() => "b", x => x + "!")
+  debug_inspect(map.get(2), content="Some(\"b!\")")
+  inspect(map.length(), content="3")
+}
+
+///|
+test "update_or_init updates when present" {
+  let map = @sorted_map.from_array([(1, "a"), (2, "b")])
+  let mut initialized = false
+  map.update_or_init(
+    2,
+    init=() => {
+      initialized = true
+      "z"
+    },
+    x => x + "!",
+  )
+  // init should not run when key was present
+  inspect(initialized, content="false")
+  debug_inspect(map.get(2), content="Some(\"b!\")")
+  inspect(map.length(), content="2")
+}
+
+///|
+test "update_or_init counter pattern" {
+  let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
+  for label in ["a", "b", "a", "c", "a", "b"] {
+    counts.update_or_init(label, init=() => 0, x => x + 1)
+  }
+  inspect(
+    counts.to_array(),
+    content=(
+      #|[("a", 3), ("b", 2), ("c", 1)]
+    ),
+  )
+}
+
+///|
 test "range with inverted bounds returns empty" {
   let map = @sorted_map.from_array([
     (1, "a"),

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -58,7 +58,7 @@ pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 #alias(add, deprecated)
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
-pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
+pub fn[K : Compare, V] SortedMap::update_or_default(Self[K, V], K, V, (V) -> V) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]
 pub fn[K, V] SortedMap::values_as_iter(Self[K, V]) -> Iter[V]

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -58,6 +58,7 @@ pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 #alias(add, deprecated)
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
+pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, init~ : () -> V, (V) -> V) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]
 pub fn[K, V] SortedMap::values_as_iter(Self[K, V]) -> Iter[V]

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -58,7 +58,6 @@ pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 #alias(add, deprecated)
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
-pub fn[K : Compare, V : Default] SortedMap::update_or_default(Self[K, V], K, (V) -> V) -> Unit
 pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -58,6 +58,7 @@ pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 #alias(add, deprecated)
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
+pub fn[K : Compare, V : Default] SortedMap::update_or_default(Self[K, V], K, (V) -> V) -> Unit
 pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -58,7 +58,7 @@ pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 #alias(add, deprecated)
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
-pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, init~ : () -> V, (V) -> V) -> Unit
+pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, init~ : V, (V) -> V) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]
 pub fn[K, V] SortedMap::values_as_iter(Self[K, V]) -> Iter[V]

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -58,7 +58,7 @@ pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 #alias(add, deprecated)
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
-pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, init~ : V, (V) -> V) -> Unit
+pub fn[K : Compare, V] SortedMap::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]
 pub fn[K, V] SortedMap::values_as_iter(Self[K, V]) -> Iter[V]


### PR DESCRIPTION
## Summary
- Adds `SortedMap::update_or_init(key, init~, f)` — the symmetric mutating counterpart to `get_or_init`.
- Idiomatic for tally/histogram patterns:
  ```moonbit
  counts.update_or_init(key, init=() => 0, x => x + 1)
  ```
- Semantics: applies `f` to the existing value, or to the value produced by `init()` when the key is absent.

## Test plan
- [x] `moon test -p moonbitlang/core/sorted_map`
- [x] `moon info && moon fmt` (mbti updated, formatting clean)
- [x] `moon check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)