### PR TITLE
feat(internal/regex_engine/shared_types/rechar_set): make trait promotions explicit via extend

### DIFF
--- a/internal/regex_engine/shared_types/rechar_set/extends.mbt
+++ b/internal/regex_engine/shared_types/rechar_set/extends.mbt
@@ -1,0 +1,31 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend RecharSet with Add::{add}
+
+///|
+pub extend RecharSet with BitAnd::{land}
+
+///|
+pub extend RecharSet with Sub::{sub}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend RecharSet with @debug.Debug::{to_repr}

--- a/internal/regex_engine/shared_types/rechar_set/moon.pkg
+++ b/internal/regex_engine/shared_types/rechar_set/moon.pkg
@@ -2,3 +2,5 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
+
+warnings = "+implicit_impl_as_method"

--- a/internal/regex_engine/shared_types/rechar_set/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/rechar_set/pkg.generated.mbti
@@ -11,6 +11,7 @@ import {
 
 // Types and methods
 type RecharSet
+pub fn RecharSet::add(Self, Self) -> Self
 pub fn RecharSet::char(Int) -> Self
 pub fn RecharSet::char_range(Int, Int) -> Self
 pub fn RecharSet::contains(Self, Int) -> Bool
@@ -22,8 +23,10 @@ pub fn RecharSet::intersection(Self, Self) -> Self
 pub fn RecharSet::intervals(Self) -> Iter[(Int, Int)]
 pub fn RecharSet::is_empty(Self) -> Bool
 pub fn RecharSet::is_subset(Self, Self) -> Bool
+pub fn RecharSet::land(Self, Self) -> Self
 pub fn RecharSet::last_interval(Self) -> (Int, Int)?
 pub fn RecharSet::offset_by(Self, (Int) -> Int) -> Self
+pub fn RecharSet::sub(Self, Self) -> Self
 pub fn RecharSet::union(Self, Self) -> Self
 pub impl Add for RecharSet
 pub impl BitAnd for RecharSet


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`internal/regex_engine/shared_types/rechar_set`** only.

The compiler flags RecharSet's Add (+), BitAnd (&) and Sub (-) operators (promoted per operator policy) and its @debug.Debug (deprecated).

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `internal/regex_engine/shared_types/rechar_set/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/internal/regex_engine/shared_types/rechar_set --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
