### PR TITLE
refactor(internal/strconv): drop redundant .to_int() on '0' literal

### DIFF
--- a/internal/strconv/strconv_decimal.mbt
+++ b/internal/strconv/strconv_decimal.mbt
@@ -485,7 +485,7 @@ fn Decimal::new_digits(self : Decimal, s : Int) -> Int {
     if i >= self.digits_num {
       break true
     }
-    let d = code_unit.to_int() - '0'.to_int()
+    let d = code_unit.to_int() - '0'
     if self.digits[i].to_int() != d {
       break self.digits[i].to_int() < d
     }


### PR DESCRIPTION
Tiny readability cleanup mirroring the same fix in `strconv`: `code_unit.to_int() - '0'.to_int()` -> `code_unit.to_int() - '0'` (the char literal overloads to `Int`). Behavior-identical. `moon test internal/strconv` 25/25, check/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)