### PR TITLE
refactor(prelude): deprecate re-exported `to_repr`, migrate last call sites

### DIFF
--- a/builtin/show_test.mbt
+++ b/builtin/show_test.mbt
@@ -814,16 +814,16 @@ test "char show hex digits" {
   // inspect('\x01', content="\x01")
   // FIXME: inspect('\x0b') will not work with update test
   // inspect('\x0b', content="\x0b")
-  inspect('\u{01}' |> to_repr, content="'\\u{01}'")
-  inspect('\u{0b}' |> to_repr, content="'\\u{0b}'")
+  inspect(Repr('\u{01}'), content="'\\u{01}'")
+  inspect(Repr('\u{0b}'), content="'\\u{0b}'")
 }
 
 ///|
 test "char show hex digits extended" {
-  inspect('\u{0605}' |> to_repr, content="'\\u{0605}'")
-  inspect('\u{FDD0}' |> to_repr, content="'\\u{fdd0}'")
-  inspect('\u{1FFFE}' |> to_repr, content="'\\u{01fffe}'")
-  inspect('\u{10FFFE}' |> to_repr, content="'\\u{10fffe}'")
+  inspect(Repr('\u{0605}'), content="'\\u{0605}'")
+  inspect(Repr('\u{FDD0}'), content="'\\u{fdd0}'")
+  inspect(Repr('\u{1FFFE}'), content="'\\u{01fffe}'")
+  inspect(Repr('\u{10FFFE}'), content="'\\u{10fffe}'")
 }
 
 ///|

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -73,6 +73,7 @@ pub fn[T] tap(T, (T) -> Unit raise) -> T raise
 #deprecated
 pub fn[T, R] then(T, (T) -> R raise?) -> R raise?
 
+#deprecated
 pub fn[Self : @debug.Debug] to_repr(Self) -> @debug.Repr
 
 // Errors

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -76,8 +76,12 @@ pub using @builtin {
 pub using @builtin {not}
 
 ///|
+pub using @debug {debug, type Repr, trait Debug, debug_inspect, repr}
+
+///|
+#deprecated("Use `Repr(x)` instead")
 #warnings("-deprecated")
-pub using @debug {debug, type Repr, trait Debug, debug_inspect, repr, to_repr}
+pub using @debug {to_repr}
 
 ///|
 #deprecated("for debugging only, not for production")


### PR DESCRIPTION
Completes the `to_repr` → `Repr(x)` migration started in c2fb8b6e.

The prelude re-export now carries `#deprecated("Use \`Repr(x)\` instead")`, matching the wording on `@debug.Debug::to_repr`'s `#as_free_fn`. Previously the re-export only had `#warnings("-deprecated")`, so user code reaching `to_repr` through the prelude got no warning at all — now it gets the same deprecation warning and migration path that direct `@debug.to_repr` users already had.

Turning the warning on surfaced the six call sites the previous pass missed, all in `builtin/show_test.mbt`:

```diff
-  inspect('\u{0605}' |> to_repr, content="'\\u{0605}'")
+  inspect(Repr('\u{0605}'), content="'\\u{0605}'")
```

`prelude/pkg.generated.mbti` picks up the `#deprecated` marker on `to_repr`; no other interface changes.

## Verification

- `moon check --deny-warn --target all` — clean
- `moon test --target all` — green (6784 wasm / 6784 wasm-gc / 6740 js / 6695 native), matching the counts at `HEAD` before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)