### PR TITLE
feat(hashmap): make trait promotions explicit via extend

### DIFF
--- a/hashmap/extends.mbt
+++ b/hashmap/extends.mbt
@@ -1,0 +1,40 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend HashMap with Default::{default}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with ToJson::{to_json}

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -491,7 +491,7 @@ fn[K : Hash + Eq + Debug, V : Eq + Debug] verify_content(
 test "hashmap.to_json" {
   let map = @hashmap.from_array([(1, "one"), (2, "two"), (3, "three")])
   let json : Json = { "1": "one", "2": "two", "3": "three" }
-  @test.assert_eq(map.to_json(), json)
+  @test.assert_eq(@json.to_json(map), json)
 }
 
 ///|

--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -12,3 +12,5 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/core/json",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -26,6 +26,7 @@ pub fn[K : Hash + Eq, V] HashMap::contains(Self[K, V], K) -> Bool
 pub fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(Self[K, V], K, V) -> Bool
 #alias(clone, deprecated)
 pub fn[K, V] HashMap::copy(Self[K, V]) -> Self[K, V]
+pub fn[K, V] HashMap::default() -> Self[K, V]
 pub fn[K, V] HashMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] HashMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
 #alias(from_iterator, deprecated)


### PR DESCRIPTION
## Summary

Enable `implicit_impl_as_method` (E0079) for the `hashmap` package and make its
trait-impl promotions explicit via `extend`, in a dedicated `hashmap/extends.mbt` shim.
This continues the per-package series migrating the library off implicit method
promotion (see #3849 for deque). Scoped to `hashmap/`.

The compiler's authoritative flagged set for `HashMap` is `Arbitrary::{arbitrary}`,
`Default::{default}`, `Eq::{equal, not_equal}`, `Show::{output, to_string}`, and
`ToJson::{to_json}`. `HashMap` is a collection (its `impl Show` is already
`#deprecated`), so both `Show` methods are deprecated. One in-package caller in the
blackbox test package used `map.to_json()`; it now uses `@json.to_json(map)`.

## Promote / deprecate

| Trait::methods | Disposition | Rationale |
| --- | --- | --- |
| `Default::{default}` | Promote (plain `pub extend`) | `Default` methods stay promoted |
| `@quickcheck.Arbitrary::{arbitrary}` | Deprecate | Use the `Arbitrary` trait instead |
| `Eq::{equal, not_equal}` | Deprecate | Use `==` / `!=` instead |
| `Show::{output, to_string}` | Deprecate (both) | `Show` on a collection; use `@debug.Debug` |
| `ToJson::{to_json}` | Deprecate | Use `@json.to_json` instead |

Policy bullets:
- Promote plain: `Default` (all methods).
- Deprecate (`#deprecated(..., skip_current_package=true)` + `#doc(hidden)`):
  `Arbitrary::{arbitrary}`, `Eq::{equal, not_equal}`, `Show::{output, to_string}`
  (collection Show deprecates both), `ToJson::{to_json}`.
- `HashMap` has no `Compare`/`Hash`/`FromJson`/arithmetic impls, so those traits are
  not in the flagged set; `@debug.Debug` is implemented but was not flagged.

## Verification

- `moon check --deny-warn --target all` — clean (0 warnings, 0 errors).
- `moon test --target all` — green on all 4 backends (wasm, wasm-gc, js, native).
- `pkg.generated.mbti` gains only the promoted method `HashMap::default()`;
  deprecated promotions stay hidden via `#doc(hidden)`.

Signed-off-by: Codex CLI <codex@openai.com>
