### PR TITLE
refactor(builtin): default `end` to `self.length()` on view constructors

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -254,12 +254,9 @@ pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
 pub fn[T] Array::view(
   self : Array[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
   }
@@ -301,12 +298,9 @@ pub fn[T] Array::view(
 pub fn[T] Array::get_view(
   self : Array[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T]? {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(ArrayView::make(self.buffer(), start, end - start))
 }
@@ -347,12 +341,9 @@ pub fn[T] Array::get_view(
 pub fn[T] ArrayView::view(
   self : ArrayView[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
   }
@@ -396,12 +387,9 @@ pub fn[T] ArrayView::view(
 pub fn[T] ArrayView::get_view(
   self : ArrayView[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T]? {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(ArrayView::make(self.buf(), self.start() + start, end - start))
 }
@@ -444,12 +432,9 @@ fn[T] unsafe_cast_fixedarray_to_uninitializedarray(
 pub fn[T] FixedArray::view(
   self : FixedArray[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
   }
@@ -495,12 +480,9 @@ pub fn[T] FixedArray::view(
 pub fn[T] FixedArray::get_view(
   self : FixedArray[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T]? {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(
     ArrayView::make(

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -175,11 +175,12 @@ pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {
 /// ```
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_ instead")
-pub fn Bytes::view(self : Bytes, start? : Int = 0, end? : Int) -> BytesView {
+pub fn Bytes::view(
+  self : Bytes,
+  start? : Int = 0,
+  end? : Int = self.length(),
+) -> BytesView {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("Invalid index for View")
   }
@@ -206,12 +207,9 @@ pub fn Bytes::view(self : Bytes, start? : Int = 0, end? : Int) -> BytesView {
 pub fn Bytes::get_view(
   self : Bytes,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> BytesView? {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(BytesView::make(self, start, end - start))
 }
@@ -223,12 +221,9 @@ pub fn Bytes::get_view(
 pub fn BytesView::get_view(
   self : BytesView,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> BytesView? {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else { None }
   Some(BytesView::make(self.bytes(), self.start() + start, end - start))
 }
@@ -251,12 +246,9 @@ pub fn BytesView::get_view(
 pub fn BytesView::view(
   self : BytesView,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> BytesView {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("Invalid index for View")
   }

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -247,12 +247,9 @@ pub fn[T] MutArrayView::unsafe_set(
 pub fn[T] Array::mut_view(
   self : Array[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> MutArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
   }
@@ -294,12 +291,9 @@ pub fn[T] Array::mut_view(
 pub fn[T] MutArrayView::mut_view(
   self : MutArrayView[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> MutArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
   }
@@ -337,12 +331,9 @@ pub fn[T] MutArrayView::mut_view(
 pub fn[T] FixedArray::mut_view(
   self : FixedArray[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> MutArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
   }
@@ -367,12 +358,9 @@ pub fn[T] FixedArray::mut_view(
 pub fn[T] MutArrayView::view(
   self : MutArrayView[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View index out of bounds")
   }

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -871,12 +871,9 @@ pub fn[T : Compare] ReadOnlyArray::lexical_compare(
 pub fn[T] ReadOnlyArray::view(
   self : ReadOnlyArray[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T] {
-  match end {
-    None => self.unsafe_reinterpret_to_fixed_array()[start:]
-    Some(e) => self.unsafe_reinterpret_to_fixed_array()[start:e]
-  }
+  self.unsafe_reinterpret_to_fixed_array()[start:end]
 }
 
 ///|
@@ -902,13 +899,10 @@ pub fn[T] ReadOnlyArray::view(
 pub fn[T] ReadOnlyArray::get_view(
   self : ReadOnlyArray[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T]? {
   let fixed = self.unsafe_reinterpret_to_fixed_array()
-  match end {
-    None => fixed.get_view(start~)
-    Some(end) => fixed.get_view(start~, end~)
-  }
+  fixed.get_view(start~, end~)
 }
 
 ///|

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -154,11 +154,12 @@ fn String::unsafe_range_equal(
 /// Returns a new string containing the specified substring.
 ///
 #deprecated("Use `str[:]` or `str[:].to_string()` instead", skip_current_package=true)
-pub fn String::substring(self : String, start? : Int = 0, end? : Int) -> String {
+pub fn String::substring(
+  self : String,
+  start? : Int = 0,
+  end? : Int = self.length(),
+) -> String {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard! start >= 0 && start <= end && end <= len
   self.unsafe_substring(start~, end~)
 }

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -105,9 +105,8 @@ pub fn StringView::start_offset(self : StringView) -> Int {
 pub fn StringView::view(
   self : StringView,
   start_offset? : Int = 0,
-  end_offset? : Int,
+  end_offset? : Int = self.length(),
 ) -> StringView {
-  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -616,9 +615,8 @@ pub fn StringView::equal_ignore_ascii_case(
 pub fn String::view(
   self : String,
   start_offset? : Int = 0,
-  end_offset? : Int,
+  end_offset? : Int = self.length(),
 ) -> StringView {
-  let end_offset = if end_offset is Some(o) { o } else { self.length() }
   guard start_offset >= 0 &&
     start_offset <= end_offset &&
     end_offset <= self.length() else {
@@ -661,12 +659,9 @@ pub fn StringView::from_iter(iter : Iter[Char]) -> StringView {
 pub fn String::get_view(
   self : String,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> StringView? {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else { None }
   if start < len && self.unsafe_get(start).is_trailing_surrogate() {
     return None
@@ -684,13 +679,10 @@ pub fn String::get_view(
 pub fn StringView::get_view(
   self : StringView,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> StringView? {
   let str_len = self.str().length()
-  let abs_end = match end {
-    None => self.end()
-    Some(end) => self.start() + end
-  }
+  let abs_end = self.start() + end
   let abs_start = self.start() + start
   guard abs_start >= self.start() &&
     abs_start <= abs_end &&
@@ -736,14 +728,11 @@ pub fn StringView::get_view(
 pub fn String::clamped_view(
   self : String,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> StringView {
   let len = self.length()
   let mut lo = if start < 0 { 0 } else if start > len { len } else { start }
-  let mut hi = match end {
-    None => len
-    Some(e) => if e < 0 { 0 } else if e > len { len } else { e }
-  }
+  let mut hi = if end < 0 { 0 } else if end > len { len } else { end }
   if lo > 0 &&
     lo < len &&
     self.unsafe_get(lo).is_trailing_surrogate() &&
@@ -782,14 +771,11 @@ pub fn String::clamped_view(
 pub fn StringView::clamped_view(
   self : StringView,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> StringView {
   let len = self.length()
   let mut lo = if start < 0 { 0 } else if start > len { len } else { start }
-  let mut hi = match end {
-    None => len
-    Some(e) => if e < 0 { 0 } else if e > len { len } else { e }
-  }
+  let mut hi = if end < 0 { 0 } else if end > len { len } else { end }
   let str = self.str()
   let base = self.start()
   if lo > 0 &&
@@ -921,11 +907,12 @@ pub fn StringView::split_at(
 /// }
 /// ```
 #alias("_[_:_]")
-pub fn String::sub(self : String, start? : Int = 0, end? : Int) -> StringView {
+pub fn String::sub(
+  self : String,
+  start? : Int = 0,
+  end? : Int = self.length(),
+) -> StringView {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard! start >= 0 && start <= end && end <= len
   if start < len {
     guard! !self.unsafe_get(start).is_trailing_surrogate()
@@ -979,15 +966,12 @@ pub fn String::sub(self : String, start? : Int = 0, end? : Int) -> StringView {
 pub fn StringView::sub(
   self : StringView,
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> StringView {
   let str_len = self.str().length()
 
   // Calculate absolute positions in the original string
-  let abs_end = match end {
-    None => self.end()
-    Some(end) => self.start() + end
-  }
+  let abs_end = self.start() + end
   let abs_start = self.start() + start
 
   // Validate bounds against the original string

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -89,12 +89,9 @@ fn[T] UninitializedArray::unsafe_set(
 pub fn[T] UninitializedArray::sub(
   self : UninitializedArray[T],
   start? : Int = 0,
-  end? : Int,
+  end? : Int = self.length(),
 ) -> ArrayView[T] {
   let len = self.length()
-  let end = match end {
-    Some(end) | (None with end = len) => end
-  }
   guard start >= 0 && start <= end && end <= len else {
     abort("View start index out of bounds")
   }


### PR DESCRIPTION
## What

The view/slice constructors in `builtin` all declared `end? : Int` with no default and then re-derived the missing case inside the body, each with a slightly different idiom:

```moonbit
let end = match end { Some(end) | (None with end = len) => end }
let end_offset = if end_offset is Some(o) { o } else { self.length() }
match end { None => fixed[start:], Some(e) => fixed[start:e] }
```

A default-argument expression can reference an earlier parameter, so `end? : Int = self.length()` states the same thing in the signature. The body then works with a plain `Int` and the unwrapping goes away — 26 functions, −62 lines net.

Covered types: `ArrayView`, `MutArrayView`, `BytesView`, `StringView`, `ReadOnlyArray`, `UninitializedArray` (plus the deprecated `String::substring`).

## Why it is behavior-preserving

- **`len`-based cases** — the default is literally the `len` the body already computed.
- **`StringView::{get_view,sub}`** used `self.end()` in the `None` branch. `self.start() + self.length()` is the same value, since `StringView::length()` is defined as `end() - start()`.
- **`{String,StringView}::clamped_view`** clamped the `Some` branch into `[0, len]`. `self.length()` is already in range, so it clamps to itself.
- **`ReadOnlyArray::view`** fell back to `fixed[start:]`, whose own default is the fixed array's length — and `ReadOnlyArray::length()` is defined as exactly that.

`moon info` produces **no `.mbti` diff**: the generated interface renders both forms as `end? : Int`, so this is not a source- or interface-breaking change for downstream users.

## Not converted

- `Iter::view` genuinely needs the `Option`: an iterator has no length, and `None` selects a `drop`-only fast path that `Some` cannot express.
- `{Array,FixedArray}::fill` take a range but are not view constructors, so they are left alone here.

## Verification

```
moon check --deny-warn --target all          # clean
moon info --target wasm,wasm-gc,js,native    # no diff
moon fmt                                     # no diff
moon bundle --all                            # clean
moon test --target all                       # wasm 6966 / wasm-gc 6967 / js 6911 / native 6885, 0 failed
moon test --release --target js,wasm,wasm-gc # 0 failed
moon test --release --target native          # 6885 passed, 0 failed
MOONC_INTERNAL_PARAMS='use_js_builtin_string = 1 |' \
  moon test --target wasm-gc [--release]     # 6967 passed, 0 failed
```
