### PR TITLE
perf(queue): mark Queue as #valtype

### DIFF
--- a/queue/types.mbt
+++ b/queue/types.mbt
@@ -17,6 +17,7 @@
 ///
 /// `push` appends to the back of the deque and `peek`/`pop` operate on the
 /// front, so all queue operations are O(1) (amortized for `push`).
+#valtype
 struct Queue[A] {
   inner : @deque.Deque[A]
 }


### PR DESCRIPTION
## Summary

`Queue[A]` is a single-field struct wrapping `@deque.Deque[A]`. Marking it `#valtype` keeps the wrapper unboxed, removing one heap indirection per queue value, matching how other single-field wrappers in core (e.g. `immut/hashset`, `immut/hashmap`) are declared.

No public API change — `moon info` produced no `.mbti` diff.

## Validation

- `moon check` clean
- `moon test queue`: 60/60 passed
- `moon fmt` / `moon info`: no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)