### PR TITLE
feat(builtin): add deprecated `length` alias for `Char::utf16_len`

### DIFF
--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -535,6 +535,7 @@ pub impl ToJson for Char with fn to_json(self : Char) -> Json {
 /// }
 /// ```
 ///
+#alias(length)
 pub fn Char::utf16_len(self : Self) -> Int {
   let code = self.to_int()
   if code <= 0xFFFF {

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -535,7 +535,7 @@ pub impl ToJson for Char with fn to_json(self : Char) -> Json {
 /// }
 /// ```
 ///
-#alias(length)
+#alias(length, deprecated="Use `utf16_len` instead")
 pub fn Char::utf16_len(self : Self) -> Int {
   let code = self.to_int()
   if code <= 0xFFFF {

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -572,6 +572,7 @@ pub fn Char::to_int(Char) -> Int
 pub fn Char::to_json(Char) -> Json
 pub fn Char::to_string(Char) -> String
 pub fn Char::to_uint(Char) -> UInt
+#alias(length)
 pub fn Char::utf16_len(Char) -> Int
 
 pub fn Int::Int(Int) -> Int

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -572,7 +572,7 @@ pub fn Char::to_int(Char) -> Int
 pub fn Char::to_json(Char) -> Json
 pub fn Char::to_string(Char) -> String
 pub fn Char::to_uint(Char) -> UInt
-#alias(length)
+#alias(length, deprecated)
 pub fn Char::utf16_len(Char) -> Int
 
 pub fn Int::Int(Int) -> Int

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -526,6 +526,7 @@ test "Case conversion with non-letters" {
 }
 
 ///|
+#warnings("-deprecated")
 test "length is an alias of utf16_len" {
   inspect('A'.length(), content="1")
   inspect('🌟'.length(), content="2")

--- a/char/char_test.mbt
+++ b/char/char_test.mbt
@@ -524,3 +524,11 @@ test "Case conversion with non-letters" {
   assert_eq('a'.to_ascii_uppercase(), 'A')
   assert_eq('z'.to_ascii_uppercase(), 'Z')
 }
+
+///|
+test "length is an alias of utf16_len" {
+  inspect('A'.length(), content="1")
+  inspect('🌟'.length(), content="2")
+  assert_eq('\u{FFFF}'.length(), '\u{FFFF}'.utf16_len())
+  assert_eq('\u{10000}'.length(), '\u{10000}'.utf16_len())
+}


### PR DESCRIPTION
## What

Adds a `length` alias to `Char::utf16_len`, marked deprecated so existing/incoming call sites keep working while new code is steered to the precise name:

```moonbit
#alias(length, deprecated="Use `utf16_len` instead")
pub fn Char::utf16_len(self : Self) -> Int
```

Calling `.length()` compiles and behaves identically to `utf16_len`, but emits warning `[0020]`:

```
 3 │   inspect('A'.length(), content="1")
   │               ───┬──
   │                  ╰──── Warning (deprecated): Use `utf16_len` instead
```

This keeps `utf16_len` as the one canonical spelling. `length` is available for discoverability — someone reaching for the familiar name finds it rather than bouncing off — but the compiler tells them what to write instead. That matters here because `length` is genuinely ambiguous for a `Char`: the value is a count of **UTF-16 code units** (1 or 2), not bytes and not graphemes, so `'🌟'.length() == 2` reads as surprising without the qualifier in the name.

`Char` had no `length` method before this, so there is no collision.

## Changes

- `builtin/char.mbt` — add the `#alias(length, deprecated=...)` attribute
- `builtin/pkg.generated.mbti` — regenerated via `moon info`
- `char/char_test.mbt` — test asserting the alias agrees with `utf16_len`, including at the BMP boundary (`U+FFFF` / `U+10000`), with `#warnings("-deprecated")` per the existing `strconv` test convention

## Validation

- `moon check` — clean
- `moon test char` — 40/40 passed
- `moon test builtin` — 2940/2940 passed
- `moon fmt` and `moon info` run; the only interface change is the added alias line
- Deprecation verified end-to-end with a scratch call site: warns with the intended message, does not error

🤖 Generated with [Claude Code](https://claude.com/claude-code)