### PR TITLE
Optimize strconv StringView digit scans

### DIFF
--- a/internal/strconv/moon.pkg
+++ b/internal/strconv/moon.pkg
@@ -7,3 +7,7 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
 }
+
+import {
+  "moonbitlang/core/bench",
+} for "test"

--- a/internal/strconv/parse_double_bench_test.mbt
+++ b/internal/strconv/parse_double_bench_test.mbt
@@ -1,0 +1,53 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let parse_double_bench_repeats = 512
+
+///|
+let parse_double_plain_bench_inputs : FixedArray[String] = [
+  "123456789012345.0", "876543210987654.0", "1234567890123.45", "7654321098765.25",
+  "123456789012345e-2", "876543210987654e-3", "1234567890123e+2", "7654321098765e-1",
+]
+
+///|
+let parse_double_underscore_bench_inputs : FixedArray[String] = [
+  "123_456_789_012_345.0", "876_543_210_987_654.0", "1_234_567_890_123.45", "7_654_321_098_765.25",
+  "123_456_789_012_345e-2", "876_543_210_987_654e-3", "1_234_567_890_123e+2", "7_654_321_098_765e-1",
+]
+
+///|
+fn parse_double_bench_sum(inputs : FixedArray[String]) -> Double {
+  let mut sum = 0.0
+  for _ in 0..<parse_double_bench_repeats {
+    for input in inputs {
+      sum += try! @strconv.parse_double(input)
+    }
+  }
+  sum
+}
+
+///|
+test "bench parse_double fast digits n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(parse_double_bench_sum(parse_double_plain_bench_inputs))
+  })
+}
+
+///|
+test "bench parse_double underscores n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(parse_double_bench_sum(parse_double_underscore_bench_inputs))
+  })
+}

--- a/internal/strconv/strconv_int.mbt
+++ b/internal/strconv/strconv_int.mbt
@@ -169,37 +169,31 @@ fn check_underscore(str : StringView) -> Bool {
     ("0[bB]", rest) => (rest, true, false)
     _ => (rest, false, false)
   }
-
-  // 'e' and 'E' are valid hex digits
-  // but are not treated as digits in decimal strings since they're used for scientific notation
-  fn is_digit(c : Char) -> Bool {
-    c is ('0'..='9') || (hex && c is ('a'..='f' | 'A'..='F'))
-  }
-
   // Track whether the previous character was an underscore
   let follow_underscore = false
   for rest = rest, allow_underscore = allow_underscore, follow_underscore = follow_underscore {
     match (rest, allow_underscore, follow_underscore) {
-      // Empty string is valid
+      // Empty string is valid.
       ([], _, _) => break true
-      // String ending with underscore is invalid
+      // String ending with underscore is invalid.
       (['_'], _, _) => break false
-      // Underscore not allowed in current position (e.g., between non-digits)
+      // Underscore not allowed in current position, e.g. between non-digits.
       (['_', ..], false, _) => break false
-      // Valid underscore - continue but mark that next char must be a digit
+      // Valid underscore: the following character must be a digit.
       (['_', .. rest], true, _) => continue rest, false, true
-      // Handle non-underscore character
-      ([c, .. rest], _, follow_underscore) =>
-        if is_digit(c) {
-          // Digit found - allow underscore in next position
-          continue rest, true, false
-        } else if follow_underscore {
-          // Non-digit found after underscore - invalid
-          break false
-        } else {
-          // Non-digit found (not after underscore) - continue but don't allow underscores
-          continue rest, false, false
-        }
+      // Decimal digits allow an underscore after them.
+      (['0'..='9', .. rest], _, _) => continue rest, true, false
+      // 'e' and 'E' are valid hex digits, but not decimal digits.
+      (['a'..='f' | 'A'..='F', .. rest], _, _) if hex =>
+        continue rest, true, false
+      // Common decimal separators/signs reset underscore allowance.
+      (['.' | 'e' | 'E' | '+' | '-', ..], _, true) => break false
+      (['.' | 'e' | 'E' | '+' | '-', .. rest], _, _) =>
+        continue rest, false, false
+      // Other characters are uncommon here. They are allowed unless they
+      // immediately follow an underscore; the number parser rejects them later.
+      ([_, ..], _, true) => break false
+      ([_, .. rest], _, _) => continue rest, false, false
     }
   }
 }

--- a/internal/strconv/strconv_string_view.mbt
+++ b/internal/strconv/strconv_string_view.mbt
@@ -20,17 +20,12 @@ fn[T] StringView::fold_digits(
   init : T,
   f : (Int, T) -> T,
 ) -> (Self, T, Int) {
-  let mut ret = init
-  let mut len = 0
-  let mut str = self
-  while str is [ch, .. rest] {
-    if ch is ('0'..='9') {
-      len += 1
-      ret = f(ch.to_int() - '0', ret)
-    } else if ch != '_' {
-      break
+  for str = self, ret = init, len = 0 {
+    match str {
+      ['0'..='9' as ch, .. rest] =>
+        continue rest, f(ch.to_int() - '0', ret), len + 1
+      ['_', .. rest] => continue rest, ret, len
+      _ => break (str, ret, len)
     }
-    str = rest
   }
-  (str, ret, len)
 }


### PR DESCRIPTION
## Summary
- make `StringView::fold_digits` use explicit BMP digit/underscore patterns instead of a catch-all `Char` binding
- make `check_underscore` classify common BMP number characters directly in the `StringView` pattern match
- add focused `parse_double` benchmarks in a separate commit

## Benchmarks
Native backend, `n=4096`:

| case | before | after | speedup |
| --- | ---: | ---: | ---: |
| parse_double fast digits | 1.26 ms | 355.78 us | 3.54x |
| parse_double underscores | 1.43 ms | 384.84 us | 3.72x |

## Validation
- `moon check internal/strconv json`
- `moon test internal/strconv`
- `moon test json`
- `moon bench --package moonbitlang/core/internal/strconv --file parse_double_bench_test.mbt --target native --target-dir /private/tmp/core-strconv-bench-before-build`
- `moon bench --package moonbitlang/core/internal/strconv --file parse_double_bench_test.mbt --target native --target-dir /private/tmp/core-strconv-bench-after`
- `moon info`
- `git diff --check`