### PR TITLE
perf(string): avoid iterator allocation in to_lower

### DIFF
--- a/builtin/simd.mbt
+++ b/builtin/simd.mbt
@@ -81,10 +81,86 @@ fn v128_load_i16x8(str : String, offset : Int) -> V128 {
 }
 
 ///|
+// Loads eight consecutive UTF-16 code units from a fixed array beginning at
+// `offset`. The caller must ensure `offset + 8 <= data.length()`.
+#borrow(data)
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.v128_load_i16x8")
+fn v128_load_fixedarray_i16x8(data : FixedArray[UInt16], offset : Int) -> V128 {
+  let lo = for i in 0..<4; word = (0 : UInt64) {
+    continue word | (data.unsafe_get(offset + i).to_uint64() << (16 * i))
+  } nobreak {
+    word
+  }
+  let hi = for i in 0..<4; word = (0 : UInt64) {
+    continue word | (data.unsafe_get(offset + 4 + i).to_uint64() << (16 * i))
+  } nobreak {
+    word
+  }
+  v128_make(lo, hi)
+}
+
+///|
+// Stores eight consecutive UTF-16 code units beginning at `offset`. The caller
+// must ensure `offset + 8 <= data.length()`.
+#borrow(data)
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.v128_store_i16x8")
+fn v128_store_i16x8(
+  data : FixedArray[UInt16],
+  offset : Int,
+  value : V128,
+) -> Unit {
+  for i in 0..<4 {
+    data.unsafe_set(offset + i, (v128_lo(value) >> (16 * i)).to_uint16())
+  }
+  for i in 0..<4 {
+    data.unsafe_set(offset + 4 + i, (v128_hi(value) >> (16 * i)).to_uint16())
+  }
+}
+
+///|
 #cfg(any(target="native", target="wasm"))
 #intrinsic("%v128.v128_and")
 fn v128_and(a : V128, b : V128) -> V128 {
   v128_make(v128_lo(a) & v128_lo(b), v128_hi(a) & v128_hi(b))
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.v128_any_true")
+fn v128_any_true(value : V128) -> Bool {
+  v128_lo(value) != 0 || v128_hi(value) != 0
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i16x8_add")
+fn i16x8_add(a : V128, b : V128) -> V128 {
+  v128_make(
+    u64_u16x4_add(v128_lo(a), v128_lo(b)),
+    u64_u16x4_add(v128_hi(a), v128_hi(b)),
+  )
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i16x8_sub")
+fn i16x8_sub(a : V128, b : V128) -> V128 {
+  v128_make(
+    u64_u16x4_sub(v128_lo(a), v128_lo(b)),
+    u64_u16x4_sub(v128_hi(a), v128_hi(b)),
+  )
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i16x8_le_u")
+fn i16x8_le_u(a : V128, b : V128) -> V128 {
+  v128_make(
+    u64_u16x4_le_mask(v128_lo(a), v128_lo(b)),
+    u64_u16x4_le_mask(v128_hi(a), v128_hi(b)),
+  )
 }
 
 ///|
@@ -122,13 +198,6 @@ fn i16x8_bitmask(value : V128) -> Int {
 }
 
 ///|
-#cfg(any(target="native", target="wasm"))
-#intrinsic("%v128.v128_any_true")
-fn v128_any_true(value : V128) -> Bool {
-  v128_lo(value) != 0 || v128_hi(value) != 0
-}
-
-///|
 // Per-byte equality mask over the eight bytes of a `UInt64`: each byte becomes
 // `0xFF` when the operands' bytes match, `0x00` otherwise.
 #cfg(any(target="native", target="wasm"))
@@ -154,6 +223,49 @@ fn u64_u16_eq_mask(a : UInt64, b : UInt64) -> UInt64 {
   for i in 0..<4; result = (0 : UInt64) {
     let shift = 16 * i
     let mask = if ((a >> shift) & 0xFFFF) == ((b >> shift) & 0xFFFF) {
+      (0xFFFF : UInt64)
+    } else {
+      0
+    }
+    continue result | (mask << shift)
+  } nobreak {
+    result
+  }
+}
+
+///|
+// Wrapping addition over four packed 16-bit lanes.
+#cfg(any(target="native", target="wasm"))
+fn u64_u16x4_add(a : UInt64, b : UInt64) -> UInt64 {
+  for i in 0..<4; result = (0 : UInt64) {
+    let shift = 16 * i
+    let lane = (a >> shift).to_uint16() + (b >> shift).to_uint16()
+    continue result | (lane.to_uint64() << shift)
+  } nobreak {
+    result
+  }
+}
+
+///|
+// Wrapping subtraction over four packed 16-bit lanes.
+#cfg(any(target="native", target="wasm"))
+fn u64_u16x4_sub(a : UInt64, b : UInt64) -> UInt64 {
+  for i in 0..<4; result = (0 : UInt64) {
+    let shift = 16 * i
+    let lane = (a >> shift).to_uint16() - (b >> shift).to_uint16()
+    continue result | (lane.to_uint64() << shift)
+  } nobreak {
+    result
+  }
+}
+
+///|
+// Unsigned less-than-or-equal mask over four packed 16-bit lanes.
+#cfg(any(target="native", target="wasm"))
+fn u64_u16x4_le_mask(a : UInt64, b : UInt64) -> UInt64 {
+  for i in 0..<4; result = (0 : UInt64) {
+    let shift = 16 * i
+    let mask = if (a >> shift).to_uint16() <= (b >> shift).to_uint16() {
       (0xFFFF : UInt64)
     } else {
       0

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1738,20 +1738,21 @@ test "View::replace_all boundary cases" {
 
 ///|
 /// Helpers for ASCII-only lowercase conversion over UTF-16 code units.
-/// Non-ASCII code units, including surrogate halves, are copied with
-/// `write_substring` and are never converted through `Char`.
+/// Non-ASCII code units, including surrogate halves, are copied unchanged and
+/// are never converted through `Char`.
 fn is_ascii_uppercase_code_unit(code_unit : Int) -> Bool {
   code_unit >= 0x41 && code_unit <= 0x5A
 }
 
 ///|
+#cfg(not(any(target="native", target="wasm")))
 fn find_ascii_uppercase_code_unit(
   data : String,
   start : Int,
   len : Int,
 ) -> Int? {
   let end = start + len
-  for i = start; i < end; i = i + 1 {
+  for i in start..<end {
     // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
     let code_unit = data.unsafe_get(i).to_int()
     if is_ascii_uppercase_code_unit(code_unit) {
@@ -1762,32 +1763,152 @@ fn find_ascii_uppercase_code_unit(
 }
 
 ///|
-/// Appends `tail` lowercased, copying unchanged runs in bulk via
-/// `write_substring` and only rewriting the ASCII uppercase code units.
-/// Compare as `Int` (not `UInt16`) so the range check inlines on every backend.
-/// Keep `tail.code_units()` directly in the loop so compiler backends can
-/// recognize and lower the zero-copy traversal at the use site.
-fn StringBuilder::write_ascii_lowered_view(
-  self : StringBuilder,
-  tail : StringView,
-) -> Unit {
-  let data = tail.data()
-  let base = tail.start_offset()
+// Check the first code unit scalarly so capitalized strings retain the lowest
+// possible startup cost. Then scan full blocks eight UTF-16 code units at a
+// time and finish with a scalar tail.
+#cfg(any(target="native", target="wasm"))
+fn find_ascii_uppercase_code_unit_simd(
+  data : String,
+  start : Int,
+  len : Int,
+) -> Int? {
+  let end = start + len
+  if is_ascii_uppercase_code_unit(data.unsafe_get(start).to_int()) {
+    return Some(0)
+  }
+  let ascii_a = i16x8_splat(0x41)
+  let ascii_range = i16x8_splat(0x5A - 0x41)
+  let tail_start = for pos = start; pos + 8 <= end; {
+    let code_units = v128_load_i16x8(data, pos)
+    let uppercase_mask = i16x8_le_u(i16x8_sub(code_units, ascii_a), ascii_range)
+    if v128_any_true(uppercase_mask) {
+      for i in pos..<(pos + 8) {
+        if is_ascii_uppercase_code_unit(data.unsafe_get(i).to_int()) {
+          return Some(i - start)
+        }
+      }
+    }
+    continue pos + 8
+  } nobreak {
+    pos
+  }
+  for i in tail_start..<end {
+    if is_ascii_uppercase_code_unit(data.unsafe_get(i).to_int()) {
+      return Some(i - start)
+    }
+  }
+  None
+}
+
+///|
+// Three SIMD blocks are enough to amortize vector setup. Keep shorter searches
+// entirely scalar rather than splitting them into a prefix and tail.
+#inline
+#cfg(any(target="native", target="wasm"))
+fn find_ascii_uppercase_code_unit(
+  data : String,
+  start : Int,
+  len : Int,
+) -> Int? {
+  if len < 24 {
+    let end = start + len
+    for i in start..<end {
+      // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
+      let code_unit = data.unsafe_get(i).to_int()
+      if is_ascii_uppercase_code_unit(code_unit) {
+        return Some(i - start)
+      }
+    }
+    None
+  } else {
+    find_ascii_uppercase_code_unit_simd(data, start, len)
+  }
+}
+
+///|
+/// Copies `view` into an exact-size UTF-16 buffer once, then patches the ASCII
+/// uppercase code units in place. `first_uppercase` is supplied by the
+/// allocation-free search in `to_lower`.
+/// Native and linear-memory Wasm can load and store this buffer eight code
+/// units at a time.
+#cfg(any(target="native", target="wasm"))
+fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
+  let len = view.length()
+  let output : FixedArray[UInt16] = FixedArray::make(len, 0)
+  output.unsafe_blit_from_string(0, view.data(), view.start_offset(), len)
+  let ascii_a = i16x8_splat(0x41)
+  let ascii_range = i16x8_splat(0x5A - 0x41)
+  let lowercase_delta = i16x8_splat(0x20)
+  let tail_start = for pos = first_uppercase; pos + 8 <= len; {
+    let code_units = v128_load_fixedarray_i16x8(output, pos)
+    // Subtraction wraps lanes below `A`, so this unsigned comparison selects
+    // exactly the inclusive `A..Z` range with one vector comparison.
+    let uppercase_mask = i16x8_le_u(i16x8_sub(code_units, ascii_a), ascii_range)
+    let lowered = i16x8_add(
+      code_units,
+      v128_and(uppercase_mask, lowercase_delta),
+    )
+    v128_store_i16x8(output, pos, lowered)
+    continue pos + 8
+  } nobreak {
+    pos
+  }
+  for i in tail_start..<len {
+    let code_unit = output.unsafe_get(i).to_int()
+    if is_ascii_uppercase_code_unit(code_unit) {
+      output.unsafe_set(i, (code_unit + 32).to_uint16())
+    }
+  }
+  unsafe_fixedarray_uint16_to_string(output)
+}
+
+///|
+/// wasm-gc and other non-linear-memory backends use scalar patching. In
+/// particular, wasm-gc represents this buffer as a GC array, for which SIMD
+/// loads and stores would expand into individual array accesses.
+#cfg(not(any(target="js", target="native", target="wasm")))
+fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
+  let len = view.length()
+  let output : FixedArray[UInt16] = FixedArray::make(len, 0)
+  output.unsafe_blit_from_string(0, view.data(), view.start_offset(), len)
+  let tail = view.view(start_offset=first_uppercase)
+  // Keep `tail.code_units()` directly in the loop so compiler backends can
+  // recognize and lower the zero-copy traversal at the use site.
+  for i, u in tail.code_units() {
+    let code_unit = u.to_int()
+    if is_ascii_uppercase_code_unit(code_unit) {
+      output.unsafe_set(first_uppercase + i, (code_unit + 32).to_uint16())
+    }
+  }
+  unsafe_fixedarray_uint16_to_string(output)
+}
+
+///|
+/// JavaScript strings cannot be patched in place, so its scalar fallback
+/// preserves chunked writes while using the non-deprecated `write_view` API.
+#cfg(target="js")
+fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
+  let buf = StringBuilder(size_hint=view.length())
+  if first_uppercase > 0 {
+    buf.write_view(view.view(end_offset=first_uppercase))
+  }
+  let tail = view.view(start_offset=first_uppercase)
   let n = tail.length()
   let mut seg = 0
   for i, u in tail.code_units() {
     let code_unit = u.to_int()
     if is_ascii_uppercase_code_unit(code_unit) {
       if seg < i {
-        self.write_substring(data, base + seg, i - seg)
+        buf.write_view(tail.view(start_offset=seg, end_offset=i))
       }
-      self.write_char((code_unit + 32).unsafe_to_char())
+      buf.write_char((code_unit + 32).unsafe_to_char())
       seg = i + 1
     }
   }
   if seg < n {
-    self.write_substring(data, base + seg, n - seg)
+    buf.write_view(tail.view(start_offset=seg))
   }
+  buf.to_string()
 }
 
 ///|
@@ -1800,10 +1921,7 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
   guard find_ascii_uppercase_code_unit(data, start, len) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder(size_hint=len)
-  buf.write_substring(data, start, idx)
-  buf.write_ascii_lowered_view(self.view(start_offset=idx))
-  buf.to_string()
+  ascii_lowercase_copy(self, idx)
 }
 
 ///|
@@ -1814,10 +1932,7 @@ pub fn String::to_lower(self : String) -> String {
   guard find_ascii_uppercase_code_unit(self, 0, len) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder(size_hint=len)
-  buf.write_substring(self, 0, idx)
-  buf.write_ascii_lowered_view(self.view(start_offset=idx))
-  buf.to_string()
+  ascii_lowercase_copy(self, idx)
 }
 
 ///|
@@ -1825,6 +1940,9 @@ test "to_lower" {
   assert_true("Hello".to_lower() == "hello")
   assert_true("HELLO".to_lower() == "hello")
   assert_true("Hello, World!".to_lower() == "hello, world!")
+  // Starts at an unaligned code-unit offset, crosses both ASCII range
+  // boundaries, fills one vector, and leaves one scalar code unit.
+  assert_true("xxA@Z[az09!".to_lower() == "xxa@z[az09!")
   assert_true("🤣A".to_lower() == "🤣a")
   assert_true("A🤣B".to_lower() == "a🤣b")
   let unpaired = String::from_array([(0xD800).unsafe_to_char(), 'A'])
@@ -1836,6 +1954,17 @@ test "to_lower" {
 test "to_lower after a non-BMP character" {
   inspect("😀X".to_lower(), content="😀x")
   inspect("a😀Xz"[1:4].to_lower(), content="😀x")
+}
+
+///|
+test "to_lower SIMD search boundaries" {
+  for uppercase_at in 0..<40 {
+    let prefix = "x".repeat(uppercase_at)
+    let suffix = "x".repeat(40 - uppercase_at)
+    assert_true((prefix + "A" + suffix).to_lower() == prefix + "a" + suffix)
+  }
+  let source = "A" + "x".repeat(40) + "Z"
+  assert_true(source[1:41].to_lower() == "x".repeat(40))
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1737,23 +1737,72 @@ test "View::replace_all boundary cases" {
 }
 
 ///|
+/// Helpers for ASCII-only lowercase conversion over UTF-16 code units.
+/// Non-ASCII code units, including surrogate halves, are copied with
+/// `write_substring` and are never converted through `Char`.
+fn is_ascii_uppercase_code_unit(code_unit : Int) -> Bool {
+  code_unit >= 0x41 && code_unit <= 0x5A
+}
+
+///|
+fn find_ascii_uppercase_code_unit(
+  data : String,
+  start : Int,
+  len : Int,
+) -> Int? {
+  let end = start + len
+  for i = start; i < end; i = i + 1 {
+    // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
+    let code_unit = data.unsafe_get(i).to_int()
+    if is_ascii_uppercase_code_unit(code_unit) {
+      return Some(i - start)
+    }
+  }
+  None
+}
+
+///|
+/// Appends `tail` lowercased, copying unchanged runs in bulk via
+/// `write_substring` and only rewriting the ASCII uppercase code units.
+/// Compare as `Int` (not `UInt16`) so the range check inlines on every backend.
+/// Keep `tail.code_units()` directly in the loop so compiler backends can
+/// recognize and lower the zero-copy traversal at the use site.
+fn StringBuilder::write_ascii_lowered_view(
+  self : StringBuilder,
+  tail : StringView,
+) -> Unit {
+  let data = tail.data()
+  let base = tail.start_offset()
+  let n = tail.length()
+  let mut seg = 0
+  for i, u in tail.code_units() {
+    let code_unit = u.to_int()
+    if is_ascii_uppercase_code_unit(code_unit) {
+      if seg < i {
+        self.write_substring(data, base + seg, i - seg)
+      }
+      self.write_char((code_unit + 32).unsafe_to_char())
+      seg = i + 1
+    }
+  }
+  if seg < n {
+    self.write_substring(data, base + seg, n - seg)
+  }
+}
+
+///|
 /// Converts this string to lowercase.
 pub fn StringView::to_lower(self : StringView) -> StringView {
   // TODO: deal with non-ascii characters
-  guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
+  let data = self.data()
+  let start = self.start_offset()
+  let len = self.length()
+  guard find_ascii_uppercase_code_unit(data, start, len) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
-  buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
-    if c.is_ascii_uppercase() {
-      // 'A' is 65 in ASCII, 'a' is 97, the difference is 32
-      buf.write_char((c.to_int() + 32).unsafe_to_char())
-    } else {
-      buf.write_char(c)
-    }
-  }
+  let buf = StringBuilder(size_hint=len)
+  buf.write_substring(data, start, idx)
+  buf.write_ascii_lowered_view(self.view(start_offset=idx))
   buf.to_string()
 }
 
@@ -1761,20 +1810,13 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
 /// Converts this string to lowercase.
 pub fn String::to_lower(self : String) -> String {
   // TODO: deal with non-ascii characters
-  guard self.find_by(x => x.is_ascii_uppercase()) is Some(idx) else {
+  let len = self.length()
+  guard find_ascii_uppercase_code_unit(self, 0, len) is Some(idx) else {
     return self
   }
-  let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
-  buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
-    if c.is_ascii_uppercase() {
-      // 'A' is 65 in ASCII, 'a' is 97, the difference is 32
-      buf.write_char((c.to_int() + 32).unsafe_to_char())
-    } else {
-      buf.write_char(c)
-    }
-  }
+  let buf = StringBuilder(size_hint=len)
+  buf.write_substring(self, 0, idx)
+  buf.write_ascii_lowered_view(self.view(start_offset=idx))
   buf.to_string()
 }
 
@@ -1783,6 +1825,11 @@ test "to_lower" {
   assert_true("Hello".to_lower() == "hello")
   assert_true("HELLO".to_lower() == "hello")
   assert_true("Hello, World!".to_lower() == "hello, world!")
+  assert_true("🤣A".to_lower() == "🤣a")
+  assert_true("A🤣B".to_lower() == "a🤣b")
+  let unpaired = String::from_array([(0xD800).unsafe_to_char(), 'A'])
+  let lowered_unpaired = String::from_array([(0xD800).unsafe_to_char(), 'a'])
+  assert_true(unpaired.to_lower() == lowered_unpaired)
 }
 
 ///|
@@ -1796,6 +1843,10 @@ test "View::to_lower" {
   assert_true("Hello"[:].to_lower() == "hello")
   assert_true("HELLO"[:].to_lower() == "hello")
   assert_true("Hello, World!"[:].to_lower() == "hello, world!")
+  assert_true("x🤣ABy"[1:5].to_lower() == "🤣ab")
+  let unpaired = String::from_array([(0xD800).unsafe_to_char(), 'A'])
+  let lowered_unpaired = String::from_array([(0xD800).unsafe_to_char(), 'a'])
+  assert_true(unpaired[:].to_lower() == lowered_unpaired)
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1740,12 +1740,15 @@ test "View::replace_all boundary cases" {
 /// Helpers for ASCII-only lowercase conversion over UTF-16 code units.
 /// Non-ASCII code units, including surrogate halves, are copied unchanged and
 /// are never converted through `Char`.
+/// Keep the comparison on `Int`: `UInt16` range checks currently introduce
+/// narrowing operations in generated native and Wasm code.
+#cfg(not(target="js"))
 fn is_ascii_uppercase_code_unit(code_unit : Int) -> Bool {
   code_unit >= 0x41 && code_unit <= 0x5A
 }
 
 ///|
-#cfg(not(any(target="native", target="wasm")))
+#cfg(not(any(target="js", target="native", target="wasm")))
 fn find_ascii_uppercase_code_unit(
   data : String,
   start : Int,
@@ -1884,35 +1887,8 @@ fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
 }
 
 ///|
-/// JavaScript strings cannot be patched in place, so its scalar fallback
-/// preserves chunked writes while using the non-deprecated `write_view` API.
-#cfg(target="js")
-fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
-  let buf = StringBuilder(size_hint=view.length())
-  if first_uppercase > 0 {
-    buf.write_view(view.view(end_offset=first_uppercase))
-  }
-  let tail = view.view(start_offset=first_uppercase)
-  let n = tail.length()
-  let mut seg = 0
-  for i, u in tail.code_units() {
-    let code_unit = u.to_int()
-    if is_ascii_uppercase_code_unit(code_unit) {
-      if seg < i {
-        buf.write_view(tail.view(start_offset=seg, end_offset=i))
-      }
-      buf.write_char((code_unit + 32).unsafe_to_char())
-      seg = i + 1
-    }
-  }
-  if seg < n {
-    buf.write_view(tail.view(start_offset=seg))
-  }
-  buf.to_string()
-}
-
-///|
 /// Converts this string to lowercase.
+#cfg(not(target="js"))
 pub fn StringView::to_lower(self : StringView) -> StringView {
   // TODO: deal with non-ascii characters
   let data = self.data()
@@ -1926,6 +1902,7 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
 
 ///|
 /// Converts this string to lowercase.
+#cfg(not(target="js"))
 pub fn String::to_lower(self : String) -> String {
   // TODO: deal with non-ascii characters
   let len = self.length()
@@ -1933,6 +1910,49 @@ pub fn String::to_lower(self : String) -> String {
     return self
   }
   ascii_lowercase_copy(self, idx)
+}
+
+///|
+/// JavaScript strings cannot be patched in place, so retain the character-loop
+/// fallback instead of allocating an intermediate substring per unchanged run.
+#cfg(target="js")
+pub fn StringView::to_lower(self : StringView) -> StringView {
+  // TODO: deal with non-ascii characters
+  guard self.find_by(c => c.is_ascii_uppercase()) is Some(idx) else {
+    return self
+  }
+  let buf = StringBuilder(size_hint=self.length())
+  let head = self.view(end_offset=idx)
+  buf.write_substring(head.data(), head.start_offset(), head.length())
+  for c in self.view(start_offset=idx) {
+    if c.is_ascii_uppercase() {
+      buf.write_char((c.to_int() + 32).unsafe_to_char())
+    } else {
+      buf.write_char(c)
+    }
+  }
+  buf.to_string()
+}
+
+///|
+/// Converts this string to lowercase.
+#cfg(target="js")
+pub fn String::to_lower(self : String) -> String {
+  // TODO: deal with non-ascii characters
+  guard self.find_by(c => c.is_ascii_uppercase()) is Some(idx) else {
+    return self
+  }
+  let buf = StringBuilder(size_hint=self.length())
+  let head = self.view(end_offset=idx)
+  buf.write_substring(head.data(), head.start_offset(), head.length())
+  for c in self.view(start_offset=idx) {
+    if c.is_ascii_uppercase() {
+      buf.write_char((c.to_int() + 32).unsafe_to_char())
+    } else {
+      buf.write_char(c)
+    }
+  }
+  buf.to_string()
 }
 
 ///|

--- a/builtin/string_to_lower_bench_test.mbt
+++ b/builtin/string_to_lower_bench_test.mbt
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Benchmarks for `to_lower`. The optimization only takes effect when the input
-// contains an ASCII uppercase code unit (otherwise `to_lower` early-returns
-// `self` with no allocation), so every input below has uppercase present.
+// Benchmarks for the changed-input conversion path and the allocation-free
+// no-change search path in `to_lower`.
 
 ///|
 // Short header-like input: the per-call cost dominates, so this best exposes
@@ -22,9 +21,39 @@
 let to_lower_bench_short : String = "Content-Type"
 
 ///|
-// Longer mixed-case input with uppercase scattered throughout: also exercises
-// the batched `write_substring` path across many segments.
+// Longer mixed-case input with uppercase scattered throughout: exercises the
+// whole-view copy and in-place patch path.
 let to_lower_bench_long : String = "The Quick Brown Fox Jumps Over The Lazy Dog. ".repeat(
+  16,
+)
+
+///|
+// A single uppercase code unit followed by a long unchanged suffix. This
+// checks that the whole-view copy retains the benefit of large batches.
+let to_lower_bench_sparse : String = "A" + "x".repeat(719)
+
+///|
+// A single uppercase code unit at the end. This exercises the SIMD pre-scan
+// before the exact-size output buffer is allocated.
+let to_lower_bench_late_uppercase : String = "x".repeat(719) + "A"
+
+///|
+// Every unchanged run has length one. This guards against reintroducing the
+// per-run overhead that motivated the whole-view copy.
+let to_lower_bench_one_unit_runs : String = "Ax".repeat(360)
+
+///|
+// Every code unit is rewritten after the initial copy. This exposes the
+// worst-case cost of patching the copied buffer.
+let to_lower_bench_all_uppercase : String = "A".repeat(720)
+
+///|
+// No conversion is needed. These inputs exercise the allocation-free search
+// and should return the original string or view.
+let to_lower_bench_no_change_short : String = "content-type"
+
+///|
+let to_lower_bench_no_change_long : String = "the quick brown fox jumps over the lazy dog. ".repeat(
   16,
 )
 
@@ -39,6 +68,36 @@ test "bench String::to_lower long" (it : @bench.T) {
 }
 
 ///|
+test "bench String::to_lower sparse" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_sparse.to_lower()) })
+}
+
+///|
+test "bench String::to_lower late-uppercase" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_late_uppercase.to_lower()) })
+}
+
+///|
+test "bench String::to_lower one-unit runs" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_one_unit_runs.to_lower()) })
+}
+
+///|
+test "bench String::to_lower all-uppercase" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_all_uppercase.to_lower()) })
+}
+
+///|
+test "bench String::to_lower no-change short" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_no_change_short.to_lower()) })
+}
+
+///|
+test "bench String::to_lower no-change long" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_no_change_long.to_lower()) })
+}
+
+///|
 test "bench StringView::to_lower short" (it : @bench.T) {
   it.bench(fn() { it.keep(to_lower_bench_short[:].to_lower()) })
 }
