### PR TITLE
test(immut/vector): add QuickCheck property tests

### DIFF
--- a/immut/vector/quickcheck_test.mbt
+++ b/immut/vector/quickcheck_test.mbt
@@ -1,0 +1,310 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Property tests for the bit-partitioned trie behind `Vector`. The default
+// QuickCheck size (~100) barely crosses the first 32-wide leaf, so the
+// expensive properties below run with `max_size=2000`: that pushes vectors
+// through the tail-flush, node-split and depth-increase transitions at 32,
+// 64, 1024, ... where the path-copying and rebalancing logic actually lives.
+
+///|
+/// Map a random seed to a length, biased toward the tree-shape boundaries:
+/// an empty vector, a tail-only vector, one full leaf plus/minus one, two
+/// leaves, and the depth-two transition around 1024.
+fn pick_len(seed : Int) -> Int {
+  let n = seed & 0x7fffffff
+  let boundaries : ReadOnlyArray[Int] = [
+    0, 1, 2, 31, 32, 33, 63, 64, 65, 1023, 1024, 1025,
+  ]
+  if n % 3 != 0 {
+    boundaries[n / 3 % boundaries.length()]
+  } else {
+    n / 3 % 1200
+  }
+}
+
+///|
+/// Build a vector holding `offset, offset + 1, ..., offset + len - 1` by one
+/// of three construction paths: bulk `makei`, element-wise `push`, or slicing
+/// out of a larger vector — the last one leaves behind the irregular tree
+/// shapes that stress `concat`'s rebalancing.
+fn build_vec(len : Int, offset : Int, mode : Int) -> @vector.Vector[Int] {
+  match (mode & 0x7fffffff) % 3 {
+    0 => @vector.makei(len, i => offset + i)
+    1 => {
+      let mut v : @vector.Vector[Int] = @vector.new()
+      for i in 0..<len {
+        v = v.push(offset + i)
+      }
+      v
+    }
+    _ => @vector.makei(len + 50, i => offset + i - 33).slice(33, 33 + len)
+  }
+}
+
+///|
+test "quickcheck: push agrees with the array model and preserves history" {
+  @quickcheck.check(
+    (xs : Array[Int]) => {
+      let snapshots : Array[(Int, @vector.Vector[Int])] = []
+      let mut v : @vector.Vector[Int] = @vector.new()
+      for i, x in xs {
+        v = v.push(x)
+        guard v.length() == i + 1 && v.get(i) == Some(x) else { return false }
+        if i % 97 == 0 {
+          snapshots.push((i + 1, v))
+        }
+      }
+      guard v.to_array() == xs else { return false }
+      // Earlier versions must still hold exactly their prefix: a push that
+      // mutated an aliased tail or node in place would have scribbled over
+      // them.
+      for snap in snapshots {
+        let (len, sv) = snap
+        guard sv.length() == len else { return false }
+        for j in 0..<len {
+          guard sv.get(j) == Some(xs[j]) else { return false }
+        }
+      }
+      // Content equality and hashing must not depend on the construction
+      // path (push-built tail/tree layout vs. bulk construction).
+      let built = @vector.from_array(xs)
+      v == built && v.hash() == built.hash()
+    },
+    max_size=2000,
+    count=40,
+  )
+}
+
+///|
+test "quickcheck: set is a persistent point update" {
+  @quickcheck.check(
+    (input : (Array[Int], Array[(Int, Int)])) => {
+      let (xs, updates) = input
+      guard xs.length() > 0 else { return true }
+      let n = xs.length()
+      let orig = @vector.from_array(xs)
+      let model = xs.copy()
+      let mut cur = orig
+      for u in updates {
+        let (i_raw, x) = u
+        let i = (i_raw & 0x7fffffff) % n
+        let prev = cur
+        cur = cur.set(i, x)
+        // the new version reads the new value...
+        guard cur.get(i) == Some(x) else { return false }
+        // ...while the version it was derived from still reads the old one
+        // (path copying must not touch the shared spine)
+        guard prev.get(i) == Some(model[i]) else { return false }
+        model[i] = x
+      }
+      // every index of the final version matches the model (indices the
+      // updates never touched must be unchanged)...
+      guard cur.to_array() == model else { return false }
+      // ...and the original vector never changed
+      orig.to_array() == xs
+    },
+    max_size=2000,
+    count=40,
+  )
+}
+
+///|
+test "quickcheck: concat agrees with array append at tree-shape boundaries" {
+  @quickcheck.check(
+    (seeds : (Int, Int, Int)) => {
+      let (sa, sb, sm) = seeds
+      let la = pick_len(sa)
+      let lb = pick_len(sb)
+      let a = build_vec(la, 0, sm)
+      let b = build_vec(lb, 1000000, (sm & 0x7fffffff) / 3)
+      let a_arr = a.to_array()
+      let b_arr = b.to_array()
+      let expected = [..a_arr, ..b_arr]
+      let c = a.concat(b)
+      guard c.length() == la + lb else { return false }
+      // random access at every index of the concatenated tree — the classic
+      // place where a mis-rebalanced node shifts elements
+      for i in 0..<expected.length() {
+        guard c.at(i) == expected[i] else { return false }
+      }
+      guard c.to_array() == expected else { return false }
+      // `+` is concat
+      guard a + b == c else { return false }
+      // both operands survive untouched
+      guard a.to_array() == a_arr && b.to_array() == b_arr else { return false }
+      // the result is a healthy vector: pushing still appends at the end
+      let d = c.push(-1)
+      d.length() == la + lb + 1 && d.at(la + lb) == -1
+    },
+    count=80,
+  )
+}
+
+///|
+test "quickcheck: concat is associative" {
+  @quickcheck.check(
+    (seeds : (Int, Int, Int, Int)) => {
+      let (sa, sb, sc, sm) = seeds
+      let m = sm & 0x7fffffff
+      let a = build_vec(pick_len(sa), 0, m)
+      let b = build_vec(pick_len(sb), 1000000, m / 3)
+      let c = build_vec(pick_len(sc), 2000000, m / 9)
+      let left = a.concat(b).concat(c)
+      let right = a.concat(b.concat(c))
+      guard left == right else { return false }
+      left.to_array() == [..a.to_array(), ..b.to_array(), ..c.to_array()]
+    },
+    count=60,
+  )
+}
+
+///|
+test "quickcheck: iteration, folds and roundtrips agree with the array model" {
+  @quickcheck.check(
+    (v : @vector.Vector[Int]) => {
+      let xs = v.to_array()
+      let n = v.length()
+      guard xs.length() == n && v.is_empty() == (n == 0) else { return false }
+      guard v.iter().to_array() == xs else { return false }
+      guard @vector.from_iter(xs.iter()) == v else { return false }
+      guard @vector.from_array(xs) == v else { return false }
+      guard v.rev().to_array() == xs.rev() else { return false }
+      let folded : Array[Int] = v.fold(init=[], (acc, x) => {
+        acc.push(x)
+        acc
+      })
+      guard folded == xs else { return false }
+      let rev_folded : Array[Int] = v.rev_fold(init=[], (acc, x) => {
+        acc.push(x)
+        acc
+      })
+      guard rev_folded == xs.rev() else { return false }
+      let eached : Array[Int] = []
+      v.each(x => eached.push(x))
+      guard eached == xs else { return false }
+      let pairs : Array[(Int, Int)] = []
+      v.eachi((i, x) => pairs.push((i, x)))
+      let expected_pairs : Array[(Int, Int)] = []
+      for i, x in xs {
+        expected_pairs.push((i, x))
+      }
+      guard pairs == expected_pairs else { return false }
+      guard v.peek() == (if n == 0 { None } else { Some(xs[n - 1]) }) else {
+        return false
+      }
+      guard v.map(x => x * 2 + 1).to_array() == xs.map(x => x * 2 + 1) else {
+        return false
+      }
+      v.filter(x => x % 3 == 0).to_array() == xs.filter(x => x % 3 == 0)
+    },
+    max_size=2000,
+    count=50,
+  )
+}
+
+///|
+test "quickcheck: take/drop/split/slice agree with the array model" {
+  @quickcheck.check(
+    (input : (@vector.Vector[Int], Int, Int)) => {
+      let (v, i_raw, j_raw) = input
+      let xs = v.to_array()
+      let n = xs.length()
+      // take/drop clamp out-of-range counts, so probe [-2, n + 2]
+      let t = (i_raw & 0x7fffffff) % (n + 5) - 2
+      let clamped = if t <= 0 { 0 } else if t > n { n } else { t }
+      guard v.take(t).to_array() == xs[0:clamped].to_owned() else {
+        return false
+      }
+      guard v.drop(t).to_array() == xs[clamped:].to_owned() else {
+        return false
+      }
+      // split at a valid index
+      let s = (i_raw & 0x7fffffff) % (n + 1)
+      let (l, r) = v.split(s)
+      guard l.length() + r.length() == n else { return false }
+      guard l.to_array() == xs[0:s].to_owned() else { return false }
+      guard r.to_array() == xs[s:].to_owned() else { return false }
+      // the split halves concatenated restore the original: this drives
+      // concat over the irregular trees that slicing leaves behind
+      guard l.concat(r) == v else { return false }
+      // slice with valid bounds
+      let e = s + (j_raw & 0x7fffffff) % (n - s + 1)
+      let sl = v.slice(s, e)
+      guard sl.to_array() == xs[s:e].to_owned() else { return false }
+      // a slice is a healthy vector: it accepts pushes and random access
+      let sl2 = sl.push(-7)
+      guard sl2.at(sl.length()) == -7 else { return false }
+      for k in 0..<sl.length() {
+        guard sl2.at(k) == xs[s + k] else { return false }
+      }
+      // the original never changed
+      v.to_array() == xs
+    },
+    max_size=2000,
+    count=40,
+  )
+}
+
+///|
+test "quickcheck: pop walks back through every push boundary" {
+  @quickcheck.check(
+    (v : @vector.Vector[Int]) => {
+      let xs = v.to_array()
+      let n = xs.length()
+      // push-then-pop is the identity
+      guard v.push(42).pop() == Some(v) else { return false }
+      let mut cur = v
+      for k in 0..<n {
+        let len = n - k
+        guard cur.length() == len && cur.peek() == Some(xs[len - 1]) else {
+          return false
+        }
+        match cur.pop() {
+          Some(next) => {
+            // one full content check half-way down, where the tail refill
+            // from the tree has happened at least once
+            if len == n / 2 + 1 {
+              guard next.to_array() == xs[0:len - 1].to_owned() else {
+                return false
+              }
+            }
+            cur = next
+          }
+          None => return false
+        }
+      }
+      guard cur.is_empty() && cur.pop() is None else { return false }
+      // the original never changed
+      v.to_array() == xs
+    },
+    max_size=2000,
+    count=40,
+  )
+}
+
+///|
+test "quickcheck: Eq and Compare agree with the array model" {
+  @quickcheck.check((pair : (@vector.Vector[Int], @vector.Vector[Int])) => {
+    let (a, b) = pair
+    let ax = a.to_array()
+    let bx = b.to_array()
+    guard (a == b) == (ax == bx) else { return false }
+    guard a.compare(b) == ax.compare(bx) else { return false }
+    guard a.compare(b) == -b.compare(a) else { return false }
+    // reflexivity, and equality with an independently built copy
+    let rebuilt = @vector.from_array(ax)
+    a == a && a.compare(a) == 0 && a == rebuilt && a.compare(rebuilt) == 0
+  })
+}


