### PR TITLE
chore: enable `implicit_impl_as_method` module-wide

### DIFF
--- a/argparse/moon.pkg
+++ b/argparse/moon.pkg
@@ -7,4 +7,4 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+unnecessary_annotation+implicit_impl_as_method"
+warnings = "+unnecessary_annotation"

--- a/bench/moon.pkg
+++ b/bench/moon.pkg
@@ -8,7 +8,6 @@ import {
   "moonbitlang/core/debug",
 }
 
-
 options(
   targets: {
     "monotonic_clock_js.mbt": [ "js" ],

--- a/bench/moon.pkg
+++ b/bench/moon.pkg
@@ -8,7 +8,6 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: {

--- a/bigint/moon.pkg
+++ b/bigint/moon.pkg
@@ -20,7 +20,7 @@ import {
   "moonbitlang/core/test",
 } for "wbtest"
 
-warnings = "-29+implicit_impl_as_method"
+warnings = "-29"
 
 options(
   targets: {

--- a/bool/moon.pkg
+++ b/bool/moon.pkg
@@ -7,4 +7,3 @@ import {
   "moonbitlang/core/int16",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/bool/moon.pkg
+++ b/bool/moon.pkg
@@ -6,4 +6,3 @@ import {
   "moonbitlang/core/char",
   "moonbitlang/core/int16",
 } for "test"
-

--- a/buffer/moon.pkg
+++ b/buffer/moon.pkg
@@ -12,4 +12,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/buffer/moon.pkg
+++ b/buffer/moon.pkg
@@ -11,4 +11,3 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/test",
 } for "test"
-

--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -22,7 +22,7 @@ import {
   "moonbitlang/core/debug",
 } for "test"
 
-warnings = "-test_unqualified_package+implicit_impl_as_method"
+warnings = "-test_unqualified_package"
 
 options(
   targets: {

--- a/bytes/internal/regex_engine/ast/moon.pkg
+++ b/bytes/internal/regex_engine/ast/moon.pkg
@@ -4,4 +4,3 @@ import {
   "moonbitlang/core/internal/regex_engine/shared_types",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/bytes/internal/regex_engine/ast/moon.pkg
+++ b/bytes/internal/regex_engine/ast/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/internal/regex_engine/shared_types",
 }
-

--- a/bytes/internal/regex_engine/moon.pkg
+++ b/bytes/internal/regex_engine/moon.pkg
@@ -12,4 +12,3 @@ import {
 import {
   "moonbitlang/core/test",
 } for "test"
-

--- a/bytes/internal/regex_engine/moon.pkg
+++ b/bytes/internal/regex_engine/moon.pkg
@@ -13,4 +13,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/char/moon.pkg
+++ b/char/moon.pkg
@@ -1,4 +1,3 @@
 import {
   "moonbitlang/core/builtin",
 }
-

--- a/char/moon.pkg
+++ b/char/moon.pkg
@@ -2,4 +2,3 @@ import {
   "moonbitlang/core/builtin",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/cmp/moon.pkg
+++ b/cmp/moon.pkg
@@ -7,4 +7,3 @@ import {
   "moonbitlang/core/int",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/cmp/moon.pkg
+++ b/cmp/moon.pkg
@@ -6,4 +6,3 @@ import {
 import {
   "moonbitlang/core/int",
 } for "test"
-

--- a/coverage/moon.pkg
+++ b/coverage/moon.pkg
@@ -1,4 +1,3 @@
 import {
   "moonbitlang/core/builtin",
 }
-

--- a/coverage/moon.pkg
+++ b/coverage/moon.pkg
@@ -2,4 +2,3 @@ import {
   "moonbitlang/core/builtin",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/debug/moon.pkg
+++ b/debug/moon.pkg
@@ -16,4 +16,4 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "-alert_visibility-test_unqualified_package+implicit_impl_as_method"
+warnings = "-alert_visibility-test_unqualified_package"

--- a/deque/moon.pkg
+++ b/deque/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },

--- a/deque/moon.pkg
+++ b/deque/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/encoding/ascii/moon.pkg
+++ b/encoding/ascii/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/encoding/ascii/moon.pkg
+++ b/encoding/ascii/moon.pkg
@@ -2,4 +2,3 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
-

--- a/encoding/base64/moon.pkg
+++ b/encoding/base64/moon.pkg
@@ -4,4 +4,3 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/encoding/base64/moon.pkg
+++ b/encoding/base64/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
-

--- a/encoding/utf16/moon.pkg
+++ b/encoding/utf16/moon.pkg
@@ -7,4 +7,3 @@ import {
 import {
   "moonbitlang/core/bench",
 } for "test"
-

--- a/encoding/utf16/moon.pkg
+++ b/encoding/utf16/moon.pkg
@@ -8,4 +8,3 @@ import {
   "moonbitlang/core/bench",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/encoding/utf8/moon.pkg
+++ b/encoding/utf8/moon.pkg
@@ -7,7 +7,6 @@ import {
   "moonbitlang/core/buffer",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: {

--- a/encoding/utf8/moon.pkg
+++ b/encoding/utf8/moon.pkg
@@ -7,7 +7,6 @@ import {
   "moonbitlang/core/buffer",
 } for "test"
 
-
 options(
   targets: {
     "decode_js.mbt": [ "js" ],

--- a/error/moon.pkg
+++ b/error/moon.pkg
@@ -7,4 +7,3 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/error/moon.pkg
+++ b/error/moon.pkg
@@ -6,4 +6,3 @@ import {
 import {
   "moonbitlang/core/json",
 } for "test"
-

--- a/float/moon.pkg
+++ b/float/moon.pkg
@@ -9,7 +9,6 @@ import {
   "moonbitlang/core/debug",
 } for "test"
 
-
 options(
   targets: {
     "round.mbt": [ "not", "js", "wasm", "wasm-gc" ],

--- a/float/moon.pkg
+++ b/float/moon.pkg
@@ -9,7 +9,6 @@ import {
   "moonbitlang/core/debug",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: {

--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -12,4 +12,3 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/core/json",
 } for "test"
-

--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -13,4 +13,3 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/hashset/moon.pkg
+++ b/hashset/moon.pkg
@@ -11,4 +11,3 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/json",
 } for "test"
-

--- a/hashset/moon.pkg
+++ b/hashset/moon.pkg
@@ -12,4 +12,3 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/immut/array/moon.pkg
+++ b/immut/array/moon.pkg
@@ -9,7 +9,7 @@ import {
   "moonbitlang/core/ref",
 } for "wbtest"
 
-warnings = "-deprecated+implicit_impl_as_method"
+warnings = "-deprecated"
 
 import {
   "moonbitlang/core/test",

--- a/immut/hashmap/moon.pkg
+++ b/immut/hashmap/moon.pkg
@@ -15,4 +15,3 @@ import {
   "moonbitlang/core/option",
   "moonbitlang/core/test",
 } for "test"
-

--- a/immut/hashmap/moon.pkg
+++ b/immut/hashmap/moon.pkg
@@ -16,4 +16,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/immut/hashset/moon.pkg
+++ b/immut/hashset/moon.pkg
@@ -14,4 +14,3 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/test",
 } for "test"
-

--- a/immut/hashset/moon.pkg
+++ b/immut/hashset/moon.pkg
@@ -15,4 +15,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/immut/internal/path/moon.pkg
+++ b/immut/internal/path/moon.pkg
@@ -1,4 +1,3 @@
 import {
   "moonbitlang/core/builtin",
 }
-

--- a/immut/internal/path/moon.pkg
+++ b/immut/internal/path/moon.pkg
@@ -2,4 +2,3 @@ import {
   "moonbitlang/core/builtin",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/immut/internal/sparse_array/moon.pkg
+++ b/immut/internal/sparse_array/moon.pkg
@@ -4,4 +4,3 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/immut/internal/sparse_array/moon.pkg
+++ b/immut/internal/sparse_array/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/debug",
 }
-

--- a/immut/priority_queue/moon.pkg
+++ b/immut/priority_queue/moon.pkg
@@ -12,7 +12,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },

--- a/immut/priority_queue/moon.pkg
+++ b/immut/priority_queue/moon.pkg
@@ -12,7 +12,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/immut/sorted_map/moon.pkg
+++ b/immut/sorted_map/moon.pkg
@@ -13,7 +13,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_wbtest.mbt": [ "not", "native", "llvm" ] },

--- a/immut/sorted_map/moon.pkg
+++ b/immut/sorted_map/moon.pkg
@@ -13,7 +13,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_wbtest.mbt": [ "not", "native", "llvm" ] },
 )

--- a/immut/sorted_set/moon.pkg
+++ b/immut/sorted_set/moon.pkg
@@ -11,7 +11,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/immut/sorted_set/moon.pkg
+++ b/immut/sorted_set/moon.pkg
@@ -11,7 +11,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },

--- a/immut/vector/moon.pkg
+++ b/immut/vector/moon.pkg
@@ -16,7 +16,6 @@ import {
   "moonbitlang/core/test",
 } for "wbtest"
 
-
 options(
   targets: {
     "panic_test.mbt": [ "not", "native", "llvm" ],

--- a/immut/vector/moon.pkg
+++ b/immut/vector/moon.pkg
@@ -16,7 +16,6 @@ import {
   "moonbitlang/core/test",
 } for "wbtest"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: {

--- a/int16/moon.pkg
+++ b/int16/moon.pkg
@@ -8,4 +8,3 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/int16/moon.pkg
+++ b/int16/moon.pkg
@@ -7,4 +7,3 @@ import {
   "moonbitlang/core/uint16",
   "moonbitlang/core/json",
 } for "test"
-

--- a/internal/regex_engine/automata/moon.pkg
+++ b/internal/regex_engine/automata/moon.pkg
@@ -5,4 +5,3 @@ import {
   "moonbitlang/core/internal/regex_engine/shared_types",
   "moonbitlang/core/ref",
 }
-

--- a/internal/regex_engine/automata/moon.pkg
+++ b/internal/regex_engine/automata/moon.pkg
@@ -6,4 +6,3 @@ import {
   "moonbitlang/core/ref",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/internal/regex_engine/shared_types/moon.pkg
+++ b/internal/regex_engine/shared_types/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/internal/regex_engine/shared_types/rechar_set",
 }
-

--- a/internal/regex_engine/shared_types/moon.pkg
+++ b/internal/regex_engine/shared_types/moon.pkg
@@ -4,4 +4,3 @@ import {
   "moonbitlang/core/internal/regex_engine/shared_types/rechar_set",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/internal/regex_engine/shared_types/rechar_set/moon.pkg
+++ b/internal/regex_engine/shared_types/rechar_set/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/internal/regex_engine/shared_types/rechar_set/moon.pkg
+++ b/internal/regex_engine/shared_types/rechar_set/moon.pkg
@@ -2,4 +2,3 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
-

--- a/json/moon.pkg
+++ b/json/moon.pkg
@@ -16,4 +16,3 @@ import {
   "moonbitlang/core/bigint",
   "moonbitlang/core/bench",
 } for "test"
-

--- a/json/moon.pkg
+++ b/json/moon.pkg
@@ -17,4 +17,3 @@ import {
   "moonbitlang/core/bench",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/lazy/moon.pkg
+++ b/lazy/moon.pkg
@@ -7,7 +7,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },

--- a/lazy/moon.pkg
+++ b/lazy/moon.pkg
@@ -7,7 +7,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/lazy_list/moon.pkg
+++ b/lazy_list/moon.pkg
@@ -8,4 +8,3 @@ import {
 import {
   "moonbitlang/core/list",
 } for "test"
-

--- a/lazy_list/moon.pkg
+++ b/lazy_list/moon.pkg
@@ -9,4 +9,3 @@ import {
   "moonbitlang/core/list",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/list/moon.pkg
+++ b/list/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native" ] },

--- a/list/moon.pkg
+++ b/list/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native" ] },
 )

--- a/moon.mod
+++ b/moon.mod
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 keywords = [ "core", "standard library" ]
 
-warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op+unnecessary_annotation+prefer_fixed_array+prefer_readonly_array-implicit_use_builtin"
+warnings = "+test_unqualified_package+unqualified_local_using+missing_doc+unnecessary_view_op+unnecessary_annotation+prefer_fixed_array+prefer_readonly_array-implicit_use_builtin+implicit_impl_as_method"

--- a/priority_queue/moon.pkg
+++ b/priority_queue/moon.pkg
@@ -13,7 +13,6 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/priority_queue/moon.pkg
+++ b/priority_queue/moon.pkg
@@ -13,7 +13,6 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },

--- a/queue/moon.pkg
+++ b/queue/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },

--- a/queue/moon.pkg
+++ b/queue/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/quickcheck/moon.pkg
+++ b/quickcheck/moon.pkg
@@ -10,4 +10,3 @@ import {
   "moonbitlang/core/float",
   "moonbitlang/core/double",
 } for "test"
-

--- a/quickcheck/moon.pkg
+++ b/quickcheck/moon.pkg
@@ -11,4 +11,3 @@ import {
   "moonbitlang/core/double",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/quickcheck/splitmix/moon.pkg
+++ b/quickcheck/splitmix/moon.pkg
@@ -4,4 +4,3 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/core/debug",
 }
-

--- a/quickcheck/splitmix/moon.pkg
+++ b/quickcheck/splitmix/moon.pkg
@@ -5,4 +5,3 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/random/moon.pkg
+++ b/random/moon.pkg
@@ -13,4 +13,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/random/moon.pkg
+++ b/random/moon.pkg
@@ -12,4 +12,3 @@ import {
   "moonbitlang/core/bench",
   "moonbitlang/core/test",
 } for "test"
-

--- a/ref/moon.pkg
+++ b/ref/moon.pkg
@@ -7,4 +7,3 @@ import {
 import {
   "moonbitlang/core/test",
 } for "test"
-

--- a/ref/moon.pkg
+++ b/ref/moon.pkg
@@ -8,4 +8,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/set/moon.pkg
+++ b/set/moon.pkg
@@ -9,4 +9,3 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
 } for "test"
-

--- a/set/moon.pkg
+++ b/set/moon.pkg
@@ -10,4 +10,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/sorted_map/moon.pkg
+++ b/sorted_map/moon.pkg
@@ -12,4 +12,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/sorted_map/moon.pkg
+++ b/sorted_map/moon.pkg
@@ -11,4 +11,3 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
 } for "test"
-

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -10,4 +10,3 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
 } for "test"
-

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -11,4 +11,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/strconv/moon.pkg
+++ b/strconv/moon.pkg
@@ -7,4 +7,4 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "-deprecated+implicit_impl_as_method"
+warnings = "-deprecated"

--- a/string/internal/regex_engine/ast/moon.pkg
+++ b/string/internal/regex_engine/ast/moon.pkg
@@ -4,4 +4,3 @@ import {
   "moonbitlang/core/internal/regex_engine/shared_types",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/string/internal/regex_engine/ast/moon.pkg
+++ b/string/internal/regex_engine/ast/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/internal/regex_engine/shared_types",
 }
-

--- a/string/internal/regex_engine/moon.pkg
+++ b/string/internal/regex_engine/moon.pkg
@@ -12,4 +12,3 @@ import {
 import {
   "moonbitlang/core/test",
 } for "test"
-

--- a/string/internal/regex_engine/moon.pkg
+++ b/string/internal/regex_engine/moon.pkg
@@ -13,4 +13,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/string/internal/regex_parser/moon.pkg
+++ b/string/internal/regex_parser/moon.pkg
@@ -4,4 +4,3 @@ import {
   "moonbitlang/core/string/internal/regex_engine" @re,
 }
 
-warnings = "+implicit_impl_as_method"

--- a/string/internal/regex_parser/moon.pkg
+++ b/string/internal/regex_parser/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/string/internal/regex_engine" @re,
 }
-

--- a/string/moon.pkg
+++ b/string/moon.pkg
@@ -20,7 +20,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
 )

--- a/string/moon.pkg
+++ b/string/moon.pkg
@@ -20,7 +20,6 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"
 
 options(
   targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },

--- a/test/moon.pkg
+++ b/test/moon.pkg
@@ -3,4 +3,3 @@ import {
   "moonbitlang/core/debug",
 }
 
-warnings = "+implicit_impl_as_method"

--- a/test/moon.pkg
+++ b/test/moon.pkg
@@ -2,4 +2,3 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
-

--- a/tuple/moon.pkg
+++ b/tuple/moon.pkg
@@ -9,4 +9,3 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/test",
 } for "test"
-

--- a/tuple/moon.pkg
+++ b/tuple/moon.pkg
@@ -10,4 +10,3 @@ import {
   "moonbitlang/core/test",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/uint/moon.pkg
+++ b/uint/moon.pkg
@@ -5,4 +5,3 @@ import {
 import {
   "moonbitlang/core/buffer",
 } for "test"
-

--- a/uint/moon.pkg
+++ b/uint/moon.pkg
@@ -6,4 +6,3 @@ import {
   "moonbitlang/core/buffer",
 } for "test"
 
-warnings = "+implicit_impl_as_method"

--- a/v128/moon.pkg
+++ b/v128/moon.pkg
@@ -9,4 +9,3 @@ import {
 import {
   "moonbitlang/core/bench",
 } for "test"
-

--- a/v128/moon.pkg
+++ b/v128/moon.pkg
@@ -10,4 +10,3 @@ import {
   "moonbitlang/core/bench",
 } for "test"
 
-warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
Follow-up to #3932.

`implicit_impl_as_method` was opted into package by package, and only **56 of 125** packages had it. That means a new package silently opts *out* by omission — which is exactly how `coverage` drifted until #3932 caught it by accident.

This moves the flag to the module-level `warnings` in `moon.mod` and drops the now-redundant per-package copies.

```diff
-warnings = "…+prefer_readonly_array-implicit_use_builtin"
+warnings = "…+prefer_readonly_array-implicit_use_builtin+implicit_impl_as_method"
```

- **50** `moon.pkg` files lose their `warnings` line entirely
- **6** keep one for unrelated flags: `strconv` and `immut/array` (`-deprecated`), `bigint` (`-29`), `argparse` (`+unnecessary_annotation`)

Net: 57 files changed, +7 / −57.

### No new warnings — and that's a real result, not a no-op

Enabling it for the 69 packages that lacked it surfaces nothing. Because "zero warnings" is exactly what a silently-ignored setting would also produce, I checked the mechanism directly: removing `coverage`'s own flag **and** its `extends.mbt` makes the warning fire from `moon.mod` alone. So module-level settings do reach packages that don't set their own, and the clean sweep is genuine.

## Verification

Run in a clean worktree at `cdff389c`, with the flag module-wide and every per-package copy removed:

- `moon check --deny-warn --target all` — clean
- `moon test --target all` — green (6783 wasm / 6783 wasm-gc / 6739 js / 6694 native), identical to `main`
- `moon test --build-only --target all --deny-warn` — exit 0, zero `implicit_impl_as_method` hits

That last one matters: generated test drivers and non-`priv` test fixtures are a known trigger for this warning (per `AGENTS.md`), so `moon check` alone wouldn't have been conclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)