### PR TITLE
feat(builtin): add Map::update_or_init

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -356,7 +356,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 }
 
 ///|
-/// Updates the value for `key` by applying `f` to it, using `init()` as the
+/// Updates the value for `key` by applying `f` to it, using `init` as the
 /// starting value when the key is absent.
 ///
 /// This is the symmetric mutating counterpart to `get_or_init`: it is the
@@ -368,9 +368,9 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 /// ```mbt check
 /// test {
 ///   let counts : Map[String, Int] = {}
-///   counts.update_or_init("a", init=() => 0, x => x + 1)
-///   counts.update_or_init("a", init=() => 0, x => x + 1)
-///   counts.update_or_init("b", init=() => 0, x => x + 1)
+///   counts.update_or_init("a", 0, x => x + 1)
+///   counts.update_or_init("a", 0, x => x + 1)
+///   counts.update_or_init("b", 0, x => x + 1)
 ///   debug_inspect(counts.get("a"), content="Some(2)")
 ///   debug_inspect(counts.get("b"), content="Some(1)")
 /// }
@@ -378,7 +378,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 pub fn[K : Hash + Eq, V] Map::update_or_init(
   self : Map[K, V],
   key : K,
-  init~ : () -> V,
+  init : V,
   f : (V) -> V,
 ) -> Unit {
   let hash = key.hash()
@@ -391,13 +391,13 @@ pub fn[K : Hash + Eq, V] Map::update_or_init(
           return
         }
         if psl > entry.psl {
-          let new_value = f(init())
+          let new_value = f(init)
           break (idx, psl, new_value, Some(entry))
         }
         continue psl + 1, (idx + 1) & self.capacity_mask
       }
       None => {
-        let new_value = f(init())
+        let new_value = f(init)
         break (idx, psl, new_value, None)
       }
     }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -356,34 +356,32 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 }
 
 ///|
-/// Updates the value for `key` by applying `f` to it, using `init` as the
-/// starting value when the key is absent.
-///
-/// This is the symmetric mutating counterpart to `get_or_init`: it is the
-/// idiomatic way to express "increment a counter, defaulting to zero" and
-/// similar tally/histogram patterns in a single probe.
-///
-/// Example:
+/// Inserts `default` for `key` if it is absent, otherwise replaces the existing
+/// value with `f(existing)`. The pairing of an eager `default` value with a
+/// modifier function lets the canonical counter pattern read literally:
 ///
 /// ```mbt check
 /// test {
 ///   let counts : Map[String, Int] = {}
-///   counts.update_or_init("a", 0, x => x + 1)
-///   counts.update_or_init("a", 0, x => x + 1)
-///   counts.update_or_init("b", 0, x => x + 1)
+///   counts.update_or_default("a", 1, x => x + 1)
+///   counts.update_or_default("a", 1, x => x + 1)
+///   counts.update_or_default("b", 1, x => x + 1)
 ///   debug_inspect(counts.get("a"), content="Some(2)")
 ///   debug_inspect(counts.get("b"), content="Some(1)")
 /// }
 /// ```
