### PR TITLE
perf(hashset): store entries as struct-of-arrays to avoid per-insert alloc

### DIFF
--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -671,6 +671,40 @@ test "clear" {
 }
 
 ///|
+test "copy sparse set only copies occupied key slots" {
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
+  fn i(s) {
+    MyString::MyString(s)
+  }
+
+  m.add("a" |> i)
+  m.add("ab" |> i)
+  m.add("bc" |> i)
+  m.add("cd" |> i)
+  m.add("abc" |> i)
+  m.add("abcdef" |> i)
+  m.remove("ab" |> i)
+  let copied = m.copy()
+  inspect(copied.length(), content="5")
+  inspect(copied.capacity(), content="8")
+  inspect(physical_equal(copied.psls, m.psls), content="false")
+  inspect(physical_equal(copied.hashes, m.hashes), content="false")
+  inspect(physical_equal(copied.keys, m.keys), content="false")
+  let mut occupied = 0
+  for idx in 0..<m.capacity {
+    @test.assert_eq(copied.psls[idx], m.psls[idx])
+    @test.assert_eq(copied.hashes[idx], m.hashes[idx])
+    if m.psls[idx] != empty_psl {
+      occupied += 1
+      assert_true(copied.keys[idx] == m.keys[idx])
+    }
+  }
+  inspect(occupied, content="5")
+  inspect(copied.contains("ab" |> i), content="false")
+  inspect(copied.contains("abcdef" |> i), content="true")
+}
+
+///|
 /// Insert a key into the hash set and returns whether the key was successfully added.
 ///
 /// Parameters:
@@ -745,7 +779,11 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
   }
   self.psls.blit_to(other.psls, len=self.capacity)
   self.hashes.blit_to(other.hashes, len=self.capacity)
-  UninitializedArray::unsafe_blit(other.keys, 0, self.keys, 0, self.capacity)
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      other.keys[i] = self.keys[i]
+    }
+  }
   other
 }
 

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -25,7 +25,9 @@ fn[K] new_hashset(capacity : Int) -> HashSet[K] {
     capacity,
     capacity_mask: capacity - 1,
     grow_at: calc_grow_threshold(capacity),
-    entries: FixedArray::make(capacity, None),
+    psls: FixedArray::make(capacity, empty_psl),
+    hashes: FixedArray::make(capacity, 0),
+    keys: UninitializedArray::make(capacity),
   }
 }
 
@@ -94,62 +96,63 @@ fn[K : Eq] HashSet::add_with_hash(
     self.grow()
   }
   let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
-      None => break (idx, psl)
-      Some(curr_entry) => {
-        if curr_entry.hash == hash && curr_entry.key == key {
-          return
-        }
-        if psl > curr_entry.psl {
-          self.push_away(idx, curr_entry)
-          break (idx, psl)
-        }
-        continue psl + 1, (idx + 1) & self.capacity_mask
-      }
+    let curr_psl = self.psls[idx]
+    if curr_psl == empty_psl {
+      break (idx, psl)
     }
+    if self.hashes[idx] == hash && self.keys[idx] == key {
+      return
+    }
+    if psl > curr_psl {
+      // Displace the richer occupant of `idx`, then write the new key here.
+      self.push_away(idx, curr_psl, self.hashes[idx], self.keys[idx])
+      break (idx, psl)
+    }
+    continue psl + 1, (idx + 1) & self.capacity_mask
   }
-  let entry = { psl, key, hash }
-  self.set_entry(entry, idx)
+  self.set_slot(idx, psl, hash, key)
   self.size += 1
 }
 
 ///|
