### PR TITLE
perf(bytes): skip redundant initialization in concatenation

### DIFF
--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -799,6 +799,34 @@ pub fn Bytes::get(self : Bytes, index : Int) -> Byte? {
 /// * `other` : The second bytes sequence.
 /// TODO: marked as intrinsic, inline if it is constant
 pub impl Add for Bytes with fn add(self : Bytes, other : Bytes) -> Bytes {
+  self.bytes_add_impl(other)
+}
+
+///|
+#cfg(not(target="js"))
+fn Bytes::bytes_add_impl(self : Bytes, other : Bytes) -> Bytes {
+  let len_self = self.length()
+  let len_other = other.length()
+  let rv = UninitializedArray::unsafe_make_and_blit_from_fixed(
+    unsafe_from_bytes(self),
+    len_self + len_other,
+    0,
+    0,
+    len_self,
+  )
+  UninitializedArray::unsafe_blit_fixed(
+    rv,
+    len_self,
+    unsafe_from_bytes(other),
+    0,
+    len_other,
+  )
+  unsafe_to_bytes(buffer_to_fixedarray(rv))
+}
+
+///|
+#cfg(target="js")
+fn Bytes::bytes_add_impl(self : Bytes, other : Bytes) -> Bytes {
   let len_self = self.length()
   let len_other = other.length()
   let rv : FixedArray[Byte] = FixedArray::make(len_self + len_other, 0)

--- a/builtin/bytes_add_bench_test.mbt
+++ b/builtin/bytes_add_bench_test.mbt
@@ -1,0 +1,24 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let bytes_add_left : Bytes = Bytes::make(500000, b'a')
+
+///|
+let bytes_add_right : Bytes = Bytes::make(500000, b'b')
+
+///|
+test "bench Bytes add total=1000000" (it : @bench.T) {
+  it.bench(fn() { it.keep(bytes_add_left + bytes_add_right) })
+}

--- a/builtin/bytes_add_bench_test.mbt
+++ b/builtin/bytes_add_bench_test.mbt
@@ -13,12 +13,8 @@
 // limitations under the License.
 
 ///|
-let bytes_add_left : Bytes = Bytes::make(500000, b'a')
-
-///|
-let bytes_add_right : Bytes = Bytes::make(500000, b'b')
-
-///|
 test "bench Bytes add total=1000000" (it : @bench.T) {
+  let bytes_add_left : Bytes = Bytes::make(500000, b'a')
+  let bytes_add_right : Bytes = Bytes::make(500000, b'b')
   it.bench(fn() { it.keep(bytes_add_left + bytes_add_right) })
 }

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -279,6 +279,19 @@ test "Bytes::add and repeat" {
 }
 
 ///|
+test "Bytes add initializes the complete result" {
+  @test.assert_eq(b"" + b"", b"")
+  @test.assert_eq(b"left" + b"", b"left")
+  @test.assert_eq(b"" + b"right", b"right")
+  let left = Bytes::makei(257, i => i.to_byte())
+  let right = Bytes::makei(259, i => (255 - i).to_byte())
+  let joined = left + right
+  @test.assert_eq(joined.length(), 516)
+  @test.assert_eq(joined[0:257].to_owned(), left)
+  @test.assert_eq(joined[257:].to_owned(), right)
+}
+
+///|
 test "panic Bytes::repeat negative" {
   let _ = b"ab".repeat(-1)
 }


### PR DESCRIPTION
## Summary

Avoid zero-initializing the concatenation result on non-JS targets before both inputs overwrite the full allocation. Allocate uninitialized storage, fill the two non-overlapping ranges with blits, then reinterpret the fully initialized buffer as `Bytes`. JS keeps the existing implementation because the required intrinsic is unavailable there.

## Benchmark

Native release, 500,000 + 500,000 bytes, averaged over eight interleaved base/head runs:

| Before | After | Improvement |
| ---: | ---: | ---: |
| 25.03 µs | 16.95 µs | 32.3% lower latency (1.48× throughput) |

## Validation

- `moon test builtin --target all`
- `moon check --target all`
- `moon info` (no interface changes)