### PR TITLE
introduce internal `@os_string` package for string with OS-native encoding

### DIFF
--- a/env/env.mbt
+++ b/env/env.mbt
@@ -79,5 +79,5 @@ pub fn rand(n : Int) -> Bytes? {
 #warnings("-unused_value")
 fn unused_function() -> Unit {
   ignore(@ref.Ref(42))
-  ignore(@utf8.encode(""))
+  let _ : (@os_string.OsString) -> Unit = ignore
 }

--- a/env/env_native.mbt
+++ b/env/env_native.mbt
@@ -13,48 +13,7 @@
 // limitations under the License.
 
 ///|
-/// On Windows, we use native `W` series unicode API,
-/// which return string in UTF-16 directly,
-/// so no need for extra encoding phase here.
-///
-/// Note: technically path etc. may not be invalid UTF-16 on Windows,
-///   but this should be extremely rare in practice.
-///   If we need to fix this case, a validation or encoding phase can be added.
-#cfg(platform="windows")
-priv struct OsString(String)
-
-///|
-/// On non-Windows platforms, path etc. are essentially binary data,
-/// and we assume they contain UTF-8 encoded text here.
-#cfg(not(platform="windows"))
-priv struct OsString(Bytes)
-
-///|
-#cfg(platform="windows")
-fn OsString::to_string(self : OsString) -> String {
-  self.0
-}
-
-///|
-#cfg(not(platform="windows"))
-fn OsString::to_string(self : OsString) -> String {
-  @utf8.decode_lossy(self.0)
-}
-
-///|
-#cfg(platform="windows")
-fn OsString::from_string(str : String) -> OsString {
-  OsString(str)
-}
-
-///|
-#cfg(not(platform="windows"))
-fn OsString::from_string(str : String) -> OsString {
-  OsString(@utf8.encode(str))
-}
-
-///|
-extern "C" fn get_cli_args_ffi() -> FixedArray[OsString] = "moonbit_rt_get_cli_args"
+extern "C" fn get_cli_args_ffi() -> FixedArray[@os_string.OsString] = "moonbit_rt_get_cli_args"
 
 ///|
 fn get_cli_args_internal() -> Array[String] {
@@ -67,7 +26,7 @@ fn get_cli_args_internal() -> Array[String] {
 extern "c" fn now_internal() -> UInt64 = "moonbit_get_ms_since_epoch"
 
 ///|
-extern "c" fn getcwd() -> OsString = "moonbit_rt_get_current_dir"
+extern "c" fn getcwd() -> @os_string.OsString = "moonbit_rt_get_current_dir"
 
 ///|
 fn current_dir_internal() -> String? {
@@ -83,7 +42,7 @@ fn current_dir_internal() -> String? {
 
 ///|
 fn get_env_var_internal(key : String) -> String? {
-  let key = OsString::from_string(key)
+  let key = @os_string.OsString::from_string(key)
   let exists = @ref.Ref(false)
   let value = get_env_var_ffi(key, exists)
   if exists.val {
@@ -96,9 +55,9 @@ fn get_env_var_internal(key : String) -> String? {
 ///|
 #borrow(key, exists)
 extern "c" fn get_env_var_ffi(
-  key : OsString,
+  key : @os_string.OsString,
   exists : @ref.Ref[Bool],
-) -> OsString = "moonbit_rt_get_env_var"
+) -> @os_string.OsString = "moonbit_rt_get_env_var"
 
 ///|
 fn get_env_vars_internal() -> Map[String, String] {
@@ -111,25 +70,31 @@ fn get_env_vars_internal() -> Map[String, String] {
 }
 
 ///|
-extern "c" fn get_env_vars_ffi() -> FixedArray[OsString] = "moonbit_rt_get_env_vars"
+extern "c" fn get_env_vars_ffi() -> FixedArray[@os_string.OsString] = "moonbit_rt_get_env_vars"
 
 ///|
 fn set_env_var_internal(key : String, value : String) -> Unit {
-  set_env_var_ffi(OsString::from_string(key), OsString::from_string(value))
+  set_env_var_ffi(
+    @os_string.OsString::from_string(key),
+    @os_string.OsString::from_string(value),
+  )
 }
 
 ///|
 #borrow(key, value)
-extern "c" fn set_env_var_ffi(key : OsString, value : OsString) -> Unit = "moonbit_rt_set_env_var"
+extern "c" fn set_env_var_ffi(
+  key : @os_string.OsString,
+  value : @os_string.OsString,
+) -> Unit = "moonbit_rt_set_env_var"
 
 ///|
 fn unset_env_var_internal(key : String) -> Unit {
-  unset_env_var_ffi(OsString::from_string(key))
+  unset_env_var_ffi(@os_string.OsString::from_string(key))
 }
 
 ///|
 #borrow(key)
-extern "c" fn unset_env_var_ffi(key : OsString) -> Unit = "moonbit_rt_unset_env_var"
+extern "c" fn unset_env_var_ffi(key : @os_string.OsString) -> Unit = "moonbit_rt_unset_env_var"
 
 ///|
 fn rand_internal(to_be_filled : FixedArray[Byte]) -> Bool {
@@ -139,7 +104,3 @@ fn rand_internal(to_be_filled : FixedArray[Byte]) -> Bool {
 ///|
 #borrow(to_be_filled)
 extern "c" fn moonbit_rt_get_random(to_be_filled : FixedArray[Byte]) -> Int = "moonbit_rt_get_random"
-
-///|
-#cfg(platform="windows")
-let _supressed_unused_warning_windows : Unit = ignore(@utf8.encode(""))

--- a/env/moon.pkg
+++ b/env/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/ref",
-  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/internal/os_string",
 }
 
 import {

--- a/internal/os_string/moon.pkg
+++ b/internal/os_string/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "moonbitlang/core/builtin",
+  "moonbitlang/core/encoding/utf8",
+}

--- a/internal/os_string/os_string.mbt
+++ b/internal/os_string/os_string.mbt
@@ -19,7 +19,7 @@
 /// which return string in UTF-16 directly,
 /// so no need for extra encoding phase here.
 ///
-/// Note: technically path etc. may not be invalid UTF-16 on Windows,
+/// Note: technically path etc. may be invalid UTF-16 on Windows,
 ///   but this should be extremely rare in practice.
 ///   If we need to fix this case, a validation or encoding phase can be added.
 #cfg(any(not(target="native"), platform="windows"))

--- a/internal/os_string/os_string.mbt
+++ b/internal/os_string/os_string.mbt
@@ -1,0 +1,71 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A string type using native encoding of current operating system.
+///
+/// On Windows, we use native `W` series unicode API,
+/// which return string in UTF-16 directly,
+/// so no need for extra encoding phase here.
+///
+/// Note: technically path etc. may not be invalid UTF-16 on Windows,
+///   but this should be extremely rare in practice.
+///   If we need to fix this case, a validation or encoding phase can be added.
+#cfg(any(not(target="native"), platform="windows"))
+struct OsString(String)
+
+///|
+/// A string type using native encoding of current operating system.
+///
+/// On non-Windows platforms, path etc. are essentially binary data,
+/// and we assume they contain UTF-8 encoded text here.
+#cfg(all(target="native", not(platform="windows")))
+struct OsString(Bytes)
+
+///|
+#cfg(any(not(target="native"), platform="windows"))
+pub impl Show for OsString with fn to_string(self) {
+  self.0
+}
+
+///|
+#cfg(all(target="native", not(platform="windows")))
+pub impl Show for OsString with fn to_string(self) {
+  @utf8.decode_lossy(self.0)
+}
+
+///|
+#deprecated
+pub extend OsString with @builtin.Show::{output}
+
+///|
+pub extend OsString with @builtin.Show::{to_string}
+
+///|
+/// Create a `OsString` from a MoonBit `StringView`
+#cfg(any(not(target="native"), platform="windows"))
+pub fn OsString::from_string(str : StringView) -> OsString {
+  OsString(str.to_owned())
+}
+
+///|
+/// Create a `OsString` from a MoonBit `StringView`
+#cfg(all(target="native", not(platform="windows")))
+pub fn OsString::from_string(str : StringView) -> OsString {
+  OsString(@utf8.encode(str))
+}
+
+///|
+#cfg(any(not(target="native"), platform="windows"))
+let _unused_import : Unit = ignore(@utf8.encode(""))

--- a/internal/os_string/pkg.generated.mbti
+++ b/internal/os_string/pkg.generated.mbti
@@ -1,0 +1,18 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/internal/os_string"
+
+// Values
+
+// Errors
+
+// Types and methods
+type OsString
+pub fn OsString::from_string(StringView) -> Self
+#deprecated
+pub fn OsString::output(Self, &Logger) -> Unit
+pub fn OsString::to_string(Self) -> String
+pub impl Show for OsString
+
+// Type aliases
+
+// Traits


### PR DESCRIPTION
This PR introduce a new internal package `moonbitlang/core/internal/os_string`, which contain string with OS-native encoding. On Linux, `@os_string.OsString` is UTF8-encoded `Bytes`, while on Windows, `@os_string.OsString` is native UTF-16 string. For non-native backends, `@os_string.OsString` is currently just `String`.

Previously, the need for string with OS-native encoding already exist in the `@env` package. This PR lift the private OS string implementation in `@env` to a new internal package, so that other packages can use the OS string abstraction as well in the future. `moonbitlang/async` makes extended use of (its own version of) OS string, so this package would be useful when we gradually merge `moonbitlang/async` into `moonbitlang/core` in the future.