### PR TITLE
feat(immut/hashmap): add HashMap constructor, deprecate from_array

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -37,14 +37,14 @@ priv enum CurrNode[K, V] {
 /// Create a new instance.
 #as_free_fn
 pub fn[K, V] HashMap::new() -> HashMap[K, V] {
-  None
+  { data: None }
 }
 
 ///|
 /// Create a map with a single key-value pair.
 #as_free_fn
 pub fn[K : Hash, V] HashMap::singleton(key : K, value : V) -> HashMap[K, V] {
-  Some(Flat(key, value, @path.of(key)))
+  { data: Some(Flat(key, value, @path.of(key))) }
 }
 
 ///|
@@ -60,7 +60,7 @@ pub fn[K : Eq + Hash, V] HashMap::contains(
 /// Lookup a key from a hash map
 #alias(find, deprecated)
 pub fn[K : Eq + Hash, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
-  match self.0 {
+  match self.data {
     None => None
     Some(node) => node.get_with_path(key, @path.of(key))
   }
@@ -70,7 +70,7 @@ pub fn[K : Eq + Hash, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
 /// Get value with `at` access semantics.
 #alias("_[_]")
 pub fn[K : Eq + Hash, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
-  guard self.0 is Some(node)
+  guard self.data is Some(node)
   node.get_with_path(key, @path.of(key)).unwrap()
 }
 
@@ -200,9 +200,11 @@ pub fn[K, V] HashMap::filter(
     }
   }
 
-  match self.0 {
-    None => None
-    Some(node) => go(node)
+  {
+    data: match self.data {
+      None => None
+      Some(node) => go(node)
+    },
   }
 }
 
@@ -226,7 +228,7 @@ pub fn[K, V, A] HashMap::fold(
     }
   }
 
-  match self.0 {
+  match self.data {
     None => init
     Some(node) => go(init, node)
   }
@@ -248,9 +250,11 @@ pub fn[K, V, A] HashMap::map(
     }
   }
 
-  match self.0 {
-    None => None
-    Some(node) => Some(go(node))
+  {
+    data: match self.data {
+      None => None
+      Some(node) => Some(go(node))
+    },
   }
 }
 
@@ -263,9 +267,11 @@ pub fn[K : Eq + Hash, V] HashMap::add(
   key : K,
   value : V,
 ) -> HashMap[K, V] {
-  match self.0 {
-    None => Some(Flat(key, value, @path.of(key)))
-    Some(node) => Some(node.add_with_path(key, value, @path.of(key)))
+  {
+    data: match self.data {
+      None => Some(Flat(key, value, @path.of(key)))
+      Some(node) => Some(node.add_with_path(key, value, @path.of(key)))
+    },
   }
 }
 
@@ -275,9 +281,11 @@ pub fn[K : Eq + Hash, V] HashMap::remove(
   self : HashMap[K, V],
   key : K,
 ) -> HashMap[K, V] {
-  match self.0 {
-    None => None
-    Some(node) => node.remove_with_path(key, @path.of(key))
+  {
+    data: match self.data {
+      None => None
+      Some(node) => node.remove_with_path(key, @path.of(key))
+    },
   }
 }
 
@@ -352,7 +360,7 @@ pub fn[K, V] HashMap::length(self : HashMap[K, V]) -> Int {
     }
   }
 
-  match self.0 {
+  match self.data {
     None => 0
     Some(node) => node_size(node)
   }
@@ -387,9 +395,11 @@ pub fn[K : Eq, V] HashMap::union(
     }
   }
 
-  match (self.0, other.0) {
-    (None, x) | (x, None) => x
-    (Some(a), Some(b)) => Some(go(a, b))
+  {
+    data: match (self.data, other.data) {
+      (None, x) | (x, None) => x
+      (Some(a), Some(b)) => Some(go(a, b))
+    },
   }
 }
 
@@ -427,9 +437,11 @@ pub fn[K : Eq, V] HashMap::union_with(
     }
   }
 
-  match (self.0, other.0) {
-    (None, x) | (x, None) => x
-    (Some(a), Some(b)) => Some(go(a, b))
+  {
+    data: match (self.data, other.data) {
+      (None, x) | (x, None) => x
+      (Some(a), Some(b)) => Some(go(a, b))
+    },
   }
 }
 
@@ -491,9 +503,11 @@ pub fn[K : Eq, V] HashMap::intersection(
     }
   }
 
-  match (self.0, other.0) {
-    (None, _) | (_, None) => None
-    (Some(a), Some(b)) => go(a, b)
+  {
+    data: match (self.data, other.data) {
+      (None, _) | (_, None) => None
+      (Some(a), Some(b)) => go(a, b)
+    },
   }
 }
 
@@ -532,9 +546,11 @@ pub fn[K : Eq, V] HashMap::intersection_with(
     }
   }
 
-  match (self.0, other.0) {
-    (None, _) | (_, None) => None
-    (Some(a), Some(b)) => go(a, b)
+  {
+    data: match (self.data, other.data) {
+      (None, _) | (_, None) => None
+      (Some(a), Some(b)) => go(a, b)
+    },
   }
 }
 
@@ -592,10 +608,10 @@ pub fn[K : Eq, V] HashMap::difference(
     }
   }
 
-  match (self.0, other.0) {
-    (None, _) => None
+  match (self.data, other.data) {
+    (None, _) => { data: None }
     (_, None) => self
-    (Some(a), Some(b)) => go(a, b)
+    (Some(a), Some(b)) => { data: go(a, b) }
   }
 }
 
@@ -616,7 +632,7 @@ pub fn[K, V] HashMap::each(
     }
   }
 
-  if self.0 is Some(node) {
+  if self.data is Some(node) {
     go(node)
   }
 }
