### PR TITLE
feat(string/internal/regex_parser): make trait promotions explicit via extend

### DIFF
--- a/string/internal/regex_parser/extends.mbt
+++ b/string/internal/regex_parser/extends.mbt
@@ -1,0 +1,30 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend ParserError with Show::{to_string}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ParserError with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ParserError with Show::{output}

--- a/string/internal/regex_parser/moon.pkg
+++ b/string/internal/regex_parser/moon.pkg
@@ -3,3 +3,5 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/string/internal/regex_engine" @re,
 }
+
+warnings = "+implicit_impl_as_method"

--- a/string/internal/regex_parser/pkg.generated.mbti
+++ b/string/internal/regex_parser/pkg.generated.mbti
@@ -12,6 +12,7 @@ pub fn parse(profile~ : @shared_types.Profile, mode~ : Mode, StringView) -> @ast
 
 // Errors
 type ParserError derive(@debug.Debug)
+pub fn ParserError::to_string(Self) -> String
 pub impl Show for ParserError
 
 // Types and methods


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`string/internal/regex_parser`** only.

ParserError (a suberror) has a genuine non-deprecated Show, so this is a Show split: Show::to_string is promoted; @debug.Debug and Show::output are deprecated.

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `string/internal/regex_parser/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/string/internal/regex_parser --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
