### PR TITLE
refactor(argparse): use Map([]) literal across remaining sites

### DIFF
--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -147,10 +147,10 @@ pub fn Command::render_help(self : Command) -> String {
 pub fn Command::parse(
   self : Command,
   argv? : ArrayView[String] = default_argv(),
-  env? : Map[String, String] = {},
+  env? : Map[String, String] = Map([]),
 ) -> Matches raise {
   try {
-    let raw = parse_command(self, argv, env, [], {}, {}, self.name)
+    let raw = parse_command(self, argv, env, [], Map([]), Map([]), self.name)
     build_matches(self, raw, [])
   } catch {
     DisplayHelp::Message(text) => print_and_exit_success(text)
@@ -169,10 +169,10 @@ fn build_matches(
   raw : Matches,
   inherited_globals : Array[Arg],
 ) -> Matches {
-  let flags : Map[String, Bool] = {}
-  let values : Map[String, Array[String]] = {}
-  let flag_counts : Map[String, Int] = {}
-  let sources : Map[String, ValueSource] = {}
+  let flags = Map([])
+  let values = Map([])
+  let flag_counts = Map([])
+  let sources = Map([])
   let specs = inherited_globals + cmd.args
 
   for spec in specs {

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -492,7 +492,7 @@ fn validate_groups(
   if groups.length() == 0 {
     return
   }
-  let group_presence : Map[String, Int] = {}
+  let group_presence = Map([])
   let group_seen : @set.Set[String] = Set([])
   let arg_seen : @set.Set[String] = Set([])
   for group in groups {


### PR DESCRIPTION
## Summary

Continue the Map-literal modernization started in #3522 by sweeping the rest of `argparse/`:

- `parser_validate.mbt`: `group_presence` accumulator in `validate_groups`
- `command.mbt`: the public `env?` parameter default in `Command::parse`
- `command.mbt`: two positional empty-Map args in the `parse_command` call
- `command.mbt`: four local accumulators in `build_matches` (`flags`, `values`, `flag_counts`, `sources`)

```diff
-  let group_presence : Map[String, Int] = {}
+  let group_presence = Map([])
```

```diff
-  env? : Map[String, String] = {},
+  env? : Map[String, String] = Map([]),
```

```diff
-  let flags : Map[String, Bool] = {}
-  let values : Map[String, Array[String]] = {}
-  let flag_counts : Map[String, Int] = {}
-  let sources : Map[String, ValueSource] = {}
+  let flags = Map([])
+  let values = Map([])
+  let flag_counts = Map([])
+  let sources = Map([])
```

Type ascriptions were dropped from locals (inferred from later populating writes) but kept on the public `env?` default to preserve API surface clarity.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)