### PR TITLE
fix(builtin): make StringView Show::output consistent with Show::to_string

### DIFF
--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -189,6 +189,11 @@ pub fn StringView::to_owned(self : StringView) -> String {
 }
 
 ///|
+pub impl Show for StringView with output(self, logger) {
+  logger.write_view(self)
+}
+
+///|
 pub impl Show for StringView with to_string(self) {
   self.to_owned()
 }


### PR DESCRIPTION

avoid intermediate allocation