### PR TITLE
fix(random): correct Lemire rejection threshold

### DIFF
--- a/random/random.mbt
+++ b/random/random.mbt
@@ -157,7 +157,8 @@ pub fn Rand::uint64(self : Rand, limit? : UInt64 = 0) -> UInt64 {
   if r.lo >= limit {
     return r.hi
   }
-  let thresh = limit.lnot() % limit
+  // In wrapping UInt64 arithmetic, ~limit + 1 is -limit modulo 2^64.
+  let thresh = (limit.lnot() + 1) % limit
   for r = r; r.lo < thresh; {
     continue umul128(self.next(), limit)
   } nobreak {

--- a/random/random_test.mbt
+++ b/random/random_test.mbt
@@ -61,6 +61,39 @@ test "Rand::new with generator" {
 }
 
 ///|
+priv struct ScriptedSource {
+  values : FixedArray[UInt64]
+  mut index : Int
+}
+
+///|
+impl @random.Source for ScriptedSource with fn next(self) -> UInt64 {
+  let value = self.values[self.index]
+  self.index += 1
+  value
+}
+
+///|
+test "Rand::uint64 applies Lemire rejection for limit 3" {
+  let source : ScriptedSource = {
+    // 3 * 0x5555555555555556 = 2^64 + 2, so the retry maps to 1.
+    values: [0UL, 0x5555555555555556UL],
+    index: 0,
+  }
+  let rand = @random.Rand::new(generator=source as &@random.Source)
+  let result = rand.uint64(limit=3)
+  @debug.debug_inspect((result, source.index), content="(1, 2)")
+}
+
+///|
+test "Rand::uint64 applies Lemire rejection at the maximum limit" {
+  let source : ScriptedSource = { values: [0UL, 2UL], index: 0 }
+  let rand = @random.Rand::new(generator=source as &@random.Source)
+  let result = rand.uint64(limit=0xffffffffffffffffUL)
+  @debug.debug_inspect((result, source.index), content="(1, 2)")
+}
+
+///|
 test {
   let random = @random.Rand::chacha8(seed=fixed_test_seed)
   inspect(random.float(), content="0.27378302812576294")


### PR DESCRIPTION
## Summary

- Compute the rejection threshold in `Rand::uint64` using the two's-complement
  representation of `-limit`:`(limit.lnot() + 1) % limit`.
- Add deterministic regressions for the smallest affected bound (`3`) and the
  largest possible UInt64 bound (`0xffffffffffffffff`).

## Problem

`Rand::uint64` used `~limit % limit` as Lemire's rejection threshold. The correct expression is `(-limit) % limit`.

For every odd bound greater than 1, the old threshold accepts one value that should be rejected. This gives one output an extra preimage, so the bounded results are not perfectly uniform. For example, with `limit = 2^63 + 1`, the affected output is nearly twice as likely as most others.

This also affects APIs built on bounded sampling, including `uint`, `int`, `int64`, and `shuffle`.

## Fix
Compute the threshold using the UInt64 representation of `-limit`:

```moonbit
let thresh = (limit.lnot() + 1) % limit
```
