### PR TITLE
perf(array): inline any/all so #locals applies to the callback

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -540,9 +540,16 @@ pub fn[T] Array::eachi(
 ///   assert_false(arr.all(x => x < 5))
 /// }
 /// ```
+#locals(f)
 #alias(every)
 pub fn[T] Array::all(self : Array[T], f : (T) -> Bool raise?) -> Bool raise? {
-  self[:].all(f)
+  // Inlined for #locals(f); see Array::any.
+  for v in self {
+    if !f(v) {
+      return false
+    }
+  }
+  true
 }
 
 ///|
@@ -556,9 +563,18 @@ pub fn[T] Array::all(self : Array[T], f : (T) -> Bool raise?) -> Bool raise? {
 ///   assert_false(arr.any(x => x < 1))
 /// }
 /// ```
+#locals(f)
 #alias(exists)
 pub fn[T] Array::any(self : Array[T], f : (T) -> Bool raise?) -> Bool raise? {
-  self[:].any(f)
+  // Inlined rather than delegating to `self[:].any(f)`: passing `f` onward
+  // counts as an escape, which would reject `#locals(f)` (see issue about
+  // propagating localness through #locals-annotated callees).
+  for v in self {
+    if f(v) {
+      return true
+    }
+  }
+  false
 }
 
 ///|


### PR DESCRIPTION
Workaround for #3832.

`Array::any` / `Array::all` forwarded their callback to the `ArrayView` implementations — and passing `f` onward counts as an escape, so the wrappers were rejected with error 4163 when annotated:

```
562 │   self[:].any(f)
    │               ┬
    │               ╰── This parameter is expected to be local, but it escapes.
```

That means call sites of these hot entry points lost closure stack-allocation, even though `ArrayView::any/all` declare `#locals(f)` themselves. #3832 proposes the real fix (propagate localness through calls to `#locals`-annotated callees, as the old `HashMap::fold` TODO already anticipated); until then, this PR inlines the two trivial loops into the wrappers and annotates them directly, with comments explaining the deliberate duplication.

## Review

Reviewed by **Codex CLI** (codex-cli 0.144.1): "No findings. The loops exactly mirror `ArrayView::all/any`: forward order, empty identities, short-circuiting, and uncaught `raise?` propagation. `f` is only invoked, never retained or forwarded, so `#locals(f)` is sound. Iteration bounds, aliases, and generated interface remain unchanged."

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- `moon check` clean, `moon fmt` applied, no `.mbti` changes
- `moon test`: 6730 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)