### PR TITLE
perf(builtin): unroll the bytes_unsafe intrinsic fallbacks

### DIFF
--- a/builtin/bytes_unsafe.mbt
+++ b/builtin/bytes_unsafe.mbt
@@ -43,9 +43,14 @@ pub fn FixedArray::unsafe_write_uint64_le(
   index : Int,
   value : UInt64,
 ) -> Unit {
-  for i in 0..<=7 {
-    bytes.unsafe_set(i + index, (value >> (8 * i)).to_byte())
-  }
+  bytes.unsafe_set(index, value.to_byte())
+  bytes.unsafe_set(index + 1, (value >> 8).to_byte())
+  bytes.unsafe_set(index + 2, (value >> 16).to_byte())
+  bytes.unsafe_set(index + 3, (value >> 24).to_byte())
+  bytes.unsafe_set(index + 4, (value >> 32).to_byte())
+  bytes.unsafe_set(index + 5, (value >> 40).to_byte())
+  bytes.unsafe_set(index + 6, (value >> 48).to_byte())
+  bytes.unsafe_set(index + 7, (value >> 56).to_byte())
 }
 
 ///|
@@ -77,9 +82,14 @@ pub fn FixedArray::unsafe_write_uint64_be(
   index : Int,
   value : UInt64,
 ) -> Unit {
-  for i in 0..<=7 {
-    bytes.unsafe_set(i + index, (value >> (8 * (7 - i))).to_byte())
-  }
+  bytes.unsafe_set(index, (value >> 56).to_byte())
+  bytes.unsafe_set(index + 1, (value >> 48).to_byte())
+  bytes.unsafe_set(index + 2, (value >> 40).to_byte())
+  bytes.unsafe_set(index + 3, (value >> 32).to_byte())
+  bytes.unsafe_set(index + 4, (value >> 24).to_byte())
+  bytes.unsafe_set(index + 5, (value >> 16).to_byte())
+  bytes.unsafe_set(index + 6, (value >> 8).to_byte())
+  bytes.unsafe_set(index + 7, value.to_byte())
 }
 
 ///|
@@ -111,9 +121,10 @@ pub fn FixedArray::unsafe_write_uint32_le(
   index : Int,
   value : UInt,
 ) -> Unit {
-  for i in 0..<=3 {
-    bytes.unsafe_set(i + index, (value >> (8 * i)).to_byte())
-  }
+  bytes.unsafe_set(index, value.to_byte())
+  bytes.unsafe_set(index + 1, (value >> 8).to_byte())
+  bytes.unsafe_set(index + 2, (value >> 16).to_byte())
+  bytes.unsafe_set(index + 3, (value >> 24).to_byte())
 }
 
 ///|
@@ -145,9 +156,10 @@ pub fn FixedArray::unsafe_write_uint32_be(
   index : Int,
   value : UInt,
 ) -> Unit {
-  for i in 0..<=3 {
-    bytes.unsafe_set(i + index, (value >> (8 * (3 - i))).to_byte())
-  }
+  bytes.unsafe_set(index, (value >> 24).to_byte())
+  bytes.unsafe_set(index + 1, (value >> 16).to_byte())
+  bytes.unsafe_set(index + 2, (value >> 8).to_byte())
+  bytes.unsafe_set(index + 3, value.to_byte())
 }
 
 ///|
@@ -177,9 +189,8 @@ pub fn FixedArray::unsafe_write_uint16_le(
   index : Int,
   value : UInt16,
 ) -> Unit {
-  for i in 0..<=1 {
-    bytes.unsafe_set(i + index, (value >> (8 * i)).to_byte())
-  }
+  bytes.unsafe_set(index, value.to_byte())
+  bytes.unsafe_set(index + 1, (value >> 8).to_byte())
 }
 
 ///|
@@ -209,9 +220,8 @@ pub fn FixedArray::unsafe_write_uint16_be(
   index : Int,
   value : UInt16,
 ) -> Unit {
-  for i in 0..<=1 {
-    bytes.unsafe_set(i + index, (value >> (8 * (1 - i))).to_byte())
-  }
+  bytes.unsafe_set(index, (value >> 8).to_byte())
+  bytes.unsafe_set(index + 1, value.to_byte())
 }
 
 // #endregion
