### PR TITLE
[codex] Add BigInt empty octets regression tests

### DIFF
--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -67,6 +67,11 @@ test "to_octets pads larger length" {
 }
 
 ///|
+test "from_octets accepts empty input with zero signum" {
+  inspect(@bigint.BigInt::from_octets(b"", signum=0), content="0")
+}
+
+///|
 test "add" {
   let a = @bigint.BigInt::from_int64(123456789012345678L)
   let b = @bigint.BigInt::from_int64(987654321098765432L)

--- a/bigint/panic_test.mbt
+++ b/bigint/panic_test.mbt
@@ -91,6 +91,11 @@ test "panic from_octets empty" {
 }
 
 ///|
+test "panic from_octets empty negative signum" {
+  @bigint.BigInt::from_octets(Bytes::new(0), signum=-1) |> ignore
+}
+
+///|
 test "panic to_octets negative" {
   (-1N).to_octets() |> ignore
 }


### PR DESCRIPTION
## Summary

Add regression coverage for the `BigInt::from_octets` empty-input edge cases covered by #3748:

- empty octets with `signum=0` returns `0`
- empty octets with a negative signum follows the rejecting panic path

## Validation

- `moon fmt`
- `moon test bigint --target all`
- `moon check --target all`

Follow-up to https://github.com/moonbitlang/core/pull/3748#discussion_r2487184868.