### PR TITLE
fix(regex): stop applying a sequence's continuation twice

### DIFF
--- a/internal/regex_engine/automata/thread_set.mbt
+++ b/internal/regex_engine/automata/thread_set.mbt
@@ -217,15 +217,32 @@ fn ThreadSet::split_at_first_match(self : ThreadSet) -> (ThreadSet, ThreadSet) {
 }
 
 ///|
+/// Drops threads that cannot contribute anything an earlier thread does not
+/// already cover: two threads with the same future differ only in priority,
+/// so the later one can go.
+///
+/// Threads in `self` all continue with `next` once they finish, which is
+/// what makes a thread that has *already* finished — one sitting at `Eps` —
+/// equivalent to a thread sitting at `next` itself. Both are keyed by
+/// `next.id` so that the pair collapses to one; without that, a sequence
+/// whose first part can both finish and continue doubles its thread set on
+/// every character.
+///
+/// The equivalence is used as a dedup key only. Rewriting the finished
+/// thread to `Exp(marks, next)` would *look* like the same statement, but
+/// the caller wraps the result in `ts_seq(.., next)`, which appends `next`
+/// again — so the continuation would be matched twice over. Keeping the
+/// thread at `Eps` also leaves `ts_seq` able to collapse a sequence whose
+/// first part has come down to a single finished thread.
 fn ThreadSet::remove_duplicates(self : ThreadSet, next : Expr) -> ThreadSet {
   let seen = @hashset.HashSet([])
   for thread in self; result = ts_empty {
     match thread {
       End(_) => break result + ts_one(thread)
-      Exp(marks, { def: Eps, .. }) =>
+      Exp(_, { def: Eps, .. }) =>
         if !seen.contains(next.id) {
           seen.add(next.id)
-          continue result + ts_exp(marks, next)
+          continue result + ts_one(thread)
         } else {
           continue result
         }

--- a/string/regex_test.mbt
+++ b/string/regex_test.mbt
@@ -724,6 +724,129 @@ test "capture/email_with_named_groups" {
   )
 }
 
+// Alternation branches that accept the same character.
+//
+// When more than one branch can consume the same character, the alternation
+// leaves more than one thread behind — two that have finished it where the
+// branches are single characters, one finished and one still going where
+// they differ in length. A thread that has finished used to be rewritten to
+// carry the continuation, and the sequence it sat in then appended that
+// continuation a second time, so the text after the alternation had to
+// appear twice for the match to succeed. Every case below turns on that,
+// and each character is exercised on both sides of the overlap.
+
+///|
+test "execute/alternation with an overlapping branch" {
+  // The two branches are the same expression, so both accept 'a'.
+  guard @string.Regex("(?:a|a)c").execute("ac") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="ac")
+  // The continuation must be consumed once, not twice.
+  guard @string.Regex("(?:a|a)c").execute("acc") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="ac")
+  // ...however long it is.
+  guard @string.Regex("(?:a|a)bc").execute("abcbc") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="abc")
+}
+
+///|
+test "execute/alternation of overlapping character classes" {
+  let regex = @string.Regex("(?:[ab]|[bc])x")
+  // 'a' comes only from the left branch, 'c' only from the right, and 'b'
+  // from both — it is the shared one that used to fail.
+  guard regex.execute("ax") is Some(m) else { fail("expected a match") }
+  inspect(m.content(), content="ax")
+  guard regex.execute("bx") is Some(m) else { fail("expected a match") }
+  inspect(m.content(), content="bx")
+  guard regex.execute("cx") is Some(m) else { fail("expected a match") }
+  inspect(m.content(), content="cx")
+  // The same alternation reached through the combinator API.
+  let combined = (re"[ab]" | re"[bc]") + re"x"
+  guard combined.execute("bx") is Some(m) else { fail("expected a match") }
+  inspect(m.content(), content="bx")
+}
+
+///|
+test "execute/alternation branches of different lengths" {
+  // Both branches start with 'a', and they finish at different points.
+  guard @string.Regex("(?:a|ab)c").execute("ac") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="ac")
+  guard @string.Regex("(?:ab|a)c").execute("abc") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="abc")
+  // A span that is not in the language must not be reported: from 0 only
+  // `a` applies, so the match can end at 1 or 2 but never at 3.
+  guard @string.Regex("(?:.a|a)(?:b|)").execute("abb") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="ab")
+}
+
+///|
+test "execute/overlapping alternation under a counted repetition" {
+  // Each iteration can only take one character here, so the bounds are what
+  // decide the length.
+  guard @string.Regex("(?:.|ab){2}").execute("aaaaa") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="aa")
+  guard @string.Regex("(?:.|ab){2,4}").execute("aaaaa") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="aaaa")
+}
+
+///|
+test "execute/overlapping alternation keeps anchors and preference" {
+  // Anchored: the whole subject has to be consumed exactly once.
+  guard @string.Regex("^(?:a|a)c$").execute("ac") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="ac")
+  inspect(@string.Regex("^(?:a|a)c$").execute("acc") is None, content="true")
+  // Preference survives the overlap: the greedy branch wins the character
+  // and the lazy one yields it, and the capture reports which.
+  guard @string.Regex("(?:(a+)|a)(a*)").execute("aaa") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="aaa")
+  debug_inspect(
+    m.group(1),
+    content=(
+      #|Some(<StringView: "aaa">)
+    ),
+  )
+  guard @string.Regex("(?:(a+?)|a)(a*)").execute("aaa") is Some(m) else {
+    fail("expected a match")
+  }
+  inspect(m.content(), content="aaa")
+  debug_inspect(
+    m.group(1),
+    content=(
+      #|Some(<StringView: "a">)
+    ),
+  )
+  // The left branch is preferred where both accept the character.
+  guard @string.Regex("(?:(a)|(a))b").execute("ab") is Some(m) else {
+    fail("expected a match")
+  }
+  debug_inspect(
+    m.group(1),
+    content=(
+      #|Some(<StringView: "a">)
+    ),
+  )
+  debug_inspect(m.group(2), content="None")
+}
+
 ///|
 test "capture/multiple_captures_same_pattern" {
   let word = re"[[:alpha:]]+"


### PR DESCRIPTION
Closes #4072.

## The bug

When more than one alternation branch accepts the same character, the alternation leaves more than one thread behind — two that have finished it where the branches are single characters, one finished and one still going where they differ in length. The text after the alternation then had to appear **twice** for the match to succeed.

```moonbit
Regex("(?:a|a)c").execute("ac")      // None
Regex("(?:a|a)c").execute("acc")     // matched "acc"
Regex("(?:a|a)bc").execute("abcbc")  // matched "abcbc"
```

Beyond missed matches it reported spans that are not in the language, and let a counted repetition run past its maximum:

```moonbit
Regex("(?:.a|a)(?:b|)").execute("abb")   // matched "abb" — the language admits ends 1 and 2 only
Regex("(?:.|ab){2,4}").execute("aaaaa")  // matched five characters
```

Both `Regex::compile` and the combinator API (`(re"[ab]" | re"[bc]") + re"x"`) were affected. The `re""` literal mostly escaped, because that path folds an alternation of character classes into a single class before the engine sees it — which is also why this went unnoticed.

## The cause

The engine is a Brzozowski-derivative simulation over a `ThreadSet`, where `Seq(pref, first, next)` means "the threads in `first`, then `next`".

`ThreadSet::remove_duplicates(self, next)` walks one set whose shared continuation is `next`. Its arm for a *finished* thread — one sitting at `Eps` — rewrote it to `Exp(marks, next)`, folding the continuation into the thread. The `Seq` arm of the same function then does

```moonbit
ts_seq(pref, first.remove_duplicates(next), next)
```

which appends `next` again. Hence the doubling. It only shows when the alternation leaves more than one thread alive, so disjoint branches were fine. Wrapping the same alternation in a capturing group also hid it — because the zero-width mark expressions a capture inserts change the continuation structure, not because slots distinguish the threads: dedup ignores marks and slots entirely.

## The fix

One line: leave the finished thread at `Eps` and emit it unchanged, keeping the `next.id` dedup key.

The key is load-bearing and the rewrite is not the same thing as the key. Keying a finished thread by `next.id` is what collapses it with a thread already sitting at `next`; without that collapse, a sequence whose first part can both finish and continue doubles its thread set every character. I tried deleting the special case outright first — keying finished threads by the `Eps` id instead — and `^(?:.a?)*$` exhausted the heap at ~31 characters. So the equivalence stays as a *key*, and only the emitted thread changes. As a bonus this restores `ts_seq`'s ability to collapse a sequence whose first part has come down to one finished thread, which the rewrite had been defeating. The resulting behaviour matches [ocaml-re](https://github.com/ocaml/ocaml-re/blob/master/lib/automata.ml), which this engine is a port of.

## Not fixed here

`^(?:.a?)*$` still exhausts the heap at 31 characters on `main` and on this branch alike — a repetition body of variable length makes the thread set grow like Fibonacci in the subject length. That is a separate, pre-existing defect, filed as #4074. This PR is deliberately no better and no worse on it.

## Tests

Five regression tests in `string/regex_test.mbt`, each of which fails without the fix: identical branches with a continuation of one and of several characters; overlapping character classes probed on both the exclusive and the shared character, plus the same alternation through the combinator API; branches of differing length in both orders; the two over-match shapes (a span outside the language, and a `{n,m}` exceeding `m`); and an anchored case plus greedy/lazy and left-branch capture preference, to pin down that the overlap does not disturb priority or which group is reported.

The property suite that found this — `Regex` against the textbook definition of the language a regular expression denotes — is not included: it also reaches #4074 and would exhaust the heap in CI. I will land it once #4074 is fixed, as a regression suite for both.

## Verification

`moon check --deny-warn --target all`, `moon test --target all`, `moon test --release` (js/wasm/wasm-gc and native), `moon test --target llvm`, `moon fmt`, `moon info`, `moon bundle --all` — all clean, no regressions across the 7000+ existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
