### PR TITLE
test(builtin): match UInt16 String::get results

### DIFF
--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1974,29 +1974,29 @@ pub fn StringView::get(self : StringView, idx : Int) -> UInt16? {
 ///|
 test "String::get supports emoji (surrogate pair)" {
   let s = "hello"
-  assert_true(s.get(0) == Some(104))
-  assert_true(s.get(4) == Some(111))
-  assert_true(s.get(5) == None)
-  assert_true(s.get(-1) == None)
+  assert_true(s.get(0) is Some(104))
+  assert_true(s.get(4) is Some(111))
+  assert_true(s.get(5) is None)
+  assert_true(s.get(-1) is None)
   let s = "a🤣b"
-  assert_true(s.get(0) == Some(97))
-  assert_true(s.get(1) == Some(55358))
-  assert_true(s.get(2) == Some(56611))
-  assert_true(s.get(3) == Some(98))
-  assert_true(s.get(4) == None)
+  assert_true(s.get(0) is Some(97))
+  assert_true(s.get(1) is Some(55358))
+  assert_true(s.get(2) is Some(56611))
+  assert_true(s.get(3) is Some(98))
+  assert_true(s.get(4) is None)
 }
 
 ///|
 test "View::get basic cases" {
   let v = "hello"[1:4]
-  assert_true(v.get(0) == Some(101))
-  assert_true(v.get(2) == Some(108))
-  assert_true(v.get(3) == None)
-  assert_true(v.get(-1) == None)
+  assert_true(v.get(0) is Some(101))
+  assert_true(v.get(2) is Some(108))
+  assert_true(v.get(3) is None)
+  assert_true(v.get(-1) is None)
   let v = "ab🤣cd"[1:5]
-  assert_true(v.get(0) == Some(98))
-  assert_true(v.get(1) == Some(55358))
-  assert_true(v.get(2) == Some(56611))
+  assert_true(v.get(0) is Some(98))
+  assert_true(v.get(1) is Some(55358))
+  assert_true(v.get(2) is Some(56611))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- update `String::get` tests to match `UInt16?` results directly
- apply the same assertion style to `StringView::get`
- cover in-bounds, out-of-bounds, and UTF-16 surrogate-pair cases consistently

## Why

Follow-up to #3965, which changed both `get` methods from `Int?` to `UInt16?`. Matching the option payload preserves the expected `UInt16` type at each test site and keeps the String and StringView coverage uniform.

## Impact

Test-only change; the public API and generated interfaces are unchanged.

## Validation

- `moon info`
- `moon fmt`
- `moon check --warn-list +73`
- `moon test` (6,929 passed)