### PR TITLE
test(argparse): use expect_error

### DIFF
--- a/argparse/command_test.mbt
+++ b/argparse/command_test.mbt
@@ -66,25 +66,20 @@ test "command policies" {
       #|
     ),
   )
-  try sub_cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required argument was not provided: 'subcommand'
-          #|
-          #|Usage: demo <command>
-          #|
-          #|Commands:
-          #|  echo  
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => sub_cmd.parse(argv=[], env=empty_env())),
+    content=(
+      #|error: the following required argument was not provided: 'subcommand'
+      #|
+      #|Usage: demo <command>
+      #|
+      #|Commands:
+      #|  echo  
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }

--- a/argparse/errors_test.mbt
+++ b/argparse/errors_test.mbt
@@ -16,26 +16,21 @@
 test "unknown argument keeps suggestion in final message" {
   let cmd = @argparse.Command("demo", flags=[FlagArg("verbose", long="verbose")])
 
-  try cmd.parse(argv=["--verbse"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--verbse' found
-          #|
-          #|  tip: a similar argument exists: '--verbose'
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --verbose   
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--verbse"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--verbse' found
+      #|
+      #|  tip: a similar argument exists: '--verbose'
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --verbose   
+      #|
+    ),
+  )
 }
 
 ///|
@@ -46,51 +41,41 @@ test "parse error show is readable" {
     positionals=[PositionArg("name")],
   )
 
-  try cmd.parse(argv=["--verbse"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--verbse' found
-          #|
-          #|  tip: a similar argument exists: '--verbose'
-          #|
-          #|Usage: demo [options] [name]
-          #|
-          #|Arguments:
-          #|  name  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --verbose   
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--verbse"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--verbse' found
+      #|
+      #|  tip: a similar argument exists: '--verbose'
+      #|
+      #|Usage: demo [options] [name]
+      #|
+      #|Arguments:
+      #|  name  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --verbose   
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["alice", "bob"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'bob' for '<name>' found; no more were expected
-          #|
-          #|Usage: demo [options] [name]
-          #|
-          #|Arguments:
-          #|  name  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --verbose   
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["alice", "bob"], env=empty_env())),
+    content=(
+      #|error: unexpected value 'bob' for '<name>' found; no more were expected
+      #|
+      #|Usage: demo [options] [name]
+      #|
+      #|Arguments:
+      #|  name  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --verbose   
+      #|
+    ),
+  )
 }
 
 ///|
@@ -99,109 +84,84 @@ test "unknown argument suggestions are exposed" {
     FlagArg("verbose", short='v', long="verbose"),
   ])
 
-  try cmd.parse(argv=["--verbse"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--verbse' found
-          #|
-          #|  tip: a similar argument exists: '--verbose'
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -v, --verbose  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--verbse"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--verbse' found
+      #|
+      #|  tip: a similar argument exists: '--verbose'
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -v, --verbose  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["-x"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '-x' found
-          #|
-          #|  tip: a similar argument exists: '-v'
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -v, --verbose  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["-x"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '-x' found
+      #|
+      #|  tip: a similar argument exists: '-v'
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -v, --verbose  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["--zzzzzzzzzz"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--zzzzzzzzzz' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -v, --verbose  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--zzzzzzzzzz"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--zzzzzzzzzz' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -v, --verbose  
+      #|
+    ),
+  )
 }
 
 ///|
 test "unified error message formatting remains stable" {
   let cmd = @argparse.Command("demo", options=[OptionArg("tag", long="tag")])
 
-  try cmd.parse(argv=["--oops"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--oops' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  --tag <tag>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--oops"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--oops' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  --tag <tag>  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["--tag"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--tag' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  --tag <tag>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--tag"], env=empty_env())),
+    content=(
+      #|error: a value is required for '--tag' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  --tag <tag>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -210,23 +170,18 @@ test "unknown short suggestion can be absent" {
     OptionArg("name", long="name"),
   ])
 
-  try cmd.parse(argv=["-x"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '-x' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  --name <name>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["-x"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '-x' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  --name <name>  
+      #|
+    ),
+  )
 }
 
 ///|

--- a/argparse/globals_test.mbt
+++ b/argparse/globals_test.mbt
@@ -455,30 +455,25 @@ test "global set option rejects duplicate occurrences across subcommands" {
     options=[OptionArg("mode", long="mode", global=true)],
     subcommands=[Command("run")],
   )
-  try
-    cmd.parse(argv=["--mode", "a", "run", "--mode", "b"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: argument '--mode' cannot be used multiple times
-          #|
-          #|Usage: demo [options] [command]
-          #|
-          #|Commands:
-          #|  run   
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  --mode <mode>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--mode", "a", "run", "--mode", "b"], env=empty_env())
+    }),
+    content=(
+      #|error: argument '--mode' cannot be used multiple times
+      #|
+      #|Usage: demo [options] [command]
+      #|
+      #|Commands:
+      #|  run   
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  --mode <mode>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -584,26 +579,23 @@ test "global set option used in both parent and child argv conflicts" {
     options=[OptionArg("mode", short='m', long="", global=true)],
     subcommands=[Command("run")],
   )
-  try cmd.parse(argv=["-m", "a", "run", "-m", "b"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: argument '-m' cannot be used multiple times
-          #|
-          #|Usage: demo [options] [command]
-          #|
-          #|Commands:
-          #|  run   
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  -m <mode>   
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["-m", "a", "run", "-m", "b"], env=empty_env())
+    }),
+    content=(
+      #|error: argument '-m' cannot be used multiple times
+      #|
+      #|Usage: demo [options] [command]
+      #|
+      #|Commands:
+      #|  run   
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  -m <mode>   
+      #|
+    ),
+  )
 }

--- a/argparse/help_test.mbt
+++ b/argparse/help_test.mbt
@@ -18,24 +18,19 @@ test "parse failure message contains error and contextual help" {
     OptionArg("count", long="count", about="repeat count"),
   ])
 
-  try cmd.parse(argv=["--bad"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--bad' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help       Show help information.
-          #|  --count <count>  repeat count
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--bad"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--bad' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help       Show help information.
+      #|  --count <count>  repeat count
+      #|
+    ),
+  )
 }
 
 ///|
@@ -44,24 +39,19 @@ test "subcommand parse errors include subcommand help" {
     Command("echo", options=[OptionArg("times", long="times")]),
   ])
 
-  try cmd.parse(argv=["echo", "--bad"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--bad' found
-          #|
-          #|Usage: demo echo [options]
-          #|
-          #|Options:
-          #|  -h, --help       Show help information.
-          #|  --times <times>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["echo", "--bad"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--bad' found
+      #|
+      #|Usage: demo echo [options]
+      #|
+      #|Options:
+      #|  -h, --help       Show help information.
+      #|  --times <times>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -99,26 +89,21 @@ test "display help and version" {
     ),
   )
 
-  try cmd.parse(argv=["--oops"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--oops' found
-          #|
-          #|Usage: demo
-          #|
-          #|demo app
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -V, --version  Show version information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--oops"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--oops' found
+      #|
+      #|Usage: demo
+      #|
+      #|demo app
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -V, --version  Show version information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -308,27 +293,22 @@ test "default subcommand help annotation and child error context" {
     ),
   )
 
-  try cmd.parse(argv=["--unknown"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--unknown' found
-          #|
-          #|Usage: openseek tui [options]
-          #|
-          #|Start interactive UI
-          #|
-          #|Options:
-          #|  -h, --help         Show help information.
-          #|  --config <config>  config
-          #|  --theme <theme>    theme
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--unknown"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--unknown' found
+      #|
+      #|Usage: openseek tui [options]
+      #|
+      #|Start interactive UI
+      #|
+      #|Options:
+      #|  -h, --help         Show help information.
+      #|  --config <config>  config
+      #|  --theme <theme>    theme
+      #|
+    ),
+  )
 }
 
 ///|
