### PR TITLE
Adjust StringBuilder size hint semantics

### DIFF
--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -23,16 +23,16 @@ struct StringBuilder {
 ///
 /// Parameters:
 ///
-/// * `size_hint` : An optional initial capacity hint for the internal buffer. If
-/// less than 1, a minimum capacity of 1 is used. Defaults to 0. It is the size of bytes, 
-/// not the size of characters. `size_hint` may be ignored on some platforms, JS for example.
+/// * `size_hint` : An optional initial capacity hint for the internal buffer,
+/// in UTF-16 code units. Defaults to 8. Use 0 to request an empty initial
+/// buffer. `size_hint` may be ignored on some platforms, JS for example.
 ///
-/// Returns a new `StringBuilder` instance with the specified initial capacity.
+/// Returns a new `StringBuilder` instance.
 ///
 #alias(new)
-pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
-  let initial = if size_hint < 1 { 1 } else { (size_hint + 1) / 2 }
-  let data : FixedArray[UInt16] = FixedArray::make(initial, 0)
+pub fn StringBuilder::StringBuilder(size_hint? : Int = 8) -> StringBuilder {
+  guard size_hint >= 0 else { abort("size_hint must be non-negative") }
+  let data : FixedArray[UInt16] = FixedArray::make(size_hint, 0)
   { data, len: 0 }
 }
 
@@ -51,9 +51,9 @@ fn StringBuilder::grow_if_necessary(
   if required <= current_len {
     return
   }
-  // current_len is at least 1
-  // double the enough_space until it larger than required
-  let enough_space = for enough_space = current_len; enough_space < required; {
+  // Double the capacity until it can hold the required length.
+  let initial = current_len.max(1)
+  let enough_space = for enough_space = initial; enough_space < required; {
     continue enough_space * 2
   } nobreak {
     enough_space

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -23,16 +23,16 @@ struct StringBuilder {
 ///
 /// Parameters:
 ///
-/// * `size_hint` : An optional initial capacity hint for the internal buffer. If
-/// less than 1, a minimum capacity of 1 is used. Defaults to 0. It is the size of bytes, 
-/// not the size of characters. `size_hint` may be ignored on some platforms, JS for example.
+/// * `size_hint` : An optional initial capacity hint for the internal buffer,
+/// in UTF-16 code units. Defaults to 8. Use 0 to request an empty initial
+/// buffer. `size_hint` may be ignored on some platforms, JS for example.
 ///
-/// Returns a new `StringBuilder` instance with the specified initial capacity.
+/// Returns a new `StringBuilder` instance.
 ///
 #alias(new, deprecated="Use `StringBuilder()` instead")
-pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
-  let initial = if size_hint < 1 { 1 } else { (size_hint + 1) / 2 }
-  let data : FixedArray[UInt16] = FixedArray::make(initial, 0)
+pub fn StringBuilder::StringBuilder(size_hint? : Int = 8) -> StringBuilder {
+  guard size_hint >= 0 else { abort("size_hint must be non-negative") }
+  let data : FixedArray[UInt16] = FixedArray::make(size_hint, 0)
   { data, len: 0, }
 }
 
@@ -54,7 +54,8 @@ fn stringbuilder_growth_capacity(
   if required < len {
     abort("StringBuilder capacity overflow")
   }
-  let enough_space = for space = current; space < required; {
+  // Start doubling from at least 1 so a zero-length initial buffer can grow.
+  let enough_space = for space = current.max(1); space < required; {
     let next = space * 2
     if next <= space {
       break required

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -22,14 +22,15 @@ struct StringBuilder {
 ///
 /// Parameters:
 ///
-/// * `size_hint` : An optional initial capacity hint for the internal buffer. If
-/// less than 1, a minimum capacity of 1 is used. Defaults to 0. It is the size of bytes, 
-/// not the size of characters. `size_hint` may be ignored on some platforms, JS for example.
+/// * `size_hint` : An optional initial capacity hint for the internal buffer,
+/// in UTF-16 code units. Defaults to 8. Use 0 to request an empty initial
+/// buffer. `size_hint` may be ignored on some platforms, JS for example.
 ///
-/// Returns a new `StringBuilder` instance with the specified initial capacity.
+/// Returns a new `StringBuilder` instance.
 ///
 #alias(new)
-pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
+pub fn StringBuilder::StringBuilder(size_hint? : Int = 8) -> StringBuilder {
+  guard size_hint >= 0 else { abort("size_hint must be non-negative") }
   ignore(size_hint)
   { val: "" }
 }

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -22,14 +22,15 @@ struct StringBuilder {
 ///
 /// Parameters:
 ///
-/// * `size_hint` : An optional initial capacity hint for the internal buffer. If
-/// less than 1, a minimum capacity of 1 is used. Defaults to 0. It is the size of bytes, 
-/// not the size of characters. `size_hint` may be ignored on some platforms, JS for example.
+/// * `size_hint` : An optional initial capacity hint for the internal buffer,
+/// in UTF-16 code units. Defaults to 8. Use 0 to request an empty initial
+/// buffer. `size_hint` may be ignored on some platforms, JS for example.
 ///
-/// Returns a new `StringBuilder` instance with the specified initial capacity.
+/// Returns a new `StringBuilder` instance.
 ///
 #alias(new, deprecated="Use `StringBuilder()` instead")
-pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
+pub fn StringBuilder::StringBuilder(size_hint? : Int = 8) -> StringBuilder {
+  guard size_hint >= 0 else { abort("size_hint must be non-negative") }
   ignore(size_hint)
   { val: "", }
 }

--- a/builtin/stringbuilder_test.mbt
+++ b/builtin/stringbuilder_test.mbt
@@ -48,6 +48,18 @@ test "reset does not mutate returned string" {
 }
 
 ///|
+test "StringBuilder size_hint zero grows" {
+  let buf = StringBuilder(size_hint=0)
+  buf.write_string("hello")
+  inspect(buf.to_string(), content="hello")
+}
+
+///|
+test "panic StringBuilder constructor negative size_hint" {
+  ignore(StringBuilder(size_hint=-1))
+}
+
+///|
 test {
   let data = ["a", "b", "c", "hello world"]
   @json.json_inspect(


### PR DESCRIPTION
## Summary

- change `StringBuilder()` to use an eager default capacity hint of 8 UTF-16 code units
- define `size_hint` consistently as UTF-16 code-unit capacity rather than bytes
- keep `StringBuilder(size_hint=0)` as the explicit empty-buffer path and make buffer growth handle zero capacity
- reject negative `size_hint` values on both buffer-backed and JS concat-backed implementations
- add tests for explicit zero-capacity growth and negative hint rejection

## Validation

- `moon fmt builtin/stringbuilder_buffer.mbt builtin/stringbuilder_concat.mbt builtin/stringbuilder_test.mbt`
- `moon check builtin`
- `moon test builtin`
- `moon info`
- `moon ide doc StringBuilder::StringBuilder`
- `git diff --check`
- `moon check`
- `moon test`