### PR TITLE
perf(string): back code unit range comparison with %string.unsafe_range_equal

### DIFF
--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -104,6 +104,43 @@ pub fn String::unsafe_substring(
 }
 
 ///|
+/// **UNSAFE**: Compares two UTF-16 code unit ranges for equality without bounds
+/// checking.
+///
+/// ⚠️ **Warning: This function is unsafe and can cause undefined behavior!**
+///
+/// # Safety
+/// - **No bounds checking**: caller must ensure both ranges
+///   `[self_off, self_off + len)` and `[other_off, other_off + len)` are fully
+///   within their respective strings.
+///
+/// # Parameters
+/// - `self`, `other`: the two strings
+/// - `self_off`, `other_off`: starting code unit offsets
+/// - `len`: number of code units to compare
+///
+/// This is the shared intrinsic-backed primitive for view/owned equality
+/// comparisons (e.g. `StringView == StringView`, `StringView::has_prefix`).
+/// The function body is the fallback implementation for targets without the
+/// intrinsic.
+#borrow(self, other)
+#intrinsic("%string.unsafe_range_equal")
+fn String::unsafe_range_equal(
+  self : String,
+  self_off~ : Int,
+  other : String,
+  other_off~ : Int,
+  len~ : Int,
+) -> Bool {
+  for i in 0..<len {
+    guard self.unsafe_get(self_off + i) == other.unsafe_get(other_off + i) else {
+      return false
+    }
+  }
+  true
+}
+
+///|
 /// Returns a new string containing characters from the original string starting
 /// at `start` index up to (but not including) `end` index.
 ///

