### PR TITLE
feat(encoding): add hex package

### DIFF
--- a/encoding/hex/README.mbt.md
+++ b/encoding/hex/README.mbt.md
@@ -1,0 +1,63 @@
+# Hexadecimal Encoding
+
+Package `encoding/hex` implements lowercase hexadecimal encoding and decoding
+for in-memory byte data.
+
+The API follows the same core model as Go's `encoding/hex`: each source byte is
+encoded as two hexadecimal characters, and decoding accepts both uppercase and
+lowercase digits. Stream encoders and decoders are intentionally left out
+because this package does not introduce an IO abstraction, and Go's
+`EncodedLen`/`DecodedLen` sizing helpers are left out because `encode` and
+`decode` allocate their own results (the lengths are simply `2 * n` and
+`n / 2`).
+
+## Encoding
+
+Use `encode` to convert bytes into a lowercase hexadecimal string.
+
+```mbt check
+///|
+test "encode" {
+  let src : Bytes = b"Hello Gopher!"
+  inspect(@hex.encode(src), content="48656c6c6f20476f7068657221")
+}
+```
+
+## Decoding
+
+Use `decode` to convert a hexadecimal string back to bytes.
+
+```mbt check
+///|
+test "decode" {
+  let decoded = @hex.decode("48656c6c6f20476f7068657221")
+  inspect(decoded, content="b\"Hello Gopher!\"")
+}
+```
+
+Uppercase hexadecimal digits are accepted too:
+
+```mbt check
+///|
+test "decode_uppercase" {
+  let decoded = @hex.decode("48656C6C6F")
+  inspect(decoded, content="b\"Hello\"")
+}
+```
+
+## Malformed Input
+
+`decode` raises `Malformed` when the input has odd length or contains any
+non-hexadecimal character.
+
+```mbt check
+///|
+test "malformed" {
+  try {
+    let _ = @hex.decode("0g")
+    panic()
+  } catch {
+    Malformed(input) => inspect(input, content="0g")
+  }
+}
+```

--- a/encoding/hex/decode.mbt
+++ b/encoding/hex/decode.mbt
@@ -1,0 +1,52 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Error type for malformed hexadecimal input.
+///
+/// `Malformed(input)` reports that `input` has odd length or contains a
+/// non-hexadecimal ASCII character.
+pub suberror Malformed {
+  Malformed(StringView)
+} derive(@debug.Debug)
+
+///|
+fn hex_value(code_unit : Int) -> Int {
+  match code_unit {
+    '0'..='9' => code_unit - '0'
+    'a'..='f' => code_unit - 'a' + 10
+    'A'..='F' => code_unit - 'A' + 10
+    _ => -1
+  }
+}
+
+///|
+/// Decodes a hexadecimal string into bytes.
+///
+/// Both lowercase and uppercase hexadecimal characters are accepted. Raises
+/// `Malformed` if the input length is odd or any character is not a
+/// hexadecimal digit.
+pub fn decode(text : StringView) -> Bytes raise Malformed {
+  if text.length() % 2 != 0 {
+    raise Malformed(text)
+  }
+  let buffer = @buffer.Buffer(size_hint=text.length() / 2)
+  for i in 0..<(text.length() / 2) {
+    let hi = hex_value(text.code_unit_at(i * 2).to_int())
+    let lo = hex_value(text.code_unit_at(i * 2 + 1).to_int())
+    guard hi >= 0 && lo >= 0 else { raise Malformed(text) }
+    buffer.write_byte(((hi << 4) | lo).to_byte())
+  }
+  buffer.to_bytes()
+}

--- a/encoding/hex/decode_test.mbt
+++ b/encoding/hex/decode_test.mbt
@@ -1,0 +1,75 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "decode" {
+  inspect(
+    try! @hex.decode("48656c6c6f20476f7068657221"),
+    content=(
+      #|b"Hello Gopher!"
+    ),
+  )
+  inspect(
+    try! @hex.decode("48656C6C6F"),
+    content=(
+      #|b"Hello"
+    ),
+  )
+  inspect(
+    try! @hex.decode("000f107f80ff"),
+    content=(
+      #|b"\x00\x0f\x10\x7f\x80\xff"
+    ),
+  )
+}
+
+///|
+test "decode all byte values" {
+  let bytes = Bytes::makei(256, i => i.to_byte())
+  let encoded = @hex.encode(bytes)
+  inspect(try! (@hex.decode(encoded) == bytes), content="true")
+}
+
+///|
+test "decode malformed" {
+  let malformed = text => {
+    try {
+      let _ = @hex.decode(text)
+      false
+    } catch {
+      Malformed(_) => true
+    }
+  }
+  inspect(malformed("0"), content="true")
+  inspect(malformed("0g"), content="true")
+  inspect(malformed("xz"), content="true")
+  inspect(malformed("12 3"), content="true")
+  inspect(malformed("12\n"), content="true")
+}
+
+///|
+test "Debug for Malformed" {
+  try {
+    let _ = @hex.decode("0g")
+    panic()
+  } catch {
+    err =>
+      @debug.debug_inspect(
+        err,
+        content=(
+          #|Malformed(<StringView: "0g">)
+        ),
+      )
+  }
+}

