### PR TITLE
refactor: use nested with-patterns and flatten nested matches

### DIFF
--- a/argparse/parser_globals_merge.mbt
+++ b/argparse/parser_globals_merge.mbt
@@ -244,16 +244,11 @@ fn merge_globals_from_child(
 ///|
 fn global_option_conflict_label(arg : Arg) -> String {
   match arg.info {
-    FlagInfo(long~, short~, ..) | OptionInfo(long~, short~, ..) =>
-      match long {
-        Some(name) => "--\{name}"
-        None =>
-          match short {
-            Some(short) => "-\{short}"
-            None => arg.name
-          }
-      }
-    PositionalInfo(_) => arg.name
+    FlagInfo(long=Some(name), ..) | OptionInfo(long=Some(name), ..) =>
+      "--\{name}"
+    FlagInfo(short=Some(short), ..) | OptionInfo(short=Some(short), ..) =>
+      "-\{short}"
+    _ => arg.name
   }
 }
 

--- a/argparse/parser_values.mbt
+++ b/argparse/parser_values.mbt
@@ -144,16 +144,11 @@ fn assign_value(
 ///|
 fn option_conflict_label(arg : Arg) -> String {
   match arg.info {
-    FlagInfo(long~, short~, ..) | OptionInfo(long~, short~, ..) =>
-      match long {
-        Some(name) => "--\{name}"
-        None =>
-          match short {
-            Some(short) => "-\{short}"
-            None => arg.name
-          }
-      }
-    PositionalInfo(_) => arg.name
+    FlagInfo(long=Some(name), ..) | OptionInfo(long=Some(name), ..) =>
+      "--\{name}"
+    FlagInfo(short=Some(short), ..) | OptionInfo(short=Some(short), ..) =>
+      "-\{short}"
+    _ => arg.name
   }
 }
 

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -564,13 +564,13 @@ fn[K, V] Node::update_height(self : Node[K, V]) -> Unit {
 
 ///|
 fn[K, V] height_ge(x1 : Node[K, V]?, x2 : Node[K, V]?) -> Bool {
-  match x2 {
-    None => true
-    Some(n2) =>
-      match x1 {
-        None => false
-        Some(n1) => n1.height >= n2.height
-      }
+  match (x1, x2) {
+    (
+      Some({ height: h1, .. })
+      | (None with h1 = 0),
+      Some({ height: h2, .. })
+      | (None with h2 = 0),
+    ) => h1 >= h2
   }
 }
 

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -34,8 +34,7 @@ fn max(x : Int, y : Int) -> Int {
 ///|
 fn[K, V] height(node : Node[K, V]?) -> Int {
   match node {
-    None => 0
-    Some(n) => n.height
+    Some({ height, .. }) | (None with height = 0) => height
   }
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -571,13 +571,13 @@ fn[V] Node::update_height(self : Node[V]) -> Unit {
 
 ///|
 fn[V] height_ge(x1 : Node[V]?, x2 : Node[V]?) -> Bool {
-  match x2 {
-    None => true
-    Some(n2) =>
-      match x1 {
-        None => false
-        Some(n1) => n1.height >= n2.height
-      }
+  match (x1, x2) {
+    (
+      Some({ height: h1, .. })
+      | (None with h1 = 0),
+      Some({ height: h2, .. })
+      | (None with h2 = 0),
+    ) => h1 >= h2
   }
 }
 

--- a/sorted_set/utils.mbt
+++ b/sorted_set/utils.mbt
@@ -29,8 +29,7 @@ fn max(x : Int, y : Int) -> Int {
 ///|
 fn[V] height(node : Node[V]?) -> Int {
   match node {
-    None => 0
-    Some(n) => n.height
+    Some({ height, .. }) | (None with height = 0) => height
   }
 }
 


### PR DESCRIPTION
Follow-up to #3808, exercising `with`-defaults in **nested** pattern positions — the feature composes anywhere a pattern goes (tuple elements, constructor payloads, struct fields), which unlocks shapes plain arm-merging can't reach.

## The showcase: both children's heights in one pattern

`height_ge` in `sorted_map` and `sorted_set` replaced a two-level nested match (4 arms) with a single arm that extracts both heights, defaulting `None` to 0:

```moonbit
fn[K, V] height_ge(x1 : Node[K, V]?, x2 : Node[K, V]?) -> Bool {
  match (x1, x2) {
    (Some({ height: h1, .. }) | (None with h1 = 0),
      Some({ height: h2, .. }) | (None with h2 = 0)) => h1 >= h2
  }
}
```

Equivalence relies on the AVL invariant that stored heights are ≥ 1 (empty = 0); Codex verified the invariant across node constructors and every `update_height` path. Arguably the new form is more principled — it states the actual math ("height of empty is 0, compare") instead of special-casing.

The unary `height` accessors collapse the same way:

```moonbit
match node {
  Some({ height, .. }) | (None with height = 0) => height
}
```

## Bonus: nested patterns without `with`

argparse's `option_conflict_label` / `global_option_conflict_label` had a triple-nested Option fallback chain; ordered arms with nested payload patterns flatten it — no `with` needed:

```moonbit
match arg.info {
  FlagInfo(long=Some(name), ..) | OptionInfo(long=Some(name), ..) => "--\{name}"
  FlagInfo(short=Some(short), ..) | OptionInfo(short=Some(short), ..) => "-\{short}"
  _ => arg.name
}
```

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1): "No findings; approved. `height_ge` is equivalent: private nodes start at height 1 and all recalculation paths preserve `height >= 1`... Argparse retains long-before-short priority; `_` identically covers unlabeled Flag/Option and PositionalInfo."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean, `moon fmt` applied, `moon info` no `.mbti` changes
- `moon test`: 6715 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)