### PR TITLE
fix(immut/hashmap): canonicalize HAMT shapes so structural Eq matches content equality

### DIFF
--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -369,7 +369,7 @@ pub fn[K, V] HashMap::filter(
       Branch(children) =>
         match children.filter(go) {
           None => None
-          Some(new_children) => Some(Branch(new_children))
+          Some(new_children) => Some(collapse_branch(new_children))
         }
     }
   }
@@ -451,6 +451,29 @@ pub fn[K : Eq + Hash, V] HashMap::add(
 }
 
 ///|
+/// Rebuild a branch whose children may have shrunk, restoring the `Node`
+/// invariant that a subtree holding a single entry is represented as
+/// `Flat` (structural `Eq` relies on shapes being canonical). A lone
+/// `Leaf` can only be a terminal collision node whose bucket emptied; its
+/// remaining path is fully consumed, so the `Flat` path is rebuilt from
+/// the slot index alone.
+fn[K, V] collapse_branch(
+  children : @sparse_array.SparseArray[Node[K, V]],
+) -> Node[K, V] {
+  match children.data {
+    [Flat(key, value, path)] =>
+      Flat(key, value, path.push(children.elem_info.first_idx()))
+    [Leaf(key, value, Empty)] =>
+      Flat(
+        key,
+        value,
+        @path.Path::exhausted().push(children.elem_info.first_idx()),
+      )
+    _ => Branch(children)
+  }
+}
+
+///|
 /// Remove an element from a map
 pub fn[K : Eq + Hash, V] HashMap::remove(
   self : HashMap[K, V],
@@ -499,17 +522,7 @@ fn[K : Eq, V] Node::remove_with_path(
             (_, None) => children.remove(idx)
             (_, Some(new_child)) => children.replace(idx, new_child)
           }
-          match new_children.data {
-            [Flat(key1, value1, path1)] =>
-              Some(
-                Flat(
-                  key1,
-                  value1,
-                  path1.push(new_children.elem_info.first_idx()),
-                ),
-              )
-            _ => Some(Branch(new_children))
-          }
+          Some(collapse_branch(new_children))
         }
       }
     }
