### PR TITLE
perf(builtin): route StringView::at through the shared OOB helper

### DIFF
--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -37,7 +37,7 @@ fn StringView::make_view(str : String, start : Int, end : Int) -> StringView = "
 #alias(code_unit_at)
 pub fn StringView::at(self : StringView, index : Int) -> UInt16 {
   guard index >= 0 && index < self.length() else {
-    abort("Index out of bounds")
+    index_out_of_bounds(self.length(), index)
   }
   self.unsafe_get(index)
 }


### PR DESCRIPTION
## Summary

Consistency follow-up to #3716 / #3717. The other checked view accessors
(`ArrayView`/`MutArrayView`/`BytesView` `::at`/`::set`) route their out-of-bounds
path through the shared `#inline(never)` `index_out_of_bounds` helper.
`StringView::at` was the last `*View::at` still inlining its own `abort` call.
Route it through the same helper so all four views share one helper and one
message.

Unlike the others, `StringView::at` used a constant `abort("Index out of bounds")`,
so it was already inlineable (clang cost ~65). **This is a consistency change,
not a perf fix** — there is no measurable speedup; the value is uniformity.

## Behavior note

This changes `StringView::at`'s panic text from `"Index out of bounds"` to the
detailed `"index out of bounds: the len is from 0 to <len> but the index is <i>"`,
matching the other views. No test or doc pinned the old text. If preferred, the
short message can be kept instead (a no-arg helper) — happy to adjust.

## Validation

- `moon fmt`
- `moon check --target all` — clean
- `moon test --target native -p builtin` (2835), `-p string` (369)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
