### PR TITLE
Add locals annotations for traversal callbacks

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -46,6 +46,7 @@ pub fn FixedArray::unsafe_reinterpret_as_bytes(
 ///   assert_eq(bytes, b"ABC")
 /// }
 /// ```
+#locals(value)
 pub fn Bytes::makei(length : Int, value : (Int) -> Byte raise?) -> Bytes raise? {
   if length <= 0 {
     return []

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -129,6 +129,7 @@ test "find" {
 ///|
 /// Returns the offset of the first character that satisfies the given predicate.
 /// If no such character is found, it returns None.
+#locals(pred)
 pub fn StringView::find_by(self : StringView, pred : (Char) -> Bool) -> Int? {
   for i, c in self {
     if pred(c) {
@@ -1765,6 +1766,7 @@ test "View::to_upper" {
 
 ///|
 /// Folds the characters of the string into a single value.
+#locals(f)
 pub fn[A] StringView::fold(
   self : StringView,
   init~ : A,
@@ -1815,6 +1817,7 @@ test "fold with raise" {
 
 ///|
 /// Function `rev_fold`.
+#locals(f)
 pub fn[A] StringView::rev_fold(
   self : StringView,
   init~ : A,

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -891,6 +891,7 @@ pub impl[A : Eq] Eq for Deque[A] with equal(self, other) {
 ///   inspect(sum, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[A] Deque::each(self : Deque[A], f : (A) -> Unit) -> Unit {
   for v in self {
     f(v)
@@ -909,6 +910,7 @@ pub fn[A] Deque::each(self : Deque[A], f : (A) -> Unit) -> Unit {
 ///   inspect(idx_sum, content="10")
 /// }
 /// ```
+#locals(f)
 pub fn[A] Deque::eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self {
     f(i, v)
@@ -927,6 +929,7 @@ pub fn[A] Deque::eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
 ///   inspect(sum, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[A] Deque::rev_each(self : Deque[A], f : (A) -> Unit) -> Unit {
   for v in self.rev_iter() {
     f(v)
@@ -945,6 +948,7 @@ pub fn[A] Deque::rev_each(self : Deque[A], f : (A) -> Unit) -> Unit {
 ///   inspect(idx_sum, content="10")
 /// }
 /// ```
+#locals(f)
 pub fn[A] Deque::rev_eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
   for i, v in self.rev_iter2() {
     f(i, v)
@@ -995,6 +999,7 @@ pub fn[A] Deque::clear(self : Deque[A]) -> Unit {
 ///   @test.assert_eq(dv2, @deque.from_array([4, 5, 6]))
 /// }
 /// ```
+#locals(f)
 pub fn[A, U] Deque::map(self : Deque[A], f : (A) -> U) -> Deque[U] {
   let cap = self.buf.length()
   if self.len == 0 {
@@ -1020,6 +1025,7 @@ pub fn[A, U] Deque::map(self : Deque[A], f : (A) -> U) -> Deque[U] {
 ///   @test.assert_eq(dv2, @deque.from_array([3, 5, 7]))
 /// }
 /// ```
+#locals(f)
 pub fn[A, U] Deque::mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
   let cap = self.buf.length()
   if self.len == 0 {
@@ -1327,6 +1333,7 @@ test "truncate zero" {
 ///   inspect(dq, content="@deque.from_array([4, 8])")
 /// }
 /// ```
+#locals(f)
 #alias(filter_map_inplace, deprecated)
 pub fn[A] Deque::retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
   guard !self.is_empty() else { return }
@@ -1385,6 +1392,7 @@ pub fn[A] Deque::retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
 ///   inspect(dq, content="@deque.from_array([2, 4])")
 /// }
 /// ```
+#locals(f)
 pub fn[A] Deque::retain(self : Deque[A], f : (A) -> Bool) -> Unit {
   guard !self.is_empty() else { return }
   let { head, buf, .. } = self
@@ -2309,6 +2317,7 @@ pub fn[A] Deque::rev(self : Deque[A]) -> Deque[A] {
 ///
 /// # Note
 /// This function handles the circular buffer nature of the deque internally.
+#locals(rand)
 pub fn[A] Deque::shuffle_in_place(
   self : Deque[A],
   rand~ : (Int) -> Int,

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -461,6 +461,7 @@ pub impl[K : Hash + Eq] Sub for HashSet[K] with sub(self, other) {
 
 ///|
 /// Removes all elements for which the predicate returns `false`.
+#locals(f)
 pub fn[K] HashSet::retain(self : HashSet[K], f : (K) -> Bool) -> Unit {
   let size = self.size
   let mut j = 0

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -217,6 +217,7 @@ pub fn[A] List::each(self : List[A], f : (A) -> Unit raise?) -> Unit raise? {
 ///   assert_eq(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
 /// }
 /// ```
+#locals(f)
 pub fn[A] List::eachi(
   self : List[A],
   f : (Int, A) -> Unit raise?,
@@ -245,6 +246,7 @@ pub fn[A] List::eachi(
 ///   )
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
   match self {
     Empty => Empty
@@ -281,6 +283,7 @@ pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
 ///   assert_eq(result, @list.from_array([10, 21, 32]))
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] List::mapi(
   self : List[A],
   f : (Int, A) -> B raise?,
@@ -319,6 +322,7 @@ pub fn[A, B] List::mapi(
 ///   )
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] List::rev_map(
   self : List[A],
   f : (A) -> B raise?,
@@ -364,6 +368,7 @@ pub fn[A] List::to_array(self : List[A]) -> Array[A] {
 ///   )
 /// }
 /// ```
+#locals(f)
 pub fn[A] List::filter(
   self : List[A],
   f : (A) -> Bool raise?,
@@ -413,6 +418,7 @@ pub fn[A] List::filter(
 ///   assert_eq(ls2.all(x => x % 2 == 0), false)
 /// }
 /// ```
+#locals(f)
 pub fn[A] List::all(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
   for x = self {
     match x {
@@ -438,6 +444,7 @@ pub fn[A] List::all(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
 ///   assert_eq(ls2.any(x => x % 2 == 0), false)
 /// }
 /// ```
+#locals(f)
 pub fn[A] List::any(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
   for x = self {
     match x {
@@ -639,6 +646,7 @@ pub fn[A] List::rev(self : List[A]) -> List[A] {
 ///   inspect(r, content="15")
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] List::fold(
   self : List[A],
   init~ : B,
@@ -667,6 +675,7 @@ pub fn[A, B] List::fold(
 ///   inspect(result, content="80") // 0*10 + 1*20 + 2*30 = 80
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] List::foldi(
   self : List[A],
   init~ : B,
@@ -729,6 +738,7 @@ pub fn[A, B] List::zip(self : List[A], other : List[B]) -> List[(A, B)] {
 ///   assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] List::flat_map(
   self : List[A],
   f : (A) -> List[B] raise?,
@@ -793,6 +803,7 @@ pub fn[A, B] List::flat_map(
 ///   assert_eq(r, @list.from_array([4, 6, 3]))
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] List::filter_map(
   self : List[A],
   f : (A) -> B? raise?,
@@ -1262,6 +1273,7 @@ pub fn[A : Eq] List::contains(self : List[A], value : A) -> Bool {
 /// }
 /// ```
 #as_free_fn
+#locals(f)
 pub fn[A, S] List::unfold(
   f : (S) -> (A, S)? raise?,
   init~ : S,
@@ -1304,6 +1316,7 @@ pub fn[A, S] List::unfold(
 /// }
 /// ```
 #as_free_fn
+#locals(f)
 pub fn[A, S] List::rev_unfold(
   f : (S) -> (A, S)? raise?,
   init~ : S,
@@ -1393,6 +1406,7 @@ pub fn[A] List::drop(self : List[A], n : Int) -> List[A] {
 ///   assert_eq(r, @list.from_array([1, 2]))
 /// }
 /// ```
+#locals(p)
 pub fn[A] List::take_while(
   self : List[A],
   p : (A) -> Bool raise?,
@@ -1432,6 +1446,7 @@ pub fn[A] List::take_while(
 ///   assert_eq(r, @list.from_array([3, 4]))
 /// }
 /// ```
+#locals(p)
 pub fn[A] List::drop_while(
   self : List[A],
   p : (A) -> Bool raise?,
@@ -1461,6 +1476,7 @@ pub fn[A] List::drop_while(
 ///   assert_eq(r, @list.from_array([0, 1, 3, 6, 10, 15]))
 /// }
 /// ```
+#locals(f)
 pub fn[A, E] List::scan_left(
   self : List[A],
   f : (E, A) -> E raise?,
@@ -1537,6 +1553,7 @@ pub fn[A : Eq, B] List::lookup(self : List[(A, B)], v : A) -> B? {
 ///   )
 /// }
 /// ```
+#locals(f)
 pub fn[A] List::find(self : List[A], f : (A) -> Bool raise?) -> A? raise? {
   for cur = self {
     match cur {
@@ -1574,6 +1591,7 @@ pub fn[A] List::find(self : List[A], f : (A) -> Bool raise?) -> A? raise? {
 /// }
 /// ```
 ///
+#locals(f)
 pub fn[A] List::find_index(
   self : Self[A],
   f : (A) -> Bool raise?,
@@ -1612,6 +1630,7 @@ pub fn[A] List::find_index(
 ///   )
 /// }
 /// ```
+#locals(f)
 pub fn[A] List::findi(self : List[A], f : (A, Int) -> Bool raise?) -> A? raise? {
   for list = self, index = 0 {
     match list {

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -223,6 +223,7 @@ pub fn[A] Queue::pop(self : Queue[A]) -> A? {
 ///   queue.each(x => sum = sum + x)
 /// }
 /// ```
+#locals(f)
 pub fn[A] Queue::each(self : Queue[A], f : (A) -> Unit) -> Unit {
   for x = self.first {
     match x {
@@ -246,6 +247,7 @@ pub fn[A] Queue::each(self : Queue[A], f : (A) -> Unit) -> Unit {
 ///   queue.eachi((i, x) => sum = sum + i * x)
 /// }
 /// ```
+#locals(f)
 pub fn[A] Queue::eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
   for x = self.first, index = 0 {
     match (x, index) {
@@ -269,6 +271,7 @@ pub fn[A] Queue::eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
 ///   @test.assert_eq(sum, 0)
 /// }
 /// ```
+#locals(f)
 pub fn[A, B] Queue::fold(self : Queue[A], init~ : B, f : (B, A) -> B) -> B {
   for x = self.first, acc = init {
     match (x, acc) {


### PR DESCRIPTION
## Summary
- add #locals annotations for callback-heavy traversal APIs in bytes, string views, lists, queues, deques, and hash sets
- keep one-shot callbacks and callbacks captured by nested helper closures out of scope

## Validation
- moon check builtin list queue deque hashset --target all --target-dir /tmp/core-locals-pr-check
- moon test builtin list queue deque hashset --target all --target-dir /tmp/core-locals-pr-test
- moon fmt
- moon info
- git diff --check

No .mbti files changed.