### PR TITLE
perf(bytes): reuse SIMD lexical comparison

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -396,16 +396,7 @@ pub impl Compare for Bytes with fn compare(self, other) {
   if cmp != 0 {
     return cmp
   }
-  for i in 0..<self_len {
-    let b1 = self.unsafe_get(i)
-    let b2 = other.unsafe_get(i)
-    let cmp = b1.compare(b2)
-    if cmp != 0 {
-      break cmp
-    }
-  } nobreak {
-    0
-  }
+  self.lexical_compare(other)
 }
 
 ///|

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -417,6 +417,25 @@ test "BytesView::lexical_compare/basic" {
 }
 
 ///|
+test "Bytes and BytesView Compare preserve shortlex ordering" {
+  let equal_left = Bytes::makei(64, i => i.to_byte())
+  let equal_right = Bytes::makei(64, i => i.to_byte())
+  inspect(equal_left.compare(equal_right), content="0")
+
+  let lower = Bytes::makei(64, i => if i == 63 { b'\x01' } else { b'\x00' })
+  let higher = Bytes::makei(64, i => if i == 63 { b'\x02' } else { b'\x00' })
+  inspect(lower.compare(higher), content="-1")
+  inspect(higher.compare(lower), content="1")
+
+  let padded_lower = b"x" + lower + b"y"
+  let padded_higher = b"z" + higher + b"w"
+  inspect(padded_lower[1:65].compare(padded_higher[1:65]), content="-1")
+
+  // Shortlex compares length before contents.
+  inspect(b"\xff".compare(b"\x00\x00"), content="-1")
+}
+
+///|
 test "Bytes find and rev_find" {
   let target = b"abcabc"
   let pattern = b"abc"

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -435,12 +435,7 @@ pub impl Compare for BytesView with fn compare(self, other) -> Int {
   let other_len = other.length()
   let cmp = self_len.compare(other_len)
   guard cmp == 0 else { return cmp }
-  for i, b1 in self {
-    let b2 = other.unsafe_get(i)
-    let cmp = b1.compare(b2)
-    guard cmp == 0 else { return cmp }
-  }
-  0
+  self.lexical_compare(other)
 }
 
 ///|

--- a/builtin/bytesview_compare_bench_test.mbt
+++ b/builtin/bytesview_compare_bench_test.mbt
@@ -1,0 +1,33 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "bench BytesView Compare equal n=1000000" (it : @bench.T) {
+  let left = Bytes::makei(1000000, i => i.to_byte())[:]
+  let right = Bytes::makei(1000000, i => i.to_byte())[:]
+  it.bench(fn() { it.keep(left.compare(right)) })
+}
+
+///|
+test "bench BytesView Compare last-diff n=1000000" (it : @bench.T) {
+  let left = Bytes::makei(1000000, i => i.to_byte())[:]
+  let right = Bytes::makei(1000000, i => {
+      if i == 999999 {
+        b'\xff'
+      } else {
+        i.to_byte()
+      }
+    })[:]
+  it.bench(fn() { it.keep(left.compare(right)) })
+}


### PR DESCRIPTION
## Summary

Reuse the existing SIMD-backed lexical comparison after the shortlex length check in `Compare` for `Bytes` and `BytesView`. This removes duplicate scalar byte-by-byte loops while preserving shortlex ordering.

## Benchmark

Native release, 1,000,000-byte `BytesView` values:

| Case | Before | After |
| --- | ---: | ---: |
| equal | 322.25 us | 31.03 us |
| last byte differs | 333.46 us | 31.00 us |

## Validation

- `moon test builtin --target all`
- `moon check`
- `moon info` (no interface changes)