### PR TITLE
refactor: replace remaining internal `op_get` with `at` + `#alias("_[_]")`

### DIFF
--- a/diff/compact.mbt
+++ b/diff/compact.mbt
@@ -22,7 +22,8 @@ priv struct CompactedElements[T]((ArrayView[T], FixedArray[Int]))
 
 ///|
 /// Read the `index`th retained element.
-fn[T] CompactedElements::op_get(self : CompactedElements[T], index : Int) -> T {
+#alias("_[_]")
+fn[T] CompactedElements::at(self : CompactedElements[T], index : Int) -> T {
   let (source, indices) = self.0
   source[indices[index]]
 }

--- a/diff/piles.mbt
+++ b/diff/piles.mbt
@@ -37,7 +37,8 @@ fn Piles::last(self : Piles) -> Pile? {
 }
 
 ///|
-fn Piles::op_get(self : Piles, i : Int) -> Pile {
+#alias("_[_]")
+fn Piles::at(self : Piles, i : Int) -> Pile {
   self.0[i]
 }
 

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -50,7 +50,7 @@ test "stringview subview" {
 }
 
 ///|
-test "stringview op_get" {
+test "stringview access" {
   let str = "Hello🤣🤣🤣"
   let view = str.view(start_offset=1, end_offset=7)
   inspect(view.iter().nth(4).unwrap(), content="🤣")
@@ -58,7 +58,7 @@ test "stringview op_get" {
 }
 
 ///|
-test "stringview op_get iter" {
+test "stringview access iter" {
   let str = "Hello🤣🤣🤣"
   let view = str.view(start_offset=1, end_offset=7)
   inspect(view.iter().nth(4).unwrap(), content="🤣")
@@ -1018,12 +1018,12 @@ test "StringView add" {
   inspect(view7 + view8, content="Hello🤣World")
 }
 
-// Added test to ensure StringView::op_get abort is covered
+// Added test to ensure StringView::at abort is covered
 // Accessing an index beyond the view length should panic
-// and cover the "Index out of bounds" branch in StringView::op_get.
+// and cover the "Index out of bounds" branch in StringView::at.
 
 ///|
-test "panic view op_get out of bounds" {
+test "panic view access out of bounds" {
   let str = "Hello"
   let view = str.view(start_offset=0, end_offset=5)
   view.code_unit_at(5) |> ignore


### PR DESCRIPTION
`CompactedElements::op_get` (`diff/compact.mbt`) and `Piles::op_get` (`diff/piles.mbt`) were the last internal methods still carrying the `op_get` name for indexing. This renames them to `at` and attaches `#alias("_[_]")`, matching the convention already in place across `builtin`, `immut`, `hashmap`, `deque`, `sorted_map` and the regex engines.

Both methods are private, so `moon info` produces **no `.mbti` diff** — indexing syntax `x[i]` keeps working unchanged at every call site.

Also refreshes stale `op_get` references left behind in `string/view_test.mbt` test names and comments (that type's accessor is `code_unit_at` now).

## Verification

- `moon check` — clean
- `moon info && moon fmt` — no `.mbti` changes, no formatting changes
- `moon test` — 7018/7018 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)