### PR TITLE
refactor(test): use `<+` template writing in test files

### DIFF
--- a/bigint/bigint_nonjs_wbtest.mbt
+++ b/bigint/bigint_nonjs_wbtest.mbt
@@ -17,9 +17,8 @@ struct MyBigInt(BigInt)
 
 ///|
 impl Show for MyBigInt with fn output(self, logger) {
-  logger.write_string(
-    "{limbs : \{@debug.Repr(self.limbs)}, sign : \{@debug.Repr(self.sign)}, len : \{self.len} }",
-  )
+  logger <+
+    "{limbs : \{@debug.Repr(self.limbs)}, sign : \{@debug.Repr(self.sign)}, len : \{self.len} }"
 }
 
 ///|

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -245,12 +245,7 @@ test "array_eachi" {
 test "array_rev_eachi" {
   let arr = ['a', 'b', 'c']
   let buf = StringBuilder()
-  arr.rev_eachi((i, x) => {
-    buf.write_object(i)
-    buf.write_string(": ")
-    buf.write_object(x)
-    buf.write_string("\n")
-  })
+  arr.rev_eachi((i, x) => buf <+ "\{i}: \{x}\n")
   inspect(
     buf,
     content=(

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -150,7 +150,7 @@ test "map_while1" {
   let exb = StringBuilder(size_hint=0)
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
-  .each(x => exb.write_string("\{x}\n"))
+  .each(x => exb <+ "\{x}\n")
   inspect(
     exb,
     content=(
@@ -169,7 +169,7 @@ test "map_while2" {
   iter
   .map_while(x => if x != 4 { Some(x) } else { None })
   .concat([|6|])
-  .each(x => exb.write_string("\{x}\n"))
+  .each(x => exb <+ "\{x}\n")
   inspect(
     exb,
     content=(

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -328,7 +328,7 @@ test "iter" {
   .iter()
   .each(e => {
     let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
+    buf <+ "[\{k}-\{v}]"
   })
   inspect(buf, content="[1-one][2-two][3-three]")
   buf.reset()
@@ -337,7 +337,7 @@ test "iter" {
   .take(2)
   .each(e => {
     let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
+    buf <+ "[\{k}-\{v}]"
   })
   inspect(buf, content="[1-one][2-two]")
 }
@@ -348,7 +348,7 @@ test "iter order" {
   m["three"] = 3
   m["two"] = 2
   let buf = StringBuilder(size_hint=0)
-  m.each((k, v) => buf.write_string("[\{k}-\{v}]"))
+  m.each((k, v) => buf <+ "[\{k}-\{v}]")
   inspect(buf.to_string(), content="[one-1][three-3][two-2]")
 }
 
@@ -641,8 +641,7 @@ fn[K : Show, V : Show] Map::_debug_entries(self : Map[K, V]) -> String {
     }
     match entry {
       None => buf.write_char('_')
-      Some({ psl, key, value, .. }) =>
-        buf.write_string("(\{psl},\{key},\{value})")
+      Some({ psl, key, value, .. }) => buf <+ "(\{psl},\{key},\{value})"
     }
   }
   buf.to_string()

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -109,7 +109,7 @@ test "StringView core operations" {
   let buf = StringBuilder()
   let it = view.iter2()
   while it.next() is Some((i, ch)) {
-    buf.write_string("\{i}:\{ch};")
+    buf <+ "\{i}:\{ch};"
   }
   inspect(buf.to_string(), content="0:b;1:😀;2:c;")
   let from_arr = StringView::from_array(['x', 'y'])

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -101,8 +101,7 @@ test "iter" {
   dv
   .iter()
   .each(x => {
-    buf.write_string(x.to_string())
-    buf.write_char('\n')
+    buf <+ "\{x}\n"
     i += 1
   })
   @test.assert_eq(i, dv.length())

--- a/immut/priority_queue/priority_queue_test.mbt
+++ b/immut/priority_queue/priority_queue_test.mbt
@@ -62,10 +62,10 @@ test "to_array" {
 test "as_iter" {
   let buf = StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
-  v.iter().each(e => buf.write_string("[\{e}]"))
+  v.iter().each(e => buf <+ "[\{e}]")
   inspect(buf, content="[3][2][1]")
   buf.reset()
-  v.iter().take(2).each(e => buf.write_string("[\{e}]"))
+  v.iter().take(2).each(e => buf <+ "[\{e}]")
   inspect(buf, content="[3][2]")
 }
 
@@ -73,10 +73,10 @@ test "as_iter" {
 test "iter" {
   let buf = StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
-  v.iter().each(e => buf.write_string("[\{e}]"))
+  v.iter().each(e => buf <+ "[\{e}]")
   inspect(buf, content="[3][2][1]")
   buf.reset()
-  v.iter().take(2).each(e => buf.write_string("[\{e}]"))
+  v.iter().take(2).each(e => buf <+ "[\{e}]")
   inspect(buf, content="[3][2]")
 }
 

--- a/immut/sorted_map/map_test.mbt
+++ b/immut/sorted_map/map_test.mbt
@@ -84,7 +84,7 @@ test "iter_take_each" {
   .iter()
   .each(e => {
     let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
+    buf <+ "[\{k}-\{v}]"
   })
   inspect(buf, content="[1-one][2-two][3-three]")
   buf.reset()
@@ -93,7 +93,7 @@ test "iter_take_each" {
   .take(2)
   .each(e => {
     let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
+    buf <+ "[\{k}-\{v}]"
   })
   inspect(buf, content="[1-one][2-two]")
 }
@@ -208,7 +208,7 @@ test "iterator" {
   .iter()
   .each(e => {
     let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
+    buf <+ "[\{k}-\{v}]"
   })
   inspect(buf, content="[1-one][2-two][3-three]")
   buf.reset()
@@ -217,7 +217,7 @@ test "iterator" {
   .take(2)
   .each(e => {
     let (k, v) = e
-    buf.write_string("[\{k}-\{v}]")
+    buf <+ "[\{k}-\{v}]"
   })
   inspect(buf, content="[1-one][2-two]")
 }

--- a/immut/sorted_map/utils_test.mbt
+++ b/immut/sorted_map/utils_test.mbt
@@ -131,14 +131,10 @@ test "iter" {
     |> @sorted_map.SortedMap
   let buf = StringBuilder()
   for k, v in map {
-    buf.write_object(k)
-    buf.write_string(": ")
-    buf.write_object(v)
-    buf.write_string("\n")
+    buf <+ "\{k}: \{v}\n"
   }
   for k, v in map {
-    buf.write_string("(\{k}, \{Repr(v)})")
-    buf.write_string("\n")
+    buf <+ "(\{k}, \{Repr(v)})\n"
   }
   inspect(
     buf,
@@ -367,7 +363,7 @@ test "range matching all elements" {
   let map = @sorted_map.SortedMap([(1, "a"), (2, "b"), (3, "c")])
   let buf = StringBuilder()
   for k, v in map.range(low=0, high=10) {
-    buf.write_string("[\{k},\{v}]")
+    buf <+ "[\{k},\{v}]"
   }
   inspect(buf, content="[1,a][2,b][3,c]")
 }
@@ -383,7 +379,7 @@ test "range partial match" {
   ])
   let buf = StringBuilder()
   for k, v in map.range(low=2, high=4) {
-    buf.write_string("[\{k},\{v}]")
+    buf <+ "[\{k},\{v}]"
   }
   inspect(buf, content="[2,b][3,c][4,d]")
 }
@@ -399,7 +395,7 @@ test "range with single element" {
   ])
   let buf = StringBuilder()
   for k, v in map.range(low=3, high=3) {
-    buf.write_string("[\{k},\{v}]")
+    buf <+ "[\{k},\{v}]"
   }
   inspect(buf, content="[3,c]")
 }
@@ -415,7 +411,7 @@ test "range at left boundary" {
   ])
   let buf = StringBuilder()
   for k, v in map.range(low=1, high=2) {
-    buf.write_string("[\{k},\{v}]")
+    buf <+ "[\{k},\{v}]"
   }
   inspect(buf, content="[1,a][2,b]")
 }
@@ -431,7 +427,7 @@ test "range at right boundary" {
   ])
   let buf = StringBuilder()
   for k, v in map.range(low=4, high=5) {
-    buf.write_string("[\{k},\{v}]")
+    buf <+ "[\{k},\{v}]"
   }
   inspect(buf, content="[4,d][5,e]")
 }
@@ -447,7 +443,7 @@ test "range with gaps in data" {
   ])
   let buf = StringBuilder()
   for k, v in map.range(low=2, high=8) {
-    buf.write_string("[\{k},\{v}]")
+    buf <+ "[\{k},\{v}]"
   }
   inspect(buf, content="[3,c][5,e][7,g]")
 }
@@ -507,7 +503,7 @@ test "range with non-existent boundaries" {
   let map = @sorted_map.SortedMap([(2, "b"), (4, "d"), (6, "f"), (8, "h")])
   let buf = StringBuilder()
   for k, v in map.range(low=3, high=7) {
-    buf.write_string("[\{k},\{v}]")
+    buf <+ "[\{k},\{v}]"
   }
   inspect(buf, content="[4,d][6,f]")
 }

--- a/immut/vector/vector_test.mbt
+++ b/immut/vector/vector_test.mbt
@@ -135,10 +135,10 @@ test "from_json rejects invalid input" {
 test "iter" {
   let buf = StringBuilder(size_hint=20)
   let v = @vector.from_array([1, 2, 3])
-  v.iter().each(e => buf.write_string("[\{e}]"))
+  v.iter().each(e => buf <+ "[\{e}]")
   inspect(buf, content="[1][2][3]")
   buf.reset()
-  v.iter().take(2).each(e => buf.write_string("[\{e}]"))
+  v.iter().take(2).each(e => buf <+ "[\{e}]")
   inspect(buf, content="[1][2]")
 }
 

--- a/json/number_bench_test.mbt
+++ b/json/number_bench_test.mbt
@@ -34,8 +34,7 @@ fn make_float_array_json(count : Int) -> String {
     if i > 0 {
       buf.write_char(',')
     }
-    buf.write_string((i * 2654435).to_string())
-    buf.write_string(".125e-2")
+    buf <+ "\{i * 2654435}.125e-2"
   }
   buf.write_char(']')
   buf.to_string()

--- a/option/option_test.mbt
+++ b/option/option_test.mbt
@@ -186,12 +186,7 @@ test "compare" {
 test "iter" {
   let x = Option::Some(42)
   let exb = StringBuilder(size_hint=0)
-  x
-  .iter()
-  .each(x => {
-    exb.write_string(x.to_string())
-    exb.write_char('\n')
-  })
+  x.iter().each(x => exb <+ "\{x}\n")
   inspect(
     exb,
     content=(
@@ -201,12 +196,7 @@ test "iter" {
   )
   exb.reset()
   let y : Int? = None
-  y
-  .iter()
-  .each(x => {
-    exb.write_string(x.to_string())
-    exb.write_char('\n')
-  })
+  y.iter().each(x => exb <+ "\{x}\n")
   inspect(exb, content="")
 }
 

--- a/priority_queue/priority_queue_test.mbt
+++ b/priority_queue/priority_queue_test.mbt
@@ -67,12 +67,12 @@ test "iter" {
   let buf = StringBuilder(size_hint=20)
   let v = @priority_queue.from_array([1, 2, 3])
   for e in v {
-    buf.write_string("[\{e}]")
+    buf <+ "[\{e}]"
   }
   inspect(buf, content="[3][2][1]")
   buf.reset()
   for e in v.iter().take(2) {
-    buf.write_string("[\{e}]")
+    buf <+ "[\{e}]"
   }
   inspect(buf, content="[3][2]")
 }

--- a/set/linked_hash_set_test.mbt
+++ b/set/linked_hash_set_test.mbt
@@ -165,10 +165,10 @@ test "each" {
 test "iter" {
   let buf = StringBuilder(size_hint=20)
   let map = @set.Set(["a", "b", "c"])
-  map.iter().each(e => buf.write_string("[\{e}]"))
+  map.iter().each(e => buf <+ "[\{e}]")
   inspect(buf, content="[a][b][c]")
   buf.reset()
-  map.iter().take(2).each(e => buf.write_string("[\{e}]"))
+  map.iter().take(2).each(e => buf <+ "[\{e}]")
   inspect(buf, content="[a][b]")
 }
 

--- a/sorted_map/map_test.mbt
+++ b/sorted_map/map_test.mbt
@@ -111,7 +111,7 @@ test "size" {
 test "each" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
   let buf = StringBuilder()
-  map.each((k, v) => buf.write_string("\{k}\{v}"))
+  map.each((k, v) => buf <+ "\{k}\{v}")
   inspect(buf.to_string(), content="1a2b3c")
 }
 
@@ -119,7 +119,7 @@ test "each" {
 test "eachi" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
   let buf = StringBuilder()
-  map.eachi((i, k, v) => buf.write_string("[\{i}]\{k}\{v}"))
+  map.eachi((i, k, v) => buf <+ "[\{i}]\{k}\{v}")
   inspect(buf.to_string(), content="[0]1a[1]2b[2]3c")
 }
 
@@ -209,7 +209,7 @@ test "iter2" {
   let map = @sorted_map.from_array([(3, "c"), (2, "b"), (1, "a")])
   let buf = StringBuilder()
   for k, v in map {
-    buf.write_string("[\{k}\{v}]")
+    buf <+ "[\{k}\{v}]"
   }
   inspect(buf, content="[1a][2b][3c]")
 }

--- a/sorted_set/set_test.mbt
+++ b/sorted_set/set_test.mbt
@@ -99,7 +99,7 @@ test "each" {
 test "eachi" {
   let set = @sorted_set.from_array([7, 2, 9, 4, 5, 6, 3, 8, 1])
   let result = StringBuilder(size_hint=10)
-  set.eachi((i, x) => result.write_string("[\{i}-\{x}]"))
+  set.eachi((i, x) => result <+ "[\{i}-\{x}]")
   inspect(
     result.to_string(),
     content="[0-1][1-2][2-3][3-4][4-5][5-6][6-7][7-8][8-9]",

--- a/strconv/double_differential_test.mbt
+++ b/strconv/double_differential_test.mbt
@@ -85,10 +85,7 @@ fn print_probe(bits : UInt64) -> String {
 fn batch(inputs : Array[String]) -> String {
   let b = StringBuilder::new()
   for s in inputs {
-    b.write_string(s)
-    b.write_string(" => ")
-    b.write_string(parse_probe(s))
-    b.write_char('\n')
+    b <+ "\{s} => \{parse_probe(s)}\n"
   }
   b.to_string()
 }
@@ -336,10 +333,7 @@ test "print: positional vs exponent notation thresholds" {
 test "parse: long digit strings (slow path)" {
   let b = StringBuilder::new()
   for c in long_digit_cases() {
-    b.write_string(c.0)
-    b.write_string(" => ")
-    b.write_string(parse_probe(c.1))
-    b.write_char('\n')
+    b <+ "\{c.0} => \{parse_probe(c.1)}\n"
   }
   inspect(
     b.to_string(),
@@ -380,8 +374,8 @@ test "parse: random 16/17-digit significands with extreme exponents" {
     let e = (rng.next() % 601UL).to_int() - 300
     let s1 = m2.to_string() + "e" + e.to_string()
     let s2 = (m * 10UL + 5UL).to_string() + "e" + (e - 1).to_string()
-    b.write_string(s1 + " => " + parse_probe(s1) + "\n")
-    b.write_string(s2 + " => " + parse_probe(s2) + "\n")
+    b <+ "\{s1} => \{parse_probe(s1)}\n"
+    b <+ "\{s2} => \{parse_probe(s2)}\n"
   }
   inspect(
     b.to_string(),
@@ -483,7 +477,7 @@ test "parse: exact halfway fractions in [2^52, 2^53)" {
     let base = m.to_string()
     for suffix in [".5", ".49999999999999999999", ".50000000000000000001"] {
       let s = base + suffix
-      b.write_string(s + " => " + parse_probe(s) + "\n")
+      b <+ "\{s} => \{parse_probe(s)}\n"
     }
   }
   inspect(
@@ -568,8 +562,7 @@ test "print: structured bit patterns" {
   let b = StringBuilder::new()
   for e in exp_fields {
     for m in sig_fields {
-      b.write_string(print_probe((e << 52) | m))
-      b.write_char('\n')
+      b <+ "\{print_probe((e << 52) | m)}\n"
     }
   }
   // A few negative representatives.
@@ -581,8 +574,7 @@ test "print: structured bit patterns" {
        0xFFEFFFFFFFFFFFFFUL, // -max finite
        0xFFF0000000000000UL, // -inf
     ] {
-    b.write_string(print_probe(bits))
-    b.write_char('\n')
+    b <+ "\{print_probe(bits)}\n"
   }
   inspect(
     b.to_string(),
@@ -683,7 +675,7 @@ test "print: random doubles, snapshot and parse-print roundtrip" {
     }
     let d = bits.reinterpret_as_double()
     let s = d.to_string()
-    b.write_string(hex16(bits) + " => " + s + "\n")
+    b <+ "\{hex16(bits)} => \{s}\n"
     // Shortest-representation guarantee: parsing the printed string must give
     // back the exact same bits (carving out -0, which prints as "0").
     if bits != 0x8000000000000000UL {

--- a/strconv/quickcheck_test.mbt
+++ b/strconv/quickcheck_test.mbt
@@ -222,14 +222,12 @@ test "quickcheck: structured numeric strings parse to a printing fixed point" {
       if neg {
         sb.write_char('-')
       }
-      sb.write_string(int_part.to_string())
+      sb <+ "\{int_part}"
       if with_frac {
-        sb.write_char('.')
-        sb.write_string(frac_part.to_string())
+        sb <+ ".\{frac_part}"
       }
       if with_exp {
-        sb.write_char('e')
-        sb.write_string(exp.to_string())
+        sb <+ "e\{exp}"
       }
       let s = sb.to_string()
       match (try? @strconv.parse_double(s)) {


### PR DESCRIPTION
Part 1 of 2, split out of #4110. **Test and benchmark files only** — no
library code is touched, and no expected output changes.

18 files, **−85 / +52** lines.

## What changes

* `buf.write_string("...\{x}...")` → `buf <+ "...\{x}..."`. The old form built
  a throwaway `StringBuilder` + `String` for the interpolation and then copied
  the result into `buf`; the template writes the pieces straight through.

* Runs of writes collapse into one template:

  ```moonbit
  arr.rev_eachi((i, x) => {
    buf.write_object(i)
    buf.write_string(": ")
    buf.write_object(x)
    buf.write_string("\n")
  })
  // becomes
  arr.rev_eachi((i, x) => buf <+ "\{i}: \{x}\n")
  ```

  Adjacent literal chunks are concatenated by the desugarer at compile time,
  so the literal part of a run becomes a single `write_string`.

## Note on the hole form

These use the plain `\{x}` hole, which desugars to
`write_string_interpolation(x)` and coerces `x` to `&Show` — one box per hole.
That is the right trade in a three-element assertion, but not in library code,
which is why #4110 uses the inline-writer form `\{l => l.write_object(x)}`
there instead. The reasoning and benchmarks for that choice live in #4110.

## Scope boundary

Strictly `*_test.mbt` / `*_wbtest.mbt` files. `builtin/fixedarray.mbt` also has
a `<+` rewrite confined to an in-file `test {}` block, but it is a library file,
so it stays in #4110 rather than here.

## Verification

* `moon check --deny-warn --target all`
* `moon test` on wasm / wasm-gc / js / native — 7458 / 7459 / 7403 / 7375
  passed, 0 failed
* `moon fmt` clean
