### PR TITLE
refactor(json): use functional loop in lex_skip_whitespace

### DIFF
--- a/json/lex_misc.mbt
+++ b/json/lex_misc.mbt
@@ -126,16 +126,17 @@ test "expect_char with surrogate pair" {
 // `struct.set` against `ctx`.
 fn ParseContext::lex_skip_whitespace(ctx : ParseContext) -> Unit {
   let end = ctx.end_offset
-  let mut offset = ctx.offset
-  while offset < end {
+  ctx.offset = for offset = ctx.offset {
+    if offset >= end {
+      break offset
+    }
     let c = ctx.input.unsafe_get(offset)
     if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
-      offset = offset + 1
+      continue offset + 1
     } else {
-      break
+      break offset
     }
   }
-  ctx.offset = offset
 }
 
 ///|


### PR DESCRIPTION
## What

Rewrites `ParseContext::lex_skip_whitespace` to use a functional `for` loop with a `continue` payload instead of a `while` loop over a `mut offset` local:

```moonbit
for offset = ctx.offset {
  if offset >= end { ctx.offset = offset; break }
  let c = ctx.input.unsafe_get(offset)
  if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
    continue offset + 1
  } else {
    ctx.offset = offset
    break
  }
}
```

## Why

This matches the loop idiom already used elsewhere in the JSON lexer (e.g. `lex_number` carries its accumulator via `continue i + 1, acc * ...`). The behavior is identical: `offset` is still carried in a loop-local binding, the whitespace set stays ASCII-only (RFC 8259), and `ctx.offset` is written exactly once on exit — so the hot-path allocation/`struct.set` properties from #(prev whitespace PR) are preserved.

## Testing

- `moon check json` — clean
- `moon test -p moonbitlang/core/json` — 172 passed, 0 failed (existing `lex_skip_whitespace` coverage unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)