### PR TITLE
perf(hashmap,hashset,set): annotate consuming parameters with #owned

### DIFF
--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -101,6 +101,7 @@ pub fn[K : Hash + Eq, V] HashMap::HashMap(
 /// }
 /// ```
 #alias("_[_]=_")
+#owned(value)
 pub fn[K : Hash + Eq, V] HashMap::set(
   self : HashMap[K, V],
   key : K,
@@ -110,6 +111,7 @@ pub fn[K : Hash + Eq, V] HashMap::set(
 }
 
 ///|
+#owned(value)
 fn[K : Eq, V] HashMap::set_with_hash(
   self : HashMap[K, V],
   key : K,
@@ -157,6 +159,7 @@ fn[K : Eq, V] HashMap::set_with_hash(
 }
 
 ///|
+#owned(entry)
 fn[K, V] HashMap::push_away(
   self : HashMap[K, V],
   idx : Int,
@@ -733,6 +736,7 @@ fn[K, V] HashMap::grow(self : HashMap[K, V]) -> Unit {
 }
 
 ///|
+#owned(entry)
 fn[K, V] HashMap::rehash_place_entry(
   self : HashMap[K, V],
   entry : Entry[K, V],

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -114,6 +114,7 @@ fn[K : Eq] HashSet::add_with_hash(
 }
 
 ///|
+#owned(entry)
 fn[K] HashSet::push_away(
   self : HashSet[K],
   idx : Int,
@@ -142,6 +143,7 @@ fn[K] HashSet::push_away(
 
 ///|
 #inline
+#owned(entry)
 fn[K] HashSet::set_entry(
   self : HashSet[K],
   entry : Entry[K],
@@ -247,6 +249,7 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
 }
 
 ///|
+#owned(entry)
 fn[K] HashSet::rehash_place_entry(self : HashSet[K], entry : Entry[K]) -> Unit {
   let hash = entry.hash
   for psl = 0, idx = hash & self.capacity_mask {

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -156,6 +156,7 @@ fn[K : Eq] Set::add_with_hash(self : Set[K], key : K, hash : Int) -> Unit {
 }
 
 ///|
+#owned(entry)
 fn[K] Set::push_away(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
     match self.entries[idx] {
@@ -179,6 +180,7 @@ fn[K] Set::push_away(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
 }
 
 ///|
+#owned(entry)
 fn[K] Set::set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
   self.entries[new_idx] = Some(entry)
   match entry.next {
@@ -329,6 +331,7 @@ pub fn[K : Hash + Eq] Set::remove_and_check(self : Set[K], key : K) -> Bool {
 }
 
 ///|
+#owned(entry)
 fn[K] Set::add_entry_to_tail(
   self : Set[K],
   idx : Int,
@@ -398,6 +401,7 @@ fn[K] Set::grow(self : Set[K]) -> Unit {
 }
 
 ///|
+#owned(outer)
 fn[K] Set::rehash_place_entry(self : Set[K], outer : Entry[K]) -> Unit {
   let hash = outer.hash
   for psl = 0, idx = hash & self.capacity_mask {

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -182,11 +182,14 @@ fn[K] Set::push_away(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
 ///|
 #owned(entry)
 fn[K] Set::set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
-  self.entries[new_idx] = Some(entry)
+  // Fix up the neighbor links before the store: the store consumes the owned
+  // `entry` reference, and touching `entry` after it would force the compiler
+  // to keep `entry` alive across the store with an extra incref/decref pair.
   match entry.next {
     None => self.tail = new_idx
     Some(next) => next.prev = new_idx
   }
+  self.entries[new_idx] = Some(entry)
 }
 
 ///|


### PR DESCRIPTION
## What

Adds `#owned(...)` to parameters consumed on every path — 11 annotations plus one enabling reorder:

- `HashMap`: `set`/`set_with_hash` **value** (stored on both the insert and the update path), and the `push_away`/`rehash_place_entry` entry plumbing
- `HashSet`: `push_away`/`set_entry`/`rehash_place_entry` entry plumbing
- `Set` (insertion-ordered): `push_away`/`set_entry`/`add_entry_to_tail`/`rehash_place_entry` entry plumbing, mirroring the pre-existing `#owned` annotations on builtin `Map`
- **Keys stay borrowed** everywhere: they are dropped on the key-already-exists path, where `#owned` would cost non-last-use callers an extra incref/decref pair (same policy as builtin `Map`)

The second commit reorders `Set::set_entry` to fix up neighbor links *before* the consuming store. Reading `entry.next` after the store forced the compiler to keep the owned reference alive across it; the naive annotation made the body worse (1 incref/1 decref → 2/4), while store-last makes it better than baseline (0/1). Worth remembering when annotating: field reads of an owned param belong before its consuming store.

## Generated code (native C)

Static incref/decref counts per emitted body, baseline → this branch. Every diffed change is an instruction removal; nothing is added:

| function | baseline | owned |
|---|---|---|
| HashMap::set_with_hash | 6 / 6 | 3 / 5 |
| HashMap::push_away | 2 / 2 | 1 / 2 |
| HashMap::rehash_place_entry | 3 / 3 | 1 / 2 |
| HashSet::add_with_hash | 2 / 3 | 2 / 2 |
| HashSet::push_away | 2 / 2 | 1 / 2 |
| HashSet::rehash_place_entry | 3 / 3 | 1 / 2 |
| Set::add_with_hash | 2 / 3 | 2 / 1 |
| Set::push_away | 2 / 2 | 1 / 0 |
| Set::set_entry | 1 / 1 | 0 / 1 |
| Set::add_entry_to_tail | 4 / 4 | 3 / 4 |
| Set::rehash_place_entry | 1 / 1 | 1 / 0 |

## Benchmarks

Native, 10k pre-built `String` keys, interleaved A/B binaries, medians over 10-round sessions. Hashing + Robin Hood probing dominates these paths (~50-90ns/op), so wins are small by construction:

- `Set::add` with growth: **−4~7%**, consistent across three sessions and under forced code alignment
- `HashMap::set` (pre-sized and growing): ±1%, within this rig's noise floor
- `HashSet::add` with growth: measured +4% at first — investigated, and it is a code-placement artifact, not the annotation: the executed hashset path contains strictly fewer instructions (table above; the bench loop itself is byte-identical), the +4% reproduces with a hashset-only binary and under `-falign-functions=64`, and collapses to **+0.5%** when every basic block is force-aligned (`-mllvm -align-all-blocks=5`), which removes placement luck symmetrically.

Control benches over untouched packages stayed within ±1% in the same runs.