### PR TITLE
[codex] Refactor source location JSON builder

### DIFF
--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -81,12 +81,8 @@ fn SourceLocRepr::parse(repr : String) -> SourceLocRepr {
 ///|
 fn SourceLocRepr::to_json_string(self : SourceLocRepr) -> String {
   let sb = StringBuilder()
-  sb.write_string("{\"filename\":")
-  self.filename.escape_to(sb)
-  sb.write_string(",\"start_line\":\{self.start_line}")
-  sb.write_string(",\"start_column\":\{self.start_column}")
-  sb.write_string(",\"end_line\":\{self.end_line}")
-  sb.write_string(",\"end_column\":\{self.end_column}}")
+  sb <+
+    $|{"filename":\{sb => self.filename.escape_to(sb)},"start_line":\{self.start_line},"start_column":\{self.start_column},"end_line":\{self.end_line},"end_column":\{self.end_column}}
   sb.to_string()
 }
 


### PR DESCRIPTION
## Summary

- Refactor `SourceLocRepr::to_json_string` to use the `StringBuilder` interpolation append form.
- Preserve the existing compact JSON output exactly, including escaped filenames and numeric location fields.

## Review notes

During local review, the initial refactor emitted extra JSON whitespace and failed the source location snapshots. I adjusted the interpolation literal to keep the previous output stable.

## Validation

- `moon fmt`
- `moon info` (no `.mbti` changes)
- `moon test builtin/source_loc_wbtest.mbt`
- `moon check`
- `moon test` (6502 passed)