@@ -662,9 +675,7 @@ pub fn[K : Eq, V] HashMap::intersection(
       (Branch(children1), Branch(children2)) =>
         match children1.intersection(children2, go) {
           None => None
-          Some({ data: [Flat(key, value, path)], elem_info }) =>
-            Some(Flat(key, value, path.push(elem_info.first_idx())))
-          Some(children) => Some(Branch(children))
+          Some(children) => Some(collapse_branch(children))
         }
       (Leaf(key1, value1, bucket1), Leaf(key2, value2, bucket2)) => {
         let kvs1 = bucket1.add((key1, value1))
@@ -708,9 +719,7 @@ pub fn[K : Eq, V] HashMap::intersection_with(
       (Branch(children1), Branch(children2)) =>
         match children1.intersection(children2, go) {
           None => None
-          Some({ data: [Flat(key, value, path)], elem_info }) =>
-            Some(Flat(key, value, path.push(elem_info.first_idx())))
-          Some(children) => Some(Branch(children))
+          Some(children) => Some(collapse_branch(children))
         }
       (Leaf(key1, value1, bucket1), Leaf(key2, value2, bucket2)) => {
         let kvs1 = bucket1.add((key1, value1))
@@ -767,9 +776,7 @@ pub fn[K : Eq, V] HashMap::difference(
       (Branch(children1), Branch(children2)) =>
         match children1.difference(children2, go) {
           None => None
-          Some({ data: [Flat(key, value, path)], elem_info }) =>
-            Some(Flat(key, value, path.push(elem_info.first_idx())))
-          Some(children) => Some(Branch(children))
+          Some(children) => Some(collapse_branch(children))
         }
       (Leaf(key1, value1, bucket1), Leaf(key2, value2, bucket2)) => {
         let kvs1 = bucket1.add((key1, value1))

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -119,21 +119,19 @@ fn[K, V] join_2(
   value2 : V,
   path2 : @path.Path,
 ) -> Node[K, V] {
+  if path1 == @path.Path::exhausted() {
+    // Both paths are fully consumed: the keys collide on the full hash,
+    // so they can only share the maximum-depth collision bucket.
+    return Leaf(key2, value2, @list.singleton((key1, value1)))
+  }
   let idx1 = path1.idx()
   let idx2 = path2.idx()
   if idx1 == idx2 {
-    let node = if path1.is_last() {
-      Leaf(key2, value2, @list.singleton((key1, value1)))
-    } else {
-      join_2(key1, value1, path1.next(), key2, value2, path2.next())
-    }
+    let node = join_2(key1, value1, path1.next(), key2, value2, path2.next())
     Branch(@sparse_array.singleton(idx1, node))
   } else {
-    let (node1, node2) = if path1.is_last() {
-      (Leaf(key1, value1, @list.empty()), Leaf(key2, value2, @list.empty()))
-    } else {
-      (Flat(key1, value1, path1.next()), Flat(key2, value2, path2.next()))
-    }
+    let node1 = Flat(key1, value1, path1.next())
+    let node2 = Flat(key2, value2, path2.next())
     Branch(@sparse_array.doubleton(idx1, node1, idx2, node2))
   }
 }
@@ -352,10 +350,15 @@ pub fn[K, V] HashMap::filter(
       Leaf(key1, value1, bucket) => {
         let new_bucket = bucket.filter(kv => pred(kv.0, kv.1))
         if pred(key1, value1) {
-          Some(Leaf(key1, value1, new_bucket))
+          match new_bucket {
+            Empty => Some(Flat(key1, value1, @path.Path::exhausted()))
+            _ => Some(Leaf(key1, value1, new_bucket))
+          }
         } else {
           match new_bucket {
             Empty => None
+            More((k1, v1), tail=Empty) =>
+              Some(Flat(k1, v1, @path.Path::exhausted()))
             More((k1, v1), tail~) => Some(Leaf(k1, v1, tail))
           }
         }
@@ -454,21 +457,15 @@ pub fn[K : Eq + Hash, V] HashMap::add(
 /// Rebuild a branch whose children may have shrunk, restoring the `Node`
 /// invariant that a subtree holding a single entry is represented as
 /// `Flat` (structural `Eq` relies on shapes being canonical). A lone
-/// `Leaf` can only be a terminal collision node whose bucket emptied; its
-/// remaining path is fully consumed, so the `Flat` path is rebuilt from
-/// the slot index alone.
+/// `Leaf` child needs no collapsing: a `Leaf` always holds at least two
+/// colliding entries, and the singleton branch chain above it is exactly
+/// the shape a fresh construction of that collision builds.
 fn[K, V] collapse_branch(
   children : @sparse_array.SparseArray[Node[K, V]],
 ) -> Node[K, V] {
   match children.data {
     [Flat(key, value, path)] =>
       Flat(key, value, path.push(children.elem_info.first_idx()))
-    [Leaf(key, value, Empty)] =>
-      Flat(
-        key,
-        value,
-        @path.Path::exhausted().push(children.elem_info.first_idx()),
-      )
     _ => Branch(children)
   }
 }
@@ -495,13 +492,19 @@ fn[K : Eq, V] Node::remove_with_path(
 ) -> Node[K, V]? {
   match self {
     Leaf(key1, value1, bucket) =>
+      // a `Leaf` sits at maximum depth, so `path` is fully consumed here
+      // and a single surviving entry becomes a `Flat` carrying it
       if key1 == key {
         match bucket {
           Empty => None
+          More((key2, value2), tail=Empty) => Some(Flat(key2, value2, path))
           More((key2, value2), tail~) => Some(Leaf(key2, value2, tail))
         }
       } else if bucket.find_index(kv => kv.0 == key) is Some(index) {
-        Some(Leaf(key1, value1, bucket.remove_at(index)))
+        match bucket.remove_at(index) {
+          Empty => Some(Flat(key1, value1, path))
+          new_bucket => Some(Leaf(key1, value1, new_bucket))
+        }
       } else {
         Some(self)
       }
@@ -682,6 +685,8 @@ pub fn[K : Eq, V] HashMap::intersection(
         let kvs2 = bucket2.add((key2, value2))
         match kvs2.filter(kv => kvs1.lookup(kv.0) is Some(_)) {
           Empty => None
+          More(head, tail=Empty) =>
+            Some(Flat(head.0, head.1, @path.Path::exhausted()))
           More(head, tail~) => Some(Leaf(head.0, head.1, tail))
         }
       }
@@ -755,6 +760,7 @@ fn[K : Eq, V] @list.List::intersection_with(
   }
   match @list.List(res) {
     Empty => None
+    More((k, v), tail=Empty) => Some(Flat(k, v, @path.Path::exhausted()))
     More((k, v), tail~) => Some(Leaf(k, v, tail))
   }
 }
@@ -783,6 +789,8 @@ pub fn[K : Eq, V] HashMap::difference(
         let kvs2 = bucket2.add((key2, value2))
         match kvs1.filter(kv => !(kvs2.lookup(kv.0) is Some(_))) {
           Empty => None
+          More(head, tail=Empty) =>
+            Some(Flat(head.0, head.1, @path.Path::exhausted()))
           More(head, tail~) => Some(Leaf(head.0, head.1, tail))
         }
       }

--- a/immut/hashmap/canonical_property_test.mbt
+++ b/immut/hashmap/canonical_property_test.mbt
@@ -1,0 +1,189 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Structural `Eq` is a valid proxy for content equality only if every
+// operation keeps the trie canonical: one shape per content, regardless of
+// history. This property sweep drives random operation sequences against
+// an association-array model and requires, after every single step, that
+// the map is `==` to a fresh `from_iter` of its content — and, at the end,
+// to a rebuild by `add` in reverse order. Each regime below picks a hash
+// quotient that stresses a different part of the trie: distinct hashes
+// (plain `Int`), first-segment collisions (`CollidingKey`), maximum-depth
+// divergence and collisions (`DeepKey`), and a single all-keys bucket
+// (`ZeroHashKey`).
+
+///|
+/// Keys that all share the one and only full-hash collision bucket.
+priv struct ZeroHashKey(Int) derive(Eq)
+
+///|
+impl Hash for ZeroHashKey with fn hash(_) {
+  0
+}
+
+///|
+impl Hash for ZeroHashKey with fn hash_combine(_, hasher) {
+  hasher.combine_int(0)
+}
+
+///|
+/// Replace-or-append, mirroring `HashMap::add`.
+fn model_add(model : Array[(Int, Int)], key : Int, value : Int) -> Unit {
+  for i, kv in model {
+    if kv.0 == key {
+      model[i] = (key, value)
+      return
+    }
+  }
+  model.push((key, value))
+}
+
+///|
+fn model_remove(model : Array[(Int, Int)], key : Int) -> Unit {
+  for i, kv in model {
+    if kv.0 == key {
+      let _ = model.remove(i)
+      return
+    }
+  }
+}
+
+///|
+fn model_lookup(model : Array[(Int, Int)], key : Int) -> Int? {
+  for kv in model {
+    if kv.0 == key {
+      return Some(kv.1)
+    }
+  }
+  None
+}
+
+///|
+/// Interpret `ops` as a stream of map operations over a 16-key universe,
+/// mirror each on the model, and require full canonicity after every step.
+fn[K : Eq + Hash] canonical_after_ops(
+  mk : (Int) -> K,
+  ops : Array[Int],
+) -> Bool {
+  let model : Array[(Int, Int)] = []
+  let mut hm : @hashmap.HashMap[K, Int] = @hashmap.new()
+  for op in ops {
+    let n = op & 0x7fffffff
+    let key = n / 8 % 16
+    let value = n / 128 % 7
+    match n % 8 {
+      0 | 1 | 2 => {
+        hm = hm.add(mk(key), value)
+        model_add(model, key, value)
+      }
+      3 => {
+        hm = hm.remove(mk(key))
+        model_remove(model, key)
+      }
+      4 => {
+        // The predicate must be expressible on the model too, so filter on
+        // the value (an `Int` in both worlds).
+        hm = hm.filter((_, v) => (v + key) % 3 != 0)
+        model.retain(kv => (kv.1 + key) % 3 != 0)
+      }
+      op_code => {
+        // A second map derived from a slice of the current content plus
+        // one possibly-fresh key, built canonically via `from_iter`.
+        let other_model : Array[(Int, Int)] = []
+        for kv in model {
+          if (kv.0 + key) % 3 != 0 {
+            model_add(other_model, kv.0, kv.1 + 1)
+          }
+        }
+        model_add(other_model, key, value)
+        let other = @hashmap.from_iter(
+          other_model.iter().map(kv => (mk(kv.0), kv.1)),
+        )
+        match op_code {
+          5 => {
+            // union: the right-hand side's value wins
+            hm = hm.union(other)
+            for kv in other_model {
+              model_add(model, kv.0, kv.1)
+            }
+          }
+          6 => {
+            // intersection: keys in both, values from the right-hand side
+            hm = hm.intersection(other)
+            model.retain(kv => model_lookup(other_model, kv.0) is Some(_))
+            for i, kv in model {
+              guard model_lookup(other_model, kv.0) is Some(v) else {
+                return false
+              }
+              model[i] = (kv.0, v)
+            }
+          }
+          _ => {
+            // difference: keys of the left-hand side absent from the right
+            hm = hm.difference(other)
+            model.retain(kv => model_lookup(other_model, kv.0) is None)
+          }
+        }
+      }
+    }
+    // Content agreement guards the model itself…
+    if hm.length() != model.length() {
+      return false
+    }
+    for kv in model {
+      if hm.get(mk(kv.0)) != Some(kv.1) {
+        return false
+      }
+    }
+    // …and this is the canonicity property: same content, same structure.
+    let rebuilt = @hashmap.from_iter(model.iter().map(kv => (mk(kv.0), kv.1)))
+    if hm != rebuilt {
+      return false
+    }
+  }
+  // Insertion-order independence: adding the final content in reverse
+  // order must reproduce the exact structure.
+  let mut reversed : @hashmap.HashMap[K, Int] = @hashmap.new()
+  for i in 0..<model.length() {
+    let kv = model[model.length() - 1 - i]
+    reversed = reversed.add(mk(kv.0), kv.1)
+  }
+  reversed == hm
+}
+
+///|
+test "quickcheck: canonical after every op (distinct hashes)" {
+  @quickcheck.check((ops : Array[Int]) => canonical_after_ops(n => n, ops))
+}
+
+///|
+test "quickcheck: canonical after every op (first-segment collisions)" {
+  @quickcheck.check((ops : Array[Int]) => {
+    canonical_after_ops(n => CollidingKey(n), ops)
+  })
+}
+
+///|
+test "quickcheck: canonical after every op (maximum-depth collisions)" {
+  @quickcheck.check((ops : Array[Int]) => {
+    canonical_after_ops(n => DeepKey(n), ops)
+  })
+}
+
+///|
+test "quickcheck: canonical after every op (single collision bucket)" {
+  @quickcheck.check((ops : Array[Int]) => {
+    canonical_after_ops(n => ZeroHashKey(n), ops)
+  })
+}

--- a/immut/hashmap/canonical_property_test.mbt
+++ b/immut/hashmap/canonical_property_test.mbt
@@ -110,23 +110,41 @@ fn[K : Eq + Hash] canonical_after_ops(
         let other = @hashmap.from_iter(
           other_model.iter().map(kv => (mk(kv.0), kv.1)),
         )
+        // The key's parity picks between the plain and the `_with`
+        // flavor of the merge, so both trie walks get exercised.
+        let merge = (x : Int, y : Int) => x * 2 + y
         match op_code {
-          5 => {
-            // union: the right-hand side's value wins
-            hm = hm.union(other)
-            for kv in other_model {
-              model_add(model, kv.0, kv.1)
+          5 =>
+            if key % 2 == 0 {
+              // union: the right-hand side's value wins
+              hm = hm.union(other)
+              for kv in other_model {
+                model_add(model, kv.0, kv.1)
+              }
+            } else {
+              // union_with: merge values of keys present on both sides
+              hm = hm.union_with(other, (_, x, y) => merge(x, y))
+              for kv in other_model {
+                match model_lookup(model, kv.0) {
+                  Some(v0) => model_add(model, kv.0, merge(v0, kv.1))
+                  None => model_add(model, kv.0, kv.1)
+                }
+              }
             }
-          }
           6 => {
-            // intersection: keys in both, values from the right-hand side
-            hm = hm.intersection(other)
+            // intersection keeps keys in both; the plain flavor takes the
+            // right-hand side's value, `_with` merges both
+            if key % 2 == 0 {
+              hm = hm.intersection(other)
+            } else {
+              hm = hm.intersection_with(other, (_, x, y) => merge(x, y))
+            }
             model.retain(kv => model_lookup(other_model, kv.0) is Some(_))
             for i, kv in model {
               guard model_lookup(other_model, kv.0) is Some(v) else {
                 return false
               }
-              model[i] = (kv.0, v)
+              model[i] = (kv.0, if key % 2 == 0 { v } else { merge(kv.1, v) })
             }
           }
           _ => {

--- a/immut/hashmap/canonical_structure_test.mbt
+++ b/immut/hashmap/canonical_structure_test.mbt
@@ -96,3 +96,92 @@ test "chained removals from a collision bucket collapse in any order" {
   assert_true(one_way == @hashmap.singleton(CollidingKey(0), 0))
   assert_true(one_way == other_way)
 }
+
+// The tests below pin canonicity at the maximum trie depth, where a single
+// entry historically had two representations: `add` into an existing
+// bottom-level branch stored `Flat(k, v, exhausted-path)` while `join_2`
+// splitting a `Flat` stored `Leaf(k, v, Empty)`. Content-equal maps built
+// through different histories then compared unequal.
+
+///|
+/// Keys whose hash lives only in the top path segment (bits 25..=29): all
+/// keys share path segments 1-5, so they diverge — or fully collide — only
+/// at the maximum trie depth.
+priv struct DeepKey(Int) derive(Eq)
+
+///|
+impl Hash for DeepKey with fn hash(self) {
+  (self.0 & 3) << 25
+}
+
+///|
+impl Hash for DeepKey with fn hash_combine(self, hasher) {
+  hasher.combine_int((self.0 & 3) << 25)
+}
+
+///|
+test "insertion order cannot affect the structure at maximum depth" {
+  let one_way : @hashmap.HashMap[DeepKey, Int] = @hashmap.new()
+    .add(DeepKey(0), 0)
+    .add(DeepKey(1), 1)
+    .add(DeepKey(2), 2)
+  let other_way : @hashmap.HashMap[DeepKey, Int] = @hashmap.new()
+    .add(DeepKey(2), 2)
+    .add(DeepKey(1), 1)
+    .add(DeepKey(0), 0)
+  assert_true(one_way == other_way)
+}
+
+///|
+test "removing a maximum-depth sibling leaves the canonical structure" {
+  let removed = @hashmap.new()
+    .add(DeepKey(0), 0)
+    .add(DeepKey(1), 1)
+    .add(DeepKey(2), 2)
+    .remove(DeepKey(1))
+  let fresh : @hashmap.HashMap[DeepKey, Int] = @hashmap.new()
+    .add(DeepKey(0), 0)
+    .add(DeepKey(2), 2)
+  assert_true(removed == fresh)
+}
+
+///|
+test "full-hash collision arriving at a maximum-depth Flat stays canonical" {
+  // 2 and 6 collide on the full hash. Adding 0 and 1 first forces the
+  // maximum-depth branch into existence, so DeepKey(2) is stored there as
+  // a single entry with a fully consumed path when DeepKey(6) arrives.
+  let one_way : @hashmap.HashMap[DeepKey, Int] = @hashmap.new()
+    .add(DeepKey(0), 0)
+    .add(DeepKey(1), 1)
+    .add(DeepKey(2), 2)
+    .add(DeepKey(6), 6)
+  let other_way : @hashmap.HashMap[DeepKey, Int] = @hashmap.new()
+    .add(DeepKey(2), 2)
+    .add(DeepKey(6), 6)
+    .add(DeepKey(0), 0)
+    .add(DeepKey(1), 1)
+  assert_eq(one_way.get(DeepKey(2)), Some(2))
+  assert_eq(one_way.get(DeepKey(6)), Some(6))
+  assert_eq(one_way.length(), 4)
+  assert_true(one_way == other_way)
+}
+
+///|
+test "intersection dropping a colliding key yields the canonical map" {
+  // Pins the `intersection`/`intersection_with` call sites that collapse
+  // shrunken branches (values come from the right-hand side).
+  let left : @hashmap.HashMap[CollidingKey, Int] = @hashmap.singleton(
+    CollidingKey(0),
+    0,
+  ).add(CollidingKey(24), 1)
+  let right : @hashmap.HashMap[CollidingKey, Int] = @hashmap.singleton(
+    CollidingKey(0),
+    0,
+  ).add(CollidingKey(8), 2)
+  let expected : @hashmap.HashMap[CollidingKey, Int] = @hashmap.singleton(
+    CollidingKey(0),
+    0,
+  )
+  assert_true(left.intersection(right) == expected)
+  assert_true(left.intersection_with(right, (_, x, y) => x + y) == expected)
+}

--- a/immut/hashmap/canonical_structure_test.mbt
+++ b/immut/hashmap/canonical_structure_test.mbt
@@ -1,0 +1,98 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `HashMap` derives structural `Eq`, so every operation must leave the tree
+// in the canonical shape a fresh construction of the same content would
+// have. These tests pin that contract for the shrinking operations
+// (`remove`, `filter`, `difference`): before the fix, they left
+// non-canonical remnants — an uncollapsed singleton branch after `filter`,
+// and a `Leaf(k, v, Empty)` node (instead of the collapsed `Flat`) after
+// removing from a full-hash collision bucket — making content-equal maps
+// compare unequal.
+//
+// Found by the QuickCheck property suite in #3999.
+
+///|
+/// Keys whose 32-bit hash keeps only the low three bits, so keys that agree
+/// on `n & 7` collide on the full hash while `Eq` still distinguishes them.
+priv struct CollidingKey(Int) derive(Eq)
+
+///|
+impl Hash for CollidingKey with fn hash(self) {
+  self.0 & 7
+}
+
+///|
+impl Hash for CollidingKey with fn hash_combine(self, hasher) {
+  hasher.combine_int(self.0 & 7)
+}
+
+///|
+test "removing a colliding key restores the canonical structure" {
+  let original : @hashmap.HashMap[CollidingKey, Int] = @hashmap.singleton(
+    CollidingKey(0),
+    0,
+  )
+  let round_trip = original.add(CollidingKey(24), 0).remove(CollidingKey(24))
+  assert_true(round_trip == original)
+  assert_true(round_trip == @hashmap.singleton(CollidingKey(0), 0))
+}
+
+///|
+test "filter down to one key yields the canonical map" {
+  // No hash collisions involved: `filter` must collapse the branch that
+  // shrank to a single entry, exactly like `remove` does.
+  let original : @hashmap.HashMap[Int, Int] = @hashmap.singleton(0, 0)
+  assert_true(original.add(1, 1).filter((k, _) => k == 0) == original)
+}
+
+///|
+test "filter dropping a colliding key yields the canonical map" {
+  let original : @hashmap.HashMap[CollidingKey, Int] = @hashmap.singleton(
+    CollidingKey(0),
+    0,
+  )
+  let filtered = original
+    .add(CollidingKey(24), 1)
+    .filter((k, _) => k == CollidingKey(0))
+  assert_true(filtered == original)
+}
+
+///|
+test "difference removing a colliding key yields the canonical map" {
+  let original : @hashmap.HashMap[CollidingKey, Int] = @hashmap.singleton(
+    CollidingKey(0),
+    0,
+  )
+  let both = original.add(CollidingKey(24), 1)
+  let only_other : @hashmap.HashMap[CollidingKey, Int] = @hashmap.singleton(
+    CollidingKey(24),
+    1,
+  )
+  assert_true(both.difference(only_other) == original)
+}
+
+///|
+test "chained removals from a collision bucket collapse in any order" {
+  // 0, 8, and 24 all hash to bucket 0, forming a three-entry collision node.
+  let base : @hashmap.HashMap[CollidingKey, Int] = @hashmap.new()
+  let all = base
+    .add(CollidingKey(0), 0)
+    .add(CollidingKey(8), 1)
+    .add(CollidingKey(24), 2)
+  let one_way = all.remove(CollidingKey(8)).remove(CollidingKey(24))
+  let other_way = all.remove(CollidingKey(24)).remove(CollidingKey(8))
+  assert_true(one_way == @hashmap.singleton(CollidingKey(0), 0))
+  assert_true(one_way == other_way)
+}

--- a/immut/hashmap/canonical_structure_test.mbt
+++ b/immut/hashmap/canonical_structure_test.mbt
@@ -167,6 +167,33 @@ test "full-hash collision arriving at a maximum-depth Flat stays canonical" {
 }
 
 ///|
+test "bulk construction agrees with incremental adds at maximum depth" {
+  // 80 entries exceed the bulk-build threshold (64), so the constructor
+  // and a sized `from_iter` take the range-partitioning bulk builder,
+  // whose bottom-level handoff must produce the same canonical shapes as
+  // plain `add` — here four maximum-depth collision buckets of 20 keys.
+  let pairs : Array[(DeepKey, Int)] = []
+  for i in 0..<80 {
+    pairs.push((DeepKey(i), i))
+  }
+  let bulk : @hashmap.HashMap[DeepKey, Int] = HashMap(pairs)
+  let via_iter = @hashmap.from_iter(pairs.iter())
+  let mut added : @hashmap.HashMap[DeepKey, Int] = @hashmap.new()
+  for kv in pairs {
+    added = added.add(kv.0, kv.1)
+  }
+  let mut reversed : @hashmap.HashMap[DeepKey, Int] = @hashmap.new()
+  for i in 0..<pairs.length() {
+    let kv = pairs[pairs.length() - 1 - i]
+    reversed = reversed.add(kv.0, kv.1)
+  }
+  assert_eq(bulk.length(), 80)
+  assert_true(bulk == added)
+  assert_true(via_iter == added)
+  assert_true(reversed == added)
+}
+
+///|
 test "intersection dropping a colliding key yields the canonical map" {
   // Pins the `intersection`/`intersection_with` call sites that collapse
   // shrunken branches (values come from the right-hand side).

--- a/immut/hashmap/moon.pkg
+++ b/immut/hashmap/moon.pkg
@@ -12,5 +12,6 @@ import {
   "moonbitlang/core/bench",
   "moonbitlang/core/int",
   "moonbitlang/core/option",
+  "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"

--- a/immut/hashmap/types.mbt
+++ b/immut/hashmap/types.mbt
@@ -16,8 +16,13 @@
 /// An non-empty immutable hash set data structure
 #unsafe_cycle_free
 priv enum Node[K, V] {
+  /// a subtree holding exactly one entry, at any depth; carries the
+  /// not-yet-consumed remainder of the key's path (only the head tag
+  /// once every segment is consumed)
   Flat(K, V, @path.Path)
-  Leaf(K, V, @list.List[(K, V)]) // use a list of buckets to resolve collision
+  /// full-hash collision bucket at maximum depth; always holds at least
+  /// two entries — a lone entry must be represented as `Flat`
+  Leaf(K, V, @list.List[(K, V)])
   /// number of all its leaf > 1. If equals 1, it should be represented as `Flat`
   Branch(@sparse_array.SparseArray[Node[K, V]])
 }

--- a/immut/internal/path/path.mbt
+++ b/immut/internal/path/path.mbt
@@ -89,3 +89,11 @@ pub fn Path::advance(self : Path, depth : Int) -> Path {
   let Path(self) = self
   self >> (SEGMENT_LENGTH * depth)
 }
+
+///|
+/// The path that remains once every index segment has been consumed: just
+/// the head tag bits. This is the remaining path of a terminal collision
+/// node, and the starting point for rebuilding a full path with `push`.
+pub fn Path::exhausted() -> Path {
+  Path(HEAD_TAG >> (SEGMENT_LENGTH * SEGMENT_NUM))
+}

--- a/immut/internal/path/pkg.generated.mbti
+++ b/immut/internal/path/pkg.generated.mbti
@@ -10,6 +10,7 @@ pub fn[A : Hash] of(A) -> Path
 pub struct Path(UInt) derive(Eq)
 pub fn Path::advance(Self, Int) -> Self
 pub fn Path::equal(Self, Self) -> Bool
+pub fn Path::exhausted() -> Self
 pub fn Path::idx(Self) -> Int
 pub fn Path::idx_at(Self, Int) -> Int
 pub fn Path::is_last(Self) -> Bool


### PR DESCRIPTION
## Problem

`HashMap` derives **structural** `Eq`, which is a valid stand-in for content equality only while the trie is *canonical*: one shape per content, regardless of operation history. Two defect families broke that:

**1. Shrinking operations left non-canonical remnants.** `remove` left `Leaf(k, v, Empty)` behind when a collision bucket emptied (and the branch unwind only collapsed `[Flat]` singletons), `filter` never collapsed at all — broken even for plain `Int` keys — and `intersection`/`intersection_with`/`difference` shared both defects:

```moonbit
// hash(k) = k & 7, so Key(0) and Key(24) collide on the full hash
let m = @hashmap.singleton(Key(0), 0)
m.add(Key(24), 0).remove(Key(24)) == m                 // false
singleton(0, 0).add(1, 1).filter((k, _) => k == 0) == singleton(0, 0)  // false
```

**2. A lone entry at maximum trie depth had two representations.** `add_with_path` filling an empty slot of a bottom-level branch stored `Flat(k, v, exhausted-path)`, while `join_2` splitting a `Flat` at the last segment stored `Leaf(k, v, Empty)` — so *insertion order alone* falsified `==` for keys sharing the low 25 hash bits. Worse, a full-hash collision arriving at such a `Flat` sent exhausted paths into `join_2`, which read the path head tag as a segment index and built a spurious branch *below* maximum depth (lookups survived by accident; the shape was unreachable by fresh construction).

Found by the QuickCheck property suite in #3999 (family 1) and during review of this PR (family 2).

## Fix

**Shrink canonicalization** — one `collapse_branch` helper applied at every site that rebuilds a possibly-shrunk branch, seeded from the new `Path::exhausted()` in `immut/internal/path` (the only generated-interface change; no public API changes).

**One canonical shape for lone maximum-depth entries** — a `Leaf` now always holds ≥ 2 colliding entries; a lone entry is `Flat` at every depth:

- `join_2` terminates explicitly on exhausted paths with a collision bucket, which *subsumes both of its `is_last` special cases* (the function gets shorter) and kills the head-tag bug.
- `remove`, `filter`, `intersection`, `intersection_with`, and `difference` convert a bucket shrinking to a single entry into `Flat(k, v, exhausted)` in place, even under branches that keep other children.
- `collapse_branch` drops its now-unreachable `[Leaf(k, v, Empty)]` case; a singleton branch chain over a (≥ 2 entry) `Leaf` is the canonical form of a full-hash collision.

The bulk builders route through the same `add_with_path`/`join_2` machinery, so `from_iter`/constructor construction is fixed by the same change.

## Tests

Red/green commit pairs, each red commit verified failing against its parent:

1. `test`: shrink-op canonical-structure tests
2. `fix`: `collapse_branch` + `Path::exhausted()`
3. `test`: maximum-depth canonicity tests + **QuickCheck property suite** — random op sequences (`add`/`remove`/`filter`/`union[_with]`/`intersection[_with]`/`difference`) mirrored on an assoc-array model under four hash regimes (distinct, first-segment collisions, maximum-depth collisions, single bucket), asserting `hm == from_iter(model)` after **every** step plus a reverse-order rebuild at the end. The shrinker reduced the maximum-depth falsification to a 3-op sequence.
4. `fix`: the terminal-representation unification
5. `test`: coverage gaps from a codex CLI review round — an 80-entry bulk-vs-incremental construction test (the property universe never crossed the 64-entry bulk threshold) and `_with`-flavor dispatch in the property.

## Validation

- Full repo suite: 6980/6980; `moon fmt` stable; `moon info` — no public API changes (internal path package gains `Path::exhausted`)
- codex CLI review: no correctness findings, no remaining reachable path producing `Leaf(k, v, Empty)`; its two low-severity coverage gaps are closed by commit 5

## Scope

**`HashSet` is intentionally not touched.** It mirrors the HAMT and shares both defect families; it will be canonicalized in one piece (shrink collapse + terminal unification + its own property suite) in a follow-up PR.

## Note

Once this merges, the weakened "restores the original **content**" property in #3999 can flip to the strong structural form (`round_trip == m`), and its op-sequence model test can assert `hm == from_iter(model)` — full canonicity — at every step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
