### PR TITLE
refactor: migrate builtin-type call sites off promoted Hash/Eq/Show methods

### DIFF
--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -531,7 +531,7 @@ test "arrayview hash invariant" {
   let arr : Array[Array[Int]] = @quickcheck.samples(20)
   for v in arr {
     let view = v[:]
-    @test.assert_eq(v.hash(), view.hash())
+    @test.assert_eq(hash(v), hash(view))
   }
 }
 

--- a/builtin/bytes_equal_bench_test.mbt
+++ b/builtin/bytes_equal_bench_test.mbt
@@ -37,7 +37,7 @@ fn make_bytes_equal_bench_aliases() -> Array[Bytes] {
 test "bench Bytes::equal n=100000 equal" (it : @bench.T) {
   let left = make_bytes_equal_bench_bytes()
   let right = make_bytes_equal_bench_bytes()
-  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+  it.bench(fn() { it.keep(left == right) })
 }
 
 ///|
@@ -46,7 +46,7 @@ test "bench Bytes::equal n=100000 aliased object" (it : @bench.T) {
   let mut index = 0
   it.bench(fn() {
     index = 1 - index
-    it.keep(Bytes::equal(aliases[index], aliases[1 - index]))
+    it.keep(aliases[index] == aliases[1 - index])
   })
 }
 
@@ -54,5 +54,5 @@ test "bench Bytes::equal n=100000 aliased object" (it : @bench.T) {
 test "bench Bytes::equal n=100000 mismatch at end" (it : @bench.T) {
   let left = make_bytes_equal_bench_bytes()
   let right = make_bytes_equal_bench_bytes(diff_at=bytes_equal_bench_size - 1)
-  it.bench(fn() { it.keep(Bytes::equal(left, right)) })
+  it.bench(fn() { it.keep(left == right) })
 }

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -223,7 +223,7 @@ test "Bytes::equal with differing bytes" {
   arr2[2] = 0x04
   let bytes1 = Bytes::from_array(arr1)
   let bytes2 = Bytes::from_array(arr2)
-  inspect(Bytes::equal(bytes1, bytes2), content="false")
+  inspect(bytes1 == bytes2, content="false")
 }
 
 ///|

--- a/builtin/double_test.mbt
+++ b/builtin/double_test.mbt
@@ -17,9 +17,9 @@ test "hash" {
   let d1 = 123.456
   let d2 = 789.012
   let d3 = 123.456
-  @test.assert_eq(d1.hash(), d1.reinterpret_as_int64() |> Hash::hash())
-  @test.assert_not_eq(d1.hash(), d2.hash())
-  @test.assert_eq(d1.hash(), d3.hash())
+  @test.assert_eq(hash(d1), d1.reinterpret_as_int64() |> Hash::hash())
+  @test.assert_not_eq(hash(d1), hash(d2))
+  @test.assert_eq(hash(d1), hash(d3))
 }
 
 ///|

--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -850,30 +850,30 @@ test "Show for Char special cases" {
 
   // Test various special character outputs
   let quote_buf = StringBuilder()
-  '\''.output(quote_buf)
+  Show::output('\'', quote_buf)
   @test.assert_eq(quote_buf.to_string(), "'")
   let backslash_buf = StringBuilder()
-  '\\'.output(backslash_buf)
+  Show::output('\\', backslash_buf)
   @test.assert_eq(backslash_buf.to_string(), "\\")
   let cr_buf = StringBuilder()
-  '\r'.output(cr_buf)
+  Show::output('\r', cr_buf)
   @test.assert_eq(cr_buf.to_string(), "\r")
   let backspace_buf = StringBuilder()
-  '\b'.output(backspace_buf)
+  Show::output('\b', backspace_buf)
   @test.assert_eq(backspace_buf.to_string(), "\b")
   let tab_buf = StringBuilder()
-  '\t'.output(tab_buf)
+  Show::output('\t', tab_buf)
   @test.assert_eq(tab_buf.to_string(), "\t")
 
   // Test hex output for control characters
   let ctrl1_buf = StringBuilder()
-  '\u{01}'.output(ctrl1_buf)
+  Show::output('\u{01}', ctrl1_buf)
   @test.assert_eq(ctrl1_buf.to_string(), "\u{01}")
   let ctrl_f_buf = StringBuilder()
-  '\u{0F}'.output(ctrl_f_buf)
+  Show::output('\u{0F}', ctrl_f_buf)
   @test.assert_eq(ctrl_f_buf.to_string(), "\u{0f}")
   let ctrl_1f_buf = StringBuilder()
-  '\u{1F}'.output(ctrl_1f_buf)
+  Show::output('\u{1F}', ctrl_1f_buf)
   @test.assert_eq(ctrl_1f_buf.to_string(), "\u{1f}")
 }
 

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -112,9 +112,9 @@ test "hash" {
   let h4 = Hasher(seed=0)
   h4.combine(b4)
   inspect(h4.finalize(), content="1297183151")
-  inspect(b1.hash() == b1.hash(), content="true")
-  inspect(b2.hash() == b2.hash(), content="true")
-  inspect(b1.hash() == b2.hash(), content="false")
+  inspect(hash(b1) == hash(b1), content="true")
+  inspect(hash(b2) == hash(b2), content="true")
+  inspect(hash(b1) == hash(b2), content="false")
 }
 
 ///|

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -363,10 +363,10 @@ test "View::to_bytes" {
 test "impl Hash for View" {
   let b0 : Bytes = b"12345678"
   let b1 : Bytes = b"56781234"
-  @test.assert_eq(b0[0:4].hash(), b1[4:8].hash())
-  @test.assert_eq(b0[4:8].hash(), b1[0:4].hash())
-  @test.assert_not_eq(b0[0:4].hash(), b1[0:4].hash())
-  @test.assert_not_eq(b0[4:8].hash(), b1[4:8].hash())
+  @test.assert_eq(hash(b0[0:4]), hash(b1[4:8]))
+  @test.assert_eq(hash(b0[4:8]), hash(b1[0:4]))
+  @test.assert_not_eq(hash(b0[0:4]), hash(b1[0:4]))
+  @test.assert_not_eq(hash(b0[4:8]), hash(b1[4:8]))
 }
 
 ///|
@@ -378,6 +378,6 @@ test "bytes view hash invariant" {
   let bytes : Array[Bytes] = @quickcheck.samples(20)
   for b in bytes {
     let view = b[:]
-    @test.assert_eq(view.hash(), b.hash())
+    @test.assert_eq(hash(view), hash(b))
   }
 }

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -240,7 +240,7 @@ pub fn[V] HashMap::get_from_bytes(
   self : HashMap[Bytes, V],
   key : BytesView,
 ) -> V? {
-  let hash = key.hash()
+  let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_bytes(entry.key) {
@@ -276,7 +276,7 @@ pub fn[V] HashMap::get_from_string(
   self : HashMap[String, V],
   key : StringView,
 ) -> V? {
-  let hash = key.hash()
+  let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
     guard self.entries[idx] is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_string(entry.key) {

--- a/internal/regex_engine/automata/state.mbt
+++ b/internal/regex_engine/automata/state.mbt
@@ -87,7 +87,7 @@ fn State::new(
   cat : @shared_types.Category,
   desc : ThreadSet,
 ) -> State {
-  { slot, cat, desc, hash: (slot, cat, desc).hash() }
+  { slot, cat, desc, hash: Hash::hash((slot, cat, desc)) }
 }
 
 ///|

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -71,7 +71,7 @@ test "View::default and hash" {
   inspect(v, content="")
   let v1 = "abc".view()
   let v2 = "abc".view()
-  @test.assert_eq(v1.hash(), v2.hash())
+  @test.assert_eq(hash(v1), hash(v2))
 }
 
 ///|

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -661,8 +661,8 @@ test "hash" {
   let a = "abc"
   let b = "def"
   let c = "abc"
-  @test.assert_eq(a.hash(), c.hash())
-  @test.assert_not_eq(a.hash(), b.hash())
+  @test.assert_eq(hash(a), hash(c))
+  @test.assert_not_eq(hash(a), hash(b))
 }
 
 ///|
@@ -674,7 +674,7 @@ test "string view hash invariant" {
   let strings : Array[String] = @quickcheck.samples(20)
   for s in strings {
     let view = s[:]
-    @test.assert_eq(s.hash(), view.hash())
+    @test.assert_eq(hash(s), hash(view))
   }
 }
 

--- a/tuple/tuple_test.mbt
+++ b/tuple/tuple_test.mbt
@@ -120,12 +120,12 @@ test "compare" {
 test "hash" {
   let tuple1 = (1, 2, 3, 4, 5)
   let tuple2 = (1, 2, 3, 4, 5)
-  inspect(tuple1.hash() == tuple2.hash(), content="true")
+  inspect(hash(tuple1) == hash(tuple2), content="true")
   let tuple3 = (5, 4, 3, 2, 1)
-  inspect(tuple1.hash() == tuple1.hash(), content="true")
-  inspect(tuple2.hash() == tuple2.hash(), content="true")
-  inspect(tuple3.hash() == tuple3.hash(), content="true")
-  inspect(tuple1.hash() == tuple3.hash(), content="false")
+  inspect(hash(tuple1) == hash(tuple1), content="true")
+  inspect(hash(tuple2) == hash(tuple2), content="true")
+  inspect(hash(tuple3) == hash(tuple3), content="true")
+  inspect(hash(tuple1) == hash(tuple3), content="false")
 }
 
 ///|

--- a/uint16/README.mbt.md
+++ b/uint16/README.mbt.md
@@ -110,10 +110,10 @@ test "UInt16 default value" {
   let a : UInt16 = 0
   inspect(a, content="0")
 
-  // Hash support is available via .hash()
+  // Hash support is available via hash()
   let value : UInt16 = 42
   // This may be random per process
-  let _ = value.hash()
+  let _ = hash(value)
 }
 ```
 

--- a/uint16/uint16_test.mbt
+++ b/uint16/uint16_test.mbt
@@ -187,12 +187,12 @@ test "UInt16::hash" {
 
 ///|
 test "UInt16::equal" {
-  inspect(UInt16::equal(1, 2), content="false")
-  inspect(UInt16::equal(2, 1), content="false")
-  inspect(UInt16::equal(1, 1), content="true")
-  inspect(UInt16::equal(0, 1), content="false")
-  inspect(UInt16::equal(1, 0), content="false")
-  inspect(UInt16::equal(0, 0), content="true")
+  inspect((1 : UInt16) == 2, content="false")
+  inspect((2 : UInt16) == 1, content="false")
+  inspect((1 : UInt16) == 1, content="true")
+  inspect((0 : UInt16) == 1, content="false")
+  inspect((1 : UInt16) == 0, content="false")
+  inspect((0 : UInt16) == 0, content="true")
 }
 
 ///|
@@ -369,7 +369,7 @@ test "UInt16::to_uint64" {
 test "UInt16::hash_combine" {
   let hasher = @builtin.Hasher(seed=0)
   let value : UInt16 = 42
-  value.hash_combine(hasher)
+  Hash::hash_combine(value, hasher)
   inspect(hasher.finalize(), content="1161967057")
 }
 

--- a/unit/README.mbt.md
+++ b/unit/README.mbt.md
@@ -134,8 +134,8 @@ test "unit trait implementations" {
   inspect(u1.compare(u2), content="0")
 
   // Hashing: consistent hash values
-  let h1 = u1.hash()
-  let h2 = u2.hash()
+  let h1 = hash(u1)
+  let h2 = hash(u2)
   inspect(h1 == h2, content="true")
 
   // Default instance


### PR DESCRIPTION
## Summary

Pre-migrates the call-site changes that #3896 (the `builtin` extend migration) would otherwise carry, so that PR shrinks to its essential content (`extends.mbt` + `moon.pkg` + `.mbti` + test-type extends). Uses the blessed forms now available on main:

- `x.hash()` → `hash(x)` — the free function introduced in #3908 (tests & READMEs)
- `x.hash_combine(h)` → `Hash::hash_combine(x, h)`
- `T::equal(a, b)` → `a == b`
- `c.output(buf)` → `Show::output(c, buf)`

`hashmap/hashmap.mbt` and `internal/regex_engine/automata/state.mbt` use `Hash::hash(...)` instead, matching file-local convention (the local `hash` binding / record field would shadow the free fn).

Semantics-preserving; no interface changes (`moon info` clean, 47 insertions / 47 deletions).

## Verification

- `moon check --deny-warn --target all` — clean
- `moon test builtin bytes hashmap internal/regex_engine string tuple uint16 unit` — 3518 passed