### PR TITLE
test(argparse): split rejected config cases

### DIFF
--- a/argparse/argparse_blackbox_test.mbt
+++ b/argparse/argparse_blackbox_test.mbt
@@ -494,104 +494,6 @@ test "default subcommand help annotation and child error context" {
 }
 
 ///|
-test "default subcommand validation rejects ambiguous root configuration" {
-  try
-    @argparse.Command(
-      "demo",
-      subcommands=[Command("run")],
-      default_subcommand="missing",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand must name a visible subcommand: missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command(
-      "demo",
-      subcommands=[Command("run")],
-      subcommand_required=true,
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand cannot be used with subcommand_required
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command(
-      "demo",
-      subcommands=[Command("run")],
-      arg_required_else_help=true,
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand cannot be used with arg_required_else_help
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command(
-      "demo",
-      options=[OptionArg("mode", long="mode")],
-      subcommands=[Command("run")],
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand only supports global root flags/options
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", long="verbose", global=true)],
-      groups=[ArgGroup("verbosity", args=["verbose"])],
-      subcommands=[Command("run")],
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand does not support root groups
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
 test "subcommand cannot follow positional arguments" {
   let cmd = @argparse.Command("demo", positionals=[PositionArg("input")], subcommands=[
     Command("run"),
@@ -1205,23 +1107,14 @@ test "indexed non-last positional allows explicit single num_args" {
 }
 
 ///|
-test "empty positional value range is rejected at build time" {
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("skip", num_args=ValueRange(lower=0, upper=0)),
-      PositionArg("name", num_args=@argparse.ValueRange::single()),
-    ]).parse(argv=["alice"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: empty value range (0..0) is unsupported
-        ),
-      )
-  } noraise {
+test "bounded positional can leave later optional positional empty" {
+  let parsed = @argparse.Command("demo", positionals=[
+    PositionArg("x", num_args=ValueRange(lower=0, upper=2)),
+    PositionArg("y"),
+  ]).parse(argv=["a"], env=empty_env()) catch {
     _ => panic()
   }
+  assert_true(parsed.values is { "x": ["a"], "y"? : None, .. })
 }
 
 ///|
@@ -1436,43 +1329,6 @@ test "set options reject duplicate occurrences" {
 }
 
 ///|
-test "flag and option args require short or long names" {
-  try
-    @argparse.Command("demo", options=[OptionArg("input", long="")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: flag/option args require short/long/env
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", flags=[FlagArg("verbose", long="")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: flag/option args require short/long/env
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
 test "append options collect values across repeated occurrences" {
   let cmd = @argparse.Command("demo", options=[
     OptionArg("arg", long="arg", action=Append),
@@ -1613,8 +1469,6 @@ test "option values reject hyphen tokens unless allow_hyphen_values is enabled" 
 }
 
 ///|
-
-///|
 test "default argv path is reachable" {
   let cmd = @argparse.Command("demo", positionals=[
     PositionArg("rest", num_args=ValueRange(lower=0), allow_hyphen_values=true),
@@ -1623,372 +1477,7 @@ test "default argv path is reachable" {
 }
 
 ///|
-test "validation branches exposed through parse" {
-  try
-    @argparse.Command("demo", flags=[FlagArg("f", long="", action=Help)]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: flag/option args require short/long/env
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("f", long="f", action=Help, negatable=true),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: help/version actions do not support negatable
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("f", long="f", action=Help, env="F"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: help/version actions do not support env/defaults
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", options=[OptionArg("x", long="x")]).parse(
-      argv=["--x", "a", "b"],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'b' found; no more were expected
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --x <x>     
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", long="x", default_values=["a", "b"]),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_values with multiple entries require action=Append
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("x", num_args=ValueRange(lower=3, upper=2)),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: max values must be >= min values
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("x", num_args=ValueRange(lower=-1, upper=2)),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: min values must be >= 0
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("x", num_args=ValueRange(lower=0, upper=-1)),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: max values must be >= 0
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  let positional_ok = @argparse.Command("demo", positionals=[
-    PositionArg("x", num_args=ValueRange(lower=0, upper=2)),
-    PositionArg("y"),
-  ]).parse(argv=["a"], env=empty_env()) catch {
-    _ => panic()
-  }
-  assert_true(positional_ok.values is { "x": ["a"], "y"? : None, .. })
-
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g"), ArgGroup("g")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate group: g
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", requires=["g"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: group cannot require itself: g
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", conflicts_with=["g"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: group cannot conflict with itself: g
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", args=["missing"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown group arg: g -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", long="x"),
-      OptionArg("x", long="y"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate arg name: x
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", long="same"),
-      OptionArg("y", long="same"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate long option: --same
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("hello", long="hello", negatable=true),
-      FlagArg("x", long="no-hello"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate long option: --no-hello
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", short='s'),
-      OptionArg("y", short='s'),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate short option: -s
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", flags=[FlagArg("x", long="x", requires=["x"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg cannot require itself: x
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("x", long="x", conflicts_with=["x"]),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg cannot conflict with itself: x
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", subcommands=[Command("x"), Command("x")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate subcommand: x
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", subcommand_required=true).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: subcommand_required requires at least one subcommand
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
-  try
-    @argparse.Command("demo", subcommands=[Command("help")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: subcommand name reserved for built-in help: help (disable with disable_help_subcommand)
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-
+test "builtin and custom help/version dispatch edge paths" {
   let custom_help = @argparse.Command("demo", flags=[
     FlagArg("custom_help", short='h', long="help", about="custom help"),
   ])
@@ -2034,26 +1523,6 @@ test "validation branches exposed through parse" {
     ),
   )
 
-  try
-    @argparse.Command("demo", flags=[FlagArg("v", long="v", action=Version)]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: version action requires command version text
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "builtin and custom help/version dispatch edge paths" {
   let versioned = @argparse.Command("demo", version="1.2.3")
   inspect(
     versioned.render_help(),
@@ -2125,46 +1594,6 @@ test "subcommand lookup falls back to positional value" {
   let parsed = cmd.parse(argv=["raw"], env=empty_env()) catch { _ => panic() }
   assert_true(parsed.values is { "input": ["raw"], .. })
   assert_true(parsed.subcommand is None)
-}
-
-///|
-test "group validation catches unknown requires target" {
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", requires=["missing"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown group requires target: g -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "group validation catches unknown conflicts_with target" {
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", conflicts_with=["missing"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown group conflicts_with target: g -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
 }
 
 ///|
@@ -2253,44 +1682,6 @@ test "group without members has no parse effect" {
   assert_true(parsed.flags is { "x": true, .. })
   let help = cmd.render_help()
   assert_true(help.has_prefix("Usage: demo [options]"))
-}
-
-///|
-test "arg validation catches unknown requires target" {
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("mode", long="mode", requires=["missing"]),
-    ]).parse(argv=["--mode", "fast"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown requires target: mode -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "arg validation catches unknown conflicts_with target" {
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("mode", long="mode", conflicts_with=["missing"]),
-    ]).parse(argv=["--mode", "fast"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown conflicts_with target: mode -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
 }
 
 ///|
@@ -3091,35 +2482,6 @@ test "inherited argv global satisfies child required global override" {
 }
 
 ///|
-test "child local arg shadowing inherited global is rejected at build time" {
-  try
-    @argparse.Command(
-      "demo",
-      options=[
-        OptionArg(
-          "mode",
-          long="mode",
-          env="MODE",
-          default_values=["safe"],
-          global=true,
-        ),
-      ],
-      subcommands=[Command("run", options=[OptionArg("mode", long="mode")])],
-    ).parse(argv=["run"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'mode' shadows an inherited global; rename the arg or mark it global
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
 test "global append env value from child is merged back to parent" {
   let cmd = @argparse.Command(
     "demo",
@@ -3220,71 +2582,6 @@ test "global set option rejects duplicate occurrences across subcommands" {
           #|  -h, --help     Show help information.
           #|  --mode <mode>  
           #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "global override with incompatible inherited type is rejected" {
-  try
-    @argparse.Command(
-      "demo",
-      options=[OptionArg("mode", long="mode", required=true, global=true)],
-      subcommands=[
-        Command("run", flags=[FlagArg("mode", long="mode", global=true)]),
-      ],
-    ).parse(argv=["run", "--mode"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: global arg 'mode' is incompatible with inherited global definition
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "child local long alias collision with inherited global is rejected" {
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", long="verbose", global=true)],
-      subcommands=[Command("run", options=[OptionArg("local", long="verbose")])],
-    ).parse(argv=["run", "--verbose"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'local' long option --verbose conflicts with inherited global 'verbose'
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "child local short alias collision with inherited global is rejected" {
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", short='v', global=true)],
-      subcommands=[Command("run", options=[OptionArg("local", short='v')])],
-    ).parse(argv=["run", "-v"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'local' short option -v conflicts with inherited global 'verbose'
         ),
       )
   } noraise {
@@ -3411,31 +2708,6 @@ test "nested global override keeps single set value without false duplicate erro
     sub_mid.subcommand is Some(("leaf", sub_leaf)) &&
     sub_leaf.values is { "mode": ["fast"], .. },
   )
-}
-
-///|
-test "global override with different negatable setting is rejected" {
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", long="verbose", negatable=true, global=true)],
-      subcommands=[
-        Command("run", flags=[
-          FlagArg("verbose", long="verbose", negatable=false, global=true),
-        ]),
-      ],
-    ).parse(argv=["run"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: global arg 'verbose' is incompatible with inherited global definition
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
 }
 
 ///|

--- a/argparse/argparse_coverage_test.mbt
+++ b/argparse/argparse_coverage_test.mbt
@@ -234,66 +234,6 @@ test "unknown long flag with an empty name has no suggestion" {
 }
 
 ///|
-test "subcommand build errors surface as validation failures" {
-  let cmd = @argparse.Command("demo", subcommands=[
-    Command("child", flags=[FlagArg("x", long="x", requires=["missing"])]),
-  ])
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown requires target: x -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "global flag cannot be redefined as an incompatible global option" {
-  let cmd = @argparse.Command(
-    "demo",
-    flags=[FlagArg("shared", long="shared", global=true)],
-    subcommands=[
-      Command("child", options=[OptionArg("shared", long="shared", global=true)]),
-    ],
-  )
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: global arg 'shared' is incompatible with inherited global definition
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
-test "subcommand long option colliding with an inherited global is rejected" {
-  let cmd = @argparse.Command(
-    "demo",
-    options=[OptionArg("opt", long="dup", global=true)],
-    subcommands=[Command("child", flags=[FlagArg("other", long="dup")])],
-  )
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'other' long option --dup conflicts with inherited global 'opt'
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
 test "compatible global flag can be redeclared in a subcommand" {
   let cmd = @argparse.Command(
     "demo",

--- a/argparse/argparse_test.mbt
+++ b/argparse/argparse_test.mbt
@@ -197,25 +197,6 @@ test "subcommand parse errors include subcommand help" {
 }
 
 ///|
-test "build errors are surfaced as validation failure message" {
-  let cmd = @argparse.Command("demo", flags=[
-    FlagArg("fast", long="fast", requires=["missing"]),
-  ])
-
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown requires target: fast -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
-}
-
-///|
 test "unknown argument keeps suggestion in final message" {
   let cmd = @argparse.Command("demo", flags=[FlagArg("verbose", long="verbose")])
 

--- a/argparse/rejected_config_test.mbt
+++ b/argparse/rejected_config_test.mbt
@@ -1,0 +1,817 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Rejected command definitions, not argv parse failures.
+///
+/// Flags/options without an argv spelling or env source are dead config: they
+/// can appear in relationships and help, but users can never set them.
+test "flag and option config requires an argv or env spelling" {
+  try
+    @argparse.Command("demo", options=[OptionArg("input", long="")]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: flag/option args require short/long/env
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", flags=[FlagArg("verbose", long="")]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: flag/option args require short/long/env
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", flags=[FlagArg("f", long="", action=Help)]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: flag/option args require short/long/env
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Default dispatch must have one visible target and must not conflict with
+/// root-level policies that also claim bare argv or leading tokens.
+test "default subcommand config rejects ambiguous root dispatch" {
+  try
+    @argparse.Command(
+      "demo",
+      subcommands=[Command("run")],
+      default_subcommand="missing",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand must name a visible subcommand: missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      subcommands=[Command("secret", hidden=true)],
+      default_subcommand="secret",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand must name a visible subcommand: secret
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      subcommands=[Command("run")],
+      subcommand_required=true,
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand cannot be used with subcommand_required
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      subcommands=[Command("run")],
+      arg_required_else_help=true,
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand cannot be used with arg_required_else_help
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      options=[OptionArg("mode", long="mode")],
+      subcommands=[Command("run")],
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand only supports global root flags/options
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      flags=[FlagArg("verbose", long="verbose", global=true)],
+      groups=[ArgGroup("verbosity", args=["verbose"])],
+      subcommands=[Command("run")],
+      default_subcommand="run",
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_subcommand does not support root groups
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Value ranges must describe a non-empty, non-negative interval. Otherwise
+/// positional allocation and usage output would encode impossible counts.
+test "value range config rejects impossible counts" {
+  try
+    @argparse.Command("demo", positionals=[
+      PositionArg("skip", num_args=ValueRange(lower=0, upper=0)),
+      PositionArg("name", num_args=@argparse.ValueRange::single()),
+    ]).parse(argv=["alice"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: empty value range (0..0) is unsupported
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", positionals=[
+      PositionArg("x", num_args=ValueRange(lower=3, upper=2)),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: max values must be >= min values
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", positionals=[
+      PositionArg("x", num_args=ValueRange(lower=-1, upper=2)),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: min values must be >= 0
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", positionals=[
+      PositionArg("x", num_args=ValueRange(lower=0, upper=-1)),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: max values must be >= 0
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Terminal actions and defaults need unambiguous triggers and output: no
+/// negated help/version, no env-triggered terminal action, no multi-default Set.
+test "action config rejects unsupported implicit behavior" {
+  try
+    @argparse.Command("demo", flags=[
+      FlagArg("f", long="f", action=Help, negatable=true),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: help/version actions do not support negatable
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", flags=[
+      FlagArg("f", long="f", action=Help, env="F"),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: help/version actions do not support env/defaults
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", options=[
+      OptionArg("x", long="x", default_values=["a", "b"]),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: default_values with multiple entries require action=Append
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", flags=[FlagArg("v", long="v", action=Version)]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: version action requires command version text
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Groups form a relationship graph. Duplicate names, self-edges, and missing
+/// targets make that graph ambiguous, unsatisfiable, or impossible to report.
+test "group config rejects circular or unknown relationships" {
+  try
+    @argparse.Command("demo", groups=[ArgGroup("g"), ArgGroup("g")]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: duplicate group: g
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", groups=[ArgGroup("g", requires=["g"])]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: group cannot require itself: g
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", groups=[ArgGroup("g", conflicts_with=["g"])]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: group cannot conflict with itself: g
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", groups=[ArgGroup("g", args=["missing"])]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: unknown group arg: g -> missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", groups=[ArgGroup("g", requires=["missing"])]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: unknown group requires target: g -> missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", groups=[ArgGroup("g", conflicts_with=["missing"])]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: unknown group conflicts_with target: g -> missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Argument names and option aliases are parser keys. Duplicates make result
+/// slots or argv tokens ambiguous; negatable flags also reserve `--no-<long>`.
+test "argument config rejects duplicate names and aliases" {
+  try
+    @argparse.Command("demo", options=[
+      OptionArg("x", long="x"),
+      OptionArg("x", long="y"),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: duplicate arg name: x
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", options=[
+      OptionArg("x", long="same"),
+      OptionArg("y", long="same"),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: duplicate long option: --same
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", flags=[
+      FlagArg("hello", long="hello", negatable=true),
+      FlagArg("x", long="no-hello"),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: duplicate long option: --no-hello
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", options=[
+      OptionArg("x", short='s'),
+      OptionArg("y", short='s'),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: duplicate short option: -s
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Argument relationships also form a graph over known args/groups. Self edges
+/// and missing nodes create unsatisfiable or unreportable requirements.
+test "argument relationship config rejects circular or unknown targets" {
+  try
+    @argparse.Command("demo", flags=[FlagArg("x", long="x", requires=["x"])]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: arg cannot require itself: x
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", flags=[
+      FlagArg("x", long="x", conflicts_with=["x"]),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: arg cannot conflict with itself: x
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", options=[
+      OptionArg("mode", long="mode", requires=["missing"]),
+    ]).parse(argv=["--mode", "fast"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: unknown requires target: mode -> missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", flags=[
+      FlagArg("fast", long="fast", requires=["missing"]),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: unknown requires target: fast -> missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", options=[
+      OptionArg("mode", long="mode", conflicts_with=["missing"]),
+    ]).parse(argv=["--mode", "fast"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: unknown conflicts_with target: mode -> missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", subcommands=[
+      Command("child", flags=[FlagArg("x", long="x", requires=["missing"])]),
+    ]).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: unknown requires target: x -> missing
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Subcommand names are dispatch keys, and built-in help owns its route.
+/// Required-subcommand config must also provide at least one possible target.
+test "subcommand config rejects ambiguous command surfaces" {
+  try
+    @argparse.Command("demo", subcommands=[Command("x"), Command("x")]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: duplicate subcommand: x
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", subcommand_required=true).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: subcommand_required requires at least one subcommand
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command("demo", subcommands=[Command("help")]).parse(
+      argv=[],
+      env=empty_env(),
+    )
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: subcommand name reserved for built-in help: help (disable with disable_help_subcommand)
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}
+
+///|
+/// Inherited globals share one Matches key across parent and child scopes.
+/// Shadowing, alias reuse, or incompatible redeclarations would make merging
+/// and dispatch depend on where the token appears.
+test "global config rejects shadowing and incompatible redeclarations" {
+  try
+    @argparse.Command(
+      "demo",
+      options=[
+        OptionArg(
+          "mode",
+          long="mode",
+          env="MODE",
+          default_values=["safe"],
+          global=true,
+        ),
+      ],
+      subcommands=[Command("run", options=[OptionArg("mode", long="mode")])],
+    ).parse(argv=["run"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: arg 'mode' shadows an inherited global; rename the arg or mark it global
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      options=[OptionArg("mode", long="mode", required=true, global=true)],
+      subcommands=[
+        Command("run", flags=[FlagArg("mode", long="mode", global=true)]),
+      ],
+    ).parse(argv=["run", "--mode"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: global arg 'mode' is incompatible with inherited global definition
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      flags=[FlagArg("verbose", long="verbose", global=true)],
+      subcommands=[Command("run", options=[OptionArg("local", long="verbose")])],
+    ).parse(argv=["run", "--verbose"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: arg 'local' long option --verbose conflicts with inherited global 'verbose'
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      flags=[FlagArg("verbose", short='v', global=true)],
+      subcommands=[Command("run", options=[OptionArg("local", short='v')])],
+    ).parse(argv=["run", "-v"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: arg 'local' short option -v conflicts with inherited global 'verbose'
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      flags=[FlagArg("verbose", long="verbose", negatable=true, global=true)],
+      subcommands=[
+        Command("run", flags=[
+          FlagArg("verbose", long="verbose", negatable=false, global=true),
+        ]),
+      ],
+    ).parse(argv=["run"], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: global arg 'verbose' is incompatible with inherited global definition
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      flags=[FlagArg("shared", long="shared", global=true)],
+      subcommands=[
+        Command("child", options=[
+          OptionArg("shared", long="shared", global=true),
+        ]),
+      ],
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: global arg 'shared' is incompatible with inherited global definition
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+
+  try
+    @argparse.Command(
+      "demo",
+      options=[OptionArg("opt", long="dup", global=true)],
+      subcommands=[Command("child", flags=[FlagArg("other", long="dup")])],
+    ).parse(argv=[], env=empty_env())
+  catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|error: command definition validation failed: arg 'other' long option --dup conflicts with inherited global 'opt'
+        ),
+      )
+  } noraise {
+    _ => panic()
+  }
+}


### PR DESCRIPTION
## Why

The argparse tests mixed command-definition validation failures with blackbox argv parsing behavior. That makes it harder to tell which cases are parser runtime errors and which are configuration invariants that protect the command model from ambiguity.

## What

This PR adds `rejected_config_test.mbt` for command definitions rejected before meaningful argv parsing. The moved cases now include comments explaining the invariant behind each rejection and the ambiguity or broken behavior it prevents. Runtime argv parse failures remain in the existing blackbox and coverage tests.

It also adds explicit coverage for a hidden `default_subcommand` target, matching the existing rule that a default subcommand must name a visible child.

## Correctness

The parser and public API are unchanged. Existing validation assertions are preserved under the new test file, and the new hidden-default case exercises the same validation path as the visible-target rule.

## Minimality

This is intentionally test-only: it reorganizes validation coverage without changing argparse behavior or generated interfaces.