### PR TITLE
warnings: enable missing_doc and document the 4 flagged sites

### DIFF
--- a/internal/regex_engine/automata/slot.mbt
+++ b/internal/regex_engine/automata/slot.mbt
@@ -37,6 +37,9 @@ pub struct Slot {
 } derive(Eq, Hash)
 
 ///|
+/// Wrap a raw slot index into a `Slot`. The index must be one that was
+/// previously produced by the slot allocator; constructing arbitrary slots
+/// is meaningful only inside the engine.
 pub fn Slot::from_index(index : Int) -> Slot {
   { index, }
 }

--- a/internal/regex_engine/shared_types/category.mbt
+++ b/internal/regex_engine/shared_types/category.mbt
@@ -84,6 +84,7 @@ pub fn Category::inexistant_or_non_word_start() -> Category {
 }
 
 ///|
+/// Convenience category: outside input or non-word (end-of-match side).
 pub fn Category::inexistant_or_non_word_end() -> Category {
   Category(1 | 8)
 }

--- a/moon.mod
+++ b/moon.mod
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 keywords = [ "core", "standard library" ]
 
-warnings = "+test_unqualified_package+unqualified_local_using"
+warnings = "+test_unqualified_package+unqualified_local_using+missing_doc"

--- a/string/internal/regex_engine/symbol_map/table.mbt
+++ b/string/internal/regex_engine/symbol_map/table.mbt
@@ -16,6 +16,9 @@
 struct Table(FixedArray[@shared_types.Rechar])
 
 ///|
+/// Map a single `Rechar` through the symbol table. ASCII codepoints are
+/// looked up directly; higher codepoints are resolved via a binary search
+/// over `(lo, hi, target)` triples stored after the ASCII region.
 pub fn Table::map(
   self : Table,
   c : @shared_types.Rechar,
@@ -43,6 +46,7 @@ pub fn Table::map(
 }
 
 ///|
+/// Apply `Table::map` to every `Rechar` in the input set.
 pub fn Table::map_set(
   self : Table,
   set : @shared_types.RecharSet,


### PR DESCRIPTION
## Summary
Enable `+missing_doc` in `moon.mod` and add docstrings for the 4 public functions the lint flags:
- `internal/regex_engine/automata/Slot::from_index`
- `internal/regex_engine/shared_types/Category::inexistant_or_non_word_end`
- `string/internal/regex_engine/symbol_map/Table::map`
- `string/internal/regex_engine/symbol_map/Table::map_set`

After this, `moon check` is clean for `missing_doc` and the warning stays on for future code.

## Test plan
- [x] `moon check` clean.
- [x] `moon test` — 6521/6521 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)