### PR TITLE
fix(list): correct List constructor and migrate off deprecated from_array

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -450,7 +450,7 @@ fn[K : Eq, V] @list.List::union_with(
       res.push(kv2)
     }
   }
-  guard @list.from_array(res) is More((k, v), tail~)
+  guard @list.List(res) is More((k, v), tail~)
   Leaf(k, v, tail)
 }
 
@@ -553,7 +553,7 @@ fn[K : Eq, V] @list.List::intersection_with(
       }
     }
   }
-  match @list.from_array(res) {
+  match @list.List(res) {
     Empty => None
     More((k, v), tail~) => Some(Leaf(k, v, tail))
   }

--- a/lazy_list/README.mbt.md
+++ b/lazy_list/README.mbt.md
@@ -111,7 +111,7 @@ list, an array, an unfolding generator. We deliberately don't provide
 ///|
 test {
   let from_arr = @lazy_list.from_iter([1, 2, 3].iter())
-  let from_list = @lazy_list.from_iter(@list.from_array([4, 5, 6]).iter())
+  let from_list = @lazy_list.from_iter(@list.List([4, 5, 6]).iter())
   debug_inspect(from_arr.to_array(), content="[1, 2, 3]")
   debug_inspect(from_list.to_array(), content="[4, 5, 6]")
 }

--- a/list/README.mbt.md
+++ b/list/README.mbt.md
@@ -51,8 +51,8 @@ You can create an empty list or a list from an array.
 test {
   let empty_list : @list.List[Int] = @list.new()
   assert_true(empty_list.is_empty())
-  let list = @list.from_array([1, 2, 3, 4, 5])
-  @debug.assert_eq(list, @list.from_array([1, 2, 3, 4, 5]))
+  let list = @list.List([1, 2, 3, 4, 5])
+  @debug.assert_eq(list, List([1, 2, 3, 4, 5]))
 }
 ```
 
@@ -67,8 +67,8 @@ Add an element to the beginning of the list.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([2, 3, 4, 5]).prepend(1)
-  @debug.assert_eq(list, @list.from_array([1, 2, 3, 4, 5]))
+  let list = @list.List([2, 3, 4, 5]).prepend(1)
+  @debug.assert_eq(list, List([1, 2, 3, 4, 5]))
 }
 ```
 
@@ -79,7 +79,7 @@ Get the number of elements in the list.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   @test.assert_eq(list.length(), 5)
 }
 ```
@@ -107,7 +107,7 @@ Get the first element of the list as an `Option`.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   assert_true(list.head() == Some(1))
 }
 ```
@@ -119,8 +119,8 @@ Get the list without its first element.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
-  @debug.assert_eq(list.unsafe_tail(), @list.from_array([2, 3, 4, 5]))
+  let list = @list.List([1, 2, 3, 4, 5])
+  @debug.assert_eq(list.unsafe_tail(), List([2, 3, 4, 5]))
 }
 ```
 
@@ -131,7 +131,7 @@ Get the nth element of the list as an `Option`.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   assert_true(list.nth(2) == Some(3))
 }
 ```
@@ -148,7 +148,7 @@ Iterate over the elements of the list.
 ///|
 test {
   let arr = []
-  @list.from_array([1, 2, 3, 4, 5]).each(x => arr.push(x))
+  @list.List([1, 2, 3, 4, 5]).each(x => arr.push(x))
   @debug.assert_eq(arr, [1, 2, 3, 4, 5])
 }
 ```
@@ -160,8 +160,8 @@ Transform each element of the list.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5]).map(x => x * 2)
-  @debug.assert_eq(list, @list.from_array([2, 4, 6, 8, 10]))
+  let list = @list.List([1, 2, 3, 4, 5]).map(x => x * 2)
+  @debug.assert_eq(list, List([2, 4, 6, 8, 10]))
 }
 ```
 
@@ -172,10 +172,10 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
-  @debug.assert_eq(list.filter(fn(x) { x % 2 == 0 }), @list.from_array([2, 4]))
+  let list = @list.List([1, 2, 3, 4, 5])
+  @debug.assert_eq(list.filter(fn(x) { x % 2 == 0 }), List([2, 4]))
   let fm = list.filter_map(fn(x) { if x > 3 { Some(x * 10) } else { None } })
-  @debug.assert_eq(fm, @list.from_array([40, 50]))
+  @debug.assert_eq(fm, List([40, 50]))
 }
 ```
 
@@ -186,7 +186,7 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3])
+  let list = @list.List([1, 2, 3])
   @test.assert_eq(list.fold(init=0, fn(acc, x) { acc + x }), 6)
   let indexed = list.foldi(init="", fn(i, acc, x) {
     acc + i.to_string() + ":" + x.to_string() + " "
@@ -200,7 +200,7 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   assert_true(list.find(fn(x) { x > 3 }) == Some(4))
   assert_true(list.find_index(fn(x) { x == 3 }) == Some(2))
   @test.assert_eq(list.any(fn(x) { x > 4 }), true)
@@ -215,9 +215,9 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3])
-  let result = list.flat_map(fn(x) { @list.from_array([x, x * 10]) })
-  @debug.assert_eq(result, @list.from_array([1, 10, 2, 20, 3, 30]))
+  let list = @list.List([1, 2, 3])
+  let result = list.flat_map(fn(x) { List([x, x * 10]) })
+  @debug.assert_eq(result, List([1, 10, 2, 20, 3, 30]))
 }
 ```
 
@@ -232,14 +232,11 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
-  @debug.assert_eq(list.take(3), @list.from_array([1, 2, 3]))
-  @debug.assert_eq(list.drop(3), @list.from_array([4, 5]))
-  @debug.assert_eq(
-    list.take_while(fn(x) { x < 4 }),
-    @list.from_array([1, 2, 3]),
-  )
-  @debug.assert_eq(list.drop_while(fn(x) { x < 4 }), @list.from_array([4, 5]))
+  let list = @list.List([1, 2, 3, 4, 5])
+  @debug.assert_eq(list.take(3), List([1, 2, 3]))
+  @debug.assert_eq(list.drop(3), List([4, 5]))
+  @debug.assert_eq(list.take_while(fn(x) { x < 4 }), List([1, 2, 3]))
+  @debug.assert_eq(list.drop_while(fn(x) { x < 4 }), List([4, 5]))
 }
 ```
 
@@ -250,9 +247,9 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 2, 1])
-  @debug.assert_eq(list.remove(2), @list.from_array([1, 3, 2, 1]))
-  @debug.assert_eq(list.remove_at(0), @list.from_array([2, 3, 2, 1]))
+  let list = @list.List([1, 2, 3, 2, 1])
+  @debug.assert_eq(list.remove(2), List([1, 3, 2, 1]))
+  @debug.assert_eq(list.remove_at(0), List([2, 3, 2, 1]))
 }
 ```
 
@@ -261,7 +258,7 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([3, 1, 4, 1, 5])
+  let list = @list.List([3, 1, 4, 1, 5])
   assert_true(list.last() == Some(5))
   assert_true(list.minimum() == Some(1))
   assert_true(list.maximum() == Some(5))
@@ -275,8 +272,8 @@ Reverse the list.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5]).rev()
-  @debug.assert_eq(list, @list.from_array([5, 4, 3, 2, 1]))
+  let list = @list.List([1, 2, 3, 4, 5]).rev()
+  @debug.assert_eq(list, List([5, 4, 3, 2, 1]))
 }
 ```
 
@@ -287,8 +284,8 @@ Concatenate two lists.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3]).concat(@list.from_array([4, 5]))
-  @debug.assert_eq(list, @list.from_array([1, 2, 3, 4, 5]))
+  let list = @list.List([1, 2, 3]).concat(List([4, 5]))
+  @debug.assert_eq(list, List([1, 2, 3, 4, 5]))
 }
 ```
 
@@ -299,11 +296,8 @@ Flatten a list of lists.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([
-    @list.from_array([1, 2]),
-    @list.from_array([3, 4]),
-  ]).flatten()
-  @debug.assert_eq(list, @list.from_array([1, 2, 3, 4]))
+  let list = @list.List([@list.List([1, 2]), List([3, 4])]).flatten()
+  @debug.assert_eq(list, List([1, 2, 3, 4]))
 }
 ```
 
@@ -314,8 +308,8 @@ Sort the list in ascending order.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([3, 1, 4, 1, 5, 9]).sort()
-  @debug.assert_eq(list, @list.from_array([1, 1, 3, 4, 5, 9]))
+  let list = @list.List([3, 1, 4, 1, 5, 9]).sort()
+  @debug.assert_eq(list, List([1, 1, 3, 4, 5, 9]))
 }
 ```
 
@@ -326,18 +320,11 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3])
-  @debug.assert_eq(list.intersperse(0), @list.from_array([1, 0, 2, 0, 3]))
-  let nested = @list.from_array([
-    @list.from_array([1, 2]),
-    @list.from_array([3, 4]),
-    @list.from_array([5]),
-  ])
-  let sep = @list.from_array([0])
-  @debug.assert_eq(
-    nested.intercalate(sep),
-    @list.from_array([1, 2, 0, 3, 4, 0, 5]),
-  )
+  let list = @list.List([1, 2, 3])
+  @debug.assert_eq(list.intersperse(0), List([1, 0, 2, 0, 3]))
+  let nested = @list.List([@list.List([1, 2]), List([3, 4]), List([5])])
+  let sep = @list.List([0])
+  @debug.assert_eq(nested.intercalate(sep), List([1, 2, 0, 3, 4, 0, 5]))
 }
 ```
 
@@ -346,13 +333,13 @@ test {
 ```mbt check
 ///|
 test {
-  let a = @list.from_array([1, 2, 3])
-  let b = @list.from_array(["a", "b", "c"])
+  let a = @list.List([1, 2, 3])
+  let b = @list.List(["a", "b", "c"])
   let zipped = @list.zip(a, b)
-  @debug.assert_eq(zipped, @list.from_array([(1, "a"), (2, "b"), (3, "c")]))
+  @debug.assert_eq(zipped, List([(1, "a"), (2, "b"), (3, "c")]))
   let (xs, ys) = zipped.unzip()
-  @debug.assert_eq(xs, @list.from_array([1, 2, 3]))
-  @debug.assert_eq(ys, @list.from_array(["a", "b", "c"]))
+  @debug.assert_eq(xs, List([1, 2, 3]))
+  @debug.assert_eq(ys, List(["a", "b", "c"]))
 }
 ```
 
@@ -363,10 +350,10 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3])
+  let list = @list.List([1, 2, 3])
   @debug.assert_eq(
     list.scan_left(fn(acc, x) { acc + x }, init=0),
-    @list.from_array([0, 1, 3, 6]),
+    List([0, 1, 3, 6]),
   )
 }
 ```
