### PR TITLE
test(diff): word diff, HTML backends, and codex-hardened weighted line alignment (prototype)

### DIFF
--- a/diff/__snapshot__/real_world.html
+++ b/diff/__snapshot__/real_world.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>
+body { font-family: monospace; }
+h3 { font-family: sans-serif; }
+.unified { white-space: pre; }
+.hunk-header { color: #00a; }
+.del { background: #ffecec; display: block; }
+.add { background: #eaffea; display: block; }
+.ctx { display: block; }
+b.wd { background: #f8b4b4; font-weight: normal; }
+b.wa { background: #97e0a0; font-weight: normal; }
+table.split { border-collapse: collapse; width: 100%; }
+table.split td { width: 50%; vertical-align: top;
+  white-space: pre-wrap; border: 1px solid #eee; display: table-cell; }
+td.empty { background: #fafafa; }
+</style></head><body>
+<h3>Verbatim git history: diff/extends.mbt across the API redesign (side-by-side)</h3>
+<table class="split">
+<tr><td class="hunk-header" colspan="2">@@ -14,13 +14,23 @@</td></tr>
+<tr><td class="ctx"></td><td class="ctx"></td></tr>
+<tr><td class="ctx">// --- promoted: kept as regular methods ---</td><td class="ctx">// --- promoted: kept as regular methods ---</td></tr>
+<tr><td class="ctx"></td><td class="ctx"></td></tr>
+<tr><td class="del">//<b class="wd"> A hunk's canonical string form is its unified-diff text, so `to_string` is</b></td><td class="add">///<b class="wa">|</b></td></tr>
+<tr><td class="del"><b class="wd">/</b>/<b class="wd"> promoted; `output` is not (use the</b> <b class="wd">trait</b> <b class="wd">or</b> <b class="wd">string</b> <b class="wd">interpolation).</b></td><td class="add"><b class="wa">pub</b> <b class="wa">extend</b> <b class="wa">DiffAlgorithm</b> <b class="wa">with</b> <b class="wa">Eq::{equal}</b></td></tr>
+<tr><td class="ctx"></td><td class="ctx"></td></tr>
+<tr><td class="ctx">///|</td><td class="ctx">///|</td></tr>
+<tr><td class="del">pub extend <b class="wd">Hunk</b> with <b class="wd">Show</b>::{<b class="wd">to_string</b>}</td><td class="add">pub extend <b class="wa">Edit</b> with <b class="wa">Eq</b>::{<b class="wa">equal</b>}</td></tr>
+<tr><td class="ctx"></td><td class="ctx"></td></tr>
+<tr><td class="ctx">// --- deprecated: hidden from the generated interface ---</td><td class="ctx">// --- deprecated: hidden from the generated interface ---</td></tr>
+<tr><td class="empty"></td><td class="add"></td></tr>
+<tr><td class="empty"></td><td class="add">///|</td></tr>
+<tr><td class="empty"></td><td class="add">#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)</td></tr>
+<tr><td class="empty"></td><td class="add">#doc(hidden)</td></tr>
+<tr><td class="empty"></td><td class="add">pub extend DiffAlgorithm with @debug.Debug::{to_repr}</td></tr>
+<tr><td class="empty"></td><td class="add"></td></tr>
+<tr><td class="empty"></td><td class="add">///|</td></tr>
+<tr><td class="empty"></td><td class="add">#deprecated("Use `!=` instead", skip_current_package=true)</td></tr>
+<tr><td class="empty"></td><td class="add">#doc(hidden)</td></tr>
+<tr><td class="empty"></td><td class="add">pub extend DiffAlgorithm with Eq::{not_equal}</td></tr>
+<tr><td class="ctx"></td><td class="ctx"></td></tr>
+<tr><td class="ctx">///|</td><td class="ctx">///|</td></tr>
+<tr><td class="ctx">#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)</td><td class="ctx">#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)</td></tr>
+<tr><td class="hunk-header" colspan="2">@@ -28,6 +38,6 @@</td></tr>
+<tr><td class="ctx">pub extend Edit with @debug.Debug::{to_repr}</td><td class="ctx">pub extend Edit with @debug.Debug::{to_repr}</td></tr>
+<tr><td class="ctx"></td><td class="ctx"></td></tr>
+<tr><td class="ctx">///|</td><td class="ctx">///|</td></tr>
+<tr><td class="del">#deprecated("Use `<b class="wd">Show::output` via the trait or `to_string</b>` instead", skip_current_package=true)</td><td class="add">#deprecated("Use `<b class="wa">!=</b>` instead", skip_current_package=true)</td></tr>
+<tr><td class="ctx">#doc(hidden)</td><td class="ctx">#doc(hidden)</td></tr>
+<tr><td class="del">pub extend <b class="wd">Hunk</b> with <b class="wd">Show</b>::{<b class="wd">output</b>}</td><td class="add">pub extend <b class="wa">Edit</b> with <b class="wa">Eq</b>::{<b class="wa">not_equal</b>}</td></tr>
+</table>
+
+<h3>Refactor from this package's history (side-by-side)</h3>
+<table class="split">
+<tr><td class="hunk-header" colspan="2">@@ -1,8 +1,7 @@</td></tr>
+<tr><td class="ctx">///|</td><td class="ctx">///|</td></tr>
+<tr><td class="del">pub <b class="wd">impl</b>[T<b class="wd"> : Show</b>] <b class="wd">Show</b> <b class="wd">for</b> Hunk[T] <b class="wd">with</b> <b class="wd">fn</b> <b class="wd">output</b>(<b class="wd">self,</b> <b class="wd">logger</b>) {</td><td class="add">pub <b class="wa">fn</b>[T] <b class="wa">Hunk::render(self</b> <b class="wa">:</b> Hunk[T]<b class="wa">,</b> <b class="wa">show~</b> <b class="wa">:</b> (<b class="wa">T)</b> <b class="wa">-&gt; String</b>)<b class="wa"> -&gt;</b> <b class="wa">String </b>{</td></tr>
+<tr><td class="del">  let <b class="wd">header</b> = <b class="wd">HunkHeader</b>::new<b class="wd">(self.edits).to_string</b>()</td><td class="add">  let <b class="wa">buf</b> = <b class="wa">StringBuilder</b>::new()</td></tr>
+<tr><td class="del">  <b class="wd">logger</b>.<b class="wd">write_string(</b>header<b class="wd">)</b></td><td class="add">  <b class="wa">buf &lt;+ "\{self</b>.header(<b class="wa">)}</b>\n<b class="wa">"</b></td></tr>
+<tr><td class="del"><b class="wd">  logger.write_char</b>(<b class="wd">'</b>\n<b class="wd">')</b></td><td class="empty"></td></tr>
+<tr><td class="ctx">  for edit in self.edits {</td><td class="ctx">  for edit in self.edits {</td></tr>
+<tr><td class="ctx">    let (prefix, slice) = match edit {</td><td class="ctx">    let (prefix, slice) = match edit {</td></tr>
+<tr><td class="ctx">      Insert(..) =&gt; ("+", edit.view_from(old=self.old, new=self.new))</td><td class="ctx">      Insert(..) =&gt; ("+", edit.view_from(old=self.old, new=self.new))</td></tr>
+<tr><td class="hunk-header" colspan="2">@@ -10,7 +9,8 @@</td></tr>
+<tr><td class="ctx">      Equal(..) =&gt; (" ", edit.view_from(old=self.old, new=self.new))</td><td class="ctx">      Equal(..) =&gt; (" ", edit.view_from(old=self.old, new=self.new))</td></tr>
+<tr><td class="ctx">    }</td><td class="ctx">    }</td></tr>
+<tr><td class="ctx">    for s in slice {</td><td class="ctx">    for s in slice {</td></tr>
+<tr><td class="del">      <b class="wd">logger.write_string(</b>"\{prefix}\{s}\n"<b class="wd">)</b></td><td class="add">      <b class="wa">buf &lt;+ </b>"\{prefix}\{<b class="wa">show(</b>s<b class="wa">)</b>}\n"</td></tr>
+<tr><td class="ctx">    }</td><td class="ctx">    }</td></tr>
+<tr><td class="ctx">  }</td><td class="ctx">  }</td></tr>
+<tr><td class="empty"></td><td class="add">  buf.to_string()</td></tr>
+<tr><td class="ctx">}</td><td class="ctx">}</td></tr>
+</table>
+
+<h3>Same refactor (unified, word highlights)</h3>
+<div class="unified">
+<span class="hunk-header">@@ -1,6 +1,5 @@</span>
+<span class="ctx"> ///|</span>
+<span class="del">-pub <b class="wd">impl</b>[T<b class="wd"> : Show</b>] <b class="wd">Show</b> <b class="wd">for</b> Hunk[T] <b class="wd">with</b> <b class="wd">fn</b> <b class="wd">output</b>(<b class="wd">self,</b> <b class="wd">logger</b>) {</span>
+<span class="del">-  let <b class="wd">header</b> = <b class="wd">HunkHeader</b>::new<b class="wd">(self.edits).to_string</b>()</span>
+<span class="del">-  <b class="wd">logger</b>.<b class="wd">write_string(</b>header<b class="wd">)</b></span>
+<span class="del">-<b class="wd">  logger.write_char</b>(<b class="wd">'</b>\n<b class="wd">')</b></span>
+<span class="add">+pub <b class="wa">fn</b>[T] <b class="wa">Hunk::render(self</b> <b class="wa">:</b> Hunk[T]<b class="wa">,</b> <b class="wa">show~</b> <b class="wa">:</b> (<b class="wa">T)</b> <b class="wa">-&gt; String</b>)<b class="wa"> -&gt;</b> <b class="wa">String </b>{</span>
+<span class="add">+  let <b class="wa">buf</b> = <b class="wa">StringBuilder</b>::new()</span>
+<span class="add">+  <b class="wa">buf &lt;+ "\{self</b>.header(<b class="wa">)}</b>\n<b class="wa">"</b></span>
+<span class="ctx">   for edit in self.edits {</span>
+<span class="hunk-header">@@ -12,5 +11,6 @@</span>
+<span class="ctx">     for s in slice {</span>
+<span class="del">-      <b class="wd">logger.write_string(</b>"\{prefix}\{s}\n"<b class="wd">)</b></span>
+<span class="add">+      <b class="wa">buf &lt;+ </b>"\{prefix}\{<b class="wa">show(</b>s<b class="wa">)</b>}\n"</span>
+<span class="ctx">     }</span>
+<span class="ctx">   }</span>
+<span class="add">+  buf.to_string()</span>
+<span class="ctx"> }</span>
+
+</div>
+<h3>Prose</h3>
+<div class="unified">
+<span class="hunk-header">@@ -1,3 +1,3 @@</span>
+<span class="del">-`group` splits the edit script into `Hunk[T]` values, keeping `<b class="wd">radius</b>` lines</span>
+<span class="del">-of surrounding context (default 3). `<b class="wd">radius</b>` must be non-negative, and</span>
+<span class="del">-`<b class="wd">radius</b>=0` emits hunks without surrounding context.</span>
+<span class="add">+`group` splits the edit script into `Hunk[T]` values, keeping `<b class="wa">context</b>` lines</span>
+<span class="add">+of surrounding context (default 3). `<b class="wa">context</b>` must be non-negative, and</span>
+<span class="add">+`<b class="wa">context</b>=0` emits hunks without surrounding context.</span>
+
+</div>
+<h3>HTML-special characters and Unicode</h3>
+<div class="unified">
+<span class="hunk-header">@@ -1,2 +1,2 @@</span>
+<span class="del">-if a &lt; b &amp;&amp; *p != '&amp;' { emit("&lt;<b class="wd">div</b>&gt;") }</span>
+<span class="del">-let 价格 = <b class="wd">10</b> // 单价</span>
+<span class="add">+if a &lt;<b class="wa">=</b> b &amp;&amp; *p != '&amp;' { emit("&lt;<b class="wa">span</b>&gt;") }</span>
+<span class="add">+let 价格 = <b class="wa">12</b> // <b class="wa">含税</b>单价</span>
+
+</div>
+</body></html>

--- a/diff/__snapshot__/real_world.html
+++ b/diff/__snapshot__/real_world.html
@@ -20,8 +20,10 @@ td.empty { background: #fafafa; }
 <tr><td class="ctx"></td><td class="ctx"></td></tr>
 <tr><td class="ctx">// --- promoted: kept as regular methods ---</td><td class="ctx">// --- promoted: kept as regular methods ---</td></tr>
 <tr><td class="ctx"></td><td class="ctx"></td></tr>
-<tr><td class="del">//<b class="wd"> A hunk's canonical string form is its unified-diff text, so `to_string` is</b></td><td class="add">///<b class="wa">|</b></td></tr>
-<tr><td class="del"><b class="wd">/</b>/<b class="wd"> promoted; `output` is not (use the</b> <b class="wd">trait</b> <b class="wd">or</b> <b class="wd">string</b> <b class="wd">interpolation).</b></td><td class="add"><b class="wa">pub</b> <b class="wa">extend</b> <b class="wa">DiffAlgorithm</b> <b class="wa">with</b> <b class="wa">Eq::{equal}</b></td></tr>
+<tr><td class="del">// A hunk's canonical string form is its unified-diff text, so `to_string` is</td><td class="empty"></td></tr>
+<tr><td class="del">// promoted; `output` is not (use the trait or string interpolation).</td><td class="empty"></td></tr>
+<tr><td class="empty"></td><td class="add">///|</td></tr>
+<tr><td class="empty"></td><td class="add">pub extend DiffAlgorithm with Eq::{equal}</td></tr>
 <tr><td class="ctx"></td><td class="ctx"></td></tr>
 <tr><td class="ctx">///|</td><td class="ctx">///|</td></tr>
 <tr><td class="del">pub extend <b class="wd">Hunk</b> with <b class="wd">Show</b>::{<b class="wd">to_string</b>}</td><td class="add">pub extend <b class="wa">Edit</b> with <b class="wa">Eq</b>::{<b class="wa">equal</b>}</td></tr>
@@ -44,7 +46,7 @@ td.empty { background: #fafafa; }
 <tr><td class="ctx">pub extend Edit with @debug.Debug::{to_repr}</td><td class="ctx">pub extend Edit with @debug.Debug::{to_repr}</td></tr>
 <tr><td class="ctx"></td><td class="ctx"></td></tr>
 <tr><td class="ctx">///|</td><td class="ctx">///|</td></tr>
-<tr><td class="del">#deprecated("Use `<b class="wd">Show::output` via the trait or `to_string</b>` instead", skip_current_package=true)</td><td class="add">#deprecated("Use `<b class="wa">!=</b>` instead", skip_current_package=true)</td></tr>
+<tr><td class="del">#deprecated(<b class="wd">"Use `Show::output` via the trait or `to_string` instead"</b>, skip_current_package=true)</td><td class="add">#deprecated(<b class="wa">"Use `!=` instead"</b>, skip_current_package=true)</td></tr>
 <tr><td class="ctx">#doc(hidden)</td><td class="ctx">#doc(hidden)</td></tr>
 <tr><td class="del">pub extend <b class="wd">Hunk</b> with <b class="wd">Show</b>::{<b class="wd">output</b>}</td><td class="add">pub extend <b class="wa">Edit</b> with <b class="wa">Eq</b>::{<b class="wa">not_equal</b>}</td></tr>
 </table>
@@ -53,10 +55,11 @@ td.empty { background: #fafafa; }
 <table class="split">
 <tr><td class="hunk-header" colspan="2">@@ -1,8 +1,7 @@</td></tr>
 <tr><td class="ctx">///|</td><td class="ctx">///|</td></tr>
-<tr><td class="del">pub <b class="wd">impl</b>[T<b class="wd"> : Show</b>] <b class="wd">Show</b> <b class="wd">for</b> Hunk[T] <b class="wd">with</b> <b class="wd">fn</b> <b class="wd">output</b>(<b class="wd">self,</b> <b class="wd">logger</b>) {</td><td class="add">pub <b class="wa">fn</b>[T] <b class="wa">Hunk::render(self</b> <b class="wa">:</b> Hunk[T]<b class="wa">,</b> <b class="wa">show~</b> <b class="wa">:</b> (<b class="wa">T)</b> <b class="wa">-&gt; String</b>)<b class="wa"> -&gt;</b> <b class="wa">String </b>{</td></tr>
+<tr><td class="del">pub <b class="wd">impl</b>[T :<b class="wd"> Show] Show</b> <b class="wd">for</b> Hunk[T] <b class="wd">with</b> <b class="wd">fn</b> <b class="wd">output</b>(<b class="wd">self,</b> <b class="wd">logger</b>) {</td><td class="add">pub <b class="wa">fn</b>[T<b class="wa">]</b> <b class="wa">Hunk</b>:<b class="wa">:render(self</b> <b class="wa">:</b> Hunk[T]<b class="wa">,</b> <b class="wa">show~</b> <b class="wa">:</b> (<b class="wa">T) -&gt;</b> <b class="wa">String</b>)<b class="wa"> -&gt; String</b> {</td></tr>
 <tr><td class="del">  let <b class="wd">header</b> = <b class="wd">HunkHeader</b>::new<b class="wd">(self.edits).to_string</b>()</td><td class="add">  let <b class="wa">buf</b> = <b class="wa">StringBuilder</b>::new()</td></tr>
-<tr><td class="del">  <b class="wd">logger</b>.<b class="wd">write_string(</b>header<b class="wd">)</b></td><td class="add">  <b class="wa">buf &lt;+ "\{self</b>.header(<b class="wa">)}</b>\n<b class="wa">"</b></td></tr>
-<tr><td class="del"><b class="wd">  logger.write_char</b>(<b class="wd">'</b>\n<b class="wd">')</b></td><td class="empty"></td></tr>
+<tr><td class="del">  logger.write_string(header)</td><td class="empty"></td></tr>
+<tr><td class="del">  logger.write_char('\n')</td><td class="empty"></td></tr>
+<tr><td class="empty"></td><td class="add">  buf &lt;+ "\{self.header()}\n"</td></tr>
 <tr><td class="ctx">  for edit in self.edits {</td><td class="ctx">  for edit in self.edits {</td></tr>
 <tr><td class="ctx">    let (prefix, slice) = match edit {</td><td class="ctx">    let (prefix, slice) = match edit {</td></tr>
 <tr><td class="ctx">      Insert(..) =&gt; ("+", edit.view_from(old=self.old, new=self.new))</td><td class="ctx">      Insert(..) =&gt; ("+", edit.view_from(old=self.old, new=self.new))</td></tr>
@@ -64,7 +67,8 @@ td.empty { background: #fafafa; }
 <tr><td class="ctx">      Equal(..) =&gt; (" ", edit.view_from(old=self.old, new=self.new))</td><td class="ctx">      Equal(..) =&gt; (" ", edit.view_from(old=self.old, new=self.new))</td></tr>
 <tr><td class="ctx">    }</td><td class="ctx">    }</td></tr>
 <tr><td class="ctx">    for s in slice {</td><td class="ctx">    for s in slice {</td></tr>
-<tr><td class="del">      <b class="wd">logger.write_string(</b>"\{prefix}\{s}\n"<b class="wd">)</b></td><td class="add">      <b class="wa">buf &lt;+ </b>"\{prefix}\{<b class="wa">show(</b>s<b class="wa">)</b>}\n"</td></tr>
+<tr><td class="del">      logger.write_string("\{prefix}\{s}\n")</td><td class="empty"></td></tr>
+<tr><td class="empty"></td><td class="add">      buf &lt;+ "\{prefix}\{show(s)}\n"</td></tr>
 <tr><td class="ctx">    }</td><td class="ctx">    }</td></tr>
 <tr><td class="ctx">  }</td><td class="ctx">  }</td></tr>
 <tr><td class="empty"></td><td class="add">  buf.to_string()</td></tr>

--- a/diff/__snapshot__/word_diff.html
+++ b/diff/__snapshot__/word_diff.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>
+body { font-family: monospace; white-space: pre; }
+.hunk-header { color: #00a; }
+.del { background: #ffecec; display: block; }
+.add { background: #eaffea; display: block; }
+.ctx { display: block; }
+b.wd { background: #f8b4b4; font-weight: normal; }
+b.wa { background: #97e0a0; font-weight: normal; }
+</style></head><body>
+<span class="hunk-header">@@ -1,5 +1,5 @@</span>
+<span class="del">-fn total(items : Array[Item]) -&gt; Int {</span>
+<span class="add">+fn total(items : Array[Item]<b class="wa">, tax~ : Int</b>) -&gt; Int {</span>
+<span class="ctx">   let mut sum = 0</span>
+<span class="ctx">   for item in items {</span>
+<span class="del">-    sum += item.price * item.count</span>
+<span class="add">+    sum += item.price * item.count<b class="wa"> + tax</b></span>
+<span class="ctx">   }</span>
+
+</body></html>

--- a/diff/diff_align_test.mbt
+++ b/diff/diff_align_test.mbt
@@ -1,0 +1,483 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Similarity-based line alignment with weighted intraline highlights, per the
+// codex-reviewed design. All arithmetic is integer (weights x20, similarity
+// in permille) so scores and tracebacks are bit-identical on every backend.
+
+///|
+priv enum TokKind {
+  Word // identifiers and numbers
+  Str // string literals and #|/$| raw-string lines
+  Marker // the `///|` block separator
+  Punct
+  Comment // content tokens inside a // comment (tokenized, not opaque)
+  Filler // comment boilerplate: the // marker and comment whitespace
+  Space
+} derive(Eq, @debug.Debug)
+
+///|
+priv struct Tok {
+  kind : TokKind
+  text : String
+}
+
+///|
+fn weight(k : TokKind) -> Int {
+  match k {
+    Word | Str | Marker => 20
+    Punct => 6
+    Comment => 2
+    Space => 1
+    // filler carries no signal either way: shared `//` markers and comment
+    // spacing must not make unrelated comments look similar
+    Filler => 0
+  }
+}
+
+///|
+/// Tokenize the body of a `//` comment: same shapes as code tokens, but all
+/// carry the low `Comment` weight, so similar comments pair while unrelated
+/// ones do not — a whole comment is never one opaque cheap token.
+fn push_comment_tokens(toks : Array[Tok], body : String) -> Unit {
+  let mut rest = body.view()
+  while rest is [_, ..] {
+    rest = lexscan rest with longest {
+      (re"^//+" as t, after=next) => {
+        toks.push({ kind: Filler, text: t.to_owned() })
+        next
+      }
+      (re"^[A-Za-z_][A-Za-z0-9_]*" as t, after=next) => {
+        toks.push({ kind: Comment, text: t.to_owned() })
+        next
+      }
+      (re"^[ \t]+" as t, after=next) => {
+        toks.push({ kind: Filler, text: t.to_owned() })
+        next
+      }
+      (re"^." as t, after=next) => {
+        toks.push({ kind: Comment, text: t.to_string() })
+        next
+      }
+      _ => abort("unreachable")
+    }
+  }
+}
+
+///|
+/// Tokenize one line (no newline). Faithful: concatenating `text`s
+/// reproduces the line. Rule order matters: `///|`, raw-string lines and
+/// string literals are recognized before the `//` comment rule, so `//`
+/// inside strings is never a comment.
+fn tokenize_line(line : String) -> Array[Tok] {
+  let toks : Array[Tok] = []
+  let mut rest = line.view()
+  while rest is [_, ..] {
+    rest = lexscan rest with longest {
+      (re"^///\|" as t, after=next) => {
+        toks.push({ kind: Marker, text: t.to_owned() })
+        next
+      }
+      (re"^#\|[^\n]*" as t, after=next) => {
+        toks.push({ kind: Str, text: t.to_owned() })
+        next
+      }
+      (re"^\$\|[^\n]*" as t, after=next) => {
+        toks.push({ kind: Str, text: t.to_owned() })
+        next
+      }
+      (re"^\"(\\.|[^\"\\])*\"" as t, after=next) => {
+        toks.push({ kind: Str, text: t.to_owned() })
+        next
+      }
+      (re"^//[^\n]*" as t, after=next) => {
+        push_comment_tokens(toks, t.to_owned())
+        next
+      }
+      (re"^[A-Za-z_][A-Za-z0-9_]*" as t, after=next) => {
+        toks.push({ kind: Word, text: t.to_owned() })
+        next
+      }
+      (re"^[0-9]+" as t, after=next) => {
+        toks.push({ kind: Word, text: t.to_owned() })
+        next
+      }
+      (re"^[ \t]+" as t, after=next) => {
+        toks.push({ kind: Space, text: t.to_owned() })
+        next
+      }
+      (re"^." as t, after=next) => {
+        toks.push({ kind: Punct, text: t.to_string() })
+        next
+      }
+      _ => abort("unreachable")
+    }
+  }
+  toks
+}
+
+///|
+fn tok_mass(ts : ArrayView[Tok]) -> Int {
+  let mut m = 0
+  for t in ts {
+    m += weight(t.kind)
+  }
+  m
+}
+
+///|
+/// Substitution is offered only between same-kind tokens, at 1.5x the class
+/// weight: cheaper than delete+insert (2x) so renames align, but expensive
+/// enough that two lines with nothing in common score ~0.25, well below the
+/// pairing threshold.
+fn subst_cost(a : Tok, b : Tok) -> Int? {
+  if a.kind == b.kind {
+    if a.text == b.text {
+      Some(0)
+    } else {
+      Some(weight(a.kind) * 3 / 2)
+    }
+  } else {
+    None
+  }
+}
+
+///|
+/// Weighted token edit distance, rolling rows (scoring only).
+fn wdist(a : ArrayView[Tok], b : ArrayView[Tok]) -> Int {
+  let n = b.length()
+  let mut prev = Array::makei(n + 1, j => if j == 0 { 0 } else { 0 })
+  let mut j0 = 0
+  for j in 1..<(n + 1) {
+    j0 += weight(b[j - 1].kind)
+    prev[j] = j0
+  }
+  let mut cur = Array::make(n + 1, 0)
+  for i in 1..<(a.length() + 1) {
+    cur[0] = prev[0] + weight(a[i - 1].kind)
+    for j in 1..<(n + 1) {
+      let del = prev[j] + weight(a[i - 1].kind)
+      let ins = cur[j - 1] + weight(b[j - 1].kind)
+      let mut best = if del < ins { del } else { ins }
+      match subst_cost(a[i - 1], b[j - 1]) {
+        Some(c) => if prev[j - 1] + c < best { best = prev[j - 1] + c }
+        None => ()
+      }
+      cur[j] = best
+    }
+    let t = prev
+    prev = cur
+    cur = t
+  }
+  prev[b.length()]
+}
+
+///|
+/// Similarity in permille: 1000 * (mass - dist) / mass over both sides.
+fn sim_pm(a : ArrayView[Tok], b : ArrayView[Tok]) -> Int {
+  let m = tok_mass(a) + tok_mass(b)
+  if m == 0 {
+    return 1000
+  }
+  (m - wdist(a, b)) * 1000 / m
+}
+
+///|
+const THETA : Int = 400 // pairing threshold, permille
+
+///|
+/// Monotone block alignment maximizing the total positive margin
+/// sum(sim - THETA); a pair is only usable when its margin is > 0.
+/// Deterministic: integer scores, stored backpointers, tie preference
+/// diag > left > up (which yields delete-before-insert in forward order).
+fn align(
+  olds : Array[Array[Tok]],
+  news : Array[Array[Tok]],
+) -> Array[(Int?, Int?)] {
+  let m = olds.length()
+  let n = news.length()
+  let dp = Array::makei(m + 1, _ => Array::make(n + 1, 0))
+  let bp = Array::makei(m + 1, _ => Array::make(n + 1, 0)) // 1 diag, 2 left, 3 up
+  for j in 1..<(n + 1) {
+    bp[0][j] = 2
+  }
+  for i in 1..<(m + 1) {
+    bp[i][0] = 3
+    for j in 1..<(n + 1) {
+      let margin = sim_pm(olds[i - 1][:], news[j - 1][:]) - THETA
+      let mut best = dp[i][j - 1]
+      let mut way = 2
+      if dp[i - 1][j] > best {
+        best = dp[i - 1][j]
+        way = 3
+      }
+      if margin > 0 && dp[i - 1][j - 1] + margin >= best {
+        best = dp[i - 1][j - 1] + margin
+        way = 1
+      }
+      dp[i][j] = best
+      bp[i][j] = way
+    }
+  }
+  let out : Array[(Int?, Int?)] = []
+  let mut i = m
+  let mut j = n
+  while i > 0 || j > 0 {
+    match bp[i][j] {
+      1 => {
+        out.push((Some(i - 1), Some(j - 1)))
+        i -= 1
+        j -= 1
+      }
+      2 => {
+        out.push((None, Some(j - 1)))
+        j -= 1
+      }
+      _ => {
+        out.push((Some(i - 1), None))
+        i -= 1
+      }
+    }
+  }
+  out.rev_in_place()
+  out
+}
+
+///|
+priv enum Op {
+  OEq(Tok)
+  OSub(Tok, Tok)
+  ODel(Tok)
+  OIns(Tok)
+}
+
+///|
+/// Full traceback for one aligned pair: the highlight script IS the scored
+/// script. Fill-time preference: equal/substitution (diag) > insert (left)
+/// > delete (up); backward left-before-up yields forward
+/// delete-before-insert. Cross-kind substitution is not offered, so it
+/// decomposes into delete+insert at equal cost.
+fn pair_ops(a : Array[Tok], b : Array[Tok]) -> Array[Op] {
+  let m = a.length()
+  let n = b.length()
+  let dp = Array::makei(m + 1, _ => Array::make(n + 1, 0))
+  let bp = Array::makei(m + 1, _ => Array::make(n + 1, 0)) // 1 diag, 2 left, 3 up
+  for j in 1..<(n + 1) {
+    dp[0][j] = dp[0][j - 1] + weight(b[j - 1].kind)
+    bp[0][j] = 2
+  }
+  for i in 1..<(m + 1) {
+    dp[i][0] = dp[i - 1][0] + weight(a[i - 1].kind)
+    bp[i][0] = 3
+    for j in 1..<(n + 1) {
+      let mut best = dp[i - 1][j] + weight(a[i - 1].kind) // delete
+      let mut way = 3
+      let ins = dp[i][j - 1] + weight(b[j - 1].kind)
+      if ins <= best {
+        best = ins
+        way = 2
+      }
+      match subst_cost(a[i - 1], b[j - 1]) {
+        Some(c) =>
+          if dp[i - 1][j - 1] + c <= best {
+            best = dp[i - 1][j - 1] + c
+            way = 1
+          }
+        None => ()
+      }
+      dp[i][j] = best
+      bp[i][j] = way
+    }
+  }
+  let out : Array[Op] = []
+  let mut i = m
+  let mut j = n
+  while i > 0 || j > 0 {
+    match bp[i][j] {
+      1 => {
+        if a[i - 1].kind == b[j - 1].kind && a[i - 1].text == b[j - 1].text {
+          out.push(OEq(a[i - 1]))
+        } else {
+          out.push(OSub(a[i - 1], b[j - 1]))
+        }
+        i -= 1
+        j -= 1
+      }
+      2 => {
+        out.push(OIns(b[j - 1]))
+        j -= 1
+      }
+      _ => {
+        out.push(ODel(a[i - 1]))
+        i -= 1
+      }
+    }
+  }
+  out.rev_in_place()
+  out
+}
+
+///|
+/// Render one aligned pair's ops as the two row bodies (left = old side,
+/// right = new side), merging adjacent highlighted tokens into single runs.
+fn pair_row_html(ops : Array[Op]) -> (String, String) {
+  let l = StringBuilder::new()
+  let r = StringBuilder::new()
+  let lrun = StringBuilder::new()
+  let rrun = StringBuilder::new()
+  fn flushes() {
+    if !lrun.is_empty() {
+      l <+ "<b class=\"wd\">\{lrun.to_string()}</b>"
+      lrun.reset()
+    }
+    if !rrun.is_empty() {
+      r <+ "<b class=\"wa\">\{rrun.to_string()}</b>"
+      rrun.reset()
+    }
+  }
+
+  for op in ops {
+    match op {
+      OEq(t) => {
+        flushes()
+        l <+ "\{esc(t.text)}"
+        r <+ "\{esc(t.text)}"
+      }
+      OSub(a, b) => {
+        lrun <+ "\{esc(a.text)}"
+        rrun <+ "\{esc(b.text)}"
+      }
+      ODel(a) => lrun <+ "\{esc(a.text)}"
+      OIns(b) => rrun <+ "\{esc(b.text)}"
+    }
+  }
+  flushes()
+  (l.to_string(), r.to_string())
+}
+
+///|
+test "tokenizer: markers, strings, raw lines, comments, faithfulness" {
+  // ///| is a full-weight structural marker, not comment content
+  @debug.debug_inspect(tokenize_line("///|")[0].kind, content="Marker")
+  // // inside a string literal is not a comment
+  let toks = tokenize_line("let s = \"a//b\" // real comment")
+  @debug.debug_inspect(
+    toks.filter(t => t.kind is Str).map(t => t.text),
+    content=(
+      #|["\"a//b\""]
+    ),
+  )
+  inspect(toks.filter(t => t.kind is Comment).length() > 0, content="true")
+  // raw-string lines are one Str token
+  @debug.debug_inspect(tokenize_line("#|x // y")[0].kind, content="Str")
+  // faithfulness, including Unicode fallbacks
+  for
+    line in ["let 名 = 'é😀'", "  a\tb  // ok", "///| x", "\"unterminated"] {
+    assert_eq(tokenize_line(line).map(t => t.text).join(""), line)
+  }
+}
+
+///|
+test "similarity: comments help but cannot veto; unrelated stays unpaired" {
+  fn sim(a : String, b : String) -> Int {
+    sim_pm(tokenize_line(a), tokenize_line(b))
+  }
+  // similar pure-comment edits pair
+  inspect(sim("// add tax", "// add the tax") > THETA, content="true")
+  // unrelated pure comments do not
+  inspect(
+    sim("// promoted; output is not", "// totally different topic here") < THETA,
+    content="true",
+  )
+  // code identical, comment rewritten: pairs strongly
+  inspect(sim("let x = 1 // sum", "let x = 1 // total") > 900, content="true")
+  // comment as tie-breaker: identical comment scores higher
+  inspect(
+    sim("let x = 1 // a", "let x = 1 // a") >
+    sim("let x = 1 // a", "let x = 1 // b"),
+    content="true",
+  )
+  // two lines with nothing in common: same-kind substitutions alone must not
+  // reach the threshold (the flat-cost trap codex flagged)
+  inspect(
+    sim("alpha beta gamma delta eps", "one two three four five") < THETA,
+    content="true",
+  )
+  // respacing pairs easily (space weight is tiny)
+  inspect(sim("f(a,b)", "f( a , b )") > 800, content="true")
+  // the real_world.html defect pair must not align
+  inspect(
+    sim(
+      "// promoted; `output` is not (use the trait or string interpolation).", "pub extend DiffAlgorithm with Eq::{equal}",
+    ) <
+    THETA,
+    content="true",
+  )
+}
+
+///|
+test "alignment: strong pair beats crossing weak pairs; gaps ordered del-first" {
+  let olds = ["unrelated_one thing", "let total = price * count"].map(
+    tokenize_line,
+  )
+  let news = ["let total = price * count + tax", "other_stuff entirely"].map(
+    tokenize_line,
+  )
+  // monotone: the strong pair (1,0) forces line 0 old to be a gap-delete and
+  // line 1 new to be a gap-insert; no weak crossing pair may win.
+  @debug.debug_inspect(
+    align(olds, news),
+    content="[(Some(0), None), (Some(1), Some(0)), (None, Some(1))]",
+  )
+  // fully unrelated block: delete rows come before insert rows
+  let a = ["aaa bbb ccc"].map(tokenize_line)
+  let b = ["xxx yyy zzz"].map(tokenize_line)
+  @debug.debug_inspect(
+    align(a, b),
+    content="[(Some(0), None), (None, Some(0))]",
+  )
+}
+
+///|
+test "pair_ops reconstruction property" {
+  for
+    pair in [
+      ("let total = a", "let sum = a"),
+      ("f(x, 1)", "g(x, 2)"),
+      ("let 名 = 'é😀' // c", "let 名 = 'z' // d"),
+      ("", "only new"),
+    ] {
+    let (oa, ob) = pair
+    let ta = tokenize_line(oa)
+    let tb = tokenize_line(ob)
+    let left = StringBuilder::new()
+    let right = StringBuilder::new()
+    for op in pair_ops(ta, tb) {
+      match op {
+        OEq(t) => {
+          left <+ "\{t.text}"
+          right <+ "\{t.text}"
+        }
+        OSub(a, b) => {
+          left <+ "\{a.text}"
+          right <+ "\{b.text}"
+        }
+        ODel(a) => left <+ "\{a.text}"
+        OIns(b) => right <+ "\{b.text}"
+      }
+    }
+    assert_eq(left.to_string(), oa)
+    assert_eq(right.to_string(), ob)
+  }
+}

--- a/diff/diff_align_test.mbt
+++ b/diff/diff_align_test.mbt
@@ -82,6 +82,13 @@ fn push_comment_tokens(toks : Array[Tok], body : String) -> Unit {
 /// inside strings is never a comment.
 fn tokenize_line(line : String) -> Array[Tok] {
   let toks : Array[Tok] = []
+  // `///|` prefix must be handled before lexscan: under `longest` matching
+  // the comment rule would otherwise swallow `///| x` whole.
+  if line is ['/', '/', '/', '|', ..] {
+    toks.push({ kind: Marker, text: "///|" })
+    push_comment_tokens(toks, line.view(start_offset=4).to_owned())
+    return toks
+  }
   let mut rest = line.view()
   while rest is [_, ..] {
     rest = lexscan rest with longest {
@@ -188,6 +195,16 @@ fn wdist(a : ArrayView[Tok], b : ArrayView[Tok]) -> Int {
 fn sim_pm(a : ArrayView[Tok], b : ArrayView[Tok]) -> Int {
   let m = tok_mass(a) + tok_mass(b)
   if m == 0 {
+    // zero semantic mass (empty or filler-only lines): there is no evidence
+    // either way, so pair only textually identical lines.
+    if a.length() != b.length() {
+      return 0
+    }
+    for i in 0..<a.length() {
+      if a[i].kind != b[i].kind || a[i].text != b[i].text {
+        return 0
+      }
+    }
     return 1000
   }
   (m - wdist(a, b)) * 1000 / m
@@ -480,4 +497,40 @@ test "pair_ops reconstruction property" {
     assert_eq(left.to_string(), oa)
     assert_eq(right.to_string(), ob)
   }
+}
+
+///|
+test "zero-mass lines pair only when identical" {
+  fn sim(a : String, b : String) -> Int {
+    sim_pm(tokenize_line(a), tokenize_line(b))
+  }
+  inspect(sim("//", "") == 0, content="true")
+  inspect(sim("//", "//   ") == 0, content="true")
+  inspect(sim("", "") == 1000, content="true")
+  inspect(sim("//", "//") == 1000, content="true")
+}
+
+///|
+test "marker classification survives trailing content" {
+  @debug.debug_inspect(tokenize_line("///| x")[0].kind, content="Marker")
+  assert_eq(tokenize_line("///| x").map(t => t.text).join(""), "///| x")
+}
+
+///|
+test "alignment objective is positive margin, not raw similarity or pair count" {
+  // A ~ Y (one word changed, sim ~ 910): the strong pair.
+  // A ~ X and B ~ Y (four words changed each, sim ~ 640): two moderate pairs.
+  // Raw-similarity or pair-count maximization would take the two moderate
+  // diagonal pairs (~1280 total); the margin objective must take the single
+  // strong pair (margin ~ 510 beats ~ 240+240).
+  let a = "alpha beta gamma delta epsilon zeta eta theta"
+  let y = "alpha beta gamma delta epsilon zeta eta CHANGED"
+  let x = "alpha beta gamma delta ONE TWO THREE FOUR"
+  let b = "FIVE SIX SEVEN EIGHT epsilon zeta eta CHANGED"
+  let olds = [a, b].map(tokenize_line)
+  let news = [x, y].map(tokenize_line)
+  @debug.debug_inspect(
+    align(olds, news),
+    content="[(None, Some(0)), (Some(0), Some(1)), (Some(1), None)]",
+  )
 }

--- a/diff/diff_html_test.mbt
+++ b/diff/diff_html_test.mbt
@@ -46,43 +46,38 @@ fn side_by_side_html(
         Delete(old_index~, old_len~, ..) if i + 1 < edits.length() &&
           edits[i + 1] is Insert(..) => {
           guard edits[i + 1] is Insert(new_index~, new_len~, ..)
-          let removed = o
-            .view(start=old_index, end=old_index + old_len)
-            .map(l => l)
-            .join("\n")
-          let added = n
-            .view(start=new_index, end=new_index + new_len)
-            .map(l => l)
-            .join("\n")
-          let inner = @diff.Diff(old=tokenize(removed), new=tokenize(added))
-          let left = side_rows(inner, old_side=true)
-          let right = side_rows(inner, old_side=false)
-          let rows = if left.length() > right.length() {
-            left.length()
-          } else {
-            right.length()
+          let old_lines = o.view(start=old_index, end=old_index + old_len)
+          let new_lines = n.view(start=new_index, end=new_index + new_len)
+          // tokenize each line once
+          let olds = old_lines.map(l => tokenize_line(l))
+          let news = new_lines.map(l => tokenize_line(l))
+          // DP work budget (cells), plus dimension guards
+          let mut work = 0
+          for ta in olds {
+            for tb in news {
+              work += (ta.length() + 1) * (tb.length() + 1)
+            }
           }
-          for k in 0..<rows {
-            // classify by row *presence*: a blank-but-present refined row is
-            // still a deletion/addition; only an absent excess row is empty.
-            let l_present = k < left.length()
-            let r_present = k < right.length()
-            let l = if l_present { left[k] } else { "" }
-            let r = if r_present { right[k] } else { "" }
-            row(
-              l,
-              if l_present {
-                "del"
-              } else {
-                "empty"
-              },
-              r,
-              if r_present {
-                "add"
-              } else {
-                "empty"
-              },
-            )
+          if olds.length() > 64 || news.length() > 64 || work > 2_000_000 {
+            // safe fallback: plain unpaired rows, never highlighted zipping
+            for l in old_lines {
+              row(esc(l), "del", "", "empty")
+            }
+            for l in new_lines {
+              row("", "empty", esc(l), "add")
+            }
+          } else {
+            for pair in align(olds, news) {
+              match pair {
+                (Some(ii), Some(jj)) => {
+                  let (lh, rh) = pair_row_html(pair_ops(olds[ii], news[jj]))
+                  row(lh, "del", rh, "add")
+                }
+                (Some(ii), None) => row(esc(old_lines[ii]), "del", "", "empty")
+                (None, Some(jj)) => row("", "empty", esc(new_lines[jj]), "add")
+                (None, None) => ()
+              }
+            }
           }
           i += 2
         }
@@ -309,4 +304,15 @@ test "real-world HTML diff page" (t : @test.Test) {
   t.writeln("</div>")
   t.writeln("</body></html>")
   t.snapshot(filename="real_world.html")
+}
+
+///|
+test "split view work budget falls back to plain rows" {
+  // one enormous line blows the DP cell budget: the fallback must render
+  // plain unpaired rows with no intraline highlights.
+  let big = "word ".repeat(800) + "end"
+  let html = side_by_side_html(old=[big], new=["tiny replacement"])
+  inspect(html.contains("<b class="), content="false")
+  inspect(html.contains("class=\"del\""), content="true")
+  inspect(html.contains("class=\"add\""), content="true")
 }

--- a/diff/diff_html_test.mbt
+++ b/diff/diff_html_test.mbt
@@ -48,17 +48,46 @@ fn side_by_side_html(
           guard edits[i + 1] is Insert(new_index~, new_len~, ..)
           let old_lines = o.view(start=old_index, end=old_index + old_len)
           let new_lines = n.view(start=new_index, end=new_index + new_len)
-          // tokenize each line once
-          let olds = old_lines.map(l => tokenize_line(l))
-          let news = new_lines.map(l => tokenize_line(l))
-          // DP work budget (cells), plus dimension guards
-          let mut work = 0
-          for ta in olds {
-            for tb in news {
-              work += (ta.length() + 1) * (tb.length() + 1)
+          // dimension guards FIRST, then tokenize once per line with a
+          // per-line token cap (which also bounds every budget term below
+          // 1025 * 1025, so the accumulating Int cannot overflow), then an
+          // early-exit cell budget for the scoring DPs.
+          let mut fallback = old_lines.length() > 64 || new_lines.length() > 64
+          let olds : Array[Array[Tok]] = []
+          let news : Array[Array[Tok]] = []
+          if !fallback {
+            line_cap~: for l in old_lines {
+              let t = tokenize_line(l)
+              if t.length() > 1024 {
+                fallback = true
+                break line_cap~
+              }
+              olds.push(t)
             }
           }
-          if olds.length() > 64 || news.length() > 64 || work > 2_000_000 {
+          if !fallback {
+            line_cap~: for l in new_lines {
+              let t = tokenize_line(l)
+              if t.length() > 1024 {
+                fallback = true
+                break line_cap~
+              }
+              news.push(t)
+            }
+          }
+          if !fallback {
+            let mut work = 0
+            budget~: for ta in olds {
+              for tb in news {
+                work += (ta.length() + 1) * (tb.length() + 1)
+                if work > 2_000_000 {
+                  fallback = true
+                  break budget~
+                }
+              }
+            }
+          }
+          if fallback {
             // safe fallback: plain unpaired rows, never highlighted zipping
             for l in old_lines {
               row(esc(l), "del", "", "empty")
@@ -69,10 +98,15 @@ fn side_by_side_html(
           } else {
             for pair in align(olds, news) {
               match pair {
-                (Some(ii), Some(jj)) => {
-                  let (lh, rh) = pair_row_html(pair_ops(olds[ii], news[jj]))
-                  row(lh, "del", rh, "add")
-                }
+                (Some(ii), Some(jj)) =>
+                  // the full traceback matrix is only built for selected
+                  // pairs, with its own per-pair cell guard
+                  if (olds[ii].length() + 1) * (news[jj].length() + 1) > 262144 {
+                    row(esc(old_lines[ii]), "del", esc(new_lines[jj]), "add")
+                  } else {
+                    let (lh, rh) = pair_row_html(pair_ops(olds[ii], news[jj]))
+                    row(lh, "del", rh, "add")
+                  }
                 (Some(ii), None) => row(esc(old_lines[ii]), "del", "", "empty")
                 (None, Some(jj)) => row("", "empty", esc(new_lines[jj]), "add")
                 (None, None) => ()
@@ -307,12 +341,30 @@ test "real-world HTML diff page" (t : @test.Test) {
 }
 
 ///|
-test "split view work budget falls back to plain rows" {
-  // one enormous line blows the DP cell budget: the fallback must render
-  // plain unpaired rows with no intraline highlights.
-  let big = "word ".repeat(800) + "end"
-  let html = side_by_side_html(old=[big], new=["tiny replacement"])
+test "per-line token cap falls back to plain rows" {
+  // two big lines that differ by one word WOULD align and highlight, but the
+  // per-line token cap (1024) forces the plain fallback: no <b> spans.
+  let big_old = "word ".repeat(600) + "same tail here"
+  let big_new = "word ".repeat(600) + "same tail CHANGED"
+  let html = side_by_side_html(old=[big_old], new=[big_new])
   inspect(html.contains("<b class="), content="false")
   inspect(html.contains("class=\"del\""), content="true")
   inspect(html.contains("class=\"add\""), content="true")
+}
+
+///|
+test "cell budget falls back to plain rows" {
+  // 50x50 alignable lines of ~30 tokens each: every pair is under the
+  // per-line cap, but the total scoring work (~2.4M cells) exceeds the 2M
+  // budget, so the block renders plain.
+  let old_lines : Array[String] = []
+  let new_lines : Array[String] = []
+  for i in 0..<50 {
+    let base = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi line\{i}"
+    old_lines.push(base)
+    new_lines.push(base + " tail")
+  }
+  let html = side_by_side_html(old=old_lines, new=new_lines)
+  inspect(html.contains("<b class="), content="false")
+  inspect(html.contains("class=\"del\""), content="true")
 }

--- a/diff/diff_html_test.mbt
+++ b/diff/diff_html_test.mbt
@@ -1,0 +1,296 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Real-world validation of HTML diff rendering on the public `@diff` API:
+// a side-by-side (split) view with intraline word highlights, exercised on
+// genuine inputs — an actual refactor from this package's own history, prose,
+// and HTML-special/Unicode content. Shares `tokenize`/`esc`/`side_rows`/
+// `word_diff_html` with diff_word_test.mbt (same blackbox package).
+
+///|
+/// GitHub-style split view: one table row per line pair. Equal lines appear
+/// on both sides; a Delete+Insert replacement is word-diffed once and its
+/// refined rows are zipped (excess lines pair with an empty cell); pure
+/// deletions/insertions leave the other cell empty.
+fn side_by_side_html(
+  old~ : ArrayView[String],
+  new~ : ArrayView[String],
+) -> String {
+  let buf = StringBuilder::new()
+  fn row(l : String, lc : String, r : String, rc : String) {
+    buf <+
+      "<tr><td class=\"\{lc}\">\{l}</td><td class=\"\{rc}\">\{r}</td></tr>\n"
+  }
+
+  buf <+ "<table class=\"split\">\n"
+  for h in @diff.Diff(old~, new~).group() {
+    buf <+
+      "<tr><td class=\"hunk-header\" colspan=\"2\">\{esc(h.header())}</td></tr>\n"
+    let edits = h.edits()
+    let o = h.old_view()
+    let n = h.new_view()
+    let mut i = 0
+    while i < edits.length() {
+      match edits[i] {
+        Delete(old_index~, old_len~, ..) if i + 1 < edits.length() &&
+          edits[i + 1] is Insert(..) => {
+          guard edits[i + 1] is Insert(new_index~, new_len~, ..)
+          let removed = o
+            .view(start=old_index, end=old_index + old_len)
+            .map(l => l)
+            .join("\n")
+          let added = n
+            .view(start=new_index, end=new_index + new_len)
+            .map(l => l)
+            .join("\n")
+          let inner = @diff.Diff(old=tokenize(removed), new=tokenize(added))
+          let left = side_rows(inner, old_side=true)
+          let right = side_rows(inner, old_side=false)
+          let rows = if left.length() > right.length() {
+            left.length()
+          } else {
+            right.length()
+          }
+          for k in 0..<rows {
+            let l = if k < left.length() { left[k] } else { "" }
+            let r = if k < right.length() { right[k] } else { "" }
+            row(
+              l,
+              if l == "" {
+                "empty"
+              } else {
+                "del"
+              },
+              r,
+              if r == "" {
+                "empty"
+              } else {
+                "add"
+              },
+            )
+          }
+          i += 2
+        }
+        Equal(old_index~, len~, ..) => {
+          for l in o.view(start=old_index, end=old_index + len) {
+            row(esc(l), "ctx", esc(l), "ctx")
+          }
+          i += 1
+        }
+        Delete(old_index~, old_len~, ..) => {
+          for l in o.view(start=old_index, end=old_index + old_len) {
+            row(esc(l), "del", "", "empty")
+          }
+          i += 1
+        }
+        Insert(new_index~, new_len~, ..) => {
+          for l in n.view(start=new_index, end=new_index + new_len) {
+            row("", "empty", esc(l), "add")
+          }
+          i += 1
+        }
+      }
+    }
+  }
+  buf <+ "</table>\n"
+  buf.to_string()
+}
+
+///|
+fn lines_of(text : String) -> Array[String] {
+  text.split("\n").map(l => l.to_owned()).collect()
+}
+
+///|
+test "real-world HTML diff page" (t : @test.Test) {
+  // Example 0: verbatim git history — diff/extends.mbt across the API
+  // redesign (commit 25334bf6 -> current main), fetched with `git show`.
+  let extends_old =
+    #|// Copyright 2026 International Digital Economy Academy
+    #|//
+    #|// Licensed under the Apache License, Version 2.0 (the "License");
+    #|// you may not use this file except in compliance with the License.
+    #|// You may obtain a copy of the License at
+    #|//
+    #|//     http://www.apache.org/licenses/LICENSE-2.0
+    #|//
+    #|// Unless required by applicable law or agreed to in writing, software
+    #|// distributed under the License is distributed on an "AS IS" BASIS,
+    #|// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    #|// See the License for the specific language governing permissions and
+    #|// limitations under the License.
+    #|
+    #|// --- promoted: kept as regular methods ---
+    #|
+    #|// A hunk's canonical string form is its unified-diff text, so `to_string` is
+    #|// promoted; `output` is not (use the trait or string interpolation).
+    #|
+    #|///|
+    #|pub extend Hunk with Show::{to_string}
+    #|
+    #|// --- deprecated: hidden from the generated interface ---
+    #|
+    #|///|
+    #|#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+    #|#doc(hidden)
+    #|pub extend Edit with @debug.Debug::{to_repr}
+    #|
+    #|///|
+    #|#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
+    #|#doc(hidden)
+    #|pub extend Hunk with Show::{output}
+  let extends_new =
+    #|// Copyright 2026 International Digital Economy Academy
+    #|//
+    #|// Licensed under the Apache License, Version 2.0 (the "License");
+    #|// you may not use this file except in compliance with the License.
+    #|// You may obtain a copy of the License at
+    #|//
+    #|//     http://www.apache.org/licenses/LICENSE-2.0
+    #|//
+    #|// Unless required by applicable law or agreed to in writing, software
+    #|// distributed under the License is distributed on an "AS IS" BASIS,
+    #|// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    #|// See the License for the specific language governing permissions and
+    #|// limitations under the License.
+    #|
+    #|// --- promoted: kept as regular methods ---
+    #|
+    #|///|
+    #|pub extend DiffAlgorithm with Eq::{equal}
+    #|
+    #|///|
+    #|pub extend Edit with Eq::{equal}
+    #|
+    #|// --- deprecated: hidden from the generated interface ---
+    #|
+    #|///|
+    #|#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+    #|#doc(hidden)
+    #|pub extend DiffAlgorithm with @debug.Debug::{to_repr}
+    #|
+    #|///|
+    #|#deprecated("Use `!=` instead", skip_current_package=true)
+    #|#doc(hidden)
+    #|pub extend DiffAlgorithm with Eq::{not_equal}
+    #|
+    #|///|
+    #|#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+    #|#doc(hidden)
+    #|pub extend Edit with @debug.Debug::{to_repr}
+    #|
+    #|///|
+    #|#deprecated("Use `!=` instead", skip_current_package=true)
+    #|#doc(hidden)
+    #|pub extend Edit with Eq::{not_equal}
+
+  // Example 1: an actual refactor from this package's history — Hunk's
+  // Show impl becoming the callback-based `render` (#3247 -> #3941 era).
+  // Raw #| strings keep the embedded \{...} interpolations literal.
+  let show_impl =
+    #|///|
+    #|pub impl[T : Show] Show for Hunk[T] with fn output(self, logger) {
+    #|  let header = HunkHeader::new(self.edits).to_string()
+    #|  logger.write_string(header)
+    #|  logger.write_char('\n')
+    #|  for edit in self.edits {
+    #|    let (prefix, slice) = match edit {
+    #|      Insert(..) => ("+", edit.view_from(old=self.old, new=self.new))
+    #|      Delete(..) => ("-", edit.view_from(old=self.old, new=self.new))
+    #|      Equal(..) => (" ", edit.view_from(old=self.old, new=self.new))
+    #|    }
+    #|    for s in slice {
+    #|      logger.write_string("\{prefix}\{s}\n")
+    #|    }
+    #|  }
+    #|}
+  let render_fn =
+    #|///|
+    #|pub fn[T] Hunk::render(self : Hunk[T], show~ : (T) -> String) -> String {
+    #|  let buf = StringBuilder::new()
+    #|  buf <+ "\{self.header()}\n"
+    #|  for edit in self.edits {
+    #|    let (prefix, slice) = match edit {
+    #|      Insert(..) => ("+", edit.view_from(old=self.old, new=self.new))
+    #|      Delete(..) => ("-", edit.view_from(old=self.old, new=self.new))
+    #|      Equal(..) => (" ", edit.view_from(old=self.old, new=self.new))
+    #|    }
+    #|    for s in slice {
+    #|      buf <+ "\{prefix}\{show(s)}\n"
+    #|    }
+    #|  }
+    #|  buf.to_string()
+    #|}
+
+  // Example 2: prose (word diff on natural language).
+  let prose_old =
+    #|`group` splits the edit script into `Hunk[T]` values, keeping `radius` lines
+    #|of surrounding context (default 3). `radius` must be non-negative, and
+    #|`radius=0` emits hunks without surrounding context.
+  let prose_new =
+    #|`group` splits the edit script into `Hunk[T]` values, keeping `context` lines
+    #|of surrounding context (default 3). `context` must be non-negative, and
+    #|`context=0` emits hunks without surrounding context.
+
+  // Example 3: HTML-special characters and Unicode.
+  let special_old =
+    #|if a < b && *p != '&' { emit("<div>") }
+    #|let 价格 = 10 // 单价
+  let special_new =
+    #|if a <= b && *p != '&' { emit("<span>") }
+    #|let 价格 = 12 // 含税单价
+
+  t.writeln("<!DOCTYPE html>")
+  t.writeln("<html><head><meta charset=\"utf-8\"><style>")
+  t.writeln("body { font-family: monospace; }")
+  t.writeln("h3 { font-family: sans-serif; }")
+  t.writeln(".unified { white-space: pre; }")
+  t.writeln(".hunk-header { color: #00a; }")
+  t.writeln(".del { background: #ffecec; display: block; }")
+  t.writeln(".add { background: #eaffea; display: block; }")
+  t.writeln(".ctx { display: block; }")
+  t.writeln("b.wd { background: #f8b4b4; font-weight: normal; }")
+  t.writeln("b.wa { background: #97e0a0; font-weight: normal; }")
+  t.writeln("table.split { border-collapse: collapse; width: 100%; }")
+  t.writeln("table.split td { width: 50%; vertical-align: top;")
+  t.writeln(
+    "  white-space: pre-wrap; border: 1px solid #eee; display: table-cell; }",
+  )
+  t.writeln("td.empty { background: #fafafa; }")
+  t.writeln("</style></head><body>")
+  t.writeln(
+    "<h3>Verbatim git history: diff/extends.mbt across the API redesign (side-by-side)</h3>",
+  )
+  t.writeln(
+    side_by_side_html(old=lines_of(extends_old), new=lines_of(extends_new)),
+  )
+  t.writeln("<h3>Refactor from this package's history (side-by-side)</h3>")
+  t.writeln(side_by_side_html(old=lines_of(show_impl), new=lines_of(render_fn)))
+  t.writeln("<h3>Same refactor (unified, word highlights)</h3>")
+  t.writeln("<div class=\"unified\">")
+  t.writeln(word_diff_html(old=lines_of(show_impl), new=lines_of(render_fn)))
+  t.writeln("</div>")
+  t.writeln("<h3>Prose</h3>")
+  t.writeln("<div class=\"unified\">")
+  t.writeln(word_diff_html(old=lines_of(prose_old), new=lines_of(prose_new)))
+  t.writeln("</div>")
+  t.writeln("<h3>HTML-special characters and Unicode</h3>")
+  t.writeln("<div class=\"unified\">")
+  t.writeln(
+    word_diff_html(old=lines_of(special_old), new=lines_of(special_new)),
+  )
+  t.writeln("</div>")
+  t.writeln("</body></html>")
+  t.snapshot(filename="real_world.html")
+}

--- a/diff/diff_html_test.mbt
+++ b/diff/diff_html_test.mbt
@@ -63,20 +63,24 @@ fn side_by_side_html(
             right.length()
           }
           for k in 0..<rows {
-            let l = if k < left.length() { left[k] } else { "" }
-            let r = if k < right.length() { right[k] } else { "" }
+            // classify by row *presence*: a blank-but-present refined row is
+            // still a deletion/addition; only an absent excess row is empty.
+            let l_present = k < left.length()
+            let r_present = k < right.length()
+            let l = if l_present { left[k] } else { "" }
+            let r = if r_present { right[k] } else { "" }
             row(
               l,
-              if l == "" {
-                "empty"
-              } else {
+              if l_present {
                 "del"
+              } else {
+                "empty"
               },
               r,
-              if r == "" {
-                "empty"
-              } else {
+              if r_present {
                 "add"
+              } else {
+                "empty"
               },
             )
           }
@@ -105,6 +109,18 @@ fn side_by_side_html(
   }
   buf <+ "</table>\n"
   buf.to_string()
+}
+
+///|
+test "split view keeps blank-but-present rows classified" {
+  // old's blank middle line is part of the replacement: it must render as a
+  // (blank) deletion cell, while the genuinely absent excess row on the new
+  // side renders as an empty cell.
+  let html = side_by_side_html(old=["foo(1)", "", "bar(2)"], new=[
+    "foo(9)", "baz(3)",
+  ])
+  inspect(html.contains("<td class=\"del\"></td>"), content="true")
+  inspect(html.contains("<td class=\"empty\"></td>"), content="true")
 }
 
 ///|

--- a/diff/diff_word_test.mbt
+++ b/diff/diff_word_test.mbt
@@ -21,6 +21,11 @@
 /// Split a text into lexical tokens: identifiers, number literals, whitespace
 /// runs, and single punctuation characters. Whitespace is kept as tokens so
 /// that concatenating the tokens reproduces the input exactly.
+///
+/// Deliberately limited: only ASCII identifiers, digit runs, spaces/tabs and
+/// newline get grouped treatment; Unicode identifiers, other whitespace and
+/// richer number syntax fall back to single-character tokens (still faithful,
+/// just finer-grained).
 fn tokenize(text : StringView) -> Array[String] {
   let tokens = []
   let mut rest = text
@@ -264,12 +269,20 @@ impl Hash for Loose with fn hash_combine(self, hasher) {
 /// aware), then drop whitespace tokens and rejoin — so any respacing or
 /// comment rewrite compares equal.
 fn loose(line : String) -> Loose {
-  let code = lexscan line[:] with longest {
-    (re"^([^/]|/[^/])*" as code, after=_) => code.to_owned()
-    _ => line
+  let code = match line.find("//") {
+    Some(i) => line.view(end_offset=i)
+    None => line.view()
   }
   let kept = tokenize(code).filter(t => !(t is [' ' | '\t', ..]))
   { text: line, key: kept.join("\u{0}") }
+}
+
+///|
+test "loose keeps a lone trailing slash significant" {
+  // regression: the previous regex-based stripper dropped a trailing `/`,
+  // making `a/` compare equal to `a`.
+  inspect(loose("a/").key == loose("a").key, content="false")
+  inspect(loose("x = a/b // c").key == loose("x=a/b").key, content="true")
 }
 
 ///|

--- a/diff/diff_word_test.mbt
+++ b/diff/diff_word_test.mbt
@@ -238,3 +238,58 @@ test "intraline word diff as a styled HTML page" (t : @test.Test) {
   t.writeln("</body></html>")
   t.snapshot(filename="word_diff.html")
 }
+
+///|
+/// Whitespace- and comment-insensitive diffing: run the diff on a *normalized
+/// key* while keeping the original text for rendering. `Diff[T]` only needs
+/// `Hash + Eq`, so the policy plugs in as a wrapper type — the algorithm,
+/// `group`, and `render` are untouched.
+priv struct Loose {
+  text : String
+  key : String
+}
+
+///|
+impl Eq for Loose with fn equal(a, b) {
+  a.key == b.key
+}
+
+///|
+impl Hash for Loose with fn hash_combine(self, hasher) {
+  Hash::hash_combine(self.key, hasher)
+}
+
+///|
+/// Normalized key: strip a trailing `//` comment (naive: not string-literal
+/// aware), then drop whitespace tokens and rejoin — so any respacing or
+/// comment rewrite compares equal.
+fn loose(line : String) -> Loose {
+  let code = lexscan line[:] with longest {
+    (re"^([^/]|/[^/])*" as code, after=_) => code.to_owned()
+    _ => line
+  }
+  let kept = tokenize(code).filter(t => !(t is [' ' | '\t', ..]))
+  { text: line, key: kept.join("\u{0}") }
+}
+
+///|
+test "whitespace- and comment-insensitive diff via a key wrapper" {
+  let old = ["fn f(a:Int)->Int{ // sum", "  a+1", "}"].map(loose)
+  let new = ["fn f( a : Int ) -> Int {   // add one", "  a+2", "}"].map(loose)
+  let hunks = @diff.Diff(old~, new~).group(context=1)
+  // Only the real change surfaces; the respaced line and rewritten comment
+  // compare Equal. Note: Equal spans may differ textually under a normalized
+  // key — `render` displays the old side's text by convention.
+  assert_eq(hunks.length(), 1)
+  inspect(
+    hunks[0].render(show=l => l.text),
+    content=(
+      #|@@ -1,3 +1,3 @@
+      #| fn f(a:Int)->Int{ // sum
+      #|-  a+1
+      #|+  a+2
+      #| }
+      #|
+    ),
+  )
+}

--- a/diff/diff_word_test.mbt
+++ b/diff/diff_word_test.mbt
@@ -1,0 +1,240 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A word-based diff with intraline refinement, written purely against the
+// public `@diff` API — a prototype of what a third-party `diff-words`
+// package would look like. Tokenization uses `lexscan`; rendering targets
+// HTML with word-level highlights inside changed lines.
+
+///|
+/// Split a text into lexical tokens: identifiers, number literals, whitespace
+/// runs, and single punctuation characters. Whitespace is kept as tokens so
+/// that concatenating the tokens reproduces the input exactly.
+fn tokenize(text : StringView) -> Array[String] {
+  let tokens = []
+  let mut rest = text
+  while rest is [_, ..] {
+    rest = lexscan rest with longest {
+      (re"^[A-Za-z_][A-Za-z0-9_]*" as tok, after=next) => {
+        tokens.push(tok.to_owned())
+        next
+      }
+      (re"^[0-9]+" as tok, after=next) => {
+        tokens.push(tok.to_owned())
+        next
+      }
+      (re"^[ \t]+" as tok, after=next) => {
+        tokens.push(tok.to_owned())
+        next
+      }
+      // single-char rules capture a `Char`, not a `StringView`
+      (re"^\n" as tok, after=next) => {
+        tokens.push(tok.to_string())
+        next
+      }
+      (re"^." as tok, after=next) => {
+        tokens.push(tok.to_string())
+        next
+      }
+      _ => abort("unreachable: `.` matches any remaining character")
+    }
+  }
+  tokens
+}
+
+///|
+test "tokenize is faithful and lexical" {
+  let toks = tokenize("let x1 = foo(bar, 42);")
+  @debug.debug_inspect(
+    toks,
+    content=(
+      #|[
+      #|  "let",
+      #|  " ",
+      #|  "x1",
+      #|  " ",
+      #|  "=",
+      #|  " ",
+      #|  "foo",
+      #|  "(",
+      #|  "bar",
+      #|  ",",
+      #|  " ",
+      #|  "42",
+      #|  ")",
+      #|  ";",
+      #|]
+    ),
+  )
+  inspect(toks.join(""), content="let x1 = foo(bar, 42);")
+}
+
+///|
+fn esc(s : String) -> String {
+  let buf = StringBuilder::new()
+  for c in s {
+    match c {
+      '&' => buf <+ "&amp;"
+      '<' => buf <+ "&lt;"
+      '>' => buf <+ "&gt;"
+      _ => buf.write_char(c)
+    }
+  }
+  buf.to_string()
+}
+
+///|
+/// Emit the rows of one side of a refined replacement. The whole replacement
+/// block (lines joined with `\n`) is word-diffed once; the old side renders
+/// Equal + Delete tokens (deletions deep-highlighted), the new side renders
+/// Equal + Insert tokens (insertions deep-highlighted). `\n` tokens split
+/// rows, so unequal line counts fall out naturally.
+fn side_rows(inner : @diff.Diff[String], old_side~ : Bool) -> Array[String] {
+  let rows = []
+  let buf = StringBuilder::new()
+  let run = StringBuilder::new()
+  fn flush_run() {
+    if run.is_empty() {
+      return
+    }
+    let cls = if old_side { "wd" } else { "wa" }
+    buf <+ "<b class=\"\{cls}\">\{run.to_string()}</b>"
+    run.reset()
+  }
+
+  fn emit(tok : String, changed : Bool) {
+    if tok == "\n" {
+      flush_run()
+      rows.push(buf.to_string())
+      buf.reset()
+    } else if changed {
+      run <+ "\{esc(tok)}"
+    } else {
+      flush_run()
+      buf <+ "\{esc(tok)}"
+    }
+  }
+
+  let o = inner.old_view()
+  let n = inner.new_view()
+  for edit in inner.edits() {
+    match edit {
+      Equal(old_index~, len~, ..) =>
+        for t in o.view(start=old_index, end=old_index + len) {
+          emit(t, false)
+        }
+      Delete(old_index~, old_len~, ..) =>
+        if old_side {
+          for t in o.view(start=old_index, end=old_index + old_len) {
+            emit(t, true)
+          }
+        }
+      Insert(new_index~, new_len~, ..) =>
+        if !old_side {
+          for t in n.view(start=new_index, end=new_index + new_len) {
+            emit(t, true)
+          }
+        }
+    }
+  }
+  flush_run()
+  rows.push(buf.to_string())
+  rows
+}
+
+///|
+/// Render a whole diff as an HTML page with intraline word refinement:
+/// line-level rows via `group()` + `Hunk` accessors, and for each
+/// Delete+Insert replacement pair, word-level highlights via a second
+/// `@diff.Diff` over `lexscan` tokens.
+fn word_diff_html(old~ : ArrayView[String], new~ : ArrayView[String]) -> String {
+  let buf = StringBuilder::new()
+  for h in @diff.Diff(old~, new~).group(context=1) {
+    buf <+ "<span class=\"hunk-header\">\{esc(h.header())}</span>\n"
+    let edits = h.edits()
+    let o = h.old_view()
+    let n = h.new_view()
+    let mut i = 0
+    while i < edits.length() {
+      match edits[i] {
+        Delete(old_index~, old_len~, ..) if i + 1 < edits.length() &&
+          edits[i + 1] is Insert(..) => {
+          guard edits[i + 1] is Insert(new_index~, new_len~, ..)
+          let removed = o
+            .view(start=old_index, end=old_index + old_len)
+            .map(l => l)
+            .join("\n")
+          let added = n
+            .view(start=new_index, end=new_index + new_len)
+            .map(l => l)
+            .join("\n")
+          let inner = @diff.Diff(old=tokenize(removed), new=tokenize(added))
+          for r in side_rows(inner, old_side=true) {
+            buf <+ "<span class=\"del\">-\{r}</span>\n"
+          }
+          for r in side_rows(inner, old_side=false) {
+            buf <+ "<span class=\"add\">+\{r}</span>\n"
+          }
+          i += 2
+        }
+        Equal(old_index~, len~, ..) => {
+          for l in o.view(start=old_index, end=old_index + len) {
+            buf <+ "<span class=\"ctx\"> \{esc(l)}</span>\n"
+          }
+          i += 1
+        }
+        Delete(old_index~, old_len~, ..) => {
+          for l in o.view(start=old_index, end=old_index + old_len) {
+            buf <+ "<span class=\"del\">-\{esc(l)}</span>\n"
+          }
+          i += 1
+        }
+        Insert(new_index~, new_len~, ..) => {
+          for l in n.view(start=new_index, end=new_index + new_len) {
+            buf <+ "<span class=\"add\">+\{esc(l)}</span>\n"
+          }
+          i += 1
+        }
+      }
+    }
+  }
+  buf.to_string()
+}
+
+///|
+test "intraline word diff as a styled HTML page" (t : @test.Test) {
+  // File-based snapshot: open diff/__snapshot__/word_diff.html in a browser.
+  let old = [
+      "fn total(items : Array[Item]) -> Int {", "  let mut sum = 0", "  for item in items {",
+      "    sum += item.price * item.count", "  }", "  sum", "}",
+    ][:]
+  let new = [
+      "fn total(items : Array[Item], tax~ : Int) -> Int {", "  let mut sum = 0",
+      "  for item in items {", "    sum += item.price * item.count + tax", "  }",
+      "  sum", "}",
+    ][:]
+  t.writeln("<!DOCTYPE html>")
+  t.writeln("<html><head><meta charset=\"utf-8\"><style>")
+  t.writeln("body { font-family: monospace; white-space: pre; }")
+  t.writeln(".hunk-header { color: #00a; }")
+  t.writeln(".del { background: #ffecec; display: block; }")
+  t.writeln(".add { background: #eaffea; display: block; }")
+  t.writeln(".ctx { display: block; }")
+  t.writeln("b.wd { background: #f8b4b4; font-weight: normal; }")
+  t.writeln("b.wa { background: #97e0a0; font-weight: normal; }")
+  t.writeln("</style></head><body>")
+  t.writeln(word_diff_html(old~, new~))
+  t.writeln("</body></html>")
+  t.snapshot(filename="word_diff.html")
+}


### PR DESCRIPTION
## Summary

A tests-only prototype series (no public API changes) validating that rich diff rendering is buildable on the public `@diff` API — and hardening it through three codex review rounds. Everything lives in blackbox tests, which see exactly what a third-party package would.

## Layers (in commit order)

**1. Word diff + intraline refinement** (`diff_word_test.mbt`)
`lexscan` tokenizer (whitespace kept for faithfulness), line diff first, each `Delete`+`Insert` replacement pair word-diffed — the pairing window guaranteed by the `Edit` contract's Delete-before-Insert normalization. Unified HTML → browser-openable `__snapshot__/word_diff.html`.

**2. Whitespace/comment-insensitive diffing** — `Loose` wrapper whose `Eq`/`Hash` compare a normalized key while rendering shows original text: ignoring formatting is an *equality policy*, not an algorithm change; the whole pipeline (`group`, `header`, `render(show~)`) is untouched.

**3. Side-by-side HTML + real-world validation** (`diff_html_test.mbt`)
GitHub-style split view; `__snapshot__/real_world.html` with verbatim git history (`diff/extends.mbt` across the API redesign, embedded byte-exact), the `Show`-impl→`render` refactor, prose, HTML-special chars + CJK. The real data immediately exposed the ordinal-zipping defect (comment line word-diffed against `pub extend DiffAlgorithm…`).

**4. Similarity-based alignment with weighted intraline highlights** (`diff_align_test.mbt`) — the fix for that defect, per a codex-reviewed design (REQUEST-CHANGES, all 6 items incorporated):
- Kinded tokens (`Word/Str/Marker/Punct/Comment/Filler/Space`); `///|` is a full-weight marker; string literals and `#|`/`$|` raw lines are recognized *before* the comment rule; comment **content** is tokenized (never one opaque token), and comment boilerplate is zero-weight `Filler` (found by test: shared `//`+spacing otherwise lets unrelated comments pair).
- **All-integer scoring** (weights ×20, permille similarity, stored backpointers) — bit-identical across wasm/js/native, snapshot-safe.
- Alignment maximizes total positive margin `Σ(sim − 0.4)`; same-kind substitution at 1.5× weight (renames cheap; nothing-in-common lines ≈ 0.25, under threshold); deterministic delete-before-insert ordering.
- **Highlights are the chosen pair's own DP traceback** — the script scored is the script rendered; substitutions show as positionally paired runs.
- Cost control: rolling-row scoring, tokenize-once, 2M-cell work budget; over budget → *plain* unpaired rows (difflib `_plain_replace` style), never highlighted zipping.
- ~10 regressions from the codex list: tokenization (markers, `//`-in-strings, raw lines, Unicode faithfulness), comment pairing semantics incl. the tie-breaker, the exact snapshot defect pair, the flat-cost trap, crossing weak-vs-strong alignment, gap ordering, `pair_ops` reconstruction property, budget fallback with zero `<b>` spans.

The unified view (`word_diff_html`) deliberately stays on plain Myers refinement as an A/B contrast on the same page.

## What this validates about `@diff`

- `Diff[T]`'s genericity: word/token diffing needed zero new API.
- The `Edit` normalization contract does real downstream work (replacement pairing).
- `Hunk`'s structural accessors carry production-shaped renderers — including the aligner, confirming codex's earlier ruling that a core similarity primitive is unnecessary.
- Weighted alignment (comments-as-tiebreaker) follows difflib/delta's two-level lineage with a substitution-matrix-style weighting; prior art notes in the discussion thread.

## Verification
- `moon check --deny-warn --target all` — clean.
- diff tests **99/99** on wasm / wasm-gc / js / native; full suite green.
- Snapshots deterministic across all four backends (integer-only scoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
