### PR TITLE
ci: raise 'run tests' step timeout to 20 minutes

### DIFF
--- a/.github/workflows/bleeding-check.yml
+++ b/.github/workflows/bleeding-check.yml
@@ -26,7 +26,7 @@ jobs:
           version: nightly
 
       - name: run tests
-        timeout-minutes: 10
+        timeout-minutes: 20
         uses: ./.github/actions/test
 
       - name: Test new allocator

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -148,7 +148,7 @@ jobs:
         run: moon check --deny-warn
 
       - name: run tests
-        timeout-minutes: 10
+        timeout-minutes: 20
         uses: ./.github/actions/test
 
       - name: moon bundle

--- a/.github/workflows/stable-check.yml
+++ b/.github/workflows/stable-check.yml
@@ -41,7 +41,7 @@ jobs:
           git diff --exit-code
 
       - name: run tests
-        timeout-minutes: 10
+        timeout-minutes: 20
         uses: ./.github/actions/test
 
       - name: moon bundle


### PR DESCRIPTION
## Problem

`stable-check (windows-latest)` on `main` failed in [run 32375552764](https://github.com/moonbitlang/core/actions/runs/32375552764): the **run tests** step hit its 10-minute `timeout-minutes` limit. The log shows all 7466 tests passing on each target right up to `##[error]The action has timed out.` — the suite has simply outgrown the limit on the slower Windows runners.

## Change

Bump `timeout-minutes` from 10 to 20 for the shared `./.github/actions/test` step in all three workflows that use it (`stable-check`, `bleeding-check`, `pre-release-check`), since they run the identical suite on the same `windows-latest` runners.

Low risk: this only widens the flake ceiling; a genuinely hung run still gets killed, just 10 minutes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)