### PR TITLE
fix(quickcheck): omit empty categories from ObservationSummary debug rendering

### DIFF
--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -474,14 +474,14 @@ test "report accepts InspectError while shrinking Raised" {
 test "classes-only summary omits the empty labels field" {
   let report = @quickcheck.report(
     (_ : Int) => true,
-    observe=input => [@quickcheck.classify(input >= 0, "non-negative")],
+    observe=_ => [@quickcheck.classify(true, "observed")],
     count=3,
     max_size=2,
   )
   debug_inspect(
     report,
     content=(
-      #|Passed(tests=3, observations={ classes: { "non-negative": 3 } })
+      #|Passed(tests=3, observations={ classes: { "observed": 3 } })
     ),
   )
 }

--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -135,7 +135,7 @@ test "discarded cases do not contribute observations" {
     content=(
       #|Passed(
       #|  tests=2,
-      #|  observations={ labels: { <List: ["1"]>: 1, <List: ["2"]>: 1 }, classes: {} },
+      #|  observations={ labels: { <List: ["1"]>: 1, <List: ["2"]>: 1 } },
       #|)
     ),
   )
@@ -466,6 +466,22 @@ test "report accepts InspectError while shrinking Raised" {
       #|  shrinks=1,
       #|  shrink_attempts=1,
       #|)
+    ),
+  )
+}
+
+///|
+test "classes-only summary omits the empty labels field" {
+  let report = @quickcheck.report(
+    (_ : Int) => true,
+    observe=input => [@quickcheck.classify(input >= 0, "non-negative")],
+    count=3,
+    max_size=2,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Passed(tests=3, observations={ classes: { "non-negative": 3 } })
     ),
   )
 }

--- a/quickcheck/observation.mbt
+++ b/quickcheck/observation.mbt
@@ -33,7 +33,22 @@ type Observations = Array[Observation]
 priv struct ObservationSummary {
   labels : Map[@list.List[String], UInt]
   classes : Map[String, UInt]
-} derive(@debug.Debug)
+}
+
+///|
+/// Snapshot-friendly rendering: empty categories are omitted, so a
+/// classes-only summary renders as `{ classes: {...} }` without a noisy
+/// `labels: {}` field (and vice versa).
+impl @debug.Debug for ObservationSummary with fn to_repr(self) {
+  let fields : Map[String, @debug.Repr] = Map([])
+  if !self.labels.is_empty() {
+    fields["labels"] = Repr(self.labels)
+  }
+  if !self.classes.is_empty() {
+    fields["classes"] = Repr(self.classes)
+  }
+  @debug.Repr::record(fields)
+}
 
 ///|
 pub impl Show for Observation with fn output(self, logger) {

--- a/quickcheck/observation.mbt
+++ b/quickcheck/observation.mbt
@@ -40,14 +40,18 @@ priv struct ObservationSummary {
 /// classes-only summary renders as `{ classes: {...} }` without a noisy
 /// `labels: {}` field (and vice versa).
 impl @debug.Debug for ObservationSummary with fn to_repr(self) {
-  let fields : Map[String, @debug.Repr] = Map([])
-  if !self.labels.is_empty() {
-    fields["labels"] = Repr(self.labels)
-  }
-  if !self.classes.is_empty() {
-    fields["classes"] = Repr(self.classes)
-  }
-  @debug.Repr::record(fields)
+  @debug.Repr::record(
+    Map(
+      [
+        ..if !self.labels.is_empty() {
+          [("labels", Repr(self.labels))]
+        },
+        ..if !self.classes.is_empty() {
+          [("classes", Repr(self.classes))]
+        },
+      ],
+    ),
+  )
 }
 
 ///|

--- a/quickcheck/observation.mbt
+++ b/quickcheck/observation.mbt
@@ -44,10 +44,10 @@ impl @debug.Debug for ObservationSummary with fn to_repr(self) {
     Map(
       [
         ..if !self.labels.is_empty() {
-          [("labels", Repr(self.labels))]
+          [("labels", @debug.Repr(self.labels))]
         },
         ..if !self.classes.is_empty() {
-          [("classes", Repr(self.classes))]
+          [("classes", @debug.Repr(self.classes))]
         },
       ],
     ),


### PR DESCRIPTION
In the snapshot-first testing workflow, a report's `Debug` rendering is effectively the API surface — and every classes-only coverage snapshot (the common case when using `classify`) currently carries a noisy `labels: {}` field, e.g. in a downstream project (moonbit-community/toml-parser#122):

```
observations={ labels: {}, classes: { "contains-table": 570, ... } }
```

`ObservationSummary` now renders via a custom `Debug` impl that omits empty categories, so the above reads `observations={ classes: {...} }` (symmetrically, labels-only summaries drop `classes: {}`). The text `failure_report` path already skipped empty categories; this aligns the Debug path.

Test plan: new classes-only rendering test; one existing labels-only snapshot updated (drops `, classes: {}`); `moon test quickcheck` 68/68; `moon check --deny-warn`, `moon fmt`, `moon info` clean (no interface change — the type is private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)