### PR TITLE
perf(bytes): use primitive Bytes::equal

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -356,20 +356,7 @@ pub fn FixedArray::set_utf16be_char(
 ///   inspect(bytes1 == bytes3, content="false")
 /// }
 /// ```
-pub impl Eq for Bytes with fn equal(self : Bytes, other : Bytes) -> Bool {
-  if self.length() != other.length() {
-    false
-  } else {
-    let len = self.length()
-    for i in 0..<len {
-      if self[i] != other[i] {
-        break false
-      }
-    } nobreak {
-      true
-    }
-  }
-}
+pub impl Eq for Bytes with fn equal(self : Bytes, other : Bytes) -> Bool = "%bytes.equal"
 
 ///|
 /// Compares two byte sequences based on shortlex order. First compares the lengths of

--- a/builtin/bytes_equal_bench_test.mbt
+++ b/builtin/bytes_equal_bench_test.mbt
@@ -1,0 +1,58 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let bytes_equal_bench_size = 100_000
+
+///|
+fn make_bytes_equal_bench_bytes(diff_at? : Int = -1) -> Bytes {
+  let arr = Array::make(bytes_equal_bench_size, b'\x61')
+  if diff_at >= 0 {
+    arr[diff_at] = b'\x62'
+  }
+  Bytes::from_array(arr)
+}
+
+///|
+fn make_bytes_equal_bench_aliases() -> Array[Bytes] {
+  let bytes = make_bytes_equal_bench_bytes()
+  let aliases = Array::make(2, b"")
+  aliases[0] = bytes
+  aliases[1] = bytes
+  aliases
+}
+
+///|
+test "bench Bytes::equal n=100000 equal" (it : @bench.T) {
+  let left = make_bytes_equal_bench_bytes()
+  let right = make_bytes_equal_bench_bytes()
+  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+}
+
+///|
+test "bench Bytes::equal n=100000 aliased object" (it : @bench.T) {
+  let aliases = make_bytes_equal_bench_aliases()
+  let mut index = 0
+  it.bench(fn() {
+    index = 1 - index
+    it.keep(Bytes::equal(aliases[index], aliases[1 - index]))
+  })
+}
+
+///|
+test "bench Bytes::equal n=100000 mismatch at end" (it : @bench.T) {
+  let left = make_bytes_equal_bench_bytes()
+  let right = make_bytes_equal_bench_bytes(diff_at=bytes_equal_bench_size - 1)
+  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+}


### PR DESCRIPTION
## Summary

- Use the `%bytes.equal` primitive for `Bytes::equal`.
- Add direct `Bytes::equal` benchmarks for equal, aliased, and end-mismatch 100,000-byte inputs.

## Benchmarks

Benchmarks call `Bytes::equal(...)` directly with 100,000-byte inputs. Lower is better.

Before: `main` at `fe8ee7f0` with the same benchmark file applied locally.
After: this branch at `9e9df1c7`.

| target | case | before | after | speedup |
| --- | --- | ---: | ---: | ---: |
| wasm | equal | 150.42 us | 7.94 us | 18.9x |
| wasm | aliased object | 150.02 us | 7.88 us | 19.0x |
| wasm | mismatch at end | 149.97 us | 7.93 us | 18.9x |
| wasm-gc | equal | 63.09 us | 63.30 us | ~same |
| wasm-gc | aliased object | 62.86 us | 62.95 us | ~same |
| wasm-gc | mismatch at end | 63.08 us | 62.95 us | ~same |
| native | equal | 30.28 us | 2.34 us | 12.9x |
| native | aliased object | 32.53 us | 5.73 ns | ~5677x |
| native | mismatch at end | 30.13 us | 2.35 us | 12.8x |
| js | equal | 92.59 us | 56.13 us | 1.65x |
| js | aliased object | 112.39 us | 83.90 us | 1.34x |
| js | mismatch at end | 94.69 us | 55.95 us | 1.69x |

## Validation

- `moon fmt`
- `moon check -p builtin --target all`
- `git diff --check`
- `moon bench -p builtin -f bytes_equal_bench_test.mbt --target wasm --release`
- `moon bench -p builtin -f bytes_equal_bench_test.mbt --target wasm-gc --release`
- `moon bench -p builtin -f bytes_equal_bench_test.mbt --target native --release`
- `moon bench -p builtin -f bytes_equal_bench_test.mbt --target js --release`

`moon info` was intentionally not run for this update.