### PR TITLE
refactor(argparse): if-is/else for both-branches Some/None match in merge_*_globals

### DIFF
--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -93,9 +93,10 @@ fn merge_global_defs(
 ) -> Array[Arg] {
   let merged = inherited_globals.copy()
   for global in globals_here {
-    match merged.search_by(arg => arg.name == global.name) {
-      Some(idx) => merged[idx] = global
-      None => merged.push(global)
+    if merged.search_by(arg => arg.name == global.name) is Some(idx) {
+      merged[idx] = global
+    } else {
+      merged.push(global)
     }
   }
   merged

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -172,9 +172,10 @@ fn merge_inherited_globals(
 ) -> Array[Arg] {
   let merged = inherited_globals.copy()
   for global in globals_here {
-    match merged.search_by(arg => arg.name == global.name) {
-      Some(idx) => merged[idx] = global
-      None => merged.push(global)
+    if merged.search_by(arg => arg.name == global.name) is Some(idx) {
+      merged[idx] = global
+    } else {
+      merged.push(global)
     }
   }
   merged


### PR DESCRIPTION
## Summary

Two near-duplicate sites — `merge_global_defs` in `parser.mbt` and `merge_inherited_globals` in `parser_validate.mbt` — both had:

```moonbit
match merged.search_by(arg => arg.name == global.name) {
  Some(idx) => merged[idx] = global
  None => merged.push(global)
}
```

Replaced with the `if X is Some(y) { ... } else { ... }` form:

```moonbit
if merged.search_by(arg => arg.name == global.name) is Some(idx) {
  merged[idx] = global
} else {
  merged.push(global)
}
```

Bundled because the two sites are byte-identical except for the surrounding function name.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)