### PR TITLE
refactor(argparse): drop duplicate PositionArg::new

### DIFF
--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -274,43 +274,6 @@ pub struct PositionArg {
 
 ///|
 /// Create a positional argument.
-pub fn PositionArg::PositionArg(
-  name : StringView,
-  about? : StringView,
-  env? : StringView,
-  default_values? : ArrayView[String],
-  num_args? : ValueRange,
-  allow_hyphen_values? : Bool = false,
-  requires? : ArrayView[String] = [],
-  conflicts_with? : ArrayView[String] = [],
-  global? : Bool = false,
-  hidden? : Bool = false,
-) -> PositionArg {
-  let name = name.to_owned()
-  let about = about.map(v => v.to_owned())
-  let env = env.map(v => v.to_owned())
-  {
-    arg: {
-      name,
-      about,
-      env,
-      requires: requires.to_owned(),
-      conflicts_with: conflicts_with.to_owned(),
-      required: false,
-      global,
-      hidden,
-      info: PositionalInfo(
-        num_args~,
-        default_values=default_values.map(values => values.to_owned()),
-        allow_hyphen_values~,
-      ),
-      multiple: range_allows_multiple(num_args),
-    },
-  }
-}
-
-///|
-/// Create a positional argument.
 ///
 /// Notes:
 /// - PositionArg order follows declaration order.
@@ -321,7 +284,8 @@ pub fn PositionArg::PositionArg(
 /// - `allow_hyphen_values=true` allows leading-`-` tokens to be consumed as
 ///   positional values (unless they match a declared option).
 /// - Tokens after `--` are always treated as positional values.
-pub fn PositionArg::new(
+#alias(new, deprecated="Use `PositionArg()` instead")
+pub fn PositionArg::PositionArg(
   name : StringView,
   about? : StringView,
   env? : StringView,

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -62,8 +62,8 @@ pub fn OptionArg::new(StringView, short? : Char, long? : StringView, about? : St
 pub struct PositionArg {
   // private fields
 } derive(@debug.Debug)
+#alias(new, deprecated)
 pub fn PositionArg::PositionArg(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
-pub fn PositionArg::new(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
 
 pub struct ValueRange {
   // private fields


### PR DESCRIPTION
## Summary
- `PositionArg::PositionArg` and `PositionArg::new` were identical functions.
- Drop the duplicate `PositionArg::new`, attach the docstring to `PositionArg::PositionArg`, and make `new` a deprecated alias.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)