### PR TITLE
feat(char): make trait promotions explicit via extend

### DIFF
--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -524,3 +524,12 @@ test "Case conversion with non-letters" {
   assert_eq('a'.to_ascii_uppercase(), 'A')
   assert_eq('z'.to_ascii_uppercase(), 'Z')
 }
+
+///|
+pub extend TestHash with Debug::{to_repr}
+
+///|
+pub extend TestHash with Eq::{equal, not_equal}
+
+///|
+pub extend TestHash with Hash::{hash, hash_combine}

--- a/char/moon.pkg
+++ b/char/moon.pkg
@@ -1,3 +1,5 @@
 import {
   "moonbitlang/core/builtin",
 }
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`char`**.

The char package has no trait promotions of its own — the only E0079 sites belong to `TestHash`, a blackbox-test struct (`derive(Hash, Eq, Debug)`) in `char_test.mbt`, which gets inline `pub extend` promotions there (plain promote). Only `char/moon.pkg` (the flag) and `char/char_test.mbt` are touched; no source `extends.mbt`; `pkg.generated.mbti` is unchanged.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/char --target all` — green (39 tests).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
