### PR TITLE
Migrate String::get to UInt16

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -867,8 +867,7 @@ pub fn[A] String::fold(String, init~ : A, (A, Char) -> A raise?) -> A raise?
 pub fn String::from_array(ArrayView[Char]) -> String
 #alias(from_iterator, deprecated)
 pub fn String::from_iter(Iter[Char]) -> String
-#deprecated
-pub fn String::get(String, Int) -> Int?
+pub fn String::get(String, Int) -> UInt16?
 pub fn String::get_char(String, Int) -> Char?
 pub fn String::get_view(String, start? : Int, end? : Int) -> StringView?
 #alias(starts_with, deprecated)
@@ -1226,8 +1225,7 @@ pub fn[A] StringView::fold(Self, init~ : A, (A, Char) -> A raise?) -> A raise?
 pub fn StringView::from_array(ArrayView[Char]) -> Self
 #alias(from_iterator, deprecated)
 pub fn StringView::from_iter(Iter[Char]) -> Self
-#deprecated
-pub fn StringView::get(Self, Int) -> Int?
+pub fn StringView::get(Self, Int) -> UInt16?
 pub fn StringView::get_char(Self, Int) -> Char?
 pub fn StringView::get_view(Self, start? : Int, end? : Int) -> Self?
 #alias(starts_with, deprecated)

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1958,19 +1958,17 @@ test "rev_fold with raise" {
 ///|
 /// Returns the UTF-16 code unit at the given index. Returns `None` if the index
 /// is out of bounds.
-#deprecated("The return type is about to change to `UInt16?` in a future release. Please check boundaries manually and use `String::code_unit_at` instead.", skip_current_package=true)
-pub fn String::get(self : String, idx : Int) -> Int? {
+pub fn String::get(self : String, idx : Int) -> UInt16? {
   guard idx >= 0 && idx < self.length() else { return None }
-  Some(self.unsafe_get(idx).to_int())
+  Some(self.unsafe_get(idx))
 }
 
 ///|
 /// Returns the UTF-16 code unit at the given index. Returns `None` if the index
 /// is out of bounds.
-#deprecated("The return type is about to change to `UInt16?` in a future release. Please check boundaries manually and use `StringView::code_unit_at` instead.", skip_current_package=true)
-pub fn StringView::get(self : StringView, idx : Int) -> Int? {
+pub fn StringView::get(self : StringView, idx : Int) -> UInt16? {
   guard idx >= 0 && idx < self.length() else { return None }
-  Some(self.unsafe_get(idx).to_int())
+  Some(self.unsafe_get(idx))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- change `String::get` and `StringView::get` to return `UInt16?`
- return UTF-16 code units directly instead of converting them to `Int`
- remove the temporary deprecation markers and regenerate the builtin interface

## Why

These APIs expose UTF-16 code units, whose canonical type is `UInt16`. They were deprecated in advance of this return-type migration; this completes that announced API change.

## Impact

This is a source-level API change for callers that explicitly require `Int?`. Callers can convert the returned code unit when an integer is needed. Bounds behavior remains unchanged.

## Validation

- `moon check --warn-list +73`
- `moon test builtin` (2,932 passed)
- `moon test` (6,929 passed)
- `moon info`
- `moon fmt`
- `git diff --check`