### PR TITLE
Optimize BytesView rev_find

### DIFF
--- a/builtin/bytes_find.mbt
+++ b/builtin/bytes_find.mbt
@@ -108,6 +108,14 @@ fn find_match_range(
 }
 
 ///|
+declare fn find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int
+
+///|
 // Scalar byte scanner for backends without direct linear-memory vector loads.
 #cfg(any(target="js", target="wasm-gc"))
 fn find_byte_from_view(
@@ -126,6 +134,37 @@ fn find_byte_from_view(
 }
 
 ///|
+// Convert view-relative bounds to backing `Bytes` offsets before scanning.
+#cfg(any(target="native", target="wasm"))
+fn find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  let target_start = target.start_offset()
+  let found = find_byte_from_bytes(
+    target.data(),
+    target_start + start,
+    target_start + end,
+    byte,
+  )
+  if found < 0 {
+    -1
+  } else {
+    found - target_start
+  }
+}
+
+///|
+declare fn rev_find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int
+
+///|
 // Scalar reverse byte scanner for backends without direct linear-memory vector
 // loads.
 #cfg(any(target="js", target="wasm-gc"))
@@ -142,6 +181,30 @@ fn rev_find_byte_from_view(
     continue pos - 1
   } nobreak {
     -1
+  }
+}
+
+///|
+// Convert view-relative bounds to backing `Bytes` offsets before reverse
+// scanning.
+#cfg(any(target="native", target="wasm"))
+fn rev_find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  let target_start = target.start_offset()
+  let found = rev_find_byte_from_bytes(
+    target.data(),
+    target_start + start,
+    target_start + end,
+    byte,
+  )
+  if found < 0 {
+    -1
+  } else {
+    found - target_start
   }
 }
 
@@ -212,51 +275,7 @@ fn rev_find_byte_from_bytes(
 }
 
 ///|
-// Convert view-relative bounds to backing `Bytes` offsets before scanning.
-#cfg(any(target="native", target="wasm"))
-fn find_byte_from_view(
-  target : BytesView,
-  start : Int,
-  end : Int,
-  byte : Byte,
-) -> Int {
-  let target_start = target.start_offset()
-  let found = find_byte_from_bytes(
-    target.data(),
-    target_start + start,
-    target_start + end,
-    byte,
-  )
-  if found < 0 {
-    -1
-  } else {
-    found - target_start
-  }
-}
-
-///|
-// Convert view-relative bounds to backing `Bytes` offsets before reverse
-// scanning.
-#cfg(any(target="native", target="wasm"))
-fn rev_find_byte_from_view(
-  target : BytesView,
-  start : Int,
-  end : Int,
-  byte : Byte,
-) -> Int {
-  let target_start = target.start_offset()
-  let found = rev_find_byte_from_bytes(
-    target.data(),
-    target_start + start,
-    target_start + end,
-    byte,
-  )
-  if found < 0 {
-    -1
-  } else {
-    found - target_start
-  }
-}
+declare fn find_short(target : BytesView, pattern : BytesView) -> Int?
 
 ///|
 // Scalar short-pattern scanner: find matches for the last byte, then verify
