### PR TITLE
refactor(immut/hashmap): use Option methods instead of match deconstruction

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -54,10 +54,7 @@ pub fn[K : Eq + Hash, V] HashMap::contains(
 /// Lookup a key from a hash map
 #alias(find, deprecated)
 pub fn[K : Eq + Hash, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
-  match self.0 {
-    None => None
-    Some(node) => node.get_with_path(key, @path.of(key))
-  }
+  self.0.bind(node => node.get_with_path(key, @path.of(key)))
 }
 
 ///|
@@ -194,10 +191,7 @@ pub fn[K, V] HashMap::filter(
     }
   }
 
-  match self.0 {
-    None => None
-    Some(node) => go(node)
-  }
+  self.0.bind(go)
 }
 
 ///|
@@ -220,10 +214,7 @@ pub fn[K, V, A] HashMap::fold(
     }
   }
 
-  match self.0 {
-    None => init
-    Some(node) => go(init, node)
-  }
+  self.0.map_or(init, node => go(init, node))
 }
 
 ///|
@@ -242,10 +233,7 @@ pub fn[K, V, A] HashMap::map(
     }
   }
 
-  match self.0 {
-    None => None
-    Some(node) => Some(go(node))
-  }
+  self.0.map(go)
 }
 
 ///|


### PR DESCRIPTION
## Summary

Four sites in `immut/hashmap/HAMT.mbt` followed shapes that map directly to existing `Option` methods:

- `HashMap::get`:
  ```diff
  -  match self.0 {
  -    None => None
  -    Some(node) => node.get_with_path(key, @path.of(key))
  -  }
  +  self.0.bind(node => node.get_with_path(key, @path.of(key)))
  ```
- `HashMap::filter`:  `match self.0 { None => None; Some(n) => go(n) }` → `self.0.bind(go)` (`go : Node -> Node?`)
- `HashMap::fold`:  `match self.0 { None => init; Some(n) => go(init, n) }` → `self.0.map_or(init, n => go(init, n))`
- `HashMap::map`:  `match self.0 { None => None; Some(n) => Some(go(n)) }` → `self.0.map(go)`

For `fold`, `init` is a passed-in value (no side effects), so eager `map_or` is safe.

Bundled because all four sit in one file and apply the same family of `Option` collapses.

## Test plan

- [x] `moon check`
- [x] `moon test -p immut/hashmap` — 109/109 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)