### PR TITLE
refactor(immut): replace `to_repr` wrappers with deprecated `extend` (2/3)

### DIFF
--- a/immut/array/debug.mbt
+++ b/immut/array/debug.mbt
@@ -21,12 +21,6 @@ pub impl[A : @debug.Debug] @debug.Debug for T[A] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
-pub fn[A : @debug.Debug] T::to_repr(self : T[A]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for Array" {
   let xs : T[Int] = T::from_array([1, 2, 3])
   @debug.debug_inspect(xs, content="<Array: [1, 2, 3]>")

--- a/immut/array/extends.mbt
+++ b/immut/array/extends.mbt
@@ -29,6 +29,11 @@ pub extend T with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
+#doc(hidden)
+pub extend T with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend T with @quickcheck.Arbitrary::{arbitrary}

--- a/immut/array/pkg.generated.mbti
+++ b/immut/array/pkg.generated.mbti
@@ -71,8 +71,6 @@ pub fn[A, B] T::rev_fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A] T::set(Self[A], Int, A) -> Self[A]
 #deprecated
 pub fn[A] T::to_array(Self[A]) -> Array[A]
-#deprecated
-pub fn[A : @debug.Debug] T::to_repr(Self[A]) -> @debug.Repr
 pub impl[A] Add for T[A]
 pub impl[A : Compare] Compare for T[A]
 pub impl[A : Eq] Eq for T[A]

