### PR TITLE
[codex] Remove try? usage in deque

### DIFF
--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -283,10 +283,11 @@ test "from_json_tail_bug" {
 ///|
 test "from_json rejects non-array" {
   let bad_json : Json = { "a": 1 }
-  let result : Result[@deque.Deque[Int], @json.JsonDecodeError] = try? @json.from_json(
-    bad_json,
-  )
-  inspect(result is Err(_), content="true")
+  try ignore((@json.from_json(bad_json) : @deque.Deque[Int])) catch {
+    _ => ()
+  } noraise {
+    _ => fail("expected Deque::from_json failure")
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Remove the remaining `try?` usage from the `deque` package tests.
- Assert the expected `from_json` failure with explicit `try/catch/noraise` instead of wrapping the call in `Result`.

## Validation

- `moon test deque`
- `moon check deque --target all`
- `moon fmt`
- `moon info` (no `deque/pkg.generated.mbti` diff)
- `git diff --check`