### PR TITLE
refactor: make String and Char Show output raw

### DIFF
--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -254,9 +254,9 @@ test "array_rev_eachi" {
   inspect(
     buf,
     content=(
-      #|0: 'c'
-      #|1: 'b'
-      #|2: 'a'
+      #|0: c
+      #|1: b
+      #|2: a
       #|
     ),
   )

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -500,11 +500,6 @@ fn Char::escape_to(self : Char, logger : &Logger, quote? : Bool = true) -> Unit 
 }
 
 ///|
-pub impl Show for Char with output(self, logger) {
-  self.escape_to(logger)
-}
-
-///|
 pub impl ToJson for Char with to_json(self : Char) -> Json {
   Json::string(self.to_string())
 }

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -431,7 +431,10 @@ pub fn Char::to_ascii_uppercase(self : Self) -> Char {
 }
 
 ///|
-/// Convert Char to String
+/// Returns the original character as a string without escaping.
+/// `Show::output` for `Char` also writes the raw character through this
+/// `Show::to_string` implementation.
+/// Use `Char::escape` when a quoted and escaped representation is needed.
 pub impl Show for Char with to_string(self : Char) -> String {
   char_to_string(self)
 }

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -503,14 +503,14 @@ test "to_string" {
   inspect(
     m.to_string(),
     content=(
-      #|{"a": 1, "b": 2, "c": 3}
+      #|{a: 1, b: 2, c: 3}
     ),
   )
   let nested_m = { "a": { "b": 2 }, "B": { "C": 3 } }
   inspect(
     nested_m.to_string(),
     content=(
-      #|{"a": {"b": 2}, "B": {"C": 3}}
+      #|{a: {b: 2}, B: {C: 3}}
     ),
   )
 }

--- a/builtin/result.mbt
+++ b/builtin/result.mbt
@@ -297,14 +297,14 @@ test "show" {
   inspect(
     ok,
     content=(
-      #|Ok("hello")
+      #|Ok(hello)
     ),
   )
   let err : Result[String, _] = Err("world")
   inspect(
     err,
     content=(
-      #|Err("world")
+      #|Err(world)
     ),
   )
 }

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -206,11 +206,6 @@ fn StringView::escape_to(
 }
 
 ///|
-pub impl Show for String with output(self, logger) {
-  self[:].escape_to(logger)
-}
-
-///|
 /// This is different from `Show::output`,
 /// here it returns the original string without escaping.
 /// The rationale is in string interpolation,

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -206,10 +206,10 @@ fn StringView::escape_to(
 }
 
 ///|
