### PR TITLE
fix(base64): keep the vector fast paths free of wrapping bounds

### DIFF
--- a/encoding/base64/decode_v128.mbt
+++ b/encoding/base64/decode_v128.mbt
@@ -130,7 +130,7 @@ fn decode_v128(text : StringView) -> Bytes? {
   let base = text.start_offset()
   let mut index = 0
   let mut written = 0
-  while index + 16 <= body && written + 16 <= out.length() {
+  while body - index >= 16 && out.length() - written >= 16 {
     let offset = base + index
     let ascii = @v128.i8x16_narrow_i16x8_u(
       @v128.v128_load_i16x8(src, offset),

--- a/encoding/base64/encode_v128.mbt
+++ b/encoding/base64/encode_v128.mbt
@@ -105,6 +105,13 @@ fn write_code_unit(out : FixedArray[Byte], offset : Int, code : Byte) -> Unit {
 #cfg(any(target="native", target="wasm"))
 fn encode_v128(bytes : BytesView, padding : Bool) -> String {
   let length = bytes.length()
+  // Three source bytes become four code units and so eight buffer bytes.
+  // The vector stores below are not bounds checked, so an input whose
+  // buffer size would wrap has to be refused before the allocation; the
+  // scalar encoder builds the string without ever materializing that
+  // buffer. The bound is a round number well inside the true ceiling,
+  // since no caller is near it either way.
+  guard length <= 0x2000_0000 else { return encode_scalar(bytes, padding~) }
   let full_groups = length / 3
   let remainder = length % 3
   let mut char_count = full_groups * 4
@@ -118,14 +125,14 @@ fn encode_v128(bytes : BytesView, padding : Bool) -> String {
   let mut written = 0
   // The load reads sixteen bytes but only twelve are consumed, so the loop
   // stops four bytes short of the end and the tail is encoded scalar.
-  while index + 16 <= end {
+  while end - index >= 16 {
     let chars = encode_block_v128(@v128.v128_load(src, index))
     @v128.v128_store(out, written, @v128.i16x8_extend_low_i8x16_u(chars))
     @v128.v128_store(out, written + 16, @v128.i16x8_extend_high_i8x16_u(chars))
     index += 12
     written += 32
   }
-  while index + 3 <= end {
+  while end - index >= 3 {
     let n = (src[index].to_int() << 16) |
       (src[index + 1].to_int() << 8) |
       src[index + 2].to_int()


### PR DESCRIPTION
Hardening only — no behaviour change for any input a real caller can construct, and no API change.

While reviewing the equivalent code in #4122, Codex CLI flagged two defects in `encoding/hex`'s new vector paths and noted that `encoding/base64` shares one of them: *"the base64 precedent shares this defect; that does not make it safe."* It shares the other as well. This fixes both there.

## The two defects

**Wrapping block bounds.** The loops tested `index + 16 <= end`. For a `BytesView` sitting at the very end of a large backing buffer, `index + 16` wraps negative and the comparison becomes true, so a short view enters the vector loop and reads past its end. All three sites now bound by subtraction:

```
while end - index >= 16          // was index + 16 <= end
while end - index >= 3           // was index + 3 <= end
while body - index >= 16 && out.length() - written >= 16
```

Each subtraction is wrap-free from the view invariants: `end = start_offset + length <= src.length() <= Int::MAX` with `index` in `[start_offset, end]`, and in the decoder `body`/`index` are view-relative with `written <= out.length()`.

**Unchecked output size.** `encode_v128` sized its UTF-16 buffer as `char_count * 2`, where `char_count` is itself `full_groups * 4` — two wrapping multiplies feeding an allocation whose vector stores are *not* bounds checked. A wrapped size means writing outside the buffer rather than failing. The encoder now declines such an input:

```moonbit
guard length <= 0x2000_0000 else { return encode_scalar(bytes, padding~) }
```

The scalar encoder builds the string through `StringBuilder` without ever materializing that buffer, and its growth is bounds checked, so it fails safely at sizes the fast path refuses.

Neither defect is reachable through a realistic caller — both need an allocation approaching two gigabytes — but the code they guard is unchecked, so the failure mode is memory corruption rather than a panic. The fix is three bounds and one guard.

## Cost

None. Native, this branch vs `origin/main`, interleaved on the same machine:

| bench | origin/main | this branch | | bench | origin/main | this branch |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 220.97 ns | 220.87 ns | | 7 | 172.83 ns | 177.90 ns |
| 2 | 38.15 ns | 38.52 ns | | 8 | 72.25 ns | 73.91 ns |
| 3 | 2.86 µs | 2.85 µs | | 9 | 2.10 µs | 2.15 µs |
| 4 | 211.15 ns | 212.43 ns | | 10 | 259.58 ns | 255.20 ns |
| 5 | 181.23 µs | 180.51 µs | | 11 | 448.31 µs | 446.44 µs |
| 6 | 16.59 µs | 16.02 µs | | 12 | 12.39 µs | 12.28 µs |

Every figure is within run-to-run noise; the loop-bound rewrite is free.

`moon test encoding/base64` passes 21/21 on native and wasm, full `moon test` 7512/7512, and `pkg.generated.mbti` is unchanged.

## Review

Reviewed by Codex CLI at `ultra` reasoning effort — approved on the first pass, verdict posted below.

One deliberate gap: the size guard needs a 512 MiB input to reach, so no test exercises it. I asked whether it should be restructured to be testable and the reviewer's answer was no — *"exercising it requires impractical CI memory, while existing differential tests cover ordinary block/tail behavior and the boundary itself has a straightforward arithmetic proof."*
