### PR TITLE
refactor: replace fall-through `match` with `guard ... is`

### DIFF
--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -413,10 +413,8 @@ pub fn[X, Y] Iter::mapi(self : Iter[X], f : (Int, X) -> Y) -> Iter[Y] {
 pub fn[X, Y] Iter::filter_map(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
   Iter::new(fn() {
     while self.next() is Some(x) {
-      match f(x) {
-        Some(_) as y => break y
-        None => ()
-      }
+      guard f(x) is (Some(_) as y) else { () }
+      break y
     } nobreak {
       None
     }

--- a/diff/diff.mbt
+++ b/diff/diff.mbt
@@ -443,13 +443,9 @@ fn[T : Eq + Hash] make_indexer(
   let mut k = 0 // valid element count
 
   for i in 0..<n {
-    match present.get(a[i]) {
-      Some(_) => {
-        ai[k] = i // record original index of this element
-        k += 1
-      }
-      None => () // doesn't exist in b, skip
-    }
+    guard present.get(a[i]) is Some(_) else { () } // doesn't exist in b, skip
+    ai[k] = i // record original index of this element
+    k += 1
   }
   let result = FixedArray::make(k, 0)
   for i in 0..<k {

--- a/json/json_encode_decode_test.mbt
+++ b/json/json_encode_decode_test.mbt
@@ -53,22 +53,16 @@ fn of_json(jv : Json) -> AllThree raise DecodeError {
       let floats_result = []
       let strings_result = []
       for n in ints {
-        match n {
-          Number(n, ..) => ints_result.push(n.to_int())
-          _ => () // error handling here
-        }
+        guard n is Number(n, ..) else { () } // error handling here
+        ints_result.push(n.to_int())
       }
       for n in floats {
-        match n {
-          Number(n, ..) => floats_result.push(n)
-          _ => () // error handling here
-        }
+        guard n is Number(n, ..) else { () } // error handling here
+        floats_result.push(n)
       }
       for s in strings {
-        match s {
-          String(s) => strings_result.push(s)
-          _ => () // error handling here
-        }
+        guard s is String(s) else { () } // error handling here
+        strings_result.push(s)
       }
       { ints: ints_result, floats: floats_result, strings: strings_result }
     }

--- a/json/json_traverse_test.mbt
+++ b/json/json_traverse_test.mbt
@@ -51,10 +51,8 @@ fn Json::prune_loc(self : Json) -> Json? {
     Array(arr) => {
       let pruned_arr = Array::new()
       for item in arr {
-        match item.prune_loc() {
-          Some(pruned_item) => pruned_arr.push(pruned_item)
-          None => () // drop this item
-        }
+        guard item.prune_loc() is Some(pruned_item) else { () } // drop this item
+        pruned_arr.push(pruned_item)
       }
       Some(Json::array(pruned_arr))
     }
@@ -65,10 +63,8 @@ fn Json::prune_loc(self : Json) -> Json? {
       // 2) iterate through all keys except "loc"
       for key, value in obj {
         if key != "loc" {
-          match value.prune_loc() {
-            Some(pruned_value) => new_obj.set(key, pruned_value)
-            None => () // drop this key-value pair
-          }
+          guard value.prune_loc() is Some(pruned_value) else { () } // drop this key-value pair
+          new_obj.set(key, pruned_value)
         }
       }
 


### PR DESCRIPTION
> **Stacked on #3945.** Base is `refactor/compound-add-assign`, so only the one commit here is new. The `diff/diff.mbt` hunk contains a `k += 1` that comes from that PR; basing this on `main` instead would have guaranteed a conflict in the same lines. GitHub will retarget to `main` automatically once #3945 merges.

Rewrites the two-arm fall-through `match` as a `guard`:

```moonbit
match item.prune_loc() {
  Some(pruned_item) => pruned_arr.push(pruned_item)
  None => () // drop this item
}
```

```moonbit
guard item.prune_loc() is Some(pruned_item) else { () } // drop this item
pruned_arr.push(pruned_item)
```

**7 sites** in `diff/diff.mbt`, `builtin/iterator.mbt` and the `json` tests.

## The moongrep pattern

The literal shape finds only the `Option` case:

```console
$ moongrep scan --pattern 'match $(x:exp) {
    Some($(p:pat)) => $(action:exp)
    None => ()
  }'
```
→ 5 hits.

Generalising both arms to whole-pattern captures roughly doubles that:

```console
$ moongrep scan --pattern 'match $(x:exp) {
    $(p1:pat) => $(action:exp)
    $(p2:pat) => ()
  }'
```
→ **11 hits**. `$(pN:pat)` captures a whole pattern AST, so one shape covers `Some(_)/None`, `Number(n, ..)/_`, `String(s)/_` and `['-', ..]/_` — the constructor is no longer baked into the query. The literal `_ => ()` form, by contrast, finds **0**, since `_` in a shape is a literal wildcard that only matches a source wildcard.

Two limitations worth recording for anyone reusing this:

- **Arm count is fixed by the shape.** `$$$` ellipsis is not supported in match-arm position (it silently matches nothing), so each arity needs its own pattern. A three-arm version of the same query finds **5 more** sites, not covered here.
- `moongrep` skips blocks its parser rejects, emitting `warning: skipping ... parse failed`. Worth reading those warnings rather than trusting a clean run.

## The rewrite is not unconditional

`guard` **skips the rest of the enclosing block** when it fails; the `()` arm falls through and lets execution continue. The two are equivalent only when the `match` is the **last statement in its block**. Of the 11 hits, 8 are in tail position and 3 are not.

Four sites are deliberately left alone:

| site | why |
| --- | --- |
| `diff/diff.mbt:160` | mid-block — the backward-search code follows it |
| `diff/diff.mbt:222` | mid-block — cost heuristics follow it |
| `string/internal/regex_parser/parser.mbt:160` | mid-block — parsing continues after it |
| `argparse/parser_validate.mbt:266` | tail, converts correctly, but reads worse — see below |

For the three mid-block ones a `guard` would silently skip the following code on the fall-through path. In all three the matched arm happens to diverge (`break`, `raise`), so only the fall-through path changes — which is exactly the path that is easy to miss in review. They want `if x is Pat { action }`; I have not made that change here since it is a different rewrite.

The `argparse` site is in tail position and compiles fine, but its two-constructor or-pattern forces the guard header across four lines:

```moonbit
guard inherited.info
  is (FlagInfo(short=inherited_short, ..)
  | OptionInfo(short=inherited_short, ..)) else {
  ()
}
```

That is worse than the `match` it replaces, so I reverted it. Happy to include it if you disagree.

## Notes

- Comments that annotated the `()` arm are moved onto the `else` branch, since that is where the fall-through now lives.
- The rewrite exercises some less common `guard` forms, all of which compile: `as` patterns (`guard f(x) is (Some(_) as y)`), and self-shadowing (`guard n is Number(n, ..)`, where the binding shadows the scrutinee).

## Testing

`moon check --target all` clean; `moon info` reports no `.mbti` change.

| target | tests |
| --- | --- |
| wasm-gc | 6873 passed, 0 failed |
| js | 6829 passed, 0 failed |
| native | 6784 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)