### PR TITLE
feat(encoding): add binary package

### DIFF
--- a/encoding/binary/README.mbt.md
+++ b/encoding/binary/README.mbt.md
@@ -1,0 +1,74 @@
+# Binary
+
+Binary encoding and decoding for in-memory byte sequences.
+
+This package covers the pieces of Go's `encoding/binary` that map directly to
+MoonBit's core library today: fixed-width unsigned integers in explicit byte
+orders, plus unsigned and signed varint helpers. Stream-oriented APIs and
+reflection-based struct encoding are intentionally out of scope.
+
+## Byte Order
+
+Use `Big` or `Little` to encode and decode fixed-width unsigned integers.
+Decoding reads from the start of a `BytesView` and leaves trailing bytes
+untouched.
+
+```mbt check
+///|
+test "byte_order_decode" {
+  inspect(try! @binary.Big.decode_uint16(b"\x03\xe8"), content="1000")
+  inspect(try! @binary.Little.decode_uint16(b"\xe8\x03"), content="1000")
+}
+```
+
+Encoding returns a new byte sequence.
+
+```mbt check
+///|
+test "byte_order_encode" {
+  assert_eq(@binary.Big.encode_uint32(0x12345678U), b"\x12\x34\x56\x78")
+  assert_eq(@binary.Little.encode_uint32(0x12345678U), b"\x78\x56\x34\x12")
+}
+```
+
+## Varints
+
+Use `encode_uvarint` and `uvarint` for unsigned 64-bit values. `uvarint`
+returns both the decoded value and the number of bytes consumed.
+
+```mbt check
+///|
+test "uvarint" {
+  assert_eq(@binary.encode_uvarint(300UL), b"\xac\x02")
+  let (value, consumed) = try! @binary.uvarint(b"\xac\x02rest")
+  inspect(value, content="300")
+  inspect(consumed, content="2")
+}
+```
+
+Use `encode_varint` and `varint` for signed 64-bit values.
+
+```mbt check
+///|
+test "varint" {
+  assert_eq(@binary.encode_varint(-300L), b"\xd7\x04")
+  let (value, consumed) = try! @binary.varint(b"\xd7\x04rest")
+  inspect(value, content="-300")
+  inspect(consumed, content="2")
+}
+```
+
+Malformed fixed-width input, incomplete varints, and overflowing varints raise
+`Malformed`.
+
+```mbt check
+///|
+test "malformed" {
+  try {
+    let _ = @binary.uvarint(b"\x80")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+}
+```

