### PR TITLE
refactor(regex_engine/automata): rename Context::new to Context::Context

### DIFF
--- a/bytes/internal/regex_engine/compile.mbt
+++ b/bytes/internal/regex_engine/compile.mbt
@@ -28,7 +28,7 @@ pub fn compile(profile~ : Profile, ast : Pattern) -> Regex {
   let symbol_map = @symbol_map.new()
   symbolize(profile~, symbol_map~, ast)
   let (symbol_table, symbol_repr) = symbol_map.finalize(profile.lb, profile.ub)
-  let ctx = @automata.Context::new()
+  let ctx = @automata.Context()
   let tc = TranslateContext::new(ctx, symbol_table)
   let (expr, pref) = translate(tc, ast)
   let expr = enforce_pref(tc.ctx, First, pref, expr)

--- a/internal/regex_engine/automata/context.mbt
+++ b/internal/regex_engine/automata/context.mbt
@@ -21,7 +21,8 @@ struct Context {
 
 ///|
 /// Create a new instance.
-pub fn Context::new() -> Context {
+#alias(new, deprecated="Use `Context()` instead")
+pub fn Context::Context() -> Context {
   Context::{
     next_expr_id: EXPR_ID_RESERVED + 1,
     book: SlotBook::empty(),

--- a/internal/regex_engine/automata/pkg.generated.mbti
+++ b/internal/regex_engine/automata/pkg.generated.mbti
@@ -34,8 +34,11 @@ pub let st_dummy : State
 // Errors
 
 // Types and methods
-type Context
-pub fn Context::new() -> Self
+pub struct Context {
+  // private fields
+}
+#alias(new, deprecated)
+pub fn Context::Context() -> Self
 
 type Expr
 

--- a/string/internal/regex_engine/compile.mbt
+++ b/string/internal/regex_engine/compile.mbt
@@ -28,7 +28,7 @@ pub fn compile(profile~ : Profile, ast : Pattern) -> Regex {
   let symbol_map = @symbol_map.new()
   symbolize(profile~, symbol_map~, ast)
   let (symbol_table, symbol_repr) = symbol_map.finalize(profile.lb, profile.ub)
-  let ctx = @automata.Context::new()
+  let ctx = @automata.Context()
   let tc = TranslateContext::new(ctx, symbol_table)
   let (expr, pref) = translate(tc, ast)
   let expr = enforce_pref(tc.ctx, First, pref, expr)


### PR DESCRIPTION
## Summary
- Renames `Context::new()` → `Context::Context()` in the internal `regex_engine/automata` package.
- `Context::new` remains available as a deprecated alias.
- Migrates the two internal callers (`bytes/internal/regex_engine/compile.mbt`, `string/internal/regex_engine/compile.mbt`).

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.
- [x] `moon test -p moonbitlang/core/string -p moonbitlang/core/bytes` — 397/397 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)