### PR TITLE
perf(sorted_set): probe fallback for strongly asymmetric difference/intersection

### DIFF
--- a/sorted_set/invariant_wbtest.mbt
+++ b/sorted_set/invariant_wbtest.mbt
@@ -182,6 +182,16 @@ test "set operations keep invariants (asymmetric sizes)" {
 }
 
 ///|
+test "set operations keep invariants (extreme asymmetry, probe fallback)" {
+  // One side far below 1/16 of the other: difference and intersection take
+  // the O(n log m) probe fallback instead of the split-based merge.
+  for seed in 1..<=3 {
+    set_ops_scenario(0xACE1UL + seed.to_uint64(), 3000, 30, 5000)
+    set_ops_scenario(0xACE2UL + seed.to_uint64(), 30, 3000, 5000)
+  }
+}
+
+///|
 test "set operations with self and empty keep invariants" {
   let rng = Rand::{ state: 77UL }
   let a : SortedSet[Int] = new_sorted_set()

--- a/sorted_set/quickcheck_test.mbt
+++ b/sorted_set/quickcheck_test.mbt
@@ -65,6 +65,38 @@ test "quickcheck: symmetric_difference matches the filter model" {
 }
 
 ///|
+test "quickcheck: strongly asymmetric sizes match the filter model" {
+  // Forces the O(n log m) probe fallback in difference/intersection
+  // (taken when one side is under 1/16 of the other) and checks it against
+  // the same filter model as the split-based path.
+  @quickcheck.check((input : (Array[Int], Array[Int])) => {
+    let (xs, ys) = input
+    let k = if xs.length() < 10 { xs.length() } else { 10 }
+    let small = @sorted_set.from_array(xs[0:k])
+    let big = @sorted_set.from_array(ys)
+    for i in 0..<600 {
+      big.add(10000 + i)
+    }
+    let d_small_big = small.difference(big)
+    let e_d_small_big = small.to_array().filter(x => !big.contains(x))
+    let d_big_small = big.difference(small)
+    let e_d_big_small = big.to_array().filter(x => !small.contains(x))
+    let i_small_big = small.intersection(big)
+    let e_i_small_big = small.to_array().filter(x => big.contains(x))
+    let i_big_small = big.intersection(small)
+    let e_i_big_small = big.to_array().filter(x => small.contains(x))
+    d_small_big.to_array() == e_d_small_big &&
+    d_small_big.length() == e_d_small_big.length() &&
+    d_big_small.to_array() == e_d_big_small &&
+    d_big_small.length() == e_d_big_small.length() &&
+    i_small_big.to_array() == e_i_small_big &&
+    i_small_big.length() == e_i_small_big.length() &&
+    i_big_small.to_array() == e_i_big_small &&
+    i_big_small.length() == e_i_big_small.length()
+  })
+}
+
+///|
 test "quickcheck: set algebra laws relate the operations" {
   @quickcheck.check((input : (Array[Int], Array[Int])) => {
     let (xs, ys) = input

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -152,6 +152,26 @@ pub fn[V : Compare] SortedSet::contains(self : SortedSet[V], value : V) -> Bool 
 }
 
 ///|
+/// Returns the stored value that compares equal to `value`, if any.
+fn[V : Compare] lookup(root : Node[V]?, value : V) -> V? {
+  for node = root {
+    match node {
+      None => break None
+      Some(n) => {
+        let compare_result = value.compare(n.value)
+        if compare_result == 0 {
+          break Some(n.value)
+        } else if compare_result < 0 {
+          continue n.left
+        } else {
+          continue n.right
+        }
+      }
+    }
+  }
+}
+
+///|
 /// Returns a new set containing all elements from both sets.
 pub fn[V : Compare] SortedSet::union(
   self : SortedSet[V],
@@ -330,6 +350,16 @@ pub fn[V : Compare] SortedSet::difference(
     (None, _) => new_sorted_set()
     (_, None) => { root: copy_tree(self.root), size: self.size }
     (Some(_), Some(_)) => {
+      // The split-based merge below copies both trees, a Theta(n + m) floor
+      // that dwarfs the O(n log m) probe loop when `self` is far smaller
+      // than `src` (the result then also has at most `self.size` elements).
+      // The 1/16 cutoff keeps the probe loop ahead of the merge even in its
+      // worst case, where every probed element is inserted into the result.
+      if self.size < src.size / 16 {
+        let ret = new_sorted_set()
+        self.each(x => if !src.contains(x) { ret.add(x) })
+        return ret
+      }
       // `found_count` ends up as the number of elements shared by both sets:
       // `aux` takes every node of `a` as a split pivot, except in subtrees
       // whose matching `b` fragment is empty and therefore shares no elements.
@@ -420,6 +450,24 @@ pub fn[V : Compare] SortedSet::intersection(
   match (self.root, src.root) {
     (None, _) | (_, None) => new_sorted_set()
     (Some(_), Some(_)) => {
+      // The intersection's key set is symmetric and fits in the smaller
+      // side, so when one side is far smaller, probing with it is
+      // O(min log max) and beats the Theta(n + m) tree copies of the
+      // split-based merge (see the analogous cutoff in `difference`).
+      // The result must still carry `self`'s stored representative of each
+      // shared value (`add` replaces compare-equal values, and the split
+      // path below emits `va` from `self`), so when the probing side is
+      // `src`, each match inserts the value looked up in `self`.
+      if self.size < src.size / 16 {
+        let ret = new_sorted_set()
+        self.each(x => if src.contains(x) { ret.add(x) })
+        return ret
+      }
+      if src.size < self.size / 16 {
+        let ret = new_sorted_set()
+        src.each(x => if lookup(self.root, x) is Some(v) { ret.add(v) })
+        return ret
+      }
       // See `difference` for why `found_count` counts each shared element
       // once.
       let mut found_count = 0

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -506,3 +506,61 @@ test "@sorted_set.symmetric_difference/identical" {
     ),
   )
 }
+
+///|
+/// Compare/Eq on `Keyed` look only at `key`; `payload` records which set a
+/// stored representative came from.
+priv struct Keyed {
+  key : Int
+  payload : Int
+}
+
+///|
+impl Eq for Keyed with fn equal(self, other) {
+  self.key == other.key
+}
+
+///|
+impl Compare for Keyed with fn compare(self, other) {
+  self.key.compare(other.key)
+}
+
+///|
+fn keyed_set(keys : Array[Int], payload : Int) -> @sorted_set.SortedSet[Keyed] {
+  let s : @sorted_set.SortedSet[Keyed] = SortedSet([])
+  for k in keys {
+    s.add({ key: k, payload })
+  }
+  s
+}
+
+///|
+test "intersection and difference preserve self's stored representatives" {
+  // src far smaller (probe fallback runs over src): the result must still
+  // carry self's stored values
+  let big_self = keyed_set(Array::makei(40, i => i), 1)
+  let small_src = keyed_set([5], 2)
+  let out = big_self.intersection(small_src).to_array()
+  assert_true(out.length() == 1 && out[0].key == 5 && out[0].payload == 1)
+
+  // self far smaller (probe fallback runs over self)
+  let small_self = keyed_set([5], 1)
+  let big_src = keyed_set(Array::makei(40, i => i), 2)
+  let out2 = small_self.intersection(big_src).to_array()
+  assert_true(out2.length() == 1 && out2[0].payload == 1)
+
+  // comparable sizes (split-based merge)
+  let a = keyed_set(Array::makei(20, i => i), 1)
+  let b = keyed_set(Array::makei(20, i => i + 10), 2)
+  let shared = a.intersection(b).to_array()
+  assert_true(shared.length() == 10)
+  for v in shared {
+    assert_true(v.payload == 1)
+  }
+
+  // difference probe fallback keeps self's values
+  let lone = keyed_set([5], 1)
+  let far = keyed_set(Array::makei(40, i => i + 100), 2)
+  let out3 = lone.difference(far).to_array()
+  assert_true(out3.length() == 1 && out3[0].payload == 1)
+}


### PR DESCRIPTION
## Summary

Follow-up to #3315. Post-merge benchmarking of the split-based set operations against the old iterate+contains loops found one severe asymmetric regression: the split-based merge copies **both** operands up front (Θ(n + m)), so `small.difference(large)` went from 2.7 µs to 1.5 ms (native, 100 vs 100K elements) — the old probe loop was O(n log m) and sublinear in the larger set.

### Fix

- **`difference`**: falls back to the probe loop (`self.each` + `src.contains`) when `self.size < src.size / 16`.
- **`intersection`**: its key set is symmetric and fits in the smaller side, so either strongly smaller side probes: `self` smaller probes directly; `src` smaller probes with `src` but inserts the value **looked up in `self`**, preserving `self`'s stored representative for types whose `Compare` inspects only part of the value — the same semantics as the split path, which always emits `self`'s `va` (this subtlety was caught by Codex review, see below).
- **`symmetric_difference`**: deliberately unguarded — every element of both sides can land in the result, so the copies are inherent; measured old-vs-new wins at every shape tried (e.g. 100 vs 100K: 18.7 ms → 1.6 ms native).

### Why 1/16

The cutoff is tuned to the probe loop's **worst case** (disjoint sets: every probed element is inserted into the growing result), measured on all four backends at m = 100K:

| boundary shape | native | js | wasm-gc | wasm |
|---|---|---|---|---|
| probe loop, disjoint n=6000 | 0.88 ms | 0.66 ms | 0.55 ms | 3.6 ms |
| split merge just above cutoff | 1.60 ms | 0.78 ms | 0.68 ms | 4.0 ms |

The probe loop stays ahead of the merge in its worst case at the cutoff on every backend, while at n = m/8 the split merge already wins the same worst case (native 1.70 ms vs 1.93 ms) — so 1/16 is the conservative choice. Just below the cutoff the guarded API is at parity with a hand-written probe loop (266 µs vs 271 µs native at n=6000): the guard adds no measurable overhead.

### Measured effect (old loop vs guarded API; native / js / wasm-gc / wasm)

| case | before (unguarded merge) | after |
|---|---|---|
| `difference` 100 vs 100K | 1.5 ms / 0.87 ms / 0.69 ms / 3.8 ms | **2.2 µs / 2.3 µs / 1.8 µs / 11.5 µs** (parity with old) |
| `intersection` 100K vs 100 | old code itself took 1.25 ms / 2.3 ms / 1.2 ms / 3.7 ms | **10 µs / 7 µs / 6 µs / 34 µs** |
| equal-size 100K, 50% overlap | — | unchanged split path, 2.4–9.1x faster than old loops |

### Tests

- QuickCheck property forcing the asymmetric fallback in **both operand orders** against the filter model (content, order, size).
- Whitebox invariant scenarios (BST bounds, AVL balance, cached heights, size field, input intactness) at 30-vs-3000 sizes.
- A key-only-`Compare` payload test proving all three `intersection` paths and the `difference` fallback emit `self`'s stored representatives.
- Mutation-verified: corrupting the `difference` fallback fails 4 tests; corrupting the `intersection` fallback fails 6; re-introducing the representative bug fails the `Keyed` test.

## Test plan
- [x] `sorted_set`: 70/70 on wasm-gc, native, and js
- [x] `moon check --warn-list +unnecessary_annotation` clean, `moon fmt` applied
- [x] `moon info`: no public API change
- [x] Codex CLI review, 4 rounds: rounds 1–2 at `xhigh` (representative-preservation blocker fixed and re-verified), rounds 3–4 at `ultra` (no code/API/test findings; one commit-message legend inconsistency fixed) — see review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
