### PR TITLE
perf(builtin): SWAR BytesView::lexical_compare on native/wasm

### DIFF
--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -728,41 +728,10 @@ pub impl Compare for BytesView with fn compare(self, other) -> Int {
 }
 
 ///|
-/// Performs a lexicographical comparison of two byte views.
-///
-/// This method compares the views byte by byte until a difference is found
-/// or one view is exhausted. Unlike the `Compare` trait implementation which
-/// uses shortlex order (shorter views come first), this method compares based
-/// purely on byte values until a difference is found.
-///
-/// # Returns
-///
-/// - A negative integer if `self` is lexicographically less than `other`
-/// - Zero if `self` is lexicographically equal to `other`
-/// - A positive integer if `self` is lexicographically greater than `other`
-///
-/// # Example
-///
-/// ```mbt check
-/// test {
-///   inspect(b"\x01\x02"[:].lexical_compare(b"\x01\x02\x03"), content="-1")
-///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02"), content="1")
-///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x03"), content="0")
-///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x04"), content="-1")
-/// }
-/// ```
-pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
-  let self_len = self.length()
-  let other_len = other.length()
-  let min_len = if self_len < other_len { self_len } else { other_len }
-  for i in 0..<min_len {
-    let cmp = self.unsafe_get(i).compare(other.unsafe_get(i))
-    if cmp != 0 {
-      return cmp
-    }
-  }
-  self_len.compare(other_len)
-}
+// `BytesView::lexical_compare` is defined per-backend: a SWAR version
+// (`bytesview_lexcmp_swar.mbt`) on native / wasm where 64-bit integer reads
+// are cheap, and a scalar version (`bytesview_lexcmp_scalar.mbt`) on wasm-gc /
+// js where emulated `UInt64` would make SWAR slower.
 
 ///|
 /// Retrieves the underlying `Bytes` from a `View`.

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -731,7 +731,7 @@ pub impl Compare for BytesView with fn compare(self, other) -> Int {
 // `BytesView::lexical_compare` is defined per-backend: a SWAR version
 // (`bytesview_lexcmp_swar.mbt`) on native / wasm where 64-bit integer reads
 // are cheap, and a scalar version (`bytesview_lexcmp_scalar.mbt`) on wasm-gc /
-// js where emulated `UInt64` would make SWAR slower.
+// js / llvm where this optimization is not selected.
 
 ///|
 /// Retrieves the underlying `Bytes` from a `View`.

--- a/builtin/bytesview_lexcmp_scalar.mbt
+++ b/builtin/bytesview_lexcmp_scalar.mbt
@@ -1,0 +1,53 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Performs a lexicographical comparison of two byte views.
+///
+/// This method compares the views byte by byte until a difference is found
+/// or one view is exhausted. Unlike the `Compare` trait implementation which
+/// uses shortlex order (shorter views come first), this method compares based
+/// purely on byte values until a difference is found.
+///
+/// # Returns
+///
+/// - A negative integer if `self` is lexicographically less than `other`
+/// - Zero if `self` is lexicographically equal to `other`
+/// - A positive integer if `self` is lexicographically greater than `other`
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   inspect(b""[:].lexical_compare(b""), content="-1")
+///   inspect(b""[:].lexical_compare(b""), content="1")
+///   inspect(b""[:].lexical_compare(b""), content="0")
+///   inspect(b""[:].lexical_compare(b""), content="-1")
+/// }
+/// ```
+///
+/// Scalar variant for backends where 64-bit reads are emulated (wasm-gc / js):
+/// a plain byte-by-byte comparison avoids the slow `UInt64` path.
+pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
+  let self_len = self.length()
+  let other_len = other.length()
+  let min_len = if self_len < other_len { self_len } else { other_len }
+  for i in 0..<min_len {
+    let cmp = self.unsafe_get(i).compare(other.unsafe_get(i))
+    if cmp != 0 {
+      return cmp
+    }
+  }
+  self_len.compare(other_len)
+}

--- a/builtin/bytesview_lexcmp_scalar.mbt
+++ b/builtin/bytesview_lexcmp_scalar.mbt
@@ -15,10 +15,10 @@
 ///|
 /// Performs a lexicographical comparison of two byte views.
 ///
-/// This method compares the views byte by byte until a difference is found
-/// or one view is exhausted. Unlike the `Compare` trait implementation which
-/// uses shortlex order (shorter views come first), this method compares based
-/// purely on byte values until a difference is found.
+/// This method returns the lexicographical ordering by byte value. Unlike the
+/// `Compare` trait implementation which uses shortlex order (shorter views come
+/// first), this method compares based purely on byte values until a difference
+/// is found.
 ///
 /// # Returns
 ///
