### PR TITLE
[codex] Use interpolation for fixed output builders

### DIFF
--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -231,11 +231,9 @@ pub impl[X : Show] Show for X?
 pub impl[X : Show] Show for X? with fn output(self, logger) {
   match self {
     None => logger.write_string("None")
-    Some(arg) => {
-      logger.write_string("Some(")
-      logger.write_object(arg)
-      logger.write_string(")")
-    }
+    Some(arg) =>
+      logger <+
+        $|Some(\{arg})
   }
 }
 
@@ -246,16 +244,12 @@ pub impl[T : Show, E : Show] Show for Result[T, E]
 ///|
 pub impl[T : Show, E : Show] Show for Result[T, E] with fn output(self, logger) {
   match self {
-    Ok(x) => {
-      logger.write_string("Ok(")
-      logger.write_object(x)
-      logger.write_string(")")
-    }
-    Err(e) => {
-      logger.write_string("Err(")
-      logger.write_object(e)
-      logger.write_string(")")
-    }
+    Ok(x) =>
+      logger <+
+        $|Ok(\{x})
+    Err(e) =>
+      logger <+
+        $|Err(\{e})
   }
 }
 

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -32,29 +32,16 @@ pub(all) suberror ParseError {
 ///|
 pub impl Show for ParseError with fn output(self, logger) {
   match self {
-    InvalidChar({ line, column }, c) => {
-      logger.write_string("Invalid character ")
-      logger.write_string(c.escape())
-      logger.write_string(" at line ")
-      logger.write_object(line)
-      logger.write_string(", column ")
-      logger.write_object(column)
-    }
+    InvalidChar({ line, column }, c) =>
+      logger <+
+        $|Invalid character \{c.escape()} at line \{line}, column \{column}
     InvalidEof => logger.write_string("Unexpected end of file")
-    InvalidNumber({ line, column }, s) => {
-      logger.write_string("Invalid number ")
-      logger.write_string(s)
-      logger.write_string(" at line ")
-      logger.write_object(line)
-      logger.write_string(", column ")
-      logger.write_object(column)
-    }
-    InvalidIdentEscape({ line, column }) => {
-      logger.write_string("Invalid escape sequence in identifier at line ")
-      logger.write_object(line)
-      logger.write_string(", column ")
-      logger.write_object(column)
-    }
+    InvalidNumber({ line, column }, s) =>
+      logger <+
+        $|Invalid number \{s} at line \{line}, column \{column}
+    InvalidIdentEscape({ line, column }) =>
+      logger <+
+        $|Invalid escape sequence in identifier at line \{line}, column \{column}
     DepthLimitExceeded =>
       logger.write_string(
         "Depth limit exceeded, please increase the max_nesting_depth parameter",

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -33,9 +33,8 @@ pub impl[X : Show] Show for Ref[X]
 
 ///|
 pub impl[X : Show] Show for Ref[X] with fn output(self, logger) {
-  logger.write_string("{val: ")
-  logger.write_object(self.val)
-  logger.write_string("}")
+  logger <+
+    $|{val: \{self.val}}
 }
 
 ///|

--- a/string/internal/regex_parser/parser_error.mbt
+++ b/string/internal/regex_parser/parser_error.mbt
@@ -20,12 +20,9 @@ suberror ParserError {
 ///|
 pub impl Show for ParserError with fn output(self, logger) {
   match self {
-    ParserError(at~, hint~) => {
-      logger.write_string("ParserError at position ")
-      logger.write_object(at)
-      logger.write_string(": ")
-      logger.write_string(hint)
-    }
+    ParserError(at~, hint~) =>
+      logger <+
+        $|ParserError at position \{at}: \{hint}
   }
 }
 


### PR DESCRIPTION
## Summary

- Use string interpolation append syntax for small fixed-format output implementations.
- Use direct interpolation such as `\{x}` for embedded `Show` values; appended interpolation writes through the target logger.
- Leave looped serializers and escaping code unchanged where explicit writes remain clearer.

## Validation

- `moon fmt`
- `moon test ref string/internal/regex_parser json builtin/show_test.mbt builtin/result_test.mbt builtin/option_test.mbt` (359 passed)
- `moon info` (no `.mbti` changes)
- `moon check`
- `moon test` (6502 passed)
