### PR TITLE
feat(immut/hashset): add HashSet constructor, deprecate from_array

### DIFF
--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -31,13 +31,13 @@
 /// Create a new instance.
 #as_free_fn
 pub fn[A] HashSet::new() -> HashSet[A] {
-  None
+  { data: None }
 }
 
 ///|
 /// Lookup a value from the hash set
 pub fn[A : Eq + Hash] HashSet::contains(self : HashSet[A], key : A) -> Bool {
-  self.0 is Some(node) && node.contains(key, @path.of(key))
+  self.data is Some(node) && node.contains(key, @path.of(key))
 }
 
 ///|
@@ -122,18 +122,22 @@ fn[A : Eq] Node::add_with_path(
 ///|
 /// Add a key to the hashset.
 pub fn[A : Eq + Hash] HashSet::add(self : HashSet[A], key : A) -> HashSet[A] {
-  match self.0 {
-    None => Some(Flat(key, @path.of(key)))
-    Some(node) => Some(node.add_with_path(key, @path.of(key)))
+  {
+    data: match self.data {
+      None => Some(Flat(key, @path.of(key)))
+      Some(node) => Some(node.add_with_path(key, @path.of(key)))
+    },
   }
 }
 
 ///|
 /// Remove an element from a set
 pub fn[A : Eq + Hash] HashSet::remove(self : HashSet[A], key : A) -> HashSet[A] {
-  match self.0 {
-    None => None
-    Some(node) => node.remove_with_path(key, @path.of(key))
+  {
+    data: match self.data {
+      None => None
+      Some(node) => node.remove_with_path(key, @path.of(key))
+    },
   }
 }
 
@@ -202,7 +206,7 @@ pub fn[A] HashSet::length(self : HashSet[A]) -> Int {
     }
   }
 
-  match self.0 {
+  match self.data {
     None => 0
     Some(node) => node_size(node)
   }
@@ -232,9 +236,11 @@ pub fn[K : Eq] HashSet::union(
     }
   }
 
-  match (self.0, other.0) {
-    (None, x) | (x, None) => x
-    (Some(a), Some(b)) => Some(go(a, b))
+  {
+    data: match (self.data, other.data) {
+      (None, x) | (x, None) => x
+      (Some(a), Some(b)) => Some(go(a, b))
+    },
   }
 }
 
@@ -271,9 +277,11 @@ pub fn[K : Eq] HashSet::intersection(
     }
   }
 
-  match (self.0, other.0) {
-    (None, _) | (_, None) => None
-    (Some(a), Some(b)) => go(a, b)
+  {
+    data: match (self.data, other.data) {
+      (None, _) | (_, None) => None
+      (Some(a), Some(b)) => go(a, b)
+    },
   }
 }
 
@@ -311,17 +319,17 @@ pub fn[K : Eq] HashSet::difference(
     }
   }
 
-  match (self.0, other.0) {
-    (None, _) => None
+  match (self.data, other.data) {
+    (None, _) => { data: None }
     (_, None) => self
-    (Some(a), Some(b)) => go(a, b)
+    (Some(a), Some(b)) => { data: go(a, b) }
   }
 }
 
 ///|
 /// Returns true if the hash set is empty.
 pub fn[A] HashSet::is_empty(self : HashSet[A]) -> Bool {
-  self.0 is None
+  self.data is None
 }
 
 ///|
@@ -341,7 +349,7 @@ pub fn[A] HashSet::each(
     }
   }
 
-  if self.0 is Some(node) {
+  if self.data is Some(node) {
     go(node)
   }
 }
