### PR TITLE
refactor(bigint)!: promote `shl`/`shr`, drop `asr`/`lsl`

### DIFF
--- a/bigint/deprecated.mbt
+++ b/bigint/deprecated.mbt
@@ -13,58 +13,6 @@
 // limitations under the License.
 
 ///|
-/// Arithmetic right shift for bigint values.
-///
-/// Deprecated: use the infix operator `>>` instead.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let x = @bigint.BigInt::from_int(16)
-///   inspect((x >> 2).to_int(), content="4")
-/// }
-/// ```
-#deprecated("Use infix bitwise operator `>>` instead")
-#coverage.skip
-pub fn BigInt::asr(self : BigInt, n : Int) -> BigInt {
-  self >> n
-}
-
-///|
-/// Left shift a bigint
-/// The sign of the result is the same as the sign of the input.
-/// Only the absolute value is shifted.
-///
-#deprecated("Use infix bitwise operator `<<` instead")
-#coverage.skip
-pub fn BigInt::shl(self : BigInt, n : Int) -> BigInt {
-  self << n
-}
-
-///|
-/// Left shift a bigint
-/// The sign of the result is the same as the sign of the input.
-/// Only the absolute value is shifted.
-///
-#deprecated("Use infix bitwise operator `<<` instead")
-#coverage.skip
-pub fn BigInt::lsl(self : BigInt, n : Int) -> BigInt {
-  self << n
-}
-
-///|
-/// Right shift a bigint
-/// The sign of the result is the same as the sign of the input.
-/// Only the absolute value is shifted.
-///
-#deprecated("Use infix bitwise operator `>>` instead")
-#coverage.skip
-pub fn BigInt::shr(self : BigInt, n : Int) -> BigInt {
-  self >> n
-}
-
-///|
 /// Deprecated: use `to_string(radix=16)` instead.
 #deprecated("Use `to_string(radix=16)` instead")
 #coverage.skip

--- a/bigint/extends.mbt
+++ b/bigint/extends.mbt
@@ -48,6 +48,12 @@ pub extend BigInt with Mul::{mul}
 pub extend BigInt with Neg::{neg}
 
 ///|
+pub extend BigInt with Shl::{shl}
+
+///|
+pub extend BigInt with Shr::{shr}
+
+///|
 pub extend BigInt with Sub::{sub}
 
 // `BigInt::to_json` is promoted (not deprecated): it has cross-package method-syntax

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -15,8 +15,6 @@ import {
 // Types and methods
 type BigInt
 pub fn BigInt::add(Self, Self) -> Self
-#deprecated
-pub fn BigInt::asr(Self, Int) -> Self
 pub fn BigInt::bit_length(Self) -> Int
 pub fn BigInt::compare(Self, Self) -> Int
 pub fn BigInt::compare_int(Self, Int) -> Int
@@ -42,16 +40,12 @@ pub fn BigInt::hash(Self) -> Int
 pub fn BigInt::is_zero(Self) -> Bool
 pub fn BigInt::land(Self, Self) -> Self
 pub fn BigInt::lor(Self, Self) -> Self
-#deprecated
-pub fn BigInt::lsl(Self, Int) -> Self
 pub fn BigInt::lxor(Self, Self) -> Self
 pub fn BigInt::mod(Self, Self) -> Self
 pub fn BigInt::mul(Self, Self) -> Self
 pub fn BigInt::neg(Self) -> Self
 pub fn BigInt::pow(Self, Self, modulus? : Self) -> Self
-#deprecated
 pub fn BigInt::shl(Self, Int) -> Self
-#deprecated
 pub fn BigInt::shr(Self, Int) -> Self
 pub fn BigInt::sub(Self, Self) -> Self
 #deprecated


### PR DESCRIPTION
`BigInt::shl` and `BigInt::shr` were hand-written deprecated wrappers that just forwarded to `<<` / `>>`. Per `AGENTS.md` the shift operators are promoted on every type, so both become promotions:

```moonbit
pub extend BigInt with Shl::{shl}
pub extend BigInt with Shr::{shr}
```

Signatures are unchanged (`(Self, Int) -> Self`) — they simply stop emitting a deprecation warning.

`BigInt::asr` and `BigInt::lsl` have no trait to promote to (`>>` and `<<` are spelled `Shr::shr` / `Shl::shl`), so they are removed rather than kept as wrappers.

### Review note: placement

The promotions live in `bigint/extends.mbt`, not `bigint/deprecated.mbt`. They are blessed public API, so they belong in the `// --- promoted: kept as regular methods ---` section next to `Add`, `Mul`, `Neg`, `Sub`, matching `int16/extends.mbt:51,54` and `builtin/extends.mbt:238,241`. Placement is interface-neutral: `bigint/pkg.generated.mbti` is byte-identical either way.

> [!WARNING]
> **`BigInt::asr` and `BigInt::lsl` are removals, not deprecations.** Callers must move to `>>` and `<<`. No references to either remain in core.

## Verification

Run in a clean worktree at `9120861a`, isolated from other in-flight work:

- `moon check --deny-warn --target all` — clean
- `moon test --target all` — green (6783 wasm / 6783 wasm-gc / 6739 js / 6694 native)
- `moon info && moon fmt` — no diff (idempotent)

Counts are exactly 1 lower than `main` on every target: the removed `BigInt::asr` doc comment contained an ```` ```mbt check ```` block, which was itself a doc test. No other test was lost.

## Follow-up (not in this PR)

The same hand-written-wrapper pattern still exists for `to_repr` in **15 packages** — `ref`, `priority_queue`, `hashset`, `hashmap`, `deque`, `list`, `queue`, `error`, and `immut/{sorted_set, priority_queue, hashset, array, sorted_map, hashmap, vector}` — each a `#deprecated` `pub fn X::to_repr(self) { Repr(self) }` that should be `pub extend X with @debug.Debug::{to_repr}` in `extends.mbt`, as `buffer` was converted in #3927.

🤖 Generated with [Claude Code](https://claude.com/claude-code)