### PR TITLE
feat(hashset): make trait promotions explicit via extend

### DIFF
--- a/hashset/extends.mbt
+++ b/hashset/extends.mbt
@@ -1,0 +1,47 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend HashSet with BitAnd::{land}
+
+///|
+pub extend HashSet with BitOr::{lor}
+
+///|
+pub extend HashSet with BitXOr::{lxor}
+
+///|
+pub extend HashSet with Default::{default}
+
+///|
+pub extend HashSet with Sub::{sub}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for debugging purposes. See https://github.com/moonbitlang/core/blob/main/debug/README.mbt.md", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with ToJson::{to_json}

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -84,7 +84,7 @@ test "copy" {
 test "to_json" {
   let data = [1, 2, 3]
   let set = @hashset.from_array([1, 2, 3])
-  let json = set.to_json()
+  let json = @json.to_json(set)
   guard json is Array(array) else { fail("Expected JSON array") }
   for item in data {
     assert_true(array.contains(item.to_json()))

--- a/hashset/moon.pkg
+++ b/hashset/moon.pkg
@@ -11,3 +11,5 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/json",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -26,6 +26,7 @@ pub fn[K] HashSet::clear(Self[K]) -> Unit
 pub fn[K : Hash + Eq] HashSet::contains(Self[K], K) -> Bool
 #alias(clone, deprecated)
 pub fn[K] HashSet::copy(Self[K]) -> Self[K]
+pub fn[K] HashSet::default() -> Self[K]
 pub fn[K : Hash + Eq] HashSet::difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] HashSet::each(Self[K], (K) -> Unit raise?) -> Unit raise?
 pub fn[K] HashSet::eachi(Self[K], (Int, K) -> Unit raise?) -> Unit raise?
@@ -40,14 +41,18 @@ pub fn[K : Hash + Eq] HashSet::is_subset(Self[K], Self[K]) -> Bool
 pub fn[K : Hash + Eq] HashSet::is_superset(Self[K], Self[K]) -> Bool
 #alias(iterator, deprecated)
 pub fn[K] HashSet::iter(Self[K]) -> Iter[K]
+pub fn[K : Hash + Eq] HashSet::land(Self[K], Self[K]) -> Self[K]
 #alias(size, deprecated)
 pub fn[K] HashSet::length(Self[K]) -> Int
+pub fn[K : Hash + Eq] HashSet::lor(Self[K], Self[K]) -> Self[K]
+pub fn[K : Hash + Eq] HashSet::lxor(Self[K], Self[K]) -> Self[K]
 #as_free_fn(deprecated)
 #deprecated
 pub fn[K] HashSet::new(capacity? : Int) -> Self[K]
 pub fn[K : Hash + Eq] HashSet::remove(Self[K], K) -> Unit
 pub fn[K : Hash + Eq] HashSet::remove_and_check(Self[K], K) -> Bool
 pub fn[K] HashSet::retain(Self[K], (K) -> Bool) -> Unit
+pub fn[K : Hash + Eq] HashSet::sub(Self[K], Self[K]) -> Self[K]
 pub fn[K : Hash + Eq] HashSet::symmetric_difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] HashSet::to_array(Self[K]) -> Array[K]
 #deprecated


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`hashset`** only.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `BitAnd` (`&`), `BitOr` (`\|`), `BitXOr` (`^`), `Sub` (`-`), `Default` | `@quickcheck.Arbitrary`, the whole **`Show`** trait, `ToJson` |

- **Set-algebra operators** promoted per the arithmetic-operator policy; **`Show`** deprecated (HashSet is a collection); **`ToJson`** → the free `@json.to_json`. Each message names the concrete replacement.
- `#doc(hidden)` on deprecations, so `pkg.generated.mbti` gains only `HashSet::{land, lor, lxor, sub, default}`.
- Migrates the blackbox test off a HashSet `.to_json()` → `@json.to_json(...)` (element-level `.to_json()` stays as trait dispatch). Scoped to `hashset/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/hashset --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
