### PR TITLE
refactor(json): drop duplicate Replacer::new

### DIFF
--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -209,7 +209,7 @@ test "replacer custom" {
   let json : Json = { "x": 1.0, "y": 2.0 }
   // double all number values
   let replaced = json.transform(
-    @json.Replacer::new(fn(_key, value) {
+    @json.Replacer(fn(_key, value) {
       match value {
         Number(n, ..) => Some(Json::number(n * 2))
         other => Some(other)

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -126,24 +126,19 @@ pub struct Replacer {
 } derive(@debug.Debug)
 
 ///|
-pub fn Replacer::Replacer(f : (String, Json) -> Json?) -> Replacer {
-  { f, }
-}
-
-///|
 /// Create a new Replacer with a custom function.
-/// 
+///
 /// The function receives `(key, value)` pairs and should return:
 /// - `Some(transformed_value)` to include the property
 /// - `None` to exclude the property
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```mbt check
 /// test {
 ///   // Transform numbers and exclude sensitive fields
 ///   ignore(
-///     @json.Replacer::new((key, value) => {
+///     @json.Replacer((key, value) => {
 ///       match key {
 ///         "password" | "secret" => None // exclude sensitive fields
 ///         _ =>
@@ -156,7 +151,8 @@ pub fn Replacer::Replacer(f : (String, Json) -> Json?) -> Replacer {
 ///   )
 /// }
 /// ```
-pub fn Replacer::new(f : (String, Json) -> Json?) -> Replacer {
+#alias(new, deprecated="Use `Replacer()` instead")
+pub fn Replacer::Replacer(f : (String, Json) -> Json?) -> Replacer {
   { f, }
 }
 
@@ -217,7 +213,7 @@ pub fn Replacer::exclude(array : ArrayView[StringView]) -> Replacer {
 /// 
 /// ### Creating Replacers
 /// 
-/// 1. **Replacer::new(f)** - Create a custom replacer with a function `(String, Json) -> Json?`:
+/// 1. **Replacer(f)** - Create a custom replacer with a function `(String, Json) -> Json?`:
 ///    - Return `Some(value)` to include the property (possibly transformed)
 ///    - Return `None` to exclude the property
 /// 
@@ -240,7 +236,7 @@ pub fn Replacer::exclude(array : ArrayView[StringView]) -> Replacer {
 ///   ignore(json.stringify(replacer=exclude_replacer)) // {"a":1,"b":2,"c":3}
 ///
 ///   // Custom transformation
-///   let transform_replacer = @json.Replacer::new((_key, value) => {
+///   let transform_replacer = @json.Replacer((_key, value) => {
 ///     match value {
 ///       Number(n, ..) => Some(Json::number(n * 10.0)) // multiply numbers by 10
 ///       _ => Some(value) // keep other values unchanged
@@ -249,7 +245,7 @@ pub fn Replacer::exclude(array : ArrayView[StringView]) -> Replacer {
 ///   ignore(json.stringify(replacer=transform_replacer)) // {"a":10,"b":20,"c":30,"password":"secret"}
 ///
 ///   // Filter and transform
-///   let filter_replacer = @json.Replacer::new((key, value) => {
+///   let filter_replacer = @json.Replacer((key, value) => {
 ///     match key {
 ///       "password" => None // exclude password
 ///       _ =>
@@ -440,7 +436,7 @@ fn escape(str : String, escape_slash~ : Bool) -> String {
 ///   // Remove sensitive data and double numeric values  
 ///   ignore(
 ///     json.transform(
-///       @json.Replacer::new((key, value) => {
+///       @json.Replacer((key, value) => {
 ///         match key {
 ///           "password" => None // exclude password fields
 ///           _ =>

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -46,10 +46,10 @@ pub(all) struct Position {
 pub struct Replacer {
   // private fields
 } derive(@debug.Debug)
+#alias(new, deprecated)
 pub fn Replacer::Replacer((String, Json) -> Json?) -> Self
 pub fn Replacer::exclude(ArrayView[StringView]) -> Self
 pub fn Replacer::keep(ArrayView[StringView]) -> Self
-pub fn Replacer::new((String, Json) -> Json?) -> Self
 
 #deprecated
 pub fn Json::as_array(Self) -> Array[Self]?

--- a/json/types_test.mbt
+++ b/json/types_test.mbt
@@ -63,7 +63,7 @@ test "Debug for ParseError" {
 
 ///|
 test "Debug for Replacer" {
-  let r = @json.Replacer::new(fn(_, v) { Some(v) })
+  let r = @json.Replacer(fn(_, v) { Some(v) })
   @debug.debug_inspect(
     r,
     content=(


### PR DESCRIPTION
## Summary
- `Replacer::Replacer` and `Replacer::new` were identical functions.
- Drop the duplicate `Replacer::new`, attach the docstring to `Replacer::Replacer`, and make `new` a deprecated alias.
- Migrate `@json.Replacer::new(...)` references in doc comments, README, and `types_test.mbt` to `@json.Replacer(...)`.

Part of a series migrating `X::new` constructors in core.

## Test plan
- [x] `moon check` — clean, no new warnings.
- [x] `moon test -p moonbitlang/core/json` — 172/172 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)