### PR TITLE
refactor(internal/regex_engine): for-in iteration in SlotBook::find_unused

### DIFF
--- a/internal/regex_engine/automata/slot_book.mbt
+++ b/internal/regex_engine/automata/slot_book.mbt
@@ -49,9 +49,9 @@ fn SlotBook::mark_used(self : SlotBook, slot : Slot) -> Unit {
 
 ///|
 fn SlotBook::find_unused(self : SlotBook) -> Slot {
-  for i = 0; i < self.0.length(); i = i + 1 {
-    if self.0[i] != -1 {
-      let bit = self.0[i].lnot().ctz()
+  for i, word in self.0 {
+    if word != -1 {
+      let bit = word.lnot().ctz()
       return Slot::from_index(i * 32 + bit)
     }
   }


### PR DESCRIPTION
## Summary

Replace the c-style index loop in `SlotBook::find_unused` with `for i, word in self.0`. The new form also caches the word once instead of indexing the underlying array twice.

```diff
-  for i = 0; i < self.0.length(); i = i + 1 {
-    if self.0[i] != -1 {
-      let bit = self.0[i].lnot().ctz()
-      return Slot::from_index(i * 32 + bit)
+  for i, word in self.0 {
+    if word != -1 {
+      let bit = word.lnot().ctz()
+      return Slot::from_index(i * 32 + bit)
     }
   }
```

## Performance note

`find_unused` is called during regex *compilation* (per pattern, once), not in the matcher hot loop. Even so, the new form does fewer array reads, so this is a wash-or-better either way.

## Test plan

- [x] `moon check`
- [x] `moon test` — 6425/6425 pass (full suite)
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)