### PR TITLE
feat(set): make trait promotions explicit via extend

### DIFF
--- a/set/README.mbt.md
+++ b/set/README.mbt.md
@@ -215,14 +215,14 @@ Sets can be serialized to JSON as arrays:
 ///|
 test "json serialization" {
   let set = @set.Set([1, 2, 3])
-  let json = set.to_json()
+  let json = @json.to_json(set)
 
   // JSON representation is an array
   @debug.debug_inspect(json, content="Array([Number(1), Number(2), Number(3)])")
 
   // String set
   let string_set = @set.Set(["a", "b", "c"])
-  let string_json = string_set.to_json()
+  let string_json = @json.to_json(string_set)
   @debug.debug_inspect(
     string_json,
     content="Array([String(\"a\"), String(\"b\"), String(\"c\")])",

--- a/set/extends.mbt
+++ b/set/extends.mbt
@@ -1,0 +1,52 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend Set with BitAnd::{land}
+
+///|
+pub extend Set with BitOr::{lor}
+
+///|
+pub extend Set with BitXOr::{lxor}
+
+///|
+pub extend Set with Default::{default}
+
+///|
+pub extend Set with Sub::{sub}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Set with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Set with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend Set with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Set with ToJson::{to_json}

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -22,6 +22,9 @@ struct Key {
 } derive(Eq)
 
 ///|
+pub extend Key with Eq::{equal, not_equal}
+
+///|
 impl Hash for Key with fn hash_combine(self, hasher) {
   hasher.combine_int(self.hash_value)
 }

--- a/set/moon.pkg
+++ b/set/moon.pkg
@@ -9,3 +9,5 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub fn[K] Set::clear(Self[K]) -> Unit
 pub fn[K : Hash + Eq] Set::contains(Self[K], K) -> Bool
 #alias(clone, deprecated)
 pub fn[K] Set::copy(Self[K]) -> Self[K]
+pub fn[K] Set::default() -> Self[K]
 pub fn[K : Hash + Eq] Set::difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] Set::each(Self[K], (K) -> Unit raise?) -> Unit raise?
 pub fn[K] Set::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
@@ -38,13 +39,17 @@ pub fn[K : Hash + Eq] Set::is_subset(Self[K], Self[K]) -> Bool
 pub fn[K : Hash + Eq] Set::is_superset(Self[K], Self[K]) -> Bool
 #alias(iterator, deprecated)
 pub fn[K] Set::iter(Self[K]) -> Iter[K]
+pub fn[K : Hash + Eq] Set::land(Self[K], Self[K]) -> Self[K]
 #alias(size, deprecated)
 pub fn[K] Set::length(Self[K]) -> Int
+pub fn[K : Hash + Eq] Set::lor(Self[K], Self[K]) -> Self[K]
+pub fn[K : Hash + Eq] Set::lxor(Self[K], Self[K]) -> Self[K]
 #as_free_fn(deprecated)
 #deprecated
 pub fn[K] Set::new(capacity? : Int) -> Self[K]
 pub fn[K : Hash + Eq] Set::remove(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] Set::remove_and_check(Self[K], K) -> Bool
+pub fn[K : Hash + Eq] Set::sub(Self[K], Self[K]) -> Self[K]
 pub fn[K : Hash + Eq] Set::symmetric_difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] Set::to_array(Self[K]) -> Array[K]
 pub fn[K : Hash + Eq] Set::union(Self[K], Self[K]) -> Self[K]


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`set`** only.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `BitAnd` (`&`), `BitOr` (`\|`), `BitXOr` (`^`), `Sub` (`-`), `Default` | `@debug.Debug`, `Eq`, the whole **`Show`** trait, `ToJson` |

- **Set-algebra operators** (`&`/`\|`/`^`/`-` = intersection/union/symmetric-difference/difference) are promoted per the arithmetic-operator policy (`.land()`/`.lor()`/… stay callable), unlike `Compare`'s `op_*`.
- **`Show`** is deprecated (Set is a collection; its `Show` impl is already `#deprecated` on `main`); **`ToJson`** → the free `@json.to_json`. Each message names the concrete replacement.
- The blackbox-test-only `Key` struct (`derive(Eq)`) gets an inline `pub extend Key with Eq` in the test file (test types can't be named from the source shim).
- `#doc(hidden)` on all deprecations, so `pkg.generated.mbti` gains only `Set::{land, lor, lxor, sub, default}`.

Migrates set's README doc examples off the now-deprecated `.to_json()` → `@json.to_json(...)`. Scoped to `set/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/set --target all` — green (65×4).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
