### PR TITLE
feat(ref): make trait promotions explicit via extend

### DIFF
--- a/ref/extends.mbt
+++ b/ref/extends.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Ref has no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Ref with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show`", skip_current_package=true)
+#doc(hidden)
+pub extend Ref with Show::{output, to_string}

--- a/ref/moon.pkg
+++ b/ref/moon.pkg
@@ -7,3 +7,5 @@ import {
 import {
   "moonbitlang/core/test",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the **per-package series** migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). This one covers **`ref`** only.

`Ref` has **no methods worth keeping promoted** — the compiler flags only `@quickcheck.Arbitrary` and `Show` (its `Show` impl is already `#deprecated` on `main`), both deprecated (`#deprecated(…, skip_current_package=true)` + `#doc(hidden)`) with concrete replacement wording. No promotions; `pkg.generated.mbti` is **unchanged**. 2 files, scoped to `ref/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/ref --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