@@ -30,14 +30,15 @@
 ///
 /// ```mbt check
 /// test {
-///   inspect(b""[:].lexical_compare(b""), content="-1")
-///   inspect(b""[:].lexical_compare(b""), content="1")
-///   inspect(b""[:].lexical_compare(b""), content="0")
-///   inspect(b""[:].lexical_compare(b""), content="-1")
+///   inspect(b"\x01\x02"[:].lexical_compare(b"\x01\x02\x03"), content="-1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02"), content="1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x03"), content="0")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x04"), content="-1")
 /// }
 /// ```
 ///
-/// Scalar variant for backends where 64-bit reads are emulated (wasm-gc / js):
+/// Scalar variant for backends where 64-bit reads are emulated or not selected
+/// for this optimization (wasm-gc / js / llvm):
 /// a plain byte-by-byte comparison avoids the slow `UInt64` path.
 pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
   let self_len = self.length()

--- a/builtin/bytesview_lexcmp_swar.mbt
+++ b/builtin/bytesview_lexcmp_swar.mbt
@@ -15,10 +15,10 @@
 ///|
 /// Performs a lexicographical comparison of two byte views.
 ///
-/// This method compares the views byte by byte until a difference is found
-/// or one view is exhausted. Unlike the `Compare` trait implementation which
-/// uses shortlex order (shorter views come first), this method compares based
-/// purely on byte values until a difference is found.
+/// This method returns the lexicographical ordering by byte value. Unlike the
+/// `Compare` trait implementation which uses shortlex order (shorter views come
+/// first), this method compares based purely on byte values until a difference
+/// is found.
 ///
 /// # Returns
 ///
@@ -30,10 +30,10 @@
 ///
 /// ```mbt check
 /// test {
-///   inspect(b""[:].lexical_compare(b""), content="-1")
-///   inspect(b""[:].lexical_compare(b""), content="1")
-///   inspect(b""[:].lexical_compare(b""), content="0")
-///   inspect(b""[:].lexical_compare(b""), content="-1")
+///   inspect(b"\x01\x02"[:].lexical_compare(b"\x01\x02\x03"), content="-1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02"), content="1")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x03"), content="0")
+///   inspect(b"\x01\x02\x03"[:].lexical_compare(b"\x01\x02\x04"), content="-1")
 /// }
 /// ```
 ///
@@ -44,7 +44,8 @@ pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
   let other_len = other.length()
   let min_len = if self_len < other_len { self_len } else { other_len }
   let mut i = 0
