### PR TITLE
Optimize UTF-16 decode with V128 fast paths

### DIFF
--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -32,6 +32,8 @@ fn suppress_unused_v128_import_on_js() -> Unit {
 
 ///|
 #cfg(not(target="js"))
+// V128 loads require FixedArray[Byte]; these types share a representation on
+// non-JS backends.
 fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
 
 ///|
@@ -65,7 +67,7 @@ fn utf16_v128_has_surrogate(value : V128) -> Bool {
 
 ///|
 #cfg(not(target="js"))
-fn utf16_has_surrogate_le_v128(bytes : BytesView) -> Bool {
+fn utf16_needs_scalar_le_v128(bytes : BytesView) -> Bool {
   if bytes.length() % 2 != 0 {
     return true
   }
@@ -94,7 +96,7 @@ fn utf16_has_surrogate_le_v128(bytes : BytesView) -> Bool {
 
 ///|
 #cfg(not(target="js"))
-fn utf16_has_surrogate_be_v128(bytes : BytesView) -> Bool {
+fn utf16_needs_scalar_be_v128(bytes : BytesView) -> Bool {
   if bytes.length() % 2 != 0 {
     return true
   }
@@ -125,6 +127,7 @@ fn utf16_has_surrogate_be_v128(bytes : BytesView) -> Bool {
 ///|
 #cfg(not(target="js"))
 fn utf16_decode_be_no_surrogate_v128(bytes : BytesView) -> String {
+  // The caller guarantees an even byte length with no surrogate code units.
   let src = bytes.data()
   let src_bytes = unsafe_fixedarray_from_bytes(src)
   let string_bytes = FixedArray::make(bytes.length(), b'\x00')
@@ -257,12 +260,12 @@ pub fn decode(
 ) -> String raise Malformed {
   let bytes = drop_utf16_bom(bytes, ignore_bom, endianness)
   if endianness is Little {
-    if !utf16_has_surrogate_le_v128(bytes) {
+    if !utf16_needs_scalar_le_v128(bytes) {
       return bytes
         .data()
         .to_unchecked_string(offset=bytes.start_offset(), length=bytes.length())
     }
-  } else if !utf16_has_surrogate_be_v128(bytes) {
+  } else if !utf16_needs_scalar_be_v128(bytes) {
     return utf16_decode_be_no_surrogate_v128(bytes)
   }
   decode_scalar(bytes, endianness)
@@ -277,17 +280,7 @@ pub fn decode_lossy(
   ignore_bom? : Bool = false,
   endianness? : Endian = Little,
 ) -> String {
-  let bytes = if ignore_bom {
-    if endianness is Little && bytes is [.. b"\xff\xfe", .. rest] {
-      rest
-    } else if endianness is Big && bytes is [.. b"\xfe\xff", .. rest] {
-      rest
-    } else {
-      bytes
-    }
-  } else {
-    bytes
-  }
+  let bytes = drop_utf16_bom(bytes, ignore_bom, endianness)
   let builder = StringBuilder(size_hint=bytes.length())
   if endianness is Little {
     for x = bytes {

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -24,13 +24,137 @@ pub suberror Malformed {
 const U_REP = '\u{FFFD}'
 
 ///|
-/// Decode input bytes/text into structured output.
-pub fn decode(
+#cfg(target="js")
+#warnings("-unused_value")
+fn suppress_unused_v128_import_on_js() -> Unit {
+  ignore(@v128.i8x16_splat(0))
+}
+
+///|
+#cfg(not(target="js"))
+fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
+
+///|
+#cfg(not(target="js"))
+fn is_utf16_surrogate(code_unit : UInt16) -> Bool {
+  let code = code_unit.to_int()
+  code >= 0xD800 && code <= 0xDFFF
+}
+
+///|
+#cfg(not(target="js"))
+fn utf16_swap_u16x8(value : V128) -> V128 {
+  @v128.i8x16_shuffle(
+    value, value, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14,
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn utf16_v128_has_surrogate(value : V128) -> Bool {
+  let lower = @v128.i16x8_splat(0xD800)
+  let upper = @v128.i16x8_splat(0xDFFF)
+  @v128.i16x8_bitmask(
+    @v128.v128_and_(
+      @v128.i16x8_ge_u(value, lower),
+      @v128.i16x8_le_u(value, upper),
+    ),
+  ) !=
+  0
+}
+
+///|
+#cfg(not(target="js"))
+fn utf16_has_surrogate_le_v128(bytes : BytesView) -> Bool {
+  if bytes.length() % 2 != 0 {
+    return true
+  }
+  let src = bytes.data()
+  if bytes.length() > 0 &&
+    is_utf16_surrogate(src.unsafe_read_uint16_le(bytes.start_offset())) {
+    return true
+  }
+  let src_bytes = unsafe_fixedarray_from_bytes(src)
+  let end = bytes.start_offset() + bytes.length()
+  let mut index = bytes.start_offset()
+  while index + 16 <= end {
+    if utf16_v128_has_surrogate(@v128.v128_load(src_bytes, index)) {
+      return true
+    }
+    index = index + 16
+  }
+  while index < end {
+    if is_utf16_surrogate(src.unsafe_read_uint16_le(index)) {
+      return true
+    }
+    index = index + 2
+  }
+  false
+}
+
+///|
+#cfg(not(target="js"))
+fn utf16_has_surrogate_be_v128(bytes : BytesView) -> Bool {
+  if bytes.length() % 2 != 0 {
+    return true
+  }
+  let src = bytes.data()
+  if bytes.length() > 0 &&
+    is_utf16_surrogate(src.unsafe_read_uint16_be(bytes.start_offset())) {
+    return true
+  }
+  let src_bytes = unsafe_fixedarray_from_bytes(src)
+  let end = bytes.start_offset() + bytes.length()
+  let mut index = bytes.start_offset()
+  while index + 16 <= end {
+    let swapped = utf16_swap_u16x8(@v128.v128_load(src_bytes, index))
+    if utf16_v128_has_surrogate(swapped) {
+      return true
+    }
+    index = index + 16
+  }
+  while index < end {
+    if is_utf16_surrogate(src.unsafe_read_uint16_be(index)) {
+      return true
+    }
+    index = index + 2
+  }
+  false
+}
+
+///|
+#cfg(not(target="js"))
+fn utf16_decode_be_no_surrogate_v128(bytes : BytesView) -> String {
+  let src = bytes.data()
+  let src_bytes = unsafe_fixedarray_from_bytes(src)
+  let string_bytes = FixedArray::make(bytes.length(), b'\x00')
+  let end = bytes.start_offset() + bytes.length()
+  let mut index = bytes.start_offset()
+  let mut written = 0
+  while index + 16 <= end {
+    let swapped = utf16_swap_u16x8(@v128.v128_load(src_bytes, index))
+    @v128.v128_store(string_bytes, written, swapped)
+    index = index + 16
+    written = written + 16
+  }
+  while index < end {
+    let code_unit = src.unsafe_read_uint16_be(index)
+    string_bytes[written] = (code_unit & 0xFF).to_byte()
+    string_bytes[written + 1] = (code_unit >> 8).to_byte()
+    index = index + 2
+    written = written + 2
+  }
+  string_bytes.unsafe_reinterpret_as_bytes().to_unchecked_string()
+}
+
+///|
+#inline
+fn drop_utf16_bom(
   bytes : BytesView,
-  ignore_bom? : Bool = false,
-  endianness? : Endian = Little,
-) -> String raise Malformed {
-  let bytes = if ignore_bom {
+  ignore_bom : Bool,
+  endianness : Endian,
+) -> BytesView {
+  if ignore_bom {
     if endianness is Little && bytes is [.. b"\xff\xfe", .. rest] {
       rest
     } else if endianness is Big && bytes is [.. b"\xfe\xff", .. rest] {
@@ -41,6 +165,13 @@ pub fn decode(
   } else {
     bytes
   }
+}
+
+///|
+fn decode_scalar(
+  bytes : BytesView,
+  endianness : Endian,
+) -> String raise Malformed {
   if endianness is Little {
     // check the string
     for x = bytes {
@@ -103,6 +234,38 @@ pub fn decode(
     }
     string_bytes.unsafe_reinterpret_as_bytes().to_unchecked_string()
   }
+}
+
+///|
+/// Decode input bytes/text into structured output.
+#cfg(target="js")
+pub fn decode(
+  bytes : BytesView,
+  ignore_bom? : Bool = false,
+  endianness? : Endian = Little,
+) -> String raise Malformed {
+  decode_scalar(drop_utf16_bom(bytes, ignore_bom, endianness), endianness)
+}
+
+///|
+/// Decode input bytes/text into structured output.
+#cfg(not(target="js"))
+pub fn decode(
+  bytes : BytesView,
+  ignore_bom? : Bool = false,
+  endianness? : Endian = Little,
+) -> String raise Malformed {
+  let bytes = drop_utf16_bom(bytes, ignore_bom, endianness)
+  if endianness is Little {
+    if !utf16_has_surrogate_le_v128(bytes) {
+      return bytes
+        .data()
+        .to_unchecked_string(offset=bytes.start_offset(), length=bytes.length())
+    }
+  } else if !utf16_has_surrogate_be_v128(bytes) {
+    return utf16_decode_be_no_surrogate_v128(bytes)
+  }
+  decode_scalar(bytes, endianness)
 }
 
 ///|

--- a/encoding/utf16/decode_test.mbt
+++ b/encoding/utf16/decode_test.mbt
@@ -27,13 +27,15 @@ test "decoding UTF16 encoded data to String" {
 
 ///|
 test "decoding UTF16 data without surrogate to String" {
-  let chars = @utf16.decode(b"\x61\x00\x62\x00\x63\x00\x60\x4f\x7d\x59")
-  inspect(chars, content="abc你好")
+  let chars = @utf16.decode(
+    b"\x61\x00\x62\x00\x63\x00\x60\x4f\x7d\x59\x64\x00\x65\x00\x66\x00",
+  )
+  inspect(chars, content="abc你好def")
   let chars_be = @utf16.decode(
-    b"\x00\x61\x00\x62\x00\x63\x4f\x60\x59\x7d",
+    b"\x00\x61\x00\x62\x00\x63\x4f\x60\x59\x7d\x00\x64\x00\x65\x00\x66",
     endianness=Big,
   )
-  inspect(chars_be, content="abc你好")
+  inspect(chars_be, content="abc你好def")
 }
 
 ///|

--- a/encoding/utf16/decode_test.mbt
+++ b/encoding/utf16/decode_test.mbt
@@ -27,6 +27,17 @@ test "decoding UTF16 encoded data to String" {
 
 ///|
 test "decoding UTF16 data without surrogate to String" {
+  let chars = @utf16.decode(b"\x61\x00\x62\x00\x63\x00\x60\x4f\x7d\x59")
+  inspect(chars, content="abc你好")
+  let chars_be = @utf16.decode(
+    b"\x00\x61\x00\x62\x00\x63\x4f\x60\x59\x7d",
+    endianness=Big,
+  )
+  inspect(chars_be, content="abc你好")
+}
+
+///|
+test "decoding UTF16 data without surrogate through V128 loop" {
   let chars = @utf16.decode(
     b"\x61\x00\x62\x00\x63\x00\x60\x4f\x7d\x59\x64\x00\x65\x00\x66\x00",
   )

--- a/encoding/utf16/decode_test.mbt
+++ b/encoding/utf16/decode_test.mbt
@@ -26,6 +26,17 @@ test "decoding UTF16 encoded data to String" {
 }
 
 ///|
+test "decoding UTF16 data without surrogate to String" {
+  let chars = @utf16.decode(b"\x61\x00\x62\x00\x63\x00\x60\x4f\x7d\x59")
+  inspect(chars, content="abc你好")
+  let chars_be = @utf16.decode(
+    b"\x00\x61\x00\x62\x00\x63\x4f\x60\x59\x7d",
+    endianness=Big,
+  )
+  inspect(chars_be, content="abc你好")
+}
+
+///|
 test "decoding UTF16 with bom" {
   let text = b"\xff\xfe\x61\x00\x62\x00\x63\x00\x60\x4f\x7d\x59\x3d\xd8\x40\xdc"
   inspect(try! @utf16.decode(text), content="﻿abc你好👀")

--- a/encoding/utf16/moon.pkg
+++ b/encoding/utf16/moon.pkg
@@ -1,4 +1,9 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
+  "moonbitlang/core/v128",
 }
+
+import {
+  "moonbitlang/core/bench",
+} for "test"

--- a/encoding/utf16/utf16_v128_bench_test.mbt
+++ b/encoding/utf16/utf16_v128_bench_test.mbt
@@ -1,0 +1,120 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let utf16_v128_bench_size = 100_000
+
+///|
+let utf16_v128_bench_ascii : String = String::make(utf16_v128_bench_size, 'a')
+
+///|
+let utf16_v128_bench_mixed : String = String::make(50_000, 'a') +
+  String::make(25_000, '中') +
+  String::make(25_000, 'b')
+
+///|
+let utf16_v128_bench_emoji : String = String::make(50_000, '👀')
+
+///|
+let utf16_v128_bench_ascii_le : Bytes = @utf16.encode(utf16_v128_bench_ascii)
+
+///|
+let utf16_v128_bench_ascii_be : Bytes = @utf16.encode(
+  utf16_v128_bench_ascii,
+  endianness=Big,
+)
+
+///|
+let utf16_v128_bench_mixed_le : Bytes = @utf16.encode(utf16_v128_bench_mixed)
+
+///|
+let utf16_v128_bench_mixed_be : Bytes = @utf16.encode(
+  utf16_v128_bench_mixed,
+  endianness=Big,
+)
+
+///|
+let utf16_v128_bench_emoji_le : Bytes = @utf16.encode(utf16_v128_bench_emoji)
+
+///|
+let utf16_v128_bench_emoji_be : Bytes = @utf16.encode(
+  utf16_v128_bench_emoji,
+  endianness=Big,
+)
+
+///|
+test "bench utf16 encode ASCII LE n=100000" (it : @bench.T) {
+  let s = utf16_v128_bench_ascii
+  it.bench(fn() { it.keep(@utf16.encode(s).length()) })
+}
+
+///|
+test "bench utf16 encode ASCII BE n=100000" (it : @bench.T) {
+  let s = utf16_v128_bench_ascii
+  it.bench(fn() { it.keep(@utf16.encode(s, endianness=Big).length()) })
+}
+
+///|
+test "bench utf16 encode mixed LE n=100000" (it : @bench.T) {
+  let s = utf16_v128_bench_mixed
+  it.bench(fn() { it.keep(@utf16.encode(s).length()) })
+}
+
+///|
+test "bench utf16 encode mixed BE n=100000" (it : @bench.T) {
+  let s = utf16_v128_bench_mixed
+  it.bench(fn() { it.keep(@utf16.encode(s, endianness=Big).length()) })
+}
+
+///|
+test "bench utf16 decode ASCII LE n=100000" (it : @bench.T) {
+  let bytes = utf16_v128_bench_ascii_le
+  it.bench(fn() { it.keep((try! @utf16.decode(bytes)).length()) })
+}
+
+///|
+test "bench utf16 decode ASCII BE n=100000" (it : @bench.T) {
+  let bytes = utf16_v128_bench_ascii_be
+  it.bench(fn() {
+    it.keep((try! @utf16.decode(bytes, endianness=Big)).length())
+  })
+}
+
+///|
+test "bench utf16 decode mixed LE n=100000" (it : @bench.T) {
+  let bytes = utf16_v128_bench_mixed_le
+  it.bench(fn() { it.keep((try! @utf16.decode(bytes)).length()) })
+}
+
+///|
+test "bench utf16 decode mixed BE n=100000" (it : @bench.T) {
+  let bytes = utf16_v128_bench_mixed_be
+  it.bench(fn() {
+    it.keep((try! @utf16.decode(bytes, endianness=Big)).length())
+  })
+}
+
+///|
+test "bench utf16 decode emoji LE n=100000" (it : @bench.T) {
+  let bytes = utf16_v128_bench_emoji_le
+  it.bench(fn() { it.keep((try! @utf16.decode(bytes)).length()) })
+}
+
+///|
+test "bench utf16 decode emoji BE n=100000" (it : @bench.T) {
+  let bytes = utf16_v128_bench_emoji_be
+  it.bench(fn() {
+    it.keep((try! @utf16.decode(bytes, endianness=Big)).length())
+  })
+}


### PR DESCRIPTION
## Summary

- Add V128-based surrogate scanning for UTF-16 decode on non-JS targets.
- Fast-path UTF-16LE inputs with no surrogate code units by reusing the existing unchecked string conversion.
- Fast-path UTF-16BE inputs with no surrogate code units by V128 byte-swapping into UTF-16LE string bytes.
- Keep JS on the scalar decode path. The V128-emulated JS path regressed no-surrogate decode to tens of milliseconds in local testing.
- Add coverage for no-surrogate UTF-16LE/BE decode and add benchmark coverage.

## Benchmark

`moon bench -p moonbitlang/core/encoding/utf16 -f utf16_v128_bench_test.mbt --target <target> --release`

The "before" numbers were taken with the same benchmark file and the V128 fast path disabled. Times below are decode benchmarks only; encode benchmarks are included in the file but are not changed by this PR.

| target | benchmark | before | after |
|---|---|---:|---:|
| native | ASCII LE n=100000 | 51.09 us | 7.37 us |
| native | ASCII BE n=100000 | 105.16 us | 13.20 us |
| native | mixed LE n=100000 | 51.08 us | 7.79 us |
| native | mixed BE n=100000 | 100.61 us | 19.72 us |
| native | emoji LE n=100000 | 49.40 us | 64.65 us |
| native | emoji BE n=100000 | 82.08 us | 80.62 us |
| wasm | ASCII LE n=100000 | 144.46 us | 11.87 us |
| wasm | ASCII BE n=100000 | 892.09 us | 20.24 us |
| wasm | mixed LE n=100000 | 143.68 us | 11.92 us |
| wasm | mixed BE n=100000 | 913.28 us | 20.07 us |
| wasm | emoji LE n=100000 | 295.06 us | 187.22 us |
| wasm | emoji BE n=100000 | 1.04 ms | 1.09 ms |
| wasm-gc | ASCII LE n=100000 | 324.13 us | 134.93 us |
| wasm-gc | ASCII BE n=100000 | 423.56 us | 232.39 us |
| wasm-gc | mixed LE n=100000 | 293.31 us | 120.18 us |
| wasm-gc | mixed BE n=100000 | 454.98 us | 218.73 us |
| wasm-gc | emoji LE n=100000 | 257.03 us | 220.00 us |
| wasm-gc | emoji BE n=100000 | 344.10 us | 356.01 us |
| js | ASCII LE n=100000 | 550.11 us | 505.02 us |
| js | ASCII BE n=100000 | 594.05 us | 606.77 us |
| js | mixed LE n=100000 | 493.91 us | 469.47 us |
| js | mixed BE n=100000 | 561.00 us | 565.57 us |
| js | emoji LE n=100000 | 503.82 us | 502.74 us |
| js | emoji BE n=100000 | 596.83 us | 604.58 us |

The fast path targets no-surrogate UTF-16 data. Surrogate-containing input falls back to the existing scalar validation/decoding path.

## Validation

- `moon fmt`
- `moon info`
- `moon test encoding/utf16 --target all`
- `moon check encoding/utf16 --target all --no-render`
- `moon bench -p moonbitlang/core/encoding/utf16 -f utf16_v128_bench_test.mbt --target native --release`
- `moon bench -p moonbitlang/core/encoding/utf16 -f utf16_v128_bench_test.mbt --target wasm --release`
- `moon bench -p moonbitlang/core/encoding/utf16 -f utf16_v128_bench_test.mbt --target wasm-gc --release`
- `moon bench -p moonbitlang/core/encoding/utf16 -f utf16_v128_bench_test.mbt --target js --release`
