### PR TITLE
refactor(immut/sorted_map): take over short names from _with_key forms

### DIFF
--- a/immut/sorted_map/README.mbt.md
+++ b/immut/sorted_map/README.mbt.md
@@ -111,29 +111,29 @@ test {
 }
 ```
 
-Use `map_with_key()` to map a function over all values.
+Use `map()` to map a function over all key-value pairs.
 
 ```mbt check
 ///|
 test {
   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
-  let map = map.map_with_key((_, v) => v + 1)
+  let map = map.map((_, v) => v + 1)
   assert_eq(map.values().collect(), [2, 3, 4])
-  let map = map.map_with_key((_k, v) => v + 1)
+  let map = map.map((_k, v) => v + 1)
   assert_eq(map.values().collect(), [3, 4, 5])
 }
 ```
 
-Use `foldl_with_key()` to fold the values in the map. The default order of fold
-is Pre-order. Similarly, you can use `rev_fold()` to do a Post-order fold.
+Use `fold()` to fold over the key-value pairs of the map. The default order is
+Pre-order; use `rev_fold()` for a Post-order fold.
 
 ```mbt check
 ///|
 test {
   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
-  assert_eq(map.foldl_with_key((acc, _, v) => acc + v, init=0), 6) // 6
+  assert_eq(map.fold((acc, _, v) => acc + v, init=0), 6) // 6
   assert_eq(
-    map.foldl_with_key((acc, k, v) => acc + k + v.to_string(), init=""),
+    map.fold((acc, k, v) => acc + k + v.to_string(), init=""),
     "a1b2c3",
   ) // "a1b2c3"
   assert_eq(
@@ -143,16 +143,16 @@ test {
 }
 ```
 
-Use `filter_with_key()` to filter all keys/values that satisfy the predicate.
+Use `filter()` to filter all key-value pairs that satisfy the predicate.
 
 ```mbt check
 ///|
 test {
   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
-  let map = map.filter_with_key((_, v) => v > 1)
+  let map = map.filter((_, v) => v > 1)
   assert_eq(map.values().collect(), [2, 3])
   assert_eq(map.keys_as_iter().collect(), ["b", "c"])
-  let map = map.filter_with_key((k, v) => k > "a" && v > 1)
+  let map = map.filter((k, v) => k > "a" && v > 1)
   assert_eq(map.values().collect(), [2, 3])
   assert_eq(map.keys_as_iter().collect(), ["b", "c"])
 }

--- a/immut/sorted_map/README.mbt.md
+++ b/immut/sorted_map/README.mbt.md
@@ -132,10 +132,7 @@ Pre-order; use `rev_fold()` for a Post-order fold.
 test {
   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
   assert_eq(map.fold((acc, _, v) => acc + v, init=0), 6) // 6
-  assert_eq(
-    map.fold((acc, k, v) => acc + k + v.to_string(), init=""),
-    "a1b2c3",
-  ) // "a1b2c3"
+  assert_eq(map.fold((acc, k, v) => acc + k + v.to_string(), init=""), "a1b2c3") // "a1b2c3"
   assert_eq(
     map.rev_fold((acc, k, v) => acc + k + v.to_string(), init=""),
     "c3b2a1",

--- a/immut/sorted_map/deprecated.mbt
+++ b/immut/sorted_map/deprecated.mbt
@@ -13,29 +13,6 @@
 // limitations under the License.
 
 ///|
-/// Ts over the values in the map.
-#deprecated("Use `map_with_key` instead. `map` will accept `(K, X) -> Y` in the future.")
-#coverage.skip
-pub fn[K, X, Y] SortedMap::map(
-  self : SortedMap[K, X],
-  f : (X) -> Y,
-) -> SortedMap[K, Y] {
-  self.map_with_key((_, value) => f(value))
-}
-
-///|
-/// Fold the values in the map.
-/// O(n).
-#deprecated("Use `foldl_with_key` instead. `fold` will accept `(A, K, V) -> A` in the future.")
-pub fn[K, V, A] SortedMap::fold(
-  self : SortedMap[K, V],
-  init~ : A,
-  f : (A, V) -> A,
-) -> A {
-  self.foldl_with_key((acc, _k, v) => f(acc, v), init~)
-}
-
-///|
 /// Return all keys of the map in ascending order.
 #deprecated("Use `keys_as_iter` instead. `keys` will return `Iter[K]` instead of `Array[K]` in the future.")
 #coverage.skip
@@ -49,15 +26,4 @@ pub fn[K, V] SortedMap::keys(self : SortedMap[K, V]) -> Array[K] {
 #coverage.skip
 pub fn[K, V] SortedMap::elems(self : SortedMap[K, V]) -> Array[V] {
   self.values().collect()
-}
-
-///|
-/// Filter values that satisfy the predicate
-#deprecated("Use `filter_with_key` instead. `filter` will accept `(K, V) -> Bool` in the future.")
-#coverage.skip
-pub fn[K, V] SortedMap::filter(
-  self : SortedMap[K, V],
-  pred : (V) -> Bool raise?,
-) -> SortedMap[K, V] raise? {
-  self.filter_with_key((_, v) => pred(v))
 }

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -105,7 +105,8 @@ pub fn[K : Compare, V] SortedMap::remove(
 
 ///|
 /// Filter key-value pairs that satisfy the predicate
-pub fn[K, V] SortedMap::filter_with_key(
+#alias(filter_with_key, deprecated)
+pub fn[K, V] SortedMap::filter(
   self : SortedMap[K, V],
   pred : (K, V) -> Bool raise?,
 ) -> SortedMap[K, V] raise? {
@@ -113,9 +114,9 @@ pub fn[K, V] SortedMap::filter_with_key(
     Empty => Empty
     Tree(k, value=v, l, r, ..) =>
       if pred(k, v) {
-        balance(k, v, l.filter_with_key(pred), r.filter_with_key(pred))
+        balance(k, v, l.filter(pred), r.filter(pred))
       } else {
-        glue(l.filter_with_key(pred), r.filter_with_key(pred))
+        glue(l.filter(pred), r.filter(pred))
       }
   }
 }
@@ -373,7 +374,7 @@ test "map" {
     (2, "two"),
     (0, "zero"),
   ])
-  let n = m.map_with_key((_, v) => v + "X")
+  let n = m.map((_, v) => v + "X")
   @test.assert_eq(
     n.debug_tree(),
     "(3,threeX,(1,oneX,(0,zeroX,_,_),(2,twoX,_,_)),(8,eightX,_,_))",
@@ -389,7 +390,7 @@ test "map_with_key" {
     (2, "two"),
     (0, "zero"),
   ])
-  let n = m.map_with_key((k, v) => "\{k}-\{v}")
+  let n = m.map((k, v) => "\{k}-\{v}")
   @test.assert_eq(
     n.debug_tree(),
     "(3,3-three,(1,1-one,(0,0-zero,_,_),(2,2-two,_,_)),(8,8-eight,_,_))",
@@ -405,7 +406,7 @@ test "filter" {
     (2, "two"),
     (0, "zero"),
   ])
-  let fm = m.filter_with_key((_, v) => v.length() > 3)
+  let fm = m.filter((_, v) => v.length() > 3)
   inspect(fm.debug_tree(), content="(3,three,(0,zero,_,_),(8,eight,_,_))")
 }
 
@@ -418,7 +419,7 @@ test "filter_with_key" {
     (2, "two"),
     (0, "zero"),
   ])
-  let fm = m.filter_with_key((k, v) => k > 3 && v.length() > 3)
+  let fm = m.filter((k, v) => k > 3 && v.length() > 3)
   inspect(fm.debug_tree(), content="(8,eight,_,_)")
 }
 

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -107,7 +107,7 @@ test "fold" {
     ("d", 4),
     ("e", 5),
   ])
-  assert_eq(m.foldl_with_key((acc, _, v) => acc + v, init=0), 15)
+  assert_eq(m.fold((acc, _, v) => acc + v, init=0), 15)
 }
 
 ///|
@@ -120,7 +120,7 @@ test "foldl_with_key" {
     ("e", 5),
   ])
   assert_eq(
-    m.foldl_with_key((acc, k, v) => acc + k + v.to_string(), init=""),
+    m.fold((acc, k, v) => acc + k + v.to_string(), init=""),
     "a1b2c3d4e5",
   )
 }

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -24,12 +24,10 @@ pub fn[K, V] SortedMap::each(Self[K, V], (K, V) -> Unit) -> Unit
 pub fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::elems(Self[K, V]) -> Array[V]
