### PR TITLE
perf(quickcheck): build arbitrary strings linearly

### DIFF
--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -121,12 +121,12 @@ pub impl Arbitrary for Char with fn arbitrary(_, rs) {
 ///|
 pub impl Arbitrary for String with fn arbitrary(size, rs) {
   let len = if size == 0 { 0 } else { rs.next_positive_int() % size }
-  for i in 0..<len; s = "" {
+  let buf = StringBuilder(size_hint=len * 2)
+  for i in 0..<len {
     let c : Char = Arbitrary::arbitrary(i, rs)
-    continue s + c.to_string()
-  } nobreak {
-    s
+    buf.write_char(c)
   }
+  buf.to_string()
 }
 
 ///|

--- a/quickcheck/arbitrary_string_bench_test.mbt
+++ b/quickcheck/arbitrary_string_bench_test.mbt
@@ -1,0 +1,26 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "bench Arbitrary String size=10000 count=100" (it : @bench.T) {
+  it.bench(fn() {
+    let state = @splitmix.new()
+    let mut total = 0
+    for _ in 0..<100 {
+      let value : String = @quickcheck.Arbitrary::arbitrary(10000, state)
+      total += value.length()
+    }
+    it.keep(total)
+  })
+}

--- a/quickcheck/moon.pkg
+++ b/quickcheck/moon.pkg
@@ -27,6 +27,7 @@ import {
 }
 
 import {
+  "moonbitlang/core/bench",
   "moonbitlang/core/float",
   "moonbitlang/core/double",
 } for "test"


### PR DESCRIPTION
Build arbitrary strings with `StringBuilder` instead of repeatedly concatenating one character at a time. This changes construction from quadratic copying to a linear append loop while preserving random-state consumption and generated values.

Native benchmark (`size=10000`, 100 generated strings):

| before | after | change |
| ---: | ---: | ---: |
| 84.85 ms | 3.26 ms | 96% faster |

Validation: all 82 QuickCheck tests pass on wasm, wasm-gc, JS, and native; `moon check --target all` and `moon info` pass.