### PR TITLE
feat(immut/hashmap): make trait promotions explicit via extend

### DIFF
--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -351,11 +351,11 @@ test "eq for random cases with different types" {
 test "hash" {
   let map1 = @hashmap.HashMap([("one", 1), ("two", 2)])
   let map2 = @hashmap.HashMap([("one", 1), ("two", 2)])
-  inspect(map1.hash() == map2.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map2), content="true")
   let map3 = @hashmap.HashMap([("two", 2), ("one", 1)])
-  inspect(map1.hash() == map3.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map3), content="true")
   let map4 = @hashmap.HashMap([("one", 1), ("two", 2), ("three", 3)])
-  inspect(map1.hash() == map4.hash(), content="false")
+  inspect(Hash::hash(map1) == Hash::hash(map4), content="false")
 }
 
 ///|
@@ -1045,7 +1045,7 @@ test "equal imply hash equal when collision" {
   let ma = @hashmap.new().add(s1, 1).add(s2, 2)
   let mb = @hashmap.new().add(s2, 2).add(s1, 1)
   inspect(ma == mb, content="true")
-  inspect(ma.hash() == mb.hash(), content="true")
+  inspect(Hash::hash(ma) == Hash::hash(mb), content="true")
 }
 
 ///|

--- a/immut/hashmap/extends.mbt
+++ b/immut/hashmap/extends.mbt
@@ -1,0 +1,37 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// HashMap has no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with Show::{output, to_string}

--- a/immut/hashmap/moon.pkg
+++ b/immut/hashmap/moon.pkg
@@ -15,3 +15,5 @@ import {
   "moonbitlang/core/option",
   "moonbitlang/core/test",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`immut/hashmap`** only.

`HashMap` has **no methods worth keeping promoted** — the compiler flags only these, all deprecated:

| Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|
| `@quickcheck.Arbitrary`, `Eq`, `Hash`, the whole **`Show`** trait |

- **`Show`** deprecated (HashMap is a collection); each message names the concrete replacement.
- `#doc(hidden)` on all, so `pkg.generated.mbti` is **unchanged**.
- Migrates the blackbox test off the now-deprecated `.hash()` → `Hash::hash(...)`. Scoped to `immut/hashmap/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/hashmap --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
