### PR TITLE
feat(diff): add `Hunk` structural accessors — the primitive for custom renderers

### DIFF
--- a/diff/README.mbt.md
+++ b/diff/README.mbt.md
@@ -117,3 +117,50 @@ test "group splits distant changes into separate hunks" {
   )
 }
 ```
+
+## Custom Renderers
+
+`render` emits plain unified text. For anything else — terminal colors, HTML,
+side-by-side — build on the structural accessors: `header()`, `edits()`, and
+the `old_view()` / `new_view()` the edit indices refer to. Core ships no color
+or markup support on purpose; a renderer is a small loop:
+
+```mbt check
+///|
+test "git-style terminal colors from the public Hunk API" {
+  let old = ["a", "b", "c"][:]
+  let new = ["a", "x", "c"][:]
+  let buf = StringBuilder::new()
+  for h in @diff.Diff(old~, new~).group(context=1) {
+    buf <+ "\u{1b}[36m\{h.header()}\u{1b}[0m\n"
+    let o = h.old_view()
+    let n = h.new_view()
+    for edit in h.edits() {
+      match edit {
+        Equal(old_index~, len~, ..) =>
+          for e in o.view(start=old_index, end=old_index + len) {
+            buf <+ " \{e}\n"
+          }
+        Delete(old_index~, old_len~, ..) =>
+          for e in o.view(start=old_index, end=old_index + old_len) {
+            buf <+ "\u{1b}[31m-\{e}\u{1b}[0m\n"
+          }
+        Insert(new_index~, new_len~, ..) =>
+          for e in n.view(start=new_index, end=new_index + new_len) {
+            buf <+ "\u{1b}[32m+\{e}\u{1b}[0m\n"
+          }
+      }
+    }
+  }
+  inspect(
+    buf.to_string().escape(),
+    content=(
+      #|"\u{1b}[36m@@ -1,3 +1,3 @@\u{1b}[0m\n a\n\u{1b}[31m-b\u{1b}[0m\n\u{1b}[32m+x\u{1b}[0m\n c\n"
+    ),
+  )
+}
+```
+
+An HTML renderer works the same way; escaping and CSS are the renderer's own
+concern (see the blackbox tests for a complete example that snapshots a styled
+page to `__snapshot__/hunk.html`).

--- a/diff/__snapshot__/hunk.html
+++ b/diff/__snapshot__/hunk.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>
+pre.hunk { font-family: monospace; }
+.hunk-header { color: #00a; }
+.del { background: #fdd; }
+.add { background: #dfd; }
+</style></head><body>
+<pre class="hunk">
+<span class="hunk-header">@@ -1,4 +1,4 @@</span>
+<span class="ctx"> let x = 1</span>
+<span class="del">-if a &lt; b {</span>
+<span class="del">-  go()</span>
+<span class="add">+if a &amp; b &lt; c {</span>
+<span class="add">+  stop()</span>
+<span class="ctx"> }</span>
+</pre>
+</body></html>

--- a/diff/diff_test.mbt
+++ b/diff/diff_test.mbt
@@ -518,3 +518,140 @@ test "property: edit scripts reconstruct new from old" {
     }
   }
 }
+
+///|
+/// A terminal renderer written purely against the public API
+/// (`header` + `edits` + views), the way a third-party `diff-ansi` package
+/// would: cyan hunk header, red removals, green additions (git's default look).
+fn[T] ansi_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
+  let buf = StringBuilder::new()
+  buf <+ "\u{1b}[36m\{h.header()}\u{1b}[0m\n"
+  let old = h.old_view()
+  let new = h.new_view()
+  for edit in h.edits() {
+    match edit {
+      Equal(old_index~, len~, ..) =>
+        for e in old.view(start=old_index, end=old_index + len) {
+          buf <+ " \{show(e)}\n"
+        }
+      Delete(old_index~, old_len~, ..) =>
+        for e in old.view(start=old_index, end=old_index + old_len) {
+          buf <+ "\u{1b}[31m-\{show(e)}\u{1b}[0m\n"
+        }
+      Insert(new_index~, new_len~, ..) =>
+        for e in new.view(start=new_index, end=new_index + new_len) {
+          buf <+ "\u{1b}[32m+\{show(e)}\u{1b}[0m\n"
+        }
+    }
+  }
+  buf.to_string()
+}
+
+///|
+/// An HTML renderer written purely against the public API, the way a
+/// third-party `diff-html` package would. Escaping is the renderer's own
+/// concern — exactly why HTML stays out of core.
+fn[T] html_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
+  fn esc(s : String) -> String {
+    let buf = StringBuilder::new()
+    for c in s {
+      match c {
+        '&' => buf.write_string("&amp;")
+        '<' => buf.write_string("&lt;")
+        '>' => buf.write_string("&gt;")
+        _ => buf.write_char(c)
+      }
+    }
+    buf.to_string()
+  }
+
+  fn line(buf : StringBuilder, cls : String, prefix : String, text : String) {
+    buf <+ "<span class=\"\{cls}\">\{prefix}\{text}</span>\n"
+  }
+
+  let buf = StringBuilder::new()
+  buf <+ "<pre class=\"hunk\">\n"
+  buf <+ "<span class=\"hunk-header\">\{esc(h.header())}</span>\n"
+  let old = h.old_view()
+  let new = h.new_view()
+  for edit in h.edits() {
+    match edit {
+      Equal(old_index~, len~, ..) =>
+        for e in old.view(start=old_index, end=old_index + len) {
+          line(buf, "ctx", " ", esc(show(e)))
+        }
+      Delete(old_index~, old_len~, ..) =>
+        for e in old.view(start=old_index, end=old_index + old_len) {
+          line(buf, "del", "-", esc(show(e)))
+        }
+      Insert(new_index~, new_len~, ..) =>
+        for e in new.view(start=new_index, end=new_index + new_len) {
+          line(buf, "add", "+", esc(show(e)))
+        }
+    }
+  }
+  buf <+ "</pre>"
+  buf.to_string()
+}
+
+///|
+test "third-party ANSI renderer over the public Hunk API" {
+  let old = ["a", "b", "c"][:]
+  let new = ["a", "x", "c"][:]
+  let hunks = @diff.Diff(old~, new~).group(context=1)
+  inspect(
+    ansi_render(hunks[0], show=l => l).escape(),
+    content=(
+      #|"\u{1b}[36m@@ -1,3 +1,3 @@\u{1b}[0m\n a\n\u{1b}[31m-b\u{1b}[0m\n\u{1b}[32m+x\u{1b}[0m\n c\n"
+    ),
+  )
+}
+
+///|
+test "third-party HTML renderer over the public Hunk API" (t : @test.Test) {
+  // File-based snapshot: the result is a real page at
+  // diff/__snapshot__/hunk.html - open it in a browser.
+  let old = ["let x = 1", "if a < b {", "  go()", "}"][:]
+  let new = ["let x = 1", "if a & b < c {", "  stop()", "}"][:]
+  t.writeln("<!DOCTYPE html>")
+  t.writeln("<html><head><meta charset=\"utf-8\"><style>")
+  t.writeln("pre.hunk { font-family: monospace; }")
+  t.writeln(".hunk-header { color: #00a; }")
+  t.writeln(".del { background: #fdd; }")
+  t.writeln(".add { background: #dfd; }")
+  t.writeln("</style></head><body>")
+  for h in @diff.Diff(old~, new~).group() {
+    t.writeln(html_render(h, show=l => l))
+  }
+  t.writeln("</body></html>")
+  t.snapshot(filename="hunk.html")
+}
+
+///|
+test "edits() with the views agrees with render()" {
+  let old = ["a", "b", "c", "d"][:]
+  let new = ["a", "x", "c", "y"][:]
+  for h in @diff.Diff(old~, new~).group(context=1) {
+    let rebuilt = StringBuilder::new()
+    rebuilt <+ "\{h.header()}\n"
+    let o = h.old_view()
+    let n = h.new_view()
+    for edit in h.edits() {
+      match edit {
+        Equal(old_index~, len~, ..) =>
+          for e in o.view(start=old_index, end=old_index + len) {
+            rebuilt <+ " \{e}\n"
+          }
+        Delete(old_index~, old_len~, ..) =>
+          for e in o.view(start=old_index, end=old_index + old_len) {
+            rebuilt <+ "-\{e}\n"
+          }
+        Insert(new_index~, new_len~, ..) =>
+          for e in n.view(start=new_index, end=new_index + new_len) {
+            rebuilt <+ "+\{e}\n"
+          }
+      }
+    }
+    assert_eq(rebuilt.to_string(), h.render(show=l => l))
+  }
+}

--- a/diff/hunk.mbt
+++ b/diff/hunk.mbt
@@ -81,6 +81,43 @@ struct Hunk[T] {
 }
 
 ///|
+/// The hunk's unified-diff header, e.g. `@@ -1,3 +1,3 @@`.
+///
+/// The numbering rules (1-based lines, single-line ranges shown without a
+/// length, empty ranges anchored to the previous line) are canonical and easy
+/// to get subtly wrong, so they live here rather than in each renderer.
+pub fn[T] Hunk::header(self : Hunk[T]) -> String {
+  Show::to_string(HunkHeader::new(self.edits))
+}
+
+///|
+/// The hunk's slice of the edit script.
+///
+/// Together with `old_view` / `new_view` this is the primitive for custom
+/// renderers (terminal colors, HTML, side-by-side, ...); `render` is the
+/// built-in unified-text one. Edit indices are absolute positions in
+/// `old_view()` / `new_view()`: slice `old_view()` with `old_index`/`old_len`
+/// for `Delete`, `new_view()` with `new_index`/`new_len` for `Insert`, and
+/// either view for `Equal`.
+pub fn[T] Hunk::edits(self : Hunk[T]) -> ArrayView[Edit] {
+  self.edits
+}
+
+///|
+/// The complete original input sequence that the hunk's `old_index` values
+/// refer to (not a hunk-local view), so a received `Hunk` is self-contained.
+pub fn[T] Hunk::old_view(self : Hunk[T]) -> ArrayView[T] {
+  self.old
+}
+
+///|
+/// The complete updated input sequence that the hunk's `new_index` values
+/// refer to (not a hunk-local view), so a received `Hunk` is self-contained.
+pub fn[T] Hunk::new_view(self : Hunk[T]) -> ArrayView[T] {
+  self.new
+}
+
+///|
 /// Render the hunk as unified-diff text: an `@@ -a,b +c,d @@` header followed
 /// by `-`/`+`/` `-prefixed lines, each terminated by a newline.
 ///
@@ -89,9 +126,7 @@ struct Hunk[T] {
 /// control the rendering (e.g. a field of a record).
 pub fn[T] Hunk::render(self : Hunk[T], show~ : (T) -> String) -> String {
   let buf = StringBuilder::new()
-  let header = Show::to_string(HunkHeader::new(self.edits))
-  buf.write_string(header)
-  buf.write_char('\n')
+  buf <+ "\{self.header()}\n"
   for edit in self.edits {
     let (prefix, slice) = match edit {
       Insert(..) => ("+", edit.view_from(old=self.old, new=self.new))
@@ -99,9 +134,7 @@ pub fn[T] Hunk::render(self : Hunk[T], show~ : (T) -> String) -> String {
       Equal(..) => (" ", edit.view_from(old=self.old, new=self.new))
     }
     for s in slice {
-      buf.write_string(prefix)
-      buf.write_string(show(s))
-      buf.write_char('\n')
+      buf <+ "\{prefix}\{show(s)}\n"
     }
   }
   buf.to_string()

--- a/diff/moon.pkg
+++ b/diff/moon.pkg
@@ -11,3 +11,7 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/core/debug",
 } for "wbtest"
+
+import {
+  "moonbitlang/core/test",
+} for "test"

--- a/diff/pkg.generated.mbti
+++ b/diff/pkg.generated.mbti
@@ -31,6 +31,10 @@ pub enum Edit {
 pub fn Edit::equal(Self, Self) -> Bool
 
 type Hunk[T]
+pub fn[T] Hunk::edits(Self[T]) -> ArrayView[Edit]
+pub fn[T] Hunk::header(Self[T]) -> String
+pub fn[T] Hunk::new_view(Self[T]) -> ArrayView[T]
+pub fn[T] Hunk::old_view(Self[T]) -> ArrayView[T]
 pub fn[T] Hunk::render(Self[T], show~ : (T) -> String) -> String
 
 // Type aliases


### PR DESCRIPTION
## Summary

Follow-up to #3247. Adds the minimal primitive that makes custom diff renderers (terminal colors, HTML, side-by-side, word-diff, …) implementable **outside core** — structural accessors mirroring `Diff`'s own:

```
pub fn[T] Hunk::header(Self[T]) -> String            // "@@ -a,b +c,d @@"
pub fn[T] Hunk::edits(Self[T]) -> ArrayView[Edit]
pub fn[T] Hunk::old_view(Self[T]) -> ArrayView[T]
pub fn[T] Hunk::new_view(Self[T]) -> ArrayView[T]
```

That is the **entire** surface addition — four functions, no new types. Core stays 100% presentation-free: no color flag, no style enum, no HTML, deliberately. Without this, a custom renderer must re-implement `group`'s context-trimming semantics from `Diff::edits()`, which silently drifts from core's.

## Design history: a per-line iterator was prototyped and rejected

The first version of this PR shipped `lines() -> Iter2[LineKind, T]` (a flattened per-line stream). Design review (maintainer question + codex adversarial pass) rejected it for the structural accessors:

1. **Lossless beats pre-flattened** — the flat stream loses edit-run structure; side-by-side/word-diff renderers would re-cluster what core already knew.
2. **One vocabulary** — reuses public `Edit`; no second `LineKind` enum whose published constructors could never be retired.
3. **Symmetry** — `Hunk` now exposes exactly what `Diff` does (`edits`/`old_view`/`new_view`), predictable for consumers.
4. A chunk-preserving convenience iterator (à la Rust `similar`'s `DiffOp::iter_slices`) can still be added later **compatibly** if slicing proves burdensome.

`header()` stays in core in either design: unified-diff numbering rules (1-based lines, single-line ranges without a length, empty ranges anchored to the previous line) are canonical and easy for every renderer to get slightly differently wrong. The views are the **complete inputs** (not hunk-local), keeping a received `Hunk` self-contained; `edits()` docs spell out which view each variant's indices slice (the one real footgun).

## Validated by dogfooding

Blackbox tests play the role of third-party packages (public API only):
- a **git-style ANSI renderer** (cyan header, red `-`, green `+`), snapshot-tested;
- an **HTML renderer** with its own escaping, written to a **file-based snapshot**: a complete styled page at `diff/__snapshot__/hunk.html` you can open directly in a browser;
- a consistency test that structural reassembly reproduces `render()` exactly;
- a README **"Custom Renderers"** recipe (compiled + snapshot-checked).

## Verification
- `moon check --deny-warn --target all` — clean.
- diff tests **88/88** on wasm / wasm-gc / js / native; full suite green.
- `.mbti` delta is exactly the four declarations above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
