### PR TITLE
Optimize Bytes uint64 aligned load

### DIFF
--- a/builtin/bitstring.mbt
+++ b/builtin/bitstring.mbt
@@ -2351,14 +2351,14 @@ pub fn Bytes::unsafe_extract_int_be_aligned(
 }
 
 ///|
-/// Forward to `BytesView::unsafe_extract_uint64_le_aligned`.
+/// Extract an aligned little-endian UInt64 directly from `Bytes`.
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub fn Bytes::unsafe_extract_uint64_le_aligned(
   bs : Bytes,
   byte_offset : Int,
 ) -> UInt64 {
-  bs[:].unsafe_extract_uint64_le_aligned(byte_offset)
+  bs.unsafe_read_uint64_le(byte_offset)
 }
 
 ///|

--- a/builtin/bitstring_uint64_aligned_bench_test.mbt
+++ b/builtin/bitstring_uint64_aligned_bench_test.mbt
@@ -1,0 +1,36 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let bitstring_uint64_aligned_bench_size = 8192
+
+///|
+fn make_bitstring_uint64_aligned_bench_bytes() -> Bytes {
+  Bytes::makei(bitstring_uint64_aligned_bench_size, i => (i & 0xff).to_byte())
+}
+
+///|
+test "bench Bytes::unsafe_extract_uint64_le_aligned n=8192" (it : @bench.T) {
+  let bytes = make_bitstring_uint64_aligned_bench_bytes()
+  let last = bitstring_uint64_aligned_bench_size - 8
+  let mut start = 0
+  it.bench(fn() {
+    start = (start + 1) & 7
+    let mut sum = 0UL
+    for offset = start; offset <= last; offset = offset + 8 {
+      sum = sum ^ bytes.unsafe_extract_uint64_le_aligned(offset)
+    }
+    it.keep(sum)
+  })
+}


### PR DESCRIPTION
## Summary
- avoid constructing a full BytesView for `Bytes::unsafe_extract_uint64_le_aligned`
- read the UInt64 directly from the underlying Bytes value
- add a focused native benchmark for the aligned UInt64 load path

## Benchmarks
Measured with native release benches. Before is `upstream/main@1c53c811` with an equivalent benchmark file applied; after is this PR head `f4ae4351`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Bytes::unsafe_extract_uint64_le_aligned | 513.30 ns | 56.10 ns | 9.15x faster (-89.1%) |

## Validation
- moon fmt
- moon info
- moon test -p moonbitlang/core/builtin --target all
- moon check --target all
- moon bench -p moonbitlang/core/builtin -f bitstring_uint64_aligned_bench_test.mbt --target native --release