@@ -363,49 +343,41 @@ test "help subcommand styles and errors" {
     ),
   )
 
-  try cmd.parse(argv=["help", "--bad"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected help argument: --bad
-          #|
-          #|Usage: demo [command]
-          #|
-          #|Commands:
-          #|  echo  echo
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["help", "--bad"], env=empty_env())),
+    content=(
+      #|error: unexpected help argument: --bad
+      #|
+      #|Usage: demo [command]
+      #|
+      #|Commands:
+      #|  echo  echo
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["help", "missing"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unknown subcommand: missing
-          #|
-          #|Usage: demo [command]
-          #|
-          #|Commands:
-          #|  echo  echo
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["help", "missing"], env=empty_env())
+    }),
+    content=(
+      #|error: unknown subcommand: missing
+      #|
+      #|Usage: demo [command]
+      #|
+      #|Commands:
+      #|  echo  echo
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -425,26 +397,21 @@ test "subcommand help includes inherited global options" {
     subcommands=[leaf],
   )
 
-  try cmd.parse(argv=["echo", "--bad"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--bad' found
-          #|
-          #|Usage: demo echo [options]
-          #|
-          #|echo
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -v, --verbose  Enable verbose mode
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["echo", "--bad"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--bad' found
+      #|
+      #|Usage: demo echo [options]
+      #|
+      #|echo
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -v, --verbose  Enable verbose mode
+      #|
+    ),
+  )
 }
 
 ///|
@@ -453,27 +420,22 @@ test "help subcommand suggestions exclude hidden commands" {
     Command("serve", about="serve"),
     Command("secret", about="secret", hidden=true),
   ])
-  try cmd.parse(argv=["help", "secrt"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unknown subcommand: secrt
-          #|
-          #|Usage: demo [command]
-          #|
-          #|Commands:
-          #|  serve  serve
-          #|  help   Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["help", "secrt"], env=empty_env())),
+    content=(
+      #|error: unknown subcommand: secrt
+      #|
+      #|Usage: demo [command]
+      #|
+      #|Commands:
+      #|  serve  serve
+      #|  help   Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -536,24 +498,19 @@ test "builtin and custom help/version dispatch edge paths" {
     ),
   )
 
-  try versioned.parse(argv=["--oops"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--oops' found
-          #|
-          #|Usage: demo
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -V, --version  Show version information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => versioned.parse(argv=["--oops"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--oops' found
+      #|
+      #|Usage: demo
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -V, --version  Show version information.
+      #|
+    ),
+  )
 
   let long_help = @argparse.Command("demo", flags=[
     FlagArg("assist", long="assist", action=Help),
@@ -599,24 +556,21 @@ test "help rendering edge paths stay stable" {
   ])
   let short_only_text = short_only_builtin.render_help()
   assert_true(short_only_text.has_prefix("Usage: demo"))
-  try short_only_builtin.parse(argv=["--help"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--help' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h                Show help information.
-          #|  --help <helpopt>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      short_only_builtin.parse(argv=["--help"], env=empty_env())
+    }),
+    content=(
+      #|error: a value is required for '--help' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h                Show help information.
+      #|  --help <helpopt>  
+      #|
+    ),
+  )
 
   let long_only_builtin = @argparse.Command("demo", flags=[
     FlagArg("custom_h", short='h'),
@@ -670,26 +624,21 @@ test "version action dispatches on custom long and short flags" {
     ),
   )
 
-  try cmd.parse(argv=["--oops"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--oops' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help        Show help information.
-          #|  -V, --version     Show version information.
-          #|  --show-version    
-          #|  -S, --show_short  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--oops"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--oops' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help        Show help information.
+      #|  -V, --version     Show version information.
+      #|  --show-version    
+      #|  -S, --show_short  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -709,48 +658,38 @@ test "global version action keeps parent version text in subcommand context" {
     subcommands=[Command("run")],
   )
 
-  try cmd.parse(argv=["--oops"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--oops' found
-          #|
-          #|Usage: demo [options] [command]
-          #|
-          #|Commands:
-          #|  run   
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help          Show help information.
-          #|  -V, --version       Show version information.
-          #|  -S, --show-version  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--oops"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--oops' found
+      #|
+      #|Usage: demo [options] [command]
+      #|
+      #|Commands:
+      #|  run   
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help          Show help information.
+      #|  -V, --version       Show version information.
+      #|  -S, --show-version  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["run", "--oops"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--oops' found
-          #|
-          #|Usage: demo run [options]
-          #|
-          #|Options:
-          #|  -h, --help          Show help information.
-          #|  -S, --show-version  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["run", "--oops"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--oops' found
+      #|
+      #|Usage: demo run [options]
+      #|
+      #|Options:
+      #|  -h, --help          Show help information.
+      #|  -S, --show-version  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -764,29 +703,24 @@ test "subcommand help puts required options in usage" {
     ),
   ])
 
-  try cmd.parse(argv=["run", "--oops"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--oops' found
-          #|
-          #|Usage: demo run --mode <mode> <file>
-          #|
-          #|Run a file
-          #|
-          #|Arguments:
-          #|  file  
-          #|
-          #|Options:
-          #|  -h, --help         Show help information.
-          #|  -m, --mode <mode>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["run", "--oops"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--oops' found
+      #|
+      #|Usage: demo run --mode <mode> <file>
+      #|
+      #|Run a file
+      #|
+      #|Arguments:
+      #|  file  
+      #|
+      #|Options:
+      #|  -h, --help         Show help information.
+      #|  -m, --mode <mode>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -859,33 +793,28 @@ test "required group usage lists every member shape" {
       PositionArg("poss", num_args=ValueRange(lower=0, upper=1)),
     ],
   )
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required arguments were not provided:
-          #|  <--opt <opt>|<posm...>|<poss>|-s|ef>
-          #|
-          #|Usage: demo [options] [posm...] [poss]
-          #|
-          #|Arguments:
-          #|  posm...  
-          #|  poss     
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  -s           
-          #|  --opt <opt>  
-          #|
-          #|Groups:
-          #|  g [required]  -s, ef, --opt <opt>, posm, poss
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env=empty_env())),
+    content=(
+      #|error: the following required arguments were not provided:
+      #|  <--opt <opt>|<posm...>|<poss>|-s|ef>
+      #|
+      #|Usage: demo [options] [posm...] [poss]
+      #|
+      #|Arguments:
+      #|  posm...  
+      #|  poss     
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  -s           
+      #|  --opt <opt>  
+      #|
+      #|Groups:
+      #|  g [required]  -s, ef, --opt <opt>, posm, poss
+      #|
+    ),
+  )
 }
 
 ///|
