### PR TITLE
Optimize map entry ownership

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -175,6 +175,7 @@ fn[K : Eq, V] Map::set_with_hash(
 }
 
 ///|
+#owned(entry)
 fn[K, V] Map::push_away(
   self : Map[K, V],
   idx : Int,
@@ -513,6 +514,7 @@ fn[K : Eq, V] Map::remove_with_hash(
 }
 
 ///|
+#owned(entry)
 fn[K, V] Map::add_entry_to_tail(
   self : Map[K, V],
   idx : Int,
@@ -582,6 +584,7 @@ fn[K, V] Map::grow(self : Map[K, V]) -> Unit {
 }
 
 ///|
+#owned(outer)
 fn[K, V] Map::rehash_place_entry(self : Map[K, V], outer : Entry[K, V]) -> Unit {
   let hash = outer.hash
   for psl = 0, idx = hash & self.capacity_mask {


### PR DESCRIPTION
## Summary

- mark `Map::add_entry_to_tail`'s `entry` parameter as owned
- mark `Map::push_away`'s `entry` parameter as owned
- mark `Map::rehash_place_entry`'s `outer` parameter as owned
- allow entry ownership to flow through insertion and rehashing without redundant retain/release pairs

## Motivation

Under the borrowed RC convention, these helpers retain parameters that they always consume by storing or forwarding. Explicit ownership lets the compiler transfer the existing reference instead.

For a native-release workload that inserts and then looks up 50,000 integer entries:

- mean runtime improved from 3.4493 ms to 3.3252 ms (3.60%)
- insertion-only runtime improved by 4.12%
- lookup performance was unchanged
- generated RC executions fell by 124,421 retains and 124,421 releases (19.22% total)

The measurements used `MOONC_RC_CONVENTION=borrow` and interleaved baseline/candidate runs.

## Validation

- `MOONC_RC_CONVENTION=borrow moon check builtin --target all`
- `MOONC_RC_CONVENTION=owned moon check builtin --target native`
- `MOONC_RC_CONVENTION=borrow moon test builtin --target native --release` — 2,889 passed
- `MOONC_RC_CONVENTION=borrow moon test --target native --release` — 6,838 passed
- `moon info --target all` — generated builtin interface unchanged
- `moon fmt --check builtin/linked_hash_map.mbt`