-/// This is different from `Show::output`,
-/// here it returns the original string without escaping.
-/// The rationale is in string interpolation,
-/// we want to show the original string, not the escaped one.
+/// Returns the original string without escaping.
+/// `Show::output` for `String` also writes the raw string through this
+/// `Show::to_string` implementation.
+/// Use `String::escape` when a quoted and escaped representation is needed.
 /// # Examples
 ///
 /// ```mbt check

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -663,14 +663,15 @@ test "Show for String" {
   inspect(
     to_string_using_output("abcdefg中文字符"),
     content=(
-      #|"abcdefg中文字符"
+      #|abcdefg中文字符
     ),
   )
   inspect(Show::to_string("abcdefg中文字符"), content="abcdefg中文字符")
   inspect(
     to_string_using_output("---\"---'---\\---\n---\t---\u{67}---"),
     content=(
-      #|"---\"---'---\\---\n---\t---g---"
+      #|---"---'---\---
+      #|---	---g---
     ),
   )
   // should be identity
@@ -694,13 +695,13 @@ test "Show for Result" {
   inspect(
     result_to_string(Ok("abc")),
     content=(
-      #|Ok("abc")
+      #|Ok(abc)
     ),
   )
   inspect(
     result_to_string(Err("def")),
     content=(
-      #|Err("def")
+      #|Err(def)
     ),
   )
 }
@@ -711,7 +712,7 @@ test "Show for Ref" {
   debug_inspect(
     Ref("abc").to_string(),
     content=(
-      #|"{val: \"abc\"}"
+      #|"{val: abc}"
     ),
   )
 }
@@ -722,7 +723,7 @@ test "Show for FixedArray" {
   debug_inspect(
     (["a", "b", "c"] : FixedArray[_]).to_string(),
     content=(
-      #|"[\"a\", \"b\", \"c\"]"
+      #|"[a, b, c]"
     ),
   )
   debug_inspect(
@@ -739,7 +740,7 @@ test "Show for Array" {
   debug_inspect(
     ["a", "b", "c"].to_string(),
     content=(
-      #|"[\"a\", \"b\", \"c\"]"
+      #|"[a, b, c]"
     ),
   )
   debug_inspect(
@@ -757,7 +758,7 @@ test "Show for ArrayView" {
   debug_inspect(
     arr[1:3].to_string(),
     content=(
-      #|"[\"b\", \"c\"]"
+      #|"[b, c]"
     ),
   )
   debug_inspect(
@@ -837,7 +838,7 @@ test "Show for Failure" {
   inspect(
     f.to_string(),
     content=(
-      #|Failure("test error message")
+      #|Failure(test error message)
     ),
   )
 }
@@ -850,30 +851,30 @@ test "Show for Char special cases" {
   // Test various special character outputs
   let quote_buf = StringBuilder()
   '\''.output(quote_buf)
-  inspect(quote_buf.to_string(), content="'\\''")
+  assert_eq(quote_buf.to_string(), "'")
   let backslash_buf = StringBuilder()
   '\\'.output(backslash_buf)
-  inspect(backslash_buf.to_string(), content="'\\\\'")
+  assert_eq(backslash_buf.to_string(), "\\")
   let cr_buf = StringBuilder()
   '\r'.output(cr_buf)
-  inspect(cr_buf.to_string(), content="'\\r'")
+  assert_eq(cr_buf.to_string(), "\r")
   let backspace_buf = StringBuilder()
   '\b'.output(backspace_buf)
-  inspect(backspace_buf.to_string(), content="'\\b'")
+  assert_eq(backspace_buf.to_string(), "\b")
   let tab_buf = StringBuilder()
   '\t'.output(tab_buf)
-  inspect(tab_buf.to_string(), content="'\\t'")
+  assert_eq(tab_buf.to_string(), "\t")
 
   // Test hex output for control characters
   let ctrl1_buf = StringBuilder()
   '\u{01}'.output(ctrl1_buf)
-  inspect(ctrl1_buf.to_string(), content="'\\u{01}'")
+  assert_eq(ctrl1_buf.to_string(), "\u{01}")
   let ctrl_f_buf = StringBuilder()
   '\u{0F}'.output(ctrl_f_buf)
-  inspect(ctrl_f_buf.to_string(), content="'\\u{0f}'")
+  assert_eq(ctrl_f_buf.to_string(), "\u{0f}")
   let ctrl_1f_buf = StringBuilder()
   '\u{1F}'.output(ctrl_1f_buf)
-  inspect(ctrl_1f_buf.to_string(), content="'\\u{1f}'")
+  assert_eq(ctrl_1f_buf.to_string(), "\u{1f}")
 }
 
 ///|

--- a/builtin/stringbuilder_test.mbt
+++ b/builtin/stringbuilder_test.mbt
@@ -112,5 +112,5 @@ test "panic StringBuilder::write_char with invalid code point" {
 test "StringBuilder::write" {
   let sb = StringBuilder()
   sb.write("abc\n")
-  assert_eq(sb.to_string(), "\"abc\\n\"")
+  assert_eq(sb.to_string(), "abc\n")
 }

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -140,16 +140,11 @@ impl Logger with write_char(self, value) {
 /// Trait for types that can be converted to `String`
 #must_implement_one(output, to_string)
 pub(open) trait Show {
-  // `output` is used for composition of aggregate structure.
   // `output` writes a string representation of `self` to a logger.
-  // `output` should produce a valid MoonBit-syntax representation if possible.
-  // For example, `Show::output` for `String` should be quoted
+  // The behaviors of output and to_string should be the same.
   output(Self, &Logger) -> Unit = _
   // `to_string` should be used by end users of `Show`,
   // for printing, interpolation, etc. only, and should not be used for composition.
-  // By default `to_string` is implemented using `output` and a buffer,
-  // but some types, such as `String`, may override `to_string`,
-  // for different (unescaped) behavior when interpolated/printed directly
   to_string(Self) -> String = _
 }
 

--- a/builtin/tuple_show_test.mbt
+++ b/builtin/tuple_show_test.mbt
@@ -16,41 +16,35 @@
 #warnings("-deprecated")
 test "2-tuple to_json" {
   let pair = (42, "hello")
-  @json.json_inspect(pair.to_string(), content="(42, \"hello\")")
+  @json.json_inspect(pair.to_string(), content="(42, hello)")
 }
 
 ///|
 #warnings("-deprecated")
 test "3-tuple to_json" {
   let triple = (42, "hello", true)
-  @json.json_inspect(triple.to_string(), content="(42, \"hello\", true)")
+  @json.json_inspect(triple.to_string(), content="(42, hello, true)")
 }
 
 ///|
 #warnings("-deprecated")
 test "4-tuple to_json" {
   let tuple = (42, "hello", true, 3.14)
-  @json.json_inspect(tuple.to_string(), content="(42, \"hello\", true, 3.14)")
+  @json.json_inspect(tuple.to_string(), content="(42, hello, true, 3.14)")
 }
 
 ///|
 #warnings("-deprecated")
 test "5-tuple to_json" {
   let tuple = (42, "hello", true, 3.14, 'a')
-  @json.json_inspect(
-    tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a')",
-  )
+  @json.json_inspect(tuple.to_string(), content="(42, hello, true, 3.14, a)")
 }
 
 ///|
 #warnings("-deprecated")
 test "6-tuple to_json" {
   let tuple = (42, "hello", true, 3.14, 'a', 1)
-  @json.json_inspect(
-    tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1)",
-  )
+  @json.json_inspect(tuple.to_string(), content="(42, hello, true, 3.14, a, 1)")
 }
 
 ///|
@@ -59,7 +53,7 @@ test "7-tuple to_json" {
   let tuple = (42, "hello", true, 3.14, 'a', 1, "world")
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\")",
+    content="(42, hello, true, 3.14, a, 1, world)",
   )
 }
 
@@ -69,7 +63,7 @@ test "8-tuple to_json" {
   let tuple = (42, "hello", true, 3.14, 'a', 1, "world", false)
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false)",
+    content="(42, hello, true, 3.14, a, 1, world, false)",
   )
 }
 
@@ -79,7 +73,7 @@ test "9-tuple to_json" {
   let tuple = (42, "hello", true, 3.14, 'a', 1, "world", false, 2.71)
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71)",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71)",
   )
 }
 
@@ -89,7 +83,7 @@ test "10-tuple to_json" {
   let tuple = (42, "hello", true, 3.14, 'a', 1, "world", false, 2.71, 'b')
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71, 'b')",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71, b)",
   )
 }
 
@@ -99,7 +93,7 @@ test "11-tuple to_json" {
   let tuple = (42, "hello", true, 3.14, 'a', 1, "world", false, 2.71, 'b', 43UL)
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71, 'b', 43)",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71, b, 43)",
   )
 }
 
