### PR TITLE
weird errors

### DIFF
--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -158,7 +158,7 @@ test "to_array" {
 
 ///|
 test "iter_collect" {
-  let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
+  let map = from_array([(3, "c"), (2, "b"), (1, "a")])
   debug_inspect(
     map.iter().collect(),
     content=(
@@ -176,7 +176,7 @@ test "iter_collect" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @sorted_map.from_iter([(1, 1), (2, 2), (3, 3)].iter()),
+    from_iter([(1, 1), (2, 2), (3, 3)].iter()),
     content=(
       #|<SortedMap: { 1: 1, 2: 2, 3: 3 }>
     ),


### PR DESCRIPTION
1. from_array is an alias which is not imported
2. from_iter also has a weird warning message
git/core$moon check
Error: [4021]
     ╭─[ /Users/hongbozhang/git/core/sorted_map/map_test.mbt:161:13 ]
     │
 161 │   let map = from_array([(3, "c"), (2, "b"), (1, "a")])
     │             ─────┬────
     │                  ╰────── The value identifier from_array is unbound.
─────╯
Warning: [0020]
     ╭─[ /Users/hongbozhang/git/core/sorted_map/map_test.mbt:179:5 ]
     │
 179 │     from_iter([(1, 1), (2, 2), (3, 3)].iter()),
     │     ────┬────
     │         ╰────── Warning (deprecated): Use SortedMap::from_iter instead.
─────╯
Warning: [0025]
     ╭─[ /Users/hongbozhang/git/core/sorted_map/map_test.mbt:179:5 ]
     │
 179 │     from_iter([(1, 1), (2, 2), (3, 3)].iter()),
     │     ────┬────
     │         ╰────── Warning (test_unqualified_package): `from_iterator` is implicitly imported in test. Use `@sorted_map.from_iterator` instead.
─────╯
