### PR TITLE
refactor(test): re-export `assert_eq` from `@debug`

### DIFF
--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -248,6 +248,9 @@ pub fn debug_inspect(
 
 ///|
 /// Assert two values are equal for debugging/tests.
+///
+/// This is the preferred test assertion for new code, especially for types
+/// that implement `Debug` but not `Show`.
 #callsite(autofill(loc))
 pub fn[T : Eq + Debug] assert_eq(
   a : T,

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -23,25 +23,7 @@ fn[T : Show] debug_string(t : T) -> String {
 }
 
 ///|
-/// Assert two values are equal using `Debug` output for diagnostics.
-///
-/// This is the preferred test assertion for new code, especially for types
-/// that implement `Debug` but not `Show`.
-#callsite(autofill(loc))
-pub fn[T : Eq + Debug] assert_eq(
-  a : T,
-  b : T,
-  msg? : String,
-  loc~ : SourceLoc,
-) -> Unit raise {
-  if a != b {
-    let fail_msg = match msg {
-      Some(msg) => msg
-      None => "`\{@debug.to_string(a)} != \{@debug.to_string(b)}`"
-    }
-    fail(fail_msg, loc~)
-  }
-}
+pub using @debug {assert_eq}
 
 ///|
 /// Assert two values are not equal using `Debug` output for diagnostics.


### PR DESCRIPTION
Package `debug` has already contained a function named `assert_eq` that utilizes structural diff, compared to `@test.assert_eq` which simply prints the textural representation of two sides. The redundancy may confuse users and mislead them to the less informative alternative in `@test`.