@@ -111,7 +105,7 @@ test "12-tuple to_json" {
   )
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71, 'b', 43, 305419896)",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71, b, 43, 305419896)",
   )
 }
 
@@ -124,7 +118,7 @@ test "13-tuple to_json" {
   )
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71, 'b', 43, 305419896, 2271560481)",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71, b, 43, 305419896, 2271560481)",
   )
 }
 
@@ -149,7 +143,7 @@ test "14-tuple to_json" {
   )
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71, 'b', 43, 305419896, 2271560481, (11259375, 1234567890))",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71, b, 43, 305419896, 2271560481, (11259375, 1234567890))",
   )
 }
 
@@ -175,7 +169,7 @@ test "15-tuple to_json" {
   )
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71, 'b', 43, 305419896, 2271560481, (11259375, 1234567890), (305419896, 2271560481, 11259375))",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71, b, 43, 305419896, 2271560481, (11259375, 1234567890), (305419896, 2271560481, 11259375))",
   )
 }
 
@@ -202,6 +196,6 @@ test "16-tuple to_json" {
   )
   @json.json_inspect(
     tuple.to_string(),
-    content="(42, \"hello\", true, 3.14, 'a', 1, \"world\", false, 2.71, 'b', 43, 305419896, 2271560481, (11259375, 1234567890), (305419896, 2271560481, 11259375), (\"wow\", [2271560481, 1234567890]))",
+    content="(42, hello, true, 3.14, a, 1, world, false, 2.71, b, 43, 305419896, 2271560481, (11259375, 1234567890), (305419896, 2271560481, 11259375), (wow, [2271560481, 1234567890]))",
   )
 }

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -25,15 +25,15 @@ test "show output" {
     buf.to_string()
   }
 
