### PR TITLE
feat(string): surrogate-safe truncation and partition (clamped_view, split_at)

### DIFF
--- a/builtin/clamped_view_test.mbt
+++ b/builtin/clamped_view_test.mbt
@@ -1,0 +1,78 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "clamped_view on BMP text behaves like plain slicing" {
+  let s = "hello world"
+  inspect(s.clamped_view(end=5), content="hello")
+  inspect(s.clamped_view(start=6), content="world")
+  inspect(s.clamped_view(start=3, end=8), content="lo wo")
+  inspect(s.clamped_view(), content="hello world")
+}
+
+///|
+test "clamped_view snaps surrogate-splitting offsets inward" {
+  let s = "ab😀cd" // 😀 occupies units 2 and 3
+  inspect(s.clamped_view(end=3), content="ab")
+  inspect(s.clamped_view(start=3), content="cd")
+  inspect(s.clamped_view(end=4), content="ab😀")
+  inspect(s.clamped_view(start=2), content="😀cd")
+  inspect(s.clamped_view(start=3, end=3), content="")
+  // never contains content outside the requested range
+  inspect(s.clamped_view(start=1, end=3), content="b")
+}
+
+///|
+test "clamped_view clamps out-of-range and inverted offsets" {
+  let s = "ab😀cd"
+  inspect(s.clamped_view(end=100), content="ab😀cd")
+  inspect(s.clamped_view(start=-5), content="ab😀cd")
+  inspect(s.clamped_view(start=100), content="")
+  inspect(s.clamped_view(start=4, end=2), content="")
+  inspect("".clamped_view(end=10), content="")
+}
+
+///|
+test "clamped_view passes unpaired surrogates through unchanged" {
+  // A lone trailing surrogate is a boundary: nothing to snap around.
+  let lone = "😀".unsafe_substring(start=1, end=2)
+  let s = "a" + lone + "b"
+  inspect(s.clamped_view(end=2).length(), content="2")
+  inspect(s.clamped_view(start=1).length(), content="2")
+  inspect(s.clamped_view(start=1, end=2).length(), content="1")
+}
+
+///|
+test "clamped_view chunking loop reassembles the original" {
+  let s = "😀😁😂😃 mixed 😄 text 😅"
+  let parts = StringBuilder()
+  let mut pos = 0
+  while pos < s.length() {
+    let chunk = s.clamped_view(start=pos, end=pos + 4)
+    parts.write_view(chunk)
+    pos += chunk.length()
+  }
+  inspect(parts.to_string() == s, content="true")
+}
+
+///|
+test "StringView::clamped_view uses view-relative offsets" {
+  let v = "xx ab😀cd".view(start_offset=3) // "ab😀cd", 😀 at units 2-3
+  inspect(v.clamped_view(end=3), content="ab")
+  inspect(v.clamped_view(start=3), content="cd")
+  inspect(v.clamped_view(start=3, end=3), content="")
+  inspect(v.clamped_view(end=100), content="ab😀cd")
+  // nested truncation
+  inspect(v.clamped_view(start=1).clamped_view(end=2), content="b")
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -754,6 +754,7 @@ pub fn[A] String::rev_fold(String, init~ : A, (A, Char) -> A raise?) -> A raise?
 pub fn String::rev_iter(String) -> Iter[Char]
 pub fn String::rev_split_once(String, StringView) -> (StringView, StringView)?
 pub fn String::split(String, StringView) -> Iter[StringView]
+pub fn String::split_at(String, Int) -> (StringView, StringView)
 pub fn String::split_once(String, StringView) -> (StringView, StringView)?
 #alias(chop_prefix)
 pub fn String::strip_prefix(String, StringView) -> StringView?
@@ -1076,6 +1077,7 @@ pub fn[A] StringView::rev_fold(Self, init~ : A, (A, Char) -> A raise?) -> A rais
 pub fn StringView::rev_iter(Self) -> Iter[Char]
 pub fn StringView::rev_split_once(Self, Self) -> (Self, Self)?
 pub fn StringView::split(Self, Self) -> Iter[Self]
+pub fn StringView::split_at(Self, Int) -> (Self, Self)
 pub fn StringView::split_once(Self, Self) -> (Self, Self)?
 pub fn StringView::start_offset(Self) -> Int
 #alias(chop_prefix)

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -706,6 +706,7 @@ pub fn String::before(String, StringView) -> StringView?
 pub fn String::char_length(String, start_offset? : Int, end_offset? : Int) -> Int
 pub fn String::char_length_eq(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
 pub fn String::char_length_ge(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
+pub fn String::clamped_view(String, start? : Int, end? : Int) -> StringView
 pub fn String::code_units(String) -> ArrayView[UInt16]
 pub fn String::compare_ignore_ascii_case(String, String) -> Int
 pub fn String::contains(String, StringView) -> Bool
@@ -1026,6 +1027,7 @@ pub fn StringView::before(Self, Self) -> Self?
 pub fn StringView::char_length(Self) -> Int
 pub fn StringView::char_length_eq(Self, Int) -> Bool
 pub fn StringView::char_length_ge(Self, Int) -> Bool
+pub fn StringView::clamped_view(Self, start? : Int, end? : Int) -> Self
 pub fn StringView::code_units(Self) -> ArrayView[UInt16]
 pub fn StringView::compare_ignore_ascii_case(Self, Self) -> Int
 pub fn StringView::contains(Self, Self) -> Bool

--- a/builtin/split_at_test.mbt
+++ b/builtin/split_at_test.mbt
@@ -1,0 +1,74 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "split_at on BMP text splits exactly" {
+  let (p, q) = "hello world".split_at(5)
+  inspect(p, content="hello")
+  inspect(q, content=" world")
+  let (p2, q2) = "abc".split_at(0)
+  inspect(p2, content="")
+  inspect(q2, content="abc")
+  let (p3, q3) = "abc".split_at(3)
+  inspect(p3, content="abc")
+  inspect(q3, content="")
+}
+
+///|
+test "split_at snaps down off a surrogate pair" {
+  let s = "ab😀cd" // 😀 occupies units 2 and 3
+  let (p, q) = s.split_at(3)
+  inspect(p, content="ab")
+  inspect(q, content="😀cd")
+  let (p2, q2) = s.split_at(2)
+  inspect(p2, content="ab")
+  inspect(q2, content="😀cd")
+  let (p3, q3) = s.split_at(4)
+  inspect(p3, content="ab😀")
+  inspect(q3, content="cd")
+}
+
+///|
+test "split_at is lossless at every offset including out-of-range" {
+  let s = "a😀b😁😂c"
+  for at in -2..<=(s.length() + 2) {
+    let (p, q) = s.split_at(at)
+    assert_eq(p.to_owned() + q.to_owned(), s)
+    if at >= 0 {
+      assert_true(p.length() <= at)
+    }
+  }
+}
+
+///|
+test "split_at treats unpaired surrogates as boundaries" {
+  let lone = "😀".unsafe_substring(start=1, end=2)
+  let s = "a" + lone + "b"
+  let (p, q) = s.split_at(1)
+  inspect(p.length(), content="1")
+  inspect(q.length(), content="2")
+  assert_eq(p.to_owned() + q.to_owned(), s)
+}
+
+///|
+test "StringView::split_at uses view-relative offsets and stays in window" {
+  let v = "xx ab😀cd yy".view(start_offset=3, end_offset=9) // "ab😀cd"
+  let (p, q) = v.split_at(3)
+  inspect(p, content="ab")
+  inspect(q, content="😀cd")
+  let (p2, q2) = v.split_at(100)
+  inspect(p2, content="ab😀cd")
+  inspect(q2, content="")
+  assert_eq(p.to_owned() + q.to_owned(), v.to_owned())
+}

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -816,6 +816,76 @@ pub fn StringView::clamped_view(
 }
 
 ///|
+/// Splits the string into a well-formed `(prefix, suffix)` pair at the given
+/// code-unit offset: the cut point is `at` clamped to the string and snapped
+/// down to the nearest character boundary, so the prefix never exceeds `at`
+/// units and a character straddling the cut goes to the suffix.
+///
+/// Total, O(1), and lossless: `prefix + suffix == self` always holds —
+/// unlike composing two `clamped_view` calls, which would drop a character
+/// straddling the cut from both halves. Unpaired surrogates are treated as
+/// boundaries and pass through unchanged.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let s = "ab😀cd"
+///   let (p, q) = s.split_at(3) // 3 splits 😀: the cut snaps down to 2
+///   inspect(p, content="ab")
+///   inspect(q, content="😀cd")
+///   let (p2, q2) = s.split_at(100) // clamped
+///   inspect(p2, content="ab😀cd")
+///   inspect(q2, content="")
+/// }
+/// ```
+pub fn String::split_at(self : String, at : Int) -> (StringView, StringView) {
+  let len = self.length()
+  let mut cut = if at < 0 { 0 } else if at > len { len } else { at }
+  if cut > 0 &&
+    cut < len &&
+    self.unsafe_get(cut).is_trailing_surrogate() &&
+    self.unsafe_get(cut - 1).is_leading_surrogate() {
+    cut -= 1
+  }
+  (StringView::make_view(self, 0, cut), StringView::make_view(self, cut, len))
+}
+
+///|
+/// Splits the view into a well-formed `(prefix, suffix)` pair at the given
+/// view-relative code-unit offset; same contract as `String::split_at`.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let v = "xx ab😀cd".view(start_offset=3)
+///   let (p, q) = v.split_at(3)
+///   inspect(p, content="ab")
+///   inspect(q, content="😀cd")
+/// }
+/// ```
+pub fn StringView::split_at(
+  self : StringView,
+  at : Int,
+) -> (StringView, StringView) {
+  let len = self.length()
+  let mut cut = if at < 0 { 0 } else if at > len { len } else { at }
+  let str = self.str()
+  let base = self.start()
+  if cut > 0 &&
+    cut < len &&
+    str.unsafe_get(base + cut).is_trailing_surrogate() &&
+    str.unsafe_get(base + cut - 1).is_leading_surrogate() {
+    cut -= 1
+  }
+  (
+    StringView::make_view(str, base, base + cut),
+    StringView::make_view(str, base + cut, self.end()),
+  )
+}
+
+///|
 /// Creates a view of a string with proper UTF-16 boundary validation.
 ///
 /// # Parameters

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -712,6 +712,110 @@ pub fn StringView::get_view(
 }
 
 ///|
+/// Returns the largest well-formed view contained in the requested range.
+/// Total: out-of-range offsets are clamped to the string, an offset that
+/// would split a surrogate pair is snapped inward (`start` forward, `end`
+/// backward), and an inverted range yields an empty view — this function
+/// never aborts and never cuts a surrogate pair in half.
+///
+/// Intended for truncation where the exact cut point does not matter, such
+/// as short summaries: the result is at most one character shorter than the
+/// requested range on each side. Unpaired surrogates already present in the
+/// input are treated as boundaries and pass through unchanged.
+///
+/// See `s[start:end]` for the aborting variant and `String::get_view` for
+/// the exact `Option`-returning variant.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let s = "ab😀cd"
+///   inspect(s.clamped_view(end=3), content="ab") // 3 splits 😀: snapped to 2
+///   inspect(s.clamped_view(start=3), content="cd") // snapped to 4
+///   inspect(s.clamped_view(end=100), content="ab😀cd") // clamped
+///   inspect(s.clamped_view(start=3, end=3), content="") // inside the pair
+/// }
+/// ```
+pub fn String::clamped_view(
+  self : String,
+  start? : Int = 0,
+  end? : Int,
+) -> StringView {
+  let len = self.length()
+  let mut lo = if start < 0 { 0 } else if start > len { len } else { start }
+  let mut hi = match end {
+    None => len
+    Some(e) => if e < 0 { 0 } else if e > len { len } else { e }
+  }
+  if lo > 0 &&
+    lo < len &&
+    self.unsafe_get(lo).is_trailing_surrogate() &&
+    self.unsafe_get(lo - 1).is_leading_surrogate() {
+    lo += 1
+  }
+  if hi > 0 &&
+    hi < len &&
+    self.unsafe_get(hi).is_trailing_surrogate() &&
+    self.unsafe_get(hi - 1).is_leading_surrogate() {
+    hi -= 1
+  }
+  if lo >= hi {
+    StringView::make_view(self, lo, lo)
+  } else {
+    StringView::make_view(self, lo, hi)
+  }
+}
+
+///|
+/// Returns the largest well-formed sub-view contained in the requested range
+/// of this view; offsets are relative to the view. Total like
+/// `String::clamped_view`: clamps out-of-range offsets, snaps
+/// surrogate-splitting offsets inward, and yields an empty view for an
+/// inverted range.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let v = "xx ab😀cd".view(start_offset=3)
+///   inspect(v.clamped_view(end=3), content="ab")
+///   inspect(v.clamped_view(start=3), content="cd")
+/// }
+/// ```
+pub fn StringView::clamped_view(
+  self : StringView,
+  start? : Int = 0,
+  end? : Int,
+) -> StringView {
+  let len = self.length()
+  let mut lo = if start < 0 { 0 } else if start > len { len } else { start }
+  let mut hi = match end {
+    None => len
+    Some(e) => if e < 0 { 0 } else if e > len { len } else { e }
+  }
+  let str = self.str()
+  let base = self.start()
+  if lo > 0 &&
+    lo < len &&
+    str.unsafe_get(base + lo).is_trailing_surrogate() &&
+    str.unsafe_get(base + lo - 1).is_leading_surrogate() {
+    lo += 1
+  }
+  if hi > 0 &&
+    hi < len &&
+    str.unsafe_get(base + hi).is_trailing_surrogate() &&
+    str.unsafe_get(base + hi - 1).is_leading_surrogate() {
+    hi -= 1
+  }
+  if lo >= hi {
+    StringView::make_view(str, base + lo, base + lo)
+  } else {
+    StringView::make_view(str, base + lo, base + hi)
+  }
+}
+
+///|
 /// Creates a view of a string with proper UTF-16 boundary validation.
 ///
 /// # Parameters


### PR DESCRIPTION
Truncating for a short summary — `s[0:10]` or `s[10:]` where the exact count doesn't matter — aborts in MoonBit when the offset splits a surrogate pair. This PR adds the **imprecise-but-total** modes of the safe-slicing family, for both `String` and `StringView`:

| API | contract |
|---|---|
| `s[a:b]` | precise, aborts on invalid range |
| `get_view(start?, end?)` | precise, `None` on invalid range |
| **`clamped_view(start?, end?)`** | **total: largest well-formed view contained in the requested range** |
| **`split_at(at)`** | **total: lossless `(prefix, suffix)` partition, cut snapped down to a boundary** |

## `clamped_view`

Out-of-range offsets clamp; an offset splitting a pair snaps inward (`start` forward, `end` backward), so the result never includes content outside the request and is at most one character short per side. Inverted ranges yield an empty view. Unpaired surrogates are boundaries and pass through. O(1) — each offset adjusts by at most one unit (a UTF-16 advantage over Rust's unstable `floor_char_boundary`, which may step three bytes).

```moonbit
"ab😀cd".clamped_view(end=3)   // "ab"
"ab😀cd".clamped_view(start=3) // "cd"
```

## `split_at`

The partition invariant is why it's a separate API rather than two `clamped_view` calls: `end` snaps down while `start` snaps up, so composing them at offset 3 of `"ab😀cd"` yields `"ab"`/`"cd"` — the 😀 would vanish from both halves. `split_at` uses one shared cut (snapped **down**), guaranteeing `prefix + suffix == self` at every offset, with `prefix.length() <= at`; the straddling character goes to the suffix.

```moonbit
"ab😀cd".split_at(3) // ("ab", "😀cd")
```

Boundary primitives (`floor/ceil_char_boundary`) are deliberately **not** exposed: chunking works without them (`pos += s.clamped_view(start=pos, end=pos+n).length()` — pinned by a reassembly test), and promoting a private helper later is non-breaking.

## Review

Both commits reviewed by **Codex CLI** (codex-cli 0.144.1), approved with no findings. Commit 1: "snap guards are bounds-safe, one-unit adjustment is sufficient... StringView arithmetic stays within its window." Commit 2: "the pairing predicate exactly matches `clamped_view`... the halves exactly tile the original view. A tuple is appropriate for this total operation; `Option`/abort belong to exact-boundary APIs such as `get_view`."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean (deprecation-warning-free), `moon fmt` applied
- `moon test`: 6730 passed, 0 failed — 11 new tests incl. a lossless sweep over every offset from −2 to len+2, malformed-input pass-through, and a chunking loop that reassembles the original
- `pkg.generated.mbti`: exactly the four intended new symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)