### PR TITLE
perf(builtin): annotate consuming Array/FixedArray parameters with #owned

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -32,6 +32,7 @@
 ///   debug_inspect(dynamic, content="[42, 42, 42]")
 /// }
 /// ```
+#owned(arr)
 pub fn[T] Array::from_fixed_array(arr : FixedArray[T]) -> Array[T] {
   let len = arr.length()
   Array::unsafe_make_and_blit_from_fixed(arr, allocate_len=len, len~)
@@ -71,6 +72,7 @@ pub fn[T] Array::from_fixed_array(arr : FixedArray[T]) -> Array[T] {
 /// ```
 /// This is because all the cells reference to the same object (the Array[Int] in this case).
 /// One should use makei() instead which creates an object for each index.
+#owned(elem)
 pub fn[T] Array::make(len : Int, elem : T) -> Array[T] {
   let arr = Array::make_uninit(len)
   for i in 0..<len {
@@ -228,6 +230,7 @@ pub fn[T] Array::get(self : Array[T], index : Int) -> T? {
 /// }
 /// ```
 #intrinsic("%array.unsafe_set")
+#owned(val)
 pub fn[T] Array::unsafe_set(self : Array[T], idx : Int, val : T) -> Unit {
   self.buffer().unsafe_set(idx, val)
 }
@@ -257,6 +260,7 @@ pub fn[T] Array::unsafe_set(self : Array[T], idx : Int, val : T) -> Unit {
 ///
 #intrinsic("%array.set")
 #alias("_[_]=_")
+#owned(value)
 pub fn[T] Array::set(self : Array[T], index : Int, value : T) -> Unit {
   let len = self.length()
   guard! index >= 0 && index < len

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -29,6 +29,7 @@ fn[T] Array::make_uninit(len : Int) -> Array[T] {
 }
 
 ///|
+#owned(src)
 fn[T] Array::unsafe_make_and_blit(
   src : UninitializedArray[T],
   allocate_len~ : Int,
@@ -49,6 +50,7 @@ fn[T] Array::unsafe_make_and_blit(
 }
 
 ///|
+#owned(src)
 fn[T] Array::unsafe_make_and_blit_from_fixed(
   src : FixedArray[T],
   allocate_len~ : Int,
@@ -65,6 +67,7 @@ fn[T] Array::unsafe_make_and_blit_from_fixed(
 }
 
 ///|
+#owned(value)
 fn[T] Array::unsafe_resize_with_default(
   self : Array[T],
   new_len : Int,
@@ -349,6 +352,7 @@ pub fn[T] Array::shrink_to_fit(self : Array[T]) -> Unit {
 ///   v.push(3)
 /// }
 /// ```
+#owned(value)
 pub fn[T] Array::push(self : Array[T], value : T) -> Unit {
   if self.length() == self.buffer().0.length() {
     self.realloc(self.length() + 1)
@@ -663,6 +667,7 @@ pub fn[T] Array::drain(self : Array[T], begin : Int, end : Int) -> Array[T] {
 ///   @debug.debug_inspect(c, content="[1, 2, 3, 6]")
 /// }
 /// ```
+#owned(value)
 pub fn[T] Array::insert(self : Array[T], index : Int, value : T) -> Unit {
   guard index >= 0 && index <= self.length() else {
     abort(
@@ -726,6 +731,7 @@ pub fn[T] Array::insert(self : Array[T], index : Int, value : T) -> Unit {
 ///   )
 /// }
 /// ```
+#owned(value)
 pub fn[A] Array::fill(
   self : Array[A],
   value : A,

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -113,6 +113,7 @@ pub impl[X] Default for FixedArray[X] with fn default() {
 ///   )
 /// }
 /// ```
+#owned(value)
 pub fn[T] FixedArray::fill(
   self : FixedArray[T],
   value : T,
@@ -135,6 +136,7 @@ pub fn[T] FixedArray::fill(
 ///|
 #coverage.skip
 #intrinsic("%fixedarray.fill")
+#owned(value)
 fn[T] FixedArray::unchecked_fill(
   self : FixedArray[T],
   start : Int,

--- a/builtin/fixedarray_block.mbt
+++ b/builtin/fixedarray_block.mbt
@@ -94,6 +94,7 @@ fn[T] FixedArray::unsafe_make_and_blit(
 ///|
 /// Creates a fixed array initialized with `init`, then blits `len` elements
 /// from `src` into it.
+#owned(src, init)
 pub fn[T] FixedArray::make_and_blit(
   src : FixedArray[T],
   allocate_len~ : Int,

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -174,6 +174,7 @@ pub fn[T] MutArrayView::unsafe_get(self : MutArrayView[T], index : Int) -> T {
 /// ```
 #intrinsic("%mutarrayview.set")
 #alias("_[_]=_")
+#owned(value)
 pub fn[T] MutArrayView::set(
   self : MutArrayView[T],
   index : Int,
@@ -207,6 +208,7 @@ pub fn[T] MutArrayView::set(
 /// ```
 #intrinsic("%mutarrayview.unsafe_set")
 #internal(unsafe, "Panic if index is out of bounds")
+#owned(value)
 pub fn[T] MutArrayView::unsafe_set(
   self : MutArrayView[T],
   index : Int,

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -164,6 +164,7 @@ fn[T] UninitializedArray::unsafe_make_and_blit_with_init(
 
 ///|
 /// Checked variant of `unsafe_make_and_blit`.
+#owned(src)
 pub fn[T] UninitializedArray::make_and_blit(
   src : UninitializedArray[T],
   allocate_len~ : Int,
@@ -229,6 +230,7 @@ test "panic as_view with invalid_end" {
 #coverage.skip
 #intrinsic("%fixedarray.fill")
 #cfg(not(target="js"))
+#owned(value)
 fn[T] UninitializedArray::unchecked_fill(
   self : UninitializedArray[T],
   start : Int,


### PR DESCRIPTION
## What

Adds `#owned(...)` to the value parameter of the builtin array store family — 17 annotations:

- `Array`: `push`, `insert`, `set`, `unsafe_set`, `make`, `fill`, `unsafe_resize_with_default`
- `FixedArray`: `fill`, `unchecked_fill`, `make_and_blit` (src, init)
- `UninitializedArray`: `unchecked_fill`, `make_and_blit` (src)
- `MutArrayView`: `set`, `unsafe_set`
- The wrappers forwarding unconditionally into the already-`#owned` blit intrinsics: `Array::unsafe_make_and_blit`, `Array::unsafe_make_and_blit_from_fixed`, `Array::from_fixed_array`

## Generated code (native C)

- `Array::push`: 1 incref/1 decref → 0/1 in every monomorphic instance — the store consumes the caller's reference
- The blit chain loses its `moonbit_incref(src)` before `moonbit_make_ref_array_with_blit`, which always consumes `src`. With the incref gone, a freshly built source arrives with refcount 1 and the runtime takes its steal path instead of copy-with-increfs — this is what makes `from_fixed_array` fast (below)
- Downstream bodies improve for free: `Array::resize_buffer` 1/2 → 1/1, `StringBuilder::grow`/`to_string`, `Json::stringify` internals — their array stores ride the same annotations
- `fill`/`make` gain +1-2 decrefs on their empty-range guard paths only: the owned surplus reference costs a constant ±1 op per call (against N per-element increfs in the loop, unchanged), which is the accepted trade of annotating this family. Benchmarks confirm neutrality
- No post-store-read hazards on this branch (scanned per-body; every hot-path change is a removal)

## Benchmarks

Native, 10k pre-built `String` elements, interleaved A/B binaries, two sessions plus an alignment-forced rebuild:

| bench | session 1 | session 2 | blocks 32B-aligned |
|---|---|---|---|
| `Array::push` (pre-sized) | **−8.6%** | **−8.9%** | −21.6% |
| `Array::push` (growing) | −3.8% | −4.5% | — |
| `FixedArray` → `Array::from_fixed_array` | **−41.0%** | **−40.4%** | −30.6% |
| `Array::make` / `fill` | ±0.3% | ±0.5% | — |

`from_fixed_array` converts a freshly built 16-element `FixedArray` per iteration: with the source uniquely owned, the runtime moves the elements instead of incref-ing each on copy and decref-ing each on free, eliminating the per-element RC traffic entirely.

One control note, for the record: a `sorted_set` control bench (no array involvement) read +5.3% against this branch's binary pair, and collapses to +0.2% when every basic block is force-aligned (`-mllvm -align-all-blocks=5`) — fixed-binary-pair code-placement luck, same phenomenon documented in #3983. The `Map` control stayed within ±0.4% throughout.