### PR TITLE
refactor(argparse): drop duplicate OptionArg::new

### DIFF
--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -172,50 +172,6 @@ pub struct OptionArg {
 
 ///|
 /// Create an option argument.
-// FIXME(upstram) rename does not work here
-pub fn OptionArg::OptionArg(
-  name : StringView,
-  short? : Char,
-  long? : StringView = name,
-  about? : StringView,
-  action? : OptionAction = Set,
-  env? : StringView,
-  default_values? : ArrayView[String],
-  allow_hyphen_values? : Bool = false,
-  requires? : ArrayView[String] = [],
-  conflicts_with? : ArrayView[String] = [],
-  required? : Bool = false,
-  global? : Bool = false,
-  hidden? : Bool = false,
-) -> OptionArg {
-  let name = name.to_owned()
-  let long = if long == "" { None } else { Some(long.to_owned()) }
-  let about = about.map(v => v.to_owned())
-  let env = env.map(v => v.to_owned())
-  {
-    arg: {
-      name,
-      about,
-      env,
-      requires: requires.to_owned(),
-      conflicts_with: conflicts_with.to_owned(),
-      required,
-      global,
-      hidden,
-      info: OptionInfo(
-        short~,
-        long~,
-        action~,
-        default_values=default_values.map(values => values.to_owned()),
-        allow_hyphen_values~,
-      ),
-      multiple: action is Append,
-    },
-  }
-}
-
-///|
-/// Create an option argument.
 ///
 /// Notes:
 /// - `long` defaults to `name`.
@@ -225,7 +181,8 @@ pub fn OptionArg::OptionArg(
 /// - `global=true` makes the option available in subcommands.
 /// - `allow_hyphen_values=true` allows values like `-1` or `--raw` to be
 ///   consumed as this option's value when parsing argv.
-pub fn OptionArg::new(
+#alias(new, deprecated="Use `OptionArg()` instead")
+pub fn OptionArg::OptionArg(
   name : StringView,
   short? : Char,
   long? : StringView = name,

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -56,8 +56,8 @@ pub(all) enum OptionAction {
 pub struct OptionArg {
   // private fields
 } derive(@debug.Debug)
+#alias(new, deprecated)
 pub fn OptionArg::OptionArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
-pub fn OptionArg::new(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
 
 pub struct PositionArg {
   // private fields


### PR DESCRIPTION
## Summary
- `OptionArg::OptionArg` and `OptionArg::new` were identical functions.
- Drop the duplicate `OptionArg::new`, attach the docstring to `OptionArg::OptionArg`, and make `new` a deprecated alias.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)