### PR TITLE
refactor: use `guard`, `.map` and `unwrap_or` over `Option` matches

### DIFF
--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -71,9 +71,8 @@ fn should_parse_as_positional(
   if !arg.has_prefix("-") || arg == "-" {
     return false
   }
-  let next = match next_positional(positionals, collected) {
-    Some(v) => v
-    None => return false
+  guard next_positional(positionals, collected) is Some(next) else {
+    return false
   }
   let next_allow = match next.info {
     FlagInfo(_) => false

--- a/argparse/parser_values.mbt
+++ b/argparse/parser_values.mbt
@@ -206,14 +206,8 @@ fn apply_env(
     if matches_has_value_or_flag(matches, name) {
       continue
     }
-    let env_name = match arg.env {
-      Some(value) => value
-      None => continue
-    }
-    let value = match env.get(env_name) {
-      Some(v) => v
-      None => continue
-    }
+    guard arg.env is Some(env_name) else { continue }
+    guard env.get(env_name) is Some(value) else { continue }
     if arg.info is (OptionInfo(_) | PositionalInfo(_)) {
       assign_value(matches, arg, value, Env)
       continue

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -358,15 +358,7 @@ pub fn[X] Iter::filter(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
 /// # Note
 /// The old iterator `self` must not be used again after calling `map`.
 pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
-  {
-    f: fn() {
-      match self.next() {
-        Some(x) => Some(f(x))
-        None => None
-      }
-    },
-    size_hint: self.size_hint,
-  }
+  { f: fn() { self.next().map(x => f(x)) }, size_hint: self.size_hint }
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1239,10 +1239,7 @@ pub fn StringView::before(
   self : StringView,
   needle : StringView,
 ) -> StringView? {
-  match self.find(needle) {
-    Some(index) => Some(self.view(end_offset=index))
-    None => None
-  }
+  self.find(needle).map(index => self.view(end_offset=index))
 }
 
 ///|
@@ -1262,10 +1259,9 @@ pub fn String::before(self : String, needle : StringView) -> StringView? {
 /// 
 /// If the separator is empty, it returns the full string.
 pub fn StringView::after(self : StringView, needle : StringView) -> StringView? {
-  match self.find(needle) {
-    Some(index) => Some(self.view(start_offset=index + needle.length()))
-    None => None
-  }
+  self
+  .find(needle)
+  .map(index => self.view(start_offset=index + needle.length()))
 }
 
 ///|
@@ -1342,10 +1338,7 @@ pub fn StringView::rev_before(
   self : StringView,
   needle : StringView,
 ) -> StringView? {
-  match self.rev_find(needle) {
-    Some(index) => Some(self.view(end_offset=index))
-    None => None
-  }
+  self.rev_find(needle).map(index => self.view(end_offset=index))
 }
 
 ///|
@@ -1380,10 +1373,9 @@ pub fn StringView::rev_after(
   self : StringView,
   needle : StringView,
 ) -> StringView? {
-  match self.rev_find(needle) {
-    Some(index) => Some(self.view(start_offset=index + needle.length()))
-    None => None
-  }
+  self
+  .rev_find(needle)
+  .map(index => self.view(start_offset=index + needle.length()))
 }
 
 ///|

--- a/debug/debug.mbt
+++ b/debug/debug.mbt
@@ -315,10 +315,7 @@ test "core builtin Debug implementations" {
 #callsite(autofill(loc))
 #deprecated("This function is for debugging only and should not be used in production", skip_current_package=true)
 pub fn[T : Debug] dump(t : T, name? : String, loc~ : SourceLoc) -> T {
-  let name = match name {
-    Some(name) => name
-    None => ""
-  }
+  let name = name.unwrap_or("")
   println("dump(\{name}@\{loc}) = \{to_string(t)}")
   t
 }

--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -160,23 +160,14 @@ fn compact_lines(lines : Array[String]) -> Array[String] {
           }
         }
         let joined0 = parts.join(" ")
-        let joined : StringView = match joined0.strip_suffix(",") {
-          Some(sv) => sv
-          None => joined0
-        }
+        let joined : StringView = joined0.strip_suffix(",").unwrap_or(joined0)
 
         // Match expected style:
         // - arrays: [a, b]
         // - records/maps: { field: value, field: value }
         if first == "{" {
-          let s1 = match joined.strip_prefix(" ") {
-            Some(sv) => sv
-            None => joined
-          }
-          let inner = match s1.strip_suffix(" ") {
-            Some(sv) => sv
-            None => s1
-          }
+          let s1 = joined.strip_prefix(" ").unwrap_or(joined)
+          let inner = s1.strip_suffix(" ").unwrap_or(s1)
           if inner == "" {
             ["{}"]
           } else {
@@ -208,10 +199,7 @@ fn compact_lines(lines : Array[String]) -> Array[String] {
           }
         }
         let joined0 = parts.join(" ")
-        let joined : StringView = match joined0.strip_suffix(",") {
-          Some(sv) => sv
-          None => joined0
-        }
+        let joined : StringView = joined0.strip_suffix(",").unwrap_or(joined0)
         ["\{first}\{joined}\{last}"]
       } else {
         let parts : Array[StringView] = [first]

--- a/immut/array/deprecated.mbt
+++ b/immut/array/deprecated.mbt
@@ -28,10 +28,7 @@ pub fn[A] T::copy(self : T[A]) -> T[A] {
       Node(node, sizes) =>
         Node(
           FixedArray::makei(node.length(), i => copy(node[i])),
-          match sizes {
-            Some(sizes) => Some(FixedArray::copy(sizes))
-            None => None
-          },
+          sizes.map(sizes => FixedArray::copy(sizes)),
         )
     }
   }

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -196,10 +196,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
   }
 
   fn push_sizes_last(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
-    match sizes {
-      Some(sizes) => Some(immutable_push(sizes, 1 + sizes[sizes.length() - 1]))
-      None => None
-    }
+    sizes.map(sizes => immutable_push(sizes, 1 + sizes[sizes.length() - 1]))
   }
 
   fn worker(node : Tree[T], shift : Int) -> Tree[T]? {

--- a/immut/array/utils.mbt
+++ b/immut/array/utils.mbt
@@ -73,10 +73,7 @@ fn get_branch_index(sizes : FixedArray[Int], index : Int) -> Int {
 ///|
 /// Copy the sizes array.
 fn copy_sizes(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
-  match sizes {
-    Some(sizes) => Some(sizes.copy())
-    None => None
-  }
+  sizes.map(sizes => sizes.copy())
 }
 
 ///|

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -651,10 +651,9 @@ pub fn[K : Eq, V] HashMap::intersection(
           None => None
         }
       (Flat(key1, _, path1), _) =>
-        match node2.get_with_path(key1, path1) {
-          Some(value2) => Some(Flat(key1, value2, path1))
-          None => None
-        }
+        node2
+        .get_with_path(key1, path1)
+        .map(value2 => Flat(key1, value2, path1))
       (Branch(children1), Branch(children2)) =>
         match children1.intersection(children2, go) {
           None => None
@@ -692,15 +691,13 @@ pub fn[K : Eq, V] HashMap::intersection_with(
   fn go(node1 : Node[_], node2) raise? {
     match (node1, node2) {
       (_, Flat(key2, value2, path2)) =>
-        match node1.get_with_path(key2, path2) {
-          Some(value1) => Some(Flat(key2, f(key2, value1, value2), path2))
-          None => None
-        }
+        node1
+        .get_with_path(key2, path2)
+        .map(value1 => Flat(key2, f(key2, value1, value2), path2))
       (Flat(key1, value1, path1), _) =>
-        match node2.get_with_path(key1, path1) {
-          Some(value2) => Some(Flat(key1, f(key1, value1, value2), path1))
-          None => None
-        }
+        node2
+        .get_with_path(key1, path1)
+        .map(value2 => Flat(key1, f(key1, value1, value2), path1))
       (Branch(children1), Branch(children2)) =>
         match children1.intersection(children2, go) {
           None => None

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -181,10 +181,7 @@ fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
   }
 
   fn push_sizes_last(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
-    match sizes {
-      Some(sizes) => Some(immutable_push(sizes, 1 + sizes[sizes.length() - 1]))
-      None => None
-    }
+    sizes.map(sizes => immutable_push(sizes, 1 + sizes[sizes.length() - 1]))
   }
 
   fn worker(node : Tree[T], shift : Int) -> Tree[T]? {

--- a/immut/vector/tree_append.mbt
+++ b/immut/vector/tree_append.mbt
@@ -28,11 +28,7 @@ fn append_sizes_last(sizes : FixedArray[Int]?, delta : Int) -> FixedArray[Int]? 
 
 ///|
 fn push_sizes_last(sizes : FixedArray[Int]?, delta : Int) -> FixedArray[Int]? {
-  match sizes {
-    Some(sizes) =>
-      Some(immutable_push(sizes, delta + sizes[sizes.length() - 1]))
-    None => None
-  }
+  sizes.map(sizes => immutable_push(sizes, delta + sizes[sizes.length() - 1]))
 }
 
 ///|

--- a/immut/vector/utils.mbt
+++ b/immut/vector/utils.mbt
@@ -109,10 +109,7 @@ fn get_branch_index(sizes : FixedArray[Int], index : Int) -> Int {
 ///|
 /// Copy the sizes array.
 fn copy_sizes(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
-  match sizes {
-    Some(sizes) => Some(sizes.copy())
-    None => None
-  }
+  sizes.map(sizes => sizes.copy())
 }
 
 ///|

--- a/internal/strconv/strconv_double.mbt
+++ b/internal/strconv/strconv_double.mbt
@@ -127,10 +127,9 @@ fn Number::try_fast_path(self : Number) -> Double? {
     } else {
       // disguised fast path
       let shift = self.exponent - max_exponent_fast_path
-      let mantissa = match
-        checked_mul(self.mantissa, int_pow10[shift.to_int()]) {
-        Some(m) => m
-        None => return None
+      guard checked_mul(self.mantissa, int_pow10[shift.to_int()])
+        is Some(mantissa) else {
+        return None
       }
       if mantissa > max_mantissa_fast_path {
         return None

--- a/internal/strconv/strconv_number.mbt
+++ b/internal/strconv/strconv_number.mbt
@@ -118,9 +118,8 @@ fn parse_number(s : StringView) -> Number? raise {
   // handle scientific format
   let exp_number = 0L
   if s is ['e' | 'E', .. rest] {
-    let (new_s, exp_number) = match parse_scientific(rest) {
-      Some(res) => res
-      None => return None
+    guard parse_scientific(rest) is Some((new_s, exp_number)) else {
+      return None
     }
     s = new_s
     exponent += exp_number

--- a/json/json_traverse_test.mbt
+++ b/json/json_traverse_test.mbt
@@ -80,10 +80,7 @@ fn Json::prune_loc(self : Json) -> Json? {
 
 ///|
 fn Json::prune_loc_test(self : Json) -> Json {
-  match self.prune_loc() {
-    Some(pruned) => pruned
-    None => "Empty"
-  }
+  self.prune_loc().unwrap_or("Empty")
 }
 
 ///|

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -118,10 +118,9 @@ fn JsonNumberScan::try_fast_double(self : JsonNumberScan) -> Double {
     }
   } else {
     let shift = self.exponent - MAX_EXPONENT_FAST_PATH
-    let mantissa = match
-      checked_mul(self.mantissa, int_pow10_table[shift.to_int()]) {
-      Some(m) => m
-      None => return @double.not_a_number
+    guard checked_mul(self.mantissa, int_pow10_table[shift.to_int()])
+      is Some(mantissa) else {
+      return @double.not_a_number
     }
     if mantissa > MAX_MANTISSA_FAST_PATH {
       return @double.not_a_number

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -129,10 +129,9 @@ fn Number::try_fast_path(self : Number) -> Double? {
     } else {
       // disguised fast path
       let shift = self.exponent - max_exponent_fast_path
-      let mantissa = match
-        checked_mul(self.mantissa, int_pow10[shift.to_int()]) {
-        Some(m) => m
-        None => return None
+      guard checked_mul(self.mantissa, int_pow10[shift.to_int()])
+        is Some(mantissa) else {
+        return None
       }
       if mantissa > max_mantissa_fast_path {
         return None

--- a/strconv/number.mbt
+++ b/strconv/number.mbt
@@ -118,9 +118,8 @@ fn parse_number(s : StringView) -> Number? raise StrConvError {
   // handle scientific format
   let exp_number = 0L
   if s is ['e' | 'E', .. rest] {
-    let (new_s, exp_number) = match parse_scientific(rest) {
-      Some(res) => res
-      None => return None
+    guard parse_scientific(rest) is Some((new_s, exp_number)) else {
+      return None
     }
     s = new_s
     exponent += exp_number


### PR DESCRIPTION
Replaces **28 two-arm `Option` matches** with whichever form actually fits each one. 19 files, **47 insertions / 115 deletions**.

## The moongrep

```console
$ moongrep scan --pattern 'match $(x:exp) {
    Some($(v:id)) => $(v:id)
    None => $(d:exp)
  }'                                            # 27  (+4 with the arms reversed)

$ moongrep scan --pattern 'match $(x:exp) {
    Some($(v:id)) => Some($(f:exp))
    None => None
  }'                                            # 17
```

The interesting part is that **neither pattern maps onto a single rewrite.** The first one's 27 hits split three ways depending on what the `None` arm actually *does* — which the shape alone cannot tell you.

## `None` diverges → `guard` (8 applied)

```diff
-  let env_name = match arg.env {
-    Some(value) => value
-    None => continue
-  }
-  let value = match env.get(env_name) {
-    Some(v) => v
-    None => continue
-  }
+  guard arg.env is Some(env_name) else { continue }
+  guard env.get(env_name) is Some(value) else { continue }
```

Unlike the tail-position-only rewrite in #3946, these are **unconditionally safe**: the `else` branch diverges, so there is no fall-through path whose semantics could change. One site destructures a tuple, which `guard parse_scientific(rest) is Some((new_s, exp_number))` handles fine.

## Literal/identifier default → `unwrap_or` (6 applied)

## Left alone (13) — the eager-evaluation trap

`unwrap_or` takes its default **as an argument**, so it is evaluated eagerly; the `None` arm is lazy. Breaking down the 13:

| shape | count | example |
| --- | --- | --- |
| multi-statement block | 5 | `sorted_map/map.mbt:150` `get_or_init` |
| call | 4 | `bigint/bigint_js.mbt:48` `syntax_err()` |
| index expression | 2 | `argparse/parser_lookup.mbt:110,116` `parts[0]` |
| whole function body | 2 | `builtin/option.mbt:95` |

The `parts[0]` pair is subtle — the index is currently only evaluated on the `None` path; `unwrap_or(parts[0])` would evaluate it on every call including `Some`.

The most dangerous single site is **`builtin/option.mbt:39`, `fn unwrap`**, whose `None` arm is `panic()`. `self.unwrap_or(panic())` would panic **unconditionally, on every call** — a pattern match alone cannot distinguish it from a harmless default.

`unwrap_or_else` would preserve laziness for the block cases, but costs a closure for no clarity gain, so I left them.

## `map` (14 of 17 applied)

- **`builtin/option.mbt:131` is `Option::map` itself** and would self-recurse. This is the *second* time this trap has appeared — same as the `is_empty` bodies in #3949. Any rewrite of the form "replace this expression with the helper that wraps it" matches the helper's own definition.
- `builtin/iterator.mbt:363` looks identical by enclosing-function name (`fn map`) but is `Iter::map` calling `Option::map` — a different function, so it converts safely. Name-based filtering alone would have wrongly excluded it.
- `split_once` / `rev_split_once` convert correctly but return tuples, and `moon fmt` then splits them into a three-line chain with a block body that reads worse than the `match`. Reverted on style — happy to include if you disagree.

## Testing

`moon check --target all` clean; `moon info` reports no `.mbti` change.

| target | tests |
| --- | --- |
| wasm-gc | 6873 passed, 0 failed |
| js | 6829 passed, 0 failed |
| native | 6784 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)