### PR TITLE
fix(builtin): make Array::unsafe_get/unsafe_set skip bounds checks

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -153,7 +153,7 @@ pub fn[T] Array::capacity(self : Array[T]) -> Int {
 ///
 #intrinsic("%array.unsafe_get")
 pub fn[T] Array::unsafe_get(self : Array[T], idx : Int) -> T {
-  self.buffer()[idx]
+  self.buffer().unsafe_get(idx)
 }
 
 ///|
@@ -229,7 +229,7 @@ pub fn[T] Array::get(self : Array[T], index : Int) -> T? {
 /// ```
 #intrinsic("%array.unsafe_set")
 pub fn[T] Array::unsafe_set(self : Array[T], idx : Int, val : T) -> Unit {
-  self.buffer()[idx] = val
+  self.buffer().unsafe_set(idx, val)
 }
 
 ///|


### PR DESCRIPTION
## What

`Array::unsafe_get` / `Array::unsafe_set` are documented unsafe — *"caller must ensure `0 <= idx < length`"* — and lower to the unchecked `%array.unsafe_get` / `%array.unsafe_set` intrinsics at real call sites. But their fallback bodies indexed the buffer through the **checked** `UninitializedArray::at` / `::set` (the `_[_]` alias = `%fixedarray.get` / `%fixedarray.set`):

```diff
 pub fn[T] Array::unsafe_get(self : Array[T], idx : Int) -> T {
-  self.buffer()[idx]
+  self.buffer().unsafe_get(idx)
 }
```

So the body performed a bounds check the `unsafe` contract says it must not.

## Effect

At real call sites nothing changes (the `%array.unsafe_*` intrinsic is already unchecked). The body is used in non-inlined / first-class-function contexts; there, an out-of-bounds `idx` previously **panicked** and now is unchecked — which is the documented `unsafe` behavior, and consistent with the corresponding intrinsic.

`moon check --deny-warn` clean; builtin suite (2877 tests) passes.

> Companion to #3729 (which removes the *duplicate* check in the checked `at`/`set`). Kept separate because this one changes fallback behavior on misuse, so it warrants its own review.