### PR TITLE
perf(hashset): probe with unchecked array access

### DIFF
--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -94,7 +94,9 @@ fn[K : Eq] HashSet::add_with_hash(
     self.grow()
   }
   let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    // SAFETY: `idx` starts masked by `capacity_mask` and every step re-masks
+    // it, so it is in bounds for `entries`, whose length is `capacity`.
+    match self.entries.unsafe_get(idx) {
       None => break (idx, psl)
       Some(curr_entry) => {
         if curr_entry.hash == hash && curr_entry.key == key {
@@ -121,7 +123,8 @@ fn[K] HashSet::push_away(
   entry : Entry[K],
 ) -> Unit {
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
-    match self.entries[idx] {
+    // SAFETY: same masked-index invariant as `add_with_hash`.
+    match self.entries.unsafe_get(idx) {
       None => {
         entry.psl = psl
         self.set_entry(entry, idx)
@@ -149,7 +152,9 @@ fn[K] HashSet::set_entry(
   entry : Entry[K],
   new_idx : Int,
 ) -> Unit {
-  self.entries[new_idx] = Some(entry)
+  // SAFETY: every caller supplies an index already proven in bounds -- from
+  // a masked probe, or from `shift_back`'s `cur`.
+  self.entries.unsafe_set(new_idx, Some(entry))
 }
 
 ///|
@@ -158,7 +163,8 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break false }
+    // SAFETY: same masked-index invariant as `add_with_hash`.
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
       break true
     }
@@ -193,7 +199,8 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
 pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break }
+    // SAFETY: same masked-index invariant as `add_with_hash`.
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break }
     if entry.hash == hash && entry.key == key {
       self.shift_back(idx)
       self.size -= 1
@@ -210,9 +217,13 @@ pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
 fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
   for cur = idx {
     let next = (cur + 1) & self.capacity_mask
-    match self.entries[next] {
+    // SAFETY: the initial `cur` is in bounds by either route its callers
+    // take -- `remove` derives it from a masked probe, and `retain` reaches
+    // here only after a checked `entries[i]` read succeeded. `next` is
+    // re-masked each step, and `cur` afterwards is a previous `next`.
+    match self.entries.unsafe_get(next) {
       None | Some({ psl: 0, .. }) => {
-        self.entries[cur] = None
+        self.entries.unsafe_set(cur, None)
         break
       }
       Some(entry) => {
@@ -253,7 +264,9 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
 fn[K] HashSet::rehash_place_entry(self : HashSet[K], entry : Entry[K]) -> Unit {
   let hash = entry.hash
   for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    // SAFETY: same masked-index invariant as `add_with_hash`; `grow` installs
+    // the new `entries` and `capacity_mask` together before rehashing.
+    match self.entries.unsafe_get(idx) {
       None => {
         entry.psl = psl
         self.set_entry(entry, idx)

--- a/hashset/hashset_bench_test.mbt
+++ b/hashset/hashset_bench_test.mbt
@@ -1,0 +1,44 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let hashset_bench_n = 50000
+
+///|
+test "bench HashSet::add n=50000" (it : @bench.T) {
+  it.bench(fn() {
+    let s = @hashset.HashSet([])
+    for i in 0..<hashset_bench_n {
+      s.add(i * 1103515245)
+    }
+    it.keep(s.length())
+  })
+}
+
+///|
+test "bench HashSet::contains n=50000" (it : @bench.T) {
+  let s = @hashset.HashSet([])
+  for i in 0..<hashset_bench_n {
+    s.add(i * 1103515245)
+  }
+  it.bench(fn() {
+    let mut hits = 0
+    for i in 0..<hashset_bench_n {
+      if s.contains(i * 1103515245) {
+        hits += 1
+      }
+    }
+    it.keep(hits)
+  })
+}

--- a/hashset/moon.pkg
+++ b/hashset/moon.pkg
@@ -10,4 +10,5 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
+  "moonbitlang/core/bench",
 } for "test"


### PR DESCRIPTION
First of two PRs splitting #3712, which bundled a struct-of-arrays layout with unchecked probing. Split apart, they turn out to pay on **different backends** — which the combined PR could not show, because each masked the other's cost. This is the probing half; the layout half is stacked on top of it.

## The change

Every probe index in `HashSet` comes from `hash & capacity_mask` and is re-masked as `(idx + 1) & capacity_mask` on each step, so it is always in bounds for `entries`, whose length is `capacity`. The bounds check on those accesses is provably redundant.

Eight masked-index sites become `unsafe_get`/`unsafe_set`, each with the invariant written out: the probe loops in `add_with_hash`, `push_away`, `contains`, `remove`, `shift_back` and `rehash_place_entry`, plus `set_entry`'s store. No layout change, no API change, `pkg.generated.mbti` untouched.

Also adds `hashset/hashset_bench_test.mbt`, which the package did not have (from #3712, credited).

## Measurements

n=50000, this branch vs `origin/main`, interleaved on one machine in a single session:

| backend | op | main | this branch | change |
| --- | --- | --- | --- | --- |
| js | `add` | 3.08 ms | 2.51 ms | **18% faster** |
| js | `contains` | 1.21 ms | 1.01 ms | **17% faster** |
| native | `add` | 2.35 ms | 2.29 ms | ~2%, ranges overlap |
| native | `contains` | 875 µs | 857 µs | ~2%, ranges overlap |
| wasm-gc | `add` | 2.30 ms | 2.30 ms | unchanged |
| wasm-gc | `contains` | 1.09 ms | 1.11 ms | unchanged |

The win is js-only, and it is a real one. js emits an explicit length comparison per access; removing it pays. wasm-gc's array access traps inherently, so there is nothing to remove. On native the boxed entry's pointer chase and `Option` unwrap dominate and the check disappears into the noise.

That asymmetry is the argument for the split: this half is what makes **js** faster, and the layout half (#stacked) is what makes **native** faster — by 35% — while costing js 18%. Bundled, they averaged out to "js unchanged" and the trade was invisible.

## Safety

An out-of-bounds unchecked access is undefined behaviour, not a test failure, so a green suite is weak evidence here. The argument is the representation invariant:

- construction establishes `capacity >= 1`, a power of two, with `entries.length() == capacity` and `capacity_mask == capacity - 1` — note `next_power_of_two(0) == 1`, and a negative capacity panics before anything is built;
- `grow` is the only resizing path, and it installs the new array, capacity and mask together before any rehash probe;
- `add_with_hash` grows before computing its first index;
- `shift_back` gets an in-bounds `cur` by either route its callers take — masked from `remove`, or after a successful checked read from `retain`;
- therefore every `set_entry` caller supplies a proven in-bounds index.

Iteration sites (`each`, `eachi`, `retain`, `to_array`) stay checked: their indices are equally provable, but no benchmark shows a gain, so they keep the form that is cheaper to audit.

## Review

Reviewed by Codex CLI at `ultra` reasoning effort — approved, verdict in a comment below. Its two substantive notes are addressed: the `shift_back`/`set_entry` SAFETY comments now document both routes an index can arrive by, rather than claiming everything is mask-derived.

Two of its suggestions I have **not** acted on, for a follow-up: the benchmark covers insertion and successful lookup but not misses, removal, or wraparound displacement; and js uses a per-process random hash seed, so a deterministic key set would make the comparison sturdier.
