### PR TITLE
feat(immut/sorted_map): make trait promotions explicit via extend

### DIFF
--- a/immut/sorted_map/extends.mbt
+++ b/immut/sorted_map/extends.mbt
@@ -1,0 +1,48 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend SortedMap with Compare::{compare}
+
+///|
+pub extend SortedMap with Default::{default}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with Show::{output, to_string}

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -270,11 +270,11 @@ test "from_iter empty iter" {
 test "hash" {
   let map1 = @sorted_map.SortedMap([("one", 1), ("two", 2)])
   let map2 = @sorted_map.SortedMap([("one", 1), ("two", 2)])
-  inspect(map1.hash() == map2.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map2), content="true")
   let map3 = @sorted_map.SortedMap([("two", 2), ("one", 1)])
-  inspect(map1.hash() == map3.hash(), content="true")
+  inspect(Hash::hash(map1) == Hash::hash(map3), content="true")
   let map4 = @sorted_map.SortedMap([("one", 1), ("two", 2), ("three", 3)])
-  inspect(map1.hash() == map4.hash(), content="false")
+  inspect(Hash::hash(map1) == Hash::hash(map4), content="false")
 }
 
 ///|

--- a/immut/sorted_map/moon.pkg
+++ b/immut/sorted_map/moon.pkg
@@ -13,6 +13,8 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: { "panic_wbtest.mbt": [ "not", "native", "llvm" ] },
 )

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -19,7 +19,9 @@ pub fn[K : Compare, V] SortedMap::SortedMap(ArrayView[(K, V)]) -> Self[K, V]
 pub fn[K : Compare, V] SortedMap::add(Self[K, V], K, V) -> Self[K, V]
 #alias("_[_]")
 pub fn[K : Compare, V] SortedMap::at(Self[K, V], K) -> V
+pub fn[K : Compare, V : Compare] SortedMap::compare(Self[K, V], Self[K, V]) -> Int
 pub fn[K : Compare, V] SortedMap::contains(Self[K, V], K) -> Bool
+pub fn[K, V] SortedMap::default() -> Self[K, V]
 pub fn[K, V] SortedMap::each(Self[K, V], (K, V) -> Unit) -> Unit
 pub fn[K, V] SortedMap::eachi(Self[K, V], (Int, K, V) -> Unit) -> Unit
 #deprecated


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`immut/sorted_map`** only — the last of the `immut/*` collections.

| Promote — plain `pub extend` | Deprecate — `#deprecated(…, skip_current_package=true)` + `#doc(hidden)` |
|---|---|
| `Compare::{compare}`, `Default` | `@quickcheck.Arbitrary`, `Compare::{op_ge, op_gt, op_le, op_lt}`, `Eq`, `Hash`, the whole **`Show`** trait |

- **Only `compare`** promoted; **`Show`** deprecated (collection). Each message names the concrete replacement. `SortedMap` has concrete `to_json`/`from_json` methods (not trait promotions), so no `ToJson`/`FromJson` extend is needed.
- `#doc(hidden)` on deprecations, so `pkg.generated.mbti` gains only `SortedMap::{compare, default}`.
- Migrates the blackbox test off deprecated `.hash()` → `Hash::hash(...)`. Scoped to `immut/sorted_map/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/sorted_map --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
