### PR TITLE
[codex] Remove try? usage in bytes

### DIFF
--- a/bytes/bitstring_pcap_test.mbt
+++ b/bytes/bitstring_pcap_test.mbt
@@ -114,7 +114,7 @@ fn pcap_ipv4_test(ipv4 : BytesView) -> Unit raise {
 
 ///|
 test "pcap_test" {
-  debug_inspect(try? pcap_test(data), content="Ok(())")
+  pcap_test(data)
 }
 
 ///|

--- a/bytes/moon.pkg
+++ b/bytes/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/core/uint64",
   "moonbitlang/core/test",
   "moonbitlang/core/quickcheck",
-  "moonbitlang/core/error",
   "moonbitlang/core/json",
   "moonbitlang/core/float",
   "moonbitlang/core/debug",


### PR DESCRIPTION
## Summary

- Remove the remaining `try?` usage from the `bytes` package tests.
- Let the success-path pcap test call the raising helper directly.
- Drop the now-unused test-only `error` import.

## Validation

- `moon test bytes`
- `moon check bytes --target all`
- `moon fmt`
- `moon info` (no `bytes/pkg.generated.mbti` diff)
- `git diff --check`