### PR TITLE
perf(string): specialize prefix and suffix matching

### DIFF
--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -261,7 +261,14 @@ test "rev_find" {
 /// Returns true if the given substring is suffix of this string.
 #alias(ends_with, deprecated)
 pub fn StringView::has_suffix(self : StringView, str : StringView) -> Bool {
-  self.rev_find(str) is Some(i) && i == self.length() - str.length()
+  let self_len = self.length()
+  let str_len = str.length()
+  guard str_len <= self_len else { return false }
+  let start = self_len - str_len
+  for i in 0..<str_len {
+    guard self.unsafe_get(start + i) == str.unsafe_get(i) else { return false }
+  }
+  true
 }
 
 ///|
@@ -289,7 +296,12 @@ test "has_suffix" {
 /// Returns true if this string starts with the given substring.
 #alias(starts_with, deprecated)
 pub fn StringView::has_prefix(self : StringView, str : StringView) -> Bool {
-  self.find(str) is Some(i) && i == 0
+  let str_len = str.length()
+  guard str_len <= self.length() else { return false }
+  for i in 0..<str_len {
+    guard self.unsafe_get(i) == str.unsafe_get(i) else { return false }
+  }
+  true
 }
 
 ///|
@@ -312,6 +324,17 @@ test "has_prefix" {
   inspect("😀😃hello".has_prefix("😀😃"), content="true")
   inspect("😀hello".has_prefix("😃"), content="false")
   inspect("hello😀".has_prefix("😀"), content="false")
+}
+
+///|
+test "StringView has_prefix and has_suffix" {
+  let view = "x😀hello worldy"[1:14]
+  assert_true(view.has_prefix("😀hello"))
+  assert_false(view.has_prefix("world"))
+  assert_false(view.has_prefix("😀hello world!"))
+  assert_true(view.has_suffix("world"))
+  assert_false(view.has_suffix("😀hello"))
+  assert_false(view.has_suffix("😀hello world!"))
 }
 
 ///|

--- a/builtin/string_methods_bench_test.mbt
+++ b/builtin/string_methods_bench_test.mbt
@@ -1,0 +1,69 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let string_methods_bench_size = 100_000
+
+///|
+let string_methods_bench_needle_size = 128
+
+///|
+let string_methods_bench_haystack : String = "a".repeat(
+  string_methods_bench_size,
+)
+
+///|
+let string_methods_bench_match : String = "a".repeat(
+  string_methods_bench_needle_size,
+)
+
+///|
+let string_methods_bench_mismatch : String = "b" +
+  "a".repeat(string_methods_bench_needle_size - 1)
+
+///|
+test "bench StringView::has_prefix match n=100000 needle=128" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(
+      string_methods_bench_haystack.has_prefix(string_methods_bench_match),
+    )
+  })
+}
+
+///|
+test "bench StringView::has_prefix mismatch n=100000 needle=128" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(
+      string_methods_bench_haystack.has_prefix(string_methods_bench_mismatch),
+    )
+  })
+}
+
+///|
+test "bench StringView::has_suffix match n=100000 needle=128" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(
+      string_methods_bench_haystack.has_suffix(string_methods_bench_match),
+    )
+  })
+}
+
+///|
+test "bench StringView::has_suffix mismatch n=100000 needle=128" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep(
+      string_methods_bench_haystack.has_suffix(string_methods_bench_mismatch),
+    )
+  })
+}


### PR DESCRIPTION
## Summary

- Specialize `StringView::has_prefix` and `StringView::has_suffix` to compare only the anchored UTF-16 code units.
- Add a sliced `StringView` regression test and benchmarks with a 100,000-code-unit haystack and a 128-code-unit needle.

## Why

The previous implementation delegated to `find` / `rev_find`. For needles longer than four code units, that generic Boyer-Moore-Horspool search builds a 256-entry skip table for every call and, on an anchored mismatch, can scan the full haystack. Prefix and suffix predicates only need to inspect their respective anchors.

On native release builds, with a 100,000-code-unit haystack and a 128-code-unit needle:

| case | before | after |
| --- | ---: | ---: |
| prefix match | 93.65 ns | 41.10 ns |
| prefix mismatch | 53.22 us | 6.09 ns |
| suffix match | 104.14 ns | 44.88 ns |
| suffix mismatch | 49.00 us | 5.79 ns |

For 10,000 prefix/suffix mismatch pairs, allocator statistics showed freed temporary memory fall from 31.5 MiB to 642.5 KiB. Peak RSS stays effectively unchanged because the allocator reuses the small temporary blocks.

## Validation

- `moon test builtin/string_methods.mbt --target wasm-gc --quiet`
- `moon test builtin/string_methods.mbt --target native --quiet`
- `moon test builtin/string_methods.mbt --target js --quiet`
- `moon check builtin --target all`
- `moon info builtin`
- `moon bench builtin/string_methods_bench_test.mbt --target native --release`
- `moon bench builtin/string_methods_bench_test.mbt --target wasm-gc --release`