### PR TITLE
warnings: enable unnecessary_annotation and drop 272 redundant qualifiers

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -53,7 +53,7 @@ pub impl Show for BigInt with fn to_string(self) {
 ///|
 pub impl @json.FromJson for BigInt with fn from_json(json, path) {
   guard json is String(s) else {
-    raise @json.JsonDecodeError(
+    raise JsonDecodeError(
       (path, "BigInt::from_json: expected number in string representation"),
     )
   }

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -1335,10 +1335,7 @@ test "ArrayView::windows shares backing" {
 ///|
 test "ArrayView::strip_prefix basic" {
   let v = [1, 2, 3, 4, 5][:]
-  debug_inspect(
-    v.strip_prefix([1, 2]),
-    content="Some(<ArrayView: [3, 4, 5]>)",
-  )
+  debug_inspect(v.strip_prefix([1, 2]), content="Some(<ArrayView: [3, 4, 5]>)")
   debug_inspect(v.strip_prefix([2, 3]), content="None")
 }
 
@@ -1382,10 +1379,7 @@ test "ArrayView::strip_prefix shares backing" {
 ///|
 test "ArrayView::strip_suffix basic" {
   let v = [1, 2, 3, 4, 5][:]
-  debug_inspect(
-    v.strip_suffix([4, 5]),
-    content="Some(<ArrayView: [1, 2, 3]>)",
-  )
+  debug_inspect(v.strip_suffix([4, 5]), content="Some(<ArrayView: [1, 2, 3]>)")
   debug_inspect(v.strip_suffix([3, 4]), content="None")
 }
 

--- a/builtin/iter2_test.mbt
+++ b/builtin/iter2_test.mbt
@@ -23,7 +23,7 @@ test "iter2_to_iter" {
 
 ///|
 test "iter2 identity function should return its input" {
-  let m : @builtin.Map[String, Int] = @builtin.Map([])
+  let m : @builtin.Map[String, Int] = Map([])
   m.set("x", 1)
   m.set("y", 2)
   let iter2 = m.iter2()

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -643,24 +643,24 @@ test "Map collision probe paths" {
   })
   debug_inspect(map.get(k1b), content="Some(30)")
   inspect(map[k1b], content="30")
-  inspect(map.get_or_default(LKey::LKey(4, 0), 99), content="99")
-  inspect(map.contains(LKey::LKey(5, 0)), content="false")
+  inspect(map.get_or_default(LKey(4, 0), 99), content="99")
+  inspect(map.contains(LKey(5, 0)), content="false")
 }
 
 ///|
 test "Map grow rehashes collision cluster in insertion order" {
   let map : Map[LKey, Int] = Map([], capacity=2)
   for i in 0..<12 {
-    map[LKey::LKey(i, i % 4)] = i * 10
+    map[LKey(i, i % 4)] = i * 10
   }
   inspect(map.length(), content="12")
   for i in 0..<12 {
-    @test.assert_eq(map.get(LKey::LKey(i, i % 4)), Some(i * 10))
+    @test.assert_eq(map.get(LKey(i, i % 4)), Some(i * 10))
   }
-  map.remove(LKey::LKey(5, 1))
-  @test.assert_eq(map.get(LKey::LKey(5, 1)), None)
-  map[LKey::LKey(12, 0)] = 120
-  @test.assert_eq(map.get(LKey::LKey(12, 0)), Some(120))
+  map.remove(LKey(5, 1))
+  @test.assert_eq(map.get(LKey(5, 1)), None)
+  map[LKey(12, 0)] = 120
+  @test.assert_eq(map.get(LKey(12, 0)), Some(120))
   debug_inspect(
     map.values().to_array(),
     content="[0, 10, 20, 30, 40, 60, 70, 80, 90, 100, 110, 120]",

--- a/builtin/operators_test.mbt
+++ b/builtin/operators_test.mbt
@@ -19,7 +19,7 @@ struct Num {
 
 ///|
 fn num(value : Int) -> Num {
-  Num::{ value, }
+  { value, }
 }
 
 ///|

--- a/builtin/option_test.mbt
+++ b/builtin/option_test.mbt
@@ -14,11 +14,11 @@
 
 ///|
 test {
-  @test.assert_eq((Option::None : Unit?), Option::None)
-  @test.assert_eq(Option::Some(1), Option::Some(1))
-  @test.assert_not_eq(Option::Some(1), Option::Some(2))
-  @test.assert_not_eq(Option::None, Option::Some(1))
-  @test.assert_not_eq(Option::Some(1), Option::None)
+  @test.assert_eq((None : Unit?), None)
+  @test.assert_eq(Option::Some(1), Some(1))
+  @test.assert_not_eq(Option::Some(1), Some(2))
+  @test.assert_not_eq(Option::None, Some(1))
+  @test.assert_not_eq(Option::Some(1), None)
 }
 
 ///|

--- a/builtin/result.mbt
+++ b/builtin/result.mbt
@@ -247,7 +247,7 @@ test "compare" {
   let err1 = Result::Err(1)
   let err2 = Result::Err(2)
   assert_eq(0, ok1.compare(ok1))
-  assert_eq(0, err2.compare(Result::Err(2)))
+  assert_eq(0, err2.compare(Err(2)))
   assert_eq(-1, ok1.compare(ok2))
   assert_eq(1, ok2.compare(ok1))
   assert_eq(-1, err1.compare(err2))

--- a/builtin/result_test.mbt
+++ b/builtin/result_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "Result equality with Ok" {
-  let result1 : Result[Int, String] = Result::Ok(1)
+  let result1 : Result[Int, String] = Ok(1)
   let result2 = Result::Ok(1)
   let result3 = Result::Ok(2)
   @test.assert_eq(result1, result2)
@@ -23,7 +23,7 @@ test "Result equality with Ok" {
 
 ///|
 test "Result equality with Err" {
-  let result1 : Result[Int, String] = Result::Err("error")
+  let result1 : Result[Int, String] = Err("error")
   let result2 = Result::Err("error")
   let result3 = Result::Err("different error")
   @test.assert_eq(result1, result2)

--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -70,8 +70,8 @@ impl Logger for TestLogger with fn write_view(self, value) {
 test "Eq helpers" {
   inspect(Eq::not_equal(1, 2), content="true")
   inspect(Eq::equal(3, 3), content="true")
-  let a : Pair = Pair::{ left: 1, right: 2 }
-  let b : Pair = Pair::{ left: 1, right: 3 }
+  let a : Pair = { left: 1, right: 2 }
+  let b : Pair = { left: 1, right: 3 }
   inspect(Eq::not_equal(a, b), content="true")
 }
 

--- a/bytes/deprecated.mbt
+++ b/bytes/deprecated.mbt
@@ -97,7 +97,6 @@ pub fn BytesRegex::execute(
 ) -> MatchResult? {
   match self.0.execute(input, last_index) {
     None => None
-    Some(result) =>
-      Some(MatchResult::{ input, group_names: self.0.group_names(), result })
+    Some(result) => Some({ input, group_names: self.0.group_names(), result })
   }
 }

--- a/bytes/internal/regex_engine/ast/pattern.mbt
+++ b/bytes/internal/regex_engine/ast/pattern.mbt
@@ -81,13 +81,13 @@ pub fn char(cs : @shared_types.RecharSet) -> Pattern {
   if cs.is_empty() {
     empty
   } else {
-    Pattern::{ desc: Char(cs), nullable: false }
+    { desc: Char(cs), nullable: false }
   }
 }
 
 ///|
 /// Epsilon pattern that matches empty input.
-pub let epsilon : Pattern = Pattern::{ desc: Sequence([]), nullable: true }
+pub let epsilon : Pattern = { desc: Sequence([]), nullable: true }
 
 ///|
 /// Concatenate patterns.
@@ -107,7 +107,7 @@ pub fn seq(exprs : ReadOnlyArray[Pattern]) -> Pattern {
     [] => epsilon
     [expr] => expr
     exprs =>
-      Pattern::{
+      {
         desc: Sequence(ReadOnlyArray::from_array(exprs)),
         nullable: exprs.all(e => e.nullable),
       }
@@ -116,7 +116,7 @@ pub fn seq(exprs : ReadOnlyArray[Pattern]) -> Pattern {
 
 ///|
 /// Empty pattern that matches nothing.
-pub let empty : Pattern = Pattern::{ desc: Alternation([]), nullable: false }
+pub let empty : Pattern = { desc: Alternation([]), nullable: false }
 
 ///|
 /// Build an alternation of patterns.
@@ -124,11 +124,7 @@ pub fn alt(exprs : ReadOnlyArray[Pattern]) -> Pattern {
   match exprs {
     [] => empty
     [expr] => expr
-    exprs =>
-      Pattern::{
-        desc: Alternation(exprs),
-        nullable: exprs.any(e => e.nullable),
-      }
+    exprs => { desc: Alternation(exprs), nullable: exprs.any(e => e.nullable) }
   }
 }
 
@@ -139,7 +135,7 @@ pub fn alt(exprs : ReadOnlyArray[Pattern]) -> Pattern {
 pub fn quantifier(expr : Pattern, q : Quantifier) -> Pattern {
   guard q.min >= 0 else { panic() }
   guard q.max is None || (q.max is Some(max) && max >= q.min) else { panic() }
-  Pattern::{ desc: Quantifier(q, expr), nullable: expr.nullable || q.min == 0 }
+  { desc: Quantifier(q, expr), nullable: expr.nullable || q.min == 0 }
 }
 
 ///|
@@ -148,7 +144,7 @@ pub fn preference(pref : @shared_types.Preference, expr : Pattern) -> Pattern {
   if expr.desc is Char(_) {
     expr
   } else {
-    Pattern::{ desc: Preference(pref, expr), nullable: expr.nullable }
+    { desc: Preference(pref, expr), nullable: expr.nullable }
   }
 }
 
@@ -173,13 +169,13 @@ pub fn first(expr : Pattern) -> Pattern {
 ///|
 /// Wrap a pattern in a capturing group.
 pub fn capture(name? : String, expr : Pattern) -> Pattern {
-  Pattern::{ desc: Capture(name~, expr), nullable: expr.nullable }
+  { desc: Capture(name~, expr), nullable: expr.nullable }
 }
 
 ///|
 /// Create an assertion pattern node.
 pub fn assertion(a : Assertion) -> Pattern {
-  Pattern::{ desc: Assertion(a), nullable: true }
+  { desc: Assertion(a), nullable: true }
 }
 
 ///|

--- a/bytes/internal/regex_engine/regex.mbt
+++ b/bytes/internal/regex_engine/regex.mbt
@@ -40,7 +40,7 @@ fn Regex::new(
   symbol_table : &@symbol_map.Table,
   symbol_repr : ReadOnlyArray[Rechar],
 ) -> Regex {
-  Regex::{
+  {
     profile,
     ctx,
     expr,
@@ -48,7 +48,7 @@ fn Regex::new(
     symbol_table,
     symbol_repr,
     start_states: [],
-    state_table: @hashmap.HashMap([]),
+    state_table: HashMap([]),
     states: [],
   }
 }

--- a/bytes/internal/regex_engine/state.mbt
+++ b/bytes/internal/regex_engine/state.mbt
@@ -38,7 +38,7 @@ fn State::new(desc : @automata.State, num_symbols : Int) -> State {
     Match(_) | Failed => true
     Running => false
   }
-  State::{
+  {
     kind: if is_break {
       Break
     } else {

--- a/bytes/internal/regex_engine/symbol_map/symbol_map.mbt
+++ b/bytes/internal/regex_engine/symbol_map/symbol_map.mbt
@@ -18,7 +18,7 @@ struct SymbolMap(@sorted_set.SortedSet[@shared_types.Rechar])
 ///|
 /// Create a new instance.
 pub fn new() -> SymbolMap {
-  SymbolMap(@sorted_set.SortedSet([]))
+  SymbolMap(SortedSet([]))
 }
 
 ///|

--- a/bytes/internal/regex_engine/translate.mbt
+++ b/bytes/internal/regex_engine/translate.mbt
@@ -25,7 +25,7 @@ fn TranslateContext::new(
   ctx : @automata.Context,
   symbol_table : &@symbol_map.Table,
 ) -> TranslateContext {
-  TranslateContext::{ ctx, pref: First, groups: [], symbol_table }
+  { ctx, pref: First, groups: [], symbol_table }
 }
 
 ///|
@@ -90,12 +90,12 @@ fn translate(
         @automata.e_seq(
           ctx~,
           First,
-          @automata.e_mark(ctx~, @automata.Mark(group_index * 2)),
+          @automata.e_mark(ctx~, Mark(group_index * 2)),
           @automata.e_seq(
             ctx~,
             First,
             cr,
-            @automata.e_mark(ctx~, @automata.Mark(group_index * 2 + 1)),
+            @automata.e_mark(ctx~, Mark(group_index * 2 + 1)),
           ),
         ),
         pref2,

--- a/cmp/README.mbt.md
+++ b/cmp/README.mbt.md
@@ -48,7 +48,7 @@ test "reverse comparison" {
 ///|
 test "reverse with arrays" {
   // Create an array with reversed integers for descending sort
-  let arr = [@cmp.Reverse(3), @cmp.Reverse(1), @cmp.Reverse(4), @cmp.Reverse(2)]
+  let arr = [@cmp.Reverse(3), Reverse(1), Reverse(4), Reverse(2)]
   // When sorted, the array will be in descending order of the wrapped values
   inspect(arr[0], content="Reverse(3)") // Access first element
 }

--- a/deque/README.mbt.md
+++ b/deque/README.mbt.md
@@ -11,7 +11,7 @@ Create an empty deque with `Deque([])`, or construct one from an array or iterat
 ```mbt check
 ///|
 test {
-  let dv : @deque.Deque[Int] = @deque.Deque([])
+  let dv : @deque.Deque[Int] = Deque([])
   @test.assert_eq(dv.is_empty(), true)
   let dv2 = @deque.from_array([1, 2, 3, 4, 5])
   @test.assert_eq(dv2.length(), 5)
@@ -25,7 +25,7 @@ Pre-allocate capacity to avoid resizing:
 ```mbt check
 ///|
 test {
-  let dv : @deque.Deque[Int] = @deque.Deque([], capacity=1024)
+  let dv : @deque.Deque[Int] = Deque([], capacity=1024)
   @test.assert_eq(dv.capacity(), 1024)
 }
 ```

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -17,7 +17,7 @@ fn[T] set_null(buffer : UninitializedArray[T], index : Int) = "%fixedarray.set_n
 
 ///|
 fn[A] new_deque(capacity : Int) -> Deque[A] {
-  Deque::{ buf: UninitializedArray::make(capacity), len: 0, head: 0 }
+  { buf: UninitializedArray::make(capacity), len: 0, head: 0 }
 }
 
 ///|
@@ -122,7 +122,7 @@ pub impl[A] Add for Deque[A] with fn add(self, other) {
   let buf = UninitializedArray::make(len)
   self.unsafe_blit_to(buf, 0)
   other.unsafe_blit_to(buf, self.len)
-  Deque::{ buf, len, head: 0 }
+  { buf, len, head: 0 }
 }
 
 ///|
@@ -174,7 +174,7 @@ pub fn[A] Deque::Deque(arr : ArrayView[A], capacity? : Int) -> Deque[A] {
   for i, x in arr {
     buf[i] = x
   }
-  Deque::{ buf, len, head: 0 }
+  { buf, len, head: 0 }
 }
 
 ///|
@@ -216,7 +216,7 @@ pub fn[A] Deque::copy(self : Deque[A]) -> Deque[A] {
   let len = self.len
   let buf = UninitializedArray::make(len)
   self.unsafe_blit_to(buf, 0)
-  Deque::{ buf, len, head: 0 }
+  { buf, len, head: 0 }
 }
 
 ///|
@@ -1076,7 +1076,7 @@ pub fn[A, U] Deque::map(self : Deque[A], f : (A) -> U) -> Deque[U] {
       let idx = (self.head + i) % cap
       buf[i] = f(self.buf[idx])
     }
-    Deque::{ buf, len: self.len, head: 0 }
+    { buf, len: self.len, head: 0 }
   }
 }
 
@@ -1102,7 +1102,7 @@ pub fn[A, U] Deque::mapi(self : Deque[A], f : (Int, A) -> U) -> Deque[U] {
       let idx = (self.head + i) % cap
       buf[i] = f(i, self.buf[idx])
     }
-    Deque::{ buf, len: self.len, head: 0 }
+    { buf, len: self.len, head: 0 }
   }
 }
 
@@ -1813,7 +1813,7 @@ pub impl[A : @json.FromJson] @json.FromJson for Deque[A] with fn from_json(
   path,
 ) {
   guard json is Array(arr) else {
-    raise @json.JsonDecodeError((path, "Deque::from_json: expected array"))
+    raise JsonDecodeError((path, "Deque::from_json: expected array"))
   }
   let len = arr.length()
   let buf = UninitializedArray::make(len)
@@ -2410,7 +2410,7 @@ pub impl[A : Compare] Compare for Deque[A] with fn compare(self, other) {
 ///       #|<Deque: [5, 4, 3, 2, 1]>
 ///     ),
 ///   )
-///   let dq : @deque.Deque[Int] = @deque.Deque([])
+///   let dq : @deque.Deque[Int] = Deque([])
 ///   dq.rev_in_place()
 ///   @debug.debug_inspect(
 ///     dq,
@@ -2470,7 +2470,7 @@ pub fn[A] Deque::rev(self : Deque[A]) -> Deque[A] {
     new_buf[i] = self.buf[src_idx]
   }
   // Create new deque with reversed elements
-  Deque::{ buf: new_buf, len, head: 0 }
+  { buf: new_buf, len, head: 0 }
 }
 
 ///|

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -293,7 +293,7 @@ test "from_json rejects non-array" {
 ///|
 test "copy" {
   debug_inspect(
-    (@deque.Deque([]) : @deque.Deque[Int]).copy(),
+    (Deque([]) : @deque.Deque[Int]).copy(),
     content=(
       #|<Deque: []>
     ),
@@ -431,20 +431,20 @@ test "front_and_back" {
   let dv = @deque.from_array([1, 2, 3, 4, 5])
   @test.assert_eq(dv.back(), Some(5))
   @test.assert_eq(dv.front(), Some(1))
-  let dv : @deque.Deque[Int] = @deque.Deque([])
+  let dv : @deque.Deque[Int] = Deque([])
   @test.assert_eq(dv.back(), None)
   @test.assert_eq(dv.front(), None)
 }
 
 ///|
 test "new_with_capacity" {
-  let d : @deque.Deque[Int] = @deque.Deque([], capacity=0)
+  let d : @deque.Deque[Int] = Deque([], capacity=0)
   inspect(d.capacity(), content="0")
 }
 
 ///|
 test "new_with_capacity_non_zero" {
-  let d : @deque.Deque[Int] = @deque.Deque([], capacity=10)
+  let d : @deque.Deque[Int] = Deque([], capacity=10)
   inspect(d.capacity(), content="10")
 }
 
@@ -710,7 +710,7 @@ test "deque push_back when empty" {
 ///|
 test "deque as_views" {
   // Test empty deque
-  let dq1 : @deque.Deque[Int] = @deque.Deque([])
+  let dq1 : @deque.Deque[Int] = Deque([])
   @json.json_inspect(dq1.as_views(), content=[[], []])
 
   // Test contiguous case (head_len >= len)
@@ -751,7 +751,7 @@ test "test_get" {
 
 ///|
 test "test_reserve_capacity" {
-  let tester : @deque.Deque[Int] = @deque.Deque([], capacity=1)
+  let tester : @deque.Deque[Int] = Deque([], capacity=1)
   inspect(tester.capacity(), content="1")
   tester.reserve_capacity(2)
   inspect(tester.capacity(), content="2")
@@ -970,7 +970,7 @@ test "deque guard iter2 coverage improvement" {
 ///|
 test "deque truncate" {
   // Empty deque
-  let dq : @deque.Deque[Int] = @deque.Deque([])
+  let dq : @deque.Deque[Int] = Deque([])
   dq.truncate(3)
   @json.json_inspect(dq, content=[])
 
@@ -1015,7 +1015,7 @@ test "deque retain" {
   let is_even = x => x % 2 == 0
 
   // Empty deque
-  let dq : @deque.Deque[Int] = @deque.Deque([])
+  let dq : @deque.Deque[Int] = Deque([])
   dq.retain(is_even)
   @json.json_inspect(dq, content=[])
 
@@ -1112,7 +1112,7 @@ test "deque retain_map" {
   let inc_if_even = inc_if(is_even)
 
   // Empty deque
-  let dq : @deque.Deque[Int] = @deque.Deque([])
+  let dq : @deque.Deque[Int] = Deque([])
   dq.retain_map(inc_if_even)
   @json.json_inspect(dq, content=[])
 
@@ -1196,7 +1196,7 @@ test "deque retain_map clears full wrapped deque" {
 
 ///|
 test "@deque.to_array/empty" {
-  let dq : @deque.Deque[Int] = @deque.Deque([])
+  let dq : @deque.Deque[Int] = Deque([])
   let arr = dq.to_array()
   @json.json_inspect(arr, content=[])
 }
@@ -1766,7 +1766,7 @@ test "rev_inplace" {
   @test.assert_eq(dq, @deque.from_array([3, 4]))
 
   // Test with empty deque
-  let empty : @deque.Deque[Int] = @deque.Deque([])
+  let empty : @deque.Deque[Int] = Deque([])
   empty.rev_in_place()
   @test.assert_eq(empty, @deque.from_array([]))
 
@@ -1803,7 +1803,7 @@ test "rev" {
   @test.assert_eq(reversed_back, @deque.from_array([3, 4, 5]))
 
   // Test with empty deque
-  let empty : @deque.Deque[Int] = @deque.Deque([])
+  let empty : @deque.Deque[Int] = Deque([])
   let empty_reversed = empty.rev()
   @test.assert_eq(empty, @deque.from_array([]))
   @test.assert_eq(empty_reversed, @deque.from_array([]))

--- a/hashmap/README.mbt.md
+++ b/hashmap/README.mbt.md
@@ -12,7 +12,7 @@ You can create an empty map using `HashMap([])` or construct it from entries usi
 ///|
 test {
   let _map1 = @hashmap.HashMap([("a", 1), ("b", 2)])
-  let _map2 : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let _map2 : @hashmap.HashMap[String, Int] = HashMap([])
 }
 ```
 
@@ -23,7 +23,7 @@ You can use `set()` to add a key-value pair to the map, and use `get()` to get a
 ```mbt check
 ///|
 test {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[String, Int] = HashMap([])
   map.set("a", 1)
   @test.assert_eq(map.get("a"), Some(1))
   @test.assert_eq(map.get_or_default("a", 0), 1)
@@ -77,7 +77,7 @@ Similarly, you can use `is_empty()` to check whether the map is empty.
 ```mbt check
 ///|
 test {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[String, Int] = HashMap([])
   @test.assert_eq(map.is_empty(), true)
 }
 ```
@@ -129,7 +129,7 @@ Use `get_or_init()` to get a value or initialize it if missing:
 ```mbt check
 ///|
 test {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[String, Int] = HashMap([])
   let val = map.get_or_init("key", () => 42)
   @test.assert_eq(val, 42)
   @test.assert_eq(map.get("key"), Some(42))

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -93,7 +93,7 @@ pub fn[K : Hash + Eq, V] HashMap::HashMap(
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+///   let map : @hashmap.HashMap[String, Int] = HashMap([])
 ///   map.set("key", 42)
 ///   debug_inspect(map.get("key"), content="Some(42)")
 ///   map.set("key", 24) // update existing key
@@ -339,7 +339,7 @@ pub fn[K : Hash + Eq, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+///   let map : @hashmap.HashMap[String, Int] = HashMap([])
 ///   let value = map.get_or_init("key", () => 42)
 ///   inspect(value, content="42")
 ///   debug_inspect(map.get("key"), content="Some(42)")
@@ -411,10 +411,7 @@ pub fn[K : Hash + Eq, V] HashMap::get_or_init(
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([
-///     ("a", 1),
-///     ("b", 2),
-///   ])
+///   let map : @hashmap.HashMap[String, Int] = HashMap([("a", 1), ("b", 2)])
 ///
 ///   // Update existing value
 ///   map.update("a", fn(v) {
@@ -489,7 +486,7 @@ pub fn[K : Hash + Eq, V] HashMap::update(
 ///
 /// ```mbt check
 /// test {
-///   let counts : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+///   let counts : @hashmap.HashMap[String, Int] = HashMap([])
 ///   counts.update_or_default("a", 1, x => x + 1)
 ///   counts.update_or_default("a", 1, x => x + 1)
 ///   counts.update_or_default("b", 1, x => x + 1)

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "new" {
-  let m : @hashmap.HashMap[Int, Int] = @hashmap.HashMap([])
+  let m : @hashmap.HashMap[Int, Int] = HashMap([])
   inspect(m.capacity(), content="8")
   inspect(m.length(), content="0")
 }
@@ -57,7 +57,7 @@ test "get_or_default" {
 
 ///|
 test "get_or_init" {
-  let m : @hashmap.HashMap[String, Array[Int]] = @hashmap.HashMap([])
+  let m : @hashmap.HashMap[String, Array[Int]] = HashMap([])
   m.get_or_init("a", () => Array::new()).push(1)
   m.get_or_init("b", () => Array::new()).push(2)
   m.get_or_init("a", () => Array::new()).push(3)
@@ -77,7 +77,7 @@ test "get_or_init full" {
 
 ///|
 test "update_or_default inserts default when absent" {
-  let m : @hashmap.HashMap[String, String] = @hashmap.HashMap([])
+  let m : @hashmap.HashMap[String, String] = HashMap([])
   m.update_or_default("k", "v", x => x + "!")
   // f is NOT applied to default on first insert
   @test.assert_eq(m.get("k"), Some("v"))
@@ -86,7 +86,7 @@ test "update_or_default inserts default when absent" {
 
 ///|
 test "update_or_default applies f when present" {
-  let m : @hashmap.HashMap[String, String] = @hashmap.HashMap([])
+  let m : @hashmap.HashMap[String, String] = HashMap([])
   m.set("k", "v")
   // default is ignored when key is present; f is applied to the existing value
   m.update_or_default("k", "z", x => x + "!")
@@ -96,7 +96,7 @@ test "update_or_default applies f when present" {
 
 ///|
 test "update_or_default counter pattern" {
-  let counts : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let counts : @hashmap.HashMap[String, Int] = HashMap([])
   for label in ["a", "b", "a", "c", "a", "b"] {
     counts.update_or_default(label, 1, x => x + 1)
   }
@@ -107,7 +107,7 @@ test "update_or_default counter pattern" {
 
 ///|
 test "update_or_default triggers grow" {
-  let m : @hashmap.HashMap[Int, Int] = @hashmap.HashMap([], capacity=2)
+  let m : @hashmap.HashMap[Int, Int] = HashMap([], capacity=2)
   for i in 0..<5 {
     m.update_or_default(i, 1, x => x + 1)
   }
@@ -253,7 +253,7 @@ test "to_array" {
 
 ///|
 test "to_array empty" {
-  let map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[Int, String] = HashMap([])
   debug_inspect(map.to_array(), content="[]")
 }
 
@@ -363,7 +363,7 @@ test "from_iter empty iter" {
 
 ///|
 test "@hashmap.contains/empty" {
-  let map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[Int, String] = HashMap([])
   inspect(map.contains(42), content="false")
 }
 
@@ -506,7 +506,7 @@ test "@hashmap.merge" {
 
 ///|
 test "@hashmap.merge empty maps" {
-  let map1 : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map1 : @hashmap.HashMap[String, Int] = HashMap([])
   let map2 = @hashmap.from_array([("a", 1), ("b", 2)])
   let merged1 = map1.merge(map2)
   verify_content(merged1, [("a", 1), ("b", 2)])
@@ -531,7 +531,7 @@ test "@hashmap.merge_in_place" {
 
 ///|
 test "@hashmap.merge_in_place empty maps" {
-  let map1 : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map1 : @hashmap.HashMap[String, Int] = HashMap([])
   let map2 = @hashmap.from_array([("a", 1), ("b", 2)])
   map1.merge_in_place(map2)
   verify_content(map1, [("a", 1), ("b", 2)])
@@ -541,7 +541,7 @@ test "@hashmap.merge_in_place empty maps" {
 
 ///|
 test "@hashmap.merge_in_place self-aliasing should be no-op" {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[String, Int] = HashMap([])
   // With 4 elements: capacity=8, size=4
   // The grow condition is size >= capacity/2, i.e., 4 >= 4
   // Without fix, merge_in_place(map) calls set_with_hash which triggers grow()
@@ -563,7 +563,7 @@ test "@hashmap.merge_in_place self-aliasing should be no-op" {
 
 ///|
 test "@hashmap.set updating existing key should not grow" {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[String, Int] = HashMap([])
   // Fill to exactly at grow threshold: capacity=8, size=4
   for i in 0..<4 {
     map.set(i.to_string(), i)
@@ -599,38 +599,38 @@ impl Hash for Key with fn hash_combine(self, hasher) {
 
 ///|
 test "hashmap collision probe paths" {
-  let map : @hashmap.HashMap[Key, Int] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[Key, Int] = HashMap([])
   let k0 = Key::Key(0, 0)
   let k1 = Key::Key(1, 1)
   map.set(k0, 10)
   map.set(k1, 20)
-  inspect(map.get_or_default(Key::Key(2, 0), 99), content="99")
-  inspect(map.contains(Key::Key(3, 0)), content="false")
+  inspect(map.get_or_default(Key(2, 0), 99), content="99")
+  inspect(map.contains(Key(3, 0)), content="false")
 }
 
 ///|
 test "hashmap get_or_init push_away" {
-  let map : @hashmap.HashMap[Key, Int] = @hashmap.HashMap([])
-  map.set(Key::Key(1, 1), 10)
-  map.set(Key::Key(2, 2), 20)
-  inspect(map.get_or_init(Key::Key(3, 1), () => 30), content="30")
-  debug_inspect(map.get(Key::Key(3, 1)), content="Some(30)")
+  let map : @hashmap.HashMap[Key, Int] = HashMap([])
+  map.set(Key(1, 1), 10)
+  map.set(Key(2, 2), 20)
+  inspect(map.get_or_init(Key(3, 1), () => 30), content="30")
+  debug_inspect(map.get(Key(3, 1)), content="Some(30)")
 }
 
 ///|
 test "hashmap grow rehashes collision cluster" {
-  let map : @hashmap.HashMap[Key, Int] = @hashmap.HashMap([], capacity=2)
+  let map : @hashmap.HashMap[Key, Int] = HashMap([], capacity=2)
   for i in 0..<12 {
-    map.set(Key::Key(i, i % 4), i * 10)
+    map.set(Key(i, i % 4), i * 10)
   }
   inspect(map.length(), content="12")
   for i in 0..<12 {
-    @test.assert_eq(map.get(Key::Key(i, i % 4)), Some(i * 10))
+    @test.assert_eq(map.get(Key(i, i % 4)), Some(i * 10))
   }
-  map.remove(Key::Key(5, 1))
-  @test.assert_eq(map.get(Key::Key(5, 1)), None)
-  map.set(Key::Key(12, 0), 120)
-  @test.assert_eq(map.get(Key::Key(12, 0)), Some(120))
+  map.remove(Key(5, 1))
+  @test.assert_eq(map.get(Key(5, 1)), None)
+  map.set(Key(12, 0), 120)
+  @test.assert_eq(map.get(Key(12, 0)), Some(120))
   inspect(map.length(), content="12")
 }
 

--- a/hashmap/types_test.mbt
+++ b/hashmap/types_test.mbt
@@ -30,8 +30,8 @@ test "HashMap equality - same content different order" {
 
 ///|
 test "HashMap equality - empty maps" {
-  let map1 : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
-  let map2 : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
+  let map1 : @hashmap.HashMap[Int, String] = HashMap([])
+  let map2 : @hashmap.HashMap[Int, String] = HashMap([])
   @test.assert_eq(map1, map2)
   assert_true(map1 == map2)
 }
@@ -62,7 +62,7 @@ test "HashMap equality - same size different values" {
 
 ///|
 test "HashMap equality - one empty one non-empty" {
-  let empty_map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([])
+  let empty_map : @hashmap.HashMap[Int, String] = HashMap([])
   let non_empty_map = @hashmap.from_array([(1, "one")])
   assert_false(empty_map == non_empty_map)
   assert_false(non_empty_map == empty_map)

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -228,7 +228,7 @@ pub fn[K, V] HashMap::length(self : HashMap[K, V]) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[Int, String] = @hashmap.HashMap([], capacity=16)
+///   let map : @hashmap.HashMap[Int, String] = HashMap([], capacity=16)
 ///   inspect(map.capacity(), content="16")
 /// }
 /// ```
@@ -250,7 +250,7 @@ pub fn[K, V] HashMap::capacity(self : HashMap[K, V]) -> Int {
 ///
 /// ```mbt check
 /// test {
-///   let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+///   let map : @hashmap.HashMap[String, Int] = HashMap([])
 ///   inspect(map.is_empty(), content="true")
 ///   map.set("key", 42)
 ///   inspect(map.is_empty(), content="false")

--- a/hashmap/utils_test.mbt
+++ b/hashmap/utils_test.mbt
@@ -68,7 +68,7 @@ test "T::retain - remove all" {
 
 ///|
 test "T::retain - empty map" {
-  let map : @hashmap.HashMap[String, Int] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[String, Int] = HashMap([])
   map.retain((_k, _v) => true)
   inspect(map.length(), content="0")
   inspect(map.is_empty(), content="true")

--- a/hashset/README.mbt.md
+++ b/hashset/README.mbt.md
@@ -12,7 +12,7 @@ You can create an empty set using `HashSet([])` or construct it from entries usi
 ///|
 test {
   let _set1 = @hashset.HashSet([1, 2, 3, 4, 5])
-  let _set2 : @hashset.HashSet[String] = @hashset.HashSet([])
+  let _set2 : @hashset.HashSet[String] = HashSet([])
 }
 ```
 
@@ -23,7 +23,7 @@ You can use `insert()` to add a key to the set, and `contains()` to check whethe
 ```mbt check
 ///|
 test {
-  let set : @hashset.HashSet[String] = @hashset.HashSet([])
+  let set : @hashset.HashSet[String] = HashSet([])
   set.add("a")
   @test.assert_eq(set.contains("a"), true)
 }
@@ -60,7 +60,7 @@ Similarly, you can use `is_empty()` to check whether the set is empty.
 ```mbt check
 ///|
 test {
-  let set : @hashset.HashSet[Int] = @hashset.HashSet([])
+  let set : @hashset.HashSet[Int] = HashSet([])
   @test.assert_eq(set.is_empty(), true)
 }
 ```

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -72,7 +72,7 @@ pub fn[K : Hash + Eq] HashSet::HashSet(
 ///
 /// ```mbt check
 /// test {
-///   let set : @hashset.HashSet[String] = @hashset.HashSet([])
+///   let set : @hashset.HashSet[String] = HashSet([])
 ///   set.add("key")
 ///   inspect(set.contains("key"), content="true")
 ///   set.add("key") // no effect since it already exists
@@ -652,7 +652,7 @@ test "clear" {
 ///
 /// ```mbt check
 /// test {
-///   let set : @hashset.HashSet[String] = @hashset.HashSet([])
+///   let set : @hashset.HashSet[String] = HashSet([])
 ///   inspect(set.add_and_check("key"), content="true") // First insertion
 ///   inspect(set.add_and_check("key"), content="false") // Already exists
 ///   inspect(set.length(), content="1")

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -32,10 +32,7 @@ impl Hash for HashSetKey with fn hash_combine(self, hasher) {
 
 ///|
 test "new_with_capacity_then_add " {
-  let set : @hashset.HashSet[(String, String)] = @hashset.HashSet(
-    [],
-    capacity=20,
-  )
+  let set : @hashset.HashSet[(String, String)] = HashSet([], capacity=20)
   set.add(("None", "Hash"))
   debug_inspect(
     set,
@@ -55,7 +52,7 @@ test "to_array" {
 
 ///|
 test "add_and_check" {
-  let set : @hashset.HashSet[String] = @hashset.HashSet([])
+  let set : @hashset.HashSet[String] = HashSet([])
   inspect(set.add_and_check("key"), content="true") // First insertion
   inspect(set.add_and_check("key"), content="false") // Already exists
   inspect(set.length(), content="1")
@@ -97,14 +94,14 @@ test "to_json" {
 
 ///|
 test "new" {
-  let m : @hashset.HashSet[Int] = @hashset.HashSet([])
+  let m : @hashset.HashSet[Int] = HashSet([])
   @test.assert_eq(m.capacity(), default_init_capacity)
   inspect(m.length(), content="0")
 }
 
 ///|
 test "new with zero capacity grows on insert" {
-  let m : @hashset.HashSet[Int] = @hashset.HashSet([], capacity=0)
+  let m : @hashset.HashSet[Int] = HashSet([], capacity=0)
   m.add(1)
   assert_true(m.contains(1))
   assert_true(m.capacity() > 0)
@@ -343,18 +340,18 @@ test "insert_and_grow" {
 
 ///|
 test "grow rehashes collision cluster" {
-  let set : @hashset.HashSet[HashSetKey] = @hashset.HashSet([], capacity=2)
+  let set : @hashset.HashSet[HashSetKey] = HashSet([], capacity=2)
   for i in 0..<12 {
-    set.add(HashSetKey::HashSetKey(i, i % 4))
+    set.add(HashSetKey(i, i % 4))
   }
   inspect(set.length(), content="12")
   for i in 0..<12 {
-    assert_true(set.contains(HashSetKey::HashSetKey(i, i % 4)))
+    assert_true(set.contains(HashSetKey(i, i % 4)))
   }
-  set.remove(HashSetKey::HashSetKey(5, 1))
-  assert_false(set.contains(HashSetKey::HashSetKey(5, 1)))
-  set.add(HashSetKey::HashSetKey(12, 0))
-  assert_true(set.contains(HashSetKey::HashSetKey(12, 0)))
+  set.remove(HashSetKey(5, 1))
+  assert_false(set.contains(HashSetKey(5, 1)))
+  set.add(HashSetKey(12, 0))
+  assert_true(set.contains(HashSetKey(12, 0)))
   inspect(set.length(), content="12")
 }
 
@@ -453,7 +450,7 @@ test "hashset arbitrary" {
 
 ///|
 test "@hashset.to_array/empty" {
-  let set : @hashset.HashSet[Int] = @hashset.HashSet([])
+  let set : @hashset.HashSet[Int] = HashSet([])
   debug_inspect(set.to_array(), content="[]")
 }
 
@@ -506,7 +503,7 @@ test "retain/none_removed" {
 
 ///|
 test "retain/empty_set" {
-  let set : @hashset.HashSet[Int] = @hashset.HashSet([])
+  let set : @hashset.HashSet[Int] = HashSet([])
   set.retain(_x => true)
   @test.assert_eq(set.length(), 0)
 }

--- a/immut/array/panic_wbtest.mbt
+++ b/immut/array/panic_wbtest.mbt
@@ -14,18 +14,18 @@
 
 ///|
 test "panic get_first on empty tree should panic" {
-  let tree : Tree[Int] = Tree::Empty
+  let tree : Tree[Int] = Empty
   tree.get_first() |> ignore
 }
 
 ///|
 test "panic get_last on empty tree should panic" {
-  let tree : Tree[Int] = Tree::Empty
+  let tree : Tree[Int] = Empty
   tree.get_last() |> ignore
 }
 
 ///|
 test "panic get on empty tree should panic" {
-  let tree : Tree[Int] = Tree::Empty
+  let tree : Tree[Int] = Empty
   tree.get(0, 5) |> ignore
 }

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -48,7 +48,7 @@ let e_max_2 : Int = E_MAX / 2
 
 ///|
 fn[T] Tree::empty() -> Tree[T] {
-  Tree::Empty
+  Empty
 }
 
 ///|

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -47,7 +47,7 @@ fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
         // concat
         let len = rng.int(limit=max_len)
         let a = Array::make(len, rng.int(limit=max_val))
-        ret.push(Op::Concat(a))
+        ret.push(Concat(a))
         continue cur_len + len
       }
       2 => {
@@ -57,7 +57,7 @@ fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
         }
         let idx = rng.int(limit=cur_len)
         let val = rng.int(limit=max_val)
-        ret.push(Op::Set(idx, val))
+        ret.push(Set(idx, val))
         continue cur_len
       }
       _ => abort("Invalid op")

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -291,7 +291,7 @@ fn[K : Eq, V] Node::remove_with_path(
     Leaf(key1, value1, bucket) =>
       if key1 == key {
         match bucket {
-          @list.Empty => None
+          Empty => None
           More((key2, value2), tail~) => Some(Leaf(key2, value2, tail))
         }
       } else if bucket.find_index(kv => kv.0 == key) is Some(index) {

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -147,7 +147,7 @@ fn[A : Eq] Node::remove_with_path(
     Leaf(key1, bucket) =>
       if key1 == key {
         match bucket {
-          @list.Empty => None
+          Empty => None
           More(key2, tail=xs) => Some(Leaf(key2, xs))
         }
       } else if bucket.find_index(x => key.equal(x)) is Some(index) {

--- a/immut/priority_queue/README.mbt.md
+++ b/immut/priority_queue/README.mbt.md
@@ -11,8 +11,7 @@ You can use `PriorityQueue([])` or `of()` to create an immutable priority queue.
 ```mbt check
 ///|
 test {
-  let _queue1 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
-  )
+  let _queue1 : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   let _queue2 = @priority_queue.from_array([1, 2, 3])
 }
 ```
@@ -37,7 +36,7 @@ You can use the `is_empty` to determine whether the immutable priority queue is 
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
+  let pq : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   @test.assert_eq(pq.is_empty(), true)
 }
 ```
@@ -62,7 +61,7 @@ You can use `push()` to add elements to the immutable priority queue and get a n
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
+  let pq : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   @test.assert_eq(pq.push(1).peek(), Some(1))
 }
 ```

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -37,7 +37,7 @@ test "to_array" {
   debug_inspect(v.to_array(), content="[4, 3, 2, 1]")
   debug_inspect(v.push(0).to_array(), content="[4, 3, 2, 1, 0]")
   debug_inspect(
-    (@priority_queue.PriorityQueue([]) : @priority_queue.PriorityQueue[Int]).to_array(),
+    (PriorityQueue([]) : @priority_queue.PriorityQueue[Int]).to_array(),
     content="[]",
   )
 }
@@ -172,7 +172,7 @@ test "hash" {
   inspect(pq1.hash() == pq2.hash(), content="true")
   let pq3 = @priority_queue.from_array([5, 4, 3, 2, 1])
   inspect(pq1.hash() == pq3.hash(), content="true")
-  let pq4 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
+  let pq4 : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   inspect(pq1.hash() == pq4.hash(), content="false")
   inspect(pq4.hash() == pq4.hash(), content="true")
   let pq5 = @priority_queue.from_array([1, 2, 3, 4, 6])
@@ -187,7 +187,7 @@ test "equal" {
   inspect(pq1 == pq2, content="true")
   let pq3 = @priority_queue.from_array([5, 4, 3, 2, 1])
   inspect(pq1 == pq3, content="true")
-  let pq4 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
+  let pq4 : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   inspect(pq1 == pq4, content="false")
   let pq5 = @priority_queue.from_array([1, 2, 3])
   inspect(pq1 == pq5, content="false")
@@ -204,7 +204,7 @@ test "complex" {
   arr.shuffle_in_place(rand~)
   let pq = for
     i in 0..<=1000
-    pq = (@priority_queue.PriorityQueue([]) : @priority_queue.PriorityQueue[Int]) {
+    pq = (PriorityQueue([]) : @priority_queue.PriorityQueue[Int]) {
     continue pq.push(arr[i])
   } nobreak {
     pq
@@ -230,8 +230,7 @@ test "compare" {
   let pq1 = @priority_queue.from_array([1, 2, 3])
   let pq2 = @priority_queue.from_array([1, 2, 4])
   let pq3 = @priority_queue.from_array([1, 2])
-  let empty : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
-  )
+  let empty : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   inspect(pq1.compare(pq2), content="-1")
   inspect(pq1.compare(pq3), content="1")
   inspect(pq3.compare(pq1), content="-1")

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -104,7 +104,7 @@ pub impl[V : @json.FromJson] @json.FromJson for SortedMap[String, V] with fn fro
   path,
 ) {
   guard json is Object(obj) else {
-    raise @json.JsonDecodeError(
+    raise JsonDecodeError(
       (path, "@immut/sorted_map.from_json: expected object"),
     )
   }

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -814,9 +814,7 @@ pub impl[A : @json.FromJson + Compare] @json.FromJson for SortedSet[A] with fn f
   path,
 ) {
   guard json is Array(arr) else {
-    raise @json.JsonDecodeError(
-      (path, "@immut/sorted_set.from_json: expected array"),
-    )
+    raise JsonDecodeError((path, "@immut/sorted_set.from_json: expected array"))
   }
   for i, x in arr; set = (new() : SortedSet[A]) {
     continue set.add(A::from_json(x, path.add_index(i)))

--- a/immut/vector/panic_wbtest.mbt
+++ b/immut/vector/panic_wbtest.mbt
@@ -14,6 +14,6 @@
 
 ///|
 test "panic get on empty tree should panic" {
-  let tree : Tree[Int] = Tree::Empty
+  let tree : Tree[Int] = Empty
   tree.get(0, 5) |> ignore
 }

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -48,7 +48,7 @@ let e_max_2 : Int = E_MAX / 2
 
 ///|
 fn[T] Tree::empty() -> Tree[T] {
-  Tree::Empty
+  Empty
 }
 
 ///|

--- a/immut/vector/utils_wbtest.mbt
+++ b/immut/vector/utils_wbtest.mbt
@@ -47,7 +47,7 @@ fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
         // concat
         let len = rng.int(limit=max_len)
         let a = Array::make(len, rng.int(limit=max_val))
-        ret.push(Op::Concat(a))
+        ret.push(Concat(a))
         continue cur_len + len
       }
       2 => {
@@ -57,7 +57,7 @@ fn random_test_gen(rng : Random, times : Int, max_lvl : Int) -> Array[Op] {
         }
         let idx = rng.int(limit=cur_len)
         let val = rng.int(limit=max_val)
-        ret.push(Op::Set(idx, val))
+        ret.push(Set(idx, val))
         continue cur_len
       }
       _ => abort("Invalid op")
@@ -131,7 +131,7 @@ fn check_array_eq(a : Array[Int], t : Vector[Int]) -> Unit raise {
 ///|
 /// Generate a random reference array of length `n`.
 fn random_array(n : Int) -> Array[Int] {
-  let rng = Random(@ref.Ref(0))
+  let rng = Random(Ref(0))
   Array::makei(n, i => rng.int(limit=i))
 }
 

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -730,10 +730,8 @@ pub impl[A : @json.FromJson] @json.FromJson for Vector[A] with fn from_json(
   json,
   path,
 ) {
-  guard json is Json::Array(arr) else {
-    raise @json.JsonDecodeError(
-      (path, "@immut/vector.from_json: expected array"),
-    )
+  guard json is Array(arr) else {
+    raise JsonDecodeError((path, "@immut/vector.from_json: expected array"))
   }
   let len = arr.length()
   guard len != 0 else { return new() }

--- a/internal/regex_engine/automata/context.mbt
+++ b/internal/regex_engine/automata/context.mbt
@@ -23,7 +23,7 @@ struct Context {
 /// Create a new instance.
 #alias(new, deprecated="Use `Context()` instead")
 pub fn Context::Context() -> Context {
-  Context::{
+  {
     next_expr_id: EXPR_ID_RESERVED + 1,
     book: SlotBook::empty(),
     book_dirty: false,

--- a/internal/regex_engine/automata/expr.mbt
+++ b/internal/regex_engine/automata/expr.mbt
@@ -109,11 +109,11 @@ pub fn e_copy(ctx~ : Context, e : Expr) -> Expr {
 }
 
 ///|
-let e_empty : Expr = Expr::{ id: EXPR_ID_EMPTY, def: Alt([]) }
+let e_empty : Expr = { id: EXPR_ID_EMPTY, def: Alt([]) }
 
 ///|
 /// Canonical epsilon expression.
-pub let e_eps : Expr = Expr::{ id: EXPR_ID_EPS, def: Eps }
+pub let e_eps : Expr = { id: EXPR_ID_EPS, def: Eps }
 
 ///|
 /// Return whether the expression is epsilon.
@@ -129,7 +129,7 @@ pub fn e_cset(ctx~ : Context, c : @shared_types.RecharSet) -> Expr {
   if c.is_empty() {
     e_empty
   } else {
-    Expr::{ id: ctx.new_expr_id(), def: Chr(c) }
+    { id: ctx.new_expr_id(), def: Chr(c) }
   }
 }
 
@@ -141,25 +141,25 @@ pub fn e_rep(
   pref : @shared_types.Preference,
   x : Expr,
 ) -> Expr {
-  Expr::{ id: ctx.new_expr_id(), def: Rep(mode, pref, x) }
+  { id: ctx.new_expr_id(), def: Rep(mode, pref, x) }
 }
 
 ///|
 /// Create a capture-mark expression node.
 pub fn e_mark(ctx~ : Context, m : Mark) -> Expr {
-  Expr::{ id: ctx.new_expr_id(), def: Mark(m) }
+  { id: ctx.new_expr_id(), def: Mark(m) }
 }
 
 ///|
 /// Create a zero-width "before-category" assertion node.
 pub fn e_before(ctx~ : Context, cat : @shared_types.Category) -> Expr {
-  Expr::{ id: ctx.new_expr_id(), def: Before(cat) }
+  { id: ctx.new_expr_id(), def: Before(cat) }
 }
 
 ///|
 /// Create a zero-width "after-category" assertion node.
 pub fn e_after(ctx~ : Context, cat : @shared_types.Category) -> Expr {
-  Expr::{ id: ctx.new_expr_id(), def: After(cat) }
+  { id: ctx.new_expr_id(), def: After(cat) }
 }
 
 ///|
@@ -172,7 +172,7 @@ pub fn e_alt(ctx~ : Context, xs : Array[Expr]) -> Expr {
   match xs {
     [] => e_empty
     [x] => x
-    xs => Expr::{ id: ctx.new_expr_id(), def: Alt(xs) }
+    xs => { id: ctx.new_expr_id(), def: Alt(xs) }
   }
 }
 
@@ -196,6 +196,6 @@ pub fn e_seq(
     (_, Alt([])) => y
     (Eps, _) => y
     (_, Eps) if pref is First => x
-    _ => Expr::{ id: ctx.new_expr_id(), def: Seq(pref, x, y) }
+    _ => { id: ctx.new_expr_id(), def: Seq(pref, x, y) }
   }
 }

--- a/internal/regex_engine/automata/state.mbt
+++ b/internal/regex_engine/automata/state.mbt
@@ -87,7 +87,7 @@ fn State::new(
   cat : @shared_types.Category,
   desc : ThreadSet,
 ) -> State {
-  State::{ slot, cat, desc, hash: (slot, cat, desc).hash() }
+  { slot, cat, desc, hash: (slot, cat, desc).hash() }
 }
 
 ///|

--- a/internal/regex_engine/shared_types/profile.mbt
+++ b/internal/regex_engine/shared_types/profile.mbt
@@ -34,5 +34,5 @@ pub fn Profile::Profile(
 ) -> Profile {
   guard valid.first_interval() is Some((lb, _)) else { panic() }
   guard valid.last_interval() is Some((_, ub)) else { panic() }
-  Profile::{ lb, ub, valid, word, word_symbolize_splits, category }
+  { lb, ub, valid, word, word_symbolize_splits, category }
 }

--- a/internal/regex_engine/shared_types/rechar_set/tree.mbt
+++ b/internal/regex_engine/shared_types/rechar_set/tree.mbt
@@ -22,8 +22,8 @@ priv enum Tree {
 #inline
 fn nw(tree : Tree) -> Int {
   match tree {
-    Tree::Empty => 1
-    Tree::Node(..) as n => n.w
+    Empty => 1
+    Node(..) as n => n.w
   }
 }
 
@@ -89,9 +89,9 @@ fn bal(l : Tree, lo : Rechar, hi : Rechar, r : Tree) -> Tree {
 ///|
 fn cat(l : Tree, r : Tree) -> Tree {
   match (l, r) {
-    (Tree::Empty, r) => r
-    (l, Tree::Empty) => l
-    (Tree::Node(..) as l, Tree::Node(..) as r) => {
+    (Empty, r) => r
+    (l, Empty) => l
+    (Node(..) as l, Node(..) as r) => {
       fn go(r : Tree) -> Tree {
         match r {
           Empty => panic()

--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -147,7 +147,7 @@ test "json path" {
     let _arr : Array[Int] = @json.from_json(([42, "not a number", 49] : Json))
     panic()
   } catch {
-    @json.JsonDecodeError((path, msg)) => {
+    JsonDecodeError((path, msg)) => {
       inspect(path, content="/1")
       inspect(msg, content="Int::from_json: expected number")
     }
@@ -209,7 +209,7 @@ test "replacer custom" {
   let json : Json = { "x": 1.0, "y": 2.0 }
   // double all number values
   let replaced = json.transform(
-    @json.Replacer(fn(_key, value) {
+    Replacer(fn(_key, value) {
       match value {
         Number(n, ..) => Some(Json::number(n * 2))
         other => Some(other)
@@ -232,7 +232,7 @@ test "parse errors" {
     let _ = @json.parse("{invalid")
     panic()
   } catch {
-    @json.InvalidChar(pos, _ch) =>
+    InvalidChar(pos, _ch) =>
       debug_inspect((pos.line, pos.column), content="(1, 1)")
     _ => panic()
   }
@@ -241,7 +241,7 @@ test "parse errors" {
     let _ = @json.parse("{\"a\":")
     panic()
   } catch {
-    @json.InvalidEof => ()
+    InvalidEof => ()
     _ => panic()
   }
 }

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -296,7 +296,7 @@ pub fn Json::stringify(
               buf.write_char('{')
               buf.write_string(indent_str(depth, indent))
               // After child value printed, we resume from this frame
-              stack.push(WriteFrame::Object(members.iter(), first=true))
+              stack.push(Object(members.iter(), first=true))
             }
           Array(arr) =>
             if arr.is_empty() {
@@ -305,7 +305,7 @@ pub fn Json::stringify(
               depth += 1
               buf.write_char('[')
               buf.write_string(indent_str(depth, indent))
-              stack.push(WriteFrame::Array(arr, i=0))
+              stack.push(Array(arr, i=0))
             }
           String(s) => {
             buf.write_char('\"')
@@ -327,7 +327,7 @@ pub fn Json::stringify(
         // No current node to write; try to resume a pending container
         match stack {
           [] => break
-          [.., WriteFrame::Array(arr, i~) as frame] =>
+          [.., Array(arr, i~) as frame] =>
             if i < arr.length() {
               let element = arr[i]
               frame.i = i + 1
@@ -343,7 +343,7 @@ pub fn Json::stringify(
               buf.write_char(']')
               continue None
             }
-          [.., WriteFrame::Object(iterator, first~) as frame] =>
+          [.., Object(iterator, first~) as frame] =>
             match iterator.next() {
               Some((k, v)) => {
                 let mut v2 = v
@@ -436,7 +436,7 @@ fn escape(str : String, escape_slash~ : Bool) -> String {
 ///   // Remove sensitive data and double numeric values  
 ///   ignore(
 ///     json.transform(
-///       @json.Replacer((key, value) => {
+///       Replacer((key, value) => {
 ///         match key {
 ///           "password" => None // exclude password fields
 ///           _ =>
@@ -501,7 +501,7 @@ pub fn json_inspect(
     Some(x) => x.stringify(escape_slash=false)
   }
   if actual != want {
-    raise InspectError::InspectError(
+    raise InspectError(
       "@EXPECT_FAILED {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{want.escape()}, \"actual\": \{actual.escape()}, \"mode\": \"json\"}",
     )
   }

--- a/json/json_inspect_test.mbt
+++ b/json/json_inspect_test.mbt
@@ -45,10 +45,10 @@ struct Line {
 
 ///|
 test "json inspect" {
-  let p1 = { x: 0, y: 0, color: Color::Red }
-  let p2 = { x: 1, y: 2, color: Color::Green }
+  let p1 = { x: 0, y: 0, color: Red }
+  let p2 = { x: 1, y: 2, color: Green }
   @json.json_inspect(p1, content={ "x": 0, "y": 0, "color": "Red" })
-  let line = { p1, p2, color: Color::Blue }
+  let line = { p1, p2, color: Blue }
   @json.json_inspect(line, content={
     "p1": { "x": 0, "y": 0, "color": "Red" },
     "p2": { "x": 1, "y": 2, "color": "Green" },

--- a/json/types_test.mbt
+++ b/json/types_test.mbt
@@ -14,19 +14,10 @@
 
 ///|
 test "ParseError::to_string coverage" {
-  let invalidCharError = @json.InvalidChar(
-    @json.Position::{ line: 1, column: 0 },
-    'a',
-  )
+  let invalidCharError = @json.InvalidChar({ line: 1, column: 0 }, 'a')
   let invalidEofError = @json.InvalidEof
-  let invalidNumberError = @json.InvalidNumber(
-    @json.Position::{ line: 1, column: 0 },
-    "123abc",
-  )
-  let invalidIdentEscapeError = @json.InvalidIdentEscape(@json.Position::{
-    line: 1,
-    column: 0,
-  })
+  let invalidNumberError = @json.InvalidNumber({ line: 1, column: 0 }, "123abc")
+  let invalidIdentEscapeError = @json.InvalidIdentEscape({ line: 1, column: 0 })
   assert_eq(
     invalidCharError.to_string(),
     "Invalid character 'a' at line 1, column 0",
@@ -55,10 +46,7 @@ test "Debug for Position" {
 
 ///|
 test "Debug for ParseError" {
-  @debug.debug_inspect(
-    (@json.ParseError::InvalidEof : @json.ParseError),
-    content="InvalidEof",
-  )
+  @debug.debug_inspect((InvalidEof : @json.ParseError), content="InvalidEof")
 }
 
 ///|

--- a/json/utils.mbt
+++ b/json/utils.mbt
@@ -21,7 +21,7 @@ fn offset_to_position(input : StringView, offset : Int) -> Position {
       continue line, column + 1
     }
   } nobreak {
-    Position::{ line, column }
+    { line, column }
   }
 }
 

--- a/lazy/lazy_test.mbt
+++ b/lazy/lazy_test.mbt
@@ -46,7 +46,7 @@ test "ready returns the value without running anything" {
 
 ///|
 test "force returns each captured value" {
-  let cells = [@lazy.Lazy(() => 1), @lazy.Lazy(() => 2), @lazy.Lazy(() => 3)]
+  let cells = [@lazy.Lazy(() => 1), Lazy(() => 2), Lazy(() => 3)]
   let mut sum = 0
   for c in cells {
     sum += c.force()
@@ -81,7 +81,7 @@ test "peek on a ready cell returns Some without running" {
 
 ///|
 test "Debug renders forced and unforced cells safely" {
-  let unforced : @lazy.Lazy[Int] = @lazy.Lazy(() => abort("must not run"))
+  let unforced : @lazy.Lazy[Int] = Lazy(() => abort("must not run"))
   @debug.debug_inspect(unforced, content="<Lazy: ...>")
   let forced = @lazy.Lazy::ready(42)
   @debug.debug_inspect(forced, content="<Lazy: 42>")
@@ -113,7 +113,7 @@ test "Debug renders the in-progress Forcing state" {
 ///|
 test "Result-as-data bridge for fallible thunks" {
   let mut runs = 0
-  let cell : @lazy.Lazy[Result[Int, Error]] = @lazy.Lazy(() => {
+  let cell : @lazy.Lazy[Result[Int, Error]] = Lazy(() => {
     runs += 1
     Ok(
       {

--- a/lazy_list/lazy_list.mbt
+++ b/lazy_list/lazy_list.mbt
@@ -64,7 +64,7 @@ pub fn[A] LazyList::lazy_cons(
   head : A,
   tail : () -> LazyList[A],
 ) -> LazyList[A] {
-  { cell: Cons(head, tail=@lazy.Lazy(tail)) }
+  { cell: Cons(head, tail=Lazy(tail)) }
 }
 
 ///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -132,7 +132,7 @@ pub impl[A : @json.FromJson] @json.FromJson for List[A] with fn from_json(
   path,
 ) {
   guard json is Array(arr) else {
-    raise @json.JsonDecodeError((path, "@list.from_json: expected array"))
+    raise JsonDecodeError((path, "@list.from_json: expected array"))
   }
   for i = arr.length() - 1, list = Empty; i >= 0; {
     continue i - 1, list.prepend(A::from_json(arr[i], path.add_index(i)))

--- a/moon.mod
+++ b/moon.mod
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 keywords = [ "core", "standard library" ]
 
-warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op"
+warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op+unnecessary_annotation"

--- a/option/option_test.mbt
+++ b/option/option_test.mbt
@@ -103,7 +103,7 @@ test "map" {
 ///|
 test "map_or" {
   let a = Option::Some("foo")
-  let b : String? = Option::None
+  let b : String? = None
   assert_eq(a.map_or(42, x => x.length()), 3)
   assert_eq(b.map_or(42, x => x.length()), 42)
 }
@@ -112,7 +112,7 @@ test "map_or" {
 test "map_or_else" {
   let k = 21
   let a = Option::Some("foo")
-  let b : String? = Option::None
+  let b : String? = None
   assert_eq(a.map_or_else(() => 2 * k, x => x.length()), 3)
   assert_eq(b.map_or_else(() => 2 * k, x => x.length()), 42)
 }
@@ -174,7 +174,7 @@ test "compare" {
   let some1 = Option::Some(1)
   let some2 = Option::Some(2)
   let none = Option::None
-  assert_eq(0, some1.compare(Option::Some(1)))
+  assert_eq(0, some1.compare(Some(1)))
   assert_eq(-1, some1.compare(some2))
   assert_eq(1, some2.compare(some1))
   assert_eq(0, none.compare(none))

--- a/priority_queue/README.mbt.md
+++ b/priority_queue/README.mbt.md
@@ -11,8 +11,7 @@ You can use `PriorityQueue([])` or `of()` to create a priority queue.
 ```mbt check
 ///|
 test {
-  let queue1 : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
-  )
+  let queue1 : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   let queue2 = @priority_queue.from_array([1, 2, 3])
   @json.json_inspect(queue1, content=[])
   @json.json_inspect(queue2, content=[3, 2, 1])
@@ -31,9 +30,9 @@ test {
   // Create a min-heap by wrapping elements with @cmp.Reverse
   let min_heap = @priority_queue.from_array([
     @cmp.Reverse(5),
-    @cmp.Reverse(2),
-    @cmp.Reverse(8),
-    @cmp.Reverse(1),
+    Reverse(2),
+    Reverse(8),
+    Reverse(1),
   ])
 
   // The smallest wrapped value (1) should be at the top
@@ -58,7 +57,7 @@ Similarly, you can use the `is_empty` to determine whether the priority queue is
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
+  let pq : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   @test.assert_eq(pq.is_empty(), true)
 }
 ```
@@ -82,7 +81,7 @@ You can use `push()` to add elements to the priority queue.
 ```mbt check
 ///|
 test {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
+  let pq : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   pq.push(1)
   pq.push(2)
   @test.assert_eq(pq.peek(), Some(2))

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -303,8 +303,7 @@ pub fn[A] PriorityQueue::clear(self : PriorityQueue[A]) -> Unit {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
-///   )
+///   let queue : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
 ///   @test.assert_eq(queue.is_empty(), true)
 /// }
 /// ```

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -14,8 +14,7 @@
 
 ///|
 test "new" {
-  let queue : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([],
-  )
+  let queue : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   @test.assert_eq(queue.length(), 0)
 }
 
@@ -128,7 +127,7 @@ test "pop" {
 
 ///|
 test "pop empty" {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue([])
+  let pq : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
   debug_inspect(pq.pop(), content="None")
 }
 

--- a/queue/README.mbt.md
+++ b/queue/README.mbt.md
@@ -9,7 +9,7 @@ You can create a queue manually by using the `new` or construct it using the `fr
 ```mbt check
 ///|
 test {
-  let _queue : @queue.Queue[Int] = @queue.Queue([])
+  let _queue : @queue.Queue[Int] = Queue([])
   let _queue1 = @queue.from_array([1, 2, 3])
 }
 ```

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -24,7 +24,7 @@ fn[A] new_queue() -> Queue[A] {
 /// ```mbt check
 /// test {
 ///   let array = Array::makei(3, idx => idx + 1)
-///   let queue : @queue.Queue[Int] = @queue.Queue(array)
+///   let queue : @queue.Queue[Int] = Queue(array)
 ///   @test.assert_eq(queue.length(), 3)
 /// }
 /// ```
@@ -81,7 +81,7 @@ pub fn[A] Queue::clear(self : Queue[A]) -> Unit {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.Queue([])
+///   let queue : @queue.Queue[Int] = Queue([])
 ///   @test.assert_eq(queue.length(), 0)
 /// }
 /// ```
@@ -95,7 +95,7 @@ pub fn[A] Queue::length(self : Queue[A]) -> Int {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.Queue([])
+///   let queue : @queue.Queue[Int] = Queue([])
 ///   assert_true(queue.is_empty())
 /// }
 /// ```
@@ -109,7 +109,7 @@ pub fn[A] Queue::is_empty(self : Queue[A]) -> Bool {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.Queue([])
+///   let queue : @queue.Queue[Int] = Queue([])
 ///   queue.push(1)
 /// }
 /// ```
@@ -270,7 +270,7 @@ pub fn[A] Queue::eachi(self : Queue[A], f : (Int, A) -> Unit) -> Unit {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.Queue([])
+///   let queue : @queue.Queue[Int] = Queue([])
 ///   let sum = queue.fold(init=0, (acc, x) => acc + x)
 ///   @test.assert_eq(sum, 0)
 /// }
@@ -322,7 +322,7 @@ pub fn[A] Queue::copy(self : Queue[A]) -> Queue[A] {
 /// # Example
 /// ```mbt check
 /// test {
-///   let dst : @queue.Queue[Int] = @queue.Queue([])
+///   let dst : @queue.Queue[Int] = Queue([])
 ///   let src : @queue.Queue[Int] = @queue.from_array([5, 6, 7, 8])
 ///   src.transfer(dst)
 /// }

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -14,13 +14,13 @@
 
 ///|
 test "new" {
-  let queue : @queue.Queue[Int] = @queue.Queue([])
+  let queue : @queue.Queue[Int] = Queue([])
   @test.assert_eq(queue.length(), 0)
 }
 
 ///|
 test "copy empty" {
-  let queue : @queue.Queue[Int] = @queue.Queue([])
+  let queue : @queue.Queue[Int] = Queue([])
   let copied = queue.copy()
   inspect(copied.length(), content="0")
 }
@@ -146,7 +146,7 @@ test "clear" {
 
 ///|
 test "is_empty" {
-  let queue : @queue.Queue[Int] = @queue.Queue([])
+  let queue : @queue.Queue[Int] = Queue([])
   assert_true(queue.is_empty())
   queue.push(1)
   queue.push(2)
@@ -195,7 +195,7 @@ test "pop" {
 
 ///|
 test "each" {
-  let queue : @queue.Queue[Int] = @queue.Queue([])
+  let queue : @queue.Queue[Int] = Queue([])
   let mut sum = 0
   queue.each(x => sum = sum + x)
   @test.assert_eq(sum, 0)
@@ -213,7 +213,7 @@ test "iter_fold" {
 
 ///|
 test "iteri" {
-  let queue : @queue.Queue[Int] = @queue.Queue([])
+  let queue : @queue.Queue[Int] = Queue([])
   let mut sum = 0
   queue.eachi((i, x) => sum = sum + i * x)
   @test.assert_eq(sum, 0)
@@ -225,7 +225,7 @@ test "iteri" {
 
 ///|
 test "fold" {
-  let queue : @queue.Queue[Int] = @queue.Queue([])
+  let queue : @queue.Queue[Int] = Queue([])
   let sum = queue.fold(init=0, (acc, x) => acc + x)
   @test.assert_eq(sum, 0)
   @queue.from_array([1, 2, 3, 4]).transfer(queue)
@@ -317,7 +317,7 @@ test "transfer_self" {
 ///|
 test "transfer_self_empty" {
   // Test self-transfer on empty queue
-  let q : @queue.Queue[Int] = @queue.Queue([])
+  let q : @queue.Queue[Int] = Queue([])
   q.transfer(q)
   debug_inspect(
     q,

--- a/result/result_test.mbt
+++ b/result/result_test.mbt
@@ -28,7 +28,7 @@ test "bind with Err" {
 
 ///|
 test "wrap0 with error" {
-  let f : () -> Int raise Failure = () => raise Failure::Failure("error")
+  let f : () -> Int raise Failure = () => raise Failure("error")
   try f() catch {
     e =>
       debug_inspect(
@@ -44,9 +44,7 @@ test "wrap0 with error" {
 
 ///|
 test "wrap2 with error result" {
-  let f : (Int, Int) -> Unit raise Failure = (_, _) => {
-    raise Failure::Failure("error")
-  }
+  let f : (Int, Int) -> Unit raise Failure = (_, _) => raise Failure("error")
   try f(1, 2) catch {
     e =>
       debug_inspect(

--- a/set/README.mbt.md
+++ b/set/README.mbt.md
@@ -10,12 +10,12 @@ There are several ways to create sets:
 ///|
 test "creating sets" {
   // Empty set
-  let empty_set : @set.Set[Int] = @set.Set([])
+  let empty_set : @set.Set[Int] = Set([])
   inspect(empty_set.length(), content="0")
   inspect(empty_set.is_empty(), content="true")
 
   // Set with initial capacity
-  let set_with_capacity : @set.Set[Int] = @set.Set([], capacity=16)
+  let set_with_capacity : @set.Set[Int] = Set([], capacity=16)
   inspect(set_with_capacity.capacity(), content="16")
 
   // From array

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -119,7 +119,7 @@ pub fn[K : Hash + Eq] Set::Set(arr : ArrayView[K], capacity? : Int) -> Set[K] {
 ///
 /// ```mbt check
 /// test {
-///   let set : @set.Set[String] = @set.Set([])
+///   let set : @set.Set[String] = Set([])
 ///   set.add("key")
 ///   inspect(set.contains("key"), content="true")
 ///   set.add("key") // no effect since it already exists
@@ -202,7 +202,7 @@ fn[K] Set::set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let set : @set.Set[String] = @set.Set([])
+///   let set : @set.Set[String] = Set([])
 ///   inspect(set.add_and_check("key"), content="true") // First insertion
 ///   inspect(set.add_and_check("key"), content="false") // Already exists
 ///   inspect(set.length(), content="1")

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -33,14 +33,14 @@ impl Hash for Key with fn hash(self) {
 
 ///|
 test "empty constructor" {
-  let m : @set.Set[Int] = @set.Set([])
+  let m : @set.Set[Int] = Set([])
   assert_eq(m.capacity(), default_init_capacity)
   assert_eq(m.length(), 0)
 }
 
 ///|
 test "constructor capacity" {
-  let empty : @set.Set[Int] = @set.Set([], capacity=16)
+  let empty : @set.Set[Int] = Set([], capacity=16)
   assert_eq(empty.capacity(), 16)
   assert_eq(empty.length(), 0)
   let below_length = @set.Set([1, 2, 3], capacity=2)
@@ -59,7 +59,7 @@ test "default" {
 
 ///|
 test "copy empty" {
-  let m : @set.Set[Int] = @set.Set([])
+  let m : @set.Set[Int] = Set([])
   let copied = m.copy()
   inspect(copied.length(), content="0")
 }
@@ -146,7 +146,7 @@ test "is_disjoint detects overlap in else branch" {
 
 ///|
 test "remove stops on shorter probe" {
-  let set : @set.Set[Key] = @set.Set([])
+  let set : @set.Set[Key] = Set([])
   set.add({ id: 1, hash_value: 0 })
   set.add({ id: 2, hash_value: 1 })
   set.remove({ id: 3, hash_value: 0 })
@@ -332,7 +332,7 @@ test "remove item causes break when psl < i" {
 
 ///|
 test "to_array_empty" {
-  debug_inspect((@set.Set([]) : @set.Set[Int]).to_array(), content="[]")
+  debug_inspect((Set([]) : @set.Set[Int]).to_array(), content="[]")
 }
 
 ///|
@@ -372,8 +372,8 @@ test "equal: same sets" {
 
 ///|
 test "equal: empty sets" {
-  let set1 : @set.Set[Int] = @set.Set([])
-  let set2 : @set.Set[Int] = @set.Set([])
+  let set1 : @set.Set[Int] = Set([])
+  let set2 : @set.Set[Int] = Set([])
   inspect(set1 == set2, content="true")
 }
 
@@ -503,7 +503,7 @@ test "trigger grow" {
 
 ///|
 test "grow rehashes collision cluster in insertion order" {
-  let set : @set.Set[Key] = @set.Set([], capacity=2)
+  let set : @set.Set[Key] = Set([], capacity=2)
   for i in 0..<12 {
     set.add({ id: i, hash_value: i % 4 })
   }

--- a/sorted_map/README.mbt.md
+++ b/sorted_map/README.mbt.md
@@ -24,7 +24,7 @@ You can create an empty SortedMap or a SortedMap from other containers.
 ```mbt check
 ///|
 test {
-  let _map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let _map1 : @sorted_map.SortedMap[Int, String] = SortedMap([])
   let _map2 = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
 }
 ```
@@ -143,7 +143,7 @@ Check if the map is empty.
 ```mbt check
 ///|
 test {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let map : @sorted_map.SortedMap[Int, String] = SortedMap([])
   @test.assert_eq(map.is_empty(), true)
 }
 ```

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -165,7 +165,7 @@ pub fn[K : Compare, V] SortedMap::get_or_init(
 /// # Example
 /// ```mbt check
 /// test {
-///   let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
+///   let counts : @sorted_map.SortedMap[String, Int] = SortedMap([])
 ///   counts.update_or_default("a", 1, x => x + 1)
 ///   counts.update_or_default("a", 1, x => x + 1)
 ///   counts.update_or_default("b", 1, x => x + 1)

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -31,7 +31,7 @@ test "remove3" {
 
 ///|
 test "remove on empty map" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let map : @sorted_map.SortedMap[Int, String] = SortedMap([])
   map.remove(1)
   inspect(map.length(), content="0")
 }
@@ -95,7 +95,7 @@ test "equal" {
 
 ///|
 test "is_empty" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let map : @sorted_map.SortedMap[Int, String] = SortedMap([])
   inspect(map.is_empty(), content="true")
   map[1] = "a"
   inspect(map.is_empty(), content="false")
@@ -295,7 +295,7 @@ test "to_json with non-empty map" {
 
 ///|
 test "to_json with empty map" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let map : @sorted_map.SortedMap[Int, String] = SortedMap([])
   @json.json_inspect(map.to_json(), content={})
 }
 
@@ -346,7 +346,7 @@ test "@sorted_map.merge" {
 
 ///|
 test "@sorted_map.merge empty maps" {
-  let map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let map1 : @sorted_map.SortedMap[Int, String] = SortedMap([])
   let map2 = @sorted_map.from_array([(1, "a"), (2, "b")])
   let merged1 = map1.merge(map2)
   debug_inspect(merged1.to_array(), content="[(1, \"a\"), (2, \"b\")]")
@@ -371,7 +371,7 @@ test "@sorted_map.merge_in_place" {
 
 ///|
 test "@sorted_map.merge_in_place empty maps" {
-  let map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let map1 : @sorted_map.SortedMap[Int, String] = SortedMap([])
   let map2 = @sorted_map.from_array([(1, "a"), (2, "b")])
   map1.merge_in_place(map2)
   debug_inspect(map1.to_array(), content="[(1, \"a\"), (2, \"b\")]")
@@ -437,7 +437,7 @@ test "update_or_default applies f when present" {
 
 ///|
 test "update_or_default counter pattern" {
-  let counts : @sorted_map.SortedMap[String, Int] = @sorted_map.SortedMap([])
+  let counts : @sorted_map.SortedMap[String, Int] = SortedMap([])
   for label in ["a", "b", "a", "c", "a", "b"] {
     counts.update_or_default(label, 1, x => x + 1)
   }
@@ -485,7 +485,7 @@ test "range with out-of-bounds keys" {
 
 ///|
 test "range on empty map" {
-  let map : @sorted_map.SortedMap[Int, String] = @sorted_map.SortedMap([])
+  let map : @sorted_map.SortedMap[Int, String] = SortedMap([])
   debug_inspect(
     map.range(1, 5).to_array(),
     content=(

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -91,9 +91,7 @@ pub impl[V : @json.FromJson] @json.FromJson for SortedMap[String, V] with fn fro
   path,
 ) {
   guard json is Object(obj) else {
-    raise @json.JsonDecodeError(
-      (path, "@sorted_map.from_json: expected object"),
-    )
+    raise JsonDecodeError((path, "@sorted_map.from_json: expected object"))
   }
   let map = new_sorted_map()
   for k, v in obj {

--- a/sorted_set/README.mbt.md
+++ b/sorted_set/README.mbt.md
@@ -11,7 +11,7 @@ You can create an empty SortedSet or a SortedSet from other containers.
 ```mbt check
 ///|
 test {
-  let _set1 : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
+  let _set1 : @sorted_set.SortedSet[Int] = SortedSet([])
   let _set2 = @sorted_set.singleton(1)
   let _set3 = @sorted_set.from_array([1])
 }
@@ -79,7 +79,7 @@ Whether the set is empty.
 ```mbt check
 ///|
 test {
-  let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
+  let set : @sorted_set.SortedSet[Int] = SortedSet([])
   @test.assert_eq(set.is_empty(), true)
 }
 ```

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "remove on empty set" {
-  let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
+  let set : @sorted_set.SortedSet[Int] = SortedSet([])
   set.remove(0)
   inspect(set.length(), content="0")
 }
@@ -97,7 +97,7 @@ test "each" {
   let result = StringBuilder(size_hint=10)
   set.each(x => result.write_string(x.to_string()))
   inspect(result.to_string(), content="123456789")
-  let set : @sorted_set.SortedSet[Int] = @sorted_set.SortedSet([])
+  let set : @sorted_set.SortedSet[Int] = SortedSet([])
   set.each(_x => abort("Impossible to reach"))
 }
 

--- a/string/internal/regex_engine/ast/pattern.mbt
+++ b/string/internal/regex_engine/ast/pattern.mbt
@@ -81,13 +81,13 @@ pub fn char(cs : @shared_types.RecharSet) -> Pattern {
   if cs.is_empty() {
     empty
   } else {
-    Pattern::{ desc: Char(cs), nullable: false }
+    { desc: Char(cs), nullable: false }
   }
 }
 
 ///|
 /// Epsilon pattern that matches empty input.
-pub let epsilon : Pattern = Pattern::{ desc: Sequence([]), nullable: true }
+pub let epsilon : Pattern = { desc: Sequence([]), nullable: true }
 
 ///|
 /// Concatenate patterns.
@@ -107,7 +107,7 @@ pub fn seq(exprs : ReadOnlyArray[Pattern]) -> Pattern {
     [] => epsilon
     [expr] => expr
     exprs =>
-      Pattern::{
+      {
         desc: Sequence(ReadOnlyArray::from_array(exprs)),
         nullable: exprs.all(e => e.nullable),
       }
@@ -116,7 +116,7 @@ pub fn seq(exprs : ReadOnlyArray[Pattern]) -> Pattern {
 
 ///|
 /// Empty pattern that matches nothing.
-pub let empty : Pattern = Pattern::{ desc: Alternation([]), nullable: false }
+pub let empty : Pattern = { desc: Alternation([]), nullable: false }
 
 ///|
 /// Build an alternation of patterns.
@@ -124,11 +124,7 @@ pub fn alt(exprs : ReadOnlyArray[Pattern]) -> Pattern {
   match exprs {
     [] => empty
     [expr] => expr
-    exprs =>
-      Pattern::{
-        desc: Alternation(exprs),
-        nullable: exprs.any(e => e.nullable),
-      }
+    exprs => { desc: Alternation(exprs), nullable: exprs.any(e => e.nullable) }
   }
 }
 
@@ -139,7 +135,7 @@ pub fn alt(exprs : ReadOnlyArray[Pattern]) -> Pattern {
 pub fn quantifier(expr : Pattern, q : Quantifier) -> Pattern {
   guard q.min >= 0 else { panic() }
   guard q.max is None || (q.max is Some(max) && max >= q.min) else { panic() }
-  Pattern::{ desc: Quantifier(q, expr), nullable: expr.nullable || q.min == 0 }
+  { desc: Quantifier(q, expr), nullable: expr.nullable || q.min == 0 }
 }
 
 ///|
@@ -148,7 +144,7 @@ pub fn preference(pref : @shared_types.Preference, expr : Pattern) -> Pattern {
   if expr.desc is Char(_) {
     expr
   } else {
-    Pattern::{ desc: Preference(pref, expr), nullable: expr.nullable }
+    { desc: Preference(pref, expr), nullable: expr.nullable }
   }
 }
 
@@ -173,13 +169,13 @@ pub fn first(expr : Pattern) -> Pattern {
 ///|
 /// Wrap a pattern in a capturing group.
 pub fn capture(name? : String, expr : Pattern) -> Pattern {
-  Pattern::{ desc: Capture(name~, expr), nullable: expr.nullable }
+  { desc: Capture(name~, expr), nullable: expr.nullable }
 }
 
 ///|
 /// Create an assertion pattern node.
 pub fn assertion(a : Assertion) -> Pattern {
-  Pattern::{ desc: Assertion(a), nullable: true }
+  { desc: Assertion(a), nullable: true }
 }
 
 ///|

--- a/string/internal/regex_engine/regex.mbt
+++ b/string/internal/regex_engine/regex.mbt
@@ -45,7 +45,7 @@ fn Regex::new(
   symbol_table : @symbol_map.Table,
   symbol_repr : ReadOnlyArray[Rechar],
 ) -> Regex {
-  Regex::{
+  {
     profile,
     ctx,
     expr,
@@ -53,7 +53,7 @@ fn Regex::new(
     symbol_table,
     symbol_repr,
     start_states: [],
-    state_table: @hashmap.HashMap([]),
+    state_table: HashMap([]),
     transition_table: [],
     final_table: [],
     states: [],

--- a/string/internal/regex_engine/symbol_map/symbol_map.mbt
+++ b/string/internal/regex_engine/symbol_map/symbol_map.mbt
@@ -18,7 +18,7 @@ struct SymbolMap(@sorted_set.SortedSet[@shared_types.Rechar])
 ///|
 /// Create a new instance.
 pub fn new() -> SymbolMap {
-  SymbolMap(@sorted_set.SortedSet([]))
+  SymbolMap(SortedSet([]))
 }
 
 ///|

--- a/string/internal/regex_engine/translate.mbt
+++ b/string/internal/regex_engine/translate.mbt
@@ -25,7 +25,7 @@ fn TranslateContext::new(
   ctx : @automata.Context,
   symbol_table : @symbol_map.Table,
 ) -> TranslateContext {
-  TranslateContext::{ ctx, pref: First, groups: [], symbol_table }
+  { ctx, pref: First, groups: [], symbol_table }
 }
 
 ///|
@@ -89,12 +89,12 @@ fn translate(
         @automata.e_seq(
           ctx~,
           First,
-          @automata.e_mark(ctx~, @automata.Mark(group_index * 2)),
+          @automata.e_mark(ctx~, Mark(group_index * 2)),
           @automata.e_seq(
             ctx~,
             First,
             cr,
-            @automata.e_mark(ctx~, @automata.Mark(group_index * 2 + 1)),
+            @automata.e_mark(ctx~, Mark(group_index * 2 + 1)),
           ),
         ),
         pref2,

--- a/string/internal/regex_parser/parser_context.mbt
+++ b/string/internal/regex_parser/parser_context.mbt
@@ -33,7 +33,7 @@ fn ParserContext::new(
   base~ : Int,
   mode~ : Mode,
 ) -> ParserContext {
-  ParserContext::{ profile, base, ignore_case: false, mode }
+  { profile, base, ignore_case: false, mode }
 }
 
 ///|

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -357,7 +357,7 @@ pub fn Regex::execute(
   match self.re().execute(input, last_index) {
     None => None
     Some(result) =>
-      Some(MatchResult::{ input, group_names: self.re().group_names(), result })
+      Some({ input, group_names: self.re().group_names(), result })
   }
 }
 

--- a/string/regex_test.mbt
+++ b/string/regex_test.mbt
@@ -235,7 +235,7 @@ test "complex/email_pattern" {
   // Put - at end to avoid it being interpreted as a range operator
   let username = @string.Regex("[a-zA-Z0-9_.+\\-]+")
   let domain_part = @string.Regex("[a-zA-Z0-9\\-]+")
-  let tld = @string.Regex("com") | @string.Regex("org") | @string.Regex("net")
+  let tld = @string.Regex("com") | Regex("org") | Regex("net")
   let email = username +
     @string.Regex::string("@") +
     domain_part +
@@ -276,7 +276,7 @@ test "complex/url_protocol" {
   let https = @string.Regex::string("https")
   let ftp = @string.Regex::string("ftp")
   let protocol = http | https | ftp
-  let url = protocol + @string.Regex::string("://") + @string.Regex("[^/]+")
+  let url = protocol + @string.Regex::string("://") + Regex("[^/]+")
   guard url.execute("https://example.com") is Some(m) else {
     fail("Expected URL match")
   }
@@ -426,7 +426,7 @@ test "complex/log_level" {
   // Fixed: Use [^\\]] to match anything except closing bracket
   // Otherwise .+ is greedy and matches past the ]
   let timestamp = @string.Regex::string("[") +
-    @string.Regex("[^\\]]+") +
+    Regex("[^\\]]+") +
     @string.Regex::string("]")
   let log_line = timestamp + @string.Regex::string(" ") + level
   guard log_line.execute("[2026-02-26 10:30:45] ERROR") is Some(m) else {
@@ -461,7 +461,7 @@ test "complex/log_level" {
 test "complex/phone_number" {
   // Match phone with optional country code and various formats
   let plus = @string.Regex::string("+")
-  let country = plus + @string.Regex("[[:digit:]]{1,3}")
+  let country = plus + Regex("[[:digit:]]{1,3}")
   let space = @string.Regex::string(" ")
   let dash = @string.Regex::string("-")
   let lparen = @string.Regex::string("(")
@@ -655,7 +655,7 @@ test "add/with_any_quantifier" {
 ///|
 test "add/with_any_quantifier_and_empty_wrappers" {
   let empty = @string.Regex::string("")
-  let re = empty + @string.Regex(".*?\\.") + empty + @string.Regex::string(" ")
+  let re = empty + Regex(".*?\\.") + empty + @string.Regex::string(" ")
   guard re.execute("abc. ") is Some(m) else { fail("Expected match") }
   inspect(m.content(), content="abc. ")
 }

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -225,7 +225,7 @@ pub fn Test::snapshot(
   let actual = self.buffer.to_string().escape()
   let expect = filename.escape()
   // always raise SnapshotError, moon will handle this
-  raise SnapshotError::SnapshotError(
+  raise SnapshotError(
     "@SNAPSHOT_TESTING {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{expect}, \"actual\": \{actual}, \"snapshot\": true}",
   )
 }

--- a/test/test_test.mbt
+++ b/test/test_test.mbt
@@ -57,13 +57,13 @@ suberror MyError {
 ///|
 fn maybe_raise(should_raise : Bool) -> Unit raise MyError {
   if should_raise {
-    raise MyError::NotFound("file.txt")
+    raise NotFound("file.txt")
   }
 }
 
 ///|
 fn raise_invalid() -> Unit raise MyError {
-  raise MyError::Invalid(reason="bad input")
+  raise Invalid(reason="bad input")
 }
 
 ///|


### PR DESCRIPTION
## Summary
Enable `+unnecessary_annotation` in `moon.mod` and drop the redundant qualifier prefix at every site the lint flags (272 sites across 80 files).

Two prefix shapes were flagged:
- **`@pkg.`** — e.g. `raise @json.JsonDecodeError(...)` inside an `impl @json.FromJson for ...` block; `JsonDecodeError` is already in scope so `@json.` is redundant.
- **`Type::`** — e.g. `LKey::value` where the receiver's type makes `LKey::` unnecessary.

The edit was performed by a script that parses each warning's column and the back-tick-delimited prefix in the message, then drops exactly that text at the warned position. No manual cleanup was needed.

## Test plan
- [x] `moon check` clean (0 warnings).
- [x] `moon test` — 6521/6521 pass.
- [x] `moon fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)