### PR TITLE
refactor(argparse): declarative levenshtein loops + Array initializers

### DIFF
--- a/argparse/parser_suggest.mbt
+++ b/argparse/parser_suggest.mbt
@@ -74,16 +74,11 @@ fn levenshtein(a : StringView, b : StringView) -> Int {
   if n == 0 {
     return m
   }
-  let mut prev = Array::new(capacity=n + 1)
-  let mut curr = Array::new(capacity=n + 1)
-  for j = 0; j <= n; {
-    prev.push(j)
-    curr.push(0)
-    continue j + 1
-  }
-  for i = 1; i <= m; {
+  let mut prev = Array::makei(n + 1, j => j)
+  let mut curr = Array::make(n + 1, 0)
+  for i in 1..<(m + 1) {
     curr[0] = i
-    for j2 = 1; j2 <= n; {
+    for j2 in 1..<(n + 1) {
       let cost = if aa[i - 1] == bb[j2 - 1] { 0 } else { 1 }
       let del = prev[j2] + 1
       let ins = curr[j2 - 1] + 1
@@ -99,12 +94,10 @@ fn levenshtein(a : StringView, b : StringView) -> Int {
       } else {
         sub
       }
-      continue j2 + 1
     }
     let temp = prev
     prev = curr
     curr = temp
-    continue i + 1
   }
   prev[n]
 }


### PR DESCRIPTION
## Summary

Modernize `levenshtein` in `argparse/parser_suggest.mbt`:

```diff
-  let mut prev = Array::new(capacity=n + 1)
-  let mut curr = Array::new(capacity=n + 1)
-  for j = 0; j <= n; {
-    prev.push(j)
-    curr.push(0)
-    continue j + 1
-  }
-  for i = 1; i <= m; {
+  let mut prev = Array::makei(n + 1, j => j)
+  let mut curr = Array::make(n + 1, 0)
+  for i in 1..<(m + 1) {
     curr[0] = i
-    for j2 = 1; j2 <= n; {
+    for j2 in 1..<(n + 1) {
       ...
-      continue j2 + 1
     }
-    continue i + 1
   }
```

Three changes, one logical concept (declarative loops in `levenshtein`):
1. Row init loop → `Array::makei` + `Array::make` (no allocation churn — both still pre-size to `n + 1`).
2. Outer c-style loop → range form.
3. Inner c-style loop → range form.

## Performance note

`levenshtein` is invoked only when argparse needs to suggest a typo correction for an unknown flag, against a bounded candidate set. Not a hot path; declarative range loops compile to the same shape as c-style loops anyway.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)