### PR TITLE
perf: specialize Int16 comparisons

### DIFF
--- a/int16/int16.mbt
+++ b/int16/int16.mbt
@@ -71,6 +71,28 @@ pub impl Compare for Int16 with fn compare(self, that) {
 }
 
 ///|
+// Int16 values may arrive as raw 16-bit bits, for example from SIMD lane
+// extraction on JavaScript. Normalize both operands before comparing them.
+pub impl Compare for Int16 with fn op_lt(x, y) {
+  x.to_int() < y.to_int()
+}
+
+///|
+pub impl Compare for Int16 with fn op_le(x, y) {
+  x.to_int() <= y.to_int()
+}
+
+///|
+pub impl Compare for Int16 with fn op_gt(x, y) {
+  x.to_int() > y.to_int()
+}
+
+///|
+pub impl Compare for Int16 with fn op_ge(x, y) {
+  x.to_int() >= y.to_int()
+}
+
+///|
 pub impl Hash for Int16 with fn hash_combine(self, hasher) {
   hasher.combine_int(self.to_int())
 }

--- a/int16/int16_test.mbt
+++ b/int16/int16_test.mbt
@@ -173,6 +173,18 @@ test "Int16::compare" {
 }
 
 ///|
+test "Int16 relational operators" {
+  inspect((-32768 : Int16) < 32767, content="true")
+  inspect((32767 : Int16) < -32768, content="false")
+  inspect((-1 : Int16) <= -1, content="true")
+  inspect((0 : Int16) <= -1, content="false")
+  inspect((32767 : Int16) > -32768, content="true")
+  inspect((-32768 : Int16) > 32767, content="false")
+  inspect((0 : Int16) >= -1, content="true")
+  inspect((-1 : Int16) >= 0, content="false")
+}
+
+///|
 test "Int16::hash" {
   let h1 = Hasher(seed=0)
   h1.combine(1)


### PR DESCRIPTION
## Summary

- specialize `Compare::op_lt`, `op_le`, `op_gt`, and `op_ge` for `Int16`
- sign-extend both operands through `Int16::to_int()` before direct integer comparison
- add relational-operator coverage across negative, zero, minimum, and maximum values

## Why

Like `UInt16` before #4025, `Int16` relational operators currently route through the generic `Compare` defaults. These specializations remove that path.

Unlike `UInt16`, using raw `%i32.lt`/etc. intrinsics is not correct for `Int16`: some backend paths can carry raw 16-bit bits. In particular, JavaScript SIMD lane extraction can present `0xffff` before signed normalization. Calling `to_int()` explicitly preserves signed semantics while still lowering to primitive comparisons.

## Codegen verification

- Wasm and Wasm-GC: `i32.extend16_s` followed by direct signed `i32.lt_s`/etc.
- JavaScript: `x << 16 >> 16` followed by direct comparison
- native: direct signed C comparison
- no generic `Compare::op_*` call remains in the inspected release output

## Validation

- `moon check --target all --deny-warn`
- `moon test --target all --deny-warn int16`
- `moon test --target js --deny-warn v128/v128_test.mbt --filter 'explicit coverage for i16 ops'`
- full `moon test --target all --deny-warn`:
  - Wasm: 7020/7020
  - Wasm-GC: 7021/7021
  - JavaScript: 6965/6965
  - native: 6939/6939
- `moon info && moon fmt` (no interface change)

Follow-up to #4024 and #4025.
