### PR TITLE
feat(builtin): add free `hash` function (prelude), symmetric with `@json.to_json`

### DIFF
--- a/builtin/hash_fn.mbt
+++ b/builtin/hash_fn.mbt
@@ -1,0 +1,28 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Compute the hash of `value`.
+///
+/// This is the free-function form of the `Hash::hash` trait method, symmetric
+/// with `@json.to_json`. Prefer it over the promoted `value.hash()` method.
+///
+/// ```mbt check
+/// test {
+///   inspect(hash(42) == hash(42), content="true")
+/// }
+/// ```
+pub fn[T : Hash] hash(value : T) -> Int {
+  Hash::hash(value)
+}

--- a/builtin/hash_fn_test.mbt
+++ b/builtin/hash_fn_test.mbt
@@ -1,0 +1,23 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "hash free function" {
+  // agrees with the trait method
+  assert_eq(hash(42), Hash::hash(42))
+  assert_eq(hash("abc"), Hash::hash("abc"))
+  // deterministic
+  assert_eq(hash([1, 2, 3]), hash([1, 2, 3]))
+  assert_not_eq(hash(1), hash(2))
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub fn debug_assert(() -> Bool) -> Unit
 #callsite(autofill(loc))
 pub fn[T] fail(StringView, loc~ : SourceLoc) -> T raise Failure
 
+pub fn[T : Hash] hash(T) -> Int
+
 pub fn[T] ignore(T) -> Unit
 
 #callsite(autofill(args_loc, loc))

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -42,6 +42,8 @@ pub fn[T : @debug.Debug] dump(T, name? : String, loc~ : @builtin.SourceLoc) -> T
 #callsite(autofill(loc))
 pub fn[T] fail(StringView, loc~ : @builtin.SourceLoc) -> T raise @builtin.Failure
 
+pub fn[T : @builtin.Hash] hash(T) -> Int
+
 pub fn[T] ignore(T) -> Unit
 
 #callsite(autofill(args_loc, loc))

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -29,6 +29,7 @@ pub using @builtin {
   debug_assert,
   fail,
   ignore,
+  hash,
   inspect,
   panic,
   physical_equal,


### PR DESCRIPTION
## Summary

Adds a free-function **`hash`** — the counterpart to the existing free `@json.to_json` / `@json.from_json`, and the blessed replacement for the promoted `value.hash()` method that the `implicit_impl_as_method` migration deprecates.

- `builtin/hash_fn.mbt`: `pub fn[T : Hash] hash(value : T) -> Int { Hash::hash(value) }`.
- `prelude/prelude.mbt`: re-exported in the `pub using @builtin { … }` block, so `hash(x)` is available **unqualified everywhere**.

`hash(x)` reads far better than `Hash::hash(x)` at call sites. With this in place, the migration's `Hash` deprecation message can point to `hash`, and the migrated call-sites can use `hash(x)`.

No conflict: the only other `hash` in the tree is a local nested helper in `builtin/bytes_find.mbt` (Rabin-Karp), which shadows within its own scope. `pkg.generated.mbti` is purely additive.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test -p moonbitlang/core/builtin --target all` — green (2872).

---
`Signed-off-by: Codex CLI <codex@openai.com>`
