### PR TITLE
Add Array callback locals benchmarks

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1794,6 +1794,7 @@ pub fn[A] Array::truncate(self : Array[A], len : Int) -> Unit {
 ///   inspect(arr, content="[4, 8]")
 /// }
 /// ```
+#locals(f)
 pub fn[A] Array::retain_map(self : Array[A], f : (A) -> A?) -> Unit {
   if self.is_empty() {
     return
@@ -1880,6 +1881,7 @@ pub fn[T] Array::push_iter(self : Self[T], iter : Iter[T]) -> Unit {
 /// Array::shuffle_in_place(arr, rand~)
 /// }
 /// ```
+#locals(rand)
 pub fn[T] Array::shuffle_in_place(
   self : Array[T],
   rand~ : (Int) -> Int,
@@ -1927,6 +1929,7 @@ pub fn[T] Array::shuffle(self : Array[T], rand~ : (Int) -> Int) -> Array[T] {
 ///
 /// # Returns
 ///
+#locals(f)
 pub fn[A, B] Array::filter_map(
   self : Array[A],
   f : (A) -> B? raise?,

--- a/builtin/array_locals_bench_test.mbt
+++ b/builtin/array_locals_bench_test.mbt
@@ -1,0 +1,268 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let array_locals_bench_size = 100_000
+
+///|
+fn make_array_locals_bench_array() -> Array[Int] {
+  Array::makei(array_locals_bench_size, i => i)
+}
+
+///|
+fn make_array_locals_bench_fixedarray() -> FixedArray[Int] {
+  FixedArray::makei(array_locals_bench_size, i => i)
+}
+
+///|
+test "bench Array::retain_map n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_array()
+  it.bench(fn() {
+    data.retain_map(x => Some(x))
+    it.keep(data.length())
+  })
+}
+
+///|
+test "bench Array::shuffle_in_place n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_array()
+  fn rand(upper : Int) -> Int {
+    upper - 1
+  }
+  it.bench(fn() {
+    data.shuffle_in_place(rand~)
+    it.keep(data[0])
+  })
+}
+
+///|
+test "bench Array::filter_map n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_array()
+  it.bench(fn() {
+    it.keep(data.filter_map(x => if x % 2 == 0 { Some(x + 1) } else { None }))
+  })
+}
+
+///|
+test "bench FixedArray::each n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() {
+    let mut sum = 0
+    data.each(x => sum = sum + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench FixedArray::eachi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() {
+    let mut sum = 0
+    data.eachi((i, x) => sum = sum + i + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench FixedArray::rev_each n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() {
+    let mut sum = 0
+    data.rev_each(x => sum = sum + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench FixedArray::rev_eachi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() {
+    let mut sum = 0
+    data.rev_eachi((i, x) => sum = sum + i + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench FixedArray::map n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.map(x => x + 1)) })
+}
+
+///|
+test "bench FixedArray::mapi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.mapi((i, x) => i + x)) })
+}
+
+///|
+test "bench FixedArray::makei n=100000" (it : @bench.T) {
+  it.bench(fn() { it.keep(FixedArray::makei(array_locals_bench_size, i => i)) })
+}
+
+///|
+test "bench FixedArray::fold n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench FixedArray::rev_fold n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.rev_fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench FixedArray::foldi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.foldi(init=0, (i, sum, x) => sum + i + x)) })
+}
+
+///|
+test "bench FixedArray::rev_foldi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.rev_foldi(init=0, (i, sum, x) => sum + i + x)) })
+}
+
+///|
+test "bench ArrayView::chunk_by n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.chunk_by((a, b) => a + 1 == b)) })
+}
+
+///|
+test "bench ArrayView::each n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() {
+    let mut sum = 0
+    view.each(x => sum = sum + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::eachi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() {
+    let mut sum = 0
+    view.eachi((i, x) => sum = sum + i + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::rev_each n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() {
+    let mut sum = 0
+    view.rev_each(x => sum = sum + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::rev_eachi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() {
+    let mut sum = 0
+    view.rev_eachi((i, x) => sum = sum + i + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::all n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.all(x => x < array_locals_bench_size)) })
+}
+
+///|
+test "bench ArrayView::any n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.any(x => x == array_locals_bench_size - 1)) })
+}
+
+///|
+test "bench ArrayView::search_by n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() {
+    it.keep(view.search_by(x => x == array_locals_bench_size - 1))
+  })
+}
+
+///|
+test "bench ArrayView::fold n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench ArrayView::rev_fold n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.rev_fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench ArrayView::foldi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.foldi(init=0, (i, sum, x) => sum + i + x)) })
+}
+
+///|
+test "bench ArrayView::rev_foldi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.rev_foldi(init=0, (i, sum, x) => sum + i + x)) })
+}
+
+///|
+test "bench ArrayView::map n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.map(x => x + 1)) })
+}
+
+///|
+test "bench ArrayView::mapi n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.mapi((i, x) => i + x)) })
+}
+
+///|
+test "bench ArrayView::filter n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.filter(x => x % 2 == 0)) })
+}
+
+///|
+test "bench ArrayView::filter_map n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() {
+    it.keep(view.filter_map(x => if x % 2 == 0 { Some(x + 1) } else { None }))
+  })
+}

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -598,6 +598,7 @@ pub fn[T] ArrayView::chunks(
 ///   inspect(v.chunk_by((a, b) => a == b), content="[[1, 1], [2, 2, 2], [3], [1]]")
 /// }
 /// ```
+#locals(pred)
 pub fn[T] ArrayView::chunk_by(
   self : ArrayView[T],
   pred : (T, T) -> Bool raise?,
@@ -759,6 +760,7 @@ pub fn[X] ArrayView::iter2(self : ArrayView[X]) -> Iter2[Int, X] {
 ///   inspect(sum, content="6")
 /// }
 /// ```
+#locals(f)
 pub fn[T] ArrayView::each(
   self : ArrayView[T],
   f : (T) -> Unit raise?,
@@ -781,6 +783,7 @@ pub fn[T] ArrayView::each(
 ///   inspect(sum, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[T] ArrayView::eachi(
   self : ArrayView[T],
   f : (Int, T) -> Unit raise?,
@@ -804,6 +807,7 @@ pub fn[T] ArrayView::eachi(
 ///   inspect(out, content="[4, 3, 2]")
 /// }
 /// ```
+#locals(f)
 pub fn[T] ArrayView::rev_each(
   self : ArrayView[T],
   f : (T) -> Unit raise?,
@@ -829,6 +833,7 @@ pub fn[T] ArrayView::rev_each(
 ///   inspect(out, content="[(0, 30), (1, 20), (2, 10)]")
 /// }
 /// ```
+#locals(f)
 pub fn[T] ArrayView::rev_eachi(
   self : ArrayView[T],
   f : (Int, T) -> Unit raise?,
@@ -851,6 +856,7 @@ pub fn[T] ArrayView::rev_eachi(
 ///   assert_true(v[1:4].all(elem => elem % 2 == 0))
 /// }
 /// ```
+#locals(f)
 #alias(every)
 pub fn[T] ArrayView::all(
   self : ArrayView[T],
@@ -876,6 +882,7 @@ pub fn[T] ArrayView::all(
 ///   assert_false(v.any(ele => ele < 1))
 /// }
 /// ```
+#locals(f)
 #alias(exists)
 pub fn[T] ArrayView::any(
   self : ArrayView[T],
@@ -954,6 +961,7 @@ pub fn[T : Eq] ArrayView::search(self : ArrayView[T], value : T) -> Int? {
 ///   debug_inspect(view.search_by(x => x > 99), content="None")
 /// }
 /// ```
+#locals(f)
 pub fn[T] ArrayView::search_by(
   self : ArrayView[T],
   f : (T) -> Bool raise?,
@@ -1154,6 +1162,7 @@ pub fn[T] ArrayView::binary_search_by(
 ///   inspect(sum, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] ArrayView::fold(
   self : ArrayView[A],
   init~ : B,
@@ -1176,6 +1185,7 @@ pub fn[A, B] ArrayView::fold(
 ///   inspect(sum, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] ArrayView::rev_fold(
   self : ArrayView[A],
   init~ : B,
@@ -1198,6 +1208,7 @@ pub fn[A, B] ArrayView::rev_fold(
 ///   inspect(sum, content="10")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] ArrayView::foldi(
   self : ArrayView[A],
   init~ : B,
@@ -1222,6 +1233,7 @@ pub fn[A, B] ArrayView::foldi(
 ///   inspect(sum, content="10")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] ArrayView::rev_foldi(
   self : ArrayView[A],
   init~ : B,
@@ -1246,14 +1258,16 @@ pub fn[A, B] ArrayView::rev_foldi(
 ///   assert_eq(v2, [5, 6])
 /// }
 /// ```
+#locals(f)
 pub fn[T, U] ArrayView::map(
   self : ArrayView[T],
   f : (T) -> U raise?,
 ) -> Array[U] raise? {
-  if self.is_empty() {
-    return []
+  let arr = Array::make_uninit(self.length())
+  for i in 0..<self.length() {
+    arr.unsafe_set(i, f(self.unsafe_get(i)))
   }
-  Array::makei(self.length(), i => f(self[i]))
+  arr
 }
 
 ///|
@@ -1267,14 +1281,16 @@ pub fn[T, U] ArrayView::map(
 ///   assert_eq(v2, [4, 6])
 /// }
 /// ```
+#locals(f)
 pub fn[T, U] ArrayView::mapi(
   self : ArrayView[T],
   f : (Int, T) -> U raise?,
 ) -> Array[U] raise? {
-  if self.is_empty() {
-    return []
+  let arr = Array::make_uninit(self.length())
+  for i in 0..<self.length() {
+    arr.unsafe_set(i, f(i, self.unsafe_get(i)))
   }
-  Array::makei(self.length(), i => f(i, self[i]))
+  arr
 }
 
 ///|
@@ -1288,6 +1304,7 @@ pub fn[T, U] ArrayView::mapi(
 ///   assert_eq(v, [4, 6])
 /// }
 /// ```
+#locals(f)
 pub fn[T] ArrayView::filter(
   self : ArrayView[T],
   f : (T) -> Bool raise?,
@@ -1316,6 +1333,7 @@ pub fn[T] ArrayView::filter(
 ///   )
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] ArrayView::filter_map(
   self : ArrayView[A],
   f : (A) -> B? raise?,

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -256,6 +256,7 @@ pub fn[T] FixedArray::binary_search_by(
 ///   assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
 /// ```
+#locals(f)
 pub fn[T] FixedArray::each(
   self : FixedArray[T],
   f : (T) -> Unit raise?,
@@ -310,6 +311,7 @@ test "each" {
 ///   assert_eq(arr, [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)])
 /// }
 /// ```
+#locals(f)
 pub fn[T] FixedArray::eachi(
   self : FixedArray[T],
   f : (Int, T) -> Unit raise?,
@@ -364,6 +366,7 @@ test "eachi" {
 ///   assert_eq(arr, [5, 4, 3, 2, 1])
 /// }
 /// ```
+#locals(f)
 pub fn[T] FixedArray::rev_each(
   self : FixedArray[T],
   f : (T) -> Unit raise?,
@@ -418,6 +421,7 @@ test "rev_each" {
 ///   assert_eq(arr, [(0, 5), (1, 4), (2, 3), (3, 2), (4, 1)])
 /// }
 /// ```
+#locals(f)
 pub fn[T] FixedArray::rev_eachi(
   self : FixedArray[T],
   f : (Int, T) -> Unit raise?,
@@ -476,6 +480,7 @@ test "rev_eachi" {
 ///   assert_eq(doubled, [2, 4, 6, 8, 10])
 /// }
 /// ```
+#locals(f)
 pub fn[T, U] FixedArray::map(
   self : FixedArray[T],
   f : (T) -> U raise?,
@@ -513,6 +518,7 @@ test "map" {
 ///   assert_eq(added, [3, 5, 7])
 /// }
 /// ```
+#locals(f)
 pub fn[T, U] FixedArray::mapi(
   self : FixedArray[T],
   f : (Int, T) -> U raise?,
@@ -630,6 +636,7 @@ test "from_array" {
 ///   inspect(sum, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] FixedArray::fold(
   self : FixedArray[A],
   init~ : B,
@@ -664,6 +671,7 @@ test "fold" {
 ///   inspect(sum, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] FixedArray::rev_fold(
   self : FixedArray[A],
   init~ : B,
@@ -698,6 +706,7 @@ test "rev_fold" {
 ///   inspect(sum, content="10")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] FixedArray::foldi(
   self : FixedArray[A],
   init~ : B,
@@ -735,6 +744,7 @@ test "fold_lefti" {
 ///   inspect(sum, content="10")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] FixedArray::rev_foldi(
   self : FixedArray[A],
   init~ : B,

--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -18,6 +18,7 @@ import {
   "moonbitlang/core/random",
   "moonbitlang/core/math", // FIXME: IDE false alarm unused package
   "moonbitlang/core/buffer",
+  "moonbitlang/core/bench",
 } for "test"
 
 warnings = "-test_unqualified_package"


### PR DESCRIPTION
## Summary

- add dedicated Array / FixedArray / ArrayView callback benchmarks with n=100000
- add `#locals` annotations for Array, FixedArray, and ArrayView callback loops
- rewrite `ArrayView::map` and `ArrayView::mapi` to direct loops so their callbacks do not escape through an `Array::makei` closure
- keep delegate wrappers such as `Array::all`, `Array::any`, `FixedArray::all`, and `FixedArray::any` unchanged; the annotations live on the ArrayView callees

## Benchmark

Ran the same benchmark file on the benchmark-only baseline commit (`e1937f46`) and the annotated commit (`82222de1`) with `--release`.

Speedup is `without #locals / with #locals`, so higher is better.

| Method | wasm-gc | wasm | js | native |
|---|---:|---:|---:|---:|
| `Array::retain_map` | 1.46x | 2.07x | 1.34x | 25.50x |
| `Array::shuffle_in_place` | 1.67x | 1.70x | 2.27x | 1.09x |
| `Array::filter_map` | 1.00x | 1.77x | 1.47x | 2.47x |
| `FixedArray::each` | 2.56x | 6.36x | 1.19x | 65.24x |
| `FixedArray::eachi` | 1.50x | 6.23x | 10.21x | 15.01x |
| `FixedArray::rev_each` | 2.30x | 4.33x | 1.13x | 4.89x |
| `FixedArray::rev_eachi` | 1.56x | 3.98x | 7.39x | 3.16x |
| `FixedArray::map` | 1.29x | 2.14x | 1.27x | 3.27x |
| `FixedArray::mapi` | 1.31x | 1.92x | 1.28x | 3.23x |
| `FixedArray::makei` | 1.00x | 0.93x | 1.19x | 1.01x |
| `FixedArray::fold` | 1.48x | 2.74x | 1.03x | 1.00x |
| `FixedArray::rev_fold` | 1.51x | 3.39x | 1.04x | 4.51x |
| `FixedArray::foldi` | 1.07x | 2.89x | 4.59x | 1.00x |
| `FixedArray::rev_foldi` | 1.10x | 3.50x | 7.17x | 2.48x |
| `ArrayView::chunk_by` | 1.24x | 3.83x | 1.61x | 5.43x |
| `ArrayView::each` | 2.02x | 8.28x | 1.46x | 39.11x |
| `ArrayView::eachi` | 1.53x | 6.68x | 10.53x | 16.73x |
| `ArrayView::rev_each` | 1.80x | 6.97x | 1.14x | 30.48x |
| `ArrayView::rev_eachi` | 1.57x | 6.49x | 10.21x | 15.86x |
| `ArrayView::all` | 1.42x | 4.95x | 1.17x | 6.00x |
| `ArrayView::any` | 1.43x | 4.96x | 1.19x | 5.97x |
| `ArrayView::search_by` | 1.45x | 5.00x | 1.19x | 5.95x |
| `ArrayView::fold` | 1.00x | 1.41x | 1.12x | 1.69x |
| `ArrayView::rev_fold` | 1.24x | 1.37x | 1.13x | 1.68x |
| `ArrayView::foldi` | 1.01x | 1.44x | 5.57x | 1.59x |
| `ArrayView::rev_foldi` | 1.19x | 1.39x | 6.03x | 1.59x |
| `ArrayView::map` | 1.36x | 6.77x | 3.56x | 38.59x |
| `ArrayView::mapi` | 1.38x | 6.93x | 3.41x | 38.67x |
| `ArrayView::filter` | 1.08x | 1.87x | 1.43x | 2.63x |
| `ArrayView::filter_map` | 0.99x | 1.78x | 1.25x | 2.47x |

## Follow-up

- remove redundant bounds checks in loops where the index is proven in range, such as ArrayView fold loops
- audit packages outside Array / FixedArray / ArrayView for callback-in-loop APIs that can benefit from missing `#locals` annotations

## Validation

- `moon fmt`
- `moon check`
- `moon test builtin --target wasm-gc`
- `moon info` (no generated interface diff)
- `moon bench -p moonbitlang/core/builtin -f array_locals_bench_test.mbt --target wasm-gc --release`
- `moon bench -p moonbitlang/core/builtin -f array_locals_bench_test.mbt --target wasm --release`
- `moon bench -p moonbitlang/core/builtin -f array_locals_bench_test.mbt --target js --release`
- `moon bench -p moonbitlang/core/builtin -f array_locals_bench_test.mbt --target native --release`
