### PR TITLE
Use blit for contiguous copies

### DIFF
--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -75,11 +75,8 @@ fn[T : Compare] MutArrayView::insertion_sort(arr : MutArrayView[T]) -> Unit {
 /// `buf` and `arr[:mid]` to `arr[:]`
 fn[T : Compare] merge(arr : MutArrayView[T], mid : Int) -> Unit {
   let buf_len = arr.length() - mid
-  let buf : FixedArray[T] = FixedArray::make(buf_len, arr[mid])
-  for i, x in arr[mid:] {
-    buf[i] = x
-  }
-  let buf : MutArrayView[T] = buf.mut_view()
+  let buf : UninitializedArray[T] = UninitializedArray::make(buf_len)
+  UninitializedArray::unsafe_blit(buf, 0, arr.buf(), arr.start() + mid, buf_len)
   let buf_remaining = for p1 = mid - 1, p2 = buf_len - 1, p = mid + buf_len - 1; p1 >=
                          0 &&
                          p2 >= 0; {
@@ -93,8 +90,14 @@ fn[T : Compare] merge(arr : MutArrayView[T], mid : Int) -> Unit {
   } nobreak {
     p2
   }
-  for i = buf_remaining; i >= 0; i = i - 1 {
-    arr[i] = buf[i]
+  if buf_remaining >= 0 {
+    UninitializedArray::unsafe_blit(
+      arr.buf(),
+      arr.start(),
+      buf,
+      0,
+      buf_remaining + 1,
+    )
   }
 }
 

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -607,10 +607,14 @@ pub fn Bytes::from_iter(iter : Iter[Byte]) -> Bytes {
 /// ```
 pub fn Bytes::to_array(self : Bytes) -> Array[Byte] {
   let len = self.length()
-  let rv = Array::make(len, b'0')
-  for i in 0..<len {
-    rv[i] = self[i]
-  }
+  let rv = Array::make_uninit(len)
+  UninitializedArray::unsafe_blit_fixed(
+    rv.buffer(),
+    0,
+    unsafe_from_bytes(self),
+    0,
+    len,
+  )
   rv
 }
 
@@ -628,10 +632,14 @@ pub fn Bytes::to_array(self : Bytes) -> Array[Byte] {
 /// ```
 pub fn BytesView::to_array(self : BytesView) -> Array[Byte] {
   let len = self.length()
-  let rv = Array::make(len, b'0')
-  for i in 0..<len {
-    rv[i] = self[i]
-  }
+  let rv = Array::make_uninit(len)
+  UninitializedArray::unsafe_blit_fixed(
+    rv.buffer(),
+    0,
+    unsafe_from_bytes(self.data()),
+    self.start_offset(),
+    len,
+  )
   rv
 }
 
@@ -778,12 +786,8 @@ pub impl Add for Bytes with add(self : Bytes, other : Bytes) -> Bytes {
   let len_self = self.length()
   let len_other = other.length()
   let rv : FixedArray[Byte] = FixedArray::make(len_self + len_other, 0)
-  for i in 0..<len_self {
-    rv[i] = self[i]
-  }
-  for i in 0..<len_other {
-    rv[len_self + i] = other[i]
-  }
+  rv.blit_from_bytes(0, self, 0, len_self)
+  rv.blit_from_bytes(len_self, other, 0, len_other)
   unsafe_to_bytes(rv)
 }
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -111,12 +111,8 @@ pub impl[A : Hash] Hash for Deque[A] with hash_combine(self, hasher) {
 pub impl[A] Add for Deque[A] with add(self, other) {
   let len = self.len + other.len
   let buf = UninitializedArray::make(len)
-  for i, x in self {
-    buf[i] = x
-  }
-  for i, x in other {
-    buf[i + self.len] = x
-  }
+  self.unsafe_blit_to(buf, 0)
+  other.unsafe_blit_to(buf, self.len)
   Deque::{ buf, len, head: 0 }
 }
 
@@ -200,9 +196,7 @@ test "from_array_empty" {
 pub fn[A] Deque::copy(self : Deque[A]) -> Deque[A] {
   let len = self.len
   let buf = UninitializedArray::make(len)
-  for i, x in self {
-    buf[i] = x
-  }
+  self.unsafe_blit_to(buf, 0)
   Deque::{ buf, len, head: 0 }
 }
 
@@ -527,11 +521,7 @@ fn[A] Deque::realloc(self : Deque[A]) -> Unit {
   let old_cap = self.buf.length()
   let new_cap = if old_cap == 0 { 8 } else { old_cap * 2 }
   let new_buf = UninitializedArray::make(new_cap)
-  // Copy elements linearly to new buffer
-  for i in 0..<self.len {
-    let src_idx = (self.head + i) % old_cap
-    new_buf[i] = self.buf[src_idx]
-  }
+  self.unsafe_blit_to(new_buf, 0)
   self.head = 0
   self.buf = new_buf
 }
@@ -843,6 +833,23 @@ pub fn[A] Deque::as_views(self : Deque[A]) -> (ArrayView[A], ArrayView[A]) {
   } else {
     (buf[head:cap], buf[:len - head_len])
   }
+}
+
+///|
+fn[A] Deque::unsafe_blit_to(
+  self : Deque[A],
+  dst : UninitializedArray[A],
+  dst_offset : Int,
+) -> Unit {
+  guard self.len != 0 else { return }
+  let (front, back) = self.as_views()
+  dst.unsafe_blit(dst_offset, self.buf, front.start_offset(), front.length())
+  dst.unsafe_blit(
+    dst_offset + front.length(),
+    self.buf,
+    back.start_offset(),
+    back.length(),
+  )
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -681,9 +681,7 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
     capacity_mask: self.capacity_mask,
     grow_at: self.grow_at,
   }
-  for i in 0..<self.capacity {
-    other.entries[i] = self.entries[i]
-  }
+  self.entries.blit_to(other.entries, len=self.capacity)
   other
 }
 


### PR DESCRIPTION
## Summary
- use blit for contiguous copies in stable sort merge, bytes conversions/concat, deque linearization paths, and hash set copy
- add a small internal deque helper for copying the two physical views into a linear buffer
- avoid initialize-then-overwrite loops in the updated paths

## Validation
- moon check builtin deque hashset --target all --target-dir /tmp/core-blit-pr-check
- moon test builtin deque hashset --target all --target-dir /tmp/core-blit-pr-test
- moon fmt
- moon info
- git diff --check

No .mbti files changed.