### PR TITLE
feat(sorted_set): make trait promotions explicit via extend

### DIFF
--- a/sorted_set/extends.mbt
+++ b/sorted_set/extends.mbt
@@ -1,0 +1,40 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend SortedSet with Default::{default}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the `@debug.Debug` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with Show::{output, to_string}

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -10,3 +10,5 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/sorted_set/pkg.generated.mbti
+++ b/sorted_set/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub fn[V : Compare] SortedSet::contains(Self[V], V) -> Bool
 #alias(clone, deprecated)
 #alias(deep_clone, deprecated)
 pub fn[V] SortedSet::copy(Self[V]) -> Self[V]
+pub fn[K] SortedSet::default() -> Self[K]
 #alias(diff, deprecated)
 pub fn[V : Compare] SortedSet::difference(Self[V], Self[V]) -> Self[V]
 pub fn[V : Compare] SortedSet::disjoint(Self[V], Self[V]) -> Bool


### PR DESCRIPTION
## Summary

Enable the `implicit_impl_as_method` warning (E0079) for the `sorted_set` package and make its
previously-implicit trait-impl promotions explicit via `extend`, in a dedicated
`sorted_set/extends.mbt` shim. This continues the per-package migration off implicit method
promotion (see #3849 for deque, plus #3851 queue, #3852 list, #3853 priority_queue).

The `SortedSet` type is a collection (its `impl Show` is already `#deprecated` on main), so both
`Show` methods are deprecated rather than promoted. This top-level `sorted_set` does not implement
Compare/Sub/Hash/ToJson/FromJson, so only the traits below are flagged by the compiler.

## Promote / deprecate

| Trait::methods | Disposition | Reason |
| --- | --- | --- |
| `Default::{default}` | Promote | plain `pub extend`, stays in the public interface |
| `@quickcheck.Arbitrary::{arbitrary}` | Deprecate | use the `Arbitrary` trait |
| `@debug.Debug::{to_repr}` | Deprecate | use the `@debug.Debug` trait |
| `Eq::{equal, not_equal}` | Deprecate | use `==` / `!=` |
| `Show::{output, to_string}` | Deprecate | use `@debug.Debug` instead of `Show` for collections |

## Policy

- Promote: arithmetic/bitwise operator traits (all methods), `Compare::{compare}` only,
  `Default`/`ToStringView`/`Logger` (all methods), and for a non-collection `Show` only `to_string`.
- Deprecate: `Compare` comparison operators, `Eq::{equal, not_equal}`, `Hash::{hash, hash_combine}`,
  `@quickcheck.Arbitrary::{arbitrary}`, `@json.FromJson`/`ToJson`, `@debug.Debug`, and for a
  collection type both `Show::{output, to_string}`.

Deprecated promotions use `#deprecated(..., skip_current_package=true)` + `#doc(hidden)` so they
remain callable within the package but are hidden from the generated interface and warn external
callers.

## Verification

- `moon check --deny-warn --target all` — clean (0 warnings, 0 errors); no callers broke.
- `moon test -p sorted_set --target all` — 56 tests pass on wasm, wasm-gc, js, native.
- `sorted_set/pkg.generated.mbti` gains only `SortedSet::default()`; no deprecated method leaks.
- Scoped to `sorted_set/` only.

Signed-off-by: Codex CLI <codex@openai.com>
