### PR TITLE
feat(debug): add `Repr(x)` constructor; deprecate free `to_repr`

### DIFF
--- a/bench/debug.mbt
+++ b/bench/debug.mbt
@@ -16,7 +16,7 @@
 pub impl @debug.Debug for Bench with fn to_repr(self) {
   @debug.Repr::opaque_(
     "Bench",
-    @debug.Repr::array(self.summaries.map(s => @debug.to_repr(s))),
+    @debug.Repr::array(self.summaries.map(s => Repr(s))),
   )
 }
 

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -47,9 +47,9 @@ priv enum Sign {
 test "internal repr" {
   fn convert(b : BigInt) -> @debug.Repr {
     @debug.Repr::record({
-      "limbs": @debug.to_repr(b.limbs),
-      "sign": @debug.to_repr(b.sign),
-      "len": @debug.to_repr(b.len),
+      "limbs": Repr(b.limbs),
+      "sign": Repr(b.sign),
+      "len": Repr(b.len),
     })
   }
   @debug.debug_inspect(

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -18,7 +18,7 @@ struct MyBigInt(BigInt)
 ///|
 impl Show for MyBigInt with fn output(self, logger) {
   logger.write_string(
-    "{limbs : \{@debug.to_repr(self.limbs)}, sign : \{@debug.to_repr(self.sign)}, len : \{self.len} }",
+    "{limbs : \{@debug.Repr(self.limbs)}, sign : \{@debug.Repr(self.sign)}, len : \{self.len} }",
   )
 }
 
@@ -67,13 +67,13 @@ fn check_invariant(a : BigInt) -> Unit raise {
   } else {
     guard a.len == 1 && a.limbs[0] == 0 else {
       fail(
-        "invariant (forall 0 <= i < len. limbs[i] == 0) => limbs[0] == 0 and len == 1 is broken: len = \{a.len}, limbs = \{@debug.to_repr(a.limbs)}",
+        "invariant (forall 0 <= i < len. limbs[i] == 0) => limbs[0] == 0 and len == 1 is broken: len = \{a.len}, limbs = \{@debug.Repr(a.limbs)}",
       )
     }
   }
   guard a.limbs.iter().drop(a.len).all(x => x == 0) else {
     fail(
-      "invariant forall len <= i < limbs.length(). limbs[i] == 0 is broken: len = \{a.len}, limbs = \{@debug.to_repr(a.limbs)}",
+      "invariant forall len <= i < limbs.length(). limbs[i] == 0 is broken: len = \{a.len}, limbs = \{@debug.Repr(a.limbs)}",
     )
   }
 }

--- a/buffer/debug.mbt
+++ b/buffer/debug.mbt
@@ -14,13 +14,13 @@
 
 ///|
 pub impl @debug.Debug for Buffer with fn to_repr(self) {
-  @debug.Repr::opaque_("Buffer", @debug.to_repr(self.to_bytes().to_array()))
+  @debug.Repr::opaque_("Buffer", Repr(self.to_bytes().to_array()))
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn Buffer::to_repr(self : Buffer) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -415,7 +415,7 @@ test "iter2" {
 test "to_string" {
   let arr = [0, 1, 2, 3, 4]
   @json.json_inspect(arr[1:3], content=[1, 2])
-  @json.json_inspect("\{to_repr(arr[1:3])}!", content="<ArrayView: [1, 2]>!")
+  @json.json_inspect("\{Repr(arr[1:3])}!", content="<ArrayView: [1, 2]>!")
 }
 
 ///|

--- a/builtin/repr_test.mbt
+++ b/builtin/repr_test.mbt
@@ -14,14 +14,14 @@
 
 ///|
 test "repr" {
-  inspect(to_repr(1), content="1")
-  inspect(to_repr("x"), content="\"x\"")
-  inspect(to_repr(true), content="true")
-  inspect(to_repr(false), content="false")
-  inspect(to_repr(1.0), content="1")
-  inspect(to_repr('a'), content="'a'")
+  inspect(Repr(1), content="1")
+  inspect(Repr("x"), content="\"x\"")
+  inspect(Repr(true), content="true")
+  inspect(Repr(false), content="false")
+  inspect(Repr(1.0), content="1")
+  inspect(Repr('a'), content="'a'")
   inspect(
-    to_repr((1, "x", '\n', ['a'])),
+    Repr((1, "x", '\n', ['a'])),
     content=(
       #|(1, "x", '\n', ['a'])
     ),

--- a/bytes/internal/regex_engine/ast/pattern.mbt
+++ b/bytes/internal/regex_engine/ast/pattern.mbt
@@ -45,7 +45,7 @@ pub struct Pattern {
 
 ///|
 pub impl @debug.Debug for Pattern with fn to_repr(self) {
-  @debug.to_repr(self.desc)
+  Repr(self.desc)
 }
 
 ///|

--- a/debug/README.mbt.md
+++ b/debug/README.mbt.md
@@ -20,7 +20,7 @@ output. Some common cases:
   textual formats such as JSON, XML, or domain-specific display text.
 - Use `debug_inspect(value, content=...)` instead of `inspect(value, content=...)`.
 - Use `@debug.assert_eq(a, b)` instead of `@test.assert_eq(a, b)`.
-- Use `\{to_repr(value)}` in string interpolation instead of `\{value}` for composed values.
+- Use `\{Repr(value)}` in string interpolation instead of `\{value}` for composed values.
 - Use `@debug.to_string(value)` instead of `value.to_string()` for composed values,
   when the string is only used for debugging.
 
@@ -58,7 +58,7 @@ Use `to_repr` in string interpolation:
 test "string interpolation" {
   let arr = [1, 2, 3]
   inspect(
-    "arr: \{to_repr(arr)}",
+    "arr: \{Repr(arr)}",
     content=(
       #|arr: [1, 2, 3]
     ),

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -15,7 +15,7 @@
 ///|
 /// Trait for types that can be converted to human-readable debugging info.
 pub(open) trait Debug {
-  #as_free_fn
+  #as_free_fn(deprecated="Use `Repr(x)` instead")
   fn to_repr(Self) -> Repr
 }
 
@@ -87,12 +87,12 @@ pub impl Debug for StringView with fn to_repr(self) {
 
 ///|
 pub impl Debug for Bytes with fn to_repr(self) {
-  Repr::opaque_("Bytes", Repr::array(self.to_array().map(x => to_repr(x))))
+  Repr::opaque_("Bytes", Repr::array(self.to_array().map(x => Repr(x))))
 }
 
 ///|
 pub impl Debug for BytesView with fn to_repr(self) {
-  Repr::opaque_("BytesView", Repr::array(self.to_array().map(x => to_repr(x))))
+  Repr::opaque_("BytesView", Repr::array(self.to_array().map(x => Repr(x))))
 }
 
 ///|
@@ -102,41 +102,41 @@ pub impl Debug for Unit with fn to_repr(_) {
 
 ///|
 pub impl[T : Debug] Debug for Array[T] with fn to_repr(self) {
-  Repr::array(self.map(x => to_repr(x)))
+  Repr::array(self.map(x => Repr(x)))
 }
 
 ///|
 pub impl[T : Debug] Debug for ArrayView[T] with fn to_repr(self) {
-  Repr::opaque_("ArrayView", Repr::array(self.map(x => to_repr(x))))
+  Repr::opaque_("ArrayView", Repr::array(self.map(x => Repr(x))))
 }
 
 ///|
 pub impl[T : Debug] Debug for FixedArray[T] with fn to_repr(self) {
   // `FixedArray` can be viewed as `ArrayView` via slicing.
   let view : ArrayView[T] = self
-  Repr::opaque_("FixedArray", Repr::array(view.map(x => to_repr(x))))
+  Repr::opaque_("FixedArray", Repr::array(view.map(x => Repr(x))))
 }
 
 ///|
 pub impl[T : Debug] Debug for ReadOnlyArray[T] with fn to_repr(self) {
   // `ReadOnlyArray` can be viewed as `ArrayView` via slicing.
   let view : ArrayView[T] = self
-  Repr::opaque_("ReadOnlyArray", Repr::array(view.map(x => to_repr(x))))
+  Repr::opaque_("ReadOnlyArray", Repr::array(view.map(x => Repr(x))))
 }
 
 ///|
 pub impl[T : Debug] Debug for T? with fn to_repr(self) {
   match self {
     None => Repr::ctor("None", [])
-    Some(x) => Repr::ctor("Some", [(None, to_repr(x))])
+    Some(x) => Repr::ctor("Some", [(None, Repr(x))])
   }
 }
 
 ///|
 pub impl[T : Debug, E : Debug] Debug for Result[T, E] with fn to_repr(self) {
   match self {
-    Ok(x) => Repr::ctor("Ok", [(None, to_repr(x))])
-    Err(e) => Repr::ctor("Err", [(None, to_repr(e))])
+    Ok(x) => Repr::ctor("Ok", [(None, Repr(x))])
+    Err(e) => Repr::ctor("Err", [(None, Repr(e))])
   }
 }
 
@@ -152,7 +152,7 @@ pub impl[A, B] Debug for Iter2[A, B] with fn to_repr(_) {
 
 ///|
 pub impl[T : Debug] Debug for MutArrayView[T] with fn to_repr(self) {
-  Repr::opaque_("MutArrayView", Repr::array(self[:].map(x => to_repr(x))))
+  Repr::opaque_("MutArrayView", Repr::array(self[:].map(x => Repr(x))))
 }
 
 ///|
@@ -162,7 +162,7 @@ pub impl Debug for StringBuilder with fn to_repr(self) {
 
 ///|
 pub impl[K : Debug, V : Debug] Debug for Map[K, V] with fn to_repr(self) {
-  Repr::map([ for k, v in self => (to_repr(k), to_repr(v)) ])
+  Repr::map([ for k, v in self => (Repr(k), Repr(v)) ])
 }
 
 ///|
@@ -173,16 +173,16 @@ pub impl Debug for Json with fn to_repr(self) {
     False => Repr::ctor("False", [])
     Number(number, repr~) =>
       match repr {
-        None => Repr::ctor("Number", [(None, to_repr(number))])
+        None => Repr::ctor("Number", [(None, Repr(number))])
         Some(_) =>
           Repr::ctor("Number", [
-            (None, to_repr(number)),
-            (Some("repr"), to_repr(repr)),
+            (None, Repr(number)),
+            (Some("repr"), Repr(repr)),
           ])
       }
-    String(string) => Repr::ctor("String", [(None, to_repr(string))])
-    Array(array) => Repr::ctor("Array", [(None, to_repr(array))])
-    Object(object) => Repr::ctor("Object", [(None, to_repr(object))])
+    String(string) => Repr::ctor("String", [(None, Repr(string))])
+    Array(array) => Repr::ctor("Array", [(None, Repr(array))])
+    Object(object) => Repr::ctor("Object", [(None, Repr(object))])
   }
 }
 
@@ -264,8 +264,8 @@ pub fn[T : Eq + Debug] assert_eq(
     let fail_msg = match msg {
       Some(msg) => msg
       None => {
-        let repr_a = to_repr(a)
-        let repr_b = to_repr(b)
+        let repr_a = Repr(a)
+        let repr_b = Repr(b)
         let diff = pretty_print_delta(diff_repr(repr_a, repr_b), use_ansi=false)
         (
           $|`\{render(repr_a)} != \{render(repr_b)}`
@@ -365,7 +365,7 @@ pub impl Debug for BenchError with fn to_repr(self) {
 ///|
 pub impl Debug for ArgsLoc with fn to_repr(self) {
   let ArgsLoc(arr) = self
-  Repr::opaque_("ArgsLoc", to_repr(arr))
+  Repr::opaque_("ArgsLoc", Repr(arr))
 }
 
 ///|

--- a/debug/debug_coverage_test.mbt
+++ b/debug/debug_coverage_test.mbt
@@ -165,15 +165,13 @@ test "render of opaque builtin types" {
 ///|
 test "depth-limited render replaces deep subtrees with ellipsis" {
   let nested = [[[[[1, 2]]]]]
-  assert_true(@debug.render(@debug.to_repr(nested)).contains("1"))
-  assert_true(
-    @debug.render(@debug.to_repr(nested), max_depth=1).contains("..."),
-  )
+  assert_true(@debug.render(Repr(nested)).contains("1"))
+  assert_true(@debug.render(Repr(nested), max_depth=1).contains("..."))
   // a depth-limited record still renders its (pruned) fields
   let p : CovPoint = { x: 7, y: 8.0 }
-  assert_true(@debug.render(@debug.to_repr(p), max_depth=1).length() > 0)
+  assert_true(@debug.render(Repr(p), max_depth=1).length() > 0)
   // depth <= 0 is treated as 1, so max_depth=0 renders identically to max_depth=1
-  let r = @debug.to_repr(nested)
+  let r = Repr(nested)
   @debug.assert_eq(@debug.render(r, max_depth=0), @debug.render(r, max_depth=1))
 }
 

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -33,7 +33,7 @@ pub impl Debug for Repr
 
 // Traits
 pub(open) trait Debug {
-  #as_free_fn
+  #as_free_fn(deprecated)
   fn to_repr(Self) -> Repr
 }
 pub impl Debug for Unit

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub fn[T : Debug] to_string(T) -> String
 
 // Types and methods
 type Repr
+pub fn[T : Debug] Repr::Repr(T) -> Self
 pub fn Repr::to_string(Self) -> String
 pub impl Show for Repr
 pub impl Debug for Repr

--- a/debug/pretty_print.mbt
+++ b/debug/pretty_print.mbt
@@ -273,7 +273,7 @@ pub fn[T : Debug] debug(x : T) -> Unit {
 
 ///|
 /// Convert a value to its debug string representation. Equivalent to
-/// `@debug.to_repr(x).to_string()`, but spelled in one step.
+/// `Repr(x).to_string()`, but spelled in one step.
 ///
 /// Also exported under the shorter name `repr` (re-exported from prelude,
 /// so it is callable without import). The two names refer to the same

--- a/debug/repr.mbt
+++ b/debug/repr.mbt
@@ -161,6 +161,31 @@ pub fn Repr::traverse(self : Repr, f : (Repr) -> Repr) -> Repr {
 }
 
 ///|
+/// Converts any value implementing `Debug` into a `Repr`.
+///
+/// This is the constructor of `Repr`, so it is written `Repr(value)`, and it is
+/// re-exported by the prelude — no import is needed.
+///
+/// Parameters:
+///
+/// * `value` : The value to convert.
+///
+/// Returns the `Repr` representation of `value`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect(Repr(42), content="42")
+///   inspect(Repr("hello"), content="\"hello\"")
+///   inspect(Repr([1, 2]), content="[1, 2]")
+/// }
+/// ```
+pub fn[T : Debug] Repr::Repr(value : T) -> Repr {
+  Debug::to_repr(value)
+}
+
+///|
 /// Construct a `Integer` leaf.
 #doc(hidden)
 pub fn Repr::integer(x : String) -> Repr {

--- a/debug/tuple_debug.mbt
+++ b/debug/tuple_debug.mbt
@@ -15,7 +15,7 @@
 ///|
 pub impl[A : Debug, B : Debug] Debug for (A, B) with fn to_repr(self) {
   let (a, b) = self
-  Repr::tuple([to_repr(a), to_repr(b)])
+  Repr::tuple([Repr(a), Repr(b)])
 }
 
 ///|
@@ -23,7 +23,7 @@ pub impl[A : Debug, B : Debug, C : Debug] Debug for (A, B, C) with fn to_repr(
   self,
 ) {
   let (a, b, c) = self
-  Repr::tuple([to_repr(a), to_repr(b), to_repr(c)])
+  Repr::tuple([Repr(a), Repr(b), Repr(c)])
 }
 
 ///|
@@ -31,7 +31,7 @@ pub impl[A : Debug, B : Debug, C : Debug, D : Debug] Debug for (A, B, C, D) with
   self,
 ) {
   let (a, b, c, d) = self
-  Repr::tuple([to_repr(a), to_repr(b), to_repr(c), to_repr(d)])
+  Repr::tuple([Repr(a), Repr(b), Repr(c), Repr(d)])
 }
 
 ///|
@@ -43,7 +43,7 @@ pub impl[A : Debug, B : Debug, C : Debug, D : Debug, E : Debug] Debug for (
   E,
 ) with fn to_repr(self) {
   let (a, b, c, d, e) = self
-  Repr::tuple([to_repr(a), to_repr(b), to_repr(c), to_repr(d), to_repr(e)])
+  Repr::tuple([Repr(a), Repr(b), Repr(c), Repr(d), Repr(e)])
 }
 
 ///|
@@ -56,14 +56,7 @@ pub impl[A : Debug, B : Debug, C : Debug, D : Debug, E : Debug, F : Debug] Debug
   F,
 ) with fn to_repr(self) {
   let (a, b, c, d, e, f) = self
-  Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-  ])
+  Repr::tuple([Repr(a), Repr(b), Repr(c), Repr(d), Repr(e), Repr(f)])
 }
 
 ///|
@@ -77,15 +70,7 @@ pub impl[
   G : Debug,
 ] Debug for (A, B, C, D, E, F, G) with fn to_repr(self) {
   let (a, b, c, d, e, f, g) = self
-  Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-  ])
+  Repr::tuple([Repr(a), Repr(b), Repr(c), Repr(d), Repr(e), Repr(f), Repr(g)])
 }
 
 ///|
@@ -101,14 +86,14 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
   ])
 }
 
@@ -126,15 +111,15 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H, I) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h, i) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
   ])
 }
 
@@ -153,16 +138,16 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H, I, J) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h, i, j) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
   ])
 }
 
@@ -182,17 +167,17 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H, I, J, K) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h, i, j, k) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
   ])
 }
 
