### PR TITLE
perf(iterator): Optimize Iter eager consumers

### DIFF
--- a/builtin/array_locals_bench_test.mbt
+++ b/builtin/array_locals_bench_test.mbt
@@ -118,6 +118,28 @@ test "bench FixedArray::fold n=100000" (it : @bench.T) {
 }
 
 ///|
+test "bench FixedArray::iter fold n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.iter().fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench FixedArray::iter each n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() {
+    let mut sum = 0
+    data.iter().each(x => sum = sum + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench FixedArray::iter to_array n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  it.bench(fn() { it.keep(data.iter().to_array()) })
+}
+
+///|
 test "bench FixedArray::rev_fold n=100000" (it : @bench.T) {
   let data = make_array_locals_bench_fixedarray()
   it.bench(fn() { it.keep(data.rev_fold(init=0, (sum, x) => sum + x)) })
@@ -214,6 +236,31 @@ test "bench ArrayView::fold n=100000" (it : @bench.T) {
   let data = make_array_locals_bench_fixedarray()
   let view = data[:]
   it.bench(fn() { it.keep(view.fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench ArrayView::iter fold n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.iter().fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench ArrayView::iter each n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() {
+    let mut sum = 0
+    view.iter().each(x => sum = sum + x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::iter to_array n=100000" (it : @bench.T) {
+  let data = make_array_locals_bench_fixedarray()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.iter().to_array()) })
 }
 
 ///|

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -364,11 +364,98 @@ test "size_hint" {
   )
   debug_inspect(too_small.collect(), content="[1, 2, 3]")
   debug_inspect(too_small.size_hint(), content="Some(0)")
+  let mut j = 0
+  let underflow = Iter::new(
+    fn() {
+      if j < 3 {
+        j += 1
+        Some(j)
+      } else {
+        None
+      }
+    },
+    size_hint=1,
+  )
+  debug_inspect(underflow.next(), content="Some(1)")
+  debug_inspect(underflow.size_hint(), content="Some(0)")
+  debug_inspect(underflow.next(), content="Some(2)")
+  debug_inspect(underflow.size_hint(), content="None")
+  debug_inspect(underflow.collect(), content="[3]")
+  debug_inspect(underflow.size_hint(), content="Some(0)")
   let too_large : Iter[Int] = Iter::new(() => None, size_hint=3)
   debug_inspect(too_large.next(), content="None")
   debug_inspect(too_large.size_hint(), content="Some(0)")
   let negative_hint : Iter[Int] = Iter::new(() => None, size_hint=-1)
   debug_inspect(negative_hint.size_hint(), content="Some(0)")
+}
+
+///|
+test "size_hint during eager consumers" {
+  let each_iter = [1, 2, 3].iter()
+  let each_hints = []
+  each_iter.each(_ => each_hints.push(each_iter.size_hint()))
+  debug_inspect(each_hints, content="[Some(2), Some(1), Some(0)]")
+  debug_inspect(each_iter.size_hint(), content="Some(0)")
+  let fold_iter = [1, 2, 3].iter()
+  let fold_hints = []
+  let sum = fold_iter.fold(init=0, (acc, x) => {
+    fold_hints.push(fold_iter.size_hint())
+    acc + x
+  })
+  debug_inspect(sum, content="6")
+  debug_inspect(fold_hints, content="[Some(2), Some(1), Some(0)]")
+  debug_inspect(fold_iter.size_hint(), content="Some(0)")
+  let eachi_iter = [1, 2, 3].iter()
+  let eachi_hints = []
+  eachi_iter.eachi((_, _) => eachi_hints.push(eachi_iter.size_hint()))
+  debug_inspect(eachi_hints, content="[Some(2), Some(1), Some(0)]")
+  debug_inspect(eachi_iter.size_hint(), content="Some(0)")
+  let count_iter = [1, 2, 3].iter()
+  debug_inspect(count_iter.count(), content="3")
+  debug_inspect(count_iter.size_hint(), content="Some(0)")
+  let to_array_iter = [1, 2, 3].iter()
+  debug_inspect(to_array_iter.to_array(), content="[1, 2, 3]")
+  debug_inspect(to_array_iter.size_hint(), content="Some(0)")
+  let mut j = 0
+  let underflow_iter = Iter::new(
+    fn() {
+      if j < 3 {
+        j += 1
+        Some(j)
+      } else {
+        None
+      }
+    },
+    size_hint=1,
+  )
+  let underflow_hints = []
+  underflow_iter.each(_ => underflow_hints.push(underflow_iter.size_hint()))
+  debug_inspect(underflow_hints, content="[Some(0), None, None]")
+  debug_inspect(underflow_iter.size_hint(), content="Some(0)")
+  let any_iter = [1, 2, 3].iter()
+  debug_inspect(any_iter.any(x => x == 2), content="true")
+  debug_inspect(any_iter.size_hint(), content="Some(1)")
+  let all_iter = [1, 2, 3].iter()
+  debug_inspect(all_iter.all(x => x < 2), content="false")
+  debug_inspect(all_iter.size_hint(), content="Some(1)")
+  let find_iter = [1, 2, 3].iter()
+  debug_inspect(find_iter.find_first(x => x == 2), content="Some(2)")
+  debug_inspect(find_iter.size_hint(), content="Some(1)")
+  let contains_iter = [1, 2, 3].iter()
+  debug_inspect(contains_iter.contains(2), content="true")
+  debug_inspect(contains_iter.size_hint(), content="Some(1)")
+  let nth_iter = [1, 2, 3].iter()
+  debug_inspect(nth_iter.nth(1), content="Some(2)")
+  debug_inspect(nth_iter.size_hint(), content="Some(1)")
+  let last_iter = [1, 2, 3].iter()
+  debug_inspect(last_iter.last(), content="Some(3)")
+  debug_inspect(last_iter.size_hint(), content="Some(0)")
+  let maximum_iter = [1, 3, 2].iter()
+  debug_inspect(maximum_iter.maximum(), content="Some(3)")
+  debug_inspect(maximum_iter.size_hint(), content="Some(0)")
+  let minimum_iter = [2, 1, 3].iter()
+  debug_inspect(minimum_iter.minimum(), content="Some(1)")
+  debug_inspect(minimum_iter.size_hint(), content="Some(0)")
 }
 
 ///|
@@ -1003,6 +1090,11 @@ test "@builtin.Iter::maximum" {
   // Empty iter should return None
   let empty_iter : Iter[Int] = Iter::empty()
   debug_inspect(empty_iter.maximum(), content="None")
+  debug_inspect([1.0, @double.not_a_number].iter().maximum(), content="Some(1)")
+  debug_inspect(
+    [@double.not_a_number, 1.0].iter().maximum(),
+    content="Some(NaN)",
+  )
 }
 
 ///|
@@ -1018,6 +1110,11 @@ test "@builtin.Iter::minimum" {
   // Test with empty sequence
   let empty : Iter[Int] = Iter::empty()
   debug_inspect(empty.minimum(), content="None")
+  debug_inspect([1.0, @double.not_a_number].iter().minimum(), content="Some(1)")
+  debug_inspect(
+    [@double.not_a_number, 1.0].iter().minimum(),
+    content="Some(NaN)",
+  )
 }
 
 ///|

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -49,8 +49,11 @@ pub fn[X] Iter::next(self : Iter[X]) -> X? {
 ///|
 /// Update `size_hint` after an element has been consumed.
 ///
-/// Eager consumers call the underlying iterator function directly to avoid
-/// `next` call overhead, but share this bookkeeping with `next`.
+/// Hot eager consumers call the underlying iterator function directly as a
+/// performance-only shortcut: they intentionally avoid one extra `next` call
+/// per element, but must route every successful pull through this helper and
+/// every exhausted pull through `finish_size_hint`, matching `next`'s
+/// bookkeeping contract.
 #inline
 fn[X] Iter::consume_size_hint(self : Iter[X]) -> Unit {
   match self.size_hint {
@@ -141,7 +144,7 @@ pub impl[X : ToJson] ToJson for Iter[X] with fn to_json(self) {
 /// - `f`: A function that takes an element of type `X` and returns `Unit`. This function is applied to each element of the iterator.
 #locals(f)
 pub fn[X] Iter::each(self : Iter[X], f : (X) -> Unit raise?) -> Unit raise? {
-  // Hot eager consumers avoid `next` call overhead but share its bookkeeping.
+  // See `consume_size_hint` for why hot eager consumers call `self.f` directly.
   let next_fn = self.f
   for next = next_fn() {
     match next {

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -296,11 +296,7 @@ pub fn[X, R] Iter::fold(
 /// Returns the number of elements in the iterator.
 #alias(length)
 pub fn[X] Iter::count(self : Iter[X]) -> Int {
-  for _ in self; count = 0 {
-    continue count + 1
-  } nobreak {
-    count
-  }
+  self.fold(init=0, (count, _) => count + 1)
 }
 
 ///|

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -39,13 +39,31 @@ priv enum IntersperseState[X] {
 #alias(head)
 pub fn[X] Iter::next(self : Iter[X]) -> X? {
   let result = (self.f)()
-  match (result, self.size_hint) {
-    (Some(_), Some(n)) =>
-      self.size_hint = if n > 0 { Some(n - 1) } else { Some(0) }
-    (None, _) => self.size_hint = Some(0)
-    _ => ()
+  match result {
+    Some(_) => self.consume_size_hint()
+    None => self.finish_size_hint()
   }
   result
+}
+
+///|
+/// Update `size_hint` after an element has been consumed.
+///
+/// Eager consumers call the underlying iterator function directly to avoid
+/// `next` call overhead, but share this bookkeeping with `next`.
+#inline
+fn[X] Iter::consume_size_hint(self : Iter[X]) -> Unit {
+  match self.size_hint {
+    Some(n) if n > 0 => self.size_hint = Some(n - 1)
+    Some(_) => self.size_hint = None
+    None => ()
+  }
+}
+
+///|
+#inline
+fn[X] Iter::finish_size_hint(self : Iter[X]) -> Unit {
+  self.size_hint = Some(0)
 }
 
 ///|
@@ -123,8 +141,20 @@ pub impl[X : ToJson] ToJson for Iter[X] with fn to_json(self) {
 /// - `f`: A function that takes an element of type `X` and returns `Unit`. This function is applied to each element of the iterator.
 #locals(f)
 pub fn[X] Iter::each(self : Iter[X], f : (X) -> Unit raise?) -> Unit raise? {
-  while self.next() is Some(x) {
-    f(x)
+  // Hot eager consumers avoid `next` call overhead but share its bookkeeping.
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        f(x)
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break
+      }
+    }
   }
 }
 
@@ -133,12 +163,21 @@ pub fn[X] Iter::each(self : Iter[X], f : (X) -> Unit raise?) -> Unit raise? {
 /// Function `any`.
 #locals(f)
 pub fn[X] Iter::any(self : Iter[X], f : (X) -> Bool) -> Bool {
-  while self.next() is Some(x) {
-    if f(x) {
-      break true
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        if f(x) {
+          break true
+        }
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break false
+      }
     }
-  } nobreak {
-    false
   }
 }
 
@@ -147,10 +186,19 @@ pub fn[X] Iter::any(self : Iter[X], f : (X) -> Bool) -> Bool {
 /// Function `all`.
 #locals(f)
 pub fn[X] Iter::all(self : Iter[X], f : (X) -> Bool) -> Bool {
-  while self.next() is Some(x) {
-    guard f(x) else { break false }
-  } nobreak {
-    true
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        guard f(x) else { break false }
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break true
+      }
+    }
   }
 }
 
@@ -171,9 +219,20 @@ pub fn[X] Iter::eachi(
   f : (Int, X) -> Unit raise?,
 ) -> Unit raise? {
   let mut i = 0
-  while self.next() is Some(x) {
-    f(i, x)
-    i += 1
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        f(i, x)
+        i += 1
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break
+      }
+    }
   }
 }
 
@@ -201,8 +260,19 @@ pub fn[X, R] Iter::fold(
   f : (R, X) -> R raise?,
 ) -> R raise? {
   let mut acc = init
-  while self.next() is Some(x) {
-    acc = f(acc, x)
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        acc = f(acc, x)
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break
+      }
+    }
   }
   acc
 }
@@ -725,12 +795,21 @@ pub fn[X] Iter::drop_while(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
 /// # Note
 /// The iterator `self` will advance past the returned element.
 pub fn[X] Iter::find_first(self : Iter[X], f : (X) -> Bool) -> X? {
-  while self.next() is Some(x) {
-    if f(x) {
-      break Some(x)
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        if f(x) {
+          break Some(x)
+        }
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break None
+      }
     }
-  } nobreak {
-    None
   }
 }
 
@@ -844,8 +923,19 @@ pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
     Some(n) => Array::new(capacity=n)
     None => []
   }
-  while self.next() is Some(x) {
-    result.push(x)
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        result.push(x)
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break
+      }
+    }
   }
   result
 }
@@ -879,12 +969,22 @@ pub fn[X] Iter::iter2(self : Iter[X]) -> Iter2[Int, X] {
 /// Returns the last element of the iterator, or `None` if the iterator is empty.
 /// The old iterator `self` must not be used again after calling `last`.
 pub fn[X] Iter::last(self : Iter[X]) -> X? {
-  for x = (None : X?), y = self.next() {
-    match (x, y) {
-      (last, None) => break last
-      (_, Some(_) as x) => continue x, self.next()
+  let mut last = None
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(_) as x => {
+        self.consume_size_hint()
+        last = x
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break
+      }
     }
   }
+  last
 }
 
 ///|
@@ -1011,12 +1111,21 @@ pub fn[X] Iter::view(self : Iter[X], start? : Int = 0, end? : Int) -> Iter[X] {
 /// # Note
 /// The old iterator `self` will advance past the searched element.
 pub fn[X : Eq] Iter::contains(self : Iter[X], value : X) -> Bool {
-  while self.next() is Some(x) {
-    if x == value {
-      break true
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        if x == value {
+          break true
+        }
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break false
+      }
     }
-  } nobreak {
-    false
   }
 }
 
@@ -1026,21 +1135,49 @@ pub fn[X : Eq] Iter::contains(self : Iter[X], value : X) -> Bool {
 /// The iterator `self` will advance past the returned element.
 pub fn[X] Iter::nth(self : Iter[X], n : Int) -> X? {
   guard n >= 0 else { None }
-  for _ in 0..<n {
-    guard self.next() is Some(_) else { break None }
-  } nobreak {
-    self.next()
+  let mut i = 0
+  let next_fn = self.f
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        if i == n {
+          break Some(x)
+        }
+        i += 1
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break None
+      }
+    }
   }
 }
 
 ///|
 /// Return the maximum element, or `None` if empty.
 pub fn[X : Compare] Iter::maximum(self : Iter[X]) -> X? {
-  guard self.next() is Some(x) else { return None }
+  let next_fn = self.f
+  guard next_fn() is Some(x) else {
+    self.finish_size_hint()
+    return None
+  }
+  self.consume_size_hint()
   let mut res = x
-  while self.next() is Some(x) {
-    if x > res {
-      res = x
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        if x > res {
+          res = x
+        }
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break
+      }
     }
   }
   Some(res)
@@ -1049,11 +1186,26 @@ pub fn[X : Compare] Iter::maximum(self : Iter[X]) -> X? {
 ///|
 /// Return the minimum element, or `None` if empty.
 pub fn[X : Compare] Iter::minimum(self : Iter[X]) -> X? {
-  guard self.next() is Some(x) else { return None }
+  let next_fn = self.f
+  guard next_fn() is Some(x) else {
+    self.finish_size_hint()
+    return None
+  }
+  self.consume_size_hint()
   let mut res = x
-  while self.next() is Some(x) {
-    if x < res {
-      res = x
+  for next = next_fn() {
+    match next {
+      Some(x) => {
+        self.consume_size_hint()
+        if x < res {
+          res = x
+        }
+        continue next_fn()
+      }
+      None => {
+        self.finish_size_hint()
+        break
+      }
     }
   }
   Some(res)


### PR DESCRIPTION
## Summary

This PR optimizes eager `Iter` consumers by avoiding the extra `self.next()` call inside hot loops.

Consumers such as `each`, `fold`, `to_array`, `find_first`, `contains`, `nth`, `maximum`, and `minimum` now call the iterator's internal `self.f` directly and use the same `#inline` size-hint bookkeeping helpers as `next`. This keeps the observable `size_hint` behavior while reducing call overhead, especially for `iter().fold` on wasm-gc.

## Changes

- Optimize eager `Iter` consumers to call `self.f` directly in hot loops
- Centralize `size_hint` bookkeeping in private `#inline` helpers shared with `next`
- Mark under-reported `size_hint` values as `None` after underflow until exhaustion
- Preserve `maximum` / `minimum` NaN behavior by keeping the old `x > res` / `x < res` update conditions
- Keep `count` delegated to `fold`
- Add tests for `size_hint` behavior during eager consumers
- Add `FixedArray` / `ArrayView` iterator benchmarks for `fold`, `each`, and `to_array`

## Benchmark

`wasm-gc --release`, `n=100000`

| benchmark | before | after |
|---|---:|---:|
| `FixedArray::iter fold` | 232.38 us | 106.13 us |
| `FixedArray::iter each` | 117.92 us | 114.23 us |
| `FixedArray::iter to_array` | 337.51 us | 283.56 us |
| `ArrayView::iter fold` | 222.62 us | 109.31 us |
| `ArrayView::iter each` | 119.45 us | 115.16 us |
| `ArrayView::iter to_array` | 364.15 us | 284.41 us |
| `Vector::iter fold` | 363.82 us | 336.28 us |
| `Vector::iter each` | 375.15 us | 336.11 us |
| `Vector::iter to_array` | 463.91 us | 433.70 us |

I also checked RSS with `hyperfine` + `/usr/bin/time -l`. The measurement covers the whole `moon bench` process rather than an individual MoonBit function; median RSS was about 1.2-1.6 MiB higher than baseline, with no large regression observed.

## Validation

```sh
moon fmt
moon info
moon check
moon test
moon test builtin --target wasm-gc
moon test builtin --target wasm
git diff --check
```

`moon test`: 6510 passed.

## Review notes

The eager consumers intentionally bypass `next` to avoid the extra method call in hot loops. To keep the code paths aligned, `next` and the eager consumers now share the same private `#inline` helpers for `size_hint` updates.
