### PR TITLE
perf(builtin): annotate view and optional access intrinsics

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -209,6 +209,7 @@ pub fn[T] Array::at(self : Array[T], index : Int) -> T {
 ///   debug_inspect(arr.get(3), content="None")
 /// }
 /// ```
+#intrinsic("%array.get_opt")
 pub fn[T] Array::get(self : Array[T], index : Int) -> T? {
   let len = self.length()
   guard index >= 0 && index < len else { None }

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -166,6 +166,7 @@ pub fn[T] ArrayView::at(self : ArrayView[T], index : Int) -> T {
 ///   debug_inspect(view.get(5), content="None")
 /// }
 /// ```
+#intrinsic("%arrayview.get_opt")
 pub fn[T] ArrayView::get(self : ArrayView[T], index : Int) -> T? {
   let len = self.length()
   guard index >= 0 && index < len else { None }
@@ -249,6 +250,7 @@ pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
 ///   inspect(view.length(), content="3") // View contains 3 elements
 /// }
 /// ```
+#intrinsic("%array.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")
 pub fn[T] Array::view(
@@ -342,6 +344,7 @@ pub fn[T] Array::get_view(
 ///   inspect(subview[0], content="3")
 /// }
 /// ```
+#intrinsic("%arrayview.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")
 pub fn[T] ArrayView::view(
@@ -439,6 +442,7 @@ fn[T] unsafe_cast_fixedarray_to_uninitializedarray(
 ///   inspect(view[0], content="2")
 /// }
 /// ```
+#intrinsic("%fixedarray.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")
 pub fn[T] FixedArray::view(

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -784,6 +784,7 @@ pub fn Bytes::is_empty(self : Bytes) -> Bool {
 ///   debug_inspect(byte, content="None")
 /// }
 /// ```
+#intrinsic("%bytes.get_opt")
 pub fn Bytes::get(self : Bytes, index : Int) -> Byte? {
   guard index >= 0 && index < self.length() else { None }
   Some(self[index])

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -121,6 +121,7 @@ pub fn BytesView::at(self : BytesView, index : Int) -> Byte {
 ///   debug_inspect(result, content="None")
 /// }
 /// ```
+#intrinsic("%bytesview.get_opt")
 pub fn BytesView::get(self : BytesView, index : Int) -> Byte? {
   guard index >= 0 && index < self.length() else { None }
   Some(self.bytes().unsafe_get(self.start() + index))
@@ -173,6 +174,7 @@ pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {
 ///   @test.assert_eq(bv[2], b'\x03')
 /// }
 /// ```
+#intrinsic("%bytes.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")
 pub fn Bytes::view(self : Bytes, start? : Int = 0, end? : Int) -> BytesView {
@@ -246,6 +248,7 @@ pub fn BytesView::get_view(
 ///   @test.assert_eq(bv2[1], b'\x02')
 /// }
 /// ```
+#intrinsic("%bytesview.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")
 pub fn BytesView::view(

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -33,6 +33,7 @@
 ///   debug_inspect(arr.get(3), content="None")
 /// }
 /// ```
+#intrinsic("%fixedarray.get_opt")
 pub fn[T] FixedArray::get(self : FixedArray[T], idx : Int) -> T? {
   let len = self.length()
   guard idx >= 0 && idx < len else { None }

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -244,6 +244,7 @@ pub fn[T] MutArrayView::unsafe_set(
 ///   inspect(view.length(), content="3") // View contains 3 elements
 /// }
 /// ```
+#intrinsic("%array.mut_view")
 pub fn[T] Array::mut_view(
   self : Array[T],
   start? : Int = 0,
@@ -291,6 +292,7 @@ pub fn[T] Array::mut_view(
 /// }
 /// ```
 // TODO: rename does not work with docstring test
+#intrinsic("%mutarrayview.mut_view")
 pub fn[T] MutArrayView::mut_view(
   self : MutArrayView[T],
   start? : Int = 0,
@@ -334,6 +336,7 @@ pub fn[T] MutArrayView::mut_view(
 ///   inspect(view[0], content="2")
 /// }
 /// ```
+#intrinsic("%fixedarray.mut_view")
 pub fn[T] FixedArray::mut_view(
   self : FixedArray[T],
   start? : Int = 0,
@@ -362,6 +365,7 @@ pub fn[T] FixedArray::mut_view(
 /// * `start` : The starting index in the array (inclusive). Defaults to 0.
 /// * `end` : The ending index in the array (exclusive). Defaults to the
 /// length of the array.
+#intrinsic("%mutarrayview.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")
 pub fn[T] MutArrayView::view(

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -100,6 +100,7 @@ pub fn[T] ReadOnlyArray::makei(
 ///   debug_inspect(arr.get(5), content="None")
 /// }
 /// ```
+#intrinsic("%readonlyarray.get_opt")
 pub fn[T] ReadOnlyArray::get(self : ReadOnlyArray[T], index : Int) -> T? {
   self.unsafe_reinterpret_to_fixed_array().get(index)
 }
@@ -866,6 +867,7 @@ pub fn[T : Compare] ReadOnlyArray::lexical_compare(
 ///   inspect(view[2], content="4")
 /// }
 /// ```
+#intrinsic("%readonlyarray.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")
 pub fn[T] ReadOnlyArray::view(

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -2690,6 +2690,7 @@ test "rev_fold with raise" {
 ///|
 /// Returns the UTF-16 code unit at the given index. Returns `None` if the index
 /// is out of bounds.
+#intrinsic("%string.get_opt")
 pub fn String::get(self : String, idx : Int) -> UInt16? {
   guard idx >= 0 && idx < self.length() else { return None }
   Some(self.unsafe_get(idx))
@@ -2698,6 +2699,7 @@ pub fn String::get(self : String, idx : Int) -> UInt16? {
 ///|
 /// Returns the UTF-16 code unit at the given index. Returns `None` if the index
 /// is out of bounds.
+#intrinsic("%stringview.get_opt")
 pub fn StringView::get(self : StringView, idx : Int) -> UInt16? {
   guard idx >= 0 && idx < self.length() else { return None }
   Some(self.unsafe_get(idx))


### PR DESCRIPTION
## Summary

- annotate checked view and mutable-view constructors with their compiler intrinsics
- annotate Option-returning indexed accessors with the new get_opt intrinsics
- retain the existing MoonBit bodies as fallback implementations

## Testing

- moon info --target wasm,wasm-gc,js,native
- moon fmt
- moon test --target all
- moon test --release --target js,wasm,wasm-gc
- moon bundle --all

moon check --deny-warn --target all is currently blocked by an existing JavaScript FFI Array deprecation in encoding/utf8/decode_js.mbt, outside this diff.