### PR TITLE
perf(builtin): speed up Bytes::equal

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -335,43 +335,6 @@ pub fn FixedArray::set_utf16be_char(
 }
 
 ///|
-/// Compares two byte sequences for equality. Returns true only if both sequences
-/// have the same length and contain identical bytes in the same order.
-///
-/// Parameters:
-///
-/// * `self` : The first byte sequence to compare.
-/// * `other` : The second byte sequence to compare.
-///
-/// Returns `true` if the byte sequences are equal, `false` otherwise.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let bytes1 = b"\x01\x02\x03"
-///   let bytes2 = b"\x01\x02\x03"
-///   let bytes3 = b"\x01\x02\x04"
-///   inspect(bytes1 == bytes2, content="true")
-///   inspect(bytes1 == bytes3, content="false")
-/// }
-/// ```
-pub impl Eq for Bytes with fn equal(self : Bytes, other : Bytes) -> Bool {
-  if self.length() != other.length() {
-    false
-  } else {
-    let len = self.length()
-    for i in 0..<len {
-      if self[i] != other[i] {
-        break false
-      }
-    } nobreak {
-      true
-    }
-  }
-}
-
-///|
 /// Compares two byte sequences based on shortlex order. First compares the lengths of
 /// the sequences, then compares bytes pairwise until a difference is found or
 /// all bytes have been compared.

--- a/builtin/bytes_equal_bench_test.mbt
+++ b/builtin/bytes_equal_bench_test.mbt
@@ -1,0 +1,58 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let bytes_equal_bench_size = 100_000
+
+///|
+fn make_bytes_equal_bench_bytes(diff_at? : Int = -1) -> Bytes {
+  let arr = Array::make(bytes_equal_bench_size, b'\x61')
+  if diff_at >= 0 {
+    arr[diff_at] = b'\x62'
+  }
+  Bytes::from_array(arr)
+}
+
+///|
+fn make_bytes_equal_bench_aliases() -> Array[Bytes] {
+  let bytes = make_bytes_equal_bench_bytes()
+  let aliases = Array::make(2, b"")
+  aliases[0] = bytes
+  aliases[1] = bytes
+  aliases
+}
+
+///|
+test "bench Bytes::equal n=100000 equal" (it : @bench.T) {
+  let left = make_bytes_equal_bench_bytes()
+  let right = make_bytes_equal_bench_bytes()
+  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+}
+
+///|
+test "bench Bytes::equal n=100000 aliased object" (it : @bench.T) {
+  let aliases = make_bytes_equal_bench_aliases()
+  let mut index = 0
+  it.bench(fn() {
+    index = 1 - index
+    it.keep(Bytes::equal(aliases[index], aliases[1 - index]))
+  })
+}
+
+///|
+test "bench Bytes::equal n=100000 mismatch at end" (it : @bench.T) {
+  let left = make_bytes_equal_bench_bytes()
+  let right = make_bytes_equal_bench_bytes(diff_at=bytes_equal_bench_size - 1)
+  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+}

--- a/builtin/bytes_equal_fast.mbt
+++ b/builtin/bytes_equal_fast.mbt
@@ -1,0 +1,44 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Compares two byte sequences for equality. Returns true only if both sequences
+/// have the same length and contain identical bytes in the same order.
+///
+/// Parameters:
+///
+/// * `self` : The first byte sequence to compare.
+/// * `other` : The second byte sequence to compare.
+///
+/// Returns `true` if the byte sequences are equal, `false` otherwise.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let bytes1 = b"\x01\x02\x03"
+///   let bytes2 = b"\x01\x02\x03"
+///   let bytes3 = b"\x01\x02\x04"
+///   inspect(bytes1 == bytes2, content="true")
+///   inspect(bytes1 == bytes3, content="false")
+/// }
+/// ```
+pub impl Eq for Bytes with fn equal(self : Bytes, other : Bytes) -> Bool {
+  if physical_equal(self, other) {
+    return true
+  }
+  let len = self.length()
+  guard len == other.length() else { return false }
+  self.unsafe_range_equal(0, other, 0, len)
+}

