### PR TITLE
fix(immut/vector): preserve concat tree sizes

### DIFF
--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -173,6 +173,17 @@ test "iter concatenated vectors" {
 }
 
 ///|
+test "concat preserves random access after normalizing singleton tail" {
+  let v = @vector.from_iter((0).until(33)).concat(
+    @vector.from_iter((33).until(65)),
+  )
+  @debug.assert_eq(v.iter().to_array(), Array::makei(65, i => i))
+  for j in 0..<65 {
+    @test.assert_eq(v.get(j), Some(j))
+  }
+}
+
+///|
 test "length" {
   let v = @vector.from_array([1, 2, 3, 4, 5])
   let ve : @vector.Vector[Int] = @vector.new()


### PR DESCRIPTION
## Summary

- Recompute tree size metadata when `push_end` or `append_right_leaf` updates a node that previously used radix indexing.
- Preserve the `Node(_, None)` invariant by switching to explicit sizes when a formerly-full node receives a partial right child.
- Add regression tests for repeated small `concat` calls and singleton-tail normalization.

## Root cause

`Node(_, None)` means all children are full enough for radix indexing. `concat` can normalize the left vector tail through `push_end` or `append_right_leaf`; those paths kept `None` even after introducing a partial leaf. Later `get`/`at`/`set` could radix-index into that partial leaf and abort.

Fixes #3721.

## Tests

- `moon test -p immut/vector --target native --filter "concat preserves random access after repeated small appends"`
- `moon test -p immut/vector --target native --filter "concat preserves random access after normalizing singleton tail"`
- `moon test -p immut/vector --target all`
- `moon check -p immut/vector --target all`
- `moon info`
- `moon fmt`
- `git diff --check`
- `moon test --target native`