### PR TITLE
Optimize String code unit search with V128

### DIFF
--- a/builtin/contains_code_unit_bench_test.mbt
+++ b/builtin/contains_code_unit_bench_test.mbt
@@ -1,0 +1,71 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Missing and late needles force a full scan; the offset view also exercises
+// the backing-string range path used by `StringView::contains_code_unit`.
+
+///|
+test "bench contains_code_unit absent n=4" (it : @bench.T) {
+  let s = String::make(4, 'a')
+  it.bench(() => it.keep(s.contains_code_unit(('z' : UInt16))))
+}
+
+///|
+test "bench contains_code_unit absent n=8" (it : @bench.T) {
+  let s = String::make(8, 'a')
+  it.bench(() => it.keep(s.contains_code_unit(('z' : UInt16))))
+}
+
+///|
+test "bench contains_code_unit present@0 n=8" (it : @bench.T) {
+  let s = String::make(8, 'a')
+  it.bench(() => it.keep(s.contains_code_unit(('a' : UInt16))))
+}
+
+///|
+test "bench contains_code_unit absent n=16" (it : @bench.T) {
+  let s = String::make(16, 'a')
+  it.bench(() => it.keep(s.contains_code_unit(('z' : UInt16))))
+}
+
+///|
+test "bench contains_code_unit absent n=64" (it : @bench.T) {
+  let s = String::make(64, 'a')
+  it.bench(() => it.keep(s.contains_code_unit(('z' : UInt16))))
+}
+
+///|
+test "bench contains_code_unit absent n=256" (it : @bench.T) {
+  let s = String::make(256, 'a')
+  it.bench(() => it.keep(s.contains_code_unit(('z' : UInt16))))
+}
+
+///|
+test "bench contains_code_unit present@end n=256" (it : @bench.T) {
+  let s = String::make(255, 'a') + "z"
+  it.bench(() => it.keep(s.contains_code_unit(('z' : UInt16))))
+}
+
+///|
+test "bench contains_code_unit present@0 n=256" (it : @bench.T) {
+  let s = String::make(256, 'a')
+  it.bench(() => it.keep(s.contains_code_unit(('a' : UInt16))))
+}
+
+///|
+test "bench StringView contains_code_unit absent n=256" (it : @bench.T) {
+  let s = "x" + String::make(256, 'a') + "y"
+  let view = s[1:257]
+  it.bench(() => it.keep(view.contains_code_unit(('z' : UInt16))))
+}

--- a/builtin/simd.mbt
+++ b/builtin/simd.mbt
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 // The 128-bit vector operations used by the SIMD byte and UTF-16 scanners in
-// `bytes_find.mbt` and `string_find_code_unit.mbt`. `builtin` cannot import
-// `moonbitlang/core/v128` (that would be a cycle), so the few ops the scanners
-// need are hosted here directly.
+// `bytes_find.mbt`, `string_find_code_unit.mbt`, and `string_methods.mbt`.
+// `builtin` cannot import `moonbitlang/core/v128` (that would be a cycle), so
+// the few ops the scanners need are hosted here directly.
 //
 // Scanner-only operations are gated to the linear-memory backends that use
 // them. `v128_make` and `v128_load` also support aligned bitstring extraction,
 // so they remain available on every backend with portable fallback bodies.
+// Scanner intrinsic declarations also carry scalar bodies for native builds
+// without hardware SIMD support.
 
 ///|
 fn v128_make(lo : UInt64, hi : UInt64) -> V128 = "%v128.make"
