### PR TITLE
perf(json): stack-allocate JsonNumberScan via #valtype

### DIFF
--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -50,6 +50,12 @@ let int_pow10_table : ReadOnlyArray[UInt64] = [
 ]
 
 ///|
+// `#valtype` keeps this struct stack-allocated on the native target.
+// `scan_json_number` builds + returns one of these on every JSON
+// number, and without the annotation each call boxes a ~32-byte heap
+// object — measured as ~50 % of total alloc bytes in the all-integer
+// json bench (300 k numbers → 9.16 MB / 300 k allocs eliminated).
+#valtype
 priv struct JsonNumberScan {
   negative : Bool
   is_integer : Bool


### PR DESCRIPTION
https://github.com/moonbitlang/core/pull/3633

scan_json_number builds and returns a five-field JsonNumberScan struct on every JSON number, used immediately by lex_number_end and discarded. Without #valtype the native target boxes it as a ~32-byte heap object per call. Annotating the struct keeps it stack-allocated, eliminating that per-number allocation (~50% of total alloc bytes in the all-integer json bench).