### PR TITLE
Refactor array traversals to use for-in loops

### DIFF
--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -23,11 +23,10 @@ fn positional_args(args : Array[Arg]) -> Array[Arg] {
 fn next_positional(positionals : Array[Arg], collected : Array[String]) -> Arg? {
   let target = collected.length()
   let total = target + 1
-  for idx in 0..<positionals.length(); cursor = 0 {
+  for idx, arg in positionals; cursor = 0 {
     if cursor >= total {
       break None
     }
-    let arg = positionals[idx]
     let remaining = total - cursor
     let take = if arg.multiple {
       let (min, max) = arg_min_max(arg)

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1325,8 +1325,8 @@ pub fn[A, B] Array::foldi(
   init~ : B,
   f : (Int, B, A) -> B raise?,
 ) -> B raise? {
-  for i = 0, acc = init; i < self.length(); {
-    continue i + 1, f(i, acc, self[i])
+  for i, x in self; acc = init {
+    continue f(i, acc, x)
   } nobreak {
     acc
   }

--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -76,8 +76,8 @@ fn[T : Compare] MutArrayView::insertion_sort(arr : MutArrayView[T]) -> Unit {
 fn[T : Compare] merge(arr : MutArrayView[T], mid : Int) -> Unit {
   let buf_len = arr.length() - mid
   let buf : FixedArray[T] = FixedArray::make(buf_len, arr[mid])
-  for i in 0..<buf.length() {
-    buf[i] = arr[mid + i]
+  for i, x in arr[mid:] {
+    buf[i] = x
   }
   let buf : MutArrayView[T] = buf.mut_view()
   let buf_remaining = for p1 = mid - 1, p2 = buf_len - 1, p = mid + buf_len - 1; p1 >=

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -954,8 +954,8 @@ pub fn[T : Eq] ArrayView::contains(self : ArrayView[T], value : T) -> Bool {
 /// }
 /// ```
 pub fn[T : Eq] ArrayView::search(self : ArrayView[T], value : T) -> Int? {
-  for i in 0..<self.length() {
-    if self.unsafe_get(i) == value {
+  for i, x in self {
+    if x == value {
       break Some(i)
     }
   } nobreak {
@@ -1183,8 +1183,8 @@ pub fn[A, B] ArrayView::fold(
   init~ : B,
   f : (B, A) -> B raise?,
 ) -> B raise? {
-  for i = 0, acc = init; i < self.length(); {
-    continue i + 1, f(acc, self[i])
+  for x in self; acc = init {
+    continue f(acc, x)
   } nobreak {
     acc
   }
@@ -1229,8 +1229,8 @@ pub fn[A, B] ArrayView::foldi(
   init~ : B,
   f : (Int, B, A) -> B raise?,
 ) -> B raise? {
-  for i = 0, acc = init; i < self.length(); {
-    continue i + 1, f(i, acc, self[i])
+  for i, x in self; acc = init {
+    continue f(i, acc, x)
   } nobreak {
     acc
   }
@@ -1279,8 +1279,8 @@ pub fn[T, U] ArrayView::map(
   f : (T) -> U raise?,
 ) -> Array[U] raise? {
   let arr = Array::make_uninit(self.length())
-  for i in 0..<self.length() {
-    arr.unsafe_set(i, f(self.unsafe_get(i)))
+  for i, x in self {
+    arr.unsafe_set(i, f(x))
   }
   arr
 }
@@ -1302,8 +1302,8 @@ pub fn[T, U] ArrayView::mapi(
   f : (Int, T) -> U raise?,
 ) -> Array[U] raise? {
   let arr = Array::make_uninit(self.length())
-  for i in 0..<self.length() {
-    arr.unsafe_set(i, f(i, self.unsafe_get(i)))
+  for i, x in self {
+    arr.unsafe_set(i, f(i, x))
   }
   arr
 }
@@ -1513,8 +1513,8 @@ pub impl[T : Eq] Eq for ArrayView[T] with equal(self, other) -> Bool {
   if self.length() != other.length() {
     return false
   }
-  for i in 0..<self.length() {
-    if !(self[i] == other[i]) {
+  for i, x in self {
+    if !(x == other[i]) {
       return false
     }
   } nobreak {
@@ -1528,8 +1528,8 @@ pub impl[T : Compare] Compare for ArrayView[T] with compare(self, other) -> Int 
   let len_other = other.length()
   let cmp = len_self.compare(len_other)
   guard cmp == 0 else { return cmp }
-  for i in 0..<len_self {
-    let cmp = self[i].compare(other[i])
+  for i, x in self {
+    let cmp = x.compare(other[i])
     guard cmp == 0 else { break cmp }
   } nobreak {
     0

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -650,8 +650,8 @@ pub impl Show for Bytes with output(self, logger) {
 /// ```
 pub impl Eq for BytesView with equal(self, other) -> Bool {
   guard self.length() == other.length() else { return false }
-  for i in 0..<self.length() {
-    guard self.unsafe_get(i) == other.unsafe_get(i) else { return false }
+  for i, byte in self {
+    guard byte == other.unsafe_get(i) else { return false }
   }
   true
 }
@@ -689,8 +689,7 @@ pub impl Compare for BytesView with compare(self, other) -> Int {
   let other_len = other.length()
   let cmp = self_len.compare(other_len)
   guard cmp == 0 else { return cmp }
-  for i in 0..<self_len {
-    let b1 = self.unsafe_get(i)
+  for i, b1 in self {
     let b2 = other.unsafe_get(i)
     let cmp = b1.compare(b2)
     guard cmp == 0 else { return cmp }

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -642,8 +642,8 @@ pub fn[A, B] FixedArray::fold(
   init~ : B,
   f : (B, A) -> B raise?,
 ) -> B raise? {
-  for i = 0, acc = init; i < self.length(); {
-    continue i + 1, f(acc, self[i])
+  for x in self; acc = init {
+    continue f(acc, x)
   } nobreak {
     acc
   }
@@ -712,8 +712,8 @@ pub fn[A, B] FixedArray::foldi(
   init~ : B,
   f : (Int, B, A) -> B raise?,
 ) -> B raise? {
-  for i = 0, acc = init; i < self.length(); {
-    continue i + 1, f(i, acc, self[i])
+  for i, x in self; acc = init {
+    continue f(i, acc, x)
   } nobreak {
     acc
   }
@@ -1059,8 +1059,8 @@ test "search" {
 /// }
 /// ```
 pub fn[T : Eq] FixedArray::contains(self : FixedArray[T], value : T) -> Bool {
-  for i in 0..<self.length() {
-    if self[i] == value {
+  for x in self {
+    if x == value {
       return true
     }
   }
@@ -1206,8 +1206,8 @@ pub impl[T : Eq] Eq for FixedArray[T] with equal(
   if self.length() != that.length() {
     return false
   }
-  for i in 0..<self.length() {
-    if self[i] != that[i] {
+  for i, x in self {
+    if x != that[i] {
       return false
     }
   }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -769,8 +769,7 @@ pub fn[K : Hash + Eq, V] Map::of(arr : FixedArray[(K, V)]) -> Map[K, V] {
   let length = arr.length()
   let m = new_map(capacity_for_length(length))
   // arr.iter((e) => { m.set(e.0, e.1) })
-  for i in 0..<length {
-    let e = arr[i]
+  for e in arr {
     m.set(e.0, e.1)
   }
   m

--- a/bytes/internal/regex_engine/execute.mbt
+++ b/bytes/internal/regex_engine/execute.mbt
@@ -47,8 +47,8 @@ pub fn MatchResult::group(self : MatchResult, index : Int) -> (Int, Int)? {
 
 ///|
 fn Regex::find_start_state(self : Regex, cat : Category) -> StateId {
-  for i in 0..<self.start_states.length() {
-    let (cat2, state_id) = self.start_states[i]
+  for start_state in self.start_states {
+    let (cat2, state_id) = start_state
     if cat2 == cat {
       return state_id
     }

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -475,8 +475,8 @@ fn[A] from_leaves(leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
     Leaf(leaves[0])
   } else if leaves.length() <= branching_factor {
     let arr = FixedArray::make(leaves.length(), Empty)
-    for i in 0..<leaves.length() {
-      arr[i] = Leaf(leaves[i])
+    for i, leaf in leaves {
+      arr[i] = Leaf(leaf)
     }
     Node(arr, None)
   } else {

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -328,20 +328,20 @@ fn[A] Tree::eachi(
   match self {
     Empty => ()
     Leaf(l) =>
-      for i in 0..<l.length() {
-        f(start + i, l[i])
+      for i, x in l {
+        f(start + i, x)
       }
     Node(ns, None) => {
       let child_shift = shift - num_bits
-      for i in 0..<ns.length(); start = start {
-        ns[i].eachi(f, child_shift, start)
+      for child in ns; start = start {
+        child.eachi(f, child_shift, start)
         continue start + (1 << shift)
       }
     }
     Node(ns, Some(sizes)) => {
       let child_shift = shift - num_bits
-      for i in 0..<ns.length(); start = start {
-        ns[i].eachi(f, child_shift, start)
+      for i, child in ns; start = start {
+        child.eachi(f, child_shift, start)
         continue start + sizes[i]
       }
     }

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -338,8 +338,8 @@ pub fn[K, V] HashMap::length(self : HashMap[K, V]) -> Int {
       Leaf(_, _, bucket) => 1 + bucket.length()
       Flat(_) => 1
       Branch(children) =>
-        for i = 0, total_size = 0; i < children.data.length(); {
-          continue i + 1, total_size + node_size(children.data[i])
+        for child in children.data; total_size = 0 {
+          continue total_size + node_size(child)
         } nobreak {
           total_size
         }

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -194,8 +194,8 @@ pub fn[A] HashSet::length(self : HashSet[A]) -> Int {
       Leaf(_, bucket) => 1 + bucket.length()
       Flat(_) => 1
       Branch(children) =>
-        for i = 0, total_size = 0; i < children.data.length(); {
-          continue i + 1, total_size + node_size(children.data[i])
+        for child in children.data; total_size = 0 {
+          continue total_size + node_size(child)
         } nobreak {
           total_size
         }

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -229,9 +229,9 @@ fn[K : Show, V : Show] SortedMap::debug_tree(self : SortedMap[K, V]) -> String {
 pub fn[K : Compare, V] SortedMap::from_array(
   array : ArrayView[(K, V)],
 ) -> SortedMap[K, V] {
-  for i = 0, mp = Empty; i < array.length(); {
-    let (k, v) = array[i]
-    continue i + 1, mp.add(k, v)
+  for item in array; mp = Empty {
+    let (k, v) = item
+    continue mp.add(k, v)
   } nobreak {
     mp
   }

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -304,20 +304,20 @@ fn[A] Tree::eachi(
   match self {
     Empty => ()
     Leaf(l) =>
-      for i in 0..<l.length() {
-        f(start + i, l[i])
+      for i, x in l {
+        f(start + i, x)
       }
     Node(ns, None) => {
       let child_shift = shift - num_bits
-      for i in 0..<ns.length(); start = start {
-        ns[i].eachi(f, child_shift, start)
+      for child in ns; start = start {
+        child.eachi(f, child_shift, start)
         continue start + (1 << shift)
       }
     }
     Node(ns, Some(sizes)) => {
       let child_shift = shift - num_bits
-      for i in 0..<ns.length(); offset = 0 {
-        ns[i].eachi(f, child_shift, start + offset)
+      for i, child in ns; offset = 0 {
+        child.eachi(f, child_shift, start + offset)
         continue sizes[i]
       }
     }

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -518,8 +518,8 @@ pub fn[A] Vector::eachi(
 ) -> Unit raise? {
   self.tree.eachi(f, self.shift, 0)
   let tail_offset = self.tail_offset()
-  for i in 0..<self.tail.length() {
-    f(tail_offset + i, self.tail[i])
+  for i, x in self.tail {
+    f(tail_offset + i, x)
   }
 }
 
@@ -757,8 +757,8 @@ fn[A] from_leaves(leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
     Leaf(leaves[0])
   } else if leaves.length() <= branching_factor {
     let arr = FixedArray::make(leaves.length(), Empty)
-    for i in 0..<leaves.length() {
-      arr[i] = Leaf(leaves[i])
+    for i, leaf in leaves {
+      arr[i] = Leaf(leaf)
     }
     Node(arr, None)
   } else {

--- a/string/internal/regex_engine/states.mbt
+++ b/string/internal/regex_engine/states.mbt
@@ -19,8 +19,8 @@ fn Regex::get_state(self : Regex, state_id : StateId) -> @automata.State {
 
 ///|
 fn Regex::stablize_start_state(self : Regex, prev_cat : Category) -> StateId {
-  for i in 0..<self.start_states.length() {
-    let (cat, state_id) = self.start_states[i]
+  for start_state in self.start_states {
+    let (cat, state_id) = start_state
     if cat == prev_cat {
       return state_id
     }


### PR DESCRIPTION
## Summary
- replace straightforward indexed traversals with for-in loops
- keep behavior and public API unchanged

## Validation
- moon check --target all --target-dir /tmp/core-forin-post-rebase-check
- moon test --target all --target-dir /tmp/core-forin-review-test
- moon fmt
- moon info