### PR TITLE
refactor(builtin): remove deprecated Show-based `@builtin.repr`

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -41,9 +41,6 @@ pub fn[T] physical_equal(T, T) -> Bool
 
 pub fn[T : Show] println(T) -> Unit
 
-#deprecated
-pub fn[T : Show] repr(T) -> String
-
 // Errors
 #deprecated
 pub(all) suberror BenchError {

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -198,15 +198,3 @@ pub fn[T : Show] &Logger::write_iter(
   self.write_string(suffix)
 }
 // TODO: Logger::write_double(self:Logger, val:Double) -> Unit
-
-///|
-/// Deprecated `Show`-based string conversion. Kept for compatibility
-/// with callers using the qualified spelling `@builtin.repr(...)`. New
-/// code should use the prelude-exported `repr` (re-exported from
-/// `@debug.to_string`), which uses `Debug`.
-#deprecated("use `repr` (Debug-based) from prelude, or `@debug.repr` / `@debug.to_string`")
-pub fn[T : Show] repr(t : T) -> String {
-  let logger = StringBuilder()
-  t.output(logger)
-  logger.to_string()
-}


### PR DESCRIPTION
## Summary

Follow-up to #3580. Removes the deprecated `@builtin.repr` entirely.

After #3580:
- `repr(x)` in user code (unqualified, via prelude) uses the new Debug-based rendering.
- `@builtin.repr(x)` (qualified) still resolved to the old Show-based function.

That asymmetry is confusing — same name, different rendering depending on how it's spelled — and only existed as a compatibility courtesy for callers who hadn't migrated. No call sites of `@builtin.repr` exist in this repo. The risk of removing it is acceptable (per maintainer review).

External callers using `@builtin.repr(...)` should switch to either:
- `repr(x)` / `@debug.repr(x)` / `@debug.to_string(x)` for the Debug-based rendering (recommended)
- `x.to_string()` for the Show-based rendering they had before

## Test plan

- [x] `moon check` clean
- [x] `moon test --target all` — passes on wasm / wasm-gc / js / native (6386–6475 tests per target)
- [x] `moon fmt`, `moon info` (mbti updated; `pub fn[T : Show] repr(T) -> String` removed from `builtin/pkg.generated.mbti`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)