### PR TITLE
feat: add Logger::write_string_interpolation

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -1319,6 +1319,7 @@ pub(open) trait Logger {
   fn write_substring(Self, String, Int, Int) -> Unit = _
   fn write_view(Self, StringView) -> Unit = _
   fn write_char(Self, Char) -> Unit = _
+  fn write_string_interpolation(Self, &Show) -> Unit = _
   fn write(Self, &Show) -> Unit = _
 }
 pub fn[T : Show] &Logger::write_iter(Self, Iter[T], prefix? : String, suffix? : String, sep? : String, trailing? : Bool) -> Unit

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -103,7 +103,13 @@ pub(open) trait Logger {
   fn write_view(Self, StringView) -> Unit = _
   /// Writes a character to the logger.
   fn write_char(Self, Char) -> Unit = _
+  fn[T : Show] write_string_interpolation(Self, T) -> Unit = _
   fn write(Self, &Show) -> Unit = _
+}
+
+///|
+impl Logger with fn write_string_interpolation(self, show) {
+  show.output(self)
 }
 
 ///|

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -103,7 +103,7 @@ pub(open) trait Logger {
   fn write_view(Self, StringView) -> Unit = _
   /// Writes a character to the logger.
   fn write_char(Self, Char) -> Unit = _
-  fn[T : Show] write_string_interpolation(Self, T) -> Unit = _
+  fn write_string_interpolation(Self, &Show) -> Unit = _
   fn write(Self, &Show) -> Unit = _
 }
 


### PR DESCRIPTION
The expression `logger <+ "{x}"` will be lowered to `logger.write_string_interpolation(x)`.

This requires the `Logger::write_string_interpolation` API.

related #3683

@myfreess @bobzhang 