### PR TITLE
Optimize FixedArray map

### DIFF
--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -498,9 +498,10 @@ pub fn[T, U] FixedArray::map(
   if self.is_empty() {
     return []
   }
-  let res = FixedArray::make(self.length(), f(self[0]))
-  for i in 1..<self.length() {
-    res[i] = f(self[i])
+  let len = self.length()
+  let res = FixedArray::make(len, f(self.unsafe_get(0)))
+  for i in 1..<len {
+    res.unsafe_set(i, f(self.unsafe_get(i)))
   }
   res
 }
@@ -536,9 +537,10 @@ pub fn[T, U] FixedArray::mapi(
   if self.is_empty() {
     return []
   }
-  let res = FixedArray::make(self.length(), f(0, self[0]))
-  for i in 1..<self.length() {
-    res[i] = f(i, self[i])
+  let len = self.length()
+  let res = FixedArray::make(len, f(0, self.unsafe_get(0)))
+  for i in 1..<len {
+    res.unsafe_set(i, f(i, self.unsafe_get(i)))
   }
   res
 }


### PR DESCRIPTION
## Summary
- optimize `FixedArray::map` and `FixedArray::mapi` by caching the length
- use `unsafe_get` / `unsafe_set` inside loops where bounds are already guaranteed
- keep behavior and public API unchanged

## Context
This follows the dependency hotspot analysis:
https://gist.github.com/mizchi/28f382dd0d9c7c1cb0ef42b202f7f24e

The dependency/call graph makes `builtin` the highest-priority optimization area by fan-out, with array-like primitives among the most frequently referenced operations. `FixedArray::map/mapi` were selected from that group because they still used safe indexing inside known-bounded loops, making the change local, API-neutral, and broadly relevant.

## Benchmarks
Measured with native release benches. Before is `upstream/main@1c53c811`; after is this PR head `862df258`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `FixedArray::map n=100000` | 38.37 us | 10.36 us | 3.70x faster (-73.0%) |
| `FixedArray::mapi n=100000` | 38.10 us | 9.84 us | 3.87x faster (-74.2%) |

## Validation
- `moon fmt`
- `moon info`
- `moon test -p moonbitlang/core/builtin --target all`
- `moon check --target all`
- `moon bench -p moonbitlang/core/builtin -f array_locals_bench_test.mbt --target native --release`
