### PR TITLE
DO NOT MERGE: bits pattern in unsafe_extract_byte regresses on every backend (~1.5x native)

### DIFF
--- a/builtin/bitstring.mbt
+++ b/builtin/bitstring.mbt
@@ -83,9 +83,7 @@ pub fn ArrayView::unsafe_extract_byte(
     (byte >> shift) & mask
   } else {
     // extract 16 bits at [byte_index, byte_index + 1]
-    let b0 = bs.unsafe_get(byte_index).to_uint()
-    let b1 = bs.unsafe_get(byte_index + 1).to_uint()
-    let data = (b0 << 8) | b1
+    guard! bs[byte_index:] is [u16be(data), ..]
     // mask off the top bits
     let bit_mask = (1U << (16 - (offset & 7))) - 1
     let data = data & bit_mask
@@ -959,9 +957,7 @@ pub fn BytesView::unsafe_extract_byte(
     (byte >> shift) & mask
   } else {
     // extract 16 bits at [byte_index, byte_index + 1]
-    let b0 = bs.unsafe_get(byte_index).to_uint()
-    let b1 = bs.unsafe_get(byte_index + 1).to_uint()
-    let data = (b0 << 8) | b1
+    guard! bs[byte_index:] is [u16be(data), ..]
     // mask off the top bits
     let bit_mask = (1U << (16 - (offset & 7))) - 1
     let data = data & bit_mask


### PR DESCRIPTION
## ⚠️ Do not merge as-is — this regresses on every backend

Opened as a **draft** to record a measured negative result from the bits-pattern sweep, as the counterpart to #4099 (which holds the conversions that win). Keeping it visible so nobody re-derives it later.

> **Re-measured 2026-09-16** — moon 0.1.20260915 / moonc v0.10.13, macOS arm64, medians of 3 runs.
> The conclusion holds: the pattern form is slower on every backend and should not be merged.
> Two things changed: the **"~27× on native" headline was a benchmark artifact** and is corrected
> below, and the cause is now pinned down to a specific line of generated C. The August numbers
> are preserved at the bottom.

## What it does

`builtin/bitstring.mbt` has the same manual 16-bit big-endian assembly in both copies of `unsafe_extract_byte` — the `ArrayView[Byte]` one and the `BytesView` one:

```moonbit
let b0 = bs.unsafe_get(byte_index).to_uint()
let b1 = bs.unsafe_get(byte_index + 1).to_uint()
let data = (b0 << 8) | b1
```

This replaces both with a bits pattern over a view starting at `byte_index`. It is correct — the full suite passes on all three backends (native 3160, wasm-gc 3201, js 3171) — and it is shorter and clearer. It is just slower.

*Spelling note:* the branch still writes `bs[byte_index:]`. `xs[a:b]` and `xs.exact_view(start=a)` are the same entry point (`#intrinsic("%bytes.view")`, `builtin/bytesview.mbt`); only the `view`/`sub` aliases carry `deprecated`. Both spellings were measured and are indistinguishable on the `BytesView` copy, so nothing below depends on which one is used.

## Measured (2026-09-16)

`moon bench --release`, 4096-byte buffer, offsets chosen so `offset & 7 == 7` and `len == 2` — every call takes the two-byte branch. Times are per bench iteration (one full sweep of the loop).

Two loop shapes, because they measure different things.

**A. Independent loop** — `acc += extract(i)` over 4095 offsets. This is the original benchmark.

| backend | manual | bits pattern | |
|---|---|---|---|
| native | 0.46 µs | 9.01 µs | 19.4× |
| wasm-gc | 10.28 µs | 19.23 µs | 1.87× |
| js | 5.44 µs | 7.84 µs | 1.44× |

**B. Dependent loop** — the next offset is derived from the extracted value, so neither form can vectorise.

| backend | manual | bits pattern | |
|---|---|---|---|
| native | 6.02 µs | 9.00 µs | **1.50×** |
| wasm-gc | 10.78 µs | 13.03 µs | **1.21×** |
| js | 8.57 µs | 11.53 µs | **1.35×** |

**B is the number to quote.** A 0.46 µs baseline over 4095 iterations is 0.11 ns/iteration — under one cycle on this machine, which is impossible for real work. The manual body is pure loads and arithmetic, so clang turns the loop into a SIMD reduction; the pattern body blocks that. So the 19× (and August's 27×) is *lost auto-vectorisation in a tight reduction loop*, not the cost of one call. Real bits-pattern matching is straight-line field extraction, which looks like B.

Mixed offsets cycling all three branches (aligned / within-byte / straddling, `len=4`): native 3.45 → 6.79 µs (1.97×), wasm-gc 11.34 → 14.02 µs (1.24×), js 4.64 → 5.66 µs (1.22×).

The `ArrayView` copy tracks the `BytesView` one within noise (native 21.1× shape A, 1.52× shape B).

## Why it is slow on native

The generated C is unambiguous. Manual form, straddling branch:

```c
int32_t b0 = buf[start + byte_index];
int32_t b1 = buf[start + byte_index + 1];
// shift / or / mask
```

Pattern form, same branch:

```c
if (byte_index < 0 || byte_index > bind_len) moonbit_panic();   // exact_view's range guard
moonbit_incref_cycle_free(buf);                                  // retain for the view
BytesView v = { buf, start + byte_index, start + bind_len };
if (v.$2 - v.$1 >= 2) {                                          // the pattern's own length check
  tmp = READ_UINT16_BE(v.$0 + v.$1);
  moonbit_decref_cycle_free(v.$0);                               // release the view
  ...
} else moonbit_panic();
```

Note the read itself is *better*: one `READ_UINT16_BE` instead of two byte loads plus a shift and an or. Everything around it is what costs.

Isolating each piece (native, shape B, 2000 iterations per bench iteration):

| variant | µs | Δ | per call |
|---|---|---|---|
| manual (main) | 6.02 | — | — |
| pattern over an **unchecked** `BytesView::make` | 6.65 | +0.63 | +0.32 ns — the pattern's own `len >= 2` check |
| … plus an explicit bounds guard, still no refcounting | 6.68 | +0.03 | +0.02 ns — **bounds checks are essentially free** |
| … plus the retain/release pair, i.e. `exact_view` | 9.00 | +2.32 | +1.16 ns — **the refcount traffic** |

So ~78% of the native regression is the retain/release pair, not the bounds check. Both are load-modify-store on the `Bytes` object header, and `moonbit_decref_cycle_free` carries a call to `moonbit_drop_object` on its cold path. That has two consequences:

1. **Native is the only backend that pays it.** js and wasm-gc are garbage-collected, so no retain/release is emitted — which is why their ratios (1.21×, 1.35×) are milder than native's 1.50×.
2. **It defeats the optimiser.** The header store aliases memory and the drop call is opaque, so clang can neither vectorise the loop nor hoist the loads across iterations. That is the entire gap between shape A and shape B on native.

A predictable, never-taken bounds branch costs almost nothing. A refcount update on a hot object header costs real cycles *and* poisons the surrounding loop. That is the whole story.

(The same ladder on the other backends, shape B, `BytesView`: wasm-gc 10.78 / 11.49 / 11.81 / 13.03, js 8.57 / 9.44 / 9.75 / 11.53. They have no refcount step, so the last jump there is the cost of going through `exact_view` itself rather than a hand-built view; not investigated further.)

## What would make this mergeable

Same condition as in August — a way to spell "read a `u16be` at a computed offset without materialising a refcounted view" — but now with a measured ceiling on what it would buy.

`bitstring.mbt` lives in `builtin`, so the private `BytesView::make` / `ArrayView::make` intrinsics are already reachable from it. Going through them removes both the bounds guard and the retain/release, and takes native from 1.50× to **1.10×** (shape B) and from 19.4× to **1.80×** (shape A).

But it still never *wins*. At best the pattern ties the three-line manual form while being harder to reason about, so even with the escape hatch in hand there is no reason to make the change. The boundary from the original write-up is unchanged:

| shape | result |
|---|---|
| whole view already in hand — no slice | big win |
| slice amortised over 4+ bytes (`u32`/`u64`) | clear win |
| slice to replace 2 byte reads (`u16` at an offset) | **loses** |

**Recommendation: leave this closed/draft.** The manual form is the right code here.

<details>
<summary>Original August 2026 numbers (superseded — see the artifact note above)</summary>

`moon bench --release`, a 4096-byte buffer read at unaligned 7-bit offsets spanning two bytes.

| backend | manual | bits pattern | |
|---|---|---|---|
| native | 467 ns | 12.6 µs | ~27× |
| wasm-gc | 9.99 µs | 18.39 µs | +84% |
| js | 7.09 µs | 9.73 µs | +37% |

The native figure was re-run twice to confirm (12.63 µs, 13.26 µs). Its 467 ns baseline is ~0.11 ns per iteration, so the original was being inlined and heavily optimized; the slice plus guard blocks that entirely.

This was measured with the independent-loop shape (A above), so the 27× is dominated by lost vectorisation rather than per-call cost. The suite counts quoted at the time (native 7370, wasm-gc 7454, js 7398) covered a wider set of packages than the 2026-09 re-run, which ran `bytes` + `builtin` only.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
