### PR TITLE
use borrow convention in CI

### DIFF
--- a/.github/workflows/bleeding-check.yml
+++ b/.github/workflows/bleeding-check.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  MOONC_RC_CONVENTION: borrow
+
 jobs:
   nightly-check:
     continue-on-error: true

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -7,6 +7,9 @@ on:
       - "pre-release*"
   pull_request:
 
+env:
+  MOONC_RC_CONVENTION: borrow
+
 jobs:
   version-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/stable-check.yml
+++ b/.github/workflows/stable-check.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   merge_group:
 
+env:
+  MOONC_RC_CONVENTION: borrow
+
 jobs:
   stable-check:
     strategy:


### PR DESCRIPTION
A couple versions ago, `moonc` introduced an experimental environment variable `MOONC_RC_CONVENTION`, whose value can be `owned` or `borrow`, and will switch the default calling convention for reference counting globally. The two conventions are both faster in some cases and slower in others. For one of the most common scenarios, processing mutable data structures such as `Array`, borrow is usually faster. So we are evaluating switching the default convention to borrow (currently the default conventions is owned). This PR uses borrow convention for CI on core, so that we can have more testing on the newly introduced borrow-by-default feature.