### PR TITLE
fix(immut/vector): three tree-shape bugs (#4083, #4084, #4086)

### DIFF
--- a/immut/vector/concat_random_access_test.mbt
+++ b/immut/vector/concat_random_access_test.mbt
@@ -63,13 +63,40 @@ test "concat random access matches iteration for many chunkings (issue #3721)" {
 /// `Tree::concat_with_suffix` splices the left vector's tail in as a third
 /// leaf, so the merge behind `rebalance` can hand it `31 + 3 + 31 = 65`
 /// children. Splitting those into a fixed *two* nodes left the second one 33
-/// wide, and radix indexing masks the child index with `BRANCHING_FACTOR - 1`
-/// - so `at` wrapped index 32 of that node back to 0 while iteration, which
-/// walks in order rather than by index, stayed correct.
+/// wide, past `BRANCHING_FACTOR`.
 ///
-/// The chunkings above are all far too small to reach a 65-wide merge; these
-/// operands cross it.
-test "concat keeps nodes within the branching factor (issue #4086)" {
+/// A 33-wide node only misreads once it is also classified radix, because that
+/// is what makes indexing mask the child index with `BRANCHING_FACTOR - 1` and
+/// wrap child 32 back to 0. That needs every one of the 65 leaves full, which
+/// in turn needs the left vector's tail to be a full chunk - so the operand has
+/// to be push-built, at a length whose tree is exactly 32 full leaves and whose
+/// tail is exactly full (1024 + 32). Iteration walks in order rather than by
+/// index, so it stayed correct throughout.
+test "concat of a push-built vector keeps random access (issue #4086)" {
+  for left_len in [1056, 1057, 2080] {
+    let mut left : @vector.Vector[Int] = @vector.new()
+    for i in 0..<left_len {
+      left = left.push(i)
+    }
+    for right_len in [1024, 1056] {
+      let joined = left.concat(@vector.makei(right_len, i => left_len + i))
+      let total = left_len + right_len
+      let expected = Array::makei(total, i => i)
+      @debug.assert_eq(joined.length(), total)
+      @debug.assert_eq(joined.iter().to_array(), expected)
+      @debug.assert_eq(Array::makei(total, j => joined[j]), expected)
+    }
+  }
+}
+
+///|
+/// The same 65-wide merge reached with bulk-built operands. These do *not*
+/// misread even with the old `rebalance`: the resulting 33-wide node holds a
+/// partial leaf, so it keeps its sizes array and indexing goes through the
+/// search path rather than the masking one. Kept as a wider guard - the shape
+/// is one reclassification away from breaking - with the structural check
+/// living in `invariants_wbtest.mbt`, which does fail on the 33-wide node.
+test "concat random access across large operands (issue #4086)" {
   for left_len in [1025, 1056, 1057, 1088, 2049, 2080] {
     for right_len in [992, 1024, 1056] {
       let left = @vector.makei(left_len, i => i)
@@ -78,27 +105,8 @@ test "concat keeps nodes within the branching factor (issue #4086)" {
       let total = left_len + right_len
       let expected = Array::makei(total, i => i)
       @debug.assert_eq(joined.length(), total)
-      // iteration was correct even when the tree was malformed ...
       @debug.assert_eq(joined.iter().to_array(), expected)
-      // ... only indexing noticed
       @debug.assert_eq(Array::makei(total, j => joined[j]), expected)
     }
-  }
-}
-
-///|
-/// The same, with a left operand built by `push` - the shape that leaves a
-/// full tail behind for `concat_with_suffix` to splice in.
-test "concat of a push-built vector keeps random access (issue #4086)" {
-  for left_len in [1056, 1057, 2080] {
-    let mut left : @vector.Vector[Int] = @vector.new()
-    for i in 0..<left_len {
-      left = left.push(i)
-    }
-    let joined = left.concat(@vector.makei(1024, i => left_len + i))
-    let total = left_len + 1024
-    let expected = Array::makei(total, i => i)
-    @debug.assert_eq(joined.iter().to_array(), expected)
-    @debug.assert_eq(Array::makei(total, j => joined[j]), expected)
   }
 }

--- a/immut/vector/concat_random_access_test.mbt
+++ b/immut/vector/concat_random_access_test.mbt
@@ -56,3 +56,49 @@ test "concat random access matches iteration for many chunkings (issue #3721)" {
     }
   }
 }
+
+///|
+/// Regression test for https://github.com/moonbitlang/core/issues/4086.
+///
+/// `Tree::concat_with_suffix` splices the left vector's tail in as a third
+/// leaf, so the merge behind `rebalance` can hand it `31 + 3 + 31 = 65`
+/// children. Splitting those into a fixed *two* nodes left the second one 33
+/// wide, and radix indexing masks the child index with `BRANCHING_FACTOR - 1`
+/// - so `at` wrapped index 32 of that node back to 0 while iteration, which
+/// walks in order rather than by index, stayed correct.
+///
+/// The chunkings above are all far too small to reach a 65-wide merge; these
+/// operands cross it.
+test "concat keeps nodes within the branching factor (issue #4086)" {
+  for left_len in [1025, 1056, 1057, 1088, 2049, 2080] {
+    for right_len in [992, 1024, 1056] {
+      let left = @vector.makei(left_len, i => i)
+      let right = @vector.makei(right_len, i => left_len + i)
+      let joined = left.concat(right)
+      let total = left_len + right_len
+      let expected = Array::makei(total, i => i)
+      @debug.assert_eq(joined.length(), total)
+      // iteration was correct even when the tree was malformed ...
+      @debug.assert_eq(joined.iter().to_array(), expected)
+      // ... only indexing noticed
+      @debug.assert_eq(Array::makei(total, j => joined[j]), expected)
+    }
+  }
+}
+
+///|
+/// The same, with a left operand built by `push` - the shape that leaves a
+/// full tail behind for `concat_with_suffix` to splice in.
+test "concat of a push-built vector keeps random access (issue #4086)" {
+  for left_len in [1056, 1057, 2080] {
+    let mut left : @vector.Vector[Int] = @vector.new()
+    for i in 0..<left_len {
+      left = left.push(i)
+    }
+    let joined = left.concat(@vector.makei(1024, i => left_len + i))
+    let total = left_len + 1024
+    let expected = Array::makei(total, i => i)
+    @debug.assert_eq(joined.iter().to_array(), expected)
+    @debug.assert_eq(Array::makei(total, j => joined[j]), expected)
+  }
+}

--- a/immut/vector/invariants_wbtest.mbt
+++ b/immut/vector/invariants_wbtest.mbt
@@ -281,6 +281,47 @@ test "radix classification survives a full-but-relaxed node" {
 }
 
 //-----------------------------------------------------------------------------
+// Regression: a short remainder attached one level too high
+//-----------------------------------------------------------------------------
+
+///|
+/// `makei`, `make` and `from_iter` all build their tree with `from_leaves`,
+/// whose height is fixed by the capacity it is given. It used to take a
+/// shortcut whenever at most `BRANCHING_FACTOR` leaves were left, building a
+/// height-1 node no matter how tall the subtree should have been. From three
+/// levels up (> 32768 elements) with a remainder of at most 1024 elements,
+/// that attached a leaf above shift 0: radix descent then read the wrong
+/// element and `Tree::size` reported garbage — `makei(32832, i => i)[32800]`
+/// returned 32768.
+test "bulk constructors put every leaf at the bottom" {
+  let level3 = BRANCHING_FACTOR * BRANCHING_FACTOR * BRANCHING_FACTOR
+  for
+    n in [
+      level3,
+      level3 + BRANCHING_FACTOR,
+      level3 + 2 * BRANCHING_FACTOR,
+      level3 + 1024,
+      level3 + 1032,
+      level3 + 2048,
+      2 * level3 + BRANCHING_FACTOR,
+    ] {
+    for mode in 0..<3 {
+      let v = match mode {
+        0 => makei(n, i => i)
+        1 => from_iter(Array::makei(n, i => i).iter())
+        _ => make(n, 7)
+      }
+      let label = "n=\{n} mode=\{mode}"
+      check_invariants(v, label)
+      ensure(v.length() == n, "\{label}: length \{v.length()}")
+      if mode != 2 {
+        check_contents(v, Array::makei(n, i => i), label)
+      }
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
 // Randomized structural sweep
 //-----------------------------------------------------------------------------
 

--- a/immut/vector/invariants_wbtest.mbt
+++ b/immut/vector/invariants_wbtest.mbt
@@ -1,0 +1,429 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Structural invariant checks for the RRB tree behind `Vector`.
+///
+/// The property tests in `quickcheck_test.mbt` compare a vector against an
+/// `Array` model, which catches wrong *elements*. They cannot see a vector
+/// whose contents are currently right but whose tree is malformed — a stale
+/// `sizes` array, a leaf above shift 0, a radix (`None`) node that is not
+/// actually radix-indexable. Those only surface later, from a *different*
+/// operation, as a wrong answer or an `abort`. `check_invariants` closes that
+/// gap by validating the representation itself after every step.
+
+//-----------------------------------------------------------------------------
+// The checker
+//-----------------------------------------------------------------------------
+
+///|
+/// Recompute the number of elements under `t` from the leaves up, ignoring
+/// every cached `sizes` array. This is the reference `Tree::size` is checked
+/// against.
+fn[A] true_size(t : Tree[A]) -> Int {
+  match t {
+    Empty => 0
+    Leaf(l) => l.length()
+    Node(children, _) => children.fold(init=0, (acc, c) => acc + true_size(c))
+  }
+}
+
+///|
+/// `Tree::get`/`Tree::set` descend a `Node(_, None)` with `get_radix`, which
+/// aborts as soon as it meets a node carrying explicit sizes. So a radix node
+/// is only usable if its *whole* subtree is radix.
+fn[A] all_radix(t : Tree[A]) -> Bool {
+  match t {
+    Empty | Leaf(_) => true
+    Node(_, Some(_)) => false
+    Node(children, None) =>
+      for c in children {
+        guard all_radix(c) else { break false }
+      } nobreak {
+        true
+      }
+  }
+}
+
+///|
+/// Is there a node that is exactly full yet still carries a sizes array?
+///
+/// Such a node is legal — `append_right_leaf` and `push_end` patch a relaxed
+/// node's sizes as it grows and never re-derive them — but it is the shape
+/// that used to make `compute_sizes` mark the parent radix. Kept so the
+/// regression test below can assert it really built one.
+fn[A] has_full_but_relaxed(t : Tree[A], shift : Int) -> Bool {
+  match t {
+    Empty | Leaf(_) => false
+    Node(children, sizes) => {
+      if sizes is Some(_) && true_size(t) == BRANCHING_FACTOR << shift {
+        return true
+      }
+      for c in children {
+        guard !has_full_but_relaxed(c, shift - NUM_BITS) else { break true }
+      } nobreak {
+        false
+      }
+    }
+  }
+}
+
+///|
+/// `@test.assert_true` takes no message and a bare `fail` inside a loop loses
+/// the index, so thread the description through explicitly.
+fn ensure(cond : Bool, msg : String) -> Unit raise {
+  guard cond else { fail(msg) }
+}
+
+///|
+/// Walk the tree, checking every structural invariant. `path` names the node
+/// being checked so a failure points at it.
+fn[A] check_tree(t : Tree[A], shift : Int, path : String) -> Unit raise {
+  match t {
+    Empty => fail("\{path}: Empty may only appear as the whole tree")
+    Leaf(l) => {
+      ensure(shift == 0, "\{path}: Leaf at shift \{shift}, expected 0")
+      ensure(l.length() > 0, "\{path}: empty Leaf")
+      ensure(
+        l.length() <= BRANCHING_FACTOR,
+        "\{path}: Leaf holds \{l.length()} > \{BRANCHING_FACTOR} elements",
+      )
+    }
+    Node(children, sizes) => {
+      let len = children.length()
+      ensure(
+        shift >= NUM_BITS,
+        "\{path}: Node at shift \{shift}, expected >= \{NUM_BITS}",
+      )
+      ensure(len > 0, "\{path}: Node with no children")
+      ensure(
+        len <= BRANCHING_FACTOR,
+        "\{path}: Node has \{len} > \{BRANCHING_FACTOR} children",
+      )
+      let child_shift = shift - NUM_BITS
+      let full_child = BRANCHING_FACTOR << child_shift
+      match sizes {
+        Some(sz) => {
+          ensure(
+            sz.length() == len,
+            "\{path}: sizes has \{sz.length()} entries for \{len} children",
+          )
+          let mut acc = 0
+          for i in 0..<len {
+            acc += true_size(children[i])
+            ensure(
+              sz[i] == acc,
+              "\{path}: sizes[\{i}] = \{sz[i]}, recomputed \{acc}",
+            )
+          }
+        }
+        None => {
+          // Radix indexing assumes every child but the last is exactly full...
+          for i in 0..<len {
+            let sz = true_size(children[i])
+            if i < len - 1 {
+              ensure(
+                sz == full_child,
+                "\{path}: radix child \{i} holds \{sz}, expected the full \{full_child}",
+              )
+            } else {
+              ensure(
+                sz > 0 && sz <= full_child,
+                "\{path}: radix last child holds \{sz}, expected 1..=\{full_child}",
+              )
+            }
+          }
+          // ...and that no descendant needs a sizes array, because `get_radix`
+          // aborts on the first one it meets.
+          ensure(
+            all_radix(t),
+            "\{path}: radix (None) node has a descendant carrying sizes; `get_radix` aborts on it",
+          )
+        }
+      }
+      ensure(
+        t.size(shift) == true_size(t),
+        "\{path}: Tree::size = \{t.size(shift)}, recomputed \{true_size(t)}",
+      )
+      for i in 0..<len {
+        check_tree(children[i], child_shift, "\{path}.\{i}")
+      }
+    }
+  }
+}
+
+///|
+/// Check every invariant documented on `Vector` and `Tree`.
+fn[A] check_invariants(v : Vector[A], what : String) -> Unit raise {
+  ensure(v.size >= 0, "\{what}: negative size \{v.size}")
+  ensure(
+    v.tail.length() <= BRANCHING_FACTOR,
+    "\{what}: tail holds \{v.tail.length()} > \{BRANCHING_FACTOR} elements",
+  )
+  ensure(v.shift >= 0, "\{what}: negative shift \{v.shift}")
+  ensure(
+    v.shift % NUM_BITS == 0,
+    "\{what}: shift \{v.shift} is not a multiple of \{NUM_BITS}",
+  )
+  match v.tree {
+    Empty =>
+      ensure(
+        v.shift == 0,
+        "\{what}: Empty tree with shift \{v.shift}, expected 0",
+      )
+    _ => check_tree(v.tree, v.shift, "\{what}.tree")
+  }
+  let tree_size = true_size(v.tree)
+  ensure(
+    v.size == tree_size + v.tail.length(),
+    "\{what}: size \{v.size} != tree \{tree_size} + tail \{v.tail.length()}",
+  )
+}
+
+///|
+/// Read every index through the public path, which is what a malformed tree
+/// eventually breaks.
+fn check_contents(
+  v : Vector[Int],
+  model : Array[Int],
+  what : String,
+) -> Unit raise {
+  ensure(
+    v.length() == model.length(),
+    "\{what}: length \{v.length()} != model \{model.length()}",
+  )
+  for i in 0..<model.length() {
+    ensure(
+      v[i] == model[i],
+      "\{what}: at(\{i}) = \{v[i]}, expected \{model[i]}",
+    )
+  }
+}
+
+//-----------------------------------------------------------------------------
+// Regression: a full node that still carries sizes
+//-----------------------------------------------------------------------------
+
+///|
+/// Build a vector whose tree holds a node that is exactly full (1024
+/// elements, 32 full leaves) but still carries a sizes array.
+///
+/// `slice` leaves a partial right-most leaf and an empty tail; a small concat
+/// parks four elements in the tail without touching the tree; the next concat
+/// overflows the tail, so `normalize_tree` calls `append_right_leaf` with
+/// delta = 4, which tops the partial `L28` up to a full `L32` while patching
+/// the node's existing sizes array instead of re-deriving it.
+fn full_but_relaxed_vector() -> Vector[Int] {
+  makei(1024, i => i)
+  .slice(0, 1020)
+  .concat(makei(4, i => 1020 + i))
+  .concat(makei(30, i => 1024 + i))
+}
+
+///|
+/// `compute_sizes` used to mark a node radix from its children's *sizes*
+/// alone. Feeding it the full-but-relaxed node above (all children full) made
+/// it drop the parent's sizes array, and the radix descent in `get_radix`
+/// then hit a child that still had one and aborted with
+/// "Node should not have sizes in get_radix".
+test "radix classification survives a full-but-relaxed node" {
+  let base = full_but_relaxed_vector()
+  ensure(
+    has_full_but_relaxed(base.tree, base.shift),
+    "base: expected a full node that still carries sizes",
+  )
+  check_invariants(base, "base")
+
+  // Grow until the root has three children: the full-but-relaxed node, a
+  // second full node, and a third holding a single leaf.
+  let mut v = base
+  let model = Array::makei(base.size, i => i)
+  for k in 0..<1027 {
+    v = v.push(base.size + k)
+    model.push(base.size + k)
+  }
+  check_invariants(v, "grown")
+
+  // Popping the last element empties that third child, so the root is rebuilt
+  // from two children that are both exactly full.
+  let p = v.pop().unwrap()
+  let _ = model.pop()
+  ensure(
+    has_full_but_relaxed(p.tree, p.shift),
+    "popped: expected the full-but-relaxed node to survive the pop",
+  )
+  check_invariants(p, "popped")
+  check_contents(p, model, "popped")
+
+  // The reads that used to abort.
+  @test.assert_eq(p[0], 0)
+  @test.assert_eq(p[500], 500)
+  @test.assert_eq(p[p.length() - 1], model[model.length() - 1])
+  let updated = p.set(0, -1)
+  check_invariants(updated, "set")
+  @test.assert_eq(updated[0], -1)
+  @test.assert_eq(p[0], 0)
+  // `take` at the same boundary rebuilds the root the same way
+  let t = v.take(2048)
+  check_invariants(t, "take")
+  @test.assert_eq(t[0], 0)
+  @test.assert_eq(t.length(), 2048)
+}
+
+//-----------------------------------------------------------------------------
+// Randomized structural sweep
+//-----------------------------------------------------------------------------
+
+///|
+/// Build `offset ..< offset + len` through one of the construction paths, so
+/// the sweep sees the different tree shapes each of them leaves behind.
+fn build_by(mode : Int, len : Int, offset : Int) -> Vector[Int] {
+  match mode % 5 {
+    0 => makei(len, i => offset + i)
+    1 => {
+      let mut v : Vector[Int] = new()
+      for i in 0..<len {
+        v = v.push(offset + i)
+      }
+      v
+    }
+    2 => from_iter(Array::makei(len, i => offset + i).iter())
+    3 => makei(len + 40, i => offset + i - 17).slice(17, 17 + len)
+    // a take that ends inside the tree leaves a partial right-most leaf and an
+    // empty tail: the shape that feeds `append_right_leaf`'s top-up path
+    _ => makei(len + BRANCHING_FACTOR * 3, i => offset + i).take(len)
+  }
+}
+
+///|
+fn replace_model(model : Array[Int], next : Array[Int]) -> Unit {
+  model.clear()
+  for x in next {
+    model.push(x)
+  }
+}
+
+///|
+test "tree invariants hold across mixed operation sequences" {
+  let rng = Random(Ref(20260816UL))
+  for trial in 0..<60 {
+    let mut v : Vector[Int] = new()
+    let model : Array[Int] = []
+    let mut next = 0
+    for step in 0..<20 {
+      let op = rng.int(limit=7)
+      match op {
+        0 => {
+          // a run of pushes, so the right spine actually grows
+          let n = 1 + rng.int(limit=70)
+          for _ in 0..<n {
+            v = v.push(next)
+            model.push(next)
+            next += 1
+          }
+        }
+        1 => {
+          let len = rng.int(limit=1200)
+          v = v.concat(build_by(rng.int(limit=5), len, next))
+          for i in 0..<len {
+            model.push(next + i)
+          }
+          next += len
+        }
+        2 => {
+          // tail-only concat: routes through `normalize_tree`
+          let len = 1 + rng.int(limit=BRANCHING_FACTOR)
+          v = v.concat(makei(len, i => next + i))
+          for i in 0..<len {
+            model.push(next + i)
+          }
+          next += len
+        }
+        3 =>
+          if model.length() > 0 {
+            let i = rng.int(limit=model.length())
+            v = v.set(i, next)
+            model[i] = next
+            next += 1
+          }
+        4 =>
+          for _ in 0..<(1 + rng.int(limit=40)) {
+            if model.length() > 0 {
+              v = v.pop().unwrap()
+              let _ = model.pop()
+            }
+          }
+        5 => {
+          let n = model.length()
+          let s = if n == 0 { 0 } else { rng.int(limit=n + 1) }
+          let e = if n == 0 { 0 } else { s + rng.int(limit=n - s + 1) }
+          v = v.slice(s, e)
+          replace_model(model, model[s:e].to_owned())
+        }
+        _ => {
+          // cut at a chunk boundary: `slice_right` can then return a child
+          // untouched and hand `compute_sizes` an all-full children array
+          let n = model.length()
+          let k = if n == 0 {
+            0
+          } else {
+            min(n, rng.int(limit=n / BRANCHING_FACTOR + 2) * BRANCHING_FACTOR)
+          }
+          v = v.take(k)
+          replace_model(model, model[0:k].to_owned())
+        }
+      }
+      check_invariants(v, "trial \{trial} step \{step} op \{op}")
+      check_contents(v, model, "trial \{trial} step \{step} op \{op}")
+    }
+  }
+}
+
+///|
+/// `normalize_tree` reaches `Tree::push_end` only when the left vector's tail
+/// holds a single element, which forces the right vector to be exactly one
+/// full chunk. Nothing used to construct that pair, so the whole of
+/// `push_end` was dead in the test suite.
+test "single-element tail routes through push_end" {
+  let mut exercised = 0
+  for base in [33, 65, 97, 1025, 1057, 2049] {
+    for mode in 0..<5 {
+      let v = build_by(mode, base, 0)
+      if v.tail.length() != 1 {
+        continue
+      }
+      exercised += 1
+      let c = v.concat(makei(BRANCHING_FACTOR, i => 1000000 + i))
+      check_invariants(c, "push_end base=\{base} mode=\{mode}")
+      check_contents(
+        c,
+        Array::makei(base + BRANCHING_FACTOR, i => {
+          if i < base {
+            i
+          } else {
+            1000000 + i - base
+          }
+        }),
+        "push_end base=\{base} mode=\{mode}",
+      )
+      // the result must keep behaving
+      check_invariants(c.push(-1), "push_end then push")
+      check_invariants(c.pop().unwrap(), "push_end then pop")
+      check_invariants(
+        c.concat(makei(1000, i => 5000000 + i)),
+        "push_end then concat",
+      )
+    }
+  }
+  ensure(exercised > 0, "no single-element-tail vector was built")
+}

--- a/immut/vector/invariants_wbtest.mbt
+++ b/immut/vector/invariants_wbtest.mbt
@@ -322,6 +322,27 @@ test "bulk constructors put every leaf at the bottom" {
 }
 
 //-----------------------------------------------------------------------------
+// Regression: a node wider than the branching factor
+//-----------------------------------------------------------------------------
+
+///|
+/// `rebalance` used to split a wide redistribution result into exactly two
+/// nodes, which holds for `Tree::concat` (its leaf case hands over a center of
+/// at most 2 children, so the merge is at most `31 + 2 + 31 = 64`) but not for
+/// `Tree::concat_with_suffix`, whose center can be three leaves. At `65` the
+/// second node came out 33 wide, and `radix_indexing` masks the child index
+/// with `BITMASK`, so index 32 of that node wrapped back to 0.
+test "concat never builds a node wider than the branching factor" {
+  for l in [1025, 1056, 1057, 1088, 2049, 2080, 2081] {
+    for r in [992, 1024, 1056] {
+      let joined = makei(l, i => i).concat(makei(r, i => l + i))
+      check_invariants(joined, "l=\{l} r=\{r}")
+      check_contents(joined, Array::makei(l + r, i => i), "l=\{l} r=\{r}")
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
 // Randomized structural sweep
 //-----------------------------------------------------------------------------
 

--- a/immut/vector/quickcheck_test.mbt
+++ b/immut/vector/quickcheck_test.mbt
@@ -295,6 +295,72 @@ test "quickcheck: pop walks back through every push boundary" {
 }
 
 ///|
+/// `slice`, tail-overflowing `concat`, `push` and `pop` each rebuild the tree
+/// a different way, and only their *combination* reaches some node shapes: a
+/// slice leaves a partial right-most leaf, a tail-overflowing concat folds the
+/// tail into it, pushes fill the level up, and a pop then rebuilds the root
+/// from what is left. Random access after that pipeline is the cheapest way to
+/// notice from outside the package that the tree came out malformed — a
+/// mis-rebuilt node shows up as a wrong element or an abort, not as a wrong
+/// length.
+test "quickcheck: random access survives slice/concat/push/pop pipelines" {
+  // A chunk is one leaf, a node is one full level of the trie. Which rebuild
+  // path each step takes is decided by alignment to these, so the seeds below
+  // become offsets *from* them rather than free lengths - a uniformly random
+  // length almost never lands on a transition.
+  let chunk = 32
+  let node = chunk * chunk
+  let offsets : ReadOnlyArray[Int] = [0, 1, chunk, chunk + 1, 2 * chunk]
+  @quickcheck.check(
+    (seeds : (Int, Int, Int, Int)) => {
+      let (s0, s1, s2, s3) = seeds
+      // `gap` leaves the tree's right-most leaf `chunk - gap` long...
+      let gap = 1 + (s1 & 0x7fffffff) % (chunk - 1)
+      let base = node * (1 + (s0 & 0x7fffffff) % 2)
+      // ...so a concat of `gap` parks exactly that many elements in the tail,
+      // and a second one that overflows the tail makes `normalize_tree` fold
+      // the first back in, topping the partial leaf up to a full `chunk`.
+      let second = chunk - gap + 1 + (s2 & 0x7fffffff) % gap
+      let model : Array[Int] = []
+      let mut v = @vector.makei(base, i => i).slice(0, base - gap)
+      for i in 0..<(base - gap) {
+        model.push(i)
+      }
+      for len in [gap, second] {
+        let start = 1000000 + model.length()
+        v = v.concat(@vector.makei(len, i => start + i))
+        for i in 0..<len {
+          model.push(start + i)
+        }
+      }
+      // Grow to a size that sits on a level boundary, so the following `pop`
+      // empties the root's last child and rebuilds the root from the rest.
+      let m = s3 & 0x7fffffff
+      let target = node * (2 + m % 2) + offsets[m / 2 % offsets.length()]
+      for k in 0..<(target - model.length()) {
+        v = v.push(2000000 + k)
+        model.push(2000000 + k)
+      }
+      v = v.pop().unwrap()
+      let _ = model.pop()
+      guard v.length() == model.length() else { return false }
+      // Read every index. A radix/relaxed mix-up shows up here as a wrong
+      // element or an abort - never as a wrong length.
+      for i in 0..<model.length() {
+        guard v.at(i) == model[i] else { return false }
+      }
+      guard v.to_array() == model else { return false }
+      // the vector must still be usable afterwards
+      let grown = v.push(-1)
+      guard grown.at(model.length()) == -1 else { return false }
+      let updated = v.set(0, -2)
+      updated.at(0) == -2 && v.at(0) == model[0]
+    },
+    count=40,
+  )
+}
+
+///|
 test "quickcheck: Eq and Compare agree with the array model" {
   @quickcheck.check((pair : (@vector.Vector[Int], @vector.Vector[Int])) => {
     let (a, b) = pair

--- a/immut/vector/quickcheck_test.mbt
+++ b/immut/vector/quickcheck_test.mbt
@@ -361,6 +361,57 @@ test "quickcheck: random access survives slice/concat/push/pop pipelines" {
 }
 
 ///|
+/// `makei`, `make` and `from_iter` share one bulk tree builder whose height
+/// comes from the capacity it is handed, not from how many leaves are left to
+/// place. A short remainder at the top of a tall tree used to be attached one
+/// level too high, so reads past the last full child silently returned the
+/// wrong element. The sizes that trip it are offsets from a level boundary, so
+/// generate them that way.
+test "quickcheck: bulk constructors round-trip at level boundaries" {
+  let chunk = 32
+  let level = chunk * chunk * chunk
+  let offsets : ReadOnlyArray[Int] = [
+    0,
+    1,
+    chunk,
+    chunk + 1,
+    2 * chunk,
+    level / chunk,
+    level / chunk + chunk,
+  ]
+  @quickcheck.check(
+    (seed : (Int, Int)) => {
+      let (s0, s1) = seed
+      let n = level * (1 + (s0 & 0x7fffffff) % 2) +
+        offsets[(s1 & 0x7fffffff) % offsets.length()]
+      let model = Array::makei(n, i => i)
+      let built = [
+        @vector.makei(n, i => i),
+        @vector.from_iter(model.iter()),
+        @vector.from_array(model),
+      ]
+      for v in built {
+        guard v.length() == n else { return false }
+        guard v.to_array() == model else { return false }
+        // `to_array` walks the tree in order, so it stays right even when the
+        // shape is wrong; indexing is what actually descends by radix
+        for i = 0, step = 1; i < n; {
+          guard v.at(i) == i else { return false }
+          continue i + step, step + 1
+        }
+        // the boundary itself, and every index of the short remainder
+        let remainder_start = n - n % level
+        for i in remainder_start..<n {
+          guard v.at(i) == i else { return false }
+        }
+      }
+      true
+    },
+    count=20,
+  )
+}
+
+///|
 test "quickcheck: Eq and Compare agree with the array model" {
   @quickcheck.check((pair : (@vector.Vector[Int], @vector.Vector[Int])) => {
     let (a, b) = pair

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -474,19 +474,20 @@ fn[A] rebalance(
       // return H height node, no upper node so no need to add another layer on top of it
     }
   } else {
-    let new_child_1 = FixedArray::makei(BRANCHING_FACTOR, i => new_t[i])
-    let new_child_2 = FixedArray::makei(new_t.length() - BRANCHING_FACTOR, i => {
-      new_t[i + BRANCHING_FACTOR]
+    // Pack the redistributed children into as many nodes as they need.
+    //
+    // Two is not always enough: `Tree::concat`'s leaf case hands us a center of
+    // at most 2 children, so `tri_merge` yields at most 31 + 2 + 31 = 64 - but
+    // `Tree::concat_with_suffix` splices the left vector's tail in as a third
+    // leaf, and 31 + 3 + 31 = 65 leaves a 33rd child over. A node that wide
+    // breaks radix indexing, which masks the child index with `BITMASK`.
+    let count = (new_t.length() + BRANCHING_FACTOR - 1) / BRANCHING_FACTOR
+    let new_children = FixedArray::makei(count, i => {
+      let lo = i * BRANCHING_FACTOR
+      let hi = min(lo + BRANCHING_FACTOR, new_t.length())
+      let chunk = FixedArray::makei(hi - lo, j => new_t[lo + j])
+      Node(chunk, compute_sizes(chunk, shift - NUM_BITS)) // height H
     })
-    let new_node_1 = Node(
-      new_child_1,
-      compute_sizes(new_child_1, shift - NUM_BITS),
-    ) // height H
-    let new_node_2 = Node(
-      new_child_2,
-      compute_sizes(new_child_2, shift - NUM_BITS),
-    ) // height H
-    let new_children = FixedArray::from_array([new_node_1, new_node_2])
     return (
       Node(new_children, compute_sizes(new_children, shift)),
       shift + NUM_BITS,

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -461,6 +461,12 @@ fn[A] rebalance(
     // All nodes can be accommodated in a single node
     let node = Node(new_t, compute_sizes(new_t, shift - NUM_BITS)) // node of H height
     if !top {
+      // This wrapper is the one place that puts `None` over a child without
+      // checking it, so it would break radix descent if it ever reached a
+      // finished tree. It cannot: `!top` means the caller is another
+      // `Tree::concat`/`concat_with_suffix` frame, whose `rebalance` feeds it
+      // straight to `tri_merge` and keeps only the child. The layer exists
+      // solely to match the height the caller asserts on.
       return (Node(FixedArray::from_array([node]), None), shift + NUM_BITS)
       // return (H+1) height node, add another layer to align with the case at the end of the thisfunction
     } else {
@@ -678,6 +684,27 @@ fn[A] redis(
 }
 
 ///|
+/// Can `self` be descended by radix indexing, i.e. without consulting a sizes
+/// array?
+///
+/// This is a *shallow* test, and that is enough: a node is only ever built
+/// with `None` when its whole subtree is radix-indexable, so `None` here
+/// implies `None` all the way down.
+///
+/// Note that being exactly full is **not** sufficient. `append_right_leaf`
+/// and `push_end` grow a relaxed node by patching its sizes array, so a node
+/// can reach its full size while still carrying one; `get_radix` aborts the
+/// moment it meets such a node.
+fn[A] Tree::is_radix(self : Tree[A]) -> Bool {
+  match self {
+    Leaf(_) => true
+    Node(_, None) => true
+    Node(_, Some(_)) => false
+    Empty => false
+  }
+}
+
+///|
 /// Given a list of trees as `children` with heights of (`shift` / `NUM_BITS`), compute the sizes array of the subtrees.
 fn[A] compute_sizes(
   children : FixedArray[Tree[A]],
@@ -689,8 +716,11 @@ fn[A] compute_sizes(
   let mut flag = true
   let full_subtree_size = BRANCHING_FACTOR << shift
   for i in 0..<len {
-    let sz = children[i].size(shift)
-    flag = flag && sz == full_subtree_size
+    let child = children[i]
+    let sz = child.size(shift)
+    // Dropping the sizes array commits every reader to radix descent, so the
+    // children must be full *and* radix themselves.
+    flag = flag && sz == full_subtree_size && child.is_radix()
     sum += sz
     sizes[i] = sum
   }

--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -442,7 +442,10 @@ fn[A] Tree::concat(
 }
 
 ///|
-/// Given three `Node`s of the same height (`shift` / `NUM_BITS`), rebalance them into two.
+/// Given three `Node`s of the same height (`shift` / `NUM_BITS`), rebalance
+/// them into as few nodes as their children need: one, or - once the merge is
+/// wider than `BRANCHING_FACTOR` - two, or three at the 65-wide maximum
+/// `Tree::concat_with_suffix` can reach.
 /// `top` is `true` if the resulting node has no upper node.
 /// Returns the new node and its shift.
 fn[A] rebalance(

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -810,35 +810,32 @@ fn[A] make_t(
 }
 
 ///|
+/// Build a radix tree of capacity `cap` over `leaves`, which must be non-empty
+/// and hold `BRANCHING_FACTOR` elements each except possibly the last.
+///
+/// `cap` alone fixes the height (`cap` = `BRANCHING_FACTOR` ^ (height + 1)), so
+/// every level has to recurse even when few leaves are left: a short remainder
+/// still belongs at the bottom, not one level down from wherever it is. Getting
+/// that wrong yields a leaf above shift 0, which throws off both radix descent
+/// and `Tree::size`.
 fn[A] from_leaves(leaves : ArrayView[FixedArray[A]], cap : Int) -> Tree[A] {
-  if cap == BRANCHING_FACTOR {
-    Leaf(leaves[0])
-  } else if leaves.length() <= BRANCHING_FACTOR {
-    let arr = FixedArray::make(leaves.length(), Empty)
-    for i, leaf in leaves {
-      arr[i] = Leaf(leaf)
-    }
-    Node(arr, None)
+  guard cap > BRANCHING_FACTOR else { return Leaf(leaves[0]) }
+  let child_cap = cap / BRANCHING_FACTOR
+  // Count in leaves rather than elements: `leaves.length() * BRANCHING_FACTOR`
+  // is the element count and is only meaningful while it fits in an `Int`.
+  let leaves_per_child = child_cap / BRANCHING_FACTOR
+  let full = leaves.length() / leaves_per_child
+  let len = if leaves.length() % leaves_per_child == 0 {
+    full
   } else {
-    let len = leaves.length() * BRANCHING_FACTOR
-    let child_cap = cap / BRANCHING_FACTOR
-    let quot = len / child_cap
-    let rem = len % child_cap
-    let times = child_cap / BRANCHING_FACTOR
-    let arr = if rem == 0 {
-      FixedArray::makei(quot, i => {
-        from_leaves(leaves[i * times:(i + 1) * times], child_cap)
-      })
-    } else {
-      let arr = FixedArray::make(quot + 1, Tree::Empty)
-      for i in 0..<quot {
-        arr[i] = from_leaves(leaves[i * times:(i + 1) * times], child_cap)
-      }
-      arr[quot] = from_leaves(leaves[times * quot:], child_cap)
-      arr
-    }
-    Node(arr, None)
+    full + 1
   }
+  let arr = FixedArray::makei(len, i => {
+    let lo = i * leaves_per_child
+    let hi = min(lo + leaves_per_child, leaves.length())
+    from_leaves(leaves[lo:hi], child_cap)
+  })
+  Node(arr, None)
 }
 
 ///|


### PR DESCRIPTION
Fixes #4083. Fixes #4084. Fixes #4086.

Three independent bugs in the RRB tree behind `@immut/vector`, all found by
adding a structural invariant checker for the representation. See #4085 for a
fourth finding (`Int` overflow) that is a design call and is **not** addressed
here.

Two of the three are **silent wrong answers**: correct length, correct
`to_array()`/`iter()`, wrong `at`/`get`/`set`. Iteration walks the tree in
order, so it stays right even when the shape is wrong — which is exactly why a
model-based property test could not see them.

---

## 1. `concat` builds a 33-child node — #4086

Most reachable of the three: a single concat of two ordinary vectors.

```moonbit
let mut left : @vector.Vector[Int] = @vector.new()
for i in 0..<1056 { left = left.push(i) }
left.concat(@vector.makei(1024, i => 1056 + i))[2048]  // 1024, expected 2048
```

`rebalance` assumed any redistribution result wider than `BRANCHING_FACTOR`
fits into exactly two nodes. That holds for `Tree::concat`, whose leaf case
hands over a center of at most 2 children (`31 + 2 + 31 = 64`), but not for
`Tree::concat_with_suffix`, which splices the left vector's tail in as a third
leaf: `31 + 3 + 31 = 65`, leaving the second node 33 wide.

The over-wide node is always malformed, but it only *misreads* once it is also
classified radix — that is what makes `radix_indexing` mask with `BITMASK` and
wrap child 32 to 0. A 33-wide node that kept its sizes array indexes through
the search path and stays correct. Being radix needs all 65 leaves full, hence
the push-built left operand above (tree of exactly 32 full leaves + a full
tail). Sweeping left lengths 1024..1200 x right {1024, 1056} x {bulk,
push-built}: **126** results are structurally malformed, **2** misread.

**Fix:** partition into `ceil(new_t.length() / BRANCHING_FACTOR)` nodes — the
same two whenever the old code was correct, three at the 65-wide maximum.

## 2. Wrong elements above 32768 — #4084

```moonbit
@vector.makei(32832, i => i)[32800]   // 32768, expected 32800
@vector.makei(33792, i => i)          // 992 indices wrong
```

Hits `makei`, `make`, `from_array` and `from_iter` alike. `from_leaves` derives
its height from the capacity it is handed, but took a shortcut whenever at most
`BRANCHING_FACTOR` leaves were left and built a height-1 node regardless. From
three levels up with a remainder of at most 1024 elements, that attaches a
`Leaf` above shift 0; radix descent then consumes the wrong number of index
bits, and `Tree::size` — which assumes children sit at `shift - NUM_BITS` —
reports garbage (33824 for 32832 elements).

**Fix:** always recurse, deriving the fan-out from `cap`. Counting in leaves
instead of elements also drops the `leaves.length() * BRANCHING_FACTOR` element
count, meaningful only while it fits in an `Int`. Every shape the old code got
right is built identically.

## 3. `at`/`set` abort — #4083

```moonbit
let mut v = @vector.makei(1024, i => i)
  .slice(0, 1020)                     // right-most leaf is L28, tail empty
  .concat(@vector.makei(4, i => i))   // 4 elements parked in the tail
  .concat(@vector.makei(30, i => i))  // overflows the tail
for k in 0..<1027 { v = v.push(k) }
v.pop().unwrap()[0]                   // abort: "Node should not have sizes in get_radix"
```

`compute_sizes` decided a node was radix-indexable — and dropped its `sizes`
array — from the children's **sizes** alone. But `Tree::get`/`Tree::set` descend
a `None` node via `get_radix`/`set_radix`, which abort on the first descendant
that still *has* a sizes array. So `None` carries a second obligation: no
descendant may need sizes.

Fullness does not imply that. `append_right_leaf` and `push_end` grow a relaxed
node by **patching** its sizes array and never re-derive it, so a node can reach
exactly its full size while still carrying one. Above, the `slice` leaves a
partial `L28`, the first `concat` parks 4 elements in the tail, and the second
overflows it so `normalize_tree` tops `L28` up to a full `L32` — 32 full leaves,
1024 elements, still relaxed. The `pop` then rebuilds the root from children
that are all full, `compute_sizes` marks it radix, and the descent walks in.

**Fix:** require each child to be full **and** radix itself. The shallow
`Tree::is_radix` check suffices because `None` is only ever assigned to a node
whose whole subtree is radix. The only other place that puts `None` over an
unchecked child is `rebalance`'s non-`top` wrapper, which never escapes into a
finished tree — the calling `rebalance` unwraps it in `tri_merge` — now spelled
out in a comment.

---

## Tests

**`invariants_wbtest.mbt` (new)** — the gap all three slipped through. The
existing property tests compare a vector against an `Array` model, so they catch
wrong *elements*; they cannot see a tree that is malformed but whose contents
still read back correctly, and which only breaks from a later, different
operation. Bugs 1 and 2 have exactly that character — bug 2 at sizes 32800 and
65568, where the tree is wrong but every read is right. The checker validates

- every `sizes` array against a recount from the leaves up
- leaves only at shift 0, non-empty, at most `BRANCHING_FACTOR` wide
- nodes at ≥ `NUM_BITS`, **1..=`BRANCHING_FACTOR` children**, `Empty` only as
  the whole tree
- radix nodes: every child but the last exactly full, **and no descendant
  carrying sizes**
- `Tree::size` against the recount, and `size == tree + tail`

plus a randomized mixed-operation sweep (push runs, concat, tail-only concat,
set, pop runs, slice, chunk-aligned take) checking invariants *and* contents
after every step. With all three fixes in place this ran 36k steps over six
seeds clean, alongside a 6900-combination concat sweep and a 7900-vector
bulk-constructor sweep; the committed sweep is sized for CI (~2.7s for the
package).

**Regression tests** — one per bug, each asserting it really built the shape it
is named after. The #4086 ones sit next to the existing #3721 tests in
`concat_random_access_test.mbt`, whose chunkings are all far too small to reach
a 65-wide merge. Of those, the push-built test is the behavioural regression
(it fails without the fix); the bulk-built matrix is labelled as the wider
guard it is, since those operands produce the malformed node without
misreading, and the structural check for them lives in the whitebox test.

**Black-box properties** — parameterised as *offsets from* a chunk/node boundary
rather than as free lengths; a uniformly random length essentially never lands
on a transition. One drives the slice/concat/push/pop pipeline, one the bulk
constructors across a level boundary. Every regression and property above fails
without its fix.

**`Tree::push_end` coverage** — coverage showed the whole function was dead in
the test suite. `normalize_tree` reaches it only when the left vector's tail
holds exactly one element, which forces the right vector to be exactly one full
chunk, and nothing constructed that pair. Now exercised across several tree
shapes together with the follow-up push/pop/concat; the path turned out correct,
just untested.

## Also noticed (not changed)

- `Vector::concat`'s `else if self.tail.is_empty()` branch is unreachable: when
  `other.tree` is `Empty`, `other.tail.length() == other.size <= BRANCHING_FACTOR`,
  so an empty `self.tail` always makes `combined_tail_len <= BRANCHING_FACTOR`
  and the first branch wins.
- `immut/vector/assertions_wbtest.mbt` contains nothing but the license header.
- `immutable_concat`'s `right_len == 0` branch and `Vector::pop`'s
  `promoted_tree is Empty` branch are unreachable from their callers.

## Verification

- `moon check --deny-warn --target all`
- `moon info --target wasm,wasm-gc,js,native` — no `.mbti` diff
- `moon test` on wasm-gc (7361), wasm (7361), js (7306), native (7278) — all pass
- `moon bench -p moonbitlang/core/immut/vector` before/after — within noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

