### PR TITLE
refactor(json): range pattern for digit checks in number lexer

### DIFF
--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -22,7 +22,7 @@ fn ParseContext::lex_decimal_integer(
       Some('.') => return ctx.lex_decimal_point(start~)
       Some('e' | 'E') => return ctx.lex_decimal_exponent(start~)
       Some(c) => {
-        if c >= '0' && c <= '9' {
+        if c is ('0'..='9') {
           continue
         }
         ctx.offset -= 1
@@ -40,7 +40,7 @@ fn ParseContext::lex_decimal_point(
 ) -> (Double, StringView?) raise ParseError {
   match ctx.read_char() {
     Some(c) =>
-      if c >= '0' && c <= '9' {
+      if c is ('0'..='9') {
         ctx.lex_decimal_fraction(start~)
       } else {
         ctx.invalid_char(shift=-1)
@@ -58,7 +58,7 @@ fn ParseContext::lex_decimal_fraction(
     match ctx.read_char() {
       Some('e' | 'E') => return ctx.lex_decimal_exponent(start~)
       Some(c) => {
-        if c >= '0' && c <= '9' {
+        if c is ('0'..='9') {
           continue
         }
         ctx.offset -= 1
@@ -77,7 +77,7 @@ fn ParseContext::lex_decimal_exponent(
   match ctx.read_char() {
     Some('+') | Some('-') => return ctx.lex_decimal_exponent_sign(start~)
     Some(c) => {
-      if c >= '0' && c <= '9' {
+      if c is ('0'..='9') {
         return ctx.lex_decimal_exponent_integer(start~)
       }
       ctx.offset -= 1
@@ -94,7 +94,7 @@ fn ParseContext::lex_decimal_exponent_sign(
 ) -> (Double, StringView?) raise ParseError {
   match ctx.read_char() {
     Some(c) => {
-      if c >= '0' && c <= '9' {
+      if c is ('0'..='9') {
         return ctx.lex_decimal_exponent_integer(start~)
       }
       ctx.offset -= 1
@@ -112,7 +112,7 @@ fn ParseContext::lex_decimal_exponent_integer(
   for ;; {
     match ctx.read_char() {
       Some(c) => {
-        if c >= '0' && c <= '9' {
+        if c is ('0'..='9') {
           continue
         }
         ctx.offset -= 1
@@ -132,7 +132,7 @@ fn ParseContext::lex_zero(
     Some('.') => ctx.lex_decimal_point(start~)
     Some('e' | 'E') => ctx.lex_decimal_exponent(start~)
     Some(c) => {
-      if c >= '0' && c <= '9' {
+      if c is ('0'..='9') {
         ctx.offset -= 1
         ctx.invalid_char()
       }


### PR DESCRIPTION
## Summary

Replace `c >= '0' && c <= '9'` with the range pattern `c is ('0'..='9')` across 7 sites in `json/lex_number.mbt`:

```diff
-        if c >= '0' && c <= '9' {
+        if c is ('0'..='9') {
           continue
         }
```

The range pattern desugars to the same two comparisons, so this is purely a syntactic cleanup with no perf impact on the JSON number-lexing path.

Same idiom previously merged in argparse (#3521, `is_negative_number`).

## Test plan

- [x] `moon check`
- [x] `moon test -p json` — 171/171 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)