### PR TITLE
refactor: use [] literal instead of Array::new() in non-test sites

### DIFF
--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -44,6 +44,6 @@ struct Bench {
 #as_free_fn
 pub fn Bench::new() -> Bench {
   let buffer = StringBuilder::new()
-  let summaries = Array::new()
+  let summaries = []
   { buffer, summaries, _storage: @ref.new(()) }
 }

--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -88,7 +88,7 @@ fn finish_read_string_array(handle : XStringArrayReadHandle) = "__moonbit_fs_uns
 
 ///|
 fn string_array_from_extern(e : XExternStringArray) -> Array[String] {
-  let buf = Array::new()
+  let buf = []
   let handle = begin_read_string_array(e)
   while true {
     let extern_str = string_array_read_string(handle)


### PR DESCRIPTION
## Summary

Two non-test sites used the capacity-less `Array::new()` constructor where the `[]` literal would do — replace for consistency with the rest of the codebase, which prefers `[]` (see e.g. `argparse/command.mbt:261`, `json/json.mbt:289`, `env/env_native.mbt:73`).

```diff
-  let summaries = Array::new()
+  let summaries = []
   { buffer, summaries, _storage: @ref.new(()) }
```

```diff
 fn string_array_from_extern(e : XExternStringArray) -> Array[String] {
-  let buf = Array::new()
+  let buf = []
```

In both, type inference picks up the expected type from the surrounding struct field / function return type, so no annotation is needed.

## Test plan

- [x] `moon check`
- [x] `moon test -p bench` — 12/12 pass
- [x] `moon test -p env` — 100/100 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)