### PR TITLE
refactor(builtin): allow raising predicate in Array::search_by

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1003,7 +1003,10 @@ pub fn[T : Eq] Array::search(self : Array[T], value : T) -> Int? {
 /// ```
 #locals(f)
 #alias(find_index, deprecated)
-pub fn[T] Array::search_by(self : Array[T], f : (T) -> Bool) -> Int? {
+pub fn[T] Array::search_by(
+  self : Array[T],
+  f : (T) -> Bool raise?,
+) -> Int? raise? {
   for i, v in self {
     if f(v) {
       break Some(i)

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -146,7 +146,7 @@ pub fn[T] Array::rev_in_place(Self[T]) -> Unit
 pub fn[T] Array::rev_iter(Self[T]) -> Iter[T]
 pub fn[T : Eq] Array::search(Self[T], T) -> Int?
 #alias(find_index, deprecated)
-pub fn[T] Array::search_by(Self[T], (T) -> Bool) -> Int?
+pub fn[T] Array::search_by(Self[T], (T) -> Bool raise?) -> Int? raise?
 #alias("_[_]=_")
 pub fn[T] Array::set(Self[T], Int, T) -> Unit
 pub fn[T] Array::shrink_to_fit(Self[T]) -> Unit


### PR DESCRIPTION
## Summary
- `Array::search_by` accepted `(T) -> Bool`, while `ArrayView::search_by` already accepted `(T) -> Bool raise?`.
- Widen `Array::search_by` to match. Existing non-raising callers continue to work; raising predicates now compose without going through a view first.

## Test plan
- [x] `moon check` clean
- [x] `moon test` — all 6484 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)