### PR TITLE
perf(hashset): store entries as struct-of-arrays

### DIFF
--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -25,7 +25,9 @@ fn[K] new_hashset(capacity : Int) -> HashSet[K] {
     capacity,
     capacity_mask: capacity - 1,
     grow_at: calc_grow_threshold(capacity),
-    entries: FixedArray::make(capacity, None),
+    psls: FixedArray::make(capacity, empty_psl),
+    hashes: FixedArray::make(capacity, 0),
+    keys: UninitializedArray::make(capacity),
   }
 }
 
@@ -95,66 +97,74 @@ fn[K : Eq] HashSet::add_with_hash(
   }
   let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
     // SAFETY: `idx` starts masked by `capacity_mask` and every step re-masks
-    // it, so it is in bounds for `entries`, whose length is `capacity`.
-    match self.entries.unsafe_get(idx) {
-      None => break (idx, psl)
-      Some(curr_entry) => {
-        if curr_entry.hash == hash && curr_entry.key == key {
-          return
-        }
-        if psl > curr_entry.psl {
-          self.push_away(idx, curr_entry)
-          break (idx, psl)
-        }
-        continue psl + 1, (idx + 1) & self.capacity_mask
-      }
+    // it, so it indexes all three backing arrays -- each of length
+    // `capacity` -- in bounds. A non-empty PSL further guarantees that
+    // `keys[idx]` was initialized by `set_slot`.
+    let curr_psl = self.psls.unsafe_get(idx)
+    if curr_psl == empty_psl {
+      break (idx, psl)
     }
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
+      return
+    }
+    if psl > curr_psl {
+      // Displace the richer occupant of `idx`, then write the new key here.
+      self.push_away(
+        idx,
+        curr_psl,
+        self.hashes.unsafe_get(idx),
+        self.keys.unsafe_get(idx),
+      )
+      break (idx, psl)
+    }
+    continue psl + 1, (idx + 1) & self.capacity_mask
   }
-  let entry = { psl, key, hash }
-  self.set_entry(entry, idx)
+  self.set_slot(idx, psl, hash, key)
   self.size += 1
 }
 
 ///|
