### PR TITLE
feat(builtin): add Json::empty_object() API

### DIFF
--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -70,6 +70,12 @@ pub fn Json::null() -> Json {
 pub let null : Json = Null
 
 ///|
+/// JSON `{}` constant.
+pub fn Json::empty_object() -> Json {
+  Object(Map([]))
+}
+
+///|
 /// Creates a JSON number value from a double-precision floating-point number.
 ///
 /// Parameters:

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -350,6 +350,7 @@ pub enum Json {
 }
 pub fn Json::array(Array[Self]) -> Self
 pub fn Json::boolean(Bool) -> Self
+pub fn Json::empty_object() -> Self
 pub fn Json::null() -> Self
 pub fn Json::number(Double, repr? : String) -> Self
 pub fn Json::object(Map[String, Self]) -> Self


### PR DESCRIPTION

`moonc` is about to emit ambiguity warnings for `{}`. In the JSON case, it will suggest using `Json::empty_object()` instead.

This PR added the `Json::empty_object()` API.

```
let json : Json = { "object": {} }
                              ^^---- use `Json::empty_object()` instead
let dict : Map = {}
                 ^^--- use `Map([])` instead
let result = { stmt1(); {} }
                        ^^
let record = {}
             ^^--- use `Record::{}` instead
```