### PR TITLE
refactor(json): use match in the hot number-scan and whitespace loops

### DIFF
--- a/json/lex_misc.mbt
+++ b/json/lex_misc.mbt
@@ -138,11 +138,9 @@ fn ParseContext::lex_skip_whitespace(ctx : ParseContext) -> Unit {
     if offset >= end {
       break offset
     }
-    let c = ctx.input.unsafe_get(offset)
-    if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
-      continue offset + 1
-    } else {
-      break offset
+    match ctx.input.unsafe_get(offset) {
+      ' ' | '\t' | '\r' | '\n' => continue offset + 1
+      _ => break offset
     }
   }
 }

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -151,41 +151,43 @@ fn ParseContext::scan_json_number(
   let mut significant_digits = 0
   let mut seen_nonzero = false
   for i = (if negative { start + 1 } else { start }); i < end; i = i + 1 {
-    let c = ctx.input.unsafe_get(i)
-    if c is ('0'..='9') {
-      let digit = c.to_int() - '0'
-      if has_exponent {
-        if exponent_part < EXPONENT_CAP {
-          let next_exponent = exponent_part * 10L + digit.to_int64()
-          exponent_part = if next_exponent > EXPONENT_CAP {
-            EXPONENT_CAP
-          } else {
-            next_exponent
+    match ctx.input.unsafe_get(i) {
+      '0'..='9' as c => {
+        let digit = c.to_int() - '0'
+        if has_exponent {
+          if exponent_part < EXPONENT_CAP {
+            let next_exponent = exponent_part * 10L + digit.to_int64()
+            exponent_part = if next_exponent > EXPONENT_CAP {
+              EXPONENT_CAP
+            } else {
+              next_exponent
+            }
           }
-        }
-      } else {
-        if has_decimal {
-          fractional_digits += 1
-        }
-        if digit != 0 || seen_nonzero {
-          seen_nonzero = true
-          significant_digits += 1
-          if significant_digits <= 19 {
-            mantissa = mantissa * 10UL +
-              UInt64::extend_uint(digit.reinterpret_as_uint())
+        } else {
+          if has_decimal {
+            fractional_digits += 1
+          }
+          if digit != 0 || seen_nonzero {
+            seen_nonzero = true
+            significant_digits += 1
+            if significant_digits <= 19 {
+              mantissa = mantissa * 10UL +
+                UInt64::extend_uint(digit.reinterpret_as_uint())
+            }
           }
         }
       }
-    } else if c == '.' {
-      has_decimal = true
-    } else if c == 'e' || c == 'E' {
-      has_exponent = true
-      if i + 1 < end {
-        let next = ctx.input.unsafe_get(i + 1)
-        if next == '-' {
-          exponent_negative = true
+      '.' => has_decimal = true
+      'e' | 'E' => {
+        has_exponent = true
+        if i + 1 < end {
+          let next = ctx.input.unsafe_get(i + 1)
+          if next == '-' {
+            exponent_negative = true
+          }
         }
       }
+      _ => ()
     }
   }
   let exponent_part = if exponent_negative {


### PR DESCRIPTION
## Summary

Group C of the JSON-lexer pattern cleanups (follow-up to #3705 / #3706): convert the two remaining char `if`/`else if` cascades — both on the parse hot path — to `match`.

- **`scan_json_number`**: `if c is ('0'..='9') { … } else if c == '.' { … } else if c == 'e' || c == 'E' { … }` → `match` with `'0'..='9' as c`, `'.'`, and `'e' | 'E'` arms (digit case still checked first).
- **`lex_skip_whitespace`**: `c == ' ' || c == '\t' || c == '\r' || c == '\n'` → a `' ' | '\t' | '\r' | '\n'` match arm.

## Benchmark (this is why Group C was held back)

These sit on the hot path, so I measured before/after with `moon bench -p json --target native --release` (n=1000 mixed object/array), including an **interleaved A/B** to control for thermal drift:

| | mean |
|---|---|
| baseline (main) | ~0.98–1.02 ms |
| after (this PR) | ~0.95–0.96 ms |

The `match` form is **neutral-to-slightly-faster, never slower** — one interleaved block showed ~5% (1.00 ms → 0.95 ms), another showed parity. So no regression; readability is the real win.

## Scope
- Pure refactor: no behavior change, `pkg.generated.mbti` untouched.
- `moon test json` — 175/175 passing; `moon check --target all` clean; `moon fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
