### PR TITLE
refactor(test): rename Test::new to Test::Test

### DIFF
--- a/test/README.mbt.md
+++ b/test/README.mbt.md
@@ -90,7 +90,7 @@ Create structured test outputs using the Test type:
 ```mbt check
 ///|
 test "test output" {
-  let t = @test.new("Example Test")
+  let t = @test.Test("Example Test")
 
   // Write output to test buffer
   t.write("Testing basic functionality: ")
@@ -112,7 +112,7 @@ Compare test outputs against saved snapshots:
 ```mbt check
 ///|
 test "snapshot testing" {
-  let t = @test.new("Snapshot Test")
+  let t = @test.Test("Snapshot Test")
 
   // Generate some output
   t.writeln("Current timestamp: 2024-01-01")

--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -40,10 +40,14 @@ pub fn[T : Show] same_object(T, T, loc~ : SourceLoc) -> Unit raise
 
 // Types and methods
 #alias(T, deprecated)
-type Test derive(@debug.Debug)
-pub fn Test::name(Self) -> String
+pub struct Test {
+  // private fields
+} derive(@debug.Debug)
+#alias(new, deprecated)
+#as_free_fn(new, deprecated)
 #as_free_fn
-pub fn Test::new(String) -> Self
+pub fn Test::Test(String) -> Self
+pub fn Test::name(Self) -> String
 #callsite(autofill(args_loc, loc))
 pub fn Test::snapshot(Self, filename~ : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise SnapshotError
 pub fn Test::write(Self, &Show) -> Unit

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -209,7 +209,7 @@ pub fn Test::writeln(self : Test, obj : &Show) -> Unit {
 /// 
 /// ```mbt check
 /// test {
-///   let t = @test.new("test.txt")
+///   let t = @test.Test("test.txt")
 ///   t.writeln("hello")
 ///   t.snapshot(filename="test.txt") // actual test block end
 /// }

--- a/test/test_test.mbt
+++ b/test/test_test.mbt
@@ -44,7 +44,7 @@ test "panic is_not called with the same object" {
 
 ///|
 test "Test name" {
-  let t = @test.new("sample")
+  let t = @test.Test("sample")
   inspect(t.name(), content="sample")
 }
 

--- a/test/types.mbt
+++ b/test/types.mbt
@@ -21,7 +21,9 @@ struct Test {
 
 ///|
 /// Create a new instance.
+#alias(new, deprecated="Use `Test()` instead")
 #as_free_fn
-pub fn Test::new(name : String) -> Test {
+#as_free_fn(new, deprecated="Use `Test()` instead")
+pub fn Test::Test(name : String) -> Test {
   { name, buffer: StringBuilder() }
 }


### PR DESCRIPTION
## Summary
- Renames `Test::new(name)` → `Test::Test(name)`, following the constructor-as-type-name pattern.
- `Test::new` and `@test.new` remain available as deprecated aliases via `#alias(new, deprecated)` and `#as_free_fn(new, deprecated)`.
- Internal callers (README doctests, in-source doc example, one wbtest) migrated to the new name.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.
- [x] `moon test -p moonbitlang/core/test` — 31/31 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)