### PR TITLE
perf(hex): vectorize encode/decode on the linear-memory backends

### DIFF
--- a/encoding/hex/decode.mbt
+++ b/encoding/hex/decode.mbt
@@ -37,7 +37,33 @@ fn hex_value(code_unit : Int) -> Int {
 /// Both lowercase and uppercase hexadecimal characters are accepted. Raises
 /// `Malformed` if the input length is odd or any character is not a
 /// hexadecimal digit.
+#cfg(not(any(target="native", target="wasm")))
 pub fn decode(text : StringView) -> Bytes raise Malformed {
+  decode_scalar(text)
+}
+
+///|
+/// Decodes a hexadecimal string into bytes.
+///
+/// Both lowercase and uppercase hexadecimal characters are accepted. Raises
+/// `Malformed` if the input length is odd or any character is not a
+/// hexadecimal digit.
+#cfg(any(target="native", target="wasm"))
+pub fn decode(text : StringView) -> Bytes raise Malformed {
+  match decode_v128(text) {
+    Some(bytes) => bytes
+    // Not handled by the fast path: short, odd-length, or invalid input.
+    // The scalar decoder is the single source of the `Malformed` rules.
+    None => decode_scalar(text)
+  }
+}
+
+///|
+/// Retained on every backend: the linear-memory backends reach it only from
+/// the differential tests and the fast path's rejections, but it is the
+/// implementation everywhere else.
+#warnings("-unused_value")
+fn decode_scalar(text : StringView) -> Bytes raise Malformed {
   if text.length() % 2 != 0 {
     raise Malformed(text)
   }

--- a/encoding/hex/decode_v128.mbt
+++ b/encoding/hex/decode_v128.mbt
@@ -1,0 +1,121 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Vectorized hexadecimal decoding for the linear-memory backends.
+//
+// A MoonBit `String` is UTF-16, so a block loads four vectors of eight code
+// units and narrows them to thirty-two ASCII characters, which decode to
+// sixteen bytes. The narrow reads its lanes as signed and saturates, so a
+// code unit in `0x0100..=0x7FFF` becomes 255 and one in `0x8000..=0xFFFF`
+// -- surrogate halves included -- becomes 0. Neither is a hex digit, so the
+// validity check rejects both and no non-ASCII code unit can masquerade as
+// a hex digit by way of its low byte.
+//
+// The fast path only handles even-length input made of hex digits. Anything
+// else defers to `decode_scalar`, which remains the single definition of the
+// `Malformed` rules.
+
+///|
+/// True when every lane holds an ASCII hex digit (`0-9`, `a-f`, `A-F`).
+#cfg(any(target="native", target="wasm"))
+fn hex_valid_v128(ascii : V128) -> Bool {
+  let digit = @v128.v128_and_(
+    @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'0')),
+    @v128.i8x16_le_u(ascii, @v128.i8x16_splat(b'9')),
+  )
+  let lower = @v128.v128_and_(
+    @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'a')),
+    @v128.i8x16_le_u(ascii, @v128.i8x16_splat(b'f')),
+  )
+  let upper = @v128.v128_and_(
+    @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'A')),
+    @v128.i8x16_le_u(ascii, @v128.i8x16_splat(b'F')),
+  )
+  @v128.i8x16_all_true(@v128.v128_or_(digit, @v128.v128_or_(lower, upper)))
+}
+
+///|
+/// Maps sixteen ASCII hex digits to their nibble values. Only meaningful
+/// after `hex_valid_v128` accepted the lanes: `- '0'` handles digits, and a
+/// further masked `- 39` (lowercase) or `- 7` (uppercase) shifts the letter
+/// ranges onto 10..=15. The adjustments are wrapping adds of the two's
+/// complements because `i8x16_add` wraps.
+#cfg(any(target="native", target="wasm"))
+fn hex_nibbles_v128(ascii : V128) -> V128 {
+  let lower = @v128.v128_and_(
+    @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'a')),
+    @v128.i8x16_splat(217), // -39 mod 256
+  )
+  let upper = @v128.v128_and_(
+    @v128.v128_and_(
+      @v128.i8x16_ge_u(ascii, @v128.i8x16_splat(b'A')),
+      @v128.i8x16_le_u(ascii, @v128.i8x16_splat(b'F')),
+    ),
+    @v128.i8x16_splat(249), // -7 mod 256
+  )
+  @v128.i8x16_add(
+    @v128.i8x16_add(ascii, @v128.i8x16_splat(208)), // -48 mod 256
+    @v128.v128_or_(lower, upper),
+  )
+}
+
+///|
+/// Decodes even-length all-hex text. Returns `None` when the fast path does
+/// not apply (short, odd-length, or invalid input), in which case the caller
+/// must use the scalar decoder.
+#cfg(any(target="native", target="wasm"))
+fn decode_v128(text : StringView) -> Bytes? {
+  let length = text.length()
+  // Below one full block the scalar decoder wins outright.
+  guard length >= 32 && length % 2 == 0 else { return None }
+  let out = FixedArray::make(length / 2, b'\x00')
+  let src = text.data()
+  let base = text.start_offset()
+  let mut index = 0
+  let mut written = 0
+  // subtraction, so that the bound cannot wrap on a very long input
+  while length - index >= 32 {
+    let offset = base + index
+    let ascii0 = @v128.i8x16_narrow_i16x8_u(
+      @v128.v128_load_i16x8(src, offset),
+      @v128.v128_load_i16x8(src, offset + 8),
+    )
+    let ascii1 = @v128.i8x16_narrow_i16x8_u(
+      @v128.v128_load_i16x8(src, offset + 16),
+      @v128.v128_load_i16x8(src, offset + 24),
+    )
+    guard hex_valid_v128(ascii0) && hex_valid_v128(ascii1) else { return None }
+    let n0 = hex_nibbles_v128(ascii0)
+    let n1 = hex_nibbles_v128(ascii1)
+    // high nibbles sit in the even lanes, low nibbles in the odd lanes
+    let hi = @v128.i8x16_shuffle(
+      n0, n1, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30,
+    )
+    let lo = @v128.i8x16_shuffle(
+      n0, n1, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31,
+    )
+    @v128.v128_store(out, written, @v128.v128_or_(@v128.i8x16_shl(hi, 4), lo))
+    index += 32
+    written += 16
+  }
+  while index < length {
+    let hi = hex_value(text.unsafe_get(index).to_int())
+    let lo = hex_value(text.unsafe_get(index + 1).to_int())
+    guard hi >= 0 && lo >= 0 else { return None }
+    out[written] = ((hi << 4) | lo).to_byte()
+    index += 2
+    written += 1
+  }
+  Some(out.unsafe_reinterpret_as_bytes())
+}

