### PR TITLE
test(internal/strconv): specify the parsers against independent oracles

### DIFF
--- a/internal/strconv/double_exact_test.mbt
+++ b/internal/strconv/double_exact_test.mbt
@@ -1,0 +1,182 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `parse_double` against exact arithmetic.
+//
+// The properties in `double_quickcheck_test.mbt` pin down internal
+// consistency: every spelling of a decimal agrees with every other, the
+// result is monotone, and it round-trips. All of that would still hold if
+// the parser were uniformly off by an ulp. What settles the remaining
+// question is the definition itself — the nearest double to the exact
+// rational `mantissa x 10^exponent`, ties to even — so the oracle below
+// computes exactly that in `BigInt` and compares bit patterns.
+//
+// The exact value is held as `num / den` with both sides integral. Scaling
+// it by a power of two puts the quotient in `[2^52, 2^53)`, and the
+// remainder decides the rounding. Nothing here shares code, tables, or
+// approximations with the implementation.
+
+///|
+
+///|
+let big_one : @bigint.BigInt = @bigint.BigInt::from_int(1)
+
+///|
+let big_two : @bigint.BigInt = @bigint.BigInt::from_int(2)
+
+///|
+let big_ten : @bigint.BigInt = @bigint.BigInt::from_int(10)
+
+///|
+/// `round(a / b)` to nearest, ties to even. `b` must be positive.
+fn div_round_even(a : @bigint.BigInt, b : @bigint.BigInt) -> @bigint.BigInt {
+  let q = a / b
+  let r = a % b
+  let twice = r * big_two
+  match twice.compare(b) {
+    c if c < 0 => q
+    c if c > 0 => q + big_one
+    // Exactly halfway: take the even neighbour.
+    _ => if (q % big_two).is_zero() { q } else { q + big_one }
+  }
+}
+
+///|
+/// Builds the double `magnitude * 2^(exponent)` from an integral
+/// significand, by assembling the IEEE-754 bit pattern directly rather than
+/// going through arithmetic that could round a second time.
+///
+/// `significand` is in `[2^52, 2^53)` for a normal number, or below `2^52`
+/// with `unbiased == -1074` for a subnormal.
+fn assemble(neg : Bool, significand : UInt64, unbiased : Int) -> Double {
+  let sign = if neg { 0x8000000000000000UL } else { 0UL }
+  let bits = if significand < 0x10000000000000UL {
+    // Subnormal (or zero): the exponent field is 0 and the significand is
+    // the fraction outright.
+    sign | significand
+  } else {
+    let biased = (unbiased + 1023).to_uint64()
+    sign | (biased << 52) | (significand - 0x10000000000000UL)
+  }
+  bits.reinterpret_as_double()
+}
+
+///|
+/// The correctly rounded double nearest to `sign * digits * 10^exponent`,
+/// or `None` when the magnitude overflows the format — matching the
+/// implementation's choice to report overflow as an error rather than as an
+/// infinity. Underflow is a signed zero, not an error.
+fn oracle_double(neg : Bool, digits : String, exponent : Int) -> Double? {
+  let mantissa = @bigint.BigInt::from_string(digits)
+  if mantissa.is_zero() {
+    return Some(assemble(neg, 0UL, 0))
+  }
+  // The exact value as num / den.
+  let mut num = mantissa
+  let mut den = big_one
+  if exponent >= 0 {
+    num = num * big_ten.pow(@bigint.BigInt::from_int(exponent))
+  } else {
+    den = big_ten.pow(@bigint.BigInt::from_int(-exponent))
+  }
+  // `p` is the position of the leading bit: the largest p with
+  // num/den >= 2^p. Start from the bit lengths and correct by one.
+  let mut p = num.bit_length() - den.bit_length()
+  if scaled_compare(num, den, p) < 0 {
+    p = p - 1
+  }
+  // Round the significand at 52 bits below the leading bit, except in the
+  // subnormal range where the exponent is pinned at -1074.
+  let shift = if p < -1022 { 1074 } else { 52 - p }
+  let (a, b) = if shift >= 0 {
+    (num.shl(shift), den)
+  } else {
+    (num, den.shl(-shift))
+  }
+  let mut q = div_round_even(a, b)
+  let mut unbiased = if p < -1022 { -1074 } else { p }
+  // Rounding up can carry into the next binade.
+  if q.compare(big_one.shl(53)) >= 0 {
+    q = q.shr(1)
+    unbiased = unbiased + 1
+  }
+  if unbiased > 1023 {
+    return None
+  }
+  Some(assemble(neg, q.to_uint64_exact(), unbiased))
+}
+
+///|
+/// Compares `num / den` with `2^p` without dividing.
+fn scaled_compare(num : @bigint.BigInt, den : @bigint.BigInt, p : Int) -> Int {
+  if p >= 0 {
+    num.compare(den.shl(p))
+  } else {
+    num.shl(-p).compare(den)
+  }
+}
+
+///|
+/// `BigInt` has no `to_uint64`; the significand always fits in 53 bits, so
+/// go through the low 64 bits of the two's complement representation.
+fn @bigint.BigInt::to_uint64_exact(self : @bigint.BigInt) -> UInt64 {
+  self.to_int64().reinterpret_as_uint64()
+}
+
+///|
+test "quickcheck: parse_double is the correctly rounded value" {
+  @quickcheck.check(
+    (input : (Bool, Array[Int], Int, Int)) => {
+      let (neg, raw, len_code, exp_code) = input
+      let exponent = wrap_index(exp_code, 760) - 380
+      let lit = Literal::make(neg, raw, len_code, exponent)
+      match (parsed(lit.plain()), oracle_double(neg, lit.digits, exponent)) {
+        (Some(a), Some(b)) => same_double(a, b)
+        (None, None) => true
+        _ => false
+      }
+    },
+    count=20000,
+  )
+}
+
+///|
+/// The same comparison aimed at the hard cases: mantissas just either side
+/// of a rounding boundary, where a parser that is even slightly imprecise
+/// picks the wrong neighbour.
+test "quickcheck: parse_double rounds correctly at the boundaries" {
+  @quickcheck.check(
+    (input : (UInt64, Int, Int)) => {
+      let (raw, exp_code, nudge) = input
+      // Start from an actual double, take its exact decimal expansion, and
+      // step a few units in the last decimal place. Halfway cases between
+      // two doubles land in this neighbourhood.
+      let significand = raw % 9007199254740992UL + 4503599627370496UL
+      let exponent = wrap_index(exp_code, 60) - 30
+      let stepped = significand.reinterpret_as_int64() +
+        (wrap_index(nudge, 11) - 5).to_int64()
+      let digits = stepped.to_string()
+      match
+        (
+          parsed("\{digits}e\{exponent}"),
+          oracle_double(false, digits, exponent),
+        ) {
+        (Some(a), Some(b)) => same_double(a, b)
+        (None, None) => true
+        _ => false
+      }
+    },
+    count=20000,
+  )
+}

