### PR TITLE
fix: label break/continue for pre-release toolchain lint

### DIFF
--- a/builtin/feature_test.mbt
+++ b/builtin/feature_test.mbt
@@ -61,7 +61,7 @@ fn labeld_break(xss : Array[Array[Double]]) -> Double? {
       }
       continue threshold
     } nobreak {
-      continue threshold
+      continue mylabel~ threshold
     }
   } nobreak {
     None

--- a/string/internal/regex_parser/parser.mbt
+++ b/string/internal/regex_parser/parser.mbt
@@ -96,7 +96,7 @@ fn Parser::class_contents(
   outer~: for rest = rest, char_set = @re.RecharSet::empty() {
     match rest {
       [] => raise ctx.error_at(rest, HINT_UNCLOSED_CHAR_CLASS)
-      [']', ..] => break (rest, char_set)
+      [']', ..] => break outer~ (rest, char_set)
       _ => {
         let (rest, left) = match rest {
           ['[', ':', ..] =>


### PR DESCRIPTION
## Summary

The pre-release toolchain (`moonc v0.10.5`, 2026-07-24) adds two new lints that fail `--deny-warn` builds:

- `unlabelled_break_in_labelled_loop`
- `unlabelled_continue_in_labelled_loop`

An unlabelled `break`/`continue` directly inside a labelled loop must now name the label (`break label~ …` / `continue label~ …`).

Two sites in the tree trip these:

- **`string/internal/regex_parser/parser.mbt`** — `break (rest, char_set)` inside the `outer~:` loop → `break outer~ (rest, char_set)`.
- **`builtin/feature_test.mbt`** — `continue threshold` in the inner loop's `nobreak` block, which targets the enclosing `mylabel~` loop → `continue mylabel~ threshold`.

No behavior change — both already targeted those loops implicitly; this just makes the label explicit as the new lint requires.

## Verification (pre-release toolchain)
- `moon check --deny-warn --target all` — clean.
- `moon info` / `moon fmt` — no `.mbti` or formatting drift.
- `moon test --target all` — green (6780 / 6780 / 6736 / 6691).

🤖 Generated with [Claude Code](https://claude.com/claude-code)