### PR TITLE
perf(buffer): elide redundant bounds checks on guarded append paths

### DIFF
--- a/buffer/buffer.mbt
+++ b/buffer/buffer.mbt
@@ -195,12 +195,16 @@ pub fn from_bytes(bytes : BytesView) -> Buffer {
 /// Create a buffer from an array.
 pub fn from_array(arr : ArrayView[Byte]) -> Buffer {
   let buf = Buffer(size_hint=arr.length())
+  // Inline write_byte because the exact capacity is known.
+  // SAFETY: the buffer was sized for `arr.length()` bytes, so every index
+  // below stays within `data`.
+  let data = buf.data
+  let mut len = buf.len
   for byte in arr {
-    // Inline write_byte because the exact capacity is known.
-    // SAFETY: known array size
-    buf.data[buf.len] = byte
-    buf.len += 1
+    data.unsafe_set(len, byte)
+    len += 1
   }
+  buf.len = len
   buf
 }
 
@@ -216,7 +220,9 @@ pub fn from_iter(iter : Iter[Byte]) -> Buffer {
     } else {
       capacity
     }
-    buf.data[buf.len] = byte
+    // SAFETY: `capacity` tracks `data.length()` and the branch above ensures
+    // `len < capacity`.
+    buf.data.unsafe_set(buf.len, byte)
     buf.len += 1
     continue capacity
   }
@@ -275,15 +281,17 @@ pub fn Buffer::write_uint64_be(self : Buffer, value : UInt64) -> Unit {
   if self.data.length() - self.len < 8 {
     self.grow(self.len + 8)
   }
+  // SAFETY: the guard above reserves 8 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = (value >> 56).to_byte()
-  self.data[offset + 1] = (value >> 48).to_byte()
-  self.data[offset + 2] = (value >> 40).to_byte()
-  self.data[offset + 3] = (value >> 32).to_byte()
-  self.data[offset + 4] = (value >> 24).to_byte()
-  self.data[offset + 5] = (value >> 16).to_byte()
-  self.data[offset + 6] = (value >> 8).to_byte()
-  self.data[offset + 7] = value.to_byte()
+  data.unsafe_set(offset, (value >> 56).to_byte())
+  data.unsafe_set(offset + 1, (value >> 48).to_byte())
+  data.unsafe_set(offset + 2, (value >> 40).to_byte())
+  data.unsafe_set(offset + 3, (value >> 32).to_byte())
+  data.unsafe_set(offset + 4, (value >> 24).to_byte())
+  data.unsafe_set(offset + 5, (value >> 16).to_byte())
+  data.unsafe_set(offset + 6, (value >> 8).to_byte())
+  data.unsafe_set(offset + 7, value.to_byte())
   self.len += 8
 }
 
@@ -314,15 +322,17 @@ pub fn Buffer::write_uint64_le(self : Buffer, value : UInt64) -> Unit {
   if self.data.length() - self.len < 8 {
     self.grow(self.len + 8)
   }
+  // SAFETY: the guard above reserves 8 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = value.to_byte()
-  self.data[offset + 1] = (value >> 8).to_byte()
-  self.data[offset + 2] = (value >> 16).to_byte()
-  self.data[offset + 3] = (value >> 24).to_byte()
-  self.data[offset + 4] = (value >> 32).to_byte()
-  self.data[offset + 5] = (value >> 40).to_byte()
-  self.data[offset + 6] = (value >> 48).to_byte()
-  self.data[offset + 7] = (value >> 56).to_byte()
+  data.unsafe_set(offset, value.to_byte())
+  data.unsafe_set(offset + 1, (value >> 8).to_byte())
+  data.unsafe_set(offset + 2, (value >> 16).to_byte())
+  data.unsafe_set(offset + 3, (value >> 24).to_byte())
+  data.unsafe_set(offset + 4, (value >> 32).to_byte())
+  data.unsafe_set(offset + 5, (value >> 40).to_byte())
+  data.unsafe_set(offset + 6, (value >> 48).to_byte())
+  data.unsafe_set(offset + 7, (value >> 56).to_byte())
   self.len += 8
 }
 
