### PR TITLE
Optimize Bytes::from_array with blit

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -445,7 +445,17 @@ pub impl Compare for Bytes with fn compare(self, other) {
 // TODO: marked as intrinsic, inline if it is constant
 #alias(of, deprecated)
 pub fn Bytes::from_array(arr : ArrayView[Byte]) -> Bytes {
-  Bytes::makei(arr.length(), i => arr[i])
+  let len = arr.length()
+  if len == 0 {
+    return []
+  }
+  let result = UninitializedArray::make_and_blit(
+    arr.buf(),
+    allocate_len=len,
+    src_offset=arr.start(),
+    len~,
+  )
+  buffer_to_fixedarray(result).unsafe_reinterpret_as_bytes()
 }
 
 ///|

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -449,11 +449,12 @@ pub fn Bytes::from_array(arr : ArrayView[Byte]) -> Bytes {
   if len == 0 {
     return []
   }
-  let result = UninitializedArray::make_and_blit(
+  let result = UninitializedArray::unsafe_make_and_blit(
     arr.buf(),
-    allocate_len=len,
-    src_offset=arr.start(),
-    len~,
+    len,
+    arr.start(),
+    0,
+    len,
   )
   buffer_to_fixedarray(result).unsafe_reinterpret_as_bytes()
 }

--- a/builtin/bytes_from_array_bench_test.mbt
+++ b/builtin/bytes_from_array_bench_test.mbt
@@ -1,3 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 ///|
 let bytes_from_array_bench_size : Int = 256 * 1024
 

--- a/builtin/bytes_from_array_bench_test.mbt
+++ b/builtin/bytes_from_array_bench_test.mbt
@@ -1,0 +1,49 @@
+///|
+let bytes_from_array_bench_size : Int = 256 * 1024
+
+///|
+let bytes_from_array_bench_source : FixedArray[Byte] = FixedArray::makei(
+  bytes_from_array_bench_size + 1,
+  fn(i) { (i & 0xff).to_byte() },
+)
+
+///|
+fn bytes_from_array_bench_makei(arr : ArrayView[Byte]) -> Bytes {
+  Bytes::makei(arr.length(), fn(i) { arr[i] })
+}
+
+///|
+test "bench Bytes::from_array n=262144 full" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(
+      Bytes::from_array(
+        bytes_from_array_bench_source[:bytes_from_array_bench_size],
+      ),
+    )
+  })
+}
+
+///|
+test "bench Bytes::from_array n=262144 sliced" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(Bytes::from_array(bytes_from_array_bench_source[1:]))
+  })
+}
+
+///|
+test "bench Bytes::makei from ArrayView n=262144 full" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(
+      bytes_from_array_bench_makei(
+        bytes_from_array_bench_source[:bytes_from_array_bench_size],
+      ),
+    )
+  })
+}
+
+///|
+test "bench Bytes::makei from ArrayView n=262144 sliced" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(bytes_from_array_bench_makei(bytes_from_array_bench_source[1:]))
+  })
+}


### PR DESCRIPTION
## Summary

This optimizes `Bytes::from_array` by copying the source `ArrayView[Byte]` with `UninitializedArray::unsafe_make_and_blit` instead of rebuilding bytes through `Bytes::makei` and per-element `ArrayView` indexing.

The motivation came from profiling a real zlib workload. In `mizchi/zlib`, `zlib_decompress` on the dynamic 256 KiB fixture spent most of its sampled time converting the decompressed `Array[Byte]` back to `Bytes`:

- `bytes_from_array`: 61.2% inclusive
- `Bytes::makei`: 48.1% inclusive
- `ArrayView::at[Byte]`: 35.2% self

This change keeps the public `Bytes::from_array` behavior the same, but routes the copy through the existing blit primitive. The latest review update uses `unsafe_make_and_blit` directly because `ArrayView` has already established the backing buffer, start offset, and length invariants.

It also adds `Bytes::unsafe_from_array_owned(Array[Byte])` for callers that can hand off an `Array[Byte]` and stop using it afterwards. This can be zero-copy when the array length already matches its capacity. If the array has spare capacity, it first calls `shrink_to_fit()` so the resulting `Bytes.length()` matches the logical array length; that fallback may allocate and copy on non-JS backends. The API is intentionally marked unsafe because the returned `Bytes` aliases the array storage.

## Benchmarks

Command:

```sh
moon bench -p moonbitlang/core/builtin -f bytes_from_array_bench_test.mbt --target native --release
moon bench -p moonbitlang/core/builtin -f bytes_from_array_bench_test.mbt --target js --release
```

| target | case | `Bytes::from_array` | old `Bytes::makei` equivalent |
|---|---:|---:|---:|
| native | full 256 KiB | 3.56 us | 186.43 us |
| native | sliced 256 KiB | 4.03 us | 187.73 us |
| js | full 256 KiB | 459.69 us | 1.11 ms |
| js | sliced 256 KiB | 453.76 us | 1.13 ms |

## Validation

```sh
moon fmt
moon info
moon check builtin --target native --release
moon check --target native --release
moon test -p moonbitlang/core/builtin --target native --release
moon test -p moonbitlang/core/builtin --target js --release
moon bench -p moonbitlang/core/builtin -f bytes_from_array_bench_test.mbt --target native --release
moon bench -p moonbitlang/core/builtin -f bytes_from_array_bench_test.mbt --target js --release
```
