### PR TITLE
refactor(builtin): generalize FixedArray::join to ToStringView

### DIFF
--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1458,44 +1458,46 @@ pub fn[A] FixedArray::last(self : FixedArray[A]) -> A? {
 }
 
 ///|
-/// Concatenate strings within an array into a single complete string.
+/// Concatenate the string-renderable elements of the array into a single
+/// complete string, separated by `separator`.
 ///
 /// Example:
-/// 
+///
 /// ```mbt check
 /// test {
 ///   let fixed_array : FixedArray[String] = ["1", "2", "3"]
 ///   inspect(fixed_array.join(","), content="1,2,3")
 /// }
 /// ```
-pub fn FixedArray::join(
-  self : FixedArray[String],
+pub fn[A : ToStringView] FixedArray::join(
+  self : FixedArray[A],
   separator : StringView,
 ) -> String {
   let len = self.length()
   if len == 0 {
     return ""
   }
-  let first = self[0]
+  let first = self[0].to_string_view()
   let size_hint = for i in 1..<len; size_hint = first.length() {
-    continue size_hint + separator.length() + self[i].length()
+    continue size_hint + separator.length() + self[i].to_string_view().length()
   } nobreak {
     size_hint
   }
   let string = StringBuilder(size_hint~)
   if separator.is_empty() {
-    for i in 0..<len {
-      string.write_string(self[i])
+    string.write_view(first)
+    for i in 1..<len {
+      string.write_view(self[i].to_string_view())
     }
   } else {
-    string.write_string(self[0])
+    string.write_view(first)
     for i in 1..<len {
       string.write_substring(
         separator.data(),
         separator.start_offset(),
         separator.length(),
       )
-      string.write_string(self[i])
+      string.write_view(self[i].to_string_view())
     }
   }
   string.to_string()
@@ -1541,6 +1543,9 @@ test "FixedArray::join" {
   inspect(fixed_array.join(" "), content="1 2 3")
   let fixed_array_empty : FixedArray[String] = []
   inspect(fixed_array_empty.join(","), content="")
+  // Any ToStringView element type works (here: StringView).
+  let view_array : FixedArray[StringView] = ["a"[:], "b"[:], "c"[:]]
+  inspect(view_array.join("-"), content="a-b-c")
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -863,7 +863,7 @@ pub fn[T : Compare] FixedArray::is_sorted(Self[T]) -> Bool
 pub fn[X] FixedArray::iter(Self[X]) -> Iter[X]
 #alias(iterator2, deprecated)
 pub fn[X] FixedArray::iter2(Self[X]) -> Iter2[Int, X]
-pub fn FixedArray::join(Self[String], StringView) -> String
+pub fn[A : ToStringView] FixedArray::join(Self[A], StringView) -> String
 pub fn[A] FixedArray::last(Self[A]) -> A?
 pub fn[T] FixedArray::length(Self[T]) -> Int
 pub fn[T : Compare] FixedArray::lexical_compare(Self[T], Self[T]) -> Int


### PR DESCRIPTION
## Summary
- `Array::join` and `ArrayView::join` already accept any `[A : ToStringView]` element type, and `ReadOnlyArray::join` was widened in #3598. `FixedArray::join` was the last holdout still hard-coded to `Self[String]`.
- Widen it to match. The body keeps its size-hint pre-pass and `StringBuilder` strategy; only the element type and the per-element `to_string_view()` coercion change.
- Add a `FixedArray[StringView]` test covering the generalization.

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test` — all 6485 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)