### PR TITLE
feat(v128): make trait promotions explicit via extend

### DIFF
--- a/v128/extends.mbt
+++ b/v128/extends.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend V128 with Show::{to_string}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend V128 with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend V128 with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend V128 with Show::{output}

--- a/v128/moon.pkg
+++ b/v128/moon.pkg
@@ -9,3 +9,5 @@ import {
 import {
   "moonbitlang/core/bench",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/v128/pkg.generated.mbti
+++ b/v128/pkg.generated.mbti
@@ -10,6 +10,7 @@ import {
 // Errors
 
 // Types and methods
+pub fn V128::to_string(V128) -> String
 pub impl Eq for V128
 pub impl Show for V128
 pub impl @debug.Debug for V128


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`v128`** only.

V128 (a SIMD vector) has a genuine non-deprecated Show, so its Show is split: Show::to_string is promoted; @debug.Debug, Eq, and Show::output are deprecated.

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `v128/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/v128 --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
