### PR TITLE
refactor(argparse): Option::map in required_option_token

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -114,15 +114,13 @@ fn required_option_token(arg : Arg) -> String? {
       }
     PositionalInfo(_) => None
   }
-  match prefix {
-    Some(prefix) =>
-      if arg.info is OptionInfo(_) {
-        Some("\{prefix} <\{arg.name}>")
-      } else {
-        Some(prefix)
-      }
-    None => None
-  }
+  prefix.map(prefix => {
+    if arg.info is OptionInfo(_) {
+      "\{prefix} <\{arg.name}>"
+    } else {
+      prefix
+    }
+  })
 }
 
 ///|


### PR DESCRIPTION
## Summary

Replace the `match prefix { Some(p) => Some(f(p)) None => None }` boilerplate with the canonical `Option::map`:

```diff
-  match prefix {
-    Some(prefix) =>
-      if arg.info is OptionInfo(_) {
-        Some("\{prefix} <\{arg.name}>")
-      } else {
-        Some(prefix)
-      }
-    None => None
-  }
+  prefix.map(prefix => if arg.info is OptionInfo(_) {
+    "\{prefix} <\{arg.name}>"
+  } else {
+    prefix
+  })
```

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — applied (lambda body braces)
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)