### PR TITLE
fix(diff): stop emitting zero-length Equal edits from group(context=0)

### DIFF
--- a/diff/diff_test.mbt
+++ b/diff/diff_test.mbt
@@ -655,3 +655,28 @@ test "edits() with the views agrees with render()" {
     assert_eq(rebuilt.to_string(), h.render(show=l => l))
   }
 }
+
+///|
+test "group without context splits on every equal run and emits no empty edits" {
+  // Regression: `group(context=0)` used to emit zero-length `Equal` edits
+  // around each split of an interior equal run, violating the documented
+  // "edits never have zero length" invariant of `Edit`.
+  let old = [1, 9, 2, 2, 2, 3, 9, 4][:]
+  let new = [1, 8, 2, 2, 2, 3, 7, 4][:]
+  let hunks = @diff.Diff(old~, new~).group(context=0)
+  assert_eq(hunks.length(), 2)
+  assert_true(
+    hunks[0].edits()
+    is [
+      Delete(old_index=1, old_len=1, new_index=1),
+      Insert(old_index=2, new_index=1, new_len=1),
+    ],
+  )
+  assert_true(
+    hunks[1].edits()
+    is [
+      Delete(old_index=6, old_len=1, new_index=6),
+      Insert(old_index=7, new_index=6, new_len=1),
+    ],
+  )
+}

--- a/diff/edit.mbt
+++ b/diff/edit.mbt
@@ -116,16 +116,22 @@ fn[T] group_edits(
         }
         // Split if this equal range is large enough
         if len > context * 2 {
-          pending.push(Equal(old_index~, new_index~, len=context))
+          if context > 0 {
+            pending.push(Equal(old_index~, new_index~, len=context))
+          }
           result.push({ edits: pending, old, new })
           let offset = len.saturating_sub(context)
-          pending = [
-            Equal(
-              old_index=old_index + offset,
-              new_index=new_index + offset,
-              len=len - offset,
-            ),
-          ]
+          pending = if context > 0 {
+            [
+              Equal(
+                old_index=old_index + offset,
+                new_index=new_index + offset,
+                len=len - offset,
+              ),
+            ]
+          } else {
+            []
+          }
         } else if len > 0 {
           pending.push(Equal(old_index~, new_index~, len~))
         }


### PR DESCRIPTION
Fixes #4051

`group(context=0)` emitted zero-length `Equal` edits around every split of an interior equal run: the split branch of `group_edits` unconditionally pushes a context-sized `Equal` trailer into the closing hunk and seeds the next hunk with a context-sized `Equal` leader, and with `context=0` both have `len=0`. That violates the documented "edits never have zero length" invariant of `Edit` as exposed through `Hunk::edits()` (rendered output was unaffected since empty edits contribute no lines).

Minimal repro:

```moonbit
let old = [1, 9, 2, 2, 2, 3, 9, 4][:]
let new = [1, 8, 2, 2, 2, 3, 7, 4][:]
@diff.Diff(old~, new~).group(context=0)
// hunk 0 ended with  Equal(old_index=2, new_index=2, len=0)
// hunk 1 began with  Equal(old_index=6, new_index=6, len=0)
```

The fix skips both context edits when `context == 0` (they carry no elements); a deterministic regression test in `diff_test.mbt` pins the corrected hunk shapes. Found by the QuickCheck property suite in #4047, which stacks on this branch.

Testing: `moon check` clean, `moon test -p moonbitlang/core/diff` passes, no `.mbti` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)