### PR TITLE
perf(sorted_map,sorted_set): annotate consuming parameters with #owned

### DIFF
--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -67,6 +67,7 @@ pub fn[K : Compare, V] SortedMap::SortedMap(
 /// ```
 #alias("_[_]=_")
 #alias(add, deprecated="Use set instead")
+#owned(value)
 pub fn[K : Compare, V] SortedMap::set(
   self : SortedMap[K, V],
   key : K,
@@ -567,6 +568,7 @@ fn[K, V] height_ge(x1 : Node[K, V]?, x2 : Node[K, V]?) -> Bool {
 }
 
 ///|
+#owned(root)
 fn[K, V] balance(root : Node[K, V]) -> Node[K, V] {
   let (l, r) = (root.left, root.right)
   let (hl, hr) = (height(l), height(r))
@@ -592,6 +594,7 @@ fn[K, V] balance(root : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
+#owned(n)
 fn[K, V] rotate_l(n : Node[K, V]) -> Node[K, V] {
   let r = n.right.unwrap()
   n.right = r.left
@@ -602,6 +605,7 @@ fn[K, V] rotate_l(n : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
+#owned(n)
 fn[K, V] rotate_r(n : Node[K, V]) -> Node[K, V] {
   let l = n.left.unwrap()
   n.left = l.right
@@ -612,6 +616,7 @@ fn[K, V] rotate_r(n : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
+#owned(n)
 fn[K, V] rotate_lr(n : Node[K, V]) -> Node[K, V] {
   let l = n.left.unwrap()
   let v = rotate_l(l)
@@ -620,6 +625,7 @@ fn[K, V] rotate_lr(n : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
+#owned(n)
 fn[K, V] rotate_rl(n : Node[K, V]) -> Node[K, V] {
   let r = n.right.unwrap()
   let v = rotate_r(r)
@@ -628,6 +634,7 @@ fn[K, V] rotate_rl(n : Node[K, V]) -> Node[K, V] {
 }
 
 ///|
+#owned(value)
 fn[K : Compare, V] add_node(
   root : Node[K, V]?,
   key : K,

--- a/sorted_map/map.mbt
+++ b/sorted_map/map.mbt
@@ -598,8 +598,11 @@ fn[K, V] balance(root : Node[K, V]) -> Node[K, V] {
 fn[K, V] rotate_l(n : Node[K, V]) -> Node[K, V] {
   let r = n.right.unwrap()
   n.right = r.left
-  r.left = Some(n)
+  // Update n's height before storing it: the store consumes the owned `n`
+  // reference, and touching `n` afterwards would force an extra
+  // incref/decref pair to keep it alive across the store.
   n.update_height()
+  r.left = Some(n)
   r.update_height()
   r
 }
@@ -609,8 +612,9 @@ fn[K, V] rotate_l(n : Node[K, V]) -> Node[K, V] {
 fn[K, V] rotate_r(n : Node[K, V]) -> Node[K, V] {
   let l = n.left.unwrap()
   n.left = l.right
-  l.right = Some(n)
+  // See rotate_l: keep the consuming store as the last use of `n`.
   n.update_height()
+  l.right = Some(n)
   l.update_height()
   l
 }

--- a/sorted_map/utils.mbt
+++ b/sorted_map/utils.mbt
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 ///|
+#owned(key, value)
 fn[K, V] new_node(key : K, value : V) -> Node[K, V] {
   { key, value, left: None, right: None, height: 1 }
 }

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -612,8 +612,11 @@ fn[V] balance(root : Node[V]) -> Node[V] {
 fn[V] rotate_l(n : Node[V]) -> Node[V] {
   let r = n.right.unwrap()
   n.right = r.left
-  r.left = Some(n)
+  // Update n's height before storing it: the store consumes the owned `n`
+  // reference, and touching `n` afterwards would force an extra
+  // incref/decref pair to keep it alive across the store.
   n.update_height()
+  r.left = Some(n)
   r.update_height()
   r
 }
@@ -623,8 +626,9 @@ fn[V] rotate_l(n : Node[V]) -> Node[V] {
 fn[V] rotate_r(n : Node[V]) -> Node[V] {
   let l = n.left.unwrap()
   n.left = l.right
-  l.right = Some(n)
+  // See rotate_l: keep the consuming store as the last use of `n`.
   n.update_height()
+  l.right = Some(n)
   l.update_height()
   l
 }

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -22,6 +22,7 @@ fn[V] new_sorted_set() -> SortedSet[V] {
 ///|
 /// Returns the one-value set containing only `value`.
 #as_free_fn
+#owned(value)
 pub fn[V] SortedSet::singleton(value : V) -> SortedSet[V] {
   { root: Some({ value, left: None, right: None, height: 1 }), size: 1 }
 }
@@ -76,6 +77,7 @@ fn[V] copy_tree(node : Node[V]?) -> Node[V]? {
 }
 
 ///|
+#owned(value, left, right)
 fn[V] new_node(
   value : V,
   left? : Node[V]? = None,
@@ -86,6 +88,7 @@ fn[V] new_node(
 }
 
 ///|
+#owned(value, left, right)
 fn[V] new_node_update_height(
   value : V,
   left~ : Node[V]?,
@@ -98,6 +101,7 @@ fn[V] new_node_update_height(
 
 ///|
 /// Adds a value to the set. If the value already exists, it is replaced.
+#owned(value)
 pub fn[V : Compare] SortedSet::add(self : SortedSet[V], value : V) -> Unit {
   let (new_root, inserted) = add_node(self.root, value)
   if self.root != new_root {
@@ -203,6 +207,7 @@ fn[V : Compare] split(root : Node[V]?, value : V) -> (Node[V]?, Node[V]?) {
 }
 
 ///|
+#owned(left, value, right)
 fn[V] join(left : Node[V]?, value : V, right : Node[V]?) -> Node[V] {
   let (hl, hr) = (height(left), height(right))
   if hl > hr + 1 {
@@ -215,6 +220,7 @@ fn[V] join(left : Node[V]?, value : V, right : Node[V]?) -> Node[V] {
 }
 
 ///|
+#owned(l, v)
 fn[V] join_left(l : Node[V]?, v : V, r : Node[V]?) -> Node[V] {
   let { value: rv, left: rl, right: rr, .. } = r.unwrap()
   let node = if height(rl) <= height(l) + 1 {
@@ -240,6 +246,7 @@ fn[V] join_left(l : Node[V]?, v : V, r : Node[V]?) -> Node[V] {
 }
 
 ///|
+#owned(v, r)
 fn[V] join_right(l : Node[V]?, v : V, r : Node[V]?) -> Node[V] {
   let { value: lv, left: ll, right: lr, .. } = l.unwrap()
   let node = if height(lr) <= height(r) + 1 {
@@ -575,6 +582,7 @@ fn[V] height_ge(x1 : Node[V]?, x2 : Node[V]?) -> Bool {
 }
 
 ///|
+#owned(root)
 fn[V] balance(root : Node[V]) -> Node[V] {
   let (l, r) = (root.left, root.right)
   let (hl, hr) = (height(l), height(r))
@@ -600,6 +608,7 @@ fn[V] balance(root : Node[V]) -> Node[V] {
 }
 
 ///|
+#owned(n)
 fn[V] rotate_l(n : Node[V]) -> Node[V] {
   let r = n.right.unwrap()
   n.right = r.left
@@ -610,6 +619,7 @@ fn[V] rotate_l(n : Node[V]) -> Node[V] {
 }
 
 ///|
+#owned(n)
 fn[V] rotate_r(n : Node[V]) -> Node[V] {
   let l = n.left.unwrap()
   n.left = l.right
@@ -620,6 +630,7 @@ fn[V] rotate_r(n : Node[V]) -> Node[V] {
 }
 
 ///|
+#owned(n)
 fn[V] rotate_lr(n : Node[V]) -> Node[V] {
   let l = n.left.unwrap()
   let v = rotate_l(l)
@@ -628,6 +639,7 @@ fn[V] rotate_lr(n : Node[V]) -> Node[V] {
 }
 
 ///|
+#owned(n)
 fn[V] rotate_rl(n : Node[V]) -> Node[V] {
   let r = n.right.unwrap()
   let v = rotate_r(r)
@@ -636,6 +648,7 @@ fn[V] rotate_rl(n : Node[V]) -> Node[V] {
 }
 
 ///|
+#owned(value)
 fn[V : Compare] add_node(root : Node[V]?, value : V) -> (Node[V]?, Bool) {
   match root {
     None => (Some(new_node(value)), true)


### PR DESCRIPTION
## What

Adds `#owned(...)` to parameters consumed on every non-panic path in the two mutable AVL trees — 21 annotations plus one enabling reorder:

- `SortedMap`: `set`/`add_node` **value** (stored on both insert and replace paths; `key` stays borrowed, dropped on the duplicate path), `new_node` key+value, and the `balance`/`rotate_*` plumbing (the node is stored into the rotated tree or returned on every path)
- `SortedSet`: `add`/`add_node` value (duplicates are *replaced*, so the value is stored on every path), `singleton`, `new_node`/`new_node_update_height`, `join`/`join_left`/`join_right` (only the parameters each actually consumes — `join_left` keeps `r` borrowed since it destructures and drops that node, symmetrically `join_right` keeps `l`), `balance`/`rotate_*`

The second commit hoists `n.update_height()` above the store in `rotate_l`/`rotate_r` (both packages). With `#owned(n)`, the store consumes the reference, and touching `n` afterwards forced the compiler to keep it alive across the store — the naive annotation regressed those bodies (3 incref/2 decref → 3/3); store-last turns them into a net win (1/1 in sorted_map, 2/2 in sorted_set).

## Generated code (native C)

Total RC ops across all emitted `sorted_map`/`sorted_set` bodies: **416 → 368 (−12%)**. The heavy consumers carry it: `join_left`/`join_right` 22 ops → 11 each, `split` 22 → 16, the `new_node` family becomes pure moves (2-3 increfs → 0). A few borrowed callers (`add_node`, `delete_node`) gain +1-2 increfs — that is the relocation for calling now-owning callees (`balance`, `rotate_*`), paid once and saved more inside.

## Benchmarks

Native, 10k pre-built `String` elements, interleaved A/B binaries, two 10/8-round sessions on a quiet machine (spreads 1-3%, controls over untouched packages ±0.3-1.6%):

| bench | session 1 | session 2 |
|---|---|---|
| sorted_set union (5k ∪ 5k) | **−5.3%** | **−4.8%** |
| sorted_set add ×10k + remove ×10k | −2.2% | −2.4% |
| sorted_set add ×10k | −1.8% | −2.4% |
| sorted_map set ×10k | −1.3% | −1.1% |

`union` benefits most because it runs almost entirely inside the annotated `split`/`join`/`join_left`/`join_right` plumbing; the insert paths are diluted by string comparisons and node allocation.