### PR TITLE
refactor: declarative comprehension in Debug for Queue / immut/HashSet

### DIFF
--- a/immut/hashset/debug.mbt
+++ b/immut/hashset/debug.mbt
@@ -17,8 +17,7 @@ using @debug {trait Debug, type Repr}
 
 ///|
 pub impl[K : Debug] Debug for HashSet[K] with to_repr(self) {
-  let xs : Array[Repr] = self.iter().to_array().map(x => @debug.to_repr(x))
-  Repr::opaque_("HashSet", Repr::array(xs))
+  Repr::opaque_("HashSet", Repr::array([ for x in self => @debug.to_repr(x) ]))
 }
 
 ///|

--- a/queue/debug.mbt
+++ b/queue/debug.mbt
@@ -17,10 +17,7 @@ using @debug {trait Debug, type Repr}
 
 ///|
 pub impl[A : Debug] Debug for Queue[A] with to_repr(self) {
-  Repr::opaque_(
-    "Queue",
-    Repr::array(self.iter().to_array().map(x => @debug.to_repr(x))),
-  )
+  Repr::opaque_("Queue", Repr::array([ for x in self => @debug.to_repr(x) ]))
 }
 
 ///|


### PR DESCRIPTION
## Summary

Two `Debug` impls had the same two-pass `iter().to_array().map(...)` shape — convert to a single-pass array comprehension.

`queue/debug.mbt`:
```diff
 pub impl[A : Debug] Debug for Queue[A] with to_repr(self) {
-  Repr::opaque_(
-    "Queue",
-    Repr::array(self.iter().to_array().map(x => @debug.to_repr(x))),
-  )
+  Repr::opaque_("Queue", Repr::array([for x in self => @debug.to_repr(x)]))
 }
```

`immut/hashset/debug.mbt`:
```diff
 pub impl[K : Debug] Debug for HashSet[K] with to_repr(self) {
-  let xs : Array[Repr] = self.iter().to_array().map(x => @debug.to_repr(x))
-  Repr::opaque_("HashSet", Repr::array(xs))
+  Repr::opaque_("HashSet", Repr::array([for x in self => @debug.to_repr(x)]))
 }
```

Both bundled because the change is identical in shape and small; both reachable only from `@debug.to_repr` / `debug_inspect`.

Drops one intermediate `Array` allocation per call. Not a hot path.

## Test plan

- [x] `moon check`
- [x] `moon test -p queue` — 143/143 pass
- [x] `moon test -p immut/hashset` — 58/58 pass
- [x] `moon fmt` — applied (internal spacing)
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)