### PR TITLE
refactor(json): rewrite lex_hex_digits with char-range patterns

### DIFF
--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -87,27 +87,14 @@ fn ParseContext::lex_hex_digits(
   n : Int,
 ) -> Int raise ParseError {
   for _ in 0..<n; r = 0 {
-    match ctx.read_char() {
-      Some(c) =>
-        if c >= 'A' {
-          // Case-folding maps '`' (0x60) to '@' (0x40), i.e. d == 9, so
-          // reject anything outside the letter range 'A'..'F' (10..15).
-          let d = (c.to_int() & (32).lnot()) - 'A'.to_int() + 10
-          if d < 10 || d > 15 {
-            ctx.invalid_char(shift=-1)
-          }
-          continue (r << 4) | d
-        } else if c >= '0' {
-          let d = c.to_int() - '0'.to_int()
-          if d > 9 {
-            ctx.invalid_char(shift=-1)
-          }
-          continue (r << 4) | d
-        } else {
-          ctx.invalid_char(shift=-1)
-        }
+    let d = match ctx.read_char() {
+      Some('0'..='9' as c) => c.to_int() - '0'
+      Some('A'..='F' as c) => c.to_int() - 'A' + 10
+      Some('a'..='f' as c) => c.to_int() - 'a' + 10
+      Some(_) => ctx.invalid_char(shift=-1)
       None => raise InvalidEof
     }
+    continue (r << 4) | d
   } nobreak {
     r
   }


### PR DESCRIPTION
## Summary

Follow-up refactor on top of the backtick fix (#3704, now merged). Rewrite `ParseContext::lex_hex_digits` using direct char-range match arms instead of the case-folding bit trick:

```moonbit
let d = match ctx.read_char() {
  Some('0'..='9' as c) => c.to_int() - '0'
  Some('A'..='F' as c) => c.to_int() - 'A' + 10
  Some('a'..='f' as c) => c.to_int() - 'a' + 10
  Some(_) => ctx.invalid_char(shift=-1)
  None => raise InvalidEof
}
continue (r << 4) | d
```

The merged fix added a `d < 10` lower bound to guard the `c & ~32` case-folding. This rewrite removes the folding mechanism entirely: the **pattern itself** is the validity check, the `(32).lnot()` magic constant is gone, and the redundant `.to_int()` on char literals is dropped (they overload to `Int` in the arithmetic context). The backtick-as-hex-digit bug becomes structurally impossible rather than guarded.

## Scope

- Pure refactor: no behavior change, `pkg.generated.mbti` untouched.
- The regression + boundary tests merged with #3704 still pass unchanged (no test edits in this PR).

## Tradeoff

The original folded upper/lowercase into a single branch for speed; this has three range arms (worst case ~6 comparisons, for lowercase `a-f`). This is the `\uXXXX`-escape path, not the JSON hot loop, so clarity + structural correctness wins. Happy to restore the folded single-branch form if perf on this path matters.

## Testing

- `moon test json` — 174/174 passing
- `moon check json --target all` — clean (only pre-existing unrelated `missing_doc` warnings) / `moon fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
