### PR TITLE
refactor: adopt or-pattern `with` defaults to merge match arms

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -315,9 +315,9 @@ fn format_entries(display : Array[(String, String)]) -> Array[String] {
 fn arg_display(arg : Arg) -> String {
   let parts = Array::new(capacity=2)
   let (short, long) = match arg.info {
-    OptionInfo(short~, long~, ..) => (short, long)
-    FlagInfo(short~, long~, ..) => (short, long)
-    PositionalInfo(_) => (None, None)
+    OptionInfo(short~, long~, ..)
+    | FlagInfo(short~, long~, ..)
+    | (PositionalInfo(_) with short = None, long = None) => (short, long)
   }
   if short is Some(short) {
     parts.push("-\{short}")

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -258,8 +258,7 @@ pub fn[T] Array::view(
 ) -> ArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
@@ -306,8 +305,7 @@ pub fn[T] Array::get_view(
 ) -> ArrayView[T]? {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(ArrayView::make(self.buffer(), start, end - start))
@@ -353,8 +351,7 @@ pub fn[T] ArrayView::view(
 ) -> ArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
@@ -403,8 +400,7 @@ pub fn[T] ArrayView::get_view(
 ) -> ArrayView[T]? {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(ArrayView::make(self.buf(), self.start() + start, end - start))
@@ -452,8 +448,7 @@ pub fn[T] FixedArray::view(
 ) -> ArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
@@ -504,8 +499,7 @@ pub fn[T] FixedArray::get_view(
 ) -> ArrayView[T]? {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(

--- a/builtin/assert.mbt
+++ b/builtin/assert.mbt
@@ -37,8 +37,7 @@
 pub fn assert_true(x : Bool, msg? : StringView, loc~ : SourceLoc) -> Unit raise {
   if !x {
     let fail_msg : StringView = match msg {
-      Some(msg) => msg
-      None => "`\{x}` is not true"
+      Some(msg) | (None with msg = "`\{x}` is not true") => msg
     }
     fail(fail_msg, loc~)
   }
@@ -74,8 +73,7 @@ pub fn assert_false(
 ) -> Unit raise {
   if x {
     let fail_msg : StringView = match msg {
-      Some(msg) => msg
-      None => "`\{x}` is not false"
+      Some(msg) | (None with msg = "`\{x}` is not false") => msg
     }
     fail(fail_msg, loc~)
   }

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -178,8 +178,7 @@ pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {
 pub fn Bytes::view(self : Bytes, start? : Int = 0, end? : Int) -> BytesView {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("Invalid index for View")
@@ -211,8 +210,7 @@ pub fn Bytes::get_view(
 ) -> BytesView? {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(BytesView::make(self, start, end - start))
@@ -229,8 +227,7 @@ pub fn BytesView::get_view(
 ) -> BytesView? {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(BytesView::make(self.bytes(), self.start() + start, end - start))
@@ -258,8 +255,7 @@ pub fn BytesView::view(
 ) -> BytesView {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("Invalid index for View")

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -786,9 +786,7 @@ pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
 pub fn[X, Y] Iter::zip(self : Iter[X], other : Iter[Y]) -> Iter[(X, Y)] {
   let size_hint = match (self.size_hint, other.size_hint) {
     (Some(n), Some(m)) if n < m => Some(n)
-    (Some(_), Some(m)) => Some(m)
-    (Some(0), _) => Some(0)
-    (_, Some(0)) => Some(0)
+    (Some(_), Some(m)) | ((Some(0), _) | (_, Some(0)) with m = 0) => Some(m)
     _ => None
   }
   {

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -249,8 +249,7 @@ pub fn[T] Array::mut_view(
 ) -> MutArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
@@ -297,8 +296,7 @@ pub fn[T] MutArrayView::mut_view(
 ) -> MutArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
@@ -341,8 +339,7 @@ pub fn[T] FixedArray::mut_view(
 ) -> MutArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
@@ -372,8 +369,7 @@ pub fn[T] MutArrayView::view(
 ) -> ArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -47,8 +47,7 @@ pub fn[X] Option::unwrap(self : X?) -> X {
 #alias(or, deprecated)
 pub fn[T] Option::unwrap_or(self : T?, default : T) -> T {
   match self {
-    None => default
-    Some(t) => t
+    Some(t) | (None with t = default) => t
   }
 }
 
@@ -72,8 +71,7 @@ pub fn[T] Option::unwrap_or_else(
 #alias(or_default, deprecated)
 pub fn[T : Default] Option::unwrap_or_default(self : T?) -> T {
   match self {
-    None => T::default()
-    Some(t) => t
+    Some(t) | (None with t = T::default()) => t
   }
 }
 

--- a/builtin/result.mbt
+++ b/builtin/result.mbt
@@ -89,8 +89,7 @@ test "map_err" {
 #alias(or)
 pub fn[T, E] Result::unwrap_or(self : Result[T, E], default : T) -> T {
   match self {
-    Ok(value) => value
-    Err(_) => default
+    Ok(value) | (Err(_) with value = default) => value
   }
 }
 
@@ -313,8 +312,7 @@ test "show" {
 /// Return the contained `Ok` value or the result of the `T::default()`.
 pub fn[T : Default, E] Result::unwrap_or_default(self : Result[T, E]) -> T {
   match self {
-    Ok(value) => value
-    Err(_) => T::default()
+    Ok(value) | (Err(_) with value = T::default()) => value
   }
 }
 

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -120,8 +120,7 @@ pub fn String::unsafe_substring(
 pub fn String::substring(self : String, start? : Int = 0, end? : Int) -> String {
   let len = self.length()
   let end = match end {
-    Some(end) => end
-    None => len
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len
   self.unsafe_substring(start~, end~)

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -669,8 +669,7 @@ pub fn String::get_view(
 ) -> StringView? {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else { None }
   if start < len && self.unsafe_get(start).is_trailing_surrogate() {
@@ -755,8 +754,7 @@ pub fn StringView::get_view(
 pub fn String::sub(self : String, start? : Int = 0, end? : Int) -> StringView {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len
   if start < len {

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -93,8 +93,7 @@ pub fn[T] UninitializedArray::sub(
 ) -> ArrayView[T] {
   let len = self.length()
   let end = match end {
-    None => len
-    Some(end) => end
+    Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
     abort("View start index out of bounds")

--- a/bytes/internal/regex_engine/ast/pattern.mbt
+++ b/bytes/internal/regex_engine/ast/pattern.mbt
@@ -104,8 +104,7 @@ pub fn seq(exprs : ReadOnlyArray[Pattern]) -> Pattern {
     }
   }
   match flatten {
-    [] => epsilon
-    [expr] => expr
+    [expr] | ([] with expr = epsilon) => expr
     exprs =>
       {
         desc: Sequence(ReadOnlyArray::from_array(exprs)),
@@ -122,8 +121,7 @@ pub let empty : Pattern = { desc: Alternation([]), nullable: false }
 /// Build an alternation of patterns.
 pub fn alt(exprs : ReadOnlyArray[Pattern]) -> Pattern {
   match exprs {
-    [] => empty
-    [expr] => expr
+    [expr] | ([] with expr = empty) => expr
     exprs => { desc: Alternation(exprs), nullable: exprs.any(e => e.nullable) }
   }
 }

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -52,8 +52,8 @@ pub fn[K : Hash + Eq] HashSet::HashSet(
 ) -> HashSet[K] {
   let length = arr.length()
   let capacity = match capacity {
-    Some(capacity) => capacity.max(capacity_for_length(length))
-    None => default_init_capacity.max(capacity_for_length(length))
+    Some(capacity) | (None with capacity = default_init_capacity) =>
+      capacity.max(capacity_for_length(length))
   }
   let m = new_hashset(capacity)
   arr.each(e => m.add(e))

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -909,8 +909,7 @@ fn[A : Compare] SortedSet::split_bis(
 #inline
 pub fn[A] SortedSet::length(self : SortedSet[A]) -> Int {
   match self {
-    Empty => 0
-    Node(size~, ..) => size
+    Node(size~, ..) | (Empty with size = 0) => size
   }
 }
 

--- a/internal/regex_engine/automata/expr.mbt
+++ b/internal/regex_engine/automata/expr.mbt
@@ -170,8 +170,7 @@ pub fn e_after(ctx~ : Context, cat : @shared_types.Category) -> Expr {
 /// - Otherwise → create Alt node
 pub fn e_alt(ctx~ : Context, xs : Array[Expr]) -> Expr {
   match xs {
-    [] => e_empty
-    [x] => x
+    [x] | ([] with x = e_empty) => x
     xs => { id: ctx.new_expr_id(), def: Alt(xs) }
   }
 }

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -497,8 +497,7 @@ pub fn json_inspect(
   let args_loc = args_loc.to_json()
   let actual = obj.to_json().stringify(escape_slash=false)
   let want = match content {
-    None => "".to_json().stringify(escape_slash=false)
-    Some(x) => x.stringify(escape_slash=false)
+    Some(x) | (None with x = "".to_json()) => x.stringify(escape_slash=false)
   }
   if actual != want {
     raise InspectError(

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1395,8 +1395,7 @@ pub fn[A] List::drop(self : List[A], n : Int) -> List[A] {
   } else {
     for a = n, b = self {
       match (a, b) {
-        (_, Empty) => break Empty
-        (1, More(_, tail=xs)) => break xs
+        (1, More(_, tail=xs)) | ((_, Empty) with xs = Empty) => break xs
         (n, More(_, tail=xs)) => continue n - 1, xs
       }
     }
@@ -1664,9 +1663,9 @@ pub fn[A] List::findi(self : List[A], f : (A, Int) -> Bool raise?) -> A? raise? 
 /// ```
 pub fn[A] List::remove_at(self : List[A], index : Int) -> List[A] {
   match (index, self) {
-    (_, Empty) => Empty
-    (_..<0, _) => self
-    (0, More(_, tail~)) => tail
+    (0, More(_, tail~))
+    | ((_, Empty) with tail = Empty)
+    | ((_..<0, _) with tail = self) => tail
     (n, More(head, tail~)) => {
       let dest = More(head, tail=Empty)
       for d = dest, t = tail, i = n - 1 {

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -200,8 +200,7 @@ pub fn[K : Compare, V] SortedMap::get_or_default(
   default : V,
 ) -> V {
   match self.get(key) {
-    Some(v) => v
-    None => default
+    Some(v) | (None with v = default) => v
   }
 }
 

--- a/string/internal/regex_engine/ast/pattern.mbt
+++ b/string/internal/regex_engine/ast/pattern.mbt
@@ -104,8 +104,7 @@ pub fn seq(exprs : ReadOnlyArray[Pattern]) -> Pattern {
     }
   }
   match flatten {
-    [] => epsilon
-    [expr] => expr
+    [expr] | ([] with expr = epsilon) => expr
     exprs =>
       {
         desc: Sequence(ReadOnlyArray::from_array(exprs)),
@@ -122,8 +121,7 @@ pub let empty : Pattern = { desc: Alternation([]), nullable: false }
 /// Build an alternation of patterns.
 pub fn alt(exprs : ReadOnlyArray[Pattern]) -> Pattern {
   match exprs {
-    [] => empty
-    [expr] => expr
+    [expr] | ([] with expr = empty) => expr
     exprs => { desc: Alternation(exprs), nullable: exprs.any(e => e.nullable) }
   }
 }

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -33,8 +33,9 @@ pub fn[T : Eq + @debug.Debug] assert_not_eq(
 ) -> Unit raise {
   if !(a != b) {
     let fail_msg = match msg {
-      Some(msg) => msg
-      None => "`\{@debug.to_string(a)} == \{@debug.to_string(b)}`"
+      Some(msg)
+      | (None with msg = "`\{@debug.to_string(a)} == \{@debug.to_string(b)}`") =>
+        msg
     }
     fail(fail_msg, loc~)
   }


### PR DESCRIPTION
> **Revived 2026-07-16**: rebased onto current main and migrated to the finalized syntax — each `with` alternative is now a parenthesized pattern `(Pat with x = e)`, with a flat binding list for multiple binders `(Pat with a = e1, b = e2)`.

Adopts the or-pattern default syntax — `Pat1(x) | (Pat2 with x = default)` — across core, merging match arms that previously duplicated a body just to supply a fixed value for a binder one alternative doesn't bind. 20 files, −79/+45 lines, no behavior change.

## Highlights — merges that or-patterns couldn't express before

**Multi-binder defaults** (`argparse/help_render.mbt`):

```moonbit
let (short, long) = match arg.info {
  OptionInfo(short~, long~, ..)
  | FlagInfo(short~, long~, ..)
  | (PositionalInfo(_) with short = None, long = None) => (short, long)
}
```

**Labeled-field accessors** (`immut/sorted_set`):

```moonbit
match self {
  Node(size~, ..) | (Empty with size = 0) => size
}
```

**Grouped alternatives sharing one default** (`Iter::zip` size hint):

```moonbit
(Some(n), Some(m)) if n < m => Some(n)
(Some(_), Some(m)) | (((Some(0), _) | (_, Some(0))) with m = 0) => Some(m)
_ => None
```

**Per-alternative defaults, including non-constant ones** (`List::remove_at`):

```moonbit
(0, More(_, tail~))
| ((_, Empty) with tail = Empty)
| ((_..<0, _) with tail = self) => tail
```

Plus the regex smart constructors (`[expr] | ([] with expr = epsilon) => expr`), `List::drop`, and lazily-evaluated failure messages in `assert_true`/`assert_false`/`@test.assert_not_eq` (the interpolated default is only built when the `None` alternative matches).

## Also included

- Deduplicated arm bodies where both arms repeated the same trailing computation: `HashSet` capacity clamping, `json_inspect`'s `want`.
- Dogfooding in the definitions the feature subsumes: `Option`/`Result` `unwrap_or` / `unwrap_or_default`, `SortedMap::get_or_default`, and the 18 `end? : Int` slicing defaults in builtin view constructors (kept as matches rather than `unwrap_or` calls to preserve the existing zero-call hot paths).

## Deliberately not converted

- `unwrap_or_else` and friends: possibly-raising calls are rejected inside a `with` default (error 4221), so the lazy-callback variants keep their two arms.
- Diverging "defaults" (`return None` / `continue` / `abort`): reads worse than separate arms, e.g. in strconv.
- Pure unwraps already expressible as `unwrap_or` with matching types.
- `ThreadSet::split_at_first_match` and `Repr::children`: mergeable, but the merged arm is denser than the original.

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1) after the syntax migration: "No findings. The order-sensitive merges at `builtin/iterator.mbt`, `list/list.mbt` preserve precedence. All defaults reference outer values/constants only... exhaustiveness is unchanged."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean, `moon fmt` round-trips the new syntax, `moon info` no `.mbti` changes
- `moon test`: 6715 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)