### PR TITLE
perf(bigint): batch digits in to_string_radix for non-power-of-two radixes

### DIFF
--- a/bigint/bigint_default.mbt
+++ b/bigint/bigint_default.mbt
@@ -1109,29 +1109,61 @@ fn BigInt::to_string_radix(self : BigInt, radix : Int) -> String {
   match pow2_shift(radix) {
     Some(shift) => self.to_string_radix_pow2(shift)
     None => {
-      let is_negative = self.sign == Negative
-      let base = BigInt::from_int(radix)
-      let value = if is_negative { -self } else { self }
-      let digits = []
-      for v = value {
-        if v > zero {
-          let (q, r) = BigInt::grade_school_div(v, base)
-          digits.push(char_from_digit(r.to_int()))
-          continue q
-        } else {
-          break
+      // Same limb-by-limb conversion as the radix-10 path in to_string:
+      // convert to base chunk = radix^chunk_len using only Int64 division,
+      // then emit chunk_len digits per slot. This replaces one full BigInt
+      // division per output digit with one Int64 division per digit.
+      let radix64 = radix.to_int64()
+      // Largest radix^chunk_len such that (slot << RADIX_BIT_LEN) | limb
+      // still fits in Int64 (slots stay below 2^(63 - RADIX_BIT_LEN)).
+      let chunk_limit = 0x7FFF_FFFF_FFFF_FFFFL >> RADIX_BIT_LEN
+      let mut chunk = radix64
+      let mut chunk_len = 1
+      while chunk <= chunk_limit / radix64 {
+        chunk = chunk * radix64
+        chunk_len += 1
+      }
+      // Digits in radix >= 3 never exceed the bit count, so this bounds the
+      // number of slots.
+      let slots = self.len * RADIX_BIT_LEN / chunk_len + 2
+      let v = Array::make(slots, 0L)
+      let mut v_idx = 0
+      for i in self.len>..0 {
+        let mut x = self.limbs[i].to_int64()
+        for j in 0..<v_idx {
+          let y = (v[j] << RADIX_BIT_LEN) | x
+          x = y / chunk
+          v[j] = y % chunk
+        }
+        while x > 0L {
+          v[v_idx] = x % chunk
+          v_idx += 1
+          x /= chunk
         }
       }
-      let builder = StringBuilder(
-        size_hint=digits.length() + (if is_negative { 1 } else { 0 }),
-      )
-      if is_negative {
-        builder.write_char('-')
+      let cap = v_idx * chunk_len + 1 // +1 for an optional sign
+      let chars = FixedArray::make(cap, '0')
+      let mut pos = cap
+      // Lower slots each contribute exactly chunk_len digits, zero-padded.
+      for i in 0..<(v_idx - 1) {
+        let mut x = v[i]
+        for _ in 0..<chunk_len {
+          pos -= 1
+          chars[pos] = char_from_digit((x % radix64).to_int())
+          x /= radix64
+        }
       }
-      for i in digits.length()>..0 {
-        builder.write_char(digits[i])
+      // The most-significant slot is emitted without leading zeros; it is
+      // non-zero because self is non-zero.
+      for x = v[v_idx - 1]; x > 0L; x = x / radix64 {
+        pos -= 1
+        chars[pos] = char_from_digit((x % radix64).to_int())
       }
-      builder.to_string()
+      if self.sign == Negative {
+        pos -= 1
+        chars[pos] = '-'
+      }
+      String::from_array(chars[pos:])
     }
   }
 }

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1105,29 +1105,61 @@ fn BigInt::to_string_radix(self : BigInt, radix : Int) -> String {
   match pow2_shift(radix) {
     Some(shift) => self.to_string_radix_pow2(shift)
     None => {
-      let is_negative = self.sign == Negative
-      let base = BigInt::from_int(radix)
-      let value = if is_negative { -self } else { self }
-      let digits = []
-      for v = value {
-        if v > zero {
-          let (q, r) = BigInt::grade_school_div(v, base)
-          digits.push(char_from_digit(r.to_int()))
-          continue q
-        } else {
-          break
+      // Same limb-by-limb conversion as the radix-10 path in to_string:
+      // convert to base chunk = radix^chunk_len using only Int64 division,
+      // then emit chunk_len digits per slot. This replaces one full BigInt
+      // division per output digit with one Int64 division per digit.
+      let radix64 = radix.to_int64()
+      // Largest radix^chunk_len such that (slot << RADIX_BIT_LEN) | limb
+      // still fits in Int64 (slots stay below 2^(63 - RADIX_BIT_LEN)).
+      let chunk_limit = 0x7FFF_FFFF_FFFF_FFFFL >> RADIX_BIT_LEN
+      let mut chunk = radix64
+      let mut chunk_len = 1
+      while chunk <= chunk_limit / radix64 {
+        chunk = chunk * radix64
+        chunk_len += 1
+      }
+      // Digits in radix >= 3 never exceed the bit count, so this bounds the
+      // number of slots.
+      let slots = self.len * RADIX_BIT_LEN / chunk_len + 2
+      let v = Array::make(slots, 0L)
+      let mut v_idx = 0
+      for i in self.len>..0 {
+        let mut x = self.limbs[i].to_int64()
+        for j in 0..<v_idx {
+          let y = (v[j] << RADIX_BIT_LEN) | x
+          x = y / chunk
+          v[j] = y % chunk
+        }
+        while x > 0L {
+          v[v_idx] = x % chunk
+          v_idx += 1
+          x /= chunk
         }
       }
-      let builder = StringBuilder(
-        size_hint=digits.length() + (if is_negative { 1 } else { 0 }),
-      )
-      if is_negative {
-        builder.write_char('-')
+      let cap = v_idx * chunk_len + 1 // +1 for an optional sign
+      let chars = FixedArray::make(cap, '0')
+      let mut pos = cap
+      // Lower slots each contribute exactly chunk_len digits, zero-padded.
+      for i in 0..<(v_idx - 1) {
+        let mut x = v[i]
+        for _ in 0..<chunk_len {
+          pos -= 1
+          chars[pos] = char_from_digit((x % radix64).to_int())
+          x /= radix64
+        }
       }
-      for i in digits.length()>..0 {
-        builder.write_char(digits[i])
+      // The most-significant slot is emitted without leading zeros; it is
+      // non-zero because self is non-zero.
+      for x = v[v_idx - 1]; x > 0L; x = x / radix64 {
+        pos -= 1
+        chars[pos] = char_from_digit((x % radix64).to_int())
       }
-      builder.to_string()
+      if self.sign == Negative {
+        pos -= 1
+        chars[pos] = '-'
+      }
+      String::from_array(chars[pos:])
     }
   }
 }

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1370,3 +1370,31 @@ test "BigInt modpow negative base normalization" {
   // (-3)^3 = -27, -27 mod 10 = 3 (canonical non-negative)
   inspect((-3N).pow(3N, modulus=10N), content="3")
 }
+
+///|
+test "to_string non-power-of-two radixes round-trip and match known values" {
+  // known small values
+  inspect(255N.to_string(radix=3), content="100110")
+  inspect((-255N).to_string(radix=3), content="-100110")
+  inspect(35N.to_string(radix=36), content="z")
+  inspect(36N.to_string(radix=36), content="10")
+  inspect(6N.to_string(radix=6), content="10")
+  // round-trip large values through every non-power-of-two radix
+  let big = (@bigint.BigInt::from_string("123456789123456789") << 700) +
+    @bigint.BigInt::from_string("987654321987654321")
+  for radix in [3, 5, 6, 7, 11, 12, 15, 20, 33, 36] {
+    let s = big.to_string(radix~)
+    assert_eq(@bigint.BigInt::from_string(s, radix~), big)
+    let s_neg = (-big).to_string(radix~)
+    assert_eq(@bigint.BigInt::from_string(s_neg, radix~), -big)
+  }
+  // boundary around a chunk: radix 3 uses 19-digit chunks; exercise values
+  // spanning one and several slots
+  for e in [1, 18, 19, 20, 37, 38, 39] {
+    let p = @bigint.BigInt::from_string("3").pow(
+      @bigint.BigInt::from_string(e.to_string()),
+    )
+    assert_eq(@bigint.BigInt::from_string(p.to_string(radix=3), radix=3), p)
+    inspect(p.to_string(radix=3).length(), content=(e + 1).to_string())
+  }
+}

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1393,3 +1393,31 @@ test "BigInt modpow negative base normalization" {
   // (-3)^3 = -27, -27 mod 10 = 3 (canonical non-negative)
   inspect((-3N).pow(3N, modulus=10N), content="3")
 }
+
+///|
+test "to_string non-power-of-two radixes round-trip and match known values" {
+  // known small values
+  inspect(255N.to_string(radix=3), content="100110")
+  inspect((-255N).to_string(radix=3), content="-100110")
+  inspect(35N.to_string(radix=36), content="z")
+  inspect(36N.to_string(radix=36), content="10")
+  inspect(6N.to_string(radix=6), content="10")
+  // round-trip large values through every non-power-of-two radix
+  let big = (@bigint.BigInt::from_string("123456789123456789") << 700) +
+    @bigint.BigInt::from_string("987654321987654321")
+  for radix in [3, 5, 6, 7, 11, 12, 15, 20, 33, 36] {
+    let s = big.to_string(radix~)
+    assert_eq(@bigint.BigInt::from_string(s, radix~), big)
+    let s_neg = (-big).to_string(radix~)
+    assert_eq(@bigint.BigInt::from_string(s_neg, radix~), -big)
+  }
+  // boundary around a chunk: radix 3 uses 19-digit chunks; exercise values
+  // spanning one and several slots
+  for e in [1, 18, 19, 20, 37, 38, 39] {
+    let p = @bigint.BigInt::from_string("3").pow(
+      @bigint.BigInt::from_string(e.to_string()),
+    )
+    assert_eq(@bigint.BigInt::from_string(p.to_string(radix=3), radix=3), p)
+    inspect(p.to_string(radix=3).length(), content=(e + 1).to_string())
+  }
+}

--- a/bigint/to_string_radix_bench_test.mbt
+++ b/bigint/to_string_radix_bench_test.mbt
@@ -1,0 +1,38 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn radix_bench_value() -> @bigint.BigInt {
+  // ~4000 bits
+  (@bigint.BigInt::from_string("7") << 4000) +
+  @bigint.BigInt::from_string("12345678901234567890")
+}
+
+///|
+test "bench bigint to_string radix=7 (4000 bits)" (it : @bench.T) {
+  let v = radix_bench_value()
+  it.bench(fn() { it.keep(v.to_string(radix=7)) })
+}
+
+///|
+test "bench bigint to_string radix=36 (4000 bits)" (it : @bench.T) {
+  let v = radix_bench_value()
+  it.bench(fn() { it.keep(v.to_string(radix=36)) })
+}
+
+///|
+test "bench bigint to_string radix=10 reference (4000 bits)" (it : @bench.T) {
+  let v = radix_bench_value()
+  it.bench(fn() { it.keep(v.to_string()) })
+}


### PR DESCRIPTION
Closes #3827.

The generic radix path (radixes 3, 5, 6, 7, ... — anything not 10 or a power of two) extracted **one digit per full BigInt division** (`grade_school_div` per output digit — O(n²) overall). This PR generalizes the limb-by-limb algorithm the radix-10 path already uses: convert into base `chunk = radix^chunk_len` slots using only `Int64` arithmetic (with `chunk` the largest power keeping `(slot << RADIX_BIT_LEN) | limb` inside `Int64`), then emit `chunk_len` digits per slot into a pre-sized buffer. The `-self` magnitude copy for negative inputs is gone too — limbs are sign-magnitude and are read directly, as radix-10 already does.

## Benchmarks (native release, ~4000-bit value; committed)

| radix | before | after | |
|---|---|---|---|
| 7 | 1.28 ms | **83 µs** | ~15× |
| 36 | 762 µs | **95 µs** | ~8× |
| 10 (reference, unchanged) | ~105 µs | ~105 µs | now matched by all radixes |

## Tests

Known values for radixes 3/6/36 (incl. negatives), `from_string` round-trips for ten non-power-of-two radixes on a 700+ bit value (positive and negative), and radix-3 digit-length checks across the chunk boundaries (3^e for e ∈ {1, 18, 19, 20, 37, 38, 39} — 19 digits per chunk).

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1): "Approved; no findings" — including an explicit overflow-bound derivation (`y ≤ chunk·2³² − 2³² + 2³² − 1 < Int64.max`), slot-count and `pos`-underflow verification, sign-magnitude equivalence for negatives, and **an independent 7,650-case differential check across all 30 applicable radixes**.

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean, `moon fmt` applied, no `.mbti` changes
- `moon test`: 6716 passed, 0 failed (bigint 157/157)

🤖 Generated with [Claude Code](https://claude.com/claude-code)