### PR TITLE
feat(immut/sorted_set): make trait promotions explicit via extend

### DIFF
--- a/immut/sorted_set/extends.mbt
+++ b/immut/sorted_set/extends.mbt
@@ -1,0 +1,51 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend SortedSet with Compare::{compare}
+
+///|
+pub extend SortedSet with Default::{default}
+
+///|
+pub extend SortedSet with Sub::{sub}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with Show::{output, to_string}

--- a/immut/sorted_set/moon.pkg
+++ b/immut/sorted_set/moon.pkg
@@ -11,6 +11,8 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -18,7 +18,9 @@ pub fn[A : Compare] SortedSet::SortedSet(ArrayView[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::add(Self[A], A) -> Self[A]
 pub fn[A] SortedSet::all(Self[A], (A) -> Bool raise?) -> Bool raise?
 pub fn[A] SortedSet::any(Self[A], (A) -> Bool raise?) -> Bool raise?
+pub fn[A : Compare] SortedSet::compare(Self[A], Self[A]) -> Int
 pub fn[A : Compare] SortedSet::contains(Self[A], A) -> Bool
+pub fn[A] SortedSet::default() -> Self[A]
 #alias(diff, deprecated)
 pub fn[A : Compare] SortedSet::difference(Self[A], Self[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::disjoint(Self[A], Self[A]) -> Bool
@@ -58,6 +60,7 @@ pub fn[A] SortedSet::rev_iter(Self[A]) -> Iter[A]
 #as_free_fn
 pub fn[A] SortedSet::singleton(A) -> Self[A]
 pub fn[A : Compare] SortedSet::split(Self[A], A) -> (Self[A], Bool, Self[A])
+pub fn[A : Compare] SortedSet::sub(Self[A], Self[A]) -> Self[A]
 pub fn[A : Compare] SortedSet::subset(Self[A], Self[A]) -> Bool
 pub fn[A : Compare] SortedSet::symmetric_difference(Self[A], Self[A]) -> Self[A]
 pub fn[A] SortedSet::to_array(Self[A]) -> Array[A]


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`immut/sorted_set`** only.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Compare::{compare}`, `Default`, `Sub` (`-`) | `@quickcheck.Arbitrary`, `Compare::{op_ge, op_gt, op_le, op_lt}`, `Eq`, `Hash`, the whole **`Show`** trait |

- **Only `compare`** promoted from `Compare`; **`Sub`** (set difference) promoted per operator policy; **`Show`** deprecated (collection). Each message names the concrete replacement.
- `#doc(hidden)` on deprecations, so `pkg.generated.mbti` gains only `SortedSet::{compare, default, sub}`. No caller migration needed. Scoped to `immut/sorted_set/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/sorted_set --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
