### PR TITLE
feat(builtin): add ReadOnlyArray::rev_iter

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -938,6 +938,7 @@ pub fn[T] ReadOnlyArray::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[A, B] ReadOnlyArray::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ReadOnlyArray::rev_foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
+pub fn[T] ReadOnlyArray::rev_iter(Self[T]) -> Iter[T]
 pub fn[T : Eq] ReadOnlyArray::search(Self[T], T) -> Int?
 pub fn[T] ReadOnlyArray::search_by(Self[T], (T) -> Bool raise?) -> Int? raise?
 pub fn[T : Eq] ReadOnlyArray::starts_with(Self[T], ArrayView[T]) -> Bool

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -184,6 +184,22 @@ pub fn[T] ReadOnlyArray::iter2(self : ReadOnlyArray[T]) -> Iter2[Int, T] {
 }
 
 ///|
+/// Returns an iterator that yields each element from the last to the first.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3]
+///   let result = []
+///   arr.rev_iter().each(x => result.push(x))
+///   debug_inspect(result, content="[3, 2, 1]")
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::rev_iter(self : ReadOnlyArray[T]) -> Iter[T] {
+  self[:].rev_iter()
+}
+
+///|
 /// Iterates over each element in the ReadOnlyArray.
 ///
 /// # Example

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -195,6 +195,9 @@ test "ReadOnlyArray strip_prefix and strip_suffix" {
 test "ReadOnlyArray iter and sub" {
   let arr : ReadOnlyArray[Int] = [1, 2, 3]
   debug_inspect(arr.iter().to_array(), content="[1, 2, 3]")
+  debug_inspect(arr.rev_iter().to_array(), content="[3, 2, 1]")
+  let empty : ReadOnlyArray[Int] = []
+  debug_inspect(empty.rev_iter().to_array(), content="[]")
   debug_inspect(
     arr[1:],
     content=(


### PR DESCRIPTION
## Summary
- `Array`, `ArrayView`, `MutArrayView`, and `FixedArray` (via its iter chain) all expose `rev_iter` to walk from the last element to the first. `ReadOnlyArray` had `iter` and `iter2` but not the reverse counterpart.
- Add it, delegating through `ArrayView::rev_iter` via `self[:]`.

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test -p moonbitlang/core/builtin` — 2833 tests pass (covers non-empty + empty cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)