### PR TITLE
refactor(argparse): collapse has_subcommands_for_help with Array::any

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -373,15 +373,7 @@ fn arg_doc(arg : Arg) -> String {
 
 ///|
 fn has_subcommands_for_help(cmd : Command) -> Bool {
-  if help_subcommand_enabled(cmd) {
-    return true
-  }
-  for sub in cmd.subcommands {
-    if !sub.hidden {
-      return true
-    }
-  }
-  false
+  help_subcommand_enabled(cmd) || cmd.subcommands.any(sub => !sub.hidden)
 }
 
 ///|


### PR DESCRIPTION
## Summary

```diff
 fn has_subcommands_for_help(cmd : Command) -> Bool {
-  if help_subcommand_enabled(cmd) {
-    return true
-  }
-  for sub in cmd.subcommands {
-    if !sub.hidden {
-      return true
-    }
-  }
-  false
+  help_subcommand_enabled(cmd) || cmd.subcommands.any(sub => !sub.hidden)
 }
```

Same `Array::any` idiom as the earlier collapses in #3530 (`has_options` / `has_long_option` / `has_short_option`). Boolean short-circuit on the early-exit branch preserves the original behavior.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)