@@ -46,4 +105,9 @@ test "bench StringView::to_lower short" (it : @bench.T) {
 ///|
 test "bench StringView::to_lower long" (it : @bench.T) {
   it.bench(fn() { it.keep(to_lower_bench_long[:].to_lower()) })
+}
+
+///|
+test "bench StringView::to_lower no-change long" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_no_change_long[:].to_lower()) })
 }

--- a/builtin/string_to_lower_bench_test.mbt
+++ b/builtin/string_to_lower_bench_test.mbt
@@ -1,0 +1,49 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Benchmarks for `to_lower`. The optimization only takes effect when the input
+// contains an ASCII uppercase code unit (otherwise `to_lower` early-returns
+// `self` with no allocation), so every input below has uppercase present.
+
+///|
+// Short header-like input: the per-call cost dominates, so this best exposes
+// the dropped per-call `Iter` allocation on the native target.
+let to_lower_bench_short : String = "Content-Type"
+
+///|
+// Longer mixed-case input with uppercase scattered throughout: also exercises
+// the batched `write_substring` path across many segments.
+let to_lower_bench_long : String = "The Quick Brown Fox Jumps Over The Lazy Dog. ".repeat(
+  16,
+)
+
+///|
+test "bench String::to_lower short" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_short.to_lower()) })
+}
+
+///|
+test "bench String::to_lower long" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_long.to_lower()) })
+}
+
+///|
+test "bench StringView::to_lower short" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_short[:].to_lower()) })
+}
+
+///|
+test "bench StringView::to_lower long" (it : @bench.T) {
+  it.bench(fn() { it.keep(to_lower_bench_long[:].to_lower()) })
+}


