### PR TITLE
feat: add StringBuilder::write_end

### DIFF
--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -152,6 +152,12 @@ pub fn StringBuilder::to_string(self : StringBuilder) -> String {
 }
 
 ///|
+#doc(hidden)
+pub fn StringBuilder::write_end(self : StringBuilder) -> String {
+  self.to_string()
+}
+
+///|
 pub impl Show for StringBuilder with to_string(self) {
   StringBuilder::to_string(self)
 }


### PR DESCRIPTION
Add `StringBuilder::write_end` API, make `let r = StringBuilder <+ "xxx \{y}"` possible.

This API is hidden because `<+` is still experimental.

@bobzhang @myfreess 

