### PR TITLE
fix(base64): decode from UTF-16 code units, not a byte reinterpretation

### DIFF
--- a/encoding/base64/decode_v128.mbt
+++ b/encoding/base64/decode_v128.mbt
@@ -16,19 +16,13 @@
 // classification uses the perfect hash on the high nibble described in
 // https://mcyoung.xyz/2023/11/27/simd-base64/.
 //
-// A MoonBit `String` is UTF-16, so a block reads thirty-two bytes to obtain
-// sixteen characters, which yield twelve decoded bytes.
+// A MoonBit `String` is UTF-16, so a block loads two vectors of eight code
+// units to obtain sixteen characters, which yield twelve decoded bytes.
 //
 // The fast path only handles canonical input: no whitespace, a length that is
 // a multiple of four, and characters drawn from the Base64 alphabet. Anything
 // else defers to `decode_scalar`, which remains the single definition of the
 // padding and trailing-bit rules.
-
-///|
-/// V128 loads address memory by byte; a `String` is UTF-16, so code unit `i`
-/// lives at byte offset `i * 2`.
-#cfg(any(target="native", target="wasm"))
-fn unsafe_fixedarray_from_string(str : String) -> FixedArray[Byte] = "%identity"
 
 ///|
 /// Offsets added to a Base64 character to reach its sextet, indexed by the
@@ -129,7 +123,7 @@ fn decode_v128(text : StringView) -> Bytes? {
     2
   }
   let out = FixedArray::make(length / 4 * 3 - padding, b'\x00')
-  let src = unsafe_fixedarray_from_string(text.data())
+  let src = text.data()
   // The final group may carry padding, so it is always left to the scalar
   // decoder; everything before it must be plain alphabet.
   let body = length - 4
