### PR TITLE
fix(js): use FixedArray at JS FFI boundaries returning arrays

### DIFF
--- a/encoding/utf8/decode_js.mbt
+++ b/encoding/utf8/decode_js.mbt
@@ -18,7 +18,7 @@ extern "js" fn decode_utf8_js(
   start : Int,
   len : Int,
   preserve_bom : Bool,
-) -> Array[String] =
+) -> FixedArray[String] =
   #| ((preserveBOMDecoder, dropBOMDecoder) => function(bytes, start, len, preserveBOM) {
   #|   try {
   #|     const end = start + len;

--- a/env/env_js.mbt
+++ b/env/env_js.mbt
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 ///|
-extern "js" fn get_cli_args_internal() -> Array[String] =
+fn get_cli_args_internal() -> Array[String] {
+  Array::from_fixed_array(get_cli_args_ffi())
+}
+
+///|
+extern "js" fn get_cli_args_ffi() -> FixedArray[String] =
   #| function() {
   #|  if (typeof process !== "undefined" && typeof process.argv !== "undefined") {
   #|    return process.argv;
@@ -78,7 +83,7 @@ fn get_env_vars_internal() -> Map[String, String] {
 }
 
 ///|
-extern "js" fn get_env_vars_array_internal() -> Array[String] =
+extern "js" fn get_env_vars_array_internal() -> FixedArray[String] =
   #| function() {
   #|   if (typeof process === "undefined" || typeof process.env === "undefined") {
   #|     return [];


### PR DESCRIPTION
Clears the last three `Using \`Array\` in JavaScript FFI is deprecated` warnings from `moon check --target all`.

On the JS backend `Array[T]` is represented as a `{buf, len}` struct while `FixedArray[T]` is a raw JS array, so an FFI declared `-> Array[String]` that returns a plain JS array hands MoonBit a malformed value.

## Changes

- `encoding/utf8/decode_js.mbt` — `decode_utf8_js` returns `FixedArray[String]`; the `.length()` / `[0]` call site is unchanged.
- `env/env_js.mbt` — `get_env_vars_array_internal` returns `FixedArray[String]`; its consumer only indexes, so no other change.
- `env/env_js.mbt` — `get_cli_args_internal` split into an `extern "js" fn get_cli_args_ffi() -> FixedArray[String]` plus a wrapper doing `Array::from_fixed_array`, since the public `env.args()` returns `Array[String]`.

The `get_cli_args_internal` case was an actual bug, not just a warning: `env.args()` was returning `process.argv` (a raw JS array) typed as `Array[String]`, which it structurally is not.

## Testing

- `moon check --target all` — clean, 0 warnings.
- `moon test --target all` — 7544 wasm, 7544 wasm-gc, 7485 js, 7462 native, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAgzTTZDhJxTvNrBAy2zFc