### PR TITLE
perf(bytes): write escaped hex digits directly

### DIFF
--- a/builtin/bytes_output_bench_test.mbt
+++ b/builtin/bytes_output_bench_test.mbt
@@ -1,0 +1,26 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let bytes_output_binary : Bytes = Bytes::makei(100000, i => i.to_byte())
+
+///|
+test "bench Bytes Show binary n=100000" (it : @bench.T) {
+  it.bench(fn() { it.keep(bytes_output_binary.to_string()) })
+}
+
+///|
+test "bench Bytes ToJson binary n=100000" (it : @bench.T) {
+  it.bench(fn() { it.keep(@json.to_json(bytes_output_binary)) })
+}

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -27,6 +27,13 @@ test "json repr" {
 }
 
 ///|
+test "Bytes output writes lowercase hex digits directly" {
+  let bytes = b"\x00\x09\x0a\x0f\x10\x7f\x80\xff"
+  inspect(bytes, content="b\"\\x00\\x09\\x0a\\x0f\\x10\\x7f\\x80\\xff\"")
+  @json.json_inspect(bytes, content="\\x00\\x09\\x0a\\x0f\\x10\\x7f\\x80\\xff")
+}
+
+///|
 test "to_string" {
   @test.assert_eq(HELLO_WORLD.to_unchecked_string(), "Hello, World!")
 }

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -328,6 +328,21 @@ pub fn BytesView::iter2(self : BytesView) -> Iter2[Int, Byte] {
 }
 
 ///|
+fn write_byte_hex(logger : &Logger, byte : Byte) -> Unit {
+  fn hex_digit(value : Int) -> Char {
+    if value < 10 {
+      (value + '0'.to_int()).unsafe_to_char()
+    } else {
+      (value - 10 + 'a'.to_int()).unsafe_to_char()
+    }
+  }
+
+  let value = byte.to_int()
+  logger.write_char(hex_digit(value >> 4))
+  logger.write_char(hex_digit(value & 0x0f))
+}
+
+///|
 pub impl Show for BytesView with fn output(self, logger) {
   logger.write_string("b\"")
   for byte in self {
@@ -335,7 +350,7 @@ pub impl Show for BytesView with fn output(self, logger) {
       logger.write_char(byte.to_char())
     } else {
       logger.write_string("\\x")
-      logger.write_string(byte.to_hex())
+      write_byte_hex(logger, byte)
     }
   }
   logger.write_string("\"")
@@ -580,7 +595,7 @@ pub impl ToJson for BytesView with fn to_json(self) -> Json {
       sb.write_char(byte.to_char())
     } else {
       sb.write_string("\\x")
-      sb.write_string(byte.to_hex())
+      write_byte_hex(sb, byte)
     }
   }
   Json::string(sb.to_string())


### PR DESCRIPTION
## Summary

Write escaped byte hex digits directly to the output logger instead of allocating a two-character `String` via `Byte::to_hex()` for every escaped byte. The private helper is shared by `Show` and `ToJson`.

## Benchmark

Native release, 100,000 binary bytes:

| Operation | Before | After |
| --- | ---: | ---: |
| `Bytes Show` | 1.65 ms | 544.43 us |
| `Bytes ToJson` | 1.46 ms | 508.42 us |

## Validation

- `moon test builtin --target all`
- `moon check`
- `moon info` (no interface changes)