### PR TITLE
fix(bigint): treat empty octets as zero in BigInt::from_octets

### DIFF
--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -199,12 +199,15 @@ extern "js" fn hex2(b : Byte) -> String =
 /// Parameters:
 ///
 /// * `octets` : A sequence of bytes representing the magnitude of the number in
-/// big-endian order. It must not be empty unless `signum` is 0.
+/// big-endian order. An empty sequence represents a zero magnitude.
 /// * `signum` : The sign of the resulting number. A negative value creates a
 /// negative number, zero returns zero, and a positive value creates a positive
 /// number. Defaults to 1.
 ///
 /// Returns a `BigInt` value represented by the byte sequence and sign.
+///
+/// An empty byte sequence yields zero for any `signum`, matching the behavior
+/// of Java's `BigInteger`, Python's `int.from_bytes`, and Rust's `num-bigint`.
 pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
   if signum < 0 {
     return -1N * BigInt::from_octets(octets, signum=1)
@@ -213,7 +216,7 @@ pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
     return 0N
   }
   if octets.is_empty() {
-    abort("empty octet string")
+    return 0N
   }
   let str = StringBuilder()
   for octet in octets {

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1427,17 +1427,17 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
 ///
 /// Parameters:
 ///
-/// * `bytes` : A sequence of bytes representing the magnitude of the number in
+/// * `input` : A sequence of bytes representing the magnitude of the number in
 /// big-endian order. An empty sequence represents a zero magnitude.
-/// * `sign` : An integer specifying the sign of the resulting number (default:
-/// 1). A value of 1 creates a positive number, -1 creates a negative number, and
-/// 0 returns zero regardless of the input bytes.
+/// * `signum` : An integer specifying the sign of the resulting number
+/// (default: 1). A positive value creates a positive number, a negative value
+/// creates a negative number, and 0 returns zero regardless of the input bytes.
 ///
 /// Returns a `BigInt` value representing the number encoded in the byte sequence
 /// with the specified sign.
 ///
-/// An empty byte sequence yields zero for any `sign`, matching the behavior of
-/// Java's `BigInteger`, Python's `int.from_bytes`, and Rust's `num-bigint`.
+/// An empty byte sequence yields zero for any `signum`, matching the behavior
+/// of Java's `BigInteger`, Python's `int.from_bytes`, and Rust's `num-bigint`.
 ///
 /// Example:
 ///

--- a/bigint/bigint_nonjs.mbt
+++ b/bigint/bigint_nonjs.mbt
@@ -1428,7 +1428,7 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
 /// Parameters:
 ///
 /// * `bytes` : A sequence of bytes representing the magnitude of the number in
-/// big-endian order. The sequence must not be empty unless `sign` is 0.
+/// big-endian order. An empty sequence represents a zero magnitude.
 /// * `sign` : An integer specifying the sign of the resulting number (default:
 /// 1). A value of 1 creates a positive number, -1 creates a negative number, and
 /// 0 returns zero regardless of the input bytes.
@@ -1436,7 +1436,8 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
 /// Returns a `BigInt` value representing the number encoded in the byte sequence
 /// with the specified sign.
 ///
-/// Throws a panic if the input byte sequence is empty and the sign is not 0.
+/// An empty byte sequence yields zero for any `sign`, matching the behavior of
+/// Java's `BigInteger`, Python's `int.from_bytes`, and Rust's `num-bigint`.
 ///
 /// Example:
 ///
@@ -1447,6 +1448,7 @@ pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
 ///   let negative = @bigint.BigInt::from_octets(bytes, signum=-1)
 ///   inspect(positive, content="66051")
 ///   inspect(negative, content="-66051")
+///   inspect(@bigint.BigInt::from_octets(b""), content="0")
 /// }
 /// ```
 pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
@@ -1457,7 +1459,7 @@ pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
     return -BigInt::from_octets(input)
   }
   if len == 0 {
-    abort("empty octet string")
+    return zero
   }
   let div = len * 8 / RADIX_BIT_LEN
   let mod = len * 8 % RADIX_BIT_LEN // number of bits in the first limb

--- a/bigint/bigint_test.mbt
+++ b/bigint/bigint_test.mbt
@@ -67,8 +67,10 @@ test "to_octets pads larger length" {
 }
 
 ///|
-test "from_octets accepts empty input with zero signum" {
+test "from_octets treats empty input as zero" {
+  inspect(@bigint.BigInt::from_octets(b""), content="0")
   inspect(@bigint.BigInt::from_octets(b"", signum=0), content="0")
+  inspect(@bigint.BigInt::from_octets(b"", signum=-1), content="0")
 }
 
 ///|

--- a/bigint/panic_test.mbt
+++ b/bigint/panic_test.mbt
@@ -86,16 +86,6 @@ test "panic pow negative exponent" {
 }
 
 ///|
-test "panic from_octets empty" {
-  @bigint.BigInt::from_octets(Bytes::new(0)) |> ignore
-}
-
-///|
-test "panic from_octets empty negative signum" {
-  @bigint.BigInt::from_octets(Bytes::new(0), signum=-1) |> ignore
-}
-
-///|
 test "panic to_octets negative" {
   (-1N).to_octets() |> ignore
 }

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -159,11 +159,6 @@ test "panic to_octets coverage for negative number than required" {
 }
 
 ///|
-test "panic from_octets coverage for empty octets" {
-  BigInt::from_octets(b"") |> ignore
-}
-
-///|
 test "panic sub_string with invalid byte_length" {
   let bytes = b"Hello, World!"
   bytes.to_unchecked_string(offset=0, length=-1) |> ignore


### PR DESCRIPTION
## Summary

Follow mainstream bigint behavior by treating an empty octet sequence as zero in `BigInt::from_octets`, instead of panicking when `signum != 0`.

An empty big-endian magnitude naturally denotes zero, and the mainstream APIs agree:

- Java: `BigInteger(signum, magnitude)` explicitly permits a zero-length magnitude and returns 0 for any signum
- Python: `int.from_bytes(b"")` returns `0`
- Rust: `num_bigint::BigInt::from_bytes_be(Sign::Minus, b"")` normalizes to zero; `BigUint::from_bytes_be(b"")` returns 0 (same for `ibig`, `rug`/GMP)

MoonBit was the outlier with `abort("empty octet string")`, and inconsistently so: the morally identical all-zero magnitude (`b"\x00"` with `signum=-1`) was already accepted and returned 0, while the zero-length one panicked.

## Changes

- `bigint/bigint_nonjs.mbt`, `bigint/bigint_js.mbt`: return zero for empty input on all signum paths; update doc comments (and add an empty-input line to the docstring example)
- `bigint/bigint_test.mbt`: extend the empty-input test to cover `signum` default, `0`, and `-1`
- `bigint/panic_test.mbt`: remove the two now-obsolete panic tests

Relaxing a documented panic into defined behavior; no public API signature changes (`moon info` reports no `.mbti` diff).

Follow-up to the contract discussion around #3748 / #3750.

## Validation

- `moon fmt`
- `moon check --target all`
- `moon test bigint --target all` (187/187 on wasm, wasm-gc, native; 162/162 on js)
- `moon info` (no `.mbti` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)