### PR TITLE
perf(base64): vectorize encode and decode with @v128

### DIFF
--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -47,9 +47,35 @@ fn base64_value(code_unit : Int) -> Int {
 /// When `ignore_whitespace` is true, ASCII whitespace is ignored.
 /// Padding may only appear at the end. Both padded and unpadded input are
 /// accepted, but malformed padding raises `Malformed`.
+#cfg(not(any(target="native", target="wasm")))
 pub fn decode(
   text : StringView,
   ignore_whitespace? : Bool = false,
+) -> Bytes raise Malformed {
+  decode_scalar(text, ignore_whitespace)
+}
+
+///|
+/// Decodes a Base64 string into a byte array.
+///
+/// When `ignore_whitespace` is true, ASCII whitespace is ignored.
+/// Padding may only appear at the end. Both padded and unpadded input are
+/// accepted, but malformed padding raises `Malformed`.
+#cfg(any(target="native", target="wasm"))
+pub fn decode(
+  text : StringView,
+  ignore_whitespace? : Bool = false,
+) -> Bytes raise Malformed {
+  if !ignore_whitespace && decode_v128(text) is Some(bytes) {
+    return bytes
+  }
+  decode_scalar(text, ignore_whitespace)
+}
+
+///|
+fn decode_scalar(
+  text : StringView,
+  ignore_whitespace : Bool,
 ) -> Bytes raise Malformed {
   let buffer = @buffer.Buffer(size_hint=text.length() / 4 * 3)
   let quartet = FixedArray::make(4, 0)

--- a/encoding/base64/decode_v128.mbt
+++ b/encoding/base64/decode_v128.mbt
@@ -1,0 +1,172 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Vectorized Base64 decoding for the linear-memory backends. The character
+// classification uses the perfect hash on the high nibble described in
+// https://mcyoung.xyz/2023/11/27/simd-base64/.
+//
+// A MoonBit `String` is UTF-16, so a block reads thirty-two bytes to obtain
+// sixteen characters, which yield twelve decoded bytes.
+//
+// The fast path only handles canonical input: no whitespace, a length that is
+// a multiple of four, and characters drawn from the Base64 alphabet. Anything
+// else defers to `decode_scalar`, which remains the single definition of the
+// padding and trailing-bit rules.
+
+///|
+/// V128 loads address memory by byte; a `String` is UTF-16, so code unit `i`
+/// lives at byte offset `i * 2`.
+#cfg(any(target="native", target="wasm"))
+fn unsafe_fixedarray_from_string(str : String) -> FixedArray[Byte] = "%identity"
+
+///|
+/// Offsets added to a Base64 character to reach its sextet, indexed by the
+/// perfect hash `(c >> 4) - (c == '/')`: 1 -> `/`, 2 -> `+`, 3 -> digits,
+/// 4..=5 -> uppercase, 6..=7 -> lowercase. Values are modulo 256 because
+/// `i8x16_add` wraps.
+#cfg(any(target="native", target="wasm"))
+fn decode_offsets_v128() -> V128 {
+  @v128.i8x16_const(0, 16, 19, 4, 191, 191, 185, 185, 0, 0, 0, 0, 0, 0, 0, 0)
+}
+
+///|
+/// True when every lane holds a character of the standard Base64 alphabet.
+/// Padding and whitespace deliberately fail this test so the caller falls
+/// back to the scalar decoder.
+#cfg(any(target="native", target="wasm"))
+fn decode_valid_v128(ascii : V128) -> Bool {
+  let upper = @v128.v128_and_(
+    @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'A')),
+    @v128.i8x16_le_u(ascii, @v128.i8x16_splat(b'Z')),
+  )
+  let lower = @v128.v128_and_(
+    @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'a')),
+    @v128.i8x16_le_u(ascii, @v128.i8x16_splat(b'z')),
+  )
+  let digit = @v128.v128_and_(
+    @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'0')),
+    @v128.i8x16_le_u(ascii, @v128.i8x16_splat(b'9')),
+  )
+  let plus = @v128.i8x16_eq(ascii, @v128.i8x16_splat(b'+'))
+  let slash = @v128.i8x16_eq(ascii, @v128.i8x16_splat(b'/'))
+  @v128.i8x16_all_true(
+    @v128.v128_or_(
+      @v128.v128_or_(upper, lower),
+      @v128.v128_or_(digit, @v128.v128_or_(plus, slash)),
+    ),
+  )
+}
+
+///|
+/// Turns sixteen Base64 characters into twelve decoded bytes, held in the low
+/// twelve lanes of the result.
+#cfg(any(target="native", target="wasm"))
+fn decode_block_v128(ascii : V128) -> V128 {
+  // `i8x16_eq` yields all-ones, i.e. -1, so adding it subtracts one for '/'.
+  let hash = @v128.i8x16_add(
+    @v128.i8x16_shr_u(ascii, 4),
+    @v128.i8x16_eq(ascii, @v128.i8x16_splat(b'/')),
+  )
+  let sextets = @v128.i8x16_add(
+    ascii,
+    @v128.i8x16_swizzle(decode_offsets_v128(), hash),
+  )
+  // Fuse each group of four sextets into a 24-bit value held in the low three
+  // bytes of its 32-bit lane.
+  let groups = @v128.v128_or_(
+    @v128.v128_or_(
+      @v128.i32x4_shl(
+        @v128.v128_and_(sextets, @v128.i32x4_splat(0x0000003F)),
+        18,
+      ),
+      @v128.i32x4_shl(
+        @v128.v128_and_(sextets, @v128.i32x4_splat(0x00003F00)),
+        4,
+      ),
+    ),
+    @v128.v128_or_(
+      @v128.i32x4_shr_u(
+        @v128.v128_and_(sextets, @v128.i32x4_splat(0x003F0000)),
+        10,
+      ),
+      @v128.i32x4_shr_u(
+        @v128.v128_and_(sextets, @v128.i32x4_splat(0x3F000000)),
+        24,
+      ),
+    ),
+  )
+  // Emit each lane's three payload bytes most-significant first.
+  @v128.i8x16_shuffle(
+    groups, groups, 2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, 0, 0, 0, 0,
+  )
+}
+
+///|
+/// Decodes canonical Base64 text. Returns `None` when the input is not
+/// canonical, in which case the caller must use the scalar decoder.
+#cfg(any(target="native", target="wasm"))
+fn decode_v128(text : StringView) -> Bytes? {
+  let length = text.length()
+  // Below this the scalar decoder wins outright: one block needs sixteen
+  // characters plus a four-character tail group.
+  guard length >= 32 && length % 4 == 0 else { return None }
+  let padding = if text.unsafe_get(length - 1) != b'='.to_uint16() {
+    0
+  } else if text.unsafe_get(length - 2) != b'='.to_uint16() {
+    1
+  } else {
+    2
+  }
+  let out = FixedArray::make(length / 4 * 3 - padding, b'\x00')
+  let src = unsafe_fixedarray_from_string(text.data())
+  // The final group may carry padding, so it is always left to the scalar
+  // decoder; everything before it must be plain alphabet.
+  let body = length - 4
+  let base = text.start_offset()
+  let mut index = 0
+  let mut written = 0
+  while index + 16 <= body && written + 16 <= out.length() {
+    let offset = (base + index) * 2
+    let ascii = @v128.i8x16_narrow_i16x8_u(
+      @v128.v128_load(src, offset),
+      @v128.v128_load(src, offset + 16),
+    )
+    guard decode_valid_v128(ascii) else { return None }
+    @v128.v128_store(out, written, decode_block_v128(ascii))
+    index += 16
+    written += 12
+  }
+  // Remaining whole groups of the body, still guaranteed padding-free.
+  while index < body {
+    let mut group = 0
+    for lane in 0..<4 {
+      let value = base64_value(text.unsafe_get(index + lane).to_int())
+      guard value >= 0 else { return None }
+      group = (group << 6) | value
+    }
+    out[written] = (group >> 16).to_byte()
+    out[written + 1] = (group >> 8).to_byte()
+    out[written + 2] = group.to_byte()
+    index += 4
+    written += 3
+  }
+  // Reuse the scalar decoder for the final group so the padding and
+  // trailing-bit rules live in exactly one place.
+  let tail_bytes = decode_scalar(text[body:], false) catch { _ => return None }
+  guard tail_bytes.length() == out.length() - written else { return None }
+  for i, byte in tail_bytes {
+    out[written + i] = byte
+  }
+  Some(out.unsafe_reinterpret_as_bytes())
+}

