### PR TITLE
refactor(bigint): read each from_octets limb with a u32be pattern

### DIFF
--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1470,7 +1470,10 @@ pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
     limbs[limbs_len - 1] = (limbs[limbs_len - 1] << 8) | input[i].to_uint()
   }
   let byte_per_limb = RADIX_BIT_LEN / 8
-  // tail; each limb is exactly one big-endian RADIX_BIT_LEN-bit word
+  // tail: at RADIX_BIT_LEN == 32 a limb is exactly one big-endian 32-bit word,
+  // so the shift-accumulate loop collapses to a single u32be read. That
+  // constant is pinned by a test in bigint_nonjs_wbtest.mbt, so narrowing it
+  // fails there rather than silently mis-decoding here.
   for i in 0..<div {
     guard! input[len - byte_per_limb - i * byte_per_limb:] is [u32be(word), ..]
     limbs[i] = word

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1468,12 +1468,10 @@ pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
     limbs[limbs_len - 1] = (limbs[limbs_len - 1] << 8) | input[i].to_uint()
   }
   let byte_per_limb = RADIX_BIT_LEN / 8
-  // tail
+  // tail; each limb is exactly one big-endian RADIX_BIT_LEN-bit word
   for i in 0..<div {
-    for j in 0..<byte_per_limb {
-      let bytes_idx = len - byte_per_limb - i * byte_per_limb + j
-      limbs[i] = (limbs[i] << 8) | input[bytes_idx].to_uint()
-    }
+    guard! input[len - byte_per_limb - i * byte_per_limb:] is [u32be(word), ..]
+    limbs[i] = word
   }
   { limbs, sign: Positive, len: normalize_len(limbs, limbs_len) }
 }

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1468,7 +1468,10 @@ pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
     limbs[limbs_len - 1] = (limbs[limbs_len - 1] << 8) | input[i].to_uint()
   }
   let byte_per_limb = RADIX_BIT_LEN / 8
-  // tail; each limb is exactly one big-endian RADIX_BIT_LEN-bit word
+  // tail: at RADIX_BIT_LEN == 32 a limb is exactly one big-endian 32-bit word,
+  // so the shift-accumulate loop collapses to a single u32be read. That
+  // constant is pinned by a test in bigint_nonjs_wbtest.mbt, so narrowing it
+  // fails there rather than silently mis-decoding here.
   for i in 0..<div {
     guard! input[len - byte_per_limb - i * byte_per_limb:] is [u32be(word), ..]
     limbs[i] = word

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1470,12 +1470,10 @@ pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
     limbs[limbs_len - 1] = (limbs[limbs_len - 1] << 8) | input[i].to_uint()
   }
   let byte_per_limb = RADIX_BIT_LEN / 8
-  // tail
+  // tail; each limb is exactly one big-endian RADIX_BIT_LEN-bit word
   for i in 0..<div {
-    for j in 0..<byte_per_limb {
-      let bytes_idx = len - byte_per_limb - i * byte_per_limb + j
-      limbs[i] = (limbs[i] << 8) | input[bytes_idx].to_uint()
-    }
+    guard! input[len - byte_per_limb - i * byte_per_limb:] is [u32be(word), ..]
+    limbs[i] = word
   }
   { limbs, sign: Positive, len: normalize_len(limbs, limbs_len), }
 }

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -182,3 +182,16 @@ test {
     content="{limbs : <FixedArray: [2, 2147483648, 0]>, sign : Negative, len : 2 }",
   ) // Int64.min_value - 2
 }
+
+///|
+/// `BigInt::from_octets` reads each tail limb with a single `u32be` bits
+/// pattern, which agrees with the shift-accumulate loop it replaced only when a
+/// limb is exactly four bytes wide. Pin the constant here so narrowing it fails
+/// this test instead of silently mis-decoding octets.
+///
+/// Deliberately `assert_eq` rather than `inspect`: a snapshot would be rewritten
+/// by `moon test --update`, which would silently retire this guard at exactly
+/// the moment it is supposed to fire.
+test "from_octets assumes 32-bit limbs" {
+  @test.assert_eq(RADIX_BIT_LEN, 32)
+}

--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -183,3 +183,16 @@ test {
     content="{limbs : <FixedArray: [2, 2147483648, 0]>, sign : Negative, len : 2 }",
   ) // Int64.min_value - 2
 }
+
+///|
+/// `BigInt::from_octets` reads each tail limb with a single `u32be` bits
+/// pattern, which agrees with the shift-accumulate loop it replaced only when a
+/// limb is exactly four bytes wide. Pin the constant here so narrowing it fails
+/// this test instead of silently mis-decoding octets.
+///
+/// Deliberately `assert_eq` rather than `inspect`: a snapshot would be rewritten
+/// by `moon test --update`, which would silently retire this guard at exactly
+/// the moment it is supposed to fire.
+test "from_octets assumes 32-bit limbs" {
+  @test.assert_eq(RADIX_BIT_LEN, 32)
+}

