### PR TITLE
feat(quickcheck): make trait promotions explicit via extend

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -84,6 +84,9 @@ struct Point {
 } derive(Debug)
 
 ///|
+pub extend Point with Debug::{to_repr}
+
+///|
 impl Arbitrary for Point with fn arbitrary(size, r0) {
   let r1 = r0.split()
   let y = @quickcheck.Arbitrary::arbitrary(size, r1)

--- a/quickcheck/arbitrary_test.mbt
+++ b/quickcheck/arbitrary_test.mbt
@@ -143,3 +143,9 @@ test "arbitrary size branches" {
   let rs4 = @splitmix.RandomState::default()
   let _ : FixedArray[Int] = @quickcheck.Arbitrary::arbitrary(3, rs4)
 }
+
+///|
+pub extend H with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+pub extend H with Debug::{to_repr}

--- a/quickcheck/moon.pkg
+++ b/quickcheck/moon.pkg
@@ -10,3 +10,5 @@ import {
   "moonbitlang/core/float",
   "moonbitlang/core/double",
 } for "test"
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`quickcheck`**.

The quickcheck package has no trait promotions of its own — the only E0079 sites belong to two test/doc types: `H` (blackbox-test struct in `arbitrary_test.mbt`, `derive(@quickcheck.Arbitrary, Debug)`) and `Point` (`README.mbt.md` doc-test struct, `derive(Debug)`). Both get inline `pub extend` promotions in their files (plain promote). No source `extends.mbt`; `pkg.generated.mbti` unchanged.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/quickcheck --target all` — green (13 tests).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