--- a/internal/strconv/double_quickcheck_test.mbt
+++ b/internal/strconv/double_quickcheck_test.mbt
@@ -1,0 +1,222 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Specification tests for `parse_double`.
+//
+// `parse_double` has three routes to an answer — Clinger's fast path, its
+// "disguised" extension, and the decimal slow path — chosen from the shape
+// of the input rather than from its value. That makes the interesting
+// specification a *representation-independence* one: two spellings of the
+// same exact decimal must produce the same double, even when they take
+// different routes. Padding a mantissa with zeros is enough to force the
+// slow path, so the properties below compare spellings that are equal by
+// construction and let the implementation pick different routes for them.
+
+///|
+/// Compares doubles by bit pattern, so `0.0` and `-0.0` are distinguished
+/// and two NaNs with the same payload compare equal.
+fn same_double(a : Double, b : Double) -> Bool {
+  a.reinterpret_as_uint64() == b.reinterpret_as_uint64()
+}
+
+///|
+fn parsed(text : String) -> Double? {
+  Some(@strconv.parse_double(text)) catch {
+    _ => None
+  }
+}
+
+///|
+fn repeat_char(c : Char, n : Int) -> String {
+  String::from_array(Array::make(n, c))
+}
+
+///|
+/// A decimal literal: `digits` scaled by `10^exponent`, optionally negative.
+/// Every spelling produced from one of these denotes the same exact number.
+struct Literal {
+  neg : Bool
+  digits : String
+  exponent : Int
+}
+
+///|
+/// `length` is taken up to 45 digits so that mantissas routinely exceed the
+/// 19 the fast path can hold — that is what makes the two routes diverge if
+/// they are going to.
+fn Literal::make(
+  neg : Bool,
+  raw : ArrayView[Int],
+  length_code : Int,
+  exponent : Int,
+) -> Literal {
+  let length = wrap_index(length_code, 45) + 1
+  let digits = String::from_array(
+    Array::makei(length, i => {
+      let seed = if raw.length() == 0 { i } else { raw[i % raw.length()] + i }
+      (wrap_index(seed, 10) + '0').unsafe_to_char()
+    }),
+  )
+  { neg, digits, exponent }
+}
+
+///|
+fn Literal::sign(self : Literal) -> String {
+  if self.neg {
+    "-"
+  } else {
+    ""
+  }
+}
+
+///|
+/// `digits e exponent` — the plain spelling.
+fn Literal::plain(self : Literal) -> String {
+  "\{self.sign()}\{self.digits}e\{self.exponent}"
+}
+
+///|
+/// The decimal point moved `p` digits in from the left, with the exponent
+/// compensating. `p == len` is the plain spelling with a trailing point.
+fn Literal::pointed(self : Literal, p : Int) -> String {
+  let len = self.digits.length()
+  let p = wrap_index(p, len + 1)
+  let head = self.digits[0:p].to_owned()
+  let tail = self.digits[p:len].to_owned()
+  let head = if head == "" { "0" } else { head }
+  "\{self.sign()}\{head}.\{tail}e\{self.exponent + len - p}"
+}
+
+///|
+/// `k` zeros appended to the mantissa, with the exponent compensating. This
+/// is the spelling that forces the slow path once the digit count passes
+/// the fast path's limit.
+fn Literal::padded(self : Literal, k : Int) -> String {
+  let k = wrap_index(k, 30)
+  "\{self.sign()}\{self.digits}\{repeat_char('0', k)}e\{self.exponent - k}"
+}
+
+///|
+/// `k` insignificant zeros in front of the mantissa.
+fn Literal::leading(self : Literal, k : Int) -> String {
+  let k = wrap_index(k, 30)
+  "\{self.sign()}\{repeat_char('0', k)}\{self.digits}e\{self.exponent}"
+}
+
+///|
+/// `0.000…digits`, with the exponent compensating — the same value written
+/// as a pure fraction.
+fn Literal::fractional(self : Literal, k : Int) -> String {
+  let k = wrap_index(k, 30)
+  let len = self.digits.length()
+  "\{self.sign()}0.\{repeat_char('0', k)}\{self.digits}e\{self.exponent + len + k}"
+}
+
+///|
+/// Every spelling of the same exact decimal must parse to the same double.
+test "quickcheck: parse_double is independent of the spelling" {
+  @quickcheck.check(
+    (input : (Bool, Array[Int], Int, Int, Int, Int)) => {
+      let (neg, raw, len_code, exp_code, p, k) = input
+      // Exponents span the whole interesting range: subnormal, normal, and
+      // both saturating ends.
+      let exponent = wrap_index(exp_code, 700) - 350
+      let lit = Literal::make(neg, raw, len_code, exponent)
+      let reference = parsed(lit.plain())
+      [
+        lit.pointed(p),
+        lit.padded(k),
+        lit.leading(k),
+        lit.fractional(k),
+        lit.padded(k + 17),
+        lit.pointed(p + 1),
+      ].all(spelling => {
+        match (parsed(spelling), reference) {
+          (Some(a), Some(b)) => same_double(a, b)
+          (None, None) => true
+          _ => false
+        }
+      })
+    },
+    count=20000,
+  )
+}
+
+///|
+/// Clinger's theorem: when the mantissa is exactly representable and the
+/// power of ten is too, one rounding gives the correctly rounded result. So
+/// on that subset the parser must agree with plain double arithmetic.
+test "quickcheck: parse_double is exact on the Clinger subset" {
+  @quickcheck.check(
+    (input : (Int64, Int)) => {
+      let (raw, exp_code) = input
+      // |mantissa| <= 2^53 and |exponent| <= 22 keep both operands exact.
+      let mantissa = raw % 9007199254740993L
+      let exponent = wrap_index(exp_code, 45) - 22
+      let text = "\{mantissa}e\{exponent}"
+      // Built by repeated multiplication rather than `pow`: every power of
+      // ten up to 10^22 is exactly representable, so this is exact.
+      let mut power = 1.0
+      for _ in 0..<exponent.abs() {
+        power = power * 10.0
+      }
+      let expected = if exponent >= 0 {
+        mantissa.to_double() * power
+      } else {
+        mantissa.to_double() / power
+      }
+      parsed(text) is Some(v) && same_double(v, expected)
+    },
+    count=20000,
+  )
+}
+
+///|
+/// Parsing is monotone: at a fixed exponent, a larger mantissa cannot parse
+/// to a smaller double.
+test "quickcheck: parse_double is monotone in the mantissa" {
+  @quickcheck.check(
+    (input : (UInt64, UInt64, Int)) => {
+      let (a, b, exp_code) = input
+      let lo = if a <= b { a } else { b }
+      let hi = if a <= b { b } else { a }
+      let exponent = wrap_index(exp_code, 700) - 350
+      match (parsed("\{lo}e\{exponent}"), parsed("\{hi}e\{exponent}")) {
+        (Some(x), Some(y)) => x <= y
+        // Overflow is reported as an error rather than an infinity, so the
+        // larger mantissa may drop out where the smaller one does not.
+        // The reverse would mean the order was inverted.
+        (Some(_), None) => true
+        (None, None) => true
+        (None, Some(_)) => false
+      }
+    },
+    count=20000,
+  )
+}
+
+///|
+/// `Double::to_string` produces a decimal that reads back as the same
+/// double — the round-trip the shortest-representation printer promises.
+test "quickcheck: to_string round-trips through parse_double" {
+  @quickcheck.check(
+    (d : Double) => {
+      if d.is_nan() || d.is_inf() {
+        return true
+      }
+      parsed(d.to_string()) is Some(back) && same_double(back, d)
+    },
+    count=20000,
+  )
+}

