### PR TITLE
perf(deque,queue,priority_queue): annotate consuming parameters with #owned

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -410,6 +410,7 @@ pub fn[A] Deque::append(self : Deque[A], other : Deque[A]) -> Unit {
 ///   )
 /// }
 /// ```
+#owned(value)
 pub fn[A] Deque::insert(self : Deque[A], index : Int, value : A) -> Unit {
   guard index >= 0 && index <= self.length() else {
     abort(
@@ -631,6 +632,7 @@ pub fn[A] Deque::back(self : Deque[A]) -> A? {
 ///   @test.assert_eq(dv.front(), Some(0))
 /// }
 /// ```
+#owned(value)
 pub fn[A] Deque::push_front(self : Deque[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
@@ -654,6 +656,7 @@ pub fn[A] Deque::push_front(self : Deque[A], value : A) -> Unit {
 ///   @test.assert_eq(dv.back(), Some(6))
 /// }
 /// ```
+#owned(value)
 pub fn[A] Deque::push_back(self : Deque[A], value : A) -> Unit {
   if self.len == self.buf.length() {
     self.realloc()
@@ -836,6 +839,7 @@ pub fn[A] Deque::at(self : Deque[A], index : Int) -> A {
 /// }
 /// ```
 #alias("_[_]=_")
+#owned(value)
 pub fn[A] Deque::set(self : Deque[A], index : Int, value : A) -> Unit {
   if index < 0 || index >= self.len {
     index_out_of_bounds(self.len, index)

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -154,6 +154,7 @@ pub fn[K : Compare] PriorityQueue::from_iter(
 }
 
 ///|
+#owned(x, y)
 fn[A : Compare] meld(x : Node[A], y : Node[A]) -> Node[A] {
   if x.content > y.content {
     y.sibling = x.child
@@ -167,6 +168,7 @@ fn[A : Compare] meld(x : Node[A], y : Node[A]) -> Node[A] {
 }
 
 ///|
+#owned(x)
 fn[A : Compare] merges(x : Node[A]?) -> Node[A]? {
   let (x, acc) = match x {
     None => return None
@@ -251,6 +253,7 @@ pub fn[A : Compare] PriorityQueue::pop(self : PriorityQueue[A]) -> A? {
 ///   @test.assert_eq(queue.length(), 1)
 /// }
 /// ```
+#owned(value)
 pub fn[A : Compare] PriorityQueue::push(
   self : PriorityQueue[A],
   value : A,

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -103,6 +103,7 @@ pub fn[A] Queue::is_empty(self : Queue[A]) -> Bool {
 ///   queue.push(1)
 /// }
 /// ```
+#owned(x)
 pub fn[A] Queue::push(self : Queue[A], x : A) -> Unit {
   self.inner.push_back(x)
 }


### PR DESCRIPTION
## What

Adds `#owned(...)` to parameters whose reference is consumed (stored into the data structure, or returned) on every non-panic path — 8 annotations:

- `Deque`: `push_back`, `push_front`, `insert`, `set` — the value is stored into `self.buf` unconditionally
- `Queue::push` — forwards into the now-owned `Deque::push_back`
- `PriorityQueue`: `push`, plus the private `meld`/`merges` node plumbing (every branch either stores the node into the other node or returns it)

## Why

`#owned` transfers ownership of one reference from caller to callee. For last-use call sites (the common pattern, e.g. `q.push(compute())` or pushing elements read out of another container), the reference moves into the store instead of paying an incref inside the callee plus a decref at the caller. Non-last-use callers incref before the call, which just relocates the incref the callee would have done — never worse.

## Benchmarks

Native target, 10k pre-built `String` elements per op (so every store is an RC operation and value allocation is outside the timed region). Two binaries built from identical bench source, with and without this branch, run strictly interleaved; medians across rounds; two independent sessions.

| bench | session 1 (10 rounds) | session 2 (8 rounds) |
|---|---|---|
| `Deque::push_back` | −5.2% | −3.4% |
| `PriorityQueue::push` | −7.7% | −9.9% |
| `PriorityQueue` push+drain | −11.4% | −12.3% |

Control benches over packages this branch does not touch (`Array::push`, `HashMap::set`, `Map::set`, `FixedArray::fill`) stayed within ±1%, confirming the harness isolates the change. (An allocation-dominated `List::prepend` control swings ±14% on identical code — run-to-run noise on this machine — so treat single-digit deltas with matching spread as indicative, not exact.)

## Generated code (native C)

Per push of an element `s` read from another container, RC traffic drops from 3 ops to 1:

```c
// before                          // after
moonbit_incref(s);                 moonbit_incref(s);   // ownership moves into the call
Deque_push_back(dst, s);           Deque_push_back(dst, s);
moonbit_decref(s);                 // gone — callee consumed the reference

// inside push_back:               // inside push_back:
moonbit_incref(value);             // gone — the store consumes the owned ref
buf[write_idx] = value;            buf[write_idx] = value;
```

Static RC-op counts in the emitted function bodies: `Deque::push_back` store-side incref removed; `PriorityQueue::push` 5 → 2; `meld` 14 → 10; `merges` 17 → 12.