### PR TITLE
feat(immut/array): make trait promotions explicit via extend

### DIFF
--- a/immut/array/extends.mbt
+++ b/immut/array/extends.mbt
@@ -1,0 +1,48 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend T with Add::{add}
+
+///|
+pub extend T with Compare::{compare}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend T with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend T with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend T with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend T with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend T with Show::{output, to_string}

--- a/immut/array/moon.pkg
+++ b/immut/array/moon.pkg
@@ -9,7 +9,7 @@ import {
   "moonbitlang/core/ref",
 } for "wbtest"
 
-warnings = "-deprecated"
+warnings = "-deprecated+implicit_impl_as_method"
 
 import {
   "moonbitlang/core/test",

--- a/immut/array/pkg.generated.mbti
+++ b/immut/array/pkg.generated.mbti
@@ -13,9 +13,11 @@ import {
 
 // Types and methods
 type T[A]
+pub fn[A] T::add(Self[A], Self[A]) -> Self[A]
 #alias("_[_]")
 #deprecated
 pub fn[A] T::at(Self[A], Int) -> A
+pub fn[A : Compare] T::compare(Self[A], Self[A]) -> Int
 #deprecated
 pub fn[A] T::concat(Self[A], Self[A]) -> Self[A]
 #alias(clone, deprecated)


### PR DESCRIPTION
## Summary

Enables the `implicit_impl_as_method` warning (E0079) for `immut/array` and makes every
trait-impl method promotion explicit through `extend`, in a dedicated
`immut/array/extends.mbt` shim. This mirrors the merged reference migration for `deque`
(#3849). The type is `T[A]`.

Trait promotions the library previously relied on implicitly are now either kept as
regular methods (plain `pub extend`) or explicitly deprecated and hidden from the
generated interface. Behavior is unchanged; only the surface of promoted method names is
made explicit.

## Promote / deprecate split

| Trait method(s) | Action | Rationale |
| --- | --- | --- |
| `Add::{add}` | Promote | Arithmetic operator trait — keep all methods promoted |
| `Compare::{compare}` | Promote | Compare: promote only `compare` |
| `@quickcheck.Arbitrary::{arbitrary}` | Deprecate | Use the `Arbitrary` trait instead |
| `Compare::{op_ge, op_gt, op_le, op_lt}` | Deprecate | Use the comparison operators (`<`, `<=`, `>=`, `>`) instead |
| `Eq::{equal, not_equal}` | Deprecate | Use `==` / `!=` instead |
| `Hash::{hash, hash_combine}` | Deprecate | Use the `Hash` trait instead |
| `Show::{output, to_string}` | Deprecate | Use `@debug.Debug` instead of `Show` for collections |

## Policy notes

- Operator traits (here `Add`) keep all their methods promoted.
- `Compare` promotes only `compare`; the relational operators are deprecated.
- `T[A]` is a collection — its `impl Show` is already `#deprecated` on `main` — so **both**
  `Show::output` and `Show::to_string` are deprecated.
- Deprecated `extend`s use `#deprecated(..., skip_current_package=true)` + `#doc(hidden)`,
  so they stay out of the generated interface and do not warn inside the package.
- The package imports no `@json`, so there are no `ToJson`/`FromJson` promotions.
- No in-package callers of the newly deprecated methods required migration.

## Verification

- `moon check --deny-warn --target all` — clean (0 warnings, 0 errors) on all four backends.
- `moon test --target all` — green (wasm / wasm-gc / js: 106 passed; native: 97 passed).
- `moon info` regenerated `pkg.generated.mbti`; it gains only the two promoted methods
  (`T::add`, `T::compare`). Deprecated promotions remain hidden.
- Scoped entirely to `immut/array/`.

Signed-off-by: Codex CLI <codex@openai.com>
