### PR TITLE
feat(queue): make trait promotions explicit via extend

### DIFF
--- a/queue/extends.mbt
+++ b/queue/extends.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Queue has no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Queue with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for debugging purposes. See https://github.com/moonbitlang/core/blob/main/debug/README.mbt.md", skip_current_package=true)
+#doc(hidden)
+pub extend Queue with Show::{output, to_string}

--- a/queue/moon.pkg
+++ b/queue/moon.pkg
@@ -10,6 +10,8 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`queue`** only.

It enables `implicit_impl_as_method` (E0079) in `queue/moon.pkg` and makes every trait-impl promotion explicit via `extend`, in a dedicated `queue/extends.mbt` shim.

Queue has **no methods worth keeping promoted** — the compiler flags only two, both deprecated:

| Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|
| `Show::{to_string, output}`, `@quickcheck.Arbitrary::{arbitrary}` |

- **`Show` is deprecated for collections (Rust-style).** Queue's `Show` impl is already `#deprecated` on `main` (steering to `@debug.Debug`), so both `to_string` and `output` are deprecated rather than promoted.
- **`Arbitrary`** → use the `Arbitrary` trait instead.
- Both carry `#doc(hidden)`, so they stay callable but are absent from `pkg.generated.mbti` — the **generated interface is unchanged**. (Queue's `Eq` impl isn't promoted anywhere, so it needs no extend.)

Just 2 files (`moon.pkg` + `extends.mbt`); no other package is touched.

## Verification
- `moon check --deny-warn --target all` — clean (zero warnings).
- `moon test --target all` — green on all four backends.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
