### PR TITLE
perf(builtin): annotate consuming Map/Json/Iter parameters with #owned

### DIFF
--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -238,6 +238,7 @@ pub fn[X] Iter::count_if(self : Iter[X], f : (X) -> Bool) -> Int {
 ///
 /// This function is intended for use by data structure authors,
 /// and should not be called by end users in general.
+#owned(f)
 pub fn[X] Iter::new(f : () -> X?, size_hint? : Int) -> Iter[X] {
   let size_hint = match size_hint {
     Some(n) if n > 0 => Some(n)
@@ -1036,6 +1037,7 @@ pub(all) struct Iter2[X, Y](Iter[(X, Y)])
 ///|
 /// Construct an `Iter2` from a pair-producing function.
 /// If the number of remaining pairs is known, pass it as `size_hint`.
+#owned(f)
 pub fn[X, Y] Iter2::new(f : () -> (X, Y)?, size_hint? : Int) -> Iter2[X, Y] {
   let size_hint = match size_hint {
     Some(n) if n > 0 => Some(n)

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -96,6 +96,7 @@ pub fn Json::empty_object() -> Json {
 ///   )
 /// }
 /// ```
+#owned(repr)
 pub fn Json::number(number : Double, repr? : String) -> Json {
   return Number(number, repr~)
 }
@@ -116,6 +117,7 @@ pub fn Json::number(number : Double, repr? : String) -> Json {
 ///   @debug.debug_inspect(Json::string("hello"), content="String(\"hello\")")
 /// }
 /// ```
+#owned(string)
 pub fn Json::string(string : String) -> Json {
   return String(string)
 }
@@ -165,6 +167,7 @@ pub fn Json::boolean(boolean : Bool) -> Json {
 ///   )
 /// }
 /// ```
+#owned(array)
 pub fn Json::array(array : Array[Json]) -> Json {
   return Array(array)
 }
@@ -190,6 +193,7 @@ pub fn Json::array(array : Array[Json]) -> Json {
 ///   )
 /// }
 /// ```
+#owned(object)
 pub fn Json::object(object : Map[String, Json]) -> Json {
   return Object(object)
 }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -126,11 +126,13 @@ pub fn[K : Hash + Eq, V] Map::Map(
 /// }
 /// ```
 #alias("_[_]=_")
+#owned(value)
 pub fn[K : Hash + Eq, V] Map::set(self : Map[K, V], key : K, value : V) -> Unit {
   self.set_with_hash(key, value, Hash::hash(key))
 }
 
 ///|
+#owned(value)
 fn[K : Eq, V] Map::set_with_hash(
   self : Map[K, V],
   key : K,
@@ -204,6 +206,7 @@ fn[K, V] Map::push_away(
 }
 
 ///|
+#owned(entry)
 fn[K, V] Map::set_entry(
   self : Map[K, V],
   entry : Entry[K, V],

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -212,11 +212,14 @@ fn[K, V] Map::set_entry(
   entry : Entry[K, V],
   new_idx : Int,
 ) -> Unit {
-  self.entries[new_idx] = Some(entry)
+  // Fix up the neighbor links before the store: the store consumes the owned
+  // `entry` reference, and touching `entry` after it would force the compiler
+  // to keep `entry` alive across the store with an extra incref/decref pair.
   match entry.next {
     None => self.tail = new_idx
     Some(next) => next.prev = new_idx
   }
+  self.entries[new_idx] = Some(entry)
 }
 
 ///|


### PR DESCRIPTION
## What

Adds `#owned(...)` to consuming parameters in builtin outside the array family — 9 annotations plus one enabling reorder:

- `Map`: `set`/`set_with_hash` **value** (stored on both the insert and the update path; `key` stays borrowed, dropped when the key exists) and `set_entry` — completing the entry-plumbing family whose other members (`push_away`/`add_entry_to_tail`/`rehash_place_entry`) already carry `#owned`
- `Json`: `string`/`array`/`object`/`number(repr)` — the argument is wrapped into the returned constructor
- `Iter::new`/`Iter2::new` — the closure is stored in the iterator struct

The second commit reorders `Map::set_entry` to fix up neighbor links before the consuming store. This is the third occurrence of the same pattern (after `Set::set_entry` in #3983 and the AVL rotations in #3987): reading a field of an owned parameter *after* its consuming store forces the compiler to keep the reference alive across it. Naive annotation regressed the body from 1 incref/1 decref to 2/5; store-last makes it 0/1, better than baseline.

## Generated code (native C)

- `Map::set_with_hash`: 6 incref/3 decref → 3/3 (all four monomorphic instances)
- `Map::push_away` (already `#owned` in main): 1/2 → 1/0 — its calls into the now-owning `set_entry` become moves
- `Map::set_entry`: 1/1 → 0/1 after the reorder
- `Iter::new`: 1/0 → 0/0
- `Json` constructors: fully inlined at every call site in the test binary — the emitted loops are byte-identical, because the RC optimizer already fuses the incref into the store once the wrapper is inlined. These annotations are enablement for non-inlined boundaries (function values, out-of-line instantiations), at zero cost to inlined ones.

## Benchmarks

Native, 10k pre-built `String` elements, interleaved A/B binaries, two sessions. Consistent with the above: `Map` set with growth −1.3~3.2% (sign consistent across sessions), pre-sized `Map` set within the ±1.6% noise floor (hashing and probing dominate, matching the hashmap result in #3983), `Json::string` and `Array::to_json` neutral as the identical codegen predicts. Controls over untouched code stayed within ±0.5%.