### PR TITLE
[codex] add count helpers

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -862,6 +862,46 @@ pub fn[T : Eq] Array::contains(self : Array[T], value : T) -> Bool {
 }
 
 ///|
+/// Counts how many elements in the array are equal to `value`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr = [1, 2, 1, 3, 1]
+///   inspect(arr.count(1), content="3")
+///   inspect(arr.count(4), content="0")
+/// }
+/// ```
+pub fn[T : Eq] Array::count(self : Array[T], value : T) -> Int {
+  self[:].count(value)
+}
+
+///|
+/// Counts how many elements in the array satisfy the predicate.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr = [1, 2, 3, 4, 5]
+///   inspect(arr.count_if(x => x % 2 == 0), content="2")
+/// }
+/// ```
+#locals(f)
+pub fn[T] Array::count_if(
+  self : Array[T],
+  f : (T) -> Bool raise?,
+) -> Int raise? {
+  for v in self; count = 0 {
+    if f(v) {
+      continue count + 1
+    }
+    continue count
+  } nobreak {
+    count
+  }
+}
+
+///|
 /// Checks if the array begins with all elements of the provided prefix array in
 /// order.
 ///

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -985,6 +985,51 @@ test "filter with error callback 2" {
 }
 
 ///|
+test "Array::count basic" {
+  let arr = [1, 2, 1, 3, 1]
+  inspect(arr.count(1), content="3")
+  inspect(arr.count(4), content="0")
+}
+
+///|
+test "Array::count empty" {
+  let arr : Array[Int] = []
+  inspect(arr.count(1), content="0")
+}
+
+///|
+test "Array::count_if basic" {
+  let arr = [1, 2, 3, 4, 5]
+  inspect(arr.count_if(x => x % 2 == 0), content="2")
+  inspect(arr.count_if(x => x > 99), content="0")
+}
+
+///|
+test "Array::count_if propagates error" {
+  let arr = [1, 2, 3]
+  try
+    ignore(
+      arr.count_if(x => {
+        if x == 2 {
+          raise Failure::Failure("count_if failed")
+        }
+        true
+      }),
+    )
+  catch {
+    e =>
+      debug_inspect(
+        e,
+        content=(
+          #|Failure("count_if failed")
+        ),
+      )
+  } noraise {
+    _ => fail("expected error")
+  }
+}
+
+///|
 test "map_inplace with error callback" {
   let arr = [1, 2, 3]
   try

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -986,6 +986,53 @@ pub fn[T : Eq] ArrayView::contains(self : ArrayView[T], value : T) -> Bool {
 }
 
 ///|
+/// Counts how many elements in the array view are equal to `value`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let view = [1, 2, 1, 3, 1][:]
+///   inspect(view.count(1), content="3")
+///   inspect(view.count(4), content="0")
+/// }
+/// ```
+pub fn[T : Eq] ArrayView::count(self : ArrayView[T], value : T) -> Int {
+  for v in self; count = 0 {
+    if v == value {
+      continue count + 1
+    }
+    continue count
+  } nobreak {
+    count
+  }
+}
+
+///|
+/// Counts how many elements in the array view satisfy the predicate.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let view = [1, 2, 3, 4, 5][:]
+///   inspect(view.count_if(x => x % 2 == 0), content="2")
+/// }
+/// ```
+#locals(f)
+pub fn[T] ArrayView::count_if(
+  self : ArrayView[T],
+  f : (T) -> Bool raise?,
+) -> Int raise? {
+  for v in self; count = 0 {
+    if f(v) {
+      continue count + 1
+    }
+    continue count
+  } nobreak {
+    count
+  }
+}
+
+///|
 /// Searches for the first occurrence of a value in the array view.
 ///
 /// # Example

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -996,6 +996,70 @@ test "ArrayView::rev_eachi empty" {
 }
 
 ///|
+test "ArrayView::count basic" {
+  let v = [1, 2, 1, 3, 1][:]
+  inspect(v.count(1), content="3")
+  inspect(v.count(4), content="0")
+}
+
+///|
+test "ArrayView::count sliced view" {
+  let v = [1, 2, 1, 3, 1][1:4]
+  inspect(v.count(1), content="1")
+  inspect(v.count(2), content="1")
+}
+
+///|
+test "ArrayView::count empty" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  inspect(v.count(1), content="0")
+}
+
+///|
+test "ArrayView::count_if basic" {
+  let v = [1, 2, 3, 4, 5][:]
+  inspect(v.count_if(x => x % 2 == 0), content="2")
+  inspect(v.count_if(x => x > 99), content="0")
+}
+
+///|
+test "ArrayView::count_if sliced view" {
+  let v = [1, 2, 3, 4, 5][1:4]
+  inspect(v.count_if(x => x % 2 == 0), content="2")
+}
+
+///|
+test "ArrayView::count_if empty" {
+  let v : ArrayView[Int] = [1, 2, 3][0:0]
+  inspect(v.count_if(_ => true), content="0")
+}
+
+///|
+test "ArrayView::count_if propagates error" {
+  let v = [1, 2, 3][:]
+  try
+    ignore(
+      v.count_if(x => {
+        if x == 2 {
+          raise Failure::Failure("count_if failed")
+        }
+        true
+      }),
+    )
+  catch {
+    e =>
+      debug_inspect(
+        e,
+        content=(
+          #|Failure("count_if failed")
+        ),
+      )
+  } noraise {
+    _ => fail("expected error")
+  }
+}
+
+///|
 test "ArrayView::search_by basic" {
   let v = [1, 2, 3, 4, 5][:]
   debug_inspect(v.search_by(x => x > 3), content="Some(3)")

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -47,6 +47,16 @@ test "count" {
 }
 
 ///|
+test "count_if" {
+  let iter = test_from_array([1, 2, 3, 4, 5, 6])
+  @test.assert_eq(iter.count_if(x => x % 2 == 0), 3)
+  let iter = test_from_array([1, 2, 3])
+  @test.assert_eq(iter.count_if(x => x > 99), 0)
+  let iter : Iter[Int] = Iter::empty()
+  @test.assert_eq(iter.count_if(_ => true), 0)
+}
+
+///|
 test "take" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = StringBuilder(size_hint=0)

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -223,7 +223,38 @@ pub fn[X, R] Iter::fold(
 /// Returns the number of elements in the iterator.
 #alias(length)
 pub fn[X] Iter::count(self : Iter[X]) -> Int {
-  self.fold((acc, _) => acc + 1, init=0)
+  for _ in self; count = 0 {
+    continue count + 1
+  } nobreak {
+    count
+  }
+}
+
+///|
+/// Counts the number of elements in the iterator that satisfy the predicate.
+///
+/// # Type Parameters
+///
+/// - `X`: The type of the elements in the iterator.
+///
+/// # Arguments
+///
+/// - `self`: The iterator to consume.
+/// - `f`: A predicate function applied to each element.
+///
+/// # Returns
+///
+/// Returns the number of elements for which `f` returns `true`.
+#locals(f)
+pub fn[X] Iter::count_if(self : Iter[X], f : (X) -> Bool) -> Int {
+  for x in self; count = 0 {
+    if f(x) {
+      continue count + 1
+    }
+    continue count
+  } nobreak {
+    count
+  }
 }
 
 // Producers

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -84,6 +84,8 @@ pub fn[T] Array::clear(Self[T]) -> Unit
 pub fn[T : Eq] Array::contains(Self[T], T) -> Bool
 #alias(clone, deprecated)
 pub fn[T] Array::copy(Self[T]) -> Self[T]
+pub fn[T : Eq] Array::count(Self[T], T) -> Int
+pub fn[T] Array::count_if(Self[T], (T) -> Bool raise?) -> Int raise?
 pub fn[T : Eq] Array::dedup(Self[T]) -> Unit
 pub fn[T] Array::drain(Self[T], Int, Int) -> Self[T]
 pub fn[T] Array::each(Self[T], (T) -> Unit raise?) -> Unit raise?
@@ -194,6 +196,8 @@ pub fn[A] ArrayView::blit_to(Self[A], Array[A], dst_offset? : Int) -> Unit
 pub fn[T] ArrayView::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[Self[T]] raise?
 pub fn[T] ArrayView::chunks(Self[T], Int) -> Array[Self[T]]
 pub fn[T : Eq] ArrayView::contains(Self[T], T) -> Bool
+pub fn[T : Eq] ArrayView::count(Self[T], T) -> Int
+pub fn[T] ArrayView::count_if(Self[T], (T) -> Bool raise?) -> Int raise?
 pub fn[T] ArrayView::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ArrayView::ends_with(Self[T], Self[T]) -> Bool
@@ -272,6 +276,7 @@ pub fn[X] Iter::concat(Self[X], Self[X]) -> Self[X]
 pub fn[X : Eq] Iter::contains(Self[X], X) -> Bool
 #alias(length)
 pub fn[X] Iter::count(Self[X]) -> Int
+pub fn[X] Iter::count_if(Self[X], (X) -> Bool) -> Int
 pub fn[X] Iter::drop(Self[X], Int) -> Self[X]
 pub fn[X] Iter::drop_while(Self[X], (X) -> Bool) -> Self[X]
 pub fn[X] Iter::each(Self[X], (X) -> Unit raise?) -> Unit raise?


### PR DESCRIPTION
## Summary

Adds count helper APIs across the array and iterator surfaces:

- `ArrayView::count(value)` and `ArrayView::count_if(predicate)`
- `Array::count(value)` and `Array::count_if(predicate)`
- `Iter::count_if(predicate)`

The `Array` methods mirror the `ArrayView` API, and `Iter::count_if` complements the existing terminal `Iter::count()` without overloading `Iter::count(value)`, keeping `count()` as the total-length operation.

## Validation

- `moon fmt`
- `moon info`
- `moon check builtin`
- `moon test builtin`
- `moon test`
- `moon ide doc '*::*count*'`