### PR TITLE
Optimize String find and rev_find with SIMD

### DIFF
--- a/builtin/simd.mbt
+++ b/builtin/simd.mbt
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The 128-bit vector operations used by the SIMD byte scanners in
-// `bytes_find.mbt`. `builtin` cannot import `moonbitlang/core/v128` (that would
-// be a cycle), so the few ops the scanners need are hosted here directly.
+// The 128-bit vector operations used by the SIMD byte and UTF-16 scanners in
+// `bytes_find.mbt` and `string_find_code_unit.mbt`. `builtin` cannot import
+// `moonbitlang/core/v128` (that would be a cycle), so the few ops the scanners
+// need are hosted here directly.
 //
 // Scanner-only operations are gated to the linear-memory backends that use
 // them. `v128_make` and `v128_load` also support aligned bitstring extraction,
@@ -40,6 +41,14 @@ fn i8x16_splat(value : Byte) -> V128 {
 }
 
 ///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i16x8_splat")
+fn i16x8_splat(value : UInt16) -> V128 {
+  let lane = value.to_uint64() * (0x0001000100010001 : UInt64)
+  v128_make(lane, lane)
+}
+
+///|
 #borrow(bytes)
 #intrinsic("%v128.v128_load")
 fn v128_load(bytes : FixedArray[Byte], offset : Int) -> V128 {
@@ -47,6 +56,26 @@ fn v128_load(bytes : FixedArray[Byte], offset : Int) -> V128 {
     fixedarray_read_uint64_le(bytes, offset),
     fixedarray_read_uint64_le(bytes, offset + 8),
   )
+}
+
+///|
+// Loads eight consecutive UTF-16 code units beginning at `offset`. The caller
+// must ensure `offset + 8 <= str.length()`.
+#borrow(str)
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.v128_load_i16x8")
+fn v128_load_i16x8(str : String, offset : Int) -> V128 {
+  let lo = for i in 0..<4; word = (0 : UInt64) {
+    continue word | (str.unsafe_get(offset + i).to_uint64() << (16 * i))
+  } nobreak {
+    word
+  }
+  let hi = for i in 0..<4; word = (0 : UInt64) {
+    continue word | (str.unsafe_get(offset + 4 + i).to_uint64() << (16 * i))
+  } nobreak {
+    word
+  }
+  v128_make(lo, hi)
 }
 
 ///|
