### PR TITLE
refactor: use constructor syntax Type(value) instead of (value : Type)

### DIFF
--- a/buffer/buffer_test.mbt
+++ b/buffer/buffer_test.mbt
@@ -461,8 +461,8 @@ test "write_uint16_be method" {
 ///|
 test "write_int16_le method" {
   let buf = Buffer(size_hint=4)
-  buf.write_int16_le((-2 : Int16))
-  buf.write_int16_le((0x1234 : Int16))
+  buf.write_int16_le(Int16(-2))
+  buf.write_int16_le(Int16(0x1234))
   inspect(
     buf.to_bytes(),
     content=(
@@ -474,8 +474,8 @@ test "write_int16_le method" {
 ///|
 test "write_int16_be method" {
   let buf = Buffer(size_hint=4)
-  buf.write_int16_be((-2 : Int16))
-  buf.write_int16_be((0x1234 : Int16))
+  buf.write_int16_be(Int16(-2))
+  buf.write_int16_be(Int16(0x1234))
   inspect(
     buf.to_bytes(),
     content=(

--- a/builtin/bytes_unsafe_test.mbt
+++ b/builtin/bytes_unsafe_test.mbt
@@ -124,7 +124,7 @@ test "unsafe_write_uint32_be basic functionality" {
 test "unsafe_write_uint16_le basic functionality" {
   // Test with known value
   let buffer : FixedArray[Byte] = FixedArray::make(2, 0)
-  FixedArray::unsafe_write_uint16_le(buffer, 0, (0x0102 : UInt16))
+  FixedArray::unsafe_write_uint16_le(buffer, 0, UInt16(0x0102))
 
   // Check each byte individually (little-endian order)
   inspect(buffer[0], content="b'\\x02'") // 0x02
@@ -132,13 +132,13 @@ test "unsafe_write_uint16_le basic functionality" {
 
   // Test with zero
   let zero_buffer : FixedArray[Byte] = FixedArray::make(2, 255)
-  FixedArray::unsafe_write_uint16_le(zero_buffer, 0, (0 : UInt16))
+  FixedArray::unsafe_write_uint16_le(zero_buffer, 0, UInt16(0))
   inspect(zero_buffer[0], content="b'\\x00'")
   inspect(zero_buffer[1], content="b'\\x00'")
 
   // Test with maximum value
   let max_buffer : FixedArray[Byte] = FixedArray::make(2, 0)
-  FixedArray::unsafe_write_uint16_le(max_buffer, 0, (0xFFFF : UInt16))
+  FixedArray::unsafe_write_uint16_le(max_buffer, 0, UInt16(0xFFFF))
   inspect(max_buffer[0], content="b'\\xFF'")
   inspect(max_buffer[1], content="b'\\xFF'")
 }
@@ -147,7 +147,7 @@ test "unsafe_write_uint16_le basic functionality" {
 test "unsafe_write_uint16_be basic functionality" {
   // Test with known value
   let buffer : FixedArray[Byte] = FixedArray::make(2, 0)
-  FixedArray::unsafe_write_uint16_be(buffer, 0, (0x0102 : UInt16))
+  FixedArray::unsafe_write_uint16_be(buffer, 0, UInt16(0x0102))
 
   // Check each byte individually (big-endian order)
   inspect(buffer[0], content="b'\\x01'") // 0x01
@@ -155,7 +155,7 @@ test "unsafe_write_uint16_be basic functionality" {
 
   // Test with alternating pattern
   let alt_buffer : FixedArray[Byte] = FixedArray::make(2, 0)
-  FixedArray::unsafe_write_uint16_be(alt_buffer, 0, (0xFF00 : UInt16))
+  FixedArray::unsafe_write_uint16_be(alt_buffer, 0, UInt16(0xFF00))
   inspect(alt_buffer[0], content="b'\\xFF'") // 0xFF
   inspect(alt_buffer[1], content="b'\\x00'") // 0x00
 }
@@ -172,7 +172,7 @@ test "unsafe write functions with different offsets" {
   FixedArray::unsafe_write_uint32_le(buffer, 8, 0x22222222U)
 
   // Write UInt16 at position 12
-  FixedArray::unsafe_write_uint16_le(buffer, 12, (0x3333 : UInt16))
+  FixedArray::unsafe_write_uint16_le(buffer, 12, UInt16(0x3333))
 
   // Check the results
   // UInt64 at 0-7 (little-endian)
@@ -231,8 +231,8 @@ test "round-trip test: UInt16" {
 
   // Temporarily avoiding direct UInt16 comparison due to compiler bug
   // Write a known pattern
-  FixedArray::unsafe_write_uint16_le(buffer, 0, (0x1234 : UInt16))
-  FixedArray::unsafe_write_uint16_be(buffer, 2, (0x1234 : UInt16))
+  FixedArray::unsafe_write_uint16_le(buffer, 0, UInt16(0x1234))
+  FixedArray::unsafe_write_uint16_be(buffer, 2, UInt16(0x1234))
 
   // Verify by checking individual bytes
   inspect(buffer[0], content="b'\\x34'") // 0x34 (little-endian)

--- a/builtin/uint16_char.mbt
+++ b/builtin/uint16_char.mbt
@@ -19,10 +19,10 @@
 /// Example:
 /// ```mbt check
 /// test {
-///   inspect((0xD800 : UInt16).is_leading_surrogate(), content="true")
-///   inspect((0xDBFF : UInt16).is_leading_surrogate(), content="true")
-///   inspect((0xDC00 : UInt16).is_leading_surrogate(), content="false")
-///   inspect((0x41 : UInt16).is_leading_surrogate(), content="false") // 'A'
+///   inspect(UInt16(0xD800).is_leading_surrogate(), content="true")
+///   inspect(UInt16(0xDBFF).is_leading_surrogate(), content="true")
+///   inspect(UInt16(0xDC00).is_leading_surrogate(), content="false")
+///   inspect(UInt16(0x41).is_leading_surrogate(), content="false") // 'A'
 /// }
 /// ```
 pub fn UInt16::is_leading_surrogate(self : Self) -> Bool {
@@ -49,10 +49,10 @@ pub fn UInt16::UInt16(self : UInt16) -> UInt16 = "%identity"
 /// Example:
 /// ```mbt check
 /// test {
-///   inspect((0xDC00 : UInt16).is_trailing_surrogate(), content="true")
-///   inspect((0xDFFF : UInt16).is_trailing_surrogate(), content="true")
-///   inspect((0xD800 : UInt16).is_trailing_surrogate(), content="false")
-///   inspect((0x41 : UInt16).is_trailing_surrogate(), content="false") // 'A'
+///   inspect(UInt16(0xDC00).is_trailing_surrogate(), content="true")
+///   inspect(UInt16(0xDFFF).is_trailing_surrogate(), content="true")
+///   inspect(UInt16(0xD800).is_trailing_surrogate(), content="false")
+///   inspect(UInt16(0x41).is_trailing_surrogate(), content="false") // 'A'
 /// }
 /// ```
 pub fn UInt16::is_trailing_surrogate(self : Self) -> Bool {
@@ -66,10 +66,10 @@ pub fn UInt16::is_trailing_surrogate(self : Self) -> Bool {
 /// Example:
 /// ```mbt check
 /// test {
-///   inspect((0xD800 : UInt16).is_surrogate(), content="true") // leading surrogate
-///   inspect((0xDC00 : UInt16).is_surrogate(), content="true") // trailing surrogate
-///   inspect((0xDFFF : UInt16).is_surrogate(), content="true") // trailing surrogate
-///   inspect((0x41 : UInt16).is_surrogate(), content="false") // 'A'
+///   inspect(UInt16(0xD800).is_surrogate(), content="true") // leading surrogate
+///   inspect(UInt16(0xDC00).is_surrogate(), content="true") // trailing surrogate
+///   inspect(UInt16(0xDFFF).is_surrogate(), content="true") // trailing surrogate
+///   inspect(UInt16(0x41).is_surrogate(), content="false") // 'A'
 /// }
 /// ```
 pub fn UInt16::is_surrogate(self : Self) -> Bool {
@@ -177,8 +177,8 @@ pub impl BitXOr for UInt16 with fn lxor(self : UInt16, that : UInt16) -> UInt16 
 ///
 /// ```mbt check
 /// test {
-///   inspect((0x0000 : UInt16).lnot().to_int(), content="65535")
-///   inspect((0xFFFF : UInt16).lnot().to_int(), content="0")
+///   inspect(UInt16(0x0000).lnot().to_int(), content="65535")
+///   inspect(UInt16(0xFFFF).lnot().to_int(), content="0")
 /// }
 /// ```
 pub fn UInt16::lnot(self : UInt16) -> UInt16 {

--- a/builtin/uint16_char_test.mbt
+++ b/builtin/uint16_char_test.mbt
@@ -14,9 +14,9 @@
 
 ///|
 test "UInt16 surrogate checks" {
-  let leading = (0xD800 : UInt16)
-  let trailing = (0xDFFF : UInt16)
-  let normal = (0x0041 : UInt16)
+  let leading = UInt16(0xD800)
+  let trailing = UInt16(0xDFFF)
+  let normal = UInt16(0x0041)
   inspect(leading.is_leading_surrogate(), content="true")
   inspect(trailing.is_trailing_surrogate(), content="true")
   inspect(leading.is_surrogate(), content="true")
@@ -29,13 +29,13 @@ test "UInt16 to_char" {
   let a = ('A' : UInt16)
   assert_true(a.to_char() is Some('A'))
   inspect(a.to_char().unwrap(), content="A")
-  assert_true((0xD800 : UInt16).to_char() is None)
+  assert_true(UInt16(0xD800).to_char() is None)
 }
 
 ///|
 test "UInt16 arithmetic and bit ops" {
-  let a = (0x0010 : UInt16)
-  let b = (0x0003 : UInt16)
+  let a = UInt16(0x0010)
+  let b = UInt16(0x0003)
   inspect((a + b).to_int(), content="19")
   inspect((a - b).to_int(), content="13")
   inspect((a * b).to_int(), content="48")
@@ -47,8 +47,8 @@ test "UInt16 arithmetic and bit ops" {
   inspect((a & b).to_int(), content="0")
   inspect((a ^ b).to_int(), content="19")
   inspect(a.lnot().to_int(), content="65519")
-  inspect((0x0000 : UInt16).lnot().to_int(), content="65535")
-  inspect((0xFFFF : UInt16).lnot().to_int(), content="0")
+  inspect(UInt16(0x0000).lnot().to_int(), content="65535")
+  inspect(UInt16(0xFFFF).lnot().to_int(), content="0")
   inspect(a.lnot().lnot().to_int(), content="16")
   inspect(a == b, content="false")
   inspect(a != b, content="true")
@@ -56,8 +56,8 @@ test "UInt16 arithmetic and bit ops" {
 
 ///|
 test "UInt16 compare and conversions" {
-  let a = (0x0010 : UInt16)
-  let b = (0x000F : UInt16)
+  let a = UInt16(0x0010)
+  let b = UInt16(0x000F)
   inspect(a.compare(b), content="1")
   inspect(b.compare(a), content="-1")
   inspect(a.to_uint(), content="16")
@@ -69,11 +69,11 @@ test "UInt16 compare and conversions" {
 ///|
 test "UInt16 hash combine" {
   let hasher = Hasher(seed=0)
-  hasher.combine((0x00FF : UInt16))
+  hasher.combine(UInt16(0x00FF))
   inspect(hasher.finalize() != 0, content="true")
 }
 
 ///|
 test "UInt16 not_equal" {
-  inspect(Eq::not_equal((0x0001 : UInt16), (0x0002 : UInt16)), content="true")
+  inspect(Eq::not_equal(UInt16(0x0001), UInt16(0x0002)), content="true")
 }

--- a/quickcheck/generator_test.mbt
+++ b/quickcheck/generator_test.mbt
@@ -111,7 +111,7 @@ test "char_range stays within bounds" {
 
 ///|
 test "panic char_range rejects surrogate bounds" {
-  ignore(@quickcheck.char_range(' ', (0xD800 : Int).unsafe_to_char()))
+  ignore(@quickcheck.char_range(' ', Int(0xD800).unsafe_to_char()))
 }
 
 ///|

--- a/uint16/uint16_test.mbt
+++ b/uint16/uint16_test.mbt
@@ -400,19 +400,19 @@ test "UInt16 char literal overloading" {
 ///|
 test "UInt16::to_char" {
   // Valid characters in BMP (Basic Multilingual Plane)
-  debug_inspect((0x41 : UInt16).to_char(), content="Some('A')")
-  debug_inspect((0x61 : UInt16).to_char(), content="Some('a')")
-  debug_inspect((0x30 : UInt16).to_char(), content="Some('0')")
-  debug_inspect((0 : UInt16).to_char(), content="Some('\\u{00}')")
-  debug_inspect((0xD7FF : UInt16).to_char(), content="Some('퟿')")
+  debug_inspect(UInt16(0x41).to_char(), content="Some('A')")
+  debug_inspect(UInt16(0x61).to_char(), content="Some('a')")
+  debug_inspect(UInt16(0x30).to_char(), content="Some('0')")
+  debug_inspect(UInt16(0).to_char(), content="Some('\\u{00}')")
+  debug_inspect(UInt16(0xD7FF).to_char(), content="Some('퟿')")
   // Surrogate range - should return None
-  debug_inspect((0xD800 : UInt16).to_char(), content="None")
-  debug_inspect((0xDBFF : UInt16).to_char(), content="None")
-  debug_inspect((0xDC00 : UInt16).to_char(), content="None")
-  debug_inspect((0xDFFF : UInt16).to_char(), content="None")
+  debug_inspect(UInt16(0xD800).to_char(), content="None")
+  debug_inspect(UInt16(0xDBFF).to_char(), content="None")
+  debug_inspect(UInt16(0xDC00).to_char(), content="None")
+  debug_inspect(UInt16(0xDFFF).to_char(), content="None")
   // Valid characters after surrogate range
-  debug_inspect((0xE000 : UInt16).to_char(), content="Some('\\u{e000}')")
-  debug_inspect((0xFFFF : UInt16).to_char(), content="Some('\\u{ffff}')")
+  debug_inspect(UInt16(0xE000).to_char(), content="Some('\\u{e000}')")
+  debug_inspect(UInt16(0xFFFF).to_char(), content="Some('\\u{ffff}')")
 }
 
 ///|


### PR DESCRIPTION
Replace old-style type annotation casts with constructor syntax across test files and documentation examples.

## Changes

| File | Count | Type |
|------|-------|------|
| `builtin/uint16_char.mbt` | 14 | doc-comment code examples |
| `builtin/uint16_char_test.mbt` | 12 | tests |
| `uint16/uint16_test.mbt` | 11 | tests |
| `builtin/bytes_unsafe_test.mbt` | 8 | tests |
| `buffer/buffer_test.mbt` | 4 | tests |
| `quickcheck/generator_test.mbt` | 1 | test |

## Example

```diff
- inspect((0xD800 : UInt16).is_leading_surrogate(), content="true")
+ inspect(UInt16(0xD800).is_leading_surrogate(), content="true")
```

## Skipped

- `builtin/simd.mbt` — `UInt64` constructor not available in the `builtin` package due to import-loop constraints

## Verified

- `moon check`: clean
- `moon test`: all 6956 tests pass
- `moon fmt --check`: clean