### PR TITLE
refactor(v128): not use method

### DIFF
--- a/v128/simd_basic.mbt
+++ b/v128/simd_basic.mbt
@@ -240,8 +240,7 @@ pub fn f64x2_splat(value : Double) -> V128 {
 #intrinsic("%v128.i8x16_extract_lane_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_extract_lane_u(value : V128, lane : Int) -> UInt {
+pub fn i8x16_extract_lane_u(value : V128, lane : Int) -> UInt {
   u8_lane(value, lane).to_uint()
 }
 
@@ -250,8 +249,7 @@ pub fn V128::i8x16_extract_lane_u(value : V128, lane : Int) -> UInt {
 #intrinsic("%v128.i8x16_extract_lane_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_extract_lane_s(value : V128, lane : Int) -> UInt {
+pub fn i8x16_extract_lane_s(value : V128, lane : Int) -> UInt {
   i8_signed(u8_lane(value, lane)).reinterpret_as_uint()
 }
 
@@ -260,8 +258,7 @@ pub fn V128::i8x16_extract_lane_s(value : V128, lane : Int) -> UInt {
 #intrinsic("%v128.i16x8_extract_lane_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extract_lane_u(value : V128, lane : Int) -> UInt {
+pub fn i16x8_extract_lane_u(value : V128, lane : Int) -> UInt {
   u16_lane(value, lane).to_uint()
 }
 
@@ -270,8 +267,7 @@ pub fn V128::i16x8_extract_lane_u(value : V128, lane : Int) -> UInt {
 #intrinsic("%v128.i16x8_extract_lane_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extract_lane_s(value : V128, lane : Int) -> UInt {
+pub fn i16x8_extract_lane_s(value : V128, lane : Int) -> UInt {
   i16_signed(u16_lane(value, lane)).reinterpret_as_uint()
 }
 
@@ -280,8 +276,7 @@ pub fn V128::i16x8_extract_lane_s(value : V128, lane : Int) -> UInt {
 #intrinsic("%v128.i32x4_extract_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extract_lane(value : V128, lane : Int) -> UInt {
+pub fn i32x4_extract_lane(value : V128, lane : Int) -> UInt {
   u32_lane(value, lane)
 }
 
@@ -290,8 +285,7 @@ pub fn V128::i32x4_extract_lane(value : V128, lane : Int) -> UInt {
 #intrinsic("%v128.i64x2_extract_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extract_lane(value : V128, lane : Int) -> UInt64 {
+pub fn i64x2_extract_lane(value : V128, lane : Int) -> UInt64 {
   u64_lane(value, lane)
 }
 
@@ -300,8 +294,7 @@ pub fn V128::i64x2_extract_lane(value : V128, lane : Int) -> UInt64 {
 #intrinsic("%v128.f32x4_extract_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_extract_lane(value : V128, lane : Int) -> Float {
+pub fn f32x4_extract_lane(value : V128, lane : Int) -> Float {
   Float::reinterpret_from_uint(u32_lane(value, lane))
 }
 
@@ -310,8 +303,7 @@ pub fn V128::f32x4_extract_lane(value : V128, lane : Int) -> Float {
 #intrinsic("%v128.f64x2_extract_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_extract_lane(value : V128, lane : Int) -> Double {
+pub fn f64x2_extract_lane(value : V128, lane : Int) -> Double {
   u64_lane(value, lane).reinterpret_as_double()
 }
 
@@ -321,12 +313,7 @@ pub fn V128::f64x2_extract_lane(value : V128, lane : Int) -> Double {
 #intrinsic("%v128.i8x16_replace_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_replace_lane(
-  value : V128,
-  replacement : UInt,
-  lane : Int,
-) -> V128 {
+pub fn i8x16_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 {
   let shift = (lane & 7) * 8
   let mask = 0xffUL << shift
   let bits = (replacement.to_uint64() & 0xffUL) << shift
@@ -344,12 +331,7 @@ pub fn V128::i8x16_replace_lane(
 #intrinsic("%v128.i16x8_replace_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_replace_lane(
-  value : V128,
-  replacement : UInt,
-  lane : Int,
-) -> V128 {
+pub fn i16x8_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 {
   let shift = (lane & 3) * 16
   let mask = 0xffffUL << shift
   let bits = (replacement.to_uint64() & 0xffffUL) << shift
@@ -367,12 +349,7 @@ pub fn V128::i16x8_replace_lane(
 #intrinsic("%v128.i32x4_replace_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_replace_lane(
-  value : V128,
-  replacement : UInt,
-  lane : Int,
-) -> V128 {
+pub fn i32x4_replace_lane(value : V128, replacement : UInt, lane : Int) -> V128 {
   let shift = (lane & 1) * 32
   let mask = 0xffffffffUL << shift
   let bits = replacement.to_uint64() << shift
@@ -390,8 +367,7 @@ pub fn V128::i32x4_replace_lane(
 #intrinsic("%v128.i64x2_replace_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_replace_lane(
+pub fn i64x2_replace_lane(
   value : V128,
   replacement : UInt64,
   lane : Int,
@@ -410,8 +386,7 @@ pub fn V128::i64x2_replace_lane(
 #intrinsic("%v128.f32x4_replace_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_replace_lane(
+pub fn f32x4_replace_lane(
   value : V128,
   replacement : Float,
   lane : Int,
@@ -424,8 +399,7 @@ pub fn V128::f32x4_replace_lane(
 #intrinsic("%v128.f64x2_replace_lane")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_replace_lane(
+pub fn f64x2_replace_lane(
   value : V128,
   replacement : Double,
   lane : Int,
@@ -438,8 +412,7 @@ pub fn V128::f64x2_replace_lane(
 #intrinsic("%v128.v128_not")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::v128_not(value : V128) -> V128 {
+pub fn v128_not(value : V128) -> V128 {
   make(lo(value).lnot(), hi(value).lnot())
 }
 
@@ -448,8 +421,7 @@ pub fn V128::v128_not(value : V128) -> V128 {
 #intrinsic("%v128.v128_and")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::v128_and_(value : V128, other : V128) -> V128 {
+pub fn v128_and_(value : V128, other : V128) -> V128 {
   make(lo(value) & lo(other), hi(value) & hi(other))
 }
 
@@ -458,8 +430,7 @@ pub fn V128::v128_and_(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.v128_or")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::v128_or_(value : V128, other : V128) -> V128 {
+pub fn v128_or_(value : V128, other : V128) -> V128 {
   make(lo(value) | lo(other), hi(value) | hi(other))
 }
 
@@ -468,8 +439,7 @@ pub fn V128::v128_or_(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.v128_xor")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::v128_xor(value : V128, other : V128) -> V128 {
+pub fn v128_xor(value : V128, other : V128) -> V128 {
   make(lo(value) ^ lo(other), hi(value) ^ hi(other))
 }
 
@@ -478,8 +448,7 @@ pub fn V128::v128_xor(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.v128_andnot")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::v128_andnot(value : V128, other : V128) -> V128 {
+pub fn v128_andnot(value : V128, other : V128) -> V128 {
   v128_and_(value, v128_not(other))
 }
 
@@ -488,8 +457,7 @@ pub fn V128::v128_andnot(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.v128_bitselect")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::v128_bitselect(value : V128, other : V128, mask : V128) -> V128 {
+pub fn v128_bitselect(value : V128, other : V128, mask : V128) -> V128 {
   v128_or_(v128_and_(value, mask), v128_andnot(other, mask))
 }
 
@@ -498,7 +466,6 @@ pub fn V128::v128_bitselect(value : V128, other : V128, mask : V128) -> V128 {
 #intrinsic("%v128.v128_any_true")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::v128_any_true(value : V128) -> Bool {
+pub fn v128_any_true(value : V128) -> Bool {
   lo(value) != 0UL || hi(value) != 0UL
 }

--- a/v128/simd_float.mbt
+++ b/v128/simd_float.mbt
@@ -249,8 +249,7 @@ fn f64_trunc_sat_u(value : Double) -> UInt {
 #intrinsic("%v128.f32x4_abs")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_abs(value : V128) -> V128 {
+pub fn f32x4_abs(value : V128) -> V128 {
   f32x4_map(value, fn(x) { x.abs() })
 }
 
@@ -259,8 +258,7 @@ pub fn V128::f32x4_abs(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_neg")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_neg(value : V128) -> V128 {
+pub fn f32x4_neg(value : V128) -> V128 {
   f32x4_map(value, fn(x) { -x })
 }
 
@@ -269,8 +267,7 @@ pub fn V128::f32x4_neg(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_sqrt")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_sqrt(value : V128) -> V128 {
+pub fn f32x4_sqrt(value : V128) -> V128 {
   f32x4_map(value, fn(x) { x.sqrt() })
 }
 
@@ -279,8 +276,7 @@ pub fn V128::f32x4_sqrt(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_ceil")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_ceil(value : V128) -> V128 {
+pub fn f32x4_ceil(value : V128) -> V128 {
   f32x4_map(value, fn(x) { x.ceil() })
 }
 
@@ -289,8 +285,7 @@ pub fn V128::f32x4_ceil(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_floor")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_floor(value : V128) -> V128 {
+pub fn f32x4_floor(value : V128) -> V128 {
   f32x4_map(value, fn(x) { x.floor() })
 }
 
@@ -299,8 +294,7 @@ pub fn V128::f32x4_floor(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_trunc")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_trunc(value : V128) -> V128 {
+pub fn f32x4_trunc(value : V128) -> V128 {
   f32x4_map(value, fn(x) { x.trunc() })
 }
 
@@ -309,8 +303,7 @@ pub fn V128::f32x4_trunc(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_nearest")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_nearest(value : V128) -> V128 {
+pub fn f32x4_nearest(value : V128) -> V128 {
   f32x4_map(value, f32_nearest_even)
 }
 
@@ -319,8 +312,7 @@ pub fn V128::f32x4_nearest(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_add")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_add(value : V128, other : V128) -> V128 {
+pub fn f32x4_add(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, fn(x, y) { x + y })
 }
 
@@ -329,8 +321,7 @@ pub fn V128::f32x4_add(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_sub")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_sub(value : V128, other : V128) -> V128 {
+pub fn f32x4_sub(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, fn(x, y) { x - y })
 }
 
@@ -339,8 +330,7 @@ pub fn V128::f32x4_sub(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_mul")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_mul(value : V128, other : V128) -> V128 {
+pub fn f32x4_mul(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, fn(x, y) { x * y })
 }
 
@@ -349,8 +339,7 @@ pub fn V128::f32x4_mul(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_div")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_div(value : V128, other : V128) -> V128 {
+pub fn f32x4_div(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, fn(x, y) { x / y })
 }
 
@@ -359,8 +348,7 @@ pub fn V128::f32x4_div(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_min")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_min(value : V128, other : V128) -> V128 {
+pub fn f32x4_min(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, f32_min)
 }
 
@@ -369,8 +357,7 @@ pub fn V128::f32x4_min(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_max")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_max(value : V128, other : V128) -> V128 {
+pub fn f32x4_max(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, f32_max)
 }
 
@@ -379,8 +366,7 @@ pub fn V128::f32x4_max(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_pmin")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_pmin(value : V128, other : V128) -> V128 {
+pub fn f32x4_pmin(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, f32_pmin)
 }
 
@@ -389,8 +375,7 @@ pub fn V128::f32x4_pmin(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_pmax")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_pmax(value : V128, other : V128) -> V128 {
+pub fn f32x4_pmax(value : V128, other : V128) -> V128 {
   f32x4_zip(value, other, f32_pmax)
 }
 
@@ -399,8 +384,7 @@ pub fn V128::f32x4_pmax(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_relaxed_min")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_relaxed_min(value : V128, other : V128) -> V128 {
+pub fn f32x4_relaxed_min(value : V128, other : V128) -> V128 {
   f32x4_min(value, other)
 }
 
@@ -409,8 +393,7 @@ pub fn V128::f32x4_relaxed_min(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_relaxed_max")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_relaxed_max(value : V128, other : V128) -> V128 {
+pub fn f32x4_relaxed_max(value : V128, other : V128) -> V128 {
   f32x4_max(value, other)
 }
 
@@ -419,12 +402,7 @@ pub fn V128::f32x4_relaxed_max(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_relaxed_madd")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_relaxed_madd(
-  value : V128,
-  other : V128,
-  addend : V128,
-) -> V128 {
+pub fn f32x4_relaxed_madd(value : V128, other : V128, addend : V128) -> V128 {
   pack_f32x4_by(i => {
     f32x4_extract_lane(value, i) * f32x4_extract_lane(other, i) +
     f32x4_extract_lane(addend, i)
@@ -436,12 +414,7 @@ pub fn V128::f32x4_relaxed_madd(
 #intrinsic("%v128.f32x4_relaxed_nmadd")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_relaxed_nmadd(
-  value : V128,
-  other : V128,
-  addend : V128,
-) -> V128 {
+pub fn f32x4_relaxed_nmadd(value : V128, other : V128, addend : V128) -> V128 {
   pack_f32x4_by(i => {
     f32x4_extract_lane(addend, i) -
     f32x4_extract_lane(value, i) * f32x4_extract_lane(other, i)
@@ -453,8 +426,7 @@ pub fn V128::f32x4_relaxed_nmadd(
 #intrinsic("%v128.f32x4_eq")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_eq(value : V128, other : V128) -> V128 {
+pub fn f32x4_eq(value : V128, other : V128) -> V128 {
   f32x4_compare(value, other, fn(x, y) { x == y })
 }
 
@@ -463,8 +435,7 @@ pub fn V128::f32x4_eq(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_ne")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_ne(value : V128, other : V128) -> V128 {
+pub fn f32x4_ne(value : V128, other : V128) -> V128 {
   f32x4_compare(value, other, fn(x, y) { x != y })
 }
 
@@ -473,8 +444,7 @@ pub fn V128::f32x4_ne(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_lt")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_lt(value : V128, other : V128) -> V128 {
+pub fn f32x4_lt(value : V128, other : V128) -> V128 {
   f32x4_compare(value, other, fn(x, y) { x < y })
 }
 
@@ -483,8 +453,7 @@ pub fn V128::f32x4_lt(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_le")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_le(value : V128, other : V128) -> V128 {
+pub fn f32x4_le(value : V128, other : V128) -> V128 {
   f32x4_compare(value, other, fn(x, y) { x <= y })
 }
 
@@ -493,8 +462,7 @@ pub fn V128::f32x4_le(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_gt")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_gt(value : V128, other : V128) -> V128 {
+pub fn f32x4_gt(value : V128, other : V128) -> V128 {
   f32x4_compare(value, other, fn(x, y) { x > y })
 }
 
@@ -503,8 +471,7 @@ pub fn V128::f32x4_gt(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_ge")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_ge(value : V128, other : V128) -> V128 {
+pub fn f32x4_ge(value : V128, other : V128) -> V128 {
   f32x4_compare(value, other, fn(x, y) { x >= y })
 }
 
@@ -513,8 +480,7 @@ pub fn V128::f32x4_ge(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f32x4_convert_i32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_convert_i32x4_s(value : V128) -> V128 {
+pub fn f32x4_convert_i32x4_s(value : V128) -> V128 {
   pack_f32x4_by(i => Float::from_int(u32_lane(value, i).reinterpret_as_int()))
 }
 
@@ -523,8 +489,7 @@ pub fn V128::f32x4_convert_i32x4_s(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_convert_i32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_convert_i32x4_u(value : V128) -> V128 {
+pub fn f32x4_convert_i32x4_u(value : V128) -> V128 {
   pack_f32x4_by(i => Float::from_uint(u32_lane(value, i)))
 }
 
@@ -533,8 +498,7 @@ pub fn V128::f32x4_convert_i32x4_u(value : V128) -> V128 {
 #intrinsic("%v128.f32x4_demote_f64x2_zero")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f32x4_demote_f64x2_zero(value : V128) -> V128 {
+pub fn f32x4_demote_f64x2_zero(value : V128) -> V128 {
   f32x4_const(
     Float::from_double(f64x2_extract_lane(value, 0)),
     Float::from_double(f64x2_extract_lane(value, 1)),
@@ -548,8 +512,7 @@ pub fn V128::f32x4_demote_f64x2_zero(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_trunc_sat_f32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_trunc_sat_f32x4_s(value : V128) -> V128 {
+pub fn i32x4_trunc_sat_f32x4_s(value : V128) -> V128 {
   pack_u32x4_by(i => f32_trunc_sat_s(f32x4_extract_lane(value, i)))
 }
 
@@ -558,8 +521,7 @@ pub fn V128::i32x4_trunc_sat_f32x4_s(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_trunc_sat_f32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_trunc_sat_f32x4_u(value : V128) -> V128 {
+pub fn i32x4_trunc_sat_f32x4_u(value : V128) -> V128 {
   pack_u32x4_by(i => f32_trunc_sat_u(f32x4_extract_lane(value, i)))
 }
 
@@ -568,8 +530,7 @@ pub fn V128::i32x4_trunc_sat_f32x4_u(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_relaxed_trunc_f32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_relaxed_trunc_f32x4_s(value : V128) -> V128 {
+pub fn i32x4_relaxed_trunc_f32x4_s(value : V128) -> V128 {
   i32x4_trunc_sat_f32x4_s(value)
 }
 
@@ -578,8 +539,7 @@ pub fn V128::i32x4_relaxed_trunc_f32x4_s(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_relaxed_trunc_f32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_relaxed_trunc_f32x4_u(value : V128) -> V128 {
+pub fn i32x4_relaxed_trunc_f32x4_u(value : V128) -> V128 {
   i32x4_trunc_sat_f32x4_u(value)
 }
 
@@ -588,8 +548,7 @@ pub fn V128::i32x4_relaxed_trunc_f32x4_u(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_abs")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_abs(value : V128) -> V128 {
+pub fn f64x2_abs(value : V128) -> V128 {
   f64x2_map(value, fn(x) { x.abs() })
 }
 
@@ -598,8 +557,7 @@ pub fn V128::f64x2_abs(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_neg")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_neg(value : V128) -> V128 {
+pub fn f64x2_neg(value : V128) -> V128 {
   f64x2_map(value, fn(x) { -x })
 }
 
@@ -608,8 +566,7 @@ pub fn V128::f64x2_neg(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_sqrt")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_sqrt(value : V128) -> V128 {
+pub fn f64x2_sqrt(value : V128) -> V128 {
   f64x2_map(value, fn(x) { x.sqrt() })
 }
 
@@ -618,8 +575,7 @@ pub fn V128::f64x2_sqrt(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_ceil")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_ceil(value : V128) -> V128 {
+pub fn f64x2_ceil(value : V128) -> V128 {
   f64x2_map(value, fn(x) { x.ceil() })
 }
 
@@ -628,8 +584,7 @@ pub fn V128::f64x2_ceil(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_floor")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_floor(value : V128) -> V128 {
+pub fn f64x2_floor(value : V128) -> V128 {
   f64x2_map(value, fn(x) { x.floor() })
 }
 
@@ -638,8 +593,7 @@ pub fn V128::f64x2_floor(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_trunc")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_trunc(value : V128) -> V128 {
+pub fn f64x2_trunc(value : V128) -> V128 {
   f64x2_map(value, fn(x) { x.trunc() })
 }
 
@@ -648,8 +602,7 @@ pub fn V128::f64x2_trunc(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_nearest")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_nearest(value : V128) -> V128 {
+pub fn f64x2_nearest(value : V128) -> V128 {
   f64x2_map(value, f64_nearest_even)
 }
 
@@ -658,8 +611,7 @@ pub fn V128::f64x2_nearest(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_add")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_add(value : V128, other : V128) -> V128 {
+pub fn f64x2_add(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, fn(x, y) { x + y })
 }
 
@@ -668,8 +620,7 @@ pub fn V128::f64x2_add(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_sub")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_sub(value : V128, other : V128) -> V128 {
+pub fn f64x2_sub(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, fn(x, y) { x - y })
 }
 
@@ -678,8 +629,7 @@ pub fn V128::f64x2_sub(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_mul")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_mul(value : V128, other : V128) -> V128 {
+pub fn f64x2_mul(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, fn(x, y) { x * y })
 }
 
@@ -688,8 +638,7 @@ pub fn V128::f64x2_mul(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_div")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_div(value : V128, other : V128) -> V128 {
+pub fn f64x2_div(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, fn(x, y) { x / y })
 }
 
@@ -698,8 +647,7 @@ pub fn V128::f64x2_div(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_min")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_min(value : V128, other : V128) -> V128 {
+pub fn f64x2_min(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, f64_min)
 }
 
@@ -708,8 +656,7 @@ pub fn V128::f64x2_min(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_max")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_max(value : V128, other : V128) -> V128 {
+pub fn f64x2_max(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, f64_max)
 }
 
@@ -718,8 +665,7 @@ pub fn V128::f64x2_max(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_pmin")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_pmin(value : V128, other : V128) -> V128 {
+pub fn f64x2_pmin(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, f64_pmin)
 }
 
@@ -728,8 +674,7 @@ pub fn V128::f64x2_pmin(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_pmax")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_pmax(value : V128, other : V128) -> V128 {
+pub fn f64x2_pmax(value : V128, other : V128) -> V128 {
   f64x2_zip(value, other, f64_pmax)
 }
 
@@ -738,8 +683,7 @@ pub fn V128::f64x2_pmax(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_relaxed_min")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_relaxed_min(value : V128, other : V128) -> V128 {
+pub fn f64x2_relaxed_min(value : V128, other : V128) -> V128 {
   f64x2_min(value, other)
 }
 
@@ -748,8 +692,7 @@ pub fn V128::f64x2_relaxed_min(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_relaxed_max")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_relaxed_max(value : V128, other : V128) -> V128 {
+pub fn f64x2_relaxed_max(value : V128, other : V128) -> V128 {
   f64x2_max(value, other)
 }
 
@@ -758,12 +701,7 @@ pub fn V128::f64x2_relaxed_max(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_relaxed_madd")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_relaxed_madd(
-  value : V128,
-  other : V128,
-  addend : V128,
-) -> V128 {
+pub fn f64x2_relaxed_madd(value : V128, other : V128, addend : V128) -> V128 {
   pack_f64x2_by(i => {
     f64x2_extract_lane(value, i) * f64x2_extract_lane(other, i) +
     f64x2_extract_lane(addend, i)
@@ -775,12 +713,7 @@ pub fn V128::f64x2_relaxed_madd(
 #intrinsic("%v128.f64x2_relaxed_nmadd")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_relaxed_nmadd(
-  value : V128,
-  other : V128,
-  addend : V128,
-) -> V128 {
+pub fn f64x2_relaxed_nmadd(value : V128, other : V128, addend : V128) -> V128 {
   pack_f64x2_by(i => {
     f64x2_extract_lane(addend, i) -
     f64x2_extract_lane(value, i) * f64x2_extract_lane(other, i)
@@ -792,8 +725,7 @@ pub fn V128::f64x2_relaxed_nmadd(
 #intrinsic("%v128.f64x2_eq")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_eq(value : V128, other : V128) -> V128 {
+pub fn f64x2_eq(value : V128, other : V128) -> V128 {
   f64x2_compare(value, other, fn(x, y) { x == y })
 }
 
@@ -802,8 +734,7 @@ pub fn V128::f64x2_eq(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_ne")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_ne(value : V128, other : V128) -> V128 {
+pub fn f64x2_ne(value : V128, other : V128) -> V128 {
   f64x2_compare(value, other, fn(x, y) { x != y })
 }
 
@@ -812,8 +743,7 @@ pub fn V128::f64x2_ne(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_lt")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_lt(value : V128, other : V128) -> V128 {
+pub fn f64x2_lt(value : V128, other : V128) -> V128 {
   f64x2_compare(value, other, fn(x, y) { x < y })
 }
 
@@ -822,8 +752,7 @@ pub fn V128::f64x2_lt(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_le")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_le(value : V128, other : V128) -> V128 {
+pub fn f64x2_le(value : V128, other : V128) -> V128 {
   f64x2_compare(value, other, fn(x, y) { x <= y })
 }
 
@@ -832,8 +761,7 @@ pub fn V128::f64x2_le(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_gt")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_gt(value : V128, other : V128) -> V128 {
+pub fn f64x2_gt(value : V128, other : V128) -> V128 {
   f64x2_compare(value, other, fn(x, y) { x > y })
 }
 
@@ -842,8 +770,7 @@ pub fn V128::f64x2_gt(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_ge")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_ge(value : V128, other : V128) -> V128 {
+pub fn f64x2_ge(value : V128, other : V128) -> V128 {
   f64x2_compare(value, other, fn(x, y) { x >= y })
 }
 
@@ -852,8 +779,7 @@ pub fn V128::f64x2_ge(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.f64x2_convert_low_i32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_convert_low_i32x4_s(value : V128) -> V128 {
+pub fn f64x2_convert_low_i32x4_s(value : V128) -> V128 {
   pack_f64x2_by(i => Double::from_int(u32_lane(value, i).reinterpret_as_int()))
 }
 
@@ -862,8 +788,7 @@ pub fn V128::f64x2_convert_low_i32x4_s(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_convert_low_i32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_convert_low_i32x4_u(value : V128) -> V128 {
+pub fn f64x2_convert_low_i32x4_u(value : V128) -> V128 {
   pack_f64x2_by(i => Double::convert_uint(u32_lane(value, i)))
 }
 
@@ -872,8 +797,7 @@ pub fn V128::f64x2_convert_low_i32x4_u(value : V128) -> V128 {
 #intrinsic("%v128.f64x2_promote_low_f32x4")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::f64x2_promote_low_f32x4(value : V128) -> V128 {
+pub fn f64x2_promote_low_f32x4(value : V128) -> V128 {
   pack_f64x2_by(i => f32x4_extract_lane(value, i).to_double())
 }
 
@@ -882,8 +806,7 @@ pub fn V128::f64x2_promote_low_f32x4(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_trunc_sat_f64x2_s_zero")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_trunc_sat_f64x2_s_zero(value : V128) -> V128 {
+pub fn i32x4_trunc_sat_f64x2_s_zero(value : V128) -> V128 {
   i32x4_const(
     f64_trunc_sat_s(f64x2_extract_lane(value, 0)),
     f64_trunc_sat_s(f64x2_extract_lane(value, 1)),
@@ -897,8 +820,7 @@ pub fn V128::i32x4_trunc_sat_f64x2_s_zero(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_trunc_sat_f64x2_u_zero")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_trunc_sat_f64x2_u_zero(value : V128) -> V128 {
+pub fn i32x4_trunc_sat_f64x2_u_zero(value : V128) -> V128 {
   i32x4_const(
     f64_trunc_sat_u(f64x2_extract_lane(value, 0)),
     f64_trunc_sat_u(f64x2_extract_lane(value, 1)),
@@ -912,8 +834,7 @@ pub fn V128::i32x4_trunc_sat_f64x2_u_zero(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_relaxed_trunc_f64x2_s_zero")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_relaxed_trunc_f64x2_s_zero(value : V128) -> V128 {
+pub fn i32x4_relaxed_trunc_f64x2_s_zero(value : V128) -> V128 {
   i32x4_trunc_sat_f64x2_s_zero(value)
 }
 
@@ -922,7 +843,6 @@ pub fn V128::i32x4_relaxed_trunc_f64x2_s_zero(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_relaxed_trunc_f64x2_u_zero")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_relaxed_trunc_f64x2_u_zero(value : V128) -> V128 {
+pub fn i32x4_relaxed_trunc_f64x2_u_zero(value : V128) -> V128 {
   i32x4_trunc_sat_f64x2_u_zero(value)
 }

--- a/v128/simd_int_arith.mbt
+++ b/v128/simd_int_arith.mbt
@@ -17,8 +17,7 @@
 #intrinsic("%v128.i8x16_add")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_add(value : V128, other : V128) -> V128 {
+pub fn i8x16_add(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => u8_lane(value, i) + u8_lane(other, i))
 }
 
@@ -27,8 +26,7 @@ pub fn V128::i8x16_add(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_sub")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_sub(value : V128, other : V128) -> V128 {
+pub fn i8x16_sub(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => u8_lane(value, i) - u8_lane(other, i))
 }
 
@@ -37,8 +35,7 @@ pub fn V128::i8x16_sub(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_add_sat_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_add_sat_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_add_sat_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => i8_add_sat_s(u8_lane(value, i), u8_lane(other, i)))
 }
 
@@ -47,8 +44,7 @@ pub fn V128::i8x16_add_sat_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_add_sat_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_add_sat_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_add_sat_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => i8_add_sat_u(u8_lane(value, i), u8_lane(other, i)))
 }
 
@@ -57,8 +53,7 @@ pub fn V128::i8x16_add_sat_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_sub_sat_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_sub_sat_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_sub_sat_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => i8_sub_sat_s(u8_lane(value, i), u8_lane(other, i)))
 }
 
@@ -67,8 +62,7 @@ pub fn V128::i8x16_sub_sat_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_sub_sat_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_sub_sat_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_sub_sat_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => i8_sub_sat_u(u8_lane(value, i), u8_lane(other, i)))
 }
 
@@ -77,8 +71,7 @@ pub fn V128::i8x16_sub_sat_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_neg")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_neg(value : V128) -> V128 {
+pub fn i8x16_neg(value : V128) -> V128 {
   pack_u8x16_by(i => (0 : Byte) - u8_lane(value, i))
 }
 
@@ -87,8 +80,7 @@ pub fn V128::i8x16_neg(value : V128) -> V128 {
 #intrinsic("%v128.i8x16_abs")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_abs(value : V128) -> V128 {
+pub fn i8x16_abs(value : V128) -> V128 {
   pack_u8x16_by(i => i8_abs(u8_lane(value, i)))
 }
 
@@ -97,8 +89,7 @@ pub fn V128::i8x16_abs(value : V128) -> V128 {
 #intrinsic("%v128.i8x16_min_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_min_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_min_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => i8_min_s(u8_lane(value, i), u8_lane(other, i)))
 }
 
@@ -107,8 +98,7 @@ pub fn V128::i8x16_min_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_min_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_min_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_min_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     if u8_lane(value, i) < u8_lane(other, i) {
       u8_lane(value, i)
@@ -123,8 +113,7 @@ pub fn V128::i8x16_min_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_max_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_max_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_max_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => i8_max_s(u8_lane(value, i), u8_lane(other, i)))
 }
 
@@ -133,8 +122,7 @@ pub fn V128::i8x16_max_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_max_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_max_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_max_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     if u8_lane(value, i) > u8_lane(other, i) {
       u8_lane(value, i)
@@ -149,8 +137,7 @@ pub fn V128::i8x16_max_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_avgr_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_avgr_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_avgr_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => i8_avgr_u(u8_lane(value, i), u8_lane(other, i)))
 }
 
@@ -159,8 +146,7 @@ pub fn V128::i8x16_avgr_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_popcnt")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_popcnt(value : V128) -> V128 {
+pub fn i8x16_popcnt(value : V128) -> V128 {
   pack_u8x16_by(i => u8_lane(value, i).to_uint().popcnt().to_byte())
 }
 
@@ -169,8 +155,7 @@ pub fn V128::i8x16_popcnt(value : V128) -> V128 {
 #intrinsic("%v128.i16x8_add")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_add(value : V128, other : V128) -> V128 {
+pub fn i16x8_add(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => u16_lane(value, i) + u16_lane(other, i))
 }
 
@@ -179,8 +164,7 @@ pub fn V128::i16x8_add(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_sub")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_sub(value : V128, other : V128) -> V128 {
+pub fn i16x8_sub(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => u16_lane(value, i) - u16_lane(other, i))
 }
 
@@ -189,8 +173,7 @@ pub fn V128::i16x8_sub(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_add_sat_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_add_sat_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_add_sat_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_add_sat_s(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -199,8 +182,7 @@ pub fn V128::i16x8_add_sat_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_add_sat_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_add_sat_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_add_sat_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_add_sat_u(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -209,8 +191,7 @@ pub fn V128::i16x8_add_sat_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_sub_sat_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_sub_sat_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_sub_sat_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_sub_sat_s(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -219,8 +200,7 @@ pub fn V128::i16x8_sub_sat_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_sub_sat_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_sub_sat_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_sub_sat_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_sub_sat_u(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -229,8 +209,7 @@ pub fn V128::i16x8_sub_sat_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_mul")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_mul(value : V128, other : V128) -> V128 {
+pub fn i16x8_mul(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => u16_lane(value, i) * u16_lane(other, i))
 }
 
@@ -239,8 +218,7 @@ pub fn V128::i16x8_mul(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_neg")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_neg(value : V128) -> V128 {
+pub fn i16x8_neg(value : V128) -> V128 {
   pack_u16x8_by(i => (0 : UInt16) - u16_lane(value, i))
 }
 
@@ -249,8 +227,7 @@ pub fn V128::i16x8_neg(value : V128) -> V128 {
 #intrinsic("%v128.i16x8_abs")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_abs(value : V128) -> V128 {
+pub fn i16x8_abs(value : V128) -> V128 {
   pack_u16x8_by(i => i16_abs(u16_lane(value, i)))
 }
 
@@ -259,8 +236,7 @@ pub fn V128::i16x8_abs(value : V128) -> V128 {
 #intrinsic("%v128.i16x8_min_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_min_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_min_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_min_s(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -269,8 +245,7 @@ pub fn V128::i16x8_min_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_min_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_min_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_min_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     if u16_lane(value, i) < u16_lane(other, i) {
       u16_lane(value, i)
@@ -285,8 +260,7 @@ pub fn V128::i16x8_min_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_max_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_max_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_max_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_max_s(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -295,8 +269,7 @@ pub fn V128::i16x8_max_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_max_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_max_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_max_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     if u16_lane(value, i) > u16_lane(other, i) {
       u16_lane(value, i)
@@ -311,8 +284,7 @@ pub fn V128::i16x8_max_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_avgr_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_avgr_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_avgr_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_avgr_u(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -321,8 +293,7 @@ pub fn V128::i16x8_avgr_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_add")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_add(value : V128, other : V128) -> V128 {
+pub fn i32x4_add(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => u32_lane(value, i) + u32_lane(other, i))
 }
 
@@ -331,8 +302,7 @@ pub fn V128::i32x4_add(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_sub")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_sub(value : V128, other : V128) -> V128 {
+pub fn i32x4_sub(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => u32_lane(value, i) - u32_lane(other, i))
 }
 
@@ -341,8 +311,7 @@ pub fn V128::i32x4_sub(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_mul")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_mul(value : V128, other : V128) -> V128 {
+pub fn i32x4_mul(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => u32_lane(value, i) * u32_lane(other, i))
 }
 
@@ -351,8 +320,7 @@ pub fn V128::i32x4_mul(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_neg")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_neg(value : V128) -> V128 {
+pub fn i32x4_neg(value : V128) -> V128 {
   pack_u32x4_by(i => (0U : UInt) - u32_lane(value, i))
 }
 
@@ -361,8 +329,7 @@ pub fn V128::i32x4_neg(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_abs")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_abs(value : V128) -> V128 {
+pub fn i32x4_abs(value : V128) -> V128 {
   pack_u32x4_by(i => {
     u32_lane(value, i).reinterpret_as_int().abs().reinterpret_as_uint()
   })
@@ -373,8 +340,7 @@ pub fn V128::i32x4_abs(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_min_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_min_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_min_s(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     if u32_lane(value, i).reinterpret_as_int() <
       u32_lane(other, i).reinterpret_as_int() {
@@ -390,8 +356,7 @@ pub fn V128::i32x4_min_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_min_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_min_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_min_u(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     if u32_lane(value, i) < u32_lane(other, i) {
       u32_lane(value, i)
@@ -406,8 +371,7 @@ pub fn V128::i32x4_min_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_max_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_max_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_max_s(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     if u32_lane(value, i).reinterpret_as_int() >
       u32_lane(other, i).reinterpret_as_int() {
@@ -423,8 +387,7 @@ pub fn V128::i32x4_max_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_max_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_max_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_max_u(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     if u32_lane(value, i) > u32_lane(other, i) {
       u32_lane(value, i)
@@ -439,8 +402,7 @@ pub fn V128::i32x4_max_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_add")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_add(value : V128, other : V128) -> V128 {
+pub fn i64x2_add(value : V128, other : V128) -> V128 {
   make(lo(value) + lo(other), hi(value) + hi(other))
 }
 
@@ -449,8 +411,7 @@ pub fn V128::i64x2_add(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_sub")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_sub(value : V128, other : V128) -> V128 {
+pub fn i64x2_sub(value : V128, other : V128) -> V128 {
   make(lo(value) - lo(other), hi(value) - hi(other))
 }
 
@@ -459,8 +420,7 @@ pub fn V128::i64x2_sub(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_mul")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_mul(value : V128, other : V128) -> V128 {
+pub fn i64x2_mul(value : V128, other : V128) -> V128 {
   make(lo(value) * lo(other), hi(value) * hi(other))
 }
 
@@ -469,8 +429,7 @@ pub fn V128::i64x2_mul(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_neg")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_neg(value : V128) -> V128 {
+pub fn i64x2_neg(value : V128) -> V128 {
   make(0UL - lo(value), 0UL - hi(value))
 }
 
@@ -479,8 +438,7 @@ pub fn V128::i64x2_neg(value : V128) -> V128 {
 #intrinsic("%v128.i64x2_abs")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_abs(value : V128) -> V128 {
+pub fn i64x2_abs(value : V128) -> V128 {
   pack_u64x2_by(i => {
     u64_lane(value, i).reinterpret_as_int64().abs().reinterpret_as_uint64()
   })

--- a/v128/simd_int_compare.mbt
+++ b/v128/simd_int_compare.mbt
@@ -17,8 +17,7 @@
 #intrinsic("%v128.i8x16_eq")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_eq(value : V128, other : V128) -> V128 {
+pub fn i8x16_eq(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => bool_to_u8_mask(u8_lane(value, i) == u8_lane(other, i)))
 }
 
@@ -27,8 +26,7 @@ pub fn V128::i8x16_eq(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_ne")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_ne(value : V128, other : V128) -> V128 {
+pub fn i8x16_ne(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => bool_to_u8_mask(u8_lane(value, i) != u8_lane(other, i)))
 }
 
@@ -37,8 +35,7 @@ pub fn V128::i8x16_ne(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_lt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_lt_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_lt_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     bool_to_u8_mask(i8_signed(u8_lane(value, i)) < i8_signed(u8_lane(other, i)))
   })
@@ -49,8 +46,7 @@ pub fn V128::i8x16_lt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_lt_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_lt_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_lt_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => bool_to_u8_mask(u8_lane(value, i) < u8_lane(other, i)))
 }
 
@@ -59,8 +55,7 @@ pub fn V128::i8x16_lt_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_le_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_le_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_le_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     bool_to_u8_mask(
       i8_signed(u8_lane(value, i)) <= i8_signed(u8_lane(other, i)),
@@ -73,8 +68,7 @@ pub fn V128::i8x16_le_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_le_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_le_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_le_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => bool_to_u8_mask(u8_lane(value, i) <= u8_lane(other, i)))
 }
 
@@ -83,8 +77,7 @@ pub fn V128::i8x16_le_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_gt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_gt_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_gt_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     bool_to_u8_mask(i8_signed(u8_lane(value, i)) > i8_signed(u8_lane(other, i)))
   })
@@ -95,8 +88,7 @@ pub fn V128::i8x16_gt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_gt_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_gt_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_gt_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => bool_to_u8_mask(u8_lane(value, i) > u8_lane(other, i)))
 }
 
@@ -105,8 +97,7 @@ pub fn V128::i8x16_gt_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_ge_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_ge_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_ge_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     bool_to_u8_mask(
       i8_signed(u8_lane(value, i)) >= i8_signed(u8_lane(other, i)),
@@ -119,8 +110,7 @@ pub fn V128::i8x16_ge_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_ge_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_ge_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_ge_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => bool_to_u8_mask(u8_lane(value, i) >= u8_lane(other, i)))
 }
 
@@ -129,8 +119,7 @@ pub fn V128::i8x16_ge_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_eq")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_eq(value : V128, other : V128) -> V128 {
+pub fn i16x8_eq(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => bool_to_u16_mask(u16_lane(value, i) == u16_lane(other, i)))
 }
 
@@ -139,8 +128,7 @@ pub fn V128::i16x8_eq(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_ne")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_ne(value : V128, other : V128) -> V128 {
+pub fn i16x8_ne(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => bool_to_u16_mask(u16_lane(value, i) != u16_lane(other, i)))
 }
 
@@ -149,8 +137,7 @@ pub fn V128::i16x8_ne(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_lt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_lt_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_lt_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     bool_to_u16_mask(
       i16_signed(u16_lane(value, i)) < i16_signed(u16_lane(other, i)),
@@ -163,8 +150,7 @@ pub fn V128::i16x8_lt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_lt_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_lt_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_lt_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => bool_to_u16_mask(u16_lane(value, i) < u16_lane(other, i)))
 }
 
@@ -173,8 +159,7 @@ pub fn V128::i16x8_lt_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_le_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_le_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_le_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     bool_to_u16_mask(
       i16_signed(u16_lane(value, i)) <= i16_signed(u16_lane(other, i)),
@@ -187,8 +172,7 @@ pub fn V128::i16x8_le_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_le_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_le_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_le_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => bool_to_u16_mask(u16_lane(value, i) <= u16_lane(other, i)))
 }
 
@@ -197,8 +181,7 @@ pub fn V128::i16x8_le_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_gt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_gt_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_gt_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     bool_to_u16_mask(
       i16_signed(u16_lane(value, i)) > i16_signed(u16_lane(other, i)),
@@ -211,8 +194,7 @@ pub fn V128::i16x8_gt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_gt_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_gt_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_gt_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => bool_to_u16_mask(u16_lane(value, i) > u16_lane(other, i)))
 }
 
@@ -221,8 +203,7 @@ pub fn V128::i16x8_gt_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_ge_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_ge_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_ge_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     bool_to_u16_mask(
       i16_signed(u16_lane(value, i)) >= i16_signed(u16_lane(other, i)),
@@ -235,8 +216,7 @@ pub fn V128::i16x8_ge_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_ge_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_ge_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_ge_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => bool_to_u16_mask(u16_lane(value, i) >= u16_lane(other, i)))
 }
 
@@ -245,8 +225,7 @@ pub fn V128::i16x8_ge_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_eq")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_eq(value : V128, other : V128) -> V128 {
+pub fn i32x4_eq(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => bool_to_u32_mask(u32_lane(value, i) == u32_lane(other, i)))
 }
 
@@ -255,8 +234,7 @@ pub fn V128::i32x4_eq(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_ne")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_ne(value : V128, other : V128) -> V128 {
+pub fn i32x4_ne(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => bool_to_u32_mask(u32_lane(value, i) != u32_lane(other, i)))
 }
 
@@ -265,8 +243,7 @@ pub fn V128::i32x4_ne(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_lt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_lt_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_lt_s(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     bool_to_u32_mask(
       u32_lane(value, i).reinterpret_as_int() <
@@ -280,8 +257,7 @@ pub fn V128::i32x4_lt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_lt_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_lt_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_lt_u(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => bool_to_u32_mask(u32_lane(value, i) < u32_lane(other, i)))
 }
 
@@ -290,8 +266,7 @@ pub fn V128::i32x4_lt_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_le_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_le_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_le_s(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     bool_to_u32_mask(
       u32_lane(value, i).reinterpret_as_int() <=
@@ -305,8 +280,7 @@ pub fn V128::i32x4_le_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_le_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_le_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_le_u(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => bool_to_u32_mask(u32_lane(value, i) <= u32_lane(other, i)))
 }
 
@@ -315,8 +289,7 @@ pub fn V128::i32x4_le_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_gt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_gt_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_gt_s(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     bool_to_u32_mask(
       u32_lane(value, i).reinterpret_as_int() >
@@ -330,8 +303,7 @@ pub fn V128::i32x4_gt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_gt_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_gt_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_gt_u(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => bool_to_u32_mask(u32_lane(value, i) > u32_lane(other, i)))
 }
 
@@ -340,8 +312,7 @@ pub fn V128::i32x4_gt_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_ge_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_ge_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_ge_s(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => {
     bool_to_u32_mask(
       u32_lane(value, i).reinterpret_as_int() >=
@@ -355,8 +326,7 @@ pub fn V128::i32x4_ge_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_ge_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_ge_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_ge_u(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => bool_to_u32_mask(u32_lane(value, i) >= u32_lane(other, i)))
 }
 
@@ -365,8 +335,7 @@ pub fn V128::i32x4_ge_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_eq")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_eq(value : V128, other : V128) -> V128 {
+pub fn i64x2_eq(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => bool_to_u64_mask(u64_lane(value, i) == u64_lane(other, i)))
 }
 
@@ -375,8 +344,7 @@ pub fn V128::i64x2_eq(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_ne")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_ne(value : V128, other : V128) -> V128 {
+pub fn i64x2_ne(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => bool_to_u64_mask(u64_lane(value, i) != u64_lane(other, i)))
 }
 
@@ -385,8 +353,7 @@ pub fn V128::i64x2_ne(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_lt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_lt_s(value : V128, other : V128) -> V128 {
+pub fn i64x2_lt_s(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     bool_to_u64_mask(
       u64_lane(value, i).reinterpret_as_int64() <
@@ -400,8 +367,7 @@ pub fn V128::i64x2_lt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_le_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_le_s(value : V128, other : V128) -> V128 {
+pub fn i64x2_le_s(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     bool_to_u64_mask(
       u64_lane(value, i).reinterpret_as_int64() <=
@@ -415,8 +381,7 @@ pub fn V128::i64x2_le_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_gt_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_gt_s(value : V128, other : V128) -> V128 {
+pub fn i64x2_gt_s(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     bool_to_u64_mask(
       u64_lane(value, i).reinterpret_as_int64() >
@@ -430,8 +395,7 @@ pub fn V128::i64x2_gt_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_ge_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_ge_s(value : V128, other : V128) -> V128 {
+pub fn i64x2_ge_s(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     bool_to_u64_mask(
       u64_lane(value, i).reinterpret_as_int64() >=

--- a/v128/simd_int_extend.mbt
+++ b/v128/simd_int_extend.mbt
@@ -84,8 +84,7 @@ fn i16_pair_dot(value : V128, other : V128, pair : Int) -> UInt {
 #intrinsic("%v128.i16x8_extend_low_i8x16_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extend_low_i8x16_s(value : V128) -> V128 {
+pub fn i16x8_extend_low_i8x16_s(value : V128) -> V128 {
   pack_u16x8_by(i => i8_signed(u8_lane(value, i)).to_uint16())
 }
 
@@ -94,8 +93,7 @@ pub fn V128::i16x8_extend_low_i8x16_s(value : V128) -> V128 {
 #intrinsic("%v128.i16x8_extend_high_i8x16_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extend_high_i8x16_s(value : V128) -> V128 {
+pub fn i16x8_extend_high_i8x16_s(value : V128) -> V128 {
   pack_u16x8_by(i => i8_signed(u8_lane(value, i + 8)).to_uint16())
 }
 
@@ -104,8 +102,7 @@ pub fn V128::i16x8_extend_high_i8x16_s(value : V128) -> V128 {
 #intrinsic("%v128.i16x8_extend_low_i8x16_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extend_low_i8x16_u(value : V128) -> V128 {
+pub fn i16x8_extend_low_i8x16_u(value : V128) -> V128 {
   pack_u16x8_by(i => u8_lane(value, i).to_uint16())
 }
 
@@ -114,8 +111,7 @@ pub fn V128::i16x8_extend_low_i8x16_u(value : V128) -> V128 {
 #intrinsic("%v128.i16x8_extend_high_i8x16_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extend_high_i8x16_u(value : V128) -> V128 {
+pub fn i16x8_extend_high_i8x16_u(value : V128) -> V128 {
   pack_u16x8_by(i => u8_lane(value, i + 8).to_uint16())
 }
 
@@ -124,8 +120,7 @@ pub fn V128::i16x8_extend_high_i8x16_u(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_extend_low_i16x8_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extend_low_i16x8_s(value : V128) -> V128 {
+pub fn i32x4_extend_low_i16x8_s(value : V128) -> V128 {
   pack_u32x4_by(i => i16_signed(u16_lane(value, i)).reinterpret_as_uint())
 }
 
@@ -134,8 +129,7 @@ pub fn V128::i32x4_extend_low_i16x8_s(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_extend_high_i16x8_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extend_high_i16x8_s(value : V128) -> V128 {
+pub fn i32x4_extend_high_i16x8_s(value : V128) -> V128 {
   pack_u32x4_by(i => i16_signed(u16_lane(value, i + 4)).reinterpret_as_uint())
 }
 
@@ -144,8 +138,7 @@ pub fn V128::i32x4_extend_high_i16x8_s(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_extend_low_i16x8_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extend_low_i16x8_u(value : V128) -> V128 {
+pub fn i32x4_extend_low_i16x8_u(value : V128) -> V128 {
   pack_u32x4_by(i => u16_lane(value, i).to_uint())
 }
 
@@ -154,8 +147,7 @@ pub fn V128::i32x4_extend_low_i16x8_u(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_extend_high_i16x8_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extend_high_i16x8_u(value : V128) -> V128 {
+pub fn i32x4_extend_high_i16x8_u(value : V128) -> V128 {
   pack_u32x4_by(i => u16_lane(value, i + 4).to_uint())
 }
 
@@ -164,8 +156,7 @@ pub fn V128::i32x4_extend_high_i16x8_u(value : V128) -> V128 {
 #intrinsic("%v128.i64x2_extend_low_i32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extend_low_i32x4_s(value : V128) -> V128 {
+pub fn i64x2_extend_low_i32x4_s(value : V128) -> V128 {
   pack_u64x2_by(i => {
     u32_lane(value, i).reinterpret_as_int().to_int64().reinterpret_as_uint64()
   })
@@ -176,8 +167,7 @@ pub fn V128::i64x2_extend_low_i32x4_s(value : V128) -> V128 {
 #intrinsic("%v128.i64x2_extend_high_i32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extend_high_i32x4_s(value : V128) -> V128 {
+pub fn i64x2_extend_high_i32x4_s(value : V128) -> V128 {
   pack_u64x2_by(i => {
     u32_lane(value, i + 2)
     .reinterpret_as_int()
@@ -191,8 +181,7 @@ pub fn V128::i64x2_extend_high_i32x4_s(value : V128) -> V128 {
 #intrinsic("%v128.i64x2_extend_low_i32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extend_low_i32x4_u(value : V128) -> V128 {
+pub fn i64x2_extend_low_i32x4_u(value : V128) -> V128 {
   pack_u64x2_by(i => u32_lane(value, i).to_uint64())
 }
 
@@ -201,8 +190,7 @@ pub fn V128::i64x2_extend_low_i32x4_u(value : V128) -> V128 {
 #intrinsic("%v128.i64x2_extend_high_i32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extend_high_i32x4_u(value : V128) -> V128 {
+pub fn i64x2_extend_high_i32x4_u(value : V128) -> V128 {
   pack_u64x2_by(i => u32_lane(value, i + 2).to_uint64())
 }
 
@@ -211,8 +199,7 @@ pub fn V128::i64x2_extend_high_i32x4_u(value : V128) -> V128 {
 #intrinsic("%v128.i8x16_relaxed_laneselect")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_relaxed_laneselect(
+pub fn i8x16_relaxed_laneselect(
   value : V128,
   other : V128,
   mask : V128,
@@ -231,8 +218,7 @@ pub fn V128::i8x16_relaxed_laneselect(
 #intrinsic("%v128.i16x8_relaxed_laneselect")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_relaxed_laneselect(
+pub fn i16x8_relaxed_laneselect(
   value : V128,
   other : V128,
   mask : V128,
@@ -251,8 +237,7 @@ pub fn V128::i16x8_relaxed_laneselect(
 #intrinsic("%v128.i32x4_relaxed_laneselect")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_relaxed_laneselect(
+pub fn i32x4_relaxed_laneselect(
   value : V128,
   other : V128,
   mask : V128,
@@ -271,8 +256,7 @@ pub fn V128::i32x4_relaxed_laneselect(
 #intrinsic("%v128.i64x2_relaxed_laneselect")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_relaxed_laneselect(
+pub fn i64x2_relaxed_laneselect(
   value : V128,
   other : V128,
   mask : V128,
@@ -291,8 +275,7 @@ pub fn V128::i64x2_relaxed_laneselect(
 #intrinsic("%v128.i8x16_narrow_i16x8_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_narrow_i16x8_s(value : V128, other : V128) -> V128 {
+pub fn i8x16_narrow_i16x8_s(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     if i < 8 {
       narrow_i16_to_i8_s(u16_lane(value, i))
@@ -307,8 +290,7 @@ pub fn V128::i8x16_narrow_i16x8_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i8x16_narrow_i16x8_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_narrow_i16x8_u(value : V128, other : V128) -> V128 {
+pub fn i8x16_narrow_i16x8_u(value : V128, other : V128) -> V128 {
   pack_u8x16_by(i => {
     if i < 8 {
       narrow_i16_to_i8_u(u16_lane(value, i))
@@ -323,8 +305,7 @@ pub fn V128::i8x16_narrow_i16x8_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_narrow_i32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_narrow_i32x4_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_narrow_i32x4_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     if i < 4 {
       narrow_i32_to_i16_s(u32_lane(value, i))
@@ -339,8 +320,7 @@ pub fn V128::i16x8_narrow_i32x4_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_narrow_i32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_narrow_i32x4_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_narrow_i32x4_u(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     if i < 4 {
       narrow_i32_to_i16_u(u32_lane(value, i))
@@ -355,8 +335,7 @@ pub fn V128::i16x8_narrow_i32x4_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_extmul_low_i8x16_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extmul_low_i8x16_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_extmul_low_i8x16_s(value : V128, other : V128) -> V128 {
   i16x8_mul(i16x8_extend_low_i8x16_s(value), i16x8_extend_low_i8x16_s(other))
 }
 
@@ -365,8 +344,7 @@ pub fn V128::i16x8_extmul_low_i8x16_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_extmul_high_i8x16_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extmul_high_i8x16_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_extmul_high_i8x16_s(value : V128, other : V128) -> V128 {
   i16x8_mul(i16x8_extend_high_i8x16_s(value), i16x8_extend_high_i8x16_s(other))
 }
 
@@ -375,8 +353,7 @@ pub fn V128::i16x8_extmul_high_i8x16_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_extmul_low_i8x16_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extmul_low_i8x16_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_extmul_low_i8x16_u(value : V128, other : V128) -> V128 {
   i16x8_mul(i16x8_extend_low_i8x16_u(value), i16x8_extend_low_i8x16_u(other))
 }
 
@@ -385,8 +362,7 @@ pub fn V128::i16x8_extmul_low_i8x16_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_extmul_high_i8x16_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extmul_high_i8x16_u(value : V128, other : V128) -> V128 {
+pub fn i16x8_extmul_high_i8x16_u(value : V128, other : V128) -> V128 {
   i16x8_mul(i16x8_extend_high_i8x16_u(value), i16x8_extend_high_i8x16_u(other))
 }
 
@@ -395,8 +371,7 @@ pub fn V128::i16x8_extmul_high_i8x16_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_extmul_low_i16x8_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extmul_low_i16x8_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_extmul_low_i16x8_s(value : V128, other : V128) -> V128 {
   i32x4_mul(i32x4_extend_low_i16x8_s(value), i32x4_extend_low_i16x8_s(other))
 }
 
@@ -405,8 +380,7 @@ pub fn V128::i32x4_extmul_low_i16x8_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_extmul_high_i16x8_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extmul_high_i16x8_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_extmul_high_i16x8_s(value : V128, other : V128) -> V128 {
   i32x4_mul(i32x4_extend_high_i16x8_s(value), i32x4_extend_high_i16x8_s(other))
 }
 
@@ -415,8 +389,7 @@ pub fn V128::i32x4_extmul_high_i16x8_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_extmul_low_i16x8_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extmul_low_i16x8_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_extmul_low_i16x8_u(value : V128, other : V128) -> V128 {
   i32x4_mul(i32x4_extend_low_i16x8_u(value), i32x4_extend_low_i16x8_u(other))
 }
 
@@ -425,8 +398,7 @@ pub fn V128::i32x4_extmul_low_i16x8_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i32x4_extmul_high_i16x8_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extmul_high_i16x8_u(value : V128, other : V128) -> V128 {
+pub fn i32x4_extmul_high_i16x8_u(value : V128, other : V128) -> V128 {
   i32x4_mul(i32x4_extend_high_i16x8_u(value), i32x4_extend_high_i16x8_u(other))
 }
 
@@ -435,8 +407,7 @@ pub fn V128::i32x4_extmul_high_i16x8_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_extmul_low_i32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extmul_low_i32x4_s(value : V128, other : V128) -> V128 {
+pub fn i64x2_extmul_low_i32x4_s(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     (u32_lane(value, i).reinterpret_as_int().to_int64() *
     u32_lane(other, i).reinterpret_as_int().to_int64()).reinterpret_as_uint64()
@@ -448,8 +419,7 @@ pub fn V128::i64x2_extmul_low_i32x4_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_extmul_high_i32x4_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extmul_high_i32x4_s(value : V128, other : V128) -> V128 {
+pub fn i64x2_extmul_high_i32x4_s(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     (u32_lane(value, i + 2).reinterpret_as_int().to_int64() *
     u32_lane(other, i + 2).reinterpret_as_int().to_int64()).reinterpret_as_uint64()
@@ -461,8 +431,7 @@ pub fn V128::i64x2_extmul_high_i32x4_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_extmul_low_i32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extmul_low_i32x4_u(value : V128, other : V128) -> V128 {
+pub fn i64x2_extmul_low_i32x4_u(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     u32_lane(value, i).to_uint64() * u32_lane(other, i).to_uint64()
   })
@@ -473,8 +442,7 @@ pub fn V128::i64x2_extmul_low_i32x4_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i64x2_extmul_high_i32x4_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_extmul_high_i32x4_u(value : V128, other : V128) -> V128 {
+pub fn i64x2_extmul_high_i32x4_u(value : V128, other : V128) -> V128 {
   pack_u64x2_by(i => {
     u32_lane(value, i + 2).to_uint64() * u32_lane(other, i + 2).to_uint64()
   })
@@ -485,8 +453,7 @@ pub fn V128::i64x2_extmul_high_i32x4_u(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_q15mulr_sat_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_q15mulr_sat_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_q15mulr_sat_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => i16_q15mulr_sat_s(u16_lane(value, i), u16_lane(other, i)))
 }
 
@@ -495,8 +462,7 @@ pub fn V128::i16x8_q15mulr_sat_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_relaxed_q15mulr_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_relaxed_q15mulr_s(value : V128, other : V128) -> V128 {
+pub fn i16x8_relaxed_q15mulr_s(value : V128, other : V128) -> V128 {
   i16x8_q15mulr_sat_s(value, other)
 }
 
@@ -505,8 +471,7 @@ pub fn V128::i16x8_relaxed_q15mulr_s(value : V128, other : V128) -> V128 {
 #intrinsic("%v128.i16x8_extadd_pairwise_i8x16_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extadd_pairwise_i8x16_s(value : V128) -> V128 {
+pub fn i16x8_extadd_pairwise_i8x16_s(value : V128) -> V128 {
   pack_u16x8_by(i => {
     (i8_signed(u8_lane(value, i * 2)) + i8_signed(u8_lane(value, i * 2 + 1))).to_uint16()
   })
@@ -517,8 +482,7 @@ pub fn V128::i16x8_extadd_pairwise_i8x16_s(value : V128) -> V128 {
 #intrinsic("%v128.i16x8_extadd_pairwise_i8x16_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_extadd_pairwise_i8x16_u(value : V128) -> V128 {
+pub fn i16x8_extadd_pairwise_i8x16_u(value : V128) -> V128 {
   pack_u16x8_by(i => {
     u8_lane(value, i * 2).to_uint16() + u8_lane(value, i * 2 + 1).to_uint16()
   })
@@ -529,8 +493,7 @@ pub fn V128::i16x8_extadd_pairwise_i8x16_u(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_extadd_pairwise_i16x8_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extadd_pairwise_i16x8_s(value : V128) -> V128 {
+pub fn i32x4_extadd_pairwise_i16x8_s(value : V128) -> V128 {
   pack_u32x4_by(i => {
     (i16_signed(u16_lane(value, i * 2)) + i16_signed(u16_lane(value, i * 2 + 1))).reinterpret_as_uint()
   })
@@ -541,8 +504,7 @@ pub fn V128::i32x4_extadd_pairwise_i16x8_s(value : V128) -> V128 {
 #intrinsic("%v128.i32x4_extadd_pairwise_i16x8_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_extadd_pairwise_i16x8_u(value : V128) -> V128 {
+pub fn i32x4_extadd_pairwise_i16x8_u(value : V128) -> V128 {
   pack_u32x4_by(i => {
     u16_lane(value, i * 2).to_uint() + u16_lane(value, i * 2 + 1).to_uint()
   })
@@ -558,11 +520,7 @@ pub fn V128::i32x4_extadd_pairwise_i16x8_u(value : V128) -> V128 {
 /// fallback below, which is correct on every backend.
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_relaxed_dot_i8x16_i7x16_s(
-  value : V128,
-  other : V128,
-) -> V128 {
+pub fn i16x8_relaxed_dot_i8x16_i7x16_s(value : V128, other : V128) -> V128 {
   pack_u16x8_by(i => {
     (i8_signed(u8_lane(value, i * 2)) * i8_signed(u8_lane(other, i * 2)) +
     i8_signed(u8_lane(value, i * 2 + 1)) * i8_signed(u8_lane(other, i * 2 + 1))).to_uint16()
@@ -574,8 +532,7 @@ pub fn V128::i16x8_relaxed_dot_i8x16_i7x16_s(
 #intrinsic("%v128.i32x4_dot_i16x8_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_dot_i16x8_s(value : V128, other : V128) -> V128 {
+pub fn i32x4_dot_i16x8_s(value : V128, other : V128) -> V128 {
   pack_u32x4_by(i => i16_pair_dot(value, other, i))
 }
 
@@ -591,8 +548,7 @@ pub fn V128::i32x4_dot_i16x8_s(value : V128, other : V128) -> V128 {
 /// fixed; the portable fallback below is correct on every backend.
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_relaxed_dot_i8x16_i7x16_add_s(
+pub fn i32x4_relaxed_dot_i8x16_i7x16_add_s(
   value : V128,
   other : V128,
   accumulator : V128,

--- a/v128/simd_int_shift.mbt
+++ b/v128/simd_int_shift.mbt
@@ -17,8 +17,7 @@
 #intrinsic("%v128.i8x16_shl")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_shl(value : V128, shift : Int) -> V128 {
+pub fn i8x16_shl(value : V128, shift : Int) -> V128 {
   let shift = shift & 7
   pack_u8x16_by(i => (u8_lane(value, i).to_uint() << shift).to_byte())
 }
@@ -28,8 +27,7 @@ pub fn V128::i8x16_shl(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i8x16_shr_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_shr_u(value : V128, shift : Int) -> V128 {
+pub fn i8x16_shr_u(value : V128, shift : Int) -> V128 {
   let shift = shift & 7
   pack_u8x16_by(i => (u8_lane(value, i).to_uint() >> shift).to_byte())
 }
@@ -39,8 +37,7 @@ pub fn V128::i8x16_shr_u(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i8x16_shr_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_shr_s(value : V128, shift : Int) -> V128 {
+pub fn i8x16_shr_s(value : V128, shift : Int) -> V128 {
   let shift = shift & 7
   pack_u8x16_by(i => (i8_signed(u8_lane(value, i)) >> shift).to_byte())
 }
@@ -50,8 +47,7 @@ pub fn V128::i8x16_shr_s(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i16x8_shl")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_shl(value : V128, shift : Int) -> V128 {
+pub fn i16x8_shl(value : V128, shift : Int) -> V128 {
   let shift = shift & 15
   pack_u16x8_by(i => (u16_lane(value, i).to_uint() << shift).to_uint16())
 }
@@ -61,8 +57,7 @@ pub fn V128::i16x8_shl(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i16x8_shr_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_shr_u(value : V128, shift : Int) -> V128 {
+pub fn i16x8_shr_u(value : V128, shift : Int) -> V128 {
   let shift = shift & 15
   pack_u16x8_by(i => (u16_lane(value, i).to_uint() >> shift).to_uint16())
 }
@@ -72,8 +67,7 @@ pub fn V128::i16x8_shr_u(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i16x8_shr_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_shr_s(value : V128, shift : Int) -> V128 {
+pub fn i16x8_shr_s(value : V128, shift : Int) -> V128 {
   let shift = shift & 15
   pack_u16x8_by(i => (i16_signed(u16_lane(value, i)) >> shift).to_uint16())
 }
@@ -83,8 +77,7 @@ pub fn V128::i16x8_shr_s(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i32x4_shl")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_shl(value : V128, shift : Int) -> V128 {
+pub fn i32x4_shl(value : V128, shift : Int) -> V128 {
   let shift = shift & 31
   pack_u32x4_by(i => u32_lane(value, i) << shift)
 }
@@ -94,8 +87,7 @@ pub fn V128::i32x4_shl(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i32x4_shr_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_shr_u(value : V128, shift : Int) -> V128 {
+pub fn i32x4_shr_u(value : V128, shift : Int) -> V128 {
   let shift = shift & 31
   pack_u32x4_by(i => u32_lane(value, i) >> shift)
 }
@@ -105,8 +97,7 @@ pub fn V128::i32x4_shr_u(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i32x4_shr_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_shr_s(value : V128, shift : Int) -> V128 {
+pub fn i32x4_shr_s(value : V128, shift : Int) -> V128 {
   let shift = shift & 31
   pack_u32x4_by(i => {
     (u32_lane(value, i).reinterpret_as_int() >> shift).reinterpret_as_uint()
@@ -118,8 +109,7 @@ pub fn V128::i32x4_shr_s(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i64x2_shl")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_shl(value : V128, shift : Int) -> V128 {
+pub fn i64x2_shl(value : V128, shift : Int) -> V128 {
   let shift = shift & 63
   make(lo(value) << shift, hi(value) << shift)
 }
@@ -129,8 +119,7 @@ pub fn V128::i64x2_shl(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i64x2_shr_u")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_shr_u(value : V128, shift : Int) -> V128 {
+pub fn i64x2_shr_u(value : V128, shift : Int) -> V128 {
   let shift = shift & 63
   make(lo(value) >> shift, hi(value) >> shift)
 }
@@ -140,8 +129,7 @@ pub fn V128::i64x2_shr_u(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i64x2_shr_s")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_shr_s(value : V128, shift : Int) -> V128 {
+pub fn i64x2_shr_s(value : V128, shift : Int) -> V128 {
   let shift = shift & 63
   pack_u64x2_by(i => {
     (u64_lane(value, i).reinterpret_as_int64() >> shift).reinterpret_as_uint64()
@@ -153,8 +141,7 @@ pub fn V128::i64x2_shr_s(value : V128, shift : Int) -> V128 {
 #intrinsic("%v128.i8x16_all_true")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_all_true(value : V128) -> Bool {
+pub fn i8x16_all_true(value : V128) -> Bool {
   for i in 0..<16 {
     if u8_lane(value, i) == 0 {
       return false
@@ -168,8 +155,7 @@ pub fn V128::i8x16_all_true(value : V128) -> Bool {
 #intrinsic("%v128.i16x8_all_true")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_all_true(value : V128) -> Bool {
+pub fn i16x8_all_true(value : V128) -> Bool {
   for i in 0..<8 {
     if u16_lane(value, i) == 0 {
       return false
@@ -183,8 +169,7 @@ pub fn V128::i16x8_all_true(value : V128) -> Bool {
 #intrinsic("%v128.i32x4_all_true")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_all_true(value : V128) -> Bool {
+pub fn i32x4_all_true(value : V128) -> Bool {
   for i in 0..<4 {
     if u32_lane(value, i) == 0 {
       return false
@@ -198,8 +183,7 @@ pub fn V128::i32x4_all_true(value : V128) -> Bool {
 #intrinsic("%v128.i64x2_all_true")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_all_true(value : V128) -> Bool {
+pub fn i64x2_all_true(value : V128) -> Bool {
   lo(value) != 0UL && hi(value) != 0UL
 }
 
@@ -208,8 +192,7 @@ pub fn V128::i64x2_all_true(value : V128) -> Bool {
 #intrinsic("%v128.i8x16_bitmask")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_bitmask(value : V128) -> Int {
+pub fn i8x16_bitmask(value : V128) -> Int {
   let mut result = 0
   for i in 0..<16 {
     result = result | (((u8_lane(value, i).to_int() >> 7) & 1) << i)
@@ -222,8 +205,7 @@ pub fn V128::i8x16_bitmask(value : V128) -> Int {
 #intrinsic("%v128.i16x8_bitmask")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i16x8_bitmask(value : V128) -> Int {
+pub fn i16x8_bitmask(value : V128) -> Int {
   let mut result = 0
   for i in 0..<8 {
     result = result | (((u16_lane(value, i).to_int() >> 15) & 1) << i)
@@ -236,8 +218,7 @@ pub fn V128::i16x8_bitmask(value : V128) -> Int {
 #intrinsic("%v128.i32x4_bitmask")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i32x4_bitmask(value : V128) -> Int {
+pub fn i32x4_bitmask(value : V128) -> Int {
   let mut result = 0
   for i in 0..<4 {
     result = result |
@@ -251,8 +232,7 @@ pub fn V128::i32x4_bitmask(value : V128) -> Int {
 #intrinsic("%v128.i64x2_bitmask")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i64x2_bitmask(value : V128) -> Int {
+pub fn i64x2_bitmask(value : V128) -> Int {
   let mut result = 0
   for i in 0..<2 {
     result = result | ((u64_lane(value, i) >> 63).to_int() << i)

--- a/v128/simd_memory.mbt
+++ b/v128/simd_memory.mbt
@@ -76,8 +76,7 @@ fn i32_extend_s(value : UInt) -> UInt64 {
 #intrinsic("%v128.i8x16_swizzle")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_swizzle(value : V128, indices : V128) -> V128 {
+pub fn i8x16_swizzle(value : V128, indices : V128) -> V128 {
   pack_u8x16_by(i => {
     let index = u8_lane(indices, i).to_int()
     if index < 16 {
@@ -93,8 +92,7 @@ pub fn V128::i8x16_swizzle(value : V128, indices : V128) -> V128 {
 #intrinsic("%v128.i8x16_relaxed_swizzle")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_relaxed_swizzle(value : V128, indices : V128) -> V128 {
+pub fn i8x16_relaxed_swizzle(value : V128, indices : V128) -> V128 {
   i8x16_swizzle(value, indices)
 }
 
@@ -112,8 +110,7 @@ fn shuffle_lane(value : V128, other : V128, index : Int) -> Byte {
 #intrinsic("%v128.i8x16_shuffle")
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
-#as_free_fn
-pub fn V128::i8x16_shuffle(
+pub fn i8x16_shuffle(
   value : V128,
   other : V128,
   i0 : Int,

--- a/v128/v128_test.mbt
+++ b/v128/v128_test.mbt
@@ -1921,24 +1921,6 @@ test "bitmask lane patterns" {
 }
 
 ///|
-test "dot-application (method style via #as_free_fn)" {
-  let a = @v128.i32x4_splat(5)
-  let b = @v128.i32x4_splat(3)
-  // V128-first ops are callable as methods...
-  assert_eq(a.i32x4_add(b), @v128.i32x4_add(a, b))
-  // ...and chain left-to-right
-  assert_eq(
-    a.i32x4_add(b).i32x4_mul(b).i32x4_sub(a),
-    @v128.i32x4_const(19, 19, 19, 19),
-  )
-  // unary and lane ops too
-  assert_eq(a.i32x4_neg().i32x4_abs(), a)
-  assert_eq(@v128.i8x16_splat(0xff).i8x16_extract_lane_u(3), 255)
-  // free-fn form (the wasm-opcode mirror) remains available unchanged
-  assert_eq(@v128.f32x4_splat(2.0).f32x4_sqrt(), @v128.f32x4_splat(1.4142135))
-}
-
-///|
 test "replace_lane out-of-range index leaves value unchanged" {
   let v = @v128.i8x16_const(
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,


### PR DESCRIPTION
We expect users to write `@v128.i8x16_add` for example.