--- a/encoding/hex/encode.mbt
+++ b/encoding/hex/encode.mbt
@@ -1,0 +1,32 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+const HEX_DIGITS : Bytes = b"0123456789abcdef"
+
+///|
+/// Encodes bytes as a lowercase hexadecimal string.
+///
+/// The returned string has length `2 * bytes.length()`.
+pub fn encode(bytes : BytesView) -> String {
+  // size_hint is measured in bytes, and each of the 2n output code units
+  // occupies two bytes in the builder's UTF-16 buffer
+  let builder = StringBuilder(size_hint=4 * bytes.length())
+  for byte in bytes {
+    let n = byte.to_int()
+    builder.write_char(HEX_DIGITS[(n >> 4) & 0x0F].to_char())
+    builder.write_char(HEX_DIGITS[n & 0x0F].to_char())
+  }
+  builder.to_string()
+}

--- a/encoding/hex/encode_test.mbt
+++ b/encoding/hex/encode_test.mbt
@@ -1,0 +1,33 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "encode" {
+  inspect(@hex.encode(b""), content="")
+  inspect(@hex.encode(b"Hello"), content="48656c6c6f")
+  inspect(@hex.encode(b"Hello Gopher!"), content="48656c6c6f20476f7068657221")
+  inspect(@hex.encode(b"\x00\x0f\x10\x7f\x80\xff"), content="000f107f80ff")
+}
+
+///|
+test "encode all byte values" {
+  let bytes = Bytes::makei(256, i => i.to_byte())
+  let encoded = @hex.encode(bytes)
+  inspect(encoded.length(), content="512")
+  inspect(encoded[:32], content="000102030405060708090a0b0c0d0e0f")
+  inspect(
+    encoded[encoded.length() - 32:],
+    content="f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+  )
+}

--- a/encoding/hex/extends.mbt
+++ b/encoding/hex/extends.mbt
@@ -1,0 +1,20 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Malformed with @debug.Debug::{to_repr}

--- a/encoding/hex/moon.pkg
+++ b/encoding/hex/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
+}

--- a/encoding/hex/pkg.generated.mbti
+++ b/encoding/hex/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/encoding/hex"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn decode(StringView) -> Bytes raise Malformed
+
+pub fn encode(BytesView) -> String
+
+// Errors
+pub suberror Malformed {
+  Malformed(StringView)
+} derive(@debug.Debug)
+
+// Types and methods
+
+// Type aliases
+
+// Traits


### PR DESCRIPTION
## Summary
- add `moonbitlang/core/encoding/hex` for in-memory lowercase hexadecimal encoding and decoding, at the same per-codec granularity as the existing `encoding/{ascii,base64,utf8,utf16}` packages
- public API is deliberately minimal: `encode(BytesView) -> String`, `decode(StringView) -> Bytes raise Malformed`, and the `Malformed` suberror — nothing else

## Scope decisions (2026-08-21 refresh)
- **`encoded_len`/`decoded_len` dropped**: `encode`/`decode` allocate their own results, so Go's sizing helpers have no caller here; the lengths are trivially `2 * n` and `n / 2` and the docs say so. They can return alongside buffer-writing variants if those are ever added.
- stream encoder/decoder APIs remain excluded (core exposes no IO abstraction here)
- rebased over three months of main drift: negative-index slicing in a test replaced, `Malformed`'s Debug promotion handled with the same deprecated `pub extend` pattern `encoding/base64` uses

## Review
Codex CLI (`xhigh`, two rounds): round 1 caught a real allocation bug — `StringBuilder`'s `size_hint` is measured in **bytes** on non-JS targets, so the `2n` hint reserved only `n` UTF-16 slots for `2n` output units, forcing a growth-and-copy on every non-empty encode; fixed to `4 * n` with the unit documented. Round 2 verified the fix and that decode's byte-buffer hint was already unit-correct.

Signed-off-by: Codex CLI <codex@openai.com>

## Follow-up
A SIMD PR (swizzle-based nibble lookup on `#cfg(native, wasm)`, following `encoding/base64`'s v128 pattern) with QuickCheck properties and native/wasm/js benchmarks is next; it will be reviewed by Codex at `ultra`.

## Validation
- `encoding/hex` 10/10; full repo `moon test` 7502/7502
- `moon check --warn-list +unnecessary_annotation` clean, `moon fmt` applied, `pkg.generated.mbti` regenerated to the trimmed surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)