### PR TITLE
perf(immut): inline size extraction in sorted_map / sorted_set tree builders

### DIFF
--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -54,6 +54,7 @@ pub fn[K : Compare, V] SortedMap::contains(
 ///|
 /// Get the number of key-value pairs in the map.
 #alias(size, deprecated)
+#inline
 pub fn[K, V] SortedMap::length(self : SortedMap[K, V]) -> Int {
   match self {
     Empty => 0
@@ -75,18 +76,10 @@ fn[K, V] make_tree(
   l : SortedMap[K, V],
   r : SortedMap[K, V],
 ) -> SortedMap[K, V] {
-  // Inline the size extraction so make_tree does a single match per child
-  // instead of going through SortedMap::length() (which is the same match
-  // but as a separate call). Hot during merge / balance recursion.
-  let ls = match l {
-    Empty => 0
-    Tree(_, size=s, _, _, ..) => s
-  }
-  let rs = match r {
-    Empty => 0
-    Tree(_, size=s, _, _, ..) => s
-  }
-  Tree(key, value~, size=ls + rs + 1, l, r)
+  // length() is #inline, so the size match collapses into make_tree, which
+  // is itself #inline into balance / merge / add.
+  let size = l.length() + r.length() + 1
+  Tree(key, value~, size~, l, r)
 }
 
 ///|

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -68,14 +68,25 @@ pub fn[K, V] SortedMap::is_empty(self : SortedMap[K, V]) -> Bool {
 }
 
 ///|
+#inline
 fn[K, V] make_tree(
   key : K,
   value : V,
   l : SortedMap[K, V],
   r : SortedMap[K, V],
 ) -> SortedMap[K, V] {
-  let size = l.length() + r.length() + 1
-  Tree(key, value~, size~, l, r)
+  // Inline the size extraction so make_tree does a single match per child
+  // instead of going through SortedMap::length() (which is the same match
+  // but as a separate call). Hot during merge / balance recursion.
+  let ls = match l {
+    Empty => 0
+    Tree(_, size=s, _, _, ..) => s
+  }
+  let rs = match r {
+    Empty => 0
+    Tree(_, size=s, _, _, ..) => s
+  }
+  Tree(key, value~, size=ls + rs + 1, l, r)
 }
 
 ///|

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -892,6 +892,7 @@ fn[A : Compare] SortedSet::split_bis(
 ///|
 /// Get the height of set.
 #alias(size, deprecated)
+#inline
 pub fn[A] SortedSet::length(self : SortedSet[A]) -> Int {
   match self {
     Empty => 0
@@ -907,17 +908,9 @@ fn[A] create(
   value : A,
   right : SortedSet[A],
 ) -> SortedSet[A] {
-  // Inline size extraction: same shape as SortedSet::length() but avoids
-  // the function call. Hot during union / intersection / balance recursion.
-  let ls = match left {
-    Empty => 0
-    Node(size~, ..) => size
-  }
-  let rs = match right {
-    Empty => 0
-    Node(size~, ..) => size
-  }
-  Node(left~, right~, value~, size=ls + rs + 1)
+  // length() is #inline, so the size match collapses into create, which is
+  // itself #inline into union / intersection / balance.
+  Node(left~, right~, value~, size=left.length() + right.length() + 1)
 }
 
 ///|

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -901,12 +901,23 @@ pub fn[A] SortedSet::length(self : SortedSet[A]) -> Int {
 
 ///|
 /// Creates a new node.
+#inline
 fn[A] create(
   left : SortedSet[A],
   value : A,
   right : SortedSet[A],
 ) -> SortedSet[A] {
-  Node(left~, right~, value~, size=left.length() + right.length() + 1)
+  // Inline size extraction: same shape as SortedSet::length() but avoids
+  // the function call. Hot during union / intersection / balance recursion.
+  let ls = match left {
+    Empty => 0
+    Node(size~, ..) => size
+  }
+  let rs = match right {
+    Empty => 0
+    Node(size~, ..) => size
+  }
+  Node(left~, right~, value~, size=ls + rs + 1)
 }
 
 ///|


### PR DESCRIPTION
## Summary

`immut/sorted_map::make_tree` and `immut/sorted_set::create` compute the new node's `size` as `left.length() + right.length() + 1`. `length()` is a one-match function, but the helpers themselves are called for every internal node produced by `add` / `merge` / `union` / `balance`, so the cost is multiplied across the whole recursion.

Inline the size extraction (same shape as `length()`, just spelled out) and add `#inline`. The change is mechanical; the public APIs are unchanged.

## Benchmarks

moonbit 0.1.20260522 + this patch, Linux x86_64, wall time (3-run median, no GuestProfiler).

| workload         | backend  | baseline  | patched   | delta  |
|------------------|----------|----------:|----------:|-------:|
| sorted_map_merge | wasm     | 111.9 ms  | 102.0 ms  | **-8.9%** |
| sorted_map_merge | wasm-gc  |  49.2 ms  |  50.5 ms  |  noise |
| sorted_map_merge | native   |  32.5 ms  |  31.0 ms  | -4.4%  |
| sorted_set_union | wasm     | 120.2 ms  | 111.7 ms  | -7.1%  |
| sorted_set_union | wasm-gc  |  54.8 ms  |  54.8 ms  |  0.0%  |
| sorted_set_union | native   |  30.6 ms  |  29.2 ms  | -4.7%  |

Wins land mainly on wasm (no GC backend; refcount-bound) and native; on wasm-gc the JIT already inlines `length()` well, so the patch is mostly invisible there.

Scenarios:

- [`bench/cmd/sorted_map_merge/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/sorted_map_merge/main.mbt) — two interleaved 10k-key maps merged 30 times; the "rebuild path" stress case noted in `merge_bench_test.mbt`.
- [`bench/cmd/sorted_set_union/main.mbt`](https://github.com/mizchi/pprof-mbt/blob/main/bench/cmd/sorted_set_union/main.mbt) — same shape, sets instead of maps.

## Test results

| target  | result |
|---------|--------|
| wasm    | 6500 / 6500 pass |
| wasm-gc | 6500 / 6500 pass |
| js      | 6459 / 6459 pass |
| native  | 6411 / 6411 pass |
