### PR TITLE
refactor: drop unnecessary -deprecated_syntax suppression

### DIFF
--- a/argparse/matches.mbt
+++ b/argparse/matches.mbt
@@ -14,6 +14,8 @@
 
 ///|
 /// Where a value/flag came from.
+// TODO(future): `derive(Show)` is deprecated syntax — switch to `derive(Debug)`
+// or a manual `Show` implementation, then remove this annotation.
 #warnings("-deprecated_syntax")
 pub enum ValueSource {
   Argv

--- a/argparse/value_range.mbt
+++ b/argparse/value_range.mbt
@@ -14,6 +14,8 @@
 
 ///|
 /// Number-of-values constraint for an argument.
+// TODO(future): `derive(Show)` is deprecated syntax — switch to `derive(Debug)`
+// or a manual `Show` implementation, then remove `-deprecated_syntax` here.
 #warnings("-deprecated_syntax-deprecated")
 pub struct ValueRange {
   priv lower : Int

--- a/builtin/failure.mbt
+++ b/builtin/failure.mbt
@@ -34,6 +34,8 @@
 ///   @json.json_inspect(err, content=["Failure", "Test assertion failed"])
 /// }
 /// ```
+// TODO(future): `derive(Show)` is deprecated syntax — switch to `derive(Debug)`
+// or a manual `Show` implementation, then remove this annotation.
 #warnings("-deprecated_syntax")
 pub(all) suberror Failure {
   Failure(String)

--- a/hashmap/types.mbt
+++ b/hashmap/types.mbt
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
 priv struct Entry[K, V] {
   mut psl : Int
   hash : Int

--- a/hashset/types.mbt
+++ b/hashset/types.mbt
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 ///|
-#warnings("-deprecated_syntax")
 priv struct Entry[K] {
   mut psl : Int
   hash : Int

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -14,6 +14,8 @@
 
 ///|
 /// Error type `JsonDecodeError`.
+// TODO(future): `derive(Show)` is deprecated syntax — switch to `derive(Debug)`
+// or a manual `Show` implementation, then remove this annotation.
 #warnings("-deprecated_syntax")
 pub(all) suberror JsonDecodeError {
   JsonDecodeError((JsonPath, String))

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 ///|
+// TODO(future): `derive(Show)` is deprecated syntax — switch to `derive(Debug)`
+// or a manual `Show` implementation, then remove this annotation.
 #warnings("-deprecated_syntax")
 struct RandomState {
   mut seed : UInt64


### PR DESCRIPTION
## Summary

Removes `#warnings("-deprecated_syntax")` where it is no longer needed, and documents
where it must stay for now.

- `hashmap/types.mbt`, `hashset/types.mbt`: annotation removed outright — the private
  `Entry` structs derive only `Debug`, no deprecated syntax.
- `argparse/matches.mbt`, `argparse/value_range.mbt`, `builtin/failure.mbt`,
  `json/from_json.mbt`, `quickcheck/splitmix/random.mbt`: removing the annotation
  triggers a `deprecated_syntax` warning because these types still `derive(Show)`,
  so the annotation is kept with a `TODO(future)` note.

## Future refactoring

The only thing keeping `-deprecated_syntax` alive is `derive(Show)` on five public
types (`ValueSource`, `ValueRange`, `Failure`, `JsonDecodeError`, `RandomState`).
Once those switch to `derive(Debug)` or a manual `Show` implementation, the
annotation can be deleted.

## Validation

- `moon check` clean (0 errors, 0 warnings)
- `moon fmt --check` clean
- `moon test` on the affected packages: 3561/3561 passed

Generated with SeekMoon