### PR TITLE
feat(coverage): make trait promotions explicit via extend

### DIFF
--- a/coverage/moon.pkg
+++ b/coverage/moon.pkg
@@ -1,3 +1,5 @@
 import {
   "moonbitlang/core/builtin",
 }
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series (see #3849). Covers **`coverage`** only.

`CoverageCounter` has a genuine (non-deprecated) `Show`, so this is a **split**: `to_string` promoted, `output` deprecated (`#doc(hidden)`). `pkg.generated.mbti` gains only `CoverageCounter::to_string`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/coverage --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
