### PR TITLE
fix(immut/hashset): canonicalize HAMT shapes so structural Eq matches content equality

### DIFF
--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -75,21 +75,19 @@ fn[A] join_2(
   key2 : A,
   path2 : @path.Path,
 ) -> Node[A] {
+  if path1 == @path.exhausted {
+    // Both paths are fully consumed: the keys collide on every path
+    // segment, so they can only share the maximum-depth collision bucket.
+    return Leaf(key2, @list.singleton(key1))
+  }
   let idx1 = path1.idx()
   let idx2 = path2.idx()
   if idx1 == idx2 {
-    let node = if path1.is_last() {
-      Leaf(key2, @list.singleton(key1))
-    } else {
-      join_2(key1, path1.next(), key2, path2.next())
-    }
+    let node = join_2(key1, path1.next(), key2, path2.next())
     Branch(@sparse_array.singleton(idx1, node))
   } else {
-    let (node1, node2) = if path1.is_last() {
-      (Leaf(key1, @list.empty()), Leaf(key2, @list.empty()))
-    } else {
-      (Flat(key1, path1.next()), Flat(key2, path2.next()))
-    }
+    let node1 = Flat(key1, path1.next())
+    let node2 = Flat(key2, path2.next())
     Branch(@sparse_array.doubleton(idx1, node1, idx2, node2))
   }
 }
@@ -306,6 +304,20 @@ pub fn[A : Eq + Hash] HashSet::remove(self : HashSet[A], key : A) -> HashSet[A] 
 }
 
 ///|
+/// Rebuild a branch whose children may have shrunk, restoring the `Node`
+/// invariant that a subtree holding a single element is represented as
+/// `Flat` (structural `Eq` relies on shapes being canonical). A lone
+/// `Leaf` child needs no collapsing: a `Leaf` always holds at least two
+/// path-colliding elements, and the singleton branch chain above it is
+/// exactly the shape a fresh construction of that collision builds.
+fn[A] collapse_branch(children : @sparse_array.SparseArray[Node[A]]) -> Node[A] {
+  match children.data {
+    [Flat(key, path)] => Flat(key, path.push(children.elem_info.first_idx()))
+    _ => Branch(children)
+  }
+}
+
+///|
 fn[A : Eq] Node::remove_with_path(
   self : Node[A],
   key : A,
@@ -313,13 +325,19 @@ fn[A : Eq] Node::remove_with_path(
 ) -> Node[A]? {
   match self {
     Leaf(key1, bucket) =>
+      // a `Leaf` sits at maximum depth, so `path` is fully consumed here
+      // and a single surviving element becomes a `Flat` carrying it
       if key1 == key {
         match bucket {
           Empty => None
+          More(key2, tail=Empty) => Some(Flat(key2, path))
           More(key2, tail=xs) => Some(Leaf(key2, xs))
         }
       } else if bucket.find_index(x => key.equal(x)) is Some(index) {
-        Some(Leaf(key1, bucket.remove_at(index)))
+        match bucket.remove_at(index) {
+          Empty => Some(Flat(key1, path))
+          new_bucket => Some(Leaf(key1, new_bucket))
+        }
       } else {
         Some(self)
       }
@@ -340,11 +358,7 @@ fn[A : Eq] Node::remove_with_path(
             (_, None) => children.remove(idx)
             (_, Some(new_child)) => children.replace(idx, new_child)
           }
-          match new_children.data {
-            [Flat(key1, path1)] =>
-              Some(Flat(key1, path1.push(new_children.elem_info.first_idx())))
-            _ => Some(Branch(new_children))
-          }
+          Some(collapse_branch(new_children))
         }
       }
     }