### PR DESCRIPTION
## Summary

- keep the allocation-free early return when a string contains no ASCII uppercase code unit
- scan eight UTF-16 code units at a time with SIMD on native and linear-memory Wasm
- copy changed inputs once into an exact-size UTF-16 buffer, then lowercase them in place
- lowercase eight code units at a time on native/Wasm, use scalar buffer patching on wasm-gc, and retain the pre-optimization character-loop fallback on JavaScript
- preserve non-ASCII code units, non-BMP characters, unpaired surrogate halves, and `StringView` boundaries exactly
- add boundary, sparse-uppercase, one-unit-run, all-uppercase, late-uppercase, and no-change benchmarks

> [!NOTE]
> The branch is rebased onto `0b89deea` and uses the released Moon `0.1.20260807` / `moonc v0.10.7+bc794d341` toolchain. Commit `0682655d` restores the pre-optimization JavaScript path after verification showed that chunking one-code-unit unchanged runs allocated a tiny substring per run and caused the reported regression.

## Implementation

`find_ascii_uppercase_code_unit` keeps strings shorter than 24 code units on the scalar path. For longer inputs it first checks the initial code unit scalarly, preserving the common capitalized-string fast path, then scans complete eight-code-unit blocks with `i16x8` operations. If a block matches, a scalar pass over that block locates the first uppercase code unit; any remaining tail is also scalar.