@@ -357,7 +365,7 @@ priv enum CurrNode[A] {
 #alias(iterator, deprecated)
 pub fn[A] HashSet::iter(self : HashSet[A]) -> Iter[A] {
   let empty = Bucket(@list.new())
-  let mut curr_node = match self.0 {
+  let mut curr_node = match self.data {
     Some(tree) => Tree(tree)
     None => empty
   }
@@ -420,10 +428,35 @@ pub impl[A : Show] Show for HashSet[A] with fn output(self, logger) {
 
 ///|
 /// Creates a hash set from an array of values.
-#as_free_fn
-#alias(of, deprecated="Use from_array instead")
-#as_free_fn(of, deprecated="Use from_array instead")
+#as_free_fn(deprecated="Use @immut/hashset.HashSet([...]) instead")
+#alias(of, deprecated="Use @immut/hashset.HashSet([...]) instead")
+#as_free_fn(of, deprecated="Use @immut/hashset.HashSet([...]) instead")
+#deprecated("Use @immut/hashset.HashSet([...]) instead")
 pub fn[A : Eq + Hash] HashSet::from_array(arr : ArrayView[A]) -> HashSet[A] {
+  for n = arr.length(), set = new() {
+    match (n, set) {
+      (0, set) => break set
+      (n, set) => {
+        let k = arr[n - 1]
+        continue n - 1, set.add(k)
+      }
+    }
+  }
+}
+
+///|
+/// Creates a hash set from an array of values.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let set = @hashset.HashSet([3, 1, 2, 3])
+///   @test.assert_eq(set.contains(1), true)
+///   @test.assert_eq(set.contains(4), false)
+/// }
+/// ```
+pub fn[A : Eq + Hash] HashSet::HashSet(arr : ArrayView[A]) -> HashSet[A] {
   for n = arr.length(), set = new() {
     match (n, set) {
       (0, set) => break set
@@ -463,23 +496,23 @@ impl[A : Eq] Eq for Node[A] with fn equal(self, other) {
 pub impl[K : Eq + Hash + @quickcheck.Arbitrary] @quickcheck.Arbitrary for HashSet[
   K,
 ] with fn arbitrary(size, rs) {
-  @quickcheck.Arbitrary::arbitrary(size, rs) |> from_array
+  @quickcheck.Arbitrary::arbitrary(size, rs) |> HashSet
 }
 
 ///|
 test "hash" {
   @test.assert_eq(
-    Hash::hash(from_array([1, 2, 3, 4])),
-    Hash::hash(from_array([3, 2]).add(1).add(4)),
+    Hash::hash(HashSet([1, 2, 3, 4])),
+    Hash::hash(HashSet([3, 2]).add(1).add(4)),
   )
   @test.assert_not_eq(
-    Hash::hash(from_array([1, 2, 3])),
-    Hash::hash(from_array([1, 2, 4])),
+    Hash::hash(HashSet([1, 2, 3])),
+    Hash::hash(HashSet([1, 2, 4])),
   )
 }
 
 ///|
 test "eq" {
-  @test.assert_eq(from_array([1, 2, 3, 4]), from_array([3, 2]).add(1).add(4))
-  @test.assert_not_eq(from_array([1, 2, 3]), from_array([1, 2, 4]))
+  @test.assert_eq(HashSet([1, 2, 3, 4]), HashSet([3, 2]).add(1).add(4))
+  @test.assert_not_eq(HashSet([1, 2, 3]), HashSet([1, 2, 4]))
 }

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -92,7 +92,7 @@ test "remove on empty set" {
 
 ///|
 test "@hashset.iter" {
-  let data = @hashset.from_array(["a", "b", "d", "e", "f"])
+  let data = @hashset.HashSet(["a", "b", "d", "e", "f"])
   let array = data.iter().collect()
   array.sort()
   debug_inspect(
@@ -113,7 +113,7 @@ test "@hashset.to_string" {
 
 ///|
 test "@hashset.from_array" {
-  let set = @hashset.from_array(["1", "2", "42"])
+  let set = @hashset.HashSet(["1", "2", "42"])
   inspect(set.contains("1"), content="true")
   inspect(set.contains("2"), content="true")
   inspect(set.contains("42"), content="true")
@@ -169,14 +169,14 @@ test "each on empty set" {
 ///|
 test "from_array with empty array" {
   let empty_array : Array[Int] = []
-  let set = @hashset.from_array(empty_array)
+  let set = @hashset.HashSet(empty_array)
   inspect(set.is_empty(), content="true")
 }
 
 ///|
 test "from_array with non-empty array" {
   let array : ReadOnlyArray[Int] = [1, 2, 3]
-  let set = @hashset.from_array(array)
+  let set = @hashset.HashSet(array)
   inspect(set.contains(1), content="true")
   inspect(set.contains(2), content="true")
   inspect(set.contains(3), content="true")
@@ -185,7 +185,7 @@ test "from_array with non-empty array" {
 
 ///|
 test "remove non-existent key from leaf" {
-  let set = @hashset.from_array([1])
+  let set = @hashset.HashSet([1])
   let result = set.remove(2)
   debug_inspect(
     result,
@@ -198,14 +198,14 @@ test "remove non-existent key from leaf" {
 ///|
 test "from_array - non-empty array" {
   let data = [1, 2, 3]
-  let set = @hashset.from_array(data)
+  let set = @hashset.HashSet(data)
   verify_content(set, data)
 }
 
 ///|
 test "hashset equality" {
-  let set1 = @hashset.from_array([1, 2])
-  let set2 = @hashset.from_array([2, 1])
+  let set1 = @hashset.HashSet([1, 2])
+  let set2 = @hashset.HashSet([2, 1])
   inspect(set1 == set2, content="true")
   let empty1 : @hashset.HashSet[Unit] = @hashset.new()
   let empty2 : @hashset.HashSet[Unit] = @hashset.new()
@@ -218,29 +218,29 @@ test "arbitrary implementation for hashset" {
   let set : @hashset.HashSet[Int] = @quickcheck.gen()
   // Make sure the generated set is valid by converting it to array and back
   let arr = set.iter().to_array()
-  let set2 = @hashset.from_array(arr)
+  let set2 = @hashset.HashSet(arr)
   @test.assert_eq(set, set2)
 }
 
 ///|
 test "equal between different constructors" {
-  let set1 = @hashset.from_array([])
-  let set2 = @hashset.from_array(["a"])
+  let set1 = @hashset.HashSet([])
+  let set2 = @hashset.HashSet(["a"])
   @test.assert_not_eq(set1, set2)
 }
 
 ///|
 test "union 2 hashsets" {
-  let set1 = @hashset.from_array([1, 2, 3])
-  let set2 = @hashset.from_array([3, 4, 5])
+  let set1 = @hashset.HashSet([1, 2, 3])
+  let set2 = @hashset.HashSet([3, 4, 5])
   let set3 = set1.union(set2)
-  let set4 = @hashset.from_array([1, 2, 3, 4, 5])
+  let set4 = @hashset.HashSet([1, 2, 3, 4, 5])
   inspect(set3 == set4, content="true")
 }
 
 ///|
 test "HAMT::union with empty" {
-  let m1 = @hashset.from_array([1])
+  let m1 = @hashset.HashSet([1])
   let m2 = @hashset.new()
   @test.assert_eq(m1.union(m2), m1)
   @test.assert_eq(m2.union(m1), m1)
@@ -248,18 +248,18 @@ test "HAMT::union with empty" {
 
 ///|
 test "HAMT::union with leaf" {
-  let m1 = @hashset.from_array([1, 2])
-  let m2 = @hashset.from_array([3])
-  let m3 = @hashset.from_array([2])
-  @test.assert_eq(m1.union(m2), @hashset.from_array([1, 2, 3]))
-  @test.assert_eq(m1.union(m3), @hashset.from_array([1, 2]))
-  @test.assert_eq(m3.union(m1), @hashset.from_array([1, 2]))
+  let m1 = @hashset.HashSet([1, 2])
+  let m2 = @hashset.HashSet([3])
+  let m3 = @hashset.HashSet([2])
+  @test.assert_eq(m1.union(m2), HashSet([1, 2, 3]))
+  @test.assert_eq(m1.union(m3), HashSet([1, 2]))
+  @test.assert_eq(m3.union(m1), HashSet([1, 2]))
 }
 
 ///|
 test "HAMT::union with branch" {
-  let m1 = @hashset.from_array([1, 2, 3])
-  let m2 = @hashset.from_array([4, 5, 6])
+  let m1 = @hashset.HashSet([1, 2, 3])
+  let m2 = @hashset.HashSet([4, 5, 6])
   let u = m1.union(m2)
   for i in 1..<=6 {
     @test.assert_eq(u.contains(i), true)
@@ -310,7 +310,7 @@ test "HAMT join_2 last segment split" {
 
 ///|
 test "HAMT::remove_with_hash collision" {
-  let set = @hashset.from_array([MyString("a"), MyString("b")])
+  let set = @hashset.HashSet([MyString("a"), MyString("b")])
   let set1 = set.remove(MyString("c"))
   inspect(set1.length(), content="2")
   let set2 = set.remove(MyString("a"))
@@ -323,8 +323,8 @@ test "HAMT::remove_with_hash collision" {
 
 ///|
 test "HAMT::union with collision" {
-  let m1 = @hashset.from_array([MyString("a"), MyString("b")])
-  let m2 = @hashset.from_array([MyString("b"), MyString("c")])
+  let m1 = @hashset.HashSet([MyString("a"), MyString("b")])
+  let m2 = @hashset.HashSet([MyString("b"), MyString("c")])
   let u = m1.union(m2)
   @test.assert_eq(u.contains(MyString("a")), true)
   @test.assert_eq(u.contains(MyString("b")), true)
@@ -333,8 +333,8 @@ test "HAMT::union with collision" {
 
 ///|
 test "HAMT::union collision identical" {
-  let m1 = @hashset.from_array([MyString("a"), MyString("b")])
-  let m2 = @hashset.from_array([MyString("a"), MyString("b")])
+  let m1 = @hashset.HashSet([MyString("a"), MyString("b")])
+  let m2 = @hashset.HashSet([MyString("a"), MyString("b")])
   let u = m1.union(m2)
   inspect(u.contains(MyString("a")), content="true")
   inspect(u.contains(MyString("b")), content="true")
@@ -344,15 +344,15 @@ test "HAMT::union collision identical" {
 ///|
 test "HAMT::union all cases" {
   let empty = @hashset.new()
-  let leaf = @hashset.from_array([1])
-  let branch = @hashset.from_array([1, 2])
-  let collision = @hashset.from_array([MyString("a"), MyString("b")])
+  let leaf = @hashset.HashSet([1])
+  let branch = @hashset.HashSet([1, 2])
+  let collision = @hashset.HashSet([MyString("a"), MyString("b")])
   @test.assert_eq(empty.union(leaf).contains(1), true)
   @test.assert_eq(leaf.union(branch).contains(2), true)
   let u1 = branch.union(branch)
   inspect(u1.contains(1), content="true")
   inspect(u1.contains(2), content="true")
-  let collision2 = @hashset.from_array([MyString("b"), MyString("c")])
+  let collision2 = @hashset.HashSet([MyString("b"), MyString("c")])
   let u2 = collision.union(collision2)
   @test.assert_eq(u2.contains(MyString("a")), true)
   @test.assert_eq(u2.contains(MyString("b")), true)
@@ -361,8 +361,8 @@ test "HAMT::union all cases" {
 
 ///|
 test "HAMT::union leaf to non-overlapping map" {
-  let leaf = @hashset.from_array([42])
-  let other = @hashset.from_array([1, 2])
+  let leaf = @hashset.HashSet([42])
+  let other = @hashset.HashSet([1, 2])
   let u = leaf.union(other)
   inspect(u.contains(42), content="true")
   inspect(u.contains(1), content="true")
@@ -371,11 +371,11 @@ test "HAMT::union leaf to non-overlapping map" {
 
 ///|
 test "@hashset.difference patch" {
-  let set1 = @hashset.from_array([1, 2, 3, 4])
-  let set2 = @hashset.from_array([3, 4, 5, 6])
-  let set3 = @hashset.from_array([])
-  let set4 = @hashset.from_array([1, 2, 3, 4, 5, 6])
-  let leaf = @hashset.from_array([1])
+  let set1 = @hashset.HashSet([1, 2, 3, 4])
+  let set2 = @hashset.HashSet([3, 4, 5, 6])
+  let set3 = @hashset.HashSet([])
+  let set4 = @hashset.HashSet([1, 2, 3, 4, 5, 6])
+  let leaf = @hashset.HashSet([1])
   verify_content(set1.difference(set2), [1, 2])
   verify_content(set1.difference(set3), [1, 2, 3, 4])
   verify_content(set3.difference(set1), [])
@@ -386,12 +386,12 @@ test "@hashset.difference patch" {
 
 ///|
 test "@hashset.intersection patch" {
-  let set1 = @hashset.from_array([1, 2, 3, 4])
-  let set2 = @hashset.from_array([3, 4, 5, 6])
-  let set3 = @hashset.from_array([])
-  let set4 = @hashset.from_array([1, 2, 3, 4, 5, 6])
-  let set5 = @hashset.from_array([7, 8, 9, 10])
-  let leaf = @hashset.from_array([1])
+  let set1 = @hashset.HashSet([1, 2, 3, 4])
+  let set2 = @hashset.HashSet([3, 4, 5, 6])
+  let set3 = @hashset.HashSet([])
+  let set4 = @hashset.HashSet([1, 2, 3, 4, 5, 6])
+  let set5 = @hashset.HashSet([7, 8, 9, 10])
+  let leaf = @hashset.HashSet([1])
   verify_content(set1.intersection(set2), [3, 4])
   verify_content(set1.intersection(set3), [])
   verify_content(set3.intersection(set1), [])
@@ -403,8 +403,8 @@ test "@hashset.intersection patch" {
 
 ///|
 test "intersection single common key" {
-  let set1 = @hashset.from_array([1, 2, 3])
-  let set2 = @hashset.from_array([3, 4, 5])
+  let set1 = @hashset.HashSet([1, 2, 3])
+  let set2 = @hashset.HashSet([3, 4, 5])
   let inter = set1.intersection(set2)
   debug_inspect(
     inter,
@@ -416,8 +416,8 @@ test "intersection single common key" {
 
 ///|
 test "intersection collision leaf" {
-  let set1 = @hashset.from_array([MyString("a"), MyString("b")])
-  let set2 = @hashset.from_array([MyString("b"), MyString("c")])
+  let set1 = @hashset.HashSet([MyString("a"), MyString("b")])
+  let set2 = @hashset.HashSet([MyString("b"), MyString("c")])
   let inter = set1.intersection(set2)
   inspect(inter.contains(MyString("b")), content="true")
   inspect(inter.length(), content="1")
@@ -425,8 +425,8 @@ test "intersection collision leaf" {
 
 ///|
 test "intersection collision empty" {
-  let set1 = @hashset.from_array([MyString("a"), MyString("b")])
-  let set2 = @hashset.from_array([MyString("c"), MyString("d")])
+  let set1 = @hashset.HashSet([MyString("a"), MyString("b")])
+  let set2 = @hashset.HashSet([MyString("c"), MyString("d")])
   let inter = set1.intersection(set2)
   inspect(inter.length(), content="0")
 }
@@ -470,15 +470,15 @@ test "collision equal coverage" {
 ///|
 test "difference with collision - Leaf case" {
   // Test (Leaf, Leaf) branch: hash collision handling
-  let set1 = @hashset.from_array([MyString("a"), MyString("b"), MyString("c")])
-  let set2 = @hashset.from_array([MyString("b")])
+  let set1 = @hashset.HashSet([MyString("a"), MyString("b"), MyString("c")])
+  let set2 = @hashset.HashSet([MyString("b")])
   let diff = set1.difference(set2)
   @test.assert_eq(diff.contains(MyString("a")), true)
   @test.assert_eq(diff.contains(MyString("b")), false)
   @test.assert_eq(diff.contains(MyString("c")), true)
   inspect(diff.length(), content="2")
   // Test when all elements in set1 are removed
-  let set3 = @hashset.from_array([MyString("a"), MyString("b"), MyString("c")])
+  let set3 = @hashset.HashSet([MyString("a"), MyString("b"), MyString("c")])
   let diff2 = set1.difference(set3)
   inspect(diff2.length(), content="0")
 }
@@ -487,23 +487,23 @@ test "difference with collision - Leaf case" {
 test "difference Flat vs Branch" {
   // Test (Flat, node) branch where Flat is not in node - line 277-282
   // When a single-element set is differenced with a multi-element set
-  let small = @hashset.from_array([100])
-  let large = @hashset.from_array([1, 2, 3, 4, 5])
+  let small = @hashset.HashSet([100])
+  let large = @hashset.HashSet([1, 2, 3, 4, 5])
   let diff1 = small.difference(large)
   @test.assert_eq(diff1.contains(100), true)
   inspect(diff1.length(), content="1")
   // When Flat element is in the other set - should return None
-  let small2 = @hashset.from_array([1])
+  let small2 = @hashset.HashSet([1])
   let diff2 = small2.difference(large)
   inspect(diff2.length(), content="0")
   // Test Flat vs collision node (Leaf)
-  let single = @hashset.from_array([MyString("z")])
-  let collision_set = @hashset.from_array([MyString("a"), MyString("b")])
+  let single = @hashset.HashSet([MyString("z")])
+  let collision_set = @hashset.HashSet([MyString("a"), MyString("b")])
   let diff3 = single.difference(collision_set)
   @test.assert_eq(diff3.contains(MyString("z")), true)
   inspect(diff3.length(), content="1")
   // Test Flat element that exists in collision set
-  let single2 = @hashset.from_array([MyString("a")])
+  let single2 = @hashset.HashSet([MyString("a")])
   let diff4 = single2.difference(collision_set)
   inspect(diff4.length(), content="0")
 }
@@ -512,8 +512,8 @@ test "difference Flat vs Branch" {
 test "difference Branch returns single Flat" {
   // Test case where Branch.difference returns a single Flat node
   // This happens when the result has only one element
-  let set1 = @hashset.from_array([1, 2])
-  let set2 = @hashset.from_array([2])
+  let set1 = @hashset.HashSet([1, 2])
+  let set2 = @hashset.HashSet([2])
   let diff = set1.difference(set2)
   @test.assert_eq(diff.contains(1), true)
   @test.assert_eq(diff.contains(2), false)
@@ -524,13 +524,13 @@ test "difference Branch returns single Flat" {
 test "difference Leaf collision - More case" {
   // Test (Leaf, Leaf) returning More(head, tail~) - line 295
   // Need hash collision where filtering leaves 2+ elements
-  let set1 = @hashset.from_array([
+  let set1 = @hashset.HashSet([
     MyString("a"),
     MyString("b"),
     MyString("c"),
     MyString("d"),
   ])
-  let set2 = @hashset.from_array([MyString("a"), MyString("b")])
+  let set2 = @hashset.HashSet([MyString("a"), MyString("b")])
   let diff = set1.difference(set2)
   @test.assert_eq(diff.contains(MyString("a")), false)
   @test.assert_eq(diff.contains(MyString("b")), false)
@@ -542,8 +542,8 @@ test "difference Leaf collision - More case" {
 ///|
 test "difference Branch single Flat result" {
   // Test Branch difference returning single Flat with path.push - line 287
-  let set1 = @hashset.from_array([1, 2, 3, 4, 5])
-  let set2 = @hashset.from_array([2, 3, 4, 5])
+  let set1 = @hashset.HashSet([1, 2, 3, 4, 5])
+  let set2 = @hashset.HashSet([2, 3, 4, 5])
   let diff = set1.difference(set2)
   @test.assert_eq(diff.contains(1), true)
   @test.assert_eq(diff.contains(2), false)

--- a/immut/hashset/README.mbt.md
+++ b/immut/hashset/README.mbt.md
@@ -15,11 +15,11 @@ test "creating immutable sets" {
   inspect(empty.is_empty(), content="true")
 
   // From array
-  let from_array_result = @hashset.from_array([1, 2, 3, 2, 1]) // Duplicates removed
+  let from_array_result = @hashset.HashSet([1, 2, 3, 2, 1]) // Duplicates removed
   inspect(from_array_result.length(), content="3")
 
   // From fixed array
-  let from_fixed = @hashset.from_array([10, 20, 30])
+  let from_fixed = @hashset.HashSet([10, 20, 30])
   inspect(from_fixed.length(), content="3")
 
   // From iterator
@@ -35,7 +35,7 @@ All operations return new sets without modifying the original:
 ```mbt check
 ///|
 test "immutable operations" {
-  let original = @hashset.from_array([1, 2, 3])
+  let original = @hashset.HashSet([1, 2, 3])
 
   // Add element - returns new set
   let with_four = original.add(4)
@@ -61,8 +61,8 @@ Perform mathematical set operations immutably:
 ```mbt check
 ///|
 test "set operations" {
-  let set1 = @hashset.from_array([1, 2, 3, 4])
-  let set2 = @hashset.from_array([3, 4, 5, 6])
+  let set1 = @hashset.HashSet([1, 2, 3, 4])
+  let set2 = @hashset.HashSet([3, 4, 5, 6])
 
   // Union - all elements from both sets
   let union_set = set1.union(set2)
@@ -89,7 +89,7 @@ Test membership and query the set:
 ```mbt check
 ///|
 test "membership and queries" {
-  let numbers = @hashset.from_array([10, 20, 30, 40, 50])
+  let numbers = @hashset.HashSet([10, 20, 30, 40, 50])
 
   // Membership testing
   inspect(numbers.contains(30), content="true")
@@ -113,7 +113,7 @@ test "membership and queries" {
 ```mbt check
 ///|
 test "iter" {
-  let set = @hashset.from_array([1, 2, 3])
+  let set = @hashset.HashSet([1, 2, 3])
   let arr = set.iter().to_array()
   arr.sort()
   @test.assert_eq(arr, [1, 2, 3])
@@ -127,7 +127,7 @@ Immutable sets share structure efficiently:
 ```mbt check
 ///|
 test "structural sharing" {
-  let base_set = @hashset.from_array([1, 2, 3, 4, 5])
+  let base_set = @hashset.HashSet([1, 2, 3, 4, 5])
 
   // Adding elements creates new sets that share structure
   let set_with_six = base_set.add(6)
@@ -154,12 +154,12 @@ Transform sets while maintaining immutability:
 ```mbt check
 ///|
 test "filtering and transformation" {
-  let numbers = @hashset.from_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  let numbers = @hashset.HashSet([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
   // Create filtered sets manually (no built-in filter/map)
-  let evens = @hashset.from_array([2, 4, 6, 8, 10])
+  let evens = @hashset.HashSet([2, 4, 6, 8, 10])
   inspect(evens.length(), content="5")
-  let doubled = @hashset.from_array([2, 4, 6, 8, 10, 12, 14, 16, 18, 20])
+  let doubled = @hashset.HashSet([2, 4, 6, 8, 10, 12, 14, 16, 18, 20])
   inspect(doubled.length(), content="10")
   inspect(doubled.contains(6), content="true") // 3 * 2 = 6
 
@@ -176,9 +176,9 @@ Build complex sets from simpler ones:
 ```mbt check
 ///|
 test "combining sets" {
-  let small_primes = @hashset.from_array([2, 3, 5, 7])
-  let small_evens = @hashset.from_array([2, 4, 6, 8])
-  let small_odds = @hashset.from_array([1, 3, 5, 7, 9])
+  let small_primes = @hashset.HashSet([2, 3, 5, 7])
+  let small_evens = @hashset.HashSet([2, 4, 6, 8])
+  let small_odds = @hashset.HashSet([1, 3, 5, 7, 9])
 
   // Combine multiple sets
   let all_small = small_primes.union(small_evens).union(small_odds)
@@ -203,7 +203,7 @@ Key differences from mutable sets:
 ///|
 test "immutable vs mutable comparison" {
   // Immutable set - creates new instances
-  let immut_set = @hashset.from_array([1, 2, 3])
+  let immut_set = @hashset.HashSet([1, 2, 3])
   let immut_with_four = immut_set.add(4)
 
   // Both sets exist independently
@@ -223,8 +223,8 @@ More complex set operations:
 ```mbt check
 ///|
 test "advanced operations" {
-  let set1 = @hashset.from_array([1, 2, 3, 4, 5])
-  let set2 = @hashset.from_array([4, 5, 6, 7, 8])
+  let set1 = @hashset.HashSet([1, 2, 3, 4, 5])
+  let set2 = @hashset.HashSet([4, 5, 6, 7, 8])
 
   // Symmetric difference (elements in either but not both)
   let sym_diff = set1.difference(set2).union(set2.difference(set1))
@@ -247,7 +247,7 @@ Immutable sets provide several performance advantages:
 ```mbt check
 ///|
 test "performance benefits" {
-  let base = @hashset.from_array([1, 2, 3, 4, 5])
+  let base = @hashset.HashSet([1, 2, 3, 4, 5])
 
   // Multiple derived sets share structure
   let derived1 = base.add(6)
@@ -286,11 +286,11 @@ test "functional programming style" {
     _numbers : @hashset.HashSet[Int],
   ) -> @hashset.HashSet[Int] {
     // Manually create processed set (no built-in filter/map)
-    let positive_squares = @hashset.from_array([1, 4, 9]) // Squares of 1, 2, 3
+    let positive_squares = @hashset.HashSet([1, 4, 9]) // Squares of 1, 2, 3
     positive_squares.add(1) // Add the number 1 (though 1 already exists)
   }
 
-  let input = @hashset.from_array([-2, -1, 0, 1, 2, 3])
+  let input = @hashset.HashSet([-2, -1, 0, 1, 2, 3])
   let result = process_numbers(input)
 
   // Input unchanged, result is new set
@@ -306,7 +306,7 @@ test "functional programming style" {
 ```mbt check
 ///|
 test "configuration usage" {
-  let base_config = @hashset.from_array(["feature1", "feature2", "feature3"])
+  let base_config = @hashset.HashSet(["feature1", "feature2", "feature3"])
   fn enable_feature(
     config : @hashset.HashSet[String],
     feature : String,

--- a/immut/hashset/debug.mbt
+++ b/immut/hashset/debug.mbt
@@ -28,6 +28,6 @@ pub fn[K : @debug.Debug] HashSet::to_repr(self : HashSet[K]) -> @debug.Repr {
 
 ///|
 test "Debug for HashSet" {
-  let hs : HashSet[Int] = from_array([3])
+  let hs : HashSet[Int] = HashSet([3])
   @debug.debug_inspect(hs, content="<HashSet: [3]>")
 }

--- a/immut/hashset/pkg.generated.mbti
+++ b/immut/hashset/pkg.generated.mbti
@@ -14,13 +14,15 @@ import {
 // Types and methods
 #alias(T, deprecated)
 type HashSet[A] derive(Eq)
+pub fn[A : Eq + Hash] HashSet::HashSet(ArrayView[A]) -> Self[A]
 pub fn[A : Eq + Hash] HashSet::add(Self[A], A) -> Self[A]
 pub fn[A : Eq + Hash] HashSet::contains(Self[A], A) -> Bool
 pub fn[K : Eq] HashSet::difference(Self[K], Self[K]) -> Self[K]
 pub fn[A] HashSet::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[A : Eq + Hash] HashSet::from_array(ArrayView[A]) -> Self[A]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)

--- a/immut/hashset/types.mbt
+++ b/immut/hashset/types.mbt
@@ -23,4 +23,6 @@ priv enum Node[A] {
 
 ///|
 #alias(T, deprecated)
-struct HashSet[A](Node[A]?) derive(Eq)
+struct HashSet[A] {
+  data : Node[A]?
+} derive(Eq)


### PR DESCRIPTION
## Summary

Provide a `@hashset.HashSet([...])` constructor for the immutable hash set (matching `@immut/hashmap.HashMap([...])` / `@list.List([...])`), and deprecate `from_array`.

`HashSet` was a positional newtype `struct HashSet(Node?)`, whose **tuple constructor reserved the `HashSet` name**. Give the field a name instead:

```moonbit
struct HashSet[A] {
  data : Node[A]?
}
```

- Frees the `HashSet` identifier so `HashSet::HashSet(...)` is allowed.
- Keeps the **exact same `Node?` representation** — internal logic unchanged apart from `self.0` → `self.data` and wrapping results in `{ data: .. }`.
- The public type stays **abstract** (field is private); the `.mbti` is unchanged apart from the new constructor.

Then: add `HashSet::HashSet(ArrayView[A]) -> HashSet[A]`, deprecate `from_array` (+ its `of` alias), migrate all usages. The `Show`/`output` format and its snapshot tests intentionally keep emitting `@immut/hashset.from_array([...])`.

Companion to #3759 (same change for `immut/hashmap`).

## Verification

- `moon check --deny-warn --target all` — 0 warnings
- `moon test` — all passing
- `immut/hashset` green on wasm / wasm-gc / js / native (59/59 each)
- `moon fmt` and `moon info` produce no additional diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)