@@ -376,9 +363,9 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
-  @test.assert_eq(list.is_prefix(@list.from_array([1, 2, 3])), true)
-  @test.assert_eq(list.is_suffix(@list.from_array([4, 5])), true)
+  let list = @list.List([1, 2, 3, 4, 5])
+  @test.assert_eq(list.is_prefix(List([1, 2, 3])), true)
+  @test.assert_eq(list.is_suffix(List([4, 5])), true)
 }
 ```
 
@@ -389,7 +376,7 @@ Look up a value in an association list (list of key-value pairs):
 ```mbt check
 ///|
 test {
-  let assoc = @list.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let assoc = @list.List([("a", 1), ("b", 2), ("c", 3)])
   assert_true(assoc.lookup("b") == Some(2))
   assert_true(assoc.lookup("z") == None)
 }
@@ -409,7 +396,7 @@ test {
       Some((n, n + 1))
     }
   })
-  @debug.assert_eq(list, @list.from_array([1, 2, 3, 4, 5]))
+  @debug.assert_eq(list, List([1, 2, 3, 4, 5]))
 }
 ```
 
@@ -422,10 +409,10 @@ test {
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3])
+  let list = @list.List([1, 2, 3])
   debug_inspect(list.iter().to_array(), content="[1, 2, 3]")
   let list2 = @list.from_iter([4, 5, 6].iter())
-  @debug.assert_eq(list2, @list.from_array([4, 5, 6]))
+  @debug.assert_eq(list2, List([4, 5, 6]))
 }
 ```
 
@@ -440,7 +427,7 @@ Convert a list to an array.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   @debug.assert_eq(list.to_array(), [1, 2, 3, 4, 5])
 }
 ```
@@ -452,8 +439,8 @@ Create a list from an array.
 ```mbt check
 ///|
 test {
-  let list = @list.from_array([1, 2, 3, 4, 5])
-  @debug.assert_eq(list, @list.from_array([1, 2, 3, 4, 5]))
+  let list = @list.List([1, 2, 3, 4, 5])
+  @debug.assert_eq(list, List([1, 2, 3, 4, 5]))
 }
 ```
 
@@ -466,8 +453,8 @@ Lists with the same elements in the same order are considered equal.
 ```mbt check
 ///|
 test {
-  let list1 = @list.from_array([1, 2, 3])
-  let list2 = @list.from_array([1, 2, 3])
+  let list1 = @list.List([1, 2, 3])
+  let list2 = @list.List([1, 2, 3])
   @test.assert_eq(list1 == list2, true)
 }
 ```
@@ -489,7 +476,7 @@ fn safe_head(list : @list.List[Int]) -> Int {
 
 ///|
 test {
-  let list = @list.from_array([1, 2, 3])
+  let list = @list.List([1, 2, 3])
   @test.assert_eq(safe_head(list), 1)
   let empty_list : @list.List[Int] = @list.new()
   @test.assert_eq(safe_head(empty_list), 0)

--- a/list/debug.mbt
+++ b/list/debug.mbt
@@ -28,6 +28,6 @@ pub fn[A : @debug.Debug] List::to_repr(self : List[A]) -> @debug.Repr {
 
 ///|
 test "Debug for List" {
-  let xs : List[Int] = from_array([1, 2, 3])
+  let xs : List[Int] = List([1, 2, 3])
   @debug.debug_inspect(xs, content="<List: [1, 2, 3]>")
 }

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -43,9 +43,9 @@ pub fn[A] List::new() -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let tail = @list.from_array([2, 3, 4])
+///   let tail = @list.List([2, 3, 4])
 ///   let ls = @list.cons(1, tail)
-///   @debug.assert_eq(ls, @list.from_array([1, 2, 3, 4]))
+///   @debug.assert_eq(ls, List([1, 2, 3, 4]))
 /// }
 /// ```
 #as_free_fn
@@ -63,8 +63,8 @@ pub fn[A] List::cons(head : A, tail : List[A]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([2, 3, 4]).prepend(1)
-///   @debug.assert_eq(ls, @list.from_array([1, 2, 3, 4]))
+///   let ls = @list.List([2, 3, 4]).prepend(1)
+///   @debug.assert_eq(ls, List([1, 2, 3, 4]))
 /// }
 /// ```
 #alias(add)
@@ -115,7 +115,7 @@ pub impl[A : ToJson] ToJson for List[A] with fn to_json(self) {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3])
+///   let ls = @list.List([1, 2, 3])
 ///   let json = ls.to_json()
 ///   @debug.debug_inspect(json, content="Array([Number(1), Number(2), Number(3)])")
 /// }
