### PR TITLE
refactor(env): range-form loop in env_wasm string_to_extern

### DIFF
--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -36,7 +36,7 @@ fn finish_create_string(handle : XStringCreateHandle) -> XExternString = "__moon
 ///|
 fn string_to_extern(s : String) -> XExternString {
   let handle = begin_create_string()
-  for i = 0; i < s.length(); i = i + 1 {
+  for i in 0..<s.length() {
     string_append_char(handle, s.code_unit_at(i).unsafe_to_char())
   }
   finish_create_string(handle)


### PR DESCRIPTION
## Summary

```diff
   let handle = begin_create_string()
-  for i = 0; i < s.length(); i = i + 1 {
+  for i in 0..<s.length() {
     string_append_char(handle, s.code_unit_at(i).unsafe_to_char())
   }
```

Same shape (step 1 over `s.length()`), just declarative. The loop intentionally iterates UTF-16 code units (note `code_unit_at` + `unsafe_to_char`); that semantics is preserved.

## Test plan

- [x] `moon check`
- [x] `moon test -p env` — 100/100 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)