### PR TITLE
refactor: use `[| ... |]` iterator literals across the project

### DIFF
--- a/buffer/buffer_test.mbt
+++ b/buffer/buffer_test.mbt
@@ -28,10 +28,10 @@ test "create buffer from array" {
 
 ///|
 test "create buffer from iterator" {
-  let iter = [b'5', b'\x00', b'6', b'\x00', b'7', b'\x00'].iter()
+  let iter = [|b'5', b'\x00', b'6', b'\x00', b'7', b'\x00'|]
   let buf = @buffer.from_iter(iter)
   inspect(buf, content="567")
-  let iter = [].iter()
+  let iter = [||]
   let buf = @buffer.from_iter(iter)
   inspect(buf, content="")
   let iter = b"0\x00".iter()

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1924,7 +1924,7 @@ pub fn[A] Array::retain_map(
 ///
 /// ```mbt check
 /// test {
-///   let iter = Iter::singleton(42)
+///   let iter = [|42|]
 ///   let arr = Array::from_iter(iter)
 ///   debug_inspect(arr, content="[42]")
 /// }

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -596,7 +596,7 @@ pub fn BytesView::to_fixedarray(self : BytesView) -> FixedArray[Byte] {
 ///
 /// ```mbt check
 /// test {
-///   let iter = Iter::singleton(b'h')
+///   let iter = [|b'h'|]
 ///   let bytes = Bytes::from_iter(iter)
 ///   inspect(
 ///     bytes,

--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -423,21 +423,21 @@ test "FixedArray::from_array with array of different type" {
 
 ///|
 test "FixedArray::from_iter with multiple elements iterator" {
-  let iter = [1, 2, 3, 4, 5].iter()
+  let iter = [|1, 2, 3, 4, 5|]
   let result = FixedArray::from_iter(iter)
   @test.assert_eq(result, [1, 2, 3, 4, 5])
 }
 
 ///|
 test "FixedArray::from_iter with single element iterator" {
-  let iter = [1].iter()
+  let iter = [|1|]
   let result = FixedArray::from_iter(iter)
   @test.assert_eq(result, [1])
 }
 
 ///|
 test "FixedArray::from_iter with empty iterator" {
-  let iter : Iter[Int] = Iter::empty()
+  let iter : Iter[Int] = [||]
   let result = FixedArray::from_iter(iter)
   @test.assert_eq(result, [])
 }

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -29,7 +29,7 @@
 ///   let x = 42
 ///   ignore(x) // Explicitly ignore the value
 ///   let mut sum = 0
-///   ignore([1, 2, 3].iter().each(x => sum += x)) // Ignore the Unit return value of each()
+///   ignore([|1, 2, 3|].each(x => sum += x)) // Ignore the Unit return value of each()
 ///   inspect(sum, content="6")
 /// }
 /// ```

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "empty" {
-  let iter = Iter::empty()
+  let iter = [||]
   let exb = StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb)
@@ -22,7 +22,7 @@ test "empty" {
 
 ///|
 test "singleton" {
-  let iter = Iter::singleton('1')
+  let iter = [|'1'|]
   let exb = StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb, content="1")
@@ -52,7 +52,7 @@ test "count_if" {
   @test.assert_eq(iter.count_if(x => x % 2 == 0), 3)
   let iter = test_from_array([1, 2, 3])
   @test.assert_eq(iter.count_if(x => x > 99), 0)
-  let iter : Iter[Int] = Iter::empty()
+  let iter : Iter[Int] = [||]
   @test.assert_eq(iter.count_if(_ => true), 0)
 }
 
@@ -113,10 +113,7 @@ test "take_while" {
 test "take_while2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = StringBuilder(size_hint=0)
-  iter
-  .take_while(x => x != '4')
-  .concat(Iter::singleton('6'))
-  .each(x => exb.write_char(x))
+  iter.take_while(x => x != '4').concat([|'6'|]).each(x => exb.write_char(x))
   inspect(exb, content="1236")
 }
 
@@ -125,7 +122,7 @@ test "take_while3" {
   let iter = test_from_array([1, 2, 3])
   let res = iter
     .take_while(x => x != 4)
-    .concat(Iter::singleton(4))
+    .concat([|4|])
     .find_first(x => x % 2 == 0)
   debug_inspect(res, content="Some(2)")
 }
@@ -168,7 +165,7 @@ test "map_while2" {
   let exb = StringBuilder(size_hint=0)
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
-  .concat(Iter::singleton(6))
+  .concat([|6|])
   .each(x => exb.write_string("\{x}\n"))
   inspect(
     exb,
@@ -187,7 +184,7 @@ test "map_while3" {
   let iter = test_from_array([1, 2, 3])
   let res = iter
     .map_while(x => if x != 4 { Some(x) } else { None })
-    .concat(Iter::singleton(4))
+    .concat([|4|])
     .find_first(x => x % 2 == 0)
   debug_inspect(res, content="Some(2)")
 }
@@ -240,7 +237,7 @@ test "drop_while2" {
   let iter = test_from_array([1, 2, 3, 4, 5])
   let res = iter
     .drop_while(x => x <= 3)
-    .concat(Iter::singleton(6))
+    .concat([|6|])
     .find_first(x => x % 3 == 0)
   debug_inspect(res, content="Some(6)")
 }
@@ -251,7 +248,7 @@ test "drop_while3" {
   let exb = StringBuilder(size_hint=0)
   let res = iter
     .drop_while(x => x < 3)
-    .concat(Iter::singleton(6))
+    .concat([|6|])
     .find_first(x => {
       exb.write_char('x')
       x % 3 == 0
@@ -266,7 +263,7 @@ test "drop_while4" {
   let iter = test_from_array([1, 2, 3, 4, 5])
   let res = iter
     .drop_while(x => x <= 3)
-    .concat(Iter::singleton(6))
+    .concat([|6|])
     .drop(3)
     .find_first(x => x % 3 == 0)
   debug_inspect(res, content="None")
@@ -292,57 +289,47 @@ test "map" {
 
 ///|
 test "size_hint" {
-  let iter = [1, 2, 3].iter()
+  // an `Iter` literal and `Array::iter` report the same hint
+  debug_inspect([1, 2, 3].iter().size_hint(), content="Some(3)")
+  let iter = [|1, 2, 3|]
   debug_inspect(iter.size_hint(), content="Some(3)")
   debug_inspect(iter.next(), content="Some(1)")
   debug_inspect(iter.size_hint(), content="Some(2)")
   debug_inspect(iter.collect(), content="[2, 3]")
   debug_inspect(iter.size_hint(), content="Some(0)")
-  debug_inspect([1, 2, 3].iter().map(x => x + 1).size_hint(), content="Some(3)")
+  debug_inspect([|1, 2, 3|].map(x => x + 1).size_hint(), content="Some(3)")
   debug_inspect(
-    [1, 2, 3].iter().mapi((i, x) => i + x).size_hint(),
+    [|1, 2, 3|].mapi((i, x) => i + x).size_hint(),
     content="Some(3)",
   )
-  debug_inspect([1, 2, 3].iter().tap(_ => ()).size_hint(), content="Some(3)")
-  debug_inspect([1, 2, 3].iter().take(2).size_hint(), content="Some(2)")
-  debug_inspect([1, 2, 3].iter().take(5).size_hint(), content="Some(3)")
-  debug_inspect([1, 2, 3].iter().take(0).size_hint(), content="Some(0)")
-  debug_inspect([1, 2, 3].iter().drop(0).size_hint(), content="Some(3)")
-  debug_inspect([1, 2, 3].iter().drop(1).size_hint(), content="Some(2)")
-  debug_inspect([1, 2, 3].iter().drop(5).size_hint(), content="Some(0)")
-  debug_inspect(
-    [1, 2, 3].iter().concat([4, 5].iter()).size_hint(),
-    content="Some(5)",
-  )
-  debug_inspect(
-    [1, 2].iter().zip([3, 4, 5].iter()).size_hint(),
-    content="Some(2)",
-  )
-  debug_inspect(
-    [1, 2, 3].iter().zip([4, 5].iter()).size_hint(),
-    content="Some(2)",
-  )
-  let empty_left : Iter[Int] = Iter::empty()
+  debug_inspect([|1, 2, 3|].tap(_ => ()).size_hint(), content="Some(3)")
+  debug_inspect([|1, 2, 3|].take(2).size_hint(), content="Some(2)")
+  debug_inspect([|1, 2, 3|].take(5).size_hint(), content="Some(3)")
+  debug_inspect([|1, 2, 3|].take(0).size_hint(), content="Some(0)")
+  debug_inspect([|1, 2, 3|].drop(0).size_hint(), content="Some(3)")
+  debug_inspect([|1, 2, 3|].drop(1).size_hint(), content="Some(2)")
+  debug_inspect([|1, 2, 3|].drop(5).size_hint(), content="Some(0)")
+  debug_inspect([|1, 2, 3|].concat([|4, 5|]).size_hint(), content="Some(5)")
+  debug_inspect([|1, 2|].zip([|3, 4, 5|]).size_hint(), content="Some(2)")
+  debug_inspect([|1, 2, 3|].zip([|4, 5|]).size_hint(), content="Some(2)")
+  let empty_left : Iter[Int] = [||]
   debug_inspect(
     empty_left.zip(Iter::new(() => Some(1))).size_hint(),
     content="Some(0)",
   )
-  let empty_right : Iter[Int] = Iter::empty()
+  let empty_right : Iter[Int] = [||]
   debug_inspect(
     Iter::new(() => Some(1)).zip(empty_right).size_hint(),
     content="Some(0)",
   )
-  debug_inspect(
-    Iter::new(() => Some(1)).zip([1].iter()).size_hint(),
-    content="None",
-  )
-  debug_inspect([1, 2, 3].iter().intersperse(0).size_hint(), content="Some(5)")
+  debug_inspect(Iter::new(() => Some(1)).zip([|1|]).size_hint(), content="None")
+  debug_inspect([|1, 2, 3|].intersperse(0).size_hint(), content="Some(5)")
   debug_inspect(
     Iter::new(() => Some(1)).intersperse(0).size_hint(),
     content="None",
   )
-  debug_inspect([1, 2, 3].iter()[1:3].size_hint(), content="Some(2)")
-  debug_inspect([1, 2, 3].iter()[3:5].size_hint(), content="Some(0)")
+  debug_inspect([|1, 2, 3|][1:3].size_hint(), content="Some(2)")
+  debug_inspect([|1, 2, 3|][3:5].size_hint(), content="Some(0)")
   debug_inspect(
     Iter::new(() => Some(1)).view(start=2, end=1).size_hint(),
     content="Some(0)",
@@ -351,7 +338,7 @@ test "size_hint" {
     Iter::new(() => Some(1)).view(start=1, end=3).size_hint(),
     content="None",
   )
-  debug_inspect([1, 2, 3].iter().filter(x => x > 1).size_hint(), content="None")
+  debug_inspect([|1, 2, 3|].filter(x => x > 1).size_hint(), content="None")
   debug_inspect(
     [1, 2, 3]
     .iter()
@@ -359,10 +346,7 @@ test "size_hint" {
     .size_hint(),
     content="None",
   )
-  debug_inspect(
-    [1, 2, 3].iter().take_while(x => x < 3).size_hint(),
-    content="None",
-  )
+  debug_inspect([|1, 2, 3|].take_while(x => x < 3).size_hint(), content="None")
   let unknown : Iter[Int] = Iter::new(() => None)
   let known_empty : Iter[Int] = Iter::new(() => None, size_hint=0)
   debug_inspect(unknown.size_hint(), content="None")
@@ -408,7 +392,7 @@ test "filter_map" {
   debug_inspect(r1, content="[3, 4, 5]")
   let r2 : Array[Unit] = arr.iter().filter_map(_x => None).collect()
   debug_inspect(r2, content="[]")
-  let r3 : Array[Unit] = [].iter().filter_map(x => Some(x)).collect()
+  let r3 : Array[Unit] = [||].filter_map(x => Some(x)).collect()
   debug_inspect(r3, content="[]")
   // Test using next() directly to ensure the closure is executed
   let it1 = [1, 2, 3, 4, 5]
@@ -425,7 +409,7 @@ test "filter_map" {
   debug_inspect(it2.next(), content="Some(3)")
   debug_inspect(it2.next(), content="None")
   // Test iter exhaustion (else branch)
-  let it3 : Iter[Unit] = [1].iter().filter_map(_ => None)
+  let it3 : Iter[Unit] = [|1|].filter_map(_ => None)
   debug_inspect(it3.next(), content="None")
 }
 
@@ -441,7 +425,7 @@ test "flat_map" {
 test "flat_map2" {
   let iter = test_from_array(['1', '2', '3', '4', '5'])
   let exb = StringBuilder(size_hint=0)
-  iter.flat_map(x => Iter::singleton(x)).each(x => exb.write_char(x))
+  iter.flat_map(x => [|x|]).each(x => exb.write_char(x))
   inspect(exb, content="12345")
 }
 
@@ -489,7 +473,7 @@ test "concat" {
 ///|
 test "zip" {
   let numbers = (1).until(6)
-  let letters = ["a", "b", "c"].iter()
+  let letters = [|"a", "b", "c"|]
   debug_inspect(
     numbers.zip(letters).collect(),
     content=(
@@ -501,7 +485,7 @@ test "zip" {
 ///|
 test "zip alias combine" {
   let numbers = (1).until(4)
-  let letters = ["x", "y", "z", "w"].iter()
+  let letters = [|"x", "y", "z", "w"|]
   debug_inspect(
     numbers.combine(letters).collect(),
     content=(
@@ -515,7 +499,7 @@ test "zip short-circuits when either side ends" {
   let lhs_evaluated = []
   let rhs_evaluated = []
   let lhs = (1).until(10).tap(x => lhs_evaluated.push(x))
-  let rhs = [10, 20].iter().tap(x => rhs_evaluated.push(x))
+  let rhs = [|10, 20|].tap(x => rhs_evaluated.push(x))
   debug_inspect(lhs.zip(rhs).collect(), content="[(1, 10), (2, 20)]")
   debug_inspect(lhs_evaluated, content="[1, 2, 3]")
   debug_inspect(rhs_evaluated, content="[10, 20]")
@@ -590,7 +574,7 @@ test "until" {
   debug_inspect(
     (@int.MAX_VALUE - 1)
     .until(@int.MAX_VALUE, inclusive=true)
-    .concat([0].iter())
+    .concat([|0|])
     .to_array(),
     content=(
       #|[2147483646, 2147483647, 0]
@@ -778,7 +762,7 @@ test "intersperse early end" {
 
 ///|
 test "intersperse stops on separator" {
-  let iter = [1, 2].iter().intersperse(0)
+  let iter = [|1, 2|].intersperse(0)
   let seen = []
   for x in iter {
     seen.push(x)
@@ -859,25 +843,25 @@ test "tree" {
 ///|
 test "Iter::intersperse" {
   debug_inspect(
-    [1, 2, 3].iter().intersperse(0).to_array(),
+    [|1, 2, 3|].intersperse(0).to_array(),
     content=(
       #|[1, 0, 2, 0, 3]
     ),
   )
   debug_inspect(
-    [1, 2, 3, 4, 5, 6, 7, 8, 9].iter().intersperse(0).to_array(),
+    [|1, 2, 3, 4, 5, 6, 7, 8, 9|].intersperse(0).to_array(),
     content=(
       #|[1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9]
     ),
   )
   debug_inspect(
-    ([] : Array[Int]).iter().intersperse(0).to_array(),
+    ([||] : Iter[Int]).intersperse(0).to_array(),
     content=(
       #|[]
     ),
   )
   debug_inspect(
-    [1].iter().intersperse(0).to_array(),
+    [|1|].intersperse(0).to_array(),
     content=(
       #|[1]
     ),
@@ -886,40 +870,40 @@ test "Iter::intersperse" {
 
 ///|
 test "Iter::last" {
-  debug_inspect([1, 2, 3].iter().last(), content="Some(3)")
-  debug_inspect([1].iter().last(), content="Some(1)")
-  debug_inspect(([] : Array[Int]).iter().last(), content="None")
+  debug_inspect([|1, 2, 3|].last(), content="Some(3)")
+  debug_inspect([|1|].last(), content="Some(1)")
+  debug_inspect(([||] : Iter[Int]).last(), content="None")
 }
 
 ///|
 test "Iter::head" {
-  debug_inspect([1, 2, 3].iter().head(), content="Some(1)")
-  debug_inspect([1].iter().head(), content="Some(1)")
-  debug_inspect(([] : Array[Int]).iter().head(), content="None")
+  debug_inspect([|1, 2, 3|].head(), content="Some(1)")
+  debug_inspect([|1|].head(), content="Some(1)")
+  debug_inspect(([||] : Iter[Int]).head(), content="None")
 }
 
 ///|
 test "Iter::as_view" {
   debug_inspect(
-    [1, 2, 3].iter()[1:2].to_array(),
+    [|1, 2, 3|][1:2].to_array(),
     content=(
       #|[2]
     ),
   )
   debug_inspect(
-    [1, 2, 3].iter()[1:].to_array(),
+    [|1, 2, 3|][1:].to_array(),
     content=(
       #|[2, 3]
     ),
   )
   debug_inspect(
-    [1, 2, 3].iter()[1:].to_array(),
+    [|1, 2, 3|][1:].to_array(),
     content=(
       #|[2, 3]
     ),
   )
   debug_inspect(
-    [1, 2, 3].iter()[:].to_array(),
+    [|1, 2, 3|][:].to_array(),
     content=(
       #|[1, 2, 3]
     ),
@@ -938,69 +922,69 @@ test "Iter::enumerate" {
 
 ///|
 test "next function - basic functionality" {
-  let iter = Iter::singleton(42)
+  let iter = [|42|]
   debug_inspect(iter.next(), content="Some(42)")
 }
 
 ///|
 test "next function - empty iter" {
-  let iter : Iter[Int] = Iter::empty()
+  let iter : Iter[Int] = [||]
   debug_inspect(iter.next(), content="None")
 }
 
 ///|
 test "next function - multiple elements" {
-  let iter = [1, 2, 3].iter()
+  let iter = [|1, 2, 3|]
   debug_inspect(iter.next(), content="Some(1)")
 }
 
 ///|
 test "next function - random cases" {
-  let iter1 = [10, 20, 30].iter()
+  let iter1 = [|10, 20, 30|]
   debug_inspect(iter1.next(), content="Some(10)")
-  let iter2 = [-5, 0, 5].iter()
+  let iter2 = [|-5, 0, 5|]
   debug_inspect(iter2.next(), content="Some(-5)")
-  let iter3 = [100, 200, 300, 400].iter()
+  let iter3 = [|100, 200, 300, 400|]
   debug_inspect(iter3.next(), content="Some(100)")
-  let iter4 = [-10, -20, -30].iter()
+  let iter4 = [|-10, -20, -30|]
   debug_inspect(iter4.next(), content="Some(-10)")
-  let iter5 = [0, 0, 0].iter()
+  let iter5 = [|0, 0, 0|]
   debug_inspect(iter5.next(), content="Some(0)")
 }
 
 ///|
 test "@builtin.join/empty_iter" {
-  let empty_iter : Iter[String] = Iter::empty()
+  let empty_iter : Iter[String] = [||]
   inspect(empty_iter.join(""), content="")
 }
 
 ///|
 test "@builtin.join/single_element" {
-  let single_elem_iter : Iter[String] = Iter::singleton("Test")
+  let single_elem_iter : Iter[String] = [|"Test"|]
   inspect(single_elem_iter.join(""), content="Test")
 }
 
 ///|
 test "@builtin.join/multiple_elements_with_separator" {
-  let iter : Iter[String] = ["A", "B", "C"].iter()
+  let iter : Iter[String] = [|"A", "B", "C"|]
   inspect(iter.join(","), content="A,B,C")
 }
 
 ///|
 test "@builtin.join/multiple_elements_without_separator" {
-  let iter : Iter[String] = ["A", "B", "C"].iter()
+  let iter : Iter[String] = [|"A", "B", "C"|]
   inspect(iter.join(""), content="ABC")
 }
 
 ///|
 test "@builtin.join/any_to_string_view_element" {
-  let iter : Iter[StringView] = ["a"[:], "b", "c"].iter()
+  let iter : Iter[StringView] = [|"a", "b", "c"|]
   inspect(iter.join("-"), content="a-b-c")
 }
 
 ///|
 test "Iter::nth" {
-  let it = () => [1, 2, 3, 4, 5].iter()
+  let it = () => [|1, 2, 3, 4, 5|]
   debug_inspect(it().nth(2), content="Some(3)")
   debug_inspect(it().nth(4), content="Some(5)")
   debug_inspect(it().nth(5), content="None")
@@ -1016,63 +1000,63 @@ test "Iter::nth" {
 ///|
 test "@builtin.Iter::maximum" {
   // Basic functionality with integers
-  debug_inspect([1, 2, 3, 4, 5].iter().maximum(), content="Some(5)")
+  debug_inspect([|1, 2, 3, 4, 5|].maximum(), content="Some(5)")
   // With negative numbers
-  debug_inspect([-5, -3, -1, -10].iter().maximum(), content="Some(-1)")
+  debug_inspect([|-5, -3, -1, -10|].maximum(), content="Some(-1)")
   // Single element
-  debug_inspect([42].iter().maximum(), content="Some(42)")
+  debug_inspect([|42|].maximum(), content="Some(42)")
   // Empty iter should return None
-  let empty_iter : Iter[Int] = Iter::empty()
+  let empty_iter : Iter[Int] = [||]
   debug_inspect(empty_iter.maximum(), content="None")
 }
 
 ///|
 test "@builtin.Iter::minimum" {
   // Test with normal sequence
-  let arr = [3, 1, 4, 1, 5].iter()
+  let arr = [|3, 1, 4, 1, 5|]
   debug_inspect(arr.minimum(), content="Some(1)")
 
   // Test with single element
-  let single = [42].iter()
+  let single = [|42|]
   debug_inspect(single.minimum(), content="Some(42)")
 
   // Test with empty sequence
-  let empty : Iter[Int] = Iter::empty()
+  let empty : Iter[Int] = [||]
   debug_inspect(empty.minimum(), content="None")
 }
 
 ///|
 test "Iter::intersperse with early termination" {
-  let iter = [1, 2, 3].iter()
+  let iter = [|1, 2, 3|]
   let result = iter.intersperse(0).take(3).collect()
   debug_inspect(result, content="[1, 0, 2]")
 }
 
 ///|
 test "Iter::iter method" {
-  let original = [1, 2, 3].iter()
+  let original = [|1, 2, 3|]
   let result = original.iter().collect()
   debug_inspect(result, content="[1, 2, 3]")
 }
 
 ///|
 test "Iter::contains method" {
-  let iter = [1, 2, 3, 4, 5].iter()
+  let iter = [|1, 2, 3, 4, 5|]
   inspect(iter.contains(3), content="true")
   inspect(iter.contains(6), content="false")
 }
 
 ///|
 test "Iter::flatten method" {
-  let nested = [[1, 2], [3, 4], [5, 6]].iter().map(x => x.iter())
+  let nested = [|[1, 2], [3, 4], [5, 6]|].map(x => x.iter())
   let flattened = nested.flatten().collect()
   debug_inspect(flattened, content="[1, 2, 3, 4, 5, 6]")
 }
 
 ///|
 test "Iter::add operator" {
-  let iter1 = [1, 2, 3].iter()
-  let iter2 = [4, 5, 6].iter()
+  let iter1 = [|1, 2, 3|]
+  let iter2 = [|4, 5, 6|]
   let result = (iter1 + iter2).collect()
   debug_inspect(result, content="[1, 2, 3, 4, 5, 6]")
 }
@@ -1128,7 +1112,7 @@ test "Float::until negative step" {
 
 ///|
 // test "group_by with consecutive identical elements" {
-//   let iter = [1, 1, 2, 2, 3, 3].iter()
+//   let iter = [|1, 1, 2, 2, 3, 3|]
 //   let grouped = iter.group_by((x) => { x })
 //   @test.assert_eq(grouped.get(1), Some([1, 1]))
 //   @test.assert_eq(grouped.get(2), Some([2, 2]))
@@ -1137,7 +1121,7 @@ test "Float::until negative step" {
 
 ///|
 // test "group_by with non-consecutive identical elements" {
-//   let iter = [1, 2, 1, 3, 2, 1].iter()
+//   let iter = [|1, 2, 1, 3, 2, 1|]
 //   let grouped = iter.group_by((x) => { x })
 //   @test.assert_eq(grouped.get(1), Some([1, 1, 1]))
 //   @test.assert_eq(grouped.get(2), Some([2, 2]))
@@ -1146,21 +1130,21 @@ test "Float::until negative step" {
 
 ///|
 // test "group_by with empty input" {
-//   let iter : Iter[Int] = Iter::empty()
+//   let iter : Iter[Int] = [||]
 //   let grouped = iter.group_by((x) => { x })
 //   @test.assert_eq(grouped.length(), 0)
 // }
 
 ///|
 // test "group_by with single element input" {
-//   let iter = [42].iter()
+//   let iter = [|42|]
 //   let grouped = iter.group_by((x) => { x })
 //   @test.assert_eq(grouped.get(42), Some([42]))
 // }
 
 ///|
 // test "group_by with custom key function" {
-//   let iter = [1, 2, 3, 4].iter()
+//   let iter = [|1, 2, 3, 4|]
 //   let grouped = iter.group_by((x) => { x % 2 })
 //   @test.assert_eq(grouped.get(0), Some([2, 4]))
 //   @test.assert_eq(grouped.get(1), Some([1, 3]))
@@ -1168,7 +1152,7 @@ test "Float::until negative step" {
 
 ///|
 // test "group_by with strings" {
-//   let iter = ["apple", "avocado", "banana", "cherry", "blueberry"].iter()
+//   let iter = [|"apple", "avocado", "banana", "cherry", "blueberry"|]
 //   let grouped = iter.group_by((s) => { s.charcode_at(0) })
 //   @test.assert_eq(grouped.get('a'), Some(["apple", "avocado"]))
 //   @test.assert_eq(grouped.get('b'), Some(["banana", "blueberry"]))
@@ -1181,13 +1165,13 @@ test "Float::until negative step" {
 //     name : String
 //     age : Int
 //   }
-//   let people = [
+//   let people = [|
 //     Person::{ name: "Alice", age: 25 },
 //     Person::{ name: "Bob", age: 25 },
 //     Person::{ name: "Charlie", age: 30 },
 //     Person::{ name: "Dave", age: 35 },
 //     Person::{ name: "Eve", age: 30 },
-//   ].iter()
+//   |]
 //   let grouped = people.group_by((p) => { p.age })
 //   let groups = grouped.values().map((a) => { a.map((p) => { p.name }) }).collect()
 //   @test.assert_eq(groups, [["Alice", "Bob"], ["Charlie", "Eve"], ["Dave"]])
@@ -1195,15 +1179,15 @@ test "Float::until negative step" {
 
 ///|
 test "iter2" {
-  let iter : Iter[Int] = [].iter()
+  let iter : Iter[Int] = [||]
   for _, _ in iter.iter2() {
     assert_true(false)
   }
-  let iter = [0, 1, 2].iter().iter2()
+  let iter = [|0, 1, 2|].iter2()
   while iter.next() is Some((i, x)) {
     @test.assert_eq(i, x)
   }
-  let iter = [0, 1, 2].iter()
+  let iter = [|0, 1, 2|]
   for i, x in iter.iter2() {
     @test.assert_eq(i, x)
   }
@@ -1211,7 +1195,7 @@ test "iter2" {
 
 ///|
 test "Iter::iter2" {
-  let iter = [0, 1, 2].iter()
+  let iter = [|0, 1, 2|]
   for i, x in iter.iter2() {
     @test.assert_eq(i, x)
   }
@@ -1222,41 +1206,41 @@ test "Iter::iter2" {
 
 ///|
 test "Iter::to_json and any on empty" {
-  let iter = [1, 2, 3].iter()
+  let iter = [|1, 2, 3|]
   @json.json_inspect(ToJson::to_json(iter), content=[1, 2, 3])
-  let empty : Iter[Int] = Iter::empty()
+  let empty : Iter[Int] = [||]
   inspect(empty.any(_ => true), content="false")
 }
 
 ///|
 test "Iter::map_while empty and last" {
-  let empty : Iter[Int] = Iter::empty()
+  let empty : Iter[Int] = [||]
   debug_inspect(empty.map_while(_ => Some(1)).collect(), content="[]")
-  debug_inspect([1, 2, 3].iter().last(), content="Some(3)")
-  let empty_last : Iter[Int] = Iter::empty()
+  debug_inspect([|1, 2, 3|].last(), content="Some(3)")
+  let empty_last : Iter[Int] = [||]
   debug_inspect(empty_last.last(), content="None")
 }
 
 ///|
 test "Iter::maximum" {
-  debug_inspect([1, 3, 2].iter().maximum(), content="Some(3)")
-  let empty : Iter[Int] = Iter::empty()
+  debug_inspect([|1, 3, 2|].maximum(), content="Some(3)")
+  let empty : Iter[Int] = [||]
   debug_inspect(empty.maximum(), content="None")
 }
 
 ///|
 test "Iter::view variants" {
-  debug_inspect([1, 2, 3].iter().view(start=-1).collect(), content="[1, 2, 3]")
-  debug_inspect([1, 2, 3].iter()[:2].collect(), content="[1, 2]")
-  debug_inspect([1, 2, 3].iter()[1:].collect(), content="[2, 3]")
-  debug_inspect([1, 2, 3, 4].iter()[1:3].collect(), content="[2, 3]")
-  debug_inspect([1, 2, 3].iter()[2:2].collect(), content="[]")
-  debug_inspect([1, 2, 3].iter()[1:0].collect(), content="[]")
+  debug_inspect([|1, 2, 3|].view(start=-1).collect(), content="[1, 2, 3]")
+  debug_inspect([|1, 2, 3|][:2].collect(), content="[1, 2]")
+  debug_inspect([|1, 2, 3|][1:].collect(), content="[2, 3]")
+  debug_inspect([|1, 2, 3, 4|][1:3].collect(), content="[2, 3]")
+  debug_inspect([|1, 2, 3|][2:2].collect(), content="[]")
+  debug_inspect([|1, 2, 3|][1:0].collect(), content="[]")
 }
 
 ///|
 test "Iter::iter and Iter2 conversions" {
-  debug_inspect([1, 2].iter().iter().collect(), content="[1, 2]")
+  debug_inspect([|1, 2|].iter().collect(), content="[1, 2]")
   let pairs = ['a', 'b']
     .iter2()
     .iter()

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -14,7 +14,9 @@
 
 ///|
 test "empty" {
-  let iter = [||]
+  // the `[||]` literal is preferred at call sites, but `Iter::empty` is still
+  // public API and needs its own coverage
+  let iter : Iter[Char] = Iter::empty()
   let exb = StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb)
@@ -22,7 +24,8 @@ test "empty" {
 
 ///|
 test "singleton" {
-  let iter = [|'1'|]
+  // likewise `Iter::singleton`, the constructor behind `[|x|]`
+  let iter = Iter::singleton('1')
   let exb = StringBuilder(size_hint=0)
   iter.each(x => exb.write_char(x))
   inspect(exb, content="1")
@@ -340,10 +343,7 @@ test "size_hint" {
   )
   debug_inspect([|1, 2, 3|].filter(x => x > 1).size_hint(), content="None")
   debug_inspect(
-    [1, 2, 3]
-    .iter()
-    .filter_map(x => if x > 1 { Some(x) } else { None })
-    .size_hint(),
+    [|1, 2, 3|].filter_map(x => if x > 1 { Some(x) } else { None }).size_hint(),
     content="None",
   )
   debug_inspect([|1, 2, 3|].take_while(x => x < 3).size_hint(), content="None")
@@ -395,16 +395,18 @@ test "filter_map" {
   let r3 : Array[Unit] = [||].filter_map(x => Some(x)).collect()
   debug_inspect(r3, content="[]")
   // Test using next() directly to ensure the closure is executed
-  let it1 = [1, 2, 3, 4, 5]
-    .iter()
-    .filter_map(x => if x % 2 == 0 { Some(x * 10) } else { None })
+  let it1 = [|1, 2, 3, 4, 5|].filter_map(x => {
+    if x % 2 == 0 {
+      Some(x * 10)
+    } else {
+      None
+    }
+  })
   debug_inspect(it1.next(), content="Some(20)")
   debug_inspect(it1.next(), content="Some(40)")
   debug_inspect(it1.next(), content="None")
   // Test None branch inside while loop
-  let it2 = [1, 2, 3]
-    .iter()
-    .filter_map(x => if x == 2 { None } else { Some(x) })
+  let it2 = [|1, 2, 3|].filter_map(x => if x == 2 { None } else { Some(x) })
   debug_inspect(it2.next(), content="Some(1)")
   debug_inspect(it2.next(), content="Some(3)")
   debug_inspect(it2.next(), content="None")

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -251,6 +251,8 @@ pub fn[X] Iter::new(f : () -> X?, size_hint? : Int) -> Iter[X] {
 ///|
 /// Creates an empty iterator.
 ///
+/// Prefer the iterator literal `[||]`, which is equivalent and shorter.
+///
 /// # Type Parameters
 ///
 /// - `X`: The type of the elements in the iterator.
@@ -264,6 +266,8 @@ pub fn[X] Iter::empty() -> Iter[X] {
 
 ///|
 /// Creates an iterator that contains a single element.
+///
+/// Prefer the iterator literal `[|elem|]`, which is equivalent and shorter.
 ///
 /// # Type Parameters
 ///
@@ -443,7 +447,7 @@ pub fn[X, Y] Iter::filter_map(self : Iter[X], f : (X) -> Y?) -> Iter[Y] {
 /// The old iterator `self` and the iterators returned by `f`
 /// must not be used again after calling `flat_map`.
 pub fn[X, Y] Iter::flat_map(self : Iter[X], f : (X) -> Iter[Y]) -> Iter[Y] {
-  let mut current_iter = Some(Iter::empty())
+  let mut current_iter = Some([||])
   Iter::new(fn() {
     guard current_iter is Some(iter) else { None }
     for x = iter.next() {
@@ -771,7 +775,7 @@ pub fn[X] Iter::concat(self : Iter[X], other : Iter[X]) -> Iter[X] {
 /// ```mbt check
 /// test {
 ///   let numbers = (1).until(5)
-///   let letters = ["a", "b", "c"].iter()
+///   let letters = [|"a", "b", "c"|]
 ///   debug_inspect(
 ///     numbers.zip(letters).collect(),
 ///     content="[(1, \"a\"), (2, \"b\"), (3, \"c\")]",
@@ -868,7 +872,7 @@ pub fn[X] Iter::last(self : Iter[X]) -> X? {
 /// ```mbt check
 /// test {
 ///   let arr = []
-///   [1, 2, 3].iter().intersperse(0).each(i => arr.push(i))
+///   [|1, 2, 3|].intersperse(0).each(i => arr.push(i))
 ///   @test.assert_eq(arr, [1, 0, 2, 0, 3])
 /// }
 /// ```
@@ -968,10 +972,10 @@ pub fn[X] Iter::view(self : Iter[X], start? : Int = 0, end? : Int) -> Iter[X] {
 ///
 /// ```mbt check
 /// test {
-///   let iter = [1, 2, 3, 4, 5].iter()
+///   let iter = [|1, 2, 3, 4, 5|]
 ///   inspect(iter.contains(3), content="true")
 ///   inspect(iter.contains(6), content="false")
-///   let iter = Iter::empty()
+///   let iter = [||]
 ///   inspect(iter.contains(1), content="false")
 /// }
 /// ```

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -102,7 +102,7 @@ test "Map constructor" {
 
 ///|
 test "Map::from_iter" {
-  let iter = [("a", 1), ("b", 2), ("c", 3)].iter()
+  let iter = [|("a", 1), ("b", 2), ("c", 3)|]
   let map = Map::from_iter(iter)
   debug_inspect(
     map,

--- a/builtin/logger_test.mbt
+++ b/builtin/logger_test.mbt
@@ -19,13 +19,7 @@ test "logger trait object calls" {
   Logger::write_string(logger, "Hello, ")
   Logger::write_char(logger, 'w')
   &Logger::write_string(logger, "orld!")
-  &Logger::write_iter(
-    logger,
-    [1, 2, 3].iter(),
-    prefix="[",
-    suffix="]",
-    sep="; ",
-  )
+  &Logger::write_iter(logger, [|1, 2, 3|], prefix="[", suffix="]", sep="; ")
   inspect(
     sb,
     content=(

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -109,8 +109,8 @@ pub impl[X] Default for X? with fn default() {
 #alias(iterator, deprecated)
 pub fn[T] Option::iter(self : T?) -> Iter[T] {
   match self {
-    Some(v) => Iter::singleton(v)
-    None => Iter::empty()
+    Some(v) => [|v|]
+    None => [||]
   }
 }
 

--- a/builtin/range.mbt
+++ b/builtin/range.mbt
@@ -24,7 +24,7 @@ fn[T : Add + Compare + Default] until_impl(
 ) -> Iter[T] {
   let zero = Default::default()
   if step == zero {
-    return Iter::empty()
+    return [||]
   }
   let mut i = start
   let mut done = false

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -61,7 +61,7 @@ pub fn[T] ReadOnlyArray::from_array(array : ArrayView[T]) -> ReadOnlyArray[T] {
 /// # Example
 /// ```mbt check
 /// test {
-///   let iter = [1, 2, 3].iter()
+///   let iter = [|1, 2, 3|]
 ///   let immut_array = ReadOnlyArray::from_iter(iter)
 ///   inspect(immut_array[0], content="1")
 /// }

--- a/builtin/readonlyarray_test.mbt
+++ b/builtin/readonlyarray_test.mbt
@@ -20,7 +20,7 @@ test "ReadOnlyArray constructors" {
   inspect(arr1[2], content="3")
 
   // Test from_iter
-  let arr2 = ReadOnlyArray::from_iter([4, 5, 6].iter())
+  let arr2 = ReadOnlyArray::from_iter([|4, 5, 6|])
   inspect(arr2[1], content="5")
 
   // Test makei

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -162,7 +162,7 @@ test "String default and to_array" {
 
 ///|
 test "String from_iter" {
-  let iter = ['a', 'b', 'c'].iter()
+  let iter = [|'a', 'b', 'c'|]
   inspect(String::from_iter(iter), content="abc")
 }
 

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -114,7 +114,7 @@ test "StringView core operations" {
   inspect(buf.to_string(), content="0:b;1:😀;2:c;")
   let from_arr = StringView::from_array(['x', 'y'])
   inspect(from_arr.to_owned(), content="xy")
-  let from_iter = StringView::from_iter(['m', 'n'].iter())
+  let from_iter = StringView::from_iter([|'m', 'n'|])
   inspect(from_iter.to_owned(), content="mn")
   let make_view = StringView::make(3, 'a')
   inspect(make_view.to_owned(), content="aaa")

--- a/bytes/bytes_test.mbt
+++ b/bytes/bytes_test.mbt
@@ -131,7 +131,7 @@ test "to_array" {
 ///|
 test "from_iter multiple elements" {
   debug_inspect(
-    Bytes::from_iter([b'\x00', b'\x01', b'\x02'].iter()).to_array(),
+    Bytes::from_iter([|b'\x00', b'\x01', b'\x02'|]).to_array(),
     content=(
       #|[0x00, 0x01, 0x02]
     ),
@@ -141,7 +141,7 @@ test "from_iter multiple elements" {
 ///|
 test "from_iter single element" {
   debug_inspect(
-    Bytes::from_iter([b'\x00'].iter()).to_array(),
+    Bytes::from_iter([|b'\x00'|]).to_array(),
     content=(
       #|[0x00]
     ),
@@ -150,7 +150,7 @@ test "from_iter single element" {
 
 ///|
 test "from_iter empty iterator" {
-  debug_inspect(Bytes::from_iter(Iter::empty()).to_array(), content="[]")
+  debug_inspect(Bytes::from_iter([||]).to_array(), content="[]")
 }
 
 ///|
@@ -230,7 +230,7 @@ test "Bytes::of with different byte values" {
 
 ///|
 test "Bytes::from_iter with multiple elements" {
-  let iter = [b'a', b'b', b'c'].iter()
+  let iter = [|b'a', b'b', b'c'|]
   let bytes = Bytes::from_iter(iter)
   inspect(
     bytes,

--- a/bytes/find_test.mbt
+++ b/bytes/find_test.mbt
@@ -124,8 +124,5 @@ test "BytesView rev_find long pattern offset view" {
 
 ///|
 test "Bytes::from_iter" {
-  inspect(
-    Bytes::from_iter(([97, 98, 99] : Array[Byte]).iter()),
-    content="b\"abc\"",
-  )
+  inspect(Bytes::from_iter([|97, 98, 99|]), content="b\"abc\"")
 }

--- a/debug/debug_coverage_test.mbt
+++ b/debug/debug_coverage_test.mbt
@@ -187,7 +187,7 @@ test "debug runs over representative values (smoke)" {
 
 ///|
 test "Debug instance for Iter renders an omitted body" {
-  let it : Iter[Int] = [1, 2, 3].iter()
+  let it : Iter[Int] = [|1, 2, 3|]
   inspect(
     @debug.to_string(it),
     content=(

--- a/deque/README.mbt.md
+++ b/deque/README.mbt.md
@@ -34,7 +34,7 @@ test {
   @test.assert_eq(dv.is_empty(), true)
   let dv2 = @deque.from_array([1, 2, 3, 4, 5])
   @test.assert_eq(dv2.length(), 5)
-  let dv3 = @deque.from_iter([1, 2, 3].iter())
+  let dv3 = @deque.from_iter([|1, 2, 3|])
   @test.assert_eq(dv3.length(), 3)
 }
 ```

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -507,7 +507,7 @@ test "reserve_and_push" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @deque.from_iter([1, 2, 3].iter()),
+    @deque.from_iter([|1, 2, 3|]),
     content=(
       #|<Deque: [1, 2, 3]>
     ),
@@ -517,7 +517,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @deque.from_iter([1].iter()),
+    @deque.from_iter([|1|]),
     content=(
       #|<Deque: [1]>
     ),
@@ -526,7 +526,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let dq : @deque.Deque[Int] = @deque.from_iter(Iter::empty())
+  let dq : @deque.Deque[Int] = @deque.from_iter([||])
   debug_inspect(
     dq,
     content=(

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -409,7 +409,7 @@ pub fn Float::until(
   inclusive? : Bool = false,
 ) -> Iter[Float] {
   if step == 0.0 {
-    return Iter::empty()
+    return [||]
   }
   let mut curr_value = Some(self)
   Iter::new(() => {

--- a/hashmap/README.mbt.md
+++ b/hashmap/README.mbt.md
@@ -221,7 +221,7 @@ test {
 ```mbt check
 ///|
 test {
-  let map = @hashmap.from_iter([("a", 1), ("b", 2)].iter())
+  let map = @hashmap.from_iter([|("a", 1), ("b", 2)|])
   @test.assert_eq(map.length(), 2)
 }
 ```

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -333,7 +333,7 @@ test "get_nonexistent_key_with_psl" {
 
 ///|
 test "from_iter multiple elements iter" {
-  let map = @hashmap.from_iter([(1, 1), (2, 2), (3, 3)].iter())
+  let map = @hashmap.from_iter([|(1, 1), (2, 2), (3, 3)|])
   guard map is { 1: 1, 2: 2, 3: 3, .. } else {
     fail("Map is not expected: \{Repr(map)}")
   }
@@ -343,7 +343,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @hashmap.from_iter([(1, 1)].iter()),
+    @hashmap.from_iter([|(1, 1)|]),
     content=(
       #|<HashMap: { 1: 1 }>
     ),
@@ -352,7 +352,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let map : @hashmap.HashMap[Int, Int] = @hashmap.from_iter(Iter::empty())
+  let map : @hashmap.HashMap[Int, Int] = @hashmap.from_iter([||])
   debug_inspect(
     map,
     content=(

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -122,7 +122,7 @@ pub fn[K, V] HashMap::iter2(self : HashMap[K, V]) -> Iter2[K, V] {
 ///
 /// ```mbt check
 /// test {
-///   let iter = [|(1, "one")|] + [|(2, "two")|]
+///   let iter = [|(1, "one"), (2, "two")|]
 ///   let map = @hashmap.from_iter(iter)
 ///   debug_inspect(map.get(1), content="Some(\"one\")")
 ///   debug_inspect(map.get(2), content="Some(\"two\")")

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -122,7 +122,7 @@ pub fn[K, V] HashMap::iter2(self : HashMap[K, V]) -> Iter2[K, V] {
 ///
 /// ```mbt check
 /// test {
-///   let iter = Iter::singleton((1, "one")) + Iter::singleton((2, "two"))
+///   let iter = [|(1, "one")|] + [|(2, "two")|]
 ///   let map = @hashmap.from_iter(iter)
 ///   debug_inspect(map.get(1), content="Some(\"one\")")
 ///   debug_inspect(map.get(2), content="Some(\"two\")")

--- a/hashset/README.mbt.md
+++ b/hashset/README.mbt.md
@@ -149,7 +149,7 @@ test {
   arr.sort()
   @test.assert_eq(arr, [1, 2, 3])
   // from_iter
-  let set2 = @hashset.from_iter([4, 5, 6].iter())
+  let set2 = @hashset.from_iter([|4, 5, 6|])
   @test.assert_eq(set2.length(), 3)
 }
 ```

--- a/hashset/hashset_test.mbt
+++ b/hashset/hashset_test.mbt
@@ -392,7 +392,7 @@ test "clear_and_reinsert" {
 
 ///|
 test "from_iter multiple elements iter" {
-  let array = @hashset.from_iter([1, 2, 3].iter()).to_array()
+  let array = @hashset.from_iter([|1, 2, 3|]).to_array()
   array.sort()
   debug_inspect(array, content="[1, 2, 3]")
 }
@@ -400,7 +400,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @hashset.from_iter([1].iter()),
+    @hashset.from_iter([|1|]),
     content=(
       #|<HashSet: [1]>
     ),
@@ -409,7 +409,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let map : @hashset.HashSet[Int] = @hashset.from_iter(Iter::empty())
+  let map : @hashset.HashSet[Int] = @hashset.from_iter([||])
   debug_inspect(
     map,
     content=(

--- a/immut/hashmap/HAMT_test.mbt
+++ b/immut/hashmap/HAMT_test.mbt
@@ -163,7 +163,7 @@ test "HAMT::iter2 with early break" {
 
 ///|
 test "HAMT::from_iter" {
-  let iter = [(1, "one"), (2, "two"), (3, "three")].iter()
+  let iter = [|(1, "one"), (2, "two"), (3, "three")|]
   let map = @hashmap.from_iter(iter)
   @test.assert_eq(map.get(1), Some("one"))
   @test.assert_eq(map.get(2), Some("two"))
@@ -172,7 +172,7 @@ test "HAMT::from_iter" {
 
 ///|
 test "HAMT::from_iter empty" {
-  let map : @hashmap.HashMap[Int, Int] = @hashmap.from_iter(Iter::empty())
+  let map : @hashmap.HashMap[Int, Int] = @hashmap.from_iter([||])
   assert_eq(map.length(), 0)
 }
 
@@ -225,7 +225,7 @@ test "HAMT::from_array duplicate keeps first value" {
 
 ///|
 test "HAMT::from_iter duplicate keeps last value" {
-  let map = @hashmap.from_iter([(1, "first"), (1, "second")].iter())
+  let map = @hashmap.from_iter([|(1, "first"), (1, "second")|])
   @test.assert_eq(map.get(1), Some("second"))
 }
 

--- a/immut/hashset/HAMT_test.mbt
+++ b/immut/hashset/HAMT_test.mbt
@@ -140,7 +140,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @hashset.from_iter([1].iter()),
+    @hashset.from_iter([|1|]),
     content=(
       #|<HashSet: [1]>
     ),
@@ -149,7 +149,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @hashset.HashSet[Int] = @hashset.from_iter(Iter::empty())
+  let pq : @hashset.HashSet[Int] = @hashset.from_iter([||])
   debug_inspect(
     pq,
     content=(
@@ -347,9 +347,7 @@ test "from_array duplicate keeps last representative" {
 
 ///|
 test "from_iter duplicate keeps first representative" {
-  let set = @hashset.from_iter(
-    [SameKey(1, "first"), SameKey(1, "second")].iter(),
-  )
+  let set = @hashset.from_iter([|SameKey(1, "first"), SameKey(1, "second")|])
   let values = set.iter().to_array()
   @test.assert_eq(values.length(), 1)
   let SameKey(_, label) = values[0]

--- a/immut/hashset/README.mbt.md
+++ b/immut/hashset/README.mbt.md
@@ -23,7 +23,7 @@ test "creating immutable sets" {
   inspect(from_fixed.length(), content="3")
 
   // From iterator
-  let from_iter = @hashset.from_iter([40, 50, 60].iter())
+  let from_iter = @hashset.from_iter([|40, 50, 60|])
   inspect(from_iter.length(), content="3")
 }
 ```

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -151,7 +151,7 @@ test "length" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @priority_queue.PriorityQueue::from_iter([1, 2, 3].iter()),
+    @priority_queue.PriorityQueue::from_iter([|1, 2, 3|]),
     content=(
       #|<PriorityQueue: [3, 2, 1]>
     ),
@@ -161,7 +161,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @priority_queue.PriorityQueue::from_iter([1].iter()),
+    @priority_queue.PriorityQueue::from_iter([|1|]),
     content=(
       #|<PriorityQueue: [1]>
     ),
@@ -170,9 +170,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.PriorityQueue::from_iter(
-    Iter::empty(),
-  )
+  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -170,9 +170,9 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.from_iter([||])
+  let empty : Iter[Int] = [||]
   debug_inspect(
-    pq,
+    @priority_queue.PriorityQueue::from_iter(empty),
     content=(
       #|<PriorityQueue: []>
     ),

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -236,7 +236,7 @@ test "show" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @sorted_map.from_iter([(1, 1), (2, 2), (3, 3)].iter()),
+    @sorted_map.from_iter([|(1, 1), (2, 2), (3, 3)|]),
     content=(
       #|<SortedMap: { 1: 1, 2: 2, 3: 3 }>
     ),
@@ -246,7 +246,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @sorted_map.from_iter([(1, 1)].iter()),
+    @sorted_map.from_iter([|(1, 1)|]),
     content=(
       #|<SortedMap: { 1: 1 }>
     ),
@@ -255,9 +255,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @sorted_map.SortedMap[Int, Int] = @sorted_map.from_iter(
-    Iter::empty(),
-  )
+  let pq : @sorted_map.SortedMap[Int, Int] = @sorted_map.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/immut/sorted_set/immutable_set_test.mbt
+++ b/immut/sorted_set/immutable_set_test.mbt
@@ -731,7 +731,7 @@ test "disjoint with different sets" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @sorted_set.from_iter([1, 2, 3].iter()),
+    @sorted_set.from_iter([|1, 2, 3|]),
     content=(
       #|<SortedSet: [1, 2, 3]>
     ),
@@ -741,7 +741,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @sorted_set.from_iter([1].iter()),
+    @sorted_set.from_iter([|1|]),
     content=(
       #|<SortedSet: [1]>
     ),
@@ -750,7 +750,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @sorted_set.SortedSet[Int] = @sorted_set.from_iter(Iter::empty())
+  let pq : @sorted_set.SortedSet[Int] = @sorted_set.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -586,7 +586,7 @@ test "new_with" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @vector.from_iter([1, 2, 3].iter()),
+    @vector.from_iter([|1, 2, 3|]),
     content=(
       #|<Vector: [1, 2, 3]>
     ),
@@ -677,7 +677,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @vector.from_iter([1].iter()),
+    @vector.from_iter([|1|]),
     content=(
       #|<Vector: [1]>
     ),
@@ -686,7 +686,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @vector.Vector[Int] = @vector.from_iter(Iter::empty())
+  let pq : @vector.Vector[Int] = @vector.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/internal/regex_engine/automata/thread_set.mbt
+++ b/internal/regex_engine/automata/thread_set.mbt
@@ -289,7 +289,7 @@ fn ThreadSet::iter_marks(self : ThreadSet) -> Iter[MarkSlotMap] {
   .iter()
   .flat_map(thread => {
     match thread {
-      End(marks) | Exp(marks, _) => Iter::singleton(marks)
+      End(marks) | Exp(marks, _) => [|marks|]
       Seq(_pref, first, _next) => first.iter_marks()
     }
   })

--- a/json/quickcheck_test.mbt
+++ b/json/quickcheck_test.mbt
@@ -113,16 +113,16 @@ impl @quickcheck.Arbitrary for ArbJson with fn arbitrary(size, state) {
 /// counterexamples.
 fn shrink_json(json : Json) -> Iter[Json] {
   match json {
-    Null => Iter::empty()
-    True | False => Iter::singleton(Json::null())
+    Null => [||]
+    True | False => [|Json::null()|]
     Number(n, ..) =>
       if n == 0.0 {
-        Iter::singleton(Json::null())
+        [|Json::null()|]
       } else {
-        [Json::null(), Json::number(0.0)].iter()
+        [|Json::null(), Json::number(0.0)|]
       }
     String(s) =>
-      Iter::singleton(Json::null()).concat(
+      [|Json::null()|].concat(
         @shrink.Shrink::shrink(s).map(smaller => Json::string(smaller)),
       )
     Array(elements) => {
@@ -143,10 +143,7 @@ fn shrink_json(json : Json) -> Iter[Json] {
             Json::array(copy)
           })
         })
-      Iter::singleton(Json::null())
-      .concat(elements.iter())
-      .concat(dropped)
-      .concat(replaced)
+      [|Json::null()|].concat(elements.iter()).concat(dropped).concat(replaced)
     }
     Object(members) => {
       let pairs = members.to_array()
@@ -173,7 +170,7 @@ fn shrink_json(json : Json) -> Iter[Json] {
             Json::object(copy)
           })
         })
-      Iter::singleton(Json::null())
+      [|Json::null()|]
       .concat(pairs.iter().map(pair => pair.1))
       .concat(dropped)
       .concat(replaced)

--- a/lazy_list/README.mbt.md
+++ b/lazy_list/README.mbt.md
@@ -99,7 +99,7 @@ without re-running the source.
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3|])
   // First traversal computes and caches cells.
   debug_inspect(xs.to_array(), content="[1, 2, 3]")
   // Second traversal walks the cache — no further pulls from the iter.
@@ -114,7 +114,7 @@ list, an array, an unfolding generator. We deliberately don't provide
 ```mbt check
 ///|
 test {
-  let from_arr = @lazy_list.from_iter([1, 2, 3].iter())
+  let from_arr = @lazy_list.from_iter([|1, 2, 3|])
   let from_list = @lazy_list.from_iter(@list.List([4, 5, 6]).iter())
   debug_inspect(from_arr.to_array(), content="[1, 2, 3]")
   debug_inspect(from_list.to_array(), content="[4, 5, 6]")
@@ -132,7 +132,7 @@ cell.
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3|])
   inspect(xs.is_empty(), content="false")
   debug_inspect(xs.head(), content="Some(1)")
   debug_inspect(xs.tail().unwrap().head(), content="Some(2)")
@@ -145,7 +145,7 @@ fresh traversal — the underlying `LazyList` is not consumed.
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3|])
   let i1 = xs.iter()
   let i2 = xs.iter()
   debug_inspect(i1.next(), content="Some(1)")
@@ -165,7 +165,7 @@ structure.
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3, 4, 5].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3, 4, 5|])
   debug_inspect(xs.map(x => x * x).to_array(), content="[1, 4, 9, 16, 25]")
   debug_inspect(xs.filter(x => x % 2 == 0).to_array(), content="[2, 4]")
   debug_inspect(xs.take(3).to_array(), content="[1, 2, 3]")
@@ -195,10 +195,10 @@ test {
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3].iter())
-  let ys = @lazy_list.from_iter(["a", "b", "c"].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3|])
+  let ys = @lazy_list.from_iter([|"a", "b", "c"|])
   debug_inspect(
-    xs.flat_map(x => @lazy_list.from_iter([x, x * 10].iter())).to_array(),
+    xs.flat_map(x => @lazy_list.from_iter([|x, x * 10|])).to_array(),
     content="[1, 10, 2, 20, 3, 30]",
   )
   debug_inspect(
@@ -221,7 +221,7 @@ through `@list.from_iter`:
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3|])
   let strict : @list.List[Int] = @list.from_iter(xs.iter())
   @debug.debug_inspect(strict, content="<List: [1, 2, 3]>")
 }
@@ -230,7 +230,7 @@ test {
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3, 4].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3, 4|])
   inspect(xs.fold(init=0, (acc, x) => acc + x), content="10")
   let total : Ref[Int] = Ref(0)
   xs.each(x => total.val = total.val + x)
@@ -245,7 +245,7 @@ full `Iter` combinator set:
 ```mbt check
 ///|
 test {
-  let xs = @lazy_list.from_iter([1, 2, 3, 4, 5].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3, 4, 5|])
   inspect(xs.iter().count(), content="5")
   debug_inspect(xs.iter().nth(2), content="Some(3)")
 }
@@ -300,7 +300,7 @@ natural way to write one is also the hardest case:
 test {
   let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
   for i in 0..<10000 {
-    acc = acc.concat(@lazy_list.from_iter([i].iter()))
+    acc = acc.concat(@lazy_list.from_iter([|i|]))
   }
   debug_inspect(acc.take(3).to_array(), content="[0, 1, 2]")
   inspect(acc.iter().count(), content="10000")
@@ -394,7 +394,7 @@ test {
     }
   }
 
-  let xs = @lazy_list.from_iter([1, 2, -1, 3].iter()).map(maybe_double)
+  let xs = @lazy_list.from_iter([|1, 2, -1, 3|]).map(maybe_double)
   let results = xs.to_array()
   debug_inspect(
     results,

--- a/lazy_list/concat_bench_test.mbt
+++ b/lazy_list/concat_bench_test.mbt
@@ -31,7 +31,7 @@ let concat_bench_len : Int = 2048
 fn bench_left_nested(depth : Int) -> @lazy_list.LazyList[Int] {
   let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
   for i in 0..<depth {
-    acc = acc.concat(@lazy_list.from_iter([i].iter()))
+    acc = acc.concat(@lazy_list.from_iter([|i|]))
   }
   acc
 }
@@ -71,7 +71,7 @@ test "bench LazyList concat while consuming n=2048" (it : @bench.T) {
   it.bench(fn() {
     let mut cur = @lazy_list.from_iter(source.iter())
     for i in 0..<concat_bench_len {
-      cur = cur.concat(@lazy_list.from_iter([i].iter()))
+      cur = cur.concat(@lazy_list.from_iter([|i|]))
       cur = cur.tail().unwrap()
     }
     it.keep(cur.head())

--- a/lazy_list/lazy_list.mbt
+++ b/lazy_list/lazy_list.mbt
@@ -79,7 +79,7 @@ pub fn[A] LazyList::lazy_cons(
 ///
 /// ```mbt check
 /// test {
-///   let xs = @lazy_list.from_iter([1, 2, 3].iter())
+///   let xs = @lazy_list.from_iter([|1, 2, 3|])
 ///   debug_inspect(xs.to_array(), content="[1, 2, 3]")
 ///   // The lazy list is re-traversable.
 ///   debug_inspect(xs.to_array(), content="[1, 2, 3]")

--- a/lazy_list/lazy_list_test.mbt
+++ b/lazy_list/lazy_list_test.mbt
@@ -22,7 +22,7 @@ test "empty / is_empty / head / tail" {
 
 ///|
 test "lazy_cons / head / tail" {
-  let ys = @lazy_list.from_iter([2, 3].iter())
+  let ys = @lazy_list.from_iter([|2, 3|])
   let xs = @lazy_list.lazy_cons(1, () => ys)
   debug_inspect(xs.head(), content="Some(1)")
   debug_inspect(xs.tail().unwrap().to_array(), content="[2, 3]")
@@ -74,31 +74,31 @@ test "infinite streams are safe to take a prefix from" {
 
 ///|
 test "map / filter (lazy)" {
-  let xs = @lazy_list.from_iter([1, 2, 3, 4, 5].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3, 4, 5|])
   debug_inspect(xs.map(x => x + 10).to_array(), content="[11, 12, 13, 14, 15]")
   debug_inspect(xs.filter(x => x % 2 == 0).to_array(), content="[2, 4]")
 }
 
 ///|
 test "take / drop / take_while / drop_while" {
-  let xs = @lazy_list.from_iter([1, 2, 3, 4, 5].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3, 4, 5|])
   debug_inspect(xs.take(3).to_array(), content="[1, 2, 3]")
   debug_inspect(xs.take(0).to_array(), content="[]")
   debug_inspect(xs.take(99).to_array(), content="[1, 2, 3, 4, 5]")
   debug_inspect(xs.drop(2).to_array(), content="[3, 4, 5]")
   debug_inspect(xs.drop(99).to_array(), content="[]")
-  let ys = @lazy_list.from_iter([1, 2, 3, 4, 1, 2].iter())
+  let ys = @lazy_list.from_iter([|1, 2, 3, 4, 1, 2|])
   debug_inspect(ys.take_while(x => x < 3).to_array(), content="[1, 2]")
   debug_inspect(ys.drop_while(x => x < 3).to_array(), content="[3, 4, 1, 2]")
 }
 
 ///|
 test "concat / flat_map / zip" {
-  let xs = @lazy_list.from_iter([1, 2, 3].iter())
-  let ys = @lazy_list.from_iter([4, 5].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3|])
+  let ys = @lazy_list.from_iter([|4, 5|])
   debug_inspect(xs.concat(ys).to_array(), content="[1, 2, 3, 4, 5]")
   debug_inspect(
-    xs.flat_map(x => @lazy_list.from_iter([x, x * 10].iter())).to_array(),
+    xs.flat_map(x => @lazy_list.from_iter([|x, x * 10|])).to_array(),
     content="[1, 10, 2, 20, 3, 30]",
   )
   // flat_map skipping empty mappings.
@@ -119,7 +119,7 @@ test "concat / flat_map / zip" {
 
 ///|
 test "each / fold" {
-  let xs = @lazy_list.from_iter([10, 20, 30, 40].iter())
+  let xs = @lazy_list.from_iter([|10, 20, 30, 40|])
   inspect(xs.fold(init=0, (acc, x) => acc + x), content="100")
   let buf = []
   xs.each(x => buf.push(x))
@@ -128,7 +128,7 @@ test "each / fold" {
 
 ///|
 test "iter bridge is independent per call" {
-  let xs = @lazy_list.from_iter([1, 2, 3].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3|])
   let i1 = xs.iter()
   let i2 = xs.iter()
   debug_inspect(i1.next(), content="Some(1)")
@@ -170,14 +170,14 @@ test "drop_while accepts a raising predicate" {
     x < 3
   }
 
-  let xs = @lazy_list.from_iter([1, 2, 3, 4].iter())
+  let xs = @lazy_list.from_iter([|1, 2, 3, 4|])
   debug_inspect(xs.drop_while(pred).to_array(), content="[3, 4]")
   // Short-circuits: pred(3) returns false, so pred(-1) is never called
   // and no error is raised even though -1 would trigger one.
-  let zs = @lazy_list.from_iter([1, 3, -1].iter())
+  let zs = @lazy_list.from_iter([|1, 3, -1|])
   debug_inspect(zs.drop_while(pred).to_array(), content="[3, -1]")
   // A predicate that raises mid-skip propagates out of drop_while.
-  let ys = @lazy_list.from_iter([1, -1, 5].iter())
+  let ys = @lazy_list.from_iter([|1, -1, 5|])
   try ys.drop_while(pred) catch {
     _ => ()
   } noraise {
@@ -225,7 +225,7 @@ test "zip's left bias: right-shorter forces one extra left tail" {
 ///|
 test "lazy semantics: map does not force tail until observed" {
   let pulls : Ref[Int] = Ref(0)
-  let xs = @lazy_list.from_iter([1, 2, 3].iter()).map(x => {
+  let xs = @lazy_list.from_iter([|1, 2, 3|]).map(x => {
     pulls.val += 1
     x * 2
   })
@@ -241,7 +241,7 @@ test "lazy semantics: map does not force tail until observed" {
 ///|
 test "Debug walks only the forced prefix" {
   // Fully forced: every element printed.
-  let strict = @lazy_list.from_iter([1, 2, 3].iter()).map(x => x)
+  let strict = @lazy_list.from_iter([|1, 2, 3|]).map(x => x)
   // Force everything.
   let _ = strict.to_array()
   @debug.debug_inspect(strict, content="<LazyList: [1, 2, 3]>")
@@ -274,7 +274,7 @@ test "Debug walks only the forced prefix" {
 fn left_nested_concat(from : Int, until : Int) -> @lazy_list.LazyList[Int] {
   let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
   for i in from..<until {
-    acc = acc.concat(@lazy_list.from_iter([i].iter()))
+    acc = acc.concat(@lazy_list.from_iter([|i|]))
   }
   acc
 }
@@ -284,7 +284,7 @@ fn left_nested_concat(from : Int, until : Int) -> @lazy_list.LazyList[Int] {
 fn right_nested_concat(from : Int, until : Int) -> @lazy_list.LazyList[Int] {
   let mut acc : @lazy_list.LazyList[Int] = @lazy_list.empty()
   for i = until - 1; i >= from; i = i - 1 {
-    acc = @lazy_list.from_iter([i].iter()).concat(acc)
+    acc = @lazy_list.from_iter([|i|]).concat(acc)
   }
   acc
 }
@@ -310,7 +310,7 @@ test "concat: a right-nested chain forces without recursing" {
 
 ///|
 test "concat: appending empty lists neither accumulates nor diverges" {
-  let mut acc = @lazy_list.from_iter([1, 2, 3].iter())
+  let mut acc = @lazy_list.from_iter([|1, 2, 3|])
   for _ in 0..<50000 {
     acc = acc.concat(@lazy_list.empty())
   }
@@ -322,7 +322,7 @@ test "flat_map over a deeply nested concat is stack safe" {
   // `flat_map` chains through `concat_lazy`, which shares `concat`'s
   // representation, so it has to survive the same shape.
   let xs = left_nested_concat(0, 20000).flat_map(x => {
-    @lazy_list.from_iter([x, x].iter())
+    @lazy_list.from_iter([|x, x|])
   })
   inspect(xs.iter().count(), content="40000")
 }
@@ -330,7 +330,7 @@ test "flat_map over a deeply nested concat is stack safe" {
 ///|
 test "concat leaves the right-hand side untouched until the left ends" {
   let pulls : Ref[Int] = Ref(0)
-  let left = @lazy_list.from_iter([1, 2].iter())
+  let left = @lazy_list.from_iter([|1, 2|])
   let right = @lazy_list.lazy_cons(3, () => {
     pulls.val += 1
     @lazy_list.empty()

--- a/lazy_list/panic_test.mbt
+++ b/lazy_list/panic_test.mbt
@@ -29,7 +29,7 @@ test "panic reentrant force through a suspended concat aborts" {
   // than on a thunk.
   let slot : Array[@lazy_list.LazyList[Int]] = []
   let left = @lazy_list.lazy_cons(1, () => slot[0].tail().unwrap())
-  let both = left.concat(@lazy_list.from_iter([2].iter()))
+  let both = left.concat(@lazy_list.from_iter([|2|]))
   slot.push(both)
   ignore(both.tail())
 }

--- a/lazy_list/quickcheck_test.mbt
+++ b/lazy_list/quickcheck_test.mbt
@@ -300,7 +300,7 @@ test "quickcheck: functor and monad laws" {
       xs().map(f).map(g).to_array() == xs().map(x => g(f(x))).to_array() &&
       // flat_map with a singleton is map (the monad's right identity
       // composed with map)
-      xs().flat_map(x => @lazy_list.from_iter([f(x)].iter())).to_array() ==
+      xs().flat_map(x => @lazy_list.from_iter([|f(x)|])).to_array() ==
       xs().map(f).to_array() &&
       // ...and with the empty list it annihilates
       xs().flat_map(_ => @lazy_list.empty()).to_array() == ([] : Array[Int])
@@ -586,7 +586,7 @@ test "quickcheck: flat_map skips runs of empty inner lists without recursing" {
         if x < threshold {
           @lazy_list.empty()
         } else {
-          @lazy_list.from_iter([x].iter())
+          @lazy_list.from_iter([|x|])
         }
       })
       mapped.head() == Some(threshold)
@@ -626,7 +626,7 @@ fn shaped_concat(depth : Int, seed : Int) -> @lazy_list.LazyList[Int] {
   }
 
   for i in 0..<depth {
-    stack.push(@lazy_list.from_iter([i].iter()))
+    stack.push(@lazy_list.from_iter([|i|]))
     while stack.length() >= 2 && next_bit() {
       merge_top()
     }
@@ -672,7 +672,7 @@ test "quickcheck: appending while consuming keeps the order" {
       let mut cur = @lazy_list.from_iter(Array::makei(steps + 1, i => i).iter())
       let seen = []
       for i in 0..<steps {
-        cur = cur.concat(@lazy_list.from_iter([start + i].iter()))
+        cur = cur.concat(@lazy_list.from_iter([|start + i|]))
         seen.push(cur.head().unwrap())
         cur = cur.tail().unwrap()
       }
@@ -707,7 +707,7 @@ test "quickcheck: the lazy combinators stay total on an infinite list" {
       expected.map(i => (i, i)) &&
       nats(counter).concat(nats(counter)).take(n).to_array() == expected &&
       nats(counter)
-      .flat_map(x => @lazy_list.from_iter([x].iter()))
+      .flat_map(x => @lazy_list.from_iter([|x|]))
       .take(n)
       .to_array() ==
       expected &&

--- a/lexbuf/lexbuf_test.mbt
+++ b/lexbuf/lexbuf_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "Lexbuf retains captures across chunks and commits lookahead" {
-  let chunks = ["ab", "cd", "!"].iter()
+  let chunks = [|"ab", "cd", "!"|]
   let lexbuf = @lexbuf.Lexbuf::from_fn(() => chunks.next())
   lexbuf.__refill()
   lexbuf.__advance(1)
@@ -34,7 +34,7 @@ test "Lexbuf retains captures across chunks and commits lookahead" {
 
 ///|
 test "Lexbuf discards consumed input without retention" {
-  let chunks = ["ab", "", "cd"].iter()
+  let chunks = [|"ab", "", "cd"|]
   let lexbuf = @lexbuf.Lexbuf::from_fn(() => chunks.next())
   lexbuf.__refill()
   lexbuf.__advance(2)
@@ -55,7 +55,7 @@ test "Lexbuf reports source EOF while buffered input remains" {
 
 ///|
 test "Lexbuf can commit before a capture-only retention" {
-  let chunks = ["ab"].iter()
+  let chunks = [|"ab"|]
   let lexbuf = @lexbuf.Lexbuf::from_fn(() => chunks.next())
   lexbuf.__refill()
   lexbuf.__advance(1)
@@ -90,10 +90,10 @@ test "Lexbuf retains a token across many chunks" {
 ///|
 test "Lexbuf preserves UTF-16 chunk boundaries" {
   let input = "a😀b"
-  let chunks = [
+  let chunks = [|
     input.unsafe_substring(start=0, end=2),
     input.unsafe_substring(start=2, end=4),
-  ].iter()
+  |]
   let lexbuf = @lexbuf.Lexbuf::from_fn(() => chunks.next())
   lexbuf.__refill()
   lexbuf.__retain_from_cursor()
@@ -107,7 +107,7 @@ test "Lexbuf preserves UTF-16 chunk boundaries" {
 
 ///|
 test "Lexbuf reads multiple chunks after compaction" {
-  let chunks = ["ab", "cd", "ef"].iter()
+  let chunks = [|"ab", "cd", "ef"|]
   let lexbuf = @lexbuf.Lexbuf::from_fn(() => chunks.next())
   lexbuf.__refill()
   lexbuf.__retain_from_cursor()

--- a/lexbuf/panic_test.mbt
+++ b/lexbuf/panic_test.mbt
@@ -28,7 +28,7 @@ test "panic Lexbuf rejects a commit without retention" {
 
 ///|
 test "panic Lexbuf rejects refill with unread input" {
-  let chunks = ["a"].iter()
+  let chunks = [|"a"|]
   let lexbuf = @lexbuf.Lexbuf::from_fn(() => chunks.next())
   lexbuf.__refill()
   lexbuf.__refill()

--- a/list/README.mbt.md
+++ b/list/README.mbt.md
@@ -411,7 +411,7 @@ test {
 test {
   let list = @list.List([1, 2, 3])
   debug_inspect(list.iter().to_array(), content="[1, 2, 3]")
-  let list2 = @list.from_iter([4, 5, 6].iter())
+  let list2 = @list.from_iter([|4, 5, 6|])
   @debug.assert_eq(list2, List([4, 5, 6]))
 }
 ```

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -787,25 +787,22 @@ test "add" {
 
 ///|
 test "from_iter multiple elements iter" {
-  debug_inspect(@list.from_iter([1, 2, 3].iter()), content="<List: [1, 2, 3]>")
+  debug_inspect(@list.from_iter([|1, 2, 3|]), content="<List: [1, 2, 3]>")
 }
 
 ///|
 test "from_iter_rev multiple elements iter" {
-  debug_inspect(
-    @list.from_iter_rev([1, 2, 3].iter()),
-    content="<List: [3, 2, 1]>",
-  )
+  debug_inspect(@list.from_iter_rev([|1, 2, 3|]), content="<List: [3, 2, 1]>")
 }
 
 ///|
 test "from_iter single element iter" {
-  debug_inspect(@list.from_iter([1].iter()), content="<List: [1]>")
+  debug_inspect(@list.from_iter([|1|]), content="<List: [1]>")
 }
 
 ///|
 test "from_iter empty iter" {
-  let pq : @list.List[Int] = @list.from_iter(Iter::empty())
+  let pq : @list.List[Int] = @list.from_iter([||])
   debug_inspect(pq, content="<List: []>")
 }
 

--- a/priority_queue/README.mbt.md
+++ b/priority_queue/README.mbt.md
@@ -126,7 +126,7 @@ test {
 ```mbt check
 ///|
 test {
-  let pq = @priority_queue.from_iter([3, 1, 2].iter())
+  let pq = @priority_queue.from_iter([|3, 1, 2|])
   @test.assert_eq(pq.peek(), Some(3))
 }
 ```

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -112,7 +112,7 @@ test "pop" {
   let pq_ = @priority_queue.from_array([1])
   pq_.pop() |> ignore
   inspect(pq_.length(), content="0")
-  let p = @priority_queue.from_iter([0, 1, 4, 5, 6, 2, 3].iter())
+  let p = @priority_queue.from_iter([|0, 1, 4, 5, 6, 2, 3|])
   p.pop() |> ignore
   p.pop() |> ignore
   p.pop() |> ignore
@@ -166,7 +166,7 @@ test "is_empty" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @priority_queue.from_iter([1, 2, 3].iter()),
+    @priority_queue.from_iter([|1, 2, 3|]),
     content=(
       #|<PriorityQueue: [3, 2, 1]>
     ),
@@ -176,7 +176,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @priority_queue.from_iter([1].iter()),
+    @priority_queue.from_iter([|1|]),
     content=(
       #|<PriorityQueue: [1]>
     ),
@@ -185,9 +185,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.from_iter(
-    Iter::empty(),
-  )
+  let pq : @priority_queue.PriorityQueue[Int] = @priority_queue.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/queue/README.mbt.md
+++ b/queue/README.mbt.md
@@ -62,7 +62,7 @@ test {
 ```mbt check
 ///|
 test {
-  let queue = @queue.from_iter([1, 2, 3].iter())
+  let queue = @queue.from_iter([|1, 2, 3|])
   @test.assert_eq(queue.length(), 3)
 }
 ```

--- a/queue/queue.mbt
+++ b/queue/queue.mbt
@@ -294,7 +294,7 @@ pub fn[A] Queue::iter(self : Queue[A]) -> Iter[A] {
 /// # Example
 /// ```mbt check
 /// test {
-///   let queue : @queue.Queue[Int] = @queue.from_iter(Iter::empty())
+///   let queue : @queue.Queue[Int] = @queue.from_iter([||])
 ///   @test.assert_eq(queue.length(), 0)
 /// }
 /// ```

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -255,7 +255,7 @@ test "iter" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @queue.from_iter([1, 2, 3].iter()),
+    @queue.from_iter([|1, 2, 3|]),
     content=(
       #|<Queue: [1, 2, 3]>
     ),
@@ -265,7 +265,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @queue.from_iter([1].iter()),
+    @queue.from_iter([|1|]),
     content=(
       #|<Queue: [1]>
     ),
@@ -274,7 +274,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @queue.Queue[Int] = @queue.from_iter(Iter::empty())
+  let pq : @queue.Queue[Int] = @queue.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -34,9 +34,9 @@ impl @quickcheck.Arbitrary for ShrinkInput with fn arbitrary(_, _) {
 ///|
 impl @shrink.Shrink for ShrinkInput with fn shrink(input) {
   if input.0 <= 0 {
-    Iter::empty()
+    [||]
   } else {
-    [ShrinkInput(input.0 - 1), ShrinkInput(0)].iter()
+    [|ShrinkInput(input.0 - 1), ShrinkInput(0)|]
   }
 }
 
@@ -59,9 +59,9 @@ impl @quickcheck.Arbitrary for DriftInput with fn arbitrary(_, _) {
 ///|
 impl @shrink.Shrink for DriftInput with fn shrink(input) {
   if input.0 == 10 {
-    [DriftInput(9), DriftInput(8)].iter()
+    [|DriftInput(9), DriftInput(8)|]
   } else {
-    Iter::empty()
+    [||]
   }
 }
 
@@ -76,9 +76,9 @@ impl @quickcheck.Arbitrary for FilteredShrinkInput with fn arbitrary(_, _) {
 ///|
 impl @shrink.Shrink for FilteredShrinkInput with fn shrink(input) {
   match input.0 {
-    10 => [FilteredShrinkInput(9), FilteredShrinkInput(7)].iter()
-    9 => [FilteredShrinkInput(8)].iter()
-    _ => Iter::empty()
+    10 => [|FilteredShrinkInput(9), FilteredShrinkInput(7)|]
+    9 => [|FilteredShrinkInput(8)|]
+    _ => [||]
   }
 }
 

--- a/quickcheck/shrink/collection.mbt
+++ b/quickcheck/shrink/collection.mbt
@@ -17,7 +17,7 @@ pub impl[T : Shrink] Shrink for @list.List[T] with fn shrink(xs) {
   let n = xs.length()
   fn shr_sub_terms(lst : @list.List[T]) {
     match lst {
-      Empty => Iter::empty()
+      Empty => [||]
       More(x, tail=xs) =>
         Shrink::shrink(x)
         .map(x_ => xs.add(x_))

--- a/quickcheck/shrink/composite.mbt
+++ b/quickcheck/shrink/composite.mbt
@@ -15,9 +15,8 @@
 ///|
 pub impl[T : Shrink] Shrink for T? with fn shrink(x) {
   match x {
-    None => Iter::empty()
-    Some(v) =>
-      Shrink::shrink(v).map(v1 => Some(v1)).concat(Iter::singleton(None))
+    None => [||]
+    Some(v) => Shrink::shrink(v).map(v1 => Some(v1)).concat([|None|])
   }
 }
 
@@ -35,7 +34,7 @@ pub impl[X : Shrink] Shrink for Array[X] with fn shrink(xs) {
   let n = view.length()
   fn shr_sub_terms(arr : ArrayView[X]) {
     match arr {
-      [] => Iter::empty()
+      [] => [||]
       [x, .. xs] =>
         X::shrink(x)
         .map(x_ => [x_, ..xs])

--- a/quickcheck/shrink/shrink.mbt
+++ b/quickcheck/shrink/shrink.mbt
@@ -41,7 +41,7 @@ pub(open) trait Shrink {
 
 ///|
 impl Shrink with fn shrink(_a) {
-  Iter::empty()
+  [||]
 }
 
 ///|
@@ -87,9 +87,9 @@ pub impl Shrink for UInt64 with fn shrink(x) {
 ///|
 pub impl Shrink for Bool with fn shrink(b) {
   if !b {
-    Iter::empty()
+    [||]
   } else {
-    Iter::singleton(false)
+    [|false|]
   }
 }
 

--- a/quickcheck/shrink/utils.mbt
+++ b/quickcheck/shrink/utils.mbt
@@ -20,7 +20,7 @@ fn[T] removes_array(k : Int, n : Int, xs : Array[T]) -> Iter[Array[T]] {
   if xs1.is_empty() {
     [|[]|]
   } else {
-    [xs1].iter().add(removes_array(k, n - k, xs1).map(x => xs2 + x))
+    [|xs1|].add(removes_array(k, n - k, xs1).map(x => xs2 + x))
   }
 }
 
@@ -40,16 +40,14 @@ fn[T] removes_list(k : Int, n : Int, xs : @list.List[T]) -> Iter[@list.List[T]] 
 fn shrink_decimal(x : Double) -> Iter[Double] {
   guard !x.is_nan() else { [|0.0, 1.0, -1.0, 2.0|] }
   guard !x.is_inf() else { [|0.0, 1.0, -1.0, 1000.0, -1000.0|] }
-  guard x >= 0.0 else {
-    Iter::singleton(-x).concat(shrink_decimal(-x).map(Double::neg))
-  }
-  guard x != 0.0 else { Iter::empty() }
+  guard x >= 0.0 else { [|-x|].concat(shrink_decimal(-x).map(Double::neg)) }
+  guard x != 0.0 else { [||] }
   [|1.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0|].flat_map(p => {
     let m = (x * p + 0.5).floor().to_int64()
     if p != 1.0 && m % 10L == 0L {
-      return Iter::empty()
+      return [||]
     }
-    Iter::singleton(m)
+    [|m|]
     .concat(Shrink::shrink(m))
     .map(n => n.to_double() / p)
     .filter(y => y >= 0.0 && y < x)

--- a/set/README.mbt.md
+++ b/set/README.mbt.md
@@ -27,7 +27,7 @@ test "creating sets" {
   inspect(from_fixed.length(), content="3")
 
   // From iterator
-  let from_iter = @set.Set::from_iter([1, 2, 3, 4, 5].iter())
+  let from_iter = @set.Set::from_iter([|1, 2, 3, 4, 5|])
   inspect(from_iter.length(), content="5")
 }
 ```

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -293,7 +293,7 @@ test "clear_and_reinsert" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @set.Set::from_iter([1, 2, 3].iter()),
+    @set.Set::from_iter([|1, 2, 3|]),
     content=(
       #|<Set: [1, 2, 3]>
     ),
@@ -303,7 +303,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @set.Set::from_iter([1].iter()),
+    @set.Set::from_iter([|1|]),
     content=(
       #|<Set: [1]>
     ),
@@ -312,7 +312,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let map : @set.Set[Int] = @set.Set::from_iter(Iter::empty())
+  let map : @set.Set[Int] = @set.Set::from_iter([||])
   debug_inspect(
     map,
     content=(

--- a/sorted_map/README.mbt.md
+++ b/sorted_map/README.mbt.md
@@ -230,7 +230,7 @@ The SortedMap supports several iterator patterns. Create a map from an iterator:
 ```mbt check
 ///|
 test {
-  let pairs = [(1, "one"), (2, "two"), (3, "three")].iter()
+  let pairs = [|(1, "one"), (2, "two"), (3, "three")|]
   let map = @sorted_map.from_iter(pairs)
   @test.assert_eq(map.length(), 3)
 }

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -176,7 +176,7 @@ test "iter_collect" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @sorted_map.from_iter([(1, 1), (2, 2), (3, 3)].iter()),
+    @sorted_map.from_iter([|(1, 1), (2, 2), (3, 3)|]),
     content=(
       #|<SortedMap: { 1: 1, 2: 2, 3: 3 }>
     ),
@@ -186,7 +186,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @sorted_map.from_iter([(1, 1)].iter()),
+    @sorted_map.from_iter([|(1, 1)|]),
     content=(
       #|<SortedMap: { 1: 1 }>
     ),
@@ -195,9 +195,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @sorted_map.SortedMap[Int, Int] = @sorted_map.from_iter(
-    Iter::empty(),
-  )
+  let pq : @sorted_map.SortedMap[Int, Int] = @sorted_map.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/sorted_set/README.mbt.md
+++ b/sorted_set/README.mbt.md
@@ -166,7 +166,7 @@ test {
   // to_array
   @test.assert_eq(set.to_array(), [1, 2, 3])
   // from_iter
-  let set2 = @sorted_set.from_iter([4, 5, 6].iter())
+  let set2 = @sorted_set.from_iter([|4, 5, 6|])
   @test.assert_eq(set2.to_array(), [4, 5, 6])
 }
 ```

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -380,13 +380,13 @@ test "equal" {
 ///|
 test "from_iter multiple elements iter" {
   debug_inspect(
-    @sorted_set.from_iter([1, 2, 3].iter()),
+    @sorted_set.from_iter([|1, 2, 3|]),
     content=(
       #|<SortedSet: [1, 2, 3]>
     ),
   )
   debug_inspect(
-    @sorted_set.from_iter([1, 1, 1].iter()),
+    @sorted_set.from_iter([|1, 1, 1|]),
     content=(
       #|<SortedSet: [1]>
     ),
@@ -396,7 +396,7 @@ test "from_iter multiple elements iter" {
 ///|
 test "from_iter single element iter" {
   debug_inspect(
-    @sorted_set.from_iter([1].iter()),
+    @sorted_set.from_iter([|1|]),
     content=(
       #|<SortedSet: [1]>
     ),
@@ -405,7 +405,7 @@ test "from_iter single element iter" {
 
 ///|
 test "from_iter empty iter" {
-  let pq : @sorted_set.SortedSet[Int] = @sorted_set.from_iter(Iter::empty())
+  let pq : @sorted_set.SortedSet[Int] = @sorted_set.from_iter([||])
   debug_inspect(
     pq,
     content=(

--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -16,7 +16,7 @@ test "string creation" {
   inspect(str1, content="Hello")
 
   // From character iterator
-  let str2 = String::from_iter(['W', 'o', 'r', 'l', 'd'].iter())
+  let str2 = String::from_iter([|'W', 'o', 'r', 'l', 'd'|])
   inspect(str2, content="World")
 
   // Default empty string

--- a/string/string_test.mbt
+++ b/string/string_test.mbt
@@ -19,7 +19,7 @@ test "String::from_array" {
 
 ///|
 test "String::from_iter" {
-  inspect(String::from_iter(['1', '2', '3', '4', '5'].iter()), content="12345")
+  inspect(String::from_iter([|'1', '2', '3', '4', '5'|]), content="12345")
 }
 
 ///|

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -635,7 +635,7 @@ test "from_array" {
 
 ///|
 test "from_iter" {
-  let v = StringView::from_iter(['a', '😭', 'b', '😂', 'c'].iter())
+  let v = StringView::from_iter([|'a', '😭', 'b', '😂', 'c'|])
   inspect(v, content="a😭b😂c")
 }
 


### PR DESCRIPTION
## What

`[|a, b|]` is sugar for building an `Iter` directly. This PR folds the three
equivalent hand-written spellings into it project-wide (273 sites, 64 files):

| before | after |
| --- | --- |
| `Iter::empty()` | `[||]` |
| `Iter::singleton(x)` | `[|x|]` |
| `[a, b, c].iter()` | `[|a, b, c|]` |

## Why this is behaviour-preserving

`Iter` is a single-pass external iterator, so the only observable differences
would be evaluation timing, traversal, and `size_hint`. All three agree:

- elements are evaluated **eagerly** at construction, exactly like the array
  literal that `.iter()` was called on;
- traversal is single-pass and identical (`take(1)` then `to_array()` yields
  `[1]` then `[2, 3]` for both spellings);
- `[|1, 2, 3|].size_hint()` is `Some(3)`, same as `[1, 2, 3].iter()`;
  `[||]` is `Some(0)`, same as `Iter::empty()`.

`.mbti` is unchanged for every package, so this is invisible to downstream users.

## Incidental cleanups the literal enables

The literal propagates its expected element type, so a few annotations that only
existed to steer the array literal could go:

- `([] : Array[Int]).iter()` → `([||] : Iter[Int])`
- `([97, 98, 99] : Array[Byte]).iter()` → `[|97, 98, 99|]`
- `["a"[:], "b", "c"].iter()` → `[|"a", "b", "c"|]` — keeping `[:]` now trips
  the `unnecessary_view_op` warning, since the view conversion is inserted
  automatically.

## Notes

- `Iter::empty` / `Iter::singleton` remain public and undeprecated; their docs
  now point at the literal.
- The `size_hint` test keeps one explicit `[1, 2, 3].iter().size_hint()`
  assertion so `Array::iter`'s own hint stays directly covered, and
  `test_from_array` in `builtin/iter_test.mbt` still goes through `Array::iter`.
- README doc-tests were converted too, so the published examples show the
  idiomatic spelling.

## Testing

- `moon check --deny-warn --target all`
- `moon info --target wasm,wasm-gc,js,native` — no `.mbti` diff
- `moon fmt`
- `moon bundle --all`
- `moon test` on wasm-gc (7352), wasm (7352), js (7297), native (7269) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
