### PR TITLE
cleanup: merge duplicate match arms, fix wrong docs and messages

### DIFF
--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -106,18 +106,10 @@ fn resolve_help_target(
 ///|
 fn split_long(arg : String) -> (StringView, String?) {
   let parts = [ for part in arg.split("=") => part ]
+  let name = parts[0].strip_prefix("--").unwrap_or(parts[0])
   if parts.length() <= 1 {
-    let name = match parts[0].strip_prefix("--") {
-      Some(view) => view
-      None => parts[0]
-    }
     (name, None)
   } else {
-    let name = match parts[0].strip_prefix("--") {
-      Some(view) => view
-      None => parts[0]
-    }
-    let value = parts[1:].join("=")
-    (name, Some(value))
+    (name, Some(parts[1:].join("=")))
   }
 }

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -174,7 +174,7 @@ pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {
 /// }
 /// ```
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_ instead")
+#alias(sub, deprecated="Use _[_:_] instead")
 pub fn Bytes::view(self : Bytes, start? : Int = 0, end? : Int) -> BytesView {
   let len = self.length()
   let end = match end {

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -36,9 +36,7 @@ pub enum Json {
 ///|
 pub impl Eq for Json with fn equal(a, b) {
   match (a, b) {
-    (Null, Null) => true
-    (True, True) => true
-    (False, False) => true
+    (Null, Null) | (True, True) | (False, False) => true
     (Number(a_num, ..), Number(b_num, ..)) => a_num == b_num
     (String(a_str), String(b_str)) => a_str == b_str
     (Array(a_arr), Array(b_arr)) => a_arr == b_arr

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -939,8 +939,12 @@ test "is_blank" {
 
 ///|
 /// Returns a new string with `padding_char`s prefixed to `self` if
-/// `self.char_length() < total_width`. The number of unicode characters in
-/// the returned string is `total_width` if padding is added.
+/// `self.length() < total_width`. The threshold and the pad count are
+/// measured in UTF-16 code units: `total_width - self.length()` copies of
+/// `padding_char` are prefixed. Characters outside the BMP count as two
+/// code units, so with such characters in `self` the result has fewer than
+/// `total_width` characters, and with a non-BMP `padding_char` the result's
+/// UTF-16 length exceeds `total_width`.
 pub fn StringView::pad_start(
   self : StringView,
   total_width : Int,
@@ -954,8 +958,12 @@ pub fn StringView::pad_start(
 
 ///|
 /// Returns a new string with `padding_char`s prefixed to `self` if
-/// `self.char_length() < total_width`. The number of unicode characters in
-/// the returned string is `total_width` if padding is added.
+/// `self.length() < total_width`. The threshold and the pad count are
+/// measured in UTF-16 code units: `total_width - self.length()` copies of
+/// `padding_char` are prefixed. Characters outside the BMP count as two
+/// code units, so with such characters in `self` the result has fewer than
+/// `total_width` characters, and with a non-BMP `padding_char` the result's
+/// UTF-16 length exceeds `total_width`.
 pub fn String::pad_start(
   self : String,
   total_width : Int,
@@ -994,8 +1002,12 @@ test "pad_start" {
 
 ///|
 /// Returns a new string with `padding_char`s appended to `self` if
-/// `self.length() < total_width`. The number of unicode characters in
-/// the returned string is `total_width` if padding is added.
+/// `self.length() < total_width`. The threshold and the pad count are
+/// measured in UTF-16 code units: `total_width - self.length()` copies of
+/// `padding_char` are appended. Characters outside the BMP count as two
+/// code units, so with such characters in `self` the result has fewer than
+/// `total_width` characters, and with a non-BMP `padding_char` the result's
+/// UTF-16 length exceeds `total_width`.
 pub fn StringView::pad_end(
   self : StringView,
   total_width : Int,
@@ -1009,8 +1021,12 @@ pub fn StringView::pad_end(
 
 ///|
 /// Returns a new string with `padding_char`s appended to `self` if
-/// `self.length() < total_width`. The number of unicode characters in
-/// the returned string is `total_width` if padding is added.
+/// `self.length() < total_width`. The threshold and the pad count are
+/// measured in UTF-16 code units: `total_width - self.length()` copies of
+/// `padding_char` are appended. Characters outside the BMP count as two
+/// code units, so with such characters in `self` the result has fewer than
+/// `total_width` characters, and with a non-BMP `padding_char` the result's
+/// UTF-16 length exceeds `total_width`.
 pub fn String::pad_end(
   self : String,
   total_width : Int,

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -96,7 +96,7 @@ pub fn[T] UninitializedArray::sub(
     Some(end) | (None with end = len) => end
   }
   guard start >= 0 && start <= end && end <= len else {
-    abort("View start index out of bounds")
+    abort("View index out of bounds")
   }
   ArrayView::make(self, start, end - start)
 }

--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -169,14 +169,8 @@ fn compact_lines(lines : Array[String]) -> Array[String] {
         // - arrays: [a, b]
         // - records/maps: { field: value, field: value }
         if first == "{" {
-          let s1 = match joined.strip_prefix(" ") {
-            Some(sv) => sv
-            None => joined
-          }
-          let inner = match s1.strip_suffix(" ") {
-            Some(sv) => sv
-            None => s1
-          }
+          let s1 = joined.strip_prefix(" ").unwrap_or(joined)
+          let inner = s1.strip_suffix(" ").unwrap_or(s1)
           if inner == "" {
             ["{}"]
           } else {

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -492,7 +492,7 @@ pub fn[A] Deque::insert(self : Deque[A], index : Int, value : A) -> Unit {
 pub fn[A] Deque::remove(self : Deque[A], index : Int) -> A {
   guard index >= 0 && index < self.length() else {
     abort(
-      "index out of bounds: the len is from 0 to \{self.length()} but the index is \{index}",
+      "index out of bounds: the len is \{self.length()} but the index is \{index}",
     )
   }
   let res = self[index]

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -356,8 +356,7 @@ fn[A : Compare] Node::push(self : Node[A], value : A, path : Path) -> Node[A] {
 pub fn[A] PriorityQueue::peek(self : PriorityQueue[A]) -> A? {
   match self.node {
     Empty => None
-    Leaf(a) => Some(a)
-    Branch(a, ..) => Some(a)
+    Leaf(a) | Branch(a, ..) => Some(a)
   }
 }
 

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -898,7 +898,7 @@ fn[A : Compare] SortedSet::split_bis(
 }
 
 ///|
-/// Get the height of set.
+/// Returns the number of elements in the set.
 #alias(size, deprecated)
 #inline
 pub fn[A] SortedSet::length(self : SortedSet[A]) -> Int {

--- a/immut/vector/tree_pop.mbt
+++ b/immut/vector/tree_pop.mbt
@@ -26,8 +26,7 @@ fn[A] Tree::last_leaf_elements(self : Tree[A]) -> FixedArray[A] {
 ///|
 fn[A] Tree::pop_rightmost_leaf(self : Tree[A], shift : Int) -> Tree[A] {
   match self {
-    Empty => Empty
-    Leaf(_) => Empty
+    Empty | Leaf(_) => Empty
     Node(children, _) => {
       let last_index = children.length() - 1
       let new_last = children[last_index].pop_rightmost_leaf(shift - NUM_BITS)

--- a/internal/regex_engine/automata/thread_set.mbt
+++ b/internal/regex_engine/automata/thread_set.mbt
@@ -161,8 +161,7 @@ fn ThreadSet::flat_map(
 ///|
 fn ThreadSet::find_first_match(self : ThreadSet) -> MarkSlotMap? {
   match self {
-    Empty => None
-    Node(i={ no_match: true }, ..) => None
+    Empty | Node(i={ no_match: true }, ..) => None
     Node(l=Empty, t=End(marks), ..) => Some(marks)
     Node(l~, t~, r~, ..) =>
       match l.find_first_match() {

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -732,8 +732,7 @@ pub fn[A, B] List::foldi(
 pub fn[A, B] List::zip(self : List[A], other : List[B]) -> List[(A, B)] {
   let res = for a = self, b = other, acc = Empty {
     match (a, b, acc) {
-      (Empty, _, acc) => break acc
-      (_, Empty, acc) => break acc
+      (Empty, _, acc) | (_, Empty, acc) => break acc
       (More(x, tail=xs), More(y, tail=ys), acc) =>
         continue xs, ys, More((x, y), tail=acc)
     }
@@ -1365,8 +1364,7 @@ pub fn[A] List::take(self : List[A], n : Int) -> List[A] {
         let dest = More(head, tail=Empty)
         for d = dest, t = tail, i = n - 1 {
           match (d, t, i) {
-            (_, Empty, _) => break
-            (_, _, 0) => break
+            (_, Empty, _) | (_, _, 0) => break
             (More(_) as dest, More(x, tail=xs), n) => {
               dest.tail = More(x, tail=Empty)
               continue dest.tail, xs, n - 1

--- a/math/algebraic_double_nonjs.mbt
+++ b/math/algebraic_double_nonjs.mbt
@@ -55,7 +55,7 @@ pub fn cbrt(x : Double) -> Double {
   let g = 3.57142857142857150787e-01 // 5/14      = 0x3FD6DB6D, 0xB6DB6DB7
   // mask the sign off, else a negative normal reads as subnormal below
   let hx = get_high_word(x).reinterpret_as_int() & 0x7fffffff
-  let sign = if x < 0.0 { true } else { false }
+  let sign = x < 0.0
   let x = abs(x)
   let t = if hx < 0x00100000 {
     let t : UInt64 = 0x43500000_00000000

--- a/sorted_map/invariant_wbtest.mbt
+++ b/sorted_map/invariant_wbtest.mbt
@@ -47,7 +47,7 @@ fn check_node(
       }
       let (lh, lc) = check_node(n.left, lower, Some(n.key))
       let (rh, rc) = check_node(n.right, Some(n.key), upper)
-      let true_height = 1 + max(lh, rh)
+      let true_height = 1 + lh.max(rh)
       if n.height != true_height {
         fail(
           "stale cached height at key \{n.key}: stored \{n.height}, actual \{true_height}",

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -552,7 +552,7 @@ fn[K, V] replace_root_with_min(
 
 ///|
 fn[K, V] Node::update_height(self : Node[K, V]) -> Unit {
-  self.height = 1 + max(height(self.left), height(self.right))
+  self.height = 1 + height(self.left).max(height(self.right))
 }
 
 ///|

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -24,15 +24,6 @@ impl[K : Eq, V] Eq for Node[K, V] with fn equal(self, other) {
 }
 
 ///|
-fn max(x : Int, y : Int) -> Int {
-  if x > y {
-    x
-  } else {
-    y
-  }
-}
-
-///|
 fn[K, V] height(node : Node[K, V]?) -> Int {
   match node {
     Some({ height, .. }) | (None with height = 0) => height

--- a/sorted_set/invariant_wbtest.mbt
+++ b/sorted_set/invariant_wbtest.mbt
@@ -49,7 +49,7 @@ fn check_node(
       }
       let (lh, lc) = check_node(n.left, lower, Some(n.value))
       let (rh, rc) = check_node(n.right, Some(n.value), upper)
-      let true_height = 1 + max(lh, rh)
+      let true_height = 1 + lh.max(rh)
       if n.height != true_height {
         fail(
           "stale cached height at value \{n.value}: stored \{n.height}, actual \{true_height}",

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -94,7 +94,7 @@ fn[V] new_node_update_height(
   left~ : Node[V]?,
   right~ : Node[V]?,
 ) -> Node[V] {
-  { value, left, right, height: max(height(left), height(right)) + 1 }
+  { value, left, right, height: height(left).max(height(right)) + 1 }
 }
 
 // Manipulations
@@ -725,7 +725,7 @@ fn[V] replace_root_with_min(root : Node[V], node : Node[V]) -> Node[V]? {
 
 ///|
 fn[V] Node::update_height(self : Node[V]) -> Unit {
-  self.height = 1 + max(height(self.left), height(self.right))
+  self.height = 1 + height(self.left).max(height(self.right))
 }
 
 ///|

--- a/sorted_set/utils.mbt
+++ b/sorted_set/utils.mbt
@@ -18,15 +18,6 @@ impl[V : Eq] Eq for Node[V] with fn equal(self, other) {
 }
 
 ///|
-fn max(x : Int, y : Int) -> Int {
-  if x > y {
-    x
-  } else {
-    y
-  }
-}
-
-///|
 fn[V] height(node : Node[V]?) -> Int {
   match node {
     Some({ height, .. }) | (None with height = 0) => height


### PR DESCRIPTION
Cleanup sweep from a repo-wide scan — all behavior-preserving simplifications plus doc/message corrections. 19 files, +44/−67.

## Simplifications

- `builtin/json`: `Eq for Json` merges `(Null, Null) | (True, True) | (False, False) => true`
- `list`: duplicate `break` arms merged in `zip` and the `take` loop
- `immut/priority_queue`: `Leaf(a) | Branch(a, ..) => Some(a)` in `peek`
- `immut/vector`: `Empty | Leaf(_) => Empty` in `pop_rightmost_leaf`
- `internal/regex_engine`: duplicate `None` arms merged in `find_first_match`
- `sorted_map`/`sorted_set`: local `max` helpers duplicating `Int::max` deleted; call sites use the method
- `argparse`: `split_long` computed `name` identically in both branches — hoisted to one `strip_prefix("--").unwrap_or(...)`
- `debug/printer`: two manual Option matches → `unwrap_or` (types align as `StringView`)
- `math`: `if x < 0.0 { true } else { false }` → `x < 0.0`

## Doc & message fixes

- **`pad_start`/`pad_end`** (builtin): docs claimed character-count semantics (`char_length()`); the implementation measures **UTF-16 code units**. Docs now describe the actual behavior, including both non-BMP consequences (non-BMP chars in `self` → fewer than `total_width` characters; non-BMP `padding_char` → UTF-16 length exceeds `total_width`).
- `immut/sorted_set`: `length`'s doc said "Get the height of set."
- `deque`: `remove`'s out-of-bounds message was copy-pasted from `insert` and named the inclusive bound `insert` accepts but `remove` doesn't.
- `builtin/bytesview`: deprecation hint was missing the closing bracket (`Use _[_:_ instead`).
- `builtin/uninitialized_array`: abort said "View start index out of bounds" for end violations too; now uses the generic message its siblings use.

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1) in two rounds. Round 1 approved all simplification hunks but rejected my pad_start/pad_end doc wording, correctly pointing out that a non-BMP `padding_char` keeps the *character* count at `total_width` while the UTF-16 length overshoots — the docs were reworded precisely. Round 2: "Approved; no findings. All four comments accurately match the implementations."

Signed-off-by: Codex CLI <codex@openai.com>

## Scope trim (2026-08-20)

Three debatable hunks from the original sweep were dropped to keep only clear wins: the `pretty_print` `info_size` 19→6 arm collapse (grouped unrelated variants such as `Tuple`/`Array` with literals by coincidental value — the flat table is easier to edit), the `remove_matches` `Empty`-into-`self` fold (a cleanup that needs a comment to justify its correctness isn't one), and the `translate` push-loop → comprehension change (pure loop-style churn). Codex CLI round 4 verified the reversions are byte-exact and only `find_first_match` remains changed in `thread_set.mbt`.

## Rebase (2026-08-20)

Rebased onto current main. One textual conflict (cbrt in `math`: main gained a sign-mask fix since — kept, with only this PR's boolean simplification applied) and two semantic conflicts (main's new `invariant_wbtest.mbt` files called the deleted local `max` helpers — migrated to `Int::max`). Codex CLI round 3 (`xhigh`) re-reviewed the rebased result fresh and signed off — see the review comment below.

## Validation

- `moon check` clean, `moon fmt` applied, no `.mbti` changes
- `moon test`: 6715 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

