### PR TITLE
fix(lazy_list): make concat stack-safe under any nesting

### DIFF
--- a/lazy_list/README.mbt.md
+++ b/lazy_list/README.mbt.md
@@ -1,9 +1,9 @@
 # LazyList
 
-A persistent, re-traversable linked list with memoized lazy tails. Built on
-top of `@lazy.Lazy`. Use it when you have a pull-based source (`Iter`,
-generator, recursive definition) that you want to consume *more than once*
-without re-running the underlying computation.
+A persistent, re-traversable linked list with memoized lazy tails. Use it
+when you have a pull-based source (`Iter`, generator, recursive definition)
+that you want to consume *more than once* without re-running the underlying
+computation.
 
 ## Table of Contents
 
@@ -44,6 +44,10 @@ so a second traversal walks the cached cells instead of re-evaluating.
 
 This shape mirrors Haskell's lazy lists / Scala's `LazyList` and is sometimes
 called "odd-style" laziness.
+
+Caching in place is a mutation, so a `LazyList` is not thread-safe even though
+it is persistent: traversing one from two threads needs external
+synchronization, the same contract `@lazy.Lazy` documents.
 
 ---
 
@@ -286,6 +290,52 @@ and never trigger user-supplied thunks. The alternative, even-style
 emptiness check itself a forcing operation. Odd-style is what Haskell's `[]`
 and Scala's `LazyList` use, and it's simpler to reason about.
 
