### PR TITLE
make ArgGroup abstract

### DIFF
--- a/argparse/arg_group.mbt
+++ b/argparse/arg_group.mbt
@@ -14,13 +14,13 @@
 
 ///|
 /// Declarative argument group constructor.
-pub struct ArgGroup {
-  priv name : String
-  priv required : Bool
-  priv multiple : Bool
-  priv args : Array[String]
-  priv requires : Array[String]
-  priv conflicts_with : Array[String]
+struct ArgGroup {
+  name : String
+  required : Bool
+  multiple : Bool
+  args : Array[String]
+  requires : Array[String]
+  conflicts_with : Array[String]
 } derive(@debug.Debug)
 
 ///|

--- a/argparse/pkg.generated.mbti
+++ b/argparse/pkg.generated.mbti
@@ -10,9 +10,7 @@ import {
 // Errors
 
 // Types and methods
-pub struct ArgGroup {
-  // private fields
-} derive(@debug.Debug)
+type ArgGroup derive(@debug.Debug)
 #alias(new, deprecated)
 pub fn ArgGroup::ArgGroup(StringView, required? : Bool, multiple? : Bool, args? : ArrayView[String], requires? : ArrayView[String], conflicts_with? : ArrayView[String]) -> Self
 


### PR DESCRIPTION
Remove `pub` from `ArgGroup` struct and drop the now-redundant `priv` keywords on all its fields. Since the struct is no longer `pub`, all fields are naturally package-private without needing `priv` annotations.