### PR TITLE
Mark API-acyclic container types as cycle-free

### DIFF
--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -15,6 +15,7 @@
 // Types
 
 ///|
+#unsafe_cycle_free
 priv struct Entry[K, V] {
   mut prev : Int
   mut next : Entry[K, V]?

--- a/immut/array/types.mbt
+++ b/immut/array/types.mbt
@@ -26,6 +26,7 @@ struct T[A] {
 ///|
 /// Invariants:
 /// - For `Node`, the sizes array is `None` if the tree is full, i.e., we can use radix indexing.
+#unsafe_cycle_free
 priv enum Tree[A] {
   Empty
   Node(FixedArray[Tree[A]], FixedArray[Int]?) // (Subtrees, Sizes of subtrees)

--- a/immut/hashmap/types.mbt
+++ b/immut/hashmap/types.mbt
@@ -14,6 +14,7 @@
 
 ///|
 /// An non-empty immutable hash set data structure
+#unsafe_cycle_free
 priv enum Node[K, V] {
   Flat(K, V, @path.Path)
   Leaf(K, V, @list.List[(K, V)]) // use a list of buckets to resolve collision

--- a/immut/hashset/types.mbt
+++ b/immut/hashset/types.mbt
@@ -14,6 +14,7 @@
 
 ///|
 /// An non-empty immutable hash set data structure
+#unsafe_cycle_free
 priv enum Node[A] {
   Flat(A, @path.Path)
   Leaf(A, @list.List[A]) // use a list of buckets to resolve collision

--- a/immut/vector/types.mbt
+++ b/immut/vector/types.mbt
@@ -29,6 +29,7 @@ struct Vector[A] {
 ///|
 /// Invariants:
 /// - For `Node`, the sizes array is `None` if the tree is full, i.e., we can use radix indexing.
+#unsafe_cycle_free
 priv enum Tree[A] {
   Empty
   Node(FixedArray[Tree[A]], FixedArray[Int]?) // (Subtrees, Sizes of subtrees)

--- a/list/types.mbt
+++ b/list/types.mbt
@@ -14,6 +14,7 @@
 
 ///|
 /// Type `List` used by this package APIs.
+#unsafe_cycle_free
 pub enum List[A] {
   Empty
   More(A, mut tail~ : List[A])

--- a/sorted_map/types.mbt
+++ b/sorted_map/types.mbt
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 ///|
+#unsafe_cycle_free
 priv struct Node[K, V] {
   mut key : K
   mut value : V

--- a/sorted_set/types.mbt
+++ b/sorted_set/types.mbt
@@ -23,6 +23,7 @@ struct SortedSet[V] {
 }
 
 ///|
+#unsafe_cycle_free
 priv struct Node[V] {
   mut value : V
   mut left : Node[V]?


### PR DESCRIPTION
## Summary

- add `#unsafe_cycle_free` to recursive container representations that cannot form cycles through their public APIs
- cover linked hash maps, immutable arrays/maps/sets/vectors, lists, sorted maps, and sorted sets

## Rationale

These types are structurally recursive and therefore look cycle-capable to conservative analysis, but their exposed APIs do not permit constructing reference cycles. The annotations make that invariant explicit without changing the public API or observable behavior.

## Validation

- `moon info` (no public interface changes)
- `moon fmt`
- `moon check --warn-list +unnecessary_annotation`
- `moon test` — 7,000 tests passed
