### PR TITLE
perf(immut): bulk build hash collections

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -228,11 +228,11 @@ fn[K : Eq, V] build_hashmap_node_range(
     let entry = entries[start]
     return Flat(entry.key, entry.value, entry.path.advance(depth))
   }
-  if entries[start].path.is_last_at(depth) {
+  if depth == 5 {
     return build_hashmap_node_by_add(entries, start, end, depth, reverse)
   }
   let starts = FixedArray::make(32, 0)
-  for i = start; i < end; i = i + 1 {
+  for i in start..<end {
     starts[entries[i].path.idx_at(depth)] += 1
   }
   let nexts = FixedArray::make(32, 0)
@@ -244,22 +244,27 @@ fn[K : Eq, V] build_hashmap_node_range(
   }
   let first = entries[start]
   let partitioned = Array::make(end - start, first)
-  for i = start; i < end; i = i + 1 {
+  for i in start..<end {
     let entry = entries[i]
     let idx = entry.path.idx_at(depth)
     let offset = nexts[idx]
     partitioned[offset] = entry
     nexts[idx] = offset + 1
   }
-  let mut child_count = 0
-  for idx = 0; idx < 32; idx = idx + 1 {
-    if nexts[idx] != starts[idx] {
-      child_count += 1
+  let child_count = for idx, next in nexts; count = 0 {
+    if next != starts[idx] {
+      continue count + 1
     }
+    continue count
+  } nobreak {
+    count
   }
-  let mut first_idx = 0
-  while nexts[first_idx] == starts[first_idx] {
-    first_idx += 1
+  let first_idx = for idx, next in nexts {
+    if next != starts[idx] {
+      break idx
+    }
+  } nobreak {
+    abort("unreachable")
   }
   let first_child = build_hashmap_node_range(
     partitioned,

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -34,6 +34,16 @@ priv enum CurrNode[K, V] {
 }
 
 ///|
+priv struct BuildEntry[K, V] {
+  key : K
+  value : V
+  path : @path.Path
+}
+
+///|
+let bulk_build_threshold = 64
+
+///|
 /// Create a new instance.
 #as_free_fn
 pub fn[K, V] HashMap::new() -> HashMap[K, V] {
@@ -164,6 +174,158 @@ fn[K : Eq, V] Node::add_with_path(
       }
     }
   }
+}
+
+///|
+fn[K : Eq, V] BuildEntry::add_to_node(
+  self : BuildEntry[K, V],
+  node : Node[K, V]?,
+) -> Node[K, V] {
+  match node {
+    None => Flat(self.key, self.value, self.path)
+    Some(node) => node.add_with_path(self.key, self.value, self.path)
+  }
+}
+
+///|
+fn[K : Eq, V] build_hashmap_node_by_add(
+  entries : Array[BuildEntry[K, V]],
+  start : Int,
+  end : Int,
+  reverse : Bool,
+) -> Node[K, V] {
+  if reverse {
+    for i = end, node = (None : Node[K, V]?) {
+      if i == start {
+        break node.unwrap()
+      }
+      let node = entries[i - 1].add_to_node(node)
+      continue i - 1, Some(node)
+    }
+  } else {
+    for i = start, node = (None : Node[K, V]?) {
+      if i == end {
+        break node.unwrap()
+      }
+      let node = entries[i].add_to_node(node)
+      continue i + 1, Some(node)
+    }
+  }
+}
+
+///|
+fn[K : Eq, V] build_hashmap_node_range(
+  entries : Array[BuildEntry[K, V]],
+  start : Int,
+  end : Int,
+  reverse : Bool,
+) -> Node[K, V] {
+  if end - start == 1 {
+    let entry = entries[start]
+    return Flat(entry.key, entry.value, entry.path)
+  }
+  if entries[start].path.is_last() {
+    return build_hashmap_node_by_add(entries, start, end, reverse)
+  }
+  let starts = FixedArray::make(32, 0)
+  for i = start; i < end; i = i + 1 {
+    starts[entries[i].path.idx()] += 1
+  }
+  let nexts = FixedArray::make(32, 0)
+  for idx = 0, offset = 0; idx < 32; {
+    let count = starts[idx]
+    starts[idx] = offset
+    nexts[idx] = offset
+    continue idx + 1, offset + count
+  }
+  let first = entries[start]
+  let partitioned = Array::make(end - start, first)
+  for i = start; i < end; i = i + 1 {
+    let entry = entries[i]
+    let idx = entry.path.idx()
+    let offset = nexts[idx]
+    partitioned[offset] = {
+      key: entry.key,
+      value: entry.value,
+      path: entry.path.next(),
+    }
+    nexts[idx] = offset + 1
+  }
+  let mut child_count = 0
+  for idx = 0; idx < 32; idx = idx + 1 {
+    if nexts[idx] != starts[idx] {
+      child_count += 1
+    }
+  }
+  let mut first_idx = 0
+  while nexts[first_idx] == starts[first_idx] {
+    first_idx += 1
+  }
+  let first_child = build_hashmap_node_range(
+    partitioned,
+    starts[first_idx],
+    nexts[first_idx],
+    reverse,
+  )
+  if child_count == 1 {
+    return match first_child {
+      Flat(key, value, path) => Flat(key, value, path.push(first_idx))
+      _ => Branch(@sparse_array.singleton(first_idx, first_child))
+    }
+  }
+  let indices = FixedArray::make(child_count, first_idx)
+  let children = FixedArray::make(child_count, first_child)
+  for idx = first_idx + 1, out = 1; idx < 32; {
+    if nexts[idx] == starts[idx] {
+      continue idx + 1, out
+    }
+    indices[out] = idx
+    children[out] = build_hashmap_node_range(
+      partitioned,
+      starts[idx],
+      nexts[idx],
+      reverse,
+    )
+    continue idx + 1, out + 1
+  }
+  Branch(@sparse_array.from_sorted_fixed_array(indices, children))
+}
+
+///|
+fn[K : Eq + Hash, V] hash_map_from_iter_by_add(
+  iter : Iter[(K, V)],
+) -> HashMap[K, V] {
+  iter.fold(init=new(), (m, e) => m.add(e.0, e.1))
+}
+
+///|
+fn[K : Eq + Hash, V] hash_map_from_array_by_add(
+  arr : ArrayView[(K, V)],
+) -> HashMap[K, V] {
+  for n = arr.length(), map = new() {
+    match (n, map) {
+      (0, map) => break map
+      (n, map) => {
+        let (k, v) = arr[n - 1]
+        continue n - 1, map.add(k, v)
+      }
+    }
+  }
+}
+
+///|
+fn[K : Eq + Hash, V] hash_map_from_array(
+  arr : ArrayView[(K, V)],
+) -> HashMap[K, V] {
+  if arr.length() <= bulk_build_threshold {
+    return hash_map_from_array_by_add(arr)
+  }
+  let entries = Array::makei(arr.length(), i => {
+    let kv = arr[i]
+    let (k, v) = kv
+    { key: k, value: v, path: @path.of(k) }
+  })
+  { data: Some(build_hashmap_node_range(entries, 0, entries.length(), true)) }
 }
 
 ///|
@@ -709,7 +871,21 @@ pub fn[K, V] HashMap::iter2(self : HashMap[K, V]) -> Iter2[K, V] {
 pub fn[K : Eq + Hash, V] HashMap::from_iter(
   iter : Iter[(K, V)],
 ) -> HashMap[K, V] {
-  iter.fold(init=new(), (m, e) => m.add(e.0, e.1))
+  if iter.size_hint() is Some(len) && len <= bulk_build_threshold {
+    return hash_map_from_iter_by_add(iter)
+  }
+  let entries = match iter.size_hint() {
+    Some(len) => Array::new(capacity=len)
+    None => []
+  }
+  iter.each(e => entries.push({ key: e.0, value: e.1, path: @path.of(e.0) }))
+  if entries.length() == 0 {
+    new()
+  } else {
+    {
+      data: Some(build_hashmap_node_range(entries, 0, entries.length(), false)),
+    }
+  }
 }
 
 ///|
@@ -735,15 +911,7 @@ pub impl[K : Show, V : Show] Show for HashMap[K, V] with fn output(self, logger)
 pub fn[K : Eq + Hash, V] HashMap::from_array(
   arr : ArrayView[(K, V)],
 ) -> HashMap[K, V] {
-  for n = arr.length(), map = new() {
-    match (n, map) {
-      (0, map) => break map
-      (n, map) => {
-        let (k, v) = arr[n - 1]
-        continue n - 1, map.add(k, v)
-      }
-    }
-  }
+  hash_map_from_array(arr)
 }
 
 ///|
@@ -761,15 +929,7 @@ pub fn[K : Eq + Hash, V] HashMap::from_array(
 pub fn[K : Eq + Hash, V] HashMap::HashMap(
   arr : ArrayView[(K, V)],
 ) -> HashMap[K, V] {
-  for n = arr.length(), map = new() {
-    match (n, map) {
-      (0, map) => break map
-      (n, map) => {
-        let (k, v) = arr[n - 1]
-        continue n - 1, map.add(k, v)
-      }
-    }
-  }
+  hash_map_from_array(arr)
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -37,7 +37,7 @@ priv enum CurrNode[K, V] {
 priv struct BuildEntry[K, V] {
   key : K
   value : V
-  path : @path.Path
+  path : @path.Path // Full path; bulk construction tracks consumed segments by depth.
 }
 
 ///|
@@ -180,10 +180,12 @@ fn[K : Eq, V] Node::add_with_path(
 fn[K : Eq, V] BuildEntry::add_to_node(
   self : BuildEntry[K, V],
   node : Node[K, V]?,
+  depth : Int,
 ) -> Node[K, V] {
+  let path = self.path.advance(depth)
   match node {
-    None => Flat(self.key, self.value, self.path)
-    Some(node) => node.add_with_path(self.key, self.value, self.path)
+    None => Flat(self.key, self.value, path)
+    Some(node) => node.add_with_path(self.key, self.value, path)
   }
 }
 
@@ -192,6 +194,7 @@ fn[K : Eq, V] build_hashmap_node_by_add(
   entries : Array[BuildEntry[K, V]],
   start : Int,
   end : Int,
+  depth : Int,
   reverse : Bool,
 ) -> Node[K, V] {
   if reverse {
@@ -199,7 +202,7 @@ fn[K : Eq, V] build_hashmap_node_by_add(
       if i == start {
         break node.unwrap()
       }
-      let node = entries[i - 1].add_to_node(node)
+      let node = entries[i - 1].add_to_node(node, depth)
       continue i - 1, Some(node)
     }
   } else {
@@ -207,7 +210,7 @@ fn[K : Eq, V] build_hashmap_node_by_add(
       if i == end {
         break node.unwrap()
       }
-      let node = entries[i].add_to_node(node)
+      let node = entries[i].add_to_node(node, depth)
       continue i + 1, Some(node)
     }
   }
@@ -218,18 +221,19 @@ fn[K : Eq, V] build_hashmap_node_range(
   entries : Array[BuildEntry[K, V]],
   start : Int,
   end : Int,
+  depth : Int,
   reverse : Bool,
 ) -> Node[K, V] {
   if end - start == 1 {
     let entry = entries[start]
-    return Flat(entry.key, entry.value, entry.path)
+    return Flat(entry.key, entry.value, entry.path.advance(depth))
   }
-  if entries[start].path.is_last() {
-    return build_hashmap_node_by_add(entries, start, end, reverse)
+  if entries[start].path.is_last_at(depth) {
+    return build_hashmap_node_by_add(entries, start, end, depth, reverse)
   }
   let starts = FixedArray::make(32, 0)
   for i = start; i < end; i = i + 1 {
-    starts[entries[i].path.idx()] += 1
+    starts[entries[i].path.idx_at(depth)] += 1
   }
   let nexts = FixedArray::make(32, 0)
   for idx = 0, offset = 0; idx < 32; {
@@ -242,13 +246,9 @@ fn[K : Eq, V] build_hashmap_node_range(
   let partitioned = Array::make(end - start, first)
   for i = start; i < end; i = i + 1 {
     let entry = entries[i]
-    let idx = entry.path.idx()
+    let idx = entry.path.idx_at(depth)
     let offset = nexts[idx]
-    partitioned[offset] = {
-      key: entry.key,
-      value: entry.value,
-      path: entry.path.next(),
-    }
+    partitioned[offset] = entry
     nexts[idx] = offset + 1
   }
   let mut child_count = 0
@@ -265,6 +265,7 @@ fn[K : Eq, V] build_hashmap_node_range(
     partitioned,
     starts[first_idx],
     nexts[first_idx],
+    depth + 1,
     reverse,
   )
   if child_count == 1 {
@@ -284,6 +285,7 @@ fn[K : Eq, V] build_hashmap_node_range(
       partitioned,
       starts[idx],
       nexts[idx],
+      depth + 1,
       reverse,
     )
     continue idx + 1, out + 1
@@ -325,7 +327,9 @@ fn[K : Eq + Hash, V] hash_map_from_array(
     let (k, v) = kv
     { key: k, value: v, path: @path.of(k) }
   })
-  { data: Some(build_hashmap_node_range(entries, 0, entries.length(), true)) }
+  {
+    data: Some(build_hashmap_node_range(entries, 0, entries.length(), 0, true)),
+  }
 }
 
 ///|
@@ -883,7 +887,9 @@ pub fn[K : Eq + Hash, V] HashMap::from_iter(
     new()
   } else {
     {
-      data: Some(build_hashmap_node_range(entries, 0, entries.length(), false)),
+      data: Some(
+        build_hashmap_node_range(entries, 0, entries.length(), 0, false),
+      ),
     }
   }
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -177,6 +177,59 @@ test "HAMT::from_iter empty" {
 }
 
 ///|
+fn rebuild_from_array_by_add(
+  data : Array[(Int, Int)],
+) -> @hashmap.HashMap[Int, Int] {
+  for n = data.length(), map = @hashmap.new() {
+    match n {
+      0 => break map
+      _ => {
+        let (k, v) = data[n - 1]
+        continue n - 1, map.add(k, v)
+      }
+    }
+  }
+}
+
+///|
+fn rebuild_from_iter_by_add(
+  data : Array[(Int, Int)],
+) -> @hashmap.HashMap[Int, Int] {
+  for kv in data; map = @hashmap.new() {
+    continue map.add(kv.0, kv.1)
+  } nobreak {
+    map
+  }
+}
+
+///|
+test "HAMT::from_array matches reverse add with duplicates" {
+  let data = Array::makei(256, i => ((i * 1103515245 + 12345) & 63, i))
+  @test.assert_eq(@hashmap.HashMap(data), rebuild_from_array_by_add(data))
+}
+
+///|
+test "HAMT::from_iter matches forward add with duplicates" {
+  let data = Array::makei(256, i => ((i * 1103515245 + 12345) & 63, i))
+  @test.assert_eq(
+    @hashmap.from_iter(data.iter()),
+    rebuild_from_iter_by_add(data),
+  )
+}
+
+///|
+test "HAMT::from_array duplicate keeps first value" {
+  let map = @hashmap.HashMap([(1, "first"), (1, "second")])
+  @test.assert_eq(map.get(1), Some("first"))
+}
+
+///|
+test "HAMT::from_iter duplicate keeps last value" {
+  let map = @hashmap.from_iter([(1, "first"), (1, "second")].iter())
+  @test.assert_eq(map.get(1), Some("second"))
+}
+
+///|
 #warnings("-deprecated")
 test "HAMT::to_string" {
   let map = @hashmap.new()

--- a/immut/hashmap/hashmap_build_bench_test.mbt
+++ b/immut/hashmap/hashmap_build_bench_test.mbt
@@ -1,0 +1,52 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let hashmap_build_bench_size = 10_000
+
+///|
+fn hashmap_build_random_key(i : Int) -> Int {
+  (i * 1103515245 + 12345) & 0x7fffffff
+}
+
+///|
+fn make_hashmap_ordered_build_data() -> Array[(Int, Int)] {
+  Array::makei(hashmap_build_bench_size, i => (i, i))
+}
+
+///|
+fn make_hashmap_random_build_data() -> Array[(Int, Int)] {
+  Array::makei(hashmap_build_bench_size, i => {
+    let key = hashmap_build_random_key(i)
+    (key, i)
+  })
+}
+
+///|
+test "bench HashMap constructor ordered n=10000" (it : @bench.T) {
+  let data = make_hashmap_ordered_build_data()
+  it.bench(fn() { it.keep(@hashmap.HashMap(data)) })
+}
+
+///|
+test "bench HashMap constructor random n=10000" (it : @bench.T) {
+  let data = make_hashmap_random_build_data()
+  it.bench(fn() { it.keep(@hashmap.HashMap(data)) })
+}
+
+///|
+test "bench HashMap::from_iter random n=10000" (it : @bench.T) {
+  let data = make_hashmap_random_build_data()
+  it.bench(fn() { it.keep(@hashmap.from_iter(data.iter())) })
+}

--- a/immut/hashmap/moon.pkg
+++ b/immut/hashmap/moon.pkg
@@ -10,6 +10,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/int",
   "moonbitlang/core/option",
   "moonbitlang/core/test",

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -30,7 +30,7 @@
 ///|
 priv struct BuildEntry[A] {
   value : A
-  path : @path.Path
+  path : @path.Path // Full path; bulk construction tracks consumed segments by depth.
 }
 
 ///|
@@ -132,10 +132,12 @@ fn[A : Eq] Node::add_with_path(
 fn[A : Eq] BuildEntry::add_to_node(
   self : BuildEntry[A],
   node : Node[A]?,
+  depth : Int,
 ) -> Node[A] {
+  let path = self.path.advance(depth)
   match node {
-    None => Flat(self.value, self.path)
-    Some(node) => node.add_with_path(self.value, self.path)
+    None => Flat(self.value, path)
+    Some(node) => node.add_with_path(self.value, path)
   }
 }
 
@@ -144,6 +146,7 @@ fn[A : Eq] build_hashset_node_by_add(
   entries : Array[BuildEntry[A]],
   start : Int,
   end : Int,
+  depth : Int,
   reverse : Bool,
 ) -> Node[A] {
   if reverse {
@@ -151,7 +154,7 @@ fn[A : Eq] build_hashset_node_by_add(
       if i == start {
         break node.unwrap()
       }
-      let node = entries[i - 1].add_to_node(node)
+      let node = entries[i - 1].add_to_node(node, depth)
       continue i - 1, Some(node)
     }
   } else {
@@ -159,7 +162,7 @@ fn[A : Eq] build_hashset_node_by_add(
       if i == end {
         break node.unwrap()
       }
-      let node = entries[i].add_to_node(node)
+      let node = entries[i].add_to_node(node, depth)
       continue i + 1, Some(node)
     }
   }
@@ -170,18 +173,19 @@ fn[A : Eq] build_hashset_node_range(
   entries : Array[BuildEntry[A]],
   start : Int,
   end : Int,
+  depth : Int,
   reverse : Bool,
 ) -> Node[A] {
   if end - start == 1 {
     let entry = entries[start]
-    return Flat(entry.value, entry.path)
+    return Flat(entry.value, entry.path.advance(depth))
   }
-  if entries[start].path.is_last() {
-    return build_hashset_node_by_add(entries, start, end, reverse)
+  if entries[start].path.is_last_at(depth) {
+    return build_hashset_node_by_add(entries, start, end, depth, reverse)
   }
   let starts = FixedArray::make(32, 0)
   for i = start; i < end; i = i + 1 {
-    starts[entries[i].path.idx()] += 1
+    starts[entries[i].path.idx_at(depth)] += 1
   }
   let nexts = FixedArray::make(32, 0)
   for idx = 0, offset = 0; idx < 32; {
@@ -194,9 +198,9 @@ fn[A : Eq] build_hashset_node_range(
   let partitioned = Array::make(end - start, first)
   for i = start; i < end; i = i + 1 {
     let entry = entries[i]
-    let idx = entry.path.idx()
+    let idx = entry.path.idx_at(depth)
     let offset = nexts[idx]
-    partitioned[offset] = { value: entry.value, path: entry.path.next() }
+    partitioned[offset] = entry
     nexts[idx] = offset + 1
   }
   let mut child_count = 0
@@ -213,6 +217,7 @@ fn[A : Eq] build_hashset_node_range(
     partitioned,
     starts[first_idx],
     nexts[first_idx],
+    depth + 1,
     reverse,
   )
   if child_count == 1 {
@@ -232,6 +237,7 @@ fn[A : Eq] build_hashset_node_range(
       partitioned,
       starts[idx],
       nexts[idx],
+      depth + 1,
       reverse,
     )
     continue idx + 1, out + 1
@@ -266,7 +272,9 @@ fn[A : Eq + Hash] hash_set_from_array(arr : ArrayView[A]) -> HashSet[A] {
     let value = arr[i]
     { value, path: @path.of(value) }
   })
-  { data: Some(build_hashset_node_range(entries, 0, entries.length(), true)) }
+  {
+    data: Some(build_hashset_node_range(entries, 0, entries.length(), 0, true)),
+  }
 }
 
 ///|
@@ -572,7 +580,9 @@ pub fn[A : Eq + Hash] HashSet::from_iter(iter : Iter[A]) -> HashSet[A] {
     new()
   } else {
     {
-      data: Some(build_hashset_node_range(entries, 0, entries.length(), false)),
+      data: Some(
+        build_hashset_node_range(entries, 0, entries.length(), 0, false),
+      ),
     }
   }
 }

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -28,6 +28,15 @@
 // - <https://lampwww.epfl.ch/papers/idealhashtrees.pdf>
 
 ///|
+priv struct BuildEntry[A] {
+  value : A
+  path : @path.Path
+}
+
+///|
+let bulk_build_threshold = 64
+
+///|
 /// Create a new instance.
 #as_free_fn
 pub fn[A] HashSet::new() -> HashSet[A] {
@@ -117,6 +126,147 @@ fn[A : Eq] Node::add_with_path(
       }
     }
   }
+}
+
+///|
+fn[A : Eq] BuildEntry::add_to_node(
+  self : BuildEntry[A],
+  node : Node[A]?,
+) -> Node[A] {
+  match node {
+    None => Flat(self.value, self.path)
+    Some(node) => node.add_with_path(self.value, self.path)
+  }
+}
+
+///|
+fn[A : Eq] build_hashset_node_by_add(
+  entries : Array[BuildEntry[A]],
+  start : Int,
+  end : Int,
+  reverse : Bool,
+) -> Node[A] {
+  if reverse {
+    for i = end, node = (None : Node[A]?) {
+      if i == start {
+        break node.unwrap()
+      }
+      let node = entries[i - 1].add_to_node(node)
+      continue i - 1, Some(node)
+    }
+  } else {
+    for i = start, node = (None : Node[A]?) {
+      if i == end {
+        break node.unwrap()
+      }
+      let node = entries[i].add_to_node(node)
+      continue i + 1, Some(node)
+    }
+  }
+}
+
+///|
+fn[A : Eq] build_hashset_node_range(
+  entries : Array[BuildEntry[A]],
+  start : Int,
+  end : Int,
+  reverse : Bool,
+) -> Node[A] {
+  if end - start == 1 {
+    let entry = entries[start]
+    return Flat(entry.value, entry.path)
+  }
+  if entries[start].path.is_last() {
+    return build_hashset_node_by_add(entries, start, end, reverse)
+  }
+  let starts = FixedArray::make(32, 0)
+  for i = start; i < end; i = i + 1 {
+    starts[entries[i].path.idx()] += 1
+  }
+  let nexts = FixedArray::make(32, 0)
+  for idx = 0, offset = 0; idx < 32; {
+    let count = starts[idx]
+    starts[idx] = offset
+    nexts[idx] = offset
+    continue idx + 1, offset + count
+  }
+  let first = entries[start]
+  let partitioned = Array::make(end - start, first)
+  for i = start; i < end; i = i + 1 {
+    let entry = entries[i]
+    let idx = entry.path.idx()
+    let offset = nexts[idx]
+    partitioned[offset] = { value: entry.value, path: entry.path.next() }
+    nexts[idx] = offset + 1
+  }
+  let mut child_count = 0
+  for idx = 0; idx < 32; idx = idx + 1 {
+    if nexts[idx] != starts[idx] {
+      child_count += 1
+    }
+  }
+  let mut first_idx = 0
+  while nexts[first_idx] == starts[first_idx] {
+    first_idx += 1
+  }
+  let first_child = build_hashset_node_range(
+    partitioned,
+    starts[first_idx],
+    nexts[first_idx],
+    reverse,
+  )
+  if child_count == 1 {
+    return match first_child {
+      Flat(value, path) => Flat(value, path.push(first_idx))
+      _ => Branch(@sparse_array.singleton(first_idx, first_child))
+    }
+  }
+  let indices = FixedArray::make(child_count, first_idx)
+  let children = FixedArray::make(child_count, first_child)
+  for idx = first_idx + 1, out = 1; idx < 32; {
+    if nexts[idx] == starts[idx] {
+      continue idx + 1, out
+    }
+    indices[out] = idx
+    children[out] = build_hashset_node_range(
+      partitioned,
+      starts[idx],
+      nexts[idx],
+      reverse,
+    )
+    continue idx + 1, out + 1
+  }
+  Branch(@sparse_array.from_sorted_fixed_array(indices, children))
+}
+
+///|
+fn[A : Eq + Hash] hash_set_from_iter_by_add(iter : Iter[A]) -> HashSet[A] {
+  iter.fold(init=new(), (s, e) => s.add(e))
+}
+
+///|
+fn[A : Eq + Hash] hash_set_from_array_by_add(arr : ArrayView[A]) -> HashSet[A] {
+  for n = arr.length(), set = new() {
+    match (n, set) {
+      (0, set) => break set
+      (n, set) => {
+        let k = arr[n - 1]
+        continue n - 1, set.add(k)
+      }
+    }
+  }
+}
+
+///|
+fn[A : Eq + Hash] hash_set_from_array(arr : ArrayView[A]) -> HashSet[A] {
+  if arr.length() <= bulk_build_threshold {
+    return hash_set_from_array_by_add(arr)
+  }
+  let entries = Array::makei(arr.length(), i => {
+    let value = arr[i]
+    { value, path: @path.of(value) }
+  })
+  { data: Some(build_hashset_node_range(entries, 0, entries.length(), true)) }
 }
 
 ///|
@@ -410,7 +560,21 @@ pub fn[A] HashSet::iter(self : HashSet[A]) -> Iter[A] {
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 pub fn[A : Eq + Hash] HashSet::from_iter(iter : Iter[A]) -> HashSet[A] {
-  iter.fold(init=new(), (s, e) => s.add(e))
+  if iter.size_hint() is Some(len) && len <= bulk_build_threshold {
+    return hash_set_from_iter_by_add(iter)
+  }
+  let entries = match iter.size_hint() {
+    Some(len) => Array::new(capacity=len)
+    None => []
+  }
+  iter.each(value => entries.push({ value, path: @path.of(value) }))
+  if entries.length() == 0 {
+    new()
+  } else {
+    {
+      data: Some(build_hashset_node_range(entries, 0, entries.length(), false)),
+    }
+  }
 }
 
 ///|
@@ -433,15 +597,7 @@ pub impl[A : Show] Show for HashSet[A] with fn output(self, logger) {
 #as_free_fn(of, deprecated="Use @immut/hashset.HashSet([...]) instead")
 #deprecated("Use @immut/hashset.HashSet([...]) instead")
 pub fn[A : Eq + Hash] HashSet::from_array(arr : ArrayView[A]) -> HashSet[A] {
-  for n = arr.length(), set = new() {
-    match (n, set) {
-      (0, set) => break set
-      (n, set) => {
-        let k = arr[n - 1]
-        continue n - 1, set.add(k)
-      }
-    }
-  }
+  hash_set_from_array(arr)
 }
 
 ///|
@@ -457,15 +613,7 @@ pub fn[A : Eq + Hash] HashSet::from_array(arr : ArrayView[A]) -> HashSet[A] {
 /// }
 /// ```
 pub fn[A : Eq + Hash] HashSet::HashSet(arr : ArrayView[A]) -> HashSet[A] {
-  for n = arr.length(), set = new() {
-    match (n, set) {
-      (0, set) => break set
-      (n, set) => {
-        let k = arr[n - 1]
-        continue n - 1, set.add(k)
-      }
-    }
-  }
+  hash_set_from_array(arr)
 }
 
 ///|

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -180,11 +180,11 @@ fn[A : Eq] build_hashset_node_range(
     let entry = entries[start]
     return Flat(entry.value, entry.path.advance(depth))
   }
-  if entries[start].path.is_last_at(depth) {
+  if depth == 5 {
     return build_hashset_node_by_add(entries, start, end, depth, reverse)
   }
   let starts = FixedArray::make(32, 0)
-  for i = start; i < end; i = i + 1 {
+  for i in start..<end {
     starts[entries[i].path.idx_at(depth)] += 1
   }
   let nexts = FixedArray::make(32, 0)
@@ -196,22 +196,27 @@ fn[A : Eq] build_hashset_node_range(
   }
   let first = entries[start]
   let partitioned = Array::make(end - start, first)
-  for i = start; i < end; i = i + 1 {
+  for i in start..<end {
     let entry = entries[i]
     let idx = entry.path.idx_at(depth)
     let offset = nexts[idx]
     partitioned[offset] = entry
     nexts[idx] = offset + 1
   }
-  let mut child_count = 0
-  for idx = 0; idx < 32; idx = idx + 1 {
-    if nexts[idx] != starts[idx] {
-      child_count += 1
+  let child_count = for idx, next in nexts; count = 0 {
+    if next != starts[idx] {
+      continue count + 1
     }
+    continue count
+  } nobreak {
+    count
   }
-  let mut first_idx = 0
-  while nexts[first_idx] == starts[first_idx] {
-    first_idx += 1
+  let first_idx = for idx, next in nexts {
+    if next != starts[idx] {
+      break idx
+    }
+  } nobreak {
+    abort("unreachable")
   }
   let first_child = build_hashset_node_range(
     partitioned,

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -159,6 +159,40 @@ test "from_iter empty iter" {
 }
 
 ///|
+fn rebuild_from_array_by_add(data : Array[Int]) -> @hashset.HashSet[Int] {
+  for n = data.length(), set = @hashset.new() {
+    match n {
+      0 => break set
+      _ => continue n - 1, set.add(data[n - 1])
+    }
+  }
+}
+
+///|
+fn rebuild_from_iter_by_add(data : Array[Int]) -> @hashset.HashSet[Int] {
+  for value in data; set = @hashset.new() {
+    continue set.add(value)
+  } nobreak {
+    set
+  }
+}
+
+///|
+test "from_array matches reverse add with duplicates" {
+  let data = Array::makei(256, i => (i * 1103515245 + 12345) & 63)
+  @test.assert_eq(@hashset.HashSet(data), rebuild_from_array_by_add(data))
+}
+
+///|
+test "from_iter matches forward add with duplicates" {
+  let data = Array::makei(256, i => (i * 1103515245 + 12345) & 63)
+  @test.assert_eq(
+    @hashset.from_iter(data.iter()),
+    rebuild_from_iter_by_add(data),
+  )
+}
+
+///|
 test "each on empty set" {
   let s = @hashset.new()
   let mut count = 0
@@ -297,6 +331,39 @@ impl Hash for SegKey with fn hash_combine(self, hasher) {
 ///|
 impl Eq for SegKey with fn equal(self, other) {
   self.0 == other.0
+}
+
+///|
+struct SameKey(Int, String)
+
+///|
+impl Hash for SameKey with fn hash_combine(self, hasher) {
+  hasher.combine_int(self.0)
+}
+
+///|
+impl Eq for SameKey with fn equal(self, other) {
+  self.0 == other.0
+}
+
+///|
+test "from_array duplicate keeps last representative" {
+  let set = @hashset.HashSet([SameKey(1, "first"), SameKey(1, "second")])
+  let values = set.iter().to_array()
+  @test.assert_eq(values.length(), 1)
+  let SameKey(_, label) = values[0]
+  inspect(label, content="second")
+}
+
+///|
+test "from_iter duplicate keeps first representative" {
+  let set = @hashset.from_iter(
+    [SameKey(1, "first"), SameKey(1, "second")].iter(),
+  )
+  let values = set.iter().to_array()
+  @test.assert_eq(values.length(), 1)
+  let SameKey(_, label) = values[0]
+  inspect(label, content="first")
 }
 
 ///|

--- a/immut/hashset/hashset_build_bench_test.mbt
+++ b/immut/hashset/hashset_build_bench_test.mbt
@@ -1,0 +1,49 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let hashset_build_bench_size = 10_000
+
+///|
+fn hashset_build_random_key(i : Int) -> Int {
+  (i * 1103515245 + 12345) & 0x7fffffff
+}
+
+///|
+fn make_hashset_ordered_build_data() -> Array[Int] {
+  Array::makei(hashset_build_bench_size, i => i)
+}
+
+///|
+fn make_hashset_random_build_data() -> Array[Int] {
+  Array::makei(hashset_build_bench_size, hashset_build_random_key)
+}
+
+///|
+test "bench HashSet constructor ordered n=10000" (it : @bench.T) {
+  let data = make_hashset_ordered_build_data()
+  it.bench(fn() { it.keep(@hashset.HashSet(data)) })
+}
+
+///|
+test "bench HashSet constructor random n=10000" (it : @bench.T) {
+  let data = make_hashset_random_build_data()
+  it.bench(fn() { it.keep(@hashset.HashSet(data)) })
+}
+
+///|
+test "bench HashSet::from_iter random n=10000" (it : @bench.T) {
+  let data = make_hashset_random_build_data()
+  it.bench(fn() { it.keep(@hashset.from_iter(data.iter())) })
+}

--- a/immut/hashset/moon.pkg
+++ b/immut/hashset/moon.pkg
@@ -10,6 +10,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/int",
   "moonbitlang/core/test",
 } for "test"

--- a/immut/internal/path/README.mbt.md
+++ b/immut/internal/path/README.mbt.md
@@ -54,7 +54,6 @@ test "depth-aware path navigation" {
   let path = @path.of("test_key")
   for depth = 0, current = path; depth < 6; {
     assert_eq(path.idx_at(depth), current.idx())
-    assert_eq(path.is_last_at(depth), current.is_last())
     assert_true(path.advance(depth) == current)
     continue depth + 1, current.next()
   }

--- a/immut/internal/path/README.mbt.md
+++ b/immut/internal/path/README.mbt.md
@@ -45,6 +45,22 @@ test "path navigation" {
 }
 ```
 
+Depth-aware navigation reads the original path without allocating an
+intermediate path for every traversed level:
+
+```mbt check
+///|
+test "depth-aware path navigation" {
+  let path = @path.of("test_key")
+  for depth = 0, current = path; depth < 6; {
+    assert_eq(path.idx_at(depth), current.idx())
+    assert_eq(path.is_last_at(depth), current.is_last())
+    assert_true(path.advance(depth) == current)
+    continue depth + 1, current.next()
+  }
+}
+```
+
 ## Path Construction
 
 Build paths for tree navigation:

--- a/immut/internal/path/path.mbt
+++ b/immut/internal/path/path.mbt
@@ -56,6 +56,14 @@ pub fn Path::is_last(self : Path) -> Bool {
 }
 
 ///|
+/// Returns whether only a single segment remains after skipping `depth`
+/// segments.
+pub fn Path::is_last_at(self : Path, depth : Int) -> Bool {
+  let Path(self) = self
+  self >> (SEGMENT_LENGTH * depth) <= MAX_TAIL
+}
+
+///|
 /// Push the given `idx` as the last segment to `self`.
 pub fn Path::push(self : Path, idx : Int) -> Path {
   let Path(self) = self
@@ -70,8 +78,22 @@ pub fn Path::idx(self : Path) -> Int {
 }
 
 ///|
+/// Returns the segment at `depth` without consuming the path.
+pub fn Path::idx_at(self : Path, depth : Int) -> Int {
+  let Path(self) = self
+  ((self >> (SEGMENT_LENGTH * depth)) & INDEX_MASK).reinterpret_as_int()
+}
+
+///|
 /// Removes last segment of `self`.
 pub fn Path::next(self : Path) -> Path {
   let Path(self) = self
   self >> SEGMENT_LENGTH
+}
+
+///|
+/// Removes `depth` segments from the path.
+pub fn Path::advance(self : Path, depth : Int) -> Path {
+  let Path(self) = self
+  self >> (SEGMENT_LENGTH * depth)
 }

--- a/immut/internal/path/path.mbt
+++ b/immut/internal/path/path.mbt
@@ -56,14 +56,6 @@ pub fn Path::is_last(self : Path) -> Bool {
 }
 
 ///|
-/// Returns whether only a single segment remains after skipping `depth`
-/// segments.
-pub fn Path::is_last_at(self : Path, depth : Int) -> Bool {
-  let Path(self) = self
-  self >> (SEGMENT_LENGTH * depth) <= MAX_TAIL
-}
-
-///|
 /// Push the given `idx` as the last segment to `self`.
 pub fn Path::push(self : Path, idx : Int) -> Path {
   let Path(self) = self

--- a/immut/internal/path/pkg.generated.mbti
+++ b/immut/internal/path/pkg.generated.mbti
@@ -8,8 +8,11 @@ pub fn[A : Hash] of(A) -> Path
 
 // Types and methods
 pub struct Path(UInt) derive(Eq)
+pub fn Path::advance(Self, Int) -> Self
 pub fn Path::idx(Self) -> Int
+pub fn Path::idx_at(Self, Int) -> Int
 pub fn Path::is_last(Self) -> Bool
+pub fn Path::is_last_at(Self, Int) -> Bool
 pub fn Path::next(Self) -> Self
 pub fn Path::push(Self, Int) -> Self
 

--- a/immut/internal/path/pkg.generated.mbti
+++ b/immut/internal/path/pkg.generated.mbti
@@ -12,7 +12,6 @@ pub fn Path::advance(Self, Int) -> Self
 pub fn Path::idx(Self) -> Int
 pub fn Path::idx_at(Self, Int) -> Int
 pub fn Path::is_last(Self) -> Bool
-pub fn Path::is_last_at(Self, Int) -> Bool
 pub fn Path::next(Self) -> Self
 pub fn Path::push(Self, Int) -> Self
 

--- a/immut/internal/sparse_array/pkg.generated.mbti
+++ b/immut/internal/sparse_array/pkg.generated.mbti
@@ -6,6 +6,8 @@ pub fn[X] doubleton(Int, X, Int, X) -> SparseArray[X]
 
 pub fn[X] empty() -> SparseArray[X]
 
+pub fn[X] from_sorted_fixed_array(FixedArray[Int], FixedArray[X]) -> SparseArray[X]
+
 pub fn[X] singleton(Int, X) -> SparseArray[X]
 
 // Errors

--- a/immut/internal/sparse_array/sparse_array.mbt
+++ b/immut/internal/sparse_array/sparse_array.mbt
@@ -67,6 +67,22 @@ pub fn[X] doubleton(
 }
 
 ///|
+/// Create a sparse array from sorted unique indices and corresponding data.
+///
+/// The caller must ensure that `indices` are sorted, unique, and have the same
+/// length as `data`.
+pub fn[X] from_sorted_fixed_array(
+  indices : FixedArray[Int],
+  data : FixedArray[X],
+) -> SparseArray[X] {
+  let mut elem_info = empty_bitset
+  for idx in indices {
+    elem_info = elem_info.add(idx)
+  }
+  { elem_info, data }
+}
+
+///|
 /// Add a new element into the sparse array.
 /// `idx` must be absent from `self`
 pub fn[X] SparseArray::add(

--- a/immut/internal/sparse_array/sparse_array_test.mbt
+++ b/immut/internal/sparse_array/sparse_array_test.mbt
@@ -37,6 +37,17 @@ test "SparseArray" {
 }
 
 ///|
+test "SparseArray::from_sorted_fixed_array" {
+  let arr = @sparse_array.from_sorted_fixed_array([0, 3, 31], ["a", "b", "c"])
+  debug_inspect(
+    [arr.get(0), arr.get(1), arr.get(3), arr.get(31)],
+    content=(
+      #|[Some("a"), None, Some("b"), Some("c")]
+    ),
+  )
+}
+
+///|
 test "SparseArray::union" {
   let arr1 = @sparse_array.singleton(0, 0)
     .add(1, 1)


### PR DESCRIPTION
## What changed

- Add a bulk construction path for immutable `HashMap::from_array` / `from_iter` and `HashSet::from_array` / `from_iter`.
- The builder partitions entries by HAMT path segment and constructs branches from contiguous ranges, avoiding repeated persistent `add` work for larger inputs.
- Avoid the hot `SparseArray::add` path during bulk construction by adding `@immut/internal/sparse_array.from_sorted_fixed_array` and building branch children in one allocation.
- Preallocate `BuildEntry` arrays for `from_array`, and use iterator `size_hint` as capacity for `from_iter`.
- Keep the old `add` loop for small inputs (`<= 64`) to avoid bulk-builder overhead.
- Preserve existing duplicate semantics:
  - `HashMap::from_array` remains first value wins.
  - `HashMap::from_iter` remains last value wins.
  - `HashSet::from_array` / `from_iter` keep their existing duplicate representative behavior.
- Add build benchmarks for HashMap / HashSet.
- Add missing docs for public `bench` clock helpers and JS `BigInt` APIs that were surfaced by `moon check`.

## Profile findings

`moon test --profile` requires `xcrun xctrace`; on this machine I ran it with:

```sh
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer moon test -p immut/hashmap --target native --profile --filter "profile HashMap*"
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer moon test -p immut/hashset --target native --profile --filter "profile HashSet*"
```

The temporary profile drivers repeatedly built a 10k-element collection and were not committed.

Before the `SparseArray` change, the profile showed `SparseArray::add` as a real hotspot:

- HashMap: `SparseArray::add` was 17.5% inclusive, mostly `moonbit_make_ref_array_with_blit` / `moonbit_unsafe_ref_array_blit`.
- HashSet: `SparseArray::add` was 18.1% inclusive with the same copy/blit cost.

After constructing sparse arrays from sorted child indices, `SparseArray::add` disappeared from the top profile entries. Samples for the same profile driver dropped:

- HashMap: 1768 -> 1162 samples
- HashSet: 1799 -> 1171 samples

The remaining top cost is now `build_*_node_range` plus allocation/drop overhead while partitioning each HAMT level.

## Benchmarks

`moon bench -p immut/hashmap --target native`

| benchmark | before | after |
|---|---:|---:|
| `HashMap::from_array ordered n=10000` | 1.59 ms | 608.22 us |
| `HashMap::from_array random n=10000` | 1.59 ms | 609.36 us |
| `HashMap::from_iter random n=10000` | 1.61 ms | 624.88 us |

`moon bench -p immut/hashset --target native`

| benchmark | before | after |
|---|---:|---:|
| `HashSet::from_array ordered n=10000` | 1.57 ms | 549.90 us |
| `HashSet::from_array random n=10000` | 1.57 ms | 551.03 us |
| `HashSet::from_iter random n=10000` | 1.58 ms | 562.71 us |

## Validation

- `moon fmt`
- `moon info`
- `moon check -p bench --target all`
- `moon check -p bigint --target all`
- `moon check -p immut/internal/sparse_array --target all`
- `moon check -p immut/hashmap --target all`
- `moon check -p immut/hashset --target all`
- `moon test -p bench --target all`
- `moon test -p bigint --target all`
- `moon test -p immut/internal/sparse_array --target all`
- `moon test -p immut/hashmap --target all`
- `moon test -p immut/hashset --target all`
- `moon bench -p immut/hashmap --target native`
- `moon bench -p immut/hashset --target native`
- `git diff --check`

The missing-doc warnings seen earlier are fixed.