### PR TITLE
Add String code_units views

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -721,6 +721,7 @@ pub fn String::before(String, StringView) -> StringView?
 pub fn String::char_length(String, start_offset? : Int, end_offset? : Int) -> Int
 pub fn String::char_length_eq(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
 pub fn String::char_length_ge(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
+pub fn String::code_units(String) -> ArrayView[UInt16]
 pub fn String::compare_ignore_ascii_case(String, String) -> Int
 pub fn String::contains(String, StringView) -> Bool
 pub fn String::contains_any(String, chars~ : StringView) -> Bool
@@ -1034,6 +1035,7 @@ pub fn StringView::before(Self, Self) -> Self?
 pub fn StringView::char_length(Self) -> Int
 pub fn StringView::char_length_eq(Self, Int) -> Bool
 pub fn StringView::char_length_ge(Self, Int) -> Bool
+pub fn StringView::code_units(Self) -> ArrayView[UInt16]
 pub fn StringView::compare_ignore_ascii_case(Self, Self) -> Int
 pub fn StringView::contains(Self, Self) -> Bool
 pub fn StringView::contains_any(Self, chars~ : Self) -> Bool

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -228,6 +228,15 @@ pub fn String::to_array(self : String) -> Array[Char] {
 }
 
 ///|
+/// Returns an `ArrayView` containing the UTF-16 code units of the string.
+///
+/// This method yields code units, not Unicode characters. Surrogate pairs are
+/// represented as two `UInt16` values.
+pub fn String::code_units(self : String) -> ArrayView[UInt16] {
+  Array::makei(self.length(), i => self.unsafe_get(i))[:]
+}
+
+///|
 /// Returns an iterator over the Unicode characters in the string.
 ///
 /// Note: This iterator yields Unicode characters, not Utf16 code units.

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -138,6 +138,21 @@ test "code_unit_at" {
 }
 
 ///|
+test "String::code_units" {
+  let units = "A😀B".code_units()
+  inspect(units.length(), content="4")
+  inspect(units.unsafe_get(0), content="65")
+  inspect(units.unsafe_get(1), content="55357")
+  inspect(units.unsafe_get(2), content="56832")
+  inspect(units.unsafe_get(3), content="66")
+  let mut sum = 0
+  for unit in units {
+    sum += unit.to_int()
+  }
+  inspect(sum, content="112320")
+}
+
+///|
 test "String default and to_array" {
   inspect(String::default(), content="")
   let chars = "Hi".to_array()

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -130,6 +130,15 @@ pub fn StringView::unsafe_get(self : StringView, index : Int) -> UInt16 {
 }
 
 ///|
+/// Returns an `ArrayView` containing the UTF-16 code units of the string view.
+///
+/// This method yields code units, not Unicode characters. Surrogate pairs are
+/// represented as two `UInt16` values.
+pub fn StringView::code_units(self : StringView) -> ArrayView[UInt16] {
+  Array::makei(self.length(), i => self.unsafe_get(i))[:]
+}
+
+///|
 /// Returns the charcode(code unit) at the given index without checking if the
 /// index is within bounds.
 /// 

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -66,6 +66,22 @@ test "unsafe_get" {
 }
 
 ///|
+test "StringView::code_units" {
+  let view = "ZA😀BY"[1:-1]
+  let units = view.code_units()
+  inspect(units.length(), content="4")
+  inspect(units.unsafe_get(0), content="65")
+  inspect(units.unsafe_get(1), content="55357")
+  inspect(units.unsafe_get(2), content="56832")
+  inspect(units.unsafe_get(3), content="66")
+  let mut sum = 0
+  for unit in units {
+    sum += unit.to_int()
+  }
+  inspect(sum, content="112320")
+}
+
+///|
 test "StringView core operations" {
   let view = "ab😀c".view(start_offset=1)
   inspect(view.char_length(), content="3")


### PR DESCRIPTION
## Summary

- Add `String::code_units() -> ArrayView[UInt16]`
- Add `StringView::code_units() -> ArrayView[UInt16]`
- Implement both with the initial copying path by materializing `Array[UInt16]` and returning its `ArrayView`
- Add tests for length, surrogate-pair code units, and `for .. in` iteration over the returned view

## Naming

The method is named `code_units()` instead of `arrayview()` or `as_arrayview()` because the call site should describe the semantic contents rather than the storage/view representation. `String::iter()` already means Unicode `Char` iteration, while existing APIs such as `code_unit_at` use “code unit” for UTF-16 unit access. `str.code_units()` makes it clear that surrogate pairs are yielded as two `UInt16` values, and it leaves room for the implementation to move from today’s copied `ArrayView` to backend intrinsics without making the public name representation-driven.

## Testing

- `moon check`
- `moon test builtin`
- `moon fmt`
- `moon info`