-#deprecated
-pub fn[K, V] SortedMap::filter(Self[K, V], (V) -> Bool raise?) -> Self[K, V] raise?
-pub fn[K, V] SortedMap::filter_with_key(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
-#deprecated
-pub fn[K, V, A] SortedMap::fold(Self[K, V], init~ : A, (A, V) -> A) -> A
-pub fn[K, V, A] SortedMap::foldl_with_key(Self[K, V], (A, K, V) -> A, init~ : A) -> A
+#alias(filter_with_key, deprecated)
+pub fn[K, V] SortedMap::filter(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
+#alias(foldl_with_key, deprecated)
+pub fn[K, V, A] SortedMap::fold(Self[K, V], (A, K, V) -> A, init~ : A) -> A
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn
@@ -52,9 +50,8 @@ pub fn[K, V] SortedMap::keys(Self[K, V]) -> Array[K]
 pub fn[K, V] SortedMap::keys_as_iter(Self[K, V]) -> Iter[K]
 #alias(size, deprecated)
 pub fn[K, V] SortedMap::length(Self[K, V]) -> Int
-#deprecated
-pub fn[K, X, Y] SortedMap::map(Self[K, X], (X) -> Y) -> Self[K, Y]
-pub fn[K, X, Y] SortedMap::map_with_key(Self[K, X], (K, X) -> Y) -> Self[K, Y]
+#alias(map_with_key, deprecated)
+pub fn[K, X, Y] SortedMap::map(Self[K, X], (K, X) -> Y) -> Self[K, Y]
 pub fn[K : Compare, V] SortedMap::merge(Self[K, V], Self[K, V]) -> Self[K, V]
 #alias(empty, deprecated)
 #as_free_fn

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -160,14 +160,15 @@ pub fn[K, V] SortedMap::eachi(
 
 ///|
 /// Maps over the key-value pairs in the map.
-pub fn[K, X, Y] SortedMap::map_with_key(
+#alias(map_with_key, deprecated)
+pub fn[K, X, Y] SortedMap::map(
   self : SortedMap[K, X],
   f : (K, X) -> Y,
 ) -> SortedMap[K, Y] {
   match self {
     Empty => Empty
     Tree(k, value~, l, r, size~) =>
-      Tree(k, value=f(k, value), size~, l.map_with_key(f), r.map_with_key(f))
+      Tree(k, value=f(k, value), size~, l.map(f), r.map(f))
   }
 }
 
@@ -193,7 +194,8 @@ pub fn[K, V, A] SortedMap::rev_fold(
 ///|
 /// Pre-order fold.
 /// O(n).
-pub fn[K, V, A] SortedMap::foldl_with_key(
+#alias(foldl_with_key, deprecated)
+pub fn[K, V, A] SortedMap::fold(
   self : SortedMap[K, V],
   f : (A, K, V) -> A,
   init~ : A,

--- a/internal/regex_engine/automata/mark_slot_map.mbt
+++ b/internal/regex_engine/automata/mark_slot_map.mbt
@@ -52,7 +52,7 @@ fn MarkSlotMap::add_mark(self : MarkSlotMap, mark : Mark) -> MarkSlotMap {
 ///|
 fn MarkSlotMap::assign_slot(self : MarkSlotMap, slot : Slot) -> MarkSlotMap {
   MarkSlotMap(
-    self.0.map_with_key((_mark, prev_slot) => {
+    self.0.map((_mark, prev_slot) => {
       if prev_slot.is_assigned() {
         prev_slot
       } else {


### PR DESCRIPTION
## Summary
- Completes the planned breaking change announced in the existing `#deprecated` notices: `SortedMap::map` / `fold` / `filter` now accept the full `(K, X) -> Y`, `(A, K, V) -> A`, `(K, V) -> Bool` shapes, taking over the names from `map_with_key` / `foldl_with_key` / `filter_with_key`.
- Mirrors the same migration already done on `@immut/hashmap` (`immut/hashmap/HAMT.mbt:171,214,237`) and the recent #3591 rename on the mutable `@sorted_map`.
- The long `_with_key` names are preserved as deprecated aliases via `#alias(<name>_with_key, deprecated)` so existing callers keep compiling.
- Removes the placeholder deprecated `map` / `fold` / `filter` stubs in `immut/sorted_map/deprecated.mbt` that were reserving the short names.
- Updates the one internal external caller (`internal/regex_engine/automata/mark_slot_map.mbt`) and the package README / tests so the workspace builds without deprecation warnings.

## Test plan
- [x] `moon check` — clean, no warnings
- [x] `moon test --package moonbitlang/core/immut/sorted_map` — 104 passed
- [x] `moon test` — full suite, 6484 passed
- [x] Regenerated `immut/sorted_map/pkg.generated.mbti`

🤖 Generated with [Claude Code](https://claude.com/claude-code)