### PR TITLE
[codex] Optimize bytes lexical compare with v128

### DIFF
--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -764,6 +764,16 @@ fn BytesView::bytesview_lexical_compare_impl(
   let self_len = self.length()
   let other_len = other.length()
   let min_len = if self_len < other_len { self_len } else { other_len }
+  if min_len >= 16 {
+    let cmp = self.unsafe_get(0).compare(other.unsafe_get(0))
+    if cmp != 0 {
+      return cmp
+    }
+    let cmp = self.unsafe_get(1).compare(other.unsafe_get(1))
+    if cmp != 0 {
+      return cmp
+    }
+  }
   let self_bytes = unsafe_from_bytes(self.bytes())
   let other_bytes = unsafe_from_bytes(other.bytes())
   let self_start = self.start()

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -730,10 +730,10 @@ pub impl Compare for BytesView with fn compare(self, other) -> Int {
 ///|
 /// Performs a lexicographical comparison of two byte views.
 ///
-/// This method compares the views byte by byte until a difference is found
-/// or one view is exhausted. Unlike the `Compare` trait implementation which
-/// uses shortlex order (shorter views come first), this method compares based
-/// purely on byte values until a difference is found.
+/// This method returns the lexicographical ordering by byte value. Unlike the
+/// `Compare` trait implementation which uses shortlex order (shorter views come
+/// first), this method compares based purely on byte values until a difference
+/// is found.
 ///
 /// # Returns
 ///
@@ -752,6 +752,52 @@ pub impl Compare for BytesView with fn compare(self, other) -> Int {
 /// }
 /// ```
 pub fn BytesView::lexical_compare(self : BytesView, other : BytesView) -> Int {
+  self.bytesview_lexical_compare_impl(other)
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn BytesView::bytesview_lexical_compare_impl(
+  self : BytesView,
+  other : BytesView,
+) -> Int {
+  let self_len = self.length()
+  let other_len = other.length()
+  let min_len = if self_len < other_len { self_len } else { other_len }
+  let self_bytes = unsafe_from_bytes(self.bytes())
+  let other_bytes = unsafe_from_bytes(other.bytes())
+  let self_start = self.start()
+  let other_start = other.start()
+  let mut i = 0
+  let block_limit = min_len - min_len % 16
+  while i < block_limit {
+    let a = v128_load(self_bytes, self_start + i)
+    let b = v128_load(other_bytes, other_start + i)
+    let diff_bits = i8x16_bitmask(i8x16_eq(a, b)) ^ 0xFFFF
+    if diff_bits != 0 {
+      let lane = diff_bits.ctz()
+      return self_bytes
+        .unsafe_get(self_start + i + lane)
+        .compare(other_bytes.unsafe_get(other_start + i + lane))
+    }
+    i = i + 16
+  }
+  while i < min_len {
+    let cmp = self.unsafe_get(i).compare(other.unsafe_get(i))
+    if cmp != 0 {
+      return cmp
+    }
+    i = i + 1
+  }
+  self_len.compare(other_len)
+}
+
+///|
+#cfg(any(target="wasm-gc", target="js"))
+fn BytesView::bytesview_lexical_compare_impl(
+  self : BytesView,
+  other : BytesView,
+) -> Int {
   let self_len = self.length()
   let other_len = other.length()
   let min_len = if self_len < other_len { self_len } else { other_len }

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -764,6 +764,7 @@ fn BytesView::bytesview_lexical_compare_impl(
   let self_len = self.length()
   let other_len = other.length()
   let min_len = if self_len < other_len { self_len } else { other_len }
+  // Avoid v128 setup for the common case where long inputs differ immediately.
   if min_len >= 16 {
     let cmp = self.unsafe_get(0).compare(other.unsafe_get(0))
     if cmp != 0 {

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -804,7 +804,7 @@ fn BytesView::bytesview_lexical_compare_impl(
 }
 
 ///|
-#cfg(any(target="wasm-gc", target="js"))
+#cfg(not(any(target="native", target="wasm")))
 fn BytesView::bytesview_lexical_compare_impl(
   self : BytesView,
   other : BytesView,

--- a/builtin/lexical_compare_bench_test.mbt
+++ b/builtin/lexical_compare_bench_test.mbt
@@ -1,0 +1,54 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let lc_equal_a : Bytes = Bytes::makei(256, i => (i % 251).to_byte())
+
+///|
+let lc_equal_b : Bytes = Bytes::makei(256, i => (i % 251).to_byte())
+
+///|
+// Identical except the last byte: full common-prefix scan.
+let lc_prefix_a : Bytes = Bytes::makei(256, i => (i % 251).to_byte())
+
+///|
+let lc_prefix_b : Bytes = Bytes::makei(256, i => {
+  if i == 255 {
+    b'\xff'
+  } else {
+    (i % 251).to_byte()
+  }
+})
+
+///|
+// Differ at byte 1: early-exit regression guard.
+let lc_early_a : Bytes = Bytes::makei(256, _ => b'a')
+
+///|
+let lc_early_b : Bytes = Bytes::makei(256, i => if i == 1 { b'b' } else { b'a' })
+
+///|
+test "bench lexical_compare equal n=256" (it : @bench.T) {
+  it.bench(fn() { it.keep(lc_equal_a.lexical_compare(lc_equal_b)) })
+}
+
+///|
+test "bench lexical_compare common-prefix n=256" (it : @bench.T) {
+  it.bench(fn() { it.keep(lc_prefix_a.lexical_compare(lc_prefix_b)) })
+}
+
+///|
+test "bench lexical_compare early-diff n=256" (it : @bench.T) {
+  it.bench(fn() { it.keep(lc_early_a.lexical_compare(lc_early_b)) })
+}


### PR DESCRIPTION
## Summary

Use a `#cfg`-selected v128 implementation for `BytesView::lexical_compare` on native and wasm. The implementation compares 16 bytes at a time with `v128_load`, `i8x16_eq`, `i8x16_bitmask`, and `ctz`, then falls back to scalar comparison for the tail and for other backends.

The v128 path also checks the first two bytes before entering the vector loop when the input is long enough to use v128, which keeps the common early-difference case close to the scalar path.

This follows the equality-mask-first-difference shape used by Go's byte comparison on SIMD-capable paths.

## Performance

Lower is better. Benchmarks compare this PR against base commit `566e2aa4` using 256-byte inputs.

| Backend | Case | Base | This PR | Speedup |
| --- | --- | ---: | ---: | ---: |
| native | equal | 133.00 ns | 19.37 ns | 6.87x |
| native | common-prefix | 133.44 ns | 19.19 ns | 6.95x |
| native | early-diff | 7.96 ns | 8.41 ns | 0.95x |
| wasm | equal | 305.15 ns | 48.08 ns | 6.35x |
| wasm | common-prefix | 302.81 ns | 49.68 ns | 6.10x |
| wasm | early-diff | 28.29 ns | 27.39 ns | 1.03x |
| wasm-gc | equal | 330.47 ns | 327.36 ns | 1.01x |
| wasm-gc | common-prefix | 305.65 ns | 301.12 ns | 1.02x |
| wasm-gc | early-diff | 12.90 ns | 14.42 ns | 0.89x |
| js | equal | 284.81 ns | 283.49 ns | 1.00x |
| js | common-prefix | 288.50 ns | 288.37 ns | 1.00x |
| js | early-diff | 10.36 ns | 10.45 ns | 0.99x |

## Validation

- `moon fmt`
- `moon info`
- `moon check builtin --target all`
- `moon check builtin --target llvm`
- `moon test builtin --target native --filter lexical_compare`
- `moon test builtin --target wasm --filter lexical_compare`
- `moon test builtin --target wasm-gc --filter lexical_compare`
- `moon test builtin --target js --filter lexical_compare`
- `moon bench --target native --package moonbitlang/core/builtin --file lexical_compare_bench_test.mbt`
- `moon bench --target wasm --package moonbitlang/core/builtin --file lexical_compare_bench_test.mbt`
- `moon bench --target wasm-gc --package moonbitlang/core/builtin --file lexical_compare_bench_test.mbt`
- `moon bench --target js --package moonbitlang/core/builtin --file lexical_compare_bench_test.mbt`