### PR TITLE
feat(sorted_map): make trait promotions explicit via extend

### DIFF
--- a/sorted_map/extends.mbt
+++ b/sorted_map/extends.mbt
@@ -1,0 +1,50 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend SortedMap with Default::{default}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `@json.from_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with @json.FromJson::{from_json}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with ToJson::{to_json}

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -284,7 +284,7 @@ test "to_json with non-empty map" {
     (2, "two"),
     (0, "zero"),
   ])
-  @json.json_inspect(map.to_json(), content={
+  @json.json_inspect(@json.to_json(map), content={
     "0": "zero",
     "1": "one",
     "2": "two",
@@ -296,7 +296,7 @@ test "to_json with non-empty map" {
 ///|
 test "to_json with empty map" {
   let map : @sorted_map.SortedMap[Int, String] = SortedMap([])
-  @json.json_inspect(map.to_json(), content=Json::empty_object())
+  @json.json_inspect(@json.to_json(map), content=Json::empty_object())
 }
 
 ///|
@@ -309,7 +309,7 @@ test "default" {
 test "from_json" {
   for
     xs in (@quickcheck.samples(20) : Array[@sorted_map.SortedMap[String, Int]]) {
-    @debug.assert_eq(xs, @json.from_json(xs.to_json()))
+    @debug.assert_eq(xs, @json.from_json(@json.to_json(xs)))
   }
 }
 

--- a/sorted_map/moon.pkg
+++ b/sorted_map/moon.pkg
@@ -11,3 +11,5 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub fn[K, V] SortedMap::clear(Self[K, V]) -> Unit
 pub fn[K : Compare, V] SortedMap::contains(Self[K, V], K) -> Bool
 #alias(clone, deprecated)
 pub fn[K, V] SortedMap::copy(Self[K, V]) -> Self[K, V]
+pub fn[K, V] SortedMap::default() -> Self[K, V]
 pub fn[K, V] SortedMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
 pub fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
 #alias(from_iterator, deprecated)


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`sorted_map`** only.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Default` | `@quickcheck.Arbitrary`, `@debug.Debug`, `Eq`, `@json.FromJson`, the whole **`Show`** trait, `ToJson` |

- **`Show` is deprecated for collections** — `SortedMap`'s `Show` impl is already `#deprecated` on `main` (→ `@debug.Debug`).
- **`ToJson`/`FromJson`** point to the `@json.to_json` / `@json.from_json` free functions; each deprecation message names the concrete replacement.
- **`#doc(hidden)`** on all deprecations, so `pkg.generated.mbti` gains only `SortedMap::default`.

Migrates sorted_map's own blackbox test off the now-deprecated `.to_json()` (→ `@json.to_json(...)`). Scoped to `sorted_map/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/sorted_map --target all` — green (87×4).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
