### PR TITLE
perf(hashmap): probe with unchecked array access

### DIFF
--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -12,6 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// SAFETY NOTE for the unchecked probe accesses in this file.
+//
+// `capacity` is always a power of two and at least 1, `capacity_mask` is
+// `capacity - 1`, and `entries.length()` is `capacity`. Every probe index is
+// therefore in bounds: it starts as `hash & capacity_mask` and each step
+// re-masks with `(idx + 1) & capacity_mask`. `grow` installs the new array,
+// capacity and mask together before any rehash probe runs, and `set_with_hash`
+// re-masks from scratch after growing. `shift_back` is the one entry point
+// that can be reached with an index which is not mask-derived -- `retain` in
+// utils.mbt passes a linear one -- so it carries its own proof at its
+// definition. On that basis the probe loops below use `unsafe_get` /
+// `unsafe_set`; the linear iteration sites keep the checked form.
+
 ///|
 let default_init_capacity = 8
 
@@ -119,8 +132,9 @@ fn[K : Eq, V] HashMap::set_with_hash(
   hash : Int,
 ) -> Unit {
   // Only grow when actually inserting a new entry, not when updating existing
+  // SAFETY: masked probe index; see the note at the top of this file.
   for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       None => {
         // Need to insert new entry - check if grow is needed first
         if self.size >= self.capacity / 2 {
@@ -129,7 +143,7 @@ fn[K : Eq, V] HashMap::set_with_hash(
           continue 0, hash & self.capacity_mask
         }
         let entry = { psl, key, value, hash }
-        self.entries[idx] = Some(entry)
+        self.entries.unsafe_set(idx, Some(entry))
         self.size += 1
         return
       }
@@ -148,7 +162,7 @@ fn[K : Eq, V] HashMap::set_with_hash(
           }
           self.push_away(idx, curr_entry)
           let entry = { psl, key, value, hash }
-          self.entries[idx] = Some(entry)
+          self.entries.unsafe_set(idx, Some(entry))
           self.size += 1
           return
         }
@@ -165,17 +179,18 @@ fn[K, V] HashMap::push_away(
   idx : Int,
   entry : Entry[K, V],
 ) -> Unit {
+  // SAFETY: masked probe index; see the note at the top of this file.
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       None => {
         entry.psl = psl
-        self.entries[idx] = Some(entry)
+        self.entries.unsafe_set(idx, Some(entry))
         break
       }
       Some(curr_entry) =>
         if psl > curr_entry.psl {
           entry.psl = psl
-          self.entries[idx] = Some(entry)
+          self.entries.unsafe_set(idx, Some(entry))
           continue curr_entry.psl + 1,
             (idx + 1) & self.capacity_mask,
             curr_entry
@@ -208,8 +223,9 @@ fn[K, V] HashMap::push_away(
 pub fn[K : Hash + Eq, V] HashMap::get(self : HashMap[K, V], key : K) -> V? {
   // self.get_with_hash(key, key.hash())
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break None }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break None }
     if entry.hash == hash && entry.key == key {
       break Some(entry.value)
     }
@@ -244,8 +260,9 @@ pub fn[V] HashMap::get_from_bytes(
   key : BytesView,
 ) -> V? {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break None }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_bytes(entry.key) {
       break Some(entry.value)
     }
@@ -280,8 +297,9 @@ pub fn[V] HashMap::get_from_string(
   key : StringView,
 ) -> V? {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break None }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break None }
     if entry.hash == hash && key.equal_to_string(entry.key) {
       break Some(entry.value)
     }
@@ -313,8 +331,9 @@ pub fn[V] HashMap::get_from_string(
 #alias("_[_]")
 pub fn[K : Hash + Eq, V] HashMap::at(self : HashMap[K, V], key : K) -> V {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard! self.entries[idx] is Some(entry)
+    guard! self.entries.unsafe_get(idx) is Some(entry)
     if entry.hash == hash && entry.key == key {
       break entry.value
     }
@@ -354,9 +373,10 @@ pub fn[K : Hash + Eq, V] HashMap::get_or_init(
   init : () -> V,
 ) -> V {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       Some(entry) => {
         if entry.hash == hash && entry.key == key {
           return entry.value
@@ -382,7 +402,7 @@ pub fn[K : Hash + Eq, V] HashMap::get_or_init(
       self.push_away(idx, entry)
     }
     let entry = { psl, hash, key, value: new_value }
-    self.entries[idx] = Some(entry)
+    self.entries.unsafe_set(idx, Some(entry))
     self.size += 1
   }
   new_value
@@ -445,9 +465,10 @@ pub fn[K : Hash + Eq, V] HashMap::update(
   f : (V?) -> V?,
 ) -> Unit {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   let (idx, psl, new_value, push_away) = for psl = 0, idx = hash &
                                                self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       Some(entry) => {
         if entry.hash == hash && entry.key == key {
           if f(Some(entry.value)) is Some(new_value) {
@@ -477,7 +498,7 @@ pub fn[K : Hash + Eq, V] HashMap::update(
     if push_away is Some(entry) {
       self.push_away(idx, entry)
     }
-    self.entries[idx] = Some({ psl, hash, key, value: new_value })
+    self.entries.unsafe_set(idx, Some({ psl, hash, key, value: new_value }))
     self.size += 1
   }
 }
@@ -508,8 +529,9 @@ pub fn[K : Hash + Eq, V] HashMap::update_or_default(
   f : (V) -> V,
 ) -> Unit {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   let (idx, psl, push_away) = for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       Some(entry) => {
         if entry.hash == hash && entry.key == key {
           entry.value = f(entry.value)
@@ -531,7 +553,7 @@ pub fn[K : Hash + Eq, V] HashMap::update_or_default(
       self.push_away(idx, entry)
     }
     let entry = { psl, hash, key, value: default }
-    self.entries[idx] = Some(entry)
+    self.entries.unsafe_set(idx, Some(entry))
     self.size += 1
   }
 }
@@ -564,8 +586,9 @@ pub fn[K : Hash + Eq, V] HashMap::get_or_default(
   default : V,
 ) -> V {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break default }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break default }
     if entry.hash == hash && entry.key == key {
       break entry.value
     }
@@ -600,8 +623,9 @@ pub fn[K : Hash + Eq, V] HashMap::contains(
   key : K,
 ) -> Bool {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { return false }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { return false }
     if entry.hash == hash && entry.key == key {
       return true
     }
@@ -642,8 +666,9 @@ pub fn[K : Hash + Eq, V : Eq] HashMap::contains_kv(
   value : V,
 ) -> Bool {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { return false }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { return false }
     if entry.hash == hash && entry.key == key && entry.value == value {
       return true
     }
@@ -685,8 +710,9 @@ fn[K : Eq, V] HashMap::remove_with_hash(
   key : K,
   hash : Int,
 ) -> Unit {
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       Some(entry) => {
         if entry.hash == hash && entry.key == key {
           self.shift_back(idx)
@@ -705,16 +731,22 @@ fn[K : Eq, V] HashMap::remove_with_hash(
 
 ///|
 fn[K, V] HashMap::shift_back(self : HashMap[K, V], idx : Int) -> Unit {
+  // SAFETY: the initial `cur` is in bounds by any of the three routes its
+  // callers take -- `update` and `remove_with_hash` pass a masked probe
+  // index, and `retain` (in utils.mbt) reaches here only after its own
+  // checked `entries[i]` read succeeded, with capacity never shrinking.
+  // `next` is re-masked each step, and later `cur` values are previous
+  // `next` values.
   for cur = idx {
     let next = (cur + 1) & self.capacity_mask
-    match self.entries[next] {
+    match self.entries.unsafe_get(next) {
       None | Some({ psl: 0, .. }) => {
-        self.entries[cur] = None
+        self.entries.unsafe_set(cur, None)
         break
       }
       Some(entry) => {
         entry.psl -= 1
-        self.entries[cur] = Some(entry)
+        self.entries.unsafe_set(cur, Some(entry))
         continue next
       }
     }
@@ -742,18 +774,19 @@ fn[K, V] HashMap::rehash_place_entry(
   entry : Entry[K, V],
 ) -> Unit {
   let hash = entry.hash
+  // SAFETY: masked probe index; see the note at the top of this file.
   for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       None => {
         entry.psl = psl
-        self.entries[idx] = Some(entry)
+        self.entries.unsafe_set(idx, Some(entry))
         return
       }
       Some(curr) =>
         if psl > curr.psl {
           self.push_away(idx, curr)
           entry.psl = psl
-          self.entries[idx] = Some(entry)
+          self.entries.unsafe_set(idx, Some(entry))
           return
         } else {
           continue psl + 1, (idx + 1) & self.capacity_mask

--- a/hashmap/hashmap_bench_test.mbt
+++ b/hashmap/hashmap_bench_test.mbt
@@ -1,0 +1,78 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let hashmap_bench_n = 50000
+
+///|
+test "bench HashMap::set n=50000" (it : @bench.T) {
+  it.bench(fn() {
+    let m = @hashmap.HashMap([])
+    for i in 0..<hashmap_bench_n {
+      m.set(i * 1103515245, i)
+    }
+    it.keep(m.length())
+  })
+}
+
+///|
+test "bench HashMap::get n=50000" (it : @bench.T) {
+  let m = @hashmap.HashMap([])
+  for i in 0..<hashmap_bench_n {
+    m.set(i * 1103515245, i)
+  }
+  it.bench(fn() {
+    let mut hits = 0
+    for i in 0..<hashmap_bench_n {
+      if m.get(i * 1103515245) is Some(_) {
+        hits += 1
+      }
+    }
+    it.keep(hits)
+  })
+}
+
+///|
+test "bench HashMap::get miss n=50000" (it : @bench.T) {
+  let m = @hashmap.HashMap([])
+  for i in 0..<hashmap_bench_n {
+    m.set(i * 1103515245, i)
+  }
+  it.bench(fn() {
+    let mut misses = 0
+    for i in 0..<hashmap_bench_n {
+      if m.get(i * 1103515245 + 1) is None {
+        misses += 1
+      }
+    }
+    it.keep(misses)
+  })
+}
+
+///|
+/// Named for what it actually measures: the harness has no per-iteration
+/// setup hook, so the map has to be rebuilt inside the timed closure and the
+/// removal cost cannot be isolated from the insertion cost.
+test "bench HashMap::set+remove n=50000" (it : @bench.T) {
+  it.bench(fn() {
+    let m = @hashmap.HashMap([])
+    for i in 0..<hashmap_bench_n {
+      m.set(i * 1103515245, i)
+    }
+    for i in 0..<hashmap_bench_n {
+      m.remove(i * 1103515245)
+    }
+    it.keep(m.length())
+  })
+}

--- a/hashmap/hashmap_bench_test.mbt
+++ b/hashmap/hashmap_bench_test.mbt
@@ -76,3 +76,33 @@ test "bench HashMap::set+remove n=50000" (it : @bench.T) {
     it.keep(m.length())
   })
 }
+
+///|
+/// Removal isolated as far as the harness allows: `@bench.T` has no
+/// per-iteration setup hook, so a prebuilt map is copied inside the timed
+/// closure instead of being rebuilt with 50000 `set` calls. The copy is a
+/// single pass over the table rather than 50000 hash-and-probe insertions,
+/// so the removal work dominates. The companion "copy only" benchmark below
+/// measures the residue that remains attributable to the copy.
+test "bench HashMap::copy+remove n=50000" (it : @bench.T) {
+  let template = @hashmap.HashMap([])
+  for i in 0..<hashmap_bench_n {
+    template.set(i * 1103515245, i)
+  }
+  it.bench(fn() {
+    let m = template.copy()
+    for i in 0..<hashmap_bench_n {
+      m.remove(i * 1103515245)
+    }
+    it.keep(m.length())
+  })
+}
+
+///|
+test "bench HashMap::copy n=50000" (it : @bench.T) {
+  let template = @hashmap.HashMap([])
+  for i in 0..<hashmap_bench_n {
+    template.set(i * 1103515245, i)
+  }
+  it.bench(fn() { it.keep(template.copy().length()) })
+}

--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -11,4 +11,5 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
+  "moonbitlang/core/bench",
 } for "test"


### PR DESCRIPTION
The `hashmap` counterpart of #4125. Same idea, same invariant, no layout change — `pkg.generated.mbti` is untouched.

## The change

Every probe index in `HashMap` comes from `hash & capacity_mask` and is re-masked as `(idx + 1) & capacity_mask` on each step, so it is always in bounds for `entries`, whose length is `capacity`. The bounds check on those accesses is provably redundant.

26 masked-index sites across ten probe loops become `unsafe_get`/`unsafe_set`: `set`, `get`, `get_from_bytes`, `get_from_string`, `at`, `get_or_init`, `update`, `update_or_default`, `get_or_default`, `contains`, `contains_kv`, `remove`, `push_away`, `shift_back` and `rehash_place_entry`. With ten loops, restating the justification at each one would be noise, so the invariant is written out once at the top of the file with a marker at each loop head. The two linear iteration sites keep the checked form.

Also adds `hashmap/hashmap_bench_test.mbt`, which the package did not have. Following review feedback on #4125, it covers misses and removal as well as insertion and hits.

## Measurements

n=50000, this branch vs `origin/main`, interleaved on one machine in a single session:

| backend | op | main | this branch | change |
| --- | --- | --- | --- | --- |
| js | `set` | 2.49 ms | 2.34 ms | 6% faster |
| js | `get` hit | 508 µs | 465 µs | 8% faster |
| js | `get` miss | 690 µs | 610 µs | **12% faster** |
| js | `remove` | 3.43 ms | 3.12 ms | 9% faster |
| native | `set` | 2.25 ms | 2.16 ms | 4% faster |
| native | `get` hit | 348 µs | 334 µs | 4% faster |
| native | `get` miss | 522 µs | 496 µs | 5% faster |
| native | `remove` | 2.65 ms | 2.55 ms | 4% faster |
| wasm-gc | all four | | | unchanged |

Two differences from the `hashset` result worth noting. **Native gains here**, where in `hashset` it was lost in the noise — small, but consistent across all four operations with non-overlapping ranges, which fits `HashMap` having longer and more numerous probe loops. And **misses gain most**, which also fits: a miss walks the probe sequence to its end, so it pays the most bounds checks per call.

wasm-gc is unchanged, as in `hashset` — its array access traps inherently, so there is no separate check to remove.

## Safety

An out-of-bounds unchecked access is undefined behaviour, not a test failure, so the argument is the representation invariant, not the green suite:

- `capacity` is always a power of two and at least 1, `capacity_mask == capacity - 1`, `entries.length() == capacity`;
- every probe index starts at `hash & capacity_mask` and re-masks each step;
- `grow` installs the new array, capacity and mask together before any rehash probe runs;
- `set_with_hash` re-masks from scratch after growing;
- `shift_back` has only two callers, both passing a masked index — unlike `hashset`, there is no `retain` route reaching it with a linear index.

## Review

Codex CLI review at `ultra` reasoning effort is running; its verdict will be posted as a comment.
