### PR TITLE
fix(math): preserve the sign of tanh for tiny negative inputs

### DIFF
--- a/math/hyperbolic_double_nonjs.mbt
+++ b/math/hyperbolic_double_nonjs.mbt
@@ -201,11 +201,14 @@ pub fn tanh(x : Double) -> Double {
     return -1.0
   }
   let ix = get_high_word(x).reinterpret_as_int() & 0x7fffffff
+  // |x| < 2^-55: tanh(x) == x to working precision, and this already carries
+  // the sign, so it must not go through the |x|-based sign fixup below.
+  if ix < 0x3c800000 {
+    return x * (1.0 + x)
+  }
   let tiny = 1.0e-300
   let z = if ix < 0x40360000 {
-    if ix < 0x3c800000 {
-      x * (1.0 + x)
-    } else if ix >= 0x3ff00000 {
+    if ix >= 0x3ff00000 {
       let t = (2.0 * x.abs()) |> expm1
       1.0 - 2.0 / (t + 2.0)
     } else {

--- a/math/hyperbolic_test.mbt
+++ b/math/hyperbolic_test.mbt
@@ -167,6 +167,21 @@ test "hyperbolic double branch coverage" {
 }
 
 ///|
+test "tanh preserves the sign of tiny inputs" {
+  // |x| < 2^-55: tanh(x) == x, so the sign must survive
+  let neg = 0x8000000000000001UL
+  let pos = 0x0000000000000001UL
+  assert_eq(
+    @math.tanh(neg.reinterpret_as_double()).reinterpret_as_uint64(),
+    neg,
+  )
+  assert_eq(
+    @math.tanh(pos.reinterpret_as_double()).reinterpret_as_uint64(),
+    pos,
+  )
+}
+
+///|
 test "cosh large-arg coverage" {
   inspect(@math.cosh(22.0), content="1792456423.065796")
   inspect(@math.cosh(100.0), content="1.3440585709080678e+43")


### PR DESCRIPTION
For `|x| < 2^-55`, `tanh(x)` equals `x`, and the tiny-input branch already computes a signed result. But it then fell through to the shared `x >= 0 ? z : -z` fixup (meant for the branches that work on `|x|`), so a tiny negative input got its sign flipped to positive on native and wasm-gc. Return the tiny-input result directly, before the fixup.

Added a regression test checking the sign is preserved for the smallest positive and negative subnormals.

Closes #3910
