### PR TITLE
use unicode-safe runtime API for `@env`

### DIFF
--- a/env/env.mbt
+++ b/env/env.mbt
@@ -59,7 +59,8 @@ pub fn unset_env_var(key : String) -> Unit {
 /// so native-only import will result in unused import warning on other targets.
 /// Manually supress the unused warning here.
 #cfg(not(target="native"))
-let _supress_unused_warning : Unit = {
+#warnings("-unused_value")
+fn unused_function() -> Unit {
   ignore(@ref.Ref(42))
   ignore(@utf8.encode(""))
 }

--- a/env/env.mbt
+++ b/env/env.mbt
@@ -53,3 +53,13 @@ pub fn set_env_var(key : String, value : String) -> Unit {
 pub fn unset_env_var(key : String) -> Unit {
   unset_env_var_internal(key)
 }
+
+///|
+/// Currently `moon` does not support conditional import,
+/// so native-only import will result in unused import warning on other targets.
+/// Manually supress the unused warning here.
+#cfg(not(target="native"))
+let _supress_unused_warning : Unit = {
+  ignore(@ref.Ref(42))
+  ignore(@utf8.encode(""))
+}

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -13,166 +13,124 @@
 // limitations under the License.
 
 ///|
-fn get_cli_args_ffi() -> FixedArray[Bytes] = "$moonbit.get_cli_args"
+/// On Windows, we use native `W` series unicode API,
+/// which return string in UTF-16 directly,
+/// so no need for extra encoding phase here.
+///
+/// Note: technically path etc. may not be invalid UTF-16 on Windows,
+///   but this should be extremely rare in practice.
+///   If we need to fix this case, a validation or encoding phase can be added.
+#cfg(platform="windows")
+priv struct OsString(String)
+
+///|
+/// On non-Windows platforms, path etc. are essentially binary data,
+/// and we assume they contain UTF-8 encoded text here.
+#cfg(not(platform="windows"))
+priv struct OsString(Bytes)
+
+///|
+#cfg(platform="windows")
+fn OsString::to_string(self : OsString) -> String {
+  self.0
+}
+
+///|
+#cfg(not(platform="windows"))
+fn OsString::to_string(self : OsString) -> String {
+  @utf8.decode_lossy(self.0)
+}
+
+///|
+#cfg(platform="windows")
+fn OsString::from_string(str : String) -> OsString {
+  OsString(str)
+}
+
+///|
+#cfg(not(platform="windows"))
+fn OsString::from_string(str : String) -> OsString {
+  OsString(@utf8.encode(str))
+}
+
+///|
+extern "C" fn get_cli_args_ffi() -> FixedArray[OsString] = "moonbit_rt_get_cli_args"
 
 ///|
 fn get_cli_args_internal() -> Array[String] {
   [
-    for t in get_cli_args_ffi() => utf8_bytes_to_mbt_string(t)
+    for t in get_cli_args_ffi() => t.to_string()
   ]
-}
-
-///|
-fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
-  let res = StringBuilder()
-  let len = bytes.length()
-  let mut i = 0
-  while i < len {
-    let mut c = bytes[i].to_int()
-    // zero byte indicates end of string
-    if c == 0 {
-      break
-    } else if c < 0x80 {
-      res.write_char(c.unsafe_to_char())
-      i += 1
-    } else if c < 0xE0 {
-      if i + 1 >= len {
-        break
-      }
-      c = ((c & 0x1F) << 6) | (bytes[i + 1].to_int() & 0x3F)
-      res.write_char(c.unsafe_to_char())
-      i += 2
-    } else if c < 0xF0 {
-      if i + 2 >= len {
-        break
-      }
-      c = ((c & 0x0F) << 12) |
-        ((bytes[i + 1].to_int() & 0x3F) << 6) |
-        (bytes[i + 2].to_int() & 0x3F)
-      res.write_char(c.unsafe_to_char())
-      i += 3
-    } else {
-      if i + 3 >= len {
-        break
-      }
-      c = ((c & 0x07) << 18) |
-        ((bytes[i + 1].to_int() & 0x3F) << 12) |
-        ((bytes[i + 2].to_int() & 0x3F) << 6) |
-        (bytes[i + 3].to_int() & 0x3F)
-      c -= 0x10000
-      res.write_char(((c >> 10) + 0xD800).unsafe_to_char())
-      res.write_char(((c & 0x3FF) + 0xDC00).unsafe_to_char())
-      i += 4
-    }
-  }
-  res.to_string()
-}
-
-///|
-fn mbt_string_to_utf8_bytes(str : String, append_nul : Bool) -> Bytes {
-  let res : Array[Byte] = []
-  let len = str.length()
-  let mut i = 0
-  while i < len {
-    let mut c = str.code_unit_at(i).to_int()
-    if 0xD800 <= c && c <= 0xDBFF {
-      c -= 0xD800
-      i = i + 1
-      let l = str.code_unit_at(i).to_int() - 0xDC00
-      c = (c << 10) + l + 0x10000
-    }
-    if c < 0x80 {
-      res.push(c.to_byte())
-    } else if c < 0x800 {
-      res.push((0xc0 + (c >> 6)).to_byte())
-      res.push((0x80 + (c & 0x3f)).to_byte())
-    } else if c < 0x10000 {
-      res.push((0xe0 + (c >> 12)).to_byte())
-      res.push((0x80 + ((c >> 6) & 0x3f)).to_byte())
-      res.push((0x80 + (c & 0x3f)).to_byte())
-    } else {
-      res.push((0xf0 + (c >> 18)).to_byte())
-      res.push((0x80 + ((c >> 12) & 0x3f)).to_byte())
-      res.push((0x80 + ((c >> 6) & 0x3f)).to_byte())
-      res.push((0x80 + (c & 0x3f)).to_byte())
-    }
-    i = i + 1
-  }
-  if append_nul {
-    res.push((0).to_byte())
-  }
-  Bytes::from_array(res)
 }
 
 ///|
 extern "c" fn now_internal() -> UInt64 = "moonbit_get_ms_since_epoch"
 
 ///|
-#borrow(ptr)
-extern "c" fn getcwd(ptr : Bytes, size : Int) -> Int = "getcwd"
+extern "c" fn getcwd() -> OsString = "moonbit_rt_get_current_dir"
 
 ///|
 fn current_dir_internal() -> String? {
-  // TODO: On Windows getcwd may fail if the path is too long(Windows allows paths up to 32k characters)
-  let buf = Bytes::new(4096)
-  let res = getcwd(buf, buf.length())
-  if res == 0 {
+  let res = getcwd().to_string()
+  // Valid current working directory can never be empty.
+  // So the runtime API use empty return value to indicate failure.
+  if res is "" {
     None
   } else {
-    Some(utf8_bytes_to_mbt_string(buf))
+    Some(res)
   }
 }
 
 ///|
 fn get_env_var_internal(key : String) -> String? {
-  let key = mbt_string_to_utf8_bytes(key, true)
-  if get_env_var_exists_ffi(key) {
-    Some(utf8_bytes_to_mbt_string(get_env_var_ffi(key)))
+  let key = OsString::from_string(key)
+  let exists = @ref.Ref(false)
+  let value = get_env_var_ffi(key, exists)
+  if exists.val {
+    Some(value.to_string())
   } else {
     None
   }
 }
 
 ///|
-#borrow(_key)
-extern "c" fn get_env_var_ffi(_key : Bytes) -> Bytes = "moonbit_rt_get_env_var"
-
-///|
-#borrow(_key)
-extern "c" fn get_env_var_exists_ffi(_key : Bytes) -> Bool = "moonbit_rt_get_env_var_exists"
+#borrow(key, exists)
+extern "c" fn get_env_var_ffi(
+  key : OsString,
+  exists : @ref.Ref[Bool],
+) -> OsString = "moonbit_rt_get_env_var2"
 
 ///|
 fn get_env_vars_internal() -> Map[String, String] {
   let env_vars = get_env_vars_ffi()
   let res = {}
   for i = 0; i < env_vars.length(); i = i + 2 {
-    res[utf8_bytes_to_mbt_string(env_vars[i])] = utf8_bytes_to_mbt_string(
-      env_vars[i + 1],
-    )
+    res[env_vars[i].to_string()] = env_vars[i + 1].to_string()
   }
   res
 }
 
 ///|
-extern "c" fn get_env_vars_ffi() -> FixedArray[Bytes] = "moonbit_rt_get_env_vars"
+extern "c" fn get_env_vars_ffi() -> FixedArray[OsString] = "moonbit_rt_get_env_vars2"
 
 ///|
 fn set_env_var_internal(key : String, value : String) -> Unit {
-  set_env_var_ffi(
-    mbt_string_to_utf8_bytes(key, true),
-    mbt_string_to_utf8_bytes(value, true),
-  )
+  set_env_var_ffi(OsString::from_string(key), OsString::from_string(value))
 }
 
 ///|
-#borrow(_key, _value)
-extern "c" fn set_env_var_ffi(_key : Bytes, _value : Bytes) -> Unit = "moonbit_rt_set_env_var"
+#borrow(key, value)
+extern "c" fn set_env_var_ffi(key : OsString, value : OsString) -> Unit = "moonbit_rt_set_env_var2"
 
 ///|
 fn unset_env_var_internal(key : String) -> Unit {
-  unset_env_var_ffi(mbt_string_to_utf8_bytes(key, true))
+  unset_env_var_ffi(OsString::from_string(key))
 }
 
 ///|
-#borrow(_key)
-extern "c" fn unset_env_var_ffi(_key : Bytes) -> Unit = "moonbit_rt_unset_env_var"
+#borrow(key)
+extern "c" fn unset_env_var_ffi(key : OsString) -> Unit = "moonbit_rt_unset_env_var2"
+
+///|
+#cfg(platform="windows")
+let _supressed_unused_warning_windows : Unit = ignore(@utf8.encode(""))

--- a/env/env_test.mbt
+++ b/env/env_test.mbt
@@ -51,3 +51,24 @@ test "env var round trip" {
   @test.assert_eq(@env.get_env_var(key), None)
   @test.assert_eq(@env.get_env_vars().get(key), None)
 }
+
+///|
+test "unicode env var round trip" {
+  let key = "__MOONBIT_CORE_ENV_TEST_中文字符_" + @env.now().to_string()
+
+  @test.assert_eq(@env.get_env_var(key), None)
+  @test.assert_eq(@env.get_env_vars().get(key), None)
+
+  @env.set_env_var(key, "")
+  @test.assert_eq(@env.get_env_var(key), Some(""))
+  @test.assert_eq(@env.get_env_vars().get(key), Some(""))
+
+  let value = "环境变量_" + @env.now().to_string()
+  @env.set_env_var(key, value)
+  @test.assert_eq(@env.get_env_var(key), Some(value))
+  @test.assert_eq(@env.get_env_vars().get(key), Some(value))
+
+  @env.unset_env_var(key)
+  @test.assert_eq(@env.get_env_var(key), None)
+  @test.assert_eq(@env.get_env_vars().get(key), None)
+}

--- a/env/moon.pkg
+++ b/env/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "moonbitlang/core/builtin",
+  "moonbitlang/core/ref",
+  "moonbitlang/core/encoding/utf8",
 }
 
 import {


### PR DESCRIPTION
Previously, implementation of `@env` API in MoonBit native runtime did not handle unicode characters correctly. When environment variable/current directory/command line arguments contain non-ASCII characters, the result will be corrupted. Native runtime of the latest MoonBit release now contains unicode-safe versions of these API, with a slightly different shape since Windows uses UTF-16 by default, while on other platforms we assume UTF-8. This PR let `moonbitlang/core/env` adapt these new, unicode-safe runtime API.