### PR TITLE
fix(immut/vector): concat no longer builds a radix node with a partial leaf

### DIFF
--- a/immut/vector/concat_random_access_test.mbt
+++ b/immut/vector/concat_random_access_test.mbt
@@ -1,0 +1,58 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Regression test for https://github.com/moonbitlang/core/issues/3721.
+///
+/// Repeatedly concatenating partial chunks used to fold a partial leaf into a
+/// node that stayed marked as full (`sizes = None`), so iteration was correct
+/// but radix random access (`get`/`at`/`set`) went out of bounds.
+test "concat preserves random access (issue #3721)" {
+  let mut v = @vector.new()
+  let mut total = 0
+  for _ in 0..<8 {
+    v = v.concat(@vector.from_iter(total.until(total + 17)))
+    total += 17
+  }
+  let expected = Array::makei(total, i => i)
+  // Iteration was always correct ...
+  @debug.assert_eq(v.iter().to_array(), expected)
+  // ... and random access must agree with it.
+  @debug.assert_eq(Array::makei(total, j => v[j]), expected)
+  @debug.assert_eq(Array::makei(total, j => v.get(j).unwrap()), expected)
+  // `set` walks the same path, so it must agree too.
+  @debug.assert_eq(
+    Array::makei(total, j => v.set(j, -j)[j]),
+    Array::makei(total, j => -j),
+  )
+}
+
+///|
+/// Random access must match iteration for arbitrary `concat` chunkings, not just
+/// the minimal reproduction above.
+test "concat random access matches iteration for many chunkings (issue #3721)" {
+  for chunk in [1, 5, 17, 31, 32, 33, 50] {
+    for count in [2, 3, 5, 8, 16] {
+      let mut v = @vector.new()
+      let mut total = 0
+      for _ in 0..<count {
+        v = v.concat(@vector.from_iter(total.until(total + chunk)))
+        total += chunk
+      }
+      let by_iter = v.iter().to_array()
+      let by_index = Array::makei(total, j => v[j])
+      @debug.assert_eq(by_index, by_iter)
+    }
+  }
+}

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -244,25 +244,9 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
       // branch is always a partial leaf, so the root needs explicit sizes even
       // when `self` was radix.
       let new_branch = new_branch_left([value], shift)
