### PR TITLE
cleanup: drop redundant ignore() in try/catch/noraise

### DIFF
--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -283,7 +283,7 @@ test "from_json_tail_bug" {
 ///|
 test "from_json rejects non-array" {
   let bad_json : Json = { "a": 1 }
-  try ignore((@json.from_json(bad_json) : @deque.Deque[Int])) catch {
+  try (@json.from_json(bad_json) : @deque.Deque[Int]) catch {
     _ => ()
   } noraise {
     _ => fail("expected Deque::from_json failure")

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -516,9 +516,7 @@ test "from_json free function" {
 test "from_json rejects non-object" {
   let bad_json : Json = [1, 2, 3]
   try
-    ignore(
-      (@sorted_map.from_json(bad_json) : @sorted_map.SortedMap[String, Int]),
-    )
+    (@sorted_map.from_json(bad_json) : @sorted_map.SortedMap[String, Int])
   catch {
     _ => ()
   } noraise {

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -602,9 +602,7 @@ test "from_json free function" {
 ///|
 test "from_json rejects non-array" {
   let bad_json : Json = { "a": 1 }
-  try
-    ignore((@sorted_set.from_json(bad_json) : @sorted_set.SortedSet[Int]))
-  catch {
+  try (@sorted_set.from_json(bad_json) : @sorted_set.SortedSet[Int]) catch {
     _ => ()
   } noraise {
     _ => fail("expected JsonDecodeError")

--- a/lazy_list/lazy_list_test.mbt
+++ b/lazy_list/lazy_list_test.mbt
@@ -178,7 +178,7 @@ test "drop_while accepts a raising predicate" {
   debug_inspect(zs.drop_while(pred).to_array(), content="[3, -1]")
   // A predicate that raises mid-skip propagates out of drop_while.
   let ys = @lazy_list.from_iter([1, -1, 5].iter())
-  try ignore(ys.drop_while(pred)) catch {
+  try ys.drop_while(pred) catch {
     _ => ()
   } noraise {
     _ => fail("expected NegativeFound to propagate")

--- a/ref/ref_test.mbt
+++ b/ref/ref_test.mbt
@@ -105,14 +105,12 @@ test "Ref::new with string" {
 test "map with error handling" {
   let x = @ref.new(10)
   try
-    ignore(
-      x.map(a => {
-        if a > 5 {
-          fail("value too large")
-        }
-        a * 2
-      }),
-    )
+    x.map(a => {
+      if a > 5 {
+        fail("value too large")
+      }
+      a * 2
+    })
   catch {
     _ => ()
   } noraise {

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -316,9 +316,7 @@ test "from_json" {
 ///|
 test "from_json rejects non-object" {
   let bad_json : Json = 1
-  try
-    ignore((@json.from_json(bad_json) : @sorted_map.SortedMap[String, Int]))
-  catch {
+  try (@json.from_json(bad_json) : @sorted_map.SortedMap[String, Int]) catch {
     _ => ()
   } noraise {
     _ => fail("expected JsonDecodeError")

--- a/string/parse_double_test.mbt
+++ b/string/parse_double_test.mbt
@@ -17,9 +17,7 @@ test "parse_double huge exponent" {
   // Exponents whose digit count exceeds what fits in `Int` must clamp before
   // they overflow the slow-path accumulator. Positive side overflows to a
   // range error; negative side underflows to zero.
-  try
-    @string.parse_double("1e999999999999999999999999999999999999") |> ignore
-  catch {
+  try @string.parse_double("1e999999999999999999999999999999999999") catch {
     e =>
       debug_inspect(
         e,
@@ -30,9 +28,7 @@ test "parse_double huge exponent" {
   } noraise {
     _ => fail("expected error")
   }
-  try
-    @string.parse_double("-1e999999999999999999999999999999999999") |> ignore
-  catch {
+  try @string.parse_double("-1e999999999999999999999999999999999999") catch {
     e =>
       debug_inspect(
         e,

--- a/string/regex_test.mbt
+++ b/string/regex_test.mbt
@@ -72,7 +72,7 @@ test "execute/range_crossing_surrogate_gap_has_no_half_match" {
 
 ///|
 test "compile/error_unclosed_group" {
-  try ignore(@string.Regex("(")) catch {
+  try @string.Regex("(") catch {
     _ => ()
   } noraise {
     _ => fail("Expected compile failure for unclosed group")
@@ -81,7 +81,7 @@ test "compile/error_unclosed_group" {
 
 ///|
 test "compile/error_unclosed_char_class" {
-  try ignore(@string.Regex("[abc")) catch {
+  try @string.Regex("[abc") catch {
     _ => ()
   } noraise {
     _ => fail("Expected compile failure for unclosed char class")
@@ -663,7 +663,7 @@ test "add/with_any_quantifier_and_empty_wrappers" {
 ///|
 test "should_raise" {
   for pattern in ["[-a]", "[^-a]", "[a-]"] {
-    try ignore(@string.Regex(pattern)) catch {
+    try @string.Regex(pattern) catch {
       _ => ()
     } noraise {
       _ => fail("expected error for pattern \{pattern}")


### PR DESCRIPTION
## Summary
Follow-up cleanup to #3660. The `try expr catch { _ => () } noraise { _ => fail(...) }` pattern does not need the inner `ignore(...)` wrapper — the `_` pattern in the catch arm already drops the result, and the noraise arm returns the never type from `fail`, so the try expression's type unifies without help.

Removes 9 sites where I added a defensive `ignore(...)` or `|> ignore` that isn't needed.

## Test plan
- [x] `moon check --target native --deny-warn` — clean.
- [x] `moon test` — 6521/6521 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)