### PR TITLE
fix: suppress legacy lexscan deprecation warnings

### DIFF
--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -59,8 +59,9 @@ priv struct SourceLocRepr {
 }
 
 ///|
+#warnings("-deprecated_syntax")
 fn SourceLocRepr::parse(repr : String) -> SourceLocRepr {
-  lexscan repr[:] with longest {
+  lexscan repr with longest {
     (re"^.+" as filename) +
     re":" +
     (re"[[:digit:]]+" as start_line) +

--- a/diff/diff_align_test.mbt
+++ b/diff/diff_align_test.mbt
@@ -50,6 +50,7 @@ fn weight(k : TokKind) -> Int {
 /// Tokenize the body of a `//` comment: same shapes as code tokens, but all
 /// carry the low `Comment` weight, so similar comments pair while unrelated
 /// ones do not — a whole comment is never one opaque cheap token.
+#warnings("-deprecated_syntax")
 fn push_comment_tokens(toks : Array[Tok], body : String) -> Unit {
   let mut rest = body.view()
   while rest is [_, ..] {
@@ -80,6 +81,7 @@ fn push_comment_tokens(toks : Array[Tok], body : String) -> Unit {
 /// reproduces the line. Rule order matters: `///|`, raw-string lines and
 /// string literals are recognized before the `//` comment rule, so `//`
 /// inside strings is never a comment.
+#warnings("-deprecated_syntax")
 fn tokenize_line(line : String) -> Array[Tok] {
   let toks : Array[Tok] = []
   // `///|` prefix must be handled before lexscan: under `longest` matching

--- a/diff/diff_word_test.mbt
+++ b/diff/diff_word_test.mbt
@@ -26,6 +26,7 @@
 /// newline get grouped treatment; Unicode identifiers, other whitespace and
 /// richer number syntax fall back to single-character tokens (still faithful,
 /// just finer-grained).
+#warnings("-deprecated_syntax")
 fn tokenize(text : StringView) -> Array[String] {
   let tokens = []
   let mut rest = text

--- a/internal/strconv/strconv_bool.mbt
+++ b/internal/strconv/strconv_bool.mbt
@@ -14,6 +14,7 @@
 
 ///|
 /// Parse a string and return the represented boolean value or an error.
+#warnings("-deprecated_syntax")
 pub fn parse_bool(str : StringView) -> Bool raise {
   lexscan str with longest {
     re"^(true|TRUE|True|t|T|1)$" => true

--- a/internal/strconv/strconv_int.mbt
+++ b/internal/strconv/strconv_int.mbt
@@ -157,6 +157,7 @@ pub fn parse_int(str : StringView, base? : Int = 0) -> Int raise {
 // Underscores must appear only between digits or between a base prefix and a digit.
 
 ///|
+#warnings("-deprecated_syntax")
 fn check_underscore(str : StringView) -> Bool {
   // Fast path: underscores are rare in practice. Without any underscore the
   // per-character scan below can never reach a `break false` arm (those all

--- a/internal/strconv/strconv_number.mbt
+++ b/internal/strconv/strconv_number.mbt
@@ -167,6 +167,7 @@ fn parse_number(s : StringView) -> Number? raise {
 
 ///|
 /// Parse the number from the string, raising `Failure` if invalid.
+#warnings("-deprecated_syntax")
 fn parse_inf_nan(rest : StringView) -> Double raise {
   let (pos, rest) = match rest {
     ['-', .. rest] => (false, rest)

--- a/strconv/bool.mbt
+++ b/strconv/bool.mbt
@@ -15,6 +15,7 @@
 ///|
 /// Parse a string and return the represented boolean value or an error.
 #deprecated("use `@string.parse_bool` instead", skip_current_package=true)
+#warnings("-deprecated_syntax")
 pub fn parse_bool(str : StringView) -> Bool raise StrConvError {
   lexscan str with longest {
     re"^(true|TRUE|True|t|T|1)$" => true

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -154,6 +154,7 @@ pub fn parse_int(str : StringView, base? : Int = 0) -> Int raise StrConvError {
 // Underscores must appear only between digits or between a base prefix and a digit.
 
 ///|
+#warnings("-deprecated_syntax")
 fn check_underscore(str : StringView) -> Bool {
   // skip the sign
   let rest = match str {

--- a/strconv/number.mbt
+++ b/strconv/number.mbt
@@ -166,6 +166,7 @@ fn parse_number(s : StringView) -> Number? raise StrConvError {
 
 ///|
 /// Parse the number from the string, raising `StrConvError` if invalid.
+#warnings("-deprecated_syntax")
 fn parse_inf_nan(rest : StringView) -> Double raise StrConvError {
   let (pos, rest) = match rest {
     ['-', .. rest] => (false, rest)

--- a/string/internal/regex_parser/parser.mbt
+++ b/string/internal/regex_parser/parser.mbt
@@ -25,6 +25,7 @@ priv enum CharOrClass {
 const MAX_QUANT = 256
 
 ///|
+#warnings("-deprecated_syntax")
 fn Parser::class_atom(
   rest : StringView,
   ctx~ : ParserContext,
@@ -178,6 +179,7 @@ fn Parser::character_class(
 }
 
 ///|
+#warnings("-deprecated_syntax")
 fn Parser::quantifier_opt(
   rest : StringView,
   ctx~ : ParserContext,
@@ -245,6 +247,7 @@ fn Parser::quant_bound(
 }
 
 ///|
+#warnings("-deprecated_syntax")
 fn Parser::term(
   rest : StringView,
   ctx~ : ParserContext,


### PR DESCRIPTION
Pre-release MoonBit now warns when non-streaming `lexscan` targets a `StringView`, which makes the pre-release matrix fail under deny-warnings.

Keep these existing `lexscan` implementations for compatibility and suppress only `deprecated_syntax` on all thirteen affected declarations, including three test-only tokenizers in `diff/`. Also pass the `String` value directly in `SourceLocRepr::parse`; `lexscan repr` works without the explicit `repr[:]` conversion.

No public interfaces change.

Validation:
- `moon check --deny-warn`
- `moon test builtin` (2940/2940)
- `moon test internal/strconv` (38/38)
- `moon test strconv` (61/61)
- `moon test string/internal/regex_parser` (94/94)
- `moon test diff` (114/114)
- `moon info`
- `moon fmt`