### PR TITLE
refactor(string/regex_parser): drop redundant .to_int() on char literals

### DIFF
--- a/string/internal/regex_parser/parser.mbt
+++ b/string/internal/regex_parser/parser.mbt
@@ -226,7 +226,7 @@ fn Parser::quant_bound(
   ctx~ : ParserContext,
 ) -> Int raise ParserError {
   for c in digits; value = 0 {
-    let digit = c.to_int() - '0'.to_int()
+    let digit = c.to_int() - '0'
     let next = value * 10 + digit
     guard next <= MAX_QUANT else {
       raise ctx.error_at(digits, HINT_QUANTIFIER_TOO_LARGE)

--- a/string/internal/regex_parser/parser_util.mbt
+++ b/string/internal/regex_parser/parser_util.mbt
@@ -17,9 +17,9 @@ fn hex2i(hex : StringView) -> Int {
   for c in hex; value = 0 {
     let value = value * 16
     match c {
-      '0'..='9' => continue value + (c.to_int() - '0'.to_int())
-      'a'..='f' => continue value + (c.to_int() - 'a'.to_int() + 10)
-      'A'..='F' => continue value + (c.to_int() - 'A'.to_int() + 10)
+      '0'..='9' => continue value + (c.to_int() - '0')
+      'a'..='f' => continue value + (c.to_int() - 'a' + 10)
+      'A'..='F' => continue value + (c.to_int() - 'A' + 10)
       _ => panic()
     }
   } nobreak {


### PR DESCRIPTION
Tiny readability cleanup in the regex parser's digit conversions (`quant_bound`, `hex2i`): char literals overload to `Int` in the arithmetic context, so `c.to_int() - '0'.to_int()` is `c.to_int() - '0'` (and likewise for `'a'`/`'A'`). Behavior-identical. `moon test string/internal/regex_parser` 94/94, check/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)