### PR TITLE
feat(builtin): add ReadOnlyArray::search_by

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -938,6 +938,7 @@ pub fn[T] ReadOnlyArray::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit rai
 pub fn[A, B] ReadOnlyArray::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ReadOnlyArray::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 pub fn[T : Eq] ReadOnlyArray::search(Self[T], T) -> Int?
+pub fn[T] ReadOnlyArray::search_by(Self[T], (T) -> Bool raise?) -> Int? raise?
 pub fn[T : Eq] ReadOnlyArray::starts_with(Self[T], ArrayView[T]) -> Bool
 #alias("_[_:_]")
 #alias(sub, deprecated)

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -413,6 +413,24 @@ pub fn[T : Eq] ReadOnlyArray::search(
 }
 
 ///|
+/// Returns the index of the first element satisfying `f`, or `None`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+///   debug_inspect(arr.search_by(x => x > 3), content="Some(3)")
+///   debug_inspect(arr.search_by(x => x > 99), content="None")
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::search_by(
+  self : ReadOnlyArray[T],
+  f : (T) -> Bool raise?,
+) -> Int? raise? {
+  self[:].search_by(f)
+}
+
+///|
 /// Checks if the ReadOnlyArray contains a specific value.
 ///
 /// # Example

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -77,6 +77,10 @@ test "ReadOnlyArray search methods" {
   debug_inspect(arr.search(2), content="Some(1)")
   debug_inspect(arr.search(5), content="None")
 
+  // Test search_by
+  debug_inspect(arr.search_by(x => x > 2), content="Some(2)")
+  debug_inspect(arr.search_by(x => x > 99), content="None")
+
   // Test contains
   inspect(arr.contains(3), content="true")
   inspect(arr.contains(5), content="false")


### PR DESCRIPTION
## Summary
- `ReadOnlyArray` already exposes `search` (by value, requires `Eq`), but lacked the predicate-based `search_by` that both `Array` and `ArrayView` provide.
- Add it, delegating through `ArrayView::search_by` via `self[:]`. Signature matches the sibling APIs (`(T) -> Bool raise?`).

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test -p moonbitlang/core/builtin` — 2833 tests pass (added Some/None cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)