@@ -277,6 +296,41 @@ fn find_short(target : BytesView, pattern : BytesView) -> Int? {
       break Some(candidate)
     }
     continue found + 1
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Native/wasm short-needle path: use the SIMD prefilter to skip most false
+// candidates, then compare the unchecked middle range only on hits.
+#cfg(any(target="native", target="wasm"))
+fn find_short(target : BytesView, pattern : BytesView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let last = target_len - pattern_len
+  let target_start = target.start_offset()
+  let candidate_end = target_start + last + 1
+  let first = pattern.unsafe_get(0)
+  let last_offset = pattern_len - 1
+  let last_byte = pattern.unsafe_get(last_offset)
+  for pos = 0; pos <= last; {
+    let found = find_short_candidate_from_bytes(
+      target.data(),
+      target_start + pos,
+      candidate_end,
+      first,
+      last_offset,
+      last_byte,
+    )
+    if found < 0 {
+      break None
+    }
+    let candidate = found - target_start
+    if find_match_range(target, pattern, candidate, 1, last_offset) {
+      break Some(candidate)
+    }
+    continue candidate + 1
   } nobreak {
     None
   }
@@ -382,39 +436,10 @@ fn rev_find_short_candidate_from_bytes(
 }
 
 ///|
-// Native/wasm short-needle path: use the SIMD prefilter to skip most false
-// candidates, then compare the unchecked middle range only on hits.
-#cfg(any(target="native", target="wasm"))
-fn find_short(target : BytesView, pattern : BytesView) -> Int? {
-  let target_len = target.length()
-  let pattern_len = pattern.length()
-  let last = target_len - pattern_len
-  let target_start = target.start_offset()
-  let candidate_end = target_start + last + 1
-  let first = pattern.unsafe_get(0)
-  let last_offset = pattern_len - 1
-  let last_byte = pattern.unsafe_get(last_offset)
-  for pos = 0; pos <= last; {
-    let found = find_short_candidate_from_bytes(
-      target.data(),
-      target_start + pos,
-      candidate_end,
-      first,
-      last_offset,
-      last_byte,
-    )
-    if found < 0 {
-      break None
-    }
-    let candidate = found - target_start
-    if find_match_range(target, pattern, candidate, 1, last_offset) {
-      break Some(candidate)
-    }
-    continue candidate + 1
-  } nobreak {
-    None
-  }
-}
+declare fn rev_find_by_byte_scanner(
+  target : BytesView,
+  pattern : BytesView,
+) -> Int?
 
 ///|
 // Scalar reverse scanner for all multi-byte patterns. It searches candidate

--- a/builtin/bytes_find.mbt
+++ b/builtin/bytes_find.mbt
@@ -126,6 +126,26 @@ fn find_byte_from_view(
 }
 
 ///|
+// Scalar reverse byte scanner for backends without direct linear-memory vector
+// loads.
+#cfg(any(target="js", target="wasm-gc"))
+fn rev_find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  for pos = end - 1; pos >= start; {
+    if target.unsafe_get(pos) == byte {
+      break pos
+    }
+    continue pos - 1
+  } nobreak {
+    -1
+  }
+}
+
+///|
 #cfg(any(target="native", target="wasm"))
 fn Bytes::v128_load(self : Bytes, offset : Int) -> V128 {
   v128_load(unsafe_from_bytes(self), offset)
@@ -161,6 +181,37 @@ fn find_byte_from_bytes(
 }
 
 ///|
+// SIMD reverse byte scanner for linear-memory backends. It scans 16-byte chunks
+// from the end and returns the highest matching offset.
+#cfg(any(target="native", target="wasm"))
+fn rev_find_byte_from_bytes(
+  data : Bytes,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  let byte_v = i8x16_splat(byte)
+  let head_end = for pos = end; pos - 16 >= start; {
+    let chunk_start = pos - 16
+    let mask = i8x16_bitmask(i8x16_eq(data.v128_load(chunk_start), byte_v))
+    if mask != 0 {
+      return chunk_start + 31 - mask.clz()
+    }
+    continue chunk_start
+  } nobreak {
+    pos
+  }
+  for pos = head_end - 1; pos >= start; {
+    if data.unsafe_get(pos) == byte {
+      break pos
+    }
+    continue pos - 1
+  } nobreak {
+    -1
+  }
+}
+
+///|
 // Convert view-relative bounds to backing `Bytes` offsets before scanning.
 #cfg(any(target="native", target="wasm"))
 fn find_byte_from_view(
@@ -171,6 +222,30 @@ fn find_byte_from_view(
 ) -> Int {
   let target_start = target.start_offset()
   let found = find_byte_from_bytes(
+    target.data(),
+    target_start + start,
+    target_start + end,
+    byte,
+  )
+  if found < 0 {
+    -1
+  } else {
+    found - target_start
+  }
+}
+
+///|
+// Convert view-relative bounds to backing `Bytes` offsets before reverse
+// scanning.
+#cfg(any(target="native", target="wasm"))
+fn rev_find_byte_from_view(
+  target : BytesView,
+  start : Int,
+  end : Int,
+  byte : Byte,
+) -> Int {
+  let target_start = target.start_offset()
+  let found = rev_find_byte_from_bytes(
     target.data(),
     target_start + start,
     target_start + end,
@@ -204,6 +279,29 @@ fn find_short(target : BytesView, pattern : BytesView) -> Int? {
     continue found + 1
   } nobreak {
     None
+  }
+}
+
+///|
+// Scalar reverse candidate scanner: match first and last bytes before scalar
+// verification of the unchecked middle range.
+#cfg(any(target="js", target="wasm-gc"))
+fn rev_find_short_candidate_from_view(
+  target : BytesView,
+  start : Int,
+  candidate_end : Int,
+  first : Byte,
+  last_offset : Int,
+  last : Byte,
+) -> Int {
+  for pos = candidate_end - 1; pos >= start; {
+    if target.unsafe_get(pos) == first &&
+      target.unsafe_get(pos + last_offset) == last {
+      break pos
+    }
+    continue pos - 1
+  } nobreak {
+    -1
   }
 }
 
@@ -245,6 +343,45 @@ fn find_short_candidate_from_bytes(
 }
 
 ///|
+// SIMD reverse short-pattern prefilter: scan candidate positions from the end,
+// matching first and last bytes before scalar verification.
+#cfg(any(target="native", target="wasm"))
+fn rev_find_short_candidate_from_bytes(
+  data : Bytes,
+  start : Int,
+  candidate_end : Int,
+  first : Byte,
+  last_offset : Int,
+  last : Byte,
+) -> Int {
+  let first_v = i8x16_splat(first)
+  let last_v = i8x16_splat(last)
+  let head_end = for pos = candidate_end; pos - 16 >= start; {
+    let chunk_start = pos - 16
+    let mask = v128_and(
+      i8x16_eq(data.v128_load(chunk_start), first_v),
+      i8x16_eq(data.v128_load(chunk_start + last_offset), last_v),
+    )
+    let bits = i8x16_bitmask(mask)
+    if bits != 0 {
+      return chunk_start + 31 - bits.clz()
+    }
+    continue chunk_start
+  } nobreak {
+    pos
+  }
+  for pos = head_end - 1; pos >= start; {
+    if data.unsafe_get(pos) == first &&
+      data.unsafe_get(pos + last_offset) == last {
+      break pos
+    }
+    continue pos - 1
+  } nobreak {
+    -1
+  }
+}
+
+///|
 // Native/wasm short-needle path: use the SIMD prefilter to skip most false
 // candidates, then compare the unchecked middle range only on hits.
 #cfg(any(target="native", target="wasm"))
@@ -274,6 +411,67 @@ fn find_short(target : BytesView, pattern : BytesView) -> Int? {
       break Some(candidate)
     }
     continue candidate + 1
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Scalar reverse scanner for all multi-byte patterns. It searches candidate
+// positions by first/last byte and verifies only the middle range on hits.
+#cfg(any(target="js", target="wasm-gc"))
+fn rev_find_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let last = target_len - pattern_len
+  let first = pattern.unsafe_get(0)
+  let last_offset = pattern_len - 1
+  let last_byte = pattern.unsafe_get(last_offset)
+  for candidate_end = last + 1; candidate_end > 0; {
+    let found = rev_find_short_candidate_from_view(
+      target, 0, candidate_end, first, last_offset, last_byte,
+    )
+    if found < 0 {
+      break None
+    }
+    if find_match_range(target, pattern, found, 1, last_offset) {
+      break Some(found)
+    }
+    continue found
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Native/wasm reverse scanner for all multi-byte patterns. It uses the SIMD
+// first/last byte prefilter and verifies only the middle range on hits.
+#cfg(any(target="native", target="wasm"))
+fn rev_find_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let last = target_len - pattern_len
+  let target_start = target.start_offset()
+  let first = pattern.unsafe_get(0)
+  let last_offset = pattern_len - 1
+  let last_byte = pattern.unsafe_get(last_offset)
+  for candidate_end = last + 1; candidate_end > 0; {
+    let found = rev_find_short_candidate_from_bytes(
+      target.data(),
+      target_start,
+      target_start + candidate_end,
+      first,
+      last_offset,
+      last_byte,
+    )
+    if found < 0 {
+      break None
+    }
+    let candidate = found - target_start
+    if find_match_range(target, pattern, candidate, 1, last_offset) {
+      break Some(candidate)
+    }
+    continue candidate
   } nobreak {
     None
   }
@@ -360,17 +558,34 @@ fn find_long_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
 /// Returns the offset of the last occurrence of the given
 /// bytes substring. If the substring is not found, `None` is returned.
 pub fn BytesView::rev_find(target : BytesView, pattern : BytesView) -> Int? {
-  // TODO: more efficient algorithm
   let target_len = target.length()
   let pattern_len = pattern.length()
-  for i = target_len - pattern_len; i >= 0; i = i - 1 {
-    for j in 0..<pattern_len {
-      guard target.unsafe_get(i + j) == pattern.unsafe_get(j) else { break }
-    } nobreak {
-      return Some(i)
+  if pattern_len == 0 {
+    return Some(target_len)
+  }
+  if pattern_len > target_len {
+    return None
+  }
+  if pattern_len == 1 {
+    let found = rev_find_byte_from_view(
+      target,
+      0,
+      target_len,
+      pattern.unsafe_get(0),
+    )
+    if found < 0 {
+      None
+    } else {
+      Some(found)
     }
-  } nobreak {
-    None
+  } else if pattern_len == target_len {
+    if find_match_range(target, pattern, 0, 0, pattern_len) {
+      Some(0)
+    } else {
+      None
+    }
+  } else {
+    rev_find_by_byte_scanner(target, pattern)
   }
 }
 

--- a/builtin/bytes_find.mbt
+++ b/builtin/bytes_find.mbt
@@ -108,6 +108,19 @@ fn find_match_range(
 }
 
 ///|
+/// Finds the first occurrence of `byte` in the view-relative range
+/// `[start, end)`.
+///
+/// The caller must ensure `0 <= start <= end <= target.length()`. The result is
+/// relative to `target`, or `-1` when `byte` does not occur in the range.
+///
+/// ```mbt check
+/// test {
+///   let target = b"--abcabc--"[2:8]
+///   debug_inspect(target[2:].find(b"b"), content="Some(2)")
+///   debug_inspect(target.find(b"x"), content="None")
+/// }
+/// ```
 declare fn find_byte_from_view(
   target : BytesView,
   start : Int,
@@ -157,6 +170,19 @@ fn find_byte_from_view(
 }
 
 ///|
+/// Finds the last occurrence of `byte` in the view-relative range
+/// `[start, end)`.
+///
+/// The caller must ensure `0 <= start <= end <= target.length()`. The result is
+/// relative to `target`, or `-1` when `byte` does not occur in the range.
+///
+/// ```mbt check
+/// test {
+///   let target = b"--abcabc--"[2:8]
+///   debug_inspect(target[:4].rev_find(b"b"), content="Some(1)")
+///   debug_inspect(target.rev_find(b"x"), content="None")
+/// }
+/// ```
 declare fn rev_find_byte_from_view(
   target : BytesView,
   start : Int,
@@ -275,6 +301,18 @@ fn rev_find_byte_from_bytes(
 }
 
 ///|
+/// Finds the first occurrence of a short, non-empty `pattern` in `target`.
+///
+/// The caller must ensure the pattern has at least two bytes, does not exceed
+/// the short-pattern limit, and is no longer than `target`.
+///
+/// ```mbt check
+/// test {
+///   let target = b"--abcabc--"[2:8]
+///   debug_inspect(target.find(b"bca"), content="Some(1)")
+///   debug_inspect(target.find(b"abd"), content="None")
+/// }
+/// ```
 declare fn find_short(target : BytesView, pattern : BytesView) -> Int?
 
 ///|
@@ -436,6 +474,18 @@ fn rev_find_short_candidate_from_bytes(
 }
 
 ///|
+/// Finds the last occurrence of a non-empty, multi-byte `pattern` in `target`.
+///
+/// The caller must ensure the pattern has at least two bytes and is shorter
+/// than `target`.
+///
+/// ```mbt check
+/// test {
+///   let target = b"--abcabc--"[2:8]
+///   debug_inspect(target.rev_find(b"abc"), content="Some(3)")
+///   debug_inspect(target.rev_find(b"abd"), content="None")
+/// }
+/// ```
 declare fn rev_find_by_byte_scanner(
   target : BytesView,
   pattern : BytesView,

--- a/bytes/find_bench_test.mbt
+++ b/bytes/find_bench_test.mbt
@@ -58,6 +58,37 @@ fn make_find_view_substring_hit_end() -> Bytes {
 }
 
 ///|
+fn make_find_single_hit_start() -> Bytes {
+  Bytes::makei(find_bench_len, i => if i == 0 { b'Z' } else { b'a' })
+}
+
+///|
+fn make_find_substring_hit_start() -> Bytes {
+  Bytes::makei(find_bench_len, i => {
+    match i {
+      0 => b'Z'
+      1 => b'a'
+      2 => b'b'
+      3 => b'c'
+      _ => b'a'
+    }
+  })
+}
+
+///|
+fn make_find_view_substring_hit_start() -> Bytes {
+  Bytes::makei(find_bench_len + 17, i => {
+    match i - 7 {
+      0 => b'Z'
+      1 => b'a'
+      2 => b'b'
+      3 => b'c'
+      _ => b'a'
+    }
+  })
+}
+
+///|
 test "bench BytesView::find single byte hit end n=4096" (it : @bench.T) {
   let data = make_find_single_hit_end()
   let view = data[:]
@@ -111,4 +142,48 @@ test "bench BytesView::find substring miss n=32" (it : @bench.T) {
   let data = Bytes::makei(32, _ => b'a')
   let view = data[:]
   it.bench(fn() { it.keep(view.find(b"aaaaZ")) })
+}
+
+///|
+test "bench BytesView::rev_find single byte hit start n=4096" (it : @bench.T) {
+  let data = make_find_single_hit_start()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.rev_find(b"Z")) })
+}
+
+///|
+test "bench BytesView::rev_find single byte miss n=4096" (it : @bench.T) {
+  let data = make_find_single_miss()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.rev_find(b"Z")) })
+}
+
+///|
+test "bench BytesView::rev_find substring rare hit start n=4096" (it : @bench.T) {
+  let data = make_find_substring_hit_start()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.rev_find(b"Zabc")) })
+}
+
+///|
+test "bench BytesView::rev_find substring dense miss n=4096" (it : @bench.T) {
+  let data = make_find_single_miss()
+  let view = data[:]
+  it.bench(fn() { it.keep(view.rev_find(b"aaaaZ")) })
+}
+
+///|
+test "bench BytesView::rev_find offset view rare hit start n=4096" (
+  it : @bench.T,
+) {
+  let data = make_find_view_substring_hit_start()
+  let view = data[7:find_bench_len + 7]
+  it.bench(fn() { it.keep(view.rev_find(b"Zabc")) })
+}
+
+///|
+test "bench BytesView::rev_find long dense miss n=4096" (it : @bench.T) {
+  let data = make_find_single_miss()
+  let pattern = Bytes::makei(40, i => if i == 39 { b'Z' } else { b'a' })
+  it.bench(fn() { it.keep(data.rev_find(pattern)) })
 }

--- a/bytes/find_test.mbt
+++ b/bytes/find_test.mbt
@@ -90,7 +90,36 @@ test "rev_find" {
   debug_inspect(b"".rev_find(b"a"), content="None")
   debug_inspect(b"hello hello".rev_find(b"hello"), content="Some(6)")
   debug_inspect(b"aaa".rev_find(b"aa"), content="Some(1)")
-  debug_inspect(b"aabaaabaa".find(b"aaa"), content="Some(3)")
+  debug_inspect(b"aabaaabaa".rev_find(b"aaa"), content="Some(3)")
+}
+
+///|
+test "BytesView rev_find edge cases" {
+  let target = b"--abcabc--"[2:8]
+  debug_inspect(target.rev_find(b""), content="Some(6)")
+  debug_inspect(target.rev_find(b"abc"), content="Some(3)")
+  debug_inspect(target.rev_find(b"bca"), content="Some(1)")
+  debug_inspect(target.rev_find(b"cab"), content="Some(2)")
+  debug_inspect(target.rev_find(b"abcabc"), content="Some(0)")
+  debug_inspect(target.rev_find(b"xabcabc"), content="None")
+  debug_inspect(b""[:].rev_find(b""), content="Some(0)")
+  debug_inspect(b""[:].rev_find(b"a"), content="None")
+}
+
+///|
+test "BytesView rev_find long pattern offset view" {
+  let data = Bytes::makei(180, i => {
+    if i >= 97 && i < 136 {
+      b'a'
+    } else if i == 136 {
+      b'b'
+    } else {
+      b'x'
+    }
+  })
+  let view = data[9:170]
+  let pattern = Bytes::makei(40, i => if i == 39 { b'b' } else { b'a' })
+  debug_inspect(view.rev_find(pattern), content="Some(88)")
 }
 
 ///|


### PR DESCRIPTION
## Summary

Optimize `BytesView::rev_find` with specialized reverse scanners instead of the previous full nested scan.

This adds:

- reverse byte scanning for single-byte patterns
- native/wasm SIMD candidate scanning for multi-byte patterns
- scalar fallback for js/wasm-gc
- regression tests for offset views and long patterns
- benchmark coverage for `rev_find`

## Benchmarks

Command: `moon bench -p moonbitlang/core/bytes -f find_bench_test.mbt --target native --release`

| Benchmark | Before | After |
| --- | ---: | ---: |
| `rev_find single byte hit start n=4096` | 1.48 us | 138.94 ns |
| `rev_find single byte miss n=4096` | 1.46 us | 138.53 ns |
| `rev_find substring rare hit start n=4096` | 1.47 us | 164.46 ns |
| `rev_find substring dense miss n=4096` | 5.13 us | 158.72 ns |
| `rev_find offset view rare hit start n=4096` | 1.46 us | 229.15 ns |
| `rev_find long dense miss n=4096` | 42.26 us | 156.68 ns |

Target spot checks after the change:

| Target | Single byte miss | Dense substring miss | Long dense miss |
| --- | ---: | ---: | ---: |
| native | 138.53 ns | 158.72 ns | 156.68 ns |
| wasm | 207.65 ns | 297.83 ns | 295.43 ns |
| wasm-gc | 1.26 us | 2.27 us | 2.21 us |
| js | 1.22 us | 1.80 us | 1.80 us |

## Validation

- `moon fmt`
- `moon test bytes builtin --target all`
- `moon check bytes builtin --target all --no-render`
- `moon info`
- `moon bench -p moonbitlang/core/bytes -f find_bench_test.mbt --target native --release`
- `moon bench -p moonbitlang/core/bytes -f find_bench_test.mbt --target wasm --release`
- `moon bench -p moonbitlang/core/bytes -f find_bench_test.mbt --target wasm-gc --release`
- `moon bench -p moonbitlang/core/bytes -f find_bench_test.mbt --target js --release`