### PR TITLE
Mark Double::to_string as intrinsic

### DIFF
--- a/builtin/double.mbt
+++ b/builtin/double.mbt
@@ -279,15 +279,10 @@ pub impl Hash for Double with hash_combine(self, hasher) {
 /// }
 /// ```
 ///
+#intrinsic("%f64.to_string")
 pub fn Double::to_string(self : Double) -> String {
   ryu_to_string(self)
 }
-
-// TODO:
-// #intrinsic("%f64.to_string")
-// impl Show for Double with to_string(self) -> String{
-//   @ryu.ryu_to_string(self)
-// }
 
 ///|
 pub impl Show for Double with output(self, logger) {


### PR DESCRIPTION
## Summary
- Mark `Double::to_string` with `#intrinsic("%f64.to_string")`
- Remove the stale TODO comment for this intrinsic

## Verification
- Compared generated JS against clean `HEAD`
- `builtin.blackbox_test.js` shrank by 372 bytes in debug and release JS test builds
- Generated JS now emits direct `String(self)` / `String(x)` calls instead of the `ryu_to_string` JS wrapper

## Tests
- `moon test builtin/double.mbt --target js`
- `moon test builtin/double_test.mbt --target js`
- `moon check --target js`
- `moon info`