### PR TITLE
fix(argparse): suggest subcommands on parse errors

### DIFF
--- a/argparse/argparse_blackbox_test.mbt
+++ b/argparse/argparse_blackbox_test.mbt
@@ -509,6 +509,130 @@ test "subcommand help includes inherited global options" {
 }
 
 ///|
+test "subcommand suggestions are only reported for parse failures" {
+  let cmd = @argparse.Command(
+    "demo",
+    positionals=[PositionArg("input", about="input file")],
+    subcommands=[Command("serve", about="serve")],
+  )
+  let positional = cmd.parse(argv=["serv"], env=empty_env()) catch {
+    _ => panic()
+  }
+  assert_true(positional.values is { "input": ["serv"], .. })
+  assert_true(positional.subcommand is None)
+
+  try cmd.parse(argv=["input.txt", "serv"], env=empty_env()) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: unexpected value 'serv' for '<input>' found; no more were expected
+          #|
+          #|  tip: a similar subcommand exists: 'serve'
+          #|
+          #|Usage: demo [input] [command]
+          #|
+          #|Commands:
+          #|  serve  serve
+          #|  help   Print help for the subcommand(s).
+          #|
+          #|Arguments:
+          #|  input  input file
+          #|
+          #|Options:
+          #|  -h, --help  Show help information.
+          #|
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  let no_positionals = @argparse.Command("demo", subcommands=[
+    Command("serve", about="serve"),
+  ])
+  try no_positionals.parse(argv=["hel"], env=empty_env()) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: unexpected value 'hel' found; no more were expected
+          #|
+          #|  tip: a similar subcommand exists: 'help'
+          #|
+          #|Usage: demo [command]
+          #|
+          #|Commands:
+          #|  serve  serve
+          #|  help   Print help for the subcommand(s).
+          #|
+          #|Options:
+          #|  -h, --help  Show help information.
+          #|
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try cmd.parse(argv=["help", "serv"], env=empty_env()) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: unknown subcommand: serv
+          #|
+          #|  tip: a similar subcommand exists: 'serve'
+          #|
+          #|Usage: demo [input] [command]
+          #|
+          #|Commands:
+          #|  serve  serve
+          #|  help   Print help for the subcommand(s).
+          #|
+          #|Arguments:
+          #|  input  input file
+          #|
+          #|Options:
+          #|  -h, --help  Show help information.
+          #|
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+test "help subcommand suggestions exclude hidden commands" {
+  let cmd = @argparse.Command("demo", subcommands=[
+    Command("serve", about="serve"),
+    Command("secret", about="secret", hidden=true),
+  ])
+  try cmd.parse(argv=["help", "secrt"], env=empty_env()) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: unknown subcommand: secrt
+          #|
+          #|Usage: demo [command]
+          #|
+          #|Commands:
+          #|  serve  serve
+          #|  help   Print help for the subcommand(s).
+          #|
+          #|Options:
+          #|  -h, --help  Show help information.
+          #|
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
 test "unknown argument suggestions are exposed" {
   let cmd = @argparse.Command("demo", flags=[
     FlagArg("verbose", short='v', long="verbose"),

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -202,37 +202,27 @@ fn arg_error_for_parse_failure(
   inherited_globals : Array[Arg],
   command_path : String,
 ) -> ArgError {
-  match err {
+  let message = match err {
     MissingGroup(name) =>
-      Message(
-        format_error_with_help(
-          missing_group_error_message(
-            cmd, inherited_globals, command_path, name,
-          ),
-          cmd,
-          inherited_globals,
-          command_path,
-        ),
-      )
-    GroupConflict(_) =>
-      Message(
-        format_error_with_help(
-          err.arg_parse_error_message(),
-          cmd,
-          inherited_globals,
-          command_path,
-        ),
-      )
-    _ =>
-      Message(
-        format_error_with_help(
-          err.arg_parse_error_message(),
-          cmd,
-          inherited_globals,
-          command_path,
-        ),
-      )
+      missing_group_error_message(cmd, inherited_globals, command_path, name)
+    TooManyPositionals(value, _) => {
+      let candidates = [ for sub in cmd.subcommands => sub.name ]
+      if help_subcommand_enabled(cmd) {
+        candidates.push("help")
+      }
+      if suggest_name(value, candidates) is Some(best) {
+        (
+          $|\{err.arg_parse_error_message()}
+          $|
+          $|  tip: a similar subcommand exists: '\{best}'
+        )
+      } else {
+        err.arg_parse_error_message()
+      }
+    }
+    _ => err.arg_parse_error_message()
   }
+  Message(format_error_with_help(message, cmd, inherited_globals, command_path))
 }
 
 ///|

--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -71,7 +71,22 @@ fn resolve_help_target(
       raise InvalidArgument("unexpected help argument: \{name}")
     }
     guard subs.iter().find_first(sub => sub.name == name) is Some(sub) else {
-      raise InvalidArgument("unknown subcommand: \{name}")
+      let message = if suggest_name(
+          name,
+          [
+            for sub in subs if !sub.hidden => sub.name
+          ],
+        )
+        is Some(best) {
+        (
+          $|unknown subcommand: \{name}
+          $|
+          $|  tip: a similar subcommand exists: '\{best}'
+        )
+      } else {
+        "unknown subcommand: \{name}"
+      }
+      raise InvalidArgument(message)
     }
     let current_globals = merge_global_defs(
       current_globals,


### PR DESCRIPTION
## Summary

- Add subcommand suggestions to argparse parse errors when a rejected bare value is close to a known subcommand.
- Add the same hint style to failed `help <subcommand>` lookups.
- Cover that successful positional parses remain silent even when the positional value resembles a subcommand.

## Why

Argparse already suggests near-miss option names, but subcommand typos currently fail without a comparable hint. This makes subcommand-heavy CLIs harder to use and forces downstream tools to duplicate suggestion logic.

## Correctness

The parser only adds a subcommand hint after parsing has already failed, so valid positional arguments are not reclassified as subcommand typos. Normal parse failures include the built-in `help` subcommand as a suggestion candidate, while `help <target>` lookup only suggests actual subcommand targets.

## Scope

The change is limited to argparse error reporting and black-box coverage. It does not add public API surface or generated interface changes.
