### PR TITLE
perf(builtin): override Hash::hash for primitive types to skip Hasher alloc

### DIFF
--- a/builtin/bool.mbt
+++ b/builtin/bool.mbt
@@ -121,6 +121,14 @@ pub impl Hash for Bool with fn hash_combine(self, hasher) {
 }
 
 ///|
+// Forward to the inline `UInt` hash to skip the per-call
+// `Hasher::new()` allocation. See `Hash for Int with fn hash` in
+// `hasher.mbt` for the rationale.
+pub impl Hash for Bool with fn hash(self : Bool) -> Int {
+  Hash::hash(if self { 1U } else { 0U })
+}
+
+///|
 /// Converts a boolean value to an unsigned 16-bit integer.
 ///
 /// Parameters:

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -45,6 +45,14 @@ pub impl Hash for Char with fn hash_combine(self, hasher) -> Unit {
 }
 
 ///|
+// Forward to the inline `UInt` hash to skip the per-call
+// `Hasher::new()` allocation. See `Hash for Int with fn hash` in
+// `hasher.mbt` for the rationale.
+pub impl Hash for Char with fn hash(self : Char) -> Int {
+  Hash::hash(self.to_uint())
+}
+
+///|
 /// Checks if the value is within the ASCII range.
 pub fn Char::is_ascii(self : Self) -> Bool {
   self is ('\u{00}'..='\u{7F}')

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -498,6 +498,29 @@ pub impl Hash for String with fn hash_combine(self, hasher) {
 }
 
 ///|
+// Override the default `Hash::hash` for `String` to skip the per-call
+// `Hasher::new()` heap allocation. The per-codepoint math is exactly
+// what `combine_string` + `finalize` does, just with the accumulator
+// held in a local `UInt` instead of a boxed `Hasher`. Big win on
+// String-keyed `HashMap`/`HashSet` probe paths — measured −450 k allocs
+// on a 10 k-element ×30-iter String-keyed hashmap bench. See
+// `Hash for Int with fn hash` for the broader rationale.
+pub impl Hash for String with fn hash(self : String) -> Int {
+  let mut acc = seed.reinterpret_as_uint() + GPRIME5
+  for i in 0..<self.length() {
+    acc = acc + 4U
+    let v = self.unsafe_get(i).to_int().reinterpret_as_uint()
+    acc = rotl(acc + v * GPRIME3, 17) * GPRIME4
+  }
+  let acc = acc ^ (acc >> 15)
+  let acc = acc * GPRIMES2
+  let acc = acc ^ (acc >> 13)
+  let acc = acc * GPRIME3
+  let acc = acc ^ (acc >> 16)
+  acc.reinterpret_as_int()
+}
+
+///|
 pub impl Hash for StringView with fn hash_combine(
   self : StringView,
   hasher : Hasher,
@@ -506,6 +529,25 @@ pub impl Hash for StringView with fn hash_combine(
   for i in self.start()..<self.end() {
     hasher.combine_uint(str.unsafe_get(i).to_int().reinterpret_as_uint())
   }
+}
+
+///|
+// Same inline-the-combine-loop trick as `Hash for String with fn hash`,
+// applied to the substring case.
+pub impl Hash for StringView with fn hash(self : StringView) -> Int {
+  let str = self.str()
+  let mut acc = seed.reinterpret_as_uint() + GPRIME5
+  for i in self.start()..<self.end() {
+    acc = acc + 4U
+    let v = str.unsafe_get(i).to_int().reinterpret_as_uint()
+    acc = rotl(acc + v * GPRIME3, 17) * GPRIME4
+  }
+  let acc = acc ^ (acc >> 15)
+  let acc = acc * GPRIMES2
+  let acc = acc ^ (acc >> 13)
+  let acc = acc * GPRIME3
+  let acc = acc ^ (acc >> 16)
+  acc.reinterpret_as_int()
 }
 
 ///|
@@ -529,6 +571,25 @@ pub impl Hash for StringView with fn hash_combine(
 /// ```
 pub impl Hash for Int with fn hash_combine(self, hasher) {
   hasher.combine_int(self)
+}
+
+///|
+// Override the default `Hash::hash` for `Int` to avoid the per-call
+// `Hasher::new()` heap allocation. The default builds a fresh
+// `Hasher` ({ mut acc : UInt }), combines, finalizes — on the
+// native target that is one boxed allocation per hash, which
+// dominates `HashSet`/`HashMap` probe paths over `Int` keys
+// (~1 M extra allocs on a 10 k-element × 50-iter HashSet bench).
+// Inline the equivalent math so single-`Int` hashing is alloc-free.
+pub impl Hash for Int with fn hash(self : Int) -> Int {
+  let acc = seed.reinterpret_as_uint() + GPRIME5 + 4U
+  let acc = rotl(acc + self.reinterpret_as_uint() * GPRIME3, 17) * GPRIME4
+  let acc = acc ^ (acc >> 15)
+  let acc = acc * GPRIMES2
+  let acc = acc ^ (acc >> 13)
+  let acc = acc * GPRIME3
+  let acc = acc ^ (acc >> 16)
+  acc.reinterpret_as_int()
 }
 
 ///|
@@ -556,6 +617,21 @@ pub impl Hash for UInt with fn hash_combine(self, hasher) {
 }
 
 ///|
+// `Hash for UInt` shares the inline math with `Int` (same single
+// 32-bit combine + avalanche) — just skips the `reinterpret_as_uint`
+// hop. See the comment on `Hash for Int with fn hash`.
+pub impl Hash for UInt with fn hash(self : UInt) -> Int {
+  let acc = seed.reinterpret_as_uint() + GPRIME5 + 4U
+  let acc = rotl(acc + self * GPRIME3, 17) * GPRIME4
+  let acc = acc ^ (acc >> 15)
+  let acc = acc * GPRIMES2
+  let acc = acc ^ (acc >> 13)
+  let acc = acc * GPRIME3
+  let acc = acc ^ (acc >> 16)
+  acc.reinterpret_as_int()
+}
+
+///|
 /// Implements the `Hash` trait for `UInt64` by combining the hash value of an
 /// unsigned 64-bit integer into a hasher.
 ///
@@ -575,6 +651,24 @@ pub impl Hash for UInt with fn hash_combine(self, hasher) {
 /// ```
 pub impl Hash for UInt64 with fn hash_combine(self, hasher) {
   hasher.combine_uint64(self)
+}
+
+///|
+// Inline 64-bit hash to skip the `Hasher::new()` heap alloc. Mirrors
+// `Hasher::combine_int64` (which combines two 32-bit halves) followed
+// by `finalize`. See the comment on `Hash for Int with fn hash`.
+pub impl Hash for UInt64 with fn hash(self : UInt64) -> Int {
+  let acc = seed.reinterpret_as_uint() + GPRIME5 + 8U
+  let low = self.to_uint()
+  let high = (self >> 32).to_uint()
+  let acc = rotl(acc + low * GPRIME3, 17) * GPRIME4
+  let acc = rotl(acc + high * GPRIME3, 17) * GPRIME4
+  let acc = acc ^ (acc >> 15)
+  let acc = acc * GPRIMES2
+  let acc = acc ^ (acc >> 13)
+  let acc = acc * GPRIME3
+  let acc = acc ^ (acc >> 16)
+  acc.reinterpret_as_int()
 }
 
 ///|

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -433,12 +433,17 @@ pub fn Hasher::combine_char(self : Hasher, value : Char) -> Unit {
 /// }
 /// ```
 pub fn Hasher::finalize(self : Hasher) -> Int {
-  self.avalanche().reinterpret_as_int()
+  finalize_acc(self.acc)
 }
 
 ///|
-fn Hasher::avalanche(self : Hasher) -> UInt {
-  let mut acc = self.acc
+fn finalize_acc(acc : UInt) -> Int {
+  avalanche_acc(acc).reinterpret_as_int()
+}
+
+///|
+fn avalanche_acc(acc : UInt) -> UInt {
+  let mut acc = acc
   acc = acc ^ (acc >> 15)
   acc *= GPRIMES2
   acc = acc ^ (acc >> 13)
@@ -449,7 +454,12 @@ fn Hasher::avalanche(self : Hasher) -> UInt {
 
 ///|
 fn Hasher::consume4(self : Hasher, input : UInt) -> Unit {
-  self.acc = rotl(self.acc + input * GPRIME3, 17) * GPRIME4
+  self.acc = consume4_acc(self.acc, input)
+}
+
+///|
+fn consume4_acc(acc : UInt, input : UInt) -> UInt {
+  rotl(acc + input * GPRIME3, 17) * GPRIME4
 }
 
 ///|
@@ -510,14 +520,9 @@ pub impl Hash for String with fn hash(self : String) -> Int {
   for i in 0..<self.length() {
     acc = acc + 4U
     let v = self.unsafe_get(i).to_int().reinterpret_as_uint()
-    acc = rotl(acc + v * GPRIME3, 17) * GPRIME4
+    acc = consume4_acc(acc, v)
   }
-  let acc = acc ^ (acc >> 15)
-  let acc = acc * GPRIMES2
-  let acc = acc ^ (acc >> 13)
-  let acc = acc * GPRIME3
-  let acc = acc ^ (acc >> 16)
-  acc.reinterpret_as_int()
+  finalize_acc(acc)
 }
 
 ///|
@@ -540,14 +545,9 @@ pub impl Hash for StringView with fn hash(self : StringView) -> Int {
   for i in self.start()..<self.end() {
     acc = acc + 4U
     let v = str.unsafe_get(i).to_int().reinterpret_as_uint()
-    acc = rotl(acc + v * GPRIME3, 17) * GPRIME4
+    acc = consume4_acc(acc, v)
   }
-  let acc = acc ^ (acc >> 15)
-  let acc = acc * GPRIMES2
-  let acc = acc ^ (acc >> 13)
-  let acc = acc * GPRIME3
-  let acc = acc ^ (acc >> 16)
-  acc.reinterpret_as_int()
+  finalize_acc(acc)
 }
 
 ///|
@@ -583,13 +583,7 @@ pub impl Hash for Int with fn hash_combine(self, hasher) {
 // Inline the equivalent math so single-`Int` hashing is alloc-free.
 pub impl Hash for Int with fn hash(self : Int) -> Int {
   let acc = seed.reinterpret_as_uint() + GPRIME5 + 4U
-  let acc = rotl(acc + self.reinterpret_as_uint() * GPRIME3, 17) * GPRIME4
-  let acc = acc ^ (acc >> 15)
-  let acc = acc * GPRIMES2
-  let acc = acc ^ (acc >> 13)
-  let acc = acc * GPRIME3
-  let acc = acc ^ (acc >> 16)
-  acc.reinterpret_as_int()
+  finalize_acc(consume4_acc(acc, self.reinterpret_as_uint()))
 }
 
 ///|
@@ -622,13 +616,7 @@ pub impl Hash for UInt with fn hash_combine(self, hasher) {
 // hop. See the comment on `Hash for Int with fn hash`.
 pub impl Hash for UInt with fn hash(self : UInt) -> Int {
   let acc = seed.reinterpret_as_uint() + GPRIME5 + 4U
-  let acc = rotl(acc + self * GPRIME3, 17) * GPRIME4
-  let acc = acc ^ (acc >> 15)
-  let acc = acc * GPRIMES2
-  let acc = acc ^ (acc >> 13)
-  let acc = acc * GPRIME3
-  let acc = acc ^ (acc >> 16)
-  acc.reinterpret_as_int()
+  finalize_acc(consume4_acc(acc, self))
 }
 
 ///|
@@ -659,16 +647,11 @@ pub impl Hash for UInt64 with fn hash_combine(self, hasher) {
 // by `finalize`. See the comment on `Hash for Int with fn hash`.
 pub impl Hash for UInt64 with fn hash(self : UInt64) -> Int {
   let acc = seed.reinterpret_as_uint() + GPRIME5 + 8U
-  let low = self.to_uint()
-  let high = (self >> 32).to_uint()
-  let acc = rotl(acc + low * GPRIME3, 17) * GPRIME4
-  let acc = rotl(acc + high * GPRIME3, 17) * GPRIME4
-  let acc = acc ^ (acc >> 15)
-  let acc = acc * GPRIMES2
-  let acc = acc ^ (acc >> 13)
-  let acc = acc * GPRIME3
-  let acc = acc ^ (acc >> 16)
-  acc.reinterpret_as_int()
+  let low = (self & 0xFFFF_FFFFUL).to_uint()
+  let high = ((self >> 32) & 0xFFFF_FFFFUL).to_uint()
+  let acc = consume4_acc(acc, low)
+  let acc = consume4_acc(acc, high)
+  finalize_acc(acc)
 }
 
 ///|

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -192,6 +192,44 @@ test "combine all" {
 }
 
 ///|
+fn[T : Hash] assert_hash_matches_hash_combine(value : T) -> Unit raise {
+  let hasher = Hasher::new()
+  Hash::hash_combine(value, hasher)
+  assert_eq(Hash::hash(value), hasher.finalize())
+}
+
+///|
+test "primitive hash matches hash_combine default path" {
+  assert_hash_matches_hash_combine(false)
+  assert_hash_matches_hash_combine(true)
+  assert_hash_matches_hash_combine('A')
+  assert_hash_matches_hash_combine('🤣')
+  assert_hash_matches_hash_combine(0)
+  assert_hash_matches_hash_combine(1)
+  assert_hash_matches_hash_combine(-1)
+  assert_hash_matches_hash_combine(2147483647)
+  assert_hash_matches_hash_combine(-2147483648)
+  assert_hash_matches_hash_combine(0U)
+  assert_hash_matches_hash_combine(1U)
+  assert_hash_matches_hash_combine(0xFFFF_FFFFU)
+  assert_hash_matches_hash_combine(0L)
+  assert_hash_matches_hash_combine(1L)
+  assert_hash_matches_hash_combine(-1L)
+  assert_hash_matches_hash_combine(9223372036854775807L)
+  assert_hash_matches_hash_combine(-9223372036854775808L)
+  assert_hash_matches_hash_combine(0UL)
+  assert_hash_matches_hash_combine(1UL)
+  assert_hash_matches_hash_combine(0xFFFF_FFFFUL)
+  assert_hash_matches_hash_combine(0x1_0000_0000UL)
+  assert_hash_matches_hash_combine(0xFFFF_FFFF_0000_0000UL)
+  assert_hash_matches_hash_combine(0xFFFF_FFFF_FFFF_FFFFUL)
+  assert_hash_matches_hash_combine("")
+  assert_hash_matches_hash_combine("abc")
+  assert_hash_matches_hash_combine("a🤣b")
+  assert_hash_matches_hash_combine("xa🤣by"[1:-1])
+}
+
+///|
 test "combine_unit" {
   let hasher = @builtin.Hasher::new(seed=0)
   hasher.combine_unit()

--- a/builtin/int64.mbt
+++ b/builtin/int64.mbt
@@ -97,6 +97,14 @@ pub impl Hash for Int64 with fn hash_combine(self, hasher) {
 }
 
 ///|
+// Avoid the per-call `Hasher::new()` heap allocation by forwarding to
+// the `UInt64` inline override in `hasher.mbt`. See `Hash for Int
+// with fn hash` for the rationale.
+pub impl Hash for Int64 with fn hash(self : Int64) -> Int {
+  Hash::hash(self.reinterpret_as_uint64())
+}
+
+///|
 /// Performs unary negation on a 64-bit signed integer, returning its arithmetic
 /// inverse.
 ///


### PR DESCRIPTION
## Summary

The default `Hash::hash` builds a fresh `Hasher` ({ mut acc : UInt }),
combines, finalizes — **one heap allocation per call**. For primitive
types the math is small enough to inline, so the allocation is pure
overhead.

This PR overrides `hash` for **eight primitive types** that already
have `hash_combine` impls:

| type | strategy |
|---|---|
| `Int`, `UInt` | inline single-word combine + avalanche |
| `Int64`, `UInt64` | inline two-half combine + avalanche |
| `String`, `StringView` | inline per-codepoint combine loop + avalanche |
| `Char` | forward to `UInt.hash` via `to_uint()` |
| `Bool` | forward to `UInt.hash` via 0 / 1 |

The default `hash_combine` impls stay unchanged (they're still needed
for composite hashing where `hash` of a sub-value can't be used
directly).

## Numbers

Measured on a native-target alloc profiler over mizchi/pprof-mbt's
bench suite (`--sample-rate 100`):

| bench | before | after | Δ |
|---|---|---|---|
| `hashset_ops` (Int keys, 10 k + 20 k probes × 50) | 2 665 300 allocs | 1 165 300 | **−56 %** |
| └ `contains` site | 1 M / 3.81 MB | gone from top sites | — |
| `hashmap_update` (Int → Int) | 620 100 allocs | 10 100 | **−98 %** |
| `hashmap_ops` (Int keys) | `Hash::hash` 100 % of probes | gone from top | — |
| `hashmap_string` (String keys, 10 k × 30) | 845 700 allocs | 395 700 | **−53 %** |
| └ `Hash::hash` site | 450 k / 1.72 MB | gone from top sites | — |

## Why this is safe

The override produces the same hash value as the default path on every
backend. The default is:

```moonbit
impl Hash with fn hash(self) {
  let h = Hasher::new()
  h.combine(self)
  h.finalize()
}
```

For `Int`, expanding `Hasher::new` → `Hasher.combine_int` → `finalize`
on `Hasher { mut acc : UInt }` gives:

```text
acc  = seed + GPRIME5            // Hasher::new()
acc += 4                         // combine_uint length
acc  = rotl(acc + v * GPRIME3, 17) * GPRIME4
acc ^= acc >> 15; acc *= GPRIMES2;
acc ^= acc >> 13; acc *= GPRIME3;
acc ^= acc >> 16
return acc.reinterpret_as_int()
```

— which is exactly what the inline override computes. `UInt` skips the
`reinterpret_as_uint` hop. `UInt64` combines low / high 32-bit halves
the same way `Hasher::combine_int64` does. `Int64` forwards to
`UInt64`. `String`/`StringView` keep the same per-codepoint loop body
as `Hasher::combine_string`, just with the accumulator in a local
`UInt`. `Char` and `Bool` forward to `UInt.hash` via their existing
conversion (matching `combine_char` / `combine_bool`).

The global `seed` (0 on native / wasm / wasm-gc, JS-randomized on the
js target) is shared with `Hasher::new()` so the output matches per-
backend.

## Test plan

- [x] `moon test --target native -p builtin -p hashset -p hashmap` — 3175 / 3175 pass
- [x] `moon test --target wasm-gc -p builtin -p hashset -p hashmap` — 3217 / 3217 pass
- [x] `moon fmt --check` clean

Independent of #3632 (json lex_skip_whitespace) and #3633 (json
lex_number tuple). Same workflow (native-target alloc profile of a
real bench, then attack the top site), different file.