### PR TITLE
refactor(builtin): rename StringBuilder::new to StringBuilder::StringBuilder

### DIFF
--- a/bench/README.mbt.md
+++ b/bench/README.mbt.md
@@ -140,7 +140,7 @@ test "string benchmarks" {
 
   // Benchmark StringBuilder (should be faster)
   bencher.bench(name="stringbuilder", fn() {
-    let builder = StringBuilder::new()
+    let builder = StringBuilder::StringBuilder()
     for _ in 0..<5 {
       builder.write_string("x")
     }

--- a/bench/README.mbt.md
+++ b/bench/README.mbt.md
@@ -140,7 +140,7 @@ test "string benchmarks" {
 
   // Benchmark StringBuilder (should be faster)
   bencher.bench(name="stringbuilder", fn() {
-    let builder = StringBuilder::StringBuilder()
+    let builder = StringBuilder()
     for _ in 0..<5 {
       builder.write_string("x")
     }

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -43,7 +43,7 @@ struct Bench {
 /// ```
 #as_free_fn
 pub fn Bench::new() -> Bench {
-  let buffer = StringBuilder::StringBuilder()
+  let buffer = StringBuilder()
   let summaries = []
   { buffer, summaries, _storage: @ref.new(()) }
 }

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -43,7 +43,7 @@ struct Bench {
 /// ```
 #as_free_fn
 pub fn Bench::new() -> Bench {
-  let buffer = StringBuilder::new()
+  let buffer = StringBuilder::StringBuilder()
   let summaries = []
   { buffer, summaries, _storage: @ref.new(()) }
 }

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -171,7 +171,7 @@ pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
   if signum == 0 {
     return 0N
   }
-  let str = StringBuilder::new()
+  let str = StringBuilder::StringBuilder()
   str.write_string("0x")
   for octet in octets {
     str.write_string(hex2(octet))

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -171,7 +171,7 @@ pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
   if signum == 0 {
     return 0N
   }
-  let str = StringBuilder::StringBuilder()
+  let str = StringBuilder()
   str.write_string("0x")
   for octet in octets {
     str.write_string(hex2(octet))

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1067,7 +1067,7 @@ fn BigInt::to_string_radix(self : BigInt, radix : Int) -> String {
           break
         }
       }
-      let builder = StringBuilder::new(
+      let builder = StringBuilder::StringBuilder(
         size_hint=digits.length() + (if is_negative { 1 } else { 0 }),
       )
       if is_negative {
@@ -1087,7 +1087,7 @@ fn BigInt::to_string_radix_pow2(self : BigInt, shift : Int) -> String {
   let value = if is_negative { -self } else { self }
   let bit_len = value.bit_length()
   let digit_len = (bit_len + shift - 1) / shift
-  let builder = StringBuilder::new(
+  let builder = StringBuilder::StringBuilder(
     size_hint=digit_len + (if is_negative { 1 } else { 0 }),
   )
   if is_negative {

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1067,7 +1067,7 @@ fn BigInt::to_string_radix(self : BigInt, radix : Int) -> String {
           break
         }
       }
-      let builder = StringBuilder::StringBuilder(
+      let builder = StringBuilder(
         size_hint=digits.length() + (if is_negative { 1 } else { 0 }),
       )
       if is_negative {
@@ -1087,7 +1087,7 @@ fn BigInt::to_string_radix_pow2(self : BigInt, shift : Int) -> String {
   let value = if is_negative { -self } else { self }
   let bit_len = value.bit_length()
   let digit_len = (bit_len + shift - 1) / shift
-  let builder = StringBuilder::StringBuilder(
+  let builder = StringBuilder(
     size_hint=digit_len + (if is_negative { 1 } else { 0 }),
   )
   if is_negative {

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -32,7 +32,7 @@ impl Show for Sign with output(self, logger) {
 
 ///|
 test "debug_string" {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   let v : Array[MyBigInt] = [0, 1, 2, 3, 4, -0, -1, -2, -3]
   (buf as &Logger).write_iter(v.iter(), sep="\n", prefix="", suffix="")
   // Logger::writer_iter()

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -32,7 +32,7 @@ impl Show for Sign with output(self, logger) {
 
 ///|
 test "debug_string" {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   let v : Array[MyBigInt] = [0, 1, 2, 3, 4, -0, -1, -2, -3]
   (buf as &Logger).write_iter(v.iter(), sep="\n", prefix="", suffix="")
   // Logger::writer_iter()

--- a/bigint/deprecated.mbt
+++ b/bigint/deprecated.mbt
@@ -76,13 +76,11 @@ pub fn BigInt::to_hex(self : BigInt, uppercase? : Bool = true) -> String {
   // WARN: this implementation assumes that `radix_bit_len` is a multiple of 4.
   let digits_per_limb = radix_bit_len / 4
   let buf = if self.sign is Negative {
-    let builder = StringBuilder::StringBuilder(
-      size_hint=self.len * digits_per_limb + 2,
-    )
+    let builder = StringBuilder(size_hint=self.len * digits_per_limb + 2)
     builder.write_char('-')
     builder
   } else {
-    StringBuilder::StringBuilder(size_hint=self.len * digits_per_limb)
+    StringBuilder(size_hint=self.len * digits_per_limb)
   }
   for i in self.len>..0 {
     // split the limb into 4-bit chunks

--- a/bigint/deprecated.mbt
+++ b/bigint/deprecated.mbt
@@ -76,11 +76,11 @@ pub fn BigInt::to_hex(self : BigInt, uppercase? : Bool = true) -> String {
   // WARN: this implementation assumes that `radix_bit_len` is a multiple of 4.
   let digits_per_limb = radix_bit_len / 4
   let buf = if self.sign is Negative {
-    let builder = StringBuilder::new(size_hint=self.len * digits_per_limb + 2)
+    let builder = StringBuilder::StringBuilder(size_hint=self.len * digits_per_limb + 2)
     builder.write_char('-')
     builder
   } else {
-    StringBuilder::new(size_hint=self.len * digits_per_limb)
+    StringBuilder::StringBuilder(size_hint=self.len * digits_per_limb)
   }
   for i in self.len>..0 {
     // split the limb into 4-bit chunks

--- a/bigint/deprecated.mbt
+++ b/bigint/deprecated.mbt
@@ -76,7 +76,9 @@ pub fn BigInt::to_hex(self : BigInt, uppercase? : Bool = true) -> String {
   // WARN: this implementation assumes that `radix_bit_len` is a multiple of 4.
   let digits_per_limb = radix_bit_len / 4
   let buf = if self.sign is Negative {
-    let builder = StringBuilder::StringBuilder(size_hint=self.len * digits_per_limb + 2)
+    let builder = StringBuilder::StringBuilder(
+      size_hint=self.len * digits_per_limb + 2,
+    )
     builder.write_char('-')
     builder
   } else {

--- a/builtin/README.mbt.md
+++ b/builtin/README.mbt.md
@@ -206,7 +206,7 @@ Efficient string building:
 ```mbt check
 ///|
 test "string builder" {
-  let builder = StringBuilder::new()
+  let builder = StringBuilder::StringBuilder()
   builder.write_string("Hello")
   builder.write_string(", ")
   builder.write_string("World!")

--- a/builtin/README.mbt.md
+++ b/builtin/README.mbt.md
@@ -206,7 +206,7 @@ Efficient string building:
 ```mbt check
 ///|
 test "string builder" {
-  let builder = StringBuilder::StringBuilder()
+  let builder = StringBuilder()
   builder.write_string("Hello")
   builder.write_string(", ")
   builder.write_string("World!")

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -244,7 +244,7 @@ test "array_eachi" {
 ///|
 test "array_rev_eachi" {
   let arr = ['a', 'b', 'c']
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   arr.rev_eachi((i, x) => {
     buf.write_object(i)
     buf.write_string(": ")

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -244,7 +244,7 @@ test "array_eachi" {
 ///|
 test "array_rev_eachi" {
   let arr = ['a', 'b', 'c']
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   arr.rev_eachi((i, x) => {
     buf.write_object(i)
     buf.write_string(": ")

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1413,7 +1413,7 @@ pub fn[A : ToStringView] ArrayView::join(
         size_hint
       }
       let size_hint = size_hint << 1
-      let buf = StringBuilder::StringBuilder(size_hint~)
+      let buf = StringBuilder(size_hint~)
       // buf.write_string(hd)
       buf.write_view(hd)
       if separator is "" {

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1413,7 +1413,7 @@ pub fn[A : ToStringView] ArrayView::join(
         size_hint
       }
       let size_hint = size_hint << 1
-      let buf = StringBuilder::new(size_hint~)
+      let buf = StringBuilder::StringBuilder(size_hint~)
       // buf.write_string(hd)
       buf.write_view(hd)
       if separator is "" {

--- a/builtin/assert.mbt
+++ b/builtin/assert.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn[T : Show] debug_string(t : T) -> String {
-  let buf = StringBuilder::new(size_hint=50)
+  let buf = StringBuilder::StringBuilder(size_hint=50)
   t.output(buf)
   buf.to_string()
 }

--- a/builtin/assert.mbt
+++ b/builtin/assert.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn[T : Show] debug_string(t : T) -> String {
-  let buf = StringBuilder::StringBuilder(size_hint=50)
+  let buf = StringBuilder(size_hint=50)
   t.output(buf)
   buf.to_string()
 }

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -80,7 +80,7 @@ fn SourceLocRepr::parse(repr : String) -> SourceLocRepr {
 
 ///|
 fn SourceLocRepr::to_json_string(self : SourceLocRepr) -> String {
-  let sb = StringBuilder::StringBuilder()
+  let sb = StringBuilder()
   sb.write_string("{\"filename\":")
   sb.write_object(self.filename)
   sb.write_string(",\"start_line\":\{self.start_line}")
@@ -122,7 +122,7 @@ pub impl Show for ArgsLoc with output(self, logger) {
 /// Returns a JSON array string where each element is either a string
 /// representation of a source location or "null".
 pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
-  let buf = StringBuilder::StringBuilder(size_hint=10)
+  let buf = StringBuilder(size_hint=10)
   let ArgsLoc(self) = self
   buf.write_char('[')
   for i, item in self {

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -80,7 +80,7 @@ fn SourceLocRepr::parse(repr : String) -> SourceLocRepr {
 
 ///|
 fn SourceLocRepr::to_json_string(self : SourceLocRepr) -> String {
-  let sb = StringBuilder::new()
+  let sb = StringBuilder::StringBuilder()
   sb.write_string("{\"filename\":")
   sb.write_object(self.filename)
   sb.write_string(",\"start_line\":\{self.start_line}")
@@ -122,7 +122,7 @@ pub impl Show for ArgsLoc with output(self, logger) {
 /// Returns a JSON array string where each element is either a string
 /// representation of a source location or "null".
 pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
-  let buf = StringBuilder::new(size_hint=10)
+  let buf = StringBuilder::StringBuilder(size_hint=10)
   let ArgsLoc(self) = self
   buf.write_char('[')
   for i, item in self {

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -685,7 +685,7 @@ pub fn Bytes::iter(self : Bytes) -> Iter[Byte] {
 ///
 /// ```mbt check
 /// test {
-///   let buf = StringBuilder::StringBuilder(size_hint=5)
+///   let buf = StringBuilder(size_hint=5)
 ///   let keys = []
 ///   let it = b"abcde".iter2()
 ///   while it.next() is Some((i, x)) {

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -685,7 +685,7 @@ pub fn Bytes::iter(self : Bytes) -> Iter[Byte] {
 ///
 /// ```mbt check
 /// test {
-///   let buf = StringBuilder::new(size_hint=5)
+///   let buf = StringBuilder::StringBuilder(size_hint=5)
 ///   let keys = []
 ///   let it = b"abcde".iter2()
 ///   while it.next() is Some((i, x)) {

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -300,7 +300,7 @@ pub fn BytesView::iter(self : BytesView) -> Iter[Byte] {
 ///
 /// ```mbt check
 /// test {
-///   let buf = StringBuilder::new(size_hint=5)
+///   let buf = StringBuilder::StringBuilder(size_hint=5)
 ///   let keys = []
 ///   let it = b"abcde"[:].iter2()
 ///   while it.next() is Some((i, x)) {
@@ -773,7 +773,7 @@ pub fn BytesView::to_owned(self : BytesView) -> Bytes {
 
 ///|
 pub impl ToJson for BytesView with to_json(self) -> Json {
-  let sb = StringBuilder::new()
+  let sb = StringBuilder::StringBuilder()
   for byte in self {
     if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
       sb.write_char(byte.to_char())

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -300,7 +300,7 @@ pub fn BytesView::iter(self : BytesView) -> Iter[Byte] {
 ///
 /// ```mbt check
 /// test {
-///   let buf = StringBuilder::StringBuilder(size_hint=5)
+///   let buf = StringBuilder(size_hint=5)
 ///   let keys = []
 ///   let it = b"abcde"[:].iter2()
 ///   while it.next() is Some((i, x)) {
@@ -773,7 +773,7 @@ pub fn BytesView::to_owned(self : BytesView) -> Bytes {
 
 ///|
 pub impl ToJson for BytesView with to_json(self) -> Json {
-  let sb = StringBuilder::StringBuilder()
+  let sb = StringBuilder()
   for byte in self {
     if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
       sb.write_char(byte.to_char())

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -465,7 +465,7 @@ fn char_to_string(char : Char) -> String {
 /// }
 /// ```
 pub fn Char::escape(self : Char, quote? : Bool = true) -> String {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   self.escape_to(buf, quote~)
   buf.to_string()
 }

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -465,7 +465,7 @@ fn char_to_string(char : Char) -> String {
 /// }
 /// ```
 pub fn Char::escape(self : Char, quote? : Bool = true) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   self.escape_to(buf, quote~)
   buf.to_string()
 }

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -60,7 +60,7 @@ pub(all) suberror InspectError {
 ///|
 fn base64_encode(data : FixedArray[Byte]) -> String {
   let base64 = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   let len = data.length()
   let rem = len % 3
   for i = 0; i < len - rem; i = i + 3 {

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -60,7 +60,7 @@ pub(all) suberror InspectError {
 ///|
 fn base64_encode(data : FixedArray[Byte]) -> String {
   let base64 = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   let len = data.length()
   let rem = len % 3
   for i = 0; i < len - rem; i = i + 3 {

--- a/builtin/existensial_test.mbt
+++ b/builtin/existensial_test.mbt
@@ -25,7 +25,7 @@ suberror IntError {
 ///|
 test {
   let v : Array[Error] = [StringError("x"), IntError(1)]
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for i in v {
     match i {
       StringError(s) => buf.write_string(s)

--- a/builtin/existensial_test.mbt
+++ b/builtin/existensial_test.mbt
@@ -25,7 +25,7 @@ suberror IntError {
 ///|
 test {
   let v : Array[Error] = [StringError("x"), IntError(1)]
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for i in v {
     match i {
       StringError(s) => buf.write_string(s)

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1346,7 +1346,7 @@ test "add" {
 test "iter" {
   let arr : FixedArray[_] = [1, 2, 3, 4, 5]
   let iter = arr.iter()
-  let exb = StringBuilder::StringBuilder()
+  let exb = StringBuilder()
   let mut i = 0
   iter.each(x => {
     exb.write_string(x.to_string())
@@ -1443,7 +1443,7 @@ pub fn FixedArray::join(
   } nobreak {
     size_hint
   }
-  let string = StringBuilder::StringBuilder(size_hint~)
+  let string = StringBuilder(size_hint~)
   if separator.is_empty() {
     for i in 0..<len {
       string.write_string(self[i])

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1346,7 +1346,7 @@ test "add" {
 test "iter" {
   let arr : FixedArray[_] = [1, 2, 3, 4, 5]
   let iter = arr.iter()
-  let exb = StringBuilder::new()
+  let exb = StringBuilder::StringBuilder()
   let mut i = 0
   iter.each(x => {
     exb.write_string(x.to_string())
@@ -1443,7 +1443,7 @@ pub fn FixedArray::join(
   } nobreak {
     size_hint
   }
-  let string = StringBuilder::new(size_hint~)
+  let string = StringBuilder::StringBuilder(size_hint~)
   if separator.is_empty() {
     for i in 0..<len {
       string.write_string(self[i])

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test "empty" {
   let iter = Iter::empty()
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb)
 }
@@ -23,7 +23,7 @@ test "empty" {
 ///|
 test "singleton" {
   let iter = Iter::singleton('1')
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb, content="1")
 }
@@ -31,7 +31,7 @@ test "singleton" {
 ///|
 test "repeat" {
   let iter = Iter::repeat('1')
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   for n in iter[:3] {
     exb.write_char(n)
   }
@@ -47,7 +47,7 @@ test "count" {
 ///|
 test "take" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.take(3).each(x => exb.write_char(x))
   inspect(exb, content="123")
   // normal take
@@ -84,7 +84,7 @@ test "take" {
 ///|
 test "take2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.take(10).concat(Iter::repeat('6').take(1)).each(x => exb.write_char(x))
   inspect(exb, content="123456")
 }
@@ -92,7 +92,7 @@ test "take2" {
 ///|
 test "take_while" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.take_while(x => x != '4').each(x => exb.write_char(x))
   inspect(exb, content="123")
 }
@@ -100,7 +100,7 @@ test "take_while" {
 ///|
 test "take_while2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter
   .take_while(x => x != '4')
   .concat(Iter::singleton('6'))
@@ -135,7 +135,7 @@ test "take_while5" {
 ///|
 test "map_while1" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
   .each(x => exb.write_string("\{x}\n"))
@@ -145,7 +145,7 @@ test "map_while1" {
 ///|
 test "map_while2" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
   .concat(Iter::singleton(6))
@@ -186,7 +186,7 @@ test "map_while5" {
 ///|
 test "drop" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.drop(3).each(x => exb.write_char(x))
   inspect(exb, content="45")
 }
@@ -201,7 +201,7 @@ test "sub" {
 ///|
 test "drop_while" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.drop_while(x => x != '4').each(x => exb.write_char(x))
   inspect(exb, content="45")
 }
@@ -219,7 +219,7 @@ test "drop_while2" {
 ///|
 test "drop_while3" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   let res = iter
     .drop_while(x => x < 3)
     .concat(Iter::singleton(6))
@@ -246,7 +246,7 @@ test "drop_while4" {
 ///|
 test "filter" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.filter(x => x != '4').each(x => exb.write_char(x))
   inspect(exb, content="1235")
 }
@@ -254,7 +254,7 @@ test "filter" {
 ///|
 test "map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter
   .map(x => (x.to_int() + 1).to_char().unwrap())
   .each(x => exb.write_char(x))
@@ -362,7 +362,7 @@ test "size_hint" {
 ///|
 test "mapi" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter
   .mapi((i, x) => (i + x.to_int()).to_char().unwrap())
   .each(x => exb.write_char(x))
@@ -403,7 +403,7 @@ test "filter_map" {
 ///|
 test "flat_map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.flat_map(x => Iter::repeat(x).take(2)).each(x => exb.write_char(x))
   inspect(exb, content="1122334455")
 }
@@ -411,7 +411,7 @@ test "flat_map" {
 ///|
 test "flat_map2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.flat_map(x => Iter::singleton(x)).each(x => exb.write_char(x))
   inspect(exb, content="12345")
 }
@@ -442,7 +442,7 @@ test "find_first2" {
 ///|
 test "tap" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   iter.tap(x => exb.write_char(x)).each(x => exb.write_char(x))
   inspect(exb, content="1122334455")
 }
@@ -452,7 +452,7 @@ test "concat" {
   let iter1 = test_from_array(['1', '2', '3'])
   let iter2 = test_from_array(['4', '5', '6'])
   let combined_iter = Iter::concat(iter1, iter2)
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   combined_iter.each(x => exb.write_char(x))
   inspect(exb, content="123456")
 }
@@ -595,7 +595,7 @@ test "until" {
 ///|
 test "each" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::new(size_hint=5)
+  let exb = StringBuilder::StringBuilder(size_hint=5)
   iter.each(x => exb.write_char(x))
   inspect(exb, content="12345")
 }
@@ -603,7 +603,7 @@ test "each" {
 ///|
 test "eachi" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::new(size_hint=5)
+  let exb = StringBuilder::StringBuilder(size_hint=5)
   iter.eachi((i, x) => exb.write_string((x + i).to_string()))
   inspect(exb, content="13579")
 }
@@ -690,7 +690,7 @@ fn Tree::iter(self : Tree) -> Iter[Int] {
 test "tree" {
   // let tree = Node(Node(Leaf(1), Leaf(2)), Node(Leaf(3), Leaf(4)))
   let tree = Node(Node(Leaf(1), 2, Leaf(3)), 4, Leaf(5))
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   tree.iter().each(x => exb.write_string(x.to_string()))
   inspect(exb, content="12345")
 }
@@ -1058,7 +1058,7 @@ test "Iter::iter and Iter2 conversions" {
     })
     .collect()
   inspect(pairs, content="[\"0:a\", \"1:b\"]")
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   let iter2 = ['x', 'y'].iter2().iter2()
   while iter2.next() is Some((_, ch)) {
     buf.write_char(ch)

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test "empty" {
   let iter = Iter::empty()
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb)
 }
@@ -23,7 +23,7 @@ test "empty" {
 ///|
 test "singleton" {
   let iter = Iter::singleton('1')
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb, content="1")
 }
@@ -31,7 +31,7 @@ test "singleton" {
 ///|
 test "repeat" {
   let iter = Iter::repeat('1')
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   for n in iter[:3] {
     exb.write_char(n)
   }
@@ -47,7 +47,7 @@ test "count" {
 ///|
 test "take" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.take(3).each(x => exb.write_char(x))
   inspect(exb, content="123")
   // normal take
@@ -84,7 +84,7 @@ test "take" {
 ///|
 test "take2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.take(10).concat(Iter::repeat('6').take(1)).each(x => exb.write_char(x))
   inspect(exb, content="123456")
 }
@@ -92,7 +92,7 @@ test "take2" {
 ///|
 test "take_while" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.take_while(x => x != '4').each(x => exb.write_char(x))
   inspect(exb, content="123")
 }
@@ -100,7 +100,7 @@ test "take_while" {
 ///|
 test "take_while2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter
   .take_while(x => x != '4')
   .concat(Iter::singleton('6'))
@@ -135,7 +135,7 @@ test "take_while5" {
 ///|
 test "map_while1" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
   .each(x => exb.write_string("\{x}\n"))
@@ -145,7 +145,7 @@ test "map_while1" {
 ///|
 test "map_while2" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
   .concat(Iter::singleton(6))
@@ -186,7 +186,7 @@ test "map_while5" {
 ///|
 test "drop" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.drop(3).each(x => exb.write_char(x))
   inspect(exb, content="45")
 }
@@ -201,7 +201,7 @@ test "sub" {
 ///|
 test "drop_while" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.drop_while(x => x != '4').each(x => exb.write_char(x))
   inspect(exb, content="45")
 }
@@ -219,7 +219,7 @@ test "drop_while2" {
 ///|
 test "drop_while3" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   let res = iter
     .drop_while(x => x < 3)
     .concat(Iter::singleton(6))
@@ -246,7 +246,7 @@ test "drop_while4" {
 ///|
 test "filter" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.filter(x => x != '4').each(x => exb.write_char(x))
   inspect(exb, content="1235")
 }
@@ -254,7 +254,7 @@ test "filter" {
 ///|
 test "map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter
   .map(x => (x.to_int() + 1).to_char().unwrap())
   .each(x => exb.write_char(x))
@@ -362,7 +362,7 @@ test "size_hint" {
 ///|
 test "mapi" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter
   .mapi((i, x) => (i + x.to_int()).to_char().unwrap())
   .each(x => exb.write_char(x))
@@ -403,7 +403,7 @@ test "filter_map" {
 ///|
 test "flat_map" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.flat_map(x => Iter::repeat(x).take(2)).each(x => exb.write_char(x))
   inspect(exb, content="1122334455")
 }
@@ -411,7 +411,7 @@ test "flat_map" {
 ///|
 test "flat_map2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.flat_map(x => Iter::singleton(x)).each(x => exb.write_char(x))
   inspect(exb, content="12345")
 }
@@ -442,7 +442,7 @@ test "find_first2" {
 ///|
 test "tap" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   iter.tap(x => exb.write_char(x)).each(x => exb.write_char(x))
   inspect(exb, content="1122334455")
 }
@@ -452,7 +452,7 @@ test "concat" {
   let iter1 = test_from_array(['1', '2', '3'])
   let iter2 = test_from_array(['4', '5', '6'])
   let combined_iter = Iter::concat(iter1, iter2)
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   combined_iter.each(x => exb.write_char(x))
   inspect(exb, content="123456")
 }
@@ -595,7 +595,7 @@ test "until" {
 ///|
 test "each" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let exb = StringBuilder::StringBuilder(size_hint=5)
+  let exb = StringBuilder(size_hint=5)
   iter.each(x => exb.write_char(x))
   inspect(exb, content="12345")
 }
@@ -603,7 +603,7 @@ test "each" {
 ///|
 test "eachi" {
   let iter = test_from_array([1, 2, 3, 4, 5])
-  let exb = StringBuilder::StringBuilder(size_hint=5)
+  let exb = StringBuilder(size_hint=5)
   iter.eachi((i, x) => exb.write_string((x + i).to_string()))
   inspect(exb, content="13579")
 }
@@ -690,7 +690,7 @@ fn Tree::iter(self : Tree) -> Iter[Int] {
 test "tree" {
   // let tree = Node(Node(Leaf(1), Leaf(2)), Node(Leaf(3), Leaf(4)))
   let tree = Node(Node(Leaf(1), 2, Leaf(3)), 4, Leaf(5))
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   tree.iter().each(x => exb.write_string(x.to_string()))
   inspect(exb, content="12345")
 }
@@ -1058,7 +1058,7 @@ test "Iter::iter and Iter2 conversions" {
     })
     .collect()
   inspect(pairs, content="[\"0:a\", \"1:b\"]")
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   let iter2 = ['x', 'y'].iter2().iter2()
   while iter2.next() is Some((_, ch)) {
     buf.write_char(ch)

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -457,7 +457,7 @@ pub fn[X] Iter::flatten(self : Iter[Iter[X]]) -> Iter[X] {
 /// Collects the elements of the iterator into a string.
 /// The old iterator `self` must not be used again after calling `join`.
 pub fn Iter::join(self : Iter[String], sep : StringView) -> String {
-  let result = StringBuilder::StringBuilder()
+  let result = StringBuilder()
   if self.next() is Some(x) {
     result.write_string(x)
     while self.next() is Some(x) {

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -457,7 +457,7 @@ pub fn[X] Iter::flatten(self : Iter[Iter[X]]) -> Iter[X] {
 /// Collects the elements of the iterator into a string.
 /// The old iterator `self` must not be used again after calling `join`.
 pub fn Iter::join(self : Iter[String], sep : StringView) -> String {
-  let result = StringBuilder::new()
+  let result = StringBuilder::StringBuilder()
   if self.next() is Some(x) {
     result.write_string(x)
     while self.next() is Some(x) {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -325,7 +325,7 @@ test "grow" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let map = { 1: "one", 2: "two", 3: "three" }
   map
   .iter()
@@ -350,7 +350,7 @@ test "iter order" {
   let m = { "one": 1 }
   m["three"] = 3
   m["two"] = 2
-  let buf = StringBuilder::StringBuilder(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   m.each((k, v) => buf.write_string("[\{k}-\{v}]"))
   inspect(buf.to_string(), content="[one-1][three-3][two-2]")
 }
@@ -664,7 +664,7 @@ test "equal_key_value_mismatch" {
 
 ///|
 fn[K : Show, V : Show] Map::_debug_entries(self : Map[K, V]) -> String {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for i, entry in self.entries {
     if i > 0 {
       buf.write_char(',')

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -325,7 +325,7 @@ test "grow" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let map = { 1: "one", 2: "two", 3: "three" }
   map
   .iter()
@@ -350,7 +350,7 @@ test "iter order" {
   let m = { "one": 1 }
   m["three"] = 3
   m["two"] = 2
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder::StringBuilder(size_hint=0)
   m.each((k, v) => buf.write_string("[\{k}-\{v}]"))
   inspect(buf.to_string(), content="[one-1][three-3][two-2]")
 }
@@ -664,7 +664,7 @@ test "equal_key_value_mismatch" {
 
 ///|
 fn[K : Show, V : Show] Map::_debug_entries(self : Map[K, V]) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for i, entry in self.entries {
     if i > 0 {
       buf.write_char(',')

--- a/builtin/logger_test.mbt
+++ b/builtin/logger_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "logger trait object calls" {
-  let sb = StringBuilder::new()
+  let sb = StringBuilder::StringBuilder()
   let logger : &Logger = sb
   Logger::write_string(logger, "Hello, ")
   Logger::write_char(logger, 'w')

--- a/builtin/logger_test.mbt
+++ b/builtin/logger_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "logger trait object calls" {
-  let sb = StringBuilder::StringBuilder()
+  let sb = StringBuilder()
   let logger : &Logger = sb
   Logger::write_string(logger, "Hello, ")
   Logger::write_char(logger, 'w')

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -442,8 +442,9 @@ pub fn SourceLoc::to_json_string(Self) -> String
 pub impl Show for SourceLoc
 
 type StringBuilder
+#alias(new)
+pub fn StringBuilder::StringBuilder(size_hint? : Int) -> Self
 pub fn StringBuilder::is_empty(Self) -> Bool
-pub fn StringBuilder::new(size_hint? : Int) -> Self
 pub fn StringBuilder::reset(Self) -> Unit
 pub fn StringBuilder::to_string(Self) -> String
 pub fn StringBuilder::write_iter(Self, Iter[Char]) -> Unit

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -441,7 +441,9 @@ pub(all) type SourceLoc
 pub fn SourceLoc::to_json_string(Self) -> String
 pub impl Show for SourceLoc
 
-type StringBuilder
+pub struct StringBuilder {
+  // private fields
+}
 #alias(new)
 pub fn StringBuilder::StringBuilder(size_hint? : Int) -> Self
 pub fn StringBuilder::is_empty(Self) -> Bool

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -108,7 +108,7 @@ test "to_hex_digit" {
 /// }
 /// ```
 pub fn String::escape(self : String, quote? : Bool = true) -> String {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   self[:].escape_to(buf, quote~)
   buf.to_string()
 }
@@ -135,7 +135,7 @@ pub fn StringView::escape(
   self : StringView,
   quote? : Bool = true,
 ) -> StringView {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   self.escape_to(buf, quote~)
   buf.to_string()
 }

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -108,7 +108,7 @@ test "to_hex_digit" {
 /// }
 /// ```
 pub fn String::escape(self : String, quote? : Bool = true) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   self[:].escape_to(buf, quote~)
   buf.to_string()
 }
@@ -135,7 +135,7 @@ pub fn StringView::escape(
   self : StringView,
   quote? : Bool = true,
 ) -> StringView {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   self.escape_to(buf, quote~)
   buf.to_string()
 }

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -655,7 +655,7 @@ test "Show for BytesView" {
 ///|
 test "Show for String" {
   fn to_string_using_output(str) {
-    let buf = StringBuilder::new()
+    let buf = StringBuilder::StringBuilder()
     Show::output(str, buf)
     buf.to_string()
   }
@@ -828,30 +828,30 @@ test "Show for Char special cases" {
   inspect('\''.to_string(), content="'")
 
   // Test various special character outputs
-  let quote_buf = StringBuilder::new()
+  let quote_buf = StringBuilder::StringBuilder()
   '\''.output(quote_buf)
   inspect(quote_buf.to_string(), content="'\\''")
-  let backslash_buf = StringBuilder::new()
+  let backslash_buf = StringBuilder::StringBuilder()
   '\\'.output(backslash_buf)
   inspect(backslash_buf.to_string(), content="'\\\\'")
-  let cr_buf = StringBuilder::new()
+  let cr_buf = StringBuilder::StringBuilder()
   '\r'.output(cr_buf)
   inspect(cr_buf.to_string(), content="'\\r'")
-  let backspace_buf = StringBuilder::new()
+  let backspace_buf = StringBuilder::StringBuilder()
   '\b'.output(backspace_buf)
   inspect(backspace_buf.to_string(), content="'\\b'")
-  let tab_buf = StringBuilder::new()
+  let tab_buf = StringBuilder::StringBuilder()
   '\t'.output(tab_buf)
   inspect(tab_buf.to_string(), content="'\\t'")
 
   // Test hex output for control characters
-  let ctrl1_buf = StringBuilder::new()
+  let ctrl1_buf = StringBuilder::StringBuilder()
   '\u{01}'.output(ctrl1_buf)
   inspect(ctrl1_buf.to_string(), content="'\\u{01}'")
-  let ctrl_f_buf = StringBuilder::new()
+  let ctrl_f_buf = StringBuilder::StringBuilder()
   '\u{0F}'.output(ctrl_f_buf)
   inspect(ctrl_f_buf.to_string(), content="'\\u{0f}'")
-  let ctrl_1f_buf = StringBuilder::new()
+  let ctrl_1f_buf = StringBuilder::StringBuilder()
   '\u{1F}'.output(ctrl_1f_buf)
   inspect(ctrl_1f_buf.to_string(), content="'\\u{1f}'")
 }

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -655,7 +655,7 @@ test "Show for BytesView" {
 ///|
 test "Show for String" {
   fn to_string_using_output(str) {
-    let buf = StringBuilder::StringBuilder()
+    let buf = StringBuilder()
     Show::output(str, buf)
     buf.to_string()
   }
@@ -828,30 +828,30 @@ test "Show for Char special cases" {
   inspect('\''.to_string(), content="'")
 
   // Test various special character outputs
-  let quote_buf = StringBuilder::StringBuilder()
+  let quote_buf = StringBuilder()
   '\''.output(quote_buf)
   inspect(quote_buf.to_string(), content="'\\''")
-  let backslash_buf = StringBuilder::StringBuilder()
+  let backslash_buf = StringBuilder()
   '\\'.output(backslash_buf)
   inspect(backslash_buf.to_string(), content="'\\\\'")
-  let cr_buf = StringBuilder::StringBuilder()
+  let cr_buf = StringBuilder()
   '\r'.output(cr_buf)
   inspect(cr_buf.to_string(), content="'\\r'")
-  let backspace_buf = StringBuilder::StringBuilder()
+  let backspace_buf = StringBuilder()
   '\b'.output(backspace_buf)
   inspect(backspace_buf.to_string(), content="'\\b'")
-  let tab_buf = StringBuilder::StringBuilder()
+  let tab_buf = StringBuilder()
   '\t'.output(tab_buf)
   inspect(tab_buf.to_string(), content="'\\t'")
 
   // Test hex output for control characters
-  let ctrl1_buf = StringBuilder::StringBuilder()
+  let ctrl1_buf = StringBuilder()
   '\u{01}'.output(ctrl1_buf)
   inspect(ctrl1_buf.to_string(), content="'\\u{01}'")
-  let ctrl_f_buf = StringBuilder::StringBuilder()
+  let ctrl_f_buf = StringBuilder()
   '\u{0F}'.output(ctrl_f_buf)
   inspect(ctrl_f_buf.to_string(), content="'\\u{0f}'")
-  let ctrl_1f_buf = StringBuilder::StringBuilder()
+  let ctrl_1f_buf = StringBuilder()
   '\u{1F}'.output(ctrl_1f_buf)
   inspect(ctrl_1f_buf.to_string(), content="'\\u{1f}'")
 }

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -28,7 +28,7 @@ pub fn String::make(length : Int, value : Char) -> String {
   if value.to_int() <= 0xFFFF {
     unsafe_make_string(length, value)
   } else {
-    let buf = StringBuilder::StringBuilder(size_hint=2 * length)
+    let buf = StringBuilder(size_hint=2 * length)
     for _ in 0..<length {
       buf.write_char(value)
     }
@@ -575,7 +575,7 @@ pub fn String::equal_ignore_ascii_case(self : String, other : String) -> Bool {
 ///
 /// For efficiency considerations, it's recommended to use `Buffer` instead.
 pub fn String::from_array(chars : ArrayView[Char]) -> String {
-  let buf = StringBuilder::StringBuilder(size_hint=chars.length() * 4)
+  let buf = StringBuilder(size_hint=chars.length() * 4)
   for c in chars {
     buf.write_char(c)
   }
@@ -586,7 +586,7 @@ pub fn String::from_array(chars : ArrayView[Char]) -> String {
 /// Convert char iterator to string,
 #alias(from_iterator, deprecated)
 pub fn String::from_iter(iter : Iter[Char]) -> String {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for c in iter {
     buf.write_char(c)
   }

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -28,7 +28,7 @@ pub fn String::make(length : Int, value : Char) -> String {
   if value.to_int() <= 0xFFFF {
     unsafe_make_string(length, value)
   } else {
-    let buf = StringBuilder::new(size_hint=2 * length)
+    let buf = StringBuilder::StringBuilder(size_hint=2 * length)
     for _ in 0..<length {
       buf.write_char(value)
     }
@@ -575,7 +575,7 @@ pub fn String::equal_ignore_ascii_case(self : String, other : String) -> Bool {
 ///
 /// For efficiency considerations, it's recommended to use `Buffer` instead.
 pub fn String::from_array(chars : ArrayView[Char]) -> String {
-  let buf = StringBuilder::new(size_hint=chars.length() * 4)
+  let buf = StringBuilder::StringBuilder(size_hint=chars.length() * 4)
   for c in chars {
     buf.write_char(c)
   }
@@ -586,7 +586,7 @@ pub fn String::from_array(chars : ArrayView[Char]) -> String {
 /// Convert char iterator to string,
 #alias(from_iterator, deprecated)
 pub fn String::from_iter(iter : Iter[Char]) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for c in iter {
     buf.write_char(c)
   }

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -986,7 +986,7 @@ pub fn StringView::repeat(self : StringView, n : Int) -> StringView {
       guard len == 0 || total / n == len else {
         abort("repeat result too large")
       }
-      let buf = StringBuilder::StringBuilder(size_hint=total)
+      let buf = StringBuilder(size_hint=total)
       let str = self.to_owned()
       for _ in 0..<n {
         buf.write_string(str)
@@ -1011,7 +1011,7 @@ pub fn String::repeat(self : String, n : Int) -> String {
       guard len == 0 || total / n == len else {
         abort("repeat result too large")
       }
-      let buf = StringBuilder::StringBuilder(size_hint=total)
+      let buf = StringBuilder(size_hint=total)
       let str = self.to_string()
       for _ in 0..<n {
         buf.write_string(str)
@@ -1059,7 +1059,7 @@ test "panic string view repeat negative" {
 /// Returns a new string with the characters in reverse order. It respects
 /// Unicode characters and surrogate pairs but not grapheme clusters.
 pub fn StringView::rev(self : StringView) -> String {
-  let buf = StringBuilder::StringBuilder(size_hint=self.length())
+  let buf = StringBuilder(size_hint=self.length())
   for c in self.rev_iter() {
     buf.write_char(c)
   }
@@ -1462,7 +1462,7 @@ pub fn StringView::replace_all(
   new~ : StringView,
 ) -> StringView {
   let len = self.length()
-  let buf = StringBuilder::StringBuilder(size_hint=len)
+  let buf = StringBuilder(size_hint=len)
   let old_len = old.length()
   let new = new.to_owned()
   // use write_substring to avoid intermediate allocations
@@ -1512,7 +1512,7 @@ pub fn String::replace_all(
   new~ : StringView,
 ) -> String {
   let len = self.length()
-  let buf = StringBuilder::StringBuilder(size_hint=len)
+  let buf = StringBuilder(size_hint=len)
   let old_len = old.length()
   let new = new.to_owned()
   // use write_substring to avoid intermediate allocations
@@ -1661,7 +1661,7 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
   guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::StringBuilder(size_hint=self.length())
+  let buf = StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {
@@ -1682,7 +1682,7 @@ pub fn String::to_lower(self : String) -> String {
   guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::StringBuilder(size_hint=self.length())
+  let buf = StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {
@@ -1717,7 +1717,7 @@ pub fn StringView::to_upper(self : StringView) -> StringView {
   guard self.find_by(c => c.is_ascii_lowercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::StringBuilder(size_hint=self.length())
+  let buf = StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {
@@ -1737,7 +1737,7 @@ pub fn String::to_upper(self : String) -> String {
   guard self.find_by(c => c.is_ascii_lowercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::StringBuilder(size_hint=self.length())
+  let buf = StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -986,7 +986,7 @@ pub fn StringView::repeat(self : StringView, n : Int) -> StringView {
       guard len == 0 || total / n == len else {
         abort("repeat result too large")
       }
-      let buf = StringBuilder::new(size_hint=total)
+      let buf = StringBuilder::StringBuilder(size_hint=total)
       let str = self.to_owned()
       for _ in 0..<n {
         buf.write_string(str)
@@ -1011,7 +1011,7 @@ pub fn String::repeat(self : String, n : Int) -> String {
       guard len == 0 || total / n == len else {
         abort("repeat result too large")
       }
-      let buf = StringBuilder::new(size_hint=total)
+      let buf = StringBuilder::StringBuilder(size_hint=total)
       let str = self.to_string()
       for _ in 0..<n {
         buf.write_string(str)
@@ -1059,7 +1059,7 @@ test "panic string view repeat negative" {
 /// Returns a new string with the characters in reverse order. It respects
 /// Unicode characters and surrogate pairs but not grapheme clusters.
 pub fn StringView::rev(self : StringView) -> String {
-  let buf = StringBuilder::new(size_hint=self.length())
+  let buf = StringBuilder::StringBuilder(size_hint=self.length())
   for c in self.rev_iter() {
     buf.write_char(c)
   }
@@ -1462,7 +1462,7 @@ pub fn StringView::replace_all(
   new~ : StringView,
 ) -> StringView {
   let len = self.length()
-  let buf = StringBuilder::new(size_hint=len)
+  let buf = StringBuilder::StringBuilder(size_hint=len)
   let old_len = old.length()
   let new = new.to_owned()
   // use write_substring to avoid intermediate allocations
@@ -1512,7 +1512,7 @@ pub fn String::replace_all(
   new~ : StringView,
 ) -> String {
   let len = self.length()
-  let buf = StringBuilder::new(size_hint=len)
+  let buf = StringBuilder::StringBuilder(size_hint=len)
   let old_len = old.length()
   let new = new.to_owned()
   // use write_substring to avoid intermediate allocations
@@ -1661,7 +1661,7 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
   guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::new(size_hint=self.length())
+  let buf = StringBuilder::StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {
@@ -1682,7 +1682,7 @@ pub fn String::to_lower(self : String) -> String {
   guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::new(size_hint=self.length())
+  let buf = StringBuilder::StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {
@@ -1717,7 +1717,7 @@ pub fn StringView::to_upper(self : StringView) -> StringView {
   guard self.find_by(c => c.is_ascii_lowercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::new(size_hint=self.length())
+  let buf = StringBuilder::StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {
@@ -1737,7 +1737,7 @@ pub fn String::to_upper(self : String) -> String {
   guard self.find_by(c => c.is_ascii_lowercase()) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder::new(size_hint=self.length())
+  let buf = StringBuilder::StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
   for c in self.view(start_offset=idx) {

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -153,7 +153,7 @@ test "String from_iter" {
 
 ///|
 test "String rev_iter with surrogate" {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   "A😀B".rev_iter().each(c => buf.write_char(c))
   inspect(buf.to_string(), content="B😀A")
 }

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -153,7 +153,7 @@ test "String from_iter" {
 
 ///|
 test "String rev_iter with surrogate" {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   "A😀B".rev_iter().each(c => buf.write_char(c))
   inspect(buf.to_string(), content="B😀A")
 }

--- a/builtin/stringbuilder.mbt
+++ b/builtin/stringbuilder.mbt
@@ -34,7 +34,7 @@ pub fn[T : Show] StringBuilder::write_object(
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::StringBuilder()
+///   let sb = StringBuilder()
 ///   let chars = "Hello🤣".iter()
 ///   sb.write_iter(chars)
 ///   assert_eq(sb.to_string(), "Hello🤣")
@@ -64,7 +64,7 @@ pub fn StringBuilder::write_iter(
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::StringBuilder()
+///   let sb = StringBuilder()
 ///   let str = "Hello, world!"
 ///   let view = str[7:12] // "world"
 ///   sb.write_stringview(view)

--- a/builtin/stringbuilder.mbt
+++ b/builtin/stringbuilder.mbt
@@ -34,7 +34,7 @@ pub fn[T : Show] StringBuilder::write_object(
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::new()
+///   let sb = StringBuilder::StringBuilder()
 ///   let chars = "Hello🤣".iter()
 ///   sb.write_iter(chars)
 ///   assert_eq(sb.to_string(), "Hello🤣")
@@ -64,7 +64,7 @@ pub fn StringBuilder::write_iter(
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::new()
+///   let sb = StringBuilder::StringBuilder()
 ///   let str = "Hello, world!"
 ///   let view = str[7:12] // "world"
 ///   sb.write_stringview(view)

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -29,7 +29,8 @@ struct StringBuilder {
 ///
 /// Returns a new `StringBuilder` instance with the specified initial capacity.
 ///
-pub fn StringBuilder::new(size_hint? : Int = 0) -> StringBuilder {
+#alias(new)
+pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
   let initial = if size_hint < 1 { 1 } else { (size_hint + 1) / 2 }
   let data : FixedArray[UInt16] = FixedArray::make(initial, 0)
   { data, len: 0 }
@@ -118,7 +119,7 @@ pub impl Logger for StringBuilder with write_char(self, ch) {
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::new()
+///   let sb = StringBuilder::StringBuilder()
 ///   sb.write_view("Hello, world!"[:5])
 ///   assert_eq(sb.to_string(), "Hello")
 /// }

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -119,7 +119,7 @@ pub impl Logger for StringBuilder with write_char(self, ch) {
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::StringBuilder()
+///   let sb = StringBuilder()
 ///   sb.write_view("Hello, world!"[:5])
 ///   assert_eq(sb.to_string(), "Hello")
 /// }

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -66,7 +66,7 @@ pub impl Logger for StringBuilder with write_char(self, ch) {
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::StringBuilder()
+///   let sb = StringBuilder()
 ///   sb.write_view("Hello, world!"[:5])
 ///   assert_eq(sb.to_string(), "Hello")
 /// }

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -28,7 +28,8 @@ struct StringBuilder {
 ///
 /// Returns a new `StringBuilder` instance with the specified initial capacity.
 ///
-pub fn StringBuilder::new(size_hint? : Int = 0) -> StringBuilder {
+#alias(new)
+pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
   ignore(size_hint)
   { val: "" }
 }
@@ -65,7 +66,7 @@ pub impl Logger for StringBuilder with write_char(self, ch) {
 ///
 /// ```mbt check
 /// test {
-///   let sb = StringBuilder::new()
+///   let sb = StringBuilder::StringBuilder()
 ///   sb.write_view("Hello, world!"[:5])
 ///   assert_eq(sb.to_string(), "Hello")
 /// }

--- a/builtin/stringbuilder_test.mbt
+++ b/builtin/stringbuilder_test.mbt
@@ -19,7 +19,7 @@
 
 ///|
 test "stringbuilder" {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   buf.write_string("hello")
   buf.write_char(' ')
   buf.write_view("world"[:3])
@@ -28,7 +28,7 @@ test "stringbuilder" {
 
 ///|
 test "is_empty method" {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   inspect(buf.is_empty(), content="true")
   buf.write_string("Test")
   inspect(buf.is_empty(), content="false")
@@ -38,7 +38,7 @@ test "is_empty method" {
 
 ///|
 test "reset does not mutate returned string" {
-  let buf = StringBuilder::new(size_hint=10)
+  let buf = StringBuilder::StringBuilder(size_hint=10)
   buf.write_string("hello")
   let first = buf.to_string()
   buf.reset()
@@ -52,19 +52,19 @@ test {
   let data = ["a", "b", "c", "hello world"]
   @json.json_inspect(
     data.map(fn(s) {
-      let sb = StringBuilder::new()
+      let sb = StringBuilder::StringBuilder()
       sb.write_string(s)
       sb.to_string()
     }),
     content=["a", "b", "c", "hello world"],
   )
-  // assert_eq({ let sb = StringBuilder::new(); sb.write_string("hello"); sb.to_string() }, "hello")
+  // assert_eq({ let sb = StringBuilder::StringBuilder(); sb.write_string("hello"); sb.to_string() }, "hello")
 }
 
 ///|
 test "write_iter" {
   let str = "Hello🤣🤣🤣"
-  let sb = StringBuilder::new()
+  let sb = StringBuilder::StringBuilder()
   sb.write_iter(str.iter())
   inspect(sb.to_string(), content="Hello🤣🤣🤣")
   let str_view = str[1:7]
@@ -75,7 +75,7 @@ test "write_iter" {
 ///|
 test "StringBuilder::write_stringview" {
   let str = "Hello🤣🤣🤣"
-  let sb = StringBuilder::new()
+  let sb = StringBuilder::StringBuilder()
 
   // Test basic substring
   let str_view = str[1:7]
@@ -104,13 +104,13 @@ test "StringBuilder::write_stringview" {
 
 ///|
 test "panic StringBuilder::write_char with invalid code point" {
-  let sb = StringBuilder::new()
+  let sb = StringBuilder::StringBuilder()
   sb.write_char((0x110000).unsafe_to_char()) |> ignore
 }
 
 ///|
 test "StringBuilder::write" {
-  let sb = StringBuilder::new()
+  let sb = StringBuilder::StringBuilder()
   sb.write("abc\n")
   assert_eq(sb.to_string(), "\"abc\\n\"")
 }

--- a/builtin/stringbuilder_test.mbt
+++ b/builtin/stringbuilder_test.mbt
@@ -19,7 +19,7 @@
 
 ///|
 test "stringbuilder" {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   buf.write_string("hello")
   buf.write_char(' ')
   buf.write_view("world"[:3])
@@ -28,7 +28,7 @@ test "stringbuilder" {
 
 ///|
 test "is_empty method" {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   inspect(buf.is_empty(), content="true")
   buf.write_string("Test")
   inspect(buf.is_empty(), content="false")
@@ -38,7 +38,7 @@ test "is_empty method" {
 
 ///|
 test "reset does not mutate returned string" {
-  let buf = StringBuilder::StringBuilder(size_hint=10)
+  let buf = StringBuilder(size_hint=10)
   buf.write_string("hello")
   let first = buf.to_string()
   buf.reset()
@@ -52,19 +52,19 @@ test {
   let data = ["a", "b", "c", "hello world"]
   @json.json_inspect(
     data.map(fn(s) {
-      let sb = StringBuilder::StringBuilder()
+      let sb = StringBuilder()
       sb.write_string(s)
       sb.to_string()
     }),
     content=["a", "b", "c", "hello world"],
   )
-  // assert_eq({ let sb = StringBuilder::StringBuilder(); sb.write_string("hello"); sb.to_string() }, "hello")
+  // assert_eq({ let sb = StringBuilder(); sb.write_string("hello"); sb.to_string() }, "hello")
 }
 
 ///|
 test "write_iter" {
   let str = "Hello🤣🤣🤣"
-  let sb = StringBuilder::StringBuilder()
+  let sb = StringBuilder()
   sb.write_iter(str.iter())
   inspect(sb.to_string(), content="Hello🤣🤣🤣")
   let str_view = str[1:7]
@@ -75,7 +75,7 @@ test "write_iter" {
 ///|
 test "StringBuilder::write_stringview" {
   let str = "Hello🤣🤣🤣"
-  let sb = StringBuilder::StringBuilder()
+  let sb = StringBuilder()
 
   // Test basic substring
   let str_view = str[1:7]
@@ -104,13 +104,13 @@ test "StringBuilder::write_stringview" {
 
 ///|
 test "panic StringBuilder::write_char with invalid code point" {
-  let sb = StringBuilder::StringBuilder()
+  let sb = StringBuilder()
   sb.write_char((0x110000).unsafe_to_char()) |> ignore
 }
 
 ///|
 test "StringBuilder::write" {
-  let sb = StringBuilder::StringBuilder()
+  let sb = StringBuilder()
   sb.write("abc\n")
   assert_eq(sb.to_string(), "\"abc\\n\"")
 }

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -71,7 +71,7 @@ test "StringView core operations" {
   inspect(view.char_length(), content="3")
   inspect(view.char_length_eq(3), content="true")
   inspect(view.char_length_ge(4), content="false")
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   let it = view.iter2()
   while it.next() is Some((i, ch)) {
     buf.write_string("\{i}:\{ch};")

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -71,7 +71,7 @@ test "StringView core operations" {
   inspect(view.char_length(), content="3")
   inspect(view.char_length_eq(3), content="true")
   inspect(view.char_length_ge(4), content="false")
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   let it = view.iter2()
   while it.next() is Some((i, ch)) {
     buf.write_string("\{i}:\{ch};")

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -162,7 +162,7 @@ impl Show with output(self, logger) {
 ///|
 /// Default implementation for `Show::to_string`, uses a `StringBuilder`
 impl Show with to_string(self) {
-  let logger = StringBuilder::StringBuilder()
+  let logger = StringBuilder()
   self.output(logger)
   logger.to_string()
 }
@@ -208,7 +208,7 @@ pub fn[T : Show] &Logger::write_iter(
 /// Function `repr`.
 #deprecated("use `to_repr` for debugging representation")
 pub fn[T : Show] repr(t : T) -> String {
-  let logger = StringBuilder::StringBuilder()
+  let logger = StringBuilder()
   t.output(logger)
   logger.to_string()
 }

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -162,7 +162,7 @@ impl Show with output(self, logger) {
 ///|
 /// Default implementation for `Show::to_string`, uses a `StringBuilder`
 impl Show with to_string(self) {
-  let logger = StringBuilder::new()
+  let logger = StringBuilder::StringBuilder()
   self.output(logger)
   logger.to_string()
 }
@@ -208,7 +208,7 @@ pub fn[T : Show] &Logger::write_iter(
 /// Function `repr`.
 #deprecated("use `to_repr` for debugging representation")
 pub fn[T : Show] repr(t : T) -> String {
-  let logger = StringBuilder::new()
+  let logger = StringBuilder::StringBuilder()
   t.output(logger)
   logger.to_string()
 }

--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "write_iter with trailing" {
-  let builder = StringBuilder::StringBuilder()
+  let builder = StringBuilder()
   let logger : &Logger = builder
   let arr : Array[Int] = [1, 2]
   logger.write_iter(arr.iter(), prefix="[", suffix="]", sep=",", trailing=true)

--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "write_iter with trailing" {
-  let builder = StringBuilder::new()
+  let builder = StringBuilder::StringBuilder()
   let logger : &Logger = builder
   let arr : Array[Int] = [1, 2]
   logger.write_iter(arr.iter(), prefix="[", suffix="]", sep=",", trailing=true)

--- a/bytes/bytes_pattern_test.mbt
+++ b/bytes/bytes_pattern_test.mbt
@@ -27,7 +27,7 @@
 /// @param bytes UTF-8 encoded byte sequence
 /// @return Decoded string
 pub fn decode_utf8(bytes : Bytes) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for x = bytes[:] {
     match x {
       // 1-byte sequence (ASCII): 0xxxxxxx

--- a/bytes/bytes_pattern_test.mbt
+++ b/bytes/bytes_pattern_test.mbt
@@ -27,7 +27,7 @@
 /// @param bytes UTF-8 encoded byte sequence
 /// @return Decoded string
 pub fn decode_utf8(bytes : Bytes) -> String {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for x = bytes[:] {
     match x {
       // 1-byte sequence (ASCII): 0xxxxxxx

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -143,7 +143,7 @@ test "from_iter empty iterator" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=5)
+  let buf = StringBuilder::StringBuilder(size_hint=5)
   b"abcde".iter().each(x => buf.write_string(x.to_string()))
   inspect(buf, content="b'\\x61'b'\\x62'b'\\x63'b'\\x64'b'\\x65'")
   buf.reset()
@@ -153,7 +153,7 @@ test "iter" {
 
 ///|
 test "iter2" {
-  let buf = StringBuilder::new(size_hint=5)
+  let buf = StringBuilder::StringBuilder(size_hint=5)
   let keys = []
   b"abcde"
   .iter2()

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -143,7 +143,7 @@ test "from_iter empty iterator" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=5)
+  let buf = StringBuilder(size_hint=5)
   b"abcde".iter().each(x => buf.write_string(x.to_string()))
   inspect(buf, content="b'\\x61'b'\\x62'b'\\x63'b'\\x64'b'\\x65'")
   buf.reset()
@@ -153,7 +153,7 @@ test "iter" {
 
 ///|
 test "iter2" {
-  let buf = StringBuilder::StringBuilder(size_hint=5)
+  let buf = StringBuilder(size_hint=5)
   let keys = []
   b"abcde"
   .iter2()

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -20,7 +20,7 @@ test "to_string" {
 ///|
 test "show output" {
   fn repr(chr) {
-    let buf = StringBuilder::new(size_hint=0)
+    let buf = StringBuilder::StringBuilder(size_hint=0)
     Show::output(chr, buf)
     buf.to_string()
   }

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -20,7 +20,7 @@ test "to_string" {
 ///|
 test "show output" {
   fn repr(chr) {
-    let buf = StringBuilder::StringBuilder(size_hint=0)
+    let buf = StringBuilder(size_hint=0)
     Show::output(chr, buf)
     buf.to_string()
   }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -110,7 +110,7 @@ pub fn end() -> Unit {
   println("----- BEGIN MOONBIT COVERAGE -----")
   let sbuf = StringBuffer::StringBuffer([])
   coverage_log(counters.val, sbuf)
-  let line_buf = StringBuilder::new()
+  let line_buf = StringBuilder::StringBuilder()
   for str in sbuf.0 {
     let start = for j in 0..<str.length(); start = 0 {
       if str.unsafe_get(j) == '\n' {
@@ -204,7 +204,7 @@ test "log" {
     ("foo/foo", test_counter_a),
     MCons(("foo/bar", test_counter_b), MNil),
   )
-  let buf = StringBuilder::new(size_hint=1024)
+  let buf = StringBuilder::StringBuilder(size_hint=1024)
   coverage_log(counters, buf)
   inspect(
     buf,
@@ -232,7 +232,7 @@ test "reset" {
     ("foo/foo", test_counter_a),
     MCons(("foo/bar", test_counter_b), MNil),
   )
-  let buf = StringBuilder::new(size_hint=1024)
+  let buf = StringBuilder::StringBuilder(size_hint=1024)
   coverage_log(counters, buf)
   inspect(
     buf,
@@ -243,7 +243,7 @@ test "reset" {
     ),
   )
   coverage_reset(counters)
-  let buf = StringBuilder::new(size_hint=1024)
+  let buf = StringBuilder::StringBuilder(size_hint=1024)
   coverage_log(counters, buf)
   inspect(
     buf,

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -110,7 +110,7 @@ pub fn end() -> Unit {
   println("----- BEGIN MOONBIT COVERAGE -----")
   let sbuf = StringBuffer::StringBuffer([])
   coverage_log(counters.val, sbuf)
-  let line_buf = StringBuilder::StringBuilder()
+  let line_buf = StringBuilder()
   for str in sbuf.0 {
     let start = for j in 0..<str.length(); start = 0 {
       if str.unsafe_get(j) == '\n' {
@@ -204,7 +204,7 @@ test "log" {
     ("foo/foo", test_counter_a),
     MCons(("foo/bar", test_counter_b), MNil),
   )
-  let buf = StringBuilder::StringBuilder(size_hint=1024)
+  let buf = StringBuilder(size_hint=1024)
   coverage_log(counters, buf)
   inspect(
     buf,
@@ -232,7 +232,7 @@ test "reset" {
     ("foo/foo", test_counter_a),
     MCons(("foo/bar", test_counter_b), MNil),
   )
-  let buf = StringBuilder::StringBuilder(size_hint=1024)
+  let buf = StringBuilder(size_hint=1024)
   coverage_log(counters, buf)
   inspect(
     buf,
@@ -243,7 +243,7 @@ test "reset" {
     ),
   )
   coverage_reset(counters)
-  let buf = StringBuilder::StringBuilder(size_hint=1024)
+  let buf = StringBuilder(size_hint=1024)
   coverage_log(counters, buf)
   inspect(
     buf,

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -96,7 +96,7 @@ test "shrink_to_fit_2" {
 ///|
 test "iter" {
   let dv = @deque.from_array([1, 2, 3, 4, 5])
-  let buf = StringBuilder::StringBuilder(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   let mut i = 0
   dv
   .iter()

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -96,7 +96,7 @@ test "shrink_to_fit_2" {
 ///|
 test "iter" {
   let dv = @deque.from_array([1, 2, 3, 4, 5])
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder::StringBuilder(size_hint=0)
   let mut i = 0
   dv
   .iter()

--- a/encoding/base64/encode.mbt
+++ b/encoding/base64/encode.mbt
@@ -26,7 +26,7 @@ pub fn encode(bytes : BytesView, padding? : Bool = true) -> String {
   if remainder != 0 {
     size_hint += if padding is true { 4 } else { remainder + 1 }
   }
-  let builder = StringBuilder::StringBuilder(size_hint~)
+  let builder = StringBuilder(size_hint~)
   for remaining = bytes {
     match remaining {
       [b0, b1, b2, .. rest] => {

--- a/encoding/base64/encode.mbt
+++ b/encoding/base64/encode.mbt
@@ -26,7 +26,7 @@ pub fn encode(bytes : BytesView, padding? : Bool = true) -> String {
   if remainder != 0 {
     size_hint += if padding is true { 4 } else { remainder + 1 }
   }
-  let builder = StringBuilder::new(size_hint~)
+  let builder = StringBuilder::StringBuilder(size_hint~)
   for remaining = bytes {
     match remaining {
       [b0, b1, b2, .. rest] => {

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -125,7 +125,7 @@ pub fn decode_lossy(
   } else {
     bytes
   }
-  let builder = StringBuilder::new(size_hint=bytes.length())
+  let builder = StringBuilder::StringBuilder(size_hint=bytes.length())
   if endianness is Little {
     for x = bytes {
       match x {

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -125,7 +125,7 @@ pub fn decode_lossy(
   } else {
     bytes
   }
-  let builder = StringBuilder::StringBuilder(size_hint=bytes.length())
+  let builder = StringBuilder(size_hint=bytes.length())
   if endianness is Little {
     for x = bytes {
       match x {

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -24,7 +24,7 @@ fn get_cli_args_internal() -> Array[String] {
 
 ///|
 fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
-  let res = StringBuilder::StringBuilder()
+  let res = StringBuilder()
   let len = bytes.length()
   let mut i = 0
   while i < len {

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -24,7 +24,7 @@ fn get_cli_args_internal() -> Array[String] {
 
 ///|
 fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
-  let res = StringBuilder::new()
+  let res = StringBuilder::StringBuilder()
   let len = bytes.length()
   let mut i = 0
   while i < len {

--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -55,7 +55,7 @@ fn finish_read_string(handle : XStringReadHandle) = "__moonbit_fs_unstable" "fin
 
 ///|
 fn string_from_extern(e : XExternString) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   let handle = begin_read_string(e)
   while true {
     let ch = string_read_char(handle)

--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -55,7 +55,7 @@ fn finish_read_string(handle : XStringReadHandle) = "__moonbit_fs_unstable" "fin
 
 ///|
 fn string_from_extern(e : XExternString) -> String {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   let handle = begin_read_string(e)
   while true {
     let ch = string_read_char(handle)

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -71,7 +71,7 @@ test "to_array empty" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let v = @array.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[1][2][3]")

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -71,7 +71,7 @@ test "to_array empty" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let v = @array.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[1][2][3]")

--- a/immut/internal/sparse_array/sparse_array_test.mbt
+++ b/immut/internal/sparse_array/sparse_array_test.mbt
@@ -80,7 +80,7 @@ test "SparseArray::intersection partial" {
 ///|
 test "SparseArray::iter" {
   let arr = @sparse_array.singleton(0, 0).add(1, 1).add(3, 3).add(31, 31)
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder::StringBuilder(size_hint=0)
   let mut is_first = true
   arr.each(x => {
     if is_first {

--- a/immut/internal/sparse_array/sparse_array_test.mbt
+++ b/immut/internal/sparse_array/sparse_array_test.mbt
@@ -80,7 +80,7 @@ test "SparseArray::intersection partial" {
 ///|
 test "SparseArray::iter" {
   let arr = @sparse_array.singleton(0, 0).add(1, 1).add(3, 3).add(31, 31)
-  let buf = StringBuilder::StringBuilder(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
   let mut is_first = true
   arr.each(x => {
     if is_first {

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -44,7 +44,7 @@ test "to_array" {
 
 ///|
 test "as_iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[3][2][1]")
@@ -55,7 +55,7 @@ test "as_iter" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[3][2][1]")

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -44,7 +44,7 @@ test "to_array" {
 
 ///|
 test "as_iter" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[3][2][1]")
@@ -55,7 +55,7 @@ test "as_iter" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[3][2][1]")

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -78,7 +78,7 @@ test "iteri" {
 
 ///|
 test "iter_take_each" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
   map
   .iter()
@@ -202,7 +202,7 @@ test "compare" {
 
 ///|
 test "iterator" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
   map
   .iter()

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -78,7 +78,7 @@ test "iteri" {
 
 ///|
 test "iter_take_each" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
   map
   .iter()
@@ -202,7 +202,7 @@ test "compare" {
 
 ///|
 test "iterator" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
   map
   .iter()

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -129,7 +129,7 @@ test "panic get after removal" {
 test "iter" {
   let map = [(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")]
     |> @sorted_map.from_array
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map {
     buf.write_object(k)
     buf.write_string(": ")
@@ -358,7 +358,7 @@ test "range with no matches" {
 ///|
 test "range matching all elements" {
   let map = @sorted_map.from_array([(1, "a"), (2, "b"), (3, "c")])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map.range(low=0, high=10) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -374,7 +374,7 @@ test "range partial match" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map.range(low=2, high=4) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -390,7 +390,7 @@ test "range with single element" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map.range(low=3, high=3) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -406,7 +406,7 @@ test "range at left boundary" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map.range(low=1, high=2) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -422,7 +422,7 @@ test "range at right boundary" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map.range(low=4, high=5) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -438,7 +438,7 @@ test "range with gaps in data" {
     (7, "g"),
     (9, "i"),
   ])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map.range(low=2, high=8) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -498,7 +498,7 @@ test "range on large dataset" {
 ///|
 test "range with non-existent boundaries" {
   let map = @sorted_map.from_array([(2, "b"), (4, "d"), (6, "f"), (8, "h")])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map.range(low=3, high=7) {
     buf.write_string("[\{k},\{v}]")
   }

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -129,7 +129,7 @@ test "panic get after removal" {
 test "iter" {
   let map = [(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")]
     |> @sorted_map.from_array
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map {
     buf.write_object(k)
     buf.write_string(": ")
@@ -358,7 +358,7 @@ test "range with no matches" {
 ///|
 test "range matching all elements" {
   let map = @sorted_map.from_array([(1, "a"), (2, "b"), (3, "c")])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map.range(low=0, high=10) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -374,7 +374,7 @@ test "range partial match" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map.range(low=2, high=4) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -390,7 +390,7 @@ test "range with single element" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map.range(low=3, high=3) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -406,7 +406,7 @@ test "range at left boundary" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map.range(low=1, high=2) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -422,7 +422,7 @@ test "range at right boundary" {
     (4, "d"),
     (5, "e"),
   ])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map.range(low=4, high=5) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -438,7 +438,7 @@ test "range with gaps in data" {
     (7, "g"),
     (9, "i"),
   ])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map.range(low=2, high=8) {
     buf.write_string("[\{k},\{v}]")
   }
@@ -498,7 +498,7 @@ test "range on large dataset" {
 ///|
 test "range with non-existent boundaries" {
   let map = @sorted_map.from_array([(2, "b"), (4, "d"), (6, "f"), (8, "h")])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map.range(low=3, high=7) {
     buf.write_string("[\{k},\{v}]")
   }

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -506,7 +506,7 @@ test "iter" {
 
 ///|
 test "iter_loop" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let set = [2, 7, 1, 2, 3, 4, 5] |> @sorted_set.from_array
   for x in set {
     buf.write_object(x)

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -506,7 +506,7 @@ test "iter" {
 
 ///|
 test "iter_loop" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let set = [2, 7, 1, 2, 3, 4, 5] |> @sorted_set.from_array
   for x in set {
     buf.write_object(x)

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -112,7 +112,7 @@ test "from_json rejects invalid input" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let v = @vector.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[1][2][3]")

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -112,7 +112,7 @@ test "from_json rejects invalid input" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let v = @vector.from_array([1, 2, 3])
   v.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[1][2][3]")

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -283,7 +283,7 @@ pub fn Json::stringify(
   indent? : Int = 0,
   replacer? : Replacer,
 ) -> String {
-  let buf = StringBuilder::new(size_hint=0)
+  let buf = StringBuilder::StringBuilder(size_hint=0)
 
   // Explicit stack to replace recursive calls
   let stack : Array[WriteFrame] = []
@@ -388,7 +388,7 @@ pub fn Json::stringify(
 
 ///|
 fn escape(str : String, escape_slash~ : Bool) -> String {
-  let buf = StringBuilder::new(size_hint=str.length())
+  let buf = StringBuilder::StringBuilder(size_hint=str.length())
   for c in str {
     match c {
       '"' => buf.write_string("\\\"")

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -283,7 +283,7 @@ pub fn Json::stringify(
   indent? : Int = 0,
   replacer? : Replacer,
 ) -> String {
-  let buf = StringBuilder::StringBuilder(size_hint=0)
+  let buf = StringBuilder(size_hint=0)
 
   // Explicit stack to replace recursive calls
   let stack : Array[WriteFrame] = []
@@ -388,7 +388,7 @@ pub fn Json::stringify(
 
 ///|
 fn escape(str : String, escape_slash~ : Bool) -> String {
-  let buf = StringBuilder::StringBuilder(size_hint=str.length())
+  let buf = StringBuilder(size_hint=str.length())
   for c in str {
     match c {
       '"' => buf.write_string("\\\"")

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -487,7 +487,7 @@ test "nested json" {
 ///|
 test "call stack overflow" {
   let depth = 50000
-  let json_string = StringBuilder::StringBuilder()
+  let json_string = StringBuilder()
   for _ in 0..<=depth {
     json_string.write_char('[')
   }
@@ -496,7 +496,7 @@ test "call stack overflow" {
   }
   let _ = @json.parse(json_string.to_string()) catch { _ => null }
   let depth = 1500
-  let json_string = StringBuilder::StringBuilder()
+  let json_string = StringBuilder()
   for _ in 0..<=depth {
     json_string.write_char('[')
   }

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -487,7 +487,7 @@ test "nested json" {
 ///|
 test "call stack overflow" {
   let depth = 50000
-  let json_string = StringBuilder::new()
+  let json_string = StringBuilder::StringBuilder()
   for _ in 0..<=depth {
     json_string.write_char('[')
   }
@@ -496,7 +496,7 @@ test "call stack overflow" {
   }
   let _ = @json.parse(json_string.to_string()) catch { _ => null }
   let depth = 1500
-  let json_string = StringBuilder::new()
+  let json_string = StringBuilder::StringBuilder()
   for _ in 0..<=depth {
     json_string.write_char('[')
   }

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn ParseContext::lex_string(ctx : ParseContext) -> String raise ParseError {
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   let mut start = ctx.offset
   fn flush(end : Int) {
     if start > 0 && end > start {

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn ParseContext::lex_string(ctx : ParseContext) -> String raise ParseError {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   let mut start = ctx.offset
   fn flush(end : Int) {
     if start > 0 && end > start {

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -679,7 +679,7 @@ test "iter_map_fold" {
 
 ///|
 test "List::output with non-empty list" {
-  let buf = StringBuilder::new(size_hint=100)
+  let buf = StringBuilder::StringBuilder(size_hint=100)
   let list = @list.from_array([1, 2, 3, 4, 5])
   Show::output(list, buf)
   debug_inspect(
@@ -692,7 +692,7 @@ test "List::output with non-empty list" {
 
 ///|
 test "List::output with empty list" {
-  let buf = StringBuilder::new(size_hint=100)
+  let buf = StringBuilder::StringBuilder(size_hint=100)
   let list : @list.List[Int] = @list.empty()
   Show::output(list, buf)
   debug_inspect(

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -679,7 +679,7 @@ test "iter_map_fold" {
 
 ///|
 test "List::output with non-empty list" {
-  let buf = StringBuilder::StringBuilder(size_hint=100)
+  let buf = StringBuilder(size_hint=100)
   let list = @list.from_array([1, 2, 3, 4, 5])
   Show::output(list, buf)
   debug_inspect(
@@ -692,7 +692,7 @@ test "List::output with non-empty list" {
 
 ///|
 test "List::output with empty list" {
-  let buf = StringBuilder::StringBuilder(size_hint=100)
+  let buf = StringBuilder(size_hint=100)
   let list : @list.List[Int] = @list.empty()
   Show::output(list, buf)
   debug_inspect(

--- a/option/option_test.mbt
+++ b/option/option_test.mbt
@@ -185,7 +185,7 @@ test "compare" {
 ///|
 test "iter" {
   let x = Option::Some(42)
-  let exb = StringBuilder::StringBuilder(size_hint=0)
+  let exb = StringBuilder(size_hint=0)
   x
   .iter()
   .each(x => {

--- a/option/option_test.mbt
+++ b/option/option_test.mbt
@@ -185,7 +185,7 @@ test "compare" {
 ///|
 test "iter" {
   let x = Option::Some(42)
-  let exb = StringBuilder::new(size_hint=0)
+  let exb = StringBuilder::StringBuilder(size_hint=0)
   x
   .iter()
   .each(x => {

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -65,7 +65,7 @@ test "to_array" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
   for e in v {
     buf.write_string("[\{e}]")

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -65,7 +65,7 @@ test "to_array" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
   for e in v {
     buf.write_string("[\{e}]")

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -163,7 +163,7 @@ test "each" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::StringBuilder(size_hint=20)
+  let buf = StringBuilder(size_hint=20)
   let map = @set.Set(["a", "b", "c"])
   map.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[a][b][c]")

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -163,7 +163,7 @@ test "each" {
 
 ///|
 test "iter" {
-  let buf = StringBuilder::new(size_hint=20)
+  let buf = StringBuilder::StringBuilder(size_hint=20)
   let map = @set.Set(["a", "b", "c"])
   map.iter().each(e => buf.write_string("[\{e}]"))
   inspect(buf, content="[a][b][c]")

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -110,7 +110,7 @@ test "size" {
 ///|
 test "each" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   map.each((k, v) => buf.write_string("\{k}\{v}"))
   inspect(buf.to_string(), content="1a2b3c")
 }
@@ -118,7 +118,7 @@ test "each" {
 ///|
 test "eachi" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   map.eachi((i, k, v) => buf.write_string("[\{i}]\{k}\{v}"))
   inspect(buf.to_string(), content="[0]1a[1]2b[2]3c")
 }
@@ -208,7 +208,7 @@ test "arbitrary" {
 ///|
 test "iter2" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
-  let buf = StringBuilder::new()
+  let buf = StringBuilder::StringBuilder()
   for k, v in map {
     buf.write_string("[\{k}\{v}]")
   }

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -110,7 +110,7 @@ test "size" {
 ///|
 test "each" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   map.each((k, v) => buf.write_string("\{k}\{v}"))
   inspect(buf.to_string(), content="1a2b3c")
 }
@@ -118,7 +118,7 @@ test "each" {
 ///|
 test "eachi" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   map.eachi((i, k, v) => buf.write_string("[\{i}]\{k}\{v}"))
   inspect(buf.to_string(), content="[0]1a[1]2b[2]3c")
 }
@@ -208,7 +208,7 @@ test "arbitrary" {
 ///|
 test "iter2" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
-  let buf = StringBuilder::StringBuilder()
+  let buf = StringBuilder()
   for k, v in map {
     buf.write_string("[\{k}\{v}]")
   }

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -90,7 +90,7 @@ test "intersect" {
 ///|
 test "each" {
   let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
-  let result = StringBuilder::new(size_hint=10)
+  let result = StringBuilder::StringBuilder(size_hint=10)
   set.each(x => result.write_string(x.to_string()))
   inspect(result.to_string(), content="123456789")
   let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
@@ -100,7 +100,7 @@ test "each" {
 ///|
 test "eachi" {
   let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
-  let result = StringBuilder::new(size_hint=10)
+  let result = StringBuilder::StringBuilder(size_hint=10)
   set.eachi((i, x) => result.write_string("[\{i}-\{x}]"))
   inspect(
     result.to_string(),

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -90,7 +90,7 @@ test "intersect" {
 ///|
 test "each" {
   let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
-  let result = StringBuilder::StringBuilder(size_hint=10)
+  let result = StringBuilder(size_hint=10)
   set.each(x => result.write_string(x.to_string()))
   inspect(result.to_string(), content="123456789")
   let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
@@ -100,7 +100,7 @@ test "each" {
 ///|
 test "eachi" {
   let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
-  let result = StringBuilder::StringBuilder(size_hint=10)
+  let result = StringBuilder(size_hint=10)
   set.eachi((i, x) => result.write_string("[\{i}-\{x}]"))
   inspect(
     result.to_string(),

--- a/string/regex_methods.mbt
+++ b/string/regex_methods.mbt
@@ -65,7 +65,7 @@ pub fn Regex::replace_by(
         let b = match buf {
           Some(b) => b
           None => {
-            let b = StringBuilder::new()
+            let b = StringBuilder::StringBuilder()
             buf = Some(b)
             b
           }

--- a/string/regex_methods.mbt
+++ b/string/regex_methods.mbt
@@ -65,7 +65,7 @@ pub fn Regex::replace_by(
         let b = match buf {
           Some(b) => b
           None => {
-            let b = StringBuilder::StringBuilder()
+            let b = StringBuilder()
             buf = Some(b)
             b
           }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -226,7 +226,7 @@ test "equal_ignore_ascii_case" {
 ///|
 test "Show::output" {
   fn repr(s : String) {
-    let buf = StringBuilder::StringBuilder(size_hint=0)
+    let buf = StringBuilder(size_hint=0)
     s |> Show::output(buf)
     buf.to_string()
   }
@@ -352,7 +352,7 @@ test "iter2" {
 
 ///|
 test "Buffer::to_bytes" {
-  let buffer = StringBuilder::StringBuilder(size_hint=16)
+  let buffer = StringBuilder(size_hint=16)
   buffer.write_string("中文")
   assert_eq(buffer.to_string(), "中文")
 }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -226,7 +226,7 @@ test "equal_ignore_ascii_case" {
 ///|
 test "Show::output" {
   fn repr(s : String) {
-    let buf = StringBuilder::new(size_hint=0)
+    let buf = StringBuilder::StringBuilder(size_hint=0)
     s |> Show::output(buf)
     buf.to_string()
   }
@@ -352,7 +352,7 @@ test "iter2" {
 
 ///|
 test "Buffer::to_bytes" {
-  let buffer = StringBuilder::new(size_hint=16)
+  let buffer = StringBuilder::StringBuilder(size_hint=16)
   buffer.write_string("中文")
   assert_eq(buffer.to_string(), "中文")
 }

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -17,7 +17,7 @@ using @debug {trait Debug}
 
 ///|
 fn[T : Show] debug_string(t : T) -> String {
-  let buf = StringBuilder::StringBuilder(size_hint=50)
+  let buf = StringBuilder(size_hint=50)
   t.output(buf)
   buf.to_string()
 }

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -17,7 +17,7 @@ using @debug {trait Debug}
 
 ///|
 fn[T : Show] debug_string(t : T) -> String {
-  let buf = StringBuilder::new(size_hint=50)
+  let buf = StringBuilder::StringBuilder(size_hint=50)
   t.output(buf)
   buf.to_string()
 }

--- a/test/types.mbt
+++ b/test/types.mbt
@@ -23,5 +23,5 @@ struct Test {
 /// Create a new instance.
 #as_free_fn
 pub fn Test::new(name : String) -> Test {
-  { name, buffer: StringBuilder::StringBuilder() }
+  { name, buffer: StringBuilder() }
 }

--- a/test/types.mbt
+++ b/test/types.mbt
@@ -23,5 +23,5 @@ struct Test {
 /// Create a new instance.
 #as_free_fn
 pub fn Test::new(name : String) -> Test {
-  { name, buffer: StringBuilder::new() }
+  { name, buffer: StringBuilder::StringBuilder() }
 }


### PR DESCRIPTION
## Summary
- Make `StringBuilder::StringBuilder` the canonical constructor; keep `StringBuilder::new` as a non-deprecated `#alias` so existing callers keep working without warnings.
- Migrate every in-tree call site to the new name (63 files).
- Both backends covered: `stringbuilder_buffer.mbt` (non-JS) and `stringbuilder_concat.mbt` (JS).

## Why not deprecate `StringBuilder::new`?
The MoonBit compiler desugars char-array string literals (e.g. `[char]`, `[hi, lo]`) into a `StringBuilder::new` call by name. If we tag the alias `deprecated`, every such literal — in core *and* in downstream user code — emits a deprecation warning, and `--deny-warn` (used by `bleeding-check` / `pre-release-check` / `stable-check`) fails.

Tracked in #3572. Once the compiler desugars to the new name, the alias can be flipped to `#alias(new, deprecated)` in a follow-up.

## Test plan
- [x] `moon check --target all --deny-warn` passes
- [x] `moon test --target wasm-gc` — 6433 passed / 0 failed
- [x] `moon test --target wasm` — 6433 passed / 0 failed
- [x] `moon test --target js` — 6392 passed / 0 failed
- [x] `moon test --target native` — 6344 passed / 0 failed
- [x] `moon check --target llvm --deny-warn` passes (test driver issue on LLVM is preexisting on `main`, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)