### PR TITLE
docs(immut/vector): write down the RRB representation contract

### DIFF
--- a/immut/vector/tree.mbt
+++ b/immut/vector/tree.mbt
@@ -13,6 +13,69 @@
 // limitations under the License.
 
 /// A tree data structure that backs the `immut/vector`.
+///
+/// # Representation contract
+///
+/// The shape invariants live on `Tree` in `types.mbt`; this is why they are
+/// what they are. `invariants_wbtest.mbt` checks them mechanically, and is the
+/// place to extend if you add a shape.
+///
+/// ## Two ways down
+///
+/// Indexing has a fast path and a general one, and `sizes` selects between
+/// them:
+///
+/// - `None` — *radix descent* (`get_radix` / `set_radix`). The child index at
+///   each level is read straight out of the index's bits,
+///   `(index >> shift) & BITMASK`. No arithmetic on the way down, no search.
+/// - `Some(cumulative)` — *search descent*. `get_branch_index` looks the child
+///   up in the cumulative sizes, and the index is rebased for the recursion.
+///
+/// `get_radix` **aborts** the moment it meets a node carrying sizes: it has
+/// already consumed the bits for that level, so it cannot switch strategies.
+/// That is the whole reason `None` has to mean "this subtree is radix all the
+/// way down" and not merely "this node is radix" — the property is inherited
+/// by every reader, so it must hold transitively.
+///
+/// ## Full and radix are independent
+///
+/// Neither implies the other, and conflating them has bitten this file twice:
+///
+/// - *Radix does not imply full.* A radix node may have a partial **last**
+///   child; that is exactly what `from_leaves` builds for a vector whose size
+///   is not a power of 32. Radix indexing still works, because only the
+///   children to the left of the target need to be full.
+/// - *Full does not imply radix.* `append_right_leaf` and `push_end` grow a
+///   relaxed node by patching its sizes array (`append_sizes_last`,
+///   `push_sizes_last`, `update_sizes_last`) instead of re-deriving it, so a
+///   node can reach exactly its full size while still carrying sizes. Marking
+///   its parent radix on the strength of the child's *size* is what made `at`
+///   abort in #4083; `compute_sizes` now also requires `Tree::is_radix`.
+///
+/// ## Who may produce `None`
+///
+/// Keeping the transitive property true means every construction site has to
+/// earn it. There are only five:
+///
+/// - `compute_sizes` — the general case; requires every child full **and**
+///   radix.
+/// - `new_branch_left` — only for a full leaf, and it builds the whole spine.
+/// - `radix_append_sizes` — only when a full leaf was appended, and only from
+///   an already-radix node.
+/// - `from_leaves` — builds nothing but radix nodes, top to bottom.
+/// - `rebalance`'s non-`top` wrapper — the one unchecked site. It is safe only
+///   because the wrapper never escapes: the calling frame feeds it straight to
+///   `tri_merge`, which keeps the child and drops the wrapper. See the comment
+///   there.
+///
+/// ## Height comes from the caller
+///
+/// Nothing in a `Tree` records its own height; every walk is handed a `shift`
+/// and decrements it by `NUM_BITS` per level. So a subtree's height is fixed by
+/// where it is attached, and a builder has to place leaves at the depth the
+/// capacity implies rather than at the depth the remaining data suggests —
+/// attaching a short remainder one level too high is #4084. `Tree::size` makes
+/// the same assumption for radix nodes, so a misplaced leaf corrupts sizes too.
 
 //-----------------------------------------------------------------------------
 // Hyperparameters
