### PR TITLE
perf(sorted_set): merge-walk symmetric_difference without intermediate sets

### DIFF
--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -308,10 +308,37 @@ pub fn[V : Compare] SortedSet::symmetric_difference(
   self : SortedSet[V],
   other : SortedSet[V],
 ) -> SortedSet[V] {
-  // TODO: Optimize this function to avoid creating two intermediate sets.
-  let set1 = self.difference(other)
-  let set2 = other.difference(self)
-  set1.union(set2)
+  // Merge-walk both sets in ascending order, keeping elements present in
+  // exactly one of them; this avoids building intermediate sets.
+  let ret = new_sorted_set()
+  let it1 = self.iter()
+  let it2 = other.iter()
+  for a = it1.next(), b = it2.next() {
+    match (a, b) {
+      (None, None) => break
+      (Some(x), None) => {
+        ret.add(x)
+        continue it1.next(), None
+      }
+      (None, Some(y)) => {
+        ret.add(y)
+        continue None, it2.next()
+      }
+      (Some(x), Some(y)) => {
+        let c = x.compare(y)
+        if c < 0 {
+          ret.add(x)
+          continue it1.next(), b
+        } else if c > 0 {
+          ret.add(y)
+          continue a, it2.next()
+        } else {
+          continue it1.next(), it2.next()
+        }
+      }
+    }
+  }
+  ret
 }
 
 ///|

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -500,6 +500,36 @@ test "@sorted_set.symmetric_difference/empty" {
 }
 
 ///|
+test "@sorted_set.symmetric_difference/interleaved" {
+  // Alternating order between the two sets exercises both advance paths
+  // of the merge walk
+  let set1 = @sorted_set.from_array([1, 3, 5, 7, 9])
+  let set2 = @sorted_set.from_array([2, 3, 6, 7, 10])
+  let result = set1.symmetric_difference(set2)
+  debug_inspect(
+    result,
+    content=(
+      #|<SortedSet: [1, 2, 5, 6, 9, 10]>
+    ),
+  )
+}
+
+///|
+test "@sorted_set.symmetric_difference/proper subset" {
+  // One set strictly inside the other's range
+  let set1 = @sorted_set.from_array([1, 2, 3, 4, 5, 6, 7, 8])
+  let set2 = @sorted_set.from_array([3, 4])
+  let result = set1.symmetric_difference(set2)
+  debug_inspect(
+    result,
+    content=(
+      #|<SortedSet: [1, 2, 5, 6, 7, 8]>
+    ),
+  )
+  debug_inspect(result.length(), content="6")
+}
+
+///|
 test "@sorted_set.symmetric_difference/identical" {
   // Test with identical sets
   let set1 = @sorted_set.from_array([1, 2, 3, 4, 5])


### PR DESCRIPTION
Resolves the `TODO: Optimize this function to avoid creating two intermediate sets` in `sorted_set/set.mbt`.

## Before

`symmetric_difference` computed `self.difference(other)`, `other.difference(self)`, then `union`ed them — roughly five tree traversals, two full `copy_tree`s inside `union`, plus `union`'s O(n+m) size-recount pass, all to produce one result set.

## After

A single in-order merge walk over both sets' pull iterators (`SortedSet::iter` is an explicit-stack ascending traversal; `Iter::next` is a consuming pull), adding elements present in exactly one set. No intermediate sets, no tree copies, one pass. Size bookkeeping stays correct because the result is built through `add`.

Adds two test cases (interleaved elements, proper subset) to exercise both advance paths of the merge walk, alongside the existing basic/empty/identical coverage.

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1): "No findings. Approved. The merge correctly emits the smaller head, skips equal heads, and drains either tail, preserving exact symmetric-difference semantics. `iter` is ascending in-order; `next` consumes one pull. `add` maintains size correctly."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean, `moon fmt` applied, no `.mbti` changes
- `moon test`: 6717 passed, 0 failed (sorted_set 58/58, incl. 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)