### PR TITLE
feat(internal/regex_engine/shared_types): make trait promotions explicit via extend

### DIFF
--- a/internal/regex_engine/shared_types/extends.mbt
+++ b/internal/regex_engine/shared_types/extends.mbt
@@ -1,0 +1,50 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend Category with Add::{add}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Category with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Category with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Preference with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Preference with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Preference with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend QuantifierMode with @debug.Debug::{to_repr}

--- a/internal/regex_engine/shared_types/moon.pkg
+++ b/internal/regex_engine/shared_types/moon.pkg
@@ -3,3 +3,5 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/internal/regex_engine/shared_types/rechar_set",
 }
+
+warnings = "+implicit_impl_as_method"

--- a/internal/regex_engine/shared_types/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/pkg.generated.mbti
@@ -12,6 +12,7 @@ import {
 
 // Types and methods
 pub struct Category(Int) derive(Eq, Hash)
+pub fn Category::add(Self, Self) -> Self
 pub fn Category::dummy() -> Self
 pub fn Category::inexistant() -> Self
 pub fn Category::inexistant_or_newline() -> Self


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`internal/regex_engine/shared_types`** only.

Three types: Category (Add operator promoted; Eq, Hash deprecated), Preference (@debug.Debug, Eq, Hash deprecated), and QuantifierMode (@debug.Debug deprecated). Only Category::add is promoted.

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `internal/regex_engine/shared_types/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/internal/regex_engine/shared_types --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
