### PR TITLE
fix(string): return UTF-16 offsets from find_by

### DIFF
--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -74,21 +74,25 @@ test "find" {
 }
 
 ///|
-/// Returns the offset of the first character that satisfies the given predicate.
-/// If no such character is found, it returns None.
+/// Returns the UTF-16 code-unit offset, relative to the beginning of this view,
+/// of the first character that satisfies the given predicate. If no such
+/// character is found, it returns None.
 #locals(pred)
 pub fn StringView::find_by(self : StringView, pred : (Char) -> Bool) -> Int? {
-  for i, c in self {
+  let mut offset = 0
+  for c in self {
     if pred(c) {
-      return Some(i)
+      return Some(offset)
     }
+    offset += c.utf16_len()
   }
   None
 }
 
 ///|
-/// Returns the offset of the first character that satisfies the given predicate.
-/// If no such character is found, it returns None.
+/// Returns the UTF-16 code-unit offset, relative to the beginning of this
+/// string, of the first character that satisfies the given predicate. If no
+/// such character is found, it returns None.
 pub fn String::find_by(self : String, pred : (Char) -> Bool) -> Int? {
   self[:].find_by(pred)
 }
@@ -104,7 +108,14 @@ test "find_by" {
   assert_true("hello".find_by(c => c is ('A'..='Z')) == None)
   assert_true("Hello".find_by(c => c is ('A'..='Z')) == Some(0))
   assert_true("αβγ".find_by(c => c == 'β') == Some(1))
-  assert_true("😀😁😂".find_by(c => c == '😂') == Some(2))
+}
+
+///|
+test "find_by returns UTF-16 code-unit offsets" {
+  assert_true("😀X".find_by(c => c == 'X') == Some(2))
+  assert_true("😀😁😂".find_by(c => c == '😂') == Some(4))
+  let view = "a😀Xz"[1:4]
+  assert_true(view.find_by(c => c == 'X') == Some(2))
 }
 
 ///|
@@ -1757,6 +1768,12 @@ test "to_lower" {
 }
 
 ///|
+test "to_lower after a non-BMP character" {
+  inspect("😀X".to_lower(), content="😀x")
+  inspect("a😀Xz"[1:4].to_lower(), content="😀x")
+}
+
+///|
 test "View::to_lower" {
   assert_true("Hello"[:].to_lower() == "hello")
   assert_true("HELLO"[:].to_lower() == "hello")
@@ -1808,6 +1825,12 @@ test "to_upper" {
   assert_true("hello".to_upper() == "HELLO")
   assert_true("HELLO".to_upper() == "HELLO")
   assert_true("Hello, World!".to_upper() == "HELLO, WORLD!")
+}
+
+///|
+test "to_upper after a non-BMP character" {
+  inspect("😀x".to_upper(), content="😀X")
+  inspect("a😀xz"[1:4].to_upper(), content="😀X")
 }
 
 ///|

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -79,14 +79,14 @@ test "find" {
 /// character is found, it returns None.
 #locals(pred)
 pub fn StringView::find_by(self : StringView, pred : (Char) -> Bool) -> Int? {
-  let mut offset = 0
-  for c in self {
+  for c in self; offset = 0 {
     if pred(c) {
-      return Some(offset)
+      break Some(offset)
     }
-    offset += c.utf16_len()
+    continue offset + c.utf16_len()
+  } nobreak {
+    None
   }
-  None
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Make `StringView::find_by` return UTF-16 code-unit offsets instead of character indices.
- Clarify that returned offsets are relative to the receiver.
- Add regression tests for non-BMP characters and non-zero-offset `StringView`s.
- Prevent `to_lower` and `to_upper` from slicing through surrogate pairs.

## Problem

`StringView::find_by` previously used the index produced by character iteration. That index counts Unicode characters, while the rest of the string slicing API expects UTF-16 code-unit offsets.

For example, searching for `X` in `"😀X"` returned `Some(1)` instead of `Some(2)`. `to_lower` and `to_upper` subsequently used that result as a slicing boundary, causing a **runtime error** because offset 1 lies inside the emoji's surrogate pair.

## Solution

Track a separate offset while iterating and advance it by `Char::utf16_len()`. This preserves linear complexity, predicate invocation order, and short-circuiting behavior. Closes #3823