### PR TITLE
refactor(quickcheck): unwrap_or / unwrap_or_else in gen

### DIFF
--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -124,14 +124,8 @@ pub impl[X : Arbitrary] Arbitrary for Iter[X] with arbitrary(size, rs) {
 ///|
 /// Generates a single random value, optionally with a given size and random state.
 pub fn[T : Arbitrary] gen(size? : Int, state? : @splitmix.RandomState) -> T {
-  let size = match size {
-    None => 0
-    Some(x) => x
-  }
-  let state = match state {
-    None => @splitmix.RandomState::default()
-    Some(x) => x
-  }
+  let size = size.unwrap_or(0)
+  let state = state.unwrap_or_else(() => @splitmix.RandomState::default())
   Arbitrary::arbitrary(size, state)
 }
 


### PR DESCRIPTION
## Summary

Replace two `match opt { None => default; Some(x) => x }` blocks with the dedicated `Option` helpers:

```diff
-  let size = match size {
-    None => 0
-    Some(x) => x
-  }
-  let state = match state {
-    None => @splitmix.RandomState::default()
-    Some(x) => x
-  }
+  let size = size.unwrap_or(0)
+  let state = state.unwrap_or_else(() => @splitmix.RandomState::default())
```

Used `unwrap_or_else` for `state` to preserve laziness (the original only constructs a fresh `RandomState` when `state` is `None`).

## Test plan

- [x] `moon check`
- [x] `moon test -p quickcheck` — 26/26 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)