### PR TITLE
Regenerate package interfaces with stable toolchain

### DIFF
--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -89,4 +89,3 @@ pub fn ValueSource::to_string(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/array/pkg.generated.mbti
+++ b/array/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn[A, B, C] zip_with(Array[A], Array[B], (A, B) -> C raise?) -> Array[C] rai
 pub using @builtin {type ArrayView as View}
 
 // Traits
-

--- a/bench/pkg.generated.mbti
+++ b/bench/pkg.generated.mbti
@@ -34,4 +34,3 @@ pub impl @debug.Debug for Timestamp
 // Type aliases
 
 // Traits
-

--- a/bigint/pkg.generated.mbti
+++ b/bigint/pkg.generated.mbti
@@ -80,4 +80,3 @@ pub impl @json.FromJson for BigInt
 // Type aliases
 
 // Traits
-

--- a/bool/pkg.generated.mbti
+++ b/bool/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/core/bool"
 // Type aliases
 
 // Traits
-

--- a/buffer/pkg.generated.mbti
+++ b/buffer/pkg.generated.mbti
@@ -84,4 +84,3 @@ pub impl Leb128 for Int
 pub impl Leb128 for Int64
 pub impl Leb128 for UInt
 pub impl Leb128 for UInt64
-

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -1647,4 +1647,3 @@ pub trait ToStringView {
 }
 pub impl ToStringView for String
 pub impl ToStringView for StringView
-

--- a/byte/pkg.generated.mbti
+++ b/byte/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub let min_value : Byte
 // Type aliases
 
 // Traits
-

--- a/bytes/internal/regex_engine/ast/pkg.generated.mbti
+++ b/bytes/internal/regex_engine/ast/pkg.generated.mbti
@@ -85,4 +85,3 @@ pub(all) struct Quantifier {
 // Type aliases
 
 // Traits
-

--- a/bytes/internal/regex_engine/pkg.generated.mbti
+++ b/bytes/internal/regex_engine/pkg.generated.mbti
@@ -85,4 +85,3 @@ pub trait Input {
 }
 pub impl Input for BytesView
 pub impl Input for StringView
-

--- a/bytes/internal/regex_engine/symbol_map/pkg.generated.mbti
+++ b/bytes/internal/regex_engine/symbol_map/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub trait Table {
   fn map(Self, Int) -> Int
   fn map_set(Self, @rechar_set.RecharSet) -> @rechar_set.RecharSet
 }
-

--- a/bytes/pkg.generated.mbti
+++ b/bytes/pkg.generated.mbti
@@ -33,4 +33,3 @@ pub fn MatchResult::named_group(Self, String) -> BytesView?
 pub using @builtin {type BytesView as View}
 
 // Traits
-

--- a/char/pkg.generated.mbti
+++ b/char/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/core/char"
 // Type aliases
 
 // Traits
-

--- a/cmp/pkg.generated.mbti
+++ b/cmp/pkg.generated.mbti
@@ -32,4 +32,3 @@ pub impl[T : Show] Show for Reverse[T]
 // Type aliases
 
 // Traits
-

--- a/coverage/pkg.generated.mbti
+++ b/coverage/pkg.generated.mbti
@@ -18,4 +18,3 @@ pub impl Show for CoverageCounter
 // Type aliases
 
 // Traits
-

--- a/debug/pkg.generated.mbti
+++ b/debug/pkg.generated.mbti
@@ -93,4 +93,3 @@ pub impl[A : Debug, B : Debug, C : Debug, D : Debug, E : Debug, F : Debug, G : D
 pub impl[A : Debug, B : Debug, C : Debug, D : Debug, E : Debug, F : Debug, G : Debug, H : Debug, I : Debug, J : Debug, K : Debug, L : Debug, M : Debug, N : Debug, O : Debug, P : Debug, Q : Debug, R : Debug, S : Debug, T : Debug, U : Debug, V : Debug] Debug for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
 pub impl Debug for BytesView
 pub impl Debug for StringView
-

--- a/deque/pkg.generated.mbti
+++ b/deque/pkg.generated.mbti
@@ -100,4 +100,3 @@ pub impl[A : @json.FromJson] @json.FromJson for Deque[A]
 // Type aliases
 
 // Traits
-

--- a/diff/pkg.generated.mbti
+++ b/diff/pkg.generated.mbti
@@ -57,4 +57,3 @@ pub fn LevenshteinEdit::equal(Self, Self) -> Bool
 // Type aliases
 
 // Traits
-

--- a/double/pkg.generated.mbti
+++ b/double/pkg.generated.mbti
@@ -47,4 +47,3 @@ pub fn Double::nan() -> Double
 // Type aliases
 
 // Traits
-

--- a/encoding/ascii/pkg.generated.mbti
+++ b/encoding/ascii/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub suberror Malformed {
 // Type aliases
 
 // Traits
-

--- a/encoding/base64/pkg.generated.mbti
+++ b/encoding/base64/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub suberror Malformed {
 // Type aliases
 
 // Traits
-

--- a/encoding/utf16/pkg.generated.mbti
+++ b/encoding/utf16/pkg.generated.mbti
@@ -26,4 +26,3 @@ pub(all) enum Endian {
 // Type aliases
 
 // Traits
-

--- a/encoding/utf8/pkg.generated.mbti
+++ b/encoding/utf8/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub suberror Malformed {
 // Type aliases
 
 // Traits
-

--- a/env/pkg.generated.mbti
+++ b/env/pkg.generated.mbti
@@ -25,4 +25,3 @@ pub fn unset_env_var(String) -> Unit
 // Type aliases
 
 // Traits
-

--- a/error/pkg.generated.mbti
+++ b/error/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub impl @debug.Debug for Error
 // Type aliases
 
 // Traits
-

--- a/float/pkg.generated.mbti
+++ b/float/pkg.generated.mbti
@@ -86,4 +86,3 @@ pub impl ToJson for Float
 // Type aliases
 
 // Traits
-

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -68,4 +68,3 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V]
 // Type aliases
 
 // Traits
-

--- a/hashset/pkg.generated.mbti
+++ b/hashset/pkg.generated.mbti
@@ -66,4 +66,3 @@ pub impl[K : @debug.Debug] @debug.Debug for HashSet[K]
 // Type aliases
 
 // Traits
-

--- a/immut/array/pkg.generated.mbti
+++ b/immut/array/pkg.generated.mbti
@@ -80,4 +80,3 @@ pub impl[A : @debug.Debug] @debug.Debug for T[A]
 // Type aliases
 
 // Traits
-

--- a/immut/hashmap/pkg.generated.mbti
+++ b/immut/hashmap/pkg.generated.mbti
@@ -65,4 +65,3 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V]
 // Type aliases
 
 // Traits
-

--- a/immut/hashset/pkg.generated.mbti
+++ b/immut/hashset/pkg.generated.mbti
@@ -45,4 +45,3 @@ pub impl[K : @debug.Debug] @debug.Debug for HashSet[K]
 // Type aliases
 
 // Traits
-

--- a/immut/internal/path/pkg.generated.mbti
+++ b/immut/internal/path/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub fn Path::push(Self, Int) -> Self
 // Type aliases
 
 // Traits
-

--- a/immut/internal/sparse_array/pkg.generated.mbti
+++ b/immut/internal/sparse_array/pkg.generated.mbti
@@ -38,4 +38,3 @@ pub fn[X] SparseArray::union(Self[X], Self[X], (X, X) -> X raise?) -> Self[X] ra
 // Type aliases
 
 // Traits
-

--- a/immut/priority_queue/pkg.generated.mbti
+++ b/immut/priority_queue/pkg.generated.mbti
@@ -45,4 +45,3 @@ pub impl[A : @debug.Debug + Compare] @debug.Debug for PriorityQueue[A]
 // Type aliases
 
 // Traits
-

--- a/immut/sorted_map/pkg.generated.mbti
+++ b/immut/sorted_map/pkg.generated.mbti
@@ -82,4 +82,3 @@ pub impl[V : @json.FromJson] @json.FromJson for SortedMap[String, V]
 // Type aliases
 
 // Traits
-

--- a/immut/sorted_set/pkg.generated.mbti
+++ b/immut/sorted_set/pkg.generated.mbti
@@ -80,4 +80,3 @@ pub impl[A : @json.FromJson + Compare] @json.FromJson for SortedSet[A]
 // Type aliases
 
 // Traits
-

--- a/immut/vector/pkg.generated.mbti
+++ b/immut/vector/pkg.generated.mbti
@@ -76,4 +76,3 @@ pub impl[A : @json.FromJson] @json.FromJson for Vector[A]
 // Type aliases
 
 // Traits
-

--- a/int/pkg.generated.mbti
+++ b/int/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub let min_value : Int
 // Type aliases
 
 // Traits
-

--- a/int16/pkg.generated.mbti
+++ b/int16/pkg.generated.mbti
@@ -61,4 +61,3 @@ pub impl ToJson for Int16
 // Type aliases
 
 // Traits
-

--- a/int64/pkg.generated.mbti
+++ b/int64/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn Int64::to_int16(Int64) -> Int16
 // Type aliases
 
 // Traits
-

--- a/internal/edit_distance/pkg.generated.mbti
+++ b/internal/edit_distance/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn[T : Eq] edit_distance_within(ArrayView[T], ArrayView[T], max_distance~ : 
 // Type aliases
 
 // Traits
-

--- a/internal/regex_engine/automata/pkg.generated.mbti
+++ b/internal/regex_engine/automata/pkg.generated.mbti
@@ -80,4 +80,3 @@ pub enum Status {
 // Type aliases
 
 // Traits
-

--- a/internal/regex_engine/shared_types/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/pkg.generated.mbti
@@ -58,4 +58,3 @@ pub type Rechar = Int
 pub using @rechar_set {type RecharSet}
 
 // Traits
-

--- a/internal/regex_engine/shared_types/rechar_set/pkg.generated.mbti
+++ b/internal/regex_engine/shared_types/rechar_set/pkg.generated.mbti
@@ -37,4 +37,3 @@ pub impl @debug.Debug for RecharSet
 pub type Rechar = Int
 
 // Traits
-

--- a/internal/strconv/pkg.generated.mbti
+++ b/internal/strconv/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn parse_uint64(StringView, base? : Int) -> UInt64 raise
 // Type aliases
 
 // Traits
-

--- a/json/pkg.generated.mbti
+++ b/json/pkg.generated.mbti
@@ -122,4 +122,3 @@ pub impl[T0 : FromJson, T1 : FromJson, T2 : FromJson, T3 : FromJson, T4 : FromJs
 pub impl[T0 : FromJson, T1 : FromJson, T2 : FromJson, T3 : FromJson, T4 : FromJson, T5 : FromJson, T6 : FromJson, T7 : FromJson, T8 : FromJson, T9 : FromJson, T10 : FromJson, T11 : FromJson, T12 : FromJson, T13 : FromJson, T14 : FromJson] FromJson for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
 pub impl[T0 : FromJson, T1 : FromJson, T2 : FromJson, T3 : FromJson, T4 : FromJson, T5 : FromJson, T6 : FromJson, T7 : FromJson, T8 : FromJson, T9 : FromJson, T10 : FromJson, T11 : FromJson, T12 : FromJson, T13 : FromJson, T14 : FromJson, T15 : FromJson] FromJson for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
 pub impl FromJson for StringView
-

--- a/lazy/pkg.generated.mbti
+++ b/lazy/pkg.generated.mbti
@@ -20,4 +20,3 @@ pub impl[A : @debug.Debug] @debug.Debug for Lazy[A]
 // Type aliases
 
 // Traits
-

--- a/lazy_list/pkg.generated.mbti
+++ b/lazy_list/pkg.generated.mbti
@@ -38,4 +38,3 @@ pub impl[A : @debug.Debug] @debug.Debug for LazyList[A]
 // Type aliases
 
 // Traits
-

--- a/lexbuf/pkg.generated.mbti
+++ b/lexbuf/pkg.generated.mbti
@@ -20,4 +20,3 @@ pub fn Lexbuf::from_string(String) -> Self
 // Type aliases
 
 // Traits
-

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -123,4 +123,3 @@ pub impl[A : @json.FromJson] @json.FromJson for List[A]
 // Type aliases
 
 // Traits
-

--- a/math/pkg.generated.mbti
+++ b/math/pkg.generated.mbti
@@ -125,4 +125,3 @@ pub fn trunc(Double) -> Double
 // Type aliases
 
 // Traits
-

--- a/option/pkg.generated.mbti
+++ b/option/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn[T] when(Bool, () -> T) -> T?
 // Type aliases
 
 // Traits
-

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -172,4 +172,3 @@ pub using @builtin {trait Sub}
 pub using @builtin {trait ToJson}
 
 // Traits
-

--- a/priority_queue/pkg.generated.mbti
+++ b/priority_queue/pkg.generated.mbti
@@ -43,4 +43,3 @@ pub impl[A : @debug.Debug + Compare] @debug.Debug for PriorityQueue[A]
 // Type aliases
 
 // Traits
-

--- a/queue/pkg.generated.mbti
+++ b/queue/pkg.generated.mbti
@@ -44,4 +44,3 @@ pub impl[A : @debug.Debug] @debug.Debug for Queue[A]
 // Type aliases
 
 // Traits
-

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -96,4 +96,3 @@ pub impl[A : Arbitrary, B : Arbitrary, C : Arbitrary, D : Arbitrary] Arbitrary f
 pub impl[A : Arbitrary, B : Arbitrary, C : Arbitrary, D : Arbitrary, E : Arbitrary] Arbitrary for (A, B, C, D, E)
 pub impl[A : Arbitrary, B : Arbitrary, C : Arbitrary, D : Arbitrary, E : Arbitrary, F : Arbitrary] Arbitrary for (A, B, C, D, E, F)
 pub impl[A : Arbitrary, B : Arbitrary, C : Arbitrary, D : Arbitrary, E : Arbitrary, F : Arbitrary, G : Arbitrary] Arbitrary for (A, B, C, D, E, F, G)
-

--- a/quickcheck/shrink/pkg.generated.mbti
+++ b/quickcheck/shrink/pkg.generated.mbti
@@ -55,4 +55,3 @@ pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink, F : Shrink]
 pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink, F : Shrink, G : Shrink] Shrink for (A, B, C, D, E, F, G)
 pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink, F : Shrink, G : Shrink, H : Shrink] Shrink for (A, B, C, D, E, F, G, H)
 pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink, F : Shrink, G : Shrink, H : Shrink, I : Shrink] Shrink for (A, B, C, D, E, F, G, H, I)
-

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -31,4 +31,3 @@ pub impl Default for RandomState
 // Type aliases
 
 // Traits
-

--- a/random/internal/random_source/pkg.generated.mbti
+++ b/random/internal/random_source/pkg.generated.mbti
@@ -14,4 +14,3 @@ pub fn ChaCha8::refill(Self) -> Unit
 // Type aliases
 
 // Traits
-

--- a/random/pkg.generated.mbti
+++ b/random/pkg.generated.mbti
@@ -36,4 +36,3 @@ pub impl @debug.Debug for Rand
 pub(open) trait Source {
   fn next(Self) -> UInt64
 }
-

--- a/range/pkg.generated.mbti
+++ b/range/pkg.generated.mbti
@@ -26,4 +26,3 @@ pub impl Step for UInt64
 pub impl Step for Float
 pub impl Step for Double
 pub impl Step for @bigint.BigInt
-

--- a/ref/pkg.generated.mbti
+++ b/ref/pkg.generated.mbti
@@ -28,4 +28,3 @@ pub impl[T : @debug.Debug] @debug.Debug for Ref[T]
 // Type aliases
 
 // Traits
-

--- a/result/pkg.generated.mbti
+++ b/result/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn[T, E] Result::is_ok(Self[T, E]) -> Bool
 // Type aliases
 
 // Traits
-

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -67,4 +67,3 @@ pub impl[K : @debug.Debug] @debug.Debug for Set[K]
 // Type aliases
 
 // Traits
-

--- a/sorted_map/pkg.generated.mbti
+++ b/sorted_map/pkg.generated.mbti
@@ -67,4 +67,3 @@ pub impl[V : @json.FromJson] @json.FromJson for SortedMap[String, V]
 // Type aliases
 
 // Traits
-

--- a/sorted_set/pkg.generated.mbti
+++ b/sorted_set/pkg.generated.mbti
@@ -58,4 +58,3 @@ pub impl[V : @debug.Debug] @debug.Debug for SortedSet[V]
 // Type aliases
 
 // Traits
-

--- a/strconv/pkg.generated.mbti
+++ b/strconv/pkg.generated.mbti
@@ -71,4 +71,3 @@ pub impl FromStr for Int64
 pub impl FromStr for UInt
 pub impl FromStr for UInt64
 pub impl FromStr for Double
-

--- a/string/internal/regex_engine/ast/pkg.generated.mbti
+++ b/string/internal/regex_engine/ast/pkg.generated.mbti
@@ -85,4 +85,3 @@ pub(all) struct Quantifier {
 // Type aliases
 
 // Traits
-

--- a/string/internal/regex_engine/pkg.generated.mbti
+++ b/string/internal/regex_engine/pkg.generated.mbti
@@ -79,4 +79,3 @@ pub type Rechar = Int
 pub using @rechar_set {type RecharSet}
 
 // Traits
-

--- a/string/internal/regex_engine/symbol_map/pkg.generated.mbti
+++ b/string/internal/regex_engine/symbol_map/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub fn Table::map_set(Self, @rechar_set.RecharSet) -> @rechar_set.RecharSet
 // Type aliases
 
 // Traits
-

--- a/string/internal/regex_parser/pkg.generated.mbti
+++ b/string/internal/regex_parser/pkg.generated.mbti
@@ -24,4 +24,3 @@ pub(all) enum Mode {
 // Type aliases
 
 // Traits
-

--- a/string/pkg.generated.mbti
+++ b/string/pkg.generated.mbti
@@ -69,4 +69,3 @@ pub impl FromStr for UInt
 pub impl FromStr for UInt64
 pub impl FromStr for Double
 pub impl FromStr for @bigint.BigInt
-

--- a/test/pkg.generated.mbti
+++ b/test/pkg.generated.mbti
@@ -53,4 +53,3 @@ pub fn Test::writeln(Self, &Show) -> Unit
 // Type aliases
 
 // Traits
-

--- a/tuple/pkg.generated.mbti
+++ b/tuple/pkg.generated.mbti
@@ -39,4 +39,3 @@ pub impl[A : Default, B : Default, C : Default, D : Default, E : Default, F : De
 // Type aliases
 
 // Traits
-

--- a/uint/pkg.generated.mbti
+++ b/uint/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub impl Default for UInt
 // Type aliases
 
 // Traits
-

--- a/uint16/pkg.generated.mbti
+++ b/uint16/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn UInt16::reinterpret_as_int16(UInt16) -> Int16
 // Type aliases
 
 // Traits
-

--- a/uint64/pkg.generated.mbti
+++ b/uint64/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub let min_value : UInt64
 // Type aliases
 
 // Traits
-

--- a/unit/pkg.generated.mbti
+++ b/unit/pkg.generated.mbti
@@ -12,4 +12,3 @@ pub fn default() -> Unit
 // Type aliases
 
 // Traits
-

--- a/v128/pkg.generated.mbti
+++ b/v128/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub impl @debug.Debug for V128
 // Type aliases
 
 // Traits
-


### PR DESCRIPTION
## Summary

- regenerate all tracked `pkg.generated.mbti` files with the current stable MoonBit toolchain
- accept the generator's removal of the trailing blank line in 79 interface files

## Root cause

The stable toolchain now emits generated interfaces without an extra final blank line. The `stable-check` workflow runs `moon info` and then `git diff --exit-code`, so the stale checked-in output caused the `moon info` job to fail on macOS, Ubuntu, and Windows.

This is generated-output normalization only; no public API declarations change. It also unblocks the stable checks observed on #3970.

## Validation

- `moon info --target wasm,wasm-gc,js,native && git diff --exit-code`
- `moon fmt`
- `moon check --warn-list +unnecessary_annotation`
- `moon test` — 7,000 tests passed