@@ -425,15 +439,14 @@ pub fn[K : Eq] HashSet::intersection(
       (Branch(children1), Branch(children2)) =>
         match children1.intersection(children2, go) {
           None => None
-          Some({ data: [Flat(key, path)], elem_info }) =>
-            Some(Flat(key, path.push(elem_info.first_idx())))
-          Some(children) => Some(Branch(children))
+          Some(children) => Some(collapse_branch(children))
         }
       (Leaf(key1, bucket1), Leaf(key2, bucket2)) => {
         let keys1 = bucket1.add(key1)
         let keys2 = bucket2.add(key2)
         match keys1.filter(k => keys2.contains(k)) {
           Empty => None
+          More(head, tail=Empty) => Some(Flat(head, @path.exhausted))
           More(head, tail~) => Some(Leaf(head, tail))
         }
       }
@@ -467,15 +480,14 @@ pub fn[K : Eq] HashSet::difference(
       (Branch(children1), Branch(children2)) =>
         match children1.difference(children2, go) {
           None => None
-          Some({ data: [Flat(key, path)], elem_info }) =>
-            Some(Flat(key, path.push(elem_info.first_idx())))
-          Some(children) => Some(Branch(children))
+          Some(children) => Some(collapse_branch(children))
         }
       (Leaf(key1, bucket1), Leaf(key2, bucket2)) => {
         let keys1 = bucket1.add(key1)
         let keys2 = bucket2.add(key2)
         match keys1.filter(k => !keys2.contains(k)) {
           Empty => None
+          More(head, tail=Empty) => Some(Flat(head, @path.exhausted))
           More(head, tail~) => Some(Leaf(head, tail))
         }
       }

--- a/immut/hashset/README.mbt.md
+++ b/immut/hashset/README.mbt.md
@@ -82,6 +82,79 @@ test "set operations" {
 }
 ```
 
+## Equality and Hashing
+
+`==` is **content equality**: two sets are equal exactly when they hold the
+same elements, no matter which sequence of operations produced them.
+`Hash` agrees with `==`, so equal sets always hash equally.
+
+```mbt check
+///|
+test "equality is content equality" {
+  // Insertion order never matters
+  let a = @hashset.new().add("x").add("y").add("z")
+  let b = @hashset.new().add("z").add("y").add("x")
+  assert_true(a == b)
+  // Bulk construction and incremental adds agree
+  let c : @hashset.HashSet[String] = HashSet(["x", "y", "z"])
+  assert_true(c == a)
+  // Operation history is invisible: add/remove round-trips restore
+  // equality
+  assert_true(a.add("w").remove("w") == a)
+  // Equal sets hash equally
+  let h1 = Hasher()
+  h1.combine(a)
+  let h2 = Hasher()
+  h2.combine(b)
+  assert_eq(h1.finalize(), h2.finalize())
+}
+```
+
+This holds even for elements whose hashes collide:
+
+```mbt check
+///|
+/// Every element hashes to the same value: all of them share one bucket.
+priv struct OneBucketElem(Int) derive(Eq)
+
+///|
+impl Hash for OneBucketElem with fn hash(_) {
+  7
+}
+
+///|
+impl Hash for OneBucketElem with fn hash_combine(_, hasher) {
+  hasher.combine_int(7)
+}
+
+///|
+test "collisions preserve content equality" {
+  let a = @hashset.new().add(OneBucketElem(1)).add(OneBucketElem(2))
+  let b = @hashset.new().add(OneBucketElem(2)).add(OneBucketElem(1))
+  assert_true(a == b)
+  // Shrinking a bucket back to one element restores the exact
+  // single-element shape
+  assert_true(a.remove(OneBucketElem(2)) == HashSet([OneBucketElem(1)]))
+}
+```
+
+One boundary to be aware of: **iteration order is unspecified**. `==` and
+`Hash` are order-blind by design, but `iter`/`each` visit elements in an
+internal order that is not part of the contract — in particular, the
+relative order of elements sharing a collision bucket reflects insertion
+history. Sort the elements if you need a deterministic order.
+
+`HashSet` shares its HAMT representation — and the *canonical form*
+invariant that makes structural equality a correct implementation of
+content equality — with `immut/hashmap`: a subtree holding one element is
+always a `Flat` node, collision buckets exist only at maximum trie depth
+with at least two elements, and every shrinking operation collapses back
+to the shape a fresh construction would build. See
+[`immut/hashmap/README.mbt.md`](../hashmap/README.mbt.md) for the full
+internals story (path bit layout, node shapes, and collapse diagrams);
+this package's canonical-structure and QuickCheck property tests pin the
+same invariant for sets.
+
 ## Membership and Queries
 
 Test membership and query the set:

--- a/immut/hashset/canonical_property_test.mbt
+++ b/immut/hashset/canonical_property_test.mbt
@@ -1,0 +1,156 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Structural `Eq` is a valid proxy for content equality only if every
+// operation keeps the trie canonical: one topology per content, regardless
+// of history. This property sweep drives random operation sequences
+// against an array model and requires, after every single step, that the
+// set is `==` to a fresh `from_iter` of its content — and, at the end, to
+// a rebuild by `add` in reverse order. Each regime below picks a hash
+// quotient that stresses a different part of the trie: distinct hashes
+// (plain `Int`), first-segment collisions (`CollidingElem`), maximum-depth
+// divergence and collisions (`DeepElem`), and a single all-elements bucket
+// (`ZeroHashElem`).
+
+///|
+/// Elements that all share the one and only collision bucket.
+priv struct ZeroHashElem(Int) derive(Eq)
+
+///|
+impl Hash for ZeroHashElem with fn hash(_) {
+  0
+}
+
+///|
+impl Hash for ZeroHashElem with fn hash_combine(_, hasher) {
+  hasher.combine_int(0)
+}
+
+///|
+fn model_insert(model : Array[Int], key : Int) -> Unit {
+  if !model.contains(key) {
+    model.push(key)
+  }
+}
+
+///|
+fn model_delete(model : Array[Int], key : Int) -> Unit {
+  for i, k in model {
+    if k == key {
+      let _ = model.remove(i)
+      return
+    }
+  }
+}
+
+///|
+/// Interpret `ops` as a stream of set operations over a 16-element
+/// universe, mirror each on the model, and require full canonicity after
+/// every step.
+fn[A : Eq + Hash] canonical_after_ops(
+  mk : (Int) -> A,
+  ops : Array[Int],
+) -> Bool {
+  let model : Array[Int] = []
+  let mut hs : @hashset.HashSet[A] = @hashset.new()
+  for op in ops {
+    let n = op & 0x7fffffff
+    let key = n / 8 % 16
+    match n % 8 {
+      0 | 1 | 2 => {
+        hs = hs.add(mk(key))
+        model_insert(model, key)
+      }
+      3 | 4 => {
+        hs = hs.remove(mk(key))
+        model_delete(model, key)
+      }
+      op_code => {
+        // A second set derived from a slice of the current content plus
+        // one possibly-fresh element, built canonically via `from_iter`.
+        let other_model : Array[Int] = []
+        for k in model {
+          if (k + key) % 3 != 0 {
+            other_model.push(k)
+          }
+        }
+        model_insert(other_model, key)
+        let other = @hashset.from_iter(other_model.iter().map(mk))
+        match op_code {
+          5 => {
+            hs = hs.union(other)
+            for k in other_model {
+              model_insert(model, k)
+            }
+          }
+          6 => {
+            hs = hs.intersection(other)
+            model.retain(k => other_model.contains(k))
+          }
+          _ => {
+            hs = hs.difference(other)
+            model.retain(k => !other_model.contains(k))
+          }
+        }
+      }
+    }
+    // Content agreement guards the model itself…
+    if hs.length() != model.length() {
+      return false
+    }
+    for k in model {
+      if !hs.contains(mk(k)) {
+        return false
+      }
+    }
+    // …and this is the canonicity property: same content, same structure.
+    let rebuilt = @hashset.from_iter(model.iter().map(mk))
+    if hs != rebuilt {
+      return false
+    }
+  }
+  // Insertion-order independence: adding the final content in reverse
+  // order must reproduce the exact structure.
+  let mut reversed : @hashset.HashSet[A] = @hashset.new()
+  for i in 0..<model.length() {
+    reversed = reversed.add(mk(model[model.length() - 1 - i]))
+  }
+  reversed == hs
+}
+
+///|
+test "quickcheck: canonical after every op (distinct hashes)" {
+  @quickcheck.check((ops : Array[Int]) => canonical_after_ops(n => n, ops))
+}
+
+///|
+test "quickcheck: canonical after every op (first-segment collisions)" {
+  @quickcheck.check((ops : Array[Int]) => {
+    canonical_after_ops(n => CollidingElem(n), ops)
+  })
+}
+
+///|
+test "quickcheck: canonical after every op (maximum-depth collisions)" {
+  @quickcheck.check((ops : Array[Int]) => {
+    canonical_after_ops(n => DeepElem(n), ops)
+  })
+}
+
+///|
+test "quickcheck: canonical after every op (single collision bucket)" {
+  @quickcheck.check((ops : Array[Int]) => {
+    canonical_after_ops(n => ZeroHashElem(n), ops)
+  })
+}

--- a/immut/hashset/canonical_property_test.mbt
+++ b/immut/hashset/canonical_property_test.mbt
@@ -19,9 +19,26 @@
 // set is `==` to a fresh `from_iter` of its content — and, at the end, to
 // a rebuild by `add` in reverse order. Each regime below picks a hash
 // quotient that stresses a different part of the trie: distinct hashes
-// (plain `Int`), first-segment collisions (`CollidingElem`), maximum-depth
-// divergence and collisions (`DeepElem`), and a single all-elements bucket
-// (`ZeroHashElem`).
+// (plain `Int`), segment-1 divergence with full collisions
+// (`CollidingElem`), mid-trie segment-3 divergence (`MidDepthElem`),
+// maximum-depth divergence and collisions (`DeepElem`), and a single
+// all-elements bucket (`ZeroHashElem`).
+
+///|
+/// Elements whose hash lives only in path segment 3 (bits 10..=14): all
+/// elements share segments 1-2 and diverge — or fully collide — at
+/// mid-trie depth.
+priv struct MidDepthElem(Int) derive(Eq)
+
+///|
+impl Hash for MidDepthElem with fn hash(self) {
+  (self.0 & 3) << 10
+}
+
+///|
+impl Hash for MidDepthElem with fn hash_combine(self, hasher) {
+  hasher.combine_int((self.0 & 3) << 10)
+}
 
 ///|
 /// Elements that all share the one and only collision bucket.
@@ -138,6 +155,13 @@ test "quickcheck: canonical after every op (distinct hashes)" {
 test "quickcheck: canonical after every op (first-segment collisions)" {
   @quickcheck.check((ops : Array[Int]) => {
     canonical_after_ops(n => CollidingElem(n), ops)
+  })
+}
+
+///|
+test "quickcheck: canonical after every op (mid-depth collisions)" {
+  @quickcheck.check((ops : Array[Int]) => {
+    canonical_after_ops(n => MidDepthElem(n), ops)
   })
 }
 

--- a/immut/hashset/canonical_structure_test.mbt
+++ b/immut/hashset/canonical_structure_test.mbt
@@ -165,3 +165,29 @@ test "bulk construction agrees with incremental adds at maximum depth" {
   assert_true(via_iter == added)
   assert_true(reversed == added)
 }
+
+///|
+test "bulk construction eliminates duplicates canonically" {
+  // 96 entries over 12 distinct elements exceed the bulk threshold while
+  // forcing duplicate elimination inside the bulk builder, through both
+  // of its traversal directions (constructor and sized `from_iter`).
+  let elems : Array[DeepElem] = []
+  for i in 0..<96 {
+    elems.push(DeepElem(i % 12))
+  }
+  let distinct_elems : Array[DeepElem] = []
+  for i in 0..<12 {
+    distinct_elems.push(DeepElem(i))
+  }
+  let bulk : @hashset.HashSet[DeepElem] = HashSet(elems)
+  let via_iter = @hashset.from_iter(elems.iter())
+  let mut added : @hashset.HashSet[DeepElem] = @hashset.new()
+  for e in elems {
+    added = added.add(e)
+  }
+  let distinct : @hashset.HashSet[DeepElem] = HashSet(distinct_elems)
+  assert_eq(bulk.length(), 12)
+  assert_true(bulk == added)
+  assert_true(via_iter == added)
+  assert_true(bulk == distinct)
+}

--- a/immut/hashset/canonical_structure_test.mbt
+++ b/immut/hashset/canonical_structure_test.mbt
@@ -1,0 +1,167 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `HashSet` shares the HAMT design (and its structural `Eq`) with
+// `immut/hashmap`, so every operation must leave the trie in the canonical
+// shape a fresh construction of the same content would have. These tests
+// pin that contract for the shrinking operations (`remove`,
+// `intersection`, `difference`) and for the insert path at maximum trie
+// depth, mirroring the hashmap suite from the canonicalization work.
+
+///|
+/// Elements whose 32-bit hash keeps only the low three bits, so values
+/// agreeing on `n & 7` collide on the whole stored path.
+priv struct CollidingElem(Int) derive(Eq)
+
+///|
+impl Hash for CollidingElem with fn hash(self) {
+  self.0 & 7
+}
+
+///|
+impl Hash for CollidingElem with fn hash_combine(self, hasher) {
+  hasher.combine_int(self.0 & 7)
+}
+
+///|
+/// Elements whose hash lives only in the top path segment (bits 25..=29):
+/// all values share path segments 1-5, so they diverge — or fully collide —
+/// only at the maximum trie depth.
+priv struct DeepElem(Int) derive(Eq)
+
+///|
+impl Hash for DeepElem with fn hash(self) {
+  (self.0 & 3) << 25
+}
+
+///|
+impl Hash for DeepElem with fn hash_combine(self, hasher) {
+  hasher.combine_int((self.0 & 3) << 25)
+}
+
+///|
+test "removing a colliding element restores the canonical structure" {
+  let original : @hashset.HashSet[CollidingElem] = HashSet([CollidingElem(0)])
+  let round_trip = original.add(CollidingElem(24)).remove(CollidingElem(24))
+  assert_true(round_trip == original)
+}
+
+///|
+test "chained removals from a collision bucket collapse in any order" {
+  // 0, 8, and 24 all hash to bucket 0, forming a three-element collision
+  // node.
+  let all : @hashset.HashSet[CollidingElem] = @hashset.new()
+    .add(CollidingElem(0))
+    .add(CollidingElem(8))
+    .add(CollidingElem(24))
+  let one_way = all.remove(CollidingElem(8)).remove(CollidingElem(24))
+  let other_way = all.remove(CollidingElem(24)).remove(CollidingElem(8))
+  assert_true(one_way == HashSet([CollidingElem(0)]))
+  assert_true(one_way == other_way)
+}
+
+///|
+test "difference removing a colliding element yields the canonical set" {
+  let original : @hashset.HashSet[CollidingElem] = HashSet([CollidingElem(0)])
+  let both = original.add(CollidingElem(24))
+  let only_other : @hashset.HashSet[CollidingElem] = HashSet([CollidingElem(24)])
+  assert_true(both.difference(only_other) == original)
+}
+
+///|
+test "intersection dropping a colliding element yields the canonical set" {
+  let left : @hashset.HashSet[CollidingElem] = HashSet([
+    CollidingElem(0),
+    CollidingElem(24),
+  ])
+  let right : @hashset.HashSet[CollidingElem] = HashSet([
+    CollidingElem(0),
+    CollidingElem(8),
+  ])
+  assert_true(left.intersection(right) == HashSet([CollidingElem(0)]))
+}
+
+///|
+test "insertion order cannot affect the structure at maximum depth" {
+  let one_way : @hashset.HashSet[DeepElem] = @hashset.new()
+    .add(DeepElem(0))
+    .add(DeepElem(1))
+    .add(DeepElem(2))
+  let other_way : @hashset.HashSet[DeepElem] = @hashset.new()
+    .add(DeepElem(2))
+    .add(DeepElem(1))
+    .add(DeepElem(0))
+  assert_true(one_way == other_way)
+}
+
+///|
+test "removing a maximum-depth sibling leaves the canonical structure" {
+  let removed = @hashset.new()
+    .add(DeepElem(0))
+    .add(DeepElem(1))
+    .add(DeepElem(2))
+    .remove(DeepElem(1))
+  let fresh : @hashset.HashSet[DeepElem] = @hashset.new()
+    .add(DeepElem(0))
+    .add(DeepElem(2))
+  assert_true(removed == fresh)
+}
+
+///|
+test "path collision arriving at a maximum-depth Flat stays canonical" {
+  // 2 and 6 collide on every path segment. Adding 0 and 1 first forces
+  // the maximum-depth branch into existence, so DeepElem(2) is stored
+  // there as a single element with a fully consumed path when DeepElem(6)
+  // arrives.
+  let one_way : @hashset.HashSet[DeepElem] = @hashset.new()
+    .add(DeepElem(0))
+    .add(DeepElem(1))
+    .add(DeepElem(2))
+    .add(DeepElem(6))
+  let other_way : @hashset.HashSet[DeepElem] = @hashset.new()
+    .add(DeepElem(2))
+    .add(DeepElem(6))
+    .add(DeepElem(0))
+    .add(DeepElem(1))
+  assert_true(one_way.contains(DeepElem(2)))
+  assert_true(one_way.contains(DeepElem(6)))
+  assert_eq(one_way.length(), 4)
+  assert_true(one_way == other_way)
+}
+
+///|
+test "bulk construction agrees with incremental adds at maximum depth" {
+  // 80 elements exceed the bulk-build threshold (64), so the constructor
+  // and a sized `from_iter` take the range-partitioning bulk builder,
+  // whose bottom-level handoff must produce the same canonical shapes as
+  // plain `add` — here four maximum-depth collision buckets of 20 keys.
+  let elems : Array[DeepElem] = []
+  for i in 0..<80 {
+    elems.push(DeepElem(i))
+  }
+  let bulk : @hashset.HashSet[DeepElem] = HashSet(elems)
+  let via_iter = @hashset.from_iter(elems.iter())
+  let mut added : @hashset.HashSet[DeepElem] = @hashset.new()
+  for e in elems {
+    added = added.add(e)
+  }
+  let mut reversed : @hashset.HashSet[DeepElem] = @hashset.new()
+  for i in 0..<elems.length() {
+    reversed = reversed.add(elems[elems.length() - 1 - i])
+  }
+  assert_eq(bulk.length(), 80)
+  assert_true(bulk == added)
+  assert_true(via_iter == added)
+  assert_true(reversed == added)
+}

--- a/immut/hashset/moon.pkg
+++ b/immut/hashset/moon.pkg
@@ -11,5 +11,6 @@ import {
 import {
   "moonbitlang/core/bench",
   "moonbitlang/core/int",
+  "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"

--- a/immut/hashset/types.mbt
+++ b/immut/hashset/types.mbt
@@ -16,8 +16,14 @@
 /// An non-empty immutable hash set data structure
 #unsafe_cycle_free
 priv enum Node[A] {
+  /// a subtree holding exactly one element, at any depth; carries the
+  /// not-yet-consumed remainder of the element's path (only the head tag
+  /// once every segment is consumed)
   Flat(A, @path.Path)
-  Leaf(A, @list.List[A]) // use a list of buckets to resolve collision
+  /// collision bucket at maximum depth (all six path segments equal);
+  /// always holds at least two elements — a lone element must be
+  /// represented as `Flat`
+  Leaf(A, @list.List[A])
   /// number of all its leaf > 1. If equals 1, it should be represented as `Flat`
   Branch(@sparse_array.SparseArray[Node[A]])
 }

--- a/immut/internal/path/path.mbt
+++ b/immut/internal/path/path.mbt
@@ -21,8 +21,9 @@
 /// - The highest 2 bits are reserved as a head tag (0b11)
 /// - The remaining bits are divided into segments of 5 bits each
 ///
-/// For example, `Path::of(x) = 0b11_10000_10101_00100_11111_01010`
-/// represents segments as [0b_10000, 0b_10101, 0b_00100, 0b_11111, 0b_01010]
+/// For example, `Path::of(x) = 0b11_10000_10101_00100_11111_01010_00110`
+/// represents segments as
+/// [0b_10000, 0b_10101, 0b_00100, 0b_11111, 0b_01010, 0b_00110]
 pub struct Path(UInt) derive(Eq)
 
 ///|


### PR DESCRIPTION
## What

Port of the `immut/hashmap` canonicalization (#4001) to `HashSet`, completing the follow-up planned there. `HashSet` derives structural `Eq` over the same HAMT design, but none of the canonicalization ever applied to it, so content-equal sets compared unequal — in more cases than the map, since the set never received even the shrink-collapse fixes:

```moonbit
// hash(e) = e & 7, so Elem(0) and Elem(24) collide on every path segment
let s = @hashset.HashSet([Elem(0)])
s.add(Elem(24)).remove(Elem(24)) == s          // false before this PR
```

Three defect families, all fixed by canonicalizing on `Flat`:

1. **Shrink remnants**: `remove` left `Leaf(k, Empty)` behind when a collision bucket emptied, and the branch unwind's inline collapse handled only `[Flat]` singletons; `intersection`/`difference` shared both defects.
2. **Dual representation at maximum depth**: a lone element was `Flat(k, exhausted)` when added into an existing bottom-level branch but `Leaf(k, Empty)` when `join_2` split at the last segment — insertion order alone falsified `==`.
3. **Head-tag bug**: a path collision arriving at a maximum-depth `Flat` sent exhausted paths into `join_2`, which consumed the head tag as a segment index and built a spurious branch below maximum depth.

The invariant after this PR (same as the map): a `Leaf` always holds ≥ 2 path-colliding elements; a lone element is `Flat` at every depth; every shrunk branch rebuild routes through one `collapse_branch` helper. `join_2`'s explicit exhausted-path termination subsumes both of its `is_last` special cases, so it gets shorter. No public API changes.

## Tests (red verified: 11 failures at the parent commit)

- **Deterministic**: shrink cases under path collisions (`remove`/`difference`/`intersection`, chained removals in any order), maximum-depth cases (insertion order, sibling removal, path collision arriving at a terminal `Flat`), and bulk-vs-incremental construction tests (80 distinct elements; 96 entries over 12 distinct elements pinning duplicate elimination through both bulk traversal directions).
- **QuickCheck property suite** (mirroring the hashmap's): random op sequences (`add`/`remove`/`union`/`intersection`/`difference`) mirrored on an array model under five hash regimes (distinct, segment-1 divergence with full collisions, mid-trie segment-3 divergence, maximum-depth collisions, single bucket), asserting `hs == from_iter(model)` after **every** step plus a reverse-order rebuild. Before the fix, three regimes falsify with 3-op shrunk counterexamples.

## Docs

`immut/hashset/README.mbt.md` gains an *Equality and Hashing* section with tested examples (order independence, bulk agreement, round-trips, engineered-collision equality, hash agreement), the unspecified-iteration-order boundary, and a canonical-form summary that defers the shared internals story (path layout, node shapes, collapse diagrams) to the `immut/hashmap` README.

## Review

A codex CLI adversarial pass (primed to refute the invariants and to diff the port against the canonicalized hashmap) found **no correctness issues and no missed porting site**: it audited every `Node` constructor site, `join_2`'s exhausted-path termination against the Path bit semantics, `union`'s symmetric arms in both orientations, `intersection`'s reuse of the original `Flat`, and both bulk-builder traversal directions. Its two low-severity coverage findings are addressed in follow-up commits:

- a mid-trie divergence regime was missing (segments 2–5) → added the `MidDepthElem` (segment-3) QuickCheck regime and corrected the `CollidingElem` regime description;
- bulk duplicate elimination was unpinned → added the 96-entry/12-distinct bulk test;
- plus a pre-existing doc nit it spotted: the `Path::of` layout example showed five segments instead of six.

## Validation

- Full repo suite: 7007/7007; `moon fmt` stable; `moon info` — no public API changes
- Once merged, both HAMT containers uphold the same documented invariant, pinned by the same style of property suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
