### PR TITLE
perf(list): add #inline to List::new

### DIFF
--- a/list/list.mbt
+++ b/list/list.mbt
@@ -26,6 +26,7 @@
 #alias(empty)
 #as_free_fn
 #as_free_fn(empty)
+#inline
 pub fn[A] List::new() -> List[A] {
   Empty
 }


### PR DESCRIPTION
Adds an `#inline` attribute to `List::new`, a trivial constructor that just returns `Empty`. Inlining lets the compiler elide the call at use sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)