### PR TITLE
feat: add write method for StringBuilder/Logger

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -447,6 +447,7 @@ pub fn StringBuilder::new(size_hint? : Int) -> Self
 pub fn StringBuilder::reset(Self) -> Unit
 pub fn StringBuilder::to_string(Self) -> String
 pub fn StringBuilder::write_iter(Self, Iter[Char]) -> Unit
+#alias(write)
 pub fn[T : Show] StringBuilder::write_object(Self, T) -> Unit
 pub fn StringBuilder::write_stringview(Self, StringView) -> Unit
 pub impl Logger for StringBuilder
@@ -1276,6 +1277,7 @@ pub(open) trait Logger {
   write_substring(Self, String, Int, Int) -> Unit = _
   write_view(Self, StringView) -> Unit = _
   write_char(Self, Char) -> Unit = _
+  write(Self, &Show) -> Unit = _
 }
 pub fn[T : Show] &Logger::write_iter(Self, Iter[T], prefix? : String, suffix? : String, sep? : String, trailing? : Bool) -> Unit
 pub fn[Obj : Show] &Logger::write_object(Self, Obj) -> Unit

--- a/builtin/stringbuilder.mbt
+++ b/builtin/stringbuilder.mbt
@@ -14,6 +14,7 @@
 
 ///|
 /// Writes the string representation of an object to the StringBuilder.
+#alias(write)
 pub fn[T : Show] StringBuilder::write_object(
   self : StringBuilder,
   obj : T,

--- a/builtin/stringbuilder_test.mbt
+++ b/builtin/stringbuilder_test.mbt
@@ -107,3 +107,10 @@ test "panic StringBuilder::write_char with invalid code point" {
   let sb = StringBuilder::new()
   sb.write_char((0x110000).unsafe_to_char()) |> ignore
 }
+
+///|
+test "StringBuilder::write" {
+  let sb = StringBuilder::new()
+  sb.write("abc\n")
+  assert_eq(sb.to_string(), "\"abc\\n\"")
+}

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -103,6 +103,12 @@ pub(open) trait Logger {
   write_view(Self, StringView) -> Unit = _
   /// Writes a character to the logger.
   write_char(Self, Char) -> Unit = _
+  write(Self, &Show) -> Unit = _
+}
+
+///|
+impl Logger with write(self, show) {
+  show.output(self)
 }
 
 ///|


### PR DESCRIPTION
Add `write` method to StringBuilder and Logger, make it possible to use the experimental syntax in the future:


```
let builder = StringBuilder::new()
builder <+ "abc\{x}"
```

```
impl Show for Pos with output(self, logger) {
  logger <+ "(\{self.x}, {self.y})"
}
```

@bobzhang 