### PR TITLE
perf(list,ref,lazy,lazy_list): annotate consuming parameters with #owned

### DIFF
--- a/lazy/lazy.mbt
+++ b/lazy/lazy.mbt
@@ -84,6 +84,7 @@ struct Lazy[A] {
 ///   @test.assert_eq(runs, 1)
 /// }
 /// ```
+#owned(thunk)
 pub fn[A] Lazy::Lazy(thunk : () -> A) -> Lazy[A] {
   { state: Unforced(thunk) }
 }
@@ -98,6 +99,7 @@ pub fn[A] Lazy::Lazy(thunk : () -> A) -> Lazy[A] {
 ///   @test.assert_eq(cell.force(), 7)
 /// }
 /// ```
+#owned(value)
 pub fn[A] Lazy::ready(value : A) -> Lazy[A] {
   { state: Forced(value) }
 }

--- a/lazy_list/lazy_list.mbt
+++ b/lazy_list/lazy_list.mbt
@@ -19,6 +19,7 @@
 ///|
 /// Strict-tail cons. Private — exposed indirectly through `lazy_cons`
 /// and as the building block for the transform combinators.
+#owned(head, tail)
 fn[A] cons(head : A, tail : LazyList[A]) -> LazyList[A] {
   { cell: Cons(head, tail=@lazy.Lazy::ready(tail)) }
 }
@@ -60,6 +61,7 @@ pub fn[A] LazyList::empty() -> LazyList[A] {
 /// }
 /// ```
 #as_free_fn
+#owned(head, tail)
 pub fn[A] LazyList::lazy_cons(
   head : A,
   tail : () -> LazyList[A],
@@ -226,6 +228,7 @@ pub fn[A] LazyList::drop_while(
 ///|
 /// Concatenates two lazy lists. The right-hand side is not forced until
 /// the left-hand side has been fully consumed.
+#owned(other)
 pub fn[A] LazyList::concat(
   self : LazyList[A],
   other : LazyList[A],

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -50,6 +50,7 @@ pub fn[A] List::new() -> List[A] {
 /// ```
 #as_free_fn
 #as_free_fn(construct, deprecated="Use cons instead")
+#owned(head, tail)
 pub fn[A] List::cons(head : A, tail : List[A]) -> List[A] {
   More(head, tail~)
 }
@@ -68,6 +69,7 @@ pub fn[A] List::cons(head : A, tail : List[A]) -> List[A] {
 /// }
 /// ```
 #alias(add)
+#owned(head)
 pub fn[A] List::prepend(self : List[A], head : A) -> List[A] {
   More(head, tail=self)
 }
@@ -595,6 +597,7 @@ pub fn[A] List::last(self : List[A]) -> A? {
 ///   @debug.assert_eq(ls, List([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 /// }
 /// ```
+#owned(other)
 pub fn[A] List::concat(self : List[A], other : List[A]) -> List[A] {
   match self {
     Empty => other
@@ -631,6 +634,7 @@ pub fn[A] List::concat(self : List[A], other : List[A]) -> List[A] {
 ///   @debug.assert_eq(ls, List([5, 4, 3, 2, 1, 6, 7, 8, 9, 10]))
 /// }
 /// ```
+#owned(other)
 pub fn[A] List::rev_concat(self : List[A], other : List[A]) -> List[A] {
   for a = self, b = other {
     match (a, b) {
@@ -1952,6 +1956,7 @@ pub fn[A] List::from_iter_rev(iter : Iter[A]) -> List[A] {
 /// }
 /// ```
 #as_free_fn
+#owned(x)
 pub fn[A] List::singleton(x : A) -> List[A] {
   More(x, tail=Empty)
 }

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -40,6 +40,7 @@ pub impl[X : Show] Show for Ref[X] with fn output(self, logger) {
 ///|
 /// create a reference from value
 #alias(new, deprecated)
+#owned(x)
 pub fn[T] Ref::Ref(x : T) -> Ref[T] {
   { val: x }
 }
@@ -56,6 +57,7 @@ test "to_string" {
 
 ///|
 /// Same as the `Ref` constructor.
+#owned(x)
 pub fn[T] new(x : T) -> Ref[T] {
   { val: x }
 }


### PR DESCRIPTION
## What

Adds `#owned(...)` to wrap-and-return constructors that store their argument in the new allocation on every path — 12 annotations:

- `List`: `cons`, `prepend`, `singleton`, `concat`/`rev_concat` (`other` is either returned or linked into the result)
- `Ref`: `Ref`/`new`
- `Lazy`: `Lazy` (the thunk is stored in the cell), `ready`
- `LazyList`: `cons`, `lazy_cons`, `concat`

## Generated code (native C)

Every annotated standalone body becomes a pure move: `ref::new` drops from 1 incref to 0 (all six monomorphic instances in the test binary), likewise `Lazy::ready`, `Lazy::Lazy`, `lazy_cons`; `LazyList::from_iter` goes 1 incref/3 decref → 1/1.

Two findings worth recording:

1. **Fully-inlined call sites already get this for free.** The hot `l = l.prepend(s)` loop compiles to byte-identical C with and without the annotation — once `prepend` is inlined, the RC optimizer already fuses the element-read incref into the node store. For tiny constructors like these, `#owned` only changes non-inlined boundaries: cross-package calls the inliner skips, function values, and generic instantiations kept out of line.
2. **The relocation equivalence is visible in the emitted code.** `Bench::keep` (which holds its argument borrowed and passes it to `ref::new`) gained exactly the incref that `ref::new` lost — the pair moves from callee to caller for non-last-use callers, it does not multiply.

## Benchmarks

Native, 10k pre-built `String` elements, interleaved A/B binaries, 12-round session on a quiet machine. As the codegen predicts, the workloads are neutral: `list_prepend` +0.3%, `ref_new` −0.1%, `lazy_ready` −0.2%, `lazy_list` build+force −0.0%, with controls over untouched packages at ±0.3% in the same run.

This branch is therefore a consistency/enablement change rather than a measured win: it completes the constructor family so non-inlined callers (and future callers in other packages) get the move semantics, at no cost to inlined ones.