### PR TITLE
refactor: adopt defer for cleanup, clearing the new fragile_catch_all lint

### DIFF
--- a/error/error_test.mbt
+++ b/error/error_test.mbt
@@ -60,21 +60,8 @@ fn[A, E : Error] protect(
   finalize~ : () -> Unit raise?,
   work : () -> A raise E,
 ) -> A raise E {
-  try work() catch {
-    e => {
-      finalize() catch {
-        _ => ()
-      }
-      raise e
-    }
-  } noraise {
-    x => {
-      finalize() catch {
-        _ => ()
-      }
-      x
-    }
-  }
+  defer (finalize() catch { _ => () })
+  work()
 }
 
 ///|
@@ -84,16 +71,11 @@ fn[A, E : Error] protect(
 /// it is hard to track which error is the original one
 /// in the type system
 fn[A] protect2(finalize~ : () -> Unit raise?, work : () -> A raise) -> A raise {
-  try work() catch {
-    e => {
-      finalize()
-      raise e
-    }
-  } noraise {
-    x => {
-      finalize()
-      x
-    }
+  let result = Ok(work()) catch { e => Err(e) }
+  finalize()
+  match result {
+    Ok(x) => x
+    Err(e) => raise e
   }
 }
 

--- a/ref/ref.mbt
+++ b/ref/ref.mbt
@@ -102,17 +102,10 @@ pub fn[T, R] Ref::map(self : Ref[T], f : (T) -> R raise?) -> Ref[R] raise? {
 pub fn[T, R] Ref::protect(self : Ref[T], a : T, f : () -> R raise?) -> R raise? {
   let old = self.val
   self.val = a
-  try f() catch {
-    err => {
-      self.val = old
-      raise err
-    }
-  } noraise {
-    r => {
-      self.val = old
-      r
-    }
+  defer {
+    self.val = old
   }
+  f()
 }
 
 ///|


### PR DESCRIPTION
The pre-release compiler grew a `fragile_catch_all` lint (error `[0092]`) that
rejects a catch-all whose handler cleans up and re-raises:

```moonbit
try <expr> catch {
  err => { <cleanup>; raise err }
}
```

Two places in core used it. `moon info` reports no `.mbti` change, so neither
is externally visible.

**`ref/ref.mbt` — `Ref::protect`.** The saved value was restored in both the
`catch` and the `noraise` arm; `defer` runs on both exits, so the duplication
goes away:

```moonbit
let old = self.val
self.val = a
defer self.val = old
f()
```

**`error/error_test.mbt` — the `protect` / `protect2` design notes.** These two
helpers exist to document which error should win when the finalizer itself
raises, so their behavior is load-bearing.

`protect` swallows the finalizer's error, so its cleanup cannot raise and it is
a plain `defer`.

`protect2` deliberately lets the finalizer's error win — and that is precisely
what neither rewrite the lint suggests can express, because a raising finalizer
is not allowed in either block (checked on moonc v0.10.8):

```
[4174] calling function with error is not allowed inside `defer`.
[4174] calling function with error is not allowed inside `errdefer`.
```

So it captures the outcome as a `Result`, runs the finalizer on the single
shared path, and re-raises afterwards — the catch arm no longer cleans up or
re-raises:

```moonbit
let result = Ok(work()) catch { e => Err(e) }
finalize()
match result {
  Ok(x) => x
  Err(e) => raise e
}
```

Behavior is pinned by tests that already existed: `"protect & finally raise
error"` still reports the work error, `"protect2 & finally raise error"` still
reports the finalizer error, and `ref`'s `"protect with error"` covers the
raising path. `moon check --deny-warn` (the CI command),
`moon test -p moonbitlang/core/ref`, and `moon test -p moonbitlang/core/error`
all pass locally on moonc v0.10.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)