### PR TITLE
fix(regex): reject empty unicode brace escape

### DIFF
--- a/string/internal/regex_parser/parser.mbt
+++ b/string/internal/regex_parser/parser.mbt
@@ -63,6 +63,7 @@ fn Parser::class_atom(
       }
       (rest, Char(c))
     }
+    (re"^\\u", after=_) => raise ctx.error_at(rest, HINT_INVALID_ESCAPE)
     (re"^\\" + (re"[\^$\\.*+?()\[\]{}|/\"\-:&]" as c), after=rest) =>
       (rest, Char(c.to_int()))
     (re"^\[:ascii:\]", after=rest) => (rest, Class(posix_cset_ascii))
@@ -289,6 +290,7 @@ fn Parser::term(
       }
       (rest, @re.char(@re.RecharSet::char(c)), false)
     }
+    (re"^\\u", after=_) => raise ctx.error_at(rest, HINT_INVALID_ESCAPE)
     (re"^\\" + (re"[\^$\\.*+?()\[\]{}|/\"]" as c), after=rest) =>
       (rest, @re.char(@re.RecharSet::char(c.to_int())), false)
     (re"^\\.", after=_) => raise ctx.error_at(rest, HINT_INVALID_ESCAPE)

--- a/string/internal/regex_parser/parser_test.mbt
+++ b/string/internal/regex_parser/parser_test.mbt
@@ -895,6 +895,18 @@ test "parse/error_invalid_escape" {
 }
 
 ///|
+test "parse/error_empty_unicode_brace_escape" {
+  debug_inspect(
+    Ok(parse(profile=profile_unicode(), mode=String, "[\\u{}]")) catch {
+      e => Err(e)
+    },
+    content=(
+      #|Err(ParserError(at=1, hint="Invalid escape sequence"))
+    ),
+  )
+}
+
+///|
 test "parse/error_unicode_out_of_range" {
   debug_inspect(
     Ok(parse(profile=profile_bytes(), mode=String, "[\\u{FFFFFF}]")) catch {


### PR DESCRIPTION
This PR fix wrong behavior of regex parser, make it reject empty unicode brace escape.