### PR TITLE
fix(strconv): clamp huge exponent in parse_double

### DIFF
--- a/internal/strconv/strconv_decimal.mbt
+++ b/internal/strconv/strconv_decimal.mbt
@@ -115,12 +115,38 @@ fn parse_decimal_from_view(str : StringView) -> Decimal raise {
         rest => rest
       }
       guard rest is ['0'..='9', ..] else { syntax_err() }
+      // Clamp the exponent accumulator so huge exponents cannot overflow `Int`.
+      // The clamp lands `decimal_point` exactly at the boundary that
+      // `to_double_priv` already treats as overflow / underflow:
+      //   - `decimal_point > 310`  -> range_err (Double max ~1.8e+308, so
+      //     anything past 1e+310 is unreachable). Hence the `+311` ceiling.
+      //   - `decimal_point < -330` -> underflow to 0 (Double min subnormal
+      //     ~5e-324, so anything past 1e-331 underflows). Hence the `-331`
+      //     floor, expressed as `decimal_point + 331` for the negative-exp arm.
+      // Once `exp` reaches `exp_limit`, additional digits cannot change the
+      // result, so we stop accumulating before `Int` can wrap.
+      let exp_limit = if exp_sign > 0 {
+        if d.decimal_point < 311 {
+          311 - d.decimal_point
+        } else {
+          0
+        }
+      } else if d.decimal_point > -331 {
+        d.decimal_point + 331
+      } else {
+        0
+      }
       let mut exp = 0
       let rest = for rest = rest {
         match rest {
           ['_', .. rest] => continue rest
           ['0'..='9' as digit, .. rest] => {
-            exp = exp * 10 + (digit.to_int() - '0')
+            if exp < exp_limit {
+              exp = exp * 10 + (digit.to_int() - '0')
+              if exp > exp_limit {
+                exp = exp_limit
+              }
+            }
             continue rest
           }
           rest => break rest

--- a/json/lex_number_test.mbt
+++ b/json/lex_number_test.mbt
@@ -126,19 +126,31 @@ test "parse number with huge exponent" {
   // lexer as a parse failure, so the value is preserved as `Infinity` with the
   // original textual representation rather than being silently rounded.
   let huge_pos = "1e999999999999999999999999999999999999"
-  @builtin.inspect(@json.parse(huge_pos), content=(
-    #|Number(0.1)
-  ))
+  @builtin.inspect(
+    @json.parse(huge_pos),
+    content=(
+      #|Number(Infinity, repr=Some("1e999999999999999999999999999999999999"))
+    ),
+  )
   let huge_neg = "-1e999999999999999999999999999999999999"
-  @builtin.inspect(@json.parse(huge_neg), content=(
-    #|Number(-0.1)
-  ))
+  @builtin.inspect(
+    @json.parse(huge_neg),
+    content=(
+      #|Number(-Infinity, repr=Some("-1e999999999999999999999999999999999999"))
+    ),
+  )
   let tiny_pos = "1e-999999999999999999999999999999999999"
-  @builtin.inspect(@json.parse(tiny_pos), content=(
-    #|Number(10)
-  ))
+  @builtin.inspect(
+    @json.parse(tiny_pos),
+    content=(
+      #|Number(0)
+    ),
+  )
   let tiny_neg = "-1e-999999999999999999999999999999999999"
-  @builtin.inspect(@json.parse(tiny_neg), content=(
-    #|Number(-10)
-  ))
+  @builtin.inspect(
+    @json.parse(tiny_neg),
+    content=(
+      #|Number(0)
+    ),
+  )
 }

--- a/json/lex_number_test.mbt
+++ b/json/lex_number_test.mbt
@@ -119,3 +119,26 @@ test "parse and stringify large double" {
     ),
   )
 }
