### PR TITLE
feat(debug): expose @debug.to_string under the shorter prelude name `repr`

### DIFF
--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -200,8 +200,11 @@ pub fn[T : Show] &Logger::write_iter(
 // TODO: Logger::write_double(self:Logger, val:Double) -> Unit
 
 ///|
-/// Function `repr`.
-#deprecated("use `to_repr` for debugging representation")
+/// Deprecated `Show`-based string conversion. Kept for compatibility
+/// with callers using the qualified spelling `@builtin.repr(...)`. New
+/// code should use the prelude-exported `repr` (re-exported from
+/// `@debug.to_string`), which uses `Debug`.
+#deprecated("use `repr` (Debug-based) from prelude, or `@debug.repr` / `@debug.to_string`")
 pub fn[T : Show] repr(t : T) -> String {
   let logger = StringBuilder()
   t.output(logger)

--- a/debug/debug_test.mbt
+++ b/debug/debug_test.mbt
@@ -193,3 +193,19 @@ test "repr" {
     ),
   )
 }
+
+///|
+test "repr alias: prelude-visible shortcut for @debug.to_string" {
+  // `repr` is the prelude-exported alias for `@debug.to_string`. Both
+  // names resolve to the same function and produce the same Debug-style
+  // string. Strings render quoted (unlike Show), tuples / arrays render
+  // structurally.
+  assert_eq(repr("hi"), "\"hi\"")
+  assert_eq(repr('a'), "'a'")
+  assert_eq(repr([1, 2, 3]), "[1, 2, 3]")
+  assert_eq(repr((1, "x")), "(1, \"x\")")
+  // Aliases agree.
+  assert_eq(repr(42), @debug.to_string(42))
+  assert_eq(repr("hi"), @debug.to_string("hi"))
+  assert_eq(repr([1, 2]), @debug.to_string([1, 2]))
+}

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub fn[T : Debug] dump(T, name? : String, loc~ : SourceLoc) -> T
 
 pub fn render(Repr, max_depth? : Int) -> String
 
+#alias(repr)
 pub fn[T : Debug] to_string(T) -> String
 
 // Errors

--- a/debug/pretty_print.mbt
+++ b/debug/pretty_print.mbt
@@ -272,15 +272,29 @@ pub fn[T : Debug] debug(x : T) -> Unit {
 }
 
 ///|
-/// Convert a value to its debug string representation.
+/// Convert a value to its debug string representation. Equivalent to
+/// `@debug.to_repr(x).to_string()`, but spelled in one step.
+///
+/// Also exported under the shorter name `repr` (re-exported from prelude,
+/// so it is callable without import). The two names refer to the same
+/// function; pick whichever reads better at the call site.
+///
+/// Note: this is the **debug** rendering, which differs from `T::to_string`
+/// (the `Show` rendering) for some types — most visibly, strings and chars
+/// are quoted and escaped here. Use `@debug.to_string` / `repr` for
+/// developer-facing output (logs, snapshots, error messages), and the
+/// `Show` `to_string` for user-facing output.
 ///
 /// # Examples
 /// ```mbt check
 /// test {
 ///   let str = @debug.to_string([1, 2, 3])
 ///   assert_eq(str, "[1, 2, 3]")
+///   // Same function under a shorter name.
+///   assert_eq(repr("hi"), "\"hi\"")
 /// }
 /// ```
+#alias(repr)
 pub fn[T : Debug] to_string(x : T) -> String {
   render(x.to_repr())
 }

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -60,8 +60,7 @@ pub fn[T] physical_equal(T, T) -> Bool
 
 pub fn[T : @builtin.Show] println(T) -> Unit
 
-#deprecated
-pub fn[T : @builtin.Show] repr(T) -> String
+pub fn[T : @debug.Debug] repr(T) -> String
 
 #deprecated
 pub fn[T] tap(T, (T) -> Unit raise) -> T raise

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -74,17 +74,12 @@ pub using @builtin {
 pub using @builtin {not}
 
 ///|
-#deprecated("use `to_repr` for debugging representation")
-#warnings("-deprecated")
-pub using @builtin {repr}
-
-///|
 #deprecated
 #warnings("-deprecated")
 pub using @builtin {type IterResult}
 
 ///|
-pub using @debug {debug, type Repr, trait Debug, debug_inspect, to_repr}
+pub using @debug {debug, type Repr, trait Debug, debug_inspect, repr, to_repr}
 
 ///|
 #deprecated("for debugging only, not for production")


### PR DESCRIPTION
## Summary

Adds `repr` as a prelude-exported, one-step Debug-string conversion. Implementation is just `#alias(repr)` on the existing `@debug.to_string` — no new function definition.

```moonbit
// Before: two steps, no shortcut name
let s = @debug.to_repr(x).to_string()

// Or one step with explicit import:
let s = @debug.to_string(x)

// After: one step, prelude-scoped:
let s = repr(x)
```

`repr` and `@debug.to_string` are the same function under two names; pick whichever reads better at the call site.

## Background

The prelude was previously re-exporting `@builtin.repr` (the *deprecated* `Show`-based version) with `#warnings("-deprecated")`. That left two slightly broken things:

- Calling `repr(x)` in user code used `Show`, which after the recent raw-Show changes (`9c7278d1`) renders strings / chars without quotes — *not* what you usually want for snapshots or error messages.
- There was no short way to spell "give me the Debug rendering of x as a String."

This PR:

1. Adds `#alias(repr)` to `@debug.to_string` — same function, two names.
2. Swaps the prelude re-export: removes `@builtin.repr` and adds `@debug.repr`.
3. Keeps the deprecated `@builtin.repr` for callers using the qualified `@builtin.repr(...)` spelling, with an updated deprecation message pointing at the new prelude `repr`.

## Semantic flip

Unqualified `repr(x)` changes meaning:

| Type          | Before (`Show`) | After (`Debug`) |
|---------------|-----------------|------------------|
| `"hi"`        | `hi`            | `"hi"`           |
| `'a'`         | `a`             | `'a'`            |
| `(1, "x")`    | `(1, x)`        | `(1, "x")`       |
| `[1, 2]`      | `[1, 2]`        | `[1, 2]`         |

Acceptable because the old behavior was already deprecated. Users wanting the old behavior:
- can call `@builtin.repr(x)` (still works, still deprecated), or
- can call `x.to_string()` (the `Show` method) directly.

## Codex review

Two passes — agreed with proposal as revised:
- ✅ `#alias` over a duplicate function definition.
- ✅ Keep `@builtin.repr` (don't delete) so qualified callers don't get a missing-symbol error. Done in this PR's second commit.

## Test plan

- [x] `moon check` clean
- [x] `moon test --target all` — 6475 / 6475 / 6434 / 6386 pass on wasm / wasm-gc / js / native
- [x] New focused tests in `debug/debug_test.mbt`:
  - `repr("hi") == "\"hi\""`, `repr('a') == "'a'"`, structural rendering for tuples / arrays
  - `repr(x) == @debug.to_string(x)` (alias resolution agreement)
  - Prelude resolution of unqualified `repr`
- [x] `moon fmt`, `moon info` (mbti updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)