### PR TITLE
refactor(argparse): drop duplicate ArgGroup::new

### DIFF
--- a/argparse/arg_group.mbt
+++ b/argparse/arg_group.mbt
@@ -25,33 +25,14 @@ pub struct ArgGroup {
 
 ///|
 /// Create an argument group.
-pub fn ArgGroup::ArgGroup(
-  name : StringView,
-  required? : Bool = false,
-  multiple? : Bool = true,
-  args? : ArrayView[String] = [],
-  requires? : ArrayView[String] = [],
-  conflicts_with? : ArrayView[String] = [],
-) -> ArgGroup {
-  {
-    name: name.to_owned(),
-    required,
-    multiple,
-    args: args.to_owned(),
-    requires: requires.to_owned(),
-    conflicts_with: conflicts_with.to_owned(),
-  }
-}
-
-///|
-/// Create an argument group.
 ///
 /// Notes:
 /// - `required=true` means at least one member of the group must be present.
 /// - `multiple=false` means group members are mutually exclusive.
 /// - `requires` and `conflicts_with` may reference either group names or
 ///   argument names.
-pub fn ArgGroup::new(
+#alias(new, deprecated="Use `ArgGroup()` instead")
+pub fn ArgGroup::ArgGroup(
   name : StringView,
   required? : Bool = false,
   multiple? : Bool = true,

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -13,8 +13,8 @@ import {
 pub struct ArgGroup {
   // private fields
 } derive(@debug.Debug)
+#alias(new, deprecated)
 pub fn ArgGroup::ArgGroup(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
-pub fn ArgGroup::new(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
 
 pub struct Command {
   // private fields


### PR DESCRIPTION
## Summary
- `ArgGroup::ArgGroup` and `ArgGroup::new` were identical functions in `arg_group.mbt`.
- Drop the duplicate `ArgGroup::new`, attach the docstring to `ArgGroup::ArgGroup`, and make `new` a deprecated alias.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)