+### Why `concat` is stack-safe at any nesting
+
+How a chain of `concat`s is associated is the caller's choice, and the most
+natural way to write one is also the hardest case:
+
+```mbt check
+///|
+test {
+  let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
+  for i in 0..<10000 {
+    acc = acc.concat(@lazy_list.from_iter([i].iter()))
+  }
+  debug_inspect(acc.take(3).to_array(), content="[0, 1, 2]")
+  inspect(acc.iter().count(), content="10000")
+}
+```
+
+Every step nests the previous result inside the *left* argument of the next
+`concat`, so the value is `((([] ++ a) ++ b) ++ c) ++ …`. The obvious
+implementation — `lazy_cons(x, () => tail.force().concat(other))` — builds
+that in O(1) per step but cannot force it: the outermost tail thunk forces
+the one below it, which forces the one below that, one stack frame per `++`.
+It also re-nests the chain to the same depth after every element, which makes
+a full traversal quadratic.
+
+So the pending right-hand sides live on the cell's tail as *data* instead of
+being closed over by a thunk. Forcing walks down to the innermost tail in a
+loop, collecting what is still owed, and hands the remainder to the cell it
+produces. Stack use is constant in the nesting depth, and a full traversal is
+linear — including when you append and consume at the same time, since
+joining two pending sequences is O(1). `flat_map` suspends its inner lists
+through the same representation.
+
+What this does *not* cover is composing arbitrarily many lazy transforms:
+`xs.map(f).map(f)...` ten thousand deep nests ten thousand thunks, and so
+does `flat_map`, so forcing one cell walks all of them. That is a property of
+composed transforms rather than of `concat`'s associativity, and it is
+unchanged here.
+
+That suspended-append state is the one reason a cell's tail is not simply a
+`@lazy.Lazy`. It is otherwise the same thing — the same states, the same
+at-most-once guarantee, the same reentrancy check — and the state lives
+*inside* the memoized cell rather than wrapping one because a `LazyList`
+allocates a tail per element, so an extra box per cell would cost every
+traversal, not just the ones that go through `concat`.
+
 ### Why is `drop_while` eager but `take_while` lazy?
 
 ```mbt check
@@ -324,11 +374,12 @@ dropWhile p xs@(x:_) | p x = dropWhile p xs'    -- eager recursion
 
 ### Why doesn't `map` / `filter` / `take_while` / `flat_map` accept `raise?`?
 
-Because their callbacks fire from inside `@lazy.Lazy` thunks. Thunks are
-non-raising by design (see `@lazy/lazy.mbt`): a raising thunk would force
-every consumer of every lazy cell to handle the effect, and memoizing
-failure forces an awkward choice between "cache the error and re-raise on
-every retry" and "retry on every force."
+Because their callbacks fire from inside the memoized tail thunks. Those are
+non-raising by design, for the reasons `@lazy` sets out (see
+`@lazy/lazy.mbt`): a raising thunk would force every consumer of every lazy
+cell to handle the effect, and memoizing failure forces an awkward choice
+between "cache the error and re-raise on every retry" and "retry on every
+force."
 
 If you need a fallible transform, wrap the result yourself:
 

--- a/lazy_list/concat_bench_test.mbt
+++ b/lazy_list/concat_bench_test.mbt
@@ -1,0 +1,79 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The three shapes that decided the tail representation, kept runnable so
+// the trade-off can be re-measured instead of re-argued:
+//
+//   * `build and traverse` is the ordinary path, one tail allocated per
+//     element. It is why `Tail` subsumes `@lazy.Lazy` rather than wrapping
+//     one — a wrapper adds a box and a dispatch to every cell here, which
+//     measured ~30% on this benchmark.
+//   * `left-nested concat` is the shape from #4066: with a recursive
+//     forcing path it overflows the stack rather than running slowly.
+//   * `concat while consuming` is why the pending sequence is a catenable
+//     tree — a flat list copies the whole backlog on every step.
+
+///|
+let concat_bench_len : Int = 2048
+
+///|
+fn bench_left_nested(depth : Int) -> @lazy_list.LazyList[Int] {
+  let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
+  for i in 0..<depth {
+    acc = acc.concat(@lazy_list.from_iter([i].iter()))
+  }
+  acc
+}
+
+///|
+test "bench LazyList build and traverse n=2048" (it : @bench.T) {
+  let source = Array::makei(concat_bench_len, i => i)
+  it.bench(fn() {
+    let xs = @lazy_list.from_iter(source.iter())
+    it.keep(xs.iter().count())
+  })
+}
+
+///|
+test "bench LazyList re-traverse a forced list n=2048" (it : @bench.T) {
+  let xs = @lazy_list.from_iter(Array::makei(concat_bench_len, i => i).iter())
+  it.keep(xs.iter().count())
+  // Every cell is cached now, so this measures the walk alone.
+  it.bench(fn() { it.keep(xs.iter().count()) })
+}
+
+///|
+test "bench LazyList left-nested concat, build only n=2048" (it : @bench.T) {
+  it.bench(fn() { it.keep(bench_left_nested(concat_bench_len).is_empty()) })
+}
+
+///|
+test "bench LazyList left-nested concat, build and traverse n=2048" (
+  it : @bench.T,
+) {
+  it.bench(fn() { it.keep(bench_left_nested(concat_bench_len).iter().count()) })
+}
+
+///|
+test "bench LazyList concat while consuming n=2048" (it : @bench.T) {
+  let source = Array::makei(concat_bench_len + 1, i => i)
+  it.bench(fn() {
+    let mut cur = @lazy_list.from_iter(source.iter())
+    for i in 0..<concat_bench_len {
+      cur = cur.concat(@lazy_list.from_iter([i].iter()))
+      cur = cur.tail().unwrap()
+    }
+    it.keep(cur.head())
+  })
+}

--- a/lazy_list/lazy_list.mbt
+++ b/lazy_list/lazy_list.mbt
@@ -21,7 +21,7 @@
 /// and as the building block for the transform combinators.
 #owned(head, tail)
 fn[A] cons(head : A, tail : LazyList[A]) -> LazyList[A] {
-  { cell: Cons(head, tail=@lazy.Lazy::ready(tail)) }
+  { cell: Cons(head, tail=Tail::ready(tail)) }
 }
 
 // =====================================================================
@@ -66,7 +66,7 @@ pub fn[A] LazyList::lazy_cons(
   head : A,
   tail : () -> LazyList[A],
 ) -> LazyList[A] {
-  { cell: Cons(head, tail=Lazy(tail)) }
+  { cell: Cons(head, tail=Tail::delay(tail)) }
 }
 
 ///|
@@ -210,8 +210,8 @@ pub fn[A] LazyList::take_while(
 /// called eagerly during the skip; a raising `pred` propagates here.
 ///
 /// (Contrast with `map` / `filter` / `take_while` / `flat_map`, whose
-/// callbacks also run inside lazy thunks. `@lazy.Lazy` thunks are
-/// non-raising by design — see `@lazy`'s rationale — so those
+/// callbacks also run inside lazy thunks. Tail thunks are non-raising by
+/// design — the same rationale `@lazy` sets out — so those
 /// combinators cannot accept a raising callback. `drop_while` only runs
 /// `pred` during the strict skip phase, so it can.)
 pub fn[A] LazyList::drop_while(
@@ -228,6 +228,14 @@ pub fn[A] LazyList::drop_while(
 ///|
 /// Concatenates two lazy lists. The right-hand side is not forced until
 /// the left-hand side has been fully consumed.
+///
+/// Building and traversing a chain of `concat`s is stack-safe however the
+/// chain is associated, so the accumulator idiom `acc = acc.concat(xs)` is
+/// safe at any length. The pending right-hand sides are recorded in the
+/// resulting cell's tail as data rather than closed over by a recursive
+/// thunk, so forcing a left-nested chain `((a ++ b) ++ c) ++ d` flattens it
+/// with a loop instead of recursing once per `++`, and a full traversal
+/// stays linear. See `Tail::force`.
 #owned(other)
 pub fn[A] LazyList::concat(
   self : LazyList[A],
@@ -235,14 +243,21 @@ pub fn[A] LazyList::concat(
 ) -> LazyList[A] {
   match self.cell {
     Empty => other
-    Cons(x, tail~) => LazyList::lazy_cons(x, () => tail.force().concat(other))
+    Cons(x, tail~) =>
+      // Appending nothing is the identity; keeping empty segments out of
+      // the pending list keeps repeated `xs.concat(empty())` free.
+      if other.cell is Empty {
+        self
+      } else {
+        { cell: Cons(x, tail=tail.append(One(Tail::ready(other)))) }
+      }
   }
 }
 
 ///|
 /// Variant of `concat` whose second argument is itself a thunk; used
 /// internally by `flat_map` to chain lazy lists without forcing them
-/// prematurely.
+/// prematurely. Stack-safe under nesting for the same reason `concat` is.
 fn[A] LazyList::concat_lazy(
   self : LazyList[A],
   other_thunk : () -> LazyList[A],
@@ -250,7 +265,7 @@ fn[A] LazyList::concat_lazy(
   match self.cell {
     Empty => other_thunk()
     Cons(x, tail~) =>
-      LazyList::lazy_cons(x, () => tail.force().concat_lazy(other_thunk))
+      { cell: Cons(x, tail=tail.append(One(Tail::delay(other_thunk)))) }
   }
 }
 

--- a/lazy_list/lazy_list_test.mbt
+++ b/lazy_list/lazy_list_test.mbt
@@ -161,8 +161,8 @@ suberror NegativeFound
 test "drop_while accepts a raising predicate" {
   // Strict skip phase: a raising predicate propagates immediately. The
   // lazy combinators (map / filter / take_while / flat_map) cannot
-  // accept raise? because they run the callback inside `@lazy.Lazy`
-  // thunks, which are non-raising by design.
+  // accept raise? because they run the callback inside the memoized
+  // tail thunks, which are non-raising by design.
   fn pred(x : Int) -> Bool raise NegativeFound {
     if x < 0 {
       raise NegativeFound
@@ -261,4 +261,111 @@ test "Debug walks only the forced prefix" {
   // Empty list has no prefix and no unforced marker.
   let empty : @lazy_list.LazyList[Int] = @lazy_list.empty()
   @debug.debug_inspect(empty, content="<LazyList: []>")
+}
+
+// =====================================================================
+// Stack safety of `concat`.
+// =====================================================================
+
+///|
+/// `((([] ++ [from]) ++ [from + 1]) ++ ...) ++ [until - 1]` — every
+/// `concat` ends up inside the left argument of the next one, which is
+/// what the accumulator idiom `acc = acc.concat(...)` builds.
+fn left_nested_concat(from : Int, until : Int) -> @lazy_list.LazyList[Int] {
+  let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
+  for i in from..<until {
+    acc = acc.concat(@lazy_list.from_iter([i].iter()))
+  }
+  acc
+}
+
+///|
+/// The mirror image: `[from] ++ ([from + 1] ++ (... ++ [until - 1]))`.
+fn right_nested_concat(from : Int, until : Int) -> @lazy_list.LazyList[Int] {
+  let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
+  for i = until - 1; i >= from; i = i - 1 {
+    acc = @lazy_list.from_iter([i].iter()).concat(acc)
+  }
+  acc
+}
+
+///|
+test "concat: a left-nested chain forces without recursing" {
+  // Reaching the *second* element is already the whole problem: it is
+  // the first tail force, and it is the one that has to see through
+  // every pending append at once.
+  let xs = left_nested_concat(0, 50000)
+  debug_inspect(xs.take(3).to_array(), content="[0, 1, 2]")
+  // ...and the rest of the traversal has to stay linear: a forcing path
+  // that re-nests the chain after every step would not finish here.
+  inspect(xs.fold(init=0, (acc, x) => acc + x), content="1249975000")
+}
+
+///|
+test "concat: a right-nested chain forces without recursing" {
+  let xs = right_nested_concat(0, 50000)
+  debug_inspect(xs.take(3).to_array(), content="[0, 1, 2]")
+  inspect(xs.fold(init=0, (acc, x) => acc + x), content="1249975000")
+}
+
+///|
+test "concat: appending empty lists neither accumulates nor diverges" {
+  let mut acc = @lazy_list.from_iter([1, 2, 3].iter())
+  for _ in 0..<50000 {
+    acc = acc.concat(@lazy_list.empty())
+  }
+  debug_inspect(acc.to_array(), content="[1, 2, 3]")
+}
+
+///|
+test "flat_map over a deeply nested concat is stack safe" {
+  // `flat_map` chains through `concat_lazy`, which shares `concat`'s
+  // representation, so it has to survive the same shape.
+  let xs = left_nested_concat(0, 20000).flat_map(x => {
+    @lazy_list.from_iter([x, x].iter())
+  })
+  inspect(xs.iter().count(), content="40000")
+}
+
+///|
+test "concat leaves the right-hand side untouched until the left ends" {
+  let pulls : Ref[Int] = Ref(0)
+  let left = @lazy_list.from_iter([1, 2].iter())
+  let right = @lazy_list.lazy_cons(3, () => {
+    pulls.val += 1
+    @lazy_list.empty()
+  })
+  let both = left.concat(right)
+  debug_inspect(both.take(3).to_array(), content="[1, 2, 3]")
+  // Only the right-hand *head* has been observed; its tail thunk has
+  // not run.
+  inspect(pulls.val, content="0")
+  debug_inspect(both.to_array(), content="[1, 2, 3]")
+  inspect(pulls.val, content="1")
+}
+
+///|
+test "concat keeps both sides memoized across traversals" {
+  let pulls : Ref[Int] = Ref(0)
+  fn counted(source : Array[Int]) -> @lazy_list.LazyList[Int] {
+    let underlying = source.iter()
+    @lazy_list.from_iter(
+      Iter::new(() => {
+        match underlying.next() {
+          None => None
+          Some(x) => {
+            pulls.val += 1
+            Some(x)
+          }
+        }
+      }),
+    )
+  }
+
+  let both = counted([1, 2]).concat(counted([3, 4]))
+  debug_inspect(both.to_array(), content="[1, 2, 3, 4]")
+  inspect(pulls.val, content="4")
+  // Second traversal walks cached cells only — no further pulls.
+  debug_inspect(both.to_array(), content="[1, 2, 3, 4]")
+  inspect(pulls.val, content="4")
 }

--- a/lazy_list/moon.pkg
+++ b/lazy_list/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/lazy",
   "moonbitlang/core/array",
   "moonbitlang/core/debug",
 }
@@ -9,4 +8,9 @@ import {
   "moonbitlang/core/list",
   "moonbitlang/core/cmp",
   "moonbitlang/core/quickcheck",
+  "moonbitlang/core/bench",
 } for "test"
+
+options(
+  targets: { "panic_test.mbt": [ "not", "native", "llvm" ] },
+)

--- a/lazy_list/panic_test.mbt
+++ b/lazy_list/panic_test.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "panic reentrant force on a tail aborts" {
+  // A thunk that forces the very tail it is producing. Letting it through
+  // would re-run the thunk and break the at-most-once guarantee, so it
+  // aborts instead — the same trade-off `@lazy.Lazy::force` makes.
+  let slot : Array[@lazy_list.LazyList[Int]] = []
+  let xs = @lazy_list.lazy_cons(1, () => slot[0].tail().unwrap())
+  slot.push(xs)
+  ignore(xs.tail())
+}
+
+///|
+test "panic reentrant force through a suspended concat aborts" {
+  // Same, but the reentrant force lands on a suspended append rather
+  // than on a thunk.
+  let slot : Array[@lazy_list.LazyList[Int]] = []
+  let left = @lazy_list.lazy_cons(1, () => slot[0].tail().unwrap())
+  let both = left.concat(@lazy_list.from_iter([2].iter()))
+  slot.push(both)
+  ignore(both.tail())
+}

--- a/lazy_list/quickcheck_test.mbt
+++ b/lazy_list/quickcheck_test.mbt
@@ -595,6 +595,94 @@ test "quickcheck: flat_map skips runs of empty inner lists without recursing" {
   )
 }
 
+///|
+/// Concatenates the singletons `[0], [1], ..., [depth - 1]` in order,
+/// associating them into a binary tree whose shape is driven by `seed`.
+///
+/// The segments are combined through a stack, merging the top two
+/// whenever the pseudo-random bit stream says so and draining what is
+/// left at the end. A run of merge bits builds a left-nested comb, a run
+/// without them a right-nested one, and a realistic seed gives a mixture
+/// of both at every scale.
+///
+/// This covers *ordering* across the association shapes the generator
+/// reaches, which is the caller's choice and not the package's. It is
+/// not the stack-safety case: the trees it draws nest far more shallowly
+/// than the 50000-deep combs in `lazy_list_test.mbt`, which are what pin
+/// that down.
+fn shaped_concat(depth : Int, seed : Int) -> @lazy_list.LazyList[Int] {
+  let stack : Array[@lazy_list.LazyList[Int]] = []
+  let mut bits = seed
+  fn next_bit() -> Bool {
+    // A plain LCG: the shape only has to vary, not be well distributed.
+    bits = bits * 1103515245 + 12345
+    (bits >> 16) % 2 == 0
+  }
+
+  fn merge_top() -> Unit {
+    let right = stack.pop().unwrap()
+    let left = stack.pop().unwrap()
+    stack.push(left.concat(right))
+  }
+
+  for i in 0..<depth {
+    stack.push(@lazy_list.from_iter([i].iter()))
+    while stack.length() >= 2 && next_bit() {
+      merge_top()
+    }
+  }
+  while stack.length() >= 2 {
+    merge_top()
+  }
+  match stack.pop() {
+    Some(xs) => xs
+    None => @lazy_list.empty()
+  }
+}
+
+///|
+test "quickcheck: a chain of concats forces at generated nesting shapes" {
+  @quickcheck.check(
+    (seed : Int) => {
+      let depth = 20000
+      let xs = shaped_concat(depth, seed)
+      // Reaching the second element is what walks the whole nesting: it
+      // is the first tail force, so it is the one that has to see
+      // through every pending append at once.
+      xs.take(2).to_array() == [0, 1] &&
+      // ...and the rest of the traversal has to come out in order.
+      xs.to_array() == Array::makei(depth, i => i)
+    },
+    count=20,
+  )
+}
+
+///|
+test "quickcheck: appending while consuming keeps the order" {
+  // Growing a list at the end while walking it from the front is the
+  // shape that a flat pending sequence makes quadratic — every step
+  // would copy everything already owed — and that the recursive
+  // implementation overflows outright. What is asserted here is the
+  // order; the quadratic variant still produces it, and shows up only
+  // as runtime.
+  @quickcheck.check(
+    (value : Int) => {
+      let steps = 20000
+      let start = wrap_index(value, 100)
+      let mut cur = @lazy_list.from_iter(Array::makei(steps + 1, i => i).iter())
+      let seen = []
+      for i in 0..<steps {
+        cur = cur.concat(@lazy_list.from_iter([start + i].iter()))
+        seen.push(cur.head().unwrap())
+        cur = cur.tail().unwrap()
+      }
+      seen == Array::makei(steps, i => i) &&
+      cur.to_array() == [steps] + Array::makei(steps, i => start + i)
+    },
+    count=5,
+  )
+}
+
 // =====================================================================
 // Infinite sources.
 // =====================================================================

--- a/lazy_list/tail.mbt
+++ b/lazy_list/tail.mbt
@@ -1,0 +1,169 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// =====================================================================
+// `Tail` — the suspended remainder of a cell: `@lazy.Lazy` plus a
+// suspended-append state. Internal; see `types.mbt` for why the append
+// state has to live inside the memoized cell rather than wrap one.
+// =====================================================================
+
+///|
+/// A tail whose value is already known. No thunk is allocated.
+#owned(value)
+fn[A] Tail::ready(value : LazyList[A]) -> Tail[A] {
+  { state: Forced(value) }
+}
+
+///|
+/// A tail computed by `thunk`, which runs at most once.
+#owned(thunk)
+fn[A] Tail::delay(thunk : () -> LazyList[A]) -> Tail[A] {
+  { state: Unforced(thunk) }
+}
+
+///|
+/// `self.append(pending)` is the tail denoting `self` followed by every
+/// list in `pending`. O(1) — nothing is forced, and the pending lists are
+/// recorded as data so that `force` can flatten them iteratively.
+///
+/// `pending` must be non-empty; callers hand back the tail unchanged
+/// rather than wrap it in an append that has nothing to append.
+#owned(pending)
+fn[A] Tail::append(self : Tail[A], pending : Pending[A]) -> Tail[A] {
+  { state: Append(self, pending) }
+}
+
+///|
+/// The tail's value if it is already known, without running anything.
+/// A suspended append reports `None`: its head cell is not determined
+/// until the append is flattened.
+fn[A] Tail::peek(self : Tail[A]) -> LazyList[A]? {
+  match self.state {
+    Forced(v) => Some(v)
+    _ => None
+  }
+}
+
+///|
+/// Forces the tail to a head cell, memoizing the result. Reentrant
+/// forces are detected and aborted, for the reason `@lazy.Lazy::force`
+/// gives: the inner force would silently re-run the thunk and break the
+/// at-most-once guarantee.
+///
+/// The `Append` case is the reason this type is not just `@lazy.Lazy`.
+/// `Append(inner, ps)` denotes `inner` followed by `ps`, and `inner` may
+/// itself be an `Append` — which is exactly the shape a left-nested chain
+/// of `concat`s builds. Instead of recursing into `inner`, walk down to
+/// the innermost non-append tail while accumulating everything still to
+/// be appended, force that single thunk, and re-attach the accumulated
+/// appends with `append_pending`. Stack use is therefore constant in the
+/// nesting depth.
+///
+/// Only the entry node is memoized. The intermediate `Append` nodes the
+/// walk passes through are left alone (and become garbage unless the
+/// caller retained the corresponding lists), which is what keeps a full
+/// traversal linear: the collected `Pending` is handed to the *result*
+/// cell instead of being re-nested once per level.
+fn[A] Tail::force(self : Tail[A]) -> LazyList[A] {
+  match self.state {
+    Forced(v) => v
+    Forcing => abort("LazyList: reentrant force on the same tail")
+    Unforced(thunk) => {
+      self.state = Forcing
+      let v = thunk()
+      self.state = Forced(v)
+      v
+    }
+    Append(inner, pending) => {
+      self.state = Forcing
+      let (base, rest) = for cur = inner, rest = pending {
+        match cur.state {
+          // `cur` denotes `next` followed by `ps`, and the whole denotes
+          // `cur` followed by `rest`, so `ps` goes in front of what we
+          // already owe.
+          Append(next, ps) => continue next, ps.concat(rest)
+          // Not an append, so this force cannot walk any further down.
+          _ => break (cur.force(), rest)
+        }
+      }
+      let value = base.append_pending(rest)
+      self.state = Forced(value)
+      value
+    }
+  }
+}
+
+///|
+/// Appends `pending` after the head cell `self`, returning a head cell.
+/// Empty segments are skipped in a loop, so a long run of empty lists
+/// costs O(1) stack.
+fn[A] LazyList::append_pending(
+  self : LazyList[A],
+  pending : Pending[A],
+) -> LazyList[A] {
+  for cur = self, rest = pending {
+    match cur.cell {
+      // A head is available: whatever is still pending moves onto its
+      // tail, still suspended.
+      Cons(x, tail~) =>
+        break if rest is Nil {
+          cur
+        } else {
+          { cell: Cons(x, tail=tail.append(rest)) }
+        }
+      // This segment contributed no head; move on to the next one.
+      Empty =>
+        match rest.uncons() {
+          None => break cur
+          Some((t, more)) => continue t.force(), more
+        }
+    }
+  }
+}
+
+///|
+/// `self` followed by `other`. O(1): the join is recorded as a `Cat` node
+/// and flattened only as `uncons` walks past it.
+#owned(other)
+fn[A] Pending::concat(self : Pending[A], other : Pending[A]) -> Pending[A] {
+  match (self, other) {
+    (Nil, _) => other
+    (_, Nil) => self
+    _ => Cat(self, other)
+  }
+}
+
+///|
+/// Splits off the first pending list, or `None` if there is none.
+///
+/// Rotates the left spine of the `Cat` tree to the right as it walks, so
+/// consuming a pending sequence once — each remainder handed on to the
+/// next `uncons` — steps over every `Cat` node at most once, i.e. O(1)
+/// amortized per element. The amortization is the usual ephemeral one:
+/// re-consuming a retained earlier remainder replays its rotations.
+/// Iterative, so an arbitrarily deep tree costs O(1) stack.
+fn[A] Pending::uncons(self : Pending[A]) -> (Tail[A], Pending[A])? {
+  for cur = self {
+    match cur {
+      Nil => break None
+      One(t) => break Some((t, Nil))
+      Cat(One(t), b) => break Some((t, b))
+      Cat(Cat(x, y), b) => continue Cat(x, Cat(y, b))
+      // Unreachable: neither `Pending::concat` nor the rotation above
+      // builds a `Cat` with an empty side. Handled rather than asserted
+      // because an empty side means exactly "nothing to append here".
+      Cat(Nil, b) => continue b
+    }
+  }
+}

--- a/lazy_list/types.mbt
+++ b/lazy_list/types.mbt
@@ -15,10 +15,72 @@
 ///|
 /// Internal cell representation. Kept private so users go through the
 /// `head` / `tail` / `iter` accessors and cannot observe (or accidentally
-/// force) the underlying `@lazy.Lazy` representation.
+/// force) the underlying `Tail` representation.
 priv enum LazyListCell[A] {
   Empty
-  Cons(A, tail~ : @lazy.Lazy[LazyList[A]])
+  Cons(A, tail~ : Tail[A])
+}
+
+///|
+/// The suspended remainder of a `Cons` cell.
+///
+/// This is `@lazy.Lazy` — the same states, the same at-most-once
+/// guarantee, the same reentrancy check — with one extra state, `Append`.
+/// The extra state is what makes `concat` stack-safe, and it has to live
+/// *inside* the memoized cell rather than wrap one: `LazyList` allocates a
+/// tail per element, so an extra box per cell would be an allocation
+/// regression on every traversal, not just on `concat`.
+///
+/// Why the extra state is needed: over a bare thunk, `concat` can only be
+/// written recursively — `xs ++ ys` has to close over a thunk that forces
+/// the tail of `xs` and appends `ys` to the *result*, so forcing a
+/// left-nested chain `((a ++ b) ++ c) ++ d` recurses once per `++`.
+/// `Append` reifies the pending appends as data instead of burying them
+/// in a closure, which lets `Tail::force` flatten the chain with a loop.
+/// See `Tail::force` and `LazyList::concat`.
+priv struct Tail[A] {
+  mut state : TailState[A]
+}
+
+///|
+/// Internal tail state.
+///
+/// - `Unforced(thunk)`: the ordinary case — the rest of the list is
+///   whatever `thunk` returns. It runs at most once.
+/// - `Forcing`: `thunk` is running. Detects a reentrant force on the same
+///   tail, which would otherwise re-run the thunk and break the
+///   at-most-once guarantee. Same rationale as `@lazy.Lazy`'s.
+/// - `Append(inner, pending)`: the rest of the list is `inner` followed by
+///   every list in `pending`, in order. Built by `concat` / `concat_lazy`,
+///   and collapsed to `Forced` by the first `Tail::force`.
+/// - `Forced(v)`: already known to be `v`; the thunk reference is dropped
+///   so its captures can be reclaimed.
+priv enum TailState[A] {
+  Unforced(() -> LazyList[A])
+  Forcing
+  Append(Tail[A], Pending[A])
+  Forced(LazyList[A])
+}
+
+///|
+/// An ordered, immutable sequence of still-suspended lists waiting to be
+/// appended. Elements are `Tail`s rather than `LazyList`s so that both
+/// `concat` (whose right-hand side is already a head cell) and
+/// `concat_lazy` (whose right-hand side is a thunk) can share one
+/// representation.
+///
+/// `Cat` makes joining two of these O(1), which is what keeps the cost of
+/// a `concat` independent of how much is already pending: appending to a
+/// list that is being consumed at the same time would otherwise copy the
+/// whole pending sequence on every step. `Pending::uncons` flattens the
+/// `Cat` spine as it walks, in amortized O(1) per element.
+///
+/// Invariant: `Pending::concat` is the only way a `Cat` is built from the
+/// outside, and it never gives one an empty side.
+priv enum Pending[A] {
+  Nil
+  One(Tail[A])
+  Cat(Pending[A], Pending[A])
 }
 
 ///|
@@ -28,6 +90,13 @@ priv enum LazyListCell[A] {
 ///
 /// Unlike `Iter[A]`, which is a single-use pull-based iterator, a
 /// `LazyList[A]` can be re-traversed any number of times.
+///
+/// ## Concurrency
+///
+/// Caching a tail in place is a mutation, so `LazyList[A]` is not
+/// thread-safe even though it is persistent. Traversing one from two
+/// threads requires external synchronization — the same contract as
+/// `@lazy.Lazy`.
 struct LazyList[A] {
   cell : LazyListCell[A]
 }


### PR DESCRIPTION
Closes #4066.

## The bug

`LazyList::concat` built its result as

```moonbit
Cons(x, tail~) => LazyList::lazy_cons(x, () => tail.force().concat(other))
```

O(1) to construct, but impossible to force without one stack frame per `++`. For `((a ++ b) ++ c) ++ d`, the outermost tail thunk forces the one below it, which forces the one below that. The accumulator idiom

```moonbit
acc = acc.concat(xs)
```

builds exactly that shape, so a 10000-step loop overflowed the stack on wasm, wasm-gc and js as soon as the **second** element was reached — the first tail force is the one that has to walk the whole nesting. It was quadratic in time as well, because the chain is re-nested to the same depth after every element. `concat_lazy`, which `flat_map` chains through, had the same shape.

## The fix

The pending right-hand sides are reified as data on the cell's tail instead of being closed over by a recursive thunk. Forcing walks down to the innermost tail in a loop, collects what is still owed, and hands the remainder to the cell it produces:

- **stack** is constant in the nesting depth, whichever way the chain is associated;
- **a full traversal is linear**, because only the entry node is memoized rather than each level being re-nested;
- the pending sequence is a **catenable tree**, so joining two of them is O(1) and appending to a list while consuming it from the front stays linear too.

`Tail` (`lazy_list/types.mbt`, `lazy_list/tail.mbt`) is `@lazy.Lazy` — same states, same at-most-once guarantee, same reentrancy abort — plus one `Append` state. It replaces the `@lazy.Lazy` tail rather than wrapping one: a `LazyList` allocates a tail per element, so boxing a `@lazy.Lazy` inside a wrapper measured **~30% slower** on build-and-traverse (1.90s vs 1.51s for 20M cells, native release), while the merged representation measures at parity on both native and wasm-gc.

The public API is unchanged (`pkg.generated.mbti` is untouched); `moon.pkg` drops the now-unused `@lazy` import.

## Behaviour that is deliberately unchanged

Composing arbitrarily many lazy transforms (`xs.map(f).map(f)…` ten thousand deep, and likewise `flat_map`) still nests one thunk per transform. That is a property of composed transforms, not of `concat`'s associativity, and the README now says so explicitly.

## Tests

| what | where |
| --- | --- |
| left- and right-nested chains at depth 50000, forced to the 2nd element and fully traversed | `lazy_list_test.mbt` |
| 50000 appends of the empty list | `lazy_list_test.mbt` |
| `flat_map` over a deeply nested source (`concat_lazy`) | `lazy_list_test.mbt` |
| randomly shaped concat trees — ordering under arbitrary association | `quickcheck_test.mbt` |
| appending while consuming from the front | `quickcheck_test.mbt` |
| right-hand side untouched until the left ends; both sides memoized across traversals | `lazy_list_test.mbt` |
| reentrancy guard, on a thunk and on a suspended append | `panic_test.mbt` |

`moon check --deny-warn --target all`, `moon test --target all`, `moon test --release` (js/wasm/wasm-gc and native), `moon test --target llvm`, `moon fmt`, `moon info` and `moon bundle --all` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
