### PR TITLE
perf(set): probe with unchecked array access

### DIFF
--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -50,6 +50,25 @@ struct Set[K] {
 
 // Implementations
 
+// SAFETY NOTE for the unchecked probe accesses in this file.
+//
+// `capacity` is always a power of two and at least 1, `capacity_mask` is
+// `capacity - 1`, and `entries.length()` is `capacity`. A probe index is
+// therefore always in bounds: it starts as `hash & capacity_mask` and each
+// step re-masks with `(idx + 1) & capacity_mask`. `grow` installs the new
+// array, capacity and mask together before any rehash probe runs.
+//
+// Only those probe indices use `unsafe_get` / `unsafe_set`. `Set` also
+// stores slot indices in the list itself -- `prev` on each entry and `tail`
+// on the set -- and `copy` walks the whole list through them, from
+// `entries[self.tail]` back along each `entries[prev]`. Every access through
+// a stored index keeps the checked form. They are in bounds too, being
+// former probe indices in a table that never shrinks, but that argument
+// depends on the list being maintained correctly rather than on arithmetic
+// alone, so it is not one to build unchecked access on. `shift_back` is
+// unchecked, but on a local caller-based proof rather than on that
+// invariant: both of its callers pass masked probe indices.
+
 ///|
 let default_init_capacity = 8
 
@@ -136,8 +155,9 @@ fn[K : Eq] Set::add_with_hash(self : Set[K], key : K, hash : Int) -> Unit {
   if self.size >= self.grow_at {
     self.grow()
   }
+  // SAFETY: masked probe index; see the note at the top of this file.
   let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       None => break (idx, psl)
       Some(curr_entry) => {
         if curr_entry.hash == hash && curr_entry.key == key {
@@ -158,8 +178,9 @@ fn[K : Eq] Set::add_with_hash(self : Set[K], key : K, hash : Int) -> Unit {
 ///|
 #owned(entry)
 fn[K] Set::push_away(self : Set[K], idx : Int, entry : Entry[K]) -> Unit {
+  // SAFETY: masked probe index; see the note at the top of this file.
   for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       None => {
         entry.psl = psl
         self.set_entry(entry, idx)
@@ -189,7 +210,7 @@ fn[K] Set::set_entry(self : Set[K], entry : Entry[K], new_idx : Int) -> Unit {
     None => self.tail = new_idx
     Some(next) => next.prev = new_idx
   }
-  self.entries[new_idx] = Some(entry)
+  self.entries.unsafe_set(new_idx, Some(entry))
 }
 
 ///|
@@ -218,8 +239,9 @@ pub fn[K : Hash + Eq] Set::add_and_check(self : Set[K], key : K) -> Bool {
     self.grow()
   }
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   let (idx, psl, added) = for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       None => break (idx, psl, true)
       Some(curr_entry) => {
         if curr_entry.hash == hash && curr_entry.key == key {
@@ -245,8 +267,9 @@ pub fn[K : Hash + Eq] Set::add_and_check(self : Set[K], key : K) -> Bool {
 pub fn[K : Hash + Eq] Set::contains(self : Set[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break false }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
       break true
     }
@@ -280,8 +303,9 @@ pub fn[K : Hash + Eq] Set::contains(self : Set[K], key : K) -> Bool {
 /// ```
 pub fn[K : Hash + Eq] Set::remove(self : Set[K], key : K) -> Unit {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break }
     if entry.hash == hash && entry.key == key {
       self.remove_entry(entry)
       self.shift_back(idx)
@@ -318,8 +342,9 @@ pub fn[K : Hash + Eq] Set::remove(self : Set[K], key : K) -> Unit {
 /// ```
 pub fn[K : Hash + Eq] Set::remove_and_check(self : Set[K], key : K) -> Bool {
   let hash = Hash::hash(key)
+  // SAFETY: masked probe index; see the note at the top of this file.
   for i = 0, idx = hash & self.capacity_mask {
-    guard self.entries[idx] is Some(entry) else { break false }
+    guard self.entries.unsafe_get(idx) is Some(entry) else { break false }
     if entry.hash == hash && entry.key == key {
       self.remove_entry(entry)
       self.shift_back(idx)
@@ -345,7 +370,7 @@ fn[K] Set::add_entry_to_tail(
     tail => self.entries[tail].unwrap().next = Some(entry)
   }
   self.tail = idx
-  self.entries[idx] = Some(entry)
+  self.entries.unsafe_set(idx, Some(entry))
   self.size += 1
 }
 
@@ -363,11 +388,16 @@ fn[K] Set::remove_entry(self : Set[K], entry : Entry[K]) -> Unit {
 
 ///|
 fn[K] Set::shift_back(self : Set[K], idx : Int) -> Unit {
+  // SAFETY: both callers -- `remove` and `remove_and_check` -- pass a masked
+  // probe index. Unlike `Map`, no route reaches here carrying a stored list
+  // index, because `Set` has no `retain`. `next` is re-masked each step and
+  // later `cur` values are previous `next` values. This is also what makes
+  // the `set_entry` call below sound.
   for cur = idx {
     let next = (cur + 1) & self.capacity_mask
-    match self.entries[next] {
+    match self.entries.unsafe_get(next) {
       None | Some({ psl: 0, .. }) => {
-        self.entries[cur] = None
+        self.entries.unsafe_set(cur, None)
         break
       }
       Some(entry) => {
@@ -407,8 +437,9 @@ fn[K] Set::grow(self : Set[K]) -> Unit {
 #owned(outer)
 fn[K] Set::rehash_place_entry(self : Set[K], outer : Entry[K]) -> Unit {
   let hash = outer.hash
+  // SAFETY: masked probe index; see the note at the top of this file.
   for psl = 0, idx = hash & self.capacity_mask {
-    match self.entries[idx] {
+    match self.entries.unsafe_get(idx) {
       None => {
         outer.psl = psl
         outer.prev = self.tail

--- a/set/linked_hash_set_bench_test.mbt
+++ b/set/linked_hash_set_bench_test.mbt
@@ -1,0 +1,78 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let set_bench_n = 50000
+
+///|
+test "bench Set::add n=50000" (it : @bench.T) {
+  it.bench(fn() {
+    let s = @set.Set([])
+    for i in 0..<set_bench_n {
+      s.add(i * 1103515245)
+    }
+    it.keep(s.length())
+  })
+}
+
+///|
+test "bench Set::contains n=50000" (it : @bench.T) {
+  let s = @set.Set([])
+  for i in 0..<set_bench_n {
+    s.add(i * 1103515245)
+  }
+  it.bench(fn() {
+    let mut hits = 0
+    for i in 0..<set_bench_n {
+      if s.contains(i * 1103515245) {
+        hits += 1
+      }
+    }
+    it.keep(hits)
+  })
+}
+
+///|
+test "bench Set::contains miss n=50000" (it : @bench.T) {
+  let s = @set.Set([])
+  for i in 0..<set_bench_n {
+    s.add(i * 1103515245)
+  }
+  it.bench(fn() {
+    let mut misses = 0
+    for i in 0..<set_bench_n {
+      if !s.contains(i * 1103515245 + 1) {
+        misses += 1
+      }
+    }
+    it.keep(misses)
+  })
+}
+
+///|
+/// Named for what it measures: `@bench.T` has no per-iteration setup hook,
+/// so the set has to be rebuilt inside the timed closure and the removal
+/// cost cannot be isolated from the insertion cost.
+test "bench Set::add+remove n=50000" (it : @bench.T) {
+  it.bench(fn() {
+    let s = @set.Set([])
+    for i in 0..<set_bench_n {
+      s.add(i * 1103515245)
+    }
+    for i in 0..<set_bench_n {
+      s.remove(i * 1103515245)
+    }
+    it.keep(s.length())
+  })
+}

--- a/set/moon.pkg
+++ b/set/moon.pkg
@@ -9,4 +9,5 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/test",
   "moonbitlang/core/quickcheck",
+  "moonbitlang/core/bench",
 } for "test"


### PR DESCRIPTION
Fourth and last in the wave applying unchecked probing to core's hash containers, after #4125 (`hashset`), #4126 (`hashmap`) and #4128 (`Map`).

## Measurements

New file `set/linked_hash_set_bench_test.mbt`. n=50000, this branch vs `origin/main`, interleaved on one machine in a single session:

| backend | op | main | this branch | change |
| --- | --- | --- | --- | --- |
| js | `add` | 3.41 ms | 2.87 ms | **16% faster** |
| js | `contains` hit | 1.20 ms | 1.02 ms | **15% faster** |
| js | `contains` miss | 1.40 ms | 1.16 ms | **17% faster** |
| js | `add+remove` | 5.05 ms | 4.14 ms | **18% faster** |
| native | all | | | within noise |
| wasm-gc | all | | | within noise |

Same shape as the other three: the saving is the explicit length comparison js emits per access, so js gains and the backends whose array access traps inherently do not. The percentages are empirical — js randomises its hash seed, so they move between runs.

## The change

Eleven masked-probe sites become `unsafe_get`/`unsafe_set`. The invariant is stated once at the top of the file with a marker at each loop head.

`Set` is a linked hash set, so as with `Map` its `entries` accesses take indices from two places: masked probe indices, and slot indices stored in the list itself (`prev`, `tail`, and the ones the copy path walks). **Only the first kind is converted.** Every access through a stored index keeps the checked form, since their being in bounds rests on the list being maintained correctly rather than on arithmetic alone.

`shift_back` is unchecked, but on a *local caller-based* proof rather than on that invariant: both of its callers pass masked probe indices, and `Set` has no `retain`, so unlike `Map` there is no route reaching it with a stored index at all. That proof is what makes the `set_entry` call inside it sound — a subtlety the review of #4128 caught in the `Map` version, where I had claimed `shift_back` stayed checked while it was in fact calling an already-converted `set_entry`.

## Review

Codex CLI review at `ultra` reasoning effort to follow. Its findings on #4128 were applied here pre-emptively, since the two containers share a structure.