### PR TITLE
perf(deque): use blit for to_array and contiguous-run loops for Eq/Compare

### DIFF
--- a/deque/conv_bench_test.mbt
+++ b/deque/conv_bench_test.mbt
@@ -1,0 +1,75 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let conv_bench_size = 10000
+
+///|
+fn make_contiguous_deque(len : Int) -> @deque.Deque[Int] {
+  let dq = @deque.Deque([], capacity=len)
+  for i in 0..<len {
+    dq.push_back(i)
+  }
+  dq
+}
+
+///|
+/// A deque holding the same elements as `make_contiguous_deque`, but whose
+/// elements wrap around the internal ring buffer boundary.
+fn make_wrapped_deque(len : Int) -> @deque.Deque[Int] {
+  let dq = @deque.Deque([], capacity=len)
+  for _ in 0..<(len / 2) {
+    dq.push_back(-1)
+  }
+  for _ in 0..<(len / 2) {
+    dq.pop_front() |> ignore
+  }
+  for i in 0..<len {
+    dq.push_back(i)
+  }
+  dq
+}
+
+///|
+test "bench Deque::to_array contiguous n=10000" (it : @bench.T) {
+  let dq = make_contiguous_deque(conv_bench_size)
+  it.bench(fn() { it.keep(dq.to_array()) })
+}
+
+///|
+test "bench Deque::to_array wrapped n=10000" (it : @bench.T) {
+  let dq = make_wrapped_deque(conv_bench_size)
+  it.bench(fn() { it.keep(dq.to_array()) })
+}
+
+///|
+test "bench Deque::op_equal contiguous n=10000" (it : @bench.T) {
+  let dq1 = make_contiguous_deque(conv_bench_size)
+  let dq2 = make_contiguous_deque(conv_bench_size)
+  it.bench(fn() { it.keep(dq1 == dq2) })
+}
+
+///|
+test "bench Deque::op_equal wrapped n=10000" (it : @bench.T) {
+  let dq1 = make_wrapped_deque(conv_bench_size)
+  let dq2 = make_contiguous_deque(conv_bench_size)
+  it.bench(fn() { it.keep(dq1 == dq2) })
+}
+
+///|
+test "bench Deque::compare wrapped n=10000" (it : @bench.T) {
+  let dq1 = make_wrapped_deque(conv_bench_size)
+  let dq2 = make_contiguous_deque(conv_bench_size)
+  it.bench(fn() { it.keep(dq1.compare(dq2)) })
+}

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -952,10 +952,36 @@ pub impl[A : Eq] Eq for Deque[A] with fn equal(self, other) {
   if self.len != other.len {
     return false
   }
-  for i in 0..<self.len {
-    if self[i] != other[i] {
-      return false
+  let len = self.len
+  let scap = self.buf.length()
+  let ocap = other.buf.length()
+  // Compare runs where both ring buffers are contiguous, so the inner loop
+  // carries no wrap-around branches. There are at most three such runs.
+  let mut k = 0
+  while k < len {
+    let mut i = self.head + k
+    if i >= scap {
+      i -= scap
     }
+    let mut j = other.head + k
+    if j >= ocap {
+      j -= ocap
+    }
+    let mut run = len - k
+    if run > scap - i {
+      run = scap - i
+    }
+    if run > ocap - j {
+      run = ocap - j
+    }
+    for _ in 0..<run {
+      if self.buf[i] != other.buf[j] {
+        return false
+      }
+      i += 1
+      j += 1
+    }
+    k += run
   }
   true
 }
@@ -1721,16 +1747,11 @@ pub fn[A] Deque::from_iter(iter : Iter[A]) -> Deque[A] {
 /// ```
 ///
 pub fn[A] Deque::to_array(self : Deque[A]) -> Array[A] {
-  let len = self.length()
-  if len == 0 {
-    []
-  } else {
-    let xs = Array::make(len, self[0])
-    for i in 0..<len {
-      xs[i] = self[i]
-    }
-    xs
-  }
+  let (front, back) = self.as_views()
+  let xs = Array::new(capacity=self.len)
+  xs.append(front)
+  xs.append(back)
+  xs
 }
 
 ///|
@@ -2385,13 +2406,37 @@ pub fn[A : Compare] Deque::binary_search(
 /// }
 /// ```
 pub impl[A : Compare] Compare for Deque[A] with fn compare(self, other) {
-  let len_self = self.length()
-  let len_other = other.length()
-  let cmp = len_self.compare(len_other)
+  let cmp = self.len.compare(other.len)
   guard cmp is 0 else { return cmp }
-  for i in 0..<len_self {
-    let cmp = self[i].compare(other[i])
-    guard cmp is 0 else { return cmp }
+  let len = self.len
+  let scap = self.buf.length()
+  let ocap = other.buf.length()
+  // Compare runs where both ring buffers are contiguous, so the inner loop
+  // carries no wrap-around branches. There are at most three such runs.
+  let mut k = 0
+  while k < len {
+    let mut i = self.head + k
+    if i >= scap {
+      i -= scap
+    }
+    let mut j = other.head + k
+    if j >= ocap {
+      j -= ocap
+    }
+    let mut run = len - k
+    if run > scap - i {
+      run = scap - i
+    }
+    if run > ocap - j {
+      run = ocap - j
+    }
+    for _ in 0..<run {
+      let cmp = self.buf[i].compare(other.buf[j])
+      guard cmp is 0 else { return cmp }
+      i += 1
+      j += 1
+    }
+    k += run
   }
   0
 }

--- a/deque/moon.pkg
+++ b/deque/moon.pkg
@@ -7,6 +7,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/test",
 } for "test"
 


### PR DESCRIPTION
This PR speeds up `Deque::to_array`, `Eq`, and `Compare` by avoiding per-element bounds-checked access through `Deque::at`.

## Changes

- **`to_array`**: previously filled the whole result with the front element via `Array::make`, then overwrote every slot through the bounds-checked `self[i]` (two writes per slot, plus a range check and a wrap-around branch per read). It now builds the result from the two ring-buffer segments returned by `as_views()` using `Array::append` (blit).
- **`Eq` / `Compare`**: previously walked both deques through `self[i]` / `other[i]`, paying a range check and a wrap-around branch per element per deque. They now walk the underlying buffers in contiguous runs — at most three per comparison — so the inner loops carry no wrap-around branches.

`moon info` reports no `.mbti` changes, so the external interface is unchanged.

## Benchmarks

`deque/conv_bench_test.mbt` (included in this PR), n=10000, Apple Silicon (M-series). "wrapped" means the deque's elements wrap around the internal ring buffer boundary.

### wasm-gc

| bench | before | after | speedup |
|---|---|---|---|
| to_array contiguous | 19.96 µs | 1.33 µs | 15.0x |
| to_array wrapped | 19.11 µs | 2.02 µs | 9.5x |
| op_equal contiguous | 29.61 µs | 4.73 µs | 6.3x |
| op_equal wrapped | 28.08 µs | 4.71 µs | 6.0x |
| compare wrapped | 19.33 µs | 5.87 µs | 3.3x |

### native

| bench | before | after | speedup |
|---|---|---|---|
| to_array contiguous | 7.55 µs | 0.49 µs | 15.4x |
| to_array wrapped | 7.64 µs | 0.71 µs | 10.8x |
| op_equal contiguous | 6.91 µs | 4.71 µs | 1.5x |
| op_equal wrapped | 6.72 µs | 4.95 µs | 1.4x |
| compare wrapped | 7.15 µs | 6.16 µs | 1.2x |

A note on the Eq/Compare approach: a simpler variant that keeps two cursors and wraps each with a per-element branch was ~2.9x faster on wasm-gc but 12–40% *slower* than the current code on native, so this PR uses the contiguous-run formulation, which is faster than the baseline on both targets.

## Checks

- `moon test` (wasm-gc, all packages), `moon test --target native/js -p moonbitlang/core/deque`: all pass
- `moon check` / `moon fmt` / `moon info`: clean, no `.mbti` diff