--- a/encoding/hex/encode.mbt
+++ b/encoding/hex/encode.mbt
@@ -19,7 +19,25 @@ const HEX_DIGITS : Bytes = b"0123456789abcdef"
 /// Encodes bytes as a lowercase hexadecimal string.
 ///
 /// The returned string has length `2 * bytes.length()`.
+#cfg(not(any(target="native", target="wasm")))
 pub fn encode(bytes : BytesView) -> String {
+  encode_scalar(bytes)
+}
+
+///|
+/// Encodes bytes as a lowercase hexadecimal string.
+///
+/// The returned string has length `2 * bytes.length()`.
+#cfg(any(target="native", target="wasm"))
+pub fn encode(bytes : BytesView) -> String {
+  encode_v128(bytes)
+}
+
+///|
+/// Retained on every backend: the linear-memory backends reach it only from
+/// the differential tests, but it is the implementation everywhere else.
+#warnings("-unused_value")
+fn encode_scalar(bytes : BytesView) -> String {
   // size_hint is measured in bytes, and each of the 2n output code units
   // occupies two bytes in the builder's UTF-16 buffer
   let builder = StringBuilder(size_hint=4 * bytes.length())

--- a/encoding/hex/encode_v128.mbt
+++ b/encoding/hex/encode_v128.mbt
@@ -1,0 +1,98 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Vectorized hexadecimal encoding for the linear-memory backends.
+//
+// Each iteration turns sixteen source bytes into thirty-two hex characters:
+// split every byte into its high and low nibble, interleave the nibbles into
+// output order, and convert each nibble to ASCII with a single register-
+// resident table lookup (`i8x16_swizzle`). Because a MoonBit `String` is
+// UTF-16, the thirty-two ASCII characters are widened to sixty-four bytes
+// before being stored.
+
+///|
+/// V128 loads require `FixedArray[Byte]`; these types share a representation
+/// on the linear-memory backends.
+#cfg(any(target="native", target="wasm"))
+fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
+
+///|
+/// The sixteen hex digits as swizzle-table lanes: lane `n` holds the ASCII
+/// code of the lowercase digit for nibble value `n`.
+#cfg(any(target="native", target="wasm"))
+fn hex_digits_v128() -> V128 {
+  @v128.i8x16_const(
+    48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99, 100, 101, 102,
+  )
+}
+
+///|
+/// Writes one ASCII character as a little-endian UTF-16 code unit.
+#cfg(any(target="native", target="wasm"))
+#inline
+fn write_code_unit(out : FixedArray[Byte], offset : Int, code : Byte) -> Unit {
+  out[offset] = code
+  out[offset + 1] = 0
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+fn encode_v128(bytes : BytesView) -> String {
+  let length = bytes.length()
+  // The vector stores are not bounds checked, so the UTF-16 byte buffer
+  // must be sized without wrapping. Its four bytes per source byte overflow
+  // sooner than the string itself does, so the scalar encoder -- which
+  // builds the string without ever materializing that buffer -- takes over
+  // from here.
+  guard length <= 0x1FFF_FFFF else { return encode_scalar(bytes) } // Int::MAX / 4
+  // 2 output code units per byte, 2 bytes per UTF-16 code unit
+  let out = FixedArray::make(length * 4, b'\x00')
+  let src = unsafe_fixedarray_from_bytes(bytes.data())
+  let base = bytes.start_offset()
+  let end = base + length
+  let table = hex_digits_v128()
+  let mut index = base
+  let mut written = 0
+  // written as a subtraction so that a view sitting at the very end of a
+  // large buffer cannot wrap the bound into accepting a short block
+  while end - index >= 16 {
+    let data = @v128.v128_load(src, index)
+    let hi = @v128.i8x16_shr_u(data, 4)
+    let lo = @v128.v128_and_(data, @v128.i8x16_splat(0x0F))
+    // interleave: source byte k produces digits at output positions 2k
+    // (high nibble) and 2k + 1 (low nibble)
+    let first = @v128.i8x16_shuffle(
+      hi, lo, 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23,
+    )
+    let second = @v128.i8x16_shuffle(
+      hi, lo, 8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31,
+    )
+    let d0 = @v128.i8x16_swizzle(table, first)
+    let d1 = @v128.i8x16_swizzle(table, second)
+    @v128.v128_store(out, written, @v128.i16x8_extend_low_i8x16_u(d0))
+    @v128.v128_store(out, written + 16, @v128.i16x8_extend_high_i8x16_u(d0))
+    @v128.v128_store(out, written + 32, @v128.i16x8_extend_low_i8x16_u(d1))
+    @v128.v128_store(out, written + 48, @v128.i16x8_extend_high_i8x16_u(d1))
+    index += 16
+    written += 64
+  }
+  while index < end {
+    let n = src[index].to_int()
+    write_code_unit(out, written, HEX_DIGITS[(n >> 4) & 0x0F])
+    write_code_unit(out, written + 2, HEX_DIGITS[n & 0x0F])
+    index += 1
+    written += 4
+  }
+  out.unsafe_reinterpret_as_bytes().to_unchecked_string()
+}

--- a/encoding/hex/moon.pkg
+++ b/encoding/hex/moon.pkg
@@ -2,4 +2,18 @@ import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
+  "moonbitlang/core/v128",
 }
+
+import {
+  "moonbitlang/core/quickcheck",
+} for "test"
+
+import {
+  "moonbitlang/core/bench",
+  "moonbitlang/core/test",
+} for "wbtest"
+
+// The v128 import is only reachable from the linear-memory backends.
+
+warnings = "-29"

--- a/encoding/hex/quickcheck_test.mbt
+++ b/encoding/hex/quickcheck_test.mbt
@@ -47,7 +47,7 @@ test "quickcheck: decode accepts any case mixture and round-trips" {
     (input : (Bytes, Array[Bool])) => {
       let (bytes, flips) = input
       let lower = @hex.encode(bytes)
-      let sb = StringBuilder(size_hint=4 * lower.length())
+      let sb = StringBuilder(size_hint=2 * lower.length())
       for i in 0..<lower.length() {
         let c = lower.unsafe_get(i).to_char().unwrap()
         let flip = flips.length() > 0 && flips[i % flips.length()]
@@ -79,7 +79,7 @@ test "quickcheck: corrupting any position makes decode raise" {
         'g', 'z', 'G', '/', ':', '@', '`', '\u{80}', '中', ' ',
       ]
       let bad = bad_pool[(char0 % bad_pool.length().reinterpret_as_uint()).reinterpret_as_int()]
-      let sb = StringBuilder(size_hint=4 * text.length())
+      let sb = StringBuilder(size_hint=2 * text.length())
       for i in 0..<text.length() {
         sb.write_char(
           if i == pos {

--- a/encoding/hex/quickcheck_test.mbt
+++ b/encoding/hex/quickcheck_test.mbt
@@ -1,0 +1,117 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Randomized properties for the hex codec, checked against a character-level
+// reference model. On the linear-memory backends the public functions take
+// the vectorized paths for large-enough inputs, so these properties fuzz the
+// SIMD code there and the scalar code elsewhere.
+
+///|
+fn reference_encode(bytes : Bytes) -> String {
+  let digits = "0123456789abcdef"
+  let sb = StringBuilder(size_hint=4 * bytes.length())
+  for b in bytes {
+    sb.write_char(digits.get_char(b.to_int() >> 4).unwrap())
+    sb.write_char(digits.get_char(b.to_int() & 0x0F).unwrap())
+  }
+  sb.to_string()
+}
+
+///|
+test "quickcheck: decode is the inverse of encode" {
+  @quickcheck.check(
+    (bytes : Bytes) => {
+      let text = @hex.encode(bytes)
+      text == reference_encode(bytes) &&
+      text.length() == 2 * bytes.length() &&
+      @hex.decode(text) == bytes
+    },
+    count=200,
+  )
+}
+
+///|
+test "quickcheck: decode accepts any case mixture and round-trips" {
+  @quickcheck.check(
+    (input : (Bytes, Array[Bool])) => {
+      let (bytes, flips) = input
+      let lower = @hex.encode(bytes)
+      let sb = StringBuilder(size_hint=4 * lower.length())
+      for i in 0..<lower.length() {
+        let c = lower.unsafe_get(i).to_char().unwrap()
+        let flip = flips.length() > 0 && flips[i % flips.length()]
+        sb.write_char(
+          if flip && c >= 'a' && c <= 'f' {
+            (c.to_int() - 32).unsafe_to_char()
+          } else {
+            c
+          },
+        )
+      }
+      @hex.decode(sb.to_string()) == bytes
+    },
+    count=200,
+  )
+}
+
+///|
+test "quickcheck: corrupting any position makes decode raise" {
+  @quickcheck.check(
+    (input : (Bytes, UInt, UInt)) => {
+      let (bytes, pos0, char0) = input
+      guard bytes.length() > 0 else { return true }
+      let text = @hex.encode(bytes)
+      let pos = (pos0 % text.length().reinterpret_as_uint()).reinterpret_as_int()
+      // any code unit outside the three hex ranges, spanning ASCII and
+      // non-ASCII space
+      let bad_pool : ReadOnlyArray[Char] = [
+        'g', 'z', 'G', '/', ':', '@', '`', '\u{80}', '中', ' ',
+      ]
+      let bad = bad_pool[(char0 % bad_pool.length().reinterpret_as_uint()).reinterpret_as_int()]
+      let sb = StringBuilder(size_hint=4 * text.length())
+      for i in 0..<text.length() {
+        sb.write_char(
+          if i == pos {
+            bad
+          } else {
+            text.unsafe_get(i).to_char().unwrap()
+          },
+        )
+      }
+      try {
+        let _ = @hex.decode(sb.to_string())
+        false
+      } catch {
+        Malformed(_) => true
+      }
+    },
+    count=200,
+  )
+}
+
+///|
+test "quickcheck: odd-length inputs always raise" {
+  @quickcheck.check(
+    (bytes : Bytes) => {
+      let text = @hex.encode(bytes) + "a"
+      try {
+        let _ = @hex.decode(text)
+        false
+      } catch {
+        Malformed(_) => true
+      }
+    },
+    count=100,
+  )
+}

--- a/encoding/hex/v128_bench_wbtest.mbt
+++ b/encoding/hex/v128_bench_wbtest.mbt
@@ -1,0 +1,75 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Scalar and public (vectorized on the linear-memory backends) codec paths
+// benchmarked side by side, so a single run per target reports both.
+
+///|
+let hex_bench_input_64 : Bytes = sample_bytes(64)
+
+///|
+let hex_bench_input_4k : Bytes = sample_bytes(4096)
+
+///|
+let hex_bench_input_64k : Bytes = sample_bytes(65536)
+
+///|
+let hex_bench_text_4k : String = encode_scalar(hex_bench_input_4k)
+
+///|
+let hex_bench_text_64k : String = encode_scalar(hex_bench_input_64k)
+
+///|
+test "bench encode scalar 4k" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode_scalar(hex_bench_input_4k).length()) })
+}
+
+///|
+test "bench encode public 64" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode(hex_bench_input_64).length()) })
+}
+
+///|
+test "bench encode public 4k" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode(hex_bench_input_4k).length()) })
+}
+
+///|
+test "bench encode public 64k" (it : @bench.T) {
+  it.bench(fn() { it.keep(encode(hex_bench_input_64k).length()) })
+}
+
+///|
+test "bench decode scalar 4k" (it : @bench.T) {
+  it.bench(fn() {
+    let bytes = try! decode_scalar(hex_bench_text_4k)
+    it.keep(bytes.length())
+  })
+}
+
+///|
+test "bench decode public 4k" (it : @bench.T) {
+  it.bench(fn() {
+    let bytes = try! decode(hex_bench_text_4k)
+    it.keep(bytes.length())
+  })
+}
+
+///|
+test "bench decode public 64k" (it : @bench.T) {
+  it.bench(fn() {
+    let bytes = try! decode(hex_bench_text_64k)
+    it.keep(bytes.length())
+  })
+}

