### PR TITLE
fix(json): parse big integer literals to correctly rounded doubles

### DIFF
--- a/json/big_integer_parse_test.mbt
+++ b/json/big_integer_parse_test.mbt
@@ -33,12 +33,16 @@ test "big integer literals parse to correctly rounded doubles" {
 
   // 2^53 + 1 rounds (ties to even) down to 2^53; the text is preserved.
   let parsed = @json.parse("9007199254740993")
-  assert_true(parsed is Number(9007199254740992.0, repr=Some("9007199254740993")))
+  assert_true(
+    parsed is Number(9007199254740992.0, repr=Some("9007199254740993")),
+  )
   inspect(parsed.stringify(), content="9007199254740993")
 
   // 2^53 itself is exactly representable.
   let parsed = @json.parse("9007199254740992")
-  assert_true(parsed is Number(9007199254740992.0, repr=Some("9007199254740992")))
+  assert_true(
+    parsed is Number(9007199254740992.0, repr=Some("9007199254740992")),
+  )
 
   // A 29-digit literal rounds to the nearest double.
   let parsed = @json.parse("12345678901234567890123456789")

--- a/json/big_integer_parse_test.mbt
+++ b/json/big_integer_parse_test.mbt
@@ -1,0 +1,106 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integer literals beyond 2^53 - 1 must parse to the correctly rounded
+// double (like every mainstream JSON implementation), with the exact source
+// text preserved in `repr` so `stringify` stays lossless. The infinity
+// sentinel is reserved for values genuinely beyond double range.
+//
+// Previously `lex_integer_end` conflated "cannot be represented exactly in
+// 2^53" with "out of double range": any integer-shaped literal above
+// 2^53 - 1 collapsed to `Number(Infinity, repr=...)`, so the same value
+// parsed differently in integer and exponent form ("10000000000000000000"
+// vs "1e19"), all such numbers compared equal, and `from_json : Double`
+// raised on values doubles represent fine.
+
+///|
+test "big integer literals parse to correctly rounded doubles" {
+  // 1e19 is exactly representable as a double.
+  let parsed = @json.parse("10000000000000000000")
+  assert_true(parsed is Number(1.0e19, repr=Some("10000000000000000000")))
+  inspect(parsed.stringify(), content="10000000000000000000")
+
+  // 2^53 + 1 rounds (ties to even) down to 2^53; the text is preserved.
+  let parsed = @json.parse("9007199254740993")
+  assert_true(parsed is Number(9007199254740992.0, repr=Some("9007199254740993")))
+  inspect(parsed.stringify(), content="9007199254740993")
+
+  // 2^53 itself is exactly representable.
+  let parsed = @json.parse("9007199254740992")
+  assert_true(parsed is Number(9007199254740992.0, repr=Some("9007199254740992")))
+
+  // A 29-digit literal rounds to the nearest double.
+  let parsed = @json.parse("12345678901234567890123456789")
+  assert_true(
+    parsed
+    is Number(1.2345678901234568e28, repr=Some("12345678901234567890123456789")),
+  )
+  inspect(parsed.stringify(), content="12345678901234567890123456789")
+
+  // Negative values round symmetrically.
+  let parsed = @json.parse("-10000000000000000000")
+  assert_true(parsed is Number(-1.0e19, repr=Some("-10000000000000000000")))
+  inspect(parsed.stringify(), content="-10000000000000000000")
+}
+
+///|
+test "integer and exponent spellings of the same value parse equal" {
+  assert_eq(@json.parse("10000000000000000000"), @json.parse("1e19"))
+  assert_eq(@json.parse("-10000000000000000000"), @json.parse("-1e19"))
+}
+
+///|
+test "distinct big integers do not compare equal" {
+  assert_not_eq(
+    @json.parse("9007199254740993"),
+    @json.parse("99999999999999999999"),
+  )
+  assert_not_eq(
+    @json.parse("10000000000000000000"),
+    @json.parse("-10000000000000000000"),
+  )
+}
+
+///|
+test "from_json decodes big integer texts as Double" {
+  let value : Double = @json.from_json(@json.parse("10000000000000000000"))
+  inspect(value, content="10000000000000000000")
+  let value : Double = @json.from_json(@json.parse("9007199254740993"))
+  inspect(value, content="9007199254740992")
+}
+
+///|
+test "only integers beyond double range keep the infinity sentinel" {
+  let huge = "9".repeat(400)
+  let parsed = @json.parse(huge)
+  assert_true(
+    parsed is Number(sentinel, repr=Some(repr)) &&
+    sentinel == @double.infinity &&
+    repr == huge,
+  )
+  inspect(parsed.stringify().length(), content="400")
+  let negative_huge = "-" + huge
+  let parsed = @json.parse(negative_huge)
+  assert_true(
+    parsed is Number(sentinel, repr=Some(repr)) &&
+    sentinel == @double.neg_infinity &&
+    repr == negative_huge,
+  )
+  // The sentinel still refuses to decode as a Double.
+  try (@json.from_json(parsed) : Double) |> ignore catch {
+    _ => ()
+  } noraise {
+    _ => fail("expected out-of-range sentinel to fail Double decoding")
+  }
+}

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -236,11 +236,22 @@ fn ParseContext::lex_integer_end(
     }
     let digit = (ctx.input.unsafe_get(i).to_int() - '0').to_int64()
     if acc > (SAFE_INTEGER_LIMIT - digit) / 10L {
+      // The literal exceeds the exact-integer range of a double (2^53 - 1).
+      // Fall back to strconv for the correctly rounded value, preserving the
+      // exact source text in `repr` so `stringify` stays lossless. Only a
+      // literal strconv itself rejects (beyond double range) keeps the
+      // infinity sentinel.
       let s = ctx.input.view(start_offset=start, end_offset=end)
-      return if negative {
-        { value: @double.neg_infinity, repr: Some(s) }
-      } else {
-        { value: @double.infinity, repr: Some(s) }
+      try {
+        let value = @internal/strconv.parse_double(s)
+        return { value, repr: Some(s) }
+      } catch {
+        _ =>
+          return if negative {
+            { value: @double.neg_infinity, repr: Some(s) }
+          } else {
+            { value: @double.infinity, repr: Some(s) }
+          }
       }
     }
     continue i + 1, acc * 10L + digit

--- a/json/lex_number_test.mbt
+++ b/json/lex_number_test.mbt
@@ -86,24 +86,30 @@ test "parse and stringify large integers" {
   debug_inspect(parsed_max, content="Number(2147483647)")
   @builtin.inspect(parsed_max.stringify(), content="2147483647")
 
-  // Test integers beyond safe JavaScript integer precision (±2^53)
-  let beyond_js_safe = "9007199254740993" // 2^53 + 1
+  // Integers beyond exact double precision (±2^53) parse to the correctly
+  // rounded value, with the exact source text preserved in `repr` so
+  // stringify stays lossless.
+  let beyond_js_safe = "9007199254740993" // 2^53 + 1, rounds to 2^53
   let parsed_beyond = @json.parse(beyond_js_safe)
   debug_inspect(
     parsed_beyond,
     content=(
-      #|Number(Infinity, repr=Some("9007199254740993"))
+      #|Number(9007199254740992, repr=Some("9007199254740993"))
     ),
   )
   @builtin.inspect(parsed_beyond.stringify(), content="9007199254740993")
 
-  // Test very large integers
+  // Very large integers still within double range round to the nearest
+  // double while keeping the exact text.
   let very_large = "12345678901234567890123456789"
   let parsed_large = @json.parse(very_large)
   debug_inspect(
     parsed_large,
     content=(
-      #|Number(Infinity, repr=Some("12345678901234567890123456789"))
+      #|Number(
+      #|  1.2345678901234568e+28,
+      #|  repr=Some("12345678901234567890123456789"),
+      #|)
     ),
   )
   @builtin.inspect(

--- a/json/moon.pkg
+++ b/json/moon.pkg
@@ -15,4 +15,5 @@ import {
   "moonbitlang/core/unit",
   "moonbitlang/core/bigint",
   "moonbitlang/core/bench",
+  "moonbitlang/core/double",
 } for "test"


### PR DESCRIPTION
## Problem

`lex_integer_end` conflated **"cannot be represented exactly in 2^53"** with **"out of double range"**: once the exact-integer accumulator overflowed `SAFE_INTEGER_LIMIT` (2^53 − 1), it returned the `Number(Infinity, repr=...)` sentinel immediately, never consulting strconv. The decimal/exponent path already falls back to strconv for correct rounding, so the same value parsed differently depending on spelling:

| Input | Before | After |
|---|---|---|
| `"1e19"` | `Number(1.0e19)` | `Number(1.0e19)` (unchanged) |
| `"10000000000000000000"` (= 1e19) | `Number(Infinity, repr=Some(...))` | `Number(1.0e19, repr=Some(...))` |
| `"9007199254740993"` (2^53 + 1) | `Number(Infinity, repr=Some(...))` | `Number(9007199254740992, repr=Some(...))` |
| `"9".repeat(400)` (beyond double range) | `Number(Infinity, repr=Some(...))` | `Number(Infinity, repr=Some(...))` (unchanged) |

Consequences of the old behavior:

- `parse("9007199254740993") == parse("99999999999999999999")` was `true` — `Eq` compares only the double value, so every big-integer text collapsed into one equivalence class
- `from_json : Double` raised on values doubles represent fine (1e19 is *exactly* representable)
- No mainstream implementation behaves this way: JS `JSON.parse` rounds correctly; serde_json / Jackson / Python keep exact or correctly rounded values; raw-text preservation (which `repr` already provides) is the opt-in layer elsewhere (Go `json.Number`, serde `arbitrary_precision`, `JSON.rawJSON`)

Found by the QuickCheck property suite in #3995 — the naive `parse(stringify(j)) == j` property falsified in 30 cases and shrank to a bare big `Number`.

## Fix

On accumulator overflow, fall back to `@internal/strconv.parse_double` for the correctly rounded value and keep the exact source text in `repr`, so `stringify` remains byte-lossless. The infinity sentinel now only applies to literals strconv itself rejects (genuinely beyond double range).

Structured as red/green commits:

1. **test(json)**: failing tests encoding the desired behavior (`json/big_integer_parse_test.mbt`)
2. **fix(json)**: the `lex_integer_end` fallback + updated expectations in `lex_number_test.mbt` (the out-of-range sentinel tests pass unchanged)

## Validation

- Full repo suite: 7029/7029 passing
- `moon fmt`, `moon info` — no public API changes

## Note

If this merges before #3995, the two-regime number-contract test there simplifies back to the universal `parse(stringify(j)) == j` property; I'll update that branch accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)