@@ -242,11 +252,14 @@ pub fn FixedArray::unsafe_write_uint16_be(
 #intrinsic("%bytes.unsafe_read_uint64_le")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint64_le(bytes : Bytes, index : Int) -> UInt64 {
-  for i in 0..<=7; result = (0 : UInt64) {
-    continue result | (bytes.unsafe_get(i + index).to_uint64() << (8 * i))
-  } nobreak {
-    result
-  }
+  bytes.unsafe_get(index).to_uint64() |
+  (bytes.unsafe_get(index + 1).to_uint64() << 8) |
+  (bytes.unsafe_get(index + 2).to_uint64() << 16) |
+  (bytes.unsafe_get(index + 3).to_uint64() << 24) |
+  (bytes.unsafe_get(index + 4).to_uint64() << 32) |
+  (bytes.unsafe_get(index + 5).to_uint64() << 40) |
+  (bytes.unsafe_get(index + 6).to_uint64() << 48) |
+  (bytes.unsafe_get(index + 7).to_uint64() << 56)
 }
 
 ///|
@@ -274,11 +287,14 @@ pub fn Bytes::unsafe_read_uint64_le(bytes : Bytes, index : Int) -> UInt64 {
 #intrinsic("%bytes.unsafe_read_uint64_be")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint64_be(bytes : Bytes, index : Int) -> UInt64 {
-  for i in 0..<=7; result = (0 : UInt64) {
-    continue result | (bytes.unsafe_get(i + index).to_uint64() << (8 * (7 - i)))
-  } nobreak {
-    result
-  }
+  (bytes.unsafe_get(index).to_uint64() << 56) |
+  (bytes.unsafe_get(index + 1).to_uint64() << 48) |
+  (bytes.unsafe_get(index + 2).to_uint64() << 40) |
+  (bytes.unsafe_get(index + 3).to_uint64() << 32) |
+  (bytes.unsafe_get(index + 4).to_uint64() << 24) |
+  (bytes.unsafe_get(index + 5).to_uint64() << 16) |
+  (bytes.unsafe_get(index + 6).to_uint64() << 8) |
+  bytes.unsafe_get(index + 7).to_uint64()
 }
 
 ///|
@@ -306,11 +322,10 @@ pub fn Bytes::unsafe_read_uint64_be(bytes : Bytes, index : Int) -> UInt64 {
 #intrinsic("%bytes.unsafe_read_uint32_le")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint32_le(bytes : Bytes, index : Int) -> UInt {
-  for i in 0..<=3; result = (0 : UInt) {
-    continue result | (bytes.unsafe_get(i + index).to_uint() << (8 * i))
-  } nobreak {
-    result
-  }
+  bytes.unsafe_get(index).to_uint() |
+  (bytes.unsafe_get(index + 1).to_uint() << 8) |
+  (bytes.unsafe_get(index + 2).to_uint() << 16) |
+  (bytes.unsafe_get(index + 3).to_uint() << 24)
 }
 
 ///|
@@ -338,11 +353,10 @@ pub fn Bytes::unsafe_read_uint32_le(bytes : Bytes, index : Int) -> UInt {
 #intrinsic("%bytes.unsafe_read_uint32_be")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint32_be(bytes : Bytes, index : Int) -> UInt {
-  for i in 0..<=3; result = (0 : UInt) {
-    continue result | (bytes.unsafe_get(i + index).to_uint() << (8 * (3 - i)))
-  } nobreak {
-    result
-  }
+  (bytes.unsafe_get(index).to_uint() << 24) |
+  (bytes.unsafe_get(index + 1).to_uint() << 16) |
+  (bytes.unsafe_get(index + 2).to_uint() << 8) |
+  bytes.unsafe_get(index + 3).to_uint()
 }
 
 ///|
@@ -368,11 +382,8 @@ pub fn Bytes::unsafe_read_uint32_be(bytes : Bytes, index : Int) -> UInt {
 #intrinsic("%bytes.unsafe_read_uint16_le")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint16_le(bytes : Bytes, index : Int) -> UInt16 {
-  for i in 0..<=1; result = (0 : UInt16) {
-    continue result | (bytes.unsafe_get(i + index).to_uint16() << (8 * i))
-  } nobreak {
-    result
-  }
+  bytes.unsafe_get(index).to_uint16() |
+  (bytes.unsafe_get(index + 1).to_uint16() << 8)
 }
 
 ///|
