### PR TITLE
docs(builtin): document Logger helpers

### DIFF
--- a/builtin/logger_test.mbt
+++ b/builtin/logger_test.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "logger trait object calls" {
+  let sb = StringBuilder::new()
+  let logger : &Logger = sb
+  Logger::write_string(logger, "Hello, ")
+  Logger::write_char(logger, 'w')
+  &Logger::write_string(logger, "orld!")
+  &Logger::write_iter(
+    logger,
+    [1, 2, 3].iter(),
+    prefix="[",
+    suffix="]",
+    sep="; ",
+  )
+  inspect(
+    sb,
+    content=(
+      #|Hello, world![1; 2; 3]
+    ),
+  )
+}

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -89,32 +89,43 @@ pub(open) trait Default {
 }
 
 ///|
-/// Trait for a logger, where debug logs can be written into
+/// Trait for append-only text sinks used by `Show` implementations.
+///
+/// A logger receives formatted output without requiring callers to allocate a
+/// complete `String` first.
 pub(open) trait Logger {
+  /// Writes a string to the logger.
   write_string(Self, String) -> Unit = _
+  /// Writes a substring of the given string to the logger.
   #deprecated("use `write_view` instead", skip_current_package=true)
   write_substring(Self, String, Int, Int) -> Unit = _
+  /// Writes a string view to the logger.
   write_view(Self, StringView) -> Unit = _
+  /// Writes a character to the logger.
   write_char(Self, Char) -> Unit = _
 }
 
 ///|
+/// Writes a substring of the given string to the logger.
 impl Logger with write_substring(self, value, start, len) {
   self.write_view(value[start:start + len])
 }
 
 ///|
+/// Writes a string to the logger.
 impl Logger with write_string(self, value) {
   self.write_view(value)
 }
 
 ///|
+/// Writes a string view to the logger.
 #deprecated("replace `impl write_substring` with `impl write_view`")
 impl Logger with write_view(self, value) {
   self.write_substring(value.data(), value.start_offset(), value.length())
 }
 
 ///|
+/// Writes a character to the logger.
 impl Logger with write_char(self, value) {
   self.write_string([value])
 }
@@ -151,13 +162,17 @@ impl Show with to_string(self) {
 }
 
 ///|
-/// Function `write_object`.
+/// Writes the `Show` representation of an object to the logger.
 pub fn[Obj : Show] &Logger::write_object(self : &Logger, obj : Obj) -> Unit {
   obj.output(self)
 }
 
 ///|
-/// Function `write_iter`.
+/// Writes an iterator of `Show` values to the logger.
+///
+/// By default, values are written in list form, such as `[1, 2]`. The
+/// `prefix`, `suffix`, and `sep` arguments customize the surrounding text and
+/// separator. If `trailing` is true, `sep` is also written after the last value.
 pub fn[T : Show] &Logger::write_iter(
   self : &Logger,
   iter : Iter[T],


### PR DESCRIPTION
## Summary
- Document the `Logger` trait, its default impls, and `write_object` / `write_iter` helpers.
- Add a test exercising `Logger` trait-object dispatch (`&Logger::write_string`, `&Logger::write_iter`, etc.).

## Test plan
- [ ] `moon test -p moonbitlang/core/builtin`
- [ ] CI passes