--- a/builtin/bytes_equal_wasmgc.mbt
+++ b/builtin/bytes_equal_wasmgc.mbt
@@ -38,8 +38,8 @@ pub impl Eq for Bytes with fn equal(self : Bytes, other : Bytes) -> Bool {
   if physical_equal(self, other) {
     return true
   }
-  guard self.length() == other.length() else { return false }
   let len = self.length()
+  guard len == other.length() else { return false }
   for i in 0..<len {
     if self[i] != other[i] {
       break false

--- a/builtin/bytes_equal_wasmgc.mbt
+++ b/builtin/bytes_equal_wasmgc.mbt
@@ -1,0 +1,50 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Compares two byte sequences for equality. Returns true only if both sequences
+/// have the same length and contain identical bytes in the same order.
+///
+/// Parameters:
+///
+/// * `self` : The first byte sequence to compare.
+/// * `other` : The second byte sequence to compare.
+///
+/// Returns `true` if the byte sequences are equal, `false` otherwise.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let bytes1 = b"\x01\x02\x03"
+///   let bytes2 = b"\x01\x02\x03"
+///   let bytes3 = b"\x01\x02\x04"
+///   inspect(bytes1 == bytes2, content="true")
+///   inspect(bytes1 == bytes3, content="false")
+/// }
+/// ```
+pub impl Eq for Bytes with fn equal(self : Bytes, other : Bytes) -> Bool {
+  if physical_equal(self, other) {
+    return true
+  }
+  guard self.length() == other.length() else { return false }
+  let len = self.length()
+  for i in 0..<len {
+    if self[i] != other[i] {
+      break false
+    }
+  } nobreak {
+    true
+  }
+}

--- a/builtin/bytes_unsafe.mbt
+++ b/builtin/bytes_unsafe.mbt
@@ -558,8 +558,9 @@ pub fn BytesView::unsafe_read_uint16_be(
 /// - `self_off`, `other_off`: starting byte offsets
 /// - `len`: number of bytes to compare
 ///
-/// This is the shared intrinsic-backed primitive for view/owned equality
-/// comparisons (e.g. `BytesView == BytesView`, `BytesView::equal_to_bytes`).
+/// This is the shared intrinsic-backed primitive for owned/view equality
+/// comparisons (e.g. `Bytes == Bytes`, `BytesView == BytesView`,
+/// `BytesView::equal_to_bytes`).
 /// The function body is the fallback implementation for targets without the
 /// intrinsic.
 #borrow(self, other)

--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -33,6 +33,8 @@ options(
     "assert_debug_test.mbt": [ "debug" ],
     "assert_release.mbt": [ "not", "debug" ],
     "assert_release_test.mbt": [ "not", "debug" ],
+    "bytes_equal_fast.mbt": [ "not", "wasm-gc" ],
+    "bytes_equal_wasmgc.mbt": [ "wasm-gc" ],
     "double_mod_js.mbt": [ "js" ],
     "double_mod_nonjs.mbt": [ "not", "js" ],
     "double_pow_js.mbt": [ "js" ],


### PR DESCRIPTION
## Summary

- Split `Bytes::equal` into target-specific implementations.
- Use `Bytes::unsafe_range_equal` with a `physical_equal` fast path on non-wasm-gc targets.
- Keep wasm-gc on the byte loop plus the same alias fast path, because `unsafe_range_equal` regressed distinct-buffer cases there in local benchmarks.
- Add direct `Bytes::equal` benchmarks for equal, aliased, and end-mismatch cases.

Fixes #3589.

## Benchmarks

Benchmarks call `Bytes::equal(...)` directly with 100,000-byte inputs. Lower is better.

Before: `upstream/main` at `183fee1c` with the same benchmark file applied locally.
After: this PR at `a428940d`.

| target | case | before | after |
| --- | --- | ---: | ---: |
| native | equal | 23.69 us +/- 183.73 ns | 1.84 us +/- 32.15 ns |
| native | aliased object | 23.79 us +/- 124.79 ns | 5.34 ns +/- 0.13 ns |
| native | mismatch at end | 25.50 us +/- 212.08 ns | 1.85 us +/- 62.76 ns |
| wasm | equal | 122.26 us +/- 974.52 ns | 53.52 us +/- 7.72 us |
| wasm | aliased object | 121.63 us +/- 427.71 ns | 15.52 ns +/- 3.05 ns |
| wasm | mismatch at end | 123.85 us +/- 3.96 us | 47.87 us +/- 587.48 ns |
| js | equal | 467.67 us +/- 11.18 us | 50.43 us +/- 656.58 ns |
| js | aliased object | 119.06 us +/- 1.46 us | 7.37 ns +/- 0.25 ns |
| js | mismatch at end | 118.66 us +/- 650.21 ns | 36.47 us +/- 10.07 us |
| wasm-gc | equal | 35.47 us +/- 141.79 ns | 40.09 us +/- 7.59 us |
| wasm-gc | aliased object | 35.90 us +/- 486.91 ns | 5.22 ns +/- 0.22 ns |
| wasm-gc | mismatch at end | 35.54 us +/- 88.56 ns | 37.19 us +/- 1.88 us |

The wasm-gc distinct-buffer cases stay close to the old loop and are noisy; the alias fast path is the intended wasm-gc improvement.

I also checked `moon test --profile` after pointing `DEVELOPER_DIR` at Xcode so `xctrace` is available. It ran successfully, but the sample count was too low to use as the primary benchmark table.

## Validation

- `moon fmt`
- `moon test -p builtin --target wasm`
- `moon test -p builtin --target wasm-gc`
- `moon test -p builtin --target native`
- `moon test -p builtin --target js`
- `moon check -p builtin --target all`
- `moon info`
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer moon test -p builtin --target native --profile`
