### PR TITLE
refactor(builtin): use Map([]) in linked_hash_map doc example

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -362,7 +362,7 @@ pub fn[K : Hash + Eq, V] Map::get_or_init(
 ///
 /// ```mbt check
 /// test {
-///   let counts : Map[String, Int] = {}
+///   let counts : Map[String, Int] = Map([])
 ///   counts.update_or_default("a", 1, x => x + 1)
 ///   counts.update_or_default("a", 1, x => x + 1)
 ///   counts.update_or_default("b", 1, x => x + 1)


### PR DESCRIPTION
## Summary

The `update_or_default` doc comment in `builtin/linked_hash_map.mbt` had the only remaining `{}` empty-Map literal in non-test code. Replace with `Map([])` for consistency with the rest of the codebase (the wider sweep landed in #3522 / #3523).

```diff
-///   let counts : Map[String, Int] = {}
+///   let counts : Map[String, Int] = Map([])
```

The doc example is a runnable `mbt check` block, so `moon test` actually compiles and runs it.

## Test plan

- [x] `moon check`
- [x] `moon test -p builtin` — 2825/2825 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)