--- a/encoding/binary/endian.mbt
+++ b/encoding/binary/endian.mbt
@@ -1,0 +1,138 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Decodes the first two bytes as an unsigned 16-bit integer using this byte
+/// order. Raises `Malformed` if fewer than two bytes are available.
+pub fn Endian::decode_uint16(
+  self : Endian,
+  bytes : BytesView,
+) -> UInt16 raise Malformed {
+  match self {
+    Big =>
+      match bytes {
+        [u16be(value), ..] => value.to_uint16()
+        _ => raise Malformed(bytes)
+      }
+    Little =>
+      match bytes {
+        [u16le(value), ..] => value.to_uint16()
+        _ => raise Malformed(bytes)
+      }
+  }
+}
+
+///|
+/// Decodes the first four bytes as an unsigned 32-bit integer using this byte
+/// order. Raises `Malformed` if fewer than four bytes are available.
+pub fn Endian::decode_uint32(
+  self : Endian,
+  bytes : BytesView,
+) -> UInt raise Malformed {
+  match self {
+    Big =>
+      match bytes {
+        [u32be(value), ..] => value
+        _ => raise Malformed(bytes)
+      }
+    Little =>
+      match bytes {
+        [u32le(value), ..] => value
+        _ => raise Malformed(bytes)
+      }
+  }
+}
+
+///|
+/// Decodes the first eight bytes as an unsigned 64-bit integer using this byte
+/// order. Raises `Malformed` if fewer than eight bytes are available.
+pub fn Endian::decode_uint64(
+  self : Endian,
+  bytes : BytesView,
+) -> UInt64 raise Malformed {
+  match self {
+    Big =>
+      match bytes {
+        [u64be(value), ..] => value
+        _ => raise Malformed(bytes)
+      }
+    Little =>
+      match bytes {
+        [u64le(value), ..] => value
+        _ => raise Malformed(bytes)
+      }
+  }
+}
+
+///|
+/// Encodes an unsigned 16-bit integer into a new two-byte sequence using this
+/// byte order.
+pub fn Endian::encode_uint16(self : Endian, value : UInt16) -> Bytes {
+  match self {
+    Big => [(value >> 8).to_byte(), value.to_byte()]
+    Little => [value.to_byte(), (value >> 8).to_byte()]
+  }
+}
+
+///|
+/// Encodes an unsigned 32-bit integer into a new four-byte sequence using this
+/// byte order.
+pub fn Endian::encode_uint32(self : Endian, value : UInt) -> Bytes {
+  match self {
+    Big =>
+      [
+        (value >> 24).to_byte(),
+        (value >> 16).to_byte(),
+        (value >> 8).to_byte(),
+        value.to_byte(),
+      ]
+    Little =>
+      [
+        value.to_byte(),
+        (value >> 8).to_byte(),
+        (value >> 16).to_byte(),
+        (value >> 24).to_byte(),
+      ]
+  }
+}
+
+///|
+/// Encodes an unsigned 64-bit integer into a new eight-byte sequence using this
+/// byte order.
+pub fn Endian::encode_uint64(self : Endian, value : UInt64) -> Bytes {
+  match self {
+    Big =>
+      [
+        (value >> 56).to_byte(),
+        (value >> 48).to_byte(),
+        (value >> 40).to_byte(),
+        (value >> 32).to_byte(),
+        (value >> 24).to_byte(),
+        (value >> 16).to_byte(),
+        (value >> 8).to_byte(),
+        value.to_byte(),
+      ]
+    Little =>
+      [
+        value.to_byte(),
+        (value >> 8).to_byte(),
+        (value >> 16).to_byte(),
+        (value >> 24).to_byte(),
+        (value >> 32).to_byte(),
+        (value >> 40).to_byte(),
+        (value >> 48).to_byte(),
+        (value >> 56).to_byte(),
+      ]
+  }
+}

