### PR TITLE
perf(builtin): add intrinsics for view accessor methods

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -71,6 +71,7 @@ fn[T] ArrayView::make(
 ///   inspect(view.length(), content="2")
 /// }
 /// ```
+#intrinsic("%arrayview.length")
 pub fn[T] ArrayView::length(self : ArrayView[T]) -> Int {
   self.len()
 }
@@ -132,6 +133,7 @@ pub fn[T] ArrayView::start_offset(self : Self[T]) -> Int {
 ///   inspect(view[1], content="4")
 /// }
 /// ```
+#intrinsic("%arrayview.get")
 #alias("_[_]")
 pub fn[T] ArrayView::at(self : ArrayView[T], index : Int) -> T {
   guard index >= 0 && index < self.len() else {

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -42,6 +42,7 @@ fn BytesView::make(b : Bytes, start : Int, len : Int) -> BytesView = "%bytesview
 ///   inspect(view.length(), content="2")
 /// }
 /// ```
+#intrinsic("%bytesview.length")
 pub fn BytesView::length(self : BytesView) -> Int {
   self.len()
 }
@@ -82,6 +83,7 @@ pub fn BytesView::is_empty(self : BytesView) -> Bool {
 ///   inspect(view[1], content="b'\\x03'")
 /// }
 /// ```
+#intrinsic("%bytesview.get")
 #alias("_[_]")
 pub fn BytesView::at(self : BytesView, index : Int) -> Byte {
   guard index >= 0 && index < self.length() else {
@@ -149,6 +151,7 @@ pub fn BytesView::get(self : BytesView, index : Int) -> Byte? {
 /// }
 /// ```
 ///
+#intrinsic("%bytesview.unsafe_get")
 #internal(unsafe, "Panic if index is out of bounds")
 #doc(hidden)
 pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -63,6 +63,7 @@ fn[T] MutArrayView::make(
 ///   inspect(view.length(), content="2")
 /// }
 /// ```
+#intrinsic("%mutarrayview.length")
 pub fn[T] MutArrayView::length(self : MutArrayView[T]) -> Int {
   self.len()
 }
@@ -112,6 +113,7 @@ pub fn[T] MutArrayView::start_offset(self : MutArrayView[T]) -> Int {
 ///   inspect(view[1], content="4")
 /// }
 /// ```
+#intrinsic("%mutarrayview.get")
 #alias("_[_]")
 pub fn[T] MutArrayView::at(self : MutArrayView[T], index : Int) -> T {
   guard index >= 0 && index < self.len() else {
@@ -141,7 +143,7 @@ pub fn[T] MutArrayView::at(self : MutArrayView[T], index : Int) -> T {
 ///   inspect(view.unsafe_get(1), content="3")
 /// }
 /// ```
-#intrinsic("%arrayview.unsafe_get")
+#intrinsic("%mutarrayview.unsafe_get")
 #internal(unsafe, "Panic if index is out of bounds")
 pub fn[T] MutArrayView::unsafe_get(self : MutArrayView[T], index : Int) -> T {
   self.buf()[self.start() + index]
@@ -170,6 +172,7 @@ pub fn[T] MutArrayView::unsafe_get(self : MutArrayView[T], index : Int) -> T {
 ///   inspect(arr[2], content="10")
 /// }
 /// ```
+#intrinsic("%mutarrayview.set")
 #alias("_[_]=_")
 pub fn[T] MutArrayView::set(
   self : MutArrayView[T],
@@ -202,7 +205,7 @@ pub fn[T] MutArrayView::set(
 ///   inspect(view[1], content="10")
 /// }
 /// ```
-#intrinsic("%arrayview.unsafe_set")
+#intrinsic("%mutarrayview.unsafe_set")
 #internal(unsafe, "Panic if index is out of bounds")
 pub fn[T] MutArrayView::unsafe_set(
   self : MutArrayView[T],

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -32,7 +32,7 @@ fn StringView::make_view(str : String, start : Int, end : Int) -> StringView = "
 /// 
 /// This method has O(1) complexity.
 /// Panics if the index is out of bounds.
-/// TODO: make it intrinsic
+#intrinsic("%stringview.get")
 #alias("_[_]")
 #alias(code_unit_at)
 pub fn StringView::at(self : StringView, index : Int) -> UInt16 {
@@ -46,6 +46,7 @@ pub fn StringView::at(self : StringView, index : Int) -> UInt16 {
 /// Returns the length of the view.
 /// 
 /// This method counts the charcodes(code unit) in the view and has O(1) complexity.
+#intrinsic("%stringview.length")
 pub fn StringView::length(self : StringView) -> Int {
   self.end() - self.start()
 }
@@ -124,6 +125,7 @@ pub fn StringView::view(
 /// index is within bounds.
 ///
 /// This method has O(1) complexity.
+#intrinsic("%stringview.unsafe_get")
 #internal(unsafe, "Undefined behavior if index is out of bounds.")
 pub fn StringView::unsafe_get(self : StringView, index : Int) -> UInt16 {
   self.str().unsafe_get(self.start() + index)


### PR DESCRIPTION
## Summary

Annotates the checked accessors and `length` methods of the view types with their corresponding compiler intrinsics, so the compiler can lower these hot accessors directly. This follows the existing `%array.*` convention, where the intrinsic is attached to the `::at`/`::set` checked accessor (not the `Option`-returning `get`).

Added/updated annotations:

- **ArrayView**: `%arrayview.length`, `%arrayview.get`
- **MutArrayView**: `%mutarrayview.length` / `get` / `set`, and migrate `unsafe_get` / `unsafe_set` from the legacy `%arrayview.*` names to the dedicated `%mutarrayview.*` family
- **BytesView**: `%bytesview.length` / `get` / `unsafe_get`
- **StringView**: `%stringview.length` / `get` / `unsafe_get` (fulfilling the existing `TODO: make it intrinsic` on `StringView::at`)

## Validation

- `moon fmt`
- `moon test --target native -p builtin` — 2835 passed, 0 failed
- `moon bench --target native -p builtin -f view_bench_test.mbt` — checked the view-accessor microbenchmarks before/after; performance is basically the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)