### PR TITLE
Optimize StringBuilder writes

### DIFF
--- a/builtin/stringbuilder.mbt
+++ b/builtin/stringbuilder.mbt
@@ -76,7 +76,5 @@ pub fn StringBuilder::write_stringview(
   self : StringBuilder,
   view : StringView,
 ) -> Unit {
-  let start = view.start()
-  let end = view.end()
-  self.write_substring(view.str(), start, end - start)
+  self.write_view(view)
 }

--- a/builtin/stringbuilder_bench_test.mbt
+++ b/builtin/stringbuilder_bench_test.mbt
@@ -1,0 +1,105 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let stringbuilder_bench_repeats = 4096
+
+///|
+let stringbuilder_bench_piece = "abcdefghijklmnop"
+
+///|
+let stringbuilder_bench_source = "0123456789abcdefghijklmnopQRSTUVWXYZ"
+
+///|
+let stringbuilder_bench_view : StringView = stringbuilder_bench_source[10:26]
+
+///|
+test "bench StringBuilder::write_string chunks n=4096" (it : @bench.T) {
+  let piece = stringbuilder_bench_piece
+  let size_hint = piece.length() * stringbuilder_bench_repeats * 2
+  it.bench(fn() {
+    let builder = StringBuilder(size_hint~)
+    for _ in 0..<stringbuilder_bench_repeats {
+      builder.write_string(piece)
+    }
+    it.keep(builder.to_string().length())
+  })
+}
+
+///|
+test "bench StringBuilder::write_view chunks n=4096" (it : @bench.T) {
+  let view = stringbuilder_bench_view
+  let size_hint = view.length() * stringbuilder_bench_repeats * 2
+  it.bench(fn() {
+    let builder = StringBuilder(size_hint~)
+    for _ in 0..<stringbuilder_bench_repeats {
+      builder.write_view(view)
+    }
+    it.keep(builder.to_string().length())
+  })
+}
+
+///|
+test "bench StringBuilder::write_stringview chunks n=4096" (it : @bench.T) {
+  let view = stringbuilder_bench_view
+  let size_hint = view.length() * stringbuilder_bench_repeats * 2
+  it.bench(fn() {
+    let builder = StringBuilder(size_hint~)
+    for _ in 0..<stringbuilder_bench_repeats {
+      builder.write_stringview(view)
+    }
+    it.keep(builder.to_string().length())
+  })
+}
+
+///|
+test "bench StringBuilder::write_char ASCII n=4096" (it : @bench.T) {
+  let size_hint = stringbuilder_bench_repeats * 2
+  it.bench(fn() {
+    let builder = StringBuilder(size_hint~)
+    for _ in 0..<stringbuilder_bench_repeats {
+      builder.write_char('x')
+    }
+    it.keep(builder.to_string().length())
+  })
+}
+
+///|
+test "bench StringBuilder::write_char non-BMP n=4096" (it : @bench.T) {
+  let ch = (0x1F923).unsafe_to_char()
+  let size_hint = stringbuilder_bench_repeats * 4
+  it.bench(fn() {
+    let builder = StringBuilder(size_hint~)
+    for _ in 0..<stringbuilder_bench_repeats {
+      builder.write_char(ch)
+    }
+    it.keep(builder.to_string().length())
+  })
+}
+
+///|
+test "bench StringBuilder::reset reuse spare capacity n=4096" (it : @bench.T) {
+  let piece = stringbuilder_bench_piece
+  let size_hint = piece.length() * 4
+  it.bench(fn() {
+    let builder = StringBuilder(size_hint~)
+    let mut sum = 0
+    for _ in 0..<stringbuilder_bench_repeats {
+      builder.write_string(piece)
+      sum += builder.to_string().length()
+      builder.reset()
+    }
+    it.keep(sum)
+  })
+}

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -77,7 +77,7 @@ fn FixedArray::unsafe_blit_from_string(
 ) -> Unit {
   let end_str_offset = str_offset + len
   for i = str_offset, j = dst_offset; i < end_str_offset; i = i + 1, j = j + 1 {
-    self[j] = str.unsafe_get(i)
+    self.unsafe_set(j, str.unsafe_get(i))
   }
 }
 
@@ -85,6 +85,9 @@ fn FixedArray::unsafe_blit_from_string(
 /// Writes a string to the StringBuilder.
 pub impl Logger for StringBuilder with fn write_string(self, str) {
   let str_len = str.length()
+  if str_len == 0 {
+    return
+  }
   self.grow_if_necessary(self.len + str_len)
   self.data.unsafe_blit_from_string(self.len, str, 0, str_len)
   self.len += str_len
@@ -133,6 +136,9 @@ pub impl Logger for StringBuilder with fn write_view(
   str : StringView,
 ) -> Unit {
   let str_len = str.length()
+  if str_len == 0 {
+    return
+  }
   self.grow_if_necessary(self.len + str_len)
   self.data.unsafe_blit_from_string(
     self.len,
@@ -146,7 +152,9 @@ pub impl Logger for StringBuilder with fn write_view(
 ///|
 /// Returns the current content of the StringBuilder as a string.
 pub fn StringBuilder::to_string(self : StringBuilder) -> String {
-  if self.len == self.data.length() {
+  if self.len == 0 {
+    ""
+  } else if self.len == self.data.length() {
     unsafe_fixedarray_uint16_to_string(self.data)
   } else {
     let data = FixedArray::make_and_blit(


### PR DESCRIPTION
## Summary
- optimize native `StringBuilder` bulk writes by using `FixedArray::unsafe_set` inside the private string blit loop
- route `StringBuilder::write_stringview` directly through `write_view`
- return `""` directly for empty `StringBuilder::to_string`
- add focused `StringBuilder` benchmarks

## Context
This follows the dependency hotspot analysis:
https://gist.github.com/mizchi/28f382dd0d9c7c1cb0ef42b202f7f24e

The dependency/call graph makes `builtin` the highest-priority optimization area by fan-out. Within that, `StringBuilder` and `Logger` paths are frequent because they sit underneath `Show`, string construction, JSON/debug output, and other formatting-heavy code. This PR keeps the public API unchanged and only tightens local hot paths.

## Benchmarks
Measured with native release benches. Before is `upstream/main@607c2745`; after is this PR head `a9fb4bd6`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `StringBuilder::write_string chunks n=4096` | 46.81 us | 12.34 us | 3.79x faster (-73.6%) |
| `StringBuilder::write_view chunks n=4096` | 38.32 us | 19.09 us | 2.01x faster (-50.2%) |
| `StringBuilder::write_stringview chunks n=4096` | 37.66 us | 19.20 us | 1.96x faster (-49.0%) |
| `StringBuilder::reset reuse spare capacity n=4096` | 88.47 us | 67.95 us | 1.30x faster (-23.2%) |
| `StringBuilder::write_char ASCII n=4096` | 4.30 us | 3.97 us | 1.08x faster (-7.7%) |
| `StringBuilder::write_char non-BMP n=4096` | 8.51 us | 8.45 us | 1.01x faster (-0.7%) |

I also tried a copy-on-write `reset` optimization, but dropped it because the extra shared-buffer check regressed one-character writes.

## Validation
- `moon fmt`
- `moon info`
- `moon test -p moonbitlang/core/builtin --target all`
- `moon check --target all`
- `moon bench -p moonbitlang/core/builtin -f stringbuilder_bench_test.mbt --target native --release`
