### PR TITLE
perf: specialize UInt16 comparisons

### DIFF
--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1740,10 +1740,9 @@ test "View::replace_all boundary cases" {
 /// Helpers for ASCII-only lowercase conversion over UTF-16 code units.
 /// Non-ASCII code units, including surrogate halves, are copied unchanged and
 /// are never converted through `Char`.
-/// Keep the comparison on `Int`: `UInt16` range checks currently introduce
-/// narrowing operations in generated native and Wasm code.
+#inline
 #cfg(not(target="js"))
-fn is_ascii_uppercase_code_unit(code_unit : Int) -> Bool {
+fn is_ascii_uppercase_code_unit(code_unit : UInt16) -> Bool {
   code_unit >= 0x41 && code_unit <= 0x5A
 }
 
@@ -1757,7 +1756,7 @@ fn find_ascii_uppercase_code_unit(
   let end = start + len
   for i in start..<end {
     // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
-    let code_unit = data.unsafe_get(i).to_int()
+    let code_unit = data.unsafe_get(i)
     if is_ascii_uppercase_code_unit(code_unit) {
       return Some(i - start)
     }
@@ -1776,7 +1775,7 @@ fn find_ascii_uppercase_code_unit_simd(
   len : Int,
 ) -> Int? {
   let end = start + len
-  if is_ascii_uppercase_code_unit(data.unsafe_get(start).to_int()) {
+  if is_ascii_uppercase_code_unit(data.unsafe_get(start)) {
     return Some(0)
   }
   let ascii_a = i16x8_splat(0x41)
@@ -1786,7 +1785,7 @@ fn find_ascii_uppercase_code_unit_simd(
     let uppercase_mask = i16x8_le_u(i16x8_sub(code_units, ascii_a), ascii_range)
     if v128_any_true(uppercase_mask) {
       for i in pos..<(pos + 8) {
-        if is_ascii_uppercase_code_unit(data.unsafe_get(i).to_int()) {
+        if is_ascii_uppercase_code_unit(data.unsafe_get(i)) {
           return Some(i - start)
         }
       }
@@ -1796,7 +1795,7 @@ fn find_ascii_uppercase_code_unit_simd(
     pos
   }
   for i in tail_start..<end {
-    if is_ascii_uppercase_code_unit(data.unsafe_get(i).to_int()) {
+    if is_ascii_uppercase_code_unit(data.unsafe_get(i)) {
       return Some(i - start)
     }
   }
@@ -1817,7 +1816,7 @@ fn find_ascii_uppercase_code_unit(
     let end = start + len
     for i in start..<end {
       // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
-      let code_unit = data.unsafe_get(i).to_int()
+      let code_unit = data.unsafe_get(i)
       if is_ascii_uppercase_code_unit(code_unit) {
         return Some(i - start)
       }
@@ -1857,9 +1856,9 @@ fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
     pos
   }
   for i in tail_start..<len {
-    let code_unit = output.unsafe_get(i).to_int()
+    let code_unit = output.unsafe_get(i)
     if is_ascii_uppercase_code_unit(code_unit) {
-      output.unsafe_set(i, (code_unit + 32).to_uint16())
+      output.unsafe_set(i, (code_unit.to_int() + 32).to_uint16())
     }
   }
   unsafe_fixedarray_uint16_to_string(output)
@@ -1878,9 +1877,8 @@ fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
   // Keep `tail.code_units()` directly in the loop so compiler backends can
   // recognize and lower the zero-copy traversal at the use site.
   for i, u in tail.code_units() {
-    let code_unit = u.to_int()
-    if is_ascii_uppercase_code_unit(code_unit) {
-      output.unsafe_set(first_uppercase + i, (code_unit + 32).to_uint16())
+    if is_ascii_uppercase_code_unit(u) {
+      output.unsafe_set(first_uppercase + i, (u.to_int() + 32).to_uint16())
     }
   }
   unsafe_fixedarray_uint16_to_string(output)

--- a/builtin/uint16_char.mbt
+++ b/builtin/uint16_char.mbt
@@ -134,6 +134,18 @@ pub impl Compare for UInt16 with fn compare(self, that) {
 }
 
 ///|
+pub impl Compare for UInt16 with fn op_lt(x, y) = "%i32.lt"
+
+///|
+pub impl Compare for UInt16 with fn op_le(x, y) = "%i32.le"
+
+///|
+pub impl Compare for UInt16 with fn op_gt(x, y) = "%i32.gt"
+
+///|
+pub impl Compare for UInt16 with fn op_ge(x, y) = "%i32.ge"
+
+///|
 pub impl Hash for UInt16 with fn hash_combine(self, hasher) {
   hasher.combine_int(self.to_int())
 }

--- a/uint16/uint16_test.mbt
+++ b/uint16/uint16_test.mbt
@@ -173,6 +173,18 @@ test "UInt16::compare" {
 }
 
 ///|
+test "UInt16 relational operators" {
+  inspect((0 : UInt16) < 65535, content="true")
+  inspect((65535 : UInt16) < 0, content="false")
+  inspect((65535 : UInt16) <= 65535, content="true")
+  inspect((65535 : UInt16) <= 32768, content="false")
+  inspect((65535 : UInt16) > 32768, content="true")
+  inspect((0 : UInt16) > 65535, content="false")
+  inspect((32768 : UInt16) >= 32767, content="true")
+  inspect((32767 : UInt16) >= 32768, content="false")
+}
+
+///|
 test "UInt16::hash" {
   let h1 = Hasher(seed=0)
   h1.combine(0)


### PR DESCRIPTION
## Summary

- specialize `UInt16`'s four relational `Compare` methods with the primitive `%i32.*` intrinsics
- keep #3806's ASCII lowercase scan in `UInt16` and explicitly inline `is_ascii_uppercase_code_unit`
- add boundary coverage for every relational operator, including values above `0x7fff`

Closes #4024.

## Root cause

`UInt16` implemented only `Compare::compare`, so `<`, `<=`, `>`, and `>=` used the generic default methods. Wasm, Wasm-GC, and JavaScript consequently called those defaults and performed extra compare/sign work in hot loops.

`UInt16` values are represented as non-negative `i32`/JavaScript numbers in the range `0...65535`, so the existing signed `i32` comparison intrinsics preserve `UInt16` ordering and can be used directly, as they already are for `Char`.

## Impact

Release codegen for a `UInt16` ASCII range check now contains direct `i32.ge_s` / `i32.le_s` instructions on Wasm and Wasm-GC, direct `>=` / `<=` expressions on JavaScript, and direct comparisons in generated C. The generic `Compare::op_*` calls are gone.

A temporary short no-match scan benchmark (10 samples x 100,000 runs) measured:

| Backend | `main` | This PR | Change |
|---|---:|---:|---:|
| Wasm | 31.18 ns | 22.63 ns | -27.4% |
| Wasm-GC | 15.53 ns | 9.12 ns | -41.3% |
| JavaScript | 13.60 ns | 10.27 ns | -24.5% |
| Native | 8.74 ns | 8.69 ns | effectively unchanged |

Native was already simplified to direct C comparisons, so a material change was not expected there.

## Revisit of #3806

With the specialized comparisons in place, `is_ascii_uppercase_code_unit` now accepts `UInt16`, is marked `#inline`, and its scan call sites no longer convert code units to `Int`. Conversion remains only where lowercase arithmetic needs explicit truncation semantics. The JavaScript character-loop fallback remains unchanged.

I ran #3806's complete 11-case benchmark matrix three times per revision and target, alternating run order, and compared the median reported means. The deltas for the `UInt16` helper versus the current `Int` helper were:

| Backend | Delta range across all 11 cases |
|---|---:|
| Native | -4.7% to +3.2% |
| Wasm | -2.1% to +1.2% |
| Wasm-GC | -1.6% to +2.2% |

The small movements go in both directions and overlap the per-run ranges; there is no systematic regression. Codegen inspection is stronger:

- Wasm-GC's no-change scan loop is instruction-for-instruction identical
- JavaScript's generated benchmark artifact is byte-identical because the fallback is under a separate target configuration
- native and linear Wasm remove redundant temporaries around scalar UTF-16 loads while retaining direct comparisons

The apparent +2.2% Wasm-GC `String::to_lower no-change long` median was also rerun five times per revision. The individual means overlap (baseline 387.08–405.73 ns, `UInt16` 385.62–422.76 ns), and the emitted loop is identical, so this is benchmark noise rather than a codegen regression.

## Validation

- `moon info && moon fmt` (no generated interface changes)
- `moon check --target all --deny-warn`
- `moon test --target all --deny-warn`
  - Wasm: 7,019 passed
  - Wasm-GC: 7,020 passed
  - JavaScript: 6,964 passed
  - Native: 6,938 passed
- `moon test --target all --deny-warn uint16` (35 passed on each backend)
- `moon test --target all --deny-warn builtin/string_methods.mbt` (63 passed on each backend)
- inspected release output for Wasm, Wasm-GC, JavaScript, and native
