### PR TITLE
feat(builtin): add `Json(x)` constructor for any `ToJson` value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,13 +87,15 @@ Within the "safe to promote" set:
   Moon's generated test drivers call `FixedArray::make(512, Byte::default())`, so
   deprecating it breaks `moon test --build-only --deny-warn`. moonbitlang/moon#1938
   removes that call; deprecate `Byte` like the rest once a moon release ships.)
-- **`ToJson::to_json`**: **not promoted** (deprecated → `@json.to_json(x)`, or
-  `ToJson::to_json(x)` in the few `builtin`-source spots that can't reach
-  `@json`), for two reasons: (1) `ToJson` logically belongs in `@json` and may
-  move there — promoting it would cycle on the move (see above); (2) `Json` has
-  literal sugar — `([x, y] : Json)`, `({ "k": v } : Json)` — so you rarely need
-  `x.to_json()` at all. It's cold (not a hot-loop op), so routing through the
-  free function costs nothing.
+- **`ToJson::to_json`**: **not promoted** — use **`Json(x)`**, the constructor of
+  `Json` (re-exported by the prelude, so it needs no import and works from every
+  package, `builtin` included). Between that and `Json`'s literal sugar
+  (`([x, y] : Json)`, `({ "k": v } : Json)`) you rarely need `x.to_json()` at
+  all, and serialization is cold, so nothing is lost by going through the
+  constructor. Because `Json(x)` is spelled the same regardless of which package
+  `Json` lives in, moving `Json`/`ToJson` to `@json` later would not churn call
+  sites — exactly how `to_repr(x)` is spelled the same though `Debug`/`Repr` live
+  in `@debug`.
 
 This policy governs a package's own `extends.mbt` (its public API surface).
 

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -195,6 +195,32 @@ pub fn Json::object(object : Map[String, Json]) -> Json {
 }
 
 ///|
+/// Converts any value implementing `ToJson` into a `Json`.
+///
+/// This is the constructor of `Json`, so it is written `Json(value)`, and it is
+/// re-exported by the prelude — no import is needed. Prefer it over calling
+/// `ToJson::to_json` directly.
+///
+/// Parameters:
+///
+/// * `value` : The value to convert.
+///
+/// Returns the `Json` representation of `value`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   @debug.debug_inspect(Json(42), content="Number(42)")
+///   @debug.debug_inspect(Json("hello"), content="String(\"hello\")")
+///   @debug.debug_inspect(Json([1, 2]), content="Array([Number(1), Number(2)])")
+/// }
+/// ```
+pub fn[T : ToJson] Json::Json(value : T) -> Json {
+  ToJson::to_json(value)
+}
+
+///|
 /// Trait for types that can be converted to `Json`
 pub(open) trait ToJson {
   fn to_json(Self) -> Json

--- a/builtin/json_test.mbt
+++ b/builtin/json_test.mbt
@@ -243,3 +243,25 @@ test "Iter[X] to_json" {
   let v = "a b c d".split(" ")
   @json.json_inspect(v, content=["a", "b", "c", "d"])
 }
+
+///|
+test "Json constructor" {
+  // `Json(x)` converts any `ToJson` value; it is the constructor of `Json`,
+  // re-exported by the prelude so no import is needed.
+  debug_inspect(Json(42), content="Number(42)")
+  debug_inspect(Json("hello"), content="String(\"hello\")")
+  debug_inspect(Json(true), content="True")
+  debug_inspect(Json([1, 2]), content="Array([Number(1), Number(2)])")
+  debug_inspect(
+    Json({ "k": 1 }),
+    content=(
+      #|Object({ "k": Number(1) })
+    ),
+  )
+}
+
+///|
+test "Json constructor is idempotent" {
+  let j : Json = [1, 2]
+  debug_inspect(Json(j), content="Array([Number(1), Number(2)])")
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -355,6 +355,7 @@ pub enum Json {
   Array(Array[Json])
   Object(Map[String, Json])
 }
+pub fn[T : ToJson] Json::Json(T) -> Self
 pub fn Json::array(Array[Self]) -> Self
 pub fn Json::boolean(Bool) -> Self
 pub fn Json::empty_object() -> Self


### PR DESCRIPTION
## Summary

Adds `Json::Json` — a constructor that converts any `ToJson` value into a `Json`:

```moonbit
pub fn[T : ToJson] Json::Json(value : T) -> Json
```

Because it's the constructor of `Json`, it's written **`Json(x)`**, and since the prelude already re-exports `type Json`, the constructor travels with it — so `Json(x)` works from **every package with no import**, `builtin` included. (Verified: it resolves from `@string`, which doesn't depend on `@json`.)

## Why

JSON conversion currently has no spelling that's reachable everywhere:

| | reachable from `builtin`? | |
|---|---|---|
| `@json.to_json(x)` | ❌ `builtin → json` cycle | needs an import |
| `ToJson::to_json(x)` | ✅ | verbose, implementer-flavored |
| **`Json(x)`** | ✅ | short, no import |

It composes with `Json`'s literal sugar — `([x, y] : Json)` for literals, `Json(x)` for conversions — and follows the established constructor convention (`Hasher(seed=0)`, `Replacer(f)`, `Deque(..)`).

## Future-proof against moving `Json` to `@json`

`Json(x)` is spelled the same regardless of which package `Json` lives in — moving `Json`/`ToJson` into `@json` later would only change prelude's `using` line, not call sites. This is exactly how `to_repr(x)` is spelled the same today even though `Debug`/`Repr` live in `@debug` (and `builtin` has *zero* references to `@debug`). Landing the spelling now means a later migration doesn't have to be revised.

## What this unblocks

The promoted `x.to_json()` method can now be deprecated with one obvious, universally available replacement — including in `builtin`'s own call sites, which was the blocker. That's a **follow-up PR**, not this one; this change is purely additive.

## Notes

- `impl ToJson for Json` lives in `@json`, so `Json(j)` on an existing `Json` is idempotent wherever that impl is visible (covered by a test).
- No existing API changed; `@json.to_json` and `ToJson::to_json` still work.

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test --target all` — green (6783 / 6783 / 6739 / 6694).
- `.mbti` diff is exactly one line: the new constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)