### PR TITLE
feat(builtin): add free `compare` function (prelude), symmetric with `hash`

### DIFF
--- a/builtin/compare_fn.mbt
+++ b/builtin/compare_fn.mbt
@@ -22,7 +22,7 @@
 ///
 /// ```mbt check
 /// test {
-///   inspect(compare(1, 2), content="-1")
+///   inspect(compare(1, 2).is_neg(), content="true")
 ///   inspect(compare("abc", "abc"), content="0")
 /// }
 /// ```

--- a/builtin/compare_fn.mbt
+++ b/builtin/compare_fn.mbt
@@ -1,0 +1,31 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Three-way comparison of two values, returning a negative integer, zero, or
+/// a positive integer when `x` is less than, equal to, or greater than `y`.
+///
+/// This is the free-function form of the `Compare::compare` trait method,
+/// symmetric with `hash`. Being a plain function, it can also be passed as a
+/// function value, e.g. `array.sort_by(compare)`.
+///
+/// ```mbt check
+/// test {
+///   inspect(compare(1, 2), content="-1")
+///   inspect(compare("abc", "abc"), content="0")
+/// }
+/// ```
+pub fn[A : Compare] compare(x : A, y : A) -> Int {
+  Compare::compare(x, y)
+}

--- a/builtin/compare_fn_test.mbt
+++ b/builtin/compare_fn_test.mbt
@@ -18,8 +18,8 @@ test "compare free function" {
   assert_eq(compare(1, 2), Compare::compare(1, 2))
   assert_eq(compare("abd", "abc"), Compare::compare("abd", "abc"))
   // three-way result
-  assert_eq(compare(1, 2), -1)
-  assert_eq(compare(2, 1), 1)
+  assert_true(compare(1, 2).is_neg())
+  assert_true(compare(2, 1).is_pos())
   assert_eq(compare("abc", "abc"), 0)
 }
 

--- a/builtin/compare_fn_test.mbt
+++ b/builtin/compare_fn_test.mbt
@@ -1,0 +1,31 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "compare free function" {
+  // agrees with the trait method
+  assert_eq(compare(1, 2), Compare::compare(1, 2))
+  assert_eq(compare("abd", "abc"), Compare::compare("abd", "abc"))
+  // three-way result
+  assert_eq(compare(1, 2), -1)
+  assert_eq(compare(2, 1), 1)
+  assert_eq(compare("abc", "abc"), 0)
+}
+
+///|
+test "compare as function value" {
+  let arr = [3, 1, 2]
+  arr.sort_by(compare)
+  assert_eq(arr, [1, 2, 3])
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub fn assert_false(Bool, msg? : StringView, loc~ : SourceLoc) -> Unit raise
 #callsite(autofill(loc))
 pub fn assert_true(Bool, msg? : StringView, loc~ : SourceLoc) -> Unit raise
 
+pub fn[A : Compare] compare(A, A) -> Int
+
 pub fn debug_assert(() -> Bool) -> Unit
 
 #callsite(autofill(loc))

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -28,6 +28,8 @@ pub fn[T : @builtin.Eq + @debug.Debug] assert_not_eq(T, T, msg? : String, loc~ :
 #callsite(autofill(loc))
 pub fn assert_true(Bool, msg? : StringView, loc~ : @builtin.SourceLoc) -> Unit raise
 
+pub fn[A : @builtin.Compare] compare(A, A) -> Int
+
 pub fn[T : @debug.Debug] debug(T) -> Unit
 
 pub fn debug_assert(() -> Bool) -> Unit

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -26,6 +26,7 @@ pub using @builtin {
   abort,
   assert_true,
   assert_false,
+  compare,
   debug_assert,
   fail,
   ignore,


### PR DESCRIPTION
## Summary

Adds a free-function **`compare`** — the counterpart to the free `hash` from #3908.

- `builtin/compare_fn.mbt`: `pub fn[A : Compare] compare(x : A, y : A) -> Int { Compare::compare(x, y) }`.
- `prelude/prelude.mbt`: re-exported in the `pub using @builtin { … }` block, so `compare(x, y)` is available **unqualified everywhere**.

Besides reading well at call sites, the free fn works as a first-class function value: `array.sort_by(compare)` instead of `array.sort_by((a, b) => a.compare(b))` (covered by a test).

No conflict: there are no bare `compare(` calls or top-level `compare` functions in the tree (only `Compare::compare` trait impls). Method syntax `x.compare(y)` stays promoted per #3896 — this is purely additive (`pkg.generated.mbti`: +2 each).

## Verification

- `moon check --deny-warn --target all` — clean (builtin, prelude).
- `moon test builtin prelude` — green (2920).