### PR TITLE
fix(json): reject backtick as hex digit in \u escapes

### DIFF
--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -90,8 +90,10 @@ fn ParseContext::lex_hex_digits(
     match ctx.read_char() {
       Some(c) =>
         if c >= 'A' {
+          // Case-folding maps '`' (0x60) to '@' (0x40), i.e. d == 9, so
+          // reject anything outside the letter range 'A'..'F' (10..15).
           let d = (c.to_int() & (32).lnot()) - 'A'.to_int() + 10
-          if d > 15 {
+          if d < 10 || d > 15 {
             ctx.invalid_char(shift=-1)
           }
           continue (r << 4) | d

--- a/json/lex_string_test.mbt
+++ b/json/lex_string_test.mbt
@@ -31,3 +31,17 @@ test "lex_hex_digits incomplete hex digits" {
     ),
   )
 }
+
+///|
+test "lex_hex_digits rejects backtick as hex digit" {
+  // '`' (0x60) case-folds to '@' (0x40) via `c & ~32`, yielding d == 9,
+  // so "\u`bcd" is accepted as U+9BCD instead of raising. This test
+  // asserts the desired InvalidChar and FAILS on the current lexer,
+  // pinning down the bug before the fix.
+  debug_inspect(
+    expect_parse_error("\"\\u`bcd\"", "expected InvalidChar"),
+    content=(
+      #|InvalidChar({ line: 1, column: 3 }, '`')
+    ),
+  )
+}

--- a/json/lex_string_test.mbt
+++ b/json/lex_string_test.mbt
@@ -33,15 +33,47 @@ test "lex_hex_digits incomplete hex digits" {
 }
 
 ///|
-test "lex_hex_digits rejects backtick as hex digit" {
-  // '`' (0x60) case-folds to '@' (0x40) via `c & ~32`, yielding d == 9,
-  // so "\u`bcd" is accepted as U+9BCD instead of raising. This test
-  // asserts the desired InvalidChar and FAILS on the current lexer,
-  // pinning down the bug before the fix.
+test "lex_hex_digits rejects non-hex characters near the letter range" {
+  // '`' (0x60) case-folds to '@' (0x40) and was previously accepted as
+  // hex digit 9, so "\u`bcd" parsed as U+9BCD instead of raising.
   debug_inspect(
     expect_parse_error("\"\\u`bcd\"", "expected InvalidChar"),
     content=(
       #|InvalidChar({ line: 1, column: 3 }, '`')
+    ),
+  )
+  debug_inspect(
+    expect_parse_error("\"\\u@bcd\"", "expected InvalidChar"),
+    content=(
+      #|InvalidChar({ line: 1, column: 3 }, '@')
+    ),
+  )
+  debug_inspect(
+    expect_parse_error("\"\\u1G23\"", "expected InvalidChar"),
+    content=(
+      #|InvalidChar({ line: 1, column: 4 }, 'G')
+    ),
+  )
+  debug_inspect(
+    expect_parse_error("\"\\u1g23\"", "expected InvalidChar"),
+    content=(
+      #|InvalidChar({ line: 1, column: 4 }, 'g')
+    ),
+  )
+}
+
+///|
+test "lex_hex_digits accepts all hex digit ranges" {
+  debug_inspect(
+    @json.parse("\"\\u09aF\""),
+    content=(
+      #|String("য")
+    ),
+  )
+  debug_inspect(
+    @json.parse("\"\\uAbfa\""),
+    content=(
+      #|String("꯺")
     ),
   )
 }


### PR DESCRIPTION
## Summary

`@json.parse` accepts backtick as hex digit 9 in `\uXXXX` escapes: the invalid JSON `"\u`bcd"` parses successfully to `"\u{9BCD}"` (`"鯍"`) instead of raising `ParseError`.

The hex letter branch of `ParseContext::lex_hex_digits` case-folds with `c & ~32` and only checks the upper bound:

```moonbit
let d = (c.to_int() & (32).lnot()) - 'A'.to_int() + 10
if d > 15 { ctx.invalid_char(shift=-1) }
```

Backtick (0x60) folds to `'@'` (0x40), yielding `d == 9`, which passes `d > 15`. It is the only character in the codespace with this property (0x41–0x5F fold to themselves; of 0x60–0x7F only 0x60 lands below `'A'` after folding). Fix: also reject `d < 10`, since every valid letter digit folds into 10–15.

## Relationship to #3678

This is the same fix as #3678, restructured into a clean **3-commit, test-driven** history:

1. **`test`** — add the regression test asserting `InvalidChar` for `` \u`bcd ``. It is **red** against current `main` (the invalid input parses), pinning down the bug.
2. **`fix`** — add the `d < 10` lower bound; turns the failing test green.
3. **`test`** — broaden coverage: `\u@bcd`, `\u1G23`, `\u1g23` rejections plus positive boundary tests that all valid hex ranges (`0-9`, `a-f`, `A-F`) still parse.

No public API change (`pkg.generated.mbti` untouched).

## Testing

- `moon test json` — 174/174 passing
- `moon fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
