### PR TITLE
feat(bytes/internal/regex_engine): make trait promotions explicit via extend

### DIFF
--- a/bytes/internal/regex_engine/extends.mbt
+++ b/bytes/internal/regex_engine/extends.mbt
@@ -1,0 +1,22 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// MatchResult has no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend MatchResult with @debug.Debug::{to_repr}

--- a/bytes/internal/regex_engine/moon.pkg
+++ b/bytes/internal/regex_engine/moon.pkg
@@ -12,3 +12,5 @@ import {
 import {
   "moonbitlang/core/test",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`bytes/internal/regex_engine`** only.

The compiler flags only @debug.Debug for the MatchResult type, which is deprecated (no promotions).

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `bytes/internal/regex_engine/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/bytes/internal/regex_engine --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
