### PR TITLE
refactor(json): use char-range/equality patterns in number + string lexers

### DIFF
--- a/json/lex_main.mbt
+++ b/json/lex_main.mbt
@@ -52,13 +52,11 @@ fn ParseContext::lex_value(
           let (n, repr) = ctx.lex_zero(start=ctx.offset - 2)
           return Number(n, repr.map(repr => repr.to_owned()))
         }
-        Some(c2) => {
-          if c2 is ('1'..='9') {
-            let (n, repr) = ctx.lex_decimal_integer(start=ctx.offset - 2)
-            return Number(n, repr.map(repr => repr.to_owned()))
-          }
-          ctx.invalid_char(shift=-1)
+        Some('1'..='9') => {
+          let (n, repr) = ctx.lex_decimal_integer(start=ctx.offset - 2)
+          return Number(n, repr.map(repr => repr.to_owned()))
         }
+        Some(_) => ctx.invalid_char(shift=-1)
         None => raise InvalidEof
       }
     Some('0') => {

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -237,10 +237,8 @@ fn ParseContext::lex_decimal_integer(
     match ctx.read_char() {
       Some('.') => return ctx.lex_decimal_point(start~)
       Some('e' | 'E') => return ctx.lex_decimal_exponent(start~)
-      Some(c) => {
-        if c is ('0'..='9') {
-          continue
-        }
+      Some('0'..='9') => continue
+      Some(_) => {
         ctx.offset -= 1
         return ctx.lex_number_end(start, ctx.offset)
       }
@@ -255,12 +253,8 @@ fn ParseContext::lex_decimal_point(
   start~ : Int,
 ) -> (Double, StringView?) raise ParseError {
   match ctx.read_char() {
-    Some(c) =>
-      if c is ('0'..='9') {
-        ctx.lex_decimal_fraction(start~)
-      } else {
-        ctx.invalid_char(shift=-1)
-      }
+    Some('0'..='9') => ctx.lex_decimal_fraction(start~)
+    Some(_) => ctx.invalid_char(shift=-1)
     None => raise InvalidEof
   }
 }
@@ -273,10 +267,8 @@ fn ParseContext::lex_decimal_fraction(
   for ;; {
     match ctx.read_char() {
       Some('e' | 'E') => return ctx.lex_decimal_exponent(start~)
-      Some(c) => {
-        if c is ('0'..='9') {
-          continue
-        }
+      Some('0'..='9') => continue
+      Some(_) => {
         ctx.offset -= 1
         return ctx.lex_number_end(start, ctx.offset)
       }
@@ -291,11 +283,9 @@ fn ParseContext::lex_decimal_exponent(
   start~ : Int,
 ) -> (Double, StringView?) raise ParseError {
   match ctx.read_char() {
-    Some('+') | Some('-') => return ctx.lex_decimal_exponent_sign(start~)
-    Some(c) => {
-      if c is ('0'..='9') {
-        return ctx.lex_decimal_exponent_integer(start~)
-      }
+    Some('+' | '-') => return ctx.lex_decimal_exponent_sign(start~)
+    Some('0'..='9') => return ctx.lex_decimal_exponent_integer(start~)
+    Some(_) => {
       ctx.offset -= 1
       ctx.invalid_char()
     }
@@ -309,10 +299,8 @@ fn ParseContext::lex_decimal_exponent_sign(
   start~ : Int,
 ) -> (Double, StringView?) raise ParseError {
   match ctx.read_char() {
-    Some(c) => {
-      if c is ('0'..='9') {
-        return ctx.lex_decimal_exponent_integer(start~)
-      }
+    Some('0'..='9') => return ctx.lex_decimal_exponent_integer(start~)
+    Some(_) => {
       ctx.offset -= 1
       ctx.invalid_char()
     }
@@ -327,10 +315,8 @@ fn ParseContext::lex_decimal_exponent_integer(
 ) -> (Double, StringView?) {
   for ;; {
     match ctx.read_char() {
-      Some(c) => {
-        if c is ('0'..='9') {
-          continue
-        }
+      Some('0'..='9') => continue
+      Some(_) => {
         ctx.offset -= 1
         return ctx.lex_number_end(start, ctx.offset)
       }
@@ -347,11 +333,11 @@ fn ParseContext::lex_zero(
   match ctx.read_char() {
     Some('.') => ctx.lex_decimal_point(start~)
     Some('e' | 'E') => ctx.lex_decimal_exponent(start~)
-    Some(c) => {
-      if c is ('0'..='9') {
-        ctx.offset -= 1
-        ctx.invalid_char()
-      }
+    Some('0'..='9') => {
+      ctx.offset -= 1
+      ctx.invalid_char()
+    }
+    Some(_) => {
       ctx.offset -= 1
       return ctx.lex_number_end(start, ctx.offset)
     }

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -24,7 +24,9 @@ fn ParseContext::lex_string(ctx : ParseContext) -> String raise ParseError {
       return ctx.input.view(start_offset=string_start, end_offset=i).to_owned()
     } else if c == '\\' {
       return ctx.lex_string_slow()
-    } else if c == '\n' || c == '\r' || c < ' ' {
+    } else if c < ' ' {
+      // Unescaped control characters (U+0000..U+001F, including \n, \r,
+      // \t) are invalid inside a JSON string.
       ctx.offset = i + 1
       ctx.invalid_char(shift=-1)
     }
@@ -48,7 +50,6 @@ fn ParseContext::lex_string_slow(ctx : ParseContext) -> String raise ParseError 
         flush(ctx.offset - 1)
         break
       }
-      Some('\n' | '\r') => ctx.invalid_char(shift=-1)
       Some('\\') => {
         flush(ctx.offset - 1)
         match ctx.read_char() {

--- a/json/lex_string_test.mbt
+++ b/json/lex_string_test.mbt
@@ -23,6 +23,18 @@ test "lex_string with forward slash escape" {
 }
 
 ///|
+test "lex_string_slow rejects raw control char after an escape" {
+  // A valid '\t' escape switches lexing to the slow path; the following
+  // raw newline must still be rejected by the control-char check.
+  debug_inspect(
+    expect_parse_error("\"\\t\nbreak\"", "expected InvalidChar"),
+    content=(
+      #|InvalidChar({ line: 1, column: 3 }, '\n')
+    ),
+  )
+}
+
+///|
 test "lex_hex_digits incomplete hex digits" {
   debug_inspect(
     expect_parse_error("\"\\u123", "expected InvalidEof"),


### PR DESCRIPTION
## Summary

Follow-up cleanup to #3705, applying the same "let the pattern be the check" idea across the rest of the JSON lexer. Two behavior-preserving refactors:

### 1. Match digit ranges directly in the number lexer
The number lexer repeatedly did `Some(c) => if c is ('0'..='9') { ... }`. Fold the range into the match pattern (`Some('0'..='9') => ...`) across `lex_decimal_integer`, `lex_decimal_point`, `lex_decimal_fraction`, `lex_decimal_exponent`, `lex_decimal_exponent_sign`, `lex_decimal_exponent_integer`, `lex_zero`, and the `'1'..='9'` arm in `lex_value`. These arms don't use the digit's value (accumulation happens in `scan_json_number`), so no binding is needed. Also merges `Some('+') | Some('-')` → `Some('+' | '-')`.

### 2. Drop redundant control-char checks in `lex_string`
Two spots named `'\n'`/`'\r'` explicitly even though the general control-char guard already covers them:
- Fast path: `c == '\n' || c == '\r' || c < ' '` is just `c < ' '` (both 0x0A and 0x0D are `< ' '` = 0x20).
- Slow path: the `Some('\n' | '\r') => invalid_char(shift=-1)` arm is subsumed by the catch-all `Some(ch) => if ch.to_int() < 32 { ... }`.

Added a slow-path regression test (raw newline after a valid `\t` escape), since that branch was previously only reached via the now-removed explicit arm.

## Scope
- Pure refactor: no behavior change, `pkg.generated.mbti` untouched.
- Independent of #3705 (different functions) — they touch `lex_string.mbt` in non-overlapping places.

## Testing
- `moon test json` — 175/175 passing (added 1 regression test)
- `moon check json --target all` — 0 errors / `moon fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
