### PR TITLE
fix(builtin): restore ReadOnlyArray::chunks and windows

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -911,6 +911,7 @@ pub fn[T] ReadOnlyArray::at(Self[T], Int) -> T
 pub fn[T : Compare] ReadOnlyArray::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] ReadOnlyArray::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
 pub fn[T] ReadOnlyArray::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[ArrayView[T]] raise?
+pub fn[T] ReadOnlyArray::chunks(Self[T], Int) -> Array[ArrayView[T]]
 pub fn[T : Eq] ReadOnlyArray::contains(Self[T], T) -> Bool
 pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
@@ -951,6 +952,7 @@ pub fn[T] ReadOnlyArray::suffixes(Self[T], include_empty? : Bool) -> Iter[ArrayV
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[T] ReadOnlyArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
+pub fn[T] ReadOnlyArray::windows(Self[T], Int) -> Array[ArrayView[T]]
 
 #alias("_[_]")
 pub fn Bytes::at(Bytes, Int) -> Byte

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -688,6 +688,59 @@ pub fn[T] ReadOnlyArray::binary_search_by(
 }
 
 ///|
+/// Splits the array into consecutive non-overlapping chunks of length `size`,
+/// from left to right. The final chunk is shorter when `length` is not a
+/// multiple of `size`. Each returned sub-view shares the original backing
+/// storage — no allocation per chunk.
+///
+/// Panics if `size <= 0`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5, 6, 7]
+///   debug_inspect(
+///     arr.chunks(3),
+///     content=(
+///       #|[<ArrayView: [1, 2, 3]>, <ArrayView: [4, 5, 6]>, <ArrayView: [7]>]
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::chunks(
+  self : ReadOnlyArray[T],
+  size : Int,
+) -> Array[ArrayView[T]] {
+  self[:].chunks(size)
+}
+
+///|
+/// Returns all contiguous sub-views of length `size`, from left to right. The
+/// result has `length - size + 1` entries when `size <= length`, and is empty
+/// otherwise. Each sub-view shares the original backing storage.
+///
+/// Panics if `size <= 0`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4]
+///   debug_inspect(
+///     arr.windows(2),
+///     content=(
+///       #|[<ArrayView: [1, 2]>, <ArrayView: [2, 3]>, <ArrayView: [3, 4]>]
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::windows(
+  self : ReadOnlyArray[T],
+  size : Int,
+) -> Array[ArrayView[T]] {
+  self[:].windows(size)
+}
+
+///|
 /// Groups consecutive elements into chunks where each adjacent pair satisfies
 /// `pred`. A new chunk starts as soon as `pred(prev, cur)` is `false`. Each
 /// returned sub-view shares the original backing storage.

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -190,6 +190,44 @@ test "ReadOnlyArray compare" {
 }
 
 ///|
+test "ReadOnlyArray chunks and windows" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5, 6, 7]
+  debug_inspect(
+    arr.chunks(3),
+    content=(
+      #|[<ArrayView: [1, 2, 3]>, <ArrayView: [4, 5, 6]>, <ArrayView: [7]>]
+    ),
+  )
+  // Exact multiple: no trailing short chunk.
+  debug_inspect(
+    arr.chunks(7),
+    content=(
+      #|[<ArrayView: [1, 2, 3, 4, 5, 6, 7]>]
+    ),
+  )
+  // Empty input gives no chunks.
+  let empty : ReadOnlyArray[Int] = []
+  debug_inspect(empty.chunks(3), content="[]")
+
+  // Windows: length - size + 1 entries.
+  let small : ReadOnlyArray[Int] = [1, 2, 3, 4]
+  debug_inspect(
+    small.windows(2),
+    content=(
+      #|[<ArrayView: [1, 2]>, <ArrayView: [2, 3]>, <ArrayView: [3, 4]>]
+    ),
+  )
+  debug_inspect(
+    small.windows(4),
+    content=(
+      #|[<ArrayView: [1, 2, 3, 4]>]
+    ),
+  )
+  // size > length yields empty.
+  debug_inspect(small.windows(5), content="[]")
+}
+
+///|
 test "ReadOnlyArray chunk_by and suffixes" {
   let arr : ReadOnlyArray[Int] = [1, 1, 2, 2, 2, 3, 1]
   debug_inspect(


### PR DESCRIPTION
## Summary
- PR #3610 (commit \`6db09843\`) accidentally deleted \`ReadOnlyArray::chunks\` and \`ReadOnlyArray::windows\` when its rebase conflict over PR #3609 was resolved by overwriting the chunks/windows block with chunk_by/suffixes instead of keeping both.
- The two methods had been added in #3609 (\`c50af5e5\`) one commit earlier — both source and mbti entries were lost.
- This PR restores both methods verbatim from #3609. No other commit in the recent batch had unpaired API removals (every other \`-pub fn\` line in the range is a matched signature widening).

## Verification of the audit
\`\`\`
$ for sha in <last 15 commits>; do git show \$sha -- builtin/pkg.generated.mbti | grep '^-pub'; done
\`\`\`
Only \`6db09843\` had unpaired removals (\`chunks\`, \`windows\`); all other removals were paired with a wider replacement signature.

## Test plan
- [x] \`moon check\` clean
- [x] \`moon fmt\` clean
- [x] \`moon test -p moonbitlang/core/builtin\` — 2848 tests pass (restored \`chunks\`/\`windows\` test included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⚠️ I will not merge this — please apply the \`Approved\` label when you're ready.