### PR DESCRIPTION
Adds `immut/vector/quickcheck_test.mbt`, a blackbox property-test suite for the persistent bit-partitioned trie vector, following the pattern of `hashmap/quickcheck_test.mbt` / `immut/hashmap/canonical_property_test.mbt`.

## Why large sizes

The default QuickCheck size (~100) barely crosses the first 32-wide leaf, so the structural transitions of the trie — tail flush at 32, node split at 64, depth increase at 1024+32 — are never reached. The expensive properties here run with `max_size=2000`, and the concat properties draw lengths from a generator explicitly biased toward the boundary sizes 0, 1, 2, 31–33, 63–65, 1023–1025.

## Properties

- **push**: pushing `xs` one element at a time reproduces the array model, with length/last-element checks at every step; snapshots taken every 97 pushes are fully re-validated at the end (catches in-place mutation of an aliased tail or node), and a push-built vector is `==` to and hashes like a bulk-built one.
- **set (persistence)**: for a random update stream, each new version reads the new value, the immediately preceding version still reads the old one, the final version matches the model at *every* index, and the original vector is untouched — the path-copying spec.
- **concat**: `a.concat(b)` agrees with array append at every index (random access on the concatenated tree), `+` is concat, both operands survive, and the result still accepts pushes. Sides are built by `makei`, by repeated `push`, or by slicing a larger vector, so rebalancing also sees irregular (sliced) trees.
- **concat associativity**: `(a ++ b) ++ c == a ++ (b ++ c)` elementwise, at boundary-biased sizes.
- **iteration/folds/roundtrips**: `iter`, `rev`, `fold`, `rev_fold`, `each`, `eachi`, `map`, `filter`, `peek` all agree with the array model; `from_iter`/`from_array`/`to_array` roundtrip up to `Eq`.
- **take/drop/split/slice**: agree with the array model, including out-of-range clamping for `take`/`drop`; split halves re-concatenate to the original; a slice remains a healthy vector (random access + push).
- **pop**: `push` then `pop` is the identity; popping down to empty walks `peek`/`length` back through every boundary with a full mid-way content check.
- **Eq/Compare**: agree with the array model (length-first ordering), are antisymmetric and reflexive, and hold against an independently rebuilt copy.

## Verification

- `moon check`: clean, no `.mbti` changes.
- `moon test -p moonbitlang/core/immut/vector`: 145/145 pass (wasm-gc), 145/145 (js), 138/138 (native — panic tests excluded there by `moon.pkg`).
- No bugs found: all properties hold as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)