### PR TITLE
refactor: declarative comprehension across all Debug impls

### DIFF
--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -162,14 +162,7 @@ pub impl Debug for StringBuilder with to_repr(self) {
 
 ///|
 pub impl[K : Debug, V : Debug] Debug for Map[K, V] with to_repr(self) {
-  Repr::map(
-    self
-    .to_array()
-    .map(kv => {
-      let (k, v) = kv
-      (to_repr(k), to_repr(v))
-    }),
-  )
+  Repr::map([ for k, v in self => (to_repr(k), to_repr(v)) ])
 }
 
 ///|

--- a/hashmap/debug.mbt
+++ b/hashmap/debug.mbt
@@ -17,10 +17,10 @@ using @debug {trait Debug, type Repr}
 
 ///|
 pub impl[K : Debug, V : Debug] Debug for HashMap[K, V] with to_repr(self) {
-  let entries : Array[(Repr, Repr)] = self
-    .to_array()
-    .map(kv => (@debug.to_repr(kv.0), @debug.to_repr(kv.1)))
-  Repr::opaque_("HashMap", Repr::map(entries))
+  Repr::opaque_(
+    "HashMap",
+    Repr::map([ for k, v in self => (@debug.to_repr(k), @debug.to_repr(v)) ]),
+  )
 }
 
 ///|

--- a/hashset/debug.mbt
+++ b/hashset/debug.mbt
@@ -17,8 +17,7 @@ using @debug {trait Debug, type Repr}
 
 ///|
 pub impl[K : Debug] Debug for HashSet[K] with to_repr(self) {
-  let xs : Array[Repr] = self.to_array().map(x => @debug.to_repr(x))
-  Repr::opaque_("HashSet", Repr::array(xs))
+  Repr::opaque_("HashSet", Repr::array([ for x in self => @debug.to_repr(x) ]))
 }
 
 ///|

--- a/immut/hashmap/debug.mbt
+++ b/immut/hashmap/debug.mbt
@@ -17,10 +17,10 @@ using @debug {trait Debug, type Repr}
 
 ///|
 pub impl[K : Debug, V : Debug] Debug for HashMap[K, V] with to_repr(self) {
-  let entries : Array[(Repr, Repr)] = self
-    .to_array()
-    .map(kv => (@debug.to_repr(kv.0), @debug.to_repr(kv.1)))
-  Repr::opaque_("HashMap", Repr::map(entries))
+  Repr::opaque_(
+    "HashMap",
+    Repr::map([ for k, v in self => (@debug.to_repr(k), @debug.to_repr(v)) ]),
+  )
 }
 
 ///|

--- a/immut/sorted_set/debug.mbt
+++ b/immut/sorted_set/debug.mbt
@@ -19,7 +19,7 @@ using @debug {trait Debug, type Repr}
 pub impl[K : Debug] Debug for SortedSet[K] with to_repr(self) {
   Repr::opaque_(
     "SortedSet",
-    Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+    Repr::array([ for x in self => @debug.to_repr(x) ]),
   )
 }
 

--- a/priority_queue/debug.mbt
+++ b/priority_queue/debug.mbt
@@ -17,8 +17,10 @@ using @debug {trait Debug, type Repr}
 
 ///|
 pub impl[A : Debug + Compare] Debug for PriorityQueue[A] with to_repr(self) {
-  let xs : Array[Repr] = self.to_array().map(x => @debug.to_repr(x))
-  Repr::opaque_("PriorityQueue", Repr::array(xs))
+  Repr::opaque_(
+    "PriorityQueue",
+    Repr::array([ for x in self => @debug.to_repr(x) ]),
+  )
 }
 
 ///|

--- a/sorted_map/debug.mbt
+++ b/sorted_map/debug.mbt
@@ -19,9 +19,7 @@ using @debug {trait Debug, type Repr}
 pub impl[K : Debug, V : Debug] Debug for SortedMap[K, V] with to_repr(self) {
   Repr::opaque_(
     "SortedMap",
-    Repr::map(
-      self.to_array().map(kv => (@debug.to_repr(kv.0), @debug.to_repr(kv.1))),
-    ),
+    Repr::map([ for k, v in self => (@debug.to_repr(k), @debug.to_repr(v)) ]),
   )
 }
 

--- a/sorted_set/debug.mbt
+++ b/sorted_set/debug.mbt
@@ -19,7 +19,7 @@ using @debug {trait Debug, type Repr}
 pub impl[V : Debug] Debug for SortedSet[V] with to_repr(self) {
   Repr::opaque_(
     "SortedSet",
-    Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+    Repr::array([ for x in self => @debug.to_repr(x) ]),
   )
 }
 


### PR DESCRIPTION
## Summary

Sweep the remaining `to_array().map(...)` two-pass pattern in 8 Debug impls and replace with a single-pass array comprehension:

- `sorted_set/debug.mbt`           (`SortedSet`)
- `priority_queue/debug.mbt`       (`PriorityQueue`)
- `hashset/debug.mbt`              (`HashSet`)
- `immut/sorted_set/debug.mbt`     (immut `SortedSet`)
- `sorted_map/debug.mbt`           (`SortedMap`, key-value)
- `hashmap/debug.mbt`              (`HashMap`, key-value)
- `immut/hashmap/debug.mbt`        (immut `HashMap`, key-value)
- `debug/debug.mbt`                (`Map`, key-value, also drops a let-binding lambda)

```diff
- let xs : Array[Repr] = self.to_array().map(x => @debug.to_repr(x))
- Repr::opaque_("Foo", Repr::array(xs))
+ Repr::opaque_("Foo", Repr::array([for x in self => @debug.to_repr(x)]))
```

For map-shaped impls the loop also destructures `(k, v)` directly:

```diff
- self.to_array().map(kv => (to_repr(kv.0), to_repr(kv.1)))
+ [for k, v in self => (to_repr(k), to_repr(v))]
```

Drops one intermediate `Array` allocation per `to_repr` call. None of these sit on a hot path — they're called from `@debug.to_repr` / `debug_inspect`. Companion to the earlier sweep in #3529 that covered `queue` and `immut/hashset`.

## Test plan

- [x] `moon check`
- [x] `moon test` — 6425/6425 pass (full suite)
- [x] `moon fmt` — applied (internal spacing inside brackets)
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)