### PR TITLE
refactor: use `-=`, `*=` and `/=` for self-arithmetic

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1395,10 +1395,10 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
       let mut exp = exp
       while exp > 0 {
         if exp % 2 == 1 {
-          result = result * base
+          result *= base
         }
-        base = base * base
-        exp = exp / 2
+        base *= base
+        exp /= 2
       }
       result
     }
@@ -1412,7 +1412,7 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
           result = result * base % modulus
         }
         base = base * base % modulus
-        exp = exp / 2
+        exp /= 2
       }
       result
     }

--- a/builtin/double_mod_nonjs.mbt
+++ b/builtin/double_mod_nonjs.mbt
@@ -102,7 +102,7 @@ pub impl Mod for Double with fn mod(self : Double, other : Double) -> Double {
   }
   // scale result
   if ex > 0 {
-    uint64_x = uint64_x - (1UL << 52)
+    uint64_x -= 1UL << 52
     uint64_x = uint64_x | (ex.to_uint64() << 52)
   } else {
     uint64_x = uint64_x >> (-ex + 1)

--- a/builtin/double_ryu_nonjs.mbt
+++ b/builtin/double_ryu_nonjs.mbt
@@ -407,7 +407,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
           q,
         )
       } else {
-        vp = vp - multipleOfPowerOf5(mv + 2UL, q).to_uint64()
+        vp -= multipleOfPowerOf5(mv + 2UL, q).to_uint64()
       }
     }
   } else {
@@ -431,7 +431,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
       if even {
         vmIsTrailingZeros = mmShift.to_int() == 1
       } else {
-        vp = vp - 1
+        vp -= 1
       }
     } else if q < 63 {
       vrIsTrailingZeros = multipleOfPowerOf2(mv, q)

--- a/builtin/double_ryu_wbtest.mbt
+++ b/builtin/double_ryu_wbtest.mbt
@@ -321,7 +321,7 @@ test "double/ryu.mbt:403" {
   if acceptBounds {
     vmIsTrailingZeros = mmShift.to_int() == 1
   } else {
-    vp = vp - 1L
+    vp -= 1L
   }
   inspect(vrIsTrailingZeros, content="true")
   inspect(vmIsTrailingZeros, content="true")

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -394,7 +394,7 @@ test "rev_each" {
     if elem != i - 1 {
       failed = true
     }
-    i = i - 1
+    i -= 1
   }
   {
     i = 1
@@ -451,7 +451,7 @@ test "rev_eachi" {
     if index != j || elem != i - 1 {
       failed = true
     }
-    i = i - 1
+    i -= 1
     j += 1
   }
   {

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -171,7 +171,7 @@ test "rev_each" {
     if elem != i - 1 {
       failed = true
     }
-    i = i - 1
+    i -= 1
   })
   assert_false(failed)
 }
@@ -185,7 +185,7 @@ test "rev_eachi" {
     if index != j || elem != i - 1 {
       failed = true
     }
-    i = i - 1
+    i -= 1
     j += 1
   })
   assert_false(failed)

--- a/internal/strconv/strconv_decimal.mbt
+++ b/internal/strconv/strconv_decimal.mbt
@@ -399,7 +399,7 @@ fn Decimal::right_shift(self : Decimal, s : Int) -> Unit {
       self.truncated = true
     }
     acc = acc & mask
-    acc = acc * 10
+    acc *= 10
   }
 
   // update and trim

--- a/math/exp.mbt
+++ b/math/exp.mbt
@@ -250,7 +250,7 @@ pub fn expm1f(x : Float) -> Float {
     if k == 128 {
       y = y * 2.0 * (0x1.0p127 : Float)
     } else {
-      y = y * twopk
+      y *= twopk
     }
     return y - 1.0
   }

--- a/math/trig.mbt
+++ b/math/trig.mbt
@@ -47,8 +47,8 @@ fn trig_reduce(x : Float, switch_over : Float) -> (Float, Int) {
       Float::reinterpret_from_int(0x4b40_0000)
     j = Float::from_int(j.reinterpret_as_int() - 0x4b40_0000)
     r = x - j * Float::reinterpret_from_int(0x3fc90f80)
-    r = r - j * Float::reinterpret_from_int(0x37354440)
-    r = r - j * Float::reinterpret_from_int(0x2c34611a)
+    r -= j * Float::reinterpret_from_int(0x37354440)
+    r -= j * Float::reinterpret_from_int(0x2c34611a)
     return (r, j.to_int())
   }
   let xispos = x > 0.0
