### PR TITLE
feat(quickcheck): add Arbitrary impl for Map to match HashMap

### DIFF
--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -168,3 +168,26 @@ pub impl[X : Arbitrary] Arbitrary for Array[X] with arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
   Array::makei(len, x => X::arbitrary(x, rs))
 }
+
+///|
+/// Returns a randomly generated map containing arbitrary key-value pairs.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let samples : Array[Map[Int, String]] = @quickcheck.samples(5)
+///   inspect(samples.length(), content="5")
+/// }
+/// ```
+pub impl[K : Arbitrary + Hash + Eq, V : Arbitrary] Arbitrary for Map[K, V] with arbitrary(
+  size,
+  rs,
+) {
+  let m : Map[K, V] = {}
+  let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
+  for _ in 0..<len {
+    m.set(K::arbitrary(size, rs), V::arbitrary(size, rs))
+  }
+  m
+}

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -186,8 +186,8 @@ pub impl[K : Arbitrary + Hash + Eq, V : Arbitrary] Arbitrary for Map[K, V] with 
 ) {
   let m : Map[K, V] = {}
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
-  for _ in 0..<len {
-    m.set(K::arbitrary(size, rs), V::arbitrary(size, rs))
+  for i in 0..<len {
+    m.set(K::arbitrary(i, rs), V::arbitrary(i, rs))
   }
   m
 }

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -38,4 +38,5 @@ pub impl Arbitrary for Bytes
 pub impl[X : Arbitrary] Arbitrary for Array[X]
 pub impl[A : Arbitrary] Arbitrary for ArrayView[A]
 pub impl[X : Arbitrary] Arbitrary for Iter[X]
+pub impl[K : Arbitrary + Hash + Eq, V : Arbitrary] Arbitrary for Map[K, V]
 


### PR DESCRIPTION
## Summary
Adds `impl @quickcheck.Arbitrary for Map[K, V]` in `quickcheck/arbitrary.mbt` alongside the other builtin type impls.

## Motivation
`HashMap` already has an `Arbitrary` impl in `hashmap/hashmap.mbt`, but the equivalent `Map` (LinkedHashMap in `builtin`) was missing one.

## Changes
- Added `impl Arbitrary for Map[K, V]` to `quickcheck/arbitrary.mbt`
- Generates keys and values independently (avoids a circular dependency with the `tuple` package)
- Updated `pkg.generated.mbti`