### PR TITLE
fix(array): respect capacity when growing

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -395,33 +395,6 @@ pub impl[T] Add for Array[T] with fn add(self, other) {
 }
 
 ///|
-/// Appends all elements from one array to the end of another array. The elements
-/// are added in-place, modifying the original array.
-///
-/// Parameters:
-///
-/// * `self` : The array to append to.
-/// * `other` : The array whose elements will be appended.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let v1 = [1, 2, 3]
-///   let v2 : ReadOnlyArray[Int] = [4, 5, 6]
-///   v1.append(v2)
-///   debug_inspect(v1, content="[1, 2, 3, 4, 5, 6]")
-///   let v1 = [1, 2, 3]
-///   let v2 : ReadOnlyArray[Int] = []
-///   v1.append(v2)
-///   debug_inspect(v1, content="[1, 2, 3]")
-/// }
-/// ```
-pub fn[T] Array::append(self : Array[T], other : ArrayView[T]) -> Unit {
-  other.blit_to(self, dst_offset=self.length())
-}
-
-///|
 /// Iterates through each element of the array in order, applying the given
 /// function to each element.
 ///

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -108,106 +108,6 @@ pub fn[A] Array::unsafe_blit_fixed(
 }
 
 ///|
-/// Copies elements from one array to another array, with support for growing the
-/// destination array if needed. The arrays may overlap, in which case the copy
-/// is performed in a way that preserves the data.
-///
-/// Parameters:
-///
-/// * `self` : The array to copy elements from.
-/// * `dst` : The array to copy elements to. Will be automatically grown
-/// if needed to accommodate the copied elements.
-/// * `len` : The number of elements to copy.
-/// * `src_offset` : Starting index in the source array. Defaults to 0.
-/// * `dst_offset` : Starting index in the destination array. Defaults to
-/// 0.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let src = [1, 2, 3, 4, 5]
-///   let dst = [0, 0]
-///   src[:3].blit_to(dst, dst_offset=1)
-///   @debug.debug_inspect(dst, content="[0, 1, 2, 3]")
-/// }
-/// ```
-///
-/// Panics if:
-///
-/// * `len` is negative
-/// * `src_offset` is negative
-/// * `dst_offset` is negative
-/// * `dst_offset` exceeds the length of destination array
-/// * `src_offset + len` exceeds the length of source array
-// TODO: make len optional and deprecate it
-#label_migration(src_offset, fill=false, msg="Use ArrayView::blit_to instead")
-#label_migration(len, fill=false, msg="Use ArrayView::blit_to instead")
-pub fn[A] Array::blit_to(
-  self : Array[A],
-  dst : Array[A],
-  len? : Int = self.length(),
-  src_offset? : Int = 0,
-  dst_offset? : Int = 0,
-) -> Unit {
-  guard len >= 0 &&
-    dst_offset >= 0 &&
-    src_offset >= 0 &&
-    dst_offset <= dst.length() &&
-    src_offset + len <= self.length()
-  if dst_offset + len > dst.length() {
-    dst.unsafe_grow_to_length(dst_offset + len)
-  }
-  Array::unsafe_blit(dst, dst_offset, self, src_offset, len)
-}
-
-///|
-/// Copies all elements from an array view to a destination array, with support
-/// for growing the destination array if needed.
-///
-/// Parameters:
-///
-/// * `self` : The array view to copy elements from.
-/// * `dst` : The array to copy elements to. Will be automatically grown
-/// if needed to accommodate the copied elements.
-/// * `dst_offset` : Starting index in the destination array. Defaults to 0.
-///
-/// Example:
-///
-/// ```mbt check
-/// test {
-///   let src = [1, 2, 3, 4, 5]
-///   let view = src[1:4] // view = [2, 3, 4]
-///   let dst = [0, 0]
-///   view.blit_to(dst, dst_offset=1)
-///   @debug.debug_inspect(dst, content="[0, 2, 3, 4]")
-/// }
-/// ```
-///
-/// Panics if:
-///
-/// * `dst_offset` is negative
-/// * `dst_offset` exceeds the length of destination array
-pub fn[A] ArrayView::blit_to(
-  self : ArrayView[A],
-  dst : Array[A],
-  dst_offset? : Int = 0,
-) -> Unit {
-  let len = self.len()
-  guard dst_offset >= 0 && dst_offset <= dst.length()
-  if dst_offset + len > dst.length() {
-    dst.unsafe_grow_to_length(dst_offset + len)
-  }
-  UninitializedArray::unsafe_blit(
-    dst.buffer(),
-    dst_offset,
-    self.buf(),
-    self.start(),
-    len,
-  )
-}
-
-///|
 test "Array::blit_to/basic" {
   let src = [1, 2, 3, 4, 5]
   let dst = [0, 0, 0, 0, 0]
@@ -233,6 +133,18 @@ test "Array::blit_to/grow_destination" {
   let dst = [0, 0]
   src[0:3].blit_to(dst, dst_offset=1)
   assert_true(dst == [0, 1, 2, 3])
+}
+
+///|
+#warnings("-deprecated")
+test "Array::blit_to/grow_destination_directly" {
+  let src = [1, 2, 3, 4]
+  let dst = [0]
+  Array::blit_to(src, dst, len=2, src_offset=1, dst_offset=1)
+  assert_true(dst == [0, 2, 3])
+  let self = [1, 2, 3]
+  Array::blit_to(self, self, len=2, dst_offset=3)
+  assert_true(self == [1, 2, 3, 1, 2])
 }
 
 ///|
@@ -287,6 +199,14 @@ test "panic Array::blit_to/boundary_cases4" {
   let dst = [0, 0, 0, 0, 0]
   // dst offset exceeding dst length
   ignore(src[0:5].blit_to(dst, dst_offset=6))
+}
+
+///|
+#warnings("-deprecated")
+test "panic Array::blit_to/reject_overflowed_source_range" {
+  let src = [1]
+  let dst = [0]
+  Array::blit_to(src, dst, len=0x7fffffff, src_offset=1)
 }
 
 ///|

--- a/builtin/array_make_blit_bench_test.mbt
+++ b/builtin/array_make_blit_bench_test.mbt
@@ -57,6 +57,56 @@ test "bench ArrayView::add Ref n=500000+500000" (it : @bench.T) {
 }
 
 ///|
+test "bench Array::blit_to Ref n=1000000 overwrite" (it : @bench.T) {
+  let src = make_blit_ref_array(make_blit_ref_bench_size)
+  let dst = Array::make(make_blit_ref_bench_size, "dst")
+  it.bench(fn() {
+    src.blit_to(dst)
+    it.keep(dst)
+  })
+}
+
+///|
+test "bench Array::blit_to Ref n=1000000 grow" (it : @bench.T) {
+  let src = make_blit_ref_array(make_blit_ref_bench_size)
+  it.bench(fn() {
+    let dst : Array[String] = []
+    src.blit_to(dst)
+    it.keep(dst)
+  })
+}
+
+///|
+test "bench ArrayView::blit_to Ref n=1000000 overwrite" (it : @bench.T) {
+  let src = make_blit_ref_array(make_blit_ref_bench_size)[:]
+  let dst = Array::make(make_blit_ref_bench_size, "dst")
+  it.bench(fn() {
+    src.blit_to(dst)
+    it.keep(dst)
+  })
+}
+
+///|
+test "bench ArrayView::blit_to Ref n=1000000 grow" (it : @bench.T) {
+  let src = make_blit_ref_array(make_blit_ref_bench_size)[:]
+  it.bench(fn() {
+    let dst : Array[String] = []
+    src.blit_to(dst)
+    it.keep(dst)
+  })
+}
+
+///|
+test "bench Array::append Ref n=1000000 grow" (it : @bench.T) {
+  let src = make_blit_ref_array(make_blit_ref_bench_size)[:]
+  it.bench(fn() {
+    let dst : Array[String] = []
+    dst.append(src)
+    it.keep(dst)
+  })
+}
+
+///|
 test "bench Array::push Ref n=1000000 resize" (it : @bench.T) {
   it.bench(fn() {
     let data : Array[String] = []

--- a/builtin/array_nonjs_test.mbt
+++ b/builtin/array_nonjs_test.mbt
@@ -19,6 +19,34 @@ test "array_capacity" {
 }
 
 ///|
+test "array_append_reuses_capacity" {
+  let arr = Array::new(capacity=4)
+  arr.push(1)
+  arr.append([2, 3])
+  inspect(arr.capacity(), content="4")
+  debug_inspect(arr, content="[1, 2, 3]")
+}
+
+///|
+test "array_append_grows_geometrically" {
+  let arr = Array::new(capacity=4)
+  arr.append([1, 2, 3, 4, 5])
+  inspect(arr.capacity(), content="8")
+  debug_inspect(arr, content="[1, 2, 3, 4, 5]")
+}
+
+///|
+test "array_blit_to_reuses_and_grows_capacity" {
+  let dst = Array::new(capacity=4)
+  dst.push(0)
+  [1, 2][:].blit_to(dst, dst_offset=1)
+  inspect(dst.capacity(), content="4")
+  [3, 4][:].blit_to(dst, dst_offset=3)
+  inspect(dst.capacity(), content="8")
+  debug_inspect(dst, content="[0, 1, 2, 3, 4]")
+}
+
+///|
 test "array_retain" {
   let arr = [1, 2, 3, 4, 5]
   @test.assert_eq(arr.capacity(), 5)

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -51,6 +51,19 @@ extern "js" fn JSArray::push(self : JSArray, value : JSValue) -> Unit =
   #| (arr, val) => { arr.push(val); }
 
 ///|
+extern "js" fn JSArray::append_view(
+  self : JSArray,
+  src : JSArray,
+  src_offset : Int,
+  len : Int,
+) -> Unit =
+  #| (dst, src, src_offset, len) => {
+  #|   for (let i = 0; i < len; i++) {
+  #|     dst.push(src[src_offset + i]);
+  #|   }
+  #| }
+
+///|
 extern "js" fn JSArray::pop(self : JSArray) -> JSValue =
   #| (arr) => arr.pop()
 
@@ -249,6 +262,91 @@ pub fn[T] Array::push(self : Array[T], value : T) -> Unit {
 }
 
 ///|
+/// Appends all elements from one array to the end of another array. The elements
+/// are added in-place, modifying the original array.
+///
+/// Parameters:
+///
+/// * `self` : The array to append to.
+/// * `other` : The array whose elements will be appended.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v1 = [1, 2, 3]
+///   let v2 : ReadOnlyArray[Int] = [4, 5, 6]
+///   v1.append(v2)
+///   debug_inspect(v1, content="[1, 2, 3, 4, 5, 6]")
+///   let v1 = [1, 2, 3]
+///   let v2 : ReadOnlyArray[Int] = []
+///   v1.append(v2)
+///   debug_inspect(v1, content="[1, 2, 3]")
+/// }
+/// ```
+pub fn[T] Array::append(self : Array[T], other : ArrayView[T]) -> Unit {
+  let old_len = self.length()
+  let append_len = other.len()
+  guard old_len + append_len >= old_len
+  JSArray::ofAnyArray(self).append_view(
+    JSArray::ofAnyFixedArray(other.buf().0),
+    other.start(),
+    append_len,
+  )
+}
+
+///|
+/// JavaScript arrays use their native length as the writable extent, so extend
+/// it before blitting into the new range.
+#label_migration(src_offset, fill=false, msg="Use ArrayView::blit_to instead")
+#label_migration(len, fill=false, msg="Use ArrayView::blit_to instead")
+pub fn[A] Array::blit_to(
+  self : Array[A],
+  dst : Array[A],
+  len? : Int = self.length(),
+  src_offset? : Int = 0,
+  dst_offset? : Int = 0,
+) -> Unit {
+  let old_len = dst.length()
+  guard len >= 0 &&
+    dst_offset >= 0 &&
+    src_offset >= 0 &&
+    dst_offset <= old_len &&
+    len <= self.length() - src_offset
+  let new_len = dst_offset + len
+  guard new_len >= 0
+  if new_len > old_len {
+    JSArray::ofAnyArray(dst).set_length(new_len)
+  }
+  Array::unsafe_blit(dst, dst_offset, self, src_offset, len)
+}
+
+///|
+/// JavaScript arrays use their native length as the writable extent, so extend
+/// it before blitting into the new range.
+pub fn[A] ArrayView::blit_to(
+  self : ArrayView[A],
+  dst : Array[A],
+  dst_offset? : Int = 0,
+) -> Unit {
+  let len = self.len()
+  let old_len = dst.length()
+  guard dst_offset >= 0 && dst_offset <= old_len
+  let new_len = dst_offset + len
+  guard new_len >= 0
+  if new_len > old_len {
+    JSArray::ofAnyArray(dst).set_length(new_len)
+  }
+  UninitializedArray::unsafe_blit(
+    dst.buffer(),
+    dst_offset,
+    self.buf(),
+    self.start(),
+    len,
+  )
+}
+
+///|
 /// Removes the last element from an array and returns it, or `None` if it is empty.
 ///
 /// # Example
@@ -352,18 +450,6 @@ pub fn[T] Array::insert(self : Array[T], index : Int, value : T) -> Unit {
     )
   }
   let _ = JSArray::ofAnyArray(self).splice1(index, 0, JSValue::ofAny(value))
-}
-
-///|
-/// Resize the array in-place so that `len` is equal to `new_len`.
-///
-/// If `new_len` is greater than `len`, the array will be extended by the
-/// difference, and the values in the new slots are left uninitilized.
-///  If `new_len` is less than `len`, it will panic
-///
-fn[T] Array::unsafe_grow_to_length(self : Array[T], new_len : Int) -> Unit {
-  guard new_len >= self.length()
-  JSArray::ofAnyArray(self).set_length(new_len)
 }
 
 ///|

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -186,6 +186,51 @@ fn[T] Array::buffer(self : Array[T]) -> UninitializedArray[T] {
 }
 
 ///|
+/// Compute the next capacity without allocating. Since arrays never shrink
+/// while growing, `required < len` means the required-size calculation
+/// overflowed.
+#inline
+fn array_growth_capacity(current : Int, len : Int, required : Int) -> Int {
+  if required < len {
+    abort("Array capacity overflow")
+  }
+  let start = if current == 0 { 8 } else { current }
+  let enough_space = for space = start; space < required; {
+    let next = space * 2
+    if next <= space {
+      break required
+    }
+    continue next
+  } nobreak {
+    space
+  }
+  enough_space
+}
+
+///|
+test "Array growth capacity doubles while representable" {
+  inspect(array_growth_capacity(8, 8, 9), content="16")
+  inspect(array_growth_capacity(8, 8, 33), content="64")
+}
+
+///|
+test "Array growth capacity falls back to the exact requirement" {
+  inspect(
+    array_growth_capacity(0x40000000, 0x40000000, 0x40000001),
+    content="1073741825",
+  )
+  inspect(
+    array_growth_capacity(0x20000000, 0x20000000, 0x40000001),
+    content="1073741825",
+  )
+}
+
+///|
+test "panic Array growth rejects a wrapped required size" {
+  ignore(array_growth_capacity(16, 16, -1))
+}
+
+///|
 fn[T] Array::resize_buffer(self : Array[T], new_capacity : Int) -> Unit {
   let old_buf = self.buf
   let old_cap = old_buf.0.length()
@@ -241,10 +286,12 @@ test "Array::resize_buffer" {
 }
 
 ///|
-/// Reallocate the array with a new capacity.
-fn[T] Array::realloc(self : Array[T]) -> Unit {
-  let old_cap = self.length()
-  let new_cap = if old_cap == 0 { 8 } else { old_cap * 2 }
+/// Reallocate the array to fit `required`. Callers keep the capacity check on
+/// their fast path and only call this when allocation is necessary.
+#inline(never)
+fn[T] Array::realloc(self : Array[T], required : Int) -> Unit {
+  let old_cap = self.capacity()
+  let new_cap = array_growth_capacity(old_cap, self.length(), required)
   self.resize_buffer(new_cap)
 }
 
@@ -304,11 +351,171 @@ pub fn[T] Array::shrink_to_fit(self : Array[T]) -> Unit {
 /// ```
 pub fn[T] Array::push(self : Array[T], value : T) -> Unit {
   if self.length() == self.buffer().0.length() {
-    self.realloc()
+    self.realloc(self.length() + 1)
   }
   let length = self.length()
   self.unsafe_set(length, value)
   self.len = length + 1
+}
+
+///|
+/// Appends all elements from one array to the end of another array. The elements
+/// are added in-place, modifying the original array.
+///
+/// Parameters:
+///
+/// * `self` : The array to append to.
+/// * `other` : The array whose elements will be appended.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let v1 = [1, 2, 3]
+///   let v2 : ReadOnlyArray[Int] = [4, 5, 6]
+///   v1.append(v2)
+///   debug_inspect(v1, content="[1, 2, 3, 4, 5, 6]")
+///   let v1 = [1, 2, 3]
+///   let v2 : ReadOnlyArray[Int] = []
+///   v1.append(v2)
+///   debug_inspect(v1, content="[1, 2, 3]")
+/// }
+/// ```
+pub fn[T] Array::append(self : Array[T], other : ArrayView[T]) -> Unit {
+  let src = other.buf()
+  let src_offset = other.start()
+  let append_len = other.len()
+  let old_len = self.len
+  let new_len = old_len + append_len
+  guard new_len >= old_len
+  if new_len > self.buf.0.length() {
+    self.realloc(new_len)
+  }
+  self.len = new_len
+  UninitializedArray::unsafe_blit(
+    self.buf,
+    old_len,
+    src,
+    src_offset,
+    append_len,
+  )
+}
+
+///|
+/// Copies elements from one array to another array, with support for growing the
+/// destination array if needed. The arrays may overlap, in which case the copy
+/// is performed in a way that preserves the data.
+///
+/// Parameters:
+///
+/// * `self` : The array to copy elements from.
+/// * `dst` : The array to copy elements to. Will be automatically grown
+/// if needed to accommodate the copied elements.
+/// * `len` : The number of elements to copy.
+/// * `src_offset` : Starting index in the source array. Defaults to 0.
+/// * `dst_offset` : Starting index in the destination array. Defaults to
+/// 0.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let src = [1, 2, 3, 4, 5]
+///   let dst = [0, 0]
+///   src[:3].blit_to(dst, dst_offset=1)
+///   @debug.debug_inspect(dst, content="[0, 1, 2, 3]")
+/// }
+/// ```
+///
+/// Panics if:
+///
+/// * `len` is negative
+/// * `src_offset` is negative
+/// * `dst_offset` is negative
+/// * `dst_offset` exceeds the length of destination array
+/// * `src_offset + len` exceeds the length of source array
+#label_migration(src_offset, fill=false, msg="Use ArrayView::blit_to instead")
+#label_migration(len, fill=false, msg="Use ArrayView::blit_to instead")
+pub fn[A] Array::blit_to(
+  self : Array[A],
+  dst : Array[A],
+  len? : Int = self.length(),
+  src_offset? : Int = 0,
+  dst_offset? : Int = 0,
+) -> Unit {
+  let old_len = dst.length()
+  guard len >= 0 &&
+    dst_offset >= 0 &&
+    src_offset >= 0 &&
+    dst_offset <= old_len &&
+    len <= self.length() - src_offset
+  let new_len = dst_offset + len
+  guard new_len >= 0
+  if new_len > dst.capacity() {
+    dst.realloc(new_len)
+  }
+  UninitializedArray::unsafe_blit(
+    dst.buffer(),
+    dst_offset,
+    self.buffer(),
+    src_offset,
+    len,
+  )
+  if new_len > old_len {
+    dst.len = new_len
+  }
+}
+
+///|
+/// Copies all elements from an array view to a destination array, with support
+/// for growing the destination array if needed.
+///
+/// Parameters:
+///
+/// * `self` : The array view to copy elements from.
+/// * `dst` : The array to copy elements to. Will be automatically grown
+/// if needed to accommodate the copied elements.
+/// * `dst_offset` : Starting index in the destination array. Defaults to 0.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let src = [1, 2, 3, 4, 5]
+///   let view = src[1:4] // view = [2, 3, 4]
+///   let dst = [0, 0]
+///   view.blit_to(dst, dst_offset=1)
+///   @debug.debug_inspect(dst, content="[0, 2, 3, 4]")
+/// }
+/// ```
+///
+/// Panics if:
+///
+/// * `dst_offset` is negative
+/// * `dst_offset` exceeds the length of destination array
+pub fn[A] ArrayView::blit_to(
+  self : ArrayView[A],
+  dst : Array[A],
+  dst_offset? : Int = 0,
+) -> Unit {
+  let len = self.len()
+  let old_len = dst.length()
+  guard dst_offset >= 0 && dst_offset <= old_len
+  let new_len = dst_offset + len
+  guard new_len >= 0
+  if new_len > dst.capacity() {
+    dst.realloc(new_len)
+  }
+  UninitializedArray::unsafe_blit(
+    dst.buffer(),
+    dst_offset,
+    self.buf(),
+    self.start(),
+    len,
+  )
+  if new_len > old_len {
+    dst.len = new_len
+  }
 }
 
 ///|
@@ -463,7 +670,7 @@ pub fn[T] Array::insert(self : Array[T], index : Int, value : T) -> Unit {
     )
   }
   if self.length() == self.buffer().0.length() {
-    self.realloc()
+    self.realloc(self.length() + 1)
   }
   UninitializedArray::unsafe_blit(
     self.buffer(),
@@ -475,24 +682,6 @@ pub fn[T] Array::insert(self : Array[T], index : Int, value : T) -> Unit {
   let length = self.length()
   self.unsafe_set(index, value)
   self.len = length + 1
-}
-
-///|
-/// Resize the array in-place so that `len` is equal to `new_len`.
-///
-/// If `new_len` is greater than `len`, the array will be extended by the
-/// difference, and the values in the new slots are left uninitialized.
-///  If `new_len` is less than `len`, it will panic
-///
-fn[T] Array::unsafe_grow_to_length(self : Array[T], new_len : Int) -> Unit {
-  guard new_len >= self.length()
-  let new_buf = UninitializedArray::make_and_blit(
-    self.buf,
-    allocate_len=new_len,
-    len=self.len,
-  )
-  self.len = new_len
-  self.buf = new_buf
 }
 
 ///|


### PR DESCRIPTION
## Why

`Array::append` and the internal grow path decide whether to reallocate from the logical length rather than the backing capacity. This discards reserved capacity and can turn repeated chunk appends into quadratic copying. `realloc` also derives its next capacity from length, which can shrink a partially filled reserved buffer.

The shared blit growth path similarly conflates preparing capacity with changing logical length. On non-JS backends, the destination length should only include elements after they have been copied.

## What changed

- make non-JS growth capacity-aware and use overflow-safe geometric expansion
- derive `realloc` from the backing capacity
- provide target-specific `Array::append` implementations so native can use backing capacity while JS pushes the selected view directly into the JavaScript array
- split `Array::blit_to` and `ArrayView::blit_to` by target
  - non-JS reallocates only when capacity is insufficient, copies into the backing buffer, and then commits the new length
  - JS extends the native array length before its bounds-checked blit
- remove the conflated `unsafe_grow_to_length` helper
- add regression coverage for capacity reuse, geometric growth, direct and overlapping blits, and overflow

## Why this is correct

Length remains the initialized element count, while capacity controls whether allocation is required. Non-JS mutation paths only reallocate when the requested length exceeds capacity. Blits then copy into the prepared backing storage before publishing the new logical length.

JavaScript arrays use their native length as both logical length and writable extent. The JS-specific blit therefore extends that length before invoking the generated bounds-checked copy, without imposing those representation semantics on other backends.

The JS append path checks the final length for overflow before copying, captures the source offset and length before mutation, and therefore also handles full and partial self-appends. It uses `push` rather than repeatedly extending `.length`: benchmarks found only a modest bulk-copy advantage for pre-sizing on V8, but severe nonlinear slowdowns from repeated length extension on JavaScriptCore.

The change is limited to Array growth, append, and blit internals plus regression tests; the public interface is unchanged.
