### PR TITLE
fix(builtin): make StringView Show::output match Show::to_string

### DIFF
--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -82,7 +82,7 @@ fn SourceLocRepr::parse(repr : String) -> SourceLocRepr {
 fn SourceLocRepr::to_json_string(self : SourceLocRepr) -> String {
   let sb = StringBuilder()
   sb.write_string("{\"filename\":")
-  sb.write_object(self.filename)
+  self.filename.escape_to(sb)
   sb.write_string(",\"start_line\":\{self.start_line}")
   sb.write_string(",\"start_column\":\{self.start_column}")
   sb.write_string(",\"end_line\":\{self.end_line}")

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -163,11 +163,6 @@ pub fn StringView::char_length(self : StringView) -> Int {
 }
 
 ///|
-pub impl Show for StringView with output(self, logger) {
-  self.escape_to(logger)
-}
-
-///|
 /// Materialize this view into an owned `String`.
 ///
 /// This crosses an ownership boundary and generally allocates. Use format

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -323,3 +323,27 @@ test "StringView::equal_to_string" {
   inspect(smile[:].equal_to_string("Hello🤣World"), content="true")
   inspect(smile[5:7].equal_to_string("🤣"), content="true")
 }
+
+///|
+/// `Show::output` for `StringView` must agree with `Show::to_string` and write
+/// the raw view contents (no quoting/escaping), matching the behavior of
+/// `Show` for `String`.
+test "StringView Show output matches to_string" {
+  fn via_output(v : StringView) {
+    let sb = StringBuilder()
+    sb.write_object(v)
+    sb.to_string()
+  }
+
+  let cases = [
+    "", "hello", "quote\"and\\back", "line1\nline2", "Hello🤣World",
+  ]
+  for case in cases {
+    let v = case[:]
+    assert_eq(via_output(v), Show::to_string(v))
+    assert_eq(via_output(v), case)
+  }
+  // Sub-view also produces raw, unescaped contents.
+  let s = "ab\"cd"
+  inspect(s[1:4], content="b\"c")
+}


### PR DESCRIPTION
## Summary
- `Show` trait doc states `output` and `to_string` must produce identical text, and `String`'s impl matches (both return the raw string). `StringView` violated this — `output` wrote a quoted/escaped form via `escape_to` while `to_string` returned the raw view.
- Drop the `Show for StringView with output` override so the trait default (`write_string(to_string())`) kicks in, restoring the invariant.
- `SourceLocRepr::to_json_string` was implicitly relying on the buggy escape to quote its filename field; switched it to call `escape_to` explicitly so its JSON output is preserved.
- Added a test exercising `Show::output` (via `StringBuilder::write_object`) and `Show::to_string` side-by-side on plain, special-character, and multi-byte StringViews.

## Test plan
- [x] `moon test --target all` (wasm / wasm-gc / js / native) — 6485 / 6485 / 6444 / 6396 passing
- [x] `moon fmt` and `moon info` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)