### PR TITLE
feat(immut/vector_map): add a persistent insertion-ordered map

### DIFF
--- a/immut/vector_map/README.mbt.md
+++ b/immut/vector_map/README.mbt.md
@@ -1,6 +1,6 @@
 # Immutable VectorMap
 
-A persistent map that iterates in **insertion order** — the immutable counterpart of the built-in insertion-ordered `Map`. Operations return a map and never disturb the receiver.
+A persistent map that iterates in **insertion order** — the immutable counterpart of the built-in insertion-ordered `Map`. Every update returns a new map and never disturbs the receiver.
 
 Reach for it over `@immut/hashmap` when the order in which entries were added is part of what you are storing: rendering a list, replaying a log, or anything whose output a reader would notice being shuffled. Reach for `@immut/sorted_map` instead when you want entries in *key* order, and for `@immut/hashmap` when order does not matter at all — it is the leaner structure.
 
@@ -167,7 +167,7 @@ test "json" {
 
 ## Skipping work on an unchanged map
 
-Two operations are guaranteed to hand back the receiver itself rather than an equal copy: removing a key that is not there, and filtering with a predicate that rejects nothing. A caller that memoises on physical identity — re-rendering only when the map is a different object — is therefore not woken by either.
+Two operations are guaranteed to hand back the receiver itself rather than an equal copy: removing a key that is not there, and filtering with a predicate that rejects nothing. `update` inherits the first, since returning `None` for a key that is absent goes through `remove`. A caller that memoises on physical identity — re-rendering only when the map is a different object — is therefore not woken by any of them.
 
 ```mbt check
 ///|
@@ -178,7 +178,7 @@ test "no_op" {
 }
 ```
 
-No such promise is made anywhere else, and in particular `add` always builds a new map even when the value it stores equals the one already there. Deciding otherwise would mean comparing values, and the only generic way to do that cheaply — `physical_equal` — is explicitly not something to hang semantics on. Check `get` yourself first if you need to skip a redundant write.
+No such promise is made beyond those, and in particular `add` always builds a new map even when the value it stores equals the one already there. Deciding otherwise would mean comparing values, and the only generic way to do that cheaply — `physical_equal` — is explicitly not something to hang semantics on. Check `get` yourself first if you need to skip a redundant write.
 
 ## How it works, and what it costs
 

--- a/immut/vector_map/README.mbt.md
+++ b/immut/vector_map/README.mbt.md
@@ -1,0 +1,210 @@
+# Immutable VectorMap
+
+A persistent map that iterates in **insertion order** — the immutable counterpart of the built-in insertion-ordered `Map`. Operations return a map and never disturb the receiver.
+
+Reach for it over `@immut/hashmap` when the order entries were added is part of what you are storing: rendering a list, replaying a log, or anything whose output a reader would notice being shuffled. Reach for `@immut/sorted_map` instead when you want entries in *key* order, and for `@immut/hashmap` when order does not matter at all — it is the leaner structure.
+
+## Create
+
+```mbt check
+///|
+test "create" {
+  let empty : @vector_map.VectorMap[String, Int] = @vector_map.new()
+  inspect(empty.is_empty(), content="true")
+  let one = @vector_map.singleton("a", 1)
+  inspect(one.length(), content="1")
+  // The array keeps its order — this is not sorted by key.
+  let m = @vector_map.VectorMap([("c", 3), ("a", 1), ("b", 2)])
+  debug_inspect(
+    m.keys().to_array(),
+    content=(
+      #|["c", "a", "b"]
+    ),
+  )
+}
+```
+
+## Order
+
+A key already in the map keeps its position when its value is replaced; a key that is new goes to the end. Removing a key and adding it back therefore moves it.
+
+```mbt check
+///|
+test "order" {
+  let m = @vector_map.VectorMap([("a", 1), ("b", 2), ("c", 3)])
+  // replacing in place: "a" stays first
+  debug_inspect(
+    m.add("a", 10).keys().to_array(),
+    content=(
+      #|["a", "b", "c"]
+    ),
+  )
+  // a fresh key is appended
+  debug_inspect(
+    m.add("d", 4).keys().to_array(),
+    content=(
+      #|["a", "b", "c", "d"]
+    ),
+  )
+  // remove-then-add moves it to the end
+  debug_inspect(
+    m.remove("a").add("a", 1).keys().to_array(),
+    content=(
+      #|["b", "c", "a"]
+    ),
+  )
+}
+```
+
+## Add, get, remove
+
+```mbt check
+///|
+test "add_get_remove" {
+  let m = @vector_map.new().add("a", 1).add("b", 2)
+  debug_inspect(m.get("a"), content="Some(1)")
+  inspect(m["b"], content="2")
+  inspect(m.contains("z"), content="false")
+  let smaller = m.remove("a")
+  debug_inspect(smaller.get("a"), content="None")
+  // the original is unchanged
+  debug_inspect(m.get("a"), content="Some(1)")
+}
+```
+
+`update` covers insert, replace and remove in one call, which is convenient when folding a change into existing state:
+
+```mbt check
+///|
+test "update" {
+  let m = @vector_map.VectorMap([("hits", 1)])
+  let bumped = m.update("hits", n => Some(n.unwrap_or(0) + 1))
+  debug_inspect(bumped.get("hits"), content="Some(2)")
+  let fresh = m.update("misses", n => Some(n.unwrap_or(0) + 1))
+  debug_inspect(fresh.get("misses"), content="Some(1)")
+  // returning None removes the key
+  inspect(m.update("hits", _ => None).is_empty(), content="true")
+}
+```
+
+## Traverse
+
+Every traversal yields entries in insertion order.
+
+```mbt check
+///|
+test "traverse" {
+  let m = @vector_map.VectorMap([("c", 3), ("a", 1), ("b", 2)])
+  debug_inspect(
+    m.to_array(),
+    content=(
+      #|[("c", 3), ("a", 1), ("b", 2)]
+    ),
+  )
+  inspect(m.fold(init=0, (acc, _, v) => acc + v), content="6")
+  let labelled = []
+  m.eachi((i, k, _) => labelled.push("\{i}:\{k}"))
+  debug_inspect(
+    labelled,
+    content=(
+      #|["0:c", "1:a", "2:b"]
+    ),
+  )
+  for k, v in m {
+    ignore((k, v))
+  }
+}
+```
+
+## Transform
+
+`map` rewrites values, keeping every key where it is. `filter` keeps the entries you select, in their existing relative order.
+
+```mbt check
+///|
+test "transform" {
+  let m = @vector_map.VectorMap([("c", 3), ("a", 1), ("b", 2)])
+  debug_inspect(
+    m.map((_, v) => v * 10).to_array(),
+    content=(
+      #|[("c", 30), ("a", 10), ("b", 20)]
+    ),
+  )
+  debug_inspect(
+    m.filter((_, v) => v > 1).to_array(),
+    content=(
+      #|[("c", 3), ("b", 2)]
+    ),
+  )
+}
+```
+
+## Equality, hashing and JSON
+
+Order is part of the content: two maps holding the same entries in different orders are **not** equal, and generally do not hash alike. That is what you want when a reordering is a visible change.
+
+```mbt check
+///|
+test "equality" {
+  let ab = @vector_map.VectorMap([("a", 1), ("b", 2)])
+  let ba = @vector_map.VectorMap([("b", 2), ("a", 1)])
+  inspect(ab == ba, content="false")
+  inspect(ab == @vector_map.new().add("a", 1).add("b", 2), content="true")
+}
+```
+
+JSON is an array of `[key, value]` pairs rather than an object, so that the order survives the round trip and keys keep their type.
+
+```mbt check
+///|
+test "json" {
+  let m = @vector_map.VectorMap([(30, "c"), (10, "a")])
+  json_inspect(m, content=[[30, "c"], [10, "a"]])
+  let back : @vector_map.VectorMap[Int, String] = @json.from_json(
+    @json.to_json(m),
+  )
+  inspect(back == m, content="true")
+}
+```
+
+## Skipping work on an unchanged map
+
+Two operations are guaranteed to hand back the receiver itself rather than an equal copy: removing a key that is not there, and filtering with a predicate that rejects nothing. A caller that memoises on physical identity — re-rendering only when the map is a different object — is therefore not woken by either.
+
+```mbt check
+///|
+test "no_op" {
+  let m = @vector_map.VectorMap([("a", 1)])
+  inspect(physical_equal(m.remove("absent"), m), content="true")
+  inspect(physical_equal(m.filter((_, _) => true), m), content="true")
+}
+```
+
+No such promise is made anywhere else, and in particular `add` always builds a new map even when the value it stores equals the one already there. Deciding otherwise would mean comparing values, and the only generic way to do that cheaply — `physical_equal` — is explicitly not something to hang semantics on. Check `get` yourself first if you need to skip a redundant write.
+
+## How it works, and what it costs
+
+Entries live in a persistent vector — the *spine* — in insertion order, and a persistent hash map — the *index* — maps each key to its slot. Iteration reads the spine straight through and never descends the hash trie, which is what makes traversing the whole map cheap; a lookup pays for both structures.
+
+| Operation | Cost |
+| --- | --- |
+| `contains` | one trie descent |
+| `get` | one trie descent, then one vector descent |
+| `add` on an existing key | one trie descent, then one vector path copied |
+| `add` on a new key | one trie descent, one trie insertion, and usually only the vector's tail rewritten |
+| `remove` | one trie descent, one trie removal, one vector write — plus the trimming or rebuild described below |
+| `length`, `is_empty` | `O(1)` |
+| iteration, `map`, `filter`, `to_array` | `O(n)` |
+
+A trie descent is `O(log n)` for keys whose hashes are reasonably distributed. Keys that collide on the full hash share a bucket that is searched linearly, so an adversarial or badly written `Hash` degrades lookup, `add` and `remove` towards `O(n)` — this map inherits that from `@immut/hashmap` and does nothing to make it worse.
+
+Removal punches a hole in the spine rather than shifting the entries after it, since shifting would invalidate the index entry for every one of them. Holes are then reclaimed two ways:
+
+- **Trimming.** A hole at the end of the spine is dropped at once, and dropping it can uncover more. Trimming `k` holes costs `k` vector pops, each of which may copy a tree path, so a single `remove` can cost `O(k log n)`.
+- **Rebuilding.** Holes in the middle accumulate until the spine is **both** at least 32 slots long **and** holding more holes than live entries. Below that length the ratio is not worth acting on, so a small map really can sit on nine holes and one entry. When it does fire, the spine is rebuilt dense and the index renumbered onto the new slots, at `O(n)`.
+
+Both are amortised only along a single line of descent. Every hole trimmed or reclaimed was paid for by the removal that made it, but a program that repeatedly returns to a version from just before a trim or a rebuild and removes again will pay the same cost each time. This is a good trade when a map's history moves mostly forward — state that is updated, occasionally rewound — and a poor one under heavy branching with heavy deletion in each branch.
+
+There is deliberately no positional lookup by rank. A slot is a physical position, holes and all, so exposing one would be either misleading or `O(n)`; iterate instead.
+
+The design follows Immutable.js's `OrderedMap`, and answers the same problem as Scala's `VectorMap`.

--- a/immut/vector_map/README.mbt.md
+++ b/immut/vector_map/README.mbt.md
@@ -188,7 +188,7 @@ Entries live in a persistent vector — the *spine* — in insertion order, and 
 | --- | --- |
 | `contains` | one trie descent |
 | `get` | one trie descent, then one vector descent |
-| `add` on an existing key | one trie descent, then one vector path copied |
+| `add` on an existing key | one trie descent, one vector descent to recover the stored key, then one vector path copied |
 | `add` on a new key | one trie descent, one trie insertion, and usually only the vector's tail rewritten |
 | `remove` | one trie descent, one trie removal, one vector write — plus the trimming or rebuild described below |
 | `length`, `is_empty` | `O(1)` |

--- a/immut/vector_map/README.mbt.md
+++ b/immut/vector_map/README.mbt.md
@@ -196,12 +196,14 @@ Entries live in a persistent vector — the *spine* — in insertion order, and 
 
 A trie descent is `O(log n)` for keys whose hashes are reasonably distributed. Keys that collide on the full hash share a bucket that is searched linearly, so an adversarial or badly written `Hash` degrades lookup, `add` and `remove` towards `O(n)` — this map inherits that from `@immut/hashmap` and does nothing to make it worse.
 
-Removal punches a hole in the spine rather than shifting the entries after it, since shifting would invalidate the index entry for every one of them. Holes are then reclaimed two ways:
+Removal punches a hole in the spine rather than shifting the entries after it, since shifting would invalidate the index entry for every one of them. Under continued removal, holes are reclaimed two ways:
 
 - **Trimming.** A hole at the end of the spine is dropped at once, and dropping it can uncover more. Trimming `k` holes costs `k` vector pops, each of which may copy a tree path, so a single `remove` can cost `O(k log n)`.
 - **Rebuilding.** Holes in the middle accumulate until the spine is **both** at least 32 slots long **and** holding more holes than live entries. Below that length the ratio is not worth acting on, so a small map really can sit on nine holes and one entry. When it does fire, the spine is rebuilt dense and the index renumbered onto the new slots, at `O(n)`.
 
-Both are amortised only along a single line of descent. Every hole trimmed or reclaimed was paid for by the removal that made it, but a program that repeatedly returns to a version from just before a trim or a rebuild and removes again will pay the same cost each time. This is a good trade when a map's history moves mostly forward — state that is updated, occasionally rewound — and a poor one under heavy branching with heavy deletion in each branch.
+Outside that cycle, a `filter` that rejects anything rebuilds the spine dense whatever its length, clearing every hole as a side effect; a `filter` that rejects nothing returns the receiver untouched, holes included.
+
+Both reclamation paths above are amortised only along a single line of descent. Every hole trimmed or reclaimed was paid for by the removal that made it, but a program that repeatedly returns to a version from just before a trim or a rebuild and removes again will pay the same cost each time. This is a good trade when a map's history moves mostly forward — state that is updated, occasionally rewound — and a poor one under heavy branching with heavy deletion in each branch.
 
 There is deliberately no positional lookup by rank. A slot is a physical position, holes and all, so exposing one would be either misleading or `O(n)`; iterate instead.
 

--- a/immut/vector_map/README.mbt.md
+++ b/immut/vector_map/README.mbt.md
@@ -160,9 +160,7 @@ JSON is an array of `[key, value]` pairs rather than an object, so that the orde
 test "json" {
   let m = @vector_map.VectorMap([(30, "c"), (10, "a")])
   json_inspect(m, content=[[30, "c"], [10, "a"]])
-  let back : @vector_map.VectorMap[Int, String] = @json.from_json(
-    @json.to_json(m),
-  )
+  let back : @vector_map.VectorMap[Int, String] = @json.from_json(Json(m))
   inspect(back == m, content="true")
 }
 ```

--- a/immut/vector_map/README.mbt.md
+++ b/immut/vector_map/README.mbt.md
@@ -2,7 +2,7 @@
 
 A persistent map that iterates in **insertion order** — the immutable counterpart of the built-in insertion-ordered `Map`. Operations return a map and never disturb the receiver.
 
-Reach for it over `@immut/hashmap` when the order entries were added is part of what you are storing: rendering a list, replaying a log, or anything whose output a reader would notice being shuffled. Reach for `@immut/sorted_map` instead when you want entries in *key* order, and for `@immut/hashmap` when order does not matter at all — it is the leaner structure.
+Reach for it over `@immut/hashmap` when the order in which entries were added is part of what you are storing: rendering a list, replaying a log, or anything whose output a reader would notice being shuffled. Reach for `@immut/sorted_map` instead when you want entries in *key* order, and for `@immut/hashmap` when order does not matter at all — it is the leaner structure.
 
 ## Create
 

--- a/immut/vector_map/README.mbt.md
+++ b/immut/vector_map/README.mbt.md
@@ -1,6 +1,6 @@
 # Immutable VectorMap
 
-A persistent map that iterates in **insertion order** — the immutable counterpart of the built-in insertion-ordered `Map`. Every update returns a new map and never disturbs the receiver.
+A persistent map that iterates in **insertion order** — the immutable counterpart of the built-in insertion-ordered `Map`. Updates return a map and never disturb the receiver: a new one when anything changed, and the receiver itself for a handful of no-ops spelled out below.
 
 Reach for it over `@immut/hashmap` when the order in which entries were added is part of what you are storing: rendering a list, replaying a log, or anything whose output a reader would notice being shuffled. Reach for `@immut/sorted_map` instead when you want entries in *key* order, and for `@immut/hashmap` when order does not matter at all — it is the leaner structure.
 

--- a/immut/vector_map/extends.mbt
+++ b/immut/vector_map/extends.mbt
@@ -23,7 +23,7 @@ pub extend VectorMap with Hash::{hash}
 // --- deprecated: hidden from the generated interface ---
 
 ///|
-#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#deprecated("Use `Json(x)` instead", skip_current_package=true)
 #doc(hidden)
 pub extend VectorMap with ToJson::{to_json}
 

--- a/immut/vector_map/extends.mbt
+++ b/immut/vector_map/extends.mbt
@@ -1,0 +1,48 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- promoted: kept as regular methods ---
+
+///|
+pub extend VectorMap with Eq::{equal}
+
+///|
+pub extend VectorMap with Hash::{hash}
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `@json.to_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend VectorMap with ToJson::{to_json}
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend VectorMap with @debug.Debug::{to_repr}
+
+///|
+#deprecated("Use `!=` instead", skip_current_package=true)
+#doc(hidden)
+pub extend VectorMap with Eq::{not_equal}
+
+///|
+#deprecated("Use `Hash::hash_combine` instead", skip_current_package=true)
+#doc(hidden)
+pub extend VectorMap with Hash::{hash_combine}
+
+///|
+#deprecated("Use `@json.from_json` instead", skip_current_package=true)
+#doc(hidden)
+pub extend VectorMap with @json.FromJson::{from_json}

--- a/immut/vector_map/invariants_wbtest.mbt
+++ b/immut/vector_map/invariants_wbtest.mbt
@@ -53,7 +53,7 @@ fn[K : Eq + Hash + Show, V] check_invariants(map : VectorMap[K, V]) -> String? {
   let mut failure = None
   map.spine.eachi((slot, entry) => {
     if entry is Some((key, _)) {
-      if map.index.get(key) != Some(slot) {
+      if map.index.get(key) != Some(slot) && failure is None {
         failure = Some(
           "slot \{slot} holds \{key}, which the index sends elsewhere",
         )

--- a/immut/vector_map/invariants_wbtest.mbt
+++ b/immut/vector_map/invariants_wbtest.mbt
@@ -1,0 +1,261 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The public tests pin down what the map means; these pin down what it is.
+// Nothing observable distinguishes a spine full of unreclaimed holes from a
+// dense one, so the bounds that keep the representation from degrading — the
+// index agreeing with the spine both ways, no trailing tombstone, holes never
+// outnumbering entries past the threshold — have to be asserted from inside.
+
+///|
+/// Every representation invariant from the doc comment on `VectorMap`, as a
+/// single predicate. Returns the first failure as a message so that a property
+/// counterexample says which invariant broke.
+fn[K : Eq + Hash + Show, V] check_invariants(map : VectorMap[K, V]) -> String? {
+  let length = map.spine.length()
+  // `size` counts exactly the live slots.
+  let mut live = 0
+  map.spine.each(entry => if entry is Some(_) { live += 1 })
+  guard live == map.size else {
+    return Some("size is \{map.size} but the spine holds \{live} entries")
+  }
+  // The index holds exactly the live keys…
+  guard map.index.length() == map.size else {
+    return Some(
+      "index holds \{map.index.length()} keys for \{map.size} entries",
+    )
+  }
+  // …and each one points at a slot carrying that same key.
+  for key, slot in map.index {
+    guard slot >= 0 && slot < length else {
+      return Some("key \{key} points at slot \{slot}, outside 0..<\{length}")
+    }
+    guard map.spine.get(slot) is Some(Some((slot_key, _))) else {
+      return Some("key \{key} points at slot \{slot}, which is a tombstone")
+    }
+    guard slot_key == key else {
+      return Some("key \{key} points at slot \{slot}, which holds \{slot_key}")
+    }
+  }
+  // Conversely every live slot is reachable through the index, at that slot —
+  // this is the direction that catches an index left stale by a rebuild.
+  let mut failure = None
+  map.spine.eachi((slot, entry) => {
+    if entry is Some((key, _)) {
+      if map.index.get(key) != Some(slot) {
+        failure = Some(
+          "slot \{slot} holds \{key}, which the index sends elsewhere",
+        )
+      }
+    }
+  })
+  guard failure is None else { return failure }
+  // A non-empty spine never ends on a hole, so an empty map is empty underneath.
+  if length > 0 {
+    guard map.spine.get(length - 1) is Some(Some(_)) else {
+      return Some("the spine ends on a tombstone")
+    }
+  }
+  // Holes stay bounded once the spine is long enough to be worth rebuilding.
+  if length >= MIN_COMPACT_LENGTH && length - map.size > map.size {
+    return Some("\{length - map.size} holes against \{map.size} entries")
+  }
+  None
+}
+
+///|
+test "invariants hold through a deletion-heavy operation sequence" {
+  @quickcheck.check(
+    (ops : Array[Int]) => {
+      let mut map : VectorMap[Int, Int] = new()
+      for op in ops {
+        let n = op & 0x7fffffff
+        let key = n / 8 % 24
+        match n % 6 {
+          0 | 1 => map = map.add(key, n % 7)
+          2 | 3 | 4 => map = map.remove(key)
+          _ => map = map.filter((k, _) => k % 3 != 0)
+        }
+        guard check_invariants(map) is None else { return false }
+      }
+      true
+    },
+    count=300,
+  )
+}
+
+///|
+test "invariants hold while the spine is churned around the threshold" {
+  // Alternating growth and shrinkage across `MIN_COMPACT_LENGTH` is where
+  // trimming, the compaction trigger and the index rebuild interact.
+  @quickcheck.check(
+    (raw : Array[Int]) => {
+      let mut map : VectorMap[Int, Int] = new()
+      let mut next = 0
+      for n in raw {
+        // `abs` would overflow on `Int::min_value`; masking cannot.
+        let count = (n & 0x7fffffff) % 12 + 1
+        // grow
+        for _ in 0..<count {
+          map = map.add(next, next)
+          next += 1
+          guard check_invariants(map) is None else { return false }
+        }
+        // shrink, oldest first, so the holes open at the front where trimming
+        // cannot reach them
+        for k in (next - count * 2)..<next {
+          if k >= 0 && n % 3 != 0 {
+            map = map.remove(k)
+            guard check_invariants(map) is None else { return false }
+          }
+        }
+      }
+      true
+    },
+    count=200,
+  )
+}
+
+///|
+test "trailing removals shrink the spine instead of leaving holes" {
+  let map = from_iter((0).until(10).map(i => (i, i)))
+  inspect(map.spine.length(), content="10")
+  // Dropping the last entry must pop it, not tombstone it…
+  let popped = map.remove(9)
+  inspect(popped.spine.length(), content="9")
+  // …and the trim keeps going over holes it uncovers.
+  let mut chained = map.remove(7).remove(8)
+  inspect(chained.spine.length(), content="10")
+  chained = chained.remove(9)
+  inspect(chained.spine.length(), content="7")
+  assert_true(check_invariants(chained) is None)
+}
+
+///|
+test "the spine is rebuilt once the holes outnumber the entries" {
+  let map = from_iter((0).until(100).map(i => (i, i)))
+  inspect(map.spine.length(), content="100")
+  // Removing 49 of the first 99 leaves 51 entries against 49 holes: still
+  // above the ratio, so nothing has been rebuilt yet.
+  let mut punched = map
+  for i in 0..<49 {
+    punched = punched.remove(i * 2)
+  }
+  inspect(punched.length(), content="51")
+  inspect(punched.spine.length(), content="100")
+  // Level pegging does not tip it either: the trigger is a strict majority of
+  // holes, so 50 against 50 still leaves the spine alone.
+  punched = punched.remove(98)
+  inspect(punched.length(), content="50")
+  inspect(punched.spine.length(), content="100")
+  // One more hole does tip it, and the spine collapses onto the live entries.
+  punched = punched.remove(97)
+  inspect(punched.length(), content="49")
+  inspect(punched.spine.length(), content="49")
+  assert_true(check_invariants(punched) is None)
+  // The rebuilt index still resolves every survivor.
+  for k, v in punched {
+    assert_true(punched.get(k) == Some(v))
+  }
+}
+
+///|
+test "a short spine is left alone however holey it gets" {
+  // Below the threshold the ratio is not worth a rebuild, so the holes stay.
+  let map = from_iter((0).until(10).map(i => (i, i)))
+  let mut punched = map
+  for i in 0..<9 {
+    punched = punched.remove(i)
+  }
+  inspect(punched.length(), content="1")
+  inspect(punched.spine.length(), content="10")
+  assert_true(check_invariants(punched) is None)
+  // Emptying it entirely still leaves nothing behind, because the trim runs
+  // regardless of the threshold.
+  punched = punched.remove(9)
+  inspect(punched.spine.length(), content="0")
+  assert_true(punched.is_empty())
+}
+
+///|
+test "appending can be what tips the spine into a rebuild" {
+  // A spine of 31 slots holding one entry is under `MIN_COMPACT_LENGTH`, so
+  // nothing reclaims its 30 holes. Appending one more entry carries it to 32,
+  // at which point the ratio is wildly over the limit — so `add` has to test
+  // for compaction too, not just `remove`.
+  let mut map = from_iter((0).until(31).map(i => (i, i)))
+  for i in 0..<30 {
+    map = map.remove(i)
+  }
+  inspect(map.length(), content="1")
+  inspect(map.spine.length(), content="31")
+  assert_true(check_invariants(map) is None)
+  let appended = map.add(100, 100)
+  inspect(appended.length(), content="2")
+  inspect(appended.spine.length(), content="2")
+  assert_true(check_invariants(appended) is None)
+  // …and the rebuild kept the order and every lookup
+  @debug.debug_inspect(appended.to_array(), content="[(30, 30), (100, 100)]")
+}
+
+///|
+test "churn under add and remove keeps reclaiming the spine" {
+  // Drives the ratio repeatedly rather than once, so a compaction that only
+  // worked from a pristine spine would show up here.
+  let mut map = from_iter((0).until(40).map(i => (i, i)))
+  let mut compactions = 0
+  for round in 0..<12 {
+    let before = map.spine.length()
+    // remove two thirds of what is there, oldest first…
+    for k, _ in map.to_array()[:map.length() * 2 / 3] {
+      map = map.remove(k)
+    }
+    // …and append fresh keys, which land past the holes
+    for j in 0..<8 {
+      map = map.add(1000 + round * 8 + j, j)
+    }
+    if map.spine.length() < before {
+      compactions += 1
+    }
+    assert_true(check_invariants(map) is None)
+  }
+  assert_true(compactions > 0)
+  // The surviving entries are still exactly what the operations left.
+  for k, v in map {
+    assert_true(map.get(k) == Some(v))
+  }
+}
+
+///|
+test "the simple constructors produce valid representations" {
+  let empty : VectorMap[String, Int] = new()
+  assert_true(check_invariants(empty) is None)
+  assert_true(check_invariants(singleton("a", 1)) is None)
+  assert_true(
+    check_invariants(VectorMap([("a", 1), ("b", 2), ("a", 3)])) is None,
+  )
+  assert_true(
+    check_invariants(from_iter((0).until(40).map(i => (i, i)))) is None,
+  )
+}
+
+///|
+test "map shares the index rather than rebuilding it" {
+  // Values change, slots do not, so the trie is handed straight over. This is
+  // what keeps a value-only transform off the hash path entirely.
+  let map = from_iter((0).until(40).map(i => (i, i)))
+  let mapped = map.map((_, v) => v * 2)
+  assert_true(physical_equal(mapped.index, map.index))
+  assert_true(check_invariants(mapped) is None)
+}

--- a/immut/vector_map/iter.mbt
+++ b/immut/vector_map/iter.mbt
@@ -1,0 +1,151 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Every traversal below walks the spine and skips tombstones, so all of them
+// yield entries in insertion order and none of them touches the hash trie.
+
+///|
+/// Apply `f` to every entry, in insertion order.
+pub fn[K, V] VectorMap::each(
+  self : VectorMap[K, V],
+  f : (K, V) -> Unit raise?,
+) -> Unit raise? {
+  self.spine.each(entry => if entry is Some((k, v)) { f(k, v) })
+}
+
+///|
+/// Apply `f` to every entry along with its position, in insertion order.
+///
+/// The position is the entry's rank among the live entries, so it always runs
+/// from `0` to `length() - 1` with no gaps, whatever the spine looks like
+/// underneath.
+pub fn[K, V] VectorMap::eachi(
+  self : VectorMap[K, V],
+  f : (Int, K, V) -> Unit raise?,
+) -> Unit raise? {
+  let mut i = 0
+  self.spine.each(entry => {
+    if entry is Some((k, v)) {
+      f(i, k, v)
+      i += 1
+    }
+  })
+}
+
+///|
+/// Iterate over the entries, in insertion order.
+#alias(iterator, deprecated)
+pub fn[K, V] VectorMap::iter(self : VectorMap[K, V]) -> Iter[(K, V)] {
+  self.spine.iter().filter_map(entry => entry)
+}
+
+///|
+/// Iterate over the entries as key/value pairs, in insertion order.
+#alias(iterator2, deprecated)
+pub fn[K, V] VectorMap::iter2(self : VectorMap[K, V]) -> Iter2[K, V] {
+  self.iter()
+}
+
+///|
+/// Iterate over the keys, in insertion order.
+pub fn[K, V] VectorMap::keys(self : VectorMap[K, V]) -> Iter[K] {
+  self.iter().map(kv => kv.0)
+}
+
+///|
+/// Iterate over the values, in insertion order.
+#alias(elems, deprecated)
+pub fn[K, V] VectorMap::values(self : VectorMap[K, V]) -> Iter[V] {
+  self.iter().map(kv => kv.1)
+}
+
+///|
+/// Fold over the entries, in insertion order.
+pub fn[K, V, A] VectorMap::fold(
+  self : VectorMap[K, V],
+  init~ : A,
+  f : (A, K, V) -> A raise?,
+) -> A raise? {
+  self.spine.fold(init~, (acc, entry) => {
+    match entry {
+      Some((k, v)) => f(acc, k, v)
+      None => acc
+    }
+  })
+}
+
+///|
+/// Collect the entries into an array, in insertion order.
+pub fn[K, V] VectorMap::to_array(self : VectorMap[K, V]) -> Array[(K, V)] {
+  let result : Array[(K, V)] = Array::new(capacity=self.size)
+  self.each((k, v) => result.push((k, v)))
+  result
+}
+
+///|
+/// Transform every value, keeping the keys and their order.
+///
+/// The index is shared with the receiver rather than rebuilt: no slot moves, so
+/// the mapping from keys to positions is unchanged.
+#alias(map_with_key, deprecated)
+pub fn[K, V, A] VectorMap::map(
+  self : VectorMap[K, V],
+  f : (K, V) -> A raise?,
+) -> VectorMap[K, A] raise? {
+  {
+    index: self.index,
+    spine: self.spine.map(entry => {
+      match entry {
+        Some((k, v)) => Some((k, f(k, v)))
+        None => None
+      }
+    }),
+    size: self.size,
+  }
+}
+
+///|
+/// Keep the entries satisfying `pred`, in their existing relative order.
+///
+/// A predicate that rejects nothing returns the receiver itself, holes and all;
+/// any other result is rebuilt dense, so filtering never *introduces* a hole.
+#alias(filter_with_key, deprecated)
+pub fn[K, V] VectorMap::filter(
+  self : VectorMap[K, V],
+  pred : (K, V) -> Bool raise?,
+) -> VectorMap[K, V] raise? {
+  // `remap` sends a surviving slot to its new dense position and a dropped one
+  // to -1, which is what lets the index be filtered and renumbered below
+  // without rehashing any key.
+  let remap = FixedArray::make(self.spine.length(), -1)
+  let kept : Array[(K, V)?] = []
+  self.spine.eachi((slot, entry) => {
+    if entry is Some((k, v)) {
+      if pred(k, v) {
+        remap[slot] = kept.length()
+        kept.push(entry)
+      }
+    }
+  })
+  if kept.length() == self.size {
+    return self
+  }
+  {
+    index: self.index
+    .filter((_, slot) => remap[slot] >= 0)
+    .map((_, slot) => remap[slot]),
+    spine: @vector.from_iter(kept.iter()),
+    size: kept.length(),
+  }
+}

--- a/immut/vector_map/iter.mbt
+++ b/immut/vector_map/iter.mbt
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 // Every traversal below walks the spine and skips tombstones, so all of them
-// yield entries in insertion order and none of them touches the hash trie.
+// yield entries in insertion order. Reading one never touches the hash trie;
+// only `filter` does, and only to carry the index over to the result.
 
 ///|
 /// Apply `f` to every entry, in insertion order. `O(n)`.

--- a/immut/vector_map/iter.mbt
+++ b/immut/vector_map/iter.mbt
@@ -16,7 +16,7 @@
 // yield entries in insertion order and none of them touches the hash trie.
 
 ///|
-/// Apply `f` to every entry, in insertion order.
+/// Apply `f` to every entry, in insertion order. `O(n)`.
 pub fn[K, V] VectorMap::each(
   self : VectorMap[K, V],
   f : (K, V) -> Unit raise?,
@@ -29,7 +29,7 @@ pub fn[K, V] VectorMap::each(
 ///
 /// The position is the entry's rank among the live entries, so it always runs
 /// from `0` to `length() - 1` with no gaps, whatever the spine looks like
-/// underneath.
+/// underneath. `O(n)`.
 pub fn[K, V] VectorMap::eachi(
   self : VectorMap[K, V],
   f : (Int, K, V) -> Unit raise?,
@@ -44,34 +44,37 @@ pub fn[K, V] VectorMap::eachi(
 }
 
 ///|
-/// Iterate over the entries, in insertion order.
+/// Iterate over the entries, in insertion order. `O(1)` to build, `O(n)` to
+/// drain.
 #alias(iterator, deprecated)
 pub fn[K, V] VectorMap::iter(self : VectorMap[K, V]) -> Iter[(K, V)] {
   self.spine.iter().filter_map(entry => entry)
 }
 
 ///|
-/// Iterate over the entries as key/value pairs, in insertion order.
+/// Iterate over the entries as key/value pairs, in insertion order. `O(1)` to
+/// build, `O(n)` to drain.
 #alias(iterator2, deprecated)
 pub fn[K, V] VectorMap::iter2(self : VectorMap[K, V]) -> Iter2[K, V] {
   self.iter()
 }
 
 ///|
-/// Iterate over the keys, in insertion order.
+/// Iterate over the keys, in insertion order. `O(1)` to build, `O(n)` to drain.
 pub fn[K, V] VectorMap::keys(self : VectorMap[K, V]) -> Iter[K] {
   self.iter().map(kv => kv.0)
 }
 
 ///|
-/// Iterate over the values, in insertion order.
+/// Iterate over the values, in insertion order. `O(1)` to build, `O(n)` to
+/// drain.
 #alias(elems, deprecated)
 pub fn[K, V] VectorMap::values(self : VectorMap[K, V]) -> Iter[V] {
   self.iter().map(kv => kv.1)
 }
 
 ///|
-/// Fold over the entries, in insertion order.
+/// Fold over the entries, in insertion order. `O(n)`.
 pub fn[K, V, A] VectorMap::fold(
   self : VectorMap[K, V],
   init~ : A,
@@ -86,7 +89,7 @@ pub fn[K, V, A] VectorMap::fold(
 }
 
 ///|
-/// Collect the entries into an array, in insertion order.
+/// Collect the entries into an array, in insertion order. `O(n)`.
 pub fn[K, V] VectorMap::to_array(self : VectorMap[K, V]) -> Array[(K, V)] {
   let result : Array[(K, V)] = Array::new(capacity=self.size)
   self.each((k, v) => result.push((k, v)))
@@ -97,7 +100,8 @@ pub fn[K, V] VectorMap::to_array(self : VectorMap[K, V]) -> Array[(K, V)] {
 /// Transform every value, keeping the keys and their order.
 ///
 /// The index is shared with the receiver rather than rebuilt: no slot moves, so
-/// the mapping from keys to positions is unchanged.
+/// the mapping from keys to positions is unchanged. `O(n)`, and no key is
+/// hashed.
 #alias(map_with_key, deprecated)
 pub fn[K, V, A] VectorMap::map(
   self : VectorMap[K, V],
@@ -120,6 +124,9 @@ pub fn[K, V, A] VectorMap::map(
 ///
 /// A predicate that rejects nothing returns the receiver itself, holes and all;
 /// any other result is rebuilt dense, so filtering never *introduces* a hole.
+///
+/// `O(n)`: one spine pass, then the index is filtered and renumbered in place
+/// of being rebuilt from the keys, so again nothing is hashed.
 #alias(filter_with_key, deprecated)
 pub fn[K, V] VectorMap::filter(
   self : VectorMap[K, V],

--- a/immut/vector_map/moon.pkg
+++ b/immut/vector_map/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "moonbitlang/core/builtin",
+  "moonbitlang/core/array",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+  "moonbitlang/core/immut/hashmap",
+  "moonbitlang/core/immut/vector",
+}
+
+import {
+  "moonbitlang/core/quickcheck",
+} for "test"
+
+import {
+  "moonbitlang/core/quickcheck",
+} for "wbtest"

--- a/immut/vector_map/pkg.generated.mbti
+++ b/immut/vector_map/pkg.generated.mbti
@@ -1,0 +1,60 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/immut/vector_map"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type VectorMap[K, V]
+pub fn[K : Eq + Hash, V] VectorMap::VectorMap(ArrayView[(K, V)]) -> Self[K, V]
+pub fn[K : Eq + Hash, V] VectorMap::add(Self[K, V], K, V) -> Self[K, V]
+#alias("_[_]")
+pub fn[K : Eq + Hash, V] VectorMap::at(Self[K, V], K) -> V
+pub fn[K : Eq + Hash, V] VectorMap::contains(Self[K, V], K) -> Bool
+pub fn[K, V] VectorMap::each(Self[K, V], (K, V) -> Unit raise?) -> Unit raise?
+pub fn[K, V] VectorMap::eachi(Self[K, V], (Int, K, V) -> Unit raise?) -> Unit raise?
+pub fn[K : Eq, V : Eq] VectorMap::equal(Self[K, V], Self[K, V]) -> Bool
+#alias(filter_with_key, deprecated)
+pub fn[K, V] VectorMap::filter(Self[K, V], (K, V) -> Bool raise?) -> Self[K, V] raise?
+pub fn[K, V, A] VectorMap::fold(Self[K, V], init~ : A, (A, K, V) -> A raise?) -> A raise?
+#alias(from_iterator, deprecated)
+#as_free_fn(from_iterator, deprecated)
+#as_free_fn
+pub fn[K : Eq + Hash, V] VectorMap::from_iter(Iter[(K, V)]) -> Self[K, V]
+#alias(find, deprecated)
+pub fn[K : Eq + Hash, V] VectorMap::get(Self[K, V], K) -> V?
+pub fn[K : Hash, V : Hash] VectorMap::hash(Self[K, V]) -> Int
+pub fn[K, V] VectorMap::is_empty(Self[K, V]) -> Bool
+#alias(iterator, deprecated)
+pub fn[K, V] VectorMap::iter(Self[K, V]) -> Iter[(K, V)]
+#alias(iterator2, deprecated)
+pub fn[K, V] VectorMap::iter2(Self[K, V]) -> Iter2[K, V]
+pub fn[K, V] VectorMap::keys(Self[K, V]) -> Iter[K]
+#alias(size, deprecated)
+pub fn[K, V] VectorMap::length(Self[K, V]) -> Int
+#alias(map_with_key, deprecated)
+pub fn[K, V, A] VectorMap::map(Self[K, V], (K, V) -> A raise?) -> Self[K, A] raise?
+#as_free_fn
+pub fn[K, V] VectorMap::new() -> Self[K, V]
+pub fn[K : Eq + Hash, V] VectorMap::remove(Self[K, V], K) -> Self[K, V]
+#as_free_fn
+pub fn[K : Hash, V] VectorMap::singleton(K, V) -> Self[K, V]
+pub fn[K, V] VectorMap::to_array(Self[K, V]) -> Array[(K, V)]
+pub fn[K : Eq + Hash, V] VectorMap::update(Self[K, V], K, (V?) -> V? raise?) -> Self[K, V] raise?
+#alias(elems, deprecated)
+pub fn[K, V] VectorMap::values(Self[K, V]) -> Iter[V]
+pub impl[K : Eq, V : Eq] Eq for VectorMap[K, V]
+pub impl[K : Hash, V : Hash] Hash for VectorMap[K, V]
+pub impl[K : ToJson, V : ToJson] ToJson for VectorMap[K, V]
+pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for VectorMap[K, V]
+pub impl[K : @json.FromJson + Eq + Hash, V : @json.FromJson] @json.FromJson for VectorMap[K, V]
+
+// Type aliases
+
+// Traits

--- a/immut/vector_map/quickcheck_test.mbt
+++ b/immut/vector_map/quickcheck_test.mbt
@@ -119,9 +119,11 @@ fn ops_agree(ops : Array[Int], remove_bias~ : Bool) -> Bool {
     // being replenished — which is what keeps appending fresh slots past the
     // holes left behind.
     let choice = if remove_bias {
-      // Only adds and removes: `filter` and `map` rebuild the spine dense, and
-      // mixing them in here would keep resetting the very hole accumulation
-      // this variant exists to produce.
+      // Only adds and removes, the two operations that create and reclaim
+      // holes. `filter` is kept out because a rejecting predicate rebuilds the
+      // spine dense, which would keep resetting the very accumulation this
+      // variant exists to produce; `map` is kept out merely because it moves
+      // neither the spine's length nor its holes, so it would add nothing here.
       match n % 6 {
         0 | 1 => 0
         _ => 3

--- a/immut/vector_map/quickcheck_test.mbt
+++ b/immut/vector_map/quickcheck_test.mbt
@@ -1,0 +1,302 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Property sweep against an association array carrying the same ordering rule:
+// a fresh key is appended, a key already present is overwritten where it sits.
+// That array IS the specification — `agrees_with_model` demands the map expose
+// exactly its entries, in exactly its order, through every traversal, and that
+// a map rebuilt from that content compares and hashes equal to the map that
+// reached it by operations. The interesting pressure is deletion: holes and the
+// rebuild that reclaims them are invisible to this model, so any slot that
+// survives an operation it should not, or any index left pointing at a stale
+// position, shows up as disagreement.
+
+///|
+/// Append if new, overwrite in place if present — `VectorMap::add`.
+fn model_add(model : Array[(Int, Int)], key : Int, value : Int) -> Unit {
+  for i, kv in model {
+    if kv.0 == key {
+      model[i] = (key, value)
+      return
+    }
+  }
+  model.push((key, value))
+}
+
+///|
+fn model_remove(model : Array[(Int, Int)], key : Int) -> Unit {
+  for i, kv in model {
+    if kv.0 == key {
+      model.remove(i) |> ignore
+      return
+    }
+  }
+}
+
+///|
+/// The full specification check for one state.
+fn agrees_with_model(
+  map : @vector_map.VectorMap[Int, Int],
+  model : Array[(Int, Int)],
+) -> Bool {
+  guard map.length() == model.length() else { return false }
+  guard map.is_empty() == model.is_empty() else { return false }
+  // Order and content, as seen through the array conversion…
+  guard map.to_array() == model else { return false }
+  // …and independently through each other traversal, since they walk the
+  // spine by different routes.
+  let via_each = []
+  map.each((k, v) => via_each.push((k, v)))
+  guard via_each == model else { return false }
+  let via_fold = map.fold(init=[], (acc : Array[(Int, Int)], k, v) => {
+    acc.push((k, v))
+    acc
+  })
+  guard via_fold == model else { return false }
+  guard map.keys().to_array() == model.map(kv => kv.0) else { return false }
+  guard map.values().to_array() == model.map(kv => kv.1) else { return false }
+  // `eachi` must number the live entries densely, whatever the spine holds.
+  let ranks = []
+  map.eachi((i, _, _) => ranks.push(i))
+  guard ranks == Array::makei(model.length(), i => i) else { return false }
+  // Lookups agree across the whole key universe, absences included.
+  for key in 0..<32 {
+    let expected = for kv in model {
+      if kv.0 == key {
+        break Some(kv.1)
+      }
+    } nobreak {
+      None
+    }
+    guard map.get(key) == expected else { return false }
+    guard map.contains(key) == (expected is Some(_)) else { return false }
+  }
+  // Same content reached by any history is the same value: equal, and equally
+  // hashed. This is what catches a stale index or an unreclaimed slot.
+  let rebuilt = @vector_map.from_iter(model.iter())
+  guard map == rebuilt else { return false }
+  let h1 = Hasher()
+  h1.combine(map)
+  let h2 = Hasher()
+  h2.combine(rebuilt)
+  h1.finalize() == h2.finalize()
+}
+
+///|
+/// Interpret `ops` as a stream of operations over a 32-key universe, mirroring
+/// each on the model and demanding agreement after every single step.
+///
+/// `remove_bias` skews the operation mix towards deletion AND starts from a map
+/// already holding the whole key universe. Both are needed to reach the regime
+/// where trimming and compaction run at all: a stream that starts empty and
+/// removes more than it adds simply stays empty, and a spine under 32 slots is
+/// never rebuilt however holey it gets.
+fn ops_agree(ops : Array[Int], remove_bias~ : Bool) -> Bool {
+  let model : Array[(Int, Int)] = []
+  let mut map : @vector_map.VectorMap[Int, Int] = @vector_map.new()
+  if remove_bias {
+    for key in 0..<32 {
+      map = map.add(key, key)
+      model_add(model, key, key)
+    }
+  }
+  for op in ops {
+    let n = op & 0x7fffffff
+    let key = n / 8 % 32
+    let value = n / 256 % 11
+    // Two adds against four removes, so the population drains while still
+    // being replenished — which is what keeps appending fresh slots past the
+    // holes left behind.
+    let choice = if remove_bias {
+      // Only adds and removes: `filter` and `map` rebuild the spine dense, and
+      // mixing them in here would keep resetting the very hole accumulation
+      // this variant exists to produce.
+      match n % 6 {
+        0 | 1 => 0
+        _ => 3
+      }
+    } else {
+      n % 8
+    }
+    match choice {
+      0 | 1 | 2 => {
+        map = map.add(key, value)
+        model_add(model, key, value)
+      }
+      3 | 4 => {
+        map = map.remove(key)
+        model_remove(model, key)
+      }
+      5 => {
+        // `update` must equal add-or-remove depending on what it returns.
+        map = map.update(key, old => {
+          if old is Some(v) && v % 2 == 0 {
+            None
+          } else {
+            Some(value)
+          }
+        })
+        let old = for kv in model {
+          if kv.0 == key {
+            break Some(kv.1)
+          }
+        } nobreak {
+          None
+        }
+        if old is Some(v) && v % 2 == 0 {
+          model_remove(model, key)
+        } else {
+          model_add(model, key, value)
+        }
+      }
+      6 => {
+        map = map.filter((k, v) => (k + v) % 3 != 0)
+        model.retain(kv => (kv.0 + kv.1) % 3 != 0)
+      }
+      _ => {
+        // `map` rewrites values without touching keys or their order.
+        map = map.map((k, v) => (v * 2 + k) % 11)
+        for i, kv in model {
+          model[i] = (kv.0, (kv.1 * 2 + kv.0) % 11)
+        }
+      }
+    }
+    guard agrees_with_model(map, model) else { return false }
+  }
+  true
+}
+
+///|
+test "quickcheck: operation sequences agree with the ordered model" {
+  @quickcheck.check(
+    (ops : Array[Int]) => ops_agree(ops, remove_bias=false),
+    count=300,
+  )
+}
+
+///|
+test "quickcheck: deletion-heavy sequences agree too" {
+  // Same property, but starting from a full universe and draining it, so the
+  // spine spends the run accumulating holes and reclaiming them.
+  @quickcheck.check(
+    (ops : Array[Int]) => ops_agree(ops, remove_bias=true),
+    count=300,
+  )
+}
+
+///|
+/// Build a map and its model from raw pairs, applying the ordering rule.
+fn build(
+  entries : Array[(Int, Int)],
+) -> (@vector_map.VectorMap[Int, Int], Array[(Int, Int)]) {
+  let model : Array[(Int, Int)] = []
+  // Masking rather than `%` keeps keys inside the probed universe for
+  // negative inputs too, and cannot overflow on `Int::min_value`.
+  let normalised = entries.map(kv => (kv.0 & 31, kv.1 & 7))
+  for kv in normalised {
+    model_add(model, kv.0, kv.1)
+  }
+  (VectorMap(normalised), model)
+}
+
+///|
+test "quickcheck: bulk construction matches repeated add" {
+  @quickcheck.check(
+    (entries : Array[(Int, Int)]) => {
+      let (map, model) = build(entries)
+      guard agrees_with_model(map, model) else { return false }
+      // The array constructor, the iterator constructor and a fold of `add`
+      // must all land on the same value.
+      let by_add = entries
+        .map(kv => (kv.0 & 31, kv.1 & 7))
+        .fold(init=@vector_map.new(), (m, kv) => m.add(kv.0, kv.1))
+      guard map == by_add else { return false }
+      map ==
+      @vector_map.from_iter(entries.iter().map(kv => (kv.0 & 31, kv.1 & 7)))
+    },
+    count=300,
+  )
+}
+
+///|
+test "quickcheck: persistence — an operation never disturbs its receiver" {
+  @quickcheck.check(
+    (input : (Array[(Int, Int)], Int, Int)) => {
+      let (entries, raw_key, raw_value) = input
+      let (map, model) = build(entries)
+      let key = raw_key & 31
+      let value = raw_value & 7
+      // Derive several new versions, then require the original intact.
+      let _ = map.add(key, value)
+      let _ = map.remove(key)
+      let _ = map.filter((k, _) => k % 2 == 0)
+      let _ = map.map((_, v) => v + 1)
+      let _ = map.update(key, _ => Some(value))
+      agrees_with_model(map, model)
+    },
+    count=200,
+  )
+}
+
+///|
+test "quickcheck: equality is exactly same-entries-same-order" {
+  @quickcheck.check(
+    (input : (Array[(Int, Int)], Int)) => {
+      let (entries, raw_shift) = input
+      let (map, model) = build(entries)
+      guard map == @vector_map.from_iter(model.iter()) else { return false }
+      // A rotation of a map with at least two distinct positions changes the
+      // order, so it must compare unequal.
+      let n = model.length()
+      guard n >= 2 else { return true }
+      // `abs` would overflow on `Int::min_value`; masking cannot.
+      let shift = (raw_shift & 0x7fffffff) % (n - 1) + 1
+      let rotated = Array::makei(n, i => model[(i + shift) % n])
+      let rotated_map = @vector_map.from_iter(rotated.iter())
+      // Same entries either way…
+      guard rotated_map.length() == map.length() else { return false }
+      for kv in model {
+        guard rotated_map.get(kv.0) == Some(kv.1) else { return false }
+      }
+      guard map != rotated_map else { return false }
+      // Perturbing a single value, leaving keys and order alone, must also be
+      // enough to make them unequal.
+      let (k0, v0) = model[0]
+      guard map != map.add(k0, v0 + 1) else { return false }
+      // A proper prefix must compare unequal from BOTH sides — a length check
+      // that only caught the short side on the right would leave `Eq`
+      // asymmetric, and comparing entry by entry would not notice.
+      let prefix = @vector_map.from_iter(model.iter().take(n - 1))
+      map != prefix && prefix != map
+    },
+    count=300,
+  )
+}
+
+///|
+test "quickcheck: json survives a round trip, order included" {
+  @quickcheck.check(
+    (entries : Array[(Int, Int)]) => {
+      let (map, _) = build(entries)
+      let decoded : @vector_map.VectorMap[Int, Int]? = Some(
+        @json.from_json(@json.to_json(map)),
+      ) catch {
+        _ => None
+      }
+      guard decoded is Some(back) else { return false }
+      back == map && back.to_array() == map.to_array()
+    },
+    count=200,
+  )
+}

--- a/immut/vector_map/quickcheck_test.mbt
+++ b/immut/vector_map/quickcheck_test.mbt
@@ -290,7 +290,7 @@ test "quickcheck: json survives a round trip, order included" {
     (entries : Array[(Int, Int)]) => {
       let (map, _) = build(entries)
       let decoded : @vector_map.VectorMap[Int, Int]? = Some(
-        @json.from_json(@json.to_json(map)),
+        @json.from_json(Json(map)),
       ) catch {
         _ => None
       }

--- a/immut/vector_map/quickcheck_test.mbt
+++ b/immut/vector_map/quickcheck_test.mbt
@@ -54,8 +54,10 @@ fn agrees_with_model(
   guard map.is_empty() == model.is_empty() else { return false }
   // Order and content, as seen through the array conversion…
   guard map.to_array() == model else { return false }
-  // …and independently through each other traversal, since they walk the
-  // spine by different routes.
+  // …and through the traversals that reach the spine by a different route:
+  // `each` walks it directly, `iter` filters its iterator, `fold` folds it.
+  // (`to_array` is `each` underneath, and `keys`/`values`/`iter2` are all
+  // `iter`, so those are checked for agreement rather than independence.)
   let via_each = []
   map.each((k, v) => via_each.push((k, v)))
   guard via_each == model else { return false }
@@ -66,6 +68,11 @@ fn agrees_with_model(
   guard via_fold == model else { return false }
   guard map.keys().to_array() == model.map(kv => kv.0) else { return false }
   guard map.values().to_array() == model.map(kv => kv.1) else { return false }
+  let via_iter2 = []
+  for k, v in map {
+    via_iter2.push((k, v))
+  }
+  guard via_iter2 == model else { return false }
   // `eachi` must number the live entries densely, whatever the spine holds.
   let ranks = []
   map.eachi((i, _, _) => ranks.push(i))
@@ -83,7 +90,9 @@ fn agrees_with_model(
     guard map.contains(key) == (expected is Some(_)) else { return false }
   }
   // Same content reached by any history is the same value: equal, and equally
-  // hashed. This is what catches a stale index or an unreclaimed slot.
+  // hashed. Both read live spine entries only — it is the lookup sweep above
+  // that catches a stale index — so what this adds is that an unreclaimed slot
+  // or a reordering never leaks into either.
   let rebuilt = @vector_map.from_iter(model.iter())
   guard map == rebuilt else { return false }
   let h1 = Hasher()
@@ -97,11 +106,12 @@ fn agrees_with_model(
 /// Interpret `ops` as a stream of operations over a 32-key universe, mirroring
 /// each on the model and demanding agreement after every single step.
 ///
-/// `remove_bias` skews the operation mix towards deletion AND starts from a map
-/// already holding the whole key universe. Both are needed to reach the regime
-/// where trimming and compaction run at all: a stream that starts empty and
-/// removes more than it adds simply stays empty, and a spine under 32 slots is
-/// never rebuilt however holey it gets.
+/// `remove_bias` skews the operation mix towards deletion and starts from a map
+/// already holding the whole key universe. Neither is strictly necessary —
+/// adding and removing from empty reaches trimming immediately, and enough
+/// churn eventually reaches a rebuild — but together they make both reliable
+/// within the op counts the generator produces, rather than leaving them to
+/// chance on a stream that spends its length near empty.
 fn ops_agree(ops : Array[Int], remove_bias~ : Bool) -> Bool {
   let model : Array[(Int, Int)] = []
   let mut map : @vector_map.VectorMap[Int, Int] = @vector_map.new()

--- a/immut/vector_map/traits_impl.mbt
+++ b/immut/vector_map/traits_impl.mbt
@@ -20,21 +20,21 @@
 /// entries needs, since a reordering is a visible change. The comparison reads
 /// the live entries only: tombstone layout is representation, and two equal
 /// maps reached by different histories may well have different spines.
+///
+/// `O(1)` when the two are physically identical or differ in length, `O(n)`
+/// otherwise — and it stops at the first entry that differs.
 pub impl[K : Eq, V : Eq] Eq for VectorMap[K, V] with fn equal(self, other) {
   if physical_equal(self, other) {
     return true
   }
+  // Comparing lengths first is not just a shortcut: the walk below stops after
+  // `self.size` entries, so without it a map would compare equal to any longer
+  // map it is a prefix of — and `Eq` would not even be symmetric.
   guard self.size == other.size else { return false }
   let left = self.iter()
   let right = other.iter()
   for _ in 0..<self.size {
-    match (left.next(), right.next()) {
-      (Some((k1, v1)), Some((k2, v2))) =>
-        if k1 != k2 || v1 != v2 {
-          return false
-        }
-      _ => return false
-    }
+    guard left.next() == right.next() else { return false }
   }
   true
 }
@@ -45,7 +45,7 @@ pub impl[K : Eq, V : Eq] Eq for VectorMap[K, V] with fn equal(self, other) {
 ///
 /// The length is not folded in separately: the hasher is fed one key and one
 /// value per entry in sequence, so a map and a proper prefix of it already
-/// diverge without help.
+/// diverge without help. `O(n)`.
 pub impl[K : Hash, V : Hash] Hash for VectorMap[K, V] with fn hash_combine(
   self,
   hasher,
@@ -71,7 +71,7 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for VectorMap[K, V] wi
 ///
 /// An array rather than an object, because the point of this type is the order
 /// of its entries and JSON object member order is not something a reader is
-/// obliged to preserve. It also keeps non-string keys intact.
+/// obliged to preserve. It also keeps non-string keys intact. `O(n)`.
 pub impl[K : ToJson, V : ToJson] ToJson for VectorMap[K, V] with fn to_json(
   self,
 ) {
@@ -81,6 +81,8 @@ pub impl[K : ToJson, V : ToJson] ToJson for VectorMap[K, V] with fn to_json(
 }
 
 ///|
+/// Decode an array of `[key, value]` pairs, applying the same duplicate-key rule
+/// as the array constructor. Two descents per pair, so `O(n log n)`.
 pub impl[K : @json.FromJson + Eq + Hash, V : @json.FromJson] @json.FromJson for VectorMap[
   K,
   V,

--- a/immut/vector_map/traits_impl.mbt
+++ b/immut/vector_map/traits_impl.mbt
@@ -1,0 +1,105 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Two maps are equal when they hold the same entries **in the same order**.
+///
+/// Order is part of the content here, so maps built from the same pairs in
+/// different orders are not equal — which is what a consumer rendering the
+/// entries needs, since a reordering is a visible change. The comparison reads
+/// the live entries only: tombstone layout is representation, and two equal
+/// maps reached by different histories may well have different spines.
+pub impl[K : Eq, V : Eq] Eq for VectorMap[K, V] with fn equal(self, other) {
+  if physical_equal(self, other) {
+    return true
+  }
+  guard self.size == other.size else { return false }
+  let left = self.iter()
+  let right = other.iter()
+  for _ in 0..<self.size {
+    match (left.next(), right.next()) {
+      (Some((k1, v1)), Some((k2, v2))) =>
+        if k1 != k2 || v1 != v2 {
+          return false
+        }
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+/// Hash the entries in insertion order, so that two maps that compare equal
+/// hash equally and two orderings of the same entries generally do not.
+///
+/// The length is not folded in separately: the hasher is fed one key and one
+/// value per entry in sequence, so a map and a proper prefix of it already
+/// diverge without help.
+pub impl[K : Hash, V : Hash] Hash for VectorMap[K, V] with fn hash_combine(
+  self,
+  hasher,
+) {
+  for k, v in self {
+    hasher.combine(k)
+    hasher.combine(v)
+  }
+}
+
+///|
+pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for VectorMap[K, V] with fn to_repr(
+  self,
+) {
+  @debug.Repr::opaque_(
+    "VectorMap",
+    @debug.Repr::map([ for k, v in self => (Repr(k), Repr(v)) ]),
+  )
+}
+
+///|
+/// Serialise as an array of `[key, value]` pairs.
+///
+/// An array rather than an object, because the point of this type is the order
+/// of its entries and JSON object member order is not something a reader is
+/// obliged to preserve. It also keeps non-string keys intact.
+pub impl[K : ToJson, V : ToJson] ToJson for VectorMap[K, V] with fn to_json(
+  self,
+) {
+  Json::array([ for k, v in self => [k.to_json(), v.to_json()] ])
+}
+
+///|
+pub impl[K : @json.FromJson + Eq + Hash, V : @json.FromJson] @json.FromJson for VectorMap[
+  K,
+  V,
+] with fn from_json(json, path) {
+  guard json is Array(pairs) else {
+    raise JsonDecodeError((path, "@immut/vector_map.from_json: expected array"))
+  }
+  let entries : Array[(K, V)] = Array::new(capacity=pairs.length())
+  for i, pair in pairs {
+    let entry_path = path.add_index(i)
+    guard pair is Array([key, value]) else {
+      raise JsonDecodeError(
+        (entry_path, "@immut/vector_map.from_json: expected [key, value] pair"),
+      )
+    }
+    entries.push(
+      (
+        @json.FromJson::from_json(key, entry_path.add_index(0)),
+        @json.FromJson::from_json(value, entry_path.add_index(1)),
+      ),
+    )
+  }
+  from_pairs(entries.iter())
+}

--- a/immut/vector_map/traits_impl.mbt
+++ b/immut/vector_map/traits_impl.mbt
@@ -59,6 +59,8 @@ pub impl[K : Hash, V : Hash] Hash for VectorMap[K, V] with fn hash_combine(
 }
 
 ///|
+/// Render the entries in insertion order. `O(n)`, plus whatever rendering each
+/// key and value costs.
 pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for VectorMap[K, V] with fn to_repr(
   self,
 ) {

--- a/immut/vector_map/traits_impl.mbt
+++ b/immut/vector_map/traits_impl.mbt
@@ -75,7 +75,9 @@ pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for VectorMap[K, V] wi
 pub impl[K : ToJson, V : ToJson] ToJson for VectorMap[K, V] with fn to_json(
   self,
 ) {
-  Json::array([ for k, v in self => [k.to_json(), v.to_json()] ])
+  [
+    for k, v in self => ([k, v] : Json)
+  ]
 }
 
 ///|

--- a/immut/vector_map/traits_impl.mbt
+++ b/immut/vector_map/traits_impl.mbt
@@ -44,8 +44,10 @@ pub impl[K : Eq, V : Eq] Eq for VectorMap[K, V] with fn equal(self, other) {
 /// hash equally and two orderings of the same entries generally do not.
 ///
 /// The length is not folded in separately: the hasher is fed one key and one
-/// value per entry in sequence, so a map and a proper prefix of it already
-/// diverge without help. `O(n)`.
+/// value per entry in sequence, so a map and a proper prefix of it already feed
+/// it different sequences. That is not a guarantee of different hashes — only
+/// equal maps hashing equally is promised, and unequal ones may always collide.
+/// `O(n)`.
 pub impl[K : Hash, V : Hash] Hash for VectorMap[K, V] with fn hash_combine(
   self,
   hasher,
@@ -82,7 +84,7 @@ pub impl[K : ToJson, V : ToJson] ToJson for VectorMap[K, V] with fn to_json(
 
 ///|
 /// Decode an array of `[key, value]` pairs, applying the same duplicate-key rule
-/// as the array constructor. Two descents per pair, so `O(n log n)`.
+/// as the array constructor, at the same `O(m log n)` for `m` pairs.
 pub impl[K : @json.FromJson + Eq + Hash, V : @json.FromJson] @json.FromJson for VectorMap[
   K,
   V,

--- a/immut/vector_map/types.mbt
+++ b/immut/vector_map/types.mbt
@@ -34,7 +34,7 @@
 /// - The last slot of a non-empty `spine` is never a tombstone, so an empty
 ///   map always has an empty spine.
 /// - Tombstones never outnumber live entries once the spine reaches
-///   `min_compact_length`.
+///   `MIN_COMPACT_LENGTH`.
 ///
 /// Note that the representation is deliberately *not* canonical: two equal maps
 /// may hold different tombstone layouts, so `Eq` compares the live entry

--- a/immut/vector_map/types.mbt
+++ b/immut/vector_map/types.mbt
@@ -43,15 +43,20 @@
 /// # Complexity
 ///
 /// Each operation carries its own cost below. Two conventions run through them:
-/// `n` is the number of live entries, and a *descent* — of the hash trie or of
-/// the spine — is `O(log n)` for keys whose hashes are reasonably distributed.
-/// Keys that collide on the whole hash share a bucket searched linearly, so a
-/// bad `Hash` degrades every keyed operation towards `O(n)`; that is inherited
-/// from `@immut/hashmap` rather than added here.
+/// `n` is the number of live entries — never the number of pairs an operation
+/// consumes, which is written `m` where the two differ — and a *descent*, of
+/// the hash trie or of the spine, is `O(log n)` for keys whose hashes are
+/// reasonably distributed. Keys that collide on the whole hash share a bucket
+/// searched linearly, so a bad `Hash` degrades every keyed operation towards
+/// `O(n)`; that is inherited from `@immut/hashmap` rather than added here.
 ///
-/// Traversals are linear in the *spine*, which the reclamation rules keep below
-/// twice the entry count, so they are `O(n)` with a constant factor that rises
-/// as holes accumulate.
+/// Traversals are linear in the *spine*, whose length the reclamation rules
+/// bound at `max(MIN_COMPACT_LENGTH - 1, 2n)`: a spine too short to be worth
+/// rebuilding is left alone however holey it gets, and above that length the
+/// trigger is a strict majority of holes, so an even split survives. Traversals
+/// are therefore `O(n)`, with a constant factor that rises as holes accumulate
+/// and, for a map that has shrunk to almost nothing, a floor set by the
+/// exemption rather than by the entry count.
 struct VectorMap[K, V] {
   index : @hashmap.HashMap[K, Int]
   spine : @vector.Vector[(K, V)?]

--- a/immut/vector_map/types.mbt
+++ b/immut/vector_map/types.mbt
@@ -1,0 +1,52 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A persistent map that iterates in **insertion order**, the immutable
+/// counterpart of the built-in insertion-ordered `Map`.
+///
+/// Entries live in a persistent vector — the *spine* — in the order they were
+/// first inserted, and a persistent hash map — the *index* — maps each key to
+/// its slot in that spine. Iteration therefore reads the spine straight
+/// through, without descending the hash trie, which is what makes it suited to
+/// rendering a collection on every state change.
+///
+/// Removal punches a hole in the spine rather than shifting the entries after
+/// it, since shifting would invalidate every index entry to their right. Those
+/// holes are reclaimed by `compact` once they outnumber the live entries.
+///
+/// # Invariants
+///
+/// - `index` holds exactly the live keys, and `spine[index[k]]` is
+///   `Some((k, _))` for every one of them.
+/// - `size` is the number of `Some` slots in `spine`.
+/// - The last slot of a non-empty `spine` is never a tombstone, so an empty
+///   map always has an empty spine.
+/// - Tombstones never outnumber live entries once the spine reaches
+///   `min_compact_length`.
+///
+/// Note that the representation is deliberately *not* canonical: two equal maps
+/// may hold different tombstone layouts, so `Eq` compares the live entry
+/// sequence rather than the underlying structure.
+struct VectorMap[K, V] {
+  index : @hashmap.HashMap[K, Int]
+  spine : @vector.Vector[(K, V)?]
+  size : Int
+}
+
+///|
+/// A spine shorter than this is never compacted: rebuilding it costs more than
+/// the slots it wastes. Matches the threshold Immutable.js uses for the same
+/// representation.
+const MIN_COMPACT_LENGTH : Int = 32

--- a/immut/vector_map/types.mbt
+++ b/immut/vector_map/types.mbt
@@ -39,6 +39,19 @@
 /// Note that the representation is deliberately *not* canonical: two equal maps
 /// may hold different tombstone layouts, so `Eq` compares the live entry
 /// sequence rather than the underlying structure.
+///
+/// # Complexity
+///
+/// Each operation carries its own cost below. Two conventions run through them:
+/// `n` is the number of live entries, and a *descent* — of the hash trie or of
+/// the spine — is `O(log n)` for keys whose hashes are reasonably distributed.
+/// Keys that collide on the whole hash share a bucket searched linearly, so a
+/// bad `Hash` degrades every keyed operation towards `O(n)`; that is inherited
+/// from `@immut/hashmap` rather than added here.
+///
+/// Traversals are linear in the *spine*, which the reclamation rules keep below
+/// twice the entry count, so they are `O(n)` with a constant factor that rises
+/// as holes accumulate.
 struct VectorMap[K, V] {
   index : @hashmap.HashMap[K, Int]
   spine : @vector.Vector[(K, V)?]

--- a/immut/vector_map/types.mbt
+++ b/immut/vector_map/types.mbt
@@ -24,10 +24,12 @@
 ///
 /// Removal punches a hole in the spine rather than shifting the entries after
 /// it, since shifting would invalidate every index entry to their right. Those
-/// holes are reclaimed by `compact` once the spine is both at least
-/// `MIN_COMPACT_LENGTH` slots long and holding more holes than live entries —
-/// a spine too short to be worth rebuilding is left alone however holey it
-/// gets.
+/// holes go two ways. A hole left at the end of the spine is trimmed at once,
+/// on the removal that made it, and trimming one can uncover more. A hole in
+/// the middle waits for `compact`, which runs only when the spine is both at
+/// least `MIN_COMPACT_LENGTH` slots long and holding more holes than live
+/// entries — a spine too short to be worth rebuilding is left alone however
+/// holey it gets.
 ///
 /// # Invariants
 ///

--- a/immut/vector_map/types.mbt
+++ b/immut/vector_map/types.mbt
@@ -24,7 +24,10 @@
 ///
 /// Removal punches a hole in the spine rather than shifting the entries after
 /// it, since shifting would invalidate every index entry to their right. Those
-/// holes are reclaimed by `compact` once they outnumber the live entries.
+/// holes are reclaimed by `compact` once the spine is both at least
+/// `MIN_COMPACT_LENGTH` slots long and holding more holes than live entries —
+/// a spine too short to be worth rebuilding is left alone however holey it
+/// gets.
 ///
 /// # Invariants
 ///

--- a/immut/vector_map/types.mbt
+++ b/immut/vector_map/types.mbt
@@ -24,12 +24,14 @@
 ///
 /// Removal punches a hole in the spine rather than shifting the entries after
 /// it, since shifting would invalidate every index entry to their right. Those
-/// holes go two ways. A hole left at the end of the spine is trimmed at once,
-/// on the removal that made it, and trimming one can uncover more. A hole in
-/// the middle waits for `compact`, which runs only when the spine is both at
-/// least `MIN_COMPACT_LENGTH` slots long and holding more holes than live
-/// entries — a spine too short to be worth rebuilding is left alone however
-/// holey it gets.
+/// holes go two ways as removals continue. A hole left at the end of the spine
+/// is trimmed at once, on the removal that made it, and trimming one can
+/// uncover more. A hole in the middle waits for `compact`, which runs only when
+/// the spine is both at least `MIN_COMPACT_LENGTH` slots long and holding more
+/// holes than live entries — a spine too short to be worth rebuilding is left
+/// alone however holey it gets. Beyond that, a `filter` that rejects anything
+/// rebuilds the spine dense whatever its length, so it clears every hole as a
+/// side effect.
 ///
 /// # Invariants
 ///

--- a/immut/vector_map/vector_map.mbt
+++ b/immut/vector_map/vector_map.mbt
@@ -1,0 +1,295 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Create an empty map.
+#as_free_fn
+pub fn[K, V] VectorMap::new() -> VectorMap[K, V] {
+  { index: @hashmap.new(), spine: @vector.new(), size: 0 }
+}
+
+///|
+/// Create a map holding a single entry.
+#as_free_fn
+pub fn[K : Hash, V] VectorMap::singleton(key : K, value : V) -> VectorMap[K, V] {
+  {
+    index: @hashmap.singleton(key, 0),
+    spine: @vector.singleton(Some((key, value))),
+    size: 1,
+  }
+}
+
+///|
+/// Create a map from an array of key-value pairs, in the array's order.
+///
+/// A repeated key keeps the position of its **first** occurrence and the value
+/// of its **last**, matching what repeated `add`s would produce.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let m = @vector_map.VectorMap([(3, "c"), (1, "a"), (3, "z")])
+///   debug_inspect(
+///     m.to_array(),
+///     content=(
+///       #|[(3, "z"), (1, "a")]
+///     ),
+///   )
+/// }
+/// ```
+pub fn[K : Eq + Hash, V] VectorMap::VectorMap(
+  arr : ArrayView[(K, V)],
+) -> VectorMap[K, V] {
+  from_pairs(arr.iter())
+}
+
+///|
+/// Create a map from an iterator of key-value pairs, in the iterator's order.
+///
+/// A repeated key keeps the position of its first occurrence and the value of
+/// its last.
+#as_free_fn
+#alias(from_iterator, deprecated)
+#as_free_fn(from_iterator, deprecated)
+pub fn[K : Eq + Hash, V] VectorMap::from_iter(
+  iter : Iter[(K, V)],
+) -> VectorMap[K, V] {
+  from_pairs(iter)
+}
+
+///|
+/// Build a dense map in a single pass: the first sighting of a key appends a
+/// slot, every later one overwrites that slot's value in place.
+fn[K : Eq + Hash, V] from_pairs(iter : Iter[(K, V)]) -> VectorMap[K, V] {
+  let entries : Array[(K, V)] = []
+  let mut index : @hashmap.HashMap[K, Int] = @hashmap.new()
+  for kv in iter {
+    let (key, value) = kv
+    match index.get(key) {
+      // Keep the key first inserted, so that the retained key and the
+      // retained position always come from the same occurrence.
+      Some(slot) => entries[slot] = (entries[slot].0, value)
+      None => {
+        index = index.add(key, entries.length())
+        entries.push((key, value))
+      }
+    }
+  }
+  {
+    index,
+    spine: @vector.from_iter(entries.iter().map(kv => Some(kv))),
+    size: entries.length(),
+  }
+}
+
+///|
+/// The number of entries in the map. This is `O(1)`.
+#alias(size, deprecated)
+pub fn[K, V] VectorMap::length(self : VectorMap[K, V]) -> Int {
+  self.size
+}
+
+///|
+/// Whether the map holds no entries.
+pub fn[K, V] VectorMap::is_empty(self : VectorMap[K, V]) -> Bool {
+  self.size == 0
+}
+
+///|
+/// Look up a key.
+#alias(find, deprecated)
+pub fn[K : Eq + Hash, V] VectorMap::get(self : VectorMap[K, V], key : K) -> V? {
+  guard self.index.get(key) is Some(slot) else { return None }
+  guard self.spine.get(slot) is Some(Some((_, value))) else { return None }
+  Some(value)
+}
+
+///|
+/// Look up a key, aborting when it is absent.
+#alias("_[_]")
+pub fn[K : Eq + Hash, V] VectorMap::at(self : VectorMap[K, V], key : K) -> V {
+  guard! self.get(key) is Some(value)
+  value
+}
+
+///|
+/// Whether the map holds an entry for `key`.
+pub fn[K : Eq + Hash, V] VectorMap::contains(
+  self : VectorMap[K, V],
+  key : K,
+) -> Bool {
+  self.index.contains(key)
+}
+
+///|
+/// Add an entry, returning a new map.
+///
+/// A key already present keeps its position and only its value is replaced; a
+/// new key is appended after every existing entry. Removing a key and adding it
+/// back therefore moves it to the end.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let m = @vector_map.VectorMap([("a", 1), ("b", 2)])
+///   // updating in place keeps "a" first
+///   debug_inspect(
+///     m.add("a", 10).keys().to_array(),
+///     content=(
+///       #|["a", "b"]
+///     ),
+///   )
+///   // re-adding after a removal appends
+///   debug_inspect(
+///     m.remove("a").add("a", 10).keys().to_array(),
+///     content=(
+///       #|["b", "a"]
+///     ),
+///   )
+/// }
+/// ```
+pub fn[K : Eq + Hash, V] VectorMap::add(
+  self : VectorMap[K, V],
+  key : K,
+  value : V,
+) -> VectorMap[K, V] {
+  match self.index.get(key) {
+    Some(slot) => {
+      // The key already stored is the one kept, so that the retained key and
+      // the retained position always come from the same insertion.
+      guard! self.spine.get(slot) is Some(Some((old_key, _)))
+      {
+        index: self.index,
+        spine: self.spine.set(slot, Some((old_key, value))),
+        size: self.size,
+      }
+    }
+    None => {
+      // Appending grows the spine, which can carry it over the length at which
+      // holes left by earlier removals become worth reclaiming — a spine of 31
+      // slots holding one entry is under the threshold and so is left alone,
+      // but the entry appended after it is not. Hence the check here as well as
+      // in `remove`: the ratio is a property of the spine, not of one operation.
+      let map = {
+        index: self.index.add(key, self.spine.length()),
+        spine: self.spine.push(Some((key, value))),
+        size: self.size + 1,
+      }
+      if map.should_compact() {
+        map.compact()
+      } else {
+        map
+      }
+    }
+  }
+}
+
+///|
+/// Remove a key, returning a new map. A key that is absent returns the receiver
+/// itself.
+pub fn[K : Eq + Hash, V] VectorMap::remove(
+  self : VectorMap[K, V],
+  key : K,
+) -> VectorMap[K, V] {
+  guard self.index.get(key) is Some(slot) else { return self }
+  // Punching a hole keeps every surviving slot where it is, so the rest of the
+  // index stays valid; trimming afterwards keeps last-in-first-out deletion
+  // from leaving anything behind at all.
+  let map = {
+    index: self.index.remove(key),
+    spine: trim_trailing(self.spine.set(slot, None)),
+    size: self.size - 1,
+  }
+  if map.should_compact() {
+    map.compact()
+  } else {
+    map
+  }
+}
+
+///|
+/// Replace, insert, or remove the entry for `key` in one step: `f` sees the
+/// current value if there is one, and its result becomes the new value, or
+/// removes the key when it is `None`.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let m = @vector_map.VectorMap([("a", 1)])
+///   let bumped = m.update("a", v => Some(v.unwrap_or(0) + 1))
+///   debug_inspect(bumped.get("a"), content="Some(2)")
+///   let cleared = m.update("a", _ => None)
+///   inspect(cleared.is_empty(), content="true")
+/// }
+/// ```
+pub fn[K : Eq + Hash, V] VectorMap::update(
+  self : VectorMap[K, V],
+  key : K,
+  f : (V?) -> V? raise?,
+) -> VectorMap[K, V] raise? {
+  match f(self.get(key)) {
+    Some(value) => self.add(key, value)
+    None => self.remove(key)
+  }
+}
+
+///|
+/// Drop tombstones off the end of the spine, restoring the invariant that a
+/// non-empty spine ends in a live entry.
+fn[K, V] trim_trailing(
+  spine : @vector.Vector[(K, V)?],
+) -> @vector.Vector[(K, V)?] {
+  for s = spine {
+    guard s.peek() is Some(None) else { break s }
+    guard s.pop() is Some(rest) else { break s }
+    continue rest
+  }
+}
+
+///|
+/// Whether the tombstones are worth an `O(n)` rebuild.
+///
+/// Rebuilding once the holes outnumber the live entries keeps the wasted slots
+/// below half, and makes each rebuild pay for the `Omega(n)` removals that
+/// caused it. Note that the threshold has to compare `holes > size` rather than
+/// `size < length / 2`: integer division would never fire on the small spines
+/// where every slot is a hole.
+fn[K, V] VectorMap::should_compact(self : VectorMap[K, V]) -> Bool {
+  let length = self.spine.length()
+  length >= MIN_COMPACT_LENGTH && length - self.size > self.size
+}
+
+///|
+/// Rebuild the spine dense and renumber the index onto the new slots.
+///
+/// No key is hashed again: `HashMap::map` walks the existing trie and replaces
+/// values in place, preserving its shape.
+fn[K, V] VectorMap::compact(self : VectorMap[K, V]) -> VectorMap[K, V] {
+  let remap = FixedArray::make(self.spine.length(), 0)
+  let kept : Array[(K, V)?] = Array::new(capacity=self.size)
+  self.spine.eachi((slot, entry) => {
+    if entry is Some(_) {
+      remap[slot] = kept.length()
+      kept.push(entry)
+    }
+  })
+  {
+    index: self.index.map((_, slot) => remap[slot]),
+    spine: @vector.from_iter(kept.iter()),
+    size: kept.length(),
+  }
+}

--- a/immut/vector_map/vector_map.mbt
+++ b/immut/vector_map/vector_map.mbt
@@ -36,7 +36,8 @@ pub fn[K : Hash, V] VectorMap::singleton(key : K, value : V) -> VectorMap[K, V] 
 /// A repeated key keeps the position of its **first** occurrence and the value
 /// of its **last**, matching what repeated `add`s would produce.
 ///
-/// Two descents per pair, so `O(n log n)`.
+/// One trie descent per input pair, plus a second for each pair that introduces
+/// a key, so `O(m log n)` for `m` pairs — repeated keys cost the lookup only.
 ///
 /// # Example
 ///
@@ -61,7 +62,8 @@ pub fn[K : Eq + Hash, V] VectorMap::VectorMap(
 /// Create a map from an iterator of key-value pairs, in the iterator's order.
 ///
 /// A repeated key keeps the position of its first occurrence and the value of
-/// its last. Two descents per pair, so `O(n log n)`.
+/// its last. One trie descent per pair, plus a second for each pair that
+/// introduces a key, so `O(m log n)` for `m` pairs.
 #as_free_fn
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
@@ -208,10 +210,11 @@ pub fn[K : Eq + Hash, V] VectorMap::add(
 /// Remove a key, returning a new map. A key that is absent returns the receiver
 /// itself.
 ///
-/// `O(log n)` amortised, but `O(n)` on a call that trims a long run of holes or
-/// rebuilds the spine. The amortisation holds along one line of descent only —
-/// repeatedly removing from a version taken just before a rebuild pays for it
-/// each time.
+/// `O(log n)` amortised. The worst case is a call that reclaims: trimming `k`
+/// uncovered holes costs `k` spine pops, each of which may copy a path, so
+/// `O(k log n)`; a rebuild costs `O(n)`. The amortisation holds along one line
+/// of descent only — repeatedly removing from a version taken just before a
+/// trim or a rebuild pays for it each time.
 pub fn[K : Eq + Hash, V] VectorMap::remove(
   self : VectorMap[K, V],
   key : K,
@@ -237,8 +240,8 @@ pub fn[K : Eq + Hash, V] VectorMap::remove(
 /// current value if there is one, and its result becomes the new value, or
 /// removes the key when it is `None`.
 ///
-/// A lookup followed by an `add` or a `remove`, so `O(log n)` amortised with
-/// their worst cases.
+/// A lookup followed by an `add` or a `remove`, so `O(log n)` amortised, with
+/// the reclamation worst cases those two carry.
 ///
 /// # Example
 ///

--- a/immut/vector_map/vector_map.mbt
+++ b/immut/vector_map/vector_map.mbt
@@ -282,10 +282,11 @@ fn[K, V] trim_trailing(
 /// Whether the tombstones are worth an `O(n)` rebuild.
 ///
 /// Rebuilding once the holes outnumber the live entries keeps the wasted slots
-/// below half, and makes each rebuild pay for the `Omega(n)` removals that
-/// caused it. Note that the threshold has to compare `holes > size` rather than
-/// `size < length / 2`: integer division would never fire on the small spines
-/// where every slot is a hole.
+/// at or below half — the comparison is strict, so an even split stands — and
+/// makes each rebuild pay for the `Omega(n)` removals that caused it. Note that
+/// the threshold has to compare `holes > size` rather than `size < length / 2`:
+/// integer division would never fire on the small spines where every slot is a
+/// hole.
 fn[K, V] VectorMap::should_compact(self : VectorMap[K, V]) -> Bool {
   let length = self.spine.length()
   length >= MIN_COMPACT_LENGTH && length - self.size > self.size

--- a/immut/vector_map/vector_map.mbt
+++ b/immut/vector_map/vector_map.mbt
@@ -284,9 +284,10 @@ fn[K, V] trim_trailing(
 /// Rebuilding once the holes outnumber the live entries keeps the wasted slots
 /// at or below half — the comparison is strict, so an even split stands — and
 /// makes each rebuild pay for the `Omega(n)` removals that caused it. Note that
-/// the threshold has to compare `holes > size` rather than `size < length / 2`:
-/// integer division would never fire on the small spines where every slot is a
-/// hole.
+/// the threshold compares `holes > size` rather than `size < length / 2`: the
+/// two disagree on odd spines carrying exactly one hole more than they carry
+/// entries, where integer division rounds the majority away — at length 33 with
+/// 16 entries and 17 holes, `size < length / 2` is `16 < 16` and never fires.
 fn[K, V] VectorMap::should_compact(self : VectorMap[K, V]) -> Bool {
   let length = self.spine.length()
   length >= MIN_COMPACT_LENGTH && length - self.size > self.size

--- a/immut/vector_map/vector_map.mbt
+++ b/immut/vector_map/vector_map.mbt
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 ///|
-/// Create an empty map.
+/// Create an empty map. `O(1)`.
 #as_free_fn
 pub fn[K, V] VectorMap::new() -> VectorMap[K, V] {
   { index: @hashmap.new(), spine: @vector.new(), size: 0 }
 }
 
 ///|
-/// Create a map holding a single entry.
+/// Create a map holding a single entry. `O(1)`.
 #as_free_fn
 pub fn[K : Hash, V] VectorMap::singleton(key : K, value : V) -> VectorMap[K, V] {
   {
@@ -35,6 +35,8 @@ pub fn[K : Hash, V] VectorMap::singleton(key : K, value : V) -> VectorMap[K, V] 
 ///
 /// A repeated key keeps the position of its **first** occurrence and the value
 /// of its **last**, matching what repeated `add`s would produce.
+///
+/// Two descents per pair, so `O(n log n)`.
 ///
 /// # Example
 ///
@@ -59,7 +61,7 @@ pub fn[K : Eq + Hash, V] VectorMap::VectorMap(
 /// Create a map from an iterator of key-value pairs, in the iterator's order.
 ///
 /// A repeated key keeps the position of its first occurrence and the value of
-/// its last.
+/// its last. Two descents per pair, so `O(n log n)`.
 #as_free_fn
 #alias(from_iterator, deprecated)
 #as_free_fn(from_iterator, deprecated)
@@ -95,20 +97,21 @@ fn[K : Eq + Hash, V] from_pairs(iter : Iter[(K, V)]) -> VectorMap[K, V] {
 }
 
 ///|
-/// The number of entries in the map. This is `O(1)`.
+/// The number of entries in the map. `O(1)` — the count is stored, unlike
+/// `@immut/hashmap.HashMap::length` which walks the whole trie.
 #alias(size, deprecated)
 pub fn[K, V] VectorMap::length(self : VectorMap[K, V]) -> Int {
   self.size
 }
 
 ///|
-/// Whether the map holds no entries.
+/// Whether the map holds no entries. `O(1)`.
 pub fn[K, V] VectorMap::is_empty(self : VectorMap[K, V]) -> Bool {
   self.size == 0
 }
 
 ///|
-/// Look up a key.
+/// Look up a key. One trie descent and one spine descent, so `O(log n)`.
 #alias(find, deprecated)
 pub fn[K : Eq + Hash, V] VectorMap::get(self : VectorMap[K, V], key : K) -> V? {
   guard self.index.get(key) is Some(slot) else { return None }
@@ -117,7 +120,7 @@ pub fn[K : Eq + Hash, V] VectorMap::get(self : VectorMap[K, V], key : K) -> V? {
 }
 
 ///|
-/// Look up a key, aborting when it is absent.
+/// Look up a key, aborting when it is absent. `O(log n)`, as for `get`.
 #alias("_[_]")
 pub fn[K : Eq + Hash, V] VectorMap::at(self : VectorMap[K, V], key : K) -> V {
   guard! self.get(key) is Some(value)
@@ -125,7 +128,8 @@ pub fn[K : Eq + Hash, V] VectorMap::at(self : VectorMap[K, V], key : K) -> V {
 }
 
 ///|
-/// Whether the map holds an entry for `key`.
+/// Whether the map holds an entry for `key`. One trie descent and no spine
+/// access at all, so `O(log n)` and cheaper than `get`.
 pub fn[K : Eq + Hash, V] VectorMap::contains(
   self : VectorMap[K, V],
   key : K,
@@ -139,6 +143,9 @@ pub fn[K : Eq + Hash, V] VectorMap::contains(
 /// A key already present keeps its position and only its value is replaced; a
 /// new key is appended after every existing entry. Removing a key and adding it
 /// back therefore moves it to the end.
+///
+/// `O(log n)` for a key already present. For a new key `O(log n)` amortised,
+/// but `O(n)` on the call that carries the spine over the rebuild threshold.
 ///
 /// # Example
 ///
@@ -200,6 +207,11 @@ pub fn[K : Eq + Hash, V] VectorMap::add(
 ///|
 /// Remove a key, returning a new map. A key that is absent returns the receiver
 /// itself.
+///
+/// `O(log n)` amortised, but `O(n)` on a call that trims a long run of holes or
+/// rebuilds the spine. The amortisation holds along one line of descent only —
+/// repeatedly removing from a version taken just before a rebuild pays for it
+/// each time.
 pub fn[K : Eq + Hash, V] VectorMap::remove(
   self : VectorMap[K, V],
   key : K,
@@ -224,6 +236,9 @@ pub fn[K : Eq + Hash, V] VectorMap::remove(
 /// Replace, insert, or remove the entry for `key` in one step: `f` sees the
 /// current value if there is one, and its result becomes the new value, or
 /// removes the key when it is `None`.
+///
+/// A lookup followed by an `add` or a `remove`, so `O(log n)` amortised with
+/// their worst cases.
 ///
 /// # Example
 ///

--- a/immut/vector_map/vector_map.mbt
+++ b/immut/vector_map/vector_map.mbt
@@ -296,8 +296,9 @@ fn[K, V] VectorMap::should_compact(self : VectorMap[K, V]) -> Bool {
 ///|
 /// Rebuild the spine dense and renumber the index onto the new slots.
 ///
-/// No key is hashed again: `HashMap::map` walks the existing trie and replaces
-/// values in place, preserving its shape.
+/// No key is hashed again: `HashMap::map` walks the existing trie and rebuilds
+/// it around the new values, node for node, so the shape is carried over
+/// without a single hash being recomputed.
 fn[K, V] VectorMap::compact(self : VectorMap[K, V]) -> VectorMap[K, V] {
   let remap = FixedArray::make(self.spine.length(), 0)
   let kept : Array[(K, V)?] = Array::new(capacity=self.size)

--- a/immut/vector_map/vector_map_test.mbt
+++ b/immut/vector_map/vector_map_test.mbt
@@ -188,8 +188,10 @@ test "update" {
       #|[("b", 2)]
     ),
   )
-  // removing something absent is a no-op
+  // removing something absent is a no-op, down to the identity of the result:
+  // `update` reaches `remove`, which hands the receiver back untouched
   assert_true(m.update("z", _ => None) == m)
+  assert_true(physical_equal(m.update("z", _ => None), m))
 }
 
 ///|
@@ -474,8 +476,10 @@ test "removals past the compaction threshold keep every promise" {
   )
   // Every survivor still resolves THROUGH THE INDEX, and to the value it was
   // given. Iterating would only read the spine, so it would not notice an index
-  // left pointing at the pre-rebuild slots; `get` and `contains` are the only
-  // black-box operations that go through it.
+  // left pointing at the pre-rebuild slots; `get` and `contains` are the direct
+  // read-only probes of it, which is what makes them the ones to sweep with
+  // here. (`add`, `remove` and `update` consult it too, but by changing the map
+  // rather than reporting on it.)
   for i in 0..<200 {
     if i % 5 == 0 {
       assert_true(sparse.contains(i))

--- a/immut/vector_map/vector_map_test.mbt
+++ b/immut/vector_map/vector_map_test.mbt
@@ -1,0 +1,526 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "construction" {
+  let empty : @vector_map.VectorMap[String, Int] = @vector_map.new()
+  inspect(empty.length(), content="0")
+  inspect(empty.is_empty(), content="true")
+  let single = @vector_map.singleton("a", 1)
+  debug_inspect(
+    single.to_array(),
+    content=(
+      #|[("a", 1)]
+    ),
+  )
+  let from_arr = @vector_map.VectorMap([("b", 2), ("a", 1), ("c", 3)])
+  debug_inspect(
+    from_arr.to_array(),
+    content=(
+      #|[("b", 2), ("a", 1), ("c", 3)]
+    ),
+  )
+  let from_it = @vector_map.from_iter([("b", 2), ("a", 1)].iter())
+  debug_inspect(
+    from_it.to_array(),
+    content=(
+      #|[("b", 2), ("a", 1)]
+    ),
+  )
+}
+
+///|
+test "a repeated key keeps the first position and the last value" {
+  let m = @vector_map.VectorMap([("a", 1), ("b", 2), ("a", 3), ("c", 4)])
+  debug_inspect(
+    m.to_array(),
+    content=(
+      #|[("a", 3), ("b", 2), ("c", 4)]
+    ),
+  )
+  inspect(m.length(), content="3")
+  // …exactly as repeated `add`s would leave it
+  let built = @vector_map.new().add("a", 1).add("b", 2).add("a", 3).add("c", 4)
+  assert_true(m == built)
+}
+
+///|
+test "singleton builds a whole map, not just a spine" {
+  // `to_array` reads only the spine, so a `singleton` that forgot to populate
+  // its index would look right and then fail every keyed operation.
+  let one = @vector_map.singleton("a", 1)
+  inspect(one.length(), content="1")
+  debug_inspect(one.get("a"), content="Some(1)")
+  inspect(one.contains("a"), content="true")
+  inspect(one["a"], content="1")
+  inspect(one.remove("a").is_empty(), content="true")
+  // replacing the value updates in place rather than appending a second entry
+  debug_inspect(
+    one.add("a", 2).to_array(),
+    content=(
+      #|[("a", 2)]
+    ),
+  )
+  debug_inspect(
+    one.update("a", v => Some(v.unwrap() + 10)).to_array(),
+    content=(
+      #|[("a", 11)]
+    ),
+  )
+  assert_true(one == VectorMap([("a", 1)]))
+}
+
+///|
+test "lookup" {
+  let m = @vector_map.VectorMap([("a", 1), ("b", 2)])
+  debug_inspect(m.get("a"), content="Some(1)")
+  debug_inspect(m.get("z"), content="None")
+  inspect(m["b"], content="2")
+  inspect(m.contains("a"), content="true")
+  inspect(m.contains("z"), content="false")
+}
+
+///|
+test "panic at on a missing key" {
+  let m : @vector_map.VectorMap[String, Int] = @vector_map.new()
+  ignore(m["missing"])
+}
+
+///|
+test "add keeps an existing key in place but appends a fresh one" {
+  let m = @vector_map.VectorMap([("a", 1), ("b", 2), ("c", 3)])
+  debug_inspect(
+    m.add("b", 20).to_array(),
+    content=(
+      #|[("a", 1), ("b", 20), ("c", 3)]
+    ),
+  )
+  debug_inspect(
+    m.add("d", 4).to_array(),
+    content=(
+      #|[("a", 1), ("b", 2), ("c", 3), ("d", 4)]
+    ),
+  )
+  // removing and re-adding moves the key to the end
+  debug_inspect(
+    m.remove("a").add("a", 1).to_array(),
+    content=(
+      #|[("b", 2), ("c", 3), ("a", 1)]
+    ),
+  )
+  // the receiver is untouched throughout
+  debug_inspect(
+    m.to_array(),
+    content=(
+      #|[("a", 1), ("b", 2), ("c", 3)]
+    ),
+  )
+}
+
+///|
+test "remove" {
+  let m = @vector_map.VectorMap([("a", 1), ("b", 2), ("c", 3)])
+  debug_inspect(
+    m.remove("b").to_array(),
+    content=(
+      #|[("a", 1), ("c", 3)]
+    ),
+  )
+  // removing the last entry, then the rest
+  inspect(m.remove("c").remove("b").remove("a").is_empty(), content="true")
+}
+
+///|
+test "a no-op returns the receiver itself" {
+  // Callers that skip work when the map is physically unchanged depend on
+  // these two, so they are contract rather than incidental optimisation.
+  let m = @vector_map.VectorMap([("a", "x"), ("b", "y")])
+  assert_true(physical_equal(m.remove("missing"), m))
+  assert_true(physical_equal(m.filter((_, _) => true), m))
+  // A holey receiver is handed back holes and all, rather than compacted.
+  let holey = @vector_map.VectorMap([("a", "x"), ("gone", "z"), ("b", "y")]).remove(
+    "gone",
+  )
+  assert_true(physical_equal(holey.filter((_, _) => true), holey))
+  // …and a real change does not preserve identity
+  assert_false(physical_equal(m.remove("a"), m))
+  assert_false(physical_equal(m.filter((k, _) => k != "a"), m))
+  // `add` makes no such promise, even when it stores the very value already
+  // there: skipping the write would mean deciding equality with
+  // `physical_equal`, which is documented as unsafe to hang semantics on. So it
+  // allocates, and only compares equal.
+  assert_true(m.add("a", m["a"]) == m)
+  assert_false(physical_equal(m.add("a", m["a"]), m))
+}
+
+///|
+test "update" {
+  let m = @vector_map.VectorMap([("a", 1), ("b", 2)])
+  // replace in place
+  debug_inspect(
+    m.update("a", v => Some(v.unwrap() + 10)).to_array(),
+    content=(
+      #|[("a", 11), ("b", 2)]
+    ),
+  )
+  // insert, appending
+  debug_inspect(
+    m.update("c", _ => Some(3)).to_array(),
+    content=(
+      #|[("a", 1), ("b", 2), ("c", 3)]
+    ),
+  )
+  // remove
+  debug_inspect(
+    m.update("a", _ => None).to_array(),
+    content=(
+      #|[("b", 2)]
+    ),
+  )
+  // removing something absent is a no-op
+  assert_true(m.update("z", _ => None) == m)
+}
+
+///|
+test "traversals all agree on insertion order" {
+  let m = @vector_map.VectorMap([("c", 3), ("a", 1), ("b", 2)])
+  debug_inspect(
+    m.keys().to_array(),
+    content=(
+      #|["c", "a", "b"]
+    ),
+  )
+  debug_inspect(m.values().to_array(), content="[3, 1, 2]")
+  let seen = []
+  m.each((k, v) => seen.push("\{k}=\{v}"))
+  debug_inspect(
+    seen,
+    content=(
+      #|["c=3", "a=1", "b=2"]
+    ),
+  )
+  let indexed = []
+  m.eachi((i, k, _) => indexed.push("\{i}:\{k}"))
+  debug_inspect(
+    indexed,
+    content=(
+      #|["0:c", "1:a", "2:b"]
+    ),
+  )
+  inspect(m.fold(init="", (acc, k, _) => acc + k), content="cab")
+  let pairs = []
+  for k, v in m {
+    pairs.push((k, v))
+  }
+  debug_inspect(
+    pairs,
+    content=(
+      #|[("c", 3), ("a", 1), ("b", 2)]
+    ),
+  )
+}
+
+///|
+test "eachi numbers the live entries, not the underlying slots" {
+  // "b" leaves a hole behind, which must not show up as a skipped index.
+  let m = @vector_map.VectorMap([("a", 1), ("b", 2), ("c", 3)]).remove("b")
+  let indexed = []
+  m.eachi((i, k, _) => indexed.push("\{i}:\{k}"))
+  debug_inspect(
+    indexed,
+    content=(
+      #|["0:a", "1:c"]
+    ),
+  )
+}
+
+///|
+test "map and filter preserve order" {
+  let m = @vector_map.VectorMap([("c", 3), ("a", 1), ("b", 2)])
+  debug_inspect(
+    m.map((k, v) => "\{k}\{v}").to_array(),
+    content=(
+      #|[("c", "c3"), ("a", "a1"), ("b", "b2")]
+    ),
+  )
+  debug_inspect(
+    m.filter((_, v) => v != 1).to_array(),
+    content=(
+      #|[("c", 3), ("b", 2)]
+    ),
+  )
+  // filtering everything out leaves an empty map
+  inspect(m.filter((_, _) => false).is_empty(), content="true")
+}
+
+///|
+test "equality is order sensitive" {
+  let ab = @vector_map.VectorMap([("a", 1), ("b", 2)])
+  let ba = @vector_map.VectorMap([("b", 2), ("a", 1)])
+  assert_true(ab == ab)
+  assert_false(ab == ba)
+  assert_true(ab != ba)
+  // equal content in equal order compares equal however it was built
+  assert_true(ab == @vector_map.new().add("a", 1).add("b", 2))
+  // A prefix is not equal to the whole — and this has to be checked from BOTH
+  // sides. Comparing entry by entry only detects the short side running out
+  // when it is on the right, so a length check that fired one way round would
+  // leave `Eq` asymmetric.
+  let a_only = @vector_map.singleton("a", 1)
+  let empty : @vector_map.VectorMap[String, Int] = @vector_map.new()
+  assert_false(ab == a_only)
+  assert_false(a_only == ab)
+  assert_false(ab == empty)
+  assert_false(empty == ab)
+  // same keys, same order, one different value
+  assert_false(ab == VectorMap([("a", 1), ("b", 99)]))
+  assert_false(ab == VectorMap([("a", 99), ("b", 2)]))
+  // same order and values, one different key
+  assert_false(ab == VectorMap([("a", 1), ("z", 2)]))
+}
+
+///|
+test "equality ignores how the holes fell" {
+  // Same live entries in the same order, but reached by different histories:
+  // one spine carries a tombstone, the other does not.
+  let punched = @vector_map.VectorMap([("a", 1), ("gone", 0), ("b", 2)]).remove(
+    "gone",
+  )
+  let dense = @vector_map.VectorMap([("a", 1), ("b", 2)])
+  assert_true(punched == dense)
+  let h1 = Hasher()
+  h1.combine(punched)
+  let h2 = Hasher()
+  h2.combine(dense)
+  inspect(h1.finalize() == h2.finalize(), content="true")
+}
+
+///|
+fn[K : Hash, V : Hash] hash_of(map : @vector_map.VectorMap[K, V]) -> Int {
+  let hasher = Hasher()
+  hasher.combine(map)
+  hasher.finalize()
+}
+
+///|
+test "every part of an entry feeds the hash" {
+  // Only "equal maps hash equally" is a contract — unequal maps are always free
+  // to collide. Each case below pins one concrete pair, so that a hash which
+  // quietly stopped folding in the keys or the values would show up rather than
+  // passing on the strength of the component it still folds in.
+  let ab = @vector_map.VectorMap([("a", 1), ("b", 2)])
+  // keys: same values, same order
+  inspect(
+    hash_of(ab) == hash_of(VectorMap([("x", 1), ("y", 2)])),
+    content="false",
+  )
+  // values: same keys, same order
+  inspect(
+    hash_of(ab) == hash_of(VectorMap([("a", 9), ("b", 8)])),
+    content="false",
+  )
+  // Shorter maps: nothing folds the length in explicitly, so these check that
+  // feeding the entries in sequence is enough to separate a prefix anyway.
+  inspect(
+    hash_of(ab) == hash_of(@vector_map.singleton("a", 1)),
+    content="false",
+  )
+  let empty : @vector_map.VectorMap[String, Int] = @vector_map.new()
+  inspect(hash_of(ab) == hash_of(empty), content="false")
+}
+
+///|
+test "hashing distinguishes the orderings" {
+  // Guards against the hash silently becoming order-insensitive the way
+  // `@immut/hashmap`'s deliberately is.
+  let ab = @vector_map.VectorMap([("a", 1), ("b", 2)])
+  let ba = @vector_map.VectorMap([("b", 2), ("a", 1)])
+  let h1 = Hasher()
+  h1.combine(ab)
+  let h2 = Hasher()
+  h2.combine(ba)
+  inspect(h1.finalize() == h2.finalize(), content="false")
+}
+
+///|
+test "Debug for VectorMap" {
+  let m = @vector_map.VectorMap([(2, "b"), (1, "a")])
+  @debug.debug_inspect(
+    m,
+    content=(
+      #|<VectorMap: { 2: "b", 1: "a" }>
+    ),
+  )
+}
+
+///|
+test "json round trip keeps the order and the key type" {
+  let m = @vector_map.VectorMap([(30, "c"), (10, "a"), (20, "b")])
+  json_inspect(m, content=[[30, "c"], [10, "a"], [20, "b"]])
+  let back : @vector_map.VectorMap[Int, String] = @json.from_json(
+    @json.to_json(m),
+  )
+  assert_true(back == m)
+}
+
+///|
+test "json decoding rejects malformed input, pointing at it" {
+  // An object cannot carry an order, so it is refused outright.
+  let bad : Json = { "a": 1 }
+  try (@json.from_json(bad) : @vector_map.VectorMap[Int, Int]) |> ignore catch {
+    JsonDecodeError((path, msg)) => {
+      inspect(
+        path,
+        content=(
+          #|
+        ),
+      )
+      inspect(msg, content="@immut/vector_map.from_json: expected array")
+    }
+  } noraise {
+    _ => fail("expected an object to be rejected")
+  }
+  // A pair of the wrong width is reported at the offending entry, not at the
+  // root — the path is what makes a decode failure diagnosable.
+  let ragged : Json = [[0, 0], [1]]
+  try
+    (@json.from_json(ragged) : @vector_map.VectorMap[Int, Int]) |> ignore
+  catch {
+    JsonDecodeError((path, msg)) => {
+      inspect(
+        path,
+        content=(
+          #|/1
+        ),
+      )
+      inspect(
+        msg,
+        content="@immut/vector_map.from_json: expected [key, value] pair",
+      )
+    }
+  } noraise {
+    _ => fail("expected a one-element pair to be rejected")
+  }
+  // A malformed KEY is reported at position 0 of its pair, a malformed value
+  // at position 1 — the two halves are decoded under different paths, so both
+  // need pinning.
+  let bad_key : Json = [[0, 0], ["not an int", 1]]
+  try
+    (@json.from_json(bad_key) : @vector_map.VectorMap[Int, Int]) |> ignore
+  catch {
+    JsonDecodeError((path, _)) =>
+      inspect(
+        path,
+        content=(
+          #|/1/0
+        ),
+      )
+  } noraise {
+    _ => fail("expected a mistyped key to be rejected")
+  }
+  // A value of the wrong type is reported inside the pair.
+  let mistyped : Json = [[0, "not an int"]]
+  try
+    (@json.from_json(mistyped) : @vector_map.VectorMap[Int, Int]) |> ignore
+  catch {
+    JsonDecodeError((path, _)) =>
+      inspect(
+        path,
+        content=(
+          #|/0/1
+        ),
+      )
+  } noraise {
+    _ => fail("expected a mistyped value to be rejected")
+  }
+}
+
+///|
+test "json decoding applies the same duplicate-key rule as construction" {
+  // Decoding goes through the same builder as `VectorMap([...])`, so a repeated
+  // key keeps its first position and its last value rather than appearing twice.
+  let dup : Json = [[1, "a"], [2, "b"], [1, "z"]]
+  let m : @vector_map.VectorMap[Int, String] = @json.from_json(dup)
+  debug_inspect(
+    m.to_array(),
+    content=(
+      #|[(1, "z"), (2, "b")]
+    ),
+  )
+  assert_true(m == VectorMap([(1, "a"), (2, "b"), (1, "z")]))
+}
+
+///|
+test "removals past the compaction threshold keep every promise" {
+  // 200 entries is well past `MIN_COMPACT_LENGTH`, so dropping most of them
+  // forces at least one rebuild of both the spine and the index.
+  let m = @vector_map.from_iter((0).until(200).map(i => (i, i * i)))
+  let sparse = (0)
+    .until(200)
+    .fold(init=m, (acc, i) => if i % 5 == 0 { acc } else { acc.remove(i) })
+  inspect(sparse.length(), content="40")
+  debug_inspect(
+    sparse.keys().to_array()[:5].to_owned(),
+    content="[0, 5, 10, 15, 20]",
+  )
+  // every survivor still resolves, and to the value it was given
+  for k, v in sparse {
+    assert_eq(v, k * k)
+  }
+  // and the rebuilt index agrees with a map built dense from the start
+  assert_true(sparse == @vector_map.from_iter(sparse.iter()))
+  // the original is untouched by all of it
+  inspect(m.length(), content="200")
+}
+
+///|
+/// A key whose identity is its `name` alone: two `TaggedKey`s with the same
+/// name are `Eq` and hash alike, but carry a `tag` that says which of them a
+/// map actually kept. Without a key like this, "the first key is retained" is
+/// unobservable — repeating an identical `String` proves nothing.
+priv struct TaggedKey {
+  name : String
+  tag : Int
+}
+
+///|
+impl Eq for TaggedKey with fn equal(self, other) {
+  self.name == other.name
+}
+
+///|
+impl Hash for TaggedKey with fn hash_combine(self, hasher) {
+  hasher.combine_string(self.name)
+}
+
+///|
+test "a replaced entry keeps the key it was first inserted with" {
+  let first = { name: "k", tag: 1 }
+  let second = { name: "k", tag: 2 }
+  let third = { name: "k", tag: 3 }
+  // Bulk construction: last value wins, but the key stays the first one, so
+  // that the retained key and the retained position come from one insertion.
+  let built = @vector_map.VectorMap([(first, "x"), (second, "y")])
+  inspect(built.length(), content="1")
+  inspect(built.to_array()[0].0.tag, content="1")
+  inspect(built.to_array()[0].1, content="y")
+  // `add` over an existing key behaves the same way.
+  let updated = built.add(third, "z")
+  inspect(updated.to_array()[0].0.tag, content="1")
+  inspect(updated.to_array()[0].1, content="z")
+  // …and after the key has been removed, the next one inserted is kept,
+  // because there is no earlier key left to retain.
+  let reinserted = built.remove(first).add(third, "z")
+  inspect(reinserted.to_array()[0].0.tag, content="3")
+}

--- a/immut/vector_map/vector_map_test.mbt
+++ b/immut/vector_map/vector_map_test.mbt
@@ -368,9 +368,7 @@ test "Debug for VectorMap" {
 test "json round trip keeps the order and the key type" {
   let m = @vector_map.VectorMap([(30, "c"), (10, "a"), (20, "b")])
   json_inspect(m, content=[[30, "c"], [10, "a"], [20, "b"]])
-  let back : @vector_map.VectorMap[Int, String] = @json.from_json(
-    @json.to_json(m),
-  )
+  let back : @vector_map.VectorMap[Int, String] = @json.from_json(Json(m))
   assert_true(back == m)
 }
 

--- a/immut/vector_map/vector_map_test.mbt
+++ b/immut/vector_map/vector_map_test.mbt
@@ -472,11 +472,20 @@ test "removals past the compaction threshold keep every promise" {
     sparse.keys().to_array()[:5].to_owned(),
     content="[0, 5, 10, 15, 20]",
   )
-  // every survivor still resolves, and to the value it was given
-  for k, v in sparse {
-    assert_eq(v, k * k)
+  // Every survivor still resolves THROUGH THE INDEX, and to the value it was
+  // given. Iterating would only read the spine, so it would not notice an index
+  // left pointing at the pre-rebuild slots; `get` and `contains` are the only
+  // black-box operations that go through it.
+  for i in 0..<200 {
+    if i % 5 == 0 {
+      assert_true(sparse.contains(i))
+      assert_eq(sparse.get(i), Some(i * i))
+    } else {
+      assert_false(sparse.contains(i))
+      assert_eq(sparse.get(i), None)
+    }
   }
-  // and the rebuilt index agrees with a map built dense from the start
+  // and the surviving order matches a map built dense from the start
   assert_true(sparse == @vector_map.from_iter(sparse.iter()))
   // the original is untouched by all of it
   inspect(m.length(), content="200")

--- a/immut/vector_map/vector_map_test.mbt
+++ b/immut/vector_map/vector_map_test.mbt
@@ -31,7 +31,7 @@ test "construction" {
       #|[("b", 2), ("a", 1), ("c", 3)]
     ),
   )
-  let from_it = @vector_map.from_iter([("b", 2), ("a", 1)].iter())
+  let from_it = @vector_map.from_iter([|("b", 2), ("a", 1)|])
   debug_inspect(
     from_it.to_array(),
     content=(


### PR DESCRIPTION
## What

Adds `@immut/vector_map`, a persistent map that iterates in **insertion order** — the immutable counterpart of the built-in insertion-ordered `Map` (`builtin/linked_hash_map.mbt`).

`@immut/hashmap` iterates in hash order and `@immut/sorted_map` in key order, so code that needs entries back in the order they were added — rendering a list, replaying a log, anything a reader would notice being shuffled — has had to assemble one by hand from a vector and a map. Insertion order is the default in this language at the `Map` level; this closes the gap on the persistent side.

## Representation

```moonbit
struct VectorMap[K, V] {
  index : @hashmap.HashMap[K, Int]   // key -> slot
  spine : @vector.Vector[(K, V)?]    // insertion order; None = tombstone
  size  : Int
}
```

Entries live in the spine in insertion order and the index maps each key to its slot, so **iteration reads the spine straight through and never descends the hash trie**. Values live in the spine rather than the index, which is the trade that makes traversal cheap at the cost of a second descent on `get`.

Removal punches a hole rather than shifting the entries after it, which would invalidate every index entry to their right. Trailing holes are dropped immediately; interior ones are reclaimed once the spine is both ≥ 32 slots and holding more holes than live entries. Compaction renumbers the index through `HashMap::map`, which preserves the trie's shape, so no key is ever hashed twice.

This is the representation behind Immutable.js's `OrderedMap`; Scala's `VectorMap` answers the same problem. The alternative — a hash index plus an ordinal-keyed balanced tree, as in Scala's `TreeSeqMap` and Haskell's `Data.Map.Ordered` — was considered and rejected: it has no tombstones, but it allocates ~5× more per single-key update and iterates scattered nodes rather than contiguous 32-wide leaves.

## Semantics

Ordering follows the built-in `Map`: an existing key keeps its position when its value is replaced, a new key is appended, and remove-then-re-add moves a key to the end. A repeated key in a constructor keeps its first position and its last value.

Order is part of the content, so `Eq` and `Hash` are **order-sensitive**, and JSON is an array of `[key, value]` pairs rather than an object — object member order is not something a reader is obliged to preserve, and an array also keeps non-string keys intact.

Deliberately omitted: **no positional lookup by rank** (a slot is a physical position, holes included, so exposing one would be misleading or `O(n)`), and **no `union`/`intersection`/`difference`** (no unambiguous ordering for the result).

## Tests

49 tests, green on wasm, wasm-gc, js and native:

- **Black-box behaviour** — construction, ordering rules, traversals agreeing with each other, transforms, equality and hashing, JSON round-trip and its rejection paths.
- **Property tests** against an association-array model that carries the same ordering rule, checking full agreement after *every* operation — including a deletion-heavy variant that prefills the key universe and drains it, so trimming and compaction actually run.
- **White-box invariant tests** asserting the representation invariants directly: `size` against the live slot count, the index and spine agreeing in *both* directions, no trailing tombstone, and holes staying bounded past the threshold. Compaction and trimming boundaries are pinned exactly, including the strict-majority trigger and the below-threshold case that is deliberately left alone.

Key fixes are mutation-verified rather than assumed — each was reverted and the suite confirmed to fail.

## Review

Reviewed by Codex CLI at `xhigh` over seven rounds. It blocked on four things, all fixed:

1. **A real defect**: `add` could push the spine past the compaction threshold while carrying stale holes, violating the documented invariant (31 slots holding 1 entry is under the threshold; appending one more entry carries it to 32 with 30 holes). `add` now runs the same check `remove` does.
2. Use of `physical_equal` for semantics in `add` — its contract says explicitly not to depend on it for program semantics, and on `Double` it can equate `0.0` and `-0.0`. Removed; the two remaining identity guarantees are structural.
3. A promoted `ToJson::to_json`, against the policy in `AGENTS.md:90`. Demoted to match every sibling collection.
4. Several false complexity claims in the README, plus a `filter` doc that contradicted its own code.

Final verdict: `Signed-off-by: Codex CLI <codex@openai.com>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
