### PR TITLE
refactor: use `is_empty()` instead of comparing `length()` to zero

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -354,7 +354,7 @@ fn arg_doc(arg : Arg) -> String {
   if arg.info
     is (OptionInfo(default_values~, ..) | PositionalInfo(default_values~, ..)) &&
     default_values is Some(values) {
-    if values.length() > 0 {
+    if !values.is_empty() {
       let defaults = values.join(", ")
       notes.push("[default: \{defaults}]")
     }
@@ -362,7 +362,7 @@ fn arg_doc(arg : Arg) -> String {
   let help = arg.about.unwrap_or("")
   if help == "" {
     notes.join(" ")
-  } else if notes.length() > 0 {
+  } else if !notes.is_empty() {
     let notes_text = notes.join(" ")
     "\{help} \{notes_text}"
   } else {

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -658,7 +658,7 @@ fn finalize_matches(
 
 ///|
 fn help_subcommand_enabled(cmd : Command) -> Bool {
-  !cmd.disable_help_subcommand && cmd.subcommands.length() > 0
+  !cmd.disable_help_subcommand && !cmd.subcommands.is_empty()
 }
 
 ///|

--- a/argparse/parser_globals_merge.mbt
+++ b/argparse/parser_globals_merge.mbt
@@ -63,8 +63,8 @@ fn merge_global_value_from_child(
   let child_vals = child.values.get(name)
   let parent_source = parent.value_sources.get(name)
   let child_source = child.value_sources.get(name)
-  let has_parent = parent_vals is Some(pv) && pv.length() > 0
-  let has_child = child_vals is Some(cv) && cv.length() > 0
+  let has_parent = parent_vals is Some(pv) && !pv.is_empty()
+  let has_child = child_vals is Some(cv) && !cv.is_empty()
   if !has_parent && !has_child {
     return
   }
@@ -82,7 +82,7 @@ fn merge_global_value_from_child(
           merged.push(v)
         }
       }
-      if merged.length() > 0 {
+      if !merged.is_empty() {
         parent.values[name] = merged
         parent.value_sources[name] = Argv
       }
@@ -90,13 +90,13 @@ fn merge_global_value_from_child(
       let choose_child = has_child &&
         (!has_parent || prefer_child_source(parent_source, child_source))
       if choose_child {
-        if child_vals is Some(cv) && cv.length() > 0 {
+        if child_vals is Some(cv) && !cv.is_empty() {
           parent.values[name] = cv.copy()
         }
         if child_source is Some(src) {
           parent.value_sources[name] = src
         }
-      } else if parent_vals is Some(pv) && pv.length() > 0 {
+      } else if parent_vals is Some(pv) && !pv.is_empty() {
         parent.values[name] = pv.copy()
         if parent_source is Some(src) {
           parent.value_sources[name] = src
@@ -116,13 +116,13 @@ fn merge_global_value_from_child(
     let choose_child = has_child &&
       (!has_parent || prefer_child_source(parent_source, child_source))
     if choose_child {
-      if child_vals is Some(cv) && cv.length() > 0 {
+      if child_vals is Some(cv) && !cv.is_empty() {
         parent.values[name] = cv.copy()
       }
       if child_source is Some(src) {
         parent.value_sources[name] = src
       }
-    } else if parent_vals is Some(pv) && pv.length() > 0 {
+    } else if parent_vals is Some(pv) && !pv.is_empty() {
       parent.values[name] = pv.copy()
       if parent_source is Some(src) {
         parent.value_sources[name] = src

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -510,7 +510,7 @@ fn validate_command_policies(
   matches : Matches,
 ) -> Unit raise ArgParseError {
   if cmd.subcommand_required &&
-    cmd.subcommands.length() > 0 &&
+    !cmd.subcommands.is_empty() &&
     matches.parsed_subcommand is None {
     raise MissingRequired("subcommand", None)
   }

--- a/argparse/parser_values.mbt
+++ b/argparse/parser_values.mbt
@@ -54,7 +54,7 @@ fn assign_positionals(
     cursor
   }
   if cursor < values.length() {
-    let overflow_label = if positionals.length() > 0 {
+    let overflow_label = if !positionals.is_empty() {
       let last = positionals[positionals.length() - 1]
       if last.multiple {
         Some("<\{last.name}...>")
@@ -160,7 +160,7 @@ fn check_duplicate_set_occurrence(
   guard arg.info is (OptionInfo(action=Set, ..) | PositionalInfo(_)) else {
     return
   }
-  if matches.values.get(arg.name) is Some(values) && values.length() > 0 {
+  if matches.values.get(arg.name) is Some(values) && !values.is_empty() {
     raise InvalidArgument(
       "argument '\{option_conflict_label(arg)}' cannot be used multiple times",
     )
@@ -253,7 +253,7 @@ fn apply_defaults(matches : Matches, args : Array[Arg]) -> Unit {
       continue
     }
     match default_values {
-      Some(values) if values.length() > 0 =>
+      Some(values) if !values.is_empty() =>
         for value in values {
           let _ = add_value(matches, arg.name, value, arg, Default)
         }

--- a/bench/stats.mbt
+++ b/bench/stats.mbt
@@ -159,7 +159,7 @@ fn iqr(quartiles~ : (Double, Double, Double)) -> Double {
 
 ///|
 fn percentile(sorted_data~ : Array[Double], pct~ : Double) -> Double {
-  guard sorted_data.length() > 0
+  guard !sorted_data.is_empty()
   guard pct >= 0.0 && pct <= 100.0
   if sorted_data.length() == 1 {
     return sorted_data[0]

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -28,7 +28,7 @@ pub fn parse_bigint(str : StringView, base? : Int = 10) -> BigInt raise {
   if base < 2 || base > 36 {
     base_err()
   }
-  if str.length() == 0 {
+  if str.is_empty() {
     syntax_err()
   }
   match str.unsafe_get(str.length() - 1) {
@@ -212,7 +212,7 @@ pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
   if signum == 0 {
     return 0N
   }
-  if octets.length() == 0 {
+  if octets.is_empty() {
     abort("empty octet string")
   }
   let str = StringBuilder()

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -43,7 +43,7 @@ test "empty constructor" {
 test "constructor capacity" {
   let empty : Map[String, Int] = Map([], capacity=16)
   assert_true(empty.capacity == 16)
-  assert_true(empty.length() == 0)
+  assert_true(empty.is_empty())
   let below_length = Map([("a", 1), ("b", 2), ("c", 3)], capacity=2)
   assert_true(below_length.capacity == 4)
   assert_true(below_length.length() == 3)
@@ -236,7 +236,7 @@ test "from_array" {
 ///|
 test "length" {
   let m : Map[String, Int] = Map([])
-  assert_true(m.length() == 0)
+  assert_true(m.is_empty())
   m.set("a", 1)
   assert_true(m.length() == 1)
 }

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -132,7 +132,7 @@ pub fn end() -> Unit {
     }
   }
   let trailing_line = line_buf.to_string()
-  if trailing_line.length() > 0 {
+  if !trailing_line.is_empty() {
     println(trailing_line)
   }
   println("----- END MOONBIT COVERAGE -----")

--- a/debug/debug_coverage_test.mbt
+++ b/debug/debug_coverage_test.mbt
@@ -169,7 +169,7 @@ test "depth-limited render replaces deep subtrees with ellipsis" {
   assert_true(@debug.render(Repr(nested), max_depth=1).contains("..."))
   // a depth-limited record still renders its (pruned) fields
   let p : CovPoint = { x: 7, y: 8.0 }
-  assert_true(@debug.render(Repr(p), max_depth=1).length() > 0)
+  assert_true(!@debug.render(Repr(p), max_depth=1).is_empty())
   // depth <= 0 is treated as 1, so max_depth=0 renders identically to max_depth=1
   let r = Repr(nested)
   @debug.assert_eq(@debug.render(r, max_depth=0), @debug.render(r, max_depth=1))

--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -273,7 +273,7 @@ fn bracket_seq_lines(
       // Also ensure the single element still gets a trailing comma in multi-line mode.
       if item.length() > 1 {
         let lines = indent_spaces(indent_by, { size: 0, lines: item }).lines
-        if lines.length() > 0 {
+        if !lines.is_empty() {
           let last_i = lines.length() - 1
           lines[last_i] += ","
         }

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1218,7 +1218,7 @@ pub fn[A : Eq] Deque::contains(self : Deque[A], value : A) -> Bool {
 /// ```
 #locals(f)
 pub fn[A] Deque::extract_if(self : Deque[A], f : (A) -> Bool) -> Deque[A] {
-  guard self.length() != 0 else { from_array([]) }
+  guard !self.is_empty() else { from_array([]) }
   let removed = from_array([])
   let write = for read in 0..<self.length(); write = 0 {
     let elem = self[read]
@@ -1436,7 +1436,7 @@ pub fn[A] Deque::retain_map(self : Deque[A], f : (A) -> A?) -> Unit {
   } nobreak {
     (idx, kept_len)
   }
-  if back.length() == 0 {
+  if back.is_empty() {
     self.truncate(kept_len)
     return
   }
@@ -1499,7 +1499,7 @@ pub fn[A] Deque::retain(self : Deque[A], f : (A) -> Bool) -> Unit {
   } nobreak {
     (idx, kept_len)
   }
-  if back.length() == 0 {
+  if back.is_empty() {
     self.truncate(kept_len)
     return
   }

--- a/diff/diff.mbt
+++ b/diff/diff.mbt
@@ -543,7 +543,7 @@ fn[T : Eq + Hash] append_patience_matches(
   new_offset : Int,
 ) -> Unit {
   let anchors = unique_lcs(old~, new~)
-  if anchors.length() == 0 {
+  if anchors.is_empty() {
     append_myers_matches(matches, cutoff, old, new, old_offset, new_offset)
     return
   }

--- a/diff/diff_wbtest.mbt
+++ b/diff/diff_wbtest.mbt
@@ -415,7 +415,7 @@ test "string array edge cases" {
   }
 
   // Should find some matches (empty strings will match)
-  inspect(result.length() > 0, content="true")
+  inspect(!result.is_empty(), content="true")
 }
 
 ///|

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -72,7 +72,7 @@ fn utf16_needs_scalar_le_v128(bytes : BytesView) -> Bool {
     return true
   }
   let src = bytes.data()
-  if bytes.length() > 0 &&
+  if !bytes.is_empty() &&
     is_utf16_surrogate(src.unsafe_read_uint16_le(bytes.start_offset())) {
     return true
   }
@@ -101,7 +101,7 @@ fn utf16_needs_scalar_be_v128(bytes : BytesView) -> Bool {
     return true
   }
   let src = bytes.data()
-  if bytes.length() > 0 &&
+  if !bytes.is_empty() &&
     is_utf16_surrogate(src.unsafe_read_uint16_be(bytes.start_offset())) {
     return true
   }

--- a/encoding/utf16/decode_test.mbt
+++ b/encoding/utf16/decode_test.mbt
@@ -203,7 +203,7 @@ test "decode_lossy with surrogate pairs" {
   // This is hard to construct but we can test the invalid surrogate path
   let invalid_surr = b"\x3d\xd8\x41\xdc"
   let result = @utf16.decode_lossy(invalid_surr)
-  assert_true(result.length() > 0)
+  assert_true(!result.is_empty())
 }
 
 ///|

--- a/env/env_test.mbt
+++ b/env/env_test.mbt
@@ -15,7 +15,7 @@
 ///|
 test {
   let args = @env.args()
-  assert_true(args.length() != 0)
+  assert_true(!args.is_empty())
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -888,7 +888,7 @@ pub fn[K : Eq + Hash, V] HashMap::from_iter(
     None => []
   }
   iter.each(e => entries.push({ key: e.0, value: e.1, path: @path.of(e.0) }))
-  if entries.length() == 0 {
+  if entries.is_empty() {
     new()
   } else {
     {

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -581,7 +581,7 @@ pub fn[A : Eq + Hash] HashSet::from_iter(iter : Iter[A]) -> HashSet[A] {
     None => []
   }
   iter.each(value => entries.push({ value, path: @path.of(value) }))
-  if entries.length() == 0 {
+  if entries.is_empty() {
     new()
   } else {
     {

--- a/immut/vector/tree_append.mbt
+++ b/immut/vector/tree_append.mbt
@@ -148,7 +148,7 @@ fn[T] Tree::concat_with_suffix(
   right_shift : Int,
   top : Bool,
 ) -> (Tree[T], Int) {
-  if suffix.length() == 0 {
+  if suffix.is_empty() {
     return Tree::concat(left, left_shift, right, right_shift, top)
   }
   if left_shift > right_shift {

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -407,7 +407,7 @@ pub fn[A] Vector::concat(self : Vector[A], other : Vector[A]) -> Vector[A] {
         size,
         self.shift,
       )
-    } else if self.tail.length() == 0 {
+    } else if self.tail.is_empty() {
       return make_t(self.tree, other.tail, size, self.shift)
     } else {
       let (tree, shift) = self.normalize_tree()
@@ -416,7 +416,7 @@ pub fn[A] Vector::concat(self : Vector[A], other : Vector[A]) -> Vector[A] {
   }
   let (tree, shift) = if self.tree is Empty {
     Tree::concat(Leaf(self.tail), 0, other.tree, other.shift, true)
-  } else if self.tail.length() == 0 {
+  } else if self.tail.is_empty() {
     Tree::concat(self.tree, self.shift, other.tree, other.shift, true)
   } else {
     Tree::concat_with_suffix(
@@ -862,7 +862,7 @@ fn tail_len_of_size(size : Int) -> Int {
 fn[A] Vector::normalize_tree(self : Vector[A]) -> (Tree[A], Int) {
   if self.size == 0 {
     (Tree::empty(), 0)
-  } else if self.tail.length() == 0 {
+  } else if self.tail.is_empty() {
     (self.tree, self.shift)
   } else if self.tail_offset() == 0 {
     (Leaf(self.tail), 0)

--- a/internal/strconv/strconv_double.mbt
+++ b/internal/strconv/strconv_double.mbt
@@ -70,7 +70,7 @@ let max_mantissa_fast_path : UInt64 = 2UL << mantissa_explicit_bits
 /// An exponent value exp scales the mantissa (significand) by 10^exp.
 /// For example, "1.23e2" represents 1.23 × 10² = 123.
 pub fn parse_double(str : StringView) -> Double raise {
-  guard str.length() > 0 else { syntax_err() }
+  guard !str.is_empty() else { syntax_err() }
   guard check_underscore(str) else { syntax_err() }
   // validate its a number
   match parse_number(str) {

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -33,7 +33,7 @@ fn[A] new_queue() -> Queue[A] {
 #alias(of, deprecated="Use from_array instead")
 #as_free_fn(of, deprecated="Use from_array instead")
 pub fn[A] Queue::Queue(arr : ArrayView[A]) -> Queue[A] {
-  guard arr.length() > 0 else { return new_queue() }
+  guard !arr.is_empty() else { return new_queue() }
   let length = arr.length()
   let last = { content: arr[length - 1], next: None }
   let first = for i = length - 2, x = last; i >= 0; {

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -72,7 +72,7 @@ let max_mantissa_fast_path : UInt64 = 2UL << mantissa_explicit_bits
 /// For example, "1.23e2" represents 1.23 × 10² = 123.
 #deprecated("use `@string.parse_double` instead", skip_current_package=true)
 pub fn parse_double(str : StringView) -> Double raise StrConvError {
-  guard str.length() > 0 else { syntax_err() }
+  guard !str.is_empty() else { syntax_err() }
   guard check_underscore(str) else { syntax_err() }
   // validate its a number
   match parse_number(str) {


### PR DESCRIPTION
**40 sites in 24 files.** `x.length() == 0` → `x.is_empty()`; `x.length() > 0` and `x.length() != 0` → `!x.is_empty()`.

## The moongrep

```console
$ moongrep scan --pattern '$(x:exp).length() == 0'   # 21
$ moongrep scan --pattern '$(x:exp).length() > 0'    # 25
$ moongrep scan --pattern '$(x:exp).length() != 0'   #  2
```

## The trap: the helper's own body matches

**8 of the 21 `== 0` hits are the body of `is_empty` itself.** Rewriting them would have produced infinite recursion:

| | |
| --- | --- |
| `builtin/array.mbt:746` | `builtin/bytesview.mbt:64` |
| `builtin/bytes.mbt:766` | `builtin/fixedarray.mbt:169` |
| `builtin/arrayview.mbt:93` | `builtin/mutarrayview.mbt:83` |
| `builtin/string_methods.mbt:875` | `immut/sorted_map/utils.mbt:68` |

A structural pattern cannot distinguish these on its own — the shape of `fn is_empty(self) { self.length() == 0 }` is *identical* to the shape of every call site it is meant to replace. I filtered them by resolving each hit's enclosing function and dropping anything inside `fn is_empty`.

This generalises: **any "replace this expression with the helper that wraps it" rewrite will match the helper's own definition.** Worth checking for every rewrite of this family, not just this one.

`moon check --target all` passing also confirms every remaining receiver genuinely has an `is_empty` method — that part did not need checking by hand.

## Not included: `iter().each`

moongrep finds 18 of `$(x:exp).iter().each($(f:exp))`, which looks like an easy `x.each(f)` collapse. **All 18 are in `_test` / `_bench_test` files that are deliberately exercising `.iter()`:**

- `builtin/option_test.mbt:56,59` — `(Some(3) : Int?).iter().each(..)` is the test *for* `Option::iter`
- `immut/vector/vector_iter_bench_test.mbt:34` — measures iterator throughput
- `builtin/iter_test.mbt:855`, `string/string_test.mbt:265`, and the rest — same story

Collapsing the call would delete the thing under test. Left entirely alone; there are no non-test occurrences of this shape in the tree.

## Testing

`moon check --target all` clean; `moon info` reports no `.mbti` change.

| target | tests |
| --- | --- |
| wasm-gc | 6873 passed, 0 failed |
| js | 6829 passed, 0 failed |
| native | 6784 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)