### PR TITLE
refactor: local simplifications with no API change

### DIFF
--- a/argparse/arg_spec.mbt
+++ b/argparse/arg_spec.mbt
@@ -241,11 +241,6 @@ pub fn PositionArg::PositionArg(
 }
 
 ///|
-fn arg_name(arg : Arg) -> String {
-  arg.name
-}
-
-///|
 fn range_allows_multiple(range : ValueRange?) -> Bool {
   range is Some(r) &&
   (match r.upper {

--- a/argparse/command.mbt
+++ b/argparse/command.mbt
@@ -138,7 +138,7 @@ fn build_matches(
   let specs = inherited_globals + cmd.args
 
   for spec in specs {
-    let name = arg_name(spec)
+    let name = spec.name
     if raw.values.get(name) is Some(vs) {
       values[name] = vs.copy()
     }

--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -71,9 +71,8 @@ fn should_parse_as_positional(
   if !arg.has_prefix("-") || arg == "-" {
     return false
   }
-  let next = match next_positional(positionals, collected) {
-    Some(v) => v
-    None => return false
+  guard next_positional(positionals, collected) is Some(next) else {
+    return false
   }
   let next_allow = match next.info {
     FlagInfo(_) => false

--- a/argparse/parser_values.mbt
+++ b/argparse/parser_values.mbt
@@ -206,14 +206,8 @@ fn apply_env(
     if matches_has_value_or_flag(matches, name) {
       continue
     }
-    let env_name = match arg.env {
-      Some(value) => value
-      None => continue
-    }
-    let value = match env.get(env_name) {
-      Some(v) => v
-      None => continue
-    }
+    guard arg.env is Some(env_name) else { continue }
+    guard env.get(env_name) is Some(value) else { continue }
     if arg.info is (OptionInfo(_) | PositionalInfo(_)) {
       assign_value(matches, arg, value, Env)
       continue

--- a/builtin/option.mbt
+++ b/builtin/option.mbt
@@ -92,10 +92,8 @@ pub fn[T, Err : Error] Option::unwrap_or_error(
   self : T?,
   err : Err,
 ) -> T raise Err {
-  match self {
-    Some(v) => v
-    None => raise err
-  }
+  guard self is Some(v) else { raise err }
+  v
 }
 
 ///|

--- a/debug/repr.mbt
+++ b/debug/repr.mbt
@@ -315,24 +315,5 @@ pub fn Repr::ctor(name : String, args : Array[(String?, Repr)]) -> Repr {
 /// This is used by diff/pretty-print when the structure is preserved but
 /// children are rendered separately.
 fn Repr::shallow(self : Repr) -> Repr {
-  match self {
-    UnitLit
-    | Integer(_)
-    | DoubleLit(_)
-    | FloatLit(_)
-    | BoolLit(_)
-    | CharLit(_)
-    | StringLit(_)
-    | Literal(_)
-    | Omitted => self
-    Tuple(_) => Tuple([])
-    Array(_) => Array([])
-    Record(_) => Record([])
-    Enum(name, _) => Enum(name, [])
-    Opaque(name, _) => Opaque(name, Omitted)
-    Map(_) => Map([])
-    RecordField(name, _) => RecordField(name, Omitted)
-    EnumLabeledArg(label, _) => EnumLabeledArg(label, Omitted)
-    MapEntry(_, _) => MapEntry(Omitted, Omitted)
-  }
+  self.with_children([])
 }

--- a/internal/strconv/strconv_double.mbt
+++ b/internal/strconv/strconv_double.mbt
@@ -138,10 +138,9 @@ fn Number::try_fast_path(self : Number) -> Double? {
     } else {
       // disguised fast path
       let shift = self.exponent - max_exponent_fast_path
-      let mantissa = match
-        checked_mul(self.mantissa, int_pow10[shift.to_int()]) {
-        Some(m) => m
-        None => return None
+      guard checked_mul(self.mantissa, int_pow10[shift.to_int()])
+        is Some(mantissa) else {
+        return None
       }
       if mantissa > max_mantissa_fast_path {
         return None

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -118,10 +118,9 @@ fn JsonNumberScan::try_fast_double(self : JsonNumberScan) -> Double {
     }
   } else {
     let shift = self.exponent - MAX_EXPONENT_FAST_PATH
-    let mantissa = match
-      checked_mul(self.mantissa, int_pow10_table[shift.to_int()]) {
-      Some(m) => m
-      None => return @double.not_a_number
+    guard checked_mul(self.mantissa, int_pow10_table[shift.to_int()])
+      is Some(mantissa) else {
+      return @double.not_a_number
     }
     if mantissa > MAX_MANTISSA_FAST_PATH {
       return @double.not_a_number

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1105,17 +1105,8 @@ pub fn[A] List::flatten(self : List[List[A]]) -> List[A] {
 #internal(unsafe, "Panic if the list is empty")
 #doc(hidden)
 pub fn[A : Compare] List::unsafe_maximum(self : List[A]) -> A {
-  match self {
-    Empty => abort("maximum: empty list")
-    More(head, tail~) =>
-      for a = tail, b = head {
-        match (a, b) {
-          (Empty, curr_max) => break curr_max
-          (More(item, tail~), curr_max) =>
-            continue tail, if item > curr_max { item } else { curr_max }
-        }
-      }
-  }
+  guard self.maximum() is Some(max) else { abort("maximum: empty list") }
+  max
 }
 
 ///|
@@ -1135,16 +1126,13 @@ pub fn[A : Compare] List::unsafe_maximum(self : List[A]) -> A {
 /// }
 /// ```
 pub fn[A : Compare] List::maximum(self : List[A]) -> A? {
-  match self {
-    Empty => None
-    More(head, tail~) =>
-      for a = tail, b = head {
-        match (a, b) {
-          (Empty, curr_max) => break Some(curr_max)
-          (More(item, tail~), curr_max) =>
-            continue tail, if item > curr_max { item } else { curr_max }
-        }
-      }
+  guard self is More(head, tail~) else { return None }
+  for rest = tail, curr_max = head {
+    match rest {
+      Empty => break Some(curr_max)
+      More(item, tail~) =>
+        continue tail, if item > curr_max { item } else { curr_max }
+    }
   }
 }
 
@@ -1169,17 +1157,8 @@ pub fn[A : Compare] List::maximum(self : List[A]) -> A? {
 #internal(unsafe, "Panic if the list is empty")
 #doc(hidden)
 pub fn[A : Compare] List::unsafe_minimum(self : List[A]) -> A {
-  match self {
-    Empty => abort("minimum: empty list")
-    More(head, tail~) =>
-      for a = tail, b = head {
-        match (a, b) {
-          (Empty, curr_min) => break curr_min
-          (More(item, tail~), curr_min) =>
-            continue tail, if item < curr_min { item } else { curr_min }
-        }
-      }
-  }
+  guard self.minimum() is Some(min) else { abort("minimum: empty list") }
+  min
 }
 
 ///|
@@ -1199,16 +1178,13 @@ pub fn[A : Compare] List::unsafe_minimum(self : List[A]) -> A {
 /// }
 /// ```
 pub fn[A : Compare] List::minimum(self : List[A]) -> A? {
-  match self {
-    Empty => None
-    More(head, tail~) =>
-      for a = tail, b = head {
-        match (a, b) {
-          (Empty, curr_min) => break Some(curr_min)
-          (More(item, tail~), curr_min) =>
-            continue tail, if item < curr_min { item } else { curr_min }
-        }
-      }
+  guard self is More(head, tail~) else { return None }
+  for rest = tail, curr_min = head {
+    match rest {
+      Empty => break Some(curr_min)
+      More(item, tail~) =>
+        continue tail, if item < curr_min { item } else { curr_min }
+    }
   }
 }
 

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -129,10 +129,9 @@ fn Number::try_fast_path(self : Number) -> Double? {
     } else {
       // disguised fast path
       let shift = self.exponent - max_exponent_fast_path
-      let mantissa = match
-        checked_mul(self.mantissa, int_pow10[shift.to_int()]) {
-        Some(m) => m
-        None => return None
+      guard checked_mul(self.mantissa, int_pow10[shift.to_int()])
+        is Some(mantissa) else {
+        return None
       }
       if mantissa > max_mantissa_fast_path {
         return None


### PR DESCRIPTION
A sweep for purely local simplifications — no behavior change, no `.mbti` diff.

## Collapse duplicated helper bodies

- **`debug`** — `Repr::shallow` re-listed every `Repr` constructor to blank out its children, which is exactly `Repr::with_children([])`. The arity fallbacks for `RecordField`/`EnumLabeledArg`/`MapEntry`/`Opaque` land on the same results, so the 20-arm `match` becomes one line.
- **`list`** — `unsafe_maximum`/`maximum` and `unsafe_minimum`/`minimum` were four copies of the same fold. The `Option`-returning ones stay as the primitives and the `unsafe_` pair delegates. The surviving loops match on the list directly instead of on a `(list, acc)` tuple.
- **`argparse`** — dropped `arg_name(arg)`, which just read `arg.name` and had a single call site.

## `guard ... is Some(x) else` for early exits

Eight sites spelled an early exit as `match opt { Some(v) => v; None => return/continue/raise }`. `guard` says the same thing in one line and keeps the happy path unindented: `builtin/option.mbt`, `strconv/double.mbt`, `internal/strconv/strconv_double.mbt`, `json/lex_number.mbt`, `argparse/parser_values.mbt` (×2), `argparse/parser_positionals.mbt`.

## Verification

- `moon check` clean.
- `moon info && moon fmt` produce **no `.mbti` diff** — nothing here is visible to package users.
- `moon test --target all` green: 7544 wasm / 7544 wasm-gc / 7485 js / 7462 native.

## Noted separately, not touched here

`strconv/number.mbt:119-127` shadows `exp_number`: the inner binding inside the `if s is ['e' | 'E', ..]` block shadows the outer `let exp_number = 0L`, so `exponent += exp_number` further down always adds `0`. The sibling copy in `internal/strconv/strconv_number.mbt` uses `let mut` plus an explicit assignment and gets this right. It is currently unobservable — that block only runs with `many_digits = true`, which makes `is_fast_path()` false and sends `parse_double` down the decimal slow path that recomputes the exponent itself — but the two copies have diverged. That's a bug rather than a simplification, so it wants its own issue and PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ef8voSud7NWVhDxFTKJXiC
