### PR TITLE
refactor(builtin): declarative reverse-range loop in Array/ArrayView::rev_foldi

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1351,8 +1351,8 @@ pub fn[A, B] Array::rev_foldi(
   f : (Int, B, A) -> B raise?,
 ) -> B raise? {
   let len = self.length()
-  for i = len - 1, acc = init; i >= 0; {
-    continue i - 1, f(len - i - 1, acc, self[i])
+  for i in len>..0; acc = init {
+    continue f(len - i - 1, acc, self[i])
   } nobreak {
     acc
   }

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1228,8 +1228,8 @@ pub fn[A, B] ArrayView::rev_foldi(
   f : (Int, B, A) -> B raise?,
 ) -> B raise? {
   let len = self.length()
-  for i = len - 1, acc = init; i >= 0; {
-    continue i - 1, f(len - i - 1, acc, self[i])
+  for i in len>..0; acc = init {
+    continue f(len - i - 1, acc, self[i])
   } nobreak {
     acc
   }


### PR DESCRIPTION
## Summary

Sibling of merged #3519 (which did `FixedArray::rev_foldi`). Same shape transform on `Array::rev_foldi` and `ArrayView::rev_foldi`:

```diff
   let len = self.length()
-  for i = len - 1, acc = init; i >= 0; {
-    continue i - 1, f(len - i - 1, acc, self[i])
+  for i in len>..0; acc = init {
+    continue f(len - i - 1, acc, self[i])
   } nobreak {
     acc
   }
```

## Performance note

Hot-path-cautious bucket — same single pass, same accumulator semantics, same body. Only the loop header changes; the new range form compiles to the same shape as a c-style countdown.

## Test plan

- [x] `moon check`
- [x] `moon test -p builtin` — 2825/2825 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)