### PR TITLE
[codex] add String all and any

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -714,6 +714,10 @@ pub fn Double::trunc(Double) -> Double
 pub fn Double::until(Double, Double, step? : Double, inclusive? : Bool) -> Iter[Double]
 
 pub fn String::after(String, StringView) -> StringView?
+#alias(every)
+pub fn String::all(String, (Char) -> Bool raise?) -> Bool raise?
+#alias(exists)
+pub fn String::any(String, (Char) -> Bool raise?) -> Bool raise?
 #alias("_[_]")
 #alias(code_unit_at)
 pub fn String::at(String, Int) -> UInt16
@@ -1030,6 +1034,10 @@ pub fn BytesView::to_owned(Self) -> Bytes
 pub fn BytesView::view(Self, start? : Int, end? : Int) -> Self
 
 pub fn StringView::after(Self, Self) -> Self?
+#alias(every)
+pub fn StringView::all(Self, (Char) -> Bool raise?) -> Bool raise?
+#alias(exists)
+pub fn StringView::any(Self, (Char) -> Bool raise?) -> Bool raise?
 #alias("_[_]")
 #alias(code_unit_at)
 pub fn StringView::at(Self, Int) -> UInt16

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -278,6 +278,50 @@ pub fn String::iter2(self : String) -> Iter2[Int, Char] {
 }
 
 ///|
+/// Checks if all characters in the string match the condition.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   assert_true("abc".all(c => c.is_ascii_lowercase()))
+///   assert_false("abc1".all(c => c.is_ascii_lowercase()))
+/// }
+/// ```
+#locals(f)
+#alias(every)
+pub fn String::all(self : String, f : (Char) -> Bool raise?) -> Bool raise? {
+  for c in self {
+    if !f(c) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Checks if any character in the string matches the condition.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   assert_true("abc1".any(c => c.is_ascii_digit()))
+///   assert_false("abc".any(c => c.is_ascii_digit()))
+/// }
+/// ```
+#locals(f)
+#alias(exists)
+pub fn String::any(self : String, f : (Char) -> Bool raise?) -> Bool raise? {
+  for c in self {
+    if f(c) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 /// Returns an iterator that yields characters from the end to the start of the string. This function handles
 /// Unicode surrogate pairs correctly, ensuring that characters are not split across surrogate pairs.
 ///

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -174,6 +174,43 @@ test "String rev_iter with surrogate" {
 }
 
 ///|
+test "String::all and any" {
+  inspect("".all(c => c == 'x'), content="true")
+  inspect("".any(c => c == 'x'), content="false")
+  inspect("abc".all(c => c.is_ascii_lowercase()), content="true")
+  inspect("abc1".all(c => c.is_ascii_lowercase()), content="false")
+  inspect("abc".every(c => c.is_ascii_lowercase()), content="true")
+  inspect("abc1".any(c => c.is_ascii_digit()), content="true")
+  inspect("abc".any(c => c.is_ascii_digit()), content="false")
+  inspect("abc".exists(c => c == 'b'), content="true")
+  inspect(
+    "a😀c".all(c => c == 'a' || c == '😀' || c == 'c'),
+    content="true",
+  )
+  inspect("a😀c".any(c => c == '😀'), content="true")
+
+  let mut any_calls = 0
+  inspect(
+    "abc".any(c => {
+      any_calls += 1
+      c == 'b'
+    }),
+    content="true",
+  )
+  inspect(any_calls, content="2")
+
+  let mut all_calls = 0
+  inspect(
+    "abc".all(c => {
+      all_calls += 1
+      c != 'b'
+    }),
+    content="false",
+  )
+  inspect(all_calls, content="2")
+}
+
+///|
 test "char_length_eq and char_length_ge" {
   let s = "hi😀"
   inspect(s.char_length_eq(3), content="true")

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -283,6 +283,58 @@ pub fn StringView::rev_iter(self : StringView) -> Iter[Char] {
 }
 
 ///|
+/// Checks if all characters in the string view match the condition.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let view = "zabc!"[1:-1]
+///   assert_true(view.all(c => c.is_ascii_lowercase()))
+///   assert_false(view.all(c => c == 'a'))
+/// }
+/// ```
+#locals(f)
+#alias(every)
+pub fn StringView::all(
+  self : StringView,
+  f : (Char) -> Bool raise?,
+) -> Bool raise? {
+  for c in self {
+    if !f(c) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Checks if any character in the string view matches the condition.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let view = "zabc!"[1:-1]
+///   assert_true(view.any(c => c == 'b'))
+///   assert_false(view.any(c => c.is_ascii_digit()))
+/// }
+/// ```
+#locals(f)
+#alias(exists)
+pub fn StringView::any(
+  self : StringView,
+  f : (Char) -> Bool raise?,
+) -> Bool raise? {
+  for c in self {
+    if f(c) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 /// Compares two views for equality. Returns true only if both views
 /// have the same length and contain identical characters in the same order.
 pub impl Eq for StringView with fn equal(self, other) {

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -106,6 +106,39 @@ test "StringView core operations" {
 }
 
 ///|
+test "StringView::all and any" {
+  let view = "Za😀b!"[1:-1]
+  inspect(""[0:0].all(c => c == 'x'), content="true")
+  inspect(""[0:0].any(c => c == 'x'), content="false")
+  inspect(view.all(c => c == 'a' || c == '😀' || c == 'b'), content="true")
+  inspect(view.all(c => c.is_ascii_lowercase()), content="false")
+  inspect(view.every(c => c == 'a' || c == '😀' || c == 'b'), content="true")
+  inspect(view.any(c => c == '😀'), content="true")
+  inspect(view.any(c => c.is_ascii_digit()), content="false")
+  inspect(view.exists(c => c == 'b'), content="true")
+
+  let mut any_calls = 0
+  inspect(
+    view.any(c => {
+      any_calls += 1
+      c == '😀'
+    }),
+    content="true",
+  )
+  inspect(any_calls, content="2")
+
+  let mut all_calls = 0
+  inspect(
+    view.all(c => {
+      all_calls += 1
+      c != '😀'
+    }),
+    content="false",
+  )
+  inspect(all_calls, content="2")
+}
+
+///|
 test "StringView comparisons" {
   let base = "hello"
   let v1 = base[:]


### PR DESCRIPTION
## Summary

Adds `all` and `any` methods for both `String` and `StringView`, matching the `ArrayView` API shape with `#locals(f)` and `every`/`exists` aliases.

The implementations use `for c in self`; MoonBit lowers string and string-view character loops to direct UTF-16 scans with surrogate-pair decoding, so this keeps the code simple while avoiding iterator allocation.

## Validation

- `moon fmt`
- `moon info`
- `moon check builtin --warn-list +73`
- `moon test builtin` (2859 passed)

Note: `moon check --warn-list +73` in this local checkout is currently blocked by an unrelated untracked file, `bigint/bench_scratch_test.mbt`, which references `@bench` without a package dependency. That file is not included in this PR.