### PR TITLE
perf(bigint): speed up large BigInt x small scalar multiplication

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -388,10 +388,10 @@ pub impl Mul for BigInt with fn mul(self : BigInt, other : BigInt) -> BigInt {
   // this on every multiplication, and the general grade-school loop has
   // a per-i branch on `j < other_len` plus carry propagation overhead
   // that disappears here.
-  let ret = if other.limbs[:other.len] is [single] {
-    self.mul_single_limb(single)
-  } else if self.limbs[:self.len] is [single] {
-    other.mul_single_limb(single)
+  let ret = if other.len == 1 {
+    self.mul_single_limb(other.limbs.unsafe_get(0))
+  } else if self.len == 1 {
+    other.mul_single_limb(self.limbs.unsafe_get(0))
   } else if self.len < karatsuba_threshold || other.len < karatsuba_threshold {
     self.grade_school_mul(other)
   } else {

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -401,8 +401,12 @@ pub impl Mul for BigInt with fn mul(self : BigInt, other : BigInt) -> BigInt {
 }
 
 ///|
-/// Multiply by a single radix-limb. Used as the fast path of `Mul::mul`
-/// when one operand has `len == 1`.
+/// Multiply the magnitude of `self` by a single radix-limb `x`. Returns
+/// a `Positive`-signed result regardless of `self.sign` — the caller in
+/// `Mul::mul` overwrites `sign` with the correct combined sign. This
+/// matches the convention of the other magnitude-only multiply helpers
+/// (`grade_school_mul`, `karatsuba_mul`). Do not call directly when a
+/// signed product is needed.
 fn BigInt::mul_single_limb(self : BigInt, x : UInt) -> BigInt {
   let n = self.len
   let limbs = FixedArray::make(n + 1, 0U)

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -388,10 +388,10 @@ pub impl Mul for BigInt with fn mul(self : BigInt, other : BigInt) -> BigInt {
   // this on every multiplication, and the general grade-school loop has
   // a per-i branch on `j < other_len` plus carry propagation overhead
   // that disappears here.
-  let ret = if other.len == 1 {
-    self.mul_single_limb(other.limbs[0])
-  } else if self.len == 1 {
-    other.mul_single_limb(self.limbs[0])
+  let ret = if other.limbs[:other.len] is [single] {
+    self.mul_single_limb(single)
+  } else if self.limbs[:self.len] is [single] {
+    other.mul_single_limb(single)
   } else if self.len < karatsuba_threshold || other.len < karatsuba_threshold {
     self.grade_school_mul(other)
   } else {
@@ -407,13 +407,18 @@ pub impl Mul for BigInt with fn mul(self : BigInt, other : BigInt) -> BigInt {
 /// matches the convention of the other magnitude-only multiply helpers
 /// (`grade_school_mul`, `karatsuba_mul`). Do not call directly when a
 /// signed product is needed.
+///
+/// Requires `self` to be non-zero and `x > 0`: with a zero operand the
+/// result would be an all-zero magnitude with `len > 1`, breaking the
+/// no-leading-zeros invariant. The call site in `Mul::mul` guarantees
+/// this via its `is_zero` guard.
 fn BigInt::mul_single_limb(self : BigInt, x : UInt) -> BigInt {
   let n = self.len
   let limbs = FixedArray::make(n + 1, 0U)
-  let xq = x.to_uint64()
+  let x_u64 = x.to_uint64()
   let mut carry = 0UL
   for i in 0..<n {
-    let product = self.limbs[i].to_uint64() * xq + carry
+    let product = self.limbs[i].to_uint64() * x_u64 + carry
     limbs[i] = (product & radix_mask).to_uint()
     carry = product >> radix_bit_len
   }

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -384,12 +384,42 @@ pub impl Mul for BigInt with fn mul(self : BigInt, other : BigInt) -> BigInt {
   if self.is_zero() || other.is_zero() {
     return zero
   }
-  let ret = if self.len < karatsuba_threshold || other.len < karatsuba_threshold {
+  // Specialize the (n-limb) x (1-limb) case. Factorial-style chains hit
+  // this on every multiplication, and the general grade-school loop has
+  // a per-i branch on `j < other_len` plus carry propagation overhead
+  // that disappears here.
+  let ret = if other.len == 1 {
+    self.mul_single_limb(other.limbs[0])
+  } else if self.len == 1 {
+    other.mul_single_limb(self.limbs[0])
+  } else if self.len < karatsuba_threshold || other.len < karatsuba_threshold {
     self.grade_school_mul(other)
   } else {
     self.karatsuba_mul(other)
   }
   { ..ret, sign: if self.sign == other.sign { Positive } else { Negative } }
+}
+
+///|
+/// Multiply by a single radix-limb. Used as the fast path of `Mul::mul`
+/// when one operand has `len == 1`.
+fn BigInt::mul_single_limb(self : BigInt, x : UInt) -> BigInt {
+  let n = self.len
+  let limbs = FixedArray::make(n + 1, 0U)
+  let xq = x.to_uint64()
+  let mut carry = 0UL
+  for i in 0..<n {
+    let product = self.limbs[i].to_uint64() * xq + carry
+    limbs[i] = (product & radix_mask).to_uint()
+    carry = product >> radix_bit_len
+  }
+  let len = if carry == 0UL {
+    n
+  } else {
+    limbs[n] = carry.to_uint()
+    n + 1
+  }
+  { limbs, sign: Positive, len }
 }
 
 // Simplest way to multiply two BigInts.

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -94,6 +94,36 @@ test "shr" {
 }
 
 ///|
+test "mul_single_limb boundaries" {
+  // 1-limb x 1-limb with maximal carry-out: (2^32 - 1)^2
+  let max_limb = 4294967295N
+  let p = max_limb * max_limb
+  check_invariant(p)
+  inspect(p, content="18446744065119617025")
+  // all-max limbs: (2^96 - 1) * (2^32 - 1), carry grows len to n + 1
+  let a = (1N << 96) - 1N
+  let p = a * max_limb
+  check_invariant(p)
+  inspect(p, content="340282366841710300949110269833929293825")
+  // commuted operand order takes the same fast path
+  let p = max_limb * a
+  check_invariant(p)
+  inspect(p, content="340282366841710300949110269833929293825")
+  // no carry-out: len stays at self.len, the spare limb beyond len stays zero
+  let p = (1N << 64) * 2N
+  check_invariant(p)
+  inspect(p, content="36893488147419103232")
+  // the dispatch applies the sign on top of the magnitude-only helper
+  inspect(a * -max_limb, content="-340282366841710300949110269833929293825")
+  inspect(-a * max_limb, content="-340282366841710300949110269833929293825")
+  inspect(-a * -max_limb, content="340282366841710300949110269833929293825")
+  // fast path agrees with the general routine on the same magnitudes
+  let fast = a.mul_single_limb(4294967295U)
+  check_invariant(fast)
+  @test.assert_eq(fast, a.grade_school_mul(max_limb))
+}
+
+///|
 test "add coverage for max(self_len, other_len)" {
   let a = BigInt::from_int(123456789)
   let b = BigInt::from_int(987654321)

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -268,6 +268,22 @@ test "mul" {
 }
 
 ///|
+test "mul by single-limb scalar" {
+  // boundary cases for the (n-limb) x (1-limb) fast path; on the js
+  // backend these go through the native BigInt, which doubles as a
+  // cross-backend oracle
+  let max_limb = 4294967295N // 2^32 - 1
+  inspect(max_limb * max_limb, content="18446744065119617025")
+  let a = (1N << 96) - 1N
+  inspect(a * max_limb, content="340282366841710300949110269833929293825")
+  inspect(max_limb * a, content="340282366841710300949110269833929293825")
+  inspect((1N << 64) * 2N, content="36893488147419103232")
+  inspect(a * -max_limb, content="-340282366841710300949110269833929293825")
+  inspect(-a * max_limb, content="-340282366841710300949110269833929293825")
+  inspect(-a * -max_limb, content="340282366841710300949110269833929293825")
+}
+
+///|
 test "div" {
   let a = @bigint.BigInt::from_int64(987654321098765432L)
   let b = @bigint.BigInt::from_int64(123456789012345678L)


### PR DESCRIPTION
## Summary

`BigInt::mul` currently dispatches into two general-purpose multiplication routines:

- `grade_school_mul` - the `O(n * m)` classical algorithm: a nested loop over both operands' limbs with per-iteration carry propagation and a `j < other_len || carry != 0` guard. Used when at least one operand has fewer than `karatsuba_threshold` (= 50) limbs.
- `karatsuba_mul` - the recursive `O(n^log2(3))` algorithm: splits both operands in half, computes three half-size products, and recombines via the Karatsuba identity. Used when both operands cross the threshold.

For asymmetric cases where one operand fits in a single radix limb, neither routine is ideal. `grade_school_mul` still pays the general nested-loop overhead, and `karatsuba_mul` is never reached because the 1-limb operand is below `karatsuba_threshold`.

This PR adds a `mul_single_limb` fast path that runs a single carry-propagating loop in `O(self.len)`. The dispatch in `Mul::mul` checks both operands, so the fast path fires regardless of operand order.

## Real-world impact

This is not specific to factorial. It optimizes the common shape where a large `BigInt` is repeatedly multiplied by a machine-word-sized scalar.

One concrete core-library path is arbitrary-radix parsing. For non-decimal / non-power-of-two radices, the value is naturally built as:

```mbt
acc = acc * base + digit
```

Here `base <= 36`, so it is a 1-limb `BigInt`, while `acc` grows with the input length. Long base-3/base-5/base-36 inputs therefore repeatedly hit the `n-limb * 1-limb` case optimized by this PR.

The same shape appears in user code for exact combinatorics and product accumulation, for example factorials, permutations, binomial/product formulas, and loops of the form:

```mbt
acc = acc * k
```

where `acc` grows beyond one limb but `k` remains a small integer.

The profiler found this because, in the factorial-style workload, `grade_school_mul` dominated wasm-gc self time. The new fast path removes the general nested-loop overhead for the asymmetric case and turns it into a single carry-propagating pass over the large operand. Workloads with this scalar-growth profile therefore see whole-program speedups on wasm, wasm-gc, and native backends, while balanced `n * n` multiplication and the JS backend remain effectively unchanged.

## Benchmarks

moonbit 0.1.20260522 + this patch, Linux x86_64, wall time (3-run median, no GuestProfiler).

`factorial(800)` (100 iterations), which repeatedly multiplies a growing accumulator by a 1-limb integer. Scenario: `bench/cmd/bigint_ops/main.mbt`.

| backend | baseline | patched | delta |
| --- | ---: | ---: | ---: |
| wasm | 255.1 ms | 80.2 ms | -68.6% |
| wasm-gc | 93.5 ms | 25.2 ms | -73.0% |
| native | 48.9 ms | 20.0 ms | -59.1% |
| js | 21.2 ms | 22.3 ms | noise |

JS is unchanged because the JS backend transpiles `BigInt` to V8's native `BigInt` rather than going through `grade_school_mul`.

Balanced-multiplication probe (repeated squaring of a 30-digit seed x 11 iterations, both operands grow together so the existing `karatsuba_mul` path is exercised) confirms the `n * n` path is not regressed. Scenario: `bench/cmd/bigint_square/main.mbt`.

| backend | baseline | patched | delta |
| --- | ---: | ---: | ---: |
| wasm | 257.1 ms | 271.9 ms | noise |
| wasm-gc | 84.8 ms | 78.2 ms | -7.8% |
| native | 57.0 ms | 58.0 ms | noise |

## Test results

`moon test` against this branch on all four targets (full core suite):

| target | result |
| --- | --- |
| wasm | 6500 / 6500 pass |
| wasm-gc | 6500 / 6500 pass |
| js | 6459 / 6459 pass |
| native | 6411 / 6411 pass |

## Notes on the helper

`mul_single_limb` returns `sign: Positive` regardless of `self.sign`. This matches the existing convention of `grade_school_mul` and `karatsuba_mul`: they return magnitude-only results, and `Mul::mul` overwrites `sign` with the combined sign of the operands at the dispatch site. The doc comment on `mul_single_limb` spells this out.