### PR TITLE
perf(hashset): store the table as two arrays, deriving each PSL

### DIFF
--- a/hashset/derived_psl_test.mbt
+++ b/hashset/derived_psl_test.mbt
@@ -1,0 +1,131 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The probe-sequence length is derived from a slot's position rather than
+// stored, so these exercise every path that used to write a PSL: displacement,
+// shift-back cascades, growth, copying, and the remapped sentinel.
+
+///|
+priv struct Coll(Int) derive(Eq)
+
+///|
+impl Hash for Coll with fn hash(self) {
+  let Coll(x) = self
+  x % 4
+}
+
+///|
+impl Hash for Coll with fn hash_combine(self, hasher) {
+  let Coll(x) = self
+  hasher.combine_int(x % 4)
+}
+
+///|
+/// Heavy collisions: long probe runs, push_away displacement, shift_back
+/// cascades, growth, and copy -- every path the derived PSL has to get right.
+test "two-array stress" {
+  let s = @hashset.HashSet([])
+  for round in 0..<6 {
+    for i in 0..<200 {
+      s.add(Coll(i + round * 200))
+    }
+    for i in 0..<200 {
+      if i % 3 == 0 {
+        s.remove(Coll(i + round * 200))
+      }
+    }
+    for i in 0..<200 {
+      if i % 3 == 0 {
+        s.add(Coll(i + round * 200))
+      }
+    }
+  }
+  inspect(s.length(), content="1200")
+  let mut found = 0
+  for i in 0..<1200 {
+    if s.contains(Coll(i)) {
+      found += 1
+    }
+  }
+  inspect(found, content="1200")
+  // absent keys must stay absent
+  let mut absent = 0
+  for i in 1200..<1400 {
+    if !s.contains(Coll(i)) {
+      absent += 1
+    }
+  }
+  inspect(absent, content="200")
+  let dup = s.copy()
+  for i in 0..<600 {
+    dup.remove(Coll(i))
+  }
+  inspect(dup.length(), content="600")
+  inspect(s.length(), content="1200")
+}
+
+///|
+/// The sentinel path: keys whose hash is exactly `empty_hash` must round-trip,
+/// since their stored hash is remapped.
+test "keys hashing to the empty sentinel" {
+  let s = @hashset.HashSet([])
+  for i in 0..<400 {
+    s.add(Coll(i))
+  }
+  // Coll(0), Coll(4), ... hash to 0, which is the sentinel value.
+  inspect(s.contains(Coll(0)), content="true")
+  inspect(s.contains(Coll(4)), content="true")
+  inspect(s.length(), content="400")
+  s.remove(Coll(0))
+  inspect(s.contains(Coll(0)), content="false")
+  inspect(s.contains(Coll(4)), content="true")
+  inspect(s.length(), content="399")
+  let arr = s.to_array()
+  inspect(arr.length(), content="399")
+}
+
+///|
+/// Differential check against a reference model over randomized operations.
+test "differential against a model" {
+  let s = @hashset.HashSet([])
+  let present = FixedArray::make(1000, false)
+  let mut state = 0x2545F491
+  let mut model_size = 0
+  for step in 0..<20000 {
+    state = state * 1103515245 + 12345
+    let k = (state >> 8) % 500
+    let slot = k + 500
+    if step % 3 == 0 {
+      s.remove(k)
+      if present[slot] {
+        present[slot] = false
+        model_size -= 1
+      }
+    } else {
+      s.add(k)
+      if !present[slot] {
+        present[slot] = true
+        model_size += 1
+      }
+    }
+  }
+  inspect(s.length() == model_size, content="true")
+  let mut agree = 0
+  for k in -500..<500 {
+    if s.contains(k) == present[k + 500] {
+      agree += 1
+    }
+  }
+  inspect(agree, content="1000")
+}

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -25,8 +25,7 @@ fn[K] new_hashset(capacity : Int) -> HashSet[K] {
     capacity,
     capacity_mask: capacity - 1,
     grow_at: calc_grow_threshold(capacity),
-    psls: FixedArray::make(capacity, empty_psl),
-    hashes: FixedArray::make(capacity, 0),
+    hashes: FixedArray::make(capacity, empty_hash),
     keys: UninitializedArray::make(capacity),
   }
 }
@@ -87,6 +86,15 @@ pub fn[K : Hash + Eq] HashSet::add(self : HashSet[K], key : K) -> Unit {
 }
 
 ///|
