### PR TITLE
perf(bytes): avoid Hasher allocation for direct hash

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -821,6 +821,28 @@ pub impl Hash for Bytes with fn hash_combine(self, hasher) {
 }
 
 ///|
+// Keep the xxHash32 accumulator local for the common `Hash::hash` path. This
+// avoids allocating a `Hasher` for every Bytes key lookup while preserving the
+// `Hash::hash_combine` result. JavaScript already optimizes the default path
+// better than this explicit loop.
+#cfg(not(target="js"))
+pub impl Hash for Bytes with fn hash(self : Bytes) -> Int {
+  let mut acc = seed.reinterpret_as_uint() + GPRIME5
+  let (cur, remain) = for cur = 0, remain = self.length(); remain >= 4; {
+    acc += 4U
+    acc = consume4_acc(acc, self.unsafe_read_uint32_le(cur))
+    continue cur + 4, remain - 4
+  } nobreak {
+    (cur, remain)
+  }
+  for cur = cur, remain = remain; remain >= 1; {
+    acc = rotl(acc + self.unsafe_get(cur).to_uint() * GPRIME5, 11) * GPRIME1
+    continue cur + 1, remain - 1
+  }
+  finalize_acc(acc)
+}
+
+///|
 /// Returns a new `Bytes` consisting of `self` repeated `count` times.
 ///
 /// Aborts if `count` is negative. If `count == 0` or `self` is empty, an empty

--- a/builtin/bytes_hash_bench_test.mbt
+++ b/builtin/bytes_hash_bench_test.mbt
@@ -1,0 +1,62 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn make_bytes_hash_bench_bytes(length : Int) -> Bytes {
+  Bytes::makei(length, i => ((i * 37 + 11) & 0xff).to_byte())
+}
+
+///|
+let bytes_hash_bench_map_size = 1024
+
+///|
+fn make_bytes_hash_bench_map_keys() -> Array[Bytes] {
+  Array::makei(bytes_hash_bench_map_size, i => {
+    Bytes::makei(32, j => ((i * 17 + j * 37 + 11) & 0xff).to_byte())
+  })
+}
+
+///|
+fn make_bytes_hash_bench_map(keys : Array[Bytes]) -> Map[Bytes, Int] {
+  let map : Map[Bytes, Int] = Map([], capacity=bytes_hash_bench_map_size * 2)
+  for i in 0..<keys.length() {
+    map.set(keys[i], i)
+  }
+  map
+}
+
+///|
+test "bench Hash::hash(Bytes) n=32" (it : @bench.T) {
+  let bytes = make_bytes_hash_bench_bytes(32)
+  it.bench(fn() { it.keep(Hash::hash(bytes)) })
+}
+
+///|
+test "bench Hash::hash(Bytes) n=8192" (it : @bench.T) {
+  let bytes = make_bytes_hash_bench_bytes(8192)
+  it.bench(fn() { it.keep(Hash::hash(bytes)) })
+}
+
+///|
+test "bench Map::at Bytes n=1024 key_bytes=32" (it : @bench.T) {
+  let keys = make_bytes_hash_bench_map_keys()
+  let map = make_bytes_hash_bench_map(keys)
+  it.bench(fn() {
+    let mut sum = 0
+    for key in keys {
+      sum += map.at(key)
+    }
+    it.keep(sum)
+  })
+}

--- a/builtin/bytes_hash_bench_test.mbt
+++ b/builtin/bytes_hash_bench_test.mbt
@@ -23,7 +23,15 @@ let bytes_hash_bench_map_size = 1024
 ///|
 fn make_bytes_hash_bench_map_keys() -> Array[Bytes] {
   Array::makei(bytes_hash_bench_map_size, i => {
-    Bytes::makei(32, j => ((i * 17 + j * 37 + 11) & 0xff).to_byte())
+    Bytes::makei(32, j => {
+      if j == 0 {
+        (i & 0xff).to_byte()
+      } else if j == 1 {
+        (i >> 8).to_byte()
+      } else {
+        ((i * 17 + j * 37 + 11) & 0xff).to_byte()
+      }
+    })
   })
 }
 
@@ -34,6 +42,12 @@ fn make_bytes_hash_bench_map(keys : Array[Bytes]) -> Map[Bytes, Int] {
     map.set(keys[i], i)
   }
   map
+}
+
+///|
+test "bytes hash bench map keys are distinct" {
+  let keys = make_bytes_hash_bench_map_keys()
+  assert_eq(make_bytes_hash_bench_map(keys).length(), bytes_hash_bench_map_size)
 }
 
 ///|

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -230,6 +230,15 @@ test "primitive hash matches hash_combine default path" {
 }
 
 ///|
+test "bytes hash matches hash_combine" {
+  for length in [0, 1, 2, 3, 4, 5, 7, 8, 31, 32, 33, 8192] {
+    assert_hash_matches_hash_combine(
+      Bytes::makei(length, i => ((i * 37 + 11) & 0xff).to_byte()),
+    )
+  }
+}
+
+///|
 test "combine_unit" {
   let hasher = @builtin.Hasher(seed=0)
   hasher.combine_unit()


### PR DESCRIPTION
## Summary

- override `Hash::hash` for `Bytes` on non-JS targets, keeping the xxHash32 accumulator local
- retain the existing default path on JS, where the explicit loop regresses
- add hash compatibility coverage and benchmarks for direct hashing and `Map[Bytes, Int]` lookups

`Map` operations such as `set`, `get`, and `at` call `Hash::hash`, so this removes the per-lookup `Hasher` allocation for `Bytes` keys.

## Benchmarks

Native (`--release`):

- `Hash::hash(Bytes 32 B)`: 14.30 ns -> 7.55 ns (~47% faster)
- `Hash::hash(Bytes 8 KiB)`: 2.94 us -> 2.79 us
- `Map::at` (1,024 keys × 32 B): 15.05 us -> 8.02 us (~47% faster)

The direct hash path also improves wasm and wasm-gc. JS keeps the current default implementation to avoid a regression.

## Validation

- `moon bench --package builtin --file bytes_hash_bench_test.mbt --target all --release`
- `moon test builtin --target all --quiet`
- `moon check builtin --target all`
- `moon info builtin`
- `moon fmt builtin/bytes.mbt builtin/hasher_test.mbt builtin/bytes_hash_bench_test.mbt`