### PR TITLE
perf(string): drop per-call Iter alloc in to_lower

### DIFF
--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1731,6 +1731,8 @@ test "View::replace_all boundary cases" {
 
 ///|
 /// Helpers for ASCII-only lowercase conversion over UTF-16 code units.
+/// Non-ASCII code units, including surrogate halves, are copied with
+/// `write_substring` and are never converted through `Char`.
 fn is_ascii_uppercase_code_unit(code_unit : Int) -> Bool {
   code_unit >= 0x41 && code_unit <= 0x5A
 }
@@ -1757,7 +1759,9 @@ fn StringBuilder::write_ascii_lowercase_code_unit(
   self : StringBuilder,
   code_unit : Int,
 ) -> Unit {
-  // SAFETY: code_unit is ASCII uppercase, so +32 is ASCII lowercase.
+  // SAFETY: code_unit is ASCII uppercase, so +32 is an ASCII lowercase code
+  // point and a valid `Char`; this helper is not used for arbitrary UTF-16
+  // code units or surrogate halves.
   self.write_char((code_unit + 32).unsafe_to_char())
 }
 

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1730,30 +1730,75 @@ test "View::replace_all boundary cases" {
 }
 
 ///|
+/// Helpers for ASCII-only lowercase conversion over UTF-16 code units.
+fn is_ascii_uppercase_code_unit(code_unit : Int) -> Bool {
+  code_unit >= 0x41 && code_unit <= 0x5A
+}
+
+///|
+fn find_ascii_uppercase_code_unit(
+  data : String,
+  start : Int,
+  len : Int,
+) -> Int? {
+  let end = start + len
+  for i = start; i < end; i = i + 1 {
+    // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
+    let code_unit = data.unsafe_get(i).to_int()
+    if is_ascii_uppercase_code_unit(code_unit) {
+      return Some(i - start)
+    }
+  }
+  None
+}
+
+///|
+fn StringBuilder::write_ascii_lowercase_code_unit(
+  self : StringBuilder,
+  code_unit : Int,
+) -> Unit {
+  // SAFETY: code_unit is ASCII uppercase, so +32 is ASCII lowercase.
+  self.write_char((code_unit + 32).unsafe_to_char())
+}
+
+///|
+fn StringBuilder::write_ascii_lowered_substring(
+  self : StringBuilder,
+  data : String,
+  start : Int,
+  len : Int,
+) -> Unit {
+  let end = start + len
+  let mut segment_start = start
+  for i = start; i < end; i = i + 1 {
+    // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
+    let code_unit = data.unsafe_get(i).to_int()
+    if is_ascii_uppercase_code_unit(code_unit) {
+      if segment_start < i {
+        self.write_substring(data, segment_start, i - segment_start)
+      }
+      self.write_ascii_lowercase_code_unit(code_unit)
+      segment_start = i + 1
+    }
+  }
+  if segment_start < end {
+    self.write_substring(data, segment_start, end - segment_start)
+  }
+}
+
+///|
 /// Converts this string to lowercase.
 pub fn StringView::to_lower(self : StringView) -> StringView {
   // TODO: deal with non-ascii characters
-  guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
+  let data = self.data()
+  let start = self.start_offset()
+  let len = self.length()
+  guard find_ascii_uppercase_code_unit(data, start, len) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
-  buf.write_substring(head.data(), head.start_offset(), head.length())
-  // Manual UTF-16 code-unit loop avoids the per-call `Iter` heap
-  // allocation that `for c in self.view(...)` triggers on the native
-  // target. Same ASCII-only conversion as before; any non-ASCII unit
-  // (BMP or surrogate half) is written through bit-identically since
-  // `write_char` of a code unit ≤ 0xFFFF emits exactly one UTF-16 unit.
-  let len = self.length()
-  for i = idx; i < len; i = i + 1 {
-    let cui = self.unsafe_get(i).to_int()
-    if cui >= 0x41 && cui <= 0x5A {
-      // 'A' is 65, 'a' is 97; difference is 32.
-      buf.write_char((cui + 32).unsafe_to_char())
-    } else {
-      buf.write_char(cui.unsafe_to_char())
-    }
-  }
+  let buf = StringBuilder(size_hint=len)
+  buf.write_substring(data, start, idx)
+  buf.write_ascii_lowered_substring(data, start + idx, len - idx)
   buf.to_string()
 }
 
@@ -1761,22 +1806,13 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
 /// Converts this string to lowercase.
 pub fn String::to_lower(self : String) -> String {
   // TODO: deal with non-ascii characters
-  guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
+  let len = self.length()
+  guard find_ascii_uppercase_code_unit(self, 0, len) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
-  buf.write_substring(head.data(), head.start_offset(), head.length())
-  // Manual UTF-16 code-unit loop — see `StringView::to_lower` above.
-  let len = self.length()
-  for i = idx; i < len; i = i + 1 {
-    let cui = self.unsafe_get(i).to_int()
-    if cui >= 0x41 && cui <= 0x5A {
-      buf.write_char((cui + 32).unsafe_to_char())
-    } else {
-      buf.write_char(cui.unsafe_to_char())
-    }
-  }
+  let buf = StringBuilder(size_hint=len)
+  buf.write_substring(self, 0, idx)
+  buf.write_ascii_lowered_substring(self, idx, len - idx)
   buf.to_string()
 }
 
@@ -1785,6 +1821,8 @@ test "to_lower" {
   assert_true("Hello".to_lower() == "hello")
   assert_true("HELLO".to_lower() == "hello")
   assert_true("Hello, World!".to_lower() == "hello, world!")
+  assert_true("🤣A".to_lower() == "🤣a")
+  assert_true("A🤣B".to_lower() == "a🤣b")
 }
 
 ///|
@@ -1792,6 +1830,7 @@ test "View::to_lower" {
   assert_true("Hello"[:].to_lower() == "hello")
   assert_true("HELLO"[:].to_lower() == "hello")
   assert_true("Hello, World!"[:].to_lower() == "hello, world!")
+  assert_true("x🤣ABy"[1:-1].to_lower() == "🤣ab")
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1823,6 +1823,9 @@ test "to_lower" {
   assert_true("Hello, World!".to_lower() == "hello, world!")
   assert_true("🤣A".to_lower() == "🤣a")
   assert_true("A🤣B".to_lower() == "a🤣b")
+  let unpaired = String::from_array([(0xD800).unsafe_to_char(), 'A'])
+  let lowered_unpaired = String::from_array([(0xD800).unsafe_to_char(), 'a'])
+  assert_true(unpaired.to_lower() == lowered_unpaired)
 }
 
 ///|
@@ -1831,6 +1834,9 @@ test "View::to_lower" {
   assert_true("HELLO"[:].to_lower() == "hello")
   assert_true("Hello, World!"[:].to_lower() == "hello, world!")
   assert_true("x🤣ABy"[1:-1].to_lower() == "🤣ab")
+  let unpaired = String::from_array([(0xD800).unsafe_to_char(), 'A'])
+  let lowered_unpaired = String::from_array([(0xD800).unsafe_to_char(), 'a'])
+  assert_true(unpaired[:].to_lower() == lowered_unpaired)
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1739,12 +1739,19 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
   let buf = StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
-    if c.is_ascii_uppercase() {
-      // 'A' is 65 in ASCII, 'a' is 97, the difference is 32
-      buf.write_char((c.to_int() + 32).unsafe_to_char())
+  // Manual UTF-16 code-unit loop avoids the per-call `Iter` heap
+  // allocation that `for c in self.view(...)` triggers on the native
+  // target. Same ASCII-only conversion as before; any non-ASCII unit
+  // (BMP or surrogate half) is written through bit-identically since
+  // `write_char` of a code unit ≤ 0xFFFF emits exactly one UTF-16 unit.
+  let len = self.length()
+  for i = idx; i < len; i = i + 1 {
+    let cui = self.unsafe_get(i).to_int()
+    if cui >= 0x41 && cui <= 0x5A {
+      // 'A' is 65, 'a' is 97; difference is 32.
+      buf.write_char((cui + 32).unsafe_to_char())
     } else {
-      buf.write_char(c)
+      buf.write_char(cui.unsafe_to_char())
     }
   }
   buf.to_string()
@@ -1760,12 +1767,14 @@ pub fn String::to_lower(self : String) -> String {
   let buf = StringBuilder(size_hint=self.length())
   let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
-    if c.is_ascii_uppercase() {
-      // 'A' is 65 in ASCII, 'a' is 97, the difference is 32
-      buf.write_char((c.to_int() + 32).unsafe_to_char())
+  // Manual UTF-16 code-unit loop — see `StringView::to_lower` above.
+  let len = self.length()
+  for i = idx; i < len; i = i + 1 {
+    let cui = self.unsafe_get(i).to_int()
+    if cui >= 0x41 && cui <= 0x5A {
+      buf.write_char((cui + 32).unsafe_to_char())
     } else {
-      buf.write_char(c)
+      buf.write_char(cui.unsafe_to_char())
     }
   }
   buf.to_string()

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1779,14 +1779,14 @@ fn StringBuilder::write_ascii_lowered_substring(
     let code_unit = data.unsafe_get(i).to_int()
     if is_ascii_uppercase_code_unit(code_unit) {
       if segment_start < i {
-        self.write_substring(data, segment_start, i - segment_start)
+        self.write_view(StringView::make_view(data, segment_start, i))
       }
       self.write_ascii_lowercase_code_unit(code_unit)
       segment_start = i + 1
     }
   }
   if segment_start < end {
-    self.write_substring(data, segment_start, end - segment_start)
+    self.write_view(StringView::make_view(data, segment_start, end))
   }
 }
 
@@ -1801,7 +1801,7 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
     return self
   }
   let buf = StringBuilder(size_hint=len)
-  buf.write_substring(data, start, idx)
+  buf.write_view(StringView::make_view(data, start, start + idx))
   buf.write_ascii_lowered_substring(data, start + idx, len - idx)
   buf.to_string()
 }
@@ -1815,7 +1815,7 @@ pub fn String::to_lower(self : String) -> String {
     return self
   }
   let buf = StringBuilder(size_hint=len)
-  buf.write_substring(self, 0, idx)
+  buf.write_view(StringView::make_view(self, 0, idx))
   buf.write_ascii_lowered_substring(self, idx, len - idx)
   buf.to_string()
 }
@@ -1837,7 +1837,9 @@ test "View::to_lower" {
   assert_true("Hello"[:].to_lower() == "hello")
   assert_true("HELLO"[:].to_lower() == "hello")
   assert_true("Hello, World!"[:].to_lower() == "hello, world!")
-  assert_true("x🤣ABy"[1:-1].to_lower() == "🤣ab")
+  assert_true(
+    "x🤣ABy".view(start_offset=1, end_offset=5).to_lower() == "🤣ab",
+  )
   let unpaired = String::from_array([(0xD800).unsafe_to_char(), 'A'])
   let lowered_unpaired = String::from_array([(0xD800).unsafe_to_char(), 'a'])
   assert_true(unpaired[:].to_lower() == lowered_unpaired)


### PR DESCRIPTION
## Summary

`String::to_lower` and `StringView::to_lower` both fall into a
`for c in self.view(start_offset=idx)` loop after the all-lowercase
fast-path guard. On the native target, that for-loop desugars into a
heap-allocated `Iter` (a closure + size_hint pair) — **one per call**.
Combined with the `StringBuilder` and result `String` they already
allocate, every uppercase-containing string passed through `to_lower`
costs one extra heap object.

Replace the iterator loop with a plain UTF-16 code-unit loop over the
view via `unsafe_get`. The conversion is unchanged (still ASCII-only
per the existing `TODO`); any non-ASCII unit — including unpaired
surrogate halves — is written through bit-identically because
`write_char` of a code unit ≤ 0xFFFF emits exactly one UTF-16 unit.

## Numbers

Measured by running mizchi/pprof-mbt's `memprofile-native` against
[`moonbitlang/async`'s `http_server_benchmark`](https://github.com/moonbitlang/async/tree/main/examples/http_server_benchmark)
under `wrk -t 8 -c 128 -d 8s` (~108 k requests served, ~4 headers each
→ ~430 k `to_lower` calls):

| metric | before | after | Δ |
|---|---|---|---|
| total allocations | 14 381 000 | 12 607 200 | **−12.3 % (−1.77 M)** |
| total bytes | 473.67 MB | 459.68 MB | **−3.0 % (−14 MB)** |
| `to_lower` attribution | 8.44 MB / 466 100 allocs | gone from top sites | — |
| `StringView::iter2` (mostly the to_lower loop) | 8.04 MB / 469 300 | 4.0 % / 434 500 | partial |

`StringBuilder::to_string` and the `StringBuilder` itself are still
allocated; only the per-iter overhead goes away.

## Why this is safe

The original iterator decoded the StringView into `Char` values
(BMP and surrogate-pair-merged), then `write_char` would re-emit
them — surrogate pairs as two code units, BMP chars as one.

The new loop iterates UTF-16 code units directly and writes each
through `write_char` of the same code unit. Since every code unit
(including surrogate halves 0xD800..0xDFFF) is ≤ 0xFFFF, the
`<= 0xFFFFU` arm of `write_char` runs and writes the unit verbatim.
Output is byte-identical to the original on all inputs.

ASCII uppercase detection is the same `0x41..=0x5A` range, just
expressed as raw code-unit comparison instead of `Char.is_ascii_uppercase()`.

## Test plan

- [x] `moon test --target native -p builtin` — 2806 / 2806 pass
- [x] `moon test --target wasm-gc -p builtin` — 2848 / 2848 pass
- [x] `moon fmt --check` clean

Same workflow as #3632 / #3633 / #3634 (native alloc profile a real
workload → attack the top site), this time exercising a live HTTP
server instead of a parser bench.