### PR TITLE
fix(immut/sorted_set): fix all compiler warnings

### DIFF
--- a/immut/sorted_set/README.mbt.md
+++ b/immut/sorted_set/README.mbt.md
@@ -15,8 +15,8 @@ You can create an empty ImmutableSet with a value separately through the followi
 test {
   let _set1 : @sorted_set.SortedSet[Int] = @sorted_set.new()
   let _set2 = @sorted_set.singleton(1)
-  let _set4 = @sorted_set.from_array([1])
-  let _set5 = @sorted_set.from_array([1])
+  let _set4 = @sorted_set.SortedSet([1])
+  let _set5 = @sorted_set.SortedSet([1])
 }
 ```
 
@@ -27,7 +27,7 @@ You can convert an immutable set to an array, which will be sorted.
 ```mbt check
 ///|
 test {
-  let set = @sorted_set.from_array([3, 2, 1])
+  let set = @sorted_set.SortedSet([3, 2, 1])
   @test.assert_eq(set.to_array(), [1, 2, 3])
 }
 ```
@@ -39,7 +39,7 @@ You can use `add` to add an element to the ImmutableSet.
 ```mbt check
 ///|
 test {
-  let set = @sorted_set.from_array([1, 2, 3, 4])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4])
   @test.assert_eq(set.add(5).to_array(), [1, 2, 3, 4, 5])
 }
 ```
@@ -49,7 +49,7 @@ You can use `remove` to remove a specific value.
 ```mbt check
 ///|
 test {
-  let set = @sorted_set.from_array([3, 8, 1])
+  let set = @sorted_set.SortedSet([3, 8, 1])
   @test.assert_eq(set.remove(8).to_array(), [1, 3])
 }
 ```
@@ -61,7 +61,7 @@ You can use `contains` to query whether an element is in the set.
 ```mbt check
 ///|
 test {
-  let set = @sorted_set.from_array([1, 2, 3, 4])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4])
   @test.assert_eq(set.contains(1), true)
   @test.assert_eq(set.contains(5), false)
 }
@@ -72,7 +72,7 @@ You can also use `min` and `max` to obtain the minimum or maximum value in the s
 ```mbt check
 ///|
 test {
-  let set = @sorted_set.from_array([1, 2, 3, 4])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4])
   @test.assert_eq(set.min(), 1)
   @test.assert_eq(set.max(), 4)
   @test.assert_eq(set.min_option(), Some(1))
@@ -87,9 +87,9 @@ You can provide an intermediate value to divide a set into two sets by `split`, 
 ```mbt check
 ///|
 test {
-  let (left, present, right) = @sorted_set.from_array([
-    7, 2, 9, 4, 5, 6, 3, 8, 1,
-  ]).split(5)
+  let (left, present, right) = @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).split(
+    5,
+  )
   @test.assert_eq(present, true)
   @test.assert_eq(left.to_array(), [1, 2, 3, 4])
   @test.assert_eq(right.to_array(), [6, 7, 8, 9])
@@ -101,8 +101,8 @@ At the same time, you can use union and inter to take the union or intersection 
 ```mbt check
 ///|
 test {
-  let set1 = @sorted_set.from_array([3, 4, 5])
-  let set2 = @sorted_set.from_array([4, 5, 6])
+  let set1 = @sorted_set.SortedSet([3, 4, 5])
+  let set2 = @sorted_set.SortedSet([4, 5, 6])
   @test.assert_eq(set1.union(set2).to_array(), [3, 4, 5, 6])
   @test.assert_eq(set1.intersection(set2).to_array(), [4, 5])
 }
@@ -113,8 +113,8 @@ You can also use the `diff` function to obtain the difference between two sets.
 ```mbt check
 ///|
 test {
-  let set1 = @sorted_set.from_array([1, 2, 3])
-  let set2 = @sorted_set.from_array([4, 5, 1])
+  let set1 = @sorted_set.SortedSet([1, 2, 3])
+  let set2 = @sorted_set.SortedSet([4, 5, 1])
   @test.assert_eq(set1.difference(set2).to_array(), [2, 3])
 }
 ```
@@ -124,7 +124,7 @@ You can use `filter` to filter the elements in the set.
 ```mbt check
 ///|
 test {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5, 6])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5, 6])
   @test.assert_eq(set.filter(v => v % 2 == 0).to_array(), [2, 4, 6])
 }
 ```
@@ -137,15 +137,13 @@ You can use `subsets` and `disjoint` to determine the inclusion and separation r
 ///|
 test {
   @test.assert_eq(
-    @sorted_set.from_array([1, 2, 3]).subset(
-      @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    @sorted_set.SortedSet([1, 2, 3]).subset(
+      SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]),
     ),
     true,
   )
   @test.assert_eq(
-    @sorted_set.from_array([1, 2, 3]).disjoint(
-      @sorted_set.from_array([4, 5, 6]),
-    ),
+    @sorted_set.SortedSet([1, 2, 3]).disjoint(SortedSet([4, 5, 6])),
     true,
   )
 }
@@ -159,13 +157,13 @@ Like other sequential containers, set also has iterative methods such as `iter`,
 ///|
 test {
   let arr = []
-  @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(v => arr.push(v))
+  @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(v => arr.push(v))
   @test.assert_eq(arr, [1, 2, 3, 4, 5, 6, 7, 8, 9])
-  let val = @sorted_set.from_array([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => {
+  let val = @sorted_set.SortedSet([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => {
     acc + x
   })
   @test.assert_eq(val, 15)
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   @test.assert_eq(set.map(x => x * 2).to_array(), [2, 4, 6])
 }
 ```
