### PR TITLE
refactor(string): avoid unnecessary code unit conversions

### DIFF
--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -85,7 +85,7 @@ pub fn decode(
             // check no rest
             if ignore_whitespace {
               for code_unit in text.code_units()[i + 1:] {
-                guard code_unit.to_int() is (' ' | '\n' | '\r' | '\t') else {
+                guard code_unit is (' ' | '\n' | '\r' | '\t') else {
                   raise Malformed(text)
                 }
               }

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -24,7 +24,7 @@ fn ParseContext::lex_string(ctx : ParseContext) -> String raise ParseError {
       return ctx.input.view(start_offset=string_start, end_offset=i).to_owned()
     } else if c == '\\' {
       return ctx.lex_string_slow()
-    } else if c == '\n' || c == '\r' || c.to_int() < 32 {
+    } else if c == '\n' || c == '\r' || c < ' ' {
       ctx.offset = i + 1
       ctx.invalid_char(shift=-1)
     }


### PR DESCRIPTION
## Summary

- Match `UInt16` code units directly against character patterns in base64 padding validation.
- Compare JSON string lexer code units against the space character literal instead of converting to `Int`.

## Test Plan

- `moon fmt`
- `moon check`
- `moon test encoding/base64` (11/11 passed)
- `moon test json` (172/172 passed)
- `git diff --check`