@@ -81,7 +81,7 @@ fn trig_reduce(x : Float, switch_over : Float) -> (Float, Int) {
   let mut q : Int = (phi >> 30).reinterpret_as_int()
   phi = phi & 0x3fffffff
   if (phi & 0x2000_0000) != 0 {
-    phi = phi - 0x4000_0000
+    phi -= 0x4000_0000
     q += 1
   }
   let s : UInt = phi & 0x8000_0000
@@ -95,12 +95,12 @@ fn trig_reduce(x : Float, switch_over : Float) -> (Float, Int) {
   while phi < 0x8000_0000 {
     phi = (phi << 1) | (plo >> 31)
     plo = plo << 1
-    exp = exp - 1
+    exp -= 1
   }
   phi = mulh(phi, 0xc90f_daa2)
   if phi < 0x8000_0000 {
     phi = phi << 1
-    exp = exp - 1
+    exp -= 1
   }
   let mut r = s +
     ((exp + 128) << 23).reinterpret_as_uint() +

--- a/math/trig_double_nonjs.mbt
+++ b/math/trig_double_nonjs.mbt
@@ -444,7 +444,7 @@ fn rem_pio2(x : Double, y : Array[Double]) -> Int {
         y[1] = z - y[0] - PIO2_1T
       } else {
         // Near pi/2, use 33+33+53 bit pi
-        z = z - PIO2_2
+        z -= PIO2_2
         y[0] = z - PIO2_2T
         y[1] = z - y[0] - PIO2_2T
       }

--- a/strconv/decimal.mbt
+++ b/strconv/decimal.mbt
@@ -390,7 +390,7 @@ fn Decimal::right_shift(self : Decimal, s : Int) -> Unit {
       self.truncated = true
     }
     acc = acc & mask
-    acc = acc * 10
+    acc *= 10
   }
 
   // update and trim


### PR DESCRIPTION
Completes the compound-assignment sweep started in #3945, which covered only `+`. **21 sites in 11 files.**

## The moongrep

One pattern per operator:

```console
$ moongrep scan --pattern '$(a:id) = $(a:id) - $(_:exp)'   # 14
$ moongrep scan --pattern '$(a:id) = $(a:id) * $(_:exp)'   #  5
$ moongrep scan --pattern '$(a:id) = $(a:id) / $(_:exp)'   #  2
```

**Matching on the AST makes this precedence-safe for free**, which matters far more here than it did for `+`:

```moonbit
x = x * a + b
```

parses as `Add(Mul(x, a), b)` — the root is `Add`, so the `*` pattern never produces it as a candidate. Rewriting it to `x *= a + b` would silently turn `(x * a) + b` into `x * (a + b)`. In #3945 I had to exclude the equivalent `x = x + a - b` trap by hand, with a bracket-depth scan for top-level operators over raw text; the structural matcher makes that machinery unnecessary.

Every hit here is therefore a rewrite of the exact same expression, with no reassociation — worth stating explicitly, since several are floating-point (`r -= j * Float::reinterpret_from_int(...)`) where reassociation would *not* have been safe.

## Where the family stops

`%=`, `&=`, `|=`, `^=`, `<<=` and `>>=` are **not MoonBit syntax**:

```
 172 │   hx &= 0x7fffffff
     │       ┬
     │       ╰── Parse error, unexpected token `=`, you may expect simple expression.
```

The corresponding `x = x & ...` shape occurs **64 times** across the tree (`&` 16, `|` 22, `^` 8, `<<` 9, `>>` 9), so this is a real gap in the language rather than an absence of opportunity — but nothing can be done about it from here. Left entirely as-is.

(The 3 apparent `>>=` matches in the tree are inside an embedded JavaScript string literal in `bigint/bigint_js.mbt`, not MoonBit code.)

## Testing

`moon check --target all` clean; `moon info` reports no `.mbti` change.

| target | tests |
| --- | --- |
| wasm-gc | 6873 passed, 0 failed |
| js | 6829 passed, 0 failed |
| native | 6784 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)