@@ -893,30 +822,25 @@ test "help subcommand cannot follow positional arguments" {
   let cmd = @argparse.Command("demo", positionals=[PositionArg("input")], subcommands=[
     Command("run"),
   ])
-  try cmd.parse(argv=["raw", "help"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: subcommand 'help' cannot be used with positional arguments
-          #|
-          #|Usage: demo [input] [command]
-          #|
-          #|Commands:
-          #|  run   
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Arguments:
-          #|  input  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["raw", "help"], env=empty_env())),
+    content=(
+      #|error: subcommand 'help' cannot be used with positional arguments
+      #|
+      #|Usage: demo [input] [command]
+      #|
+      #|Commands:
+      #|  run   
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Arguments:
+      #|  input  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|

--- a/argparse/moon.pkg
+++ b/argparse/moon.pkg
@@ -8,4 +8,8 @@ import {
   "moonbitlang/core/internal/edit_distance",
 }
 
+import {
+  "moonbitlang/core/test",
+} for "test"
+
 warnings = "+unnecessary_annotation"

--- a/argparse/options_test.mbt
+++ b/argparse/options_test.mbt
@@ -104,67 +104,52 @@ test "options and multiple values" {
 ///|
 test "flag does not accept inline value" {
   let cmd = @argparse.Command("demo", flags=[FlagArg("verbose", long="verbose")])
-  try cmd.parse(argv=["--verbose=true"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--verbose=true' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --verbose   
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--verbose=true"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--verbose=true' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --verbose   
+      #|
+    ),
+  )
 }
 
 ///|
 test "built-in long flags do not accept inline value" {
   let cmd = @argparse.Command("demo", version="1.2.3")
 
-  try cmd.parse(argv=["--help=1"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--help=1' found
-          #|
-          #|Usage: demo
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -V, --version  Show version information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--help=1"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--help=1' found
+      #|
+      #|Usage: demo
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -V, --version  Show version information.
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["--version=1"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--version=1' found
-          #|
-          #|Usage: demo
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -V, --version  Show version information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--version=1"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--version=1' found
+      #|
+      #|Usage: demo
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -V, --version  Show version information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -206,65 +191,50 @@ test "negation parsing and invalid negation forms" {
   assert_true(off.flags is { "cache": false, .. })
   assert_true(off.sources is { "cache": Argv, .. })
 
-  try cmd.parse(argv=["--no-path"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--no-path' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  --[no-]cache   
-          #|  --path <path>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--no-path"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--no-path' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  --[no-]cache   
+      #|  --path <path>  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["--no-missing"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--no-missing' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  --[no-]cache   
-          #|  --path <path>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--no-missing"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--no-missing' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  --[no-]cache   
+      #|  --path <path>  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["--no-cache=1"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--no-cache=1' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  --[no-]cache   
-          #|  --path <path>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--no-cache=1"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--no-cache=1' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  --[no-]cache   
+      #|  --path <path>  
+      #|
+    ),
+  )
 
   let count_cmd = @argparse.Command("demo", flags=[
     FlagArg("verbose", long="verbose", action=Count, negatable=true),
@@ -295,89 +265,69 @@ test "env parsing for settrue setfalse count and invalid values" {
   assert_true(parsed.flag_counts is { "v": 3, .. })
   assert_true(parsed.sources is { "on": Env, "off": Env, "v": Env, .. })
 
-  try cmd.parse(argv=[], env={ "ON": "bad" }) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: invalid value 'bad' for boolean flag; expected one of: 1, 0, true, false, yes, no, on, off
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --on        [env: ON]
-          #|  --off       [env: OFF]
-          #|  --v         [env: V]
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env={ "ON": "bad" })),
+    content=(
+      #|error: invalid value 'bad' for boolean flag; expected one of: 1, 0, true, false, yes, no, on, off
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --on        [env: ON]
+      #|  --off       [env: OFF]
+      #|  --v         [env: V]
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=[], env={ "OFF": "bad" }) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: invalid value 'bad' for boolean flag; expected one of: 1, 0, true, false, yes, no, on, off
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --on        [env: ON]
-          #|  --off       [env: OFF]
-          #|  --v         [env: V]
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env={ "OFF": "bad" })),
+    content=(
+      #|error: invalid value 'bad' for boolean flag; expected one of: 1, 0, true, false, yes, no, on, off
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --on        [env: ON]
+      #|  --off       [env: OFF]
+      #|  --v         [env: V]
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=[], env={ "V": "bad" }) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: invalid value 'bad' for count; expected a non-negative integer
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --on        [env: ON]
-          #|  --off       [env: OFF]
-          #|  --v         [env: V]
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env={ "V": "bad" })),
+    content=(
+      #|error: invalid value 'bad' for count; expected a non-negative integer
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --on        [env: ON]
+      #|  --off       [env: OFF]
+      #|  --v         [env: V]
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=[], env={ "V": "-1" }) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: invalid value '-1' for count; expected a non-negative integer
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --on        [env: ON]
-          #|  --off       [env: OFF]
-          #|  --v         [env: V]
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env={ "V": "-1" })),
+    content=(
+      #|error: invalid value '-1' for count; expected a non-negative integer
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --on        [env: ON]
+      #|  --off       [env: OFF]
+      #|  --v         [env: V]
+      #|
+    ),
+  )
 }
 
 ///|
@@ -389,47 +339,41 @@ test "options consume exactly one value per occurrence" {
   assert_true(parsed.values is { "tag": ["a"], .. })
   assert_true(parsed.sources is { "tag": Argv, .. })
 
-  try cmd.parse(argv=["--tag", "a", "b"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'b' found; no more were expected
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  --tag <tag>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--tag", "a", "b"], env=empty_env())
+    }),
+    content=(
+      #|error: unexpected value 'b' found; no more were expected
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  --tag <tag>  
+      #|
+    ),
+  )
 }
 
 ///|
 test "set options reject duplicate occurrences" {
   let cmd = @argparse.Command("demo", options=[OptionArg("mode", long="mode")])
-  try cmd.parse(argv=["--mode", "a", "--mode", "b"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: argument '--mode' cannot be used multiple times
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  --mode <mode>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--mode", "a", "--mode", "b"], env=empty_env())
+    }),
+    content=(
+      #|error: argument '--mode' cannot be used multiple times
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  --mode <mode>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -458,45 +402,39 @@ test "option parsing stops at the next option token" {
   assert_true(stopped.values is { "arg": ["x"], .. })
   assert_true(stopped.flags is { "verbose": true, .. })
 
-  try cmd.parse(argv=["--arg=x", "y", "--verbose"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'y' found; no more were expected
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help       Show help information.
-          #|  --verbose        
-          #|  -a, --arg <arg>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--arg=x", "y", "--verbose"], env=empty_env())
+    }),
+    content=(
+      #|error: unexpected value 'y' found; no more were expected
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help       Show help information.
+      #|  --verbose        
+      #|  -a, --arg <arg>  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["-ax", "y", "--verbose"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'y' found; no more were expected
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help       Show help information.
-          #|  --verbose        
-          #|  -a, --arg <arg>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["-ax", "y", "--verbose"], env=empty_env())
+    }),
+    content=(
+      #|error: unexpected value 'y' found; no more were expected
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help       Show help information.
+      #|  --verbose        
+      #|  -a, --arg <arg>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -506,25 +444,22 @@ test "options always require a value" {
     flags=[FlagArg("verbose", long="verbose")],
     options=[OptionArg("opt", long="opt")],
   )
-  try cmd.parse(argv=["--opt", "--verbose"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--opt' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  --verbose    
-          #|  --opt <opt>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--opt", "--verbose"], env=empty_env())
+    }),
+    content=(
+      #|error: a value is required for '--opt' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  --verbose    
+      #|  --opt <opt>  
+      #|
+    ),
+  )
 
   let zero_value_required = @argparse.Command("demo", options=[
     OptionArg("opt", long="opt", required=true),
@@ -551,29 +486,24 @@ test "options require one value per occurrence" {
   }
   assert_true(with_value.values is { "tag": ["x"], .. })
 
-  try
-    @argparse.Command("demo", options=[OptionArg("tag", long="tag")]).parse(
-      argv=["--tag"],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--tag' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  --tag <tag>  
-          #|
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[OptionArg("tag", long="tag")]).parse(
+        argv=["--tag"],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: a value is required for '--tag' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  --tag <tag>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -587,25 +517,20 @@ test "short options require one value before next option token" {
   assert_true(ok.values is { "x": ["a"], .. })
   assert_true(ok.flags is { "verbose": true, .. })
 
-  try cmd.parse(argv=["-x", "-v"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '-x' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help     Show help information.
-          #|  -v, --verbose  
-          #|  -x, --x <x>    
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["-x", "-v"], env=empty_env())),
+    content=(
+      #|error: a value is required for '-x' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help     Show help information.
+      #|  -v, --verbose  
+      #|  -x, --x <x>    
+      #|
+    ),
+  )
 }
 
 ///|
@@ -637,48 +562,42 @@ test "missing option values are reported when next token is another option" {
   assert_true(ok.values is { "arg": ["x"], .. })
   assert_true(ok.flags is { "verbose": true, .. })
 
-  try cmd.parse(argv=["--arg", "--verbose"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--arg' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  --verbose    
-          #|  --arg <arg>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--arg", "--verbose"], env=empty_env())
+    }),
+    content=(
+      #|error: a value is required for '--arg' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  --verbose    
+      #|  --arg <arg>  
+      #|
+    ),
+  )
 }
 
 ///|
 test "short-only set options use short label in duplicate errors" {
   let cmd = @argparse.Command("demo", options=[OptionArg("mode", short='m')])
-  try cmd.parse(argv=["-m", "a", "-m", "b"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: argument '--mode' cannot be used multiple times
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help         Show help information.
-          #|  -m, --mode <mode>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["-m", "a", "-m", "b"], env=empty_env())
+    }),
+    content=(
+      #|error: argument '--mode' cannot be used multiple times
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help         Show help information.
+      #|  -m, --mode <mode>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -716,24 +635,21 @@ test "duplicate short-only set option reports the short flag label" {
   let cmd = @argparse.Command("demo", options=[
     OptionArg("mode", short='m', long=""),
   ])
-  try cmd.parse(argv=["-m", "a", "-m", "b"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: argument '-m' cannot be used multiple times
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  -m <mode>   
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["-m", "a", "-m", "b"], env=empty_env())
+    }),
+    content=(
+      #|error: argument '-m' cannot be used multiple times
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  -m <mode>   
+      #|
+    ),
+  )
 }
 
 ///|
@@ -752,24 +668,19 @@ test "boolean env flags accept falsy values" {
 ///|
 test "unknown long flag with an empty name has no suggestion" {
   let cmd = @argparse.Command("demo", flags=[FlagArg("verbose", long="verbose")])
-  try cmd.parse(argv=["--=value"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --verbose   
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--=value"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --verbose   
+      #|
+    ),
+  )
 }
 
 ///|
@@ -786,45 +697,35 @@ test "long empty string disables long alias" {
   assert_true(matches.flags is { "verbose": true, .. })
   assert_true(matches.values is { "count": ["3"], .. })
 
-  try cmd.parse(argv=["--verbose"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--verbose' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  -v          
-          #|  -c <count>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--verbose"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--verbose' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  -v          
+      #|  -c <count>  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["--count", "3"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '--count' found
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  -v          
-          #|  -c <count>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--count", "3"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '--count' found
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  -v          
+      #|  -c <count>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -848,43 +749,33 @@ test "long and short value parsing branches" {
   }
   assert_true(short_attached.values is { "count": ["4"], .. })
 
-  try cmd.parse(argv=["--count"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--count' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help           Show help information.
-          #|  -c, --count <count>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["--count"], env=empty_env())),
+    content=(
+      #|error: a value is required for '--count' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help           Show help information.
+      #|  -c, --count <count>  
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["-c"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '-c' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help           Show help information.
-          #|  -c, --count <count>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["-c"], env=empty_env())),
+    content=(
+      #|error: a value is required for '-c' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help           Show help information.
+      #|  -c, --count <count>  
+      #|
+    ),
+  )
 }
 
 ///|
@@ -892,28 +783,21 @@ test "option values reject hyphen tokens unless allow_hyphen_values is enabled" 
   let strict = @argparse.Command("demo", options=[
     OptionArg("pattern", long="pattern"),
   ])
-  let mut rejected = false
-  try strict.parse(argv=["--pattern", "-file"], env=empty_env()) catch {
-    err => {
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--pattern' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help           Show help information.
-          #|  --pattern <pattern>  
-          #|
-        ),
-      )
-      rejected = true
-    }
-  } noraise {
-    _ => rejected = true
-  }
-  assert_true(rejected)
+  inspect(
+    @test.expect_error(() => {
+      strict.parse(argv=["--pattern", "-file"], env=empty_env())
+    }),
+    content=(
+      #|error: a value is required for '--pattern' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help           Show help information.
+      #|  --pattern <pattern>  
+      #|
+    ),
+  )
 
   let permissive = @argparse.Command("demo", options=[
     OptionArg("pattern", long="pattern", allow_hyphen_values=true),
@@ -1014,24 +898,19 @@ test "defaults and value range helpers through public API" {
   }
   assert_true(lower_absent.values is { "tag"? : None, .. })
 
-  try lower_only.parse(argv=["--tag"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: a value is required for '--tag' but none was supplied
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help   Show help information.
-          #|  --tag <tag>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => lower_only.parse(argv=["--tag"], env=empty_env())),
+    content=(
+      #|error: a value is required for '--tag' but none was supplied
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help   Show help information.
+      #|  --tag <tag>  
+      #|
+    ),
+  )
 
   let single_range = @argparse.ValueRange::single()
   inspect(

--- a/argparse/positionals_test.mbt
+++ b/argparse/positionals_test.mbt
@@ -62,26 +62,23 @@ test "positionals dash handling and separator" {
   }
   assert_true(negative.values is { "n": ["-9"], .. })
 
-  try negative_cmd.parse(argv=["x", "y"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'y' for '<n>' found; no more were expected
-          #|
-          #|Usage: demo [n]
-          #|
-          #|Arguments:
-          #|  n  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      negative_cmd.parse(argv=["x", "y"], env=empty_env())
+    }),
+    content=(
+      #|error: unexpected value 'y' for '<n>' found; no more were expected
+      #|
+      #|Usage: demo [n]
+      #|
+      #|Arguments:
+      #|  n  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -181,26 +178,21 @@ test "positional num_args lower bound rejects missing argv values" {
     PositionArg("first", num_args=ValueRange(lower=2, upper=3)),
   ])
 
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: 'first' requires at least 2 values but only 0 were provided
-          #|
-          #|Usage: demo <first...>
-          #|
-          #|Arguments:
-          #|  first...  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env=empty_env())),
+    content=(
+      #|error: 'first' requires at least 2 values but only 0 were provided
+      #|
+      #|Usage: demo <first...>
+      #|
+      #|Arguments:
+      #|  first...  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -230,26 +222,21 @@ test "allow_hyphen positional treats unknown long token as value" {
 ///|
 test "non-bmp hyphen token reports unknown argument without panic" {
   let cmd = @argparse.Command("demo", positionals=[PositionArg("value")])
-  try cmd.parse(argv=["-🎉"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '-🎉' found
-          #|
-          #|Usage: demo [value]
-          #|
-          #|Arguments:
-          #|  value  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["-🎉"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '-🎉' found
+      #|
+      #|Usage: demo [value]
+      #|
+      #|Arguments:
+      #|  value  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -259,26 +246,21 @@ test "positional default values exceeding num_args upper bound are rejected" {
       "a", "b", "c",
     ]),
   ])
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: 'tags' allows at most 2 values but 3 were provided
-          #|
-          #|Usage: demo [tags...]
-          #|
-          #|Arguments:
-          #|  tags...  [default: a, b, c]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env=empty_env())),
+    content=(
+      #|error: 'tags' allows at most 2 values but 3 were provided
+      #|
+      #|Usage: demo [tags...]
+      #|
+      #|Arguments:
+      #|  tags...  [default: a, b, c]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -287,27 +269,22 @@ test "earlier variadic positional reserves values for a later required one" {
     PositionArg("head", num_args=ValueRange(lower=0)),
     PositionArg("tail", num_args=ValueRange(lower=2)),
   ])
-  try cmd.parse(argv=["only"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: 'tail' requires at least 2 values but only 1 were provided
-          #|
-          #|Usage: demo [head...] <tail...>
-          #|
-          #|Arguments:
-          #|  head...  
-          #|  tail...  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["only"], env=empty_env())),
+    content=(
+      #|error: 'tail' requires at least 2 values but only 1 were provided
+      #|
+      #|Usage: demo [head...] <tail...>
+      #|
+      #|Arguments:
+      #|  head...  
+      #|  tail...  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -317,26 +294,21 @@ test "extra values past a bounded variadic positional report the variadic label"
   ])
   let ok = cmd.parse(argv=["a", "b"], env=empty_env()) catch { _ => panic() }
   assert_true(ok.values is { "items": ["a", "b"], .. })
-  try cmd.parse(argv=["a", "b", "c"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'c' for '<items...>' found; no more were expected
-          #|
-          #|Usage: demo [items...]
-          #|
-          #|Arguments:
-          #|  items...  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["a", "b", "c"], env=empty_env())),
+    content=(
+      #|error: unexpected value 'c' for '<items...>' found; no more were expected
+      #|
+      #|Usage: demo [items...]
+      #|
+      #|Arguments:
+      #|  items...  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -348,26 +320,21 @@ test "bounded variadic positional stops accepting hyphen tokens once full" {
       allow_hyphen_values=true,
     ),
   ])
-  try cmd.parse(argv=["a", "b", "-c"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '-c' found
-          #|
-          #|Usage: demo [items...]
-          #|
-          #|Arguments:
-          #|  items...  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["a", "b", "-c"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '-c' found
+      #|
+      #|Usage: demo [items...]
+      #|
+      #|Arguments:
+      #|  items...  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -379,25 +346,20 @@ test "hyphen token is rejected while a later positional still needs values" {
     PositionArg("head", num_args=ValueRange(lower=0), allow_hyphen_values=true),
     PositionArg("tail", num_args=ValueRange(lower=2)),
   ])
-  try cmd.parse(argv=["-x"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected argument '-x' found
-          #|
-          #|Usage: demo [head...] <tail...>
-          #|
-          #|Arguments:
-          #|  head...  
-          #|  tail...  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["-x"], env=empty_env())),
+    content=(
+      #|error: unexpected argument '-x' found
+      #|
+      #|Usage: demo [head...] <tail...>
+      #|
+      #|Arguments:
+      #|  head...  
+      #|  tail...  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }

--- a/argparse/rejected_config_test.mbt
+++ b/argparse/rejected_config_test.mbt
@@ -18,652 +18,471 @@
 /// Flags/options without an argv spelling or env source are dead config: they
 /// can appear in relationships and help, but users can never set them.
 test "flag and option config requires an argv or env spelling" {
-  try
-    @argparse.Command("demo", options=[OptionArg("input", long="")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: flag/option args require short/long/env
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[OptionArg("input", long="")]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: flag/option args require short/long/env
+    ),
+  )
 
-  try
-    @argparse.Command("demo", flags=[FlagArg("verbose", long="")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: flag/option args require short/long/env
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[FlagArg("verbose", long="")]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: flag/option args require short/long/env
+    ),
+  )
 
-  try
-    @argparse.Command("demo", flags=[FlagArg("f", long="", action=Help)]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: flag/option args require short/long/env
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[FlagArg("f", long="", action=Help)]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: flag/option args require short/long/env
+    ),
+  )
 }
 
 ///|
 /// Default dispatch must have one visible target and must not conflict with
 /// root-level policies that also claim bare argv or leading tokens.
 test "default subcommand config rejects ambiguous root dispatch" {
-  try
-    @argparse.Command(
-      "demo",
-      subcommands=[Command("run")],
-      default_subcommand="missing",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand must name a visible subcommand: missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        subcommands=[Command("run")],
+        default_subcommand="missing",
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: default_subcommand must name a visible subcommand: missing
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      subcommands=[Command("secret", hidden=true)],
-      default_subcommand="secret",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand must name a visible subcommand: secret
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        subcommands=[Command("secret", hidden=true)],
+        default_subcommand="secret",
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: default_subcommand must name a visible subcommand: secret
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      subcommands=[Command("run")],
-      subcommand_required=true,
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand cannot be used with subcommand_required
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        subcommands=[Command("run")],
+        subcommand_required=true,
+        default_subcommand="run",
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: default_subcommand cannot be used with subcommand_required
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      subcommands=[Command("run")],
-      arg_required_else_help=true,
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand cannot be used with arg_required_else_help
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        subcommands=[Command("run")],
+        arg_required_else_help=true,
+        default_subcommand="run",
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: default_subcommand cannot be used with arg_required_else_help
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      options=[OptionArg("mode", long="mode")],
-      subcommands=[Command("run")],
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand only supports global root flags/options
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        options=[OptionArg("mode", long="mode")],
+        subcommands=[Command("run")],
+        default_subcommand="run",
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: default_subcommand only supports global root flags/options
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", long="verbose", global=true)],
-      groups=[ArgGroup("verbosity", args=["verbose"])],
-      subcommands=[Command("run")],
-      default_subcommand="run",
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_subcommand does not support root groups
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        flags=[FlagArg("verbose", long="verbose", global=true)],
+        groups=[ArgGroup("verbosity", args=["verbose"])],
+        subcommands=[Command("run")],
+        default_subcommand="run",
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: default_subcommand does not support root groups
+    ),
+  )
 }
 
 ///|
 /// Value ranges must describe a non-empty, non-negative interval. Otherwise
 /// positional allocation and usage output would encode impossible counts.
 test "value range config rejects impossible counts" {
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("skip", num_args=ValueRange(lower=0, upper=0)),
-      PositionArg("name", num_args=@argparse.ValueRange::single()),
-    ]).parse(argv=["alice"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: empty value range (0..0) is unsupported
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", positionals=[
+        PositionArg("skip", num_args=ValueRange(lower=0, upper=0)),
+        PositionArg("name", num_args=@argparse.ValueRange::single()),
+      ]).parse(argv=["alice"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: empty value range (0..0) is unsupported
+    ),
+  )
 
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("x", num_args=ValueRange(lower=3, upper=2)),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: max values must be >= min values
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", positionals=[
+        PositionArg("x", num_args=ValueRange(lower=3, upper=2)),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: max values must be >= min values
+    ),
+  )
 
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("x", num_args=ValueRange(lower=-1, upper=2)),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: min values must be >= 0
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", positionals=[
+        PositionArg("x", num_args=ValueRange(lower=-1, upper=2)),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: min values must be >= 0
+    ),
+  )
 
-  try
-    @argparse.Command("demo", positionals=[
-      PositionArg("x", num_args=ValueRange(lower=0, upper=-1)),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: max values must be >= 0
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", positionals=[
+        PositionArg("x", num_args=ValueRange(lower=0, upper=-1)),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: max values must be >= 0
+    ),
+  )
 }
 
 ///|
 /// Terminal actions and defaults need unambiguous triggers and output: no
 /// negated help/version, no env-triggered terminal action, no multi-default Set.
 test "action config rejects unsupported implicit behavior" {
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("f", long="f", action=Help, negatable=true),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: help/version actions do not support negatable
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[
+        FlagArg("f", long="f", action=Help, negatable=true),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: help/version actions do not support negatable
+    ),
+  )
 
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("f", long="f", action=Help, env="F"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: help/version actions do not support env/defaults
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[
+        FlagArg("f", long="f", action=Help, env="F"),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: help/version actions do not support env/defaults
+    ),
+  )
 
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", long="x", default_values=["a", "b"]),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: default_values with multiple entries require action=Append
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[
+        OptionArg("x", long="x", default_values=["a", "b"]),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: default_values with multiple entries require action=Append
+    ),
+  )
 
-  try
-    @argparse.Command("demo", flags=[FlagArg("v", long="v", action=Version)]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: version action requires command version text
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[FlagArg("v", long="v", action=Version)]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: version action requires command version text
+    ),
+  )
 }
 
 ///|
 /// Groups form a relationship graph. Duplicate names, self-edges, and missing
 /// targets make that graph ambiguous, unsatisfiable, or impossible to report.
 test "group config rejects circular or unknown relationships" {
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g"), ArgGroup("g")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate group: g
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", groups=[ArgGroup("g"), ArgGroup("g")]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: duplicate group: g
+    ),
+  )
 
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", requires=["g"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: group cannot require itself: g
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", groups=[ArgGroup("g", requires=["g"])]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: group cannot require itself: g
+    ),
+  )
 
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", conflicts_with=["g"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: group cannot conflict with itself: g
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", groups=[ArgGroup("g", conflicts_with=["g"])]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: group cannot conflict with itself: g
+    ),
+  )
 
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", args=["missing"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown group arg: g -> missing
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", groups=[ArgGroup("g", args=["missing"])]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: unknown group arg: g -> missing
+    ),
+  )
 
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", requires=["missing"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown group requires target: g -> missing
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", groups=[ArgGroup("g", requires=["missing"])]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: unknown group requires target: g -> missing
+    ),
+  )
 
