### PR TITLE
refactor(string): use  regex literal for compile-time patterns

### DIFF
--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -199,7 +199,7 @@ Use `Regex` for string regex matching, replacement, and splitting:
 ```mbt check
 ///|
 test "string regex basics" {
-  let regex = @string.Regex("[[:digit:]]+")
+  let regex = re"[[:digit:]]+"
 
   guard regex.execute("id=42") is Some(m) else { fail("Expected match") }
   inspect(m.content(), content="42")
@@ -258,7 +258,7 @@ test "parse integers with base" {
 ```mbt check
 ///|
 test "match result" {
-  let re = @string.Regex("([[:alpha:]]+)=([[:digit:]]+)")
+  let re = re"([[:alpha:]]+)=([[:digit:]]+)"
   guard re.execute("key=42") is Some(m) else { fail("no match") }
   inspect(m.content(), content="key=42")
   inspect(m.before(), content="")
@@ -273,7 +273,7 @@ Named capture groups via `(?<name>...)`:
 ```mbt check
 ///|
 test "named groups" {
-  let re = @string.Regex("(?<name>[[:alpha:]]+):(?<val>[[:digit:]]+)")
+  let re = re"(?<name>[[:alpha:]]+):(?<val>[[:digit:]]+)"
   guard re.execute("age:30") is Some(m) else { fail("no match") }
   debug_inspect(m.named_group("name"), content="Some(<StringView: \"age\">)")
   debug_inspect(m.named_group("val"), content="Some(<StringView: \"30\">)")
@@ -287,7 +287,7 @@ test "named groups" {
 ```mbt check
 ///|
 test "find and split" {
-  let digits = @string.Regex("[[:digit:]]+")
+  let digits = re"[[:digit:]]+"
   let matches = digits
     .find("a1b22c333")
     .map(fn(m) { m.content().to_owned() })
@@ -309,7 +309,7 @@ test "regex combinators" {
   let abc = @string.Regex::string("abc")
   inspect(abc.execute("xabcy") is Some(_), content="true")
   // repeat: match 2 to 4 digits
-  let digits = @string.Regex("[[:digit:]]").repeat(min=2, max=4)
+  let digits = re"[[:digit:]]".repeat(min=2, max=4)
   guard digits.execute("a12345") is Some(m) else { fail("no match") }
   inspect(m.content(), content="1234") // greedy: takes max
   // alternation with |

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -59,7 +59,7 @@ pub struct Regex {
 ///
 /// ```mbt check
 /// test {
-///   let regex = @string.Regex("[[:digit:]]+")
+///   let regex = re"[[:digit:]]+"
 ///   guard regex.execute("a12b") is Some(m) else { fail("Expected match") }
 ///   inspect(m.content(), content="12")
 /// }
@@ -220,15 +220,11 @@ pub fn Regex::string(str : StringView) -> Regex {
 ///
 /// ```mbt check
 /// test {
-///   let greedy = @string.Regex("[[:digit:]]").repeat(min=2, max=4)
+///   let greedy = re"[[:digit:]]".repeat(min=2, max=4)
 ///   guard greedy.execute("a12345") is Some(m1) else { fail("Expected match") }
 ///   inspect(m1.content(), content="1234")
 ///
-///   let nongreedy = @string.Regex("[[:digit:]]").repeat(
-///     min=2,
-///     max=4,
-///     greedy=false,
-///   )
+///   let nongreedy = re"[[:digit:]]".repeat(min=2, max=4, greedy=false)
 ///   guard nongreedy.execute("a12345") is Some(m2) else { fail("Expected match") }
 ///   inspect(m2.content(), content="12")
 /// }
@@ -326,7 +322,7 @@ pub impl BitOr for Regex with fn lor(self, other) -> Regex {
 ///
 /// ```mbt check
 /// test {
-///   let regex = @string.Regex("[[:digit:]]+")
+///   let regex = re"[[:digit:]]+"
 ///   let input = "a12b34"
 ///
 ///   guard regex.execute(input) is Some(first) else {
@@ -344,7 +340,7 @@ pub impl BitOr for Regex with fn lor(self, other) -> Regex {
 ///
 /// ```mbt check
 /// test {
-///   let anchored = @string.Regex("^ab$")
+///   let anchored = re"^ab$"
 ///   inspect(anchored.execute("ab", last_index=0) is Some(_), content="true")
 ///   inspect(anchored.execute("xaby", last_index=1) is Some(_), content="false")
 /// }
@@ -371,7 +367,7 @@ pub fn Regex::execute(
 ///
 /// ```mbt check
 /// test {
-///   let digit = @string.Regex("[[:digit:]]+").capture("number")
+///   let digit = re"[[:digit:]]+".capture("number")
 ///   let regex = @string.Regex::string("ID: ") + digit
 ///   guard regex.execute("ID: 12345") is Some(m) else { fail("Expected match") }
 ///   debug_inspect(
@@ -385,9 +381,9 @@ pub fn Regex::execute(
 ///
 /// ```mbt check
 /// test {
-///   let user = @string.Regex("[[:alpha:]]+").capture("user")
-///   let domain = @string.Regex("[[:alpha:]]+").capture("domain")
-///   let tld = @string.Regex("[[:alpha:]]+").capture("tld")
+///   let user = re"[[:alpha:]]+".capture("user")
+///   let domain = re"[[:alpha:]]+".capture("domain")
+///   let tld = re"[[:alpha:]]+".capture("tld")
 ///   let email = user +
 ///     @string.Regex::string("@") +
 ///     domain +

--- a/string/regex_methods.mbt
+++ b/string/regex_methods.mbt
@@ -39,7 +39,7 @@ fn StringView::next_char_index(self : StringView, index : Int) -> Int {
 /// 
 /// ```mbt check
 /// test {
-///   let regex = @string.Regex("[[:digit:]]+")
+///   let regex = re"[[:digit:]]+"
 ///   let result = regex.replace_by("a12b3", m => "[\{m.content()}]")
 ///   inspect(result, content="a[12]b[3]")
 /// }
@@ -104,7 +104,7 @@ pub fn Regex::replace_by(
 ///
 /// ```mbt check
 /// test {
-///   let regex = @string.Regex("[[:digit:]]+")
+///   let regex = re"[[:digit:]]+"
 ///   let matches = regex.find("a12b3").to_array()
 ///   inspect(matches.length(), content="2")
 ///   inspect(matches[0].content(), content="12")
@@ -141,7 +141,7 @@ pub fn Regex::find(regex : Regex, str : StringView) -> Iter[MatchResult] {
 /// 
 /// ```mbt check
 /// test {
-///   let regex = @string.Regex(",")
+///   let regex = re","
 ///   let parts = regex.split("a,,b").to_array()
 ///   inspect(parts.length(), content="3")
 ///   inspect(parts[0], content="a")

--- a/string/regex_methods_test.mbt
+++ b/string/regex_methods_test.mbt
@@ -37,7 +37,7 @@ fn has_unpaired_surrogate(str : StringView) -> Bool {
 
 ///|
 test "split/basic" {
-  let regex = @string.Regex(" ")
+  let regex = re" "
   let result = regex.split("hello world test").to_array()
   inspect(result.length(), content="3")
   inspect(result[0], content="hello")
@@ -47,7 +47,7 @@ test "split/basic" {
 
 ///|
 test "split/multiple_spaces" {
-  let regex = @string.Regex("[[:space:]]+")
+  let regex = re"[[:space:]]+"
   let result = regex.split("hello   world\t\ntest").to_array()
   inspect(result.length(), content="3")
   inspect(result[0], content="hello")
@@ -57,7 +57,7 @@ test "split/multiple_spaces" {
 
 ///|
 test "split/digit_delimiter" {
-  let regex = @string.Regex("[[:digit:]]+")
+  let regex = re"[[:digit:]]+"
   let result = regex.split("abc123def456ghi").to_array()
   inspect(result.length(), content="3")
   inspect(result[0], content="abc")
@@ -67,7 +67,7 @@ test "split/digit_delimiter" {
 
 ///|
 test "split/no_match" {
-  let regex = @string.Regex("xyz")
+  let regex = re"xyz"
   let result = regex.split("hello world test").to_array()
   inspect(result.length(), content="1")
   inspect(result[0], content="hello world test")
@@ -75,7 +75,7 @@ test "split/no_match" {
 
 ///|
 test "split/pattern_at_start" {
-  let regex = @string.Regex("^hello")
+  let regex = re"^hello"
   let result = regex.split("hello world test").to_array()
   inspect(result.length(), content="2")
   inspect(result[0], content="")
@@ -84,7 +84,7 @@ test "split/pattern_at_start" {
 
 ///|
 test "split/pattern_at_end" {
-  let regex = @string.Regex("test$")
+  let regex = re"test$"
   let result = regex.split("hello world test").to_array()
   inspect(result.length(), content="2")
   inspect(result[0], content="hello world ")
@@ -93,7 +93,7 @@ test "split/pattern_at_end" {
 
 ///|
 test "split/consecutive_delimiters" {
-  let regex = @string.Regex(",")
+  let regex = re","
   let result = regex.split("a,,b,,,c").to_array()
   inspect(result.length(), content="6")
   inspect(result[0], content="a")
@@ -106,7 +106,7 @@ test "split/consecutive_delimiters" {
 
 ///|
 test "split/empty_string" {
-  let regex = @string.Regex("a")
+  let regex = re"a"
   let result = regex.split("").to_array()
   inspect(result.length(), content="1")
   inspect(result[0], content="")
@@ -114,7 +114,7 @@ test "split/empty_string" {
 
 ///|
 test "split/single_character" {
-  let regex = @string.Regex("a")
+  let regex = re"a"
   let result = regex.split("banana").to_array()
   inspect(result.length(), content="4")
   inspect(result[0], content="b")
@@ -125,7 +125,7 @@ test "split/single_character" {
 
 ///|
 test "split/unicode" {
-  let regex = @string.Regex("，")
+  let regex = re"，"
   let result = regex.split("你好，世界，谢谢").to_array()
   inspect(result.length(), content="3")
   inspect(result[0], content="你好")
@@ -135,7 +135,7 @@ test "split/unicode" {
 
 ///|
 test "split/alternation_pattern" {
-  let regex = @string.Regex("[,;]")
+  let regex = re"[,;]"
   let result = regex.split("a,b;c,d").to_array()
   inspect(result.length(), content="4")
   inspect(result[0], content="a")
@@ -146,7 +146,7 @@ test "split/alternation_pattern" {
 
 ///|
 test "split/complex_pattern" {
-  let regex = @string.Regex("[[:alpha:]]+")
+  let regex = re"[[:alpha:]]+"
   let result = regex.split("123abc456def789").to_array()
   inspect(result.length(), content="3")
   inspect(result[0], content="123")
@@ -156,7 +156,7 @@ test "split/complex_pattern" {
 
 ///|
 test "split/single_element_no_split" {
-  let regex = @string.Regex(",")
+  let regex = re","
   let result = regex.split("hello").to_array()
   inspect(result.length(), content="1")
   inspect(result[0], content="hello")
@@ -164,7 +164,7 @@ test "split/single_element_no_split" {
 
 ///|
 test "split/entire_match" {
-  let regex = @string.Regex(".+")
+  let regex = re".+"
   let result = regex.split("hello").to_array()
   inspect(result.length(), content="2")
   inspect(result[0], content="")
@@ -197,7 +197,7 @@ test "split/non_word_boundary_does_not_break_surrogate_pair" {
 
 ///|
 test "split_replace/range_crossing_surrogate_gap_does_not_break_surrogate_pair" {
-  let regex = @string.Regex("[\\uD7FF-\\uE000]")
+  let regex = re"[\uD7FF-\uE000]"
   let split_result = regex.split("😀").to_array()
   debug_inspect(
     split_result,
@@ -212,35 +212,35 @@ test "split_replace/range_crossing_surrogate_gap_does_not_break_surrogate_pair" 
 
 ///|
 test "replace_by/zero_width_edge_case" {
-  let regex = @string.Regex("")
+  let regex = re""
   let result = regex.replace_by("abc", _m => "x")
   inspect(result, content="xaxbxcx")
 }
 
 ///|
 test "replace_by/limit_basic" {
-  let regex = @string.Regex("[[:digit:]]+")
+  let regex = re"[[:digit:]]+"
   let result = regex.replace_by("a1b22c333", _m => "#", limit=2)
   inspect(result, content="a#b#c333")
 }
 
 ///|
 test "replace_by/limit_zero" {
-  let regex = @string.Regex("[[:digit:]]+")
+  let regex = re"[[:digit:]]+"
   let result = regex.replace_by("a1b22", _m => "#", limit=0)
   inspect(result, content="a1b22")
 }
 
 ///|
 test "replace_by/limit_with_empty_pattern_and_surrogate_pair" {
-  let regex = @string.Regex("")
+  let regex = re""
   let result = regex.replace_by("a😀b", _m => "x", limit=2)
   inspect(result, content="xax😀b")
 }
 
 ///|
 test "replace_by/zero_width_with_surrogate_pair" {
-  let regex = @string.Regex("")
+  let regex = re""
   let result = regex.replace_by("a😀b", _m => "x")
   inspect(result, content="xax😀xbx")
 }
@@ -254,7 +254,7 @@ test "replace_by/non_word_boundary_does_not_break_surrogate_pair" {
 
 ///|
 test "split/zero_width_with_surrogate_pair" {
-  let regex = @string.Regex("")
+  let regex = re""
   let result = regex.split("a😀b").to_array()
   debug_inspect(
     result,
@@ -272,7 +272,7 @@ test "split/zero_width_with_surrogate_pair" {
 
 ///|
 test "split/empty_pattern_empty_input" {
-  let regex = @string.Regex("")
+  let regex = re""
   let result = regex.split("").to_array()
   debug_inspect(
     result,
@@ -284,7 +284,7 @@ test "split/empty_pattern_empty_input" {
 
 ///|
 test "split/long_string" {
-  let regex = @string.Regex(",")
+  let regex = re","
   let result = regex.split("a,b,c,d,e,f,g,h,i,j").to_array()
   inspect(result.length(), content="10")
   inspect(result[0], content="a")
@@ -293,7 +293,7 @@ test "split/long_string" {
 
 ///|
 test "split/alternation_multiple" {
-  let regex = @string.Regex("[abc]")
+  let regex = re"[abc]"
   let result = regex.split("xayazbzc").to_array()
   inspect(result.length(), content="5")
   inspect(result[0], content="x")
@@ -315,7 +315,7 @@ test "split/tab_and_newline" {
 
 ///|
 test "find/capture_groups_and_named_groups" {
-  let regex = @string.Regex("(?<word>[a-z]+)-(?<num>[0-9]+)")
+  let regex = re"(?<word>[a-z]+)-(?<num>[0-9]+)"
   let words = regex
     .find("ab-12 cd-345")
     .map(m => m.named_group("word").unwrap())
@@ -347,7 +347,7 @@ test "find/capture_groups_and_named_groups" {
 
 ///|
 test "find/next_and_exhaustion" {
-  let regex = @string.Regex("[[:digit:]]+")
+  let regex = re"[[:digit:]]+"
   let iter = regex.find("a1b22")
   guard iter.next() is Some(first) else { fail("Expected first match") }
   guard iter.next() is Some(second) else { fail("Expected second match") }
@@ -358,7 +358,7 @@ test "find/next_and_exhaustion" {
 
 ///|
 test "find/no_match" {
-  let regex = @string.Regex("xyz")
+  let regex = re"xyz"
   let iter = regex.find("hello world")
   guard iter.next() is None else { fail("Expected no match") }
 }
@@ -375,7 +375,7 @@ test "find/word_boundary_positions" {
 
 ///|
 test "find/empty_pattern_progress_and_empty_input" {
-  let regex = @string.Regex("")
+  let regex = re""
   let positions = regex.find("abc").map(m => m.before().length()).collect()
   let surrogate_positions = regex
     .find("a😀b")

--- a/string/regex_test.mbt
+++ b/string/regex_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "execute/non_capture_group" {
-  let regex = @string.Regex("(?:ab)(c)(?:d)")
+  let regex = re"(?:ab)(c)(?:d)"
   guard regex.execute("abcd") is Some(m) else { fail("Expected match") }
   debug_inspect(
     m,
@@ -30,7 +30,7 @@ test "execute/non_capture_group" {
 
 ///|
 test "execute/non_capture_with_named_group" {
-  let regex = @string.Regex("(?:a)(b)(?:c)(?<d>d)")
+  let regex = re"(?:a)(b)(?:c)(?<d>d)"
   guard regex.execute("abcd") is Some(m) else { fail("Expected match") }
   debug_inspect(
     m,
@@ -46,7 +46,7 @@ test "execute/non_capture_with_named_group" {
 
 ///|
 test "execute/any_char_on_supplementary_plane" {
-  let regex = @string.Regex(".")
+  let regex = re"."
   guard regex.execute("😀") is Some(m) else {
     fail("Expected match for supplementary-plane Unicode escape")
   }
@@ -64,7 +64,7 @@ test "execute/any_char_on_supplementary_plane" {
 
 ///|
 test "execute/range_crossing_surrogate_gap_has_no_half_match" {
-  let regex = @string.Regex("[\\uD7FF-\\uE000]")
+  let regex = re"[\uD7FF-\uE000]"
   guard regex.execute("😀") is None else {
     fail("Expected no surrogate-half match")
   }
@@ -90,7 +90,7 @@ test "compile/error_unclosed_char_class" {
 
 ///|
 test "compile/unicode_escape_supplementary_plane" {
-  let regex = @string.Regex("\\u{1F600}")
+  let regex = re"\u{1F600}"
   guard regex.execute("a😀b") is Some(m) else {
     fail("Expected match for supplementary-plane Unicode escape")
   }
@@ -132,7 +132,7 @@ test "string/literal_metacharacters" {
 
 ///|
 test "repeat/greedy_and_nongreedy" {
-  let base = @string.Regex("[[:digit:]]")
+  let base = re"[[:digit:]]"
   let greedy = base.repeat(min=2, max=4)
   let nongreedy = base.repeat(min=2, max=4, greedy=false)
   guard greedy.execute("a12345") is Some(m1) else {
@@ -165,25 +165,25 @@ test "repeat/greedy_and_nongreedy" {
 
 ///|
 test "panic repeat/invalid_min_negative" {
-  let base = @string.Regex("[[:digit:]]")
+  let base = re"[[:digit:]]"
   ignore(base.repeat(min=-1))
 }
 
 ///|
 test "panic repeat/invalid_max_less_than_min" {
-  let base = @string.Regex("[[:digit:]]")
+  let base = re"[[:digit:]]"
   ignore(base.repeat(min=3, max=2))
 }
 
 ///|
 test "panic repeat/invalid_min_too_large" {
-  let base = @string.Regex("[[:digit:]]")
+  let base = re"[[:digit:]]"
   ignore(base.repeat(min=257))
 }
 
 ///|
 test "panic repeat/invalid_max_too_large" {
-  let base = @string.Regex("[[:digit:]]")
+  let base = re"[[:digit:]]"
   ignore(base.repeat(min=0, max=257))
 }
 
@@ -233,9 +233,9 @@ test "complex/email_pattern" {
   // Build readable email pattern using + and |
   // Use simpler character class - avoid complex mixing with POSIX classes
   // Put - at end to avoid it being interpreted as a range operator
-  let username = @string.Regex("[a-zA-Z0-9_.+\\-]+")
-  let domain_part = @string.Regex("[a-zA-Z0-9\\-]+")
-  let tld = @string.Regex("com") | Regex("org") | Regex("net")
+  let username = re"[a-zA-Z0-9_.+\-]+"
+  let domain_part = re"[a-zA-Z0-9\-]+"
+  let tld = re"com" | re"org" | re"net"
   let email = username +
     @string.Regex::string("@") +
     domain_part +
@@ -276,7 +276,7 @@ test "complex/url_protocol" {
   let https = @string.Regex::string("https")
   let ftp = @string.Regex::string("ftp")
   let protocol = http | https | ftp
-  let url = protocol + @string.Regex::string("://") + Regex("[^/]+")
+  let url = protocol + @string.Regex::string("://") + re"[^/]+"
   guard url.execute("https://example.com") is Some(m) else {
     fail("Expected URL match")
   }
@@ -314,9 +314,9 @@ test "complex/url_protocol" {
 ///|
 test "complex/date_formats" {
   // Support multiple date formats using | for readability
-  let year = @string.Regex("[[:digit:]]{4}")
-  let month = @string.Regex("[[:digit:]]{2}")
-  let day = @string.Regex("[[:digit:]]{2}")
+  let year = re"[[:digit:]]{4}"
+  let month = re"[[:digit:]]{2}"
+  let day = re"[[:digit:]]{2}"
   let dash_sep = @string.Regex::string("-")
   let slash_sep = @string.Regex::string("/")
   let dot_sep = @string.Regex::string(".")
@@ -366,8 +366,8 @@ test "complex/date_formats" {
 ///|
 test "complex/programming_identifier" {
   // Match valid programming identifiers with optional namespace
-  let start_char = @string.Regex("[[:alpha:]_]")
-  let id_char = @string.Regex("[[:alnum:]_]")
+  let start_char = re"[[:alpha:]_]"
+  let id_char = re"[[:alnum:]_]"
   let identifier = start_char + id_char.repeat(min=0)
   let namespace_sep = @string.Regex::string("::")
   let namespaced_id = (identifier + namespace_sep).repeat(min=0) + identifier
@@ -426,7 +426,7 @@ test "complex/log_level" {
   // Fixed: Use [^\\]] to match anything except closing bracket
   // Otherwise .+ is greedy and matches past the ]
   let timestamp = @string.Regex::string("[") +
-    Regex("[^\\]]+") +
+    re"[^\]]+" +
     @string.Regex::string("]")
   let log_line = timestamp + @string.Regex::string(" ") + level
   guard log_line.execute("[2026-02-26 10:30:45] ERROR") is Some(m) else {
@@ -461,14 +461,14 @@ test "complex/log_level" {
 test "complex/phone_number" {
   // Match phone with optional country code and various formats
   let plus = @string.Regex::string("+")
-  let country = plus + Regex("[[:digit:]]{1,3}")
+  let country = plus + re"[[:digit:]]{1,3}"
   let space = @string.Regex::string(" ")
   let dash = @string.Regex::string("-")
   let lparen = @string.Regex::string("(")
   let rparen = @string.Regex::string(")")
-  let area = @string.Regex("[[:digit:]]{3}")
-  let prefix = @string.Regex("[[:digit:]]{3}")
-  let line = @string.Regex("[[:digit:]]{4}")
+  let area = re"[[:digit:]]{3}"
+  let prefix = re"[[:digit:]]{3}"
+  let line = re"[[:digit:]]{4}"
   let phone = country.repeat(min=0, max=1) +
     space.repeat(min=0, max=1) +
     ((lparen + area + rparen) | area) +
@@ -494,13 +494,13 @@ test "complex/phone_number" {
 ///|
 test "complex/semantic_version" {
   // Match semantic versioning with optional pre-release and build metadata
-  let digits = @string.Regex("[[:digit:]]+")
+  let digits = re"[[:digit:]]+"
   let dot = @string.Regex::string(".")
   let major_minor_patch = digits + dot + digits + dot + digits
   let dash = @string.Regex::string("-")
   // Fixed: pre-release and build can contain dots (e.g., "beta.1", "build.123")
   // Put - at the very end to avoid range interpretation
-  let alphanum = @string.Regex("[a-zA-Z0-9.\\-]+")
+  let alphanum = re"[a-zA-Z0-9.\-]+"
   let pre_release = dash + alphanum
   let plus = @string.Regex::string("+")
   let build_meta = plus + alphanum
@@ -539,7 +539,7 @@ test "complex/semantic_version" {
 test "complex/hex_color" {
   // Match hex colors in different formats
   let hash = @string.Regex::string("#")
-  let hex = @string.Regex("[0-9a-fA-F]")
+  let hex = re"[0-9a-fA-F]"
   // Match longest first to avoid short match on long colors
   let alpha_color = hash + hex + hex + hex + hex + hex + hex + hex + hex
   let long_color = hash + hex + hex + hex + hex + hex + hex
@@ -592,8 +592,8 @@ test "complex/json_number" {
   let minus = @string.Regex::string("-")
   let plus_sign = @string.Regex::string("+")
   let zero = @string.Regex::string("0")
-  let digit19 = @string.Regex("[1-9]")
-  let digit = @string.Regex("[[:digit:]]")
+  let digit19 = re"[1-9]"
+  let digit = re"[[:digit:]]"
   let int = zero | (digit19 + digit.repeat(min=0))
   let dot = @string.Regex::string(".")
   let frac = dot + digit.repeat(min=1)
@@ -646,7 +646,7 @@ test "complex/json_number" {
 
 ///|
 test "add/with_any_quantifier" {
-  let re1 = @string.Regex(".*?\\.")
+  let re1 = re".*?\."
   let re2 = re1 + @string.Regex::string(" ")
   guard re1.execute("abc.") is Some(_) else { fail("Expected match") }
   guard re2.execute("abc. ") is Some(_) else { fail("Expected match") }
@@ -655,7 +655,7 @@ test "add/with_any_quantifier" {
 ///|
 test "add/with_any_quantifier_and_empty_wrappers" {
   let empty = @string.Regex::string("")
-  let re = empty + Regex(".*?\\.") + empty + @string.Regex::string(" ")
+  let re = empty + re".*?\." + empty + @string.Regex::string(" ")
   guard re.execute("abc. ") is Some(m) else { fail("Expected match") }
   inspect(m.content(), content="abc. ")
 }
@@ -673,7 +673,7 @@ test "should_raise" {
 
 ///|
 test "escaped_dash_in_char_class" {
-  let regex = @string.Regex("[a\\-z]")
+  let regex = re"[a\-z]"
   inspect(regex.execute("a-z") is Some(_), content="true")
   inspect(regex.execute("b") is Some(_), content="false")
   inspect(regex.execute("-") is Some(_), content="true")
@@ -683,7 +683,7 @@ test "escaped_dash_in_char_class" {
 
 ///|
 test "capture/simple_named_group" {
-  let digit = @string.Regex("[[:digit:]]+").capture("number")
+  let digit = re"[[:digit:]]+".capture("number")
   let regex = @string.Regex::string("ID: ") + digit
   guard regex.execute("ID: 12345") is Some(m) else { fail("Expected match") }
   inspect(m.content(), content="ID: 12345")
@@ -697,9 +697,9 @@ test "capture/simple_named_group" {
 
 ///|
 test "capture/email_with_named_groups" {
-  let user = @string.Regex("[[:alpha:]]+").capture("user")
-  let domain = @string.Regex("[[:alpha:]]+").capture("domain")
-  let tld = @string.Regex("[[:alpha:]]+").capture("tld")
+  let user = re"[[:alpha:]]+".capture("user")
+  let domain = re"[[:alpha:]]+".capture("domain")
+  let tld = re"[[:alpha:]]+".capture("tld")
   let email = user +
     @string.Regex::string("@") +
     domain +
@@ -726,7 +726,7 @@ test "capture/email_with_named_groups" {
 
 ///|
 test "capture/multiple_captures_same_pattern" {
-  let word = @string.Regex("[[:alpha:]]+")
+  let word = re"[[:alpha:]]+"
   let first = word.capture("first")
   let second = word.capture("second")
   let regex = first + @string.Regex::string(" ") + second


### PR DESCRIPTION
## Summary
Converts ~82 `@string.Regex("<literal>")` and `Regex("<literal>")` call sites in `string/` to the `re"<literal>"` regex literal, which lets the compiler validate the pattern at compile time instead of raising at runtime.

### Kept as `Regex(...)`
- **Variable patterns** — `Regex(pattern)`, `Regex(make_large_pattern())`, etc. `re"..."` only accepts a literal.
- **Intentionally-invalid patterns** under `try` / `try!` / `try?` (e.g. `Regex("(")`, `Regex("[abc")`, `Regex("[-a]")`) — these test the runtime failure path; converting them would fail at *compile* time.
- **`\b` / `\B` word-boundary** patterns — the runtime engine accepts them, but the compile-time literal rejects them. Kept as `@string.Regex("\\b")` / `"\\B"`.

### Files touched
- `string/README.mbt.md`
- `string/regex.mbt`
- `string/regex_methods.mbt`
- `string/regex_methods_test.mbt`
- `string/regex_test.mbt`

## Test plan
- [x] `moon check` clean.
- [x] `moon test` — 6521/6521 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)