### PR TITLE
feat(buffer): add write_utf8, Buffer() constructor, prelude export, deprecate @buffer.new

### DIFF
--- a/buffer/README.mbt.md
+++ b/buffer/README.mbt.md
@@ -9,9 +9,9 @@ Create an empty buffer, optionally with a capacity hint to reduce reallocations:
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new()
+  let buf = Buffer()
   assert_eq(buf.is_empty(), true)
-  let buf2 = @buffer.new(size_hint=1024)
+  let buf2 = Buffer(size_hint=1024)
   assert_eq(buf2.length(), 0)
 }
 ```
@@ -37,17 +37,17 @@ Write individual bytes, byte slices, or byte iterators:
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_byte(b'H')
   buf.write_byte(b'i')
   buf.write_bytes(b" world")
   inspect(buf.to_bytes(), content="b\"Hi world\"")
   // write a sub-range via BytesView
-  let buf2 = @buffer.new()
+  let buf2 = Buffer()
   buf2.write_bytesview(b"Hello"[0:2])
   inspect(buf2.to_bytes(), content="b\"He\"")
   // write from an iterator
-  let buf3 = @buffer.new()
+  let buf3 = Buffer()
   buf3.write_iter(b"ok".iter())
   inspect(buf3.to_bytes(), content="b\"ok\"")
 }
@@ -61,14 +61,14 @@ All integer writes come in `_be` (big-endian) and `_le` (little-endian) variants
 ///|
 test {
   // 32-bit signed/unsigned
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_int_be(0x01020304)
   inspect(buf.to_bytes(), content="b\"\\x01\\x02\\x03\\x04\"")
-  let buf2 = @buffer.new()
+  let buf2 = Buffer()
   buf2.write_int_le(0x01020304)
   inspect(buf2.to_bytes(), content="b\"\\x04\\x03\\x02\\x01\"")
   // unsigned 32-bit
-  let buf3 = @buffer.new()
+  let buf3 = Buffer()
   buf3.write_uint_be(0xAABBU)
   inspect(buf3.to_bytes(), content="b\"\\x00\\x00\\xaa\\xbb\"")
 }
@@ -80,23 +80,23 @@ test {
 ///|
 test {
   // 16-bit signed
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_int16_be((0x0102 : Int16))
   buf.write_int16_le((0x0102 : Int16))
   inspect(buf.to_bytes(), content="b\"\\x01\\x02\\x02\\x01\"")
   // 16-bit unsigned
-  let buf2 = @buffer.new()
+  let buf2 = Buffer()
   buf2.write_uint16_be(Int::to_uint16(0x00AB))
   inspect(buf2.to_bytes(), content="b\"\\x00\\xab\"")
   // 64-bit signed
-  let buf3 = @buffer.new()
+  let buf3 = Buffer()
   buf3.write_int64_be(0x0102030405060708L)
   inspect(
     buf3.to_bytes(),
     content="b\"\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\"",
   )
   // 64-bit unsigned
-  let buf4 = @buffer.new()
+  let buf4 = Buffer()
   buf4.write_uint64_le(0xAABBUL)
   inspect(
     buf4.to_bytes(),
@@ -110,10 +110,10 @@ test {
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_float_be(1.0)
   assert_eq(buf.length(), 4)
-  let buf2 = @buffer.new()
+  let buf2 = Buffer()
   buf2.write_double_le(1.0)
   assert_eq(buf2.length(), 8)
 }
@@ -127,16 +127,16 @@ Write individual characters or entire strings as UTF-8 or UTF-16 (LE/BE):
 ///|
 test {
   // UTF-8
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_char_utf8('A')
   buf.write_string_utf8("BC")
   inspect(buf.to_bytes(), content="b\"ABC\"")
   // UTF-16 little-endian
-  let buf2 = @buffer.new()
+  let buf2 = Buffer()
   buf2.write_char_utf16le('A')
   inspect(buf2.to_bytes(), content="b\"A\\x00\"")
   // UTF-16 big-endian
-  let buf3 = @buffer.new()
+  let buf3 = Buffer()
   buf3.write_string_utf16be("AB")
   inspect(buf3.to_bytes(), content="b\"\\x00A\\x00B\"")
 }
@@ -149,7 +149,7 @@ Write any type that implements `Show` via `write_object()`. The buffer also impl
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_object(42)
   // write_object uses the Show trait, producing UTF-16LE string bytes
   assert_eq(buf.length(), 4) // "42" in UTF-16LE = 4 bytes
@@ -163,10 +163,10 @@ Write integers in LEB128 variable-length encoding. Supported for `Int`, `UInt`, 
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_leb128(624485)
   inspect(buf.to_bytes(), content="b\"\\xe5\\x8e&\"")
-  let buf2 = @buffer.new()
+  let buf2 = Buffer()
   buf2.write_leb128(300UL)
   inspect(buf2.to_bytes(), content="b\"\\xac\\x02\"")
 }
@@ -179,7 +179,7 @@ test {
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_bytes(b"hello")
   let bytes = buf.to_bytes()
   inspect(bytes, content="b\"hello\"")
@@ -195,7 +195,7 @@ test {
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_bytes(b"data")
   assert_eq(buf.length(), 4)
   buf.reset()
@@ -210,7 +210,7 @@ Pre-allocate capacity to minimize reallocations when the final size is known:
 ```mbt check
 ///|
 test {
-  let buf = @buffer.new(size_hint=1024)
+  let buf = Buffer(size_hint=1024)
   for i in 0..<100 {
     buf.write_int_le(i)
   }

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -23,7 +23,7 @@
 /// # Usage
 ///
 /// ```mbt nocheck
-///   let buf = @buffer.new(size_hint=100)
+///   let buf = Buffer(size_hint=100)
 ///   buf.write_string("Tes")
 ///   buf.write_char('t')
 ///   inspect(
@@ -71,7 +71,7 @@ fn Buffer::grow_if_necessary(self : Buffer, required : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_string("Test")
 ///   inspect(buf.length(), content="8") // each char takes 2 bytes in UTF-16
 /// }
@@ -94,7 +94,7 @@ pub fn Buffer::length(self : Buffer) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   inspect(buf.is_empty(), content="true")
 ///   buf.write_string("test")
 ///   inspect(buf.is_empty(), content="false")
@@ -119,16 +119,15 @@ pub fn Buffer::is_empty(self : Buffer) -> Bool {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new(size_hint=10)
+///   let buf = Buffer(size_hint=10)
 ///   inspect(buf.length(), content="0")
 ///   buf.write_string("test")
 ///   inspect(buf.length(), content="8")
 /// }
 /// ```
+#deprecated("use `Buffer()` instead (with `Buffer` in scope via the prelude)")
 pub fn new(size_hint? : Int = 0) -> Buffer {
-  let initial = if size_hint < 1 { 1 } else { size_hint }
-  let data = FixedArray::make(initial, Byte::default())
-  { data, len: 0 }
+  Buffer(size_hint~)
 }
 
 ///|
@@ -152,14 +151,16 @@ pub fn new(size_hint? : Int = 0) -> Buffer {
 /// }
 /// ```
 pub fn Buffer::Buffer(size_hint? : Int = 0) -> Buffer {
-  new(size_hint=size_hint)
+  let initial = if size_hint < 1 { 1 } else { size_hint }
+  let data = FixedArray::make(initial, Byte::default())
+  { data, len: 0 }
 }
 
 ///|
 /// Create a buffer from a bytes.
 pub fn from_bytes(bytes : BytesView) -> Buffer {
   let val_len = bytes.length()
-  let buf = new(size_hint=val_len)
+  let buf = Buffer(size_hint=val_len)
   // inline write_bytes, skip grow_if_necessary check
   // SAFETY: known bytes size
   buf.data.blit_from_bytes(0, bytes.data(), bytes.start_offset(), val_len)
@@ -170,7 +171,7 @@ pub fn from_bytes(bytes : BytesView) -> Buffer {
 ///|
 /// Create a buffer from an array.
 pub fn from_array(arr : ArrayView[Byte]) -> Buffer {
-  let buf = new(size_hint=arr.length())
+  let buf = Buffer(size_hint=arr.length())
   for byte in arr {
     // inline write_byte, skip grow_if_necessary check
     // SAFETY: known array size
@@ -183,7 +184,7 @@ pub fn from_array(arr : ArrayView[Byte]) -> Buffer {
 ///|
 /// Create a buffer from an iterator.
 pub fn from_iter(iter : Iter[Byte]) -> Buffer {
-  let buf = new()
+  let buf = Buffer()
   for byte in iter; capacity = buf.data.length() {
     // inline write_byte and grow_if_necessary
     // only call grow_if_necessary when necessary
@@ -213,7 +214,7 @@ pub fn from_iter(iter : Iter[Byte]) -> Buffer {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_string("Test")
 ///   // Each UTF-16 char takes 2 bytes in little-endian format
 ///   // 'T' -> [0x54, 0x00]
@@ -247,7 +248,7 @@ pub impl Logger for Buffer with write_string(self, value) {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_uint64_be(0xAABBCCDD11223344)
 ///   // Bytes are written in big-endian order
 ///   inspect(
@@ -285,7 +286,7 @@ pub fn Buffer::write_uint64_be(self : Buffer, value : UInt64) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_uint64_le(0x0123456789ABCDEF)
 ///   inspect(
 ///     buf.contents(),
@@ -322,7 +323,7 @@ pub fn Buffer::write_uint64_le(self : Buffer, value : UInt64) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_int64_be(0x0102030405060708L)
 ///   inspect(
 ///     buf.contents(),
@@ -348,7 +349,7 @@ pub fn Buffer::write_int64_be(self : Buffer, value : Int64) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_int64_le(-1L)
 ///   inspect(
 ///     buf.contents(),
@@ -375,7 +376,7 @@ pub fn Buffer::write_int64_le(self : Buffer, value : Int64) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_uint_be(0x12345678)
 ///   inspect(
 ///     buf.contents(),
@@ -409,7 +410,7 @@ pub fn Buffer::write_uint_be(self : Buffer, value : UInt) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_uint_le(0x12345678)
 ///   inspect(
 ///     buf.contents(),
@@ -442,7 +443,7 @@ pub fn Buffer::write_uint_le(self : Buffer, value : UInt) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_int_be(0x12345678)
 ///   inspect(
 ///     buf.contents(),
@@ -470,7 +471,7 @@ pub fn Buffer::write_int_be(self : Buffer, value : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_int_le(-1)
 ///   inspect(buf.contents(), content="b\"\\xff\\xff\\xff\\xff\"")
 /// }
@@ -492,7 +493,7 @@ pub fn Buffer::write_int_le(self : Buffer, value : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_uint16_be(0x1234)
 ///   inspect(
 ///     buf.contents(),
@@ -524,7 +525,7 @@ pub fn Buffer::write_uint16_be(self : Buffer, value : UInt16) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_uint16_le(0x1234)
 ///   inspect(
 ///     buf.contents(),
@@ -555,7 +556,7 @@ pub fn Buffer::write_uint16_le(self : Buffer, value : UInt16) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_int16_be(0x1234)
 ///   inspect(
 ///     buf.contents(),
@@ -586,7 +587,7 @@ pub fn Buffer::write_int16_be(self : Buffer, value : Int16) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_int16_le(-1)
 ///   inspect(
 ///     buf.contents(),
@@ -617,7 +618,7 @@ pub fn Buffer::write_int16_le(self : Buffer, value : Int16) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_double_be(1.0)
 ///   inspect(
 ///     buf.contents(),
@@ -644,7 +645,7 @@ pub fn Buffer::write_double_be(self : Buffer, value : Double) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_double_le(3.14)
 ///   inspect(
 ///     buf.contents(),
@@ -672,7 +673,7 @@ pub fn Buffer::write_double_le(self : Buffer, value : Double) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_float_be(3.14)
 ///   // In big-endian format, 3.14 is represented as [0x40, 0x48, 0xF5, 0xC3]
 ///   inspect(
@@ -700,7 +701,7 @@ pub fn Buffer::write_float_be(self : Buffer, value : Float) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_float_le(3.14)
 ///   // The bytes are written in little-endian format
 ///   inspect(
@@ -730,7 +731,7 @@ pub fn Buffer::write_float_le(self : Buffer, value : Float) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_object(42)
 ///   inspect(buf.contents().to_unchecked_string(), content="42")
 /// }
@@ -753,7 +754,7 @@ pub fn Buffer::write_object(self : Buffer, value : &Show) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_utf8(42)
 ///   inspect(
 ///     buf.contents(),
@@ -779,7 +780,7 @@ pub fn[T : Show] Buffer::write_utf8(self : Buffer, value : T) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_bytes(b"Test")
 ///   inspect(
 ///     buf.contents(),
@@ -805,7 +806,7 @@ pub fn Buffer::write_bytes(self : Buffer, value : BytesView) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   let view = b"Test"[1:3]
 ///   buf.write_bytesview(view)
 ///   inspect(
@@ -923,7 +924,7 @@ pub fn Buffer::write_char_utf16be(buf : Self, value : Char) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_string_utf8("Hi")
 ///   inspect(buf.contents().length(), content="2")
 /// }
@@ -946,7 +947,7 @@ pub fn Buffer::write_string_utf8(buf : Self, string : StringView) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_string_utf16le("A")
 ///   inspect(buf.contents().length(), content="2")
 /// }
@@ -976,7 +977,7 @@ pub fn Buffer::write_string_utf16le(buf : Self, string : StringView) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_string_utf16be("A")
 ///   inspect(buf.contents().length(), content="2")
 /// }
@@ -1007,7 +1008,7 @@ pub fn Buffer::write_string_utf16be(buf : Self, string : StringView) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_view("Hello, World!"[:5])
 ///   inspect(
 ///     buf.contents(),
@@ -1041,7 +1042,7 @@ pub impl Logger for Buffer with write_view(self : Buffer, value : StringView) ->
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_char('A')
 ///   inspect(
 ///     buf.contents(),
@@ -1070,7 +1071,7 @@ pub impl Logger for Buffer with write_char(self : Buffer, value : Char) -> Unit 
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_byte(b'\x41')
 ///   inspect(
 ///     buf.contents(),
@@ -1098,7 +1099,7 @@ pub fn Buffer::write_byte(self : Buffer, value : Byte) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   let bytes = b"Hello"
 ///   buf.write_iter(bytes.iter())
 ///   inspect(
@@ -1127,7 +1128,7 @@ pub fn Buffer::write_iter(self : Buffer, iter : Iter[Byte]) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_string("Hello")
 ///   inspect(buf.length(), content="10")
 ///   buf.reset()
@@ -1154,7 +1155,7 @@ pub fn Buffer::reset(self : Buffer) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_string("Test")
 ///   let bytes = buf.to_bytes()
 ///   inspect(bytes.length(), content="8") //utf16
@@ -1175,7 +1176,7 @@ pub fn Buffer::to_bytes(self : Buffer) -> Bytes {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_byte(b'A')
 ///   let v = buf.view()
 ///   inspect(v.length(), content="1")

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -716,6 +716,34 @@ pub fn Buffer::write_object(self : Buffer, value : &Show) -> Unit {
 }
 
 ///|
+/// Writes the `Show` representation of any value into the buffer as UTF-8
+/// encoded bytes.
+///
+/// Parameters:
+///
+/// * `self` : The buffer to write to.
+/// * `value` : Any value that implements the `Show` trait. The value is
+/// converted to a string via `Show::to_string` and then encoded as UTF-8.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let buf = @buffer.new()
+///   buf.write_utf8(42)
+///   inspect(
+///     buf.contents(),
+///     content=(
+///       #|b"42"
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T : Show] Buffer::write_utf8(self : Buffer, value : T) -> Unit {
+  self.write_string_utf8(value.to_string())
+}
+
+///|
 /// Writes a sequence of bytes into the buffer.
 ///
 /// Parameters:

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -132,6 +132,30 @@ pub fn new(size_hint? : Int = 0) -> Buffer {
 }
 
 ///|
+/// Creates a new extensible buffer. Enables the constructor-call syntax
+/// `Buffer()` (also `Buffer(size_hint=N)`) when `Buffer` is in scope, e.g.
+/// via the prelude.
+///
+/// Parameters:
+///
+/// * `size_hint` : Initial capacity of the buffer in bytes. Defaults to 0.
+///
+/// Returns a new `Buffer`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let buf = Buffer()
+///   buf.write_string("test")
+///   inspect(buf.length(), content="8")
+/// }
+/// ```
+pub fn Buffer::Buffer(size_hint? : Int = 0) -> Buffer {
+  new(size_hint=size_hint)
+}
+
+///|
 /// Create a buffer from a bytes.
 pub fn from_bytes(bytes : BytesView) -> Buffer {
   let val_len = bytes.length()

--- a/buffer/buffer_test.mbt
+++ b/buffer/buffer_test.mbt
@@ -41,7 +41,7 @@ test "create buffer from iterator" {
 
 ///|
 test "length method" {
-  let buf = @buffer.new(size_hint=100)
+  let buf = Buffer(size_hint=100)
   inspect(buf.length(), content="0")
   buf.write_string("Test")
   inspect(buf.length(), content="8")
@@ -49,7 +49,7 @@ test "length method" {
 
 ///|
 test "is_empty method" {
-  let buf = @buffer.new(size_hint=100)
+  let buf = Buffer(size_hint=100)
   inspect(buf.is_empty(), content="true")
   buf.write_string("Test")
   inspect(buf.is_empty(), content="false")
@@ -57,14 +57,14 @@ test "is_empty method" {
 
 ///|
 test "expect method with matching content" {
-  let buf = @buffer.new(size_hint=100)
+  let buf = Buffer(size_hint=100)
   buf.write_string("Test")
   inspect(buf, content="Test")
 }
 
 ///|
 test "grow_if_necessary method" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_string(
     "This is a test string that is longer than the initial capacity",
   )
@@ -73,14 +73,14 @@ test "grow_if_necessary method" {
 
 ///|
 test "write_substring method" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_view("Hello, World!"[7:12])
   inspect(buf, content="World")
 }
 
 ///|
 test "write_byte method" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_byte(b'A')
   buf.write_byte(b'\x00')
   inspect(buf, content="A")
@@ -88,7 +88,7 @@ test "write_byte method" {
 
 ///|
 test "write_utf8 method" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_utf8(42)
   buf.write_utf8('!')
   buf.write_utf8("hi"[:])
@@ -102,7 +102,7 @@ test "write_utf8 method" {
 
 ///|
 test "to_bytes method" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_string("Test")
   let bytes = buf.to_bytes()
   inspect(bytes.length(), content="8") // Each character in "Test" is 2 bytes
@@ -110,7 +110,7 @@ test "to_bytes method" {
 
 ///|
 test "write_bytes" {
-  let buf = @buffer.new(size_hint=4)
+  let buf = Buffer(size_hint=4)
   buf.write_bytes(b"1\x002\x003\x004\x00")
   buf.write_bytes(b"5\x006\x007\x008\x00")
   inspect(buf, content="12345678")
@@ -118,7 +118,7 @@ test "write_bytes" {
 
 ///|
 test "write_uint64_le method" {
-  let buf = @buffer.new(size_hint=16)
+  let buf = Buffer(size_hint=16)
   buf.write_uint64_le(0xdeadbeefaabbccdd)
   buf.write_uint64_le(0xfacefeedaabbccdd)
   inspect(
@@ -131,7 +131,7 @@ test "write_uint64_le method" {
 
 ///|
 test "write_uint64_be method" {
-  let buf = @buffer.new(size_hint=16)
+  let buf = Buffer(size_hint=16)
   buf.write_uint64_be(0xdeadbeefaabbccdd)
   buf.write_uint64_be(0xfacefeedaabbccdd)
   inspect(
@@ -144,7 +144,7 @@ test "write_uint64_be method" {
 
 ///|
 test "write_int64_le method" {
-  let buf = @buffer.new(size_hint=16)
+  let buf = Buffer(size_hint=16)
   buf.write_int64_le(-2)
   buf.write_int64_le(0xdeadbeeffacefeed)
   inspect(
@@ -157,7 +157,7 @@ test "write_int64_le method" {
 
 ///|
 test "write_int64_be method" {
-  let buf = @buffer.new(size_hint=16)
+  let buf = Buffer(size_hint=16)
   buf.write_int64_be(-2)
   buf.write_int64_be(0xdeadbeef)
   inspect(
@@ -170,7 +170,7 @@ test "write_int64_be method" {
 
 ///|
 test "write_uint_le method" {
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_uint_le(0xdeadbeef)
   buf.write_uint_le(0xdeadc0de)
   inspect(
@@ -183,7 +183,7 @@ test "write_uint_le method" {
 
 ///|
 test "write_uint_be method" {
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_uint_be(0xdeadbeef)
   buf.write_uint_be(0xdeadc0de)
   inspect(
@@ -196,7 +196,7 @@ test "write_uint_be method" {
 
 ///|
 test "write_int_le method" {
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_int_le(-2)
   buf.write_int_le(0xdeadbeef)
   inspect(
@@ -209,7 +209,7 @@ test "write_int_le method" {
 
 ///|
 test "write_int_be method" {
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_int_be(-2)
   buf.write_int_be(0xdeadbeef)
   inspect(
@@ -222,7 +222,7 @@ test "write_int_be method" {
 
 ///|
 test "write_string_utf16be and view" {
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_string_utf16be("AZ")
   inspect(
     buf.to_bytes(),
@@ -235,25 +235,25 @@ test "write_string_utf16be and view" {
 
 ///|
 test "panic Buffer::write_char_utf8 out of range" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_char_utf8((0x110000).unsafe_to_char())
 }
 
 ///|
 test "panic Buffer::write_char_utf16le out of range" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_char_utf16le((0x110000).unsafe_to_char())
 }
 
 ///|
 test "panic Buffer::write_char_utf16be out of range" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_char_utf16be((0x110000).unsafe_to_char())
 }
 
 ///|
 test "write_double_le method" {
-  let buf = @buffer.new(size_hint=16)
+  let buf = Buffer(size_hint=16)
   buf.write_double_le(-2)
   buf.write_double_le(3.14)
   inspect(
@@ -266,7 +266,7 @@ test "write_double_le method" {
 
 ///|
 test "write_double_be method" {
-  let buf = @buffer.new(size_hint=16)
+  let buf = Buffer(size_hint=16)
   buf.write_double_be(-2)
   buf.write_double_be(3.14)
   inspect(
@@ -279,7 +279,7 @@ test "write_double_be method" {
 
 ///|
 test "write_float_le method" {
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_float_le(-2)
   buf.write_float_le(3.14)
   inspect(
@@ -292,7 +292,7 @@ test "write_float_le method" {
 
 ///|
 test "write_float_be method" {
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_float_be(-2)
   buf.write_float_be(3.14)
   inspect(
@@ -306,7 +306,7 @@ test "write_float_be method" {
 ///|
 test "write_iter" {
   let bytes = b"hello"
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_iter(bytes.iter())
   inspect(
     buf.contents(),
@@ -326,7 +326,7 @@ test "write_iter" {
 
 ///|
 test "write_bytesview" {
-  let buf = @buffer.new(size_hint=4)
+  let buf = Buffer(size_hint=4)
   buf.write_bytesview(b"Test"[1:3])
   inspect(
     buf.contents(),
@@ -338,7 +338,7 @@ test "write_bytesview" {
 
 ///|
 test "write_stringview" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_string_utf16le("hello"[1:3])
   inspect(
     buf.contents(),
@@ -350,7 +350,7 @@ test "write_stringview" {
 
 ///|
 test "write_char_utf8" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_char_utf8('A')
   buf.write_char_utf8('α')
   buf.write_char_utf8('啊')
@@ -365,7 +365,7 @@ test "write_char_utf8" {
 
 ///|
 test "write_char" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_char('A')
   buf.write_char('α')
   buf.write_char('啊')
@@ -380,7 +380,7 @@ test "write_char" {
 
 ///|
 test "write_char_utf16le" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_char_utf16le('A')
   buf.write_char_utf16le('α')
   buf.write_char_utf16le('啊')
@@ -395,7 +395,7 @@ test "write_char_utf16le" {
 
 ///|
 test "write_char_utf16be" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_char_utf16be('A')
   buf.write_char_utf16be('α')
   buf.write_char_utf16be('啊')
@@ -413,7 +413,7 @@ const BOM : Char = '\u{FEFF}'
 
 ///|
 test "write_bom_utf8" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_char_utf8(BOM)
   inspect(
     buf.to_bytes(),
@@ -425,7 +425,7 @@ test "write_bom_utf8" {
 
 ///|
 test "write_bom_utf16le" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_char_utf16le(BOM)
   inspect(
     buf.to_bytes(),
@@ -437,7 +437,7 @@ test "write_bom_utf16le" {
 
 ///|
 test "write_bom_utf16be" {
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_char_utf16be(BOM)
   inspect(
     buf.to_bytes(),
@@ -449,7 +449,7 @@ test "write_bom_utf16be" {
 
 ///|
 test "write_uint16_le method" {
-  let buf = @buffer.new(size_hint=4)
+  let buf = Buffer(size_hint=4)
   buf.write_uint16_le(Int::to_uint16(0x1234))
   buf.write_uint16_le(Int::to_uint16(0xabcd))
   inspect(
@@ -462,7 +462,7 @@ test "write_uint16_le method" {
 
 ///|
 test "write_uint16_be method" {
-  let buf = @buffer.new(size_hint=4)
+  let buf = Buffer(size_hint=4)
   buf.write_uint16_be(Int::to_uint16(0x1234))
   buf.write_uint16_be(Int::to_uint16(0xabcd))
   inspect(
@@ -475,7 +475,7 @@ test "write_uint16_be method" {
 
 ///|
 test "write_int16_le method" {
-  let buf = @buffer.new(size_hint=4)
+  let buf = Buffer(size_hint=4)
   buf.write_int16_le((-2 : Int16))
   buf.write_int16_le((0x1234 : Int16))
   inspect(
@@ -488,7 +488,7 @@ test "write_int16_le method" {
 
 ///|
 test "write_int16_be method" {
-  let buf = @buffer.new(size_hint=4)
+  let buf = Buffer(size_hint=4)
   buf.write_int16_be((-2 : Int16))
   buf.write_int16_be((0x1234 : Int16))
   inspect(

--- a/buffer/buffer_test.mbt
+++ b/buffer/buffer_test.mbt
@@ -87,6 +87,20 @@ test "write_byte method" {
 }
 
 ///|
+test "write_utf8 method" {
+  let buf = @buffer.new()
+  buf.write_utf8(42)
+  buf.write_utf8('!')
+  buf.write_utf8("hi"[:])
+  inspect(
+    buf.contents(),
+    content=(
+      #|b"42!hi"
+    ),
+  )
+}
+
+///|
 test "to_bytes method" {
   let buf = @buffer.new(size_hint=10)
   buf.write_string("Test")

--- a/buffer/debug.mbt
+++ b/buffer/debug.mbt
@@ -28,7 +28,7 @@ pub fn Buffer::to_repr(self : Buffer) -> Repr {
 
 ///|
 test "Debug for Buffer" {
-  let buf = new()
+  let buf = Buffer()
   buf.write_bytes(b"ab")
   @debug.debug_inspect(buf, content="<Buffer: [0x61, 0x62]>")
 }

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -56,6 +56,7 @@ pub fn Buffer::write_uint64_be(Self, UInt64) -> Unit
 pub fn Buffer::write_uint64_le(Self, UInt64) -> Unit
 pub fn Buffer::write_uint_be(Self, UInt) -> Unit
 pub fn Buffer::write_uint_le(Self, UInt) -> Unit
+pub fn[T : Show] Buffer::write_utf8(Self, T) -> Unit
 pub impl Logger for Buffer
 pub impl Show for Buffer
 pub impl @debug.Debug for Buffer

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -18,7 +18,10 @@ pub fn new(size_hint? : Int) -> Buffer
 
 // Types and methods
 #alias(T, deprecated)
-type Buffer
+pub struct Buffer {
+  // private fields
+}
+pub fn Buffer::Buffer(size_hint? : Int) -> Self
 pub fn Buffer::is_empty(Self) -> Bool
 pub fn Buffer::length(Self) -> Int
 pub fn Buffer::reset(Self) -> Unit

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -12,6 +12,7 @@ pub fn from_bytes(BytesView) -> Buffer
 
 pub fn from_iter(Iter[Byte]) -> Buffer
 
+#deprecated
 pub fn new(size_hint? : Int) -> Buffer
 
 // Errors

--- a/buffer/sleb128.mbt
+++ b/buffer/sleb128.mbt
@@ -14,7 +14,7 @@
 
 ///|
 trait Leb128 {
-  output(Self, Buffer) -> Unit
+  fn output(Self, Buffer) -> Unit
 }
 
 ///|
@@ -74,7 +74,7 @@ pub impl Leb128 for Int64 with output(self, buffer) {
 ///
 /// ```mbt check
 /// test {
-///   let buf = @buffer.new()
+///   let buf = Buffer()
 ///   buf.write_leb128(127)
 ///   inspect(buf.contents().length() > 0, content="true")
 /// }

--- a/buffer/sleb128.mbt
+++ b/buffer/sleb128.mbt
@@ -14,7 +14,7 @@
 
 ///|
 trait Leb128 {
-  fn output(Self, Buffer) -> Unit
+  output(Self, Buffer) -> Unit
 }
 
 ///|

--- a/buffer/sleb128_test.mbt
+++ b/buffer/sleb128_test.mbt
@@ -20,7 +20,7 @@ fn[A : Leb128] @buffer.Buffer::test_leb128(self : Self, x : A) -> Unit {
 
 ///|
 test "write_leb128 Int" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.test_leb128(0)
   inspect(
     buffer.to_bytes(),
@@ -63,7 +63,7 @@ test "write_leb128 Int" {
 
 ///|
 test "write_leb128 Int64" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.write_leb128(0L)
   assert_eq(buffer.to_bytes(), b"\x00")
   buffer.reset()
@@ -88,7 +88,7 @@ test "write_leb128 Int64" {
 
 ///|
 test "write_leb128 UInt" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   // Test zero
   buffer.write_leb128(0U)
   assert_eq(buffer.to_bytes(), b"\x00")
@@ -137,7 +137,7 @@ test "write_leb128 UInt" {
 
 ///|
 test "write_leb128_edge_cases" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
 
   // Test boundary values for each byte length
   buffer.write_leb128(0U)
@@ -171,7 +171,7 @@ test "write_leb128_edge_cases" {
 
 ///|
 test "write_leb128_consecutive_writes" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
 
   // Test writing multiple values consecutively
   buffer.write_leb128(1U)
@@ -184,7 +184,7 @@ test "write_leb128_consecutive_writes" {
 
 ///|
 test "write_leb128_negative_values" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
 
   // Test negative values for SLEB128
   buffer.write_leb128(-1)
@@ -206,7 +206,7 @@ test "write_leb128_negative_values" {
 
 ///|
 test "write_leb128_negative_Int64" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
 
   // Test negative Int64 values for SLEB128
   buffer.write_leb128(-1L)
@@ -254,14 +254,14 @@ test "write_leb128_negative_Int64" {
 
 ///|
 test {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.write_leb128(-65)
   assert_eq(buffer.to_bytes(), b"\xbf\x7f")
 }
 
 ///|
 test "write_leb128 UInt64" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.write_leb128(0UL)
   assert_eq(buffer.to_bytes(), b"\x00")
   buffer.reset()
@@ -287,7 +287,7 @@ test "write_leb128 UInt64" {
 
 ///|
 test "write_leb128 UInt64 large values" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.write_leb128(0xFFFFFFFFUL)
   assert_eq(buffer.to_bytes(), b"\xff\xff\xff\xff\x0f")
   buffer.reset()

--- a/builtin/double_test.mbt
+++ b/builtin/double_test.mbt
@@ -92,7 +92,7 @@ test "panic is_close with invalid relative and absolute tolerances" {
 ///|
 fn Double::to_le_bytes_local(self : Double) -> Bytes {
   // self.reinterpret_as_uint64().to_le_bytes()
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_uint64_le(self.reinterpret_as_uint64())
   return buf.to_bytes()
 }
@@ -100,7 +100,7 @@ fn Double::to_le_bytes_local(self : Double) -> Bytes {
 ///|
 fn Double::to_be_bytes_local(self : Double) -> Bytes {
   // self.reinterpret_as_uint64().to_be_bytes()
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_uint64_be(self.reinterpret_as_uint64())
   return buf.to_bytes()
 }

--- a/double/README.mbt.md
+++ b/double/README.mbt.md
@@ -76,7 +76,7 @@ test "binary representation" {
 
   // Convert to big-endian and little-endian bytes
   // Different byte orders should produce different results
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.write_double_be(num)
   inspect(
     buffer.to_bytes(),

--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -51,7 +51,7 @@ pub fn decode(
   text : StringView,
   ignore_whitespace? : Bool = false,
 ) -> Bytes raise Malformed {
-  let buffer = @buffer.new(size_hint=text.length() / 4 * 3)
+  let buffer = @buffer.Buffer(size_hint=text.length() / 4 * 3)
   let quartet = FixedArray::make(4, 0)
   let mut count = 0
   for i in 0..<text.length() {
@@ -142,7 +142,7 @@ pub fn decode_lossy(
   text : StringView,
   ignore_whitespace? : Bool = false,
 ) -> Bytes {
-  let buffer = @buffer.new(size_hint=text.length() / 4 * 3)
+  let buffer = @buffer.Buffer(size_hint=text.length() / 4 * 3)
   let quartet = FixedArray::make(4, 0)
   let mut count = 0
   for i in 0..<text.length() {

--- a/encoding/utf8/decode_test.mbt
+++ b/encoding/utf8/decode_test.mbt
@@ -27,7 +27,7 @@ test "U+FFFD" {
 
 ///|
 test "decoding UTF8 encoded data to String" {
-  let buf = @buffer.new(size_hint=10)
+  let buf = Buffer(size_hint=10)
   buf.write_bytes(b"abc")
   buf.write_bytes(b"\xe4\xbd\xa0") // 你
   buf.write_bytes(b"\xe5\xa5\xbd") // 好

--- a/encoding/utf8/encode_test.mbt
+++ b/encoding/utf8/encode_test.mbt
@@ -33,7 +33,7 @@ test "encode" {
 
 ///|
 fn encode_via_buffer(str : StringView, bom : Bool) -> Bytes {
-  let buffer = @buffer.new(size_hint=str.length() * 4)
+  let buffer = Buffer(size_hint=str.length() * 4)
   if bom {
     buffer.write_char_utf8('\u{FEFF}')
   }

--- a/int/README.mbt.md
+++ b/int/README.mbt.md
@@ -29,7 +29,7 @@ test "byte conversions" {
   let num = 258 // 0x0102 in hex
 
   // Big-endian conversion (most significant byte first)
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_int_be(num)
   let be_bytes = buf.contents()
   inspect(
@@ -65,7 +65,7 @@ test "method syntax" {
   inspect(n.abs(), content="42")
 
   // Byte conversions using method syntax
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_int_be(n)
   let be = buf.contents()
   buf.reset()

--- a/int/int_test.mbt
+++ b/int/int_test.mbt
@@ -76,7 +76,7 @@ test "abs function coverage" {
 
 ///|
 test "to_le_bytes" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.write_int_le(0x12345678)
   let bytes = buffer.contents()
   inspect(
@@ -89,7 +89,7 @@ test "to_le_bytes" {
 
 ///|
 test "to_be_bytes" {
-  let buffer = @buffer.new()
+  let buffer = Buffer()
   buffer.write_int_be(0x12345678)
   let bytes = buffer.contents()
   inspect(

--- a/int64/int64_test.mbt
+++ b/int64/int64_test.mbt
@@ -129,7 +129,7 @@ test "Int64::popcnt mixed cases" {
 ///|
 fn Int64::to_be_bytes_local(self : Int64) -> Bytes {
   // self.reinterpret_as_uint64().to_be_bytes()
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_int64_be(self)
   buf.to_bytes()
 }
@@ -148,7 +148,7 @@ test "to_be_bytes" {
 ///|
 fn Int64::to_le_bytes_local(self : Int64) -> Bytes {
   // self.reinterpret_as_uint64().to_le_bytes()
-  let buf = @buffer.new(size_hint=8)
+  let buf = Buffer(size_hint=8)
   buf.write_int64_le(self)
   buf.to_bytes()
 }

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -22,7 +22,7 @@ pub(all) suberror JsonDecodeError {
 ///|
 /// Trait for types that can be converted from `Json`
 pub(open) trait FromJson {
-  fn from_json(Json, JsonPath) -> Self raise JsonDecodeError
+  from_json(Json, JsonPath) -> Self raise JsonDecodeError
 }
 
 ///|

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -22,7 +22,7 @@ pub(all) suberror JsonDecodeError {
 ///|
 /// Trait for types that can be converted from `Json`
 pub(open) trait FromJson {
-  from_json(Json, JsonPath) -> Self raise JsonDecodeError
+  fn from_json(Json, JsonPath) -> Self raise JsonDecodeError
 }
 
 ///|
@@ -292,7 +292,7 @@ pub impl FromJson for Bytes with from_json(json, path) {
   guard json is String(a) else {
     decode_error(path, "Bytes::from_json: expected string")
   }
-  let buffer = @buffer.new(size_hint=a.length())
+  let buffer = @buffer.Buffer(size_hint=a.length())
   for x = a[:] {
     match x {
       [] => break

--- a/prelude/moon.pkg
+++ b/prelude/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/bigint",
+  "moonbitlang/core/buffer",
   "moonbitlang/core/set",
   "moonbitlang/core/json",
   "moonbitlang/core/debug",

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/core/prelude"
 
 import {
   "moonbitlang/core/bigint",
+  "moonbitlang/core/buffer",
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
@@ -82,6 +83,8 @@ pub using @builtin {type Array}
 pub using @builtin {type ArrayView}
 
 pub using @bigint {type BigInt}
+
+pub using @buffer {type Buffer}
 
 pub using @builtin {type Failure}
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 ///|
+pub using @buffer {type Buffer}
+
+///|
 pub using @set {type Set}
 
 ///|

--- a/uint/uint_test.mbt
+++ b/uint/uint_test.mbt
@@ -65,7 +65,7 @@ test "default" {
 test "to_le_bytes" {
   let x : UInt = 0x12345678U
   // let bytes = x.to_le_bytes()
-  let buf = @buffer.new()
+  let buf = Buffer()
   buf.write_uint_le(x)
   let bytes = buf.to_bytes()
   inspect(bytes[0].to_int(), content="120") // 0x78


### PR DESCRIPTION
## Summary
Four related changes to make `Buffer` more ergonomic:

1. **`Buffer::write_utf8`** — `fn[T : Show] Buffer::write_utf8(self, value : T) -> Unit`. Writes the `Show` representation as UTF-8 bytes. Pairs with the existing `Buffer::write_object` (which goes through the default `Logger` impl and emits UTF-16). Current impl is `self.write_string_utf8(value.to_string())`; the signature is the contract — we can later route `Show::output` directly through a UTF-8-encoding logger to skip the intermediate `String` without changing callers. `write_char_utf8` / `write_string_utf8` are kept as fast paths.

2. **`Buffer::Buffer` constructor** — enables `let buf = Buffer()` (and `Buffer(size_hint=N)`). Mirrors the `StringBuilder::StringBuilder` pattern.

3. **Prelude export** — `pub using @buffer {type Buffer}` so `Buffer` is in scope by default, like `Set`, `BigInt`, `Map`, etc.

4. **Deprecate `@buffer.new`** — kept for backward compatibility but marked `#deprecated`, with the body delegating to `Buffer::Buffer`. All in-tree call sites migrated:
   - Test code and READMEs use the unqualified `Buffer(...)` form (prelude is in scope).
   - Non-test production code in packages that prelude transitively depends on (`encoding/base64`, `json`) uses `@buffer.Buffer(...)` since the prelude isn't auto-imported there.

## Test plan
- [x] `moon fmt`
- [x] `moon check`
- [x] `moon test` — 6504 passed, 0 failed
- [x] New `write_utf8` unit test covering `Int`, `Char`, `StringView` payloads
- [x] New doctest demonstrating `let buf = Buffer()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)