### PR TITLE
[codex] perf(immut): mark HAMT wrappers as valtype

### DIFF
--- a/immut/hashmap/types.mbt
+++ b/immut/hashmap/types.mbt
@@ -22,6 +22,7 @@ priv enum Node[K, V] {
 }
 
 ///|
+#valtype
 struct HashMap[K, V] {
   data : Node[K, V]?
 } derive(Eq)

--- a/immut/hashset/types.mbt
+++ b/immut/hashset/types.mbt
@@ -22,6 +22,7 @@ priv enum Node[A] {
 }
 
 ///|
+#valtype
 struct HashSet[A] {
   data : Node[A]?
 } derive(Eq)


### PR DESCRIPTION
## Summary

- Mark the record-style immutable HAMT `HashMap` wrapper as `#valtype`.
- Mark the matching immutable HAMT `HashSet` wrapper as `#valtype`.

## Notes

I also checked nearby one-field wrappers. The tuple/newtype-style `Path(UInt)` and `Bitset(UInt)` are already guaranteed unboxed by the compiler, and `#valtype` is rejected there. The mutable `hashmap.HashMap` has multiple fields, so it is not part of this one-field wrapper change.

`moon info` did not produce generated interface changes.

## Validation

- `moon check`
- `moon test immut/hashmap immut/hashset`
- `moon info && moon fmt`
- `git diff --check`
- `moon test`