### PR TITLE
refactor(argparse): collapse format_entries to fold + comprehension

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -291,23 +291,16 @@ fn render_section(
 
 ///|
 fn format_entries(display : Array[(String, String)]) -> Array[String] {
-  let entries = Array::new(capacity=display.length())
-  let max_len = for item in display; max_len = 0 {
-    let (name, _) = item
-    if name.length() > max_len {
-      continue name.length()
-    } else {
-      continue max_len
-    }
-  } nobreak {
-    max_len
-  }
-  for item in display {
-    let (name, doc) = item
+  let max_len = display
+    .iter()
+    .fold(init=0, (acc, item) => acc.max(item.0.length()))
+  fn fmt(name : String, doc : String) -> String {
     let padding = " ".repeat(max_len - name.length() + 2)
-    entries.push("  \{name}\{padding}\{doc}")
+    "  \{name}\{padding}\{doc}"
   }
-  entries
+  [
+    for item in display => fmt(item.0, item.1)
+  ]
 }
 
 ///|

--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -291,9 +291,7 @@ fn render_section(
 
 ///|
 fn format_entries(display : Array[(String, String)]) -> Array[String] {
-  let max_len = display
-    .iter()
-    .fold(init=0, (acc, item) => acc.max(item.0.length()))
+  let max_len = display.fold(init=0, (acc, item) => acc.max(item.0.length()))
   fn fmt(name : String, doc : String) -> String {
     let padding = " ".repeat(max_len - name.length() + 2)
     "  \{name}\{padding}\{doc}"


### PR DESCRIPTION
## Summary

`format_entries` had two stateful loops to (1) compute the maximum name length, then (2) build the formatted entries. Replace both with a single fold + comprehension:

```diff
 fn format_entries(display : Array[(String, String)]) -> Array[String] {
-  let entries = Array::new(capacity=display.length())
-  let max_len = for item in display; max_len = 0 {
-    let (name, _) = item
-    if name.length() > max_len {
-      continue name.length()
-    } else {
-      continue max_len
-    }
-  } nobreak {
-    max_len
-  }
-  for item in display {
-    let (name, doc) = item
-    let padding = " ".repeat(max_len - name.length() + 2)
-    entries.push("  \{name}\{padding}\{doc}")
-  }
-  entries
+  let max_len = display
+    .iter()
+    .fold(init=0, (acc, item) => acc.max(item.0.length()))
+  fn fmt(name : String, doc : String) -> String {
+    let padding = " ".repeat(max_len - name.length() + 2)
+    "  \{name}\{padding}\{doc}"
+  }
+  [for item in display => fmt(item.0, item.1)]
 }
```

The nested `fmt` helper exists because string interpolation can't contain `"` inside `\{ }`, so the `padding` `let` can't be inlined into a comprehension body — it's a single-expression closure capturing `max_len`.

Removes one `let mut`-style accumulator and one imperative-push loop.

## Test plan

- [x] `moon check`
- [x] `moon test -p argparse` — 225/225 pass
- [x] `moon fmt` — no change
- [x] `moon info` — no `.mbti` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)