### PR TITLE
feat(debug): make trait promotions explicit via extend

### DIFF
--- a/debug/delta_wbtest.mbt
+++ b/debug/delta_wbtest.mbt
@@ -16,6 +16,9 @@
 struct Empty {} derive(Debug)
 
 ///|
+pub extend Empty with Debug::{to_repr}
+
+///|
 test "diff: arrays collapse when all children differ" {
   let x = Repr::array([Repr::integer("1"), Repr::integer("2")])
   let y = Repr::array([Repr::integer("3"), Repr::integer("4")])

--- a/debug/extends.mbt
+++ b/debug/extends.mbt
@@ -1,0 +1,30 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend Repr with Show::{to_string}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Repr with Debug::{to_repr}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Repr with Show::{output}

--- a/debug/moon.pkg
+++ b/debug/moon.pkg
@@ -16,4 +16,4 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "-alert_visibility-test_unqualified_package"
+warnings = "-alert_visibility-test_unqualified_package+implicit_impl_as_method"

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub fn[T : Debug] to_string(T) -> String
 
 // Types and methods
 type Repr
+pub fn Repr::to_string(Self) -> String
 pub impl Show for Repr
 pub impl Debug for Repr
 


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`debug`** only.

The debug package defines the Debug trait. The source type Repr has a genuine non-deprecated Show, so its Show is split (Show::to_string promoted, output deprecated) and its Debug is deprecated. The whitebox-test-only 'Empty' struct (derive(Debug)) gets an inline pub extend in delta_wbtest.mbt (test type, can't be named from the source shim). Extends use the local Debug:: trait.

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `debug/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/debug --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
