### PR TITLE
add `@test.expect_error` for testing program that should raise error

### DIFF
--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -19,6 +19,9 @@ pub fn[T : @debug.Debug] assert_not_same_object(T, T, loc~ : SourceLoc) -> Unit 
 pub fn[T : @debug.Debug] assert_same_object(T, T, loc~ : SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
+pub fn[T, E : Error] expect_error(() -> T raise E, loc~ : SourceLoc) -> E raise Failure
+
+#callsite(autofill(loc))
 pub fn[T] fail(StringView, loc~ : SourceLoc) -> T raise
 
 #alias(is_not, deprecated)

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -191,3 +191,20 @@ pub fn Test::snapshot(
 pub fn Test::name(self : Self) -> String {
   self.name
 }
+
+///|
+#callsite(autofill(loc))
+pub fn[T, E : Error] expect_error(
+  f : () -> T raise E,
+  loc~ : SourceLoc,
+) -> E raise Failure {
+  try f() catch {
+    err => err
+  } noraise {
+    _ =>
+      @builtin.fail(
+        "expected error, but program succeed without raising anything",
+        loc~,
+      )
+  }
+}

--- a/test/test_test.mbt
+++ b/test/test_test.mbt
@@ -47,3 +47,26 @@ test "Test name" {
   let t = @test.new("sample")
   inspect(t.name(), content="sample")
 }
+
+///|
+fn maybe_raise(should_raise : Bool) -> Unit raise {
+  if should_raise {
+    raise Failure::Failure("failure")
+  }
+}
+
+///|
+test "expect_error" {
+  inspect(
+    @test.expect_error(() => maybe_raise(true)),
+    content=(
+      #|Failure(failure)
+    ),
+  )
+  inspect(
+    @test.expect_error(() => @test.expect_error(() => maybe_raise(false))),
+    content=(
+      #|Failure(test/test_test.mbt:67:30-67:74@moonbitlang/core FAILED: expected error, but program succeed without raising anything)
+    ),
+  )
+}


### PR DESCRIPTION
The next version of MoonBit would deprecate the `try?` syntax, because it is often misused. MoonBit favor native `raise` instead of `Result` for error handling. The main "valid" usage of `try?` is testing program that should raise an error, because the result of `try?` can be supplied to `debug_inspect` etc. directly.

As a compensation of deprecating `try?`, this PR add a tiny helper `@test.expect_error`, which accepts a callback that is expected to raise an error. If the callback indeed raise an error, the error value will be returned, and the result can be further refined using `inspect`, `assert_true(.. is MyErr(_))` etc.. If the callback does not raise any error, `@test.expect_error` will fail with location information of the `@test.expect_error` call, failing the test and letting user know what is happening.