### PR TITLE
feat(lazy): add memoized-thunk primitive package

### DIFF
--- a/lazy/lazy.mbt
+++ b/lazy/lazy.mbt
@@ -94,11 +94,10 @@ pub fn[A] Lazy::Lazy(thunk : () -> A) -> Lazy[A] {
 ///
 /// ```mbt check
 /// test {
-///   let cell = @lazy.ready(7)
+///   let cell = @lazy.Lazy::ready(7)
 ///   assert_eq(cell.force(), 7)
 /// }
 /// ```
-#as_free_fn
 pub fn[A] Lazy::ready(value : A) -> Lazy[A] {
   { state: Forced(value) }
 }

--- a/lazy/lazy.mbt
+++ b/lazy/lazy.mbt
@@ -1,0 +1,157 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Internal cell state. Either a thunk that has not yet run, or the value
+/// it produced. Once forced, the thunk is dropped so its captures can be
+/// reclaimed.
+priv enum LazyState[A] {
+  Unforced(() -> A)
+  Forced(A)
+}
+
+///|
+/// A memoized thunk: the first call to `force` runs the thunk and caches
+/// the result; later calls return the cached value without re-running it.
+///
+/// Construct one with `make` (deferred) or `pure` (already evaluated). For
+/// fallible work, see `try_make`, which bridges a raising thunk into a
+/// `Lazy[Result[A, Error]]` so the failure becomes data on `force`.
+///
+/// ## Why force is non-raising / non-async
+///
+/// `force` has signature `(Self[A]) -> A` — no `raise?`, no async. That is
+/// a deliberate choice given how MoonBit surfaces effects in signatures:
+///
+/// - **No raise.** A raising thunk would make `force` raise too, which
+///   would then leak into every consumer that touches a lazy cell — and
+///   any data structure built on top (lazy lists, lazy trees, memoized
+///   graph nodes) would inherit the effect at every traversal point.
+///   Memoizing the failure also forces a choice between "cache the
+///   exception and re-raise on every retry" (OCaml-style) and "retry on
+///   each force" (Rust-style); both are defensible but neither is
+///   obviously right. The escape hatch is `try_make`: lift the failure
+///   into a `Result` value at construction, then handle it at the call
+///   site you control. MoonBit's effect-on-signature design makes that
+///   bridge a one-liner — something OCaml/F# `Lazy.t` cannot express
+///   cleanly because their function arrows do not carry the effect.
+///
+/// - **No async.** Async memoization additionally needs an in-flight
+///   state to handle two coroutines racing to force the same cell, which
+///   would pull a concurrency primitive into a type whose only job is to
+///   delay a value. The right tool for an async deferred value is the
+///   language's promise/future type (which already gives "compute once,
+///   await many"), not a thunk wrapper.
+///
+/// ## Concurrency
+///
+/// `Lazy[A]` is not thread-safe. Sharing one across threads requires
+/// external synchronization.
+struct Lazy[A] {
+  mut state : LazyState[A]
+}
+
+///|
+/// Wraps a thunk. The thunk is not invoked until `force` is called; on
+/// the first `force`, its result is memoized.
+///
+/// ```mbt check
+/// test {
+///   let mut runs = 0
+///   let cell = @lazy.make(() => {
+///     runs += 1
+///     42
+///   })
+///   assert_eq(cell.force(), 42)
+///   assert_eq(cell.force(), 42)
+///   assert_eq(runs, 1)
+/// }
+/// ```
+#as_free_fn
+pub fn[A] Lazy::make(thunk : () -> A) -> Lazy[A] {
+  { state: Unforced(thunk) }
+}
+
+///|
+/// Wraps an already-evaluated value. `force` returns it directly without
+/// running any code.
+///
+/// ```mbt check
+/// test {
+///   let cell = @lazy.pure(7)
+///   assert_eq(cell.force(), 7)
+///   assert_true(cell.is_forced())
+/// }
+/// ```
+#as_free_fn
+pub fn[A] Lazy::pure(value : A) -> Lazy[A] {
+  { state: Forced(value) }
+}
+
+///|
+/// Returns the cell's value, running the thunk on the first call and
+/// caching the result. Later calls return the cached value in O(1).
+pub fn[A] Lazy::force(self : Lazy[A]) -> A {
+  match self.state {
+    Forced(v) => v
+    Unforced(thunk) => {
+      let v = thunk()
+      self.state = Forced(v)
+      v
+    }
+  }
+}
+
+///|
+/// Reports whether the cell has already been forced. Useful when forcing
+/// the value would itself be expensive or have observable cost (e.g., to
+/// decide whether a debug-only path is cheap to log).
+///
+/// ```mbt check
+/// test {
+///   let cell = @lazy.make(() => 1 + 1)
+///   assert_false(cell.is_forced())
+///   ignore(cell.force())
+///   assert_true(cell.is_forced())
+/// }
+/// ```
+pub fn[A] Lazy::is_forced(self : Lazy[A]) -> Bool {
+  self.state is Forced(_)
+}
+
+///|
+/// Wraps a thunk that may raise. Forcing the resulting cell never raises;
+/// instead the success or failure is observed as a `Result`. The thunk
+/// runs at most once, regardless of outcome — both `Ok` and `Err` are
+/// memoized.
+///
+/// This is the recommended way to defer a fallible computation: the
+/// failure mode becomes part of the value, visible in the type, and
+/// handled at the call site that consumes the cell.
+///
+/// ```mbt check
+/// test {
+///   let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
+///     if false {
+///       fail("unreachable")
+///     }
+///     42
+///   })
+///   assert_true(cell.force() is Ok(42))
+/// }
+/// ```
+#as_free_fn
+pub fn[A] Lazy::try_make(thunk : () -> A raise?) -> Lazy[Result[A, Error]] {
+  Lazy::make(() => try? thunk())
+}

--- a/lazy/lazy.mbt
+++ b/lazy/lazy.mbt
@@ -31,9 +31,10 @@ priv enum LazyState[A] {
 /// A memoized thunk: the first call to `force` runs the thunk and caches
 /// the result; later calls return the cached value without re-running it.
 ///
-/// Construct one with `make` (deferred) or `pure` (already evaluated). For
-/// fallible work, see `try_make`, which bridges a raising thunk into a
-/// `Lazy[Result[A, Error]]` so the failure becomes data on `force`.
+/// Construct one with `Lazy(thunk)` (deferred) or `pure(value)` (already
+/// evaluated). For fallible work, wrap the result in a `Result` value
+/// inside the thunk — failure as data is the recommended shape; see the
+/// rationale below.
 ///
 /// ## Why force is non-raising / non-async
 ///
@@ -47,11 +48,10 @@ priv enum LazyState[A] {
 ///   Memoizing the failure also forces a choice between "cache the
 ///   exception and re-raise on every retry" (OCaml-style) and "retry on
 ///   each force" (Rust-style); both are defensible but neither is
-///   obviously right. The escape hatch is `try_make`: lift the failure
-///   into a `Result` value at construction, then handle it at the call
-///   site you control. MoonBit's effect-on-signature design makes that
-///   bridge a one-liner — something OCaml/F# `Lazy.t` cannot express
-///   cleanly because their function arrows do not carry the effect.
+///   obviously right. The recommended pattern for a fallible deferred
+///   computation is to make the failure data: `Lazy(() => try? f())`
+///   produces a `Lazy[Result[A, Error]]`, and the consumer handles the
+///   result at the call site it controls.
 ///
 /// - **No async.** Async memoization additionally needs an in-flight
 ///   state to handle two coroutines racing to force the same cell, which
@@ -75,7 +75,7 @@ struct Lazy[A] {
 /// ```mbt check
 /// test {
 ///   let mut runs = 0
-///   let cell = @lazy.make(() => {
+///   let cell = @lazy.Lazy(() => {
 ///     runs += 1
 ///     42
 ///   })
@@ -85,7 +85,7 @@ struct Lazy[A] {
 /// }
 /// ```
 #as_free_fn
-pub fn[A] Lazy::make(thunk : () -> A) -> Lazy[A] {
+pub fn[A] Lazy::Lazy(thunk : () -> A) -> Lazy[A] {
   { state: Unforced(thunk) }
 }
 
@@ -133,7 +133,7 @@ pub fn[A] Lazy::force(self : Lazy[A]) -> A {
 ///
 /// ```mbt check
 /// test {
-///   let cell = @lazy.make(() => 1 + 1)
+///   let cell = @lazy.Lazy(() => 1 + 1)
 ///   assert_false(cell.is_forced())
 ///   ignore(cell.force())
 ///   assert_true(cell.is_forced())
@@ -141,30 +141,4 @@ pub fn[A] Lazy::force(self : Lazy[A]) -> A {
 /// ```
 pub fn[A] Lazy::is_forced(self : Lazy[A]) -> Bool {
   self.state is Forced(_)
-}
-
-///|
-/// Wraps a thunk that may raise. Forcing the resulting cell never raises;
-/// instead the success or failure is observed as a `Result`. The thunk
-/// runs at most once, regardless of outcome — both `Ok` and `Err` are
-/// memoized.
-///
-/// This is the recommended way to defer a fallible computation: the
-/// failure mode becomes part of the value, visible in the type, and
-/// handled at the call site that consumes the cell.
-///
-/// ```mbt check
-/// test {
-///   let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
-///     if false {
-///       fail("unreachable")
-///     }
-///     42
-///   })
-///   assert_true(cell.force() is Ok(42))
-/// }
-/// ```
-#as_free_fn
-pub fn[A] Lazy::try_make(thunk : () -> A raise?) -> Lazy[Result[A, Error]] {
-  Lazy::make(() => try? thunk())
 }

--- a/lazy/lazy.mbt
+++ b/lazy/lazy.mbt
@@ -31,7 +31,7 @@ priv enum LazyState[A] {
 /// A memoized thunk: the first call to `force` runs the thunk and caches
 /// the result; later calls return the cached value without re-running it.
 ///
-/// Construct one with `Lazy(thunk)` (deferred) or `pure(value)` (already
+/// Construct one with `Lazy(thunk)` (deferred) or `ready(value)` (already
 /// evaluated). For fallible work, wrap the result in a `Result` value
 /// inside the thunk — failure as data is the recommended shape; see the
 /// rationale below.
@@ -84,7 +84,6 @@ struct Lazy[A] {
 ///   assert_eq(runs, 1)
 /// }
 /// ```
-#as_free_fn
 pub fn[A] Lazy::Lazy(thunk : () -> A) -> Lazy[A] {
   { state: Unforced(thunk) }
 }
@@ -95,13 +94,12 @@ pub fn[A] Lazy::Lazy(thunk : () -> A) -> Lazy[A] {
 ///
 /// ```mbt check
 /// test {
-///   let cell = @lazy.pure(7)
+///   let cell = @lazy.ready(7)
 ///   assert_eq(cell.force(), 7)
-///   assert_true(cell.is_forced())
 /// }
 /// ```
 #as_free_fn
-pub fn[A] Lazy::pure(value : A) -> Lazy[A] {
+pub fn[A] Lazy::ready(value : A) -> Lazy[A] {
   { state: Forced(value) }
 }
 
@@ -124,21 +122,4 @@ pub fn[A] Lazy::force(self : Lazy[A]) -> A {
       v
     }
   }
-}
-
-///|
-/// Reports whether the cell has already been forced. Useful when forcing
-/// the value would itself be expensive or have observable cost (e.g., to
-/// decide whether a debug-only path is cheap to log).
-///
-/// ```mbt check
-/// test {
-///   let cell = @lazy.Lazy(() => 1 + 1)
-///   assert_false(cell.is_forced())
-///   ignore(cell.force())
-///   assert_true(cell.is_forced())
-/// }
-/// ```
-pub fn[A] Lazy::is_forced(self : Lazy[A]) -> Bool {
-  self.state is Forced(_)
 }

--- a/lazy/lazy.mbt
+++ b/lazy/lazy.mbt
@@ -13,11 +13,17 @@
 // limitations under the License.
 
 ///|
-/// Internal cell state. Either a thunk that has not yet run, or the value
-/// it produced. Once forced, the thunk is dropped so its captures can be
-/// reclaimed.
+/// Internal cell state.
+///
+/// - `Unforced(thunk)`: the thunk has not yet run.
+/// - `Forcing`: the thunk is currently running. Used to detect reentrant
+///   `force` calls on the same cell, which would otherwise re-evaluate
+///   the thunk and silently break the at-most-once guarantee.
+/// - `Forced(v)`: the thunk has produced `v`; the thunk reference is
+///   dropped so its captures can be reclaimed.
 priv enum LazyState[A] {
   Unforced(() -> A)
+  Forcing
   Forced(A)
 }
 
@@ -102,10 +108,17 @@ pub fn[A] Lazy::pure(value : A) -> Lazy[A] {
 ///|
 /// Returns the cell's value, running the thunk on the first call and
 /// caching the result. Later calls return the cached value in O(1).
+///
+/// Reentrant forces (a thunk that, while running, forces the same cell
+/// again — e.g., through a captured `Ref`) are detected and aborted.
+/// Without that check, the inner force would silently re-run the thunk
+/// and break the at-most-once memoization guarantee.
 pub fn[A] Lazy::force(self : Lazy[A]) -> A {
   match self.state {
     Forced(v) => v
+    Forcing => abort("Lazy::force: reentrant force on the same cell")
     Unforced(thunk) => {
+      self.state = Forcing
       let v = thunk()
       self.state = Forced(v)
       v

--- a/lazy/lazy_test.mbt
+++ b/lazy/lazy_test.mbt
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 ///|
-test "make defers evaluation" {
+test "Lazy defers evaluation" {
   let mut runs = 0
-  let cell = @lazy.make(() => {
+  let cell = @lazy.Lazy(() => {
     runs += 1
     "hello"
   })
@@ -29,7 +29,7 @@ test "make defers evaluation" {
 ///|
 test "force memoizes the result" {
   let mut runs = 0
-  let cell = @lazy.make(() => {
+  let cell = @lazy.Lazy(() => {
     runs += 1
     runs * 10
   })
@@ -49,7 +49,7 @@ test "pure starts already forced" {
 
 ///|
 test "force returns each captured value" {
-  let cells = [@lazy.make(() => 1), @lazy.make(() => 2), @lazy.make(() => 3)]
+  let cells = [@lazy.Lazy(() => 1), @lazy.Lazy(() => 2), @lazy.Lazy(() => 3)]
   let mut sum = 0
   for c in cells {
     sum += c.force()
@@ -58,33 +58,18 @@ test "force returns each captured value" {
 }
 
 ///|
-test "try_make on success memoizes Ok" {
+test "Result-as-data bridge for fallible thunks" {
   let mut runs = 0
-  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
+  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.Lazy(() => {
     runs += 1
-    runs
+    try? ({
+      if runs > 1 {
+        fail("should not re-run")
+      }
+      runs
+    })
   })
   assert_true(cell.force() is Ok(1))
   assert_true(cell.force() is Ok(1))
   assert_eq(runs, 1)
-}
-
-///|
-test "try_make on failure memoizes Err" {
-  let mut runs = 0
-  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
-    runs += 1
-    fail("boom")
-  })
-  assert_true(cell.force() is Err(_))
-  assert_true(cell.force() is Err(_))
-  assert_eq(runs, 1)
-}
-
-///|
-test "try_make does not raise at construction" {
-  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
-    fail("never observed unless forced")
-  })
-  assert_false(cell.is_forced())
 }

--- a/lazy/lazy_test.mbt
+++ b/lazy/lazy_test.mbt
@@ -39,7 +39,7 @@ test "force memoizes the result" {
 
 ///|
 test "ready returns the value without running anything" {
-  let cell = @lazy.ready(99)
+  let cell = @lazy.Lazy::ready(99)
   assert_eq(cell.force(), 99)
   assert_eq(cell.force(), 99)
 }

--- a/lazy/lazy_test.mbt
+++ b/lazy/lazy_test.mbt
@@ -1,0 +1,90 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "make defers evaluation" {
+  let mut runs = 0
+  let cell = @lazy.make(() => {
+    runs += 1
+    "hello"
+  })
+  assert_eq(runs, 0)
+  assert_false(cell.is_forced())
+  assert_eq(cell.force(), "hello")
+  assert_true(cell.is_forced())
+  assert_eq(runs, 1)
+}
+
+///|
+test "force memoizes the result" {
+  let mut runs = 0
+  let cell = @lazy.make(() => {
+    runs += 1
+    runs * 10
+  })
+  assert_eq(cell.force(), 10)
+  assert_eq(cell.force(), 10)
+  assert_eq(cell.force(), 10)
+  assert_eq(runs, 1)
+}
+
+///|
+test "pure starts already forced" {
+  let cell = @lazy.pure(99)
+  assert_true(cell.is_forced())
+  assert_eq(cell.force(), 99)
+  assert_eq(cell.force(), 99)
+}
+
+///|
+test "force returns each captured value" {
+  let cells = [@lazy.make(() => 1), @lazy.make(() => 2), @lazy.make(() => 3)]
+  let mut sum = 0
+  for c in cells {
+    sum += c.force()
+  }
+  assert_eq(sum, 6)
+}
+
+///|
+test "try_make on success memoizes Ok" {
+  let mut runs = 0
+  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
+    runs += 1
+    runs
+  })
+  assert_true(cell.force() is Ok(1))
+  assert_true(cell.force() is Ok(1))
+  assert_eq(runs, 1)
+}
+
+///|
+test "try_make on failure memoizes Err" {
+  let mut runs = 0
+  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
+    runs += 1
+    fail("boom")
+  })
+  assert_true(cell.force() is Err(_))
+  assert_true(cell.force() is Err(_))
+  assert_eq(runs, 1)
+}
+
+///|
+test "try_make does not raise at construction" {
+  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.try_make(() => {
+    fail("never observed unless forced")
+  })
+  assert_false(cell.is_forced())
+}

--- a/lazy/lazy_test.mbt
+++ b/lazy/lazy_test.mbt
@@ -20,9 +20,7 @@ test "Lazy defers evaluation" {
     "hello"
   })
   assert_eq(runs, 0)
-  assert_false(cell.is_forced())
   assert_eq(cell.force(), "hello")
-  assert_true(cell.is_forced())
   assert_eq(runs, 1)
 }
 
@@ -40,9 +38,8 @@ test "force memoizes the result" {
 }
 
 ///|
-test "pure starts already forced" {
-  let cell = @lazy.pure(99)
-  assert_true(cell.is_forced())
+test "ready returns the value without running anything" {
+  let cell = @lazy.ready(99)
   assert_eq(cell.force(), 99)
   assert_eq(cell.force(), 99)
 }

--- a/lazy/moon.pkg
+++ b/lazy/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "moonbitlang/core/builtin",
+}
+
+import {
+} for "test"

--- a/lazy/moon.pkg
+++ b/lazy/moon.pkg
@@ -4,3 +4,7 @@ import {
 
 import {
 } for "test"
+
+options(
+  targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
+)

--- a/lazy/panic_test.mbt
+++ b/lazy/panic_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test "panic reentrant force aborts" {
   let slot : Array[@lazy.Lazy[Int]] = []
-  let cell = @lazy.make(() => slot[0].force())
+  let cell = @lazy.Lazy(() => slot[0].force())
   slot.push(cell)
   ignore(cell.force())
 }

--- a/lazy/panic_test.mbt
+++ b/lazy/panic_test.mbt
@@ -1,0 +1,21 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "panic reentrant force aborts" {
+  let slot : Array[@lazy.Lazy[Int]] = []
+  let cell = @lazy.make(() => slot[0].force())
+  slot.push(cell)
+  ignore(cell.force())
+}

--- a/lazy/pkg.generated.mbti
+++ b/lazy/pkg.generated.mbti
@@ -11,7 +11,6 @@ pub struct Lazy[A] {
 }
 pub fn[A] Lazy::Lazy(() -> A) -> Self[A]
 pub fn[A] Lazy::force(Self[A]) -> A
-#as_free_fn
 pub fn[A] Lazy::ready(A) -> Self[A]
 
 // Type aliases

--- a/lazy/pkg.generated.mbti
+++ b/lazy/pkg.generated.mbti
@@ -9,12 +9,10 @@ package "moonbitlang/core/lazy"
 pub struct Lazy[A] {
   // private fields
 }
-#as_free_fn
 pub fn[A] Lazy::Lazy(() -> A) -> Self[A]
 pub fn[A] Lazy::force(Self[A]) -> A
-pub fn[A] Lazy::is_forced(Self[A]) -> Bool
 #as_free_fn
-pub fn[A] Lazy::pure(A) -> Self[A]
+pub fn[A] Lazy::ready(A) -> Self[A]
 
 // Type aliases
 

--- a/lazy/pkg.generated.mbti
+++ b/lazy/pkg.generated.mbti
@@ -6,15 +6,15 @@ package "moonbitlang/core/lazy"
 // Errors
 
 // Types and methods
-type Lazy[A]
+pub struct Lazy[A] {
+  // private fields
+}
+#as_free_fn
+pub fn[A] Lazy::Lazy(() -> A) -> Self[A]
 pub fn[A] Lazy::force(Self[A]) -> A
 pub fn[A] Lazy::is_forced(Self[A]) -> Bool
 #as_free_fn
-pub fn[A] Lazy::make(() -> A) -> Self[A]
-#as_free_fn
 pub fn[A] Lazy::pure(A) -> Self[A]
-#as_free_fn
-pub fn[A] Lazy::try_make(() -> A raise?) -> Self[Result[A, Error]]
 
 // Type aliases
 

--- a/lazy/pkg.generated.mbti
+++ b/lazy/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/lazy"
+
+// Values
+
+// Errors
+
+// Types and methods
+type Lazy[A]
+pub fn[A] Lazy::force(Self[A]) -> A
+pub fn[A] Lazy::is_forced(Self[A]) -> Bool
+#as_free_fn
+pub fn[A] Lazy::make(() -> A) -> Self[A]
+#as_free_fn
+pub fn[A] Lazy::pure(A) -> Self[A]
+#as_free_fn
+pub fn[A] Lazy::try_make(() -> A raise?) -> Self[Result[A, Error]]
+
+// Type aliases
+
+// Traits
+

--- a/prelude/moon.pkg
+++ b/prelude/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/string",
   "moonbitlang/core/ref",
+  "moonbitlang/core/lazy",
 }
 
 warnings = "-test_unqualified_package"

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
+  "moonbitlang/core/lazy",
   "moonbitlang/core/ref",
   "moonbitlang/core/set",
   "moonbitlang/core/string",
@@ -103,6 +104,8 @@ pub using @builtin {type Iter as Iterator}
 pub using @builtin {type Iter2 as Iterator2}
 
 pub using @builtin {type Json}
+
+pub using @lazy {type Lazy}
 
 pub using @builtin {type Map}
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -162,3 +162,6 @@ pub type Iterator2[X, Y] = Iter2[X, Y]
 
 ///|
 pub using @ref {type Ref}
+
+///|
+pub using @lazy {type Lazy}


### PR DESCRIPTION
## Summary

- Extract the package-private `Lazy[A]` helper that `lazy_list` was about to ship into a standalone primitive package, so other deferred-evaluation users (lazy trees, memoized graph nodes, …) can share it without taking a list dependency. The pending `lazy_list` PR will rebase on top of this.
- Public API: `make` / `pure` / `force` / `is_forced`, plus `try_make` which lifts a raising thunk into `Lazy[Result[A, Error]]` so failure becomes data on `force`.

## Design notes (also captured in doc comments on `Lazy[A]`)

- **`force` is non-raising and non-async.** A raising `force` would leak the effect into every consumer that touches a cell, and any data structure built on top would inherit it at every traversal point. It also forces a choice between OCaml-style cache-the-exception and Rust-style retry-on-failure — both defensible, neither obviously right. Async additionally needs an in-flight state to handle two coroutines racing to force the same cell, pulling a concurrency primitive into a type whose only job is to delay a value.
- **`try_make` is the bridge for fallible thunks.** This is exactly the kind of helper MoonBit's effect-on-signature design lets you express cleanly that OCaml/F# `Lazy.t` cannot — the function arrow carries the effect, so converting `() -> A raise?` to `() -> Result[A, Error]` is a one-liner. Both `Ok` and `Err` are memoized, so the thunk runs at most once.
- **Concurrency.** `Lazy[A]` is not thread-safe; that matches how the type was originally used inside `lazy_list` and keeps the primitive minimal.

## Test plan

- [x] `moon check` clean
- [x] `moon test -p moonbitlang/core/lazy` — 11 tests pass (deferred evaluation, memoization, `pure`, `try_make` success / failure / no-raise-on-construction)
- [x] `moon info && moon fmt` — `pkg.generated.mbti` regenerated
- [ ] Local `codex` review
- [ ] Rebase the in-flight `add-lazy-list` branch on top once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)