### PR TITLE
refactor(string): add intrinsic for code_units methods

### DIFF
--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -232,8 +232,9 @@ pub fn String::to_array(self : String) -> Array[Char] {
 ///
 /// This method yields code units, not Unicode characters. Surrogate pairs are
 /// represented as two `UInt16` values.
+#intrinsic("%string.code_units")
 pub fn String::code_units(self : String) -> ArrayView[UInt16] {
-  Array::makei(self.length(), i => self.unsafe_get(i))
+  FixedArray::makei(self.length(), i => self.unsafe_get(i))
 }
 
 ///|

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -136,8 +136,14 @@ pub fn StringView::unsafe_get(self : StringView, index : Int) -> UInt16 {
 ///
 /// This method yields code units, not Unicode characters. Surrogate pairs are
 /// represented as two `UInt16` values.
+///
+/// Note: the default implementation copies the entire underlying string into a
+/// fresh `FixedArray` and then slices it, so the returned view does not alias
+/// the original string's storage. Some backends lower the intrinsic to a
+/// zero-copy view instead.
+#intrinsic("%stringview.code_units")
 pub fn StringView::code_units(self : StringView) -> ArrayView[UInt16] {
-  Array::makei(self.length(), i => self.unsafe_get(i))
+  FixedArray::makei(self.str().length(), i => self.str().unsafe_get(i))[self.start():self.end()]
 }
 
 ///|

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -82,6 +82,25 @@ test "StringView::code_units" {
 }
 
 ///|
+test "StringView::code_units start offset" {
+  // Index 0 of the returned view must map to the view's start offset, not the
+  // start of the underlying string.
+  let s = "Hello, 世界"
+  let view = s[7:] // "世界"
+  let units = view.code_units()
+  inspect(units.length(), content="2")
+  inspect(units[0], content="19990") // '世', not 'H'
+  inspect(units[1], content="30028") // '界'
+
+  // A view starting past a surrogate pair still indexes from its own offset.
+  let emoji = "😀ab"[2:] // "ab", skipping the two surrogate code units
+  let emoji_units = emoji.code_units()
+  inspect(emoji_units.length(), content="2")
+  inspect(emoji_units[0], content="97") // 'a'
+  inspect(emoji_units[1], content="98") // 'b'
+}
+
+///|
 test "StringView core operations" {
   let view = "ab😀c".view(start_offset=1)
   inspect(view.char_length(), content="3")


### PR DESCRIPTION
The compiler has added placeholders for these intrinsics but hasn't implemented them yet so all backends use the default implement at this moment.