### PR TITLE
fix(bigint): canonicalize from_octets with leading zero limbs

### DIFF
--- a/bigint/bigint_wbtest.mbt
+++ b/bigint/bigint_wbtest.mbt
@@ -575,6 +575,30 @@ test "from_octets" {
   check_invariant(a)
   @test.assert_eq(a, 0)
 
+  // Test multiple leading zero limbs
+  let a = BigInt::from_octets(b"\x00\x00\x00\x00\x00\x00\x00\x00\x26")
+  check_invariant(a)
+  inspect(a.to_string(), content="38")
+  @test.assert_eq(a, 38N)
+  @test.assert_eq(a.compare(38N), 0)
+
+  // Test zero spanning multiple limbs
+  let a = BigInt::from_octets(
+    b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+  )
+  check_invariant(a)
+  inspect(a.to_string(), content="0")
+  @test.assert_eq(a, 0N)
+  @test.assert_eq(a.compare(0N), 0)
+  let a = BigInt::from_octets(
+    b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+    signum=-1,
+  )
+  check_invariant(a)
+  inspect(a.to_string(), content="0")
+  @test.assert_eq(a, 0N)
+  @test.assert_eq(a.compare(0N), 0)
+
   // Test positive number
   let a = BigInt::from_octets(b"\x01")
   check_invariant(a)


### PR DESCRIPTION
Closes #3809.

## Problem

`BigInt::from_octets` only removed one zero most-significant limb. Inputs with more than one zero limb retained an invalid logical length, so non-JS backends could compare equal values incorrectly. An all-zero multi-limb input could also form a negative zero and make `to_string` panic.

## Fix

Use the existing `normalize_len` helper to compute the canonical logical length after constructing the limbs.

## Tests

Extend the existing whitebox `from_octets` coverage with the issue input and multi-limb zero inputs for both default and negative signums. Each case checks the internal invariant plus string, equality, and comparison behavior.

## Validation

- `moon check --deny-warn --target all`
- `moon test --target all`
- `moon test --release --target js,wasm,wasm-gc`
- `moon test --target native --release`
- JS builtin string tests on wasm-gc in debug and release
- `moon info --target wasm,wasm-gc,js,native` (no interface diff)
- `moon fmt --check`
- `moon bundle --all`