@@ -117,6 +119,13 @@ fn i8x16_bitmask(value : V128) -> Int {
 #intrinsic("%v128.i16x8_bitmask")
 fn i16x8_bitmask(value : V128) -> Int {
   u64_u16_high_bits(v128_lo(value)) | (u64_u16_high_bits(v128_hi(value)) << 4)
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.v128_any_true")
+fn v128_any_true(value : V128) -> Bool {
+  v128_lo(value) != 0 || v128_hi(value) != 0
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -456,12 +456,60 @@ test "View::to_array" {
 /// This searches raw UTF-16 code units and does not combine surrogate pairs.
 /// Use `contains_char` when searching for a Unicode character.
 pub fn StringView::contains_code_unit(self : StringView, code : UInt16) -> Bool {
-  for i in 0..<self.length() {
-    if self.unsafe_get(i) == code {
+  string_contains_code_unit(self.str(), self.start(), self.end(), code)
+}
+
+///|
+// The caller must ensure `0 <= start <= end <= str.length()`.
+#inline
+fn string_contains_code_unit_scalar(
+  str : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Bool {
+  for i in start..<end {
+    if str.unsafe_get(i) == code {
       return true
     }
   }
   false
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+fn string_contains_code_unit(
+  str : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Bool {
+  string_contains_code_unit_scalar(str, start, end, code)
+}
+
+///|
+// Scan eight UTF-16 code units at a time on linear-memory backends, then scan
+// the remaining tail one code unit at a time.
+#cfg(any(target="native", target="wasm"))
+fn string_contains_code_unit(
+  str : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Bool {
+  guard start + 8 <= end else {
+    return string_contains_code_unit_scalar(str, start, end, code)
+  }
+  let needle = i16x8_splat(code)
+  let tail_start = for pos = start; pos + 8 <= end; {
+    if v128_any_true(i16x8_eq(v128_load_i16x8(str, pos), needle)) {
+      return true
+    }
+    continue pos + 8
+  } nobreak {
+    pos
+  }
+  string_contains_code_unit_scalar(str, tail_start, end, code)
 }
 
 ///|
@@ -486,7 +534,7 @@ pub fn String::contains(self : String, str : StringView) -> Bool {
 /// This searches raw UTF-16 code units and does not combine surrogate pairs.
 /// Use `contains_char` when searching for a Unicode character.
 pub fn String::contains_code_unit(self : String, code : UInt16) -> Bool {
-  self[:].contains_code_unit(code)
+  string_contains_code_unit(self, 0, self.length(), code)
 }
 
 ///|
@@ -539,6 +587,25 @@ test "contains_code_unit" {
   inspect("😀".contains_code_unit(0xDE00), content="true")
   let leading_surrogate = String::from_array([(0xD800).unsafe_to_char()])
   inspect(leading_surrogate.contains_code_unit(0xD800), content="true")
+}
+
+///|
+test "contains_code_unit SIMD blocks and view bounds" {
+  let str = "01234567abcdefghZ"
+  inspect(str.contains_code_unit(('0' : UInt16)), content="true")
+  inspect(str.contains_code_unit(('7' : UInt16)), content="true")
+  inspect(str.contains_code_unit(('a' : UInt16)), content="true")
+  inspect(str.contains_code_unit(('h' : UInt16)), content="true")
+  inspect(str.contains_code_unit(('Z' : UInt16)), content="true")
+  inspect(str.contains_code_unit(('x' : UInt16)), content="false")
+  let view = ("x" + str + "y")[1:18]
+  inspect(view.contains_code_unit(('x' : UInt16)), content="false")
+  inspect(view.contains_code_unit(('a' : UInt16)), content="true")
+  inspect(view.contains_code_unit(('Z' : UInt16)), content="true")
+  inspect(view.contains_code_unit(('y' : UInt16)), content="false")
+  let wide = "01234567abcd😀efgh"
+  inspect(wide.contains_code_unit(0xD83D), content="true")
+  inspect(wide.contains_code_unit(0xDE00), content="true")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- add builtin V128 helpers for loading and comparing eight UTF-16 code units
- optimize `String::contains_code_unit` and `StringView::contains_code_unit` with eight-wide scans on native and wasm targets
- retain the scalar implementation for other targets and for short/tail ranges
- add SIMD block, view-boundary, surrogate-code-unit, and benchmark coverage

## Why

Code-unit searches previously inspected one UTF-16 code unit at a time. The new intrinsic allows native and wasm backends to scan eight code units per iteration while preserving the existing behavior and public API.

## Impact

Long missing or late-match searches are substantially faster on SIMD-enabled targets. String views continue to honor their exact backing-string bounds, and non-native/non-wasm targets keep the scalar path. Generated package interfaces are unchanged.

## Benchmark

Isolated native ARM64 release runs comparing the scalar baseline with this implementation (lower is better):

| Case | Scalar baseline | V128 | Speedup |
| --- | ---: | ---: | ---: |
| `String`, absent, n=4 | 7.84 ns | 6.50 ns | 1.21× |
| `String`, absent, n=8 | 8.81 ns | 6.49 ns | 1.36× |
| `String`, present at 0, n=8 | 5.77 ns | 5.69 ns | 1.01× |
| `String`, absent, n=256 | 82.26 ns | 16.10 ns | 5.11× |
| offset `StringView`, absent, n=256 | 86.38 ns | 17.47 ns | 4.94× |

The SIMD path improves full scans substantially while keeping the immediate-match case effectively unchanged.

## Validation

- `moon fmt`
- `moon info` (no `.mbti` changes)
- `moon check --target all -p builtin`
- `moon test --target all -p builtin`
  - wasm: 2,886 passed
  - wasm-gc: 2,886 passed
  - JavaScript: 2,874 passed
  - native: 2,844 passed
- `moon test`: 6,716 passed
