### PR TITLE
refactor(ref, error): replace `to_repr` wrappers with deprecated `extend` (3/3)

### DIFF
--- a/error/debug.mbt
+++ b/error/debug.mbt
@@ -21,12 +21,6 @@ pub impl @debug.Debug for Error with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn Error::to_repr(self : Error) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for Error" {
   fn fail_with_error() -> Unit raise {
     raise InspectError::InspectError("test error")

--- a/error/extends.mbt
+++ b/error/extends.mbt
@@ -17,6 +17,11 @@
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Error with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Error with Show::{output}

--- a/error/pkg.generated.mbti
+++ b/error/pkg.generated.mbti
@@ -11,8 +11,6 @@ import {
 
 // Types and methods
 pub fn Error::to_json(Self) -> Json
-#deprecated
-pub fn Error::to_repr(Self) -> @debug.Repr
 pub fn Error::to_string(Self) -> String
 pub impl Show for Error
 pub impl ToJson for Error

--- a/ref/debug.mbt
+++ b/ref/debug.mbt
@@ -18,12 +18,6 @@ pub impl[T : @debug.Debug] @debug.Debug for Ref[T] with fn to_repr(self) {
 }
 
 ///|
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[T : @debug.Debug] Ref::to_repr(self : Ref[T]) -> @debug.Repr {
-  Repr(self)
-}
-
-///|
 test "Debug for Ref" {
   let r : Ref[Int] = new(1)
   @debug.debug_inspect(r, content="<Ref: 1>")

--- a/ref/extends.mbt
+++ b/ref/extends.mbt
@@ -17,6 +17,11 @@
 // --- deprecated: hidden from the generated interface ---
 
 ///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Ref with @debug.Debug::{to_repr}
+
+///|
 #deprecated("Use `@quickcheck.Arbitrary::arbitrary` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Ref with @quickcheck.Arbitrary::{arbitrary}

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -22,8 +22,6 @@ pub fn[T, R] Ref::map(Self[T], (T) -> R raise?) -> Self[R] raise?
 pub fn[T, R] Ref::protect(Self[T], T, () -> R raise?) -> R raise?
 #as_free_fn
 pub fn[T] Ref::swap(Self[T], Self[T]) -> Unit
-#deprecated
-pub fn[T : @debug.Debug] Ref::to_repr(Self[T]) -> @debug.Repr
 pub fn[T] Ref::update(Self[T], (T) -> T raise?) -> Unit raise?
 #deprecated
 pub impl[X : Show] Show for Ref[X]


### PR DESCRIPTION
**3 of 3**, closing out the sweep started in #3929 and #3930. Two packages left over that don't fit either family: `ref` and `error`.

```moonbit
-#deprecated("use `Repr(a)` instead", skip_current_package=true)
-pub fn[T : @debug.Debug] Ref::to_repr(self : Ref[T]) -> @debug.Repr {
-  Repr(self)
-}
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Ref with @debug.Debug::{to_repr}
```

With all three merged, **no `pub fn X::to_repr(self) { Repr(self) }` wrapper remains in core** — verified by applying the three branches together and grepping.

### API impact

`Ref::to_repr` and `Error::to_repr` drop out of their `pkg.generated.mbti` due to `#doc(hidden)`. Both remain callable and still warn.

## Verification

Run in a clean worktree, based on `53d77be0`:

- `moon check --deny-warn --target all` — clean
- `moon test --target all` — green (6783 wasm / 6783 wasm-gc / 6739 js / 6694 native), identical to base
- `moon info && moon fmt` — applied, diff included

## The set

| PR | Packages |
|----|----------|
| #3929 | `deque`, `hashmap`, `hashset`, `list`, `priority_queue`, `queue` |
| #3930 | `immut/{array, hashmap, hashset, priority_queue, sorted_map, sorted_set, vector}` |
| this  | `ref`, `error` |

File sets are disjoint; the three can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)