### PR TITLE
feat(quickcheck): classify coverage labels on report; make QuickCheckReport matchable

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -89,15 +89,41 @@ test "inspect a counterexample" {
 }
 ```
 
-`report` returns an abstract `QuickCheckReport[A]` whose `Debug`
-representation distinguishes `Passed`, `GaveUp`, `Falsified`, and `Raised`.
-Every error from the property is represented by `Raised`; the driver does not
-distinguish errors used by `inspect` or snapshot tests. Calling `report` itself
-does not raise and does not require the input type to implement `Debug`.
+`report` returns a `QuickCheckReport[A]` that can be pattern matched on
+`Passed`, `GaveUp`, `Falsified`, and `Raised` (its `Debug` representation
+shows the same structure). Every error from the property is represented by
+`Raised`; the driver does not distinguish errors used by `inspect` or snapshot
+tests. Calling `report` itself does not raise and does not require the input
+type to implement `Debug`.
 
 Properties should be deterministic and should not mutate or consume their
 input. In particular, an `Iter` is single-use; generate an `Array` and create a
 fresh iterator inside the property when replayable sequence behavior matters.
+
+## Coverage Classification
+
+`report` accepts `classify` labels — `(name, predicate)` pairs tallied over
+every accepted test case — so a test can assert that the generator keeps
+exercising the interesting regions of the input space. Counts come back in
+`Passed(labels~)` in declaration order, including labels that never matched:
+
+```mbt check
+///|
+test "classification labels" {
+  let result = @quickcheck.report(
+    (_ : Int) => true,
+    classify=[("negative", x => x < 0), ("even", x => x % 2 == 0)],
+    seed=11,
+  )
+  guard result is Passed(tests=100, labels~) else { fail("expected pass") }
+  debug_inspect(
+    labels,
+    content=(
+      #|{ "negative": 46, "even": 55 }
+    ),
+  )
+}
+```
 
 ## Basic Usage
 

--- a/quickcheck/driver.mbt
+++ b/quickcheck/driver.mbt
@@ -51,8 +51,8 @@ priv enum CaseOutcome {
 /// `tests` includes the failing test case. `shrinks` counts accepted shrink
 /// steps, while `shrink_attempts` counts every shrink candidate examined,
 /// including candidates rejected by `filter`.
-enum QuickCheckReport[A] {
-  Passed(tests~ : UInt)
+pub enum QuickCheckReport[A] {
+  Passed(tests~ : UInt, labels~ : Map[String, UInt])
   /// The configured discard budget was exhausted before `count` tests completed.
   GaveUp(tests~ : UInt, discarded~ : UInt)
   Falsified(
@@ -168,22 +168,48 @@ fn[A : @debug.Debug] failure_report(report : QuickCheckReport[A]) -> String {
 /// does not require the input type to implement `Debug`. Cases rejected by the
 /// pure `filter` do not count as tests. The run gives up after `discard_ratio`
 /// discarded cases per requested test.
+///
+/// `classify` labels test cases for coverage statistics: each passing case is
+/// tallied against every `(label, predicate)` pair it satisfies, and the
+/// counts are returned in `Passed(labels~)` (in declaration order, including
+/// labels that never matched). Use this to check that generators keep
+/// exercising the interesting regions of the input space:
+///
+/// ```mbt check
+/// test "coverage of even inputs" {
+///   let result = @quickcheck.report((_ : Int) => true, classify=[
+///     ("even", x => x % 2 == 0),
+///   ])
+///   guard result is Passed(tests=100, labels~) else { fail("expected pass") }
+///   assert_true(labels.get("even") is Some(hits) && hits > 30 && hits < 70)
+/// }
+/// ```
 pub fn[A : Arbitrary + @shrink.Shrink] report(
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
+  classify? : Array[(String, (A) -> Bool)] = [],
   count? : UInt = 100,
   max_size? : UInt = 100,
   max_shrinks? : UInt = 100,
   discard_ratio? : UInt = 10,
   seed? : UInt64 = 37,
 ) -> QuickCheckReport[A] {
+  let labels : Map[String, UInt] = Map(classify.map(entry => (entry.0, 0U)))
   let state = @splitmix.new(seed~)
   for tests = 0U, discarded = 0U, recent_discards = 0U; tests < count; {
     let size = size_at(tests, count, max_size, recent_discards)
     let input : A = Arbitrary::arbitrary(size, state.split())
     let outcome = evaluate_case(property, filter, input)
     match outcome {
-      Passed => continue tests + 1, discarded, 0U
+      Passed => {
+        for entry in classify {
+          let (label, predicate) = entry
+          if predicate(input) {
+            labels[label] = labels[label] + 1
+          }
+        }
+        continue tests + 1, discarded, 0U
+      }
       Discarded => {
         let next_discarded = discarded + 1
         if discard_ratio == 0 || next_discarded / discard_ratio >= count {
@@ -222,7 +248,7 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
       }
     }
   } nobreak {
-    Passed(tests=count)
+    Passed(tests=count, labels~)
   }
 }
 

--- a/quickcheck/driver.mbt
+++ b/quickcheck/driver.mbt
@@ -194,7 +194,14 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
   discard_ratio? : UInt = 10,
   seed? : UInt64 = 37,
 ) -> QuickCheckReport[A] {
-  let labels : Map[String, UInt] = Map(classify.map(entry => (entry.0, 0U)))
+  let labels : Map[String, UInt] = Map([])
+  for entry in classify {
+    let (label, _) = entry
+    guard !labels.contains(label) else {
+      abort("report: duplicate classify label `\{label}`")
+    }
+    labels[label] = 0U
+  }
   let state = @splitmix.new(seed~)
   for tests = 0U, discarded = 0U, recent_discards = 0U; tests < count; {
     let size = size_at(tests, count, max_size, recent_discards)

--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -461,3 +461,13 @@ test "classification only counts accepted cases" {
   inspect(tests, content="50")
   debug_inspect(labels.get("even"), content="Some(50)")
 }
+
+///|
+test "panic report rejects duplicate classify labels" {
+  ignore(
+    @quickcheck.report((_ : Int) => true, classify=[
+      ("dup", _ => true),
+      ("dup", _ => false),
+    ]),
+  )
+}

--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -91,7 +91,12 @@ priv suberror QcError {
 ///|
 test "report returns a structured passing report" {
   let report = @quickcheck.report((x : Int) => x == x, count=2, seed=7)
-  debug_inspect(report, content="Passed(tests=2)")
+  debug_inspect(
+    report,
+    content=(
+      #|Passed(tests=2, labels={})
+    ),
+  )
 }
 
 ///|
@@ -421,4 +426,38 @@ test "report accepts InspectError while shrinking Raised" {
       #|)
     ),
   )
+}
+
+///|
+test "report tallies classification labels" {
+  let result = @quickcheck.report(
+    (_ : Int) => true,
+    classify=[
+      ("negative", x => x < 0),
+      ("even", x => x % 2 == 0),
+      ("huge", x => x > 1000000),
+    ],
+    count=100,
+    seed=11,
+  )
+  debug_inspect(
+    result,
+    content=(
+      #|Passed(tests=100, labels={ "negative": 46, "even": 55, "huge": 0 })
+    ),
+  )
+}
+
+///|
+test "classification only counts accepted cases" {
+  let result = @quickcheck.report(
+    (_ : Int) => true,
+    filter=x => x % 2 == 0,
+    classify=[("even", x => x % 2 == 0)],
+    count=50,
+    seed=3,
+  )
+  guard result is Passed(tests~, labels~) else { fail("expected pass") }
+  inspect(tests, content="50")
+  debug_inspect(labels.get("even"), content="Some(50)")
 }

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -28,7 +28,7 @@ pub fn[T] one_of(Array[Generator[T]]) -> Generator[T]
 
 pub fn[T] pure(T) -> Generator[T]
 
-pub fn[A : Arbitrary + @shrink.Shrink] report((A) -> Bool raise?, filter? : (A) -> Bool, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
+pub fn[A : Arbitrary + @shrink.Shrink] report((A) -> Bool raise?, filter? : (A) -> Bool, classify? : Array[(String, (A) -> Bool)], count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
 
 pub fn[X : Arbitrary] samples(Int) -> Array[X]
 
@@ -48,7 +48,12 @@ pub fn[T] Generator::sample(Self[T], size? : Int, seed? : UInt64) -> T
 pub fn[T] Generator::samples(Self[T], count? : Int, size? : Int, seed? : UInt64) -> Array[T]
 pub fn[T] Generator::scale(Self[T], (Int) -> Int) -> Self[T]
 
-type QuickCheckReport[A] derive(@debug.Debug)
+pub enum QuickCheckReport[A] {
+  Passed(tests~ : UInt, labels~ : Map[String, UInt])
+  GaveUp(tests~ : UInt, discarded~ : UInt)
+  Falsified(counterexample~ : A, tests~ : UInt, size~ : Int, shrinks~ : UInt, shrink_attempts~ : UInt)
+  Raised(counterexample~ : A, error~ : Error, tests~ : UInt, size~ : Int, shrinks~ : UInt, shrink_attempts~ : UInt)
+} derive(@debug.Debug)
 
 // Type aliases
 pub using @splitmix {type RandomState}


### PR DESCRIPTION
Follow-up to #3955, second of three scoped PRs from https://github.com/moonbitlang/core/pull/3955#issuecomment-5189971358. Restores the coverage-statistics workflow (`classify`/`label` in classic QuickCheck) that migrating projects lose — in moonbit-community/toml-parser#122 we had to hand-roll a fixed-seed sample tally to keep distribution regressions visible.

- `report()` gains `classify? : Array[(String, (A) -> Bool)]`: each accepted case is tallied against every label; counts are returned in `Passed(labels~)` in declaration order, including labels that never matched (a dead generator branch shows as an explicit `0`).
- `QuickCheckReport` becomes `pub` — pattern-matchable but still not constructible. Without this, callers can only render results via `Debug` (even this package's own black-box tests can't destructure a report), and `classify`'s counts would be unreachable. Existing `Passed` debug snapshots gain a `labels={}` field.

The two changes ship together because classify's tests and docs require the matchable enum.

Test plan: new driver tests (label tally snapshot; filter interaction — discarded cases are not tallied), README section with a checked example, docstring example on `report`; `moon test quickcheck` 60/60; `moon check --deny-warn`, `moon fmt`, `moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)