### PR TITLE
feat: unbiased ranged integer generation for splitmix

### DIFF
--- a/quickcheck/splitmix/README.mbt.md
+++ b/quickcheck/splitmix/README.mbt.md
@@ -54,6 +54,29 @@ test "random number generation" {
 }
 ```
 
+## Bounded Unsigned Integers
+
+Use `next_uint_below` and `next_uint64_below` for unbiased values below an
+exclusive upper bound. Unlike `% upper`, these methods reject excess source
+words so every result in the requested interval has the same probability.
+
+```mbt check
+///|
+test "bounded unsigned generation" {
+  let rng = @splitmix.new(seed=42UL)
+  debug_inspect(
+    (
+      rng.next_uint_below(10U),
+      rng.next_uint64_below(3UL),
+      rng.next_uint_below(16U),
+    ),
+    content=(
+      #|(0, 1, 9)
+    ),
+  )
+}
+```
+
 ## Floating-Point Random Numbers
 
 Generate random floating-point values:

--- a/quickcheck/splitmix/README.mbt.md
+++ b/quickcheck/splitmix/README.mbt.md
@@ -56,9 +56,10 @@ test "random number generation" {
 
 ## Bounded Unsigned Integers
 
-Use `next_uint_below` and `next_uint64_below` for unbiased values below an
-exclusive upper bound. Unlike `% upper`, these methods reject excess source
+Pass `limit` to `next_uint` or `next_uint64` for unbiased values below an
+exclusive upper bound. Unlike `% limit`, these methods reject excess source
 words so every result in the requested interval has the same probability.
+Omitting `limit` generates across the complete unsigned range.
 
 ```mbt check
 ///|
