### PR TITLE
test(immut): QuickCheck property suites for vector and hashmap; finds HAMT Eq bug

### DIFF
--- a/immut/hashmap/moon.pkg
+++ b/immut/hashmap/moon.pkg
@@ -12,5 +12,7 @@ import {
   "moonbitlang/core/bench",
   "moonbitlang/core/int",
   "moonbitlang/core/option",
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/shrink",
   "moonbitlang/core/test",
 } for "test"

--- a/immut/hashmap/quickcheck_test.mbt
+++ b/immut/hashmap/quickcheck_test.mbt
@@ -1,0 +1,257 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Property-based tests for the HAMT.
+//
+// Keys use a deliberately degenerate hash (8 buckets) drawn from a small
+// range, so collision buckets, key overwrites, and removals of present keys
+// are exercised constantly — the paths where HAMT bugs live. The builtin
+// mutable `Map` (an independent implementation) serves as the model.
+
+///|
+/// Key with a collision-heavy hash: only `self.0 & 7` contributes, while
+/// `Eq` still distinguishes all keys.
+priv struct Key(Int) derive(Eq, @debug.Debug)
+
+///|
+impl Hash for Key with fn hash(self) {
+  self.0 & 7
+}
+
+///|
+impl Hash for Key with fn hash_combine(self, hasher) {
+  hasher.combine_int(self.0 & 7)
+}
+
+///|
+/// Keys come from a small range so random operations frequently hit
+/// existing keys (overwrites, real removals) and collide in buckets.
+impl @quickcheck.Arbitrary for Key with fn arbitrary(_size, state) {
+  Key(@quickcheck.int_range(0, 32).run(0, state))
+}
+
+///|
+impl @shrink.Shrink for Key with fn shrink(self) {
+  @shrink.Shrink::shrink(self.0).map(k => Key(k))
+}
+
+///|
+/// Whether the HAMT and the model map hold exactly the same entries.
+fn agrees_with(hm : @hashmap.HashMap[Key, Int], model : Map[Key, Int]) -> Bool {
+  guard hm.length() == model.length() else { return false }
+  for k, v in model {
+    guard hm.get(k) == Some(v) else { return false }
+  }
+  for k, v in hm.iter2() {
+    guard model.get(k) == Some(v) else { return false }
+  }
+  true
+}
+
+///|
+test "add/remove agree with the builtin Map model at every step" {
+  @quickcheck.check((ops : Array[(Bool, Key, Int)]) => {
+    let mut hm : @hashmap.HashMap[Key, Int] = @hashmap.new()
+    let model : Map[Key, Int] = Map([])
+    for op in ops {
+      let (is_add, key, value) = op
+      if is_add {
+        hm = hm.add(key, value)
+        model[key] = value
+      } else {
+        hm = hm.remove(key)
+        model.remove(key)
+      }
+      guard agrees_with(hm, model) else { return false }
+      guard hm.contains(key) == model.contains(key) else { return false }
+    }
+    true
+  })
+}
+
+///|
+test "construction order does not affect equality or hash" {
+  @quickcheck.check((pairs : Array[(Key, Int)]) => {
+    // Deduplicate keys first so both construction orders hold identical
+    // content.
+    let dedup : Map[Key, Int] = Map([])
+    for pair in pairs {
+      dedup[pair.0] = pair.1
+    }
+    let unique = dedup.to_array()
+    let forward = @hashmap.from_iter(unique.iter())
+    let backward = @hashmap.from_iter(unique.rev().iter())
+    forward == backward &&
+    forward.hash() == backward.hash() &&
+    forward.length() == unique.length()
+  })
+}
+
+///|
+/// KNOWN BUG: the stronger form `round_trip == m` is falsified — removing a
+/// key from a collision bucket leaves a non-canonical `Leaf(k, v, Empty)`
+/// node where a fresh map holds `Flat(k, v, path)`, and the derived
+/// structural `Eq` then reports content-equal maps as unequal (minimal
+/// counterexample: `{Key(0): 0}` vs `add(Key(24), 0).remove(Key(24))`;
+/// `filter` produces the same shape). Until that is fixed, this checks
+/// content equality and hash consistency, which do hold.
+test "adding then removing a fresh key restores the original content" {
+  @quickcheck.check((input : (@hashmap.HashMap[Key, Int], Key, Int)) => {
+    let (m, key, value) = input
+    guard !m.contains(key) else { return true }
+    let round_trip = m.add(key, value).remove(key)
+    guard round_trip.length() == m.length() && round_trip.hash() == m.hash() else {
+      return false
+    }
+    for k, v in m.iter2() {
+      guard round_trip.get(k) == Some(v) else { return false }
+    }
+    true
+  })
+}
+
+///|
+test "overwriting a key behaves like last-write-wins" {
+  @quickcheck.check((input : (@hashmap.HashMap[Key, Int], Key, Int, Int)) => {
+    let (m, key, v1, v2) = input
+    let twice = m.add(key, v1).add(key, v2)
+    twice == m.add(key, v2) &&
+    twice.get(key) == Some(v2) &&
+    twice.length() == m.add(key, v2).length()
+  })
+}
+
+///|
+/// `union`/`intersection` are documented right-biased; `difference` keeps
+/// entries of `self` absent from `other`.
+test "union/intersection/difference agree with the model" {
+  @quickcheck.check((
+    input : (@hashmap.HashMap[Key, Int], @hashmap.HashMap[Key, Int]),
+  ) => {
+    let (a, b) = input
+    let u = a.union(b)
+    let i = a.intersection(b)
+    let d = a.difference(b)
+    let mut common = 0
+    for k, av in a.iter2() {
+      if b.contains(k) {
+        common += 1
+        guard u.get(k) == b.get(k) else { return false }
+        guard i.get(k) == b.get(k) else { return false }
+        guard d.get(k) is None else { return false }
+      } else {
+        guard u.get(k) == Some(av) else { return false }
+        guard i.get(k) is None else { return false }
+        guard d.get(k) == Some(av) else { return false }
+      }
+    }
+    for k, bv in b.iter2() {
+      guard u.get(k) == Some(bv) else { return false }
+      if !a.contains(k) {
+        guard i.get(k) is None && d.get(k) is None else { return false }
+      }
+    }
+    u.length() == a.length() + b.length() - common &&
+    i.length() == common &&
+    d.length() == a.length() - common &&
+    a.union(a) == a &&
+    a.union(@hashmap.new()) == a &&
+    @hashmap.new().union(a) == a
+  })
+}
+
+///|
+test "union_with/intersection_with combine values through the function" {
+  @quickcheck.check((
+    input : (@hashmap.HashMap[Key, Int], @hashmap.HashMap[Key, Int]),
+  ) => {
+    let (a, b) = input
+    let u = a.union_with(b, (_, x, y) => x + y)
+    let i = a.intersection_with(b, (_, x, y) => x * y)
+    for k, av in a.iter2() {
+      match b.get(k) {
+        Some(bv) => {
+          guard u.get(k) == Some(av + bv) && i.get(k) == Some(av * bv) else {
+            return false
+          }
+        }
+        None => {
+          guard u.get(k) == Some(av) && i.get(k) is None else { return false }
+        }
+      }
+    }
+    for k, bv in b.iter2() {
+      if !a.contains(k) {
+        guard u.get(k) == Some(bv) && i.get(k) is None else { return false }
+      }
+    }
+    true
+  })
+}
+
+///|
+test "iter/keys/values/to_array are mutually consistent" {
+  @quickcheck.check((m : @hashmap.HashMap[Key, Int]) => {
+    let pairs = m.to_array()
+    guard pairs.length() == m.length() else { return false }
+    guard m.iter().to_array() == pairs else { return false }
+    guard m.keys().to_array() == pairs.map(p => p.0) else { return false }
+    guard m.values().to_array() == pairs.map(p => p.1) else { return false }
+    // each key appears exactly once and maps to its listed value
+    let seen : Map[Key, Unit] = Map([])
+    for pair in pairs {
+      guard !seen.contains(pair.0) else { return false }
+      seen[pair.0] = ()
+      guard m.get(pair.0) == Some(pair.1) else { return false }
+    }
+    true
+  })
+}
+
+///|
+/// Pins that the key generator keeps producing hash collisions: if someone
+/// "fixes" `Key`'s degenerate hash, every property above silently loses its
+/// adversarial coverage, and this snapshot is the tripwire.
+test "collision coverage stays adversarial" {
+  let report = @quickcheck.report(
+    (m : @hashmap.HashMap[Key, Int]) => m.length() == m.to_array().length(),
+    observe=m => {
+      let buckets : Map[Int, Int] = Map([])
+      let mut collisions = 0
+      for k, _ in m.iter2() {
+        let bucket = k.0 & 7
+        let count = buckets.get(bucket).unwrap_or(0)
+        if count == 1 {
+          collisions += 1
+        }
+        buckets[bucket] = count + 1
+      }
+      [
+        @quickcheck.classify(collisions > 0, "has colliding buckets"),
+        @quickcheck.classify(m.length() >= 8, "at least 8 entries"),
+      ]
+    },
+    count=100,
+    seed=37,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Passed(
+      #|  tests=100,
+      #|  observations={ classes: { "has colliding buckets": 78, "at least 8 entries": 71 } },
+      #|)
+    ),
+  )
+}

