### PR TITLE
refactor: remove redundant Show::output impls

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -46,6 +46,11 @@ pub impl ToJson for BigInt with to_json(self : BigInt) -> Json {
 }
 
 ///|
+pub impl Show for BigInt with to_string(self) {
+  BigInt::to_string(self)
+}
+
+///|
 pub impl @json.FromJson for BigInt with from_json(json, path) {
   guard json is String(s) else {
     raise @json.JsonDecodeError(

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -124,11 +124,6 @@ fn BigInt::from_string_radix(str : String, radix : Int) -> BigInt {
 }
 
 ///|
-pub impl Show for BigInt with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 /// Converts a `BigInt` value to a string representation in the specified radix.
 ///
 /// Parameters:

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1019,33 +1019,6 @@ pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
 }
 
 ///|
-/// Formats and writes a `BigInt` value to a logger by converting it to a string
-/// representation.
-///
-/// Implements the `Show` trait for `BigInt` type, allowing `BigInt` values to be
-/// converted to strings and used in string interpolation.
-///
-/// Parameters:
-///
-/// * `self` : The `BigInt` value to be formatted.
-/// * `logger` : A logger that implements the `Logger` trait, which will receive
-/// the formatted string output.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let n = 12345678901234567890N
-///   inspect(n, content="12345678901234567890")
-///   let neg = -42N
-///   inspect(neg, content="-42")
-/// }
-/// ```
-pub impl Show for BigInt with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 fn digit_from_char(x : Int) -> Int {
   match x {
     '0'..='9' => x - '0'

--- a/builtin/double.mbt
+++ b/builtin/double.mbt
@@ -285,11 +285,6 @@ pub fn Double::to_string(self : Double) -> String {
 }
 
 ///|
-pub impl Show for Double with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 pub impl Show for Double with to_string(self) {
   Double::to_string(self)
 }

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -23,11 +23,6 @@ pub impl Show for Unit with to_string(_self) {
 }
 
 ///|
-pub impl Show for Bool with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 pub impl Show for Bool with to_string(self) {
   if self {
     "true"
@@ -37,18 +32,8 @@ pub impl Show for Bool with to_string(self) {
 }
 
 ///|
-pub impl Show for Int with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 pub impl Show for Int with to_string(self) {
   Int::to_string(self)
-}
-
-///|
-pub impl Show for Int64 with output(self, logger) {
-  logger.write_string(self.to_string())
 }
 
 ///|
@@ -57,18 +42,8 @@ pub impl Show for Int64 with to_string(self) {
 }
 
 ///|
-pub impl Show for UInt with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 pub impl Show for UInt with to_string(self) {
   UInt::to_string(self)
-}
-
-///|
-pub impl Show for UInt64 with output(self, logger) {
-  logger.write_string(self.to_string())
 }
 
 ///|
@@ -77,18 +52,8 @@ pub impl Show for UInt64 with to_string(self) {
 }
 
 ///|
-pub impl Show for Byte with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 pub impl Show for Byte with to_string(self) {
   Byte::to_string(self)
-}
-
-///|
-pub impl Show for UInt16 with output(self, logger) {
-  logger.write_string(self.to_string())
 }
 
 ///|

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -151,9 +151,8 @@ pub fn StringBuilder::to_string(self : StringBuilder) -> String {
 }
 
 ///|
-/// TODO: improve perf
-pub impl Show for StringBuilder with output(self, logger) {
-  logger.write_string(self.to_string())
+pub impl Show for StringBuilder with to_string(self) {
+  StringBuilder::to_string(self)
 }
 
 ///|

--- a/error/error.mbt
+++ b/error/error.mbt
@@ -16,29 +16,8 @@
 fn Error::to_string(self : Error) -> String = "%error.to_string"
 
 ///|
-/// Implements `Show` trait for `Error` type by converting the error into a
-/// string representation.
-///
-/// Parameters:
-///
-/// * `self`: The error value to be converted.
-/// * `logger`: A buffer that accumulates the string representation.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let error : Error = Failure::Failure("test error")
-///   inspect(
-///     error,
-///     content=(
-///       #|Failure("test error")
-///     ),
-///   )
-/// }
-/// ```
-pub impl Show for Error with output(self, logger) {
-  logger.write_string(self.to_string())
+pub impl Show for Error with to_string(self) {
+  Error::to_string(self)
 }
 
 ///|

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -13,27 +13,6 @@
 // limitations under the License.
 
 ///|
-/// Converts a floating-point number to its string representation.
-///
-/// Parameters:
-///
-/// * `self` : The floating-point number to be converted.
-/// * `logger` : The logger to write the string representation to.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let f : Float = 3.14
-///   let s = f.to_double().to_string()
-///   inspect(s, content="3.140000104904175")
-/// }
-/// ```
-pub impl Show for Float with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 pub impl Show for Float with to_string(self) {
   self.to_double().to_string()
 }

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -126,11 +126,6 @@ pub impl ToJson for Int16 with to_json(self : Int16) -> Json {
 }
 
 ///|
-pub impl Show for Int16 with output(self, logger) {
-  logger.write_string(self.to_string())
-}
-
-///|
 pub impl Show for Int16 with to_string(self) {
   Int16::to_string(self)
 }


### PR DESCRIPTION
## Summary
- The default `Show::output` is `logger.write_string(self.to_string())`. Drop the output overrides for types that already have an explicit `Show::to_string` impl: `Bool`, `Int`, `Int64`, `UInt`, `UInt64`, `Byte`, `UInt16`, `Int16`, `Float`, `Double`.
- For `BigInt`, `Error`, and `StringBuilder` — which previously satisfied `Show` via an `output` impl plus a regular `to_string` method — replace the redundant `output` impl with an explicit `Show::to_string` impl so `must_implement_one` is still satisfied while the default `output` kicks in.

Net diff: +9 / -124.

## Test plan
- [x] `moon check --target all`
- [x] `moon test` (wasm-gc): 6424/6424 passing
- [x] `moon test --target js`: 6383/6383 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)