### PR TITLE
Add aligned V128 bitstring extraction APIs

### DIFF
--- a/builtin/bitstring_v128.mbt
+++ b/builtin/bitstring_v128.mbt
@@ -1,0 +1,89 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Runtime support for the `v128le(v)` bitstring pattern. A `V128` has no
+// inherent lane structure, so its byte view is the little-endian layout of
+// `@v128.v128_load`: byte `k` -> i8x16 lane `k`, with bytes 0..7 in `lo` and
+// bytes 8..15 in `hi`. The bitstring pattern is restricted to byte-aligned
+// offsets and uses that intrinsic through the private `v128_load` helper in
+// `simd.mbt`.
+
+///|
+/// Extract 16 byte-aligned bytes as a `V128` (little-endian byte order).
+#internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
+pub fn ArrayView::unsafe_extract_v128_aligned(
+  bs : ArrayView[Byte],
+  byte_offset : Int,
+) -> V128 {
+  v128_load(buffer_to_fixedarray(bs.buf()), bs.start() + byte_offset)
+}
+
+///|
+/// Extract 16 byte-aligned bytes as a `V128` (little-endian byte order).
+#internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
+pub fn BytesView::unsafe_extract_v128_aligned(
+  bs : BytesView,
+  byte_offset : Int,
+) -> V128 {
+  v128_load(unsafe_from_bytes(bs.bytes()), bs.start() + byte_offset)
+}
+
+///|
+/// Extract 16 byte-aligned bytes directly from `Bytes` as a `V128`.
+#borrow(bs)
+#internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
+pub fn Bytes::unsafe_extract_v128_aligned(
+  bs : Bytes,
+  byte_offset : Int,
+) -> V128 {
+  v128_load(unsafe_from_bytes(bs), byte_offset)
+}
+
+///|
+/// Forward to `ArrayView::unsafe_extract_v128_aligned`.
+#internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
+pub fn Array::unsafe_extract_v128_aligned(
+  bs : Array[Byte],
+  byte_offset : Int,
+) -> V128 {
+  bs[:].unsafe_extract_v128_aligned(byte_offset)
+}
+
+///|
+/// Load 16 byte-aligned bytes directly from a fixed array.
+#internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
+pub fn FixedArray::unsafe_extract_v128_aligned(
+  bs : FixedArray[Byte],
+  byte_offset : Int,
+) -> V128 {
+  v128_load(bs, byte_offset)
+}
+
+///|
+/// Forward to `FixedArray::unsafe_extract_v128_aligned`.
+#internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
+pub fn ReadOnlyArray::unsafe_extract_v128_aligned(
+  bs : ReadOnlyArray[Byte],
+  byte_offset : Int,
+) -> V128 {
+  bs
+  .unsafe_reinterpret_to_fixed_array()
+  .unsafe_extract_v128_aligned(byte_offset)
+}

--- a/builtin/simd.mbt
+++ b/builtin/simd.mbt
@@ -16,12 +16,11 @@
 // `bytes_find.mbt`. `builtin` cannot import `moonbitlang/core/v128` (that would
 // be a cycle), so the few ops the scanners need are hosted here directly.
 //
-// These are gated to the linear-memory backends that have the intrinsics, the
-// same targets the scanners run on; the function bodies exist only so the
-// `#intrinsic` declarations type-check and are never executed there.
+// Scanner-only operations are gated to the linear-memory backends that use
+// them. `v128_make` and `v128_load` also support aligned bitstring extraction,
+// so they remain available on every backend with portable fallback bodies.
 
 ///|
-#cfg(any(target="native", target="wasm"))
 fn v128_make(lo : UInt64, hi : UInt64) -> V128 = "%v128.make"
 
 ///|
@@ -42,7 +41,6 @@ fn i8x16_splat(value : Byte) -> V128 {
 
 ///|
 #borrow(bytes)
-#cfg(any(target="native", target="wasm"))
 #intrinsic("%v128.v128_load")
 fn v128_load(bytes : FixedArray[Byte], offset : Int) -> V128 {
   v128_make(


### PR DESCRIPTION
## Summary

- add internal aligned V128 extraction APIs for Bytes, BytesView, Array[Byte], ArrayView[Byte], FixedArray[Byte], and ReadOnlyArray[Byte]
- reuse the existing builtin `v128_load` implementation and make its portable fallback available on every backend
- keep the API surface aligned-only for compiler-generated `v128le` bitstring patterns

## Why

The compiler-side V128 bitstring work needs core methods that load 16 bytes from a byte-aligned offset and can be specialized to the existing V128 load intrinsic.

The experimental benchmark is intentionally excluded from this PR because it depends on compiler-side `v128le` pattern support that is being implemented separately.

## Validation

- `moon check --target all --warn-list +73`
- `moon test v128 --target all`
  - 34/34 passed on wasm
  - 34/34 passed on wasm-gc
  - 34/34 passed on JavaScript
  - 34/34 passed on native
- `moon fmt`
- `moon info`
