### PR TITLE
Optimize Bytes rev_find

### DIFF
--- a/builtin/bytes_find.mbt
+++ b/builtin/bytes_find.mbt
@@ -360,14 +360,34 @@ fn find_long_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
 /// Returns the offset of the last occurrence of the given
 /// bytes substring. If the substring is not found, `None` is returned.
 pub fn BytesView::rev_find(target : BytesView, pattern : BytesView) -> Int? {
-  // TODO: more efficient algorithm
   let target_len = target.length()
   let pattern_len = pattern.length()
-  for i = target_len - pattern_len; i >= 0; i = i - 1 {
-    for j in 0..<pattern_len {
-      guard target.unsafe_get(i + j) == pattern.unsafe_get(j) else { break }
+  if pattern_len == 0 {
+    return Some(target_len)
+  }
+  if pattern_len > target_len {
+    return None
+  }
+  if pattern_len == 1 {
+    let byte = pattern.unsafe_get(0)
+    return for i = target_len - 1; i >= 0; i = i - 1 {
+      if target.unsafe_get(i) == byte {
+        break Some(i)
+      }
     } nobreak {
-      return Some(i)
+      None
+    }
+  }
+  let last_offset = pattern_len - 1
+  let first = pattern.unsafe_get(0)
+  let last = pattern.unsafe_get(last_offset)
+  for candidate = target_len - pattern_len
+      candidate >= 0
+      candidate = candidate - 1 {
+    if target.unsafe_get(candidate) == first &&
+      target.unsafe_get(candidate + last_offset) == last &&
+      find_match_range(target, pattern, candidate, 1, last_offset) {
+      return Some(candidate)
     }
   } nobreak {
     None

--- a/builtin/bytes_find_bench_test.mbt
+++ b/builtin/bytes_find_bench_test.mbt
@@ -1,0 +1,43 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let bytes_find_bench_size = 100_000
+
+///|
+fn make_bytes_find_bench_bytes(
+  needle : Bytes,
+  at~ : Int,
+  fill? : Byte = b'\x61',
+) -> Bytes {
+  let arr = Array::make(bytes_find_bench_size, fill)
+  for i in 0..<needle.length() {
+    arr[at + i] = needle.unsafe_get(i)
+  }
+  Bytes::from_array(arr)
+}
+
+///|
+test "bench Bytes::rev_find short needle at front n=100000" (it : @bench.T) {
+  let needle = b"abc"
+  let bytes = make_bytes_find_bench_bytes(needle, at=0)
+  it.bench(fn() { it.keep(bytes.rev_find(needle)) })
+}
+
+///|
+test "bench Bytes::rev_find long needle at front n=100000" (it : @bench.T) {
+  let needle = b"abcdefghijklmnopqrstuvwxyz0123456789"
+  let bytes = make_bytes_find_bench_bytes(needle, at=0)
+  it.bench(fn() { it.keep(bytes.rev_find(needle)) })
+}

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -425,6 +425,10 @@ test "Bytes find and rev_find" {
   debug_inspect(target.find(b"zzz"), content="None")
   debug_inspect(target[:].find(b"bca"), content="Some(1)")
   debug_inspect(target[:].rev_find(b"bca"), content="Some(1)")
+  debug_inspect(target.rev_find(b""), content="Some(6)")
+  debug_inspect(target.rev_find(b"abcdefg"), content="None")
+  debug_inspect(target.rev_find(b"c"), content="Some(5)")
+  debug_inspect(b"xxabcxxabczz"[2:10].rev_find(pattern), content="Some(5)")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- handle `BytesView::rev_find` edge cases before entering the scan
- check the first and last bytes before comparing the remaining range
- add tests and native benchmarks for worst-case reverse search

## Benchmarks
Measured with native release benches. Before is `upstream/main@1c53c811` with this PR's benchmark file applied; after is this PR head `a023cece`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Bytes::rev_find short needle at front | 52.63 us | 30.79 us | 1.71x faster (-41.5%) |
| Bytes::rev_find long needle at front | 52.49 us | 30.55 us | 1.72x faster (-41.8%) |

Time Profiler traces from the generated native bench executable showed the workload was almost entirely in `BytesView::rev_find`.

## Validation
- moon fmt
- moon info
- moon test -p moonbitlang/core/builtin --target all
- moon check --target all
- moon bench -p moonbitlang/core/builtin -f bytes_find_bench_test.mbt --target native --release