### PR TITLE
refactor(builtin): allow raising closure in Array::rev_each

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -469,7 +469,10 @@ pub fn[T] Array::each(self : Array[T], f : (T) -> Unit raise?) -> Unit raise? {
 /// }
 /// ```
 #locals(f)
-pub fn[T] Array::rev_each(self : Array[T], f : (T) -> Unit raise?) -> Unit raise? {
+pub fn[T] Array::rev_each(
+  self : Array[T],
+  f : (T) -> Unit raise?,
+) -> Unit raise? {
   let len = self.length()
   for i in 0..<len {
     f(self[len - i - 1])

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -469,7 +469,7 @@ pub fn[T] Array::each(self : Array[T], f : (T) -> Unit raise?) -> Unit raise? {
 /// }
 /// ```
 #locals(f)
-pub fn[T] Array::rev_each(self : Array[T], f : (T) -> Unit) -> Unit {
+pub fn[T] Array::rev_each(self : Array[T], f : (T) -> Unit raise?) -> Unit raise? {
   let len = self.length()
   for i in 0..<len {
     f(self[len - i - 1])

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -134,7 +134,7 @@ pub fn[T] Array::resize(Self[T], Int, T) -> Unit
 pub fn[T] Array::retain(Self[T], (T) -> Bool raise?) -> Unit raise?
 pub fn[A] Array::retain_map(Self[A], (A) -> A?) -> Unit
 pub fn[T] Array::rev(Self[T]) -> Self[T]
-pub fn[T] Array::rev_each(Self[T], (T) -> Unit) -> Unit
+pub fn[T] Array::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] Array::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 #alias(fold_right, deprecated)
 pub fn[A, B] Array::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?


### PR DESCRIPTION
## Summary
- `Array::rev_each` accepted a non-raising `(T) -> Unit`, while every sibling iteration method — `Array::each`, `Array::eachi`, `Array::rev_eachi`, and `ArrayView/FixedArray/ReadOnlyArray::rev_each` — already accepted `(T) -> Unit raise?`.
- Widen the signature to match. Existing callers that pass a non-raising closure are unaffected.

## Test plan
- [x] `moon check` clean
- [x] `moon test -p moonbitlang/core/builtin` — all 2831 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)