### PR TITLE
feat(immut/internal/path): make trait promotions explicit via extend

### DIFF
--- a/immut/internal/path/extends.mbt
+++ b/immut/internal/path/extends.mbt
@@ -1,0 +1,22 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Every trait-method promotion below is deprecated (none are kept as regular methods).
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Path with Eq::{equal, not_equal}

--- a/immut/internal/path/moon.pkg
+++ b/immut/internal/path/moon.pkg
@@ -1,3 +1,5 @@
 import {
   "moonbitlang/core/builtin",
 }
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`immut/internal/path`** only.

The compiler flags only Eq for the Path type, which is deprecated in favour of the `==` / `!=` operators (no promotions).

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `immut/internal/path/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/internal/path --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
