### PR TITLE
feat(immut/sorted_map): add SortedMap constructor, deprecate from_array

### DIFF
--- a/immut/sorted_map/README.mbt.md
+++ b/immut/sorted_map/README.mbt.md
@@ -24,7 +24,7 @@ Also, you can construct it from an array using `of()` or `from_array()`.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   @test.assert_eq(map.values().collect(), [1, 2, 3])
   @test.assert_eq(map.keys_as_iter().collect(), ["a", "b", "c"])
 }
@@ -51,7 +51,7 @@ You can use `remove()` to remove a key-value pair from the map.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let map = map.remove("a")
   @test.assert_eq(map.get("a"), None)
 }
@@ -64,7 +64,7 @@ You can use `contains()` to check whether a key exists.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   @test.assert_eq(map.contains("a"), true)
   @test.assert_eq(map.contains("d"), false)
 }
@@ -77,7 +77,7 @@ You can use `size()` to get the number of key-value pairs in the map.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   @test.assert_eq(map.length(), 3)
 }
 ```
@@ -99,7 +99,7 @@ Use `each()` or `eachi()` to iterate through all key-value pairs.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let arr = []
   map.each((k, v) => arr.push("key:\{k}, value:\{v}"))
   @test.assert_eq(arr, ["key:a, value:1", "key:b, value:2", "key:c, value:3"])
@@ -116,7 +116,7 @@ Use `map()` to map a function over all key-value pairs.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let map = map.map((_, v) => v + 1)
   @test.assert_eq(map.values().collect(), [2, 3, 4])
   let map = map.map((_k, v) => v + 1)
@@ -130,7 +130,7 @@ Pre-order; use `rev_fold()` for a Post-order fold.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   @test.assert_eq(map.fold((acc, _, v) => acc + v, init=0), 6) // 6
   @test.assert_eq(
     map.fold((acc, k, v) => acc + k + v.to_string(), init=""),
@@ -148,7 +148,7 @@ Use `filter()` to filter all key-value pairs that satisfy the predicate.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let map = map.filter((_, v) => v > 1)
   @test.assert_eq(map.values().collect(), [2, 3])
   @test.assert_eq(map.keys_as_iter().collect(), ["b", "c"])
@@ -165,7 +165,7 @@ Use `values()` to get all values in ascending order of their keys.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let values = map.values()
   @test.assert_eq(values.collect(), [1, 2, 3])
 }
@@ -176,7 +176,7 @@ Use `keys()` to get all keys of the map in ascending order.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let keys = map.keys_as_iter() // ["a", "b", "c"]
   @test.assert_eq(keys.collect(), ["a", "b", "c"])
 }
@@ -189,7 +189,7 @@ Use `rev_keys()` to get all keys in descending order.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let keys = map.rev_keys().collect()
   @test.assert_eq(keys, ["c", "b", "a"])
 }
@@ -200,7 +200,7 @@ Use `rev_values()` to get all values in descending order of their keys.
 ```mbt check
 ///|
 test {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let values = map.rev_values().collect()
   @test.assert_eq(values, [3, 2, 1])
 }

