### PR TITLE
Add argparse default subcommand dispatch

### DIFF
--- a/argparse/argparse_blackbox_test.mbt
+++ b/argparse/argparse_blackbox_test.mbt
@@ -331,6 +331,267 @@ test "global flag keeps parent argv over child env fallback" {
 }
 
 ///|
+test "default subcommand dispatches through normal child parsing" {
+  let tui = @argparse.Command(
+    "tui",
+    about="Start interactive UI",
+    flags=[FlagArg("trace", short='t')],
+    options=[OptionArg("theme", long="theme")],
+    positionals=[PositionArg("workspace")],
+  )
+  let mcp = @argparse.Command("mcp", about="Run MCP server", options=[
+    OptionArg("port", long="port"),
+  ])
+  let cmd = @argparse.Command(
+    "openseek",
+    options=[OptionArg("config", long="config", global=true)],
+    flags=[FlagArg("verbose", short='v', action=Count, global=true)],
+    subcommands=[tui, mcp],
+    default_subcommand="tui",
+  )
+
+  let bare = cmd.parse(argv=[], env=empty_env()) catch { _ => panic() }
+  assert_true(bare.subcommand is Some(("tui", _)))
+
+  let defaulted = cmd.parse(
+    argv=["--config", "config.toml", "--theme", "dark", "workspace"],
+    env=empty_env(),
+  ) catch {
+    _ => panic()
+  }
+  assert_true(defaulted.values is { "config": ["config.toml"], .. })
+  assert_true(
+    defaulted.subcommand is Some(("tui", sub)) &&
+    sub.values
+    is {
+      "config": ["config.toml"],
+      "theme": ["dark"],
+      "workspace": ["workspace"],
+      ..
+    },
+  )
+
+  let short_global = cmd.parse(argv=["-v", "--theme", "dark"], env=empty_env()) catch {
+    _ => panic()
+  }
+  assert_true(short_global.flag_counts is { "verbose": 1, .. })
+  assert_true(
+    short_global.subcommand is Some(("tui", sub)) &&
+    sub.values is { "theme": ["dark"], .. } &&
+    sub.flag_counts is { "verbose": 1, .. },
+  )
+
+  let mixed_short = cmd.parse(argv=["-vt"], env=empty_env()) catch {
+    _ => panic()
+  }
+  assert_true(mixed_short.flag_counts is { "verbose": 1, .. })
+  assert_true(
+    mixed_short.subcommand is Some(("tui", sub)) &&
+    sub.flags is { "trace": true, .. } &&
+    sub.flag_counts is { "verbose": 1, .. },
+  )
+
+  let explicit = cmd.parse(argv=["mcp", "--port", "9000"], env=empty_env()) catch {
+    _ => panic()
+  }
+  assert_true(
+    explicit.subcommand is Some(("mcp", sub)) &&
+    sub.values is { "port": ["9000"], .. },
+  )
+}
+
+///|
+test "default subcommand gives exact subcommands precedence over positionals" {
+  let cmd = @argparse.Command(
+    "openseek",
+    subcommands=[
+      Command("tui", positionals=[PositionArg("workspace")]),
+      Command("mcp"),
+    ],
+    default_subcommand="tui",
+  )
+
+  let explicit = cmd.parse(argv=["mcp"], env=empty_env()) catch { _ => panic() }
+  assert_true(explicit.subcommand is Some(("mcp", _)))
+
+  let positional = cmd.parse(argv=["project"], env=empty_env()) catch {
+    _ => panic()
+  }
+  assert_true(
+    positional.subcommand is Some(("tui", sub)) &&
+    sub.values is { "workspace": ["project"], .. },
+  )
+
+  let explicit_default = cmd.parse(argv=["tui", "mcp"], env=empty_env()) catch {
+    _ => panic()
+  }
+  assert_true(
+    explicit_default.subcommand is Some(("tui", sub)) &&
+    sub.values is { "workspace": ["mcp"], .. },
+  )
+
+  let after_dash_dash = cmd.parse(argv=["--", "mcp"], env=empty_env()) catch {
+    _ => panic()
+  }
+  assert_true(
+    after_dash_dash.subcommand is Some(("tui", sub)) &&
+    sub.values is { "workspace": ["mcp"], .. },
+  )
+}
+
+///|
+test "default subcommand help annotation and child error context" {
+  let cmd = @argparse.Command(
+    "openseek",
+    options=[OptionArg("config", long="config", about="config", global=true)],
+    subcommands=[
+      Command("tui", about="Start interactive UI", options=[
+        OptionArg("theme", long="theme", about="theme"),
+      ]),
+      Command("mcp", about="Run MCP server"),
+    ],
+    default_subcommand="tui",
+  )
+
+  inspect(
+    cmd.render_help(),
+    content=(
+      #|Usage: openseek [options] [command]
+      #|
+      #|Commands:
+      #|  tui   Start interactive UI (default)
+      #|  mcp   Run MCP server
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help         Show help information.
+      #|  --config <config>  config
+      #|
+    ),
+  )
+
+  try cmd.parse(argv=["--unknown"], env=empty_env()) catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: unexpected argument '--unknown' found
+          #|
+          #|Usage: openseek tui [options]
+          #|
+          #|Start interactive UI
+          #|
+          #|Options:
+          #|  -h, --help         Show help information.
+          #|  --config <config>  config
+          #|  --theme <theme>    theme
+          #|
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+test "default subcommand validation rejects ambiguous root configuration" {
+  try
+    @argparse.Command(
+      "demo",
+      subcommands=[Command("run")],
+      default_subcommand="missing",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand must name a visible subcommand: missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      subcommands=[Command("run")],
+      subcommand_required=true,
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand cannot be used with subcommand_required
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      subcommands=[Command("run")],
+      arg_required_else_help=true,
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand cannot be used with arg_required_else_help
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      options=[OptionArg("mode", long="mode")],
+      subcommands=[Command("run")],
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand only supports global root flags/options
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      flags=[FlagArg("verbose", long="verbose", global=true)],
+      groups=[ArgGroup("verbosity", args=["verbose"])],
+      subcommands=[Command("run")],
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand does not support root groups
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
 test "subcommand cannot follow positional arguments" {
   let cmd = @argparse.Command("demo", positionals=[PositionArg("input")], subcommands=[
     Command("run"),

--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -26,6 +26,7 @@ pub struct Command {
   priv disable_help_subcommand : Bool
   priv arg_required_else_help : Bool
   priv subcommand_required : Bool
+  priv default_subcommand : String?
   priv hidden : Bool
   priv mut build_error : ArgBuildError?
 } derive(@debug.Debug)
@@ -41,6 +42,7 @@ pub struct Command {
 /// - `disable_help_subcommand` disables built-in `help <subcommand>` routing.
 /// - `arg_required_else_help=true` prints help when no argv tokens are provided.
 /// - `subcommand_required=true` requires selecting a subcommand.
+/// - `default_subcommand` dispatches missing subcommands to a visible child.
 /// - `hidden=true` omits this command from parent command listings.
 #alias(new, deprecated="Use `Command()` instead")
 pub fn Command::Command(
@@ -58,6 +60,7 @@ pub fn Command::Command(
   subcommand_required? : Bool = false,
   hidden? : Bool = false,
   groups? : ArrayView[ArgGroup] = [],
+  default_subcommand? : StringView,
 ) -> Command {
   let (parsed_args, arg_error) = collect_args(flags, options, positionals)
   let groups = groups.to_owned()
@@ -73,6 +76,7 @@ pub fn Command::Command(
     disable_help_subcommand,
     arg_required_else_help,
     subcommand_required,
+    default_subcommand: default_subcommand.map(v => v.to_owned()),
     hidden,
     build_error: arg_error,
   }

--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -240,7 +240,17 @@ fn positional_entries(cmd : Command) -> Array[String] {
 fn subcommand_entries(cmd : Command) -> Array[String] {
   let display = [
     for sub in cmd.subcommands if !sub.hidden => {
-      (sub.name, sub.about.unwrap_or(""))
+      let doc = sub.about.unwrap_or("")
+      let doc = if cmd.default_subcommand is Some(name) && name == sub.name {
+        if doc == "" {
+          "(default)"
+        } else {
+          "\{doc} (default)"
+        }
+      } else {
+        doc
+      }
+      (sub.name, doc)
     }
   ]
   if help_subcommand_enabled(cmd) {

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -367,9 +367,62 @@ fn parse_command_impl(
   let positional_values = []
   let mut i = 0
   let mut positional_arg_found = false
+  let default_subcommand = match cmd.default_subcommand {
+    Some(default_name) =>
+      subcommands
+      .iter()
+      .find_first(sub => sub.name == default_name && !sub.hidden)
+    None => None
+  }
+  fn dispatch_subcommand(
+    sub : Command,
+    rest : ArrayView[String],
+  ) -> Matches raise _ {
+    let sub_path = if command_path == "" {
+      sub.name
+    } else {
+      "\{command_path} \{sub.name}"
+    }
+    let child_local_non_globals = collect_non_global_names(sub.args)
+    let child_seed = seed_child_globals_from_parent(
+      matches, child_globals, child_local_non_globals,
+    )
+    let sub_matches = parse_command(
+      sub,
+      rest,
+      env,
+      child_globals,
+      child_version_long,
+      child_version_short,
+      sub_path,
+      seed_matches=child_seed,
+    )
+    matches.parsed_subcommand = Some((sub.name, sub_matches))
+    // Merge argv-provided globals from the subcommand parse into the parent
+    // so globals work even when they appear after the subcommand name.
+    merge_globals_from_child(
+      matches, sub_matches, child_globals, child_local_non_globals,
+    )
+    let env_args = env_resolution_args(inherited_globals, args)
+    let parent_matches = finalize_matches(
+      cmd, args, groups, matches, positionals, positional_values, env_args, env,
+    )
+    validate_relationships(parent_matches, args)
+    if parent_matches.parsed_subcommand is Some((sub_name, sub_m)) {
+      // After parent parsing, copy the final globals into the subcommand.
+      propagate_globals_to_child(
+        parent_matches, sub_m, child_globals, child_local_non_globals,
+      )
+      parent_matches.parsed_subcommand = Some((sub_name, sub_m))
+    }
+    parent_matches
+  }
   while i < argv.length() {
     let arg = argv[i]
     if arg == "--" {
+      if default_subcommand is Some(sub) {
+        return dispatch_subcommand(sub, argv[i:])
+      }
       if i + 1 < argv.length() {
         positional_arg_found = true
       }
@@ -430,6 +483,8 @@ fn parse_command_impl(
             }
             matches.flags[spec.name] = value
             matches.flag_sources[spec.name] = Argv
+          } else if default_subcommand is Some(sub) {
+            return dispatch_subcommand(sub, argv[i:])
           } else {
             raise_unknown_long(name, long_index)
           }
@@ -487,7 +542,17 @@ fn parse_command_impl(
         }
         let spec = match short_index.get(short) {
           Some(v) => v
-          None => raise_unknown_short(short, short_index)
+          None =>
+            if default_subcommand is Some(sub) {
+              let remaining = Array::new(capacity=argv.length() - i)
+              remaining.push("-\{short}\{String::from_iter(chars)}")
+              for rest in argv[i + 1:] {
+                remaining.push(rest)
+              }
+              return dispatch_subcommand(sub, remaining)
+            } else {
+              raise_unknown_short(short, short_index)
+            }
         }
         if spec.info is (OptionInfo(_) | PositionalInfo(_)) {
           check_duplicate_set_occurrence(matches, spec)
@@ -546,50 +611,18 @@ fn parse_command_impl(
       if positional_arg_found {
         raise_subcommand_conflict(sub.name)
       }
-      let rest = argv[i + 1:]
-      let sub_path = if command_path == "" {
-        sub.name
-      } else {
-        "\{command_path} \{sub.name}"
-      }
-      let child_local_non_globals = collect_non_global_names(sub.args)
-      let child_seed = seed_child_globals_from_parent(
-        matches, child_globals, child_local_non_globals,
-      )
-      let sub_matches = parse_command(
-        sub,
-        rest,
-        env,
-        child_globals,
-        child_version_long,
-        child_version_short,
-        sub_path,
-        seed_matches=child_seed,
-      )
-      matches.parsed_subcommand = Some((sub.name, sub_matches))
-      // Merge argv-provided globals from the subcommand parse into the parent
-      // so globals work even when they appear after the subcommand name.
-      merge_globals_from_child(
-        matches, sub_matches, child_globals, child_local_non_globals,
-      )
-      let env_args = env_resolution_args(inherited_globals, args)
-      let parent_matches = finalize_matches(
-        cmd, args, groups, matches, positionals, positional_values, env_args, env,
-      )
-      validate_relationships(parent_matches, args)
-      if parent_matches.parsed_subcommand is Some((sub_name, sub_m)) {
-        // After parent parsing, copy the final globals into the subcommand.
-        propagate_globals_to_child(
-          parent_matches, sub_m, child_globals, child_local_non_globals,
-        )
-        parent_matches.parsed_subcommand = Some((sub_name, sub_m))
-      }
-      return parent_matches
+      return dispatch_subcommand(sub, argv[i + 1:])
+    }
+    if default_subcommand is Some(sub) {
+      return dispatch_subcommand(sub, argv[i:])
     }
 
     positional_values.push(arg)
     positional_arg_found = true
     i = i + 1
+  }
+  if default_subcommand is Some(sub) {
+    return dispatch_subcommand(sub, [])
   }
   let env_args = env_resolution_args(inherited_globals, args)
   let final_matches = finalize_matches(

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -102,6 +102,7 @@ fn validate_command(
   validate_group_refs(args, groups)
   validate_subcommand_defs(cmd.subcommands)
   validate_subcommand_required_policy(cmd)
+  validate_default_subcommand_policy(cmd)
   validate_help_subcommand(cmd)
   validate_version_actions(cmd)
   let child_inherited_globals = merge_inherited_globals(
@@ -449,6 +450,39 @@ fn validate_subcommand_required_policy(
 ) -> Unit raise ArgBuildError {
   if cmd.subcommand_required && cmd.subcommands.is_empty() {
     raise Unsupported("subcommand_required requires at least one subcommand")
+  }
+}
+
+///|
+fn validate_default_subcommand_policy(
+  cmd : Command,
+) -> Unit raise ArgBuildError {
+  guard cmd.default_subcommand is Some(name) else { return }
+  if cmd.subcommand_required {
+    raise Unsupported(
+      "default_subcommand cannot be used with subcommand_required",
+    )
+  }
+  if cmd.arg_required_else_help {
+    raise Unsupported(
+      "default_subcommand cannot be used with arg_required_else_help",
+    )
+  }
+  if cmd.subcommands.iter().find_first(sub => sub.name == name && !sub.hidden)
+    is None {
+    raise Unsupported(
+      "default_subcommand must name a visible subcommand: \{name}",
+    )
+  }
+  if !cmd.groups.is_empty() {
+    raise Unsupported("default_subcommand does not support root groups")
+  }
+  for arg in cmd.args {
+    if !(arg.global && arg.info is (FlagInfo(_) | OptionInfo(_))) {
+      raise Unsupported(
+        "default_subcommand only supports global root flags/options",
+      )
+    }
   }
 }
 

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub struct Command {
   // private fields
 } derive(@debug.Debug)
 #alias(new, deprecated)
-pub fn Command::Command(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Self], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup]) -> Self
+pub fn Command::Command(StringView, flags? : ArrayView[FlagArg], options? : ArrayView[OptionArg], positionals? : ArrayView[PositionArg], subcommands? : ArrayView[Self], about? : StringView, version? : StringView, disable_help_flag? : Bool, disable_version_flag? : Bool, disable_help_subcommand? : Bool, arg_required_else_help? : Bool, subcommand_required? : Bool, hidden? : Bool, groups? : ArrayView[ArgGroup], default_subcommand? : StringView) -> Self
 #as_free_fn
 pub fn Command::parse(Self, argv? : ArrayView[String], env? : Map[String, String]) -> Matches raise
 pub fn Command::render_help(Self) -> String


### PR DESCRIPTION
## Why

Some CLIs use the root command as a dispatcher while still wanting a bare invocation to run a concrete child command. For example, `openseek` should behave like `openseek tui`, while `openseek mcp` should still select the explicit `mcp` subcommand.

Without parser support, each application has to rewrite argv or manually dispatch `None`, which bypasses the normal child parsing surface for options, positionals, defaults, globals, and help context.

## What changed

This adds a narrow `default_subcommand` option to `Command`. When configured, missing subcommands dispatch to the named visible child through the same parser path used by explicit subcommands.

The feature is intentionally restricted to dispatcher-style roots. A command with `default_subcommand` may expose global root flags/options, but root-local args and groups are rejected to avoid ambiguity over whether tokens belong to the root command or the default child.

## Why this shape

Exact subcommand names still take precedence. Other tokens are parsed by the default child. This preserves valid child positionals such as `openseek project` and avoids fuzzy subcommand guessing before the selected parse path fails.

Root help remains root-focused and only annotates the default child as `(default)`. Child-specific options stay in child help, so `cmd help <subcommand>` and `cmd <subcommand> --help` remain the precise help paths.

The change is minimal: it adds one constructor option, validates ambiguous configurations at command-build time, and reuses the existing subcommand parse/merge/finalize path for default dispatch.