### PR TITLE
Avoid reevaluating duplicate QuickCheck shrinks

### DIFF
--- a/quickcheck/driver.mbt
+++ b/quickcheck/driver.mbt
@@ -191,6 +191,7 @@ impl Eq for CaseOutcome with fn equal(expected, actual) {
 fn[A : @shrink.Shrink] shrink_failure(
   property : (A) -> Bool raise?,
   filter : (A) -> Bool,
+  shrink_equal : (A, A) -> Bool,
   input : A,
   initial : CaseOutcome,
   max_shrinks : UInt,
@@ -200,11 +201,16 @@ fn[A : @shrink.Shrink] shrink_failure(
   let mut successful = 0U
   let mut attempted = 0U
   let mut found = true
+  let seen = [input]
   while attempted < max_shrinks && found {
     found = false
     let candidates = @shrink.Shrink::shrink(current)
     while attempted < max_shrinks && candidates.next() is Some(candidate) {
       attempted = attempted + 1
+      if seen.any(previous => shrink_equal(previous, candidate)) {
+        continue
+      }
+      seen.push(candidate)
       let outcome = evaluate_case(property, filter, candidate)
       if initial == outcome {
         current = candidate
@@ -288,6 +294,7 @@ fn[A : @debug.Debug] failure_report(report : QuickCheckReport[A]) -> String {
 pub fn[A : Arbitrary + @shrink.Shrink] report(
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
+  shrink_equal? : (A, A) -> Bool = (_, _) => false,
   observe? : (A) -> Observations = _ => [],
   counterexample_context? : (A) -> String,
   count? : UInt = 100,
@@ -317,7 +324,7 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
       _ => {
         let completed_tests = tests + 1
         let (counterexample, outcome, shrinks, shrink_attempts) = shrink_failure(
-          property, filter, input, outcome, max_shrinks,
+          property, filter, shrink_equal, input, outcome, max_shrinks,
         )
         let context = counterexample_context.map(render => {
           render(counterexample)
@@ -377,6 +384,9 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
 ///
 /// * `property`: A deterministic function returning `true` on success.
 /// * `filter`: A pure precondition returning `true` for cases to test.
+/// * `shrink_equal`: An optional equivalence relation used to avoid evaluating
+///   duplicate shrink candidates. Duplicate candidates still consume a shrink
+///   attempt, so infinite shrink streams remain bounded by `max_shrinks`.
 /// * `observe`: A pure function classifying cases with `label`, `classify`, or
 ///   `collect`.
 /// * `counterexample_context`: A pure function rendering the shrunk
@@ -405,6 +415,7 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
 pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check(
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
+  shrink_equal? : (A, A) -> Bool = (_, _) => false,
   observe? : (A) -> Observations = _ => [],
   counterexample_context? : (A) -> String,
   count? : UInt = 100,
@@ -417,6 +428,7 @@ pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check(
   let result = report(
     property,
     filter~,
+    shrink_equal~,
     observe~,
     counterexample_context?,
     count~,

--- a/quickcheck/driver.mbt
+++ b/quickcheck/driver.mbt
@@ -191,7 +191,7 @@ impl Eq for CaseOutcome with fn equal(expected, actual) {
 fn[A : @shrink.Shrink] shrink_failure(
   property : (A) -> Bool raise?,
   filter : (A) -> Bool,
-  shrink_equal : (A, A) -> Bool,
+  shrink_equal : ((A, A) -> Bool)?,
   input : A,
   initial : CaseOutcome,
   max_shrinks : UInt,
@@ -201,16 +201,18 @@ fn[A : @shrink.Shrink] shrink_failure(
   let mut successful = 0U
   let mut attempted = 0U
   let mut found = true
-  let seen = [input]
+  let seen = shrink_equal.map(_ => [input])
   while attempted < max_shrinks && found {
     found = false
     let candidates = @shrink.Shrink::shrink(current)
     while attempted < max_shrinks && candidates.next() is Some(candidate) {
       attempted = attempted + 1
-      if seen.any(previous => shrink_equal(previous, candidate)) {
-        continue
+      if (shrink_equal, seen) is (Some(equal), Some(seen)) {
+        if seen.any(previous => equal(previous, candidate)) {
+          continue
+        }
+        seen.push(candidate)
       }
-      seen.push(candidate)
       let outcome = evaluate_case(property, filter, candidate)
       if initial == outcome {
         current = candidate
@@ -294,7 +296,7 @@ fn[A : @debug.Debug] failure_report(report : QuickCheckReport[A]) -> String {
 pub fn[A : Arbitrary + @shrink.Shrink] report(
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
-  shrink_equal? : (A, A) -> Bool = (_, _) => false,
+  shrink_equal? : (A, A) -> Bool,
   observe? : (A) -> Observations = _ => [],
   counterexample_context? : (A) -> String,
   count? : UInt = 100,
@@ -415,7 +417,7 @@ pub fn[A : Arbitrary + @shrink.Shrink] report(
 pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check(
   property : (A) -> Bool raise?,
   filter? : (A) -> Bool = _ => true,
-  shrink_equal? : (A, A) -> Bool = (_, _) => false,
+  shrink_equal? : (A, A) -> Bool,
   observe? : (A) -> Observations = _ => [],
   counterexample_context? : (A) -> String,
   count? : UInt = 100,
@@ -428,7 +430,7 @@ pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check(
   let result = report(
     property,
     filter~,
-    shrink_equal~,
+    shrink_equal?,
     observe~,
     counterexample_context?,
     count~,

--- a/quickcheck/driver_test.mbt
+++ b/quickcheck/driver_test.mbt
@@ -534,3 +534,70 @@ test "context is attached to raised failures too" {
     ),
   )
 }
+
+///|
+test "report does not reevaluate equivalent shrink candidates" {
+  let mut property_calls = 0
+  let report = @quickcheck.report(
+    (_ : RepeatingInput) => {
+      property_calls = property_calls + 1
+      false
+    },
+    shrink_equal=(a, b) => a.0 == b.0,
+    count=1,
+    max_shrinks=10,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Falsified(
+      #|  counterexample=RepeatingInput(0),
+      #|  tests=1,
+      #|  size=0,
+      #|  shrinks=0,
+      #|  shrink_attempts=10,
+      #|)
+    ),
+  )
+  inspect(property_calls, content="1")
+}
+
+///|
+priv struct CyclicShrinkInput(Int) derive(Debug)
+
+///|
+impl @quickcheck.Arbitrary for CyclicShrinkInput with fn arbitrary(_, _) {
+  CyclicShrinkInput(2)
+}
+
+///|
+impl @shrink.Shrink for CyclicShrinkInput with fn shrink(input) {
+  [|CyclicShrinkInput(if input.0 == 2 { 1 } else { 2 })|]
+}
+
+///|
+test "report does not revisit earlier shrink candidates" {
+  let mut property_calls = 0
+  let report = @quickcheck.report(
+    (_ : CyclicShrinkInput) => {
+      property_calls = property_calls + 1
+      false
+    },
+    shrink_equal=(a, b) => a.0 == b.0,
+    count=1,
+    max_shrinks=10,
+  )
+  debug_inspect(
+    report,
+    content=(
+      #|Falsified(
+      #|  counterexample=CyclicShrinkInput(1),
+      #|  tests=1,
+      #|  size=0,
+      #|  shrinks=1,
+      #|  shrink_attempts=2,
+      #|)
+    ),
+  )
+  inspect(property_calls, content="2")
+}

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -18,7 +18,7 @@ import {
 pub fn char_range(Char, Char) -> Generator[Char]
 
 #callsite(autofill(loc))
-pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check((A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64, loc~ : SourceLoc) -> Unit raise
+pub fn[A : Arbitrary + @shrink.Shrink + @debug.Debug] check((A) -> Bool raise?, filter? : (A) -> Bool, shrink_equal? : (A, A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64, loc~ : SourceLoc) -> Unit raise
 
 pub fn classify(Bool, String) -> Observation
 
@@ -38,7 +38,7 @@ pub fn[T] one_of(Array[Generator[T]]) -> Generator[T]
 
 pub fn[T] pure(T) -> Generator[T]
 
-pub fn[A : Arbitrary + @shrink.Shrink] report((A) -> Bool raise?, filter? : (A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
+pub fn[A : Arbitrary + @shrink.Shrink] report((A) -> Bool raise?, filter? : (A) -> Bool, shrink_equal? : (A, A) -> Bool, observe? : (A) -> Array[Observation], counterexample_context? : (A) -> String, count? : UInt, max_size? : UInt, max_shrinks? : UInt, discard_ratio? : UInt, seed? : UInt64) -> QuickCheckReport[A]
 
 pub fn[X : Arbitrary] samples(Int) -> Array[X]
 


### PR DESCRIPTION
Adds an optional `shrink_equal` equivalence function to `report` and `check`. When supplied, the shrink driver tracks candidates it has already examined and skips repeated property/filter evaluation.

Duplicate candidates still count toward `max_shrinks`, preserving termination for infinite shrink streams. The default comparator treats candidates as distinct, so existing callers and types without `Eq` or `Hash` remain unaffected.

Tests cover both a self-repeating shrinker and an `A -> B -> A` cycle.

Validation: `moon test --target all`, `moon check --target all`, and `moon info`.