### PR TITLE
Optimize StringView code_units for small slices

### DIFF
--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -137,13 +137,20 @@ pub fn StringView::unsafe_get(self : StringView, index : Int) -> UInt16 {
 /// This method yields code units, not Unicode characters. Surrogate pairs are
 /// represented as two `UInt16` values.
 ///
-/// Note: the default implementation copies the entire underlying string into a
-/// fresh `FixedArray` and then slices it, so the returned view does not alias
-/// the original string's storage. Some backends lower the intrinsic to a
-/// zero-copy view instead.
+/// Note: the default implementation copies code units into a fresh
+/// `FixedArray`, so the returned view does not alias the original string's
+/// storage. Some backends lower the intrinsic to a zero-copy view instead.
 #intrinsic("%stringview.code_units")
 pub fn StringView::code_units(self : StringView) -> ArrayView[UInt16] {
-  FixedArray::makei(self.str().length(), i => self.str().unsafe_get(i))[self.start():self.end()]
+  let len = self.length()
+  let str_len = self.str().length()
+  if len * 2 < str_len {
+    let str = self.str()
+    let start = self.start()
+    FixedArray::makei(len, i => str.unsafe_get(start + i))
+  } else {
+    FixedArray::makei(self.str().length(), i => self.str().unsafe_get(i))[self.start():self.end()]
+  }
 }
 
 ///|

--- a/builtin/stringview_code_units_bench_test.mbt
+++ b/builtin/stringview_code_units_bench_test.mbt
@@ -1,0 +1,39 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let stringview_code_units_bench_size = 100_000
+
+///|
+let stringview_code_units_bench_source : String = "x" +
+  String::make(stringview_code_units_bench_size, 'a') +
+  "y"
+
+///|
+let stringview_code_units_bench_full : StringView = stringview_code_units_bench_source[1:stringview_code_units_bench_size +
+  1]
+
+///|
+test "bench StringView::code_units small slice of large backing n=16/100000" (
+  it : @bench.T,
+) {
+  let view = stringview_code_units_bench_source[10:26]
+  it.bench(fn() { it.keep(view.code_units().length()) })
+}
+
+///|
+test "bench StringView::code_units full slice n=100000" (it : @bench.T) {
+  let view = stringview_code_units_bench_full
+  it.bench(fn() { it.keep(view.code_units().length()) })
+}


### PR DESCRIPTION
## Summary
- optimize `StringView::code_units` for small views over large backing strings
- allocate only the view length when the view is less than half of the backing string
- keep the existing whole-backing copy path for large views to preserve current throughput
- add focused `StringView::code_units` benchmarks

## Context
This follows the dependency hotspot analysis:
https://gist.github.com/mizchi/28f382dd0d9c7c1cb0ef42b202f7f24e

`StringView` is in the high-priority `builtin` area and appears frequently in string, regex, JSON, and parsing paths. The previous fallback implementation copied the entire backing string and then sliced it, which is disproportionately expensive for a small view into a large string.

## Benchmarks
Measured with native release benches. Before is `upstream/main@607c2745`; after is this PR head `74774ede`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `StringView::code_units small slice of large backing n=16/100000` | 5.09 us | 17.02 ns | 299x faster (-99.7%) |
| `StringView::code_units full slice n=100000` | 4.94 us | 5.03 us | roughly unchanged |

I also tried caching `str()` / `start()` in `StringView` comparison loops, but dropped it because it regressed `compare` and ASCII folded comparisons on native release benches.

## Validation
- `moon fmt`
- `moon info`
- `moon test -p moonbitlang/core/builtin --target all`
- `moon check --target all`
- `moon bench -p moonbitlang/core/builtin -f stringview_code_units_bench_test.mbt --target native --release`
