### PR TITLE
refactor(immut): make RRB-tree radix constants const for const propagation

### DIFF
--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -29,14 +29,14 @@ pub fn[A] T::new() -> T[A] {
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
 #as_free_fn(deprecated="Use the corresponding function in `immut/vector` instead")
 pub fn[A] T::make(len : Int, value : A) -> T[A] {
-  let quot = len / branching_factor
-  let rem = len % branching_factor
+  let quot = len / BRANCHING_FACTOR
+  let rem = len % BRANCHING_FACTOR
   let leaves = if rem == 0 {
-    Array::make(quot, FixedArray::make(branching_factor, value))
+    Array::make(quot, FixedArray::make(BRANCHING_FACTOR, value))
   } else {
     let arr : Array[FixedArray[A]] = Array::make(
       quot + 1,
-      FixedArray::make(branching_factor, value),
+      FixedArray::make(BRANCHING_FACTOR, value),
     )
     arr[quot] = FixedArray::make(rem, value)
     arr
@@ -52,20 +52,20 @@ pub fn[A] T::make(len : Int, value : A) -> T[A] {
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
 #as_free_fn(deprecated="Use the corresponding function in `immut/vector` instead")
 pub fn[A] T::makei(len : Int, f : (Int) -> A raise?) -> T[A] raise? {
-  let quot = len / branching_factor
-  let rem = len % branching_factor
+  let quot = len / BRANCHING_FACTOR
+  let rem = len % BRANCHING_FACTOR
   let leaves = if rem == 0 {
     Array::makei(quot, k => {
-      FixedArray::makei(branching_factor, i => f(k * branching_factor + i))
+      FixedArray::makei(BRANCHING_FACTOR, i => f(k * BRANCHING_FACTOR + i))
     })
   } else {
     let arr : Array[FixedArray[A]] = Array::make(quot + 1, [])
     for k in 0..<quot {
-      arr[k] = FixedArray::makei(branching_factor, i => {
-        f(k * branching_factor + i)
+      arr[k] = FixedArray::makei(BRANCHING_FACTOR, i => {
+        f(k * BRANCHING_FACTOR + i)
       })
     }
-    arr[quot] = FixedArray::makei(rem, i => f(quot * branching_factor + i))
+    arr[quot] = FixedArray::makei(rem, i => f(quot * BRANCHING_FACTOR + i))
     arr
   }
   let size = len
@@ -104,18 +104,18 @@ pub fn[A] T::from_iter(iter : Iter[A]) -> T[A] {
   let leaves = []
   while iter.next() is Some(x) {
     if index == 0 {
-      buf = FixedArray::make(branching_factor, x)
+      buf = FixedArray::make(BRANCHING_FACTOR, x)
       index += 1
-    } else if index < branching_factor {
+    } else if index < BRANCHING_FACTOR {
       buf[index] = x
       index += 1
     } else {
       leaves.push(buf)
       index = 1
-      buf = FixedArray::make(branching_factor, x)
+      buf = FixedArray::make(BRANCHING_FACTOR, x)
     }
   }
-  if index == branching_factor {
+  if index == BRANCHING_FACTOR {
     leaves.push(buf)
   } else if index > 0 {
     let res = FixedArray::make_and_blit(
@@ -479,20 +479,20 @@ pub impl[A : Compare] Compare for T[A] with fn compare(self, other) {
 
 ///|
 fn[A] from_leaves(leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
-  if cap == branching_factor {
+  if cap == BRANCHING_FACTOR {
     Leaf(leaves[0])
-  } else if leaves.length() <= branching_factor {
+  } else if leaves.length() <= BRANCHING_FACTOR {
     let arr = FixedArray::make(leaves.length(), Empty)
     for i, leaf in leaves {
       arr[i] = Leaf(leaf)
     }
     Node(arr, None)
   } else {
-    let len = leaves.length() * branching_factor
-    let child_cap = cap / branching_factor
+    let len = leaves.length() * BRANCHING_FACTOR
+    let child_cap = cap / BRANCHING_FACTOR
     let quot = len / child_cap
     let rem = len % child_cap
-    let times = child_cap / branching_factor
+    let times = child_cap / BRANCHING_FACTOR
     let arr = if rem == 0 {
       FixedArray::makei(quot, i => {
         from_leaves(leaves[i * times:(i + 1) * times], child_cap)
@@ -511,9 +511,9 @@ fn[A] from_leaves(leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
 
 ///|
 fn shift_cap_of_size(size : Int) -> (Int, Int) {
-  for cap = branching_factor, depth = 0; cap < size; {
-    continue cap * branching_factor, depth + 1
+  for cap = BRANCHING_FACTOR, depth = 0; cap < size; {
+    continue cap * BRANCHING_FACTOR, depth + 1
   } nobreak {
-    (num_bits * depth, cap)
+    (NUM_BITS * depth, cap)
   }
 }

--- a/immut/array/array_wbtest.mbt
+++ b/immut/array/array_wbtest.mbt
@@ -44,7 +44,7 @@ test "mix" {
   inspect(ct1, content="19800")
   inspect(ct2, content="19800")
   inspect(v.tree.is_empty_tree(), content="false")
-  let large_const = branching_factor * branching_factor + 1
+  let large_const = BRANCHING_FACTOR * BRANCHING_FACTOR + 1
   let v = for i in 0..<large_const; v = (T::new() : T[Int]) {
     continue v.push(i)
   } nobreak {
@@ -66,7 +66,7 @@ test "get" {
   inspect(v[0], content=v_content[0].to_string())
   inspect(v[bf - 1], content=v_content[bf - 1].to_string())
   inspect(v[bf / 2], content=v_content[bf / 2].to_string())
-  let bf = branching_factor
+  let bf = BRANCHING_FACTOR
   let v_content = random_array(bf)
   let v = T::from_iter(v_content.iter())
   inspect(v.length(), content=bf.to_string())

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -21,14 +21,14 @@
 ///|
 /// The controlling factor of the tree depth.
 /// This is the only parameter you normally would adjust.
-let num_bits = 5
+const NUM_BITS = 5
 
 ///|
-/// Invariant: `branching_factor` is a power of 2.
-let branching_factor : Int = 1 << num_bits
+/// Invariant: `BRANCHING_FACTOR` is a power of 2.
+const BRANCHING_FACTOR : Int = 1 << NUM_BITS
 
 ///|
-let bitmask : Int = branching_factor - 1
+const BITMASK : Int = BRANCHING_FACTOR - 1
 
 ///|
 /// The threshold for switching to a linear search.
@@ -56,7 +56,7 @@ fn[T] Tree::empty() -> Tree[T] {
 fn[T] new_branch_left(leaf : FixedArray[T], shift : Int) -> Tree[T] {
   match shift {
     0 => Leaf(leaf)
-    s => Node([new_branch_left(leaf, s - num_bits)], None) // size is None because we can use radix indexing
+    s => Node([new_branch_left(leaf, s - NUM_BITS)], None) // size is None because we can use radix indexing
   }
 }
 
@@ -92,14 +92,14 @@ fn[T] Tree::get_last(self : Tree[T]) -> T {
 /// Get the element at the given index.
 /// 
 /// Precondition:
-/// - `self` is of height `shift / num_bits`.
+/// - `self` is of height `shift / NUM_BITS`.
 fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
   fn get_radix(node : Tree[T], shift : Int) -> T {
     for cur = node, s = shift {
       match cur {
-        Leaf(leaf) => break leaf[index & bitmask]
+        Leaf(leaf) => break leaf[index & BITMASK]
         Node(node, None) =>
-          continue node[radix_indexing(index, s)], s - num_bits
+          continue node[radix_indexing(index, s)], s - NUM_BITS
         Node(_, Some(_)) =>
           abort("Unreachable: Node should not have sizes in get_radix")
         Empty => abort("Index out of bounds")
@@ -116,7 +116,7 @@ fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
       } else {
         index - sizes[branch_index - 1]
       }
-      children[branch_index].get(sub_index, shift - num_bits)
+      children[branch_index].get(sub_index, shift - NUM_BITS)
     }
     Node(_, None) => get_radix(self, shift)
     Empty => abort("Index out of bounds")
@@ -131,19 +131,19 @@ fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
 /// Set a value at the given index.
 /// 
 /// Precondition:
-/// - `self` is of height `shift / num_bits`.
+/// - `self` is of height `shift / NUM_BITS`.
 fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] {
   // TODO: optimize this as loop
   fn set_radix(node : Tree[T], shift : Int) -> Tree[T] {
     match node {
-      Leaf(leaf) => Leaf(immutable_set(leaf, index & bitmask, value))
+      Leaf(leaf) => Leaf(immutable_set(leaf, index & BITMASK, value))
       Node(node, None) => {
         let sub_idx = radix_indexing(index, shift)
         Node(
           immutable_set(
             node,
             sub_idx,
-            set_radix(node[radix_indexing(index, shift)], shift - num_bits),
+            set_radix(node[radix_indexing(index, shift)], shift - NUM_BITS),
           ),
           None,
         )
@@ -155,7 +155,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
   }
 
   match self {
-    Leaf(leaf) => Leaf(immutable_set(leaf, index & bitmask, value))
+    Leaf(leaf) => Leaf(immutable_set(leaf, index & BITMASK, value))
     Node(children, Some(sizes)) => {
       let branch_index = get_branch_index(sizes, index)
       let sub_index = if branch_index == 0 {
@@ -167,7 +167,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
         immutable_set(
           children,
           branch_index,
-          children[branch_index].set(sub_index, shift - num_bits, value),
+          children[branch_index].set(sub_index, shift - NUM_BITS, value),
         ),
         Some(sizes),
       )
@@ -181,7 +181,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
 /// Push a value to the end of the tree.
 /// 
 /// Precondition:
-/// - The height of `self` = `shift` / `num_bits` (the height starts from 0).
+/// - The height of `self` = `shift` / `NUM_BITS` (the height starts from 0).
 /// - `length` is the number of elements in the tree.
 fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
   fn update_sizes_last(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
@@ -210,7 +210,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
             "Unreachable: Leaf should not have a non-zero shift, which means we have not reached the bottom of the tree",
           )
         }
-        if leaf.length() < branching_factor {
+        if leaf.length() < BRANCHING_FACTOR {
           Some(Leaf(immutable_push(leaf, value)))
         } else {
           None
@@ -218,7 +218,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
       }
       Node(nodes, sizes) => {
         let len = nodes.length()
-        match worker(nodes[len - 1], shift - num_bits) {
+        match worker(nodes[len - 1], shift - NUM_BITS) {
           // We have successfully pushed the value, now duplicate its ancestor nodes.
           Some(new_node) => {
             let new_nodes = nodes.copy()
@@ -228,13 +228,13 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
           }
           // We need to create a new node to push the value.
           None =>
-            if len < branching_factor {
+            if len < BRANCHING_FACTOR {
               let sizes = push_sizes_last(sizes)
               Some(
                 Node(
                   immutable_push(
                     nodes,
-                    new_branch_left([value], shift - num_bits),
+                    new_branch_left([value], shift - NUM_BITS),
                   ),
                   sizes,
                 ),
@@ -266,7 +266,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
               "Unreachable: Empty tree should have fallen into the Some(new_tree) branch",
             )
         },
-        shift + num_bits,
+        shift + NUM_BITS,
       )
     }
   }
@@ -332,14 +332,14 @@ fn[A] Tree::eachi(
         f(start + i, x)
       }
     Node(ns, None) => {
-      let child_shift = shift - num_bits
+      let child_shift = shift - NUM_BITS
       for child in ns; start = start {
         child.eachi(f, child_shift, start)
         continue start + (1 << shift)
       }
     }
     Node(ns, Some(sizes)) => {
-      let child_shift = shift - num_bits
+      let child_shift = shift - NUM_BITS
       for i, child in ns; start = start {
         child.eachi(f, child_shift, start)
         continue start + sizes[i]
@@ -397,7 +397,7 @@ fn[A, B] Tree::map(self : Tree[A], f : (A) -> B raise?) -> Tree[B] raise? {
 /// 
 /// Preconditions:
 /// - `left` and `right` are not `Empty`.
-/// - `left` and `right` are of height `left_shift / num_bits` and `right_shift / num_bits`, respectively.
+/// - `left` and `right` are of height `left_shift / NUM_BITS` and `right_shift / NUM_BITS`, respectively.
 fn[A] Tree::concat(
   left : Tree[A],
   left_shift : Int,
@@ -408,7 +408,7 @@ fn[A] Tree::concat(
   if left_shift > right_shift {
     let (c, c_shift) = Tree::concat(
       left.right_child(),
-      left_shift - num_bits,
+      left_shift - NUM_BITS,
       right,
       right_shift,
       false,
@@ -420,7 +420,7 @@ fn[A] Tree::concat(
       left,
       left_shift,
       right.left_child(),
-      right_shift - num_bits,
+      right_shift - NUM_BITS,
       false,
     )
     guard c_shift == right_shift
@@ -432,7 +432,7 @@ fn[A] Tree::concat(
     let left_len = left_elems.length()
     let right_len = right_elems.length()
     let len = left_len + right_len
-    if top && len <= branching_factor {
+    if top && len <= BRANCHING_FACTOR {
       return (
         Leaf(
           FixedArray::makei(len, (i : Int) => {
@@ -451,16 +451,16 @@ fn[A] Tree::concat(
           FixedArray::from_array([left, right]),
           Some(FixedArray::from_array([left_len, len])),
         ),
-        num_bits,
+        NUM_BITS,
       )
     }
   } else {
     // Handle Node case
     let (c, c_shift) = Tree::concat(
       left.right_child(),
-      left_shift - num_bits,
+      left_shift - NUM_BITS,
       right.left_child(),
-      right_shift - num_bits,
+      right_shift - NUM_BITS,
       false,
     )
     guard c_shift == left_shift
@@ -470,7 +470,7 @@ fn[A] Tree::concat(
 }
 
 ///|
-/// Given three `Node`s of the same height (`shift` / `num_bits`), rebalance them into two.
+/// Given three `Node`s of the same height (`shift` / `NUM_BITS`), rebalance them into two.
 /// `top` is `true` if the resulting node has no upper node.
 /// Returns the new node and its shift.
 fn[A] rebalance(
@@ -480,38 +480,38 @@ fn[A] rebalance(
   shift : Int,
   top : Bool,
 ) -> (Tree[A], Int) {
-  // Suppose H = shift / num_bits
+  // Suppose H = shift / NUM_BITS
   let t = tri_merge(left, center, right) // t is a list of trees of (H-1) height
   let (nc, nc_len) = redis_plan(t)
-  let new_t = redis(t, nc, nc_len, shift - num_bits) // new_t is a list of trees of (H-1) height
+  let new_t = redis(t, nc, nc_len, shift - NUM_BITS) // new_t is a list of trees of (H-1) height
   guard new_t.length() == nc_len
-  if nc_len <= branching_factor {
+  if nc_len <= BRANCHING_FACTOR {
     // All nodes can be accommodated in a single node
-    let node = Node(new_t, compute_sizes(new_t, shift - num_bits)) // node of H height
+    let node = Node(new_t, compute_sizes(new_t, shift - NUM_BITS)) // node of H height
     if !top {
-      return (Node(FixedArray::from_array([node]), None), shift + num_bits)
+      return (Node(FixedArray::from_array([node]), None), shift + NUM_BITS)
       // return (H+1) height node, add another layer to align with the case at the end of the thisfunction
     } else {
       return (node, shift)
       // return H height node, no upper node so no need to add another layer on top of it
     }
   } else {
-    let new_child_1 = FixedArray::makei(branching_factor, i => new_t[i])
-    let new_child_2 = FixedArray::makei(new_t.length() - branching_factor, i => {
-      new_t[i + branching_factor]
+    let new_child_1 = FixedArray::makei(BRANCHING_FACTOR, i => new_t[i])
+    let new_child_2 = FixedArray::makei(new_t.length() - BRANCHING_FACTOR, i => {
+      new_t[i + BRANCHING_FACTOR]
     })
     let new_node_1 = Node(
       new_child_1,
-      compute_sizes(new_child_1, shift - num_bits),
+      compute_sizes(new_child_1, shift - NUM_BITS),
     ) // height H
     let new_node_2 = Node(
       new_child_2,
-      compute_sizes(new_child_2, shift - num_bits),
+      compute_sizes(new_child_2, shift - NUM_BITS),
     ) // height H
     let new_children = FixedArray::from_array([new_node_1, new_node_2])
     return (
       Node(new_children, compute_sizes(new_children, shift)),
-      shift + num_bits,
+      shift + NUM_BITS,
     ) // return (H+1) height node
   }
 }
@@ -520,7 +520,7 @@ fn[A] rebalance(
 /// Given three trees of the same height (if not `Empty`), merge them into one.
 /// `left` and `right` might be `Node` or `Empty`.
 /// `center` is always a `Node`.
-/// The resulting array might be longer than `branching_factor`,
+/// The resulting array might be longer than `BRANCHING_FACTOR`,
 /// which will be handled by `rebalance` later.
 /// 
 /// Preconditions:
@@ -572,20 +572,20 @@ fn[A] tri_merge(
 fn[A] redis_plan(t : FixedArray[Tree[A]]) -> (FixedArray[Int], Int) {
   let node_counts = FixedArray::makei(t.length(), i => t[i].local_size())
   let total_nodes = node_counts.fold(init=0, (acc, x) => acc + x)
-  // round up to the nearest integer of S/branching_factor
-  let opt_len = (total_nodes + branching_factor - 1) / branching_factor
+  // round up to the nearest integer of S/BRANCHING_FACTOR
+  let opt_len = (total_nodes + BRANCHING_FACTOR - 1) / BRANCHING_FACTOR
   let mut new_len = t.length()
   let mut i = 0
   while opt_len + e_max_2 < new_len {
     // Skip over all nodes satisfying the invariant.
-    while node_counts[i] > branching_factor - e_max_2 {
+    while node_counts[i] > BRANCHING_FACTOR - e_max_2 {
       i += 1
     }
 
     // Found short node, so redistribute over the next nodes
     let mut remaining_nodes = node_counts[i]
     while remaining_nodes > 0 {
-      let min_size = min(remaining_nodes + node_counts[i + 1], branching_factor)
+      let min_size = min(remaining_nodes + node_counts[i + 1], BRANCHING_FACTOR)
       node_counts[i] = min_size
       remaining_nodes = remaining_nodes + node_counts[i + 1] - min_size
       i += 1
@@ -604,7 +604,7 @@ fn[A] redis_plan(t : FixedArray[Tree[A]]) -> (FixedArray[Int], Int) {
 /// 
 /// Preconditions:
 /// - forall i in 0..node_nums, old_t[i] != Empty.
-/// - `old_t` contains a list of trees, each of (`shift` / `num_bits`) height.
+/// - `old_t` contains a list of trees, each of (`shift` / `NUM_BITS`) height.
 /// - `node_counts` contains the number of children of each node in `new_t` (the redistributed version of `old_t`).
 /// - `node_nums` is the length of `node_counts`.
 /// 
@@ -697,8 +697,8 @@ fn[A] redis(
         }
         new_t[i] = Node(
           new_node_chldrn,
-          compute_sizes(new_node_chldrn, shift - num_bits),
-        ) // each node in `new_t` is of height (`shift` / `num_bits`)
+          compute_sizes(new_node_chldrn, shift - NUM_BITS),
+        ) // each node in `new_t` is of height (`shift` / `NUM_BITS`)
       }
     }
   }
@@ -706,7 +706,7 @@ fn[A] redis(
 }
 
 ///|
-/// Given a list of trees as `children` with heights of (`shift` / `num_bits`), compute the sizes array of the subtrees.
+/// Given a list of trees as `children` with heights of (`shift` / `NUM_BITS`), compute the sizes array of the subtrees.
 fn[A] compute_sizes(
   children : FixedArray[Tree[A]],
   shift : Int,
@@ -715,7 +715,7 @@ fn[A] compute_sizes(
   let sizes = FixedArray::make(len, 0)
   let mut sum = 0
   let mut flag = true
-  let full_subtree_size = branching_factor << shift
+  let full_subtree_size = BRANCHING_FACTOR << shift
   for i in 0..<len {
     let sz = children[i].size(shift)
     flag = flag && sz == full_subtree_size

--- a/immut/array/tree_utils.mbt
+++ b/immut/array/tree_utils.mbt
@@ -83,7 +83,7 @@ fn[A] Tree::size(self : Tree[A], shift : Int) -> Int {
     Node(_, Some(sizes)) => sizes[sizes.length() - 1]
     Node(children, None) => {
       let len_1 = children.length() - 1
-      (len_1 << shift) + children[len_1].size(shift - num_bits)
+      (len_1 << shift) + children[len_1].size(shift - NUM_BITS)
     }
   }
 }

--- a/immut/array/tree_utils_wbtest.mbt
+++ b/immut/array/tree_utils_wbtest.mbt
@@ -110,8 +110,8 @@ test "Tree::size for Node without sizes" {
   let node_tree = Node(FixedArray::from_array([child1, child2]), None)
 
   // This will compute size based on the formula
-  // The calculation: (len_1 << shift) + children[len_1].size(shift - num_bits)
-  // With shift=6 and num_bits=5 (typical for immutable arrays)
+  // The calculation: (len_1 << shift) + children[len_1].size(shift - NUM_BITS)
+  // With shift=6 and NUM_BITS=5 (typical for immutable arrays)
   let result = node_tree.size(6)
   inspect(result >= 3, content="true") // At least the size of the last leaf
 }

--- a/immut/array/types.mbt
+++ b/immut/array/types.mbt
@@ -14,7 +14,7 @@
 
 ///|
 /// Invariants:
-/// - `shift` = tree height * `num_bits`. When it is 0, we are at the leaf level.
+/// - `shift` = tree height * `NUM_BITS`. When it is 0, we are at the leaf level.
 /// - `size` = the number of elements in the tree.
 /// - `shift` is not used when `tree` is `Empty`.
 struct T[A] {

--- a/immut/array/utils.mbt
+++ b/immut/array/utils.mbt
@@ -46,7 +46,7 @@ fn shr_as_uint(x : Int, y : Int) -> Int {
 ///|
 /// Given an index and a shift, return the index of the branch that contains the given index.
 fn radix_indexing(index : Int, shift : Int) -> Int {
-  shr_as_uint(index, shift) & bitmask
+  shr_as_uint(index, shift) & BITMASK
 }
 
 ///|

--- a/immut/array/utils_wbtest.mbt
+++ b/immut/array/utils_wbtest.mbt
@@ -110,7 +110,7 @@ fn execute_array_test(rs : Array[Op]) -> Unit raise {
 /// Compute the power of the branching factor.
 fn branching_factor_power(a : Int) -> Int {
   for _ in 0..<a; ret = 1 {
-    continue ret * branching_factor
+    continue ret * BRANCHING_FACTOR
   } nobreak {
     ret
   }

--- a/immut/array/utils_wbtest2.mbt
+++ b/immut/array/utils_wbtest2.mbt
@@ -39,7 +39,7 @@ test "shr_as_uint" {
 
 ///|
 test "radix_indexing" {
-  // Assuming bitmask is 31 (0x1F) for 5 bits
+  // Assuming BITMASK is 31 (0x1F) for 5 bits
   inspect(radix_indexing(35, 5), content="1") // 35 >> 5 = 1, 1 & 31 = 1
   inspect(radix_indexing(100, 5), content="3") // 100 >> 5 = 3, 3 & 31 = 3
   inspect(radix_indexing(7, 5), content="0") // 7 >> 5 = 0, 0 & 31 = 0

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -21,14 +21,14 @@
 ///|
 /// The controlling factor of the tree depth.
 /// This is the only parameter you normally would adjust.
-let num_bits = 5
+const NUM_BITS = 5
 
 ///|
-/// Invariant: `branching_factor` is a power of 2.
-let branching_factor : Int = 1 << num_bits
+/// Invariant: `BRANCHING_FACTOR` is a power of 2.
+const BRANCHING_FACTOR : Int = 1 << NUM_BITS
 
 ///|
-let bitmask : Int = branching_factor - 1
+const BITMASK : Int = BRANCHING_FACTOR - 1
 
 ///|
 /// The threshold for switching to a linear search.
@@ -56,7 +56,7 @@ fn[T] Tree::empty() -> Tree[T] {
 fn[T] new_branch_left(leaf : FixedArray[T], shift : Int) -> Tree[T] {
   match shift {
     0 => Leaf(leaf)
-    s => Node([new_branch_left(leaf, s - num_bits)], None) // size is None because we can use radix indexing
+    s => Node([new_branch_left(leaf, s - NUM_BITS)], None) // size is None because we can use radix indexing
   }
 }
 
@@ -68,14 +68,14 @@ fn[T] new_branch_left(leaf : FixedArray[T], shift : Int) -> Tree[T] {
 /// Get the element at the given index.
 /// 
 /// Precondition:
-/// - `self` is of height `shift / num_bits`.
+/// - `self` is of height `shift / NUM_BITS`.
 fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
   fn get_radix(node : Tree[T], shift : Int) -> T {
     for cur = node, s = shift {
       match cur {
-        Leaf(leaf) => break leaf[index & bitmask]
+        Leaf(leaf) => break leaf[index & BITMASK]
         Node(node, None) =>
-          continue node[radix_indexing(index, s)], s - num_bits
+          continue node[radix_indexing(index, s)], s - NUM_BITS
         Node(_, Some(_)) =>
           abort("Unreachable: Node should not have sizes in get_radix")
         Empty => abort("Index out of bounds")
@@ -92,7 +92,7 @@ fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
       } else {
         index - sizes[branch_index - 1]
       }
-      children[branch_index].get(sub_index, shift - num_bits)
+      children[branch_index].get(sub_index, shift - NUM_BITS)
     }
     Node(_, None) => get_radix(self, shift)
     Empty => abort("Index out of bounds")
@@ -107,19 +107,19 @@ fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
 /// Set a value at the given index.
 /// 
 /// Precondition:
-/// - `self` is of height `shift / num_bits`.
+/// - `self` is of height `shift / NUM_BITS`.
 fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] {
   // TODO: optimize this as loop
   fn set_radix(node : Tree[T], shift : Int) -> Tree[T] {
     match node {
-      Leaf(leaf) => Leaf(immutable_set(leaf, index & bitmask, value))
+      Leaf(leaf) => Leaf(immutable_set(leaf, index & BITMASK, value))
       Node(node, None) => {
         let sub_idx = radix_indexing(index, shift)
         Node(
           immutable_set(
             node,
             sub_idx,
-            set_radix(node[radix_indexing(index, shift)], shift - num_bits),
+            set_radix(node[radix_indexing(index, shift)], shift - NUM_BITS),
           ),
           None,
         )
@@ -131,7 +131,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
   }
 
   match self {
-    Leaf(leaf) => Leaf(immutable_set(leaf, index & bitmask, value))
+    Leaf(leaf) => Leaf(immutable_set(leaf, index & BITMASK, value))
     Node(children, Some(sizes)) => {
       let branch_index = get_branch_index(sizes, index)
       let sub_index = if branch_index == 0 {
@@ -143,7 +143,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
         immutable_set(
           children,
           branch_index,
-          children[branch_index].set(sub_index, shift - num_bits, value),
+          children[branch_index].set(sub_index, shift - NUM_BITS, value),
         ),
         Some(sizes),
       )
@@ -157,7 +157,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
 /// Push a value to the end of the tree.
 /// 
 /// Precondition:
-/// - The height of `self` = `shift` / `num_bits` (the height starts from 0).
+/// - The height of `self` = `shift` / `NUM_BITS` (the height starts from 0).
 /// - `length` is the number of elements in the tree.
 fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
   fn update_sizes_last(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
@@ -186,7 +186,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
             "Unreachable: Leaf should not have a non-zero shift, which means we have not reached the bottom of the tree",
           )
         }
-        if leaf.length() < branching_factor {
+        if leaf.length() < BRANCHING_FACTOR {
           Some(Leaf(immutable_push(leaf, value)))
         } else {
           None
@@ -194,7 +194,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
       }
       Node(nodes, sizes) => {
         let len = nodes.length()
-        match worker(nodes[len - 1], shift - num_bits) {
+        match worker(nodes[len - 1], shift - NUM_BITS) {
           // We have successfully pushed the value, now duplicate its ancestor nodes.
           Some(new_node) => {
             let new_nodes = nodes.copy()
@@ -204,13 +204,13 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
           }
           // We need to create a new node to push the value.
           None =>
-            if len < branching_factor {
+            if len < BRANCHING_FACTOR {
               let sizes = push_sizes_last(sizes)
               Some(
                 Node(
                   immutable_push(
                     nodes,
-                    new_branch_left([value], shift - num_bits),
+                    new_branch_left([value], shift - NUM_BITS),
                   ),
                   sizes,
                 ),
@@ -242,7 +242,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
               "Unreachable: Empty tree should have fallen into the Some(new_tree) branch",
             )
         },
-        shift + num_bits,
+        shift + NUM_BITS,
       )
     }
   }
@@ -296,14 +296,14 @@ fn[A] Tree::eachi(
         f(start + i, x)
       }
     Node(ns, None) => {
-      let child_shift = shift - num_bits
+      let child_shift = shift - NUM_BITS
       for child in ns; start = start {
         child.eachi(f, child_shift, start)
         continue start + (1 << shift)
       }
     }
     Node(ns, Some(sizes)) => {
-      let child_shift = shift - num_bits
+      let child_shift = shift - NUM_BITS
       for i, child in ns; offset = 0 {
         child.eachi(f, child_shift, start + offset)
         continue sizes[i]
@@ -361,7 +361,7 @@ fn[A, B] Tree::map(self : Tree[A], f : (A) -> B raise?) -> Tree[B] raise? {
 /// 
 /// Preconditions:
 /// - `left` and `right` are not `Empty`.
-/// - `left` and `right` are of height `left_shift / num_bits` and `right_shift / num_bits`, respectively.
+/// - `left` and `right` are of height `left_shift / NUM_BITS` and `right_shift / NUM_BITS`, respectively.
 fn[A] Tree::concat(
   left : Tree[A],
   left_shift : Int,
@@ -372,7 +372,7 @@ fn[A] Tree::concat(
   if left_shift > right_shift {
     let (c, c_shift) = Tree::concat(
       left.right_child(),
-      left_shift - num_bits,
+      left_shift - NUM_BITS,
       right,
       right_shift,
       false,
@@ -384,7 +384,7 @@ fn[A] Tree::concat(
       left,
       left_shift,
       right.left_child(),
-      right_shift - num_bits,
+      right_shift - NUM_BITS,
       false,
     )
     guard c_shift == right_shift
@@ -396,7 +396,7 @@ fn[A] Tree::concat(
     let left_len = left_elems.length()
     let right_len = right_elems.length()
     let len = left_len + right_len
-    if top && len <= branching_factor {
+    if top && len <= BRANCHING_FACTOR {
       return (
         Leaf(
           FixedArray::makei(len, (i : Int) => {
@@ -415,16 +415,16 @@ fn[A] Tree::concat(
           FixedArray::from_array([left, right]),
           Some(FixedArray::from_array([left_len, len])),
         ),
-        num_bits,
+        NUM_BITS,
       )
     }
   } else {
     // Handle Node case
     let (c, c_shift) = Tree::concat(
       left.right_child(),
-      left_shift - num_bits,
+      left_shift - NUM_BITS,
       right.left_child(),
-      right_shift - num_bits,
+      right_shift - NUM_BITS,
       false,
     )
     guard c_shift == left_shift
@@ -434,7 +434,7 @@ fn[A] Tree::concat(
 }
 
 ///|
-/// Given three `Node`s of the same height (`shift` / `num_bits`), rebalance them into two.
+/// Given three `Node`s of the same height (`shift` / `NUM_BITS`), rebalance them into two.
 /// `top` is `true` if the resulting node has no upper node.
 /// Returns the new node and its shift.
 fn[A] rebalance(
@@ -444,38 +444,38 @@ fn[A] rebalance(
   shift : Int,
   top : Bool,
 ) -> (Tree[A], Int) {
-  // Suppose H = shift / num_bits
+  // Suppose H = shift / NUM_BITS
   let t = tri_merge(left, center, right) // t is a list of trees of (H-1) height
   let (nc, nc_len) = redis_plan(t)
-  let new_t = redis(t, nc, nc_len, shift - num_bits) // new_t is a list of trees of (H-1) height
+  let new_t = redis(t, nc, nc_len, shift - NUM_BITS) // new_t is a list of trees of (H-1) height
   guard new_t.length() == nc_len
-  if nc_len <= branching_factor {
+  if nc_len <= BRANCHING_FACTOR {
     // All nodes can be accommodated in a single node
-    let node = Node(new_t, compute_sizes(new_t, shift - num_bits)) // node of H height
+    let node = Node(new_t, compute_sizes(new_t, shift - NUM_BITS)) // node of H height
     if !top {
-      return (Node(FixedArray::from_array([node]), None), shift + num_bits)
+      return (Node(FixedArray::from_array([node]), None), shift + NUM_BITS)
       // return (H+1) height node, add another layer to align with the case at the end of the thisfunction
     } else {
       return (node, shift)
       // return H height node, no upper node so no need to add another layer on top of it
     }
   } else {
-    let new_child_1 = FixedArray::makei(branching_factor, i => new_t[i])
-    let new_child_2 = FixedArray::makei(new_t.length() - branching_factor, i => {
-      new_t[i + branching_factor]
+    let new_child_1 = FixedArray::makei(BRANCHING_FACTOR, i => new_t[i])
+    let new_child_2 = FixedArray::makei(new_t.length() - BRANCHING_FACTOR, i => {
+      new_t[i + BRANCHING_FACTOR]
     })
     let new_node_1 = Node(
       new_child_1,
-      compute_sizes(new_child_1, shift - num_bits),
+      compute_sizes(new_child_1, shift - NUM_BITS),
     ) // height H
     let new_node_2 = Node(
       new_child_2,
-      compute_sizes(new_child_2, shift - num_bits),
+      compute_sizes(new_child_2, shift - NUM_BITS),
     ) // height H
     let new_children = FixedArray::from_array([new_node_1, new_node_2])
     return (
       Node(new_children, compute_sizes(new_children, shift)),
-      shift + num_bits,
+      shift + NUM_BITS,
     ) // return (H+1) height node
   }
 }
@@ -484,7 +484,7 @@ fn[A] rebalance(
 /// Given three trees of the same height (if not `Empty`), merge them into one.
 /// `left` and `right` might be `Node` or `Empty`.
 /// `center` is always a `Node`.
-/// The resulting array might be longer than `branching_factor`,
+/// The resulting array might be longer than `BRANCHING_FACTOR`,
 /// which will be handled by `rebalance` later.
 /// 
 /// Preconditions:
@@ -536,20 +536,20 @@ fn[A] tri_merge(
 fn[A] redis_plan(t : FixedArray[Tree[A]]) -> (FixedArray[Int], Int) {
   let node_counts = FixedArray::makei(t.length(), i => t[i].local_size())
   let total_nodes = node_counts.fold(init=0, (acc, x) => acc + x)
-  // round up to the nearest integer of S/branching_factor
-  let opt_len = (total_nodes + branching_factor - 1) / branching_factor
+  // round up to the nearest integer of S/BRANCHING_FACTOR
+  let opt_len = (total_nodes + BRANCHING_FACTOR - 1) / BRANCHING_FACTOR
   let mut new_len = t.length()
   let mut i = 0
   while opt_len + e_max_2 < new_len {
     // Skip over all nodes satisfying the invariant.
-    while node_counts[i] > branching_factor - e_max_2 {
+    while node_counts[i] > BRANCHING_FACTOR - e_max_2 {
       i += 1
     }
 
     // Found short node, so redistribute over the next nodes
     let mut remaining_nodes = node_counts[i]
     while remaining_nodes > 0 {
-      let min_size = min(remaining_nodes + node_counts[i + 1], branching_factor)
+      let min_size = min(remaining_nodes + node_counts[i + 1], BRANCHING_FACTOR)
       node_counts[i] = min_size
       remaining_nodes = remaining_nodes + node_counts[i + 1] - min_size
       i += 1
@@ -568,7 +568,7 @@ fn[A] redis_plan(t : FixedArray[Tree[A]]) -> (FixedArray[Int], Int) {
 /// 
 /// Preconditions:
 /// - forall i in 0..node_nums, old_t[i] != Empty.
-/// - `old_t` contains a list of trees, each of (`shift` / `num_bits`) height.
+/// - `old_t` contains a list of trees, each of (`shift` / `NUM_BITS`) height.
 /// - `node_counts` contains the number of children of each node in `new_t` (the redistributed version of `old_t`).
 /// - `node_nums` is the length of `node_counts`.
 /// 
@@ -661,8 +661,8 @@ fn[A] redis(
         }
         new_t[i] = Node(
           new_node_chldrn,
-          compute_sizes(new_node_chldrn, shift - num_bits),
-        ) // each node in `new_t` is of height (`shift` / `num_bits`)
+          compute_sizes(new_node_chldrn, shift - NUM_BITS),
+        ) // each node in `new_t` is of height (`shift` / `NUM_BITS`)
       }
     }
   }
@@ -670,7 +670,7 @@ fn[A] redis(
 }
 
 ///|
-/// Given a list of trees as `children` with heights of (`shift` / `num_bits`), compute the sizes array of the subtrees.
+/// Given a list of trees as `children` with heights of (`shift` / `NUM_BITS`), compute the sizes array of the subtrees.
 fn[A] compute_sizes(
   children : FixedArray[Tree[A]],
   shift : Int,
@@ -679,7 +679,7 @@ fn[A] compute_sizes(
   let sizes = FixedArray::make(len, 0)
   let mut sum = 0
   let mut flag = true
-  let full_subtree_size = branching_factor << shift
+  let full_subtree_size = BRANCHING_FACTOR << shift
   for i in 0..<len {
     let sz = children[i].size(shift)
     flag = flag && sz == full_subtree_size

--- a/immut/vector/tree_append.mbt
+++ b/immut/vector/tree_append.mbt
@@ -56,7 +56,7 @@ fn[T] Tree::append_right_leaf(
         guard shift == 0 else {
           abort("Unreachable: Leaf should only appear at shift 0")
         }
-        if elems.length() + delta <= branching_factor {
+        if elems.length() + delta <= BRANCHING_FACTOR {
           Some(Leaf(immutable_concat(elems, leaf)))
         } else {
           None
@@ -64,7 +64,7 @@ fn[T] Tree::append_right_leaf(
       }
       Node(nodes, sizes) => {
         let len = nodes.length()
-        match worker(nodes[len - 1], shift - num_bits, leaf, delta) {
+        match worker(nodes[len - 1], shift - NUM_BITS, leaf, delta) {
           Some(new_node) =>
             Some(
               Node(
@@ -73,10 +73,10 @@ fn[T] Tree::append_right_leaf(
               ),
             )
           None =>
-            if len < branching_factor {
+            if len < BRANCHING_FACTOR {
               Some(
                 Node(
-                  immutable_push(nodes, new_branch_left(leaf, shift - num_bits)),
+                  immutable_push(nodes, new_branch_left(leaf, shift - NUM_BITS)),
                   push_sizes_last(sizes, delta),
                 ),
               )
@@ -104,7 +104,7 @@ fn[T] Tree::append_right_leaf(
           Empty =>
             abort("Unreachable: Empty tree should have been handled in worker")
         },
-        shift + num_bits,
+        shift + NUM_BITS,
       )
     }
   }
@@ -127,7 +127,7 @@ fn[T] Tree::concat_with_suffix(
   if left_shift > right_shift {
     let (c, c_shift) = Tree::concat_with_suffix(
       left.right_child(),
-      left_shift - num_bits,
+      left_shift - NUM_BITS,
       suffix,
       right,
       right_shift,
@@ -141,7 +141,7 @@ fn[T] Tree::concat_with_suffix(
       left_shift,
       suffix,
       right.left_child(),
-      right_shift - num_bits,
+      right_shift - NUM_BITS,
       false,
     )
     guard c_shift == right_shift
@@ -154,15 +154,15 @@ fn[T] Tree::concat_with_suffix(
       (new_children[0], 0)
     } else {
       let node = Node(new_children, compute_sizes(new_children, 0))
-      (node, num_bits)
+      (node, NUM_BITS)
     }
   } else {
     let (c, c_shift) = Tree::concat_with_suffix(
       left.right_child(),
-      left_shift - num_bits,
+      left_shift - NUM_BITS,
       suffix,
       right.left_child(),
-      right_shift - num_bits,
+      right_shift - NUM_BITS,
       false,
     )
     guard c_shift == left_shift

--- a/immut/vector/tree_pop.mbt
+++ b/immut/vector/tree_pop.mbt
@@ -30,17 +30,17 @@ fn[A] Tree::pop_rightmost_leaf(self : Tree[A], shift : Int) -> Tree[A] {
     Leaf(_) => Empty
     Node(children, _) => {
       let last_index = children.length() - 1
-      let new_last = children[last_index].pop_rightmost_leaf(shift - num_bits)
+      let new_last = children[last_index].pop_rightmost_leaf(shift - NUM_BITS)
       if new_last is Empty {
         if last_index == 0 {
           Empty
         } else {
           let new_children = immutable_slice(children, 0, last_index)
-          Node(new_children, compute_sizes(new_children, shift - num_bits))
+          Node(new_children, compute_sizes(new_children, shift - NUM_BITS))
         }
       } else {
         let new_children = immutable_set(children, last_index, new_last)
-        Node(new_children, compute_sizes(new_children, shift - num_bits))
+        Node(new_children, compute_sizes(new_children, shift - NUM_BITS))
       }
     }
   }
@@ -52,7 +52,7 @@ fn[A] Tree::shrink_top(self : Tree[A], shift : Int) -> (Tree[A], Int) {
   for tree = self {
     match tree {
       Node(children, _) if current_shift > 0 && children.length() == 1 => {
-        current_shift -= num_bits
+        current_shift -= NUM_BITS
         continue children[0]
       }
       Empty => break (Empty, 0)

--- a/immut/vector/tree_slice.mbt
+++ b/immut/vector/tree_slice.mbt
@@ -22,7 +22,7 @@ fn[A] Tree::slice_right(self : Tree[A], shift : Int, end : Int) -> Tree[A] {
     Empty => Empty
     Leaf(leaf) => Leaf(immutable_slice(leaf, 0, end))
     Node(children, sizes) => {
-      let child_shift = shift - num_bits
+      let child_shift = shift - NUM_BITS
       let child_index = match sizes {
         Some(sizes) => get_branch_index(sizes, end - 1)
         None => radix_indexing(end - 1, shift)
@@ -52,7 +52,7 @@ fn[A] Tree::slice_left(self : Tree[A], shift : Int, start : Int) -> Tree[A] {
     Empty => Empty
     Leaf(leaf) => Leaf(immutable_slice(leaf, start, leaf.length()))
     Node(children, sizes) => {
-      let child_shift = shift - num_bits
+      let child_shift = shift - NUM_BITS
       let child_index = match sizes {
         Some(sizes) => get_branch_index(sizes, start)
         None => radix_indexing(start, shift)

--- a/immut/vector/tree_utils.mbt
+++ b/immut/vector/tree_utils.mbt
@@ -83,7 +83,7 @@ fn[A] Tree::size(self : Tree[A], shift : Int) -> Int {
     Node(_, Some(sizes)) => sizes[sizes.length() - 1]
     Node(children, None) => {
       let len_1 = children.length() - 1
-      (len_1 << shift) + children[len_1].size(shift - num_bits)
+      (len_1 << shift) + children[len_1].size(shift - NUM_BITS)
     }
   }
 }

--- a/immut/vector/tree_utils_wbtest.mbt
+++ b/immut/vector/tree_utils_wbtest.mbt
@@ -110,8 +110,8 @@ test "Tree::size for Node without sizes" {
   let node_tree = Node(FixedArray::from_array([child1, child2]), None)
 
   // This will compute size based on the formula
-  // The calculation: (len_1 << shift) + children[len_1].size(shift - num_bits)
-  // With shift=6 and num_bits=5 (typical for immutable arrays)
+  // The calculation: (len_1 << shift) + children[len_1].size(shift - NUM_BITS)
+  // With shift=6 and NUM_BITS=5 (typical for immutable arrays)
   let result = node_tree.size(6)
   inspect(result >= 3, content="true") // At least the size of the last leaf
 }

--- a/immut/vector/types.mbt
+++ b/immut/vector/types.mbt
@@ -14,9 +14,9 @@
 
 ///|
 /// Invariants:
-/// - `shift` = tree height * `num_bits`. When it is 0, we are at the leaf level.
+/// - `shift` = tree height * `NUM_BITS`. When it is 0, we are at the leaf level.
 /// - `size` = the total number of elements in `tree` and `tail`.
-/// - `tail` stores the right-most chunk and has at most `branching_factor` elements.
+/// - `tail` stores the right-most chunk and has at most `BRANCHING_FACTOR` elements.
 /// - `tree` stores the prefix before `tail`.
 /// - `shift` is not used when `tree` is `Empty`.
 struct Vector[A] {

--- a/immut/vector/utils.mbt
+++ b/immut/vector/utils.mbt
@@ -82,7 +82,7 @@ fn shr_as_uint(x : Int, y : Int) -> Int {
 ///|
 /// Given an index and a shift, return the index of the branch that contains the given index.
 fn radix_indexing(index : Int, shift : Int) -> Int {
-  shr_as_uint(index, shift) & bitmask
+  shr_as_uint(index, shift) & BITMASK
 }
 
 ///|

--- a/immut/vector/utils_wbtest.mbt
+++ b/immut/vector/utils_wbtest.mbt
@@ -110,7 +110,7 @@ fn execute_array_test(rs : Array[Op]) -> Unit raise {
 /// Compute the power of the branching factor.
 fn branching_factor_power(a : Int) -> Int {
   for _ in 0..<a; ret = 1 {
-    continue ret * branching_factor
+    continue ret * BRANCHING_FACTOR
   } nobreak {
     ret
   }

--- a/immut/vector/utils_wbtest2.mbt
+++ b/immut/vector/utils_wbtest2.mbt
@@ -39,7 +39,7 @@ test "shr_as_uint" {
 
 ///|
 test "radix_indexing" {
-  // Assuming bitmask is 31 (0x1F) for 5 bits
+  // Assuming BITMASK is 31 (0x1F) for 5 bits
   inspect(radix_indexing(35, 5), content="1") // 35 >> 5 = 1, 1 & 31 = 1
   inspect(radix_indexing(100, 5), content="3") // 100 >> 5 = 3, 3 & 31 = 3
   inspect(radix_indexing(7, 5), content="0") // 7 >> 5 = 0, 0 & 31 = 0

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -51,8 +51,8 @@ pub fn[A] Vector::make(len : Int, value : A) -> Vector[A] {
     (Tree::empty(), 0)
   } else {
     let leaves = Array::make(
-      tree_len / branching_factor,
-      FixedArray::make(branching_factor, value),
+      tree_len / BRANCHING_FACTOR,
+      FixedArray::make(BRANCHING_FACTOR, value),
     )
     let (shift, cap) = shift_cap_of_size(tree_len)
     (from_leaves(leaves, cap), shift)
@@ -71,11 +71,11 @@ pub fn[A] Vector::makei(len : Int, f : (Int) -> A raise?) -> Vector[A] raise? {
   let (tree, shift) = if tree_len == 0 {
     (Tree::empty(), 0)
   } else {
-    let quot = tree_len / branching_factor
+    let quot = tree_len / BRANCHING_FACTOR
     let leaves : Array[FixedArray[A]] = Array::make(quot, [])
     for k in 0..<quot {
-      leaves[k] = FixedArray::makei(branching_factor, i => {
-        f(k * branching_factor + i)
+      leaves[k] = FixedArray::makei(BRANCHING_FACTOR, i => {
+        f(k * BRANCHING_FACTOR + i)
       })
     }
     let (shift, cap) = shift_cap_of_size(tree_len)
@@ -113,21 +113,21 @@ pub fn[A] Vector::from_iter(iter : Iter[A]) -> Vector[A] {
   let leaves = []
   while iter.next() is Some(x) {
     if index == 0 {
-      buf = FixedArray::make(branching_factor, x)
+      buf = FixedArray::make(BRANCHING_FACTOR, x)
       index += 1
-    } else if index < branching_factor {
+    } else if index < BRANCHING_FACTOR {
       buf[index] = x
       index += 1
     } else {
       leaves.push(buf)
       index = 1
-      buf = FixedArray::make(branching_factor, x)
+      buf = FixedArray::make(BRANCHING_FACTOR, x)
     }
   }
   if index == 0 {
     return new()
   }
-  let tail = if index == branching_factor {
+  let tail = if index == BRANCHING_FACTOR {
     if leaves.is_empty() {
       buf
     } else {
@@ -137,7 +137,7 @@ pub fn[A] Vector::from_iter(iter : Iter[A]) -> Vector[A] {
   } else {
     FixedArray::make_and_blit(buf, allocate_len=index, init=buf[0], len=index)
   }
-  let tree_len = leaves.length() * branching_factor
+  let tree_len = leaves.length() * BRANCHING_FACTOR
   let (tree, shift) = if tree_len == 0 {
     (Tree::empty(), 0)
   } else {
@@ -319,7 +319,7 @@ pub fn[A] Vector::set(self : Vector[A], index : Int, value : A) -> Vector[A] {
 /// }
 /// ```
 pub fn[A] Vector::push(self : Vector[A], value : A) -> Vector[A] {
-  if self.tail.length() < branching_factor {
+  if self.tail.length() < BRANCHING_FACTOR {
     make_t(
       self.tree,
       immutable_push(self.tail, value),
@@ -400,7 +400,7 @@ pub fn[A] Vector::concat(self : Vector[A], other : Vector[A]) -> Vector[A] {
   let size = self.size + other.size
   if other.tree is Empty {
     let combined_tail_len = self.tail.length() + other.tail.length()
-    if combined_tail_len <= branching_factor {
+    if combined_tail_len <= BRANCHING_FACTOR {
       return make_t(
         self.tree,
         immutable_concat(self.tail, other.tail),
@@ -801,20 +801,20 @@ fn[A] make_t(
 
 ///|
 fn[A] from_leaves(leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
-  if cap == branching_factor {
+  if cap == BRANCHING_FACTOR {
     Leaf(leaves[0])
-  } else if leaves.length() <= branching_factor {
+  } else if leaves.length() <= BRANCHING_FACTOR {
     let arr = FixedArray::make(leaves.length(), Empty)
     for i, leaf in leaves {
       arr[i] = Leaf(leaf)
     }
     Node(arr, None)
   } else {
-    let len = leaves.length() * branching_factor
-    let child_cap = cap / branching_factor
+    let len = leaves.length() * BRANCHING_FACTOR
+    let child_cap = cap / BRANCHING_FACTOR
     let quot = len / child_cap
     let rem = len % child_cap
-    let times = child_cap / branching_factor
+    let times = child_cap / BRANCHING_FACTOR
     let arr = if rem == 0 {
       FixedArray::makei(quot, i => {
         from_leaves(leaves[i * times:(i + 1) * times], child_cap)
@@ -833,10 +833,10 @@ fn[A] from_leaves(leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
 
 ///|
 fn tail_len_of_size(size : Int) -> Int {
-  if size <= branching_factor {
+  if size <= BRANCHING_FACTOR {
     size
   } else {
-    let rem = size % branching_factor
+    let rem = size % BRANCHING_FACTOR
     if rem == 0 {
       0
     } else {
@@ -905,9 +905,9 @@ fn[A] Vector::slice_unchecked(
 
 ///|
 fn shift_cap_of_size(size : Int) -> (Int, Int) {
-  for cap = branching_factor, depth = 0; cap < size; {
-    continue cap * branching_factor, depth + 1
+  for cap = BRANCHING_FACTOR, depth = 0; cap < size; {
+    continue cap * BRANCHING_FACTOR, depth + 1
   } nobreak {
-    (num_bits * depth, cap)
+    (NUM_BITS * depth, cap)
   }
 }

--- a/immut/vector/vector_wbtest.mbt
+++ b/immut/vector/vector_wbtest.mbt
@@ -148,7 +148,7 @@ test "mix" {
   inspect(ct1, content="19800")
   inspect(ct2, content="19800")
   inspect(v.tree.is_empty_tree(), content="false")
-  let large_const = branching_factor * branching_factor + 1
+  let large_const = BRANCHING_FACTOR * BRANCHING_FACTOR + 1
   let v = for i in 0..<large_const; v = (new() : Vector[Int]) {
     continue v.push(i)
   } nobreak {
@@ -170,7 +170,7 @@ test "get" {
   inspect(v[0], content=v_content[0].to_string())
   inspect(v[bf - 1], content=v_content[bf - 1].to_string())
   inspect(v[bf / 2], content=v_content[bf / 2].to_string())
-  let bf = branching_factor
+  let bf = BRANCHING_FACTOR
   let v_content = random_array(bf)
   let v = from_iter(v_content.iter())
   inspect(v.length(), content=bf.to_string())
@@ -226,11 +226,11 @@ test "from_iter keeps trailing chunk in tail" {
 
 ///|
 test "push flushes full tail into tree" {
-  let values = from_iter((0).until(branching_factor))
-  let pushed = values.push(branching_factor)
+  let values = from_iter((0).until(BRANCHING_FACTOR))
+  let pushed = values.push(BRANCHING_FACTOR)
   inspect(pushed.tree.is_empty_tree(), content="false")
   inspect(pushed.tail.length(), content="1")
-  inspect(pushed.tail[0], content=branching_factor.to_string())
+  inspect(pushed.tail[0], content=BRANCHING_FACTOR.to_string())
 }
 
 ///|
@@ -260,7 +260,7 @@ test "concat with exact-multiple inputs keeps result tree-only" {
   let right = from_iter((64).until(128))
   let combined = left.concat(right)
   inspect(combined.tree.is_empty_tree(), content="false")
-  @test.assert_eq(combined.shift, num_bits)
+  @test.assert_eq(combined.shift, NUM_BITS)
   @test.assert_eq(combined.tail.length(), 0)
   @test.assert_eq(combined.to_array(), Array::makei(128, i => i))
 }
@@ -271,10 +271,10 @@ test "pop singleton tail promotes previous leaf into tail" {
   let popped = values.pop().unwrap()
   inspect(popped.tree.is_empty_tree(), content="true")
   @test.assert_eq(popped.shift, 0)
-  @test.assert_eq(popped.tail.length(), branching_factor)
+  @test.assert_eq(popped.tail.length(), BRANCHING_FACTOR)
   @test.assert_eq(popped.tail[0], 0)
-  @test.assert_eq(popped.tail[branching_factor - 1], branching_factor - 1)
-  @test.assert_eq(popped.to_array(), Array::makei(branching_factor, i => i))
+  @test.assert_eq(popped.tail[BRANCHING_FACTOR - 1], BRANCHING_FACTOR - 1)
+  @test.assert_eq(popped.to_array(), Array::makei(BRANCHING_FACTOR, i => i))
 }
 
 ///|
@@ -291,14 +291,14 @@ test "pop tree-only suffix promotes partial leaf into tail" {
 
 ///|
 test "pop shrinks top after removing last branch" {
-  let size = branching_factor * branching_factor + branching_factor + 1
+  let size = BRANCHING_FACTOR * BRANCHING_FACTOR + BRANCHING_FACTOR + 1
   let values = from_iter((0).until(size))
   let popped = values.pop().unwrap()
   @test.assert_eq(popped.length(), size - 1)
-  @test.assert_eq(popped.shift, num_bits)
-  @test.assert_eq(popped.tail.length(), branching_factor)
-  @test.assert_eq(popped.tail[0], branching_factor * branching_factor)
-  @test.assert_eq(popped.tail[branching_factor - 1], size - 2)
+  @test.assert_eq(popped.shift, NUM_BITS)
+  @test.assert_eq(popped.tail.length(), BRANCHING_FACTOR)
+  @test.assert_eq(popped.tail[0], BRANCHING_FACTOR * BRANCHING_FACTOR)
+  @test.assert_eq(popped.tail[BRANCHING_FACTOR - 1], size - 2)
   @test.assert_eq(popped.to_array(), Array::makei(size - 1, i => i))
 }
 


### PR DESCRIPTION
## Summary

Scanned the repo for top-level `let` bindings that are compile-time primitive constants and would benefit from being `const`, so the backend can constant-propagate / strength-reduce instead of loading a runtime global. This PR applies the highest-value, self-contained case: the RRB-tree radix constants in `immut/array` and `immut/vector`.

- `num_bits` → `NUM_BITS`, `branching_factor` → `BRANCHING_FACTOR`, `bitmask` → `BITMASK` in both (twin) packages. `BRANCHING_FACTOR = 1 << NUM_BITS = 32`, a power of two.
- As `const`, the divisor in the `len / BRANCHING_FACTOR` and `len % BRANCHING_FACTOR` sites (`array.mbt` / `vector.mbt` construction & rebalance paths; operands are non-negative lengths/capacities) is a compile-time constant the backend can strength-reduce. The per-element get/set path already used `& BITMASK` + shifts and is unchanged.
- Package-private bindings: **no public API / `.mbti` change**. Pure rename + `let`→`const`; no value changes. The `branching_factor_power` test helper keeps its name.

Honest note: as with #3681, on optimizing native release builds moonc likely already folds these `let` globals, so the measurable win is marginal; the change makes the source not rely on the optimizer and matches the UPPER_CASE `const` idiom already used across core (strconv, encoding/base64, regex, …).

## Other const candidates found (left out to keep this focused)

The scan surfaced more top-level constant `let`s that could move to `const` as follow-ups, e.g. `quickcheck/splitmix` `golden_gamma`; `builtin/double_round.mbt` & `float/round.mbt` `sign_mask`/`exp_bias`/`exp_bits`/`frac_bits`; `builtin/double_ryu_nonjs.mbt` `gDOUBLE_*`/`gPOW5_TABLE_SIZE`; `math/exp.mbt` & `math/log.mbt` table-size constants; `internal/strconv` / `strconv` fast-path thresholds. Happy to follow up.

## Test results

- `moon check` (whole project): clean
- `moon test`: `immut/array` 105/105 and `immut/vector` 124/124 on wasm, wasm-gc, js; native 96/96 and 117/117 — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
