### PR TITLE
feat(lazy_list): make trait promotions explicit via extend

### DIFF
--- a/lazy_list/extends.mbt
+++ b/lazy_list/extends.mbt
@@ -1,0 +1,22 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// LazyList has no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend LazyList with @debug.Debug::{to_repr}

--- a/lazy_list/moon.pkg
+++ b/lazy_list/moon.pkg
@@ -8,3 +8,5 @@ import {
 import {
   "moonbitlang/core/list",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`lazy_list`** only.

`LazyList`'s only compiler-flagged promotion is `@debug.Debug`, which is deprecated (`#deprecated(…, skip_current_package=true)` + `#doc(hidden)`, → `Debug::to_repr`). No promotions; `pkg.generated.mbti` is **unchanged**. 2 files, scoped to `lazy_list/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/lazy_list --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
