### PR TITLE
feat: add lnot to Int16 and UInt16

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -644,6 +644,7 @@ pub fn UInt::trunc_double(Double) -> UInt
 pub fn UInt16::is_leading_surrogate(UInt16) -> Bool
 pub fn UInt16::is_surrogate(UInt16) -> Bool
 pub fn UInt16::is_trailing_surrogate(UInt16) -> Bool
+pub fn UInt16::lnot(UInt16) -> UInt16
 pub fn UInt16::to_byte(UInt16) -> Byte
 pub fn UInt16::to_char(UInt16) -> Char?
 pub fn UInt16::to_int(UInt16) -> Int

--- a/builtin/uint16_char.mbt
+++ b/builtin/uint16_char.mbt
@@ -151,6 +151,28 @@ pub impl BitXOr for UInt16 with fn lxor(self : UInt16, that : UInt16) -> UInt16 
 }
 
 ///|
+/// Performs a bitwise NOT operation on a `UInt16` value, flipping every bit
+/// within its 16-bit width.
+///
+/// Parameters:
+///
+/// - `self` : The `UInt16` value to apply the bitwise NOT operation on.
+///
+/// Returns the result of the bitwise NOT operation as a `UInt16`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect((0x0000 : UInt16).lnot().to_int(), content="65535")
+///   inspect((0xFFFF : UInt16).lnot().to_int(), content="0")
+/// }
+/// ```
+pub fn UInt16::lnot(self : UInt16) -> UInt16 {
+  self.to_int().lnot().to_uint16()
+}
+
+///|
 pub impl Default for UInt16 with fn default() {
   0
 }

--- a/builtin/uint16_char_test.mbt
+++ b/builtin/uint16_char_test.mbt
@@ -46,6 +46,10 @@ test "UInt16 arithmetic and bit ops" {
   inspect((a | b).to_int(), content="19")
   inspect((a & b).to_int(), content="0")
   inspect((a ^ b).to_int(), content="19")
+  inspect(a.lnot().to_int(), content="65519")
+  inspect((0x0000 : UInt16).lnot().to_int(), content="65535")
+  inspect((0xFFFF : UInt16).lnot().to_int(), content="0")
+  inspect(a.lnot().lnot().to_int(), content="16")
   inspect(a == b, content="false")
   inspect(a != b, content="true")
 }

--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -101,6 +101,28 @@ pub impl BitXOr for Int16 with fn lxor(self : Int16, that : Int16) -> Int16 {
 }
 
 ///|
+/// Performs a bitwise NOT operation on an `Int16` value, flipping every bit
+/// within its 16-bit width.
+///
+/// Parameters:
+///
+/// * `self` : The `Int16` value to apply the bitwise NOT operation on.
+///
+/// Returns the result of the bitwise NOT operation as an `Int16`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect((0 : Int16).lnot(), content="-1")
+///   inspect((-1 : Int16).lnot(), content="0")
+/// }
+/// ```
+pub fn Int16::lnot(self : Int16) -> Int16 {
+  Int16::from_int(self.to_int().lnot())
+}
+
+///|
 pub impl Neg for Int16 with fn neg(self : Int16) -> Int16 {
   Int16::from_int(-self.to_int())
 }

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -394,6 +394,18 @@ test "Int16::lxor" {
 }
 
 ///|
+test "Int16::lnot" {
+  let lnot = (a : Int16) => a.lnot()
+  inspect(lnot(0), content="-1")
+  inspect(lnot(-1), content="0")
+  inspect(lnot(1), content="-2")
+  inspect(lnot(32767), content="-32768")
+  inspect(lnot(-32768), content="32767")
+  // Double negation is the identity within the 16-bit width.
+  inspect(lnot(lnot(12345)), content="12345")
+}
+
+///|
 test "Int16::mod" {
   let mod = (a : Int16, b : Int16) => a % b
   inspect(mod(10, 3), content="1")

--- a/int16/pkg.generated.mbti
+++ b/int16/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub fn Int16::abs(Int16) -> Int16
 pub fn Int16::from_byte(Byte) -> Int16
 pub fn Int16::from_int(Int) -> Int16
 pub fn Int16::from_int64(Int64) -> Int16
+pub fn Int16::lnot(Int16) -> Int16
 pub fn Int16::reinterpret_as_uint16(Int16) -> UInt16
 pub fn Int16::reinterpret_from_uint16(UInt16) -> Int16
 pub fn Int16::to_byte(Int16) -> Byte


### PR DESCRIPTION
## What

Add `Int16::lnot` and `UInt16::lnot`.

## Why

`Int16` and `UInt16` already implement `land` / `lor` / `lxor` / `shl` / `shr`, but `lnot` was missing — every other integer type (`Byte`, `Int`, `UInt`, `Int64`, `UInt64`) provides it. These two 16-bit types were the only gap in the bitwise API, forcing users to round-trip through `Int` for a primitive op the rest of the family exposes directly.

## How

The implementations delegate to `Int::lnot` within the 16-bit width, matching the existing style of the other bitwise ops on these types:

​```moonbit
pub fn Int16::lnot(self : Int16) -> Int16 { Int16::from_int(self.to_int().lnot()) }
pub fn UInt16::lnot(self : UInt16) -> UInt16 { self.to_int().lnot().to_uint16() }
​```

## Tests

Doc examples on both functions, plus boundary-value and double-negation cases. Verified with `moon fmt` / `moon check` (no warnings) / `moon test` (int16: 43, builtin: 2878 passed) / `moon info`.