+      let len = self.size(shift)
       (
-        match self {
-          Leaf(leaf) => {
-            let len = leaf.length()
-            Node([self, new_branch], Some([len, 1 + len]))
-          }
-          Node(_nodes, Some(sizes)) => {
-            let len = sizes[sizes.length() - 1]
-            Node([self, new_branch], Some([len, 1 + len]))
-          }
-          Node(_nodes, None) => {
-            let len = self.size(shift)
-            Node([self, new_branch], Some([len, 1 + len]))
-          }
-          Empty =>
-            abort(
-              "Unreachable: Empty tree should have fallen into the Some(new_tree) branch",
-            )
-        },
+        Node([self, new_branch], Some(FixedArray::from_array([len, 1 + len]))),
         shift + NUM_BITS,
       )
     }

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -54,9 +54,18 @@ fn[T] Tree::empty() -> Tree[T] {
 ///|
 /// Create a new tree with a single leaf. Note that the resulting tree is a left-skewed tree.
 fn[T] new_branch_left(leaf : FixedArray[T], shift : Int) -> Tree[T] {
+  // A full leaf keeps the branch radix-indexable (`None`). A partial leaf must
+  // be relaxed (`Some`): on its own it sits at the right edge, but once another
+  // leaf is appended to its right it becomes an interior, non-full leaf and
+  // radix indexing would read out of bounds.
+  let sizes : FixedArray[Int]? = if leaf.length() == BRANCHING_FACTOR {
+    None
+  } else {
+    Some([leaf.length()])
+  }
   match shift {
     0 => Leaf(leaf)
-    s => Node([new_branch_left(leaf, s - NUM_BITS)], None) // size is None because we can use radix indexing
+    s => Node([new_branch_left(leaf, s - NUM_BITS)], sizes)
   }
 }
 
@@ -196,25 +205,29 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
         let len = nodes.length()
         match worker(nodes[len - 1], shift - NUM_BITS) {
           // We have successfully pushed the value, now duplicate its ancestor nodes.
+          // Pushing a single value always lands in a partial leaf, so a radix
+          // (`None`) node must switch to explicit sizes.
           Some(new_node) => {
             let new_nodes = nodes.copy()
             new_nodes[len - 1] = new_node
-            let sizes = update_sizes_last(sizes)
-            Some(Node(new_nodes, sizes))
+            let new_sizes = match sizes {
+              Some(_) => update_sizes_last(sizes)
+              None => compute_sizes(new_nodes, shift - NUM_BITS)
+            }
+            Some(Node(new_nodes, new_sizes))
           }
           // We need to create a new node to push the value.
           None =>
             if len < BRANCHING_FACTOR {
-              let sizes = push_sizes_last(sizes)
-              Some(
-                Node(
-                  immutable_push(
-                    nodes,
-                    new_branch_left([value], shift - NUM_BITS),
-                  ),
-                  sizes,
-                ),
+              let new_nodes = immutable_push(
+                nodes,
+                new_branch_left([value], shift - NUM_BITS),
               )
+              let new_sizes = match sizes {
+                Some(_) => push_sizes_last(sizes)
+                None => compute_sizes(new_nodes, shift - NUM_BITS)
+              }
+              Some(Node(new_nodes, new_sizes))
             } else {
               None
             }
@@ -227,16 +240,24 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
   match worker(self, shift) {
     Some(new_tree) => (new_tree, shift)
     None => {
+      // The new root holds `self` plus a fresh single-element branch. That
+      // branch is always a partial leaf, so the root needs explicit sizes even
+      // when `self` was radix.
       let new_branch = new_branch_left([value], shift)
       (
         match self {
-          Leaf(_leaf) => Node([self, new_branch], None)
+          Leaf(leaf) => {
+            let len = leaf.length()
+            Node([self, new_branch], Some([len, 1 + len]))
+          }
           Node(_nodes, Some(sizes)) => {
             let len = sizes[sizes.length() - 1]
-            let sizes = FixedArray::from_array([len, 1 + len])
-            Node([self, new_branch], Some(sizes))
+            Node([self, new_branch], Some([len, 1 + len]))
           }
-          Node(_nodes, None) => Node([self, new_branch], None)
+          Node(_nodes, None) => {
+            let len = self.size(shift)
+            Node([self, new_branch], Some([len, 1 + len]))
+          }
           Empty =>
             abort(
               "Unreachable: Empty tree should have fallen into the Some(new_tree) branch",

--- a/immut/vector/tree_append.mbt
+++ b/immut/vector/tree_append.mbt
@@ -65,21 +65,38 @@ fn[T] Tree::append_right_leaf(
       Node(nodes, sizes) => {
         let len = nodes.length()
         match worker(nodes[len - 1], shift - NUM_BITS, leaf, delta) {
-          Some(new_node) =>
-            Some(
-              Node(
-                immutable_set(nodes, len - 1, new_node),
-                append_sizes_last(sizes, delta),
-              ),
-            )
+          Some(new_node) => {
+            // The right spine absorbed the leaf below us. If `sizes` was `None`
+            // (radix) and we just folded in a partial leaf, the node is no
+            // longer full and must carry an explicit sizes array.
+            let new_nodes = immutable_set(nodes, len - 1, new_node)
+            let new_sizes = match sizes {
+              Some(_) => append_sizes_last(sizes, delta)
+              None =>
+                if delta == BRANCHING_FACTOR {
+                  None
+                } else {
+                  compute_sizes(new_nodes, shift - NUM_BITS)
+                }
+            }
+            Some(Node(new_nodes, new_sizes))
+          }
           None =>
             if len < BRANCHING_FACTOR {
-              Some(
-                Node(
-                  immutable_push(nodes, new_branch_left(leaf, shift - NUM_BITS)),
-                  push_sizes_last(sizes, delta),
-                ),
+              let new_nodes = immutable_push(
+                nodes,
+                new_branch_left(leaf, shift - NUM_BITS),
               )
+              let new_sizes = match sizes {
+                Some(_) => push_sizes_last(sizes, delta)
+                None =>
+                  if delta == BRANCHING_FACTOR {
+                    None
+                  } else {
+                    compute_sizes(new_nodes, shift - NUM_BITS)
+                  }
+              }
+              Some(Node(new_nodes, new_sizes))
             } else {
               None
             }
@@ -95,12 +112,25 @@ fn[T] Tree::append_right_leaf(
       let new_branch = new_branch_left(leaf, shift)
       (
         match self {
-          Leaf(_) => Node([self, new_branch], None)
+          // A fresh root over `[self, new_branch]` stays radix only when every
+          // leaf is full: `self` is already radix and the appended leaf is full.
+          Leaf(elems) =>
+            if elems.length() == BRANCHING_FACTOR && delta == BRANCHING_FACTOR {
+              Node([self, new_branch], None)
+            } else {
+              Node([self, new_branch], Some([elems.length(), elems.length() + delta]))
+            }
           Node(_, Some(sizes)) => {
             let len = sizes[sizes.length() - 1]
             Node([self, new_branch], Some([len, len + delta]))
           }
-          Node(_, None) => Node([self, new_branch], None)
+          Node(_, None) =>
+            if delta == BRANCHING_FACTOR {
+              Node([self, new_branch], None)
+            } else {
+              let len = self.size(shift)
+              Node([self, new_branch], Some([len, len + delta]))
+            }
           Empty =>
             abort("Unreachable: Empty tree should have been handled in worker")
         },

--- a/immut/vector/tree_append.mbt
+++ b/immut/vector/tree_append.mbt
@@ -36,6 +36,22 @@ fn push_sizes_last(sizes : FixedArray[Int]?, delta : Int) -> FixedArray[Int]? {
 }
 
 ///|
+/// Sizes for a previously radix (`None`) node whose right spine just absorbed a
+/// leaf of `delta` elements. It stays radix only when a full leaf was appended;
+/// any partial leaf leaves the node non-full, so it needs explicit sizes.
+fn[T] radix_append_sizes(
+  children : FixedArray[Tree[T]],
+  child_shift : Int,
+  delta : Int,
+) -> FixedArray[Int]? {
+  if delta == BRANCHING_FACTOR {
+    None
+  } else {
+    compute_sizes(children, child_shift)
+  }
+}
+
+///|
 /// Append a leaf to the right spine of a tree without going through generic tree concat.
 fn[T] Tree::append_right_leaf(
   self : Tree[T],
@@ -72,12 +88,7 @@ fn[T] Tree::append_right_leaf(
             let new_nodes = immutable_set(nodes, len - 1, new_node)
             let new_sizes = match sizes {
               Some(_) => append_sizes_last(sizes, delta)
-              None =>
-                if delta == BRANCHING_FACTOR {
-                  None
-                } else {
-                  compute_sizes(new_nodes, shift - NUM_BITS)
-                }
+              None => radix_append_sizes(new_nodes, shift - NUM_BITS, delta)
             }
             Some(Node(new_nodes, new_sizes))
           }
@@ -89,12 +100,7 @@ fn[T] Tree::append_right_leaf(
               )
               let new_sizes = match sizes {
                 Some(_) => push_sizes_last(sizes, delta)
-                None =>
-                  if delta == BRANCHING_FACTOR {
-                    None
-                  } else {
-                    compute_sizes(new_nodes, shift - NUM_BITS)
-                  }
+                None => radix_append_sizes(new_nodes, shift - NUM_BITS, delta)
               }
               Some(Node(new_nodes, new_sizes))
             } else {
@@ -109,33 +115,24 @@ fn[T] Tree::append_right_leaf(
   match worker(self, shift, leaf, delta) {
     Some(new_tree) => (new_tree, shift)
     None => {
+      // A fresh root over `[self, new_branch]` stays radix only when every leaf
+      // is full: `self` is already radix and the appended leaf is full too.
       let new_branch = new_branch_left(leaf, shift)
-      (
-        match self {
-          // A fresh root over `[self, new_branch]` stays radix only when every
-          // leaf is full: `self` is already radix and the appended leaf is full.
-          Leaf(elems) =>
-            if elems.length() == BRANCHING_FACTOR && delta == BRANCHING_FACTOR {
-              Node([self, new_branch], None)
-            } else {
-              Node([self, new_branch], Some([elems.length(), elems.length() + delta]))
-            }
-          Node(_, Some(sizes)) => {
-            let len = sizes[sizes.length() - 1]
-            Node([self, new_branch], Some([len, len + delta]))
-          }
-          Node(_, None) =>
-            if delta == BRANCHING_FACTOR {
-              Node([self, new_branch], None)
-            } else {
-              let len = self.size(shift)
-              Node([self, new_branch], Some([len, len + delta]))
-            }
-          Empty =>
-            abort("Unreachable: Empty tree should have been handled in worker")
-        },
-        shift + NUM_BITS,
-      )
+      let self_radix = match self {
+        Node(_, None) => true
+        Leaf(elems) => elems.length() == BRANCHING_FACTOR
+        Node(_, Some(_)) => false
+        Empty =>
+          abort("Unreachable: Empty tree should have been handled in worker")
+      }
+      let new_sizes : FixedArray[Int]? = if self_radix &&
+        delta == BRANCHING_FACTOR {
+        None
+      } else {
+        let len = self.size(shift)
+        Some([len, len + delta])
+      }
+      (Node([self, new_branch], new_sizes), shift + NUM_BITS)
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #3721.

`@immut/vector.Vector::concat` could produce a tree whose `iter()`/`to_array()`
view was correct but whose **random access** (`get`/`at`/`set`) threw `array
element access out of bounds`.

The small-right-operand path of `concat` (`other.tree is Empty`) folds the left
tail into the tree via `normalize_tree` → `Tree::push_end` /
`Tree::append_right_leaf`. Those right-spine helpers propagated the radix marker
(`sizes = None`) even when the appended chunk was a **partial** leaf, yielding a
`Node(_, None)` that radix indexing wrongly treats as full and then indexes out
of range for an interior index.

## Fix

A right-spine append keeps a node radix only when every leaf stays full, i.e. the
appended leaf is itself full (`delta == BRANCHING_FACTOR`). Otherwise the touched
nodes carry an explicit sizes array (via `compute_sizes`). This covers both the
new-branch path and the spine-absorbed path (a partial leaf can land in a short,
left-packed subtree). `push_end` always appends a single value, so it always
relaxes; `append_right_leaf` keeps the radix fast path for the full-leaf case
used by `push`, so `push` is not affected.

## Commits

1. `test` — failing black-box regression test (minimal 8×17 repro + a sweep over
   many chunk sizes/counts).
2. `fix` — keep sizes when folding a partial leaf into the tree.
3. `refactor` — dedupe the radix-vs-relaxed sizing decision (no behavior change).

## Validation

- New regression tests fail before the fix, pass after.
- All existing `immut/vector` tests pass on **wasm, wasm-gc, js, native**.
- A local randomized stress test (3000 trials of mixed `push`/`concat`/`set`/`pop`)
  confirms random access always agrees with a reference model and a precise
  left-packed radix invariant holds (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)