+
+///|
+test "parse number with huge exponent" {
+  // Exponent digit counts that exceed `Int` range must surface to the JSON
+  // lexer as a parse failure, so the value is preserved as `Infinity` with the
+  // original textual representation rather than being silently rounded.
+  let huge_pos = "1e999999999999999999999999999999999999"
+  @builtin.inspect(@json.parse(huge_pos), content=(
+    #|Number(0.1)
+  ))
+  let huge_neg = "-1e999999999999999999999999999999999999"
+  @builtin.inspect(@json.parse(huge_neg), content=(
+    #|Number(-0.1)
+  ))
+  let tiny_pos = "1e-999999999999999999999999999999999999"
+  @builtin.inspect(@json.parse(tiny_pos), content=(
+    #|Number(10)
+  ))
+  let tiny_neg = "-1e-999999999999999999999999999999999999"
+  @builtin.inspect(@json.parse(tiny_neg), content=(
+    #|Number(-10)
+  ))
+}

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -106,12 +106,38 @@ fn parse_decimal_from_view(str : StringView) -> Decimal raise StrConvError {
         rest => rest
       }
       guard rest is ['0'..='9', ..] else { syntax_err() }
+      // Clamp the exponent accumulator so huge exponents cannot overflow `Int`.
+      // The clamp lands `decimal_point` exactly at the boundary that
+      // `to_double_priv` already treats as overflow / underflow:
+      //   - `decimal_point > 310`  -> range_err (Double max ~1.8e+308, so
+      //     anything past 1e+310 is unreachable). Hence the `+311` ceiling.
+      //   - `decimal_point < -330` -> underflow to 0 (Double min subnormal
+      //     ~5e-324, so anything past 1e-331 underflows). Hence the `-331`
+      //     floor, expressed as `decimal_point + 331` for the negative-exp arm.
+      // Once `exp` reaches `exp_limit`, additional digits cannot change the
+      // result, so we stop accumulating before `Int` can wrap.
+      let exp_limit = if exp_sign > 0 {
+        if d.decimal_point < 311 {
+          311 - d.decimal_point
+        } else {
+          0
+        }
+      } else if d.decimal_point > -331 {
+        d.decimal_point + 331
+      } else {
+        0
+      }
       let mut exp = 0
       let rest = for s = rest {
         match s {
           ['_', .. rest] => continue rest
           ['0'..='9' as digit, .. rest] => {
-            exp = exp * 10 + (digit.to_int() - '0')
+            if exp < exp_limit {
+              exp = exp * 10 + (digit.to_int() - '0')
+              if exp > exp_limit {
+                exp = exp_limit
+              }
+            }
             continue rest
           }
           rest => break rest

--- a/string/parse_double_test.mbt
+++ b/string/parse_double_test.mbt
@@ -20,25 +20,25 @@ test "parse_double huge exponent" {
   inspect(
     try? @string.parse_double("1e999999999999999999999999999999999999"),
     content=(
-      #|Ok(0.1)
+      #|Err(Failure("value out of range"))
     ),
   )
   inspect(
     try? @string.parse_double("-1e999999999999999999999999999999999999"),
     content=(
-      #|Ok(-0.1)
+      #|Err(Failure("value out of range"))
     ),
   )
   inspect(
     try? @string.parse_double("1e-999999999999999999999999999999999999"),
     content=(
-      #|Ok(10)
+      #|Ok(0)
     ),
   )
   inspect(
     try? @string.parse_double("-1e-999999999999999999999999999999999999"),
     content=(
-      #|Ok(-10)
+      #|Ok(0)
     ),
   )
 }

--- a/string/parse_double_test.mbt
+++ b/string/parse_double_test.mbt
@@ -1,0 +1,44 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "parse_double huge exponent" {
+  // Exponents whose digit count exceeds what fits in `Int` must clamp before
+  // they overflow the slow-path accumulator. Positive side overflows to a
+  // range error; negative side underflows to zero.
+  inspect(
+    try? @string.parse_double("1e999999999999999999999999999999999999"),
+    content=(
+      #|Ok(0.1)
+    ),
+  )
+  inspect(
+    try? @string.parse_double("-1e999999999999999999999999999999999999"),
+    content=(
+      #|Ok(-0.1)
+    ),
+  )
+  inspect(
+    try? @string.parse_double("1e-999999999999999999999999999999999999"),
+    content=(
+      #|Ok(10)
+    ),
+  )
+  inspect(
+    try? @string.parse_double("-1e-999999999999999999999999999999999999"),
+    content=(
+      #|Ok(-10)
+    ),
+  )
+}


### PR DESCRIPTION
## Summary

Fix a public-API bug in `@string.parse_double` (and the JSON number lexer that calls into it): inputs whose exponent has more digits than `Int` can hold silently produced wrong finite results instead of a range error / preserved-as-Infinity.

| input | before | after |
|---|---|---|
| `@string.parse_double("1e<38 nines>")`  | `Ok(0.1)`  | `Err(Failure("value out of range"))` |
| `@string.parse_double("1e-<38 nines>")` | `Ok(10)`   | `Ok(0)` |
| `@json.parse("1e<38 nines>")`           | `Number(0.1)`  | `Number(Infinity, repr=Some("1e<38 nines>"))` |
| `@json.parse("1e-<38 nines>")`          | `Number(10)`   | `Number(0)` |

For comparison, the *already-correct* path on `main` for `1e999999999` (9-digit exponent that doesn't overflow `Int`) returns `Number(Infinity, repr=Some("1e999999999"))` — the bug was that wider exponents quietly lost their magnitude instead.

The decimal slow path (`parse_decimal_from_view`) accumulated exponent digits into a plain `Int` with no cap. Once digits saturated `Int`, the accumulator wrapped, scrambling `decimal_point` and bypassing the `decimal_point > 310` / `< -330` overflow checks in `Decimal::to_double_priv`.

The clamp lands `decimal_point` exactly at the boundary that `to_double_priv` already treats as overflow / underflow:
- `decimal_point > 310` → `range_err` (Double max ~1.8e+308; anything past 1e+310 is unreachable). Hence the `+311` ceiling.
- `decimal_point < -330` → underflow to 0 (Double min subnormal ~5e-324; anything past 1e-331 underflows). Hence the `-331` floor (`decimal_point + 331` for the negative-exp arm).

#3464 only patched `internal/strconv/strconv_decimal.mbt`. The user-facing `@strconv.parse_double` lives in `strconv/decimal.mbt`, which has its own copy of the slow path — so the public deprecated API was still broken. This PR clamps both copies. (The duplication itself is worth a follow-up dedupe.)

## Commit layout

The change is split into three commits to make the bug visible at the public API:

1. **`test: document parse_double huge-exponent bug at public APIs`** — adds inspect-snapshot tests through `@string.parse_double` (`string/parse_double_test.mbt`) and `@json.parse` (`json/lex_number_test.mbt`). On `main` they capture `Ok(0.1)` / `Number(0.1)` etc. — clearly wrong next to neighbouring tests that show the correct `Number(Infinity, repr=...)` behavior for shorter overflow inputs.
2. **`fix(strconv): clamp huge exponent in parse_double slow path`** — clamps the exponent accumulator in both `internal/strconv/strconv_decimal.mbt` (the live path) and `strconv/decimal.mbt` (the deprecated copy), with a comment explaining where `311` and `331` come from.
3. **`test: promote huge-exponent snapshots to regression guards`** — updates the snapshots to the now-correct `Err(value out of range)` / `Number(Infinity, repr=...)` (positive) and `Ok(0)` / `Number(0)` (negative).

## Validation

- [x] `moon fmt`
- [x] `moon info`
- [x] `moon check`
- [x] `moon test` — 6425 / 6425 pass

## Related

Supersedes / extends #3464 (which only touched `internal/strconv` and so didn't actually fix the public API). Tests sit at the public-API boundary in `string/` and `json/` rather than in the deprecated `strconv/` package.