### PR TITLE
feat(immut/priority_queue): make trait promotions explicit via extend

### DIFF
--- a/immut/priority_queue/extends.mbt
+++ b/immut/priority_queue/extends.mbt
@@ -1,0 +1,50 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend PriorityQueue with Compare::{compare}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with Show::{output, to_string}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with ToJson::{to_json}

--- a/immut/priority_queue/moon.pkg
+++ b/immut/priority_queue/moon.pkg
@@ -12,6 +12,8 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -18,6 +18,7 @@ type PriorityQueue[A]
 #as_free_fn(of, deprecated)
 #as_free_fn(from_array)
 pub fn[A : Compare] PriorityQueue::PriorityQueue(ArrayView[A]) -> Self[A]
+pub fn[A : Compare] PriorityQueue::compare(Self[A], Self[A]) -> Int
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
 #as_free_fn

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -185,14 +185,14 @@ test "from_iter empty iter" {
 test "hash" {
   let pq1 = @priority_queue.from_array([1, 2, 3, 4, 5])
   let pq2 = @priority_queue.from_array([1, 2, 3, 4, 5])
-  inspect(pq1.hash() == pq2.hash(), content="true")
+  inspect(Hash::hash(pq1) == Hash::hash(pq2), content="true")
   let pq3 = @priority_queue.from_array([5, 4, 3, 2, 1])
-  inspect(pq1.hash() == pq3.hash(), content="true")
+  inspect(Hash::hash(pq1) == Hash::hash(pq3), content="true")
   let pq4 : @priority_queue.PriorityQueue[Int] = PriorityQueue([])
-  inspect(pq1.hash() == pq4.hash(), content="false")
-  inspect(pq4.hash() == pq4.hash(), content="true")
+  inspect(Hash::hash(pq1) == Hash::hash(pq4), content="false")
+  inspect(Hash::hash(pq4) == Hash::hash(pq4), content="true")
   let pq5 = @priority_queue.from_array([1, 2, 3, 4, 6])
-  inspect(pq1.hash() == pq5.hash(), content="false")
+  inspect(Hash::hash(pq1) == Hash::hash(pq5), content="false")
 }
 
 ///|
@@ -258,6 +258,6 @@ test "compare" {
 test "to_json" {
   let pq = @priority_queue.from_array([1, 2, 3])
   @json.json_inspect(pq.peek().unwrap(), content=3)
-  let json = pq.to_json()
+  let json = @json.to_json(pq)
   @json.json_inspect(json, content=[3, 2, 1])
 }


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`immut/priority_queue`** only.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Compare::{compare}` | `@quickcheck.Arbitrary`, `Compare::{op_ge, op_gt, op_le, op_lt}`, `Eq`, `Hash`, the whole **`Show`** trait, `ToJson` |

- **Only `compare`** promoted; **`Show`** deprecated (collection); `ToJson` → the free `@json.to_json`. Each message names the concrete replacement.
- `#doc(hidden)` on deprecations, so `pkg.generated.mbti` gains only `PriorityQueue::compare`.
- Migrates the blackbox test off deprecated `.hash()` / `.to_json()`. Scoped to `immut/priority_queue/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/priority_queue --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