--- a/encoding/hex/v128_wbtest.mbt
+++ b/encoding/hex/v128_wbtest.mbt
@@ -1,0 +1,175 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Differential tests pinning the vectorized paths against the scalar ones.
+// Lengths sweep every residue modulo sixteen (encode blocks) and modulo
+// thirty-two (decode blocks), so every block-count and tail combination is
+// covered. On the backends without the vectorized paths these compare the
+// scalar implementation with itself, which keeps the file portable.
+
+///|
+/// Deterministic pseudo-random bytes covering all 256 byte values.
+fn sample_bytes(length : Int) -> Bytes {
+  let out = FixedArray::make(length, b'\x00')
+  let mut state = 0x2545F491U
+  for i in 0..<length {
+    state = state * 1664525 + 1013904223
+    out[i] = ((state >> 16) & 0xFF).reinterpret_as_int().to_byte()
+  }
+  out.unsafe_reinterpret_as_bytes()
+}
+
+///|
+test "encode agrees with the scalar encoder across all tail residues" {
+  for length in 0..<80 {
+    let bytes = sample_bytes(length)
+    @test.assert_eq(encode(bytes), encode_scalar(bytes))
+  }
+}
+
+///|
+test "decode agrees with the scalar decoder across all block counts" {
+  for length in 0..<80 {
+    let bytes = sample_bytes(length)
+    let lowercase = encode(bytes)
+    @test.assert_eq(decode(lowercase), bytes)
+    @test.assert_eq(decode(lowercase), decode_scalar(lowercase))
+    // uppercase exercise the letter-range adjustment lanes
+    let uppercase = lowercase.to_upper()
+    @test.assert_eq(decode(uppercase), bytes)
+    @test.assert_eq(decode(uppercase), decode_scalar(uppercase))
+  }
+}
+
+///|
+/// Builds a string from raw UTF-16 code units, so that a test can plant code
+/// units -- lone surrogates included -- that no `Char` can express.
+fn string_of_code_units(units : ArrayView[Int]) -> String {
+  let out = FixedArray::make(units.length() * 2, b'\x00')
+  for i, unit in units {
+    out[i * 2] = (unit & 0xFF).to_byte()
+    out[i * 2 + 1] = ((unit >> 8) & 0xFF).to_byte()
+  }
+  out.unsafe_reinterpret_as_bytes().to_unchecked_string()
+}
+
+///|
+/// The tests above compare the public entry points against the scalar ones,
+/// which stay green even if the fast paths stopped being reached. This one
+/// calls them directly: `encode_v128` must agree with the scalar encoder,
+/// and `decode_v128` must accept a well-formed block rather than defer.
+/// (Which path the entry points dispatch to is a `#cfg` decision; the
+/// benchmarks are what would show a regression there.)
+#cfg(any(target="native", target="wasm"))
+test "the vector paths are engaged, not merely present" {
+  let bytes = sample_bytes(48)
+  let text = encode_scalar(bytes)
+  @test.assert_eq(encode_v128(bytes), text)
+  match decode_v128(text) {
+    Some(decoded) => @test.assert_eq(decoded, bytes)
+    None => fail("decode_v128 declined a well-formed block")
+  }
+}
+
+///|
+test "non-ASCII code units are rejected in every lane" {
+  // The six above 0x00FF each have a low byte that is a valid hex
+  // character, so a decoder that truncated code units instead of
+  // saturating them would accept the input and decode it to the wrong
+  // bytes. 0x00FF is the value saturation itself produces and 0x0000 the
+  // value the signed lanes fold the high half onto, so both must be
+  // rejected on their own account too.
+  let aliasing_units = [
+    0x0000, 0x00FF, 0x0130, 0x0161, 0xD830, 0xDC30, 0xFF41, 0x1030,
+  ]
+  // one whole block, so the planted code unit always lands in the fast path
+  let body = encode_scalar(sample_bytes(16))
+  for unit in aliasing_units {
+    for position in 0..<body.length() {
+      let units = Array::makei(body.length(), i => {
+        if i == position {
+          unit
+        } else {
+          body.unsafe_get(i).to_int()
+        }
+      })
+      let corrupted = string_of_code_units(units)
+      let raised = try {
+        let _ = decode(corrupted)
+        false
+      } catch {
+        Malformed(_) => true
+      }
+      assert_true(raised)
+    }
+  }
+}
+
+///|
+test "vectorized paths honor view start and end offsets" {
+  // A view can start and stop anywhere inside its backing buffer, and the
+  // fast paths index from `start_offset`, so both bounds must be respected.
+  // The padding on either side is itself valid hex, which means a base or
+  // length mistake decodes successfully to the wrong bytes instead of
+  // failing over to the scalar decoder and quietly producing the right
+  // answer.
+  for length in 32..<72 {
+    for pad in 1..<5 {
+      let padded = sample_bytes(pad + length + pad)
+      let bytes_view = padded[pad:pad + length]
+      @test.assert_eq(encode(bytes_view), encode_scalar(bytes_view))
+      let body = encode_scalar(bytes_view)
+      let sb = StringBuilder(size_hint=4 * (pad + body.length() + pad))
+      for _ in 0..<pad {
+        sb.write_char('a')
+      }
+      sb.write_string(body)
+      for _ in 0..<pad {
+        sb.write_char('b')
+      }
+      let text = sb.to_string()
+      let text_view = text[pad:pad + body.length()]
+      @test.assert_eq(decode(text_view), bytes_view.to_owned())
+      @test.assert_eq(decode(text_view), decode_scalar(text_view))
+    }
+  }
+}
+
+///|
+test "invalid characters at every lane position defer to the scalar error" {
+  // a valid 64-digit body with one invalid character planted at each
+  // position: the fast path must reject the block and the scalar decoder
+  // must raise, regardless of which lane the invalid byte lands in
+  let body = encode(sample_bytes(32))
+  for position in 0..<body.length() {
+    let sb = StringBuilder(size_hint=4 * body.length())
+    for i in 0..<body.length() {
+      sb.write_char(
+        if i == position {
+          'g'
+        } else {
+          body.unsafe_get(i).to_char().unwrap()
+        },
+      )
+    }
+    let corrupted = sb.to_string()
+    let raised = try {
+      let _ = decode(corrupted)
+      false
+    } catch {
+      Malformed(_) => true
+    }
+    assert_true(raised)
+  }
+}

