### PR TITLE
refactor(argparse): view + range patterns in is_negative_number

### DIFF
--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -101,13 +101,14 @@ fn is_negative_number(arg : String) -> Bool {
   if arg.length() < 2 {
     return false
   }
-  guard arg.get_char(0) is Some('-') else { return false }
-  for i = 1; i < arg.length(); {
-    let ch = arg.get_char(i).unwrap()
-    if ch < '0' || ch > '9' {
-      return false
+  guard arg is ['-', .. rest] else { return false }
+  for ch in rest {
+    if ch is ('0'..='9') {
+      continue
+    } else {
+      break false
     }
-    continue i + ch.utf16_len()
+  } nobreak {
+    true
   }
-  true
 }


### PR DESCRIPTION
## Summary

Replace manual UTF-16 walk with a destructuring view pattern and a character-range pattern in `is_negative_number`:

```diff
-  guard arg.get_char(0) is Some('-') else { return false }
-  for i = 1; i < arg.length(); {
-    let ch = arg.get_char(i).unwrap()
-    if ch < '0' || ch > '9' { return false }
-    continue i + ch.utf16_len()
-  }
-  true
+  guard arg is ['-', .. rest] else { return false }
+  for ch in rest {
+    if ch is ('0'..='9') { continue } else { break false }
+  } nobreak { true }
```

The view pattern walks code points natively, eliminating the manual `utf16_len` accounting.

Edge cases preserved by the existing `length() < 2` early return:
- `""` → false (early)
- `"-"` → false (early)
- `"-0"` → true
- `"--"` → false (rest = "-", not a digit)
- `"--5"` → false (rest = "-5", first char not a digit)

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff

Part of declarative-style sweep; sibling to #3519, #3520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)