### PR TITLE
[codex] refactor(json): thread parse depth explicitly

### DIFF
--- a/json/internal_types.mbt
+++ b/json/internal_types.mbt
@@ -17,20 +17,11 @@ priv struct ParseContext {
   mut offset : Int
   input : StringView
   end_offset : Int
-  mut remaining_available_depth : Int
 }
 
 ///|
-fn ParseContext::make(
-  input : StringView,
-  max_nesting_depth : Int,
-) -> ParseContext {
-  {
-    offset: 0,
-    input,
-    end_offset: input.length(),
-    remaining_available_depth: max_nesting_depth,
-  }
+fn ParseContext::make(input : StringView) -> ParseContext {
+  { offset: 0, input, end_offset: input.length() }
 }
 
 ///|

--- a/json/lex_misc.mbt
+++ b/json/lex_misc.mbt
@@ -93,7 +93,7 @@ fn ParseContext::expect_ascii_char(
 
 ///|
 test "expect_char" {
-  let ctx = ParseContext::make("abc", 1)
+  let ctx = ParseContext::make("abc")
   ctx.expect_char('a')
   ctx.expect_char('b')
   ctx.expect_char('c')
@@ -107,7 +107,7 @@ test "expect_char" {
 ///|
 test "expect_char with surrogate pair" {
   // "\uD83D\uDE00" // todo: shall we allow this?
-  let ctx = ParseContext::make("a\u{1F600}bc\u{1F600}c", 1)
+  let ctx = ParseContext::make("a\u{1F600}bc\u{1F600}c")
   ctx.expect_char('a')
   ctx.expect_char((0x1F600).unsafe_to_char())
   ctx.expect_char('b')
@@ -148,25 +148,25 @@ fn ParseContext::lex_skip_whitespace(ctx : ParseContext) -> Unit {
 ///|
 test "lex_skip_whitespace" {
   // Empty input: nothing to skip.
-  let ctx = ParseContext::make("", 1)
+  let ctx = ParseContext::make("")
   ctx.lex_skip_whitespace()
   json_inspect(ctx.offset, content=0)
   // Only whitespace: offset advances to end.
-  let ctx = ParseContext::make("   \t\r\n", 1)
+  let ctx = ParseContext::make("   \t\r\n")
   ctx.lex_skip_whitespace()
   json_inspect(ctx.offset, content=6)
   // Mixed whitespace before a token: stops at the first non-ws byte.
-  let ctx = ParseContext::make(" \t\r\n{", 1)
+  let ctx = ParseContext::make(" \t\r\n{")
   ctx.lex_skip_whitespace()
   json_inspect(ctx.offset, content=4)
   // No leading whitespace: offset unchanged.
-  let ctx = ParseContext::make("{}", 1)
+  let ctx = ParseContext::make("{}")
   ctx.lex_skip_whitespace()
   json_inspect(ctx.offset, content=0)
   // Non-ASCII / Unicode whitespace (e.g. U+00A0 NBSP) must NOT be
   // treated as JSON whitespace — RFC 8259 limits the set to the four
   // ASCII chars handled above.
-  let ctx = ParseContext::make("\u{00A0}x", 1)
+  let ctx = ParseContext::make("\u{00A0}x")
   ctx.lex_skip_whitespace()
   json_inspect(ctx.offset, content=0)
 }

--- a/json/parse.mbt
+++ b/json/parse.mbt
@@ -30,8 +30,8 @@ pub fn parse(
   input : StringView,
   max_nesting_depth? : Int = 1024,
 ) -> Json raise ParseError {
-  let ctx = ParseContext::make(input, max_nesting_depth)
-  let val = ctx.parse_value()
+  let ctx = ParseContext::make(input)
+  let val = ctx.parse_value(remaining_available_depth=max_nesting_depth)
   ctx.lex_skip_whitespace()
   if ctx.offset >= ctx.end_offset {
     val
@@ -41,15 +41,19 @@ pub fn parse(
 }
 
 ///|
-fn ParseContext::parse_value(ctx : ParseContext) -> Json raise ParseError {
+fn ParseContext::parse_value(
+  ctx : ParseContext,
+  remaining_available_depth~ : Int,
+) -> Json raise ParseError {
   let tok = ctx.lex_value(allow_rbracket=false)
-  ctx.parse_value2(tok)
+  ctx.parse_value2(tok, remaining_available_depth~)
 }
 
 ///|
 fn ParseContext::parse_value2(
   ctx : ParseContext,
   tok : Token,
+  remaining_available_depth~ : Int,
 ) -> Json raise ParseError {
   match tok {
     Null => null
@@ -57,34 +61,33 @@ fn ParseContext::parse_value2(
     False => Json::boolean(false)
     Number(n, repr) => Json::number(n, repr?)
     String(s) => Json::string(s)
-    LBrace => ctx.parse_object()
-    LBracket => ctx.parse_array()
+    LBrace => ctx.parse_object(remaining_available_depth~)
+    LBracket => ctx.parse_array(remaining_available_depth~)
     RBracket | RBrace | Comma => abort("unreachable")
   }
 }
 
 ///|
-fn ParseContext::parse_object(ctx : ParseContext) -> Json raise ParseError {
-  if ctx.remaining_available_depth <= 0 {
+fn ParseContext::parse_object(
+  ctx : ParseContext,
+  remaining_available_depth~ : Int,
+) -> Json raise ParseError {
+  if remaining_available_depth <= 0 {
     raise DepthLimitExceeded
   }
-  ctx.remaining_available_depth -= 1
+  let child_remaining_available_depth = remaining_available_depth - 1
   let map = Map([])
   for x = ctx.lex_property_name() {
     match x {
-      RBrace => {
-        ctx.remaining_available_depth += 1
-        break Json::object(map)
-      }
+      RBrace => break Json::object(map)
       String(name) => {
         ctx.lex_after_property_name()
-        map[name] = ctx.parse_value()
+        map[name] = ctx.parse_value(
+          remaining_available_depth=child_remaining_available_depth,
+        )
         match ctx.lex_after_object_value() {
           Comma => continue ctx.lex_property_name2()
-          RBrace => {
-            ctx.remaining_available_depth += 1
-            break Json::object(map)
-          }
+          RBrace => break Json::object(map)
           _ => abort("unreachable")
         }
       }
@@ -94,27 +97,29 @@ fn ParseContext::parse_object(ctx : ParseContext) -> Json raise ParseError {
 }
 
 ///|
-fn ParseContext::parse_array(ctx : ParseContext) -> Json raise ParseError {
-  if ctx.remaining_available_depth <= 0 {
+fn ParseContext::parse_array(
+  ctx : ParseContext,
+  remaining_available_depth~ : Int,
+) -> Json raise ParseError {
+  if remaining_available_depth <= 0 {
     raise DepthLimitExceeded
   }
-  ctx.remaining_available_depth -= 1
+  let child_remaining_available_depth = remaining_available_depth - 1
   let vec = []
   for x = ctx.lex_value(allow_rbracket=true) {
     match x {
-      RBracket => {
-        ctx.remaining_available_depth += 1
-        break Json::array(vec)
-      }
+      RBracket => break Json::array(vec)
       tok => {
-        vec.push(ctx.parse_value2(tok))
+        vec.push(
+          ctx.parse_value2(
+            tok,
+            remaining_available_depth=child_remaining_available_depth,
+          ),
+        )
         let tok2 = ctx.lex_after_array_value()
         match tok2 {
           Comma => continue ctx.lex_value(allow_rbracket=false)
-          RBracket => {
-            ctx.remaining_available_depth += 1
-            break Json::array(vec)
-          }
+          RBracket => break Json::array(vec)
           _ => abort("unreachable")
         }
       }


### PR DESCRIPTION
## Summary

Refactor the `json` parser so nesting depth is threaded through the recursive parse calls instead of stored as mutable state on `ParseContext`.

This keeps `ParseContext` focused on lexer/cursor state (`offset`, `input`, `end_offset`) and makes the depth budget explicit in `parse_value`, `parse_value2`, `parse_object`, and `parse_array`.

## JSON package focus

- Removed `remaining_available_depth` from the private `ParseContext` struct.
- Changed `ParseContext::make` to only initialize cursor state.
- Passed `remaining_available_depth` as a labeled private parameter through recursive parser calls.
- Preserved the existing `max_nesting_depth` public API and `DepthLimitExceeded` behavior.

## Validation

- `moon check json`
- `moon test json` (175/175 passed)
- `moon fmt`
- `moon info`
- Confirmed `json/pkg.generated.mbti` is unchanged.
- Ran a fresh `codex review --uncommitted`; no actionable correctness findings were reported.