### PR TITLE
perf(builtin): aligned bitstring extraction fast paths via entry/slow split

### DIFF
--- a/builtin/bitstring.mbt
+++ b/builtin/bitstring.mbt
@@ -108,8 +108,26 @@ pub fn ArrayView::unsafe_extract_uint_le(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    if len == 32 {
+      return bs.unsafe_extract_uint_le_aligned(offset >> 3)
+    }
+    if len == 16 {
+      return bs.unsafe_extract_uint16_le_aligned(offset >> 3)
+    }
+  }
+  bs.unsafe_extract_uint_le_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint_le`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn ArrayView::unsafe_extract_uint_le_slow(
+  bs : ArrayView[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -146,8 +164,26 @@ pub fn ArrayView::unsafe_extract_uint_be(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    if len == 32 {
+      return bs.unsafe_extract_uint_be_aligned(offset >> 3)
+    }
+    if len == 16 {
+      return bs.unsafe_extract_uint16_be_aligned(offset >> 3)
+    }
+  }
+  bs.unsafe_extract_uint_be_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint_be`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn ArrayView::unsafe_extract_uint_be_slow(
+  bs : ArrayView[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -191,8 +227,21 @@ pub fn ArrayView::unsafe_extract_uint64_le(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if len == 64 && (offset & 7) == 0 {
+    return bs.unsafe_extract_uint64_le_aligned(offset >> 3)
+  }
+  bs.unsafe_extract_uint64_le_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint64_le`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn ArrayView::unsafe_extract_uint64_le_slow(
+  bs : ArrayView[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt64 {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()
@@ -253,8 +302,21 @@ pub fn ArrayView::unsafe_extract_uint64_be(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if len == 64 && (offset & 7) == 0 {
+    return bs.unsafe_extract_uint64_be_aligned(offset >> 3)
+  }
+  bs.unsafe_extract_uint64_be_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint64_be`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn ArrayView::unsafe_extract_uint64_be_slow(
+  bs : ArrayView[Byte],
+  offset : Int,
+  len : Int,
+) -> UInt64 {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()
@@ -984,8 +1046,26 @@ pub fn BytesView::unsafe_extract_uint_le(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    if len == 32 {
+      return bs.unsafe_extract_uint_le_aligned(offset >> 3)
+    }
+    if len == 16 {
+      return bs.unsafe_extract_uint16_le_aligned(offset >> 3)
+    }
+  }
+  bs.unsafe_extract_uint_le_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint_le`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn BytesView::unsafe_extract_uint_le_slow(
+  bs : BytesView,
+  offset : Int,
+  len : Int,
+) -> UInt {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -1022,8 +1102,26 @@ pub fn BytesView::unsafe_extract_uint_be(
   offset : Int,
   len : Int,
 ) -> UInt {
+  if (offset & 7) == 0 {
+    if len == 32 {
+      return bs.unsafe_extract_uint_be_aligned(offset >> 3)
+    }
+    if len == 16 {
+      return bs.unsafe_extract_uint16_be_aligned(offset >> 3)
+    }
+  }
+  bs.unsafe_extract_uint_be_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint_be`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn BytesView::unsafe_extract_uint_be_slow(
+  bs : BytesView,
+  offset : Int,
+  len : Int,
+) -> UInt {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8)
   match bytes_needed {
@@ -1067,8 +1165,21 @@ pub fn BytesView::unsafe_extract_uint64_le(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if len == 64 && (offset & 7) == 0 {
+    return bs.unsafe_extract_uint64_le_aligned(offset >> 3)
+  }
+  bs.unsafe_extract_uint64_le_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint64_le`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn BytesView::unsafe_extract_uint64_le_slow(
+  bs : BytesView,
+  offset : Int,
+  len : Int,
+) -> UInt64 {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()
@@ -1129,8 +1240,21 @@ pub fn BytesView::unsafe_extract_uint64_be(
   offset : Int,
   len : Int,
 ) -> UInt64 {
+  if len == 64 && (offset & 7) == 0 {
+    return bs.unsafe_extract_uint64_be_aligned(offset >> 3)
+  }
+  bs.unsafe_extract_uint64_be_slow(offset, len)
+}
+
+///|
+/// Outlined slow path of `unsafe_extract_uint64_be`, kept out of the entry
+/// function so the aligned fast paths above stay small enough to inline.
+fn BytesView::unsafe_extract_uint64_be_slow(
+  bs : BytesView,
+  offset : Int,
+  len : Int,
+) -> UInt64 {
   let bytes_needed = (len + 7) / 8
-  // TODO: add fast path for aligned case
   // non-aligned case: extract bytes using unsafe_extract_byte
   let b0 = bs.unsafe_extract_byte(offset, 8).to_uint64()
   let b1 = bs.unsafe_extract_byte(offset + 8, 8).to_uint64()

--- a/builtin/bitstring_extract_bench_test.mbt
+++ b/builtin/bitstring_extract_bench_test.mbt
@@ -1,0 +1,192 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Benchmarks for the generic bitstring extractors (workload shape from
+// PR #3777 by @mizchi): the aligned exact-width fast paths (32/64-bit and
+// 16-bit), plus the outlined slow-path cases they must not pessimize —
+// unaligned offsets and aligned widths without a fixed-width helper
+// (e.g. 24-bit).
+
+///|
+let bitstring_extract_bench_size = 8192
+
+///|
+fn bitstring_extract_bench_bytes() -> Bytes {
+  Bytes::makei(bitstring_extract_bench_size, i => (i & 0xff).to_byte())
+}
+
+///|
+fn bitstring_extract_bench_array() -> Array[Byte] {
+  Array::makei(bitstring_extract_bench_size, i => (i & 0xff).to_byte())
+}
+
+///|
+test "bench BytesView uint_le aligned len=32" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 4
+  it.bench(fn() {
+    let mut acc : UInt = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      acc = acc ^ view.unsafe_extract_uint_le(byte_offset * 8, 32)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench BytesView uint_be aligned len=32" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 4
+  it.bench(fn() {
+    let mut acc : UInt = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      acc = acc ^ view.unsafe_extract_uint_be(byte_offset * 8, 32)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench ArrayView uint_le aligned len=32" (it : @bench.T) {
+  let arr = bitstring_extract_bench_array()
+  let view = arr[:]
+  let last = bitstring_extract_bench_size - 4
+  it.bench(fn() {
+    let mut acc : UInt = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      acc = acc ^ view.unsafe_extract_uint_le(byte_offset * 8, 32)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench ArrayView uint_be aligned len=32" (it : @bench.T) {
+  let arr = bitstring_extract_bench_array()
+  let view = arr[:]
+  let last = bitstring_extract_bench_size - 4
+  it.bench(fn() {
+    let mut acc : UInt = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      acc = acc ^ view.unsafe_extract_uint_be(byte_offset * 8, 32)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench BytesView uint64_le aligned len=64" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 8
+  it.bench(fn() {
+    let mut acc : UInt64 = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      acc = acc ^ view.unsafe_extract_uint64_le(byte_offset * 8, 64)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench BytesView uint64_be aligned len=64" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 8
+  it.bench(fn() {
+    let mut acc : UInt64 = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      acc = acc ^ view.unsafe_extract_uint64_be(byte_offset * 8, 64)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench ArrayView uint64_le aligned len=64" (it : @bench.T) {
+  let arr = bitstring_extract_bench_array()
+  let view = arr[:]
+  let last = bitstring_extract_bench_size - 8
+  it.bench(fn() {
+    let mut acc : UInt64 = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      acc = acc ^ view.unsafe_extract_uint64_le(byte_offset * 8, 64)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench ArrayView uint64_be aligned len=64" (it : @bench.T) {
+  let arr = bitstring_extract_bench_array()
+  let view = arr[:]
+  let last = bitstring_extract_bench_size - 8
+  it.bench(fn() {
+    let mut acc : UInt64 = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      acc = acc ^ view.unsafe_extract_uint64_be(byte_offset * 8, 64)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench BytesView uint_le unaligned len=32" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 5
+  it.bench(fn() {
+    let mut acc : UInt = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 4 {
+      acc = acc ^ view.unsafe_extract_uint_le(byte_offset * 8 + 4, 32)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench BytesView uint64_le unaligned len=64" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 9
+  it.bench(fn() {
+    let mut acc : UInt64 = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 8 {
+      acc = acc ^ view.unsafe_extract_uint64_le(byte_offset * 8 + 4, 64)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench BytesView uint_le aligned len=16" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 2
+  it.bench(fn() {
+    let mut acc : UInt = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 2 {
+      acc = acc ^ view.unsafe_extract_uint_le(byte_offset * 8, 16)
+    }
+    it.keep(acc)
+  })
+}
+
+///|
+test "bench BytesView uint_le aligned len=24" (it : @bench.T) {
+  let view = bitstring_extract_bench_bytes()[:]
+  let last = bitstring_extract_bench_size - 3
+  it.bench(fn() {
+    let mut acc : UInt = 0
+    for byte_offset = 0; byte_offset <= last; byte_offset = byte_offset + 3 {
+      acc = acc ^ view.unsafe_extract_uint_le(byte_offset * 8, 24)
+    }
+    it.keep(acc)
+  })
+}

--- a/builtin/bitstring_extract_equiv_test.mbt
+++ b/builtin/bitstring_extract_equiv_test.mbt
@@ -1,0 +1,111 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Equivalence sweep for the generic bitstring integer extractors: every
+// (offset, len) combination — aligned and unaligned, exact-width and
+// partial — is checked against a byte-composition reference built from
+// `unsafe_extract_byte`, so the aligned fast paths and the outlined slow
+// paths must agree with the specified bit semantics everywhere.
+
+///|
+fn extract_ref_le(read : (Int, Int) -> UInt, offset : Int, len : Int) -> UInt64 {
+  let n = (len + 7) / 8
+  let mut acc : UInt64 = 0
+  for k in 0..<n {
+    let bits = if k == n - 1 { len - 8 * k } else { 8 }
+    acc = acc | (read(offset + 8 * k, bits).to_uint64() << (8 * k))
+  }
+  acc
+}
+
+///|
+fn extract_ref_be(read : (Int, Int) -> UInt, offset : Int, len : Int) -> UInt64 {
+  let n = (len + 7) / 8
+  let mut acc : UInt64 = 0
+  for k in 0..<n {
+    let bits = if k == n - 1 { len - 8 * k } else { 8 }
+    acc = (acc << bits) | read(offset + 8 * k, bits).to_uint64()
+  }
+  acc
+}
+
+///|
+test "generic uint extraction agrees with the byte-composition reference" {
+  let bytes = Bytes::makei(32, i => ((i * 37 + 11) & 0xff).to_byte())
+  let arr = Array::makei(32, i => ((i * 37 + 11) & 0xff).to_byte())
+  // both zero-origin views and a nonzero-origin subview, so the aligned
+  // helpers' start-offset handling is exercised too
+  let bv = bytes[:]
+  let av = arr[:]
+  let bv2 = bytes[3:]
+  let av2 = arr[3:]
+  let bv_read = (o : Int, l : Int) => bv.unsafe_extract_byte(o, l)
+  let av_read = (o : Int, l : Int) => av.unsafe_extract_byte(o, l)
+  let bv2_read = (o : Int, l : Int) => bv2.unsafe_extract_byte(o, l)
+  let av2_read = (o : Int, l : Int) => av2.unsafe_extract_byte(o, l)
+  for offset in 0..<=16 {
+    for len in 9..<=32 {
+      assert_eq(
+        bv.unsafe_extract_uint_le(offset, len).to_uint64(),
+        extract_ref_le(bv_read, offset, len),
+      )
+      assert_eq(
+        bv.unsafe_extract_uint_be(offset, len).to_uint64(),
+        extract_ref_be(bv_read, offset, len),
+      )
+      assert_eq(
+        av.unsafe_extract_uint_le(offset, len).to_uint64(),
+        extract_ref_le(av_read, offset, len),
+      )
+      assert_eq(
+        av.unsafe_extract_uint_be(offset, len).to_uint64(),
+        extract_ref_be(av_read, offset, len),
+      )
+      assert_eq(
+        bv2.unsafe_extract_uint_le(offset, len).to_uint64(),
+        extract_ref_le(bv2_read, offset, len),
+      )
+      assert_eq(
+        av2.unsafe_extract_uint_be(offset, len).to_uint64(),
+        extract_ref_be(av2_read, offset, len),
+      )
+    }
+    for len in 33..<=64 {
+      assert_eq(
+        bv.unsafe_extract_uint64_le(offset, len),
+        extract_ref_le(bv_read, offset, len),
+      )
+      assert_eq(
+        bv.unsafe_extract_uint64_be(offset, len),
+        extract_ref_be(bv_read, offset, len),
+      )
+      assert_eq(
+        av.unsafe_extract_uint64_le(offset, len),
+        extract_ref_le(av_read, offset, len),
+      )
+      assert_eq(
+        av.unsafe_extract_uint64_be(offset, len),
+        extract_ref_be(av_read, offset, len),
+      )
+      assert_eq(
+        bv2.unsafe_extract_uint64_le(offset, len),
+        extract_ref_le(bv2_read, offset, len),
+      )
+      assert_eq(
+        av2.unsafe_extract_uint64_be(offset, len),
+        extract_ref_be(av2_read, offset, len),
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Supersedes #3777 (thanks @mizchi for identifying the aligned-delegation opportunity and the benchmark workload). That PR's inline guards, re-benchmarked against current main, **regressed native u32 by 17–26%**: the guards pushed the large generic bodies past the native inliner's threshold ([full analysis on #3777](https://github.com/moonbitlang/core/pull/3777#issuecomment-5352307912)). This PR lands the shape that keeps inlining: each of the eight generic extractors becomes a **small entry** (aligned exact-width checks delegating to the existing `*_aligned` intrinsic-backed helpers) that tail-calls the previous byte-by-byte body, **outlined verbatim into a private `*_slow` function**.

## Benchmarks (`moon bench --release`, 8192-byte views, XOR-fold loops; main → this PR, BytesView cells)

| case | native | js | wasm | wasm-gc |
|---|---:|---:|---:|---:|
| aligned u32 | 5.01 → **1.88 µs** (2.7x) | 30.5 → **2.5–4.6 µs**¹ | 16.8 → **8.2 µs** (2.0x) | 14.5 → **5.1 µs** (2.8x) |
| aligned u64 | 3.06 → **0.94 µs** (3.2x) | 111.8 → **93.3 µs** | 13.6 → **4.1 µs** (3.3x) | 12.4 → **3.8 µs** (3.2x) |
| unaligned u32/u64 | par | par | par | par |
| aligned len=16 | 0.48 → 3.76 µs² | 21.2 → **8.0 µs** | 19.2 → **16.6 µs** | 15.2 → **11.3 µs** |
| aligned len=24 | par | bimodal¹ | 17.7 → 23.7 µs³ | par |

¹ V8 tier-up bimodality: the same build measures both fast and slow steady states on these cells (u32-le swings 2.6–20 µs within a run; the be cell is stable at 2.5 µs).
² Main's trivially-inlined two-byte path gets **loop-vectorized** by LLVM in this synthetic XOR-fold (0.117 ns/op is sub-cycle — impossible without SIMD), which no call-based path can match; single-call latency is normal scalar speed (~0.9 ns/op), and every other backend improves on this case. Verified against native assembly during review.
³ A real, disclosed concession isolated to aligned widths that have no fixed-width helper — rare in bitstring patterns.

For comparison, #3777's inline-guard shape measured **5.27 µs** on native aligned u32 — slower than doing nothing.

## Tests

- **`bitstring_extract_equiv_test.mbt`**: sweeps every `(offset ∈ 0..=16, len ∈ 9..=32 and 33..=64)` combination — aligned and unaligned, exact and partial widths — on both view types, both endiannesses, and both zero-origin and nonzero-origin subviews, against a byte-composition reference built from `unsafe_extract_byte`. Mutation-verified: swapping one aligned helper's endianness fails the sweep.
- **`bitstring_extract_bench_test.mbt`**: the aligned exact widths plus the slow-path shapes (unaligned, aligned-16, aligned-24), so future changes see both sides of the guard.

## Review

Codex CLI (`xhigh`), first-round sign-off: all eight outlined slow bodies verified **verbatim** against origin/main; all twelve guard/helper pairings correct in view, width, endianness, and `offset >> 3` conversion; LE/BE reference semantics verified including partial-byte placement; the vectorization explanation corroborated against native assembly; generated interface unchanged. Its two wording nits and the nonzero-origin-view coverage suggestion are incorporated.

Signed-off-by: Codex CLI <codex@openai.com>

## Validation

- Full repo `moon test`: 7464/7464 (builtin 2943/2943)
- `moon check --warn-list +unnecessary_annotation` clean, `moon fmt` applied, no `.mbti` change (the `*_slow` functions are private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
