### PR TITLE
Optimize bytes find

### DIFF
--- a/builtin/bytes_find.mbt
+++ b/builtin/bytes_find.mbt
@@ -13,28 +13,347 @@
 // limitations under the License.
 
 ///|
-/// Returns the offset of the first occurrence of the given
-/// bytes substring. If the substring is not found, `None` is returned.
+let find_max_short_pattern : Int = 32
+
+///|
+let find_max_bruteforce : Int = 64
+
+///|
+let find_prime_rk : UInt = 16777619U
+
+///|
+/// Returns the offset of the first occurrence of the given bytes substring.
+///
+/// If the substring is not found, `None` is returned.
 pub fn BytesView::find(target : BytesView, pattern : BytesView) -> Int? {
-  // TODO: more efficient algorithm
+  find_index(target, pattern)
+}
+
+///|
+/// Returns the offset of the first occurrence of the given bytes substring.
+///
+/// If the substring is not found, `None` is returned.
+pub fn Bytes::find(target : Bytes, pattern : BytesView) -> Int? {
+  target[:].find(pattern)
+}
+
+///|
+// Handle trivial cases first, use the short-pattern scanner when the pattern is
+// small, then use the guarded long-pattern scanner.
+fn find_index(target : BytesView, pattern : BytesView) -> Int? {
   let target_len = target.length()
   let pattern_len = pattern.length()
-  for i in 0..<=(target_len - pattern_len) {
-    for j in 0..<pattern_len {
-      guard target.unsafe_get(i + j) == pattern.unsafe_get(j) else { break }
-    } nobreak {
-      return Some(i)
+  if pattern_len == 0 {
+    return Some(0)
+  }
+  if pattern_len > target_len {
+    return None
+  }
+  if pattern_len == 1 {
+    let found = find_byte_from_view(
+      target,
+      0,
+      target_len,
+      pattern.unsafe_get(0),
+    )
+    if found < 0 {
+      None
+    } else {
+      Some(found)
     }
+  } else if pattern_len == target_len {
+    if find_match_range(target, pattern, 0, 0, pattern_len) {
+      Some(0)
+    } else {
+      None
+    }
+  } else if pattern_len <= find_max_short_pattern {
+    find_short(target, pattern)
+  } else {
+    find_long_by_byte_scanner(target, pattern)
+  }
+}
+
+///|
+// Number of failed first-byte candidates tolerated before the long scanner
+// switches to Rabin-Karp. This keeps dense false positives linear-time.
+#inline
+fn find_cutover(i : Int) -> Int {
+  4 + i / 16
+}
+
+///|
+#inline
+fn find_match_range(
+  target : BytesView,
+  pattern : BytesView,
+  candidate : Int,
+  start : Int,
+  end : Int,
+) -> Bool {
+  // Some callers already check the full requested range.
+  if start >= end {
+    return true
+  }
+  // `candidate`, `start`, and `end` are relative to the views. Convert both
+  // sides to offsets in their backing `Bytes` before comparing.
+  target
+  .data()
+  .unsafe_range_equal(
+    target.start_offset() + candidate + start,
+    pattern.data(),
+    pattern.start_offset() + start,
+    end - start,
+  )
+}
+
+///|
+// Scalar byte scanner for backends without direct linear-memory vector loads.
+#cfg(any(target="js", target="wasm-gc"))
+fn find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  for pos in start..<end {
+    if target.unsafe_get(pos) == byte {
+      break pos
+    }
+  } nobreak {
+    -1
+  }
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn Bytes::v128_load(self : Bytes, offset : Int) -> V128 {
+  v128_load(unsafe_from_bytes(self), offset)
+}
+
+///|
+// SIMD byte scanner for linear-memory backends. The vector loop scans 16 bytes
+// at a time, then the scalar tail handles the remaining bytes.
+#cfg(any(target="native", target="wasm"))
+fn find_byte_from_bytes(
+  data : Bytes,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  let byte_v = i8x16_splat(byte)
+  let tail_start = for pos = start; pos + 16 <= end; {
+    let mask = i8x16_bitmask(i8x16_eq(data.v128_load(pos), byte_v))
+    if mask != 0 {
+      return pos + mask.ctz()
+    }
+    continue pos + 16
+  } nobreak {
+    pos
+  }
+  for pos in tail_start..<end {
+    if data.unsafe_get(pos) == byte {
+      break pos
+    }
+  } nobreak {
+    -1
+  }
+}
+
+///|
+// Convert view-relative bounds to backing `Bytes` offsets before scanning.
+#cfg(any(target="native", target="wasm"))
+fn find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  let target_start = target.start_offset()
+  let found = find_byte_from_bytes(
+    target.data(),
+    target_start + start,
+    target_start + end,
+    byte,
+  )
+  if found < 0 {
+    -1
+  } else {
+    found - target_start
+  }
+}
+
+///|
+// Scalar short-pattern scanner: find matches for the last byte, then verify
+// the unchecked prefix range for each candidate.
+#cfg(any(target="js", target="wasm-gc"))
+fn find_short(target : BytesView, pattern : BytesView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let last_offset = pattern_len - 1
+  let last_byte = pattern.unsafe_get(last_offset)
+  for anchor_pos = last_offset; anchor_pos < target_len; {
+    let found = find_byte_from_view(target, anchor_pos, target_len, last_byte)
+    if found < 0 {
+      break None
+    }
+    let candidate = found - last_offset
+    if find_match_range(target, pattern, candidate, 0, last_offset) {
+      break Some(candidate)
+    }
+    continue found + 1
   } nobreak {
     None
   }
 }
 
 ///|
-/// Returns the offset of the first occurrence of the given
-/// bytes substring. If the substring is not found, `None` is returned.
-pub fn Bytes::find(target : Bytes, pattern : BytesView) -> Int? {
-  target[:].find(pattern)
+// SIMD short-pattern prefilter: match first and last bytes before scalar
+// verification of the unchecked middle range.
+#cfg(any(target="native", target="wasm"))
+fn find_short_candidate_from_bytes(
+  data : Bytes,
+  start : Int,
+  candidate_end : Int,
+  first : Byte,
+  last_offset : Int,
+  last : Byte,
+) -> Int {
+  let first_v = i8x16_splat(first)
+  let last_v = i8x16_splat(last)
+  let tail_start = for pos = start; pos + 16 <= candidate_end; {
+    let mask = v128_and(
+      i8x16_eq(data.v128_load(pos), first_v),
+      i8x16_eq(data.v128_load(pos + last_offset), last_v),
+    )
+    let bits = i8x16_bitmask(mask)
+    if bits != 0 {
+      return pos + bits.ctz()
+    }
+    continue pos + 16
+  } nobreak {
+    pos
+  }
+  for pos in tail_start..<candidate_end {
+    if data.unsafe_get(pos) == first &&
+      data.unsafe_get(pos + last_offset) == last {
+      break pos
+    }
+  } nobreak {
+    -1
+  }
+}
+
+///|
+// Native/wasm short-needle path: use the SIMD prefilter to skip most false
+// candidates, then compare the unchecked middle range only on hits.
+#cfg(any(target="native", target="wasm"))
+fn find_short(target : BytesView, pattern : BytesView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let last = target_len - pattern_len
+  let target_start = target.start_offset()
+  let candidate_end = target_start + last + 1
+  let first = pattern.unsafe_get(0)
+  let last_offset = pattern_len - 1
+  let last_byte = pattern.unsafe_get(last_offset)
+  for pos = 0; pos <= last; {
+    let found = find_short_candidate_from_bytes(
+      target.data(),
+      target_start + pos,
+      candidate_end,
+      first,
+      last_offset,
+      last_byte,
+    )
+    if found < 0 {
+      break None
+    }
+    let candidate = found - target_start
+    if find_match_range(target, pattern, candidate, 1, last_offset) {
+      break Some(candidate)
+    }
+    continue candidate + 1
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Linear-time fallback for long needles. Hash matches are verified to avoid
+// returning false positives from collisions.
+fn find_rabin_karp_from(
+  target : BytesView,
+  pattern : BytesView,
+  start : Int,
+) -> Int? {
+  fn hash(bytes : BytesView, start : Int, length : Int) -> UInt {
+    for i in 0..<length; hash = 0U {
+      continue hash * find_prime_rk + bytes.unsafe_get(start + i).to_uint()
+    } nobreak {
+      hash
+    }
+  }
+
+  fn prime_pow(length : Int) -> UInt {
+    for pow = 1U, square = find_prime_rk, exp = length; exp > 0; {
+      let next_pow = if exp % 2 == 1 { pow * square } else { pow }
+      continue next_pow, square * square, exp / 2
+    } nobreak {
+      pow
+    }
+  }
+
+  let pattern_len = pattern.length()
+  let target_len = target.length()
+  if start + pattern_len > target_len {
+    return None
+  }
+  let pattern_hash = hash(pattern, 0, pattern_len)
+  let pow = prime_pow(pattern_len)
+  let hash = hash(target, start, pattern_len)
+  if hash == pattern_hash &&
+    find_match_range(target, pattern, start, 0, pattern_len) {
+    return Some(start)
+  }
+  for index = start + pattern_len, hash = hash; index < target_len; {
+    let hash = hash * find_prime_rk + target.unsafe_get(index).to_uint()
+    let hash = hash - pow * target.unsafe_get(index - pattern_len).to_uint()
+    let candidate = index - pattern_len + 1
+    if hash == pattern_hash &&
+      find_match_range(target, pattern, candidate, 0, pattern_len) {
+      break Some(candidate)
+    }
+    continue index + 1, hash
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Long-needle scanner: start with first-byte candidates for common fast cases,
+// but switch to Rabin-Karp after enough failed verifications.
+fn find_long_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let last = target_len - pattern_len
+  let first_byte = pattern.unsafe_get(0)
+  for pos = 0, failures = 0; pos <= last; {
+    let found = find_byte_from_view(target, pos, target_len, first_byte)
+    if found < 0 || found > last {
+      break None
+    }
+    if find_match_range(target, pattern, found, 1, pattern_len) {
+      break Some(found)
+    }
+    let failures = failures + 1
+    if failures > find_max_bruteforce || failures > find_cutover(found) {
+      break find_rabin_karp_from(target, pattern, found + 1)
+    }
+    continue found + 1, failures
+  } nobreak {
+    None
+  }
 }
 
 ///|

--- a/builtin/simd.mbt
+++ b/builtin/simd.mbt
@@ -1,0 +1,107 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The 128-bit vector operations used by the SIMD byte scanners in
+// `bytes_find.mbt`. `builtin` cannot import `moonbitlang/core/v128` (that would
+// be a cycle), so the few ops the scanners need are hosted here directly.
+//
+// These are gated to the linear-memory backends that have the intrinsics, the
+// same targets the scanners run on; the function bodies exist only so the
+// `#intrinsic` declarations type-check and are never executed there.
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn v128_make(lo : UInt64, hi : UInt64) -> V128 = "%v128.make"
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn v128_lo(value : V128) -> UInt64 = "%v128.lo"
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn v128_hi(value : V128) -> UInt64 = "%v128.hi"
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i8x16_splat")
+fn i8x16_splat(value : Byte) -> V128 {
+  let lane = value.to_uint64() * (0x0101010101010101 : UInt64)
+  v128_make(lane, lane)
+}
+
+///|
+#borrow(bytes)
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.v128_load")
+fn v128_load(bytes : FixedArray[Byte], offset : Int) -> V128 {
+  v128_make(
+    fixedarray_read_uint64_le(bytes, offset),
+    fixedarray_read_uint64_le(bytes, offset + 8),
+  )
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.v128_and")
+fn v128_and(a : V128, b : V128) -> V128 {
+  v128_make(v128_lo(a) & v128_lo(b), v128_hi(a) & v128_hi(b))
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i8x16_eq")
+fn i8x16_eq(a : V128, b : V128) -> V128 {
+  v128_make(
+    u64_byte_eq_mask(v128_lo(a), v128_lo(b)),
+    u64_byte_eq_mask(v128_hi(a), v128_hi(b)),
+  )
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i8x16_bitmask")
+fn i8x16_bitmask(value : V128) -> Int {
+  u64_high_bits(v128_lo(value)) | (u64_high_bits(v128_hi(value)) << 8)
+}
+
+///|
+// Per-byte equality mask over the eight bytes of a `UInt64`: each byte becomes
+// `0xFF` when the operands' bytes match, `0x00` otherwise.
+#cfg(any(target="native", target="wasm"))
+fn u64_byte_eq_mask(a : UInt64, b : UInt64) -> UInt64 {
+  for i in 0..<8; result = (0 : UInt64) {
+    let shift = 8 * i
+    let mask = if ((a >> shift) & 0xFF) == ((b >> shift) & 0xFF) {
+      (0xFF : UInt64)
+    } else {
+      0
+    }
+    continue result | (mask << shift)
+  } nobreak {
+    result
+  }
+}
+
+///|
+// Gathers the high bit (bit 7) of each of the eight bytes of a `UInt64` into
+// the low eight bits of an `Int`.
+#cfg(any(target="native", target="wasm"))
+fn u64_high_bits(value : UInt64) -> Int {
+  for i in 0..<8; result = 0 {
+    let bit = ((value >> (8 * i + 7)) & 1).to_int()
+    continue result | (bit << i)
+  } nobreak {
+    result
+  }
+}

--- a/bytes/find_bench_test.mbt
+++ b/bytes/find_bench_test.mbt
@@ -1,0 +1,114 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let find_bench_len : Int = 4096
+
+///|
+fn make_find_single_hit_end() -> Bytes {
+  Bytes::makei(find_bench_len, i => {
+    if i == find_bench_len - 1 {
+      b'Z'
+    } else {
+      b'a'
+    }
+  })
+}
+
+///|
+fn make_find_single_miss() -> Bytes {
+  Bytes::makei(find_bench_len, _ => b'a')
+}
+
+///|
+fn make_find_substring_hit_end() -> Bytes {
+  Bytes::makei(find_bench_len, i => {
+    match i - (find_bench_len - 4) {
+      0 => b'Z'
+      1 => b'a'
+      2 => b'b'
+      3 => b'c'
+      _ => b'a'
+    }
+  })
+}
+
+///|
+fn make_find_view_substring_hit_end() -> Bytes {
+  Bytes::makei(find_bench_len + 17, i => {
+    match i - (find_bench_len + 7 - 4) {
+      0 => b'Z'
+      1 => b'a'
+      2 => b'b'
+      3 => b'c'
+      _ => b'a'
+    }
+  })
+}
+
+///|
+test "bench BytesView::find single byte hit end n=4096" (it : @bench.T) {
+  let data = make_find_single_hit_end()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.find(b"Z")) })
+}
+
+///|
+test "bench BytesView::find single byte miss n=4096" (it : @bench.T) {
+  let data = make_find_single_miss()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.find(b"Z")) })
+}
+
+///|
+test "bench BytesView::find substring rare hit end n=4096" (it : @bench.T) {
+  let data = make_find_substring_hit_end()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.find(b"Zabc")) })
+}
+
+///|
+test "bench BytesView::find substring dense miss n=4096" (it : @bench.T) {
+  let data = make_find_single_miss()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.find(b"aaaaZ")) })
+}
+
+///|
+test "bench BytesView::find offset view rare hit end n=4096" (it : @bench.T) {
+  let data = make_find_view_substring_hit_end()
+  let view = data[7:find_bench_len + 7]
+  it.bench(fn() { it.keep(view.find(b"Zabc")) })
+}
+
+///|
+test "bench BytesView::find long dense miss n=4096" (it : @bench.T) {
+  let data = make_find_single_miss()
+  let pattern = Bytes::makei(40, i => if i == 39 { b'Z' } else { b'a' })
+  it.bench(fn() { it.keep(data.find(pattern)) })
+}
+
+///|
+test "bench BytesView::find single byte miss n=32" (it : @bench.T) {
+  let data = Bytes::makei(32, _ => b'a')
+  let view = data[:]
+  it.bench(fn() { it.keep(view.find(b"Z")) })
+}
+
+///|
+test "bench BytesView::find substring miss n=32" (it : @bench.T) {
+  let data = Bytes::makei(32, _ => b'a')
+  let view = data[:]
+  it.bench(fn() { it.keep(view.find(b"aaaaZ")) })
+}

