### PR TITLE
feat(float): make trait promotions explicit via extend

### DIFF
--- a/float/extends.mbt
+++ b/float/extends.mbt
@@ -1,0 +1,71 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods (blessed public API) ---
+
+///|
+pub extend Float with Add::{add}
+
+///|
+pub extend Float with Compare::{compare}
+
+///|
+pub extend Float with Default::{default}
+
+///|
+pub extend Float with Div::{div}
+
+///|
+pub extend Float with Mod::{mod}
+
+///|
+pub extend Float with Mul::{mul}
+
+///|
+pub extend Float with Neg::{neg}
+
+///|
+pub extend Float with Show::{to_string}
+
+///|
+pub extend Float with Sub::{sub}
+
+// `Float::to_json` is promoted (not deprecated) because it has cross-package
+// method-syntax callers (json/builtin tests); deprecating it would break the
+// `--deny-warn` workspace build. It can be deprecated in a coordinated follow-up.
+
+///|
+pub extend Float with ToJson::{to_json}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend Float with Compare::{op_lt, op_le, op_ge, op_gt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Float with Eq::{not_equal, equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Float with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Float with Show::{output}

--- a/float/extends.mbt
+++ b/float/extends.mbt
@@ -53,7 +53,7 @@ pub extend Float with ToJson::{to_json}
 ///|
 #deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
 #doc(hidden)
-pub extend Float with Compare::{op_lt, op_le, op_ge, op_gt}
+pub extend Float with Compare::{op_ge, op_gt, op_le, op_lt}
 
 ///|
 #deprecated("Use `==` / `!=` instead", skip_current_package=true)

--- a/float/float_test.mbt
+++ b/float/float_test.mbt
@@ -251,3 +251,6 @@ test "Float constructor syntax" {
   let x : Float = 42
   inspect(Float(x), content="42")
 }
+
+///|
+pub extend FloatHashInput with Hash::{hash, hash_combine}

--- a/float/moon.pkg
+++ b/float/moon.pkg
@@ -9,6 +9,8 @@ import {
   "moonbitlang/core/debug",
 } for "test"
 
+warnings = "+implicit_impl_as_method"
+
 options(
   targets: {
     "round.mbt": [ "not", "js", "wasm", "wasm-gc" ],

--- a/float/pkg.generated.mbti
+++ b/float/pkg.generated.mbti
@@ -22,9 +22,13 @@ pub let not_a_number : Float
 // Types and methods
 #as_free_fn(deprecated)
 pub fn Float::abs(Float) -> Float
+pub fn Float::add(Float, Float) -> Float
 #as_free_fn
 pub fn Float::ceil(Float) -> Float
 pub fn Float::clamp(Float, min~ : Float, max~ : Float) -> Float
+pub fn Float::compare(Float, Float) -> Int
+pub fn Float::default() -> Float
+pub fn Float::div(Float, Float) -> Float
 #as_free_fn
 pub fn Float::floor(Float) -> Float
 pub fn Float::from_byte(Byte) -> Float
@@ -41,6 +45,9 @@ pub fn Float::is_pos_inf(Float) -> Bool
 pub fn Float::lerp(Float, target~ : Float, t~ : Float) -> Float
 pub fn Float::max(Float, Float) -> Float
 pub fn Float::min(Float, Float) -> Float
+pub fn Float::mod(Float, Float) -> Float
+pub fn Float::mul(Float, Float) -> Float
+pub fn Float::neg(Float) -> Float
 #as_free_fn(deprecated)
 #deprecated
 pub fn Float::pow(Float, Float) -> Float
@@ -52,10 +59,13 @@ pub fn Float::reinterpret_from_uint(UInt) -> Float
 pub fn Float::round(Float) -> Float
 pub fn Float::signum(Float) -> Float
 pub fn Float::sqrt(Float) -> Float
+pub fn Float::sub(Float, Float) -> Float
 pub fn Float::to_be_bytes(Float) -> Bytes
 pub fn Float::to_double(Float) -> Double
 pub fn Float::to_int(Float) -> Int
+pub fn Float::to_json(Float) -> Json
 pub fn Float::to_le_bytes(Float) -> Bytes
+pub fn Float::to_string(Float) -> String
 #as_free_fn
 pub fn Float::trunc(Float) -> Float
 pub fn Float::until(Float, Float, step? : Float, inclusive? : Bool) -> Iter[Float]


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`float`**.

- **Promote** (plain `pub extend`): `Float`'s arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`), `Compare::{compare}`, `Default`, `Show::{to_string}`, and `ToJson::{to_json}`.
- **Deprecate** (`#deprecated(..., skip_current_package=true)` + `#doc(hidden)`): `Float`'s `Compare::{op_ge,op_gt,op_le,op_lt}`, `Eq`, `Hash`, `Show::{output}`.
- Test type `FloatHashInput` (`float_test.mbt`) gets an inline `pub extend … Hash::{hash, hash_combine}`.

> `Float::to_json` is **promoted, not deprecated** (unlike the Int16 value-type template): it has cross-package method-syntax callers — `float.to_json()` / `(x : Float).to_json()` in `builtin/json_test.mbt` and `json/{to_json_test,from_json_test}.mbt` — so deprecating it would break `--deny-warn`. This mirrors the promote-only decision for `builtin`; a coordinated follow-up can deprecate it once those callers move to `@json.to_json`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/float --target all` — green (87 tests).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
