### PR TITLE
fix(buffer): guard capacity doubling against Int overflow

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -41,15 +41,25 @@ struct Buffer {
 }
 
 ///|
-/// Expand the buffer size if capacity smaller than required space.
-fn Buffer::grow_if_necessary(self : Buffer, required : Int) -> Unit {
-  let start = if self.data.length() <= 0 { 1 } else { self.data.length() }
-  let enough_space = for space = start {
+/// Smallest capacity reached by repeatedly doubling `current` until it
+/// covers `required`. Doubling a capacity past 2^30 overflows Int (and can
+/// loop forever, e.g. 2^30 -> INT_MIN -> 0 -> 0); when that happens, fall
+/// back to exactly `required`.
+fn grow_capacity(current : Int, required : Int) -> Int {
+  for space = current {
     if space >= required {
       break space
     }
-    continue space * 2
+    let doubled = space * 2
+    continue if doubled > 0 { doubled } else { required }
   }
+}
+
+///|
+/// Expand the buffer size if capacity smaller than required space.
+fn Buffer::grow_if_necessary(self : Buffer, required : Int) -> Unit {
+  let start = if self.data.length() <= 0 { 1 } else { self.data.length() }
+  let enough_space = grow_capacity(start, required)
   if enough_space != self.data.length() {
     let new_data = FixedArray::make_and_blit(
       self.data,

--- a/buffer/grow_wbtest.mbt
+++ b/buffer/grow_wbtest.mbt
@@ -1,0 +1,31 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "grow_capacity doubles until the requirement is covered" {
+  inspect(grow_capacity(1, 100), content="128")
+  inspect(grow_capacity(3, 24), content="24")
+  inspect(grow_capacity(16, 16), content="16")
+  inspect(grow_capacity(16, 17), content="32")
+}
+
+///|
+test "grow_capacity survives Int overflow instead of looping forever" {
+  // 2^30 doubles to INT_MIN; the old loop then went 0 -> 0 -> ... forever.
+  let big = 1 << 30
+  inspect(grow_capacity(big, big + 1) == big + 1, content="true")
+  // A non-power-of-two start overflows to a negative value on the way up;
+  // the fallback allocates exactly the requirement.
+  inspect(grow_capacity(11, 1_500_000_000), content="1500000000")
+}


### PR DESCRIPTION
`Buffer::grow_if_necessary` doubled capacity until it covered the requirement. Once capacity passes 2³⁰, `space * 2` overflows `Int`:

- a **power-of-two** capacity wraps to `INT_MIN`, then sticks at `0 → 0 → ...` — writes needing more than ~1 GiB of buffer **hung forever**;
- a **non-power-of-two** capacity bounces through wrapped values and accidentally terminates on whatever positive value the wraparound lands on (e.g. growing from 11 toward 1.5 G allocated 1,610,612,736 via a negative intermediate).

## Fix

The capacity computation moves into a pure `grow_capacity(current, required)` helper that falls back to exactly `required` on the first overflowing doubling. Below the overflow threshold the doubling sequence is byte-for-byte unchanged; past it, the buffer allocates the exact requirement instead of hanging or trusting wraparound.

Whitebox tests (`buffer/grow_wbtest.mbt`) pin the normal doubling path and both overflow boundary cases — **without allocating memory**, so they're CI-safe.

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1) in two rounds. Round 1 rejected the initial version: it disproved my "identical capacity for all previously-terminating inputs" claim with the 11 → 1.5 G wraparound counterexample, confirmed the power-of-two hang (2³⁰ → INT_MIN → 0 → 0), audited that no other grow path in `buffer/` shares the bug, and demanded CI-safe tests via a pure helper. All applied. Round 2: "Approved. `grow_capacity` correctly detects overflowing doubles... the commit message accurately scopes the behavior difference."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean, `moon fmt` applied, no `.mbti` changes
- `moon test`: 6717 passed, 0 failed (buffer 98/98, incl. 2 new boundary tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)