--- a/bytes/find_test.mbt
+++ b/bytes/find_test.mbt
@@ -28,6 +28,57 @@ test "find" {
 }
 
 ///|
+test "BytesView find edge cases" {
+  let target = b"--abcabc--"[2:8]
+  debug_inspect(target.find(b""), content="Some(0)")
+  debug_inspect(target.find(b"abc"), content="Some(0)")
+  debug_inspect(target.find(b"bca"), content="Some(1)")
+  debug_inspect(target.find(b"cab"), content="Some(2)")
+  debug_inspect(target.find(b"abcabc"), content="Some(0)")
+  debug_inspect(target.find(b"abcabcx"), content="None")
+  debug_inspect(b""[:].find(b""), content="Some(0)")
+  debug_inspect(b""[:].find(b"a"), content="None")
+}
+
+///|
+test "BytesView find long input" {
+  let target = Bytes::makei(64, i => if i == 60 { b'Z' } else { b'a' })
+  debug_inspect(target.find(b"Z"), content="Some(60)")
+  debug_inspect(target.find(b"aaaaZ"), content="Some(56)")
+  debug_inspect(target.find(b"b"), content="None")
+  let view = target[3:63]
+  debug_inspect(view.find(b"Z"), content="Some(57)")
+  debug_inspect(view.find(b"aaaaZ"), content="Some(53)")
+}
+
+///|
+test "BytesView find dense candidates" {
+  let target = Bytes::makei(160, i => if i == 127 { b'b' } else { b'a' })
+  let pattern = Bytes::makei(40, i => if i == 39 { b'b' } else { b'a' })
+  debug_inspect(target.find(pattern), content="Some(88)")
+  debug_inspect(
+    target.find(Bytes::makei(40, i => if i == 39 { b'c' } else { b'a' })),
+    content="None",
+  )
+}
+
+///|
+test "BytesView find long pattern offset view" {
+  let data = Bytes::makei(180, i => {
+    if i >= 97 && i < 136 {
+      b'a'
+    } else if i == 136 {
+      b'b'
+    } else {
+      b'x'
+    }
+  })
+  let view = data[9:170]
+  let pattern = Bytes::makei(40, i => if i == 39 { b'b' } else { b'a' })
+  debug_inspect(view.find(pattern), content="Some(88)")
+}
+
+///|
 test "rev_find" {
   debug_inspect(b"hello".rev_find(b"o"), content="Some(4)")
   debug_inspect(b"hello".rev_find(b"l"), content="Some(3)")

--- a/bytes/moon.pkg
+++ b/bytes/moon.pkg
@@ -5,6 +5,7 @@ import {
 
 import {
   "moonbitlang/core/array",
+  "moonbitlang/core/bench",
   "moonbitlang/core/double",
   "moonbitlang/core/uint",
   "moonbitlang/core/uint64",


### PR DESCRIPTION
## Summary

- Move `Bytes::find` and `BytesView::find` from `builtin` into the `bytes` package.
- Add a bytes search implementation with trivial-case dispatch, SIMD byte search on linear-memory backends, short-pattern candidate filtering, and a Rabin-Karp fallback for long dense-candidate cases.
- Reuse `Bytes::unsafe_range_equal` from the bytes package through a hidden public API after view-relative bounds are validated by the search logic.
- Add edge-case tests and an all-backend benchmark file.

## Validation

- `git diff --check`
- `moon fmt`
- `env MOONC_RC_CONVENTION=borrow moon info --target wasm,wasm-gc,js,native`
- `moon check --target all bytes --no-render`
- `moon test --target all bytes/find_test.mbt --no-render`
- `moon bench --target all --release -p moonbitlang/core/bytes -f find_bench_test.mbt --no-render --warn-list=-74-20 --no-parallelize`

## Performance

Baseline is current `origin/main` with the same `bytes/find_bench_test.mbt` harness copied into a temporary worktree. Benchmarks were run with `--release`; speedup is `main mean / PR mean`.

| backend | workload | main | PR | speedup |
| --- | --- | ---: | ---: | ---: |
| wasm | byte miss n=4096 | 4.05 us | 274.65 ns | 14.7x |
| wasm | substring dense miss n=4096 | 14.29 us | 378.09 ns | 37.8x |
| wasm | long dense miss n=4096 | 102.18 us | 4.78 us | 21.4x |
| wasm | substring miss n=32 | 119.24 ns | 35.02 ns | 3.4x |
| wasm-gc | byte miss n=4096 | 4.04 us | 2.04 us | 2.0x |
| wasm-gc | substring dense miss n=4096 | 14.21 us | 2.01 us | 7.1x |
| wasm-gc | long dense miss n=4096 | 98.98 us | 4.74 us | 20.9x |
| wasm-gc | substring miss n=32 | 104.09 ns | 24.58 ns | 4.2x |
| js | byte miss n=4096 | 3.45 us | 2.27 us | 1.5x |
| js | substring dense miss n=4096 | 12.98 us | 2.27 us | 5.7x |
| js | long dense miss n=4096 | 96.24 us | 4.74 us | 20.3x |
| js | substring miss n=32 | 96.82 ns | 25.48 ns | 3.8x |
| native | byte miss n=4096 | 1.78 us | 136.15 ns | 13.1x |
| native | substring dense miss n=4096 | 7.86 us | 181.08 ns | 43.4x |
| native | long dense miss n=4096 | 48.44 us | 4.57 us | 10.6x |
| native | substring miss n=32 | 63.92 ns | 14.52 ns | 4.4x |

The full run also covers byte hit, rare substring hit, offset-view hit, and byte miss n=32.