### PR TITLE
perf(hashmap,hashset,set,builtin): skip Eq and load-factor checks during grow rehash

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -573,7 +573,9 @@ fn[K, V] Map::grow(self : Map[K, V]) -> Unit {
       None => break
       Some(e) => {
         let next_in_chain = e.next
-        // Reset LL fields; rehash_place_entry fills them.
+        // Clear `next` so the entry detaches from the old chain;
+        // rehash_place_entry will rewrite `prev` and `psl` and link this
+        // entry as the new tail.
         e.next = None
         self.rehash_place_entry(e)
         continue next_in_chain

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -558,7 +558,10 @@ fn[K, V] Map::shift_back(self : Map[K, V], idx : Int) -> Unit {
 }
 
 ///|
-fn[K, V] Map::grow(self : Map[K, V]) -> Unit {
+/// `[K : Eq]` kept for trait-surface symmetry with the rest of the
+/// builtin `Map` private API; the rehash loop does not call `key == key`.
+#warnings("-unused_trait_bound")
+fn[K : Eq, V] Map::grow(self : Map[K, V]) -> Unit {
   let old_head = self.head
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -558,10 +558,7 @@ fn[K, V] Map::shift_back(self : Map[K, V], idx : Int) -> Unit {
 }
 
 ///|
-/// `[K : Eq]` kept for trait-surface symmetry with the rest of the
-/// builtin `Map` private API; the rehash loop does not call `key == key`.
-#warnings("-unused_trait_bound")
-fn[K : Eq, V] Map::grow(self : Map[K, V]) -> Unit {
+fn[K, V] Map::grow(self : Map[K, V]) -> Unit {
   let old_head = self.head
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)
@@ -576,9 +573,6 @@ fn[K : Eq, V] Map::grow(self : Map[K, V]) -> Unit {
       None => break
       Some(e) => {
         let next_in_chain = e.next
-        // Clear `next` so the entry detaches from the old chain;
-        // rehash_place_entry will rewrite `prev` and `psl` and link this
-        // entry as the new tail.
         e.next = None
         self.rehash_place_entry(e)
         continue next_in_chain
@@ -588,10 +582,6 @@ fn[K : Eq, V] Map::grow(self : Map[K, V]) -> Unit {
 }
 
 ///|
-/// Place an existing entry into the (already-resized) table. This is the
-/// fast path used by `grow`: like `set_with_hash` but skips the key
-/// equality check (entries from the old table are unique) and the
-/// load-factor check (we just doubled capacity).
 fn[K, V] Map::rehash_place_entry(self : Map[K, V], outer : Entry[K, V]) -> Unit {
   let hash = outer.hash
   for psl = 0, idx = hash & self.capacity_mask {

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -558,7 +558,7 @@ fn[K, V] Map::shift_back(self : Map[K, V], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq, V] Map::grow(self : Map[K, V]) -> Unit {
+fn[K, V] Map::grow(self : Map[K, V]) -> Unit {
   let old_head = self.head
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)
@@ -570,11 +570,43 @@ fn[K : Eq, V] Map::grow(self : Map[K, V]) -> Unit {
   self.tail = -1
   for x = old_head {
     match x {
-      Some({ next, key, value, hash, .. }) => {
-        self.set_with_hash(key, value, hash)
-        continue next
-      }
       None => break
+      Some(e) => {
+        let next_in_chain = e.next
+        // Reset LL fields; rehash_place_entry fills them.
+        e.next = None
+        self.rehash_place_entry(e)
+        continue next_in_chain
+      }
+    }
+  }
+}
+
+///|
+/// Place an existing entry into the (already-resized) table. This is the
+/// fast path used by `grow`: like `set_with_hash` but skips the key
+/// equality check (entries from the old table are unique) and the
+/// load-factor check (we just doubled capacity).
+fn[K, V] Map::rehash_place_entry(self : Map[K, V], outer : Entry[K, V]) -> Unit {
+  let hash = outer.hash
+  for psl = 0, idx = hash & self.capacity_mask {
+    match self.entries[idx] {
+      None => {
+        outer.psl = psl
+        outer.prev = self.tail
+        self.add_entry_to_tail(idx, outer)
+        return
+      }
+      Some(curr) =>
+        if psl > curr.psl {
+          self.push_away(idx, curr)
+          outer.psl = psl
+          outer.prev = self.tail
+          self.add_entry_to_tail(idx, outer)
+          return
+        } else {
+          continue psl + 1, (idx + 1) & self.capacity_mask
+        }
     }
   }
 }

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -648,6 +648,26 @@ test "Map collision probe paths" {
 }
 
 ///|
+test "Map grow rehashes collision cluster in insertion order" {
+  let map : Map[LKey, Int] = Map([], capacity=2)
+  for i in 0..<12 {
+    map[LKey::LKey(i, i % 4)] = i * 10
+  }
+  inspect(map.length(), content="12")
+  for i in 0..<12 {
+    assert_eq(map.get(LKey::LKey(i, i % 4)), Some(i * 10))
+  }
+  map.remove(LKey::LKey(5, 1))
+  assert_eq(map.get(LKey::LKey(5, 1)), None)
+  map[LKey::LKey(12, 0)] = 120
+  assert_eq(map.get(LKey::LKey(12, 0)), Some(120))
+  debug_inspect(
+    map.values().to_array(),
+    content="[0, 10, 20, 30, 40, 60, 70, 80, 90, 100, 110, 120]",
+  )
+}
+
+///|
 test "Map early exit on psl" {
   let map : Map[LKey, Int] = {}
   let k1 = LKey::LKey(1, 0)

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -722,7 +722,13 @@ fn[K, V] HashMap::shift_back(self : HashMap[K, V], idx : Int) -> Unit {
 }
 
 ///|
-fn[K, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
+/// `[K : Eq]` is kept on the signature even though the rehash loop no
+/// longer calls `key == key`: it keeps the trait surface of `grow`
+/// symmetric with the rest of the HashMap private API (every other
+/// helper that touches `entries` carries it) and leaves room for a
+/// future debug-only invariant check without an API change.
+#warnings("-unused_trait_bound")
+fn[K : Eq, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
   let old_entries = self.entries
   let new_capacity = self.capacity << 1
   let new_mask = new_capacity - 1

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -722,44 +722,41 @@ fn[K, V] HashMap::shift_back(self : HashMap[K, V], idx : Int) -> Unit {
 }
 
 ///|
-/// `[K : Eq]` is kept on the signature even though the rehash loop no
-/// longer calls `key == key`: it keeps the trait surface of `grow`
-/// symmetric with the rest of the HashMap private API (every other
-/// helper that touches `entries` carries it) and leaves room for a
-/// future debug-only invariant check without an API change.
-#warnings("-unused_trait_bound")
-fn[K : Eq, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
+fn[K, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
   let old_entries = self.entries
   let new_capacity = self.capacity << 1
-  let new_mask = new_capacity - 1
   self.entries = FixedArray::make(new_capacity, None)
   self.capacity = new_capacity
-  self.capacity_mask = new_mask
-  // size is unchanged: we move the same entries, no Eq check, no
-  // load-factor check. set_with_hash's general path repeats key == key on
-  // every probe step and re-checks `size >= capacity/2`; both are pure
-  // overhead during a rehash.
+  self.capacity_mask = new_capacity - 1
   for entry in old_entries {
-    if entry is Some(e) {
-      let hash = e.hash
-      // Robin Hood probe specialized for "all keys are distinct"
-      for psl = 0, idx = hash & new_mask, ent = e {
-        match self.entries[idx] {
-          None => {
-            ent.psl = psl
-            self.entries[idx] = Some(ent)
-            break
-          }
-          Some(curr) =>
-            if psl > curr.psl {
-              ent.psl = psl
-              self.entries[idx] = Some(ent)
-              continue curr.psl + 1, (idx + 1) & new_mask, curr
-            } else {
-              continue psl + 1, (idx + 1) & new_mask, ent
-            }
-        }
+    if entry is Some(entry) {
+      self.rehash_place_entry(entry)
+    }
+  }
+}
+
+///|
+fn[K, V] HashMap::rehash_place_entry(
+  self : HashMap[K, V],
+  entry : Entry[K, V],
+) -> Unit {
+  let hash = entry.hash
+  for psl = 0, idx = hash & self.capacity_mask {
+    match self.entries[idx] {
+      None => {
+        entry.psl = psl
+        self.entries[idx] = Some(entry)
+        return
       }
+      Some(curr) =>
+        if psl > curr.psl {
+          self.push_away(idx, curr)
+          entry.psl = psl
+          self.entries[idx] = Some(entry)
+          return
+        } else {
+          continue psl + 1, (idx + 1) & self.capacity_mask
+        }
     }
   }
 }

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -722,16 +722,38 @@ fn[K, V] HashMap::shift_back(self : HashMap[K, V], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
+fn[K, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
   let old_entries = self.entries
   let new_capacity = self.capacity << 1
+  let new_mask = new_capacity - 1
   self.entries = FixedArray::make(new_capacity, None)
   self.capacity = new_capacity
-  self.capacity_mask = new_capacity - 1
-  self.size = 0
+  self.capacity_mask = new_mask
+  // size is unchanged: we move the same entries, no Eq check, no
+  // load-factor check. set_with_hash's general path repeats key == key on
+  // every probe step and re-checks `size >= capacity/2`; both are pure
+  // overhead during a rehash.
   for entry in old_entries {
-    if entry is Some({ key, value, hash, .. }) {
-      self.set_with_hash(key, value, hash)
+    if entry is Some(e) {
+      let hash = e.hash
+      // Robin Hood probe specialized for "all keys are distinct"
+      for psl = 0, idx = hash & new_mask, ent = e {
+        match self.entries[idx] {
+          None => {
+            ent.psl = psl
+            self.entries[idx] = Some(ent)
+            break
+          }
+          Some(curr) =>
+            if psl > curr.psl {
+              ent.psl = psl
+              self.entries[idx] = Some(ent)
+              continue curr.psl + 1, (idx + 1) & new_mask, curr
+            } else {
+              continue psl + 1, (idx + 1) & new_mask, ent
+            }
+        }
+      }
     }
   }
 }

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -618,6 +618,23 @@ test "hashmap get_or_init push_away" {
 }
 
 ///|
+test "hashmap grow rehashes collision cluster" {
+  let map : @hashmap.HashMap[Key, Int] = @hashmap.HashMap([], capacity=2)
+  for i in 0..<12 {
+    map.set(Key::Key(i, i % 4), i * 10)
+  }
+  inspect(map.length(), content="12")
+  for i in 0..<12 {
+    assert_eq(map.get(Key::Key(i, i % 4)), Some(i * 10))
+  }
+  map.remove(Key::Key(5, 1))
+  assert_eq(map.get(Key::Key(5, 1)), None)
+  map.set(Key::Key(12, 0), 120)
+  assert_eq(map.get(Key::Key(12, 0)), Some(120))
+  inspect(map.length(), content="12")
+}
+
+///|
 test "hashmap default" {
   let map : @hashmap.HashMap[Int, Int] = Default::default()
   inspect(map.length(), content="0")

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -223,10 +223,7 @@ fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
 }
 
 ///|
-/// `[K : Eq]` kept for trait-surface symmetry with the rest of the
-/// HashSet private API; the rehash loop does not call `key == key`.
-#warnings("-unused_trait_bound")
-fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
+fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
   // handle zero capacity
   if self.capacity == 0 {
     self.capacity = default_init_capacity
@@ -237,35 +234,37 @@ fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
     return
   }
   let old_entries = self.entries
-  self.entries = FixedArray::make(self.capacity * 2, None)
-  self.capacity = self.capacity * 2
-  let new_mask = self.capacity - 1
-  self.capacity_mask = new_mask
+  let new_capacity = self.capacity * 2
+  self.entries = FixedArray::make(new_capacity, None)
+  self.capacity = new_capacity
+  self.capacity_mask = new_capacity - 1
   self.grow_at = calc_grow_threshold(self.capacity)
-  // size unchanged: we move the same entries. add_with_hash's general path
-  // repeats key == key on every probe step and re-checks grow_at; both are
-  // pure overhead during a rehash since all old keys are unique and the
-  // load factor just halved.
   for entry in old_entries {
-    if entry is Some(e) {
-      let hash = e.hash
-      for psl = 0, idx = hash & new_mask, ent = e {
-        match self.entries[idx] {
-          None => {
-            ent.psl = psl
-            self.entries[idx] = Some(ent)
-            break
-          }
-          Some(curr) =>
-            if psl > curr.psl {
-              ent.psl = psl
-              self.entries[idx] = Some(ent)
-              continue curr.psl + 1, (idx + 1) & new_mask, curr
-            } else {
-              continue psl + 1, (idx + 1) & new_mask, ent
-            }
-        }
+    if entry is Some(entry) {
+      self.rehash_place_entry(entry)
+    }
+  }
+}
+
+///|
+fn[K] HashSet::rehash_place_entry(self : HashSet[K], entry : Entry[K]) -> Unit {
+  let hash = entry.hash
+  for psl = 0, idx = hash & self.capacity_mask {
+    match self.entries[idx] {
+      None => {
+        entry.psl = psl
+        self.set_entry(entry, idx)
+        return
       }
+      Some(curr) =>
+        if psl > curr.psl {
+          self.push_away(idx, curr)
+          entry.psl = psl
+          self.set_entry(entry, idx)
+          return
+        } else {
+          continue psl + 1, (idx + 1) & self.capacity_mask
+        }
     }
   }
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -223,7 +223,10 @@ fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
 }
 
 ///|
-fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
+/// `[K : Eq]` kept for trait-surface symmetry with the rest of the
+/// HashSet private API; the rehash loop does not call `key == key`.
+#warnings("-unused_trait_bound")
+fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
   // handle zero capacity
   if self.capacity == 0 {
     self.capacity = default_init_capacity

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -223,7 +223,7 @@ fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
+fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
   // handle zero capacity
   if self.capacity == 0 {
     self.capacity = default_init_capacity
@@ -236,12 +236,33 @@ fn[K : Eq] HashSet::grow(self : HashSet[K]) -> Unit {
   let old_entries = self.entries
   self.entries = FixedArray::make(self.capacity * 2, None)
   self.capacity = self.capacity * 2
-  self.capacity_mask = self.capacity - 1
+  let new_mask = self.capacity - 1
+  self.capacity_mask = new_mask
   self.grow_at = calc_grow_threshold(self.capacity)
-  self.size = 0
+  // size unchanged: we move the same entries. add_with_hash's general path
+  // repeats key == key on every probe step and re-checks grow_at; both are
+  // pure overhead during a rehash since all old keys are unique and the
+  // load factor just halved.
   for entry in old_entries {
-    if entry is Some({ key, hash, .. }) {
-      self.add_with_hash(key, hash)
+    if entry is Some(e) {
+      let hash = e.hash
+      for psl = 0, idx = hash & new_mask, ent = e {
+        match self.entries[idx] {
+          None => {
+            ent.psl = psl
+            self.entries[idx] = Some(ent)
+            break
+          }
+          Some(curr) =>
+            if psl > curr.psl {
+              ent.psl = psl
+              self.entries[idx] = Some(ent)
+              continue curr.psl + 1, (idx + 1) & new_mask, curr
+            } else {
+              continue psl + 1, (idx + 1) & new_mask, ent
+            }
+        }
+      }
     }
   }
 }

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -16,6 +16,21 @@
 let default_init_capacity = 8
 
 ///|
+priv struct HashSetKey(Int, Int) derive(Eq)
+
+///|
+impl Hash for HashSetKey with fn hash(self) {
+  let HashSetKey(_, hash) = self
+  hash
+}
+
+///|
+impl Hash for HashSetKey with fn hash_combine(self, hasher) {
+  let HashSetKey(_, hash) = self
+  hasher.combine_int(hash)
+}
+
+///|
 test "new_with_capacity_then_add " {
   let set : @hashset.HashSet[(String, String)] = @hashset.HashSet(
     [],
@@ -324,6 +339,23 @@ test "insert_and_grow" {
   }
   inspect(m.length(), content="10")
   inspect(m.capacity(), content="16")
+}
+
+///|
+test "grow rehashes collision cluster" {
+  let set : @hashset.HashSet[HashSetKey] = @hashset.HashSet([], capacity=2)
+  for i in 0..<12 {
+    set.add(HashSetKey::HashSetKey(i, i % 4))
+  }
+  inspect(set.length(), content="12")
+  for i in 0..<12 {
+    assert_true(set.contains(HashSetKey::HashSetKey(i, i % 4)))
+  }
+  set.remove(HashSetKey::HashSetKey(5, 1))
+  assert_false(set.contains(HashSetKey::HashSetKey(5, 1)))
+  set.add(HashSetKey::HashSetKey(12, 0))
+  assert_true(set.contains(HashSetKey::HashSetKey(12, 0)))
+  inspect(set.length(), content="12")
 }
 
 ///|

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -389,7 +389,9 @@ fn[K] Set::grow(self : Set[K]) -> Unit {
       None => break
       Some(e) => {
         let next_in_chain = e.next
-        // Reset LL fields; rehash_place_entry fills them.
+        // Clear `next` so the entry detaches from the old chain;
+        // rehash_place_entry will rewrite `prev` and `psl` and link this
+        // entry as the new tail.
         e.next = None
         self.rehash_place_entry(e)
         continue next_in_chain

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -374,7 +374,11 @@ fn[K] Set::shift_back(self : Set[K], idx : Int) -> Unit {
 }
 
 ///|
-fn[K] Set::grow(self : Set[K]) -> Unit {
+/// `[K : Eq]` kept for trait-surface symmetry with the rest of the
+/// `Set` (linked hash set) private API; the rehash loop does not call
+/// `key == key`.
+#warnings("-unused_trait_bound")
+fn[K : Eq] Set::grow(self : Set[K]) -> Unit {
   let old_head = self.head
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -374,11 +374,7 @@ fn[K] Set::shift_back(self : Set[K], idx : Int) -> Unit {
 }
 
 ///|
-/// `[K : Eq]` kept for trait-surface symmetry with the rest of the
-/// `Set` (linked hash set) private API; the rehash loop does not call
-/// `key == key`.
-#warnings("-unused_trait_bound")
-fn[K : Eq] Set::grow(self : Set[K]) -> Unit {
+fn[K] Set::grow(self : Set[K]) -> Unit {
   let old_head = self.head
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)
@@ -393,9 +389,6 @@ fn[K : Eq] Set::grow(self : Set[K]) -> Unit {
       None => break
       Some(e) => {
         let next_in_chain = e.next
-        // Clear `next` so the entry detaches from the old chain;
-        // rehash_place_entry will rewrite `prev` and `psl` and link this
-        // entry as the new tail.
         e.next = None
         self.rehash_place_entry(e)
         continue next_in_chain
@@ -405,10 +398,6 @@ fn[K : Eq] Set::grow(self : Set[K]) -> Unit {
 }
 
 ///|
-/// Place an existing entry into the (already-resized) table. Like
-/// `add_with_hash` but skips the key equality check (entries from the
-/// old table are unique) and the load-factor check (we just doubled
-/// capacity).
 fn[K] Set::rehash_place_entry(self : Set[K], outer : Entry[K]) -> Unit {
   let hash = outer.hash
   for psl = 0, idx = hash & self.capacity_mask {

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -374,7 +374,7 @@ fn[K] Set::shift_back(self : Set[K], idx : Int) -> Unit {
 }
 
 ///|
-fn[K : Eq] Set::grow(self : Set[K]) -> Unit {
+fn[K] Set::grow(self : Set[K]) -> Unit {
   let old_head = self.head
   let new_capacity = self.capacity << 1
   self.entries = FixedArray::make(new_capacity, None)
@@ -386,11 +386,43 @@ fn[K : Eq] Set::grow(self : Set[K]) -> Unit {
   self.tail = -1
   for x = old_head {
     match x {
-      Some({ next, key, hash, .. }) => {
-        self.add_with_hash(key, hash)
-        continue next
-      }
       None => break
+      Some(e) => {
+        let next_in_chain = e.next
+        // Reset LL fields; rehash_place_entry fills them.
+        e.next = None
+        self.rehash_place_entry(e)
+        continue next_in_chain
+      }
+    }
+  }
+}
+
+///|
+/// Place an existing entry into the (already-resized) table. Like
+/// `add_with_hash` but skips the key equality check (entries from the
+/// old table are unique) and the load-factor check (we just doubled
+/// capacity).
+fn[K] Set::rehash_place_entry(self : Set[K], outer : Entry[K]) -> Unit {
+  let hash = outer.hash
+  for psl = 0, idx = hash & self.capacity_mask {
+    match self.entries[idx] {
+      None => {
+        outer.psl = psl
+        outer.prev = self.tail
+        self.add_entry_to_tail(idx, outer)
+        return
+      }
+      Some(curr) =>
+        if psl > curr.psl {
+          self.push_away(idx, curr)
+          outer.psl = psl
+          outer.prev = self.tail
+          self.add_entry_to_tail(idx, outer)
+          return
+        } else {
+          continue psl + 1, (idx + 1) & self.capacity_mask
+        }
     }
   }
 }

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -502,6 +502,24 @@ test "trigger grow" {
 }
 
 ///|
+test "grow rehashes collision cluster in insertion order" {
+  let set : @set.Set[Key] = @set.Set([], capacity=2)
+  for i in 0..<12 {
+    set.add({ id: i, hash_value: i % 4 })
+  }
+  inspect(set.length(), content="12")
+  for i in 0..<12 {
+    assert_true(set.contains({ id: i, hash_value: i % 4 }))
+  }
+  set.remove({ id: 5, hash_value: 1 })
+  assert_false(set.contains({ id: 5, hash_value: 1 }))
+  set.add({ id: 12, hash_value: 0 })
+  let mut ids = ""
+  set.each(key => ids += "\{key.id},")
+  inspect(ids, content="0,1,2,3,4,6,7,8,9,10,11,12,")
+}
+
+///|
 test "is_disjoint" {
   let set1 = @set.Set(["a", "b"])
   let set2 = @set.Set(["c", "d"])


### PR DESCRIPTION
## Summary

`HashMap::grow`, `HashSet::grow`, builtin `Map::grow`, and `Set::grow` (the linked hash set in `core/set`) currently rehash entries by re-calling the public `set_with_hash` / `add_with_hash` path. Inside that path two checks are dead weight during a rehash:

1. The **key equality check** (`curr_entry.hash == hash && curr_entry.key == key`) — the entries being re-inserted came from an old table where they were already unique by construction, so this can never match.
2. The **load-factor / `grow_at` check** — the capacity just doubled, so the load factor is 50% by construction and no further grow is needed.

Replace each of the four growth helpers with a specialized Robin-Hood swap loop that skips both checks. This also lets each function drop the `Eq` constraint that was only needed for the (never-firing) equality check.

For builtin `Map` (the linked hash map used by `@json`) and `core/set::Set` (also a linked hash set) the change preserves the `prev` / `next` linked-list invariants by reusing the existing `add_entry_to_tail` / `push_away` helpers rather than inlining a fresh probe.

## Benchmarks

moonbit 0.1.20260522 + this patch, Linux x86_64, wall time (3-run median, no GuestProfiler).

| workload         | backend  | baseline  | patched   | delta  |
|------------------|----------|----------:|----------:|-------:|
| hashmap_ops      | wasm     | 276.1 ms  | 215.8 ms  | **-21.9%** |
| hashmap_ops      | wasm-gc  | 130.2 ms  |  98.9 ms  | **-24.0%** |
| hashmap_ops      | js       | 162.3 ms  | 134.3 ms  | **-17.3%** |
| hashmap_ops      | native   |  96.1 ms  |  81.1 ms  | **-15.6%** |
| hashmap_string   | wasm     | 171.3 ms  | 149.5 ms  | -12.7% |
| hashmap_string   | wasm-gc  |  70.5 ms  |  65.2 ms  |  -7.5% |
| hashmap_update   | wasm     |  68.7 ms  |  71.8 ms  |  noise |
| hashmap_update   | wasm-gc  |  32.5 ms  |  30.7 ms  |  -5.5% |
| hashset_ops      | wasm     | 279.7 ms  | 222.3 ms  | **-20.5%** |
| hashset_ops      | wasm-gc  | 117.5 ms  |  97.1 ms  | **-17.4%** |
| hashset_ops      | js       | 155.4 ms  | 134.0 ms  | **-13.8%** |
| hashset_ops      | native   |  94.1 ms  |  84.8 ms  |  -9.9% |
| json_parse       | wasm-gc  | 239.7 ms  | 224.9 ms  |  -6.2% |
| json_parse       | native   | 168.2 ms  | 157.9 ms  |  -6.1% |
| json_numbers     | wasm-gc  | 133.9 ms  | 124.8 ms  |  -6.8% |

Scenarios:

- [`bench/cmd/hashmap_ops/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/hashmap_ops/main.mbt) — 10k distinct Int keys, fill + hit + miss × 50 iter
- [`bench/cmd/hashset_ops/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/hashset_ops/main.mbt) — 10k distinct Int keys, fill + hit + miss × 50 iter
- [`bench/cmd/hashmap_string/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/hashmap_string/main.mbt) — 5k distinct String keys, fill + hit + miss × 30 iter; checks the patch is not Int-key-specific
- [`bench/cmd/hashmap_update/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/hashmap_update/main.mbt) — pre-fill with `capacity = 2 * n`, then 30 rounds of value updates. `grow` is never called after the initial fill, so this is a regression check on the value-update path of `set_with_hash`. The patch is invisible here, confirming the non-rehash path is untouched.
- [`bench/cmd/json_parse/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/json_parse/main.mbt) and [`bench/cmd/json_numbers/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/json_numbers/main.mbt) — use builtin `Map` (linked hash map). 1 grow per object × 1000 objects × 50 iter.

## Test results

`moon test` on all four targets:

| target  | result |
|---------|--------|
| wasm    | 6500 / 6500 pass |
| wasm-gc | 6500 / 6500 pass |
| js      | 6459 / 6459 pass |
| native  | 6411 / 6411 pass |

## Relation to existing work

- #1349 (merged 2024-12): made grow stop re-hashing by passing the stored `hash` through to `set_with_hash`. This PR is the next step on the same path — the inner loop is now lean enough to drop the remaining redundant checks.
- #3164 (merged 2026-01): made the grow check fire only when `set_with_hash` is actually inserting (not when updating). That patch lives in the public path; the new path here lives only in the rehash branch and removes the check entirely.

The three implementations are kept in sync (same Robin-Hood swap, same shape) — they had aligned in #2533.
