### PR TITLE
refactor(string): inline ASCII uppercase patterns

### DIFF
--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -1737,16 +1737,6 @@ test "View::replace_all boundary cases" {
 }
 
 ///|
-/// Helpers for ASCII-only lowercase conversion over UTF-16 code units.
-/// Non-ASCII code units, including surrogate halves, are copied unchanged and
-/// are never converted through `Char`.
-#inline
-#cfg(not(target="js"))
-fn is_ascii_uppercase_code_unit(code_unit : UInt16) -> Bool {
-  code_unit >= 0x41 && code_unit <= 0x5A
-}
-
-///|
 #cfg(not(any(target="js", target="native", target="wasm")))
 fn find_ascii_uppercase_code_unit(
   data : String,
@@ -1757,7 +1747,7 @@ fn find_ascii_uppercase_code_unit(
   for i in start..<end {
     // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
     let code_unit = data.unsafe_get(i)
-    if is_ascii_uppercase_code_unit(code_unit) {
+    if code_unit is ('A'..='Z') {
       return Some(i - start)
     }
   }
@@ -1775,7 +1765,7 @@ fn find_ascii_uppercase_code_unit_simd(
   len : Int,
 ) -> Int? {
   let end = start + len
-  if is_ascii_uppercase_code_unit(data.unsafe_get(start)) {
+  if data.unsafe_get(start) is ('A'..='Z') {
     return Some(0)
   }
   let ascii_a = i16x8_splat(0x41)
@@ -1785,7 +1775,7 @@ fn find_ascii_uppercase_code_unit_simd(
     let uppercase_mask = i16x8_le_u(i16x8_sub(code_units, ascii_a), ascii_range)
     if v128_any_true(uppercase_mask) {
       for i in pos..<(pos + 8) {
-        if is_ascii_uppercase_code_unit(data.unsafe_get(i)) {
+        if data.unsafe_get(i) is ('A'..='Z') {
           return Some(i - start)
         }
       }
@@ -1795,7 +1785,7 @@ fn find_ascii_uppercase_code_unit_simd(
     pos
   }
   for i in tail_start..<end {
-    if is_ascii_uppercase_code_unit(data.unsafe_get(i)) {
+    if data.unsafe_get(i) is ('A'..='Z') {
       return Some(i - start)
     }
   }
@@ -1817,7 +1807,7 @@ fn find_ascii_uppercase_code_unit(
     for i in start..<end {
       // SAFETY: i stays within the caller-provided UTF-16 slice bounds.
       let code_unit = data.unsafe_get(i)
-      if is_ascii_uppercase_code_unit(code_unit) {
+      if code_unit is ('A'..='Z') {
         return Some(i - start)
       }
     }
@@ -1857,7 +1847,7 @@ fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
   }
   for i in tail_start..<len {
     let code_unit = output.unsafe_get(i)
-    if is_ascii_uppercase_code_unit(code_unit) {
+    if code_unit is ('A'..='Z') {
       output.unsafe_set(i, (code_unit.to_int() + 32).to_uint16())
     }
   }
@@ -1877,7 +1867,7 @@ fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
   // Keep `tail.code_units()` directly in the loop so compiler backends can
   // recognize and lower the zero-copy traversal at the use site.
   for i, u in tail.code_units() {
-    if is_ascii_uppercase_code_unit(u) {
+    if u is ('A'..='Z') {
       output.unsafe_set(first_uppercase + i, (u.to_int() + 32).to_uint16())
     }
   }


### PR DESCRIPTION
## Summary

- remove `is_ascii_uppercase_code_unit`
- use the `UInt16`-overloaded `x is ('A'..='Z')` pattern directly at scalar scan and patch sites
- keep the JavaScript backend fallback unchanged

## Why

The range pattern resolves from its `UInt16` scrutinee, so the character bounds use the intended overload. Direct call-site patterns are also important here: codegen inspection showed that `#inline` on the helper was only a hint and the range-pattern helper remained as a call on some backends.

## Codegen verification

- no `is_ascii_uppercase_code_unit` symbol remains in release Wasm, Wasm-GC, or native output
- Wasm and Wasm-GC lower the checks directly to integer `ge`/`le` comparisons
- native C lowers them directly to `>= 65 && <= 90`

## Validation

- `moon check --target all --deny-warn`
- `moon test --target all --deny-warn builtin/string_methods.mbt` (63/63 on Wasm, Wasm-GC, JavaScript, and native)
- `moon info && moon fmt` (no interface change)
- the 11-case lowercase benchmark completes on native, Wasm, and Wasm-GC

Follow-up to #3806 and #4025.