### PR TITLE
perf(builtin): avoid duplicate bounds check in Array::at and Array::set

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -183,7 +183,7 @@ pub fn[T] Array::unsafe_get(self : Array[T], idx : Int) -> T {
 pub fn[T] Array::at(self : Array[T], index : Int) -> T {
   let len = self.length()
   guard index >= 0 && index < len
-  self.buffer()[index]
+  self.buffer().unsafe_get(index)
 }
 
 ///|
@@ -260,7 +260,7 @@ pub fn[T] Array::unsafe_set(self : Array[T], idx : Int, val : T) -> Unit {
 pub fn[T] Array::set(self : Array[T], index : Int, value : T) -> Unit {
   let len = self.length()
   guard index >= 0 && index < len
-  self.buffer()[index] = value
+  self.buffer().unsafe_set(index, value)
 }
 
 ///|


### PR DESCRIPTION
## What

`Array::at` and `Array::set` validate `index` with a `guard` and then index the backing buffer through the **checked** `UninitializedArray::at` / `::set` (the `_[_]` alias = `%fixedarray.get` / `%fixedarray.set`), which performs the *same* bounds check a second time. Switch the post-`guard` access to the unchecked `unsafe_get` / `unsafe_set` buffer accessors.

```diff
 pub fn[T] Array::at(self : Array[T], index : Int) -> T {
   let len = self.length()
   guard index >= 0 && index < len
-  self.buffer()[index]
+  self.buffer().unsafe_get(index)
 }
```

This matches how `ArrayView::at` is already written (`self.buf().unsafe_get(...)` after its guard).

## Safety

Behavior is identical. After `guard index >= 0 && index < len`, and since `len <= buffer.length()`, `index` is always a valid buffer index, so the removed check could never have fired.

Affects the non-inlined / fallback function body (in optimized builds `a[i]` lowers to the `%array.get` intrinsic); debug builds and any first-class use of these methods now skip the redundant check. `moon check --deny-warn` clean; builtin suite (2877 tests) passes.