### PR TITLE
feat(builtin): add ReadOnlyArray::chunks and windows

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -910,6 +910,7 @@ pub fn[T] ReadOnlyArray::any(Self[T], (T) -> Bool raise?) -> Bool raise?
 pub fn[T] ReadOnlyArray::at(Self[T], Int) -> T
 pub fn[T : Compare] ReadOnlyArray::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] ReadOnlyArray::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
+pub fn[T] ReadOnlyArray::chunks(Self[T], Int) -> Array[ArrayView[T]]
 pub fn[T : Eq] ReadOnlyArray::contains(Self[T], T) -> Bool
 pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
@@ -949,6 +950,7 @@ pub fn[T : Eq] ReadOnlyArray::strip_suffix(Self[T], ArrayView[T]) -> ArrayView[T
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[T] ReadOnlyArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
+pub fn[T] ReadOnlyArray::windows(Self[T], Int) -> Array[ArrayView[T]]
 
 #alias("_[_]")
 pub fn Bytes::at(Bytes, Int) -> Byte

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -688,6 +688,59 @@ pub fn[T] ReadOnlyArray::binary_search_by(
 }
 
 ///|
+/// Splits the array into consecutive non-overlapping chunks of length `size`,
+/// from left to right. The final chunk is shorter when `length` is not a
+/// multiple of `size`. Each returned sub-view shares the original backing
+/// storage — no allocation per chunk.
+///
+/// Panics if `size <= 0`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5, 6, 7]
+///   debug_inspect(
+///     arr.chunks(3),
+///     content=(
+///       #|[<ArrayView: [1, 2, 3]>, <ArrayView: [4, 5, 6]>, <ArrayView: [7]>]
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::chunks(
+  self : ReadOnlyArray[T],
+  size : Int,
+) -> Array[ArrayView[T]] {
+  self[:].chunks(size)
+}
+
+///|
+/// Returns all contiguous sub-views of length `size`, from left to right. The
+/// result has `length - size + 1` entries when `size <= length`, and is empty
+/// otherwise. Each sub-view shares the original backing storage.
+///
+/// Panics if `size <= 0`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4]
+///   debug_inspect(
+///     arr.windows(2),
+///     content=(
+///       #|[<ArrayView: [1, 2]>, <ArrayView: [2, 3]>, <ArrayView: [3, 4]>]
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::windows(
+  self : ReadOnlyArray[T],
+  size : Int,
+) -> Array[ArrayView[T]] {
+  self[:].windows(size)
+}
+
+///|
 /// Performs a lexicographical comparison of two arrays.
 ///
 /// Unlike the `Compare` trait implementation (shortlex — shorter arrays come

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -190,6 +190,44 @@ test "ReadOnlyArray compare" {
 }
 
 ///|
+test "ReadOnlyArray chunks and windows" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5, 6, 7]
+  debug_inspect(
+    arr.chunks(3),
+    content=(
+      #|[<ArrayView: [1, 2, 3]>, <ArrayView: [4, 5, 6]>, <ArrayView: [7]>]
+    ),
+  )
+  // Exact multiple: no trailing short chunk.
+  debug_inspect(
+    arr.chunks(7),
+    content=(
+      #|[<ArrayView: [1, 2, 3, 4, 5, 6, 7]>]
+    ),
+  )
+  // Empty input gives no chunks.
+  let empty : ReadOnlyArray[Int] = []
+  debug_inspect(empty.chunks(3), content="[]")
+
+  // Windows: length - size + 1 entries.
+  let small : ReadOnlyArray[Int] = [1, 2, 3, 4]
+  debug_inspect(
+    small.windows(2),
+    content=(
+      #|[<ArrayView: [1, 2]>, <ArrayView: [2, 3]>, <ArrayView: [3, 4]>]
+    ),
+  )
+  debug_inspect(
+    small.windows(4),
+    content=(
+      #|[<ArrayView: [1, 2, 3, 4]>]
+    ),
+  )
+  // size > length yields empty.
+  debug_inspect(small.windows(5), content="[]")
+}
+
+///|
 test "ReadOnlyArray strip_prefix and strip_suffix" {
   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
   debug_inspect(


### PR DESCRIPTION
## Summary
- `Array` and `ArrayView` both expose `chunks` (non-overlapping fixed-size slices, with a possibly-short trailing chunk) and `windows` (all overlapping sub-views of a fixed size). `ReadOnlyArray` didn't.
- Add both, returning `Array[ArrayView[T]]` to match the sibling signatures. The views themselves are read-only (`ArrayView` has no `set` operator), so this doesn't open a hole in the read-only contract.
- Implementations route through `ArrayView` via `self[:]`.
- Tests cover: exact-multiple chunks, the trailing short chunk, empty input; windows of various sizes including `size > length`.

## Test plan
- [x] `moon check` clean
- [x] `moon fmt` clean
- [x] `moon test -p moonbitlang/core/builtin` — 2842 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)