### PR TITLE
fix(list): label breaks in labelled loops

### DIFF
--- a/list/list.mbt
+++ b/list/list.mbt
@@ -779,10 +779,10 @@ pub fn[A, B] List::flat_map(
             // continue looping on the `tail` of `self`
             loop_over_tail~: for d = dest1, t = tail {
               match (d, t) {
-                (_, Empty) => break
+                (_, Empty) => break loop_over_tail~
                 (More(_) as dest, More(t_hd, tail=Empty)) => {
                   dest.tail = f(t_hd)
-                  break
+                  break loop_over_tail~
                 }
                 (dest, More(t_hd, tail=t_tl)) =>
                   for d2 = dest, t2 = f(t_hd) {
@@ -1056,10 +1056,10 @@ pub fn[A] List::flatten(self : List[List[A]]) -> List[A] {
             // continue looping on the `tail` of `self`
             loop_over_tail~: for d = dest1, t = tail {
               match (d, t) {
-                (_, Empty) => break
+                (_, Empty) => break loop_over_tail~
                 (More(_) as dest, More(t_hd, tail=Empty)) => {
                   dest.tail = t_hd
-                  break
+                  break loop_over_tail~
                 }
                 (dest, More(t_hd, tail=t_tl)) =>
                   for d2 = dest, t2 = t_hd {


### PR DESCRIPTION
## Summary

- Make four direct exits from `loop_over_tail~` explicit in `List::flat_map` and `List::flatten`.
- Preserve existing behavior while preparing the list package for the upcoming compiler's E4111 validation.

## Root cause

The two labelled loops used unlabelled `break` expressions for their direct exits. The upcoming compiler requires `break loop_over_tail~` when exiting a labelled loop directly.

## Impact

This is a source-compatibility fix for the next MoonBit release. It does not change the public API or runtime behavior.

## Validation

- `moon check --warn-list +unnecessary_annotation`
- `moon test list` — 210 passed
- `moon test` — 6,774 passed
- `moon info`
- `moon fmt`
- Confirmed no `.mbti` changes