### PR TITLE
perf(strconv): skip underscore validation scan when none present

### DIFF
--- a/internal/strconv/strconv_int.mbt
+++ b/internal/strconv/strconv_int.mbt
@@ -158,6 +158,11 @@ pub fn parse_int(str : StringView, base? : Int = 0) -> Int raise {
 
 ///|
 fn check_underscore(str : StringView) -> Bool {
+  // Fast path: underscores are rare in practice. Without any underscore the
+  // per-character scan below can never reach a `break false` arm (those all
+  // require a preceding underscore), so validation always succeeds. Probe the
+  // raw code units once (no sub-view allocation) and skip the loop entirely.
+  guard str.contains_code_unit(('_' : UInt16)) else { return true }
   // skip the sign
   let rest = match str {
     ['+' | '-', .. rest] => rest


### PR DESCRIPTION
## Motivation

Profiling `parse_double` (native, Time Profiler) on plain numeric inputs
showed **~37% of self time in `check_underscore`** — a validation pass that
runs on *every* call before parsing, even when the input contains no
underscore at all. Each `.. rest` slice in its `StringView` match also churns
reference counts.

## Change

`check_underscore` walks the whole string with a multi-arm match to validate
underscore placement. Without any underscore present the scan can never reach
a `break false` arm (they all require a preceding underscore), so the result
is always `true`. Probe the raw code units once with `contains_code_unit`
(a tight loop, no sub-view allocation) and skip the match loop entirely in
that common case.

This is the single call site of `check_underscore` (`parse_double`).

## Benchmark

`internal/strconv/parse_double_bench_test.mbt`, native:

| case | before | after | |
|---|---|---|---|
| fast digits, n=4096 | 137.8 µs | **107.4 µs** | ~22% faster |
| underscores, n=4096 | 170.1 µs | 170.5 µs | unchanged |

Inputs that actually contain underscores are unaffected (they still run the
full validation); only the no-underscore fast path is sped up.

## Validation

`moon test -p internal/strconv` passes on native and js (25/25 each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
