### PR TITLE
refactor(string): iterate code units directly

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -936,11 +936,11 @@ pub fn Buffer::write_string_utf8(buf : Self, string : StringView) -> Unit {
 pub fn Buffer::write_string_utf16le(buf : Self, string : StringView) -> Unit {
   let len = string.length()
   buf.grow_if_necessary(buf.len + len * 2)
-  for i in 0..<len {
-    let j = buf.len + i * 2
-    let c = string.unsafe_get(i).to_int().reinterpret_as_uint()
+  for code_unit in string.code_units(); j = buf.len {
+    let c = code_unit.to_int().reinterpret_as_uint()
     buf.data[j] = (c & 0xff).to_byte()
     buf.data[j + 1] = (c >> 8).to_byte()
+    continue j + 2
   }
   buf.len += len * 2
 }
@@ -965,11 +965,11 @@ pub fn Buffer::write_string_utf16le(buf : Self, string : StringView) -> Unit {
 pub fn Buffer::write_string_utf16be(buf : Self, string : StringView) -> Unit {
   let len = string.length()
   buf.grow_if_necessary(buf.len + len * 2)
-  for i in 0..<len {
-    let j = buf.len + i * 2
-    let c = string.unsafe_get(i).to_int().reinterpret_as_uint()
+  for code_unit in string.code_units(); j = buf.len {
+    let c = code_unit.to_int().reinterpret_as_uint()
     buf.data[j + 1] = (c & 0xff).to_byte()
     buf.data[j] = (c >> 8).to_byte()
+    continue j + 2
   }
   buf.len += len * 2
 }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -115,8 +115,8 @@ pub fn end() -> Unit {
   coverage_log(counters.val, sbuf)
   let line_buf = StringBuilder()
   for str in sbuf.0 {
-    let start = for j in 0..<str.length(); start = 0 {
-      if str.unsafe_get(j) == '\n' {
+    let start = for j, code_unit in str.code_units(); start = 0 {
+      if code_unit == '\n' {
         line_buf.write_view(str[start:j])
         println(line_buf.to_string())
         line_buf.reset()

--- a/encoding/ascii/encode.mbt
+++ b/encoding/ascii/encode.mbt
@@ -19,8 +19,7 @@
 pub fn encode(str : StringView) -> Bytes {
   let length = str.length()
   let arr = FixedArray::make(length, b'\x00')
-  for i in 0..<length {
-    let code_unit = str.code_unit_at(i)
+  for i, code_unit in str.code_units() {
     if code_unit > 0x7F {
       panic()
     }

--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -54,8 +54,8 @@ pub fn decode(
   let buffer = @buffer.Buffer(size_hint=text.length() / 4 * 3)
   let quartet = FixedArray::make(4, 0)
   let mut count = 0
-  for i in 0..<text.length() {
-    match base64_value(text.code_unit_at(i).to_int()) {
+  for i, code_unit in text.code_units() {
+    match base64_value(code_unit.to_int()) {
       WRITESPACE =>
         if ignore_whitespace {
           continue
@@ -84,9 +84,8 @@ pub fn decode(
             }
             // check no rest
             if ignore_whitespace {
-              for j in (i + 1)..<text.length() {
-                guard text.code_unit_at(j).to_int()
-                  is (' ' | '\n' | '\r' | '\t') else {
+              for code_unit in text.code_units()[i + 1:] {
+                guard code_unit.to_int() is (' ' | '\n' | '\r' | '\t') else {
                   raise Malformed(text)
                 }
               }
@@ -145,8 +144,8 @@ pub fn decode_lossy(
   let buffer = @buffer.Buffer(size_hint=text.length() / 4 * 3)
   let quartet = FixedArray::make(4, 0)
   let mut count = 0
-  for i in 0..<text.length() {
-    match base64_value(text.code_unit_at(i).to_int()) {
+  for code_unit in text.code_units() {
+    match base64_value(code_unit.to_int()) {
       WRITESPACE => if !ignore_whitespace { break }
       PADDING => break
       INVALID_CHAR => ()

--- a/encoding/utf16/encode.mbt
+++ b/encoding/utf16/encode.mbt
@@ -37,18 +37,18 @@ pub fn encode(
     let arr = FixedArray::make(str.length() * 2 + 2, b'\x00')
     arr[0] = 0xFE
     arr[1] = 0xFF
-    for i in 0..<str.length() {
-      let code_unit = str.code_unit_at(i)
-      arr[2 + i * 2] = (code_unit >> 8).to_byte()
-      arr[2 + i * 2 + 1] = (code_unit & 0xFF).to_byte()
+    for code_unit in str.code_units(); i = 2 {
+      arr[i] = (code_unit >> 8).to_byte()
+      arr[i + 1] = (code_unit & 0xFF).to_byte()
+      continue i + 2
     }
     arr.unsafe_reinterpret_as_bytes()
   } else {
     let arr = FixedArray::make(str.length() * 2, b'\x00')
-    for i in 0..<str.length() {
-      let code_unit = str.code_unit_at(i)
-      arr[i * 2] = (code_unit >> 8).to_byte()
-      arr[i * 2 + 1] = (code_unit & 0xFF).to_byte()
+    for code_unit in str.code_units(); i = 0 {
+      arr[i] = (code_unit >> 8).to_byte()
+      arr[i + 1] = (code_unit & 0xFF).to_byte()
+      continue i + 2
     }
     arr.unsafe_reinterpret_as_bytes()
   }

--- a/env/env_wasm.mbt
+++ b/env/env_wasm.mbt
@@ -36,8 +36,8 @@ fn finish_create_string(handle : XStringCreateHandle) -> XExternString = "__moon
 ///|
 fn string_to_extern(s : String) -> XExternString {
   let handle = begin_create_string()
-  for i in 0..<s.length() {
-    string_append_char(handle, s.code_unit_at(i).unsafe_to_char())
+  for code_unit in s.code_units() {
+    string_append_char(handle, code_unit.unsafe_to_char())
   }
   finish_create_string(handle)
 }

--- a/internal/strconv/strconv_decimal.mbt
+++ b/internal/strconv/strconv_decimal.mbt
@@ -481,11 +481,11 @@ fn Decimal::new_digits(self : Decimal, s : Int) -> Int {
   let new_digits = left_shift_cheats[s].0
   let cheat_num = left_shift_cheats[s].1
   // check if the leading digits lexicographically less than cheats num.
-  let less = for i in 0..<cheat_num.length() {
+  let less = for i, code_unit in cheat_num.code_units() {
     if i >= self.digits_num {
       break true
     }
-    let d = cheat_num.unsafe_get(i).to_int() - '0'.to_int()
+    let d = code_unit.to_int() - '0'.to_int()
     if self.digits[i].to_int() != d {
       break self.digits[i].to_int() < d
     }

--- a/json/utils.mbt
+++ b/json/utils.mbt
@@ -14,8 +14,8 @@
 
 ///|
 fn offset_to_position(input : StringView, offset : Int) -> Position {
-  for i in 0..<offset; line = 1, column = 0 {
-    if input.unsafe_get(i) == '\n' {
+  for code_unit in input.code_units()[:offset]; line = 1, column = 0 {
+    if code_unit == '\n' {
       continue line + 1, 0
     } else {
       continue line, column + 1

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -472,11 +472,11 @@ fn Decimal::new_digits(self : Decimal, s : Int) -> Int {
   let new_digits = left_shift_cheats[s].0
   let cheat_num = left_shift_cheats[s].1
   // check if the leading digits lexicographically less than cheats num.
-  let less = for i in 0..<cheat_num.length() {
+  let less = for i, code_unit in cheat_num.code_units() {
     if i >= self.digits_num {
       break true
     }
-    let d = cheat_num.unsafe_get(i).to_int() - '0'.to_int()
+    let d = code_unit.to_int() - '0'.to_int()
     if self.digits[i].to_int() != d {
       break self.digits[i].to_int() < d
     }

--- a/string/ascii_case_insensitive_map_test.mbt
+++ b/string/ascii_case_insensitive_map_test.mbt
@@ -44,8 +44,8 @@ fn AsciiCaseInsensitiveString::new(s : String) -> AsciiCaseInsensitiveString {
 /// the same bucket.
 impl Hash for AsciiCaseInsensitiveString with fn hash_combine(self, hasher) {
   let s = self.raw
-  for i in 0..<s.length() {
-    let mut c = s.unsafe_get(i)
+  for code_unit in s.code_units() {
+    let mut c = code_unit
     // Fold ASCII 'A'..'Z' (0x41..0x5A) to 'a'..'z' (0x61..0x7A).
     if c >= ('A' : UInt16) && c <= ('Z' : UInt16) {
       c = c + (32 : UInt16)


### PR DESCRIPTION
## Summary

- Replace simple index-based string and string-view code-unit loops with direct `for .. in code_units()` iteration.
- Keep index variables only where they are still needed for output positions or slicing.
- Leave allocation-sensitive hashing and low-level string blit paths indexed.

## Test Plan

- `moon fmt`
- `moon check`
- `moon test` (6521/6521 passed)
- `moon info`