### PR TITLE
Optimize Vector iterator leaf traversal

### DIFF
--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -480,10 +480,19 @@ pub fn[A] Vector::iter(self : Vector[A]) -> Iter[A] {
   let mut in_tree = true
   let mut curr_tree = self.tree
   let mut curr_index = 0
+  let mut curr_leaf : FixedArray[A] = []
+  let mut leaf_index = 0
+  let mut leaf_len = 0
   let parents = []
   let mut tail_index = 0
+  let tail_len = self.tail.length()
   Iter::new(
     fn() {
+      if leaf_index < leaf_len {
+        let elem = curr_leaf.unsafe_get(leaf_index)
+        leaf_index += 1
+        return Some(elem)
+      }
       let tree_result = if in_tree {
         for tree = curr_tree {
           match tree {
@@ -495,8 +504,12 @@ pub fn[A] Vector::iter(self : Vector[A]) -> Iter[A] {
               continue child
             }
             Leaf(elems) if curr_index < elems.length() => {
+              let len = elems.length()
               let elem = elems.unsafe_get(curr_index)
-              curr_index += 1
+              curr_leaf = elems
+              leaf_len = len
+              leaf_index = curr_index + 1
+              curr_index = len
               break Some(elem)
             }
             _ if parents.pop() is Some((parent_tree, parent_index)) => {
@@ -516,7 +529,7 @@ pub fn[A] Vector::iter(self : Vector[A]) -> Iter[A] {
       match tree_result {
         Some(_) => tree_result
         None =>
-          if tail_index < self.tail.length() {
+          if tail_index < tail_len {
             let elem = self.tail.unsafe_get(tail_index)
             tail_index += 1
             Some(elem)


### PR DESCRIPTION
## Summary

Optimize `immut/vector` iteration by keeping the current leaf as a fast path inside `Vector::iter`.

Previously every element yielded from a leaf re-entered the tree-walking `match` path. This change consumes the rest of the current leaf directly, then resumes tree traversal only when that leaf is exhausted. It also caches the tail length used by the iterator.

## Benchmarks

Command: `moon bench -p moonbitlang/core/immut/vector -f vector_iter_bench_test.mbt --target <target> --release`

| Target | Benchmark | Before | After |
| --- | --- | ---: | ---: |
| native | `Vector::iter fold n=100000` | 334.97 us | 224.07 us |
| native | `Vector::iter each n=100000` | 312.65 us | 218.52 us |
| native | `Vector::iter to_array n=100000` | 360.73 us | 240.80 us |
| native | `Vector::for-in n=100000` | 329.46 us | 218.21 us |
| wasm | `Vector::iter fold n=100000` | 801.73 us | 519.59 us |
| wasm | `Vector::iter each n=100000` | 851.77 us | 541.83 us |
| wasm | `Vector::iter to_array n=100000` | 949.47 us | 645.65 us |
| wasm | `Vector::for-in n=100000` | 831.38 us | 550.82 us |
| wasm-gc | `Vector::iter fold n=100000` | 384.37 us | 372.41 us |
| wasm-gc | `Vector::iter each n=100000` | 396.70 us | 378.68 us |
| wasm-gc | `Vector::iter to_array n=100000` | 499.90 us | 462.63 us |
| wasm-gc | `Vector::for-in n=100000` | 385.19 us | 361.97 us |
| js | `Vector::iter fold n=100000` | 654.88 us | 502.46 us |
| js | `Vector::iter each n=100000` | 602.04 us | 472.71 us |
| js | `Vector::iter to_array n=100000` | 1.17 ms | 1.04 ms |
| js | `Vector::for-in n=100000` | 594.08 us | 492.01 us |

## Validation

- `moon fmt`
- `moon test immut/vector --target all`
- `moon check immut/vector --target all --no-render`
- `moon info`
- `moon bench -p moonbitlang/core/immut/vector -f vector_iter_bench_test.mbt --target native --release`
- `moon bench -p moonbitlang/core/immut/vector -f vector_iter_bench_test.mbt --target wasm --release`
- `moon bench -p moonbitlang/core/immut/vector -f vector_iter_bench_test.mbt --target wasm-gc --release`
- `moon bench -p moonbitlang/core/immut/vector -f vector_iter_bench_test.mbt --target js --release`