### PR TITLE
feat(builtin): add ReadOnlyArray::lexical_compare

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -929,6 +929,7 @@ pub fn[T] ReadOnlyArray::iter2(Self[T]) -> Iter2[Int, T]
 pub fn[A : ToStringView] ReadOnlyArray::join(Self[A], StringView) -> String
 pub fn[T] ReadOnlyArray::last(Self[T]) -> T?
 pub fn[T] ReadOnlyArray::length(Self[T]) -> Int
+pub fn[T : Compare] ReadOnlyArray::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T] ReadOnlyArray::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 pub fn[T, U] ReadOnlyArray::map(Self[T], (T) -> U raise?) -> Self[U] raise?
 pub fn[T, U] ReadOnlyArray::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -575,6 +575,32 @@ pub fn[T] ReadOnlyArray::binary_search_by(
 }
 
 ///|
+/// Performs a lexicographical comparison of two arrays.
+///
+/// Unlike the `Compare` trait implementation (shortlex — shorter arrays come
+/// first), this method compares purely by element values; length only breaks
+/// ties when one array is a prefix of the other.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let a : ReadOnlyArray[Int] = [1, 2]
+///   let b : ReadOnlyArray[Int] = [1, 2, 3]
+///   inspect(a.lexical_compare(b), content="-1")
+///   inspect(b.lexical_compare(a), content="1")
+///   inspect(b.lexical_compare(b), content="0")
+///   let c : ReadOnlyArray[Int] = [1, 2, 4]
+///   inspect(b.lexical_compare(c), content="-1")
+/// }
+/// ```
+pub fn[T : Compare] ReadOnlyArray::lexical_compare(
+  self : ReadOnlyArray[T],
+  other : ReadOnlyArray[T],
+) -> Int {
+  self[:].lexical_compare(other[:])
+}
+
+///|
 /// Creates a view of a subarray.
 ///
 /// # Example

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -165,6 +165,25 @@ test "ReadOnlyArray compare" {
 }
 
 ///|
+test "ReadOnlyArray lexical_compare" {
+  let a : ReadOnlyArray[Int] = [1, 2]
+  let b : ReadOnlyArray[Int] = [1, 2, 3]
+  let c : ReadOnlyArray[Int] = [1, 2, 4]
+  inspect(a.lexical_compare(b), content="-1") // a is a strict prefix
+  inspect(b.lexical_compare(a), content="1")
+  inspect(b.lexical_compare(b), content="0")
+  inspect(b.lexical_compare(c), content="-1")
+
+  // The pure-lex order differs from shortlex `compare` when one array is
+  // longer but its first differing element is greater. With shortlex, the
+  // shorter wins (length first); with lexical, the smaller element wins.
+  let short_big : ReadOnlyArray[Int] = [9]
+  let long_small : ReadOnlyArray[Int] = [1, 2, 3]
+  inspect(short_big.compare(long_small), content="-1") // shortlex
+  inspect(short_big.lexical_compare(long_small), content="1") // lex
+}
+
+///|
 test "ReadOnlyArray iter and sub" {
   let arr : ReadOnlyArray[Int] = [1, 2, 3]
   debug_inspect(arr.iter().to_array(), content="[1, 2, 3]")


### PR DESCRIPTION
## Summary
- `ReadOnlyArray` implements `Compare`, but that's shortlex (length first, ties broken element-wise) — same as `Array` / `FixedArray`'s `Compare` impl.
- `Array`, `ArrayView`, and `FixedArray` additionally expose `lexical_compare` for the pure lexicographic order (element-wise first; length only breaks ties when one is a prefix of the other). `ReadOnlyArray` was the lone holdout.
- Added by delegating through `ArrayView::lexical_compare` via `self[:]`.
- Test covers the divergence between shortlex `compare` and pure-lex `lexical_compare`.

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test -p moonbitlang/core/builtin` — 2834 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)