### PR TITLE
feat: enable implicit_impl_as_method; make trait promotions explicit

### DIFF
--- a/argparse/extends.mbt
+++ b/argparse/extends.mbt
@@ -1,0 +1,97 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend FlagAction with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend OptionAction with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend ValueRange with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend ValueSource with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend ArgGroup with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Command with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend FlagAction with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend FlagArg with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Matches with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend OptionAction with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend OptionArg with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend PositionArg with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend ValueRange with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend ValueSource with @debug.Debug::{to_repr}
+
+///|
+pub extend FlagAction with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend FlagAction with Show::{output}
+
+///|
+pub extend OptionAction with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend OptionAction with Show::{output}
+
+///|
+pub extend ValueRange with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend ValueRange with Show::{output}
+
+///|
+pub extend ValueSource with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend ValueSource with Show::{output}

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub struct ArgGroup {
 } derive(@debug.Debug)
 #alias(new, deprecated)
 pub fn ArgGroup::ArgGroup(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
+#deprecated
+pub fn ArgGroup::to_repr(Self) -> @debug.Repr
 
 pub struct Command {
   // private fields
@@ -24,6 +26,8 @@ pub fn Command::Command(StringView, flags? : ArrayView[FlagArg], options? : Arra
 #as_free_fn
 pub fn Command::parse(Self, argv? : ArrayView[String], env? : Map[String, String]) -> Matches raise
 pub fn Command::render_help(Self) -> String
+#deprecated
+pub fn Command::to_repr(Self) -> @debug.Repr
 
 pub(all) enum FlagAction {
   SetTrue
@@ -32,12 +36,23 @@ pub(all) enum FlagAction {
   Help
   Version
 } derive(Eq, Show, @debug.Debug)
+#deprecated
+pub fn FlagAction::equal(Self, Self) -> Bool
+#deprecated
+pub fn FlagAction::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn FlagAction::output(Self, &Logger) -> Unit
+#deprecated
+pub fn FlagAction::to_repr(Self) -> @debug.Repr
+pub fn FlagAction::to_string(Self) -> String
 
 pub struct FlagArg {
   // private fields
 } derive(@debug.Debug)
 #alias(new, deprecated)
 pub fn FlagArg::FlagArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : FlagAction, env? : StringView, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, negatable? : Bool, hidden? : Bool) -> Self
+#deprecated
+pub fn FlagArg::to_repr(Self) -> @debug.Repr
 
 pub struct Matches {
   flags : Map[String, Bool]
@@ -47,36 +62,69 @@ pub struct Matches {
   subcommand : (String, Matches)?
   // private fields
 } derive(@debug.Debug)
+#deprecated
+pub fn Matches::to_repr(Self) -> @debug.Repr
 
 pub(all) enum OptionAction {
   Set
   Append
 } derive(Eq, Show, @debug.Debug)
+#deprecated
+pub fn OptionAction::equal(Self, Self) -> Bool
+#deprecated
+pub fn OptionAction::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn OptionAction::output(Self, &Logger) -> Unit
+#deprecated
+pub fn OptionAction::to_repr(Self) -> @debug.Repr
+pub fn OptionAction::to_string(Self) -> String
 
 pub struct OptionArg {
   // private fields
 } derive(@debug.Debug)
 #alias(new, deprecated)
 pub fn OptionArg::OptionArg(StringView, short? : Char, long? : StringView, about? : StringView, action? : OptionAction, env? : StringView, default_values? : ArrayView[String], allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], required? : Bool, global? : Bool, hidden? : Bool) -> Self
+#deprecated
+pub fn OptionArg::to_repr(Self) -> @debug.Repr
 
 pub struct PositionArg {
   // private fields
 } derive(@debug.Debug)
 #alias(new, deprecated)
 pub fn PositionArg::PositionArg(StringView, about? : StringView, env? : StringView, default_values? : ArrayView[String], num_args? : ValueRange, allow_hyphen_values? : Bool, requires? : ArrayView[String], conflicts_with? : ArrayView[String], global? : Bool, hidden? : Bool) -> Self
+#deprecated
+pub fn PositionArg::to_repr(Self) -> @debug.Repr
 
 pub struct ValueRange {
   // private fields
 } derive(Eq, Show, @debug.Debug)
 #alias(new, deprecated)
 pub fn ValueRange::ValueRange(lower? : Int, upper? : Int) -> Self
+#deprecated
+pub fn ValueRange::equal(Self, Self) -> Bool
+#deprecated
+pub fn ValueRange::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn ValueRange::output(Self, &Logger) -> Unit
 pub fn ValueRange::single() -> Self
+#deprecated
+pub fn ValueRange::to_repr(Self) -> @debug.Repr
+pub fn ValueRange::to_string(Self) -> String
 
 pub enum ValueSource {
   Argv
   Env
   Default
 } derive(Eq, Show, @debug.Debug)
+#deprecated
+pub fn ValueSource::equal(Self, Self) -> Bool
+#deprecated
+pub fn ValueSource::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn ValueSource::output(Self, &Logger) -> Unit
+#deprecated
+pub fn ValueSource::to_repr(Self) -> @debug.Repr
+pub fn ValueSource::to_string(Self) -> String
 
 // Type aliases
 

--- a/bench/extends.mbt
+++ b/bench/extends.mbt
@@ -1,0 +1,28 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Bench with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Summary with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Timestamp with @debug.Debug::{to_repr}
+
+///|
+pub extend Summary with ToJson::{to_json}

--- a/bench/pkg.generated.mbti
+++ b/bench/pkg.generated.mbti
@@ -24,11 +24,18 @@ pub fn Bench::Bench() -> Self
 pub fn Bench::bench(Self, name? : String, () -> Unit, count? : UInt) -> Unit
 pub fn Bench::dump_summaries(Self) -> String
 pub fn[Any] Bench::keep(Self, Any) -> Unit
+#deprecated
+pub fn Bench::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for Bench
 
 type Summary derive(ToJson, @debug.Debug)
+pub fn Summary::to_json(Self) -> Json
+#deprecated
+pub fn Summary::to_repr(Self) -> @debug.Repr
 
 type Timestamp
+#deprecated
+pub fn Timestamp::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for Timestamp
 
 // Type aliases

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -283,21 +283,21 @@ pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
 }
 
 ///|
-extern "js" fn BigInt::compare(self : BigInt, other : BigInt) -> Int =
+extern "js" fn BigInt::compare_js(self : BigInt, other : BigInt) -> Int =
   #|(x, y) => x < y ? -1 : x > y ? 1 : 0
 
 ///|
 pub impl Compare for BigInt with fn compare(self, other) {
-  self.compare(other)
+  self.compare_js(other)
 }
 
 ///|
-extern "js" fn BigInt::equal(self : BigInt, other : BigInt) -> Bool =
+extern "js" fn BigInt::equal_js(self : BigInt, other : BigInt) -> Bool =
   #|(x, y) => x === y
 
 ///|
 pub impl Eq for BigInt with fn equal(self, other) {
-  self.equal(other)
+  self.equal_js(other)
 }
 
 ///|

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1220,10 +1220,10 @@ test "@bigint.BigInt::hash" {
       x.finalize()
     }
   inspect(hash1, content="-813420232")
-  assert_eq(0N.hash(), (-0N).hash())
+  assert_eq(Hash::hash(0N), Hash::hash(-0N))
 
   // Positive and negative of same magnitude should have different hashes
-  assert_not_eq(1N.hash(), (-1N).hash())
+  assert_not_eq(Hash::hash(1N), Hash::hash(-1N))
 
   // Test small positive numbers
   let hash2 = Hasher(seed=0)
@@ -1301,16 +1301,16 @@ test "@bigint.BigInt::hash" {
 test "@bigint.BigInt::hash consistency" {
   // Test that hash is consistent across multiple calls
   let big = 999888777666555444333222111N
-  let hash1 = big.hash()
-  let hash2 = big.hash()
-  let hash3 = big.hash()
+  let hash1 = Hash::hash(big)
+  let hash2 = Hash::hash(big)
+  let hash3 = Hash::hash(big)
   assert_eq(hash1, hash2)
   assert_eq(hash1, hash3)
 
   // Test with negative number
   let neg_big = -big
-  let neg_hash1 = neg_big.hash()
-  let neg_hash2 = neg_big.hash()
+  let neg_hash1 = Hash::hash(neg_big)
+  let neg_hash2 = Hash::hash(neg_big)
   assert_eq(neg_hash1, neg_hash2)
   assert_not_eq(hash1, neg_hash1)
 }
@@ -1324,7 +1324,7 @@ test "default" {
 ///|
 test "BigInt bit ops and arbitrary" {
   let rs = @splitmix.new(seed=1)
-  let _ = @bigint.BigInt::arbitrary(1, rs)
+  let _ : @bigint.BigInt = @quickcheck.Arbitrary::arbitrary(1, rs)
   let small = @bigint.BigInt::from_int(1)
   let big = @bigint.BigInt::from_string("123456789012345678901234567891")
   inspect(small.land(big).to_string(), content="1")

--- a/bigint/extends.mbt
+++ b/bigint/extends.mbt
@@ -1,0 +1,39 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend BigInt with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend BigInt with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend BigInt with @json.FromJson::{from_json}
+
+///|
+pub extend BigInt with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend BigInt with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend BigInt with Show::{output}
+
+///|
+pub extend BigInt with ToJson::{to_json}

--- a/bigint/extends_js.mbt
+++ b/bigint/extends_js.mbt
@@ -1,0 +1,47 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend BigInt with Eq::{equal, not_equal}
+
+///|
+pub extend BigInt with Add::{add}
+
+///|
+pub extend BigInt with BitAnd::{land}
+
+///|
+pub extend BigInt with BitOr::{lor}
+
+///|
+pub extend BigInt with BitXOr::{lxor}
+
+///|
+pub extend BigInt with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend BigInt with Div::{div}
+
+///|
+pub extend BigInt with Mod::{mod}
+
+///|
+pub extend BigInt with Mul::{mul}
+
+///|
+pub extend BigInt with Neg::{neg}
+
+///|
+pub extend BigInt with Sub::{sub}

--- a/bigint/extends_nonjs.mbt
+++ b/bigint/extends_nonjs.mbt
@@ -1,0 +1,47 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend BigInt with Eq::{equal, not_equal}
+
+///|
+pub extend BigInt with Add::{add}
+
+///|
+pub extend BigInt with BitAnd::{land}
+
+///|
+pub extend BigInt with BitOr::{lor}
+
+///|
+pub extend BigInt with BitXOr::{lxor}
+
+///|
+pub extend BigInt with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend BigInt with Div::{div}
+
+///|
+pub extend BigInt with Mod::{mod}
+
+///|
+pub extend BigInt with Mul::{mul}
+
+///|
+pub extend BigInt with Neg::{neg}
+
+///|
+pub extend BigInt with Sub::{sub}

--- a/bigint/moon.pkg
+++ b/bigint/moon.pkg
@@ -28,5 +28,7 @@ options(
     "bigint_js_wbtest.mbt": [ "js" ],
     "bigint_nonjs.mbt": [ "not", "js" ],
     "bigint_nonjs_wbtest.mbt": [ "not", "js" ],
+    "extends_js.mbt": [ "js" ],
+    "extends_nonjs.mbt": [ "not", "js" ],
   },
 )

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -14,14 +14,22 @@ import {
 
 // Types and methods
 type BigInt
+pub fn BigInt::add(Self, Self) -> Self
+#deprecated
+pub fn BigInt::arbitrary(Int, @splitmix.RandomState) -> Self
 #deprecated
 pub fn BigInt::asr(Self, Int) -> Self
 pub fn BigInt::bit_length(Self) -> Int
+pub fn BigInt::compare(Self, Self) -> Int
 pub fn BigInt::compare_int(Self, Int) -> Int
 pub fn BigInt::compare_int64(Self, Int64) -> Int
 pub fn BigInt::compare_uint(Self, UInt) -> Int
 pub fn BigInt::compare_uint64(Self, UInt64) -> Int
 pub fn BigInt::ctz(Self) -> Int
+pub fn BigInt::default() -> Self
+pub fn BigInt::div(Self, Self) -> Self
+#deprecated
+pub fn BigInt::equal(Self, Self) -> Bool
 pub fn BigInt::equal_int(Self, Int) -> Bool
 pub fn BigInt::equal_int64(Self, Int64) -> Bool
 pub fn BigInt::equal_uint(Self, UInt) -> Bool
@@ -30,24 +38,48 @@ pub fn BigInt::equal_uint64(Self, UInt64) -> Bool
 pub fn BigInt::from_hex(String) -> Self
 pub fn BigInt::from_int(Int) -> Self
 pub fn BigInt::from_int64(Int64) -> Self
+#deprecated
+pub fn BigInt::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BigInt::from_octets(BytesView, signum? : Int) -> Self
 pub fn BigInt::from_string(String, radix? : Int) -> Self
 pub fn BigInt::from_uint(UInt) -> Self
 pub fn BigInt::from_uint64(UInt64) -> Self
+#deprecated
+pub fn BigInt::hash(Self) -> Int
+#deprecated
+pub fn BigInt::hash_combine(Self, Hasher) -> Unit
 pub fn BigInt::is_zero(Self) -> Bool
+pub fn BigInt::land(Self, Self) -> Self
+pub fn BigInt::lor(Self, Self) -> Self
 #deprecated
 pub fn BigInt::lsl(Self, Int) -> Self
+pub fn BigInt::lxor(Self, Self) -> Self
+pub fn BigInt::mod(Self, Self) -> Self
+pub fn BigInt::mul(Self, Self) -> Self
+pub fn BigInt::neg(Self) -> Self
+#deprecated
+pub fn BigInt::not_equal(Self, Self) -> Bool
+pub fn BigInt::op_ge(Self, Self) -> Bool
+pub fn BigInt::op_gt(Self, Self) -> Bool
+pub fn BigInt::op_le(Self, Self) -> Bool
+pub fn BigInt::op_lt(Self, Self) -> Bool
+#deprecated
+pub fn BigInt::output(Self, &Logger) -> Unit
 pub fn BigInt::pow(Self, Self, modulus? : Self) -> Self
 #deprecated
 pub fn BigInt::shl(Self, Int) -> Self
 #deprecated
 pub fn BigInt::shr(Self, Int) -> Self
+pub fn BigInt::sub(Self, Self) -> Self
 #deprecated
 pub fn BigInt::to_hex(Self, uppercase? : Bool) -> String
 pub fn BigInt::to_int(Self) -> Int
 pub fn BigInt::to_int16(Self) -> Int16
 pub fn BigInt::to_int64(Self) -> Int64
+pub fn BigInt::to_json(Self) -> Json
 pub fn BigInt::to_octets(Self, length? : Int) -> Bytes
+#deprecated
+pub fn BigInt::to_repr(Self) -> @debug.Repr
 pub fn BigInt::to_string(Self, radix? : Int) -> String
 pub fn BigInt::to_uint(Self) -> UInt
 pub fn BigInt::to_uint16(Self) -> UInt16

--- a/bool/bool_test.mbt
+++ b/bool/bool_test.mbt
@@ -58,3 +58,15 @@ test "bool convert" {
   inspect(true.to_int16(), content="1")
   inspect(false.to_int16(), content="0")
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend TestHash with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend TestHash with Debug::{to_repr}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend TestHash with Hash::{hash, hash_combine}

--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -1013,6 +1013,21 @@ pub impl Logger for Buffer with fn write_char(self : Buffer, value : Char) -> Un
 }
 
 ///|
+/// Deprecated substring writer, kept as a regular method (rather than a promoted
+/// `Logger` method) because `Logger::write_substring` is itself deprecated and
+/// cannot be referenced from a cross-package `extend`. Delegates to `write_view`,
+/// matching the `Logger` trait's default behavior.
+#deprecated("use `write_view` instead", skip_current_package=true)
+pub fn Buffer::write_substring(
+  self : Buffer,
+  value : String,
+  start : Int,
+  len : Int,
+) -> Unit {
+  self.write_view(value[start:start + len])
+}
+
+///|
 /// Writes a single byte to the end of the buffer. The buffer will automatically
 /// grow if necessary to accommodate the new byte.
 ///

--- a/buffer/extends.mbt
+++ b/buffer/extends.mbt
@@ -1,0 +1,34 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+// `write_substring` is intentionally omitted here: it is a deprecated `Logger`
+// method, and `extend`ing it from this (cross-)package would reference a
+// deprecated method (an error). Instead it is shadowed by a manual
+// `#deprecated fn Buffer::write_substring` in buffer.mbt, which clears the
+// promotion without needing a package-level exemption.
+pub extend Buffer with Logger::{
+  write,
+  write_char,
+  write_string,
+  write_string_interpolation,
+  write_view,
+}
+
+///|
+pub extend Buffer with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Buffer with Show::{output}

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -22,15 +22,22 @@ type Buffer
 pub fn Buffer::Buffer(size_hint? : Int) -> Self
 pub fn Buffer::is_empty(Self) -> Bool
 pub fn Buffer::length(Self) -> Int
+#deprecated
+pub fn Buffer::output(Self, &Logger) -> Unit
 pub fn Buffer::reset(Self) -> Unit
 #alias(contents)
 pub fn Buffer::to_bytes(Self) -> Bytes
 #deprecated
 pub fn Buffer::to_repr(Self) -> @debug.Repr
+pub fn Buffer::to_string(Self) -> String
 pub fn Buffer::view(Self) -> ArrayView[Byte]
+#deprecated
+pub fn Buffer::write(Self, &Show) -> Unit
 pub fn Buffer::write_byte(Self, Byte) -> Unit
 pub fn Buffer::write_bytes(Self, BytesView) -> Unit
 pub fn Buffer::write_bytesview(Self, BytesView) -> Unit
+#deprecated
+pub fn Buffer::write_char(Self, Char) -> Unit
 pub fn Buffer::write_char_utf16be(Self, Char) -> Unit
 pub fn Buffer::write_char_utf16le(Self, Char) -> Unit
 pub fn Buffer::write_char_utf8(Self, Char) -> Unit
@@ -48,10 +55,16 @@ pub fn Buffer::write_iter(Self, Iter[Byte]) -> Unit
 pub fn[A : Leb128] Buffer::write_leb128(Self, A) -> Unit
 #deprecated
 pub fn Buffer::write_object(Self, &Show) -> Unit
+#deprecated
+pub fn Buffer::write_string(Self, String) -> Unit
+#deprecated
+pub fn Buffer::write_string_interpolation(Self, &Show) -> Unit
 pub fn Buffer::write_string_utf16be(Self, StringView) -> Unit
 #alias(write_stringview, deprecated)
 pub fn Buffer::write_string_utf16le(Self, StringView) -> Unit
 pub fn Buffer::write_string_utf8(Self, StringView) -> Unit
+#deprecated
+pub fn Buffer::write_substring(Self, String, Int, Int) -> Unit
 pub fn Buffer::write_uint16_be(Self, UInt16) -> Unit
 pub fn Buffer::write_uint16_le(Self, UInt16) -> Unit
 pub fn Buffer::write_uint64_be(Self, UInt64) -> Unit
@@ -60,6 +73,8 @@ pub fn Buffer::write_uint_be(Self, UInt) -> Unit
 pub fn Buffer::write_uint_le(Self, UInt) -> Unit
 #alias(write_bytes_interpolation)
 pub fn[T : Show] Buffer::write_utf8(Self, T) -> Unit
+#deprecated
+pub fn Buffer::write_view(Self, StringView) -> Unit
 #deprecated
 pub impl Logger for Buffer
 pub impl Show for Buffer

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -299,7 +299,7 @@ pub impl[T : Eq] Eq for Array[T] with fn equal(self, other) {
 ///|
 pub impl[T : Hash] Hash for Array[T] with fn hash_combine(self, hasher) {
   for v in self {
-    v.hash_combine(hasher)
+    Hash::hash_combine(v, hasher)
   }
 }
 

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -1595,3 +1595,9 @@ test "timsort_early_return_for_small_arrays" {
   // With the bug, we get at least 45 + 9 = 54 comparisons.
   inspect(count.val, content="45")
 }
+
+///|
+pub extend MX with Default::{default}
+
+///|
+pub extend MX with ToJson::{to_json}

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -531,7 +531,7 @@ test "arrayview hash invariant" {
   let arr : Array[Array[Int]] = @quickcheck.samples(20)
   for v in arr {
     let view = v[:]
-    @test.assert_eq(v.hash(), view.hash())
+    @test.assert_eq(Hash::hash(v), Hash::hash(view))
   }
 }
 

--- a/builtin/bytes_equal_bench_test.mbt
+++ b/builtin/bytes_equal_bench_test.mbt
@@ -37,7 +37,7 @@ fn make_bytes_equal_bench_aliases() -> Array[Bytes] {
 test "bench Bytes::equal n=100000 equal" (it : @bench.T) {
   let left = make_bytes_equal_bench_bytes()
   let right = make_bytes_equal_bench_bytes()
-  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+  it.bench(fn() { it.keep(left == right) })
 }
 
 ///|
@@ -46,7 +46,7 @@ test "bench Bytes::equal n=100000 aliased object" (it : @bench.T) {
   let mut index = 0
   it.bench(fn() {
     index = 1 - index
-    it.keep(Bytes::equal(aliases[index], aliases[1 - index]))
+    it.keep(aliases[index] == aliases[1 - index])
   })
 }
 
@@ -54,5 +54,5 @@ test "bench Bytes::equal n=100000 aliased object" (it : @bench.T) {
 test "bench Bytes::equal n=100000 mismatch at end" (it : @bench.T) {
   let left = make_bytes_equal_bench_bytes()
   let right = make_bytes_equal_bench_bytes(diff_at=bytes_equal_bench_size - 1)
-  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+  it.bench(fn() { it.keep(left == right) })
 }

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -223,7 +223,7 @@ test "Bytes::equal with differing bytes" {
   arr2[2] = 0x04
   let bytes1 = Bytes::from_array(arr1)
   let bytes2 = Bytes::from_array(arr2)
-  inspect(Bytes::equal(bytes1, bytes2), content="false")
+  inspect(bytes1 == bytes2, content="false")
 }
 
 ///|

--- a/builtin/char_test.mbt
+++ b/builtin/char_test.mbt
@@ -85,3 +85,7 @@ test "char printable and ascii case" {
 test "panic Char::is_digit invalid radix" {
   '0'.is_digit(1U) |> ignore
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend H with @debug.Debug::{to_repr}

--- a/builtin/double_test.mbt
+++ b/builtin/double_test.mbt
@@ -17,9 +17,9 @@ test "hash" {
   let d1 = 123.456
   let d2 = 789.012
   let d3 = 123.456
-  @test.assert_eq(d1.hash(), d1.reinterpret_as_int64() |> Hash::hash())
-  @test.assert_not_eq(d1.hash(), d2.hash())
-  @test.assert_eq(d1.hash(), d3.hash())
+  @test.assert_eq(Hash::hash(d1), d1.reinterpret_as_int64() |> Hash::hash())
+  @test.assert_not_eq(Hash::hash(d1), Hash::hash(d2))
+  @test.assert_eq(Hash::hash(d1), Hash::hash(d3))
 }
 
 ///|

--- a/builtin/extends.mbt
+++ b/builtin/extends.mbt
@@ -1,0 +1,1020 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Array with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend ArrayView with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Bool with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Byte with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Bytes with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend BytesView with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Char with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Double with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend FixedArray with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Int with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Int64 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Json with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Map with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend MutArrayView with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Option with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend ReadOnlyArray with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Result with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend String with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend StringView with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend UInt with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend UInt16 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend UInt64 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Unit with Eq::{equal, not_equal}
+
+///|
+pub extend ArgsLoc with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend ArgsLoc with Show::{output}
+
+///|
+pub extend Array with Add::{add}
+
+///|
+pub extend Array with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Array with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Array with Hash::{hash, hash_combine}
+
+///|
+pub extend Array with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Array with Show::{output}
+
+///|
+pub extend Array with ToJson::{to_json}
+
+///|
+pub extend ArrayView with Add::{add}
+
+///|
+pub extend ArrayView with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend ArrayView with Hash::{hash, hash_combine}
+
+///|
+pub extend ArrayView with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend ArrayView with Show::{output}
+
+///|
+pub extend ArrayView with ToJson::{to_json}
+
+///|
+pub extend Bool with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Bool with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Bool with Hash::{hash, hash_combine}
+
+///|
+pub extend Bool with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Bool with Show::{output}
+
+///|
+pub extend Bool with ToJson::{to_json}
+
+///|
+pub extend Byte with Add::{add}
+
+///|
+pub extend Byte with BitAnd::{land}
+
+///|
+pub extend Byte with BitOr::{lor}
+
+///|
+pub extend Byte with BitXOr::{lxor}
+
+///|
+pub extend Byte with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Byte with Default::{default}
+
+///|
+pub extend Byte with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Byte with Hash::{hash, hash_combine}
+
+///|
+pub extend Byte with Mod::{mod}
+
+///|
+pub extend Byte with Mul::{mul}
+
+///|
+pub extend Byte with Shl::{shl}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Byte with Show::{output}
+
+///|
+pub extend Byte with Shr::{shr}
+
+///|
+pub extend Byte with Sub::{sub}
+
+///|
+pub extend Byte with ToJson::{to_json}
+
+///|
+pub extend Bytes with Add::{add}
+
+///|
+pub extend Bytes with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Bytes with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Bytes with Hash::{hash, hash_combine}
+
+///|
+pub extend Bytes with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Bytes with Show::{output}
+
+///|
+pub extend Bytes with ToJson::{to_json}
+
+///|
+pub extend BytesView with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend BytesView with Hash::{hash, hash_combine}
+
+///|
+pub extend BytesView with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend BytesView with Show::{output}
+
+///|
+pub extend BytesView with ToJson::{to_json}
+
+///|
+pub extend Char with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Char with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Char with Hash::{hash, hash_combine}
+
+///|
+pub extend Char with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Char with Show::{output}
+
+///|
+pub extend Char with ToJson::{to_json}
+
+///|
+pub extend Double with Add::{add}
+
+///|
+pub extend Double with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Double with Default::{default}
+
+///|
+pub extend Double with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Double with Hash::{hash, hash_combine}
+
+///|
+pub extend Double with Mul::{mul}
+
+///|
+pub extend Double with Neg::{neg}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Double with Show::{output}
+
+///|
+pub extend Double with Sub::{sub}
+
+///|
+pub extend Double with ToJson::{to_json}
+
+///|
+pub extend Failure with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Failure with Show::{output}
+
+///|
+pub extend Failure with ToJson::{to_json}
+
+///|
+pub extend FixedArray with Add::{add}
+
+///|
+pub extend FixedArray with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend FixedArray with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend FixedArray with Hash::{hash, hash_combine}
+
+///|
+pub extend FixedArray with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend FixedArray with Show::{output}
+
+///|
+pub extend FixedArray with ToJson::{to_json}
+
+///|
+pub extend Int with Add::{add}
+
+///|
+pub extend Int with BitAnd::{land}
+
+///|
+pub extend Int with BitOr::{lor}
+
+///|
+pub extend Int with BitXOr::{lxor}
+
+///|
+pub extend Int with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Int with Default::{default}
+
+///|
+pub extend Int with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Int with Hash::{hash, hash_combine}
+
+///|
+pub extend Int with Mod::{mod}
+
+///|
+pub extend Int with Mul::{mul}
+
+///|
+pub extend Int with Neg::{neg}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Int with Show::{output}
+
+///|
+pub extend Int with Sub::{sub}
+
+///|
+pub extend Int with ToJson::{to_json}
+
+///|
+pub extend Int64 with Add::{add}
+
+///|
+pub extend Int64 with BitAnd::{land}
+
+///|
+pub extend Int64 with BitOr::{lor}
+
+///|
+pub extend Int64 with BitXOr::{lxor}
+
+///|
+pub extend Int64 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Int64 with Default::{default}
+
+///|
+pub extend Int64 with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Int64 with Hash::{hash, hash_combine}
+
+///|
+pub extend Int64 with Mod::{mod}
+
+///|
+pub extend Int64 with Mul::{mul}
+
+///|
+pub extend Int64 with Neg::{neg}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Int64 with Show::{output}
+
+///|
+pub extend Int64 with Sub::{sub}
+
+///|
+pub extend Int64 with ToJson::{to_json}
+
+///|
+pub extend Iter with Add::{add}
+
+///|
+pub extend Iter with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Iter with Show::{output}
+
+///|
+pub extend Iter with ToJson::{to_json}
+
+///|
+pub extend Iter2 with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Iter2 with Show::{output}
+
+///|
+pub extend Json with Default::{default}
+
+///|
+pub extend Map with Default::{default}
+
+///|
+pub extend Map with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Map with Show::{output}
+
+///|
+pub extend Map with ToJson::{to_json}
+
+///|
+pub extend MutArrayView with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend MutArrayView with Hash::{hash, hash_combine}
+
+///|
+pub extend MutArrayView with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend MutArrayView with Show::{output}
+
+///|
+pub extend Option with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Option with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Option with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Option with Show::{output}
+
+///|
+pub extend Option with ToJson::{to_json}
+
+///|
+pub extend ReadOnlyArray with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend ReadOnlyArray with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend ReadOnlyArray with Hash::{hash, hash_combine}
+
+///|
+pub extend ReadOnlyArray with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend ReadOnlyArray with Show::{output}
+
+///|
+pub extend ReadOnlyArray with ToJson::{to_json}
+
+///|
+pub extend Result with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Result with Hash::{hash, hash_combine}
+
+///|
+pub extend Result with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Result with Show::{output}
+
+///|
+pub extend Result with ToJson::{to_json}
+
+///|
+pub extend SourceLoc with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend SourceLoc with Show::{output}
+
+///|
+pub extend String with Add::{add}
+
+///|
+pub extend String with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend String with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend String with Hash::{hash, hash_combine}
+
+///|
+pub extend String with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend String with Show::{output}
+
+///|
+pub extend String with ToJson::{to_json}
+
+///|
+pub extend String with ToStringView::{to_string_view}
+
+///|
+pub extend StringView with Add::{add}
+
+///|
+pub extend StringView with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend StringView with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend StringView with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend StringView with Show::{output}
+
+///|
+pub extend StringView with ToJson::{to_json}
+
+///|
+pub extend StringView with ToStringView::{to_string_view}
+
+///|
+pub extend UInt with Add::{add}
+
+///|
+pub extend UInt with BitAnd::{land}
+
+///|
+pub extend UInt with BitOr::{lor}
+
+///|
+pub extend UInt with BitXOr::{lxor}
+
+///|
+pub extend UInt with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend UInt with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend UInt with Hash::{hash, hash_combine}
+
+///|
+pub extend UInt with Mod::{mod}
+
+///|
+pub extend UInt with Mul::{mul}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend UInt with Show::{output}
+
+///|
+pub extend UInt with Sub::{sub}
+
+///|
+pub extend UInt with ToJson::{to_json}
+
+///|
+pub extend UInt16 with Add::{add}
+
+///|
+pub extend UInt16 with BitAnd::{land}
+
+///|
+pub extend UInt16 with BitOr::{lor}
+
+///|
+pub extend UInt16 with BitXOr::{lxor}
+
+///|
+pub extend UInt16 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend UInt16 with Default::{default}
+
+///|
+pub extend UInt16 with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend UInt16 with Hash::{hash, hash_combine}
+
+///|
+pub extend UInt16 with Mod::{mod}
+
+///|
+pub extend UInt16 with Mul::{mul}
+
+///|
+pub extend UInt16 with Shl::{shl}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend UInt16 with Show::{output}
+
+///|
+pub extend UInt16 with Shr::{shr}
+
+///|
+pub extend UInt16 with Sub::{sub}
+
+///|
+pub extend UInt16 with ToJson::{to_json}
+
+///|
+pub extend UInt64 with Add::{add}
+
+///|
+pub extend UInt64 with BitAnd::{land}
+
+///|
+pub extend UInt64 with BitOr::{lor}
+
+///|
+pub extend UInt64 with BitXOr::{lxor}
+
+///|
+pub extend UInt64 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend UInt64 with Default::{default}
+
+///|
+pub extend UInt64 with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend UInt64 with Hash::{hash, hash_combine}
+
+///|
+pub extend UInt64 with Mod::{mod}
+
+///|
+pub extend UInt64 with Mul::{mul}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend UInt64 with Show::{output}
+
+///|
+pub extend UInt64 with Sub::{sub}
+
+///|
+pub extend UInt64 with ToJson::{to_json}
+
+///|
+pub extend Unit with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Unit with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Unit with Hash::{hash, hash_combine}
+
+///|
+pub extend Unit with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Unit with Show::{output}
+
+///|
+pub extend Unit with ToJson::{to_json}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple10 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple11 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple12 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple13 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple14 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple15 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple16 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple2 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple3 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple4 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple5 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple6 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple7 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple8 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Tuple9 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple10 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple11 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple12 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple13 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple14 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple15 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple16 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple2 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple3 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple4 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple5 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple6 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple7 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple8 with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Tuple9 with Show::{output}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Tuple2 with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Tuple3 with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Tuple4 with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Tuple5 with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Tuple6 with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Tuple7 with Hash::{hash, hash_combine}
+
+///|
+pub extend Tuple10 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple10 with Show::{to_string}
+
+///|
+pub extend Tuple10 with ToJson::{to_json}
+
+///|
+pub extend Tuple11 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple11 with Show::{to_string}
+
+///|
+pub extend Tuple11 with ToJson::{to_json}
+
+///|
+pub extend Tuple12 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple12 with Show::{to_string}
+
+///|
+pub extend Tuple12 with ToJson::{to_json}
+
+///|
+pub extend Tuple13 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple13 with Show::{to_string}
+
+///|
+pub extend Tuple13 with ToJson::{to_json}
+
+///|
+pub extend Tuple14 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple14 with Show::{to_string}
+
+///|
+pub extend Tuple14 with ToJson::{to_json}
+
+///|
+pub extend Tuple15 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple15 with Show::{to_string}
+
+///|
+pub extend Tuple15 with ToJson::{to_json}
+
+///|
+pub extend Tuple16 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple16 with Show::{to_string}
+
+///|
+pub extend Tuple16 with ToJson::{to_json}
+
+///|
+pub extend Tuple2 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple2 with Show::{to_string}
+
+///|
+pub extend Tuple2 with ToJson::{to_json}
+
+///|
+pub extend Tuple3 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple3 with Show::{to_string}
+
+///|
+pub extend Tuple3 with ToJson::{to_json}
+
+///|
+pub extend Tuple4 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple4 with Show::{to_string}
+
+///|
+pub extend Tuple4 with ToJson::{to_json}
+
+///|
+pub extend Tuple5 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple5 with Show::{to_string}
+
+///|
+pub extend Tuple5 with ToJson::{to_json}
+
+///|
+pub extend Tuple6 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple6 with Show::{to_string}
+
+///|
+pub extend Tuple6 with ToJson::{to_json}
+
+///|
+pub extend Tuple7 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple7 with Show::{to_string}
+
+///|
+pub extend Tuple7 with ToJson::{to_json}
+
+///|
+pub extend Tuple8 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple8 with Show::{to_string}
+
+///|
+pub extend Tuple8 with ToJson::{to_json}
+
+///|
+pub extend Tuple9 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Tuple9 with Show::{to_string}
+
+///|
+pub extend Tuple9 with ToJson::{to_json}

--- a/builtin/extends_js.mbt
+++ b/builtin/extends_js.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub extend Double with Mod::{mod}
+
+///|
+pub extend StringBuilder with Logger::{write_char, write_string, write_view}
+
+///|
+#deprecated("use `write_view` instead", skip_current_package=true)
+pub extend StringBuilder with Logger::{write_substring}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend StringBuilder with Show::{output}

--- a/builtin/extends_nonjs.mbt
+++ b/builtin/extends_nonjs.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub extend Double with Mod::{mod}
+
+///|
+pub extend StringBuilder with Logger::{write_char, write_string, write_view}
+
+///|
+#deprecated("use `write_view` instead", skip_current_package=true)
+pub extend StringBuilder with Logger::{write_substring}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend StringBuilder with Show::{output}

--- a/builtin/feature_test.mbt
+++ b/builtin/feature_test.mbt
@@ -95,3 +95,10 @@ test "try!" {
 
   inspect(hello(), content="ello world")
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend RangeImpl with @debug.Debug::{to_repr}
+
+///|
+pub extend RangeImpl with ToJson::{to_json}

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1254,7 +1254,7 @@ pub impl[T : Eq] Eq for FixedArray[T] with fn equal(
 ///|
 pub impl[T : Hash] Hash for FixedArray[T] with fn hash_combine(self, hasher) {
   for v in self {
-    v.hash_combine(hasher)
+    Hash::hash_combine(v, hasher)
   }
 }
 

--- a/builtin/guard_feature_test.mbt
+++ b/builtin/guard_feature_test.mbt
@@ -50,3 +50,14 @@ test "simplify" {
   let simplified = simplify(e)
   @json.json_inspect(simplified, content=["Lit", 0])
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Expr with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Expr with @debug.Debug::{to_repr}
+
+///|
+pub extend Expr with ToJson::{to_json}

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -122,7 +122,7 @@ extern "js" fn random_seed() -> Int =
 /// }
 /// ```
 pub fn[T : Hash] Hasher::combine(self : Hasher, value : T) -> Unit {
-  value.hash_combine(self)
+  Hash::hash_combine(value, self)
 }
 
 ///|

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -1158,7 +1158,7 @@ pub fn[K : Hash + Eq, V] Map::update(
 /// }
 /// ```
 pub fn[V] Map::get_from_bytes(map : Self[Bytes, V], key : BytesView) -> V? {
-  let hash = key.hash()
+  let hash = Hash::hash(key)
   for i = 0, idx = hash & map.capacity_mask {
     guard map.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_bytes(entry.key) {
@@ -1195,7 +1195,7 @@ pub fn[V] Map::get_from_bytes(map : Self[Bytes, V], key : BytesView) -> V? {
 /// }
 /// ```
 pub fn[V] Map::get_from_string(map : Self[String, V], key : StringView) -> V? {
-  let hash = key.hash()
+  let hash = Hash::hash(key)
   for i = 0, idx = hash & map.capacity_mask {
     guard map.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_string(entry.key) {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -586,7 +586,7 @@ test "remove_entry_head" {
   assert_true(head.prev == -1)
   assert_true(head.next is None)
   assert_true(head.psl == 0)
-  assert_true(head.hash == (2).hash())
+  assert_true(head.hash == Hash::hash(2))
   assert_true(head.key == 2)
   assert_true(head.value == 2)
 }
@@ -604,7 +604,7 @@ test "remove_entry_tail" {
   assert_true(tail.prev == -1)
   assert_true(tail.next is None)
   assert_true(tail.psl == 0)
-  assert_true(tail.hash == (1).hash())
+  assert_true(tail.hash == Hash::hash(1))
   assert_true(tail.key == 1)
   assert_true(tail.value == 1)
 }
@@ -647,3 +647,7 @@ fn[K : Show, V : Show] Map::_debug_entries(self : Map[K, V]) -> String {
   }
   buf.to_string()
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend MyString with Eq::{equal, not_equal}

--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -54,5 +54,7 @@ options(
     "panic_wbtest.mbt": [ "not", "native", "llvm" ],
     "stringbuilder_buffer.mbt": [ "not", "js" ],
     "stringbuilder_concat.mbt": [ "js" ],
+    "extends_js.mbt": [ "js" ],
+    "extends_nonjs.mbt": [ "not", "js" ],
   },
 )

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -470,5 +470,5 @@ pub impl[T : Compare] Compare for MutArrayView[T] with fn compare(self, other) -
 
 ///|
 pub impl[A : Hash] Hash for MutArrayView[A] with fn hash_combine(self, hasher) {
-  self[:].hash_combine(hasher)
+  Hash::hash_combine(self[:], hasher)
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -42,6 +42,10 @@ pub(all) suberror BenchError {
 pub(all) suberror Failure {
   Failure(String)
 } derive(Show, ToJson)
+#deprecated
+pub fn Failure::output(Self, &Logger) -> Unit
+pub fn Failure::to_json(Self) -> Json
+pub fn Failure::to_string(Self) -> String
 
 pub(all) suberror InspectError {
   InspectError(String)
@@ -53,10 +57,14 @@ pub(all) suberror SnapshotError {
 
 // Types and methods
 pub(all) struct ArgsLoc(Array[SourceLoc?])
+#deprecated
+pub fn ArgsLoc::output(Self, &Logger) -> Unit
 pub fn ArgsLoc::to_json(Self) -> String
+pub fn ArgsLoc::to_string(Self) -> String
 pub impl Show for ArgsLoc
 
 type Array[T]
+pub fn[T] Array::add(Self[T], Self[T]) -> Self[T]
 #alias(every)
 pub fn[T] Array::all(Self[T], (T) -> Bool raise?) -> Bool raise?
 #alias(exists)
@@ -73,16 +81,20 @@ pub fn[T] Array::capacity(Self[T]) -> Int
 pub fn[T] Array::chunk_by(Self[T], (T, T) -> Bool raise?) -> Self[ArrayView[T]] raise?
 pub fn[T] Array::chunks(Self[T], Int) -> Self[ArrayView[T]]
 pub fn[T] Array::clear(Self[T]) -> Unit
+pub fn[T : Compare] Array::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] Array::contains(Self[T], T) -> Bool
 #alias(clone, deprecated)
 pub fn[T] Array::copy(Self[T]) -> Self[T]
 pub fn[T : Eq] Array::count(Self[T], T) -> Int
 pub fn[T] Array::count_if(Self[T], (T) -> Bool raise?) -> Int raise?
 pub fn[T : Eq] Array::dedup(Self[T]) -> Unit
+pub fn[T] Array::default() -> Self[T]
 pub fn[T] Array::drain(Self[T], Int, Int) -> Self[T]
 pub fn[T] Array::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] Array::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] Array::ends_with(Self[T], ArrayView[T]) -> Bool
+#deprecated
+pub fn[T : Eq] Array::equal(Self[T], Self[T]) -> Bool
 pub fn[T] Array::extract_if(Self[T], (T) -> Bool raise?) -> Self[T] raise?
 pub fn[A] Array::fill(Self[A], A, start? : Int, end? : Int) -> Unit
 pub fn[T] Array::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
@@ -97,6 +109,10 @@ pub fn[T] Array::from_fixed_array(FixedArray[T]) -> Self[T]
 pub fn[T] Array::from_iter(Iter[T]) -> Self[T]
 pub fn[T] Array::get(Self[T], Int) -> T?
 pub fn[T] Array::get_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]?
+#deprecated
+pub fn[T : Hash] Array::hash(Self[T]) -> Int
+#deprecated
+pub fn[T : Hash] Array::hash_combine(Self[T], Hasher) -> Unit
 pub fn[T] Array::insert(Self[T], Int, T) -> Unit
 pub fn[T] Array::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] Array::is_sorted(Self[T]) -> Bool
@@ -118,6 +134,14 @@ pub fn[T, U] Array::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?
 pub fn[T] Array::mapi_in_place(Self[T], (Int, T) -> T raise?) -> Unit raise?
 pub fn[T] Array::mut_view(Self[T], start? : Int, end? : Int) -> MutArrayView[T]
 pub fn[T] Array::new(capacity? : Int) -> Self[T]
+#deprecated
+pub fn[T : Eq] Array::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Array::op_ge(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Array::op_gt(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Array::op_le(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Array::op_lt(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[X : Show] Array::output(Self[X], &Logger) -> Unit
 pub fn[T] Array::pop(Self[T]) -> T?
 pub fn[T] Array::push(Self[T], T) -> Unit
 pub fn[T] Array::push_iter(Self[T], Iter[T]) -> Unit
@@ -155,6 +179,9 @@ pub fn[T : Eq] Array::strip_prefix(Self[T], ArrayView[T]) -> ArrayView[T]?
 pub fn[T : Eq] Array::strip_suffix(Self[T], ArrayView[T]) -> ArrayView[T]?
 pub fn[T] Array::suffixes(Self[T], include_empty? : Bool) -> Iter[ArrayView[T]]
 pub fn[T] Array::swap(Self[T], Int, Int) -> Unit
+pub fn[X : ToJson] Array::to_json(Self[X]) -> Json
+#deprecated
+pub fn[X : Show] Array::to_string(Self[X]) -> String
 pub fn[A] Array::truncate(Self[A], Int) -> Unit
 pub fn[A] Array::unsafe_blit_fixed(Self[A], Int, FixedArray[A], Int, Int) -> Unit
 pub fn[T] Array::unsafe_get(Self[T], Int) -> T
@@ -176,6 +203,7 @@ pub impl[X : Show] Show for Array[X]
 pub impl[X : ToJson] ToJson for Array[X]
 
 type ArrayView[T]
+pub fn[T] ArrayView::add(Self[T], Self[T]) -> Self[T]
 #alias(every)
 pub fn[T] ArrayView::all(Self[T], (T) -> Bool raise?) -> Bool raise?
 #alias(exists)
@@ -187,18 +215,25 @@ pub fn[T] ArrayView::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int,
 pub fn[A] ArrayView::blit_to(Self[A], Array[A], dst_offset? : Int) -> Unit
 pub fn[T] ArrayView::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[Self[T]] raise?
 pub fn[T] ArrayView::chunks(Self[T], Int) -> Array[Self[T]]
+pub fn[T : Compare] ArrayView::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] ArrayView::contains(Self[T], T) -> Bool
 pub fn[T : Eq] ArrayView::count(Self[T], T) -> Int
 pub fn[T] ArrayView::count_if(Self[T], (T) -> Bool raise?) -> Int raise?
 pub fn[T] ArrayView::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ArrayView::ends_with(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[T : Eq] ArrayView::equal(Self[T], Self[T]) -> Bool
 pub fn[T] ArrayView::filter(Self[T], (T) -> Bool raise?) -> Array[T] raise?
 pub fn[A, B] ArrayView::filter_map(Self[A], (A) -> B? raise?) -> Array[B] raise?
 pub fn[A, B] ArrayView::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] ArrayView::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
 pub fn[T] ArrayView::get(Self[T], Int) -> T?
 pub fn[T] ArrayView::get_view(Self[T], start? : Int, end? : Int) -> Self[T]?
+#deprecated
+pub fn[A : Hash] ArrayView::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] ArrayView::hash_combine(Self[A], Hasher) -> Unit
 pub fn[T] ArrayView::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] ArrayView::is_sorted(Self[T]) -> Bool
 #alias(iterator, deprecated)
@@ -211,6 +246,14 @@ pub fn[T] ArrayView::length(Self[T]) -> Int
 pub fn[T : Compare] ArrayView::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T, U] ArrayView::map(Self[T], (T) -> U raise?) -> Array[U] raise?
 pub fn[T, U] ArrayView::mapi(Self[T], (Int, T) -> U raise?) -> Array[U] raise?
+#deprecated
+pub fn[T : Eq] ArrayView::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ArrayView::op_ge(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ArrayView::op_gt(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ArrayView::op_le(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ArrayView::op_lt(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[X : Show] ArrayView::output(Self[X], &Logger) -> Unit
 pub fn[T] ArrayView::rev(Self[T]) -> Array[T]
 pub fn[T] ArrayView::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
@@ -225,8 +268,11 @@ pub fn[T : Eq] ArrayView::starts_with(Self[T], Self[T]) -> Bool
 pub fn[T : Eq] ArrayView::strip_prefix(Self[T], Self[T]) -> Self[T]?
 pub fn[T : Eq] ArrayView::strip_suffix(Self[T], Self[T]) -> Self[T]?
 pub fn[T] ArrayView::suffixes(Self[T], include_empty? : Bool) -> Iter[Self[T]]
+pub fn[X : ToJson] ArrayView::to_json(Self[X]) -> Json
 #alias(to_array, deprecated)
 pub fn[T] ArrayView::to_owned(Self[T]) -> Array[T]
+#deprecated
+pub fn[X : Show] ArrayView::to_string(Self[X]) -> String
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[T] ArrayView::view(Self[T], start? : Int, end? : Int) -> Self[T]
@@ -260,6 +306,7 @@ pub fn Hasher::finalize(Self) -> Int
 
 #alias(Iterator, deprecated)
 type Iter[X]
+pub fn[T] Iter::add(Self[T], Self[T]) -> Self[T]
 pub fn[X] Iter::all(Self[X], (X) -> Bool) -> Bool
 pub fn[X] Iter::any(Self[X], (X) -> Bool) -> Bool
 pub fn[X] Iter::concat(Self[X], Self[X]) -> Self[X]
@@ -295,6 +342,8 @@ pub fn[X] Iter::new(() -> X?, size_hint? : Int) -> Self[X]
 #alias(peek, deprecated)
 pub fn[X] Iter::next(Self[X]) -> X?
 pub fn[X] Iter::nth(Self[X], Int) -> X?
+#deprecated
+pub fn[X : Show] Iter::output(Self[X], &Logger) -> Unit
 pub fn[X] Iter::repeat(X) -> Self[X]
 pub fn[X] Iter::singleton(X) -> Self[X]
 pub fn[X] Iter::size_hint(Self[X]) -> Int?
@@ -303,6 +352,9 @@ pub fn[X] Iter::take_while(Self[X], (X) -> Bool) -> Self[X]
 pub fn[X] Iter::tap(Self[X], (X) -> Unit) -> Self[X]
 #alias(collect)
 pub fn[X] Iter::to_array(Self[X]) -> Array[X]
+pub fn[X : ToJson] Iter::to_json(Self[X]) -> Json
+#deprecated
+pub fn[X : Show] Iter::to_string(Self[X]) -> String
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[X] Iter::view(Self[X], start? : Int, end? : Int) -> Self[X]
@@ -323,7 +375,11 @@ pub fn[X, Y] Iter2::iter(Self[X, Y]) -> Iter[(X, Y)]
 pub fn[X, Y] Iter2::iter2(Self[X, Y]) -> Self[X, Y]
 pub fn[X, Y] Iter2::new(() -> (X, Y)?, size_hint? : Int) -> Self[X, Y]
 pub fn[X, Y] Iter2::next(Self[X, Y]) -> (X, Y)?
+#deprecated
+pub fn[X : Show, Y : Show] Iter2::output(Self[X, Y], &Logger) -> Unit
 pub fn[X, Y] Iter2::to_array(Self[X, Y]) -> Array[(X, Y)]
+#deprecated
+pub fn[X : Show, Y : Show] Iter2::to_string(Self[X, Y]) -> String
 #deprecated
 pub impl[X : Show, Y : Show] Show for Iter2[X, Y]
 
@@ -338,7 +394,12 @@ pub enum Json {
 }
 pub fn Json::array(Array[Self]) -> Self
 pub fn Json::boolean(Bool) -> Self
+pub fn Json::default() -> Self
 pub fn Json::empty_object() -> Self
+#deprecated
+pub fn Json::equal(Self, Self) -> Bool
+#deprecated
+pub fn Json::not_equal(Self, Self) -> Bool
 pub fn Json::null() -> Self
 pub fn Json::number(Double, repr? : String) -> Self
 pub fn Json::object(Map[String, Self]) -> Self
@@ -357,8 +418,11 @@ pub fn[K : Hash + Eq, V] Map::contains(Self[K, V], K) -> Bool
 pub fn[K : Hash + Eq, V : Eq] Map::contains_kv(Self[K, V], K, V) -> Bool
 #alias(clone, deprecated)
 pub fn[K, V] Map::copy(Self[K, V]) -> Self[K, V]
+pub fn[K, V] Map::default() -> Self[K, V]
 pub fn[K, V] Map::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] Map::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[K : Hash + Eq, V : Eq] Map::equal(Self[K, V], Self[K, V]) -> Bool
 #alias(from_iterator, deprecated)
 pub fn[K : Hash + Eq, V] Map::from_iter(Iter[(K, V)]) -> Self[K, V]
 pub fn[K : Hash + Eq, V] Map::get(Self[K, V], K) -> V?
@@ -380,12 +444,19 @@ pub fn[K : Eq, V] Map::merge_in_place(Self[K, V], Self[K, V]) -> Unit
 #deprecated
 pub fn[K, V] Map::new(capacity? : Int) -> Self[K, V]
 #deprecated
+pub fn[K : Hash + Eq, V : Eq] Map::not_equal(Self[K, V], Self[K, V]) -> Bool
+#deprecated
 pub fn[K : Hash + Eq, V] Map::of(FixedArray[(K, V)]) -> Self[K, V]
+#deprecated
+pub fn[K : Show, V : Show] Map::output(Self[K, V], &Logger) -> Unit
 pub fn[K : Hash + Eq, V] Map::remove(Self[K, V], K) -> Unit
 pub fn[K, V] Map::retain(Self[K, V], (K, V) -> Bool) -> Unit
 #alias("_[_]=_")
 pub fn[K : Hash + Eq, V] Map::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] Map::to_array(Self[K, V]) -> Array[(K, V)]
+pub fn[K : Show, V : ToJson] Map::to_json(Self[K, V]) -> Json
+#deprecated
+pub fn[K : Show, V : Show] Map::to_string(Self[K, V]) -> String
 pub fn[K : Hash + Eq, V] Map::update(Self[K, V], K, (V?) -> V?) -> Unit
 pub fn[K : Hash + Eq, V] Map::update_or_default(Self[K, V], K, V, (V) -> V) -> Unit
 pub fn[K, V] Map::values(Self[K, V]) -> Iter[V]
@@ -398,6 +469,13 @@ pub impl[K : Show, V : ToJson] ToJson for Map[K, V]
 type MutArrayView[T]
 #alias("_[_]")
 pub fn[T] MutArrayView::at(Self[T], Int) -> T
+pub fn[T : Compare] MutArrayView::compare(Self[T], Self[T]) -> Int
+#deprecated
+pub fn[T : Eq] MutArrayView::equal(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[A : Hash] MutArrayView::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] MutArrayView::hash_combine(Self[A], Hasher) -> Unit
 pub fn[T] MutArrayView::is_empty(Self[T]) -> Bool
 #alias(iterator, deprecated)
 pub fn[X] MutArrayView::iter(Self[X]) -> Iter[X]
@@ -405,6 +483,14 @@ pub fn[X] MutArrayView::iter(Self[X]) -> Iter[X]
 pub fn[X] MutArrayView::iter2(Self[X]) -> Iter2[Int, X]
 pub fn[T] MutArrayView::length(Self[T]) -> Int
 pub fn[T] MutArrayView::mut_view(Self[T], start? : Int, end? : Int) -> Self[T]
+#deprecated
+pub fn[T : Eq] MutArrayView::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] MutArrayView::op_ge(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] MutArrayView::op_gt(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] MutArrayView::op_le(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] MutArrayView::op_lt(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[X : Show] MutArrayView::output(Self[X], &Logger) -> Unit
 #alias(rev_iterator, deprecated)
 pub fn[X] MutArrayView::rev_iter(Self[X]) -> Iter[X]
 #alias("_[_]=_")
@@ -416,6 +502,8 @@ pub fn[T : Compare] MutArrayView::stable_sort(Self[T]) -> Unit
 pub fn[T] MutArrayView::start_offset(Self[T]) -> Int
 #alias(to_array, deprecated)
 pub fn[T] MutArrayView::to_owned(Self[T]) -> Array[T]
+#deprecated
+pub fn[X : Show] MutArrayView::to_string(Self[X]) -> String
 pub fn[T] MutArrayView::unsafe_get(Self[T], Int) -> T
 pub fn[T] MutArrayView::unsafe_set(Self[T], Int, T) -> Unit
 #alias("_[_:_]")
@@ -428,20 +516,30 @@ pub impl[A : Hash] Hash for MutArrayView[A]
 pub impl[X : Show] Show for MutArrayView[X]
 
 pub(all) type SourceLoc
+#deprecated
+pub fn SourceLoc::output(Self, &Logger) -> Unit
 pub fn SourceLoc::to_json_string(Self) -> String
+pub fn SourceLoc::to_string(Self) -> String
 pub impl Show for SourceLoc
 
 type StringBuilder
 #alias(new)
 pub fn StringBuilder::StringBuilder(size_hint? : Int) -> Self
 pub fn StringBuilder::is_empty(Self) -> Bool
+#deprecated
+pub fn StringBuilder::output(Self, &Logger) -> Unit
 pub fn StringBuilder::reset(Self) -> Unit
 pub fn StringBuilder::to_string(Self) -> String
+pub fn StringBuilder::write_char(Self, Char) -> Unit
 pub fn StringBuilder::write_iter(Self, Iter[Char]) -> Unit
 #alias(write)
 #alias(write_string_interpolation)
 pub fn[T : Show] StringBuilder::write_object(Self, T) -> Unit
+pub fn StringBuilder::write_string(Self, String) -> Unit
 pub fn StringBuilder::write_stringview(Self, StringView) -> Unit
+#deprecated
+pub fn StringBuilder::write_substring(Self, String, Int, Int) -> Unit
+pub fn StringBuilder::write_view(Self, StringView) -> Unit
 pub impl Logger for StringBuilder
 pub impl Show for StringBuilder
 
@@ -456,21 +554,84 @@ pub fn[T] UninitializedArray::set(Self[T], Int, T) -> Unit
 #alias("_[_:_]")
 pub fn[T] UninitializedArray::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 
+pub fn Unit::compare(Unit, Unit) -> Int
+pub fn Unit::default() -> Unit
+#deprecated
+pub fn Unit::equal(Unit, Unit) -> Bool
+#deprecated
+pub fn Unit::hash(Unit) -> Int
+#deprecated
+pub fn Unit::hash_combine(Unit, Hasher) -> Unit
+#deprecated
+pub fn Unit::not_equal(Unit, Unit) -> Bool
+pub fn Unit::op_ge(Unit, Unit) -> Bool
+pub fn Unit::op_gt(Unit, Unit) -> Bool
+pub fn Unit::op_le(Unit, Unit) -> Bool
+pub fn Unit::op_lt(Unit, Unit) -> Bool
+#deprecated
+pub fn Unit::output(Unit, &Logger) -> Unit
+pub fn Unit::to_json(Unit) -> Json
+pub fn Unit::to_string(Unit) -> String
+
+pub fn Bool::compare(Bool, Bool) -> Int
+pub fn Bool::default() -> Bool
+#deprecated
+pub fn Bool::equal(Bool, Bool) -> Bool
+#deprecated
+pub fn Bool::hash(Bool) -> Int
+#deprecated
+pub fn Bool::hash_combine(Bool, Hasher) -> Unit
+#deprecated
+pub fn Bool::not_equal(Bool, Bool) -> Bool
 #deprecated
 pub fn Bool::op_compare(Bool, Bool) -> Int
+pub fn Bool::op_ge(Bool, Bool) -> Bool
+pub fn Bool::op_gt(Bool, Bool) -> Bool
+pub fn Bool::op_le(Bool, Bool) -> Bool
+pub fn Bool::op_lt(Bool, Bool) -> Bool
+#deprecated
+pub fn Bool::output(Bool, &Logger) -> Unit
 pub fn Bool::to_int(Bool) -> Int
 pub fn Bool::to_int16(Bool) -> Int16
 pub fn Bool::to_int64(Bool) -> Int64
+pub fn Bool::to_json(Bool) -> Json
+pub fn Bool::to_string(Bool) -> String
 pub fn Bool::to_uint(Bool) -> UInt
 pub fn Bool::to_uint16(Bool) -> UInt16
 pub fn Bool::to_uint64(Bool) -> UInt64
 
+pub fn Byte::add(Byte, Byte) -> Byte
+pub fn Byte::compare(Byte, Byte) -> Int
+pub fn Byte::default() -> Byte
+pub fn Byte::div(Byte, Byte) -> Byte
+#deprecated
+pub fn Byte::equal(Byte, Byte) -> Bool
+#deprecated
+pub fn Byte::hash(Byte) -> Int
+#deprecated
+pub fn Byte::hash_combine(Byte, Hasher) -> Unit
+pub fn Byte::land(Byte, Byte) -> Byte
 pub fn Byte::lnot(Byte) -> Byte
+pub fn Byte::lor(Byte, Byte) -> Byte
 #deprecated
 pub fn Byte::lsl(Byte, Int) -> Byte
 #deprecated
 pub fn Byte::lsr(Byte, Int) -> Byte
+pub fn Byte::lxor(Byte, Byte) -> Byte
+pub fn Byte::mod(Byte, Byte) -> Byte
+pub fn Byte::mul(Byte, Byte) -> Byte
+#deprecated
+pub fn Byte::not_equal(Byte, Byte) -> Bool
+pub fn Byte::op_ge(Byte, Byte) -> Bool
+pub fn Byte::op_gt(Byte, Byte) -> Bool
+pub fn Byte::op_le(Byte, Byte) -> Bool
+pub fn Byte::op_lt(Byte, Byte) -> Bool
+#deprecated
+pub fn Byte::output(Byte, &Logger) -> Unit
 pub fn Byte::popcnt(Byte) -> Int
+pub fn Byte::shl(Byte, Int) -> Byte
+pub fn Byte::shr(Byte, Int) -> Byte
+pub fn Byte::sub(Byte, Byte) -> Byte
 pub fn Byte::to_char(Byte) -> Char
 pub fn Byte::to_double(Byte) -> Double
 #deprecated
@@ -480,14 +641,23 @@ pub fn Byte::to_int(Byte) -> Int
 #deprecated
 pub fn Byte::to_int16(Byte) -> Int16
 pub fn Byte::to_int64(Byte) -> Int64
+pub fn Byte::to_json(Byte) -> Json
 pub fn Byte::to_string(Byte) -> String
 pub fn Byte::to_uint(Byte) -> UInt
 pub fn Byte::to_uint16(Byte) -> UInt16
 pub fn Byte::to_uint64(Byte) -> UInt64
 
+pub fn Char::compare(Char, Char) -> Int
+pub fn Char::default() -> Char
+#deprecated
+pub fn Char::equal(Char, Char) -> Bool
 pub fn Char::escape(Char, quote? : Bool) -> String
 #deprecated
 pub fn Char::from_int(Int) -> Char
+#deprecated
+pub fn Char::hash(Char) -> Int
+#deprecated
+pub fn Char::hash_combine(Char, Hasher) -> Unit
 pub fn Char::is_ascii(Char) -> Bool
 pub fn Char::is_ascii_alphabetic(Char) -> Bool
 pub fn Char::is_ascii_control(Char) -> Bool
@@ -505,18 +675,38 @@ pub fn Char::is_digit(Char, UInt) -> Bool
 pub fn Char::is_numeric(Char) -> Bool
 pub fn Char::is_printable(Char) -> Bool
 pub fn Char::is_whitespace(Char) -> Bool
+#deprecated
+pub fn Char::not_equal(Char, Char) -> Bool
+pub fn Char::op_ge(Char, Char) -> Bool
+pub fn Char::op_gt(Char, Char) -> Bool
+pub fn Char::op_le(Char, Char) -> Bool
+pub fn Char::op_lt(Char, Char) -> Bool
+#deprecated
+pub fn Char::output(Char, &Logger) -> Unit
 pub fn Char::to_ascii_lowercase(Char) -> Char
 pub fn Char::to_ascii_uppercase(Char) -> Char
 pub fn Char::to_int(Char) -> Int
+pub fn Char::to_json(Char) -> Json
+pub fn Char::to_string(Char) -> String
 pub fn Char::to_uint(Char) -> UInt
 pub fn Char::utf16_len(Char) -> Int
 
 pub fn Int::abs(Int) -> Int
+pub fn Int::add(Int, Int) -> Int
 #deprecated
 pub fn Int::asr(Int, Int) -> Int
 pub fn Int::clamp(Int, min~ : Int, max~ : Int) -> Int
 pub fn Int::clz(Int) -> Int
+pub fn Int::compare(Int, Int) -> Int
 pub fn Int::ctz(Int) -> Int
+pub fn Int::default() -> Int
+pub fn Int::div(Int, Int) -> Int
+#deprecated
+pub fn Int::equal(Int, Int) -> Bool
+#deprecated
+pub fn Int::hash(Int) -> Int
+#deprecated
+pub fn Int::hash_combine(Int, Hasher) -> Unit
 pub fn Int::is_leading_surrogate(Int) -> Bool
 pub fn Int::is_neg(Int) -> Bool
 pub fn Int::is_non_neg(Int) -> Bool
@@ -524,14 +714,28 @@ pub fn Int::is_non_pos(Int) -> Bool
 pub fn Int::is_pos(Int) -> Bool
 pub fn Int::is_surrogate(Int) -> Bool
 pub fn Int::is_trailing_surrogate(Int) -> Bool
+pub fn Int::land(Int, Int) -> Int
 pub fn Int::lnot(Int) -> Int
+pub fn Int::lor(Int, Int) -> Int
 #deprecated
 pub fn Int::lsl(Int, Int) -> Int
 #deprecated
 pub fn Int::lsr(Int, Int) -> Int
+pub fn Int::lxor(Int, Int) -> Int
 pub fn Int::max(Int, Int) -> Int
 pub fn Int::min(Int, Int) -> Int
+pub fn Int::mod(Int, Int) -> Int
+pub fn Int::mul(Int, Int) -> Int
+pub fn Int::neg(Int) -> Int
 pub fn Int::next_power_of_two(Int) -> Int
+#deprecated
+pub fn Int::not_equal(Int, Int) -> Bool
+pub fn Int::op_ge(Int, Int) -> Bool
+pub fn Int::op_gt(Int, Int) -> Bool
+pub fn Int::op_le(Int, Int) -> Bool
+pub fn Int::op_lt(Int, Int) -> Bool
+#deprecated
+pub fn Int::output(Int, &Logger) -> Unit
 pub fn Int::popcnt(Int) -> Int
 #deprecated
 pub fn Int::reinterpret_as_float(Int) -> Float
@@ -540,6 +744,7 @@ pub fn Int::reinterpret_as_uint(Int) -> UInt
 pub fn Int::shl(Int, Int) -> Int
 #deprecated
 pub fn Int::shr(Int, Int) -> Int
+pub fn Int::sub(Int, Int) -> Int
 pub fn Int::to_byte(Int) -> Byte
 pub fn Int::to_char(Int) -> Char?
 pub fn Int::to_double(Int) -> Double
@@ -548,6 +753,7 @@ pub fn Int::to_float(Int) -> Float
 #deprecated
 pub fn Int::to_int16(Int) -> Int16
 pub fn Int::to_int64(Int) -> Int64
+pub fn Int::to_json(Int) -> Json
 pub fn Int::to_string(Int, radix? : Int) -> String
 #deprecated
 pub fn Int::to_uint(Int) -> UInt
@@ -556,19 +762,43 @@ pub fn Int::to_uint64(Int) -> UInt64
 pub fn Int::until(Int, Int, step? : Int, inclusive? : Bool) -> Iter[Int]
 
 pub fn Int64::abs(Int64) -> Int64
+pub fn Int64::add(Int64, Int64) -> Int64
 #deprecated
 pub fn Int64::asr(Int64, Int) -> Int64
 pub fn Int64::clamp(Int64, min~ : Int64, max~ : Int64) -> Int64
 pub fn Int64::clz(Int64) -> Int
+pub fn Int64::compare(Int64, Int64) -> Int
 pub fn Int64::ctz(Int64) -> Int
+pub fn Int64::default() -> Int64
+pub fn Int64::div(Int64, Int64) -> Int64
+#deprecated
+pub fn Int64::equal(Int64, Int64) -> Bool
 pub fn Int64::from_int(Int) -> Int64
+#deprecated
+pub fn Int64::hash(Int64) -> Int
+#deprecated
+pub fn Int64::hash_combine(Int64, Hasher) -> Unit
+pub fn Int64::land(Int64, Int64) -> Int64
 pub fn Int64::lnot(Int64) -> Int64
+pub fn Int64::lor(Int64, Int64) -> Int64
 #deprecated
 pub fn Int64::lsl(Int64, Int) -> Int64
 #deprecated
 pub fn Int64::lsr(Int64, Int) -> Int64
+pub fn Int64::lxor(Int64, Int64) -> Int64
 pub fn Int64::max(Int64, Int64) -> Int64
 pub fn Int64::min(Int64, Int64) -> Int64
+pub fn Int64::mod(Int64, Int64) -> Int64
+pub fn Int64::mul(Int64, Int64) -> Int64
+pub fn Int64::neg(Int64) -> Int64
+#deprecated
+pub fn Int64::not_equal(Int64, Int64) -> Bool
+pub fn Int64::op_ge(Int64, Int64) -> Bool
+pub fn Int64::op_gt(Int64, Int64) -> Bool
+pub fn Int64::op_le(Int64, Int64) -> Bool
+pub fn Int64::op_lt(Int64, Int64) -> Bool
+#deprecated
+pub fn Int64::output(Int64, &Logger) -> Unit
 pub fn Int64::popcnt(Int64) -> Int
 pub fn Int64::reinterpret_as_double(Int64) -> Double
 pub fn Int64::reinterpret_as_uint64(Int64) -> UInt64
@@ -576,27 +806,51 @@ pub fn Int64::reinterpret_as_uint64(Int64) -> UInt64
 pub fn Int64::shl(Int64, Int) -> Int64
 #deprecated
 pub fn Int64::shr(Int64, Int) -> Int64
+pub fn Int64::sub(Int64, Int64) -> Int64
 pub fn Int64::to_byte(Int64) -> Byte
 pub fn Int64::to_double(Int64) -> Double
 #deprecated
 pub fn Int64::to_float(Int64) -> Float
 pub fn Int64::to_int(Int64) -> Int
+pub fn Int64::to_json(Int64) -> Json
 pub fn Int64::to_string(Int64, radix? : Int) -> String
 pub fn Int64::to_uint16(Int64) -> UInt16
 #deprecated
 pub fn Int64::to_uint64(Int64) -> UInt64
 pub fn Int64::until(Int64, Int64, step? : Int64, inclusive? : Bool) -> Iter[Int64]
 
+pub fn UInt::add(UInt, UInt) -> UInt
 pub fn UInt::clamp(UInt, min~ : UInt, max~ : UInt) -> UInt
 pub fn UInt::clz(UInt) -> Int
+pub fn UInt::compare(UInt, UInt) -> Int
 pub fn UInt::ctz(UInt) -> Int
+pub fn UInt::div(UInt, UInt) -> UInt
+#deprecated
+pub fn UInt::equal(UInt, UInt) -> Bool
+#deprecated
+pub fn UInt::hash(UInt) -> Int
+#deprecated
+pub fn UInt::hash_combine(UInt, Hasher) -> Unit
+pub fn UInt::land(UInt, UInt) -> UInt
 pub fn UInt::lnot(UInt) -> UInt
+pub fn UInt::lor(UInt, UInt) -> UInt
 #deprecated
 pub fn UInt::lsl(UInt, Int) -> UInt
 #deprecated
 pub fn UInt::lsr(UInt, Int) -> UInt
+pub fn UInt::lxor(UInt, UInt) -> UInt
 pub fn UInt::max(UInt, UInt) -> UInt
 pub fn UInt::min(UInt, UInt) -> UInt
+pub fn UInt::mod(UInt, UInt) -> UInt
+pub fn UInt::mul(UInt, UInt) -> UInt
+#deprecated
+pub fn UInt::not_equal(UInt, UInt) -> Bool
+pub fn UInt::op_ge(UInt, UInt) -> Bool
+pub fn UInt::op_gt(UInt, UInt) -> Bool
+pub fn UInt::op_le(UInt, UInt) -> Bool
+pub fn UInt::op_lt(UInt, UInt) -> Bool
+#deprecated
+pub fn UInt::output(UInt, &Logger) -> Unit
 pub fn UInt::popcnt(UInt) -> Int
 #deprecated
 pub fn UInt::reinterpret_as_float(UInt) -> Float
@@ -605,37 +859,89 @@ pub fn UInt::reinterpret_as_int(UInt) -> Int
 pub fn UInt::shl(UInt, Int) -> UInt
 #deprecated
 pub fn UInt::shr(UInt, Int) -> UInt
+pub fn UInt::sub(UInt, UInt) -> UInt
 pub fn UInt::to_byte(UInt) -> Byte
 pub fn UInt::to_double(UInt) -> Double
 #deprecated
 pub fn UInt::to_float(UInt) -> Float
 #deprecated
 pub fn UInt::to_int(UInt) -> Int
+pub fn UInt::to_json(UInt) -> Json
 pub fn UInt::to_string(UInt, radix? : Int) -> String
 pub fn UInt::to_uint16(UInt) -> UInt16
 pub fn UInt::to_uint64(UInt) -> UInt64
 pub fn UInt::trunc_double(Double) -> UInt
 
+pub fn UInt16::add(UInt16, UInt16) -> UInt16
+pub fn UInt16::compare(UInt16, UInt16) -> Int
+pub fn UInt16::default() -> UInt16
+pub fn UInt16::div(UInt16, UInt16) -> UInt16
+#deprecated
+pub fn UInt16::equal(UInt16, UInt16) -> Bool
+#deprecated
+pub fn UInt16::hash(UInt16) -> Int
+#deprecated
+pub fn UInt16::hash_combine(UInt16, Hasher) -> Unit
 pub fn UInt16::is_leading_surrogate(UInt16) -> Bool
 pub fn UInt16::is_surrogate(UInt16) -> Bool
 pub fn UInt16::is_trailing_surrogate(UInt16) -> Bool
+pub fn UInt16::land(UInt16, UInt16) -> UInt16
 pub fn UInt16::lnot(UInt16) -> UInt16
+pub fn UInt16::lor(UInt16, UInt16) -> UInt16
+pub fn UInt16::lxor(UInt16, UInt16) -> UInt16
+pub fn UInt16::mod(UInt16, UInt16) -> UInt16
+pub fn UInt16::mul(UInt16, UInt16) -> UInt16
+#deprecated
+pub fn UInt16::not_equal(UInt16, UInt16) -> Bool
+pub fn UInt16::op_ge(UInt16, UInt16) -> Bool
+pub fn UInt16::op_gt(UInt16, UInt16) -> Bool
+pub fn UInt16::op_le(UInt16, UInt16) -> Bool
+pub fn UInt16::op_lt(UInt16, UInt16) -> Bool
+#deprecated
+pub fn UInt16::output(UInt16, &Logger) -> Unit
+pub fn UInt16::shl(UInt16, Int) -> UInt16
+pub fn UInt16::shr(UInt16, Int) -> UInt16
+pub fn UInt16::sub(UInt16, UInt16) -> UInt16
 pub fn UInt16::to_byte(UInt16) -> Byte
 pub fn UInt16::to_char(UInt16) -> Char?
 pub fn UInt16::to_int(UInt16) -> Int
 pub fn UInt16::to_int64(UInt16) -> Int64
+pub fn UInt16::to_json(UInt16) -> Json
 pub fn UInt16::to_string(UInt16, radix? : Int) -> String
 pub fn UInt16::to_uint(UInt16) -> UInt
 pub fn UInt16::to_uint64(UInt16) -> UInt64
 
+pub fn UInt64::add(UInt64, UInt64) -> UInt64
 pub fn UInt64::clz(UInt64) -> Int
+pub fn UInt64::compare(UInt64, UInt64) -> Int
 pub fn UInt64::ctz(UInt64) -> Int
+pub fn UInt64::default() -> UInt64
+pub fn UInt64::div(UInt64, UInt64) -> UInt64
+#deprecated
+pub fn UInt64::equal(UInt64, UInt64) -> Bool
 pub fn UInt64::extend_uint(UInt) -> UInt64
+#deprecated
+pub fn UInt64::hash(UInt64) -> Int
+#deprecated
+pub fn UInt64::hash_combine(UInt64, Hasher) -> Unit
+pub fn UInt64::land(UInt64, UInt64) -> UInt64
 pub fn UInt64::lnot(UInt64) -> UInt64
+pub fn UInt64::lor(UInt64, UInt64) -> UInt64
 #deprecated
 pub fn UInt64::lsl(UInt64, Int) -> UInt64
 #deprecated
 pub fn UInt64::lsr(UInt64, Int) -> UInt64
+pub fn UInt64::lxor(UInt64, UInt64) -> UInt64
+pub fn UInt64::mod(UInt64, UInt64) -> UInt64
+pub fn UInt64::mul(UInt64, UInt64) -> UInt64
+#deprecated
+pub fn UInt64::not_equal(UInt64, UInt64) -> Bool
+pub fn UInt64::op_ge(UInt64, UInt64) -> Bool
+pub fn UInt64::op_gt(UInt64, UInt64) -> Bool
+pub fn UInt64::op_le(UInt64, UInt64) -> Bool
+pub fn UInt64::op_lt(UInt64, UInt64) -> Bool
+#deprecated
+pub fn UInt64::output(UInt64, &Logger) -> Unit
 pub fn UInt64::popcnt(UInt64) -> Int
 pub fn UInt64::reinterpret_as_double(UInt64) -> Double
 pub fn UInt64::reinterpret_as_int64(UInt64) -> Int64
@@ -643,6 +949,7 @@ pub fn UInt64::reinterpret_as_int64(UInt64) -> Int64
 pub fn UInt64::shl(UInt64, Int) -> UInt64
 #deprecated
 pub fn UInt64::shr(UInt64, Int) -> UInt64
+pub fn UInt64::sub(UInt64, UInt64) -> UInt64
 pub fn UInt64::to_be_bytes(UInt64) -> Bytes
 pub fn UInt64::to_byte(UInt64) -> Byte
 pub fn UInt64::to_double(UInt64) -> Double
@@ -651,6 +958,7 @@ pub fn UInt64::to_float(UInt64) -> Float
 pub fn UInt64::to_int(UInt64) -> Int
 #deprecated
 pub fn UInt64::to_int64(UInt64) -> Int64
+pub fn UInt64::to_json(UInt64) -> Json
 pub fn UInt64::to_le_bytes(UInt64) -> Bytes
 pub fn UInt64::to_string(UInt64, radix? : Int) -> String
 pub fn UInt64::to_uint(UInt64) -> UInt
@@ -658,12 +966,22 @@ pub fn UInt64::to_uint16(UInt64) -> UInt16
 pub fn UInt64::trunc_double(Double) -> UInt64
 
 pub fn Double::abs(Double) -> Double
+pub fn Double::add(Double, Double) -> Double
 pub fn Double::ceil(Double) -> Double
 pub fn Double::clamp(Double, min~ : Double, max~ : Double) -> Double
+pub fn Double::compare(Double, Double) -> Int
 pub fn Double::convert_uint(UInt) -> Double
 pub fn Double::convert_uint64(UInt64) -> Double
+pub fn Double::default() -> Double
+pub fn Double::div(Double, Double) -> Double
+#deprecated
+pub fn Double::equal(Double, Double) -> Bool
 pub fn Double::floor(Double) -> Double
 pub fn Double::from_int(Int) -> Double
+#deprecated
+pub fn Double::hash(Double) -> Int
+#deprecated
+pub fn Double::hash_combine(Double, Hasher) -> Unit
 pub fn Double::is_close(Double, Double, relative_tolerance? : Double, absolute_tolerance? : Double) -> Bool
 pub fn Double::is_inf(Double) -> Bool
 pub fn Double::is_nan(Double) -> Bool
@@ -672,6 +990,17 @@ pub fn Double::is_pos_inf(Double) -> Bool
 pub fn Double::lerp(Double, target~ : Double, t~ : Double) -> Double
 pub fn Double::max(Double, Double) -> Double
 pub fn Double::min(Double, Double) -> Double
+pub fn Double::mod(Double, Double) -> Double
+pub fn Double::mul(Double, Double) -> Double
+pub fn Double::neg(Double) -> Double
+#deprecated
+pub fn Double::not_equal(Double, Double) -> Bool
+pub fn Double::op_ge(Double, Double) -> Bool
+pub fn Double::op_gt(Double, Double) -> Bool
+pub fn Double::op_le(Double, Double) -> Bool
+pub fn Double::op_lt(Double, Double) -> Bool
+#deprecated
+pub fn Double::output(Double, &Logger) -> Unit
 #deprecated
 pub fn Double::pow(Double, Double) -> Double
 #deprecated
@@ -683,16 +1012,19 @@ pub fn Double::reinterpret_as_uint64(Double) -> UInt64
 pub fn Double::round(Double) -> Double
 pub fn Double::signum(Double) -> Double
 pub fn Double::sqrt(Double) -> Double
+pub fn Double::sub(Double, Double) -> Double
 #deprecated
 pub fn Double::to_float(Double) -> Float
 pub fn Double::to_int(Double) -> Int
 pub fn Double::to_int64(Double) -> Int64
+pub fn Double::to_json(Double) -> Json
 pub fn Double::to_string(Double) -> String
 pub fn Double::to_uint(Double) -> UInt
 pub fn Double::to_uint64(Double) -> UInt64
 pub fn Double::trunc(Double) -> Double
 pub fn Double::until(Double, Double, step? : Double, inclusive? : Bool) -> Iter[Double]
 
+pub fn String::add(String, String) -> String
 pub fn String::after(String, StringView) -> StringView?
 #alias(every)
 pub fn String::all(String, (Char) -> Bool raise?) -> Bool raise?
@@ -708,11 +1040,15 @@ pub fn String::char_length_eq(String, Int, start_offset? : Int, end_offset? : In
 pub fn String::char_length_ge(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
 pub fn String::clamped_view(String, start? : Int, end? : Int) -> StringView
 pub fn String::code_units(String) -> ArrayView[UInt16]
+pub fn String::compare(String, String) -> Int
 pub fn String::compare_ignore_ascii_case(String, String) -> Int
 pub fn String::contains(String, StringView) -> Bool
 pub fn String::contains_any(String, chars~ : StringView) -> Bool
 pub fn String::contains_char(String, Char) -> Bool
 pub fn String::contains_code_unit(String, UInt16) -> Bool
+pub fn String::default() -> String
+#deprecated
+pub fn String::equal(String, String) -> Bool
 pub fn String::equal_ignore_ascii_case(String, String) -> Bool
 pub fn String::escape(String, quote? : Bool) -> String
 pub fn String::find(String, StringView) -> Int?
@@ -729,6 +1065,10 @@ pub fn String::get_view(String, start? : Int, end? : Int) -> StringView?
 pub fn String::has_prefix(String, StringView) -> Bool
 #alias(ends_with, deprecated)
 pub fn String::has_suffix(String, StringView) -> Bool
+#deprecated
+pub fn String::hash(String) -> Int
+#deprecated
+pub fn String::hash_combine(String, Hasher) -> Unit
 pub fn String::is_blank(String) -> Bool
 pub fn String::is_empty(String) -> Bool
 #alias(iterator, deprecated)
@@ -739,7 +1079,15 @@ pub fn String::iter2(String) -> Iter2[Int, Char]
 pub fn String::length(String) -> Int
 pub fn String::lexical_compare(String, String) -> Int
 pub fn String::make(Int, Char) -> String
+#deprecated
+pub fn String::not_equal(String, String) -> Bool
 pub fn String::offset_of_nth_char(String, Int, start_offset? : Int, end_offset? : Int) -> Int?
+pub fn String::op_ge(String, String) -> Bool
+pub fn String::op_gt(String, String) -> Bool
+pub fn String::op_le(String, String) -> Bool
+pub fn String::op_lt(String, String) -> Bool
+#deprecated
+pub fn String::output(String, &Logger) -> Unit
 pub fn String::pad_end(String, Int, Char) -> String
 pub fn String::pad_start(String, Int, Char) -> String
 pub fn String::repeat(String, Int) -> String
@@ -768,7 +1116,10 @@ pub fn String::suffixes(String, include_empty? : Bool) -> Iter[StringView]
 pub fn String::to_array(String) -> Array[Char]
 #deprecated
 pub fn String::to_bytes(String) -> Bytes
+pub fn String::to_json(String) -> Json
 pub fn String::to_lower(String) -> String
+pub fn String::to_string(String) -> String
+pub fn String::to_string_view(String) -> StringView
 pub fn String::to_upper(String) -> String
 #label_migration(chars, alias=char_set)
 pub fn String::trim(String, chars? : StringView) -> StringView
@@ -784,9 +1135,17 @@ pub fn String::unsafe_substring(String, start~ : Int, end~ : Int) -> String
 pub fn String::view(String, start_offset? : Int, end_offset? : Int) -> StringView
 
 pub fn[T, U] Option::bind(T?, (T) -> U? raise?) -> U? raise?
+pub fn[X : Compare] Option::compare(X?, X?) -> Int
+pub fn[X] Option::default() -> X?
+#deprecated
+pub fn[X : Eq] Option::equal(X?, X?) -> Bool
 pub fn[T] Option::filter(T?, (T) -> Bool raise?) -> T? raise?
 #deprecated
 pub fn[T] Option::flatten(T??) -> T?
+#deprecated
+pub fn[X : Hash] Option::hash(X?) -> Int
+#deprecated
+pub fn[X : Hash] Option::hash_combine(X?, Hasher) -> Unit
 #deprecated
 pub fn[T] Option::is_empty(T?) -> Bool
 #deprecated
@@ -798,6 +1157,15 @@ pub fn[T] Option::iter(T?) -> Iter[T]
 pub fn[T, U] Option::map(T?, (T) -> U raise?) -> U? raise?
 pub fn[T, U] Option::map_or(T?, U, (T) -> U raise?) -> U raise?
 pub fn[T, U] Option::map_or_else(T?, () -> U raise?, (T) -> U raise?) -> U raise?
+#deprecated
+pub fn[X : Eq] Option::not_equal(X?, X?) -> Bool
+pub fn[X : Compare] Option::op_ge(X?, X?) -> Bool
+pub fn[X : Compare] Option::op_gt(X?, X?) -> Bool
+pub fn[X : Compare] Option::op_le(X?, X?) -> Bool
+pub fn[X : Compare] Option::op_lt(X?, X?) -> Bool
+#deprecated
+pub fn[X : Show] Option::output(X?, &Logger) -> Unit
+pub fn[T : ToJson] Option::to_json(T?) -> Json
 #deprecated
 pub fn[X : Show] Option::to_string(X?) -> String
 pub fn[X] Option::unwrap(X?) -> X
@@ -811,10 +1179,28 @@ pub fn[T] Option::unwrap_or_else(T?, () -> T raise?) -> T raise?
 pub fn[T, Err : Error] Option::unwrap_or_error(T?, Err) -> T raise Err
 
 pub fn[T, E, U] Result::bind(Self[T, E], (T) -> Self[U, E]) -> Self[U, E]
+pub fn[T : Compare, E : Compare] Result::compare(Self[T, E], Self[T, E]) -> Int
+#deprecated
+pub fn[T : Eq, E : Eq] Result::equal(Self[T, E], Self[T, E]) -> Bool
 pub fn[T, E] Result::flatten(Self[Self[T, E], E]) -> Self[T, E]
+#deprecated
+pub fn[T : Hash, E : Hash] Result::hash(Self[T, E]) -> Int
+#deprecated
+pub fn[T : Hash, E : Hash] Result::hash_combine(Self[T, E], Hasher) -> Unit
 pub fn[T, E, U] Result::map(Self[T, E], (T) -> U) -> Self[U, E]
 pub fn[T, E, F] Result::map_err(Self[T, E], (E) -> F) -> Self[T, F]
+#deprecated
+pub fn[T : Eq, E : Eq] Result::not_equal(Self[T, E], Self[T, E]) -> Bool
+pub fn[T : Compare, E : Compare] Result::op_ge(Self[T, E], Self[T, E]) -> Bool
+pub fn[T : Compare, E : Compare] Result::op_gt(Self[T, E], Self[T, E]) -> Bool
+pub fn[T : Compare, E : Compare] Result::op_le(Self[T, E], Self[T, E]) -> Bool
+pub fn[T : Compare, E : Compare] Result::op_lt(Self[T, E], Self[T, E]) -> Bool
+#deprecated
+pub fn[T : Show, E : Show] Result::output(Self[T, E], &Logger) -> Unit
+pub fn[Ok : ToJson, Err : ToJson] Result::to_json(Self[Ok, Err]) -> Json
 pub fn[T, E] Result::to_option(Self[T, E]) -> T?
+#deprecated
+pub fn[T : Show, E : Show] Result::to_string(Self[T, E]) -> String
 pub fn[T, E] Result::unwrap(Self[T, E]) -> T
 pub fn[T, E] Result::unwrap_err(Self[T, E]) -> E
 #alias(or)
@@ -824,6 +1210,7 @@ pub fn[T : Default, E] Result::unwrap_or_default(Self[T, E]) -> T
 pub fn[T, E] Result::unwrap_or_else(Self[T, E], () -> T raise?) -> T raise?
 pub fn[T, E : Error] Result::unwrap_or_error(Self[T, E]) -> T raise E
 
+pub fn[T] FixedArray::add(Self[T], Self[T]) -> Self[T]
 #alias(every)
 pub fn[T] FixedArray::all(Self[T], (T) -> Bool raise?) -> Bool raise?
 #alias(exists)
@@ -836,12 +1223,16 @@ pub fn FixedArray::blit_from_bytes(Self[Byte], Int, Bytes, Int, Int) -> Unit
 pub fn FixedArray::blit_from_bytesview(Self[Byte], Int, BytesView) -> Unit
 pub fn FixedArray::blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
 pub fn[A] FixedArray::blit_to(Self[A], Self[A], len~ : Int, src_offset? : Int, dst_offset? : Int) -> Unit
+pub fn[T : Compare] FixedArray::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] FixedArray::contains(Self[T], T) -> Bool
 #alias(clone, deprecated)
 pub fn[T] FixedArray::copy(Self[T]) -> Self[T]
+pub fn[X] FixedArray::default() -> Self[X]
 pub fn[T] FixedArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] FixedArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] FixedArray::ends_with(Self[T], ArrayView[T]) -> Bool
+#deprecated
+pub fn[T : Eq] FixedArray::equal(Self[T], Self[T]) -> Bool
 pub fn[T] FixedArray::fill(Self[T], T, start? : Int, end? : Int) -> Unit
 pub fn[A, B] FixedArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] FixedArray::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
@@ -850,6 +1241,10 @@ pub fn[T] FixedArray::from_array(ArrayView[T]) -> Self[T]
 pub fn[T] FixedArray::from_iter(Iter[T]) -> Self[T]
 pub fn[T] FixedArray::get(Self[T], Int) -> T?
 pub fn[T] FixedArray::get_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]?
+#deprecated
+pub fn[T : Hash] FixedArray::hash(Self[T]) -> Int
+#deprecated
+pub fn[T : Hash] FixedArray::hash_combine(Self[T], Hasher) -> Unit
 pub fn[T] FixedArray::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] FixedArray::is_sorted(Self[T]) -> Bool
 #alias(iterator, deprecated)
@@ -866,6 +1261,14 @@ pub fn[T] FixedArray::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 pub fn[T, U] FixedArray::map(Self[T], (T) -> U raise?) -> Self[U] raise?
 pub fn[T, U] FixedArray::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?
 pub fn[T] FixedArray::mut_view(Self[T], start? : Int, end? : Int) -> MutArrayView[T]
+#deprecated
+pub fn[T : Eq] FixedArray::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] FixedArray::op_ge(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] FixedArray::op_gt(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] FixedArray::op_le(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] FixedArray::op_lt(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[X : Show] FixedArray::output(Self[X], &Logger) -> Unit
 pub fn[T] FixedArray::rev(Self[T]) -> Self[T]
 pub fn[T] FixedArray::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] FixedArray::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
@@ -885,6 +1288,9 @@ pub fn[T, K : Compare] FixedArray::sort_by_key(Self[T], (T) -> K) -> Unit
 pub fn[T : Compare] FixedArray::stable_sort(Self[T]) -> Unit
 pub fn[T : Eq] FixedArray::starts_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T] FixedArray::swap(Self[T], Int, Int) -> Unit
+pub fn[X : ToJson] FixedArray::to_json(Self[X]) -> Json
+#deprecated
+pub fn[X : Show] FixedArray::to_string(Self[X]) -> String
 pub fn[A] FixedArray::unsafe_blit(Self[A], Int, Self[A], Int, Int) -> Unit
 pub fn FixedArray::unsafe_write_uint16_be(Self[Byte], Int, UInt16) -> Unit
 pub fn FixedArray::unsafe_write_uint16_le(Self[Byte], Int, UInt16) -> Unit
@@ -906,10 +1312,14 @@ pub fn[T : Compare] ReadOnlyArray::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] ReadOnlyArray::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
 pub fn[T] ReadOnlyArray::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[ArrayView[T]] raise?
 pub fn[T] ReadOnlyArray::chunks(Self[T], Int) -> Array[ArrayView[T]]
+pub fn[T : Compare] ReadOnlyArray::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] ReadOnlyArray::contains(Self[T], T) -> Bool
+pub fn[T] ReadOnlyArray::default() -> Self[T]
 pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ReadOnlyArray::ends_with(Self[T], ArrayView[T]) -> Bool
+#deprecated
+pub fn[T : Eq] ReadOnlyArray::equal(Self[T], Self[T]) -> Bool
 pub fn[T] ReadOnlyArray::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
 pub fn[A, B] ReadOnlyArray::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 pub fn[A, B] ReadOnlyArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
@@ -919,6 +1329,10 @@ pub fn[T] ReadOnlyArray::from_array(ArrayView[T]) -> Self[T]
 pub fn[T] ReadOnlyArray::from_iter(Iter[T]) -> Self[T]
 pub fn[T] ReadOnlyArray::get(Self[T], Int) -> T?
 pub fn[T] ReadOnlyArray::get_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]?
+#deprecated
+pub fn[T : Hash] ReadOnlyArray::hash(Self[T]) -> Int
+#deprecated
+pub fn[T : Hash] ReadOnlyArray::hash_combine(Self[T], Hasher) -> Unit
 pub fn[T] ReadOnlyArray::is_empty(Self[T]) -> Bool
 pub fn[T : Compare] ReadOnlyArray::is_sorted(Self[T]) -> Bool
 #alias(iterator, deprecated)
@@ -931,6 +1345,14 @@ pub fn[T : Compare] ReadOnlyArray::lexical_compare(Self[T], Self[T]) -> Int
 pub fn[T] ReadOnlyArray::makei(Int, (Int) -> T raise?) -> Self[T] raise?
 pub fn[T, U] ReadOnlyArray::map(Self[T], (T) -> U raise?) -> Self[U] raise?
 pub fn[T, U] ReadOnlyArray::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?
+#deprecated
+pub fn[T : Eq] ReadOnlyArray::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ReadOnlyArray::op_ge(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ReadOnlyArray::op_gt(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ReadOnlyArray::op_le(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] ReadOnlyArray::op_lt(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[T : Show] ReadOnlyArray::output(Self[T], &Logger) -> Unit
 pub fn[T] ReadOnlyArray::rev(Self[T]) -> Self[T]
 pub fn[T] ReadOnlyArray::rev_each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::rev_eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
@@ -943,18 +1365,26 @@ pub fn[T : Eq] ReadOnlyArray::starts_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] ReadOnlyArray::strip_prefix(Self[T], ArrayView[T]) -> ArrayView[T]?
 pub fn[T : Eq] ReadOnlyArray::strip_suffix(Self[T], ArrayView[T]) -> ArrayView[T]?
 pub fn[T] ReadOnlyArray::suffixes(Self[T], include_empty? : Bool) -> Iter[ArrayView[T]]
+pub fn[T : ToJson] ReadOnlyArray::to_json(Self[T]) -> Json
+#deprecated
+pub fn[T : Show] ReadOnlyArray::to_string(Self[T]) -> String
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn[T] ReadOnlyArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] ReadOnlyArray::windows(Self[T], Int) -> Array[ArrayView[T]]
 
+pub fn Bytes::add(Bytes, Bytes) -> Bytes
 #alias("_[_]")
 pub fn Bytes::at(Bytes, Int) -> Byte
 pub fn Bytes::chop_prefix(Bytes, BytesView) -> BytesView?
 pub fn Bytes::chop_suffix(Bytes, BytesView) -> BytesView?
+pub fn Bytes::compare(Bytes, Bytes) -> Int
 #alias(clone, deprecated)
 #deprecated
 pub fn Bytes::copy(Bytes) -> Bytes
+pub fn Bytes::default() -> Bytes
+#deprecated
+pub fn Bytes::equal(Bytes, Bytes) -> Bool
 pub fn Bytes::find(Bytes, BytesView) -> Int?
 #alias(of, deprecated)
 pub fn Bytes::from_array(ArrayView[Byte]) -> Bytes
@@ -966,6 +1396,10 @@ pub fn Bytes::get(Bytes, Int) -> Byte?
 pub fn Bytes::get_view(Bytes, start? : Int, end? : Int) -> BytesView?
 pub fn Bytes::has_prefix(Bytes, BytesView) -> Bool
 pub fn Bytes::has_suffix(Bytes, BytesView) -> Bool
+#deprecated
+pub fn Bytes::hash(Bytes) -> Int
+#deprecated
+pub fn Bytes::hash_combine(Bytes, Hasher) -> Unit
 pub fn Bytes::is_empty(Bytes) -> Bool
 #alias(iterator, deprecated)
 pub fn Bytes::iter(Bytes) -> Iter[Byte]
@@ -977,28 +1411,294 @@ pub fn Bytes::make(Int, Byte) -> Bytes
 pub fn Bytes::makei(Int, (Int) -> Byte raise?) -> Bytes raise?
 pub fn Bytes::new(Int) -> Bytes
 #deprecated
+pub fn Bytes::not_equal(Bytes, Bytes) -> Bool
+#deprecated
 pub fn Bytes::of_string(String) -> Bytes
+pub fn Bytes::op_ge(Bytes, Bytes) -> Bool
+pub fn Bytes::op_gt(Bytes, Bytes) -> Bool
+pub fn Bytes::op_le(Bytes, Bytes) -> Bool
+pub fn Bytes::op_lt(Bytes, Bytes) -> Bool
+#deprecated
+pub fn Bytes::output(Bytes, &Logger) -> Unit
 pub fn Bytes::repeat(Bytes, Int) -> Bytes
 pub fn Bytes::rev_find(Bytes, BytesView) -> Int?
 pub fn Bytes::to_array(Bytes) -> Array[Byte]
 #label_migration(len, fill=false)
 pub fn Bytes::to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
+pub fn Bytes::to_json(Bytes) -> Json
+pub fn Bytes::to_string(Bytes) -> String
 pub fn Bytes::to_unchecked_string(Bytes, offset? : Int, length? : Int) -> String
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn Bytes::view(Bytes, start? : Int, end? : Int) -> BytesView
 
+pub fn[T0 : Compare, T1 : Compare] Tuple(2)::compare((T0, T1), (T0, T1)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq] Tuple(2)::equal((T0, T1), (T0, T1)) -> Bool
+#deprecated
+pub fn[A : Hash, B : Hash] Tuple(2)::hash((A, B)) -> Int
+#deprecated
+pub fn[A : Hash, B : Hash] Tuple(2)::hash_combine((A, B), Hasher) -> Unit
+#deprecated
+pub fn[T0 : Eq, T1 : Eq] Tuple(2)::not_equal((T0, T1), (T0, T1)) -> Bool
+pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_ge((T0, T1), (T0, T1)) -> Bool
+pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_gt((T0, T1), (T0, T1)) -> Bool
+pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_le((T0, T1), (T0, T1)) -> Bool
+pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_lt((T0, T1), (T0, T1)) -> Bool
+#deprecated
+pub fn[A : Show, B : Show] Tuple(2)::output((A, B), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson] Tuple(2)::to_json((A, B)) -> Json
+#deprecated
+pub fn[A : Show, B : Show] Tuple(2)::to_string((A, B)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::compare((T0, T1, T2), (T0, T1, T2)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq] Tuple(3)::equal((T0, T1, T2), (T0, T1, T2)) -> Bool
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash] Tuple(3)::hash((A, B, C)) -> Int
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash] Tuple(3)::hash_combine((A, B, C), Hasher) -> Unit
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq] Tuple(3)::not_equal((T0, T1, T2), (T0, T1, T2)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_ge((T0, T1, T2), (T0, T1, T2)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_gt((T0, T1, T2), (T0, T1, T2)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_le((T0, T1, T2), (T0, T1, T2)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_lt((T0, T1, T2), (T0, T1, T2)) -> Bool
+#deprecated
+pub fn[A : Show, B : Show, C : Show] Tuple(3)::output((A, B, C), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson] Tuple(3)::to_json((A, B, C)) -> Json
+#deprecated
+pub fn[A : Show, B : Show, C : Show] Tuple(3)::to_string((A, B, C)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::compare((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq] Tuple(4)::equal((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash] Tuple(4)::hash((A, B, C, D)) -> Int
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash] Tuple(4)::hash_combine((A, B, C, D), Hasher) -> Unit
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq] Tuple(4)::not_equal((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_ge((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_gt((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_le((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_lt((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show] Tuple(4)::output((A, B, C, D), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson] Tuple(4)::to_json((A, B, C, D)) -> Json
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show] Tuple(4)::to_string((A, B, C, D)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::compare((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq] Tuple(5)::equal((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash] Tuple(5)::hash((A, B, C, D, E)) -> Int
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash] Tuple(5)::hash_combine((A, B, C, D, E), Hasher) -> Unit
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq] Tuple(5)::not_equal((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_ge((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_gt((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_le((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_lt((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show, E : Show] Tuple(5)::output((A, B, C, D, E), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson] Tuple(5)::to_json((A, B, C, D, E)) -> Json
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show, E : Show] Tuple(5)::to_string((A, B, C, D, E)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::compare((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq] Tuple(6)::equal((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash] Tuple(6)::hash((A, B, C, D, E, F)) -> Int
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash] Tuple(6)::hash_combine((A, B, C, D, E, F), Hasher) -> Unit
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq] Tuple(6)::not_equal((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_ge((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_gt((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_le((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_lt((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Tuple(6)::output((A, B, C, D, E, F), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson] Tuple(6)::to_json((A, B, C, D, E, F)) -> Json
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show] Tuple(6)::to_string((A, B, C, D, E, F)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::compare((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq] Tuple(7)::equal((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] Tuple(7)::hash((A, B, C, D, E, F, G)) -> Int
+#deprecated
+pub fn[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] Tuple(7)::hash_combine((A, B, C, D, E, F, G), Hasher) -> Unit
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq] Tuple(7)::not_equal((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_ge((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_gt((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_le((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_lt((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show] Tuple(7)::output((A, B, C, D, E, F, G), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson] Tuple(7)::to_json((A, B, C, D, E, F, G)) -> Json
+#deprecated
+pub fn[A : Show, B : Show, C : Show, D : Show, E : Show, F : Show, G : Show] Tuple(7)::to_string((A, B, C, D, E, F, G)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::compare((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq] Tuple(8)::equal((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq] Tuple(8)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_le((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show] Tuple(8)::output((T0, T1, T2, T3, T4, T5, T6, T7), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson] Tuple(8)::to_json((A, B, C, D, E, F, G, H)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show] Tuple(8)::to_string((T0, T1, T2, T3, T4, T5, T6, T7)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq] Tuple(9)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq] Tuple(9)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show] Tuple(9)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson] Tuple(9)::to_json((A, B, C, D, E, F, G, H, I)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show] Tuple(9)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq] Tuple(10)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq] Tuple(10)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show] Tuple(10)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson] Tuple(10)::to_json((A, B, C, D, E, F, G, H, I, J)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show] Tuple(10)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq] Tuple(11)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq] Tuple(11)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show] Tuple(11)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson] Tuple(11)::to_json((A, B, C, D, E, F, G, H, I, J, K)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show] Tuple(11)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq] Tuple(12)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq] Tuple(12)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show] Tuple(12)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson] Tuple(12)::to_json((A, B, C, D, E, F, G, H, I, J, K, L)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show] Tuple(12)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq] Tuple(13)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq] Tuple(13)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show] Tuple(13)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson] Tuple(13)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show] Tuple(13)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq] Tuple(14)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq] Tuple(14)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show] Tuple(14)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson] Tuple(14)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show] Tuple(14)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq] Tuple(15)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq] Tuple(15)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show] Tuple(15)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson, O : ToJson] Tuple(15)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show] Tuple(15)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> String
+
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Int
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq] Tuple(16)::equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
+#deprecated
+pub fn[T0 : Eq, T1 : Eq, T2 : Eq, T3 : Eq, T4 : Eq, T5 : Eq, T6 : Eq, T7 : Eq, T8 : Eq, T9 : Eq, T10 : Eq, T11 : Eq, T12 : Eq, T13 : Eq, T14 : Eq, T15 : Eq] Tuple(16)::not_equal((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
+pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show] Tuple(16)::output((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), &Logger) -> Unit
+pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson, O : ToJson, P : ToJson] Tuple(16)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)) -> Json
+#deprecated
+pub fn[T0 : Show, T1 : Show, T2 : Show, T3 : Show, T4 : Show, T5 : Show, T6 : Show, T7 : Show, T8 : Show, T9 : Show, T10 : Show, T11 : Show, T12 : Show, T13 : Show, T14 : Show, T15 : Show] Tuple(16)::to_string((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> String
+
 #alias("_[_]")
 pub fn BytesView::at(Self, Int) -> Byte
 pub fn BytesView::chop_prefix(Self, Self) -> Self?
 pub fn BytesView::chop_suffix(Self, Self) -> Self?
+pub fn BytesView::compare(Self, Self) -> Int
 pub fn BytesView::data(Self) -> Bytes
+#deprecated
+pub fn BytesView::equal(Self, Self) -> Bool
 pub fn BytesView::equal_to_bytes(Self, Bytes) -> Bool
 pub fn BytesView::find(Self, Self) -> Int?
 pub fn BytesView::get(Self, Int) -> Byte?
 pub fn BytesView::get_view(Self, start? : Int, end? : Int) -> Self?
 pub fn BytesView::has_prefix(Self, Self) -> Bool
 pub fn BytesView::has_suffix(Self, Self) -> Bool
+#deprecated
+pub fn BytesView::hash(Self) -> Int
+#deprecated
+pub fn BytesView::hash_combine(Self, Hasher) -> Unit
 pub fn BytesView::is_empty(Self) -> Bool
 #alias(iterator, deprecated)
 pub fn BytesView::iter(Self) -> Iter[Byte]
@@ -1006,16 +1706,27 @@ pub fn BytesView::iter(Self) -> Iter[Byte]
 pub fn BytesView::iter2(Self) -> Iter2[Int, Byte]
 pub fn BytesView::length(Self) -> Int
 pub fn BytesView::lexical_compare(Self, Self) -> Int
+#deprecated
+pub fn BytesView::not_equal(Self, Self) -> Bool
+pub fn BytesView::op_ge(Self, Self) -> Bool
+pub fn BytesView::op_gt(Self, Self) -> Bool
+pub fn BytesView::op_le(Self, Self) -> Bool
+pub fn BytesView::op_lt(Self, Self) -> Bool
+#deprecated
+pub fn BytesView::output(Self, &Logger) -> Unit
 pub fn BytesView::rev_find(Self, Self) -> Int?
 pub fn BytesView::start_offset(Self) -> Int
 pub fn BytesView::to_array(Self) -> Array[Byte]
 pub fn BytesView::to_fixedarray(Self) -> FixedArray[Byte]
+pub fn BytesView::to_json(Self) -> Json
 #alias(to_bytes, deprecated)
 pub fn BytesView::to_owned(Self) -> Bytes
+pub fn BytesView::to_string(Self) -> String
 #alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn BytesView::view(Self, start? : Int, end? : Int) -> Self
 
+pub fn StringView::add(Self, Self) -> Self
 pub fn StringView::after(Self, Self) -> Self?
 #alias(every)
 pub fn StringView::all(Self, (Char) -> Bool raise?) -> Bool raise?
@@ -1030,12 +1741,16 @@ pub fn StringView::char_length_eq(Self, Int) -> Bool
 pub fn StringView::char_length_ge(Self, Int) -> Bool
 pub fn StringView::clamped_view(Self, start? : Int, end? : Int) -> Self
 pub fn StringView::code_units(Self) -> ArrayView[UInt16]
+pub fn StringView::compare(Self, Self) -> Int
 pub fn StringView::compare_ignore_ascii_case(Self, Self) -> Int
 pub fn StringView::contains(Self, Self) -> Bool
 pub fn StringView::contains_any(Self, chars~ : Self) -> Bool
 pub fn StringView::contains_char(Self, Char) -> Bool
 pub fn StringView::contains_code_unit(Self, UInt16) -> Bool
 pub fn StringView::data(Self) -> String
+pub fn StringView::default() -> Self
+#deprecated
+pub fn StringView::equal(Self, Self) -> Bool
 pub fn StringView::equal_ignore_ascii_case(Self, Self) -> Bool
 pub fn StringView::equal_to_string(Self, String) -> Bool
 pub fn StringView::escape(Self, quote? : Bool) -> Self
@@ -1053,6 +1768,10 @@ pub fn StringView::get_view(Self, start? : Int, end? : Int) -> Self?
 pub fn StringView::has_prefix(Self, Self) -> Bool
 #alias(ends_with, deprecated)
 pub fn StringView::has_suffix(Self, Self) -> Bool
+#deprecated
+pub fn StringView::hash(Self) -> Int
+#deprecated
+pub fn StringView::hash_combine(Self, Hasher) -> Unit
 pub fn StringView::is_blank(Self) -> Bool
 pub fn StringView::is_empty(Self) -> Bool
 #alias(iterator, deprecated)
@@ -1062,7 +1781,15 @@ pub fn StringView::iter2(Self) -> Iter2[Int, Char]
 pub fn StringView::length(Self) -> Int
 pub fn StringView::lexical_compare(Self, Self) -> Int
 pub fn StringView::make(Int, Char) -> Self
+#deprecated
+pub fn StringView::not_equal(Self, Self) -> Bool
 pub fn StringView::offset_of_nth_char(Self, Int) -> Int?
+pub fn StringView::op_ge(Self, Self) -> Bool
+pub fn StringView::op_gt(Self, Self) -> Bool
+pub fn StringView::op_le(Self, Self) -> Bool
+pub fn StringView::op_lt(Self, Self) -> Bool
+#deprecated
+pub fn StringView::output(Self, &Logger) -> Unit
 pub fn StringView::pad_end(Self, Int, Char) -> String
 pub fn StringView::pad_start(Self, Int, Char) -> String
 pub fn StringView::repeat(Self, Int) -> Self
@@ -1090,9 +1817,11 @@ pub fn StringView::suffixes(Self, include_empty? : Bool) -> Iter[Self]
 pub fn StringView::to_array(Self) -> Array[Char]
 #deprecated
 pub fn StringView::to_bytes(Self) -> Bytes
+pub fn StringView::to_json(Self) -> Json
 pub fn StringView::to_lower(Self) -> Self
 #alias(to_string, deprecated)
 pub fn StringView::to_owned(Self) -> String
+pub fn StringView::to_string_view(Self) -> Self
 pub fn StringView::to_upper(Self) -> Self
 #label_migration(chars, alias=char_set)
 pub fn StringView::trim(Self, chars? : Self) -> Self
@@ -1108,6 +1837,35 @@ pub fn StringView::unsafe_get(Self, Int) -> UInt16
 pub fn StringView::view(Self, start_offset? : Int, end_offset? : Int) -> Self
 
 // Type aliases
+pub type Tuple10[A, B, C, D, E, F, G, H, I, J] = (A, B, C, D, E, F, G, H, I, J)
+
+pub type Tuple11[A, B, C, D, E, F, G, H, I, J, K] = (A, B, C, D, E, F, G, H, I, J, K)
+
+pub type Tuple12[A, B, C, D, E, F, G, H, I, J, K, L] = (A, B, C, D, E, F, G, H, I, J, K, L)
+
+pub type Tuple13[A, B, C, D, E, F, G, H, I, J, K, L, M] = (A, B, C, D, E, F, G, H, I, J, K, L, M)
+
+pub type Tuple14[A, B, C, D, E, F, G, H, I, J, K, L, M, N] = (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
+
+pub type Tuple15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
+
+pub type Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] = (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
+
+pub type Tuple2[A, B] = (A, B)
+
+pub type Tuple3[A, B, C] = (A, B, C)
+
+pub type Tuple4[A, B, C, D] = (A, B, C, D)
+
+pub type Tuple5[A, B, C, D, E] = (A, B, C, D, E)
+
+pub type Tuple6[A, B, C, D, E, F] = (A, B, C, D, E, F)
+
+pub type Tuple7[A, B, C, D, E, F, G] = (A, B, C, D, E, F, G)
+
+pub type Tuple8[A, B, C, D, E, F, G, H] = (A, B, C, D, E, F, G, H)
+
+pub type Tuple9[A, B, C, D, E, F, G, H, I] = (A, B, C, D, E, F, G, H, I)
 
 // Traits
 pub(open) trait Add {

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -961,7 +961,7 @@ pub impl[T : Eq] Eq for ReadOnlyArray[T] with fn equal(self, other) {
 
 ///|
 pub impl[T : Hash] Hash for ReadOnlyArray[T] with fn hash_combine(self, hasher) {
-  self.unsafe_reinterpret_to_fixed_array().hash_combine(hasher)
+  Hash::hash_combine(self.unsafe_reinterpret_to_fixed_array(), hasher)
 }
 
 ///|

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -850,30 +850,30 @@ test "Show for Char special cases" {
 
   // Test various special character outputs
   let quote_buf = StringBuilder()
-  '\''.output(quote_buf)
+  Show::output('\'', quote_buf)
   @test.assert_eq(quote_buf.to_string(), "'")
   let backslash_buf = StringBuilder()
-  '\\'.output(backslash_buf)
+  Show::output('\\', backslash_buf)
   @test.assert_eq(backslash_buf.to_string(), "\\")
   let cr_buf = StringBuilder()
-  '\r'.output(cr_buf)
+  Show::output('\r', cr_buf)
   @test.assert_eq(cr_buf.to_string(), "\r")
   let backspace_buf = StringBuilder()
-  '\b'.output(backspace_buf)
+  Show::output('\b', backspace_buf)
   @test.assert_eq(backspace_buf.to_string(), "\b")
   let tab_buf = StringBuilder()
-  '\t'.output(tab_buf)
+  Show::output('\t', tab_buf)
   @test.assert_eq(tab_buf.to_string(), "\t")
 
   // Test hex output for control characters
   let ctrl1_buf = StringBuilder()
-  '\u{01}'.output(ctrl1_buf)
+  Show::output('\u{01}', ctrl1_buf)
   @test.assert_eq(ctrl1_buf.to_string(), "\u{01}")
   let ctrl_f_buf = StringBuilder()
-  '\u{0F}'.output(ctrl_f_buf)
+  Show::output('\u{0F}', ctrl_f_buf)
   @test.assert_eq(ctrl_f_buf.to_string(), "\u{0f}")
   let ctrl_1f_buf = StringBuilder()
-  '\u{1F}'.output(ctrl_1f_buf)
+  Show::output('\u{1F}', ctrl_1f_buf)
   @test.assert_eq(ctrl_1f_buf.to_string(), "\u{1f}")
 }
 

--- a/builtin/string_overloading_feature_test.mbt
+++ b/builtin/string_overloading_feature_test.mbt
@@ -62,3 +62,11 @@ test {
   // let z0 = FromString::from_string("")
   // ...
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend MyInt with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend MyString with @debug.Debug::{to_repr}

--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -89,3 +89,23 @@ test "Logger defaults" {
   Logger::write_char(logger, '!')
   inspect(logger.output, content="hi!")
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Data with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Pair with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Data with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Pair with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Data with Hash::{hash, hash_combine}

--- a/builtin/tuple.mbt
+++ b/builtin/tuple.mbt
@@ -1,0 +1,175 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Named alias for the 2-element tuple type `(A, B)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple2[A, B] = (A, B)
+
+///|
+/// Named alias for the 3-element tuple type `(A, B, C)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple3[A, B, C] = (A, B, C)
+
+///|
+/// Named alias for the 4-element tuple type `(A, B, C, D)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple4[A, B, C, D] = (A, B, C, D)
+
+///|
+/// Named alias for the 5-element tuple type `(A, B, C, D, E)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple5[A, B, C, D, E] = (A, B, C, D, E)
+
+///|
+/// Named alias for the 6-element tuple type `(A, B, C, D, E, F)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple6[A, B, C, D, E, F] = (A, B, C, D, E, F)
+
+///|
+/// Named alias for the 7-element tuple type `(A, B, C, D, E, F, G)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple7[A, B, C, D, E, F, G] = (A, B, C, D, E, F, G)
+
+///|
+/// Named alias for the 8-element tuple type `(A, B, C, D, E, F, G, H)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple8[A, B, C, D, E, F, G, H] = (A, B, C, D, E, F, G, H)
+
+///|
+/// Named alias for the 9-element tuple type `(A, B, C, D, E, F, G, H, I)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple9[A, B, C, D, E, F, G, H, I] = (A, B, C, D, E, F, G, H, I)
+
+///|
+/// Named alias for the 10-element tuple type `(A, B, C, D, E, F, G, H, I, J)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple10[A, B, C, D, E, F, G, H, I, J] = (A, B, C, D, E, F, G, H, I, J)
+
+///|
+/// Named alias for the 11-element tuple type `(A, B, C, D, E, F, G, H, I, J, K)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple11[A, B, C, D, E, F, G, H, I, J, K] = (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+)
+
+///|
+/// Named alias for the 12-element tuple type `(A, B, C, D, E, F, G, H, I, J, K, L)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple12[A, B, C, D, E, F, G, H, I, J, K, L] = (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+)
+
+///|
+/// Named alias for the 13-element tuple type `(A, B, C, D, E, F, G, H, I, J, K, L, M)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple13[A, B, C, D, E, F, G, H, I, J, K, L, M] = (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+)
+
+///|
+/// Named alias for the 14-element tuple type `(A, B, C, D, E, F, G, H, I, J, K, L, M, N)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple14[A, B, C, D, E, F, G, H, I, J, K, L, M, N] = (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+)
+
+///|
+/// Named alias for the 15-element tuple type `(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] = (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+)
+
+///|
+/// Named alias for the 16-element tuple type `(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)`, so its trait
+/// impls can be promoted with an explicit `extend` declaration.
+pub type Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] = (
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+)

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -112,9 +112,9 @@ test "hash" {
   let h4 = Hasher(seed=0)
   h4.combine(b4)
   inspect(h4.finalize(), content="1297183151")
-  inspect(b1.hash() == b1.hash(), content="true")
-  inspect(b2.hash() == b2.hash(), content="true")
-  inspect(b1.hash() == b2.hash(), content="false")
+  inspect(Hash::hash(b1) == Hash::hash(b1), content="true")
+  inspect(Hash::hash(b2) == Hash::hash(b2), content="true")
+  inspect(Hash::hash(b1) == Hash::hash(b2), content="false")
 }
 
 ///|

--- a/bytes/internal/regex_engine/ast/extends.mbt
+++ b/bytes/internal/regex_engine/ast/extends.mbt
@@ -1,0 +1,29 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Assertion with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Pattern with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend PatternDesc with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Quantifier with @debug.Debug::{to_repr}

--- a/bytes/internal/regex_engine/ast/pkg.generated.mbti
+++ b/bytes/internal/regex_engine/ast/pkg.generated.mbti
@@ -58,12 +58,16 @@ pub enum Assertion {
   EndOfWord
   NotWordBoundary
 } derive(@debug.Debug)
+#deprecated
+pub fn Assertion::to_repr(Self) -> @debug.Repr
 
 pub struct Pattern {
   desc : PatternDesc
   nullable : Bool
 }
 pub fn Pattern::is_anchored(Self) -> Bool
+#deprecated
+pub fn Pattern::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for Pattern
 
 pub enum PatternDesc {
@@ -75,12 +79,16 @@ pub enum PatternDesc {
   Capture(name~ : String?, Pattern)
   Assertion(Assertion)
 } derive(@debug.Debug)
+#deprecated
+pub fn PatternDesc::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Quantifier {
   min : Int
   max : Int?
   mode : @shared_types.QuantifierMode
 } derive(@debug.Debug)
+#deprecated
+pub fn Quantifier::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/bytes/internal/regex_engine/extends.mbt
+++ b/bytes/internal/regex_engine/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend MatchResult with @debug.Debug::{to_repr}

--- a/bytes/internal/regex_engine/pkg.generated.mbti
+++ b/bytes/internal/regex_engine/pkg.generated.mbti
@@ -54,6 +54,8 @@ pub let start_of_word : @ast.Pattern
 // Types and methods
 type MatchResult derive(@debug.Debug)
 pub fn MatchResult::group(Self, Int) -> (Int, Int)?
+#deprecated
+pub fn MatchResult::to_repr(Self) -> @debug.Repr
 
 type Regex
 pub fn[T : Input] Regex::execute(Self, T, Int) -> MatchResult?

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -363,10 +363,10 @@ test "View::to_bytes" {
 test "impl Hash for View" {
   let b0 : Bytes = b"12345678"
   let b1 : Bytes = b"56781234"
-  @test.assert_eq(b0[0:4].hash(), b1[4:8].hash())
-  @test.assert_eq(b0[4:8].hash(), b1[0:4].hash())
-  @test.assert_not_eq(b0[0:4].hash(), b1[0:4].hash())
-  @test.assert_not_eq(b0[4:8].hash(), b1[4:8].hash())
+  @test.assert_eq(Hash::hash(b0[0:4]), Hash::hash(b1[4:8]))
+  @test.assert_eq(Hash::hash(b0[4:8]), Hash::hash(b1[0:4]))
+  @test.assert_not_eq(Hash::hash(b0[0:4]), Hash::hash(b1[0:4]))
+  @test.assert_not_eq(Hash::hash(b0[4:8]), Hash::hash(b1[4:8]))
 }
 
 ///|
@@ -378,6 +378,6 @@ test "bytes view hash invariant" {
   let bytes : Array[Bytes] = @quickcheck.samples(20)
   for b in bytes {
     let view = b[:]
-    @test.assert_eq(view.hash(), b.hash())
+    @test.assert_eq(Hash::hash(view), Hash::hash(b))
   }
 }

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -524,3 +524,15 @@ test "Case conversion with non-letters" {
   assert_eq('a'.to_ascii_uppercase(), 'A')
   assert_eq('z'.to_ascii_uppercase(), 'Z')
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend TestHash with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend TestHash with Debug::{to_repr}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend TestHash with Hash::{hash, hash_combine}

--- a/cmp/README.mbt.md
+++ b/cmp/README.mbt.md
@@ -71,6 +71,10 @@ struct Person {
 } derive(Debug)
 
 ///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Person with Debug::{to_repr}
+
+///|
 test "cmp_by_key" {
   // Compare strings by their length
   let s1 = "hello"

--- a/cmp/extends.mbt
+++ b/cmp/extends.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Reverse with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Reverse with @debug.Debug::{to_repr}
+
+///|
+pub extend Reverse with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Reverse with Hash::{hash, hash_combine}
+
+///|
+pub extend Reverse with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Reverse with Show::{output}

--- a/cmp/pkg.generated.mbti
+++ b/cmp/pkg.generated.mbti
@@ -22,6 +22,24 @@ pub fn[T, K : Compare] minmax_by_key(T, T, (T) -> K) -> (T, T)
 
 // Types and methods
 pub(all) struct Reverse[T](T) derive(Eq, Hash, Show, @debug.Debug)
+pub fn[T : Compare] Reverse::compare(Self[T], Self[T]) -> Int
+#deprecated
+pub fn[T : Eq] Reverse::equal(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[T : Hash] Reverse::hash(Self[T]) -> Int
+#deprecated
+pub fn[T : Hash] Reverse::hash_combine(Self[T], Hasher) -> Unit
+#deprecated
+pub fn[T : Eq] Reverse::not_equal(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Reverse::op_ge(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Reverse::op_gt(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Reverse::op_le(Self[T], Self[T]) -> Bool
+pub fn[T : Compare] Reverse::op_lt(Self[T], Self[T]) -> Bool
+#deprecated
+pub fn[T : Show] Reverse::output(Self[T], &Logger) -> Unit
+#deprecated
+pub fn[T : @debug.Debug] Reverse::to_repr(Self[T]) -> @debug.Repr
+pub fn[T : Show] Reverse::to_string(Self[T]) -> String
 pub impl[T : Compare] Compare for Reverse[T]
 
 // Type aliases

--- a/coverage/extends.mbt
+++ b/coverage/extends.mbt
@@ -1,0 +1,20 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub extend CoverageCounter with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend CoverageCounter with Show::{output}

--- a/coverage/pkg.generated.mbti
+++ b/coverage/pkg.generated.mbti
@@ -12,6 +12,9 @@ pub fn track(String, CoverageCounter) -> Unit
 type CoverageCounter
 pub fn CoverageCounter::incr(Self, Int) -> Unit
 pub fn CoverageCounter::new(Int) -> Self
+#deprecated
+pub fn CoverageCounter::output(Self, &Logger) -> Unit
+pub fn CoverageCounter::to_string(Self) -> String
 pub impl Show for CoverageCounter
 
 // Type aliases

--- a/debug/delta_wbtest.mbt
+++ b/debug/delta_wbtest.mbt
@@ -117,3 +117,7 @@ test "diff: mismatched label kinds are Different" {
     fail("expected Different(Integer, StringLit)")
   }
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Empty with Debug::{to_repr}

--- a/debug/extends.mbt
+++ b/debug/extends.mbt
@@ -1,0 +1,24 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Repr with Debug::{to_repr}
+
+///|
+pub extend Repr with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Repr with Show::{output}

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -24,6 +24,11 @@ pub fn[T : Debug] to_string(T) -> String
 
 // Types and methods
 type Repr
+#deprecated
+pub fn Repr::output(Self, &Logger) -> Unit
+#deprecated
+pub fn Repr::to_repr(Self) -> Self
+pub fn Repr::to_string(Self) -> String
 pub impl Show for Repr
 pub impl Debug for Repr
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -79,8 +79,8 @@ pub impl[A : Show] Show for Deque[A] with fn output(self, logger) {
 ///   let dq1 = @deque.from_array([1, 2, 3])
 ///   let dq2 = @deque.from_array([1, 2, 3])
 ///   let dq3 = @deque.from_array([1, 2, 3, 4])
-///   @test.assert_eq(dq1.hash(), dq2.hash()) // same elements → same hash
-///   @test.assert_not_eq(dq1.hash(), dq3.hash()) // different elements → different hash
+///   @test.assert_eq(Hash::hash(dq1), Hash::hash(dq2)) // same elements → same hash
+///   @test.assert_not_eq(Hash::hash(dq1), Hash::hash(dq3)) // different elements → different hash
 /// }
 /// ```
 ///
@@ -90,7 +90,7 @@ pub impl[A : Show] Show for Deque[A] with fn output(self, logger) {
 ///
 pub impl[A : Hash] Hash for Deque[A] with fn hash_combine(self, hasher) {
   for v in self {
-    v.hash_combine(hasher)
+    Hash::hash_combine(v, hasher)
   }
 }
 

--- a/deque/extends.mbt
+++ b/deque/extends.mbt
@@ -1,0 +1,41 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Deque with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend Deque with @json.FromJson::{from_json}
+
+///|
+pub extend Deque with Add::{add}
+
+///|
+pub extend Deque with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Deque with Hash::{hash, hash_combine}
+
+///|
+pub extend Deque with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Deque with Show::{output}
+
+///|
+pub extend Deque with ToJson::{to_json}

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -17,6 +17,7 @@ type Deque[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A] Deque::Deque(ArrayView[A], capacity? : Int) -> Self[A]
+pub fn[A] Deque::add(Self[A], Self[A]) -> Self[A]
 pub fn[A] Deque::append(Self[A], Self[A]) -> Unit
 pub fn[A] Deque::as_views(Self[A]) -> (ArrayView[A], ArrayView[A])
 #alias("_[_]")
@@ -29,12 +30,15 @@ pub fn[A] Deque::capacity(Self[A]) -> Int
 pub fn[A] Deque::chunk_by(Self[A], (A, A) -> Bool raise?) -> Self[Self[A]] raise?
 pub fn[A] Deque::chunks(Self[A], Int) -> Self[Self[A]]
 pub fn[A] Deque::clear(Self[A]) -> Unit
+pub fn[A : Compare] Deque::compare(Self[A], Self[A]) -> Int
 pub fn[A : Eq] Deque::contains(Self[A], A) -> Bool
 #alias(clone, deprecated)
 pub fn[A] Deque::copy(Self[A]) -> Self[A]
 pub fn[A] Deque::drain(Self[A], start~ : Int, len? : Int) -> Self[A]
 pub fn[A] Deque::each(Self[A], (A) -> Unit) -> Unit
 pub fn[A] Deque::eachi(Self[A], (Int, A) -> Unit) -> Unit
+#deprecated
+pub fn[A : Eq] Deque::equal(Self[A], Self[A]) -> Bool
 pub fn[A] Deque::extract_if(Self[A], (A) -> Bool) -> Self[A]
 pub fn[A] Deque::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A] Deque::flatten(Self[Self[A]]) -> Self[A]
@@ -42,8 +46,14 @@ pub fn[A] Deque::flatten(Self[Self[A]]) -> Self[A]
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
 pub fn[A] Deque::from_iter(Iter[A]) -> Self[A]
+#deprecated
+pub fn[A : @json.FromJson] Deque::from_json(Json, @json.JsonPath) -> Self[A] raise @json.JsonDecodeError
 pub fn[A] Deque::front(Self[A]) -> A?
 pub fn[A] Deque::get(Self[A], Int) -> A?
+#deprecated
+pub fn[A : Hash] Deque::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] Deque::hash_combine(Self[A], Hasher) -> Unit
 pub fn[A] Deque::insert(Self[A], Int, A) -> Unit
 pub fn[A] Deque::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
@@ -57,6 +67,14 @@ pub fn[A, U] Deque::mapi(Self[A], (Int, A) -> U) -> Self[U]
 #as_free_fn(deprecated)
 #deprecated
 pub fn[A] Deque::new(capacity? : Int) -> Self[A]
+#deprecated
+pub fn[A : Eq] Deque::not_equal(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Deque::op_ge(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Deque::op_gt(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Deque::op_le(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Deque::op_lt(Self[A], Self[A]) -> Bool
+#deprecated
+pub fn[A : Show] Deque::output(Self[A], &Logger) -> Unit
 pub fn[A] Deque::pop_back(Self[A]) -> A?
 pub fn[A] Deque::pop_front(Self[A]) -> A?
 pub fn[A] Deque::push_back(Self[A], A) -> Unit
@@ -82,8 +100,11 @@ pub fn[A] Deque::shrink_to_fit(Self[A]) -> Unit
 pub fn[A] Deque::shuffle(Self[A], rand~ : (Int) -> Int) -> Self[A]
 pub fn[A] Deque::shuffle_in_place(Self[A], rand~ : (Int) -> Int) -> Unit
 pub fn[A] Deque::to_array(Self[A]) -> Array[A]
+pub fn[A : ToJson] Deque::to_json(Self[A]) -> Json
 #deprecated
 pub fn[A : @debug.Debug] Deque::to_repr(Self[A]) -> @debug.Repr
+#deprecated
+pub fn[A : Show] Deque::to_string(Self[A]) -> String
 pub fn[A] Deque::truncate(Self[A], Int) -> Unit
 pub impl[A] Add for Deque[A]
 pub impl[A : Compare] Compare for Deque[A]

--- a/encoding/ascii/extends.mbt
+++ b/encoding/ascii/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Malformed with @debug.Debug::{to_repr}

--- a/encoding/ascii/pkg.generated.mbti
+++ b/encoding/ascii/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn encode(StringView) -> Bytes
 pub suberror Malformed {
   Malformed(BytesView)
 } derive(@debug.Debug)
+#deprecated
+pub fn Malformed::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 

--- a/encoding/base64/extends.mbt
+++ b/encoding/base64/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Malformed with @debug.Debug::{to_repr}

--- a/encoding/base64/pkg.generated.mbti
+++ b/encoding/base64/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn encode(BytesView, padding? : Bool) -> String
 pub suberror Malformed {
   Malformed(StringView)
 } derive(@debug.Debug)
+#deprecated
+pub fn Malformed::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 

--- a/encoding/utf16/extends.mbt
+++ b/encoding/utf16/extends.mbt
@@ -1,0 +1,21 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Endian with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Malformed with @debug.Debug::{to_repr}

--- a/encoding/utf16/pkg.generated.mbti
+++ b/encoding/utf16/pkg.generated.mbti
@@ -16,12 +16,16 @@ pub fn encode(StringView, bom? : Bool, endianness? : Endian) -> Bytes
 pub suberror Malformed {
   Malformed(BytesView)
 } derive(@debug.Debug)
+#deprecated
+pub fn Malformed::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 pub(all) enum Endian {
   Little
   Big
 } derive(@debug.Debug)
+#deprecated
+pub fn Endian::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/encoding/utf8/extends.mbt
+++ b/encoding/utf8/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Malformed with @debug.Debug::{to_repr}

--- a/encoding/utf8/pkg.generated.mbti
+++ b/encoding/utf8/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn encode(StringView, bom? : Bool) -> Bytes
 pub suberror Malformed {
   Malformed(BytesView)
 } derive(@debug.Debug)
+#deprecated
+pub fn Malformed::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 

--- a/error/README.mbt.md
+++ b/error/README.mbt.md
@@ -90,6 +90,9 @@ suberror MyError {
 } derive(ToJson)
 
 ///|
+pub extend MyError with ToJson::{to_json}
+
+///|
 test "error display and json" {
   let error : Error = MyError(42)
 

--- a/error/error.mbt
+++ b/error/error.mbt
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 ///|
-fn Error::to_string(self : Error) -> String = "%error.to_string"
+/// Returns the human-readable string representation of the error.
+pub fn Error::to_string(self : Error) -> String = "%error.to_string"
 
 ///|
 pub impl Show for Error with fn to_string(self) {
@@ -21,7 +22,8 @@ pub impl Show for Error with fn to_string(self) {
 }
 
 ///|
-fn Error::to_json(self : Error) -> Json = "%error.to_json"
+/// Returns the JSON representation of the error.
+pub fn Error::to_json(self : Error) -> Json = "%error.to_json"
 
 ///|
 pub impl ToJson for Error with fn to_json(self) {

--- a/error/error_test.mbt
+++ b/error/error_test.mbt
@@ -225,3 +225,6 @@ test "error to json" {
     ),
   )
 }
+
+///|
+pub extend ErrWithToJson with ToJson::{to_json}

--- a/error/extends.mbt
+++ b/error/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Error with Show::{output}

--- a/error/pkg.generated.mbti
+++ b/error/pkg.generated.mbti
@@ -11,7 +11,11 @@ import {
 
 // Types and methods
 #deprecated
+pub fn Error::output(Self, &Logger) -> Unit
+pub fn Error::to_json(Self) -> Json
+#deprecated
 pub fn Error::to_repr(Self) -> @debug.Repr
+pub fn Error::to_string(Self) -> String
 pub impl Show for Error
 pub impl ToJson for Error
 pub impl @debug.Debug for Error

--- a/float/extends.mbt
+++ b/float/extends.mbt
@@ -1,0 +1,55 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Float with Eq::{equal, not_equal}
+
+///|
+pub extend Float with Add::{add}
+
+///|
+pub extend Float with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Float with Default::{default}
+
+///|
+pub extend Float with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Float with Hash::{hash, hash_combine}
+
+///|
+pub extend Float with Mod::{mod}
+
+///|
+pub extend Float with Mul::{mul}
+
+///|
+pub extend Float with Neg::{neg}
+
+///|
+pub extend Float with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Float with Show::{output}
+
+///|
+pub extend Float with Sub::{sub}
+
+///|
+pub extend Float with ToJson::{to_json}

--- a/float/float_test.mbt
+++ b/float/float_test.mbt
@@ -242,3 +242,7 @@ test "Float::signum" {
   assert_eq((0.0 : Float).signum(), 0.0)
   assert_true(@float.not_a_number.signum().is_nan())
 }
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend FloatHashInput with Hash::{hash, hash_combine}

--- a/float/pkg.generated.mbti
+++ b/float/pkg.generated.mbti
@@ -22,9 +22,15 @@ pub let not_a_number : Float
 // Types and methods
 #as_free_fn(deprecated)
 pub fn Float::abs(Float) -> Float
+pub fn Float::add(Float, Float) -> Float
 #as_free_fn
 pub fn Float::ceil(Float) -> Float
 pub fn Float::clamp(Float, min~ : Float, max~ : Float) -> Float
+pub fn Float::compare(Float, Float) -> Int
+pub fn Float::default() -> Float
+pub fn Float::div(Float, Float) -> Float
+#deprecated
+pub fn Float::equal(Float, Float) -> Bool
 #as_free_fn
 pub fn Float::floor(Float) -> Float
 pub fn Float::from_byte(Byte) -> Float
@@ -33,6 +39,10 @@ pub fn Float::from_int(Int) -> Float
 pub fn Float::from_int64(Int64) -> Float
 pub fn Float::from_uint(UInt) -> Float
 pub fn Float::from_uint64(UInt64) -> Float
+#deprecated
+pub fn Float::hash(Float) -> Int
+#deprecated
+pub fn Float::hash_combine(Float, Hasher) -> Unit
 pub fn Float::is_close(Float, Float, relative_tolerance? : Float, absolute_tolerance? : Float) -> Bool
 pub fn Float::is_inf(Float) -> Bool
 pub fn Float::is_nan(Float) -> Bool
@@ -41,6 +51,17 @@ pub fn Float::is_pos_inf(Float) -> Bool
 pub fn Float::lerp(Float, target~ : Float, t~ : Float) -> Float
 pub fn Float::max(Float, Float) -> Float
 pub fn Float::min(Float, Float) -> Float
+pub fn Float::mod(Float, Float) -> Float
+pub fn Float::mul(Float, Float) -> Float
+pub fn Float::neg(Float) -> Float
+#deprecated
+pub fn Float::not_equal(Float, Float) -> Bool
+pub fn Float::op_ge(Float, Float) -> Bool
+pub fn Float::op_gt(Float, Float) -> Bool
+pub fn Float::op_le(Float, Float) -> Bool
+pub fn Float::op_lt(Float, Float) -> Bool
+#deprecated
+pub fn Float::output(Float, &Logger) -> Unit
 #as_free_fn(deprecated)
 #deprecated
 pub fn Float::pow(Float, Float) -> Float
@@ -52,10 +73,13 @@ pub fn Float::reinterpret_from_uint(UInt) -> Float
 pub fn Float::round(Float) -> Float
 pub fn Float::signum(Float) -> Float
 pub fn Float::sqrt(Float) -> Float
+pub fn Float::sub(Float, Float) -> Float
 pub fn Float::to_be_bytes(Float) -> Bytes
 pub fn Float::to_double(Float) -> Double
 pub fn Float::to_int(Float) -> Int
+pub fn Float::to_json(Float) -> Json
 pub fn Float::to_le_bytes(Float) -> Bytes
+pub fn Float::to_string(Float) -> String
 #as_free_fn
 pub fn Float::trunc(Float) -> Float
 pub fn Float::until(Float, Float, step? : Float, inclusive? : Bool) -> Iter[Float]

--- a/hashmap/extends.mbt
+++ b/hashmap/extends.mbt
@@ -1,0 +1,34 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend HashMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend HashMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend HashMap with Default::{default}
+
+///|
+pub extend HashMap with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend HashMap with Show::{output}
+
+///|
+pub extend HashMap with ToJson::{to_json}

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -203,7 +203,7 @@ fn[K, V] HashMap::push_away(
 /// }
 /// ```
 pub fn[K : Hash + Eq, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
-  // self.get_with_hash(key, key.hash())
+  // self.get_with_hash(key, Hash::hash(key))
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
@@ -240,7 +240,7 @@ pub fn[V] HashMap::get_from_bytes(
   self : HashMap[Bytes, V],
   key : BytesView,
 ) -> V? {
-  let hash = key.hash()
+  let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_bytes(entry.key) {
@@ -276,7 +276,7 @@ pub fn[V] HashMap::get_from_string(
   self : HashMap[String, V],
   key : StringView,
 ) -> V? {
-  let hash = key.hash()
+  let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_string(entry.key) {

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -18,6 +18,8 @@ type HashMap[K, V]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[K : Hash + Eq, V] HashMap::HashMap(ArrayView[(K, V)], capacity? : Int) -> Self[K, V]
+#deprecated
+pub fn[K : @quickcheck.Arbitrary + Hash + Eq, V : @quickcheck.Arbitrary] HashMap::arbitrary(Int, @splitmix.RandomState) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] HashMap::at(Self[K, V], K) -> V
 pub fn[K, V] HashMap::capacity(Self[K, V]) -> Int
@@ -26,8 +28,11 @@ pub fn[K : Hash + Eq, V] HashMap::contains(Self[K, V], K) -> Bool
 pub fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(Self[K, V], K, V) -> Bool
 #alias(clone, deprecated)
 pub fn[K, V] HashMap::copy(Self[K, V]) -> Self[K, V]
+pub fn[K, V] HashMap::default() -> Self[K, V]
 pub fn[K, V] HashMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] HashMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[K : Hash + Eq, V : Eq] HashMap::equal(Self[K, V], Self[K, V]) -> Bool
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
@@ -51,13 +56,20 @@ pub fn[K : Eq, V] HashMap::merge_in_place(Self[K, V], Self[K, V]) -> Unit
 #as_free_fn(deprecated)
 #deprecated
 pub fn[K, V] HashMap::new(capacity? : Int) -> Self[K, V]
+#deprecated
+pub fn[K : Hash + Eq, V : Eq] HashMap::not_equal(Self[K, V], Self[K, V]) -> Bool
+#deprecated
+pub fn[K : Show, V : Show] HashMap::output(Self[K, V], &Logger) -> Unit
 pub fn[K : Hash + Eq, V] HashMap::remove(Self[K, V], K) -> Unit
 pub fn[K, V] HashMap::retain(Self[K, V], (K, V) -> Bool) -> Unit
 #alias("_[_]=_")
 pub fn[K : Hash + Eq, V] HashMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] HashMap::to_array(Self[K, V]) -> Array[(K, V)]
+pub fn[K : Show, V : ToJson] HashMap::to_json(Self[K, V]) -> Json
 #deprecated
 pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(Self[K, V]) -> @debug.Repr
+#deprecated
+pub fn[K : Show, V : Show] HashMap::to_string(Self[K, V]) -> String
 pub fn[K : Hash + Eq, V] HashMap::update(Self[K, V], K, (V?) -> V?) -> Unit
 pub fn[K : Hash + Eq, V] HashMap::update_or_default(Self[K, V], K, V, (V) -> V) -> Unit
 pub fn[K, V] HashMap::values(Self[K, V]) -> Iter[V]

--- a/hashset/extends.mbt
+++ b/hashset/extends.mbt
@@ -1,0 +1,42 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend HashSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend HashSet with BitAnd::{land}
+
+///|
+pub extend HashSet with BitOr::{lor}
+
+///|
+pub extend HashSet with BitXOr::{lxor}
+
+///|
+pub extend HashSet with Default::{default}
+
+///|
+pub extend HashSet with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend HashSet with Show::{output}
+
+///|
+pub extend HashSet with Sub::{sub}
+
+///|
+pub extend HashSet with ToJson::{to_json}

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -21,11 +21,14 @@ pub fn[K : Hash + Eq] HashSet::HashSet(ArrayView[K], capacity? : Int) -> Self[K]
 #alias(insert, deprecated)
 pub fn[K : Hash + Eq] HashSet::add(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] HashSet::add_and_check(Self[K], K) -> Bool
+#deprecated
+pub fn[X : @quickcheck.Arbitrary + Eq + Hash] HashSet::arbitrary(Int, @splitmix.RandomState) -> Self[X]
 pub fn[K] HashSet::capacity(Self[K]) -> Int
 pub fn[K] HashSet::clear(Self[K]) -> Unit
 pub fn[K : Hash + Eq] HashSet::contains(Self[K], K) -> Bool
 #alias(clone, deprecated)
 pub fn[K] HashSet::copy(Self[K]) -> Self[K]
+pub fn[K] HashSet::default() -> Self[K]
 pub fn[K : Hash + Eq] HashSet::difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] HashSet::each(Self[K], (K) -> Unit raise?) -> Unit raise?
 pub fn[K] HashSet::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
@@ -40,18 +43,27 @@ pub fn[K : Hash + Eq] HashSet::is_subset(Self[K], Self[K]) -> Bool
 pub fn[K : Hash + Eq] HashSet::is_superset(Self[K], Self[K]) -> Bool
 #alias(iterator, deprecated)
 pub fn[K] HashSet::iter(Self[K]) -> Iter[K]
+pub fn[K : Hash + Eq] HashSet::land(Self[K], Self[K]) -> Self[K]
 #alias(size, deprecated)
 pub fn[K] HashSet::length(Self[K]) -> Int
+pub fn[K : Hash + Eq] HashSet::lor(Self[K], Self[K]) -> Self[K]
+pub fn[K : Hash + Eq] HashSet::lxor(Self[K], Self[K]) -> Self[K]
 #as_free_fn(deprecated)
 #deprecated
 pub fn[K] HashSet::new(capacity? : Int) -> Self[K]
+#deprecated
+pub fn[K : Show] HashSet::output(Self[K], &Logger) -> Unit
 pub fn[K : Hash + Eq] HashSet::remove(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] HashSet::remove_and_check(Self[K], K) -> Bool
 pub fn[K] HashSet::retain(Self[K], (K) -> Bool) -> Unit
+pub fn[K : Hash + Eq] HashSet::sub(Self[K], Self[K]) -> Self[K]
 pub fn[K : Hash + Eq] HashSet::symmetric_difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] HashSet::to_array(Self[K]) -> Array[K]
+pub fn[X : ToJson] HashSet::to_json(Self[X]) -> Json
 #deprecated
 pub fn[K : @debug.Debug] HashSet::to_repr(Self[K]) -> @debug.Repr
+#deprecated
+pub fn[K : Show] HashSet::to_string(Self[K]) -> String
 pub fn[K : Hash + Eq] HashSet::union(Self[K], Self[K]) -> Self[K]
 pub impl[K : Hash + Eq] BitAnd for HashSet[K]
 pub impl[K : Hash + Eq] BitOr for HashSet[K]

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -261,12 +261,12 @@ test "from_iter empty iter" {
 test "hash" {
   let l1 = @array.from_array([1, 2, 3, 4, 5])
   let l2 = @array.from_array([1, 2, 3, 4, 5])
-  inspect(l1.hash() == l2.hash(), content="true")
+  inspect(Hash::hash(l1) == Hash::hash(l2), content="true")
   let l3 = @array.from_array([5, 4, 3, 2, 1])
-  inspect(l1.hash() == l3.hash(), content="false")
+  inspect(Hash::hash(l1) == Hash::hash(l3), content="false")
   let l4 : @array.T[Int] = @array.from_array([])
-  inspect(l1.hash() == l4.hash(), content="false")
-  inspect(l4.hash() == l4.hash(), content="true")
+  inspect(Hash::hash(l1) == Hash::hash(l4), content="false")
+  inspect(Hash::hash(l4) == Hash::hash(l4), content="true")
 }
 
 ///|

--- a/immut/array/extends.mbt
+++ b/immut/array/extends.mbt
@@ -1,0 +1,38 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend T with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend T with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend T with Add::{add}
+
+///|
+pub extend T with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend T with Hash::{hash, hash_combine}
+
+///|
+pub extend T with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend T with Show::{output}

--- a/immut/array/pkg.generated.mbti
+++ b/immut/array/pkg.generated.mbti
@@ -13,9 +13,13 @@ import {
 
 // Types and methods
 type T[A]
+pub fn[A] T::add(Self[A], Self[A]) -> Self[A]
+#deprecated
+pub fn[X : @quickcheck.Arbitrary] T::arbitrary(Int, @splitmix.RandomState) -> Self[X]
 #alias("_[_]")
 #deprecated
 pub fn[A] T::at(Self[A], Int) -> A
+pub fn[A : Compare] T::compare(Self[A], Self[A]) -> Int
 #deprecated
 pub fn[A] T::concat(Self[A], Self[A]) -> Self[A]
 #alias(clone, deprecated)
@@ -25,6 +29,8 @@ pub fn[A] T::copy(Self[A]) -> Self[A]
 pub fn[A] T::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 #deprecated
 pub fn[A] T::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[A : Eq] T::equal(Self[A], Self[A]) -> Bool
 #alias(fold_left, deprecated)
 #deprecated
 pub fn[A, B] T::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
@@ -40,6 +46,10 @@ pub fn[A] T::from_array(ArrayView[A]) -> Self[A]
 pub fn[A] T::from_iter(Iter[A]) -> Self[A]
 #deprecated
 pub fn[A] T::get(Self[A], Int) -> A?
+#deprecated
+pub fn[A : Hash] T::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] T::hash_combine(Self[A], Hasher) -> Unit
 #deprecated
 pub fn[A] T::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
@@ -59,6 +69,14 @@ pub fn[A, B] T::map(Self[A], (A) -> B raise?) -> Self[B] raise?
 #deprecated
 pub fn[A] T::new() -> Self[A]
 #deprecated
+pub fn[A : Eq] T::not_equal(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] T::op_ge(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] T::op_gt(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] T::op_le(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] T::op_lt(Self[A], Self[A]) -> Bool
+#deprecated
+pub fn[A : Show] T::output(Self[A], &Logger) -> Unit
+#deprecated
 pub fn[A] T::push(Self[A], A) -> Self[A]
 #alias(fold_right, deprecated)
 #deprecated
@@ -69,6 +87,8 @@ pub fn[A] T::set(Self[A], Int, A) -> Self[A]
 pub fn[A] T::to_array(Self[A]) -> Array[A]
 #deprecated
 pub fn[A : @debug.Debug] T::to_repr(Self[A]) -> @debug.Repr
+#deprecated
+pub fn[A : Show] T::to_string(Self[A]) -> String
 pub impl[A] Add for T[A]
 pub impl[A : Compare] Compare for T[A]
 pub impl[A : Eq] Eq for T[A]

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -351,11 +351,11 @@ test "eq for random cases with different types" {
 test "hash" {
   let map1 = @hashmap.HashMap([("one", 1), ("two", 2)])
   let map2 = @hashmap.HashMap([("one", 1), ("two", 2)])
-  inspect(map1.hash() == map2.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map2), content="true")
   let map3 = @hashmap.HashMap([("two", 2), ("one", 1)])
-  inspect(map1.hash() == map3.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map3), content="true")
   let map4 = @hashmap.HashMap([("one", 1), ("two", 2), ("three", 3)])
-  inspect(map1.hash() == map4.hash(), content="false")
+  inspect(Hash::hash(map1) == Hash::hash(map4), content="false")
 }
 
 ///|
@@ -1045,7 +1045,7 @@ test "equal imply hash equal when collision" {
   let ma = @hashmap.new().add(s1, 1).add(s2, 2)
   let mb = @hashmap.new().add(s2, 2).add(s1, 1)
   inspect(ma == mb, content="true")
-  inspect(ma.hash() == mb.hash(), content="true")
+  inspect(Hash::hash(ma) == Hash::hash(mb), content="true")
 }
 
 ///|

--- a/immut/hashmap/extends.mbt
+++ b/immut/hashmap/extends.mbt
@@ -1,0 +1,32 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend HashMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend HashMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend HashMap with Hash::{hash, hash_combine}
+
+///|
+pub extend HashMap with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend HashMap with Show::{output}

--- a/immut/hashmap/pkg.generated.mbti
+++ b/immut/hashmap/pkg.generated.mbti
@@ -15,11 +15,15 @@ import {
 type HashMap[K, V] derive(Eq)
 pub fn[K : Eq + Hash, V] HashMap::HashMap(ArrayView[(K, V)]) -> Self[K, V]
 pub fn[K : Eq + Hash, V] HashMap::add(Self[K, V], K, V) -> Self[K, V]
+#deprecated
+pub fn[K : Eq + Hash + @quickcheck.Arbitrary, V : @quickcheck.Arbitrary] HashMap::arbitrary(Int, @splitmix.RandomState) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Eq + Hash, V] HashMap::at(Self[K, V], K) -> V
 pub fn[K : Eq + Hash, V] HashMap::contains(Self[K, V], K) -> Bool
 pub fn[K : Eq, V] HashMap::difference(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K, V] HashMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[K : Eq, V : Eq] HashMap::equal(Self[K, V], Self[K, V]) -> Bool
 #alias(filter_with_key, deprecated)
 pub fn[K, V] HashMap::filter(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
 #alias(fold_with_key, deprecated)
@@ -35,6 +39,10 @@ pub fn[K : Eq + Hash, V] HashMap::from_array(ArrayView[(K, V)]) -> Self[K, V]
 pub fn[K : Eq + Hash, V] HashMap::from_iter(Iter[(K, V)]) -> Self[K, V]
 #alias(find, deprecated)
 pub fn[K : Eq + Hash, V] HashMap::get(Self[K, V], K) -> V?
+#deprecated
+pub fn[K : Hash, V : Hash] HashMap::hash(Self[K, V]) -> Int
+#deprecated
+pub fn[K : Hash, V : Hash] HashMap::hash_combine(Self[K, V], Hasher) -> Unit
 pub fn[K : Eq, V] HashMap::intersection(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K : Eq, V] HashMap::intersection_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?) -> Self[K, V] raise?
 #alias(iterator, deprecated)
@@ -48,12 +56,18 @@ pub fn[K, V] HashMap::length(Self[K, V]) -> Int
 pub fn[K, V, A] HashMap::map(Self[K, V], (K, V) -> A raise?) -> Self[K, A] raise?
 #as_free_fn
 pub fn[K, V] HashMap::new() -> Self[K, V]
+#deprecated
+pub fn[K : Eq, V : Eq] HashMap::not_equal(Self[K, V], Self[K, V]) -> Bool
+#deprecated
+pub fn[K : Show, V : Show] HashMap::output(Self[K, V], &Logger) -> Unit
 pub fn[K : Eq + Hash, V] HashMap::remove(Self[K, V], K) -> Self[K, V]
 #as_free_fn
 pub fn[K : Hash, V] HashMap::singleton(K, V) -> Self[K, V]
 pub fn[K, V] HashMap::to_array(Self[K, V]) -> Array[(K, V)]
 #deprecated
 pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(Self[K, V]) -> @debug.Repr
+#deprecated
+pub fn[K : Show, V : Show] HashMap::to_string(Self[K, V]) -> String
 #alias(merge)
 pub fn[K : Eq, V] HashMap::union(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K : Eq, V] HashMap::union_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?) -> Self[K, V] raise?

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -633,7 +633,7 @@ pub fn[A : Eq + Hash] HashSet::HashSet(arr : ArrayView[A]) -> HashSet[A] {
 
 ///|
 pub impl[A : Hash] Hash for HashSet[A] with fn hash_combine(self, hasher) {
-  hasher.combine(self.iter().fold(init=0, (x, y) => x ^ y.hash()))
+  hasher.combine(self.iter().fold(init=0, (x, y) => x ^ Hash::hash(y)))
 }
 
 ///|

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -616,3 +616,7 @@ test "difference Branch single Flat result" {
   @test.assert_eq(diff.contains(2), false)
   inspect(diff.length(), content="1")
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend MyString with @debug.Debug::{to_repr}

--- a/immut/hashset/extends.mbt
+++ b/immut/hashset/extends.mbt
@@ -1,0 +1,32 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend HashSet with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend HashSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend HashSet with Hash::{hash, hash_combine}
+
+///|
+pub extend HashSet with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend HashSet with Show::{output}

--- a/immut/hashset/pkg.generated.mbti
+++ b/immut/hashset/pkg.generated.mbti
@@ -15,9 +15,13 @@ import {
 type HashSet[A] derive(Eq)
 pub fn[A : Eq + Hash] HashSet::HashSet(ArrayView[A]) -> Self[A]
 pub fn[A : Eq + Hash] HashSet::add(Self[A], A) -> Self[A]
+#deprecated
+pub fn[K : Eq + Hash + @quickcheck.Arbitrary] HashSet::arbitrary(Int, @splitmix.RandomState) -> Self[K]
 pub fn[A : Eq + Hash] HashSet::contains(Self[A], A) -> Bool
 pub fn[K : Eq] HashSet::difference(Self[K], Self[K]) -> Self[K]
 pub fn[A] HashSet::each(Self[A], (A) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[A : Eq] HashSet::equal(Self[A], Self[A]) -> Bool
 #alias(of, deprecated)
 #as_free_fn(of, deprecated)
 #as_free_fn(deprecated)
@@ -27,6 +31,10 @@ pub fn[A : Eq + Hash] HashSet::from_array(ArrayView[A]) -> Self[A]
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
 pub fn[A : Eq + Hash] HashSet::from_iter(Iter[A]) -> Self[A]
+#deprecated
+pub fn[A : Hash] HashSet::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] HashSet::hash_combine(Self[A], Hasher) -> Unit
 pub fn[K : Eq] HashSet::intersection(Self[K], Self[K]) -> Self[K]
 pub fn[A] HashSet::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
@@ -35,9 +43,15 @@ pub fn[A] HashSet::iter(Self[A]) -> Iter[A]
 pub fn[A] HashSet::length(Self[A]) -> Int
 #as_free_fn
 pub fn[A] HashSet::new() -> Self[A]
+#deprecated
+pub fn[A : Eq] HashSet::not_equal(Self[A], Self[A]) -> Bool
+#deprecated
+pub fn[A : Show] HashSet::output(Self[A], &Logger) -> Unit
 pub fn[A : Eq + Hash] HashSet::remove(Self[A], A) -> Self[A]
 #deprecated
 pub fn[K : @debug.Debug] HashSet::to_repr(Self[K]) -> @debug.Repr
+#deprecated
+pub fn[A : Show] HashSet::to_string(Self[A]) -> String
 pub fn[K : Eq] HashSet::union(Self[K], Self[K]) -> Self[K]
 pub impl[A : Hash] Hash for HashSet[A]
 #deprecated

--- a/immut/internal/path/extends.mbt
+++ b/immut/internal/path/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Path with Eq::{equal, not_equal}

--- a/immut/internal/path/path.mbt
+++ b/immut/internal/path/path.mbt
@@ -41,7 +41,7 @@ const HEAD_TAG : UInt = 0xffffffffU << (SEGMENT_LENGTH * SEGMENT_NUM)
 /// Creates a Path using the lowest (SEGMENT_LENGTH * SEGMENT_NUM)
 /// bits of the key's hash.
 pub fn[A : Hash] of(key : A) -> Path {
-  key.hash().reinterpret_as_uint() | HEAD_TAG
+  Hash::hash(key).reinterpret_as_uint() | HEAD_TAG
 }
 
 ///|

--- a/immut/internal/path/pkg.generated.mbti
+++ b/immut/internal/path/pkg.generated.mbti
@@ -9,10 +9,14 @@ pub fn[A : Hash] of(A) -> Path
 // Types and methods
 pub struct Path(UInt) derive(Eq)
 pub fn Path::advance(Self, Int) -> Self
+#deprecated
+pub fn Path::equal(Self, Self) -> Bool
 pub fn Path::idx(Self) -> Int
 pub fn Path::idx_at(Self, Int) -> Int
 pub fn Path::is_last(Self) -> Bool
 pub fn Path::next(Self) -> Self
+#deprecated
+pub fn Path::not_equal(Self, Self) -> Bool
 pub fn Path::push(Self, Int) -> Self
 
 // Type aliases

--- a/immut/internal/sparse_array/extends.mbt
+++ b/immut/internal/sparse_array/extends.mbt
@@ -1,0 +1,21 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Bitset with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend SparseArray with Eq::{equal, not_equal}

--- a/immut/internal/sparse_array/pkg.generated.mbti
+++ b/immut/internal/sparse_array/pkg.generated.mbti
@@ -14,7 +14,11 @@ pub fn[X] singleton(Int, X) -> SparseArray[X]
 
 // Types and methods
 pub struct Bitset(UInt) derive(Eq)
+#deprecated
+pub fn Bitset::equal(Self, Self) -> Bool
 pub fn Bitset::first_idx(Self) -> Int
+#deprecated
+pub fn Bitset::not_equal(Self, Self) -> Bool
 
 pub struct SparseArray[X] {
   elem_info : Bitset
@@ -23,12 +27,16 @@ pub struct SparseArray[X] {
 pub fn[X] SparseArray::add(Self[X], Int, X) -> Self[X]
 pub fn[X] SparseArray::difference(Self[X], Self[X], (X, X) -> X?) -> Self[X]?
 pub fn[X] SparseArray::each(Self[X], (X) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[X : Eq] SparseArray::equal(Self[X], Self[X]) -> Bool
 pub fn[X] SparseArray::filter(Self[X], (X) -> X? raise?) -> Self[X]? raise?
 pub fn[X] SparseArray::get(Self[X], Int) -> X?
 pub fn[X] SparseArray::intersection(Self[X], Self[X], (X, X) -> X? raise?) -> Self[X]? raise?
 #alias(size, deprecated)
 pub fn[X] SparseArray::length(Self[X]) -> Int
 pub fn[X, Y] SparseArray::map(Self[X], (X) -> Y raise?) -> Self[Y] raise?
+#deprecated
+pub fn[X : Eq] SparseArray::not_equal(Self[X], Self[X]) -> Bool
 pub fn[X] SparseArray::remove(Self[X], Int) -> Self[X]
 pub fn[X] SparseArray::replace(Self[X], Int, X) -> Self[X]
 pub fn[X] SparseArray::union(Self[X], Self[X], (X, X) -> X raise?) -> Self[X] raise?

--- a/immut/priority_queue/extends.mbt
+++ b/immut/priority_queue/extends.mbt
@@ -1,0 +1,38 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend PriorityQueue with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend PriorityQueue with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend PriorityQueue with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend PriorityQueue with Hash::{hash, hash_combine}
+
+///|
+pub extend PriorityQueue with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend PriorityQueue with Show::{output}
+
+///|
+pub extend PriorityQueue with ToJson::{to_json}

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -18,10 +18,19 @@ type PriorityQueue[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A : Compare] PriorityQueue::PriorityQueue(ArrayView[A]) -> Self[A]
+#deprecated
+pub fn[X : @quickcheck.Arbitrary + Compare] PriorityQueue::arbitrary(Int, @splitmix.RandomState) -> Self[X]
+pub fn[A : Compare] PriorityQueue::compare(Self[A], Self[A]) -> Int
+#deprecated
+pub fn[A : Compare] PriorityQueue::equal(Self[A], Self[A]) -> Bool
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
 pub fn[A : Compare] PriorityQueue::from_iter(Iter[A]) -> Self[A]
+#deprecated
+pub fn[A : Hash + Compare] PriorityQueue::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash + Compare] PriorityQueue::hash_combine(Self[A], Hasher) -> Unit
 pub fn[A] PriorityQueue::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
 pub fn[A : Compare] PriorityQueue::iter(Self[A]) -> Iter[A]
@@ -29,12 +38,23 @@ pub fn[A] PriorityQueue::length(Self[A]) -> Int
 #as_free_fn(deprecated)
 #deprecated
 pub fn[A] PriorityQueue::new() -> Self[A]
+#deprecated
+pub fn[A : Compare] PriorityQueue::not_equal(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] PriorityQueue::op_ge(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] PriorityQueue::op_gt(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] PriorityQueue::op_le(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] PriorityQueue::op_lt(Self[A], Self[A]) -> Bool
+#deprecated
+pub fn[A : Show + Compare] PriorityQueue::output(Self[A], &Logger) -> Unit
 pub fn[A] PriorityQueue::peek(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::pop(Self[A]) -> Self[A]?
 pub fn[A : Compare] PriorityQueue::push(Self[A], A) -> Self[A]
 pub fn[A : Compare] PriorityQueue::to_array(Self[A]) -> Array[A]
+pub fn[A : ToJson + Compare] PriorityQueue::to_json(Self[A]) -> Json
 #deprecated
 pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(Self[A]) -> @debug.Repr
+#deprecated
+pub fn[A : Show + Compare] PriorityQueue::to_string(Self[A]) -> String
 pub impl[A : Compare] Compare for PriorityQueue[A]
 pub impl[A : Compare] Eq for PriorityQueue[A]
 pub impl[A : Hash + Compare] Hash for PriorityQueue[A]

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -185,14 +185,14 @@ test "from_iter empty iter" {
 test "hash" {
   let pq1 = @priority_queue.from_array([1, 2, 3, 4, 5])
   let pq2 = @priority_queue.from_array([1, 2, 3, 4, 5])
-  inspect(pq1.hash() == pq2.hash(), content="true")
+  inspect(Hash::hash(pq1) == Hash::hash(pq2), content="true")
   let pq3 = @priority_queue.from_array([5, 4, 3, 2, 1])
-  inspect(pq1.hash() == pq3.hash(), content="true")
+  inspect(Hash::hash(pq1) == Hash::hash(pq3), content="true")
   let pq4 : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
-  inspect(pq1.hash() == pq4.hash(), content="false")
-  inspect(pq4.hash() == pq4.hash(), content="true")
+  inspect(Hash::hash(pq1) == Hash::hash(pq4), content="false")
+  inspect(Hash::hash(pq4) == Hash::hash(pq4), content="true")
   let pq5 = @priority_queue.from_array([1, 2, 3, 4, 6])
-  inspect(pq1.hash() == pq5.hash(), content="false")
+  inspect(Hash::hash(pq1) == Hash::hash(pq5), content="false")
 }
 
 ///|

--- a/immut/sorted_map/extends.mbt
+++ b/immut/sorted_map/extends.mbt
@@ -1,0 +1,38 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend SortedMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend SortedMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend SortedMap with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend SortedMap with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend SortedMap with Hash::{hash, hash_combine}
+
+///|
+pub extend SortedMap with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend SortedMap with Show::{output}

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -270,11 +270,11 @@ test "from_iter empty iter" {
 test "hash" {
   let map1 = @sorted_map.SortedMap([("one", 1), ("two", 2)])
   let map2 = @sorted_map.SortedMap([("one", 1), ("two", 2)])
-  inspect(map1.hash() == map2.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map2), content="true")
   let map3 = @sorted_map.SortedMap([("two", 2), ("one", 1)])
-  inspect(map1.hash() == map3.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map3), content="true")
   let map4 = @sorted_map.SortedMap([("one", 1), ("two", 2), ("three", 3)])
-  inspect(map1.hash() == map4.hash(), content="false")
+  inspect(Hash::hash(map1) == Hash::hash(map4), content="false")
 }
 
 ///|

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -17,13 +17,19 @@ type SortedMap[K, V]
 pub fn[K : Compare, V] SortedMap::SortedMap(ArrayView[(K, V)]) -> Self[K, V]
 #alias(insert, deprecated)
 pub fn[K : Compare, V] SortedMap::add(Self[K, V], K, V) -> Self[K, V]
+#deprecated
+pub fn[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] SortedMap::arbitrary(Int, @splitmix.RandomState) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Compare, V] SortedMap::at(Self[K, V], K) -> V
+pub fn[K : Compare, V : Compare] SortedMap::compare(Self[K, V], Self[K, V]) -> Int
 pub fn[K : Compare, V] SortedMap::contains(Self[K, V], K) -> Bool
+pub fn[K, V] SortedMap::default() -> Self[K, V]
 pub fn[K, V] SortedMap::each(Self[K, V], (K, V) -> Unit) -> Unit
 pub fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit) -> Unit
 #deprecated
 pub fn[K, V] SortedMap::elems(Self[K, V]) -> Array[V]
+#deprecated
+pub fn[K : Eq, V : Eq] SortedMap::equal(Self[K, V], Self[K, V]) -> Bool
 #alias(filter_with_key, deprecated)
 pub fn[K, V] SortedMap::filter(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
 #alias(foldl_with_key, deprecated)
@@ -41,6 +47,10 @@ pub fn[K : Compare, V] SortedMap::from_iter(Iter[(K, V)]) -> Self[K, V]
 pub fn[V : @json.FromJson] SortedMap::from_json(Json) -> Self[String, V] raise @json.JsonDecodeError
 #alias(lookup, deprecated)
 pub fn[K : Compare, V] SortedMap::get(Self[K, V], K) -> V?
+#deprecated
+pub fn[K : Hash, V : Hash] SortedMap::hash(Self[K, V]) -> Int
+#deprecated
+pub fn[K : Hash, V : Hash] SortedMap::hash_combine(Self[K, V], Hasher) -> Unit
 pub fn[K, V] SortedMap::is_empty(Self[K, V]) -> Bool
 #alias(iterator, deprecated)
 pub fn[K, V] SortedMap::iter(Self[K, V]) -> Iter[(K, V)]
@@ -57,6 +67,14 @@ pub fn[K : Compare, V] SortedMap::merge(Self[K, V], Self[K, V]) -> Self[K, V]
 #alias(empty, deprecated)
 #as_free_fn
 pub fn[K, V] SortedMap::new() -> Self[K, V]
+#deprecated
+pub fn[K : Eq, V : Eq] SortedMap::not_equal(Self[K, V], Self[K, V]) -> Bool
+pub fn[K : Compare, V : Compare] SortedMap::op_ge(Self[K, V], Self[K, V]) -> Bool
+pub fn[K : Compare, V : Compare] SortedMap::op_gt(Self[K, V], Self[K, V]) -> Bool
+pub fn[K : Compare, V : Compare] SortedMap::op_le(Self[K, V], Self[K, V]) -> Bool
+pub fn[K : Compare, V : Compare] SortedMap::op_lt(Self[K, V], Self[K, V]) -> Bool
+#deprecated
+pub fn[K : Show, V : Show] SortedMap::output(Self[K, V], &Logger) -> Unit
 pub fn[K : Compare, V] SortedMap::range(Self[K, V], low~ : K, high~ : K) -> Iter2[K, V]
 pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Self[K, V]
 #alias(foldr_with_key)
@@ -69,6 +87,8 @@ pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Show, V : ToJson] SortedMap::to_json(Self[K, V]) -> Json
 #deprecated
 pub fn[K : @debug.Debug, V : @debug.Debug] SortedMap::to_repr(Self[K, V]) -> @debug.Repr
+#deprecated
+pub fn[K : Show, V : Show] SortedMap::to_string(Self[K, V]) -> String
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Iter[V]
 pub impl[K : Compare, V : Compare] Compare for SortedMap[K, V]
 pub impl[K, V] Default for SortedMap[K, V]

--- a/immut/sorted_set/extends.mbt
+++ b/immut/sorted_set/extends.mbt
@@ -1,0 +1,41 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend SortedSet with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend SortedSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend SortedSet with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend SortedSet with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend SortedSet with Hash::{hash, hash_combine}
+
+///|
+pub extend SortedSet with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend SortedSet with Show::{output}
+
+///|
+pub extend SortedSet with Sub::{sub}

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -1056,7 +1056,7 @@ fn[A] SortedSet::concat(
 ///|
 pub impl[A : Hash] Hash for SortedSet[A] with fn hash_combine(self, hasher) {
   for t in self {
-    t.hash_combine(hasher)
+    Hash::hash_combine(t, hasher)
   }
 }
 

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -18,11 +18,17 @@ pub fn[A : Compare] SortedSet::SortedSet(ArrayView[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::add(Self[A], A) -> Self[A]
 pub fn[A] SortedSet::all(Self[A], (A) -> Bool raise?) -> Bool raise?
 pub fn[A] SortedSet::any(Self[A], (A) -> Bool raise?) -> Bool raise?
+#deprecated
+pub fn[X : @quickcheck.Arbitrary + Compare] SortedSet::arbitrary(Int, @splitmix.RandomState) -> Self[X]
+pub fn[A : Compare] SortedSet::compare(Self[A], Self[A]) -> Int
 pub fn[A : Compare] SortedSet::contains(Self[A], A) -> Bool
+pub fn[A] SortedSet::default() -> Self[A]
 #alias(diff, deprecated)
 pub fn[A : Compare] SortedSet::difference(Self[A], Self[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::disjoint(Self[A], Self[A]) -> Bool
 pub fn[A] SortedSet::each(Self[A], (A) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[A : Eq] SortedSet::equal(Self[A], Self[A]) -> Bool
 pub fn[A] SortedSet::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A, B] SortedSet::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 #alias(of, deprecated)
@@ -36,6 +42,10 @@ pub fn[A : Compare] SortedSet::from_array(ArrayView[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::from_iter(Iter[A]) -> Self[A]
 #as_free_fn
 pub fn[A : @json.FromJson + Compare] SortedSet::from_json(Json) -> Self[A] raise @json.JsonDecodeError
+#deprecated
+pub fn[A : Hash] SortedSet::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] SortedSet::hash_combine(Self[A], Hasher) -> Unit
 #alias(inter, deprecated)
 pub fn[A : Compare] SortedSet::intersection(Self[A], Self[A]) -> Self[A]
 pub fn[A] SortedSet::is_empty(Self[A]) -> Bool
@@ -50,6 +60,14 @@ pub fn[A] SortedSet::min(Self[A]) -> A
 pub fn[A] SortedSet::min_option(Self[A]) -> A?
 #as_free_fn
 pub fn[A] SortedSet::new() -> Self[A]
+#deprecated
+pub fn[A : Eq] SortedSet::not_equal(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] SortedSet::op_ge(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] SortedSet::op_gt(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] SortedSet::op_le(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] SortedSet::op_lt(Self[A], Self[A]) -> Bool
+#deprecated
+pub fn[A : Show] SortedSet::output(Self[A], &Logger) -> Unit
 pub fn[A : Compare] SortedSet::range(Self[A], low~ : A, high~ : A) -> Iter[A]
 pub fn[A : Compare] SortedSet::remove(Self[A], A) -> Self[A]
 pub fn[A] SortedSet::remove_min(Self[A]) -> Self[A]
@@ -58,12 +76,15 @@ pub fn[A] SortedSet::rev_iter(Self[A]) -> Iter[A]
 #as_free_fn
 pub fn[A] SortedSet::singleton(A) -> Self[A]
 pub fn[A : Compare] SortedSet::split(Self[A], A) -> (Self[A], Bool, Self[A])
+pub fn[A : Compare] SortedSet::sub(Self[A], Self[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::subset(Self[A], Self[A]) -> Bool
 pub fn[A : Compare] SortedSet::symmetric_difference(Self[A], Self[A]) -> Self[A]
 pub fn[A] SortedSet::to_array(Self[A]) -> Array[A]
 pub fn[A : ToJson] SortedSet::to_json(Self[A]) -> Json
 #deprecated
 pub fn[K : @debug.Debug] SortedSet::to_repr(Self[K]) -> @debug.Repr
+#deprecated
+pub fn[A : Show] SortedSet::to_string(Self[A]) -> String
 pub fn[A : Compare] SortedSet::union(Self[A], Self[A]) -> Self[A]
 pub impl[A : Compare] Add for SortedSet[A]
 pub impl[A : Compare] Compare for SortedSet[A]

--- a/immut/vector/extends.mbt
+++ b/immut/vector/extends.mbt
@@ -1,0 +1,45 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Vector with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Vector with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend Vector with @json.FromJson::{from_json}
+
+///|
+pub extend Vector with Add::{add}
+
+///|
+pub extend Vector with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Vector with Hash::{hash, hash_combine}
+
+///|
+pub extend Vector with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Vector with Show::{output}
+
+///|
+pub extend Vector with ToJson::{to_json}

--- a/immut/vector/pkg.generated.mbti
+++ b/immut/vector/pkg.generated.mbti
@@ -19,8 +19,12 @@ type Vector[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A] Vector::Vector(ArrayView[A]) -> Self[A]
+pub fn[A] Vector::add(Self[A], Self[A]) -> Self[A]
+#deprecated
+pub fn[X : @quickcheck.Arbitrary] Vector::arbitrary(Int, @splitmix.RandomState) -> Self[X]
 #alias("_[_]")
 pub fn[A] Vector::at(Self[A], Int) -> A
+pub fn[A : Compare] Vector::compare(Self[A], Self[A]) -> Int
 pub fn[A] Vector::concat(Self[A], Self[A]) -> Self[A]
 pub fn[A : Eq] Vector::contains(Self[A], A) -> Bool
 #alias(clone, deprecated)
@@ -29,6 +33,8 @@ pub fn[A] Vector::copy(Self[A]) -> Self[A]
 pub fn[A] Vector::drop(Self[A], Int) -> Self[A]
 pub fn[A] Vector::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 pub fn[A] Vector::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[A : Eq] Vector::equal(Self[A], Self[A]) -> Bool
 pub fn[A] Vector::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 #alias(fold_left, deprecated)
 pub fn[A, B] Vector::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
@@ -36,7 +42,13 @@ pub fn[A, B] Vector::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
 pub fn[A] Vector::from_iter(Iter[A]) -> Self[A]
+#deprecated
+pub fn[A : @json.FromJson] Vector::from_json(Json, @json.JsonPath) -> Self[A] raise @json.JsonDecodeError
 pub fn[A] Vector::get(Self[A], Int) -> A?
+#deprecated
+pub fn[A : Hash] Vector::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] Vector::hash_combine(Self[A], Hasher) -> Unit
 pub fn[A] Vector::is_empty(Self[A]) -> Bool
 #alias(iterator, deprecated)
 pub fn[A] Vector::iter(Self[A]) -> Iter[A]
@@ -48,6 +60,14 @@ pub fn[A] Vector::makei(Int, (Int) -> A raise?) -> Self[A] raise?
 pub fn[A, B] Vector::map(Self[A], (A) -> B raise?) -> Self[B] raise?
 #as_free_fn
 pub fn[A] Vector::new() -> Self[A]
+#deprecated
+pub fn[A : Eq] Vector::not_equal(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Vector::op_ge(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Vector::op_gt(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Vector::op_le(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] Vector::op_lt(Self[A], Self[A]) -> Bool
+#deprecated
+pub fn[A : Show] Vector::output(Self[A], &Logger) -> Unit
 pub fn[A] Vector::peek(Self[A]) -> A?
 pub fn[A] Vector::pop(Self[A]) -> Self[A]?
 pub fn[A] Vector::push(Self[A], A) -> Self[A]
@@ -61,8 +81,11 @@ pub fn[A] Vector::slice(Self[A], Int, Int) -> Self[A]
 pub fn[A] Vector::split(Self[A], Int) -> (Self[A], Self[A])
 pub fn[A] Vector::take(Self[A], Int) -> Self[A]
 pub fn[A] Vector::to_array(Self[A]) -> Array[A]
+pub fn[A : ToJson] Vector::to_json(Self[A]) -> Json
 #deprecated
 pub fn[A : @debug.Debug] Vector::to_repr(Self[A]) -> @debug.Repr
+#deprecated
+pub fn[A : Show] Vector::to_string(Self[A]) -> String
 pub impl[A] Add for Vector[A]
 pub impl[A : Compare] Compare for Vector[A]
 pub impl[A : Eq] Eq for Vector[A]

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -705,12 +705,12 @@ test "from_iter empty iter" {
 test "hash" {
   let l1 = @vector.from_array([1, 2, 3, 4, 5])
   let l2 = @vector.from_array([1, 2, 3, 4, 5])
-  inspect(l1.hash() == l2.hash(), content="true")
+  inspect(Hash::hash(l1) == Hash::hash(l2), content="true")
   let l3 = @vector.from_array([5, 4, 3, 2, 1])
-  inspect(l1.hash() == l3.hash(), content="false")
+  inspect(Hash::hash(l1) == Hash::hash(l3), content="false")
   let l4 : @vector.Vector[Int] = @vector.from_array([])
-  inspect(l1.hash() == l4.hash(), content="false")
-  inspect(l4.hash() == l4.hash(), content="true")
+  inspect(Hash::hash(l1) == Hash::hash(l4), content="false")
+  inspect(Hash::hash(l4) == Hash::hash(l4), content="true")
 }
 
 ///|

--- a/int16/extends.mbt
+++ b/int16/extends.mbt
@@ -1,0 +1,67 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Int16 with Eq::{equal, not_equal}
+
+///|
+pub extend Int16 with Add::{add}
+
+///|
+pub extend Int16 with BitAnd::{land}
+
+///|
+pub extend Int16 with BitOr::{lor}
+
+///|
+pub extend Int16 with BitXOr::{lxor}
+
+///|
+pub extend Int16 with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend Int16 with Default::{default}
+
+///|
+pub extend Int16 with Div::{div}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Int16 with Hash::{hash, hash_combine}
+
+///|
+pub extend Int16 with Mod::{mod}
+
+///|
+pub extend Int16 with Mul::{mul}
+
+///|
+pub extend Int16 with Neg::{neg}
+
+///|
+pub extend Int16 with Shl::{shl}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Int16 with Show::{output}
+
+///|
+pub extend Int16 with Shr::{shr}
+
+///|
+pub extend Int16 with Sub::{sub}
+
+///|
+pub extend Int16 with ToJson::{to_json}

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -199,12 +199,12 @@ test "Int16::hash" {
 
 ///|
 test "Int16::equal" {
-  inspect(Int16::equal(1, 2), content="false")
-  inspect(Int16::equal(2, 1), content="false")
-  inspect(Int16::equal(1, 1), content="true")
-  inspect(Int16::equal(-1, 1), content="false")
-  inspect(Int16::equal(1, -1), content="false")
-  inspect(Int16::equal(-1, -1), content="true")
+  inspect((1 : Int16) == 2, content="false")
+  inspect((2 : Int16) == 1, content="false")
+  inspect((1 : Int16) == 1, content="true")
+  inspect((-1 : Int16) == 1, content="false")
+  inspect((1 : Int16) == -1, content="false")
+  inspect((-1 : Int16) == -1, content="true")
 }
 
 ///|

--- a/int16/pkg.generated.mbti
+++ b/int16/pkg.generated.mbti
@@ -16,15 +16,43 @@ pub let min_value : Int16
 
 // Types and methods
 pub fn Int16::abs(Int16) -> Int16
+pub fn Int16::add(Int16, Int16) -> Int16
+pub fn Int16::compare(Int16, Int16) -> Int
+pub fn Int16::default() -> Int16
+pub fn Int16::div(Int16, Int16) -> Int16
+#deprecated
+pub fn Int16::equal(Int16, Int16) -> Bool
 pub fn Int16::from_byte(Byte) -> Int16
 pub fn Int16::from_int(Int) -> Int16
 pub fn Int16::from_int64(Int64) -> Int16
+#deprecated
+pub fn Int16::hash(Int16) -> Int
+#deprecated
+pub fn Int16::hash_combine(Int16, Hasher) -> Unit
+pub fn Int16::land(Int16, Int16) -> Int16
 pub fn Int16::lnot(Int16) -> Int16
+pub fn Int16::lor(Int16, Int16) -> Int16
+pub fn Int16::lxor(Int16, Int16) -> Int16
+pub fn Int16::mod(Int16, Int16) -> Int16
+pub fn Int16::mul(Int16, Int16) -> Int16
+pub fn Int16::neg(Int16) -> Int16
+#deprecated
+pub fn Int16::not_equal(Int16, Int16) -> Bool
+pub fn Int16::op_ge(Int16, Int16) -> Bool
+pub fn Int16::op_gt(Int16, Int16) -> Bool
+pub fn Int16::op_le(Int16, Int16) -> Bool
+pub fn Int16::op_lt(Int16, Int16) -> Bool
+#deprecated
+pub fn Int16::output(Int16, &Logger) -> Unit
 pub fn Int16::reinterpret_as_uint16(Int16) -> UInt16
 pub fn Int16::reinterpret_from_uint16(UInt16) -> Int16
+pub fn Int16::shl(Int16, Int) -> Int16
+pub fn Int16::shr(Int16, Int) -> Int16
+pub fn Int16::sub(Int16, Int16) -> Int16
 pub fn Int16::to_byte(Int16) -> Byte
 pub fn Int16::to_int(Int16) -> Int
 pub fn Int16::to_int64(Int16) -> Int64
+pub fn Int16::to_json(Int16) -> Json
 pub fn Int16::to_string(Int16, radix? : Int) -> String
 pub impl Add for Int16
 pub impl BitAnd for Int16

--- a/internal/regex_engine/automata/extends.mbt
+++ b/internal/regex_engine/automata/extends.mbt
@@ -1,0 +1,48 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Mark with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend MarkSlotMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Slot with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend State with Eq::{equal, not_equal}
+
+///|
+pub extend Mark with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Mark with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend MarkSlotMap with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Slot with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend State with Hash::{hash, hash_combine}

--- a/internal/regex_engine/automata/pkg.generated.mbti
+++ b/internal/regex_engine/automata/pkg.generated.mbti
@@ -41,21 +41,58 @@ pub fn Context::Context() -> Self
 type Expr
 
 pub(all) struct Mark(Int) derive(Compare, Eq, Hash)
+pub fn Mark::compare(Self, Self) -> Int
+#deprecated
+pub fn Mark::equal(Self, Self) -> Bool
+#deprecated
+pub fn Mark::hash(Self) -> Int
+#deprecated
+pub fn Mark::hash_combine(Self, Hasher) -> Unit
+#deprecated
+pub fn Mark::not_equal(Self, Self) -> Bool
+pub fn Mark::op_ge(Self, Self) -> Bool
+pub fn Mark::op_gt(Self, Self) -> Bool
+pub fn Mark::op_le(Self, Self) -> Bool
+pub fn Mark::op_lt(Self, Self) -> Bool
 
 type MarkSlotMap derive(Eq, Hash)
+#deprecated
+pub fn MarkSlotMap::equal(Self, Self) -> Bool
 pub fn MarkSlotMap::get_slot(Self, Mark) -> Slot
+#deprecated
+pub fn MarkSlotMap::hash(Self) -> Int
+#deprecated
+pub fn MarkSlotMap::hash_combine(Self, Hasher) -> Unit
 pub fn MarkSlotMap::iter2(Self) -> Iter2[Mark, Slot]
+#deprecated
+pub fn MarkSlotMap::not_equal(Self, Self) -> Bool
 
 pub struct Slot {
   index : Int
 } derive(Eq, Hash)
+#deprecated
+pub fn Slot::equal(Self, Self) -> Bool
 pub fn Slot::from_index(Int) -> Self
+#deprecated
+pub fn Slot::hash(Self) -> Int
+#deprecated
+pub fn Slot::hash_combine(Self, Hasher) -> Unit
 pub fn Slot::is_assigned(Self) -> Bool
+#deprecated
+pub fn Slot::not_equal(Self, Self) -> Bool
 pub fn Slot::unassigned() -> Self
 
 pub struct State {
   // private fields
 }
+#deprecated
+pub fn State::equal(Self, Self) -> Bool
+#deprecated
+pub fn State::hash(Self) -> Int
+#deprecated
+pub fn State::hash_combine(Self, Hasher) -> Unit
+#deprecated
+pub fn State::not_equal(Self, Self) -> Bool
 pub fn State::slot(Self) -> Slot
 pub fn State::start(@shared_types.Category, Expr) -> Self
 pub fn State::status(Self) -> Status

--- a/internal/regex_engine/automata/state.mbt
+++ b/internal/regex_engine/automata/state.mbt
@@ -87,7 +87,7 @@ fn State::new(
   cat : @shared_types.Category,
   desc : ThreadSet,
 ) -> State {
-  { slot, cat, desc, hash: (slot, cat, desc).hash() }
+  { slot, cat, desc, hash: Hash::hash((slot, cat, desc)) }
 }
 
 ///|

--- a/internal/regex_engine/shared_types/extends.mbt
+++ b/internal/regex_engine/shared_types/extends.mbt
@@ -1,0 +1,40 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Category with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Preference with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Preference with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend QuantifierMode with @debug.Debug::{to_repr}
+
+///|
+pub extend Category with Add::{add}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Category with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend Preference with Hash::{hash, hash_combine}

--- a/internal/regex_engine/shared_types/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/pkg.generated.mbti
@@ -12,13 +12,22 @@ import {
 
 // Types and methods
 pub struct Category(Int) derive(Eq, Hash)
+pub fn Category::add(Self, Self) -> Self
 pub fn Category::dummy() -> Self
+#deprecated
+pub fn Category::equal(Self, Self) -> Bool
+#deprecated
+pub fn Category::hash(Self) -> Int
+#deprecated
+pub fn Category::hash_combine(Self, Hasher) -> Unit
 pub fn Category::inexistant() -> Self
 pub fn Category::inexistant_or_newline() -> Self
 pub fn Category::inexistant_or_non_word_end() -> Self
 pub fn Category::inexistant_or_non_word_start() -> Self
 pub fn Category::intersects(Self, Self) -> Bool
 pub fn Category::newline() -> Self
+#deprecated
+pub fn Category::not_equal(Self, Self) -> Bool
 pub fn Category::not_word() -> Self
 pub fn Category::not_word_end() -> Self
 pub fn Category::not_word_start() -> Self
@@ -30,6 +39,16 @@ pub(all) enum Preference {
   Longest
   First
 } derive(Eq, Hash, @debug.Debug)
+#deprecated
+pub fn Preference::equal(Self, Self) -> Bool
+#deprecated
+pub fn Preference::hash(Self) -> Int
+#deprecated
+pub fn Preference::hash_combine(Self, Hasher) -> Unit
+#deprecated
+pub fn Preference::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn Preference::to_repr(Self) -> @debug.Repr
 
 pub struct Profile {
   lb : Int
@@ -46,6 +65,8 @@ pub(all) enum QuantifierMode {
   Greedy
   NonGreedy
 } derive(@debug.Debug)
+#deprecated
+pub fn QuantifierMode::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 pub type Rechar = Int

--- a/internal/regex_engine/shared_types/rechar_set/extends.mbt
+++ b/internal/regex_engine/shared_types/rechar_set/extends.mbt
@@ -1,0 +1,26 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend RecharSet with @debug.Debug::{to_repr}
+
+///|
+pub extend RecharSet with Add::{add}
+
+///|
+pub extend RecharSet with BitAnd::{land}
+
+///|
+pub extend RecharSet with Sub::{sub}

--- a/internal/regex_engine/shared_types/rechar_set/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/rechar_set/pkg.generated.mbti
@@ -11,6 +11,7 @@ import {
 
 // Types and methods
 type RecharSet
+pub fn RecharSet::add(Self, Self) -> Self
 pub fn RecharSet::char(Int) -> Self
 pub fn RecharSet::char_range(Int, Int) -> Self
 pub fn RecharSet::contains(Self, Int) -> Bool
@@ -22,8 +23,12 @@ pub fn RecharSet::intersection(Self, Self) -> Self
 pub fn RecharSet::intervals(Self) -> Iter[(Int, Int)]
 pub fn RecharSet::is_empty(Self) -> Bool
 pub fn RecharSet::is_subset(Self, Self) -> Bool
+pub fn RecharSet::land(Self, Self) -> Self
 pub fn RecharSet::last_interval(Self) -> (Int, Int)?
 pub fn RecharSet::offset_by(Self, (Int) -> Int) -> Self
+pub fn RecharSet::sub(Self, Self) -> Self
+#deprecated
+pub fn RecharSet::to_repr(Self) -> @debug.Repr
 pub fn RecharSet::union(Self, Self) -> Self
 pub impl Add for RecharSet
 pub impl BitAnd for RecharSet

--- a/json/derive_json_test.mbt
+++ b/json/derive_json_test.mbt
@@ -78,3 +78,21 @@ test {
     ),
   )
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Hello with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Hello with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend Hello with @json.FromJson::{from_json}
+
+///|
+pub extend Hello with ToJson::{to_json}
+
+///|
+pub extend Hello3 with ToJson::{to_json}

--- a/json/extends.mbt
+++ b/json/extends.mbt
@@ -1,0 +1,96 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend JsonDecodeError with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend JsonPath with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend ParseError with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Position with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend JsonDecodeError with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend JsonPath with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend ParseError with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Position with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Replacer with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend Json with FromJson::{from_json}
+
+///|
+pub extend Json with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Json with Show::{output}
+
+///|
+pub extend Json with ToJson::{to_json}
+
+///|
+pub extend JsonDecodeError with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend JsonDecodeError with Show::{output}
+
+///|
+pub extend JsonDecodeError with ToJson::{to_json}
+
+///|
+pub extend JsonPath with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend JsonPath with Show::{output}
+
+///|
+pub extend JsonPath with ToJson::{to_json}
+
+///|
+pub extend ParseError with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend ParseError with Show::{output}
+
+///|
+pub extend ParseError with ToJson::{to_json}
+
+///|
+pub extend Position with ToJson::{to_json}

--- a/json/from_to_json_test.mbt
+++ b/json/from_to_json_test.mbt
@@ -40,3 +40,18 @@ test {
   )
   assert_true(e0 == e)
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Expr with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Expr with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend Expr with @json.FromJson::{from_json}
+
+///|
+pub extend Expr with ToJson::{to_json}

--- a/json/json_encode_decode_test.mbt
+++ b/json/json_encode_decode_test.mbt
@@ -91,3 +91,19 @@ test {
     ),
   )
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend AllThree with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend DecodeError with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend AllThree with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend DecodeError with @debug.Debug::{to_repr}

--- a/json/json_inspect_test.mbt
+++ b/json/json_inspect_test.mbt
@@ -63,3 +63,12 @@ test "json inspect error paths" {
     expect_error(() => @json.json_inspect(1, content=2), "expected mismatch"),
   )
 }
+
+///|
+pub extend Color with ToJson::{to_json}
+
+///|
+pub extend Line with ToJson::{to_json}
+
+///|
+pub extend P with ToJson::{to_json}

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -622,3 +622,6 @@ fn[A : FromJson] test_json_export(x : A) -> A {
 test {
   let _ : Int = test_json_export(42)
 }
+
+///|
+pub extend NestedJsonValue with ToJson::{to_json}

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -21,6 +21,16 @@ pub fn valid(StringView) -> Bool
 pub(all) suberror JsonDecodeError {
   JsonDecodeError((JsonPath, String))
 } derive(Eq, Show, ToJson, @debug.Debug)
+#deprecated
+pub fn JsonDecodeError::equal(Self, Self) -> Bool
+#deprecated
+pub fn JsonDecodeError::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn JsonDecodeError::output(Self, &Logger) -> Unit
+pub fn JsonDecodeError::to_json(Self) -> Json
+#deprecated
+pub fn JsonDecodeError::to_repr(Self) -> @debug.Repr
+pub fn JsonDecodeError::to_string(Self) -> String
 
 pub(all) suberror ParseError {
   InvalidChar(Position, Char)
@@ -29,12 +39,32 @@ pub(all) suberror ParseError {
   InvalidIdentEscape(Position)
   DepthLimitExceeded
 } derive(Eq, ToJson, @debug.Debug)
+#deprecated
+pub fn ParseError::equal(Self, Self) -> Bool
+#deprecated
+pub fn ParseError::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn ParseError::output(Self, &Logger) -> Unit
+pub fn ParseError::to_json(Self) -> Json
+#deprecated
+pub fn ParseError::to_repr(Self) -> @debug.Repr
+pub fn ParseError::to_string(Self) -> String
 pub impl Show for ParseError
 
 // Types and methods
 type JsonPath derive(Eq, @debug.Debug)
 pub fn JsonPath::add_index(Self, Int) -> Self
 pub fn JsonPath::add_key(Self, String) -> Self
+#deprecated
+pub fn JsonPath::equal(Self, Self) -> Bool
+#deprecated
+pub fn JsonPath::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn JsonPath::output(Self, &Logger) -> Unit
+pub fn JsonPath::to_json(Self) -> Json
+#deprecated
+pub fn JsonPath::to_repr(Self) -> @debug.Repr
+pub fn JsonPath::to_string(Self) -> String
 pub impl Show for JsonPath
 pub impl ToJson for JsonPath
 
@@ -42,6 +72,13 @@ pub(all) struct Position {
   line : Int
   column : Int
 } derive(Eq, ToJson, @debug.Debug)
+#deprecated
+pub fn Position::equal(Self, Self) -> Bool
+#deprecated
+pub fn Position::not_equal(Self, Self) -> Bool
+pub fn Position::to_json(Self) -> Json
+#deprecated
+pub fn Position::to_repr(Self) -> @debug.Repr
 
 pub struct Replacer {
   // private fields
@@ -50,6 +87,8 @@ pub struct Replacer {
 pub fn Replacer::Replacer((String, Json) -> Json?) -> Self
 pub fn Replacer::exclude(ArrayView[StringView]) -> Self
 pub fn Replacer::keep(ArrayView[StringView]) -> Self
+#deprecated
+pub fn Replacer::to_repr(Self) -> @debug.Repr
 
 #deprecated
 pub fn Json::as_array(Self) -> Array[Self]?
@@ -64,8 +103,15 @@ pub fn Json::as_object(Self) -> Map[String, Self]?
 #deprecated
 pub fn Json::as_string(Self) -> String?
 #deprecated
+pub fn Json::from_json(Self, JsonPath) -> Self raise JsonDecodeError
+#deprecated
 pub fn Json::item(Self, Int) -> Self?
+#deprecated
+pub fn Json::output(Self, &Logger) -> Unit
 pub fn Json::stringify(Self, escape_slash? : Bool, indent? : Int, replacer? : Replacer) -> String
+pub fn Json::to_json(Self) -> Self
+#deprecated
+pub fn Json::to_string(Self) -> String
 pub fn Json::transform(Self, Replacer) -> Self
 #deprecated
 pub fn Json::value(Self, String) -> Self?

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -478,3 +478,18 @@ test "Tuple::to_json" {
     ),
   )
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Opt with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Opt with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend Opt with @json.FromJson::{from_json}
+
+///|
+pub extend Opt with ToJson::{to_json}

--- a/lazy/extends.mbt
+++ b/lazy/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Lazy with @debug.Debug::{to_repr}

--- a/lazy/pkg.generated.mbti
+++ b/lazy/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub fn[A] Lazy::Lazy(() -> A) -> Self[A]
 pub fn[A] Lazy::force(Self[A]) -> A
 pub fn[A] Lazy::peek(Self[A]) -> A?
 pub fn[A] Lazy::ready(A) -> Self[A]
+#deprecated
+pub fn[A : @debug.Debug] Lazy::to_repr(Self[A]) -> @debug.Repr
 pub impl[A : @debug.Debug] @debug.Debug for Lazy[A]
 
 // Type aliases

--- a/lazy_list/extends.mbt
+++ b/lazy_list/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend LazyList with @debug.Debug::{to_repr}

--- a/lazy_list/pkg.generated.mbti
+++ b/lazy_list/pkg.generated.mbti
@@ -32,6 +32,8 @@ pub fn[A] LazyList::tail(Self[A]) -> Self[A]?
 pub fn[A] LazyList::take(Self[A], Int) -> Self[A]
 pub fn[A] LazyList::take_while(Self[A], (A) -> Bool) -> Self[A]
 pub fn[A] LazyList::to_array(Self[A]) -> Array[A]
+#deprecated
+pub fn[A : @debug.Debug] LazyList::to_repr(Self[A]) -> @debug.Repr
 pub fn[A, B] LazyList::zip(Self[A], Self[B]) -> Self[(A, B)]
 pub impl[A : @debug.Debug] @debug.Debug for LazyList[A]
 

--- a/list/extends.mbt
+++ b/list/extends.mbt
@@ -1,0 +1,38 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend List with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend List with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend List with Compare::{compare, op_ge, op_gt, op_le, op_lt}
+
+///|
+pub extend List with Default::{default}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+pub extend List with Hash::{hash, hash_combine}
+
+///|
+pub extend List with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend List with Show::{output}

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -813,12 +813,12 @@ test "from_iter empty iter" {
 test "hash" {
   let l1 = @list.List([1, 2, 3, 4, 5])
   let l2 = @list.List([1, 2, 3, 4, 5])
-  debug_inspect(l1.hash() == l2.hash(), content="true")
+  debug_inspect(Hash::hash(l1) == Hash::hash(l2), content="true")
   let l3 = @list.List([5, 4, 3, 2, 1])
-  debug_inspect(l1.hash() == l3.hash(), content="false")
+  debug_inspect(Hash::hash(l1) == Hash::hash(l3), content="false")
   let l4 : @list.List[Int] = List([])
-  debug_inspect(l1.hash() == l4.hash(), content="false")
-  debug_inspect(l4.hash() == l4.hash(), content="true")
+  debug_inspect(Hash::hash(l1) == Hash::hash(l4), content="false")
+  debug_inspect(Hash::hash(l4) == Hash::hash(l4), content="true")
 }
 
 ///|

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -21,15 +21,21 @@ pub enum List[A] {
 pub fn[A] List::List(ArrayView[A]) -> Self[A]
 pub fn[A] List::all(Self[A], (A) -> Bool raise?) -> Bool raise?
 pub fn[A] List::any(Self[A], (A) -> Bool raise?) -> Bool raise?
+#deprecated
+pub fn[X : @quickcheck.Arbitrary] List::arbitrary(Int, @splitmix.RandomState) -> Self[X]
+pub fn[A : Compare] List::compare(Self[A], Self[A]) -> Int
 pub fn[A] List::concat(Self[A], Self[A]) -> Self[A]
 #as_free_fn(construct, deprecated)
 #as_free_fn
 pub fn[A] List::cons(A, Self[A]) -> Self[A]
 pub fn[A : Eq] List::contains(Self[A], A) -> Bool
+pub fn[X] List::default() -> Self[X]
 pub fn[A] List::drop(Self[A], Int) -> Self[A]
 pub fn[A] List::drop_while(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A] List::each(Self[A], (A) -> Unit raise?) -> Unit raise?
 pub fn[A] List::eachi(Self[A], (Int, A) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[A : Eq] List::equal(Self[A], Self[A]) -> Bool
 pub fn[A] List::filter(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A, B] List::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 pub fn[A] List::find(Self[A], (A) -> Bool raise?) -> A? raise?
@@ -54,6 +60,10 @@ pub fn[A] List::from_iter(Iter[A]) -> Self[A]
 pub fn[A] List::from_iter_rev(Iter[A]) -> Self[A]
 #as_free_fn
 pub fn[A : @json.FromJson] List::from_json(Json) -> Self[A] raise @json.JsonDecodeError
+#deprecated
+pub fn[A : Hash] List::hash(Self[A]) -> Int
+#deprecated
+pub fn[A : Hash] List::hash_combine(Self[A], Hasher) -> Unit
 pub fn[A] List::head(Self[A]) -> A?
 pub fn[A] List::intercalate(Self[Self[A]], Self[A]) -> Self[A]
 pub fn[A] List::intersperse(Self[A], A) -> Self[A]
@@ -75,7 +85,15 @@ pub fn[A : Compare] List::minimum(Self[A]) -> A?
 #as_free_fn(empty)
 #as_free_fn
 pub fn[A] List::new() -> Self[A]
+#deprecated
+pub fn[A : Eq] List::not_equal(Self[A], Self[A]) -> Bool
 pub fn[A] List::nth(Self[A], Int) -> A?
+pub fn[A : Compare] List::op_ge(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] List::op_gt(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] List::op_le(Self[A], Self[A]) -> Bool
+pub fn[A : Compare] List::op_lt(Self[A], Self[A]) -> Bool
+#deprecated
+pub fn[A : Show] List::output(Self[A], &Logger) -> Unit
 #alias(add)
 pub fn[A] List::prepend(Self[A], A) -> Self[A]
 pub fn[A : Eq] List::remove(Self[A], A) -> Self[A]
@@ -104,6 +122,8 @@ pub fn[A] List::to_array(Self[A]) -> Array[A]
 pub fn[A : ToJson] List::to_json(Self[A]) -> Json
 #deprecated
 pub fn[A : @debug.Debug] List::to_repr(Self[A]) -> @debug.Repr
+#deprecated
+pub fn[A : Show] List::to_string(Self[A]) -> String
 #as_free_fn
 pub fn[A, S] List::unfold((S) -> (A, S)? raise?, init~ : S) -> Self[A] raise?
 pub fn[A] List::unsafe_tail(Self[A]) -> Self[A]

--- a/moon.mod
+++ b/moon.mod
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 keywords = [ "core", "standard library" ]
 
-warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op+unnecessary_annotation+prefer_fixed_array+prefer_readonly_array"
+warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op+unnecessary_annotation+prefer_fixed_array+prefer_readonly_array+implicit_impl_as_method"

--- a/priority_queue/extends.mbt
+++ b/priority_queue/extends.mbt
@@ -1,0 +1,30 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend PriorityQueue with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend PriorityQueue with Default::{default}
+
+///|
+pub extend PriorityQueue with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend PriorityQueue with Show::{output}
+
+///|
+pub extend PriorityQueue with ToJson::{to_json}

--- a/priority_queue/pkg.generated.mbti
+++ b/priority_queue/pkg.generated.mbti
@@ -18,9 +18,12 @@ type PriorityQueue[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A : Compare] PriorityQueue::PriorityQueue(ArrayView[A]) -> Self[A]
+#deprecated
+pub fn[X : @quickcheck.Arbitrary + Compare] PriorityQueue::arbitrary(Int, @splitmix.RandomState) -> Self[X]
 pub fn[A] PriorityQueue::clear(Self[A]) -> Unit
 #alias(clone, deprecated)
 pub fn[A] PriorityQueue::copy(Self[A]) -> Self[A]
+pub fn[K] PriorityQueue::default() -> Self[K]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
@@ -32,12 +35,17 @@ pub fn[A] PriorityQueue::length(Self[A]) -> Int
 #as_free_fn(deprecated)
 #deprecated
 pub fn[A] PriorityQueue::new() -> Self[A]
+#deprecated
+pub fn[A : Show + Compare] PriorityQueue::output(Self[A], &Logger) -> Unit
 pub fn[A] PriorityQueue::peek(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::pop(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::push(Self[A], A) -> Unit
 pub fn[A : Compare] PriorityQueue::to_array(Self[A]) -> Array[A]
+pub fn[A : ToJson + Compare] PriorityQueue::to_json(Self[A]) -> Json
 #deprecated
 pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(Self[A]) -> @debug.Repr
+#deprecated
+pub fn[A : Show + Compare] PriorityQueue::to_string(Self[A]) -> String
 pub impl[K] Default for PriorityQueue[K]
 #deprecated
 pub impl[A : Show + Compare] Show for PriorityQueue[A]

--- a/queue/extends.mbt
+++ b/queue/extends.mbt
@@ -1,0 +1,24 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Queue with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend Queue with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Queue with Show::{output}

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -18,6 +18,8 @@ type Queue[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A] Queue::Queue(ArrayView[A]) -> Self[A]
+#deprecated
+pub fn[X : @quickcheck.Arbitrary] Queue::arbitrary(Int, @splitmix.RandomState) -> Self[X]
 pub fn[A] Queue::clear(Self[A]) -> Unit
 #alias(clone, deprecated)
 pub fn[A] Queue::copy(Self[A]) -> Self[A]
@@ -35,11 +37,15 @@ pub fn[A] Queue::length(Self[A]) -> Int
 #as_free_fn(deprecated)
 #deprecated
 pub fn[A] Queue::new() -> Self[A]
+#deprecated
+pub fn[A : Show] Queue::output(Self[A], &Logger) -> Unit
 pub fn[A] Queue::peek(Self[A]) -> A?
 pub fn[A] Queue::pop(Self[A]) -> A?
 pub fn[A] Queue::push(Self[A], A) -> Unit
 #deprecated
 pub fn[A : @debug.Debug] Queue::to_repr(Self[A]) -> @debug.Repr
+#deprecated
+pub fn[A : Show] Queue::to_string(Self[A]) -> String
 pub fn[A] Queue::transfer(Self[A], Self[A]) -> Unit
 #deprecated
 pub impl[A : Show] Show for Queue[A]

--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -84,6 +84,10 @@ struct Point {
 } derive(Debug)
 
 ///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Point with Debug::{to_repr}
+
+///|
 impl Arbitrary for Point with fn arbitrary(size, r0) {
   let r1 = r0.split()
   let y = @quickcheck.Arbitrary::arbitrary(size, r1)

--- a/quickcheck/arbitrary_test.mbt
+++ b/quickcheck/arbitrary_test.mbt
@@ -143,3 +143,11 @@ test "arbitrary size branches" {
   let rs4 = @splitmix.RandomState::default()
   let _ : FixedArray[Int] = @quickcheck.Arbitrary::arbitrary(3, rs4)
 }
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend H with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend H with Debug::{to_repr}

--- a/quickcheck/splitmix/extends.mbt
+++ b/quickcheck/splitmix/extends.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend RandomState with @debug.Debug::{to_repr}
+
+///|
+pub extend RandomState with Default::{default}
+
+///|
+pub extend RandomState with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend RandomState with Show::{output}

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -13,6 +13,7 @@ pub fn new(seed? : UInt64) -> RandomState
 // Types and methods
 type RandomState derive(Show, @debug.Debug)
 pub fn RandomState::clone(Self) -> Self
+pub fn RandomState::default() -> Self
 #deprecated
 pub fn RandomState::new(seed? : UInt64) -> Self
 pub fn RandomState::next(Self) -> Unit
@@ -24,7 +25,12 @@ pub fn RandomState::next_positive_int(Self) -> Int
 pub fn RandomState::next_two_uint(Self) -> (UInt, UInt)
 pub fn RandomState::next_uint(Self) -> UInt
 pub fn RandomState::next_uint64(Self) -> UInt64
+#deprecated
+pub fn RandomState::output(Self, &Logger) -> Unit
 pub fn RandomState::split(Self) -> Self
+#deprecated
+pub fn RandomState::to_repr(Self) -> @debug.Repr
+pub fn RandomState::to_string(Self) -> String
 pub impl Default for RandomState
 
 // Type aliases

--- a/random/extends.mbt
+++ b/random/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Rand with @debug.Debug::{to_repr}

--- a/random/pkg.generated.mbti
+++ b/random/pkg.generated.mbti
@@ -26,6 +26,8 @@ pub fn Rand::int(Self, limit? : Int) -> Int
 pub fn Rand::int64(Self, limit? : Int64) -> Int64
 pub fn Rand::new(generator? : &Source) -> Self
 pub fn Rand::shuffle(Self, Int, (Int, Int) -> Unit) -> Unit
+#deprecated
+pub fn Rand::to_repr(Self) -> @debug.Repr
 pub fn Rand::uint(Self, limit? : UInt) -> UInt
 pub fn Rand::uint64(Self, limit? : UInt64) -> UInt64
 pub impl @debug.Debug for Rand

--- a/ref/extends.mbt
+++ b/ref/extends.mbt
@@ -1,0 +1,24 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Ref with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend Ref with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Ref with Show::{output}

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -18,12 +18,18 @@ pub(all) struct Ref[T] {
 }
 #alias(new, deprecated)
 pub fn[T] Ref::Ref(T) -> Self[T]
+#deprecated
+pub fn[X : @quickcheck.Arbitrary] Ref::arbitrary(Int, @splitmix.RandomState) -> Self[X]
 pub fn[T, R] Ref::map(Self[T], (T) -> R raise?) -> Self[R] raise?
+#deprecated
+pub fn[X : Show] Ref::output(Self[X], &Logger) -> Unit
 pub fn[T, R] Ref::protect(Self[T], T, () -> R raise?) -> R raise?
 #as_free_fn
 pub fn[T] Ref::swap(Self[T], Self[T]) -> Unit
 #deprecated
 pub fn[T : @debug.Debug] Ref::to_repr(Self[T]) -> @debug.Repr
+#deprecated
+pub fn[X : Show] Ref::to_string(Self[X]) -> String
 pub fn[T] Ref::update(Self[T], (T) -> T raise?) -> Unit raise?
 #deprecated
 pub impl[X : Show] Show for Ref[X]

--- a/set/extends.mbt
+++ b/set/extends.mbt
@@ -1,0 +1,46 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Set with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Set with @debug.Debug::{to_repr}
+
+///|
+pub extend Set with BitAnd::{land}
+
+///|
+pub extend Set with BitOr::{lor}
+
+///|
+pub extend Set with BitXOr::{lxor}
+
+///|
+pub extend Set with Default::{default}
+
+///|
+pub extend Set with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Set with Show::{output}
+
+///|
+pub extend Set with Sub::{sub}
+
+///|
+pub extend Set with ToJson::{to_json}

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -576,3 +576,7 @@ test "bitwise_operations" {
   inspect(sym_diff.contains("a"), content="true")
   inspect(sym_diff.contains("d"), content="true")
 }
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend Key with Eq::{equal, not_equal}

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -24,9 +24,12 @@ pub fn[K] Set::clear(Self[K]) -> Unit
 pub fn[K : Hash + Eq] Set::contains(Self[K], K) -> Bool
 #alias(clone, deprecated)
 pub fn[K] Set::copy(Self[K]) -> Self[K]
+pub fn[K] Set::default() -> Self[K]
 pub fn[K : Hash + Eq] Set::difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] Set::each(Self[K], (K) -> Unit raise?) -> Unit raise?
 pub fn[K] Set::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[K : Hash + Eq] Set::equal(Self[K], Self[K]) -> Bool
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
@@ -38,15 +41,28 @@ pub fn[K : Hash + Eq] Set::is_subset(Self[K], Self[K]) -> Bool
 pub fn[K : Hash + Eq] Set::is_superset(Self[K], Self[K]) -> Bool
 #alias(iterator, deprecated)
 pub fn[K] Set::iter(Self[K]) -> Iter[K]
+pub fn[K : Hash + Eq] Set::land(Self[K], Self[K]) -> Self[K]
 #alias(size, deprecated)
 pub fn[K] Set::length(Self[K]) -> Int
+pub fn[K : Hash + Eq] Set::lor(Self[K], Self[K]) -> Self[K]
+pub fn[K : Hash + Eq] Set::lxor(Self[K], Self[K]) -> Self[K]
 #as_free_fn(deprecated)
 #deprecated
 pub fn[K] Set::new(capacity? : Int) -> Self[K]
+#deprecated
+pub fn[K : Hash + Eq] Set::not_equal(Self[K], Self[K]) -> Bool
+#deprecated
+pub fn[K : Show] Set::output(Self[K], &Logger) -> Unit
 pub fn[K : Hash + Eq] Set::remove(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] Set::remove_and_check(Self[K], K) -> Bool
+pub fn[K : Hash + Eq] Set::sub(Self[K], Self[K]) -> Self[K]
 pub fn[K : Hash + Eq] Set::symmetric_difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] Set::to_array(Self[K]) -> Array[K]
+pub fn[X : ToJson] Set::to_json(Self[X]) -> Json
+#deprecated
+pub fn[K : @debug.Debug] Set::to_repr(Self[K]) -> @debug.Repr
+#deprecated
+pub fn[K : Show] Set::to_string(Self[K]) -> String
 pub fn[K : Hash + Eq] Set::union(Self[K], Self[K]) -> Self[K]
 pub impl[K : Hash + Eq] BitAnd for Set[K]
 pub impl[K : Hash + Eq] BitOr for Set[K]

--- a/sorted_map/extends.mbt
+++ b/sorted_map/extends.mbt
@@ -1,0 +1,42 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend SortedMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend SortedMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend SortedMap with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+pub extend SortedMap with @json.FromJson::{from_json}
+
+///|
+pub extend SortedMap with Default::{default}
+
+///|
+pub extend SortedMap with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend SortedMap with Show::{output}
+
+///|
+pub extend SortedMap with ToJson::{to_json}

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -19,18 +19,25 @@ type SortedMap[K, V]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[K : Compare, V] SortedMap::SortedMap(ArrayView[(K, V)]) -> Self[K, V]
+#deprecated
+pub fn[K : @quickcheck.Arbitrary + Compare, V : @quickcheck.Arbitrary] SortedMap::arbitrary(Int, @splitmix.RandomState) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Compare, V] SortedMap::at(Self[K, V], K) -> V
 pub fn[K, V] SortedMap::clear(Self[K, V]) -> Unit
 pub fn[K : Compare, V] SortedMap::contains(Self[K, V], K) -> Bool
 #alias(clone, deprecated)
 pub fn[K, V] SortedMap::copy(Self[K, V]) -> Self[K, V]
+pub fn[K, V] SortedMap::default() -> Self[K, V]
 pub fn[K, V] SortedMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[K : Eq, V : Eq] SortedMap::equal(Self[K, V], Self[K, V]) -> Bool
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
 pub fn[K : Compare, V] SortedMap::from_iter(Iter[(K, V)]) -> Self[K, V]
+#deprecated
+pub fn[V : @json.FromJson] SortedMap::from_json(Json, @json.JsonPath) -> Self[String, V] raise @json.JsonDecodeError
 pub fn[K : Compare, V] SortedMap::get(Self[K, V], K) -> V?
 pub fn[K : Compare, V] SortedMap::get_or_default(Self[K, V], K, V) -> V
 pub fn[K : Compare, V] SortedMap::get_or_init(Self[K, V], K, () -> V) -> V
@@ -48,12 +55,21 @@ pub fn[K : Compare, V] SortedMap::merge_in_place(Self[K, V], Self[K, V]) -> Unit
 #as_free_fn(deprecated)
 #deprecated
 pub fn[K, V] SortedMap::new() -> Self[K, V]
+#deprecated
+pub fn[K : Eq, V : Eq] SortedMap::not_equal(Self[K, V], Self[K, V]) -> Bool
+#deprecated
+pub fn[K : Show, V : Show] SortedMap::output(Self[K, V], &Logger) -> Unit
 pub fn[K : Compare, V] SortedMap::range(Self[K, V], K, K) -> Iter2[K, V]
 pub fn[K : Compare, V] SortedMap::remove(Self[K, V], K) -> Unit
 #alias("_[_]=_")
 #alias(add, deprecated)
 pub fn[K : Compare, V] SortedMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
+pub fn[K : Show, V : ToJson] SortedMap::to_json(Self[K, V]) -> Json
+#deprecated
+pub fn[K : @debug.Debug, V : @debug.Debug] SortedMap::to_repr(Self[K, V]) -> @debug.Repr
+#deprecated
+pub fn[K : Show, V : Show] SortedMap::to_string(Self[K, V]) -> String
 pub fn[K : Compare, V] SortedMap::update_or_default(Self[K, V], K, V, (V) -> V) -> Unit
 #alias(values_as_iter, deprecated)
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Iter[V]

--- a/sorted_set/extends.mbt
+++ b/sorted_set/extends.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend SortedSet with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend SortedSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend SortedSet with @debug.Debug::{to_repr}
+
+///|
+pub extend SortedSet with Default::{default}
+
+///|
+pub extend SortedSet with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend SortedSet with Show::{output}

--- a/sorted_set/pkg.generated.mbti
+++ b/sorted_set/pkg.generated.mbti
@@ -19,15 +19,20 @@ type SortedSet[V]
 #as_free_fn(from_array)
 pub fn[V : Compare] SortedSet::SortedSet(ArrayView[V]) -> Self[V]
 pub fn[V : Compare] SortedSet::add(Self[V], V) -> Unit
+#deprecated
+pub fn[X : @quickcheck.Arbitrary + Compare] SortedSet::arbitrary(Int, @splitmix.RandomState) -> Self[X]
 pub fn[V : Compare] SortedSet::contains(Self[V], V) -> Bool
 #alias(clone, deprecated)
 #alias(deep_clone, deprecated)
 pub fn[V] SortedSet::copy(Self[V]) -> Self[V]
+pub fn[K] SortedSet::default() -> Self[K]
 #alias(diff, deprecated)
 pub fn[V : Compare] SortedSet::difference(Self[V], Self[V]) -> Self[V]
 pub fn[V : Compare] SortedSet::disjoint(Self[V], Self[V]) -> Bool
 pub fn[V] SortedSet::each(Self[V], (V) -> Unit raise?) -> Unit raise?
 pub fn[V] SortedSet::eachi(Self[V], (Int, V) -> Unit raise?) -> Unit raise?
+#deprecated
+pub fn[V : Eq] SortedSet::equal(Self[V], Self[V]) -> Bool
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn
@@ -42,6 +47,10 @@ pub fn[V] SortedSet::length(Self[V]) -> Int
 #as_free_fn(deprecated)
 #deprecated
 pub fn[V] SortedSet::new() -> Self[V]
+#deprecated
+pub fn[V : Eq] SortedSet::not_equal(Self[V], Self[V]) -> Bool
+#deprecated
+pub fn[V : Show] SortedSet::output(Self[V], &Logger) -> Unit
 pub fn[V : Compare] SortedSet::range(Self[V], V, V) -> Iter[V]
 pub fn[V : Compare] SortedSet::remove(Self[V], V) -> Unit
 #as_free_fn
@@ -49,6 +58,10 @@ pub fn[V] SortedSet::singleton(V) -> Self[V]
 pub fn[V : Compare] SortedSet::subset(Self[V], Self[V]) -> Bool
 pub fn[V : Compare] SortedSet::symmetric_difference(Self[V], Self[V]) -> Self[V]
 pub fn[V] SortedSet::to_array(Self[V]) -> Array[V]
+#deprecated
+pub fn[V : @debug.Debug] SortedSet::to_repr(Self[V]) -> @debug.Repr
+#deprecated
+pub fn[V : Show] SortedSet::to_string(Self[V]) -> String
 pub fn[V : Compare] SortedSet::union(Self[V], Self[V]) -> Self[V]
 pub impl[K] Default for SortedSet[K]
 pub impl[V : Eq] Eq for SortedSet[V]

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -584,7 +584,8 @@ pub impl Show for Decimal with fn output(self, logger) {
 }
 
 ///|
-fn Decimal::to_string(self : Decimal) -> String {
+/// Returns the decimal string representation of this value.
+pub fn Decimal::to_string(self : Decimal) -> String {
   Show::to_string(self)
 }
 

--- a/strconv/extends.mbt
+++ b/strconv/extends.mbt
@@ -1,0 +1,32 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Decimal with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend StrConvError with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend Decimal with Show::{output}
+
+///|
+pub extend StrConvError with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend StrConvError with Show::{output}

--- a/strconv/pkg.generated.mbti
+++ b/strconv/pkg.generated.mbti
@@ -35,6 +35,11 @@ pub fn parse_uint64(StringView, base? : Int) -> UInt64 raise StrConvError
 pub(all) suberror StrConvError {
   StrConvError(String)
 } derive(@debug.Debug)
+#deprecated
+pub fn StrConvError::output(Self, &Logger) -> Unit
+#deprecated
+pub fn StrConvError::to_repr(Self) -> @debug.Repr
+pub fn StrConvError::to_string(Self) -> String
 pub impl Show for StrConvError
 
 // Types and methods
@@ -45,11 +50,16 @@ pub fn Decimal::from_int64(Int64) -> Self
 #deprecated
 pub fn Decimal::new() -> Self
 #deprecated
+pub fn Decimal::output(Self, &Logger) -> Unit
+#deprecated
 pub fn Decimal::parse_decimal(StringView) -> Self raise StrConvError
 #deprecated
 pub fn Decimal::shift(Self, Int) -> Unit
 #deprecated
 pub fn Decimal::to_double(Self) -> Double raise StrConvError
+#deprecated
+pub fn Decimal::to_repr(Self) -> @debug.Repr
+pub fn Decimal::to_string(Self) -> String
 pub impl Show for Decimal
 
 // Type aliases

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -71,7 +71,7 @@ test "View::default and hash" {
   inspect(v, content="")
   let v1 = "abc".view()
   let v2 = "abc".view()
-  @test.assert_eq(v1.hash(), v2.hash())
+  @test.assert_eq(Hash::hash(v1), Hash::hash(v2))
 }
 
 ///|

--- a/string/extends.mbt
+++ b/string/extends.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend MatchResult with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Regex with @debug.Debug::{to_repr}
+
+///|
+pub extend Regex with Add::{add}
+
+///|
+pub extend Regex with BitOr::{lor}

--- a/string/internal/regex_engine/ast/extends.mbt
+++ b/string/internal/regex_engine/ast/extends.mbt
@@ -1,0 +1,29 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Assertion with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Pattern with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend PatternDesc with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Quantifier with @debug.Debug::{to_repr}

--- a/string/internal/regex_engine/ast/pkg.generated.mbti
+++ b/string/internal/regex_engine/ast/pkg.generated.mbti
@@ -58,12 +58,16 @@ pub enum Assertion {
   EndOfWord
   NotWordBoundary
 } derive(@debug.Debug)
+#deprecated
+pub fn Assertion::to_repr(Self) -> @debug.Repr
 
 pub struct Pattern {
   desc : PatternDesc
   nullable : Bool
 }
 pub fn Pattern::is_anchored(Self) -> Bool
+#deprecated
+pub fn Pattern::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for Pattern
 
 pub enum PatternDesc {
@@ -75,12 +79,16 @@ pub enum PatternDesc {
   Capture(name~ : String?, Pattern)
   Assertion(Assertion)
 } derive(@debug.Debug)
+#deprecated
+pub fn PatternDesc::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Quantifier {
   min : Int
   max : Int?
   mode : @shared_types.QuantifierMode
 } derive(@debug.Debug)
+#deprecated
+pub fn Quantifier::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/string/internal/regex_engine/extends.mbt
+++ b/string/internal/regex_engine/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend MatchResult with @debug.Debug::{to_repr}

--- a/string/internal/regex_engine/pkg.generated.mbti
+++ b/string/internal/regex_engine/pkg.generated.mbti
@@ -54,6 +54,8 @@ pub let start_of_word : @ast.Pattern
 // Types and methods
 type MatchResult derive(@debug.Debug)
 pub fn MatchResult::group(Self, Int) -> (Int, Int)?
+#deprecated
+pub fn MatchResult::to_repr(Self) -> @debug.Repr
 
 type Regex
 pub fn Regex::execute(Self, StringView, Int) -> MatchResult?

--- a/string/internal/regex_parser/extends.mbt
+++ b/string/internal/regex_parser/extends.mbt
@@ -1,0 +1,24 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend ParserError with @debug.Debug::{to_repr}
+
+///|
+pub extend ParserError with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend ParserError with Show::{output}

--- a/string/internal/regex_parser/pkg.generated.mbti
+++ b/string/internal/regex_parser/pkg.generated.mbti
@@ -12,6 +12,11 @@ pub fn parse(profile~ : @shared_types.Profile, mode~ : Mode, StringView) -> @ast
 
 // Errors
 type ParserError derive(@debug.Debug)
+#deprecated
+pub fn ParserError::output(Self, &Logger) -> Unit
+#deprecated
+pub fn ParserError::to_repr(Self) -> @debug.Repr
+pub fn ParserError::to_string(Self) -> String
 pub impl Show for ParserError
 
 // Types and methods

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -31,19 +31,25 @@ pub fn MatchResult::before(Self) -> StringView
 pub fn MatchResult::content(Self) -> StringView
 pub fn MatchResult::group(Self, Int) -> StringView?
 pub fn MatchResult::named_group(Self, String) -> StringView?
+#deprecated
+pub fn MatchResult::to_repr(Self) -> @debug.Repr
 
 pub struct Regex {
   // private fields
 }
 #alias(new, deprecated)
 pub fn Regex::Regex(StringView) -> Self raise
+pub fn Regex::add(Self, Self) -> Self
 pub fn Regex::capture(Self, String) -> Self
 pub fn Regex::execute(Self, StringView, last_index? : Int) -> MatchResult?
 pub fn Regex::find(Self, StringView) -> Iter[MatchResult]
+pub fn Regex::lor(Self, Self) -> Self
 pub fn Regex::repeat(Self, min? : Int, max? : Int, greedy? : Bool) -> Self
 pub fn Regex::replace_by(Self, StringView, (MatchResult) -> StringView, limit? : Int) -> StringView
 pub fn Regex::split(Self, StringView) -> Iter[StringView]
 pub fn Regex::string(StringView) -> Self
+#deprecated
+pub fn Regex::to_repr(Self) -> @debug.Repr
 pub fn Regex::unsafe_from_string(StringView) -> Self
 pub impl Add for Regex
 pub impl BitOr for Regex

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -1025,3 +1025,7 @@ test "guard const" {
 test "string default" {
   inspect(String::default(), content="")
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend StringPatternToken with @debug.Debug::{to_repr}

--- a/string/string_unicode_test.mbt
+++ b/string/string_unicode_test.mbt
@@ -37,3 +37,7 @@ test {
   // FIXME:The output is not ideal, we would prefer
   // to see the Unicode code points, e.g.
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Data with @debug.Debug::{to_repr}

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -661,8 +661,8 @@ test "hash" {
   let a = "abc"
   let b = "def"
   let c = "abc"
-  @test.assert_eq(a.hash(), c.hash())
-  @test.assert_not_eq(a.hash(), b.hash())
+  @test.assert_eq(Hash::hash(a), Hash::hash(c))
+  @test.assert_not_eq(Hash::hash(a), Hash::hash(b))
 }
 
 ///|
@@ -674,7 +674,7 @@ test "string view hash invariant" {
   let strings : Array[String] = @quickcheck.samples(20)
   for s in strings {
     let view = s[:]
-    @test.assert_eq(s.hash(), view.hash())
+    @test.assert_eq(Hash::hash(s), Hash::hash(view))
   }
 }
 

--- a/test/README.mbt.md
+++ b/test/README.mbt.md
@@ -27,6 +27,14 @@ Use `@test.assert_eq` and `@test.assert_not_eq` to compare values in tests:
 struct User(Int) derive(Eq, @debug.Debug)
 
 ///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend User with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend User with @debug.Debug::{to_repr}
+
+///|
 test "equality assertions" {
   @test.assert_eq(User(1), User(1))
   @test.assert_not_eq(User(1), User(2))

--- a/test/extends.mbt
+++ b/test/extends.mbt
@@ -1,0 +1,17 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend Test with @debug.Debug::{to_repr}

--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -47,6 +47,8 @@ pub fn Test::Test(String) -> Self
 pub fn Test::name(Self) -> String
 #callsite(autofill(args_loc, loc))
 pub fn Test::snapshot(Self, filename~ : String, loc~ : SourceLoc, args_loc~ : ArgsLoc) -> Unit raise SnapshotError
+#deprecated
+pub fn Test::to_repr(Self) -> @debug.Repr
 pub fn Test::write(Self, &Show) -> Unit
 pub fn Test::writeln(Self, &Show) -> Unit
 

--- a/test/test_test.mbt
+++ b/test/test_test.mbt
@@ -104,3 +104,7 @@ test "expect_error result composes with assert_true(... is ...)" {
 test "panic expect_error fails when the callback does not raise" {
   let _ = @test.expect_error(() => maybe_raise(false))
 }
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend MyError with @debug.Debug::{to_repr}

--- a/tuple/extends.mbt
+++ b/tuple/extends.mbt
@@ -1,0 +1,82 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Tuple2 with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Tuple3 with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Tuple4 with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Tuple5 with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Tuple6 with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+pub extend Tuple7 with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend Tuple10 with Default::{default}
+
+///|
+pub extend Tuple11 with Default::{default}
+
+///|
+pub extend Tuple12 with Default::{default}
+
+///|
+pub extend Tuple13 with Default::{default}
+
+///|
+pub extend Tuple14 with Default::{default}
+
+///|
+pub extend Tuple15 with Default::{default}
+
+///|
+pub extend Tuple16 with Default::{default}
+
+///|
+pub extend Tuple2 with Default::{default}
+
+///|
+pub extend Tuple3 with Default::{default}
+
+///|
+pub extend Tuple4 with Default::{default}
+
+///|
+pub extend Tuple5 with Default::{default}
+
+///|
+pub extend Tuple6 with Default::{default}
+
+///|
+pub extend Tuple7 with Default::{default}
+
+///|
+pub extend Tuple8 with Default::{default}
+
+///|
+pub extend Tuple9 with Default::{default}

--- a/tuple/pkg.generated.mbti
+++ b/tuple/pkg.generated.mbti
@@ -37,40 +37,67 @@ pub fn[T, U, V] uncurry((T) -> (U) -> V) -> (T, U) -> V
 // Errors
 
 // Types and methods
+#deprecated
+pub fn[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary] Tuple(2)::arbitrary(Int, @splitmix.RandomState) -> (A, B)
+pub fn[A : Default, B : Default] Tuple(2)::default() -> (A, B)
 pub impl[A : Default, B : Default] Default for (A, B)
 pub impl[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary] @quickcheck.Arbitrary for (A, B)
 
+#deprecated
+pub fn[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary] Tuple(3)::arbitrary(Int, @splitmix.RandomState) -> (A, B, C)
+pub fn[A : Default, B : Default, C : Default] Tuple(3)::default() -> (A, B, C)
 pub impl[A : Default, B : Default, C : Default] Default for (A, B, C)
 pub impl[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary] @quickcheck.Arbitrary for (A, B, C)
 
+#deprecated
+pub fn[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary] Tuple(4)::arbitrary(Int, @splitmix.RandomState) -> (A, B, C, D)
+pub fn[A : Default, B : Default, C : Default, D : Default] Tuple(4)::default() -> (A, B, C, D)
 pub impl[A : Default, B : Default, C : Default, D : Default] Default for (A, B, C, D)
 pub impl[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary] @quickcheck.Arbitrary for (A, B, C, D)
 
+#deprecated
+pub fn[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary] Tuple(5)::arbitrary(Int, @splitmix.RandomState) -> (A, B, C, D, E)
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default] Tuple(5)::default() -> (A, B, C, D, E)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default] Default for (A, B, C, D, E)
 pub impl[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary] @quickcheck.Arbitrary for (A, B, C, D, E)
 
+#deprecated
+pub fn[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary, F : @quickcheck.Arbitrary] Tuple(6)::arbitrary(Int, @splitmix.RandomState) -> (A, B, C, D, E, F)
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default] Tuple(6)::default() -> (A, B, C, D, E, F)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default] Default for (A, B, C, D, E, F)
 pub impl[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary, F : @quickcheck.Arbitrary] @quickcheck.Arbitrary for (A, B, C, D, E, F)
 
+#deprecated
+pub fn[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary, F : @quickcheck.Arbitrary, G : @quickcheck.Arbitrary] Tuple(7)::arbitrary(Int, @splitmix.RandomState) -> (A, B, C, D, E, F, G)
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default] Tuple(7)::default() -> (A, B, C, D, E, F, G)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default] Default for (A, B, C, D, E, F, G)
 pub impl[A : @quickcheck.Arbitrary, B : @quickcheck.Arbitrary, C : @quickcheck.Arbitrary, D : @quickcheck.Arbitrary, E : @quickcheck.Arbitrary, F : @quickcheck.Arbitrary, G : @quickcheck.Arbitrary] @quickcheck.Arbitrary for (A, B, C, D, E, F, G)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default] Tuple(8)::default() -> (A, B, C, D, E, F, G, H)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default] Default for (A, B, C, D, E, F, G, H)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default] Tuple(9)::default() -> (A, B, C, D, E, F, G, H, I)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default] Default for (A, B, C, D, E, F, G, H, I)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default] Tuple(10)::default() -> (A, B, C, D, E, F, G, H, I, J)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default] Default for (A, B, C, D, E, F, G, H, I, J)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default] Tuple(11)::default() -> (A, B, C, D, E, F, G, H, I, J, K)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default] Default for (A, B, C, D, E, F, G, H, I, J, K)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default] Tuple(12)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default] Default for (A, B, C, D, E, F, G, H, I, J, K, L)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default] Tuple(13)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default] Default for (A, B, C, D, E, F, G, H, I, J, K, L, M)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default] Tuple(14)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default] Default for (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default, O : Default] Tuple(15)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default, O : Default] Default for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
 
+pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default, O : Default, P : Default] Tuple(16)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
 pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default, O : Default, P : Default] Default for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
 
 // Type aliases

--- a/tuple/tuple_test.mbt
+++ b/tuple/tuple_test.mbt
@@ -120,12 +120,12 @@ test "compare" {
 test "hash" {
   let tuple1 = (1, 2, 3, 4, 5)
   let tuple2 = (1, 2, 3, 4, 5)
-  inspect(tuple1.hash() == tuple2.hash(), content="true")
+  inspect(Hash::hash(tuple1) == Hash::hash(tuple2), content="true")
   let tuple3 = (5, 4, 3, 2, 1)
-  inspect(tuple1.hash() == tuple1.hash(), content="true")
-  inspect(tuple2.hash() == tuple2.hash(), content="true")
-  inspect(tuple3.hash() == tuple3.hash(), content="true")
-  inspect(tuple1.hash() == tuple3.hash(), content="false")
+  inspect(Hash::hash(tuple1) == Hash::hash(tuple1), content="true")
+  inspect(Hash::hash(tuple2) == Hash::hash(tuple2), content="true")
+  inspect(Hash::hash(tuple3) == Hash::hash(tuple3), content="true")
+  inspect(Hash::hash(tuple1) == Hash::hash(tuple3), content="false")
 }
 
 ///|

--- a/uint/extends.mbt
+++ b/uint/extends.mbt
@@ -1,0 +1,16 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub extend UInt with Default::{default}

--- a/uint/pkg.generated.mbti
+++ b/uint/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub let min_value : UInt
 // Errors
 
 // Types and methods
+pub fn UInt::default() -> UInt
 pub fn UInt::to_int64(UInt) -> Int64
 pub impl Default for UInt
 

--- a/uint16/README.mbt.md
+++ b/uint16/README.mbt.md
@@ -110,10 +110,10 @@ test "UInt16 default value" {
   let a : UInt16 = 0
   inspect(a, content="0")
 
-  // Hash support is available via .hash()
+  // Hash support is available via Hash::hash()
   let value : UInt16 = 42
   // This may be random per process
-  let _ = value.hash()
+  let _ = Hash::hash(value)
 }
 ```
 

--- a/uint16/uint16_test.mbt
+++ b/uint16/uint16_test.mbt
@@ -187,12 +187,12 @@ test "UInt16::hash" {
 
 ///|
 test "UInt16::equal" {
-  inspect(UInt16::equal(1, 2), content="false")
-  inspect(UInt16::equal(2, 1), content="false")
-  inspect(UInt16::equal(1, 1), content="true")
-  inspect(UInt16::equal(0, 1), content="false")
-  inspect(UInt16::equal(1, 0), content="false")
-  inspect(UInt16::equal(0, 0), content="true")
+  inspect((1 : UInt16) == 2, content="false")
+  inspect((2 : UInt16) == 1, content="false")
+  inspect((1 : UInt16) == 1, content="true")
+  inspect((0 : UInt16) == 1, content="false")
+  inspect((1 : UInt16) == 0, content="false")
+  inspect((0 : UInt16) == 0, content="true")
 }
 
 ///|
@@ -369,7 +369,7 @@ test "UInt16::to_uint64" {
 test "UInt16::hash_combine" {
   let hasher = @builtin.Hasher(seed=0)
   let value : UInt16 = 42
-  value.hash_combine(hasher)
+  Hash::hash_combine(value, hasher)
   inspect(hasher.finalize(), content="1161967057")
 }
 

--- a/uint64/README.mbt.md
+++ b/uint64/README.mbt.md
@@ -135,7 +135,7 @@ test "UInt64 default value" {
   let a : UInt64 = 0UL
   inspect(a, content="0")
 
-  // Hash support is available via .hash()
+  // Hash support is available via Hash::hash()
   let value : UInt64 = 42UL
   inspect(Hasher(seed=0)..combine(value).finalize(), content="-1962516083")
 }

--- a/unit/README.mbt.md
+++ b/unit/README.mbt.md
@@ -134,8 +134,8 @@ test "unit trait implementations" {
   inspect(u1.compare(u2), content="0")
 
   // Hashing: consistent hash values
-  let h1 = u1.hash()
-  let h2 = u2.hash()
+  let h1 = Hash::hash(u1)
+  let h2 = Hash::hash(u2)
   inspect(h1 == h2, content="true")
 
   // Default instance

--- a/v128/extends.mbt
+++ b/v128/extends.mbt
@@ -1,0 +1,28 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+pub extend V128 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Debug` trait instead", skip_current_package=true)
+pub extend V128 with @debug.Debug::{to_repr}
+
+///|
+pub extend V128 with Show::{to_string}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+pub extend V128 with Show::{output}

--- a/v128/pkg.generated.mbti
+++ b/v128/pkg.generated.mbti
@@ -10,6 +10,15 @@ import {
 // Errors
 
 // Types and methods
+#deprecated
+pub fn V128::equal(V128, V128) -> Bool
+#deprecated
+pub fn V128::not_equal(V128, V128) -> Bool
+#deprecated
+pub fn V128::output(V128, &Logger) -> Unit
+#deprecated
+pub fn V128::to_repr(V128) -> @debug.Repr
+pub fn V128::to_string(V128) -> String
 pub impl Eq for V128
 pub impl Show for V128
 pub impl @debug.Debug for V128


### PR DESCRIPTION
## Summary

Enables the `implicit_impl_as_method` warning (E0079) in `moon.mod`, so promoting a trait-impl method to a regular `.method()` now requires an explicit `extend` declaration, and makes **every** existing promotion in the library explicit.

**Policy** (~630 `extend` declarations):

| | Traits / methods | Effect |
|---|---|---|
| **Promote** — plain `pub extend` | `Show::to_string`, `ToJson`, `Compare`, `ToStringView`, `Logger` (writes), `Default`, and **all operator traits** (`Add`, `Sub`, `Mul`, `Div`, `Mod`, `Neg`, `BitAnd`, `BitOr`, `BitXOr`, `Shl`, `Shr`) | stay callable as regular methods — `x.to_string()`, `x.to_json()`, `x.compare(y)`, `T::default()`, `a.add(b)`, `a.land(b)`, `a.mod(b)`, … |
| **Deprecate** — `#deprecated(…, skip_current_package=true) pub extend` | `Show::output`, `Hash` (`hash`, `hash_combine`), `Eq`, `Debug`, `Arbitrary`, `FromJson`, `Logger::write_substring` | callers get a deprecation alert (use `==`/`!=`, `Hash::hash(x)`, `Show::output` via the trait, etc.); `skip_current_package=true` keeps our own in-package callers quiet |

`Show` is split per-method: `to_string` (the user-facing method) is promoted, while `output` (machinery that custom impls delegate to) is deprecated. Note: `Show` for container types (`Array`, `Option`, `Result`, `FixedArray`, `Deque`, `HashMap`, …) is **already `#deprecated` on `main`** (steering to `@debug.Debug`), so those types' promoted `to_string`/`output` inherit that deprecation; non-container types (`Bool`, `Char`, `Int`, …) promote `to_string` cleanly.

## Extends live in shim files

To keep the mechanical declarations from being mixed into real code, every source `extend` is collected into a per-package **`extends.mbt`** shim. Target-split types (`BigInt`, `Double`, `StringBuilder`, whose impls differ per backend) get gated `extends_js.mbt` / `extends_nonjs.mbt` shims registered in `moon.pkg`. The only `extend`s that remain inline are in `*_test.mbt` files, whose local test types can't be referenced from a source shim.

The result: the **real-code review surface is small** — `moon.mod`, two `moon.pkg` (just the gated-shim registrations), `builtin/tuple.mbt` (the 15 tuple aliases), and four small code fixes (see below). Everything else is shims, `pkg.generated.mbti`, test files, and README examples.

## Tuple types

Tuple trait impls (`Compare`/`Eq`/`Show`/`Hash`/`ToJson` in `builtin`, `Default`/`Arbitrary` in `tuple`) can't be reached by a bare `extend` — the compiler's `Tuple2`…`Tuple16` are structural, not writable identifiers (`pub extend Tuple10 with …` → `[E4024] type/trait not found`). This PR gives them nameable aliases:

```moonbit
pub type Tuple2[A, B] = (A, B)   // … through Tuple16, in builtin/tuple.mbt
```

and `extend`s each impl through the alias, so **`builtin` and `tuple` need no exemption** — the warning is fully enforced there.

## No package exemptions

The warning is enforced in **every** package — no `moon.pkg` disables `implicit_impl_as_method`.

The one awkward spot is `Buffer`: its (already deprecated) `Logger` impl promotes the deprecated `Logger::write_substring` default, and neither `extend` form works — `pub extend Buffer with Logger::{write_substring}` *references* the deprecated method, which errors cross-package (the deprecation's `skip_current_package=true` only silences `builtin`'s own references, not `buffer`'s), and omitting it leaves the promotion implicit (E0079). So it's resolved via the compiler's other documented remedy — "manually define regular methods" — a `#deprecated pub fn Buffer::write_substring(...)` that delegates to `write_view` (exactly the `Logger` trait-default behavior), which shadows the promotion and clears the warning.

## Small code fixes (the non-shim source changes)

- `bigint/bigint_js.mbt` — renamed the private JS externs `BigInt::compare`/`equal` to `*_js` so the promoted `compare`/`equal` methods no longer collide with them (and to avoid latent self-recursion once promoted).
- `error/error.mbt`, `strconv/decimal.mbt` — made `Error::to_string`/`to_json` and `Decimal::to_string` regular `pub` methods (they collided with the promoted names of the same trait method).
- `buffer/buffer.mbt` — added a manual `#deprecated pub fn Buffer::write_substring(...)` (delegating to `write_view`) so `Buffer`'s deprecated `write_substring` promotion is made explicit without the package exemption.
- A handful of test/README call sites that used the now-deprecated `Eq`/`Arbitrary` promoted methods were migrated (`Int16::equal(a, b)` → `(a : Int16) == b`, `X::arbitrary` → the `Arbitrary` trait); README examples that derive `Eq`/`Debug`/`ToJson` gained the matching `extend`.

## Verification

- `moon check --deny-warn --target all` — clean (0 warnings).
- `moon test --target all` — green: wasm 6754, wasm-gc 6754, js 6710, native 6665.

## Review

Reviewed and signed off by Codex CLI (multiple rounds). It confirmed all 128 `Hash`/`Show` receiver rewrites preserve receivers and arguments exactly; that an earlier finding (a supposed missing `StringBuilder` `Logger` promotion) was a **false positive** — those are `Logger` *trait-default* impls, not per-type promotions (no E0079 fires, and forcing them into the extend ICEs `moonc`); that the tuple aliases are transparent and arity-correct with extend inventories exactly matching the impls; and that the manual `Buffer::write_substring` reproduces the `Logger` trait default exactly, leaving no package-level exemption.

`Signed-off-by: Codex CLI <codex@openai.com>`

## New public API added by this PR (non-deprecated)

The `extend` promotions add **486** new non-deprecated public methods (plus **15** named `Tuple2`…`Tuple16` types) to `pkg.generated.mbti`; deprecated additions (`Eq`, `Hash`, `Debug`, `Arbitrary`, `FromJson`, `Show::output`) are omitted. Collected from the `.mbti` diff vs `main`:

<details><summary>486 methods, grouped by package</summary>


**`argparse`** (4)
```moonbit
pub fn FlagAction::to_string(Self) -> String
pub fn OptionAction::to_string(Self) -> String
pub fn ValueRange::to_string(Self) -> String
pub fn ValueSource::to_string(Self) -> String
```

**`bench`** (1)
```moonbit
pub fn Summary::to_json(Self) -> Json
```

**`bigint`** (16)
```moonbit
pub fn BigInt::add(Self, Self) -> Self
pub fn BigInt::compare(Self, Self) -> Int
pub fn BigInt::default() -> Self
pub fn BigInt::div(Self, Self) -> Self
pub fn BigInt::land(Self, Self) -> Self
pub fn BigInt::lor(Self, Self) -> Self
pub fn BigInt::lxor(Self, Self) -> Self
pub fn BigInt::mod(Self, Self) -> Self
pub fn BigInt::mul(Self, Self) -> Self
pub fn BigInt::neg(Self) -> Self
pub fn BigInt::op_ge(Self, Self) -> Bool
pub fn BigInt::op_gt(Self, Self) -> Bool
pub fn BigInt::op_le(Self, Self) -> Bool
pub fn BigInt::op_lt(Self, Self) -> Bool
pub fn BigInt::sub(Self, Self) -> Self
pub fn BigInt::to_json(Self) -> Json
```

**`buffer`** (1)
```moonbit
pub fn Buffer::to_string(Self) -> String
```

**`builtin`** (317)
```moonbit
pub fn ArgsLoc::to_string(Self) -> String
pub fn Bool::compare(Bool, Bool) -> Int
pub fn Bool::default() -> Bool
pub fn Bool::op_ge(Bool, Bool) -> Bool
pub fn Bool::op_gt(Bool, Bool) -> Bool
pub fn Bool::op_le(Bool, Bool) -> Bool
pub fn Bool::op_lt(Bool, Bool) -> Bool
pub fn Bool::to_json(Bool) -> Json
pub fn Bool::to_string(Bool) -> String
pub fn Byte::add(Byte, Byte) -> Byte
pub fn Byte::compare(Byte, Byte) -> Int
pub fn Byte::default() -> Byte
pub fn Byte::div(Byte, Byte) -> Byte
pub fn Byte::land(Byte, Byte) -> Byte
pub fn Byte::lor(Byte, Byte) -> Byte
pub fn Byte::lxor(Byte, Byte) -> Byte
pub fn Byte::mod(Byte, Byte) -> Byte
pub fn Byte::mul(Byte, Byte) -> Byte
pub fn Byte::op_ge(Byte, Byte) -> Bool
pub fn Byte::op_gt(Byte, Byte) -> Bool
pub fn Byte::op_le(Byte, Byte) -> Bool
pub fn Byte::op_lt(Byte, Byte) -> Bool
pub fn Byte::shl(Byte, Int) -> Byte
pub fn Byte::shr(Byte, Int) -> Byte
pub fn Byte::sub(Byte, Byte) -> Byte
pub fn Byte::to_json(Byte) -> Json
pub fn Bytes::add(Bytes, Bytes) -> Bytes
pub fn Bytes::compare(Bytes, Bytes) -> Int
pub fn Bytes::default() -> Bytes
pub fn Bytes::op_ge(Bytes, Bytes) -> Bool
pub fn Bytes::op_gt(Bytes, Bytes) -> Bool
pub fn Bytes::op_le(Bytes, Bytes) -> Bool
pub fn Bytes::op_lt(Bytes, Bytes) -> Bool
pub fn Bytes::to_json(Bytes) -> Json
pub fn Bytes::to_string(Bytes) -> String
pub fn BytesView::compare(Self, Self) -> Int
pub fn BytesView::op_ge(Self, Self) -> Bool
pub fn BytesView::op_gt(Self, Self) -> Bool
pub fn BytesView::op_le(Self, Self) -> Bool
pub fn BytesView::op_lt(Self, Self) -> Bool
pub fn BytesView::to_json(Self) -> Json
pub fn BytesView::to_string(Self) -> String
pub fn Char::compare(Char, Char) -> Int
pub fn Char::default() -> Char
pub fn Char::op_ge(Char, Char) -> Bool
pub fn Char::op_gt(Char, Char) -> Bool
pub fn Char::op_le(Char, Char) -> Bool
pub fn Char::op_lt(Char, Char) -> Bool
pub fn Char::to_json(Char) -> Json
pub fn Char::to_string(Char) -> String
pub fn Double::add(Double, Double) -> Double
pub fn Double::compare(Double, Double) -> Int
pub fn Double::default() -> Double
pub fn Double::div(Double, Double) -> Double
pub fn Double::mod(Double, Double) -> Double
pub fn Double::mul(Double, Double) -> Double
pub fn Double::neg(Double) -> Double
pub fn Double::op_ge(Double, Double) -> Bool
pub fn Double::op_gt(Double, Double) -> Bool
pub fn Double::op_le(Double, Double) -> Bool
pub fn Double::op_lt(Double, Double) -> Bool
pub fn Double::sub(Double, Double) -> Double
pub fn Double::to_json(Double) -> Json
pub fn Failure::to_json(Self) -> Json
pub fn Failure::to_string(Self) -> String
pub fn Int64::add(Int64, Int64) -> Int64
pub fn Int64::compare(Int64, Int64) -> Int
pub fn Int64::default() -> Int64
pub fn Int64::div(Int64, Int64) -> Int64
pub fn Int64::land(Int64, Int64) -> Int64
pub fn Int64::lor(Int64, Int64) -> Int64
pub fn Int64::lxor(Int64, Int64) -> Int64
pub fn Int64::mod(Int64, Int64) -> Int64
pub fn Int64::mul(Int64, Int64) -> Int64
pub fn Int64::neg(Int64) -> Int64
pub fn Int64::op_ge(Int64, Int64) -> Bool
pub fn Int64::op_gt(Int64, Int64) -> Bool
pub fn Int64::op_le(Int64, Int64) -> Bool
pub fn Int64::op_lt(Int64, Int64) -> Bool
pub fn Int64::sub(Int64, Int64) -> Int64
pub fn Int64::to_json(Int64) -> Json
pub fn Int::add(Int, Int) -> Int
pub fn Int::compare(Int, Int) -> Int
pub fn Int::default() -> Int
pub fn Int::div(Int, Int) -> Int
pub fn Int::land(Int, Int) -> Int
pub fn Int::lor(Int, Int) -> Int
pub fn Int::lxor(Int, Int) -> Int
pub fn Int::mod(Int, Int) -> Int
pub fn Int::mul(Int, Int) -> Int
pub fn Int::neg(Int) -> Int
pub fn Int::op_ge(Int, Int) -> Bool
pub fn Int::op_gt(Int, Int) -> Bool
pub fn Int::op_le(Int, Int) -> Bool
pub fn Int::op_lt(Int, Int) -> Bool
pub fn Int::sub(Int, Int) -> Int
pub fn Int::to_json(Int) -> Json
pub fn Json::default() -> Self
pub fn SourceLoc::to_string(Self) -> String
pub fn String::add(String, String) -> String
pub fn String::compare(String, String) -> Int
pub fn String::default() -> String
pub fn String::op_ge(String, String) -> Bool
pub fn String::op_gt(String, String) -> Bool
pub fn String::op_le(String, String) -> Bool
pub fn String::op_lt(String, String) -> Bool
pub fn String::to_json(String) -> Json
pub fn String::to_string(String) -> String
pub fn String::to_string_view(String) -> StringView
pub fn StringBuilder::write_char(Self, Char) -> Unit
pub fn StringBuilder::write_string(Self, String) -> Unit
pub fn StringBuilder::write_view(Self, StringView) -> Unit
pub fn StringView::add(Self, Self) -> Self
pub fn StringView::compare(Self, Self) -> Int
pub fn StringView::default() -> Self
pub fn StringView::op_ge(Self, Self) -> Bool
pub fn StringView::op_gt(Self, Self) -> Bool
pub fn StringView::op_le(Self, Self) -> Bool
pub fn StringView::op_lt(Self, Self) -> Bool
pub fn StringView::to_json(Self) -> Json
pub fn StringView::to_string_view(Self) -> Self
pub fn UInt16::add(UInt16, UInt16) -> UInt16
pub fn UInt16::compare(UInt16, UInt16) -> Int
pub fn UInt16::default() -> UInt16
pub fn UInt16::div(UInt16, UInt16) -> UInt16
pub fn UInt16::land(UInt16, UInt16) -> UInt16
pub fn UInt16::lor(UInt16, UInt16) -> UInt16
pub fn UInt16::lxor(UInt16, UInt16) -> UInt16
pub fn UInt16::mod(UInt16, UInt16) -> UInt16
pub fn UInt16::mul(UInt16, UInt16) -> UInt16
pub fn UInt16::op_ge(UInt16, UInt16) -> Bool
pub fn UInt16::op_gt(UInt16, UInt16) -> Bool
pub fn UInt16::op_le(UInt16, UInt16) -> Bool
pub fn UInt16::op_lt(UInt16, UInt16) -> Bool
pub fn UInt16::shl(UInt16, Int) -> UInt16
pub fn UInt16::shr(UInt16, Int) -> UInt16
pub fn UInt16::sub(UInt16, UInt16) -> UInt16
pub fn UInt16::to_json(UInt16) -> Json
pub fn UInt64::add(UInt64, UInt64) -> UInt64
pub fn UInt64::compare(UInt64, UInt64) -> Int
pub fn UInt64::default() -> UInt64
pub fn UInt64::div(UInt64, UInt64) -> UInt64
pub fn UInt64::land(UInt64, UInt64) -> UInt64
pub fn UInt64::lor(UInt64, UInt64) -> UInt64
pub fn UInt64::lxor(UInt64, UInt64) -> UInt64
pub fn UInt64::mod(UInt64, UInt64) -> UInt64
pub fn UInt64::mul(UInt64, UInt64) -> UInt64
pub fn UInt64::op_ge(UInt64, UInt64) -> Bool
pub fn UInt64::op_gt(UInt64, UInt64) -> Bool
pub fn UInt64::op_le(UInt64, UInt64) -> Bool
pub fn UInt64::op_lt(UInt64, UInt64) -> Bool
pub fn UInt64::sub(UInt64, UInt64) -> UInt64
pub fn UInt64::to_json(UInt64) -> Json
pub fn UInt::add(UInt, UInt) -> UInt
pub fn UInt::compare(UInt, UInt) -> Int
pub fn UInt::div(UInt, UInt) -> UInt
pub fn UInt::land(UInt, UInt) -> UInt
pub fn UInt::lor(UInt, UInt) -> UInt
pub fn UInt::lxor(UInt, UInt) -> UInt
pub fn UInt::mod(UInt, UInt) -> UInt
pub fn UInt::mul(UInt, UInt) -> UInt
pub fn UInt::op_ge(UInt, UInt) -> Bool
pub fn UInt::op_gt(UInt, UInt) -> Bool
pub fn UInt::op_le(UInt, UInt) -> Bool
pub fn UInt::op_lt(UInt, UInt) -> Bool
pub fn UInt::sub(UInt, UInt) -> UInt
pub fn UInt::to_json(UInt) -> Json
pub fn Unit::compare(Unit, Unit) -> Int
pub fn Unit::default() -> Unit
pub fn Unit::op_ge(Unit, Unit) -> Bool
pub fn Unit::op_gt(Unit, Unit) -> Bool
pub fn Unit::op_le(Unit, Unit) -> Bool
pub fn Unit::op_lt(Unit, Unit) -> Bool
pub fn Unit::to_json(Unit) -> Json
pub fn Unit::to_string(Unit) -> String
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson, O : ToJson, P : ToJson] Tuple(16)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson, O : ToJson] Tuple(15)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson, N : ToJson] Tuple(14)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M, N)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson, M : ToJson] Tuple(13)::to_json((A, B, C, D, E, F, G, H, I, J, K, L, M)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson, L : ToJson] Tuple(12)::to_json((A, B, C, D, E, F, G, H, I, J, K, L)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson, K : ToJson] Tuple(11)::to_json((A, B, C, D, E, F, G, H, I, J, K)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson, J : ToJson] Tuple(10)::to_json((A, B, C, D, E, F, G, H, I, J)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson, I : ToJson] Tuple(9)::to_json((A, B, C, D, E, F, G, H, I)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson, H : ToJson] Tuple(8)::to_json((A, B, C, D, E, F, G, H)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson, G : ToJson] Tuple(7)::to_json((A, B, C, D, E, F, G)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson, F : ToJson] Tuple(6)::to_json((A, B, C, D, E, F)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson, E : ToJson] Tuple(5)::to_json((A, B, C, D, E)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson, D : ToJson] Tuple(4)::to_json((A, B, C, D)) -> Json
pub fn[A : ToJson, B : ToJson, C : ToJson] Tuple(3)::to_json((A, B, C)) -> Json
pub fn[A : ToJson, B : ToJson] Tuple(2)::to_json((A, B)) -> Json
pub fn[K : Show, V : ToJson] Map::to_json(Self[K, V]) -> Json
pub fn[K, V] Map::default() -> Self[K, V]
pub fn[Ok : ToJson, Err : ToJson] Result::to_json(Self[Ok, Err]) -> Json
pub fn[T : Compare, E : Compare] Result::compare(Self[T, E], Self[T, E]) -> Int
pub fn[T : Compare, E : Compare] Result::op_ge(Self[T, E], Self[T, E]) -> Bool
pub fn[T : Compare, E : Compare] Result::op_gt(Self[T, E], Self[T, E]) -> Bool
pub fn[T : Compare, E : Compare] Result::op_le(Self[T, E], Self[T, E]) -> Bool
pub fn[T : Compare, E : Compare] Result::op_lt(Self[T, E], Self[T, E]) -> Bool
pub fn[T : Compare] Array::compare(Self[T], Self[T]) -> Int
pub fn[T : Compare] Array::op_ge(Self[T], Self[T]) -> Bool
pub fn[T : Compare] Array::op_gt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] Array::op_le(Self[T], Self[T]) -> Bool
pub fn[T : Compare] Array::op_lt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ArrayView::compare(Self[T], Self[T]) -> Int
pub fn[T : Compare] ArrayView::op_ge(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ArrayView::op_gt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ArrayView::op_le(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ArrayView::op_lt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] FixedArray::compare(Self[T], Self[T]) -> Int
pub fn[T : Compare] FixedArray::op_ge(Self[T], Self[T]) -> Bool
pub fn[T : Compare] FixedArray::op_gt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] FixedArray::op_le(Self[T], Self[T]) -> Bool
pub fn[T : Compare] FixedArray::op_lt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] MutArrayView::compare(Self[T], Self[T]) -> Int
pub fn[T : Compare] MutArrayView::op_ge(Self[T], Self[T]) -> Bool
pub fn[T : Compare] MutArrayView::op_gt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] MutArrayView::op_le(Self[T], Self[T]) -> Bool
pub fn[T : Compare] MutArrayView::op_lt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ReadOnlyArray::compare(Self[T], Self[T]) -> Int
pub fn[T : Compare] ReadOnlyArray::op_ge(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ReadOnlyArray::op_gt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ReadOnlyArray::op_le(Self[T], Self[T]) -> Bool
pub fn[T : Compare] ReadOnlyArray::op_lt(Self[T], Self[T]) -> Bool
pub fn[T : ToJson] Option::to_json(T?) -> Json
pub fn[T : ToJson] ReadOnlyArray::to_json(Self[T]) -> Json
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare, T15 : Compare] Tuple(16)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare, T14 : Compare] Tuple(15)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare, T13 : Compare] Tuple(14)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare, T12 : Compare] Tuple(13)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare, T11 : Compare] Tuple(12)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare, T10 : Compare] Tuple(11)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare, T9 : Compare] Tuple(10)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::compare((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_le((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare, T8 : Compare] Tuple(9)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7, T8), (T0, T1, T2, T3, T4, T5, T6, T7, T8)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::compare((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_ge((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_gt((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_le((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare, T7 : Compare] Tuple(8)::op_lt((T0, T1, T2, T3, T4, T5, T6, T7), (T0, T1, T2, T3, T4, T5, T6, T7)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::compare((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_ge((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_gt((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_le((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare, T6 : Compare] Tuple(7)::op_lt((T0, T1, T2, T3, T4, T5, T6), (T0, T1, T2, T3, T4, T5, T6)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::compare((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_ge((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_gt((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_le((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare, T5 : Compare] Tuple(6)::op_lt((T0, T1, T2, T3, T4, T5), (T0, T1, T2, T3, T4, T5)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::compare((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_ge((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_gt((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_le((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare, T4 : Compare] Tuple(5)::op_lt((T0, T1, T2, T3, T4), (T0, T1, T2, T3, T4)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::compare((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_ge((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_gt((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_le((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare, T3 : Compare] Tuple(4)::op_lt((T0, T1, T2, T3), (T0, T1, T2, T3)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::compare((T0, T1, T2), (T0, T1, T2)) -> Int
pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_ge((T0, T1, T2), (T0, T1, T2)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_gt((T0, T1, T2), (T0, T1, T2)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_le((T0, T1, T2), (T0, T1, T2)) -> Bool
pub fn[T0 : Compare, T1 : Compare, T2 : Compare] Tuple(3)::op_lt((T0, T1, T2), (T0, T1, T2)) -> Bool
pub fn[T0 : Compare, T1 : Compare] Tuple(2)::compare((T0, T1), (T0, T1)) -> Int
pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_ge((T0, T1), (T0, T1)) -> Bool
pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_gt((T0, T1), (T0, T1)) -> Bool
pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_le((T0, T1), (T0, T1)) -> Bool
pub fn[T0 : Compare, T1 : Compare] Tuple(2)::op_lt((T0, T1), (T0, T1)) -> Bool
pub fn[T] Array::add(Self[T], Self[T]) -> Self[T]
pub fn[T] Array::default() -> Self[T]
pub fn[T] ArrayView::add(Self[T], Self[T]) -> Self[T]
pub fn[T] FixedArray::add(Self[T], Self[T]) -> Self[T]
pub fn[T] Iter::add(Self[T], Self[T]) -> Self[T]
pub fn[T] ReadOnlyArray::default() -> Self[T]
pub fn[X : Compare] Option::compare(X?, X?) -> Int
pub fn[X : Compare] Option::op_ge(X?, X?) -> Bool
pub fn[X : Compare] Option::op_gt(X?, X?) -> Bool
pub fn[X : Compare] Option::op_le(X?, X?) -> Bool
pub fn[X : Compare] Option::op_lt(X?, X?) -> Bool
pub fn[X : ToJson] Array::to_json(Self[X]) -> Json
pub fn[X : ToJson] ArrayView::to_json(Self[X]) -> Json
pub fn[X : ToJson] FixedArray::to_json(Self[X]) -> Json
pub fn[X : ToJson] Iter::to_json(Self[X]) -> Json
pub fn[X] FixedArray::default() -> Self[X]
pub fn[X] Option::default() -> X?
```

**`cmp`** (6)
```moonbit
pub fn[T : Compare] Reverse::compare(Self[T], Self[T]) -> Int
pub fn[T : Compare] Reverse::op_ge(Self[T], Self[T]) -> Bool
pub fn[T : Compare] Reverse::op_gt(Self[T], Self[T]) -> Bool
pub fn[T : Compare] Reverse::op_le(Self[T], Self[T]) -> Bool
pub fn[T : Compare] Reverse::op_lt(Self[T], Self[T]) -> Bool
pub fn[T : Show] Reverse::to_string(Self[T]) -> String
```

**`coverage`** (1)
```moonbit
pub fn CoverageCounter::to_string(Self) -> String
```

**`debug`** (1)
```moonbit
pub fn Repr::to_string(Self) -> String
```

**`deque`** (7)
```moonbit
pub fn[A : Compare] Deque::compare(Self[A], Self[A]) -> Int
pub fn[A : Compare] Deque::op_ge(Self[A], Self[A]) -> Bool
pub fn[A : Compare] Deque::op_gt(Self[A], Self[A]) -> Bool
pub fn[A : Compare] Deque::op_le(Self[A], Self[A]) -> Bool
pub fn[A : Compare] Deque::op_lt(Self[A], Self[A]) -> Bool
pub fn[A : ToJson] Deque::to_json(Self[A]) -> Json
pub fn[A] Deque::add(Self[A], Self[A]) -> Self[A]
```

**`error`** (2)
```moonbit
pub fn Error::to_json(Self) -> Json
pub fn Error::to_string(Self) -> String
```

**`float`** (14)
```moonbit
pub fn Float::add(Float, Float) -> Float
pub fn Float::compare(Float, Float) -> Int
pub fn Float::default() -> Float
pub fn Float::div(Float, Float) -> Float
pub fn Float::mod(Float, Float) -> Float
pub fn Float::mul(Float, Float) -> Float
pub fn Float::neg(Float) -> Float
pub fn Float::op_ge(Float, Float) -> Bool
pub fn Float::op_gt(Float, Float) -> Bool
pub fn Float::op_le(Float, Float) -> Bool
pub fn Float::op_lt(Float, Float) -> Bool
pub fn Float::sub(Float, Float) -> Float
pub fn Float::to_json(Float) -> Json
pub fn Float::to_string(Float) -> String
```

**`hashmap`** (2)
```moonbit
pub fn[K : Show, V : ToJson] HashMap::to_json(Self[K, V]) -> Json
pub fn[K, V] HashMap::default() -> Self[K, V]
```

**`hashset`** (6)
```moonbit
pub fn[K : Hash + Eq] HashSet::land(Self[K], Self[K]) -> Self[K]
pub fn[K : Hash + Eq] HashSet::lor(Self[K], Self[K]) -> Self[K]
pub fn[K : Hash + Eq] HashSet::lxor(Self[K], Self[K]) -> Self[K]
pub fn[K : Hash + Eq] HashSet::sub(Self[K], Self[K]) -> Self[K]
pub fn[K] HashSet::default() -> Self[K]
pub fn[X : ToJson] HashSet::to_json(Self[X]) -> Json
```

**`immut/array`** (6)
```moonbit
pub fn[A : Compare] T::compare(Self[A], Self[A]) -> Int
pub fn[A : Compare] T::op_ge(Self[A], Self[A]) -> Bool
pub fn[A : Compare] T::op_gt(Self[A], Self[A]) -> Bool
pub fn[A : Compare] T::op_le(Self[A], Self[A]) -> Bool
pub fn[A : Compare] T::op_lt(Self[A], Self[A]) -> Bool
pub fn[A] T::add(Self[A], Self[A]) -> Self[A]
```

**`immut/priority_queue`** (6)
```moonbit
pub fn[A : Compare] PriorityQueue::compare(Self[A], Self[A]) -> Int
pub fn[A : Compare] PriorityQueue::op_ge(Self[A], Self[A]) -> Bool
pub fn[A : Compare] PriorityQueue::op_gt(Self[A], Self[A]) -> Bool
pub fn[A : Compare] PriorityQueue::op_le(Self[A], Self[A]) -> Bool
pub fn[A : Compare] PriorityQueue::op_lt(Self[A], Self[A]) -> Bool
pub fn[A : ToJson + Compare] PriorityQueue::to_json(Self[A]) -> Json
```

**`immut/sorted_map`** (6)
```moonbit
pub fn[K : Compare, V : Compare] SortedMap::compare(Self[K, V], Self[K, V]) -> Int
pub fn[K : Compare, V : Compare] SortedMap::op_ge(Self[K, V], Self[K, V]) -> Bool
pub fn[K : Compare, V : Compare] SortedMap::op_gt(Self[K, V], Self[K, V]) -> Bool
pub fn[K : Compare, V : Compare] SortedMap::op_le(Self[K, V], Self[K, V]) -> Bool
pub fn[K : Compare, V : Compare] SortedMap::op_lt(Self[K, V], Self[K, V]) -> Bool
pub fn[K, V] SortedMap::default() -> Self[K, V]
```

**`immut/sorted_set`** (7)
```moonbit
pub fn[A : Compare] SortedSet::compare(Self[A], Self[A]) -> Int
pub fn[A : Compare] SortedSet::op_ge(Self[A], Self[A]) -> Bool
pub fn[A : Compare] SortedSet::op_gt(Self[A], Self[A]) -> Bool
pub fn[A : Compare] SortedSet::op_le(Self[A], Self[A]) -> Bool
pub fn[A : Compare] SortedSet::op_lt(Self[A], Self[A]) -> Bool
pub fn[A : Compare] SortedSet::sub(Self[A], Self[A]) -> Self[A]
pub fn[A] SortedSet::default() -> Self[A]
```

**`immut/vector`** (7)
```moonbit
pub fn[A : Compare] Vector::compare(Self[A], Self[A]) -> Int
pub fn[A : Compare] Vector::op_ge(Self[A], Self[A]) -> Bool
pub fn[A : Compare] Vector::op_gt(Self[A], Self[A]) -> Bool
pub fn[A : Compare] Vector::op_le(Self[A], Self[A]) -> Bool
pub fn[A : Compare] Vector::op_lt(Self[A], Self[A]) -> Bool
pub fn[A : ToJson] Vector::to_json(Self[A]) -> Json
pub fn[A] Vector::add(Self[A], Self[A]) -> Self[A]
```

**`int16`** (18)
```moonbit
pub fn Int16::add(Int16, Int16) -> Int16
pub fn Int16::compare(Int16, Int16) -> Int
pub fn Int16::default() -> Int16
pub fn Int16::div(Int16, Int16) -> Int16
pub fn Int16::land(Int16, Int16) -> Int16
pub fn Int16::lor(Int16, Int16) -> Int16
pub fn Int16::lxor(Int16, Int16) -> Int16
pub fn Int16::mod(Int16, Int16) -> Int16
pub fn Int16::mul(Int16, Int16) -> Int16
pub fn Int16::neg(Int16) -> Int16
pub fn Int16::op_ge(Int16, Int16) -> Bool
pub fn Int16::op_gt(Int16, Int16) -> Bool
pub fn Int16::op_le(Int16, Int16) -> Bool
pub fn Int16::op_lt(Int16, Int16) -> Bool
pub fn Int16::shl(Int16, Int) -> Int16
pub fn Int16::shr(Int16, Int) -> Int16
pub fn Int16::sub(Int16, Int16) -> Int16
pub fn Int16::to_json(Int16) -> Json
```

**`internal/regex_engine/automata`** (5)
```moonbit
pub fn Mark::compare(Self, Self) -> Int
pub fn Mark::op_ge(Self, Self) -> Bool
pub fn Mark::op_gt(Self, Self) -> Bool
pub fn Mark::op_le(Self, Self) -> Bool
pub fn Mark::op_lt(Self, Self) -> Bool
```

**`internal/regex_engine/shared_types`** (1)
```moonbit
pub fn Category::add(Self, Self) -> Self
```

**`internal/regex_engine/shared_types/rechar_set`** (3)
```moonbit
pub fn RecharSet::add(Self, Self) -> Self
pub fn RecharSet::land(Self, Self) -> Self
pub fn RecharSet::sub(Self, Self) -> Self
```

**`json`** (8)
```moonbit
pub fn Json::to_json(Self) -> Self
pub fn JsonDecodeError::to_json(Self) -> Json
pub fn JsonDecodeError::to_string(Self) -> String
pub fn JsonPath::to_json(Self) -> Json
pub fn JsonPath::to_string(Self) -> String
pub fn ParseError::to_json(Self) -> Json
pub fn ParseError::to_string(Self) -> String
pub fn Position::to_json(Self) -> Json
```

**`list`** (6)
```moonbit
pub fn[A : Compare] List::compare(Self[A], Self[A]) -> Int
pub fn[A : Compare] List::op_ge(Self[A], Self[A]) -> Bool
pub fn[A : Compare] List::op_gt(Self[A], Self[A]) -> Bool
pub fn[A : Compare] List::op_le(Self[A], Self[A]) -> Bool
pub fn[A : Compare] List::op_lt(Self[A], Self[A]) -> Bool
pub fn[X] List::default() -> Self[X]
```

**`priority_queue`** (2)
```moonbit
pub fn[A : ToJson + Compare] PriorityQueue::to_json(Self[A]) -> Json
pub fn[K] PriorityQueue::default() -> Self[K]
```

**`quickcheck/splitmix`** (2)
```moonbit
pub fn RandomState::default() -> Self
pub fn RandomState::to_string(Self) -> String
```

**`set`** (6)
```moonbit
pub fn[K : Hash + Eq] Set::land(Self[K], Self[K]) -> Self[K]
pub fn[K : Hash + Eq] Set::lor(Self[K], Self[K]) -> Self[K]
pub fn[K : Hash + Eq] Set::lxor(Self[K], Self[K]) -> Self[K]
pub fn[K : Hash + Eq] Set::sub(Self[K], Self[K]) -> Self[K]
pub fn[K] Set::default() -> Self[K]
pub fn[X : ToJson] Set::to_json(Self[X]) -> Json
```

**`sorted_map`** (2)
```moonbit
pub fn[K : Show, V : ToJson] SortedMap::to_json(Self[K, V]) -> Json
pub fn[K, V] SortedMap::default() -> Self[K, V]
```

**`sorted_set`** (1)
```moonbit
pub fn[K] SortedSet::default() -> Self[K]
```

**`strconv`** (2)
```moonbit
pub fn Decimal::to_string(Self) -> String
pub fn StrConvError::to_string(Self) -> String
```

**`string`** (2)
```moonbit
pub fn Regex::add(Self, Self) -> Self
pub fn Regex::lor(Self, Self) -> Self
```

**`string/internal/regex_parser`** (1)
```moonbit
pub fn ParserError::to_string(Self) -> String
```

**`tuple`** (15)
```moonbit
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default, O : Default, P : Default] Tuple(16)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default, O : Default] Tuple(15)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default, N : Default] Tuple(14)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default, M : Default] Tuple(13)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L, M)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default, L : Default] Tuple(12)::default() -> (A, B, C, D, E, F, G, H, I, J, K, L)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default, K : Default] Tuple(11)::default() -> (A, B, C, D, E, F, G, H, I, J, K)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default, J : Default] Tuple(10)::default() -> (A, B, C, D, E, F, G, H, I, J)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default, I : Default] Tuple(9)::default() -> (A, B, C, D, E, F, G, H, I)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default, H : Default] Tuple(8)::default() -> (A, B, C, D, E, F, G, H)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default, G : Default] Tuple(7)::default() -> (A, B, C, D, E, F, G)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default, F : Default] Tuple(6)::default() -> (A, B, C, D, E, F)
pub fn[A : Default, B : Default, C : Default, D : Default, E : Default] Tuple(5)::default() -> (A, B, C, D, E)
pub fn[A : Default, B : Default, C : Default, D : Default] Tuple(4)::default() -> (A, B, C, D)
pub fn[A : Default, B : Default, C : Default] Tuple(3)::default() -> (A, B, C)
pub fn[A : Default, B : Default] Tuple(2)::default() -> (A, B)
```

**`uint`** (1)
```moonbit
pub fn UInt::default() -> UInt
```

**`v128`** (1)
```moonbit
pub fn V128::to_string(V128) -> String
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
