### PR TITLE
refactor(coverage): declare `Show` promotions explicitly

### DIFF
--- a/coverage/extends.mbt
+++ b/coverage/extends.mbt
@@ -1,0 +1,25 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend CoverageCounter with Show::{to_string}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+#doc(hidden)
+pub extend CoverageCounter with Show::{output}

--- a/coverage/moon.pkg
+++ b/coverage/moon.pkg
@@ -1,3 +1,5 @@
 import {
   "moonbitlang/core/builtin",
 }
+
+warnings = "+implicit_impl_as_method"

--- a/coverage/pkg.generated.mbti
+++ b/coverage/pkg.generated.mbti
@@ -12,6 +12,7 @@ pub fn track(String, CoverageCounter) -> Unit
 type CoverageCounter
 pub fn CoverageCounter::incr(Self, Int) -> Unit
 pub fn CoverageCounter::new(Int) -> Self
+pub fn CoverageCounter::to_string(Self) -> String
 pub impl Show for CoverageCounter
 
 // Type aliases


### PR DESCRIPTION
`coverage` was missing `warnings = "+implicit_impl_as_method"` in its `moon.pkg`, so `impl Show for CoverageCounter` still relied on the deprecated implicit promotion of `to_string`/`output` to regular methods:

```
Warning (implicit_impl_as_method): The methods to_string, output from `impl Show for
CoverageCounter` are implicit promoted as regular method for `CoverageCounter`. This
behavior is deprecated and will be removed in the future.
```

This enables the warning — matching every other package that impls a builtin trait — and adds the explicit declarations in a new `coverage/extends.mbt`.

### Why `to_string` is promoted but `output` is not

Following the split used by `strconv`, `bigint`, `int16`, `v128`, `argparse` and `json`:

```moonbit
// --- promoted: kept as regular methods ---
pub extend CoverageCounter with Show::{to_string}

// --- deprecated: hidden from the generated interface ---
#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
#doc(hidden)
pub extend CoverageCounter with Show::{output}
```

`CoverageCounter`'s rendering *is* its coverage dump format — `end()` calls `counter.to_string()` to emit it — so it has a canonical string form and the promotion is warranted. `Show::output` is never promoted per `AGENTS.md`, hence the deprecated + hidden form with the canonical message (used by 20+ other types).

`skip_current_package=true` keeps the package's own `to_string` calls (`coverage.mbt:176`, plus the tests) warning-free.

### API impact

`coverage/pkg.generated.mbti` gains one line:

```diff
+pub fn CoverageCounter::to_string(Self) -> String
```

`output` stays out of the interface via `#doc(hidden)`. Nothing is removed.

Also adds the missing trailing newline to `coverage/moon.pkg`.

## Verification

Run in a clean worktree at `a835bddd`:

- `moon check --deny-warn --target all` — clean
- `moon test --target all` — green (6783 wasm / 6783 wasm-gc / 6739 js / 6694 native), identical to `main`
- `moon info && moon fmt` — no diff (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)