### PR TITLE
Use WASIp1 proc_exit for wasm argparse exit

### DIFF
--- a/argparse/runtime_exit_wasm.mbt
+++ b/argparse/runtime_exit_wasm.mbt
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 ///|
-#cfg(any(target="wasm", target="wasm-gc"))
+#cfg(target="wasm")
+fn runtime_wasm_exit(code : Int) -> Unit = "wasi_snapshot_preview1" "proc_exit"
+
+///|
+#cfg(target="wasm-gc")
 fn runtime_wasm_exit(code : Int) -> Unit = "__moonbit_sys_unstable" "exit"
 
 ///|


### PR DESCRIPTION
## Why

`argparse` uses a wasm-specific exit helper for help and version display paths. Linear wasm can use the standard WASIp1 `proc_exit` import instead of the MoonBit unstable sys exit import.

## Why this is correct

The change preserves the existing successful-exit behavior for `argparse` while routing only the linear `wasm` target to `wasi_snapshot_preview1.proc_exit`. The `wasm-gc` target keeps the existing unstable import, so this does not change its host requirements.

## Why this is minimal

The change is limited to the backend-gated `runtime_wasm_exit` declaration. No parser behavior or public API is changed.