### PR TITLE
[codex] deprecate Buffer Logger impl

### DIFF
--- a/buffer/README.mbt.md
+++ b/buffer/README.mbt.md
@@ -144,15 +144,14 @@ test {
 
 ## Writing Show Objects
 
-Write any type that implements `Show` via `write_object()`. The buffer also implements the `Logger` trait, so it can be passed to `output()`.
+Write any type that implements `Show` as UTF-8 bytes via `write_utf8()`. The current `write_object()` and `Logger` implementation for `Buffer` write UTF-16LE bytes and are deprecated; a future breaking release may restore them with UTF-8 semantics.
 
 ```mbt check
 ///|
 test {
   let buf = Buffer()
-  buf.write_object(42)
-  // write_object uses the Show trait, producing UTF-16LE string bytes
-  assert_eq(buf.length(), 4) // "42" in UTF-16LE = 4 bytes
+  buf.write_utf8(42)
+  inspect(buf.to_bytes(), content="b\"42\"")
 }
 ```
 

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -229,6 +229,15 @@ pub fn from_iter(iter : Iter[Byte]) -> Buffer {
 ///   )
 /// }
 /// ```
+
+///|
+/// This Logger impl currently writes UTF-16LE bytes for compatibility. After a
+/// breaking-change window, Buffer may implement Logger again with UTF-8
+/// semantics.
+#deprecated("Buffer's current Logger impl writes UTF-16LE bytes; use StringBuilder or explicit Buffer encoders. A future breaking release may restore it with UTF-8 semantics.", skip_current_package=true)
+pub impl Logger for Buffer
+
+///|
 pub impl Logger for Buffer with write_string(self, value) {
   self.grow_if_necessary(self.len + value.length() * 2)
   self.data.blit_from_string(self.len, value, 0, value.length())
@@ -736,6 +745,7 @@ pub fn Buffer::write_float_le(self : Buffer, value : Float) -> Unit {
 ///   inspect(buf.contents().to_unchecked_string(), content="42")
 /// }
 /// ```
+#deprecated("Buffer::write_object writes UTF-16LE bytes; use write_utf8 or explicit Buffer encoders. A future breaking release may restore it with UTF-8 semantics.", skip_current_package=true)
 pub fn Buffer::write_object(self : Buffer, value : &Show) -> Unit {
   self.write_string(value.to_string())
 }

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -24,8 +24,8 @@
 ///
 /// ```mbt nocheck
 ///   let buf = Buffer(size_hint=100)
-///   buf.write_string("Tes")
-///   buf.write_char('t')
+///   buf.write_string_utf16le("Tes")
+///   buf.write_char_utf16le('t')
 ///   inspect(
 ///     buf.contents(), 
 ///     content=(
@@ -72,7 +72,7 @@ fn Buffer::grow_if_necessary(self : Buffer, required : Int) -> Unit {
 /// ```mbt check
 /// test {
 ///   let buf = Buffer()
-///   buf.write_string("Test")
+///   buf.write_string_utf16le("Test")
 ///   inspect(buf.length(), content="8") // each char takes 2 bytes in UTF-16
 /// }
 /// ```
@@ -96,7 +96,7 @@ pub fn Buffer::length(self : Buffer) -> Int {
 /// test {
 ///   let buf = Buffer()
 ///   inspect(buf.is_empty(), content="true")
-///   buf.write_string("test")
+///   buf.write_string_utf16le("test")
 ///   inspect(buf.is_empty(), content="false")
 /// }
 /// ```
@@ -121,7 +121,7 @@ pub fn Buffer::is_empty(self : Buffer) -> Bool {
 /// test {
 ///   let buf = Buffer(size_hint=10)
 ///   inspect(buf.length(), content="0")
-///   buf.write_string("test")
+///   buf.write_string_utf16le("test")
 ///   inspect(buf.length(), content="8")
 /// }
 /// ```
@@ -146,7 +146,7 @@ pub fn new(size_hint? : Int = 0) -> Buffer {
 /// ```mbt check
 /// test {
 ///   let buf = Buffer()
-///   buf.write_string("test")
+///   buf.write_string_utf16le("test")
 ///   inspect(buf.length(), content="8")
 /// }
 /// ```
@@ -209,26 +209,6 @@ pub fn from_iter(iter : Iter[Byte]) -> Buffer {
 ///
 /// * `buffer` : The buffer to write to.
 /// * `string` : The string to be written.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let buf = Buffer()
-///   buf.write_string("Test")
-///   // Each UTF-16 char takes 2 bytes in little-endian format
-///   // 'T' -> [0x54, 0x00]
-///   // 'e' -> [0x65, 0x00]
-///   // 's' -> [0x73, 0x00]
-///   // 't' -> [0x74, 0x00]
-///   inspect(
-///     buf.contents(),
-///     content=(
-///       #|b"T\x00e\x00s\x00t\x00"
-///     ),
-///   )
-/// }
-/// ```
 
 ///|
 /// This Logger impl currently writes UTF-16LE bytes for compatibility. After a
@@ -735,16 +715,6 @@ pub fn Buffer::write_float_le(self : Buffer, value : Float) -> Unit {
 /// * `value` : Any value that implements the `Show` trait. The value will be
 /// converted to a string using its `to_string` method before being written to
 /// the buffer.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let buf = Buffer()
-///   buf.write_object(42)
-///   inspect(buf.contents().to_unchecked_string(), content="42")
-/// }
-/// ```
 #deprecated("Buffer::write_object writes UTF-16LE bytes; use write_utf8 or explicit Buffer encoders. A future breaking release may restore it with UTF-8 semantics.", skip_current_package=true)
 pub fn Buffer::write_object(self : Buffer, value : &Show) -> Unit {
   self.write_string(value.to_string())
@@ -1013,21 +983,6 @@ pub fn Buffer::write_string_utf16be(buf : Self, string : StringView) -> Unit {
 /// non-negative.
 /// * `count` : The number of characters to write. Must be non-negative and
 /// `offset + count` must not exceed the length of the source string.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let buf = Buffer()
-///   buf.write_view("Hello, World!"[:5])
-///   inspect(
-///     buf.contents(),
-///     content=(
-///       #|b"H\x00e\x00l\x00l\x00o\x00"
-///     ),
-///   )
-/// }
-/// ```
 pub impl Logger for Buffer with write_view(self : Buffer, value : StringView) -> Unit {
   self.grow_if_necessary(self.len + value.length() * 2)
   self.data.blit_from_string(
@@ -1047,21 +1002,6 @@ pub impl Logger for Buffer with write_view(self : Buffer, value : StringView) ->
 ///
 /// * `buffer` : The buffer to write to.
 /// * `char` : The character to be written.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let buf = Buffer()
-///   buf.write_char('A')
-///   inspect(
-///     buf.contents(),
-///     content=(
-///       #|b"A\x00"
-///     ),
-///   )
-/// }
-/// ```
 pub impl Logger for Buffer with write_char(self : Buffer, value : Char) -> Unit {
   self.grow_if_necessary(self.len + 4)
   let inc = self.data.set_utf16le_char(self.len, value)
@@ -1139,7 +1079,7 @@ pub fn Buffer::write_iter(self : Buffer, iter : Iter[Byte]) -> Unit {
 /// ```mbt check
 /// test {
 ///   let buf = Buffer()
-///   buf.write_string("Hello")
+///   buf.write_string_utf16le("Hello")
 ///   inspect(buf.length(), content="10")
 ///   buf.reset()
 ///   inspect(buf.length(), content="0")
@@ -1166,7 +1106,7 @@ pub fn Buffer::reset(self : Buffer) -> Unit {
 /// ```mbt check
 /// test {
 ///   let buf = Buffer()
-///   buf.write_string("Test")
+///   buf.write_string_utf16le("Test")
 ///   let bytes = buf.to_bytes()
 ///   inspect(bytes.length(), content="8") //utf16
 /// }

--- a/buffer/buffer_test.mbt
+++ b/buffer/buffer_test.mbt
@@ -43,7 +43,7 @@ test "create buffer from iterator" {
 test "length method" {
   let buf = Buffer(size_hint=100)
   inspect(buf.length(), content="0")
-  buf.write_string("Test")
+  buf.write_string_utf16le("Test")
   inspect(buf.length(), content="8")
 }
 
@@ -51,30 +51,30 @@ test "length method" {
 test "is_empty method" {
   let buf = Buffer(size_hint=100)
   inspect(buf.is_empty(), content="true")
-  buf.write_string("Test")
+  buf.write_string_utf16le("Test")
   inspect(buf.is_empty(), content="false")
 }
 
 ///|
 test "expect method with matching content" {
   let buf = Buffer(size_hint=100)
-  buf.write_string("Test")
+  buf.write_string_utf16le("Test")
   inspect(buf, content="Test")
 }
 
 ///|
 test "grow_if_necessary method" {
   let buf = Buffer(size_hint=10)
-  buf.write_string(
+  buf.write_string_utf16le(
     "This is a test string that is longer than the initial capacity",
   )
   assert_true(buf.to_bytes().length() >= 60)
 }
 
 ///|
-test "write_substring method" {
+test "write UTF-16LE string view" {
   let buf = Buffer(size_hint=10)
-  buf.write_view("Hello, World!"[7:12])
+  buf.write_string_utf16le("Hello, World!"[7:12])
   inspect(buf, content="World")
 }
 
@@ -103,7 +103,7 @@ test "write_utf8 method" {
 ///|
 test "to_bytes method" {
   let buf = Buffer(size_hint=10)
-  buf.write_string("Test")
+  buf.write_string_utf16le("Test")
   let bytes = buf.to_bytes()
   inspect(bytes.length(), content="8") // Each character in "Test" is 2 bytes
 }
@@ -359,21 +359,6 @@ test "write_char_utf8" {
     buf.to_bytes(),
     content=(
       #|b"A\xce\xb1\xe5\x95\x8a\xf0\x9f\x98\xa6"
-    ),
-  )
-}
-
-///|
-test "write_char" {
-  let buf = Buffer(size_hint=10)
-  buf.write_char('A')
-  buf.write_char('α')
-  buf.write_char('啊')
-  buf.write_char('😦')
-  inspect(
-    buf.to_bytes(),
-    content=(
-      #|b"A\x00\xb1\x03JU=\xd8&\xde"
     ),
   )
 }

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -49,6 +49,7 @@ pub fn Buffer::write_int_be(Self, Int) -> Unit
 pub fn Buffer::write_int_le(Self, Int) -> Unit
 pub fn Buffer::write_iter(Self, Iter[Byte]) -> Unit
 pub fn[A : Leb128] Buffer::write_leb128(Self, A) -> Unit
+#deprecated
 pub fn Buffer::write_object(Self, &Show) -> Unit
 pub fn Buffer::write_string_utf16be(Self, StringView) -> Unit
 #alias(write_stringview, deprecated)
@@ -61,6 +62,7 @@ pub fn Buffer::write_uint64_le(Self, UInt64) -> Unit
 pub fn Buffer::write_uint_be(Self, UInt) -> Unit
 pub fn Buffer::write_uint_le(Self, UInt) -> Unit
 pub fn[T : Show] Buffer::write_utf8(Self, T) -> Unit
+#deprecated
 pub impl Logger for Buffer
 pub impl Show for Buffer
 pub impl @debug.Debug for Buffer


### PR DESCRIPTION
## Summary

Deprecate the implicit UTF-16 text-writing surface on `Buffer`:

- `impl Logger for Buffer`, which provides `write`, `write_string`, `write_view`, and `write_char` with UTF-16LE byte semantics
- `Buffer::write_object`, which also writes UTF-16LE bytes via the current logger path

The source and README note the intended direction: after a breaking-change window, these APIs may be restored with UTF-8 semantics. Explicit byte, numeric, UTF-8, and UTF-16 writers remain available.

The follow-up cleanup commit removes deprecated examples and updates checked docs/tests to use explicit UTF-16LE or UTF-8 APIs, keeping deny-warn CI clean.

## Validation

- `moon info`
- `moon fmt`
- `moon check --target all --deny-warn`
- `moon test buffer --target all --deny-warn` (96 passed on wasm, wasm-gc, js, and native)