### PR TITLE
refactor(argparse): Map literal + spread + comprehension in build_*_index

### DIFF
--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -17,8 +17,8 @@ fn build_long_index(
   globals : Array[Arg],
   args : Array[Arg],
 ) -> Map[String, Arg] {
-  let index : Map[String, Arg] = {}
-  for arg in globals.iter() + args.iter() {
+  let index = Map([])
+  for arg in [..globals, ..args] {
     if arg.info is (FlagInfo(long~, ..) | OptionInfo(long~, ..)) &&
       long is Some(name) {
       index[name] = arg
@@ -29,20 +29,13 @@ fn build_long_index(
 
 ///|
 fn build_short_index(globals : Array[Arg], args : Array[Arg]) -> Map[Char, Arg] {
-  let index : Map[Char, Arg] = {}
-  for arg in globals {
-    if arg.info is (FlagInfo(short~, ..) | OptionInfo(short~, ..)) &&
-      short is Some(value) {
-      index[value] = arg
-    }
-  }
-  for arg in args {
-    if arg.info is (FlagInfo(short~, ..) | OptionInfo(short~, ..)) &&
-      short is Some(value) {
-      index[value] = arg
-    }
-  }
-  index
+  Map(
+    [
+      for arg in [..globals, ..args] if arg.info
+      is (FlagInfo(short~, ..) | OptionInfo(short~, ..)) &&
+      short is Some(value) => (value, arg)
+    ],
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary

`build_long_index`:
```diff
-  let index : Map[String, Arg] = {}
-  for arg in globals.iter() + args.iter() {
+  let index = Map([])
+  for arg in [..globals, ..args] {
     if arg.info is (FlagInfo(long~, ..) | OptionInfo(long~, ..)) &&
       long is Some(name) {
       index[name] = arg
     }
   }
   index
```

`build_short_index`: collapse two near-identical population loops into a single Map comprehension:
```diff
-  let index : Map[Char, Arg] = {}
-  for arg in globals { ... if ... { index[v] = arg } }
-  for arg in args    { ... if ... { index[v] = arg } }
-  index
+  Map(
+    [
+      for arg in [..globals, ..args]
+      if arg.info is (FlagInfo(short~, ..) | OptionInfo(short~, ..)) &&
+        short is Some(value) => (value, arg)
+    ],
+  )
```

## Performance note (per "no perf regression in hot path" guardrail)

argparse runs once at CLI startup with bounded inputs (typically <20 flags). The `[..globals, ..args]` spread allocates a small temporary array; acceptable here. I would **not** apply this transform inside hot-path packages (`builtin`, `bigint`, `string`, etc.) where the original loop avoided allocation.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff

Final piece of in-flight 4-PR split. Siblings: #3519, #3520, #3521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)