### PR TITLE
refactor(argparse): set comprehension in collect_non_global_names

### DIFF
--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -45,7 +45,7 @@ fn collect_globals(args : Array[Arg]) -> Array[Arg] {
 
 ///|
 fn collect_non_global_names(args : Array[Arg]) -> @set.Set[String] {
-  @set.from_iter(args.iter().filter(arg => !arg.global).map(arg => arg.name))
+  Set([ for arg in args if !arg.global => arg.name ])
 }
 
 ///|


### PR DESCRIPTION
## Summary

```diff
 fn collect_non_global_names(args : Array[Arg]) -> @set.Set[String] {
-  @set.from_iter(args.iter().filter(arg => !arg.global).map(arg => arg.name))
+  Set([for arg in args if !arg.global => arg.name])
 }
```

Same shape transform as the comprehension in #3522 (`build_short_index`), applied to the small set built in `collect_non_global_names`.

## Performance note

The new form materializes a small intermediate `Array[String]` (bounded by the non-global arg count, typically <20) before passing it to `Set::Set`. The original `from_iter` walks the iter and inserts directly. Acceptable in argparse (non-hot CLI startup path); I would not apply this in a hot-path package.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — applied (internal spacing inside brackets)
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)