--- a/immut/hashmap/debug.mbt
+++ b/immut/hashmap/debug.mbt
@@ -23,14 +23,6 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V] with
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(
-  self : HashMap[K, V],
-) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for HashMap" {
   let hm : HashMap[Int, String] = HashMap([(2, "b")])
   @debug.debug_inspect(

--- a/immut/hashmap/extends.mbt
+++ b/immut/hashmap/extends.mbt
@@ -23,6 +23,11 @@ pub extend HashMap with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashMap with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend HashMap with @quickcheck.Arbitrary::{arbitrary}

--- a/immut/hashmap/pkg.generated.mbti
+++ b/immut/hashmap/pkg.generated.mbti
@@ -54,8 +54,6 @@ pub fn[K : Eq + Hash, V] HashMap::remove(Self[K, V], K) -> Self[K, V]
 #as_free_fn
 pub fn[K : Hash, V] HashMap::singleton(K, V) -> Self[K, V]
 pub fn[K, V] HashMap::to_array(Self[K, V]) -> Array[(K, V)]
-#deprecated
-pub fn[K : @debug.Debug, V : @debug.Debug] HashMap::to_repr(Self[K, V]) -> @debug.Repr
 #alias(merge)
 pub fn[K : Eq, V] HashMap::union(Self[K, V], Self[K, V]) -> Self[K, V]
 pub fn[K : Eq, V] HashMap::union_with(Self[K, V], Self[K, V], (K, V, V) -> V raise?) -> Self[K, V] raise?

--- a/immut/hashset/debug.mbt
+++ b/immut/hashset/debug.mbt
@@ -21,12 +21,6 @@ pub impl[K : @debug.Debug] @debug.Debug for HashSet[K] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[K : @debug.Debug] HashSet::to_repr(self : HashSet[K]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for HashSet" {
   let hs : HashSet[Int] = HashSet([3])
   @debug.debug_inspect(hs, content="<HashSet: [3]>")

--- a/immut/hashset/extends.mbt
+++ b/immut/hashset/extends.mbt
@@ -23,6 +23,11 @@ pub extend HashSet with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend HashSet with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend HashSet with @quickcheck.Arbitrary::{arbitrary}

--- a/immut/hashset/pkg.generated.mbti
+++ b/immut/hashset/pkg.generated.mbti
@@ -38,8 +38,6 @@ pub fn[A] HashSet::length(Self[A]) -> Int
 #as_free_fn
 pub fn[A] HashSet::new() -> Self[A]
 pub fn[A : Eq + Hash] HashSet::remove(Self[A], A) -> Self[A]
-#deprecated
-pub fn[K : @debug.Debug] HashSet::to_repr(Self[K]) -> @debug.Repr
 pub fn[K : Eq] HashSet::union(Self[K], Self[K]) -> Self[K]
 pub impl[A : Hash] Hash for HashSet[A]
 #deprecated

--- a/immut/priority_queue/debug.mbt
+++ b/immut/priority_queue/debug.mbt
@@ -21,14 +21,6 @@ pub impl[A : @debug.Debug + Compare] @debug.Debug for PriorityQueue[A] with fn t
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(
-  self : PriorityQueue[A],
-) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for PriorityQueue" {
   let pq : PriorityQueue[Int] = from_array([3, 1, 2])
   @debug.debug_inspect(pq, content="<PriorityQueue: [3, 2, 1]>")

--- a/immut/priority_queue/extends.mbt
+++ b/immut/priority_queue/extends.mbt
@@ -26,6 +26,11 @@ pub extend PriorityQueue with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend PriorityQueue with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend PriorityQueue with @quickcheck.Arbitrary::{arbitrary}

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -36,8 +36,6 @@ pub fn[A] PriorityQueue::peek(Self[A]) -> A?
 pub fn[A : Compare] PriorityQueue::pop(Self[A]) -> Self[A]?
 pub fn[A : Compare] PriorityQueue::push(Self[A], A) -> Self[A]
 pub fn[A : Compare] PriorityQueue::to_array(Self[A]) -> Array[A]
-#deprecated
-pub fn[A : @debug.Debug + Compare] PriorityQueue::to_repr(Self[A]) -> @debug.Repr
 pub impl[A : Compare] Compare for PriorityQueue[A]
 pub impl[A : Compare] Eq for PriorityQueue[A]
 pub impl[A : Hash + Compare] Hash for PriorityQueue[A]

--- a/immut/sorted_map/debug.mbt
+++ b/immut/sorted_map/debug.mbt
@@ -23,14 +23,6 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for SortedMap[K, V] wi
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[K : @debug.Debug, V : @debug.Debug] SortedMap::to_repr(
-  self : SortedMap[K, V],
-) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for SortedMap" {
   let sm : SortedMap[Int, String] = SortedMap([(1, "a"), (2, "b")])
   @debug.debug_inspect(

--- a/immut/sorted_map/extends.mbt
+++ b/immut/sorted_map/extends.mbt
@@ -26,6 +26,11 @@ pub extend SortedMap with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedMap with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend SortedMap with @quickcheck.Arbitrary::{arbitrary}

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -70,8 +70,6 @@ pub fn[K, V] SortedMap::rev_values(Self[K, V]) -> Iter[V]
 pub fn[K, V] SortedMap::singleton(K, V) -> Self[K, V]
 pub fn[K, V] SortedMap::to_array(Self[K, V]) -> Array[(K, V)]
 pub fn[K : Show, V : ToJson] SortedMap::to_json(Self[K, V]) -> Json
-#deprecated
-pub fn[K : @debug.Debug, V : @debug.Debug] SortedMap::to_repr(Self[K, V]) -> @debug.Repr
 pub fn[K, V] SortedMap::values(Self[K, V]) -> Iter[V]
 pub impl[K : Compare, V : Compare] Compare for SortedMap[K, V]
 pub impl[K, V] Default for SortedMap[K, V]

--- a/immut/sorted_set/debug.mbt
+++ b/immut/sorted_set/debug.mbt
@@ -21,12 +21,6 @@ pub impl[K : @debug.Debug] @debug.Debug for SortedSet[K] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[K : @debug.Debug] SortedSet::to_repr(self : SortedSet[K]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for SortedSet" {
   let ss : SortedSet[Int] = SortedSet([3, 1, 2])
   @debug.debug_inspect(ss, content="<SortedSet: [1, 2, 3]>")

--- a/immut/sorted_set/extends.mbt
+++ b/immut/sorted_set/extends.mbt
@@ -29,6 +29,11 @@ pub extend SortedSet with Sub::{sub}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SortedSet with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend SortedSet with @quickcheck.Arbitrary::{arbitrary}

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -66,8 +66,6 @@ pub fn[A : Compare] SortedSet::subset(Self[A], Self[A]) -> Bool
 pub fn[A : Compare] SortedSet::symmetric_difference(Self[A], Self[A]) -> Self[A]
 pub fn[A] SortedSet::to_array(Self[A]) -> Array[A]
 pub fn[A : ToJson] SortedSet::to_json(Self[A]) -> Json
-#deprecated
-pub fn[K : @debug.Debug] SortedSet::to_repr(Self[K]) -> @debug.Repr
 pub fn[A : Compare] SortedSet::union(Self[A], Self[A]) -> Self[A]
 pub impl[A : Compare] Add for SortedSet[A]
 pub impl[A : Compare] Compare for SortedSet[A]

--- a/immut/vector/debug.mbt
+++ b/immut/vector/debug.mbt
@@ -21,12 +21,6 @@ pub impl[A : @debug.Debug] @debug.Debug for Vector[A] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[A : @debug.Debug] Vector::to_repr(self : Vector[A]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for Vector" {
   let xs : Vector[Int] = from_array([1, 2, 3])
   @debug.debug_inspect(xs, content="<Vector: [1, 2, 3]>")

--- a/immut/vector/extends.mbt
+++ b/immut/vector/extends.mbt
@@ -29,6 +29,11 @@ pub extend Vector with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@json.from_json` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Vector with @json.FromJson::{from_json}

--- a/immut/vector/pkg.generated.mbti
+++ b/immut/vector/pkg.generated.mbti
@@ -65,8 +65,6 @@ pub fn[A] Vector::slice(Self[A], Int, Int) -> Self[A]
 pub fn[A] Vector::split(Self[A], Int) -> (Self[A], Self[A])
 pub fn[A] Vector::take(Self[A], Int) -> Self[A]
 pub fn[A] Vector::to_array(Self[A]) -> Array[A]
-#deprecated
-pub fn[A : @debug.Debug] Vector::to_repr(Self[A]) -> @debug.Repr
 pub impl[A] Add for Vector[A]
 pub impl[A : Compare] Compare for Vector[A]
 pub impl[A : Eq] Eq for Vector[A]


### PR DESCRIPTION
**2 of 3.** Companion to #3929, same mechanical change applied to the `immut/*` family. Disjoint file sets, so the two can land in either order.

**This PR:** `immut/array`, `immut/hashmap`, `immut/hashset`, `immut/priority_queue`, `immut/sorted_map`, `immut/sorted_set`, `immut/vector`.

```moonbit
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[A : @debug.Debug] Vector::to_repr(self : Vector[A]) -> @debug.Repr {
-  Repr(self)
-}
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Vector with @debug.Debug::{to_repr}
```

The wrapper leaves `debug.mbt`; the `extend` joins the deprecated section of `extends.mbt`.

**`immut/array` keeps its own message** — "Use the corresponding function in `immut/vector` instead" — rather than being normalised to the generic wording, since that package is deprecated wholesale in favour of `immut/vector`.

### API impact

`X::to_repr` drops out of each `pkg.generated.mbti` due to `#doc(hidden)`. It remains callable and still warns — nothing is removed.

## Verification

Run in a clean worktree, based on `53d77be0`:

- `moon check --deny-warn --target all` — clean
- `moon test --target all` — green (6783 wasm / 6783 wasm-gc / 6739 js / 6694 native)
- `moon info && moon fmt` — applied, diff included

Counts match this base exactly. Note they are 1 lower than #3929's, which is branched one commit earlier: #3928 removed `BigInt::asr`, whose doc comment contained a ```` ```mbt check ```` doc test. Not a regression in either PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)