-  try
-    @argparse.Command("demo", groups=[ArgGroup("g", conflicts_with=["missing"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown group conflicts_with target: g -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", groups=[
+        ArgGroup("g", conflicts_with=["missing"]),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: unknown group conflicts_with target: g -> missing
+    ),
+  )
 }
 
 ///|
 /// Argument names and option aliases are parser keys. Duplicates make result
 /// slots or argv tokens ambiguous; negatable flags also reserve `--no-<long>`.
 test "argument config rejects duplicate names and aliases" {
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", long="x"),
-      OptionArg("x", long="y"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate arg name: x
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[
+        OptionArg("x", long="x"),
+        OptionArg("x", long="y"),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: duplicate arg name: x
+    ),
+  )
 
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", long="same"),
-      OptionArg("y", long="same"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate long option: --same
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[
+        OptionArg("x", long="same"),
+        OptionArg("y", long="same"),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: duplicate long option: --same
+    ),
+  )
 
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("hello", long="hello", negatable=true),
-      FlagArg("x", long="no-hello"),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate long option: --no-hello
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[
+        FlagArg("hello", long="hello", negatable=true),
+        FlagArg("x", long="no-hello"),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: duplicate long option: --no-hello
+    ),
+  )
 
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("x", short='s'),
-      OptionArg("y", short='s'),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate short option: -s
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[
+        OptionArg("x", short='s'),
+        OptionArg("y", short='s'),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: duplicate short option: -s
+    ),
+  )
 }
 
 ///|
 /// Argument relationships also form a graph over known args/groups. Self edges
 /// and missing nodes create unsatisfiable or unreportable requirements.
 test "argument relationship config rejects circular or unknown targets" {
-  try
-    @argparse.Command("demo", flags=[FlagArg("x", long="x", requires=["x"])]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg cannot require itself: x
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[FlagArg("x", long="x", requires=["x"])]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: arg cannot require itself: x
+    ),
+  )
 
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("x", long="x", conflicts_with=["x"]),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg cannot conflict with itself: x
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[
+        FlagArg("x", long="x", conflicts_with=["x"]),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: arg cannot conflict with itself: x
+    ),
+  )
 
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("mode", long="mode", requires=["missing"]),
-    ]).parse(argv=["--mode", "fast"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown requires target: mode -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[
+        OptionArg("mode", long="mode", requires=["missing"]),
+      ]).parse(argv=["--mode", "fast"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: unknown requires target: mode -> missing
+    ),
+  )
 
-  try
-    @argparse.Command("demo", flags=[
-      FlagArg("fast", long="fast", requires=["missing"]),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown requires target: fast -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", flags=[
+        FlagArg("fast", long="fast", requires=["missing"]),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: unknown requires target: fast -> missing
+    ),
+  )
 
-  try
-    @argparse.Command("demo", options=[
-      OptionArg("mode", long="mode", conflicts_with=["missing"]),
-    ]).parse(argv=["--mode", "fast"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown conflicts_with target: mode -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", options=[
+        OptionArg("mode", long="mode", conflicts_with=["missing"]),
+      ]).parse(argv=["--mode", "fast"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: unknown conflicts_with target: mode -> missing
+    ),
+  )
 
-  try
-    @argparse.Command("demo", subcommands=[
-      Command("child", flags=[FlagArg("x", long="x", requires=["missing"])]),
-    ]).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: unknown requires target: x -> missing
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", subcommands=[
+        Command("child", flags=[FlagArg("x", long="x", requires=["missing"])]),
+      ]).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: unknown requires target: x -> missing
+    ),
+  )
 }
 
 ///|
 /// Subcommand names are dispatch keys, and built-in help owns its route.
 /// Required-subcommand config must also provide at least one possible target.
 test "subcommand config rejects ambiguous command surfaces" {
-  try
-    @argparse.Command("demo", subcommands=[Command("x"), Command("x")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: duplicate subcommand: x
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", subcommands=[Command("x"), Command("x")]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: duplicate subcommand: x
+    ),
+  )
 
-  try
-    @argparse.Command("demo", subcommand_required=true).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: subcommand_required requires at least one subcommand
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", subcommand_required=true).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: subcommand_required requires at least one subcommand
+    ),
+  )
 
