### PR TITLE
test(debug): add missing test for the `Repr(x)` constructor

### DIFF
--- a/debug/repr_test.mbt
+++ b/debug/repr_test.mbt
@@ -1,0 +1,23 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "Repr constructor" {
+  // `Repr(x)` converts any `Debug` value; it is the constructor of `Repr`,
+  // re-exported by the prelude so no import is needed.
+  inspect(Repr(42), content="42")
+  inspect(Repr("hello"), content="\"hello\"")
+  inspect(Repr(true), content="true")
+  inspect(Repr([1, 2]), content="[1, 2]")
+}


### PR DESCRIPTION
## Summary

The test written alongside `Repr::Repr` in #3925 **never got committed** — the file was new and the commit staged tracked files only (`git add -u`), so it was silently dropped. The constructor shipped untested. This adds it back.

```moonbit
test "Repr constructor" {
  inspect(Repr(42), content="42")
  inspect(Repr("hello"), content="\"hello\"")
  inspect(Repr(true), content="true")
  inspect(Repr([1, 2]), content="[1, 2]")
}
```

## Verification
- `debug` package goes 70 → 71 tests, all passing (verified by removing/restoring the file).
- `moon check --deny-warn --target all` clean; `.mbti` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)