### PR TITLE
perf(quickcheck): execute zipped generators directly

### DIFF
--- a/quickcheck/generator.mbt
+++ b/quickcheck/generator.mbt
@@ -125,7 +125,10 @@ pub fn[T, U, V] Generator::zip_with(
   other : Generator[U],
   combine : (T, U) -> V,
 ) -> Generator[V] {
-  self.flat_map(first => other.map(second => combine(first, second)))
+  Generator((size, state) => {
+    let other_state = state.split()
+    combine(self.run(size, state), other.run(size, other_state))
+  })
 }
 
 ///|
@@ -136,7 +139,15 @@ pub fn[T, U, V, W] Generator::zip_with3(
   third : Generator[V],
   combine : (T, U, V) -> W,
 ) -> Generator[W] {
-  self.flat_map(a => second.flat_map(b => third.map(c => combine(a, b, c))))
+  Generator((size, state) => {
+    let second_state = state.split()
+    let third_state = second_state.split()
+    combine(
+      self.run(size, state),
+      second.run(size, second_state),
+      third.run(size, third_state),
+    )
+  })
 }
 
 ///|

--- a/quickcheck/generator_bench_test.mbt
+++ b/quickcheck/generator_bench_test.mbt
@@ -1,0 +1,29 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "bench Generator::zip_with n=1000000" (it : @bench.T) {
+  let generator = @quickcheck.int_range(0, 1000).zip_with(
+    @quickcheck.int_range(0, 1000),
+    (a, b) => a + b,
+  )
+  it.bench(fn() {
+    let state = @splitmix.new()
+    let mut sum = 0
+    for _ in 0..<1000000 {
+      sum += generator.run(100, state)
+    }
+    it.keep(sum)
+  })
+}

--- a/quickcheck/moon.pkg
+++ b/quickcheck/moon.pkg
@@ -27,6 +27,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/float",
   "moonbitlang/core/double",
 } for "test"


### PR DESCRIPTION
Implement `Generator::zip_with` and `zip_with3` directly instead of composing `flat_map` and `map`. The previous composition allocated temporary generators and closures for every generated sample.

The state splitting and evaluation order are preserved.

Native benchmark (`zip_with`, 1,000,000 samples):

| before | after | change |
| ---: | ---: | ---: |
| 38.66 ms | 11.64 ms | 70% faster |

Validation: all 82 QuickCheck tests pass on wasm, wasm-gc, JS, and native; `moon check --target all` and `moon info` pass.