### PR TITLE
feat(json): add free `to_json` function (symmetric with `from_json`)

### DIFF
--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub fn json_inspect(&ToJson, content? : Json, loc~ : SourceLoc, args_loc~ : Args
 #label_migration(max_nesting_depth, fill=false)
 pub fn parse(StringView, max_nesting_depth? : Int) -> Json raise ParseError
 
+pub fn[T : ToJson] to_json(T) -> Json
+
 pub fn valid(StringView) -> Bool
 
 // Errors

--- a/json/to_json.mbt
+++ b/json/to_json.mbt
@@ -1,0 +1,31 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Convert `value` to `Json`.
+///
+/// This is the free-function form of the `ToJson` trait method, symmetric with
+/// `@json.from_json`. Prefer it over the promoted `value.to_json()` method.
+///
+/// ```mbt check
+/// test {
+///   @debug.debug_inspect(
+///     @json.to_json([1, 2, 3]),
+///     content="Array([Number(1), Number(2), Number(3)])",
+///   )
+/// }
+/// ```
+pub fn[T : ToJson] to_json(value : T) -> Json {
+  ToJson::to_json(value)
+}


### PR DESCRIPTION
## Summary

Adds a free `@json.to_json(value)` function — the `ToJson` counterpart to the existing `@json.from_json` — delegating to `ToJson::to_json`. It gives a first-class free-function form for `value -> Json`, so callers can write `@json.to_json(x)` instead of relying on the implicitly-promoted `x.to_json()` method.

```mbt
@json.to_json([1, 2, 3]) // Array([Number(1), Number(2), Number(3)])
```

## Why

Prerequisite for the `implicit_impl_as_method` (E0079) migration — the per-package series that makes trait-method promotions explicit (first PR #3849). Once this lands, those PRs can deprecate the promoted `to_json` method in favour of this free function, exactly mirroring how `from_json` already works.

The doc example is a checked (`mbt check`) doctest, so this behaviour is verified in CI. It uses `@debug.debug_inspect` rather than `inspect`, since `Json`'s `Show` impl is deprecated in favour of `Debug`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/json --target all` — green (185 tests × 4 backends).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
