### PR TITLE
warnings: enable prefer_readonly_array and annotate the 33 flagged sites

### DIFF
--- a/bench/README.mbt.md
+++ b/bench/README.mbt.md
@@ -108,7 +108,7 @@ test "data structure benchmarks" {
 
   // Benchmark FixedArray access
   bencher.bench(name="fixedarray_access", fn() {
-    let arr = [0, 1, 2, 3, 4]
+    let arr : ReadOnlyArray[Int] = [0, 1, 2, 3, 4]
     let mut sum = 0
     for i in 0..<arr.length() {
       sum = sum + arr[i]

--- a/bool/README.mbt.md
+++ b/bool/README.mbt.md
@@ -67,7 +67,7 @@ test "bool to specialized integer types" {
 ///|
 test "boolean indexing" {
   // Use boolean conversion for array indexing
-  let options = ["default", "enhanced"]
+  let options : ReadOnlyArray[String] = ["default", "enhanced"]
   let use_enhanced = true
   let selected = options[use_enhanced.to_int()]
   inspect(selected, content="enhanced")
@@ -112,8 +112,8 @@ test "statistical operations" {
   inspect(success_rate > 0.7, content="true")
 
   // Boolean to numeric conversion for weighted calculations
-  let feature_enabled = [true, false, true]
-  let weights = [0.6, 0.3, 0.1]
+  let feature_enabled : ReadOnlyArray[Bool] = [true, false, true]
+  let weights : ReadOnlyArray[Double] = [0.6, 0.3, 0.1]
 
   // Calculate weighted score manually to avoid zip complexity
   let score1 = feature_enabled[0].to_int().to_double() * weights[0]

--- a/buffer/buffer_test.mbt
+++ b/buffer/buffer_test.mbt
@@ -21,7 +21,7 @@ test "create buffer from bytes" {
 
 ///|
 test "create buffer from array" {
-  let arr = [b'4', b'\x00', b'5', b'\x00', b'6', b'\x00']
+  let arr : ReadOnlyArray[Byte] = [b'4', b'\x00', b'5', b'\x00', b'6', b'\x00']
   let buf = @buffer.from_array(arr)
   inspect(buf, content="456")
 }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -148,7 +148,7 @@ pub fn[T] Array::capacity(self : Array[T]) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [1, 2, 3]
+///   let arr : Array[Int] = [1, 2, 3]
 ///   inspect(arr.unsafe_get(1), content="2")
 /// }
 /// ```
@@ -175,7 +175,7 @@ pub fn[T] Array::unsafe_get(self : Array[T], idx : Int) -> T {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [1, 2, 3]
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3]
 ///   inspect(arr[1], content="2")
 /// }
 /// ```
@@ -403,11 +403,11 @@ pub impl[T] Add for Array[T] with fn add(self, other) {
 /// ```mbt check
 /// test {
 ///   let v1 = [1, 2, 3]
-///   let v2 = [4, 5, 6]
+///   let v2 : ReadOnlyArray[Int] = [4, 5, 6]
 ///   v1.append(v2)
 ///   debug_inspect(v1, content="[1, 2, 3, 4, 5, 6]")
 ///   let v1 = [1, 2, 3]
-///   let v2 : Array[Int] = []
+///   let v2 : ReadOnlyArray[Int] = []
 ///   v1.append(v2)
 ///   debug_inspect(v1, content="[1, 2, 3]")
 /// }

--- a/builtin/array_sort.mbt
+++ b/builtin/array_sort.mbt
@@ -121,7 +121,7 @@ pub fn[T, K : Compare] MutArrayView::sort_by_key(
 ///   let arr = [1, 2, 3, 4, 5]
 ///   let view = arr[1:4]
 ///   inspect(view.is_sorted(), content="true")
-///   let descending = [5, 4, 3, 2, 1]
+///   let descending : ReadOnlyArray[Int] = [5, 4, 3, 2, 1]
 ///   inspect(descending[:].is_sorted(), content="false")
 /// }
 /// ```

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -143,7 +143,7 @@ test "array_drain" {
 ///|
 test "array_append" {
   let arr1 = [1, 2, 3]
-  let arr2 = [4, 5, 6]
+  let arr2 : ReadOnlyArray[Int] = [4, 5, 6]
   arr1.append(arr2)
   @test.assert_eq(arr1.length(), 6)
   // @test.assert_eq(arr1.capacity(), 6)
@@ -786,7 +786,7 @@ test "array view implicit conversion" {
     x.length()
   }
 
-  let arr = [1, 2, 3]
+  let arr : ReadOnlyArray[Int] = [1, 2, 3]
   inspect(f(arr), content="3")
 }
 

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -71,9 +71,9 @@ pub fn[T] Array::new(capacity? : Int = 0) -> Array[T] {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [1, 2, 3]
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3]
 ///   inspect(arr.length(), content="3")
-///   let empty : Array[Int] = []
+///   let empty : ReadOnlyArray[Int] = []
 ///   inspect(empty.length(), content="0")
 /// }
 /// ```

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -468,7 +468,7 @@ test "fixedarray_sub" {
 
 ///|
 test "ArrayView::suffixes" {
-  let arr = [1, 2, 3]
+  let arr : ReadOnlyArray[Int] = [1, 2, 3]
   let suffixes = arr[:].suffixes().collect()
   @json.json_inspect(suffixes, content=[[1, 2, 3], [2, 3], [3]])
   let suffixes_with_empty = arr[:].suffixes(include_empty=true).collect()

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -434,7 +434,7 @@ pub impl Compare for Bytes with fn compare(self, other) {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [b'h', b'i']
+///   let arr : ReadOnlyArray[Byte] = [b'h', b'i']
 ///   let bytes = Bytes::from_array(arr)
 ///   inspect(
 ///     bytes,

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -626,7 +626,7 @@ test "fixedarray_new_with_index" {
 ///
 /// ```mbt check
 /// test {
-///   let dynamic_array = [1, 2, 3, 4, 5]
+///   let dynamic_array : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
 ///   let fixed_array = FixedArray::from_array(dynamic_array)
 ///   debug_inspect(
 ///     fixed_array,

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -46,7 +46,7 @@ pub fn[T] ReadOnlyArray::at(self : ReadOnlyArray[T], index : Int) -> T {
 /// # Example
 /// ```mbt check
 /// test {
-///   let dynamic_array = [1, 2, 3, 4, 5]
+///   let dynamic_array : Array[Int] = [1, 2, 3, 4, 5]
 ///   let immut_array = ReadOnlyArray::from_array(dynamic_array)
 ///   inspect(immut_array[0], content="1")
 /// }

--- a/bytes/README.mbt.md
+++ b/bytes/README.mbt.md
@@ -56,7 +56,7 @@ test "bytes creation" {
 ```mbt check
 ///|
 test "bytes conversion" {
-  let original = [b'x', b'y', b'z']
+  let original : ReadOnlyArray[Byte] = [b'x', b'y', b'z']
   let bytes = Bytes::from_array(original)
 
   // Convert to array

--- a/cmp/README.mbt.md
+++ b/cmp/README.mbt.md
@@ -48,7 +48,12 @@ test "reverse comparison" {
 ///|
 test "reverse with arrays" {
   // Create an array with reversed integers for descending sort
-  let arr = [@cmp.Reverse(3), Reverse(1), Reverse(4), Reverse(2)]
+  let arr : ReadOnlyArray[@cmp.Reverse[Int]] = [
+    Reverse(3),
+    Reverse(1),
+    Reverse(4),
+    Reverse(2),
+  ]
   // When sorted, the array will be in descending order of the wrapped values
   inspect(arr[0], content="Reverse(3)") // Access first element
 }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -150,7 +150,7 @@ test "add_empty" {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [1, 2, 3, 4, 5]
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
 ///   let dq = @deque.Deque(arr)
 ///   @debug.debug_inspect(
 ///     dq,

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -537,7 +537,7 @@ test "from_iter empty iter" {
 
 ///|
 test "from_array with single element" {
-  let arr = [42]
+  let arr : ReadOnlyArray[Int] = [42]
   let deque = @deque.from_array(arr)
   inspect(deque.length(), content="1")
   @test.assert_eq(deque.front(), Some(42))

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -49,7 +49,7 @@ fn capacity_for_length(length : Int) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [(1, "one"), (2, "two"), (1, "ONE")]
+///   let arr : ReadOnlyArray[(Int, String)] = [(1, "one"), (2, "two"), (1, "ONE")]
 ///   let map = @hashmap.HashMap(arr)
 ///   debug_inspect(map.get(1), content="Some(\"ONE\")")
 ///   debug_inspect(map.get(2), content="Some(\"two\")")
@@ -963,7 +963,7 @@ fn[K : Hash + Eq, V : Eq] verify_content(
 ///|
 test "arbitrary" {
   let samples : Array[HashMap[String, Int]] = @quickcheck.samples(20)
-  let data = [
+  let data : ReadOnlyArray[Array[(String, Int)]] = [
     [],
     [],
     [],

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -387,7 +387,7 @@ test "@hashmap.contains/after_operations" {
 
 ///|
 test "@hashmap.from_array" {
-  let array = [("a", 1), ("b", 2), ("c", 3)]
+  let array : ReadOnlyArray[(String, Int)] = [("a", 1), ("b", 2), ("c", 3)]
   let map = @hashmap.from_array(array)
   for k, v in map {
     @test.assert_eq(map.get(k), Some(v))
@@ -397,7 +397,11 @@ test "@hashmap.from_array" {
 
 ///|
 test "@hashmap.from_array with int key" {
-  let array = [(1, "one"), (2, "two"), (3, "three")]
+  let array : ReadOnlyArray[(Int, String)] = [
+    (1, "one"),
+    (2, "two"),
+    (3, "three"),
+  ]
   let map = @hashmap.from_array(array)
   for k, v in map {
     @test.assert_eq(map.get(k), Some(v))

--- a/hashmap/utils_test.mbt
+++ b/hashmap/utils_test.mbt
@@ -145,7 +145,7 @@ test "T::retain - large map with complex predicate" {
 test "T::retain - with collisions" {
   // Create keys that likely hash to same buckets
   let map = @hashmap.HashMap([])
-  let keys = ["a", "aa", "aaa", "aaaa", "aaaaa"]
+  let keys : ReadOnlyArray[String] = ["a", "aa", "aaa", "aaaa", "aaaaa"]
   for i = 0; i < keys.length(); i = i + 1 {
     map.set(keys[i], i)
   }

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -136,7 +136,7 @@ test "of" {
 
 ///|
 test "from_array" {
-  let arr = ["a", "b", "c"]
+  let arr : ReadOnlyArray[String] = ["a", "b", "c"]
   let m = @hashset.from_array(arr)
   assert_true(m.contains("a"))
   assert_true(m.contains("b"))
@@ -421,7 +421,7 @@ test "from_iter empty iter" {
 ///|
 test "hashset arbitrary" {
   let samples : Array[@hashset.HashSet[Int]] = @quickcheck.samples(20)
-  let cases = [
+  let cases : ReadOnlyArray[@hashset.HashSet[Int]] = [
     @hashset.from_array([]),
     @hashset.from_array([]),
     @hashset.from_array([]),

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -175,7 +175,7 @@ test "from_array with empty array" {
 
 ///|
 test "from_array with non-empty array" {
-  let array = [1, 2, 3]
+  let array : ReadOnlyArray[Int] = [1, 2, 3]
   let set = @hashset.from_array(array)
   inspect(set.contains(1), content="true")
   inspect(set.contains(2), content="true")

--- a/math/algebraic_test.mbt
+++ b/math/algebraic_test.mbt
@@ -55,7 +55,7 @@ test "@math.hypotf" {
 
 ///|
 test "@math.hypot small ratio" {
-  let ys = [0.0]
+  let ys : ReadOnlyArray[Double] = [0.0]
   let small = @math.hypot(1.0, ys[0])
   assert_true(small.is_close(1.0))
 }

--- a/moon.mod
+++ b/moon.mod
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 keywords = [ "core", "standard library" ]
 
-warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op+unnecessary_annotation+prefer_fixed_array"
+warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op+unnecessary_annotation+prefer_fixed_array+prefer_readonly_array"

--- a/quickcheck/splitmix/README.mbt.md
+++ b/quickcheck/splitmix/README.mbt.md
@@ -145,8 +145,16 @@ test "deterministic testing" {
   let rng2 = @splitmix.new(seed=777UL)
 
   // Generate same sequence
-  let seq1 = [rng1.next_int(), rng1.next_int(), rng1.next_int()]
-  let seq2 = [rng2.next_int(), rng2.next_int(), rng2.next_int()]
+  let seq1 : ReadOnlyArray[Int] = [
+    rng1.next_int(),
+    rng1.next_int(),
+    rng1.next_int(),
+  ]
+  let seq2 : ReadOnlyArray[Int] = [
+    rng2.next_int(),
+    rng2.next_int(),
+    rng2.next_int(),
+  ]
   inspect(seq1[0] == seq2[0], content="true")
   inspect(seq1[1] == seq2[1], content="true")
   inspect(seq1[2] == seq2[2], content="true")

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -104,7 +104,7 @@ test "of" {
 
 ///|
 test "from_array" {
-  let arr = ["a", "b", "c"]
+  let arr : ReadOnlyArray[String] = ["a", "b", "c"]
   let m = @set.Set(arr)
   assert_true(m.contains("a"))
   assert_true(m.contains("b"))

--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -11,7 +11,7 @@ Create strings from various sources:
 ///|
 test "string creation" {
   // From character array
-  let chars = ['H', 'e', 'l', 'l', 'o']
+  let chars : ReadOnlyArray[Char] = ['H', 'e', 'l', 'l', 'o']
   let str1 = String::from_array(chars)
   inspect(str1, content="Hello")
 


### PR DESCRIPTION
## Summary
Enable `+prefer_readonly_array` in `moon.mod` and annotate the 33 sites it flags. Most are docstring/README examples and tests where the Array literal is only read; an explicit `: Array[T]` (when the doc is demonstrating an `Array` API) or `: ReadOnlyArray[T]` (when the example is purely indexed read) makes the choice explicit and satisfies the lint.

## Test plan
- [x] `moon check` clean (0 warnings).
- [x] `moon test` — 6521/6521 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)