-  inspect(repr('a'), content="'a'")
-  inspect(repr('\''), content="'\\''")
-  inspect(repr('"'), content="'\"'")
-  inspect(repr('\\'), content="'\\\\'")
-  inspect(repr('\n'), content="'\\n'")
-  inspect(repr('\r'), content="'\\r'")
-  inspect(repr('\b'), content="'\\b'")
-  inspect(repr('\t'), content="'\\t'")
-  assert_eq(repr((0).unsafe_to_char()), "'\\u{00}'")
+  assert_eq(repr('a'), "a")
+  assert_eq(repr('\''), "'")
+  assert_eq(repr('"'), "\"")
+  assert_eq(repr('\\'), "\\")
+  assert_eq(repr('\n'), "\n")
+  assert_eq(repr('\r'), "\r")
+  assert_eq(repr('\b'), "\b")
+  assert_eq(repr('\t'), "\t")
+  assert_eq(repr((0).unsafe_to_char()), "\u{00}")
 }
 
 ///|

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -195,7 +195,7 @@ test "map" {
   inspect(
     v.map(e => e.to_string()),
     content=(
-      #|@immut/array.from_array(["1", "2", "3", "4", "5"])
+      #|@immut/array.from_array([1, 2, 3, 4, 5])
     ),
   )
   inspect(

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -143,11 +143,11 @@ test "iter" {
   inspect(
     buf,
     content=(
-      #|0: "zero"
-      #|1: "one"
-      #|2: "two"
-      #|3: "three"
-      #|8: "eight"
+      #|0: zero
+      #|1: one
+      #|2: two
+      #|3: three
+      #|8: eight
       #|(0, "zero")
       #|(1, "one")
       #|(2, "two")

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -292,7 +292,7 @@ test "tuple failure" {
   inspect(
     v.unwrap_err(),
     content=(
-      #|JsonDecodeError((, "expected tuple of size 3"))
+      #|JsonDecodeError((, expected tuple of size 3))
     ),
   )
   let u = ((1, 2), (3, 4))
@@ -302,7 +302,7 @@ test "tuple failure" {
   inspect(
     v.unwrap_err(),
     content=(
-      #|JsonDecodeError((/1, "Int::from_json: expected number"))
+      #|JsonDecodeError((/1, Int::from_json: expected number))
     ),
   )
 }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -231,27 +231,17 @@ test "Show::output" {
     buf.to_string()
   }
 
-  assert_eq(repr("a"), "\"a\"")
-  assert_eq(repr("'"), "\"'\"")
-  assert_eq(repr("\""), "\"\\\"\"")
-  assert_eq(repr("\\"), "\"\\\\\"")
-  assert_eq(repr("\n"), "\"\\n\"")
-  assert_eq(repr("\r"), "\"\\r\"")
-  assert_eq(repr("\b"), "\"\\b\"")
-  assert_eq(repr("\t"), "\"\\t\"")
-  inspect(
-    repr("\u{00}"),
-    content=(
-      #|"\u{00}"
-    ),
-  )
-  inspect(
-    repr("\u0000"),
-    content=(
-      #|"\u{00}"
-    ),
-  )
-  assert_eq(repr("abc'\"def\\"), "\"abc'\\\"def\\\\\"")
+  assert_eq(repr("a"), "a")
+  assert_eq(repr("'"), "'")
+  assert_eq(repr("\""), "\"")
+  assert_eq(repr("\\"), "\\")
+  assert_eq(repr("\n"), "\n")
+  assert_eq(repr("\r"), "\r")
+  assert_eq(repr("\b"), "\b")
+  assert_eq(repr("\t"), "\t")
+  assert_eq(repr("\u{00}"), "\u{00}")
+  assert_eq(repr("\u0000"), "\u{00}")
+  assert_eq(repr("abc'\"def\\"), "abc'\"def\\")
 }
 
 ///|


### PR DESCRIPTION
This PR will change the behaviors for `impl Show for String` and `impl Show for Char`.

## Summary

- Remove the specialized `Show::output` implementations for `String` and `Char`, so they use the default raw `to_string()` output.
- Update affected `Show`/`to_string` tests and snapshots to match the new raw string/char output semantics.
- Keep deprecated composite `Show` coverage where the tests intentionally verify `to_string()` behavior.

## Tests

- `moon test`