### PR TITLE
feat: shrink facade in quickcheck root

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -238,7 +238,9 @@ test "builtin types" {
 
 ## Custom Types
 
-Implement `Arbitrary` trait for custom types:
+Implement the `Arbitrary` and `Shrink` traits for custom types. Both traits are
+available from the `quickcheck` facade; no separate `quickcheck/shrink` import
+is needed:
 
 ```mbt check
 ///|
@@ -248,10 +250,18 @@ priv struct Point {
 } derive(Debug)
 
 ///|
-impl Arbitrary for Point with fn arbitrary(size, r0) {
+impl @quickcheck.Arbitrary for Point with fn arbitrary(size, r0) {
   let r1 = r0.split()
   let y = @quickcheck.Arbitrary::arbitrary(size, r1)
   { x: @quickcheck.Arbitrary::arbitrary(size, r0), y }
+}
+
+///|
+impl @quickcheck.Shrink for Point with fn shrink(self) {
+  @quickcheck.Shrink::shrink((self.x, self.y)).map(pair => {
+    x: pair.0,
+    y: pair.1,
+  })
 }
 
 ///|
@@ -269,6 +279,17 @@ test "custom type generation" {
     content=(
       #|<ArrayView:
       #|  [{ x: 0, y: 1 }, { x: -1, y: -5 }, { x: -6, y: -6 }, { x: -1, y: 7 }]>
+    ),
+  )
+}
+
+///|
+test "custom type shrinking" {
+  let point : Point = { x: 2, y: 1 }
+  debug_inspect(
+    @quickcheck.Shrink::shrink(point).collect(),
+    content=(
+      #|[{ x: 1, y: 1 }, { x: 0, y: 1 }, { x: 2, y: 0 }]
     ),
   )
 }

--- a/quickcheck/facade.mbt
+++ b/quickcheck/facade.mbt
@@ -1,0 +1,20 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// The shrinking trait required by `check` and `report`.
+///
+/// Re-exported by the QuickCheck facade so custom input types can implement
+/// both `Arbitrary` and `Shrink` through a single package import.
+pub using @shrink {trait Shrink}

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -73,6 +73,8 @@ pub impl[A : @debug.Debug] @debug.Debug for QuickCheckReport[A]
 // Type aliases
 pub using @splitmix {type RandomState}
 
+pub using @shrink {trait Shrink}
+
 // Traits
 pub(open) trait Arbitrary {
   fn arbitrary(Int, @splitmix.RandomState) -> Self


### PR DESCRIPTION
Make the `Shrink` trait visible in QuickCheck root
#4077 