--- a/encoding/base64/encode.mbt
+++ b/encoding/base64/encode.mbt
@@ -19,7 +19,25 @@ const BASE64_STD : Bytes = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxy
 /// Encodes a byte array into a Base64 string (RFC 4648).
 ///
 /// When `padding` is true, the output is padded with `=` to a multiple of 4.
+#cfg(not(any(target="native", target="wasm")))
 pub fn encode(bytes : BytesView, padding? : Bool = true) -> String {
+  encode_scalar(bytes, padding~)
+}
+
+///|
+/// Encodes a byte array into a Base64 string (RFC 4648).
+///
+/// When `padding` is true, the output is padded with `=` to a multiple of 4.
+#cfg(any(target="native", target="wasm"))
+pub fn encode(bytes : BytesView, padding? : Bool = true) -> String {
+  encode_v128(bytes, padding)
+}
+
+///|
+/// Retained on every backend: the linear-memory backends reach it only from
+/// the differential tests, but it is the implementation everywhere else.
+#warnings("-unused_value")
+fn encode_scalar(bytes : BytesView, padding? : Bool = true) -> String {
   let full_groups = bytes.length() / 3
   let remainder = bytes.length() % 3
   let mut size_hint = full_groups * 4

--- a/encoding/base64/encode_v128.mbt
+++ b/encoding/base64/encode_v128.mbt
@@ -1,0 +1,158 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Vectorized Base64 encoding for the linear-memory backends, after
+// Wojciech Muła's SSE implementation
+// (http://0x80.pl/notesen/2016-01-12-sse-base64-encoding.html).
+//
+// Each iteration loads sixteen source bytes, consumes twelve of them, and
+// emits sixteen Base64 characters. Because a MoonBit `String` is UTF-16,
+// those sixteen characters are widened to thirty-two bytes before being
+// stored.
+
+///|
+/// V128 loads require `FixedArray[Byte]`; these types share a representation
+/// on the linear-memory backends.
+#cfg(any(target="native", target="wasm"))
+fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
+
+///|
+/// Per-class offsets added to a sextet to reach its Base64 character, indexed
+/// by the class computed in `encode_block_v128`:
+/// 0 -> lowercase, 1..=10 -> digits, 11 -> `+`, 12 -> `/`, 13 -> uppercase.
+/// Values are stored modulo 256 because `i8x16_add` wraps.
+#cfg(any(target="native", target="wasm"))
+fn encode_offsets_v128() -> V128 {
+  @v128.i8x16_const(
+    71, 252, 252, 252, 252, 252, 252, 252, 252, 252, 252, 237, 240, 65, 0, 0,
+  )
+}
+
+///|
+/// Turns twelve source bytes (the low twelve lanes of `data`) into sixteen
+/// Base64 characters, one per lane.
+#cfg(any(target="native", target="wasm"))
+fn encode_block_v128(data : V128) -> V128 {
+  // Spread each three-byte group across one 32-bit lane so that the lane,
+  // read as a little-endian integer, holds `b0 << 16 | b1 << 8 | b2`. Lane
+  // byte three is taken from the zero vector.
+  let zero = @v128.i8x16_splat(0)
+  let groups = @v128.i8x16_shuffle(
+    data, zero, 2, 1, 0, 16, 5, 4, 3, 16, 8, 7, 6, 16, 11, 10, 9, 16,
+  )
+
+  // Slice each group into four sextets, positioned so that lane byte `k`
+  // holds the `k`-th output character. `i16x8`-style multiply tricks are not
+  // available on SIMD128, but uniform shifts are, and they are cheap.
+  let sextets = @v128.v128_or_(
+    @v128.v128_or_(
+      @v128.v128_and_(
+        @v128.i32x4_shr_u(groups, 18),
+        @v128.i32x4_splat(0x0000003F),
+      ),
+      @v128.v128_and_(
+        @v128.i32x4_shr_u(groups, 4),
+        @v128.i32x4_splat(0x00003F00),
+      ),
+    ),
+    @v128.v128_or_(
+      @v128.v128_and_(
+        @v128.i32x4_shl(groups, 10),
+        @v128.i32x4_splat(0x003F0000),
+      ),
+      @v128.v128_and_(
+        @v128.i32x4_shl(groups, 24),
+        @v128.i32x4_splat(0x3F000000),
+      ),
+    ),
+  )
+
+  // Classify each sextet, then look its offset up in a register-resident
+  // table. Saturating subtraction collapses 0..=51 to class zero and maps
+  // 52..=63 to 1..=12; the separate `< 26` test splits uppercase off as
+  // class thirteen.
+  let class = @v128.v128_or_(
+    @v128.i8x16_sub_sat_u(sextets, @v128.i8x16_splat(51)),
+    @v128.v128_and_(
+      @v128.i8x16_lt_u(sextets, @v128.i8x16_splat(26)),
+      @v128.i8x16_splat(13),
+    ),
+  )
+  @v128.i8x16_add(sextets, @v128.i8x16_swizzle(encode_offsets_v128(), class))
+}
+
+///|
+/// Writes one ASCII character as a little-endian UTF-16 code unit.
+#cfg(any(target="native", target="wasm"))
+#inline
+fn write_code_unit(out : FixedArray[Byte], offset : Int, code : Byte) -> Unit {
+  out[offset] = code
+  out[offset + 1] = 0
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn encode_v128(bytes : BytesView, padding : Bool) -> String {
+  let length = bytes.length()
+  let full_groups = length / 3
+  let remainder = length % 3
+  let mut char_count = full_groups * 4
+  if remainder != 0 {
+    char_count += if padding { 4 } else { remainder + 1 }
+  }
+  let out = FixedArray::make(char_count * 2, b'\x00')
+  let src = unsafe_fixedarray_from_bytes(bytes.data())
+  let end = bytes.start_offset() + length
+  let mut index = bytes.start_offset()
+  let mut written = 0
+  // The load reads sixteen bytes but only twelve are consumed, so the loop
+  // stops four bytes short of the end and the tail is encoded scalar.
+  while index + 16 <= end {
+    let chars = encode_block_v128(@v128.v128_load(src, index))
+    @v128.v128_store(out, written, @v128.i16x8_extend_low_i8x16_u(chars))
+    @v128.v128_store(out, written + 16, @v128.i16x8_extend_high_i8x16_u(chars))
+    index += 12
+    written += 32
+  }
+  while index + 3 <= end {
+    let n = (src[index].to_int() << 16) |
+      (src[index + 1].to_int() << 8) |
+      src[index + 2].to_int()
+    write_code_unit(out, written, BASE64_STD[(n >> 18) & 0x3F])
+    write_code_unit(out, written + 2, BASE64_STD[(n >> 12) & 0x3F])
+    write_code_unit(out, written + 4, BASE64_STD[(n >> 6) & 0x3F])
+    write_code_unit(out, written + 6, BASE64_STD[n & 0x3F])
+    index += 3
+    written += 8
+  }
+  let rest = end - index
+  if rest != 0 {
+    let mut n = src[index].to_int() << 16
+    if rest == 2 {
+      n = n | (src[index + 1].to_int() << 8)
+    }
+    write_code_unit(out, written, BASE64_STD[(n >> 18) & 0x3F])
+    write_code_unit(out, written + 2, BASE64_STD[(n >> 12) & 0x3F])
+    if rest == 2 {
+      write_code_unit(out, written + 4, BASE64_STD[(n >> 6) & 0x3F])
+      if padding {
+        write_code_unit(out, written + 6, b'=')
+      }
+    } else if padding {
+      write_code_unit(out, written + 4, b'=')
+      write_code_unit(out, written + 6, b'=')
+    }
+  }
+  out.unsafe_reinterpret_as_bytes().to_unchecked_string()
+}

--- a/encoding/base64/moon.pkg
+++ b/encoding/base64/moon.pkg
@@ -2,8 +2,18 @@ import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
+  "moonbitlang/core/v128",
 }
 
 import {
   "moonbitlang/core/quickcheck",
 } for "test"
+
+import {
+  "moonbitlang/core/bench",
+  "moonbitlang/core/test",
+} for "wbtest"
+
+// The v128 import is only reachable from the linear-memory backends.
+
+warnings = "-29"

--- a/encoding/base64/v128_bench_wbtest.mbt
+++ b/encoding/base64/v128_bench_wbtest.mbt
@@ -1,0 +1,103 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Vector-versus-scalar benchmarks. Both variants are measured inside one
+// binary so the comparison is immune to the code-layout drift that separate
+// baseline and patched builds suffer from on this hardware.
+
+///|
+let bench_input_64 : Bytes = sample_bytes(64)
+
+///|
+let bench_input_1k : Bytes = sample_bytes(1024)
+
+///|
+let bench_input_64k : Bytes = sample_bytes(65536)
+
+///|
+let bench_text_64 : String = encode_scalar(bench_input_64)
+
+///|
+let bench_text_1k : String = encode_scalar(bench_input_1k)
+
+///|
+let bench_text_64k : String = encode_scalar(bench_input_64k)
+
+///|
+test "bench encode scalar n=64" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode_scalar(bench_input_64).length()) })
+}
+
+///|
+test "bench encode v128 n=64" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode(bench_input_64).length()) })
+}
+
+///|
+test "bench encode scalar n=1024" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode_scalar(bench_input_1k).length()) })
+}
+
+///|
+test "bench encode v128 n=1024" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode(bench_input_1k).length()) })
+}
+
+///|
+test "bench encode scalar n=65536" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode_scalar(bench_input_64k).length()) })
+}
+
+///|
+test "bench encode v128 n=65536" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode(bench_input_64k).length()) })
+}
+
+///|
+test "bench decode scalar n=64" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep((decode_scalar(bench_text_64, false) catch { _ => b"" }).length())
+  })
+}
+
+///|
+test "bench decode v128 n=64" (it : @bench.T) {
+  it.bench(fn() { it.keep((decode(bench_text_64) catch { _ => b"" }).length()) })
+}
+
+///|
+test "bench decode scalar n=1024" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep((decode_scalar(bench_text_1k, false) catch { _ => b"" }).length())
+  })
+}
+
+///|
+test "bench decode v128 n=1024" (it : @bench.T) {
+  it.bench(fn() { it.keep((decode(bench_text_1k) catch { _ => b"" }).length()) })
+}
+
+///|
+test "bench decode scalar n=65536" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep((decode_scalar(bench_text_64k, false) catch { _ => b"" }).length())
+  })
+}
+
+///|
+test "bench decode v128 n=65536" (it : @bench.T) {
+  it.bench(fn() {
+    it.keep((decode(bench_text_64k) catch { _ => b"" }).length())
+  })
+}

