### PR TITLE
feat(bigint): make trait promotions explicit via extend

### DIFF
--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -283,21 +283,21 @@ pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
 }
 
 ///|
-extern "js" fn BigInt::compare(self : BigInt, other : BigInt) -> Int =
+extern "js" fn BigInt::compare_js(self : BigInt, other : BigInt) -> Int =
   #|(x, y) => x < y ? -1 : x > y ? 1 : 0
 
 ///|
 pub impl Compare for BigInt with fn compare(self, other) {
-  self.compare(other)
+  self.compare_js(other)
 }
 
 ///|
-extern "js" fn BigInt::equal(self : BigInt, other : BigInt) -> Bool =
+extern "js" fn BigInt::equal_js(self : BigInt, other : BigInt) -> Bool =
   #|(x, y) => x === y
 
 ///|
 pub impl Eq for BigInt with fn equal(self, other) {
-  self.equal(other)
+  self.equal_js(other)
 }
 
 ///|

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -1220,10 +1220,10 @@ test "@bigint.BigInt::hash" {
       x.finalize()
     }
   inspect(hash1, content="-813420232")
-  assert_eq(0N.hash(), (-0N).hash())
+  assert_eq(Hash::hash(0N), Hash::hash(-0N))
 
   // Positive and negative of same magnitude should have different hashes
-  assert_not_eq(1N.hash(), (-1N).hash())
+  assert_not_eq(Hash::hash(1N), Hash::hash(-1N))
 
   // Test small positive numbers
   let hash2 = Hasher(seed=0)
