### PR TITLE
refactor(regex_engine/shared_types): drop duplicate Profile::new

### DIFF
--- a/internal/regex_engine/shared_types/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/pkg.generated.mbti
@@ -39,8 +39,8 @@ pub struct Profile {
   word_symbolize_splits : ReadOnlyArray[@rechar_set.RecharSet]
   category : (Int) -> Category
 }
+#alias(new, deprecated)
 pub fn Profile::Profile(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Self
-pub fn Profile::new(valid~ : @rechar_set.RecharSet, word~ : @rechar_set.RecharSet, word_symbolize_splits? : ReadOnlyArray[@rechar_set.RecharSet], category~ : (Int) -> Category) -> Self
 
 pub(all) enum QuantifierMode {
   Greedy

--- a/internal/regex_engine/shared_types/profile.mbt
+++ b/internal/regex_engine/shared_types/profile.mbt
@@ -24,20 +24,9 @@ pub struct Profile {
 }
 
 ///|
-pub fn Profile::Profile(
-  valid~ : RecharSet,
-  word~ : RecharSet,
-  word_symbolize_splits? : ReadOnlyArray[RecharSet] = [word],
-  category~ : (Rechar) -> Category,
-) -> Profile {
-  guard valid.first_interval() is Some((lb, _)) else { panic() }
-  guard valid.last_interval() is Some((_, ub)) else { panic() }
-  Profile::{ lb, ub, valid, word, word_symbolize_splits, category }
-}
-
-///|
 /// Create a new instance.
-pub fn Profile::new(
+#alias(new, deprecated="Use `Profile()` instead")
+pub fn Profile::Profile(
   valid~ : RecharSet,
   word~ : RecharSet,
   word_symbolize_splits? : ReadOnlyArray[RecharSet] = [word],


### PR DESCRIPTION
## Summary
- `Profile::Profile` and `Profile::new` were two functions with **identical bodies** in `profile.mbt`.
- Drop the duplicate `Profile::new` and add `#alias(new, deprecated=\"Use \`Profile()\` instead\")` to `Profile::Profile`.
- Net result: `Profile::new` still callable as a deprecated alias; no public surface change beyond the deprecation.
- All existing call sites already use `Profile(...)`, so no migration needed.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)