### PR TITLE
refactor: build to_json result without mutation; lean on check-mode coercion

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1658,7 +1658,9 @@ pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
 /// ```
 ///
 pub impl[A : ToJson] ToJson for Deque[A] with to_json(self : Deque[A]) -> Json {
-  Json::array([ for x in self => x.to_json() ])
+  [
+    for x in self => x
+  ]
 }
 
 ///|

--- a/hashmap/json.mbt
+++ b/hashmap/json.mbt
@@ -14,9 +14,12 @@
 
 ///|
 pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V] with to_json(self) {
-  let object = Map([], capacity=self.capacity)
-  for k, v in self {
-    object[k.to_string()] = v.to_json()
-  }
-  Json::object(object)
+  Json::object(
+    Map(
+      capacity=self.capacity,
+      [
+        for k, v in self => (k.to_string(), v.to_json())
+      ],
+    ),
+  )
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -690,13 +690,9 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      res.push(key.to_json())
-    }
-  }
-  Json::array(res)
+  [
+    for entry in self.entries if entry is Some({ key, .. }) => key
+  ]
 }
 
 ///|

--- a/immut/priority_queue/types.mbt
+++ b/immut/priority_queue/types.mbt
@@ -30,5 +30,7 @@ priv enum Node[A] {
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(
   self : PriorityQueue[A],
 ) {
-  Json::array([ for item in self => item.to_json() ])
+  [
+    for item in self => item
+  ]
 }

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -791,7 +791,9 @@ pub impl[A : Show] Show for SortedSet[A] with output(self, logger) {
 
 ///|
 pub impl[A : ToJson] ToJson for SortedSet[A] with to_json(self) {
-  Json::array([ for a in self => a.to_json() ])
+  [
+    for a in self => a
+  ]
 }
 
 ///|

--- a/priority_queue/moon.pkg
+++ b/priority_queue/moon.pkg
@@ -4,13 +4,13 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/splitmix",
-  "moonbitlang/core/json",
 }
 
 import {
   "moonbitlang/core/random",
   "moonbitlang/core/cmp",
   "moonbitlang/core/test",
+  "moonbitlang/core/json",
 } for "test"
 
 options(

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -133,7 +133,9 @@ pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
 
 ///|
 pub impl[A : ToJson + Compare] ToJson for PriorityQueue[A] with to_json(self) {
-  Json::array([ for x in self => x.to_json() ])
+  [
+    for x in self => x
+  ]
 }
 
 ///|


### PR DESCRIPTION
## Summary

Apply the comprehension-based build pattern across more `ToJson` impls. Per maintainer feedback: rely on check-mode coercion — no need to wrap in `Json::array(...)` when the return type is `Json`, no need to call `x.to_json()` inside the comprehension when `X : ToJson` is in scope (see existing `immut/vector/vector.mbt:669` for the canonical form).

**`hashmap/json.mbt` — `HashMap::to_json`** (Map shape kept; check-mode unwrap is for arrays only):
```diff
 pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V] with to_json(self) {
-  let object = Map([], capacity=self.capacity)
-  for k, v in self {
-    object[k.to_string()] = v.to_json()
-  }
-  Json::object(object)
+  Json::object(
+    Map(
+      capacity=self.capacity,
+      [for k, v in self => (k.to_string(), v.to_json())],
+    ),
+  )
 }
```

**`hashset/hashset.mbt` — `HashSet::to_json`**:
```diff
 pub impl[X : ToJson] ToJson for HashSet[X] with to_json(self) {
-  let res = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      res.push(key.to_json())
-    }
-  }
-  Json::array(res)
+  [for entry in self.entries if entry is Some({ key, .. }) => key]
 }
```

**`priority_queue/priority_queue.mbt`, `immut/sorted_set/immutable_set.mbt`, `immut/priority_queue/types.mbt`** — already had `Json::array([for x in self => x.to_json()])`; drop both the outer wrap and the inner `to_json()`:
```diff
-Json::array([ for x in self => x.to_json() ])
+[for x in self => x]
```

**`priority_queue/moon.pkg`** — move `moonbitlang/core/json` to the test-only import block (only `README.mbt.md` doctest needs `@json.json_inspect` now that the impl no longer mentions `Json::`).

Style note: labeled args before positional (`capacity=...`).

## Test plan

- [x] `moon check`
- [x] `moon test` — 6425/6425 pass (full suite)
- [x] `moon fmt` — applied
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)