### PR TITLE
perf(bigint): build to_string digits in one pass instead of prepending

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1047,7 +1047,7 @@ pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
   let chars = FixedArray::make(cap, '0')
   let mut pos = cap
   // Lower slots each contribute exactly `decimal_radix_bit_len` digits,
-  // zero-padded (leading zeros fall out of `char_from_digit(0)`).
+  // zero-padded (the most-significant slot is handled separately to avoid leading zeros).
   for i in 0..<(v_idx - 1) {
     let mut x = v[i]
     for _ in 0..<decimal_radix_bit_len {

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1025,7 +1025,6 @@ pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
     decimal_radix_bit_len.to_double() +
     1,
   )
-  let s = if self.sign == Negative { "-" } else { "" }
   let v = Array::make(decimal_len, 0L)
   let mut v_idx = 0
   for i in self.len>..0 {
@@ -1041,21 +1040,33 @@ pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
       x /= decimal_mask
     }
   }
-  let mut ret = ""
+  // Materialize the decimal digits into a pre-sized buffer, filling from the
+  // least-significant end, so the result is built with a single allocation
+  // instead of the O(n^2) prepending string concatenations this used to do.
+  let cap = v_idx * decimal_radix_bit_len + 1 // +1 for an optional sign
+  let chars = FixedArray::make(cap, '0')
+  let mut pos = cap
+  // Lower slots each contribute exactly `decimal_radix_bit_len` digits,
+  // zero-padded (leading zeros fall out of `char_from_digit(0)`).
   for i in 0..<(v_idx - 1) {
+    let mut x = v[i]
     for _ in 0..<decimal_radix_bit_len {
-      let x = v[i] % 10L
-      v[i] /= 10L
-      ret = x.to_string() + ret
+      pos -= 1
+      chars[pos] = char_from_digit((x % 10L).to_int())
+      x /= 10L
     }
   }
-  let ret = for x = v[v_idx - 1], ret = ret; x > 0L; { // v_idx is at least 1, we check is_zero() at the beginning.
-    let y = x % 10L
-    continue x / 10L, y.to_string() + ret
-  } nobreak {
-    ret
+  // The most-significant slot is emitted without leading zeros. `v_idx >= 1`
+  // and the top slot is non-zero (guarded by the is_zero() check above).
+  for x = v[v_idx - 1]; x > 0L; x = x / 10L {
+    pos -= 1
+    chars[pos] = char_from_digit((x % 10L).to_int())
   }
-  s + ret
+  if self.sign == Negative {
+    pos -= 1
+    chars[pos] = '-'
+  }
+  String::from_array(chars[pos:])
 }
 
 ///|

--- a/bigint/moon.pkg
+++ b/bigint/moon.pkg
@@ -11,6 +11,10 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
+} for "test"
+
+import {
   "moonbitlang/core/test",
 } for "wbtest"
 

--- a/bigint/to_string_bench_test.mbt
+++ b/bigint/to_string_bench_test.mbt
@@ -1,0 +1,44 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Builds a BigInt whose base-10 representation has exactly `digits` digits
+/// (a leading 1 followed by repeated 9s), so `to_string` cost scales with the
+/// requested width.
+fn make_decimal(digits : Int) -> @bigint.BigInt {
+  let buf = StringBuilder(size_hint=digits)
+  buf.write_char('1')
+  for _ in 1..<digits {
+    buf.write_char('9')
+  }
+  @bigint.BigInt::from_string(buf.to_string())
+}
+
+///|
+test "bench BigInt::to_string n=40 digits" (it : @bench.T) {
+  let n = make_decimal(40)
+  it.bench(fn() { it.keep(n.to_string()) })
+}
+
+///|
+test "bench BigInt::to_string n=400 digits" (it : @bench.T) {
+  let n = make_decimal(400)
+  it.bench(fn() { it.keep(n.to_string()) })
+}
+
+///|
+test "bench BigInt::to_string n=4000 digits" (it : @bench.T) {
+  let n = make_decimal(4000)
+  it.bench(fn() { it.keep(n.to_string()) })
+}

--- a/bigint/to_string_bench_test.mbt
+++ b/bigint/to_string_bench_test.mbt
@@ -17,6 +17,7 @@
 /// (a leading 1 followed by repeated 9s), so `to_string` cost scales with the
 /// requested width.
 fn make_decimal(digits : Int) -> @bigint.BigInt {
+  guard digits >= 1 else { abort("make_decimal: digits must be >= 1") }
   let buf = StringBuilder(size_hint=digits)
   buf.write_char('1')
   for _ in 1..<digits {


### PR DESCRIPTION
## Motivation

Profiling `BigInt::to_string` (native, Time Profiler) showed the digit-emission
phase dominated by string allocation: `moonbit_add_string` and per-digit
`moonbit_make_string`. The cause is this loop:

```mbt
ret = digit.to_string() + ret
```

It prepends each decimal digit into a freshly allocated string, which is
**quadratic in the digit count** and allocates a one-char string plus a full
copy of the accumulator per digit.

## Change

Emit the digits least-significant-first into a pre-sized `FixedArray[Char]`
and materialize the result string once with `String::from_array`.

Note: the limb→decimal base-conversion loop above this (`for i in self.len>..0
{ for j in 0..<v_idx { ... } }`) is a *separate* O(n²) cost and is left
untouched here — this PR only removes the quadratic **string building** in the
digit-emission phase.

## Benchmark

New `bigint/to_string_bench_test.mbt`, native:

| digits | before | after | |
|---|---|---|---|
| 40 | 649.9 ns | **148.1 ns** | 4.4x |
| 400 | 9.73 µs | **2.76 µs** | 3.5x |
| 4000 | 410.4 µs | **194.5 µs** | 2.1x |

(The gain shrinks at very large widths because the untouched base-conversion
loop becomes the dominant term there.)

## Validation

`moon test -p bigint` passes on native, wasm-gc (494/494) and js (466/466,
unaffected — the js backend uses a separate `to_string` in `bigint_js.mbt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