@@ -68,9 +97,26 @@ fn i8x16_eq(a : V128, b : V128) -> V128 {
 
 ///|
 #cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i16x8_eq")
+fn i16x8_eq(a : V128, b : V128) -> V128 {
+  v128_make(
+    u64_u16_eq_mask(v128_lo(a), v128_lo(b)),
+    u64_u16_eq_mask(v128_hi(a), v128_hi(b)),
+  )
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
 #intrinsic("%v128.i8x16_bitmask")
 fn i8x16_bitmask(value : V128) -> Int {
   u64_high_bits(v128_lo(value)) | (u64_high_bits(v128_hi(value)) << 8)
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+#intrinsic("%v128.i16x8_bitmask")
+fn i16x8_bitmask(value : V128) -> Int {
+  u64_u16_high_bits(v128_lo(value)) | (u64_u16_high_bits(v128_hi(value)) << 4)
 }
 
 ///|
@@ -92,12 +138,43 @@ fn u64_byte_eq_mask(a : UInt64, b : UInt64) -> UInt64 {
 }
 
 ///|
+// Per-lane equality mask over the four 16-bit lanes of a `UInt64`: each lane
+// becomes `0xFFFF` when the operands' lanes match, `0x0000` otherwise.
+#cfg(any(target="native", target="wasm"))
+fn u64_u16_eq_mask(a : UInt64, b : UInt64) -> UInt64 {
+  for i in 0..<4; result = (0 : UInt64) {
+    let shift = 16 * i
+    let mask = if ((a >> shift) & 0xFFFF) == ((b >> shift) & 0xFFFF) {
+      (0xFFFF : UInt64)
+    } else {
+      0
+    }
+    continue result | (mask << shift)
+  } nobreak {
+    result
+  }
+}
+
+///|
 // Gathers the high bit (bit 7) of each of the eight bytes of a `UInt64` into
 // the low eight bits of an `Int`.
 #cfg(any(target="native", target="wasm"))
 fn u64_high_bits(value : UInt64) -> Int {
   for i in 0..<8; result = 0 {
     let bit = ((value >> (8 * i + 7)) & 1).to_int()
+    continue result | (bit << i)
+  } nobreak {
+    result
+  }
+}
+
+///|
+// Gathers the high bit (bit 15) of each of the four 16-bit lanes of a `UInt64`
+// into the low four bits of an `Int`.
+#cfg(any(target="native", target="wasm"))
+fn u64_u16_high_bits(value : UInt64) -> Int {
+  for i in 0..<4; result = 0 {
+    let bit = ((value >> (16 * i + 15)) & 1).to_int()
     continue result | (bit << i)
   } nobreak {
     result

--- a/builtin/string_find_code_unit.mbt
+++ b/builtin/string_find_code_unit.mbt
@@ -1,0 +1,174 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+// Convert view-relative bounds to backing-string offsets before scanning.
+fn find_code_unit_from_view(
+  target : StringView,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  let target_start = target.start_offset()
+  let found = find_code_unit_from_string(
+    target.data(),
+    target_start + start,
+    target_start + end,
+    code,
+  )
+  if found < 0 {
+    -1
+  } else {
+    found - target_start
+  }
+}
+
+///|
+// Convert view-relative bounds to backing-string offsets before reverse
+// scanning.
+fn rev_find_code_unit_from_view(
+  target : StringView,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  let target_start = target.start_offset()
+  let found = rev_find_code_unit_from_string(
+    target.data(),
+    target_start + start,
+    target_start + end,
+    code,
+  )
+  if found < 0 {
+    -1
+  } else {
+    found - target_start
+  }
+}
+
+///|
+// The caller must ensure `0 <= start <= end <= data.length()`.
+#inline
+fn find_code_unit_scalar(
+  data : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  for pos in start..<end {
+    if data.unsafe_get(pos) == code {
+      break pos
+    }
+  } nobreak {
+    -1
+  }
+}
+
+///|
+// The caller must ensure `0 <= start <= end <= data.length()`.
+#inline
+fn rev_find_code_unit_scalar(
+  data : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  for pos = end - 1; pos >= start; {
+    if data.unsafe_get(pos) == code {
+      break pos
+    }
+    continue pos - 1
+  } nobreak {
+    -1
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+fn find_code_unit_from_string(
+  data : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  find_code_unit_scalar(data, start, end, code)
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+fn rev_find_code_unit_from_string(
+  data : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  rev_find_code_unit_scalar(data, start, end, code)
+}
+
+///|
+// SIMD code-unit scanner for linear-memory backends. The vector loop scans
+// eight UTF-16 code units at a time, then the scalar tail handles the remainder.
+#cfg(any(target="native", target="wasm"))
+fn find_code_unit_from_string(
+  data : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  guard start < end else { return -1 }
+  if data.unsafe_get(start) == code {
+    return start
+  }
+  let code_v = i16x8_splat(code)
+  let tail_start = for pos = start; pos + 8 <= end; {
+    let mask = i16x8_bitmask(i16x8_eq(v128_load_i16x8(data, pos), code_v))
+    if mask != 0 {
+      return pos + mask.ctz()
+    }
+    continue pos + 8
+  } nobreak {
+    pos
+  }
+  find_code_unit_scalar(data, tail_start, end, code)
+}
+
+///|
+// SIMD reverse code-unit scanner for linear-memory backends. It scans
+// eight-code-unit chunks from the end and returns the highest matching offset.
+#cfg(any(target="native", target="wasm"))
+fn rev_find_code_unit_from_string(
+  data : String,
+  start : Int,
+  end : Int,
+  code : UInt16,
+) -> Int {
+  guard start < end else { return -1 }
+  if data.unsafe_get(end - 1) == code {
+    return end - 1
+  }
+  let code_v = i16x8_splat(code)
+  let head_end = for pos = end; pos - 8 >= start; {
+    let chunk_start = pos - 8
+    let mask = i16x8_bitmask(
+      i16x8_eq(v128_load_i16x8(data, chunk_start), code_v),
+    )
+    if mask != 0 {
+      return chunk_start + 31 - mask.clz()
+    }
+    continue chunk_start
+  } nobreak {
+    pos
+  }
+  rev_find_code_unit_scalar(data, start, head_end, code)
+}

--- a/builtin/string_find_code_unit.mbt
+++ b/builtin/string_find_code_unit.mbt
@@ -172,3 +172,342 @@ fn rev_find_code_unit_from_string(
   }
   rev_find_code_unit_scalar(data, start, head_end, code)
 }
+
+///|
+// Finds a multi-code-unit pattern by scanning candidate positions where both
+// the first and last code units match, then checking only the middle range.
+// The caller must ensure `2 <= pattern.length() <= target.length()`.
+fn find_by_two_anchors(target : StringView, pattern : StringView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
+  let last_offset = pattern_len - 1
+  let candidate_end = target_start + target_len - pattern_len + 1
+  let first = pattern.unsafe_get(0)
+  let last = pattern.unsafe_get(last_offset)
+  let middle_len = last_offset - 1
+  for pos = target_start, failures = 0; pos < candidate_end; {
+    let found = find_two_anchor_candidate_from_string(
+      target.data(),
+      pos,
+      candidate_end,
+      first,
+      last_offset,
+      last,
+    )
+    if found < 0 {
+      break None
+    }
+    if string_ranges_equal(
+        target.data(),
+        found + 1,
+        pattern.data(),
+        pattern_start + 1,
+        middle_len,
+      ) {
+      break Some(found - target_start)
+    }
+    let failures = failures + 1
+    let scanned = found - target_start
+    if two_anchor_should_fallback(failures, scanned) {
+      break find_pattern_scalar_from(target, pattern, scanned + 1)
+    }
+    continue found + 1, failures
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Finds the last multi-code-unit pattern occurrence using the same two-anchor
+// prefilter as the forward search. Candidate positions are scanned backwards.
+// The caller must ensure `2 <= pattern.length() <= target.length()`.
+fn rev_find_by_two_anchors(target : StringView, pattern : StringView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  let target_start = target.start_offset()
+  let pattern_start = pattern.start_offset()
+  let last_offset = pattern_len - 1
+  let first = pattern.unsafe_get(0)
+  let last = pattern.unsafe_get(last_offset)
+  let middle_len = last_offset - 1
+  let last_candidate = target_len - pattern_len
+  for candidate_end = target_start + last_candidate + 1, failures = 0; candidate_end >
+     target_start; {
+    let found = rev_find_two_anchor_candidate_from_string(
+      target.data(),
+      target_start,
+      candidate_end,
+      first,
+      last_offset,
+      last,
+    )
+    if found < 0 {
+      break None
+    }
+    if string_ranges_equal(
+        target.data(),
+        found + 1,
+        pattern.data(),
+        pattern_start + 1,
+        middle_len,
+      ) {
+      break Some(found - target_start)
+    }
+    let candidate = found - target_start
+    let failures = failures + 1
+    let scanned = last_candidate - candidate
+    if two_anchor_should_fallback(failures, scanned) {
+      break rev_find_pattern_scalar_before(target, pattern, candidate)
+    }
+    continue found, failures
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Dense first/last-anchor matches make repeated SIMD candidate scans more
+// expensive than direct comparison. Cut over after enough false candidates,
+// following the guarded-scanner strategy used by Bytes search.
+#inline
+fn two_anchor_should_fallback(failures : Int, scanned : Int) -> Bool {
+  failures > 64 || failures > 4 + scanned / 8
+}
+
+///|
+// Direct forward fallback used after the two-anchor filter encounters dense
+// false positives. It checks the middle first because the cutover has already
+// established that first/last matches are not selective. `start` is relative
+// to `target`.
+fn find_pattern_scalar_from(
+  target : StringView,
+  pattern : StringView,
+  start : Int,
+) -> Int? {
+  let pattern_len = pattern.length()
+  let last_offset = pattern_len - 1
+  let first = pattern.unsafe_get(0)
+  let last = pattern.unsafe_get(last_offset)
+  let last_candidate = target.length() - pattern_len
+  for candidate in start..<=last_candidate {
+    let middle_matches = for i in 1..<last_offset {
+      if target.unsafe_get(candidate + i) != pattern.unsafe_get(i) {
+        break false
+      }
+    } nobreak {
+      true
+    }
+    if middle_matches &&
+      target.unsafe_get(candidate) == first &&
+      target.unsafe_get(candidate + last_offset) == last {
+      break Some(candidate)
+    }
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Direct reverse fallback used after the two-anchor filter encounters dense
+// false positives. It checks the middle first because the cutover has already
+// established that first/last matches are not selective. `candidate_end` is
+// target-relative and exclusive.
+fn rev_find_pattern_scalar_before(
+  target : StringView,
+  pattern : StringView,
+  candidate_end : Int,
+) -> Int? {
+  guard candidate_end > 0 else { return None }
+  let pattern_len = pattern.length()
+  let last_offset = pattern_len - 1
+  let first = pattern.unsafe_get(0)
+  let last = pattern.unsafe_get(last_offset)
+  for candidate = candidate_end - 1; candidate >= 0; {
+    let middle_matches = for i in 1..<last_offset {
+      if target.unsafe_get(candidate + i) != pattern.unsafe_get(i) {
+        break false
+      }
+    } nobreak {
+      true
+    }
+    if middle_matches &&
+      target.unsafe_get(candidate) == first &&
+      target.unsafe_get(candidate + last_offset) == last {
+      break Some(candidate)
+    }
+    continue candidate - 1
+  } nobreak {
+    None
+  }
+}
+
+///|
+// Compares two raw UTF-16 ranges. The caller must ensure both ranges are in
+// bounds; using backing strings directly also permits isolated surrogate code
+// units without constructing intermediate StringViews.
+#inline
+fn string_ranges_equal(
+  left : String,
+  left_start : Int,
+  right : String,
+  right_start : Int,
+  length : Int,
+) -> Bool {
+  for i in 0..<length {
+    if left.unsafe_get(left_start + i) != right.unsafe_get(right_start + i) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+// Scalar first/last-code-unit candidate scanner.
+#inline
+fn find_two_anchor_candidate_scalar(
+  data : String,
+  start : Int,
+  candidate_end : Int,
+  first : UInt16,
+  last_offset : Int,
+  last : UInt16,
+) -> Int {
+  for pos in start..<candidate_end {
+    if data.unsafe_get(pos) == first &&
+      data.unsafe_get(pos + last_offset) == last {
+      break pos
+    }
+  } nobreak {
+    -1
+  }
+}
+
+///|
+// Scalar reverse first/last-code-unit candidate scanner.
+#inline
+fn rev_find_two_anchor_candidate_scalar(
+  data : String,
+  start : Int,
+  candidate_end : Int,
+  first : UInt16,
+  last_offset : Int,
+  last : UInt16,
+) -> Int {
+  for pos = candidate_end - 1; pos >= start; {
+    if data.unsafe_get(pos) == first &&
+      data.unsafe_get(pos + last_offset) == last {
+      break pos
+    }
+    continue pos - 1
+  } nobreak {
+    -1
+  }
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+fn find_two_anchor_candidate_from_string(
+  data : String,
+  start : Int,
+  candidate_end : Int,
+  first : UInt16,
+  last_offset : Int,
+  last : UInt16,
+) -> Int {
+  find_two_anchor_candidate_scalar(
+    data, start, candidate_end, first, last_offset, last,
+  )
+}
+
+///|
+#cfg(not(any(target="native", target="wasm")))
+fn rev_find_two_anchor_candidate_from_string(
+  data : String,
+  start : Int,
+  candidate_end : Int,
+  first : UInt16,
+  last_offset : Int,
+  last : UInt16,
+) -> Int {
+  rev_find_two_anchor_candidate_scalar(
+    data, start, candidate_end, first, last_offset, last,
+  )
+}
+
+///|
+// SIMD first/last-code-unit prefilter. Eight candidate positions are checked
+// per iteration and the middle range is left to the caller for verification.
+#cfg(any(target="native", target="wasm"))
+fn find_two_anchor_candidate_from_string(
+  data : String,
+  start : Int,
+  candidate_end : Int,
+  first : UInt16,
+  last_offset : Int,
+  last : UInt16,
+) -> Int {
+  guard start < candidate_end else { return -1 }
+  if data.unsafe_get(start) == first &&
+    data.unsafe_get(start + last_offset) == last {
+    return start
+  }
+  let first_v = i16x8_splat(first)
+  let last_v = i16x8_splat(last)
+  let tail_start = for pos = start; pos + 8 <= candidate_end; {
+    let mask = v128_and(
+      i16x8_eq(v128_load_i16x8(data, pos), first_v),
+      i16x8_eq(v128_load_i16x8(data, pos + last_offset), last_v),
+    )
+    let bits = i16x8_bitmask(mask)
+    if bits != 0 {
+      return pos + bits.ctz()
+    }
+    continue pos + 8
+  } nobreak {
+    pos
+  }
+  find_two_anchor_candidate_scalar(
+    data, tail_start, candidate_end, first, last_offset, last,
+  )
+}
+
+///|
+// SIMD reverse first/last-code-unit prefilter. It returns the highest matching
+// candidate position from each eight-lane block.
+#cfg(any(target="native", target="wasm"))
+fn rev_find_two_anchor_candidate_from_string(
+  data : String,
+  start : Int,
+  candidate_end : Int,
+  first : UInt16,
+  last_offset : Int,
+  last : UInt16,
+) -> Int {
+  guard start < candidate_end else { return -1 }
+  let final_candidate = candidate_end - 1
+  if data.unsafe_get(final_candidate) == first &&
+    data.unsafe_get(final_candidate + last_offset) == last {
+    return final_candidate
+  }
+  let first_v = i16x8_splat(first)
+  let last_v = i16x8_splat(last)
+  let head_end = for pos = candidate_end; pos - 8 >= start; {
+    let chunk_start = pos - 8
+    let mask = v128_and(
+      i16x8_eq(v128_load_i16x8(data, chunk_start), first_v),
+      i16x8_eq(v128_load_i16x8(data, chunk_start + last_offset), last_v),
+    )
+    let bits = i16x8_bitmask(mask)
+    if bits != 0 {
+      return chunk_start + 31 - bits.clz()
+    }
+    continue chunk_start
+  } nobreak {
+    pos
+  }
+  rev_find_two_anchor_candidate_scalar(
+    data, start, head_end, first, last_offset, last,
+  )
+}

--- a/builtin/string_find_code_unit_bench_test.mbt
+++ b/builtin/string_find_code_unit_bench_test.mbt
@@ -79,3 +79,52 @@ test "bench StringView rev_find one code unit absent n=256" (it : @bench.T) {
   let view = str[1:257]
   it.bench(() => it.keep(view.rev_find("z")))
 }
+
+///|
+test "bench find two anchors absent n=256" (it : @bench.T) {
+  let str = String::make(256, 'a')
+  it.bench(() => it.keep(str.find("az")))
+}
+
+///|
+test "bench find two anchors present@end n=256" (it : @bench.T) {
+  let str = String::make(255, 'a') + "z"
+  it.bench(() => it.keep(str.find("az")))
+}
+
+///|
+test "bench find two anchors dense false positives n=256" (it : @bench.T) {
+  let str = String::make(256, 'a')
+  it.bench(() => it.keep(str.find("abaa")))
+}
+
+///|
+test "bench find two anchors long absent n=256" (it : @bench.T) {
+  let str = String::make(256, 'a')
+  it.bench(() => it.keep(str.find("zaaaaaaaaaaaaaaz")))
+}
+
+///|
+test "bench rev_find two anchors absent n=256" (it : @bench.T) {
+  let str = String::make(256, 'a')
+  it.bench(() => it.keep(str.rev_find("za")))
+}
+
+///|
+test "bench rev_find two anchors present@start n=256" (it : @bench.T) {
+  let str = "z" + String::make(255, 'a')
+  it.bench(() => it.keep(str.rev_find("za")))
+}
+
+///|
+test "bench rev_find two anchors dense false positives n=256" (it : @bench.T) {
+  let str = String::make(256, 'a')
+  it.bench(() => it.keep(str.rev_find("abaa")))
+}
+
+///|
+test "bench StringView find two anchors absent n=256" (it : @bench.T) {
+  let str = "x" + String::make(256, 'a') + "y"
+  let view = str[1:257]
+  it.bench(() => it.keep(view.find("az")))
+}

--- a/builtin/string_find_code_unit_bench_test.mbt
+++ b/builtin/string_find_code_unit_bench_test.mbt
@@ -1,0 +1,81 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "bench find one code unit absent n=4" (it : @bench.T) {
+  let str = String::make(4, 'a')
+  it.bench(() => it.keep(str.find("z")))
+}
+
+///|
+test "bench find one code unit absent n=8" (it : @bench.T) {
+  let str = String::make(8, 'a')
+  it.bench(() => it.keep(str.find("z")))
+}
+
+///|
+test "bench find one code unit present@0 n=8" (it : @bench.T) {
+  let str = String::make(8, 'a')
+  it.bench(() => it.keep(str.find("a")))
+}
+
+///|
+test "bench find one code unit absent n=64" (it : @bench.T) {
+  let str = String::make(64, 'a')
+  it.bench(() => it.keep(str.find("z")))
+}
+
+///|
+test "bench find one code unit absent n=256" (it : @bench.T) {
+  let str = String::make(256, 'a')
+  it.bench(() => it.keep(str.find("z")))
+}
+
+///|
+test "bench find one code unit present@end n=256" (it : @bench.T) {
+  let str = String::make(255, 'a') + "z"
+  it.bench(() => it.keep(str.find("z")))
+}
+
+///|
+test "bench rev_find one code unit absent n=256" (it : @bench.T) {
+  let str = String::make(256, 'a')
+  it.bench(() => it.keep(str.rev_find("z")))
+}
+
+///|
+test "bench rev_find one code unit present@start n=256" (it : @bench.T) {
+  let str = "z" + String::make(255, 'a')
+  it.bench(() => it.keep(str.rev_find("z")))
+}
+
+///|
+test "bench rev_find one code unit present@end n=8" (it : @bench.T) {
+  let str = String::make(7, 'a') + "z"
+  it.bench(() => it.keep(str.rev_find("z")))
+}
+
+///|
+test "bench StringView find one code unit absent n=256" (it : @bench.T) {
+  let str = "x" + String::make(256, 'a') + "y"
+  let view = str[1:257]
+  it.bench(() => it.keep(view.find("z")))
+}
+
+///|
+test "bench StringView rev_find one code unit absent n=256" (it : @bench.T) {
+  let str = "x" + String::make(256, 'a') + "y"
+  let view = str[1:257]
+  it.bench(() => it.keep(view.rev_find("z")))
+}

--- a/builtin/string_find_code_unit_test.mbt
+++ b/builtin/string_find_code_unit_test.mbt
@@ -1,0 +1,84 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "find one code unit across SIMD blocks and view bounds" {
+  let str = "01234567abcdefghZ"
+  debug_inspect(str.find("0"), content="Some(0)")
+  debug_inspect(str.find("7"), content="Some(7)")
+  debug_inspect(str.find("a"), content="Some(8)")
+  debug_inspect(str.find("h"), content="Some(15)")
+  debug_inspect(str.find("Z"), content="Some(16)")
+  debug_inspect(str.find("x"), content="None")
+  let view = ("x" + str + "y")[1:18]
+  debug_inspect(view.find("x"), content="None")
+  debug_inspect(view.find("a"), content="Some(8)")
+  debug_inspect(view.find("Z"), content="Some(16)")
+  debug_inspect(view.find("y"), content="None")
+}
+
+///|
+test "rev_find one code unit across SIMD blocks and view bounds" {
+  let str = "01234567abcdefghZ"
+  debug_inspect(str.rev_find("0"), content="Some(0)")
+  debug_inspect(str.rev_find("7"), content="Some(7)")
+  debug_inspect(str.rev_find("a"), content="Some(8)")
+  debug_inspect(str.rev_find("h"), content="Some(15)")
+  debug_inspect(str.rev_find("Z"), content="Some(16)")
+  debug_inspect(str.rev_find("x"), content="None")
+  let view = ("x" + str + "y")[1:18]
+  debug_inspect(view.rev_find("x"), content="None")
+  debug_inspect(view.rev_find("a"), content="Some(8)")
+  debug_inspect(view.rev_find("Z"), content="Some(16)")
+  debug_inspect(view.rev_find("y"), content="None")
+}
+
+///|
+test "find and rev_find isolated surrogate code units" {
+  let leading = String::from_array([(0xD800).unsafe_to_char()])
+  let str = "01234567" + leading + "abcdefgh" + leading
+  debug_inspect(str.find(leading), content="Some(8)")
+  debug_inspect(str.rev_find(leading), content="Some(17)")
+}
+
+///|
+test "one-code-unit find agrees with scalar search for every view range" {
+  let str = "abacabadabacabaeabacabadabacaba"
+  for start in 0..<=str.length() {
+    for end in start..<=str.length() {
+      let view = str[start:end]
+      for needle in "abcdez" {
+        let needle_str = String::make(1, needle)
+        let code = needle_str.unsafe_get(0)
+        let expected = for i in 0..<view.length() {
+          if view.unsafe_get(i) == code {
+            break Some(i)
+          }
+        } nobreak {
+          None
+        }
+        let expected_rev = for i = view.length() - 1; i >= 0; {
+          if view.unsafe_get(i) == code {
+            break Some(i)
+          }
+          continue i - 1
+        } nobreak {
+          None
+        }
+        assert_eq(view.find(needle_str), expected)
+        assert_eq(view.rev_find(needle_str), expected_rev)
+      }
+    }
+  }
+}

--- a/builtin/string_find_code_unit_test.mbt
+++ b/builtin/string_find_code_unit_test.mbt
@@ -13,6 +13,59 @@
 // limitations under the License.
 
 ///|
+fn scalar_find_for_test(target : StringView, pattern : StringView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  if pattern_len == 0 {
+    return Some(0)
+  }
+  if pattern_len > target_len {
+    return None
+  }
+  for pos in 0..<=(target_len - pattern_len) {
+    let matches = for i in 0..<pattern_len {
+      if target.unsafe_get(pos + i) != pattern.unsafe_get(i) {
+        break false
+      }
+    } nobreak {
+      true
+    }
+    if matches {
+      break Some(pos)
+    }
+  } nobreak {
+    None
+  }
+}
+
+///|
+fn scalar_rev_find_for_test(target : StringView, pattern : StringView) -> Int? {
+  let target_len = target.length()
+  let pattern_len = pattern.length()
+  if pattern_len == 0 {
+    return Some(target_len)
+  }
+  if pattern_len > target_len {
+    return None
+  }
+  for pos = target_len - pattern_len; pos >= 0; {
+    let matches = for i in 0..<pattern_len {
+      if target.unsafe_get(pos + i) != pattern.unsafe_get(i) {
+        break false
+      }
+    } nobreak {
+      true
+    }
+    if matches {
+      break Some(pos)
+    }
+    continue pos - 1
+  } nobreak {
+    None
+  }
+}
+
+///|
 test "find one code unit across SIMD blocks and view bounds" {
   let str = "01234567abcdefghZ"
   debug_inspect(str.find("0"), content="Some(0)")
@@ -78,6 +131,50 @@ test "one-code-unit find agrees with scalar search for every view range" {
         }
         assert_eq(view.find(needle_str), expected)
         assert_eq(view.rev_find(needle_str), expected_rev)
+      }
+    }
+  }
+}
+
+///|
+test "two-anchor find and rev_find across SIMD blocks and view bounds" {
+  let str = "xxxxxxxabxxxxxxxab"
+  debug_inspect(str.find("ab"), content="Some(7)")
+  debug_inspect(str.rev_find("ab"), content="Some(16)")
+  debug_inspect(str.find("abx"), content="Some(7)")
+  debug_inspect(str.rev_find("abx"), content="Some(7)")
+  debug_inspect(str.find("abxxxxxxxab"), content="Some(7)")
+  debug_inspect(str.rev_find("abxxxxxxxab"), content="Some(7)")
+  debug_inspect(str.find("abaa"), content="None")
+  debug_inspect(str.rev_find("abaa"), content="None")
+  let view = ("q" + str + "r")[1:19]
+  debug_inspect(view.find("ab"), content="Some(7)")
+  debug_inspect(view.rev_find("ab"), content="Some(16)")
+  debug_inspect(view.find("qab"), content="None")
+  debug_inspect(view.rev_find("abr"), content="None")
+  debug_inspect(view.find(str + "x"), content="None")
+  debug_inspect(view.rev_find(str + "x"), content="None")
+  let forward_fallback = String::make(16, 'a') + "abaa"
+  debug_inspect(forward_fallback.find("abaa"), content="Some(16)")
+  let reverse_fallback = "abaa" + String::make(16, 'a')
+  debug_inspect(reverse_fallback.rev_find("abaa"), content="Some(0)")
+}
+
+///|
+test "multi-code-unit find agrees with scalar search for every view range" {
+  let str = "abacabadabacabaeabacabadabacaba"
+  let patterns = [
+    "aa", "ab", "ba", "aba", "caba", "abacabae", "abacabadabacabaeabac", "zz",
+  ]
+  for start in 0..<=str.length() {
+    for end in start..<=str.length() {
+      let view = str[start:end]
+      for pattern in patterns {
+        assert_eq(view.find(pattern), scalar_find_for_test(view, pattern))
+        assert_eq(
+          view.rev_find(pattern),
+          scalar_rev_find_for_test(view, pattern),
+        )
       }
     }
   }

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -16,7 +16,8 @@
 /// Returns the offset (charcode index) of the first occurrence of the given
 /// substring. If the substring is not found, it returns None.
 pub fn StringView::find(self : StringView, str : StringView) -> Int? {
-  match str.length() {
+  let pattern_len = str.length()
+  match pattern_len {
     0 => Some(0)
     1 => {
       let found = find_code_unit_from_view(
@@ -31,81 +32,15 @@ pub fn StringView::find(self : StringView, str : StringView) -> Int? {
         Some(found)
       }
     }
-    2..=4 => brute_force_find(self, str)
-    _ => boyer_moore_horspool_find(self, str)
+    _ =>
+      if pattern_len > self.length() {
+        None
+      } else {
+        find_by_two_anchors(self, str)
+      }
   }
   // TODO: When the pattern string is long (>= 256),
   // consider using Two-Way algorithm to ensure linear time complexity.
-}
-
-///|
-/// Simple brute force string search algorithm
-/// Scans the haystack left to right, matching the needle at each position
-fn brute_force_find(haystack : StringView, needle : StringView) -> Int? {
-  let haystack_len = haystack.length()
-  let needle_len = needle.length()
-  guard needle_len > 0 else { return Some(0) }
-  guard haystack_len >= needle_len else { return None }
-  let needle_first = needle.unsafe_get(0)
-  let forward_len = haystack_len - needle_len
-  for i in 0..<=forward_len {
-    if haystack.unsafe_get(i) != needle_first {
-      continue
-    }
-    // Check remaining charcodes for full match
-    for j in 1..<needle_len {
-      if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
-        break
-      }
-    } nobreak {
-      return Some(i)
-    }
-  }
-  None
-}
-
-///|
-/// Boyer-Moore-Horspool algorithm for string search (left to right)
-/// More efficient than brute force for longer patterns by using bad char heuristic
-fn boyer_moore_horspool_find(
-  haystack : StringView,
-  needle : StringView,
-) -> Int? {
-  let haystack_len = haystack.length()
-  let needle_len = needle.length()
-  guard needle_len > 0 else { return Some(0) }
-  guard haystack_len >= needle_len else { return None }
-  // Build skip table
-  let skip_table = FixedArray::make(1 << 8, needle_len)
-  for i in 0..<(needle_len - 1) {
-    skip_table[needle.unsafe_get(i).to_int() & 0xFF] = needle_len - 1 - i
-  }
-  for i = 0
-      i <= haystack_len - needle_len
-      i = i +
-        skip_table[haystack.unsafe_get(i + needle_len - 1).to_int() & 0xFF] {
-    // Check all charcodes for match at current position
-    for j in 0..<=(needle_len - 1) {
-      if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
-        break
-      }
-    } nobreak {
-      return Some(i)
-    }
-  }
-  None
-}
-
-///|
-test "boyer_moore_horspool_find edge cases" {
-  assert_true(boyer_moore_horspool_find("abc", "") == Some(0))
-  assert_true(boyer_moore_horspool_find("ab", "abcd") == None)
-}
-
-///|
-test "boyer_moore_horspool_rev_find edge cases" {
-  assert_true(boyer_moore_horspool_rev_find("abc", "") == Some(3))
-  assert_true(boyer_moore_horspool_rev_find("ab", "abcd") == None)
 }
 
 ///|
@@ -176,7 +111,8 @@ test "find_by" {
 /// Returns the offset of the last occurrence of the given substring. If the
 /// substring is not found, it returns None.
 pub fn StringView::rev_find(self : StringView, str : StringView) -> Int? {
-  match str.length() {
+  let pattern_len = str.length()
+  match pattern_len {
     0 => Some(self.length())
     1 => {
       let found = rev_find_code_unit_from_view(
@@ -191,66 +127,15 @@ pub fn StringView::rev_find(self : StringView, str : StringView) -> Int? {
         Some(found)
       }
     }
-    2..=4 => brute_force_rev_find(self, str)
-    _ => boyer_moore_horspool_rev_find(self, str)
+    _ =>
+      if pattern_len > self.length() {
+        None
+      } else {
+        rev_find_by_two_anchors(self, str)
+      }
   }
   // TODO: When the pattern string is long (>= 256),
   // consider using Two-Way algorithm to ensure linear time complexity.
-}
-
-///|
-/// Simple brute force string search algorithm
-/// Scans the haystack right to left, matching the needle at each position
-fn brute_force_rev_find(haystack : StringView, needle : StringView) -> Int? {
-  let haystack_len = haystack.length()
-  let needle_len = needle.length()
-  guard needle_len > 0 else { return Some(haystack_len) }
-  guard haystack_len >= needle_len else { return None }
-  let needle_first = needle.unsafe_get(0)
-  for i in (haystack_len - needle_len)>=..0 {
-    if haystack.unsafe_get(i) != needle_first {
-      continue
-    }
-    // Check remaining charcodes for full match
-    for j in 1..<needle_len {
-      if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
-        break
-      }
-    } nobreak {
-      return Some(i)
-    }
-  }
-  None
-}
-
-///|
-/// Boyer-Moore-Horspool algorithm for reverse string search (right to left)
-/// More efficient than brute force for longer patterns by using bad char heuristic
-fn boyer_moore_horspool_rev_find(
-  haystack : StringView,
-  needle : StringView,
-) -> Int? {
-  let haystack_len = haystack.length()
-  let needle_len = needle.length()
-  guard needle_len > 0 else { return Some(haystack_len) }
-  guard haystack_len >= needle_len else { return None }
-  let skip_table = FixedArray::make(1 << 8, needle_len)
-  for i in needle_len>..1 {
-    skip_table[needle.unsafe_get(i).to_int() & 0xFF] = i
-  }
-  for i = haystack_len - needle_len
-      i >= 0
-      i = i - skip_table[haystack.unsafe_get(i).to_int() & 0xFF] {
-    // Check all charcodes for match at current position
-    for j in 0..<needle_len {
-      if haystack.unsafe_get(i + j) != needle.unsafe_get(j) {
-        break
-      }
-    } nobreak {
-      return Some(i)
-    }
-  }
-  None
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -16,10 +16,23 @@
 /// Returns the offset (charcode index) of the first occurrence of the given
 /// substring. If the substring is not found, it returns None.
 pub fn StringView::find(self : StringView, str : StringView) -> Int? {
-  if str.length() <= 4 {
-    brute_force_find(self, str)
-  } else {
-    boyer_moore_horspool_find(self, str)
+  match str.length() {
+    0 => Some(0)
+    1 => {
+      let found = find_code_unit_from_view(
+        self,
+        0,
+        self.length(),
+        str.unsafe_get(0),
+      )
+      if found < 0 {
+        None
+      } else {
+        Some(found)
+      }
+    }
+    2..=4 => brute_force_find(self, str)
+    _ => boyer_moore_horspool_find(self, str)
   }
   // TODO: When the pattern string is long (>= 256),
   // consider using Two-Way algorithm to ensure linear time complexity.
@@ -163,10 +176,23 @@ test "find_by" {
 /// Returns the offset of the last occurrence of the given substring. If the
 /// substring is not found, it returns None.
 pub fn StringView::rev_find(self : StringView, str : StringView) -> Int? {
-  if str.length() <= 4 {
-    brute_force_rev_find(self, str)
-  } else {
-    boyer_moore_horspool_rev_find(self, str)
+  match str.length() {
+    0 => Some(self.length())
+    1 => {
+      let found = rev_find_code_unit_from_view(
+        self,
+        0,
+        self.length(),
+        str.unsafe_get(0),
+      )
+      if found < 0 {
+        None
+      } else {
+        Some(found)
+      }
+    }
+    2..=4 => brute_force_rev_find(self, str)
+    _ => boyer_moore_horspool_rev_find(self, str)
   }
   // TODO: When the pattern string is long (>= 256),
   // consider using Two-Way algorithm to ensure linear time complexity.


### PR DESCRIPTION
## Summary

- add forward and reverse SIMD scanners for single UTF-16 code units
- route one-code-unit `StringView::find` and `StringView::rev_find` through eight-lane batch comparison on native and wasm
- replace the brute-force/Boyer-Moore-Horspool multi-code-unit paths with a first/last-code-unit two-anchor prefilter mirroring Bytes search
- verify only the unchecked middle range after an anchor hit
- cut over to a middle-first scalar scan when anchor matches become dense
- retain scalar implementations under `#cfg(not(any(target="native", target="wasm")))`
- cover SIMD boundaries, sliced views, isolated surrogate code units, dense-anchor fallback, and exhaustive view ranges

## Motivation

String search previously compared one UTF-16 code unit at a time for one-unit patterns, then used either brute force or a freshly allocated 256-entry Boyer-Moore-Horspool skip table for longer patterns. Bytes search already avoids those costs by batching candidate comparisons and using first/last anchors.

This change mirrors that structure for String search using the V128 String load intrinsic and `i16x8` comparisons. It preserves raw UTF-16 code-unit semantics, including sliced views and isolated surrogate code units.

## Benchmark results

Native ARM64 release build. Times are per operation.

### Single-code-unit search

Compared with the exact `origin/main` base (`8ab300fb`).

| Case | Scalar | SIMD | Speedup |
| --- | ---: | ---: | ---: |
| find absent, 64 code units | 26.53 ns | 11.15 ns | 2.38x |
| find absent, 256 code units | 90.79 ns | 21.42 ns | 4.24x |
| find at end, 256 code units | 98.49 ns | 20.46 ns | 4.81x |
| rev_find absent, 256 code units | 94.30 ns | 19.06 ns | 4.95x |
| rev_find at start, 256 code units | 95.43 ns | 18.70 ns | 5.10x |
| sliced StringView find absent, 256 code units | 89.59 ns | 20.16 ns | 4.44x |
| sliced StringView rev_find absent, 256 code units | 91.10 ns | 18.46 ns | 4.93x |

### Two-anchor multi-code-unit search

Compared with the exact pre-two-anchor PR commit (`f231dde4`) using the identical benchmark file.

| Case | Previous | Two-anchor | Speedup |
| --- | ---: | ---: | ---: |
| find `az` absent, 256 code units | 179.79 ns | 31.72 ns | 5.67x |
| find `az` at end, 256 code units | 179.78 ns | 32.50 ns | 5.53x |
| find long pattern absent, 256 code units | 190.62 ns | 28.31 ns | 6.73x |
| rev_find `za` absent, 256 code units | 90.09 ns | 32.38 ns | 2.78x |
| rev_find `za` at start, 256 code units | 94.04 ns | 31.53 ns | 2.98x |
| sliced StringView find absent, 256 code units | 178.92 ns | 31.30 ns | 5.72x |
| find dense false positives, 256 code units | 177.16 ns | 163.01 ns | 1.09x |
| rev_find dense false positives, 256 code units | 184.99 ns | 168.28 ns | 1.10x |

## Validation

- `moon fmt`
- `moon info` (no interface changes)
- `moon check --target all -p builtin --warn-list +73`
- `moon check --target llvm -p builtin --warn-list +73`
- `moon test --target all -p builtin`
  - wasm: 2889/2889
  - wasm-gc: 2889/2889
  - js: 2877/2877
  - native: 2847/2847
- `moon test` (6719/6719 tests passed)
- `git diff --check`
