### PR TITLE
refactor(builtin): allow raising predicate in Array::extract_if

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1444,7 +1444,10 @@ pub fn[T : Eq] Array::dedup(self : Array[T]) -> Unit {
 /// }
 /// ```
 #locals(f)
-pub fn[T] Array::extract_if(self : Array[T], f : (T) -> Bool) -> Array[T] {
+pub fn[T] Array::extract_if(
+  self : Array[T],
+  f : (T) -> Bool raise?,
+) -> Array[T] raise? {
   let removed = []
   for read in 0..<self.length(); write = 0 {
     let elem = self[read]

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -89,7 +89,7 @@ pub fn[T] Array::drain(Self[T], Int, Int) -> Self[T]
 pub fn[T] Array::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] Array::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] Array::ends_with(Self[T], ArrayView[T]) -> Bool
-pub fn[T] Array::extract_if(Self[T], (T) -> Bool) -> Self[T]
+pub fn[T] Array::extract_if(Self[T], (T) -> Bool raise?) -> Self[T] raise?
 pub fn[A] Array::fill(Self[A], A, start? : Int, end? : Int) -> Unit
 pub fn[T] Array::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
 pub fn[A, B] Array::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?


### PR DESCRIPTION
## Summary
- Sibling combinators (`Array::filter`, `Array::retain`, `Array::split`, `Array::chunk_by`, `Array::filter_map`) all accept `(T) -> Bool raise?`. `Array::extract_if` was the odd one out, restricted to non-raising predicates. Widen its signature to match.
- Behavior on a raising predicate matches `Array::retain`: the array may be left in a partially-compacted state because the trailing \`truncate\` runs only after the loop's normal exit. This is the same trade-off the rest of the family already makes.

## Test plan
- [x] \`moon check\` clean
- [x] \`moon fmt\` clean
- [x] \`moon test\` — all 6485 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)