Once a change is required:

- **native and linear Wasm** copy the entire view into an exact-size `FixedArray[UInt16]`, lowercase full blocks with SIMD, and patch the scalar tail
- **wasm-gc and other non-linear-memory backends** use the same exact-size copy with scalar patching
- **JavaScript** retains the original `find_by` plus character-loop `StringBuilder` fallback; JavaScript strings cannot use the in-place UTF-16 buffer path

If the pre-scan finds no uppercase code unit, `to_lower` returns the original string or view without allocating.

## Why

PR #3635 removes the per-call `Iter` allocation and batches unchanged runs, but conversion still crosses the builder API for each changed unit/run. Since `to_lower` already works at the UTF-16 level, copying the input once and patching that buffer removes this per-run overhead and exposes a straightforward SIMD loop.

The pre-scan is also worth retaining: lowercase inputs return `self` without allocating. SIMD makes that extra pass inexpensive for long strings on native and linear Wasm.

## Impact

Measured on an Apple M3 Max running macOS 26.2 with Moon `0.1.20260724` and `moonc v0.10.5+5e7afb0c0`.

Both revisions used the same `builtin/string_to_lower_bench_test.mbt` and were run with:

```sh
moon bench --release --target native builtin/string_to_lower_bench_test.mbt
moon bench --release --target wasm builtin/string_to_lower_bench_test.mbt
moon bench --release --target wasm-gc builtin/string_to_lower_bench_test.mbt
moon bench --release --target js builtin/string_to_lower_bench_test.mbt
```

