### PR TITLE
refactor(strconv): drop redundant .to_int() on '0' literal

### DIFF
--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -476,7 +476,7 @@ fn Decimal::new_digits(self : Decimal, s : Int) -> Int {
     if i >= self.digits_num {
       break true
     }
-    let d = code_unit.to_int() - '0'.to_int()
+    let d = code_unit.to_int() - '0'
     if self.digits[i].to_int() != d {
       break self.digits[i].to_int() < d
     }


### PR DESCRIPTION
Tiny readability cleanup: in `decimal.mbt` the digit conversion `code_unit.to_int() - '0'.to_int()` can drop the literal's `.to_int()` — a char literal overloads to `Int` in the arithmetic context, so `'0'.to_int()` is just `'0'`.

Behavior-identical. `moon test strconv` 60/60, `moon check` / `moon fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)