### PR TITLE
perf(v128): optimize packed loads and truth checks

### DIFF
--- a/v128/lanes.mbt
+++ b/v128/lanes.mbt
@@ -79,6 +79,41 @@ fn pack_u64x2_by(f : (Int) -> UInt64) -> V128 {
 }
 
 ///|
+fn widen_u8x4_to_u16x4(value : UInt64) -> UInt64 {
+  (value & 0xffUL) |
+  ((value & 0xff00UL) << 8) |
+  ((value & 0xff0000UL) << 16) |
+  ((value & 0xff000000UL) << 24)
+}
+
+///|
+fn sign_extend_u8x4_to_u16x4(value : UInt64) -> UInt64 {
+  let value = widen_u8x4_to_u16x4(value)
+  value | (((value & 0x0080008000800080UL) << 1) * 0xffUL)
+}
+
+///|
+fn widen_u16x2_to_u32x2(value : UInt64) -> UInt64 {
+  (value & 0xffffUL) | ((value & 0xffff0000UL) << 16)
+}
+
+///|
+fn sign_extend_u16x2_to_u32x2(value : UInt64) -> UInt64 {
+  let value = widen_u16x2_to_u32x2(value)
+  value | (((value & 0x0000800000008000UL) << 1) * 0xffffUL)
+}
+
+///|
+fn sign_extend_u32_to_u64(value : UInt64) -> UInt64 {
+  let value = value & 0xffffffffUL
+  if (value & 0x80000000UL) != 0UL {
+    value | 0xffffffff00000000UL
+  } else {
+    value
+  }
+}
+
+///|
 fn i8_signed(value : Byte) -> Int {
   let value = value.to_int()
   if value >= 128 {

--- a/v128/moon.pkg
+++ b/v128/moon.pkg
@@ -5,3 +5,7 @@ import {
   "moonbitlang/core/int16",
   "moonbitlang/core/int64",
 }
+
+import {
+  "moonbitlang/core/bench",
+} for "test"

--- a/v128/simd_basic.mbt
+++ b/v128/simd_basic.mbt
@@ -314,15 +314,14 @@ pub fn f64x2_extract_lane(value : V128, lane : Int) -> Double {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn i8x16_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 {
+  guard lane >= 0 && lane < 16 else { return value }
   let shift = (lane & 7) * 8
   let mask = 0xffUL << shift
   let bits = (replacement.to_uint64() & 0xffUL) << shift
-  if lane >= 0 && lane < 8 {
+  if lane < 8 {
     make((lo(value) & mask.lnot()) | bits, hi(value))
-  } else if lane >= 8 && lane < 16 {
-    make(lo(value), (hi(value) & mask.lnot()) | bits)
   } else {
-    value
+    make(lo(value), (hi(value) & mask.lnot()) | bits)
   }
 }
 
@@ -332,15 +331,14 @@ pub fn i8x16_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn i16x8_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 {
+  guard lane >= 0 && lane < 8 else { return value }
   let shift = (lane & 3) * 16
   let mask = 0xffffUL << shift
   let bits = (replacement.to_uint64() & 0xffffUL) << shift
-  if lane >= 0 && lane < 4 {
+  if lane < 4 {
     make((lo(value) & mask.lnot()) | bits, hi(value))
-  } else if lane >= 4 && lane < 8 {
-    make(lo(value), (hi(value) & mask.lnot()) | bits)
   } else {
-    value
+    make(lo(value), (hi(value) & mask.lnot()) | bits)
   }
 }
 
@@ -350,15 +348,14 @@ pub fn i16x8_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn i32x4_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 {
+  guard lane >= 0 && lane < 4 else { return value }
   let shift = (lane & 1) * 32
   let mask = 0xffffffffUL << shift
   let bits = replacement.to_uint64() << shift
-  if lane >= 0 && lane < 2 {
+  if lane < 2 {
     make((lo(value) & mask.lnot()) | bits, hi(value))
-  } else if lane >= 2 && lane < 4 {
-    make(lo(value), (hi(value) & mask.lnot()) | bits)
   } else {
-    value
+    make(lo(value), (hi(value) & mask.lnot()) | bits)
   }
 }
 

--- a/v128/simd_int_shift.mbt
+++ b/v128/simd_int_shift.mbt
@@ -13,6 +13,17 @@
 // limitations under the License.
 
 ///|
+fn has_zero_byte(value : UInt64) -> Bool {
+  ((value - 0x0101010101010101UL) & value.lnot() & 0x8080808080808080UL) != 0UL
+}
+
+///|
+fn has_zero_u16_lane(value : UInt64) -> Bool {
+  let bytes = value | (value >> 8) | 0xff00ff00ff00ff00UL
+  has_zero_byte(bytes)
+}
+
+///|
 /// Lane-wise left shift over sixteen 8-bit integer lanes by `shift` (modulo lane width).
 #intrinsic("%v128.i8x16_shl")
 #internal(experimental, "subject to breaking change without notice")
@@ -142,12 +153,7 @@ pub fn i64x2_shr_s(value : V128, shift : Int) -> V128 {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn i8x16_all_true(value : V128) -> Bool {
-  for i in 0..<16 {
-    if u8_lane(value, i) == 0 {
-      return false
-    }
-  }
-  true
+  !has_zero_byte(lo(value)) && !has_zero_byte(hi(value))
 }
 
 ///|
@@ -156,12 +162,7 @@ pub fn i8x16_all_true(value : V128) -> Bool {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn i16x8_all_true(value : V128) -> Bool {
-  for i in 0..<8 {
-    if u16_lane(value, i) == 0 {
-      return false
-    }
-  }
-  true
+  !has_zero_u16_lane(lo(value)) && !has_zero_u16_lane(hi(value))
 }
 
 ///|
@@ -170,12 +171,12 @@ pub fn i16x8_all_true(value : V128) -> Bool {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn i32x4_all_true(value : V128) -> Bool {
-  for i in 0..<4 {
-    if u32_lane(value, i) == 0 {
-      return false
-    }
-  }
-  true
+  let lo_word = lo(value)
+  let hi_word = hi(value)
+  (lo_word & 0xffffffffUL) != 0UL &&
+  lo_word >> 32 != 0UL &&
+  (hi_word & 0xffffffffUL) != 0UL &&
+  hi_word >> 32 != 0UL
 }
 
 ///|

--- a/v128/simd_memory.mbt
+++ b/v128/simd_memory.mbt
@@ -65,21 +65,6 @@ fn store_u64_le(bytes : FixedArray[Byte], offset : Int, value : UInt64) -> Unit 
 }
 
 ///|
-fn i8_extend_s(value : Byte) -> UInt16 {
-  i8_signed(value).to_uint16()
-}
-
-///|
-fn i16_extend_s(value : UInt16) -> UInt {
-  i16_signed(value).reinterpret_as_uint()
-}
-
-///|
-fn i32_extend_s(value : UInt) -> UInt64 {
-  value.reinterpret_as_int().to_int64().reinterpret_as_uint64()
-}
-
-///|
 /// Selects bytes of `value` indexed by `indices`; indices >= 16 yield zero.
 #intrinsic("%v128.i8x16_swizzle")
 #internal(experimental, "subject to breaking change without notice")
@@ -177,7 +162,8 @@ pub fn v128_load(bytes : FixedArray[Byte], offset : Int) -> V128 {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn v128_load8x8_s(bytes : FixedArray[Byte], offset : Int) -> V128 {
-  pack_u16x8_by(i => i8_extend_s(bytes.unsafe_get(offset + i)))
+  let value = load_u64_le(bytes, offset)
+  make(sign_extend_u8x4_to_u16x4(value), sign_extend_u8x4_to_u16x4(value >> 32))
 }
 
 ///|
@@ -187,7 +173,8 @@ pub fn v128_load8x8_s(bytes : FixedArray[Byte], offset : Int) -> V128 {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn v128_load8x8_u(bytes : FixedArray[Byte], offset : Int) -> V128 {
-  pack_u16x8_by(i => bytes.unsafe_get(offset + i).to_uint16())
+  let value = load_u64_le(bytes, offset)
+  make(widen_u8x4_to_u16x4(value), widen_u8x4_to_u16x4(value >> 32))
 }
 
 ///|
@@ -197,7 +184,11 @@ pub fn v128_load8x8_u(bytes : FixedArray[Byte], offset : Int) -> V128 {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn v128_load16x4_s(bytes : FixedArray[Byte], offset : Int) -> V128 {
-  pack_u32x4_by(i => i16_extend_s(load_u16_le(bytes, offset + i * 2)))
+  let value = load_u64_le(bytes, offset)
+  make(
+    sign_extend_u16x2_to_u32x2(value),
+    sign_extend_u16x2_to_u32x2(value >> 32),
+  )
 }
 
 ///|
@@ -207,7 +198,8 @@ pub fn v128_load16x4_s(bytes : FixedArray[Byte], offset : Int) -> V128 {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn v128_load16x4_u(bytes : FixedArray[Byte], offset : Int) -> V128 {
-  pack_u32x4_by(i => load_u16_le(bytes, offset + i * 2).to_uint())
+  let value = load_u64_le(bytes, offset)
+  make(widen_u16x2_to_u32x2(value), widen_u16x2_to_u32x2(value >> 32))
 }
 
 ///|
@@ -217,7 +209,8 @@ pub fn v128_load16x4_u(bytes : FixedArray[Byte], offset : Int) -> V128 {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn v128_load32x2_s(bytes : FixedArray[Byte], offset : Int) -> V128 {
-  pack_u64x2_by(i => i32_extend_s(load_u32_le(bytes, offset + i * 4)))
+  let value = load_u64_le(bytes, offset)
+  make(sign_extend_u32_to_u64(value), sign_extend_u32_to_u64(value >> 32))
 }
 
 ///|
@@ -227,7 +220,8 @@ pub fn v128_load32x2_s(bytes : FixedArray[Byte], offset : Int) -> V128 {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn v128_load32x2_u(bytes : FixedArray[Byte], offset : Int) -> V128 {
-  pack_u64x2_by(i => load_u32_le(bytes, offset + i * 4).to_uint64())
+  let value = load_u64_le(bytes, offset)
+  make(value & 0xffffffffUL, value >> 32)
 }
 
 ///|

--- a/v128/simd_memory.mbt
+++ b/v128/simd_memory.mbt
@@ -28,11 +28,14 @@ fn load_u32_le(bytes : FixedArray[Byte], offset : Int) -> UInt {
 
 ///|
 fn load_u64_le(bytes : FixedArray[Byte], offset : Int) -> UInt64 {
-  let mut result = 0UL
-  for i in 0..<8 {
-    result = result | (bytes.unsafe_get(offset + i).to_uint64() << (i * 8))
-  }
-  result
+  bytes.unsafe_get(offset).to_uint64() |
+  (bytes.unsafe_get(offset + 1).to_uint64() << 8) |
+  (bytes.unsafe_get(offset + 2).to_uint64() << 16) |
+  (bytes.unsafe_get(offset + 3).to_uint64() << 24) |
+  (bytes.unsafe_get(offset + 4).to_uint64() << 32) |
+  (bytes.unsafe_get(offset + 5).to_uint64() << 40) |
+  (bytes.unsafe_get(offset + 6).to_uint64() << 48) |
+  (bytes.unsafe_get(offset + 7).to_uint64() << 56)
 }
 
 ///|
@@ -51,9 +54,14 @@ fn store_u32_le(bytes : FixedArray[Byte], offset : Int, value : UInt) -> Unit {
 
 ///|
 fn store_u64_le(bytes : FixedArray[Byte], offset : Int, value : UInt64) -> Unit {
-  for i in 0..<8 {
-    bytes.unsafe_set(offset + i, (value >> (i * 8)).to_byte())
-  }
+  bytes.unsafe_set(offset, value.to_byte())
+  bytes.unsafe_set(offset + 1, (value >> 8).to_byte())
+  bytes.unsafe_set(offset + 2, (value >> 16).to_byte())
+  bytes.unsafe_set(offset + 3, (value >> 24).to_byte())
+  bytes.unsafe_set(offset + 4, (value >> 32).to_byte())
+  bytes.unsafe_set(offset + 5, (value >> 40).to_byte())
+  bytes.unsafe_set(offset + 6, (value >> 48).to_byte())
+  bytes.unsafe_set(offset + 7, (value >> 56).to_byte())
 }
 
 ///|

--- a/v128/v128_bench_test.mbt
+++ b/v128/v128_bench_test.mbt
@@ -1,0 +1,132 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let v128_bench_size = 10_000
+
+///|
+fn make_v128_bench_values() -> Array[V128] {
+  Array::makei(v128_bench_size, i => {
+    let x = i.to_uint64()
+    @v128.i64x2_const(x * 0x0000000000010001UL, x * 0x0000000100000001UL)
+  })
+}
+
+///|
+fn make_v128_bench_bytes() -> FixedArray[Byte] {
+  FixedArray::makei(v128_bench_size + 80, i => (i & 0xff).to_byte())
+}
+
+///|
+test "bench V128 i64x2_add n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(1UL, 2UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i64x2_add(acc, values.unsafe_get(i))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 i32x4_add n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut acc = @v128.i32x4_const(1, 2, 3, 4)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i32x4_add(acc, values.unsafe_get(i))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 i8x16_add n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut acc = @v128.i8x16_splat(1)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i8x16_add(acc, values.unsafe_get(i))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 i8x16_splat n=10000" (it : @bench.T) {
+  it.bench(fn() {
+    let mut acc = @v128.i8x16_splat(0)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i8x16_add(acc, @v128.i8x16_splat((i & 0xff).to_byte()))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 i8x16_extract_lane_u n=10000" (it : @bench.T) {
+  let value = @v128.i8x16_const(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+  )
+  it.bench(fn() {
+    let mut sum = 0
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      sum = sum + @v128.i8x16_extract_lane_u(value, i & 15).reinterpret_as_int()
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench V128 i8x16_replace_lane n=10000" (it : @bench.T) {
+  it.bench(fn() {
+    let mut acc = @v128.i8x16_splat(0)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i8x16_replace_lane(
+        acc,
+        (i & 0xff).reinterpret_as_uint(),
+        i & 15,
+      )
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 i8x16_bitmask n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut sum = 0
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      sum = sum + @v128.i8x16_bitmask(values.unsafe_get(i))
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench V128 load/store n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let offset = i & 63
+      let value = @v128.v128_load(bytes, offset)
+      acc = @v128.i64x2_add(acc, value)
+      @v128.v128_store(bytes, offset, acc)
+    }
+    it.keep(acc)
+  })
+}

--- a/v128/v128_bench_test.mbt
+++ b/v128/v128_bench_test.mbt
@@ -130,3 +130,257 @@ test "bench V128 load/store n=10000" (it : @bench.T) {
     it.keep(acc)
   })
 }
+
+///|
+test "bench V128 load8x8_u n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i64x2_add(acc, @v128.v128_load8x8_u(bytes, i & 63))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load8x8_s n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i64x2_add(acc, @v128.v128_load8x8_s(bytes, i & 63))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load16x4_u n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i64x2_add(acc, @v128.v128_load16x4_u(bytes, i & 63))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load16x4_s n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i64x2_add(acc, @v128.v128_load16x4_s(bytes, i & 63))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load32x2_u n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i64x2_add(acc, @v128.v128_load32x2_u(bytes, i & 63))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load32x2_s n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i64x2_add(acc, @v128.v128_load32x2_s(bytes, i & 63))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load_splat n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let offset = i & 63
+      acc = @v128.i64x2_add(acc, @v128.v128_load8_splat(bytes, offset))
+      acc = @v128.i64x2_add(acc, @v128.v128_load16_splat(bytes, offset))
+      acc = @v128.i64x2_add(acc, @v128.v128_load32_splat(bytes, offset))
+      acc = @v128.i64x2_add(acc, @v128.v128_load64_splat(bytes, offset))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load8_lane n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.v128_load8_lane(bytes, i & 63, acc, i & 15)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load16_lane n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.v128_load16_lane(bytes, i & 63, acc, i & 7)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load32_lane n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.v128_load32_lane(bytes, i & 63, acc, i & 3)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 load64_lane n=10000" (it : @bench.T) {
+  let bytes = make_v128_bench_bytes()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.v128_load64_lane(bytes, i & 63, acc, i & 1)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 extend i8x16 to i16x8 n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let value = values.unsafe_get(i)
+      acc = @v128.i64x2_add(acc, @v128.i16x8_extend_low_i8x16_s(value))
+      acc = @v128.i64x2_add(acc, @v128.i16x8_extend_high_i8x16_u(value))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 extend i16x8 to i32x4 n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let value = values.unsafe_get(i)
+      acc = @v128.i64x2_add(acc, @v128.i32x4_extend_low_i16x8_s(value))
+      acc = @v128.i64x2_add(acc, @v128.i32x4_extend_high_i16x8_u(value))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 extend i32x4 to i64x2 n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let value = values.unsafe_get(i)
+      acc = @v128.i64x2_add(acc, @v128.i64x2_extend_low_i32x4_s(value))
+      acc = @v128.i64x2_add(acc, @v128.i64x2_extend_high_i32x4_u(value))
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 all_true n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut count = 0
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let value = values.unsafe_get(i)
+      if @v128.i8x16_all_true(value) {
+        count = count + 1
+      }
+      if @v128.i16x8_all_true(value) {
+        count = count + 1
+      }
+      if @v128.i32x4_all_true(value) {
+        count = count + 1
+      }
+      if @v128.i64x2_all_true(value) {
+        count = count + 1
+      }
+    }
+    it.keep(count)
+  })
+}
+
+///|
+test "bench V128 bitmask all widths n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut sum = 0
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let value = values.unsafe_get(i)
+      sum = sum + @v128.i8x16_bitmask(value)
+      sum = sum + @v128.i16x8_bitmask(value)
+      sum = sum + @v128.i32x4_bitmask(value)
+      sum = sum + @v128.i64x2_bitmask(value)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench V128 swizzle n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  let indices = @v128.i8x16_const(
+    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+  )
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      acc = @v128.i8x16_add(
+        acc,
+        @v128.i8x16_swizzle(values.unsafe_get(i), indices),
+      )
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench V128 shuffle n=10000" (it : @bench.T) {
+  let values = make_v128_bench_values()
+  it.bench(fn() {
+    let mut acc = @v128.i64x2_const(0UL, 0UL)
+    for i = 0; i < v128_bench_size; i = i + 1 {
+      let value = values.unsafe_get(i)
+      acc = @v128.i8x16_add(
+        acc,
+        @v128.i8x16_shuffle(
+          value, acc, 0, 17, 2, 19, 4, 21, 6, 23, 8, 25, 10, 27, 12, 29, 14, 31,
+        ),
+      )
+    }
+    it.keep(acc)
+  })
+}

--- a/v128/v128_test.mbt
+++ b/v128/v128_test.mbt
@@ -218,20 +218,30 @@ test "integer masks and truth tests" {
   inspect(@v128.i8x16_bitmask(bytes), content="32773")
   assert_false(@v128.i8x16_all_true(bytes))
   assert_true(@v128.i8x16_all_true(@v128.i8x16_splat(1)))
+  assert_false(
+    @v128.i8x16_all_true(
+      @v128.i8x16_const(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0),
+    ),
+  )
 
   let words = @v128.i16x8_const(0x8000, 0, 1, 2, 3, 4, 0xffff, 0x7fff)
   inspect(@v128.i16x8_bitmask(words), content="65")
   assert_false(@v128.i16x8_all_true(words))
   assert_true(@v128.i16x8_all_true(@v128.i16x8_splat(1)))
+  assert_false(@v128.i16x8_all_true(@v128.i16x8_const(1, 2, 3, 4, 5, 6, 7, 0)))
 
   inspect(
     @v128.i32x4_bitmask(@v128.i32x4_const(0x80000000, 0, 0xffffffff, 1)),
     content="5",
   )
+  assert_false(@v128.i32x4_all_true(@v128.i32x4_const(1, 2, 3, 0)))
+  assert_true(@v128.i32x4_all_true(@v128.i32x4_splat(1)))
   inspect(
     @v128.i64x2_bitmask(@v128.i64x2_const(0x8000000000000000UL, 1UL)),
     content="1",
   )
+  assert_false(@v128.i64x2_all_true(@v128.i64x2_const(1UL, 0UL)))
+  assert_true(@v128.i64x2_all_true(@v128.i64x2_splat(1UL)))
 }
 
 ///|


### PR DESCRIPTION
## Summary
- add v128 microbenchmarks for arithmetic, loads, lane loads, extension, masks, swizzle, and shuffle paths
- optimize v128 load/store helpers and packed load sign/zero extension by widening from 64-bit reads
- speed up all_true checks with word-level zero-lane detection and add edge-case tests

## Benchmarks
Measured with `moon bench -p v128 --release`.

- `load/store n=10000`: 128.95 us -> about 90 us
- `load8x8_u n=10000`: 82.22 us -> 26.86 us
- `load8x8_s n=10000`: 194.45 us -> 33.03 us
- `load16x4_u n=10000`: 75.81 us -> 24.05 us
- `load16x4_s n=10000`: 88.14 us -> 27.35 us
- `load32x2_u n=10000`: 49.16 us -> 23.49 us
- `load32x2_s n=10000`: 54.35 us -> 24.48 us
- `all_true` all widths: 11.06 us -> 9.83 us

## Validation
- `moon fmt`
- `moon test -p v128`
- `moon bench -p v128 --release`
- `moon check`
- `moon info`
- `moon test` (6645 passed)
