### PR TITLE
feat(string/internal/regex_engine/ast): make trait promotions explicit via extend

### DIFF
--- a/string/internal/regex_engine/ast/extends.mbt
+++ b/string/internal/regex_engine/ast/extends.mbt
@@ -1,0 +1,38 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Assertion, Pattern, PatternDesc and Quantifier have no promoted trait methods;
+// every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Assertion with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Pattern with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PatternDesc with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Quantifier with @debug.Debug::{to_repr}

--- a/string/internal/regex_engine/ast/moon.pkg
+++ b/string/internal/regex_engine/ast/moon.pkg
@@ -3,3 +3,5 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/internal/regex_engine/shared_types",
 }
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`string/internal/regex_engine/ast`** only.

The compiler flags only @debug.Debug for the Assertion, Pattern, PatternDesc and Quantifier types, all deprecated (no promotions).

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `string/internal/regex_engine/ast/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/string/internal/regex_engine/ast --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
