### PR TITLE
refactor: use multi-line string literals for escape-heavy strings

### DIFF
--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -123,7 +123,11 @@ fn format_error_with_help(
   inherited_globals : Array[Arg],
   command_path : String,
 ) -> String {
-  "\{msg}\n\n\{render_help_for_context(cmd, inherited_globals, command_path)}"
+  (
+    $|\{msg}
+    $|
+    $|\{render_help_for_context(cmd, inherited_globals, command_path)}
+  )
 }
 
 ///|

--- a/buffer/README.mbt.md
+++ b/buffer/README.mbt.md
@@ -63,14 +63,29 @@ test {
   // 32-bit signed/unsigned
   let buf = Buffer()
   buf.write_int_be(0x01020304)
-  inspect(buf.to_bytes(), content="b\"\\x01\\x02\\x03\\x04\"")
+  inspect(
+    buf.to_bytes(),
+    content=(
+      #|b"\x01\x02\x03\x04"
+    ),
+  )
   let buf2 = Buffer()
   buf2.write_int_le(0x01020304)
-  inspect(buf2.to_bytes(), content="b\"\\x04\\x03\\x02\\x01\"")
+  inspect(
+    buf2.to_bytes(),
+    content=(
+      #|b"\x04\x03\x02\x01"
+    ),
+  )
   // unsigned 32-bit
   let buf3 = Buffer()
   buf3.write_uint_be(0xAABBU)
-  inspect(buf3.to_bytes(), content="b\"\\x00\\x00\\xaa\\xbb\"")
+  inspect(
+    buf3.to_bytes(),
+    content=(
+      #|b"\x00\x00\xaa\xbb"
+    ),
+  )
 }
 ```
 
@@ -83,24 +98,38 @@ test {
   let buf = Buffer()
   buf.write_int16_be((0x0102 : Int16))
   buf.write_int16_le((0x0102 : Int16))
-  inspect(buf.to_bytes(), content="b\"\\x01\\x02\\x02\\x01\"")
+  inspect(
+    buf.to_bytes(),
+    content=(
+      #|b"\x01\x02\x02\x01"
+    ),
+  )
   // 16-bit unsigned
   let buf2 = Buffer()
   buf2.write_uint16_be(Int::to_uint16(0x00AB))
-  inspect(buf2.to_bytes(), content="b\"\\x00\\xab\"")
+  inspect(
+    buf2.to_bytes(),
+    content=(
+      #|b"\x00\xab"
+    ),
+  )
   // 64-bit signed
   let buf3 = Buffer()
   buf3.write_int64_be(0x0102030405060708L)
   inspect(
     buf3.to_bytes(),
-    content="b\"\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\"",
+    content=(
+      #|b"\x01\x02\x03\x04\x05\x06\x07\x08"
+    ),
   )
   // 64-bit unsigned
   let buf4 = Buffer()
   buf4.write_uint64_le(0xAABBUL)
   inspect(
     buf4.to_bytes(),
-    content="b\"\\xbb\\xaa\\x00\\x00\\x00\\x00\\x00\\x00\"",
+    content=(
+      #|b"\xbb\xaa\x00\x00\x00\x00\x00\x00"
+    ),
   )
 }
 ```

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -1174,7 +1174,12 @@ test "array_fill - empty array" {
 test "array_fill - with different types" {
   let str_arr = ["a", "b", "c", "d"]
   str_arr.fill("x", start=1, end=3)
-  debug_inspect(str_arr, content="[\"a\", \"x\", \"x\", \"d\"]")
+  debug_inspect(
+    str_arr,
+    content=(
+      #|["a", "x", "x", "d"]
+    ),
+  )
   let bool_arr = [true, false, true, false]
   bool_arr.fill(true, start=0, end=2)
   debug_inspect(bool_arr, content="[true, true, true, false]")

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -196,7 +196,9 @@ pub fn inspect(
     let expect_base64 = "\"\{base64_encode_string_codepoint(content)}\""
     let actual_base64 = "\"\{base64_encode_string_codepoint(actual)}\""
     raise InspectError(
-      "@EXPECT_FAILED {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{expect_escaped}, \"actual\": \{actual_escaped}, \"expect_base64\": \{expect_base64}, \"actual_base64\": \{actual_base64}}",
+      (
+        $|@EXPECT_FAILED {"loc": \{loc}, "args_loc": \{args_loc}, "expect": \{expect_escaped}, "actual": \{actual_escaped}, "expect_base64": \{expect_base64}, "actual_base64": \{actual_base64}}
+      ),
     )
   }
 }

--- a/builtin/double_test.mbt
+++ b/builtin/double_test.mbt
@@ -120,7 +120,9 @@ test "to_be_bytes with negative number" {
 test "to_le_bytes with infinity" {
   inspect(
     (1.0 / 0.0).to_le_bytes_local(),
-    content="b\"\\x00\\x00\\x00\\x00\\x00\\x00\\xf0\\x7f\"",
+    content=(
+      #|b"\x00\x00\x00\x00\x00\x00\xf0\x7f"
+    ),
   )
 }
 

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -151,7 +151,15 @@ test "map_while1" {
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
   .each(x => exb.write_string("\{x}\n"))
-  inspect(exb, content="1\n2\n3\n")
+  inspect(
+    exb,
+    content=(
+      #|1
+      #|2
+      #|3
+      #|
+    ),
+  )
 }
 
 ///|
@@ -162,7 +170,16 @@ test "map_while2" {
   .map_while(x => if x != 4 { Some(x) } else { None })
   .concat(Iter::singleton(6))
   .each(x => exb.write_string("\{x}\n"))
-  inspect(exb, content="1\n2\n3\n6\n")
+  inspect(
+    exb,
+    content=(
+      #|1
+      #|2
+      #|3
+      #|6
+      #|
+    ),
+  )
 }
 
 ///|
@@ -475,7 +492,9 @@ test "zip" {
   let letters = ["a", "b", "c"].iter()
   debug_inspect(
     numbers.zip(letters).collect(),
-    content="[(1, \"a\"), (2, \"b\"), (3, \"c\")]",
+    content=(
+      #|[(1, "a"), (2, "b"), (3, "c")]
+    ),
   )
 }
 
@@ -485,7 +504,9 @@ test "zip alias combine" {
   let letters = ["x", "y", "z", "w"].iter()
   debug_inspect(
     numbers.combine(letters).collect(),
-    content="[(1, \"x\"), (2, \"y\"), (3, \"z\")]",
+    content=(
+      #|[(1, "x"), (2, "y"), (3, "z")]
+    ),
   )
 }
 

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -152,7 +152,11 @@ test "map::contains_kv" {
   inspect(map.contains_kv("a", 1), content="true")
   inspect(map.contains_kv("a", 2), content="false")
   guard map is { "a": 1, "b": 2, "c": 3, .. } else {
-    fail("map is not { \"a\": 1, \"b\": 2, \"c\": 3 }")
+    fail(
+      (
+        #|map is not { "a": 1, "b": 2, "c": 3 }
+      ),
+    )
   }
 }
 
@@ -444,7 +448,12 @@ test "Map::retain - iteration order after retain" {
   // Check that insertion order is maintained for remaining elements
   let keys = []
   map.each((k, _v) => keys.push(k))
-  debug_inspect(keys, content="[\"first\", \"second\", \"fourth\", \"fifth\"]")
+  debug_inspect(
+    keys,
+    content=(
+      #|["first", "second", "fourth", "fifth"]
+    ),
+  )
   let values = []
   map.each((_k, v) => values.push(v))
   debug_inspect(values, content="[1, 2, 4, 5]")

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -19,10 +19,30 @@ test "basic1" {
   let bv2 = bs[:]
   let bv3 = bs[1:]
   let bv4 = bs[:4]
-  inspect(bv1, content="b\"\\x01\\x02\\x03\"")
-  inspect(bv2, content="b\"\\x00\\x01\\x02\\x03\\x04\\x05\"")
-  inspect(bv3, content="b\"\\x01\\x02\\x03\\x04\\x05\"")
-  inspect(bv4, content="b\"\\x00\\x01\\x02\\x03\"")
+  inspect(
+    bv1,
+    content=(
+      #|b"\x01\x02\x03"
+    ),
+  )
+  inspect(
+    bv2,
+    content=(
+      #|b"\x00\x01\x02\x03\x04\x05"
+    ),
+  )
+  inspect(
+    bv3,
+    content=(
+      #|b"\x01\x02\x03\x04\x05"
+    ),
+  )
+  inspect(
+    bv4,
+    content=(
+      #|b"\x00\x01\x02\x03"
+    ),
+  )
   @json.json_inspect(bv1, content="\\x01\\x02\\x03")
   @json.json_inspect(b"abc"[:], content="abc")
 }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -222,7 +222,12 @@ test "log" {
 ///|
 test "backslash escape" {
   let s = "\n\r\t\b\"'\\"
-  inspect(s.escape(), content="\"\\n\\r\\t\\b\\\"'\\\\\"")
+  inspect(
+    s.escape(),
+    content=(
+      #|"\n\r\t\b\"'\\"
+    ),
+  )
 }
 
 ///|

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -241,7 +241,9 @@ pub fn debug_inspect(
   }
   if actual != want {
     raise InspectError(
-      "@EXPECT_FAILED {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{want.escape()}, \"actual\": \{actual.escape()} }",
+      (
+        $|@EXPECT_FAILED {"loc": \{loc}, "args_loc": \{args_loc}, "expect": \{want.escape()}, "actual": \{actual.escape()} }
+      ),
     )
   }
 }
@@ -265,7 +267,11 @@ pub fn[T : Eq + Debug] assert_eq(
         let repr_a = to_repr(a)
         let repr_b = to_repr(b)
         let diff = pretty_print_delta(diff_repr(repr_a, repr_b), use_ansi=false)
-        "`\{render(repr_a)} != \{render(repr_b)}`\ndiff:\n\{diff}"
+        (
+          $|`\{render(repr_a)} != \{render(repr_b)}`
+          $|diff:
+          $|\{diff}
+        )
       }
     }
     fail(fail_msg, loc~)

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -213,7 +213,12 @@ test "iter2" {
 test "rev_keys returns keys in descending order" {
   let map = @sorted_map.SortedMap([("a", 1), ("b", 2), ("c", 3)])
   let keys = map.rev_keys().collect()
-  debug_inspect(keys, content="[\"c\", \"b\", \"a\"]")
+  debug_inspect(
+    keys,
+    content=(
+      #|["c", "b", "a"]
+    ),
+  )
 }
 
 ///|
@@ -329,7 +334,9 @@ test "rev_values with complex tree" {
   let values = map.rev_values().collect()
   debug_inspect(
     values,
-    content="[\"25\", \"20\", \"18\", \"15\", \"12\", \"10\", \"5\"]",
+    content=(
+      #|["25", "20", "18", "15", "12", "10", "5"]
+    ),
   )
 }
 

--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -44,7 +44,9 @@ test "parse and validate jsons" {
 ///|
 test "json object navigation" {
   let json = @json.parse(
-    "{\"string\":\"hello\",\"number\":42,\"array\":[1,2,3]}",
+    (
+      #|{"string":"hello","number":42,"array":[1,2,3]}
+    ),
   )
 
   // Access string
@@ -166,20 +168,20 @@ test "stringify options" {
   // compact (default)
   inspect(
     json.stringify(),
-    content="{\"name\":\"Alice\",\"age\":30,\"secret\":\"hidden\"}",
+    content=(
+      #|{"name":"Alice","age":30,"secret":"hidden"}
+    ),
   )
   // pretty-printed
   inspect(
     json.stringify(indent=2),
-    content={
-      let output =
-        #|{
-        #|  "name": "Alice",
-        #|  "age": 30,
-        #|  "secret": "hidden"
-        #|}
-      output
-    },
+    content=(
+      #|{
+      #|  "name": "Alice",
+      #|  "age": 30,
+      #|  "secret": "hidden"
+      #|}
+    ),
   )
 }
 ```
@@ -194,10 +196,20 @@ test "replacer keep and exclude" {
   let json : Json = { "name": "Alice", "age": 30, "secret": "hidden" }
   // keep only specified keys
   let kept = json.stringify(replacer=@json.Replacer::keep(["name", "age"]))
-  inspect(kept, content="{\"name\":\"Alice\",\"age\":30}")
+  inspect(
+    kept,
+    content=(
+      #|{"name":"Alice","age":30}
+    ),
+  )
   // exclude specified keys
   let excluded = json.stringify(replacer=@json.Replacer::exclude(["secret"]))
-  inspect(excluded, content="{\"name\":\"Alice\",\"age\":30}")
+  inspect(
+    excluded,
+    content=(
+      #|{"name":"Alice","age":30}
+    ),
+  )
 }
 ```
 

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -502,7 +502,9 @@ pub fn json_inspect(
   }
   if actual != want {
     raise InspectError(
-      "@EXPECT_FAILED {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{want.escape()}, \"actual\": \{actual.escape()}, \"mode\": \"json\"}",
+      (
+        $|@EXPECT_FAILED {"loc": \{loc}, "args_loc": \{args_loc}, "expect": \{want.escape()}, "actual": \{actual.escape()}, "mode": "json"}
+      ),
     )
   }
 }

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -139,8 +139,22 @@ test "stringify" {
 ///|
 test "stringify with custom indents" {
   let json : Json = { "a": 1 }
-  inspect(json.stringify(indent=5), content="{\n     \"a\": 1\n}")
-  inspect(json.stringify(indent=7), content="{\n       \"a\": 1\n}")
+  inspect(
+    json.stringify(indent=5),
+    content=(
+      #|{
+      #|     "a": 1
+      #|}
+    ),
+  )
+  inspect(
+    json.stringify(indent=7),
+    content=(
+      #|{
+      #|       "a": 1
+      #|}
+    ),
+  )
 }
 
 ///|

--- a/json/parse_test.mbt
+++ b/json/parse_test.mbt
@@ -207,13 +207,21 @@ test "parses string" {
 
 ///|
 test "parses quotes in string" {
-  let json = test_parse("[\"\\\"\",\"'\"]")
+  let json = test_parse(
+    (
+      #|["\"","'"]
+    ),
+  )
   @debug.assert_eq(json, Json::array([Json::string("\""), Json::string("'")]))
 }
 
 ///|
 test "parses escaped characters" {
-  let json = test_parse("\"\\b\\f\\n\\r\\t\\u01fF\\\"\"")
+  let json = test_parse(
+    (
+      #|"\b\f\n\r\t\u01fF\""
+    ),
+  )
   @debug.assert_eq(json, Json::string("\u0008\u000C\n\r\t\u01FF\""))
 }
 //endregion

--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -292,9 +292,19 @@ test "find and split" {
     .find("a1b22c333")
     .map(fn(m) { m.content().to_owned() })
     .collect()
-  debug_inspect(matches, content="[\"1\", \"22\", \"333\"]")
+  debug_inspect(
+    matches,
+    content=(
+      #|["1", "22", "333"]
+    ),
+  )
   let parts = digits.split("a1b22c333").map(fn(v) { v.to_owned() }).collect()
-  debug_inspect(parts, content="[\"a\", \"b\", \"c\", \"\"]")
+  debug_inspect(
+    parts,
+    content=(
+      #|["a", "b", "c", ""]
+    ),
+  )
 }
 ```
 

--- a/test/test.mbt
+++ b/test/test.mbt
@@ -226,7 +226,9 @@ pub fn Test::snapshot(
   let expect = filename.escape()
   // always raise SnapshotError, moon will handle this
   raise SnapshotError(
-    "@SNAPSHOT_TESTING {\"loc\": \{loc}, \"args_loc\": \{args_loc}, \"expect\": \{expect}, \"actual\": \{actual}, \"snapshot\": true}",
+    (
+      $|@SNAPSHOT_TESTING {"loc": \{loc}, "args_loc": \{args_loc}, "expect": \{expect}, "actual": \{actual}, "snapshot": true}
+    ),
   )
 }
 

--- a/tuple/tuple_test.mbt
+++ b/tuple/tuple_test.mbt
@@ -135,8 +135,18 @@ test "show" {
   let tuple4 = (1, 2, 3, "hello")
   let tuple5 = ([1], "2", 3, ([4] : Array[_]), 5)
   debug_inspect(tuple2, content="(1, 2)")
-  debug_inspect(tuple3, content="(\"a\", \"b\", \"c\")")
-  debug_inspect(tuple4, content="(1, 2, 3, \"hello\")")
+  debug_inspect(
+    tuple3,
+    content=(
+      #|("a", "b", "c")
+    ),
+  )
+  debug_inspect(
+    tuple4,
+    content=(
+      #|(1, 2, 3, "hello")
+    ),
+  )
   debug_inspect(
     tuple5,
     content=(


### PR DESCRIPTION
Converts string literals dense with `\"` / `\n` / `\\x` escapes to multi-line string literals (`#|` raw, `$|` interpolated, and the parenthesized `(#|...)` argument form). 18 files, +217/−49, no behavior change.

## Highlights

**Protocol strings** — the `@EXPECT_FAILED` / `@SNAPSHOT_TESTING` messages in `builtin/console`, `json`, `debug`, and `test` each drop ~a dozen quote escapes; the source now reads as the JSON it produces:

```moonbit
raise InspectError(
  (
    $|@EXPECT_FAILED {"loc": \{loc}, "args_loc": \{args_loc}, "expect": \{want.escape()}, "actual": \{actual.escape()}, "mode": "json"}
  ),
)
```

**Multi-line messages** — `assert_eq`'s diff message and argparse's `format_error_with_help` now mirror their output layout:

```moonbit
(
  $|`\{render(repr_a)} != \{render(repr_b)}`
  $|diff:
  $|\{diff}
)
```

**Verbatim test expectations** — quote-heavy and byte-dump `content=` strings use raw `(#|...)` lines (`#|b"\x01\x02\x03\x04"` instead of `"b\"\\x01\\x02\\x03\\x04\""`); JSON escapes stay visible as JSON escapes, and trailing newlines are preserved via a final empty `#|` line.

**Bonus cleanup** — `json/README.mbt.md`'s `content={ let output = #|...; output }` workaround replaced with the direct `(#|...)` form.

Deliberately not converted: whitespace-sensitive strings whose `\t`/`\r` must remain processed escapes (e.g. `json/parse_test.mbt` whitespace tests).

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1) in three passes:
1. Full semantic review: "No correctness findings. All 17 conversions are character-for-character equivalent... I would revert none" — plus follow-up candidates, which were applied.
2. Verification of the follow-up round: "PASS — all 27 converted strings... character-for-character equivalent", explicitly confirming trailing newlines and literal backslashes.
3. Final sign-off: "Confirmed HEAD is the same 18-file refactor, and spot-checked strings remain character-for-character equivalent."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean; `moon fmt` round-trips the multi-line forms
- `moon test`: 6715 passed, 0 failed
- No `pkg.generated.mbti` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)