### PR TITLE
feat(list): make trait promotions explicit via extend

### DIFF
--- a/list/extends.mbt
+++ b/list/extends.mbt
@@ -1,0 +1,48 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend List with Compare::{compare}
+
+///|
+pub extend List with Default::{default}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend List with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend List with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend List with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend List with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend List with Show::{output, to_string}

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -813,12 +813,12 @@ test "from_iter empty iter" {
 test "hash" {
   let l1 = @list.List([1, 2, 3, 4, 5])
   let l2 = @list.List([1, 2, 3, 4, 5])
-  debug_inspect(l1.hash() == l2.hash(), content="true")
+  debug_inspect(Hash::hash(l1) == Hash::hash(l2), content="true")
   let l3 = @list.List([5, 4, 3, 2, 1])
-  debug_inspect(l1.hash() == l3.hash(), content="false")
+  debug_inspect(Hash::hash(l1) == Hash::hash(l3), content="false")
   let l4 : @list.List[Int] = List([])
-  debug_inspect(l1.hash() == l4.hash(), content="false")
-  debug_inspect(l4.hash() == l4.hash(), content="true")
+  debug_inspect(Hash::hash(l1) == Hash::hash(l4), content="false")
+  debug_inspect(Hash::hash(l4) == Hash::hash(l4), content="true")
 }
 
 ///|

--- a/list/moon.pkg
+++ b/list/moon.pkg
@@ -10,6 +10,8 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: { "panic_test.mbt": [ "not", "native" ] },
 )

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -21,11 +21,13 @@ pub enum List[A] {
 pub fn[A] List::List(ArrayView[A]) -> Self[A]
 pub fn[A] List::all(Self[A], (A) -> Bool raise?) -> Bool raise?
 pub fn[A] List::any(Self[A], (A) -> Bool raise?) -> Bool raise?
+pub fn[A : Compare] List::compare(Self[A], Self[A]) -> Int
 pub fn[A] List::concat(Self[A], Self[A]) -> Self[A]
 #as_free_fn(construct, deprecated)
 #as_free_fn
 pub fn[A] List::cons(A, Self[A]) -> Self[A]
 pub fn[A : Eq] List::contains(Self[A], A) -> Bool
+pub fn[X] List::default() -> Self[X]
 pub fn[A] List::drop(Self[A], Int) -> Self[A]
 pub fn[A] List::drop_while(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A] List::each(Self[A], (A) -> Unit raise?) -> Unit raise?


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`list`** only.

It enables `implicit_impl_as_method` (E0079) in `list/moon.pkg` and makes every trait-impl promotion explicit via `extend`, in a dedicated `list/extends.mbt` shim (promotions first, deprecations after):

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Compare::{compare}`, `Default` | `Compare::{op_ge, op_gt, op_le, op_lt}`, `Eq`, `Hash`, `@quickcheck.Arbitrary`, and the whole **`Show`** trait (`to_string` + `output`) |

- **Only `compare` is promoted from `Compare`** — callers use `<` / `<=` / `>=` / `>`, never `x.op_lt(y)`.
- **`Show` is deprecated for collections (Rust-style)** — `List`'s `Show` impl is already `#deprecated` on `main` (→ `@debug.Debug`).
- **Deprecated promotions carry `#doc(hidden)`** — `pkg.generated.mbti` gains only `List::compare` and `List::default`.

The only non-shim change is migrating **list's own blackbox test** off the now-deprecated promoted `.hash()` (`l.hash()` → `Hash::hash(l)`). No other package is touched.

## Verification
- `moon check --deny-warn --target all` — clean (zero warnings).
- `moon test --target all` — green on all four backends.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
