### PR TITLE
fix(stringbuilder): guard capacity growth against Int overflow

### DIFF
--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -55,5 +55,6 @@ options(
     "stringbuilder_buffer.mbt": [ "not", "js" ],
     "stringbuilder_buffer_wbtest.mbt": [ "not", "js" ],
     "stringbuilder_concat.mbt": [ "js" ],
+    "stringbuilder_grow_wbtest.mbt": [ "not", "js" ],
   },
 )

--- a/builtin/stringbuilder_bench_test.mbt
+++ b/builtin/stringbuilder_bench_test.mbt
@@ -89,6 +89,18 @@ test "bench StringBuilder::write_char non-BMP n=4096" (it : @bench.T) {
 }
 
 ///|
+test "bench StringBuilder growth from minimum capacity n=4096" (it : @bench.T) {
+  let piece = stringbuilder_bench_piece
+  it.bench(fn() {
+    let builder = StringBuilder(size_hint=1)
+    for _ in 0..<stringbuilder_bench_repeats {
+      builder.write_string(piece)
+    }
+    it.keep(builder.to_string().length())
+  })
+}
+
+///|
 test "bench StringBuilder::reset reuse spare capacity n=4096" (it : @bench.T) {
   let piece = stringbuilder_bench_piece
   let size_hint = piece.length() * 4

--- a/builtin/stringbuilder_grow_wbtest.mbt
+++ b/builtin/stringbuilder_grow_wbtest.mbt
@@ -1,0 +1,36 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "StringBuilder growth_capacity doubles until the requirement is covered" {
+  inspect(stringbuilder_growth_capacity(1, 0, 100), content="128")
+  inspect(stringbuilder_growth_capacity(3, 0, 24), content="24")
+  inspect(stringbuilder_growth_capacity(16, 0, 16), content="16")
+  inspect(stringbuilder_growth_capacity(16, 0, 17), content="32")
+}
+
+///|
+test "StringBuilder growth_capacity survives Int overflow" {
+  // 2^30 doubles to INT_MIN; the old loop then went 0 -> 0 -> ... forever.
+  let big = 1 << 30
+  inspect(
+    stringbuilder_growth_capacity(big, 0, big + 1) == big + 1,
+    content="true",
+  )
+  // A non-power-of-two start can overflow to a negative value on the way up.
+  inspect(
+    stringbuilder_growth_capacity(11, 0, 1_500_000_000),
+    content="1500000000",
+  )
+}


### PR DESCRIPTION
## Summary

- Guard `StringBuilder` capacity growth against `Int` overflow.
- Add allocation-free whitebox coverage for normal growth and overflow boundaries.
- Add a focused native growth benchmark.

## Root cause

`StringBuilder::grow_if_necessary` repeatedly doubled the backing capacity. Once the capacity exceeded `2^30`, `Int` overflow could make the loop cycle through non-positive values and never reach the requested length. The new private helper falls back to the exact requested capacity after an overflowing double.

This is the `StringBuilder` counterpart to #3822, but it changes the separate UTF-16 builder implementation.

## Benchmark

`StringBuilder growth from minimum capacity n=4096`, lower is better.

- Environment: Apple M5 (arm64), macOS Darwin 25.5.0, MoonBit `0.1.20260824`
- Command: `moon bench --release --target native -p moonbitlang/core/builtin -f stringbuilder_bench_test.mbt -i 5`
- Three sequential runs: 15.17 µs, 14.56 µs, 14.82 µs
- Mean across runs: **14.85 µs**

Each run contains 10 benchmark samples.

## Validation

- `moon info && moon fmt`
- `moon test`: 7546 passed, 0 failed
- `moon check`
- No generated interface or formatting diff
