### PR TITLE
Fix dense symbol map offsets

### DIFF
--- a/bytes/internal/regex_engine/symbol_map/symbol_map.mbt
+++ b/bytes/internal/regex_engine/symbol_map/symbol_map.mbt
@@ -44,11 +44,9 @@ pub fn SymbolMap::finalize(
   ub : @shared_types.Rechar,
 ) -> (&Table, ReadOnlyArray[@shared_types.Rechar]) {
   if ub - lb < 1024 {
-    let (table, repr) = self.finalize_dense(lb, ub)
-    (table as &Table, repr)
+    self.finalize_dense(lb, ub)
   } else {
-    let (table, repr) = self.finalize_sparse(lb, ub)
-    (table as &Table, repr)
+    self.finalize_sparse(lb, ub)
   }
 }
 
@@ -57,17 +55,24 @@ fn SymbolMap::finalize_dense(
   self : SymbolMap,
   lb : @shared_types.Rechar,
   ub : @shared_types.Rechar,
-) -> (DenseTable, ReadOnlyArray[@shared_types.Rechar]) {
+) -> (&Table, ReadOnlyArray[@shared_types.Rechar]) {
   let repr = []
   let table = FixedArray::make(ub - lb + 1, 0)
   self.each_intervals(lb, ub, (lo, hi) => {
     let symbol = repr.length()
     repr.push(lo)
     for c in lo..<=hi {
-      table[c] = symbol
+      table[c - lb] = symbol
     }
   })
-  (DenseTable(table), ReadOnlyArray::from_array(repr))
+  (
+    if lb == 0 {
+      DenseTableWithZeroLb(table) as &Table
+    } else {
+      DenseTable(table, lb) as &Table
+    },
+    ReadOnlyArray::from_array(repr),
+  )
 }
 
 ///|
@@ -75,7 +80,7 @@ fn SymbolMap::finalize_sparse(
   self : SymbolMap,
   lb : @shared_types.Rechar,
   ub : @shared_types.Rechar,
-) -> (SparseTable, ReadOnlyArray[@shared_types.Rechar]) {
+) -> (&Table, ReadOnlyArray[@shared_types.Rechar]) {
   let repr = []
   let entries = []
   self.each_intervals(lb, ub, (lo, hi) => {
@@ -84,7 +89,7 @@ fn SymbolMap::finalize_sparse(
     entries.push({ lo, hi, symbol })
   })
   (
-    SparseTable(ReadOnlyArray::from_array(entries)),
+    SparseTable(ReadOnlyArray::from_array(entries)) as &Table,
     ReadOnlyArray::from_array(repr),
   )
 }

--- a/bytes/internal/regex_engine/symbol_map/symbol_map_test.mbt
+++ b/bytes/internal/regex_engine/symbol_map/symbol_map_test.mbt
@@ -13,17 +13,15 @@
 // limitations under the License.
 
 ///|
-priv struct DenseTableWithZeroLb(FixedArray[@shared_types.Rechar])
-
-///|
-impl Table for DenseTableWithZeroLb with map(self, c) {
-  self.0.unsafe_get(c)
-}
-
-///|
-priv struct DenseTable(FixedArray[@shared_types.Rechar], @shared_types.Rechar)
-
-///|
-impl Table for DenseTable with map(self, c) {
-  self.0.unsafe_get(c - self.1)
+test "dense table respects non-zero lower bound" {
+  let symbol_map = @symbol_map.new()
+  symbol_map.split(@shared_types.RecharSet::char(11))
+  let (table, repr) = symbol_map.finalize(10, 12)
+  assert_eq(repr.length(), 3)
+  assert_eq(repr[0], 10)
+  assert_eq(repr[1], 11)
+  assert_eq(repr[2], 12)
+  assert_eq(table.map(10), 0)
+  assert_eq(table.map(11), 1)
+  assert_eq(table.map(12), 2)
 }


### PR DESCRIPTION
This pull request refactors the dense table implementation in the regex engine's symbol map to correctly support non-zero lower bounds, and updates the interface for table finalization. It also adds a new test to ensure the dense table behaves as expected when the lower bound is not zero.

**Dense table improvements:**

* Introduced two separate structs: `DenseTableWithZeroLb` for tables with a zero lower bound, and `DenseTable` for tables with arbitrary lower bounds, updating their `Table` trait implementations accordingly. (`bytes/internal/regex_engine/symbol_map/dense_table.mbt` [bytes/internal/regex_engine/symbol_map/dense_table.mbtL16-R29](diffhunk://#diff-a946b33da43285b49225bfac607e97d4e01e9c97ac49305850261980a4e7eda9L16-R29))
* Modified `SymbolMap::finalize_dense` to return the appropriate table type based on the lower bound and to correctly offset indices by the lower bound. (`bytes/internal/regex_engine/symbol_map/symbol_map.mbt` [bytes/internal/regex_engine/symbol_map/symbol_map.mbtL60-R83](diffhunk://#diff-a679609f98e5185f23b4697a7b8a423ac3239126749cbddc2fe7f77575826756L60-R83))

**API and type signature changes:**

* Changed the return type of `SymbolMap::finalize`, `finalize_dense`, and `finalize_sparse` to always return a trait object (`&Table`) instead of concrete table types, simplifying downstream usage. (`bytes/internal/regex_engine/symbol_map/symbol_map.mbt` [[1]](diffhunk://#diff-a679609f98e5185f23b4697a7b8a423ac3239126749cbddc2fe7f77575826756L47-R49) [[2]](diffhunk://#diff-a679609f98e5185f23b4697a7b8a423ac3239126749cbddc2fe7f77575826756L60-R83) [[3]](diffhunk://#diff-a679609f98e5185f23b4697a7b8a423ac3239126749cbddc2fe7f77575826756L87-R92)

**Testing improvements:**

* Added a new test to verify that the dense table implementation correctly handles non-zero lower bounds. (`bytes/internal/regex_engine/symbol_map/symbol_map_test.mbt` [bytes/internal/regex_engine/symbol_map/symbol_map_test.mbtR1-R27](diffhunk://#diff-387b05767f5d971186e5478b69988357db1c08dbc78aa3f4f023f6461c69e6abR1-R27))