### PR TITLE
refactor: use structured Repr::record instead of Repr::literal

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -46,9 +46,11 @@ priv enum Sign {
 ///|
 test "internal repr" {
   fn convert(b : BigInt) -> @debug.Repr {
-    @debug.Repr::literal(
-      "{ limbs: \{@debug.to_string(b.limbs)}, sign: \{@debug.to_string(b.sign)}, len: \{b.len} }",
-    )
+    @debug.Repr::record({
+      "limbs": @debug.to_repr(b.limbs),
+      "sign": @debug.to_repr(b.sign),
+      "len": @debug.to_repr(b.len),
+    })
   }
   @debug.debug_inspect(
     [0N, 1, 2, 3, 4, -1, -2, -3, -4].map(convert),

--- a/debug/repr.mbt
+++ b/debug/repr.mbt
@@ -220,7 +220,10 @@ pub fn Repr::array(children : Array[Repr]) -> Repr {
 /// Construct a `Record` node from pre-built child `Repr`s.
 #doc(hidden)
 pub fn Repr::record(fields : Map[String, Repr]) -> Repr {
-  Record(fields.to_array().map(p => RecordField(p.0, p.1)))
+  Record([
+    for name, value in fields =>
+      RecordField(name, value)
+  ])
 }
 
 ///|

--- a/debug/repr.mbt
+++ b/debug/repr.mbt
@@ -220,10 +220,7 @@ pub fn Repr::array(children : Array[Repr]) -> Repr {
 /// Construct a `Record` node from pre-built child `Repr`s.
 #doc(hidden)
 pub fn Repr::record(fields : Map[String, Repr]) -> Repr {
-  Record([
-    for name, value in fields =>
-      RecordField(name, value)
-  ])
+  Record([ for name, value in fields => RecordField(name, value) ])
 }
 
 ///|


### PR DESCRIPTION
## Changes

- **debug/repr.mbt**: Simplify `Repr::record` implementation using a for-loop iteration over the map instead of `to_array().map()`
- **bigint/bigint_nonjs.mbt**: Convert the internal repr test to use structured `Repr::record` with proper typed fields instead of string interpolation via `Repr::literal`

This makes the bigint debug representation more structured and consistent with how other types use the `Repr` API.