### PR TITLE
refactor(builtin): generalize ReadOnlyArray::join to ToStringView

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -926,7 +926,7 @@ pub fn[T : Compare] ReadOnlyArray::is_sorted(Self[T]) -> Bool
 #alias(iterator, deprecated)
 pub fn[T] ReadOnlyArray::iter(Self[T]) -> Iter[T]
 pub fn[T] ReadOnlyArray::iter2(Self[T]) -> Iter2[Int, T]
-pub fn ReadOnlyArray::join(Self[String], StringView) -> String
+pub fn[A : ToStringView] ReadOnlyArray::join(Self[A], StringView) -> String
 pub fn[T] ReadOnlyArray::last(Self[T]) -> T?
 pub fn[T] ReadOnlyArray::length(Self[T]) -> Int
 pub fn[T] ReadOnlyArray::makei(Int, (Int) -> T raise?) -> Self[T] raise?

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -614,7 +614,7 @@ pub fn[T] ReadOnlyArray::get_view(
 }
 
 ///|
-/// Joins string elements with a separator.
+/// Joins the string-renderable elements with a separator.
 ///
 /// # Example
 /// ```mbt check
@@ -624,11 +624,11 @@ pub fn[T] ReadOnlyArray::get_view(
 ///   inspect(arr.join(" "), content="hello world moon")
 /// }
 /// ```
-pub fn ReadOnlyArray::join(
-  self : ReadOnlyArray[String],
+pub fn[A : ToStringView] ReadOnlyArray::join(
+  self : ReadOnlyArray[A],
   separator : StringView,
 ) -> String {
-  self.unsafe_reinterpret_to_fixed_array().join(separator)
+  self[:].join(separator)
 }
 
 ///|

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -105,6 +105,10 @@ test "ReadOnlyArray trait implementations" {
   // Test join for strings
   let str_arr : ReadOnlyArray[String] = ["a", "b", "c"]
   inspect(str_arr.join(","), content="a,b,c")
+
+  // Test join for any ToStringView element (here: StringView).
+  let view_arr : ReadOnlyArray[StringView] = ["a"[:], "b"[:], "c"[:]]
+  inspect(view_arr.join("-"), content="a-b-c")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- `Array::join` and `ArrayView::join` accept any `[A : ToStringView]` element type, but `ReadOnlyArray::join` was restricted to `Self[String]`. That left `ReadOnlyArray[StringView]` (and any other `ToStringView` user type) unable to use `.join`.
- Generalize the signature and route through `ArrayView::join` via `self[:]` so we keep a single implementation path. Existing `ReadOnlyArray[String]` callers continue to compile unchanged.
- Add a test covering `ReadOnlyArray[StringView]`.

Note: `FixedArray::join` and `Iter::join` are also still restricted to `Self[String]`. Leaving those for separate PRs.

## Test plan
- [x] `moon check` clean
- [x] `moon test` — all 6484 tests pass (including new StringView-element join test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)