### PR TITLE
feat(immut/hashset): make trait promotions explicit via extend

### DIFF
--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -304,6 +304,9 @@ test "HAMT::union with branch" {
 struct MyString(String) derive(@debug.Debug)
 
 ///|
+pub extend MyString with @debug.Debug::{to_repr}
+
+///|
 impl Hash for MyString with fn hash_combine(_self, hasher) {
   hasher.combine(1)
 }

--- a/immut/hashset/extends.mbt
+++ b/immut/hashset/extends.mbt
@@ -1,0 +1,37 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// HashSet has no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with Show::{output, to_string}

--- a/immut/hashset/moon.pkg
+++ b/immut/hashset/moon.pkg
@@ -14,3 +14,5 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/test",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`immut/hashset`** only.

`HashSet` has **no methods worth keeping promoted** — all flagged impls are deprecated:

| Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|
| `@quickcheck.Arbitrary`, `Eq`, `Hash`, the whole **`Show`** trait |

- **`Show`** deprecated (HashSet is a collection); each message names the concrete replacement.
- `#doc(hidden)` on all, so `pkg.generated.mbti` is **unchanged**.
- The blackbox-test-only `MyString` struct (`derive(@debug.Debug)`) gets an inline `pub extend MyString with @debug.Debug` in the test file. Scoped to `immut/hashset/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/hashset --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
