### PR TITLE
feat(builtin): add ReadOnlyArray::filter and filter_map

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -914,6 +914,8 @@ pub fn[T : Eq] ReadOnlyArray::contains(Self[T], T) -> Bool
 pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ReadOnlyArray::ends_with(Self[T], ArrayView[T]) -> Bool
+pub fn[T] ReadOnlyArray::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
+pub fn[A, B] ReadOnlyArray::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 pub fn[A, B] ReadOnlyArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ReadOnlyArray::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 pub fn[T] ReadOnlyArray::from_array(ArrayView[T]) -> Self[T]

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -317,6 +317,53 @@ pub fn[T, U] ReadOnlyArray::mapi(
 }
 
 ///|
+/// Returns a new ReadOnlyArray containing the elements for which `f` returns
+/// `true`, in original order.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+///   debug_inspect(
+///     arr.filter(x => x % 2 == 0),
+///     content=(
+///       #|<ReadOnlyArray: [2, 4]>
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::filter(
+  self : ReadOnlyArray[T],
+  f : (T) -> Bool raise?,
+) -> ReadOnlyArray[T] raise? {
+  ReadOnlyArray::from_array(self[:].filter(f)[:])
+}
+
+///|
+/// Returns a new ReadOnlyArray that maps and filters in one pass: for each
+/// element, `Some(new_value)` includes the mapped value and `None` drops it.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+///   let out = arr.filter_map(x => if x % 2 == 0 { Some(x * 10) } else { None })
+///   debug_inspect(
+///     out,
+///     content=(
+///       #|<ReadOnlyArray: [20, 40]>
+///     ),
+///   )
+/// }
+/// ```
+pub fn[A, B] ReadOnlyArray::filter_map(
+  self : ReadOnlyArray[A],
+  f : (A) -> B? raise?,
+) -> ReadOnlyArray[B] raise? {
+  ReadOnlyArray::from_array(self[:].filter_map(f)[:])
+}
+
+///|
 /// Folds the ReadOnlyArray from left to right.
 ///
 /// # Example

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -70,6 +70,31 @@ test "ReadOnlyArray functional methods" {
 }
 
 ///|
+test "ReadOnlyArray filter and filter_map" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+  let evens = arr.filter(x => x % 2 == 0)
+  inspect(evens.length(), content="2")
+  inspect(evens[0], content="2")
+  inspect(evens[1], content="4")
+
+  // filter_map: keep evens, multiply by 10.
+  let mapped = arr.filter_map(x => if x % 2 == 0 { Some(x * 10) } else { None })
+  inspect(mapped.length(), content="2")
+  inspect(mapped[0], content="20")
+  inspect(mapped[1], content="40")
+
+  // Empty input passes through.
+  let empty : ReadOnlyArray[Int] = []
+  inspect(empty.filter(_ => true).length(), content="0")
+  inspect(empty.filter_map(x => Some(x)).length(), content="0")
+
+  // No element passes / all dropped.
+  inspect(arr.filter(_ => false).length(), content="0")
+  let none_out : ReadOnlyArray[Int] = arr.filter_map(_ => None)
+  inspect(none_out.length(), content="0")
+}
+
+///|
 test "ReadOnlyArray search methods" {
   let arr : ReadOnlyArray[Int] = [1, 2, 3, 2, 4]
 


### PR DESCRIPTION
## Summary
- `Array` and `ArrayView` both provide `filter` and `filter_map`. `ReadOnlyArray` didn't, despite already having `map`/`mapi`/`fold`/`rev` and friends.
- Add them, returning `ReadOnlyArray` to match the convention of `ReadOnlyArray::map` (which returns `ReadOnlyArray`, not `Array`).
- Implementations route through `ArrayView::filter` / `filter_map` and reinterpret the result.
- Tests cover the success path, empty input, none-passes, and all-dropped (filter_map returning `None`).

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test -p moonbitlang/core/builtin` — 2842 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)