@@ -1301,16 +1301,16 @@ test "@bigint.BigInt::hash" {
 test "@bigint.BigInt::hash consistency" {
   // Test that hash is consistent across multiple calls
   let big = 999888777666555444333222111N
-  let hash1 = big.hash()
-  let hash2 = big.hash()
-  let hash3 = big.hash()
+  let hash1 = Hash::hash(big)
+  let hash2 = Hash::hash(big)
+  let hash3 = Hash::hash(big)
   assert_eq(hash1, hash2)
   assert_eq(hash1, hash3)
 
   // Test with negative number
   let neg_big = -big
-  let neg_hash1 = neg_big.hash()
-  let neg_hash2 = neg_big.hash()
+  let neg_hash1 = Hash::hash(neg_big)
+  let neg_hash2 = Hash::hash(neg_big)
   assert_eq(neg_hash1, neg_hash2)
   assert_not_eq(hash1, neg_hash1)
 }
@@ -1324,7 +1324,7 @@ test "default" {
 ///|
 test "BigInt bit ops and arbitrary" {
   let rs = @splitmix.new(seed=1)
-  let _ = @bigint.BigInt::arbitrary(1, rs)
+  let _ : @bigint.BigInt = @quickcheck.Arbitrary::arbitrary(1, rs)
   let small = @bigint.BigInt::from_int(1)
   let big = @bigint.BigInt::from_string("123456789012345678901234567891")
   inspect(small.land(big).to_string(), content="1")

--- a/bigint/extends.mbt
+++ b/bigint/extends.mbt
@@ -1,0 +1,91 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods (blessed public API) ---
+
+///|
+pub extend BigInt with Add::{add}
+
+///|
+pub extend BigInt with BitAnd::{land}
+
+///|
+pub extend BigInt with BitOr::{lor}
+
+///|
+pub extend BigInt with BitXOr::{lxor}
+
+///|
+pub extend BigInt with Compare::{compare}
+
+///|
+pub extend BigInt with Default::{default}
+
+///|
+pub extend BigInt with Div::{div}
+
+///|
+pub extend BigInt with Mod::{mod}
+
+///|
+pub extend BigInt with Mul::{mul}
+
+///|
+pub extend BigInt with Neg::{neg}
+
+///|
+pub extend BigInt with Sub::{sub}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend BigInt with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `@json.from_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend BigInt with @json.FromJson::{from_json}
+
+///|
+#deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
+#doc(hidden)
+pub extend BigInt with @quickcheck.Arbitrary::{arbitrary}
+
+///|
+#deprecated("Use the comparison operators (`<`, `<=`, `>=`, `>`) instead", skip_current_package=true)
+#doc(hidden)
+pub extend BigInt with Compare::{op_lt, op_le, op_ge, op_gt}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend BigInt with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Hash::hash` / `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend BigInt with Hash::{hash, hash_combine}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend BigInt with Show::{output}
+
+// `BigInt::to_json` is promoted (not deprecated): it has cross-package method-syntax
+// callers (builtin/json tests); deprecating it would break `--deny-warn`.
+
+///|
+pub extend BigInt with ToJson::{to_json}

--- a/bigint/moon.pkg
+++ b/bigint/moon.pkg
@@ -20,7 +20,7 @@ import {
   "moonbitlang/core/test",
 } for "wbtest"
 
-warnings = "-29"
+warnings = "-29+implicit_impl_as_method"
 
 options(
   targets: {

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -14,14 +14,18 @@ import {
 
 // Types and methods
 type BigInt
+pub fn BigInt::add(Self, Self) -> Self
 #deprecated
 pub fn BigInt::asr(Self, Int) -> Self
 pub fn BigInt::bit_length(Self) -> Int
+pub fn BigInt::compare(Self, Self) -> Int
 pub fn BigInt::compare_int(Self, Int) -> Int
 pub fn BigInt::compare_int64(Self, Int64) -> Int
 pub fn BigInt::compare_uint(Self, UInt) -> Int
 pub fn BigInt::compare_uint64(Self, UInt64) -> Int
 pub fn BigInt::ctz(Self) -> Int
+pub fn BigInt::default() -> Self
+pub fn BigInt::div(Self, Self) -> Self
 pub fn BigInt::equal_int(Self, Int) -> Bool
 pub fn BigInt::equal_int64(Self, Int64) -> Bool
 pub fn BigInt::equal_uint(Self, UInt) -> Bool
@@ -35,18 +39,26 @@ pub fn BigInt::from_string(String, radix? : Int) -> Self
 pub fn BigInt::from_uint(UInt) -> Self
 pub fn BigInt::from_uint64(UInt64) -> Self
 pub fn BigInt::is_zero(Self) -> Bool
+pub fn BigInt::land(Self, Self) -> Self
+pub fn BigInt::lor(Self, Self) -> Self
 #deprecated
 pub fn BigInt::lsl(Self, Int) -> Self
+pub fn BigInt::lxor(Self, Self) -> Self
+pub fn BigInt::mod(Self, Self) -> Self
+pub fn BigInt::mul(Self, Self) -> Self
+pub fn BigInt::neg(Self) -> Self
 pub fn BigInt::pow(Self, Self, modulus? : Self) -> Self
 #deprecated
 pub fn BigInt::shl(Self, Int) -> Self
 #deprecated
 pub fn BigInt::shr(Self, Int) -> Self
+pub fn BigInt::sub(Self, Self) -> Self
 #deprecated
 pub fn BigInt::to_hex(Self, uppercase? : Bool) -> String
 pub fn BigInt::to_int(Self) -> Int
 pub fn BigInt::to_int16(Self) -> Int16
 pub fn BigInt::to_int64(Self) -> Int64
+pub fn BigInt::to_json(Self) -> Json
 pub fn BigInt::to_octets(Self, length? : Int) -> Bytes
 pub fn BigInt::to_string(Self, radix? : Int) -> String
 pub fn BigInt::to_uint(Self) -> UInt


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers **`bigint`** (target-split js/nonjs).

- **Promote** (plain `pub extend`): `BigInt`'s arithmetic/bitwise (`Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`/`BitAnd`/`BitOr`/`BitXOr`), `Compare::{compare}`, `Default`, `ToJson::{to_json}`.
- **Deprecate** (`#deprecated(..., skip_current_package=true)` + `#doc(hidden)`): `Compare::{op_ge,op_gt,op_le,op_lt}`, `Eq`, `Hash`, `Show::{output}`, `@debug.Debug::{to_repr}`, `@json.FromJson::{from_json}`, `@quickcheck.Arbitrary::{arbitrary}`.

Two non-mechanical details:
- **JS extern collision**: `bigint_js.mbt`'s `extern "js" fn BigInt::compare` / `::equal` share names with the promoted `Compare::{compare}` / `Eq` (E4056, JS target only). The externs are renamed to `compare_js` / `equal_js` (private — not in the `.mbti`) and their two impl bodies updated accordingly.
- **`to_json` promoted, not deprecated**: it has cross-package method-syntax callers (`builtin/json_test.mbt`, `json/{to_json_test,from_json_test}.mbt`); deprecating would break `--deny-warn` (mirrors `builtin`/`float`). bigint's own blackbox-test callers of the deprecated `hash`/`arbitrary` were migrated to `Hash::hash(x)` / `@quickcheck.Arbitrary::arbitrary`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/bigint --target all` — green (140 js / 165 native).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