@@ -213,18 +198,18 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H, I, J, K, L) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h, i, j, k, l) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
   ])
 }
 
@@ -246,19 +231,19 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H, I, J, K, L, M) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
   ])
 }
 
@@ -281,20 +266,20 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H, I, J, K, L, M, N) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
   ])
 }
 
@@ -318,21 +303,21 @@ pub impl[
 ] Debug for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) with fn to_repr(self) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
   ])
 }
 
@@ -359,22 +344,22 @@ pub impl[
 ) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
-    to_repr(p),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
+    Repr(p),
   ])
 }
 
@@ -402,23 +387,23 @@ pub impl[
 ) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
-    to_repr(p),
-    to_repr(q),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
+    Repr(p),
+    Repr(q),
   ])
 }
 
@@ -447,24 +432,24 @@ pub impl[
 ) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
-    to_repr(p),
-    to_repr(q),
-    to_repr(r),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
+    Repr(p),
+    Repr(q),
+    Repr(r),
   ])
 }
 
@@ -494,25 +479,25 @@ pub impl[
 ) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
-    to_repr(p),
-    to_repr(q),
-    to_repr(r),
-    to_repr(s),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
+    Repr(p),
+    Repr(q),
+    Repr(r),
+    Repr(s),
   ])
 }
 
@@ -543,26 +528,26 @@ pub impl[
 ) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
