### PR TITLE
Add debug object trace writer

### DIFF
--- a/debug/moon.pkg
+++ b/debug/moon.pkg
@@ -17,3 +17,12 @@ import {
 } for "test"
 
 warnings = "-alert_visibility-test_unqualified_package"
+
+options(
+  targets: {
+    "trace_debug.mbt": [ "debug" ],
+    "trace_debug_test.mbt": [ "debug" ],
+    "trace_release.mbt": [ "not", "debug" ],
+    "trace_release_test.mbt": [ "not", "debug" ],
+  },
+)

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -11,6 +11,8 @@ pub fn[T : Debug] debug(T) -> Unit
 #callsite(autofill(args_loc, loc))
 pub fn debug_inspect(&Debug, content? : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise InspectError
 
+pub let debug_object : DebugObject?
+
 #deprecated
 #callsite(autofill(loc))
 pub fn[T : Debug] dump(T, name? : String, loc~ : SourceLoc) -> T
@@ -23,6 +25,11 @@ pub fn[T : Debug] to_string(T) -> String
 // Errors
 
 // Types and methods
+type DebugObject
+pub fn DebugObject::write_object_begin(Self) -> Unit
+pub fn DebugObject::write_object_end(Self) -> Unit
+pub fn[T : Debug] DebugObject::write_object_field(Self, String, T) -> Unit
+
 type Repr
 pub impl Show for Repr
 pub impl Debug for Repr

--- a/debug/trace.mbt
+++ b/debug/trace.mbt
@@ -1,0 +1,63 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Debug-only object-template writer.
+///
+/// This type is intentionally minimal: it supports object-template fields, so
+/// `@debug.debug_object <? { "name": value }` can log debug values in debug
+/// builds while compiling to a no-op in release builds.
+#warnings("-struct_never_constructed")
+struct DebugObject {
+  buffer : StringBuilder
+  mut first : Bool
+}
+
+///|
+/// Starts a debug object template.
+///
+/// This resets the internal buffer before object fields are written.
+pub fn DebugObject::write_object_begin(self : DebugObject) -> Unit {
+  self.buffer.reset()
+  self.first = true
+}
+
+///|
+/// Ends a debug object template.
+///
+/// This flushes the accumulated object fields.
+pub fn DebugObject::write_object_end(self : DebugObject) -> Unit {
+  println(self.buffer.to_string())
+  self.buffer.reset()
+  self.first = true
+}
+
+///|
+/// Writes one debug object-template field.
+///
+/// The field value must implement `Debug`.
+pub fn[T : Debug] DebugObject::write_object_field(
+  self : DebugObject,
+  name : String,
+  value : T,
+) -> Unit {
+  if self.first {
+    self.first = false
+  } else {
+    self.buffer.write_string(", ")
+  }
+  self.buffer.write_string(name)
+  self.buffer.write_string(" = ")
+  self.buffer.write_string(to_string(value))
+}

--- a/debug/trace_debug.mbt
+++ b/debug/trace_debug.mbt
@@ -1,0 +1,30 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Return a debug object-template writer in debug builds.
+///
+/// Intended usage:
+///
+/// ```mbt nocheck
+/// @debug.debug_object <? { "value": value }
+/// ```
+///
+/// The object field value must implement `Debug`. In release builds this
+/// value is `None`, so `<?` skips the template and does not evaluate
+/// field values.
+pub let debug_object : DebugObject? = Some({
+  buffer: StringBuilder(),
+  first: true,
+})

--- a/debug/trace_debug_test.mbt
+++ b/debug/trace_debug_test.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "debug_object/debug" {
+  guard debug_object is Some(_)
+  let mut evaluated = false
+  debug_object <?
+    {
+      "value": {
+        evaluated = true
+        [1, 2, 3]
+      },
+    }
+  inspect(evaluated, content="true")
+}

--- a/debug/trace_release.mbt
+++ b/debug/trace_release.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Return no debug object-template writer in release builds.
+pub let debug_object : DebugObject? = None

--- a/debug/trace_release_test.mbt
+++ b/debug/trace_release_test.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "debug_object/release" {
+  guard debug_object is None
+  let mut evaluated = false
+  debug_object <?
+    {
+      "value": {
+        evaluated = true
+        [1, 2, 3]
+      },
+    }
+  inspect(evaluated, content="false")
+}

--- a/prelude/README.mbt.md
+++ b/prelude/README.mbt.md
@@ -42,7 +42,7 @@ test "Set constructor from prelude" {
 ## Re-exported Functions
 
 - `println`, `abort`, `panic`, `fail` — output and error handling
-- `inspect`, `debug_inspect`, `debug`, `to_repr` — debugging
+- `inspect`, `debug_inspect`, `debug`, `debug_object`, `to_repr` — debugging
 - `@test.assert_eq`, `@test.assert_not_eq`, `assert_true`, `assert_false`, `debug_assert` — assertions
 - `ignore`, `physical_equal` — utilities
 - `json_inspect` — JSON-based snapshot testing

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -35,6 +35,8 @@ pub fn debug_assert(() -> Bool) -> Unit
 #callsite(autofill(args_loc, loc))
 pub fn debug_inspect(&@debug.Debug, content? : String, loc~ : @builtin.SourceLoc, args_loc~ : @builtin.ArgsLoc) -> Unit raise @builtin.InspectError
 
+pub let debug_object : @debug.DebugObject?
+
 #deprecated
 #callsite(autofill(loc))
 pub fn[T : @debug.Debug] dump(T, name? : String, loc~ : @builtin.SourceLoc) -> T

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -82,7 +82,15 @@ pub using @builtin {not}
 pub using @builtin {type IterResult}
 
 ///|
-pub using @debug {debug, type Repr, trait Debug, debug_inspect, repr, to_repr}
+pub using @debug {
+  debug,
+  debug_object,
+  type Repr,
+  trait Debug,
+  debug_inspect,
+  repr,
+  to_repr,
+}
 
 ///|
 #deprecated("for debugging only, not for production")


### PR DESCRIPTION
## Summary

- add `@debug.debug_object` as a debug-only optional object-template writer
- compile it to `None` in release mode so `<?` skips evaluating debug fields
- re-export `debug_object` from `prelude`

Example:

```mbt
@debug.debug_object <? { "value": value }
```

## Known issues / follow-ups

1. **Re-entrancy:** `debug_object` is a package-level optional writer, so nested use can reuse the same buffer. A nested `debug_object <? ...` inside a field expression can interfere with the outer trace.
2. **Build system artifact mode:** currently the bundled core is built under release mode and only the release-mode artifacts are used. This needs a build-system-side fix so `moonbitlang/core` artifacts from both release mode and debug mode can be used.

## Tests

- `moon fmt`
- `moon check debug`
- `moon check --release debug`
- `moon test debug`
- `moon test --release debug`
- `moon check prelude`
- `moon test prelude`
- `moon info`
- `moon check`