### PR TITLE
fix(math): use unsigned compare for cosh near-overflow boundary

### DIFF
--- a/math/hyperbolic_double_nonjs.mbt
+++ b/math/hyperbolic_double_nonjs.mbt
@@ -141,8 +141,13 @@ pub fn cosh(x : Double) -> Double {
   if ix < 0x40862E42 {
     return 0.5 * exp(x.abs())
   }
-  let lx = get_low_word(x).reinterpret_as_int()
-  if ix < 0x408633ce || (ix == 0x408633ce && lx <= 0x8fb9f87d) {
+  // |x| in [log(maxdouble), overflow threshold]: compute via the scaled form
+  // 0.5 * exp(0.5*|x|) * exp(0.5*|x|) to avoid overflow in the intermediate exp.
+  // The threshold bit pattern 0x408633ce8fb9f87d must be compared as an unsigned
+  // 64-bit integer (mirroring `sinh`); a split high/low-word comparison with a
+  // signed low word misclassifies low words in [0, 0x7fffffff] and wrongly
+  // overflows to infinity for finite values just below the threshold.
+  if x.abs().reinterpret_as_uint64() <= 0x408633ce8fb9f87d {
     let w = exp(0.5 * x.abs())
     let t = 0.5 * w
     return t * w

--- a/math/hyperbolic_double_nonjs.mbt
+++ b/math/hyperbolic_double_nonjs.mbt
@@ -126,8 +126,9 @@ pub fn cosh(x : Double) -> Double {
     return @double.infinity
   }
   let ix = get_high_word(x).reinterpret_as_int() & 0x7fffffff
+  let abs_x = x.abs()
   if ix < 0x3fd62e43 {
-    let t = expm1(x.abs())
+    let t = expm1(abs_x)
     let w = 1.0 + t
     if ix < 0x3c800000 {
       return w
@@ -135,11 +136,11 @@ pub fn cosh(x : Double) -> Double {
     return 1.0 + t * t / (w + w)
   }
   if ix < 0x40360000 {
-    let t = exp(x.abs())
+    let t = exp(abs_x)
     return 0.5 * t + 0.5 / t
   }
   if ix < 0x40862E42 {
-    return 0.5 * exp(x.abs())
+    return 0.5 * exp(abs_x)
   }
   // |x| in [log(maxdouble), overflow threshold]: compute via the scaled form
   // 0.5 * exp(0.5*|x|) * exp(0.5*|x|) to avoid overflow in the intermediate exp.
@@ -147,8 +148,8 @@ pub fn cosh(x : Double) -> Double {
   // 64-bit integer (mirroring `sinh`); a split high/low-word comparison with a
   // signed low word misclassifies low words in [0, 0x7fffffff] and wrongly
   // overflows to infinity for finite values just below the threshold.
-  if x.abs().reinterpret_as_uint64() <= 0x408633ce8fb9f87d {
-    let w = exp(0.5 * x.abs())
+  if abs_x.reinterpret_as_uint64() <= 0x408633ce8fb9f87d {
+    let w = exp(0.5 * abs_x)
     let t = 0.5 * w
     return t * w
   }

--- a/math/hyperbolic_test.mbt
+++ b/math/hyperbolic_test.mbt
@@ -178,3 +178,20 @@ test "cosh large-arg coverage" {
   assert_true(!cosh_near_overflow.is_inf())
   assert_true(!cosh_near_overflow.is_nan())
 }
+
+///|
+test "cosh near-overflow low-word boundary" {
+  // 710.4757080078125 has bit pattern 0x408633ce40000000: it shares the high-word
+  // bucket 0x408633ce with the overflow threshold, and its low word 0x40000000 is
+  // below the threshold low word 0x8fb9f87d as an unsigned value. The old code
+  // compared low words as signed Int, where the threshold 0x8fb9f87d is negative
+  // (-1883637635), so a positive low word such as 0x40000000 failed
+  // `lx <= 0x8fb9f87d` and wrongly fell through to Infinity, even though cosh here
+  // is finite (~1.7974e308, just below DBL_MAX). Guard both signs.
+  let x = 710.4757080078125
+  assert_true(!@math.cosh(x).is_inf())
+  assert_true(!@math.cosh(x).is_nan())
+  assert_true(@math.cosh(x) > 1.79e308)
+  assert_true(!@math.cosh(-x).is_inf())
+  assert_true(@math.cosh(-x) > 1.79e308)
+}

--- a/math/hyperbolic_test.mbt
+++ b/math/hyperbolic_test.mbt
@@ -181,17 +181,18 @@ test "cosh large-arg coverage" {
 
 ///|
 test "cosh near-overflow low-word boundary" {
-  // 710.4757080078125 has bit pattern 0x408633ce40000000: it shares the high-word
-  // bucket 0x408633ce with the overflow threshold, and its low word 0x40000000 is
-  // below the threshold low word 0x8fb9f87d as an unsigned value. The old code
-  // compared low words as signed Int, where the threshold 0x8fb9f87d is negative
-  // (-1883637635), so a positive low word such as 0x40000000 failed
-  // `lx <= 0x8fb9f87d` and wrongly fell through to Infinity, even though cosh here
-  // is finite (~1.7974e308, just below DBL_MAX). Guard both signs.
-  let x = 710.4757080078125
-  assert_true(!@math.cosh(x).is_inf())
-  assert_true(!@math.cosh(x).is_nan())
-  assert_true(@math.cosh(x) > 1.79e308)
-  assert_true(!@math.cosh(-x).is_inf())
-  assert_true(@math.cosh(-x) > 1.79e308)
+  // Build the value from its exact bit pattern 0x408633ce40000000
+  // (~710.4757080078125) so the test does not depend on decimal-literal rounding.
+  // It shares the high-word bucket 0x408633ce with the overflow threshold, and its
+  // low word 0x40000000 is below the threshold low word 0x8fb9f87d as an unsigned
+  // value. The old code compared low words as signed Int, where the threshold
+  // 0x8fb9f87d is negative (-1883637635), so a positive low word such as
+  // 0x40000000 failed `lx <= 0x8fb9f87d` and wrongly fell through to Infinity, even
+  // though cosh here is finite (~1.7974e308, just below DBL_MAX). Guard both signs.
+  let x = 0x408633ce40000000L.reinterpret_as_double()
+  assert_eq(x.reinterpret_as_uint64(), 0x408633ce40000000)
+  let pos = @math.cosh(x)
+  let neg = @math.cosh(-x)
+  assert_true(!pos.is_inf() && !pos.is_nan() && pos > 1.79e308)
+  assert_true(!neg.is_inf() && !neg.is_nan() && neg > 1.79e308)
 }


### PR DESCRIPTION
## Summary

Follow-up to #3690. While reviewing that fix, an independent review (codex CLI) and I found a second, pre-existing bug in the same `cosh(x : Double)` function (non-JS backend), in the near-overflow boundary branch.

The branch that handles `|x|` between `log(maxdouble)` and the overflow threshold compared the **low word** of `|x|` as a **signed** `Int`:

```moonbit
let lx = get_low_word(x).reinterpret_as_int()
if ix < 0x408633ce || (ix == 0x408633ce && lx <= 0x8fb9f87d) { ... }
```

The threshold low word `0x8fb9f87d` is **negative** when interpreted as a signed `Int` (`-1883637635`). So for any `x` whose high word is exactly `0x408633ce` and whose low word is in `[0x00000000, 0x7fffffff]` (positive when signed), the test `lx <= 0x8fb9f87d` is false and the code falls through to `Infinity` — even though those values are below the true overflow threshold and have a **finite** `cosh`.

For example, `cosh(710.4757080078125)` (bit pattern `0x408633ce40000000`) returned `Infinity` instead of the correct `~1.7974e308`.

## Fix

Replace the split high/low-word comparison with a single **unsigned 64-bit** comparison of `|x|` against the threshold, mirroring the analogous `sinh` branch in the same file:

```moonbit
if x.abs().reinterpret_as_uint64() <= 0x408633ce8fb9f87d { ... }
```

`ix` already has its sign bit cleared, so `x.abs().reinterpret_as_uint64()` reproduces the intended `(ix << 32) | low_word` magnitude pattern; the inclusive `<=` matches the fdlibm/FreeBSD `e_cosh.c` reference. A regression test exercising the affected high-word bucket (for both signs) is added.

The JS backend (`Math.cosh` delegation) and the `float` variant are unaffected.

## Validation

- [x] `moon fmt`
- [x] `moon check math --deny-warn`
- [x] `moon test math --target all` (139/139 passed on wasm, wasm-gc, js, native)
- [x] `moon info` (no `.mbti` signature change)
- [x] Independently reviewed with codex CLI (no functional issues; one comment-wording nit addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)