The protocol used three measured invocations per revision and target, alternating which revision ran first so drift affects both sides evenly. Each table reports the median of each benchmark's reported mean. Lower is better; Δ is `HEAD / baseline - 1`. These historical tables were captured at `e62403e5`; their JavaScript rows document the regression that is superseded by the fallback verification below.

### 1. HEAD against main

Baseline is this PR's merge base, `8720b4b3`.

| target | case | main | HEAD | Δ |
|---|---|---:|---:|---:|
| native | short | 60.80 ns | 19.67 ns | −67.6% faster |
| native | mixed long | 1.47 µs | 85.65 ns | −94.2% faster |
| native | late uppercase | 851.20 ns | 95.32 ns | −88.8% faster |
| native | one-unit runs | 1.20 µs | 85.42 ns | −92.9% faster |
| native | no-change long | 777.93 ns | 58.23 ns | −92.5% faster |
| wasm | short | 175.55 ns | 59.92 ns | −65.9% faster |
| wasm | mixed long | 3.11 µs | 492.34 ns | −84.2% faster |
| wasm | late uppercase | 2.68 µs | 510.36 ns | −81.0% faster |
| wasm | one-unit runs | 3.33 µs | 496.23 ns | −85.1% faster |
| wasm | no-change long | 2.54 µs | 95.51 ns | −96.2% faster |
| wasm-gc | short | 62.51 ns | 28.41 ns | −54.6% faster |
| wasm-gc | mixed long | 2.06 µs | 1.10 µs | −46.6% faster |
| wasm-gc | late uppercase | 1.81 µs | 882.16 ns | −51.3% faster |
| wasm-gc | one-unit runs | 1.94 µs | 1.01 µs | −47.9% faster |
| wasm-gc | no-change long | 1.44 µs | 448.06 ns | −68.9% faster |
| js | short | 111.19 ns | 64.89 ns | −41.6% faster |
| js | mixed long | 5.57 µs | 4.54 µs | −18.5% faster |
| js | late uppercase | 1.76 µs | 1.56 µs | −11.4% faster |
| js | one-unit runs | 5.15 µs | 6.52 µs | +26.6% slower |
| js | no-change long | 1.87 µs | 1.71 µs | −8.6% faster |

