### PR TITLE
refactor(sorted_map): rename keys_as_iter/values_as_iter to keys/values

### DIFF
--- a/sorted_map/README.mbt.md
+++ b/sorted_map/README.mbt.md
@@ -167,8 +167,8 @@ Get all keys or values from the map.
 ///|
 test {
   let map = @sorted_map.from_array([(3, "three"), (1, "one"), (2, "two")])
-  @debug.assert_eq(map.keys_as_iter().collect(), [1, 2, 3])
-  @debug.assert_eq(map.values_as_iter().collect(), ["one", "two", "three"])
+  @debug.assert_eq(map.keys().collect(), [1, 2, 3])
+  @debug.assert_eq(map.values().collect(), ["one", "two", "three"])
 }
 ```
 

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -22,22 +22,3 @@ pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
   new_sorted_map()
 }
 
-///|
-/// Return an iterator of keys.
-#deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
-#coverage.skip
-pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
-  let keys = Array::new(capacity=self.size)
-  self.each((k, _v) => keys.push(k))
-  keys
-}
-
-///|
-/// Return an iterator of values.
-#deprecated("Use `values_as_iter` instead. `values` will return `Iter[V]` instead of `Array[V]` in the future.")
-#coverage.skip
-pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Array[V] {
-  let values = Array::new(capacity=self.size)
-  self.each((_k, v) => values.push(v))
-  values
-}

--- a/sorted_map/deprecated.mbt
+++ b/sorted_map/deprecated.mbt
@@ -21,4 +21,3 @@
 pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
   new_sorted_map()
 }
-

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -266,7 +266,8 @@ pub fn[K, V] SortedMap::eachi(
 
 ///|
 /// Returns an iterator over the keys in ascending order.
-pub fn[K, V] SortedMap::keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
+#alias(keys_as_iter, deprecated)
+pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Iter[K] {
   let todo_list = []
   let mut next_node = self.root
   Iter::new(
@@ -291,7 +292,8 @@ pub fn[K, V] SortedMap::keys_as_iter(self : SortedMap[K, V]) -> Iter[K] {
 
 ///|
 /// Returns an iterator over the values in ascending key order.
-pub fn[K, V] SortedMap::values_as_iter(self : SortedMap[K, V]) -> Iter[V] {
+#alias(values_as_iter, deprecated)
+pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Iter[V] {
   let todo_list = []
   let mut next_node = self.root
   Iter::new(

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -127,7 +127,7 @@ test "eachi" {
 test "keys" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
   debug_inspect(
-    map.keys_as_iter().to_array(),
+    map.keys().to_array(),
     content=(
       #|[1, 2, 3]
     ),
@@ -138,7 +138,7 @@ test "keys" {
 test "values" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
   debug_inspect(
-    map.values_as_iter().to_array(),
+    [..map.values()],
     content=(
       #|["a", "b", "c"]
     ),

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -42,9 +42,8 @@ pub fn[K, V] SortedMap::is_empty(Self[K, V]) -> Bool
 pub fn[K, V] SortedMap::iter(Self[K, V]) -> Iter[(K, V)]
 #alias(iterator2, deprecated)
 pub fn[K, V] SortedMap::iter2(Self[K, V]) -> Iter2[K, V]
-#deprecated
-pub fn[K, V] SortedMap::keys(Self[K, V]) -> Array[K]
-pub fn[K, V] SortedMap::keys_as_iter(Self[K, V]) -> Iter[K]
+#alias(keys_as_iter, deprecated)
+pub fn[K, V] SortedMap::keys(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 pub fn[K, V] SortedMap::length(Self[K, V]) -> Int
 pub fn[K : Compare, V] SortedMap::merge(Self[K, V], Self[K, V]) -> Self[K, V]
@@ -59,9 +58,8 @@ pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Compare, V] SortedMap::update_or_default(Self[K, V], K, V, (V) -> V) -> Unit
-#deprecated
-pub fn[K, V] SortedMap::values(Self[K, V]) -> Array[V]
-pub fn[K, V] SortedMap::values_as_iter(Self[K, V]) -> Iter[V]
+#alias(values_as_iter, deprecated)
+pub fn[K, V] SortedMap::values(Self[K, V]) -> Iter[V]
 pub impl[K, V] Default for SortedMap[K, V]
 pub impl[K : Eq, V : Eq] Eq for SortedMap[K, V]
 #deprecated


### PR DESCRIPTION
## Summary
- Complete the planned breaking change announced in the previous `#deprecated` notices: `SortedMap::keys`/`values` now return `Iter[K]`/`Iter[V]` instead of `Array`, taking over the names from `keys_as_iter`/`values_as_iter`.
- Preserve back-compat by exposing the old `_as_iter` names as deprecated aliases via `#alias(..., deprecated)`.
- Update internal callers (`README.mbt.md`, `map_test.mbt`) so the package builds without deprecation warnings.

## Test plan
- [x] `moon check` — clean, no warnings
- [x] `moon test` — full suite (6476 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)