@@ -398,11 +409,8 @@ pub fn Bytes::unsafe_read_uint16_le(bytes : Bytes, index : Int) -> UInt16 {
 #intrinsic("%bytes.unsafe_read_uint16_be")
 #doc(hidden)
 pub fn Bytes::unsafe_read_uint16_be(bytes : Bytes, index : Int) -> UInt16 {
-  for i in 0..<=1; result = (0 : UInt16) {
-    continue result | (bytes.unsafe_get(i + index).to_uint16() << (8 * (1 - i)))
-  } nobreak {
-    result
-  }
+  (bytes.unsafe_get(index).to_uint16() << 8) |
+  bytes.unsafe_get(index + 1).to_uint16()
 }
 
 ///|
@@ -596,66 +604,64 @@ fn buffer_to_fixedarray(buf : UninitializedArray[Byte]) -> FixedArray[Byte] = "%
 #borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint16_le")
 fn fixedarray_read_uint16_le(bytes : FixedArray[Byte], index : Int) -> UInt16 {
-  for i in 0..<=1; result = (0 : UInt16) {
-    continue result | (bytes.unsafe_get(i + index).to_uint16() << (8 * i))
-  } nobreak {
-    result
-  }
+  bytes.unsafe_get(index).to_uint16() |
+  (bytes.unsafe_get(index + 1).to_uint16() << 8)
 }
 
 ///|
 #borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint16_be")
 fn fixedarray_read_uint16_be(bytes : FixedArray[Byte], index : Int) -> UInt16 {
-  for i in 0..<=1; result = (0 : UInt16) {
-    continue result | (bytes.unsafe_get(i + index).to_uint16() << (8 * (1 - i)))
-  } nobreak {
-    result
-  }
+  (bytes.unsafe_get(index).to_uint16() << 8) |
+  bytes.unsafe_get(index + 1).to_uint16()
 }
 
 ///|
 #borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint32_le")
 fn fixedarray_read_uint32_le(bytes : FixedArray[Byte], index : Int) -> UInt {
-  for i in 0..<=3; result = (0 : UInt) {
-    continue result | (bytes.unsafe_get(i + index).to_uint() << (8 * i))
-  } nobreak {
-    result
-  }
+  bytes.unsafe_get(index).to_uint() |
+  (bytes.unsafe_get(index + 1).to_uint() << 8) |
+  (bytes.unsafe_get(index + 2).to_uint() << 16) |
+  (bytes.unsafe_get(index + 3).to_uint() << 24)
 }
 
 ///|
 #borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint32_be")
 fn fixedarray_read_uint32_be(bytes : FixedArray[Byte], index : Int) -> UInt {
-  for i in 0..<=3; result = (0 : UInt) {
-    continue result | (bytes.unsafe_get(i + index).to_uint() << (8 * (3 - i)))
-  } nobreak {
-    result
-  }
+  (bytes.unsafe_get(index).to_uint() << 24) |
+  (bytes.unsafe_get(index + 1).to_uint() << 16) |
+  (bytes.unsafe_get(index + 2).to_uint() << 8) |
+  bytes.unsafe_get(index + 3).to_uint()
 }
 
 ///|
 #borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint64_le")
 fn fixedarray_read_uint64_le(bytes : FixedArray[Byte], index : Int) -> UInt64 {
-  for i in 0..<=7; result = (0 : UInt64) {
-    continue result | (bytes.unsafe_get(i + index).to_uint64() << (8 * i))
-  } nobreak {
-    result
-  }
+  bytes.unsafe_get(index).to_uint64() |
+  (bytes.unsafe_get(index + 1).to_uint64() << 8) |
+  (bytes.unsafe_get(index + 2).to_uint64() << 16) |
+  (bytes.unsafe_get(index + 3).to_uint64() << 24) |
+  (bytes.unsafe_get(index + 4).to_uint64() << 32) |
+  (bytes.unsafe_get(index + 5).to_uint64() << 40) |
+  (bytes.unsafe_get(index + 6).to_uint64() << 48) |
+  (bytes.unsafe_get(index + 7).to_uint64() << 56)
 }
 
 ///|
 #borrow(bytes)
 #intrinsic("%bytes.unsafe_read_uint64_be")
 fn fixedarray_read_uint64_be(bytes : FixedArray[Byte], index : Int) -> UInt64 {
-  for i in 0..<=7; result = (0 : UInt64) {
-    continue result | (bytes.unsafe_get(i + index).to_uint64() << (8 * (7 - i)))
-  } nobreak {
-    result
-  }
+  (bytes.unsafe_get(index).to_uint64() << 56) |
+  (bytes.unsafe_get(index + 1).to_uint64() << 48) |
+  (bytes.unsafe_get(index + 2).to_uint64() << 40) |
+  (bytes.unsafe_get(index + 3).to_uint64() << 32) |
+  (bytes.unsafe_get(index + 4).to_uint64() << 24) |
+  (bytes.unsafe_get(index + 5).to_uint64() << 16) |
+  (bytes.unsafe_get(index + 6).to_uint64() << 8) |
+  bytes.unsafe_get(index + 7).to_uint64()
 }
 
 // #endregion

--- a/builtin/bytes_unsafe_bench_test.mbt
+++ b/builtin/bytes_unsafe_bench_test.mbt
@@ -1,0 +1,97 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Benchmarks for the `#intrinsic` fallback bodies in `bytes_unsafe.mbt`.
+//
+// These are lowered at the call site on native, so these numbers are expected
+// to be flat there; on wasm-gc and js the fallback body is what actually runs.
+// Only the little-endian variants are measured — the big-endian ones differ
+// solely in the constant shift amounts and compile to the same shape.
+
+///|
+let bytes_unsafe_bench_len = 4096
+
+///|
+fn bytes_unsafe_bench_data() -> Bytes {
+  Bytes::makei(bytes_unsafe_bench_len, i => ((i * 37 + 11) & 0xff).to_byte())
+}
+
+///|
+test "bench Bytes::unsafe_read_uint16_le n=4096" (it : @bench.T) {
+  let data = bytes_unsafe_bench_data()
+  it.bench(fn() {
+    let mut acc = (0 : UInt16)
+    for i in 0..<(bytes_unsafe_bench_len - 1) {
+      acc = acc + data.unsafe_read_uint16_le(i)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench Bytes::unsafe_read_uint32_le n=4096" (it : @bench.T) {
+  let data = bytes_unsafe_bench_data()
+  it.bench(fn() {
+    let mut acc = 0U
+    for i in 0..<(bytes_unsafe_bench_len - 3) {
+      acc = acc + data.unsafe_read_uint32_le(i)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench Bytes::unsafe_read_uint64_le n=4096" (it : @bench.T) {
+  let data = bytes_unsafe_bench_data()
+  it.bench(fn() {
+    let mut acc = 0UL
+    for i in 0..<(bytes_unsafe_bench_len - 7) {
+      acc = acc + data.unsafe_read_uint64_le(i)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench FixedArray::unsafe_write_uint16_le n=4096" (it : @bench.T) {
+  let buf = FixedArray::make(bytes_unsafe_bench_len, b'\x00')
+  it.bench(fn() {
+    for i in 0..<(bytes_unsafe_bench_len - 1) {
+      buf.unsafe_write_uint16_le(i, (i & 0xffff).to_uint16())
+    }
+    it.keep(buf[0])
+  })
+}
+
+///|
+test "bench FixedArray::unsafe_write_uint32_le n=4096" (it : @bench.T) {
+  let buf = FixedArray::make(bytes_unsafe_bench_len, b'\x00')
+  it.bench(fn() {
+    for i in 0..<(bytes_unsafe_bench_len - 3) {
+      buf.unsafe_write_uint32_le(i, i.reinterpret_as_uint())
+    }
+    it.keep(buf[0])
+  })
+}
+
+///|
+test "bench FixedArray::unsafe_write_uint64_le n=4096" (it : @bench.T) {
+  let buf = FixedArray::make(bytes_unsafe_bench_len, b'\x00')
+  it.bench(fn() {
+    for i in 0..<(bytes_unsafe_bench_len - 7) {
+      buf.unsafe_write_uint64_le(i, i.to_uint64())
+    }
+    it.keep(buf[0])
+  })
+}

--- a/builtin/bytes_unsafe_unroll_wbtest.mbt
+++ b/builtin/bytes_unsafe_unroll_wbtest.mbt
@@ -182,29 +182,31 @@ test "unrolled writes round-trip through the loop-form readers" {
 
 ///|
 /// A write must touch exactly its own bytes and leave the neighbours alone.
+/// All six writers are covered, since each carries its own unrolled body.
 test "unrolled writes do not disturb neighbouring bytes" {
   let len = 32
   let fill = b'\x3C'
-  for i in 0..<(len - 7) {
-    let fa = FixedArray::make(len, fill)
-    fa.unsafe_write_uint64_le(i, 0xFFFF_FFFF_FFFF_FFFF)
-    for j in 0..<len {
-      if j < i || j > i + 7 {
-        check(fa[j], fill)
-      } else {
-        check(fa[j], b'\xFF')
+  fn check_span(
+    width : Int,
+    write : (FixedArray[Byte], Int) -> Unit,
+  ) -> Unit raise {
+    for i in 0..<(len - width + 1) {
+      let fa = FixedArray::make(len, fill)
+      write(fa, i)
+      for j in 0..<len {
+        if j < i || j >= i + width {
+          check(fa[j], fill)
+        } else {
+          check(fa[j], b'\xFF')
+        }
       }
     }
   }
-  for i in 0..<(len - 1) {
-    let fa = FixedArray::make(len, fill)
-    fa.unsafe_write_uint16_be(i, 0xFFFF)
-    for j in 0..<len {
-      if j < i || j > i + 1 {
-        check(fa[j], fill)
-      } else {
-        check(fa[j], b'\xFF')
-      }
-    }
-  }
+
+  check_span(8, (fa, i) => fa.unsafe_write_uint64_le(i, 0xFFFF_FFFF_FFFF_FFFF))
+  check_span(8, (fa, i) => fa.unsafe_write_uint64_be(i, 0xFFFF_FFFF_FFFF_FFFF))
+  check_span(4, (fa, i) => fa.unsafe_write_uint32_le(i, 0xFFFF_FFFF))
+  check_span(4, (fa, i) => fa.unsafe_write_uint32_be(i, 0xFFFF_FFFF))
+  check_span(2, (fa, i) => fa.unsafe_write_uint16_le(i, 0xFFFF))
+  check_span(2, (fa, i) => fa.unsafe_write_uint16_be(i, 0xFFFF))
 }

--- a/builtin/bytes_unsafe_unroll_wbtest.mbt
+++ b/builtin/bytes_unsafe_unroll_wbtest.mbt
@@ -1,0 +1,210 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Equivalence tests for the unrolled `#intrinsic` fallback bodies in
+// `bytes_unsafe.mbt`. Each `ref_*` function below is the loop form those
+// bodies used to have, kept here as an independent oracle: the unrolled
+// implementations must agree with it at every offset, for every sample value.
+//
+// These matter because the fallbacks are dead code on native (the intrinsics
+// are lowered at the call site) but are the real implementation on wasm-gc and
+// js, so a byte-order slip would only surface on two of three backends.
+
+///|
+/// `builtin` cannot depend on `@test`, so `assert_eq` is not available here;
+/// `assert_true` is the only assertion in scope.
+fn[T : Eq] check(actual : T, expected : T) -> Unit raise {
+  assert_true(actual == expected)
+}
+
+///|
+fn ref_read_u16_le(b : Bytes, index : Int) -> UInt16 {
+  for i in 0..<=1; result = (0 : UInt16) {
+    continue result | (b[i + index].to_uint16() << (8 * i))
+  } nobreak {
+    result
+  }
+}
+
+///|
+fn ref_read_u16_be(b : Bytes, index : Int) -> UInt16 {
+  for i in 0..<=1; result = (0 : UInt16) {
+    continue result | (b[i + index].to_uint16() << (8 * (1 - i)))
+  } nobreak {
+    result
+  }
+}
+
+///|
+fn ref_read_u32_le(b : Bytes, index : Int) -> UInt {
+  for i in 0..<=3; result = (0 : UInt) {
+    continue result | (b[i + index].to_uint() << (8 * i))
+  } nobreak {
+    result
+  }
+}
+
+///|
+fn ref_read_u32_be(b : Bytes, index : Int) -> UInt {
+  for i in 0..<=3; result = (0 : UInt) {
+    continue result | (b[i + index].to_uint() << (8 * (3 - i)))
+  } nobreak {
+    result
+  }
+}
+
+///|
+fn ref_read_u64_le(b : Bytes, index : Int) -> UInt64 {
+  for i in 0..<=7; result = (0 : UInt64) {
+    continue result | (b[i + index].to_uint64() << (8 * i))
+  } nobreak {
+    result
+  }
+}
+
+///|
+fn ref_read_u64_be(b : Bytes, index : Int) -> UInt64 {
+  for i in 0..<=7; result = (0 : UInt64) {
+    continue result | (b[i + index].to_uint64() << (8 * (7 - i)))
+  } nobreak {
+    result
+  }
+}
+
+///|
+/// A byte pattern with every bit position exercised, plus 0x00 and 0xFF runs so
+/// sign-extension and zero-extension slips show up.
+fn sample_bytes(len : Int) -> Bytes {
+  Bytes::makei(len, i => {
+    match i % 8 {
+      0 => b'\x00'
+      1 => b'\xFF'
+      2 => b'\x80'
+      3 => b'\x01'
+      4 => b'\x7F'
+      5 => b'\xAA'
+      6 => b'\x55'
+      _ => (i * 31 + 7).to_byte()
+    }
+  })
+}
+
+///|
+test "unrolled Bytes reads agree with the loop form at every offset" {
+  let len = 64
+  let b = sample_bytes(len)
+  for i in 0..<(len - 1) {
+    check(b.unsafe_read_uint16_le(i), ref_read_u16_le(b, i))
+    check(b.unsafe_read_uint16_be(i), ref_read_u16_be(b, i))
+  }
+  for i in 0..<(len - 3) {
+    check(b.unsafe_read_uint32_le(i), ref_read_u32_le(b, i))
+    check(b.unsafe_read_uint32_be(i), ref_read_u32_be(b, i))
+  }
+  for i in 0..<(len - 7) {
+    check(b.unsafe_read_uint64_le(i), ref_read_u64_le(b, i))
+    check(b.unsafe_read_uint64_be(i), ref_read_u64_be(b, i))
+  }
+}
+
+///|
+/// The private `fixedarray_read_*` helpers carry their own copies of the same
+/// unrolled bodies, so they need their own check.
+test "unrolled FixedArray reads agree with the loop form at every offset" {
+  let len = 64
+  let b = sample_bytes(len)
+  let fa = FixedArray::makei(len, i => b[i])
+  for i in 0..<(len - 1) {
+    check(fixedarray_read_uint16_le(fa, i), ref_read_u16_le(b, i))
+    check(fixedarray_read_uint16_be(fa, i), ref_read_u16_be(b, i))
+  }
+  for i in 0..<(len - 3) {
+    check(fixedarray_read_uint32_le(fa, i), ref_read_u32_le(b, i))
+    check(fixedarray_read_uint32_be(fa, i), ref_read_u32_be(b, i))
+  }
+  for i in 0..<(len - 7) {
+    check(fixedarray_read_uint64_le(fa, i), ref_read_u64_le(b, i))
+    check(fixedarray_read_uint64_be(fa, i), ref_read_u64_be(b, i))
+  }
+}
+
+///|
+let u64_samples : Array[UInt64] = [
+  0, 1, 0xFF, 0x100, 0x7FFF_FFFF, 0x8000_0000, 0xFFFF_FFFF, 0x1_0000_0000, 0x0123_4567_89AB_CDEF,
+  0xFEDC_BA98_7654_3210, 0x7FFF_FFFF_FFFF_FFFF, 0x8000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF,
+]
+
+///|
+/// Writes go through the unrolled `unsafe_write_*`; reading them back with the
+/// independent `ref_read_*` oracle pins the byte order in both directions.
+test "unrolled writes round-trip through the loop-form readers" {
+  let len = 32
+  for value in u64_samples {
+    let v32 = value.to_uint()
+    let v16 = value.to_uint16()
+    for i in 0..<(len - 7) {
+      let fa = FixedArray::make(len, b'\x00')
+      fa.unsafe_write_uint64_le(i, value)
+      check(ref_read_u64_le(unsafe_to_bytes(fa), i), value)
+      let fa = FixedArray::make(len, b'\x00')
+      fa.unsafe_write_uint64_be(i, value)
+      check(ref_read_u64_be(unsafe_to_bytes(fa), i), value)
+    }
+    for i in 0..<(len - 3) {
+      let fa = FixedArray::make(len, b'\x00')
+      fa.unsafe_write_uint32_le(i, v32)
+      check(ref_read_u32_le(unsafe_to_bytes(fa), i), v32)
+      let fa = FixedArray::make(len, b'\x00')
+      fa.unsafe_write_uint32_be(i, v32)
+      check(ref_read_u32_be(unsafe_to_bytes(fa), i), v32)
+    }
+    for i in 0..<(len - 1) {
+      let fa = FixedArray::make(len, b'\x00')
+      fa.unsafe_write_uint16_le(i, v16)
+      check(ref_read_u16_le(unsafe_to_bytes(fa), i), v16)
+      let fa = FixedArray::make(len, b'\x00')
+      fa.unsafe_write_uint16_be(i, v16)
+      check(ref_read_u16_be(unsafe_to_bytes(fa), i), v16)
+    }
+  }
+}
+
+///|
+/// A write must touch exactly its own bytes and leave the neighbours alone.
+test "unrolled writes do not disturb neighbouring bytes" {
+  let len = 32
+  let fill = b'\x3C'
+  for i in 0..<(len - 7) {
+    let fa = FixedArray::make(len, fill)
+    fa.unsafe_write_uint64_le(i, 0xFFFF_FFFF_FFFF_FFFF)
+    for j in 0..<len {
+      if j < i || j > i + 7 {
+        check(fa[j], fill)
+      } else {
+        check(fa[j], b'\xFF')
+      }
+    }
+  }
+  for i in 0..<(len - 1) {
+    let fa = FixedArray::make(len, fill)
+    fa.unsafe_write_uint16_be(i, 0xFFFF)
+    for j in 0..<len {
+      if j < i || j > i + 1 {
+        check(fa[j], fill)
+      } else {
+        check(fa[j], b'\xFF')
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Every `#intrinsic("%bytes.unsafe_*")` helper in `builtin/bytes_unsafe.mbt` carries a MoonBit fallback body, and all 18 of them were written as a `for i in 0..<=N` loop that computes its shift amount as `8 * i` at runtime. This unrolls them into straight-line `unsafe_get`/`unsafe_set` chains with constant shifts.

That matters because **the fallbacks are not dead code on two of three backends**:

- **native** lowers the intrinsics at the call site — the generated C for `Hasher::combine_bytes` contains `READ_UINT32_LE(ptr)` — so the loop bodies never ran there.
- **wasm-gc** and **js** do *not* lower them. The emitted wasm for `Bytes::unsafe_read_uint32_le` was a four-iteration `loop` carrying an induction variable, with an `i32.mul` computing the shift per byte; the js output was the same shape with `Math.imul(8, i)`. So every byte paid a bound test, an induction-variable add, an index add and a multiply on top of the load and the `or`.

Scope: 6 `FixedArray` writers, 6 `Bytes` readers, 6 private `fixedarray_read_*` readers. `BytesView::unsafe_read_*` delegate to the `Bytes` ones and needed no change. `unsafe_range_equal`'s genuinely variable-length loop is deliberately untouched.

## Performance

`moon bench --release`, 3 runs per backend per revision, figures are means. The A/B is the first commit (benchmarks, loop bodies) against the second (unrolled). Micro-benchmarks sweep a 4096-byte buffer at every valid offset.

### wasm-gc — where the fallback is the implementation

| benchmark | loop | unrolled | Δ |
|---|---|---|---|
| `Bytes::unsafe_read_uint16_le` | 5.76 µs | 2.85 µs | **−50.5%** |
| `Bytes::unsafe_read_uint32_le` | 9.27 µs | 5.38 µs | **−41.9%** |
| `Bytes::unsafe_read_uint64_le` | 18.53 µs | 10.02 µs | **−45.9%** |
| `FixedArray::unsafe_write_uint16_le` | 6.08 µs | 2.22 µs | **−63.4%** |
| `FixedArray::unsafe_write_uint32_le` | 9.91 µs | 4.85 µs | **−51.1%** |
| `FixedArray::unsafe_write_uint64_le` | 23.39 µs | 12.20 µs | **−47.9%** |

### js — also runs the fallback

| benchmark | loop | unrolled | Δ |
|---|---|---|---|
| `Bytes::unsafe_read_uint16_le` | 11.72 µs | 2.54 µs | **−78.3%** (see caveat) |
| `Bytes::unsafe_read_uint32_le` | 4.38 µs | 3.67 µs | **−16.1%** |
| `Bytes::unsafe_read_uint64_le` | 386.8 µs | 342.5 µs | −11.4% |
| `FixedArray::unsafe_write_uint16_le` | 2.38 µs | 1.64 µs | **−31.1%** |
| `FixedArray::unsafe_write_uint32_le` | 3.54 µs | 3.24 µs | −8.5% |
| `FixedArray::unsafe_write_uint64_le` | 688.6 µs | 676.0 µs | −1.8% |

### native — fallbacks are dead code, so this is the no-regression check

| benchmark | loop | unrolled | Δ |
|---|---|---|---|
| `Bytes::unsafe_read_uint16_le` | 444.4 ns | 442.0 ns | −0.5% |
| `Bytes::unsafe_read_uint32_le` | 438.7 ns | 436.4 ns | −0.5% |
| `Bytes::unsafe_read_uint64_le` | 489.5 ns | 473.8 ns | −3.2% |
| `FixedArray::unsafe_write_uint16_le` | 593.8 ns | 596.7 ns | +0.5% |
| `FixedArray::unsafe_write_uint32_le` | 598.6 ns | 608.5 ns | +1.6% |
| `FixedArray::unsafe_write_uint64_le` | 631.2 ns | 611.2 ns | −3.2% |

All within ±2% apart from two rows that are bimodal *on both sides* — `read_uint64_le` lands at either ~460 ns or ~503 ns and `write_uint64_le` at either ~589 ns or ~653 ns regardless of revision — so those two Δs are layout artefacts, not signal. Native is unchanged, as expected.

### Downstream, on wasm-gc

Using the existing `builtin/bytes_hash_bench_test.mbt` from main. `Hash for Bytes with fn hash` is `#cfg(not(target="js"))` and calls `unsafe_read_uint32_le`, so every `Bytes` hash on wasm-gc was paying the loop:

| benchmark | loop | unrolled | Δ |
|---|---|---|---|
| `Hash::hash(Bytes) n=32` | 27.75 ns | 20.29 ns | **−26.9%** |
| `Hash::hash(Bytes) n=8192` | 5.15 µs | 4.84 µs | −6.1% |
| `Map::at Bytes n=1024 key_bytes=32` | 55.36 µs | 52.58 µs | **−5.0%** |

### Two things worth noting separately

**The js 64-bit helpers are pathologically slow in absolute terms** — 343 µs for the same 4096-byte sweep that the 32-bit reader does in 3.7 µs, roughly 90×. That is `UInt64` emulation, not the loop: on js `UInt64` compiles to `BigInt`, so the loop form allocated a BigInt for the shift amount (`BigInt(Math.imul(8, i) & 63)`) and another for the byte on every iteration, and applied two `BigInt.asUintN(64, ...)` masks per byte. Unrolling removes the loop and the `Math.imul` and shaves 11% off the read and 2% off the write, but cannot close a gap that is entirely about the number representation. Worth its own investigation; this PR does not address it.

One concrete follow-up visible in the output: even unrolled, the js backend emits `BigInt(8 & 63)` — constructing a BigInt at runtime from a compile-time constant. Emitting `8n`, or hoisting module-level constants, would drop 7 allocations per 64-bit read. That is a backend fix, not a core one.

**The js 16-bit reader was bimodal before this change**, which is why its −78.3% is the one figure here I would not quote precisely — a single run reported 11.72 µs mean with σ = 7.15 µs and a 3.38–17.4 µs range, i.e. the JIT was landing in two different states within one measurement. After unrolling it is stable at ~2.5 µs with σ ≈ 0.5 µs. So this also removes a source of measurement instability — but it means the true baseline sits somewhere in 3.4-17.4 µs depending which state you catch, so read that row as a direction rather than a magnitude. The direction is safe: even the fastest observed baseline batch, 3.38 µs, is slower than the unrolled mean.

## Correctness

`builtin/bytes_unsafe_unroll_wbtest.mbt` keeps **the deleted loop form** as `ref_read_*` oracles, independent of the unrolled code, and asserts:

- all six `Bytes` readers and all six private `fixedarray_read_*` readers agree with the oracle at every valid offset over a 64-byte pattern chosen to expose sign/zero-extension slips;
- all six writers round-trip through the oracles across 13 `UInt64` sample values at every valid offset;
- every writer touches exactly its own span and leaves neighbouring bytes alone.

Mutation-verified rather than asserted — each of these was applied, observed to fail, and reverted:

| mutation | result |
|---|---|
| `unsafe_read_uint32_le` second term `<< 8` → `<< 16` | read-equivalence test fails |
| `unsafe_write_uint16_be` reordered to little-endian | write round-trip test fails |
| `unsafe_write_uint32_be` last store `index + 3` → `index + 4` | neighbour-span test fails |

## Test plan

- [x] `moon test` passes on all three backends — native 7370, wasm-gc 7454, js 7398
- [x] `moon fmt`, `moon check`, `moon info` clean; no `.mbti` change (no public signature is touched)
- [x] Benchmarks run on native, wasm-gc and js

## Follow-up, not in this PR

Implementing `%bytes.unsafe_read_*` / `%bytes.unsafe_write_*` in the wasm-gc and js backends would additionally inline this sequence at the call site. It would not change the arithmetic — neither backend has a multi-byte load primitive (wasm-gc bytes are a GC `array i8`; js indexes elementwise), so the emitted code would be this same unrolled chain — but it would remove the remaining call boundary.

Reviewed by Codex CLI over two rounds; the second round parametrized the neighbour check across all six writers in response to its one observation.

Signed-off-by: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