Native, linear Wasm, and wasm-gc improve on every case. The historical JavaScript one-unit-run regression came from allocating a `StringView` and owned substring for each one-code-unit unchanged run. Commit `0682655d` removes JavaScript from that chunked path and restores the original character-loop implementation.

Fresh alternating runs on the current toolchain put JavaScript `one-unit runs` at 3.88–4.05 µs on the fallback versus 4.82 µs on the chunked PR revision, recovering about 18–20%. Direct comparison with current `main` (3.64–4.00 µs) is within run-to-run noise, as expected from using the same implementation.

### 2. HEAD against #3635

PR #3635 targets the same function. To keep the comparison to the two implementations, its branch (`b1f5585d`) was rebased onto the same `8720b4b3` base used above; it rebased cleanly and its production diff is unchanged at 82 insertions / 24 deletions.

One test-only edit was required to make that baseline runnable: #3635 asserts on `"x🤣ABy"[1:-1]`, and `String::sub` on current `main` rejects negative indices outright (`guard start >= 0 && start <= end && end <= len`), so the expression panics before `to_lower` is reached. Changing it to `[1:5]` — the same form this PR uses — makes #3635 pass 2881/2881 on native. No production code was touched.

| target | case | #3635 | this PR | Δ |
|---|---|---:|---:|---:|
| native | short | 60.21 ns | 19.83 ns | −67.1% faster |
| native | mixed long | 1.41 µs | 85.94 ns | −93.9% faster |
| native | late uppercase | 310.67 ns | 97.88 ns | −68.5% faster |
| native | one-unit runs | 2.09 µs | 86.26 ns | −95.9% faster |
| native | no-change long | 212.65 ns | 58.56 ns | −72.5% faster |
| wasm | short | 155.37 ns | 59.90 ns | −61.4% faster |
| wasm | mixed long | 2.91 µs | 500.06 ns | −82.8% faster |
| wasm | late uppercase | 976.17 ns | 514.89 ns | −47.3% faster |
| wasm | one-unit runs | 5.16 µs | 496.41 ns | −90.4% faster |
| wasm | no-change long | 477.06 ns | 95.56 ns | −80.0% faster |
| wasm-gc | short | 60.11 ns | 29.02 ns | −51.7% faster |
| wasm-gc | mixed long | 2.19 µs | 1.09 µs | −50.2% faster |
| wasm-gc | late uppercase | 911.22 ns | 884.10 ns | −3.0% faster |
| wasm-gc | one-unit runs | 3.48 µs | 1.03 µs | −70.4% faster |
| wasm-gc | no-change long | 452.06 ns | 461.15 ns | +2.0% slower |
| js | short | 72.71 ns | 66.55 ns | −8.5% faster |
| js | mixed long | 5.45 µs | 4.64 µs | −14.9% faster |
| js | late uppercase | 1.58 µs | 1.60 µs | +1.3% slower |
| js | one-unit runs | 8.44 µs | 6.57 µs | −22.2% faster |
| js | no-change long | 1.72 µs | 1.75 µs | +1.7% slower |

