### PR TITLE
fix(bigint): make bitwise ops depend on value, not construction history

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1567,16 +1567,16 @@ pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
 /// }
 /// ```
 pub impl BitAnd for BigInt with fn land(self : BigInt, other : BigInt) -> BigInt {
-  let max_length = if self.limbs.length() < other.limbs.length() {
-    other.limbs.length() + 1
+  let max_length = if self.len < other.len {
+    other.len + 1
   } else {
-    self.limbs.length() + 1
+    self.len + 1
   }
   // Extend the limbs to store the sign bits
   let x_limbs = FixedArray::make(max_length, 0U)
-  x_limbs.unsafe_blit(0, self.limbs, 0, self.limbs.length())
+  x_limbs.unsafe_blit(0, self.limbs, 0, self.len)
   let y_limbs = FixedArray::make(max_length, 0U)
-  y_limbs.unsafe_blit(0, other.limbs, 0, other.limbs.length())
+  y_limbs.unsafe_blit(0, other.limbs, 0, other.len)
 
   // Calculate the complement code per 2
   if self.sign == Negative {
@@ -1628,9 +1628,9 @@ pub impl BitAnd for BigInt with fn land(self : BigInt, other : BigInt) -> BigInt
   }
 
   // return the result
-  let limbs = FixedArray::make(max_length - 1, 0U)
-  limbs.unsafe_blit(0, x_limbs, 0, max_length - 1)
-  { limbs, sign: new_sign, len: normalize_len(limbs, max_length - 1) }
+  let limbs = FixedArray::make(max_length, 0U)
+  limbs.unsafe_blit(0, x_limbs, 0, max_length)
+  { limbs, sign: new_sign, len: normalize_len(limbs, max_length) }
 }
 
 ///|
@@ -1657,16 +1657,16 @@ pub impl BitAnd for BigInt with fn land(self : BigInt, other : BigInt) -> BigInt
 /// }
 /// ```
 pub impl BitOr for BigInt with fn lor(self : BigInt, other : BigInt) -> BigInt {
-  let max_length = if self.limbs.length() < other.limbs.length() {
-    other.limbs.length() + 1
+  let max_length = if self.len < other.len {
+    other.len + 1
   } else {
-    self.limbs.length() + 1
+    self.len + 1
   }
   // Extend the limbs to store the sign bits
   let x_limbs = FixedArray::make(max_length, 0U)
-  x_limbs.unsafe_blit(0, self.limbs, 0, self.limbs.length())
+  x_limbs.unsafe_blit(0, self.limbs, 0, self.len)
   let y_limbs = FixedArray::make(max_length, 0U)
-  y_limbs.unsafe_blit(0, other.limbs, 0, other.limbs.length())
+  y_limbs.unsafe_blit(0, other.limbs, 0, other.len)
 
   // Calculate the complement code per 2
   if self.sign == Negative {
@@ -1718,9 +1718,9 @@ pub impl BitOr for BigInt with fn lor(self : BigInt, other : BigInt) -> BigInt {
   }
 
   // return the result
-  let limbs = FixedArray::make(max_length - 1, 0U)
-  limbs.unsafe_blit(0, x_limbs, 0, max_length - 1)
-  { limbs, sign: new_sign, len: normalize_len(limbs, max_length - 1) }
+  let limbs = FixedArray::make(max_length, 0U)
+  limbs.unsafe_blit(0, x_limbs, 0, max_length)
+  { limbs, sign: new_sign, len: normalize_len(limbs, max_length) }
 }
 
 ///|
@@ -1747,16 +1747,16 @@ pub impl BitOr for BigInt with fn lor(self : BigInt, other : BigInt) -> BigInt {
 /// }
 /// ```
 pub impl BitXOr for BigInt with fn lxor(self : BigInt, other : BigInt) -> BigInt {
-  let max_length = if self.limbs.length() < other.limbs.length() {
-    other.limbs.length() + 1
+  let max_length = if self.len < other.len {
+    other.len + 1
   } else {
-    self.limbs.length() + 1
+    self.len + 1
   }
   // Extend the limbs to store the sign bits
   let x_limbs = FixedArray::make(max_length, 0U)
-  x_limbs.unsafe_blit(0, self.limbs, 0, self.limbs.length())
+  x_limbs.unsafe_blit(0, self.limbs, 0, self.len)
   let y_limbs = FixedArray::make(max_length, 0U)
-  y_limbs.unsafe_blit(0, other.limbs, 0, other.limbs.length())
+  y_limbs.unsafe_blit(0, other.limbs, 0, other.len)
 
   // Calculate the complement code per 2
   if self.sign == Negative {
@@ -1808,9 +1808,9 @@ pub impl BitXOr for BigInt with fn lxor(self : BigInt, other : BigInt) -> BigInt
   }
 
   // return the result
-  let limbs = FixedArray::make(max_length - 1, 0U)
-  limbs.unsafe_blit(0, x_limbs, 0, max_length - 1)
-  { limbs, sign: new_sign, len: normalize_len(limbs, max_length - 1) }
+  let limbs = FixedArray::make(max_length, 0U)
+  limbs.unsafe_blit(0, x_limbs, 0, max_length)
+  { limbs, sign: new_sign, len: normalize_len(limbs, max_length) }
 }
 
 ///|

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -863,6 +863,24 @@ test "lxor_result_zero_normalization" {
 }
 
 ///|
+test "bitwise ops depend on value, not construction history" {
+  let from_hex = @bigint.BigInt::from_string("80000000", radix=16)
+  let literal = 2147483648N
+
+  assert_eq(from_hex, literal)
+
+  // x & -x = lowest set bit = 2^31
+  assert_eq(from_hex & -from_hex, literal & -literal)
+  assert_eq(from_hex & -from_hex, 2147483648N)
+  // x | -x = -2^31 = -2147483648
+  assert_eq(from_hex | -from_hex, literal | -literal)
+  assert_eq(from_hex | -from_hex, -2147483648N)
+  // x ^ -x = -(2^31 + 2^31) = -2^32 = -4294967296
+  assert_eq(from_hex ^ -from_hex, literal ^ -literal)
+  assert_eq(from_hex ^ -from_hex, -4294967296N)
+}
+
+///|
 test "to_int" {
   let a = @bigint.BigInt::from_int(1234567899)
   inspect(a.to_int(), content="1234567899")


### PR DESCRIPTION
# Fix: Make `BigInt` bitwise operations depend on the value, not on construction history

> close #3810

## Summary

The `BitAnd`, `BitOr` and `BitXOr` implementations of `@bigint.BigInt` computed their two's-complement working width from `limbs.length()` (the allocated `FixedArray` capacity) instead of the logical number of significant limbs `len`. Because different construction paths allocate different capacities for numerically equal values, the result of a bitwise operation depended on **how** the operands were constructed rather than on their value.

> *Two `BigInt` values that compare equal must be substitutable in every arithmetic and bitwise operation.*

## Reproduction

On the non-JavaScript backend:

```moonbit
test "xor depends on value, not construction history" {
  let from_hex = @bigint.BigInt::from_string("80000000", radix=16)
  let literal  = 2147483648N            // == from_hex

  assert_eq(from_hex, literal)                         // passes
  assert_eq(from_hex ^ -from_hex, literal ^ -literal)  // FAILS
}
```

Observed before the fix:

- `from_hex ^ -from_hex` = `0`
- `literal   ^ -literal`   = `-4294967296` = `-2^32`

## Root cause

The `BigInt` struct keeps a magnitude array `limbs` (`FixedArray[UInt]`, base `2^32`) alongside a `len` field. By invariant, `limbs` may contain leading zeros, so the struct comment explicitly forbids using `limbs.length()`; one must use `len`. The bitwise implementations violated this in two places.

### 1. Working width used capacity instead of length

```moonbit
let max_length = if self.limbs.length() < other.limbs.length() {
  other.limbs.length() + 1
} else {
  self.limbs.length() + 1
}
```

`from_string("80000000", radix=16)` goes through `from_string_radix_pow2`, which allocates exactly 1 limb, while the literal `2147483648N` goes through `from_int64` → `from_uint64`, which allocates 2 limbs. Equal values therefore received different working widths.

### 2. Result dropped the "sign extension" limb

The result kept only `max_length - 1` limbs:

```moonbit
let limbs = FixedArray::make(max_length - 1, 0U)
limbs.unsafe_blit(0, x_limbs, 0, max_length - 1)
```

For `x = 2^31` we have `x ^ (-x) = -2^32`, whose magnitude is `[0, 1]` in base `2^32` — i.e. it needs **two** limbs. With `max_length = 2` only 1 limb survives, the top limb `1` is truncated, and the result collapses to `0`.

Because the two construction paths chose different `max_length`, one path "happened" to be wide enough and the other was not.

## Fix

### Affected file and functions

| File | Trait method | Lines (approx.) |
|------|-------------|-----------------|
| `bigint/bigint_nonjs.mbt` | `BitAnd::land` | 1569–1634 |
| | `BitOr::lor` | 1659–1724 |
| | `BitXOr::lxor` | 1749–1814 |

All three implementations share the same structure and received the same three changes. Below, each change is shown as a before/after diff.

### Change 1: working width uses `len` instead of `limbs.length()`

**Before:**
```moonbit
let max_length = if self.limbs.length() < other.limbs.length() {
  other.limbs.length() + 1
} else {
  self.limbs.length() + 1
}
```

**After:**
```moonbit
let max_length = if self.len < other.len {
  other.len + 1
} else {
  self.len + 1
}
```

**Why:** `limbs.length()` is the allocated `FixedArray` capacity, which varies with the construction path even for equal values. `len` is the number of significant limbs and depends only on the value, as required by the struct invariant.

### Change 2: copy only the significant limbs

**Before:**
```moonbit
x_limbs.unsafe_blit(0, self.limbs, 0, self.limbs.length())
y_limbs.unsafe_blit(0, other.limbs, 0, other.limbs.length())
```

**After:**
```moonbit
x_limbs.unsafe_blit(0, self.limbs, 0, self.len)
y_limbs.unsafe_blit(0, other.limbs, 0, other.len)
```

**Why:** Copying the full capacity could include leading-zero limbs beyond `len`. Although those zeros are harmless for positive numbers, they are redundant; copying only `len` limbs is cleaner and consistent with the new width calculation. The remaining slots in `x_limbs`/`y_limbs` stay zero-initialized by `FixedArray::make`.

### Change 3: keep all `max_length` limbs in the result

**Before:**
```moonbit
let limbs = FixedArray::make(max_length - 1, 0U)
limbs.unsafe_blit(0, x_limbs, 0, max_length - 1)
{ limbs, sign: new_sign, len: normalize_len(limbs, max_length - 1) }
```

**After:**
```moonbit
let limbs = FixedArray::make(max_length, 0U)
limbs.unsafe_blit(0, x_limbs, 0, max_length)
{ limbs, sign: new_sign, len: normalize_len(limbs, max_length) }
```

**Why:** The old code discarded the top limb (the "sign extension" slot). For negative results whose magnitude needs one more limb than the operands (e.g. `x ^ (-x) = -2^32` with magnitude `[0, 1]`), that top limb carries real data and must not be dropped. Keeping all `max_length` limbs and letting `normalize_len` strip trailing zeros is always safe: positive results have a zero top limb that gets trimmed, while negative results keep the limb they need.

### Correct values after the fix

For `x = 2^31`:

| Expression | Result |
|-----------|--------|
| `x & (-x)` | `2^31` = `2147483648` |
| `x \| (-x)` | `-2^31` = `-2147483648` |
| `x ^ (-x)` | `-2^32` = `-4294967296` |

## Regression test

The new test compares both construction paths and asserts the exact expected values (not only mutual equality, which would also pass when both paths are consistently wrong):

```moonbit
test "bitwise ops depend on value, not construction history" {
  let from_hex = @bigint.BigInt::from_string("80000000", radix=16)
  let literal = 2147483648N
  assert_eq(from_hex, literal)

  assert_eq(from_hex & -from_hex, literal & -literal)
  assert_eq(from_hex & -from_hex, 2147483648N)

  assert_eq(from_hex | -from_hex, literal | -literal)
  assert_eq(from_hex | -from_hex, -2147483648N)

  assert_eq(from_hex ^ -from_hex, literal ^ -literal)
  assert_eq(from_hex ^ -from_hex, -4294967296N)
}
```

## Validation

| Check | Result |
|-------|--------|
| `moon test --target wasm -p bigint` | 528 / 528 passed |
| `moon info` | interface (`.mbti`) unchanged |
| `moon fmt` | formatting clean |

The generated public interface (`bigint/pkg.generated.mbti`) is unchanged: this is a pure internal implementation fix with no public API impact.