@@ -406,11 +416,13 @@ pub fn Buffer::write_uint_be(self : Buffer, value : UInt) -> Unit {
   if self.data.length() - self.len < 4 {
     self.grow(self.len + 4)
   }
+  // SAFETY: the guard above reserves 4 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = (value >> 24).to_byte()
-  self.data[offset + 1] = (value >> 16).to_byte()
-  self.data[offset + 2] = (value >> 8).to_byte()
-  self.data[offset + 3] = value.to_byte()
+  data.unsafe_set(offset, (value >> 24).to_byte())
+  data.unsafe_set(offset + 1, (value >> 16).to_byte())
+  data.unsafe_set(offset + 2, (value >> 8).to_byte())
+  data.unsafe_set(offset + 3, value.to_byte())
   self.len += 4
 }
 
@@ -442,11 +454,13 @@ pub fn Buffer::write_uint_le(self : Buffer, value : UInt) -> Unit {
   if self.data.length() - self.len < 4 {
     self.grow(self.len + 4)
   }
+  // SAFETY: the guard above reserves 4 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = value.to_byte()
-  self.data[offset + 1] = (value >> 8).to_byte()
-  self.data[offset + 2] = (value >> 16).to_byte()
-  self.data[offset + 3] = (value >> 24).to_byte()
+  data.unsafe_set(offset, value.to_byte())
+  data.unsafe_set(offset + 1, (value >> 8).to_byte())
+  data.unsafe_set(offset + 2, (value >> 16).to_byte())
+  data.unsafe_set(offset + 3, (value >> 24).to_byte())
   self.len += 4
 }
 
@@ -527,9 +541,11 @@ pub fn Buffer::write_uint16_be(self : Buffer, value : UInt16) -> Unit {
   if self.data.length() - self.len < 2 {
     self.grow(self.len + 2)
   }
+  // SAFETY: the guard above reserves 2 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = (value.to_int() >> 8).to_byte()
-  self.data[offset + 1] = value.to_byte()
+  data.unsafe_set(offset, (value.to_int() >> 8).to_byte())
+  data.unsafe_set(offset + 1, value.to_byte())
   self.len += 2
 }
 
@@ -561,9 +577,11 @@ pub fn Buffer::write_uint16_le(self : Buffer, value : UInt16) -> Unit {
   if self.data.length() - self.len < 2 {
     self.grow(self.len + 2)
   }
+  // SAFETY: the guard above reserves 2 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = value.to_byte()
-  self.data[offset + 1] = (value.to_int() >> 8).to_byte()
+  data.unsafe_set(offset, value.to_byte())
+  data.unsafe_set(offset + 1, (value.to_int() >> 8).to_byte())
   self.len += 2
 }
 
@@ -594,9 +612,11 @@ pub fn Buffer::write_int16_be(self : Buffer, value : Int16) -> Unit {
   if self.data.length() - self.len < 2 {
     self.grow(self.len + 2)
   }
+  // SAFETY: the guard above reserves 2 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = (value.to_int() >> 8).to_byte()
-  self.data[offset + 1] = value.to_byte()
+  data.unsafe_set(offset, (value.to_int() >> 8).to_byte())
+  data.unsafe_set(offset + 1, value.to_byte())
   self.len += 2
 }
 
@@ -627,9 +647,11 @@ pub fn Buffer::write_int16_le(self : Buffer, value : Int16) -> Unit {
   if self.data.length() - self.len < 2 {
     self.grow(self.len + 2)
   }
+  // SAFETY: the guard above reserves 2 bytes at `len`.
+  let data = self.data
   let offset = self.len
-  self.data[offset] = value.to_byte()
-  self.data[offset + 1] = (value.to_int() >> 8).to_byte()
+  data.unsafe_set(offset, value.to_byte())
+  data.unsafe_set(offset + 1, (value.to_int() >> 8).to_byte())
   self.len += 2
 }
 