--- a/builtin/string_equal_bench_test.mbt
+++ b/builtin/string_equal_bench_test.mbt
@@ -1,0 +1,48 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let string_equal_bench_size = 100_000
+
+///|
+fn make_string_equal_bench_string(diff_at? : Int = -1) -> String {
+  let builder = StringBuilder(size_hint=string_equal_bench_size * 2)
+  for i in 0..<string_equal_bench_size {
+    builder.write_char(if i == diff_at { 'b' } else { 'a' })
+  }
+  builder.to_string()
+}
+
+///|
+test "bench StringView::equal n=100000 equal" (it : @bench.T) {
+  let left = make_string_equal_bench_string()[:]
+  let right = make_string_equal_bench_string()[:]
+  it.bench(fn() { it.keep(left == right) })
+}
+
+///|
+test "bench StringView::equal n=100000 mismatch at end" (it : @bench.T) {
+  let left = make_string_equal_bench_string()[:]
+  let right = make_string_equal_bench_string(
+      diff_at=string_equal_bench_size - 1,
+    )[:]
+  it.bench(fn() { it.keep(left == right) })
+}
+
+///|
+test "bench StringView::equal_to_string n=100000 equal" (it : @bench.T) {
+  let left = make_string_equal_bench_string()[:]
+  let right = make_string_equal_bench_string()
+  it.bench(fn() { it.keep(left.equal_to_string(right)) })
+}

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -187,10 +187,19 @@ pub fn StringView::has_suffix(self : StringView, str : StringView) -> Bool {
   let str_len = str.length()
   guard str_len <= self_len else { return false }
   let start = self_len - str_len
-  for i in 0..<str_len {
-    guard self.unsafe_get(start + i) == str.unsafe_get(i) else { return false }
+  // Compare the anchor code unit inline: a mismatch there is the common case
+  // and is cheaper to reject than to pay the range-compare call overhead.
+  guard str_len == 0 || self.unsafe_get(start) == str.unsafe_get(0) else {
+    return false
   }
-  true
+  self
+  .str()
+  .unsafe_range_equal(
+    str.str(),
+    self_off=self.start() + start,
+    other_off=str.start(),
+    len=str_len,
+  )
 }
 
 ///|
@@ -220,10 +229,19 @@ test "has_suffix" {
 pub fn StringView::has_prefix(self : StringView, str : StringView) -> Bool {
   let str_len = str.length()
   guard str_len <= self.length() else { return false }
-  for i in 0..<str_len {
-    guard self.unsafe_get(i) == str.unsafe_get(i) else { return false }
+  // Compare the anchor code unit inline: a mismatch there is the common case
+  // and is cheaper to reject than to pay the range-compare call overhead.
+  guard str_len == 0 || self.unsafe_get(0) == str.unsafe_get(0) else {
+    return false
   }
-  true
+  self
+  .str()
+  .unsafe_range_equal(
+    str.str(),
+    self_off=self.start(),
+    other_off=str.start(),
+    len=str_len,
+  )
 }
 
 ///|

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -351,13 +351,14 @@ pub impl Eq for StringView with fn equal(self, other) {
   if physical_equal(self.str(), other.str()) && self.start() == other.start() {
     return true
   }
-  for i in 0..<len {
-    guard self.str().unsafe_get(self.start() + i) ==
-      other.str().unsafe_get(other.start() + i) else {
-      return false
-    }
-  }
-  true
+  self
+  .str()
+  .unsafe_range_equal(
+    other.str(),
+    self_off=self.start(),
+    other_off=other.start(),
+    len~,
+  )
 }
 
 ///|
@@ -391,12 +392,7 @@ pub fn StringView::equal_to_string(self : StringView, other : String) -> Bool {
   if physical_equal(self.str(), other) && self.start() == 0 {
     return true
   }
-  for i in 0..<len {
-    guard self.str().unsafe_get(self.start() + i) == other.unsafe_get(i) else {
-      return false
-    }
-  }
-  true
+  self.str().unsafe_range_equal(other, self_off=self.start(), other_off=0, len~)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Add a private `String::unsafe_range_equal` primitive backed by `#intrinsic("%string.unsafe_range_equal")`, mirroring the existing `Bytes::unsafe_range_equal`. The MoonBit body stays as the fallback for backends without the intrinsic; on native it lowers to a single `memcmp`.
- Route the hand-rolled UTF-16 code unit loops through it: `StringView::has_prefix`, `StringView::has_suffix`, `Eq for StringView`, `StringView::equal_to_string`.
- Add `builtin/string_equal_bench_test.mbt`, modelled on `bytes_equal_bench_test.mbt`.

## Why

`#3841` specialized the anchored prefix/suffix predicates but still compared one code unit at a time, and the `StringView` equality paths never had a specialization at all. All four sites are exactly the shape the intrinsic exists for.

Native release, 100,000-code-unit haystack with a 128-code-unit needle for the anchored predicates, 100,000 code units for equality:

| case | before | after |
| --- | ---: | ---: |
| `has_prefix` match | 47.45 ns | 12.35 ns |
| `has_prefix` mismatch at first code unit | 6.11 ns | 6.82 ns |
| `has_suffix` match | 49.80 ns | 12.78 ns |
| `has_suffix` mismatch at first code unit | 5.88 ns | 6.77 ns |
| `StringView ==` equal | 26.87 us | 4.09 us |
| `StringView ==` mismatch at end | 27.26 us | 4.05 us |
| `equal_to_string` equal | 30.77 us | 4.08 us |

wasm-gc has no intrinsic for this yet and runs the fallback body; it stays flat within noise (86.45 ns -> 88.88 ns for `has_prefix` match, 61.48 us -> 61.80 us for `StringView ==`).

## Notes

Two deliberate decisions, both driven by measurement:

- The early-mismatch path pays call setup that the old loop avoided by bailing at index 0. `has_prefix`/`has_suffix` therefore compare the anchor code unit inline first, which recovers most of it (7.82 ns -> 6.82 ns) at no cost to the match case.
- `find`/`rev_find` are left alone. Routing the two-anchor middle check through the intrinsic moved `find two anchors dense false positives` from 161.38 ns to 174.05 ns, and converting the scalar fallback loops moved it to 734.38 ns. Those ranges are short and usually mismatch early, so the inline early-exit loop is the right shape there.

## Validation

- `moon test builtin --target native` (2895 passed)
- `moon test builtin --target wasm-gc` (2937 passed)
- `moon test builtin --target wasm` (2937 passed)
- `moon test builtin --target js` (2914 passed)
- `moon check builtin --target all`
- `moon info builtin` (no `.mbti` change; the primitive is private)
- `moon bench builtin/string_methods_bench_test.mbt --target native --release`
- `moon bench builtin/string_equal_bench_test.mbt --target native --release`
- `moon bench builtin/string_find_code_unit_bench_test.mbt --target native --release`
