### PR TITLE
fix(bigint): correct to_uint/to_uint64 truncation of large negatives

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1851,8 +1851,15 @@ pub fn BigInt::to_int(self : BigInt) -> Int {
 /// }
 /// ```
 pub fn BigInt::to_uint(self : BigInt) -> UInt {
-  let value = if self.sign == Negative { (1N << 32) + self } else { self }
-  value.limbs[0]
+  // Truncation to the low 32 bits is a ring homomorphism, so for a
+  // negative value it is the wrapping negation of the magnitude's low
+  // limb. (Adding one modulus and reading the limb would be wrong
+  // whenever the sum is still negative, i.e. whenever |self| > 2^32.)
+  if self.sign == Negative {
+    0U - self.limbs[0]
+  } else {
+    self.limbs[0]
+  }
 }
 
 ///|
@@ -1900,15 +1907,22 @@ pub fn BigInt::to_int64(self : BigInt) -> Int64 {
 /// }
 /// ```
 pub fn BigInt::to_uint64(self : BigInt) -> UInt64 {
-  let value = if self.sign == Negative { (1N << 64) + self } else { self }
   let len = 64 / RADIX_BIT_LEN
-  let len = if value.len < len { value.len } else { len }
+  let len = if self.len < len { self.len } else { len }
   let mut result = 0UL
   for i in len>..0 {
     result = result << RADIX_BIT_LEN
-    result = result | (value.limbs[i].to_uint64() & RADIX_MASK)
+    result = result | (self.limbs[i].to_uint64() & RADIX_MASK)
   }
-  result
+  // Truncation to the low 64 bits is a ring homomorphism, so for a
+  // negative value it is the wrapping negation of the magnitude's low
+  // bits. (Adding one modulus and reading the limbs would be wrong
+  // whenever the sum is still negative, i.e. whenever |self| > 2^64.)
+  if self.sign == Negative {
+    0UL - result
+  } else {
+    result
+  }
 }
 
 ///|

--- a/bigint/truncation_regression_test.mbt
+++ b/bigint/truncation_regression_test.mbt
@@ -1,0 +1,53 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression tests for moonbitlang/core#4050 — the non-js
+// `to_uint`/`to_uint64` (and hence `to_int`/`to_int64`) added one
+// modulus and read sign-magnitude limbs, which is wrong whenever the
+// sum is still negative, i.e. for negative values with |x| > 2^32
+// (resp. 2^64) — already -(2^32 + 1) was mishandled; only exact
+// multiples of the modulus and scattered coincidental residues came out
+// right. js was already correct via `BigInt.asUintN`.
+
+///|
+test "to_uint truncates large negatives to two's complement" {
+  // the failure region starts right past one modulus:
+  // x mod 2^32 for x = -(2^32 + 1) is 2^32 - 1
+  inspect((-(1N << 32) - 1N).to_uint(), content="4294967295")
+  // x mod 2^32 for x = -(2^33 + 5) is 2^32 - 5 (js oracle: BigInt.asUintN)
+  inspect((-(1N << 33) - 5N).to_uint(), content="4294967291")
+  inspect((-(1N << 34)).to_uint(), content="0")
+  inspect((-(1N << 33) - 4294967295N).to_uint(), content="1")
+  inspect((-(1N << 80) - 5N).to_uint(), content="4294967291")
+  // reinterpretation must follow
+  inspect((-(1N << 33) - 5N).to_int(), content="-5")
+  // still-correct cases within one modulus
+  inspect((-5N).to_uint(), content="4294967291")
+  inspect((-4294967296N).to_uint(), content="0")
+}
+
+///|
+test "to_uint64 truncates large negatives to two's complement" {
+  // the failure region starts right past one modulus:
+  // y mod 2^64 for y = -(2^64 + 1) is 2^64 - 1
+  inspect((-(1N << 64) - 1N).to_uint64(), content="18446744073709551615")
+  // y mod 2^64 for y = -(2^65 + 5) is 2^64 - 5
+  inspect((-(1N << 65) - 5N).to_uint64(), content="18446744073709551611")
+  inspect((-(1N << 66)).to_uint64(), content="0")
+  inspect((-(1N << 80) - 5N).to_uint64(), content="18446744073709551611")
+  inspect((-(1N << 65) - 5N).to_int64(), content="-5")
+  // still-correct cases within one modulus
+  inspect((-5N).to_uint64(), content="18446744073709551611")
+  inspect((-(1N << 64)).to_uint64(), content="0")
+}


### PR DESCRIPTION
Fixes #4050

**Scope note:** this PR now contains only the truncation fix. The js `to_octets(length=0)` fix (#4052) that was previously bundled here moved to its own independent PR: #4063. The two PRs touch disjoint files and each merges on its own.

The non-js `to_uint`/`to_uint64` (and hence `to_int`/`to_int64`, which reinterpret their results) computed the truncation of a negative value by adding one modulus (`(1N << 32) + self`) and reading `limbs[0]` — but limbs are sign-magnitude, so whenever the sum is still negative, i.e. whenever |x| > 2^32 (resp. 2^64), it returned magnitude bits instead of two's complement. Already `-(2^32 + 1)` was mishandled: `(-(1N << 32) - 1N).to_uint()` returned `1` instead of `4294967295`, and `(-(1N << 33) - 5N).to_uint()` returned `5` instead of `4294967291`; only exact modulus multiples and scattered coincidental residues came out right. js was already correct via `BigInt.asUintN` and is unchanged — this was a native/wasm-gc vs js divergence.

Truncation to 2^k is a ring homomorphism, so for a negative value it equals the wrapping negation of the low magnitude bits — computed that way now (`bigint/bigint_nonjs.mbt`).

Deterministic regression tests in `bigint/truncation_regression_test.mbt` cover the exact failure boundary (`-(2^32 + 1)`, `-(2^64 + 1)`), the 2^33/2^65 crossovers, exact modulus multiples, wide values, `to_int`/`to_int64` reinterpretation, and still-correct cases within one modulus.

Found by deep property testing; the tests-only deep suite is #4046 (stacked on this branch).

Verified standalone: `moon test -p moonbitlang/core/bigint` passes on native (171), js (146), and wasm-gc (171); `moon check`, `moon info && moon fmt` clean, no `.mbti` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