@@ -861,34 +883,44 @@ pub fn Buffer::write_char_utf8(buf : Self, value : Char) -> Unit {
       if buf.len >= buf.data.length() {
         buf.grow(buf.len + 1)
       }
-      buf.data[buf.len] = ((code & 0x7F) | 0x00).to_byte()
+      // SAFETY: the guard above reserves 1 byte at `len`.
+      buf.data.unsafe_set(buf.len, ((code & 0x7F) | 0x00).to_byte())
       buf.len += 1
     }
     _..<0x0800 => {
       if buf.data.length() - buf.len < 2 {
         buf.grow(buf.len + 2)
       }
-      buf.data[buf.len] = (((code >> 6) & 0x1F) | 0xC0).to_byte()
-      buf.data[buf.len + 1] = ((code & 0x3F) | 0x80).to_byte()
+      // SAFETY: the guard above reserves 2 bytes at `len`.
+      let data = buf.data
+      let offset = buf.len
+      data.unsafe_set(offset, (((code >> 6) & 0x1F) | 0xC0).to_byte())
+      data.unsafe_set(offset + 1, ((code & 0x3F) | 0x80).to_byte())
       buf.len += 2
     }
     _..<0x010000 => {
       if buf.data.length() - buf.len < 3 {
         buf.grow(buf.len + 3)
       }
-      buf.data[buf.len] = (((code >> 12) & 0x0F) | 0xE0).to_byte()
-      buf.data[buf.len + 1] = (((code >> 6) & 0x3F) | 0x80).to_byte()
-      buf.data[buf.len + 2] = ((code & 0x3F) | 0x80).to_byte()
+      // SAFETY: the guard above reserves 3 bytes at `len`.
+      let data = buf.data
+      let offset = buf.len
+      data.unsafe_set(offset, (((code >> 12) & 0x0F) | 0xE0).to_byte())
+      data.unsafe_set(offset + 1, (((code >> 6) & 0x3F) | 0x80).to_byte())
+      data.unsafe_set(offset + 2, ((code & 0x3F) | 0x80).to_byte())
       buf.len += 3
     }
     _..<0x110000 => {
       if buf.data.length() - buf.len < 4 {
         buf.grow(buf.len + 4)
       }
-      buf.data[buf.len] = (((code >> 18) & 0x07) | 0xF0).to_byte()
-      buf.data[buf.len + 1] = (((code >> 12) & 0x3F) | 0x80).to_byte()
-      buf.data[buf.len + 2] = (((code >> 6) & 0x3F) | 0x80).to_byte()
-      buf.data[buf.len + 3] = ((code & 0x3F) | 0x80).to_byte()
+      // SAFETY: the guard above reserves 4 bytes at `len`.
+      let data = buf.data
+      let offset = buf.len
+      data.unsafe_set(offset, (((code >> 18) & 0x07) | 0xF0).to_byte())
+      data.unsafe_set(offset + 1, (((code >> 12) & 0x3F) | 0x80).to_byte())
+      data.unsafe_set(offset + 2, (((code >> 6) & 0x3F) | 0x80).to_byte())
+      data.unsafe_set(offset + 3, ((code & 0x3F) | 0x80).to_byte())
       buf.len += 4
     }
     _ => abort("Char out of range")
