### PR TITLE
fix(math): make sinh overflow-threshold boundary inclusive

### DIFF
--- a/math/hyperbolic_double_nonjs.mbt
+++ b/math/hyperbolic_double_nonjs.mbt
@@ -81,7 +81,11 @@ pub fn sinh(x : Double) -> Double {
   if ix < 0x40862E42 {
     return h * exp(abs_x)
   }
-  if abs_x.reinterpret_as_uint64() < 0x408633ce8fb9f87d {
+  // |x| in [log(maxdouble), overflow threshold]: the boundary is inclusive, so
+  // the exact threshold value 0x408633ce8fb9f87d (~710.4758600739439) still has a
+  // finite sinh and must take the scaled branch. Matches the fdlibm `e_sinh.c`
+  // reference and the analogous `cosh` branch.
+  if abs_x.reinterpret_as_uint64() <= 0x408633ce8fb9f87d {
     let w = exp(0.5 * abs_x)
     let t = h * w
     return t * w

--- a/math/hyperbolic_test.mbt
+++ b/math/hyperbolic_test.mbt
@@ -196,3 +196,20 @@ test "cosh near-overflow low-word boundary" {
   assert_true(!pos.is_inf() && !pos.is_nan() && pos > 1.79e308)
   assert_true(!neg.is_inf() && !neg.is_nan() && neg > 1.79e308)
 }
+
+///|
+test "sinh overflow-threshold boundary" {
+  // 0x1.633ce8fb9f87dp9 (bit pattern 0x408633ce8fb9f87d) is exactly the overflow
+  // threshold ~710.4758600739439, written as a Double hex-float literal so the test
+  // does not depend on decimal rounding. The boundary is inclusive: sinh is still
+  // finite here (~1.7977e308, just below DBL_MAX); a strict `<` comparison wrongly
+  // overflowed to +/-Infinity at this exact value. Guard both signs, plus a larger
+  // value that must still overflow.
+  let threshold : Double = 0x1.633ce8fb9f87dp9
+  assert_eq(threshold.reinterpret_as_uint64(), 0x408633ce8fb9f87d)
+  let pos = @math.sinh(threshold)
+  let neg = @math.sinh(-threshold)
+  assert_true(!pos.is_inf() && !pos.is_nan() && pos > 1.79e308)
+  assert_true(!neg.is_inf() && !neg.is_nan() && neg < -1.79e308)
+  assert_true(@math.sinh(711.0).is_inf())
+}


### PR DESCRIPTION
## Summary

Follow-up to #3690 / #3691. While fixing the `cosh` near-overflow boundary, codex CLI and I noticed the analogous `sinh` branch in the same file (`math/hyperbolic_double_nonjs.mbt`, non-JS backend) had a related off-by-one boundary bug.

The `sinh` near-overflow branch used a **strict** `<` against the overflow threshold `0x408633ce8fb9f87d` (`|x| ≈ 710.4758600739439):

```moonbit
if abs_x.reinterpret_as_uint64() < 0x408633ce8fb9f87d { ... scaled exp ... }
x * shuge   // overflow
```

The fdlibm `e_sinh.c` reference treats this boundary as **inclusive** (`lx <= 0x8fb9f87d`). At exactly the threshold value, `sinh` is still finite (`~1.7977e308`, just below `DBL_MAX`), so it must take the scaled-exp branch rather than fall through to `x * shuge` and overflow.

As a result, `sinh(710.4758600739439)` returned `±Infinity`, even though `cosh` at the same point correctly returns the finite `1.7976931348621744e+308`.

## Fix

Change `<` to `<=`, matching the reference and the analogous (now-consistent) `cosh` branch:

```moonbit
if abs_x.reinterpret_as_uint64() <= 0x408633ce8fb9f87d { ... }
```

A regression test exercises the exact threshold (both signs) plus a larger value that must still overflow. The scaled computation has finite intermediates at the threshold (`w ≈ 1.896e154`), and the next representable value above the threshold (`0x408633ce8fb9f87e`) correctly overflows. The JS backend (`Math.sinh` delegation) and the `float` variant are unaffected.

## Validation

- [x] `moon fmt`
- [x] `moon check math --deny-warn`
- [x] `moon test math --target all` (139/139 passed on wasm, wasm-gc, js, native)
- [x] `moon info` (no `.mbti` signature change)
- [x] Independently reviewed with codex CLI: *"None. The `<=` change is correct."* — verified the threshold bit pattern, finite value, reference, and cross-target behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)