### PR TITLE
Replace find_match_range with labeled unsafe_range_equal

### DIFF
--- a/builtin/bytes_find.mbt
+++ b/builtin/bytes_find.mbt
@@ -243,6 +243,8 @@ fn Bytes::v128_load(self : Bytes, offset : Int) -> V128 {
 ///|
 // SIMD byte scanner for linear-memory backends. The vector loop scans 16 bytes
 // at a time, then the scalar tail handles the remaining bytes.
+//
+// Returns the first index of `byte` in `data[start..end)`, or -1 if absent.
 #cfg(any(target="native", target="wasm"))
 fn find_byte_from_bytes(
   data : Bytes,
@@ -250,16 +252,34 @@ fn find_byte_from_bytes(
   end : Int,
   byte : Byte,
 ) -> Int {
+  // Broadcast the needle to all 16 lanes so a single vector compare tests 16
+  // haystack bytes at once:
+  //   byte_v = [byte, byte, byte, ..., byte]   (lanes 15..0)
   let byte_v = i8x16_splat(byte)
+  // Vector loop. `for` is an expression here: `tail_start` is bound to the
+  // value the loop yields. It yields in one of two ways:
+  //   - `return` on a hit, exiting the whole function; or
+  //   - falling through the `pos + 16 <= end` guard (a full chunk no longer
+  //     fits), running `nobreak` whose `pos` becomes `tail_start`.
   let tail_start = for pos = start; pos + 16 <= end; {
+    // Load 16 bytes, compare lanewise (0xFF on match / 0x00 on miss), then
+    // gather each lane's high bit into a 16-bit integer: bit i set <=> lane i
+    // matched.
+    //
+    //   chunk :  ..  62 72 61 77 6E 20 61 78 20   (searching 0x61 'a')
+    //   eq    :  ..  00 00 FF 00 00 00 FF 00 00
+    //   mask  :  0b...0100_0100  = 0x0044         (bits 2 and 6 set)
     let mask = i8x16_bitmask(i8x16_eq(data.v128_load(pos), byte_v))
     if mask != 0 {
+      // ctz = index of the lowest set bit = first matching lane, which yields
+      // first-occurrence order. 0x0044 -> ctz 2 -> absolute index `pos + 2`.
       return pos + mask.ctz()
     }
     continue pos + 16
   } nobreak {
     pos
   }
+  // Scalar tail: fewer than 16 bytes remain, so scan them one at a time.
   for pos in tail_start..<end {
     if data.unsafe_get(pos) == byte {
       break pos

--- a/builtin/bytes_find.mbt
+++ b/builtin/bytes_find.mbt
@@ -62,7 +62,7 @@ fn find_index(target : BytesView, pattern : BytesView) -> Int? {
       Some(found)
     }
   } else if pattern_len == target_len {
-    if find_match_range(target, pattern, 0, 0, pattern_len) {
+    if target == pattern {
       Some(0)
     } else {
       None
@@ -80,31 +80,6 @@ fn find_index(target : BytesView, pattern : BytesView) -> Int? {
 #inline
 fn find_cutover(i : Int) -> Int {
   4 + i / 16
-}
-
-///|
-#inline
-fn find_match_range(
-  target : BytesView,
-  pattern : BytesView,
-  candidate : Int,
-  start : Int,
-  end : Int,
-) -> Bool {
-  // Some callers already check the full requested range.
-  if start >= end {
-    return true
-  }
-  // `candidate`, `start`, and `end` are relative to the views. Convert both
-  // sides to offsets in their backing `Bytes` before comparing.
-  target
-  .data()
-  .unsafe_range_equal(
-    target.start_offset() + candidate + start,
-    pattern.data(),
-    pattern.start_offset() + start,
-    end - start,
-  )
 }
 
 ///|
@@ -342,6 +317,8 @@ declare fn find_short(target : BytesView, pattern : BytesView) -> Int?
 fn find_short(target : BytesView, pattern : BytesView) -> Int? {
   let target_len = target.length()
   let pattern_len = pattern.length()
+  let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
   let last_offset = pattern_len - 1
   let last_byte = pattern.unsafe_get(last_offset)
   for anchor_pos = last_offset; anchor_pos < target_len; {
@@ -349,8 +326,16 @@ fn find_short(target : BytesView, pattern : BytesView) -> Int? {
     if found < 0 {
       break None
     }
+    // The last byte already matched; verify the prefix range only.
     let candidate = found - last_offset
-    if find_match_range(target, pattern, candidate, 0, last_offset) {
+    if target
+      .data()
+      .unsafe_range_equal(
+        pattern.data(),
+        self_off=target_start + candidate,
+        other_off=pattern_start,
+        len=last_offset,
+      ) {
       break Some(candidate)
     }
     continue found + 1
@@ -368,10 +353,14 @@ fn find_short(target : BytesView, pattern : BytesView) -> Int? {
   let pattern_len = pattern.length()
   let last = target_len - pattern_len
   let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
   let candidate_end = target_start + last + 1
   let first = pattern.unsafe_get(0)
   let last_offset = pattern_len - 1
   let last_byte = pattern.unsafe_get(last_offset)
+  // First and last bytes are matched by the prefilter; only the middle range
+  // needs verification. `len=0` (two-byte patterns) trivially compares equal.
+  let middle_len = last_offset - 1
   for pos = 0; pos <= last; {
     let found = find_short_candidate_from_bytes(
       target.data(),
@@ -385,7 +374,14 @@ fn find_short(target : BytesView, pattern : BytesView) -> Int? {
       break None
     }
     let candidate = found - target_start
-    if find_match_range(target, pattern, candidate, 1, last_offset) {
+    if target
+      .data()
+      .unsafe_range_equal(
+        pattern.data(),
+        self_off=found + 1,
+        other_off=pattern_start + 1,
+        len=middle_len,
+      ) {
       break Some(candidate)
     }
     continue candidate + 1
@@ -519,9 +515,15 @@ fn rev_find_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
   let target_len = target.length()
   let pattern_len = pattern.length()
   let last = target_len - pattern_len
+  let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
   let first = pattern.unsafe_get(0)
   let last_offset = pattern_len - 1
   let last_byte = pattern.unsafe_get(last_offset)
+  // First and last bytes are matched by the candidate scanner; only the middle
+  // range needs verification. `len=0` (two-byte patterns) trivially compares
+  // equal.
+  let middle_len = last_offset - 1
   for candidate_end = last + 1; candidate_end > 0; {
     let found = rev_find_short_candidate_from_view(
       target, 0, candidate_end, first, last_offset, last_byte,
@@ -529,7 +531,14 @@ fn rev_find_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
     if found < 0 {
       break None
     }
-    if find_match_range(target, pattern, found, 1, last_offset) {
+    if target
+      .data()
+      .unsafe_range_equal(
+        pattern.data(),
+        self_off=target_start + found + 1,
+        other_off=pattern_start + 1,
+        len=middle_len,
+      ) {
       break Some(found)
     }
     continue found
@@ -547,9 +556,13 @@ fn rev_find_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
   let pattern_len = pattern.length()
   let last = target_len - pattern_len
   let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
   let first = pattern.unsafe_get(0)
   let last_offset = pattern_len - 1
   let last_byte = pattern.unsafe_get(last_offset)
+  // First and last bytes are matched by the prefilter; only the middle range
+  // needs verification. `len=0` (two-byte patterns) trivially compares equal.
+  let middle_len = last_offset - 1
   for candidate_end = last + 1; candidate_end > 0; {
     let found = rev_find_short_candidate_from_bytes(
       target.data(),
@@ -563,7 +576,14 @@ fn rev_find_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
       break None
     }
     let candidate = found - target_start
-    if find_match_range(target, pattern, candidate, 1, last_offset) {
+    if target
+      .data()
+      .unsafe_range_equal(
+        pattern.data(),
+        self_off=found + 1,
+        other_off=pattern_start + 1,
+        len=middle_len,
+      ) {
       break Some(candidate)
     }
     continue candidate
@@ -602,11 +622,20 @@ fn find_rabin_karp_from(
   if start + pattern_len > target_len {
     return None
   }
+  let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
   let pattern_hash = hash(pattern, 0, pattern_len)
   let pow = prime_pow(pattern_len)
   let hash = hash(target, start, pattern_len)
   if hash == pattern_hash &&
-    find_match_range(target, pattern, start, 0, pattern_len) {
+    target
+    .data()
+    .unsafe_range_equal(
+      pattern.data(),
+      self_off=target_start + start,
+      other_off=pattern_start,
+      len=pattern_len,
+    ) {
     return Some(start)
   }
   for index = start + pattern_len, hash = hash; index < target_len; {
@@ -614,7 +643,14 @@ fn find_rabin_karp_from(
     let hash = hash - pow * target.unsafe_get(index - pattern_len).to_uint()
     let candidate = index - pattern_len + 1
     if hash == pattern_hash &&
-      find_match_range(target, pattern, candidate, 0, pattern_len) {
+      target
+      .data()
+      .unsafe_range_equal(
+        pattern.data(),
+        self_off=target_start + candidate,
+        other_off=pattern_start,
+        len=pattern_len,
+      ) {
       break Some(candidate)
     }
     continue index + 1, hash
@@ -630,13 +666,23 @@ fn find_long_by_byte_scanner(target : BytesView, pattern : BytesView) -> Int? {
   let target_len = target.length()
   let pattern_len = pattern.length()
   let last = target_len - pattern_len
+  let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
   let first_byte = pattern.unsafe_get(0)
   for pos = 0, failures = 0; pos <= last; {
     let found = find_byte_from_view(target, pos, target_len, first_byte)
     if found < 0 || found > last {
       break None
     }
-    if find_match_range(target, pattern, found, 1, pattern_len) {
+    // The first byte already matched; verify the remaining suffix range.
+    if target
+      .data()
+      .unsafe_range_equal(
+        pattern.data(),
+        self_off=target_start + found + 1,
+        other_off=pattern_start + 1,
+        len=pattern_len - 1,
+      ) {
       break Some(found)
     }
     let failures = failures + 1
@@ -674,7 +720,7 @@ pub fn BytesView::rev_find(target : BytesView, pattern : BytesView) -> Int? {
       Some(found)
     }
   } else if pattern_len == target_len {
-    if find_match_range(target, pattern, 0, 0, pattern_len) {
+    if target == pattern {
       Some(0)
     } else {
       None

--- a/builtin/bytes_unsafe.mbt
+++ b/builtin/bytes_unsafe.mbt
@@ -566,10 +566,10 @@ pub fn BytesView::unsafe_read_uint16_be(
 #intrinsic("%bytes.unsafe_range_equal")
 fn Bytes::unsafe_range_equal(
   self : Bytes,
-  self_off : Int,
+  self_off~ : Int,
   other : Bytes,
-  other_off : Int,
-  len : Int,
+  other_off~ : Int,
+  len~ : Int,
 ) -> Bool {
   for i in 0..<len {
     guard self.unsafe_get(self_off + i) == other.unsafe_get(other_off + i) else {

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -655,7 +655,12 @@ pub impl Eq for BytesView with fn equal(self, other) -> Bool {
   guard len == other.length() else { return false }
   self
   .bytes()
-  .unsafe_range_equal(self.start(), other.bytes(), other.start(), len)
+  .unsafe_range_equal(
+    other.bytes(),
+    self_off=self.start(),
+    other_off=other.start(),
+    len~,
+  )
 }
 
 ///|
@@ -679,7 +684,9 @@ pub impl Eq for BytesView with fn equal(self, other) -> Bool {
 pub fn BytesView::equal_to_bytes(self : BytesView, other : Bytes) -> Bool {
   let len = self.length()
   guard len == other.length() else { return false }
-  self.bytes().unsafe_range_equal(self.start(), other, 0, len)
+  self
+  .bytes()
+  .unsafe_range_equal(other, self_off=self.start(), other_off=0, len~)
 }
 
 ///|


### PR DESCRIPTION
## Summary

Follow-up to #3785.

- Add labeled parameters to `Bytes::unsafe_range_equal` (`self_off~`, `other_off~`, `len~`), keeping parameter order unchanged so the `%bytes.unsafe_range_equal` intrinsic mapping is untouched.
- Delete the `find_match_range` wrapper and inline it at all nine call sites in `bytes_find.mbt`; the labels keep the offset arithmetic self-describing.
- Full-length compares in `find_index`/`rev_find` become plain `target == pattern` (lengths already known equal).
- The prefilter verify sites hoist `middle_len = last_offset - 1` once per search; the former `start >= end` early-return is now the `len=0` case of `unsafe_range_equal`, which both the fallback body and the intrinsic handle (covered by the 2-byte-pattern tests, e.g. `b"aaa".find(b"aa")` / `b"aaa".rev_find(b"aa")`).
- Also documents the SIMD byte scanner (`find_byte_from_bytes`) line by line.

No public API change (`moon info` clean).

## Validation

Re-run after rebasing onto main:

- `moon check builtin --target all`
- `moon test bytes builtin --target all` (wasm 3025, wasm-gc 3025, js 3013, native 2983 — all pass)
- `moon fmt`, `moon info`

Reviewed by codex CLI (no issues found: offset arithmetic, bounds, `len=0` edge, comments-only doc commit all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)