@@ -159,8 +159,8 @@ pub fn[A : @json.FromJson] List::from_json(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
-///   @debug.assert_eq(ls, @list.from_array([1, 2, 3, 4, 5]))
+///   let ls = @list.List([1, 2, 3, 4, 5])
+///   @debug.assert_eq(ls, List([1, 2, 3, 4, 5]))
 /// }
 /// ```
 #as_free_fn(deprecated="Use @list.List([...]) instead")
@@ -182,13 +182,13 @@ pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
 ///   debug_inspect(
 ///     lst,
 ///     content=(
-///       #|<List: [1, 2, 3, 4]>
+///       #|<List: [1, 2, 3, 4, 5]>
 ///     ),
 ///   )
 /// }
 /// ```
 pub fn[A] List::List(arr : ArrayView[A]) -> List[A] {
-  for i in (arr.length() - 1)>..0; list = Empty {
+  for i in arr.length()>..0; list = Empty {
     continue More(arr[i], tail=list)
   } nobreak {
     list
@@ -214,7 +214,7 @@ pub fn[A] List::length(self : List[A]) -> Int {
 /// ```mbt check
 /// test {
 ///   let arr = []
-///   @list.from_array([1, 2, 3, 4, 5]).each(x => arr.push(x))
+///   @list.List([1, 2, 3, 4, 5]).each(x => arr.push(x))
 ///   @debug.assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
 /// ```
@@ -239,7 +239,7 @@ pub fn[A] List::each(self : List[A], f : (A) -> Unit raise?) -> Unit raise? {
 /// ```mbt check
 /// test {
 ///   let arr = []
-///   @list.from_array([1, 2, 3, 4, 5]).eachi((i, x) => arr.push("(\{i},\{x})"))
+///   @list.List([1, 2, 3, 4, 5]).eachi((i, x) => arr.push("(\{i},\{x})"))
 ///   @debug.assert_eq(arr, ["(0,1)", "(1,2)", "(2,3)", "(3,4)", "(4,5)"])
 /// }
 /// ```
@@ -267,8 +267,8 @@ pub fn[A] List::eachi(
 /// ```mbt check
 /// test {
 ///   @debug.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).map(x => x * 2),
-///     @list.from_array([2, 4, 6, 8, 10]),
+///     @list.List([1, 2, 3, 4, 5]).map(x => x * 2),
+///     List([2, 4, 6, 8, 10]),
 ///   )
 /// }
 /// ```
@@ -304,9 +304,9 @@ pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([10, 20, 30])
+///   let ls = @list.List([10, 20, 30])
 ///   let result = ls.mapi((i, x) => x + i)
-///   @debug.assert_eq(result, @list.from_array([10, 21, 32]))
+///   @debug.assert_eq(result, List([10, 21, 32]))
 /// }
 /// ```
 #locals(f)
@@ -343,8 +343,8 @@ pub fn[A, B] List::mapi(
 /// ```mbt check
 /// test {
 ///   @debug.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).rev_map(x => x * 2),
-///     @list.from_array([10, 8, 6, 4, 2]),
+///     @list.List([1, 2, 3, 4, 5]).rev_map(x => x * 2),
+///     List([10, 8, 6, 4, 2]),
 ///   )
 /// }
 /// ```
@@ -370,7 +370,7 @@ pub fn[A, B] List::rev_map(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   let arr = ls.to_array()
 ///   @debug.assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
@@ -389,8 +389,8 @@ pub fn[A] List::to_array(self : List[A]) -> Array[A] {
 /// ```mbt check
 /// test {
 ///   @debug.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).filter(x => x % 2 == 0),
-///     @list.from_array([2, 4]),
+///     @list.List([1, 2, 3, 4, 5]).filter(x => x % 2 == 0),
+///     List([2, 4]),
 ///   )
 /// }
 /// ```
@@ -438,9 +438,9 @@ pub fn[A] List::filter(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([2, 4, 6, 8])
+///   let ls = @list.List([2, 4, 6, 8])
 ///   @test.assert_eq(ls.all(x => x % 2 == 0), true)
-///   let ls2 = @list.from_array([2, 3, 6, 8])
+///   let ls2 = @list.List([2, 3, 6, 8])
 ///   @test.assert_eq(ls2.all(x => x % 2 == 0), false)
 /// }
 /// ```
@@ -464,9 +464,9 @@ pub fn[A] List::all(self : List[A], f : (A) -> Bool raise?) -> Bool raise? {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 3, 5, 6])
+///   let ls = @list.List([1, 3, 5, 6])
 ///   @test.assert_eq(ls.any(x => x % 2 == 0), true)
-///   let ls2 = @list.from_array([1, 3, 5, 7])
+///   let ls2 = @list.List([1, 3, 5, 7])
 ///   @test.assert_eq(ls2.any(x => x % 2 == 0), false)
 /// }
 /// ```
@@ -501,9 +501,9 @@ pub fn[A] List::unsafe_head(self : List[A]) -> A {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   let tail = ls.unsafe_tail()
-///   @debug.assert_eq(tail, @list.from_array([2, 3, 4, 5]))
+///   @debug.assert_eq(tail, List([2, 3, 4, 5]))
 /// }
 /// ```
 /// 
@@ -524,7 +524,7 @@ pub fn[A] List::unsafe_tail(self : List[A]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   assert_true(@list.from_array([1, 2, 3, 4, 5]).head() == Some(1))
+///   assert_true(@list.List([1, 2, 3, 4, 5]).head() == Some(1))
 /// }
 /// ```
 pub fn[A] List::head(self : List[A]) -> A? {
@@ -544,7 +544,7 @@ pub fn[A] List::head(self : List[A]) -> A? {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   @test.assert_eq(ls.unsafe_last(), 5)
 /// }
 /// ```
@@ -571,7 +571,7 @@ pub fn[A] List::unsafe_last(self : List[A]) -> A {
 ///
 /// ```mbt check
 /// test {
-///   assert_true(@list.from_array([1, 2, 3, 4, 5]).last() == Some(5))
+///   assert_true(@list.List([1, 2, 3, 4, 5]).last() == Some(5))
 /// }
 /// ```
 pub fn[A] List::last(self : List[A]) -> A? {
@@ -591,10 +591,8 @@ pub fn[A] List::last(self : List[A]) -> A? {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5]).concat(
-///     @list.from_array([6, 7, 8, 9, 10]),
-///   )
-///   @debug.assert_eq(ls, @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+///   let ls = @list.List([1, 2, 3, 4, 5]).concat(List([6, 7, 8, 9, 10]))
+///   @debug.assert_eq(ls, List([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 /// }
 /// ```
 pub fn[A] List::concat(self : List[A], other : List[A]) -> List[A] {
@@ -629,10 +627,8 @@ pub fn[A] List::concat(self : List[A], other : List[A]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5]).rev_concat(
-///     @list.from_array([6, 7, 8, 9, 10]),
-///   )
-///   @debug.assert_eq(ls, @list.from_array([5, 4, 3, 2, 1, 6, 7, 8, 9, 10]))
+///   let ls = @list.List([1, 2, 3, 4, 5]).rev_concat(List([6, 7, 8, 9, 10]))
+///   @debug.assert_eq(ls, List([5, 4, 3, 2, 1, 6, 7, 8, 9, 10]))
 /// }
 /// ```
 pub fn[A] List::rev_concat(self : List[A], other : List[A]) -> List[A] {
@@ -651,10 +647,7 @@ pub fn[A] List::rev_concat(self : List[A], other : List[A]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   @debug.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).rev(),
-///     @list.from_array([5, 4, 3, 2, 1]),
-///   )
+///   @debug.assert_eq(@list.List([1, 2, 3, 4, 5]).rev(), List([5, 4, 3, 2, 1]))
 /// }
 /// ```
 pub fn[A] List::rev(self : List[A]) -> List[A] {
@@ -668,7 +661,7 @@ pub fn[A] List::rev(self : List[A]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let r = @list.from_array([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => acc + x)
+///   let r = @list.List([1, 2, 3, 4, 5]).fold(init=0, (acc, x) => acc + x)
 ///   inspect(r, content="15")
 /// }
 /// ```
@@ -696,7 +689,7 @@ pub fn[A, B] List::fold(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([10, 20, 30])
+///   let ls = @list.List([10, 20, 30])
 ///   let result = ls.foldi(init=0, (i, acc, x) => acc + x * i)
 ///   inspect(result, content="80") // 0*10 + 1*20 + 2*30 = 80
 /// }
@@ -725,19 +718,10 @@ pub fn[A, B] List::foldi(
 ///
 /// ```mbt check
 /// test {
-///   let r = @list.zip(
-///     @list.from_array([1, 2, 3, 4, 5]),
-///     @list.from_array([6, 7, 8, 9, 10]),
-///   )
-///   @debug.assert_eq(
-///     r,
-///     @list.from_array([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]),
-///   )
-///   let r2 = @list.zip(
-///     @list.from_array([1, 2]),
-///     @list.from_array([6, 7, 8, 9, 10]),
-///   )
-///   @debug.assert_eq(r2, @list.from_array([(1, 6), (2, 7)]))
+///   let r = @list.zip(List([1, 2, 3, 4, 5]), List([6, 7, 8, 9, 10]))
+///   @debug.assert_eq(r, List([(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]))
+///   let r2 = @list.zip(List([1, 2]), List([6, 7, 8, 9, 10]))
+///   @debug.assert_eq(r2, List([(1, 6), (2, 7)]))
 /// }
 /// ```
 #as_free_fn
@@ -762,9 +746,9 @@ pub fn[A, B] List::zip(self : List[A], other : List[B]) -> List[(A, B)] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3])
-///   let r = ls.flat_map(x => @list.from_array([x, x * 2]))
-///   @debug.assert_eq(r, @list.from_array([1, 2, 2, 4, 3, 6]))
+///   let ls = @list.List([1, 2, 3])
+///   let r = ls.flat_map(x => List([x, x * 2]))
+///   @debug.assert_eq(r, List([1, 2, 2, 4, 3, 6]))
 /// }
 /// ```
 #locals(f)
@@ -827,9 +811,9 @@ pub fn[A, B] List::flat_map(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([4, 2, 2, 6, 3, 1])
+///   let ls = @list.List([4, 2, 2, 6, 3, 1])
 ///   let r = ls.filter_map(x => if x >= 3 { Some(x) } else { None })
-///   @debug.assert_eq(r, @list.from_array([4, 6, 3]))
+///   @debug.assert_eq(r, List([4, 6, 3]))
 /// }
 /// ```
 #locals(f)
@@ -876,7 +860,7 @@ pub fn[A, B] List::filter_map(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   @test.assert_eq(ls.unsafe_nth(2), 3)
 /// }
 /// ```
@@ -906,7 +890,7 @@ pub fn[A] List::unsafe_nth(self : List[A], n : Int) -> A {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   assert_true(ls.nth(2) == Some(3))
 ///   assert_true(ls.nth(10) == None)
 /// }
@@ -930,7 +914,7 @@ pub fn[A] List::nth(self : List[A], n : Int) -> A? {
 ///
 /// ```mbt check
 /// test {
-///   @debug.assert_eq(@list.repeat(5, 1), @list.from_array([1, 1, 1, 1, 1]))
+///   @debug.assert_eq(@list.repeat(5, 1), List([1, 1, 1, 1, 1]))
 /// }
 /// ```
 #as_free_fn
@@ -957,11 +941,8 @@ pub fn[A] List::repeat(n : Int, x : A) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array(["1", "2", "3", "4", "5"]).intersperse("|")
-///   @debug.assert_eq(
-///     ls,
-///     @list.from_array(["1", "|", "2", "|", "3", "|", "4", "|", "5"]),
-///   )
+///   let ls = @list.List(["1", "2", "3", "4", "5"]).intersperse("|")
+///   @debug.assert_eq(ls, List(["1", "|", "2", "|", "3", "|", "4", "|", "5"]))
 /// }
 /// ```
 pub fn[A] List::intersperse(self : List[A], separator : A) -> List[A] {
@@ -998,7 +979,7 @@ pub fn[A] List::intersperse(self : List[A], separator : A) -> List[A] {
 /// test {
 ///   let empty_list : @list.List[Int] = @list.empty()
 ///   @test.assert_eq(empty_list.is_empty(), true)
-///   let non_empty = @list.from_array([1, 2, 3])
+///   let non_empty = @list.List([1, 2, 3])
 ///   @test.assert_eq(non_empty.is_empty(), false)
 /// }
 /// ```
@@ -1013,9 +994,9 @@ pub fn[A] List::is_empty(self : List[A]) -> Bool {
 ///
 /// ```mbt check
 /// test {
-///   let (a, b) = @list.from_array([(1, 2), (3, 4), (5, 6)]).unzip()
-///   @debug.assert_eq(a, @list.from_array([1, 3, 5]))
-///   @debug.assert_eq(b, @list.from_array([2, 4, 6]))
+///   let (a, b) = @list.List([(1, 2), (3, 4), (5, 6)]).unzip()
+///   @debug.assert_eq(a, List([1, 3, 5]))
+///   @debug.assert_eq(b, List([2, 4, 6]))
 /// }
 /// ```
 pub fn[A, B] List::unzip(self : List[(A, B)]) -> (List[A], List[B]) {
@@ -1047,12 +1028,8 @@ pub fn[A, B] List::unzip(self : List[(A, B)]) -> (List[A], List[B]) {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([
-///     @list.from_array([1, 2, 3]),
-///     @list.from_array([4, 5, 6]),
-///     @list.from_array([7, 8, 9]),
-///   ]).flatten()
-///   @debug.assert_eq(ls, @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+///   let ls = @list.List([@list.List([1, 2, 3]), List([4, 5, 6]), List([7, 8, 9])]).flatten()
+///   @debug.assert_eq(ls, List([1, 2, 3, 4, 5, 6, 7, 8, 9]))
 /// }
 /// ```
 pub fn[A] List::flatten(self : List[List[A]]) -> List[A] {
@@ -1114,7 +1091,7 @@ pub fn[A] List::flatten(self : List[List[A]]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 3, 2, 5, 4])
+///   let ls = @list.List([1, 3, 2, 5, 4])
 ///   @test.assert_eq(ls.unsafe_maximum(), 5)
 /// }
 /// ```
@@ -1148,7 +1125,7 @@ pub fn[A : Compare] List::unsafe_maximum(self : List[A]) -> A {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 3, 2, 5, 4])
+///   let ls = @list.List([1, 3, 2, 5, 4])
 ///   assert_true(ls.maximum() == Some(5))
 ///   let empty : @list.List[Int] = @list.empty()
 ///   assert_true(empty.maximum() == None)
@@ -1178,7 +1155,7 @@ pub fn[A : Compare] List::maximum(self : List[A]) -> A? {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 3, 2, 5, 4])
+///   let ls = @list.List([1, 3, 2, 5, 4])
 ///   @test.assert_eq(ls.unsafe_minimum(), 1)
 /// }
 /// ```
@@ -1212,7 +1189,7 @@ pub fn[A : Compare] List::unsafe_minimum(self : List[A]) -> A {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 3, 2, 5, 4])
+///   let ls = @list.List([1, 3, 2, 5, 4])
 ///   assert_true(ls.minimum() == Some(1))
 ///   let empty : @list.List[Int] = @list.empty()
 ///   assert_true(empty.minimum() == None)
@@ -1239,14 +1216,14 @@ pub fn[A : Compare] List::minimum(self : List[A]) -> A? {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 123, 52, 3, 6, 0, -6, -76]).sort()
-///   @debug.assert_eq(ls, @list.from_array([-76, -6, 0, 1, 3, 6, 52, 123]))
+///   let ls = @list.List([1, 123, 52, 3, 6, 0, -6, -76]).sort()
+///   @debug.assert_eq(ls, List([-76, -6, 0, 1, 3, 6, 52, 123]))
 /// }
 /// ```
 pub fn[A : Compare] List::sort(self : List[A]) -> List[A] {
   let arr = self.to_array()
   arr.sort()
-  from_array(arr)
+  List(arr)
 }
 
 ///|
@@ -1259,10 +1236,10 @@ pub fn[A : Compare] List::sort(self : List[A]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let a = @list.from_array([1, 2, 3])
-///   let b = @list.from_array([4, 5, 6])
+///   let a = @list.List([1, 2, 3])
+///   let b = @list.List([4, 5, 6])
 ///   let result = a + b
-///   @debug.assert_eq(result, @list.from_array([1, 2, 3, 4, 5, 6]))
+///   @debug.assert_eq(result, List([1, 2, 3, 4, 5, 6]))
 /// }
 /// ```
 pub impl[A] Add for List[A] with fn add(self, other) {
@@ -1279,7 +1256,7 @@ pub impl[A] Add for List[A] with fn add(self, other) {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   @test.assert_eq(ls.contains(3), true)
 ///   @test.assert_eq(ls.contains(6), false)
 /// }
@@ -1301,7 +1278,7 @@ pub fn[A : Eq] List::contains(self : List[A], value : A) -> Bool {
 /// ```mbt check
 /// test {
 ///   let r = @list.unfold(init=0, i => if i == 3 { None } else { Some((i, i + 1)) })
-///   @debug.assert_eq(r, @list.from_array([0, 1, 2]))
+///   @debug.assert_eq(r, List([0, 1, 2]))
 /// }
 /// ```
 #as_free_fn
@@ -1344,7 +1321,7 @@ pub fn[A, S] List::unfold(
 ///     i => if i == 3 { None } else { Some((i, i + 1)) },
 ///     init=0,
 ///   )
-///   @debug.assert_eq(r, @list.from_array([2, 1, 0]))
+///   @debug.assert_eq(r, List([2, 1, 0]))
 /// }
 /// ```
 #as_free_fn
@@ -1369,9 +1346,9 @@ pub fn[A, S] List::rev_unfold(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   let r = ls.take(3)
-///   @debug.assert_eq(r, @list.from_array([1, 2, 3]))
+///   @debug.assert_eq(r, List([1, 2, 3]))
 /// }
 /// ```
 pub fn[A] List::take(self : List[A], n : Int) -> List[A] {
@@ -1407,9 +1384,9 @@ pub fn[A] List::take(self : List[A], n : Int) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   let r = ls.drop(3)
-///   @debug.assert_eq(r, @list.from_array([4, 5]))
+///   @debug.assert_eq(r, List([4, 5]))
 /// }
 /// ```
 pub fn[A] List::drop(self : List[A], n : Int) -> List[A] {
@@ -1433,9 +1410,9 @@ pub fn[A] List::drop(self : List[A], n : Int) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4])
+///   let ls = @list.List([1, 2, 3, 4])
 ///   let r = ls.take_while(x => x < 3)
-///   @debug.assert_eq(r, @list.from_array([1, 2]))
+///   @debug.assert_eq(r, List([1, 2]))
 /// }
 /// ```
 #locals(p)
@@ -1473,9 +1450,9 @@ pub fn[A] List::take_while(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4])
+///   let ls = @list.List([1, 2, 3, 4])
 ///   let r = ls.drop_while(x => x < 3)
-///   @debug.assert_eq(r, @list.from_array([3, 4]))
+///   @debug.assert_eq(r, List([3, 4]))
 /// }
 /// ```
 #locals(p)
@@ -1503,9 +1480,9 @@ pub fn[A] List::drop_while(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   let r = ls.scan_left((acc, x) => acc + x, init=0)
-///   @debug.assert_eq(r, @list.from_array([0, 1, 3, 6, 10, 15]))
+///   @debug.assert_eq(r, List([0, 1, 3, 6, 10, 15]))
 /// }
 /// ```
 #locals(f)
@@ -1537,9 +1514,9 @@ pub fn[A, E] List::scan_left(
 /// # Example
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   let r = ls.scan_right((acc, x) => acc + x, init=0)
-///   @debug.assert_eq(r, @list.from_array([15, 14, 12, 9, 5, 0]))
+///   @debug.assert_eq(r, List([15, 14, 12, 9, 5, 0]))
 /// }
 /// ```
 pub fn[A, B] List::scan_right(
@@ -1557,7 +1534,7 @@ pub fn[A, B] List::scan_right(
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([(1, "a"), (2, "b"), (3, "c")])
+///   let ls = @list.List([(1, "a"), (2, "b"), (3, "c")])
 ///   assert_true(ls.lookup(3) == Some("c"))
 /// }
 /// ```
@@ -1578,11 +1555,9 @@ pub fn[A : Eq, B] List::lookup(self : List[(A, B)], v : A) -> B? {
 /// ```mbt check
 /// test {
 ///   assert_true(
-///     @list.from_array([1, 3, 5, 8]).find(element => element % 2 == 0) == Some(8),
+///     @list.List([1, 3, 5, 8]).find(element => element % 2 == 0) == Some(8),
 ///   )
-///   assert_true(
-///     @list.from_array([1, 3, 5]).find(element => element % 2 == 0) == None,
-///   )
+///   assert_true(@list.List([1, 3, 5]).find(element => element % 2 == 0) == None)
 /// }
 /// ```
 #locals(f)
@@ -1617,7 +1592,7 @@ pub fn[A] List::find(self : List[A], f : (A) -> Bool raise?) -> A? raise? {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   debug_inspect(ls.find_index(x => x % 2 == 0), content="Some(1)")
 ///   debug_inspect(ls.find_index(x => x > 10), content="None")
 /// }
@@ -1649,13 +1624,13 @@ pub fn[A] List::find_index(
 /// ```mbt check
 /// test {
 ///   assert_true(
-///     @list.from_array([1, 3, 5, 8]).findi((element, index) => {
+///     @list.List([1, 3, 5, 8]).findi((element, index) => {
 ///       element % 2 == 0 && index == 3
 ///     }) ==
 ///     Some(8),
 ///   )
 ///   assert_true(
-///     @list.from_array([1, 3, 8, 5]).findi((element, index) => {
+///     @list.List([1, 3, 8, 5]).findi((element, index) => {
 ///       element % 2 == 0 && index == 3
 ///     }) ==
 ///     None,
@@ -1684,10 +1659,7 @@ pub fn[A] List::findi(self : List[A], f : (A, Int) -> Bool raise?) -> A? raise? 
 ///
 /// ```mbt check
 /// test {
-///   @debug.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).remove_at(2),
-///     @list.from_array([1, 2, 4, 5]),
-///   )
+///   @debug.assert_eq(@list.List([1, 2, 3, 4, 5]).remove_at(2), List([1, 2, 4, 5]))
 /// }
 /// ```
 pub fn[A] List::remove_at(self : List[A], index : Int) -> List[A] {
@@ -1723,10 +1695,7 @@ pub fn[A] List::remove_at(self : List[A], index : Int) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   @debug.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).remove(3),
-///     @list.from_array([1, 2, 4, 5]),
-///   )
+///   @debug.assert_eq(@list.List([1, 2, 3, 4, 5]).remove(3), List([1, 2, 4, 5]))
 /// }
 /// ```
 pub fn[A : Eq] List::remove(self : List[A], elem : A) -> List[A] {
@@ -1761,10 +1730,7 @@ pub fn[A : Eq] List::remove(self : List[A], elem : A) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).is_prefix(@list.from_array([1, 2, 3])),
-///     true,
-///   )
+///   @test.assert_eq(@list.List([1, 2, 3, 4, 5]).is_prefix(List([1, 2, 3])), true)
 /// }
 /// ```
 pub fn[A : Eq] List::is_prefix(self : List[A], prefix : List[A]) -> Bool {
@@ -1789,10 +1755,7 @@ pub fn[A : Eq] List::is_prefix(self : List[A], prefix : List[A]) -> Bool {
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(
-///     @list.from_array([1, 2, 3, 4, 5]).is_suffix(@list.from_array([3, 4, 5])),
-///     true,
-///   )
+///   @test.assert_eq(@list.List([1, 2, 3, 4, 5]).is_suffix(List([3, 4, 5])), true)
 /// }
 /// ```
 pub fn[A : Eq] List::is_suffix(self : List[A], suffix : List[A]) -> Bool {
@@ -1809,13 +1772,9 @@ pub fn[A : Eq] List::is_suffix(self : List[A], suffix : List[A]) -> Bool {
 /// # Example
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([
-///     @list.from_array([1, 2, 3]),
-///     @list.from_array([4, 5, 6]),
-///     @list.from_array([7, 8, 9]),
-///   ])
-///   let r = ls.intercalate(@list.from_array([0]))
-///   @debug.assert_eq(r, @list.from_array([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]))
+///   let ls = @list.List([@list.List([1, 2, 3]), List([4, 5, 6]), List([7, 8, 9])])
+///   let r = ls.intercalate(List([0]))
+///   @debug.assert_eq(r, List([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]))
 /// }
 /// ```
 pub fn[A] List::intercalate(self : List[List[A]], sep : List[A]) -> List[A] {
@@ -1854,7 +1813,7 @@ pub fn[X] default() -> List[X] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([1, 2, 3, 4, 5])
+///   let ls = @list.List([1, 2, 3, 4, 5])
 ///   let iter = ls.iter()
 ///   let sum = iter.fold(init=0, (acc, x) => acc + x)
 ///   inspect(sum, content="15")
@@ -1884,7 +1843,7 @@ pub fn[A] List::iter(self : List[A]) -> Iter[A] {
 ///
 /// ```mbt check
 /// test {
-///   let ls = @list.from_array([10, 20, 30])
+///   let ls = @list.List([10, 20, 30])
 ///   let iter = ls.iter2()
 ///   debug_inspect(iter.to_array(), content="[(0, 10), (1, 20), (2, 30)]")
 /// }
@@ -1919,7 +1878,7 @@ pub fn[A] List::iter2(self : List[A]) -> Iter2[Int, A] {
 ///   let arr = [1, 2, 3, 4, 5]
 ///   let iter = arr.iter()
 ///   let ls = @list.from_iter(iter)
-///   @debug.assert_eq(ls, @list.from_array([1, 2, 3, 4, 5]))
+///   @debug.assert_eq(ls, List([1, 2, 3, 4, 5]))
 /// }
 /// ```
 #as_free_fn
@@ -1957,7 +1916,7 @@ pub fn[A] List::from_iter(iter : Iter[A]) -> List[A] {
 ///   let arr = [1, 2, 3, 4, 5]
 ///   let iter = arr.iter()
 ///   let ls = @list.from_iter_rev(iter)
-///   @debug.assert_eq(ls, @list.from_array([5, 4, 3, 2, 1]))
+///   @debug.assert_eq(ls, List([5, 4, 3, 2, 1]))
 /// }
 /// ```
 #as_free_fn
@@ -1975,7 +1934,7 @@ pub fn[A] List::from_iter_rev(iter : Iter[A]) -> List[A] {
 /// # Example
 ///
 /// ```mbt test
-/// let ls = @list.from_array([1, 2, 3, 4, 5])
+/// let ls = @list.List([1, 2, 3, 4, 5])
 /// @debug.assert_eq(ls.to_array(), [1, 2, 3, 4, 5])
 /// ```
 
@@ -1987,7 +1946,7 @@ pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for List[X] with fn ar
   size,
   rs,
 ) {
-  @quickcheck.Arbitrary::arbitrary(size, rs) |> from_array
+  @quickcheck.Arbitrary::arbitrary(size, rs) |> List
 }
 
 ///|
@@ -2000,7 +1959,7 @@ pub impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for List[X] with fn ar
 /// ```mbt check
 /// test {
 ///   let ls = @list.singleton(42)
-///   @debug.assert_eq(ls, @list.from_array([42]))
+///   @debug.assert_eq(ls, List([42]))
 ///   @test.assert_eq(ls.length(), 1)
 /// }
 /// ```
@@ -2063,9 +2022,9 @@ fn[A] List::reverse_in_place(self : List[A]) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   let list1 = @list.from_array([1, 2, 3])
-///   let list2 = @list.from_array([1, 2, 4])
-///   let list3 = @list.from_array([1, 2])
+///   let list1 = @list.List([1, 2, 3])
+///   let list2 = @list.List([1, 2, 4])
+///   let list3 = @list.List([1, 2])
 ///   inspect(list1.compare(list2), content="-1") // list1 < list2
 ///   inspect(list1.compare(list3), content="1") // list1 > list3
 ///   inspect(list3.compare(list1), content="-1") // list3 < list1 (shorter)

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -163,12 +163,33 @@ pub fn[A : @json.FromJson] List::from_json(
 ///   @debug.assert_eq(ls, @list.from_array([1, 2, 3, 4, 5]))
 /// }
 /// ```
-#as_free_fn
-#alias(of, deprecated="Use from_array instead")
-#as_free_fn(of, deprecated="Use from_array instead")
+#as_free_fn(deprecated="Use @list.List([...]) instead")
+#alias(of, deprecated="Use @list.List([...]) instead")
+#as_free_fn(of, deprecated="Use @list.List([...]) instead")
+#deprecated("Use @list.List([...]) instead")
 pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
   for i = arr.length() - 1, list = Empty; i >= 0; {
     continue i - 1, More(arr[i], tail=list)
+  } nobreak {
+    list
+  }
+}
+
+///|
+/// ```mbt check
+/// test {
+///   let lst = @list.List([1, 2, 3, 4, 5])
+///   debug_inspect(
+///     lst,
+///     content=(
+///       #|<List: [1, 2, 3, 4]>
+///     ),
+///   )
+/// }
+/// ```
+pub fn[A] List::List(arr : ArrayView[A]) -> List[A] {
+  for i in (arr.length() - 1)>..0; list = Empty {
+    continue More(arr[i], tail=list)
   } nobreak {
     list
   }

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "from_array" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let el : @list.List[Int] = @list.empty()
   debug_inspect(ls, content="<List: [1, 2, 3, 4, 5]>")
   debug_inspect(el, content="<List: []>")
@@ -30,14 +30,14 @@ test "pipe" {
 
 ///|
 test "length" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.length(), content="5")
   debug_inspect(@list.singleton(11), content="<List: [11]>")
 }
 
 ///|
 test "iter" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let failed = for i, x in ls; failed = false {
     if x != i + 1 {
       continue true
@@ -54,7 +54,7 @@ test "iter" {
 test "iteri" {
   let mut v = 0
   let mut failed = false
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   for i, x in ls {
     if x != i + 1 || i != v {
       failed = true
@@ -66,7 +66,7 @@ test "iteri" {
 
 ///|
 test "iter2" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let mut failed = false
   let it = ls.iter2()
   while it.next() is Some((i, x)) {
@@ -79,7 +79,7 @@ test "iter2" {
 
 ///|
 test "map" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let rs : @list.List[Int] = @list.empty()
   debug_inspect(ls.map(x => x * 2), content="<List: [2, 4, 6, 8, 10]>")
   debug_inspect(rs.map(x => x * 2), content="<List: []>")
@@ -87,7 +87,7 @@ test "map" {
 
 ///|
 test "mapi" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let el : @list.List[Int] = @list.empty()
   debug_inspect(ls.mapi((i, x) => i * x), content="<List: [0, 2, 6, 12, 20]>")
   debug_inspect(el.mapi((i, x) => i * x), content="<List: []>")
@@ -95,7 +95,7 @@ test "mapi" {
 
 ///|
 test "rev_map" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let rs : @list.List[Int] = @list.empty()
   debug_inspect(ls.rev_map(x => x * 2), content="<List: [10, 8, 6, 4, 2]>")
   debug_inspect(rs.rev_map(x => x * 2), content="<List: []>")
@@ -103,7 +103,7 @@ test "rev_map" {
 
 ///|
 test "to_array" {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   let empty : @list.List[Int] = @list.empty()
   let array = list.to_array()
   let earray = empty.to_array()
@@ -113,7 +113,7 @@ test "to_array" {
 
 ///|
 test "filter" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let rs : @list.List[Int] = @list.empty()
   debug_inspect(ls.filter(x => x % 2 == 0), content="<List: [2, 4]>")
   debug_inspect(rs.filter(x => x % 2 == 0), content="<List: []>")
@@ -121,21 +121,21 @@ test "filter" {
 
 ///|
 test "all" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.all(x => x > 0), content="true")
   debug_inspect(ls.all(x => x > 1), content="false")
 }
 
 ///|
 test "any" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.any(x => x > 4), content="true")
   debug_inspect(ls.any(x => x > 5), content="false")
 }
 
 ///|
 test "unsafe_tail" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.unsafe_tail(), content="<List: [2, 3, 4, 5]>")
 }
 
@@ -147,28 +147,28 @@ test "panic unsafe_tail" {
 
 ///|
 test "head_exn" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.head(), content="Some(1)")
 }
 
 ///|
 test "head" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
-  let el : @list.List[Int] = @list.from_array([])
+  let ls = @list.List([1, 2, 3, 4, 5])
+  let el : @list.List[Int] = List([])
   debug_inspect(ls.head(), content="Some(1)")
   debug_inspect(el.head(), content="None")
 }
 
 ///|
 test "last" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.last(), content="Some(5)")
 }
 
 ///|
 test "concat" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
-  let rs = @list.from_array([6, 7, 8, 9, 10])
+  let ls = @list.List([1, 2, 3, 4, 5])
+  let rs = @list.List([6, 7, 8, 9, 10])
   debug_inspect(ls.concat(@list.empty()), content="<List: [1, 2, 3, 4, 5]>")
   debug_inspect(
     (@list.empty() : @list.List[Int]).concat(rs),
@@ -182,8 +182,8 @@ test "concat" {
 
 ///|
 test "rev_concat" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
-  let rs = @list.from_array([6, 7, 8, 9, 10])
+  let ls = @list.List([1, 2, 3, 4, 5])
+  let rs = @list.List([6, 7, 8, 9, 10])
   debug_inspect(@list.empty().rev_concat(ls), content="<List: [1, 2, 3, 4, 5]>")
   debug_inspect(
     rs.rev_concat(@list.empty()),
@@ -197,15 +197,15 @@ test "rev_concat" {
 
 ///|
 test "rev" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
-  let rs = @list.from_array([5, 4, 3, 2, 1])
+  let ls = @list.List([1, 2, 3, 4, 5])
+  let rs = @list.List([5, 4, 3, 2, 1])
   debug_inspect(rs.rev(), content="<List: [1, 2, 3, 4, 5]>")
   debug_inspect(ls.rev().rev(), content="<List: [1, 2, 3, 4, 5]>")
 }
 
 ///|
 test "fold" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let el : @list.List[Int] = @list.empty()
   debug_inspect(el.fold((acc, x) => acc + x, init=0), content="0")
   debug_inspect(ls.fold((acc, x) => acc + x, init=0), content="15")
@@ -213,7 +213,7 @@ test "fold" {
 
 ///|
 test "rev_fold" {
-  let ls = @list.from_array(["1", "2", "3", "4", "5"])
+  let ls = @list.List(["1", "2", "3", "4", "5"])
   let el : @list.List[String] = @list.empty()
   debug_inspect(
     ls.rev().fold((acc, x) => x + acc, init=""),
@@ -231,7 +231,7 @@ test "rev_fold" {
 
 ///|
 test "foldi" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let el : @list.List[Int] = @list.empty()
   debug_inspect(ls.foldi((i, acc, x) => acc + i * x, init=0), content="40")
   debug_inspect(el.foldi((i, acc, x) => acc + i * x, init=0), content="0")
@@ -239,7 +239,7 @@ test "foldi" {
 
 ///|
 test "rev_foldi" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   let el : @list.List[Int] = @list.empty()
   debug_inspect(
     ls.rev().foldi((i, acc, x) => x * i + acc, init=0),
@@ -250,8 +250,8 @@ test "rev_foldi" {
 
 ///|
 test "zip" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
-  let rs = @list.from_array([6, 7, 8, 9, 10])
+  let ls = @list.List([1, 2, 3, 4, 5])
+  let rs = @list.List([6, 7, 8, 9, 10])
   debug_inspect(
     ls.zip(rs),
     content="<List: [(1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]>",
@@ -260,27 +260,24 @@ test "zip" {
 
 ///|
 test "flat_map" {
-  let ls = @list.from_array([1, 2, 3])
+  let ls = @list.List([1, 2, 3])
   let rs : @list.List[Int] = @list.empty()
+  debug_inspect(rs.flat_map(x => List([x, x * 2])), content="<List: []>")
   debug_inspect(
-    rs.flat_map(x => @list.from_array([x, x * 2])),
-    content="<List: []>",
-  )
-  debug_inspect(
-    ls.flat_map(x => @list.from_array([x, x * 2])),
+    ls.flat_map(x => List([x, x * 2])),
     content="<List: [1, 2, 2, 4, 3, 6]>",
   )
 }
 
 ///|
 test "flat_map single element" {
-  let ls = @list.from_array([1])
-  debug_inspect(ls.flat_map(x => @list.from_array([x])), content="<List: [1]>")
+  let ls = @list.List([1])
+  debug_inspect(ls.flat_map(x => List([x])), content="<List: [1]>")
 }
 
 ///|
 test "filter_map" {
-  let ls = @list.from_array([4, 2, 2, 6, 3, 1])
+  let ls = @list.List([4, 2, 2, 6, 3, 1])
   let rs : @list.List[Int] = @list.empty()
   debug_inspect(
     ls.filter_map(x => if x >= 3 { Some(x) } else { None }),
@@ -294,7 +291,7 @@ test "filter_map" {
 
 ///|
 test "nth" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.nth(0), content="Some(1)")
   debug_inspect(ls.nth(1), content="Some(2)")
   debug_inspect(ls.nth(20), content="None")
@@ -313,7 +310,7 @@ test "panic List::repeat negative" {
 
 ///|
 test "intersperse" {
-  let ls = @list.from_array(["1", "2", "3", "4", "5"])
+  let ls = @list.List(["1", "2", "3", "4", "5"])
   let el : @list.List[String] = @list.empty()
   debug_inspect(
     ls.intersperse("|"),
@@ -326,14 +323,14 @@ test "intersperse" {
 
 ///|
 test "is_empty" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.is_empty(), content="false")
   debug_inspect((@list.empty() : @list.List[Unit]).is_empty(), content="true")
 }
 
 ///|
 test "unzip" {
-  let ls = @list.from_array([(1, 2), (3, 4), (5, 6)])
+  let ls = @list.List([(1, 2), (3, 4), (5, 6)])
   let (a, b) = ls.unzip()
   debug_inspect(a, content="<List: [1, 3, 5]>")
   debug_inspect(b, content="<List: [2, 4, 6]>")
@@ -341,11 +338,7 @@ test "unzip" {
 
 ///|
 test "flatten" {
-  let ls = @list.from_array([
-    @list.from_array([1, 2, 3]),
-    @list.from_array([4, 5, 6]),
-    @list.from_array([7, 8, 9]),
-  ])
+  let ls = @list.List([@list.List([1, 2, 3]), List([4, 5, 6]), List([7, 8, 9])])
   let el : @list.List[@list.List[Int]] = @list.empty()
   debug_inspect(ls.flatten(), content="<List: [1, 2, 3, 4, 5, 6, 7, 8, 9]>")
   debug_inspect(el.flatten(), content="<List: []>")
@@ -353,34 +346,31 @@ test "flatten" {
 
 ///|
 test "flatten with empty head" {
-  let ls = @list.from_array([
-    (@list.empty() : @list.List[Int]),
-    @list.from_array([1, 2]),
-  ])
+  let ls = @list.List([(@list.empty() : @list.List[Int]), List([1, 2])])
   debug_inspect(ls.flatten(), content="<List: [1, 2]>")
 }
 
 ///|
 test "flatten single list" {
-  let ls = @list.from_array([@list.from_array([1, 2])])
+  let ls = @list.List([@list.List([1, 2])])
   debug_inspect(ls.flatten(), content="<List: [1, 2]>")
 }
 
 ///|
 test "maximum" {
-  let ls = @list.from_array([1, 123, 52, 3, 6, 0, -6, -76])
+  let ls = @list.List([1, 123, 52, 3, 6, 0, -6, -76])
   debug_inspect(ls.maximum(), content="Some(123)")
 }
 
 ///|
 test "minimum" {
-  let ls = @list.from_array([1, 123, 52, 3, 6, 0, -6, -76])
+  let ls = @list.List([1, 123, 52, 3, 6, 0, -6, -76])
   debug_inspect(ls.minimum(), content="Some(-76)")
 }
 
 ///|
 test "sort" {
-  let ls = @list.from_array([1, 123, 52, 3, 6, 0, -6, -76])
+  let ls = @list.List([1, 123, 52, 3, 6, 0, -6, -76])
   let el : @list.List[Int] = @list.empty()
   debug_inspect(el.sort(), content="<List: []>")
   debug_inspect(ls.sort(), content="<List: [-76, -6, 0, 1, 3, 6, 52, 123]>")
@@ -390,13 +380,13 @@ test "sort" {
 test "sort-stack-safety" {
   let arr = FixedArray::makei(100_000, x => x)
   arr.rev_in_place()
-  let ls = @list.from_array(arr)
+  let ls = @list.List(arr)
   ls.sort() |> ignore
 }
 
 ///|
 test "contain" {
-  let ls = @list.from_array([1, 2, 3])
+  let ls = @list.List([1, 2, 3])
   debug_inspect(ls.contains(1), content="true")
   debug_inspect(ls.contains(2), content="true")
   debug_inspect(ls.contains(3), content="true")
@@ -430,7 +420,7 @@ test "rev_unfold" {
 
 ///|
 test "take" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.take(3), content="<List: [1, 2, 3]>")
   debug_inspect(ls.take(-1), content="<List: []>")
   debug_inspect(ls.take(7), content="<List: [1, 2, 3, 4, 5]>")
@@ -440,7 +430,7 @@ test "take" {
 
 ///|
 test "drop" {
-  let ls = @list.from_array([1, 2, 3, 4, 5]).drop(3)
+  let ls = @list.List([1, 2, 3, 4, 5]).drop(3)
   let el : @list.List[Int] = @list.empty()
   debug_inspect(ls, content="<List: [4, 5]>")
   debug_inspect(ls.drop(-10), content="<List: [4, 5]>")
@@ -452,7 +442,7 @@ test "drop" {
 
 ///|
 test "take_while" {
-  let ls = @list.from_array([0, 1, 2, 3, 4]).take_while(x => x < 3)
+  let ls = @list.List([0, 1, 2, 3, 4]).take_while(x => x < 3)
   let el : @list.List[Int] = @list.empty().take_while(_e => true)
   debug_inspect(ls, content="<List: [0, 1, 2]>")
   debug_inspect(el, content="<List: []>")
@@ -460,7 +450,7 @@ test "take_while" {
 
 ///|
 test "drop_while" {
-  let ls = @list.from_array([0, 1, 2, 3, 4]).drop_while(x => x < 3)
+  let ls = @list.List([0, 1, 2, 3, 4]).drop_while(x => x < 3)
   let el : @list.List[Int] = @list.empty().drop_while(_e => true)
   debug_inspect(ls, content="<List: [3, 4]>")
   debug_inspect(el, content="<List: []>")
@@ -469,14 +459,8 @@ test "drop_while" {
 ///|
 test "scan_left" {
   let el = @list.empty().scan_left((acc, x) => acc + x, init=0)
-  let ls = @list.from_array([1, 2, 3, 4, 5]).scan_left(
-    (acc, x) => acc + x,
-    init=0,
-  )
-  let ls2 = @list.from_array([1, 2, 3, 4]).scan_left(
-    (acc, x) => acc - x,
-    init=100,
-  )
+  let ls = @list.List([1, 2, 3, 4, 5]).scan_left((acc, x) => acc + x, init=0)
+  let ls2 = @list.List([1, 2, 3, 4]).scan_left((acc, x) => acc - x, init=100)
   debug_inspect(el, content="<List: [0]>")
   debug_inspect(ls, content="<List: [0, 1, 3, 6, 10, 15]>")
   debug_inspect(ls2, content="<List: [100, 99, 97, 94, 90]>")
@@ -487,7 +471,7 @@ test "scan_left calls f once per element" {
   // Verify that scan_left evaluates f exactly once per element,
   // not twice (which was the previous bug)
   let mut call_count = 0
-  let result = @list.from_array([1, 2, 3]).scan_left(
+  let result = @list.List([1, 2, 3]).scan_left(
     (acc, x) => {
       call_count += 1
       acc + x
@@ -502,14 +486,8 @@ test "scan_left calls f once per element" {
 ///|
 test "scan_right" {
   let el = @list.empty().scan_right((acc, x) => x + acc, init=0)
-  let ls = @list.from_array([1, 2, 3, 4]).scan_right(
-    (acc, x) => x + acc,
-    init=0,
-  )
-  let ls2 = @list.from_array([1, 2, 3, 4]).scan_right(
-    (acc, x) => x - acc,
-    init=100,
-  )
+  let ls = @list.List([1, 2, 3, 4]).scan_right((acc, x) => x + acc, init=0)
+  let ls2 = @list.List([1, 2, 3, 4]).scan_right((acc, x) => x - acc, init=100)
   debug_inspect(el, content="<List: [0]>")
   debug_inspect(ls, content="<List: [10, 9, 7, 4, 0]>")
   debug_inspect(ls2, content="<List: [98, -97, 99, -96, 100]>")
@@ -517,7 +495,7 @@ test "scan_right" {
 
 ///|
 test "lookup" {
-  let ls = @list.from_array([(1, "a"), (2, "b"), (3, "c")])
+  let ls = @list.List([(1, "a"), (2, "b"), (3, "c")])
   let el : @list.List[(Int, Int)] = @list.empty()
   debug_inspect(el.lookup(1), content="None")
   debug_inspect(
@@ -532,11 +510,11 @@ test "lookup" {
 ///|
 test "find" {
   debug_inspect(
-    @list.from_array([1, 3, 5, 8]).find(element => element % 2 == 0),
+    @list.List([1, 3, 5, 8]).find(element => element % 2 == 0),
     content="Some(8)",
   )
   debug_inspect(
-    @list.from_array([1, 3, 5, 7]).find(element => element % 2 == 0),
+    @list.List([1, 3, 5, 7]).find(element => element % 2 == 0),
     content="None",
   )
   debug_inspect(
@@ -548,15 +526,11 @@ test "find" {
 ///|
 test "findi" {
   debug_inspect(
-    @list.from_array([1, 3, 5, 8]).findi((element, i) => {
-      element % 2 == 0 && i == 3
-    }),
+    @list.List([1, 3, 5, 8]).findi((element, i) => element % 2 == 0 && i == 3),
     content="Some(8)",
   )
   debug_inspect(
-    @list.from_array([1, 3, 8, 5]).findi((element, i) => {
-      element % 2 == 0 && i == 3
-    }),
+    @list.List([1, 3, 8, 5]).findi((element, i) => element % 2 == 0 && i == 3),
     content="None",
   )
   debug_inspect(
@@ -569,17 +543,17 @@ test "findi" {
 
 ///|
 test "remove_at" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.remove_at(2), content="<List: [1, 2, 4, 5]>")
   debug_inspect(ls.remove_at(0), content="<List: [2, 3, 4, 5]>")
   debug_inspect(
-    @list.from_array(["a", "b", "c", "d", "e"]).remove_at(2),
+    @list.List(["a", "b", "c", "d", "e"]).remove_at(2),
     content=(
       #|<List: ["a", "b", "d", "e"]>
     ),
   )
   debug_inspect(
-    @list.from_array(["a", "b", "c", "d", "e"]).remove_at(5),
+    @list.List(["a", "b", "c", "d", "e"]).remove_at(5),
     content=(
       #|<List: ["a", "b", "c", "d", "e"]>
     ),
@@ -589,17 +563,17 @@ test "remove_at" {
 ///|
 test "remove" {
   debug_inspect(
-    @list.from_array([1, 2, 3, 4, 5]).remove(3),
+    @list.List([1, 2, 3, 4, 5]).remove(3),
     content="<List: [1, 2, 4, 5]>",
   )
   debug_inspect(
-    @list.from_array(["a", "b", "c", "d", "e"]).remove("c"),
+    @list.List(["a", "b", "c", "d", "e"]).remove("c"),
     content=(
       #|<List: ["a", "b", "d", "e"]>
     ),
   )
   debug_inspect(
-    @list.from_array(["a", "b", "c", "d", "e"]).remove("f"),
+    @list.List(["a", "b", "c", "d", "e"]).remove("f"),
     content=(
       #|<List: ["a", "b", "c", "d", "e"]>
     ),
@@ -609,57 +583,44 @@ test "remove" {
 ///|
 test "is_prefix" {
   debug_inspect(
-    @list.from_array([1, 2, 3, 4, 5]).is_prefix(@list.from_array([1, 2, 3])),
+    @list.List([1, 2, 3, 4, 5]).is_prefix(List([1, 2, 3])),
     content="true",
   )
   debug_inspect(
-    @list.from_array([1, 2, 3, 4, 5]).is_prefix(@list.from_array([3, 2, 3])),
+    @list.List([1, 2, 3, 4, 5]).is_prefix(List([3, 2, 3])),
     content="false",
   )
-  debug_inspect(
-    @list.empty().is_prefix(@list.from_array([1, 2, 3])),
-    content="false",
-  )
+  debug_inspect(@list.empty().is_prefix(List([1, 2, 3])), content="false")
 }
 
 ///|
 test "equal" {
-  debug_inspect(
-    @list.from_array([1, 2, 3]) == @list.from_array([1, 2, 3]),
-    content="true",
-  )
-  debug_inspect(
-    @list.from_array([1, 2, 3]) == @list.from_array([1, 3, 3]),
-    content="false",
-  )
-  debug_inspect(@list.empty() == @list.from_array([1]), content="false")
+  debug_inspect(@list.List([1, 2, 3]) == List([1, 2, 3]), content="true")
+  debug_inspect(@list.List([1, 2, 3]) == List([1, 3, 3]), content="false")
+  debug_inspect(@list.empty() == List([1]), content="false")
 }
 
 ///|
 test "is_suffix" {
   debug_inspect(
-    @list.from_array([1, 2, 3, 4, 5]).is_suffix(@list.from_array([3, 4, 5])),
+    @list.List([1, 2, 3, 4, 5]).is_suffix(List([3, 4, 5])),
     content="true",
   )
   debug_inspect(
-    @list.from_array([1, 2, 3, 4, 5]).is_suffix(@list.from_array([3, 4, 6])),
+    @list.List([1, 2, 3, 4, 5]).is_suffix(List([3, 4, 6])),
     content="false",
   )
 }
 
 ///|
 test "intercalate" {
-  let ls = @list.from_array([
-    @list.from_array([1, 2, 3]),
-    @list.from_array([4, 5, 6]),
-    @list.from_array([7, 8, 9]),
-  ])
+  let ls = @list.List([@list.List([1, 2, 3]), List([4, 5, 6]), List([7, 8, 9])])
   let el : @list.List[@list.List[Int]] = @list.empty()
   debug_inspect(
-    ls.intercalate(@list.from_array([0])),
+    ls.intercalate(List([0])),
     content="<List: [1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9]>",
   )
-  debug_inspect(el.intersperse(@list.from_array([1])), content="<List: []>")
+  debug_inspect(el.intersperse(List([1])), content="<List: []>")
 }
 
 ///|
@@ -670,7 +631,7 @@ test "default" {
 
 ///|
 test "iter_map_fold" {
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(
     ls.iter().map(x => x + 1).fold((a, b) => a + b, init=0),
     content="20",
@@ -681,7 +642,7 @@ test "iter_map_fold" {
 #warnings("-deprecated")
 test "List::output with non-empty list" {
   let buf = StringBuilder(size_hint=100)
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   Show::output(list, buf)
   debug_inspect(
     buf,
@@ -707,7 +668,7 @@ test "List::output with empty list" {
 
 ///|
 test "List::to_json with non-empty list" {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   @json.json_inspect(ToJson::to_json(list), content=[1, 2, 3, 4, 5])
 }
 
@@ -726,7 +687,7 @@ test "List::from_json" {
 
 ///|
 test "to_json/from_json" {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   let json_expected : Json = [1, 2, 3, 4, 5]
   @json.json_inspect(list, content=json_expected)
   let list2 : @list.List[Int] = @json.from_json(json_expected)
@@ -745,7 +706,7 @@ test "to_json/from_json" {
 
 ///|
 test "eachi" {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   let mut acc = 0
   list.eachi((i, x) => acc += x * i)
   debug_inspect(acc, content="40")
@@ -753,45 +714,45 @@ test "eachi" {
 
 ///|
 test "List::head_exn with non-empty list" {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   let head = list.head()
   assert_true(head == Some(1))
 }
 
 ///|
 test "List::last with non-empty list" {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   let last = list.last()
   assert_true(last == Some(5))
 }
 
 ///|
 test "List::zip with lists of equal length" {
-  let list1 = @list.from_array([1, 2, 3])
-  let list2 = @list.from_array(["a", "b", "c"])
+  let list1 = @list.List([1, 2, 3])
+  let list2 = @list.List(["a", "b", "c"])
   let zipped = list1.zip(list2)
-  let expected = @list.from_array([(1, "a"), (2, "b"), (3, "c")])
+  let expected = @list.List([(1, "a"), (2, "b"), (3, "c")])
   @debug.assert_eq(zipped, expected)
 }
 
 ///|
 test "@list.zip with empty list" {
   debug_inspect(
-    @list.from_array([1]).zip((@list.empty() : @list.List[Int])),
+    @list.List([1]).zip((@list.empty() : @list.List[Int])),
     content="<List: []>",
   )
 }
 
 ///|
 test "List::nth_exn with valid index" {
-  let list = @list.from_array([1, 2, 3, 4, 5])
+  let list = @list.List([1, 2, 3, 4, 5])
   let nth = list.nth(2)
   assert_true(nth == Some(3))
 }
 
 ///|
 test "List::maximum with non-empty list" {
-  let list = @list.from_array([1, 3, 5, 2, 4])
+  let list = @list.List([1, 3, 5, 2, 4])
   let max = list.maximum()
   assert_true(max == Some(5))
 }
@@ -803,7 +764,7 @@ test "@list.maximum with empty list" {
 
 ///|
 test "List::minimum with non-empty list" {
-  let list = @list.from_array([1, 3, 5, 2, 4])
+  let list = @list.List([1, 3, 5, 2, 4])
   let min = list.minimum()
   assert_true(min == Some(1))
 }
@@ -815,18 +776,9 @@ test "@list.minimum with empty list" {
 
 ///|
 test "add" {
-  debug_inspect(
-    @list.from_array([1]) + @list.from_array([]),
-    content="<List: [1]>",
-  )
-  debug_inspect(
-    @list.from_array([]) + @list.from_array([1]),
-    content="<List: [1]>",
-  )
-  debug_inspect(
-    @list.from_array([1]) + @list.from_array([1]),
-    content="<List: [1, 1]>",
-  )
+  debug_inspect(@list.List([1]) + List([]), content="<List: [1]>")
+  debug_inspect(@list.List([]) + List([1]), content="<List: [1]>")
+  debug_inspect(@list.List([1]) + List([1]), content="<List: [1, 1]>")
   debug_inspect(
     (@list.empty() : @list.List[Int]) + (@list.empty() : @list.List[Int]),
     content="<List: []>",
@@ -859,20 +811,20 @@ test "from_iter empty iter" {
 
 ///|
 test "hash" {
-  let l1 = @list.from_array([1, 2, 3, 4, 5])
-  let l2 = @list.from_array([1, 2, 3, 4, 5])
+  let l1 = @list.List([1, 2, 3, 4, 5])
+  let l2 = @list.List([1, 2, 3, 4, 5])
   debug_inspect(l1.hash() == l2.hash(), content="true")
-  let l3 = @list.from_array([5, 4, 3, 2, 1])
+  let l3 = @list.List([5, 4, 3, 2, 1])
   debug_inspect(l1.hash() == l3.hash(), content="false")
-  let l4 : @list.List[Int] = @list.from_array([])
+  let l4 : @list.List[Int] = List([])
   debug_inspect(l1.hash() == l4.hash(), content="false")
   debug_inspect(l4.hash() == l4.hash(), content="true")
 }
 
 ///|
 test "immutability" {
-  let l1 = @list.from_array([1, 2])
-  let l2 = @list.from_array([l1, l1, l1, l1]).flatten()
+  let l1 = @list.List([1, 2])
+  let l2 = @list.List([l1, l1, l1, l1]).flatten()
   debug_inspect(l2, content="<List: [1, 2, 1, 2, 1, 2, 1, 2]>")
   debug_inspect(l1, content="<List: [1, 2]>")
   let l3 = l1.flat_map(_ => l1)
@@ -883,14 +835,14 @@ test "immutability" {
 ///|
 test "advanced list manipulations" {
   // Test multiple operations chained together
-  let l = @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  let l = @list.List([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
   // Filter even numbers, double them, and take first 3
   let result = l.filter(x => x % 2 == 0).map(x => x * 2).take(3)
   debug_inspect(result, content="<List: [4, 8, 12]>")
 
   // Perform multiple transformations and ensure original list stays unchanged
-  let orig = @list.from_array([3, 1, 4, 1, 5, 9, 2, 6])
+  let orig = @list.List([3, 1, 4, 1, 5, 9, 2, 6])
   let sorted = orig.sort()
   let filtered = orig.filter(x => x > 3)
   let mapped = orig.map(x => x * x)
@@ -903,14 +855,14 @@ test "advanced list manipulations" {
 ///|
 test "scan_right complex operations" {
   // Test scan_right with more complex operations
-  let l1 = @list.from_array([1, 2, 3, 4])
+  let l1 = @list.List([1, 2, 3, 4])
 
   // Calculate running product from right to left
   let products = l1.scan_right((acc, x) => x * acc, init=1)
   debug_inspect(products, content="<List: [24, 24, 12, 4, 1]>")
 
   // Test with string concatenation
-  let l2 = @list.from_array(["a", "b", "c"])
+  let l2 = @list.List(["a", "b", "c"])
   let concat = l2.scan_right((acc, x) => x + acc, init="")
   debug_inspect(
     concat,
@@ -920,7 +872,7 @@ test "scan_right complex operations" {
   )
 
   // Test with more complex function
-  let l3 = @list.from_array([10, 5, 8, 2])
+  let l3 = @list.List([10, 5, 8, 2])
   let result = l3.scan_right((acc, x) => if x > acc { x } else { acc }, init=0)
   debug_inspect(result, content="<List: [10, 8, 8, 2, 0]>")
 }
@@ -928,7 +880,7 @@ test "scan_right complex operations" {
 ///|
 test "drop advanced cases" {
   // Test drop with various edge cases
-  let l = @list.from_array([1, 2, 3, 4, 5])
+  let l = @list.List([1, 2, 3, 4, 5])
 
   // Drop negative number (should be treated as 0)
   debug_inspect(l.drop(-3), content="<List: [1, 2, 3, 4, 5]>")
@@ -950,7 +902,7 @@ test "drop advanced cases" {
 ///|
 test "list manual grouping implementation" {
   // Test manual grouping implementation
-  let mixed = @list.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+  let mixed = @list.List([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
   // Manually implement partition for even/odd
   let evens = mixed.filter(x => x % 2 == 0)
@@ -966,11 +918,11 @@ test "list manual grouping implementation" {
 ///|
 test "equality" {
   // Test equality operators
-  let l1 = @list.from_array([1, 2, 3])
-  let l2 = @list.from_array([1, 2, 3])
-  let l3 = @list.from_array([1, 2, 4])
-  let l4 = @list.from_array([1, 2])
-  let l5 = @list.from_array([1, 2, 3, 4])
+  let l1 = @list.List([1, 2, 3])
+  let l2 = @list.List([1, 2, 3])
+  let l3 = @list.List([1, 2, 4])
+  let l4 = @list.List([1, 2])
+  let l5 = @list.List([1, 2, 3, 4])
 
   // Test equality
   assert_true(l1 == l2)
@@ -981,19 +933,19 @@ test "equality" {
 
 ///|
 test "advanced folding operations" {
-  let l = @list.from_array([1, 2, 3, 4, 5])
+  let l = @list.List([1, 2, 3, 4, 5])
 
   // Test fold for sum of squares
   let result = l.fold((acc, x) => acc + x * x, init=0)
   debug_inspect(result, content="55")
 
   // Test fold with more complex operations
-  let texts = @list.from_array(["hello", "world", "moonbit"])
+  let texts = @list.List(["hello", "world", "moonbit"])
   let counts = texts.fold((acc, s) => acc + s.length(), init=0)
   debug_inspect(counts, content="17")
 
   // Test with multiple fold operations
-  let list = @list.from_array([10, 20, 30, 40, 50])
+  let list = @list.List([10, 20, 30, 40, 50])
   let sum = list.fold((acc, x) => acc + x, init=0)
   let max = list.fold(
     (acc, x) => if x > acc { x } else { acc },
@@ -1007,7 +959,7 @@ test "advanced folding operations" {
 
 ///|
 test "remove_at edge cases" {
-  let l = @list.from_array([1, 2, 3, 4, 5])
+  let l = @list.List([1, 2, 3, 4, 5])
 
   // Remove at negative index (should not change list)
   debug_inspect(l.remove_at(-1), content="<List: [1, 2, 3, 4, 5]>")
@@ -1030,11 +982,7 @@ test "remove_at edge cases" {
 ///|
 test "nested lists operations" {
   // Test operations on nested lists
-  let nested = @list.from_array([
-    @list.from_array([1, 2]),
-    @list.from_array([3, 4]),
-    @list.from_array([5, 6]),
-  ])
+  let nested = @list.List([@list.List([1, 2]), List([3, 4]), List([5, 6])])
 
   // Map each inner list
   let mapped = nested.map(inner => inner.map(x => x * 2))
@@ -1058,7 +1006,7 @@ test "nested lists operations" {
 
 ///|
 test "find and filter combination" {
-  let l = @list.from_array([1, 2, 3, 4, 5])
+  let l = @list.List([1, 2, 3, 4, 5])
 
   // Find first even number
   let first_even = l.find(x => x % 2 == 0)
@@ -1086,7 +1034,7 @@ test "intersperse with complex values" {
   // Test intersperse with different types of elements
 
   // String elements
-  let words = @list.from_array(["hello", "moonbit", "world"])
+  let words = @list.List(["hello", "moonbit", "world"])
   debug_inspect(
     words.intersperse(", "),
     content=(
@@ -1095,12 +1043,8 @@ test "intersperse with complex values" {
   )
 
   // List elements
-  let lists = @list.from_array([
-    @list.from_array([1, 2]),
-    @list.from_array([3, 4]),
-    @list.from_array([5, 6]),
-  ])
-  let separator = @list.from_array([0, 0])
+  let lists = @list.List([@list.List([1, 2]), List([3, 4]), List([5, 6])])
+  let separator = @list.List([0, 0])
   let result = lists.intersperse(separator)
   debug_inspect(result.length(), content="5")
 
@@ -1109,7 +1053,7 @@ test "intersperse with complex values" {
   debug_inspect(empty.intersperse(0), content="<List: []>")
 
   // Single element list with intersperse
-  let single = @list.from_array(["a"])
+  let single = @list.List(["a"])
   debug_inspect(
     single.intersperse(","),
     content=(
@@ -1147,28 +1091,28 @@ test "complex list recursion safety" {
 
 ///|
 test "is_prefix and is_suffix complex cases" {
-  let l = @list.from_array([1, 2, 3, 4, 5])
+  let l = @list.List([1, 2, 3, 4, 5])
 
   // Test is_prefix with various scenarios
-  assert_true(l.is_prefix(@list.from_array([1])))
-  assert_true(l.is_prefix(@list.from_array([1, 2])))
-  assert_true(l.is_prefix(@list.from_array([1, 2, 3])))
-  assert_false(l.is_prefix(@list.from_array([2, 3])))
-  assert_false(l.is_prefix(@list.from_array([0, 1, 2])))
+  assert_true(l.is_prefix(List([1])))
+  assert_true(l.is_prefix(List([1, 2])))
+  assert_true(l.is_prefix(List([1, 2, 3])))
+  assert_false(l.is_prefix(List([2, 3])))
+  assert_false(l.is_prefix(List([0, 1, 2])))
 
   // Test is_suffix with various scenarios
-  assert_true(l.is_suffix(@list.from_array([5])))
-  assert_true(l.is_suffix(@list.from_array([4, 5])))
-  assert_true(l.is_suffix(@list.from_array([3, 4, 5])))
-  assert_false(l.is_suffix(@list.from_array([2, 5])))
-  assert_false(l.is_suffix(@list.from_array([3, 4, 6])))
+  assert_true(l.is_suffix(List([5])))
+  assert_true(l.is_suffix(List([4, 5])))
+  assert_true(l.is_suffix(List([3, 4, 5])))
+  assert_false(l.is_suffix(List([2, 5])))
+  assert_false(l.is_suffix(List([3, 4, 6])))
 
   // Test with empty list
   let empty : @list.List[Int] = @list.empty()
-  assert_true(empty.is_prefix(@list.from_array([])))
-  assert_true(empty.is_suffix(@list.from_array([])))
-  assert_true(l.is_prefix(@list.from_array([])))
-  assert_true(l.is_suffix(@list.from_array([])))
+  assert_true(empty.is_prefix(List([])))
+  assert_true(empty.is_suffix(List([])))
+  assert_true(l.is_prefix(List([])))
+  assert_true(l.is_suffix(List([])))
 }
 
 ///|
@@ -1177,20 +1121,20 @@ test "find_index" {
   let empty = @list.empty()
   debug_inspect(empty.find_index(x => x > 0), content="None")
   // basic
-  let ls = @list.from_array([1, 2, 3, 4, 5])
+  let ls = @list.List([1, 2, 3, 4, 5])
   debug_inspect(ls.find_index(x => x > 3), content="Some(3)")
   debug_inspect(ls.find_index(x => x < 0), content="None")
   debug_inspect(ls.find_index(x => x == 1), content="Some(0)")
   // all-match
-  let ls = @list.from_array([2, 4, 6, 8, 10])
+  let ls = @list.List([2, 4, 6, 8, 10])
   debug_inspect(ls.find_index(x => x % 2 == 0), content="Some(0)")
 }
 
 ///|
 test "compare" {
-  let list1 = @list.from_array([1, 2, 3])
-  let list2 = @list.from_array([1, 2, 4])
-  let list3 = @list.from_array([1, 2])
+  let list1 = @list.List([1, 2, 3])
+  let list2 = @list.List([1, 2, 4])
+  let list3 = @list.List([1, 2])
   let empty : @list.List[Int] = @list.empty()
 
   // Test lexicographic comparison
@@ -1212,15 +1156,9 @@ test "compare" {
 
 ///|
 test "flat_map and filter_map skip empties" {
-  let ls = @list.from_array([0, 1, 2])
+  let ls = @list.List([0, 1, 2])
   debug_inspect(
-    ls.flat_map(x => {
-      if x == 0 {
-        @list.empty()
-      } else {
-        @list.from_array([x, x])
-      }
-    }),
+    ls.flat_map(x => if x == 0 { @list.empty() } else { List([x, x]) }),
     content="<List: [1, 1, 2, 2]>",
   )
   debug_inspect(
@@ -1247,18 +1185,15 @@ test "take and take_while edge cases" {
   let empty : @list.List[Int] = @list.empty()
   debug_inspect(empty.take(3), content="<List: []>")
   debug_inspect(
-    @list.from_array([1, 2]).take_while(_ => true),
+    @list.List([1, 2]).take_while(_ => true),
     content="<List: [1, 2]>",
   )
-  debug_inspect(
-    @list.from_array([1, 2]).take_while(_ => false),
-    content="<List: []>",
-  )
+  debug_inspect(@list.List([1, 2]).take_while(_ => false), content="<List: []>")
 }
 
 ///|
 test "remove empty and head" {
-  let ls = @list.from_array([1, 2, 3])
+  let ls = @list.List([1, 2, 3])
   debug_inspect(ls.remove(1), content="<List: [2, 3]>")
   let empty : @list.List[Int] = @list.empty()
   debug_inspect(empty.remove(1), content="<List: []>")

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-test "from_array" {
+test "List constructor" {
   let ls = @list.List([1, 2, 3, 4, 5])
   let el : @list.List[Int] = @list.empty()
   debug_inspect(ls, content="<List: [1, 2, 3, 4, 5]>")

--- a/list/panic_test.mbt
+++ b/list/panic_test.mbt
@@ -40,7 +40,7 @@ test "panic @list.unsafe_minimum with empty list" {
 ///|
 test "unsafe_head with non-empty list" {
   // Test the non-panic path of unsafe_head to cover line 407
-  let list = @list.from_array([1, 2, 3])
+  let list = @list.List([1, 2, 3])
   inspect(list.unsafe_head(), content="1")
 }
 

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub enum List[A] {
   Empty
   More(A, mut tail~ : List[A])
 }
+pub fn[A] List::List(ArrayView[A]) -> Self[A]
 pub fn[A] List::all(Self[A], (A) -> Bool raise?) -> Bool raise?
 pub fn[A] List::any(Self[A], (A) -> Bool raise?) -> Bool raise?
 pub fn[A] List::concat(Self[A], Self[A]) -> Self[A]
@@ -41,7 +42,8 @@ pub fn[A, B] List::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] List::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[A] List::from_array(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)


### PR DESCRIPTION
## Summary

The recently introduced `List::List` constructor (commit `d4980e7b`) had a descending-range off-by-one: `(arr.length() - 1)>..0` is **start-exclusive**, so it dropped the last element (`@list.List([1, 2, 3, 4, 5])` produced `[1, 2, 3, 4]`). This PR:

- **Fixes the constructor** to `arr.length()>..0` so all elements are included, and corrects its doc test (`<List: [1, 2, 3, 4, 5]>`).
- **Migrates** all `@list.from_array(...)` / `from_array(...)` usages to the new `List(...)` constructor across `list`, `immut/hashmap`, `lazy_list`, and the READMEs, clearing the 359 deprecation warnings.
- **Drops the redundant `@list.` qualifier** where the expected type is already known (otherwise `moon check` flags `unnecessary_annotation`).

The `Show`/`output` format string (and its snapshot tests) intentionally still emit `@list.from_array([...])`.

## Verification

- `moon check --deny-warn --target all` — 0 warnings
- `moon test` — 6616 passed, 0 failed (default target)
- `list` package green on wasm / wasm-gc / js / native
- `moon fmt` and `moon info` produce no additional diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)