@@ -137,10 +131,10 @@ fn decode_v128(text : StringView) -> Bytes? {
   let mut index = 0
   let mut written = 0
   while index + 16 <= body && written + 16 <= out.length() {
-    let offset = (base + index) * 2
+    let offset = base + index
     let ascii = @v128.i8x16_narrow_i16x8_u(
-      @v128.v128_load(src, offset),
-      @v128.v128_load(src, offset + 16),
+      @v128.v128_load_i16x8(src, offset),
+      @v128.v128_load_i16x8(src, offset + 8),
     )
     guard decode_valid_v128(ascii) else { return None }
     @v128.v128_store(out, written, decode_block_v128(ascii))

--- a/v128/simd_memory.mbt
+++ b/v128/simd_memory.mbt
@@ -19,6 +19,15 @@ fn load_u16_le(bytes : FixedArray[Byte], offset : Int) -> UInt16 {
 }
 
 ///|
+fn load_u16x4_le(str : String, offset : Int) -> UInt64 {
+  for i in 0..<4; word = (0 : UInt64) {
+    continue word | (str.unsafe_get(offset + i).to_uint64() << (16 * i))
+  } nobreak {
+    word
+  }
+}
+
+///|
 fn load_u32_le(bytes : FixedArray[Byte], offset : Int) -> UInt {
   bytes.unsafe_get(offset).to_uint() |
   (bytes.unsafe_get(offset + 1).to_uint() << 8) |
@@ -153,6 +162,18 @@ pub fn i8x16_shuffle(
 #doc(hidden)
 pub fn v128_load(bytes : FixedArray[Byte], offset : Int) -> V128 {
   make(load_u64_le(bytes, offset), load_u64_le(bytes, offset + 8))
+}
+
+///|
+/// Loads eight consecutive UTF-16 code units of `str` starting at code unit
+/// `offset` into the eight 16-bit lanes of the vector. The caller must ensure
+/// `offset + 8 <= str.length()`.
+#intrinsic("%v128.v128_load_i16x8")
+#borrow(str)
+#internal(experimental, "subject to breaking change without notice")
+#doc(hidden)
+pub fn v128_load_i16x8(str : String, offset : Int) -> V128 {
+  make(load_u16x4_le(str, offset), load_u16x4_le(str, offset + 4))
 }
 
 ///|

--- a/v128/v128_test.mbt
+++ b/v128/v128_test.mbt
@@ -460,6 +460,25 @@ test "loads and stores" {
 }
 
 ///|
+test "load eight code units from a string" {
+  // The offset counts code units, not bytes, and a code unit above 0xFF is
+  // loaded into its lane whole.
+  let str = "AB\u{4E2D}\u{6587}CDEFGH"
+  assert_eq(
+    @v128.v128_load_i16x8(str, 0),
+    @v128.i16x8_const(
+      0x0041, 0x0042, 0x4E2D, 0x6587, 0x0043, 0x0044, 0x0045, 0x0046,
+    ),
+  )
+  assert_eq(
+    @v128.v128_load_i16x8(str, 2),
+    @v128.i16x8_const(
+      0x4E2D, 0x6587, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047, 0x0048,
+    ),
+  )
+}
+
+///|
 test "integer widening narrowing and dot products" {
   let bytes = @v128.i8x16_const(
     0x80, 0xff, 1, 2, 3, 4, 5, 6, 0x7f, 0, 0xfe, 0xfd, 8, 9, 10, 11,


### PR DESCRIPTION
## What

`encoding/base64`'s `decode_v128` reached the byte-addressed `@v128.v128_load` by casting the view's `String` to `FixedArray[Byte]` through `%identity`:

```moonbit
#cfg(any(target="native", target="wasm"))
fn unsafe_fixedarray_from_string(str : String) -> FixedArray[Byte] = "%identity"
```

A `String` is not a byte array on any backend. The cast lies about both the element type and the length field, and it only worked because `v128_load` consults neither.

`builtin` already loads code units directly — `string_find_code_unit.mbt` and `string_methods.mbt` scan strings through a private `v128_load_i16x8` over the `%v128.v128_load_i16x8` intrinsic — so this exposes that same load from `@v128`, with the portable fallback body the package's other loads carry, and the decoder now indexes `src` in code units.

This was the only `String` → `FixedArray[Byte]` cast in the tree. `encode_v128.mbt`'s `%identity` is `Bytes` → `FixedArray[Byte]` (same representation, and it converts back through `Bytes::to_unchecked_string`), so it stays.

## Codegen

The doubling moves out of library code and into the compiler; the emitted load is the same one:

- native: `Moonbit_simd_v128_load_u16(src, offset)`, which is `vld1q_u8((const uint8_t *)(p0 + offset))`
- wasm: `v128.load align=1`, after `i32.const 1; i32.shl` on the code-unit index

## Performance

Roughly 3% slower on the vectorized decode. Baseline and patched were built into separate target dirs and re-benched interleaved from their cached builds (`moon bench --target native -p moonbitlang/core/encoding/base64 -f v128_bench_wbtest.mbt --no-parallelize`), median of four rounds:

| benchmark | before | after | delta |
| --- | --- | --- | --- |
| decode v128 n=64 | 66.7 ns | 67.6 ns | +1.3% |
| decode v128 n=1024 | 235.0 ns | 242.7 ns | +3.3% |
| decode v128 n=65536 | 11.62 µs | 11.94 µs | +2.7% |
| encode v128 (untouched) | — | — | ±2%, no direction |

The raw runs at n=65536 do not overlap (before 11.56–11.67 µs, after 11.92–12.02 µs), and the cause is in the generated code rather than in code placement.

Both forms compute the same address, `src + offset * 2`; only the placement of the `* 2` differs — before it happens in MoonBit's `Int` arithmetic and reaches a `uint8_t *` helper, after it happens in the C pointer arithmetic of the `uint16_t *` helper. LLVM would normally erase that difference by strength-reducing both into a pointer advancing 32 bytes per iteration, but that rewrite needs `sext(i + 16) == sext(i) + 16`, i.e. no signed overflow on the 32-bit counter. `Int` wraps in MoonBit, so the C is compiled `-fwrapv`, no `nsw` is attached, and the counter stays 32-bit — the scaling then has to happen at every use.

Only at that point does the addressing mode matter: a 128-bit `ldr q` register-offset mode folds a sign-extend, but scales by 1 or 16, never 2. The byte-offset form wanted scale 1, so the extend was free and LLVM could even keep the byte offset as the counter; the code-unit form materializes each byte address first.

```
before:  ldr q22, [x20, w9, sxtw]      after:  sbfiz x10, x9, #1, #32
         add w10, w9, #0x10                    ldr   q22, [x20, x10]
         ldr q23, [x20, w10, sxtw]             add   w9, w9, #0x8
         ...                                   sbfiz x9, x9, #1, #32
         add w9, w9, #0x20                     ldr   q23, [x20, x9]
```

The same two loops written in plain C compile identically at `-O2` and diverge exactly when `-fwrapv` is added, which confirms the mechanism outside MoonBit.

Hoisting the loop counter into string coordinates removes one of those instructions but does not move the measurement — the cost is the added latency on the address dependency chain, not the instruction count — so the loop keeps its original shape. Lowering `%v128.v128_load_i16x8` against a pointer or 64-bit induction variable, instead of a 32-bit code-unit index re-extended at each use, would close the gap, and would help `builtin`'s string scanners, which all use this same pattern. For scale, the vector path is still ~22× faster than the scalar decoder at n=65536.

## Testing

- `moon test --target native` (7347 passed) and `--target wasm` (7430 passed), including `encoding/base64`'s differential whitebox tests, which pin the vector decoder against the scalar one across every block-count, tail, and padding residue
- new `@v128` test for the load, passing on native/wasm (intrinsic path) and wasm-gc/js (fallback path)
- `moon check --deny-warn --target all`, `moon info`, `moon fmt` — no `.mbti` churn, since the function is `#doc(hidden)` like the package's other loads
