### PR TITLE
refactor(builtin): generalize Iter::join to ToStringView

### DIFF
--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -960,6 +960,12 @@ test "@builtin.join/multiple_elements_without_separator" {
 }
 
 ///|
+test "@builtin.join/any_to_string_view_element" {
+  let iter : Iter[StringView] = ["a"[:], "b"[:], "c"[:]].iter()
+  inspect(iter.join("-"), content="a-b-c")
+}
+
+///|
 test "Iter::nth" {
   let it = () => [1, 2, 3, 4, 5].iter()
   debug_inspect(it().nth(2), content="Some(3)")

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -465,15 +465,16 @@ pub fn[X] Iter::flatten(self : Iter[Iter[X]]) -> Iter[X] {
 }
 
 ///|
-/// Collects the elements of the iterator into a string.
+/// Collects the string-renderable elements of the iterator into a single
+/// string, separated by `sep`.
 /// The old iterator `self` must not be used again after calling `join`.
-pub fn Iter::join(self : Iter[String], sep : StringView) -> String {
+pub fn[A : ToStringView] Iter::join(self : Iter[A], sep : StringView) -> String {
   let result = StringBuilder()
   if self.next() is Some(x) {
-    result.write_string(x)
+    result.write_view(x.to_string_view())
     while self.next() is Some(x) {
       result.write_view(sep)
-      result.write_string(x)
+      result.write_view(x.to_string_view())
     }
   }
   result.to_string()

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -284,7 +284,7 @@ pub fn[X] Iter::intersperse(Self[X], X) -> Self[X]
 pub fn[X] Iter::iter(Self[X]) -> Self[X]
 #alias(iterator2)
 pub fn[X] Iter::iter2(Self[X]) -> Iter2[Int, X]
-pub fn Iter::join(Self[String], StringView) -> String
+pub fn[A : ToStringView] Iter::join(Self[A], StringView) -> String
 #deprecated
 pub fn[X] Iter::just_run(Self[X], (X) -> IterResult) -> Unit
 pub fn[X] Iter::last(Self[X]) -> X?


### PR DESCRIPTION
## Summary
- `Array::join`, `ArrayView::join`, `ReadOnlyArray::join` (#3598), and `FixedArray::join` (#3600) all accept any `[A : ToStringView]` element type. `Iter::join` was the last holdout still hard-coded to `Iter[String]`.
- Widen the signature and use `to_string_view()` on each element. Add an `Iter[StringView]` test covering the new path.

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test` — all 6485 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)