### PR TITLE
deprecate Lexbuf::from_string

### DIFF
--- a/lexbuf/deprecated.mbt
+++ b/lexbuf/deprecated.mbt
@@ -1,0 +1,28 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Creates a lexbuf whose complete input is already available.
+///
+/// Deprecated: use `StringScanner` instead.
+#deprecated("Use `StringScanner` instead")
+pub fn Lexbuf::from_string(content : String) -> Lexbuf {
+  {
+    source: () => None,
+    storage: LexbufStorage::from_string(content),
+    cursor: 0,
+    retained_from: -1,
+    eof: true,
+  }
+}

--- a/lexbuf/lexbuf.mbt
+++ b/lexbuf/lexbuf.mbt
@@ -31,18 +31,6 @@ pub fn Lexbuf::from_fn(source : () -> String?) -> Lexbuf {
 }
 
 ///|
-/// Creates a lexbuf whose complete input is already available.
-pub fn Lexbuf::from_string(content : String) -> Lexbuf {
-  {
-    source: () => None,
-    storage: LexbufStorage::from_string(content),
-    cursor: 0,
-    retained_from: -1,
-    eof: true,
-  }
-}
-
-///|
 /// Compiler protocol: returns the absolute offset of the next code unit.
 /// The cursor must stay in the buffered range. Generated `lexscan` code calls
 /// this when starting a scan and when recording or comparing scan positions.

--- a/lexbuf/lexbuf_test.mbt
+++ b/lexbuf/lexbuf_test.mbt
@@ -45,6 +45,7 @@ test "Lexbuf discards consumed input without retention" {
 }
 
 ///|
+#warnings("-deprecated")
 test "Lexbuf reports source EOF while buffered input remains" {
   let lexbuf = @lexbuf.Lexbuf::from_string("a")
   inspect(lexbuf.__eof_reached(), content="true")
@@ -122,6 +123,7 @@ test "Lexbuf reads multiple chunks after compaction" {
 }
 
 ///|
+#warnings("-deprecated")
 test "Lexbuf returns an empty retained view" {
   let lexbuf = @lexbuf.Lexbuf::from_string("abc")
   lexbuf.__retain_from_cursor()

--- a/lexbuf/panic_test.mbt
+++ b/lexbuf/panic_test.mbt
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 ///|
+#warnings("-deprecated")
 test "panic Lexbuf rejects an unretained view" {
   let lexbuf = @lexbuf.Lexbuf::from_string("a")
   lexbuf.__get_stringview(0, 1) |> ignore
 }
 
 ///|
+#warnings("-deprecated")
 test "panic Lexbuf rejects a commit without retention" {
   let lexbuf = @lexbuf.Lexbuf::from_string("a")
   lexbuf.__commit_to(0)

--- a/lexbuf/pkg.generated.mbti
+++ b/lexbuf/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub struct Lexbuf {
   // private fields
 }
 pub fn Lexbuf::from_fn(() -> String?) -> Self
+#deprecated
 pub fn Lexbuf::from_string(String) -> Self
 
 pub(all) struct StringScanner {


### PR DESCRIPTION
This PR deprecate `Lexbuf::from_string` in favor of `StringScanner`.