### PR TITLE
feat(immut/internal/sparse_array): make trait promotions explicit via extend

### DIFF
--- a/immut/internal/sparse_array/extends.mbt
+++ b/immut/internal/sparse_array/extends.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bitset and SparseArray have no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Bitset with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SparseArray with Eq::{equal, not_equal}

--- a/immut/internal/sparse_array/moon.pkg
+++ b/immut/internal/sparse_array/moon.pkg
@@ -3,3 +3,5 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/debug",
 }
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`immut/internal/sparse_array`** only.

The compiler flags only Eq for the Bitset and SparseArray types, both deprecated (no promotions).

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `immut/internal/sparse_array/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/immut/internal/sparse_array --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
