### PR TITLE
perf(list): avoid allocations in is_suffix

### DIFF
--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1758,7 +1758,10 @@ pub fn[A : Eq] List::is_prefix(self : List[A], prefix : List[A]) -> Bool {
 /// }
 /// ```
 pub fn[A : Eq] List::is_suffix(self : List[A], suffix : List[A]) -> Bool {
-  self.rev().is_prefix(suffix.rev())
+  let self_length = self.length()
+  let suffix_length = suffix.length()
+  suffix_length <= self_length &&
+  self.drop(self_length - suffix_length).is_prefix(suffix)
 }
 
 ///|

--- a/list/list_bench_test.mbt
+++ b/list/list_bench_test.mbt
@@ -27,6 +27,12 @@ test "bench List::from_array n=100000" (it : @bench.T) {
 }
 
 ///|
+test "bench List::from_array n=8" (it : @bench.T) {
+  let data : ReadOnlyArray[Int] = [0, 1, 2, 3, 4, 5, 6, 7]
+  it.bench(fn() { it.keep(@list.List(data)) })
+}
+
+///|
 test "bench List::from_iter n=100000" (it : @bench.T) {
   let data = make_list_bench_array()
   it.bench(fn() { it.keep(@list.from_iter(data.iter())) })
@@ -102,4 +108,15 @@ test "bench List::is_suffix n=100000 suffix=50000" (it : @bench.T) {
 test "bench List::scan_right n=100000" (it : @bench.T) {
   let data = @list.List(make_list_bench_array())
   it.bench(fn() { it.keep(data.scan_right(init=0, (acc, x) => acc + x)) })
+}
+
+///|
+test "bench List::cons n=100000" (it : @bench.T) {
+  it.bench(fn() {
+    let mut result = @list.empty()
+    for i = 0; i < list_bench_size; i = i + 1 {
+      result = @list.cons(i, result)
+    }
+    it.keep(result)
+  })
 }

--- a/list/list_bench_test.mbt
+++ b/list/list_bench_test.mbt
@@ -1,0 +1,85 @@
+///|
+let list_bench_size = 100_000
+
+///|
+fn make_list_bench_array() -> Array[Int] {
+  Array::makei(list_bench_size, i => i)
+}
+
+///|
+test "bench List::from_array n=100000" (it : @bench.T) {
+  let data = make_list_bench_array()
+  it.bench(fn() { it.keep(@list.List(data)) })
+}
+
+///|
+test "bench List::from_iter n=100000" (it : @bench.T) {
+  let data = make_list_bench_array()
+  it.bench(fn() { it.keep(@list.from_iter(data.iter())) })
+}
+
+///|
+test "bench List::to_array n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.to_array()) })
+}
+
+///|
+test "bench List::each n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() {
+    let mut sum = 0
+    data.each(x => sum += x)
+    it.keep(sum)
+  })
+}
+
+///|
+test "bench List::fold n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench List::iter fold n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.iter().fold(init=0, (sum, x) => sum + x)) })
+}
+
+///|
+test "bench List::map n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.map(x => x + 1)) })
+}
+
+///|
+test "bench List::filter half n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.filter(x => x % 2 == 0)) })
+}
+
+///|
+test "bench List::concat n=50000+50000" (it : @bench.T) {
+  let left = @list.List(Array::makei(list_bench_size / 2, i => i))
+  let right = @list.List(Array::makei(list_bench_size / 2, i => i))
+  it.bench(fn() { it.keep(left.concat(right)) })
+}
+
+///|
+test "bench List::flat_map singleton n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.flat_map(@list.singleton)) })
+}
+
+///|
+test "bench List::zip n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.zip(data)) })
+}
+
+///|
+test "bench List::is_suffix n=100000 suffix=50000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  let suffix = data.drop(list_bench_size / 2)
+  it.bench(fn() { it.keep(data.is_suffix(suffix)) })
+}