Across the full 11-benchmark matrix on all four targets, this PR is faster on 40 of 44 measurements. The four exceptions — wasm-gc `no-change long` (+2.0%) and `StringView no-change long` (+2.5%), and JavaScript `late uppercase` (+1.3%) and `no-change long` (+1.7%) — all have per-round ranges that overlap the baseline's, so they are ties rather than regressions. Every case where the two implementations genuinely diverge favours this PR.

The JavaScript rows in this historical #3635 table predate `0682655d`; JavaScript now uses the same fallback as `main`, so they are not claims about the current head.

PR #3635's published end-to-end native profile reported 12.3% fewer allocations and 3.0% fewer allocated bytes than the pre-change implementation. Those allocation measurements were not rerun here, so they remain context from #3635 rather than fresh measurements for this PR.

## Validation

The latest checks were run on `0682655d` with Moon `0.1.20260807` and `moonc v0.10.7+bc794d341`:

- `moon check --target all --warn-list +73` — clean
- targeted `builtin/string_methods.mbt` tests on native, Wasm, Wasm-GC, and JavaScript — 63/63 on each target
- `moon test` — 7018/7018
- `moon info && moon fmt` — no interface changes

The earlier release-toolchain validation below was run before the JavaScript-only fallback commit; its native/Wasm/Wasm-GC results remain representative.

