### PR TITLE
refactor(argparse): collapse usage_tail to filter-and-join

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -50,23 +50,21 @@ fn render_help_with_usage_override(
 
 ///|
 fn usage_tail(cmd : Command) -> String {
-  let mut tail = ""
-  let required_options = required_option_usage(cmd)
-  if required_options != "" {
-    tail = "\{tail} \{required_options}"
+  let parts = [
+    required_option_usage(cmd),
+    if has_options(cmd) {
+      "[options]"
+    } else {
+      ""
+    },
+    positional_usage(cmd),
+    subcommand_usage(cmd),
+  ].filter(p => p != "")
+  if parts.is_empty() {
+    ""
+  } else {
+    " " + parts.join(" ")
   }
-  if has_options(cmd) {
-    tail = "\{tail} [options]"
-  }
-  let pos = positional_usage(cmd)
-  if pos != "" {
-    tail = "\{tail} \{pos}"
-  }
-  let sub = subcommand_usage(cmd)
-  if sub != "" {
-    tail = "\{tail} \{sub}"
-  }
-  tail
 }
 
 ///|


### PR DESCRIPTION
## Summary

`usage_tail` had a `let mut tail = \"\"` plus four conditional `tail = \"\{tail} \{...}\"` accumulations. Replace with a single array literal, filter-non-empty, and join:

```diff
 fn usage_tail(cmd : Command) -> String {
-  let mut tail = \"\"
-  let required_options = required_option_usage(cmd)
-  if required_options != \"\" {
-    tail = \"\{tail} \{required_options}\"
-  }
-  if has_options(cmd) {
-    tail = \"\{tail} [options]\"
-  }
-  let pos = positional_usage(cmd)
-  if pos != \"\" {
-    tail = \"\{tail} \{pos}\"
-  }
-  let sub = subcommand_usage(cmd)
-  if sub != \"\" {
-    tail = \"\{tail} \{sub}\"
-  }
-  tail
+  let parts = [
+    required_option_usage(cmd),
+    if has_options(cmd) { \"[options]\" } else { \"\" },
+    positional_usage(cmd),
+    subcommand_usage(cmd),
+  ].filter(p => p != \"\")
+  if parts.is_empty() {
+    \"\"
+  } else {
+    \" \" + parts.join(\" \")
+  }
 }
```

Eliminates the `let mut` accumulator. Each helper still called once.

## Test plan

- [x] \`moon check\`
- [x] \`moon test -p argparse\` — 225/225 pass
- [x] \`moon fmt\` — no change
- [x] \`moon info\` — no \`.mbti\` diff (semantics-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)