### PR TITLE
docs: add mermaid/d2 diagrams to package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@
 
 moonbitlang/core is the standard library of the [MoonBit language](https://www.moonbitlang.com/). It is released alongside the compiler. You can view the documentation for the latest official release at <https://mooncakes.io/docs/moonbitlang/core/>. This repository serves as the development repository.
 
+## Architecture at a glance
+
+Almost every package in this repository sits on top of `builtin`, which is
+available in every MoonBit program without an import (`builtin` itself
+bootstraps on the tiny `abort` package). `prelude` is opened automatically
+and re-exports the commonly used names from `builtin` plus a few companions
+(`Debug`, `BigInt`, `Ref`, `Lazy`, test assertions, …). Everything else is an
+ordinary package imported as `moonbitlang/core/<pkg>` and used via `@<pkg>`:
+
+```mermaid
+graph BT
+  builtin["<b>builtin</b> (implicitly available, no import)<br/>Array · FixedArray · Map · String · Bytes · views<br/>Iter · StringBuilder · Json<br/>traits: Eq · Compare · Hash · Show · ToJson · Default"]
+  prelude["<b>prelude</b> — auto-opened re-exports<br/>from builtin, debug, test, bigint, …"] --> builtin
+  values["<b>value types</b><br/>bool · byte · char · unit · option · result<br/>error · ref · tuple · cmp · range · lazy"] --> builtin
+  numbers["<b>numerics</b><br/>int · uint · int16 · uint16 · int64 · uint64<br/>double · float · bigint · v128 · math"] --> builtin
+  text["<b>text & binary</b><br/>string · bytes · buffer · encoding/*<br/>strconv · lexbuf"] --> builtin
+  mut["<b>mutable collections</b><br/>array · hashmap · hashset · deque · queue<br/>priority_queue · set · sorted_map · sorted_set"] --> builtin
+  imm["<b>immutable collections</b><br/>list · lazy_list · immut/array<br/>immut/hashmap · immut/sorted_map · …"] --> builtin
+  tools["<b>algorithms & tooling</b><br/>json · diff · random · quickcheck · argparse<br/>bench · test · debug · env"] --> builtin
+```
+
 ## Current status
 
 It is experimental and under active development. At this early stage, our primary focus is on enhancing the functionality of `moonbitlang/core`.

--- a/builtin/README.mbt.md
+++ b/builtin/README.mbt.md
@@ -181,6 +181,48 @@ test "fixed arrays" {
 }
 ```
 
+## Views (Zero-Copy Slices)
+
+Each owning container has a matching view type created with the `a[start:end]`
+slice syntax. A view is a small record holding a reference to the shared
+storage plus its window bounds, so slicing never copies the elements:
+
+```d2
+direction: right
+owners: "Owning containers" {
+  arr: "Array[T] / FixedArray[T] / ReadOnlyArray[T]"
+  bytes: "Bytes"
+  str: "String"
+}
+views: "Zero-copy views (shared storage + window bounds)" {
+  arrview: "ArrayView[T]"
+  bytesview: "BytesView"
+  strview: "StringView"
+}
+owners.arr -> views.arrview: "a[start:end]"
+owners.bytes -> views.bytesview: "b[start:end]"
+owners.str -> views.strview: "s[start:end]"
+```
+
+Views are ideal for rest patterns (`[first, .. rest]`) and for passing
+sub-sequences without allocation; functions taking a view also accept the
+owning container through implicit conversion. Note that the `s[start:end]`
+slice syntax on `String` panics when a boundary would split a UTF-16
+surrogate pair:
+
+```mbt check
+///|
+test "views are zero copy" {
+  let arr = [1, 2, 3, 4, 5]
+  let view = arr[1:4]
+  @test.assert_eq(view.length(), 3)
+  @test.assert_eq(view[0], 2)
+  guard! view is [first, .. rest]
+  @test.assert_eq(first, 2)
+  @test.assert_eq(rest.length(), 2)
+}
+```
+
 ## String Operations
 
 Basic string functionality:

--- a/deque/README.mbt.md
+++ b/deque/README.mbt.md
@@ -2,6 +2,25 @@
 
 A double-ended queue backed by a growable ring buffer. Supports O(1) amortized push/pop at both ends and O(1) random access, similar to C++ `std::deque` and Rust `VecDeque`.
 
+## Layout
+
+Following the Rust `VecDeque` design, only `head` and `len` are stored; the
+back position is computed as `(head + len - 1) % cap`. When the logical
+sequence reaches the end of the buffer it simply wraps around, so neither
+`push_front` nor `push_back` ever shifts elements:
+
+```mermaid
+flowchart LR
+  subgraph buf["buf, cap = 8 — logical order 1·2·3·4·5, head = 5, len = 5"]
+    direction LR
+    c0["0: 4"] --- c1["1: 5 ⟵ back"] --- c2["2: ·"] --- c3["3: ·"] --- c4["4: ·"] --- c5["5: 1 ⟵ head"] --- c6["6: 2"] --- c7["7: 3"]
+  end
+  c7 -. wraps to index 0 .-> c0
+```
+
+Growing allocates a larger buffer and re-linearizes the elements; iteration
+and indexing translate logical positions through `head` the same way.
+
 # Usage
 
 ## Create

--- a/diff/README.mbt.md
+++ b/diff/README.mbt.md
@@ -8,6 +8,24 @@ default, or patience diff when you pass `algorithm=Patience`.
 result to split far-apart changes into separate `Hunk[T]` values for
 unified-diff-style output.
 
+```mermaid
+flowchart LR
+  old["old : ArrayView[T]"] --> D["Diff(old~, new~,<br/>cutoff?, algorithm?)"]
+  new["new : ArrayView[T]"] --> D
+  D -->|"Myers (default)"| M["Myers O((N+M)·D)<br/>divide and conquer, linear space"]
+  D -->|"Patience"| P["anchors = LCS of elements unique<br/>to both sides, Myers in the gaps"]
+  M --> E["edit script:<br/>Equal / Delete / Insert"]
+  P --> E
+  E -->|"group(context?)"| H["Array[Hunk[T]]"]
+  H --> R["render: unified text,<br/>HTML, word diff, …"]
+```
+
+The separate Levenshtein functions live outside this pipeline:
+`edit_distance` / `edit_distance_within` answer only "how many edits" with a
+two-row dynamic program (banded when you give `max_distance`), and
+`levenshtein_edits` produces a run-length script that, unlike `Edit`, also
+has a `Replace` operation for substitutions.
+
 ## Compute A Diff
 
 `Diff(old~, new~)` computes the full sequence of `Delete`, `Insert`, and

--- a/hashmap/README.mbt.md
+++ b/hashmap/README.mbt.md
@@ -2,6 +2,28 @@
 
 A mutable hash map based on a Robin Hood hash table.
 
+## How It Works
+
+Entries live in one flat power-of-two array of `{psl, hash, key, value}`
+slots, where `psl` (probe sequence length) is how far the entry sits from its
+ideal slot `hash & (capacity - 1)`. Insertion keeps probe distances short by
+letting a "poor" entry (large `psl`) evict a "rich" one (smaller `psl`),
+which then continues looking for a home — that is the Robin Hood part.
+Lookups can stop as soon as they meet a slot whose `psl` is smaller than the
+distance probed so far, so misses are cheap too.
+
+```mermaid
+flowchart TD
+  S["set(k, v)"] --> H["idx = hash & mask, psl = 0"]
+  H --> C{"entries[idx]?"}
+  C -->|"same hash and key"| U["update value in place"]
+  C -->|"occupied, psl ≤ slot's psl"| N["idx = (idx + 1) & mask, psl += 1"] --> C
+  C -->|"empty, or occupied with psl > slot's psl"| G{"size ≥ capacity / 2?"}
+  G -->|"yes"| R["double capacity, rehash all, restart"] --> H
+  G -->|"no, slot was empty"| P["store {psl, hash, k, v}"]
+  G -->|"no, stealing"| E["swap: evict the richer entry,<br/>keep probing to re-place it"] --> N
+```
+
 # Usage
 
 ## Create

--- a/immut/array/README.mbt.md
+++ b/immut/array/README.mbt.md
@@ -2,6 +2,28 @@
 
 Immutable array is a persistent data structure that provides random access and update operations. Based on Clojure's [persistent vector](https://hypirion.com/musings/understanding-persistent-vector-pt-1).
 
+## How It Works
+
+The elements live in a 32-way tree: internal `Node`s hold up to 32 children
+and `Leaf`s hold up to 32 elements. Indexing walks the tree using 5 bits of
+the index per level (`(i >> shift) & 0x1F`), so random access and point
+updates are O(log32 n) — effectively constant for practical sizes. For
+example, 70 elements need just one internal node above three leaves:
+
+```mermaid
+graph TD
+  T["{ tree, size = 70, shift = 5 }"] --> N["Node — children indexed by bits i >> 5"]
+  N --> L0["Leaf: elements 0‥31<br/>(bits i & 0x1F)"]
+  N --> L1["Leaf: elements 32‥63"]
+  N --> L2["Leaf: elements 64‥69"]
+```
+
+`set` copies only the path from the root to the affected leaf (at most
+log32 n nodes) and shares every other subtree with the original array, which
+is why updates are cheap and old versions remain valid. Nodes produced by
+`concat` may be "relaxed" — not all subtrees completely full — and carry a
+per-child size table that indexing consults instead of the pure 5-bit path.
+
 # Usage
 
 ## Create

--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -4,6 +4,19 @@ The `json` package provides comprehensive JSON handling capabilities, including
 parsing, stringifying, and type-safe conversion between JSON and other MoonBit
 data types.
 
+Everything revolves around the builtin `Json` enum
+(`Null · True · False · Number · String · Array · Object`), which can also be
+written as a literal in MoonBit source:
+
+```mermaid
+flowchart LR
+  S["text : StringView"] -->|"@json.parse<br/>raise ParseError"| J["Json (builtin enum)"]
+  L["Json literal in source<br/>{ #quot;name#quot;: #quot;Alice#quot;, #quot;tags#quot;: [1, 2] }"] --> J
+  J -->|"@json.from_json (T : FromJson)<br/>raise JsonDecodeError, reports a JsonPath"| T["typed value T"]
+  T -->|"@json.to_json (T : ToJson)"| J
+  J -->|"stringify(escape_slash?, indent?, replacer?)"| O["String"]
+```
+
 ## Basic JSON Operations
 
 ### Parsing and Validating JSON

--- a/json/README.mbt.md
+++ b/json/README.mbt.md
@@ -11,7 +11,7 @@ written as a literal in MoonBit source:
 ```mermaid
 flowchart LR
   S["text : StringView"] -->|"@json.parse<br/>raise ParseError"| J["Json (builtin enum)"]
-  L["Json literal in source<br/>{ #quot;name#quot;: #quot;Alice#quot;, #quot;tags#quot;: [1, 2] }"] --> J
+  L["Json literal in source<br/>{ &quot;name&quot;: &quot;Alice&quot;, &quot;tags&quot;: [1, 2] }"] --> J
   J -->|"@json.from_json (T : FromJson)<br/>raise JsonDecodeError, reports a JsonPath"| T["typed value T"]
   T -->|"@json.to_json (T : ToJson)"| J
   J -->|"stringify(escape_slash?, indent?, replacer?)"| O["String"]

--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -125,7 +125,26 @@ test "string comparison" {
 
 ## String Views
 
-String views provide efficient substring operations without copying:
+String views provide efficient substring operations without copying. A
+`String` stores UTF-16 code units, and a view is just a `{str, start, end}`
+window into those units. A character outside the Basic Multilingual Plane is
+stored as a surrogate pair, and the `s[start:end]` slice syntax panics
+rather than split one:
+
+```d2
+direction: right
+str: "String \"a😀b\" — UTF-16 code units" {
+  u0: "[0] 'a'"
+  u1: "[1] 0xD83D high surrogate"
+  u2: "[2] 0xDE00 low surrogate"
+  u3: "[3] 'b'"
+}
+view: "StringView {str, start, end}\ns[1:3] is the full 😀 (ok)\ns[2:4] starts inside 😀 → panics"
+view -> str: "zero copy, indices are code units"
+```
+
+`s[i]` returns the code unit at `i`, `s.get_char(i)` decodes a full `Char`,
+and `for c in s` iterates characters (decoding surrogate pairs):
 
 ```mbt check
 ///|


### PR DESCRIPTION
## Summary

The MoonBit code viewer now renders `mermaid` and `d2` fences (moonbitlang/editor#19), so this PR adds 8 diagrams where a picture explains the code base faster than prose — mermaid for flows/trees, d2 for static structure, matching the editor repo's convention:

| Where | Diagram |
|---|---|
| `README.md` | package layering at a glance: `builtin`/`prelude` foundation, thematic groups on top (mermaid) |
| `builtin/README.mbt.md` | new **Views (Zero-Copy Slices)** section: owning containers vs shared-storage views (d2) + an executable `mbt check` example using `guard!` rest patterns |
| `string/README.mbt.md` | UTF-16 code units vs `StringView` window; `s[start:end]` panics rather than split a surrogate pair (d2) |
| `hashmap/README.mbt.md` | Robin Hood insertion flow: probe, steal-from-the-rich, grow at `capacity/2` before placing any new entry (mermaid) |
| `deque/README.mbt.md` | ring-buffer layout: `head`/`len`, computed back index, wrap-around (mermaid) |
| `immut/array/README.mbt.md` | 32-way trie, 5-bit index paths, path copying on `set`, relaxed size tables from `concat` (mermaid) |
| `diff/README.mbt.md` | pipeline: Myers/Patience → edit script → hunks → renderers, plus how the Levenshtein functions relate (mermaid) |
| `json/README.mbt.md` | the builtin `Json` enum at the center of parse / literal / `FromJson` / `ToJson` / `stringify` (mermaid) |

Diagram claims were checked against the implementations (`set_with_hash`, `Deque::realloc`, `NUM_BITS`/`Tree`, patience fallback, banded `edit_distance_within`, `String::view`, prelude re-exports, …), and every block was syntax-validated by actually rendering it (mermaid.ink for mermaid, kroki.io for d2). GitHub renders the mermaid blocks natively; the two d2 blocks show as code on GitHub but render in the MoonBit viewer.

## Checks

- `moon check --target all` clean; `moon fmt` clean; no `pkg.generated.mbti` changes
- `moon test builtin string hashmap deque immut/array diff json`: all passing (the new views example runs as a real test)
- Codex review across 3 rounds; its corrections (builtin node contents, prelude scope, surrogate-panic scoping to slice syntax, hashmap grow-check placement, complexity scoping, json literal/stringify details) are folded in

Signed-off-by: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)