### PR TITLE
perf(builtin): use unchecked array access in sort inner loops

### DIFF
--- a/builtin/array_sort_by_impl.mbt
+++ b/builtin/array_sort_by_impl.mbt
@@ -48,8 +48,8 @@ fn[T] fixed_quick_sort_by(
     if pred is Some(p) {
       // pred is less than all elements in arr
       // If pivot equals to pred, then we can skip all elements that are equal to pred.
-      if cmp(p, arr[pivot]) == 0 {
-        let i = for i = pivot; i < len && cmp(p, arr[i]) == 0; {
+      if cmp(p, arr.unsafe_get(pivot)) == 0 {
+        let i = for i = pivot; i < len && cmp(p, arr.unsafe_get(i)) == 0; {
           continue i + 1
         } nobreak {
           i
@@ -62,9 +62,13 @@ fn[T] fixed_quick_sort_by(
     // Reduce the stack depth by only call quick_sort on the smaller partition.
     if left.length() < right.length() {
       fixed_quick_sort_by(left, cmp, pred, limit)
-      continue limit, right, Some(arr[pivot]), was_partitioned, balanced
+      continue limit,
+        right,
+        Some(arr.unsafe_get(pivot)),
+        was_partitioned,
+        balanced
     } else {
-      fixed_quick_sort_by(right, cmp, Some(arr[pivot]), limit)
+      fixed_quick_sort_by(right, cmp, Some(arr.unsafe_get(pivot)), limit)
       continue limit, left, pred, was_partitioned, balanced
     }
   }
@@ -82,7 +86,8 @@ fn[T] fixed_try_bubble_sort_by(
 ) -> Bool {
   let max_tries = 8
   for i in 1..<arr.length(); tries = 0 {
-    let sorted = for j = i, sorted = true; j > 0 && cmp(arr[j - 1], arr[j]) > 0; {
+    let sorted = for j = i, sorted = true; j > 0 &&
+                    cmp(arr.unsafe_get(j - 1), arr.unsafe_get(j)) > 0; {
       arr.swap(j, j - 1)
       continue j - 1, false
     } nobreak {
@@ -110,7 +115,9 @@ fn[T] fixed_try_bubble_sort_by(
 /// Returns whether the array is sorted.
 fn[T] fixed_bubble_sort_by(arr : MutArrayView[T], cmp : (T, T) -> Int) -> Unit {
   for i in 1..<arr.length() {
-    for j = i; j > 0 && cmp(arr[j - 1], arr[j]) > 0; j = j - 1 {
+    for j = i
+        j > 0 && cmp(arr.unsafe_get(j - 1), arr.unsafe_get(j)) > 0
+        j = j - 1 {
       arr.swap(j, j - 1)
     }
   }
@@ -131,11 +138,11 @@ fn[T] fixed_partition_by(
   pivot_index : Int,
 ) -> (Int, Bool) {
   arr.swap(pivot_index, arr.length() - 1)
-  let pivot = arr[arr.length() - 1]
+  let pivot = arr.unsafe_get(arr.length() - 1)
   let (i, partitioned) = for
     j in 0..<(arr.length() - 1)
     i = 0, partitioned = true {
-    if cmp(arr[j], pivot) < 0 {
+    if cmp(arr.unsafe_get(j), pivot) < 0 {
       if i != j {
         arr.swap(i, j)
         continue i + 1, false
@@ -171,7 +178,7 @@ fn[T] fixed_choose_pivot_by(
     let a = len / 4 * 1
     let c = len / 4 * 3
     let sort_2 = (a : Int, b : Int) => {
-      if cmp(arr[a], arr[b]) > 0 {
+      if cmp(arr.unsafe_get(a), arr.unsafe_get(b)) > 0 {
         arr.swap(a, b)
         swaps += 1
       }
@@ -216,12 +223,13 @@ fn[T] fixed_sift_down_by(
 ) -> Unit {
   let len = arr.length()
   for index = index, child = index * 2 + 1; child < len; {
-    let child = if child + 1 < len && cmp(arr[child], arr[child + 1]) < 0 {
+    let child = if child + 1 < len &&
+      cmp(arr.unsafe_get(child), arr.unsafe_get(child + 1)) < 0 {
       child + 1
     } else {
       child
     }
-    if cmp(arr[index], arr[child]) >= 0 {
+    if cmp(arr.unsafe_get(index), arr.unsafe_get(child)) >= 0 {
       return
     }
     arr.swap(index, child)

--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -64,7 +64,7 @@ fn[T : Compare] timsort(arr : MutArrayView[T]) -> Unit {
 ///|
 fn[T : Compare] MutArrayView::insertion_sort(arr : MutArrayView[T]) -> Unit {
   for i in 1..<arr.length() {
-    for j = i; j > 0 && arr[j] < arr[j - 1]; j = j - 1 {
+    for j = i; j > 0 && arr.unsafe_get(j) < arr.unsafe_get(j - 1); j = j - 1 {
       arr.swap(j, j - 1)
     }
   }
@@ -84,11 +84,11 @@ fn[T : Compare] merge(arr : MutArrayView[T], mid : Int) -> Unit {
   let buf_remaining = for p1 = mid - 1, p2 = buf_len - 1, p = mid + buf_len - 1; p1 >=
                          0 &&
                          p2 >= 0; {
-    if arr[p1] > buf[p2] {
-      arr[p] = arr[p1]
+    if arr.unsafe_get(p1) > buf[p2] {
+      arr.unsafe_set(p, arr.unsafe_get(p1))
       continue p1 - 1, p2, p - 1
     } else {
-      arr[p] = buf[p2]
+      arr.unsafe_set(p, buf[p2])
       continue p1, p2 - 1, p - 1
     }
   } nobreak {
@@ -114,10 +114,10 @@ fn[T : Compare] find_streak(arr : MutArrayView[T]) -> (Int, Bool) {
   if len < 2 {
     return (len, false)
   }
-  let assume_reverse = arr[1] < arr[0]
+  let assume_reverse = arr.unsafe_get(1) < arr.unsafe_get(0)
   if assume_reverse {
     let end = for idx in 2..<len {
-      if arr[idx] < arr[idx - 1] {
+      if arr.unsafe_get(idx) < arr.unsafe_get(idx - 1) {
         continue
       }
       break idx
@@ -127,7 +127,7 @@ fn[T : Compare] find_streak(arr : MutArrayView[T]) -> (Int, Bool) {
     (end, true)
   } else {
     let end = for idx in 2..<len {
-      if arr[idx] >= arr[idx - 1] {
+      if arr.unsafe_get(idx) >= arr.unsafe_get(idx - 1) {
         continue
       }
       break idx
@@ -219,9 +219,10 @@ fn[T] MutArrayView::slice(
 
 ///|
 fn[T] MutArrayView::swap(arr : MutArrayView[T], i : Int, j : Int) -> Unit {
-  let temp = arr[i]
-  arr[i] = arr[j]
-  arr[j] = temp
+  // Callers are internal sort helpers that only pass in-bounds indices.
+  let temp = arr.unsafe_get(i)
+  arr.unsafe_set(i, arr.unsafe_get(j))
+  arr.unsafe_set(j, temp)
 }
 
 ///|
@@ -230,10 +231,10 @@ fn[T] MutArrayView::rev_in_place(arr : MutArrayView[T]) -> Unit {
   let mid_len = len / 2
   for i in 0..<mid_len {
     let j = len - i - 1
-    // Swap elements
-    let temp = arr[i]
-    arr[i] = arr[j]
-    arr[j] = temp
+    // Swap elements (i and j are in bounds by construction)
+    let temp = arr.unsafe_get(i)
+    arr.unsafe_set(i, arr.unsafe_get(j))
+    arr.unsafe_set(j, temp)
   }
 }
 
@@ -272,8 +273,8 @@ fn[T : Compare] fixed_quick_sort(
     if pred is Some(p) {
       // pred is less than all elements in arr
       // If pivot equals to pred, then we can skip all elements that are equal to pred.
-      if p == arr[pivot] {
-        let i = for i = pivot; i < len && p == arr[i]; {
+      if p == arr.unsafe_get(pivot) {
+        let i = for i = pivot; i < len && p == arr.unsafe_get(i); {
           continue i + 1
         } nobreak {
           i
@@ -286,9 +287,13 @@ fn[T : Compare] fixed_quick_sort(
     // Reduce the stack depth by only call fixed_quick_sort on the smaller fixed_partition.
     if left.length() < right.length() {
       fixed_quick_sort(left, pred, limit)
-      continue limit, right, Some(arr[pivot]), was_partitioned, balanced
+      continue limit,
+        right,
+        Some(arr.unsafe_get(pivot)),
+        was_partitioned,
+        balanced
     } else {
-      fixed_quick_sort(right, Some(arr[pivot]), limit)
+      fixed_quick_sort(right, Some(arr.unsafe_get(pivot)), limit)
       continue limit, left, pred, was_partitioned, balanced
     }
   }
@@ -312,7 +317,8 @@ fn fixed_get_limit(len : Int) -> Int {
 fn[T : Compare] fixed_try_bubble_sort(arr : MutArrayView[T]) -> Bool {
   let max_tries = 8
   for i in 1..<arr.length(); tries = 0 {
-    let sorted = for j = i, sorted = true; j > 0 && arr[j - 1] > arr[j]; {
+    let sorted = for j = i, sorted = true; j > 0 &&
+                    arr.unsafe_get(j - 1) > arr.unsafe_get(j); {
       arr.swap(j, j - 1)
       continue j - 1, false
     } nobreak {
@@ -340,7 +346,7 @@ fn[T : Compare] fixed_try_bubble_sort(arr : MutArrayView[T]) -> Bool {
 /// Returns whether the array is sorted.
 fn[T : Compare] fixed_bubble_sort(arr : MutArrayView[T]) -> Unit {
   for i in 1..<arr.length() {
-    for j = i; j > 0 && arr[j - 1] > arr[j]; j = j - 1 {
+    for j = i; j > 0 && arr.unsafe_get(j - 1) > arr.unsafe_get(j); j = j - 1 {
       arr.swap(j, j - 1)
     }
   }
@@ -360,11 +366,11 @@ fn[T : Compare] fixed_partition(
   pivot_index : Int,
 ) -> (Int, Bool) {
   arr.swap(pivot_index, arr.length() - 1)
-  let pivot = arr[arr.length() - 1]
+  let pivot = arr.unsafe_get(arr.length() - 1)
   let (i, partitioned) = for
     j in 0..<(arr.length() - 1)
     i = 0, partitioned = true {
-    if arr[j] < pivot {
+    if arr.unsafe_get(j) < pivot {
       if i != j {
         arr.swap(i, j)
         continue i + 1, false
@@ -397,7 +403,7 @@ fn[T : Compare] fixed_choose_pivot(arr : MutArrayView[T]) -> (Int, Bool) {
     let a = len / 4 * 1
     let c = len / 4 * 3
     let sort_2 = (a : Int, b : Int) => {
-      if arr[a] > arr[b] {
+      if arr.unsafe_get(a) > arr.unsafe_get(b) {
         arr.swap(a, b)
         swaps += 1
       }
@@ -438,12 +444,13 @@ fn[T : Compare] fixed_heap_sort(arr : MutArrayView[T]) -> Unit {
 fn[T : Compare] fixed_sift_down(arr : MutArrayView[T], index : Int) -> Unit {
   let len = arr.length()
   for index = index, child = index * 2 + 1; child < len; {
-    let child = if child + 1 < len && arr[child] < arr[child + 1] {
+    let child = if child + 1 < len &&
+      arr.unsafe_get(child) < arr.unsafe_get(child + 1) {
       child + 1
     } else {
       child
     }
-    if arr[index] >= arr[child] {
+    if arr.unsafe_get(index) >= arr.unsafe_get(child) {
       return
     }
     arr.swap(index, child)

--- a/builtin/sort_bench_test.mbt
+++ b/builtin/sort_bench_test.mbt
@@ -1,0 +1,48 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn sort_bench_data(n : Int) -> Array[Int] {
+  Array::makei(n, i => (i * 1103515245 + 12345) & 0x7fffffff)
+}
+
+///|
+test "bench Array::sort n=1000" (it : @bench.T) {
+  let base = sort_bench_data(1000)
+  it.bench(fn() {
+    let a = base.copy()
+    a.sort()
+    it.keep(a)
+  })
+}
+
+///|
+test "bench Array::sort n=100000" (it : @bench.T) {
+  let base = sort_bench_data(100000)
+  it.bench(fn() {
+    let a = base.copy()
+    a.sort()
+    it.keep(a)
+  })
+}
+
+///|
+test "bench Array::sort_by n=10000" (it : @bench.T) {
+  let base = sort_bench_data(10000)
+  it.bench(fn() {
+    let a = base.copy()
+    a.sort_by((x, y) => x - y)
+    it.keep(a)
+  })
+}


### PR DESCRIPTION
## Motivation

Profiling `Array::sort` (native, Time Profiler) showed **~53% of the time in
`MutArrayView::at` / `MutArrayView::set`** — pure element-access overhead — with
zero allocation. The sort helpers operate on a `MutArrayView` and index it with
the checked `arr[i]` accessor, which on every comparison and swap performs a
bounds check *and* goes through the non-inlined `buf()` / `start()` / `len()`
accessors.

## Change

Every index used inside the sort helpers is derived from the view's own length
and is provably in bounds, so the hot reads/writes are switched to
`unsafe_get` / `unsafe_set`. This covers both `sort` (Compare) and `sort_by`:
`swap`, `rev_in_place`, partition, bubble, insertion, merge, heap sift-down and
choose-pivot.

No behavioral change — same algorithm, same results, just without the redundant
per-access bounds check.

## Benchmark

`builtin/sort_bench_test.mbt` (native, distinct `Int` keys):

| case | before | after | |
|---|---|---|---|
| `sort` n=1000 | 52.8 µs | **8.6 µs** | 6.1x |
| `sort` n=100000 | 8.65 ms | **3.88 ms** | 2.2x |
| `sort_by` n=10000 | 801 µs | **280 µs** | 2.9x |

Gains are data-dependent — duplicate-heavy inputs see closer to 2x — but the
bounds-check overhead is removed in all cases (profile: `MutArrayView::at`
disappears from the top entirely).

## Validation

`moon test -p builtin` passes on native (2835), wasm-gc (2877), wasm (2877) and
js (2865). The existing sort correctness tests (`fixed_test_sort`, sort/sort_by/
heap_sort/bubble_sort, `sort_by_fallback`) all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
