### PR TITLE
refactor(builtin): deprecate Map::of(FixedArray) in favor of Map / from_array

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -769,7 +769,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with equal(
 
 ///|
 /// Function `of`.
-#deprecated("Use `Map([..])` or `Map::from_array` instead")
+#deprecated("Use `Map([(k, v), ...])` or `Map::from_array` instead")
 pub fn[K : Hash + Eq, V] Map::of(arr : FixedArray[(K, V)]) -> Map[K, V] {
   let length = arr.length()
   let m = new_map(capacity_for_length(length))

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -769,6 +769,7 @@ pub impl[K : Hash + Eq, V : Eq] Eq for Map[K, V] with equal(
 
 ///|
 /// Function `of`.
+#deprecated("Use `Map([..])` or `Map::from_array` instead")
 pub fn[K : Hash + Eq, V] Map::of(arr : FixedArray[(K, V)]) -> Map[K, V] {
   let length = arr.length()
   let m = new_map(capacity_for_length(length))

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -49,6 +49,7 @@ test "Map::default" {
 }
 
 ///|
+#warnings("-deprecated")
 test "Map::of" {
   let arr : FixedArray[(String, Int)] = [("a", 1), ("b", 2), ("c", 3)]
   let map = Map::of(arr)

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -393,6 +393,7 @@ pub fn[K : Eq, V] Map::merge(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K : Eq, V] Map::merge_in_place(Self[K, V], Self[K, V]) -> Unit
 #deprecated
 pub fn[K, V] Map::new(capacity? : Int) -> Self[K, V]
+#deprecated
 pub fn[K : Hash + Eq, V] Map::of(FixedArray[(K, V)]) -> Self[K, V]
 pub fn[K : Hash + Eq, V] Map::remove(Self[K, V], K) -> Unit
 pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit


### PR DESCRIPTION
## Summary

`@hashmap.HashMap` already exposes `of` only as a deprecated alias of the canonical `HashMap::HashMap(ArrayView, capacity?)` / `from_array` constructor (see `hashmap/hashmap.mbt:58-65`).

`builtin.Map` still carried a separate, non-deprecated `Map::of(FixedArray)` function that duplicates the constructor's work but takes a different array shape (`FixedArray` instead of `ArrayView`) and doesn't accept `capacity?`.

This PR aligns the two map APIs: `Map::of` is now `#deprecated`, pointing users to `Map([..])` or `Map::from_array(..)`. The implementation is kept so existing call sites continue to compile (just with a warning).

- adds `#deprecated("Use \`Map([..])\` or \`Map::from_array\` instead")` to `Map::of`
- annotates the single in-tree caller (a grow-coverage test) with `#warnings(\"-deprecated\")` so it still exercises the deprecated path

After [moonbitlang/core#3586](https://github.com/moonbitlang/core/pull/3586) and this PR, `Map` and `HashMap` share the same recommended constructor surface.

## Test plan
- [x] `moon check` clean
- [x] `moon test --package moonbitlang/core/builtin` → 2827 passed
- [x] Verified no other `Map::of` usages in the repo (`grep -rn 'Map::of\\b' --include='*.mbt'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)