### PR TITLE
refactor(collections): replace `to_repr` wrappers with deprecated `extend` (1/3)

### DIFF
--- a/deque/debug.mbt
+++ b/deque/debug.mbt
@@ -21,12 +21,6 @@ pub impl[A : @debug.Debug] @debug.Debug for Deque[A] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[A : @debug.Debug] Deque::to_repr(self : Deque[A]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for Deque" {
   let dq : Deque[Int] = from_array([1, 2, 3])
   @debug.debug_inspect(dq, content="<Deque: [1, 2, 3]>")

--- a/deque/extends.mbt
+++ b/deque/extends.mbt
@@ -29,6 +29,11 @@ pub extend Deque with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@json.from_json` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Deque with @json.FromJson::{from_json}

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -86,8 +86,6 @@ pub fn[A] Deque::shrink_to_fit(Self[A]) -> Unit
 pub fn[A] Deque::shuffle(Self[A], rand~ : (Int) -> Int) -> Self[A]
 pub fn[A] Deque::shuffle_in_place(Self[A], rand~ : (Int) -> Int) -> Unit
 pub fn[A] Deque::to_array(Self[A]) -> Array[A]
-#deprecated
-pub fn[A : @debug.Debug] Deque::to_repr(Self[A]) -> @debug.Repr
 pub fn[A] Deque::truncate(Self[A], Int) -> Unit
 pub impl[A] Add for Deque[A]
 pub impl[A : Compare] Compare for Deque[A]

--- a/hashmap/debug.mbt
+++ b/hashmap/debug.mbt
@@ -23,14 +23,6 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V] with
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(
-  self : HashMap[K, V],
-) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for HashMap" {
   let hm : HashMap[Int, String] = from_array([(2, "b")])
   @debug.debug_inspect(

--- a/hashmap/extends.mbt
+++ b/hashmap/extends.mbt
@@ -20,6 +20,11 @@ pub extend HashMap with Eq::{equal}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend HashMap with @quickcheck.Arbitrary::{arbitrary}

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -57,8 +57,6 @@ pub fn[K, V] HashMap::retain(Self[K, V], (K, V) -> Bool) -> Unit
 #alias("_[_]=_")
 pub fn[K : Hash + Eq, V] HashMap::set(Self[K, V], K, V) -> Unit
 pub fn[K, V] HashMap::to_array(Self[K, V]) -> Array[(K, V)]
-#deprecated
-pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(Self[K, V]) -> @debug.Repr
 pub fn[K : Hash + Eq, V] HashMap::update(Self[K, V], K, (V?) -> V?) -> Unit
 pub fn[K : Hash + Eq, V] HashMap::update_or_default(Self[K, V], K, V, (V) -> V) -> Unit
 pub fn[K, V] HashMap::values(Self[K, V]) -> Iter[V]

--- a/hashset/debug.mbt
+++ b/hashset/debug.mbt
@@ -21,12 +21,6 @@ pub impl[K : @debug.Debug] @debug.Debug for HashSet[K] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[K : @debug.Debug] HashSet::to_repr(self : HashSet[K]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for HashSet" {
   let hs : HashSet[Int] = from_array([1])
   @debug.debug_inspect(hs, content="<HashSet: [1]>")

--- a/hashset/extends.mbt
+++ b/hashset/extends.mbt
@@ -29,6 +29,11 @@ pub extend HashSet with Sub::{sub}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend HashSet with @quickcheck.Arbitrary::{arbitrary}

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -54,8 +54,6 @@ pub fn[K] HashSet::retain(Self[K], (K) -> Bool) -> Unit
 pub fn[K : Hash + Eq] HashSet::sub(Self[K], Self[K]) -> Self[K]
 pub fn[K : Hash + Eq] HashSet::symmetric_difference(Self[K], Self[K]) -> Self[K]
 pub fn[K] HashSet::to_array(Self[K]) -> Array[K]
-#deprecated
-pub fn[K : @debug.Debug] HashSet::to_repr(Self[K]) -> @debug.Repr
 pub fn[K : Hash + Eq] HashSet::union(Self[K], Self[K]) -> Self[K]
 pub impl[K : Hash + Eq] BitAnd for HashSet[K]
 pub impl[K : Hash + Eq] BitOr for HashSet[K]

--- a/list/debug.mbt
+++ b/list/debug.mbt
@@ -21,12 +21,6 @@ pub impl[A : @debug.Debug] @debug.Debug for List[A] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[A : @debug.Debug] List::to_repr(self : List[A]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for List" {
   let xs : List[Int] = List([1, 2, 3])
   @debug.debug_inspect(xs, content="<List: [1, 2, 3]>")

--- a/list/extends.mbt
+++ b/list/extends.mbt
@@ -26,6 +26,11 @@ pub extend List with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend List with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend List with @quickcheck.Arbitrary::{arbitrary}

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -105,8 +105,6 @@ pub fn[A] List::take(Self[A], Int) -> Self[A]
 pub fn[A] List::take_while(Self[A], (A) -> Bool raise?) -> Self[A] raise?
 pub fn[A] List::to_array(Self[A]) -> Array[A]
 pub fn[A : ToJson] List::to_json(Self[A]) -> Json
-#deprecated
-pub fn[A : @debug.Debug] List::to_repr(Self[A]) -> @debug.Repr
 #as_free_fn
 pub fn[A, S] List::unfold((S) -> (A, S)? raise?, init~ : S) -> Self[A] raise?
 pub fn[A] List::unsafe_tail(Self[A]) -> Self[A]

--- a/priority_queue/debug.mbt
+++ b/priority_queue/debug.mbt
@@ -23,14 +23,6 @@ pub impl[A : @debug.Debug + Compare] @debug.Debug for PriorityQueue[A] with fn t
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(
-  self : PriorityQueue[A],
-) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for PriorityQueue" {
   let pq : PriorityQueue[Int] = from_array([3, 1, 2])
   @debug.debug_inspect(pq, content="<PriorityQueue: [3, 2, 1]>")

--- a/priority_queue/extends.mbt
+++ b/priority_queue/extends.mbt
@@ -15,6 +15,11 @@
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend PriorityQueue with @quickcheck.Arbitrary::{arbitrary}

--- a/priority_queue/pkg.generated.mbti
+++ b/priority_queue/pkg.generated.mbti
@@ -36,8 +36,6 @@ pub fn[A] PriorityQueue::peek(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::pop(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::push(Self[A], A) -> Unit
 pub fn[A : Compare] PriorityQueue::to_array(Self[A]) -> Array[A]
-#deprecated
-pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(Self[A]) -> @debug.Repr
 pub impl[K] Default for PriorityQueue[K]
 #deprecated
 pub impl[A : Show + Compare] Show for PriorityQueue[A]

--- a/queue/debug.mbt
+++ b/queue/debug.mbt
@@ -21,12 +21,6 @@ pub impl[A : @debug.Debug] @debug.Debug for Queue[A] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[A : @debug.Debug] Queue::to_repr(self : Queue[A]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for Queue" {
   let q : Queue[Int] = from_array([1, 2, 3])
   @debug.debug_inspect(q, content="<Queue: [1, 2, 3]>")

--- a/queue/extends.mbt
+++ b/queue/extends.mbt
@@ -17,6 +17,11 @@
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Queue with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Queue with @quickcheck.Arbitrary::{arbitrary}

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -38,8 +38,6 @@ pub fn[A] Queue::new() -> Self[A]
 pub fn[A] Queue::peek(Self[A]) -> A?
 pub fn[A] Queue::pop(Self[A]) -> A?
 pub fn[A] Queue::push(Self[A], A) -> Unit
-#deprecated
-pub fn[A : @debug.Debug] Queue::to_repr(Self[A]) -> @debug.Repr
 pub fn[A] Queue::transfer(Self[A], Self[A]) -> Unit
 #deprecated
 pub impl[A : Show] Show for Queue[A]


### PR DESCRIPTION
**1 of 3.** Sweeps out the hand-written `X::to_repr` wrapper pattern left over after #3927, which converted only `buffer`. Fifteen packages still had it; this PR does six of them, split by area to keep review small.

**This PR:** `deque`, `hashmap`, `hashset`, `list`, `priority_queue`, `queue`.

Each package had:

```moonbit
#deprecated("use `Repr(a)` instead", skip_current_package=true)
pub fn[A : @debug.Debug] Queue::to_repr(self : Queue[A]) -> @debug.Repr {
  Repr(self)
}
```

replaced by the promotion form already used by **51** other types in core:

```moonbit
#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
#doc(hidden)
pub extend Queue with @debug.Debug::{to_repr}
```

The wrapper leaves `debug.mbt`; the `extend` joins the deprecated section of `extends.mbt`, ahead of the other deprecated promotions, matching `bigint/extends.mbt` and `sorted_set/extends.mbt`.

Note the message is the canonical `"Use \`Debug::to_repr\` instead"` (51 occurrences), not the one-off wording I used for `buffer` in #3927 — that outlier is worth normalising separately.

### API impact

`X::to_repr` drops out of each `pkg.generated.mbti` because of `#doc(hidden)`. It remains callable and still warns — no removal, unlike #3927's tuple commit or #3928.

## Verification

Run in a clean worktree off `main`:

- `moon check --deny-warn --target all` — clean
- `moon test --target all` — green (6784 wasm / 6784 wasm-gc / 6740 js / 6695 native), identical to `main`
- `moon info && moon fmt` — applied, diff included

🤖 Generated with [Claude Code](https://claude.com/claude-code)