@@ -66,9 +67,9 @@ test "bounded unsigned generation" {
   let rng = @splitmix.new(seed=42UL)
   debug_inspect(
     (
-      rng.next_uint_below(10U),
-      rng.next_uint64_below(3UL),
-      rng.next_uint_below(16U),
+      rng.next_uint(limit=10U),
+      rng.next_uint64(limit=3UL),
+      rng.next_uint(limit=16U),
     ),
     content=(
       #|(0, 1, 9)

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -22,10 +22,8 @@ pub fn RandomState::next_int(Self) -> Int
 pub fn RandomState::next_int64(Self) -> Int64
 pub fn RandomState::next_positive_int(Self) -> Int
 pub fn RandomState::next_two_uint(Self) -> (UInt, UInt)
-pub fn RandomState::next_uint(Self) -> UInt
-pub fn RandomState::next_uint64(Self) -> UInt64
-pub fn RandomState::next_uint64_below(Self, UInt64) -> UInt64
-pub fn RandomState::next_uint_below(Self, UInt) -> UInt
+pub fn RandomState::next_uint(Self, limit? : UInt) -> UInt
+pub fn RandomState::next_uint64(Self, limit? : UInt64) -> UInt64
 pub fn RandomState::split(Self) -> Self
 pub fn RandomState::to_string(Self) -> String
 pub impl Default for RandomState

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -24,6 +24,8 @@ pub fn RandomState::next_positive_int(Self) -> Int
 pub fn RandomState::next_two_uint(Self) -> (UInt, UInt)
 pub fn RandomState::next_uint(Self) -> UInt
 pub fn RandomState::next_uint64(Self) -> UInt64
+pub fn RandomState::next_uint64_below(Self, UInt64) -> UInt64
+pub fn RandomState::next_uint_below(Self, UInt) -> UInt
 pub fn RandomState::split(Self) -> Self
 pub fn RandomState::to_string(Self) -> String
 pub impl Default for RandomState

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -55,9 +55,50 @@ pub fn RandomState::next_uint64(self : RandomState) -> UInt64 {
 }
 
 ///|
+/// Returns an unbiased random `UInt64` in the half-open interval `[0, upper)`.
+///
+/// Uses bitmask rejection so every result has the same probability. Rejected
+/// words consume additional values from this random state.
+///
+/// # Panics
+///
+/// Panics if `upper` is zero.
+pub fn RandomState::next_uint64_below(
+  self : RandomState,
+  upper : UInt64,
+) -> UInt64 {
+  guard upper > 0UL else {
+    abort("RandomState::next_uint64_below: upper must be positive")
+  }
+  let mask = if upper == 1UL {
+    0UL
+  } else {
+    0xffff_ffff_ffff_ffffUL >> (upper - 1UL).clz()
+  }
+  for candidate = self.next_uint64() & mask; candidate >= upper; {
+    continue self.next_uint64() & mask
+  } nobreak {
+    candidate
+  }
+}
+
+///|
 /// Get the next random number as a 32-bit unsigned integer.
 pub fn RandomState::next_uint(self : RandomState) -> UInt {
   self.next_uint64().to_uint()
+}
+
+///|
+/// Returns an unbiased random `UInt` in the half-open interval `[0, upper)`.
+///
+/// # Panics
+///
+/// Panics if `upper` is zero.
+pub fn RandomState::next_uint_below(self : RandomState, upper : UInt) -> UInt {
+  guard upper > 0U else {
+    abort("RandomState::next_uint_below: upper must be positive")
+  }
+  self.next_uint64_below(upper.to_uint64()).to_uint()
 }
 
 ///|

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -47,58 +47,57 @@ pub fn RandomState::next(self : RandomState) -> Unit {
 }
 
 ///|
-/// Get the next random number as a 64-bit unsigned integer.
-pub fn RandomState::next_uint64(self : RandomState) -> UInt64 {
+fn RandomState::next_uint64_raw(self : RandomState) -> UInt64 {
   let { seed, gamma } = self
   self.seed = seed + gamma
   mix64(self.seed)
 }
 
 ///|
-/// Returns an unbiased random `UInt64` in the half-open interval `[0, upper)`.
+/// Returns a random `UInt64`.
 ///
-/// Uses bitmask rejection so every result has the same probability. Rejected
-/// words consume additional values from this random state.
+/// With no `limit`, values span the complete `UInt64` range. With `limit`,
+/// this method uses bitmask rejection to return an unbiased value in the
+/// half-open interval `[0, limit)`. Rejected words consume additional values
+/// from this random state.
 ///
 /// # Panics
 ///
-/// Panics if `upper` is zero.
-pub fn RandomState::next_uint64_below(
-  self : RandomState,
-  upper : UInt64,
-) -> UInt64 {
-  guard upper > 0UL else {
-    abort("RandomState::next_uint64_below: upper must be positive")
-  }
-  let mask = if upper == 1UL {
-    0UL
-  } else {
-    0xffff_ffff_ffff_ffffUL >> (upper - 1UL).clz()
-  }
-  for candidate = self.next_uint64() & mask; candidate >= upper; {
-    continue self.next_uint64() & mask
-  } nobreak {
-    candidate
+/// Panics if `limit` is explicitly set to zero.
+pub fn RandomState::next_uint64(self : RandomState, limit? : UInt64) -> UInt64 {
+  match limit {
+    None => self.next_uint64_raw()
+    Some(0UL) => abort("RandomState::next_uint64: limit must be positive")
+    Some(limit) => {
+      let mask = if limit == 1UL {
+        0UL
+      } else {
+        0xffff_ffff_ffff_ffffUL >> (limit - 1UL).clz()
+      }
+      for candidate = self.next_uint64_raw() & mask; candidate >= limit; {
+        continue self.next_uint64_raw() & mask
+      } nobreak {
+        candidate
+      }
+    }
   }
 }
 
 ///|
-/// Get the next random number as a 32-bit unsigned integer.
-pub fn RandomState::next_uint(self : RandomState) -> UInt {
-  self.next_uint64().to_uint()
-}
-
-///|
-/// Returns an unbiased random `UInt` in the half-open interval `[0, upper)`.
+/// Returns a random `UInt`.
+///
+/// With no `limit`, values span the complete `UInt` range. With `limit`, this
+/// method returns an unbiased value in the half-open interval `[0, limit)`.
 ///
 /// # Panics
 ///
-/// Panics if `upper` is zero.
-pub fn RandomState::next_uint_below(self : RandomState, upper : UInt) -> UInt {
-  guard upper > 0U else {
-    abort("RandomState::next_uint_below: upper must be positive")
+/// Panics if `limit` is explicitly set to zero.
+pub fn RandomState::next_uint(self : RandomState, limit? : UInt) -> UInt {
+  match limit {
+    None => self.next_uint64_raw().to_uint()
+    Some(0U) => abort("RandomState::next_uint: limit must be positive")
+    Some(limit) => self.next_uint64(limit=limit.to_uint64()).to_uint()
   }
-  self.next_uint64_below(upper.to_uint64()).to_uint()
 }
 
 ///|

--- a/quickcheck/splitmix/random_test.mbt
+++ b/quickcheck/splitmix/random_test.mbt
@@ -52,3 +52,41 @@ test "mix_gamma else branch seed" {
   let state = @splitmix.new(seed=930507UL)
   inspect(state.next_uint(), content="3773570134")
 }
+
+///|
+test "next_uint64_below skips masked values outside the bound" {
+  let state = @splitmix.new(seed=7UL)
+  let value = state.next_uint64_below(3UL)
+  debug_inspect((value, state.next_uint64()), content="(2, 622236291405445593)")
+}
+
+///|
+test "next_uint_below skips masked values outside the bound" {
+  let state = @splitmix.new(seed=7UL)
+  let value = state.next_uint_below(3U)
+  debug_inspect((value, state.next_uint64()), content="(2, 622236291405445593)")
+}
+
+///|
+test "next_uint64_below handles unit and power-of-two bounds" {
+  let unit = @splitmix.new(seed=1UL)
+  let unit_value = unit.next_uint64_below(1UL)
+  let power = @splitmix.new(seed=1UL)
+  let power_value = power.next_uint64_below(8UL)
+  debug_inspect(
+    (unit_value, unit.next_uint64(), power_value, power.next_uint64()),
+    content="(0, 9482272708574442377, 1, 9482272708574442377)",
+  )
+}
+
+///|
+test "panic next_uint64_below rejects a zero bound" {
+  let state = @splitmix.new(seed=1UL)
+  ignore(state.next_uint64_below(0UL))
+}
+
+///|
+test "panic next_uint_below rejects a zero bound" {
+  let state = @splitmix.new(seed=1UL)
+  ignore(state.next_uint_below(0U))
+}

--- a/quickcheck/splitmix/random_test.mbt
+++ b/quickcheck/splitmix/random_test.mbt
@@ -54,25 +54,25 @@ test "mix_gamma else branch seed" {
 }
 
 ///|
-test "next_uint64_below skips masked values outside the bound" {
+test "next_uint64 with a limit skips masked values outside the bound" {
   let state = @splitmix.new(seed=7UL)
-  let value = state.next_uint64_below(3UL)
+  let value = state.next_uint64(limit=3UL)
   debug_inspect((value, state.next_uint64()), content="(2, 622236291405445593)")
 }
 
 ///|
-test "next_uint_below skips masked values outside the bound" {
+test "next_uint with a limit skips masked values outside the bound" {
   let state = @splitmix.new(seed=7UL)
-  let value = state.next_uint_below(3U)
+  let value = state.next_uint(limit=3U)
   debug_inspect((value, state.next_uint64()), content="(2, 622236291405445593)")
 }
 
 ///|
-test "next_uint64_below handles unit and power-of-two bounds" {
+test "next_uint64 handles unit and power-of-two limits" {
   let unit = @splitmix.new(seed=1UL)
-  let unit_value = unit.next_uint64_below(1UL)
+  let unit_value = unit.next_uint64(limit=1UL)
   let power = @splitmix.new(seed=1UL)
-  let power_value = power.next_uint64_below(8UL)
+  let power_value = power.next_uint64(limit=8UL)
   debug_inspect(
     (unit_value, unit.next_uint64(), power_value, power.next_uint64()),
     content="(0, 9482272708574442377, 1, 9482272708574442377)",
@@ -80,13 +80,13 @@ test "next_uint64_below handles unit and power-of-two bounds" {
 }
 
 ///|
-test "panic next_uint64_below rejects a zero bound" {
+test "panic next_uint64 rejects a zero limit" {
   let state = @splitmix.new(seed=1UL)
-  ignore(state.next_uint64_below(0UL))
+  ignore(state.next_uint64(limit=0UL))
 }
 
 ///|
-test "panic next_uint_below rejects a zero bound" {
+test "panic next_uint rejects a zero limit" {
   let state = @splitmix.new(seed=1UL)
-  ignore(state.next_uint_below(0U))
+  ignore(state.next_uint(limit=0U))
 }


### PR DESCRIPTION
This is a prerequisite PR; certain value generation within `quickcheck` requires optimization. Before that, however, we need to enable `splitmix` to support unbiased random number generation within a range, as the common %-based approach yields a non-uniform distribution.