- `moon check --deny-warn --target all` — clean
- `moon test -p moonbitlang/core/builtin --target <t>`
  - native: 2882/2882
  - wasm: 2924/2924
  - wasm-gc: 2924/2924
  - JavaScript: 2909/2909
- `moon test` (full repository suite, default target): 6897/6897
- `moon info --target wasm,wasm-gc,js,native` — no `.mbti` changes
- `moon fmt` — no diff
- native codegen inspection of `ascii_lowercase_copy`: `ldr q3` / `add.8h` / `cmhi.8h` / `and.16b` / `add.8h` / `str q3`, and of `find_ascii_uppercase_code_unit_simd`: `ldr q2` / `add.8h` / `cmhi.8h` / `umaxv.16b`
- Wasm codegen inspection: `v128.load`, `v128.store`, `i16x8.splat`, `i16x8.sub`, `i16x8.add`, `i16x8.le_u`, `v128.and`, and `v128.any_true` all present in the emitted module

### Rebase note

The rebase onto `8720b4b3` produced one conflict, in the `builtin/simd.mbt` header comment. `main` had independently un-gated `v128_make` and `v128_load` for aligned bitstring extraction and rewritten that paragraph; this branch had rewritten the same paragraph to cover string routines as well as byte scanners. The resolution keeps both facts. No executable code conflicted.


