### PR TITLE
refactor(builtin): deprecate `at` in favor of index operator `[i]`

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -180,6 +180,7 @@ pub fn[T] Array::unsafe_get(self : Array[T], idx : Int) -> T {
 ///
 #intrinsic("%array.get")
 #alias("_[_]")
+#deprecated("use `arr[i]` instead of `arr.at(i)`")
 pub fn[T] Array::at(self : Array[T], index : Int) -> T {
   let len = self.length()
   guard index >= 0 && index < len

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -133,6 +133,7 @@ pub fn[T] ArrayView::start_offset(self : Self[T]) -> Int {
 /// }
 /// ```
 #alias("_[_]")
+#deprecated("use `view[i]` instead of `view.at(i)`")
 pub fn[T] ArrayView::at(self : ArrayView[T], index : Int) -> T {
   guard index >= 0 && index < self.len() else {
     index_out_of_bounds(self.len(), index)

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1389,6 +1389,7 @@ pub impl Default for Char with fn default() = "%char_default"
 /// }
 /// ```
 #alias("_[_]")
+#deprecated("use `bytes[i]` instead of `bytes.at(i)`")
 pub fn Bytes::at(self : Bytes, idx : Int) -> Byte = "%bytes_get"
 
 ///|
@@ -1741,6 +1742,7 @@ pub fn String::length(self : String) -> Int = "%string_length"
 /// Panics if the index is out of bounds.
 #alias("_[_]")
 #alias(code_unit_at)
+#deprecated("use `str[i]` (or `str.code_unit_at(i)`) instead of `str.at(i)`")
 pub fn String::at(self : String, idx : Int) -> UInt16 = "%string_get"
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -71,6 +71,7 @@ pub fn[T] Array::all(Self[T], (T) -> Bool raise?) -> Bool raise?
 pub fn[T] Array::any(Self[T], (T) -> Bool raise?) -> Bool raise?
 pub fn[T] Array::append(Self[T], ArrayView[T]) -> Unit
 #alias("_[_]")
+#deprecated
 pub fn[T] Array::at(Self[T], Int) -> T
 pub fn[T : Compare] Array::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] Array::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
@@ -189,6 +190,7 @@ pub fn[T] ArrayView::all(Self[T], (T) -> Bool raise?) -> Bool raise?
 #alias(exists)
 pub fn[T] ArrayView::any(Self[T], (T) -> Bool raise?) -> Bool raise?
 #alias("_[_]")
+#deprecated
 pub fn[T] ArrayView::at(Self[T], Int) -> T
 pub fn[T : Compare] ArrayView::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] ArrayView::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
@@ -724,6 +726,7 @@ pub fn String::all(String, (Char) -> Bool raise?) -> Bool raise?
 pub fn String::any(String, (Char) -> Bool raise?) -> Bool raise?
 #alias("_[_]")
 #alias(code_unit_at)
+#deprecated
 pub fn String::at(String, Int) -> UInt16
 pub fn String::before(String, StringView) -> StringView?
 #alias(codepoint_length, deprecated)
@@ -971,6 +974,7 @@ pub fn[T] ReadOnlyArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] ReadOnlyArray::windows(Self[T], Int) -> Array[ArrayView[T]]
 
 #alias("_[_]")
+#deprecated
 pub fn Bytes::at(Bytes, Int) -> Byte
 pub fn Bytes::chop_prefix(Bytes, BytesView) -> BytesView?
 pub fn Bytes::chop_suffix(Bytes, BytesView) -> BytesView?


### PR DESCRIPTION
## What

Deprecate the `at` method in favor of the index operator `[i]` for `Array`, `ArrayView`, `Bytes`, and `String`.

All four are declared with `#alias("_[_]")`, so `xs[i]` and `xs.at(i)` are the *same* function. This adds `#deprecated` to nudge users toward the shorter `xs[i]` spelling.

## Why it's safe

`#deprecated` on an aliased method fires **only** on the explicit `.at(i)` method call — verified against the toolchain:

| call | warns? |
|------|--------|
| `xs.at(i)` | ✅ deprecated |
| `xs[i]` (operator alias) | — no warning |
| `str.code_unit_at(i)` (named alias on `String::at`) | — no warning |

So `xs[i]` keeps working untouched, and `String`'s descriptive `code_unit_at` alias stays available.

No non-test call sites in core use `.at()` on these four types, so nothing internal needs migrating. `moon check --deny-warn` is clean and the builtin suite (2877 tests) passes.

## Note for reviewers

For `String`, `str[i]` returns a `UInt16` code unit (not a `Char`); the deprecation message points to both `str[i]` and `str.code_unit_at(i)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)