### PR TITLE
[codex] Optimize Array::push ownership

### DIFF
--- a/builtin/array_push_bench_test.mbt
+++ b/builtin/array_push_bench_test.mbt
@@ -1,0 +1,92 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let array_push_bench_size = 200_000
+
+///|
+priv struct ArrayPushBenchStruct {
+  x : Int
+  y : Int
+}
+
+///|
+fn make_array_push_bench_pairs() -> FixedArray[(Int, Int)] {
+  FixedArray::makei(array_push_bench_size, i => (i, i + 1))
+}
+
+///|
+fn make_array_push_bench_structs() -> FixedArray[ArrayPushBenchStruct] {
+  FixedArray::makei(array_push_bench_size, i => { x: i, y: i + 1 })
+}
+
+///|
+test "bench Array::push Int preallocated n=200000" (it : @bench.T) {
+  it.bench(
+    fn() {
+      let arr = Array::new(capacity=array_push_bench_size)
+      for i in 0..<array_push_bench_size {
+        arr.push(i)
+      }
+      it.keep(arr)
+    },
+    count=20,
+  )
+}
+
+///|
+test "bench Array::push Int growing n=200000" (it : @bench.T) {
+  it.bench(
+    fn() {
+      let arr : Array[Int] = []
+      for i in 0..<array_push_bench_size {
+        arr.push(i)
+      }
+      it.keep(arr)
+    },
+    count=20,
+  )
+}
+
+///|
+test "bench Array::push tuple preallocated n=200000" (it : @bench.T) {
+  let values = make_array_push_bench_pairs()
+  it.bench(
+    fn() {
+      let arr = Array::new(capacity=array_push_bench_size)
+      for i in 0..<array_push_bench_size {
+        arr.push(values[i])
+      }
+      it.keep(arr)
+    },
+    count=20,
+  )
+}
+
+///|
+test "bench Array::push struct preallocated n=200000" (it : @bench.T) {
+  let values = make_array_push_bench_structs()
+  let first = values[0]
+  it.keep(first.x + first.y)
+  it.bench(
+    fn() {
+      let arr = Array::new(capacity=array_push_bench_size)
+      for i in 0..<array_push_bench_size {
+        arr.push(values[i])
+      }
+      it.keep(arr)
+    },
+    count=20,
+  )
+}

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -126,6 +126,7 @@ fn[T] Array::buffer(self : Array[T]) -> UninitializedArray[T] {
 }
 
 ///|
+#borrow(self)
 fn[T] Array::resize_buffer(self : Array[T], new_capacity : Int) -> Unit {
   let new_buf = UninitializedArray::make(new_capacity)
   let old_buf = self.buf
@@ -179,8 +180,9 @@ test "Array::resize_buffer" {
 
 ///|
 /// Reallocate the array with a new capacity.
+#borrow(self)
 fn[T] Array::realloc(self : Array[T]) -> Unit {
-  let old_cap = self.length()
+  let old_cap = self.len
   let new_cap = if old_cap == 0 { 8 } else { old_cap * 2 }
   self.resize_buffer(new_cap)
 }
@@ -239,12 +241,14 @@ pub fn[T] Array::shrink_to_fit(self : Array[T]) -> Unit {
 ///   v.push(3)
 /// }
 /// ```
+#borrow(self)
+#owned(value)
 pub fn[T] Array::push(self : Array[T], value : T) -> Unit {
-  if self.length() == self.buffer().0.length() {
+  if self.len == self.buf.0.length() {
     self.realloc()
   }
-  let length = self.length()
-  self.unsafe_set(length, value)
+  let length = self.len
+  self.buf.0.unsafe_set(length, unsafe_maybe_uninit(value))
   self.len = length + 1
 }
 

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -16,6 +16,10 @@
 struct UninitializedArray[T](FixedArray[UnsafeMaybeUninit[T]])
 
 ///|
+#owned(value)
+fn[T] unsafe_maybe_uninit(value : T) -> UnsafeMaybeUninit[T] = "%identity"
+
+///|
 /// Creates an uninitialized array of the specified size.
 ///
 /// Parameters:


### PR DESCRIPTION
## Summary

- Mark the non-JS `Array::push` receiver as borrowed and the appended value as owned.
- Avoid hot-path `length()`/`buffer()` helper calls by reading the private `len` and `buf` fields directly.
- Write through the backing fixed array with an internal `UnsafeMaybeUninit` identity conversion, avoiding the public `Array::unsafe_set` path and its extra helper/bounds work.
- Add focused native-release benchmarks for preallocated integer push, growing integer push, preallocated tuple push, and preallocated struct push.

## Generated C inspection

For `Array[Int]::push`, the optimized native release C hot path contains direct field reads, capacity comparison, direct buffer write, and length update. It has no `moonbit_incref` or `moonbit_decref` calls unless the reallocation branch is taken.

For reference-element instantiations, including an explicit `ArrayPushBenchStruct`, generated C still emits old-slot decref logic for the fixed-array assignment, for example a null check followed by `moonbit_decref(old)`. That appears to come from fixed-array assignment semantics for reference-containing element types. Removing that last call for reference arrays would likely need a compiler/runtime primitive for writing into known-uninitialized storage without dropping the previous slot contents.

## Benchmarks

Command used for each pass:

```sh
moon bench --target native --release -p builtin -f array_push_bench_test.mbt --no-parallelize
```

Baseline, three runs on `origin/main` implementation plus the benchmark file before adding the struct case:

| benchmark | baseline means |
| --- | --- |
| `Array::push Int preallocated n=200000` | 286.89 us, 286.42 us, 287.51 us |
| `Array::push Int growing n=200000` | 481.61 us, 480.30 us, 480.90 us |
| `Array::push tuple preallocated n=200000` | 921.64 us, 924.64 us, 912.56 us |

Optimized implementation, three runs before rebase:

| benchmark | optimized means |
| --- | --- |
| `Array::push Int preallocated n=200000` | 73.92 us, 72.05 us, 72.13 us |
| `Array::push Int growing n=200000` | 266.33 us, 261.93 us, 267.80 us |
| `Array::push tuple preallocated n=200000` | 315.45 us, 306.56 us, 310.55 us |

Final rebased validation benchmark after adding the explicit struct case:

| benchmark | mean |
| --- | --- |
| `Array::push Int preallocated n=200000` | 73.34 us +/- 0.85 us |
| `Array::push Int growing n=200000` | 266.59 us +/- 3.08 us |
| `Array::push tuple preallocated n=200000` | 313.94 us +/- 5.01 us |
| `Array::push struct preallocated n=200000` | 313.64 us +/- 4.58 us |

## Validation

- `moon fmt`
- `moon info`
- `moon check builtin`
- `moon test --target native builtin --filter 'Array::resize_buffer'`
- `moon test`
- benchmark command above