### PR TITLE
perf(ascii): vectorize decode on non-JS targets

### DIFF
--- a/encoding/ascii/ascii_bench_test.mbt
+++ b/encoding/ascii/ascii_bench_test.mbt
@@ -1,0 +1,47 @@
+///|
+let ascii_bench_size = 100_000
+
+///|
+let ascii_bench_bytes : Bytes = Bytes::make(ascii_bench_size, b'A')
+
+///|
+let ascii_bench_bytes_15 : Bytes = Bytes::make(15, b'A')
+
+///|
+let ascii_bench_bytes_16 : Bytes = Bytes::make(16, b'A')
+
+///|
+let ascii_bench_bytes_32 : Bytes = Bytes::make(32, b'A')
+
+///|
+let ascii_bench_bytes_64 : Bytes = Bytes::make(64, b'A')
+
+///|
+test "bench ASCII decode n=15" (it : @bench.T) {
+  let bytes = ascii_bench_bytes_15
+  it.bench(fn() { it.keep((try! @ascii.decode(bytes)).length()) })
+}
+
+///|
+test "bench ASCII decode n=16" (it : @bench.T) {
+  let bytes = ascii_bench_bytes_16
+  it.bench(fn() { it.keep((try! @ascii.decode(bytes)).length()) })
+}
+
+///|
+test "bench ASCII decode n=32" (it : @bench.T) {
+  let bytes = ascii_bench_bytes_32
+  it.bench(fn() { it.keep((try! @ascii.decode(bytes)).length()) })
+}
+
+///|
+test "bench ASCII decode n=64" (it : @bench.T) {
+  let bytes = ascii_bench_bytes_64
+  it.bench(fn() { it.keep((try! @ascii.decode(bytes)).length()) })
+}
+
+///|
+test "bench ASCII decode n=100000" (it : @bench.T) {
+  let bytes = ascii_bench_bytes
+  it.bench(fn() { it.keep((try! @ascii.decode(bytes)).length()) })
+}

--- a/encoding/ascii/ascii_bench_test.mbt
+++ b/encoding/ascii/ascii_bench_test.mbt
@@ -1,3 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 ///|
 let ascii_bench_size = 100_000
 

--- a/encoding/ascii/ascii_bench_test.mbt
+++ b/encoding/ascii/ascii_bench_test.mbt
@@ -5,6 +5,12 @@ let ascii_bench_size = 100_000
 let ascii_bench_bytes : Bytes = Bytes::make(ascii_bench_size, b'A')
 
 ///|
+let ascii_bench_large_size = 1_000_000
+
+///|
+let ascii_bench_large_bytes : Bytes = Bytes::make(ascii_bench_large_size, b'A')
+
+///|
 let ascii_bench_bytes_15 : Bytes = Bytes::make(15, b'A')
 
 ///|