+/// The probe-sequence length of the occupied slot `idx`: how far it sits from
+/// the slot its hash asked for. Derived rather than stored -- see the note on
+/// `HashSet`.
+#inline
+fn[K] HashSet::psl_at(self : HashSet[K], idx : Int, stored : Int) -> Int {
+  (idx - (stored & self.capacity_mask)) & self.capacity_mask
+}
+
+///|
 fn[K : Eq] HashSet::add_with_hash(
   self : HashSet[K],
   key : K,
@@ -95,31 +103,27 @@ fn[K : Eq] HashSet::add_with_hash(
   if self.size >= self.grow_at {
     self.grow()
   }
-  let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
+  let stored = store_hash(hash)
+  let idx = for psl = 0, idx = stored & self.capacity_mask {
     // SAFETY: `idx` starts masked by `capacity_mask` and every step re-masks
-    // it, so it indexes all three backing arrays -- each of length
-    // `capacity` -- in bounds. A non-empty PSL further guarantees that
-    // `keys[idx]` was initialized by `set_slot`.
-    let curr_psl = self.psls.unsafe_get(idx)
-    if curr_psl == empty_psl {
-      break (idx, psl)
+    // it, so it indexes both backing arrays -- each of length `capacity` --
+    // in bounds. A non-empty slot further guarantees that `keys[idx]` was
+    // initialized by `set_slot`.
+    let curr = self.hashes.unsafe_get(idx)
+    if curr == empty_hash {
+      break idx
     }
-    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
+    if curr == stored && self.keys.unsafe_get(idx) == key {
       return
     }
-    if psl > curr_psl {
+    if psl > self.psl_at(idx, curr) {
       // Displace the richer occupant of `idx`, then write the new key here.
-      self.push_away(
-        idx,
-        curr_psl,
-        self.hashes.unsafe_get(idx),
-        self.keys.unsafe_get(idx),
-      )
-      break (idx, psl)
+      self.push_away(idx, curr, self.keys.unsafe_get(idx))
+      break idx
     }
     continue psl + 1, (idx + 1) & self.capacity_mask
   }
-  self.set_slot(idx, psl, hash, key)
+  self.set_slot(idx, stored, key)
   self.size += 1
 }
 
@@ -130,23 +134,24 @@ fn[K : Eq] HashSet::add_with_hash(
 fn[K] HashSet::push_away(
   self : HashSet[K],
   idx : Int,
-  psl : Int,
-  hash : Int,
+  stored : Int,
   key : K,
 ) -> Unit {
-  for psl = psl + 1, idx = (idx + 1) & self.capacity_mask, hash = hash, key = key {
+  for psl = self.psl_at(idx, stored) + 1, idx = (idx + 1) & self.capacity_mask, stored = stored, key = key {
     // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
-    let curr_psl = self.psls.unsafe_get(idx)
-    if curr_psl == empty_psl {
-      self.set_slot(idx, psl, hash, key)
+    let curr = self.hashes.unsafe_get(idx)
+    if curr == empty_hash {
+      self.set_slot(idx, stored, key)
       break
-    } else if psl > curr_psl {
-      let curr_hash = self.hashes.unsafe_get(idx)
+    } else if psl > self.psl_at(idx, curr) {
       let curr_key = self.keys.unsafe_get(idx)
-      self.set_slot(idx, psl, hash, key)
-      continue curr_psl + 1, (idx + 1) & self.capacity_mask, curr_hash, curr_key
+      self.set_slot(idx, stored, key)
+      continue self.psl_at(idx, curr) + 1,
+        (idx + 1) & self.capacity_mask,
+        curr,
+        curr_key
     } else {
-      continue psl + 1, (idx + 1) & self.capacity_mask, hash, key
+      continue psl + 1, (idx + 1) & self.capacity_mask, stored, key
     }
   }
 }
@@ -156,14 +161,12 @@ fn[K] HashSet::push_away(
 fn[K] HashSet::set_slot(
   self : HashSet[K],
   idx : Int,
-  psl : Int,
-  hash : Int,
+  stored : Int,
   key : K,
 ) -> Unit {
   // SAFETY: every caller derives `idx` from a `capacity_mask` probe, so it is
-  // in bounds for all three arrays.
-  self.psls.unsafe_set(idx, psl)
-  self.hashes.unsafe_set(idx, hash)
+  // in bounds for both arrays.
+  self.hashes.unsafe_set(idx, stored)
   self.keys.unsafe_set(idx, key)
 }
 
@@ -171,18 +174,17 @@ fn[K] HashSet::set_slot(
 /// Returns `true` if the set contains the given key.
 pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
-  let hash = Hash::hash(key)
-  for i = 0, idx = hash & self.capacity_mask {
-    // SAFETY: `idx` is masked by `capacity_mask`; all backing arrays have
-    // length `capacity`, so the probe index is in bounds.
-    let psl = self.psls.unsafe_get(idx)
-    guard psl != empty_psl else { break false }
-    // SAFETY: the same index invariant applies to `hashes`; a non-empty PSL
+  let stored = store_hash(Hash::hash(key))
+  for i = 0, idx = stored & self.capacity_mask {
+    // SAFETY: `idx` is masked by `capacity_mask`; both backing arrays have
+    // length `capacity`, so the probe index is in bounds. A non-empty slot
     // also guarantees that `keys[idx]` was initialized by `set_slot`.
-    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
+    let curr = self.hashes.unsafe_get(idx)
+    guard curr != empty_hash else { break false }
+    if curr == stored && self.keys.unsafe_get(idx) == key {
       break true
     }
-    if i > psl {
+    if i > self.psl_at(idx, curr) {
       break false
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -211,17 +213,17 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
 /// }
 /// ```
 pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
-  let hash = Hash::hash(key)
-  for i = 0, idx = hash & self.capacity_mask {
+  let stored = store_hash(Hash::hash(key))
+  for i = 0, idx = stored & self.capacity_mask {
     // SAFETY: same masked-index and initialized-key invariants as `contains`.
-    let psl = self.psls.unsafe_get(idx)
-    guard psl != empty_psl else { break }
-    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
+    let curr = self.hashes.unsafe_get(idx)
+    guard curr != empty_hash else { break }
+    if curr == stored && self.keys.unsafe_get(idx) == key {
       self.shift_back(idx)
       self.size -= 1
       break
     }
-    if i > psl {
+    if i > self.psl_at(idx, curr) {
       break
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -236,21 +238,18 @@ fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
   // later `cur` values are previous `next` values.
   for cur = idx {
     let next = (cur + 1) & self.capacity_mask
-    let next_psl = self.psls.unsafe_get(next)
-    if next_psl == empty_psl || next_psl == 0 {
-      self.psls.unsafe_set(cur, empty_psl)
-      // Not redundant with the line above: the PSL marks the slot free, but
+    let next_stored = self.hashes.unsafe_get(next)
+    if next_stored == empty_hash || self.psl_at(next, next_stored) == 0 {
+      self.hashes.unsafe_set(cur, empty_hash)
+      // Not redundant with the line above: the hash marks the slot free, but
       // the key slot would still hold the removed key alive until something
       // overwrites it, retaining up to one dead key per vacated slot.
       self.keys.set_null(cur)
       break
     } else {
-      self.set_slot(
-        cur,
-        next_psl - 1,
-        self.hashes.unsafe_get(next),
-        self.keys.unsafe_get(next),
-      )
+      // Moving the occupant one slot back drops its derived PSL by one, so
+      // nothing has to be recomputed or written for it.
+      self.set_slot(cur, next_stored, self.keys.unsafe_get(next))
       continue next
     }
   }
@@ -264,27 +263,25 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
     self.capacity_mask = self.capacity - 1
     self.grow_at = calc_grow_threshold(self.capacity)
     self.size = 0
-    self.psls = FixedArray::make(self.capacity, empty_psl)
-    self.hashes = FixedArray::make(self.capacity, 0)
+    self.hashes = FixedArray::make(self.capacity, empty_hash)
     self.keys = UninitializedArray::make(self.capacity)
     return
   }
-  let old_psls = self.psls
   let old_hashes = self.hashes
   let old_keys = self.keys
   let old_capacity = self.capacity
   let new_capacity = self.capacity * 2
-  self.psls = FixedArray::make(new_capacity, empty_psl)
-  self.hashes = FixedArray::make(new_capacity, 0)
+  self.hashes = FixedArray::make(new_capacity, empty_hash)
   self.keys = UninitializedArray::make(new_capacity)
   self.capacity = new_capacity
   self.capacity_mask = new_capacity - 1
   self.grow_at = calc_grow_threshold(self.capacity)
   for i in 0..<old_capacity {
-    // SAFETY: `i < old_capacity`, the length of all three old arrays, and a
-    // non-empty PSL means the old key slot was initialized.
-    if old_psls.unsafe_get(i) != empty_psl {
-      self.rehash_place_entry(old_hashes.unsafe_get(i), old_keys.unsafe_get(i))
+    // SAFETY: `i < old_capacity`, the length of both old arrays, and a
+    // non-empty slot means the old key slot was initialized.
+    let stored = old_hashes.unsafe_get(i)
+    if stored != empty_hash {
+      self.rehash_place_entry(stored, old_keys.unsafe_get(i))
     }
   }
 }
@@ -292,23 +289,18 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
 ///|
 fn[K] HashSet::rehash_place_entry(
   self : HashSet[K],
-  hash : Int,
+  stored : Int,
   key : K,
 ) -> Unit {
-  for psl = 0, idx = hash & self.capacity_mask {
+  for psl = 0, idx = stored & self.capacity_mask {
     // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
-    let curr_psl = self.psls.unsafe_get(idx)
-    if curr_psl == empty_psl {
-      self.set_slot(idx, psl, hash, key)
+    let curr = self.hashes.unsafe_get(idx)
+    if curr == empty_hash {
+      self.set_slot(idx, stored, key)
       return
-    } else if psl > curr_psl {
-      self.push_away(
-        idx,
-        curr_psl,
-        self.hashes.unsafe_get(idx),
-        self.keys.unsafe_get(idx),
-      )
-      self.set_slot(idx, psl, hash, key)
+    } else if psl > self.psl_at(idx, curr) {
+      self.push_away(idx, curr, self.keys.unsafe_get(idx))
+      self.set_slot(idx, stored, key)
       return
     } else {
       continue psl + 1, (idx + 1) & self.capacity_mask
@@ -354,7 +346,7 @@ pub fn[K] HashSet::each(
   f : (K) -> Unit raise?,
 ) -> Unit raise? {
   for i in 0..<self.capacity {
-    if self.psls[i] != empty_psl {
+    if self.hashes[i] != empty_hash {
       f(self.keys[i])
     }
   }
@@ -368,7 +360,7 @@ pub fn[K] HashSet::eachi(
   f : (Int, K) -> Unit raise?,
 ) -> Unit raise? {
   for i in 0..<self.capacity; idx = 0 {
-    if self.psls[i] != empty_psl {
+    if self.hashes[i] != empty_hash {
       f(idx, self.keys[i])
       continue idx + 1
     } else {
@@ -383,8 +375,8 @@ pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
   // Reuse the existing buffers (keeps the allocated space) and only null the
   // occupied key slots so their references can be reclaimed.
   for i in 0..<self.capacity {
-    if self.psls[i] != empty_psl {
-      self.psls[i] = empty_psl
+    if self.hashes[i] != empty_hash {
+      self.hashes[i] = empty_hash
       self.keys.set_null(i)
     }
   }
@@ -405,7 +397,7 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
         // SAFETY: `idx < len`, which is the capacity captured when the
         // iterator was created, and the table never shrinks; a non-empty PSL
         // means the key slot was initialized.
-        if self.psls.unsafe_get(idx) != empty_psl {
+        if self.hashes.unsafe_get(idx) != empty_hash {
           return Some(self.keys.unsafe_get(idx))
         }
       } nobreak {
@@ -421,7 +413,7 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
   let arr = Array::new(capacity=self.size)
   for i in 0..<self.capacity {
-    if self.psls[i] != empty_psl {
+    if self.hashes[i] != empty_hash {
       arr.push(self.keys[i])
     }
   }
@@ -553,7 +545,7 @@ pub fn[K] HashSet::retain(self : HashSet[K], f : (K) -> Bool) -> Unit {
   let size = self.size
   let mut j = 0
   for i = 0; j < size; i = i + 1 {
-    while self.psls[i] != empty_psl {
+    while self.hashes[i] != empty_hash {
       j += 1
       if f(self.keys[i]) {
         break
@@ -574,10 +566,10 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
   for i in 0..<self.capacity; s = "" {
     let s = if i > 0 { s + "," } else { s }
-    continue if self.psls[i] == empty_psl {
+    continue if self.hashes[i] == empty_hash {
         s + "_"
       } else {
-        s + "(\{self.psls[i]},\{self.keys[i]})"
+        s + "(\{self.psl_at(i, self.hashes[i])},\{self.keys[i]})"
       }
   } nobreak {
     s
@@ -712,18 +704,16 @@ test "clear" {
   m.add("Go" |> i)
   m.add("C++" |> i)
   m.add("Java" |> i)
-  let psls = m.psls
   let hashes = m.hashes
   let keys = m.keys
   inspect(m.length(), content="4")
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
-  inspect(physical_equal(m.psls, psls), content="true")
   inspect(physical_equal(m.hashes, hashes), content="true")
   inspect(physical_equal(m.keys, keys), content="true")
   for i in 0..<m.capacity {
-    @test.assert_eq(m.psls[i], empty_psl)
+    @test.assert_eq(m.hashes[i], empty_hash)
   }
   m.add("MoonBit" |> i)
   inspect(m.length(), content="1")
@@ -747,14 +737,12 @@ test "copy sparse set only copies occupied key slots" {
   let copied = m.copy()
   inspect(copied.length(), content="5")
   inspect(copied.capacity(), content="8")
-  inspect(physical_equal(copied.psls, m.psls), content="false")
   inspect(physical_equal(copied.hashes, m.hashes), content="false")
   inspect(physical_equal(copied.keys, m.keys), content="false")
   let mut occupied = 0
   for idx in 0..<m.capacity {
-    @test.assert_eq(copied.psls[idx], m.psls[idx])
     @test.assert_eq(copied.hashes[idx], m.hashes[idx])
-    if m.psls[idx] != empty_psl {
+    if m.hashes[idx] != empty_hash {
       occupied += 1
       assert_true(copied.keys[idx] == m.keys[idx])
     }
@@ -837,7 +825,6 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
   // disturb the other's probe sequences.
   let other = {
     capacity: self.capacity,
-    psls: self.psls.copy(),
     hashes: self.hashes.copy(),
     keys: UninitializedArray::make(self.capacity),
     size: self.size,
@@ -847,7 +834,7 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
   for i in 0..<self.capacity {
     // SAFETY: `i < capacity`, the length of every backing array, and a
     // non-empty PSL means the key slot was initialized.
-    if self.psls.unsafe_get(i) != empty_psl {
+    if self.hashes.unsafe_get(i) != empty_hash {
       other.keys.unsafe_set(i, self.keys.unsafe_get(i))
     }
   }
@@ -860,7 +847,7 @@ pub impl[X : ToJson] ToJson for HashSet[X] with fn to_json(self) {
   // Built directly rather than via `to_array`, which would materialize an
   // `Array[X]` before the `Array[Json]`.
   [
-    for i in 0..<self.capacity if self.psls[i] != empty_psl => self.keys[i]
+    for i in 0..<self.capacity if self.hashes[i] != empty_hash => self.keys[i]
   ]
 }
 

--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -25,7 +25,9 @@ fn[K] new_hashset(capacity : Int) -> HashSet[K] {
     capacity,
     capacity_mask: capacity - 1,
     grow_at: calc_grow_threshold(capacity),
-    entries: FixedArray::make(capacity, None),
+    psls: FixedArray::make(capacity, empty_psl),
+    hashes: FixedArray::make(capacity, 0),
+    keys: UninitializedArray::make(capacity),
   }
 }
 
@@ -95,66 +97,74 @@ fn[K : Eq] HashSet::add_with_hash(
   }
   let (idx, psl) = for psl = 0, idx = hash & self.capacity_mask {
     // SAFETY: `idx` starts masked by `capacity_mask` and every step re-masks
-    // it, so it is in bounds for `entries`, whose length is `capacity`.
-    match self.entries.unsafe_get(idx) {
-      None => break (idx, psl)
-      Some(curr_entry) => {
-        if curr_entry.hash == hash && curr_entry.key == key {
-          return
-        }
-        if psl > curr_entry.psl {
-          self.push_away(idx, curr_entry)
-          break (idx, psl)
-        }
-        continue psl + 1, (idx + 1) & self.capacity_mask
-      }
+    // it, so it indexes all three backing arrays -- each of length
+    // `capacity` -- in bounds. A non-empty PSL further guarantees that
+    // `keys[idx]` was initialized by `set_slot`.
+    let curr_psl = self.psls.unsafe_get(idx)
+    if curr_psl == empty_psl {
+      break (idx, psl)
     }
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
+      return
+    }
+    if psl > curr_psl {
+      // Displace the richer occupant of `idx`, then write the new key here.
+      self.push_away(
+        idx,
+        curr_psl,
+        self.hashes.unsafe_get(idx),
+        self.keys.unsafe_get(idx),
+      )
+      break (idx, psl)
+    }
+    continue psl + 1, (idx + 1) & self.capacity_mask
   }
-  let entry = { psl, key, hash }
-  self.set_entry(entry, idx)
+  self.set_slot(idx, psl, hash, key)
   self.size += 1
 }
 
 ///|
-#owned(entry)
+// Relocates the key triple `(psl, hash, key)` -- which has just been bumped out
+// of an earlier slot -- to a later slot, Robin-Hood style, starting from the
+// slot after `idx`.
 fn[K] HashSet::push_away(
   self : HashSet[K],
   idx : Int,
-  entry : Entry[K],
+  psl : Int,
+  hash : Int,
+  key : K,
 ) -> Unit {
-  for psl = entry.psl + 1, idx = (idx + 1) & self.capacity_mask, entry = entry {
-    // SAFETY: same masked-index invariant as `add_with_hash`.
-    match self.entries.unsafe_get(idx) {
-      None => {
-        entry.psl = psl
-        self.set_entry(entry, idx)
-        break
-      }
-      Some(curr_entry) =>
-        if psl > curr_entry.psl {
-          entry.psl = psl
-          self.set_entry(entry, idx)
-          continue curr_entry.psl + 1,
-            (idx + 1) & self.capacity_mask,
-            curr_entry
-        } else {
-          continue psl + 1, (idx + 1) & self.capacity_mask, entry
-        }
+  for psl = psl + 1, idx = (idx + 1) & self.capacity_mask, hash = hash, key = key {
+    // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
+    let curr_psl = self.psls.unsafe_get(idx)
+    if curr_psl == empty_psl {
+      self.set_slot(idx, psl, hash, key)
+      break
+    } else if psl > curr_psl {
+      let curr_hash = self.hashes.unsafe_get(idx)
+      let curr_key = self.keys.unsafe_get(idx)
+      self.set_slot(idx, psl, hash, key)
+      continue curr_psl + 1, (idx + 1) & self.capacity_mask, curr_hash, curr_key
+    } else {
+      continue psl + 1, (idx + 1) & self.capacity_mask, hash, key
     }
   }
 }
 
 ///|
 #inline
-#owned(entry)
-fn[K] HashSet::set_entry(
+fn[K] HashSet::set_slot(
   self : HashSet[K],
-  entry : Entry[K],
-  new_idx : Int,
+  idx : Int,
+  psl : Int,
+  hash : Int,
+  key : K,
 ) -> Unit {
-  // SAFETY: every caller supplies an index already proven in bounds -- from
-  // a masked probe, or from `shift_back`'s `cur`.
-  self.entries.unsafe_set(new_idx, Some(entry))
+  // SAFETY: every caller derives `idx` from a `capacity_mask` probe, so it is
+  // in bounds for all three arrays.
+  self.psls.unsafe_set(idx, psl)
+  self.hashes.unsafe_set(idx, hash)
+  self.keys.unsafe_set(idx, key)
 }
 
 ///|
@@ -163,12 +173,16 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
   // inline lookup to avoid unnecessary allocations
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    // SAFETY: same masked-index invariant as `add_with_hash`.
-    guard self.entries.unsafe_get(idx) is Some(entry) else { break false }
-    if entry.hash == hash && entry.key == key {
+    // SAFETY: `idx` is masked by `capacity_mask`; all backing arrays have
+    // length `capacity`, so the probe index is in bounds.
+    let psl = self.psls.unsafe_get(idx)
+    guard psl != empty_psl else { break false }
+    // SAFETY: the same index invariant applies to `hashes`; a non-empty PSL
+    // also guarantees that `keys[idx]` was initialized by `set_slot`.
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
       break true
     }
-    if i > entry.psl {
+    if i > psl {
       break false
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -199,14 +213,15 @@ pub fn[K : Hash + Eq] HashSet::contains(self : HashSet[K], key : K) -> Bool {
 pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
   let hash = Hash::hash(key)
   for i = 0, idx = hash & self.capacity_mask {
-    // SAFETY: same masked-index invariant as `add_with_hash`.
-    guard self.entries.unsafe_get(idx) is Some(entry) else { break }
-    if entry.hash == hash && entry.key == key {
+    // SAFETY: same masked-index and initialized-key invariants as `contains`.
+    let psl = self.psls.unsafe_get(idx)
+    guard psl != empty_psl else { break }
+    if self.hashes.unsafe_get(idx) == hash && self.keys.unsafe_get(idx) == key {
       self.shift_back(idx)
       self.size -= 1
       break
     }
-    if i > entry.psl {
+    if i > psl {
       break
     }
     continue i + 1, (idx + 1) & self.capacity_mask
@@ -215,22 +230,28 @@ pub fn[K : Hash + Eq] HashSet::remove(self : HashSet[K], key : K) -> Unit {
 
 ///|
 fn[K] HashSet::shift_back(self : HashSet[K], idx : Int) -> Unit {
+  // SAFETY: `cur` is in bounds by either route its callers take -- `remove`
+  // derives it from a masked probe, and `retain` reaches here only after a
+  // checked read of that slot succeeded. `next` is re-masked each step, and
+  // later `cur` values are previous `next` values.
   for cur = idx {
     let next = (cur + 1) & self.capacity_mask
-    // SAFETY: the initial `cur` is in bounds by either route its callers
-    // take -- `remove` derives it from a masked probe, and `retain` reaches
-    // here only after a checked `entries[i]` read succeeded. `next` is
-    // re-masked each step, and `cur` afterwards is a previous `next`.
-    match self.entries.unsafe_get(next) {
-      None | Some({ psl: 0, .. }) => {
-        self.entries.unsafe_set(cur, None)
-        break
-      }
-      Some(entry) => {
-        entry.psl -= 1
-        self.set_entry(entry, cur)
-        continue next
-      }
+    let next_psl = self.psls.unsafe_get(next)
+    if next_psl == empty_psl || next_psl == 0 {
+      self.psls.unsafe_set(cur, empty_psl)
+      // Not redundant with the line above: the PSL marks the slot free, but
+      // the key slot would still hold the removed key alive until something
+      // overwrites it, retaining up to one dead key per vacated slot.
+      self.keys.set_null(cur)
+      break
+    } else {
+      self.set_slot(
+        cur,
+        next_psl - 1,
+        self.hashes.unsafe_get(next),
+        self.keys.unsafe_get(next),
+      )
+      continue next
     }
   }
 }
@@ -243,44 +264,54 @@ fn[K] HashSet::grow(self : HashSet[K]) -> Unit {
     self.capacity_mask = self.capacity - 1
     self.grow_at = calc_grow_threshold(self.capacity)
     self.size = 0
-    self.entries = FixedArray::make(self.capacity, None)
+    self.psls = FixedArray::make(self.capacity, empty_psl)
+    self.hashes = FixedArray::make(self.capacity, 0)
+    self.keys = UninitializedArray::make(self.capacity)
     return
   }
-  let old_entries = self.entries
+  let old_psls = self.psls
+  let old_hashes = self.hashes
+  let old_keys = self.keys
+  let old_capacity = self.capacity
   let new_capacity = self.capacity * 2
-  self.entries = FixedArray::make(new_capacity, None)
+  self.psls = FixedArray::make(new_capacity, empty_psl)
+  self.hashes = FixedArray::make(new_capacity, 0)
+  self.keys = UninitializedArray::make(new_capacity)
   self.capacity = new_capacity
   self.capacity_mask = new_capacity - 1
   self.grow_at = calc_grow_threshold(self.capacity)
-  for entry in old_entries {
-    if entry is Some(entry) {
-      self.rehash_place_entry(entry)
+  for i in 0..<old_capacity {
+    // SAFETY: `i < old_capacity`, the length of all three old arrays, and a
+    // non-empty PSL means the old key slot was initialized.
+    if old_psls.unsafe_get(i) != empty_psl {
+      self.rehash_place_entry(old_hashes.unsafe_get(i), old_keys.unsafe_get(i))
     }
   }
 }
 
 ///|
-#owned(entry)
-fn[K] HashSet::rehash_place_entry(self : HashSet[K], entry : Entry[K]) -> Unit {
-  let hash = entry.hash
+fn[K] HashSet::rehash_place_entry(
+  self : HashSet[K],
+  hash : Int,
+  key : K,
+) -> Unit {
   for psl = 0, idx = hash & self.capacity_mask {
-    // SAFETY: same masked-index invariant as `add_with_hash`; `grow` installs
-    // the new `entries` and `capacity_mask` together before rehashing.
-    match self.entries.unsafe_get(idx) {
-      None => {
-        entry.psl = psl
-        self.set_entry(entry, idx)
-        return
-      }
-      Some(curr) =>
-        if psl > curr.psl {
-          self.push_away(idx, curr)
-          entry.psl = psl
-          self.set_entry(entry, idx)
-          return
-        } else {
-          continue psl + 1, (idx + 1) & self.capacity_mask
-        }
+    // SAFETY: same masked-index and initialized-key invariants as `add_with_hash`.
+    let curr_psl = self.psls.unsafe_get(idx)
+    if curr_psl == empty_psl {
+      self.set_slot(idx, psl, hash, key)
+      return
+    } else if psl > curr_psl {
+      self.push_away(
+        idx,
+        curr_psl,
+        self.hashes.unsafe_get(idx),
+        self.keys.unsafe_get(idx),
+      )
+      self.set_slot(idx, psl, hash, key)
+      return
+    } else {
+      continue psl + 1, (idx + 1) & self.capacity_mask
     }
   }
 }
@@ -322,9 +353,9 @@ pub fn[K] HashSet::each(
   self : HashSet[K],
   f : (K) -> Unit raise?,
 ) -> Unit raise? {
-  for entry in self.entries {
-    if entry is Some({ key, .. }) {
-      f(key)
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      f(self.keys[i])
     }
   }
 }
@@ -337,8 +368,8 @@ pub fn[K] HashSet::eachi(
   f : (Int, K) -> Unit raise?,
 ) -> Unit raise? {
   for i in 0..<self.capacity; idx = 0 {
-    if self.entries[i] is Some({ key, .. }) {
-      f(idx, key)
+    if self.psls[i] != empty_psl {
+      f(idx, self.keys[i])
       continue idx + 1
     } else {
       continue idx
@@ -349,7 +380,14 @@ pub fn[K] HashSet::eachi(
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
 pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
-  self.entries.fill(None)
+  // Reuse the existing buffers (keeps the allocated space) and only null the
+  // occupied key slots so their references can be reclaimed.
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      self.psls[i] = empty_psl
+      self.keys.set_null(i)
+    }
+  }
   self.size = 0
 }
 
@@ -358,14 +396,17 @@ pub fn[K] HashSet::clear(self : HashSet[K]) -> Unit {
 #alias(iterator, deprecated)
 pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
   let mut i = 0
-  let len = self.entries.length()
+  let len = self.capacity
   Iter::new(
     fn() {
       while i < len {
-        let entry = self.entries.unsafe_get(i)
+        let idx = i
         i += 1
-        if entry is Some({ key, .. }) {
-          return Some(key)
+        // SAFETY: `idx < len`, which is the capacity captured when the
+        // iterator was created, and the table never shrinks; a non-empty PSL
+        // means the key slot was initialized.
+        if self.psls.unsafe_get(idx) != empty_psl {
+          return Some(self.keys.unsafe_get(idx))
         }
       } nobreak {
         None
@@ -378,9 +419,13 @@ pub fn[K] HashSet::iter(self : HashSet[K]) -> Iter[K] {
 ///|
 /// Converts the hash set to an array.
 pub fn[K] HashSet::to_array(self : HashSet[K]) -> Array[K] {
-  [
-    for entry in self.entries if entry is Some({ key, .. }) => key
-  ]
+  let arr = Array::new(capacity=self.size)
+  for i in 0..<self.capacity {
+    if self.psls[i] != empty_psl {
+      arr.push(self.keys[i])
+    }
+  }
+  arr
 }
 
 ///|
@@ -508,9 +553,9 @@ pub fn[K] HashSet::retain(self : HashSet[K], f : (K) -> Bool) -> Unit {
   let size = self.size
   let mut j = 0
   for i = 0; j < size; i = i + 1 {
-    while self.entries[i] is Some(entry) {
+    while self.psls[i] != empty_psl {
       j += 1
-      if f(entry.key) {
+      if f(self.keys[i]) {
         break
       } else {
         self.shift_back(i)
@@ -527,11 +572,12 @@ fn calc_grow_threshold(capacity : Int) -> Int {
 
 ///|
 fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
-  for i in 0..<self.entries.length(); s = "" {
+  for i in 0..<self.capacity; s = "" {
     let s = if i > 0 { s + "," } else { s }
-    continue match self.entries[i] {
-        None => s + "_"
-        Some({ psl, key, .. }) => s + "(\{psl},\{key})"
+    continue if self.psls[i] == empty_psl {
+        s + "_"
+      } else {
+        s + "(\{self.psls[i]},\{self.keys[i]})"
       }
   } nobreak {
     s
@@ -539,7 +585,7 @@ fn[K : Show] HashSet::_debug_entries(self : HashSet[K]) -> String {
 }
 
 ///|
-priv struct MyString(String) derive(Eq, @debug.Debug)
+priv struct MyString(String) derive(Eq)
 
 ///|
 impl Hash for MyString with fn hash(self) {
@@ -551,6 +597,26 @@ impl Hash for MyString with fn hash(self) {
 impl Hash for MyString with fn hash_combine(self, hasher) {
   let MyString(self) = self
   hasher.combine_string(self)
+}
+
+///|
+test "contains handles collided slots across table wraparound" {
+  let m : HashSet[MyString] = new_hashset(8)
+  fn key(value) {
+    MyString::MyString(value)
+  }
+
+  // All keys hash to 7, so the probe sequence starts at the final slot and
+  // wraps around to the start of the table.
+  m.add("aaaaaaa" |> key)
+  m.add("bbbbbbb" |> key)
+  m.add("ccccccc" |> key)
+  m.add("ddddddd" |> key)
+  m.add("eeeeeee" |> key)
+
+  assert_true(m.contains("aaaaaaa" |> key))
+  assert_true(m.contains("eeeeeee" |> key))
+  assert_false(m.contains("fffffff" |> key))
 }
 
 ///|
@@ -638,12 +704,64 @@ test "grow" {
 ///|
 test "clear" {
   let m : HashSet[MyString] = new_hashset(default_init_capacity)
+  fn i(s) {
+    MyString::MyString(s)
+  }
+
+  m.add("C" |> i)
+  m.add("Go" |> i)
+  m.add("C++" |> i)
+  m.add("Java" |> i)
+  let psls = m.psls
+  let hashes = m.hashes
+  let keys = m.keys
+  inspect(m.length(), content="4")
   m.clear()
   inspect(m.length(), content="0")
   inspect(m.capacity(), content="8")
-  for entry in m.entries {
-    @test.assert_same_object(entry, None)
+  inspect(physical_equal(m.psls, psls), content="true")
+  inspect(physical_equal(m.hashes, hashes), content="true")
+  inspect(physical_equal(m.keys, keys), content="true")
+  for i in 0..<m.capacity {
+    @test.assert_eq(m.psls[i], empty_psl)
   }
+  m.add("MoonBit" |> i)
+  inspect(m.length(), content="1")
+  inspect(m.contains("MoonBit" |> i), content="true")
+}
+
+///|
+test "copy sparse set only copies occupied key slots" {
+  let m : HashSet[MyString] = new_hashset(default_init_capacity)
+  fn i(s) {
+    MyString::MyString(s)
+  }
+
+  m.add("a" |> i)
+  m.add("ab" |> i)
+  m.add("bc" |> i)
+  m.add("cd" |> i)
+  m.add("abc" |> i)
+  m.add("abcdef" |> i)
+  m.remove("ab" |> i)
+  let copied = m.copy()
+  inspect(copied.length(), content="5")
+  inspect(copied.capacity(), content="8")
+  inspect(physical_equal(copied.psls, m.psls), content="false")
+  inspect(physical_equal(copied.hashes, m.hashes), content="false")
+  inspect(physical_equal(copied.keys, m.keys), content="false")
+  let mut occupied = 0
+  for idx in 0..<m.capacity {
+    @test.assert_eq(copied.psls[idx], m.psls[idx])
+    @test.assert_eq(copied.hashes[idx], m.hashes[idx])
+    if m.psls[idx] != empty_psl {
+      occupied += 1
+      assert_true(copied.keys[idx] == m.keys[idx])
+    }
+  }
+  inspect(occupied, content="5")
+  inspect(copied.contains("ab" |> i), content="false")
+  inspect(copied.contains("abcdef" |> i), content="true")
 }
 
 ///|
@@ -710,19 +828,27 @@ pub fn[K : Hash + Eq] HashSet::remove_and_check(
 /// Copy the set, creating a new set with the same keys.
 #alias(clone, deprecated)
 pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
+  // `copy` on the metadata arrays rather than make-then-blit: it is one
+  // allocation-and-copy each instead of allocate, fill, then overwrite, and
+  // on js it lowers to `Array.slice`.
+  //
+  // Independence is structural here, unlike the boxed layout this replaces:
+  // the arrays hold values, not shared mutable entries, so neither set can
+  // disturb the other's probe sequences.
   let other = {
     capacity: self.capacity,
-    entries: FixedArray::make(self.capacity, None),
+    psls: self.psls.copy(),
+    hashes: self.hashes.copy(),
+    keys: UninitializedArray::make(self.capacity),
     size: self.size,
     capacity_mask: self.capacity_mask,
     grow_at: self.grow_at,
   }
-  // Rebuild each entry rather than blitting the references: `Entry::psl` is
-  // mutable and `shift_back` decrements it, so sharing entries would let a
-  // removal on one set corrupt the probe sequences of the other.
   for i in 0..<self.capacity {
-    if self.entries[i] is Some({ psl, hash, key }) {
-      other.entries[i] = Some({ psl, hash, key })
+    // SAFETY: `i < capacity`, the length of every backing array, and a
+    // non-empty PSL means the key slot was initialized.
+    if self.psls.unsafe_get(i) != empty_psl {
+      other.keys.unsafe_set(i, self.keys.unsafe_get(i))
     }
   }
   other
@@ -731,8 +857,10 @@ pub fn[K] HashSet::copy(self : HashSet[K]) -> HashSet[K] {
 ///|
 /// ToJson implementation for hashset
 pub impl[X : ToJson] ToJson for HashSet[X] with fn to_json(self) {
+  // Built directly rather than via `to_array`, which would materialize an
+  // `Array[X]` before the `Array[Json]`.
   [
-    for entry in self.entries if entry is Some({ key, .. }) => key
+    for i in 0..<self.capacity if self.psls[i] != empty_psl => self.keys[i]
   ]
 }
 

--- a/hashset/hashset_bench_test.mbt
+++ b/hashset/hashset_bench_test.mbt
@@ -42,3 +42,35 @@ test "bench HashSet::contains n=50000" (it : @bench.T) {
     it.keep(hits)
   })
 }
+
+///|
+/// Removal isolated as far as the harness allows: `@bench.T` has no
+/// per-iteration setup hook, so a prebuilt set is copied inside the timed
+/// closure rather than rebuilt with 50000 `add` calls. The companion "copy
+/// only" benchmark below measures the residue attributable to the copy.
+///
+/// This exists because the removal path had no coverage at all: the
+/// struct-of-arrays conversion silently reverted `remove`/`shift_back` to
+/// checked access and no benchmark noticed.
+test "bench HashSet::copy+remove n=50000" (it : @bench.T) {
+  let template = @hashset.HashSet([])
+  for i in 0..<hashset_bench_n {
+    template.add(i * 1103515245)
+  }
+  it.bench(fn() {
+    let s = template.copy()
+    for i in 0..<hashset_bench_n {
+      s.remove(i * 1103515245)
+    }
+    it.keep(s.length())
+  })
+}
+
+///|
+test "bench HashSet::copy n=50000" (it : @bench.T) {
+  let template = @hashset.HashSet([])
+  for i in 0..<hashset_bench_n {
+    template.add(i * 1103515245)
+  }
+  it.bench(fn() { it.keep(template.copy().length()) })
+}

--- a/hashset/hashset_bench_test.mbt
+++ b/hashset/hashset_bench_test.mbt
@@ -74,3 +74,39 @@ test "bench HashSet::copy n=50000" (it : @bench.T) {
   }
   it.bench(fn() { it.keep(template.copy().length()) })
 }
+
+///|
+/// Reference-type keys, where the boxed layout stores a pointer in its entry
+/// and this one stores it directly in the key array. The integer benchmarks
+/// cannot show that difference.
+let hashset_bench_strings : Array[String] = Array::makei(50000, i => {
+  "key-\{i * 7}"
+})
+
+///|
+test "bench HashSet::add string n=50000" (it : @bench.T) {
+  it.bench(fn() {
+    let s = @hashset.HashSet([])
+    for k in hashset_bench_strings {
+      s.add(k)
+    }
+    it.keep(s.length())
+  })
+}
+
+///|
+test "bench HashSet::contains string n=50000" (it : @bench.T) {
+  let s = @hashset.HashSet([])
+  for k in hashset_bench_strings {
+    s.add(k)
+  }
+  it.bench(fn() {
+    let mut hits = 0
+    for k in hashset_bench_strings {
+      if s.contains(k) {
+        hits += 1
+      }
+    }
+    it.keep(hits)
+  })
+}

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -13,9 +13,27 @@
 // limitations under the License.
 
 ///|
-/// `psls[i] == empty_psl` marks an empty slot. A real probe-sequence length is
-/// always `>= 0`, so `-1` is a safe sentinel.
-let empty_psl : Int = -1
+/// `hashes[i] == empty_hash` marks an empty slot. Any `Int` can legitimately
+/// be a hash, so `store_hash` remaps this one value onto another; the two then
+/// share a bucket, which costs an occasional extra key comparison and nothing
+/// else, since lookups compare keys as well as hashes.
+let empty_hash : Int = 0
+
+///|
+/// The value real hashes equal to `empty_hash` are stored as.
+let remapped_hash : Int = 1
+
+///|
+/// Maps a key's hash onto the value stored in `hashes`, keeping the sentinel
+/// unambiguous.
+#inline
+fn store_hash(hash : Int) -> Int {
+  if hash == empty_hash {
+    remapped_hash
+  } else {
+    hash
+  }
+}
 
 ///|
 /// Package-local unchecked accessors for the key storage. These are kept
@@ -50,11 +68,17 @@ fn[K] UninitializedArray::set_null(
 ///|
 /// Mutable hash set, not thread safe.
 ///
-/// The table is stored as a struct-of-arrays (`psls` / `hashes` / `keys`)
-/// rather than an array of boxed entries, so inserting a key does not allocate
-/// a per-entry object. For an occupied slot `i`, `hashes[i]` caches the key's
-/// hash and `keys[i]` holds the key; for an empty slot `psls[i] == empty_psl`
-/// and `keys[i]` is unused.
+/// The table is stored as two parallel arrays rather than an array of boxed
+/// entries, so inserting a key does not allocate a per-entry object. For an
+/// occupied slot `i`, `hashes[i]` caches the key's stored hash and `keys[i]`
+/// holds the key; for an empty slot `hashes[i] == empty_hash` and `keys[i]` is
+/// unused.
+///
+/// There is no probe-sequence-length array. A slot's PSL is implied by where
+/// it sits relative to where its hash wanted it, so `psl_at` derives it with
+/// two arithmetic operations instead of a third random memory access. That
+/// identity holds because every write to a slot happens as the key lands in
+/// it, and the derivation follows the key whenever displacement moves it.
 ///
 /// # Example
 ///
@@ -66,8 +90,7 @@ fn[K] UninitializedArray::set_null(
 /// }
 /// ```
 struct HashSet[K] {
-  mut psls : FixedArray[Int] // probe sequence length, or empty_psl when empty
-  mut hashes : FixedArray[Int] // cached key hash for occupied slots
+  mut hashes : FixedArray[Int] // stored key hash, or empty_hash when empty
   mut keys : UninitializedArray[K] // key storage for occupied slots
   mut size : Int // active key count
   mut capacity : Int // current capacity

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -13,14 +13,35 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
-priv struct Entry[K] {
-  mut psl : Int
-  hash : Int
-  key : K
-} derive(@debug.Debug)
+/// `psls[i] == empty_psl` marks an empty slot. A real probe-sequence length is
+/// always `>= 0`, so `-1` is a safe sentinel.
+let empty_psl : Int = -1
 
-/// A mutable hash set implements with Robin Hood hashing.
+///|
+/// Package-local unchecked accessors for the key storage. These are kept
+/// private here rather than exposed from `builtin`: `set_null` and
+/// `unsafe_set` can corrupt memory, so the fewer packages that can name them
+/// the better.
+fn[K] UninitializedArray::unsafe_get(
+  self : UninitializedArray[K],
+  idx : Int,
+) -> K = "%fixedarray.unsafe_get"
+
+///|
+fn[K] UninitializedArray::unsafe_set(
+  self : UninitializedArray[K],
+  idx : Int,
+  key : K,
+) -> Unit = "%fixedarray.unsafe_set"
+
+///|
+/// Releases the key reference stored at `idx` so the collector can reclaim it.
+fn[K] UninitializedArray::set_null(
+  self : UninitializedArray[K],
+  idx : Int,
+) -> Unit = "%fixedarray.set_null"
+
+/// A mutable hash set implemented with Robin Hood hashing.
 ///
 /// reference:
 /// - <https://programming.guide/robin-hood-hashing.html>
@@ -28,6 +49,12 @@ priv struct Entry[K] {
 
 ///|
 /// Mutable hash set, not thread safe.
+///
+/// The table is stored as a struct-of-arrays (`psls` / `hashes` / `keys`)
+/// rather than an array of boxed entries, so inserting a key does not allocate
+/// a per-entry object. For an occupied slot `i`, `hashes[i]` caches the key's
+/// hash and `keys[i]` holds the key; for an empty slot `psls[i] == empty_psl`
+/// and `keys[i]` is unused.
 ///
 /// # Example
 ///
@@ -39,7 +66,9 @@ priv struct Entry[K] {
 /// }
 /// ```
 struct HashSet[K] {
-  mut entries : FixedArray[Entry[K]?]
+  mut psls : FixedArray[Int] // probe sequence length, or empty_psl when empty
+  mut hashes : FixedArray[Int] // cached key hash for occupied slots
+  mut keys : UninitializedArray[K] // key storage for occupied slots
   mut size : Int // active key count
   mut capacity : Int // current capacity
   mut capacity_mask : Int // capacity_mask = capacity - 1, used to find idx


### PR DESCRIPTION
Supersedes #4127, which I have marked draft. Same goal — stop allocating a boxed `Entry` per key — but without the js regression that made #4127 unlandable.

The design is Codex CLI's, proposed while explaining that regression. I implemented and measured it.

## What changed

#4127 stored three arrays: `psls`, `hashes`, `keys`. A probe step read all three, at the same index in three arrays 512 KB apart, so it touched **three cache lines where the boxed layout touched one** — the entry object holds psl, hash and key together. That cost js insertion 15% growing and 44% pre-sized.

A slot's probe-sequence length is not independent state. It is the distance between where the key sits and where its hash asked it to sit:

```
psl = (idx - (stored_hash & mask)) & mask
```

So `psls` goes away. Two arrays remain, and a probe step trades a random load in a 512 KB array for two arithmetic operations.

`hashes[i] == 0` marks an empty slot. Any `Int` can be a real hash, so `store_hash` remaps `0` onto `1`; the two then share a bucket, which costs an occasional extra key comparison and nothing else, since lookups compare keys as well as hashes.

`shift_back` no longer writes a PSL at all — moving an occupant one slot back *is* the decrement.

## Verifying the premise before building

`psl` was a `mut` field, which suggests independent state. I checked rather than assumed: I instrumented `set_slot` on the three-array branch to assert `psl == (idx - (hash & mask)) & mask` on **every** write, then ran the full suite on three backends plus a four-bucket collision stress with removals, shift-back cascades, growth and copy. It never fired. Every PSL write happened as a key landed in a slot, always equal to its displacement.

## Measurements

n=50000, against `main`, interleaved on one machine in a single session:

| backend | op | main | this branch | change |
| --- | --- | --- | --- | --- |
| native | `add` | 2.23 ms | 1.42 ms | **36% faster** |
| native | `contains` | 842 µs | 744 µs | 12% faster |
| native | `copy` | 484 µs | 65 µs | **86% faster** |
| native | `add` string | 3.51 ms | 3.22 ms | 8% faster |
| native | `contains` string | 2.16 ms | 1.84 ms | 15% faster |
| wasm-gc | `add` | 2.20 ms | 1.78 ms | **19% faster** |
| wasm-gc | `contains` | 1.06 ms | 987 µs | 7% faster |
| wasm-gc | `copy` | 373 µs | 168 µs | **55% faster** |
| wasm-gc | `add` string | 3.36 ms | 3.00 ms | 11% faster |
| wasm-gc | `contains` string | 2.61 ms | 2.41 ms | 8% faster |
| js | `add` | 2.37 ms | 2.33 ms | **unchanged** |
| js | `contains` | 962 µs | 904 µs | 6% faster |
| js | `copy` | 432 µs | 314 µs | 27% faster |
| js | `add` string | 3.41 ms | 3.58 ms | **5% slower** |
| js | `contains` string | 2.40 ms | 2.21 ms | 8% faster |

Faster on fourteen of fifteen. The two js insertion figures are the mean of two alternating samples per side, since they are what the design turns on: integer `add` came out 2.32/2.33 against 2.38/2.36, string `add` 3.57/3.59 against 3.42/3.39.

String keys are benchmarked because the boxed layout stores a pointer inside its entry where this one stores it directly in the key array — a difference integer benchmarks cannot show. That case is the single remaining regression, at 5%.

## Tests

The derivation is now load-bearing rather than merely true, so `derived_psl_test.mbt` covers the paths that used to write a PSL: a four-bucket collision stress with removal and reinsertion across six growth rounds, keys whose hash is the remapped sentinel, and a 20000-operation differential run against a bitmap model.

## Review

Verified by Codex CLI at `xhigh`. It found **no algorithmic defect** — `psl_at` correct across wraparound, `shift_back`'s implicit decrement exact, `push_away` preserving the Robin Hood recurrence and terminating, growth reinserting under the new mask, the sentinel remap sound, every `psl_at` call guarded by an occupied slot, and miss lookup retaining its early exit. Full verdict in a comment below.

It withheld a sign-off on methodology rather than correctness: its sandbox is read-only, so it could not run fresh interleaved benchmarks and would not certify numbers it had not reproduced. The alternating samples above are my response to that; the benchmark claims remain mine.

One gap it names and I have not closed: deleting `keys.set_null(cur)` in `shift_back` would leave every test passing while removed keys stayed reachable. That is the same liveness gap discussed on #3712 — no portable way to assert it across four backends — so the guard is a comment at the line explaining why it is not redundant.
