### PR TITLE
refactor: build to_array result without mutation (HashSet, SortedMap)

### DIFF
--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -335,13 +335,9 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
 ///|
 /// Converts the hash set to an array.
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
-  let arr = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      arr.push(key)
-    }
-  }
-  arr
+  [
+    for entry in self.entries if entry is Some({ key, .. }) => key
+  ]
 }
 
 ///|

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -317,9 +317,9 @@ pub fn[K, V] SortedMap::values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
 ///|
 /// Returns an array of all key-value pairs in ascending key order.
 pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
-  let arr = Array::new(capacity=self.size)
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [
+    for k, v in self => (k, v)
+  ]
 }
 
 ///|


### PR DESCRIPTION
## Summary

Two more sites collapse to a comprehension, mirroring the `to_json` sweep in #3547:

**`hashset/hashset.mbt` — `HashSet::to_array`:**
```diff
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
-  let arr = Array::new(capacity=self.size)
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      arr.push(key)
-    }
-  }
-  arr
+  [for entry in self.entries if entry is Some({ key, .. }) => key]
 }
```

**`sorted_map/map.mbt` — `SortedMap::to_array`:**
```diff
 pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
-  let arr = Array::new(capacity=self.size)
-  self.each((k, v) => arr.push((k, v)))
-  arr
+  [for k, v in self => (k, v)]
 }
```

Both `to_array` methods are conversion paths, not on the matching/insertion hot path of the underlying data structure.

## Test plan

- [x] `moon check`
- [x] `moon test` — 6425/6425 pass (full suite)
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)