### PR TITLE
refactor: use `<+` template writing in library code

### DIFF
--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -325,17 +325,25 @@ pub fn BytesView::iter2(self : BytesView) -> Iter2[Int, Byte] {
 }
 
 ///|
-pub impl Show for BytesView with fn output(self, logger) {
-  logger.write_string("b\"")
+/// Writes the bytes with printable ASCII kept as-is and everything else
+/// rendered as `\xHH`, without the surrounding `b"`/`"`. Shared by `Show`,
+/// which adds the quotes, and `ToJson`, which does not.
+///
+/// Generic over the logger rather than taking `&Logger` so that `ToJson`'s
+/// concrete `StringBuilder` keeps direct dispatch.
+fn[L : Logger] BytesView::escape_to(self : BytesView, logger : L) -> Unit {
   for byte in self {
     if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
       logger.write_char(byte.to_char())
     } else {
-      logger.write_string("\\x")
-      logger.write_string(byte.to_hex())
+      logger <+ "\\x\{l => l.write_string(byte.to_hex())}"
     }
   }
-  logger.write_string("\"")
+}
+
+///|
+pub impl Show for BytesView with fn output(self, logger) {
+  logger <+ "b\"\{l => self.escape_to(l)}\""
 }
 
 ///|
@@ -577,14 +585,7 @@ pub fn BytesView::to_owned(self : BytesView) -> Bytes {
 ///|
 pub impl ToJson for BytesView with fn to_json(self) -> Json {
   let sb = StringBuilder()
-  for byte in self {
-    if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
-      sb.write_char(byte.to_char())
-    } else {
-      sb.write_string("\\x")
-      sb.write_string(byte.to_hex())
-    }
-  }
+  self.escape_to(sb)
   Json::string(sb.to_string())
 }
 

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -498,9 +498,7 @@ fn Char::escape_to(self : Char, logger : &Logger, quote? : Bool = true) -> Unit 
     ' '..='~' => logger.write_char(self)
     _ =>
       if !self.is_printable() {
-        logger.write_string("\\u{")
-        logger.write_string(self.to_hex())
-        logger.write_char('}')
+        logger <+ "\\u{\{l => l.write_string(self.to_hex())}}"
       } else {
         logger.write_char(self)
       }

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -81,8 +81,7 @@ fn base64_encode(data : FixedArray[Byte]) -> String {
     let x1 = base64[(b0 & 0x03) << 4]
     buf.write_char(x0.to_char())
     buf.write_char(x1.to_char())
-    buf.write_char('=')
-    buf.write_char('=')
+    buf <+ "=="
   } else if rem == 2 {
     let b0 = data[len - 2].to_int()
     let b1 = data[len - 1].to_int()

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1387,8 +1387,7 @@ test "iter" {
   let exb = StringBuilder()
   let mut i = 0
   iter.each(x => {
-    exb.write_string(x.to_string())
-    exb.write_char('\n')
+    exb <+ "\{x}\n"
     i += 1
   })
   assert_true(i == arr.length())

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -63,15 +63,14 @@ pub impl[X : Show] Show for Iter[X]
 
 ///|
 pub impl[X : Show] Show for Iter[X] with fn output(self, logger) {
-  logger.write_string("[")
+  logger <+ "["
   if self.next() is Some(x) {
     logger.write_object(x)
     while self.next() is Some(x) {
-      logger.write_string(", ")
-      logger.write_object(x)
+      logger <+ ", \{l => l.write_object(x)}"
     }
   }
-  logger.write_string("]")
+  logger <+ "]"
 }
 
 ///|

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -629,17 +629,15 @@ pub impl[K : Show, V : Show] Show for Map[K, V]
 
 ///|
 pub impl[K : Show, V : Show] Show for Map[K, V] with fn output(self, logger) {
-  logger.write_string("{")
+  logger <+ "{"
   for x = 0, y = self.head {
     match (x, y) {
-      (_, None) => break logger.write_string("}")
+      (_, None) => break logger <+ "}"
       (i, Some({ key, value, next, .. })) => {
         if i > 0 {
-          logger.write_string(", ")
+          logger <+ ", "
         }
-        logger.write_object(key)
-        logger.write_string(": ")
-        logger.write_object(value)
+        logger <+ "\{l => l.write_object(key)}: \{l => l.write_object(value)}"
         continue i + 1, next
       }
     }

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -191,9 +191,7 @@ fn StringView::escape_to(
       code =>
         if code < ' ' {
           flush_segment(seg, i)
-          logger.write_string("\\u{")
-          logger.write_string(code.to_byte().to_hex())
-          logger.write_char('}')
+          logger <+ "\\u{\{l => l.write_string(code.to_byte().to_hex())}}"
           continue i + 1, i + 1
         } else {
           continue i + 1, seg

--- a/diff/hunk.mbt
+++ b/diff/hunk.mbt
@@ -20,15 +20,13 @@ impl Show for Range with fn output(self, logger) {
   let mut beginning = self.0 + 1 // from array index to line number
   let len = self.1 - self.0
   if len == 1 {
-    logger.write_string(beginning.to_string())
+    logger.write_object(beginning)
   } else {
     if len == 0 {
       // empty ranges begin at line just before the range
       beginning -= 1
     }
-    logger.write_string(beginning.to_string())
-    logger.write_char(',')
-    logger.write_string(len.to_string())
+    logger <+ "\{l => l.write_object(beginning)},\{l => l.write_object(len)}"
   }
 }
 
@@ -67,7 +65,7 @@ fn HunkHeader::new(edits : ArrayView[Edit]) -> Self {
 
 ///|
 impl Show for HunkHeader with fn output(self, logger) {
-  logger.write_string("@@ -\{self.0} +\{self.1} @@")
+  logger <+ "@@ -\{self.0} +\{self.1} @@"
 }
 
 ///|

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -343,18 +343,14 @@ pub impl[K : Show, V : Show] Show for HashMap[K, V]
 
 ///|
 pub impl[K : Show, V : Show] Show for HashMap[K, V] with fn output(self, logger) {
-  logger.write_string("HashMap::from_array([")
+  logger <+ "HashMap::from_array(["
   self.eachi((i, k, v) => {
     if i > 0 {
-      logger.write_string(", ")
+      logger <+ ", "
     }
-    logger.write_string("(")
-    logger.write_object(k)
-    logger.write_string(", ")
-    logger.write_object(v)
-    logger.write_string(")")
+    logger <+ "(\{l => l.write_object(k)}, \{l => l.write_object(v)})"
   })
-  logger.write_string("])")
+  logger <+ "])"
 }
 
 ///|

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -307,19 +307,15 @@ pub fn Json::stringify(
               buf.write_string(indent_str(depth, indent))
               stack.push(Array(arr, i=0))
             }
-          String(s) => {
-            buf.write_char('\"')
-            buf.write_string(escape(s, escape_slash~))
-            buf.write_char('\"')
-          }
+          String(s) => buf <+ "\"\{b => escape_to(b, s, escape_slash~)}\""
           Number(n, repr~) =>
             match repr {
               None => buf.write_object(n)
               Some(r) => buf.write_string(r)
             }
-          True => buf.write_string("true")
-          False => buf.write_string("false")
-          Null => buf.write_string("null")
+          True => buf <+ "true"
+          False => buf <+ "false"
+          Null => buf <+ "null"
         }
         continue None
       }
@@ -358,10 +354,7 @@ pub fn Json::stringify(
                   buf.write_char(',')
                   buf.write_string(indent_str(depth, indent))
                 }
-                buf.write_char('\"')
-                buf.write_string(escape(k, escape_slash~))
-                buf.write_char('\"')
-                buf.write_char(':')
+                buf <+ "\"\{b => escape_to(b, k, escape_slash~)}\":"
                 if indent > 0 {
                   buf.write_char(' ')
                 }
@@ -383,36 +376,30 @@ pub fn Json::stringify(
 }
 
 ///|
-fn escape(str : String, escape_slash~ : Bool) -> String {
-  let buf = StringBuilder(size_hint=str.length())
+/// Writes `str` with JSON escaping applied directly to `buf`, so that callers
+/// never materialize the escaped string.
+fn escape_to(buf : &Logger, str : String, escape_slash~ : Bool) -> Unit {
   for c in str {
     match c {
-      '"' => buf.write_string("\\\"")
-      '\\' => buf.write_string("\\\\")
-      '/' =>
-        if escape_slash {
-          buf.write_string("\\/")
-        } else {
-          buf.write_char(c)
-        }
-      '\n' => buf.write_string("\\n")
-      '\r' => buf.write_string("\\r")
-      '\b' => buf.write_string("\\b")
-      '\t' => buf.write_string("\\t")
+      '"' => buf <+ "\\\""
+      '\\' => buf <+ "\\\\"
+      '/' => if escape_slash { buf <+ "\\/" } else { buf.write_char(c) }
+      '\n' => buf <+ "\\n"
+      '\r' => buf <+ "\\r"
+      '\b' => buf <+ "\\b"
+      '\t' => buf <+ "\\t"
       _ => {
         let code = c.to_int()
         if code == 0x0C {
-          buf.write_string("\\f")
+          buf <+ "\\f"
         } else if code < ' ' {
-          buf.write_string("\\u00")
-          buf.write_string(code.to_byte().to_hex())
+          buf <+ "\\u00\{b => b.write_string(code.to_byte().to_hex())}"
         } else {
           buf.write_char(c)
         }
       }
     }
   }
-  buf.to_string()
 }
 
 ///|

--- a/json/json_path.mbt
+++ b/json/json_path.mbt
@@ -49,8 +49,8 @@ pub impl Show for JsonPath with fn output(self, logger) {
     }
     for ch in token.iter() {
       match ch {
-        '~' => logger.write_string("~0")
-        '/' => logger.write_string("~1")
+        '~' => logger <+ "~0"
+        '/' => logger <+ "~1"
         _ => logger.write_char(ch)
       }
     }
@@ -60,16 +60,10 @@ pub impl Show for JsonPath with fn output(self, logger) {
   fn build_path(path : JsonPath, logger : &Logger) -> Unit {
     match path {
       Root => ()
-      Key(parent, key~) => {
-        build_path(parent, logger)
-        logger.write_char('/')
-        write_token(logger, key)
-      }
-      Index(parent, index~) => {
-        build_path(parent, logger)
-        logger.write_char('/')
-        logger.write_object(index)
-      }
+      Key(parent, key~) =>
+        logger <+ "\{l => build_path(parent, l)}/\{l => write_token(l, key)}"
+      Index(parent, index~) =>
+        logger <+ "\{l => build_path(parent, l)}/\{l => l.write_object(index)}"
     }
   }
 

--- a/json/stringify_bench_test.mbt
+++ b/json/stringify_bench_test.mbt
@@ -1,0 +1,44 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A document whose strings all need escaping, so that `stringify` spends its
+/// time in the escaping path rather than in `Map` iteration.
+fn escape_heavy_doc(count : Int) -> Json {
+  let items = []
+  for i in 0..<count {
+    items.push(
+      (
+        {
+          "name": "item \{i} with \"quotes\" and \\ backslashes",
+          "path": "/usr/local/share/item/\{i}",
+          "note": "line\nbreak\ttab",
+          "n": Json::number(i.to_double()),
+        } : Json),
+    )
+  }
+  { "items": Json::array(items) }
+}
+
+///|
+test "bench json stringify escape-heavy n=200" (it : @bench.T) {
+  let doc = escape_heavy_doc(200)
+  it.bench(() => it.keep(doc.stringify()))
+}
+
+///|
+test "bench json stringify escape-heavy indent=2 n=200" (it : @bench.T) {
+  let doc = escape_heavy_doc(200)
+  it.bench(() => it.keep(doc.stringify(indent=2)))
+}

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -35,7 +35,7 @@ pub impl Show for ParseError with fn output(self, logger) {
     InvalidChar({ line, column }, c) =>
       logger <+
         $|Invalid character \{c.escape()} at line \{line}, column \{column}
-    InvalidEof => logger.write_string("Unexpected end of file")
+    InvalidEof => logger <+ "Unexpected end of file"
     InvalidNumber({ line, column }, s) =>
       logger <+
         $|Invalid number \{s} at line \{line}, column \{column}
@@ -43,9 +43,8 @@ pub impl Show for ParseError with fn output(self, logger) {
       logger <+
         $|Invalid escape sequence in identifier at line \{line}, column \{column}
     DepthLimitExceeded =>
-      logger.write_string(
-        "Depth limit exceeded, please increase the max_nesting_depth parameter",
-      )
+      logger <+
+        $|Depth limit exceeded, please increase the max_nesting_depth parameter
   }
 }
 
@@ -57,34 +56,18 @@ pub impl Show for Json
 #warnings("-deprecated")
 pub impl Show for Json with fn output(self, logger) {
   match self {
-    Null => logger.write_string("Null")
-    True => logger.write_string("True")
-    False => logger.write_string("False")
+    Null => logger <+ "Null"
+    True => logger <+ "True"
+    False => logger <+ "False"
     Number(n, repr~) => {
-      logger.write_string("Number(")
-      Show::output(n, logger)
+      logger <+ "Number(\{l => Show::output(n, l)}"
       if repr is Some(repr) {
-        logger.write_string(", repr=")
-        logger.write_string("Some(")
-        Show::output(repr, logger)
-        logger.write_string(")")
+        logger <+ ", repr=Some(\{l => Show::output(repr, l)})"
       }
-      logger.write_string(")")
+      logger <+ ")"
     }
-    String(s) => {
-      logger.write_string("String(")
-      Show::output(s, logger)
-      logger.write_string(")")
-    }
-    Array(a) => {
-      logger.write_string("Array(")
-      Show::output(a, logger)
-      logger.write_string(")")
-    }
-    Object(o) => {
-      logger.write_string("Object(")
-      Show::output(o, logger)
-      logger.write_string(")")
-    }
+    String(s) => logger <+ "String(\{l => Show::output(s, l)})"
+    Array(a) => logger <+ "Array(\{l => Show::output(a, l)})"
+    Object(o) => logger <+ "Object(\{l => Show::output(o, l)})"
   }
 }

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -437,13 +437,13 @@ pub impl[K : Show] Show for Set[K]
 
 ///|
 pub impl[K : Show] Show for Set[K] with fn output(self, logger) {
-  logger.write_string("{")
+  logger <+ "{"
   for i = 0, curr = self.head {
     match (i, curr) {
-      (_, None) => break logger.write_string("}")
+      (_, None) => break logger <+ "}"
       (i, Some({ key, next, .. })) => {
         if i > 0 {
-          logger.write_string(", ")
+          logger <+ ", "
         }
         logger.write_object(key)
         continue i + 1, next

--- a/v128/simd_basic.mbt
+++ b/v128/simd_basic.mbt
@@ -29,14 +29,19 @@ pub impl Eq for V128 with fn not_equal(self : V128, other : V128) -> Bool {
 }
 
 ///|
-fn u64_hex(value : UInt64) -> String {
+fn u64_hex_to(logger : &Logger, value : UInt64) -> Unit {
   let digits = value.to_string(radix=16)
-  let buf = StringBuilder::new()
-  buf.write_string("0x")
+  logger <+ "0x"
   for _ in digits.length()..<16 {
-    buf.write_char('0')
+    logger.write_char('0')
   }
-  buf.write_string(digits)
+  logger.write_string(digits)
+}
+
+///|
+fn u64_hex(value : UInt64) -> String {
+  let buf = StringBuilder::new()
+  u64_hex_to(buf, value)
   buf.to_string()
 }
 
@@ -46,11 +51,8 @@ fn u64_hex(value : UInt64) -> String {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub impl Show for V128 with fn output(self : V128, logger) {
-  logger.write_string("V128(")
-  logger.write_string(u64_hex(lo(self)))
-  logger.write_string(", ")
-  logger.write_string(u64_hex(hi(self)))
-  logger.write_string(")")
+  logger <+
+    "V128(\{l => u64_hex_to(l, lo(self))}, \{l => u64_hex_to(l, hi(self))})"
 }
 
 ///|


### PR DESCRIPTION
Part 2 of 2. **Library code only** — the test-file half is #4111, which can
land independently.

Sweep replacing `write_string` / `write_char` / `write_object` sequences with
the `<+` template-writing operator, continuing what 1c47134d ("Use
interpolation for fixed output builders") started in `show.mbt`,
`json/types.mbt` and `ref.mbt`.

15 files, **-130 / +126** lines (+44 of which is the new benchmark, so the
library code itself is a net -48).

## Which form, and why

I benchmarked the three candidate spellings before sweeping, because they are
*not* equivalent. All numbers below are `moon bench`, 2000 writes per
iteration, native and js:

| spelling | native | js |
| --- | --- | --- |
| `write_string("(") ; write_object(a) ; …` (baseline) | 50.1 µs | 71.4 µs |
| `logger <+ "(\{a}, \{b})"` | 70.7 µs (**+41%**) | 100.3 µs (**+40%**) |
| `logger <+ "(\{l => l.write_object(a)}, …)"` | 49.1 µs (par) | 75.3 µs (par) |
| `write_string("x=\{a}, y=\{b}")` (baseline) | 155.5 µs | 95.1 µs |
| `logger <+ "x=\{a}, y=\{b}"` | 66.3 µs (**2.3x**) | 98.9 µs (par) |
| `logger <+ "x=\{l => …}, y=\{l => …}"` | 45.8 µs (**3.4x**) | 64.5 µs (**1.5x**) |
| `write_string("aaaa"); write_string("bbbb"); write_string("cccc")` | 28.9 µs | 27.3 µs |
| `logger <+ "aaaabbbbcccc"` | 13.6 µs (**2.1x**) | 6.7 µs (**4.1x**) |

The reason is in the desugaring. `\{x}` becomes
`write_string_interpolation(x)`, whose parameter is `&Show`, so every
interpolation coerces its argument into a trait object — one allocation per
hole, on every backend:

```js
logger.method_table.method_4(logger.self,
  { self: a, method_table: Int_as_Show });   // <- allocation
```

The inline-writer form `\{l => …}` hits the compiler's `make_inline_write`
path instead and desugars to `writer |> (l => …)`, which emits *byte
identical* code to the direct call it replaces. And adjacent literal chunks
are concatenated at compile time, so a run of literal writes collapses into
one `write_string`.

So the sweep uses:

* `buf.write_string("...\{x}...")` → `buf <+ "...\{x}..."` — the old form
  built a throwaway `StringBuilder` + `String` and then copied it in.
* runs of adjacent literal writes → one template.
* `write_object(x)` → `\{l => l.write_object(x)}`, **not** `\{x}`, so
  monomorphic `Show` dispatch is preserved. (#4111 uses plain `\{x}` in test
  bodies, where readability wins and one box per element in a three-element
  assertion is irrelevant.)

## Streaming instead of materializing

Three helpers grew writer variants so callers stop building intermediate
strings:

* `json`: `escape(str, escape_slash~) -> String` → `escape_to(buf, str,
  escape_slash~)`. `stringify` now escapes straight into the output builder
  rather than allocating one escaped `String` per key and per string value.
* `v128`: added `u64_hex_to(logger, value)`; `u64_hex` keeps its `String`
  signature for the `Debug` impl.
* `builtin`: `BytesView::escape_to` — this also de-duplicates the escaping
  loop, which `Show` and `ToJson` each had their own copy of. It is generic
  over the logger (`fn[L : Logger]`) rather than taking `&Logger`, so
  `ToJson`'s concrete `StringBuilder` keeps direct dispatch; taking `&Logger`
  there measured ~5% slower on `Bytes::to_json` (92.8 µs → 98.1 µs native,
  4 KiB input), and the generic version is back at 93.3 µs.

`json/stringify_bench_test.mbt` is added here so the claim is reproducible.
Escape-heavy document, n = 200:

|  | before | after | |
| --- | --- | --- | --- |
| native | 152.0 µs | 122.8 µs | **1.24x** |
| native, `indent=2` | 158.4 µs | 131.5 µs | **1.20x** |
| js | 193.6 µs | 175.8 µs | **1.10x** |
| js, `indent=2` | 206.3 µs | 186.2 µs | **1.11x** |

## Deliberately not touched

* **`builtin/tuple_show.mbt`** (150 `write_string` calls, the single biggest
  candidate). Keeping it allocation-free needs the inline-writer form, and
  the 16-tuple impl would become one ~450 character string literal that
  `moon fmt` cannot break. The five-line-per-impl status quo reads better.
* **Isolated `write_string("literal")` calls.** `x <+ "lit"` desugars to
  exactly `x.write_string("lit")`, so converting the ~250 standalone ones
  would be pure diff noise. They are converted only inside `Show` impls that
  this PR was already rewriting.
* **Isolated `write_string(x.to_string())`.** For types whose `Show` only
  implements `to_string` (`Int`, `Byte`, …), the default `output` *is*
  `write_string(self.to_string())` — so `<+ "\{x}"` would allocate the same
  string and add a box on top.

## Follow-up worth considering (not in this PR)

The pre-existing `<+ "\{x}"` sites in `builtin/show.mbt` (`Show for X?`,
`Show for Result`), `ref.mbt` and `cmp.mbt` pay that ~40% trait-object cost
today. Either switching them to the inline-writer form, or teaching the
desugarer to emit a monomorphic `write_object` when the interpolated
expression's `Show` instance is statically known, would recover it — the
latter would make plain `\{x}` the right answer everywhere and is the better
fix.

## Verification

* `moon check --deny-warn --target all`
* `moon test` on wasm / wasm-gc / js / native — 7458 / 7459 / 7403 / 7375
  passed, 0 failed (re-run after the split)
* `moon info --target wasm,wasm-gc,js,native` — no `.mbti` drift (every new
  helper is package-private)
* `moon fmt` clean

## Review

Reviewed by Codex CLI (`codex exec`, read-only sandbox) against the desugaring
in `parsing_util.ml`. Verdict: approve, no correctness or shipped-path
performance blocker. It independently confirmed output equivalence for
`Show for Json` (including the `repr=Some(...)` case), both `stringify` escape
sites, the `json_path` recursion moved into interpolation holes, the
`BytesView` quote split between `Show` and `ToJson`, `diff/hunk`'s
`write_string(x.to_string())` → `write_object(x)`, `V128`'s padding and word
order, and the literal-brace vs `\{` escaping in the `\u{...}` rewrites.

Its two findings are addressed: the `&Logger` dispatch on
`BytesView::to_json` is fixed by the generic signature, and the plain-`\{x}`
holes it flagged were all in test code, which now lives in #4111 with that
choice called out as deliberate.

Note that the review ran against the pre-split commit (all 33 files); the
library hunks here are unchanged from what it read.