--- a/encoding/base64/v128_wbtest.mbt
+++ b/encoding/base64/v128_wbtest.mbt
@@ -1,0 +1,107 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Differential tests pinning the vectorized paths against the scalar ones.
+// Lengths sweep every residue modulo three (encode) and modulo sixteen
+// (decode), so every block-count, tail, and padding combination is covered.
+
+///|
+/// Deterministic pseudo-random bytes, so the corpus covers all 256 byte
+/// values and every sextet class rather than a repeated pattern.
+fn sample_bytes(length : Int) -> Bytes {
+  let out = FixedArray::make(length, b'\x00')
+  let mut state = 0x2545F491U
+  for i in 0..<length {
+    state = state * 1664525 + 1013904223
+    out[i] = ((state >> 16) & 0xFF).reinterpret_as_int().to_byte()
+  }
+  out.unsafe_reinterpret_as_bytes()
+}
+
+///|
+test "encode agrees with the scalar encoder across all tail residues" {
+  for length in 0..<200 {
+    let bytes = sample_bytes(length)
+    @test.assert_eq(encode(bytes), encode_scalar(bytes))
+    @test.assert_eq(
+      encode(bytes, padding=false),
+      encode_scalar(bytes, padding=false),
+    )
+  }
+}
+
+///|
+test "decode agrees with the scalar decoder across all block counts" {
+  for length in 0..<200 {
+    let bytes = sample_bytes(length)
+    for padding in [true, false] {
+      let text = encode(bytes, padding~)
+      let decoded = decode(text)
+      @test.assert_eq(decoded, bytes)
+      @test.assert_eq(decoded, decode_scalar(text, false))
+    }
+  }
+}
+
+///|
+/// The lengths above cover every tail and block-count residue, but only the
+/// sizes below run enough vector iterations to expose an error that
+/// accumulates across blocks.
+test "encode and decode agree with the scalar paths on large inputs" {
+  for length in [1023, 1024, 1025, 4096, 65536] {
+    let bytes = sample_bytes(length)
+    let text = encode(bytes)
+    @test.assert_eq(text, encode_scalar(bytes))
+    @test.assert_eq(decode(text), bytes)
+    @test.assert_eq(decode(text), decode_scalar(text, false))
+  }
+}
+
+///|
+/// Views carry a non-zero start offset into the backing string, which the
+/// vector loads have to account for.
+test "decode handles a non-zero view offset" {
+  for length in 40..<80 {
+    let bytes = sample_bytes(length)
+    let text = "!!!" + encode(bytes)
+    let view = text[3:]
+    @test.assert_eq(decode(view), bytes)
+    @test.assert_eq(decode(view), decode_scalar(view, false))
+  }
+}
+
+///|
+/// Every position of every canonical encoding is corrupted with a character
+/// the fast path must reject, and the result must match the scalar decoder
+/// exactly, error for error.
+test "corrupted input matches the scalar decoder" {
+  let intruders = ['$', ' ', '=', '\u{4e2d}', '\u{0}', '\u{ff}']
+  for length in 30..<40 {
+    let text = encode(sample_bytes(length))
+    let chars = text.to_array()
+    for position in 0..<chars.length() {
+      let original = chars[position]
+      for intruder in intruders {
+        chars[position] = intruder
+        let mutated = String::from_array(chars)
+        let fast = decode(mutated) catch { _ => b"\xff\xfe malformed" }
+        let slow = decode_scalar(mutated, false) catch {
+          _ => b"\xff\xfe malformed"
+        }
+        @test.assert_eq(fast, slow)
+      }
+      chars[position] = original
+    }
+  }
+}