-  while i + 8 <= min_len {
+  let block_limit = min_len - min_len % 8
+  while i < block_limit {
     let a = self.unsafe_read_uint64_be(i)
     let b = other.unsafe_read_uint64_be(i)
     if a != b {

--- a/builtin/bytesview_lexcmp_swar.mbt
+++ b/builtin/bytesview_lexcmp_swar.mbt
@@ -1,0 +1,63 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Performs a lexicographical comparison of two byte views.
+///
+/// This method compares the views byte by byte until a difference is found
+/// or one view is exhausted. Unlike the `Compare` trait implementation which
+/// uses shortlex order (shorter views come first), this method compares based
+/// purely on byte values until a difference is found.
+///
+/// # Returns
+///
+/// - A negative integer if `self` is lexicographically less than `other`
+/// - Zero if `self` is lexicographically equal to `other`
+/// - A positive integer if `self` is lexicographically greater than `other`
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   inspect(b""[:].lexical_compare(b""), content="-1")
+///   inspect(b""[:].lexical_compare(b""), content="1")
+///   inspect(b""[:].lexical_compare(b""), content="0")
+///   inspect(b""[:].lexical_compare(b""), content="-1")
+/// }
+/// ```
+///
+/// Native / wasm SWAR variant: compares 8 bytes per step via big-endian
+/// `UInt64` reads, so an unsigned 64-bit comparison reproduces the byte order.
+pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
+  let self_len = self.length()
+  let other_len = other.length()
+  let min_len = if self_len < other_len { self_len } else { other_len }
+  let mut i = 0
+  while i + 8 <= min_len {
+    let a = self.unsafe_read_uint64_be(i)
+    let b = other.unsafe_read_uint64_be(i)
+    if a != b {
+      return a.compare(b)
+    }
+    i = i + 8
+  }
+  while i < min_len {
+    let cmp = self.unsafe_get(i).compare(other.unsafe_get(i))
+    if cmp != 0 {
+      return cmp
+    }
+    i = i + 1
+  }
+  self_len.compare(other_len)
+}

--- a/builtin/lexical_compare_bench_test.mbt
+++ b/builtin/lexical_compare_bench_test.mbt
@@ -1,0 +1,54 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let lc_equal_a : Bytes = Bytes::makei(256, i => (i % 251).to_byte())
+
+///|
+let lc_equal_b : Bytes = Bytes::makei(256, i => (i % 251).to_byte())
+
+///|
+// identical except the very last byte -> full common-prefix scan
+let lc_prefix_a : Bytes = Bytes::makei(256, i => (i % 251).to_byte())
+
+///|
+let lc_prefix_b : Bytes = Bytes::makei(256, i => {
+  if i == 255 {
+    b'\xff'
+  } else {
+    (i % 251).to_byte()
+  }
+})
+
+///|
+// differ at byte 1 -> early-exit case (regression guard)
+let lc_early_a : Bytes = Bytes::makei(256, _ => b'a')
+
+///|
+let lc_early_b : Bytes = Bytes::makei(256, i => if i == 1 { b'b' } else { b'a' })
+
+///|
+test "bench lexical_compare equal n=256" (it : @bench.T) {
+  it.bench(fn() { it.keep(lc_equal_a.lexical_compare(lc_equal_b)) })
+}
+
+///|
+test "bench lexical_compare common-prefix n=256" (it : @bench.T) {
+  it.bench(fn() { it.keep(lc_prefix_a.lexical_compare(lc_prefix_b)) })
+}
+
+///|
+test "bench lexical_compare early-diff n=256" (it : @bench.T) {
+  it.bench(fn() { it.keep(lc_early_a.lexical_compare(lc_early_b)) })
+}

--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -26,6 +26,8 @@ warnings = "-test_unqualified_package"
 
 options(
   targets: {
+    "bytesview_lexcmp_swar.mbt": [ "native", "wasm" ],
+    "bytesview_lexcmp_scalar.mbt": [ "wasm-gc", "js", "llvm" ],
     "array_nonjs_test.mbt": [ "not", "js" ],
     "arraycore_js.mbt": [ "js" ],
     "arraycore_nonjs.mbt": [ "not", "js" ],


### PR DESCRIPTION
## Change

`BytesView::lexical_compare` compared a byte at a time. On backends with cheap
64-bit integers (native, wasm), reading 8 bytes at a time **big-endian** lets a
single unsigned `UInt64` comparison settle a whole 8-byte run — a big-endian
read makes the `UInt64` ordering coincide with the lexical (unsigned, left-to-
right) byte ordering. Falls back to a scalar byte loop for the `< 8`-byte tail
and then compares lengths.

No public API change (same `BytesView::lexical_compare`; `Bytes::lexical_compare`
delegates to it). It stays in `builtin` — this is plain `UInt64` arithmetic, no
`v128` dependency.

## Benchmark (n=256)

| backend | scalar | this PR | |
|---|---|---|---|
| native | ~92–130 ns | **~28 ns** | 3.3–4.6× |
| wasm | ~172 ns | **~104 ns** | 1.7× |
| wasm-gc | ~157 ns | ~157 ns (scalar) | unchanged |
| js | ~137 ns | ~137 ns (scalar) | unchanged |

Early-exit case (inputs differ at byte 1): no regression on any backend
(~6–8 ns, same as scalar).

## ⚠️ Concern worth discussing: large per-runtime divergence

The reason this is **gated to native/wasm via `moon.pkg`** rather than applied
everywhere is that the SWAR path is a *regression* on the GC backends, because
`UInt64` is emulated there:

- **js**: applying SWAR unconditionally is **~37× slower** (5.1 µs vs 137 ns).
- **wasm-gc**: ~1.3× slower.

So the same source-level "optimization" swings from a 4× win to a 37× loss
depending purely on the runtime's `UInt64` cost. A couple of implications I'd
like input on:

1. **Is per-backend gating like this the pattern we want** for this kind of
   integer-width-sensitive optimization, or is the maintenance/readability cost
   (two impls + a `moon.pkg` split per op) not worth a native-only win?
2. **Benchmarking is noisy and runtime-dependent here** — the scalar baseline's
   "equal" case had high variance (σ up to ~50 ns), and the win only exists on
   2 of 4 backends. If we take more of these, it probably needs a more
   disciplined harness (fixed inputs per backend, regression gating that is
   itself per-backend) so a "win" on one runtime doesn't hide a "loss" on
   another. Happy to align on a convention before adding more SWAR ops.

I'm comfortable dropping this if the gating tradeoff isn't worth it; mainly
raising it as a concrete data point on the per-runtime divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