-#owned(entry)
+// Relocates the key triple `(psl, hash, key)` -- which has just been bumped out
+// of an earlier slot -- to a later slot, Robin-Hood style, starting from the
+// slot after `idx`.
 fn[K] HashSet::push_away(
   self : HashSet[K],
   idx : Int,
-  entry : Entry[K],
+  psl : Int,
+  hash : Int,
+  key : K,
 ) -> Unit {
-  for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
-    match self.entries[idx] {
-      None => {
-        entry.psl = psl
-        self.set_entry(entry, idx)
-        break
-      }
-      Some(curr_entry) =>
-        if psl > curr_entry.psl {
-          entry.psl = psl
-          self.set_entry(entry, idx)
-          continue curr_entry.psl + 1,
-            (idx + 1) & self.capacity_mask,
-            curr_entry
-        } else {
-          continue psl + 1, (idx + 1) & self.capacity_mask, entry
-        }
+  for psl = psl + 1, idx = (idx + 1) & self.capacity_mask, hash = hash, key = key {
+    let curr_psl = self.psls[idx]
+    if curr_psl == empty_psl {
+      self.set_slot(idx, psl, hash, key)
+      break
+    } else if psl > curr_psl {
+      let curr_hash = self.hashes[idx]
+      let curr_key = self.keys[idx]
+      self.set_slot(idx, psl, hash, key)
+      continue curr_psl + 1, (idx + 1) & self.capacity_mask, curr_hash, curr_key
+    } else {
+      continue psl + 1, (idx + 1) & self.capacity_mask, hash, key
     }
   }
 }
 
 ///|
 #inline
-#owned(entry)
-fn[K] HashSet::set_entry(
+fn[K] HashSet::set_slot(
   self : HashSet[K],
-  entry : Entry[K],
-  new_idx : Int,
+  idx : Int,
+  psl : Int,
+  hash : Int,
+  key : K,
 ) -> Unit {
-  self.entries[new_idx] = Some(entry)
+  self.psls[idx] = psl
+  self.hashes[idx] = hash
+  self.keys[idx] = key
 }
 
 ///|
@@ -158,11 +161,12 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break false }
-    if entry.hash == hash && entry.key == key {
+    let psl = self.psls[idx]
+    guard psl != empty_psl else { break false }
+    if self.hashes[idx] == hash && self.keys[idx] == key {
       break true
     }
-    if i > entry.psl {
+    if i > psl {
       break false
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -193,13 +197,14 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
 pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break }
-    if entry.hash == hash && entry.key == key {
+    let psl = self.psls[idx]
+    guard psl != empty_psl else { break }
+    if self.hashes[idx] == hash && self.keys[idx] == key {
       self.shift_back(idx)
       self.size -= 1
       break
     }
-    if i > entry.psl {
+    if i > psl {
       break
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -210,16 +215,14 @@ pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
 fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
   for cur = idx {
     let next = (cur + 1) & self.capacity_mask
-    match self.entries[next] {
-      None | Some({ psl: 0, .. }) => {
-        self.entries[cur] = None
-        break
-      }
-      Some(entry) => {
-        entry.psl -= 1
-        self.set_entry(entry, cur)
-        continue next
-      }
+    let next_psl = self.psls[next]
+    if next_psl == empty_psl || next_psl == 0 {
+      self.psls[cur] = empty_psl
+      set_null(self.keys, cur)
+      break
+    } else {
+      self.set_slot(cur, next_psl - 1, self.hashes[next], self.keys[next])
+      continue next
     }
   }
 }
@@ -232,42 +235,46 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
     self.capacity_mask = self.capacity - 1
     self.grow_at = calc_grow_threshold(self.capacity)
     self.size = 0
-    self.entries = FixedArray::make(self.capacity, None)
+    self.psls = FixedArray::make(self.capacity, empty_psl)
+    self.hashes = FixedArray::make(self.capacity, 0)
+    self.keys = UninitializedArray::make(self.capacity)
     return
   }
-  let old_entries = self.entries
+  let old_psls = self.psls
+  let old_hashes = self.hashes
+  let old_keys = self.keys
+  let old_capacity = self.capacity
   let new_capacity = self.capacity * 2
-  self.entries = FixedArray::make(new_capacity, None)
+  self.psls = FixedArray::make(new_capacity, empty_psl)
+  self.hashes = FixedArray::make(new_capacity, 0)
+  self.keys = UninitializedArray::make(new_capacity)
   self.capacity = new_capacity
   self.capacity_mask = new_capacity - 1
   self.grow_at = calc_grow_threshold(self.capacity)
-  for entry in old_entries {
-    if entry is Some(entry) {
-      self.rehash_place_entry(entry)
+  for i in 0..<old_capacity {
+    if old_psls[i] != empty_psl {
+      self.rehash_place_entry(old_hashes[i], old_keys[i])
     }
   }
 }
 
 ///|
-#owned(entry)
-fn[K] HashSet::rehash_place_entry(self : HashSet[K], entry : Entry[K]) -> Unit {
-  let hash = entry.hash
+fn[K] HashSet::rehash_place_entry(
+  self : HashSet[K],
+  hash : Int,
+  key : K,
+) -> Unit {
   for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
-      None => {
-        entry.psl = psl
-        self.set_entry(entry, idx)
-        return
-      }
-      Some(curr) =>
-        if psl > curr.psl {
-          self.push_away(idx, curr)
-          entry.psl = psl
-          self.set_entry(entry, idx)
-          return
-        } else {
-          continue psl + 1, (idx + 1) & self.capacity_mask
-        }
+    let curr_psl = self.psls[idx]
+    if curr_psl == empty_psl {
+      self.set_slot(idx, psl, hash, key)
+      return
+    } else if psl > curr_psl {
+      self.push_away(idx, curr_psl, self.hashes[idx], self.keys[idx])
+      self.set_slot(idx, psl, hash, key)
+      return
+    } else {
+      continue psl + 1, (idx + 1) & self.capacity_mask
     }
   }
 }
@@ -309,9 +316,9 @@ pub fn[K] HashSet::each(
   self : HashSet[K],
   f : (K) -> Unit raise?,
 ) -> Unit raise? {
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      f(key)
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      f(self.keys[i])
     }
   }
 }
@@ -324,8 +331,8 @@ pub fn[K] HashSet::eachi(
   f : (Int, K) -> Unit raise?,
 ) -> Unit raise? {
   for i in 0..<self.capacity; idx = 0 {
-    if self.entries[i] is Some({ key, .. }) {
-      f(idx, key)
+    if self.psls[i] != empty_psl {
+      f(idx, self.keys[i])
       continue idx + 1
     } else {
       continue idx
@@ -336,7 +343,14 @@ pub fn[K] HashSet::eachi(
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
 pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
-  self.entries.fill(None)
+  // Reuse the existing buffers (keeps the allocated space) and only null the
+  // occupied key slots so their references can be reclaimed.
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      self.psls[i] = empty_psl
+      set_null(self.keys, i)
+    }
+  }
   self.size = 0
 }
 
@@ -345,14 +359,14 @@ pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
   let mut i = 0
-  let len = self.entries.length()
+  let len = self.capacity
   Iter::new(
     fn() {
       while i < len {
-        let entry = self.entries.unsafe_get(i)
+        let idx = i
         i += 1
-        if entry is Some({ key, .. }) {
-          return Some(key)
+        if self.psls[idx] != empty_psl {
+          return Some(self.keys[idx])
         }
       } nobreak {
         None
@@ -365,9 +379,13 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
 ///|
 /// Converts the hash set to an array.
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
-  [
-    for entry in self.entries if entry is Some({ key, .. }) => key
-  ]
+  let arr = Array::new(capacity=self.size)
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      arr.push(self.keys[i])
+    }
+  }
+  arr
 }
 
 ///|
@@ -495,9 +513,9 @@ pub fn[K] HashSet::retain(self : HashSet[K], f : (K) -> Bool) -> Unit {
   let size = self.size
   let mut j = 0
   for i = 0; j < size; i = i + 1 {
-    while self.entries[i] is Some(entry) {
+    while self.psls[i] != empty_psl {
       j += 1
-      if f(entry.key) {
+      if f(self.keys[i]) {
         break
       } else {
         self.shift_back(i)
@@ -514,11 +532,12 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 
 ///|
 fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
-  for i in 0..<self.entries.length(); s = "" {
+  for i in 0..<self.capacity; s = "" {
     let s = if i > 0 { s + "," } else { s }
-    continue match self.entries[i] {
-        None => s + "_"
-        Some({ psl, key, .. }) => s + "(\{psl},\{key})"
+    continue if self.psls[i] == empty_psl {
+        s + "_"
+      } else {
+        s + "(\{self.psls[i]},\{self.keys[i]})"
       }
   } nobreak {
     s
@@ -526,7 +545,7 @@ fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
 }
 
 ///|
-priv struct MyString(String) derive(Eq, @debug.Debug)
+priv struct MyString(String) derive(Eq)
 
 ///|
 impl Hash for MyString with fn hash(self) {
@@ -628,8 +647,8 @@ test "clear" {
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
-  for entry in m.entries {
-    @test.assert_same_object(entry, None)
+  for i in 0..<m.capacity {
+    @test.assert_eq(m.psls[i], empty_psl)
   }
 }
 
@@ -699,21 +718,23 @@ pub fn[K : Hash + Eq] HashSet::remove_and_check(
 pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
   let other = {
     capacity: self.capacity,
-    entries: FixedArray::make(self.capacity, None),
+    psls: FixedArray::make(self.capacity, empty_psl),
+    hashes: FixedArray::make(self.capacity, 0),
+    keys: UninitializedArray::make(self.capacity),
     size: self.size,
     capacity_mask: self.capacity_mask,
     grow_at: self.grow_at,
   }
-  self.entries.blit_to(other.entries, len=self.capacity)
+  self.psls.blit_to(other.psls, len=self.capacity)
+  self.hashes.blit_to(other.hashes, len=self.capacity)
+  UninitializedArray::unsafe_blit(other.keys, 0, self.keys, 0, self.capacity)
   other
 }
 
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with fn to_json(self) {
-  [
-    for entry in self.entries if entry is Some({ key, .. }) => key
-  ]
+  self.to_array().to_json()
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -104,8 +104,7 @@ fn[K : Eq] HashSet::add_with_hash(
     if curr_psl == empty_psl {
       break (idx, psl)
     }
-    if self.hashes.unsafe_get(idx) == hash &&
-      unsafe_get_initialized_key(self.keys, idx) == key {
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
       return
     }
     if psl > curr_psl {
@@ -114,7 +113,7 @@ fn[K : Eq] HashSet::add_with_hash(
         idx,
         curr_psl,
         self.hashes.unsafe_get(idx),
-        unsafe_get_initialized_key(self.keys, idx),
+        self.keys.unsafe_get(idx),
       )
       break (idx, psl)
     }
@@ -143,7 +142,7 @@ fn[K] HashSet::push_away(
       break
     } else if psl > curr_psl {
       let curr_hash = self.hashes.unsafe_get(idx)
-      let curr_key = unsafe_get_initialized_key(self.keys, idx)
+      let curr_key = self.keys.unsafe_get(idx)
       self.set_slot(idx, psl, hash, key)
       continue curr_psl + 1, (idx + 1) & self.capacity_mask, curr_hash, curr_key
     } else {
@@ -165,7 +164,7 @@ fn[K] HashSet::set_slot(
   // in bounds for all three arrays.
   self.psls.unsafe_set(idx, psl)
   self.hashes.unsafe_set(idx, hash)
-  unsafe_set_key(self.keys, idx, key)
+  self.keys.unsafe_set(idx, key)
 }
 
 ///|
@@ -180,8 +179,7 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
     guard psl != empty_psl else { break false }
     // SAFETY: the same index invariant applies to `hashes`; a non-empty PSL
     // also guarantees that `keys[idx]` was initialized by `set_slot`.
-    if self.hashes.unsafe_get(idx) == hash &&
-      unsafe_get_initialized_key(self.keys, idx) == key {
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
       break true
     }
     if i > psl {
@@ -236,7 +234,10 @@ fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
     let next_psl = self.psls[next]
     if next_psl == empty_psl || next_psl == 0 {
       self.psls[cur] = empty_psl
-      set_null(self.keys, cur)
+      // Not redundant with the line above: the PSL marks the slot free, but
+      // the key slot would still hold the removed key alive until something
+      // overwrites it, retaining up to one dead key per vacated slot.
+      self.keys.set_null(cur)
       break
     } else {
       self.set_slot(cur, next_psl - 1, self.hashes[next], self.keys[next])
@@ -273,10 +274,7 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
     // SAFETY: `i < old_capacity`, the length of all three old arrays, and a
     // non-empty PSL means the old key slot was initialized.
     if old_psls.unsafe_get(i) != empty_psl {
-      self.rehash_place_entry(
-        old_hashes.unsafe_get(i),
-        unsafe_get_initialized_key(old_keys, i),
-      )
+      self.rehash_place_entry(old_hashes.unsafe_get(i), old_keys.unsafe_get(i))
     }
   }
 }
@@ -298,7 +296,7 @@ fn[K] HashSet::rehash_place_entry(
         idx,
         curr_psl,
         self.hashes.unsafe_get(idx),
-        unsafe_get_initialized_key(self.keys, idx),
+        self.keys.unsafe_get(idx),
       )
       self.set_slot(idx, psl, hash, key)
       return
@@ -377,7 +375,7 @@ pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
   for i in 0..<self.capacity {
     if self.psls[i] != empty_psl {
       self.psls[i] = empty_psl
-      set_null(self.keys, i)
+      self.keys.set_null(i)
     }
   }
   self.size = 0

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -96,16 +96,26 @@ fn[K : Eq] HashSet::add_with_hash(
     self.grow()
   }
   let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
-    let curr_psl = self.psls[idx]
+    // SAFETY: `idx` starts masked by `capacity_mask` and every step re-masks
+    // it, so it indexes all three backing arrays -- each of length
+    // `capacity` -- in bounds. A non-empty PSL further guarantees that
+    // `keys[idx]` was initialized by `set_slot`.
+    let curr_psl = self.psls.unsafe_get(idx)
     if curr_psl == empty_psl {
       break (idx, psl)
     }
-    if self.hashes[idx] == hash && self.keys[idx] == key {
+    if self.hashes.unsafe_get(idx) == hash &&
+      unsafe_get_initialized_key(self.keys, idx) == key {
       return
     }
     if psl > curr_psl {
       // Displace the richer occupant of `idx`, then write the new key here.
-      self.push_away(idx, curr_psl, self.hashes[idx], self.keys[idx])
+      self.push_away(
+        idx,
+        curr_psl,
+        self.hashes.unsafe_get(idx),
+        unsafe_get_initialized_key(self.keys, idx),
+      )
       break (idx, psl)
     }
     continue psl + 1, (idx + 1) & self.capacity_mask
@@ -126,13 +136,14 @@ fn[K] HashSet::push_away(
   key : K,
 ) -> Unit {
   for psl = psl + 1, idx = (idx + 1) & self.capacity_mask, hash = hash, key = key {
-    let curr_psl = self.psls[idx]
+    // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
+    let curr_psl = self.psls.unsafe_get(idx)
     if curr_psl == empty_psl {
       self.set_slot(idx, psl, hash, key)
       break
     } else if psl > curr_psl {
-      let curr_hash = self.hashes[idx]
-      let curr_key = self.keys[idx]
+      let curr_hash = self.hashes.unsafe_get(idx)
+      let curr_key = unsafe_get_initialized_key(self.keys, idx)
       self.set_slot(idx, psl, hash, key)
       continue curr_psl + 1, (idx + 1) & self.capacity_mask, curr_hash, curr_key
     } else {
@@ -150,9 +161,11 @@ fn[K] HashSet::set_slot(
   hash : Int,
   key : K,
 ) -> Unit {
-  self.psls[idx] = psl
-  self.hashes[idx] = hash
-  self.keys[idx] = key
+  // SAFETY: every caller derives `idx` from a `capacity_mask` probe, so it is
+  // in bounds for all three arrays.
+  self.psls.unsafe_set(idx, psl)
+  self.hashes.unsafe_set(idx, hash)
+  unsafe_set_key(self.keys, idx, key)
 }
 
 ///|
@@ -257,8 +270,13 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
   self.capacity_mask = new_capacity - 1
   self.grow_at = calc_grow_threshold(self.capacity)
   for i in 0..<old_capacity {
-    if old_psls[i] != empty_psl {
-      self.rehash_place_entry(old_hashes[i], old_keys[i])
+    // SAFETY: `i < old_capacity`, the length of all three old arrays, and a
+    // non-empty PSL means the old key slot was initialized.
+    if old_psls.unsafe_get(i) != empty_psl {
+      self.rehash_place_entry(
+        old_hashes.unsafe_get(i),
+        unsafe_get_initialized_key(old_keys, i),
+      )
     }
   }
 }
@@ -270,12 +288,18 @@ fn[K] HashSet::rehash_place_entry(
   key : K,
 ) -> Unit {
   for psl = 0, idx = hash & self.capacity_mask {
-    let curr_psl = self.psls[idx]
+    // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
+    let curr_psl = self.psls.unsafe_get(idx)
     if curr_psl == empty_psl {
       self.set_slot(idx, psl, hash, key)
       return
     } else if psl > curr_psl {
-      self.push_away(idx, curr_psl, self.hashes[idx], self.keys[idx])
+      self.push_away(
+        idx,
+        curr_psl,
+        self.hashes.unsafe_get(idx),
+        unsafe_get_initialized_key(self.keys, idx),
+      )
       self.set_slot(idx, psl, hash, key)
       return
     } else {

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -161,9 +161,14 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    let psl = self.psls[idx]
+    // SAFETY: `idx` is masked by `capacity_mask`; all backing arrays have
+    // length `capacity`, so the probe index is in bounds.
+    let psl = self.psls.unsafe_get(idx)
     guard psl != empty_psl else { break false }
-    if self.hashes[idx] == hash && self.keys[idx] == key {
+    // SAFETY: the same index invariant applies to `hashes`; a non-empty PSL
+    // also guarantees that `keys[idx]` was initialized by `set_slot`.
+    if self.hashes.unsafe_get(idx) == hash &&
+      unsafe_get_initialized_key(self.keys, idx) == key {
       break true
     }
     if i > psl {
@@ -557,6 +562,26 @@ impl Hash for MyString with fn hash(self) {
 impl Hash for MyString with fn hash_combine(self, hasher) {
   let MyString(self) = self
   hasher.combine_string(self)
+}
+
+///|
+test "contains handles collided slots across table wraparound" {
+  let m : HashSet[MyString] = new_hashset(8)
+  fn key(value) {
+    MyString::MyString(value)
+  }
+
+  // All keys hash to 7, so the probe sequence starts at the final slot and
+  // wraps around to the start of the table.
+  m.add("aaaaaaa" |> key)
+  m.add("bbbbbbb" |> key)
+  m.add("ccccccc" |> key)
+  m.add("ddddddd" |> key)
+  m.add("eeeeeee" |> key)
+
+  assert_true(m.contains("aaaaaaa" |> key))
+  assert_true(m.contains("eeeeeee" |> key))
+  assert_false(m.contains("fffffff" |> key))
 }
 
 ///|

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -644,12 +644,30 @@ test "grow" {
 ///|
 test "clear" {
   let m : HashSet[MyString] = new_hashset(default_init_capacity)
+  fn i(s) {
+    MyString::MyString(s)
+  }
+
+  m.add("C" |> i)
+  m.add("Go" |> i)
+  m.add("C++" |> i)
+  m.add("Java" |> i)
+  let psls = m.psls
+  let hashes = m.hashes
+  let keys = m.keys
+  inspect(m.length(), content="4")
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
+  inspect(physical_equal(m.psls, psls), content="true")
+  inspect(physical_equal(m.hashes, hashes), content="true")
+  inspect(physical_equal(m.keys, keys), content="true")
   for i in 0..<m.capacity {
     @test.assert_eq(m.psls[i], empty_psl)
   }
+  m.add("MoonBit" |> i)
+  inspect(m.length(), content="1")
+  inspect(m.contains("MoonBit" |> i), content="true")
 }
 
 ///|

--- a/hashset/hashset_bench_test.mbt
+++ b/hashset/hashset_bench_test.mbt
@@ -1,0 +1,44 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let hashset_bench_n = 50000
+
+///|
+test "bench HashSet::add n=50000" (it : @bench.T) {
+  it.bench(fn() {
+    let s = @hashset.HashSet([])
+    for i in 0..<hashset_bench_n {
+      s.add(i * 1103515245)
+    }
+    it.keep(s.length())
+  })
+}
+
+///|
+test "bench HashSet::contains n=50000" (it : @bench.T) {
+  let s = @hashset.HashSet([])
+  for i in 0..<hashset_bench_n {
+    s.add(i * 1103515245)
+  }
+  it.bench(fn() {
+    let mut hits = 0
+    for i in 0..<hashset_bench_n {
+      if s.contains(i * 1103515245) {
+        hits += 1
+      }
+    }
+    it.keep(hits)
+  })
+}

--- a/hashset/moon.pkg
+++ b/hashset/moon.pkg
@@ -10,4 +10,5 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
+  "moonbitlang/core/bench",
 } for "test"

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
-priv struct Entry[K] {
-  mut psl : Int
-  hash : Int
-  key : K
-} derive(@debug.Debug)
+/// `psls[i] == empty_psl` marks an empty slot. A real probe-sequence length is
+/// always `>= 0`, so `-1` is a safe sentinel.
+let empty_psl : Int = -1
 
-/// A mutable hash set implements with Robin Hood hashing.
+///|
+/// Releases the key reference stored at `idx` so the collector can reclaim it.
+fn[K] set_null(keys : UninitializedArray[K], idx : Int) = "%fixedarray.set_null"
+
+/// A mutable hash set implemented with Robin Hood hashing.
 ///
 /// reference:
 /// - <https://programming.guide/robin-hood-hashing.html>
@@ -28,6 +29,12 @@ priv struct Entry[K] {
 
 ///|
 /// Mutable hash set, not thread safe.
+///
+/// The table is stored as a struct-of-arrays (`psls` / `hashes` / `keys`)
+/// rather than an array of boxed entries, so inserting a key does not allocate
+/// a per-entry object. For an occupied slot `i`, `hashes[i]` caches the key's
+/// hash and `keys[i]` holds the key; for an empty slot `psls[i] == empty_psl`
+/// and `keys[i]` is unused.
 ///
 /// # Example
 ///
@@ -39,7 +46,9 @@ priv struct Entry[K] {
 /// }
 /// ```
 struct HashSet[K] {
-  mut entries : FixedArray[Entry[K]?]
+  mut psls : FixedArray[Int] // probe sequence length, or empty_psl when empty
+  mut hashes : FixedArray[Int] // cached key hash for occupied slots
+  mut keys : UninitializedArray[K] // key storage for occupied slots
   mut size : Int // active key count
   mut capacity : Int // current capacity
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -28,6 +28,9 @@ fn[K] set_null(keys : UninitializedArray[K], idx : Int) = "%fixedarray.set_null"
 /// occupied slot.
 fn[K] unsafe_get_initialized_key(keys : UninitializedArray[K], idx : Int) -> K = "%fixedarray.unsafe_get"
 
+///|
+fn[K] unsafe_set_key(keys : UninitializedArray[K], idx : Int, key : K) -> Unit = "%fixedarray.unsafe_set"
+
 /// A mutable hash set implemented with Robin Hood hashing.
 ///
 /// reference:

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -18,18 +18,28 @@
 let empty_psl : Int = -1
 
 ///|
+/// Package-local unchecked accessors for the key storage. These are kept
+/// private here rather than exposed from `builtin`: `set_null` and
+/// `unsafe_set` can corrupt memory, so the fewer packages that can name them
+/// the better.
+fn[K] UninitializedArray::unsafe_get(
+  self : UninitializedArray[K],
+  idx : Int,
+) -> K = "%fixedarray.unsafe_get"
+
+///|
+fn[K] UninitializedArray::unsafe_set(
+  self : UninitializedArray[K],
+  idx : Int,
+  key : K,
+) -> Unit = "%fixedarray.unsafe_set"
+
+///|
 /// Releases the key reference stored at `idx` so the collector can reclaim it.
-fn[K] set_null(keys : UninitializedArray[K], idx : Int) = "%fixedarray.set_null"
-
-///|
-/// Reads an initialized key slot without checking its index.
-///
-/// Callers must ensure that `idx` is within the backing array and refers to an
-/// occupied slot.
-fn[K] unsafe_get_initialized_key(keys : UninitializedArray[K], idx : Int) -> K = "%fixedarray.unsafe_get"
-
-///|
-fn[K] unsafe_set_key(keys : UninitializedArray[K], idx : Int, key : K) -> Unit = "%fixedarray.unsafe_set"
+fn[K] UninitializedArray::set_null(
+  self : UninitializedArray[K],
+  idx : Int,
+) -> Unit = "%fixedarray.set_null"
 
 /// A mutable hash set implemented with Robin Hood hashing.
 ///

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -21,6 +21,13 @@ let empty_psl : Int = -1
 /// Releases the key reference stored at `idx` so the collector can reclaim it.
 fn[K] set_null(keys : UninitializedArray[K], idx : Int) = "%fixedarray.set_null"
 
+///|
+/// Reads an initialized key slot without checking its index.
+///
+/// Callers must ensure that `idx` is within the backing array and refers to an
+/// occupied slot.
+fn[K] unsafe_get_initialized_key(keys : UninitializedArray[K], idx : Int) -> K = "%fixedarray.unsafe_get"
+
 /// A mutable hash set implemented with Robin Hood hashing.
 ///
 /// reference:


### PR DESCRIPTION
## Motivation

`HashSet` stored its table as `FixedArray[Entry[K]?]`, where
`Entry { psl, hash, key }` is a heap-allocated struct. Every newly inserted key
therefore allocates one `Entry` object. Profiling `HashSet::add` (native, Time
Profiler) attributed **~11% of the time to the per-entry malloc**, on top of the
reference-counting churn (incref/decref/drop) of the boxed entries.

## Change

Replace the array of boxed entries with a **struct-of-arrays** layout:

```
psls   : FixedArray[Int]        // probe sequence length; -1 marks an empty slot
hashes : FixedArray[Int]        // cached key hash for occupied slots
keys   : UninitializedArray[K]  // key storage for occupied slots
```

`psls[i] == -1` is the empty-slot sentinel — a real probe-sequence length is
always `>= 0`, so no extra occupancy array is needed. Inserting a key now writes
three array slots with no allocation. Vacated slots (remove / shift-back / clear)
have their key `set_null`-ed so it stays collectable. `UninitializedArray[K]` is
the same primitive already used by `@deque`.

Same Robin Hood algorithm, same observable behavior — only the storage layout
changes.

## Benchmark

`hashset/hashset_bench_test.mbt` (native, n=50000):

| op | before | after | |
|---|---|---|---|
| `add` | 1.95 ms | **1.38 ms** | ~29% faster |
| `contains` | 657 µs | 675 µs | unchanged (read path does not allocate) |

The `add` win exceeds the 11% the profiler attributed to malloc alone, because
the boxed-entry reference-counting churn disappears too. `contains` is on the
read path and neither layout allocates, so it is unchanged.

## Validation

`moon test -p hashset` passes on native, wasm-gc, wasm and js (132 each).
`moon check` is clean and the package `.mbti` is unchanged (the struct fields
are private, so this is a pure internal change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
