### PR TITLE
perf(json): reuse scan_json_number mantissa for safe integers

### DIFF
--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -355,10 +355,20 @@ fn ParseContext::lex_number_end(
   // large or precision-sensitive numbers so existing rounding behavior is kept.
   let scan = ctx.scan_json_number(start, end)
   if scan.is_integer {
-    // For safe integers, scan_json_number already computed the absolute value
-    // in scan.mantissa. Use it directly instead of re-scanning digits in
-    // lex_integer_end. Overflow / many-digits paths still defer to that helper.
+    // `is_integer` is set by `scan_json_number` only when no `.` and no `e/E`
+    // are seen, so for that branch `scan.exponent` is structurally 0 and
+    // `scan.mantissa` is exactly the unsigned absolute value of the integer
+    // literal. The `scan.exponent == 0L` guard restates that invariant
+    // locally so a future relaxation of `is_integer` cannot silently make
+    // this branch return an unscaled value; in that case we just fall
+    // through to `lex_integer_end`.
+    //
+    // The mantissa <= 2^53 - 1 check (`SAFE_INTEGER_LIMIT`) keeps the
+    // returned Double lossless. `reinterpret_as_uint64` / `reinterpret_as_int64`
+    // are value-preserving here because both operands sit in [0, 2^53), well
+    // inside the overlap of Int64+ and UInt64.
     if !scan.many_digits &&
+      scan.exponent == 0L &&
       scan.mantissa <= SAFE_INTEGER_LIMIT.reinterpret_as_uint64() {
       let v = scan.mantissa.reinterpret_as_int64()
       let signed = if scan.negative { -v } else { v }

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -355,6 +355,15 @@ fn ParseContext::lex_number_end(
   // large or precision-sensitive numbers so existing rounding behavior is kept.
   let scan = ctx.scan_json_number(start, end)
   if scan.is_integer {
+    // For safe integers, scan_json_number already computed the absolute value
+    // in scan.mantissa. Use it directly instead of re-scanning digits in
+    // lex_integer_end. Overflow / many-digits paths still defer to that helper.
+    if !scan.many_digits &&
+      scan.mantissa <= SAFE_INTEGER_LIMIT.reinterpret_as_uint64() {
+      let v = scan.mantissa.reinterpret_as_int64()
+      let signed = if scan.negative { -v } else { v }
+      return (signed.to_double(), None)
+    }
     return ctx.lex_integer_end(start, end)
   }
   match scan.try_fast_double() {


### PR DESCRIPTION
## Summary

`lex_number_end` calls `scan_json_number` to scan every digit once and compute `mantissa` / `exponent`. For integers it then dispatches to `lex_integer_end`, which **scans the same digits a second time** to build an `Int64` accumulator with overflow detection.

For safe integers (mantissa ≤ `2^53 − 1`, not `many_digits`) `scan.mantissa` already *is* the absolute value. Use it directly. Overflow / many-digits paths still defer to `lex_integer_end` so the existing behavior is preserved.

This sits on top of #3593 / #3594 (the JSON parser fast-path work merged in May): it removes the remaining redundant scan that those PRs left in place.

## Benchmarks

moonbit 0.1.20260522 + this patch, Linux x86_64, wall time (3-run median, no GuestProfiler).

| workload     | backend  | baseline  | patched   | delta   |
|--------------|----------|----------:|----------:|--------:|
| json_numbers | wasm     | 167.4 ms  | 158.2 ms  |  -5.5%  |
| json_numbers | wasm-gc  | 129.9 ms  | 117.6 ms  |  **-9.5%**  |
| json_numbers | js       | 247.6 ms  | 180.8 ms  | **-27.0%**  |
| json_numbers | native   |  54.5 ms  |  55.6 ms  |  noise  |
| json_parse   | wasm     | 578.8 ms  | 566.0 ms  |  -2.2%  |
| json_parse   | wasm-gc  | 222.7 ms  | 223.8 ms  |  noise  |
| json_parse   | js       | 341.8 ms  | 336.8 ms  |  -1.5%  |

Scenarios:

- [`bench/cmd/json_numbers/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/json_numbers/main.mbt) — flat array of 10000 safe integers; the patch fires on every value.
- [`bench/cmd/json_parse/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/json_parse/main.mbt) — mixed-object array. Each object has 4 integers + 2 doubles + several strings, so the fast path covers a smaller fraction of work; gain is consequently smaller.

The js -27% on `json_numbers` is the most striking: V8 inlines the safe-int branch cleanly so dispatch + a second digit walk collapses to a single arithmetic chain.

## Test results

| target  | result |
|---------|--------|
| wasm    | 6500 / 6500 pass |
| wasm-gc | 6500 / 6500 pass |
| js      | 6459 / 6459 pass |
| native  | 6411 / 6411 pass |
