### PR TITLE
perf(json): write escaped strings directly

### DIFF
--- a/json/escape_quickcheck_wbtest.mbt
+++ b/json/escape_quickcheck_wbtest.mbt
@@ -95,20 +95,24 @@ test "quickcheck: need_escape agrees with the scalar reference" {
 }
 
 ///|
-test "quickcheck: escape matches the per-code-unit model" {
+test "quickcheck: write_escaped matches the per-code-unit model" {
+  fn actual(str : String, escape_slash : Bool) -> String {
+    let buf = StringBuilder()
+    write_escaped(buf, str, escape_slash~)
+    buf.to_string()
+  }
   @quickcheck.check(count=300, (input : (Array[Int], Bool)) => {
     let (seeds, escape_slash) = input
     let str = adversarial_string(seeds, allow_surrogates=true)
-    guard escape(str, escape_slash~) == model_escape(str, escape_slash) else {
+    guard actual(str, escape_slash) == model_escape(str, escape_slash) else {
       return false
     }
-    // The no-copy fast path must fire exactly when nothing is escapable.
-    (escape(str, escape_slash~) == str) ==
+    (actual(str, escape_slash) == str) ==
     !need_escape_scalar(str, escape_slash, 0, str.length())
   })
   @quickcheck.check(count=300, (input : (String, Bool)) => {
     let (str, escape_slash) = input
-    escape(str, escape_slash~) == model_escape(str, escape_slash)
+    actual(str, escape_slash) == model_escape(str, escape_slash)
   })
 }
 

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -307,7 +307,7 @@ pub fn Json::stringify(
             }
           String(s) => {
             buf.write_char('\"')
-            buf.write_string(escape(s, escape_slash~))
+            write_escaped(buf, s, escape_slash~)
             buf.write_char('\"')
           }
           Number(n, repr~) =>
@@ -363,7 +363,7 @@ pub fn Json::stringify(
                   }
                 }
                 buf.write_char('\"')
-                buf.write_string(escape(k, escape_slash~))
+                write_escaped(buf, k, escape_slash~)
                 buf.write_char('\"')
                 buf.write_char(':')
                 if indent > 0 {
@@ -457,12 +457,15 @@ fn need_escape(str : String, escape_slash : Bool) -> Bool {
 }
 
 ///|
-fn escape(str : String, escape_slash~ : Bool) -> String {
-  let len = str.length()
+fn write_escaped(
+  buf : StringBuilder,
+  str : String,
+  escape_slash~ : Bool,
+) -> Unit {
   if !need_escape(str, escape_slash) {
-    return str
+    buf.write_string(str)
+    return
   }
-  let buf = StringBuilder(size_hint=len)
   for code in str.code_units() {
     match code {
       '"' => buf.write_string("\\\"")
@@ -487,7 +490,6 @@ fn escape(str : String, escape_slash~ : Bool) -> String {
         }
     }
   }
-  buf.to_string()
 }
 
 ///|


### PR DESCRIPTION
Write escaped JSON strings and object keys directly into the final `StringBuilder` instead of allocating an intermediate escaped `String` and copying it again.

Native benchmark (`n=2048`):

| case | before | after |
| --- | ---: | ---: |
| slash escaped | 261.28 µs | 160.30 µs |
| quotes and controls | 296.05 µs | 132.87 µs |
| no escape | 36.10 µs | 33.79 µs |

Validation: `moon test json --target all`, `moon check --target all`, and `moon info`.