@@ -639,7 +655,7 @@ pub fn[K, V] HashMap::values(self : HashMap[K, V]) -> Iter[V] {
 #alias(iterator, deprecated)
 pub fn[K, V] HashMap::iter(self : HashMap[K, V]) -> Iter[(K, V)] {
   let empty = Bucket(@list.new())
-  let mut curr_node = match self.0 {
+  let mut curr_node = match self.data {
     Some(tree) => Tree(tree)
     None => empty
   }
@@ -712,10 +728,37 @@ pub impl[K : Show, V : Show] Show for HashMap[K, V] with fn output(self, logger)
 
 ///|
 /// Creates a hash map from an array of key-value pairs.
-#as_free_fn
-#alias(of, deprecated="Use from_array instead")
-#as_free_fn(of, deprecated="Use from_array instead")
+#as_free_fn(deprecated="Use @immut/hashmap.HashMap([...]) instead")
+#alias(of, deprecated="Use @immut/hashmap.HashMap([...]) instead")
+#as_free_fn(of, deprecated="Use @immut/hashmap.HashMap([...]) instead")
+#deprecated("Use @immut/hashmap.HashMap([...]) instead")
 pub fn[K : Eq + Hash, V] HashMap::from_array(
+  arr : ArrayView[(K, V)],
+) -> HashMap[K, V] {
+  for n = arr.length(), map = new() {
+    match (n, map) {
+      (0, map) => break map
+      (n, map) => {
+        let (k, v) = arr[n - 1]
+        continue n - 1, map.add(k, v)
+      }
+    }
+  }
+}
+
+///|
+/// Creates a hash map from an array of key-value pairs.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let m = @hashmap.HashMap([(1, "one"), (2, "two")])
+///   @test.assert_eq(m.get(1), Some("one"))
+///   @test.assert_eq(m.get(2), Some("two"))
+/// }
+/// ```
+pub fn[K : Eq + Hash, V] HashMap::HashMap(
   arr : ArrayView[(K, V)],
 ) -> HashMap[K, V] {
   for n = arr.length(), map = new() {
@@ -742,7 +785,7 @@ pub impl[K : Eq + Hash + @quickcheck.Arbitrary, V : @quickcheck.Arbitrary] @quic
   K,
   V,
 ] with fn arbitrary(size, rs) {
-  @quickcheck.Arbitrary::arbitrary(size, rs) |> from_array
+  @quickcheck.Arbitrary::arbitrary(size, rs) |> HashMap
 }
 
 ///|

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -92,7 +92,7 @@ test "HAMT::remove" {
 
 ///|
 test "keys" {
-  let m = @hashmap.from_array([(1, "one"), (2, "two")])
+  let m = @hashmap.HashMap([(1, "one"), (2, "two")])
   let keys = () => m.keys()
   inspect(keys().contains(1), content="true")
   inspect(keys().contains(2), content="true")
@@ -101,7 +101,7 @@ test "keys" {
 
 ///|
 test "HAMT::values" {
-  let m = @hashmap.from_array([(1, "one"), (2, "two")])
+  let m = @hashmap.HashMap([(1, "one"), (2, "two")])
   let values = () => m.values()
   inspect(values().contains("one"), content="true")
   inspect(values().contains("two"), content="true")
@@ -110,7 +110,7 @@ test "HAMT::values" {
 
 ///|
 test "HAMT::iter" {
-  let data = @hashmap.from_array([
+  let data = @hashmap.HashMap([
     (0, "a"),
     (2, "b"),
     (3, "d"),
@@ -129,7 +129,7 @@ test "HAMT::iter" {
 
 ///|
 test "HAMT::iter2" {
-  let data = @hashmap.from_array([
+  let data = @hashmap.HashMap([
     (0, "a"),
     (2, "b"),
     (3, "d"),
@@ -148,7 +148,7 @@ test "HAMT::iter2" {
 
 ///|
 test "HAMT::iter2 with early break" {
-  let data = @hashmap.from_array([(1, "a"), (2, "b"), (3, "c")])
+  let data = @hashmap.HashMap([(1, "a"), (2, "b"), (3, "c")])
   let count = for _k, _v in data.iter2(); count = 0 {
     let count = count + 1
     if count == 2 {
@@ -190,7 +190,7 @@ test "HAMT::to_string" {
 
 ///|
 test "HAMT::from_array" {
-  let map = @hashmap.from_array([(1, "1"), (2, "2"), (42, "42")])
+  let map = @hashmap.HashMap([(1, "1"), (2, "2"), (42, "42")])
   debug_inspect((1, map.get(1)), content="(1, Some(\"1\"))")
   debug_inspect((2, map.get(2)), content="(2, Some(\"2\"))")
   debug_inspect((42, map.get(42)), content="(42, Some(\"42\"))")
@@ -199,7 +199,7 @@ test "HAMT::from_array" {
 
 ///|
 test "to_array" {
-  let m = @hashmap.from_array([(1, "one"), (2, "two")])
+  let m = @hashmap.HashMap([(1, "one"), (2, "two")])
   let arr = m.to_array()
   inspect(arr.length(), content="2")
   assert_eq(arr.contains((1, "one")), true)
@@ -216,7 +216,7 @@ test "HAMT::iter on empty map" {
 
 ///|
 test "HAMT::iter on collision map" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   let iter = map.iter()
   let results = []
   while iter.next() is Some(pair) {
@@ -227,7 +227,7 @@ test "HAMT::iter on collision map" {
 
 ///|
 test "HAMT::iter on branch map" {
-  let map = @hashmap.from_array([(1, 10), (2, 20), (3, 30), (4, 40)])
+  let map = @hashmap.HashMap([(1, 10), (2, 20), (3, 30), (4, 40)])
   let iter = map.iter()
   let mut count = 0
   while iter.next() is Some(_) {
@@ -244,79 +244,64 @@ test "eq for boundary cases" {
   inspect(empty_map1 == empty_map2, content="true")
 
   // Test with one empty map and one non-empty map
-  let non_empty_map : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(1, 1)])
+  let non_empty_map : @hashmap.HashMap[Int, Int] = HashMap([(1, 1)])
   inspect(empty_map1 == non_empty_map, content="false")
   inspect(non_empty_map == empty_map1, content="false")
 
   // Test with maps of different sizes
-  let larger_map : @hashmap.HashMap[Int, Int] = @hashmap.from_array([
-    (1, 1),
-    (2, 2),
-  ])
+  let larger_map : @hashmap.HashMap[Int, Int] = HashMap([(1, 1), (2, 2)])
   inspect(non_empty_map == larger_map, content="false")
 }
 
 ///|
 test "eq for random cases" {
   // Test with maps containing different keys
-  let map1 : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(1, 1), (2, 2)])
-  let map2 : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(1, 1), (3, 3)])
+  let map1 : @hashmap.HashMap[Int, Int] = HashMap([(1, 1), (2, 2)])
+  let map2 : @hashmap.HashMap[Int, Int] = HashMap([(1, 1), (3, 3)])
   inspect(map1 == map2, content="false")
 
   // Test with maps containing same keys but different values
-  let map3 : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(1, 1), (2, 3)])
+  let map3 : @hashmap.HashMap[Int, Int] = HashMap([(1, 1), (2, 3)])
   inspect(map1 == map3, content="false")
 
   // Test with maps containing same keys and values but in different order
-  let map4 : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(2, 2), (1, 1)])
+  let map4 : @hashmap.HashMap[Int, Int] = HashMap([(2, 2), (1, 1)])
   inspect(map1 == map4, content="true")
 
   // Test with maps containing same keys and values but with different hash collisions
-  let map5 : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(1, 1), (11, 11)])
-  let map6 : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(1, 1), (11, 11)])
+  let map5 : @hashmap.HashMap[Int, Int] = HashMap([(1, 1), (11, 11)])
+  let map6 : @hashmap.HashMap[Int, Int] = HashMap([(1, 1), (11, 11)])
   inspect(map5 == map6, content="true")
 
   // Test with maps containing same keys and values but with different hash collisions and different order
-  let map7 : @hashmap.HashMap[Int, Int] = @hashmap.from_array([(11, 11), (1, 1)])
+  let map7 : @hashmap.HashMap[Int, Int] = HashMap([(11, 11), (1, 1)])
   inspect(map5 == map7, content="true")
 }
 
 ///|
 test "eq for random cases with different types" {
   // Test with maps containing different types
-  let map8 : @hashmap.HashMap[String, Int] = @hashmap.from_array([
-    ("one", 1),
-    ("two", 2),
-  ])
-  let map9 : @hashmap.HashMap[String, Int] = @hashmap.from_array([
-    ("one", 1),
-    ("two", 2),
-  ])
+  let map8 : @hashmap.HashMap[String, Int] = HashMap([("one", 1), ("two", 2)])
+  let map9 : @hashmap.HashMap[String, Int] = HashMap([("one", 1), ("two", 2)])
   inspect(map8 == map9, content="true")
 
   // Test with maps containing same keys but different values of different types
-  let map10 : @hashmap.HashMap[String, Int] = @hashmap.from_array([
-    ("one", 1),
-    ("two", 3),
-  ])
+  let map10 : @hashmap.HashMap[String, Int] = HashMap([("one", 1), ("two", 3)])
   inspect(map8 == map10, content="false")
 
   // Test with maps containing different keys of different types
-  let map11 : @hashmap.HashMap[String, Int] = @hashmap.from_array([
-    ("one", 1),
-    ("three", 3),
-  ])
+  let map11 : @hashmap.HashMap[String, Int] = HashMap([("one", 1), ("three", 3)])
   inspect(map8 == map11, content="false")
 }
 
 ///|
 test "hash" {
-  let map1 = @hashmap.from_array([("one", 1), ("two", 2)])
-  let map2 = @hashmap.from_array([("one", 1), ("two", 2)])
+  let map1 = @hashmap.HashMap([("one", 1), ("two", 2)])
+  let map2 = @hashmap.HashMap([("one", 1), ("two", 2)])
   inspect(map1.hash() == map2.hash(), content="true")
-  let map3 = @hashmap.from_array([("two", 2), ("one", 1)])
+  let map3 = @hashmap.HashMap([("two", 2), ("one", 1)])
   inspect(map1.hash() == map3.hash(), content="true")
-  let map4 = @hashmap.from_array([("one", 1), ("two", 2), ("three", 3)])
+  let map4 = @hashmap.HashMap([("one", 1), ("two", 2), ("three", 3)])
   inspect(map1.hash() == map4.hash(), content="false")
 }
 
@@ -330,14 +315,14 @@ test "each on empty map" {
 
 ///|
 test "remove non-existent key with hash collision" {
-  let map = @hashmap.from_array([("a", 1)])
+  let map = @hashmap.HashMap([("a", 1)])
   let new_map = map.remove("b")
   inspect(new_map.length(), content="1")
 }
 
 ///|
 test "remove all keys from collision bucket" {
-  let map = @hashmap.from_array([("a", 1), ("b", 2)])
+  let map = @hashmap.HashMap([("a", 1), ("b", 2)])
   let map1 = map.remove("a")
   let map2 = map1.remove("b")
   inspect(map2.length(), content="0")
@@ -345,32 +330,25 @@ test "remove all keys from collision bucket" {
 
 ///|
 test "union 2 hashmaps, choose the right hand side" {
-  let map1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let map2 = @hashmap.from_array([(1, 10), (2, 20), (4, 40)])
+  let map1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let map2 = @hashmap.HashMap([(1, 10), (2, 20), (4, 40)])
   let map3 = map1.union(map2)
-  let map4 = @hashmap.from_array([(1, 10), (2, 20), (3, 3), (4, 40)])
+  let map4 = @hashmap.HashMap([(1, 10), (2, 20), (3, 3), (4, 40)])
   inspect(map3 == map4, content="true")
 }
 
 ///|
 test "union 2 hashmaps, without conflict" {
-  let map1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let map2 = @hashmap.from_array([(4, 4), (5, 5), (6, 6)])
+  let map1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let map2 = @hashmap.HashMap([(4, 4), (5, 5), (6, 6)])
   let map3 = map1.union(map2)
-  let map4 = @hashmap.from_array([
-    (1, 1),
-    (2, 2),
-    (3, 3),
-    (4, 4),
-    (5, 5),
-    (6, 6),
-  ])
+  let map4 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)])
   inspect(map3 == map4, content="true")
 }
 
 ///|
 test "HAMT::contains" {
-  let map = @hashmap.from_array([(1, "one")])
+  let map = @hashmap.HashMap([(1, "one")])
   inspect(map.contains(1), content="true")
   inspect(map.contains(2), content="false")
   let map2 = map.add(2, "two")
@@ -381,7 +359,7 @@ test "HAMT::contains" {
 
 ///|
 test "filter with simple predicate" {
-  let map = @hashmap.from_array([(1, 1), (2, 2), (3, 3), (4, 4)])
+  let map = @hashmap.HashMap([(1, 1), (2, 2), (3, 3), (4, 4)])
   let only_even = map.filter((_, v) => v % 2 == 0)
   inspect(only_even.contains(1), content="false")
   inspect(only_even.contains(2), content="true")
@@ -391,7 +369,7 @@ test "filter with simple predicate" {
 
 ///|
 test "filter with all elements matching" {
-  let map = @hashmap.from_array([(1, 1), (2, 2)])
+  let map = @hashmap.HashMap([(1, 1), (2, 2)])
   let filtered = map.filter((_, v) => v > 0)
   inspect(filtered.contains(1), content="true")
   inspect(filtered.contains(2), content="true")
@@ -399,7 +377,7 @@ test "filter with all elements matching" {
 
 ///|
 test "filter with no elements matching" {
-  let map = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
+  let map = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
   let filtered = map.filter((_, v) => v > 10)
   @test.assert_eq(filtered.get(1), None)
   @test.assert_eq(filtered.get(2), None)
@@ -409,7 +387,7 @@ test "filter with no elements matching" {
 
 ///|
 test "filter with collision" {
-  let map = @hashmap.from_array([(1, 10), (2, 20)]).add(1, 30)
+  let map = @hashmap.HashMap([(1, 10), (2, 20)]).add(1, 30)
   let filtered = map.filter((_, v) => v == 30)
   @test.assert_eq(filtered.get(1), Some(30))
   @test.assert_eq(filtered.get(2), None)
@@ -435,7 +413,7 @@ test "filter with branch nodes" {
 
 ///|
 test "HAMT::fold_with_key" {
-  let map = @hashmap.from_array([(1, "a"), (2, "b")])
+  let map = @hashmap.HashMap([(1, "a"), (2, "b")])
   let result = map.fold(init="", (acc, k, v) => acc + "\{k}:\{v}, ")
   // order of elements is not guaranteed, so we check for substrings
   inspect(result.contains("1:a"), content="true")
@@ -444,14 +422,14 @@ test "HAMT::fold_with_key" {
 
 ///|
 test "HAMT::fold" {
-  let map = @hashmap.from_array([(1, 10), (2, 20), (3, 30)])
+  let map = @hashmap.HashMap([(1, 10), (2, 20), (3, 30)])
   let result = map.fold(init=0, (acc, _, v) => acc + v)
   inspect(result, content="60")
 }
 
 ///|
 test "HAMT::map" {
-  let map = @hashmap.from_array([(1, 10), (2, 20)])
+  let map = @hashmap.HashMap([(1, 10), (2, 20)])
   let mapped = map.map((_, v) => v * 2)
   @test.assert_eq(mapped.get(1), Some(20))
   @test.assert_eq(mapped.get(2), Some(40))
@@ -461,7 +439,7 @@ test "HAMT::map" {
 ///|
 test "HAMT::map with overflow" {
   let max = 2147483647 // Int.max_value
-  let map = @hashmap.from_array([(1, max)])
+  let map = @hashmap.HashMap([(1, max)])
   let mapped = map.map((_, v) => v + 1)
   @test.assert_eq(mapped.get(1), Some(-2147483648))
 }
@@ -483,7 +461,7 @@ test "HAMT::map_with_key leaf" {
 
 ///|
 test "HAMT::map_with_key collision" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)]) // Collision
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)]) // Collision
   let mapped = map.map((k, v) => k.0 + ":" + v.to_string())
   @test.assert_eq(mapped.get(MyString("a")), Some("a:1"))
   @test.assert_eq(mapped.get(MyString("b")), Some("b:2"))
@@ -548,7 +526,7 @@ impl Eq for SegKey with fn equal(self, other) {
 
 ///|
 test "get collision" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   @test.assert_eq(map.get(MyString("a")), Some(1))
   @test.assert_eq(map.get(MyString("b")), Some(2))
   @test.assert_eq(map.get(MyString("c")), None)
@@ -556,7 +534,7 @@ test "get collision" {
 
 ///|
 test "add_with_hash collision" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   @test.assert_eq(map.get(MyString("a")), Some(1))
   @test.assert_eq(map.get(MyString("b")), Some(2))
   @test.assert_eq(map.get(MyString("c")), None)
@@ -587,28 +565,28 @@ test "HAMT leaf bucket updates" {
 
 ///|
 test "empty filtering" {
-  let map : @hashmap.HashMap[Int, Int] = @hashmap.from_array([])
+  let map : @hashmap.HashMap[Int, Int] = HashMap([])
   let _filtered = map.filter((_, v) => v > 2)
   inspect(map.length(), content="0")
 }
 
 ///|
 test "filter with collision - all removed" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   let filtered = map.filter((_, v) => v > 2)
   inspect(filtered.length(), content="0")
 }
 
 ///|
 test "filter with collision - one left" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   let filtered = map.filter((_, v) => v == 1)
   inspect(filtered.length(), content="1")
 }
 
 ///|
 test "filter with collision - more than one left" {
-  let map = @hashmap.from_array([
+  let map = @hashmap.HashMap([
     (MyString("a"), 1),
     (MyString("b"), 2),
     (MyString("c"), 3),
@@ -626,14 +604,14 @@ test "HAMT::fold_with_key on empty" {
 
 ///|
 test "HAMT::fold_with_key on collision" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   let result = map.fold(init=0, (acc, _k, v) => acc + v)
   inspect(result, content="3")
 }
 
 ///|
 test "HAMT::remove_with_hash collision" {
-  let map = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let map = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   let map1 = map.remove(MyString("c"))
   inspect(map1.length(), content="2")
   let map2 = map.remove(MyString("a"))
@@ -653,7 +631,7 @@ test "HAMT::remove from empty map" {
 
 ///|
 test "HAMT::remove from collision bucket non-primary key" {
-  let map = @hashmap.from_array([
+  let map = @hashmap.HashMap([
     (MyString("a"), 1),
     (MyString("b"), 2),
     (MyString("c"), 3),
@@ -667,7 +645,7 @@ test "HAMT::remove from collision bucket non-primary key" {
 
 ///|
 test "HAMT::union with empty" {
-  let m1 = @hashmap.from_array([(1, 1)])
+  let m1 = @hashmap.HashMap([(1, 1)])
   let m2 = @hashmap.new()
   @debug.assert_eq(m1.union(m2), m1)
   @debug.assert_eq(m2.union(m1), m1)
@@ -675,7 +653,7 @@ test "HAMT::union with empty" {
 
 ///|
 test "HAMT::union with leaf" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(3, 3)
   let m3 = @hashmap.singleton(2, 20)
   @test.assert_eq(m1.union(m2).get(3), Some(3))
@@ -685,8 +663,8 @@ test "HAMT::union with leaf" {
 
 ///|
 test "HAMT::union with branch" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let m2 = @hashmap.from_array([(4, 4), (5, 5), (6, 6)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(4, 4), (5, 5), (6, 6)])
   let u = m1.union(m2)
   for i in 1..<=6 {
     inspect(u.contains(i), content="true")
@@ -695,8 +673,8 @@ test "HAMT::union with branch" {
 
 ///|
 test "HAMT::union with collision" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("b"), 20), (MyString("c"), 3)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("b"), 20), (MyString("c"), 3)])
   let u = m1.union(m2)
   @test.assert_eq(u.get(MyString("a")), Some(1))
   @test.assert_eq(u.get(MyString("b")), Some(20))
@@ -705,8 +683,8 @@ test "HAMT::union with collision" {
 
 ///|
 test "HAMT::union collision all keys in second" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([
     (MyString("a"), 10),
     (MyString("b"), 20),
     (MyString("c"), 3),
@@ -722,14 +700,14 @@ test "HAMT::union collision all keys in second" {
 test "HAMT::union all cases" {
   let empty = @hashmap.new()
   let leaf = @hashmap.singleton(1, 1)
-  let branch = @hashmap.from_array([(1, 1), (2, 2)])
-  let collision = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let branch = @hashmap.HashMap([(1, 1), (2, 2)])
+  let collision = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   @test.assert_eq(empty.union(leaf).get(1), Some(1))
   @test.assert_eq(leaf.union(branch).get(2), Some(2))
   let u1 = branch.union(branch)
   @test.assert_eq(u1.get(1), Some(1))
   @test.assert_eq(u1.get(2), Some(2))
-  let collision2 = @hashmap.from_array([(MyString("b"), 20), (MyString("c"), 3)])
+  let collision2 = @hashmap.HashMap([(MyString("b"), 20), (MyString("c"), 3)])
   let u2 = collision.union(collision2)
   @test.assert_eq(u2.get(MyString("a")), Some(1))
   @test.assert_eq(u2.get(MyString("b")), Some(20))
@@ -739,7 +717,7 @@ test "HAMT::union all cases" {
 ///|
 test "HAMT::union leaf to non-overlapping map" {
   let leaf = @hashmap.singleton(42, 100)
-  let other = @hashmap.from_array([(1, 1), (2, 2)])
+  let other = @hashmap.HashMap([(1, 1), (2, 2)])
   let u = leaf.union(other)
   @test.assert_eq(u.get(42), Some(100))
   @test.assert_eq(u.get(1), Some(1))
@@ -748,7 +726,7 @@ test "HAMT::union leaf to non-overlapping map" {
 
 ///|
 test "HAMT::intersection with empty" {
-  let m1 = @hashmap.from_array([(1, 1)])
+  let m1 = @hashmap.HashMap([(1, 1)])
   let m2 = @hashmap.new()
   assert_eq(m1.intersection(m2).length(), 0)
   assert_eq(m2.intersection(m1).length(), 0)
@@ -756,7 +734,7 @@ test "HAMT::intersection with empty" {
 
 ///|
 test "HAMT::intersection with leaf" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(2, 2)
   let m3 = @hashmap.singleton(3, 3)
   @test.assert_eq(m1.intersection(m2).get(2), Some(2))
@@ -766,8 +744,8 @@ test "HAMT::intersection with leaf" {
 
 ///|
 test "HAMT::intersection with branch" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let m2 = @hashmap.from_array([(2, 2), (3, 30), (4, 4)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(2, 2), (3, 30), (4, 4)])
   let inter = m1.intersection(m2)
   @test.assert_eq(inter.get(1), None)
   @test.assert_eq(inter.get(2), Some(2))
@@ -778,7 +756,7 @@ test "HAMT::intersection with branch" {
 ///|
 test "HAMT::intersection singleton with non-overlapping branch" {
   let m1 = @hashmap.singleton(10, 100)
-  let m2 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
   let inter = m1.intersection(m2)
   assert_eq(inter.length(), 0)
   @test.assert_eq(inter.get(10), None)
@@ -786,16 +764,16 @@ test "HAMT::intersection singleton with non-overlapping branch" {
 
 ///|
 test "HAMT::intersection branch with non-overlapping branch" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
-  let m2 = @hashmap.from_array([(3, 3), (4, 4)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
+  let m2 = @hashmap.HashMap([(3, 3), (4, 4)])
   let inter = m1.intersection(m2)
   assert_eq(inter.length(), 0)
 }
 
 ///|
 test "HAMT::intersection branch to single flat" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (100, 100)])
-  let m2 = @hashmap.from_array([(1, 10), (3, 3), (200, 200)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (100, 100)])
+  let m2 = @hashmap.HashMap([(1, 10), (3, 3), (200, 200)])
   let inter = m1.intersection(m2)
   assert_eq(inter.length(), 1)
   @test.assert_eq(inter.get(1), Some(10))
@@ -805,8 +783,8 @@ test "HAMT::intersection branch to single flat" {
 
 ///|
 test "HAMT::intersection with collision" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("b"), 20), (MyString("c"), 3)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("b"), 20), (MyString("c"), 3)])
   let inter = m1.intersection(m2)
   @test.assert_eq(inter.get(MyString("a")), None)
   @test.assert_eq(inter.get(MyString("b")), Some(20))
@@ -815,15 +793,15 @@ test "HAMT::intersection with collision" {
 
 ///|
 test "HAMT::intersection with collision no overlap" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("c"), 3), (MyString("d"), 4)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("c"), 3), (MyString("d"), 4)])
   let inter = m1.intersection(m2)
   assert_eq(inter.length(), 0)
 }
 
 ///|
 test "HAMT::intersection_with with empty" {
-  let m1 = @hashmap.from_array([(1, 1)])
+  let m1 = @hashmap.HashMap([(1, 1)])
   let m2 = @hashmap.new()
   assert_eq(m1.intersection_with(m2, (_k, v1, v2) => v1 + v2).length(), 0)
   assert_eq(m2.intersection_with(m1, (_k, v1, v2) => v1 + v2).length(), 0)
@@ -831,7 +809,7 @@ test "HAMT::intersection_with with empty" {
 
 ///|
 test "HAMT::intersection_with with leaf" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(2, 20)
   let m3 = @hashmap.singleton(3, 30)
   @test.assert_eq(
@@ -850,8 +828,8 @@ test "HAMT::intersection_with with leaf" {
 
 ///|
 test "HAMT::intersection_with with branch" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let m2 = @hashmap.from_array([(2, 20), (3, 30), (4, 4)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(2, 20), (3, 30), (4, 4)])
   let inter = m1.intersection_with(m2, (_k, v1, v2) => v1 * v2)
   @test.assert_eq(inter.get(1), None)
   @test.assert_eq(inter.get(2), Some(40))
@@ -862,15 +840,15 @@ test "HAMT::intersection_with with branch" {
 ///|
 test "HAMT::intersection_with singleton with non-overlapping branch" {
   let m1 = @hashmap.singleton(10, 100)
-  let m2 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
   let inter = m1.intersection_with(m2, (_k, v1, v2) => v1 + v2)
   assert_eq(inter.length(), 0)
 }
 
 ///|
 test "HAMT::intersection_with branch returns single element" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let m2 = @hashmap.from_array([(2, 20), (4, 4)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(2, 20), (4, 4)])
   let inter = m1.intersection_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(inter.get(1), None)
   @test.assert_eq(inter.get(2), Some(22))
@@ -880,8 +858,8 @@ test "HAMT::intersection_with branch returns single element" {
 
 ///|
 test "HAMT::intersection_with branch to single flat" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (100, 100)])
-  let m2 = @hashmap.from_array([(1, 10), (3, 3), (200, 200)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (100, 100)])
+  let m2 = @hashmap.HashMap([(1, 10), (3, 3), (200, 200)])
   let inter = m1.intersection_with(m2, (_k, v1, v2) => v1 * v2)
   assert_eq(inter.length(), 1)
   @test.assert_eq(inter.get(1), Some(10))
@@ -889,8 +867,8 @@ test "HAMT::intersection_with branch to single flat" {
 
 ///|
 test "HAMT::intersection_with with collision" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("a"), 10), (MyString("c"), 3)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("a"), 10), (MyString("c"), 3)])
   let inter = m1.intersection_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(inter.get(MyString("a")), Some(11))
   @test.assert_eq(inter.get(MyString("b")), None)
@@ -899,15 +877,15 @@ test "HAMT::intersection_with with collision" {
 
 ///|
 test "HAMT::intersection_with collision no overlap" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("c"), 3), (MyString("d"), 4)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("c"), 3), (MyString("d"), 4)])
   let inter = m1.intersection_with(m2, (_k, v1, v2) => v1 + v2)
   assert_eq(inter.length(), 0)
 }
 
 ///|
 test "HAMT::difference with empty" {
-  let m1 = @hashmap.from_array([(1, 1)])
+  let m1 = @hashmap.HashMap([(1, 1)])
   let m2 = @hashmap.new()
   @debug.assert_eq(m1.difference(m2), m1)
   assert_eq(m2.difference(m1).length(), 0)
@@ -915,7 +893,7 @@ test "HAMT::difference with empty" {
 
 ///|
 test "HAMT::difference with leaf" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(2, 2)
   let m3 = @hashmap.singleton(3, 3)
   @test.assert_eq(m1.difference(m2).get(2), None)
@@ -925,8 +903,8 @@ test "HAMT::difference with leaf" {
 
 ///|
 test "HAMT::difference with branch" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let m2 = @hashmap.from_array([(2, 2), (3, 30), (4, 4)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(2, 2), (3, 30), (4, 4)])
   let diff = m1.difference(m2)
   @test.assert_eq(diff.get(1), Some(1))
   @test.assert_eq(diff.get(2), None)
@@ -937,7 +915,7 @@ test "HAMT::difference with branch" {
 ///|
 test "HAMT::difference singleton with non-overlapping branch" {
   let m1 = @hashmap.singleton(10, 100)
-  let m2 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
   let diff = m1.difference(m2)
   @test.assert_eq(diff.get(10), Some(100))
   assert_eq(diff.length(), 1)
@@ -945,16 +923,16 @@ test "HAMT::difference singleton with non-overlapping branch" {
 
 ///|
 test "HAMT::difference branch becomes empty" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
-  let m2 = @hashmap.from_array([(1, 10), (2, 20), (3, 30)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
+  let m2 = @hashmap.HashMap([(1, 10), (2, 20), (3, 30)])
   let diff = m1.difference(m2)
   assert_eq(diff.length(), 0)
 }
 
 ///|
 test "HAMT::difference branch to single flat" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (100, 100)])
-  let m2 = @hashmap.from_array([(1, 10), (3, 3), (200, 200)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (100, 100)])
+  let m2 = @hashmap.HashMap([(1, 10), (3, 3), (200, 200)])
   let diff = m1.difference(m2)
   assert_eq(diff.length(), 2)
   @test.assert_eq(diff.get(1), None)
@@ -964,8 +942,8 @@ test "HAMT::difference branch to single flat" {
 
 ///|
 test "HAMT::difference with collision" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("b"), 20), (MyString("c"), 3)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("b"), 20), (MyString("c"), 3)])
   let diff = m1.difference(m2)
   @test.assert_eq(diff.get(MyString("a")), Some(1))
   @test.assert_eq(diff.get(MyString("b")), None)
@@ -974,8 +952,8 @@ test "HAMT::difference with collision" {
 
 ///|
 test "HAMT::difference collision becomes empty" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("a"), 10), (MyString("b"), 20)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("a"), 10), (MyString("b"), 20)])
   let diff = m1.difference(m2)
   assert_eq(diff.length(), 0)
 }
@@ -990,11 +968,11 @@ test "HAMT::each" {
   let mut sum_leaf = 0
   leaf.each((k, v) => sum_leaf = sum_leaf + k + v)
   inspect(sum_leaf, content="11")
-  let collision = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
+  let collision = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   let mut sum_collision = 0
   collision.each((_k : MyString, v : Int) => sum_collision = sum_collision + v)
   inspect(sum_collision, content="3")
-  let branch = @hashmap.from_array([(1, 1), (2, 2), (3, 3), (4, 4)])
+  let branch = @hashmap.HashMap([(1, 1), (2, 2), (3, 3), (4, 4)])
   let mut sum_branch = 0
   branch.each((_k, v) => sum_branch = sum_branch + v)
   inspect(sum_branch, content="10")
@@ -1019,7 +997,7 @@ test "equal imply hash equal when collision" {
 
 ///|
 test "HAMT::union_with with empty" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
   let m2 = @hashmap.new()
   let u1 = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(u1.get(1), Some(1))
@@ -1031,7 +1009,7 @@ test "HAMT::union_with with empty" {
 
 ///|
 test "HAMT::union_with with leaf" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2)])
   let m2 = @hashmap.singleton(2, 20)
   let m3 = @hashmap.singleton(3, 30)
   let u1 = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
@@ -1045,8 +1023,8 @@ test "HAMT::union_with with leaf" {
 
 ///|
 test "HAMT::union_with with branch" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let m2 = @hashmap.from_array([(2, 20), (3, 30), (4, 40)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(2, 20), (3, 30), (4, 40)])
   let u = m1.union_with(m2, (_k, v1, v2) => v1 * v2)
   @test.assert_eq(u.get(1), Some(1))
   @test.assert_eq(u.get(2), Some(40))
@@ -1056,8 +1034,8 @@ test "HAMT::union_with with branch" {
 
 ///|
 test "HAMT::union_with with collision" {
-  let m1 = @hashmap.from_array([(MyString("a"), 1), (MyString("b"), 2)])
-  let m2 = @hashmap.from_array([(MyString("b"), 20), (MyString("c"), 3)])
+  let m1 = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
+  let m2 = @hashmap.HashMap([(MyString("b"), 20), (MyString("c"), 3)])
   let u = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(u.get(MyString("a")), Some(1))
   @test.assert_eq(u.get(MyString("b")), Some(22))
@@ -1066,8 +1044,8 @@ test "HAMT::union_with with collision" {
 
 ///|
 test "HAMT::union_with all non-overlapping" {
-  let m1 = @hashmap.from_array([(1, 10), (2, 20)])
-  let m2 = @hashmap.from_array([(3, 30), (4, 40)])
+  let m1 = @hashmap.HashMap([(1, 10), (2, 20)])
+  let m2 = @hashmap.HashMap([(3, 30), (4, 40)])
   let u = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(u.get(1), Some(10))
   @test.assert_eq(u.get(2), Some(20))
@@ -1077,8 +1055,8 @@ test "HAMT::union_with all non-overlapping" {
 
 ///|
 test "HAMT::union_with all overlapping" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
-  let m2 = @hashmap.from_array([(1, 10), (2, 20), (3, 30)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(1, 10), (2, 20), (3, 30)])
   let u = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(u.get(1), Some(11))
   @test.assert_eq(u.get(2), Some(22))
@@ -1087,8 +1065,8 @@ test "HAMT::union_with all overlapping" {
 
 ///|
 test "HAMT::union_with with custom merge function" {
-  let m1 = @hashmap.from_array([(1, "a"), (2, "b")])
-  let m2 = @hashmap.from_array([(2, "c"), (3, "d")])
+  let m1 = @hashmap.HashMap([(1, "a"), (2, "b")])
+  let m2 = @hashmap.HashMap([(2, "c"), (3, "d")])
   let u = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(u.get(1), Some("a"))
   @test.assert_eq(u.get(2), Some("bc"))
@@ -1098,7 +1076,7 @@ test "HAMT::union_with with custom merge function" {
 ///|
 test "HAMT::union_with singleton with branch" {
   let m1 = @hashmap.singleton(1, 10)
-  let m2 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
   let u = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(u.get(1), Some(11))
   @test.assert_eq(u.get(2), Some(2))
@@ -1107,7 +1085,7 @@ test "HAMT::union_with singleton with branch" {
 
 ///|
 test "HAMT::union_with branch with singleton" {
-  let m1 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
+  let m1 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
   let m2 = @hashmap.singleton(1, 10)
   let u = m1.union_with(m2, (_k, v1, v2) => v1 * v2)
   @test.assert_eq(u.get(1), Some(10))
@@ -1118,7 +1096,7 @@ test "HAMT::union_with branch with singleton" {
 ///|
 test "HAMT::union_with singleton with non-overlapping branch" {
   let m1 = @hashmap.singleton(10, 100)
-  let m2 = @hashmap.from_array([(1, 1), (2, 2), (3, 3)])
+  let m2 = @hashmap.HashMap([(1, 1), (2, 2), (3, 3)])
   let u = m1.union_with(m2, (_k, v1, v2) => v1 + v2)
   @test.assert_eq(u.get(1), Some(1))
   @test.assert_eq(u.get(2), Some(2))
@@ -1128,8 +1106,8 @@ test "HAMT::union_with singleton with non-overlapping branch" {
 
 ///|
 test "HAMT::merge is alias for union" {
-  let map1 = @hashmap.from_array([("a", 1), ("b", 2)])
-  let map2 = @hashmap.from_array([("b", 3), ("c", 4)])
+  let map1 = @hashmap.HashMap([("a", 1), ("b", 2)])
+  let map2 = @hashmap.HashMap([("b", 3), ("c", 4)])
   let merged = map1.merge(map2)
   debug_inspect(merged.get("a"), content="Some(1)")
   debug_inspect(merged.get("b"), content="Some(3)")

--- a/immut/hashmap/README.mbt.md
+++ b/immut/hashmap/README.mbt.md
@@ -11,7 +11,7 @@ test "create" {
   inspect(empty.length(), content="0")
   let single = @hashmap.singleton("a", 1)
   debug_inspect(single.get("a"), content="Some(1)")
-  let from_arr = @hashmap.from_array([("a", 1), ("b", 2)])
+  let from_arr = @hashmap.HashMap([("a", 1), ("b", 2)])
   inspect(from_arr.length(), content="2")
 }
 ```
@@ -54,7 +54,7 @@ test "iteration" {
 ```mbt check
 ///|
 test "transform" {
-  let map = @hashmap.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @hashmap.HashMap([("a", 1), ("b", 2), ("c", 3)])
   let doubled = map.map((_k, v) => v * 2)
   debug_inspect(doubled.get("b"), content="Some(4)")
   let filtered = map.filter((_k, v) => v > 1)
@@ -70,7 +70,7 @@ Use `map["key"]` (the `at` operator) for direct access. Panics if the key is not
 ```mbt check
 ///|
 test "index_access" {
-  let map = @hashmap.from_array([("x", 10), ("y", 20)])
+  let map = @hashmap.HashMap([("x", 10), ("y", 20)])
   @test.assert_eq(map["x"], 10)
   @test.assert_eq(map["y"], 20)
 }
@@ -106,8 +106,8 @@ test "iteration_full" {
 ```mbt check
 ///|
 test "set_operations" {
-  let m1 = @hashmap.from_array([("a", 1), ("b", 2)])
-  let m2 = @hashmap.from_array([("b", 20), ("c", 3)])
+  let m1 = @hashmap.HashMap([("a", 1), ("b", 2)])
+  let m2 = @hashmap.HashMap([("b", 20), ("c", 3)])
   // Union prefers right map on conflicts
   let u = m1.union(m2)
   debug_inspect(u.get("b"), content="Some(20)")

--- a/immut/hashmap/debug.mbt
+++ b/immut/hashmap/debug.mbt
@@ -36,7 +36,7 @@ pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(
 
 ///|
 test "Debug for HashMap" {
-  let hm : HashMap[Int, String] = from_array([(2, "b")])
+  let hm : HashMap[Int, String] = HashMap([(2, "b")])
   @debug.debug_inspect(
     hm,
     content=(

--- a/immut/hashmap/pattern_test.mbt
+++ b/immut/hashmap/pattern_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "pattern" {
-  let m = @hashmap.from_array([
+  let m = @hashmap.HashMap([
     ("name", "John Doe"),
     ("age", "43"),
     ("is_human", "true"),

--- a/immut/hashmap/pkg.generated.mbti
+++ b/immut/hashmap/pkg.generated.mbti
@@ -14,6 +14,7 @@ import {
 // Types and methods
 #alias(T, deprecated)
 type HashMap[K, V] derive(Eq)
+pub fn[K : Eq + Hash, V] HashMap::HashMap(ArrayView[(K, V)]) -> Self[K, V]
 pub fn[K : Eq + Hash, V] HashMap::add(Self[K, V], K, V) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Eq + Hash, V] HashMap::at(Self[K, V], K) -> V
@@ -26,7 +27,8 @@ pub fn[K, V] HashMap::filter(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] ra
 pub fn[K, V, A] HashMap::fold(Self[K, V], init~ : A, (A, K, V) -> A raise?) -> A raise?
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[K : Eq + Hash, V] HashMap::from_array(ArrayView[(K, V)]) -> Self[K, V]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)

--- a/immut/hashmap/types.mbt
+++ b/immut/hashmap/types.mbt
@@ -23,4 +23,6 @@ priv enum Node[K, V] {
 
 ///|
 #alias(T, deprecated)
-struct HashMap[K, V](Node[K, V]?) derive(Eq)
+struct HashMap[K, V] {
+  data : Node[K, V]?
+} derive(Eq)


### PR DESCRIPTION
## Summary

Provide a `@hashmap.HashMap([...])` constructor for the immutable hash map (matching `@list.List([...])` / `@sorted_set.SortedSet([...])`), and deprecate `from_array`.

`HashMap` was a positional newtype `struct HashMap(Node?)`, whose **tuple constructor reserved the `HashMap` name** — a `HashMap::HashMap` function collided with it. Give the field a name instead:

```moonbit
struct HashMap[K, V] {
  data : Node[K, V]?
}
```

- Frees the `HashMap` identifier (named structs construct via `{ data: .. }`, not `HashMap(..)`), so `HashMap::HashMap(...)` is allowed.
- Keeps the **exact same `Node?` representation** — internal logic is unchanged apart from `self.0` → `self.data` and wrapping results in `{ data: .. }`. No enum, no `SparseArray` changes, no per-node conversions.
- The public type stays **abstract** (the field is private), so the `.mbti` is unchanged apart from the new constructor.

Then: add `HashMap::HashMap(ArrayView[(K, V)]) -> HashMap[K, V]`, deprecate `from_array` (+ its `of` alias), and migrate all usages across impl/tests/README. The `Show`/`output` format and its snapshot tests intentionally keep emitting `@immut/hashmap.from_array([...])`.

## Verification

- `moon check --deny-warn --target all` — 0 warnings
- `moon test` — all passing (default target)
- `immut/hashmap` green on wasm / wasm-gc / js / native (110/110 each)
- `moon fmt` and `moon info` produce no additional diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)