### PR TITLE
Optimize aligned bitstring integer extraction

### DIFF
--- a/builtin/bitstring.mbt
+++ b/builtin/bitstring.mbt
@@ -108,8 +108,16 @@ pub fn ArrayView::unsafe_extract_uint_le(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    let byte_offset = offset >> 3
+    if len == 16 {
+      return bs.unsafe_extract_uint16_le_aligned(byte_offset)
+    }
+    if len == 32 {
+      return bs.unsafe_extract_uint_le_aligned(byte_offset)
+    }
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -146,8 +154,16 @@ pub fn ArrayView::unsafe_extract_uint_be(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    let byte_offset = offset >> 3
+    if len == 16 {
+      return bs.unsafe_extract_uint16_be_aligned(byte_offset)
+    }
+    if len == 32 {
+      return bs.unsafe_extract_uint_be_aligned(byte_offset)
+    }
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -191,8 +207,10 @@ pub fn ArrayView::unsafe_extract_uint64_le(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if (offset & 7) == 0 && len == 64 {
+    return bs.unsafe_extract_uint64_le_aligned(offset >> 3)
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()
@@ -253,8 +271,10 @@ pub fn ArrayView::unsafe_extract_uint64_be(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if (offset & 7) == 0 && len == 64 {
+    return bs.unsafe_extract_uint64_be_aligned(offset >> 3)
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()
@@ -984,8 +1004,16 @@ pub fn BytesView::unsafe_extract_uint_le(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    let byte_offset = offset >> 3
+    if len == 16 {
+      return bs.unsafe_extract_uint16_le_aligned(byte_offset)
+    }
+    if len == 32 {
+      return bs.unsafe_extract_uint_le_aligned(byte_offset)
+    }
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -1022,8 +1050,16 @@ pub fn BytesView::unsafe_extract_uint_be(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    let byte_offset = offset >> 3
+    if len == 16 {
+      return bs.unsafe_extract_uint16_be_aligned(byte_offset)
+    }
+    if len == 32 {
+      return bs.unsafe_extract_uint_be_aligned(byte_offset)
+    }
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -1067,8 +1103,10 @@ pub fn BytesView::unsafe_extract_uint64_le(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if (offset & 7) == 0 && len == 64 {
+    return bs.unsafe_extract_uint64_le_aligned(offset >> 3)
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()
@@ -1129,8 +1167,10 @@ pub fn BytesView::unsafe_extract_uint64_be(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if (offset & 7) == 0 && len == 64 {
+    return bs.unsafe_extract_uint64_be_aligned(offset >> 3)
+  }
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()

--- a/builtin/bitstring_generic_aligned_bench_test.mbt
+++ b/builtin/bitstring_generic_aligned_bench_test.mbt
@@ -1,0 +1,154 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let bitstring_generic_aligned_bench_size = 8192
+
+///|
+fn make_bitstring_generic_aligned_bench_bytes() -> Bytes {
+  Bytes::makei(bitstring_generic_aligned_bench_size, i => (i & 0xff).to_byte())
+}
+
+///|
+fn make_bitstring_generic_aligned_bench_array() -> Array[Byte] {
+  Array::makei(bitstring_generic_aligned_bench_size, i => (i & 0xff).to_byte())
+}
+
+///|
+test "bench BytesView::unsafe_extract_uint_le aligned len=32 n=8192" (
+  it : @bench.T,
+) {
+  let bytes = make_bitstring_generic_aligned_bench_bytes()
+  let view = bytes[:]
+  let last = bitstring_generic_aligned_bench_size - 4
+  it.bench(fn() {
+    let mut sum = 0U
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      sum = sum ^ view.unsafe_extract_uint_le(byte_offset << 3, 32)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::unsafe_extract_uint_le aligned len=32 n=8192" (
+  it : @bench.T,
+) {
+  let arr = make_bitstring_generic_aligned_bench_array()
+  let view = arr[:]
+  let last = bitstring_generic_aligned_bench_size - 4
+  it.bench(fn() {
+    let mut sum = 0U
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      sum = sum ^ view.unsafe_extract_uint_le(byte_offset << 3, 32)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench BytesView::unsafe_extract_uint_be aligned len=32 n=8192" (
+  it : @bench.T,
+) {
+  let bytes = make_bitstring_generic_aligned_bench_bytes()
+  let view = bytes[:]
+  let last = bitstring_generic_aligned_bench_size - 4
+  it.bench(fn() {
+    let mut sum = 0U
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      sum = sum ^ view.unsafe_extract_uint_be(byte_offset << 3, 32)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::unsafe_extract_uint_be aligned len=32 n=8192" (
+  it : @bench.T,
+) {
+  let arr = make_bitstring_generic_aligned_bench_array()
+  let view = arr[:]
+  let last = bitstring_generic_aligned_bench_size - 4
+  it.bench(fn() {
+    let mut sum = 0U
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      sum = sum ^ view.unsafe_extract_uint_be(byte_offset << 3, 32)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench BytesView::unsafe_extract_uint64_le aligned len=64 n=8192" (
+  it : @bench.T,
+) {
+  let bytes = make_bitstring_generic_aligned_bench_bytes()
+  let view = bytes[:]
+  let last = bitstring_generic_aligned_bench_size - 8
+  it.bench(fn() {
+    let mut sum = 0UL
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      sum = sum ^ view.unsafe_extract_uint64_le(byte_offset << 3, 64)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench BytesView::unsafe_extract_uint64_be aligned len=64 n=8192" (
+  it : @bench.T,
+) {
+  let bytes = make_bitstring_generic_aligned_bench_bytes()
+  let view = bytes[:]
+  let last = bitstring_generic_aligned_bench_size - 8
+  it.bench(fn() {
+    let mut sum = 0UL
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      sum = sum ^ view.unsafe_extract_uint64_be(byte_offset << 3, 64)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::unsafe_extract_uint64_be aligned len=64 n=8192" (
+  it : @bench.T,
+) {
+  let arr = make_bitstring_generic_aligned_bench_array()
+  let view = arr[:]
+  let last = bitstring_generic_aligned_bench_size - 8
+  it.bench(fn() {
+    let mut sum = 0UL
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      sum = sum ^ view.unsafe_extract_uint64_be(byte_offset << 3, 64)
+    }
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench ArrayView::unsafe_extract_uint64_le aligned len=64 n=8192" (
+  it : @bench.T,
+) {
+  let arr = make_bitstring_generic_aligned_bench_array()
+  let view = arr[:]
+  let last = bitstring_generic_aligned_bench_size - 8
+  it.bench(fn() {
+    let mut sum = 0UL
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      sum = sum ^ view.unsafe_extract_uint64_le(byte_offset << 3, 64)
+    }
+    it.keep(sum)
+  })
+}


### PR DESCRIPTION
## Summary
- add exact-width byte-aligned fast paths to generic bitstring integer extraction
- cover `ArrayView[Byte]` and `BytesView` for 16/32-bit UInt and 64-bit UInt64 extraction
- add focused native benchmarks for aligned generic `unsafe_extract_uint*` calls

## Benchmarks
Measured with native release benches. Before is `upstream/main@1c53c811` with an equivalent benchmark file applied; after is this PR head `7d8649c9`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `BytesView::unsafe_extract_uint_le aligned len=32` | 3.34 us | 2.07 us | 1.61x faster (-38.0%) |
| `ArrayView::unsafe_extract_uint_le aligned len=32` | 2.77 us | 2.25 us | 1.23x faster (-18.8%) |
| `BytesView::unsafe_extract_uint_be aligned len=32` | 3.18 us | 2.41 us | 1.32x faster (-24.2%) |
| `ArrayView::unsafe_extract_uint_be aligned len=32` | 3.71 us | 2.11 us | 1.76x faster (-43.1%) |
| `BytesView::unsafe_extract_uint64_le aligned len=64` | 1.89 us | 1.20 us | 1.57x faster (-36.5%) |
| `BytesView::unsafe_extract_uint64_be aligned len=64` | 2.17 us | 1.51 us | 1.44x faster (-30.4%) |
| `ArrayView::unsafe_extract_uint64_be aligned len=64` | 1.99 us | 1.45 us | 1.37x faster (-27.1%) |
| `ArrayView::unsafe_extract_uint64_le aligned len=64` | 1.93 us | 1.47 us | 1.31x faster (-23.8%) |

## Validation
- `moon fmt`
- `moon info`
- `moon test -p moonbitlang/core/builtin --target all`
- `moon check --target all`
- `moon bench -p moonbitlang/core/builtin -f bitstring_generic_aligned_bench_test.mbt --target native --release`
