### PR TITLE
fix(math): let hypot return Infinity when one argument is infinite and the other is NaN

### DIFF
--- a/math/algebraic_double_nonjs.mbt
+++ b/math/algebraic_double_nonjs.mbt
@@ -107,11 +107,11 @@ pub fn cbrt(x : Double) -> Double {
 /// }
 /// ```
 pub fn hypot(x : Double, y : Double) -> Double {
-  if x.is_nan() || y.is_nan() {
-    return @double.not_a_number
-  }
   if x.is_inf() || y.is_inf() {
     return @double.infinity
+  }
+  if x.is_nan() || y.is_nan() {
+    return @double.not_a_number
   }
   let x = x.abs()
   let y = y.abs()

--- a/math/algebraic_test.mbt
+++ b/math/algebraic_test.mbt
@@ -59,3 +59,28 @@ test "@math.hypot small ratio" {
   let small = @math.hypot(1.0, ys[0])
   assert_true(small.is_close(1.0))
 }
+
+///|
+test "@math.hypot nan and infinity" {
+  // an infinite argument yields +Infinity even when the other is NaN
+  inspect(
+    @math.hypot(@double.not_a_number, @double.infinity),
+    content="Infinity",
+  )
+  inspect(
+    @math.hypot(@double.infinity, @double.not_a_number),
+    content="Infinity",
+  )
+  inspect(
+    @math.hypot(@double.not_a_number, @double.neg_infinity),
+    content="Infinity",
+  )
+  inspect(
+    @math.hypot(@double.neg_infinity, @double.not_a_number),
+    content="Infinity",
+  )
+  inspect(@math.hypot(@double.not_a_number, 1.0), content="NaN")
+  inspect(@math.hypot(1.0, @double.not_a_number), content="NaN")
+  inspect(@math.hypot(@double.infinity, 1.0), content="Infinity")
+  inspect(@math.hypot(1.0, @double.neg_infinity), content="Infinity")
+}


### PR DESCRIPTION
`hypot` checked for NaN before infinity, so `hypot(NaN, Infinity)` returned NaN on native and wasm-gc. Per IEEE 754 / C99, an infinite argument gives +Infinity even when the other is NaN (this is what the JS target already does via `Math.hypot`). Swapped the two checks so infinity wins.

Added a regression test covering both orders, negative infinity, and the still-NaN cases.

Closes #3913
