### PR TITLE
feat(test): add assert_raise and expect_error helpers

### DIFF
--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -16,7 +16,13 @@ pub fn[T : Eq + @debug.Debug] assert_not_eq(T, T, msg? : String, loc~ : SourceLo
 pub fn[T : @debug.Debug] assert_not_same_object(T, T, loc~ : SourceLoc) -> Unit raise
 
 #callsite(autofill(loc))
+pub fn[T, E : Error] assert_raise(() -> T raise E, loc~ : SourceLoc) -> Unit raise
+
+#callsite(autofill(loc))
 pub fn[T : @debug.Debug] assert_same_object(T, T, loc~ : SourceLoc) -> Unit raise
+
+#callsite(autofill(loc))
+pub fn[T, E : Error] expect_error(() -> T raise E, loc~ : SourceLoc) -> E raise
 
 #callsite(autofill(loc))
 pub fn[T] fail(StringView, loc~ : SourceLoc) -> T raise

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -133,11 +133,58 @@ pub fn[T : Debug] assert_not_same_object(
 
 ///|
 /// Expected to be used in test blocks, don't catch this error.
-///  
+///
 /// Produces an error message similar to @builtin.fail.
 #callsite(autofill(loc))
 pub fn[T] fail(msg : StringView, loc~ : SourceLoc) -> T raise {
   @builtin.fail(msg, loc~)
+}
+
+///|
+/// Assert that the given callback raises an error.
+///
+/// Use this when you only care that the callback raises, not what was raised.
+/// If you need to inspect the error value, use `@test.expect_error` instead.
+///
+/// If the callback does not raise, the test fails at the call site of
+/// `assert_raise`.
+#callsite(autofill(loc))
+pub fn[T, E : Error] assert_raise(
+  f : () -> T raise E,
+  loc~ : SourceLoc,
+) -> Unit raise {
+  try f() catch {
+    _ => ()
+  } noraise {
+    _ =>
+      @builtin.fail(
+        "expected error, but program succeed without raising anything",
+        loc~,
+      )
+  }
+}
+
+///|
+/// Run the given callback and return the error it raises, so the caller can
+/// further interrogate it (`inspect`, `guard ... is`, `assert_true`, etc.).
+///
+/// If the callback does not raise, the test fails at the call site of
+/// `expect_error`. If you do not need the error value, prefer
+/// `@test.assert_raise`.
+#callsite(autofill(loc))
+pub fn[T, E : Error] expect_error(
+  f : () -> T raise E,
+  loc~ : SourceLoc,
+) -> E raise {
+  try f() catch {
+    err => err
+  } noraise {
+    _ =>
+      @builtin.fail(
+        "expected error, but program succeed without raising anything",
+        loc~,
+      )
+  }
 }
 
 ///|

--- a/test/test_test.mbt
+++ b/test/test_test.mbt
@@ -47,3 +47,60 @@ test "Test name" {
   let t = @test.new("sample")
   inspect(t.name(), content="sample")
 }
+
+///|
+suberror MyError {
+  NotFound(String)
+  Invalid(reason~ : String)
+} derive(Debug)
+
+///|
+fn maybe_raise(should_raise : Bool) -> Unit raise MyError {
+  if should_raise {
+    raise MyError::NotFound("file.txt")
+  }
+}
+
+///|
+fn raise_invalid() -> Unit raise MyError {
+  raise MyError::Invalid(reason="bad input")
+}
+
+///|
+test "assert_raise passes when the callback raises" {
+  @test.assert_raise(() => maybe_raise(true))
+}
+
+///|
+test "panic assert_raise fails when the callback does not raise" {
+  @test.assert_raise(() => maybe_raise(false))
+}
+
+///|
+test "expect_error returns the raised error" {
+  let err = @test.expect_error(() => maybe_raise(true))
+  debug_inspect(
+    err,
+    content=(
+      #|NotFound("file.txt")
+    ),
+  )
+}
+
+///|
+test "expect_error result composes with guard ... is" {
+  guard @test.expect_error(() => maybe_raise(true)) is NotFound(_) else {
+    @test.fail("expected NotFound variant")
+  }
+}
+
+///|
+test "expect_error result composes with assert_true(... is ...)" {
+  let err = @test.expect_error(raise_invalid)
+  assert_true(err is Invalid(reason=_))
+}
+
+///|
+test "panic expect_error fails when the callback does not raise" {
+  let _ = @test.expect_error(() => maybe_raise(false))
+}


### PR DESCRIPTION
## Summary

Alternative design for the testing-error-helpers discussion in #3652, splitting the use case in two so the type doesn't have to do double duty.

- **`@test.assert_raise(f) -> Unit raise`** — for "I just want to assert it raises." No return value, no `let _ = ` ceremony at the call site.
- **`@test.expect_error(f) -> E raise`** — for "give me the error so I can interrogate it." Returns the raised error so the caller can compose directly with `inspect`, `guard ... is`, or `assert_true(... is ...)`.

Both helpers fail at the call site (with `loc` autofilled) when the callback does not raise. Both use open `raise` to match the existing test-helper convention (`fail`, `assert_same_object`).

### Why two functions instead of one

`expect_error` alone (as in #3652) forces every caller to bind or discard the returned error, even when they only care that *something* was raised. Splitting lets each call site read directly:

```moonbit
// don't care what was raised
@test.assert_raise(() => open(path))

// do care
guard @test.expect_error(() => open(path)) is File_not_found(_) else { ... }
let err = @test.expect_error(() => parse(input))
assert_true(err is InvalidSyntax(_))
```

### Why `E raise` (open) instead of `E raise Failure`

The narrower `raise Failure` bound buys nothing for callers (they propagate up to the test runner either way) and is inconsistent with the surrounding `@test.fail` / `@test.assert_same_object` signatures. Open `raise` leaves room to change the internal failure type later without it being a breaking change.

## Test plan

- [x] `assert_raise` passes when the callback raises
- [x] `assert_raise` fails (panic test) when the callback does not raise
- [x] `expect_error` returns the raised error (snapshot via `debug_inspect`)
- [x] `expect_error` composes with `guard ... is Pattern`
- [x] `expect_error` composes with `assert_true(err is Pattern)` (including labeled-field patterns)
- [x] `expect_error` fails (panic test) when the callback does not raise
- [x] `moon check`, `moon test test`, `moon fmt`, `moon info` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)