### PR TITLE
feat(priority_queue): make trait promotions explicit via extend

### DIFF
--- a/priority_queue/extends.mbt
+++ b/priority_queue/extends.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend PriorityQueue with Default::{default}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with ToJson::{to_json}

--- a/priority_queue/moon.pkg
+++ b/priority_queue/moon.pkg
@@ -13,6 +13,8 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/priority_queue/pkg.generated.mbti
+++ b/priority_queue/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub fn[A : Compare] PriorityQueue::PriorityQueue(ArrayView[A]) -> Self[A]
 pub fn[A] PriorityQueue::clear(Self[A]) -> Unit
 #alias(clone, deprecated)
 pub fn[A] PriorityQueue::copy(Self[A]) -> Self[A]
+pub fn[K] PriorityQueue::default() -> Self[K]
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`priority_queue`** only.

It enables `implicit_impl_as_method` (E0079) in `priority_queue/moon.pkg` and makes every trait-impl promotion explicit via `extend`, in a dedicated `priority_queue/extends.mbt` shim.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Default` | `@quickcheck.Arbitrary`, the whole **`Show`** trait (`to_string` + `output`), `ToJson` |

- **`Show` is deprecated for collections (Rust-style)** — `PriorityQueue`'s `Show` impl is already `#deprecated` on `main` (→ `@debug.Debug`).
- **`ToJson` is deprecated in favour of the free `@json.to_json`** (#3850).
- **Deprecated promotions carry `#doc(hidden)`** — `pkg.generated.mbti` gains only `PriorityQueue::default`.

3 files, scoped to `priority_queue/`; no other package touched, no caller migration needed.

## Verification
- `moon check --deny-warn --target all` — clean (zero warnings).
- `moon test --target all` — green on all four backends.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
