### PR TITLE
refactor(argparse): 'is' pattern for Some-or-noop match blocks (3 files)

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -349,9 +349,8 @@ fn positional_display(arg : Arg) -> String {
 ///|
 fn arg_doc(arg : Arg) -> String {
   let notes = []
-  match arg.env {
-    Some(env_name) => notes.push("[env: \{env_name}]")
-    None => ()
+  if arg.env is Some(env_name) {
+    notes.push("[env: \{env_name}]")
   }
   if arg.info
     is (OptionInfo(default_values~, ..) | PositionalInfo(default_values~, ..)) &&

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -339,9 +339,8 @@ fn parse_command_impl(
   command_path : String,
   seed_matches : Matches,
 ) -> Matches raise {
-  match cmd.build_error {
-    Some(err) => raise err
-    None => ()
+  if cmd.build_error is Some(err) {
+    raise err
   }
   let args = cmd.args
   let groups = cmd.groups
@@ -588,15 +587,12 @@ fn parse_command_impl(
         cmd, args, groups, matches, positionals, positional_values, env_args, env,
       )
       validate_relationships(parent_matches, args)
-      match parent_matches.parsed_subcommand {
-        Some((sub_name, sub_m)) => {
-          // After parent parsing, copy the final globals into the subcommand.
-          propagate_globals_to_child(
-            parent_matches, sub_m, child_globals, child_local_non_globals,
-          )
-          parent_matches.parsed_subcommand = Some((sub_name, sub_m))
-        }
-        None => ()
+      if parent_matches.parsed_subcommand is Some((sub_name, sub_m)) {
+        // After parent parsing, copy the final globals into the subcommand.
+        propagate_globals_to_child(
+          parent_matches, sub_m, child_globals, child_local_non_globals,
+        )
+        parent_matches.parsed_subcommand = Some((sub_name, sub_m))
       }
       return parent_matches
     }

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -94,9 +94,8 @@ fn validate_command(
   groups : Array[ArgGroup],
   inherited_globals : Array[Arg],
 ) -> Unit raise ArgBuildError {
-  match cmd.build_error {
-    Some(err) => raise err
-    None => ()
+  if cmd.build_error is Some(err) {
+    raise err
   }
   validate_inherited_global_shadowing(args, inherited_globals)
   validate_group_defs(args, groups)


### PR DESCRIPTION
## Summary

Same idiom as #3533 but in three other argparse files:

- `parser.mbt`:
  - `match cmd.build_error { Some(err) => raise err; None => () }` → `if cmd.build_error is Some(err) { raise err }`
  - `match parent_matches.parsed_subcommand { Some((sub_name, sub_m)) => block; None => () }` → `if ... is Some((sub_name, sub_m)) { block }`
- `parser_validate.mbt`:
  - `match cmd.build_error { Some(err) => raise err; None => () }` → `if cmd.build_error is Some(err) { raise err }`
- `help_render.mbt`:
  - `match arg.env { Some(env_name) => notes.push(...); None => () }` → `if arg.env is Some(env_name) { notes.push(...) }`

Bundled across files because the change is identical in shape and trivially small per-site.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)