### PR TITLE
refactor(builtin): declarative for-in with carry-state in Array::retain

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1144,16 +1144,13 @@ pub fn[T] Array::swap(self : Array[T], i : Int, j : Int) -> Unit {
 /// TODO: perf could be improved
 #locals(f)
 pub fn[T] Array::retain(self : Array[T], f : (T) -> Bool raise?) -> Unit raise? {
-  let len = self.length()
-  for i = 0, j = 0; i < len; {
-    let item = self.unsafe_get(i)
-    if f(item) {
-      self.unsafe_set(j, item)
-      continue i + 1, j + 1
+  for v in self; j = 0 {
+    if f(v) {
+      self.unsafe_set(j, v)
+      continue j + 1
     }
-    continue i + 1, j
+    continue j
   } nobreak {
-    // we use `else` here to capture `j`
     self.unsafe_truncate_to_length(j)
   }
 }


### PR DESCRIPTION
## Summary

Use `for v in self; j = 0 { ... }` carry-state form to drop the manual read index in `Array::retain`. The iterator handles `i`; only the write index `j` needs to be threaded.

```diff
-  let len = self.length()
-  for i = 0, j = 0; i < len; {
-    let item = self.unsafe_get(i)
-    if f(item) {
-      self.unsafe_set(j, item)
-      continue i + 1, j + 1
-    }
-    continue i + 1, j
+  for v in self; j = 0 {
+    if f(v) {
+      self.unsafe_set(j, v)
+      continue j + 1
+    }
+    continue j
   } nobreak {
-    // we use `else` here to capture `j`
     self.unsafe_truncate_to_length(j)
   }
```

Hot-path-cautious: same single pass, same predicate calls, same writes; only the iteration vehicle changes.

Part of declarative-style sweep; sibling to #3519.

## Test plan

- [x] `moon check`
- [x] `moon test -p builtin` — 2825/2825 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)