### PR TITLE
feat(deque): make trait promotions explicit via extend (per-package migration 1/N)

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -79,8 +79,8 @@ pub impl[A : Show] Show for Deque[A] with fn output(self, logger) {
 ///   let dq1 = @deque.from_array([1, 2, 3])
 ///   let dq2 = @deque.from_array([1, 2, 3])
 ///   let dq3 = @deque.from_array([1, 2, 3, 4])
-///   @test.assert_eq(dq1.hash(), dq2.hash()) // same elements → same hash
-///   @test.assert_not_eq(dq1.hash(), dq3.hash()) // different elements → different hash
+///   @test.assert_eq(Hash::hash(dq1), Hash::hash(dq2)) // same elements → same hash
+///   @test.assert_not_eq(Hash::hash(dq1), Hash::hash(dq3)) // different elements → different hash
 /// }
 /// ```
 ///
@@ -1772,12 +1772,16 @@ pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
 ///
 /// Returns a JSON array containing all elements from the deque converted to
 /// their JSON representations.
-/// test "T::to_json" {
-///   let dq = @deque.from_array([1, 2, 3])
-///   let json = dq.to_json()
-///   inspect(json, content="Array([Number(1), Number(2), Number(3)])")
-/// ```
 ///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let dq = @deque.from_array([1, 2, 3])
+///   let json = @json.to_json(dq)
+///   @debug.debug_inspect(json, content="Array([Number(1), Number(2), Number(3)])")
+/// }
+/// ```
 pub impl[A : ToJson] ToJson for Deque[A] with fn to_json(self : Deque[A]) -> Json {
   [
     for x in self => x

--- a/deque/extends.mbt
+++ b/deque/extends.mbt
@@ -1,0 +1,53 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend Deque with Add::{add}
+
+///|
+pub extend Deque with Compare::{compare}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with @json.FromJson::{from_json}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with ToJson::{to_json}

--- a/deque/moon.pkg
+++ b/deque/moon.pkg
@@ -10,6 +10,8 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -17,6 +17,7 @@ type Deque[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A] Deque::Deque(ArrayView[A], capacity? : Int) -> Self[A]
+pub fn[A] Deque::add(Self[A], Self[A]) -> Self[A]
 pub fn[A] Deque::append(Self[A], Self[A]) -> Unit
 pub fn[A] Deque::as_views(Self[A]) -> (ArrayView[A], ArrayView[A])
 #alias("_[_]")
@@ -29,6 +30,7 @@ pub fn[A] Deque::capacity(Self[A]) -> Int
 pub fn[A] Deque::chunk_by(Self[A], (A, A) -> Bool raise?) -> Self[Self[A]] raise?
 pub fn[A] Deque::chunks(Self[A], Int) -> Self[Self[A]]
 pub fn[A] Deque::clear(Self[A]) -> Unit
+pub fn[A : Compare] Deque::compare(Self[A], Self[A]) -> Int
 pub fn[A : Eq] Deque::contains(Self[A], A) -> Bool
 #alias(clone, deprecated)
 pub fn[A] Deque::copy(Self[A]) -> Self[A]


### PR DESCRIPTION
## Summary

First of a **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion — replacing the single large #3846 with small, scoped PRs. This one covers **`deque`** only.

It enables `implicit_impl_as_method` (E0079) in `deque/moon.pkg` and makes every trait-impl promotion explicit via `extend`, in a dedicated `deque/extends.mbt` shim (promotions first, deprecations after):

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Add`, `Compare::{compare}` | `Compare::{op_ge, op_gt, op_le, op_lt}`, `Eq`, `Hash`, `@json.FromJson`, `ToJson`, and the whole **`Show`** trait (`to_string` + `output`) |

Policy points worth calling out:

- **Only `compare` is promoted from `Compare`.** The operator methods (`op_lt`/`op_le`/`op_ge`/`op_gt`) are deprecated — callers use the `<` / `<=` / `>=` / `>` operators, never `x.op_lt(y)` (which has zero method callers in the tree).
- **`Show` is deprecated for collections (Rust-style).** Like Rust, where collections implement `Debug` rather than `Display`, a `Deque` shouldn't be `Show`n — its `Show` impl is already `#deprecated` on `main` (steering to `@debug.Debug`), so both `to_string` and `output` are deprecated rather than promoted.
- **`ToJson` is deprecated in favour of the free `@json.to_json`** (added in #3850, now merged, symmetric with `@json.from_json`) — so `to_json` is not promoted as a method here.
- **Deprecated promotions carry `#doc(hidden)`.** They stay callable (with a deprecation warning) but are removed from `pkg.generated.mbti`, so the generated-interface diff shows only the genuinely-new promoted methods (`add`, `compare`).

Besides the shim + the one-line `moon.pkg` flag, this fixes two doc examples that used now-deprecated promoted methods:
- the `Hash::hash` example (`dq.hash()` → `Hash::hash(dq)`);
- the `ToJson` example, which was a **malformed, never-compiled block** (a bare `test "…" {` with no `` ```mbt `` fence), rewritten as a proper checked (`` ```mbt check ``) doctest using `@json.to_json(dq)` and `@debug.debug_inspect`.

**No other package is touched** — there are no cross-package callers of `deque`'s newly-deprecated methods.

## Verification
- `moon check --deny-warn --target all` — clean (zero warnings).
- `moon test --target all` — green on all four backends.

## Context
Supersedes the monolithic #3846 (closed). Depends only on the free `@json.to_json` from #3850 (merged). Same policy and mechanics, delivered one package at a time for reviewability.