-  try
-    @argparse.Command("demo", subcommands=[Command("help")]).parse(
-      argv=[],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: subcommand name reserved for built-in help: help (disable with disable_help_subcommand)
-        ),
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command("demo", subcommands=[Command("help")]).parse(
+        argv=[],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: command definition validation failed: subcommand name reserved for built-in help: help (disable with disable_help_subcommand)
+    ),
+  )
 }
 
 ///|
@@ -671,147 +490,114 @@ test "subcommand config rejects ambiguous command surfaces" {
 /// Shadowing, alias reuse, or incompatible redeclarations would make merging
 /// and dispatch depend on where the token appears.
 test "global config rejects shadowing and incompatible redeclarations" {
-  try
-    @argparse.Command(
-      "demo",
-      options=[
-        OptionArg(
-          "mode",
-          long="mode",
-          env="MODE",
-          default_values=["safe"],
-          global=true,
-        ),
-      ],
-      subcommands=[Command("run", options=[OptionArg("mode", long="mode")])],
-    ).parse(argv=["run"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'mode' shadows an inherited global; rename the arg or mark it global
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        options=[
+          OptionArg(
+            "mode",
+            long="mode",
+            env="MODE",
+            default_values=["safe"],
+            global=true,
+          ),
+        ],
+        subcommands=[Command("run", options=[OptionArg("mode", long="mode")])],
+      ).parse(argv=["run"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: arg 'mode' shadows an inherited global; rename the arg or mark it global
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      options=[OptionArg("mode", long="mode", required=true, global=true)],
-      subcommands=[
-        Command("run", flags=[FlagArg("mode", long="mode", global=true)]),
-      ],
-    ).parse(argv=["run", "--mode"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: global arg 'mode' is incompatible with inherited global definition
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        options=[OptionArg("mode", long="mode", required=true, global=true)],
+        subcommands=[
+          Command("run", flags=[FlagArg("mode", long="mode", global=true)]),
+        ],
+      ).parse(argv=["run", "--mode"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: global arg 'mode' is incompatible with inherited global definition
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", long="verbose", global=true)],
-      subcommands=[Command("run", options=[OptionArg("local", long="verbose")])],
-    ).parse(argv=["run", "--verbose"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'local' long option --verbose conflicts with inherited global 'verbose'
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        flags=[FlagArg("verbose", long="verbose", global=true)],
+        subcommands=[
+          Command("run", options=[OptionArg("local", long="verbose")]),
+        ],
+      ).parse(argv=["run", "--verbose"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: arg 'local' long option --verbose conflicts with inherited global 'verbose'
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", short='v', global=true)],
-      subcommands=[Command("run", options=[OptionArg("local", short='v')])],
-    ).parse(argv=["run", "-v"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'local' short option -v conflicts with inherited global 'verbose'
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        flags=[FlagArg("verbose", short='v', global=true)],
+        subcommands=[Command("run", options=[OptionArg("local", short='v')])],
+      ).parse(argv=["run", "-v"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: arg 'local' short option -v conflicts with inherited global 'verbose'
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("verbose", long="verbose", negatable=true, global=true)],
-      subcommands=[
-        Command("run", flags=[
-          FlagArg("verbose", long="verbose", negatable=false, global=true),
-        ]),
-      ],
-    ).parse(argv=["run"], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: global arg 'verbose' is incompatible with inherited global definition
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        flags=[FlagArg("verbose", long="verbose", negatable=true, global=true)],
+        subcommands=[
+          Command("run", flags=[
+            FlagArg("verbose", long="verbose", negatable=false, global=true),
+          ]),
+        ],
+      ).parse(argv=["run"], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: global arg 'verbose' is incompatible with inherited global definition
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      flags=[FlagArg("shared", long="shared", global=true)],
-      subcommands=[
-        Command("child", options=[
-          OptionArg("shared", long="shared", global=true),
-        ]),
-      ],
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: global arg 'shared' is incompatible with inherited global definition
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        flags=[FlagArg("shared", long="shared", global=true)],
+        subcommands=[
+          Command("child", options=[
+            OptionArg("shared", long="shared", global=true),
+          ]),
+        ],
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: global arg 'shared' is incompatible with inherited global definition
+    ),
+  )
 
-  try
-    @argparse.Command(
-      "demo",
-      options=[OptionArg("opt", long="dup", global=true)],
-      subcommands=[Command("child", flags=[FlagArg("other", long="dup")])],
-    ).parse(argv=[], env=empty_env())
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: command definition validation failed: arg 'other' long option --dup conflicts with inherited global 'opt'
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      @argparse.Command(
+        "demo",
+        options=[OptionArg("opt", long="dup", global=true)],
+        subcommands=[Command("child", flags=[FlagArg("other", long="dup")])],
+      ).parse(argv=[], env=empty_env())
+    }),
+    content=(
+      #|error: command definition validation failed: arg 'other' long option --dup conflicts with inherited global 'opt'
+    ),
+  )
 }

--- a/argparse/relationships_test.mbt
+++ b/argparse/relationships_test.mbt
@@ -19,25 +19,22 @@ test "relationships and num args" {
     OptionArg("config", long="config"),
   ])
 
-  try requires_cmd.parse(argv=["--mode", "fast"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required argument was not provided: 'config' (required by 'mode')
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help         Show help information.
-          #|  --mode <mode>      
-          #|  --config <config>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      requires_cmd.parse(argv=["--mode", "fast"], env=empty_env())
+    }),
+    content=(
+      #|error: the following required argument was not provided: 'config' (required by 'mode')
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help         Show help information.
+      #|  --mode <mode>      
+      #|  --config <config>  
+      #|
+    ),
+  )
 
   let appended = @argparse.Command("demo", options=[
     OptionArg("tag", long="tag", action=Append),
@@ -57,52 +54,44 @@ test "arg groups required and multiple" {
     flags=[FlagArg("fast", long="fast"), FlagArg("slow", long="slow")],
   )
 
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required arguments were not provided:
-          #|  <--fast|--slow>
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --fast      
-          #|  --slow      
-          #|
-          #|Groups:
-          #|  mode [required] [exclusive]  --fast, --slow
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env=empty_env())),
+    content=(
+      #|error: the following required arguments were not provided:
+      #|  <--fast|--slow>
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --fast      
+      #|  --slow      
+      #|
+      #|Groups:
+      #|  mode [required] [exclusive]  --fast, --slow
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["--fast", "--slow"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: group conflict mode
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --fast      
-          #|  --slow      
-          #|
-          #|Groups:
-          #|  mode [required] [exclusive]  --fast, --slow
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--fast", "--slow"], env=empty_env())
+    }),
+    content=(
+      #|error: group conflict mode
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --fast      
+      #|  --slow      
+      #|
+      #|Groups:
+      #|  mode [required] [exclusive]  --fast, --slow
+      #|
+    ),
+  )
 }
 
 ///|
