### PR TITLE
refactor(bigint): functional loop for leading-zero scan in from_string

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1157,16 +1157,21 @@ fn BigInt::from_string_radix_pow2(
   if start == len {
     abort("invalid character")
   }
-  let mut first = start
-  while first < len {
+  // Skip leading zeros; `first` is the index of the first significant
+  // digit. Carried as a functional loop variable rather than a mutable
+  // local, yielded via `break first`.
+  let first = for first = start {
+    if first >= len {
+      break first
+    }
     let digit = digit_from_char(input.unsafe_get(first).to_int())
     if digit < 0 || digit >= radix {
       abort("invalid character")
     }
     if digit != 0 {
-      break
+      break first
     }
-    first += 1
+    continue first + 1
   }
   if first == len {
     return zero

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -536,6 +536,49 @@ test "from_string radix 16" {
 }
 
 ///|
+// Regression coverage for the leading-zero scan in
+// `from_string_radix_pow2` (the loop that skips zeros before the first
+// significant digit). Exercises the power-of-2 radix path across the
+// boundary cases of that scan: all-zeros, leading zeros before a value,
+// leading zeros that span more than one limb, and the negative sign.
+test "from_string pow2 radix leading zeros" {
+  // All zeros (any length / radix) must normalize to 0.
+  inspect(@bigint.BigInt::from_string("0", radix=2).to_string(), content="0")
+  inspect(@bigint.BigInt::from_string("0000", radix=2).to_string(), content="0")
+  inspect(
+    @bigint.BigInt::from_string("00000000", radix=16).to_string(),
+    content="0",
+  )
+  inspect(
+    @bigint.BigInt::from_string("-0000", radix=16).to_string(),
+    content="0",
+  )
+  // Leading zeros before a value: the scan must land on the first
+  // significant digit and produce the same result as without them.
+  inspect(@bigint.BigInt::from_string("0010", radix=2).to_string(), content="2")
+  inspect(
+    @bigint.BigInt::from_string("00ff", radix=16).to_string(),
+    content="255",
+  )
+  inspect(
+    @bigint.BigInt::from_string("-00ff", radix=16).to_string(),
+    content="-255",
+  )
+  inspect(@bigint.BigInt::from_string("0007", radix=8).to_string(), content="7")
+  // Many leading zeros (more than one limb's worth) followed by a large
+  // multi-limb value: result must match the zero-free spelling.
+  inspect(
+    @bigint.BigInt::from_string("0000000000000000112210F47DE98115", radix=16).to_string(),
+    content="1234567890123456789",
+  )
+  // A single significant digit after a long run of zeros.
+  inspect(
+    @bigint.BigInt::from_string("00000000000000000000000000000001", radix=16).to_string(),
+    content="1",
+  )
+}
+
+///|
 test "from_string negative zero" {
   let z = @bigint.BigInt::from_string("-0")
   inspect(z.to_string(), content="0")


### PR DESCRIPTION
## What

Two things in `bigint`:

1. **Refactor** the leading-zero scan in `from_string_radix_pow2` from a mutable `while` loop to a functional `for` loop (same pattern as the recent JSON whitespace change). `first` is now a loop-carried variable yielded via `break first` instead of a `let mut` read out after the loop:

   ```moonbit
   let first = for first = start {
     if first >= len { break first }
     let digit = digit_from_char(input.unsafe_get(first).to_int())
     if digit < 0 || digit >= radix { abort("invalid character") }
     if digit != 0 { break first }
     continue first + 1
   }
   ```

   This matches the digit-accumulation loops already in the same file. Behavior is identical: `first` lands on the first significant digit, or `len` for all-zeros input.

2. **Regression tests** for that scan's boundary cases via the public `from_string(_, radix~)` power-of-2 path:
   - all-zeros (including negative-signed) → `0`
   - leading zeros before a value
   - leading zeros spanning more than one limb (must match the zero-free spelling)
   - a single significant digit after a long zero run

## Why

Pure cleanup — removes a mutable local in favor of the codebase's functional-loop idiom — plus locking in the scan's edge-case behavior so the refactor (and future ones) can't silently regress it.

## Testing

`moon test -p moonbitlang/core/bigint --target all`:
- wasm: 154 passed · wasm-gc: 154 passed · js: 130 passed · native: 154 passed (0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)