@@ -903,8 +935,11 @@ pub fn Buffer::write_char_utf16le(buf : Self, value : Char) -> Unit {
     if buf.data.length() - buf.len < 2 {
       buf.grow(buf.len + 2)
     }
-    buf.data[buf.len + 0] = (code & 0xFF).to_byte()
-    buf.data[buf.len + 1] = (code >> 8).to_byte()
+    // SAFETY: the guard above reserves 2 bytes at `len`.
+    let data = buf.data
+    let offset = buf.len
+    data.unsafe_set(offset, (code & 0xFF).to_byte())
+    data.unsafe_set(offset + 1, (code >> 8).to_byte())
     buf.len += 2
   } else if code < 0x110000 {
     let cp = code - 0x10000
@@ -913,10 +948,13 @@ pub fn Buffer::write_char_utf16le(buf : Self, value : Char) -> Unit {
     if buf.data.length() - buf.len < 4 {
       buf.grow(buf.len + 4)
     }
-    buf.data[buf.len + 0] = (high & 0xFF).to_byte()
-    buf.data[buf.len + 1] = (high >> 8).to_byte()
-    buf.data[buf.len + 2] = (low & 0xFF).to_byte()
-    buf.data[buf.len + 3] = (low >> 8).to_byte()
+    // SAFETY: the guard above reserves 4 bytes at `len`.
+    let data = buf.data
+    let offset = buf.len
+    data.unsafe_set(offset, (high & 0xFF).to_byte())
+    data.unsafe_set(offset + 1, (high >> 8).to_byte())
+    data.unsafe_set(offset + 2, (low & 0xFF).to_byte())
+    data.unsafe_set(offset + 3, (low >> 8).to_byte())
     buf.len += 4
   } else {
     abort("Char out of range")
@@ -931,8 +969,11 @@ pub fn Buffer::write_char_utf16be(buf : Self, value : Char) -> Unit {
     if buf.data.length() - buf.len < 2 {
       buf.grow(buf.len + 2)
     }
-    buf.data[buf.len + 0] = (code >> 8).to_byte()
-    buf.data[buf.len + 1] = (code & 0xFF).to_byte()
+    // SAFETY: the guard above reserves 2 bytes at `len`.
+    let data = buf.data
+    let offset = buf.len
+    data.unsafe_set(offset, (code >> 8).to_byte())
+    data.unsafe_set(offset + 1, (code & 0xFF).to_byte())
     buf.len += 2
   } else if code < 0x110000 {
     if buf.data.length() - buf.len < 4 {
@@ -941,10 +982,13 @@ pub fn Buffer::write_char_utf16be(buf : Self, value : Char) -> Unit {
     let cp = code - 0x10000
     let high = (cp >> 10) | 0xD800
     let low = (cp & 0x3FF) | 0xDC00
-    buf.data[buf.len + 0] = (high >> 8).to_byte()
-    buf.data[buf.len + 1] = (high & 0xFF).to_byte()
-    buf.data[buf.len + 2] = (low >> 8).to_byte()
-    buf.data[buf.len + 3] = (low & 0xFF).to_byte()
+    // SAFETY: the guard above reserves 4 bytes at `len`.
+    let data = buf.data
+    let offset = buf.len
+    data.unsafe_set(offset, (high >> 8).to_byte())
+    data.unsafe_set(offset + 1, (high & 0xFF).to_byte())
+    data.unsafe_set(offset + 2, (low >> 8).to_byte())
+    data.unsafe_set(offset + 3, (low & 0xFF).to_byte())
     buf.len += 4
   } else {
     abort("Char out of range")
@@ -998,10 +1042,13 @@ pub fn Buffer::write_string_utf16le(buf : Self, string : StringView) -> Unit {
   if required > buf.data.length() || required < buf.len {
     buf.grow(required)
   }
+  // SAFETY: the guard above reserves `len * 2` bytes at `buf.len`, and
+  // `code_units()` yields exactly `len` code units.
+  let data = buf.data
   for code_unit in string.code_units(); j = buf.len {
     let c = code_unit.to_int().reinterpret_as_uint()
-    buf.data[j] = (c & 0xff).to_byte()
-    buf.data[j + 1] = (c >> 8).to_byte()
+    data.unsafe_set(j, (c & 0xff).to_byte())
+    data.unsafe_set(j + 1, (c >> 8).to_byte())
     continue j + 2
   }
   buf.len += len * 2
@@ -1030,10 +1077,13 @@ pub fn Buffer::write_string_utf16be(buf : Self, string : StringView) -> Unit {
   if required > buf.data.length() || required < buf.len {
     buf.grow(required)
   }
+  // SAFETY: the guard above reserves `len * 2` bytes at `buf.len`, and
+  // `code_units()` yields exactly `len` code units.
+  let data = buf.data
   for code_unit in string.code_units(); j = buf.len {
     let c = code_unit.to_int().reinterpret_as_uint()
-    buf.data[j + 1] = (c & 0xff).to_byte()
-    buf.data[j] = (c >> 8).to_byte()
+    data.unsafe_set(j + 1, (c & 0xff).to_byte())
+    data.unsafe_set(j, (c >> 8).to_byte())
     continue j + 2
   }
   buf.len += len * 2
@@ -1105,7 +1155,9 @@ pub fn Buffer::write_byte(self : Buffer, value : Byte) -> Unit {
   if self.len >= self.data.length() {
     self.grow(self.len + 1)
   }
-  self.data[self.len] = value
+  // SAFETY: the guard above restores `len < data.length()`, and the buffer
+  // invariant keeps `len >= 0`.
+  self.data.unsafe_set(self.len, value)
   self.len += 1
 }
 

--- a/buffer/moon.pkg
+++ b/buffer/moon.pkg
@@ -8,6 +8,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/int",
   "moonbitlang/core/test",
 } for "test"

--- a/buffer/write_bench_test.mbt
+++ b/buffer/write_bench_test.mbt
@@ -17,6 +17,10 @@
 /// closure and rewound with `reset()`, so each run measures only the append
 /// loop: `Buffer(size_hint=n)` would otherwise charge every run a malloc plus
 /// a zero-fill of the whole capacity, on freshly handed-back memory.
+///
+/// Each run keeps the buffer itself rather than `buf.length()`: the length is
+/// derivable from the fixed loop bounds, so keeping only that would let the
+/// backend prove the byte stores unobservable and drop the loop under test.
 let buffer_bench_repeats = 4096
 
 ///|
@@ -30,7 +34,7 @@ test "bench Buffer::write_byte n=4096" (it : @bench.T) {
     for i in 0..<buffer_bench_repeats {
       buf.write_byte(i.to_byte())
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -42,7 +46,7 @@ test "bench Buffer::write_uint16_be n=4096" (it : @bench.T) {
     for i in 0..<buffer_bench_repeats {
       buf.write_uint16_be(i.to_uint16())
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -54,7 +58,7 @@ test "bench Buffer::write_uint_le n=4096" (it : @bench.T) {
     for i in 0..<buffer_bench_repeats {
       buf.write_uint_le(i.reinterpret_as_uint())
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -66,7 +70,7 @@ test "bench Buffer::write_uint64_be n=4096" (it : @bench.T) {
     for i in 0..<buffer_bench_repeats {
       buf.write_uint64_be(i.to_uint64())
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -78,7 +82,7 @@ test "bench Buffer::write_char_utf8 ASCII n=4096" (it : @bench.T) {
     for _ in 0..<buffer_bench_repeats {
       buf.write_char_utf8('x')
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -91,7 +95,7 @@ test "bench Buffer::write_char_utf8 non-BMP n=4096" (it : @bench.T) {
     for _ in 0..<buffer_bench_repeats {
       buf.write_char_utf8(ch)
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -103,7 +107,7 @@ test "bench Buffer::write_char_utf16le BMP n=4096" (it : @bench.T) {
     for _ in 0..<buffer_bench_repeats {
       buf.write_char_utf16le('x')
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -116,7 +120,7 @@ test "bench Buffer::write_string_utf16le chunks n=4096" (it : @bench.T) {
     for _ in 0..<buffer_bench_repeats {
       buf.write_string_utf16le(piece)
     }
-    it.keep(buf.length())
+    it.keep(buf)
   })
 }
 
@@ -126,8 +130,6 @@ test "bench Buffer::write_string_utf16le chunks n=4096" (it : @bench.T) {
 test "bench @buffer.from_array n=4096" (it : @bench.T) {
   let arr = Array::makei(buffer_bench_repeats, i => i.to_byte())
   it.bench(fn() {
-    // Keep the buffer itself: keeping only `length()` lets the backend prove
-    // the copied bytes are dead and drop the loop entirely.
     let buf = @buffer.from_array(arr)
     it.keep(buf)
   })

--- a/buffer/write_bench_test.mbt
+++ b/buffer/write_bench_test.mbt
@@ -1,0 +1,123 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Append-path benchmarks. Every buffer is created with an exact `size_hint` so
+/// the measured loop stays on the fast path and does not pay for growth.
+let buffer_bench_repeats = 4096
+
+///|
+let buffer_bench_piece = "abcdefghijklmnop"
+
+///|
+test "bench Buffer::write_byte n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    let buf = Buffer(size_hint=buffer_bench_repeats)
+    for i in 0..<buffer_bench_repeats {
+      buf.write_byte(i.to_byte())
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench Buffer::write_uint16_be n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    let buf = Buffer(size_hint=buffer_bench_repeats * 2)
+    for i in 0..<buffer_bench_repeats {
+      buf.write_uint16_be(i.to_uint16())
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench Buffer::write_uint_le n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    let buf = Buffer(size_hint=buffer_bench_repeats * 4)
+    for i in 0..<buffer_bench_repeats {
+      buf.write_uint_le(i.reinterpret_as_uint())
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench Buffer::write_uint64_be n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    let buf = Buffer(size_hint=buffer_bench_repeats * 8)
+    for i in 0..<buffer_bench_repeats {
+      buf.write_uint64_be(i.to_uint64())
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench Buffer::write_char_utf8 ASCII n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    let buf = Buffer(size_hint=buffer_bench_repeats)
+    for _ in 0..<buffer_bench_repeats {
+      buf.write_char_utf8('x')
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench Buffer::write_char_utf8 non-BMP n=4096" (it : @bench.T) {
+  let ch = (0x1F923).unsafe_to_char()
+  it.bench(fn() {
+    let buf = Buffer(size_hint=buffer_bench_repeats * 4)
+    for _ in 0..<buffer_bench_repeats {
+      buf.write_char_utf8(ch)
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench Buffer::write_char_utf16le BMP n=4096" (it : @bench.T) {
+  it.bench(fn() {
+    let buf = Buffer(size_hint=buffer_bench_repeats * 2)
+    for _ in 0..<buffer_bench_repeats {
+      buf.write_char_utf16le('x')
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench Buffer::write_string_utf16le chunks n=4096" (it : @bench.T) {
+  let piece = buffer_bench_piece
+  let size_hint = piece.length() * buffer_bench_repeats * 2
+  it.bench(fn() {
+    let buf = Buffer(size_hint~)
+    for _ in 0..<buffer_bench_repeats {
+      buf.write_string_utf16le(piece)
+    }
+    it.keep(buf.length())
+  })
+}
+
+///|
+test "bench @buffer.from_array n=4096" (it : @bench.T) {
+  let arr = Array::makei(buffer_bench_repeats, i => i.to_byte())
+  it.bench(fn() {
+    // Keep the buffer itself: keeping only `length()` lets the backend prove
+    // the copied bytes are dead and drop the loop entirely.
+    let buf = @buffer.from_array(arr)
+    it.keep(buf)
+  })
+}

--- a/buffer/write_bench_test.mbt
+++ b/buffer/write_bench_test.mbt
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 ///|
-/// Append-path benchmarks. Every buffer is created with an exact `size_hint` so
-/// the measured loop stays on the fast path and does not pay for growth.
+/// Append-path benchmarks. The buffer is allocated once outside the timed
+/// closure and rewound with `reset()`, so each run measures only the append
+/// loop: `Buffer(size_hint=n)` would otherwise charge every run a malloc plus
+/// a zero-fill of the whole capacity, on freshly handed-back memory.
 let buffer_bench_repeats = 4096
 
 ///|
@@ -22,8 +24,9 @@ let buffer_bench_piece = "abcdefghijklmnop"
 
 ///|
 test "bench Buffer::write_byte n=4096" (it : @bench.T) {
+  let buf = Buffer(size_hint=buffer_bench_repeats)
   it.bench(fn() {
-    let buf = Buffer(size_hint=buffer_bench_repeats)
+    buf.reset()
     for i in 0..<buffer_bench_repeats {
       buf.write_byte(i.to_byte())
     }
@@ -33,8 +36,9 @@ test "bench Buffer::write_byte n=4096" (it : @bench.T) {
 
 ///|
 test "bench Buffer::write_uint16_be n=4096" (it : @bench.T) {
+  let buf = Buffer(size_hint=buffer_bench_repeats * 2)
   it.bench(fn() {
-    let buf = Buffer(size_hint=buffer_bench_repeats * 2)
+    buf.reset()
     for i in 0..<buffer_bench_repeats {
       buf.write_uint16_be(i.to_uint16())
     }
@@ -44,8 +48,9 @@ test "bench Buffer::write_uint16_be n=4096" (it : @bench.T) {
 
 ///|
 test "bench Buffer::write_uint_le n=4096" (it : @bench.T) {
+  let buf = Buffer(size_hint=buffer_bench_repeats * 4)
   it.bench(fn() {
-    let buf = Buffer(size_hint=buffer_bench_repeats * 4)
+    buf.reset()
     for i in 0..<buffer_bench_repeats {
       buf.write_uint_le(i.reinterpret_as_uint())
     }
@@ -55,8 +60,9 @@ test "bench Buffer::write_uint_le n=4096" (it : @bench.T) {
 
 ///|
 test "bench Buffer::write_uint64_be n=4096" (it : @bench.T) {
+  let buf = Buffer(size_hint=buffer_bench_repeats * 8)
   it.bench(fn() {
-    let buf = Buffer(size_hint=buffer_bench_repeats * 8)
+    buf.reset()
     for i in 0..<buffer_bench_repeats {
       buf.write_uint64_be(i.to_uint64())
     }
@@ -66,8 +72,9 @@ test "bench Buffer::write_uint64_be n=4096" (it : @bench.T) {
 
 ///|
 test "bench Buffer::write_char_utf8 ASCII n=4096" (it : @bench.T) {
+  let buf = Buffer(size_hint=buffer_bench_repeats)
   it.bench(fn() {
-    let buf = Buffer(size_hint=buffer_bench_repeats)
+    buf.reset()
     for _ in 0..<buffer_bench_repeats {
       buf.write_char_utf8('x')
     }
@@ -78,8 +85,9 @@ test "bench Buffer::write_char_utf8 ASCII n=4096" (it : @bench.T) {
 ///|
 test "bench Buffer::write_char_utf8 non-BMP n=4096" (it : @bench.T) {
   let ch = (0x1F923).unsafe_to_char()
+  let buf = Buffer(size_hint=buffer_bench_repeats * 4)
   it.bench(fn() {
-    let buf = Buffer(size_hint=buffer_bench_repeats * 4)
+    buf.reset()
     for _ in 0..<buffer_bench_repeats {
       buf.write_char_utf8(ch)
     }
@@ -89,8 +97,9 @@ test "bench Buffer::write_char_utf8 non-BMP n=4096" (it : @bench.T) {
 
 ///|
 test "bench Buffer::write_char_utf16le BMP n=4096" (it : @bench.T) {
+  let buf = Buffer(size_hint=buffer_bench_repeats * 2)
   it.bench(fn() {
-    let buf = Buffer(size_hint=buffer_bench_repeats * 2)
+    buf.reset()
     for _ in 0..<buffer_bench_repeats {
       buf.write_char_utf16le('x')
     }
@@ -101,9 +110,9 @@ test "bench Buffer::write_char_utf16le BMP n=4096" (it : @bench.T) {
 ///|
 test "bench Buffer::write_string_utf16le chunks n=4096" (it : @bench.T) {
   let piece = buffer_bench_piece
-  let size_hint = piece.length() * buffer_bench_repeats * 2
+  let buf = Buffer(size_hint=piece.length() * buffer_bench_repeats * 2)
   it.bench(fn() {
-    let buf = Buffer(size_hint~)
+    buf.reset()
     for _ in 0..<buffer_bench_repeats {
       buf.write_string_utf16le(piece)
     }
@@ -112,6 +121,8 @@ test "bench Buffer::write_string_utf16le chunks n=4096" (it : @bench.T) {
 }
 
 ///|
+/// Unlike the benchmarks above this one necessarily includes the allocation:
+/// allocating and filling the buffer is what `from_array` does.
 test "bench @buffer.from_array n=4096" (it : @bench.T) {
   let arr = Array::makei(buffer_bench_repeats, i => i.to_byte())
   it.bench(fn() {


### PR DESCRIPTION
## What

Every append in `Buffer` already guards capacity before writing, but the indexed writes that follow still emit a full `idx < 0 || idx >= len` check plus a panic branch — the compiler does not propagate the guard. Generated C for `write_byte`, before:

```c
_M0L4dataS6243 = self->$0;
_M0L3lenS6244  = self->$1;
if (_M0L3lenS6244 < 0 || _M0L3lenS6244 >= Moonbit_array_length(_M0L4dataS6243)) {
  moonbit_panic();
}
_M0L4dataS6243[_M0L3lenS6244] = value;
```

This replaces those writes with `FixedArray::unsafe_set` in the 15 encoders where a preceding guard establishes the bound, and hoists `data`/`offset` into locals so each function loads the fields once instead of per byte. `uleb128.mbt` / `sleb128.mbt` already used this pattern.

| function | writes per call | guard |
| --- | --- | --- |
| `write_uint64_be` / `_le` | 8 | `data.length() - len < 8` |
| `write_uint_be` / `_le` | 4 | `data.length() - len < 4` |
| `write_uint16_be` / `_le`, `write_int16_be` / `_le` | 2 | `data.length() - len < 2` |
| `write_byte` | 1 | `len >= data.length()` |
| `write_char_utf8` | 1–4 | per-branch reserve |
| `write_char_utf16le` / `_be` | 2 or 4 | per-branch reserve |
| `write_string_utf16le` / `_be` | 2 per code unit | `required = len + n*2` |
| `from_array`, `from_iter` | 1 per element | exact capacity / loop-carried capacity |

Bulk `blit_*` calls and the `data[0:len]` slices in `contents()` / `to_bytesview()` are untouched. No public API change — `pkg.generated.mbti` is unchanged.

## Safety

Each site rests on the documented buffer invariant `0 <= len <= data.length()`:

- the guard leaves `len + k < data.length()` for every `k` written;
- `grow` aborts through `buffer_growth_capacity` when the size computation overflows, so a negative `required` can never reach a write;
- `write_string_utf16le` / `_be` additionally rely on `code_units()` yielding exactly `length()` items (`length() == end - start`), which is what `required` reserves.

## Effect on generated code

Native release, `buffer.blackbox_test.c`, across the 35 emitted `Buffer` functions:

| | before | after |
| --- | --- | --- |
| `moonbit_panic()` sites | 59 | 0 |
| total function body size | 2005 lines | 1492 lines |

Per function: `write_uint64_be` 8 panics / 167 lines → 0 / 97; `write_char_utf8` 10 / 301 → 0 / 207; `write_uint16_le` 2 / 57 → 0 / 41. The remaining `Moonbit_array_length` calls are the capacity guards themselves.

At the machine-code level: both builds inline `write_char_utf8` and `write_byte` into their callers, so the loop that actually runs is the inlined one. Per iteration it goes from 13 instructions to 9 for the `write_char_utf8` ASCII branch (the `tbnz` / `ldur` / `cmp` / `b.ge` check disappears), and from 14 to 10 for `write_byte`.

## Benchmarks

New file `buffer/write_bench_test.mbt`. Measured on native with `moon bench --target native -p buffer -f write_bench_test.mbt --no-parallelize`, baseline and patched built into separate `--target-dir`s and re-benched interleaved over 3 rounds:

| benchmark | before | after | delta (3 rounds) |
| --- | ---: | ---: | --- |
| `write_uint_le` n=4096 | 8,030 ns | 2,263 ns | −71.8 / −71.7 / −72.0 % |
| `write_uint64_be` n=4096 | 11,437 ns | 3,383 ns | −70.4 / −70.5 / −70.2 % |
| `write_char_utf16le` BMP n=4096 | 3,427 ns | 1,707 ns | −50.2 / −49.9 / −50.4 % |
| `write_uint16_be` n=4096 | 3,440 ns | 1,763 ns | −48.7 / −48.6 / −48.9 % |
| `write_char_utf8` ASCII n=4096 | 2,290 ns | 1,413 ns | −38.3 / −38.1 / −38.5 % |
| `write_string_utf16le` n=4096 | 46,107 ns | 28,733 ns | −37.7 / −37.5 / −37.9 % |
| `write_char_utf8` non-BMP n=4096 | 10,193 ns | 8,927 ns | −12.4 / −12.1 / −12.6 % |
| `write_byte` n=4096 | 2,357 ns | 2,103 ns | −10.7 / −10.6 / −10.9 % |
| `from_array` n=4096 | 150 ns | 142 ns | −5.2 / −5.0 / −5.4 % |

The buffer is allocated once outside the timed closure and rewound with `reset()` — that is what the second commit does. Allocating inside the closure charged every run a malloc plus a zero-fill of the whole capacity (128KB for the utf16le case) on freshly handed-back memory, which swamped the shorter benchmarks: it read as a 50% *regression* on the `write_char_utf8` ASCII branch, against an inlined loop that had gotten 4 instructions shorter. Worth knowing if you re-run these.

Each run keeps the buffer itself rather than `buf.length()`: the length is derivable from the fixed loop bounds, so keeping only that would leave the byte stores unobservable in principle and invite the backend to drop the loop under test. The emitted code shows the stores survived in both builds even before that change — hoisting the buffer out already made it escape into the closure — and hardening it moved every figure by less than two points.

`from_array` is the exception and still allocates, because allocating and filling is what it does — its number is mostly malloc and zero-fill. Its copy loop does improve: baseline compiles to a 44-instruction scalar byte loop, patched to 108 instructions using vector stores, since dropping the per-element check is what allows the backend to vectorize it.

## Testing

- `moon check` — 0 errors; `moon fmt --check` clean; `moon info` leaves `pkg.generated.mbti` unchanged.
- `moon test -p buffer` — 99/99 on native, wasm-gc, wasm and js.
- Every dependent package on native: `builtin` 2898, `int` 5375, `string` 371, `bytes` 138, `uint` 86, `int64` 37, `encoding/base64` 21, `encoding/utf8` 21, `double` 11, `prelude` 3 — all passing.


