### PR TITLE
Optimize immutable vector contains

### DIFF
--- a/immut/vector/moon.pkg
+++ b/immut/vector/moon.pkg
@@ -7,6 +7,10 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
+} for "test"
+
+import {
   "moonbitlang/core/ref",
   "moonbitlang/core/test",
 } for "wbtest"

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -263,6 +263,25 @@ fn[A] Tree::each(self : Tree[A], f : (A) -> Unit raise?) -> Unit raise? {
 }
 
 ///|
+fn[A : Eq] Tree::contains(self : Tree[A], value : A) -> Bool {
+  match self {
+    Empty => false
+    Leaf(elems) =>
+      for elem in elems {
+        guard elem != value else { break true }
+      } nobreak {
+        false
+      }
+    Node(children, _) =>
+      for child in children {
+        guard !child.contains(value) else { break true }
+      } nobreak {
+        false
+      }
+  }
+}
+
+///|
 fn[A] Tree::iter(self : Tree[A]) -> Iter[A] {
   let mut curr_tree = self
   let mut curr_index = 0

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -260,8 +260,10 @@ pub fn[A] Vector::peek(self : Vector[A]) -> A? {
 /// }
 /// ```
 pub fn[A : Eq] Vector::contains(self : Vector[A], value : A) -> Bool {
-  // TODO: optimize this to scan the tree and tail directly instead of going through `iter`.
-  self.iter().contains(value)
+  if self.tree.contains(value) {
+    return true
+  }
+  self.tail.contains(value)
 }
 
 //-----------------------------------------------------------------------------

--- a/immut/vector/vector_contains_bench_test.mbt
+++ b/immut/vector/vector_contains_bench_test.mbt
@@ -1,0 +1,39 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let contains_bench_size = 100_000
+
+///|
+fn make_contains_bench_vector() -> @vector.Vector[Int] {
+  @vector.from_iter((0).until(contains_bench_size))
+}
+
+///|
+test "bench Vector::contains missing n=100000" (it : @bench.T) {
+  let data = make_contains_bench_vector()
+  it.bench(fn() { it.keep(data.contains(-1)) })
+}
+
+///|
+test "bench Vector::contains tree-end n=100000" (it : @bench.T) {
+  let data = make_contains_bench_vector()
+  it.bench(fn() { it.keep(data.contains(contains_bench_size - 33)) })
+}
+
+///|
+test "bench Vector::contains tail-end n=100000" (it : @bench.T) {
+  let data = make_contains_bench_vector()
+  it.bench(fn() { it.keep(data.contains(contains_bench_size - 1)) })
+}


### PR DESCRIPTION
## Summary
- scan immutable vector trees and tails directly in Vector::contains instead of going through Iter
- add focused Vector::contains benchmarks

## Benchmarks
Native backend, n=100000:

| case | before | after | speedup |
| --- | ---: | ---: | ---: |
| missing | 1.31 ms | 35.46 us | 36.94x |
| tree-end | 1.31 ms | 35.93 us | 36.46x |
| tail-end | 1.31 ms | 35.57 us | 36.83x |

## Validation
- moon check immut/vector --target all --target-dir /tmp/core-vector-contains-check
- moon test immut/vector --target all --target-dir /tmp/core-vector-contains-test
- moon bench --package immut/vector --target native --target-dir /tmp/core-vector-contains-bench-before
- moon bench --package immut/vector --target native --target-dir /tmp/core-vector-contains-bench-after
- moon fmt
- moon info
- git diff --check