### PR TITLE
chore(extend): align deprecation messages to concrete wording

### DIFF
--- a/deque/extends.mbt
+++ b/deque/extends.mbt
@@ -33,12 +33,12 @@ pub extend Deque with Compare::{op_ge, op_gt, op_le, op_lt}
 pub extend Deque with Eq::{equal, not_equal}
 
 ///|
-#deprecated("Use the `FromJson` trait instead", skip_current_package=true)
+#deprecated("Use `@json.from_json` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Deque with @json.FromJson::{from_json}
 
 ///|
-#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Deque with Hash::{hash, hash_combine}
 

--- a/hashmap/extends.mbt
+++ b/hashmap/extends.mbt
@@ -20,7 +20,7 @@ pub extend HashMap with Default::{default}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
-#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend HashMap with @quickcheck.Arbitrary::{arbitrary}
 

--- a/list/extends.mbt
+++ b/list/extends.mbt
@@ -23,7 +23,7 @@ pub extend List with Default::{default}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
-#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend List with @quickcheck.Arbitrary::{arbitrary}
 
@@ -38,7 +38,7 @@ pub extend List with Compare::{op_ge, op_gt, op_le, op_lt}
 pub extend List with Eq::{equal, not_equal}
 
 ///|
-#deprecated("Use the `Hash` trait instead", skip_current_package=true)
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
 #doc(hidden)
 pub extend List with Hash::{hash, hash_combine}
 

--- a/priority_queue/extends.mbt
+++ b/priority_queue/extends.mbt
@@ -20,7 +20,7 @@ pub extend PriorityQueue with Default::{default}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
-#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend PriorityQueue with @quickcheck.Arbitrary::{arbitrary}
 

--- a/sorted_set/extends.mbt
+++ b/sorted_set/extends.mbt
@@ -20,7 +20,7 @@ pub extend SortedSet with Default::{default}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
-#deprecated("Use the `Arbitrary` trait instead", skip_current_package=true)
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend SortedSet with @quickcheck.Arbitrary::{arbitrary}
 


### PR DESCRIPTION
## Summary

Follow-up to the per-package `implicit_impl_as_method` migration. The five earliest-migrated packages (**deque, list, priority_queue, hashmap, sorted_set**) shipped with the pre-canonical *"Use the `X` trait instead"* deprecation wording. This aligns them with the **concrete wording** adopted for the rest of the series (per the Copilot review), so every package's deprecation warning names the exact replacement:

| Trait | Message |
|---|---|
| `Hash` | Use `Hash::hash` / `Hash::hash_combine` instead |
| `@quickcheck.Arbitrary` | Use `@quickcheck.Arbitrary::arbitrary` instead |
| `@json.FromJson` | Use `@json.from_json` instead |

**Message strings only** — no logic, no `extend` coverage change, `#doc(hidden)` intact, and `pkg.generated.mbti` is unchanged for all five packages. The deprecated methods stay callable.

## Verification
- `moon check --deny-warn --target all` — clean.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
