### PR TITLE
feat(hashmap): add FromJson impl for HashMap[String, V] to match Map

### DIFF
--- a/hashmap/extends.mbt
+++ b/hashmap/extends.mbt
@@ -25,6 +25,11 @@ pub extend HashMap with Eq::{equal}
 pub extend HashMap with @debug.Debug::{to_repr}
 
 ///|
+#deprecated("Use `@json.from_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with @json.FromJson::{from_json}
+
+///|
 #deprecated("Use `Default::default` instead", skip_current_package=true)
 #doc(hidden)
 pub extend HashMap with Default::{default}

--- a/hashmap/json.mbt
+++ b/hashmap/json.mbt
@@ -23,3 +23,34 @@ pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V] with to_json(self) {
     ),
   )
 }
+
+///|
+/// Decodes a `HashMap[String, V]` from a JSON object.
+///
+/// Each key in the JSON object becomes a `String` key in the map, and each
+/// value is decoded using `V`'s `FromJson` implementation.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let m : @hashmap.HashMap[String, Int] = @json.from_json(
+///     { "a": 1, "b": 2 }.to_json(),
+///   )
+///   debug_inspect(m.get("a"), content="Some(1)")
+///   debug_inspect(m.get("b"), content="Some(2)")
+/// }
+/// ```
+pub impl[V : @json.FromJson] @json.FromJson for HashMap[String, V] with from_json(
+  json,
+  path,
+) {
+  guard json is Object(obj) else {
+    raise @json.JsonDecodeError((path, "HashMap::from_json: expected object"))
+  }
+  let res : HashMap[String, V] = HashMap([])
+  for k, v in obj {
+    res[k] = @json.FromJson::from_json(v, path.add_key(k))
+  }
+  res
+}

--- a/hashmap/json.mbt
+++ b/hashmap/json.mbt
@@ -23,3 +23,37 @@ pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V] with fn to_json(self) {
     ),
   )
 }
+
+///|
+/// Decodes a `HashMap[String, V]` from a JSON object.
+///
+/// Each key in the JSON object becomes a `String` key in the map, and each
+/// value is decoded using `V`'s `FromJson` implementation.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let m : @hashmap.HashMap[String, Int] = @json.from_json({ "a": 1, "b": 2 })
+///   debug_inspect(m.get("a"), content="Some(1)")
+///   debug_inspect(m.get("b"), content="Some(2)")
+/// }
+/// ```
+pub impl[V : @json.FromJson] @json.FromJson for HashMap[String, V] with fn from_json(
+  json,
+  path,
+) {
+  guard json is Object(obj) else {
+    raise JsonDecodeError((path, "@hashmap.from_json: expected object"))
+  }
+  // The object's size is known, so size the table for it once instead of
+  // rehashing as the entries go in.
+  let res : HashMap[String, V] = HashMap(
+    [],
+    capacity=capacity_for_length(obj.length()),
+  )
+  for k, v in obj {
+    res[k] = V::from_json(v, path.add_key(k))
+  }
+  res
+}

--- a/hashmap/json_test.mbt
+++ b/hashmap/json_test.mbt
@@ -1,0 +1,78 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "from_json round-trips whatever to_json produced" {
+  for map in (@quickcheck.samples(50) : Array[@hashmap.HashMap[String, Int]]) {
+    let restored : @hashmap.HashMap[String, Int] = @json.from_json(
+      @json.to_json(map),
+    )
+    @debug.assert_eq(restored, map)
+  }
+}
+
+///|
+test "from_json decodes an object" {
+  let restored : @hashmap.HashMap[String, Int] = @json.from_json({
+    "key1": 42,
+    "key2": 100,
+    "key3": -5,
+  })
+  inspect(restored.length(), content="3")
+  debug_inspect(restored.get("key1"), content="Some(42)")
+  debug_inspect(restored.get("key3"), content="Some(-5)")
+  debug_inspect(restored.get("missing"), content="None")
+}
+
+///|
+test "from_json decodes an empty object and nested values" {
+  let empty : @hashmap.HashMap[String, Int] = @json.from_json({})
+  inspect(empty.length(), content="0")
+  let nested : @hashmap.HashMap[String, Array[Int]] = @json.from_json({
+    "a": [1, 2],
+    "b": [],
+  })
+  debug_inspect(nested.get("a"), content="Some([1, 2])")
+  debug_inspect(nested.get("b"), content="Some([])")
+}
+
+///|
+test "from_json rejects a non-object" {
+  let bad : Json = 1
+  try (@json.from_json(bad) : @hashmap.HashMap[String, Int]) catch {
+    err =>
+      inspect(
+        err,
+        content="JsonDecodeError((, @hashmap.from_json: expected object))",
+      )
+  } noraise {
+    _ => fail("expected JsonDecodeError")
+  }
+}
+
+///|
+test "from_json reports the path of the value that failed" {
+  // The decoder extends the path with each key, so a failure inside one
+  // entry has to name that entry rather than the object as a whole.
+  let bad : Json = { "ok": 1, "wrong": "not an int" }
+  try (@json.from_json(bad) : @hashmap.HashMap[String, Int]) catch {
+    err =>
+      inspect(
+        err,
+        content="JsonDecodeError((/wrong, Int::from_json: expected number))",
+      )
+  } noraise {
+    _ => fail("expected JsonDecodeError")
+  }
+}

--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/tuple",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/int",
+  "moonbitlang/core/json",
 }
 
 import {

--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/test",
   "moonbitlang/core/int",
+  "moonbitlang/core/json",
 }
 
 import {

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/core/hashmap"
 
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/splitmix",
 }
@@ -67,6 +68,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V]
 pub impl[K : Show, V : Show] Show for HashMap[K, V]
 pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V]
 pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V]
+pub impl[V : @json.FromJson] @json.FromJson for HashMap[String, V]
 pub impl[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] @quickcheck.Arbitrary for HashMap[K, V]
 
 // Type aliases

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/core/hashmap"
 
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/json",
 }
 
 // Values
@@ -64,6 +65,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V]
 pub impl[K : Show, V : Show] Show for HashMap[K, V]
 pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V]
 pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V]
+pub impl[V : @json.FromJson] @json.FromJson for HashMap[String, V]
 
 // Type aliases
 


### PR DESCRIPTION
## Summary
Adds `impl FromJson for HashMap[String, V]` to mirror the same impl that `Map[String, V]` already has in `json/from_json.mbt`.

## Motivation
`Map` and `HashMap` should have a consistent API. `HashMap` was missing JSON deserialization support.

## Changes
- Added `impl @json.FromJson for HashMap[String, V]` in `hashmap/json.mbt`
- Added `moonbitlang/core/json` as a non-test import in `hashmap/moon.pkg`
- Uses the public `JsonPath::add_key` API (enum variants are private)
- Updated `pkg.generated.mbti`