### PR TITLE
[codex] perf(builtin): avoid duplicate MutArrayView checked bounds

### DIFF
--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -119,7 +119,7 @@ pub fn[T] MutArrayView::at(self : MutArrayView[T], index : Int) -> T {
       "index out of bounds: the len is from 0 to \{self.len()} but the index is \{index}",
     )
   }
-  self.buf()[self.start() + index]
+  self.buf().unsafe_get(self.start() + index)
 }
 
 ///|
@@ -183,7 +183,7 @@ pub fn[T] MutArrayView::set(
       "index out of bounds: the len is from 0 to \{self.len()} but the index is \{index}",
     )
   }
-  self.buf()[self.start() + index] = value
+  self.buf().unsafe_set(self.start() + index, value)
 }
 
 ///|

--- a/builtin/mutarrayview_bench_test.mbt
+++ b/builtin/mutarrayview_bench_test.mbt
@@ -1,0 +1,71 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let mutarrayview_bench_size = 100_000
+
+///|
+fn make_mutarrayview_bench_array() -> Array[Int] {
+  Array::makei(mutarrayview_bench_size + 2, i => i % 1024)
+}
+
+///|
+test "bench MutArrayView::at Int n=100000" (it : @bench.T) {
+  let data = make_mutarrayview_bench_array()
+  let view = data.mut_view(start=1, end=mutarrayview_bench_size + 1)
+  it.bench(fn() {
+    let mut sum = 0
+    for i = 0; i < mutarrayview_bench_size; i = i + 1 {
+      sum = sum + view[i]
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench MutArrayView::unsafe_get Int n=100000" (it : @bench.T) {
+  let data = make_mutarrayview_bench_array()
+  let view = data.mut_view(start=1, end=mutarrayview_bench_size + 1)
+  it.bench(fn() {
+    let mut sum = 0
+    for i = 0; i < mutarrayview_bench_size; i = i + 1 {
+      sum = sum + view.unsafe_get(i)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench MutArrayView::set Int n=100000" (it : @bench.T) {
+  let data = make_mutarrayview_bench_array()
+  let view = data.mut_view(start=1, end=mutarrayview_bench_size + 1)
+  it.bench(fn() {
+    for i = 0; i < mutarrayview_bench_size; i = i + 1 {
+      view[i] = i % 1024
+    }
+    it.keep(view[0] + view[mutarrayview_bench_size - 1])
+  })
+}
+
+///|
+test "bench MutArrayView::unsafe_set Int n=100000" (it : @bench.T) {
+  let data = make_mutarrayview_bench_array()
+  let view = data.mut_view(start=1, end=mutarrayview_bench_size + 1)
+  it.bench(fn() {
+    for i = 0; i < mutarrayview_bench_size; i = i + 1 {
+      view.unsafe_set(i, i % 1024)
+    }
+    it.keep(view.unsafe_get(0) + view.unsafe_get(mutarrayview_bench_size - 1))
+  })
+}

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -41,6 +41,13 @@ pub fn[T] UninitializedArray::at(
 ) -> T = "%fixedarray.get"
 
 ///|
+#internal(unsafe, "For internal use only.")
+fn[T] UninitializedArray::unsafe_get(
+  self : UninitializedArray[T],
+  index : Int,
+) -> T = "%fixedarray.unsafe_get"
+
+///|
 /// Sets the value at the specified index in an uninitialized array.
 ///
 /// Parameters:
@@ -54,6 +61,14 @@ pub fn[T] UninitializedArray::set(
   index : Int,
   value : T,
 ) = "%fixedarray.set"
+
+///|
+#internal(unsafe, "For internal use only.")
+fn[T] UninitializedArray::unsafe_set(
+  self : UninitializedArray[T],
+  index : Int,
+  value : T,
+) -> Unit = "%fixedarray.unsafe_set"
 
 ///|
 /// Creates a view into a portion of the uninitialized array.


### PR DESCRIPTION
## Summary

This keeps the existing view-relative guard in checked `MutArrayView::at` / `MutArrayView::set`, but avoids re-entering the checked backing-array access after that guard has already proved the physical index is valid for a well-formed view.

Changes:

- add package-private `UninitializedArray::unsafe_get` / `unsafe_set` wrappers for `%fixedarray.unsafe_get` / `%fixedarray.unsafe_set`
- use those wrappers in checked `MutArrayView::at` and `MutArrayView::set` after the existing `index >= 0 && index < self.len()` guard
- add focused `MutArrayView` checked-vs-unsafe access microbenches

Generated native C check:

- before: checked `MutArrayView::at` / `set` performed the view-relative guard, then emitted a second physical backing-array check using `Moonbit_array_length(...)` before loading/storing
- after: checked `MutArrayView::at` / `set` still perform the view-relative guard, then directly load/store `buf[start + index]`

## Microbenchmarks

Command used in separate worktrees:

```sh
moon bench --target native -p builtin -f mutarrayview_bench_test.mbt --no-parallelize --target-dir <tmp-build-dir>
```

Baseline was `origin/main` at `0d1b1128`; patched was this branch at `2f37e60b`.

| benchmark | origin/main | patched |
| --- | ---: | ---: |
| `MutArrayView::at Int n=100000` | `97.75 us +- 0.56 us` | `98.67 us +- 3.05 us` |
| `MutArrayView::unsafe_get Int n=100000` | `3.68 us +- 0.15 us` | `3.61 us +- 0.05 us` |
| `MutArrayView::set Int n=100000` | `99.24 us +- 3.60 us` | `98.38 us +- 1.08 us` |
| `MutArrayView::unsafe_set Int n=100000` | `5.42 us +- 0.21 us` | `5.34 us +- 0.19 us` |

So this removes the duplicate generated physical bounds check, but it is not a measurable speedup in this focused benchmark. The remaining cost is dominated by the checked accessor call and the view-relative guard / cold abort path, not by the second backing-array length check alone.

## Validation

- `moon fmt`
- `moon info` checked; no public API additions from the private helpers, generated `.mbti` churn was not committed
- `moon check --target native -p builtin --no-render`
- `moon check --target all -p builtin --no-render --target-dir /tmp/core-mutarrayview-check-build` (passes; existing missing-doc warnings in unrelated generated/bench support files)
- `moon test --target native -p builtin --no-render --target-dir /tmp/core-mutarrayview-builtin-test-build` (`2835` passed)
