### PR TITLE
Optimize ChaCha8 random source next

### DIFF
--- a/random/internal/random_source/pkg.generated.mbti
+++ b/random/internal/random_source/pkg.generated.mbti
@@ -8,7 +8,7 @@ package "moonbitlang/core/random/internal/random_source"
 // Types and methods
 type ChaCha8
 pub fn ChaCha8::new(BytesView) -> Self
-pub fn ChaCha8::next(Self) -> UInt64?
+pub fn ChaCha8::next_uint64(Self) -> UInt64
 pub fn ChaCha8::refill(Self) -> Unit
 
 // Type aliases

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -53,11 +53,11 @@ const SEED_CHUNK_NUM = 4
 ///|
 /// Return the next random `UInt64`, refilling the internal buffer when needed.
 pub fn ChaCha8::next_uint64(self : ChaCha8) -> UInt64 {
-  let i = self.i
+  let mut i = self.i
   if i >= self.n {
     self.refill()
+    i = 0
   }
-  let i = self.i
   self.i = i + 1
   let index = i.reinterpret_as_int() & (BUFFER_CHUNK_NUM - 1)
   let lo = self.buffer[index * 2].to_uint64()
@@ -66,7 +66,10 @@ pub fn ChaCha8::next_uint64(self : ChaCha8) -> UInt64 {
 }
 
 ///|
-/// Function `refill`.
+/// Refill the internal buffer and reset the read cursor.
+///
+/// After refill, `self.i == 0` and `self.n` is either `BUFFER_CHUNK_NUM` or
+/// `BUFFER_CHUNK_NUM - SEED_CHUNK_NUM`, so `self.i < self.n`.
 pub fn ChaCha8::refill(self : ChaCha8) -> Unit {
   self.counter += COUNTER_INC
   if self.counter == COUNTER_MAX {

--- a/random/internal/random_source/random_source_chacha.mbt
+++ b/random/internal/random_source/random_source_chacha.mbt
@@ -51,17 +51,18 @@ const BUFFER_CHUNK_NUM = 32
 const SEED_CHUNK_NUM = 4
 
 ///|
-/// Function `next`.
-pub fn ChaCha8::next(self : ChaCha8) -> UInt64? {
+/// Return the next random `UInt64`, refilling the internal buffer when needed.
+pub fn ChaCha8::next_uint64(self : ChaCha8) -> UInt64 {
   let i = self.i
   if i >= self.n {
-    return None
+    self.refill()
   }
+  let i = self.i
   self.i = i + 1
   let index = i.reinterpret_as_int() & (BUFFER_CHUNK_NUM - 1)
   let lo = self.buffer[index * 2].to_uint64()
   let hi = self.buffer[index * 2 + 1].to_uint64()
-  Some((hi << 32) | lo)
+  (hi << 32) | lo
 }
 
 ///|
@@ -283,17 +284,8 @@ test "BUFFER_CHUNK_NUM is power of 2" {
 test "output" {
   let s = ChaCha8::new(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
   let res = Array::new(capacity=372)
-  fn uint64(s : ChaCha8) -> UInt64 {
-    for ;; {
-      if s.next() is Some(x) {
-        return x
-      }
-      s.refill()
-    }
-  }
-
   for _ in 0..<372 {
-    let x = uint64(s)
+    let x = s.next_uint64()
     res.push(x)
   }
   let expected = [

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -27,12 +27,7 @@ pub(open) trait Source {
 impl Source for @random_source.ChaCha8 with fn next(
   self : @random_source.ChaCha8,
 ) -> UInt64 {
-  for ;; {
-    if self.next() is Some(x) {
-      return x
-    }
-    self.refill()
-  }
+  self.next_uint64()
 }
 
 ///|


### PR DESCRIPTION
## Summary
- add a non-optional ChaCha8::next_uint64 path that refills internally
- use it for the ChaCha8 Source implementation to avoid per-value Option matching in Rand hot paths
- update generated interfaces for the touched random packages

## Performance
Before this change, repeated local runs of the existing benchmark were around 38.3-38.5 ms:

```
moon bench -p moonbitlang/core/random -f random_test.mbt
bench random: ~38.3-38.5 ms
```

With this change, repeated runs are around 31.1-31.4 ms:

```
moon bench -p moonbitlang/core/random -f random_test.mbt
bench random: 31.16 ms ± 578.23 us
```

## Validation
- `moon fmt --check random/random.mbt random/internal/random_source/random_source_chacha.mbt`
- `moon check random random/internal/random_source`
- `moon test random random/internal/random_source`
- `moon check`
- `moon bench -p moonbitlang/core/random -f random_test.mbt`