### PR TITLE
refactor(argparse): drop duplicate ValueRange::new

### DIFF
--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -68,8 +68,8 @@ pub fn PositionArg::new(StringView, about? : StringView, env? : StringView, defa
 pub struct ValueRange {
   // private fields
 } derive(Eq, Show, @debug.Debug)
+#alias(new, deprecated)
 pub fn ValueRange::ValueRange(lower? : Int, upper? : Int) -> Self
-pub fn ValueRange::new(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::single() -> Self
 
 pub enum ValueSource {

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -22,6 +22,13 @@ pub struct ValueRange {
 
 ///|
 /// Create a value-count range.
+///
+/// Notes:
+/// - `lower` defaults to `0`.
+/// - `upper` omitted means no upper bound.
+/// - `ValueRange(lower=0)` means `0..`.
+/// - `ValueRange(lower=1, upper=3)` means `1..=3`.
+#alias(new, deprecated="Use `ValueRange()` instead")
 pub fn ValueRange::ValueRange(lower? : Int = 0, upper? : Int) -> ValueRange {
   { lower, upper }
 }
@@ -30,16 +37,4 @@ pub fn ValueRange::ValueRange(lower? : Int = 0, upper? : Int) -> ValueRange {
 /// Exact single-value range (`1..1`).
 pub fn ValueRange::single() -> ValueRange {
   ValueRange(lower=1, upper=1)
-}
-
-///|
-/// Create a value-count range.
-///
-/// Notes:
-/// - `lower` defaults to `0`.
-/// - `upper` omitted means no upper bound.
-/// - `ValueRange(lower=0)` means `0..`.
-/// - `ValueRange(lower=1, upper=3)` means `1..=3`.
-pub fn ValueRange::new(lower? : Int = 0, upper? : Int) -> ValueRange {
-  { lower, upper }
 }


### PR DESCRIPTION
## Summary
- `ValueRange::ValueRange` and `ValueRange::new` were identical functions in `value_range.mbt`.
- Drop the duplicate `ValueRange::new`, attach the better docstring to `ValueRange::ValueRange`, and make `new` a deprecated alias.
- No behavior change; `ValueRange::new` still callable as deprecated alias.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.
- [x] `moon test -p moonbitlang/core/argparse` — 130/130 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)