### PR TITLE
perf(fixedarray): elide reverse traversal bounds checks

### DIFF
--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -382,7 +382,7 @@ pub fn[T] FixedArray::rev_each(
   f : (T) -> Unit raise?,
 ) -> Unit raise? {
   for i in self.length()>..0 {
-    f(self[i])
+    f(self.unsafe_get(i))
   }
 }
 
@@ -438,7 +438,7 @@ pub fn[T] FixedArray::rev_eachi(
 ) -> Unit raise? {
   let len = self.length()
   for i in 0..<len {
-    f(i, self[len - i - 1])
+    f(i, self.unsafe_get(len - i - 1))
   }
 }
 
@@ -700,7 +700,7 @@ pub fn[A, B] FixedArray::rev_fold(
   f : (B, A) -> B raise?,
 ) -> B raise? {
   for i = self.length() - 1, acc = init; i >= 0; {
-    continue i - 1, f(acc, self[i])
+    continue i - 1, f(acc, self.unsafe_get(i))
   } nobreak {
     acc
   }
@@ -774,7 +774,7 @@ pub fn[A, B] FixedArray::rev_foldi(
 ) -> B raise? {
   let len = self.length()
   for i in len>..0; acc = init {
-    continue f(len - i - 1, acc, self[i])
+    continue f(len - i - 1, acc, self.unsafe_get(i))
   } nobreak {
     acc
   }


### PR DESCRIPTION
## Summary

- Use `unsafe_get` in `FixedArray::rev_each`, `rev_eachi`, `rev_fold`, and `rev_foldi`.
- Preserve the existing loop forms, including the descending loop used by `rev_each`.

## Why

Every index in these loops is derived from the array length and remains in range. The checked `self[i]` access nevertheless emitted expensive native bounds checks.

The equivalent `ArrayView` reverse operations already use `unsafe_get`. This change aligns the fixed-array implementation with that established invariant and removes the native-only gap.

## Benchmarks

Existing benchmark: `builtin/array_locals_bench_test.mbt`, 100,000 `Int` elements. Lower is better.

| Operation | native before | native after | improvement |
| --- | ---: | ---: | ---: |
| `rev_each` | 23.84 µs | 4.40 µs | 82% |
| `rev_eachi` | 9.34 µs | 9.06 µs | 3% |
| `rev_fold` | 23.31 µs | 4.57 µs | 80% |
| `rev_foldi` | 48.89 µs | 12.56 µs | 74% |

wasm-gc remains within measurement variance (`rev_each` 32.01 → 31.89 µs; `rev_fold` 31.98 → 31.41 µs).

## Validation

- `moon test builtin --target all --quiet`
- `moon check builtin --target all`
- `moon info builtin`
- `moon fmt builtin/fixedarray.mbt`

No public API changes.