### PR TITLE
feat: forall and forall_shrink

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -124,6 +124,57 @@ test "context describes the shrunk counterexample" {
 }
 ```
 
+## Explicit Generators
+
+Use `forall` when the input must come from a hand-written `Generator` rather
+than an `Arbitrary` instance. The generator receives the same size schedule as
+`check`, and its values are not shrunk. This is useful for constrained domains,
+where a general-purpose shrinker could produce values outside the domain:
+
+```mbt check
+///|
+test "explicit generator" {
+  @quickcheck.forall(
+    @quickcheck.int_range(1, 100),
+    (x : Int) => x > 0,
+    count=20,
+  )
+}
+```
+
+`forall_shrink` and `report_forall_shrink` accept a shrinker explicitly when
+the generated type has a domain-preserving shrinking strategy.
+The `report_*` variants return `QuickCheckReport` instead of raising or
+failing the test; `report_forall` is the no-shrink counterpart of `report`.
+
+For example, a report can use a shrinker that keeps a failing value inside a
+restricted domain:
+
+```mbt check
+///|
+test "explicit shrinker" {
+  let report = @quickcheck.report_forall_shrink(
+    @quickcheck.pure(4),
+    (x : Int) => if x == 4 { [|3|] } else { [||] },
+    (x : Int) => x < 3,
+    count=1,
+    max_size=0,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Falsified(
+      #|  counterexample=3,
+      #|  tests=1,
+      #|  size=0,
+      #|  shrinks=1,
+      #|  shrink_attempts=1,
+      #|)
+    ),
+  )
+}
+```
+
 Properties should be deterministic and should not mutate or consume their
 input. In particular, an `Iter` is single-use; generate an `Array` and create a
 fresh iterator inside the property when replayable sequence behavior matters.

--- a/quickcheck/driver.mbt
+++ b/quickcheck/driver.mbt
@@ -188,9 +188,10 @@ impl Eq for CaseOutcome with fn equal(expected, actual) {
 }
 
 ///|
-fn[A : @shrink.Shrink] shrink_failure(
+fn[A] shrink_failure(
   property : (A) -> Bool raise?,
   filter : (A) -> Bool,
+  shrinker : (A) -> Iter[A],
   input : A,
   initial : CaseOutcome,
   max_shrinks : UInt,
@@ -202,7 +203,7 @@ fn[A : @shrink.Shrink] shrink_failure(
   let mut found = true
   while attempted < max_shrinks && found {
     found = false
-    let candidates = @shrink.Shrink::shrink(current)
+    let candidates = shrinker(current)
     while attempted < max_shrinks && candidates.next() is Some(candidate) {
       attempted = attempted + 1
       let outcome = evaluate_case(property, filter, candidate)
@@ -271,21 +272,11 @@ fn[A : @debug.Debug] failure_report(report : QuickCheckReport[A]) -> String {
 }
 
 ///|
-/// Checks `property` and returns a structured report.
-///
-/// Returning `false` records a falsification; every error raised by the
-/// property is recorded separately. Unlike `check`, this function does not
-/// turn either result into a test failure, does not raise property errors, and
-/// does not require the input type to implement `Debug`. Cases rejected by the
-/// pure `filter` do not count as tests. The run gives up after `discard_ratio`
-/// discarded cases per requested test. The pure `observe` function is
-/// evaluated and aggregated only after a top-level case succeeds.
-///
-/// `counterexample_context` attaches a human-readable description of the shrunk
-/// counterexample to a failure — for example the rendered form of a
-/// generated document — without conflating it with errors raised by the
-/// property itself.
-pub fn[A : Arbitrary + @shrink.Shrink] report(
+/// Internal implementation shared by the `Arbitrary`- and
+/// `Generator`-based entry points.
+fn[A] report_with(
+  generator : Generator[A],
+  shrinker : (A) -> Iter[A],
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
   observe? : (A) -> Observations = _ => [],
@@ -300,7 +291,7 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
   let observations = ObservationSummary::empty()
   for tests = 0U, discarded = 0U, recent_discards = 0U; tests < count; {
     let size = size_at(tests, count, max_size, recent_discards)
-    let input : A = Arbitrary::arbitrary(size, state.split())
+    let input : A = generator.run(size, state.split())
     let outcome = evaluate_case(property, filter, input)
     match outcome {
       Passed => {
@@ -317,7 +308,7 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
       _ => {
         let completed_tests = tests + 1
         let (counterexample, outcome, shrinks, shrink_attempts) = shrink_failure(
-          property, filter, input, outcome, max_shrinks,
+          property, filter, shrinker, input, outcome, max_shrinks,
         )
         let context = counterexample_context.map(render => {
           render(counterexample)
@@ -354,6 +345,114 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
   } nobreak {
     Passed(tests=count, observations~)
   }
+}
+
+///|
+/// Checks `property` and returns a structured report using the input type's
+/// `Arbitrary` and `Shrink` instances.
+///
+/// Returning `false` records a falsification; every error raised by the
+/// property is recorded separately. Unlike `check`, this function does not
+/// turn either result into a test failure, does not raise property errors, and
+/// does not require the input type to implement `Debug`. Cases rejected by the
+/// pure `filter` do not count as tests. The run gives up after `discard_ratio`
+/// discarded cases per requested test. The pure `observe` function is
+/// evaluated and aggregated only after a top-level case succeeds.
+///
+/// `counterexample_context` attaches a human-readable description of the shrunk
+/// counterexample to a failure — for example the rendered form of a
+/// generated document — without conflating it with errors raised by the
+/// property itself.
+pub fn[A : Arbitrary + @shrink.Shrink] report(
+  property : (A) -> Bool raise?,
+  filter? : (A) -> Bool = _ => true,
+  observe? : (A) -> Observations = _ => [],
+  counterexample_context? : (A) -> String,
+  count? : UInt = 100,
+  max_size? : UInt = 100,
+  max_shrinks? : UInt = 100,
+  discard_ratio? : UInt = 10,
+  seed? : UInt64 = 37,
+) -> QuickCheckReport[A] {
+  report_with(
+    Generator((size, state) => Arbitrary::arbitrary(size, state)),
+    @shrink.Shrink::shrink,
+    property,
+    filter~,
+    observe~,
+    counterexample_context?,
+    count~,
+    max_size~,
+    max_shrinks~,
+    discard_ratio~,
+    seed~,
+  )
+}
+
+///|
+/// Checks a property using an explicit generator.
+///
+/// Unlike `report`, this function does not require `Arbitrary` or `Shrink`.
+/// Generated values are not shrunk, which keeps values inside a generator's
+/// domain when that domain has constraints that a general-purpose shrinker
+/// cannot preserve. Use `report_forall_shrink` when the generator has a
+/// domain-preserving shrinker.
+pub fn[A] report_forall(
+  generator : Generator[A],
+  property : (A) -> Bool raise?,
+  filter? : (A) -> Bool = _ => true,
+  observe? : (A) -> Observations = _ => [],
+  counterexample_context? : (A) -> String,
+  count? : UInt = 100,
+  max_size? : UInt = 100,
+  discard_ratio? : UInt = 10,
+  seed? : UInt64 = 37,
+) -> QuickCheckReport[A] {
+  report_with(
+    generator,
+    _ => Iter::empty(),
+    property,
+    filter~,
+    observe~,
+    counterexample_context?,
+    count~,
+    max_size~,
+    discard_ratio~,
+    seed~,
+  )
+}
+
+///|
+/// Checks a property using an explicit generator and a custom shrinker.
+///
+/// The shrinker is used only after a generated case fails. It is responsible
+/// for preserving any invariants enforced by `generator`.
+pub fn[A] report_forall_shrink(
+  generator : Generator[A],
+  shrinker : (A) -> Iter[A],
+  property : (A) -> Bool raise?,
+  filter? : (A) -> Bool = _ => true,
+  observe? : (A) -> Observations = _ => [],
+  counterexample_context? : (A) -> String,
+  count? : UInt = 100,
+  max_size? : UInt = 100,
+  max_shrinks? : UInt = 100,
+  discard_ratio? : UInt = 10,
+  seed? : UInt64 = 37,
+) -> QuickCheckReport[A] {
+  report_with(
+    generator,
+    shrinker,
+    property,
+    filter~,
+    observe~,
+    counterexample_context?,
+    count~,
+    max_size~,
+    max_shrinks~,
+    discard_ratio~,
+    seed~,
+  )
 }
 
 ///|
@@ -425,10 +524,83 @@ pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check(
     discard_ratio~,
     seed~,
   )
+  finish_check(result, loc)
+}
+
+///|
+fn[A : @debug.Debug] finish_check(
+  result : QuickCheckReport[A],
+  loc : SourceLoc,
+) -> Unit raise {
   match result {
     Passed(observations~, ..) if observations.is_empty() => ()
     Passed(tests~, observations~) => println(observations.report(tests))
     GaveUp(..) | Falsified(..) | Raised(..) =>
       fail(failure_report(result), loc~)
   }
+}
+
+///|
+/// Checks a property using an explicit generator. Generated values are not
+/// shrunk, and the input type does not need an `Arbitrary` or `Shrink`
+/// instance. Use `forall_shrink` when a custom shrinker is available.
+#callsite(autofill(loc))
+pub fn[A : @debug.Debug] forall(
+  generator : Generator[A],
+  property : (A) -> Bool raise?,
+  filter? : (A) -> Bool = _ => true,
+  observe? : (A) -> Observations = _ => [],
+  counterexample_context? : (A) -> String,
+  count? : UInt = 100,
+  max_size? : UInt = 100,
+  discard_ratio? : UInt = 10,
+  seed? : UInt64 = 37,
+  loc~ : SourceLoc,
+) -> Unit raise {
+  let result = report_forall(
+    generator,
+    property,
+    filter~,
+    observe~,
+    counterexample_context?,
+    count~,
+    max_size~,
+    discard_ratio~,
+    seed~,
+  )
+  finish_check(result, loc)
+}
+
+///|
+/// Checks a property using an explicit generator and custom shrinker. The
+/// input type does not need an `Arbitrary` or `Shrink` instance.
+#callsite(autofill(loc))
+pub fn[A : @debug.Debug] forall_shrink(
+  generator : Generator[A],
+  shrinker : (A) -> Iter[A],
+  property : (A) -> Bool raise?,
+  filter? : (A) -> Bool = _ => true,
+  observe? : (A) -> Observations = _ => [],
+  counterexample_context? : (A) -> String,
+  count? : UInt = 100,
+  max_size? : UInt = 100,
+  max_shrinks? : UInt = 100,
+  discard_ratio? : UInt = 10,
+  seed? : UInt64 = 37,
+  loc~ : SourceLoc,
+) -> Unit raise {
+  let result = report_forall_shrink(
+    generator,
+    shrinker,
+    property,
+    filter~,
+    observe~,
+    counterexample_context?,
+    count~,
+    max_size~,
+    max_shrinks~,
+    discard_ratio~,
+    seed~,
+  )
+  finish_check(result, loc)
 }

--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -83,6 +83,111 @@ impl @shrink.Shrink for FilteredShrinkInput with fn shrink(input) {
 }
 
 ///|
+priv struct ForAllInput(Int) derive(Debug)
+
+///|
+priv struct CustomForAllInput(Int) derive(Debug)
+
+///|
+test "report_forall uses an explicit generator without Arbitrary" {
+  let report = @quickcheck.report_forall(
+    Generator((size, _) => ForAllInput(size)),
+    (input : ForAllInput) => input.0 < 3,
+    count=3,
+    max_size=4,
+    seed=1,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Falsified(
+      #|  counterexample=ForAllInput(4),
+      #|  tests=3,
+      #|  size=4,
+      #|  shrinks=0,
+      #|  shrink_attempts=0,
+      #|)
+    ),
+  )
+}
+
+///|
+test "report_forall does not shrink outside a generator domain" {
+  let report = @quickcheck.report_forall(
+    @quickcheck.int_range(10, 11),
+    (input : Int) => input < 10,
+    count=1,
+    max_size=0,
+    seed=1,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Falsified(
+      #|  counterexample=10,
+      #|  tests=1,
+      #|  size=0,
+      #|  shrinks=0,
+      #|  shrink_attempts=0,
+      #|)
+    ),
+  )
+}
+
+///|
+test "report_forall_shrink uses a custom shrinker without Shrink" {
+  let report = @quickcheck.report_forall_shrink(
+    @quickcheck.pure(CustomForAllInput(4)),
+    (input : CustomForAllInput) => {
+      if input.0 == 4 {
+        [|CustomForAllInput(3)|]
+      } else {
+        [||]
+      }
+    },
+    (input : CustomForAllInput) => input.0 < 3,
+    count=1,
+    max_size=0,
+    seed=1,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Falsified(
+      #|  counterexample=CustomForAllInput(3),
+      #|  tests=1,
+      #|  size=0,
+      #|  shrinks=1,
+      #|  shrink_attempts=1,
+      #|)
+    ),
+  )
+}
+
+///|
+test "forall drives a passing property without Arbitrary or Shrink" {
+  @quickcheck.forall(
+    Generator((_, _) => ForAllInput(1)),
+    (input : ForAllInput) => input.0 == 1,
+    count=3,
+    max_size=0,
+    seed=1,
+  )
+}
+
+///|
+test "forall_shrink drives a passing property with a custom shrinker" {
+  @quickcheck.forall_shrink(
+    @quickcheck.pure(CustomForAllInput(1)),
+    (_ : CustomForAllInput) => [||],
+    (input : CustomForAllInput) => input.0 == 1,
+    count=1,
+    max_size=0,
+    seed=1,
+  )
+}
+
+///|
 priv suberror QcError {
   InitialRaised
   ShrunkRaised
@@ -525,7 +630,7 @@ test "context is attached to raised failures too" {
       #|Raised(
       #|  counterexample=3,
       #|  context="rendered input <3>",
-      #|  error=Failure("quickcheck/driver_test.mbt:516:30-516:42@moonbitlang/core FAILED: boom"),
+      #|  error=Failure("quickcheck/driver_test.mbt:621:30-621:42@moonbitlang/core FAILED: boom"),
       #|  tests=5,
       #|  size=4,
       #|  shrinks=0,

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -26,6 +26,12 @@ pub fn[T : @debug.Debug] collect(T) -> Observation
 
 pub fn[T] elements(Array[T]) -> Generator[T]
 
+#callsite(autofill(loc))
+pub fn[A : @debug.Debug] forall(Generator[A], (A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, discard_ratio? : UInt, seed? : UInt64, loc~ : SourceLoc) -> Unit raise
+
+#callsite(autofill(loc))
+pub fn[A : @debug.Debug] forall_shrink(Generator[A], (A) -> Iter[A], (A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64, loc~ : SourceLoc) -> Unit raise
+
 pub fn[T] frequency(Array[(UInt, Generator[T])]) -> Generator[T]
 
 pub fn[T : Arbitrary] gen(size? : Int, state? : @splitmix.RandomState) -> T
@@ -39,6 +45,10 @@ pub fn[T] one_of(Array[Generator[T]]) -> Generator[T]
 pub fn[T] pure(T) -> Generator[T]
 
 pub fn[A : Arbitrary + @shrink.Shrink] report((A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
+
+pub fn[A] report_forall(Generator[A], (A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
+
+pub fn[A] report_forall_shrink(Generator[A], (A) -> Iter[A], (A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
 
 pub fn[X : Arbitrary] samples(Int) -> Array[X]
 


### PR DESCRIPTION
A design choice: When using an explicit generator, its `Shrink` instance typically no longer applies; consequently, the `forall` here does not rely on `Shrink`. If such functionality is required, consider using `forall_shrink`.

#4078