### PR TITLE
refactor(argparse): use Array::is_empty instead of length() == 0

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -270,7 +270,7 @@ fn render_section(
   lines : Array[String],
   keep_empty? : Bool = false,
 ) -> String {
-  if lines.length() == 0 {
+  if lines.is_empty() {
     if keep_empty {
       (
         $|
@@ -330,7 +330,7 @@ fn arg_display(arg : Arg) -> String {
       parts.push("--\{long}")
     }
   }
-  if parts.length() == 0 {
+  if parts.is_empty() {
     arg.name
   } else {
     parts.join(", ")
@@ -403,7 +403,7 @@ fn group_label(group : ArgGroup) -> String {
   if !group.multiple {
     tags.push("[exclusive]")
   }
-  if tags.length() == 0 {
+  if tags.is_empty() {
     group.name
   } else {
     let tags_text = tags.join(" ")

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -168,7 +168,7 @@ fn group_usage_expr(
       is Some(idx) &&
       !args[idx].hidden => arg_usage_token_for_group(args[idx])
     ]
-    if members.length() == 0 {
+    if members.is_empty() {
       return None
     }
     let joined = members.join("|")
@@ -345,7 +345,7 @@ fn parse_command_impl(
   let args = cmd.args
   let groups = cmd.groups
   let subcommands = cmd.subcommands
-  if cmd.arg_required_else_help && argv.length() == 0 {
+  if cmd.arg_required_else_help && argv.is_empty() {
     raise_context_help(cmd, inherited_globals, command_path)
   }
   let matches = seed_matches

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -387,7 +387,7 @@ fn validate_group_refs(
   args : Array[Arg],
   groups : Array[ArgGroup],
 ) -> Unit raise ArgBuildError {
-  if groups.length() == 0 {
+  if groups.is_empty() {
     return
   }
   let arg_index : @set.Set[String] = Set([])
@@ -432,7 +432,7 @@ fn validate_requires_conflicts_targets(
 
 ///|
 fn validate_subcommand_defs(subs : Array[Command]) -> Unit raise ArgBuildError {
-  if subs.length() == 0 {
+  if subs.is_empty() {
     return
   }
   let seen : @set.Set[String] = Set([])
@@ -447,7 +447,7 @@ fn validate_subcommand_defs(subs : Array[Command]) -> Unit raise ArgBuildError {
 fn validate_subcommand_required_policy(
   cmd : Command,
 ) -> Unit raise ArgBuildError {
-  if cmd.subcommand_required && cmd.subcommands.length() == 0 {
+  if cmd.subcommand_required && cmd.subcommands.is_empty() {
     raise Unsupported("subcommand_required requires at least one subcommand")
   }
 }
@@ -488,7 +488,7 @@ fn validate_groups(
   groups : Array[ArgGroup],
   matches : Matches,
 ) -> Unit raise ArgParseError {
-  if groups.length() == 0 {
+  if groups.is_empty() {
     return
   }
   let group_presence = Map([])


### PR DESCRIPTION
## Summary

argparse uniformly used `xs.length() == 0`, while the rest of moonbitlang/core prefers `.is_empty()` (60+ uses across `builtin`, `deque`, `immut/vector`, `list`, `bench`, etc., and zero in argparse before this PR). Style consistency fix.

```diff
-if groups.length() == 0 {
+if groups.is_empty() {
```

9 sites across:
- `parser.mbt` (2)
- `parser_validate.mbt` (4)
- `help_render.mbt` (3)

Bundled because all sites are mechanical, identical, and live in the same package.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)