### PR TITLE
feat(argparse): make trait promotions explicit via extend

### DIFF
--- a/argparse/extends.mbt
+++ b/argparse/extends.mbt
@@ -1,0 +1,119 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend FlagAction with Show::{to_string}
+
+///|
+pub extend OptionAction with Show::{to_string}
+
+///|
+pub extend ValueRange with Show::{to_string}
+
+///|
+pub extend ValueSource with Show::{to_string}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ArgGroup with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Command with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend FlagAction with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend FlagArg with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Matches with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend OptionAction with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend OptionArg with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PositionArg with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ValueRange with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ValueSource with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend FlagAction with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend OptionAction with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ValueRange with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ValueSource with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend FlagAction with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend OptionAction with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ValueRange with Show::{output}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ValueSource with Show::{output}

--- a/argparse/moon.pkg
+++ b/argparse/moon.pkg
@@ -7,4 +7,4 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+unnecessary_annotation"
+warnings = "+unnecessary_annotation+implicit_impl_as_method"

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -32,6 +32,7 @@ pub(all) enum FlagAction {
   Help
   Version
 } derive(Eq, Show, @debug.Debug)
+pub fn FlagAction::to_string(Self) -> String
 
 pub struct FlagArg {
   // private fields
@@ -52,6 +53,7 @@ pub(all) enum OptionAction {
   Set
   Append
 } derive(Eq, Show, @debug.Debug)
+pub fn OptionAction::to_string(Self) -> String
 
 pub struct OptionArg {
   // private fields
@@ -71,12 +73,14 @@ pub struct ValueRange {
 #alias(new, deprecated)
 pub fn ValueRange::ValueRange(lower? : Int, upper? : Int) -> Self
 pub fn ValueRange::single() -> Self
+pub fn ValueRange::to_string(Self) -> String
 
 pub enum ValueSource {
   Argv
   Env
   Default
 } derive(Eq, Show, @debug.Debug)
+pub fn ValueSource::to_string(Self) -> String
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`argparse`** only.

10 types (ArgGroup, Command, FlagAction, FlagArg, Matches, OptionAction, OptionArg, PositionArg, ValueRange, ValueSource). @debug.Debug is deprecated for all; Eq is deprecated for FlagAction/OptionAction/ValueRange/ValueSource; those four also derive a genuine Show, so their Show is split (to_string promoted, output deprecated). Only the four Show::to_string methods are promoted. The existing 'warnings' key in moon.pkg was extended (not duplicated).

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `argparse/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/argparse --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
