### PR TITLE
perf(builtin,deque): make checked index accessors inlineable

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -135,9 +135,7 @@ pub fn[T] ArrayView::start_offset(self : Self[T]) -> Int {
 #alias("_[_]")
 pub fn[T] ArrayView::at(self : ArrayView[T], index : Int) -> T {
   guard index >= 0 && index < self.len() else {
-    abort(
-      "index out of bounds: the len is from 0 to \{self.len()} but the index is \{index}",
-    )
+    index_out_of_bounds(self.len(), index)
   }
   self.buf().unsafe_get(self.start() + index)
 }

--- a/builtin/bounds.mbt
+++ b/builtin/bounds.mbt
@@ -1,0 +1,29 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Aborts with the standard "index out of bounds" diagnostic.
+///
+/// Factored out of the checked accessors (`at` / `set`) and marked
+/// `#inline(never)` on purpose: the failure path builds a `StringBuilder` and
+/// formats the message, which makes the accessor body too large for the
+/// C/LLVM backend to inline. Hoisting it into this shared cold function keeps
+/// the hot accessors small enough to inline (and the surrounding loop to
+/// vectorize) while preserving the exact diagnostic message.
+#inline(never)
+fn[T] index_out_of_bounds(len : Int, index : Int) -> T {
+  abort(
+    "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+  )
+}

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -85,9 +85,7 @@ pub fn BytesView::is_empty(self : BytesView) -> Bool {
 #alias("_[_]")
 pub fn BytesView::at(self : BytesView, index : Int) -> Byte {
   guard index >= 0 && index < self.length() else {
-    abort(
-      "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
-    )
+    index_out_of_bounds(self.length(), index)
   }
   self.bytes().unsafe_get(self.start() + index)
 }

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -115,9 +115,7 @@ pub fn[T] MutArrayView::start_offset(self : MutArrayView[T]) -> Int {
 #alias("_[_]")
 pub fn[T] MutArrayView::at(self : MutArrayView[T], index : Int) -> T {
   guard index >= 0 && index < self.len() else {
-    abort(
-      "index out of bounds: the len is from 0 to \{self.len()} but the index is \{index}",
-    )
+    index_out_of_bounds(self.len(), index)
   }
   self.buf().unsafe_get(self.start() + index)
 }
@@ -179,9 +177,7 @@ pub fn[T] MutArrayView::set(
   value : T,
 ) -> Unit {
   guard index >= 0 && index < self.len() else {
-    abort(
-      "index out of bounds: the len is from 0 to \{self.len()} but the index is \{index}",
-    )
+    index_out_of_bounds(self.len(), index)
   }
   self.buf().unsafe_set(self.start() + index, value)
 }

--- a/deque/bounds.mbt
+++ b/deque/bounds.mbt
@@ -1,0 +1,26 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Aborts with the standard "index out of bounds" diagnostic.
+///
+/// Marked `#inline(never)` so the cold message-formatting path stays out of the
+/// checked accessor bodies (`Deque::at` / `Deque::set`), keeping them small
+/// enough for the C/LLVM backend to inline while preserving the exact message.
+#inline(never)
+fn[T] index_out_of_bounds(len : Int, index : Int) -> T {
+  abort(
+    "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
+  )
+}

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -813,10 +813,7 @@ pub fn[A] Deque::pop_back(self : Deque[A]) -> A? {
 #alias("_[_]")
 pub fn[A] Deque::at(self : Deque[A], index : Int) -> A {
   if index < 0 || index >= self.len {
-    let len = self.len
-    abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
-    )
+    index_out_of_bounds(self.len, index)
   }
   if self.head + index < self.buf.length() {
     self.buf[self.head + index]
@@ -841,10 +838,7 @@ pub fn[A] Deque::at(self : Deque[A], index : Int) -> A {
 #alias("_[_]=_")
 pub fn[A] Deque::set(self : Deque[A], index : Int, value : A) -> Unit {
   if index < 0 || index >= self.len {
-    let len = self.len
-    abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
-    )
+    index_out_of_bounds(self.len, index)
   }
   if self.head + index < self.buf.length() {
     self.buf[self.head + index] = value


### PR DESCRIPTION
## Summary

The checked index accessors emit an interpolated `abort(...)` on the
out-of-bounds path. That message builds a `StringBuilder` and formats via
several calls, which inflates the accessor body well past the C/LLVM backend's
inline-cost threshold. The backend then cannot inline the accessor, so every
element access in a loop becomes an out-of-line call — which blocks
auto-vectorization and keeps the loop scalar. This is why `at` benchmarks were
~25x slower than `unsafe_get` even after #3714/#3715 removed the duplicate
physical bounds check: removing the duplicate check left the *call* in place,
and the call (not the check) is the real cost.

This PR hoists the cold message-formatting into a shared `#inline(never)`
`index_out_of_bounds` helper, so the hot accessor body becomes small enough to
inline. The exact diagnostic message is unchanged.

## Root cause (measured)

clang's `-O2` inline-cost threshold is 225. With the formatting inline:

```
at_full   not inlined  (cost=810, threshold=225)
```

The ~7 formatting calls on the abort path (`StringBuilder`, `write_object`,
`write_string`, `to_string`, `abort`) dominate the cost. The branch itself is
cheap and perfectly predicted — it is the *non-inlinable call* that prevents
vectorization.

## Fix

A private, cold helper per package (no public API change):

```mbt
#inline(never)
fn[T] index_out_of_bounds(len : Int, index : Int) -> T {
  abort("index out of bounds: the len is from 0 to \{len} but the index is \{index}")
}
```

The accessors now `guard ... else { index_out_of_bounds(len, index) }`. After
this, clang inlines the accessor (cost 40), proves the view-relative guard
redundant against the loop bound, eliminates it, and auto-vectorizes the loop.

## Sweep

Refactored the small hot accessors where the abort dominates the body:

- `ArrayView::at`
- `MutArrayView::at`, `MutArrayView::set`
- `BytesView::at`
- `Deque::at`, `Deque::set`

Deliberately **not** changed (the abort is not the bottleneck — these bodies
are large because they blit/realloc, and they are not called per-element in
tight loops): `Array::remove`, `Array::insert`, `Array::split_at`,
`Deque::insert`, `Deque::remove`. The `op_get`/`op_set` primitives on `Array`
itself are compiler intrinsics (`%array.get`), not source-level aborts, so they
are out of scope here.

## Benchmarks

`moon bench --target native -p builtin -f view_bench_test.mbt --no-parallelize`

| benchmark | before | after | |
|---|---:|---:|---|
| `ArrayView::at` Int n=100000 | 122.75 µs | **4.67 µs** | 26x — now == `unsafe_get` (4.62 µs) |
| `MutArrayView::at` Int n=100000 | 123.49 µs | **4.60 µs** | 27x |
| `MutArrayView::set` Int n=100000 | ~123 µs | **7.70 µs** | == `unsafe_set` (7.41 µs) |
| `ArrayView::unsafe_get` (control) | 4.62 µs | 4.62 µs | unchanged |

The checked accessor is now as fast as the unchecked one, with bounds safety
and the identical error message retained.

## Generated C / assembly

- `ArrayView::at` body shrinks to: view-relative guard, `return buf[start+index]`
  on success, and a single `return index_out_of_bounds(len, index)` cold call on
  failure.
- clang remark: `ArrayView::at` / `MutArrayView::at` inlined into the bench loop
  at **cost=40** (was 810); the cold `index_out_of_bounds` stays out of line.
- The bench loop vectorizes: NEON `ldp q4,q5` / `ldp q6,q7` + `add.4s` (16
  ints/iteration).

## Validation

- `moon fmt`
- `moon check --target all` — clean (only pre-existing `missing_doc` warnings in
  unrelated files; the new helper is private and documented). No `.mbti` change
  (generated `.mbti` churn from `moon info` was not committed).
- `moon test --target native -p builtin` — 2835 passed
- `moon test --target native -p deque` — 225 passed (panic-message tests confirm
  the diagnostic is byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
