### PR TITLE
perf(list): single-pass two-pointer has_suffix; rename is_prefix/is_suffix with deprecated aliases

### DIFF
--- a/list/README.mbt.md
+++ b/list/README.mbt.md
@@ -364,8 +364,8 @@ test {
 ///|
 test {
   let list = @list.List([1, 2, 3, 4, 5])
-  @test.assert_eq(list.is_prefix(List([1, 2, 3])), true)
-  @test.assert_eq(list.is_suffix(List([4, 5])), true)
+  @test.assert_eq(list.has_prefix(List([1, 2, 3])), true)
+  @test.assert_eq(list.has_suffix(List([4, 5])), true)
 }
 ```
 

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1733,10 +1733,11 @@ pub fn[A : Eq] List::remove(self : List[A], elem : A) -> List[A] {
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(@list.List([1, 2, 3, 4, 5]).is_prefix(List([1, 2, 3])), true)
+///   @test.assert_eq(@list.List([1, 2, 3, 4, 5]).has_prefix(List([1, 2, 3])), true)
 /// }
 /// ```
-pub fn[A : Eq] List::is_prefix(self : List[A], prefix : List[A]) -> Bool {
+#alias(is_prefix, deprecated)
+pub fn[A : Eq] List::has_prefix(self : List[A], prefix : List[A]) -> Bool {
   for a = self, b = prefix {
     match (a, b) {
       (_, Empty) => break true
@@ -1758,11 +1759,41 @@ pub fn[A : Eq] List::is_prefix(self : List[A], prefix : List[A]) -> Bool {
 ///
 /// ```mbt check
 /// test {
-///   @test.assert_eq(@list.List([1, 2, 3, 4, 5]).is_suffix(List([3, 4, 5])), true)
+///   @test.assert_eq(@list.List([1, 2, 3, 4, 5]).has_suffix(List([3, 4, 5])), true)
 /// }
 /// ```
-pub fn[A : Eq] List::is_suffix(self : List[A], suffix : List[A]) -> Bool {
-  self.rev().is_prefix(suffix.rev())
+#alias(is_suffix, deprecated)
+pub fn[A : Eq] List::has_suffix(self : List[A], suffix : List[A]) -> Bool {
+  guard suffix is More(_) else { return true }
+  // One pass, no allocation. First advance `lead` one node per `suffix`
+  // node, so `lead` ends up `suffix.length()` nodes into `self` (or proves
+  // the suffix is longer than the list). Then slide `lag` (from the start)
+  // and `lead` together: when `lead` falls off the end, `lag` is exactly
+  // `suffix.length()` nodes from the end — the only window where the suffix
+  // can match — and an element-wise comparison of that equal-length window
+  // decides. List `==` is deliberately not used for the window: its
+  // physical-equality shortcut would declare a NaN-carrying list a suffix
+  // of itself, changing the observable element-wise behavior.
+  for lead = self, probe = suffix {
+    match (lead, probe) {
+      (_, Empty) =>
+        break for lag = self, ahead = lead {
+          match (lag, ahead) {
+            (_, Empty) => break lag.has_prefix(suffix)
+            (More(_, tail=lag_tail), More(_, tail=ahead_tail)) =>
+              continue lag_tail, ahead_tail
+            (Empty, More(_)) =>
+              // `ahead` starts deeper in the same list than `lag` and both
+              // advance together, so `ahead` empties first; this arm only
+              // satisfies exhaustiveness.
+              break false
+          }
+        }
+      (Empty, More(_)) => break false
+      (More(_, tail=lead_tail), More(_, tail=probe_tail)) =>
+        continue lead_tail, probe_tail
+    }
+  }
 }
 
 ///|

--- a/list/list_test.mbt
+++ b/list/list_test.mbt
@@ -581,16 +581,16 @@ test "remove" {
 }
 
 ///|
-test "is_prefix" {
+test "has_prefix" {
   debug_inspect(
-    @list.List([1, 2, 3, 4, 5]).is_prefix(List([1, 2, 3])),
+    @list.List([1, 2, 3, 4, 5]).has_prefix(List([1, 2, 3])),
     content="true",
   )
   debug_inspect(
-    @list.List([1, 2, 3, 4, 5]).is_prefix(List([3, 2, 3])),
+    @list.List([1, 2, 3, 4, 5]).has_prefix(List([3, 2, 3])),
     content="false",
   )
-  debug_inspect(@list.empty().is_prefix(List([1, 2, 3])), content="false")
+  debug_inspect(@list.empty().has_prefix(List([1, 2, 3])), content="false")
 }
 
 ///|
@@ -601,13 +601,13 @@ test "equal" {
 }
 
 ///|
-test "is_suffix" {
+test "has_suffix" {
   debug_inspect(
-    @list.List([1, 2, 3, 4, 5]).is_suffix(List([3, 4, 5])),
+    @list.List([1, 2, 3, 4, 5]).has_suffix(List([3, 4, 5])),
     content="true",
   )
   debug_inspect(
-    @list.List([1, 2, 3, 4, 5]).is_suffix(List([3, 4, 6])),
+    @list.List([1, 2, 3, 4, 5]).has_suffix(List([3, 4, 6])),
     content="false",
   )
 }
@@ -1087,29 +1087,29 @@ test "complex list recursion safety" {
 }
 
 ///|
-test "is_prefix and is_suffix complex cases" {
+test "has_prefix and has_suffix complex cases" {
   let l = @list.List([1, 2, 3, 4, 5])
 
-  // Test is_prefix with various scenarios
-  assert_true(l.is_prefix(List([1])))
-  assert_true(l.is_prefix(List([1, 2])))
-  assert_true(l.is_prefix(List([1, 2, 3])))
-  assert_false(l.is_prefix(List([2, 3])))
-  assert_false(l.is_prefix(List([0, 1, 2])))
+  // Test has_prefix with various scenarios
+  assert_true(l.has_prefix(List([1])))
+  assert_true(l.has_prefix(List([1, 2])))
+  assert_true(l.has_prefix(List([1, 2, 3])))
+  assert_false(l.has_prefix(List([2, 3])))
+  assert_false(l.has_prefix(List([0, 1, 2])))
 
-  // Test is_suffix with various scenarios
-  assert_true(l.is_suffix(List([5])))
-  assert_true(l.is_suffix(List([4, 5])))
-  assert_true(l.is_suffix(List([3, 4, 5])))
-  assert_false(l.is_suffix(List([2, 5])))
-  assert_false(l.is_suffix(List([3, 4, 6])))
+  // Test has_suffix with various scenarios
+  assert_true(l.has_suffix(List([5])))
+  assert_true(l.has_suffix(List([4, 5])))
+  assert_true(l.has_suffix(List([3, 4, 5])))
+  assert_false(l.has_suffix(List([2, 5])))
+  assert_false(l.has_suffix(List([3, 4, 6])))
 
   // Test with empty list
   let empty : @list.List[Int] = @list.empty()
-  assert_true(empty.is_prefix(List([])))
-  assert_true(empty.is_suffix(List([])))
-  assert_true(l.is_prefix(List([])))
-  assert_true(l.is_suffix(List([])))
+  assert_true(empty.has_prefix(List([])))
+  assert_true(empty.has_suffix(List([])))
+  assert_true(l.has_prefix(List([])))
+  assert_true(l.has_suffix(List([])))
 }
 
 ///|
@@ -1200,4 +1200,41 @@ test "remove empty and head" {
 test "List default trait" {
   let ls : @list.List[Int] = Default::default()
   debug_inspect(ls, content="<List: []>")
+}
+
+///|
+test "has_suffix boundaries" {
+  let l = @list.List([1, 2, 3, 4, 5])
+  let empty : @list.List[Int] = @list.empty()
+  // empty suffixes
+  assert_true(l.has_suffix(empty))
+  assert_true(empty.has_suffix(empty))
+  // empty list, non-empty suffix
+  assert_false(empty.has_suffix(l))
+  // the whole list, and a physically shared tail
+  assert_true(l.has_suffix(l))
+  assert_true(l.has_suffix(l.drop(2)))
+  // longer than the list
+  assert_false(l.has_suffix(List([0, 1, 2, 3, 4, 5])))
+  // same length, different content
+  assert_false(l.has_suffix(List([1, 2, 3, 4, 6])))
+  assert_false(l.has_suffix(List([0, 2, 3, 4, 5])))
+  // mismatch only at the window's first element
+  assert_false(l.has_suffix(List([0, 4, 5])))
+  // single element
+  assert_true(l.has_suffix(List([5])))
+  assert_false(l.has_suffix(List([1])))
+}
+
+///|
+test "has_suffix window comparison is element-wise" {
+  // List `==` short-circuits on physical equality, but the suffix window
+  // comparison is element-wise, so a NaN-carrying list is not even its own
+  // suffix — matching the previous rev-based implementation and
+  // has_prefix's behavior.
+  let nan = 0.0 / 0.0
+  let xs = @list.List([nan])
+  assert_true(xs == xs)
+  assert_false(xs.has_suffix(xs))
+  assert_false(xs.has_prefix(xs))
 }

--- a/list/pkg.generated.mbti
+++ b/list/pkg.generated.mbti
@@ -54,13 +54,15 @@ pub fn[A] List::from_iter(Iter[A]) -> Self[A]
 pub fn[A] List::from_iter_rev(Iter[A]) -> Self[A]
 #as_free_fn
 pub fn[A : @json.FromJson] List::from_json(Json) -> Self[A] raise @json.JsonDecodeError
+#alias(is_prefix, deprecated)
+pub fn[A : Eq] List::has_prefix(Self[A], Self[A]) -> Bool
+#alias(is_suffix, deprecated)
+pub fn[A : Eq] List::has_suffix(Self[A], Self[A]) -> Bool
 pub fn[A : Hash] List::hash(Self[A]) -> Int
 pub fn[A] List::head(Self[A]) -> A?
 pub fn[A] List::intercalate(Self[Self[A]], Self[A]) -> Self[A]
 pub fn[A] List::intersperse(Self[A], A) -> Self[A]
 pub fn[A] List::is_empty(Self[A]) -> Bool
-pub fn[A : Eq] List::is_prefix(Self[A], Self[A]) -> Bool
-pub fn[A : Eq] List::is_suffix(Self[A], Self[A]) -> Bool
 #alias(iterator, deprecated)
 pub fn[A] List::iter(Self[A]) -> Iter[A]
 #alias(iterator2, deprecated)

--- a/list/quickcheck_test.mbt
+++ b/list/quickcheck_test.mbt
@@ -246,6 +246,26 @@ test "quickcheck: intersperse matches an Array reference" {
 }
 
 ///|
+test "quickcheck: has_suffix agrees with the Array reference" {
+  @quickcheck.check(
+    (input : (@list.List[Int], @list.List[Int], Int)) => {
+      let (xs, ys, k) = input
+      let a = xs.to_array()
+      let b = ys.to_array()
+      let expected = a.length() >= b.length() &&
+        a[a.length() - b.length():].to_owned() == b
+      guard xs.has_suffix(ys) == expected else { return false }
+      // Every drop of a list is one of its suffixes, both as the physically
+      // shared tail and as a structurally equal unshared copy.
+      let len = xs.length()
+      let clamped = if k < 0 { 0 } else if k > len { len } else { k }
+      xs.has_suffix(xs.drop(clamped)) && xs.has_suffix(List(a[clamped:]))
+    },
+    count=300,
+  )
+}
+
+///|
 test "quickcheck: element queries agree with the Array reference" {
   @quickcheck.check(
     (input : (@list.List[Int], Int)) => {


### PR DESCRIPTION
## Summary

Supersedes the `is_suffix` optimization proposed in #3840 (thanks @mizchi for identifying the allocation problem and the benchmark methodology) with a strictly faster single-pass version, and renames the pair to `has_prefix`/`has_suffix` to match the `String`/`Bytes` naming convention.

### Three implementations compared

| | approach | cost |
|---|---|---|
| main | `self.rev().is_prefix(suffix.rev())` | 2 reversal allocations (O(n)+O(m) nodes) |
| #3840 | `len cmp` + `drop` + `is_prefix` | allocation-free, but **2n + m** steps (two `length()` walks, then drop, then compare) |
| this PR | two-pointer lead/lag | allocation-free, **n + m** steps, no `length()` calls |

The algorithm: advance a `lead` pointer one node per `suffix` node (proving along the way that the suffix isn't longer), then slide `lead` and a `lag` pointer together; when `lead` falls off the end, `lag` sits exactly `suffix.length()` nodes from the end — the only window where the suffix can match — and an element-wise comparison of that equal-length window decides. An empty suffix returns `true` in O(1).

### Benchmarks (`moon bench --release`, n=100K, m=50K unless noted; old / #3840 / this)

| case | native | js | wasm-gc |
|---|---|---|---|
| match | 1.33 ms / 418 µs / **287 µs** | 621 / 337 / **200 µs** | 783 / 312 / **221 µs** |
| mismatch at window start | 1.34 ms / 315 µs / **184 µs** | 610 / 255 / **124 µs** | 758 / 237 / **140 µs** |
| shared-tail suffix (`l.drop(50K)`) | 1.34 ms / 394 µs / **272 µs** | 469 / 332 / **194 µs** | 745 / 318 / **211 µs** |
| tiny suffix m=10 | 833 µs / 305 µs / **154 µs** | — | — |
| empty suffix | 817 µs / 302 µs / **6.7 ns** | 260 / 234 µs / **8.1 ns** | 263 / 237 µs / **7.5 ns** |

1.4–2x faster than #3840's version on every shape, 3–5x faster than main, and O(1) instead of O(n) for the empty suffix.

### Rename

`is_suffix` → `has_suffix`, `is_prefix` → `has_prefix`, each keeping the old name as `#alias(is_..., deprecated)` — the same convention as `String::has_suffix` (which itself carries `ends_with` as a deprecated alias) and `Bytes::has_prefix`/`has_suffix`. All in-repo call sites (tests, docstrings, README) are migrated; a repo-wide grep found no callers outside the `list` package.

### Semantics note (caught by Codex review)

An earlier draft compared the window with List `==`, whose physical-equality shortcut would have made a NaN-carrying list a suffix of itself — observably diverging from the old element-wise behavior. The window comparison is element-wise (`has_prefix` on the equal-length window), reproducing the old semantics exactly, and a NaN regression test pins this.

### Tests

- Boundary coverage: empty/whole/longer/same-length-different/window-start-mismatch/single-element/physically-shared-tail.
- NaN test pinning the element-wise window semantics.
- QuickCheck property: `has_suffix` against an Array-slice reference model, plus the law that every `drop(k)` is a suffix — both as the physically shared tail and as an unshared copy.
- Mutation-verified: skipping the window comparison fails 4 tests; accepting a longer suffix fails 2; the NaN test fails on the `==`-based window.

## Test plan
- [x] `list`: 226/226 on wasm-gc and js, 218/218 on native (`panic_test.mbt` is excluded on native)
- [x] `moon check --warn-list +unnecessary_annotation` clean, `moon fmt` applied
- [x] `moon info`: `.mbti` change is exactly the rename + deprecated aliases
- [x] Codex CLI review (2 rounds, reasoning `xhigh`): round-1 blocking issue (NaN/physical-equality semantics) fixed and re-verified; round-2 sign-off — see review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
