### PR TITLE
refactor(builtin): use is_empty() for length() == 0 guards

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -631,7 +631,7 @@ pub fn[T, U] Array::mapi(
   self : Array[T],
   f : (Int, T) -> U raise?,
 ) -> Array[U] raise? {
-  if self.length() == 0 {
+  if self.is_empty() {
     return []
   }
   let arr = Array::make_uninit(self.length())

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -209,7 +209,7 @@ pub fn[T] Array::push(self : Array[T], value : T) -> Unit {
 /// }
 /// ```
 pub fn[T] Array::pop(self : Array[T]) -> T? {
-  if self.length() == 0 {
+  if self.is_empty() {
     None
   } else {
     let v = self.unsafe_pop()

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1250,7 +1250,7 @@ pub fn[T, U] ArrayView::map(
   self : ArrayView[T],
   f : (T) -> U raise?,
 ) -> Array[U] raise? {
-  if self.length() == 0 {
+  if self.is_empty() {
     return []
   }
   Array::makei(self.length(), i => f(self[i]))
@@ -1271,7 +1271,7 @@ pub fn[T, U] ArrayView::mapi(
   self : ArrayView[T],
   f : (Int, T) -> U raise?,
 ) -> Array[U] raise? {
-  if self.length() == 0 {
+  if self.is_empty() {
     return []
   }
   Array::makei(self.length(), i => f(i, self[i]))

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -818,7 +818,7 @@ pub fn Bytes::repeat(self : Self, count : Int) -> Bytes {
   if count < 0 {
     abort("negative repeat count")
   }
-  if count == 0 || self.length() == 0 {
+  if count == 0 || self.is_empty() {
     return []
   }
   if count == 1 {

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -480,7 +480,7 @@ pub fn[T, U] FixedArray::map(
   self : FixedArray[T],
   f : (T) -> U raise?,
 ) -> FixedArray[U] raise? {
-  if self.length() == 0 {
+  if self.is_empty() {
     return []
   }
   let res = FixedArray::make(self.length(), f(self[0]))
@@ -517,7 +517,7 @@ pub fn[T, U] FixedArray::mapi(
   self : FixedArray[T],
   f : (Int, T) -> U raise?,
 ) -> FixedArray[U] raise? {
-  if self.length() == 0 {
+  if self.is_empty() {
     return []
   }
   let res = FixedArray::make(self.length(), f(0, self[0]))
@@ -1434,7 +1434,7 @@ pub fn FixedArray::join(
     size_hint
   }
   let string = StringBuilder::new(size_hint~)
-  if separator.length() == 0 {
+  if separator.is_empty() {
     for i in 0..<len {
       string.write_string(self[i])
     }


### PR DESCRIPTION
## Summary

8 mechanical sites in `builtin/` replaced `self.length() == 0` (or `separator.length() == 0`) with `.is_empty()`:

- `builtin/array.mbt` — Array::mapi guard
- `builtin/arrayview.mbt` — two ArrayView guards
- `builtin/fixedarray.mbt` — three FixedArray guards (incl. one on `separator`)
- `builtin/arraycore_js.mbt` — JS-backend array guard
- `builtin/bytes.mbt` — Bytes guard inside an or-condition

`is_empty()`'s body is itself `self.length() == 0`, so after inlining the compiled IR is identical — this is purely a style consistency fix matching the wider codebase (60+ existing `.is_empty()` uses).

Same idiom recently merged in argparse (#3539).

## Test plan

- [x] `moon check`
- [x] `moon test` — 6425/6425 pass (full suite)
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)