### PR TITLE
perf(builtin): annotate Array::resize default with #owned; document bare-prim exclusion

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1241,6 +1241,7 @@ pub fn[T] Array::retain(self : Array[T], f : (T) -> Bool raise?) -> Unit raise? 
 /// }
 /// ```
 ///
+#owned(f)
 pub fn[T] Array::resize(self : Array[T], new_len : Int, f : T) -> Unit {
   if new_len < 0 {
     abort("negative new length")

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -1619,6 +1619,11 @@ pub fn[T] FixedArray::at(self : FixedArray[T], idx : Int) -> T = "%fixedarray.ge
 #doc(hidden)
 pub fn[T] FixedArray::unsafe_get(self : FixedArray[T], idx : Int) -> T = "%fixedarray.unsafe_get"
 
+// The bare-primitive store and make definitions below (`= "%fixedarray.set"`
+// etc.) intentionally carry no `#owned` annotation: calls lower inline to the
+// primitive, whose value operand already consumes the reference, so the
+// generated code is optimal without one (verified against native C output).
+
 ///|
 /// Set fixed-array element without safe bounds checks.
 /// Unsafe variant of `set`.

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -47,6 +47,10 @@ fn[T] UninitializedArray::unsafe_get(
   index : Int,
 ) -> T = "%fixedarray.unsafe_get"
 
+// `set`/`unsafe_set` are bare primitives and need no `#owned` annotation:
+// calls lower inline to `%fixedarray.set`/`%fixedarray.unsafe_set`, whose
+// value operand already consumes the reference (verified against native C).
+
 ///|
 /// Sets the value at the specified index in an uninitialized array.
 ///


### PR DESCRIPTION
## What

Follow-up to the two open items from #3989's review:

1. Add `#owned(f)` to `Array::resize` — the one remaining wrapper that forwards a value parameter into an already-`#owned` callee (`unsafe_resize_with_default`).
2. Document, at the declaration sites, why the bare-primitive store/make definitions (`FixedArray::set`/`unsafe_set`, `UninitializedArray::set`/`unsafe_set`, `FixedArray::make`) intentionally carry no `#owned` annotation.

#3989 merged while this was being prepared, so this now sits directly on `main` as a single commit.

## Evidence (generated native C)

`resize` probe — `arr.resize(8, x.to_string())` with a caller-owned temp:

Before: the caller keeps the temp through the call and drops it afterwards, and `resize` increfs at the owned inner boundary:

```c
_M0MPC15array5Array6resizeGsE(arr, 8, tmp);
moonbit_decref(tmp);            // caller-side surplus
```

After: the call transfers ownership — caller-side RC ops disappear entirely, and inside `resize` the grow path forwards `f` into `unsafe_resize_with_default` with zero RC ops. The truncate and no-op paths gain one constant `moonbit_decref(f)` — the same ±1 trade #3989 accepts for `fill`/`make`.

Bare-prim probe — `arr[3] = x.to_string()` on `FixedArray` *without* any annotation already compiles to the optimal form:

```c
old = arr[3];
moonbit_decref(old);
arr[3] = tmp;                   // temp consumed directly, no incref/decref pair
```

Calls to these declarations lower inline to the primitive, whose value operand already consumes the reference — an `#owned` annotation there would be a no-op. Now stated in comments at both declaration clusters so the asymmetry (annotated `#intrinsic`+body functions vs. unannotated bare prims) doesn't have to be re-derived from C output next time.

## Benchmarks

Micro-benchmarks of `resize` (grow-64 / truncate with a temp `String` default) are neutral within noise against the #3989 base — expected, since the change removes 2 RC ops per call against a 64-slot fill loop. The benefit is the zero-op temp transfer for callers and family consistency, not a headline number.

## Validation

- `moon check`: clean; `moon fmt` + `moon info`: zero drift (no `.mbti` changes)
- `moon test` (wasm-gc): 7021/7021
- `moon test --target native`: 6931/6931
