### PR TITLE
refactor(builtin): allow raising mapper in Array::retain_map

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1845,7 +1845,10 @@ pub fn[A] Array::truncate(self : Array[A], len : Int) -> Unit {
 /// }
 /// ```
 #locals(f)
-pub fn[A] Array::retain_map(self : Array[A], f : (A) -> A?) -> Unit {
+pub fn[A] Array::retain_map(
+  self : Array[A],
+  f : (A) -> A? raise?,
+) -> Unit raise? {
   if self.is_empty() {
     return
   }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -132,7 +132,7 @@ pub fn[T] Array::repeat(Self[T], Int) -> Self[T]
 pub fn[T] Array::reserve_capacity(Self[T], Int) -> Unit
 pub fn[T] Array::resize(Self[T], Int, T) -> Unit
 pub fn[T] Array::retain(Self[T], (T) -> Bool raise?) -> Unit raise?
-pub fn[A] Array::retain_map(Self[A], (A) -> A?) -> Unit
+pub fn[A] Array::retain_map(Self[A], (A) -> A? raise?) -> Unit raise?
 pub fn[T] Array::rev(Self[T]) -> Self[T]
 pub fn[T] Array::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] Array::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?


### PR DESCRIPTION
## Summary
- `Array::retain` and `Array::filter_map` both accept a raising closure, but `Array::retain_map` — which is the in-place hybrid of the two — was restricted to a non-raising mapper. Widen its signature to match.
- Behavior on a raising mapper matches `Array::retain`: the array may be left in a partially-compacted state if the trailing `truncate` doesn't run. This is the same trade-off the rest of the family already makes.

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test` — all 6485 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)