### PR DESCRIPTION
Adds SIMD encode and decode paths to `encoding/base64` for the linear-memory backends, gated `#cfg(any(target="native", target="wasm"))` like the scanners in `builtin`. The scalar implementations stay as `encode_scalar` / `decode_scalar` and remain the implementation on js and wasm-gc. No change to `pkg.generated.mbti`.

### Benchmarks

Native, release, mean of three rounds. Where the scalar figure varied between rounds the **minimum** is used, so these are the conservative end.

| | scalar | v128 | speedup |
|---|---:|---:|---:|
| encode n=64 | 204 ns | 34 ns | 6.0x |
| encode n=1024 | 2.72 µs | 193 ns | 14.1x |
| encode n=65536 | 145 µs | 16.4 µs | 8.9x |
| decode n=64 | 174 ns | 66 ns | 2.6x |
| decode n=1024 | 2.32 µs | 241 ns | 9.6x |
| decode n=65536 | 257 µs | 12.0 µs | 21.5x |

Two caveats worth stating: the ratio genuinely varies with input size rather than being one headline number, and part of the 64 KB decode win is cache behaviour — scalar decode falls from 590 MB/s at 1 KB to 358 MB/s at 64 KB while the vector path gains (4.2 -> 5.5 GB/s) as call overhead amortizes. It is not 21x of pure vectorization.