--- a/internal/strconv/moon.pkg
+++ b/internal/strconv/moon.pkg
@@ -10,4 +10,6 @@ import {
 
 import {
   "moonbitlang/core/bench",
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/bigint",
 } for "test"

--- a/internal/strconv/quickcheck_test.mbt
+++ b/internal/strconv/quickcheck_test.mbt
@@ -1,0 +1,392 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Specification tests for the integer parsers.
+//
+// The oracle below is written from the documented grammar, not from the
+// implementation: sign, optional base prefix, digits separated by single
+// underscores, every digit below the base, and a magnitude that fits the
+// target type. Accumulation is done in `UInt64` with an exact
+// `acc > (limit - d) / base` overflow test, so the oracle's notion of "out
+// of range" does not depend on the same threshold arithmetic the
+// implementation uses.
+//
+// The inputs are short strings over an alphabet chosen to sit on the
+// grammar's boundaries — digits either side of every base, letters either
+// side of 'f' and 'z', both cases, the prefix letters, underscore, both
+// signs, and two characters that are never valid.
+
+///|
+let alphabet : Array[Char] = [
+  '0', '1', '7', '8', '9', 'a', 'f', 'g', 'z', 'A', 'F', 'Z', '_', '+', '-', 'x',
+  'X', 'o', 'O', 'b', 'B', ' ', '.',
+]
+
+///|
+/// Bases worth trying: 0 (infer), every base with a prefix, the two
+/// endpoints of the valid range, a couple of ordinary ones, and three
+/// invalid ones.
+let bases : Array[Int] = [0, 2, 8, 10, 16, 36, 3, 7, 35, 1, 37, -1]
+
+///|
+fn wrap_index(value : Int, modulus : Int) -> Int {
+  let r = value % modulus
+  if r < 0 {
+    r + modulus
+  } else {
+    r
+  }
+}
+
+///|
+fn make_text(codes : ArrayView[Int]) -> String {
+  String::from_array(
+    Array::makei(codes.length(), i => {
+      alphabet[wrap_index(codes[i], alphabet.length())]
+    }),
+  )
+}
+
+///|
+/// The digit value of `c` in base 36, or `None` if it is not a digit.
+fn digit_value(c : Char) -> Int? {
+  let n = c.to_int()
+  if n >= '0' && n <= '9' {
+    Some(n - '0')
+  } else if n >= 'a' && n <= 'z' {
+    Some(n - 'a' + 10)
+  } else if n >= 'A' && n <= 'Z' {
+    Some(n - 'A' + 10)
+  } else {
+    None
+  }
+}
+
+///|
+/// The base a prefix introduces, if `chars[i..]` starts with one.
+fn prefix_base(chars : ArrayView[Char], i : Int) -> Int? {
+  if i + 1 >= chars.length() || chars[i] != '0' {
+    return None
+  }
+  match chars[i + 1] {
+    'x' | 'X' => Some(16)
+    'o' | 'O' => Some(8)
+    'b' | 'B' => Some(2)
+    _ => None
+  }
+}
+
+///|
+/// Shared front end: validates the base, consumes a sign if `signed`, and
+/// consumes a base prefix when it agrees with `base`. Returns the sign, the
+/// effective base, the index of the first digit, and whether an underscore
+/// may lead the digits (only just after a prefix).
+fn scan_prefix(
+  chars : ArrayView[Char],
+  base : Int,
+  signed : Bool,
+) -> (Bool, Int, Int, Bool)? {
+  guard base == 0 || (base >= 2 && base <= 36) else { return None }
+  guard chars.length() > 0 else { return None }
+  let mut i = 0
+  let mut neg = false
+  if chars[0] is ('+' | '-') {
+    guard signed else { return None }
+    neg = chars[0] == '-'
+    i = 1
+  }
+  match prefix_base(chars, i) {
+    Some(p) if base == 0 || base == p => Some((neg, p, i + 2, true))
+    _ => Some((neg, if base == 0 { 10 } else { base }, i, false))
+  }
+}
+
+///|
+/// The digits of `chars[start..]` in `base`, or `None` if the digit/underscore
+/// grammar is violated. `lead_underscore` says whether a single underscore may
+/// come first (it may, exactly when a prefix was just consumed).
+fn scan_digits(
+  chars : ArrayView[Char],
+  start : Int,
+  base : Int,
+  lead_underscore : Bool,
+) -> Array[Int]? {
+  let digits = []
+  let mut underscore_ok = lead_underscore
+  let mut after_underscore = false
+  for i in start..<chars.length() {
+    if chars[i] == '_' {
+      guard underscore_ok else { return None }
+      underscore_ok = false
+      after_underscore = true
+    } else {
+      guard digit_value(chars[i]) is Some(d) && d < base else { return None }
+      digits.push(d)
+      underscore_ok = true
+      after_underscore = false
+    }
+  }
+  // A trailing underscore, or no digit at all, is not a number.
+  guard !after_underscore && digits.length() > 0 else { return None }
+  Some(digits)
+}
+
+///|
+/// Folds `digits` in `base`, or `None` if the magnitude exceeds `limit`.
+/// Exact: `acc * base + d <= limit` iff `acc <= (limit - d) / base`.
+fn fold_digits(digits : ArrayView[Int], base : Int, limit : UInt64) -> UInt64? {
+  let b = base.to_uint64()
+  let mut acc = 0UL
+  for d in digits {
+    let dv = d.to_uint64()
+    guard acc <= (limit - dv) / b else { return None }
+    acc = acc * b + dv
+  }
+  Some(acc)
+}
+
+///|
+/// Reference `parse_int64`. `None` means "must be rejected".
+fn oracle_int64(text : String, base : Int) -> Int64? {
+  let chars = text.to_array()[:]
+  guard scan_prefix(chars, base, true) is Some((neg, eff, start, lead)) else {
+    return None
+  }
+  guard scan_digits(chars, start, eff, lead) is Some(digits) else {
+    return None
+  }
+  // Two's complement: the negative range reaches one further than the
+  // positive one.
+  let limit = if neg { 0x8000000000000000UL } else { 0x7fffffffffffffffUL }
+  guard fold_digits(digits, eff, limit) is Some(magnitude) else { return None }
+  let v = magnitude.reinterpret_as_int64()
+  Some(if neg { 0L - v } else { v })
+}
+
+///|
+/// Reference `parse_uint64`. Signs are not part of the grammar here.
+fn oracle_uint64(text : String, base : Int) -> UInt64? {
+  let chars = text.to_array()[:]
+  guard scan_prefix(chars, base, false) is Some((_, eff, start, lead)) else {
+    return None
+  }
+  guard scan_digits(chars, start, eff, lead) is Some(digits) else {
+    return None
+  }
+  fold_digits(digits, eff, 0xffffffffffffffffUL)
+}
+
+///|
+fn actual_int64(text : String, base : Int) -> Int64? {
+  Some(@strconv.parse_int64(text, base~)) catch {
+    _ => None
+  }
+}
+
+///|
+fn actual_int(text : String, base : Int) -> Int? {
+  Some(@strconv.parse_int(text, base~)) catch {
+    _ => None
+  }
+}
+
+///|
+fn actual_uint64(text : String, base : Int) -> UInt64? {
+  Some(@strconv.parse_uint64(text, base~)) catch {
+    _ => None
+  }
+}
+
+///|
+fn actual_uint(text : String, base : Int) -> UInt? {
+  Some(@strconv.parse_uint(text, base~)) catch {
+    _ => None
+  }
+}
+
+// =====================================================================
+// Well-formed numerals, biased at the type boundaries.
+//
+// Random text is good at the grammar but almost never long enough to
+// overflow: `Int64` needs 19 decimal digits. These properties render a
+// magnitude in the target base instead — with every combination of sign,
+// prefix, and interior underscores the grammar allows — and bias the
+// magnitude towards the values where a threshold is off by one.
+// =====================================================================
+
+///|
+/// Magnitudes where an overflow check can be wrong by one.
+let boundaries : Array[UInt64] = [
+  0, 1, 0x7ffffffe, 0x7fffffff, 0x80000000, 0x80000001, 0xfffffffe, 0xffffffff, 0x100000000,
+  0x7ffffffffffffffe, 0x7fffffffffffffff, 0x8000000000000000, 0x8000000000000001,
+  0xfffffffffffffffe, 0xffffffffffffffff,
+]
+
+///|
+/// `choice` either keeps the generated magnitude or swaps in a boundary,
+/// so a run covers both the bulk of the space and its edges.
+fn pick_magnitude(raw : UInt64, choice : Int) -> UInt64 {
+  if choice % 2 == 0 {
+    boundaries[wrap_index(choice / 2, boundaries.length())]
+  } else {
+    raw
+  }
+}
+
+///|
+/// Renders `magnitude` in `base`. `flags` selects the sign, whether a base
+/// prefix is emitted (only where one exists and agrees), the digit case,
+/// and which gaps between digits get an underscore.
+fn render(magnitude : UInt64, base : Int, flags : Int) -> String {
+  let digits = []
+  let b = base.to_uint64()
+  let mut n = magnitude
+  if n == 0 {
+    digits.push(0)
+  }
+  while n > 0 {
+    digits.push((n % b).to_int())
+    n = n / b
+  }
+  digits.rev_in_place()
+  let upper = flags / 2 % 2 == 0
+  let out = StringBuilder::new()
+  match flags % 4 {
+    1 => out.write_char('+')
+    2 => out.write_char('-')
+    _ => ()
+  }
+  if flags / 4 % 2 == 0 {
+    match base {
+      16 => out.write_string("0x")
+      8 => out.write_string("0o")
+      2 => out.write_string("0b")
+      _ => ()
+    }
+  }
+  for i, d in digits {
+    // An underscore may sit between any two digits; the bit pattern of
+    // `flags` decides which gaps take one.
+    if i > 0 && flags / 8 / (1 << (i % 20)) % 2 == 1 {
+      out.write_char('_')
+    }
+    let c = if d < 10 {
+      (d + '0').unsafe_to_char()
+    } else if upper {
+      (d - 10 + 'A').unsafe_to_char()
+    } else {
+      (d - 10 + 'a').unsafe_to_char()
+    }
+    out.write_char(c)
+  }
+  out.to_string()
+}
+
+///|
+test "quickcheck: signed numerals at the type boundaries" {
+  @quickcheck.check(
+    (input : (UInt64, Int, Int, Int)) => {
+      let (raw, choice, base_code, flags) = input
+      let base = bases[wrap_index(base_code, bases.length())]
+      let render_base = if base is (2..=36) { base } else { 10 }
+      let text = render(pick_magnitude(raw, choice), render_base, flags)
+      actual_int64(text, base) == oracle_int64(text, base) &&
+      actual_int(text, base) ==
+      (match oracle_int64(text, base) {
+        Some(v) if v >= -2147483648L && v <= 2147483647L => Some(v.to_int())
+        _ => None
+      })
+    },
+    count=20000,
+  )
+}
+
+///|
+test "quickcheck: unsigned numerals at the type boundaries" {
+  @quickcheck.check(
+    (input : (UInt64, Int, Int, Int)) => {
+      let (raw, choice, base_code, flags) = input
+      let base = bases[wrap_index(base_code, bases.length())]
+      let render_base = if base is (2..=36) { base } else { 10 }
+      let text = render(pick_magnitude(raw, choice), render_base, flags)
+      actual_uint64(text, base) == oracle_uint64(text, base) &&
+      actual_uint(text, base) ==
+      (match oracle_uint64(text, base) {
+        Some(v) if v <= 0xffffffffUL => Some(v.to_uint())
+        _ => None
+      })
+    },
+    count=20000,
+  )
+}
+
+///|
+test "quickcheck: parse_int64 agrees with the grammar" {
+  @quickcheck.check(
+    (input : (Int, Array[Int])) => {
+      let (base_code, codes) = input
+      let base = bases[wrap_index(base_code, bases.length())]
+      let text = make_text(codes)
+      actual_int64(text, base) == oracle_int64(text, base)
+    },
+    count=20000,
+  )
+}
+
+///|
+test "quickcheck: parse_uint64 agrees with the grammar" {
+  @quickcheck.check(
+    (input : (Int, Array[Int])) => {
+      let (base_code, codes) = input
+      let base = bases[wrap_index(base_code, bases.length())]
+      let text = make_text(codes)
+      actual_uint64(text, base) == oracle_uint64(text, base)
+    },
+    count=20000,
+  )
+}
+
+///|
+test "quickcheck: parse_int is parse_int64 narrowed to 32 bits" {
+  @quickcheck.check(
+    (input : (Int, Array[Int])) => {
+      let (base_code, codes) = input
+      let base = bases[wrap_index(base_code, bases.length())]
+      let text = make_text(codes)
+      let expected = match oracle_int64(text, base) {
+        Some(v) if v >= -2147483648L && v <= 2147483647L => Some(v.to_int())
+        _ => None
+      }
+      actual_int(text, base) == expected
+    },
+    count=20000,
+  )
+}
+
+///|
+test "quickcheck: parse_uint is parse_uint64 narrowed to 32 bits" {
+  @quickcheck.check(
+    (input : (Int, Array[Int])) => {
+      let (base_code, codes) = input
+      let base = bases[wrap_index(base_code, bases.length())]
+      let text = make_text(codes)
+      let expected = match oracle_uint64(text, base) {
+        Some(v) if v <= 0xffffffffUL => Some(v.to_uint())
+        _ => None
+      }
+      actual_uint(text, base) == expected
+    },
+    count=20000,
+  )
+}


### PR DESCRIPTION
`internal/strconv` is the live number parser — `json`, `string` and the `Double`/`Int` parse entry points all bottom out here — and it had no property-based coverage. This adds three suites that state what the parsers are supposed to compute, independently of how they compute it.

**Tests only; no library change.** No defects found: the parsers are correct on everything these check.

## Integers — `quickcheck_test.mbt`

The oracle is the documented grammar written out longhand: sign, optional base prefix, digits separated by single underscores, every digit below the base, magnitude within the target type. It accumulates in `UInt64` with an exact `acc <= (limit - d) / base` test, so its notion of "out of range" does not inherit the implementation's threshold arithmetic.

Two generators feed it:

- **short strings over a boundary alphabet** — digits either side of every base, letters either side of `f` and `z`, both cases, the prefix letters, underscore, both signs, and two characters that are never valid;
- **well-formed numerals** rendered from magnitudes biased at the type limits, with every combination of sign, prefix, digit case and interior underscores. Random text is good at exercising the grammar but almost never long enough to overflow — `Int64` needs 19 decimal digits — so the overflow paths need numerals built on purpose.

## Doubles — `double_quickcheck_test.mbt`

`parse_double` chooses between Clinger's fast path, its disguised extension and the decimal slow path from the *shape* of the input rather than its value. That makes the interesting property representation-independence: every spelling of one exact decimal — decimal point moved, zeros padded onto the mantissa, leading zeros, written as a pure fraction — must produce the same double even though the routes differ. Padding a mantissa past the fast path's digit limit is enough to force the slow path, so these comparisons straddle the boundary by construction.

Also here: exactness on the subset where Clinger's theorem applies (mantissa and power of ten both exactly representable, so one rounding is provably correct), monotonicity in the mantissa, and the `to_string` round-trip.

## Doubles, exactly — `double_exact_test.mbt`

Everything above would still hold if the parser were uniformly off by an ulp. This suite settles the definition itself: the nearest double to the exact rational `mantissa × 10^exponent`, ties to even, computed in `BigInt` and compared bit for bit. It shares no code, tables or approximations with the implementation — the value is held as `num / den`, scaled by a power of two until the quotient has 53 bits, and the remainder decides the rounding.

I validated the oracle before trusting its verdict. It reproduces the classic hard-to-round cases, and the implementation agrees with it on all of them:

| input | bits |
| --- | --- |
| `0.1` | `0x3FB999999999999A` |
| `1e23` | `0x44B52D02C7E14AF6` |
| `9007199254740993` (2^53+1) | `0x4340000000000000` — ties to even |
| `9007199254740995` (2^53+3) | `0x4340000000000002` |
| `2.2250738585072011e-308` | `0x000FFFFFFFFFFFFF` — largest subnormal |
| `2.2250738585072014e-308` | `0x0010000000000000` — smallest normal |
| `2.4703282292062327e-324` / `…28e-324` | `0` / `1` — either side of the midpoint below the smallest subnormal |
| `17976931348623157e292` / `…59e292` | largest finite / range error |

## Verification

`moon check --deny-warn --target all`, `moon test --target all`, `moon test --release` (js/wasm/wasm-gc and native), `moon fmt`, `moon info` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
