### PR TITLE
fix: use qualified trait calls for implicitly promoted impl methods

### DIFF
--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -85,7 +85,7 @@ test "Eq::equal on custom impl" {
 ///|
 test "Logger defaults" {
   let logger = TestLogger::{ output: "" }
-  logger.write_string("hi")
-  logger.write_char('!')
+  Logger::write_string(logger, "hi")
+  Logger::write_char(logger, '!')
   inspect(logger.output, content="hi!")
 }

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -988,7 +988,7 @@ test "arbitrary" {
 test "equal imply hash equal when collision" {
   let s1 = MyString("1")
   let s2 = MyString("2")
-  inspect(s1.hash() == s2.hash(), content="true") // collisions
+  inspect(Hash::hash(s1) == Hash::hash(s2), content="true") // collisions
   let ma = @hashmap.new().add(s1, 1).add(s2, 2)
   let mb = @hashmap.new().add(s2, 2).add(s1, 1)
   inspect(ma == mb, content="true")


### PR DESCRIPTION
Unblocks CI: the pre-release toolchain now deprecates calling a local `impl Trait for Type` method (or a trait default method) via dot syntax without an `extend` declaration, and CI's deny-warn promotes it to an error — so **every PR currently fails `pre-release-check` / `pre-release-native-opt-test`** (see #3812 / #3813, which fail on these pre-existing sites in ~20s while all other checks pass).

Three call sites, all in test files:

- `builtin/traits_test.mbt`: `logger.write_string("hi")` / `logger.write_char('!')` → `Logger::write_string(logger, "hi")` / `Logger::write_char(logger, '!')` — still exercises the Logger *default* methods, which dispatch through `TestLogger`'s `write_view` impl
- `immut/hashmap/HAMT_test.mbt`: `s1.hash() == s2.hash()` → `Hash::hash(s1) == Hash::hash(s2)`

Qualified trait calls are used instead of the new `extend Type with Trait::{...}` declaration because the stable toolchain must still parse these files.

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1): "No findings; approved. Qualified calls preserve dispatch and behavior... the test still exercises both defaults... Repository-wide review found no additional CI-relevant implicit-promotion calls."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean, `moon fmt` no-op
- `moon test builtin/traits_test.mbt` 5/5, `moon test immut/hashmap/HAMT_test.mbt` 100/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)