--- a/encoding/hex/v128_wbtest.mbt
+++ b/encoding/hex/v128_wbtest.mbt
@@ -45,7 +45,7 @@ test "decode agrees with the scalar decoder across all block counts" {
     let lowercase = encode(bytes)
     @test.assert_eq(decode(lowercase), bytes)
     @test.assert_eq(decode(lowercase), decode_scalar(lowercase))
-    // uppercase exercise the letter-range adjustment lanes
+    // uppercase exercises the letter-range adjustment lanes
     let uppercase = lowercase.to_upper()
     @test.assert_eq(decode(uppercase), bytes)
     @test.assert_eq(decode(uppercase), decode_scalar(uppercase))
@@ -130,7 +130,7 @@ test "vectorized paths honor view start and end offsets" {
       let bytes_view = padded[pad:pad + length]
       @test.assert_eq(encode(bytes_view), encode_scalar(bytes_view))
       let body = encode_scalar(bytes_view)
-      let sb = StringBuilder(size_hint=4 * (pad + body.length() + pad))
+      let sb = StringBuilder(size_hint=2 * (pad + body.length() + pad))
       for _ in 0..<pad {
         sb.write_char('a')
       }
@@ -153,7 +153,7 @@ test "invalid characters at every lane position defer to the scalar error" {
   // must raise, regardless of which lane the invalid byte lands in
   let body = encode(sample_bytes(32))
   for position in 0..<body.length() {
-    let sb = StringBuilder(size_hint=4 * body.length())
+    let sb = StringBuilder(size_hint=2 * body.length())
     for i in 0..<body.length() {
       sb.write_char(
         if i == position {


### PR DESCRIPTION
Follow-up to #3625, which landed `encoding/hex` with a scalar-only codec. This adds v128 fast paths for `encode` and `decode` on the linear-memory backends, structured exactly like the sibling `encoding/base64`: the scalar codec stays on every backend as the reference implementation, and the public entry points dispatch with `#cfg`.

## How it works

**Encode** — 16 source bytes per iteration. Split each byte into its nibbles (`i8x16_shr_u` and a mask), interleave them into output order with two `i8x16_shuffle`s, and convert nibbles to ASCII with one register-resident `i8x16_swizzle` table. A MoonBit `String` is UTF-16, so the 32 characters are widened with `i16x8_extend_low/high_i8x16_u` before being stored.

**Decode** — 32 characters per iteration. Four `v128_load_i16x8` are narrowed pairwise with `i8x16_narrow_i16x8_u`; that instruction reads its lanes as signed and saturates, so a code unit in `0x0100..=0x7FFF` becomes 255 and one in `0x8000..=0xFFFF` (surrogate halves included) becomes 0. Neither is a hex digit, so no non-ASCII code unit can masquerade as one by way of its low byte. The three hex ranges are then validated vectorially and folded to nibbles with wrapping adds. Anything the fast path will not take — short, odd-length, or invalid input — falls back to `decode_scalar`, which remains the single authority on the `Malformed` rules, so `decode` raises on exactly the inputs it did before.

## Performance

`moon bench encoding/hex`, 4 KiB payload, scalar path vs. the public entry point on the same run:

| target | encode scalar | encode | speedup | decode scalar | decode | speedup |
| ------ | ------------- | ------ | ------- | ------------- | ------ | ------- |
| native | 16.33 µs | 634 ns | **25.8x** | 7.56 µs | 815 ns | **9.3x** |
| wasm | 35.64 µs | 947 ns | **37.6x** | 21.17 µs | 1.33 µs | **15.9x** |
| js | 38.60 µs | 35.93 µs | 1.07x | 43.38 µs | 44.01 µs | 0.99x |

js keeps the scalar path by `#cfg`, so both columns measure the same code and confirm no regression there. Other sizes, public entry point: 64 B encode is 34.5 ns native / 94.5 ns wasm / 608 ns js; 64 KiB is 16.0 µs / 15.7 µs / 687 µs encode and 12.7 µs / 20.5 µs / 746 µs decode.

## Correctness

Differential white-box tests pin both fast paths against the scalar ones: every length from 0 to 79 (so every block count and tail residue), views that start *and* end inside a larger buffer whose padding is itself valid hex, an invalid character planted at every lane position, and raw UTF-16 code units — lone surrogates included — planted at every position of a full block. A `#cfg`-gated test calls `encode_v128` and `decode_v128` directly, so the suite fails if the fast path is ever silently disabled rather than exercised.

Four quickcheck properties cover decode∘encode against an independent reference encoder, case-mixture round-trips, corruption at any position raising `Malformed`, and odd-length input raising `Malformed`.

Each of these mutations makes the suite fail, which is how I know the tests discriminate: an interleave shuffle index, the `-7` nibble adjustment constant, either `start_offset()` replaced by `0`, the saturating narrow replaced by a truncating shuffle, and `decode_v128` returning `None` unconditionally.

Both block loops bound themselves by subtraction, and the encoder declines an input whose UTF-16 byte buffer would not fit in an `Int`, so no vector store can be reached through a wrapped index.

`moon test` passes 7512/7512; `encoding/hex` is 20/20 on native and wasm, 19/19 on wasm-gc and js. `pkg.generated.mbti` is unchanged — this is an implementation change only.

## Review

Reviewed by Codex CLI at `ultra` reasoning effort over two rounds. Round 1 withheld approval over two P1 memory-safety findings — a wrapping `length * 4` output size and a `index + 16` block bound that could wrap for a view near `Int::MAX` — plus P2s on test discrimination and a P3 documentation error about the narrow's signed-lane behaviour. All are fixed; round 2 verdict and sign-off are posted in a comment below.
