### PR TITLE
perf(lexbuf): reduce small-chunk merge limit

### DIFF
--- a/lexbuf/lexbuf_bench_test.mbt
+++ b/lexbuf/lexbuf_bench_test.mbt
@@ -1,0 +1,64 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn bench_retained_chunks(
+  it : @bench.T,
+  chunk : String,
+  chunk_count : Int,
+) -> Unit {
+  let total = chunk.length() * chunk_count
+  it.bench(fn() {
+    let mut remaining = chunk_count
+    let lexbuf = @lexbuf.Lexbuf::from_fn(() => {
+      if remaining == 0 {
+        None
+      } else {
+        remaining -= 1
+        Some(chunk)
+      }
+    })
+    lexbuf.__refill()
+    lexbuf.__retain_from_cursor()
+    while lexbuf.__get_cursor() < total {
+      let cursor = lexbuf.__get_cursor()
+      lexbuf.__unsafe_code_unit_at(cursor) |> ignore
+      lexbuf.__advance(1)
+      if lexbuf.__get_cursor() == lexbuf.__buffer_end() {
+        lexbuf.__refill()
+      }
+    }
+    it.keep(lexbuf.__get_stringview(0, total).length())
+  })
+}
+
+///|
+test "bench Lexbuf retained token chunks=10000 size=1" (it : @bench.T) {
+  bench_retained_chunks(it, "x", 10000)
+}
+
+///|
+test "bench Lexbuf retained token chunks=1250 size=8" (it : @bench.T) {
+  bench_retained_chunks(it, "x".repeat(8), 1250)
+}
+
+///|
+test "bench Lexbuf retained token chunks=157 size=64" (it : @bench.T) {
+  bench_retained_chunks(it, "x".repeat(64), 157)
+}
+
+///|
+test "bench Lexbuf retained token chunks=20 size=512" (it : @bench.T) {
+  bench_retained_chunks(it, "x".repeat(512), 20)
+}

--- a/lexbuf/moon.pkg
+++ b/lexbuf/moon.pkg
@@ -1,3 +1,7 @@
 import {
   "moonbitlang/core/builtin",
 }
+
+import {
+  "moonbitlang/core/bench",
+} for "test"

--- a/lexbuf/storage.mbt
+++ b/lexbuf/storage.mbt
@@ -26,7 +26,7 @@ priv struct LexbufStorage {
 }
 
 ///|
-const LEXBUF_MERGED_CHUNK_LIMIT : Int = 512
+const LEXBUF_MERGED_CHUNK_LIMIT : Int = 64
 
 ///|
 fn LexbufStorage::LexbufStorage() -> LexbufStorage {

--- a/lexbuf/storage_wbtest.mbt
+++ b/lexbuf/storage_wbtest.mbt
@@ -19,12 +19,12 @@ test "LexbufStorage merges input into the last small chunk" {
     storage.append("x")
   }
   inspect(storage.chunks.length(), content="1")
-  inspect(storage.chunks[0].length(), content="512")
+  inspect(storage.chunks[0].length(), content="64")
   inspect(storage.chunk_starts.length(), content="1")
   inspect(storage.chunk_starts[0], content="0")
   inspect(
     storage.get_stringview(0, LEXBUF_MERGED_CHUNK_LIMIT).length(),
-    content="512",
+    content="64",
   )
 }
 
@@ -35,13 +35,16 @@ test "LexbufStorage caps merged chunks" {
     storage.append("x")
   }
   inspect(storage.chunks.length(), content="2")
-  inspect(storage.chunks[0].length(), content="512")
-  inspect(storage.chunks[1].length(), content="512")
+  inspect(storage.chunks[0].length(), content="64")
+  inspect(storage.chunks[1].length(), content="64")
   inspect(storage.chunk_starts.length(), content="2")
   inspect(storage.chunk_starts[0], content="0")
-  inspect(storage.chunk_starts[1], content="512")
-  inspect(storage.unsafe_code_unit_at(511), content="120")
-  inspect(storage.unsafe_code_unit_at(512), content="120")
+  inspect(storage.chunk_starts[1], content="64")
+  inspect(
+    storage.unsafe_code_unit_at(LEXBUF_MERGED_CHUNK_LIMIT - 1),
+    content="120",
+  )
+  inspect(storage.unsafe_code_unit_at(LEXBUF_MERGED_CHUNK_LIMIT), content="120")
 }
 
 ///|
@@ -93,7 +96,7 @@ test "LexbufStorage discards complete chunks and preserves absolute offsets" {
   storage.append("z".repeat(LEXBUF_MERGED_CHUNK_LIMIT + 1))
   storage.discard_before(LEXBUF_MERGED_CHUNK_LIMIT + 1)
   inspect(storage.chunks.length(), content="2")
-  inspect(storage.buffer_start, content="513")
+  inspect(storage.buffer_start, content="65")
   inspect(
     storage.unsafe_code_unit_at(LEXBUF_MERGED_CHUNK_LIMIT + 1),
     content="121",
@@ -102,7 +105,7 @@ test "LexbufStorage discards complete chunks and preserves absolute offsets" {
     LEXBUF_MERGED_CHUNK_LIMIT + 1,
     2 * (LEXBUF_MERGED_CHUNK_LIMIT + 1) + 1,
   )
-  inspect(view.length(), content="514")
+  inspect(view.length(), content="66")
   inspect(view.unsafe_get(0).to_int(), content="121")
   inspect(view.unsafe_get(view.length() - 1).to_int(), content="122")
 }


### PR DESCRIPTION
Reduces the maximum merged Lexbuf chunk size from 512 to 64 UTF-16 code units. Repeatedly appending tiny chunks currently copies an increasingly large merged string; a lower cap reduces that copying while retaining chunk coalescing.

Native release benchmarks for a retained token totaling about 10,000 code units:

| Input chunks | Before | After |
| --- | ---: | ---: |
| 10,000 × 1 | 238.20 µs | 177.57 µs |
| 1,250 × 8 | 45.61 µs | 38.76 µs |
| 157 × 64 | 20.10 µs | 18.45 µs |
| 20 × 512 | 13.44 µs | 13.72 µs |

The large-chunk case is effectively unchanged, while tiny chunks improve by up to 25%.

Validation: `moon test lexbuf --target all`, `moon check --target all`, and `moon info`.