--- a/list/list_bench_test.mbt
+++ b/list/list_bench_test.mbt
@@ -97,3 +97,9 @@ test "bench List::is_suffix n=100000 suffix=50000" (it : @bench.T) {
   let suffix = data.drop(list_bench_size / 2)
   it.bench(fn() { it.keep(data.is_suffix(suffix)) })
 }
+
+///|
+test "bench List::scan_right n=100000" (it : @bench.T) {
+  let data = @list.List(make_list_bench_array())
+  it.bench(fn() { it.keep(data.scan_right(init=0, (acc, x) => acc + x)) })
+}

--- a/list/list_bench_test.mbt
+++ b/list/list_bench_test.mbt
@@ -1,3 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 ///|
 let list_bench_size = 100_000
 

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -603,6 +603,15 @@ test "equal" {
 ///|
 test "is_suffix" {
   debug_inspect(
+    (@list.empty() : @list.List[Int]).is_suffix(@list.empty()),
+    content="true",
+  )
+  debug_inspect(
+    (@list.empty() : @list.List[Int]).is_suffix(List([1])),
+    content="false",
+  )
+  debug_inspect(@list.List([1, 2]).is_suffix(@list.empty()), content="true")
+  debug_inspect(
     @list.List([1, 2, 3, 4, 5]).is_suffix(List([3, 4, 5])),
     content="true",
   )

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -21,6 +21,13 @@ test "List constructor" {
 }
 
 ///|
+test "List constructor ArrayView" {
+  let values = [0, 1, 2, 3, 4]
+  debug_inspect(@list.List(values[1:4]), content="<List: [1, 2, 3]>")
+  debug_inspect(@list.List(values[2:2]), content="<List: []>")
+}
+
+///|
 test "pipe" {
   debug_inspect(
     1 |> x => { @list.List::prepend(@list.empty(), x) },

--- a/list/moon.pkg
+++ b/list/moon.pkg
@@ -7,6 +7,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/test",
 } for "test"
 


### PR DESCRIPTION
## Summary

- avoid allocating reversed copies in `List::is_suffix`
- add boundary coverage for empty and longer suffixes, plus ArrayView construction
- add native benchmarks for core `List` operations, including construction, `is_suffix`, and `scan_right`

## Rationale

`is_suffix` previously reversed both input lists before comparing their prefixes. The new implementation compares lengths, advances to the candidate suffix, and compares directly. This preserves the API and behavior while avoiding temporary list allocations.

The construction benchmarks cover both large array conversion and repeated `cons`, so future runtime or representation work can measure allocation-related changes without modifying the public `List` enum.

## Benchmark

Native release, 100,000-element list with a 50,000-element suffix:

| implementation | mean |
| --- | ---: |
| before (reverse both lists) | 890.66 us |
| after (direct comparison) | 303.47 us |

This is approximately a 2.9x speedup on the measured case.

Construction baselines (native release):

| operation | mean |
| --- | ---: |
| `List(ArrayView)`, 100,000 elements | 473.23 us |
| `List(ArrayView)`, 8 elements | 49.48 ns |
| repeated `cons`, 100,000 elements | 498.34 us |

## Memory

Native release, 1,000,000-element list with a 500,000-element suffix, measured with `/usr/bin/time -l` and mimalloc statistics:

| implementation | maximum RSS | peak memory footprint |
| --- | ---: | ---: |
| before (reverse both lists) | 82.1 MB | 81.6 MB |
| after (direct comparison) | 38.0 MB | 37.4 MB |

The direct comparison reduces peak RSS by approximately 54% in this case.

## Validation

- `moon check list --target all`
- `moon test list/list_test.mbt --target wasm-gc --quiet`
- `moon bench list/list_bench_test.mbt --target native --release --index 0`
- `moon bench list/list_bench_test.mbt --target native --release --index 1`
- `moon bench list/list_bench_test.mbt --target native --release --index 12`
- `moon bench list/list_bench_test.mbt --target native --release --index 13`
- `moon bench list/list_bench_test.mbt --target native --release --index 14`