-    to_repr(p),
-    to_repr(q),
-    to_repr(r),
-    to_repr(s),
-    to_repr(t),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
+    Repr(p),
+    Repr(q),
+    Repr(r),
+    Repr(s),
+    Repr(t),
   ])
 }
 
@@ -594,27 +579,27 @@ pub impl[
 ) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
-    to_repr(p),
-    to_repr(q),
-    to_repr(r),
-    to_repr(s),
-    to_repr(t),
-    to_repr(u),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
+    Repr(p),
+    Repr(q),
+    Repr(r),
+    Repr(s),
+    Repr(t),
+    Repr(u),
   ])
 }
 
@@ -647,27 +632,27 @@ pub impl[
 ) {
   let (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) = self
   Repr::tuple([
-    to_repr(a),
-    to_repr(b),
-    to_repr(c),
-    to_repr(d),
-    to_repr(e),
-    to_repr(f),
-    to_repr(g),
-    to_repr(h),
-    to_repr(i),
-    to_repr(j),
-    to_repr(k),
-    to_repr(l),
-    to_repr(m),
-    to_repr(n),
-    to_repr(o),
-    to_repr(p),
-    to_repr(q),
-    to_repr(r),
-    to_repr(s),
-    to_repr(t),
-    to_repr(u),
-    to_repr(v),
+    Repr(a),
+    Repr(b),
+    Repr(c),
+    Repr(d),
+    Repr(e),
+    Repr(f),
+    Repr(g),
+    Repr(h),
+    Repr(i),
+    Repr(j),
+    Repr(k),
+    Repr(l),
+    Repr(m),
+    Repr(n),
+    Repr(o),
+    Repr(p),
+    Repr(q),
+    Repr(r),
+    Repr(s),
+    Repr(t),
+    Repr(u),
+    Repr(v),
   ])
 }

