### PR TITLE
perf(immut): heapify priority queue builds

### DIFF
--- a/immut/priority_queue/deprecated.mbt
+++ b/immut/priority_queue/deprecated.mbt
@@ -19,5 +19,5 @@
 #deprecated("Use `PriorityQueue([])` instead")
 #as_free_fn(deprecated="Use `PriorityQueue([])` instead")
 pub fn[A] PriorityQueue::new() -> PriorityQueue[A] {
-  new_priority_queue()
+  { node: Empty, size: 0 }
 }

--- a/immut/priority_queue/moon.pkg
+++ b/immut/priority_queue/moon.pkg
@@ -6,6 +6,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/random",
   "moonbitlang/core/json",
   "moonbitlang/core/test",

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -19,6 +19,7 @@ fn[A] new_priority_queue() -> PriorityQueue[A] {
 
 ///|
 /// Creates a new immutable priority queue from an array.
+/// O(n).
 ///
 /// # Example
 /// ```mbt check
@@ -34,10 +35,63 @@ fn[A] new_priority_queue() -> PriorityQueue[A] {
 pub fn[A : Compare] PriorityQueue::PriorityQueue(
   array : ArrayView[A],
 ) -> PriorityQueue[A] {
-  for x in array; pq = (new_priority_queue() : PriorityQueue[A]) {
-    continue pq.push(x)
-  } nobreak {
-    pq
+  let len = array.length()
+  guard len > 0 else { return new_priority_queue() }
+  let heap = Array::makei(len, i => array[i])
+  priority_queue_heapify(heap)
+  { node: priority_queue_node_from_heap(heap, 0, len), size: len }
+}
+
+///|
+fn[A : Compare] priority_queue_heapify(heap : Array[A]) -> Unit {
+  let len = heap.length()
+  for i = len / 2 - 1; i >= 0; {
+    priority_queue_sift_down(heap, i, len)
+    continue i - 1
+  }
+}
+
+///|
+fn[A : Compare] priority_queue_sift_down(
+  heap : Array[A],
+  start : Int,
+  len : Int,
+) -> Unit {
+  for root = start {
+    let left = root * 2 + 1
+    guard left < len else { break }
+    let right = left + 1
+    let child = if right < len && heap[right] > heap[left] {
+      right
+    } else {
+      left
+    }
+    guard heap[root] < heap[child] else { break }
+    heap.swap(root, child)
+    continue child
+  }
+}
+
+///|
+fn[A] priority_queue_node_from_heap(
+  heap : Array[A],
+  index : Int,
+  len : Int,
+) -> Node[A] {
+  if index >= len {
+    Empty
+  } else {
+    let value = heap[index]
+    let left_index = index * 2 + 1
+    if left_index >= len {
+      Leaf(value)
+    } else {
+      Branch(
+        value,
+        left=priority_queue_node_from_heap(heap, left_index, len),
+        right=priority_queue_node_from_heap(heap, left_index + 1, len),
+      )
+    }
   }
 }
 
@@ -79,7 +133,7 @@ pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
 pub fn[A : Compare] PriorityQueue::from_iter(
   iter : Iter[A],
 ) -> PriorityQueue[A] {
-  iter.fold(init=new_priority_queue(), (s, e) => s.push(e))
+  PriorityQueue(iter.to_array())
 }
 
 ///|

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -37,51 +37,49 @@ pub fn[A : Compare] PriorityQueue::PriorityQueue(
 ) -> PriorityQueue[A] {
   let len = array.length()
   guard len > 0 else { return new_priority_queue() }
-  let heap = Array::makei(len, i => array[i])
-  priority_queue_heapify(heap)
+  let heap = FixedArray::from_array(array)
+  heapify(heap)
   { node: priority_queue_node_from_heap(heap, 0, len), size: len }
 }
 
 ///|
-fn[A : Compare] priority_queue_heapify(heap : Array[A]) -> Unit {
+fn[A : Compare] heapify(heap : FixedArray[A]) -> Unit {
   let len = heap.length()
   for i = len / 2 - 1; i >= 0; {
-    priority_queue_sift_down(heap, i, len)
+    sift_down(heap, i, len)
     continue i - 1
   }
 }
 
 ///|
-fn[A : Compare] priority_queue_sift_down(
-  heap : Array[A],
-  start : Int,
-  len : Int,
-) -> Unit {
+fn[A : Compare] sift_down(heap : FixedArray[A], start : Int, len : Int) -> Unit {
   for root = start {
     let left = root * 2 + 1
     guard left < len else { break }
     let right = left + 1
-    let child = if right < len && heap[right] > heap[left] {
+    let child = if right < len && heap.unsafe_get(right) > heap.unsafe_get(left) {
       right
     } else {
       left
     }
-    guard heap[root] < heap[child] else { break }
-    heap.swap(root, child)
+    guard heap.unsafe_get(root) < heap.unsafe_get(child) else { break }
+    let root_value = heap.unsafe_get(root)
+    heap.unsafe_set(root, heap.unsafe_get(child))
+    heap.unsafe_set(child, root_value)
     continue child
   }
 }
 
 ///|
 fn[A] priority_queue_node_from_heap(
-  heap : Array[A],
+  heap : FixedArray[A],
   index : Int,
   len : Int,
 ) -> Node[A] {
   if index >= len {
     Empty
   } else {
-    let value = heap[index]
+    let value = heap.unsafe_get(index)
     let left_index = index * 2 + 1
     if left_index >= len {
       Leaf(value)

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 ///|
-fn[A] new_priority_queue() -> PriorityQueue[A] {
-  { node: Empty, size: 0 }
-}
-
-///|
 /// Creates a new immutable priority queue from an array.
-/// O(n).
+///
+/// Runs in O(n): the elements are copied once and turned into a heap in place,
+/// which is asymptotically faster than inserting them one by one with `push`
+/// (O(n log n)).
 ///
 /// # Example
 /// ```mbt check
@@ -35,16 +33,51 @@ fn[A] new_priority_queue() -> PriorityQueue[A] {
 pub fn[A : Compare] PriorityQueue::PriorityQueue(
   array : ArrayView[A],
 ) -> PriorityQueue[A] {
-  let len = array.length()
-  guard len > 0 else { return new_priority_queue() }
-  let heap = FixedArray::from_array(array)
+  // `array` is borrowed, so copy it into a buffer we own before heapifying.
+  from_array_in_place(array.to_owned().mut_view())
+}
+
+///|
+/// Builds a priority queue from `heap`, reordering it in place.
+///
+/// The caller must own the buffer behind `heap` and not use it afterwards: the
+/// elements are permuted into heap order rather than copied, which is what lets
+/// callers such as `from_iter` skip the extra allocation that
+/// `PriorityQueue(ArrayView)` needs for its defensive copy.
+///
+/// ## Why this produces a valid queue
+///
+/// The queue is a binary max-heap kept as a complete binary tree (`Node`). The
+/// exact same tree is what `push`/`pop` maintain: the `k`-th node in level
+/// order lands at array index `k`, whose children live at `2*k+1` and `2*k+2`.
+/// So reading `heap` with that child rule yields a tree of the *same shape* the
+/// rest of the module expects.
+///
+/// `heapify` then enforces the ordering invariant with Floyd's bottom-up
+/// build-heap: it sifts down every internal node from `len/2 - 1` back to the
+/// root. Visiting a node only after both of its child subtrees are already
+/// heaps means a single `sift_down` per node suffices to make `heap` a max-heap
+/// (each parent `>=` both children). Because most nodes sit near the bottom and
+/// sink only a short distance, the whole pass is O(n) rather than the
+/// O(n log n) of `len` repeated `push`es.
+///
+/// Finally `priority_queue_node_from_heap` transcribes the implicit array tree
+/// into `Node` using the same index-to-child mapping, so the result keeps both
+/// the complete-tree shape and the heap invariant and can be consumed directly
+/// by `pop`/`peek`.
+fn[A : Compare] from_array_in_place(heap : MutArrayView[A]) -> PriorityQueue[A] {
+  let len = heap.length()
+  guard len > 0 else { return { node: Empty, size: 0 } }
   heapify(heap)
   { node: priority_queue_node_from_heap(heap, 0, len), size: len }
 }
 
 ///|
-fn[A : Compare] heapify(heap : FixedArray[A]) -> Unit {
+/// Floyd bottom-up build-heap: reorders `heap` into a max-heap in O(n).
+fn[A : Compare] heapify(heap : MutArrayView[A]) -> Unit {
   let len = heap.length()
+  // Everything past `len / 2 - 1` is a leaf and already a trivial heap, so only
+  // the internal nodes need sifting, deepest first.
   for i = len / 2 - 1; i >= 0; {
     sift_down(heap, i, len)
     continue i - 1
@@ -52,7 +85,13 @@ fn[A : Compare] heapify(heap : FixedArray[A]) -> Unit {
 }
 
 ///|
-fn[A : Compare] sift_down(heap : FixedArray[A], start : Int, len : Int) -> Unit {
+/// Sinks the element at `start` until the subtree rooted there is a max-heap,
+/// repeatedly swapping it with its larger child.
+fn[A : Compare] sift_down(
+  heap : MutArrayView[A],
+  start : Int,
+  len : Int,
+) -> Unit {
   for root = start {
     let left = root * 2 + 1
     guard left < len else { break }
@@ -71,8 +110,10 @@ fn[A : Compare] sift_down(heap : FixedArray[A], start : Int, len : Int) -> Unit 
 }
 
 ///|
+/// Transcribes the implicit array heap into the persistent `Node` tree,
+/// preserving the `index -> (2*index+1, 2*index+2)` child mapping.
 fn[A] priority_queue_node_from_heap(
-  heap : FixedArray[A],
+  heap : MutArrayView[A],
   index : Int,
   len : Int,
 ) -> Node[A] {
@@ -131,7 +172,9 @@ pub fn[A : Compare] PriorityQueue::iter(self : PriorityQueue[A]) -> Iter[A] {
 pub fn[A : Compare] PriorityQueue::from_iter(
   iter : Iter[A],
 ) -> PriorityQueue[A] {
-  PriorityQueue(iter.to_array())
+  // `to_array` already yields a fresh array we own, so view it in place and
+  // heapify without copying it again through the public ctor.
+  from_array_in_place(iter.to_array().mut_view())
 }
 
 ///|

--- a/immut/priority_queue/priority_queue_build_bench_test.mbt
+++ b/immut/priority_queue/priority_queue_build_bench_test.mbt
@@ -1,0 +1,59 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let priority_queue_build_bench_size = 10_000
+
+///|
+fn make_priority_queue_ordered_values() -> Array[Int] {
+  Array::makei(priority_queue_build_bench_size, i => i)
+}
+
+///|
+fn make_priority_queue_reverse_values() -> Array[Int] {
+  Array::makei(priority_queue_build_bench_size, i => {
+    priority_queue_build_bench_size - i - 1
+  })
+}
+
+///|
+fn make_priority_queue_random_values() -> Array[Int] {
+  Array::makei(priority_queue_build_bench_size, i => {
+    (i * 1103515245 + 12345) & 0x7fffffff
+  })
+}
+
+///|
+test "bench PriorityQueue::from_array ordered n=10000" (it : @bench.T) {
+  let values = make_priority_queue_ordered_values()
+  it.bench(fn() { it.keep(@priority_queue.from_array(values)) })
+}
+
+///|
+test "bench PriorityQueue::from_array reverse n=10000" (it : @bench.T) {
+  let values = make_priority_queue_reverse_values()
+  it.bench(fn() { it.keep(@priority_queue.from_array(values)) })
+}
+
+///|
+test "bench PriorityQueue::from_array random n=10000" (it : @bench.T) {
+  let values = make_priority_queue_random_values()
+  it.bench(fn() { it.keep(@priority_queue.from_array(values)) })
+}
+
+///|
+test "bench PriorityQueue::from_iter random n=10000" (it : @bench.T) {
+  let values = make_priority_queue_random_values()
+  it.bench(fn() { it.keep(@priority_queue.from_iter(values.iter())) })
+}

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -25,6 +25,22 @@ test "from_array" {
 }
 
 ///|
+test "from_array large pop order" {
+  let values = Array::makei(1000, i => (i * 1103515245 + 12345) & 0x7fffffff)
+  let expected = values.copy()
+  expected.sort()
+  expected.rev_in_place()
+  let pq = @priority_queue.from_array(values)
+  let pq = for value in expected; pq = pq {
+    @test.assert_eq(pq.peek(), Some(value))
+    continue pq.pop().unwrap()
+  } nobreak {
+    pq
+  }
+  @test.assert_eq(pq.is_empty(), true)
+}
+
+///|
 test "PriorityQueue constructor" {
   let queue = @priority_queue.PriorityQueue([1, 6, 3, 4, 5])
   debug_inspect(queue.peek(), content="Some(6)")


### PR DESCRIPTION
## Summary

- build `PriorityQueue` from `ArrayView` with Floyd heapify instead of repeated persistent `push`
- route `PriorityQueue::from_iter` through the same heapify builder after collecting the iterator
- add a large pop-order regression test and build benchmarks

## Benchmark

Before this change, the same benchmark file on the old push-based builder reported roughly:

| case | old mean |
| --- | ---: |
| `PriorityQueue::from_array ordered n=10000` | 1.04 ms |
| `PriorityQueue::from_array reverse n=10000` | 1.00 ms |
| `PriorityQueue::from_array random n=10000` | 1.02 ms |
| `PriorityQueue::from_iter random n=10000` | 1.02 ms |

After this change, `moon bench -p immut/priority_queue --target native` reports:

| case | new mean |
| --- | ---: |
| `PriorityQueue::from_array ordered n=10000` | 68.78 us |
| `PriorityQueue::from_array reverse n=10000` | 66.86 us |
| `PriorityQueue::from_array random n=10000` | 92.97 us |
| `PriorityQueue::from_iter random n=10000` | 89.63 us |

## Validation

- `moon fmt`
- `moon info`
- `moon test -p immut/priority_queue --target all`
- `moon check -p immut/priority_queue --target all`
- `moon bench -p immut/priority_queue --target native`
- `git diff --check`

`moon check` still reports pre-existing missing-doc warnings in unrelated bench/bigint files, with 0 errors.