### PR TITLE
feat(test): make trait promotions explicit via extend

### DIFF
--- a/test/README.mbt.md
+++ b/test/README.mbt.md
@@ -27,6 +27,12 @@ Use `@test.assert_eq` and `@test.assert_not_eq` to compare values in tests:
 struct User(Int) derive(Eq, @debug.Debug)
 
 ///|
+pub extend User with @debug.Debug::{to_repr}
+
+///|
+pub extend User with Eq::{equal, not_equal}
+
+///|
 test "equality assertions" {
   @test.assert_eq(User(1), User(1))
   @test.assert_not_eq(User(1), User(2))

--- a/test/extends.mbt
+++ b/test/extends.mbt
@@ -1,0 +1,22 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test has no promoted trait methods; every promotion below is deprecated.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Test with @debug.Debug::{to_repr}

--- a/test/moon.pkg
+++ b/test/moon.pkg
@@ -2,3 +2,5 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
+
+warnings = "+implicit_impl_as_method"

--- a/test/test_test.mbt
+++ b/test/test_test.mbt
@@ -55,6 +55,9 @@ suberror MyError {
 } derive(Debug)
 
 ///|
+pub extend MyError with @debug.Debug::{to_repr}
+
+///|
 fn maybe_raise(should_raise : Bool) -> Unit raise MyError {
   if should_raise {
     raise NotFound("file.txt")


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`test`** only.

Three types: the source type Test (its @debug.Debug is deprecated, no promotions); the blackbox-test-only MyError suberror (derive(Debug)) gets an inline pub extend in test_test.mbt; the README doc-example User struct (derive(Eq, @debug.Debug)) gets inline pub extends for both Debug and Eq. Test-only/doc types use plain promote to clear the warning.

Deprecations carry `#doc(hidden)`, so `pkg.generated.mbti` gains only the promoted methods. Scoped to `test/`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/test --target all` — green.

---
`Signed-off-by: Codex CLI <codex@openai.com>`
