### PR TITLE
[codex] Remove deprecated IterResult

### DIFF
--- a/builtin/iter.mbt
+++ b/builtin/iter.mbt
@@ -13,17 +13,6 @@
 // limitations under the License.
 
 ///|
-/// Control signal used by deprecated iterator callbacks.
-///
-/// `IterContinue` keeps iteration running, `IterEnd` stops it.
-///
-#deprecated(skip_current_package=true)
-pub(all) enum IterResult {
-  IterEnd // false
-  IterContinue // true
-} derive(Eq)
-
-///|
 /// Creates an iterator that iterates over a range of Int with default step 1.
 /// To grow the range downward, set the `step` parameter to a negative value.
 ///

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -58,35 +58,6 @@ pub fn[X] Iter::size_hint(self : Iter[X]) -> Int? {
 }
 
 ///|
-/// Consume iterator elements while callback returns `IterContinue`.
-///
-/// Deprecated: prefer explicit loops.
-/// Function `run`.
-#locals(f)
-#deprecated("write a loop instead.")
-pub fn[X] Iter::run(self : Iter[X], f : (X) -> IterResult) -> IterResult {
-  while self.next() is Some(x) {
-    guard f(x) is IterContinue else { break IterEnd }
-  } nobreak {
-    IterContinue
-  }
-}
-
-///|
-/// Consume iterator elements and ignore final continuation state.
-///
-/// Deprecated: prefer explicit loops.
-/// Function `just_run`.
-#deprecated("write a loop instead.")
-pub fn[X] Iter::just_run(self : Iter[X], f : (X) -> IterResult) -> Unit {
-  while self.next() is Some(x) {
-    if f(x) is IterEnd {
-      break
-    }
-  }
-}
-
-///|
 #deprecated("Use Debug instead of Show for debugging purposes. See https://github.com/moonbitlang/core/blob/main/debug/README.mbt.md")
 pub impl[X : Show] Show for Iter[X]
 
@@ -1108,20 +1079,6 @@ pub impl[X : Show, Y : Show] Show for Iter2[X, Y]
 #warnings("-deprecated")
 pub impl[X : Show, Y : Show] Show for Iter2[X, Y] with fn output(self, logger) {
   self.0.output(logger)
-}
-
-///|
-/// Consume pairs while callback returns `IterContinue`.
-#deprecated("write a loop instead.")
-pub fn[X, Y] Iter2::run(
-  self : Iter2[X, Y],
-  f : (X, Y) -> IterResult,
-) -> IterResult {
-  while self.0.next() is Some((x, y)) {
-    guard f(x, y) is IterContinue else { break IterEnd }
-  } nobreak {
-    IterContinue
-  }
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -284,8 +284,6 @@ pub fn[X] Iter::iter(Self[X]) -> Self[X]
 #alias(iterator2)
 pub fn[X] Iter::iter2(Self[X]) -> Iter2[Int, X]
 pub fn[A : ToStringView] Iter::join(Self[A], StringView) -> String
-#deprecated
-pub fn[X] Iter::just_run(Self[X], (X) -> IterResult) -> Unit
 pub fn[X] Iter::last(Self[X]) -> X?
 pub fn[X, Y] Iter::map(Self[X], (X) -> Y) -> Self[Y]
 pub fn[X, Y] Iter::map_while(Self[X], (X) -> Y?) -> Self[Y]
@@ -298,8 +296,6 @@ pub fn[X] Iter::new(() -> X?, size_hint? : Int) -> Self[X]
 pub fn[X] Iter::next(Self[X]) -> X?
 pub fn[X] Iter::nth(Self[X], Int) -> X?
 pub fn[X] Iter::repeat(X) -> Self[X]
-#deprecated
-pub fn[X] Iter::run(Self[X], (X) -> IterResult) -> IterResult
 pub fn[X] Iter::singleton(X) -> Self[X]
 pub fn[X] Iter::size_hint(Self[X]) -> Int?
 pub fn[X] Iter::take(Self[X], Int) -> Self[X]
@@ -327,17 +323,9 @@ pub fn[X, Y] Iter2::iter(Self[X, Y]) -> Iter[(X, Y)]
 pub fn[X, Y] Iter2::iter2(Self[X, Y]) -> Self[X, Y]
 pub fn[X, Y] Iter2::new(() -> (X, Y)?, size_hint? : Int) -> Self[X, Y]
 pub fn[X, Y] Iter2::next(Self[X, Y]) -> (X, Y)?
-#deprecated
-pub fn[X, Y] Iter2::run(Self[X, Y], (X, Y) -> IterResult) -> IterResult
 pub fn[X, Y] Iter2::to_array(Self[X, Y]) -> Array[(X, Y)]
 #deprecated
 pub impl[X : Show, Y : Show] Show for Iter2[X, Y]
-
-#deprecated
-pub(all) enum IterResult {
-  IterEnd
-  IterContinue
-} derive(Eq)
 
 pub enum Json {
   Null

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -368,15 +368,6 @@ pub impl Debug for Hasher with fn to_repr(_) {
 }
 
 ///|
-#warnings("-deprecated")
-pub impl Debug for IterResult with fn to_repr(self) {
-  match self {
-    IterEnd => Repr::ctor("IterEnd", [])
-    IterContinue => Repr::ctor("IterContinue", [])
-  }
-}
-
-///|
 pub impl[T] Debug for UninitializedArray[T] with fn to_repr(_) {
   Repr::opaque_("UninitializedArray", Repr::omitted())
 }

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -61,7 +61,6 @@ pub impl Debug for Hasher
 pub impl Debug for InspectError
 pub impl[A] Debug for Iter[A]
 pub impl[A, B] Debug for Iter2[A, B]
-pub impl Debug for IterResult
 pub impl Debug for Json
 pub impl[K : Debug, V : Debug] Debug for Map[K, V]
 pub impl[T : Debug] Debug for MutArrayView[T]

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -97,9 +97,6 @@ pub using @builtin {type Iter}
 pub using @builtin {type Iter2}
 
 #deprecated
-pub using @builtin {type IterResult}
-
-#deprecated
 pub using @builtin {type Iter as Iterator}
 
 #deprecated

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -74,11 +74,6 @@ pub using @builtin {
 pub using @builtin {not}
 
 ///|
-#deprecated
-#warnings("-deprecated")
-pub using @builtin {type IterResult}
-
-///|
 pub using @debug {debug, type Repr, trait Debug, debug_inspect, repr, to_repr}
 
 ///|


### PR DESCRIPTION
## Summary

Remove the long-deprecated `IterResult` API from core.

This also removes the deprecated iterator callbacks whose signatures depended on it:

- `Iter::run`
- `Iter::just_run`
- `Iter2::run`

The prelude re-export and `Debug for IterResult` implementation are removed as well, and generated interfaces were refreshed.

## User impact

Users should replace these deprecated callbacks with explicit loops, `next`, or `each` depending on the use case.

## Validation

- `moon check`
- `moon info && moon fmt`
- `moon test`