### PR TITLE
Optimize immutable vector iterator

### DIFF
--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -282,37 +282,6 @@ fn[A : Eq] Tree::contains(self : Tree[A], value : A) -> Bool {
 }
 
 ///|
-fn[A] Tree::iter(self : Tree[A]) -> Iter[A] {
-  let mut curr_tree = self
-  let mut curr_index = 0
-  let parents = []
-  Iter::new(fn() {
-    for tree = curr_tree {
-      match tree {
-        Node(children, _) as t if curr_index < children.length() => {
-          let child = children.unsafe_get(curr_index)
-          parents.push((t, curr_index + 1))
-          curr_tree = child
-          curr_index = 0
-          continue child
-        }
-        Leaf(elems) if curr_index < elems.length() => {
-          let elem = elems.unsafe_get(curr_index)
-          curr_index += 1
-          break Some(elem)
-        }
-        _ if parents.pop() is Some((parent_tree, parent_index)) => {
-          curr_tree = parent_tree
-          curr_index = parent_index
-          continue parent_tree
-        }
-        _ => break None
-      }
-    }
-  })
-}
-
-///|
 /// For each element in the tree, apply the function `f` with the index of the element.
 fn[A] Tree::eachi(
   self : Tree[A],

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -479,10 +479,56 @@ pub impl[A] Add for Vector[A] with add(self, other) {
 /// Returns an iterator over the elements of the vector.
 #alias(iterator, deprecated)
 pub fn[A] Vector::iter(self : Vector[A]) -> Iter[A] {
-  let tree_iter = self.tree.iter()
-  let tail_iter = self.tail.iter()
-  let iter = tree_iter.concat(tail_iter)
-  Iter::new(() => iter.next(), size_hint=self.size)
+  let mut in_tree = true
+  let mut curr_tree = self.tree
+  let mut curr_index = 0
+  let parents = []
+  let mut tail_index = 0
+  Iter::new(
+    fn() {
+      let tree_result = if in_tree {
+        for tree = curr_tree {
+          match tree {
+            Node(children, _) as t if curr_index < children.length() => {
+              let child = children.unsafe_get(curr_index)
+              parents.push((t, curr_index + 1))
+              curr_tree = child
+              curr_index = 0
+              continue child
+            }
+            Leaf(elems) if curr_index < elems.length() => {
+              let elem = elems.unsafe_get(curr_index)
+              curr_index += 1
+              break Some(elem)
+            }
+            _ if parents.pop() is Some((parent_tree, parent_index)) => {
+              curr_tree = parent_tree
+              curr_index = parent_index
+              continue parent_tree
+            }
+            _ => {
+              in_tree = false
+              break None
+            }
+          }
+        }
+      } else {
+        None
+      }
+      match tree_result {
+        Some(_) => tree_result
+        None =>
+          if tail_index < self.tail.length() {
+            let elem = self.tail.unsafe_get(tail_index)
+            tail_index += 1
+            Some(elem)
+          } else {
+            None
+          }
+      }
+    },
+    size_hint=self.size,
+  )
 }
 
 ///|

--- a/immut/vector/vector_iter_bench_test.mbt
+++ b/immut/vector/vector_iter_bench_test.mbt
@@ -1,0 +1,56 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let vector_iter_bench_size = 100_000
+
+///|
+fn make_vector_iter_bench_vector() -> @vector.Vector[Int] {
+  @vector.from_iter((0).until(vector_iter_bench_size))
+}
+
+///|
+test "bench Vector::iter fold n=100000" (it : @bench.T) {
+  let data = make_vector_iter_bench_vector()
+  it.bench(fn() { it.keep(data.iter().fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench Vector::iter each n=100000" (it : @bench.T) {
+  let data = make_vector_iter_bench_vector()
+  it.bench(fn() {
+    let mut sum = 0
+    data.iter().each(x => sum += x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench Vector::iter to_array n=100000" (it : @bench.T) {
+  let data = make_vector_iter_bench_vector()
+  it.bench(fn() { it.keep(data.iter().to_array()) })
+}
+
+///|
+test "bench Vector::for-in n=100000" (it : @bench.T) {
+  let data = make_vector_iter_bench_vector()
+  it.bench(fn() {
+    let sum = for x in data; sum = 0 {
+      continue sum + x
+    } nobreak {
+      sum
+    }
+    it.keep(sum)
+  })
+}

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -147,6 +147,30 @@ test "iter" {
 }
 
 ///|
+test "iter tree and tail" {
+  let values = @vector.from_iter((0).until(70))
+  @debug.assert_eq(values.iter().to_array(), Array::makei(70, i => i))
+  inspect(values.iter().count(), content="70")
+}
+
+///|
+test "iter sliced tree and tail" {
+  let values = @vector.from_iter((0).until(96))
+  let sliced = values.slice(17, 83)
+  @debug.assert_eq(sliced.iter().to_array(), Array::makei(66, i => i + 17))
+  inspect(sliced.iter().count(), content="66")
+}
+
+///|
+test "iter concatenated vectors" {
+  let left = @vector.from_iter((0).until(45))
+  let right = @vector.from_iter((45).until(90))
+  let combined = left.concat(right)
+  @debug.assert_eq(combined.iter().to_array(), Array::makei(90, i => i))
+  inspect(combined.iter().count(), content="90")
+}
+
+///|
 test "length" {
   let v = @vector.from_array([1, 2, 3, 4, 5])
   let ve : @vector.Vector[Int] = @vector.new()


### PR DESCRIPTION
## Summary
- avoid composing vector iteration through Tree::iter, FixedArray::iter, and Iter::concat
- implement Vector::iter as a single state machine over the tree prefix and tail
- add focused vector iteration benchmarks

## Benchmarks
Native backend, n=100000:

| case | before | after | speedup |
| --- | ---: | ---: | ---: |
| iter().fold | 1.34 ms | 723.81 us | 1.85x |
| iter().each | 1.33 ms | 717.15 us | 1.85x |
| iter().to_array | 1.36 ms | 785.01 us | 1.73x |
| for x in vector | 1.33 ms | 726.79 us | 1.83x |

## Validation
- moon test immut/vector --target all --target-dir /tmp/core-vector-iter-test
- moon check immut/vector --target all --target-dir /tmp/core-vector-iter-check
- moon bench --package immut/vector --file vector_iter_bench_test.mbt --target native --target-dir /tmp/core-vector-iter-bench-before
- moon bench --package immut/vector --file vector_iter_bench_test.mbt --target native --target-dir /tmp/core-vector-iter-bench-after2
- moon fmt
- moon info
- git diff --check