### PR TITLE
refactor(quickcheck/splitmix): drop deprecated derive(Show) from RandomState

### DIFF
--- a/quickcheck/splitmix/README.mbt.md
+++ b/quickcheck/splitmix/README.mbt.md
@@ -11,15 +11,30 @@ Create and initialize random number generators:
 test "random state creation" {
   // Create with default seed
   let rng1 = @splitmix.new()
-  inspect(rng1.to_string().length() > 0, content="true")
+  debug_inspect(
+    rng1,
+    content=(
+      #|{ seed: 6185074585042305769, gamma: 16934044424796929712 }
+    ),
+  )
 
   // Create with specific seed
   let rng2 = @splitmix.new(seed=12345UL)
-  inspect(rng2.to_string().length() > 0, content="true")
+  debug_inspect(
+    rng2,
+    content=(
+      #|{ seed: 1716623506685013753, gamma: 14663218685290508263 }
+    ),
+  )
 
   // Clone existing state
   let rng3 = rng2.clone()
-  inspect(rng3.to_string().length() > 0, content="true")
+  debug_inspect(
+    rng3,
+    content=(
+      #|{ seed: 1716623506685013753, gamma: 14663218685290508263 }
+    ),
+  )
 }
 ```
 
@@ -34,7 +49,12 @@ test "random number generation" {
 
   // Generate random integers
   let int_val = rng.next_int()
-  inspect(int_val.to_string().length() > 0, content="true")
+  debug_inspect(
+    int_val,
+    content=(
+      #|-1716621765
+    ),
+  )
 
   // Generate positive integers only
   let pos_int = rng.next_positive_int()
@@ -42,15 +62,30 @@ test "random number generation" {
 
   // Generate UInt values
   let uint_val = rng.next_uint()
-  inspect(uint_val.to_string().length() > 0, content="true")
+  debug_inspect(
+    uint_val,
+    content=(
+      #|40636561
+    ),
+  )
 
   // Generate Int64 values
   let int64_val = rng.next_int64()
-  inspect(int64_val.to_string().length() > 0, content="true")
+  debug_inspect(
+    int64_val,
+    content=(
+      #|640680877524568329
+    ),
+  )
 
   // Generate UInt64 values
   let uint64_val = rng.next_uint64()
-  inspect(uint64_val.to_string().length() > 0, content="true")
+  debug_inspect(
+    uint64_val,
+    content=(
+      #|11629490981681548516
+    ),
+  )
 }
 ```
 
@@ -117,8 +152,18 @@ test "advanced operations" {
 
   // Generate two UInt values at once
   let (uint1, uint2) = rng.next_two_uint()
-  inspect(uint1.to_string().length() > 0, content="true")
-  inspect(uint2.to_string().length() > 0, content="true")
+  debug_inspect(
+    uint1,
+    content=(
+      #|3306273023
+    ),
+  )
+  debug_inspect(
+    uint2,
+    content=(
+      #|472035372
+    ),
+  )
 
   // Split the generator (for parallel use)
   let split_rng = rng.split()
@@ -126,8 +171,18 @@ test "advanced operations" {
   // Both generators should work independently
   let original_val = rng.next_int()
   let split_val = split_rng.next_int()
-  inspect(original_val.to_string().length() > 0, content="true")
-  inspect(split_val.to_string().length() > 0, content="true")
+  debug_inspect(
+    original_val,
+    content=(
+      #|2115132817
+    ),
+  )
+  debug_inspect(
+    split_val,
+    content=(
+      #|400628363
+    ),
+  )
 }
 ```
 
@@ -145,7 +200,12 @@ test "state management" {
 
   // Generate value after advancing
   let after_advance = rng.next_int()
-  inspect(after_advance.to_string().length() > 0, content="true")
+  debug_inspect(
+    after_advance,
+    content=(
+      #|817660368
+    ),
+  )
 
   // Create independent copy
   let independent = rng.clone()

--- a/quickcheck/splitmix/extends.mbt
+++ b/quickcheck/splitmix/extends.mbt
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// --- promoted: kept as regular methods ---
-
-///|
-pub extend RandomState with Show::{to_string}
-
 // --- deprecated: hidden from the generated interface ---
 
 ///|
@@ -28,8 +23,3 @@ pub extend RandomState with @debug.Debug::{to_repr}
 #deprecated("Use `Default::default` instead", skip_current_package=true)
 #doc(hidden)
 pub extend RandomState with Default::{default}
-
-///|
-#deprecated("Use `Show::output` via the trait or `to_string` instead", skip_current_package=true)
-#doc(hidden)
-pub extend RandomState with Show::{output}

--- a/quickcheck/splitmix/pkg.generated.mbti
+++ b/quickcheck/splitmix/pkg.generated.mbti
@@ -11,7 +11,7 @@ pub fn new(seed? : UInt64) -> RandomState
 // Errors
 
 // Types and methods
-type RandomState derive(Show, @debug.Debug)
+type RandomState derive(@debug.Debug)
 pub fn RandomState::clone(Self) -> Self
 #deprecated
 pub fn RandomState::new(seed? : UInt64) -> Self
@@ -25,7 +25,6 @@ pub fn RandomState::next_two_uint(Self) -> (UInt, UInt)
 pub fn RandomState::next_uint(Self, limit? : UInt) -> UInt
 pub fn RandomState::next_uint64(Self, limit? : UInt64) -> UInt64
 pub fn RandomState::split(Self) -> Self
-pub fn RandomState::to_string(Self) -> String
 pub impl Default for RandomState
 
 // Type aliases

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -13,13 +13,10 @@
 // limitations under the License.
 
 ///|
-// TODO(future): `derive(Show)` is deprecated syntax — switch to `derive(Debug)`
-// or a manual `Show` implementation, then remove this annotation.
-#warnings("-deprecated_syntax")
 struct RandomState {
   mut seed : UInt64
   gamma : UInt64
-} derive(Show, @debug.Debug)
+} derive(@debug.Debug)
 
 ///|
 let golden_gamma : UInt64 = 0x9e3779b97f4a7c15


### PR DESCRIPTION
## Summary

Removes `derive(Show)` — deprecated syntax — from `RandomState`, along with the `#warnings("-deprecated_syntax")` suppression and the `#deprecated_syntax` TODO comment. The `Show` instance was only ever used by doctest display smoke checks (`rng.to_string().length() > 0`), so `derive(@debug.Debug)` alone suffices.

## Changes

- `random.mbt`: `derive(Show, @debug.Debug)` → `derive(@debug.Debug)`; drop suppression + TODO.
- `extends.mbt`: remove the promoted `Show::{to_string}` extend and the deprecated hidden `Show::{output}` extend (both required the `Show` impl).
- `README.mbt.md`: replace the weak `inspect(x.to_string().length() > 0, content="true")` smoke checks with `debug_inspect` snapshots of the deterministic seeded values (generated via `moon test --update`).
- `pkg.generated.mbti`: regenerated with `moon info` — `pub impl Show` and `RandomState::to_string` are gone from the public interface.

## Validation

- `moon check` (module-wide): clean.
- `moon test quickcheck/splitmix`: 19/19 passed (includes updated README doctests).
- `moon test quickcheck`: 82/82 passed.
- `moon fmt --check quickcheck`: clean.

Note: removing `RandomState::to_string()` / the `Show` impl is a breaking change for any external caller relying on them; this is the migration the prior TODO anticipated.

Generated with SeekMoon