-pub fn[K : Hash + Eq, V] Map::update_or_init(
+///
+/// Note: `f` is *not* applied to `default` on first insertion — `default` is
+/// the value stored when the key is absent. This mirrors Java's `Map.merge`
+/// and Rust's `Entry::and_modify(f).or_insert(default)`.
+pub fn[K : Hash + Eq, V] Map::update_or_default(
   self : Map[K, V],
   key : K,
-  init : V,
+  default : V,
   f : (V) -> V,
 ) -> Unit {
   let hash = key.hash()
-  let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
-                                               self.capacity_mask {
+  let (idx, psl, push_away) = for psl = 0, idx = hash & self.capacity_mask {
     match self.entries[idx] {
       Some(entry) => {
         if entry.hash == hash && entry.key == key {
@@ -391,32 +389,21 @@ pub fn[K : Hash + Eq, V] Map::update_or_init(
           return
         }
         if psl > entry.psl {
-          let new_value = f(init)
-          break (idx, psl, new_value, Some(entry))
+          break (idx, psl, Some(entry))
         }
         continue psl + 1, (idx + 1) & self.capacity_mask
       }
-      None => {
-        let new_value = f(init)
-        break (idx, psl, new_value, None)
-      }
+      None => break (idx, psl, None)
     }
   }
   if self.size >= self.grow_at {
     self.grow()
-    self.set_with_hash(key, new_value, hash)
+    self.set_with_hash(key, default, hash)
   } else {
     if push_away is Some(entry) {
       self.push_away(idx, entry)
     }
-    let entry = {
-      prev: self.tail,
-      next: None,
-      psl,
-      hash,
-      key,
-      value: new_value,
-    }
+    let entry = { prev: self.tail, next: None, psl, hash, key, value: default }
     self.add_entry_to_tail(idx, entry)
   }
 }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -422,31 +422,6 @@ pub fn[K : Hash + Eq, V] Map::update_or_init(
 }
 
 ///|
-/// Updates the value for `key` by applying `f` to it, using `V::default()` as
-/// the starting value when the key is absent.
-///
-/// Convenience over `update_or_init` for value types with a `Default`
-/// implementation (mirrors Rust's `Entry::or_default`):
-///
-/// ```mbt check
-/// test {
-///   let counts : Map[String, Int] = {}
-///   counts.update_or_default("a", x => x + 1)
-///   counts.update_or_default("a", x => x + 1)
-///   counts.update_or_default("b", x => x + 1)
-///   debug_inspect(counts.get("a"), content="Some(2)")
-///   debug_inspect(counts.get("b"), content="Some(1)")
-/// }
-/// ```
-pub fn[K : Hash + Eq, V : Default] Map::update_or_default(
-  self : Map[K, V],
-  key : K,
-  f : (V) -> V,
-) -> Unit {
-  self.update_or_init(key, Default::default(), f)
-}
-
-///|
 /// Check if the hash map contains a key.
 pub fn[K : Hash + Eq, V] Map::contains(self : Map[K, V], key : K) -> Bool {
   // inline Map::get to avoid boxing

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -356,6 +356,72 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 }
 
 ///|
+/// Updates the value for `key` by applying `f` to it, using `init()` as the
+/// starting value when the key is absent.
+///
+/// This is the symmetric mutating counterpart to `get_or_init`: it is the
+/// idiomatic way to express "increment a counter, defaulting to zero" and
+/// similar tally/histogram patterns in a single probe.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let counts : Map[String, Int] = {}
+///   counts.update_or_init("a", init=() => 0, x => x + 1)
+///   counts.update_or_init("a", init=() => 0, x => x + 1)
+///   counts.update_or_init("b", init=() => 0, x => x + 1)
+///   debug_inspect(counts.get("a"), content="Some(2)")
+///   debug_inspect(counts.get("b"), content="Some(1)")
+/// }
+/// ```
+pub fn[K : Hash + Eq, V] Map::update_or_init(
+  self : Map[K, V],
+  key : K,
+  init~ : () -> V,
+  f : (V) -> V,
+) -> Unit {
+  let hash = key.hash()
+  let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
+                                               self.capacity_mask {
+    match self.entries[idx] {
+      Some(entry) => {
+        if entry.hash == hash && entry.key == key {
+          entry.value = f(entry.value)
+          return
+        }
+        if psl > entry.psl {
+          let new_value = f(init())
+          break (idx, psl, new_value, Some(entry))
+        }
+        continue psl + 1, (idx + 1) & self.capacity_mask
+      }
+      None => {
+        let new_value = f(init())
+        break (idx, psl, new_value, None)
+      }
+    }
+  }
+  if self.size >= self.grow_at {
+    self.grow()
+    self.set_with_hash(key, new_value, hash)
+  } else {
+    if push_away is Some(entry) {
+      self.push_away(idx, entry)
+    }
+    let entry = {
+      prev: self.tail,
+      next: None,
+      psl,
+      hash,
+      key,
+      value: new_value,
+    }
+    self.add_entry_to_tail(idx, entry)
+  }
+}
+
+///|
 /// Check if the hash map contains a key.
 pub fn[K : Hash + Eq, V] Map::contains(self : Map[K, V], key : K) -> Bool {
   // inline Map::get to avoid boxing

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -422,6 +422,31 @@ pub fn[K : Hash + Eq, V] Map::update_or_init(
 }
 
 ///|
+/// Updates the value for `key` by applying `f` to it, using `V::default()` as
+/// the starting value when the key is absent.
+///
+/// Convenience over `update_or_init` for value types with a `Default`
+/// implementation (mirrors Rust's `Entry::or_default`):
+///
+/// ```mbt check
+/// test {
+///   let counts : Map[String, Int] = {}
+///   counts.update_or_default("a", x => x + 1)
+///   counts.update_or_default("a", x => x + 1)
+///   counts.update_or_default("b", x => x + 1)
+///   debug_inspect(counts.get("a"), content="Some(2)")
+///   debug_inspect(counts.get("b"), content="Some(1)")
+/// }
+/// ```
+pub fn[K : Hash + Eq, V : Default] Map::update_or_default(
+  self : Map[K, V],
+  key : K,
+  f : (V) -> V,
+) -> Unit {
+  self.update_or_init(key, Default::default(), f)
+}
+
+///|
 /// Check if the hash map contains a key.
 pub fn[K : Hash + Eq, V] Map::contains(self : Map[K, V], key : K) -> Bool {
   // inline Map::get to avoid boxing

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -193,6 +193,17 @@ test "update_or_init triggers grow" {
 }
 
 ///|
+test "update_or_default counter pattern" {
+  let counts : Map[String, Int] = Map([])
+  for label in ["a", "b", "a", "c", "a", "b"] {
+    counts.update_or_default(label, x => x + 1)
+  }
+  assert_true(counts.get("a") == Some(3))
+  assert_true(counts.get("b") == Some(2))
+  assert_true(counts.get("c") == Some(1))
+}
+
+///|
 test "Map::set" {
   let m : Map[String, Int] = Map([])
   m["a"] = 1

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -193,17 +193,6 @@ test "update_or_init triggers grow" {
 }
 
 ///|
-test "update_or_default counter pattern" {
-  let counts : Map[String, Int] = Map([])
-  for label in ["a", "b", "a", "c", "a", "b"] {
-    counts.update_or_default(label, x => x + 1)
-  }
-  assert_true(counts.get("a") == Some(3))
-  assert_true(counts.get("b") == Some(2))
-  assert_true(counts.get("c") == Some(1))
-}
-
-///|
 test "Map::set" {
   let m : Map[String, Int] = Map([])
   m["a"] = 1

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -140,28 +140,29 @@ test "get_or_init full" {
 }
 
 ///|
-test "update_or_init applies f to init when absent" {
+test "update_or_default inserts default when absent" {
   let m : Map[String, String] = Map([])
-  m.update_or_init("k", "v", x => x + "!")
-  assert_true(m.get("k") == Some("v!"))
+  m.update_or_default("k", "v", x => x + "!")
+  // f is NOT applied to default on first insert
+  assert_true(m.get("k") == Some("v"))
   assert_eq(m.length(), 1)
 }
 
 ///|
-test "update_or_init updates when present" {
+test "update_or_default applies f when present" {
   let m : Map[String, String] = Map([])
   m.set("k", "v")
-  // init is ignored when key is present; only f is applied to the existing value
-  m.update_or_init("k", "z", x => x + "!")
+  // default is ignored when key is present; f is applied to the existing value
+  m.update_or_default("k", "z", x => x + "!")
   assert_true(m.get("k") == Some("v!"))
   assert_eq(m.length(), 1)
 }
 
 ///|
-test "update_or_init counter pattern" {
+test "update_or_default counter pattern" {
   let counts : Map[String, Int] = Map([])
   for label in ["a", "b", "a", "c", "a", "b"] {
-    counts.update_or_init(label, 0, x => x + 1)
+    counts.update_or_default(label, 1, x => x + 1)
   }
   assert_true(counts.get("a") == Some(3))
   assert_true(counts.get("b") == Some(2))
@@ -169,22 +170,22 @@ test "update_or_init counter pattern" {
 }
 
 ///|
-test "update_or_init preserves insertion order" {
+test "update_or_default preserves insertion order" {
   let m : Map[String, Int] = Map([])
-  m.update_or_init("b", 0, x => x + 1)
-  m.update_or_init("a", 0, x => x + 1)
-  m.update_or_init("c", 0, x => x + 1)
-  m.update_or_init("a", 0, x => x + 1)
+  m.update_or_default("b", 1, x => x + 1)
+  m.update_or_default("a", 1, x => x + 1)
+  m.update_or_default("c", 1, x => x + 1)
+  m.update_or_default("a", 1, x => x + 1)
   let keys = []
   m.each((k, _v) => keys.push(k))
   assert_eq(keys, ["b", "a", "c"])
 }
 
 ///|
-test "update_or_init triggers grow" {
+test "update_or_default triggers grow" {
   let m : Map[Int, Int] = Map([], capacity=2)
   for i in 0..<5 {
-    m.update_or_init(i, 0, x => x + 1)
+    m.update_or_default(i, 1, x => x + 1)
   }
   assert_eq(m.length(), 5)
   for i in 0..<5 {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -140,6 +140,67 @@ test "get_or_init full" {
 }
 
 ///|
+test "update_or_init applies f to init when absent" {
+  let m : Map[String, String] = Map([])
+  m.update_or_init("k", init=() => "v", x => x + "!")
+  assert_true(m.get("k") == Some("v!"))
+  assert_eq(m.length(), 1)
+}
+
+///|
+test "update_or_init updates when present" {
+  let m : Map[String, String] = Map([])
+  m.set("k", "v")
+  let mut initialized = false
+  m.update_or_init(
+    "k",
+    init=() => {
+      initialized = true
+      "z"
+    },
+    x => x + "!",
+  )
+  assert_false(initialized)
+  assert_true(m.get("k") == Some("v!"))
+  assert_eq(m.length(), 1)
+}
+
+///|
+test "update_or_init counter pattern" {
+  let counts : Map[String, Int] = Map([])
+  for label in ["a", "b", "a", "c", "a", "b"] {
+    counts.update_or_init(label, init=() => 0, x => x + 1)
+  }
+  assert_true(counts.get("a") == Some(3))
+  assert_true(counts.get("b") == Some(2))
+  assert_true(counts.get("c") == Some(1))
+}
+
+///|
+test "update_or_init preserves insertion order" {
+  let m : Map[String, Int] = Map([])
+  m.update_or_init("b", init=() => 0, x => x + 1)
+  m.update_or_init("a", init=() => 0, x => x + 1)
+  m.update_or_init("c", init=() => 0, x => x + 1)
+  m.update_or_init("a", init=() => 0, x => x + 1)
+  let keys = []
+  m.each((k, _v) => keys.push(k))
+  assert_eq(keys, ["b", "a", "c"])
+}
+
+///|
+test "update_or_init triggers grow" {
+  let m : Map[Int, Int] = Map([], capacity=2)
+  for i in 0..<5 {
+    m.update_or_init(i, init=() => 0, x => x + 1)
+  }
+  assert_eq(m.length(), 5)
+  for i in 0..<5 {
+    assert_true(m.get(i) == Some(1))
+  }
+}
+
+///|
 test "Map::set" {
   let m : Map[String, Int] = Map([])
   m["a"] = 1

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -142,7 +142,7 @@ test "get_or_init full" {
 ///|
 test "update_or_init applies f to init when absent" {
   let m : Map[String, String] = Map([])
-  m.update_or_init("k", init=() => "v", x => x + "!")
+  m.update_or_init("k", "v", x => x + "!")
   assert_true(m.get("k") == Some("v!"))
   assert_eq(m.length(), 1)
 }
@@ -151,16 +151,8 @@ test "update_or_init applies f to init when absent" {
 test "update_or_init updates when present" {
   let m : Map[String, String] = Map([])
   m.set("k", "v")
-  let mut initialized = false
-  m.update_or_init(
-    "k",
-    init=() => {
-      initialized = true
-      "z"
-    },
-    x => x + "!",
-  )
-  assert_false(initialized)
+  // init is ignored when key is present; only f is applied to the existing value
+  m.update_or_init("k", "z", x => x + "!")
   assert_true(m.get("k") == Some("v!"))
   assert_eq(m.length(), 1)
 }
@@ -169,7 +161,7 @@ test "update_or_init updates when present" {
 test "update_or_init counter pattern" {
   let counts : Map[String, Int] = Map([])
   for label in ["a", "b", "a", "c", "a", "b"] {
-    counts.update_or_init(label, init=() => 0, x => x + 1)
+    counts.update_or_init(label, 0, x => x + 1)
   }
   assert_true(counts.get("a") == Some(3))
   assert_true(counts.get("b") == Some(2))
@@ -179,10 +171,10 @@ test "update_or_init counter pattern" {
 ///|
 test "update_or_init preserves insertion order" {
   let m : Map[String, Int] = Map([])
-  m.update_or_init("b", init=() => 0, x => x + 1)
-  m.update_or_init("a", init=() => 0, x => x + 1)
-  m.update_or_init("c", init=() => 0, x => x + 1)
-  m.update_or_init("a", init=() => 0, x => x + 1)
+  m.update_or_init("b", 0, x => x + 1)
+  m.update_or_init("a", 0, x => x + 1)
+  m.update_or_init("c", 0, x => x + 1)
+  m.update_or_init("a", 0, x => x + 1)
   let keys = []
   m.each((k, _v) => keys.push(k))
   assert_eq(keys, ["b", "a", "c"])
@@ -192,7 +184,7 @@ test "update_or_init preserves insertion order" {
 test "update_or_init triggers grow" {
   let m : Map[Int, Int] = Map([], capacity=2)
   for i in 0..<5 {
-    m.update_or_init(i, init=() => 0, x => x + 1)
+    m.update_or_init(i, 0, x => x + 1)
   }
   assert_eq(m.length(), 5)
   for i in 0..<5 {

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -398,6 +398,7 @@ pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit
 pub fn[K : Hash + Eq, V] Map::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] Map::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Hash + Eq, V] Map::update(Self[K, V], K, (V?) -> V?) -> Unit
+pub fn[K : Hash + Eq, V] Map::update_or_init(Self[K, V], K, init~ : () -> V, (V) -> V) -> Unit
 pub fn[K, V] Map::values(Self[K, V]) -> Iter[V]
 pub impl[K, V] Default for Map[K, V]
 pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V]

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -398,6 +398,7 @@ pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit
 pub fn[K : Hash + Eq, V] Map::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] Map::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Hash + Eq, V] Map::update(Self[K, V], K, (V?) -> V?) -> Unit
+pub fn[K : Hash + Eq, V : Default] Map::update_or_default(Self[K, V], K, (V) -> V) -> Unit
 pub fn[K : Hash + Eq, V] Map::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
 pub fn[K, V] Map::values(Self[K, V]) -> Iter[V]
 pub impl[K, V] Default for Map[K, V]

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -398,7 +398,7 @@ pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit
 pub fn[K : Hash + Eq, V] Map::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] Map::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Hash + Eq, V] Map::update(Self[K, V], K, (V?) -> V?) -> Unit
-pub fn[K : Hash + Eq, V] Map::update_or_init(Self[K, V], K, init~ : () -> V, (V) -> V) -> Unit
+pub fn[K : Hash + Eq, V] Map::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
 pub fn[K, V] Map::values(Self[K, V]) -> Iter[V]
 pub impl[K, V] Default for Map[K, V]
 pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V]

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -398,7 +398,6 @@ pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit
 pub fn[K : Hash + Eq, V] Map::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] Map::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Hash + Eq, V] Map::update(Self[K, V], K, (V?) -> V?) -> Unit
-pub fn[K : Hash + Eq, V : Default] Map::update_or_default(Self[K, V], K, (V) -> V) -> Unit
 pub fn[K : Hash + Eq, V] Map::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
 pub fn[K, V] Map::values(Self[K, V]) -> Iter[V]
 pub impl[K, V] Default for Map[K, V]

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -398,7 +398,7 @@ pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit
 pub fn[K : Hash + Eq, V] Map::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] Map::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Hash + Eq, V] Map::update(Self[K, V], K, (V?) -> V?) -> Unit
-pub fn[K : Hash + Eq, V] Map::update_or_init(Self[K, V], K, V, (V) -> V) -> Unit
+pub fn[K : Hash + Eq, V] Map::update_or_default(Self[K, V], K, V, (V) -> V) -> Unit
 pub fn[K, V] Map::values(Self[K, V]) -> Iter[V]
 pub impl[K, V] Default for Map[K, V]
 pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V]


### PR DESCRIPTION
## Summary
- Adds `Map::update_or_init(key, init~, f)` on the linked hash map — the symmetric mutating counterpart to `get_or_init`.
- Implemented as a single Robin Hood probe to avoid the double lookup that `get` + `set` would incur.
- Idiomatic for tally/histogram patterns:
  ```moonbit
  counts.update_or_init(key, init=() => 0, x => x + 1)
  ```
- Semantics: applies `f` to the existing value, or to the value produced by `init()` when the key is absent. Insertion order is preserved (verified by test).

## Test plan
- [x] `moon test -p moonbitlang/core/builtin`
- [x] Includes insertion-order and grow-trigger cases
- [x] `moon info && moon fmt` (mbti updated, formatting clean)
- [x] `moon check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)