### PR TITLE
fix(immut/sorted_set): implement Sub

### DIFF
--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -528,6 +528,12 @@ pub fn[A : Compare] SortedSet::difference(
 }
 
 ///|
+/// Difference of two sorted sets.
+pub impl[A : Compare] Sub for SortedSet[A] with fn sub(self, other) {
+  self.difference(other)
+}
+
+///|
 /// Returns a new set containing elements that are in either `self` or `other`,
 /// but not in both sets.
 ///

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -126,6 +126,18 @@ test "diff" {
 }
 
 ///|
+test "sub" {
+  let set1 = @sorted_set.SortedSet([1, 2, 3])
+  let set2 = @sorted_set.SortedSet([2, 4])
+  debug_inspect(
+    set1 - set2,
+    content=(
+      #|<SortedSet: [1, 3]>
+    ),
+  )
+}
+
+///|
 test "inter" {
   debug_inspect(
     @sorted_set.SortedSet([3, 4, 5]).intersection(SortedSet([4, 5, 6])),

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -73,6 +73,7 @@ pub impl[A : Eq] Eq for SortedSet[A]
 pub impl[A : Hash] Hash for SortedSet[A]
 #deprecated
 pub impl[A : Show] Show for SortedSet[A]
+pub impl[A : Compare] Sub for SortedSet[A]
 pub impl[A : ToJson] ToJson for SortedSet[A]
 pub impl[K : @debug.Debug] @debug.Debug for SortedSet[K]
 pub impl[A : @json.FromJson + Compare] @json.FromJson for SortedSet[A]


### PR DESCRIPTION
## Summary

- Add `Sub` for `@immut/sorted_set.SortedSet`.
- Delegate `set1 - set2` to the existing `difference` implementation.
- Add a regression test for the subtraction operator and update the generated interface.

Fixes #3347.

## Tests

- `moon test -p immut/sorted_set --target native --filter sub`
- `moon test -p immut/sorted_set --target all`
- `moon check -p immut/sorted_set --target all`
- `moon info`
- `moon fmt`
- `git diff --check`
- `moon check -p immut/sorted_set --target all --deny-warn`
- `moon test --target native`