### PR TITLE
[codex] hide unsafe char conversions

### DIFF
--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1529,6 +1529,7 @@ pub fn Int::to_byte(self : Int) -> Byte = "%i32_to_byte"
 /// Convert integer to char without validity checks.
 ///
 /// Undefined behavior for surrogate or out-of-range values.
+#doc(hidden)
 pub fn Int::unsafe_to_char(self : Int) -> Char = "%char_from_int"
 
 ///|

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -431,7 +431,7 @@ test "flat_map2" {
 ///|
 test "fold" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
-  let result = (iter.fold((acc, x) => acc + x.to_int(), init=0) / 5).unsafe_to_char()
+  let result = iter.fold((acc, x) => acc + x.to_int(), init=0) / 5
   @test.assert_eq(result, '3')
 }
 

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -578,7 +578,6 @@ pub fn Int::to_string(Int, radix? : Int) -> String
 pub fn Int::to_uint(Int) -> UInt
 pub fn Int::to_uint16(Int) -> UInt16
 pub fn Int::to_uint64(Int) -> UInt64
-pub fn Int::unsafe_to_char(Int) -> Char
 pub fn Int::until(Int, Int, step? : Int, inclusive? : Bool) -> Iter[Int]
 
 pub fn Int64::abs(Int64) -> Int64
@@ -652,7 +651,6 @@ pub fn UInt16::to_int64(UInt16) -> Int64
 pub fn UInt16::to_string(UInt16, radix? : Int) -> String
 pub fn UInt16::to_uint(UInt16) -> UInt
 pub fn UInt16::to_uint64(UInt16) -> UInt64
-pub fn UInt16::unsafe_to_char(UInt16) -> Char
 
 pub fn UInt64::clz(UInt64) -> Int
 pub fn UInt64::ctz(UInt64) -> Int

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -672,7 +672,7 @@ test "contains_char" {
   inspect("hello world".contains_char('w'), content="true")
   inspect("😀😀".contains_char('😀'), content="true")
   inspect("😀😀".contains_char('😃'), content="false")
-  inspect("hello".contains_char((104).unsafe_to_char()), content="true") // 'h' is 104 in ASCII
+  inspect("hello".contains_char('h'), content="true")
   let leading_surrogate = String::from_array([(0xD800).unsafe_to_char()])
   inspect(
     leading_surrogate.contains_char((0xD800).unsafe_to_char()),

--- a/builtin/uint16_char.mbt
+++ b/builtin/uint16_char.mbt
@@ -65,6 +65,7 @@ pub fn UInt16::is_surrogate(self : Self) -> Bool {
 
 ///|
 /// Unsafe variant of `to_char`.
+#doc(hidden)
 pub fn UInt16::unsafe_to_char(self : UInt16) -> Char {
   self.to_int().unsafe_to_char()
 }

--- a/builtin/uint16_char_test.mbt
+++ b/builtin/uint16_char_test.mbt
@@ -25,10 +25,10 @@ test "UInt16 surrogate checks" {
 }
 
 ///|
-test "UInt16 to_char and unsafe_to_char" {
-  let a = (0x0041 : UInt16)
+test "UInt16 to_char" {
+  let a = ('A' : UInt16)
   assert_true(a.to_char() is Some('A'))
-  inspect(a.unsafe_to_char(), content="A")
+  inspect(a.to_char().unwrap(), content="A")
   assert_true((0xD800 : UInt16).to_char() is None)
 }
 

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -33,7 +33,7 @@ test "show output" {
   assert_eq(repr('\r'), "\r")
   assert_eq(repr('\b'), "\b")
   assert_eq(repr('\t'), "\t")
-  assert_eq(repr((0).unsafe_to_char()), "\u{00}")
+  assert_eq(repr('\u{00}'), "\u{00}")
 }
 
 ///|

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -401,7 +401,7 @@ test "panic length_eq should panic on invalid surrogate pair" {
 test "panic_length_ge invalid surrogate pair" {
   let invalid_surrogate_pair = String::from_array([
     (0xD800).unsafe_to_char(), // Leading surrogate
-    (0x0041).unsafe_to_char(), // Invalid trailing surrogate (just a regular 'A')
+    'A', // Invalid trailing surrogate (just a regular 'A')
   ])
   let view = invalid_surrogate_pair[:]
   // This should abort with "invalid surrogate pair"

--- a/uint16/uint16_test.mbt
+++ b/uint16/uint16_test.mbt
@@ -390,15 +390,11 @@ test "Int16::reinterpret_from_uint16" {
 }
 
 ///|
-test "UInt16::unsafe_to_char" {
-  let c1 = (0x41 : UInt16).unsafe_to_char()
-  inspect(c1.to_int(), content="65")
-  let c2 = (0x61 : UInt16).unsafe_to_char()
-  inspect(c2.to_int(), content="97")
-  let c3 = (0x30 : UInt16).unsafe_to_char()
-  inspect(c3.to_int(), content="48")
-  let c4 = (0x20 : UInt16).unsafe_to_char()
-  inspect(c4.to_int(), content="32")
+test "UInt16 char literal overloading" {
+  inspect(('A' : UInt16).to_int(), content="65")
+  inspect(('a' : UInt16).to_int(), content="97")
+  inspect(('0' : UInt16).to_int(), content="48")
+  inspect((' ' : UInt16).to_int(), content="32")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Hide `Int::unsafe_to_char` and `UInt16::unsafe_to_char` from generated docs/interfaces with `#doc(hidden)`.
- Regenerate `builtin/pkg.generated.mbti` so the hidden unsafe conversions are no longer listed.
- Replace a few test-only/literal uses of `unsafe_to_char` with character literals or checked `to_char()` usage.

## Impact

This keeps the unchecked conversion escape hatch available for internal/raw UTF-16 and performance-sensitive code, while removing it from the documented public surface. `Int::to_char` and `UInt16::to_char` remain the visible checked conversions.

## Validation

- `moon fmt`
- `moon info`
- `moon check --target all` (passes; existing missing-doc warnings remain in unrelated `bench`/JS bigint files)
- `moon test` (6547/6547 passed)
- `git diff --check`