@@ -175,7 +173,7 @@ You can also use `rev_iter()` to iterate in descending order.
 ```mbt check
 ///|
 test {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let arr = []
   set.rev_iter().each(v => arr.push(v))
   @test.assert_eq(arr, [5, 4, 3, 2, 1])
@@ -189,8 +187,8 @@ test {
 ```mbt check
 ///|
 test {
-  @test.assert_eq(@sorted_set.from_array([2, 4, 6]).all(v => v % 2 == 0), true)
-  @test.assert_eq(@sorted_set.from_array([1, 4, 3]).any(v => v % 2 == 0), true)
+  @test.assert_eq(@sorted_set.SortedSet([2, 4, 6]).all(v => v % 2 == 0), true)
+  @test.assert_eq(@sorted_set.SortedSet([1, 4, 3]).any(v => v % 2 == 0), true)
 }
 ```
 
@@ -201,9 +199,9 @@ test {
 ```mbt check
 ///|
 test {
-  let set1 : @sorted_set.SortedSet[Int] = @sorted_set.from_array([])
+  let set1 : @sorted_set.SortedSet[Int] = SortedSet([])
   @test.assert_eq(set1.is_empty(), true)
-  let set2 = @sorted_set.from_array([1])
+  let set2 = @sorted_set.SortedSet([1])
   @test.assert_eq(set2.is_empty(), false)
 }
 ```

--- a/immut/sorted_set/debug.mbt
+++ b/immut/sorted_set/debug.mbt
@@ -28,6 +28,6 @@ pub fn[K : @debug.Debug] SortedSet::to_repr(self : SortedSet[K]) -> @debug.Repr 
 
 ///|
 test "Debug for SortedSet" {
-  let ss : SortedSet[Int] = from_array([3, 1, 2])
+  let ss : SortedSet[Int] = SortedSet([3, 1, 2])
   @debug.debug_inspect(ss, content="<SortedSet: [1, 2, 3]>")
 }

--- a/immut/sorted_set/generic.mbt
+++ b/immut/sorted_set/generic.mbt
@@ -22,7 +22,7 @@
 /// # Example
 ///
 /// ```mbt nocheck
-///   let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+///   let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
 ///   let result = set.rev_iter().collect()
 ///   @test.assert_eq(result, [5, 4, 3, 2, 1])
 /// ```