--- a/immut/sorted_map/debug.mbt
+++ b/immut/sorted_map/debug.mbt
@@ -34,7 +34,7 @@ pub fn[K : @debug.Debug, V : @debug.Debug] SortedMap::to_repr(
 
 ///|
 test "Debug for SortedMap" {
-  let sm : SortedMap[Int, String] = from_array([(1, "a"), (2, "b")])
+  let sm : SortedMap[Int, String] = SortedMap([(1, "a"), (2, "b")])
   @debug.debug_inspect(
     sm,
     content=(

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -149,8 +149,8 @@ pub fn[K, V] SortedMap::to_array(self : SortedMap[K, V]) -> Array[(K, V)] {
 ///
 /// ```mbt check
 /// test {
-///   let map1 = @sorted_map.from_array([(1, "a"), (2, "b")])
-///   let map2 = @sorted_map.from_array([(2, "c"), (3, "d")])
+///   let map1 = @sorted_map.SortedMap([(1, "a"), (2, "b")])
+///   let map2 = @sorted_map.SortedMap([(2, "c"), (3, "d")])
 ///   let merged = map1.merge(map2)
 ///   debug_inspect(merged.get(1), content="Some(\"a\")")
 ///   debug_inspect(merged.get(2), content="Some(\"c\")")
@@ -299,7 +299,7 @@ fn[K, V] balance(
 
 ///|
 test "from_array" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -314,7 +314,7 @@ test "from_array" {
 
 ///|
 test "insert" {
-  let m = from_array([(3, "three"), (8, "eight"), (1, "one")])
+  let m = SortedMap([(3, "three"), (8, "eight"), (1, "one")])
   inspect(m.debug_tree(), content="(3,three,(1,one,_,_),(8,eight,_,_))")
   let m = m.add(5, "five").add(2, "two").add(0, "zero").add(1, "one_updated")
   inspect(
@@ -325,7 +325,7 @@ test "insert" {
 
 ///|
 test "remove" {
-  let m1 = from_array([
+  let m1 = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -349,7 +349,7 @@ test "remove" {
 
 ///|
 test "contains" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -367,7 +367,7 @@ test "contains" {
 
 ///|
 test "map" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -383,7 +383,7 @@ test "map" {
 
 ///|
 test "map_with_key" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -399,7 +399,7 @@ test "map_with_key" {
 
 ///|
 test "filter" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -412,7 +412,7 @@ test "filter" {
 
 ///|
 test "filter_with_key" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -437,7 +437,7 @@ test "empty" {
 
 ///|
 test "split_max" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -459,7 +459,7 @@ test "split_max" {
 
 ///|
 test "split_min" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (2, "two"),
@@ -481,7 +481,7 @@ test "split_min" {
 
 ///|
 test "glue" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -505,7 +505,7 @@ test "glue" {
 
 ///|
 test "split_max with non-empty tree" {
-  let m = from_array([
+  let m = SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "lookup" {
-  let m = @sorted_map.from_array([
+  let m = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -28,7 +28,7 @@ test "lookup" {
 
 ///|
 test "size" {
-  let m = @sorted_map.from_array([
+  let m = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -50,7 +50,7 @@ test "is_empty" {
 
 ///|
 test "iter" {
-  let m = @sorted_map.from_array([
+  let m = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -64,7 +64,7 @@ test "iter" {
 
 ///|
 test "iteri" {
-  let m = @sorted_map.from_array([
+  let m = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -79,7 +79,7 @@ test "iteri" {
 ///|
 test "iter_take_each" {
   let buf = StringBuilder(size_hint=20)
-  let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let map = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   map
   .iter()
   .each(e => {
@@ -100,7 +100,7 @@ test "iter_take_each" {
 
 ///|
 test "fold" {
-  let m = @sorted_map.from_array([
+  let m = @sorted_map.SortedMap([
     ("a", 1),
     ("b", 2),
     ("c", 3),
@@ -112,7 +112,7 @@ test "fold" {
 
 ///|
 test "foldl_with_key" {
-  let m = @sorted_map.from_array([
+  let m = @sorted_map.SortedMap([
     ("a", 1),
     ("b", 2),
     ("c", 3),
@@ -127,7 +127,7 @@ test "foldl_with_key" {
 
 ///|
 test "foldr_with_key" {
-  let m = @sorted_map.from_array([
+  let m = @sorted_map.SortedMap([
     ("a", 1),
     ("b", 2),
     ("c", 3),
@@ -142,45 +142,45 @@ test "foldr_with_key" {
 
 ///|
 test "collect" {
-  let m = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let m = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   @test.assert_eq(m.iter().collect(), [(1, "one"), (2, "two"), (3, "three")])
 }
 
 ///|
 test "to_array" {
-  let m = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let m = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   @test.assert_eq(m.to_array(), [(1, "one"), (2, "two"), (3, "three")])
 }
 
 ///|
 test "keys" {
-  let m = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let m = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   @test.assert_eq(m.keys_as_iter().collect(), [1, 2, 3])
 }
 
 ///|
 test "values" {
-  let m = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let m = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   @test.assert_eq(m.values().collect(), ["one", "two", "three"])
 }
 
 ///|
 test "equal" {
-  let m1 = @sorted_map.from_array([
+  let m1 = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
     (2, "two"),
     (0, "zero"),
   ])
-  let m2 = @sorted_map.from_array([
+  let m2 = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
     (2, "two"),
     (0, "zero"),
   ])
-  let m3 = @sorted_map.from_array([
+  let m3 = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -203,7 +203,7 @@ test "compare" {
 ///|
 test "iterator" {
   let buf = StringBuilder(size_hint=20)
-  let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let map = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   map
   .iter()
   .each(e => {
@@ -224,7 +224,7 @@ test "iterator" {
 
 ///|
 test "show" {
-  let m = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let m = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   debug_inspect(
     m,
     content=(
@@ -268,19 +268,19 @@ test "from_iter empty iter" {
 
 ///|
 test "hash" {
-  let map1 = @sorted_map.from_array([("one", 1), ("two", 2)])
-  let map2 = @sorted_map.from_array([("one", 1), ("two", 2)])
+  let map1 = @sorted_map.SortedMap([("one", 1), ("two", 2)])
+  let map2 = @sorted_map.SortedMap([("one", 1), ("two", 2)])
   inspect(map1.hash() == map2.hash(), content="true")
-  let map3 = @sorted_map.from_array([("two", 2), ("one", 1)])
+  let map3 = @sorted_map.SortedMap([("two", 2), ("one", 1)])
   inspect(map1.hash() == map3.hash(), content="true")
-  let map4 = @sorted_map.from_array([("one", 1), ("two", 2), ("three", 3)])
+  let map4 = @sorted_map.SortedMap([("one", 1), ("two", 2), ("three", 3)])
   inspect(map1.hash() == map4.hash(), content="false")
 }
 
 ///|
 test "@immut/sorted_map.merge" {
-  let map1 = @sorted_map.from_array([(1, "a"), (2, "b")])
-  let map2 = @sorted_map.from_array([(2, "c"), (3, "d")])
+  let map1 = @sorted_map.SortedMap([(1, "a"), (2, "b")])
+  let map2 = @sorted_map.SortedMap([(2, "c"), (3, "d")])
   let merged = map1.merge(map2)
   debug_inspect(merged.get(1), content="Some(\"a\")")
   debug_inspect(merged.get(2), content="Some(\"c\")")
@@ -294,7 +294,7 @@ test "@immut/sorted_map.merge" {
 ///|
 test "@immut/sorted_map.merge empty maps" {
   let map1 : @sorted_map.SortedMap[Int, String] = @sorted_map.new()
-  let map2 = @sorted_map.from_array([(1, "a"), (2, "b")])
+  let map2 = @sorted_map.SortedMap([(1, "a"), (2, "b")])
   let merged1 = map1.merge(map2)
   debug_inspect(merged1.to_array(), content="[(1, \"a\"), (2, \"b\")]")
   let merged2 = map2.merge(map1)
@@ -305,8 +305,8 @@ test "@immut/sorted_map.merge empty maps" {
 
 ///|
 test "@immut/sorted_map.merge with overlapping keys" {
-  let map1 = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
-  let map2 = @sorted_map.from_array([(2, "TWO"), (3, "THREE"), (4, "FOUR")])
+  let map1 = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
+  let map2 = @sorted_map.SortedMap([(2, "TWO"), (3, "THREE"), (4, "FOUR")])
   let merged = map1.merge(map2)
   debug_inspect(merged.get(1), content="Some(\"one\")")
   debug_inspect(merged.get(2), content="Some(\"TWO\")")

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -15,6 +15,7 @@ import {
 // Types and methods
 #alias(T, deprecated)
 type SortedMap[K, V]
+pub fn[K : Compare, V] SortedMap::SortedMap(ArrayView[(K, V)]) -> Self[K, V]
 #alias(insert, deprecated)
 pub fn[K : Compare, V] SortedMap::add(Self[K, V], K, V) -> Self[K, V]
 #alias("_[_]")
@@ -30,7 +31,8 @@ pub fn[K, V] SortedMap::filter(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] 
 pub fn[K, V, A] SortedMap::fold(Self[K, V], (A, K, V) -> A, init~ : A) -> A
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
-#as_free_fn
+#as_free_fn(deprecated)
+#deprecated
 pub fn[K : Compare, V] SortedMap::from_array(ArrayView[(K, V)]) -> Self[K, V]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)

--- a/immut/sorted_map/traits_impl.mbt
+++ b/immut/sorted_map/traits_impl.mbt
@@ -55,7 +55,7 @@ pub impl[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] @quickc
   K,
   V,
 ] with fn arbitrary(size, rs) {
-  @quickcheck.Arbitrary::arbitrary(size, rs) |> from_array
+  @quickcheck.Arbitrary::arbitrary(size, rs) |> SortedMap
 }
 
 ///|

--- a/immut/sorted_map/types.mbt
+++ b/immut/sorted_map/types.mbt
@@ -25,7 +25,7 @@
 ///
 /// ```mbt check
 /// test {
-///   let map1 = @sorted_map.from_array([(3, "three"), (8, "eight"), (1, "one")])
+///   let map1 = @sorted_map.SortedMap([(3, "three"), (8, "eight"), (1, "one")])
 ///   let map2 = map1.add(2, "two").remove(3)
 ///   @test.assert_eq(map2.get(2), Some("two"))
 ///   let map3 = map2.add(2, "updated")

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -229,10 +229,35 @@ fn[K : Show, V : Show] SortedMap::debug_tree(self : SortedMap[K, V]) -> String {
 ///|
 /// Build a map from an array of key-value pairs.
 /// O(n*log n).
-#as_free_fn
-#alias(of, deprecated="Use from_array instead")
-#as_free_fn(of, deprecated="Use from_array instead")
+#as_free_fn(deprecated="Use @immut/sorted_map.SortedMap([...]) instead")
+#alias(of, deprecated="Use @immut/sorted_map.SortedMap([...]) instead")
+#as_free_fn(of, deprecated="Use @immut/sorted_map.SortedMap([...]) instead")
+#deprecated("Use @immut/sorted_map.SortedMap([...]) instead")
 pub fn[K : Compare, V] SortedMap::from_array(
+  array : ArrayView[(K, V)],
+) -> SortedMap[K, V] {
+  for item in array; mp = Empty {
+    let (k, v) = item
+    continue mp.add(k, v)
+  } nobreak {
+    mp
+  }
+}
+
+///|
+/// Build a map from an array of key-value pairs.
+/// O(n*log n).
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let m = @sorted_map.SortedMap([(3, "c"), (1, "a"), (2, "b")])
+///   @test.assert_eq(m.get(1), Some("a"))
+///   @test.assert_eq(m.get(3), Some("c"))
+/// }
+/// ```
+pub fn[K : Compare, V] SortedMap::SortedMap(
   array : ArrayView[(K, V)],
 ) -> SortedMap[K, V] {
   for item in array; mp = Empty {
@@ -313,7 +338,7 @@ pub fn[K, V] SortedMap::iter2(self : SortedMap[K, V]) -> Iter2[K, V] {
 ///
 /// ```mbt check
 /// test {
-///   let map = @sorted_map.from_array([
+///   let map = @sorted_map.SortedMap([
 ///     (1, "a"),
 ///     (2, "b"),
 ///     (3, "c"),
@@ -394,7 +419,7 @@ pub fn[K, V] SortedMap::values(self : SortedMap[K, V]) -> Iter[V] {
 ///
 /// ```mbt check
 /// test {
-///   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+///   let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
 ///   let keys = map.rev_keys().collect()
 ///   @test.assert_eq(keys, ["c", "b", "a"])
 /// }
@@ -432,7 +457,7 @@ pub fn[K, V] SortedMap::rev_keys(self : SortedMap[K, V]) -> Iter[K] {
 /// # Example
 ///
 /// ```mbt nocheck
-///   let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+///   let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
 ///   let values = map.rev_values().collect()
 ///   @test.assert_eq(values, [3, 2, 1])
 /// ```

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "get with existing key" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -26,7 +26,7 @@ test "get with existing key" {
 
 ///|
 test "_[_] with existing key" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -38,7 +38,7 @@ test "_[_] with existing key" {
 
 ///|
 test "get with non-existing key" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -50,7 +50,7 @@ test "get with non-existing key" {
 
 ///|
 test "get with pattern" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -63,7 +63,7 @@ test "get with pattern" {
 
 ///|
 test "get after insertion" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -76,7 +76,7 @@ test "get after insertion" {
 
 ///|
 test "_[_] after insertion" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -89,7 +89,7 @@ test "_[_] after insertion" {
 
 ///|
 test "get after removal" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -102,7 +102,7 @@ test "get after removal" {
 
 ///|
 test "panic get with non-existing key" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -114,7 +114,7 @@ test "panic get with non-existing key" {
 
 ///|
 test "panic get after removal" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -128,7 +128,7 @@ test "panic get after removal" {
 ///|
 test "iter" {
   let map = [(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")]
-    |> @sorted_map.from_array
+    |> @sorted_map.SortedMap
   let buf = StringBuilder()
   for k, v in map {
     buf.write_object(k)
@@ -173,7 +173,7 @@ test "panic get with empty map" {
 ///|
 test "to_json with non-empty map" {
   let map = [(3, "three"), (8, "eight"), (1, "one"), (2, "two"), (0, "zero")]
-    |> @sorted_map.from_array
+    |> @sorted_map.SortedMap
   @json.json_inspect(map.to_json(), content={
     "0": "zero",
     "1": "one",
@@ -205,20 +205,20 @@ test "default" {
 
 ///|
 test "iter2" {
-  let map = @sorted_map.from_array([(2, "two"), (1, "one")])
+  let map = @sorted_map.SortedMap([(2, "two"), (1, "one")])
   debug_inspect(map.iter2().to_array(), content="[(1, \"one\"), (2, \"two\")]")
 }
 
 ///|
 test "rev_keys returns keys in descending order" {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let keys = map.rev_keys().collect()
   debug_inspect(keys, content="[\"c\", \"b\", \"a\"]")
 }
 
 ///|
 test "rev_values returns values in descending key order" {
-  let map = @sorted_map.from_array([("a", 1), ("b", 2), ("c", 3)])
+  let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let values = map.rev_values().collect()
   debug_inspect(values, content="[3, 2, 1]")
 }
@@ -251,21 +251,21 @@ test "rev_values on single element map" {
 
 ///|
 test "rev_keys early termination" {
-  let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let map = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   let result = map.rev_keys().take(2).collect()
   debug_inspect(result, content="[3, 2]")
 }
 
 ///|
 test "rev_values early termination" {
-  let map = @sorted_map.from_array([(1, "one"), (2, "two"), (3, "three")])
+  let map = @sorted_map.SortedMap([(1, "one"), (2, "two"), (3, "three")])
   let result = map.rev_values().take(2).collect()
   debug_inspect(result, content="[\"three\", \"two\"]")
 }
 
 ///|
 test "rev_keys is reverse of keys" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -288,7 +288,7 @@ test "rev_keys is reverse of keys (quickcheck)" {
 
 ///|
 test "rev_values is reverse of values" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (3, "three"),
     (8, "eight"),
     (1, "one"),
@@ -302,7 +302,7 @@ test "rev_values is reverse of values" {
 
 ///|
 test "rev_keys with complex tree" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (15, "15"),
     (10, "10"),
     (20, "20"),
@@ -317,7 +317,7 @@ test "rev_keys with complex tree" {
 
 ///|
 test "rev_values with complex tree" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (15, "15"),
     (10, "10"),
     (20, "20"),
@@ -346,7 +346,7 @@ test "range on empty map" {
 
 ///|
 test "range with no matches" {
-  let map = @sorted_map.from_array([(1, "a"), (2, "b"), (3, "c")])
+  let map = @sorted_map.SortedMap([(1, "a"), (2, "b"), (3, "c")])
   let count = for _, _ in map.range(low=10, high=20); count = 0 {
     continue count + 1
   } nobreak {
@@ -357,7 +357,7 @@ test "range with no matches" {
 
 ///|
 test "range matching all elements" {
-  let map = @sorted_map.from_array([(1, "a"), (2, "b"), (3, "c")])
+  let map = @sorted_map.SortedMap([(1, "a"), (2, "b"), (3, "c")])
   let buf = StringBuilder()
   for k, v in map.range(low=0, high=10) {
     buf.write_string("[\{k},\{v}]")
@@ -367,7 +367,7 @@ test "range matching all elements" {
 
 ///|
 test "range partial match" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (1, "a"),
     (2, "b"),
     (3, "c"),
@@ -383,7 +383,7 @@ test "range partial match" {
 
 ///|
 test "range with single element" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (1, "a"),
     (2, "b"),
     (3, "c"),
@@ -399,7 +399,7 @@ test "range with single element" {
 
 ///|
 test "range at left boundary" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (1, "a"),
     (2, "b"),
     (3, "c"),
@@ -415,7 +415,7 @@ test "range at left boundary" {
 
 ///|
 test "range at right boundary" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (1, "a"),
     (2, "b"),
     (3, "c"),
@@ -431,7 +431,7 @@ test "range at right boundary" {
 
 ///|
 test "range with gaps in data" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (1, "a"),
     (3, "c"),
     (5, "e"),
@@ -447,7 +447,7 @@ test "range with gaps in data" {
 
 ///|
 test "range with inverted bounds" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (1, "a"),
     (2, "b"),
     (3, "c"),
@@ -464,7 +464,7 @@ test "range with inverted bounds" {
 
 ///|
 test "range with early termination" {
-  let map = @sorted_map.from_array([
+  let map = @sorted_map.SortedMap([
     (1, "a"),
     (2, "b"),
     (3, "c"),
@@ -486,7 +486,7 @@ test "range with early termination" {
 ///|
 test "range on large dataset" {
   let arr = Array::makei(100, fn(i) { (i, "val\{i}") })
-  let map = @sorted_map.from_array(arr)
+  let map = @sorted_map.SortedMap(arr)
   let count = for _, _ in map.range(low=25, high=75); count = 0 {
     continue count + 1
   } nobreak {
@@ -497,7 +497,7 @@ test "range on large dataset" {
 
 ///|
 test "range with non-existent boundaries" {
-  let map = @sorted_map.from_array([(2, "b"), (4, "d"), (6, "f"), (8, "h")])
+  let map = @sorted_map.SortedMap([(2, "b"), (4, "d"), (6, "f"), (8, "h")])
   let buf = StringBuilder()
   for k, v in map.range(low=3, high=7) {
     buf.write_string("[\{k},\{v}]")


### PR DESCRIPTION
## Summary

Add a `@sorted_map.SortedMap([...])` constructor for the immutable sorted map (matching `@list.List([...])` / `@sorted_set.SortedSet([...])`), and deprecate `from_array`.

`SortedMap` is an `enum` (`Empty` / `Tree`), so there is no constructor-name conflict — this is a clean, `List`-style change (no struct surgery needed).

- Add `SortedMap::SortedMap(ArrayView[(K, V)]) -> SortedMap[K, V]`.
- Deprecate `from_array` (+ its `of` alias).
- Migrate all usages across impl/tests/README. The `Show`/`output` format and its snapshot tests intentionally keep emitting `@immut/sorted_map.from_array([...])`.

Found via a repo-wide scan for collections that have `from_array` but no `Type([...])` constructor (companion to #3759 / #3760 / #3757).

## Verification

- `moon check --deny-warn --target all` — 0 warnings
- `moon test` — all passing
- `immut/sorted_map` green on wasm / wasm-gc / js / native (105/105, native 103/103)
- `moon fmt` and `moon info` produce no additional diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)