### PR TITLE
feat: Add iterator size hints

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1856,7 +1856,7 @@ pub fn[T] Array::from_iter(iter : Iter[T]) -> Array[T] {
 pub fn[T] Array::push_iter(self : Self[T], iter : Iter[T]) -> Unit {
   // This function used by [Array spread operator](https://docs.moonbitlang.com/en/latest/language/fundamentals.html#spread-operator)
   // it can't be removed and deprecated
-  if iter.length() is Some(n) {
+  if iter.size_hint() is Some(n) {
     self.reserve_capacity(self.length() + n)
   }
   for x in iter {
@@ -2063,7 +2063,7 @@ pub fn[A, B] Array::zip_to_iter2(
       i += 1
       Some(elem)
     },
-    length~,
+    size_hint=length,
   ).iter2()
 }
 

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1856,6 +1856,9 @@ pub fn[T] Array::from_iter(iter : Iter[T]) -> Array[T] {
 pub fn[T] Array::push_iter(self : Self[T], iter : Iter[T]) -> Unit {
   // This function used by [Array spread operator](https://docs.moonbitlang.com/en/latest/language/fundamentals.html#spread-operator)
   // it can't be removed and deprecated
+  if iter.length() is Some(n) {
+    self.reserve_capacity(self.length() + n)
+  }
   for x in iter {
     self.push(x)
   }
@@ -2053,12 +2056,15 @@ pub fn[A, B] Array::zip_to_iter2(
     other.length()
   }
   let mut i = 0
-  Iter2::new(() => {
-    guard i < length else { None }
-    let elem = (self[i], other[i])
-    i += 1
-    Some(elem)
-  }).iter2()
+  Iter2::new(
+    () => {
+      guard i < length else { None }
+      let elem = (self[i], other[i])
+      i += 1
+      Some(elem)
+    },
+    length~,
+  ).iter2()
 }
 
 ///|

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -534,22 +534,25 @@ pub fn[T] ArrayView::suffixes(
 ) -> Iter[ArrayView[T]] {
   let len = self.length()
   let mut i = 0
-  Iter::new(fn() -> ArrayView[T]? {
-    if i < len {
-      let suffix = self[i:]
-      i += 1
-      Some(suffix)
-    } else if i == len {
-      i += 1
-      if include_empty {
-        Some(self[len:])
+  Iter::new(
+    fn() -> ArrayView[T]? {
+      if i < len {
+        let suffix = self[i:]
+        i += 1
+        Some(suffix)
+      } else if i == len {
+        i += 1
+        if include_empty {
+          Some(self[len:])
+        } else {
+          None
+        }
       } else {
         None
       }
-    } else {
-      None
-    }
-  })
+    },
+    length=if include_empty { len + 1 } else { len },
+  )
 }
 
 ///|
@@ -677,12 +680,16 @@ pub fn[T] ArrayView::windows(
 #alias(iterator, deprecated)
 pub fn[X] ArrayView::iter(self : ArrayView[X]) -> Iter[X] {
   let mut i = 0
-  Iter::new(fn() {
-    guard i < self.length() else { None }
-    let elem = self.unsafe_get(i)
-    i += 1
-    Some(elem)
-  })
+  let len = self.length()
+  Iter::new(
+    fn() {
+      guard i < len else { None }
+      let elem = self.unsafe_get(i)
+      i += 1
+      Some(elem)
+    },
+    length=len,
+  )
 }
 
 ///|
@@ -700,12 +707,16 @@ pub fn[X] ArrayView::iter(self : ArrayView[X]) -> Iter[X] {
 /// ```
 #alias(rev_iterator, deprecated)
 pub fn[X] ArrayView::rev_iter(self : ArrayView[X]) -> Iter[X] {
-  let mut i = self.length()
-  Iter::new(fn() {
-    guard i > 0 else { None }
-    i -= 1
-    Some(self.unsafe_get(i))
-  })
+  let len = self.length()
+  let mut i = len
+  Iter::new(
+    fn() {
+      guard i > 0 else { None }
+      i -= 1
+      Some(self.unsafe_get(i))
+    },
+    length=len,
+  )
 }
 
 ///|
@@ -732,12 +743,16 @@ pub fn[X] ArrayView::rev_iter(self : ArrayView[X]) -> Iter[X] {
 #alias(iterator2, deprecated)
 pub fn[X] ArrayView::iter2(self : ArrayView[X]) -> Iter2[Int, X] {
   let mut i = 0
-  Iter2::new(fn() {
-    guard i < self.length() else { None }
-    let result = Some((i, self.unsafe_get(i)))
-    i += 1
-    result
-  })
+  let len = self.length()
+  Iter2::new(
+    fn() {
+      guard i < len else { None }
+      let result = Some((i, self.unsafe_get(i)))
+      i += 1
+      result
+    },
+    length=len,
+  )
 }
 
 ///|

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -551,7 +551,7 @@ pub fn[T] ArrayView::suffixes(
         None
       }
     },
-    length=if include_empty { len + 1 } else { len },
+    size_hint=if include_empty { len + 1 } else { len },
   )
 }
 
@@ -688,7 +688,7 @@ pub fn[X] ArrayView::iter(self : ArrayView[X]) -> Iter[X] {
       i += 1
       Some(elem)
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -715,7 +715,7 @@ pub fn[X] ArrayView::rev_iter(self : ArrayView[X]) -> Iter[X] {
       i -= 1
       Some(self.unsafe_get(i))
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -751,7 +751,7 @@ pub fn[X] ArrayView::iter2(self : ArrayView[X]) -> Iter2[Int, X] {
       i += 1
       result
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -657,12 +657,15 @@ pub fn BytesView::to_array(self : BytesView) -> Array[Byte] {
 pub fn Bytes::iter(self : Bytes) -> Iter[Byte] {
   let mut i = 0
   let len = self.length()
-  Iter::new(fn() {
-    guard i < len else { None }
-    let c = self.unsafe_get(i)
-    i += 1
-    Some(c)
-  })
+  Iter::new(
+    fn() {
+      guard i < len else { None }
+      let c = self.unsafe_get(i)
+      i += 1
+      Some(c)
+    },
+    length=len,
+  )
 }
 
 ///|
@@ -688,12 +691,15 @@ pub fn Bytes::iter(self : Bytes) -> Iter[Byte] {
 pub fn Bytes::iter2(self : Bytes) -> Iter2[Int, Byte] {
   let mut i = 0
   let len = self.length()
-  Iter::new(fn() {
-    guard i < len else { None }
-    let result = (i, self.unsafe_get(i))
-    i += 1
-    Some(result)
-  })
+  Iter::new(
+    fn() {
+      guard i < len else { None }
+      let result = (i, self.unsafe_get(i))
+      i += 1
+      Some(result)
+    },
+    length=len,
+  )
 }
 
 ///|

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -664,7 +664,7 @@ pub fn Bytes::iter(self : Bytes) -> Iter[Byte] {
       i += 1
       Some(c)
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -698,7 +698,7 @@ pub fn Bytes::iter2(self : Bytes) -> Iter2[Int, Byte] {
       i += 1
       Some(result)
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -282,12 +282,15 @@ pub fn BytesView::view(
 pub fn BytesView::iter(self : BytesView) -> Iter[Byte] {
   let mut i = 0
   let len = self.length()
-  Iter::new(fn() {
-    guard i < len else { None }
-    let result = self.unsafe_get(i)
-    i += 1
-    Some(result)
-  })
+  Iter::new(
+    fn() {
+      guard i < len else { None }
+      let result = self.unsafe_get(i)
+      i += 1
+      Some(result)
+    },
+    length=len,
+  )
 }
 
 ///|
@@ -312,12 +315,15 @@ pub fn BytesView::iter(self : BytesView) -> Iter[Byte] {
 pub fn BytesView::iter2(self : BytesView) -> Iter2[Int, Byte] {
   let mut i = 0
   let len = self.length()
-  Iter2::new(fn() {
-    guard i < len else { None }
-    let result = (i, self.unsafe_get(i))
-    i += 1
-    Some(result)
-  })
+  Iter2::new(
+    fn() {
+      guard i < len else { None }
+      let result = (i, self.unsafe_get(i))
+      i += 1
+      Some(result)
+    },
+    length=len,
+  )
 }
 
 ///|

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -289,7 +289,7 @@ pub fn BytesView::iter(self : BytesView) -> Iter[Byte] {
       i += 1
       Some(result)
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -322,7 +322,7 @@ pub fn BytesView::iter2(self : BytesView) -> Iter2[Int, Byte] {
       i += 1
       Some(result)
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -262,6 +262,79 @@ test "map" {
 }
 
 ///|
+test "length" {
+  let iter = [1, 2, 3].iter()
+  debug_inspect(iter.length(), content="Some(3)")
+  debug_inspect(iter.next(), content="Some(1)")
+  debug_inspect(iter.length(), content="Some(2)")
+  debug_inspect(iter.collect(), content="[2, 3]")
+  debug_inspect(iter.length(), content="Some(0)")
+  debug_inspect([1, 2, 3].iter().map(x => x + 1).length(), content="Some(3)")
+  debug_inspect(
+    [1, 2, 3].iter().mapi((i, x) => i + x).length(),
+    content="Some(3)",
+  )
+  debug_inspect([1, 2, 3].iter().tap(_ => ()).length(), content="Some(3)")
+  debug_inspect([1, 2, 3].iter().take(2).length(), content="Some(2)")
+  debug_inspect([1, 2, 3].iter().take(5).length(), content="Some(3)")
+  debug_inspect([1, 2, 3].iter().take(0).length(), content="Some(0)")
+  debug_inspect([1, 2, 3].iter().drop(0).length(), content="Some(3)")
+  debug_inspect([1, 2, 3].iter().drop(1).length(), content="Some(2)")
+  debug_inspect([1, 2, 3].iter().drop(5).length(), content="Some(0)")
+  debug_inspect(
+    [1, 2, 3].iter().concat([4, 5].iter()).length(),
+    content="Some(5)",
+  )
+  debug_inspect([1, 2].iter().zip([3, 4, 5].iter()).length(), content="Some(2)")
+  debug_inspect([1, 2, 3].iter().zip([4, 5].iter()).length(), content="Some(2)")
+  let empty_left : Iter[Int] = Iter::empty()
+  debug_inspect(
+    empty_left.zip(Iter::new(() => Some(1))).length(),
+    content="Some(0)",
+  )
+  let empty_right : Iter[Int] = Iter::empty()
+  debug_inspect(
+    Iter::new(() => Some(1)).zip(empty_right).length(),
+    content="Some(0)",
+  )
+  debug_inspect(
+    Iter::new(() => Some(1)).zip([1].iter()).length(),
+    content="None",
+  )
+  debug_inspect([1, 2, 3].iter().intersperse(0).length(), content="Some(5)")
+  debug_inspect(
+    Iter::new(() => Some(1)).intersperse(0).length(),
+    content="None",
+  )
+  debug_inspect([1, 2, 3].iter()[1:3].length(), content="Some(2)")
+  debug_inspect([1, 2, 3].iter()[3:5].length(), content="Some(0)")
+  debug_inspect(
+    Iter::new(() => Some(1)).view(start=2, end=1).length(),
+    content="Some(0)",
+  )
+  debug_inspect(
+    Iter::new(() => Some(1)).view(start=1, end=3).length(),
+    content="None",
+  )
+  debug_inspect([1, 2, 3].iter().filter(x => x > 1).length(), content="None")
+  debug_inspect(
+    [1, 2, 3]
+    .iter()
+    .filter_map(x => if x > 1 { Some(x) } else { None })
+    .length(),
+    content="None",
+  )
+  debug_inspect(
+    [1, 2, 3].iter().take_while(x => x < 3).length(),
+    content="None",
+  )
+  let unknown : Iter[Int] = Iter::new(() => None)
+  let known_empty : Iter[Int] = Iter::new(() => None, length=0)
+  debug_inspect(unknown.length(), content="None")
+  debug_inspect(known_empty.length(), content="Some(0)")
+}
+
+///|
 test "mapi" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = StringBuilder::new(size_hint=0)

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -262,76 +262,101 @@ test "map" {
 }
 
 ///|
-test "length" {
+test "size_hint" {
   let iter = [1, 2, 3].iter()
-  debug_inspect(iter.length(), content="Some(3)")
+  debug_inspect(iter.size_hint(), content="Some(3)")
   debug_inspect(iter.next(), content="Some(1)")
-  debug_inspect(iter.length(), content="Some(2)")
+  debug_inspect(iter.size_hint(), content="Some(2)")
   debug_inspect(iter.collect(), content="[2, 3]")
-  debug_inspect(iter.length(), content="Some(0)")
-  debug_inspect([1, 2, 3].iter().map(x => x + 1).length(), content="Some(3)")
+  debug_inspect(iter.size_hint(), content="Some(0)")
+  debug_inspect([1, 2, 3].iter().map(x => x + 1).size_hint(), content="Some(3)")
   debug_inspect(
-    [1, 2, 3].iter().mapi((i, x) => i + x).length(),
+    [1, 2, 3].iter().mapi((i, x) => i + x).size_hint(),
     content="Some(3)",
   )
-  debug_inspect([1, 2, 3].iter().tap(_ => ()).length(), content="Some(3)")
-  debug_inspect([1, 2, 3].iter().take(2).length(), content="Some(2)")
-  debug_inspect([1, 2, 3].iter().take(5).length(), content="Some(3)")
-  debug_inspect([1, 2, 3].iter().take(0).length(), content="Some(0)")
-  debug_inspect([1, 2, 3].iter().drop(0).length(), content="Some(3)")
-  debug_inspect([1, 2, 3].iter().drop(1).length(), content="Some(2)")
-  debug_inspect([1, 2, 3].iter().drop(5).length(), content="Some(0)")
+  debug_inspect([1, 2, 3].iter().tap(_ => ()).size_hint(), content="Some(3)")
+  debug_inspect([1, 2, 3].iter().take(2).size_hint(), content="Some(2)")
+  debug_inspect([1, 2, 3].iter().take(5).size_hint(), content="Some(3)")
+  debug_inspect([1, 2, 3].iter().take(0).size_hint(), content="Some(0)")
+  debug_inspect([1, 2, 3].iter().drop(0).size_hint(), content="Some(3)")
+  debug_inspect([1, 2, 3].iter().drop(1).size_hint(), content="Some(2)")
+  debug_inspect([1, 2, 3].iter().drop(5).size_hint(), content="Some(0)")
   debug_inspect(
-    [1, 2, 3].iter().concat([4, 5].iter()).length(),
+    [1, 2, 3].iter().concat([4, 5].iter()).size_hint(),
     content="Some(5)",
   )
-  debug_inspect([1, 2].iter().zip([3, 4, 5].iter()).length(), content="Some(2)")
-  debug_inspect([1, 2, 3].iter().zip([4, 5].iter()).length(), content="Some(2)")
+  debug_inspect(
+    [1, 2].iter().zip([3, 4, 5].iter()).size_hint(),
+    content="Some(2)",
+  )
+  debug_inspect(
+    [1, 2, 3].iter().zip([4, 5].iter()).size_hint(),
+    content="Some(2)",
+  )
   let empty_left : Iter[Int] = Iter::empty()
   debug_inspect(
-    empty_left.zip(Iter::new(() => Some(1))).length(),
+    empty_left.zip(Iter::new(() => Some(1))).size_hint(),
     content="Some(0)",
   )
   let empty_right : Iter[Int] = Iter::empty()
   debug_inspect(
-    Iter::new(() => Some(1)).zip(empty_right).length(),
+    Iter::new(() => Some(1)).zip(empty_right).size_hint(),
     content="Some(0)",
   )
   debug_inspect(
-    Iter::new(() => Some(1)).zip([1].iter()).length(),
+    Iter::new(() => Some(1)).zip([1].iter()).size_hint(),
     content="None",
   )
-  debug_inspect([1, 2, 3].iter().intersperse(0).length(), content="Some(5)")
+  debug_inspect([1, 2, 3].iter().intersperse(0).size_hint(), content="Some(5)")
   debug_inspect(
-    Iter::new(() => Some(1)).intersperse(0).length(),
+    Iter::new(() => Some(1)).intersperse(0).size_hint(),
     content="None",
   )
-  debug_inspect([1, 2, 3].iter()[1:3].length(), content="Some(2)")
-  debug_inspect([1, 2, 3].iter()[3:5].length(), content="Some(0)")
+  debug_inspect([1, 2, 3].iter()[1:3].size_hint(), content="Some(2)")
+  debug_inspect([1, 2, 3].iter()[3:5].size_hint(), content="Some(0)")
   debug_inspect(
-    Iter::new(() => Some(1)).view(start=2, end=1).length(),
+    Iter::new(() => Some(1)).view(start=2, end=1).size_hint(),
     content="Some(0)",
   )
   debug_inspect(
-    Iter::new(() => Some(1)).view(start=1, end=3).length(),
+    Iter::new(() => Some(1)).view(start=1, end=3).size_hint(),
     content="None",
   )
-  debug_inspect([1, 2, 3].iter().filter(x => x > 1).length(), content="None")
+  debug_inspect([1, 2, 3].iter().filter(x => x > 1).size_hint(), content="None")
   debug_inspect(
     [1, 2, 3]
     .iter()
     .filter_map(x => if x > 1 { Some(x) } else { None })
-    .length(),
+    .size_hint(),
     content="None",
   )
   debug_inspect(
-    [1, 2, 3].iter().take_while(x => x < 3).length(),
+    [1, 2, 3].iter().take_while(x => x < 3).size_hint(),
     content="None",
   )
   let unknown : Iter[Int] = Iter::new(() => None)
-  let known_empty : Iter[Int] = Iter::new(() => None, length=0)
-  debug_inspect(unknown.length(), content="None")
-  debug_inspect(known_empty.length(), content="Some(0)")
+  let known_empty : Iter[Int] = Iter::new(() => None, size_hint=0)
+  debug_inspect(unknown.size_hint(), content="None")
+  debug_inspect(known_empty.size_hint(), content="Some(0)")
+  let mut i = 0
+  let too_small = Iter::new(
+    fn() {
+      if i < 3 {
+        i += 1
+        Some(i)
+      } else {
+        None
+      }
+    },
+    size_hint=1,
+  )
+  debug_inspect(too_small.collect(), content="[1, 2, 3]")
+  debug_inspect(too_small.size_hint(), content="Some(0)")
+  let too_large : Iter[Int] = Iter::new(() => None, size_hint=3)
+  debug_inspect(too_large.next(), content="None")
+  debug_inspect(too_large.size_hint(), content="Some(0)")
+  let negative_hint : Iter[Int] = Iter::new(() => None, size_hint=-1)
+  debug_inspect(negative_hint.size_hint(), content="Some(0)")
 }
 
 ///|

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -19,7 +19,10 @@
 /// All read operations on `Iterator` will advance the iterator,
 /// and would give different result when called multiple times.
 #alias(Iterator, deprecated="The name `Iterator` is deprecated, use `Iter` instead. Note that if you have defined `iterator()` method to support `for .. in` loop, you should also rename `iterator()` to `iter()`. See https://github.com/moonbitlang/core/pull/3127 for more details.")
-struct Iter[X](() -> X?)
+struct Iter[X] {
+  f : () -> X?
+  mut length : Int?
+}
 
 ///|
 /// Get the next element from an iterator, or return `None` if no more element exists.
@@ -28,7 +31,25 @@ struct Iter[X](() -> X?)
 #alias(peek, deprecated)
 #alias(head)
 pub fn[X] Iter::next(self : Iter[X]) -> X? {
-  (self.0)()
+  let result = (self.f)()
+  debug_assert(() => {
+    match (result, self.length) {
+      (None, Some(n)) => n == 0
+      _ => true
+    }
+  })
+  match (result, self.length) {
+    (Some(_), Some(n)) => self.length = Some(n - 1)
+    (None, _) => self.length = Some(0)
+    _ => ()
+  }
+  result
+}
+
+///|
+/// Returns the exact number of remaining elements if it is known.
+pub fn[X] Iter::length(self : Iter[X]) -> Int? {
+  self.length
 }
 
 ///|
@@ -201,11 +222,12 @@ pub fn[X] Iter::count(self : Iter[X]) -> Int {
 /// Create a new iterator by supplying a `next` function directly.
 /// The supplied function should output the next element being iterated
 /// everytime it is called.
+/// If the exact number of remaining elements is known, pass it as `length`.
 ///
 /// This function is intended for use by data structure authors,
 /// and should not be called by end users in general.
-pub fn[X] Iter::new(f : () -> X?) -> Iter[X] {
-  Iter(f)
+pub fn[X] Iter::new(f : () -> X?, length? : Int) -> Iter[X] {
+  { f, length }
 }
 
 ///|
@@ -219,7 +241,7 @@ pub fn[X] Iter::new(f : () -> X?) -> Iter[X] {
 ///
 /// Returns an empty iterator of type `Iter[X]`.
 pub fn[X] Iter::empty() -> Iter[X] {
-  () => None
+  Iter::new(() => None, length=0)
 }
 
 ///|
@@ -238,14 +260,17 @@ pub fn[X] Iter::empty() -> Iter[X] {
 /// Returns an iterator of type `Iter[X]` that contains the single element `a`.
 pub fn[X] Iter::singleton(elem : X) -> Iter[X] {
   let mut consumed = false
-  fn() {
-    if consumed {
-      None
-    } else {
-      consumed = true
-      Some(elem)
-    }
-  }
+  Iter::new(
+    fn() {
+      if consumed {
+        None
+      } else {
+        consumed = true
+        Some(elem)
+      }
+    },
+    length=1,
+  )
 }
 
 ///|
@@ -263,7 +288,7 @@ pub fn[X] Iter::singleton(elem : X) -> Iter[X] {
 ///
 /// Returns an iterator of type `Iter[X]` that repeats the element `x` indefinitely.
 pub fn[X] Iter::repeat(x : X) -> Iter[X] {
-  () => Some(x)
+  Iter::new(() => Some(x))
 }
 
 ///|
@@ -285,7 +310,7 @@ pub fn[X] Iter::repeat(x : X) -> Iter[X] {
 /// # Note
 /// The old iterator `self` must not be used again after calling `filter`.
 pub fn[X] Iter::filter(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
-  fn() {
+  Iter::new(fn() {
     while self.next() is Some(x) {
       if f(x) {
         break Some(x)
@@ -293,7 +318,7 @@ pub fn[X] Iter::filter(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
     } nobreak {
       None
     }
-  }
+  })
 }
 
 ///|
@@ -316,11 +341,14 @@ pub fn[X] Iter::filter(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
 /// # Note
 /// The old iterator `self` must not be used again after calling `map`.
 pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
-  fn() {
-    match self.next() {
-      Some(x) => Some(f(x))
-      None => None
-    }
+  {
+    f: fn() {
+      match self.next() {
+        Some(x) => Some(f(x))
+        None => None
+      }
+    },
+    length: self.length,
   }
 }
 
@@ -345,15 +373,18 @@ pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
 /// The old iterator `self` must not be used again after calling `mapi`.
 pub fn[X, Y] Iter::mapi(self : Iter[X], f : (Int, X) -> Y) -> Iter[Y] {
   let mut i = 0
-  fn() {
-    match self.next() {
-      Some(x) => {
-        let result = f(i, x)
-        i += 1
-        Some(result)
+  {
+    f: fn() {
+      match self.next() {
+        Some(x) => {
+          let result = f(i, x)
+          i += 1
+          Some(result)
+        }
+        None => None
       }
-      None => None
-    }
+    },
+    length: self.length,
   }
 }
 
@@ -363,7 +394,7 @@ pub fn[X, Y] Iter::mapi(self : Iter[X], f : (Int, X) -> Y) -> Iter[Y] {
 ///
 /// The old iterator `self` must not be used again after calling `filter_map`.
 pub fn[X, Y] Iter::filter_map(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
-  fn() {
+  Iter::new(fn() {
     while self.next() is Some(x) {
       match f(x) {
         Some(_) as y => break y
@@ -372,7 +403,7 @@ pub fn[X, Y] Iter::filter_map(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
     } nobreak {
       None
     }
-  }
+  })
 }
 
 ///|
@@ -397,7 +428,7 @@ pub fn[X, Y] Iter::filter_map(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
 /// must not be used again after calling `flat_map`.
 pub fn[X, Y] Iter::flat_map(self : Iter[X], f : (X) -> Iter[Y]) -> Iter[Y] {
   let mut current_iter = Some(Iter::empty())
-  fn() {
+  Iter::new(fn() {
     guard current_iter is Some(iter) else { None }
     for x = iter.next() {
       match x {
@@ -410,7 +441,7 @@ pub fn[X, Y] Iter::flat_map(self : Iter[X], f : (X) -> Iter[Y]) -> Iter[Y] {
         }
       }
     }
-  }
+  })
 }
 
 ///|
@@ -453,12 +484,15 @@ pub fn Iter::join(self : Iter[String], sep : StringView) -> String {
 /// # Note
 /// The old iterator `self` must not be used again after calling `tap`.
 pub fn[X] Iter::tap(self : Iter[X], f : (X) -> Unit) -> Iter[X] {
-  fn() {
-    let result = self.next()
-    if result is Some(x) {
-      f(x)
-    }
-    result
+  {
+    f: fn() {
+      let result = self.next()
+      if result is Some(x) {
+        f(x)
+      }
+      result
+    },
+    length: self.length,
   }
 }
 
@@ -482,13 +516,23 @@ pub fn[X] Iter::tap(self : Iter[X], f : (X) -> Unit) -> Iter[X] {
 /// The old iterator `self` must not be used again after calling `take`.
 pub fn[X] Iter::take(self : Iter[X], n : Int) -> Iter[X] {
   let mut remaining = n
-  fn() {
-    guard remaining > 0 else { None }
-    let result = self.next()
-    if result is Some(_) {
-      remaining -= 1
-    }
-    result
+  let length = match self.length {
+    Some(_) if n <= 0 => Some(0)
+    Some(len) if n < len => Some(n)
+    Some(len) => Some(len)
+    None if n <= 0 => Some(0)
+    None => None
+  }
+  {
+    f: fn() {
+      guard remaining > 0 else { None }
+      let result = self.next()
+      if result is Some(_) {
+        remaining -= 1
+      }
+      result
+    },
+    length,
   }
 }
 
@@ -512,7 +556,7 @@ pub fn[X] Iter::take(self : Iter[X], n : Int) -> Iter[X] {
 /// The old iterator `self` must not be used again after calling `take_while`.
 pub fn[X] Iter::take_while(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
   let mut still_running = true
-  fn() {
+  Iter::new(fn() {
     guard still_running else { None }
     let result = self.next()
     if result is Some(x) && !f(x) {
@@ -521,7 +565,7 @@ pub fn[X] Iter::take_while(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
     } else {
       result
     }
-  }
+  })
 }
 
 ///|
@@ -529,7 +573,7 @@ pub fn[X] Iter::take_while(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
 /// The old iterator `self` must not be used again after calling `map_while`.
 pub fn[X, Y] Iter::map_while(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
   let mut still_running = true
-  fn() {
+  Iter::new(fn() {
     guard still_running else { None }
     let src = self.next()
     guard src is Some(x) else { None }
@@ -538,7 +582,7 @@ pub fn[X, Y] Iter::map_while(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
       still_running = false
     }
     result
-  }
+  })
 }
 
 ///|
@@ -561,13 +605,22 @@ pub fn[X, Y] Iter::map_while(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
 /// The old iterator `self` must not be used again after calling `drop`.
 pub fn[X] Iter::drop(self : Iter[X], n : Int) -> Iter[X] {
   let mut remaining = n
-  fn() {
-    while remaining > 0 {
-      guard self.next() is Some(_) else { break None }
-      remaining -= 1
-    } nobreak {
-      self.next()
-    }
+  let length = match self.length {
+    Some(len) if n <= 0 => Some(len)
+    Some(len) if n < len => Some(len - n)
+    Some(_) => Some(0)
+    None => None
+  }
+  {
+    f: fn() {
+      while remaining > 0 {
+        guard self.next() is Some(_) else { break None }
+        remaining -= 1
+      } nobreak {
+        self.next()
+      }
+    },
+    length,
   }
 }
 
@@ -591,7 +644,7 @@ pub fn[X] Iter::drop(self : Iter[X], n : Int) -> Iter[X] {
 /// The old iterator `self` must not be used again after calling `drop_while`.
 pub fn[X] Iter::drop_while(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
   let mut dropped = false
-  fn() {
+  Iter::new(fn() {
     if !dropped {
       dropped = true
       for x = self.next() {
@@ -603,7 +656,7 @@ pub fn[X] Iter::drop_while(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
     } else {
       self.next()
     }
-  }
+  })
 }
 
 ///|
@@ -654,18 +707,25 @@ pub fn[X] Iter::find_first(self : Iter[X], f : (X) -> Bool) -> X? {
 /// The old iterator `self` and `other` must not be used again after calling `tap`.
 pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
   let mut in_first = true
-  fn() {
-    if in_first {
-      let result = self.next()
-      if result is None {
-        in_first = false
-        other.next()
+  let length = match (self.length, other.length) {
+    (Some(n), Some(m)) => Some(n + m)
+    _ => None
+  }
+  {
+    f: fn() {
+      if in_first {
+        let result = self.next()
+        if result is None {
+          in_first = false
+          other.next()
+        } else {
+          result
+        }
       } else {
-        result
+        other.next()
       }
-    } else {
-      other.next()
-    }
+    },
+    length,
   }
 }
 
@@ -706,10 +766,20 @@ pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
 /// The old iterators `self` and `other` must not be used again after calling `zip`.
 #alias(combine)
 pub fn[X, Y] Iter::zip(self : Iter[X], other : Iter[Y]) -> Iter[(X, Y)] {
-  fn() {
-    guard self.next() is Some(x) else { None }
-    guard other.next() is Some(y) else { None }
-    Some((x, y))
+  let length = match (self.length, other.length) {
+    (Some(n), Some(m)) if n < m => Some(n)
+    (Some(_), Some(m)) => Some(m)
+    (Some(0), _) => Some(0)
+    (_, Some(0)) => Some(0)
+    _ => None
+  }
+  {
+    f: fn() {
+      guard self.next() is Some(x) else { None }
+      guard other.next() is Some(y) else { None }
+      Some((x, y))
+    },
+    length,
   }
 }
 
@@ -723,7 +793,10 @@ pub impl[T] Add for Iter[T] with add(self, other) {
 /// The old iterator `self` must not be used again.
 #alias(collect)
 pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
-  let result = []
+  let result = match self.length {
+    Some(n) => Array::new(capacity=n)
+    None => []
+  }
   while self.next() is Some(x) {
     result.push(x)
   }
@@ -744,11 +817,14 @@ pub fn[X] Iter::iter(self : Iter[X]) -> Iter[X] {
 #alias(iterator2)
 pub fn[X] Iter::iter2(self : Iter[X]) -> Iter2[Int, X] {
   let mut i = 0
-  Iter(() => {
-    guard self.next() is Some(elem) else { None }
-    let result = Some((i, elem))
-    i += 1
-    result
+  Iter2({
+    f: () => {
+      guard self.next() is Some(elem) else { None }
+      let result = Some((i, elem))
+      i += 1
+      result
+    },
+    length: self.length,
   })
 }
 
@@ -791,27 +867,35 @@ pub fn[X] Iter::intersperse(self : Iter[X], sep : X) -> Iter[X] {
     Output_Sep
   }
   let mut state = Init
-  fn() {
-    match state {
-      Init => {
-        let result = self.next()
-        state = Output_Sep
-        result
-      }
-      Output_Elem(x) => {
-        state = Output_Sep
-        Some(x)
-      }
-      Output_Sep =>
-        // make sure we only output the separator when there is remaining element
-        match self.next() {
-          Some(x) => {
-            state = Output_Elem(x)
-            Some(sep)
-          }
-          None => None
+  let length = match self.length {
+    Some(0) => Some(0)
+    Some(n) => Some(n * 2 - 1)
+    None => None
+  }
+  {
+    f: fn() {
+      match state {
+        Init => {
+          let result = self.next()
+          state = Output_Sep
+          result
         }
-    }
+        Output_Elem(x) => {
+          state = Output_Sep
+          Some(x)
+        }
+        Output_Sep =>
+          // make sure we only output the separator when there is remaining element
+          match self.next() {
+            Some(x) => {
+              state = Output_Elem(x)
+              Some(sep)
+            }
+            None => None
+          }
+      }
+    },
+    length,
   }
 }
 
@@ -827,22 +911,33 @@ pub fn[X] Iter::view(self : Iter[X], start? : Int = 0, end? : Int) -> Iter[X] {
     (start, None) => self.drop(start)
     (start, Some(end)) => {
       let mut index = 0
-      fn() {
-        if index >= end {
-          return None
-        }
-        while index < start {
-          guard self.next() is Some(_) else { return None }
-          index += 1
-        }
-        if index >= end {
-          return None
-        }
-        let result = self.next()
-        if result is Some(_) {
-          index += 1
-        }
-        result
+      let length = match self.length {
+        Some(_) if end <= start => Some(0)
+        Some(len) if start >= len => Some(0)
+        Some(len) if end < len => Some(end - start)
+        Some(len) => Some(len - start)
+        None if end <= start => Some(0)
+        None => None
+      }
+      {
+        f: fn() {
+          if index >= end {
+            return None
+          }
+          while index < start {
+            guard self.next() is Some(_) else { return None }
+            index += 1
+          }
+          if index >= end {
+            return None
+          }
+          let result = self.next()
+          if result is Some(_) {
+            index += 1
+          }
+          result
+        },
+        length,
       }
     }
   }
@@ -931,8 +1026,9 @@ pub(all) struct Iter2[X, Y](Iter[(X, Y)])
 
 ///|
 /// Construct an `Iter2` from a pair-producing function.
-pub fn[X, Y] Iter2::new(f : () -> (X, Y)?) -> Iter2[X, Y] {
-  Iter2(Iter::new(f))
+/// If the exact number of remaining pairs is known, pass it as `length`.
+pub fn[X, Y] Iter2::new(f : () -> (X, Y)?, length? : Int) -> Iter2[X, Y] {
+  Iter2({ f, length })
 }
 
 ///|

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -21,7 +21,7 @@
 #alias(Iterator, deprecated="The name `Iterator` is deprecated, use `Iter` instead. Note that if you have defined `iterator()` method to support `for .. in` loop, you should also rename `iterator()` to `iter()`. See https://github.com/moonbitlang/core/pull/3127 for more details.")
 struct Iter[X] {
   f : () -> X?
-  mut length : Int?
+  mut size_hint : Int?
 }
 
 ///|
@@ -32,24 +32,22 @@ struct Iter[X] {
 #alias(head)
 pub fn[X] Iter::next(self : Iter[X]) -> X? {
   let result = (self.f)()
-  debug_assert(() => {
-    match (result, self.length) {
-      (None, Some(n)) => n == 0
-      _ => true
-    }
-  })
-  match (result, self.length) {
-    (Some(_), Some(n)) => self.length = Some(n - 1)
-    (None, _) => self.length = Some(0)
+  match (result, self.size_hint) {
+    (Some(_), Some(n)) =>
+      self.size_hint = if n > 0 { Some(n - 1) } else { Some(0) }
+    (None, _) => self.size_hint = Some(0)
     _ => ()
   }
   result
 }
 
 ///|
-/// Returns the exact number of remaining elements if it is known.
-pub fn[X] Iter::length(self : Iter[X]) -> Int? {
-  self.length
+/// Returns the hinted number of remaining elements if it is known.
+///
+/// The hint is intended to be exact for iterators produced by trusted
+/// collection APIs and adapters, but it must not be used for correctness.
+pub fn[X] Iter::size_hint(self : Iter[X]) -> Int? {
+  self.size_hint
 }
 
 ///|
@@ -222,12 +220,17 @@ pub fn[X] Iter::count(self : Iter[X]) -> Int {
 /// Create a new iterator by supplying a `next` function directly.
 /// The supplied function should output the next element being iterated
 /// everytime it is called.
-/// If the exact number of remaining elements is known, pass it as `length`.
+/// If the number of remaining elements is known, pass it as `size_hint`.
 ///
 /// This function is intended for use by data structure authors,
 /// and should not be called by end users in general.
-pub fn[X] Iter::new(f : () -> X?, length? : Int) -> Iter[X] {
-  { f, length }
+pub fn[X] Iter::new(f : () -> X?, size_hint? : Int) -> Iter[X] {
+  let size_hint = match size_hint {
+    Some(n) if n > 0 => Some(n)
+    Some(_) => Some(0)
+    None => None
+  }
+  { f, size_hint }
 }
 
 ///|
@@ -241,7 +244,7 @@ pub fn[X] Iter::new(f : () -> X?, length? : Int) -> Iter[X] {
 ///
 /// Returns an empty iterator of type `Iter[X]`.
 pub fn[X] Iter::empty() -> Iter[X] {
-  Iter::new(() => None, length=0)
+  Iter::new(() => None, size_hint=0)
 }
 
 ///|
@@ -269,7 +272,7 @@ pub fn[X] Iter::singleton(elem : X) -> Iter[X] {
         Some(elem)
       }
     },
-    length=1,
+    size_hint=1,
   )
 }
 
@@ -348,7 +351,7 @@ pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
         None => None
       }
     },
-    length: self.length,
+    size_hint: self.size_hint,
   }
 }
 
@@ -384,7 +387,7 @@ pub fn[X, Y] Iter::mapi(self : Iter[X], f : (Int, X) -> Y) -> Iter[Y] {
         None => None
       }
     },
-    length: self.length,
+    size_hint: self.size_hint,
   }
 }
 
@@ -492,7 +495,7 @@ pub fn[X] Iter::tap(self : Iter[X], f : (X) -> Unit) -> Iter[X] {
       }
       result
     },
-    length: self.length,
+    size_hint: self.size_hint,
   }
 }
 
@@ -516,7 +519,7 @@ pub fn[X] Iter::tap(self : Iter[X], f : (X) -> Unit) -> Iter[X] {
 /// The old iterator `self` must not be used again after calling `take`.
 pub fn[X] Iter::take(self : Iter[X], n : Int) -> Iter[X] {
   let mut remaining = n
-  let length = match self.length {
+  let size_hint = match self.size_hint {
     Some(_) if n <= 0 => Some(0)
     Some(len) if n < len => Some(n)
     Some(len) => Some(len)
@@ -532,7 +535,7 @@ pub fn[X] Iter::take(self : Iter[X], n : Int) -> Iter[X] {
       }
       result
     },
-    length,
+    size_hint,
   }
 }
 
@@ -605,7 +608,7 @@ pub fn[X, Y] Iter::map_while(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
 /// The old iterator `self` must not be used again after calling `drop`.
 pub fn[X] Iter::drop(self : Iter[X], n : Int) -> Iter[X] {
   let mut remaining = n
-  let length = match self.length {
+  let size_hint = match self.size_hint {
     Some(len) if n <= 0 => Some(len)
     Some(len) if n < len => Some(len - n)
     Some(_) => Some(0)
@@ -620,7 +623,7 @@ pub fn[X] Iter::drop(self : Iter[X], n : Int) -> Iter[X] {
         self.next()
       }
     },
-    length,
+    size_hint,
   }
 }
 
@@ -707,7 +710,7 @@ pub fn[X] Iter::find_first(self : Iter[X], f : (X) -> Bool) -> X? {
 /// The old iterator `self` and `other` must not be used again after calling `tap`.
 pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
   let mut in_first = true
-  let length = match (self.length, other.length) {
+  let size_hint = match (self.size_hint, other.size_hint) {
     (Some(n), Some(m)) => Some(n + m)
     _ => None
   }
@@ -725,7 +728,7 @@ pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
         other.next()
       }
     },
-    length,
+    size_hint,
   }
 }
 
@@ -766,7 +769,7 @@ pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
 /// The old iterators `self` and `other` must not be used again after calling `zip`.
 #alias(combine)
 pub fn[X, Y] Iter::zip(self : Iter[X], other : Iter[Y]) -> Iter[(X, Y)] {
-  let length = match (self.length, other.length) {
+  let size_hint = match (self.size_hint, other.size_hint) {
     (Some(n), Some(m)) if n < m => Some(n)
     (Some(_), Some(m)) => Some(m)
     (Some(0), _) => Some(0)
@@ -779,7 +782,7 @@ pub fn[X, Y] Iter::zip(self : Iter[X], other : Iter[Y]) -> Iter[(X, Y)] {
       guard other.next() is Some(y) else { None }
       Some((x, y))
     },
-    length,
+    size_hint,
   }
 }
 
@@ -793,7 +796,7 @@ pub impl[T] Add for Iter[T] with add(self, other) {
 /// The old iterator `self` must not be used again.
 #alias(collect)
 pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
-  let result = match self.length {
+  let result = match self.size_hint {
     Some(n) => Array::new(capacity=n)
     None => []
   }
@@ -824,7 +827,7 @@ pub fn[X] Iter::iter2(self : Iter[X]) -> Iter2[Int, X] {
       i += 1
       result
     },
-    length: self.length,
+    size_hint: self.size_hint,
   })
 }
 
@@ -867,7 +870,7 @@ pub fn[X] Iter::intersperse(self : Iter[X], sep : X) -> Iter[X] {
     Output_Sep
   }
   let mut state = Init
-  let length = match self.length {
+  let size_hint = match self.size_hint {
     Some(0) => Some(0)
     Some(n) => Some(n * 2 - 1)
     None => None
@@ -895,7 +898,7 @@ pub fn[X] Iter::intersperse(self : Iter[X], sep : X) -> Iter[X] {
           }
       }
     },
-    length,
+    size_hint,
   }
 }
 
@@ -911,7 +914,7 @@ pub fn[X] Iter::view(self : Iter[X], start? : Int = 0, end? : Int) -> Iter[X] {
     (start, None) => self.drop(start)
     (start, Some(end)) => {
       let mut index = 0
-      let length = match self.length {
+      let size_hint = match self.size_hint {
         Some(_) if end <= start => Some(0)
         Some(len) if start >= len => Some(0)
         Some(len) if end < len => Some(end - start)
@@ -937,7 +940,7 @@ pub fn[X] Iter::view(self : Iter[X], start? : Int = 0, end? : Int) -> Iter[X] {
           }
           result
         },
-        length,
+        size_hint,
       }
     }
   }
@@ -1026,9 +1029,14 @@ pub(all) struct Iter2[X, Y](Iter[(X, Y)])
 
 ///|
 /// Construct an `Iter2` from a pair-producing function.
-/// If the exact number of remaining pairs is known, pass it as `length`.
-pub fn[X, Y] Iter2::new(f : () -> (X, Y)?, length? : Int) -> Iter2[X, Y] {
-  Iter2({ f, length })
+/// If the number of remaining pairs is known, pass it as `size_hint`.
+pub fn[X, Y] Iter2::new(f : () -> (X, Y)?, size_hint? : Int) -> Iter2[X, Y] {
+  let size_hint = match size_hint {
+    Some(n) if n > 0 => Some(n)
+    Some(_) => Some(0)
+    None => None
+  }
+  Iter2({ f, size_hint })
 }
 
 ///|

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -674,15 +674,18 @@ pub fn[K, V] Map::clear(self : Map[K, V]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[K, V] Map::iter(self : Map[K, V]) -> Iter[(K, V)] {
   let mut curr_entry = self.head
-  Iter::new(fn() {
-    match curr_entry {
-      Some({ key, value, next, .. }) => {
-        curr_entry = next
-        Some((key, value))
+  Iter::new(
+    fn() {
+      match curr_entry {
+        Some({ key, value, next, .. }) => {
+          curr_entry = next
+          Some((key, value))
+        }
+        None => None
       }
-      None => None
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|
@@ -696,30 +699,36 @@ pub fn[K, V] Map::iter2(self : Map[K, V]) -> Iter2[K, V] {
 /// Return an iterator of keys.
 pub fn[K, V] Map::keys(self : Map[K, V]) -> Iter[K] {
   let mut curr_entry = self.head
-  Iter::new(fn() {
-    match curr_entry {
-      Some({ key, next, .. }) => {
-        curr_entry = next
-        Some(key)
+  Iter::new(
+    fn() {
+      match curr_entry {
+        Some({ key, next, .. }) => {
+          curr_entry = next
+          Some(key)
+        }
+        None => None
       }
-      None => None
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|
 /// Return an iterator of values.
 pub fn[K, V] Map::values(self : Map[K, V]) -> Iter[V] {
   let mut curr_entry = self.head
-  Iter::new(fn() {
-    match curr_entry {
-      Some({ value, next, .. }) => {
-        curr_entry = next
-        Some(value)
+  Iter::new(
+    fn() {
+      match curr_entry {
+        Some({ value, next, .. }) => {
+          curr_entry = next
+          Some(value)
+        }
+        None => None
       }
-      None => None
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -674,17 +674,18 @@ pub fn[K, V] Map::clear(self : Map[K, V]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[K, V] Map::iter(self : Map[K, V]) -> Iter[(K, V)] {
   let mut curr_entry = self.head
+  let len = self.size
+  let mut remaining = len
   Iter::new(
     fn() {
-      match curr_entry {
-        Some({ key, value, next, .. }) => {
-          curr_entry = next
-          Some((key, value))
-        }
-        None => None
+      guard remaining > 0 && curr_entry is Some({ key, value, next, .. }) else {
+        None
       }
+      curr_entry = next
+      remaining -= 1
+      Some((key, value))
     },
-    length=self.size,
+    length=len,
   )
 }
 
@@ -699,17 +700,16 @@ pub fn[K, V] Map::iter2(self : Map[K, V]) -> Iter2[K, V] {
 /// Return an iterator of keys.
 pub fn[K, V] Map::keys(self : Map[K, V]) -> Iter[K] {
   let mut curr_entry = self.head
+  let len = self.size
+  let mut remaining = len
   Iter::new(
     fn() {
-      match curr_entry {
-        Some({ key, next, .. }) => {
-          curr_entry = next
-          Some(key)
-        }
-        None => None
-      }
+      guard remaining > 0 && curr_entry is Some({ key, next, .. }) else { None }
+      curr_entry = next
+      remaining -= 1
+      Some(key)
     },
-    length=self.size,
+    length=len,
   )
 }
 
@@ -717,17 +717,18 @@ pub fn[K, V] Map::keys(self : Map[K, V]) -> Iter[K] {
 /// Return an iterator of values.
 pub fn[K, V] Map::values(self : Map[K, V]) -> Iter[V] {
   let mut curr_entry = self.head
+  let len = self.size
+  let mut remaining = len
   Iter::new(
     fn() {
-      match curr_entry {
-        Some({ value, next, .. }) => {
-          curr_entry = next
-          Some(value)
-        }
-        None => None
+      guard remaining > 0 && curr_entry is Some({ value, next, .. }) else {
+        None
       }
+      curr_entry = next
+      remaining -= 1
+      Some(value)
     },
-    length=self.size,
+    length=len,
   )
 }
 

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -685,7 +685,7 @@ pub fn[K, V] Map::iter(self : Map[K, V]) -> Iter[(K, V)] {
       remaining -= 1
       Some((key, value))
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -709,7 +709,7 @@ pub fn[K, V] Map::keys(self : Map[K, V]) -> Iter[K] {
       remaining -= 1
       Some(key)
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -728,7 +728,7 @@ pub fn[K, V] Map::values(self : Map[K, V]) -> Iter[V] {
       remaining -= 1
       Some(value)
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -412,24 +412,32 @@ pub fn[T] MutArrayView::to_owned(self : MutArrayView[T]) -> Array[T] {
 #alias(iterator, deprecated)
 pub fn[X] MutArrayView::iter(self : MutArrayView[X]) -> Iter[X] {
   let mut i = 0
-  Iter::new(fn() {
-    guard i < self.length() else { None }
-    let elem = self.unsafe_get(i)
-    i += 1
-    Some(elem)
-  })
+  let len = self.length()
+  Iter::new(
+    fn() {
+      guard i < len else { None }
+      let elem = self.unsafe_get(i)
+      i += 1
+      Some(elem)
+    },
+    length=len,
+  )
 }
 
 ///|
 /// Function `rev_iter`.
 #alias(rev_iterator, deprecated)
 pub fn[X] MutArrayView::rev_iter(self : MutArrayView[X]) -> Iter[X] {
-  let mut i = self.length()
-  Iter::new(fn() {
-    guard i > 0 else { None }
-    i -= 1
-    Some(self.unsafe_get(i))
-  })
+  let len = self.length()
+  let mut i = len
+  Iter::new(
+    fn() {
+      guard i > 0 else { None }
+      i -= 1
+      Some(self.unsafe_get(i))
+    },
+    length=len,
+  )
 }
 
 ///|
@@ -437,12 +445,16 @@ pub fn[X] MutArrayView::rev_iter(self : MutArrayView[X]) -> Iter[X] {
 #alias(iterator2, deprecated)
 pub fn[X] MutArrayView::iter2(self : MutArrayView[X]) -> Iter2[Int, X] {
   let mut i = 0
-  Iter2::new(fn() {
-    guard i < self.length() else { None }
-    let result = Some((i, self.unsafe_get(i)))
-    i += 1
-    result
-  })
+  let len = self.length()
+  Iter2::new(
+    fn() {
+      guard i < len else { None }
+      let result = Some((i, self.unsafe_get(i)))
+      i += 1
+      result
+    },
+    length=len,
+  )
 }
 
 ///|

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -420,7 +420,7 @@ pub fn[X] MutArrayView::iter(self : MutArrayView[X]) -> Iter[X] {
       i += 1
       Some(elem)
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -436,7 +436,7 @@ pub fn[X] MutArrayView::rev_iter(self : MutArrayView[X]) -> Iter[X] {
       i -= 1
       Some(self.unsafe_get(i))
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -453,7 +453,7 @@ pub fn[X] MutArrayView::iter2(self : MutArrayView[X]) -> Iter2[Int, X] {
       i += 1
       result
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -289,12 +289,13 @@ pub fn Iter::join(Self[String], StringView) -> String
 #deprecated
 pub fn[X] Iter::just_run(Self[X], (X) -> IterResult) -> Unit
 pub fn[X] Iter::last(Self[X]) -> X?
+pub fn[X] Iter::length(Self[X]) -> Int?
 pub fn[X, Y] Iter::map(Self[X], (X) -> Y) -> Self[Y]
 pub fn[X, Y] Iter::map_while(Self[X], (X) -> Y?) -> Self[Y]
 pub fn[X, Y] Iter::mapi(Self[X], (Int, X) -> Y) -> Self[Y]
 pub fn[X : Compare] Iter::maximum(Self[X]) -> X?
 pub fn[X : Compare] Iter::minimum(Self[X]) -> X?
-pub fn[X] Iter::new(() -> X?) -> Self[X]
+pub fn[X] Iter::new(() -> X?, length? : Int) -> Self[X]
 #alias(head)
 #alias(peek, deprecated)
 pub fn[X] Iter::next(Self[X]) -> X?
@@ -325,7 +326,7 @@ pub fn[X, Y] Iter2::each(Self[X, Y], (X, Y) -> Unit) -> Unit
 pub fn[X, Y] Iter2::iter(Self[X, Y]) -> Iter[(X, Y)]
 #alias(iterator2)
 pub fn[X, Y] Iter2::iter2(Self[X, Y]) -> Self[X, Y]
-pub fn[X, Y] Iter2::new(() -> (X, Y)?) -> Self[X, Y]
+pub fn[X, Y] Iter2::new(() -> (X, Y)?, length? : Int) -> Self[X, Y]
 pub fn[X, Y] Iter2::next(Self[X, Y]) -> (X, Y)?
 #deprecated
 pub fn[X, Y] Iter2::run(Self[X, Y], (X, Y) -> IterResult) -> IterResult

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -289,13 +289,12 @@ pub fn Iter::join(Self[String], StringView) -> String
 #deprecated
 pub fn[X] Iter::just_run(Self[X], (X) -> IterResult) -> Unit
 pub fn[X] Iter::last(Self[X]) -> X?
-pub fn[X] Iter::length(Self[X]) -> Int?
 pub fn[X, Y] Iter::map(Self[X], (X) -> Y) -> Self[Y]
 pub fn[X, Y] Iter::map_while(Self[X], (X) -> Y?) -> Self[Y]
 pub fn[X, Y] Iter::mapi(Self[X], (Int, X) -> Y) -> Self[Y]
 pub fn[X : Compare] Iter::maximum(Self[X]) -> X?
 pub fn[X : Compare] Iter::minimum(Self[X]) -> X?
-pub fn[X] Iter::new(() -> X?, length? : Int) -> Self[X]
+pub fn[X] Iter::new(() -> X?, size_hint? : Int) -> Self[X]
 #alias(head)
 #alias(peek, deprecated)
 pub fn[X] Iter::next(Self[X]) -> X?
@@ -304,6 +303,7 @@ pub fn[X] Iter::repeat(X) -> Self[X]
 #deprecated
 pub fn[X] Iter::run(Self[X], (X) -> IterResult) -> IterResult
 pub fn[X] Iter::singleton(X) -> Self[X]
+pub fn[X] Iter::size_hint(Self[X]) -> Int?
 pub fn[X] Iter::take(Self[X], Int) -> Self[X]
 pub fn[X] Iter::take_while(Self[X], (X) -> Bool) -> Self[X]
 pub fn[X] Iter::tap(Self[X], (X) -> Unit) -> Self[X]
@@ -326,7 +326,7 @@ pub fn[X, Y] Iter2::each(Self[X, Y], (X, Y) -> Unit) -> Unit
 pub fn[X, Y] Iter2::iter(Self[X, Y]) -> Iter[(X, Y)]
 #alias(iterator2)
 pub fn[X, Y] Iter2::iter2(Self[X, Y]) -> Self[X, Y]
-pub fn[X, Y] Iter2::new(() -> (X, Y)?, length? : Int) -> Self[X, Y]
+pub fn[X, Y] Iter2::new(() -> (X, Y)?, size_hint? : Int) -> Self[X, Y]
 pub fn[X, Y] Iter2::next(Self[X, Y]) -> (X, Y)?
 #deprecated
 pub fn[X, Y] Iter2::run(Self[X, Y], (X, Y) -> IterResult) -> IterResult

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1439,14 +1439,15 @@ pub fn[A] Deque::retain(self : Deque[A], f : (A) -> Bool) -> Unit {
 #alias(iterator, deprecated)
 pub fn[A] Deque::iter(self : Deque[A]) -> Iter[A] {
   let mut index = 0
+  let len = self.len
   Iter::new(
     fn() {
-      guard index < self.len else { None }
+      guard index < len else { None }
       let elem = self.buf[(self.head + index) % self.buf.length()]
       index += 1
       Some(elem)
     },
-    length=self.len,
+    length=len,
   )
 }
 
@@ -1478,14 +1479,15 @@ pub fn[A] Deque::iter(self : Deque[A]) -> Iter[A] {
 #alias(iterator2, deprecated)
 pub fn[A] Deque::iter2(self : Deque[A]) -> Iter2[Int, A] {
   let mut index = 0
+  let len = self.len
   Iter2::new(
     fn() {
-      guard index < self.len else { None }
+      guard index < len else { None }
       let result = (index, self.buf[(self.head + index) % self.buf.length()])
       index += 1
       Some(result)
     },
-    length=self.len,
+    length=len,
   )
 }
 
@@ -1511,14 +1513,15 @@ pub fn[A] Deque::iter2(self : Deque[A]) -> Iter2[Int, A] {
 /// ```
 #alias(rev_iterator, deprecated)
 pub fn[A] Deque::rev_iter(self : Deque[A]) -> Iter[A] {
-  let mut index = self.len
+  let len = self.len
+  let mut index = len
   Iter::new(
     fn() {
       guard index > 0 else { None }
       index -= 1
       Some(self.buf[(self.head + index) % self.buf.length()])
     },
-    length=self.len,
+    length=len,
   )
 }
 
@@ -1549,15 +1552,16 @@ pub fn[A] Deque::rev_iter(self : Deque[A]) -> Iter[A] {
 /// ```
 #alias(rev_iterator2, deprecated)
 pub fn[A] Deque::rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
-  let mut rev_index = self.len
+  let len = self.len
+  let mut rev_index = len
   Iter2::new(
     fn() {
       guard rev_index > 0 else { None }
-      let index = self.len - rev_index
+      let index = len - rev_index
       rev_index -= 1
       Some((index, self.buf[(self.head + rev_index) % self.buf.length()]))
     },
-    length=self.len,
+    length=len,
   )
 }
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1447,7 +1447,7 @@ pub fn[A] Deque::iter(self : Deque[A]) -> Iter[A] {
       index += 1
       Some(elem)
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -1487,7 +1487,7 @@ pub fn[A] Deque::iter2(self : Deque[A]) -> Iter2[Int, A] {
       index += 1
       Some(result)
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -1521,7 +1521,7 @@ pub fn[A] Deque::rev_iter(self : Deque[A]) -> Iter[A] {
       index -= 1
       Some(self.buf[(self.head + index) % self.buf.length()])
     },
-    length=len,
+    size_hint=len,
   )
 }
 
@@ -1561,7 +1561,7 @@ pub fn[A] Deque::rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
       rev_index -= 1
       Some((index, self.buf[(self.head + rev_index) % self.buf.length()]))
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1439,12 +1439,15 @@ pub fn[A] Deque::retain(self : Deque[A], f : (A) -> Bool) -> Unit {
 #alias(iterator, deprecated)
 pub fn[A] Deque::iter(self : Deque[A]) -> Iter[A] {
   let mut index = 0
-  Iter::new(fn() {
-    guard index < self.len else { None }
-    let elem = self.buf[(self.head + index) % self.buf.length()]
-    index += 1
-    Some(elem)
-  })
+  Iter::new(
+    fn() {
+      guard index < self.len else { None }
+      let elem = self.buf[(self.head + index) % self.buf.length()]
+      index += 1
+      Some(elem)
+    },
+    length=self.len,
+  )
 }
 
 ///|
@@ -1475,12 +1478,15 @@ pub fn[A] Deque::iter(self : Deque[A]) -> Iter[A] {
 #alias(iterator2, deprecated)
 pub fn[A] Deque::iter2(self : Deque[A]) -> Iter2[Int, A] {
   let mut index = 0
-  Iter2::new(fn() {
-    guard index < self.len else { None }
-    let result = (index, self.buf[(self.head + index) % self.buf.length()])
-    index += 1
-    Some(result)
-  })
+  Iter2::new(
+    fn() {
+      guard index < self.len else { None }
+      let result = (index, self.buf[(self.head + index) % self.buf.length()])
+      index += 1
+      Some(result)
+    },
+    length=self.len,
+  )
 }
 
 ///|
@@ -1506,11 +1512,14 @@ pub fn[A] Deque::iter2(self : Deque[A]) -> Iter2[Int, A] {
 #alias(rev_iterator, deprecated)
 pub fn[A] Deque::rev_iter(self : Deque[A]) -> Iter[A] {
   let mut index = self.len
-  Iter::new(fn() {
-    guard index > 0 else { None }
-    index -= 1
-    Some(self.buf[(self.head + index) % self.buf.length()])
-  })
+  Iter::new(
+    fn() {
+      guard index > 0 else { None }
+      index -= 1
+      Some(self.buf[(self.head + index) % self.buf.length()])
+    },
+    length=self.len,
+  )
 }
 
 ///|
@@ -1541,12 +1550,15 @@ pub fn[A] Deque::rev_iter(self : Deque[A]) -> Iter[A] {
 #alias(rev_iterator2, deprecated)
 pub fn[A] Deque::rev_iter2(self : Deque[A]) -> Iter2[Int, A] {
   let mut rev_index = self.len
-  Iter2::new(fn() {
-    guard rev_index > 0 else { None }
-    let index = self.len - rev_index
-    rev_index -= 1
-    Some((index, self.buf[(self.head + rev_index) % self.buf.length()]))
-  })
+  Iter2::new(
+    fn() {
+      guard rev_index > 0 else { None }
+      let index = self.len - rev_index
+      rev_index -= 1
+      Some((index, self.buf[(self.head + rev_index) % self.buf.length()]))
+    },
+    length=self.len,
+  )
 }
 
 ///|

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -87,7 +87,7 @@ pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
         None
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
 }
 
@@ -399,7 +399,7 @@ pub fn[K, V] HashMap::keys(self : HashMap[K, V]) -> Iter[K] {
         None
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
   iter.iter()
 }
@@ -440,7 +440,7 @@ pub fn[K, V] HashMap::values(self : HashMap[K, V]) -> Iter[V] {
         None
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
   iter.iter()
 }

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -75,17 +75,20 @@ pub fn[K, V] HashMap::clear(self : HashMap[K, V]) -> Unit {
 pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
   let mut i = 0
   let len = self.entries.length()
-  Iter::new(fn() {
-    while i < len {
-      let entry = self.entries.unsafe_get(i)
-      i += 1
-      if entry is Some({ key, value, .. }) {
-        return Some((key, value))
+  Iter::new(
+    fn() {
+      while i < len {
+        let entry = self.entries.unsafe_get(i)
+        i += 1
+        if entry is Some({ key, value, .. }) {
+          return Some((key, value))
+        }
+      } nobreak {
+        None
       }
-    } nobreak {
-      None
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|
@@ -384,17 +387,20 @@ pub impl[K : Show, V : Show] Show for HashMap[K, V] with output(self, logger) {
 /// ```
 pub fn[K, V] HashMap::keys(self : HashMap[K, V]) -> Iter[K] {
   let mut i = 0
-  let iter = Iter::new(() => {
-    while i < self.entries.length() {
-      let entry = self.entries[i]
-      i += 1
-      if entry is Some({ key, .. }) {
-        break Some(key)
+  let iter = Iter::new(
+    () => {
+      while i < self.entries.length() {
+        let entry = self.entries[i]
+        i += 1
+        if entry is Some({ key, .. }) {
+          break Some(key)
+        }
+      } nobreak {
+        None
       }
-    } nobreak {
-      None
-    }
-  })
+    },
+    length=self.size,
+  )
   iter.iter()
 }
 
@@ -422,17 +428,20 @@ pub fn[K, V] HashMap::keys(self : HashMap[K, V]) -> Iter[K] {
 /// ```
 pub fn[K, V] HashMap::values(self : HashMap[K, V]) -> Iter[V] {
   let mut i = 0
-  let iter = Iter::new(() => {
-    while i < self.entries.length() {
-      let entry = self.entries[i]
-      i += 1
-      if entry is Some({ value, .. }) {
-        break Some(value)
+  let iter = Iter::new(
+    () => {
+      while i < self.entries.length() {
+        let entry = self.entries[i]
+        i += 1
+        if entry is Some({ value, .. }) {
+          break Some(value)
+        }
+      } nobreak {
+        None
       }
-    } nobreak {
-      None
-    }
-  })
+    },
+    length=self.size,
+  )
   iter.iter()
 }
 

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -316,17 +316,20 @@ pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
 pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
   let mut i = 0
   let len = self.entries.length()
-  Iter::new(fn() {
-    while i < len {
-      let entry = self.entries.unsafe_get(i)
-      i += 1
-      if entry is Some({ key, .. }) {
-        return Some(key)
+  Iter::new(
+    fn() {
+      while i < len {
+        let entry = self.entries.unsafe_get(i)
+        i += 1
+        if entry is Some({ key, .. }) {
+          return Some(key)
+        }
+      } nobreak {
+        None
       }
-    } nobreak {
-      None
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -328,7 +328,7 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
         None
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
 }
 

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -293,7 +293,8 @@ pub impl[A] Add for T[A] with add(self, other) {
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
 #alias(iterator, deprecated="Use the corresponding function in `immut/vector` instead")
 pub fn[A] T::iter(self : T[A]) -> Iter[A] {
-  self.tree.iter()
+  let iter = self.tree.iter()
+  Iter::new(() => iter.next(), length=self.size)
 }
 
 ///|

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -294,7 +294,7 @@ pub impl[A] Add for T[A] with add(self, other) {
 #alias(iterator, deprecated="Use the corresponding function in `immut/vector` instead")
 pub fn[A] T::iter(self : T[A]) -> Iter[A] {
   let iter = self.tree.iter()
-  Iter::new(() => iter.next(), length=self.size)
+  Iter::new(() => iter.next(), size_hint=self.size)
 }
 
 ///|

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -263,7 +263,7 @@ pub fn[K, V] SortedMap::iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
         }
       }
     },
-    length=self.length(),
+    size_hint=self.length(),
   )
 }
 
@@ -416,7 +416,7 @@ pub fn[K, V] SortedMap::rev_keys(self : SortedMap[K, V]) -> Iter[K] {
         }
       }
     },
-    length=self.length(),
+    size_hint=self.length(),
   )
 }
 
@@ -453,7 +453,7 @@ pub fn[K, V] SortedMap::rev_values(self : SortedMap[K, V]) -> Iter[V] {
         }
       }
     },
-    length=self.length(),
+    size_hint=self.length(),
   )
 }
 

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -243,25 +243,28 @@ pub fn[K : Compare, V] SortedMap::from_array(
 pub fn[K, V] SortedMap::iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
   let mut curr_node = self
   let parents = []
-  Iter::new(fn() {
-    for x = curr_node {
-      match x {
-        Tree(k, value~, Empty, r, ..) => {
-          curr_node = r
-          break Some((k, value))
+  Iter::new(
+    fn() {
+      for x = curr_node {
+        match x {
+          Tree(k, value~, Empty, r, ..) => {
+            curr_node = r
+            break Some((k, value))
+          }
+          Tree(k, value~, l, r, ..) => {
+            parents.push((k, value, r))
+            continue l
+          }
+          Empty if parents.pop() is Some((k, v, r)) => {
+            curr_node = r
+            break Some((k, v))
+          }
+          Empty => break None
         }
-        Tree(k, value~, l, r, ..) => {
-          parents.push((k, value, r))
-          continue l
-        }
-        Empty if parents.pop() is Some((k, v, r)) => {
-          curr_node = r
-          break Some((k, v))
-        }
-        Empty => break None
       }
-    }
-  })
+    },
+    length=self.length(),
+  )
 }
 
 ///|
@@ -393,25 +396,28 @@ pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Iter[V] {
 pub fn[K, V] SortedMap::rev_keys(self : SortedMap[K, V]) -> Iter[K] {
   let mut curr_node = self
   let parents = []
-  Iter::new(fn() {
-    for x = curr_node {
-      match x {
-        Tree(k, l, Empty, ..) => {
-          curr_node = l
-          break Some(k)
+  Iter::new(
+    fn() {
+      for x = curr_node {
+        match x {
+          Tree(k, l, Empty, ..) => {
+            curr_node = l
+            break Some(k)
+          }
+          Tree(k, l, r, ..) => {
+            parents.push((k, l))
+            continue r
+          }
+          Empty if parents.pop() is Some((k, l)) => {
+            curr_node = l
+            break Some(k)
+          }
+          Empty => break None
         }
-        Tree(k, l, r, ..) => {
-          parents.push((k, l))
-          continue r
-        }
-        Empty if parents.pop() is Some((k, l)) => {
-          curr_node = l
-          break Some(k)
-        }
-        Empty => break None
       }
-    }
-  })
+    },
+    length=self.length(),
+  )
 }
 
 ///|
@@ -427,25 +433,28 @@ pub fn[K, V] SortedMap::rev_keys(self : SortedMap[K, V]) -> Iter[K] {
 pub fn[K, V] SortedMap::rev_values(self : SortedMap[K, V]) -> Iter[V] {
   let mut curr_node = self
   let parents = []
-  Iter::new(fn() {
-    for x = curr_node {
-      match x {
-        Tree(_k, value~, l, Empty, ..) => {
-          curr_node = l
-          break Some(value)
+  Iter::new(
+    fn() {
+      for x = curr_node {
+        match x {
+          Tree(_k, value~, l, Empty, ..) => {
+            curr_node = l
+            break Some(value)
+          }
+          Tree(_k, value~, l, r, ..) => {
+            parents.push((value, l))
+            continue r
+          }
+          Empty if parents.pop() is Some((v, l)) => {
+            curr_node = l
+            break Some(v)
+          }
+          Empty => break None
         }
-        Tree(_k, value~, l, r, ..) => {
-          parents.push((value, l))
-          continue r
-        }
-        Empty if parents.pop() is Some((v, l)) => {
-          curr_node = l
-          break Some(v)
-        }
-        Empty => break None
       }
-    }
-  })
+    },
+    length=self.length(),
+  )
 }
 
 ///|

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -30,25 +30,28 @@
 pub fn[A] SortedSet::rev_iter(self : SortedSet[A]) -> Iter[A] {
   let mut curr_node = self
   let parents = []
-  Iter::new(fn() {
-    for x = curr_node {
-      match x {
-        Node(left~, right=Empty, value~, ..) => {
-          curr_node = left
-          break Some(value)
+  Iter::new(
+    fn() {
+      for x = curr_node {
+        match x {
+          Node(left~, right=Empty, value~, ..) => {
+            curr_node = left
+            break Some(value)
+          }
+          Node(left~, right~, value~, ..) => {
+            parents.push((value, left))
+            continue right
+          }
+          Empty if parents.pop() is Some((value, left)) => {
+            curr_node = left
+            break Some(value)
+          }
+          Empty => break None
         }
-        Node(left~, right~, value~, ..) => {
-          parents.push((value, left))
-          continue right
-        }
-        Empty if parents.pop() is Some((value, left)) => {
-          curr_node = left
-          break Some(value)
-        }
-        Empty => break None
       }
-    }
-  })
+    },
+    length=self.length(),
+  )
 }
 
 ///|
@@ -57,25 +60,28 @@ pub fn[A] SortedSet::rev_iter(self : SortedSet[A]) -> Iter[A] {
 pub fn[A] SortedSet::iter(self : SortedSet[A]) -> Iter[A] {
   let mut curr_node = self
   let parents = []
-  Iter::new(fn() {
-    for x = curr_node {
-      match x {
-        Node(left=Empty, right~, value~, size=_) => {
-          curr_node = right
-          break Some(value)
+  Iter::new(
+    fn() {
+      for x = curr_node {
+        match x {
+          Node(left=Empty, right~, value~, size=_) => {
+            curr_node = right
+            break Some(value)
+          }
+          Node(left~, right~, value~, size=_) => {
+            parents.push((value, right))
+            continue left
+          }
+          Empty if parents.pop() is Some((value, right)) => {
+            curr_node = right
+            break Some(value)
+          }
+          Empty => break None
         }
-        Node(left~, right~, value~, size=_) => {
-          parents.push((value, right))
-          continue left
-        }
-        Empty if parents.pop() is Some((value, right)) => {
-          curr_node = right
-          break Some(value)
-        }
-        Empty => break None
       }
-    }
-  })
+    },
+    length=self.length(),
+  )
 }
 
 ///|

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -50,7 +50,7 @@ pub fn[A] SortedSet::rev_iter(self : SortedSet[A]) -> Iter[A] {
         }
       }
     },
-    length=self.length(),
+    size_hint=self.length(),
   )
 }
 
@@ -80,7 +80,7 @@ pub fn[A] SortedSet::iter(self : SortedSet[A]) -> Iter[A] {
         }
       }
     },
-    length=self.length(),
+    size_hint=self.length(),
   )
 }
 

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -480,7 +480,7 @@ pub fn[A] Vector::iter(self : Vector[A]) -> Iter[A] {
   let tree_iter = self.tree.iter()
   let tail_iter = self.tail.iter()
   let iter = tree_iter.concat(tail_iter)
-  Iter::new(() => iter.next(), length=self.size)
+  Iter::new(() => iter.next(), size_hint=self.size)
 }
 
 ///|

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -479,7 +479,8 @@ pub impl[A] Add for Vector[A] with add(self, other) {
 pub fn[A] Vector::iter(self : Vector[A]) -> Iter[A] {
   let tree_iter = self.tree.iter()
   let tail_iter = self.tail.iter()
-  tree_iter.concat(tail_iter)
+  let iter = tree_iter.concat(tail_iter)
+  Iter::new(() => iter.next(), length=self.size)
 }
 
 ///|

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -365,7 +365,7 @@ pub fn[A] Queue::iter(self : Queue[A]) -> Iter[A] {
       remaining -= 1
       Some(content)
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -356,15 +356,18 @@ pub fn[A] Queue::transfer(self : Queue[A], dst : Queue[A]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[A] Queue::iter(self : Queue[A]) -> Iter[A] {
   let mut next_node = self.first
-  Iter::new(fn() {
-    match next_node {
-      None => None
-      Some({ content, next }) => {
-        next_node = next
-        Some(content)
+  Iter::new(
+    fn() {
+      match next_node {
+        None => None
+        Some({ content, next }) => {
+          next_node = next
+          Some(content)
+        }
       }
-    }
-  })
+    },
+    length=self.length,
+  )
 }
 
 ///|

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -356,17 +356,16 @@ pub fn[A] Queue::transfer(self : Queue[A], dst : Queue[A]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[A] Queue::iter(self : Queue[A]) -> Iter[A] {
   let mut next_node = self.first
+  let len = self.length
+  let mut remaining = len
   Iter::new(
     fn() {
-      match next_node {
-        None => None
-        Some({ content, next }) => {
-          next_node = next
-          Some(content)
-        }
-      }
+      guard remaining > 0 && next_node is Some({ content, next }) else { None }
+      next_node = next
+      remaining -= 1
+      Some(content)
     },
-    length=self.length,
+    length=len,
   )
 }
 

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -477,15 +477,18 @@ pub fn[K] Set::clear(self : Set[K]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[K] Set::iter(self : Set[K]) -> Iter[K] {
   let mut curr_entry = self.head
-  Iter::new(fn() {
-    match curr_entry {
-      Some({ key, next, .. }) => {
-        curr_entry = next
-        Some(key)
+  Iter::new(
+    fn() {
+      match curr_entry {
+        Some({ key, next, .. }) => {
+          curr_entry = next
+          Some(key)
+        }
+        None => None
       }
-      None => None
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -477,17 +477,16 @@ pub fn[K] Set::clear(self : Set[K]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[K] Set::iter(self : Set[K]) -> Iter[K] {
   let mut curr_entry = self.head
+  let len = self.size
+  let mut remaining = len
   Iter::new(
     fn() {
-      match curr_entry {
-        Some({ key, next, .. }) => {
-          curr_entry = next
-          Some(key)
-        }
-        None => None
-      }
+      guard remaining > 0 && curr_entry is Some({ key, next, .. }) else { None }
+      curr_entry = next
+      remaining -= 1
+      Some(key)
     },
-    length=self.size,
+    length=len,
   )
 }
 

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -486,7 +486,7 @@ pub fn[K] Set::iter(self : Set[K]) -> Iter[K] {
       remaining -= 1
       Some(key)
     },
-    length=len,
+    size_hint=len,
   )
 }
 

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -269,21 +269,24 @@ pub fn[K, V] SortedMap::eachi(
 pub fn[K, V] SortedMap::keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
   let todo_list = []
   let mut next_node = self.root
-  Iter::new(fn() {
-    for x = next_node {
-      match x {
-        Some({ left, key, value: _, right, height: _ }) => {
-          todo_list.push((key, right))
-          continue left
+  Iter::new(
+    fn() {
+      for x = next_node {
+        match x {
+          Some({ left, key, value: _, right, height: _ }) => {
+            todo_list.push((key, right))
+            continue left
+          }
+          None if todo_list.pop() is Some((key, right)) => {
+            next_node = right
+            break Some(key)
+          }
+          None => break None
         }
-        None if todo_list.pop() is Some((key, right)) => {
-          next_node = right
-          break Some(key)
-        }
-        None => break None
       }
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|
@@ -291,21 +294,24 @@ pub fn[K, V] SortedMap::keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
 pub fn[K, V] SortedMap::values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
   let todo_list = []
   let mut next_node = self.root
-  Iter::new(fn() {
-    for x = next_node {
-      match x {
-        Some({ left, key: _, value, right, height: _ }) => {
-          todo_list.push((value, right))
-          continue left
+  Iter::new(
+    fn() {
+      for x = next_node {
+        match x {
+          Some({ left, key: _, value, right, height: _ }) => {
+            todo_list.push((value, right))
+            continue left
+          }
+          None if todo_list.pop() is Some((value, right)) => {
+            next_node = right
+            break Some(value)
+          }
+          None => break None
         }
-        None if todo_list.pop() is Some((value, right)) => {
-          next_node = right
-          break Some(value)
-        }
-        None => break None
       }
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|
@@ -322,21 +328,24 @@ pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
 pub fn[K, V] SortedMap::iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
   let todo_list = []
   let mut next_node = self.root
-  Iter::new(fn() {
-    for x = next_node {
-      match x {
-        Some({ left, key, value, right, height: _ }) => {
-          todo_list.push((key, value, right))
-          continue left
+  Iter::new(
+    fn() {
+      for x = next_node {
+        match x {
+          Some({ left, key, value, right, height: _ }) => {
+            todo_list.push((key, value, right))
+            continue left
+          }
+          None if todo_list.pop() is Some((key, value, right)) => {
+            next_node = right
+            break Some((key, value))
+          }
+          None => break None
         }
-        None if todo_list.pop() is Some((key, value, right)) => {
-          next_node = right
-          break Some((key, value))
-        }
-        None => break None
       }
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -285,7 +285,7 @@ pub fn[K, V] SortedMap::keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
         }
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
 }
 
@@ -310,7 +310,7 @@ pub fn[K, V] SortedMap::values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
         }
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
 }
 
@@ -344,7 +344,7 @@ pub fn[K, V] SortedMap::iter(self : SortedMap[K, V]) -> Iter[(K, V)] {
         }
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -425,25 +425,28 @@ pub fn[V] SortedSet::to_array(self : SortedSet[V]) -> Array[V] {
 pub fn[V] SortedSet::iter(self : SortedSet[V]) -> Iter[V] {
   let mut curr_node = self.root
   let parents = []
-  Iter::new(fn() {
-    for x = curr_node {
-      match x {
-        Some({ left: None, value, right, height: _ }) => {
-          curr_node = right
-          break Some(value)
+  Iter::new(
+    fn() {
+      for x = curr_node {
+        match x {
+          Some({ left: None, value, right, height: _ }) => {
+            curr_node = right
+            break Some(value)
+          }
+          Some({ left, value, right, height: _ }) => {
+            parents.push((value, right))
+            continue left
+          }
+          None if parents.pop() is Some((value, right)) => {
+            curr_node = right
+            break Some(value)
+          }
+          None => break None
         }
-        Some({ left, value, right, height: _ }) => {
-          parents.push((value, right))
-          continue left
-        }
-        None if parents.pop() is Some((value, right)) => {
-          curr_node = right
-          break Some(value)
-        }
-        None => break None
       }
-    }
-  })
+    },
+    length=self.size,
+  )
 }
 
 ///|
@@ -474,7 +477,14 @@ pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for SortedSe
 
 ///|
 impl[T : Show] Show for Node[T] with output(self, logger) {
-  let x = { root: Some(self), size: 0 } // Hack for test
+  fn count(root : Node[T]?) -> Int {
+    match root {
+      None => 0
+      Some(root) => count(root.left) + count(root.right) + 1
+    }
+  }
+
+  let x = { root: Some(self), size: count(Some(self)) }
   logger.write_iter(x.iter())
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -445,7 +445,7 @@ pub fn[V] SortedSet::iter(self : SortedSet[V]) -> Iter[V] {
         }
       }
     },
-    length=self.size,
+    size_hint=self.size,
   )
 }
 


### PR DESCRIPTION
## Design

The goal is to provide a size hint for iterators, which can help reduce allocations. Rust's `size_hint` uses an always-present lower bound plus [an optional upper bound which is rarely used](https://internals.rust-lang.org/t/is-size-hint-1-ever-used/8187). Here we take a different approach and introduce `size_hint`, an optional remaining-count hint. For example, `map` preserves the hint, while `filter` drops it because the output size is unknown.

The hint is intended to be exact for trusted collection iterators and iterator adapters that can preserve that information, but it is still only a performance hint. User-provided hints are not treated as correctness invariants: negative hints are clamped to zero, consuming an iterator never drives the hint below zero, and an iterator ending early simply updates the hint to `Some(0)`.

## Summary

- add remaining-size hint metadata to `Iter` and expose `Iter::size_hint`
- make `Iter::new` and `Iter2::new` accept `size_hint? : Int`
- propagate trusted hints through size-preserving iterator adapters and collection iterators, and drop them for filtering/range cases where the output size is unknown
- use hints for preallocation, while keeping iteration correctness independent from the hint value
- tolerate incorrect user-supplied hints by clamping negative and over-consumed hints to zero
- keep construction-time traversal bounds for deque, queue, and linked insertion-order iterators so their hints match the traversal created at iterator construction

## Non-goal

Mutating a collection while consuming one of its iterators remains unsupported. Captured bounds and `size_hint` metadata are only for keeping performance hints aligned with the traversal created at iterator construction; they do not make concurrent mutation supported.

## Validation

- `moon check`
- `moon fmt`
- `moon info`
- `moon test`
- `git diff --check`