### PR TITLE
[codex] feat(buffer): add write bytes interpolation alias

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -748,6 +748,7 @@ pub fn Buffer::write_object(self : Buffer, value : &Show) -> Unit {
 ///   )
 /// }
 /// ```
+#alias(write_bytes_interpolation)
 pub fn[T : Show] Buffer::write_utf8(self : Buffer, value : T) -> Unit {
   self.write_string_utf8(value.to_string())
 }

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -61,6 +61,7 @@ pub fn Buffer::write_uint64_be(Self, UInt64) -> Unit
 pub fn Buffer::write_uint64_le(Self, UInt64) -> Unit
 pub fn Buffer::write_uint_be(Self, UInt) -> Unit
 pub fn Buffer::write_uint_le(Self, UInt) -> Unit
+#alias(write_bytes_interpolation)
 pub fn[T : Show] Buffer::write_utf8(Self, T) -> Unit
 #deprecated
 pub impl Logger for Buffer


### PR DESCRIPTION
## Summary

Add `#alias(write_bytes_interpolation)` to `Buffer::write_utf8`, matching the interpolation alias pattern used by `StringBuilder::write_object`.

## Validation

- `moon fmt`
- `moon info`
- `moon check`
- `moon test buffer`
- `moon test`

@bobzhang 