### PR TITLE
fix: convert intended-panic guards to guard! (warning 0087)

### DIFF
--- a/argparse/README.mbt.md
+++ b/argparse/README.mbt.md
@@ -128,7 +128,7 @@ test "global count flag success snapshot" {
       #|{ "verbose": 2 }
     ),
   )
-  guard parsed.subcommand is Some(("run", child))
+  guard! parsed.subcommand is Some(("run", child))
   @debug.debug_inspect(
     child.flag_counts,
     content=(

--- a/argparse/parser_validate.mbt
+++ b/argparse/parser_validate.mbt
@@ -281,7 +281,7 @@ fn validate_flag_arg(
   ctx : ValidationCtx,
 ) -> Unit raise ArgBuildError {
   validate_named_option_arg(arg)
-  guard arg.info is FlagInfo(action~, negatable~, ..)
+  guard! arg.info is FlagInfo(action~, negatable~, ..)
   if action is (Help | Version) {
     guard !negatable else {
       raise Unsupported("help/version actions do not support negatable")
@@ -323,7 +323,7 @@ fn validate_positional_arg(
 
 ///|
 fn validate_named_option_arg(arg : Arg) -> Unit raise ArgBuildError {
-  guard arg.info
+  guard! arg.info
     is (FlagInfo(long~, short~, ..) | OptionInfo(long~, short~, ..))
   guard long is Some(_) || short is Some(_) || arg.env is Some(_) else {
     raise Unsupported("flag/option args require short/long/env")

--- a/bench/stats.mbt
+++ b/bench/stats.mbt
@@ -159,8 +159,8 @@ fn iqr(quartiles~ : (Double, Double, Double)) -> Double {
 
 ///|
 fn percentile(sorted_data~ : Array[Double], pct~ : Double) -> Double {
-  guard !sorted_data.is_empty()
-  guard pct >= 0.0 && pct <= 100.0
+  guard! !sorted_data.is_empty()
+  guard! pct >= 0.0 && pct <= 100.0
   if sorted_data.length() == 1 {
     return sorted_data[0]
   }

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1403,7 +1403,7 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
       result
     }
     Some(modulus) => {
-      guard !(modulus.is_zero() || modulus.sign == Negative)
+      guard! !(modulus.is_zero() || modulus.sign == Negative)
       let mut result = 1N % modulus
       let mut base = (self % modulus + modulus) % modulus
       let mut exp = exp

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -182,7 +182,7 @@ pub fn[T] Array::unsafe_get(self : Array[T], idx : Int) -> T {
 #alias("_[_]")
 pub fn[T] Array::at(self : Array[T], index : Int) -> T {
   let len = self.length()
-  guard index >= 0 && index < len
+  guard! index >= 0 && index < len
   self.buffer().unsafe_get(index)
 }
 
@@ -259,7 +259,7 @@ pub fn[T] Array::unsafe_set(self : Array[T], idx : Int, val : T) -> Unit {
 #alias("_[_]=_")
 pub fn[T] Array::set(self : Array[T], index : Int, value : T) -> Unit {
   let len = self.length()
-  guard index >= 0 && index < len
+  guard! index >= 0 && index < len
   self.buffer().unsafe_set(index, value)
 }
 
@@ -1534,7 +1534,7 @@ pub fn[T] Array::extract_if(
 /// }
 /// ```
 pub fn[T] Array::chunks(self : Array[T], size : Int) -> Array[ArrayView[T]] {
-  guard size > 0
+  guard! size > 0
   let len = self.length()
   if len == 0 {
     return []
@@ -1637,7 +1637,7 @@ pub fn[T] Array::chunk_by(
 /// }
 /// ```
 pub fn[T] Array::windows(self : Array[T], size : Int) -> Array[ArrayView[T]] {
-  guard size > 0
+  guard! size > 0
   let len = self.length() - size + 1
   if len < 1 {
     return []

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -153,7 +153,7 @@ fn[T] Array::unsafe_resize_with_default(
   value : T,
 ) -> Unit {
   let len = self.length()
-  guard new_len >= len
+  guard! new_len >= len
   JSArray::ofAnyArray(self).set_length(new_len)
   for i in len..<new_len {
     self.unsafe_set(i, value)
@@ -287,7 +287,7 @@ pub fn[T] Array::push(self : Array[T], value : T) -> Unit {
 pub fn[T] Array::append(self : Array[T], other : ArrayView[T]) -> Unit {
   let old_len = self.length()
   let append_len = other.len()
-  guard old_len + append_len >= old_len
+  guard! old_len + append_len >= old_len
   JSArray::ofAnyArray(self).append_view(
     JSArray::ofAnyFixedArray(other.buf().0),
     other.start(),
@@ -308,13 +308,13 @@ pub fn[A] Array::blit_to(
   dst_offset? : Int = 0,
 ) -> Unit {
   let old_len = dst.length()
-  guard len >= 0 &&
+  guard! len >= 0 &&
     dst_offset >= 0 &&
     src_offset >= 0 &&
     dst_offset <= old_len &&
     len <= self.length() - src_offset
   let new_len = dst_offset + len
-  guard new_len >= 0
+  guard! new_len >= 0
   if new_len > old_len {
     JSArray::ofAnyArray(dst).set_length(new_len)
   }
@@ -331,9 +331,9 @@ pub fn[A] ArrayView::blit_to(
 ) -> Unit {
   let len = self.len()
   let old_len = dst.length()
-  guard dst_offset >= 0 && dst_offset <= old_len
+  guard! dst_offset >= 0 && dst_offset <= old_len
   let new_len = dst_offset + len
-  guard new_len >= 0
+  guard! new_len >= 0
   if new_len > old_len {
     JSArray::ofAnyArray(dst).set_length(new_len)
   }
@@ -502,11 +502,11 @@ pub fn[A] Array::fill(
 ) -> Unit {
   let array_length = self.length()
   guard array_length > 0 else { return }
-  guard start >= 0 && start < array_length
+  guard! start >= 0 && start < array_length
   let end = match end {
     None => array_length
     Some(e) => {
-      guard e >= 0 && e <= array_length
+      guard! e >= 0 && e <= array_length
       e
     }
   }

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -71,7 +71,7 @@ fn[T] Array::unsafe_resize_with_default(
   value : T,
 ) -> Unit {
   let len = self.length()
-  guard new_len >= len
+  guard! new_len >= len
   if new_len <= self.capacity() {
     self.buf.unchecked_fill(len, value, new_len - len)
   } else {
@@ -166,7 +166,7 @@ pub fn[T] Array::length(self : Array[T]) -> Int {
 /// TODO: this can be optimized by using the intrinsic to null out the range
 fn[T] Array::unsafe_truncate_to_length(self : Array[T], new_len : Int) -> Unit {
   let len = self.length()
-  guard new_len <= len
+  guard! new_len <= len
   for i in new_len..<len {
     self.buf.set_null(i)
   }
@@ -387,7 +387,7 @@ pub fn[T] Array::append(self : Array[T], other : ArrayView[T]) -> Unit {
   let append_len = other.len()
   let old_len = self.len
   let new_len = old_len + append_len
-  guard new_len >= old_len
+  guard! new_len >= old_len
   if new_len > self.buf.0.length() {
     self.realloc(new_len)
   }
@@ -444,13 +444,13 @@ pub fn[A] Array::blit_to(
   dst_offset? : Int = 0,
 ) -> Unit {
   let old_len = dst.length()
-  guard len >= 0 &&
+  guard! len >= 0 &&
     dst_offset >= 0 &&
     src_offset >= 0 &&
     dst_offset <= old_len &&
     len <= self.length() - src_offset
   let new_len = dst_offset + len
-  guard new_len >= 0
+  guard! new_len >= 0
   if new_len > dst.capacity() {
     dst.realloc(new_len)
   }
@@ -500,9 +500,9 @@ pub fn[A] ArrayView::blit_to(
 ) -> Unit {
   let len = self.len()
   let old_len = dst.length()
-  guard dst_offset >= 0 && dst_offset <= old_len
+  guard! dst_offset >= 0 && dst_offset <= old_len
   let new_len = dst_offset + len
-  guard new_len >= 0
+  guard! new_len >= 0
   if new_len > dst.capacity() {
     dst.realloc(new_len)
   }
@@ -566,7 +566,7 @@ pub fn[T] Array::pop(self : Array[T]) -> T? {
 #alias(pop_exn, deprecated)
 pub fn[T] Array::unsafe_pop(self : Array[T]) -> T {
   let len = self.length()
-  guard len != 0
+  guard! len != 0
   let index = len - 1
   let v = self.unsafe_get(index)
   self.buf.set_null(index)
@@ -623,7 +623,7 @@ pub fn[T] Array::remove(self : Array[T], index : Int) -> T {
 /// }
 /// ```
 pub fn[T] Array::drain(self : Array[T], begin : Int, end : Int) -> Array[T] {
-  guard begin >= 0 && end <= self.length() && begin <= end
+  guard! begin >= 0 && end <= self.length() && begin <= end
   let num = end - begin
   let v = {
     buf: UninitializedArray::make_and_blit(
@@ -734,11 +734,11 @@ pub fn[A] Array::fill(
 ) -> Unit {
   let array_length = self.length()
   guard array_length > 0 else { return }
-  guard start >= 0 && start < array_length
+  guard! start >= 0 && start < array_length
   let length = match end {
     None => array_length
     Some(e) => {
-      guard e >= start && e <= array_length
+      guard! e >= start && e <= array_length
       e
     }
   }

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -587,7 +587,7 @@ pub fn[T] ArrayView::chunks(
   self : ArrayView[T],
   size : Int,
 ) -> Array[ArrayView[T]] {
-  guard size > 0
+  guard! size > 0
   let len = self.length()
   if len == 0 {
     return []
@@ -673,7 +673,7 @@ pub fn[T] ArrayView::windows(
   self : ArrayView[T],
   size : Int,
 ) -> Array[ArrayView[T]] {
-  guard size > 0
+  guard! size > 0
   let len = self.length() - size + 1
   if len < 1 {
     return []

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -1238,7 +1238,7 @@ test "ArrayView::strip_prefix on sliced view" {
 ///|
 test "ArrayView::strip_prefix shares backing" {
   let arr : FixedArray[Int] = [1, 2, 3, 4, 5]
-  guard arr[:].strip_prefix([1, 2]) is Some(rest)
+  guard! arr[:].strip_prefix([1, 2]) is Some(rest)
   arr[2] = 99
   debug_inspect(
     rest,

--- a/builtin/assert_debug.mbt
+++ b/builtin/assert_debug.mbt
@@ -26,5 +26,5 @@
 ///
 /// Panic in debug mode when `x()` returns `false`.
 pub fn debug_assert(x : () -> Bool) -> Unit {
-  guard x()
+  guard! x()
 }

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -81,7 +81,7 @@ pub fn Bytes::to_unchecked_string(
 ) -> String {
   let len = self.length()
   let length = if length is Some(l) { l } else { len - offset }
-  guard offset >= 0 && length >= 0 && offset + length <= len
+  guard! offset >= 0 && length >= 0 && offset + length <= len
   unsafe_sub_string(self, offset, length)
 }
 
@@ -135,7 +135,7 @@ pub fn FixedArray::blit_from_string(
   let e2 = str_offset + length - 1
   let len1 = self.length()
   let len2 = str.length()
-  guard length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
+  guard! length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
   let end_str_offset = str_offset + length
   for i = str_offset, j = bytes_offset; i < end_str_offset; i = i + 1, j = j + 2 {
     let c = str.unsafe_get(i).to_int().reinterpret_as_uint()
@@ -164,7 +164,7 @@ pub fn FixedArray::blit_from_bytes(
   let e2 = src_offset + length - 1
   let len1 = self.length()
   let len2 = src.length()
-  guard length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
+  guard! length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
   FixedArray::unsafe_blit(
     self,
     bytes_offset,
@@ -494,7 +494,7 @@ pub fn Bytes::from_fixedarray(arr : FixedArray[Byte], len? : Int) -> Bytes {
   let len = match len {
     None => arr.length()
     Some(x) => {
-      guard 0 <= x && x <= arr.length()
+      guard! 0 <= x && x <= arr.length()
       x
     }
   }
@@ -544,7 +544,7 @@ pub fn Bytes::to_fixedarray(self : Bytes, len? : Int) -> FixedArray[Byte] {
   let len = match len {
     None => self.length()
     Some(x) => {
-      guard 0 <= x && x <= self.length()
+      guard! 0 <= x && x <= self.length()
       x
     }
   }

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -340,7 +340,7 @@ pub fn BytesView::iter2(self : BytesView) -> Iter2[Int, Byte] {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x12\x34\x56\x78"
-///   guard bytes is [u32be(x), ..]
+///   guard! bytes is [u32be(x), ..]
 ///   inspect(x, content="305419896") // 0x12345678
 /// }
 /// ```
@@ -373,7 +373,7 @@ pub fn BytesView::to_uint_be(self : BytesView) -> UInt {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x01\x02\x03\x04"
-///   guard bytes is [u32le(x), ..]
+///   guard! bytes is [u32le(x), ..]
 ///   inspect(x, content="67305985") // 0x04030201
 /// }
 /// ```
@@ -408,7 +408,7 @@ pub fn BytesView::to_uint_le(self : BytesView) -> UInt {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x01\x23\x45\x67\x89\xAB\xCD\xEF"
-///   guard bytes is [u64be(x), ..]
+///   guard! bytes is [u64be(x), ..]
 ///   inspect(x, content="81985529216486895")
 /// }
 /// ```
@@ -448,7 +448,7 @@ pub fn BytesView::to_uint64_be(self : BytesView) -> UInt64 {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x01\x02\x03\x04\x05\x06\x07\x08"
-///   guard bytes is [u64le(x), ..]
+///   guard! bytes is [u64le(x), ..]
 ///   inspect(x, content="578437695752307201")
 /// }
 /// ```
@@ -475,14 +475,14 @@ pub fn BytesView::to_uint64_le(self : BytesView) -> UInt64 {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x00\x00\x00\x2A"
-///   guard bytes is [u32be(u), ..]
+///   guard! bytes is [u32be(u), ..]
 ///   inspect(u.reinterpret_as_int(), content="42")
 /// }
 /// ```
 #deprecated
 #doc(hidden)
 pub fn BytesView::to_int_be(self : BytesView) -> Int {
-  guard self is [u32be(u32), ..]
+  guard! self is [u32be(u32), ..]
   u32.reinterpret_as_int()
 }
 
@@ -496,14 +496,14 @@ pub fn BytesView::to_int_be(self : BytesView) -> Int {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x2A\x00\x00\x00"
-///   guard bytes is [u32le(u), ..]
+///   guard! bytes is [u32le(u), ..]
 ///   inspect(u.reinterpret_as_int(), content="42")
 /// }
 /// ```
 #deprecated
 #doc(hidden)
 pub fn BytesView::to_int_le(self : BytesView) -> Int {
-  guard self is [u32le(u32), ..]
+  guard! self is [u32le(u32), ..]
   u32.reinterpret_as_int()
 }
 
@@ -517,14 +517,14 @@ pub fn BytesView::to_int_le(self : BytesView) -> Int {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x00\x00\x00\x00\x00\x00\x00\x2A"
-///   guard bytes is [u64be(u), ..]
+///   guard! bytes is [u64be(u), ..]
 ///   inspect(u.reinterpret_as_int64(), content="42")
 /// }
 /// ```
 #deprecated
 #doc(hidden)
 pub fn BytesView::to_int64_be(self : BytesView) -> Int64 {
-  guard self is [u64be(u64), ..]
+  guard! self is [u64be(u64), ..]
   u64.reinterpret_as_int64()
 }
 
@@ -538,14 +538,14 @@ pub fn BytesView::to_int64_be(self : BytesView) -> Int64 {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x2A\x00\x00\x00\x00\x00\x00\x00"
-///   guard bytes is [u64le(u), ..]
+///   guard! bytes is [u64le(u), ..]
 ///   inspect(u.reinterpret_as_int64(), content="42")
 /// }
 /// ```
 #deprecated
 #doc(hidden)
 pub fn BytesView::to_int64_le(self : BytesView) -> Int64 {
-  guard self is [u64le(u64), ..]
+  guard! self is [u64le(u64), ..]
   u64.reinterpret_as_int64()
 }
 
@@ -568,14 +568,14 @@ pub fn BytesView::to_int64_le(self : BytesView) -> Int64 {
 /// test {
 ///   // Bytes representing 1.0 in IEEE 754 double-precision format (big-endian)
 ///   let bytes = b"\x3F\xF0\x00\x00\x00\x00\x00\x00"
-///   guard bytes is [u64be(bits), ..]
+///   guard! bytes is [u64be(bits), ..]
 ///   inspect(bits.reinterpret_as_double(), content="1")
 /// }
 /// ```
 #deprecated("Use bits pattern directly")
 #doc(hidden)
 pub fn BytesView::to_double_be(self : BytesView) -> Double {
-  guard self is [u64be(u64), ..]
+  guard! self is [u64be(u64), ..]
   u64.reinterpret_as_double()
 }
 
@@ -596,14 +596,14 @@ pub fn BytesView::to_double_be(self : BytesView) -> Double {
 /// ```mbt check
 /// test {
 ///   let bytes = b"\x00\x00\x00\x00\x00\x00\xF0\x3F" // represents 1.0 in little-endian
-///   guard bytes is [u64le(bits), ..]
+///   guard! bytes is [u64le(bits), ..]
 ///   inspect(bits.reinterpret_as_double(), content="1")
 /// }
 /// ```
 #deprecated("Use bits pattern directly")
 #doc(hidden)
 pub fn BytesView::to_double_le(self : BytesView) -> Double {
-  guard self is [u64le(u64), ..]
+  guard! self is [u64le(u64), ..]
   u64.reinterpret_as_double()
 }
 

--- a/builtin/bytesview_test.mbt
+++ b/builtin/bytesview_test.mbt
@@ -60,7 +60,7 @@ test "Bytes::get_view" {
   debug_inspect(bs.get_view(end=10), content="None")
   debug_inspect(bs.get_view(start=3, end=2), content="None")
   // Pattern-match composition.
-  guard bs.get_view(start=1) is Some([b'\x01', b'\x02', ..])
+  guard! bs.get_view(start=1) is Some([b'\x01', b'\x02', ..])
 }
 
 ///|
@@ -72,7 +72,7 @@ test "BytesView::get_view" {
   debug_inspect(view.get_view(start=10), content="None")
   debug_inspect(view.get_view(end=10), content="None")
   debug_inspect(view.get_view(start=3, end=2), content="None")
-  guard view.get_view(start=1) is Some([b'\x02', b'\x03', ..])
+  guard! view.get_view(start=1) is Some([b'\x02', b'\x03', ..])
 }
 
 ///|

--- a/builtin/double.mbt
+++ b/builtin/double.mbt
@@ -122,7 +122,7 @@ pub fn Double::max(self : Double, other : Double) -> Double {
 /// }
 /// ```
 pub fn Double::clamp(self : Double, min~ : Double, max~ : Double) -> Double {
-  guard min <= max
+  guard! min <= max
   if self < min {
     min
   } else if self > max {

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -121,11 +121,11 @@ pub fn[T] FixedArray::fill(
 ) -> Unit {
   let array_length = self.length()
   guard array_length > 0 else { return }
-  guard start >= 0 && start < array_length
+  guard! start >= 0 && start < array_length
   let length = match end {
     None => array_length - start
     Some(e) => {
-      guard e >= start && e <= array_length
+      guard! e >= start && e <= array_length
       e - start
     }
   }

--- a/builtin/int.mbt
+++ b/builtin/int.mbt
@@ -44,7 +44,7 @@ pub fn Int::Int(self : Int) -> Int = "%identity"
 /// }
 /// ```
 pub fn Int::next_power_of_two(self : Int) -> Int {
-  guard self >= 0
+  guard! self >= 0
   if self <= 1 {
     return 1
   }
@@ -106,7 +106,7 @@ pub fn Int::max(self : Int, other : Int) -> Int {
 /// }
 /// ```
 pub fn Int::clamp(self : Int, min~ : Int, max~ : Int) -> Int {
-  guard min <= max
+  guard! min <= max
   if self < min {
     min
   } else if self > max {

--- a/builtin/int64.mbt
+++ b/builtin/int64.mbt
@@ -94,7 +94,7 @@ pub fn Int64::max(self : Int64, other : Int64) -> Int64 {
 ///|
 /// Clamps the value `self` between `min` and `max`.
 pub fn Int64::clamp(self : Int64, min~ : Int64, max~ : Int64) -> Int64 {
-  guard min <= max
+  guard! min <= max
   if self < min {
     min
   } else if self > max {

--- a/builtin/json_test.mbt
+++ b/builtin/json_test.mbt
@@ -220,7 +220,7 @@ test "Bool::to_json true" {
 ///|
 test "to_hex_digit" {
   let str = "\n\r\b\t\u{0C}\u{00}"
-  guard Json::string(str) is String(escaped)
+  guard! Json::string(str) is String(escaped)
   @test.assert_eq(escaped, "\n\r\b\t\u{0c}\u{00}")
 }
 

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -253,11 +253,11 @@ pub fn[K : Hash + Eq, V] Map::get(self : Map[K, V], key : K) -> V? {
 pub fn[K : Hash + Eq, V] Map::at(self : Map[K, V], key : K) -> V {
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry)
+    guard! self.entries[idx] is Some(entry)
     if entry.hash == hash && entry.key == key {
       return entry.value
     }
-    guard i <= entry.psl
+    guard! i <= entry.psl
     continue i + 1, (idx + 1) & self.capacity_mask
   }
 }
@@ -839,7 +839,7 @@ pub fn[K, V, V2] Map::map(self : Map[K, V], f : (K, V) -> V2) -> Map[K, V2] {
   if self.size == 0 {
     return other
   }
-  guard self.entries[self.tail] is Some(last)
+  guard! self.entries[self.tail] is Some(last)
   for entry = last, idx = self.tail, next = (None : Entry[K, V2]?) {
     let { prev, psl, hash, key, value, .. } = entry
     let new_value = f(key, value)
@@ -872,7 +872,7 @@ pub fn[K, V] Map::copy(self : Map[K, V]) -> Map[K, V] {
   if self.size == 0 {
     return other
   }
-  guard self.entries[self.tail] is Some(last)
+  guard! self.entries[self.tail] is Some(last)
   for entry = last, idx = self.tail, next = (None : Entry[K, V]?) {
     let { prev, psl, hash, key, value, .. } = entry
     let new_entry = { prev, next, psl, hash, key, value }
@@ -991,7 +991,7 @@ pub fn[K, V] Map::retain(self : Map[K, V], f : (K, V) -> Bool) -> Unit {
     match (x, y) {
       (Some({ key, value, next, prev: idx, .. }), remove_prev) => {
         if remove_prev {
-          guard self.entries[idx] is Some(entry)
+          guard! self.entries[idx] is Some(entry)
           self.remove_entry(entry)
           self.shift_back(idx)
           self.size -= 1
@@ -1001,7 +1001,7 @@ pub fn[K, V] Map::retain(self : Map[K, V], f : (K, V) -> Bool) -> Unit {
       (None, remove_prev) => {
         if remove_prev {
           let idx = self.tail
-          guard self.entries[idx] is Some(entry)
+          guard! self.entries[idx] is Some(entry)
           self.remove_entry(entry)
           self.shift_back(idx)
           self.size -= 1

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -81,7 +81,7 @@ test "get" {
   assert_true(m.get("d") == None)
 
   // pattern
-  guard m is { "a": 1, "b": 2, "c": 3, "d"? : None, .. }
+  guard! m is { "a": 1, "b": 2, "c": 3, "d"? : None, .. }
 }
 
 ///|
@@ -582,7 +582,7 @@ test "remove_entry_head" {
   map.remove(1)
   // This should ensure the head is updated correctly
   assert_false(map.head is None)
-  guard map.head is Some(head)
+  guard! map.head is Some(head)
   assert_true(head.prev == -1)
   assert_true(head.next is None)
   assert_true(head.psl == 0)
@@ -600,7 +600,7 @@ test "remove_entry_tail" {
   // This should ensure the tail is updated correctly
   assert_false(map.tail is -1)
   assert_false(map.entries[map.tail] is None)
-  guard map.entries[map.tail] is Some(tail)
+  guard! map.entries[map.tail] is Some(tail)
   assert_true(tail.prev == -1)
   assert_true(tail.next is None)
   assert_true(tail.psl == 0)

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -122,7 +122,7 @@ pub fn String::substring(self : String, start? : Int = 0, end? : Int) -> String 
   let end = match end {
     Some(end) | (None with end = len) => end
   }
-  guard start >= 0 && start <= end && end <= len
+  guard! start >= 0 && start <= end && end <= len
   self.unsafe_substring(start~, end~)
 }
 

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -930,12 +930,12 @@ pub fn String::sub(self : String, start? : Int = 0, end? : Int) -> StringView {
   let end = match end {
     Some(end) | (None with end = len) => end
   }
-  guard start >= 0 && start <= end && end <= len
+  guard! start >= 0 && start <= end && end <= len
   if start < len {
-    guard !self.unsafe_get(start).is_trailing_surrogate()
+    guard! !self.unsafe_get(start).is_trailing_surrogate()
   }
   if end < len {
-    guard !self.unsafe_get(end).is_trailing_surrogate()
+    guard! !self.unsafe_get(end).is_trailing_surrogate()
   }
   StringView::make_view(self, start, end)
 }
@@ -995,16 +995,16 @@ pub fn StringView::sub(
   let abs_start = self.start() + start
 
   // Validate bounds against the original string
-  guard abs_start >= self.start() &&
+  guard! abs_start >= self.start() &&
     abs_start <= abs_end &&
     abs_end <= self.end()
 
   // Check for surrogate pair boundaries
   if abs_start < str_len {
-    guard !self.str().unsafe_get(abs_start).is_trailing_surrogate()
+    guard! !self.str().unsafe_get(abs_start).is_trailing_surrogate()
   }
   if abs_end < str_len {
-    guard !self.str().unsafe_get(abs_end).is_trailing_surrogate()
+    guard! !self.str().unsafe_get(abs_end).is_trailing_surrogate()
   }
   StringView::make_view(self.str(), abs_start, abs_end)
 }

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -357,7 +357,7 @@ test "StringView::get_view" {
   // Splitting a surrogate pair.
   debug_inspect(view.get_view(end=5), content="None")
   // Pattern-match composition: the optional form is matchable.
-  guard s.get_view(end=5) is Some("Hello")
+  guard! s.get_view(end=5) is Some("Hello")
 }
 
 ///|

--- a/builtin/uint.mbt
+++ b/builtin/uint.mbt
@@ -48,7 +48,7 @@ pub fn UInt::max(self : UInt, other : UInt) -> UInt {
 ///|
 /// Clamps the value `self` between `min` and `max`.
 pub fn UInt::clamp(self : UInt, min~ : UInt, max~ : UInt) -> UInt {
-  guard min <= max
+  guard! min <= max
   if self < min {
     min
   } else if self > max {

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -168,14 +168,14 @@ test "View::get out_of_bounds" {
 ///|
 test "to_uint_be with b'\\xFF\\xFF\\xFF\\xFF'" {
   let bytes = b"\xFF\xFF\xFF\xFF"[:]
-  guard bytes is [u32be(x), ..]
+  guard! bytes is [u32be(x), ..]
   inspect(x, content="4294967295")
 }
 
 ///|
 test "View::to_uint_le with non-zero bytes" {
   let bytes = b"\x01\x02\x03\x04"
-  guard bytes is [u32le(x), ..]
+  guard! bytes is [u32le(x), ..]
   inspect(x, content="67305985") // 67305985 = 0x04030201
 }
 
@@ -191,7 +191,7 @@ test "panic View::to_uint_le/out_of_bounds" {
 ///|
 test "View::to_uint64_be/first_byte_operation" {
   let bytes = b"\xFF\x00\x00\x00\x00\x00\x00\x00" // First byte is all 1s
-  guard bytes is [u64be(result), ..]
+  guard! bytes is [u64be(result), ..]
   // First byte shifted left by 56 bits should give us: 0xFF00000000000000
   inspect(result, content="18374686479671623680")
 }
@@ -199,22 +199,22 @@ test "View::to_uint64_be/first_byte_operation" {
 ///|
 test "test View::to_uint64_le with binary pattern" {
   let bytes = b"\x01\x00\x00\x00\x00\x00\x00\x00"
-  guard bytes is [u64le(x), ..]
+  guard! bytes is [u64le(x), ..]
   inspect(x, content="1")
   let bytes2 = b"\x00\x01\x00\x00\x00\x00\x00\x00"
-  guard bytes2 is [u64le(x2), ..]
+  guard! bytes2 is [u64le(x2), ..]
   inspect(x2, content="256")
 
   // Test all bytes set to non-zero values
   let bytes3 = b"\x01\x02\x03\x04\x05\x06\x07\x08"
-  guard bytes3 is [u64le(x3), ..]
+  guard! bytes3 is [u64le(x3), ..]
   inspect(x3, content="578437695752307201")
 }
 
 ///|
 test "test View::to_int_le with a non-zero 32-bit number" {
   let bytes = b"\x78\x56\x34\x12"
-  guard bytes is [i32le(x), ..]
+  guard! bytes is [i32le(x), ..]
   inspect(x, content="305419896")
 }
 
@@ -251,13 +251,13 @@ test "panic to_float_be/short_input" {
 test "View::to_float_le with different values" {
   // Test with value 0.0
   let bytes = b"\x00\x00\x00\x00"
-  guard bytes is [u32le(bits), ..]
+  guard! bytes is [u32le(bits), ..]
   let f = Float::reinterpret_from_uint(bits)
   inspect(f.to_double(), content="0")
 
   // Test with value -1.0
   let bytes2 = b"\x00\x00\x80\xBF"
-  guard bytes2 is [u32le(bits2), ..]
+  guard! bytes2 is [u32le(bits2), ..]
   let f2 = Float::reinterpret_from_uint(bits2)
   inspect(f2.to_double(), content="-1")
 }
@@ -265,7 +265,7 @@ test "View::to_float_le with different values" {
 ///|
 test "View::to_double_be/zero" {
   let bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00"
-  guard bytes is [u64be(bits), ..]
+  guard! bytes is [u64be(bits), ..]
   inspect(bits.reinterpret_as_double(), content="0")
 }
 
@@ -273,7 +273,7 @@ test "View::to_double_be/zero" {
 test "test to_double_le with normal float" {
   // 3.14 in little-endian IEEE 754 double format
   let bytes = b"\x1F\x85\xEB\x51\xB8\x1E\x09\x40"
-  guard bytes is [u64le(bits), ..]
+  guard! bytes is [u64le(bits), ..]
   inspect(bits.reinterpret_as_double(), content="3.14")
 }
 
@@ -296,7 +296,7 @@ test "iter break early" {
 ///|
 test "View::to_int_be with positive value" {
   let bytes = b"\x00\x00\x00\x01"[:] // Represents 1 in big-endian
-  guard bytes is [i32be(x), ..]
+  guard! bytes is [i32be(x), ..]
   inspect(x, content="1")
 }
 

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -258,7 +258,7 @@ pub fn[A] Deque::blit_to(
   src_offset? : Int = 0,
   dst_offset? : Int = 0,
 ) -> Unit {
-  guard len >= 0 &&
+  guard! len >= 0 &&
     dst_offset >= 0 &&
     src_offset >= 0 &&
     dst_offset <= dst.length() &&
@@ -1865,7 +1865,7 @@ pub impl[A : @json.FromJson] @json.FromJson for Deque[A] with fn from_json(
 /// 
 /// * `size` is not positive
 pub fn[A] Deque::chunks(self : Deque[A], size : Int) -> Deque[Deque[A]] {
-  guard size > 0
+  guard! size > 0
   let chunks = from_array([])
   for i = 0; i < self.length(); {
     let chunk = Deque([], capacity=size)

--- a/diff/diff_html_test.mbt
+++ b/diff/diff_html_test.mbt
@@ -45,7 +45,7 @@ fn side_by_side_html(
       match edits[i] {
         Delete(old_index~, old_len~, ..) if i + 1 < edits.length() &&
           edits[i + 1] is Insert(..) => {
-          guard edits[i + 1] is Insert(new_index~, new_len~, ..)
+          guard! edits[i + 1] is Insert(new_index~, new_len~, ..)
           let old_lines = o.view(start=old_index, end=old_index + old_len)
           let new_lines = n.view(start=new_index, end=new_index + new_len)
           // dimension guards FIRST, then tokenize once per line with a

--- a/diff/diff_word_test.mbt
+++ b/diff/diff_word_test.mbt
@@ -175,7 +175,7 @@ fn word_diff_html(old~ : ArrayView[String], new~ : ArrayView[String]) -> String 
       match edits[i] {
         Delete(old_index~, old_len~, ..) if i + 1 < edits.length() &&
           edits[i + 1] is Insert(..) => {
-          guard edits[i + 1] is Insert(new_index~, new_len~, ..)
+          guard! edits[i + 1] is Insert(new_index~, new_len~, ..)
           let removed = o
             .view(start=old_index, end=old_index + old_len)
             .map(l => l)

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -262,7 +262,7 @@ pub fn Float::max(self : Float, other : Float) -> Float {
 /// }
 /// ```
 pub fn Float::clamp(self : Float, min~ : Float, max~ : Float) -> Float {
-  guard min <= max
+  guard! min <= max
   if self < min {
     min
   } else if self > max {

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -311,11 +311,11 @@ pub fn[V] HashMap::get_from_string(
 pub fn[K : Hash + Eq, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry)
+    guard! self.entries[idx] is Some(entry)
     if entry.hash == hash && entry.key == key {
       break entry.value
     }
-    guard i <= entry.psl
+    guard! i <= entry.psl
     continue i + 1, (idx + 1) & self.capacity_mask
   }
 }

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -31,7 +31,7 @@ test "get" {
   debug_inspect(m.get("d"), content="None")
 
   // pattern
-  guard m is { "a": 1, "b": 2, "c": 3, "d"? : None, .. }
+  guard! m is { "a": 1, "b": 2, "c": 3, "d"? : None, .. }
 }
 
 ///|

--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -184,7 +184,7 @@ pub fn[A] T::length(self : T[A]) -> Int {
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
 #alias("_[_]")
 pub fn[A] T::at(self : T[A], index : Int) -> A {
-  guard index >= 0 && index < self.size
+  guard! index >= 0 && index < self.size
   if index == 0 {
     self.tree.get_first()
   } else if index == self.size - 1 {
@@ -238,7 +238,7 @@ pub fn[A] T::get(self : T[A], index : Int) -> A? {
 /// ```
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
 pub fn[A] T::set(self : T[A], index : Int, value : A) -> T[A] {
-  guard index >= 0 && index < self.size
+  guard! index >= 0 && index < self.size
   {
     tree: self.tree.set(index, self.shift, value),
     size: self.size,

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -413,7 +413,7 @@ fn[A] Tree::concat(
       right_shift,
       false,
     )
-    guard c_shift == left_shift
+    guard! c_shift == left_shift
     return rebalance(left, c, Empty, left_shift, top)
   } else if right_shift > left_shift {
     let (c, c_shift) = Tree::concat(
@@ -423,7 +423,7 @@ fn[A] Tree::concat(
       right_shift - NUM_BITS,
       false,
     )
-    guard c_shift == right_shift
+    guard! c_shift == right_shift
     return rebalance(Empty, c, right, right_shift, top)
   } else if left_shift == 0 {
     // Handle Leaf case
@@ -463,8 +463,8 @@ fn[A] Tree::concat(
       right_shift - NUM_BITS,
       false,
     )
-    guard c_shift == left_shift
-    guard c_shift == right_shift
+    guard! c_shift == left_shift
+    guard! c_shift == right_shift
     return rebalance(left, c, right, left_shift, top)
   }
 }
@@ -484,7 +484,7 @@ fn[A] rebalance(
   let t = tri_merge(left, center, right) // t is a list of trees of (H-1) height
   let (nc, nc_len) = redis_plan(t)
   let new_t = redis(t, nc, nc_len, shift - NUM_BITS) // new_t is a list of trees of (H-1) height
-  guard new_t.length() == nc_len
+  guard! new_t.length() == nc_len
   if nc_len <= BRANCHING_FACTOR {
     // All nodes can be accommodated in a single node
     let node = Node(new_t, compute_sizes(new_t, shift - NUM_BITS)) // node of H height
@@ -644,7 +644,7 @@ fn[A] redis(
         while new_offset < new_leaf_len {
           old_leaf_elems = old_t[j].leaf_elements()
           old_leaf_len = old_leaf_elems.length()
-          guard j < old_len  // This shouldn't be triggered if the plan was correctly generated
+          guard! j < old_len  // This shouldn't be triggered if the plan was correctly generated
           let remaining = min(
             new_leaf_len - new_offset,
             old_leaf_len - old_offset,
@@ -680,7 +680,7 @@ fn[A] redis(
         while new_offset < new_node_len {
           old_node_chldrn = old_t[j].node_children()
           old_node_len = old_node_chldrn.length()
-          guard j < old_len
+          guard! j < old_len
           let remaining = min(
             new_node_len - new_offset,
             old_node_len - old_offset,

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -80,7 +80,7 @@ pub fn[K : Eq + Hash, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
 /// Get value with `at` access semantics.
 #alias("_[_]")
 pub fn[K : Eq + Hash, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
-  guard self.data is Some(node)
+  guard! self.data is Some(node)
   node.get_with_path(key, @path.of(key)).unwrap()
 }
 
@@ -633,7 +633,7 @@ fn[K : Eq, V] @list.List::union_with(
       res.push(kv2)
     }
   }
-  guard @list.List(res) is More((k, v), tail~)
+  guard! @list.List(res) is More((k, v), tail~)
   Leaf(k, v, tail)
 }
 

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -235,12 +235,12 @@ fn[K, V] balance(
   //        / \             / \
   //       y   z           x   y
   fn single_l(k1, v1, x, r) {
-    guard r is Tree(k2, value=v2, y, z, ..)
+    guard! r is Tree(k2, value=v2, y, z, ..)
     make_tree(k2, v2, make_tree(k1, v1, x, y), z)
   }
 
   fn single_r(k2, v2, l, z) {
-    guard l is Tree(k1, value=v1, x, y, ..)
+    guard! l is Tree(k1, value=v1, x, y, ..)
     make_tree(k1, v1, x, make_tree(k2, v2, y, z))
   }
 
@@ -252,7 +252,7 @@ fn[K, V] balance(
   //     / \
   //    y1 y2
   fn double_l(k1, v1, x, r) {
-    guard r is Tree(k3, value=v3, Tree(k2, value=v2, y1, y2, ..), z, ..)
+    guard! r is Tree(k3, value=v3, Tree(k2, value=v2, y1, y2, ..), z, ..)
     make_tree(k2, v2, make_tree(k1, v1, x, y1), make_tree(k3, v3, y2, z))
   }
 
@@ -264,7 +264,7 @@ fn[K, V] balance(
   //    / \
   //   y1 y2
   fn double_r(k3, v3, l, z) {
-    guard l is Tree(k1, value=v1, x, Tree(k2, value=v2, y1, y2, ..), ..)
+    guard! l is Tree(k1, value=v1, x, Tree(k2, value=v2, y1, y2, ..), ..)
     make_tree(k2, v2, make_tree(k1, v1, x, y1), make_tree(k3, v3, y2, z))
   }
 
@@ -274,7 +274,7 @@ fn[K, V] balance(
     make_tree(key, value, l, r)
   } else if rn > ratio * ln {
     // right is too big
-    guard r is Tree(_, rl, rr, ..)
+    guard! r is Tree(_, rl, rr, ..)
     let rln = rl.length()
     let rrn = rr.length()
     if rln < rrn {
@@ -284,7 +284,7 @@ fn[K, V] balance(
     }
   } else if ln > ratio * rn {
     // left is too big
-    guard l is Tree(_, ll, lr, ..)
+    guard! l is Tree(_, ll, lr, ..)
     let lln = ll.length()
     let lrn = lr.length()
     if lrn < lln {

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -57,7 +57,7 @@ test "get with pattern" {
     (2, "two"),
     (0, "zero"),
   ])
-  guard map
+  guard! map
     is { 3: "three", 8: "eight", 1: "one", 2: "two", 0: "zero", 4? : None, .. }
 }
 

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -382,7 +382,7 @@ fn[A] Tree::concat(
       right_shift,
       false,
     )
-    guard c_shift == left_shift
+    guard! c_shift == left_shift
     return rebalance(left, c, Empty, left_shift, top)
   } else if right_shift > left_shift {
     let (c, c_shift) = Tree::concat(
@@ -392,7 +392,7 @@ fn[A] Tree::concat(
       right_shift - NUM_BITS,
       false,
     )
-    guard c_shift == right_shift
+    guard! c_shift == right_shift
     return rebalance(Empty, c, right, right_shift, top)
   } else if left_shift == 0 {
     // Handle Leaf case
@@ -432,8 +432,8 @@ fn[A] Tree::concat(
       right_shift - NUM_BITS,
       false,
     )
-    guard c_shift == left_shift
-    guard c_shift == right_shift
+    guard! c_shift == left_shift
+    guard! c_shift == right_shift
     return rebalance(left, c, right, left_shift, top)
   }
 }
@@ -453,7 +453,7 @@ fn[A] rebalance(
   let t = tri_merge(left, center, right) // t is a list of trees of (H-1) height
   let (nc, nc_len) = redis_plan(t)
   let new_t = redis(t, nc, nc_len, shift - NUM_BITS) // new_t is a list of trees of (H-1) height
-  guard new_t.length() == nc_len
+  guard! new_t.length() == nc_len
   if nc_len <= BRANCHING_FACTOR {
     // All nodes can be accommodated in a single node
     let node = Node(new_t, compute_sizes(new_t, shift - NUM_BITS)) // node of H height
@@ -613,7 +613,7 @@ fn[A] redis(
         while new_offset < new_leaf_len {
           old_leaf_elems = old_t[j].leaf_elements()
           old_leaf_len = old_leaf_elems.length()
-          guard j < old_len  // This shouldn't be triggered if the plan was correctly generated
+          guard! j < old_len  // This shouldn't be triggered if the plan was correctly generated
           let remaining = min(
             new_leaf_len - new_offset,
             old_leaf_len - old_offset,
@@ -649,7 +649,7 @@ fn[A] redis(
         while new_offset < new_node_len {
           old_node_chldrn = old_t[j].node_children()
           old_node_len = old_node_chldrn.length()
-          guard j < old_len
+          guard! j < old_len
           let remaining = min(
             new_node_len - new_offset,
             old_node_len - old_offset,

--- a/immut/vector/tree_append.mbt
+++ b/immut/vector/tree_append.mbt
@@ -160,7 +160,7 @@ fn[T] Tree::concat_with_suffix(
       right_shift,
       false,
     )
-    guard c_shift == left_shift
+    guard! c_shift == left_shift
     rebalance(left, c, Empty, left_shift, top)
   } else if right_shift > left_shift {
     let (c, c_shift) = Tree::concat_with_suffix(
@@ -171,7 +171,7 @@ fn[T] Tree::concat_with_suffix(
       right_shift - NUM_BITS,
       false,
     )
-    guard c_shift == right_shift
+    guard! c_shift == right_shift
     rebalance(Empty, c, right, right_shift, top)
   } else if left_shift == 0 {
     let leaves = FixedArray::from_array([left, Leaf(suffix), right])
@@ -192,8 +192,8 @@ fn[T] Tree::concat_with_suffix(
       right_shift - NUM_BITS,
       false,
     )
-    guard c_shift == left_shift
-    guard c_shift == right_shift
+    guard! c_shift == left_shift
+    guard! c_shift == right_shift
     rebalance(left, c, right, left_shift, top)
   }
 }

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -200,7 +200,7 @@ fn[A] Vector::tail_offset(self : Vector[A]) -> Int {
 /// ```
 #alias("_[_]")
 pub fn[A] Vector::at(self : Vector[A], index : Int) -> A {
-  guard index >= 0 && index < self.size
+  guard! index >= 0 && index < self.size
   let tail_offset = self.tail_offset()
   if index >= tail_offset {
     self.tail[index - tail_offset]
@@ -279,7 +279,7 @@ pub fn[A : Eq] Vector::contains(self : Vector[A], value : A) -> Bool {
 /// }
 /// ```
 pub fn[A] Vector::set(self : Vector[A], index : Int, value : A) -> Vector[A] {
-  guard index >= 0 && index < self.size
+  guard! index >= 0 && index < self.size
   let tail_len = self.tail.length()
   if tail_len == 0 {
     make_t(

--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -79,7 +79,7 @@ test "json object navigation" {
   debug_inspect(array_opt, content="Some([Number(1), Number(2), Number(3)])")
 
   // Handle missing keys gracefully
-  guard json is { "value"? : value, .. }
+  guard! json is { "value"? : value, .. }
   debug_inspect(value, content="None")
 }
 ```
@@ -100,7 +100,7 @@ test "json array navigation" {
   debug_inspect(missing, content="None")
 
   // Iterate through array
-  guard array is Array(values)
+  guard! array is Array(values)
   debug_inspect(
     values.iter().to_array(),
     content=(

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -177,7 +177,7 @@ pub impl[X : FromJson] FromJson for Array[X] with fn from_json(json, path) {
   guard json is Array(a) else {
     decode_error(path, "Array::from_json: expected array")
   }
-  guard JsonPath::Index(path, index=0) is (Index(_) as new_path)
+  guard! JsonPath::Index(path, index=0) is (Index(_) as new_path)
   a.mapi((i, x) => {
     new_path.index = i
     FromJson::from_json(x, new_path)
@@ -189,7 +189,7 @@ pub impl[X : FromJson] FromJson for ArrayView[X] with fn from_json(json, path) {
   guard json is Array(a) else {
     decode_error(path, "ArrayView::from_json: expected array")
   }
-  guard JsonPath::Index(path, index=0) is (Index(_) as new_path)
+  guard! JsonPath::Index(path, index=0) is (Index(_) as new_path)
   a.mapi((i, x) => {
     new_path.index = i
     FromJson::from_json(x, new_path)
@@ -205,7 +205,7 @@ pub impl[X : FromJson] FromJson for FixedArray[X] with fn from_json(json, path) 
   if len == 0 {
     return []
   }
-  guard JsonPath::Index(path, index=0) is (Index(_) as new_path)
+  guard! JsonPath::Index(path, index=0) is (Index(_) as new_path)
   let res = FixedArray::make(
     len,
     FromJson::from_json(a.unsafe_get(0), new_path),
@@ -228,7 +228,7 @@ pub impl[V : FromJson] FromJson for Map[String, V] with fn from_json(json, path)
     decode_error(path, "Map::from_json: expected object")
   }
   let res = Map([])
-  guard JsonPath::Key(path, key="") is (Key(_) as new_path)
+  guard! JsonPath::Key(path, key="") is (Key(_) as new_path)
   // Map::map_with_key
   for k, v in obj {
     new_path.key = k

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -582,7 +582,7 @@ pub fn[K] Set::copy(self : Set[K]) -> Set[K] {
   if self.size == 0 {
     return other
   }
-  guard self.entries[self.tail] is Some(last)
+  guard! self.entries[self.tail] is Some(last)
   for entry = last, idx = self.tail, next = (None : Entry[K]?) {
     match (entry, idx, next) {
       ({ prev, psl, hash, key, .. }, idx, next) => {

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -57,7 +57,7 @@ test "get" {
   debug_inspect(map.get(4), content="None")
 
   // pattern
-  guard map is { 1: "a", 2: "b", 3: "c", 4? : None, .. }
+  guard! map is { 1: "a", 2: "b", 3: "c", 4? : None, .. }
 }
 
 ///|

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -1007,7 +1007,7 @@ test "string chars array" {
 ///|
 test "gard tail position" {
   let s = "abc"
-  guard s is [.., ch]
+  guard! s is [.., ch]
   @test.assert_eq(ch, 'c') // failed
 }
 


### PR DESCRIPTION
## Summary

Recent toolchains added **warning 0087 (`guard_inexhaustive`)** for `guard` statements without an `else` clause whose condition/pattern the compiler cannot prove total — such guards panic when they fail. `moon check --target all` currently reports 141 such warnings in core.

All flagged sites (library invariant/precondition checks, test extractions, docstring and `.mbt.md` examples) rely on the intended panic-on-failure behavior, so this PR mechanically converts them to the new `guard!` form: identical runtime semantics, but the panic is declared intentional and the warning is silenced.

- 141 sites across 44 files, every changed line is exactly `guard` → `guard!`
- `moon check --target all`: 0 warnings, 0 errors
- `moon test --target all`: all passing (js 6873, native 6838, wasm/wasm-gc ok)
- `moon fmt` clean; no public API change (generated `.mbti` unchanged)
- verified the `latest` release toolchain (moonc v0.10.5+5e7afb0c0, 2026-07-27) already parses `guard!`, so stable-check CI is safe

Codex review: "All 141 changes are exact `guard` → `guard!` rewrites; no other text changed. Every panic remains appropriate as a precondition, test assertion, or internal invariant."

Signed-off-by: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)