### PR TITLE
Clean up stale #warnings suppressions

### DIFF
--- a/encoding/base64/encode.mbt
+++ b/encoding/base64/encode.mbt
@@ -36,7 +36,6 @@ pub fn encode(bytes : BytesView, padding? : Bool = true) -> String {
 ///|
 /// Retained on every backend: the linear-memory backends reach it only from
 /// the differential tests, but it is the implementation everywhere else.
-#warnings("-unused_value")
 fn encode_scalar(bytes : BytesView, padding? : Bool = true) -> String {
   let full_groups = bytes.length() / 3
   let remainder = bytes.length() % 3

--- a/encoding/hex/decode.mbt
+++ b/encoding/hex/decode.mbt
@@ -62,7 +62,6 @@ pub fn decode(text : StringView) -> Bytes raise Malformed {
 /// Retained on every backend: the linear-memory backends reach it only from
 /// the differential tests and the fast path's rejections, but it is the
 /// implementation everywhere else.
-#warnings("-unused_value")
 fn decode_scalar(text : StringView) -> Bytes raise Malformed {
   if text.length() % 2 != 0 {
     raise Malformed(text)

--- a/encoding/hex/encode.mbt
+++ b/encoding/hex/encode.mbt
@@ -36,7 +36,6 @@ pub fn encode(bytes : BytesView) -> String {
 ///|
 /// Retained on every backend: the linear-memory backends reach it only from
 /// the differential tests, but it is the implementation everywhere else.
-#warnings("-unused_value")
 fn encode_scalar(bytes : BytesView) -> String {
   // size_hint is measured in bytes, and each of the 2n output code units
   // occupies two bytes in the builder's UTF-16 buffer

--- a/internal/regex_engine/automata/delta.mbt
+++ b/internal/regex_engine/automata/delta.mbt
@@ -44,8 +44,6 @@
 /// - `delta_expr`: Computes derivative of expression, handling all expression types
 /// - `delta_threads`: Applies derivative to a collection of threads
 /// - `find_slot`: Allocates a slot for the new state to track positions
-#warnings("-3")
-priv struct Delta {}
 
 ///|
 #valtype

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -613,6 +613,11 @@ test "transformer with array" {
 }
 
 ///|
+// Kept for testing purposes: the `FromJson` bound is unused in the body (hence
+// the suppression), but it is asserted at the call site in the test below —
+// `test_json_export(42)` type-checks only because `Int` implements `FromJson`.
+// Do not remove the bound or the suppression: that would silently weaken the
+// test into a plain identity check.
 #warnings("-unused_trait_bound")
 fn[A : FromJson] test_json_export(x : A) -> A {
   x

--- a/strconv/README.mbt.md
+++ b/strconv/README.mbt.md
@@ -10,7 +10,6 @@ Parse integers in various bases:
 
 ```mbt check
 ///|
-#warnings("-deprecated")
 test "parse_int" {
   inspect(@strconv.parse_int("42"), content="42")
   inspect(@strconv.parse_int("101", base=2), content="5")
@@ -22,7 +21,6 @@ Parse 64-bit integers and unsigned integers:
 
 ```mbt check
 ///|
-#warnings("-deprecated")
 test "parse_int64_uint" {
   inspect(
     @strconv.parse_int64("9223372036854775807"),
@@ -40,7 +38,6 @@ test "parse_int64_uint" {
 
 ```mbt check
 ///|
-#warnings("-deprecated")
 test "parse_other" {
   inspect(@strconv.parse_bool("true"), content="true")
   inspect(@strconv.parse_double("3.14"), content="3.14")
@@ -54,7 +51,6 @@ Use `@string.from_str` in new code.
 
 ```mbt check
 ///|
-#warnings("-deprecated")
 test "from_str" {
   let i : Int = @strconv.from_str("123")
   inspect(i, content="123")
@@ -75,7 +71,6 @@ Use the `@string` versions in new code.
 
 ```mbt check
 ///|
-#warnings("-deprecated")
 test "error_handling" {
   let result : Result[Int, _] = try? @strconv.parse_int("abc")
   inspect(result is Err(_), content="true")

--- a/strconv/double.mbt
+++ b/strconv/double.mbt
@@ -57,7 +57,6 @@ let max_mantissa_fast_path : UInt64 = 2UL << mantissa_explicit_bits
 ///
 /// Examples:
 /// ```mbt check
-/// #warnings("-deprecated")
 /// test {
 ///   inspect(@strconv.parse_double("123"), content="123")
 ///   inspect(@strconv.parse_double("12.34"), content="12.34")

--- a/strconv/int.mbt
+++ b/strconv/int.mbt
@@ -70,7 +70,6 @@ test {
 /// These underscores do not affect the value.
 /// Examples:
 /// ```mbt check
-/// #warnings("-deprecated")
 /// test {
 ///   inspect(@strconv.parse_int64("123"), content="123")
 ///   inspect(@strconv.parse_int64("0xff", base=0), content="255")

--- a/strconv/uint.mbt
+++ b/strconv/uint.mbt
@@ -30,7 +30,6 @@ const UINT64_MAX : UInt64 = 0xffffffffffffffffUL
 /// These underscores do not affect the value.
 /// Examples:
 /// ```mbt check
-/// #warnings("-deprecated")
 /// test {
 ///   inspect(@strconv.parse_uint64("123"), content="123")
 ///   inspect(@strconv.parse_uint64("0xff", base=0), content="255")


### PR DESCRIPTION
## Summary

Cleanup pass over stale `#warnings(...)` suppressions across the codebase. Each candidate was verified empirically: remove the suppression, run `moon check` (including per-target checks and doc-block validation), and restore it only if a warning reappeared. Three genuinely stale suppressions were removed; one suppression was documented and retained because it serves a testing purpose.

## Changes

1. **`internal/regex_engine/automata/delta.mbt`** — remove dead `priv struct Delta {}` and its `#warnings("-3")`. The empty struct was never referenced (introduced with the original import of the file); removing it surfaced warning `[0003] unused_type_declaration`, so the struct itself was deleted rather than keeping the suppression.

2. **`encoding/base64/encode.mbt`, `encoding/hex/encode.mbt`, `encoding/hex/decode.mbt`** — drop `#warnings("-unused_value")` on `encode_scalar` / `decode_scalar`. These are referenced from `_wbtest.mbt` differential tests on every target (and are the production implementation on non-native targets), so the unused-value warning never fires. Verified clean on `native`/`wasm`/`wasm-gc`/`js`.

3. **`json/json_test.mbt`** — add an explanatory note to `test_json_export`. The `FromJson` bound and its `#warnings("-unused_trait_bound")` are intentionally kept: the bound is unused in the body (hence the suppression) but asserted at the call site — `test_json_export(42)` type-checks only because `Int` implements `FromJson`. The note documents this so the suppression is not mistaken for stale.

4. **`strconv/int.mbt`, `strconv/double.mbt`, `strconv/uint.mbt`, `strconv/README.mbt.md`** — drop `#warnings("-deprecated")` inside `mbt check` doc examples. The `parse_*` functions are deprecated with `skip_current_package=true`, so in-package doc examples never trigger the deprecation warning. Confirmed `moon check` validates doc blocks (a deliberately injected bogus symbol was caught) and that removal stays warning-free.

## Kept (verified still-needed)

- `-unused_value` on conditional-import v128 suppression functions (`json/json.mbt`, `encoding/ascii/decode.mbt`, `encoding/utf16/decode.mbt`, `env/env.mbt`) — warnings reappear on `js`/`wasm-gc`.
- `-deprecated` inside intentionally deprecated API definitions and tests that exercise deprecated APIs.
- `-deprecated_syntax` sites carrying `TODO(future)` comments for the `derive(Show)` migration.
- `-unused_trait_bound` on `json_test.test_json_export` — kept and documented (see change 3).

## Validation

- `moon check` clean (0 warnings, 0 errors) at repo root and per-target for touched packages.
- `moon fmt --check` clean.
- `moon test` passes for `encoding/base64`, `encoding/hex`, `json`, `strconv`, `argparse`.
