### PR TITLE
feat(quickcheck/splitmix): make trait promotions explicit via extend

### DIFF
--- a/quickcheck/splitmix/extends.mbt
+++ b/quickcheck/splitmix/extends.mbt
@@ -1,0 +1,33 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend RandomState with Default::{default}
+
+///|
+pub extend RandomState with Show::{to_string}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend RandomState with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend RandomState with Show::{output}

--- a/quickcheck/splitmix/moon.pkg
+++ b/quickcheck/splitmix/moon.pkg
@@ -4,3 +4,5 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/core/debug",
 }
+
+warnings = "+implicit_impl_as_method"

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -13,6 +13,7 @@ pub fn new(seed? : UInt64) -> RandomState
 // Types and methods
 type RandomState derive(Show, @debug.Debug)
 pub fn RandomState::clone(Self) -> Self
+pub fn RandomState::default() -> Self
 #deprecated
 pub fn RandomState::new(seed? : UInt64) -> Self
 pub fn RandomState::next(Self) -> Unit
@@ -25,6 +26,7 @@ pub fn RandomState::next_two_uint(Self) -> (UInt, UInt)
 pub fn RandomState::next_uint(Self) -> UInt
 pub fn RandomState::next_uint64(Self) -> UInt64
 pub fn RandomState::split(Self) -> Self
+pub fn RandomState::to_string(Self) -> String
 pub impl Default for RandomState
 
 // Type aliases


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`quickcheck/splitmix`** only.

RandomState has a derived (non-deprecated) Show, so Show is split: Show::to_string and Default are promoted; @debug.Debug and Show::output are deprecated.

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `quickcheck/splitmix/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/quickcheck/splitmix --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
