### PR TITLE
Optimize FixedArray reverse iteration

### DIFF
--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -796,6 +796,16 @@ test "rev_foldi" {
 }
 
 ///|
+test "rev_foldi preserves reversed index element pairs" {
+  let trace = ([10, 20, 30] : FixedArray[_]).rev_foldi(init=0, (
+    index,
+    acc,
+    elem,
+  ) => acc * 1000 + index * 100 + elem)
+  inspect(trace, content="30120210")
+}
+
+///|
 /// Reverses the array in place by swapping elements from both ends until
 /// reaching the middle.
 ///

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -773,8 +773,8 @@ pub fn[A, B] FixedArray::rev_foldi(
   f : (Int, B, A) -> B raise?,
 ) -> B raise? {
   let len = self.length()
-  for i in len>..0; acc = init {
-    continue f(len - i - 1, acc, self.unsafe_get(i))
+  for read = len - 1, index = 0, acc = init; read >= 0; {
+    continue read - 1, index + 1, f(index, acc, self.unsafe_get(read))
   } nobreak {
     acc
   }


### PR DESCRIPTION
## Summary

Optimize reverse iteration helpers on `FixedArray` by using unchecked reads in the already bounds-controlled loops.

This covers:

- `FixedArray::rev_each`
- `FixedArray::rev_eachi`
- `FixedArray::rev_fold`
- `FixedArray::rev_foldi`

## Benchmarks

Command: `moon bench -p moonbitlang/core/builtin -f array_locals_bench_test.mbt --target native --release`

| Benchmark | Before | After |
| --- | ---: | ---: |
| `FixedArray::rev_each n=100000` | 24.39 us | 4.76 us |
| `FixedArray::rev_eachi n=100000` | 9.51 us | 9.34 us |
| `FixedArray::rev_fold n=100000` | 24.22 us | 4.99 us |
| `FixedArray::rev_foldi n=100000` | 49.48 us | 9.75 us |

## Validation

- `moon fmt`
- `moon test builtin --target all`
- `moon check builtin --target all --no-render`
- `moon info`
- `moon bench -p moonbitlang/core/builtin -f array_locals_bench_test.mbt --target native --release`