-#owned(entry)
+// Relocates the key triple `(psl, hash, key)` -- which has just been bumped out
+// of an earlier slot -- to a later slot, Robin-Hood style, starting from the
+// slot after `idx`.
 fn[K] HashSet::push_away(
   self : HashSet[K],
   idx : Int,
-  entry : Entry[K],
+  psl : Int,
+  hash : Int,
+  key : K,
 ) -> Unit {
-  for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
-    // SAFETY: same masked-index invariant as `add_with_hash`.
-    match self.entries.unsafe_get(idx) {
-      None => {
-        entry.psl = psl
-        self.set_entry(entry, idx)
-        break
-      }
-      Some(curr_entry) =>
-        if psl > curr_entry.psl {
-          entry.psl = psl
-          self.set_entry(entry, idx)
-          continue curr_entry.psl + 1,
-            (idx + 1) & self.capacity_mask,
-            curr_entry
-        } else {
-          continue psl + 1, (idx + 1) & self.capacity_mask, entry
-        }
+  for psl = psl + 1, idx = (idx + 1) & self.capacity_mask, hash = hash, key = key {
+    // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
+    let curr_psl = self.psls.unsafe_get(idx)
+    if curr_psl == empty_psl {
+      self.set_slot(idx, psl, hash, key)
+      break
+    } else if psl > curr_psl {
+      let curr_hash = self.hashes.unsafe_get(idx)
+      let curr_key = self.keys.unsafe_get(idx)
+      self.set_slot(idx, psl, hash, key)
+      continue curr_psl + 1, (idx + 1) & self.capacity_mask, curr_hash, curr_key
+    } else {
+      continue psl + 1, (idx + 1) & self.capacity_mask, hash, key
     }
   }
 }
 
 ///|
 #inline
-#owned(entry)
-fn[K] HashSet::set_entry(
+fn[K] HashSet::set_slot(
   self : HashSet[K],
-  entry : Entry[K],
-  new_idx : Int,
+  idx : Int,
+  psl : Int,
+  hash : Int,
+  key : K,
 ) -> Unit {
-  // SAFETY: every caller supplies an index already proven in bounds -- from
-  // a masked probe, or from `shift_back`'s `cur`.
-  self.entries.unsafe_set(new_idx, Some(entry))
+  // SAFETY: every caller derives `idx` from a `capacity_mask` probe, so it is
+  // in bounds for all three arrays.
+  self.psls.unsafe_set(idx, psl)
+  self.hashes.unsafe_set(idx, hash)
+  self.keys.unsafe_set(idx, key)
 }
 
 ///|
@@ -163,12 +173,16 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    // SAFETY: same masked-index invariant as `add_with_hash`.
-    guard self.entries.unsafe_get(idx) is Some(entry) else { break false }
-    if entry.hash == hash && entry.key == key {
+    // SAFETY: `idx` is masked by `capacity_mask`; all backing arrays have
+    // length `capacity`, so the probe index is in bounds.
+    let psl = self.psls.unsafe_get(idx)
+    guard psl != empty_psl else { break false }
+    // SAFETY: the same index invariant applies to `hashes`; a non-empty PSL
+    // also guarantees that `keys[idx]` was initialized by `set_slot`.
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
       break true
     }
-    if i > entry.psl {
+    if i > psl {
       break false
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -199,14 +213,15 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
 pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    // SAFETY: same masked-index invariant as `add_with_hash`.
-    guard self.entries.unsafe_get(idx) is Some(entry) else { break }
-    if entry.hash == hash && entry.key == key {
+    // SAFETY: same masked-index and initialized-key invariants as `contains`.
+    let psl = self.psls.unsafe_get(idx)
+    guard psl != empty_psl else { break }
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
       self.shift_back(idx)
       self.size -= 1
       break
     }
-    if i > entry.psl {
+    if i > psl {
       break
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -215,22 +230,28 @@ pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
 
 ///|
 fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
+  // SAFETY: `cur` is in bounds by either route its callers take -- `remove`
+  // derives it from a masked probe, and `retain` reaches here only after a
+  // checked read of that slot succeeded. `next` is re-masked each step, and
+  // later `cur` values are previous `next` values.
   for cur = idx {
     let next = (cur + 1) & self.capacity_mask
-    // SAFETY: the initial `cur` is in bounds by either route its callers
-    // take -- `remove` derives it from a masked probe, and `retain` reaches
-    // here only after a checked `entries[i]` read succeeded. `next` is
-    // re-masked each step, and `cur` afterwards is a previous `next`.
-    match self.entries.unsafe_get(next) {
-      None | Some({ psl: 0, .. }) => {
-        self.entries.unsafe_set(cur, None)
-        break
-      }
-      Some(entry) => {
-        entry.psl -= 1
-        self.set_entry(entry, cur)
-        continue next
-      }
+    let next_psl = self.psls.unsafe_get(next)
+    if next_psl == empty_psl || next_psl == 0 {
+      self.psls.unsafe_set(cur, empty_psl)
+      // Not redundant with the line above: the PSL marks the slot free, but
+      // the key slot would still hold the removed key alive until something
+      // overwrites it, retaining up to one dead key per vacated slot.
+      self.keys.set_null(cur)
+      break
+    } else {
+      self.set_slot(
+        cur,
+        next_psl - 1,
+        self.hashes.unsafe_get(next),
+        self.keys.unsafe_get(next),
+      )
+      continue next
     }
   }
 }
@@ -243,44 +264,54 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
     self.capacity_mask = self.capacity - 1
     self.grow_at = calc_grow_threshold(self.capacity)
     self.size = 0
-    self.entries = FixedArray::make(self.capacity, None)
+    self.psls = FixedArray::make(self.capacity, empty_psl)
+    self.hashes = FixedArray::make(self.capacity, 0)
+    self.keys = UninitializedArray::make(self.capacity)
     return
   }
-  let old_entries = self.entries
+  let old_psls = self.psls
+  let old_hashes = self.hashes
+  let old_keys = self.keys
+  let old_capacity = self.capacity
   let new_capacity = self.capacity * 2
-  self.entries = FixedArray::make(new_capacity, None)
+  self.psls = FixedArray::make(new_capacity, empty_psl)
+  self.hashes = FixedArray::make(new_capacity, 0)
+  self.keys = UninitializedArray::make(new_capacity)
   self.capacity = new_capacity
   self.capacity_mask = new_capacity - 1
   self.grow_at = calc_grow_threshold(self.capacity)
-  for entry in old_entries {
-    if entry is Some(entry) {
-      self.rehash_place_entry(entry)
+  for i in 0..<old_capacity {
+    // SAFETY: `i < old_capacity`, the length of all three old arrays, and a
+    // non-empty PSL means the old key slot was initialized.
+    if old_psls.unsafe_get(i) != empty_psl {
+      self.rehash_place_entry(old_hashes.unsafe_get(i), old_keys.unsafe_get(i))
     }
   }
 }
 
 ///|
-#owned(entry)
-fn[K] HashSet::rehash_place_entry(self : HashSet[K], entry : Entry[K]) -> Unit {
-  let hash = entry.hash
+fn[K] HashSet::rehash_place_entry(
+  self : HashSet[K],
+  hash : Int,
+  key : K,
+) -> Unit {
   for psl = 0, idx = hash & self.capacity_mask {
-    // SAFETY: same masked-index invariant as `add_with_hash`; `grow` installs
-    // the new `entries` and `capacity_mask` together before rehashing.
-    match self.entries.unsafe_get(idx) {
-      None => {
-        entry.psl = psl
-        self.set_entry(entry, idx)
-        return
-      }
-      Some(curr) =>
-        if psl > curr.psl {
-          self.push_away(idx, curr)
-          entry.psl = psl
-          self.set_entry(entry, idx)
-          return
-        } else {
-          continue psl + 1, (idx + 1) & self.capacity_mask
-        }
+    // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
+    let curr_psl = self.psls.unsafe_get(idx)
+    if curr_psl == empty_psl {
+      self.set_slot(idx, psl, hash, key)
+      return
+    } else if psl > curr_psl {
+      self.push_away(
+        idx,
+        curr_psl,
+        self.hashes.unsafe_get(idx),
+        self.keys.unsafe_get(idx),
+      )
+      self.set_slot(idx, psl, hash, key)
+      return
+    } else {
+      continue psl + 1, (idx + 1) & self.capacity_mask
     }
   }
 }
@@ -322,9 +353,9 @@ pub fn[K] HashSet::each(
   self : HashSet[K],
   f : (K) -> Unit raise?,
 ) -> Unit raise? {
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      f(key)
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      f(self.keys[i])
     }
   }
 }
@@ -337,8 +368,8 @@ pub fn[K] HashSet::eachi(
   f : (Int, K) -> Unit raise?,
 ) -> Unit raise? {
   for i in 0..<self.capacity; idx = 0 {
-    if self.entries[i] is Some({ key, .. }) {
-      f(idx, key)
+    if self.psls[i] != empty_psl {
+      f(idx, self.keys[i])
       continue idx + 1
     } else {
       continue idx
@@ -349,7 +380,14 @@ pub fn[K] HashSet::eachi(
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
 pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
-  self.entries.fill(None)
+  // Reuse the existing buffers (keeps the allocated space) and only null the
+  // occupied key slots so their references can be reclaimed.
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      self.psls[i] = empty_psl
+      self.keys.set_null(i)
+    }
+  }
   self.size = 0
 }
 
@@ -358,14 +396,17 @@ pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
   let mut i = 0
-  let len = self.entries.length()
+  let len = self.capacity
   Iter::new(
     fn() {
       while i < len {
-        let entry = self.entries.unsafe_get(i)
+        let idx = i
         i += 1
-        if entry is Some({ key, .. }) {
-          return Some(key)
+        // SAFETY: `idx < len`, which is the capacity captured when the
+        // iterator was created, and the table never shrinks; a non-empty PSL
+        // means the key slot was initialized.
+        if self.psls.unsafe_get(idx) != empty_psl {
+          return Some(self.keys.unsafe_get(idx))
         }
       } nobreak {
         None
@@ -378,9 +419,13 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
 ///|
 /// Converts the hash set to an array.
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
-  [
-    for entry in self.entries if entry is Some({ key, .. }) => key
-  ]
+  let arr = Array::new(capacity=self.size)
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      arr.push(self.keys[i])
+    }
+  }
+  arr
 }
 
 ///|
@@ -508,9 +553,9 @@ pub fn[K] HashSet::retain(self : HashSet[K], f : (K) -> Bool) -> Unit {
   let size = self.size
   let mut j = 0
   for i = 0; j < size; i = i + 1 {
-    while self.entries[i] is Some(entry) {
+    while self.psls[i] != empty_psl {
       j += 1
-      if f(entry.key) {
+      if f(self.keys[i]) {
         break
       } else {
         self.shift_back(i)
@@ -527,11 +572,12 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 
 ///|
 fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
-  for i in 0..<self.entries.length(); s = "" {
+  for i in 0..<self.capacity; s = "" {
     let s = if i > 0 { s + "," } else { s }
-    continue match self.entries[i] {
-        None => s + "_"
-        Some({ psl, key, .. }) => s + "(\{psl},\{key})"
+    continue if self.psls[i] == empty_psl {
+        s + "_"
+      } else {
+        s + "(\{self.psls[i]},\{self.keys[i]})"
       }
   } nobreak {
     s
@@ -539,7 +585,7 @@ fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
 }
 
 ///|
-priv struct MyString(String) derive(Eq, @debug.Debug)
+priv struct MyString(String) derive(Eq)
 
 ///|
 impl Hash for MyString with fn hash(self) {
@@ -551,6 +597,26 @@ impl Hash for MyString with fn hash(self) {
 impl Hash for MyString with fn hash_combine(self, hasher) {
   let MyString(self) = self
   hasher.combine_string(self)
+}
+
+///|
+test "contains handles collided slots across table wraparound" {
+  let m : HashSet[MyString] = new_hashset(8)
+  fn key(value) {
+    MyString::MyString(value)
+  }
+
+  // All keys hash to 7, so the probe sequence starts at the final slot and
+  // wraps around to the start of the table.
+  m.add("aaaaaaa" |> key)
+  m.add("bbbbbbb" |> key)
+  m.add("ccccccc" |> key)
+  m.add("ddddddd" |> key)
+  m.add("eeeeeee" |> key)
+
+  assert_true(m.contains("aaaaaaa" |> key))
+  assert_true(m.contains("eeeeeee" |> key))
+  assert_false(m.contains("fffffff" |> key))
 }
 
 ///|
@@ -638,12 +704,64 @@ test "grow" {
 ///|
 test "clear" {
   let m : HashSet[MyString] = new_hashset(default_init_capacity)
+  fn i(s) {
+    MyString::MyString(s)
+  }
+
+  m.add("C" |> i)
+  m.add("Go" |> i)
+  m.add("C++" |> i)
+  m.add("Java" |> i)
+  let psls = m.psls
+  let hashes = m.hashes
+  let keys = m.keys
+  inspect(m.length(), content="4")
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
-  for entry in m.entries {
-    @test.assert_same_object(entry, None)
+  inspect(physical_equal(m.psls, psls), content="true")
+  inspect(physical_equal(m.hashes, hashes), content="true")
+  inspect(physical_equal(m.keys, keys), content="true")
+  for i in 0..<m.capacity {
+    @test.assert_eq(m.psls[i], empty_psl)
   }
+  m.add("MoonBit" |> i)
+  inspect(m.length(), content="1")
+  inspect(m.contains("MoonBit" |> i), content="true")
+}
+
+///|
+test "copy sparse set only copies occupied key slots" {
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
+  fn i(s) {
+    MyString::MyString(s)
+  }
+
+  m.add("a" |> i)
+  m.add("ab" |> i)
+  m.add("bc" |> i)
+  m.add("cd" |> i)
+  m.add("abc" |> i)
+  m.add("abcdef" |> i)
+  m.remove("ab" |> i)
+  let copied = m.copy()
+  inspect(copied.length(), content="5")
+  inspect(copied.capacity(), content="8")
+  inspect(physical_equal(copied.psls, m.psls), content="false")
+  inspect(physical_equal(copied.hashes, m.hashes), content="false")
+  inspect(physical_equal(copied.keys, m.keys), content="false")
+  let mut occupied = 0
+  for idx in 0..<m.capacity {
+    @test.assert_eq(copied.psls[idx], m.psls[idx])
+    @test.assert_eq(copied.hashes[idx], m.hashes[idx])
+    if m.psls[idx] != empty_psl {
+      occupied += 1
+      assert_true(copied.keys[idx] == m.keys[idx])
+    }
+  }
+  inspect(occupied, content="5")
+  inspect(copied.contains("ab" |> i), content="false")
+  inspect(copied.contains("abcdef" |> i), content="true")
 }
 
 ///|
@@ -710,19 +828,27 @@ pub fn[K : Hash + Eq] HashSet::remove_and_check(
 /// Copy the set, creating a new set with the same keys.
 #alias(clone, deprecated)
 pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
+  // `copy` on the metadata arrays rather than make-then-blit: it is one
+  // allocation-and-copy each instead of allocate, fill, then overwrite, and
+  // on js it lowers to `Array.slice`.
+  //
+  // Independence is structural here, unlike the boxed layout this replaces:
+  // the arrays hold values, not shared mutable entries, so neither set can
+  // disturb the other's probe sequences.
   let other = {
     capacity: self.capacity,
-    entries: FixedArray::make(self.capacity, None),
+    psls: self.psls.copy(),
+    hashes: self.hashes.copy(),
+    keys: UninitializedArray::make(self.capacity),
     size: self.size,
     capacity_mask: self.capacity_mask,
     grow_at: self.grow_at,
   }
-  // Rebuild each entry rather than blitting the references: `Entry::psl` is
-  // mutable and `shift_back` decrements it, so sharing entries would let a
-  // removal on one set corrupt the probe sequences of the other.
   for i in 0..<self.capacity {
-    if self.entries[i] is Some({ psl, hash, key }) {
-      other.entries[i] = Some({ psl, hash, key })
+    // SAFETY: `i < capacity`, the length of every backing array, and a
+    // non-empty PSL means the key slot was initialized.
+    if self.psls.unsafe_get(i) != empty_psl {
+      other.keys.unsafe_set(i, self.keys.unsafe_get(i))
     }
   }
   other
@@ -731,8 +857,10 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with fn to_json(self) {
+  // Built directly rather than via `to_array`, which would materialize an
+  // `Array[X]` before the `Array[Json]`.
   [
-    for entry in self.entries if entry is Some({ key, .. }) => key
+    for i in 0..<self.capacity if self.psls[i] != empty_psl => self.keys[i]
   ]
 }
 

--- a/hashset/hashset_bench_test.mbt
+++ b/hashset/hashset_bench_test.mbt
@@ -42,3 +42,35 @@ test "bench HashSet::contains n=50000" (it : @bench.T) {
     it.keep(hits)
   })
 }
+
+///|
+/// Removal isolated as far as the harness allows: `@bench.T` has no
+/// per-iteration setup hook, so a prebuilt set is copied inside the timed
+/// closure rather than rebuilt with 50000 `add` calls. The companion "copy
+/// only" benchmark below measures the residue attributable to the copy.
+///
+/// This exists because the removal path had no coverage at all: the
+/// struct-of-arrays conversion silently reverted `remove`/`shift_back` to
+/// checked access and no benchmark noticed.
+test "bench HashSet::copy+remove n=50000" (it : @bench.T) {
+  let template = @hashset.HashSet([])
+  for i in 0..<hashset_bench_n {
+    template.add(i * 1103515245)
+  }
+  it.bench(fn() {
+    let s = template.copy()
+    for i in 0..<hashset_bench_n {
+      s.remove(i * 1103515245)
+    }
+    it.keep(s.length())
+  })
+}
+
+///|
+test "bench HashSet::copy n=50000" (it : @bench.T) {
+  let template = @hashset.HashSet([])
+  for i in 0..<hashset_bench_n {
+    template.add(i * 1103515245)
+  }
+  it.bench(fn() { it.keep(template.copy().length()) })
+}

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -13,14 +13,35 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
-priv struct Entry[K] {
-  mut psl : Int
-  hash : Int
-  key : K
-} derive(@debug.Debug)
+/// `psls[i] == empty_psl` marks an empty slot. A real probe-sequence length is
+/// always `>= 0`, so `-1` is a safe sentinel.
+let empty_psl : Int = -1
 
-/// A mutable hash set implements with Robin Hood hashing.
+///|
+/// Package-local unchecked accessors for the key storage. These are kept
+/// private here rather than exposed from `builtin`: `set_null` and
+/// `unsafe_set` can corrupt memory, so the fewer packages that can name them
+/// the better.
+fn[K] UninitializedArray::unsafe_get(
+  self : UninitializedArray[K],
+  idx : Int,
+) -> K = "%fixedarray.unsafe_get"
+
+///|
+fn[K] UninitializedArray::unsafe_set(
+  self : UninitializedArray[K],
+  idx : Int,
+  key : K,
+) -> Unit = "%fixedarray.unsafe_set"
+
+///|
+/// Releases the key reference stored at `idx` so the collector can reclaim it.
+fn[K] UninitializedArray::set_null(
+  self : UninitializedArray[K],
+  idx : Int,
+) -> Unit = "%fixedarray.set_null"
+
+/// A mutable hash set implemented with Robin Hood hashing.
 ///
 /// reference:
 /// - <https://programming.guide/robin-hood-hashing.html>
@@ -28,6 +49,12 @@ priv struct Entry[K] {
 
 ///|
 /// Mutable hash set, not thread safe.
+///
+/// The table is stored as a struct-of-arrays (`psls` / `hashes` / `keys`)
+/// rather than an array of boxed entries, so inserting a key does not allocate
+/// a per-entry object. For an occupied slot `i`, `hashes[i]` caches the key's
+/// hash and `keys[i]` holds the key; for an empty slot `psls[i] == empty_psl`
+/// and `keys[i]` is unused.
 ///
 /// # Example
 ///
@@ -39,7 +66,9 @@ priv struct Entry[K] {
 /// }
 /// ```
 struct HashSet[K] {
-  mut entries : FixedArray[Entry[K]?]
+  mut psls : FixedArray[Int] // probe sequence length, or empty_psl when empty
+  mut hashes : FixedArray[Int] // cached key hash for occupied slots
+  mut keys : UninitializedArray[K] // key storage for occupied slots
   mut size : Int // active key count
   mut capacity : Int // current capacity
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx


### PR DESCRIPTION
Second of two PRs splitting #3712. **Stacked on #4125** — review that one first; this diff is `hongbo/hashset-unchecked..hongbo/hashset-soa`.

Original layout work by @mizchi, carried over with authorship.

## The change

`FixedArray[Entry[K]?]` with a heap-allocated `Entry { psl, hash, key }` becomes three parallel arrays:

```
psls   : FixedArray[Int]        // -1 marks an empty slot
hashes : FixedArray[Int]
keys   : UninitializedArray[K]
```

`psls[i] == -1` is the empty-slot sentinel — a real probe sequence length is always `>= 0` — so no separate occupancy array is needed. Inserting writes three slots and allocates nothing. Vacated slots get `set_null` so the key stays collectable. Same Robin Hood algorithm, same observable behaviour, `pkg.generated.mbti` unchanged.

The unchecked accessors are declared package-locally as methods on `UninitializedArray` in `hashset/types.mbt` rather than exposed from `builtin`. That is deliberate: `set_null` and `unsafe_set` can corrupt memory or resurrect a freed slot, so the fewer packages able to name them, the better.

## Measurements

n=50000, against its parent #4125, interleaved on one machine in a single session:

| backend | op | parent (boxed + unchecked) | this (SoA) | change |
| --- | --- | --- | --- | --- |
| native | `add` | 2.29 ms | 1.49 ms | **35% faster** |
| native | `contains` | 871 µs | 792 µs | 9% faster |
| wasm-gc | `add` | 2.38 ms | 1.98 ms | **17% faster** |
| wasm-gc | `contains` | 1.15 ms | 1.06 ms | 8% faster |
| js | `add` | 2.55 ms | 3.02 ms | **18% slower** |
| js | `contains` | 1.05 ms | 1.05 ms | unchanged |

Against `origin/main`, the two PRs together give native `add` 2.35 → 1.49 ms, wasm-gc 2.30 → 1.98 ms, js 3.08 → 3.02 ms.

**That js number is the whole reason for the split.** Measured against `main`, the combined #3712 looked like "big native win, js unchanged" — but the js parity was the probing win cancelling out the layout's cost, not the layout being free. Only separating them shows the layout costs js 18% on its own.

## Where the js cost actually comes from

I attributed it to the three-array probe. The review disproved that with generated-code measurements and localised it to **`grow`**: allocating and initialising three backing stores costs ~0.68 ms against ~0.25 ms for one, while the rehash loops themselves came out about equal.

That materially narrows the affected workload:

- **unknown-size incremental construction** regresses ~18–19% for integers, ~14% for short strings — which is exactly what this benchmark measures, i.e. the worst case;
- **pre-sized construction** is near parity (+2.8%, or roughly equal with construction excluded);
- **lookup** is neutral for integers and modestly faster for strings.

So the cost is a construction-and-growth cost on js, not a steady-state one. A caller who sizes the set up front barely pays it.

## Recommendation

The review recommends landing as is — option (a) — rather than a `#cfg(target="js")` fork keeping the boxed layout on js:

> Duplicating the storage engine — and potentially doing the same for Map/Set — adds more maintenance and semantic-drift risk than the growth-only JS cost justifies.

I agree, with the caveat that this is a judgement call and the numbers above are what it rests on. The final stack is near parity with `main` on js while gaining 35% on native and 17% on wasm-gc.

## Review

Reviewed by Codex CLI at `ultra` reasoning effort — approved, verdict below. Two non-blocking test gaps it names and I have not closed: reclamation is argued from emitted code rather than a weak-reference test (see the discussion of the liveness gap on #3712), and remove-then-grow plus wraparound shift-back deserve focused regression tests.
