### PR TITLE
feat(immut/vector): make trait promotions explicit via extend

### DIFF
--- a/immut/vector/extends.mbt
+++ b/immut/vector/extends.mbt
@@ -1,0 +1,58 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend Vector with Add::{add}
+
+///|
+pub extend Vector with Compare::{compare}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `@json.from_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with @json.FromJson::{from_json}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with ToJson::{to_json}

--- a/immut/vector/moon.pkg
+++ b/immut/vector/moon.pkg
@@ -16,6 +16,8 @@ import {
   "moonbitlang/core/test",
 } for "wbtest"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: {
     "panic_test.mbt": [ "not", "native", "llvm" ],

--- a/immut/vector/pkg.generated.mbti
+++ b/immut/vector/pkg.generated.mbti
@@ -19,8 +19,10 @@ type Vector[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A] Vector::Vector(ArrayView[A]) -> Self[A]
+pub fn[A] Vector::add(Self[A], Self[A]) -> Self[A]
 #alias("_[_]")
 pub fn[A] Vector::at(Self[A], Int) -> A
+pub fn[A : Compare] Vector::compare(Self[A], Self[A]) -> Int
 pub fn[A] Vector::concat(Self[A], Self[A]) -> Self[A]
 pub fn[A : Eq] Vector::contains(Self[A], A) -> Bool
 #alias(clone, deprecated)

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -113,7 +113,7 @@ test "to_json" {
 ///|
 test "from_json" {
   for xs in (@quickcheck.samples(20) : Array[@vector.Vector[Int]]) {
-    @debug.assert_eq(xs, @json.from_json(xs.to_json()))
+    @debug.assert_eq(xs, @json.from_json(@json.to_json(xs)))
   }
 }
 
@@ -705,12 +705,12 @@ test "from_iter empty iter" {
 test "hash" {
   let l1 = @vector.from_array([1, 2, 3, 4, 5])
   let l2 = @vector.from_array([1, 2, 3, 4, 5])
-  inspect(l1.hash() == l2.hash(), content="true")
+  inspect(Hash::hash(l1) == Hash::hash(l2), content="true")
   let l3 = @vector.from_array([5, 4, 3, 2, 1])
-  inspect(l1.hash() == l3.hash(), content="false")
+  inspect(Hash::hash(l1) == Hash::hash(l3), content="false")
   let l4 : @vector.Vector[Int] = @vector.from_array([])
-  inspect(l1.hash() == l4.hash(), content="false")
-  inspect(l4.hash() == l4.hash(), content="true")
+  inspect(Hash::hash(l1) == Hash::hash(l4), content="false")
+  inspect(Hash::hash(l4) == Hash::hash(l4), content="true")
 }
 
 ///|


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`immut/vector`** only.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Add` (`+`), `Compare::{compare}` | `@quickcheck.Arbitrary`, `Compare::{op_ge, op_gt, op_le, op_lt}`, `Eq`, `@json.FromJson`, `Hash`, the whole **`Show`** trait, `ToJson` |

- **`Add`** (vector concatenation) promoted per operator policy; **only `compare`** from `Compare`; **`Show`** deprecated (collection); `ToJson`/`FromJson` → the `@json` free functions. Each message names the concrete replacement.
- `#doc(hidden)` on deprecations, so `pkg.generated.mbti` gains only `Vector::{add, compare}`.
- Migrates the blackbox test off deprecated `.hash()` / `.to_json()` → `Hash::hash(...)` / `@json.to_json(...)`. Scoped to `immut/vector/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/vector --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
