### PR TITLE
feat(encoding/utf16): make trait promotions explicit via extend

### DIFF
--- a/encoding/utf16/extends.mbt
+++ b/encoding/utf16/extends.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Endian and Malformed have no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Endian with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Malformed with @debug.Debug::{to_repr}

--- a/encoding/utf16/moon.pkg
+++ b/encoding/utf16/moon.pkg
@@ -7,3 +7,5 @@ import {
 import {
   "moonbitlang/core/bench",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series (see #3849). Covers **`encoding/utf16`** only.

Both the `Endian` and `Malformed` types have only a `@debug.Debug` promotion, deprecated (`#doc(hidden)`, → `Debug::to_repr`). No promotions; `pkg.generated.mbti` unchanged.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/encoding/utf16 --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