@@ -116,30 +105,27 @@ test "arg groups requires and conflicts" {
     flags=[FlagArg("fast", long="fast"), FlagArg("json", long="json")],
   )
 
-  try requires_cmd.parse(argv=["--fast"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required arguments were not provided:
-          #|  <--json>
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --fast      
-          #|  --json      
-          #|
-          #|Groups:
-          #|  mode    --fast
-          #|  output  --json
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      requires_cmd.parse(argv=["--fast"], env=empty_env())
+    }),
+    content=(
+      #|error: the following required arguments were not provided:
+      #|  <--json>
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --fast      
+      #|  --json      
+      #|
+      #|Groups:
+      #|  mode    --fast
+      #|  output  --json
+      #|
+    ),
+  )
 
   let conflict_cmd = @argparse.Command(
     "demo",
@@ -150,29 +136,26 @@ test "arg groups requires and conflicts" {
     flags=[FlagArg("fast", long="fast"), FlagArg("json", long="json")],
   )
 
-  try conflict_cmd.parse(argv=["--fast", "--json"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: group conflict mode conflicts with output
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|  --fast      
-          #|  --json      
-          #|
-          #|Groups:
-          #|  mode    --fast
-          #|  output  --json
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      conflict_cmd.parse(argv=["--fast", "--json"], env=empty_env())
+    }),
+    content=(
+      #|error: group conflict mode conflicts with output
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|  --fast      
+      #|  --json      
+      #|
+      #|Groups:
+      #|  mode    --fast
+      #|  output  --json
+      #|
+    ),
+  )
 }
 
 ///|
