### PR TITLE
refactor: build Map from comprehension instead of mutating loop (3 sites)

### DIFF
--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -17,14 +17,13 @@ fn build_long_index(
   globals : Array[Arg],
   args : Array[Arg],
 ) -> Map[String, Arg] {
-  let index = Map([])
-  for arg in [..globals, ..args] {
-    if arg.info is (FlagInfo(long~, ..) | OptionInfo(long~, ..)) &&
-      long is Some(name) {
-      index[name] = arg
-    }
-  }
-  index
+  Map(
+    [
+      for arg in [..globals, ..args] if arg.info
+      is (FlagInfo(long~, ..) | OptionInfo(long~, ..)) &&
+      long is Some(name) => (name, arg)
+    ],
+  )
 }
 
 ///|

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -80,11 +80,14 @@ pub impl[K : Show, V : Show] Show for SortedMap[K, V] with output(self, logger) 
 
 ///|
 pub impl[K : Show, V : ToJson] ToJson for SortedMap[K, V] with to_json(self) {
-  let capacity = self.length()
-  guard capacity != 0 else { return Json::object(Map([])) }
-  let jsons = Map([], capacity~)
-  self.each((k, v) => jsons[k.to_string()] = v.to_json())
-  Json::object(jsons)
+  Json::object(
+    Map(
+      capacity=self.length(),
+      [
+        for k, v in self => (k.to_string(), v.to_json())
+      ],
+    ),
+  )
 }
 
 ///|

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -67,11 +67,14 @@ pub impl[K : Show, V : Show] Show for SortedMap[K, V] with output(self, logger) 
 
 ///|
 pub impl[K : Show, V : ToJson] ToJson for SortedMap[K, V] with to_json(self) {
-  let capacity = self.length()
-  guard capacity != 0 else { return Json::object(Map([])) }
-  let jsons = Map([], capacity~)
-  self.each((k, v) => jsons[k.to_string()] = v.to_json())
-  Json::object(jsons)
+  Json::object(
+    Map(
+      capacity=self.length(),
+      [
+        for k, v in self => (k.to_string(), v.to_json())
+      ],
+    ),
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary

Apply the "build Map without mutation" idiom (per the pattern in `builtin/json.mbt`'s `Map::to_json`) across three more sites:

- `sorted_map/utils.mbt` — `SortedMap::to_json`
- `immut/sorted_map/traits_impl.mbt` — `SortedMap::to_json`
- `argparse/parser_lookup.mbt` — `build_long_index`

Each had `let m = Map([], capacity=...)` followed by an imperative populating loop. Replace with a single Map comprehension:

```diff
-pub impl[K : Show, V : ToJson] ToJson for SortedMap[K, V] with to_json(self) {
-  let capacity = self.length()
-  guard capacity != 0 else { return Json::object(Map([])) }
-  let jsons = Map([], capacity~)
-  self.each((k, v) => jsons[k.to_string()] = v.to_json())
-  Json::object(jsons)
+pub impl[K : Show, V : ToJson] ToJson for SortedMap[K, V] with to_json(self) {
+  Json::object(
+    Map(
+      capacity=self.length(),
+      [for k, v in self => (k.to_string(), v.to_json())],
+    ),
+  )
 }
```

`build_long_index` collapses the same way `build_short_index` already did (in #3522).

The `guard capacity != 0` early-return is removed because `Map::Map` already handles `capacity=0` (it bumps to `default_init_capacity`).

Style note: labeled args (`capacity=...`) before positional, per maintainer preference.

## Test plan

- [x] `moon check`
- [x] `moon test` — 6425/6425 pass (full suite)
- [x] `moon fmt` — applied
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)