### PR TITLE
refactor(argparse): drop duplicate FlagArg::new

### DIFF
--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -84,42 +84,6 @@ pub struct FlagArg {
 
 ///|
 /// Create a flag argument.
-pub fn FlagArg::FlagArg(
-  name : StringView,
-  short? : Char,
-  long? : StringView = name,
-  about? : StringView,
-  action? : FlagAction = SetTrue,
-  env? : StringView,
-  requires? : ArrayView[String] = [],
-  conflicts_with? : ArrayView[String] = [],
-  required? : Bool = false,
-  global? : Bool = false,
-  negatable? : Bool = false,
-  hidden? : Bool = false,
-) -> FlagArg {
-  let name = name.to_owned()
-  let long = if long == "" { None } else { Some(long.to_owned()) }
-  let about = about.map(v => v.to_owned())
-  let env = env.map(v => v.to_owned())
-  {
-    arg: {
-      name,
-      about,
-      env,
-      global,
-      hidden,
-      requires: requires.to_owned(),
-      conflicts_with: conflicts_with.to_owned(),
-      required,
-      info: FlagInfo(short~, long~, action~, negatable~),
-      multiple: false,
-    },
-  }
-}
-
-///|
-/// Create a flag argument.
 ///
 /// Notes:
 /// - `long` defaults to `name`.
@@ -129,7 +93,8 @@ pub fn FlagArg::FlagArg(
 /// - `negatable=true` accepts `--no-<long>` for long flags.
 /// - If `env` is set, accepted boolean values are:
 ///   `1`, `0`, `true`, `false`, `yes`, `no`, `on`, `off`.
-pub fn FlagArg::new(
+#alias(new, deprecated="Use `FlagArg()` instead")
+pub fn FlagArg::FlagArg(
   name : StringView,
   short? : Char,
   long? : StringView = name,

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -36,8 +36,8 @@ pub(all) enum FlagAction {
 pub struct FlagArg {
   // private fields
 } derive(@debug.Debug)
+#alias(new, deprecated)
 pub fn FlagArg::FlagArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
-pub fn FlagArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
 
 pub struct Matches {
   flags : Map[String, Bool]


### PR DESCRIPTION
## Summary
- `FlagArg::FlagArg` and `FlagArg::new` were identical functions.
- Drop the duplicate `FlagArg::new`, attach the docstring to `FlagArg::FlagArg`, and make `new` a deprecated alias.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)