### PR TITLE
feat(json): make trait promotions explicit via extend

### DIFF
--- a/json/derive_json_test.mbt
+++ b/json/derive_json_test.mbt
@@ -78,3 +78,18 @@ test {
     ),
   )
 }
+
+///|
+pub extend Hello with Debug::{to_repr}
+
+///|
+pub extend Hello with Eq::{equal, not_equal}
+
+///|
+pub extend Hello with FromJson::{from_json}
+
+///|
+pub extend Hello with ToJson::{to_json}
+
+///|
+pub extend Hello3 with ToJson::{to_json}

--- a/json/extends.mbt
+++ b/json/extends.mbt
@@ -1,0 +1,121 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods (blessed public API) ---
+
+///|
+pub extend JsonDecodeError with Show::{to_string}
+
+///|
+pub extend JsonPath with Show::{to_string}
+
+///|
+pub extend ParseError with Show::{to_string}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@json.from_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Json with FromJson::{from_json}
+
+///|
+#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
+#doc(hidden)
+pub extend Json with Show::{to_string, output}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Json with ToJson::{to_json}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonDecodeError with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonDecodeError with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonDecodeError with Show::{output}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonDecodeError with ToJson::{to_json}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonPath with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonPath with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonPath with Show::{output}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend JsonPath with ToJson::{to_json}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ParseError with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ParseError with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ParseError with Show::{output}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ParseError with ToJson::{to_json}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Position with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `==` / `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Position with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Position with ToJson::{to_json}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Replacer with @debug.Debug::{to_repr}

--- a/json/from_to_json_test.mbt
+++ b/json/from_to_json_test.mbt
@@ -40,3 +40,15 @@ test {
   )
   assert_true(e0 == e)
 }
+
+///|
+pub extend Expr with Debug::{to_repr}
+
+///|
+pub extend Expr with Eq::{equal, not_equal}
+
+///|
+pub extend Expr with FromJson::{from_json}
+
+///|
+pub extend Expr with ToJson::{to_json}

--- a/json/json_encode_decode_test.mbt
+++ b/json/json_encode_decode_test.mbt
@@ -91,3 +91,15 @@ test {
     ),
   )
 }
+
+///|
+pub extend AllThree with Debug::{to_repr}
+
+///|
+pub extend AllThree with Eq::{equal, not_equal}
+
+///|
+pub extend DecodeError with Debug::{to_repr}
+
+///|
+pub extend DecodeError with Eq::{equal, not_equal}

--- a/json/json_inspect_test.mbt
+++ b/json/json_inspect_test.mbt
@@ -63,3 +63,12 @@ test "json inspect error paths" {
     expect_error(() => @json.json_inspect(1, content=2), "expected mismatch"),
   )
 }
+
+///|
+pub extend Color with ToJson::{to_json}
+
+///|
+pub extend Line with ToJson::{to_json}
+
+///|
+pub extend P with ToJson::{to_json}

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -622,3 +622,6 @@ fn[A : FromJson] test_json_export(x : A) -> A {
 test {
   let _ : Int = test_json_export(42)
 }
+
+///|
+pub extend NestedJsonValue with ToJson::{to_json}

--- a/json/moon.pkg
+++ b/json/moon.pkg
@@ -16,3 +16,5 @@ import {
   "moonbitlang/core/bigint",
   "moonbitlang/core/bench",
 } for "test"
+
+warnings = "+implicit_impl_as_method"

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub fn valid(StringView) -> Bool
 pub(all) suberror JsonDecodeError {
   JsonDecodeError((JsonPath, String))
 } derive(Eq, Show, ToJson, @debug.Debug)
+pub fn JsonDecodeError::to_string(Self) -> String
 
 pub(all) suberror ParseError {
   InvalidChar(Position, Char)
@@ -31,12 +32,14 @@ pub(all) suberror ParseError {
   InvalidIdentEscape(Position)
   DepthLimitExceeded
 } derive(Eq, ToJson, @debug.Debug)
+pub fn ParseError::to_string(Self) -> String
 pub impl Show for ParseError
 
 // Types and methods
 type JsonPath derive(Eq, @debug.Debug)
 pub fn JsonPath::add_index(Self, Int) -> Self
 pub fn JsonPath::add_key(Self, String) -> Self
+pub fn JsonPath::to_string(Self) -> String
 pub impl Show for JsonPath
 pub impl ToJson for JsonPath
 

--- a/json/to_json_test.mbt
+++ b/json/to_json_test.mbt
@@ -478,3 +478,15 @@ test "Tuple::to_json" {
     ),
   )
 }
+
+///|
+pub extend Opt with Debug::{to_repr}
+
+///|
+pub extend Opt with Eq::{equal, not_equal}
+
+///|
+pub extend Opt with FromJson::{from_json}
+
+///|
+pub extend Opt with ToJson::{to_json}


### PR DESCRIPTION
## Summary

Part of the per-package series migrating `moonbitlang/core` off implicit trait-method promotion (see #3849 for `deque`). Covers the **`json`** package itself.

- **Promote** (plain `pub extend`): `Show::{to_string}` for `JsonPath`, `JsonDecodeError`, `ParseError` (display/error types).
- **Deprecate** (`#deprecated(..., skip_current_package=true)` + `#doc(hidden)`):
  - `Json`: `FromJson`, `ToJson`, `Show::{to_string, output}` (Json's Show is already `#deprecated` on main → deprecate fully).
  - `JsonPath` / `JsonDecodeError` / `ParseError`: `@debug.Debug::{to_repr}`, `Eq`, `Show::{output}`, `ToJson::{to_json}` (`to_string` promoted).
  - `Position`: `@debug.Debug`, `Eq`, `ToJson`. `Replacer`: `@debug.Debug`.
- 10 blackbox-test / doc types (`AllThree`, `Color`, `DecodeError`, `Expr`, `Hello`, `Hello3`, `Line`, `NestedJsonValue`, `Opt`, `P`) get inline `pub extend` promotions in their own test files.

> Deprecating `Json`/`JsonPath`/… `to_json` + `from_json` has **zero cross-package ripple** — downstream uses the free `@json.to_json` / `@json.from_json` (and the traits), not `x.to_json()` method syntax; internal calls are covered by `skip_current_package`.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/json --target all` — green (185 tests).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
