### PR TITLE
refactor(builtin): deprecate `StringBuilder::new` in favor of `StringBuilder()`

### DIFF
--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -457,7 +457,7 @@ pub fn SourceLoc::to_string(Self) -> String
 pub impl Show for SourceLoc
 
 type StringBuilder
-#alias(new)
+#alias(new, deprecated)
 pub fn StringBuilder::StringBuilder(size_hint? : Int) -> Self
 pub fn StringBuilder::is_empty(Self) -> Bool
 pub fn StringBuilder::reset(Self) -> Unit

--- a/builtin/stringbuilder_buffer.mbt
+++ b/builtin/stringbuilder_buffer.mbt
@@ -29,7 +29,7 @@ struct StringBuilder {
 ///
 /// Returns a new `StringBuilder` instance with the specified initial capacity.
 ///
-#alias(new)
+#alias(new, deprecated="Use `StringBuilder()` instead")
 pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
   let initial = if size_hint < 1 { 1 } else { (size_hint + 1) / 2 }
   let data : FixedArray[UInt16] = FixedArray::make(initial, 0)

--- a/builtin/stringbuilder_concat.mbt
+++ b/builtin/stringbuilder_concat.mbt
@@ -28,7 +28,7 @@ struct StringBuilder {
 ///
 /// Returns a new `StringBuilder` instance with the specified initial capacity.
 ///
-#alias(new)
+#alias(new, deprecated="Use `StringBuilder()` instead")
 pub fn StringBuilder::StringBuilder(size_hint? : Int = 0) -> StringBuilder {
   ignore(size_hint)
   { val: "" }

--- a/diff/README.mbt.md
+++ b/diff/README.mbt.md
@@ -148,7 +148,7 @@ or markup support on purpose; a renderer is a small loop:
 test "git-style terminal colors from the public Hunk API" {
   let old = ["a", "b", "c"][:]
   let new = ["a", "x", "c"][:]
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   for h in @diff.Diff(old~, new~).group(context=1) {
     buf <+ "\u{1b}[36m\{h.header()}\u{1b}[0m\n"
     let o = h.old_view()

--- a/diff/diff_align_test.mbt
+++ b/diff/diff_align_test.mbt
@@ -349,10 +349,10 @@ fn pair_ops(a : Array[Tok], b : Array[Tok]) -> Array[Op] {
 /// Render one aligned pair's ops as the two row bodies (left = old side,
 /// right = new side), merging adjacent highlighted tokens into single runs.
 fn pair_row_html(ops : Array[Op]) -> (String, String) {
-  let l = StringBuilder::new()
-  let r = StringBuilder::new()
-  let lrun = StringBuilder::new()
-  let rrun = StringBuilder::new()
+  let l = StringBuilder()
+  let r = StringBuilder()
+  let lrun = StringBuilder()
+  let rrun = StringBuilder()
   fn flushes() {
     if !lrun.is_empty() {
       l <+ "<b class=\"wd\">\{lrun.to_string()}</b>"
@@ -478,8 +478,8 @@ test "pair_ops reconstruction property" {
     let (oa, ob) = pair
     let ta = tokenize_line(oa)
     let tb = tokenize_line(ob)
-    let left = StringBuilder::new()
-    let right = StringBuilder::new()
+    let left = StringBuilder()
+    let right = StringBuilder()
     for op in pair_ops(ta, tb) {
       match op {
         OEq(t) => {

--- a/diff/diff_html_test.mbt
+++ b/diff/diff_html_test.mbt
@@ -27,7 +27,7 @@ fn side_by_side_html(
   old~ : ArrayView[String],
   new~ : ArrayView[String],
 ) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   fn row(l : String, lc : String, r : String, rc : String) {
     buf <+
       "<tr><td class=\"\{lc}\">\{l}</td><td class=\"\{rc}\">\{r}</td></tr>\n"

--- a/diff/diff_test.mbt
+++ b/diff/diff_test.mbt
@@ -524,7 +524,7 @@ test "property: edit scripts reconstruct new from old" {
 /// (`header` + `edits` + views), the way a third-party `diff-ansi` package
 /// would: cyan hunk header, red removals, green additions (git's default look).
 fn[T] ansi_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   buf <+ "\u{1b}[36m\{h.header()}\u{1b}[0m\n"
   let old = h.old_view()
   let new = h.new_view()
@@ -553,7 +553,7 @@ fn[T] ansi_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
 /// concern — exactly why HTML stays out of core.
 fn[T] html_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
   fn esc(s : String) -> String {
-    let buf = StringBuilder::new()
+    let buf = StringBuilder()
     for c in s {
       match c {
         '&' => buf.write_string("&amp;")
@@ -569,7 +569,7 @@ fn[T] html_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
     buf <+ "<span class=\"\{cls}\">\{prefix}\{text}</span>\n"
   }
 
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   buf <+ "<pre class=\"hunk\">\n"
   buf <+ "<span class=\"hunk-header\">\{esc(h.header())}</span>\n"
   let old = h.old_view()
@@ -632,7 +632,7 @@ test "edits() with the views agrees with render()" {
   let old = ["a", "b", "c", "d"][:]
   let new = ["a", "x", "c", "y"][:]
   for h in @diff.Diff(old~, new~).group(context=1) {
-    let rebuilt = StringBuilder::new()
+    let rebuilt = StringBuilder()
     rebuilt <+ "\{h.header()}\n"
     let o = h.old_view()
     let n = h.new_view()

--- a/diff/diff_word_test.mbt
+++ b/diff/diff_word_test.mbt
@@ -87,7 +87,7 @@ test "tokenize is faithful and lexical" {
 
 ///|
 fn esc(s : String) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   for c in s {
     match c {
       '&' => buf <+ "&amp;"
@@ -107,8 +107,8 @@ fn esc(s : String) -> String {
 /// rows, so unequal line counts fall out naturally.
 fn side_rows(inner : @diff.Diff[String], old_side~ : Bool) -> Array[String] {
   let rows = []
-  let buf = StringBuilder::new()
-  let run = StringBuilder::new()
+  let buf = StringBuilder()
+  let run = StringBuilder()
   fn flush_run() {
     if run.is_empty() {
       return
@@ -164,7 +164,7 @@ fn side_rows(inner : @diff.Diff[String], old_side~ : Bool) -> Array[String] {
 /// Delete+Insert replacement pair, word-level highlights via a second
 /// `@diff.Diff` over `lexmatch` tokens.
 fn word_diff_html(old~ : ArrayView[String], new~ : ArrayView[String]) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   for h in @diff.Diff(old~, new~).group(context=1) {
     buf <+ "<span class=\"hunk-header\">\{esc(h.header())}</span>\n"
     let edits = h.edits()

--- a/diff/hunk.mbt
+++ b/diff/hunk.mbt
@@ -125,7 +125,7 @@ pub fn[T] Hunk::new_view(self : Hunk[T]) -> ArrayView[T] {
 /// a `Show` bound so that element types need no `Show` impl and callers
 /// control the rendering (e.g. a field of a record).
 pub fn[T] Hunk::render(self : Hunk[T], show~ : (T) -> String) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   buf <+ "\{self.header()}\n"
   for edit in self.edits {
     let (prefix, slice) = match edit {

--- a/diff/quickcheck_test.mbt
+++ b/diff/quickcheck_test.mbt
@@ -456,7 +456,7 @@ fn changes(edits : ArrayView[@diff.Edit]) -> Array[@diff.Edit] {
 
 ///|
 fn to_text(a : Array[Int]) -> String {
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   for x in a {
     buf.write_char(
       match x & 3 {

--- a/internal/strconv/quickcheck_test.mbt
+++ b/internal/strconv/quickcheck_test.mbt
@@ -261,7 +261,7 @@ fn render(magnitude : UInt64, base : Int, flags : Int) -> String {
   }
   digits.rev_in_place()
   let upper = flags / 2 % 2 == 0
-  let out = StringBuilder::new()
+  let out = StringBuilder()
   match flags % 4 {
     1 => out.write_char('+')
     2 => out.write_char('-')

--- a/internal/strconv/strconv_coverage_test.mbt
+++ b/internal/strconv/strconv_coverage_test.mbt
@@ -157,7 +157,7 @@ test "double slow path: signs, subnormals and buffer-filling fractions" {
   inspect(@strconv.parse_double("4.9e-324") > 0.0, content="true")
   // a fraction with more than the 800-digit buffer overflows it and forces
   // left-shift truncation/trimming during the binary conversion
-  let frac = StringBuilder::new()
+  let frac = StringBuilder()
   frac.write_string("0.")
   for _ in 0..<90 {
     frac.write_string("1234567890")
@@ -165,14 +165,14 @@ test "double slow path: signs, subnormals and buffer-filling fractions" {
   frac.write_string("5")
   inspect(@strconv.parse_double(frac.to_string()) > 0.0, content="true")
   // the same digit count at magnitude ~1.5 drives right-shift truncation
-  let mid = StringBuilder::new()
+  let mid = StringBuilder()
   mid.write_string("1.5")
   for _ in 0..<90 {
     mid.write_string("1234567890")
   }
   inspect(@strconv.parse_double(mid.to_string()) > 1.0, content="true")
   // a huge integer part runs through the slow path and overflows the range
-  let big = StringBuilder::new()
+  let big = StringBuilder()
   for _ in 0..<40 {
     big.write_string("1234567890")
   }
@@ -183,7 +183,7 @@ test "double slow path: signs, subnormals and buffer-filling fractions" {
 test "double slow path: exponents past the digit-position limits" {
   // a large positive exponent with a long integer part pushes the decimal
   // point past the upper accumulation limit
-  let hi = StringBuilder::new()
+  let hi = StringBuilder()
   for _ in 0..<320 {
     hi.write_string("9")
   }
@@ -191,7 +191,7 @@ test "double slow path: exponents past the digit-position limits" {
   inspect(double_raises(hi.to_string()), content="true")
   // a long leading-zero fraction with a negative exponent pushes the decimal
   // point past the lower limit, underflowing to zero
-  let lo = StringBuilder::new()
+  let lo = StringBuilder()
   lo.write_string("0.")
   for _ in 0..<340 {
     lo.write_string("0")

--- a/json/json_coverage_test.mbt
+++ b/json/json_coverage_test.mbt
@@ -102,7 +102,7 @@ test "nesting beyond the configured depth limit is rejected" {
   let deep_array = String::make(9, '[') + String::make(9, ']')
   inspect(parse_raises(deep_array, max_nesting_depth=8), content="true")
   // the same for deeply nested objects (a separate depth check)
-  let sb = StringBuilder::new()
+  let sb = StringBuilder()
   for _ in 0..<9 {
     sb.write_string("{\"a\":")
   }

--- a/strconv/double_differential_test.mbt
+++ b/strconv/double_differential_test.mbt
@@ -45,7 +45,7 @@ fn Rng::next(self : Rng) -> UInt64 {
 ///|
 fn hex16(bits : UInt64) -> String {
   let s = bits.to_string(radix=16)
-  let b = StringBuilder::new()
+  let b = StringBuilder()
   b.write_string("0x")
   for _ in 0..<(16 - s.length()) {
     b.write_char('0')
@@ -83,7 +83,7 @@ fn print_probe(bits : UInt64) -> String {
 
 ///|
 fn batch(inputs : Array[String]) -> String {
-  let b = StringBuilder::new()
+  let b = StringBuilder()
   for s in inputs {
     b <+ "\{s} => \{parse_probe(s)}\n"
   }
@@ -331,7 +331,7 @@ test "print: positional vs exponent notation thresholds" {
 
 ///|
 test "parse: long digit strings (slow path)" {
-  let b = StringBuilder::new()
+  let b = StringBuilder()
   for c in long_digit_cases() {
     b <+ "\{c.0} => \{parse_probe(c.1)}\n"
   }
@@ -366,7 +366,7 @@ test "parse: long digit strings (slow path)" {
 ///|
 test "parse: random 16/17-digit significands with extreme exponents" {
   let rng = { s: 0xDEADBEEFCAFEF00DUL }
-  let b = StringBuilder::new()
+  let b = StringBuilder()
   for _ in 0..<40 {
     let m = 4503599627370496UL + rng.next() % 4503599627370496UL
     let delta = (rng.next() % 5UL).to_int64() - 2L
@@ -471,7 +471,7 @@ test "parse: exact halfway fractions in [2^52, 2^53)" {
   // perfect tie (round-half-to-even), and the 20-digit neighbours force the
   // slow path to decide the tie from truncated digits.
   let rng = { s: 0x0123456789ABCDEFUL }
-  let b = StringBuilder::new()
+  let b = StringBuilder()
   for _ in 0..<20 {
     let m = 4503599627370496UL + rng.next() % 4503599627370496UL
     let base = m.to_string()
@@ -559,7 +559,7 @@ test "print: structured bit patterns" {
     0x0000000000000UL, 0x0000000000001UL, 0x0000000000002UL, 0x8000000000000UL, 0xFFFFFFFFFFFFFUL,
     0xFFFFFFFFFFFFEUL, 0x5555555555555UL, 0xAAAAAAAAAAAAAUL,
   ]
-  let b = StringBuilder::new()
+  let b = StringBuilder()
   for e in exp_fields {
     for m in sig_fields {
       b <+ "\{print_probe((e << 52) | m)}\n"
@@ -664,7 +664,7 @@ test "print: structured bit patterns" {
 ///|
 test "print: random doubles, snapshot and parse-print roundtrip" {
   let rng = { s: 0xF00DF00DF00DF00DUL }
-  let b = StringBuilder::new()
+  let b = StringBuilder()
   for i in 0..<100 {
     let mut bits = rng.next()
     if ((bits >> 52) & 0x7FFUL) == 0x7FFUL {

--- a/strconv/quickcheck_test.mbt
+++ b/strconv/quickcheck_test.mbt
@@ -43,7 +43,7 @@ fn u32_of_bytes(q : (Byte, Byte, Byte, Byte)) -> UInt {
 
 ///|
 fn insert_char(s : String, pos : Int, inserted : Char) -> String {
-  let sb = StringBuilder::new()
+  let sb = StringBuilder()
   let mut i = 0
   for c in s {
     if i == pos {
@@ -218,7 +218,7 @@ test "quickcheck: structured numeric strings parse to a printing fixed point" {
     (parts : (UInt, UInt, Int, (Bool, Bool, Bool))) => {
       let (int_part, frac_part, e, (neg, with_frac, with_exp)) = parts
       let exp = e * 4
-      let sb = StringBuilder::new()
+      let sb = StringBuilder()
       if neg {
         sb.write_char('-')
       }

--- a/v128/simd_basic.mbt
+++ b/v128/simd_basic.mbt
@@ -31,7 +31,7 @@ pub impl Eq for V128 with fn not_equal(self : V128, other : V128) -> Bool {
 ///|
 fn u64_hex(value : UInt64) -> String {
   let digits = value.to_string(radix=16)
-  let buf = StringBuilder::new()
+  let buf = StringBuilder()
   buf.write_string("0x")
   for _ in digits.length()..<16 {
     buf.write_char('0')


### PR DESCRIPTION
## What

Marks the `new` alias on `StringBuilder::StringBuilder` as deprecated, steering users to the constructor syntax:

```moonbit
// before
let sb = StringBuilder::new()
// after
let sb = StringBuilder()
```

## Changes

- `builtin/stringbuilder_buffer.mbt`: `#alias(new)` → `#alias(new, deprecated="Use \`StringBuilder()\` instead")`, following the same pattern as `Bench()` / `Test()` / `Ref()`.
- Migrated all internal call sites (36 across `strconv`, `internal/strconv`, `diff`, `json`, `v128`) to `StringBuilder()` so the repo builds warning-free.
- Regenerated `builtin/pkg.generated.mbti` via `moon info`.

The raw-string quote of `Hunk::render` source in `diff/diff_html_test.mbt` is left untouched — it is diff-example input data, not a call site.

## Validation

- `moon check` — clean, no deprecation warnings
- `moon test` — 7461 passed, 0 failed
- `moon fmt` / `moon info` — only the intended `.mbti` diff (`#alias(new)` → `#alias(new, deprecated)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)