@@ -95,7 +95,7 @@ pub fn[A : Compare] SortedSet::from_iter(iter : Iter[A]) -> SortedSet[A] {
 
 ///|
 test {
-  @json.json_inspect(from_array([2, 7, 1, 2, 3, 4, 5]), content=[
+  @json.json_inspect(SortedSet([2, 7, 1, 2, 3, 4, 5]), content=[
     1, 2, 3, 4, 5, 7,
   ])
 }
@@ -134,22 +134,22 @@ pub impl[A : Compare] Compare for SortedSet[A] with fn compare(self, other) -> I
 
 ///|
 test "Eq - equal sets" {
-  let s1 = from_array([1, 2, 3, 4, 5])
-  let s2 = from_array([5, 4, 3, 2, 1])
+  let s1 = SortedSet([1, 2, 3, 4, 5])
+  let s2 = SortedSet([5, 4, 3, 2, 1])
   inspect(s1 == s2, content="true")
 }
 
 ///|
 test "Eq - different elements same size" {
-  let s1 = from_array([1, 2, 3, 4, 5])
-  let s2 = from_array([1, 2, 3, 4, 6])
+  let s1 = SortedSet([1, 2, 3, 4, 5])
+  let s2 = SortedSet([1, 2, 3, 4, 6])
   inspect(s1 == s2, content="false")
 }
 
 ///|
 test "Eq - different sizes" {
-  let s1 = from_array([1, 2, 3])
-  let s2 = from_array([1, 2, 3, 4, 5])
+  let s1 = SortedSet([1, 2, 3])
+  let s2 = SortedSet([1, 2, 3, 4, 5])
   inspect(s1 == s2, content="false")
 }
 
@@ -163,42 +163,42 @@ test "Eq - empty sets" {
 ///|
 test "Eq - one empty one not" {
   let s1 : SortedSet[Int] = new()
-  let s2 = from_array([1])
+  let s2 = SortedSet([1])
   inspect(s1 == s2, content="false")
 }
 
 ///|
 test "Compare - equal sets" {
-  let s1 = from_array([1, 2, 3])
-  let s2 = from_array([3, 2, 1])
+  let s1 = SortedSet([1, 2, 3])
+  let s2 = SortedSet([3, 2, 1])
   inspect(s1.compare(s2), content="0")
 }
 
 ///|
 test "Compare - first smaller by size" {
-  let s1 = from_array([1, 2])
-  let s2 = from_array([1, 2, 3])
+  let s1 = SortedSet([1, 2])
+  let s2 = SortedSet([1, 2, 3])
   inspect(s1.compare(s2) < 0, content="true")
 }
 
 ///|
 test "Compare - first larger by size" {
-  let s1 = from_array([1, 2, 3, 4])
-  let s2 = from_array([1, 2])
+  let s1 = SortedSet([1, 2, 3, 4])
+  let s2 = SortedSet([1, 2])
   inspect(s1.compare(s2) > 0, content="true")
 }
 
 ///|
 test "Compare - same size first smaller by elements" {
-  let s1 = from_array([1, 2, 3])
-  let s2 = from_array([1, 2, 4])
+  let s1 = SortedSet([1, 2, 3])
+  let s2 = SortedSet([1, 2, 4])
   inspect(s1.compare(s2) < 0, content="true")
 }
 
 ///|
 test "Compare - same size first larger by elements" {
-  let s1 = from_array([1, 2, 5])
-  let s2 = from_array([1, 2, 4])
+  let s1 = SortedSet([1, 2, 5])
+  let s2 = SortedSet([1, 2, 4])
   inspect(s1.compare(s2) > 0, content="true")
 }
 

--- a/immut/sorted_set/generic_test.mbt
+++ b/immut/sorted_set/generic_test.mbt
@@ -14,21 +14,21 @@
 
 ///|
 test "sorted set equality comparison with unequal elements" {
-  let set1 = @sorted_set.from_array([1, 2, 3])
-  let set2 = @sorted_set.from_array([1, 2, 4])
+  let set1 = @sorted_set.SortedSet([1, 2, 3])
+  let set2 = @sorted_set.SortedSet([1, 2, 4])
   assert_false(set1 == set2)
 }
 
 ///|
 test "compare with shared prefix" {
-  let set1 = @sorted_set.from_array([1, 2, 3])
-  let set2 = @sorted_set.from_array([1, 2, 4])
+  let set1 = @sorted_set.SortedSet([1, 2, 3])
+  let set2 = @sorted_set.SortedSet([1, 2, 4])
   assert_true(set1 < set2)
 }
 
 ///|
 test "iter early termination - value" {
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   let count = for x in set; count = 0 {
     if x == 2 {
       break count
@@ -43,7 +43,7 @@ test "iter early termination - value" {
 
 ///|
 test "iter terminates on right" {
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   let result = set.iter().take(2).to_array()
   debug_inspect(result, content="[1, 2]")
 }
@@ -72,7 +72,7 @@ test "iter with early termination on left subtree" {
 
 ///|
 test "rev_iter returns elements in descending order" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let result = set.rev_iter().collect()
   debug_inspect(result, content="[5, 4, 3, 2, 1]")
 }
@@ -93,21 +93,21 @@ test "rev_iter on single element set" {
 
 ///|
 test "rev_iter early termination" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let result = set.rev_iter().take(3).collect()
   debug_inspect(result, content="[5, 4, 3]")
 }
 
 ///|
 test "rev_iter on unbalanced insertion" {
-  let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
+  let set = @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1])
   let result = set.rev_iter().collect()
   debug_inspect(result, content="[9, 8, 7, 6, 5, 4, 3, 2, 1]")
 }
 
 ///|
 test "rev_iter is reverse of iter" {
-  let set = @sorted_set.from_array([3, 1, 4, 1, 5, 9, 2, 6])
+  let set = @sorted_set.SortedSet([3, 1, 4, 1, 5, 9, 2, 6])
   let forward = set.iter().collect()
   let reverse = set.rev_iter().collect()
   @test.assert_eq(reverse, forward.rev())
@@ -138,7 +138,7 @@ test "rev_iter with early termination on right subtree" {
 
 ///|
 test "rev_iter with complex tree structure" {
-  let set = @sorted_set.from_array([
+  let set = @sorted_set.SortedSet([
     15, 10, 20, 5, 12, 18, 25, 3, 7, 11, 14, 17, 19, 23, 27,
   ])
   let result = set.rev_iter().collect()
@@ -150,7 +150,7 @@ test "rev_iter with complex tree structure" {
 
 ///|
 test "rev_iter terminates on left" {
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   let result = set.rev_iter().take(2).to_array()
   debug_inspect(result, content="[3, 2]")
 }

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -38,11 +38,20 @@ pub fn[A] SortedSet::singleton(value : A) -> SortedSet[A] {
 }
 
 ///|
-/// Initialize an ImmutableSet[T] from an Array[T]
-#as_free_fn
-#alias(of, deprecated="Use from_array instead")
-#as_free_fn(of, deprecated="Use from_array instead")
-pub fn[A : Compare] SortedSet::from_array(array : ArrayView[A]) -> SortedSet[A] {
+/// Creates a sorted set from an array view.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   @test.assert_eq(@sorted_set.SortedSet([3, 1, 2]).to_array(), [1, 2, 3])
+/// }
+/// ```
+#alias(from_array, deprecated="Use SortedSet([...]) instead")
+#as_free_fn(from_array, deprecated="Use SortedSet([...]) instead")
+#alias(of, deprecated="Use SortedSet([...]) instead")
+#as_free_fn(of, deprecated="Use SortedSet([...]) instead")
+pub fn[A : Compare] SortedSet::SortedSet(array : ArrayView[A]) -> SortedSet[A] {
   for i = array.length() - 1, set = Empty; i >= 0; {
     continue i - 1, set.add(array[i])
   } nobreak {
@@ -79,8 +88,8 @@ pub fn[A] SortedSet::to_array(self : SortedSet[A]) -> Array[A] {
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([3, 4, 5]).remove_min(),
-///     @sorted_set.from_array([4, 5]),
+///     @sorted_set.SortedSet([3, 4, 5]).remove_min(),
+///     SortedSet([4, 5]),
 ///   )
 /// }
 /// ```
@@ -104,8 +113,8 @@ pub fn[A] SortedSet::remove_min(self : SortedSet[A]) -> SortedSet[A] {
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([6, 3, 8, 1]).add(5),
-///     @sorted_set.from_array([1, 3, 5, 6, 8]),
+///     @sorted_set.SortedSet([6, 3, 8, 1]).add(5),
+///     SortedSet([1, 3, 5, 6, 8]),
 ///   )
 /// }
 /// ```
@@ -145,10 +154,7 @@ pub fn[A : Compare] SortedSet::add(
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(
-///     @sorted_set.from_array([3, 8, 1]).remove(8),
-///     @sorted_set.from_array([1, 3]),
-///   )
+///   @test.assert_eq(@sorted_set.SortedSet([3, 8, 1]).remove(8), SortedSet([1, 3]))
 /// }
 /// ```
 pub fn[A : Compare] SortedSet::remove(
@@ -188,7 +194,7 @@ pub fn[A : Compare] SortedSet::remove(
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(@sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).min(), 1)
+///   @test.assert_eq(@sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).min(), 1)
 /// }
 /// ```
 pub fn[A] SortedSet::min(self : SortedSet[A]) -> A {
@@ -230,7 +236,7 @@ pub fn[A] SortedSet::min_option(self : SortedSet[A]) -> A? {
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(@sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).max(), 9)
+///   @test.assert_eq(@sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).max(), 9)
 /// }
 /// ```
 pub fn[A] SortedSet::max(self : SortedSet[A]) -> A {
@@ -273,12 +279,12 @@ pub fn[A] SortedSet::max_option(self : SortedSet[A]) -> A? {
 ///
 /// ```mbt check
 /// test {
-///   let (left, present, right) = @sorted_set.from_array([
-///     7, 2, 9, 4, 5, 6, 3, 8, 1,
-///   ]).split(5)
+///   let (left, present, right) = @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).split(
+///     5,
+///   )
 ///   inspect(present, content="true")
-///   @test.assert_eq(left, @sorted_set.from_array([1, 2, 3, 4]))
-///   @test.assert_eq(right, @sorted_set.from_array([6, 7, 8, 9]))
+///   @test.assert_eq(left, SortedSet([1, 2, 3, 4]))
+///   @test.assert_eq(right, SortedSet([6, 7, 8, 9]))
 /// }
 /// ```
 pub fn[A : Compare] SortedSet::split(
@@ -353,7 +359,7 @@ pub fn[A : Compare] SortedSet::contains(self : SortedSet[A], value : A) -> Bool 
 ///
 /// ```mbt check
 /// test {
-///   let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+///   let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
 ///   let result = []
 ///   for v in set.range(low=2, high=4) {
 ///     result.push(v)
@@ -406,8 +412,8 @@ pub fn[A : Compare] SortedSet::range(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([3, 4, 5]).union(@sorted_set.from_array([4, 5, 6])),
-///     @sorted_set.from_array([3, 4, 5, 6]),
+///     @sorted_set.SortedSet([3, 4, 5]).union(SortedSet([4, 5, 6])),
+///     SortedSet([3, 4, 5, 6]),
 ///   )
 /// }
 /// ```
@@ -445,8 +451,8 @@ pub fn[A : Compare] SortedSet::union(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([3, 4, 5]) + @sorted_set.from_array([4, 5, 6]),
-///     @sorted_set.from_array([3, 4, 5, 6]),
+///     @sorted_set.SortedSet([3, 4, 5]) + SortedSet([4, 5, 6]),
+///     SortedSet([3, 4, 5, 6]),
 ///   )
 /// }
 /// ```
@@ -462,10 +468,8 @@ pub impl[A : Compare] Add for SortedSet[A] with fn add(self, other) {
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([3, 4, 5]).intersection(
-///       @sorted_set.from_array([4, 5, 6]),
-///     ),
-///     @sorted_set.from_array([4, 5]),
+///     @sorted_set.SortedSet([3, 4, 5]).intersection(SortedSet([4, 5, 6])),
+///     SortedSet([4, 5]),
 ///   )
 /// }
 /// ```
@@ -492,10 +496,8 @@ pub fn[A : Compare] SortedSet::intersection(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([1, 2, 3]).difference(
-///       @sorted_set.from_array([4, 5, 1]),
-///     ),
-///     @sorted_set.from_array([2, 3]),
+///     @sorted_set.SortedSet([1, 2, 3]).difference(SortedSet([4, 5, 1])),
+///     SortedSet([2, 3]),
 ///   )
 /// }
 /// ```
@@ -531,8 +533,8 @@ pub fn[A : Compare] SortedSet::difference(
 ///
 /// ```mbt check
 /// test {
-///   let set1 = @sorted_set.from_array([1, 2, 3, 4])
-///   let set2 = @sorted_set.from_array([3, 4, 5, 6])
+///   let set1 = @sorted_set.SortedSet([1, 2, 3, 4])
+///   let set2 = @sorted_set.SortedSet([3, 4, 5, 6])
 ///   @debug.debug_inspect(
 ///     set1.symmetric_difference(set2),
 ///     content=(
@@ -566,8 +568,8 @@ pub fn[A : Compare] SortedSet::symmetric_difference(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([1, 2, 3]).subset(
-///       @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]),
+///     @sorted_set.SortedSet([1, 2, 3]).subset(
+///       SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]),
 ///     ),
 ///     true,
 ///   )
@@ -606,9 +608,7 @@ pub fn[A : Compare] SortedSet::subset(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([1, 2, 3]).disjoint(
-///       @sorted_set.from_array([4, 5, 6]),
-///     ),
+///     @sorted_set.SortedSet([1, 2, 3]).disjoint(SortedSet([4, 5, 6])),
 ///     true,
 ///   )
 /// }
@@ -639,7 +639,7 @@ pub fn[A : Compare] SortedSet::disjoint(
 /// ```mbt check
 /// test {
 ///   let arr = []
-///   @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(x => arr.push(x))
+///   @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(x => arr.push(x))
 ///   @test.assert_eq(arr, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 /// }
 /// ```
@@ -665,7 +665,7 @@ pub fn[A] SortedSet::each(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => acc + x),
+///     @sorted_set.SortedSet([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => acc + x),
 ///     15,
 ///   )
 /// }
@@ -690,8 +690,8 @@ pub fn[A, B] SortedSet::fold(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([1, 2, 3]).map(x => x * 2),
-///     @sorted_set.from_array([2, 4, 6]),
+///     @sorted_set.SortedSet([1, 2, 3]).map(x => x * 2),
+///     SortedSet([2, 4, 6]),
 ///   )
 /// }
 /// ```
@@ -713,7 +713,7 @@ pub fn[A, B : Compare] SortedSet::map(
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(@sorted_set.from_array([2, 4, 6]).all(v => v % 2 == 0), true)
+///   @test.assert_eq(@sorted_set.SortedSet([2, 4, 6]).all(v => v % 2 == 0), true)
 /// }
 /// ```
 pub fn[A] SortedSet::all(
@@ -733,7 +733,7 @@ pub fn[A] SortedSet::all(
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(@sorted_set.from_array([1, 4, 3]).any(v => v % 2 == 0), true)
+///   @test.assert_eq(@sorted_set.SortedSet([1, 4, 3]).any(v => v % 2 == 0), true)
 /// }
 /// ```
 pub fn[A] SortedSet::any(
@@ -754,8 +754,8 @@ pub fn[A] SortedSet::any(
 /// ```mbt check
 /// test {
 ///   @test.assert_eq(
-///     @sorted_set.from_array([1, 2, 3, 4, 5, 6]).filter(v => v % 2 == 0),
-///     @sorted_set.from_array([2, 4, 6]),
+///     @sorted_set.SortedSet([1, 2, 3, 4, 5, 6]).filter(v => v % 2 == 0),
+///     SortedSet([2, 4, 6]),
 ///   )
 /// }
 /// ```
@@ -790,7 +790,7 @@ pub impl[A : Show] Show for SortedSet[A]
 pub impl[A : Show] Show for SortedSet[A] with fn output(self, logger) {
   logger.write_iter(
     self.iter(),
-    prefix="@immut/sorted_set.from_array([",
+    prefix="@immut/sorted_set.SortedSet([",
     suffix="])",
   )
 }
@@ -836,7 +836,7 @@ pub fn[A : @json.FromJson + Compare] SortedSet::from_json(
 pub impl[X : @quickcheck.Arbitrary + Compare] @quickcheck.Arbitrary for SortedSet[
   X,
 ] with fn arbitrary(size, rs) {
-  @quickcheck.Arbitrary::arbitrary(size, rs) |> from_array
+  @quickcheck.Arbitrary::arbitrary(size, rs) |> SortedSet
 }
 
 // The following are the helper functions or types used by the internal implementation of ImmutableSet
@@ -1047,17 +1047,17 @@ pub impl[A : Hash] Hash for SortedSet[A] with fn hash_combine(self, hasher) {
 
 ///|
 test "split_bis" {
-  inspect(from_array([1, 2, 3]).split_bis(1), content="Found")
-  inspect(from_array([1, 2, 3]).split_bis(3), content="Found")
-  inspect(from_array([1, 2, 3]).split_bis(0), content="NotFound")
-  inspect(from_array([1, 2, 3]).split_bis(4), content="NotFound")
+  inspect(SortedSet([1, 2, 3]).split_bis(1), content="Found")
+  inspect(SortedSet([1, 2, 3]).split_bis(3), content="Found")
+  inspect(SortedSet([1, 2, 3]).split_bis(0), content="NotFound")
+  inspect(SortedSet([1, 2, 3]).split_bis(4), content="NotFound")
 }
 
 ///|
 test "balance with left height greater" {
-  let left = from_array([1, 2, 3])
+  let left = SortedSet([1, 2, 3])
   let value = 4
-  let right = from_array([5])
+  let right = SortedSet([5])
   let balanced_set = balance(left, value, right)
   @debug.debug_inspect(
     balanced_set,
@@ -1069,9 +1069,9 @@ test "balance with left height greater" {
 
 ///|
 test "balance with right height greater" {
-  let left = from_array([1])
+  let left = SortedSet([1])
   let value = 2
-  let right = from_array([3, 4, 5])
+  let right = SortedSet([3, 4, 5])
   let balanced_set = balance(left, value, right)
   @debug.debug_inspect(
     balanced_set,
@@ -1083,9 +1083,9 @@ test "balance with right height greater" {
 
 ///|
 test "join with different heights" {
-  let left = from_array([1, 2, 3])
+  let left = SortedSet([1, 2, 3])
   let value = 4
-  let right = from_array([5, 6, 7])
+  let right = SortedSet([5, 6, 7])
   let joined_set = join(left, value, right)
   @debug.debug_inspect(
     joined_set,
@@ -1098,11 +1098,11 @@ test "join with different heights" {
 ///|
 test "hash" {
   @test.assert_eq(
-    Hash::hash(from_array([1, 2, 3, 4])),
-    Hash::hash(from_array([3, 2]).add(1).add(4)),
+    Hash::hash(SortedSet([1, 2, 3, 4])),
+    Hash::hash(SortedSet([3, 2]).add(1).add(4)),
   )
   @test.assert_not_eq(
-    Hash::hash(from_array([1, 2, 3])),
-    Hash::hash(from_array([1, 2, 4])),
+    Hash::hash(SortedSet([1, 2, 3])),
+    Hash::hash(SortedSet([1, 2, 4])),
   )
 }

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -41,104 +41,84 @@ test "default" {
 ///|
 test "disjoint" {
   inspect(
-    @sorted_set.from_array([1]).disjoint(@sorted_set.from_array([1, 2, 3])),
+    @sorted_set.SortedSet([1]).disjoint(SortedSet([1, 2, 3])),
     content="false",
   )
   inspect(
-    @sorted_set.from_array([1, 2, 3]).disjoint(
-      @sorted_set.from_array([1, 2, 3]),
-    ),
+    @sorted_set.SortedSet([1, 2, 3]).disjoint(SortedSet([1, 2, 3])),
     content="false",
   )
   inspect(
-    @sorted_set.from_array([1, 2, 3]).disjoint(
-      @sorted_set.from_array([4, 5, 6]),
-    ),
+    @sorted_set.SortedSet([1, 2, 3]).disjoint(SortedSet([4, 5, 6])),
     content="true",
   )
   inspect(
-    @sorted_set.from_array([1, 2, 3]).subset(@sorted_set.from_array([3, 4, 5])),
+    @sorted_set.SortedSet([1, 2, 3]).subset(SortedSet([3, 4, 5])),
     content="false",
   )
 }
 
 ///|
 test "disjoint same instance" {
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   inspect(set.disjoint(set), content="false")
 }
 
 ///|
 test "subset" {
   inspect(
-    @sorted_set.from_array([1, 2, 3]).subset(
-      @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    @sorted_set.SortedSet([1, 2, 3]).subset(
+      SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]),
     ),
     content="true",
   )
   inspect(
-    @sorted_set.from_array([1, 2, 3]).subset(
-      @sorted_set.from_array([10, 11, 12, 13, 14]),
-    ),
+    @sorted_set.SortedSet([1, 2, 3]).subset(SortedSet([10, 11, 12, 13, 14])),
     content="false",
   )
   // element not in other but previously missed by buggy self-reference
   inspect(
-    @sorted_set.from_array([1, 2, 5]).subset(
-      @sorted_set.from_array([1, 2, 3, 4]),
-    ),
+    @sorted_set.SortedSet([1, 2, 5]).subset(SortedSet([1, 2, 3, 4])),
     content="false",
   )
   inspect(
-    @sorted_set.from_array([0, 3, 4]).subset(
-      @sorted_set.from_array([1, 2, 3, 4]),
-    ),
+    @sorted_set.SortedSet([0, 3, 4]).subset(SortedSet([1, 2, 3, 4])),
     content="false",
   )
   // exact match
   inspect(
-    @sorted_set.from_array([1, 2, 3]).subset(@sorted_set.from_array([1, 2, 3])),
+    @sorted_set.SortedSet([1, 2, 3]).subset(SortedSet([1, 2, 3])),
     content="true",
   )
   // empty is subset of anything
-  inspect(
-    @sorted_set.new().subset(@sorted_set.from_array([1, 2, 3])),
-    content="true",
-  )
+  inspect(@sorted_set.new().subset(SortedSet([1, 2, 3])), content="true")
   // nothing is subset of empty (except empty)
-  inspect(
-    @sorted_set.from_array([1]).subset(@sorted_set.new()),
-    content="false",
-  )
+  inspect(@sorted_set.SortedSet([1]).subset(@sorted_set.new()), content="false")
 }
 
 ///|
 test "diff" {
   let empty = @sorted_set.new()
   debug_inspect(
-    empty.difference(@sorted_set.from_array([1, 2, 3])),
+    empty.difference(SortedSet([1, 2, 3])),
     content=(
       #|<SortedSet: []>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3]).difference(empty),
+    @sorted_set.SortedSet([1, 2, 3]).difference(empty),
     content=(
       #|<SortedSet: [1, 2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3]).difference(
-      @sorted_set.from_array([4, 5, 1]),
-    ),
+    @sorted_set.SortedSet([1, 2, 3]).difference(SortedSet([4, 5, 1])),
     content=(
       #|<SortedSet: [2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3]).difference(
-      @sorted_set.from_array([1, 2, 3]),
-    ),
+    @sorted_set.SortedSet([1, 2, 3]).difference(SortedSet([1, 2, 3])),
     content=(
       #|<SortedSet: []>
     ),
@@ -148,15 +128,13 @@ test "diff" {
 ///|
 test "inter" {
   debug_inspect(
-    @sorted_set.from_array([3, 4, 5]).intersection(
-      @sorted_set.from_array([4, 5, 6]),
-    ),
+    @sorted_set.SortedSet([3, 4, 5]).intersection(SortedSet([4, 5, 6])),
     content=(
       #|<SortedSet: [4, 5]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([3, 4]).intersection(@sorted_set.from_array([5, 6])),
+    @sorted_set.SortedSet([3, 4]).intersection(SortedSet([5, 6])),
     content=(
       #|<SortedSet: []>
     ),
@@ -167,37 +145,37 @@ test "inter" {
 test "union" {
   let empty = @sorted_set.new()
   debug_inspect(
-    empty.union(@sorted_set.from_array([4, 5, 6])),
+    empty.union(SortedSet([4, 5, 6])),
     content=(
       #|<SortedSet: [4, 5, 6]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([4, 5, 6]).union(empty),
+    @sorted_set.SortedSet([4, 5, 6]).union(empty),
     content=(
       #|<SortedSet: [4, 5, 6]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([3]).union(@sorted_set.from_array([4, 5, 6])),
+    @sorted_set.SortedSet([3]).union(SortedSet([4, 5, 6])),
     content=(
       #|<SortedSet: [3, 4, 5, 6]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([3, 4, 5]).union(@sorted_set.from_array([6])),
+    @sorted_set.SortedSet([3, 4, 5]).union(SortedSet([6])),
     content=(
       #|<SortedSet: [3, 4, 5, 6]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([3, 4, 5]).union(@sorted_set.from_array([4, 5, 6])),
+    @sorted_set.SortedSet([3, 4, 5]).union(SortedSet([4, 5, 6])),
     content=(
       #|<SortedSet: [3, 4, 5, 6]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([3, 4, 5]) + @sorted_set.from_array([4, 5, 6]),
+    @sorted_set.SortedSet([3, 4, 5]) + SortedSet([4, 5, 6]),
     content=(
       #|<SortedSet: [3, 4, 5, 6]>
     ),
@@ -206,8 +184,8 @@ test "union" {
 
 ///|
 test "union smaller left non-singleton" {
-  let left = @sorted_set.from_array([1, 3])
-  let right = @sorted_set.from_array([0, 2, 4, 5])
+  let left = @sorted_set.SortedSet([1, 3])
+  let right = @sorted_set.SortedSet([0, 2, 4, 5])
   debug_inspect(
     left.union(right),
     content=(
@@ -221,7 +199,7 @@ test "union smaller left non-singleton" {
 ///|
 test "map" {
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3, 4, 5]).map(x => x * 2),
+    @sorted_set.SortedSet([1, 2, 3, 4, 5]).map(x => x * 2),
     content=(
       #|<SortedSet: [2, 4, 6, 8, 10]>
     ),
@@ -230,7 +208,7 @@ test "map" {
 
 ///|
 test "map non-monotonic" {
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   debug_inspect(
     set.map(x => 4 - x),
     content=(
@@ -241,24 +219,18 @@ test "map non-monotonic" {
 
 ///|
 test "all" {
+  inspect(@sorted_set.SortedSet([2, 4, 6]).all(v => v % 2 == 0), content="true")
   inspect(
-    @sorted_set.from_array([2, 4, 6]).all(v => v % 2 == 0),
-    content="true",
-  )
-  inspect(
-    @sorted_set.from_array([1, 3, 5]).all(v => v % 2 == 0),
+    @sorted_set.SortedSet([1, 3, 5]).all(v => v % 2 == 0),
     content="false",
   )
 }
 
 ///|
 test "any" {
+  inspect(@sorted_set.SortedSet([1, 4, 3]).any(v => v % 2 == 0), content="true")
   inspect(
-    @sorted_set.from_array([1, 4, 3]).any(v => v % 2 == 0),
-    content="true",
-  )
-  inspect(
-    @sorted_set.from_array([1, 5, 3]).any(v => v % 2 == 0),
+    @sorted_set.SortedSet([1, 5, 3]).any(v => v % 2 == 0),
     content="false",
   )
 }
@@ -266,7 +238,7 @@ test "any" {
 ///|
 test "fold" {
   inspect(
-    @sorted_set.from_array([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => acc + x),
+    @sorted_set.SortedSet([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => acc + x),
     content="15",
   )
 }
@@ -274,7 +246,7 @@ test "fold" {
 ///|
 test "filter" {
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3, 4, 5, 6]).filter(v => v % 2 == 0),
+    @sorted_set.SortedSet([1, 2, 3, 4, 5, 6]).filter(v => v % 2 == 0),
     content=(
       #|<SortedSet: [2, 4, 6]>
     ),
@@ -283,9 +255,9 @@ test "filter" {
 
 ///|
 test "split" {
-  let (left, present, right) = @sorted_set.from_array([
-    7, 2, 9, 4, 5, 6, 3, 8, 1,
-  ]).split(5)
+  let (left, present, right) = @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).split(
+    5,
+  )
   inspect(present, content="true")
   debug_inspect(
     left,
@@ -299,9 +271,9 @@ test "split" {
       #|<SortedSet: [6, 7, 8, 9]>
     ),
   )
-  let (left, present, right) = @sorted_set.from_array([
-    7, 2, 9, 4, 5, 6, 3, 8, 1,
-  ]).split(0)
+  let (left, present, right) = @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).split(
+    0,
+  )
   inspect(present, content="false")
   debug_inspect(
     left,
@@ -320,11 +292,11 @@ test "split" {
 ///|
 test "contain" {
   inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 6, 3, 8, 1]).add(5).contains(5),
+    @sorted_set.SortedSet([7, 2, 9, 4, 6, 3, 8, 1]).add(5).contains(5),
     content="true",
   )
   inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 6, 3, 8, 1]).contains(5),
+    @sorted_set.SortedSet([7, 2, 9, 4, 6, 3, 8, 1]).contains(5),
     content="false",
   )
 }
@@ -332,7 +304,7 @@ test "contain" {
 ///|
 test "to_array" {
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).to_array(),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).to_array(),
     content="[1, 2, 3, 4, 5, 6, 7, 8, 9]",
   )
 }
@@ -340,7 +312,7 @@ test "to_array" {
 ///|
 test "from_fixed_array" {
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5, 6, 7, 8, 9]>
     ),
@@ -350,7 +322,7 @@ test "from_fixed_array" {
 ///|
 test "from_array" {
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5, 6, 7, 8, 9]>
     ),
@@ -360,7 +332,7 @@ test "from_array" {
 ///|
 test "remove_min" {
   debug_inspect(
-    @sorted_set.from_array([3, 4, 5]).remove_min(),
+    @sorted_set.SortedSet([3, 4, 5]).remove_min(),
     content=(
       #|<SortedSet: [4, 5]>
     ),
@@ -370,55 +342,55 @@ test "remove_min" {
 ///|
 test "add" {
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 6, 3, 8, 1]).add(5),
+    @sorted_set.SortedSet([7, 2, 9, 4, 6, 3, 8, 1]).add(5),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5, 6, 7, 8, 9]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([2]).add(1),
+    @sorted_set.SortedSet([2]).add(1),
     content=(
       #|<SortedSet: [1, 2]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([2]).add(3),
+    @sorted_set.SortedSet([2]).add(3),
     content=(
       #|<SortedSet: [2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([2]).add(1).add(3),
+    @sorted_set.SortedSet([2]).add(1).add(3),
     content=(
       #|<SortedSet: [1, 2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([1, 2]).add(1),
+    @sorted_set.SortedSet([1, 2]).add(1),
     content=(
       #|<SortedSet: [1, 2]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([2, 3]).add(3),
+    @sorted_set.SortedSet([2, 3]).add(3),
     content=(
       #|<SortedSet: [2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3]).add(1),
+    @sorted_set.SortedSet([1, 2, 3]).add(1),
     content=(
       #|<SortedSet: [1, 2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3]).add(3),
+    @sorted_set.SortedSet([1, 2, 3]).add(3),
     content=(
       #|<SortedSet: [1, 2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([1]).add(2).add(2),
+    @sorted_set.SortedSet([1]).add(2).add(2),
     content=(
       #|<SortedSet: [1, 2]>
     ),
@@ -435,31 +407,31 @@ test "remove" {
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(1),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(1),
     content=(
       #|<SortedSet: [2, 3, 4, 5, 6, 7, 8, 9]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(9),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(9),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5, 6, 7, 8]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(8),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(8),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5, 6, 7, 9]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(0),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(0),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5, 6, 7, 8, 9]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(10),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).remove(10),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5, 6, 7, 8, 9]>
     ),
@@ -486,10 +458,7 @@ test "merge and concat with empty right" {
 
 ///|
 test "min" {
-  inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).min(),
-    content="1",
-  )
+  inspect(@sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).min(), content="1")
 }
 
 ///|
@@ -497,17 +466,14 @@ test "min_option" {
   let empty : @sorted_set.SortedSet[Int] = @sorted_set.new()
   debug_inspect(empty.min_option(), content="None")
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).min_option(),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).min_option(),
     content="Some(1)",
   )
 }
 
 ///|
 test "max" {
-  inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).max(),
-    content="9",
-  )
+  inspect(@sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).max(), content="9")
 }
 
 ///|
@@ -515,7 +481,7 @@ test "max_option" {
   let empty : @sorted_set.SortedSet[Int] = @sorted_set.new()
   debug_inspect(empty.max_option(), content="None")
   debug_inspect(
-    @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).max_option(),
+    @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).max_option(),
     content="Some(9)",
   )
 }
@@ -523,22 +489,22 @@ test "max_option" {
 ///|
 test "is_empty" {
   inspect(
-    (@sorted_set.from_array([]) : @sorted_set.SortedSet[Int]).is_empty(),
+    (SortedSet([]) : @sorted_set.SortedSet[Int]).is_empty(),
     content="true",
   )
-  inspect(@sorted_set.from_array([1]).is_empty(), content="false")
+  inspect(@sorted_set.SortedSet([1]).is_empty(), content="false")
 }
 
 ///|
 test "to_string" {
   debug_inspect(
-    @sorted_set.from_array([1, 2, 3, 4, 5]),
+    @sorted_set.SortedSet([1, 2, 3, 4, 5]),
     content=(
       #|<SortedSet: [1, 2, 3, 4, 5]>
     ),
   )
   debug_inspect(
-    (@sorted_set.from_array([]) : @sorted_set.SortedSet[Int]),
+    (SortedSet([]) : @sorted_set.SortedSet[Int]),
     content=(
       #|<SortedSet: []>
     ),
@@ -571,13 +537,10 @@ test "compare" {
 
 ///|
 test "to_json" {
-  @json.json_inspect(@sorted_set.from_array([5, 2, 4, 3, 1]), content=[
+  @json.json_inspect(@sorted_set.SortedSet([5, 2, 4, 3, 1]), content=[
     1, 2, 3, 4, 5,
   ])
-  @json.json_inspect(
-    (@sorted_set.from_array([]) : @sorted_set.SortedSet[Int]),
-    content=[],
-  )
+  @json.json_inspect((SortedSet([]) : @sorted_set.SortedSet[Int]), content=[])
 }
 
 ///|
@@ -612,11 +575,11 @@ test "from_json rejects non-array" {
 ///|
 test "iter" {
   let mut s = ""
-  @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(x => {
+  @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1]).each(x => {
     s += x.to_string()
   })
   inspect(s, content="123456789")
-  let empty : @sorted_set.SortedSet[Int] = @sorted_set.from_array([])
+  let empty : @sorted_set.SortedSet[Int] = SortedSet([])
   s = ""
   empty.each(x => s += x.to_string())
   inspect(s, content="")
@@ -625,7 +588,7 @@ test "iter" {
 ///|
 test "iter_loop" {
   let buf = StringBuilder(size_hint=20)
-  let set = [2, 7, 1, 2, 3, 4, 5] |> @sorted_set.from_array
+  let set = @sorted_set.SortedSet([2, 7, 1, 2, 3, 4, 5])
   for x in set {
     buf.write_object(x)
   }
@@ -689,7 +652,7 @@ test "iter_loop" {
 
 ///|
 test "split with value not in set" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let (left, present, right) = set.split(6)
   inspect(present, content="false")
   debug_inspect(
@@ -708,7 +671,7 @@ test "split with value not in set" {
 
 ///|
 test "remove_min on non-empty set" {
-  let set = @sorted_set.from_array([3, 4, 5])
+  let set = @sorted_set.SortedSet([3, 4, 5])
   let new_set = set.remove_min()
   debug_inspect(
     new_set,
@@ -720,22 +683,22 @@ test "remove_min on non-empty set" {
 
 ///|
 test "min on non-empty set" {
-  let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
+  let set = @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1])
   let min_value = set.min()
   inspect(min_value, content="1")
 }
 
 ///|
 test "max on non-empty set" {
-  let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
+  let set = @sorted_set.SortedSet([7, 2, 9, 4, 5, 6, 3, 8, 1])
   let max_value = set.max()
   inspect(max_value, content="9")
 }
 
 ///|
 test "union with different heights" {
-  let set1 = @sorted_set.from_array([3, 4, 5])
-  let set2 = @sorted_set.from_array([4, 5, 6])
+  let set1 = @sorted_set.SortedSet([3, 4, 5])
+  let set2 = @sorted_set.SortedSet([4, 5, 6])
   let union_set = set1.union(set2)
   debug_inspect(
     union_set,
@@ -747,8 +710,8 @@ test "union with different heights" {
 
 ///|
 test "disjoint with different sets" {
-  let set1 = @sorted_set.from_array([1, 2, 3])
-  let set2 = @sorted_set.from_array([4, 5, 6])
+  let set1 = @sorted_set.SortedSet([1, 2, 3])
+  let set2 = @sorted_set.SortedSet([4, 5, 6])
   let disjoint = set1.disjoint(set2)
   inspect(disjoint, content="true")
 }
@@ -791,12 +754,12 @@ test "size" {
   inspect(empty_set.length(), content="0")
 
   // Single element set should have size 1
-  inspect(@sorted_set.from_array([1]).length(), content="1")
+  inspect(@sorted_set.SortedSet([1]).length(), content="1")
 
   // Multiple elements set should have correct size
   // The order of insertion should not affect the size
   inspect(
-    @sorted_set.from_array([3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5]).length(),
+    @sorted_set.SortedSet([3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5]).length(),
     content="7",
   )
 }
@@ -805,7 +768,7 @@ test "size" {
 test "@sorted_set.symmetric_difference" {
   // Empty sets
   let empty = @sorted_set.new()
-  let set1 = @sorted_set.from_array([1, 2, 3])
+  let set1 = @sorted_set.SortedSet([1, 2, 3])
   debug_inspect(
     empty.symmetric_difference(empty),
     content=(
@@ -829,8 +792,8 @@ test "@sorted_set.symmetric_difference" {
 ///|
 test "@sorted_set.symmetric_difference/disjoint" {
   // Disjoint sets should union all elements
-  let set1 = @sorted_set.from_array([1, 3, 5])
-  let set2 = @sorted_set.from_array([2, 4, 6])
+  let set1 = @sorted_set.SortedSet([1, 3, 5])
+  let set2 = @sorted_set.SortedSet([2, 4, 6])
   debug_inspect(
     set1.symmetric_difference(set2),
     content=(
@@ -842,8 +805,8 @@ test "@sorted_set.symmetric_difference/disjoint" {
 ///|
 test "@sorted_set.symmetric_difference/overlapping" {
   // Sets with overlapping elements should only include non-common elements
-  let set1 = @sorted_set.from_array([1, 2, 3, 4])
-  let set2 = @sorted_set.from_array([3, 4, 5, 6])
+  let set1 = @sorted_set.SortedSet([1, 2, 3, 4])
+  let set2 = @sorted_set.SortedSet([3, 4, 5, 6])
   debug_inspect(
     set1.symmetric_difference(set2),
     content=(
@@ -865,7 +828,7 @@ test "range on empty set" {
 
 ///|
 test "range with no matches" {
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   let count = for _ in set.range(low=10, high=20); count = 0 {
     continue count + 1
   } nobreak {
@@ -876,7 +839,7 @@ test "range with no matches" {
 
 ///|
 test "range matching all elements" {
-  let set = @sorted_set.from_array([1, 2, 3])
+  let set = @sorted_set.SortedSet([1, 2, 3])
   let arr = []
   for v in set.range(low=0, high=10) {
     arr.push(v)
@@ -886,7 +849,7 @@ test "range matching all elements" {
 
 ///|
 test "range partial match" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let arr = []
   for v in set.range(low=2, high=4) {
     arr.push(v)
@@ -896,7 +859,7 @@ test "range partial match" {
 
 ///|
 test "range with single element" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let arr = []
   for v in set.range(low=3, high=3) {
     arr.push(v)
@@ -906,7 +869,7 @@ test "range with single element" {
 
 ///|
 test "range at left boundary" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let arr = []
   for v in set.range(low=1, high=2) {
     arr.push(v)
@@ -916,7 +879,7 @@ test "range at left boundary" {
 
 ///|
 test "range at right boundary" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let arr = []
   for v in set.range(low=4, high=5) {
     arr.push(v)
@@ -926,7 +889,7 @@ test "range at right boundary" {
 
 ///|
 test "range with gaps in data" {
-  let set = @sorted_set.from_array([1, 3, 5, 7, 9])
+  let set = @sorted_set.SortedSet([1, 3, 5, 7, 9])
   let arr = []
   for v in set.range(low=2, high=8) {
     arr.push(v)
@@ -936,7 +899,7 @@ test "range with gaps in data" {
 
 ///|
 test "range with inverted bounds" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let count = for _ in set.range(low=5, high=2); count = 0 {
     continue count + 1
   } nobreak {
@@ -947,7 +910,7 @@ test "range with inverted bounds" {
 
 ///|
 test "range with early termination" {
-  let set = @sorted_set.from_array([1, 2, 3, 4, 5])
+  let set = @sorted_set.SortedSet([1, 2, 3, 4, 5])
   let count = for _ in set.range(low=1, high=5); count = 0 {
     let count = count + 1
     if count == 2 {
@@ -963,7 +926,7 @@ test "range with early termination" {
 ///|
 test "range on large dataset" {
   let arr = Array::makei(100, fn(i) { i })
-  let set = @sorted_set.from_array(arr)
+  let set = @sorted_set.SortedSet(arr)
   let count = for _ in set.range(low=25, high=75); count = 0 {
     continue count + 1
   } nobreak {
@@ -974,7 +937,7 @@ test "range on large dataset" {
 
 ///|
 test "range with non-existent boundaries" {
-  let set = @sorted_set.from_array([2, 4, 6, 8])
+  let set = @sorted_set.SortedSet([2, 4, 6, 8])
   let arr = []
   for v in set.range(low=3, high=7) {
     arr.push(v)

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -15,6 +15,11 @@ import {
 // Types and methods
 #alias(T, deprecated)
 type SortedSet[A]
+#alias(from_array, deprecated)
+#alias(of, deprecated)
+#as_free_fn(of, deprecated)
+#as_free_fn(from_array, deprecated)
+pub fn[A : Compare] SortedSet::SortedSet(ArrayView[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::add(Self[A], A) -> Self[A]
 pub fn[A] SortedSet::all(Self[A], (A) -> Bool raise?) -> Bool raise?
 pub fn[A] SortedSet::any(Self[A], (A) -> Bool raise?) -> Bool raise?
@@ -25,10 +30,6 @@ pub fn[A : Compare] SortedSet::disjoint(Self[A], Self[A]) -> Bool
 pub fn[A] SortedSet::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 pub fn[A] SortedSet::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A, B] SortedSet::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
-#alias(of, deprecated)
-#as_free_fn(of, deprecated)
-#as_free_fn
-pub fn[A : Compare] SortedSet::from_array(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn


### PR DESCRIPTION
## Summary

Fixes all 220+ compiler warnings in `immut/sorted_set`.

### Changes

1. **Replace deprecated `from_array()` calls** with `SortedSet()` constructor in all source, test, and doc files
2. **Convert separate `from_array` function body** into a deprecated `#alias` of `SortedSet::SortedSet`, matching the pattern used by the mutable `sorted_set` package
3. **Fix missing documentation** on the `SortedSet` constructor
4. **Drop unnecessary `@sorted_set.` prefix** in doc comments where the expected type is known from context
5. **Remove `+unnecessary_annotation` warning flag**: it produces false positives in `_test.mbt` files when the function name matches the type name, and directly contradicts the `+test_unqualified_package` flag

### Verification

```
moon check  →  0 warnings, 0 errors
moon test immut/sorted_set  →  134 passed, 0 failed
moon test sorted_set        →  56 passed, 0 failed
```