### PR TITLE
[codex] Add StringBuilder interpolation write alias

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -459,6 +459,7 @@ pub fn StringBuilder::reset(Self) -> Unit
 pub fn StringBuilder::to_string(Self) -> String
 pub fn StringBuilder::write_iter(Self, Iter[Char]) -> Unit
 #alias(write)
+#alias(write_string_interpolation)
 pub fn[T : Show] StringBuilder::write_object(Self, T) -> Unit
 pub fn StringBuilder::write_stringview(Self, StringView) -> Unit
 pub impl Logger for StringBuilder

--- a/builtin/stringbuilder.mbt
+++ b/builtin/stringbuilder.mbt
@@ -15,6 +15,7 @@
 ///|
 /// Writes the string representation of an object to the StringBuilder.
 #alias(write)
+#alias(write_string_interpolation)
 pub fn[T : Show] StringBuilder::write_object(
   self : StringBuilder,
   obj : T,


### PR DESCRIPTION
## Summary

Adds `write_string_interpolation` as an alias for `StringBuilder::write_object`, alongside the existing `write` alias.

This makes the alias visible in the generated builtin package interface and available through IDE documentation lookup.

## Validation

- `moon fmt`
- `moon info`
- `moon check`
- `moon test` (6,524 passed, 0 failed)
