### PR TITLE
perf(builtin): make Array::swap inlineable (follow-up to #3716)

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1170,10 +1170,7 @@ pub fn[T] Array::binary_search_by(
 /// ```
 pub fn[T] Array::swap(self : Array[T], i : Int, j : Int) -> Unit {
   if i >= self.length() || j >= self.length() || i < 0 || j < 0 {
-    let len = self.length()
-    abort(
-      "index out of bounds: the len is from 0 to \{len} but the index is (\{i}, \{j})",
-    )
+    index_out_of_bounds2(self.length(), i, j)
   }
   let temp = self.unsafe_get(i)
   self.unsafe_set(i, self.unsafe_get(j))

--- a/builtin/bounds.mbt
+++ b/builtin/bounds.mbt
@@ -27,3 +27,14 @@ fn[T] index_out_of_bounds(len : Int, index : Int) -> T {
     "index out of bounds: the len is from 0 to \{len} but the index is \{index}",
   )
 }
+
+///|
+/// Variant of [index_out_of_bounds] for accessors that take two indices (e.g.
+/// `Array::swap`). Kept `#inline(never)` for the same reason: keep the cold
+/// formatting out of the small hot accessor body so it stays inlineable.
+#inline(never)
+fn[T] index_out_of_bounds2(len : Int, i : Int, j : Int) -> T {
+  abort(
+    "index out of bounds: the len is from 0 to \{len} but the index is (\{i}, \{j})",
+  )
+}


### PR DESCRIPTION
## Summary

Follow-up to #3716. That PR made the checked view/deque accessors inlineable by
hoisting their interpolated out-of-bounds `abort` into a shared `#inline(never)`
helper. `Array::swap` is the same kind of small, hot accessor (used throughout
sorting / partitioning / shuffling) but was left out because its message carries
*two* indices and could not reuse the single-index `index_out_of_bounds` helper.

## Problem

`Array::swap`'s body is tiny (a bounds guard + three `unsafe_get`/`unsafe_set`),
but the out-of-bounds path inlines `abort("index out of bounds: ... (\{i}, \{j})")`,
which lowers to `StringBuilder` allocation + interpolation. That inflates the
body past clang's `-O2` inline-cost threshold:

```
'Array::swap' not inlined into <caller> because too costly to inline (cost=995, threshold=225)
```

So `swap` is emitted as an out-of-line call and loops that call it keep the call
per iteration.

## Fix

Add a two-index `index_out_of_bounds2(len, i, j)` cold helper (`#inline(never)`)
next to the existing `index_out_of_bounds`, and route `Array::swap` through it.

After this, `swap` drops to **cost ~70** and clang inlines it into its callers.
The diagnostic message is byte-identical (the helper formats the same string),
so panic-message tests are unchanged.

## Validation

- `moon fmt`
- `moon check --target native` — clean
- `moon test --target native -p builtin` — 2835 passed (swap correctness + panic
  tests included)
- Inline-cost check (clang `-Rpass`): `Array::swap` goes from "not inlined, too
  costly (cost=995)" to inlined (cost=70); the cold `index_out_of_bounds2` stays
  out of line, as intended.

No public API change (`index_out_of_bounds2` is private); no `.mbti` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