--- a/encoding/binary/endian_test.mbt
+++ b/encoding/binary/endian_test.mbt
@@ -1,0 +1,152 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "decode fixed-width unsigned integers" {
+  inspect(try! @binary.Big.decode_uint16(b"\x12\x34"), content="4660")
+  inspect(try! @binary.Little.decode_uint16(b"\x34\x12"), content="4660")
+  inspect(
+    try! @binary.Big.decode_uint32(b"\x12\x34\x56\x78"),
+    content="305419896",
+  )
+  inspect(
+    try! @binary.Little.decode_uint32(b"\x78\x56\x34\x12"),
+    content="305419896",
+  )
+  inspect(
+    try! @binary.Big.decode_uint64(b"\x01\x23\x45\x67\x89\xab\xcd\xef"),
+    content="81985529216486895",
+  )
+  inspect(
+    try! @binary.Little.decode_uint64(b"\xef\xcd\xab\x89\x67\x45\x23\x01"),
+    content="81985529216486895",
+  )
+}
+
+///|
+test "decode from views with offsets" {
+  inspect(try! @binary.Big.decode_uint16(b"\xff\x12\x34"[1:]), content="4660")
+  inspect(
+    try! @binary.Little.decode_uint32(b"\xff\x78\x56\x34\x12"[1:]),
+    content="305419896",
+  )
+  inspect(
+    try! @binary.Big.decode_uint64(b"\xff\x01\x23\x45\x67\x89\xab\xcd\xef"[1:]),
+    content="81985529216486895",
+  )
+}
+
+///|
+test "encode fixed-width unsigned integers" {
+  inspect(
+    @binary.Big.encode_uint16((0x1234 : UInt16)),
+    content=(
+      #|b"\x124"
+    ),
+  )
+  inspect(
+    @binary.Little.encode_uint16((0x1234 : UInt16)),
+    content=(
+      #|b"4\x12"
+    ),
+  )
+  inspect(
+    @binary.Big.encode_uint32(0x12345678U),
+    content=(
+      #|b"\x124Vx"
+    ),
+  )
+  inspect(
+    @binary.Little.encode_uint32(0x12345678U),
+    content=(
+      #|b"xV4\x12"
+    ),
+  )
+  inspect(
+    @binary.Big.encode_uint64(0x0123456789abcdefUL),
+    content=(
+      #|b"\x01#Eg\x89\xab\xcd\xef"
+    ),
+  )
+  inspect(
+    @binary.Little.encode_uint64(0x0123456789abcdefUL),
+    content=(
+      #|b"\xef\xcd\xab\x89gE#\x01"
+    ),
+  )
+}
+
+///|
+test "fixed-width round trips" {
+  let u16_values = [
+    (0 : UInt16),
+    (1 : UInt16),
+    (0x1234 : UInt16),
+    (0xffff : UInt16),
+  ]
+  for value in u16_values {
+    assert_eq(
+      try! @binary.Big.decode_uint16(@binary.Big.encode_uint16(value)),
+      value,
+    )
+    assert_eq(
+      try! @binary.Little.decode_uint16(@binary.Little.encode_uint16(value)),
+      value,
+    )
+  }
+  let u32_values = [0U, 1U, 0x12345678U, 0xffffffffU]
+  for value in u32_values {
+    assert_eq(
+      try! @binary.Big.decode_uint32(@binary.Big.encode_uint32(value)),
+      value,
+    )
+    assert_eq(
+      try! @binary.Little.decode_uint32(@binary.Little.encode_uint32(value)),
+      value,
+    )
+  }
+  let u64_values = [0UL, 1UL, 0x0123456789abcdefUL, 0xffffffffffffffffUL]
+  for value in u64_values {
+    assert_eq(
+      try! @binary.Big.decode_uint64(@binary.Big.encode_uint64(value)),
+      value,
+    )
+    assert_eq(
+      try! @binary.Little.decode_uint64(@binary.Little.encode_uint64(value)),
+      value,
+    )
+  }
+}
+
+///|
+test "decode malformed fixed-width inputs" {
+  try {
+    let _ = @binary.Big.decode_uint16(b"\x01")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+  try {
+    let _ = @binary.Big.decode_uint32(b"\x01\x02\x03")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+  try {
+    let _ = @binary.Big.decode_uint64(b"\x01\x02\x03\x04")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+}

--- a/encoding/binary/moon.pkg
+++ b/encoding/binary/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
+}

--- a/encoding/binary/pkg.generated.mbti
+++ b/encoding/binary/pkg.generated.mbti
@@ -1,0 +1,43 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/encoding/binary"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub const MAX_VARINT_LEN_16 : Int = 3
+
+pub const MAX_VARINT_LEN_32 : Int = 5
+
+pub const MAX_VARINT_LEN_64 : Int = 10
+
+pub fn encode_uvarint(UInt64) -> Bytes
+
+pub fn encode_varint(Int64) -> Bytes
+
+pub fn uvarint(BytesView) -> (UInt64, Int) raise Malformed
+
+pub fn varint(BytesView) -> (Int64, Int) raise Malformed
+
+// Errors
+pub suberror Malformed {
+  Malformed(BytesView)
+} derive(@debug.Debug)
+
+// Types and methods
+pub(all) enum Endian {
+  Little
+  Big
+} derive(@debug.Debug)
+pub fn Endian::decode_uint16(Self, BytesView) -> UInt16 raise Malformed
+pub fn Endian::decode_uint32(Self, BytesView) -> UInt raise Malformed
+pub fn Endian::decode_uint64(Self, BytesView) -> UInt64 raise Malformed
+pub fn Endian::encode_uint16(Self, UInt16) -> Bytes
+pub fn Endian::encode_uint32(Self, UInt) -> Bytes
+pub fn Endian::encode_uint64(Self, UInt64) -> Bytes
+
+// Type aliases
+
+// Traits
+

--- a/encoding/binary/types.mbt
+++ b/encoding/binary/types.mbt
@@ -1,0 +1,38 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Type `Endian` specifies how fixed-width integer values map to byte order.
+pub(all) enum Endian {
+  Little
+  Big
+} derive(@debug.Debug)
+
+///|
+/// Error type `Malformed`.
+pub suberror Malformed {
+  Malformed(BytesView)
+} derive(@debug.Debug)
+
+///|
+/// Maximum byte length of a varint-encoded 16-bit integer.
+pub const MAX_VARINT_LEN_16 : Int = 3
+
+///|
+/// Maximum byte length of a varint-encoded 32-bit integer.
+pub const MAX_VARINT_LEN_32 : Int = 5
+
+///|
+/// Maximum byte length of a varint-encoded 64-bit integer.
+pub const MAX_VARINT_LEN_64 : Int = 10

--- a/encoding/binary/varint.mbt
+++ b/encoding/binary/varint.mbt
@@ -1,0 +1,80 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Encodes an unsigned 64-bit integer as a variable-length byte sequence.
+///
+/// The encoding is compatible with Go's `encoding/binary` varint helpers.
+pub fn encode_uvarint(value : UInt64) -> Bytes {
+  let buffer = @buffer.Buffer(size_hint=MAX_VARINT_LEN_64)
+  let mut x = value
+  while x >= 0x80UL {
+    buffer.write_byte(((x & 0x7fUL).to_int() | 0x80).to_byte())
+    x = x >> 7
+  }
+  buffer.write_byte(x.to_byte())
+  buffer.to_bytes()
+}
+
+///|
+/// Decodes an unsigned 64-bit integer from a variable-length byte sequence.
+///
+/// Returns the decoded value and the number of consumed bytes. Trailing bytes
+/// are left unread. Raises `Malformed` when the input is incomplete or would
+/// overflow `UInt64`.
+pub fn uvarint(bytes : BytesView) -> (UInt64, Int) raise Malformed {
+  let mut value = 0UL
+  let mut shift = 0
+  for i in 0..<bytes.length() {
+    let byte = bytes[i].to_uint64()
+    if byte < 0x80UL {
+      guard i != MAX_VARINT_LEN_64 - 1 || byte <= 1UL else {
+        raise Malformed(bytes)
+      }
+      return (value | (byte << shift), i + 1)
+    }
+    guard i != MAX_VARINT_LEN_64 - 1 else { raise Malformed(bytes) }
+    value = value | ((byte & 0x7fUL) << shift)
+    shift += 7
+  }
+  raise Malformed(bytes)
+}
+
+///|
+/// Encodes a signed 64-bit integer as a variable-length byte sequence.
+///
+/// Negative values use the same zig-zag mapping as Go's `encoding/binary`
+/// `PutVarint`.
+pub fn encode_varint(value : Int64) -> Bytes {
+  let mut x = value.reinterpret_as_uint64() << 1
+  if value < 0L {
+    x = x.lnot()
+  }
+  encode_uvarint(x)
+}
+
+///|
+/// Decodes a signed 64-bit integer from a variable-length byte sequence.
+///
+/// Returns the decoded value and the number of consumed bytes. Trailing bytes
+/// are left unread. Raises `Malformed` when the input is incomplete or would
+/// overflow `Int64`.
+pub fn varint(bytes : BytesView) -> (Int64, Int) raise Malformed {
+  let (unsigned, consumed) = uvarint(bytes)
+  let mut value = (unsigned >> 1).reinterpret_as_int64()
+  if (unsigned & 1UL) != 0UL {
+    value = value.lnot()
+  }
+  (value, consumed)
+}

--- a/encoding/binary/varint_test.mbt
+++ b/encoding/binary/varint_test.mbt
@@ -1,0 +1,166 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "varint length constants" {
+  inspect(@binary.MAX_VARINT_LEN_16, content="3")
+  inspect(@binary.MAX_VARINT_LEN_32, content="5")
+  inspect(@binary.MAX_VARINT_LEN_64, content="10")
+}
+
+///|
+test "encode uvarint" {
+  assert_eq(@binary.encode_uvarint(0UL), b"\x00")
+  assert_eq(@binary.encode_uvarint(1UL), b"\x01")
+  assert_eq(@binary.encode_uvarint(127UL), b"\x7f")
+  assert_eq(@binary.encode_uvarint(128UL), b"\x80\x01")
+  assert_eq(@binary.encode_uvarint(255UL), b"\xff\x01")
+  assert_eq(@binary.encode_uvarint(256UL), b"\x80\x02")
+  assert_eq(@binary.encode_uvarint(300UL), b"\xac\x02")
+  assert_eq(
+    @binary.encode_uvarint(0xffffffffffffffffUL),
+    b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01",
+  )
+}
+
+///|
+test "decode uvarint" {
+  let cases = [
+    (b"\x00", 0UL, 1),
+    (b"\x01", 1UL, 1),
+    (b"\x7f", 127UL, 1),
+    (b"\x80\x01", 128UL, 2),
+    (b"\xff\x01", 255UL, 2),
+    (b"\x80\x02", 256UL, 2),
+    (b"\xac\x02rest", 300UL, 2),
+    (
+      b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01tail", 18446744073709551615UL, 10,
+    ),
+  ]
+  for case in cases {
+    let (bytes, want, want_consumed) = case
+    let (got, consumed) = try! @binary.uvarint(bytes)
+    assert_eq(got, want)
+    assert_eq(consumed, want_consumed)
+  }
+}
+
+///|
+test "uvarint round trips" {
+  let values = [
+    0UL, 1UL, 2UL, 127UL, 128UL, 255UL, 256UL, 300UL, 16384UL, 0xffffffffffffffffUL,
+  ]
+  for value in values {
+    let encoded = @binary.encode_uvarint(value)
+    let (decoded, consumed) = try! @binary.uvarint(encoded)
+    assert_eq(decoded, value)
+    assert_eq(consumed, encoded.length())
+  }
+}
+
+///|
+test "encode varint" {
+  assert_eq(@binary.encode_varint(-65L), b"\x81\x01")
+  assert_eq(@binary.encode_varint(-64L), b"\x7f")
+  assert_eq(@binary.encode_varint(-2L), b"\x03")
+  assert_eq(@binary.encode_varint(-1L), b"\x01")
+  assert_eq(@binary.encode_varint(0L), b"\x00")
+  assert_eq(@binary.encode_varint(1L), b"\x02")
+  assert_eq(@binary.encode_varint(2L), b"\x04")
+  assert_eq(@binary.encode_varint(63L), b"\x7e")
+  assert_eq(@binary.encode_varint(64L), b"\x80\x01")
+  assert_eq(@binary.encode_varint(300L), b"\xd8\x04")
+  assert_eq(@binary.encode_varint(-300L), b"\xd7\x04")
+}
+
+///|
+test "decode varint" {
+  let cases = [
+    (b"\x81\x01", -65L, 2),
+    (b"\x7f", -64L, 1),
+    (b"\x03", -2L, 1),
+    (b"\x01", -1L, 1),
+    (b"\x00", 0L, 1),
+    (b"\x02", 1L, 1),
+    (b"\x04", 2L, 1),
+    (b"\x7e", 63L, 1),
+    (b"\x80\x01", 64L, 2),
+    (b"\xd8\x04tail", 300L, 2),
+    (b"\xd7\x04tail", -300L, 2),
+  ]
+  for case in cases {
+    let (bytes, want, want_consumed) = case
+    let (got, consumed) = try! @binary.varint(bytes)
+    assert_eq(got, want)
+    assert_eq(consumed, want_consumed)
+  }
+}
+
+///|
+test "varint round trips" {
+  let values = [
+    -9223372036854775808L, -300L, -65L, -64L, -2L, -1L, 0L, 1L, 2L, 63L, 64L, 300L,
+    9223372036854775807L,
+  ]
+  for value in values {
+    let encoded = @binary.encode_varint(value)
+    let (decoded, consumed) = try! @binary.varint(encoded)
+    assert_eq(decoded, value)
+    assert_eq(consumed, encoded.length())
+  }
+}
+
+///|
+test "malformed varints" {
+  try {
+    let _ = @binary.uvarint(b"")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+  try {
+    let _ = @binary.uvarint(b"\x80")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+  try {
+    let _ = @binary.uvarint(b"\x80\x80\x80\x80\x80\x80\x80\x80\x80\x02")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+  try {
+    let _ = @binary.uvarint(b"\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+  try {
+    let _ = @binary.varint(b"\x80")
+    panic()
+  } catch {
+    Malformed(_) => ()
+  }
+}
+
+///|
+test "Debug for Malformed" {
+  try {
+    let _ = @binary.uvarint(b"\x80")
+    panic()
+  } catch {
+    err => @debug.debug_inspect(err, content="Malformed(<BytesView: [0x80]>)")
+  }
+}


### PR DESCRIPTION
## Summary

- add `encoding/binary` for checked fixed-width unsigned integer byte-order helpers
- add Go-compatible unsigned and signed varint encode/decode helpers with max length constants
- add generated interface metadata, README examples, and blackbox tests for round trips, views, trailing bytes, overflow, and malformed input

## Scope

This intentionally covers the in-memory subset of Go-style `encoding/binary`. Stream-oriented read/write APIs and reflection-based struct encoding are left out because core does not have the corresponding IO abstraction in scope for this PR.

## Validation

- `moon check encoding/binary`
- `moon test encoding/binary`
- `moon info`
- `moon fmt`
- `moon check`
- `moon test`