### PR TITLE
refactor(bench): rename Bench::new to Bench::Bench

### DIFF
--- a/bench/README.mbt.md
+++ b/bench/README.mbt.md
@@ -31,7 +31,7 @@ Use the `T` type to collect multiple benchmarks:
 ///|
 #skip("slow tests")
 test "benchmark collection" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Add multiple benchmarks to the collection
   bencher.bench(name="array_creation", fn() {
@@ -62,7 +62,7 @@ Compare the performance of different implementations:
 ///|
 #skip("slow tests")
 test "algorithm comparison" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Benchmark linear search
   bencher.bench(name="linear_search", fn() {
@@ -96,7 +96,7 @@ Benchmark different data structure operations:
 ///|
 #skip("slow tests")
 test "data structure benchmarks" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Benchmark Array operations
   bencher.bench(name="array_append", fn() {
@@ -128,7 +128,7 @@ Measure string manipulation performance:
 ///|
 #skip("slow tests")
 test "string benchmarks" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Benchmark string concatenation
   bencher.bench(name="string_concat", fn() {
@@ -159,7 +159,7 @@ Use `keep` to prevent compiler optimizations from eliminating benchmarked code:
 ///|
 #skip("slow tests")
 test "preventing optimization" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
   bencher.bench(name="with_keep", fn() {
     let result = Array::makei(5, fn(i) { i * i })
     // Prevent the compiler from optimizing away the computation
@@ -178,7 +178,7 @@ Control the number of benchmark iterations:
 ///|
 #skip("slow tests")
 test "iteration control" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Run with more iterations for more stable results
   bencher.bench(
@@ -216,7 +216,7 @@ test "iteration control" {
 ///|
 #skip("slow tests")
 test "isolation example" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Good: Measure only the operation of interest
   let data = Array::makei(10, fn(i) { i }) // Setup outside benchmark
@@ -238,7 +238,7 @@ test "isolation example" {
 ///|
 #skip("slow tests")
 test "warmup example" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
   fn expensive_operation() -> Int {
     let mut result = 0
     for i in 0..<5 {
@@ -268,7 +268,7 @@ test "warmup example" {
 ///|
 #skip("slow tests")
 test "meaningful names" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Good: Descriptive names that explain what's being measured
   bencher.bench(name="array_insert_10_items", fn() {
@@ -305,7 +305,7 @@ Benchmarks can be integrated into your testing workflow:
 ///|
 #skip("slow tests")
 test "performance regression test" {
-  let bencher = @bench.new()
+  let bencher = @bench.Bench()
 
   // Benchmark a critical path
   bencher.bench(name="critical_algorithm", fn() {

--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -144,7 +144,7 @@ test "bench - Summary struct properties" {
 ///|
 #skip("slow benchmarking test")
 test "bench - T struct and bench method" {
-  let bench_obj = new()
+  let bench_obj = Bench()
 
   // Ensure the buffer is initially empty
   inspect(bench_obj.buffer.is_empty(), content="true")
@@ -199,7 +199,7 @@ test "bench - monotonic clock functionality" {
 
 ///|
 test "bench - keep stores value" {
-  let b = new()
+  let b = Bench()
   @test.assert_eq(b.summaries.length(), 0)
   b.keep(123)
   @test.assert_eq(b.summaries.length(), 0)

--- a/bench/bench_test.mbt
+++ b/bench/bench_test.mbt
@@ -29,7 +29,7 @@ test "bench single_bench minimal" {
 
 ///|
 test "bench buffer writes with multiple samples" {
-  let bench = @bench.Bench::new()
+  let bench = @bench.Bench()
   bench.bench(() => ignore(1 + 1), name="first", count=1)
   bench.bench(() => ignore(2 + 2), name="second", count=1)
   inspect(bench.dump_summaries().contains(","), content="true")
@@ -37,7 +37,7 @@ test "bench buffer writes with multiple samples" {
 
 ///|
 test "Debug for Bench and Timestamp" {
-  let bench = @bench.Bench::new()
+  let bench = @bench.Bench()
   @debug.debug_inspect(bench, content="<Bench: []>")
   let ts = @bench.monotonic_clock_start()
   @debug.debug_inspect(ts, content="<Timestamp: ...>")

--- a/bench/pkg.generated.mbti
+++ b/bench/pkg.generated.mbti
@@ -16,12 +16,16 @@ pub fn single_bench(name? : String, () -> Unit, count? : UInt) -> Summary
 
 // Types and methods
 #alias(T)
-type Bench
+pub struct Bench {
+  // private fields
+}
+#alias(new, deprecated)
+#as_free_fn(new, deprecated)
+#as_free_fn
+pub fn Bench::Bench() -> Self
 pub fn Bench::bench(Self, name? : String, () -> Unit, count? : UInt) -> Unit
 pub fn Bench::dump_summaries(Self) -> String
 pub fn[Any] Bench::keep(Self, Any) -> Unit
-#as_free_fn
-pub fn Bench::new() -> Self
 pub impl @debug.Debug for Bench
 
 type Summary derive(ToJson, @debug.Debug)

--- a/bench/types.mbt
+++ b/bench/types.mbt
@@ -36,13 +36,15 @@ struct Bench {
 ///
 /// ```mbt check
 /// test {
-///   let b = @bench.new()
+///   let b = @bench.Bench()
 ///   let json = b.dump_summaries()
 ///   inspect(json, content="[]")
 /// }
 /// ```
+#alias(new, deprecated="Use `Bench()` instead")
 #as_free_fn
-pub fn Bench::new() -> Bench {
+#as_free_fn(new, deprecated="Use `Bench()` instead")
+pub fn Bench::Bench() -> Bench {
   let buffer = StringBuilder()
   let summaries = []
   { buffer, summaries, _storage: @ref.new(()) }


### PR DESCRIPTION
## Summary
- Renames `Bench::new()` → `Bench::Bench()`, following the constructor-as-type-name pattern (`Hasher::Hasher`, `Ref::Ref`, mutable `HashMap::HashMap`).
- `Bench::new` and the free `@bench.new` remain available as deprecated aliases via `#alias(new, deprecated)` and `#as_free_fn(new, deprecated)`.
- README doctests and one in-source doc example migrated to the new name; no new warnings.

Part of a series migrating `X::new` constructors in core (see also #3572).

## Test plan
- [x] `moon check` — clean (0 errors, no new warnings).
- [x] `moon test -p moonbitlang/core/bench` — 11/11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)