@@ -195,27 +178,24 @@ test "negatable and conflicts" {
   }
   assert_true(no_failfast.flags is { "failfast": true, .. })
 
-  try cmd.parse(argv=["--verbose", "--quiet"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: conflicting arguments: verbose and quiet
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help       Show help information.
-          #|  --[no-]cache     
-          #|  --[no-]failfast  
-          #|  --verbose        
-          #|  --quiet          
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["--verbose", "--quiet"], env=empty_env())
+    }),
+    content=(
+      #|error: conflicting arguments: verbose and quiet
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help       Show help information.
+      #|  --[no-]cache     
+      #|  --[no-]failfast  
+      #|  --verbose        
+      #|  --quiet          
+      #|
+    ),
+  )
 }
 
 ///|
@@ -236,28 +216,25 @@ test "group requires/conflicts can target argument names" {
   assert_true(ok.flags is { "fast": true, .. })
   assert_true(ok.values is { "config": ["cfg.toml"], .. })
 
-  try requires_cmd.parse(argv=["--fast"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required argument was not provided: 'config'
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help         Show help information.
-          #|  --fast             
-          #|  --config <config>  
-          #|
-          #|Groups:
-          #|  mode  --fast
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      requires_cmd.parse(argv=["--fast"], env=empty_env())
+    }),
+    content=(
+      #|error: the following required argument was not provided: 'config'
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help         Show help information.
+      #|  --fast             
+      #|  --config <config>  
+      #|
+      #|Groups:
+      #|  mode  --fast
+      #|
+    ),
+  )
 
   let conflicts_cmd = @argparse.Command(
     "demo",
@@ -266,33 +243,28 @@ test "group requires/conflicts can target argument names" {
     options=[OptionArg("config", long="config")],
   )
 
-  try
-    conflicts_cmd.parse(
-      argv=["--fast", "--config", "cfg.toml"],
-      env=empty_env(),
-    )
-  catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: group conflict mode conflicts with config
-          #|
-          #|Usage: demo [options]
-          #|
-          #|Options:
-          #|  -h, --help         Show help information.
-          #|  --fast             
-          #|  --config <config>  
-          #|
-          #|Groups:
-          #|  mode  --fast
-          #|
-        ),
+  inspect(
+    @test.expect_error(() => {
+      conflicts_cmd.parse(
+        argv=["--fast", "--config", "cfg.toml"],
+        env=empty_env(),
       )
-  } noraise {
-    _ => panic()
-  }
+    }),
+    content=(
+      #|error: group conflict mode conflicts with config
+      #|
+      #|Usage: demo [options]
+      #|
+      #|Options:
+      #|  -h, --help         Show help information.
+      #|  --fast             
+      #|  --config <config>  
+      #|
+      #|Groups:
+      #|  mode  --fast
+      #|
+    ),
+  )
 }
 
 ///|
