### PR TITLE
feat(quickcheck): Generator::spawn draws from an Arbitrary instance

### DIFF
--- a/quickcheck/generator.mbt
+++ b/quickcheck/generator.mbt
@@ -36,7 +36,7 @@ pub fn[T] Generator::Generator(
 ///
 /// ```mbt check
 /// test "spawn draws from Arbitrary" {
-///   let strings : @quickcheck.Generator[String] = @quickcheck.Generator::spawn()
+///   let strings : @quickcheck.Generator[String] = @quickcheck.spawn()
 ///   let lengths = strings.samples(count=3, size=4, seed=37).map(s => s.length())
 ///   debug_inspect(
 ///     lengths,
@@ -46,7 +46,7 @@ pub fn[T] Generator::Generator(
 ///   )
 /// }
 /// ```
-pub fn[T : Arbitrary] Generator::spawn() -> Generator[T] {
+pub fn[T : Arbitrary] spawn() -> Generator[T] {
   Generator(Arbitrary::arbitrary)
 }
 

--- a/quickcheck/generator.mbt
+++ b/quickcheck/generator.mbt
@@ -37,7 +37,7 @@ pub fn[T] Generator::Generator(
 /// ```mbt check
 /// test "spawn draws from Arbitrary" {
 ///   let strings : @quickcheck.Generator[String] = @quickcheck.Generator::spawn()
-///   let lengths = strings.samples(count=3, size=4).map(s => s.length())
+///   let lengths = strings.samples(count=3, size=4, seed=37).map(s => s.length())
 ///   debug_inspect(
 ///     lengths,
 ///     content=(

--- a/quickcheck/generator.mbt
+++ b/quickcheck/generator.mbt
@@ -30,6 +30,27 @@ pub fn[T] Generator::Generator(
 }
 
 ///|
+/// Creates a generator that draws values from the type's `Arbitrary`
+/// instance, for mixing `Arbitrary`-based generation into hand-written
+/// generators.
+///
+/// ```mbt check
+/// test "spawn draws from Arbitrary" {
+///   let strings : @quickcheck.Generator[String] = @quickcheck.Generator::spawn()
+///   let lengths = strings.samples(count=3, size=4).map(s => s.length())
+///   debug_inspect(
+///     lengths,
+///     content=(
+///       #|[3, 2, 1]
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T : Arbitrary] Generator::spawn() -> Generator[T] {
+  Generator(Arbitrary::arbitrary)
+}
+
+///|
 /// Runs a generator with an explicit size and random state.
 pub fn[T] Generator::run(
   self : Generator[T],

--- a/quickcheck/generator_test.mbt
+++ b/quickcheck/generator_test.mbt
@@ -176,8 +176,8 @@ test "zip_with and zip_with3 combine generator outputs" {
 
 ///|
 test "spawn composes with generator combinators" {
-  let entries = (@quickcheck.Generator::spawn() : @quickcheck.Generator[String])
-    .zip((@quickcheck.Generator::spawn() : @quickcheck.Generator[Int]))
+  let entries = (@quickcheck.spawn() : @quickcheck.Generator[String])
+    .zip((@quickcheck.spawn() : @quickcheck.Generator[Int]))
     .samples(count=3, size=4, seed=37)
   debug_inspect(
     entries,

--- a/quickcheck/generator_test.mbt
+++ b/quickcheck/generator_test.mbt
@@ -178,7 +178,7 @@ test "zip_with and zip_with3 combine generator outputs" {
 test "spawn composes with generator combinators" {
   let entries = (@quickcheck.Generator::spawn() : @quickcheck.Generator[String])
     .zip((@quickcheck.Generator::spawn() : @quickcheck.Generator[Int]))
-    .samples(count=3, size=4)
+    .samples(count=3, size=4, seed=37)
   debug_inspect(
     entries,
     content=(

--- a/quickcheck/generator_test.mbt
+++ b/quickcheck/generator_test.mbt
@@ -173,3 +173,16 @@ test "zip_with and zip_with3 combine generator outputs" {
     ),
   )
 }
+
+///|
+test "spawn composes with generator combinators" {
+  let entries = (@quickcheck.Generator::spawn() : @quickcheck.Generator[String])
+    .zip((@quickcheck.Generator::spawn() : @quickcheck.Generator[Int]))
+    .samples(count=3, size=4)
+  debug_inspect(
+    entries,
+    content=(
+      #|[("", 3), ("Z\b", 3), ("", 0)]
+    ),
+  )
+}

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -55,6 +55,7 @@ pub fn[T] Generator::run(Self[T], Int, @splitmix.RandomState) -> T
 pub fn[T] Generator::sample(Self[T], size? : Int, seed? : UInt64) -> T
 pub fn[T] Generator::samples(Self[T], count? : Int, size? : Int, seed? : UInt64) -> Array[T]
 pub fn[T] Generator::scale(Self[T], (Int) -> Int) -> Self[T]
+pub fn[T : Arbitrary] Generator::spawn() -> Self[T]
 pub fn[T, U] Generator::zip(Self[T], Self[U]) -> Self[(T, U)]
 pub fn[T, U, V] Generator::zip_with(Self[T], Self[U], (T, U) -> V) -> Self[V]
 pub fn[T, U, V, W] Generator::zip_with3(Self[T], Self[U], Self[V], (T, U, V) -> W) -> Self[W]

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -42,6 +42,8 @@ pub fn[X : Arbitrary] samples(Int) -> Array[X]
 
 pub fn[T] sized((Int) -> Generator[T]) -> Generator[T]
 
+pub fn[T : Arbitrary] spawn() -> Generator[T]
+
 // Errors
 
 // Types and methods
@@ -55,7 +57,6 @@ pub fn[T] Generator::run(Self[T], Int, @splitmix.RandomState) -> T
 pub fn[T] Generator::sample(Self[T], size? : Int, seed? : UInt64) -> T
 pub fn[T] Generator::samples(Self[T], count? : Int, size? : Int, seed? : UInt64) -> Array[T]
 pub fn[T] Generator::scale(Self[T], (Int) -> Int) -> Self[T]
-pub fn[T : Arbitrary] Generator::spawn() -> Self[T]
 pub fn[T, U] Generator::zip(Self[T], Self[U]) -> Self[(T, U)]
 pub fn[T, U, V] Generator::zip_with(Self[T], Self[U], (T, U) -> V) -> Self[V]
 pub fn[T, U, V, W] Generator::zip_with3(Self[T], Self[U], Self[V], (T, U, V) -> W) -> Self[W]


### PR DESCRIPTION
Last item from the #3955 feedback (https://github.com/moonbitlang/core/pull/3955#issuecomment-5189971358, point 6). Bridging from an `Arbitrary` instance into the `Generator` combinator world is possible via `Generator(Arbitrary::arbitrary)` but non-obvious, and every hand-written generator suite re-derives the same helper (the third-party package had it as `Gen::spawn`; moonbit-community/toml-parser#122 carries a local copy).

`Generator::spawn()` makes the one-liner a documented core API:

```moonbit
let strings : @quickcheck.Generator[String] = @quickcheck.Generator::spawn()
```

Test plan: docstring example plus a test composing `spawn` with `zip`; `moon test quickcheck` 69/69; `moon check --deny-warn`, `moon fmt`, `moon info` clean (one added interface line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)