### PR TITLE
feat(bool): make trait promotions explicit via extend

### DIFF
--- a/bool/bool_test.mbt
+++ b/bool/bool_test.mbt
@@ -58,3 +58,12 @@ test "bool convert" {
   inspect(true.to_int16(), content="1")
   inspect(false.to_int16(), content="0")
 }
+
+///|
+pub extend TestHash with Debug::{to_repr}
+
+///|
+pub extend TestHash with Eq::{equal, not_equal}
+
+///|
+pub extend TestHash with Hash::{hash, hash_combine}

--- a/bool/moon.pkg
+++ b/bool/moon.pkg
@@ -6,3 +6,5 @@ import {
   "moonbitlang/core/char",
   "moonbitlang/core/int16",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`bool`**.

The bool package has no trait promotions of its own — the only E0079 sites belong to `TestHash`, a blackbox-test struct (`derive(Hash, Eq, Debug)`) in `bool_test.mbt`, which gets inline `pub extend` promotions there (plain promote). Only `bool/moon.pkg` (the flag) and `bool/bool_test.mbt` are touched; no source `extends.mbt`; `pkg.generated.mbti` is unchanged.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/bool --target all` — green (8 tests).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
