### PR TITLE
test: add QuickCheck property tests for HashMap, HashSet, SortedMap, SortedSet

### DIFF
--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -9,4 +9,5 @@ import {
 import {
   "moonbitlang/core/test",
   "moonbitlang/core/json",
+  "moonbitlang/core/quickcheck",
 } for "test"

--- a/hashmap/quickcheck_test.mbt
+++ b/hashmap/quickcheck_test.mbt
@@ -1,0 +1,77 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn model_set(model : Array[(Int, Int)], key : Int, value : Int) -> Unit {
+  for i, entry in model {
+    if entry.0 == key {
+      model[i] = (key, value)
+      return
+    }
+  }
+  model.push((key, value))
+}
+
+///|
+fn model_remove(model : Array[(Int, Int)], key : Int) -> Unit {
+  for i, entry in model {
+    if entry.0 == key {
+      model.remove(i) |> ignore
+      return
+    }
+  }
+}
+
+///|
+fn agrees_with_model(
+  map : @hashmap.HashMap[Int, Int],
+  model : Array[(Int, Int)],
+) -> Bool {
+  if map.length() != model.length() {
+    return false
+  }
+  for entry in model {
+    if map.get(entry.0) != Some(entry.1) {
+      return false
+    }
+  }
+  let actual = map.to_array()
+  actual.sort()
+  let expected = model.copy()
+  expected.sort()
+  actual == expected
+}
+
+///|
+test "quickcheck: mutations agree with an association-array model" {
+  @quickcheck.check((ops : Array[(Int, Int)]) => {
+    let map : @hashmap.HashMap[Int, Int] = HashMap([])
+    let model : Array[(Int, Int)] = []
+    for op in ops {
+      // A small key space deliberately generates replacements and removals.
+      let key = op.0 % 31
+      if op.1 % 4 == 0 {
+        map.remove(key)
+        model_remove(model, key)
+      } else {
+        map.set(key, op.1)
+        model_set(model, key, op.1)
+      }
+      if !agrees_with_model(map, model) {
+        return false
+      }
+    }
+    true
+  })
+}

--- a/hashset/moon.pkg
+++ b/hashset/moon.pkg
@@ -9,4 +9,5 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/core/int",
   "moonbitlang/core/json",
+  "moonbitlang/core/quickcheck",
 } for "test"

--- a/hashset/quickcheck_test.mbt
+++ b/hashset/quickcheck_test.mbt
@@ -1,0 +1,66 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn normalized(xs : Array[Int]) -> Array[Int] {
+  let result : Array[Int] = []
+  for x in xs {
+    let x = x % 47
+    if !result.contains(x) {
+      result.push(x)
+    }
+  }
+  result.sort()
+  result
+}
+
+///|
+test "quickcheck: construction and mutation preserve set semantics" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (inserted, removed) = input
+    let set : @hashset.HashSet[Int] = HashSet([])
+    for x in inserted {
+      set.add(x % 47)
+    }
+    for x in removed {
+      set.remove(x % 47)
+    }
+    let removed = normalized(removed)
+    let expected = normalized(inserted)
+    expected.retain(x => !removed.contains(x))
+    let actual = set.to_array()
+    actual.sort()
+    actual == expected && set.length() == expected.length()
+  })
+}
+
+///|
+test "quickcheck: union, intersection, and difference obey membership laws" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let a = @hashset.from_array(xs.map(x => x % 47))
+    let b = @hashset.from_array(ys.map(x => x % 47))
+    let union = a.union(b)
+    let intersection = a.intersection(b)
+    let difference = a.difference(b)
+    for x in -46..<47 {
+      if union.contains(x) != (a.contains(x) || b.contains(x)) ||
+        intersection.contains(x) != (a.contains(x) && b.contains(x)) ||
+        difference.contains(x) != (a.contains(x) && !b.contains(x)) {
+        return false
+      }
+    }
+    true
+  })
+}

--- a/sorted_map/quickcheck_property_test.mbt
+++ b/sorted_map/quickcheck_property_test.mbt
@@ -1,0 +1,27 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "quickcheck: iteration is ordered and round-trips map contents" {
+  @quickcheck.check((entries : Array[(Int, Int)]) => {
+    let map = @sorted_map.from_array(entries)
+    let actual = map.to_array()
+    for i in 1..<actual.length() {
+      if actual[i - 1].0 >= actual[i].0 {
+        return false
+      }
+    }
+    @sorted_map.from_array(actual) == map
+  })
+}

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -7,5 +7,6 @@ import {
 
 import {
   "moonbitlang/core/array",
+  "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"

--- a/sorted_set/quickcheck_test.mbt
+++ b/sorted_set/quickcheck_test.mbt
@@ -1,0 +1,52 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "quickcheck: iteration is sorted and duplicate-free" {
+  @quickcheck.check((xs : Array[Int]) => {
+    let set = @sorted_set.from_array(xs)
+    let actual = set.to_array()
+    for i in 1..<actual.length() {
+      if actual[i - 1] >= actual[i] {
+        return false
+      }
+    }
+    @sorted_set.from_array(actual) == set
+  })
+}
+
+///|
+test "quickcheck: set operations obey membership laws" {
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let a = @sorted_set.from_array(xs)
+    let b = @sorted_set.from_array(ys)
+    let union = a.union(b)
+    let intersection = a.intersection(b)
+    let difference = a.difference(b)
+    for x in xs {
+      if !union.contains(x) ||
+        intersection.contains(x) != b.contains(x) ||
+        difference.contains(x) == b.contains(x) {
+        return false
+      }
+    }
+    for y in ys {
+      if !union.contains(y) || difference.contains(y) {
+        return false
+      }
+    }
+    true
+  })
+}


### PR DESCRIPTION
### Motivation

- Increase property-based test coverage for built-in collection types to catch regressions and validate invariants under randomized workloads.
- Exercise mutation, iteration, ordering, and set/map operation laws that are tedious or brittle to test with only example-based tests.

### Description

- Added QuickCheck property tests: `hashmap/quickcheck_test.mbt`, `hashset/quickcheck_test.mbt`, `sorted_map/quickcheck_property_test.mbt`, and `sorted_set/quickcheck_test.mbt` that cover model-based mutations, membership laws, ordering, and round-trip properties. 
- Updated package manifests to import `moonbitlang/core/quickcheck` in `hashmap/moon.pkg`, `hashset/moon.pkg`, and `sorted_set/moon.pkg` so the new tests run as part of the package test suites. 
- Implemented lightweight helpers inside tests such as a model-association array check for `HashMap` and a `normalized` helper for `HashSet` to compare expected semantics against the data-structure behavior. 
- Tests focus on `set`/`remove`/`union`/`intersection`/`difference` semantics and iteration-order invariants for sorted collections.

### Testing

- Ran `moon info && moon fmt` and `moon check` successfully with no check errors after fixes. 
- Ran `moon test` for the repository and observed: "Total tests: 7024, passed: 7024, failed: 0." 
- Attempted to create a GitHub PR via `gh pr create` but PR creation could not proceed because this environment lacks GitHub authentication or a configured remote; the branch with the changes is ready to push and open a PR once credentials/remotes are provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7eb7e4df1883209b1423d330c8aafe)