--- a/deque/debug.mbt
+++ b/deque/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[A : @debug.Debug] @debug.Debug for Deque[A] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "Deque",
-    @debug.Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+    @debug.Repr::array(self.to_array().map(x => Repr(x))),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[A : @debug.Debug] Deque::to_repr(self : Deque[A]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/error/debug.mbt
+++ b/error/debug.mbt
@@ -21,9 +21,9 @@ pub impl @debug.Debug for Error with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn Error::to_repr(self : Error) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/hashmap/debug.mbt
+++ b/hashmap/debug.mbt
@@ -18,20 +18,16 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V] with
 ) {
   @debug.Repr::opaque_(
     "HashMap",
-    @debug.Repr::map(
-      [
-        for k, v in self => (@debug.to_repr(k), @debug.to_repr(v))
-      ],
-    ),
+    @debug.Repr::map([ for k, v in self => (Repr(k), Repr(v)) ]),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(
   self : HashMap[K, V],
 ) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -335,7 +335,7 @@ test "get_nonexistent_key_with_psl" {
 test "from_iter multiple elements iter" {
   let map = @hashmap.from_iter([(1, 1), (2, 2), (3, 3)].iter())
   guard map is { 1: 1, 2: 2, 3: 3, .. } else {
-    fail("Map is not expected: \{@debug.to_repr(map)}")
+    fail("Map is not expected: \{Repr(map)}")
   }
   inspect(map.length(), content="3")
 }
@@ -481,7 +481,7 @@ fn[K : Hash + Eq + Debug, V : Eq + Debug] verify_content(
     let (k, v) = entry
     assert_true(
       map.contains_kv(k, v),
-      msg="Key \{@debug.to_repr(k)} with value \{@debug.to_repr(v)} not found in map \{@debug.to_repr(map)}",
+      msg="Key \{Repr(k)} with value \{Repr(v)} not found in map \{Repr(map)}",
     )
   }
   @test.assert_eq(map.length(), expected.length())

--- a/hashset/debug.mbt
+++ b/hashset/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[K : @debug.Debug] @debug.Debug for HashSet[K] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "HashSet",
-    @debug.Repr::array([ for x in self => @debug.to_repr(x) ]),
+    @debug.Repr::array([ for x in self => Repr(x) ]),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[K : @debug.Debug] HashSet::to_repr(self : HashSet[K]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/immut/array/debug.mbt
+++ b/immut/array/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[A : @debug.Debug] @debug.Debug for T[A] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "Array",
-    @debug.Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+    @debug.Repr::array(self.to_array().map(x => Repr(x))),
   )
 }
 
 ///|
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
 pub fn[A : @debug.Debug] T::to_repr(self : T[A]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/immut/hashmap/debug.mbt
+++ b/immut/hashmap/debug.mbt
@@ -18,20 +18,16 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V] with
 ) {
   @debug.Repr::opaque_(
     "HashMap",
-    @debug.Repr::map(
-      [
-        for k, v in self => (@debug.to_repr(k), @debug.to_repr(v))
-      ],
-    ),
+    @debug.Repr::map([ for k, v in self => (Repr(k), Repr(v)) ]),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(
   self : HashMap[K, V],
 ) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/immut/hashset/debug.mbt
+++ b/immut/hashset/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[K : @debug.Debug] @debug.Debug for HashSet[K] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "HashSet",
-    @debug.Repr::array([ for x in self => @debug.to_repr(x) ]),
+    @debug.Repr::array([ for x in self => Repr(x) ]),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[K : @debug.Debug] HashSet::to_repr(self : HashSet[K]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/immut/priority_queue/debug.mbt
+++ b/immut/priority_queue/debug.mbt
@@ -16,16 +16,16 @@
 pub impl[A : @debug.Debug + Compare] @debug.Debug for PriorityQueue[A] with fn to_repr(
   self,
 ) {
-  let xs : Array[@debug.Repr] = self.to_array().map(x => @debug.to_repr(x))
+  let xs : Array[@debug.Repr] = self.to_array().map(x => Repr(x))
   @debug.Repr::opaque_("PriorityQueue", @debug.Repr::array(xs))
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(
   self : PriorityQueue[A],
 ) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/immut/sorted_map/debug.mbt
+++ b/immut/sorted_map/debug.mbt
@@ -18,18 +18,16 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for SortedMap[K, V] wi
 ) {
   @debug.Repr::opaque_(
     "SortedMap",
-    @debug.Repr::map(
-      self.to_array().map(kv => (@debug.to_repr(kv.0), @debug.to_repr(kv.1))),
-    ),
+    @debug.Repr::map(self.to_array().map(kv => (Repr(kv.0), Repr(kv.1)))),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[K : @debug.Debug, V : @debug.Debug] SortedMap::to_repr(
   self : SortedMap[K, V],
 ) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -137,7 +137,7 @@ test "iter" {
     buf.write_string("\n")
   }
   for k, v in map {
-    buf.write_string("(\{k}, \{@debug.to_repr(v)})")
+    buf.write_string("(\{k}, \{Repr(v)})")
     buf.write_string("\n")
   }
   inspect(

--- a/immut/sorted_set/debug.mbt
+++ b/immut/sorted_set/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[K : @debug.Debug] @debug.Debug for SortedSet[K] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "SortedSet",
-    @debug.Repr::array([ for x in self => @debug.to_repr(x) ]),
+    @debug.Repr::array([ for x in self => Repr(x) ]),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[K : @debug.Debug] SortedSet::to_repr(self : SortedSet[K]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/immut/vector/debug.mbt
+++ b/immut/vector/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[A : @debug.Debug] @debug.Debug for Vector[A] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "Vector",
-    @debug.Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+    @debug.Repr::array(self.to_array().map(x => Repr(x))),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[A : @debug.Debug] Vector::to_repr(self : Vector[A]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/internal/regex_engine/shared_types/rechar_set/rechar_set.mbt
+++ b/internal/regex_engine/shared_types/rechar_set/rechar_set.mbt
@@ -359,5 +359,5 @@ pub impl BitAnd for RecharSet with fn land(self, other) {
 
 ///|
 pub impl @debug.Debug for RecharSet with fn to_repr(self) {
-  @debug.to_repr(self.intervals().to_array())
+  Repr(self.intervals().to_array())
 }

--- a/lazy/debug.mbt
+++ b/lazy/debug.mbt
@@ -25,7 +25,7 @@
 /// Safe to call on infinite or effectful thunks.
 pub impl[A : @debug.Debug] @debug.Debug for Lazy[A] with fn to_repr(self) {
   match self.state {
-    Forced(v) => @debug.Repr::opaque_("Lazy", @debug.to_repr(v))
+    Forced(v) => @debug.Repr::opaque_("Lazy", Repr(v))
     Forcing => @debug.Repr::opaque_("Lazy", @debug.Repr::literal("forcing"))
     Unforced(_) => @debug.Repr::opaque_("Lazy", @debug.Repr::omitted())
   }

--- a/lazy/lazy_test.mbt
+++ b/lazy/lazy_test.mbt
@@ -101,7 +101,7 @@ test "Debug renders the in-progress Forcing state" {
   let observed : Ref[String] = Ref("")
   let holder : Array[@lazy.Lazy[Int]] = []
   let cell = @lazy.Lazy(() => {
-    observed.val = @debug.to_repr(holder[0]).to_string()
+    observed.val = Repr(holder[0]).to_string()
     42
   })
   holder.push(cell)

--- a/lazy_list/debug.mbt
+++ b/lazy_list/debug.mbt
@@ -31,7 +31,7 @@ pub impl[A : @debug.Debug] @debug.Debug for LazyList[A] with fn to_repr(self) {
     match cur.cell {
       Empty => break
       Cons(x, tail~) => {
-        parts.push(@debug.to_repr(x))
+        parts.push(@debug.Repr(x))
         match tail.peek() {
           Some(next) => continue next
           None => {

--- a/list/debug.mbt
+++ b/list/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[A : @debug.Debug] @debug.Debug for List[A] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "List",
-    @debug.Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+    @debug.Repr::array(self.to_array().map(x => Repr(x))),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[A : @debug.Debug] List::to_repr(self : List[A]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -76,6 +76,7 @@ pub using @builtin {
 pub using @builtin {not}
 
 ///|
+#warnings("-deprecated")
 pub using @debug {debug, type Repr, trait Debug, debug_inspect, repr, to_repr}
 
 ///|

--- a/priority_queue/debug.mbt
+++ b/priority_queue/debug.mbt
@@ -18,16 +18,16 @@ pub impl[A : @debug.Debug + Compare] @debug.Debug for PriorityQueue[A] with fn t
 ) {
   @debug.Repr::opaque_(
     "PriorityQueue",
-    @debug.Repr::array([ for x in self => @debug.to_repr(x) ]),
+    @debug.Repr::array([ for x in self => Repr(x) ]),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(
   self : PriorityQueue[A],
 ) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/queue/debug.mbt
+++ b/queue/debug.mbt
@@ -16,14 +16,14 @@
 pub impl[A : @debug.Debug] @debug.Debug for Queue[A] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "Queue",
-    @debug.Repr::array([ for x in self => @debug.to_repr(x) ]),
+    @debug.Repr::array([ for x in self => Repr(x) ]),
   )
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[A : @debug.Debug] Queue::to_repr(self : Queue[A]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/ref/debug.mbt
+++ b/ref/debug.mbt
@@ -14,13 +14,13 @@
 
 ///|
 pub impl[T : @debug.Debug] @debug.Debug for Ref[T] with fn to_repr(self) {
-  @debug.Repr::opaque_("Ref", @debug.to_repr(self.val))
+  @debug.Repr::opaque_("Ref", Repr(self.val))
 }
 
 ///|
-#deprecated("use `to_repr(a)` instead", skip_current_package=true)
+#deprecated("use `Repr(a)` instead", skip_current_package=true)
 pub fn[T : @debug.Debug] Ref::to_repr(self : Ref[T]) -> @debug.Repr {
-  @debug.to_repr(self)
+  Repr(self)
 }
 
 ///|

--- a/set/debug.mbt
+++ b/set/debug.mbt
@@ -16,7 +16,7 @@
 pub impl[K : @debug.Debug] @debug.Debug for Set[K] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "Set",
-    @debug.Repr::array(self.to_array().map(x => @debug.to_repr(x))),
+    @debug.Repr::array(self.to_array().map(x => Repr(x))),
   )
 }
 

--- a/sorted_map/debug.mbt
+++ b/sorted_map/debug.mbt
@@ -18,11 +18,7 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for SortedMap[K, V] wi
 ) {
   @debug.Repr::opaque_(
     "SortedMap",
-    @debug.Repr::map(
-      [
-        for k, v in self => (@debug.to_repr(k), @debug.to_repr(v))
-      ],
-    ),
+    @debug.Repr::map([ for k, v in self => (Repr(k), Repr(v)) ]),
   )
 }
 

--- a/sorted_set/debug.mbt
+++ b/sorted_set/debug.mbt
@@ -16,7 +16,7 @@
 pub impl[V : @debug.Debug] @debug.Debug for SortedSet[V] with fn to_repr(self) {
   @debug.Repr::opaque_(
     "SortedSet",
-    @debug.Repr::array([ for x in self => @debug.to_repr(x) ]),
+    @debug.Repr::array([ for x in self => Repr(x) ]),
   )
 }
 

--- a/string/internal/regex_engine/ast/pattern.mbt
+++ b/string/internal/regex_engine/ast/pattern.mbt
@@ -45,7 +45,7 @@ pub struct Pattern {
 
 ///|
 pub impl @debug.Debug for Pattern with fn to_repr(self) {
-  @debug.to_repr(self.desc)
+  Repr(self.desc)
 }
 
 ///|

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -79,7 +79,7 @@ const MAX_REPEAT_QUANTIFIER = 256
 
 ///|
 pub impl @debug.Debug for Regex with fn to_repr(self) {
-  @debug.Repr::opaque_("Regex", @debug.to_repr(self.pat))
+  @debug.Repr::opaque_("Regex", Repr(self.pat))
 }
 
 ///|

--- a/string/string_unicode_test.mbt
+++ b/string/string_unicode_test.mbt
@@ -29,7 +29,7 @@ test {
   )
   let v = "\u{00AD}Hello, \u{2060}世界\t\n!\u{1D173}"
   inspect(
-    to_repr(v),
+    Repr(v),
     content=(
       #|"­Hello, ⁠世界\t\n!𝅳"
     ),


### PR DESCRIPTION
## Summary

Adds the `Repr` counterpart to `Json(x)` (#3924), and migrates off the free `to_repr`.

**1. Constructor**

```moonbit
pub fn[T : Debug] Repr::Repr(value : T) -> Repr
```

Because it's the constructor of `Repr`, it's written **`Repr(x)`**, and since the prelude already re-exports `type Repr` (`prelude/prelude.mbt:79`) the constructor travels with it — no import needed.

**2. `to_repr` deprecated + all call sites migrated**

The free `to_repr` (generated by `#as_free_fn` on `Debug::to_repr`) is now `#as_free_fn(deprecated="Use \`Repr(x)\` instead")`, and every call site is migrated.

## Spelling

Which form a call site uses follows normal prelude scoping — core's own library and whitebox code sits *below* prelude in the dep graph and never gets its re-exports (exactly why that code already wrote `@debug.to_repr(x)` rather than bare `to_repr(x)`):

| Context | Spelling |
|---|---|
| User code, blackbox tests, packages with `Repr` in scope | `Repr(x)` |
| Whitebox / library without it — `bigint/bigint_nonjs_wbtest.mbt`, `lazy_list/debug.mbt` | `@debug.Repr(x)` |

The compiler drove this: after rewriting, `unnecessary_annotation` identified where `@debug.` could be dropped, and `Repr is unbound` identified the two files that must keep it.

Also updated: the `#deprecated` messages on the per-package `X::to_repr` wrappers now say ``use `Repr(a)` instead`` rather than ``use `to_repr(a)` instead``, so they point at the surviving spelling.

## Prelude

`to_repr` stays in prelude's re-export list, with `#warnings("-deprecated")` at the re-export site. Existing user code therefore gets a **deprecation warning and a migration path** rather than an unbound identifier.

## Interface effect

`debug/pkg.generated.mbti` gains the constructor and marks the free function deprecated:

```diff
+pub fn[T : Debug] Repr::Repr(T) -> Self
 pub(open) trait Debug {
-  #as_free_fn
+  #as_free_fn(deprecated)
   fn to_repr(Self) -> Repr
 }
```

## Verification
- `moon check --deny-warn --target all` — clean.
- `moon test --target all` — green (6785 / 6785 / 6741 / 6696).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
