### PR TITLE
Optimize Array retain

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1203,17 +1203,22 @@ pub fn[T] Array::swap(self : Array[T], i : Int, j : Int) -> Unit {
 ///   debug_inspect(arr, content="[1, 2, 3]")
 /// }
 /// ```
-/// TODO: perf could be improved
 #locals(f)
 pub fn[T] Array::retain(self : Array[T], f : (T) -> Bool raise?) -> Unit raise? {
-  for v in self; j = 0 {
+  let len = self.length()
+  let write = for read, v in self; write = 0 {
     if f(v) {
-      self.unsafe_set(j, v)
-      continue j + 1
+      if read != write {
+        self.unsafe_set(write, v)
+      }
+      continue write + 1
     }
-    continue j
+    continue write
   } nobreak {
-    self.unsafe_truncate_to_length(j)
+    write
+  }
+  if write != len {
+    self.unsafe_truncate_to_length(write)
   }
 }
 

--- a/builtin/array_retain_bench_test.mbt
+++ b/builtin/array_retain_bench_test.mbt
@@ -1,0 +1,84 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let array_retain_bench_size = 100_000
+
+///|
+fn make_array_retain_bench_ints() -> Array[Int] {
+  Array::makei(array_retain_bench_size, i => i)
+}
+
+///|
+fn make_array_retain_bench_refs() -> Array[Ref[Int]] {
+  Array::makei(array_retain_bench_size, i => Ref(i))
+}
+
+///|
+test "bench Array::retain all keep Int n=100000" (it : @bench.T) {
+  let data = make_array_retain_bench_ints()
+  it.bench(fn() {
+    let mut checksum = 0
+    data.retain(x => {
+      checksum = checksum ^ x
+      true
+    })
+    it.keep(checksum)
+  })
+}
+
+///|
+test "bench Array::retain all keep Ref n=100000" (it : @bench.T) {
+  let data = make_array_retain_bench_refs()
+  it.bench(fn() {
+    let mut checksum = 0
+    data.retain(x => {
+      checksum = checksum ^ x.val
+      true
+    })
+    it.keep(checksum)
+  })
+}
+
+///|
+test "bench Array::retain drop tail n=100000" (it : @bench.T) {
+  let base = make_array_retain_bench_ints()
+  let last = array_retain_bench_size - 1
+  it.bench(fn() {
+    let data = base.copy()
+    data.retain(x => x < last)
+    it.keep(data.length())
+  })
+}
+
+///|
+test "bench Array::retain late sparse drop n=100000" (it : @bench.T) {
+  let base = make_array_retain_bench_ints()
+  let half = array_retain_bench_size / 2
+  it.bench(fn() {
+    let data = base.copy()
+    data.retain(x => x < half || (x & 1) == 0)
+    it.keep(data.length())
+  })
+}
+
+///|
+test "bench Array::retain drop first n=100000" (it : @bench.T) {
+  let base = make_array_retain_bench_ints()
+  it.bench(fn() {
+    let data = base.copy()
+    data.retain(x => x > 0)
+    it.keep(data.length())
+  })
+}


### PR DESCRIPTION
## Summary
- avoid redundant self-writes in `Array::retain` before any element is removed
- skip truncation when the retained length is unchanged
- add a focused native benchmark for common retain patterns

## Benchmarks
Measured with native release benches on `upstream/main@1c53c811` before and this PR head `febfc642` after.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `Array::retain all keep Int n=100000` | 31.08 us | 2.98 us | 10.4x faster |
| `Array::retain all keep Ref n=100000` | 67.31 us | 24.81 us | 2.7x faster |
| `Array::retain drop tail n=100000` | 39.59 us | 34.41 us | 1.15x faster |
| `Array::retain late sparse drop n=100000` | 55.71 us | 44.60 us | 1.25x faster |
| `Array::retain drop first n=100000` | 37.44 us | 34.47 us | 1.09x faster |

## Validation
- `moon fmt`
- `moon info`
- `moon test -p moonbitlang/core/builtin --target all`
- `moon check --target all`
- `moon bench -p moonbitlang/core/builtin -f array_retain_bench_test.mbt --target native --release`
