### PR TITLE
refactor(quickcheck): clarify counterexample context

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -95,7 +95,7 @@ Every error from the property is represented by `Raised`; the driver does not
 distinguish errors used by `inspect` or snapshot tests. Calling `report` itself
 does not raise and does not require the input type to implement `Debug`.
 
-`context` attaches a human-readable rendering of the shrunk counterexample
+`counterexample_context` attaches a human-readable rendering of the shrunk counterexample
 to a failure — useful when the generated value's `Debug` form is not the
 most readable description of what failed (for example, a rendered document
 rather than its AST):
@@ -105,7 +105,7 @@ rather than its AST):
 test "context describes the shrunk counterexample" {
   let report = @quickcheck.report(
     (x : Int) => x < 3,
-    context=x => "rendered input <\{x}>",
+    counterexample_context=x => "rendered input <\{x}>",
     seed=7,
   )
   debug_inspect(

--- a/quickcheck/driver.mbt
+++ b/quickcheck/driver.mbt
@@ -281,7 +281,7 @@ fn[A : @debug.Debug] failure_report(report : QuickCheckReport[A]) -> String {
 /// discarded cases per requested test. The pure `observe` function is
 /// evaluated and aggregated only after a top-level case succeeds.
 ///
-/// `context` attaches a human-readable description of the shrunk
+/// `counterexample_context` attaches a human-readable description of the shrunk
 /// counterexample to a failure — for example the rendered form of a
 /// generated document — without conflating it with errors raised by the
 /// property itself.
@@ -289,7 +289,7 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
   observe? : (A) -> Observations = _ => [],
-  context? : (A) -> String,
+  counterexample_context? : (A) -> String,
   count? : UInt = 100,
   max_size? : UInt = 100,
   max_shrinks? : UInt = 100,
@@ -319,7 +319,9 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
         let (counterexample, outcome, shrinks, shrink_attempts) = shrink_failure(
           property, filter, input, outcome, max_shrinks,
         )
-        let context = context.map(render => render(counterexample))
+        let context = counterexample_context.map(render => {
+          render(counterexample)
+        })
         return match outcome {
           Falsified =>
             Falsified(
@@ -377,8 +379,8 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
 /// * `filter`: A pure precondition returning `true` for cases to test.
 /// * `observe`: A pure function classifying cases with `label`, `classify`, or
 ///   `collect`.
-/// * `context`: A pure function rendering the shrunk counterexample as a
-///   human-readable string included in the failure report.
+/// * `counterexample_context`: A pure function rendering the shrunk
+///   counterexample as a human-readable string included in the failure report.
 /// * `count`: Number of non-discarded cases to test. Zero performs no tests.
 /// * `max_size`: Largest requested generator size. Values above the `Int`
 ///   range accepted by `Arbitrary` are saturated at `Int::MAX_VALUE`.
@@ -404,7 +406,7 @@ pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check(
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
   observe? : (A) -> Observations = _ => [],
-  context? : (A) -> String,
+  counterexample_context? : (A) -> String,
   count? : UInt = 100,
   max_size? : UInt = 100,
   max_shrinks? : UInt = 100,
@@ -416,7 +418,7 @@ pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check(
     property,
     filter~,
     observe~,
-    context?,
+    counterexample_context?,
     count~,
     max_size~,
     max_shrinks~,

--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -490,7 +490,7 @@ test "classes-only summary omits the empty labels field" {
 test "context renders the shrunk counterexample" {
   let report = @quickcheck.report(
     (x : Int) => x < 3,
-    context=x => "rendered input <\{x}>",
+    counterexample_context=x => "rendered input <\{x}>",
     count=100,
     max_shrinks=100,
     seed=7,
@@ -514,7 +514,7 @@ test "context renders the shrunk counterexample" {
 test "context is attached to raised failures too" {
   let report = @quickcheck.report(
     (x : Int) => if x >= 3 { fail("boom") } else { true },
-    context=x => "rendered input <\{x}>",
+    counterexample_context=x => "rendered input <\{x}>",
     count=100,
     max_shrinks=100,
     seed=7,

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -16,7 +16,7 @@ import {
 pub fn char_range(Char, Char) -> Generator[Char]
 
 #callsite(autofill(loc))
-pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check((A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64, loc~ : SourceLoc) -> Unit raise
+pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check((A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64, loc~ : SourceLoc) -> Unit raise
 
 pub fn classify(Bool, String) -> Observation
 
@@ -36,7 +36,7 @@ pub fn[T] one_of(Array[Generator[T]]) -> Generator[T]
 
 pub fn[T] pure(T) -> Generator[T]
 
-pub fn[A : Arbitrary + @shrink.Shrink] report((A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
+pub fn[A : Arbitrary + @shrink.Shrink] report((A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
 
 pub fn[X : Arbitrary] samples(Int) -> Array[X]
 


### PR DESCRIPTION
Rename the optional `context` callback on `quickcheck.report` and `quickcheck.check` to `counterexample_context`.

The more explicit label makes the callback’s input and purpose clear at call sites, while the `QuickCheckReport` failure field remains the concise `context` because it is already adjacent to `counterexample`.

Validation:
- `moon check quickcheck --warn-list +unnecessary_annotation`
- `moon test quickcheck` (74/74)
- `moon info`
- `moon fmt`