### PR TITLE
fix(bigint): validate length before the zero shortcut in js to_octets

### DIFF
--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -239,14 +239,21 @@ pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
 /// Returns a byte sequence representing the number in big-endian order.
 ///
 /// Throws a panic if the input number is negative, or if `length` is zero or
-/// negative for a non-zero input.
+/// negative.
 pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
   if self < 0 {
     abort("negative BigInt")
   }
   if self == 0 {
     return match length {
-      Some(len) => Bytes::make(len, 0)
+      Some(len) =>
+        // keep the documented contract (and the non-js behavior): a
+        // non-positive requested length panics even for zero
+        if len <= 0 {
+          abort("negative length")
+        } else {
+          Bytes::make(len, 0)
+        }
       None => [0]
     }
   }

--- a/bigint/octets_regression_test.mbt
+++ b/bigint/octets_regression_test.mbt
@@ -1,0 +1,31 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression test for moonbitlang/core#4052 — the js `to_octets` ran its
+// zero shortcut before validating the requested length, silently
+// returning b"" for `0N.to_octets(length=0)` while the documented
+// contract (and every other target) panics on a non-positive length.
+
+///|
+test "panic to_octets of zero rejects non-positive length" {
+  // documented contract: non-positive length panics on every target
+  // (the js implementation used to return b"" here)
+  let _ = 0N.to_octets(length=0)
+}
+
+///|
+test "to_octets of zero still pads positive lengths" {
+  inspect(0N.to_octets(), content="b\"\\x00\"")
+  inspect(0N.to_octets(length=3), content="b\"\\x00\\x00\\x00\"")
+}


### PR DESCRIPTION
Fixes #4052

The js `BigInt::to_octets` ran its zero shortcut before validating the requested length, so `0N.to_octets(length=0)` silently returned `b""` while the documented contract (and the native/wasm-gc implementations) panics on a non-positive length. This validates the length before the zero shortcut and aligns the docstring, which previously said the panic applied only "for a non-zero input".

Includes a cross-target `panic` regression test (`bigint/octets_regression_test.mbt`) pinning the contract on every backend, plus positive-length padding cases for zero.

Independent of #4054 (the truncation fix for #4050); the two PRs touch disjoint files and each merges on its own.

Verified standalone: `moon test -p moonbitlang/core/bigint` passes on native (171), js (146), and wasm-gc (171); `moon check`, `moon info && moon fmt` clean, no `.mbti` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
