### PR TITLE
refactor: use compound assignment `+=` for self-additions

### DIFF
--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -452,7 +452,7 @@ fn parse_command_impl(
       ) {
       positional_values.push(arg)
       positional_arg_found = true
-      i = i + 1
+      i += 1
       continue
     }
     if arg.has_prefix("--") {
@@ -506,7 +506,7 @@ fn parse_command_impl(
                   short_index,
                 )
               if can_take_next {
-                i = i + 1
+                i += 1
                 assign_value(matches, spec, argv[i], Argv)
               } else {
                 raise ArgParseError::MissingValue("--\{name}")
@@ -529,7 +529,7 @@ fn parse_command_impl(
             }
           }
       }
-      i = i + 1
+      i += 1
       continue
     }
     if arg.has_prefix("-") && arg != "-" {
@@ -597,7 +597,7 @@ fn parse_command_impl(
           }
         }
       }
-      i = i + 1 + (if consumed_next { 1 } else { 0 })
+      i += 1 + (if consumed_next { 1 } else { 0 })
       continue
     }
     if help_subcommand_enabled(cmd) && arg == "help" {
@@ -623,7 +623,7 @@ fn parse_command_impl(
 
     positional_values.push(arg)
     positional_arg_found = true
-    i = i + 1
+    i += 1
   }
   if default_subcommand is Some(sub) {
     return dispatch_subcommand(sub, [])

--- a/argparse/parser_values.mbt
+++ b/argparse/parser_values.mbt
@@ -40,7 +40,7 @@ fn assign_positionals(
       let mut taken = 0
       while taken < take {
         add_value(matches, arg.name, values[cursor + taken], arg, Argv)
-        taken = taken + 1
+        taken += 1
       }
       continue cursor + taken
     }

--- a/bench/bench_test.mbt
+++ b/bench/bench_test.mbt
@@ -17,7 +17,7 @@ test "bench single_bench minimal" {
   let summary = @bench.single_bench(
     () => {
       let mut x = 0
-      x = x + 1
+      x += 1
       ignore(x)
     },
     name="noop",

--- a/bench/monotonic_clock_wasm.mbt
+++ b/bench/monotonic_clock_wasm.mbt
@@ -57,7 +57,7 @@ pub fn monotonic_clock_start() -> Timestamp = "__moonbit_time_unstable" "instant
 ///   let start = @bench.monotonic_clock_start()
 ///   let mut x = 0
 ///   for _ in 0..<100 {
-///     x = x + 1
+///     x += 1
 ///   }
 ///   ignore(x)
 ///   let elapsed_us = @bench.monotonic_clock_end(start)

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -685,7 +685,7 @@ fn BigInt::grade_school_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
       borrow = borrow >> RADIX_BIT_LEN
       carry = carry >> RADIX_BIT_LEN
     }
-    borrow = borrow + a[i + b_len].reinterpret_as_int64()
+    borrow += a[i + b_len].reinterpret_as_int64()
     borrow -= carry.reinterpret_as_int64()
     a[i + b_len] = (borrow & RADIX_MASK.reinterpret_as_int64()).reinterpret_as_uint64()
     borrow = borrow >> RADIX_BIT_LEN

--- a/buffer/sleb128.mbt
+++ b/buffer/sleb128.mbt
@@ -35,11 +35,11 @@ pub impl Leb128 for Int with fn output(self, buffer) {
     }
     if need_more {
       data.unsafe_set(len, (byte | 0x80).to_byte())
-      len = len + 1
+      len += 1
       continue next_value
     } else {
       data.unsafe_set(len, byte.to_byte())
-      len = len + 1
+      len += 1
       break
     }
   }
@@ -64,11 +64,11 @@ pub impl Leb128 for Int64 with fn output(self, buffer) {
     }
     if need_more {
       data.unsafe_set(len, (byte | 0x80).to_byte())
-      len = len + 1
+      len += 1
       continue next_value
     } else {
       data.unsafe_set(len, byte.to_byte())
-      len = len + 1
+      len += 1
       break
     }
   }

--- a/buffer/uleb128.mbt
+++ b/buffer/uleb128.mbt
@@ -23,12 +23,12 @@ pub impl Leb128 for UInt with fn output(self, buffer) {
     if value < 128U {
       // Single byte: no continuation bit (0xxxxxxx)
       data.unsafe_set(len, value.to_byte())
-      len = len + 1
+      len += 1
       break
     } else {
       // Multiple bytes: set continuation bit (1xxxxxxx) and continue
       data.unsafe_set(len, ((value & 127U) | 128U).to_byte())
-      len = len + 1
+      len += 1
       continue value >> 7
     }
   }
@@ -46,12 +46,12 @@ pub impl Leb128 for UInt64 with fn output(self, buffer) {
     if value < 128UL {
       // Single byte: no continuation bit (0xxxxxxx)
       data.unsafe_set(len, value.to_byte())
-      len = len + 1
+      len += 1
       break
     } else {
       // Multiple bytes: set continuation bit (1xxxxxxx) and continue
       data.unsafe_set(len, ((value & 127UL) | 128UL).to_byte())
-      len = len + 1
+      len += 1
       continue value >> 7
     }
   }

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -438,7 +438,7 @@ pub fn[T] Array::append(self : Array[T], other : ArrayView[T]) -> Unit {
 /// test {
 ///   let arr = [1, 2, 3]
 ///   let mut sum = 0
-///   arr.each(x => sum = sum + x)
+///   arr.each(x => sum += x)
 ///   inspect(sum, content="6")
 /// }
 /// ```
@@ -492,7 +492,7 @@ pub fn[T] Array::rev_each(
 /// test {
 ///   let v = [3, 4, 5]
 ///   let mut sum = 0
-///   v.rev_eachi((i, x) => sum = sum + x + i)
+///   v.rev_eachi((i, x) => sum += x + i)
 ///   @test.assert_eq(sum, 15)
 /// }
 /// ```
@@ -515,7 +515,7 @@ pub fn[T] Array::rev_eachi(
 /// test {
 ///   let v = [3, 4, 5]
 ///   let mut sum = 0
-///   v.eachi((i, x) => sum = sum + x + i)
+///   v.eachi((i, x) => sum += x + i)
 ///   inspect(sum, content="15")
 /// }
 /// ```
@@ -1772,7 +1772,7 @@ pub fn[T] Array::split(
 /// test {
 ///   let arr = [1, 2, 3]
 ///   let mut sum = 0
-///   arr.iter().each(x => sum = sum + x)
+///   arr.iter().each(x => sum += x)
 ///   inspect(sum, content="6")
 /// }
 /// ```
@@ -1824,7 +1824,7 @@ pub fn[T] Array::rev_iter(self : Array[T]) -> Iter[T] {
 /// test {
 ///   let arr = [10, 20, 30]
 ///   let mut sum = 0
-///   arr.iter2().each((i, x) => sum = sum + i + x)
+///   arr.iter2().each((i, x) => sum += i + x)
 ///   inspect(sum, content="63") // (0 + 10) + (1 + 20) + (2 + 30) = 63
 /// }
 /// ```

--- a/builtin/array_locals_bench_test.mbt
+++ b/builtin/array_locals_bench_test.mbt
@@ -59,7 +59,7 @@ test "bench FixedArray::each n=100000" (it : @bench.T) {
   let data = make_array_locals_bench_fixedarray()
   it.bench(fn() {
     let mut sum = 0
-    data.each(x => sum = sum + x)
+    data.each(x => sum += x)
     it.keep(sum)
   })
 }
@@ -69,7 +69,7 @@ test "bench FixedArray::eachi n=100000" (it : @bench.T) {
   let data = make_array_locals_bench_fixedarray()
   it.bench(fn() {
     let mut sum = 0
-    data.eachi((i, x) => sum = sum + i + x)
+    data.eachi((i, x) => sum += i + x)
     it.keep(sum)
   })
 }
@@ -79,7 +79,7 @@ test "bench FixedArray::rev_each n=100000" (it : @bench.T) {
   let data = make_array_locals_bench_fixedarray()
   it.bench(fn() {
     let mut sum = 0
-    data.rev_each(x => sum = sum + x)
+    data.rev_each(x => sum += x)
     it.keep(sum)
   })
 }
@@ -89,7 +89,7 @@ test "bench FixedArray::rev_eachi n=100000" (it : @bench.T) {
   let data = make_array_locals_bench_fixedarray()
   it.bench(fn() {
     let mut sum = 0
-    data.rev_eachi((i, x) => sum = sum + i + x)
+    data.rev_eachi((i, x) => sum += i + x)
     it.keep(sum)
   })
 }
@@ -148,7 +148,7 @@ test "bench ArrayView::each n=100000" (it : @bench.T) {
   let view = data[:]
   it.bench(fn() {
     let mut sum = 0
-    view.each(x => sum = sum + x)
+    view.each(x => sum += x)
     it.keep(sum)
   })
 }
@@ -159,7 +159,7 @@ test "bench ArrayView::eachi n=100000" (it : @bench.T) {
   let view = data[:]
   it.bench(fn() {
     let mut sum = 0
-    view.eachi((i, x) => sum = sum + i + x)
+    view.eachi((i, x) => sum += i + x)
     it.keep(sum)
   })
 }
@@ -170,7 +170,7 @@ test "bench ArrayView::rev_each n=100000" (it : @bench.T) {
   let view = data[:]
   it.bench(fn() {
     let mut sum = 0
-    view.rev_each(x => sum = sum + x)
+    view.rev_each(x => sum += x)
     it.keep(sum)
   })
 }
@@ -181,7 +181,7 @@ test "bench ArrayView::rev_eachi n=100000" (it : @bench.T) {
   let view = data[:]
   it.bench(fn() {
     let mut sum = 0
-    view.rev_eachi((i, x) => sum = sum + i + x)
+    view.rev_eachi((i, x) => sum += i + x)
     it.keep(sum)
   })
 }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -221,7 +221,7 @@ test "array_sort_by_pred_skip_duplicates" {
 test "array_each" {
   let arr = [1, 2, 3]
   let mut sum = 0
-  arr.each(x => sum = sum + x)
+  arr.each(x => sum += x)
   @test.assert_eq(sum, 6)
 }
 
@@ -229,7 +229,7 @@ test "array_each" {
 test "array_rev_each" {
   let arr = [1, 2, 3]
   let mut sum = 0
-  arr.rev_each(x => sum = sum + x)
+  arr.rev_each(x => sum += x)
   inspect(sum, content="6")
 }
 
@@ -237,7 +237,7 @@ test "array_rev_each" {
 test "array_eachi" {
   let arr = [1, 2, 3]
   let mut sum = 0
-  arr.eachi((i, x) => sum = sum + i + x)
+  arr.eachi((i, x) => sum += i + x)
   @test.assert_eq(sum, 9)
 }
 

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -705,7 +705,7 @@ pub fn[T] ArrayView::windows(
 ///   let arr = [1, 2, 3]
 ///   let view = arr[1:]
 ///   let mut sum = 0
-///   view.iter().each(x => sum = sum + x)
+///   view.iter().each(x => sum += x)
 ///   inspect(sum, content="5")
 /// }
 /// ```
@@ -765,8 +765,8 @@ pub fn[X] ArrayView::rev_iter(self : ArrayView[X]) -> Iter[X] {
 ///   view
 ///   .iter2()
 ///   .each((i, x) => {
-///     sum = sum + x
-///     sum_keys = sum_keys + i
+///     sum += x
+///     sum_keys += i
 ///   })
 ///   inspect(sum, content="5")
 ///   inspect(sum_keys, content="1")
@@ -802,7 +802,7 @@ pub fn[X] ArrayView::iter2(self : ArrayView[X]) -> Iter2[Int, X] {
 /// test {
 ///   let arr = [1, 2, 3][:]
 ///   let mut sum = 0
-///   arr.each(x => sum = sum + x)
+///   arr.each(x => sum += x)
 ///   inspect(sum, content="6")
 /// }
 /// ```
@@ -825,7 +825,7 @@ pub fn[T] ArrayView::each(
 /// test {
 ///   let v = [3, 4, 5][:]
 ///   let mut sum = 0
-///   v.eachi((i, x) => sum = sum + x + i)
+///   v.eachi((i, x) => sum += x + i)
 ///   inspect(sum, content="15")
 /// }
 /// ```

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -404,8 +404,8 @@ test "iter2" {
   view
   .iter2()
   .each((i, x) => {
-    sum = sum + x
-    sum_keys = sum_keys + i
+    sum += x
+    sum_keys += i
   })
   inspect(sum, content="5")
   inspect(sum_keys, content="1")

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -299,7 +299,7 @@ test "each" {
   let v = [1, 2, 3, 4, 5]
   let s = v[2:5]
   let mut sum = 0
-  s.each(x => sum = sum + x)
+  s.each(x => sum += x)
   inspect(sum, content="12")
 }
 
@@ -307,7 +307,7 @@ test "each" {
 test "eachi" {
   let v = [3, 4, 5][:]
   let mut sum = 0
-  v.eachi((i, x) => sum = sum + x + i)
+  v.eachi((i, x) => sum += x + i)
   inspect(sum, content="15")
 }
 

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -680,7 +680,7 @@ pub fn BytesView::to_array(self : BytesView) -> Array[Byte] {
 /// test {
 ///   let bytes = Bytes::from_array([b'h', b'i'])
 ///   let mut sum = 0
-///   bytes.iter().each(b => sum = sum + b.to_int())
+///   bytes.iter().each(b => sum += b.to_int())
 ///   inspect(sum, content="209") // ASCII values: 'h'(104) + 'i'(105) = 209
 /// }
 /// ```

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -790,14 +790,14 @@ fn BytesView::bytesview_lexical_compare_impl(
         .unsafe_get(self_start + i + lane)
         .compare(other_bytes.unsafe_get(other_start + i + lane))
     }
-    i = i + 16
+    i += 16
   }
   while i < min_len {
     let cmp = self.unsafe_get(i).compare(other.unsafe_get(i))
     if cmp != 0 {
       return cmp
     }
-    i = i + 1
+    i += 1
   }
   self_len.compare(other_len)
 }

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -272,7 +272,7 @@ pub fn BytesView::view(
 /// test {
 ///   let bv = b"\x00\x01\x02\x03\x04\x05"[:]
 ///   let mut sum = 0
-///   bv.iter().each(x => sum = sum + x.to_int())
+///   bv.iter().each(x => sum += x.to_int())
 ///   inspect(sum, content="15")
 /// }
 /// ```

--- a/builtin/double_ryu_nonjs.mbt
+++ b/builtin/double_ryu_nonjs.mbt
@@ -225,7 +225,7 @@ fn double_computePow5(i : Int) -> Pow5Pair {
   let sum : UInt64 = high0 + low1
   let mut high1 = high1
   if sum < high0 {
-    high1 = high1 + 1UL
+    high1 += 1UL
   }
   let delta : Int = pow5bits(i) - pow5bits(base2)
   let a : UInt64 = shiftright128(low0, sum, delta) +
@@ -251,7 +251,7 @@ fn double_computeInvPow5(i : Int) -> Pow5Pair {
   let sum = high0 + low1
   let mut high1 = high1
   if sum < high0 {
-    high1 = high1 + 1UL
+    high1 += 1UL
   }
   let delta : Int = pow5bits(base2) - pow5bits(i)
   let a : UInt64 = shiftright128(low0, sum, delta) +
@@ -460,7 +460,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
       vr = vrDiv10
       vp = vpDiv10
       vm = vmDiv10
-      removed = removed + 1
+      removed += 1
     }
     if vmIsTrailingZeros {
       while true {
@@ -477,7 +477,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
         vr = vrDiv10
         vp = vpDiv10
         vm = vmDiv10
-        removed = removed + 1
+        removed += 1
       }
     }
     if vrIsTrailingZeros && lastRemovedDigit == 5 && vr % 2 == 0 {
@@ -499,7 +499,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
       vr = vrDiv100
       vp = vpDiv100
       vm = vmDiv100
-      removed = removed + 2
+      removed += 2
     }
     // Loop iterations below (approximately), without optimization above:
     // 0: 0.03%, 1: 13.8%, 2: 70.6%, 3: 14.0%, 4: 1.40%, 5: 0.14%, 6+: 0.02%
@@ -517,7 +517,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
       vr = vrDiv10
       vp = vpDiv10
       vm = vmDiv10
-      removed = removed + 1
+      removed += 1
     }
     output = vr + (vr == vm || roundUp).to_uint64()
   }
@@ -700,7 +700,7 @@ test "double/ryu.mbt:205" {
   let sum = high0 + low1
   let mut high1 = high1
   if sum < high0 {
-    high1 = high1 + 1
+    high1 += 1
   }
   inspect(high1, content="222222222")
 }
@@ -715,7 +715,7 @@ test "double/ryu.mbt:230" {
   let sum = high0 + low1
   let mut high1 = high1
   if sum < high0 {
-    high1 = high1 + 1UL
+    high1 += 1UL
   }
   assert_true(high1 == 222222222UL)
 }

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -284,7 +284,7 @@ test "each" {
     if elem != i + 1 {
       failed = true
     }
-    i = i + 1
+    i += 1
   }
   {
     i = 0
@@ -339,7 +339,7 @@ test "eachi" {
     if index != i || elem != i + 1 {
       failed = true
     }
-    i = i + 1
+    i += 1
   }
   {
     i = 0
@@ -452,7 +452,7 @@ test "rev_eachi" {
       failed = true
     }
     i = i - 1
-    j = j + 1
+    j += 1
   }
   {
     i = 1
@@ -1387,7 +1387,7 @@ test "iter" {
   iter.each(x => {
     exb.write_string(x.to_string())
     exb.write_char('\n')
-    i = i + 1
+    i += 1
   })
   assert_true(i == arr.length())
   inspect(

--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -114,7 +114,7 @@ test "fixed array iter with early termination" {
 test "FixedArray::iter2 with empty array" {
   let arr : FixedArray[Int] = []
   let mut count = 0
-  arr.iter2().each((_, _) => count = count + 1)
+  arr.iter2().each((_, _) => count += 1)
   inspect(count, content="0")
 }
 

--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -102,7 +102,7 @@ test "fixed array iter with early termination" {
   let mut count = 0
   let iter = arr.iter()
   for x in iter {
-    count = count + 1
+    count += 1
     if x == 2 {
       break
     }

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -522,7 +522,7 @@ pub impl Hash for String with fn hash_combine(self, hasher) {
 pub impl Hash for String with fn hash(self : String) -> Int {
   let mut acc = seed.reinterpret_as_uint() + GPRIME5
   for i in 0..<self.length() {
-    acc = acc + 4U
+    acc += 4U
     let v = self.unsafe_get(i).to_int().reinterpret_as_uint()
     acc = consume4_acc(acc, v)
   }
@@ -547,7 +547,7 @@ pub impl Hash for StringView with fn hash(self : StringView) -> Int {
   let str = self.str()
   let mut acc = seed.reinterpret_as_uint() + GPRIME5
   for i in self.start()..<self.end() {
-    acc = acc + 4U
+    acc += 4U
     let v = str.unsafe_get(i).to_int().reinterpret_as_uint()
     acc = consume4_acc(acc, v)
   }

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -29,7 +29,8 @@
 ///   let x = 42
 ///   ignore(x) // Explicitly ignore the value
 ///   let mut sum = 0
-///   ignore([1, 2, 3].iter().each(x => sum = sum + x)) // Ignore the Unit return value of each()
+///   ignore([1, 2, 3].iter().each(x => sum += x)) // Ignore the Unit return value of each()
+///   inspect(sum, content="6")
 /// }
 /// ```
 pub fn[T] ignore(t : T) -> Unit = "%ignore"

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -140,7 +140,7 @@ test "Map:: iter2" {
   let map = { "a": 1, "b": 2, "c": 3 }
   let v = map.iter2()
   let mut res = ""
-  v.each((k, v) => res = res + k + v.to_string())
+  v.each((k, v) => res += k + v.to_string())
   inspect(res, content="a1b2c3")
 }
 

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -130,7 +130,7 @@ test "Map::iter" {
   let v = map.iter()
   let mut res = ""
   while v.next() is Some((k, v)) {
-    res = res + k + v.to_string()
+    res += k + v.to_string()
   }
   inspect(res, content="a1b2c3")
 }

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -187,7 +187,7 @@ pub fn[T] ReadOnlyArray::last(self : ReadOnlyArray[T]) -> T? {
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3]
 ///   let mut sum = 0
-///   arr.iter().each(fn(x) { sum = sum + x })
+///   arr.iter().each(fn(x) { sum += x })
 ///   inspect(sum, content="6")
 /// }
 /// ```
@@ -204,7 +204,7 @@ pub fn[T] ReadOnlyArray::iter(self : ReadOnlyArray[T]) -> Iter[T] {
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [10, 20, 30]
 ///   let mut sum = 0
-///   arr.iter2().each(fn(i, x) { sum = sum + i + x })
+///   arr.iter2().each(fn(i, x) { sum += i + x })
 ///   inspect(sum, content="63") // (0+10) + (1+20) + (2+30) = 63
 /// }
 /// ```

--- a/builtin/traits_test.mbt
+++ b/builtin/traits_test.mbt
@@ -63,7 +63,7 @@ impl Eq for Wrapper with fn equal(self, other) {
 
 ///|
 impl Logger for TestLogger with fn write_view(self, value) {
-  self.output = self.output + value.to_owned()
+  self.output += value.to_owned()
 }
 
 ///|

--- a/builtin/view_bench_test.mbt
+++ b/builtin/view_bench_test.mbt
@@ -37,7 +37,7 @@ test "bench ArrayView::at Int n=100000" (it : @bench.T) {
   it.bench(fn() {
     let mut sum = 0
     for i = 0; i < view_bench_size; i = i + 1 {
-      sum = sum + view[i]
+      sum += view[i]
     }
     it.keep(sum)
   })
@@ -51,7 +51,7 @@ test "bench ArrayView::get Int n=100000" (it : @bench.T) {
     let mut sum = 0
     for i = 0; i < view_bench_size; i = i + 1 {
       if view.get(i) is Some(x) {
-        sum = sum + x
+        sum += x
       }
     }
     it.keep(sum)
@@ -65,7 +65,7 @@ test "bench ArrayView::unsafe_get Int n=100000" (it : @bench.T) {
   it.bench(fn() {
     let mut sum = 0
     for i = 0; i < view_bench_size; i = i + 1 {
-      sum = sum + view.unsafe_get(i)
+      sum += view.unsafe_get(i)
     }
     it.keep(sum)
   })
@@ -110,7 +110,7 @@ test "bench MutArrayView::at Int n=100000" (it : @bench.T) {
   it.bench(fn() {
     let mut sum = 0
     for i = 0; i < view_bench_size; i = i + 1 {
-      sum = sum + view[i]
+      sum += view[i]
     }
     it.keep(sum)
   })
@@ -123,7 +123,7 @@ test "bench MutArrayView::unsafe_get Int n=100000" (it : @bench.T) {
   it.bench(fn() {
     let mut sum = 0
     for i = 0; i < view_bench_size; i = i + 1 {
-      sum = sum + view.unsafe_get(i)
+      sum += view.unsafe_get(i)
     }
     it.keep(sum)
   })

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -286,8 +286,8 @@ test "iter break early" {
   .iter()
   .take(2)
   .each(x => {
-    count = count + 1
-    total = total + x.to_int()
+    count += 1
+    total += x.to_int()
   })
   inspect(count, content="2")
   inspect(total, content="3") // \x01 + \x02 = 3

--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -275,7 +275,7 @@ fn bracket_seq_lines(
         let lines = indent_spaces(indent_by, { size: 0, lines: item }).lines
         if lines.length() > 0 {
           let last_i = lines.length() - 1
-          lines[last_i] = lines[last_i] + ","
+          lines[last_i] += ","
         }
         [open, ..lines, close]
       } else {

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -968,7 +968,7 @@ pub impl[A : Eq] Eq for Deque[A] with fn equal(self, other) {
 /// test {
 ///   let dv = @deque.from_array([1, 2, 3, 4, 5])
 ///   let mut sum = 0
-///   dv.each(x => sum = sum + x)
+///   dv.each(x => sum += x)
 ///   inspect(sum, content="15")
 /// }
 /// ```
@@ -987,7 +987,7 @@ pub fn[A] Deque::each(self : Deque[A], f : (A) -> Unit) -> Unit {
 /// test {
 ///   let dv = @deque.from_array([1, 2, 3, 4, 5])
 ///   let mut idx_sum = 0
-///   dv.eachi((i, _x) => idx_sum = idx_sum + i)
+///   dv.eachi((i, _x) => idx_sum += i)
 ///   inspect(idx_sum, content="10")
 /// }
 /// ```
@@ -1006,7 +1006,7 @@ pub fn[A] Deque::eachi(self : Deque[A], f : (Int, A) -> Unit) -> Unit {
 /// test {
 ///   let dv = @deque.from_array([1, 2, 3, 4, 5])
 ///   let mut sum = 0
-///   dv.rev_each(x => sum = sum + x)
+///   dv.rev_each(x => sum += x)
 ///   inspect(sum, content="15")
 /// }
 /// ```
@@ -1025,7 +1025,7 @@ pub fn[A] Deque::rev_each(self : Deque[A], f : (A) -> Unit) -> Unit {
 /// test {
 ///   let dv = @deque.from_array([1, 2, 3, 4, 5])
 ///   let mut idx_sum = 0
-///   dv.rev_eachi((i, _x) => idx_sum = idx_sum + i)
+///   dv.rev_eachi((i, _x) => idx_sum += i)
 ///   inspect(idx_sum, content="10")
 /// }
 /// ```
@@ -1532,7 +1532,7 @@ pub fn[A] Deque::retain(self : Deque[A], f : (A) -> Bool) -> Unit {
 /// test {
 ///   let dq = @deque.from_array([1, 2, 3, 4, 5])
 ///   let mut sum = 0
-///   dq.iter().each(x => sum = sum + x)
+///   dq.iter().each(x => sum += x)
 ///   inspect(sum, content="15")
 /// }
 /// ```
@@ -1571,7 +1571,7 @@ pub fn[A] Deque::iter(self : Deque[A]) -> Iter[A] {
 ///   let mut sum = 0
 ///   let it = dq.iter2()
 ///   while it.next() is Some((i, x)) {
-///     sum = sum + i * x
+///     sum += i * x
 ///   }
 ///   inspect(sum, content="80") // 0*10 + 1*20 + 2*30 = 80
 /// }
@@ -1645,7 +1645,7 @@ pub fn[A] Deque::rev_iter(self : Deque[A]) -> Iter[A] {
 ///   let mut s = ""
 ///   let it = dq.rev_iter2()
 ///   while it.next() is Some((i, x)) {
-///     s = s + "\{i}:\{x} "
+///     s += "\{i}:\{x} "
 ///   }
 ///   inspect(s, content="0:3 1:2 2:1 ")
 /// }

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -103,7 +103,7 @@ test "iter" {
   .each(x => {
     buf.write_string(x.to_string())
     buf.write_char('\n')
-    i = i + 1
+    i += 1
   })
   @test.assert_eq(i, dv.length())
   inspect(
@@ -186,7 +186,7 @@ test "rev_eachi" {
       failed = true
     }
     i = i - 1
-    j = j + 1
+    j += 1
   })
   assert_false(failed)
 }
@@ -199,7 +199,7 @@ test "iteri" {
     if index != i || elem != i + 1 {
       failed = true
     }
-    i = i + 1
+    i += 1
   })
   assert_false(failed)
 }
@@ -212,7 +212,7 @@ test "each" {
     if elem != i + 1 {
       failed = true
     }
-    i = i + 1
+    i += 1
   })
   assert_false(failed)
 }

--- a/diff/diff_wbtest.mbt
+++ b/diff/diff_wbtest.mbt
@@ -431,7 +431,7 @@ test "large array performance" {
   }
   let match_count = @ref.Ref(0)
   for _old_idx, _new_idx in iter_matches(old~, new~, cutoff=None) {
-    match_count.val = match_count.val + 1
+    match_count.val += 1
   }
 
   // Should find approximately half matches

--- a/diff/unique.mbt
+++ b/diff/unique.mbt
@@ -36,7 +36,7 @@ fn[T : Eq + Hash] find_unique(
   )
   for i = 0; i < old.length(); i = i + 1 {
     if match_lines.get(old[i]) is Some(count_record) {
-      count_record.old_count = count_record.old_count + 1
+      count_record.old_count += 1
     } else {
       match_lines[old[i]] = {
         old_idx: i,
@@ -48,7 +48,7 @@ fn[T : Eq + Hash] find_unique(
   }
   for i = 0; i < new.length(); i = i + 1 {
     if match_lines.get(new[i]) is Some(count_record) {
-      count_record.new_count = count_record.new_count + 1
+      count_record.new_count += 1
       if count_record.new_idx == -1 {
         count_record.new_idx = i
       }

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -83,13 +83,13 @@ fn utf16_needs_scalar_le_v128(bytes : BytesView) -> Bool {
     if utf16_v128_has_surrogate(@v128.v128_load(src_bytes, index)) {
       return true
     }
-    index = index + 16
+    index += 16
   }
   while index < end {
     if is_utf16_surrogate(src.unsafe_read_uint16_le(index)) {
       return true
     }
-    index = index + 2
+    index += 2
   }
   false
 }
@@ -113,13 +113,13 @@ fn utf16_needs_scalar_be_v128(bytes : BytesView) -> Bool {
     if utf16_v128_has_surrogate(swapped) {
       return true
     }
-    index = index + 16
+    index += 16
   }
   while index < end {
     if is_utf16_surrogate(src.unsafe_read_uint16_be(index)) {
       return true
     }
-    index = index + 2
+    index += 2
   }
   false
 }
@@ -137,15 +137,15 @@ fn utf16_decode_be_no_surrogate_v128(bytes : BytesView) -> String {
   while index + 16 <= end {
     let swapped = utf16_swap_u16x8(@v128.v128_load(src_bytes, index))
     @v128.v128_store(string_bytes, written, swapped)
-    index = index + 16
-    written = written + 16
+    index += 16
+    written += 16
   }
   while index < end {
     let code_unit = src.unsafe_read_uint16_be(index)
     string_bytes[written] = (code_unit & 0xFF).to_byte()
     string_bytes[written + 1] = (code_unit >> 8).to_byte()
-    index = index + 2
-    written = written + 2
+    index += 2
+    written += 2
   }
   string_bytes.unsafe_reinterpret_as_bytes().to_unchecked_string()
 }

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -469,7 +469,7 @@ pub fn[K, V] HashMap::retain(self : HashMap[K, V], f : (K, V) -> Bool) -> Unit {
   let mut j = 0
   for i = 0; j < size; i = i + 1 {
     while self.entries[i] is Some(entry) {
-      j = j + 1
+      j += 1
       if f(entry.key, entry.value) {
         break
       } else {

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -493,7 +493,7 @@ pub fn[K] HashSet::retain(self : HashSet[K], f : (K) -> Bool) -> Unit {
   let mut j = 0
   for i = 0; j < size; i = i + 1 {
     while self.entries[i] is Some(entry) {
-      j = j + 1
+      j += 1
       if f(entry.key) {
         break
       } else {

--- a/immut/array/array_test.mbt
+++ b/immut/array/array_test.mbt
@@ -138,7 +138,7 @@ test "iteri" {
   v.eachi((_i, _e) => abort("never reach"))
   let v = @array.from_array([1, 2, 3, 4, 5])
   let mut s = 0
-  v.eachi((i, e) => s = s + i * e)
+  v.eachi((i, e) => s += i * e)
   inspect(s, content="40")
   let vec = []
   v.eachi((i, _e) => vec.push(i))

--- a/immut/array/array_wbtest.mbt
+++ b/immut/array/array_wbtest.mbt
@@ -34,9 +34,9 @@ test "mix" {
     v2
   }
   let mut ct = 0
-  v.each(e => ct = ct + e)
+  v.each(e => ct += e)
   inspect(ct, content="4950")
-  v2.each(e => ct = ct + e)
+  v2.each(e => ct += e)
   inspect(ct, content="14850")
   let v2 = v2.map(e => e * 2)
   let ct1 = v2.fold((a, b) => a + b, init=0)

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -362,7 +362,7 @@ test "hash" {
 test "each on empty map" {
   let empty = @hashmap.new()
   let mut sum = 0
-  empty.each((k : Int, v : Int) => sum = sum + k + v)
+  empty.each((k : Int, v : Int) => sum += k + v)
   inspect(sum, content="0")
 }
 
@@ -1015,19 +1015,19 @@ test "HAMT::difference collision becomes empty" {
 test "HAMT::each" {
   let empty = @hashmap.new()
   let mut sum = 0
-  empty.each((k : Int, v : Int) => sum = sum + k + v)
+  empty.each((k : Int, v : Int) => sum += k + v)
   inspect(sum, content="0")
   let leaf = @hashmap.singleton(1, 10)
   let mut sum_leaf = 0
-  leaf.each((k, v) => sum_leaf = sum_leaf + k + v)
+  leaf.each((k, v) => sum_leaf += k + v)
   inspect(sum_leaf, content="11")
   let collision = @hashmap.HashMap([(MyString("a"), 1), (MyString("b"), 2)])
   let mut sum_collision = 0
-  collision.each((_k : MyString, v : Int) => sum_collision = sum_collision + v)
+  collision.each((_k : MyString, v : Int) => sum_collision += v)
   inspect(sum_collision, content="3")
   let branch = @hashmap.HashMap([(1, 1), (2, 2), (3, 3), (4, 4)])
   let mut sum_branch = 0
-  branch.each((_k, v) => sum_branch = sum_branch + v)
+  branch.each((_k, v) => sum_branch += v)
   inspect(sum_branch, content="10")
 }
 

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -196,7 +196,7 @@ test "from_iter matches forward add with duplicates" {
 test "each on empty set" {
   let s = @hashset.new()
   let mut count = 0
-  s.each((_x : Int) => count = count + 1)
+  s.each((_x : Int) => count += 1)
   inspect(count, content="0")
 }
 

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -58,7 +58,7 @@ test "iter" {
     (0, "zero"),
   ])
   let mut s = ""
-  m.each((k, v) => s = s + "(\{k},\{v})")
+  m.each((k, v) => s += "(\{k},\{v})")
   inspect(s, content="(0,zero)(1,one)(2,two)(3,three)(8,eight)")
 }
 
@@ -72,7 +72,7 @@ test "iteri" {
     (0, "zero"),
   ])
   let mut s = ""
-  m.eachi((i, k, v) => s = s + "(\{i},\{k},\{v})")
+  m.eachi((i, k, v) => s += "(\{i},\{k},\{v})")
   inspect(s, content="(0,0,zero)(1,1,one)(2,2,two)(3,3,three)(4,8,eight)")
 }
 

--- a/immut/sorted_set/generic_test.mbt
+++ b/immut/sorted_set/generic_test.mbt
@@ -60,7 +60,7 @@ test "iter with early termination on left subtree" {
   let mut count = 0
   let iter = set.iter()
   for _ in iter {
-    count = count + 1
+    count += 1
     if count == 1 {
       break
     }

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -316,7 +316,7 @@ test "iteri" {
   v.eachi((_i, _e) => abort("never reach"))
   let v = @vector.from_array([1, 2, 3, 4, 5])
   let mut s = 0
-  v.eachi((i, e) => s = s + i * e)
+  v.eachi((i, e) => s += i * e)
   inspect(s, content="40")
   let vec = []
   v.eachi((i, _e) => vec.push(i))

--- a/immut/vector/vector_wbtest.mbt
+++ b/immut/vector/vector_wbtest.mbt
@@ -138,9 +138,9 @@ test "mix" {
     v2
   }
   let mut ct = 0
-  v.each(e => ct = ct + e)
+  v.each(e => ct += e)
   inspect(ct, content="4950")
-  v2.each(e => ct = ct + e)
+  v2.each(e => ct += e)
   inspect(ct, content="14850")
   let v2 = v2.map(e => e * 2)
   let ct1 = v2.fold((a, b) => a + b, init=0)

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -59,7 +59,7 @@ test "iteri" {
     if x != i + 1 || i != v {
       failed = true
     }
-    v = v + 1
+    v += 1
   }
   debug_inspect(failed, content="false")
 }

--- a/math/trig.mbt
+++ b/math/trig.mbt
@@ -82,7 +82,7 @@ fn trig_reduce(x : Float, switch_over : Float) -> (Float, Int) {
   phi = phi & 0x3fffffff
   if (phi & 0x2000_0000) != 0 {
     phi = phi - 0x4000_0000
-    q = q + 1
+    q += 1
   }
   let s : UInt = phi & 0x8000_0000
   if phi >= 0x8000_0000 {

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -224,7 +224,8 @@ pub fn[A] Queue::pop(self : Queue[A]) -> A? {
 /// test {
 ///   let queue : @queue.Queue[Int] = @queue.from_array([1, 2, 3, 4])
 ///   let mut sum = 0
-///   queue.each(x => sum = sum + x)
+///   queue.each(x => sum += x)
+///   inspect(sum, content="10")
 /// }
 /// ```
 #locals(f)
@@ -248,7 +249,8 @@ pub fn[A] Queue::each(self : Queue[A], f : (A) -> Unit) -> Unit {
 /// test {
 ///   let queue : @queue.Queue[Int] = @queue.from_array([1, 2, 3, 4])
 ///   let mut sum = 0
-///   queue.eachi((i, x) => sum = sum + i * x)
+///   queue.eachi((i, x) => sum += i * x)
+///   inspect(sum, content="20")
 /// }
 /// ```
 #locals(f)

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -341,7 +341,7 @@ pub fn[A] Queue::transfer(self : Queue[A], dst : Queue[A]) -> Unit {
       }
       Some(last) => {
         last.next = self.first
-        dst.length = dst.length + self.length
+        dst.length += self.length
         dst.last = self.last
         self.clear()
       }

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -197,11 +197,11 @@ test "pop" {
 test "each" {
   let queue : @queue.Queue[Int] = Queue([])
   let mut sum = 0
-  queue.each(x => sum = sum + x)
+  queue.each(x => sum += x)
   @test.assert_eq(sum, 0)
   @queue.from_array([1, 2, 3, 4]).transfer(queue)
   sum = 0
-  queue.each(x => sum = sum + x)
+  queue.each(x => sum += x)
   @test.assert_eq(sum, 10)
 }
 
@@ -215,11 +215,11 @@ test "iter_fold" {
 test "iteri" {
   let queue : @queue.Queue[Int] = Queue([])
   let mut sum = 0
-  queue.eachi((i, x) => sum = sum + i * x)
+  queue.eachi((i, x) => sum += i * x)
   @test.assert_eq(sum, 0)
   @queue.from_array([1, 2, 3, 4]).transfer(queue)
   sum = 0
-  queue.eachi((i, x) => sum = sum + i * x)
+  queue.eachi((i, x) => sum += i * x)
   @test.assert_eq(sum, 20)
 }
 

--- a/quickcheck/arbitrary_test.mbt
+++ b/quickcheck/arbitrary_test.mbt
@@ -100,7 +100,7 @@ test "arbitrary_iter_break" {
   // An Iter with a length greater than 0 is required here
   let mut i = 0
   for _ in iter {
-    i = i + 1
+    i += 1
     break
   } nobreak {
     panic()

--- a/range/range_test.mbt
+++ b/range/range_test.mbt
@@ -452,7 +452,7 @@ test "iter via for-comprehension into array" {
 test "iter is lazy" {
   let mut count = 0
   for i in @range.iter(from=0, to=100) {
-    count = count + 1
+    count += 1
     if i == 4 {
       break
     }

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -259,7 +259,7 @@ pub fn[K, V] SortedMap::eachi(
   let mut i = 0
   self.each((k, v) => {
     f(i, k, v)
-    i = i + 1
+    i += 1
   })
 }
 

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -173,7 +173,7 @@ pub fn[V : Compare] SortedSet::union(
       let mut ct = 0
       let ret = { root: t, size: 0 }
       // TODO: optimize this. Avoid counting the size of the set.
-      ret.each(_x => ct = ct + 1)
+      ret.each(_x => ct += 1)
       ret.size = ct
       ret
     }

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -397,7 +397,7 @@ pub fn[V] SortedSet::eachi(
   let mut i = 0
   self.each(v => {
     f(i, v)
-    i = i + 1
+    i += 1
   })
 }
 
@@ -414,7 +414,7 @@ pub fn[V] SortedSet::to_array(self : SortedSet[V]) -> Array[V] {
       if root is Some(root) {
         dfs(root.left)
         arr[i] = root.value
-        i = i + 1
+        i += 1
         dfs(root.right)
       }
     }

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -38,7 +38,7 @@ test "String iter2 with surrogate pairs" {
 
   // Count characters using iter2
   let mut count = 0
-  s.iter2().each((_, _) => count = count + 1)
+  s.iter2().each((_, _) => count += 1)
   inspect(count, content="11") // 5 chars + emoji + 5 chars
 }
 

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -32,7 +32,7 @@ test "String iter2 with surrogate pairs" {
     if i < 3 {
       result.push((idx, c))
     }
-    i = i + 1
+    i += 1
   })
   debug_inspect(result, content="[(0, 'H'), (1, 'e'), (2, 'l')]")
 

--- a/string/ascii_case_insensitive_map_test.mbt
+++ b/string/ascii_case_insensitive_map_test.mbt
@@ -48,7 +48,7 @@ impl Hash for AsciiCaseInsensitiveString with fn hash_combine(self, hasher) {
     let mut c = code_unit
     // Fold ASCII 'A'..'Z' (0x41..0x5A) to 'a'..'z' (0x61..0x7A).
     if c >= ('A' : UInt16) && c <= ('Z' : UInt16) {
-      c = c + (32 : UInt16)
+      c += (32 : UInt16)
     }
     hasher.combine_uint(c.to_int().reinterpret_as_uint())
   }

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -262,9 +262,7 @@ test "to_array" {
 ///|
 test "chars" {
   let mut str = ""
-  "A😊𠮷BA😊𠮷B"
-  .iter()
-  .each(c => str = str + c.to_int().to_string() + "\n")
+  "A😊𠮷BA😊𠮷B".iter().each(c => str += c.to_int().to_string() + "\n")
   inspect(
     str,
     content=(
@@ -294,7 +292,7 @@ test "rev_iter" {
   let mut str = ""
   "A😊𠮷BA😊𠮷B"
   .rev_iter()
-  .each(c => str = str + c.to_int().to_string() + "\n")
+  .each(c => str += c.to_int().to_string() + "\n")
   inspect(
     str,
     content=(
@@ -322,9 +320,7 @@ test "rev_iter" {
 ///|
 test "iter2" {
   let mut str = ""
-  "A😊𠮷BA😊𠮷B"
-  .iter2()
-  .each((i, c) => str = str + "\{i}: \{c.to_int()} \n")
+  "A😊𠮷BA😊𠮷B".iter2().each((i, c) => str += "\{i}: \{c.to_int()} \n")
   inspect(
     str,
     content=(

--- a/v128/v128_bench_test.mbt
+++ b/v128/v128_bench_test.mbt
@@ -83,7 +83,7 @@ test "bench V128 i8x16_extract_lane_u n=10000" (it : @bench.T) {
   it.bench(fn() {
     let mut sum = 0
     for i = 0; i < v128_bench_size; i = i + 1 {
-      sum = sum + @v128.i8x16_extract_lane_u(value, i & 15).reinterpret_as_int()
+      sum += @v128.i8x16_extract_lane_u(value, i & 15).reinterpret_as_int()
     }
     it.keep(sum)
   })
@@ -110,7 +110,7 @@ test "bench V128 i8x16_bitmask n=10000" (it : @bench.T) {
   it.bench(fn() {
     let mut sum = 0
     for i = 0; i < v128_bench_size; i = i + 1 {
-      sum = sum + @v128.i8x16_bitmask(values.unsafe_get(i))
+      sum += @v128.i8x16_bitmask(values.unsafe_get(i))
     }
     it.keep(sum)
   })
@@ -317,16 +317,16 @@ test "bench V128 all_true n=10000" (it : @bench.T) {
     for i = 0; i < v128_bench_size; i = i + 1 {
       let value = values.unsafe_get(i)
       if @v128.i8x16_all_true(value) {
-        count = count + 1
+        count += 1
       }
       if @v128.i16x8_all_true(value) {
-        count = count + 1
+        count += 1
       }
       if @v128.i32x4_all_true(value) {
-        count = count + 1
+        count += 1
       }
       if @v128.i64x2_all_true(value) {
-        count = count + 1
+        count += 1
       }
     }
     it.keep(count)
@@ -340,10 +340,10 @@ test "bench V128 bitmask all widths n=10000" (it : @bench.T) {
     let mut sum = 0
     for i = 0; i < v128_bench_size; i = i + 1 {
       let value = values.unsafe_get(i)
-      sum = sum + @v128.i8x16_bitmask(value)
-      sum = sum + @v128.i16x8_bitmask(value)
-      sum = sum + @v128.i32x4_bitmask(value)
-      sum = sum + @v128.i64x2_bitmask(value)
+      sum += @v128.i8x16_bitmask(value)
+      sum += @v128.i16x8_bitmask(value)
+      sum += @v128.i32x4_bitmask(value)
+      sum += @v128.i64x2_bitmask(value)
     }
     it.keep(sum)
   })


### PR DESCRIPTION
Rewrites `x = x + a` as `x += a` and `a.y = a.y + b` as `a.y += b` across the tree — **146 sites in 49 files** (83 code statements, 37 embedded expressions, 26 in doc examples).

`moon info` reports no `.mbti` changes, so no package's public interface moves.

### Finding the sites took two complementary scans

Neither scan alone is sufficient, which is worth recording:

- **`moongrep --pattern '$(a:id) = $(a:id) + $(_:exp)'`** matches on the AST, so it finds occurrences regardless of layout — in particular inside single-line lambda bodies like `arr.each(x => sum = sum + x)`, which a line-anchored text scan cannot see. But it skips blocks it fails to parse, and its pattern does **not** match left-nested chains: `sum = sum + i + x` is `Add(Add(sum, i), x)`, whose left operand is not the bare lvalue.
- **A text scan** catches those chains and the unparseable blocks, but needs paren- and string-aware scanning to find where the RHS ends — in `each(x => sum = sum + x)` the RHS stops before the lambda's `)`, and in `s = s + "(\{k},\{v})"` the parens inside the literal must not be counted.

Both scans now report zero remaining sites, apart from the deliberate exclusions below.

### Deliberately left alone

1. **`for` loop update clauses** (83 sites) — `for i = 0; i < n; i = i + 1 {`. The third clause of a `for` is a binding update, not an assignment statement, and does not accept `+=`.

2. **`let` shadowing** (28 sites) — `let count = count + 1` introduces a *new* binding that shadows the old one. It is not an assignment and has no `+=` form.

3. **Two sites that would reassociate** — `immut/array/tree.mbt:590` and `immut/vector/tree.mbt:559`:

   ```moonbit
   remaining_nodes = remaining_nodes + node_counts[i + 1] - min_size
   ```

   Folding to `+=` turns `(x + a) - b` into `x + (a - b)`. That is equivalent for these `Int`s, but the rewrite stops being purely syntactic — and the same shape over `Double` would not be safe — so it isn't worth it for two lines.

### One behavioural note for review

Converting three **doc examples** surfaced `unused_value` warnings on `sum` (`queue/queue.mbt` ×2, `builtin/intrinsics.mbt` ×1). Those examples accumulate into `sum` and then never read it — `sum = sum + x` was merely hiding that by mentioning `sum` on the right-hand side, whereas the compiler treats `+=` as write-only for this analysis.

Rather than revert the rewrite, I completed the examples with the assertion they were missing (`inspect(sum, content="10")` and friends). These are ```` ```mbt check ```` doctests, so they are compiled *and executed* — I confirmed the values are checked by deliberately breaking one and watching it fail. This is the only part of the PR that is not a pure syntactic rewrite; it is easy to drop if you'd rather.

`moon fmt` also collapsed three wrapped iterator chains in `string/string_test.mbt` onto single lines, since the shorter `+=` brings them under the line-width limit.

### Testing

`moon check --target all` — clean, no warnings.

| target | tests |
| --- | --- |
| wasm-gc | 6873 passed, 0 failed |
| js | 6829 passed, 0 failed |
| native | 6784 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)