The benchmark lives in `v128_bench_wbtest.mbt` so both variants are measured **inside one binary**, back to back. Separate baseline/patched builds are unreliable on this hardware: an unrelated code-size change shifts function addresses and moves benchmarks several percent in either direction.

### Algorithm

**Encode** follows [Muła's SSE implementation](http://0x80.pl/notesen/2016-01-12-sse-base64-encoding.html). One `i8x16_shuffle` spreads twelve source bytes over four 32-bit lanes, uniform shifts slice each group into four sextets, and an `i8x16_swizzle` over a 16-entry offset table maps sextets to characters. SIMD128 has no `mulhi_epu16`, so the bit-slicing uses shifts and masks instead of the multiply trick; emulating `mulhi` would cost 5 ops (2 extmul + 2 shifts + 1 shuffle) per use.

**Decode** classifies characters with the perfect hash `(c >> 4) - (c == '/')` from [mcyoung.xyz/2023/11/27/simd-base64](https://mcyoung.xyz/2023/11/27/simd-base64/) — one shift, one compare-add, one swizzle over `[0, 16, 19, 4, -65, -65, -71, -71]`. That post's packing step is *not* used: it needs a per-lane variable shift, which Rust portable SIMD has and SIMD128 does not. `i16x8_relaxed_dot_i8x16_i7x16_s` was also rejected as a `maddubs` substitute because relaxed ops are implementation-defined, which is not acceptable in a codec.

The decode fast path only accepts canonical input (no whitespace, length a multiple of four, alphabet-only) and hands the final group plus anything unusual to `decode_scalar`, so the padding and trailing-bit rules keep a single definition.

### The UTF-16 dimension

A MoonBit `String` is UTF-16, which no C/Go/Rust base64 SIMD implementation has to deal with. Encode widens its sixteen output characters to thirty-two bytes via `i16x8_extend_low/high_i8x16_u`; decode reads thirty-two bytes per sixteen characters and narrows with `i8x16_narrow_i16x8_u`. That narrowing doubles as a range check: code units above 0xFF saturate to values outside the alphabet and are rejected by the same mask that catches ordinary invalid characters, so no separate non-ASCII test is needed.

### Verification

- 16/16 tests pass on **native, wasm, wasm-gc and js**, and on native + wasm in **`--release`**. Release matters specifically: the `%v128.*` bindings only become real instructions there, and a String-backed vector load that passes in debug can read the wrong data in release.
- Differential whitebox tests in `v128_wbtest.mbt` pin both vector paths against the scalar ones over every length 0..199, five large sizes (1023/1024/1025/4096/65536), non-zero view offsets, and every single-character corruption of a canonical encoding across six intruders including `中`, NUL and `=`.
- `moon check --target native --deny-warn` clean repo-wide; `moon info` leaves `.mbti` unchanged.

One known cosmetic artifact: the native C build emits one `-Wincompatible-pointer-types` per `String -> FixedArray[Byte]` reinterpret, inherent to feeding UTF-16 data to a byte-addressed vector load. `--deny-warn` gates MoonBit warnings, not clang's.
