### PR TITLE
perf(immut): annotate consuming parameters with #owned

### DIFF
--- a/immut/array/array.mbt
+++ b/immut/array/array.mbt
@@ -28,6 +28,7 @@ pub fn[A] T::new() -> T[A] {
 /// Create a persistent array with a given length and value.
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
 #as_free_fn(deprecated="Use the corresponding function in `immut/vector` instead")
+#owned(value)
 pub fn[A] T::make(len : Int, value : A) -> T[A] {
   let quot = len / BRANCHING_FACTOR
   let rem = len % BRANCHING_FACTOR
@@ -237,6 +238,7 @@ pub fn[A] T::get(self : T[A], index : Int) -> A? {
 /// }
 /// ```
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
+#owned(value)
 pub fn[A] T::set(self : T[A], index : Int, value : A) -> T[A] {
   guard! index >= 0 && index < self.size
   {
@@ -257,6 +259,7 @@ pub fn[A] T::set(self : T[A], index : Int, value : A) -> T[A] {
 /// }
 /// ```
 #deprecated("Use the corresponding function in `immut/vector` instead", skip_current_package=true)
+#owned(value)
 pub fn[A] T::push(self : T[A], value : A) -> T[A] {
   let (tree, shift) = self.tree.push_end(self.shift, value)
   { tree, size: self.size + 1, shift }

--- a/immut/array/tree.mbt
+++ b/immut/array/tree.mbt
@@ -53,6 +53,7 @@ fn[T] Tree::empty() -> Tree[T] {
 
 ///|
 /// Create a new tree with a single leaf. Note that the resulting tree is a left-skewed tree.
+#owned(leaf)
 fn[T] new_branch_left(leaf : FixedArray[T], shift : Int) -> Tree[T] {
   match shift {
     0 => Leaf(leaf)
@@ -132,6 +133,7 @@ fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
 /// 
 /// Precondition:
 /// - `self` is of height `shift / NUM_BITS`.
+#owned(value)
 fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] {
   // TODO: optimize this as loop
   fn set_radix(node : Tree[T], shift : Int) -> Tree[T] {
@@ -183,6 +185,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
 /// Precondition:
 /// - The height of `self` = `shift` / `NUM_BITS` (the height starts from 0).
 /// - `length` is the number of elements in the tree.
+#owned(value)
 fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
   fn update_sizes_last(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
     match sizes {

--- a/immut/array/utils.mbt
+++ b/immut/array/utils.mbt
@@ -17,6 +17,7 @@
 
 ///|
 /// Set the value at the given index. This operation is O(n).
+#owned(v)
 fn[T] immutable_set(arr : FixedArray[T], i : Int, v : T) -> FixedArray[T] {
   let arr = arr.copy()
   arr[i] = v
@@ -25,6 +26,7 @@ fn[T] immutable_set(arr : FixedArray[T], i : Int, v : T) -> FixedArray[T] {
 
 ///|
 /// Add an element to the end of the array. This operation is O(n).
+#owned(val)
 fn[T] immutable_push(arr : FixedArray[T], val : T) -> FixedArray[T] {
   let len = arr.length()
   let new_arr = FixedArray::make_and_blit(

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -53,6 +53,7 @@ pub fn[K, V] HashMap::new() -> HashMap[K, V] {
 ///|
 /// Create a map with a single key-value pair.
 #as_free_fn
+#owned(key, value)
 pub fn[K : Hash, V] HashMap::singleton(key : K, value : V) -> HashMap[K, V] {
   { data: Some(Flat(key, value, @path.of(key))) }
 }
@@ -109,6 +110,7 @@ fn[K : Eq, V] Node::get_with_path(
 
 ///|
 /// require: key1 != key2, path1 and path2 has the same length
+#owned(key1, value1, key2, value2)
 fn[K, V] join_2(
   key1 : K,
   value1 : V,
@@ -137,6 +139,7 @@ fn[K, V] join_2(
 }
 
 ///|
+#owned(value)
 fn[K : Eq, V] Node::add_with_path(
   self : Node[K, V],
   key : K,
@@ -433,6 +436,7 @@ pub fn[K, V, A] HashMap::map(
 /// Add a key-value pair to the hashmap.
 ///
 /// If a pair with the same key already exists, the old one is replaced
+#owned(value)
 pub fn[K : Eq + Hash, V] HashMap::add(
   self : HashMap[K, V],
   key : K,

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -68,6 +68,7 @@ fn[A : Eq] Node::contains(self : Node[A], key : A, path : @path.Path) -> Bool {
 
 ///|
 /// require: key1 != key2, path1 and path2 has the same length
+#owned(key1, key2)
 fn[A] join_2(
   key1 : A,
   path1 : @path.Path,

--- a/immut/internal/sparse_array/sparse_array.mbt
+++ b/immut/internal/sparse_array/sparse_array.mbt
@@ -29,6 +29,7 @@ pub fn[X] empty() -> SparseArray[X] {
 
 ///|
 /// Create a singleton value.
+#owned(value)
 pub fn[X] singleton(idx : Int, value : X) -> SparseArray[X] {
   { elem_info: empty_bitset.add(idx), data: [value] }
 }
@@ -50,6 +51,7 @@ fn[X] SparseArray::unsafe_get(self : SparseArray[X], idx : Int) -> X {
 
 ///|
 /// Create a two-element value.
+#owned(value1, value2)
 pub fn[X] doubleton(
   idx1 : Int,
   value1 : X,
@@ -71,6 +73,7 @@ pub fn[X] doubleton(
 ///
 /// The caller must ensure that `indices` are sorted, unique, and have the same
 /// length as `data`.
+#owned(data)
 pub fn[X] from_sorted_fixed_array(
   indices : FixedArray[Int],
   data : FixedArray[X],
@@ -85,6 +88,7 @@ pub fn[X] from_sorted_fixed_array(
 ///|
 /// Add a new element into the sparse array.
 /// `idx` must be absent from `self`
+#owned(value)
 pub fn[X] SparseArray::add(
   self : SparseArray[X],
   idx : Int,
@@ -278,6 +282,7 @@ pub fn[X] SparseArray::filter(
 
 ///|
 /// Function `replace`.
+#owned(value)
 pub fn[X] SparseArray::replace(
   self : SparseArray[X],
   idx : Int,

--- a/immut/priority_queue/priority_queue.mbt
+++ b/immut/priority_queue/priority_queue.mbt
@@ -246,6 +246,7 @@ fn[A] Node::remove_last_leaf(self : Node[A], path : Path) -> (A, Node[A]) {
 
 ///|
 /// require: self is not empty
+#owned(value)
 fn[A : Compare] Node::change_and_down(self : Node[A], value : A) -> Node[A] {
   match self {
     Empty => abort("unreachable")
@@ -308,6 +309,7 @@ pub fn[A : Compare] PriorityQueue::unsafe_pop(
 ///   @test.assert_eq(queue.push(1).length(), 1)
 /// }
 /// ```
+#owned(value)
 pub fn[A : Compare] PriorityQueue::push(
   self : PriorityQueue[A],
   value : A,
@@ -322,6 +324,7 @@ pub fn[A : Compare] PriorityQueue::push(
 }
 
 ///|
+#owned(value)
 fn[A : Compare] Node::push(self : Node[A], value : A, path : Path) -> Node[A] {
   match self {
     Empty => Leaf(value)

--- a/immut/sorted_map/map.mbt
+++ b/immut/sorted_map/map.mbt
@@ -17,6 +17,7 @@
 /// O(log n).
 ///
 #alias(insert, deprecated)
+#owned(value)
 pub fn[K : Compare, V] SortedMap::add(
   self : SortedMap[K, V],
   key : K,

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -23,6 +23,7 @@ pub fn[K, V] SortedMap::new() -> SortedMap[K, V] {
 ///|
 /// Create a map with a single key-value pair.
 #as_free_fn
+#owned(key, value)
 pub fn[K, V] SortedMap::singleton(key : K, value : V) -> SortedMap[K, V] {
   Tree(key, value~, size=1, Empty, Empty)
 }
@@ -70,6 +71,7 @@ pub fn[K, V] SortedMap::is_empty(self : SortedMap[K, V]) -> Bool {
 
 ///|
 #inline
+#owned(key, value, l, r)
 fn[K, V] make_tree(
   key : K,
   value : V,

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -33,6 +33,7 @@ pub impl[A] Default for SortedSet[A] with fn default() {
 ///|
 /// Returns the one-value ImmutableSet containing only `value`.
 #as_free_fn
+#owned(value)
 pub fn[A] SortedSet::singleton(value : A) -> SortedSet[A] {
   Node(left=Empty, value~, right=Empty, size=1)
 }
@@ -909,6 +910,7 @@ pub fn[A] SortedSet::length(self : SortedSet[A]) -> Int {
 ///|
 /// Creates a new node.
 #inline
+#owned(left, value, right)
 fn[A] create(
   left : SortedSet[A],
   value : A,
@@ -964,6 +966,7 @@ fn[A] balance(
 }
 
 ///|
+#owned(value)
 fn[A] SortedSet::add_min_value(self : SortedSet[A], value : A) -> SortedSet[A] {
   match self {
     Empty => singleton(value)
@@ -973,6 +976,7 @@ fn[A] SortedSet::add_min_value(self : SortedSet[A], value : A) -> SortedSet[A] {
 }
 
 ///|
+#owned(value)
 fn[A] SortedSet::add_max_value(self : SortedSet[A], value : A) -> SortedSet[A] {
   match self {
     Empty => singleton(value)

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -53,6 +53,7 @@ fn[T] Tree::empty() -> Tree[T] {
 
 ///|
 /// Create a new tree with a single leaf. Note that the resulting tree is a left-skewed tree.
+#owned(leaf)
 fn[T] new_branch_left(leaf : FixedArray[T], shift : Int) -> Tree[T] {
   // A full leaf keeps the branch radix-indexable (`None`). A partial leaf must
   // be relaxed (`Some`): on its own it sits at the right edge, but once another
@@ -117,6 +118,7 @@ fn[T] Tree::get(self : Tree[T], index : Int, shift : Int) -> T {
 /// 
 /// Precondition:
 /// - `self` is of height `shift / NUM_BITS`.
+#owned(value)
 fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] {
   // TODO: optimize this as loop
   fn set_radix(node : Tree[T], shift : Int) -> Tree[T] {
@@ -168,6 +170,7 @@ fn[T] Tree::set(self : Tree[T], index : Int, shift : Int, value : T) -> Tree[T] 
 /// Precondition:
 /// - The height of `self` = `shift` / `NUM_BITS` (the height starts from 0).
 /// - `length` is the number of elements in the tree.
+#owned(value)
 fn[T] Tree::push_end(self : Tree[T], shift : Int, value : T) -> (Tree[T], Int) {
   fn update_sizes_last(sizes : FixedArray[Int]?) -> FixedArray[Int]? {
     match sizes {

--- a/immut/vector/utils.mbt
+++ b/immut/vector/utils.mbt
@@ -17,6 +17,7 @@
 
 ///|
 /// Set the value at the given index. This operation is O(n).
+#owned(v)
 fn[T] immutable_set(arr : FixedArray[T], i : Int, v : T) -> FixedArray[T] {
   let arr = arr.copy()
   arr[i] = v
@@ -25,6 +26,7 @@ fn[T] immutable_set(arr : FixedArray[T], i : Int, v : T) -> FixedArray[T] {
 
 ///|
 /// Add an element to the end of the array. This operation is O(n).
+#owned(val)
 fn[T] immutable_push(arr : FixedArray[T], val : T) -> FixedArray[T] {
   let len = arr.length()
   let new_arr = FixedArray::make_and_blit(

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -35,6 +35,7 @@ pub fn[A] Vector::new() -> Vector[A] {
 /// }
 /// ```
 #as_free_fn
+#owned(value)
 pub fn[A] Vector::singleton(value : A) -> Vector[A] {
   make_t(Tree::empty(), [value], 1, 0)
 }
@@ -42,6 +43,7 @@ pub fn[A] Vector::singleton(value : A) -> Vector[A] {
 ///|
 /// Create a persistent vector with a given length and value.
 #as_free_fn
+#owned(value)
 pub fn[A] Vector::make(len : Int, value : A) -> Vector[A] {
   guard len > 0 else { new() }
   let tail_len = tail_len_of_size(len)
@@ -278,6 +280,7 @@ pub fn[A : Eq] Vector::contains(self : Vector[A], value : A) -> Bool {
 ///   @debug.assert_eq(v.set(1, 10), @vector.from_array([1, 10, 3, 4, 5]))
 /// }
 /// ```
+#owned(value)
 pub fn[A] Vector::set(self : Vector[A], index : Int, value : A) -> Vector[A] {
   guard! index >= 0 && index < self.size
   let tail_len = self.tail.length()
@@ -318,6 +321,7 @@ pub fn[A] Vector::set(self : Vector[A], index : Int, value : A) -> Vector[A] {
 ///   @debug.assert_eq(v.push(4), @vector.from_array([1, 2, 3, 4]))
 /// }
 /// ```
+#owned(value)
 pub fn[A] Vector::push(self : Vector[A], value : A) -> Vector[A] {
   if self.tail.length() < BRANCHING_FACTOR {
     make_t(
@@ -795,6 +799,7 @@ pub impl[A : Compare] Compare for Vector[A] with fn compare(self, other) {
 //-----------------------------------------------------------------------------
 
 ///|
+#owned(tree, tail)
 fn[A] make_t(
   tree : Tree[A],
   tail : FixedArray[A],


### PR DESCRIPTION
## What

Adds `#owned(...)` to parameters that persistent structures store into freshly allocated nodes on every non-panic path — 38 annotations:

- `immut/internal/sparse_array`: `singleton`/`doubleton`/`add`/`replace` values, `from_sorted_fixed_array` data
- `immut/hashmap` + `immut/hashset` HAMT: `singleton`, `join_2`, `add`/`add_with_path` **value**
- `immut/sorted_map`: `singleton`, `make_tree` (the module's single allocation site), `add` value
- `immut/sorted_set`: `singleton`, `create`, `add_min_value`/`add_max_value`
- `immut/priority_queue`: `push`, `Node::push`, `change_and_down`
- `immut/vector` + `immut/array`: `push`/`set`/`make`/`singleton`, `make_t`, `immutable_set`/`immutable_push` values, `new_branch_left`, `Tree::set`/`Tree::push_end`

Keys stay borrowed where the equal-key path drops them (HAMT `add` key, sorted_map `add` key), and the destructure-heavy `join`/`balance`/`merge`/`union` helpers are left borrowed — the node parameter is usually dropped there after field extraction, so plain `#owned` would only relocate refcount traffic (those are candidates for reuse analysis instead). `immutable_push` keeps its `arr` parameter borrowed for now: transferring it only pays off once `FixedArray::make_and_blit` is `#owned` too (follow-up after the builtin array branch).

## Generated code (native C)

Static incref/decref counts per emitted body, baseline → this branch (all changes are removals; a sweep specifically looking for bodies where `#owned` *added* RC ops found none):

| function | baseline | owned |
|---|---|---|
| immut/hashmap `HashMap::add` | 52 / 39 | 38 / 31 |
| immut/priority_queue `push` | 14 / 3 | 8 / 1 |
| `Vector::push` | 8 / 7 | 7 / 3 |
| `Vector::set` | 10 / 17 | 11 / 12 |
| `make_t` | 2 / 0 | 0 / 0 |
| `immutable_set` / `immutable_push` | 2 / 2 each | 0 / 2 each |
| sparse_array `doubleton` | 5 / 0 | 1 / 0 |

## Benchmarks

Native, 10k pre-built `String` elements, interleaved A/B binaries, medians over two sessions (10 + 8 rounds). Persistent structures are allocation-dominated (~300–600ns/op: node allocations + comparisons/hashing), so the removed RC ops translate into small wins by construction:

| bench | session 1 | session 2 |
|---|---|---|
| sorted_map add ×10k | −1.3% | −2.0% |
| priority_queue push ×10k | −2.7% | −2.6% |
| priority_queue push+drain | −1.2% | −0.9% |
| vector push ×10k | −1.0% | −0.7% |
| vector set ×10k | −0.5% | +0.9% |
| hashmap (HAMT) add ×10k | +0.1% | −0.0% |

Control benches over packages this branch does not touch (`Array::push`, `Deque::push_back`) stayed within ±0.9% in the same runs.