### PR TITLE
feat(uint): make trait promotions explicit via extend

### DIFF
--- a/uint/extends.mbt
+++ b/uint/extends.mbt
@@ -1,0 +1,18 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend UInt with Default::{default}

--- a/uint/moon.pkg
+++ b/uint/moon.pkg
@@ -5,3 +5,5 @@ import {
 import {
   "moonbitlang/core/buffer",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/uint/pkg.generated.mbti
+++ b/uint/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub let min_value : UInt
 // Errors
 
 // Types and methods
+pub fn UInt::default() -> UInt
 pub fn UInt::to_int64(UInt) -> Int64
 pub impl Default for UInt
 


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`uint`** only.

It enables `implicit_impl_as_method` (E0079) in `uint/moon.pkg` and makes its sole trait-impl promotion explicit via `extend`:

| Promote — plain `pub extend` |
|---|
| `Default` |

`UInt`'s only compiler-flagged promotion is `Default` (its arithmetic operators are not trait-impl promotions), so nothing is deprecated. `pkg.generated.mbti` gains only `UInt::default`. 3 files, scoped to `uint/`.

## Verification
- `moon check --deny-warn --target all` — clean (zero warnings).
- `moon test --target all` — green on all four backends.