@@ -43,5 +49,11 @@ test "bench ASCII decode n=64" (it : @bench.T) {
 ///|
 test "bench ASCII decode n=100000" (it : @bench.T) {
   let bytes = ascii_bench_bytes
+  it.bench(fn() { it.keep((try! @ascii.decode(bytes)).length()) })
+}
+
+///|
+test "bench ASCII decode n=1000000" (it : @bench.T) {
+  let bytes = ascii_bench_large_bytes
   it.bench(fn() { it.keep((try! @ascii.decode(bytes)).length()) })
 }

--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -45,6 +45,7 @@ fn finish_string(buffer : FixedArray[UInt16], len : Int) -> String {
 
 ///|
 #cfg(not(target="js"))
+#inline
 fn decode_scalar(bytes : BytesView) -> String raise Malformed {
   let t : FixedArray[UInt16] = FixedArray::make(bytes.length(), 0)
   let tlen = for tlen = 0, bs = bytes {

--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -22,6 +22,17 @@ pub suberror Malformed {
 fn unsafe_fixedarray_uint16_to_string(buffer : FixedArray[UInt16]) -> String = "%string.unsafe_from_uint16_fixedarray"
 
 ///|
+#cfg(target="js")
+#warnings("-unused_value")
+fn suppress_unused_v128_import_on_js() -> Unit {
+  ignore(@v128.i8x16_splat(0))
+}
+
+///|
+#cfg(not(target="js"))
+fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
+
+///|
 fn finish_string(buffer : FixedArray[UInt16], len : Int) -> String {
   if len == buffer.length() {
     unsafe_fixedarray_uint16_to_string(buffer)
@@ -33,9 +44,85 @@ fn finish_string(buffer : FixedArray[UInt16], len : Int) -> String {
 }
 
 ///|
+#cfg(not(target="js"))
+fn decode_scalar(bytes : BytesView) -> String raise Malformed {
+  let t : FixedArray[UInt16] = FixedArray::make(bytes.length(), 0)
+  let tlen = for tlen = 0, bs = bytes {
+    match (tlen, bs) {
+      (tlen, []) => break tlen
+      (tlen, [0..=0x7F as b, .. rest]) => {
+        t.unsafe_set(tlen, b.to_uint16())
+        continue tlen + 1, rest
+      }
+      (_, _ as bytes) => raise Malformed(bytes)
+    }
+  }
+  finish_string(t, tlen)
+}
+
+///|
+#cfg(not(target="js"))
+fn decode_v128(bytes : BytesView) -> String raise Malformed {
+  let length = bytes.length()
+  let result = FixedArray::make(length * 2, b'\x00')
+  let source = unsafe_fixedarray_from_bytes(bytes.data())
+  let source_start = bytes.start_offset()
+  let source_end = source_start + length
+  let mut source_offset = source_start
+  let mut result_offset = 0
+  while source_offset + 16 <= source_end {
+    let block = @v128.v128_load(source, source_offset)
+    let non_ascii = @v128.i8x16_bitmask(block)
+    if non_ascii != 0 {
+      let malformed_offset = source_offset - source_start + non_ascii.ctz()
+      raise Malformed(bytes[malformed_offset:])
+    }
+    @v128.v128_store(
+      result,
+      result_offset,
+      @v128.i16x8_extend_low_i8x16_u(block),
+    )
+    @v128.v128_store(
+      result,
+      result_offset + 16,
+      @v128.i16x8_extend_high_i8x16_u(block),
+    )
+    source_offset = source_offset + 16
+    result_offset = result_offset + 32
+  }
+  while source_offset < source_end {
+    let byte = source.unsafe_get(source_offset)
+    if byte > b'\x7F' {
+      raise Malformed(bytes[source_offset - source_start:])
+    }
+    result.unsafe_set(result_offset, byte)
+    result.unsafe_set(result_offset + 1, b'\x00')
+    source_offset = source_offset + 1
+    result_offset = result_offset + 2
+  }
+  result.unsafe_reinterpret_as_bytes().to_unchecked_string()
+}
+
+///|
 /// Decodes an ASCII byte array into a string.
 ///
 /// Raises `Malformed` if any byte is outside the ASCII range.
+#cfg(not(target="js"))
+#inline
+pub fn decode(bytes : BytesView) -> String raise Malformed {
+  // The scalar loop is faster below this crossover point on supported targets.
+  if bytes.length() >= 64 {
+    decode_v128(bytes)
+  } else {
+    decode_scalar(bytes)
+  }
+}
+
+///|
+/// Decodes an ASCII byte array into a string.
+///
+/// Raises `Malformed` if any byte is outside the ASCII range.
+#cfg(target="js")
 pub fn decode(bytes : BytesView) -> String raise Malformed {
   let t : FixedArray[UInt16] = FixedArray::make(bytes.length(), 0)
   let tlen = for tlen = 0, bs = bytes {

--- a/encoding/ascii/decode_v128_wbtest.mbt
+++ b/encoding/ascii/decode_v128_wbtest.mbt
@@ -1,0 +1,22 @@
+///|
+test "V128 decode handles a view and scalar tail" {
+  let bytes = b"!0123456789ABCDEF?"
+  inspect(decode_v128(bytes[1:]), content="0123456789ABCDEF?")
+}
+
+///|
+test "V128 decode reports the first non-ASCII byte in a block" {
+  let bytes = b"0123456789ABC\xffDEF"
+  try {
+    let _ = decode_v128(bytes)
+    panic()
+  } catch {
+    Malformed(rest) =>
+      inspect(
+        rest,
+        content=(
+          #|b"\xffDEF"
+        ),
+      )
+  }
+}

--- a/encoding/ascii/decode_v128_wbtest.mbt
+++ b/encoding/ascii/decode_v128_wbtest.mbt
@@ -1,3 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 ///|
 test "V128 decode handles a view and scalar tail" {
   let bytes = b"!0123456789ABCDEF?"

--- a/encoding/ascii/decode_v128_wbtest.mbt
+++ b/encoding/ascii/decode_v128_wbtest.mbt
@@ -13,6 +13,49 @@
 // limitations under the License.
 
 ///|
+fn v128_outcome(view : BytesView) -> (String?, Bytes?) {
+  (Some(decode_v128(view)), None) catch {
+    Malformed(rest) => (None, Some(rest.to_owned()))
+  }
+}
+
+///|
+fn scalar_outcome(view : BytesView) -> (String?, Bytes?) {
+  (Some(decode_scalar(view)), None) catch {
+    Malformed(rest) => (None, Some(rest.to_owned()))
+  }
+}
+
+///|
+/// The SIMD decoder must agree with the scalar decoder — same string on
+/// success, same remaining view on failure — on arbitrary payloads seen
+/// through views with arbitrary (unaligned) start offsets.
+test "quickcheck: V128 decode agrees with scalar decode" {
+  @quickcheck.check(count=300, (input : (Array[Int], Int, Bool)) => {
+    let (seeds, pad_seed, all_valid) = input
+    let payload = seeds.map(seed => {
+      if all_valid || (seed & 0xF) != 0xF {
+        (seed & 0x7F).to_byte()
+      } else {
+        (0x80 | (seed & 0x7F)).to_byte()
+      }
+    })
+    let pad = pad_seed % 17
+    let pad = if pad < 0 { pad + 17 } else { pad }
+    let full : Array[Byte] = []
+    for _ in 0..<pad {
+      full.push(b'\xFF')
+    }
+    full.append(payload)
+    for _ in 0..<16 {
+      full.push(b'\xFF')
+    }
+    let view = Bytes::from_array(full)[pad:pad + payload.length()]
+    v128_outcome(view) == scalar_outcome(view)
+  })
+}
+
+///|
 test "V128 decode handles a view and scalar tail" {
   let bytes = b"!0123456789ABCDEF?"
   inspect(decode_v128(bytes[1:]), content="0123456789ABCDEF?")

--- a/encoding/ascii/finish_string_wbtest.mbt
+++ b/encoding/ascii/finish_string_wbtest.mbt
@@ -1,0 +1,41 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Every decoder finishes through `finish_string`; it must keep exactly the
+/// first `len` code units, both when the buffer is full and when it must
+/// truncate.
+test "quickcheck: finish_string keeps exactly the first len code units" {
+  @quickcheck.check(count=100, (input : (Array[Int], Int)) => {
+    let units = input.0.map(x => (x & 0x7F).to_uint16())
+    let buffer = FixedArray::makei(units.length(), i => units[i])
+    let take = if units.is_empty() {
+      0
+    } else {
+      let r = input.1 % (units.length() + 1)
+      if r < 0 {
+        r + units.length() + 1
+      } else {
+        r
+      }
+    }
+    let expected = StringBuilder(size_hint=take)
+    for i in 0..<take {
+      expected.write_char(
+        units[i].to_uint().reinterpret_as_int().unsafe_to_char(),
+      )
+    }
+    finish_string(buffer, take) == expected.to_string()
+  })
+}

--- a/encoding/ascii/moon.pkg
+++ b/encoding/ascii/moon.pkg
@@ -1,4 +1,13 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
+  "moonbitlang/core/v128",
 }
+
+import {
+  "moonbitlang/core/bench",
+} for "test"
+
+options(
+  targets: { "decode_v128_wbtest.mbt": [ "not", "js" ] },
+)

--- a/encoding/ascii/moon.pkg
+++ b/encoding/ascii/moon.pkg
@@ -6,7 +6,12 @@ import {
 
 import {
   "moonbitlang/core/bench",
+  "moonbitlang/core/quickcheck",
 } for "test"
+
+import {
+  "moonbitlang/core/quickcheck",
+} for "wbtest"
 
 options(
   targets: { "decode_v128_wbtest.mbt": [ "not", "js" ] },

--- a/encoding/ascii/quickcheck_test.mbt
+++ b/encoding/ascii/quickcheck_test.mbt
@@ -1,0 +1,142 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Property-based tests for ASCII decoding: `decode` and `decode_lossy` must
+// agree with a byte-by-byte model on arbitrary payloads and on views whose
+// out-of-view neighbors are invalid bytes, for lengths on both sides of the
+// SIMD crossover, with the `Malformed` view pointing at exactly the first
+// invalid byte.
+
+///|
+/// A valid ASCII byte biased toward the range boundaries.
+fn valid_byte(seed : Int) -> Byte {
+  match seed & 0x7 {
+    0 => b'\x00'
+    1 => b'\x7F'
+    2 => b'A'
+    3 => b' '
+    _ => ((seed >> 3) & 0x7F).to_byte()
+  }
+}
+
+///|
+/// Maps an arbitrary Int into `0..<modulus` without discarding cases.
+fn wrap_index(value : Int, modulus : Int) -> Int {
+  let r = value % modulus
+  if r < 0 {
+    r + modulus
+  } else {
+    r
+  }
+}
+
+///|
+fn model_decode_lossy(payload : Array[Byte]) -> String {
+  let buf = StringBuilder(size_hint=payload.length())
+  for b in payload {
+    if b <= b'\x7F' {
+      buf.write_char(b.to_int().unsafe_to_char())
+    } else {
+      buf.write_char('\u{FFFD}')
+    }
+  }
+  buf.to_string()
+}
+
+///|
+/// Embeds `payload` between runs of invalid `0xFF` bytes and returns the view
+/// covering exactly `payload`, so any scan that reads beyond the view sees
+/// bytes that must not influence the result.
+fn poisoned_view(payload : Array[Byte], pad : Int) -> BytesView {
+  let full : Array[Byte] = []
+  for _ in 0..<pad {
+    full.push(b'\xFF')
+  }
+  full.append(payload)
+  for _ in 0..<16 {
+    full.push(b'\xFF')
+  }
+  Bytes::from_array(full)[pad:pad + payload.length()]
+}
+
+///|
+test "quickcheck: decode agrees with the byte model on valid payloads" {
+  @quickcheck.check(count=300, (input : (Array[Int], Int)) => {
+    let (seeds, pad_seed) = input
+    let payload = seeds.map(valid_byte)
+    let view = poisoned_view(payload, wrap_index(pad_seed, 17))
+    let expected = model_decode_lossy(payload)
+    try @ascii.decode(view) catch {
+      Malformed(_) => false
+    } noraise {
+      decoded =>
+        decoded == expected &&
+        // A fully valid payload decodes identically through the lossy
+        // decoder, and re-encoding restores the original bytes.
+        @ascii.decode_lossy(view) == expected &&
+        @ascii.encode(decoded) == Bytes::from_array(payload)
+    }
+  })
+}
+
+///|
+test "quickcheck: Malformed points at the first invalid byte" {
+  @quickcheck.check(count=300, (input : (Array[Int], Int, Int)) => {
+    let (seeds, plant_seed, pad_seed) = input
+    guard seeds.length() > 0 else { return true }
+    let payload = seeds.map(valid_byte)
+    let plant = wrap_index(plant_seed, payload.length())
+    payload[plant] = if (plant_seed & 1) == 0 { b'\x80' } else { b'\xFF' }
+    let view = poisoned_view(payload, wrap_index(pad_seed, 17))
+    // The remaining view starts at the first invalid byte (the planted one,
+    // unless the seeds already produced an earlier one).
+    let mut first = plant
+    for i, b in payload {
+      if b > b'\x7F' {
+        first = i
+        break
+      }
+    }
+    try @ascii.decode(view) catch {
+      Malformed(rest) =>
+        rest.to_owned() == Bytes::from_array(payload)[first:].to_owned() &&
+        @ascii.decode_lossy(view) == model_decode_lossy(payload)
+    } noraise {
+      _ => false
+    }
+  })
+}
+
+///|
+/// Exhaustively plants an invalid byte at every position for lengths around
+/// the 16-byte SIMD blocks and the 64-byte crossover.
+test "decode malformed position sweep" {
+  let lengths = [1, 15, 16, 17, 31, 32, 63, 64, 65, 80, 96]
+  for len in lengths {
+    let clean = Array::make(len, b'A')
+    let view = poisoned_view(clean, 3)
+    assert_eq(try! @ascii.decode(view), "A".repeat(len))
+    for pos in 0..<len {
+      let payload = Array::make(len, b'A')
+      payload[pos] = b'\x80'
+      let view = poisoned_view(payload, 3)
+      try @ascii.decode(view) catch {
+        Malformed(rest) => assert_eq(rest.length(), len - pos)
+      } noraise {
+        _ => fail("expected Malformed at \{pos} for length \{len}")
+      }
+      assert_eq(@ascii.decode_lossy(view), model_decode_lossy(payload))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a non-JS SIMD path for `@ascii.decode`.
- Process sixteen input bytes at once: reject blocks with any high bit set, then zero-extend ASCII bytes into UTF-16 output lanes.
- Keep the scalar path below the measured 64-byte crossover point and retain the existing JavaScript implementation.
- Add whitebox coverage for non-zero views and an invalid byte inside a SIMD block.
- Add decode benchmarks from 15 bytes to 1,000,000 bytes.

## Correctness

The SIMD path uses `i8x16_bitmask` to locate the first byte with its high bit set. On failure it raises `Malformed` with the same remaining `BytesView` as the scalar decoder.

## Benchmarks

`moon bench -p encoding/ascii -f ascii_bench_test.mbt --target <target> --release --no-parallelize`

| Target | n=100,000 before | after | n=1,000,000 before | after |
| --- | ---: | ---: | ---: | ---: |
| native | 26.19 us | ~10 us | 255.93 us | 77.65 us |
| wasm | 50.70 us | 19.65–21.41 us | 532.81 us | 144.01 us |
| wasm-gc | 212.94 us | 150.34 us | 2.15 ms | 1.40 ms |

`n=15`, `n=16`, and `n=32` remain on the scalar path and stayed within measurement variance of the baseline.

## Validation

- `moon test -p encoding/ascii --target all --no-render`
  - wasm: 10/10; wasm-gc: 10/10; js: 8/8; native: 10/10
- `moon check encoding/ascii --target all --no-render`
- `moon info -p encoding/ascii`
- `moon fmt --check` for all changed files
- `git diff --check`

The installed compiler rejects an unrelated pattern in `builtin/iterator.mbt:789` on an unmodified upstream checkout. The test and check commands above used a temporary equivalent rewrite of that pattern; it is not included in this PR.

`moon bench --profile` is not available in the installed Moon CLI, so the validation uses release benchmarks and generated-C inspection instead.