--- a/immut/vector/moon.pkg
+++ b/immut/vector/moon.pkg
@@ -7,6 +7,7 @@ import {
 
 import {
   "moonbitlang/core/bench",
+  "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"

--- a/immut/vector/quickcheck_test.mbt
+++ b/immut/vector/quickcheck_test.mbt
@@ -1,0 +1,163 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Property-based tests for the persistent vector.
+//
+// The strategy is model-based: every operation must agree with the same
+// operation on a plain `Array`, persistence must hold (originals are never
+// observably changed), and `Eq`/`Hash` must be content-based regardless of
+// how the internal tree was built (push-built, from_array, or reassembled
+// by split/concat — the paths where RRB-style rebalancing bugs live).
+
+///|
+/// Maps an arbitrary Int into `0..<modulus` without discarding cases.
+fn wrap_index(value : Int, modulus : Int) -> Int {
+  let r = value % modulus
+  if r < 0 {
+    r + modulus
+  } else {
+    r
+  }
+}
+
+///|
+test "to_array/from_array/iter/length agree" {
+  @quickcheck.check((v : @vector.Vector[Int]) => {
+    let arr = v.to_array()
+    @vector.from_array(arr) == v &&
+    v.iter().to_array() == arr &&
+    v.length() == arr.length() &&
+    v.is_empty() == (arr.length() == 0)
+  })
+}
+
+///|
+test "push/pop/set/get agree with the array model and preserve the original" {
+  @quickcheck.check((input : (@vector.Vector[Int], Int, Int)) => {
+    let (v, raw_index, x) = input
+    let arr = v.to_array()
+    let pushed = v.push(x)
+    guard pushed.to_array() == arr + [x] else { return false }
+    // pop inverts push, and the original is untouched
+    guard pushed.pop() is Some(back) && back == v && v.to_array() == arr else {
+      return false
+    }
+    if arr.length() > 0 {
+      let i = wrap_index(raw_index, arr.length())
+      let updated = v.set(i, x)
+      let expected = arr.copy()
+      expected[i] = x
+      guard updated.to_array() == expected && updated[i] == x else {
+        return false
+      }
+      // persistence: the original still holds its old element
+      guard v.get(i) == Some(arr[i]) else { return false }
+    }
+    true
+  })
+}
+
+///|
+test "split/take/drop reassemble to the identical vector" {
+  @quickcheck.check((input : (@vector.Vector[Int], Int)) => {
+    let (v, raw) = input
+    let i = wrap_index(raw, v.length() + 1)
+    let arr = v.to_array()
+    let (left, right) = v.split(i)
+    left.to_array() == arr[:i].to_owned() &&
+    right.to_array() == arr[i:].to_owned() &&
+    left.concat(right) == v &&
+    v.take(i).concat(v.drop(i)) == v &&
+    left.concat(right).hash() == v.hash()
+  })
+}
+
+///|
+test "concat agrees with array concatenation" {
+  @quickcheck.check((input : (@vector.Vector[Int], @vector.Vector[Int])) => {
+    let (a, b) = input
+    let combined = a.concat(b)
+    combined.to_array() == a.to_array() + b.to_array() &&
+    combined == a + b &&
+    combined.length() == a.length() + b.length()
+  })
+}
+
+///|
+test "slice agrees with array slicing" {
+  @quickcheck.check((input : (@vector.Vector[Int], Int, Int)) => {
+    let (v, raw_i, raw_j) = input
+    let n = v.length()
+    let i = wrap_index(raw_i, n + 1)
+    let j = i + wrap_index(raw_j, n - i + 1)
+    v.slice(i, j).to_array() == v.to_array()[i:j].to_owned()
+  })
+}
+
+///|
+test "rev/map/filter/fold agree with the array model" {
+  @quickcheck.check((v : @vector.Vector[Int]) => {
+    let arr = v.to_array()
+    v.rev().to_array() == arr.rev() &&
+    v.rev().rev() == v &&
+    v.map(x => x * 2).to_array() == arr.map(x => x * 2) &&
+    v.filter(x => x % 3 == 0).to_array() == arr.filter(x => x % 3 == 0) &&
+    v.fold(init=0, (acc, x) => acc + x) == arr.fold(init=0, (acc, x) => acc + x)
+  })
+}
+
+///|
+test "Eq/Compare/contains are content-based" {
+  @quickcheck.check((input : (@vector.Vector[Int], @vector.Vector[Int], Int)) => {
+    let (a, b, x) = input
+    (a == b) == (a.to_array() == b.to_array()) &&
+    a.compare(b) == a.to_array().compare(b.to_array()) &&
+    a == @vector.from_array(a.to_array()) &&
+    a.contains(x) == a.to_array().contains(x)
+  })
+}
+
+///|
+/// Vectors from `Arbitrary` stay small, so drive deep trees (node width is
+/// 32, so thousands of elements give three levels) through the
+/// rebalancing-heavy paths explicitly.
+test "deep trees survive split/concat/slice/push" {
+  @quickcheck.check(
+    (input : (Int, Int, Int)) => {
+      let (raw_n, raw_i, raw_j) = input
+      let n = 1000 + wrap_index(raw_n, 2000)
+      let v = @vector.makei(n, i => i)
+      let i = wrap_index(raw_i, n + 1)
+      let j = i + wrap_index(raw_j, n - i + 1)
+      let (left, right) = v.split(i)
+      guard left.concat(right) == v else { return false }
+      let s = v.slice(i, j)
+      guard s.length() == j - i else { return false }
+      for k in 0..<s.length() {
+        guard s[k] == i + k else { return false }
+      }
+      let pushed = left.concat(right).push(n)
+      pushed[n] == n && pushed.length() == n + 1
+    },
+    count=20,
+  )
+}
+
+///|
+test "ToJson/FromJson roundtrip" {
+  @quickcheck.check((v : @vector.Vector[Int]) => {
+    let back : @vector.Vector[Int] = @json.from_json(@json.to_json(v))
+    back == v
+  })
+}


### PR DESCRIPTION
## Summary

Applies the property-based approach from #3995 to two persistent structures — and it found a real bug in the HAMT on its first run (details below).

### `immut/vector` (9 properties, all passing)

Model-based against plain `Array`: `to_array`/`from_array`/`iter` round-trips; `push`/`pop`/`set` with persistence of the original; **`split`/`take`/`drop` reassembling to the identical vector** (with `hash` agreement); `concat`/`slice` against array concatenation/slicing; `rev`/`map`/`filter`/`fold`; content-based `Eq`/`Compare`/`contains` across construction paths; a deep-tree property driving 1000–3000-element vectors through `split`/`concat`/`slice`/`push` (three tree levels, where RRB-style rebalancing bugs live); `ToJson`/`FromJson` round-trip.

### `immut/hashmap` (8 properties)

Keys use a deliberately degenerate 8-bucket hash (`hash(k) = k & 7`) drawn from a small range, so collision buckets, overwrites, and removals of present keys are exercised constantly; the builtin mutable `Map` — an independent implementation — serves as the model. Properties: add/remove agreement with the model **at every step** of random op sequences; construction-order independence of `Eq` and `hash`; last-write-wins overwrites; `union`/`intersection`/`difference` and the `*_with` variants against the model (both documented right-biased — verified); `iter`/`keys`/`values`/`to_array` consistency; an observation snapshot pinning that collision coverage stays adversarial (78% of generated maps have colliding buckets — the tripwire if someone "fixes" `Key`'s hash).

## 🐛 Found: HAMT `Eq` reports content-equal maps as unequal

The canonicity property `m.add(k, v).remove(k) == m` (for fresh `k`) was falsified in 7 cases and shrank to the minimal collision essence:

```moonbit
// hash(k) = k & 7, so Key(0) and Key(24) share a bucket
let m = @hashmap.new().add(Key(0), 0)
let rt = m.add(Key(24), 0).remove(Key(24))
m == rt                    // false — but both are { Key(0): 0 }
rt == (fresh { Key(0): 0 }) // false as well
```

**Root cause**: `Node::remove_with_path` (HAMT.mbt:478/481) leaves the surviving entry as `Leaf(k, v, Empty)` when a collision bucket empties, while a never-collided map holds `Flat(k, v, path)` — and `HashMap` derives *structural* `Eq`, so the shapes compare unequal despite identical content. `filter` constructs the same non-canonical shape (HAMT.mbt:359). `hash` remains content-consistent (verified equal across all three shapes), and lookups/adds on the damaged node work fine — the corruption is observable only through `Eq` and anything built on it.

**Fix options** (not included here; the affected test is weakened to content-equality with a KNOWN BUG note so this PR stays green):
1. Collapse `Leaf(k, v, Empty)` to `Flat(k, v, path)` in `remove_with_path` — the `path` parameter is reusable since all keys in a collision bucket share the full hash. Cheap and local, but `filter` can't do the same (no path available and no `K : Hash` bound to recompute one).
2. Store the path in `Leaf` so both `remove` and `filter` can canonicalize — internal representation change, fixes the bug class completely.
3. Make `Eq` content-based — but entry lookup needs `K : Hash`, which the current `Eq` constraint (`K : Eq, V : Eq`) doesn't provide.

Happy to do the red-test-then-fix flow (as in #3996) once a direction is picked — option 2 looks right to me.

## Validation

- Full repo suite: 7055/7055 passing
- `moon fmt`, `moon info` — no public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)