@@ -324,24 +296,19 @@ test "required and env-fed ranged values validate after parsing" {
   let required_cmd = @argparse.Command("demo", options=[
     OptionArg("input", long="input", required=true),
   ])
-  try required_cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required argument was not provided: 'input'
-          #|
-          #|Usage: demo --input <input>
-          #|
-          #|Options:
-          #|  -h, --help       Show help information.
-          #|  --input <input>  
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => required_cmd.parse(argv=[], env=empty_env())),
+    content=(
+      #|error: the following required argument was not provided: 'input'
+      #|
+      #|Usage: demo --input <input>
+      #|
+      #|Options:
+      #|  -h, --help       Show help information.
+      #|  --input <input>  
+      #|
+    ),
+  )
 
   let env_min_cmd = @argparse.Command("demo", options=[
     OptionArg("pair", long="pair", env="PAIR"),
@@ -360,21 +327,16 @@ test "required group with only hidden members reports a plain message" {
     groups=[ArgGroup("mode", required=true, args=["fast"])],
     flags=[FlagArg("fast", long="fast", hidden=true)],
   )
-  try cmd.parse(argv=[], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: the following required argument group was not provided: 'mode'
-          #|
-          #|Usage: demo
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=[], env=empty_env())),
+    content=(
+      #|error: the following required argument group was not provided: 'mode'
+      #|
+      #|Usage: demo
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }

--- a/argparse/subcommands_test.mbt
+++ b/argparse/subcommands_test.mbt
@@ -140,30 +140,25 @@ test "subcommand cannot follow positional arguments" {
   let cmd = @argparse.Command("demo", positionals=[PositionArg("input")], subcommands=[
     Command("run"),
   ])
-  try cmd.parse(argv=["raw", "run"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: subcommand 'run' cannot be used with positional arguments
-          #|
-          #|Usage: demo [input] [command]
-          #|
-          #|Commands:
-          #|  run   
-          #|  help  Print help for the subcommand(s).
-          #|
-          #|Arguments:
-          #|  input  
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["raw", "run"], env=empty_env())),
+    content=(
+      #|error: subcommand 'run' cannot be used with positional arguments
+      #|
+      #|Usage: demo [input] [command]
+      #|
+      #|Commands:
+      #|  run   
+      #|  help  Print help for the subcommand(s).
+      #|
+      #|Arguments:
+      #|  input  
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|
@@ -179,86 +174,73 @@ test "subcommand suggestions are only reported for parse failures" {
   assert_true(positional.values is { "input": ["serv"], .. })
   assert_true(positional.subcommand is None)
 
-  try cmd.parse(argv=["input.txt", "serv"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'serv' for '<input>' found; no more were expected
-          #|
-          #|  tip: a similar subcommand exists: 'serve'
-          #|
-          #|Usage: demo [input] [command]
-          #|
-          #|Commands:
-          #|  serve  serve
-          #|  help   Print help for the subcommand(s).
-          #|
-          #|Arguments:
-          #|  input  input file
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => {
+      cmd.parse(argv=["input.txt", "serv"], env=empty_env())
+    }),
+    content=(
+      #|error: unexpected value 'serv' for '<input>' found; no more were expected
+      #|
+      #|  tip: a similar subcommand exists: 'serve'
+      #|
+      #|Usage: demo [input] [command]
+      #|
+      #|Commands:
+      #|  serve  serve
+      #|  help   Print help for the subcommand(s).
+      #|
+      #|Arguments:
+      #|  input  input file
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 
   let no_positionals = @argparse.Command("demo", subcommands=[
     Command("serve", about="serve"),
   ])
-  try no_positionals.parse(argv=["hel"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unexpected value 'hel' found; no more were expected
-          #|
-          #|  tip: a similar subcommand exists: 'help'
-          #|
-          #|Usage: demo [command]
-          #|
-          #|Commands:
-          #|  serve  serve
-          #|  help   Print help for the subcommand(s).
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => no_positionals.parse(argv=["hel"], env=empty_env())),
+    content=(
+      #|error: unexpected value 'hel' found; no more were expected
+      #|
+      #|  tip: a similar subcommand exists: 'help'
+      #|
+      #|Usage: demo [command]
+      #|
+      #|Commands:
+      #|  serve  serve
+      #|  help   Print help for the subcommand(s).
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 
-  try cmd.parse(argv=["help", "serv"], env=empty_env()) catch {
-    err =>
-      inspect(
-        err,
-        content=(
-          #|error: unknown subcommand: serv
-          #|
-          #|  tip: a similar subcommand exists: 'serve'
-          #|
-          #|Usage: demo [input] [command]
-          #|
-          #|Commands:
-          #|  serve  serve
-          #|  help   Print help for the subcommand(s).
-          #|
-          #|Arguments:
-          #|  input  input file
-          #|
-          #|Options:
-          #|  -h, --help  Show help information.
-          #|
-        ),
-      )
-  } noraise {
-    _ => panic()
-  }
+  inspect(
+    @test.expect_error(() => cmd.parse(argv=["help", "serv"], env=empty_env())),
+    content=(
+      #|error: unknown subcommand: serv
+      #|
+      #|  tip: a similar subcommand exists: 'serve'
+      #|
+      #|Usage: demo [input] [command]
+      #|
+      #|Commands:
+      #|  serve  serve
+      #|  help   Print help for the subcommand(s).
+      #|
+      #|Arguments:
+      #|  input  input file
+      #|
+      #|Options:
+      #|  -h, --help  Show help information.
+      #|
+    ),
+  )
 }
 
 ///|


### PR DESCRIPTION
## Why

Argparse expected-failure tests used repetitive `try`/`catch` scaffolding even though the shared test helper provides `@test.expect_error` for this purpose.

## What changed

Expected-error assertions across the argparse black-box suites now use `@test.expect_error` while retaining their exact error snapshots. The package adds the test-only helper import required by that API.

## Why this is correct

Each converted test still asserts that the same operation raises and preserves the same expected error output. Expected-success paths are unchanged.

## Scope

This is test-only cleanup; argparse behavior and public APIs are unchanged.