### PR TITLE
refactor(immut): if-is for None=>() match in HAMT each helpers

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -610,9 +610,8 @@ pub fn[K, V] HashMap::each(
     }
   }
 
-  match self.0 {
-    None => ()
-    Some(node) => go(node)
+  if self.0 is Some(node) {
+    go(node)
   }
 }
 

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -341,9 +341,8 @@ pub fn[A] HashSet::each(
     }
   }
 
-  match self.0 {
-    None => ()
-    Some(node) => go(node)
+  if self.0 is Some(node) {
+    go(node)
   }
 }
 


### PR DESCRIPTION
## Summary

Both `immut/hashset/HAMT.mbt` and `immut/hashmap/HAMT.mbt` had a noop-on-empty match in their iteration helper:

```diff
-  match self.0 {
-    None => ()
-    Some(node) => go(node)
-  }
+  if self.0 is Some(node) {
+    go(node)
+  }
```

Both sites share the exact same shape, so bundled.

## Test plan

- [x] `moon check`
- [x] `moon test` — 6425/6425 pass (full suite)
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)