@@ -443,9 +506,24 @@ fn[A] Tree::concat(
 
 ///|
 /// Given three `Node`s of the same height (`shift` / `NUM_BITS`), rebalance
-/// them into as few nodes as their children need: one, or - once the merge is
-/// wider than `BRANCHING_FACTOR` - two, or three at the 65-wide maximum
-/// `Tree::concat_with_suffix` can reach.
+/// them into as few nodes as their children need.
+///
+/// How wide can the merge get? `tri_merge` drops `left`'s last child and
+/// `right`'s first, so it yields
+/// `(left_arity - 1) + center_arity + (right_arity - 1)`, and `redis_plan` only
+/// ever shortens that. With `left_arity` and `right_arity` at most
+/// `BRANCHING_FACTOR`:
+///
+/// - from `Tree::concat`, whose leaf case hands over a two-child center, at
+///   most `31 + 2 + 31 = 64` — two nodes;
+/// - from `Tree::concat_with_suffix`, which splices the left vector's tail in
+///   as a third leaf, at most `31 + 3 + 31 = 65` — three.
+///
+/// So the result is one node, or `ceil(n / BRANCHING_FACTOR)` of them, which is
+/// never more than three. Assuming two was #4086: the leftover 33rd child made
+/// a node wider than the radix index can address, and `radix_indexing` masked
+/// child 32 back to 0.
+///
 /// `top` is `true` if the resulting node has no upper node.
 /// Returns the new node and its shift.
 fn[A] rebalance(
@@ -551,6 +629,29 @@ fn[A] tri_merge(
 
 ///|
 /// Create a redistribution plan for the tree.
+///
+/// Returns the per-node child counts and how many of them are live: the first
+/// `new_len` entries of the returned array describe the new nodes, and
+/// anything past that is scratch left over from the merge.
+///
+/// The plan preserves the total number of children and only ever shortens the
+/// list, merging short nodes rightwards until the length is within `e_max_2`
+/// of the optimum. Two things about the loop are worth spelling out, because
+/// both look out of bounds and are not:
+///
+/// - `node_counts[i + 1]` (the carry step) can name the slot just past the live
+///   prefix. It never does. The carry only advances while
+///   `remaining + node_counts[i + 1] > BRANCHING_FACTOR`, so reaching the last
+///   live slot with a carry would mean every slot before it holds a full
+///   `BRANCHING_FACTOR`, hence `opt_len >= new_len - 1` — which contradicts the
+///   `opt_len + e_max_2 < new_len` that let us into the loop at all.
+/// - the leading scan `while node_counts[i] > BRANCHING_FACTOR - e_max_2` is
+///   bounded for the same reason: if every live node were full there would be
+///   no slack and the outer loop would not have been entered.
+///
+/// Termination: each pass drops `new_len` by one and `new_len` is bounded
+/// below by `opt_len + e_max_2`. `i` is only rewound by one per pass, after
+/// having advanced by at least one, so it never goes negative.
 fn[A] redis_plan(t : FixedArray[Tree[A]]) -> (FixedArray[Int], Int) {
   let node_counts = FixedArray::makei(t.length(), i => t[i].local_size())
   let total_nodes = node_counts.fold(init=0, (acc, x) => acc + x)
@@ -592,6 +693,13 @@ fn[A] redis_plan(t : FixedArray[Tree[A]]) -> (FixedArray[Int], Int) {
 /// 
 /// Postcondition:
 /// - The resulting trees in `new_t` are of the same height as trees in `old_t`.
+///
+/// The `guard! j < old_len` in each branch is a leftover: `old_t[j]` is already
+/// indexed on the line above it, so a plan that overran would fault there
+/// first and the guard can never fire. It is harmless because the only plans
+/// that reach here come from `redis_plan`, which conserves the child total and
+/// emits positive counts, so the cursor is exhausted exactly when the source
+/// is. Do not read it as an active bounds check.
 fn[A] redis(
   old_t : FixedArray[Tree[A]],
   node_counts : FixedArray[Int],

--- a/immut/vector/types.mbt
+++ b/immut/vector/types.mbt
@@ -18,7 +18,9 @@
 /// - `size` = the total number of elements in `tree` and `tail`.
 /// - `tail` stores the right-most chunk and has at most `BRANCHING_FACTOR` elements.
 /// - `tree` stores the prefix before `tail`.
-/// - `shift` is not used when `tree` is `Empty`.
+/// - `shift` is 0 when `tree` is `Empty`, and otherwise names the height of
+///   `tree` exactly: every operation that walks the tree is handed this `shift`
+///   and decrements it by `NUM_BITS` per level, so a `Leaf` must sit at shift 0.
 struct Vector[A] {
   tree : Tree[A]
   tail : FixedArray[A]
@@ -27,8 +29,26 @@ struct Vector[A] {
 }
 
 ///|
-/// Invariants:
-/// - For `Node`, the sizes array is `None` if the tree is full, i.e., we can use radix indexing.
+/// The RRB tree behind `Vector`.
+///
+/// Invariants (see the "Representation contract" block in `tree.mbt` for the
+/// reasoning, and `invariants_wbtest.mbt` for the executable version):
+///
+/// - `Empty` appears only as a whole tree, never as a child.
+/// - A `Leaf` holds 1..=`BRANCHING_FACTOR` elements and only ever sits at
+///   shift 0.
+/// - A `Node` has 1..=`BRANCHING_FACTOR` children, all of the same height.
+/// - `sizes` is `Some(cumulative)` — a running total, so the last entry is the
+///   subtree's element count — or `None` to mean **the whole subtree can be
+///   descended by radix indexing**: every child but the last is exactly full,
+///   *and* no descendant carries a sizes array of its own.
+///
+/// Note what `None` does **not** mean. It is not "this node is full": a radix
+/// node may have a partial last child (that is what a freshly built tree looks
+/// like), and conversely a node can be exactly full and still carry sizes,
+/// because `append_right_leaf` and `push_end` grow a relaxed node by patching
+/// its sizes array rather than re-deriving it. Treating full as equivalent to
+/// radix is what made `at` abort in #4083.
 #unsafe_cycle_free
 priv enum Tree[A] {
   Empty

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -398,7 +398,7 @@ pub fn[A] Vector::pop(self : Vector[A]) -> Vector[A]? {
 /// The result always takes `other`'s tail, so the work is deciding what
 /// happens to `self`'s. In order of cost:
 ///
-/// 1. `other` is tree-only-empty and the two tails fit in one chunk — splice
+/// 1. `other.tree` is `Empty` and the two tails fit in one chunk — splice
 ///    the tails, leave `self.tree` alone. No tree work at all.
 /// 2. Same, but the tails overflow — `normalize_tree` folds `self`'s tail into
 ///    its tree, then `other`'s tail becomes the new tail.

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -393,7 +393,20 @@ pub fn[A] Vector::pop(self : Vector[A]) -> Vector[A]? {
 }
 
 ///|
-/// Given two trees, concatenate them into a new tree.
+/// Concatenate two vectors.
+///
+/// The result always takes `other`'s tail, so the work is deciding what
+/// happens to `self`'s. In order of cost:
+///
+/// 1. `other` is tree-only-empty and the two tails fit in one chunk — splice
+///    the tails, leave `self.tree` alone. No tree work at all.
+/// 2. Same, but the tails overflow — `normalize_tree` folds `self`'s tail into
+///    its tree, then `other`'s tail becomes the new tail.
+/// 3. `other` has a tree and `self` has no tail — a plain `Tree::concat`.
+/// 4. Both have substance — `Tree::concat_with_suffix` threads `self`'s tail
+///    through the splice as an extra leaf, rather than normalizing first and
+///    concatenating in two passes. This is the case that can widen a merge to
+///    65 children; see `rebalance`.
 pub fn[A] Vector::concat(self : Vector[A], other : Vector[A]) -> Vector[A] {
   if self.is_empty() {
     return other
@@ -853,6 +866,21 @@ fn tail_len_of_size(size : Int) -> Int {
 }
 
 ///|
+/// Fold the tail into the tree and return the combined tree with its shift, so
+/// the caller can treat the vector as tree-only.
+///
+/// This is the only route by which a *partial* leaf reaches
+/// `append_right_leaf`: `push` always flushes a tail that is exactly
+/// `BRANCHING_FACTOR` long, whereas here the delta is whatever the tail happens
+/// to hold. That is what lets a partial right-most leaf be topped up in place —
+/// and, because the top-up patches the parent's sizes array rather than
+/// re-deriving it, what can leave a node exactly full while still relaxed
+/// (see the representation contract in `tree.mbt`).
+///
+/// A single-element tail goes through `push_end` instead, which is otherwise
+/// unreachable: `Vector::concat` only calls this when the two tails overflow
+/// `BRANCHING_FACTOR` together, so a 1-element left tail forces the right
+/// operand to be exactly one full chunk.
 fn[A] Vector::normalize_tree(self : Vector[A]) -> (Tree[A], Int) {
   if self.size == 0 {
     (Tree::empty(), 0)


### PR DESCRIPTION
Follow-up to #4082. Comments only — no `.mbti` change, no behaviour change.

## Why

All three bugs fixed in #4082 came from the same place: the rules the RRB tree
relies on lived in people's heads, and the one rule that *was* written down was
wrong. `types.mbt` said

> For `Node`, the sizes array is `None` if the tree is full, i.e., we can use
> radix indexing.

That is the exact misconception behind #4083 — a node can be exactly full and
still carry sizes, because `append_right_leaf`/`push_end` patch the sizes array
as the node grows instead of re-deriving it. It is also wrong in the other
direction: a radix node may have a partial **last** child, which is what every
freshly built tree looks like.

## What is documented now

- **`types.mbt`** — what `None` actually means (*the whole subtree can be
  descended by radix indexing*), the leaf/node width and placement invariants,
  and an explicit note that "full" and "radix" imply each other in neither
  direction.
- **`tree.mbt`** — a *Representation contract* header:
  - the two descent paths, and why `get_radix` aborts rather than switching
    strategies (it has already consumed that level's bits) — which is *why* the
    property has to be transitive rather than local;
  - why full and radix are independent, with the concrete mechanism for each
    direction;
  - an enumeration of the five sites allowed to produce `None` and what each
    one has to prove, including the `rebalance` wrapper that is unchecked and
    safe only because it never escapes;
  - that height comes from the caller's `shift`, not from the data, so a
    builder must place leaves at the depth the capacity implies (#4084).
- **`rebalance`** — the derivation of the merge width:
  `(left_arity - 1) + center_arity + (right_arity - 1)`, at most 64 through
  `Tree::concat` and 65 through `concat_with_suffix`, hence `ceil(n / 32)`
  nodes and never more than three (#4086).
- **`redis_plan`** — why the two reads that look out of bounds are not
  (`node_counts[i + 1]` and the leading scan), each resting on the loop's own
  `opt_len + e_max_2 < new_len` guard, plus the termination argument.
- **`redis`** — that its `guard! j < old_len` sits *after* the indexing it
  guards, so it can never fire. Harmless, since every caller passes a plan from
  `redis_plan` which conserves the child total, but it should not be read as an
  active bounds check.
- **`Vector::concat`** — the four branches and what each costs, including which
  one reaches `concat_with_suffix`.
- **`Vector::normalize_tree`** — that it is the only route by which a *partial*
  leaf reaches `append_right_leaf` (`push` always flushes a full chunk), and the
  only reachable caller of `push_end`.

Each claim is one the executable checker in `invariants_wbtest.mbt` already
enforces, or a bound I re-derived while reviewing; the prose and the checker are
meant to be read together.

## Verification

- `moon check --deny-warn --target all`
- `moon info --target wasm,wasm-gc,js,native` — no `.mbti` diff
- `moon test` — wasm-gc 7367, native 7284, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