--- a/bigint/from_octets_bench_test.mbt
+++ b/bigint/from_octets_bench_test.mbt
@@ -1,0 +1,30 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn from_octets_bench_data(len : Int) -> Bytes {
+  Bytes::makei(len, i => ((i * 37 + 11) & 0xff).to_byte())
+}
+
+///|
+test "bench BigInt::from_octets n=64" (it : @bench.T) {
+  let data = from_octets_bench_data(64)
+  it.bench(fn() { it.keep(@bigint.BigInt::from_octets(data)) })
+}
+
+///|
+test "bench BigInt::from_octets n=1024" (it : @bench.T) {
+  let data = from_octets_bench_data(1024)
+  it.bench(fn() { it.keep(@bigint.BigInt::from_octets(data)) })
+}


### PR DESCRIPTION
## Summary

`BigInt::from_octets`'s tail loop assembles each limb from `byte_per_limb` indexed byte reads plus constant shifts. Since `RADIX_BIT_LEN = 32`, that inner loop is exactly one big-endian 32-bit read, so it collapses to a single `u32be` bits pattern. Five lines become two.

Plus `bigint/from_octets_bench_test.mbt` so the result is reproducible.

> **Rebased.** This PR originally also converted `BytesView::to_uint_be/le` and `to_uint64_be/le` to bits patterns. #4101 has since **deleted** those four functions outright (they were `#deprecated` + `#doc(hidden)` and had no remaining call sites), so that commit is obsolete and was dropped in the rebase. The measurements it carried are preserved at the bottom of this description for the record.

## Why this site and not others

The pattern's cost is constructing a view, and the payoff scales with how many byte operations that view replaces:

| shape | result |
|---|---|
| whole view already in hand — no slice needed | big win |
| slice amortized over 4+ bytes (`u32`/`u64` at an offset) | clear win — **this PR** |
| slice to replace only 2 byte reads (`u16` at an offset) | **loses** — view construction dominates |

That last row is why `builtin/bitstring.mbt`'s `unsafe_extract_byte` is not here. One site that regressed badly is split into #4100 and deliberately not in this PR.

## Performance

`moon bench --release`, 6 interleaved base/head runs per backend, means reported.

| `BigInt::from_octets` | native | wasm-gc | js |
|---|---|---|---|
| n=1024 | 428.71 → 266.59 ns (**−37.8%**) | 1.538 µs → 805.90 ns (**−47.6%**) | 27.05 → 26.80 µs (−0.9%, noise) |
| n=64 | 40.49 → 30.96 ns (**−23.5%**) | 111.98 → 63.88 ns (**−43.0%**) | 1.775 → 1.767 µs (−0.5%, noise) |

js is a genuine control: `bigint_js.mbt` carries its own `from_octets`, which this PR does not touch, and it duly did not move.

## Review response — the hard-coded 32-bit read

Copilot flagged that the tail now hard-codes `u32be` while `byte_per_limb` is still derived from `RADIX_BIT_LEN`, and suggested guarding the fast path behind `RADIX_BIT_LEN == 32` with the old shift-accumulate loop as a generic fallback.

The concern is right; the suggested remedy is not, because **that fallback would not actually be generic**. `byte_per_limb` is `RADIX_BIT_LEN / 8`, and the file only requires `RADIX_BIT_LEN` to be a multiple of 4 and at most 32. For the documented-legal widths 4, 12, 20 and 28 the division truncates and the old loop mis-decodes exactly as badly — it would trade a loud failure for a quiet one, and add a branch no test can ever reach (this PR's patch coverage is currently 100%).

So the assumption is **pinned** instead: a whitebox test asserts `RADIX_BIT_LEN == 32`, and the comment above the loop names it. Narrowing the constant now fails a test rather than silently mis-decoding octets.

The pin deliberately uses `@test.assert_eq`, not `inspect`. A snapshot would be rewritten by `moon test --update`, which would retire the guard at exactly the moment it is supposed to fire. Both halves are verified: temporarily setting the expected value to 16 fails with `32 != 16`, and `moon test --update` leaves it failing rather than quietly rewriting it.

For what it's worth, the new code cannot silently mis-decode even without the test: at any `byte_per_limb < 4` the first tail iteration slices fewer than four bytes and the `guard!` panics.

## Test plan

- [x] `moon test --target all` — wasm 7444, wasm-gc 7445, js 7388, native 7361, zero failures
- [x] `moon check --deny-warn` clean
- [x] `moon fmt` and `moon info --target wasm,wasm-gc,js,native` produce no diff — no public signature is touched
- [x] Benchmarks run on native, wasm-gc and js

<details>
<summary>Dropped: <code>BytesView</code> converter measurements (superseded by #4101, which deleted these functions)</summary>

4096-byte sweep, `moon bench --release`:

| | native | wasm-gc | js |
|---|---|---|---|
| `to_uint_be` | 8.61 → 4.28 µs (−50%) | 17.96 → 11.13 µs (−38%) | 8.72 → 7.89 µs (−10%) |
| `to_uint_le` | 8.59 → 4.27 µs (−50%) | 17.81 → 11.23 µs (−37%) | 8.61 → 7.84 µs (−9%) |
| `to_uint64_be` | 13.31 → 4.35 µs (−67%) | 23.94 → 16.99 µs (−29%) | 357.5 → 340.9 µs (−5%) |
| `to_uint64_le` | 13.23 → 4.23 µs (−68%) | 23.55 → 16.72 µs (−29%) | 351.6 → 349.6 µs (−1%) |

</details>

Signed-off-by: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
