### PR TITLE
feat(int16): make trait promotions explicit via extend

### DIFF
--- a/int16/extends.mbt
+++ b/int16/extends.mbt
@@ -1,0 +1,81 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend Int16 with Add::{add}
+
+///|
+pub extend Int16 with Sub::{sub}
+
+///|
+pub extend Int16 with Mul::{mul}
+
+///|
+pub extend Int16 with Div::{div}
+
+///|
+pub extend Int16 with Mod::{mod}
+
+///|
+pub extend Int16 with Neg::{neg}
+
+///|
+pub extend Int16 with BitAnd::{land}
+
+///|
+pub extend Int16 with BitOr::{lor}
+
+///|
+pub extend Int16 with BitXOr::{lxor}
+
+///|
+pub extend Int16 with Shl::{shl}
+
+///|
+pub extend Int16 with Shr::{shr}
+
+///|
+pub extend Int16 with Compare::{compare}
+
+///|
+pub extend Int16 with Default::{default}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend Int16 with Compare::{op_ge, op_gt, op_le, op_lt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Int16 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Int16 with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Int16 with Show::{output}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Int16 with ToJson::{to_json}

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -198,6 +198,7 @@ test "Int16::hash" {
 }
 
 ///|
+#warnings("-deprecated")
 test "Int16::equal" {
   inspect(Int16::equal(1, 2), content="false")
   inspect(Int16::equal(2, 1), content="false")
@@ -446,6 +447,7 @@ test "Int16::abs" {
 }
 
 ///|
+#warnings("-deprecated")
 test "Int16::to_json" {
   @debug.debug_inspect(Int16::to_json(0), content="Number(0)")
   @debug.debug_inspect(Int16::to_json(1), content="Number(1)")

--- a/int16/moon.pkg
+++ b/int16/moon.pkg
@@ -7,3 +7,5 @@ import {
   "moonbitlang/core/uint16",
   "moonbitlang/core/json",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/int16/pkg.generated.mbti
+++ b/int16/pkg.generated.mbti
@@ -16,12 +16,25 @@ pub let min_value : Int16
 
 // Types and methods
 pub fn Int16::abs(Int16) -> Int16
+pub fn Int16::add(Int16, Int16) -> Int16
+pub fn Int16::compare(Int16, Int16) -> Int
+pub fn Int16::default() -> Int16
+pub fn Int16::div(Int16, Int16) -> Int16
 pub fn Int16::from_byte(Byte) -> Int16
 pub fn Int16::from_int(Int) -> Int16
 pub fn Int16::from_int64(Int64) -> Int16
+pub fn Int16::land(Int16, Int16) -> Int16
 pub fn Int16::lnot(Int16) -> Int16
+pub fn Int16::lor(Int16, Int16) -> Int16
+pub fn Int16::lxor(Int16, Int16) -> Int16
+pub fn Int16::mod(Int16, Int16) -> Int16
+pub fn Int16::mul(Int16, Int16) -> Int16
+pub fn Int16::neg(Int16) -> Int16
 pub fn Int16::reinterpret_as_uint16(Int16) -> UInt16
 pub fn Int16::reinterpret_from_uint16(UInt16) -> Int16
+pub fn Int16::shl(Int16, Int) -> Int16
+pub fn Int16::shr(Int16, Int) -> Int16
+pub fn Int16::sub(Int16, Int16) -> Int16
 pub fn Int16::to_byte(Int16) -> Byte
 pub fn Int16::to_int(Int16) -> Int
 pub fn Int16::to_int64(Int16) -> Int64


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`int16`** only.

Int16 is a numeric type: its arithmetic/bitwise operators (Add/Sub/Mul/Div/Mod/Neg/BitAnd/BitOr/BitXOr/Shl/Shr), Compare::compare, and Default are PROMOTED; Compare operators, Eq, Hash, Show::output (its to_string is already an explicit method, not flagged), and ToJson are DEPRECATED. Two tests that specifically exercise the deprecated Int16::equal / Int16::to_json methods carry #warnings("-deprecated") (matching the existing convention for tests of deprecated APIs).

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `int16/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/int16 --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
