### PR TITLE
warnings: enable unnecessary_view_op and drop redundant  views

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -922,7 +922,7 @@ pub fn[T : Eq] Array::ends_with(self : Array[T], suffix : ArrayView[T]) -> Bool 
 /// ```mbt check
 /// test {
 ///   let v = [1, 2, 3, 4, 5]
-///   let v2 = v.strip_prefix([1, 2][:])
+///   let v2 = v.strip_prefix([1, 2])
 ///   debug_inspect(
 ///     v2,
 ///     content=(
@@ -949,7 +949,7 @@ pub fn[T : Eq] Array::strip_prefix(
 /// ```mbt check
 /// test {
 ///   let v = [3, 4, 5]
-///   let v2 = v.strip_suffix([5][:])
+///   let v2 = v.strip_suffix([5])
 ///   debug_inspect(
 ///     v2,
 ///     content=(

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -406,17 +406,17 @@ test "lexical_compare" {
 ///|
 test "array_strip_prefix" {
   let arr = [1, 2, 3]
-  debug_inspect(arr.strip_prefix([1, 2][:]), content="Some(<ArrayView: [3]>)")
-  debug_inspect(arr.strip_prefix([1, 2, 3][:]), content="Some(<ArrayView: []>)")
-  debug_inspect(arr.strip_prefix([2, 3][:]), content="None")
+  debug_inspect(arr.strip_prefix([1, 2]), content="Some(<ArrayView: [3]>)")
+  debug_inspect(arr.strip_prefix([1, 2, 3]), content="Some(<ArrayView: []>)")
+  debug_inspect(arr.strip_prefix([2, 3]), content="None")
 }
 
 ///|
 test "array_strip_suffix" {
   let arr = [1, 2, 3]
-  debug_inspect(arr.strip_suffix([2, 3][:]), content="Some(<ArrayView: [1]>)")
-  debug_inspect(arr.strip_suffix([1, 2, 3][:]), content="Some(<ArrayView: []>)")
-  debug_inspect(arr.strip_suffix([1, 2][:]), content="None")
+  debug_inspect(arr.strip_suffix([2, 3]), content="Some(<ArrayView: [1]>)")
+  debug_inspect(arr.strip_suffix([1, 2, 3]), content="Some(<ArrayView: []>)")
+  debug_inspect(arr.strip_suffix([1, 2]), content="None")
 }
 
 ///|

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1100,12 +1100,12 @@ pub fn[T : Eq] ArrayView::ends_with(
 /// test {
 ///   let v = [1, 2, 3, 4, 5][:]
 ///   debug_inspect(
-///     v.strip_prefix([1, 2][:]),
+///     v.strip_prefix([1, 2]),
 ///     content=(
 ///       #|Some(<ArrayView: [3, 4, 5]>)
 ///     ),
 ///   )
-///   debug_inspect(v.strip_prefix([2, 3][:]), content="None")
+///   debug_inspect(v.strip_prefix([2, 3]), content="None")
 /// }
 /// ```
 pub fn[T : Eq] ArrayView::strip_prefix(
@@ -1130,12 +1130,12 @@ pub fn[T : Eq] ArrayView::strip_prefix(
 /// test {
 ///   let v = [1, 2, 3, 4, 5][:]
 ///   debug_inspect(
-///     v.strip_suffix([4, 5][:]),
+///     v.strip_suffix([4, 5]),
 ///     content=(
 ///       #|Some(<ArrayView: [1, 2, 3]>)
 ///     ),
 ///   )
-///   debug_inspect(v.strip_suffix([3, 4][:]), content="None")
+///   debug_inspect(v.strip_suffix([3, 4]), content="None")
 /// }
 /// ```
 pub fn[T : Eq] ArrayView::strip_suffix(

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -1336,40 +1336,40 @@ test "ArrayView::windows shares backing" {
 test "ArrayView::strip_prefix basic" {
   let v = [1, 2, 3, 4, 5][:]
   debug_inspect(
-    v.strip_prefix([1, 2][:]),
+    v.strip_prefix([1, 2]),
     content="Some(<ArrayView: [3, 4, 5]>)",
   )
-  debug_inspect(v.strip_prefix([2, 3][:]), content="None")
+  debug_inspect(v.strip_prefix([2, 3]), content="None")
 }
 
 ///|
 test "ArrayView::strip_prefix empty prefix" {
   let v = [1, 2, 3][:]
-  debug_inspect(v.strip_prefix([][:]), content="Some(<ArrayView: [1, 2, 3]>)")
+  debug_inspect(v.strip_prefix([]), content="Some(<ArrayView: [1, 2, 3]>)")
 }
 
 ///|
 test "ArrayView::strip_prefix full match" {
   let v = [1, 2, 3][:]
-  debug_inspect(v.strip_prefix([1, 2, 3][:]), content="Some(<ArrayView: []>)")
+  debug_inspect(v.strip_prefix([1, 2, 3]), content="Some(<ArrayView: []>)")
 }
 
 ///|
 test "ArrayView::strip_prefix too long" {
   let v = [1, 2][:]
-  debug_inspect(v.strip_prefix([1, 2, 3][:]), content="None")
+  debug_inspect(v.strip_prefix([1, 2, 3]), content="None")
 }
 
 ///|
 test "ArrayView::strip_prefix on sliced view" {
   let v = [0, 1, 2, 3, 4][1:]
-  debug_inspect(v.strip_prefix([1, 2][:]), content="Some(<ArrayView: [3, 4]>)")
+  debug_inspect(v.strip_prefix([1, 2]), content="Some(<ArrayView: [3, 4]>)")
 }
 
 ///|
 test "ArrayView::strip_prefix shares backing" {
   let arr = [1, 2, 3, 4, 5]
-  guard arr[:].strip_prefix([1, 2][:]) is Some(rest)
+  guard arr[:].strip_prefix([1, 2]) is Some(rest)
   arr[2] = 99
   debug_inspect(
     rest,
@@ -1383,32 +1383,32 @@ test "ArrayView::strip_prefix shares backing" {
 test "ArrayView::strip_suffix basic" {
   let v = [1, 2, 3, 4, 5][:]
   debug_inspect(
-    v.strip_suffix([4, 5][:]),
+    v.strip_suffix([4, 5]),
     content="Some(<ArrayView: [1, 2, 3]>)",
   )
-  debug_inspect(v.strip_suffix([3, 4][:]), content="None")
+  debug_inspect(v.strip_suffix([3, 4]), content="None")
 }
 
 ///|
 test "ArrayView::strip_suffix empty suffix" {
   let v = [1, 2, 3][:]
-  debug_inspect(v.strip_suffix([][:]), content="Some(<ArrayView: [1, 2, 3]>)")
+  debug_inspect(v.strip_suffix([]), content="Some(<ArrayView: [1, 2, 3]>)")
 }
 
 ///|
 test "ArrayView::strip_suffix full match" {
   let v = [1, 2, 3][:]
-  debug_inspect(v.strip_suffix([1, 2, 3][:]), content="Some(<ArrayView: []>)")
+  debug_inspect(v.strip_suffix([1, 2, 3]), content="Some(<ArrayView: []>)")
 }
 
 ///|
 test "ArrayView::strip_suffix too long" {
   let v = [1, 2][:]
-  debug_inspect(v.strip_suffix([0, 1, 2][:]), content="None")
+  debug_inspect(v.strip_suffix([0, 1, 2]), content="None")
 }
 
 ///|
 test "ArrayView::strip_suffix on sliced view" {
   let v = [0, 1, 2, 3, 4][:4]
-  debug_inspect(v.strip_suffix([2, 3][:]), content="Some(<ArrayView: [0, 1]>)")
+  debug_inspect(v.strip_suffix([2, 3]), content="Some(<ArrayView: [0, 1]>)")
 }

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1544,7 +1544,7 @@ test "FixedArray::join" {
   let fixed_array_empty : FixedArray[String] = []
   inspect(fixed_array_empty.join(","), content="")
   // Any ToStringView element type works (here: StringView).
-  let view_array : FixedArray[StringView] = ["a"[:], "b"[:], "c"[:]]
+  let view_array : FixedArray[StringView] = ["a", "b", "c"]
   inspect(view_array.join("-"), content="a-b-c")
 }
 

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -963,7 +963,7 @@ test "@builtin.join/multiple_elements_without_separator" {
 
 ///|
 test "@builtin.join/any_to_string_view_element" {
-  let iter : Iter[StringView] = ["a"[:], "b"[:], "c"[:]].iter()
+  let iter : Iter[StringView] = ["a"[:], "b", "c"].iter()
   inspect(iter.join("-"), content="a-b-c")
 }
 

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -336,7 +336,7 @@ pub fn[T] ReadOnlyArray::filter(
   self : ReadOnlyArray[T],
   f : (T) -> Bool raise?,
 ) -> ReadOnlyArray[T] raise? {
-  ReadOnlyArray::from_array(self[:].filter(f)[:])
+  ReadOnlyArray::from_array(self[:].filter(f))
 }
 
 ///|
@@ -360,7 +360,7 @@ pub fn[A, B] ReadOnlyArray::filter_map(
   self : ReadOnlyArray[A],
   f : (A) -> B? raise?,
 ) -> ReadOnlyArray[B] raise? {
-  ReadOnlyArray::from_array(self[:].filter_map(f)[:])
+  ReadOnlyArray::from_array(self[:].filter_map(f))
 }
 
 ///|
@@ -534,7 +534,7 @@ pub fn[T : Compare] ReadOnlyArray::is_sorted(self : ReadOnlyArray[T]) -> Bool {
 /// ```mbt check
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
-///   inspect(arr.starts_with([1, 2][:]), content="true")
+///   inspect(arr.starts_with([1, 2]), content="true")
 /// }
 /// ```
 pub fn[T : Eq] ReadOnlyArray::starts_with(
@@ -551,7 +551,7 @@ pub fn[T : Eq] ReadOnlyArray::starts_with(
 /// ```mbt check
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
-///   inspect(arr.ends_with([4, 5][:]), content="true")
+///   inspect(arr.ends_with([4, 5]), content="true")
 /// }
 /// ```
 pub fn[T : Eq] ReadOnlyArray::ends_with(
@@ -571,12 +571,12 @@ pub fn[T : Eq] ReadOnlyArray::ends_with(
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
 ///   debug_inspect(
-///     arr.strip_prefix([1, 2][:]),
+///     arr.strip_prefix([1, 2]),
 ///     content=(
 ///       #|Some(<ArrayView: [3, 4, 5]>)
 ///     ),
 ///   )
-///   debug_inspect(arr.strip_prefix([2, 3][:]), content="None")
+///   debug_inspect(arr.strip_prefix([2, 3]), content="None")
 /// }
 /// ```
 pub fn[T : Eq] ReadOnlyArray::strip_prefix(
@@ -596,12 +596,12 @@ pub fn[T : Eq] ReadOnlyArray::strip_prefix(
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
 ///   debug_inspect(
-///     arr.strip_suffix([4, 5][:]),
+///     arr.strip_suffix([4, 5]),
 ///     content=(
 ///       #|Some(<ArrayView: [1, 2, 3]>)
 ///     ),
 ///   )
-///   debug_inspect(arr.strip_suffix([3, 4][:]), content="None")
+///   debug_inspect(arr.strip_suffix([3, 4]), content="None")
 /// }
 /// ```
 pub fn[T : Eq] ReadOnlyArray::strip_suffix(
@@ -822,7 +822,7 @@ pub fn[T : Compare] ReadOnlyArray::lexical_compare(
   self : ReadOnlyArray[T],
   other : ReadOnlyArray[T],
 ) -> Int {
-  self[:].lexical_compare(other[:])
+  self[:].lexical_compare(other)
 }
 
 ///|

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -136,7 +136,7 @@ test "ReadOnlyArray trait implementations" {
   inspect(str_arr.join(","), content="a,b,c")
 
   // Test join for any ToStringView element (here: StringView).
-  let view_arr : ReadOnlyArray[StringView] = ["a"[:], "b"[:], "c"[:]]
+  let view_arr : ReadOnlyArray[StringView] = ["a", "b", "c"]
   inspect(view_arr.join("-"), content="a-b-c")
 }
 
@@ -284,23 +284,23 @@ test "ReadOnlyArray chunk_by and suffixes" {
 test "ReadOnlyArray strip_prefix and strip_suffix" {
   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
   debug_inspect(
-    arr.strip_prefix([1, 2][:]),
+    arr.strip_prefix([1, 2]),
     content=(
       #|Some(<ArrayView: [3, 4, 5]>)
     ),
   )
-  debug_inspect(arr.strip_prefix([2, 3][:]), content="None")
+  debug_inspect(arr.strip_prefix([2, 3]), content="None")
   debug_inspect(
-    arr.strip_suffix([4, 5][:]),
+    arr.strip_suffix([4, 5]),
     content=(
       #|Some(<ArrayView: [1, 2, 3]>)
     ),
   )
-  debug_inspect(arr.strip_suffix([3, 4][:]), content="None")
+  debug_inspect(arr.strip_suffix([3, 4]), content="None")
 
   // Empty prefix / suffix returns the full / empty trailing view.
   debug_inspect(
-    arr.strip_prefix([][:]),
+    arr.strip_prefix([]),
     content=(
       #|Some(<ArrayView: [1, 2, 3, 4, 5]>)
     ),

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -233,7 +233,7 @@ pub fn String::to_array(self : String) -> Array[Char] {
 /// This method yields code units, not Unicode characters. Surrogate pairs are
 /// represented as two `UInt16` values.
 pub fn String::code_units(self : String) -> ArrayView[UInt16] {
-  Array::makei(self.length(), i => self.unsafe_get(i))[:]
+  Array::makei(self.length(), i => self.unsafe_get(i))
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -327,9 +327,9 @@ test "has_prefix" {
 ///
 /// ```mbt check
 /// test {
-///   assert_true("hello world".strip_suffix(" world") == Some("hello"[:]))
+///   assert_true("hello world".strip_suffix(" world") == Some("hello"))
 ///   assert_true("hello world".strip_suffix(" moon") == None)
-///   assert_true("hello".strip_suffix("hello") == Some(""[:]))
+///   assert_true("hello".strip_suffix("hello") == Some(""))
 /// }
 /// ```
 #alias(chop_suffix)
@@ -339,26 +339,26 @@ pub fn String::strip_suffix(self : String, suffix : StringView) -> StringView? {
 
 ///|
 test "strip_prefix" {
-  assert_true("hello world".strip_prefix("hello ") == Some("world"[:]))
+  assert_true("hello world".strip_prefix("hello ") == Some("world"))
   assert_true("hello world".strip_prefix("hi ") == None)
-  assert_true("hello".strip_prefix("hello") == Some(""[:]))
-  assert_true("".strip_prefix("") == Some(""[:]))
+  assert_true("hello".strip_prefix("hello") == Some(""))
+  assert_true("".strip_prefix("") == Some(""))
   assert_true("".strip_prefix("a") == None)
-  assert_true("abc".strip_prefix("") == Some("abc"[:]))
-  assert_true("😀hello".strip_prefix("😀") == Some("hello"[:]))
-  assert_true("😀😃hello".strip_prefix("😀😃") == Some("hello"[:]))
+  assert_true("abc".strip_prefix("") == Some("abc"))
+  assert_true("😀hello".strip_prefix("😀") == Some("hello"))
+  assert_true("😀😃hello".strip_prefix("😀😃") == Some("hello"))
 }
 
 ///|
 test "strip_suffix" {
-  assert_true("hello world".strip_suffix(" world") == Some("hello"[:]))
+  assert_true("hello world".strip_suffix(" world") == Some("hello"))
   assert_true("hello world".strip_suffix(" moon") == None)
-  assert_true("hello".strip_suffix("hello") == Some(""[:]))
-  assert_true("".strip_suffix("") == Some(""[:]))
+  assert_true("hello".strip_suffix("hello") == Some(""))
+  assert_true("".strip_suffix("") == Some(""))
   assert_true("".strip_suffix("a") == None)
-  assert_true("abc".strip_suffix("") == Some("abc"[:]))
-  assert_true("hello😀".strip_suffix("😀") == Some("hello"[:]))
-  assert_true("hello😀😃".strip_suffix("😀😃") == Some("hello"[:]))
+  assert_true("abc".strip_suffix("") == Some("abc"))
+  assert_true("hello😀".strip_suffix("😀") == Some("hello"))
+  assert_true("hello😀😃".strip_suffix("😀😃") == Some("hello"))
 }
 
 ///|
@@ -372,9 +372,9 @@ test "strip_suffix" {
 ///
 /// ```mbt check
 /// test {
-///   assert_true("hello world".strip_prefix("hello ") == Some("world"[:]))
+///   assert_true("hello world".strip_prefix("hello ") == Some("world"))
 ///   assert_true("hello world".strip_prefix("hi ") == None)
-///   assert_true("hello".strip_prefix("hello") == Some(""[:]))
+///   assert_true("hello".strip_prefix("hello") == Some(""))
 /// }
 /// ```
 #alias(chop_prefix)
@@ -394,9 +394,9 @@ pub fn String::strip_prefix(self : String, prefix : StringView) -> StringView? {
 /// ```mbt check
 /// test {
 ///   let view = "hello world"[:]
-///   assert_true(view.strip_prefix("hello ") == Some("world"[:]))
+///   assert_true(view.strip_prefix("hello ") == Some("world"))
 ///   assert_true(view.strip_prefix("hi ") == None)
-///   assert_true(view.strip_prefix("hello world") == Some(""[:]))
+///   assert_true(view.strip_prefix("hello world") == Some(""))
 /// }
 /// ```
 #alias(chop_prefix)
@@ -424,9 +424,9 @@ pub fn StringView::strip_prefix(
 /// ```mbt check
 /// test {
 ///   let view = "hello world"[:]
-///   assert_true(view.strip_suffix(" world") == Some("hello"[:]))
+///   assert_true(view.strip_suffix(" world") == Some("hello"))
 ///   assert_true(view.strip_suffix(" moon") == None)
-///   assert_true(view.strip_suffix("hello world") == Some(""[:]))
+///   assert_true(view.strip_suffix("hello world") == Some(""))
 /// }
 /// ```
 #alias(chop_suffix)
@@ -478,30 +478,30 @@ pub fn StringView::to_bytes(self : StringView) -> Bytes {
 ///|
 test "View::strip_prefix" {
   let view = "hello world"[:]
-  assert_true(view.strip_prefix("hello ") == Some("world"[:]))
+  assert_true(view.strip_prefix("hello ") == Some("world"))
   assert_true(view.strip_prefix("hi ") == None)
-  assert_true(view.strip_prefix("hello world") == Some(""[:]))
-  assert_true(view.strip_prefix("") == Some("hello world"[:]))
+  assert_true(view.strip_prefix("hello world") == Some(""))
+  assert_true(view.strip_prefix("") == Some("hello world"))
   let empty_view = ""[:]
-  assert_true(empty_view.strip_prefix("") == Some(""[:]))
+  assert_true(empty_view.strip_prefix("") == Some(""))
   assert_true(empty_view.strip_prefix("a") == None)
   let unicode_view = "😀hello😃"[:]
-  assert_true(unicode_view.strip_prefix("😀") == Some("hello😃"[:]))
+  assert_true(unicode_view.strip_prefix("😀") == Some("hello😃"))
   assert_true(unicode_view.strip_prefix("😃") == None)
 }
 
 ///|
 test "View::strip_suffix" {
   let view = "hello world"[:]
-  assert_true(view.strip_suffix(" world") == Some("hello"[:]))
+  assert_true(view.strip_suffix(" world") == Some("hello"))
   assert_true(view.strip_suffix(" moon") == None)
-  assert_true(view.strip_suffix("hello world") == Some(""[:]))
-  assert_true(view.strip_suffix("") == Some("hello world"[:]))
+  assert_true(view.strip_suffix("hello world") == Some(""))
+  assert_true(view.strip_suffix("") == Some("hello world"))
   let empty_view = ""[:]
-  assert_true(empty_view.strip_suffix("") == Some(""[:]))
+  assert_true(empty_view.strip_suffix("") == Some(""))
   assert_true(empty_view.strip_suffix("a") == None)
   let unicode_view = "😀hello😃"[:]
-  assert_true(unicode_view.strip_suffix("😃") == Some("😀hello"[:]))
+  assert_true(unicode_view.strip_suffix("😃") == Some("😀hello"))
   assert_true(unicode_view.strip_suffix("😀") == None)
 }
 
@@ -1218,7 +1218,7 @@ pub fn String::after(self : String, needle : StringView) -> StringView? {
 ///
 /// ```mbt check
 /// test {
-///   assert_true("a::b::c".rev_split_once("::") == Some(("a::b"[:], "c"[:])))
+///   assert_true("a::b::c".rev_split_once("::") == Some(("a::b", "c")))
 ///   assert_true("nope".rev_split_once("::") == None)
 /// }
 /// ```
@@ -1247,7 +1247,7 @@ pub fn StringView::rev_split_once(
 ///
 /// ```mbt check
 /// test {
-///   assert_true("a::b::c".rev_split_once("::") == Some(("a::b"[:], "c"[:])))
+///   assert_true("a::b::c".rev_split_once("::") == Some(("a::b", "c")))
 /// }
 /// ```
 pub fn String::rev_split_once(
@@ -1266,7 +1266,7 @@ pub fn String::rev_split_once(
 ///
 /// ```mbt check
 /// test {
-///   assert_true("a/b/c.txt".rev_before("/") == Some("a/b"[:]))
+///   assert_true("a/b/c.txt".rev_before("/") == Some("a/b"))
 /// }
 /// ```
 pub fn StringView::rev_before(
@@ -1288,7 +1288,7 @@ pub fn StringView::rev_before(
 ///
 /// ```mbt check
 /// test {
-///   assert_true("a/b/c.txt".rev_before("/") == Some("a/b"[:]))
+///   assert_true("a/b/c.txt".rev_before("/") == Some("a/b"))
 /// }
 /// ```
 pub fn String::rev_before(self : String, needle : StringView) -> StringView? {
@@ -1304,7 +1304,7 @@ pub fn String::rev_before(self : String, needle : StringView) -> StringView? {
 ///
 /// ```mbt check
 /// test {
-///   assert_true("a/b/c.txt".rev_after("/") == Some("c.txt"[:]))
+///   assert_true("a/b/c.txt".rev_after("/") == Some("c.txt"))
 /// }
 /// ```
 pub fn StringView::rev_after(
@@ -1326,7 +1326,7 @@ pub fn StringView::rev_after(
 ///
 /// ```mbt check
 /// test {
-///   assert_true("a/b/c.txt".rev_after("/") == Some("c.txt"[:]))
+///   assert_true("a/b/c.txt".rev_after("/") == Some("c.txt"))
 /// }
 /// ```
 pub fn String::rev_after(self : String, needle : StringView) -> StringView? {
@@ -1374,34 +1374,34 @@ test "split" {
 
 ///|
 test "split_once before after" {
-  assert_true("a=b=c".split_once("=") == Some(("a"[:], "b=c"[:])))
-  assert_true("a=b=c".before("=") == Some("a"[:]))
-  assert_true("a=b=c".after("=") == Some("b=c"[:]))
+  assert_true("a=b=c".split_once("=") == Some(("a", "b=c")))
+  assert_true("a=b=c".before("=") == Some("a"))
+  assert_true("a=b=c".after("=") == Some("b=c"))
   assert_true("nope".split_once("=") == None)
   assert_true("nope".before("=") == None)
   assert_true("nope".after("=") == None)
-  assert_true("".split_once("") == Some((""[:], ""[:])))
-  assert_true("".before("") == Some(""[:]))
-  assert_true("".after("") == Some(""[:]))
-  assert_true("hello".split_once("") == Some((""[:], "hello"[:])))
-  assert_true("hello".before("") == Some(""[:]))
-  assert_true("hello".after("") == Some("hello"[:]))
-  assert_true("😊::🚀".split_once("::") == Some(("😊"[:], "🚀"[:])))
+  assert_true("".split_once("") == Some(("", "")))
+  assert_true("".before("") == Some(""))
+  assert_true("".after("") == Some(""))
+  assert_true("hello".split_once("") == Some(("", "hello")))
+  assert_true("hello".before("") == Some(""))
+  assert_true("hello".after("") == Some("hello"))
+  assert_true("😊::🚀".split_once("::") == Some(("😊", "🚀")))
 }
 
 ///|
 test "rev_split_once rev_before rev_after" {
-  assert_true("a=b=c".rev_split_once("=") == Some(("a=b"[:], "c"[:])))
-  assert_true("a=b=c".rev_before("=") == Some("a=b"[:]))
-  assert_true("a=b=c".rev_after("=") == Some("c"[:]))
+  assert_true("a=b=c".rev_split_once("=") == Some(("a=b", "c")))
+  assert_true("a=b=c".rev_before("=") == Some("a=b"))
+  assert_true("a=b=c".rev_after("=") == Some("c"))
   assert_true("nope".rev_split_once("=") == None)
   assert_true("nope".rev_before("=") == None)
   assert_true("nope".rev_after("=") == None)
-  assert_true("a/b/c.txt".rev_before("/") == Some("a/b"[:]))
-  assert_true("a/b/c.txt".rev_after("/") == Some("c.txt"[:]))
-  assert_true("one=two".rev_split_once("=") == Some(("one"[:], "two"[:])))
+  assert_true("a/b/c.txt".rev_before("/") == Some("a/b"))
+  assert_true("a/b/c.txt".rev_after("/") == Some("c.txt"))
+  assert_true("one=two".rev_split_once("=") == Some(("one", "two")))
   assert_true(
-    "😊::🚀::⭐".rev_split_once("::") == Some(("😊::🚀"[:], "⭐"[:])),
+    "😊::🚀::⭐".rev_split_once("::") == Some(("😊::🚀", "⭐")),
   )
 }
 

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -135,7 +135,7 @@ pub fn StringView::unsafe_get(self : StringView, index : Int) -> UInt16 {
 /// This method yields code units, not Unicode characters. Surrogate pairs are
 /// represented as two `UInt16` values.
 pub fn StringView::code_units(self : StringView) -> ArrayView[UInt16] {
-  Array::makei(self.length(), i => self.unsafe_get(i))[:]
+  Array::makei(self.length(), i => self.unsafe_get(i))
 }
 
 ///|

--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -162,7 +162,7 @@ fn compact_lines(lines : Array[String]) -> Array[String] {
         let joined0 = parts.join(" ")
         let joined : StringView = match joined0.strip_suffix(",") {
           Some(sv) => sv
-          None => joined0[:]
+          None => joined0
         }
 
         // Match expected style:
@@ -210,7 +210,7 @@ fn compact_lines(lines : Array[String]) -> Array[String] {
         let joined0 = parts.join(" ")
         let joined : StringView = match joined0.strip_suffix(",") {
           Some(sv) => sv
-          None => joined0[:]
+          None => joined0
         }
         ["\{first}\{joined}\{last}"]
       } else {

--- a/moon.mod
+++ b/moon.mod
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 keywords = [ "core", "standard library" ]
 
-warnings = "+test_unqualified_package+unqualified_local_using+missing_doc"
+warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op"


### PR DESCRIPTION
## Summary
Enable `+unnecessary_view_op` in `moon.mod` and drop the unnecessary `[:]` view conversion at every site the lint flags (~111 sites across `builtin/string_methods.mbt`, `builtin/arrayview*`, `builtin/readonlyarray*`, `builtin/array*`, `debug/printer.mbt`, etc.).

In two `ReadOnlyArray` methods (`filter`, `filter_map`), only the outer `[:]` was removable; the inner `self[:]` is kept because removing it makes `self.filter(f)` / `self.filter_map(f)` dispatch back into the same method instead of into `ArrayView::filter`/`filter_map`. The lint flagged both but only one is genuinely unnecessary.

## Test plan
- [x] `moon check` clean.
- [x] `moon test` — 6521/6521 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)