### PR TITLE
perf(json): index large replacer key sets

### DIFF
--- a/json/json.mbt
+++ b/json/json.mbt
@@ -116,14 +116,48 @@ priv enum WriteFrame {
 ///|
 /// A Replacer provides a way to filter and transform JSON object properties during stringification.
 /// 
-/// Replacers contain a function that takes a property key and value, and returns:
+/// A replacer takes a property key and value, and returns:
 /// - `Some(value)` to include the property in the output (possibly transformed)
 /// - `None` to exclude the property from the output
 /// 
 /// Only applies to object properties, not array elements.
+///
+/// The replacer is consulted at every nesting level, including inside objects
+/// it has just kept, matching JavaScript's `JSON.stringify`. So a replacer that
+/// keeps only `"a"` turns `{"a": {"b": 1}}` into `{"a": {}}` — the nested
+/// `"b"` is filtered by the same rule.
 pub struct Replacer {
-  priv f : (String, Json) -> Json?
+  priv kind : ReplacerKind
 } derive(@debug.Debug)
+
+///|
+priv enum ReplacerKind {
+  Custom((String, Json) -> Json?)
+  Keep(ArrayView[StringView])
+  Exclude(ArrayView[StringView])
+  AdaptiveKeep(ReplacerKeyLookup)
+  AdaptiveExclude(ReplacerKeyLookup)
+} derive(@debug.Debug)
+
+///|
+/// Lookup state for a key set large enough to be worth indexing. The index is
+/// built on first heavy use and then reused for the lifetime of the `Replacer`.
+priv struct ReplacerKeyLookup {
+  keys : ArrayView[StringView]
+  mut linear_lookups : Int
+  mut index : Map[StringView, Unit]?
+} derive(@debug.Debug)
+
+///|
+// Linear scanning beats hashing for very small key sets, even when repeated
+// for every property of a large object.
+const REPLACER_INDEX_MIN_KEY_COUNT = 9
+
+///|
+// Building an index costs O(keys). Delaying it until the replacer has actually
+// been consulted this many times keeps one-shot uses allocation-free and bounds
+// the wasted work to REPLACER_INDEX_LOOKUP_THRESHOLD * keys.
+const REPLACER_INDEX_LOOKUP_THRESHOLD = 64
 
 ///|
 /// Create a new Replacer with a custom function.
@@ -153,12 +187,17 @@ pub struct Replacer {
 /// ```
 #alias(new, deprecated="Use `Replacer()` instead")
 pub fn Replacer::Replacer(f : (String, Json) -> Json?) -> Replacer {
-  { f, }
+  { kind: Custom(f) }
 }
 
 ///|
 /// Create a Replacer that only keeps the specified property keys.
-/// All other properties will be excluded from the output.
+/// All other properties will be excluded from the output, at every nesting
+/// level — `keep(["a"])` turns `{"a": {"b": 1}, "c": 2}` into `{"a": {}}`.
+///
+/// `array` is read while the replacer is in use, and a large key list is
+/// indexed on first heavy use, so mutating `array` afterwards is not
+/// guaranteed to be observed.
 /// 
 /// ## Example
 /// 
@@ -175,12 +214,21 @@ pub fn Replacer::Replacer(f : (String, Json) -> Json?) -> Replacer {
 /// }
 /// ```
 pub fn Replacer::keep(array : ArrayView[StringView]) -> Replacer {
-  { f: (idx, value) => if array.contains(idx) { Some(value) } else { None } }
+  if array.length() < REPLACER_INDEX_MIN_KEY_COUNT {
+    { kind: Keep(array) }
+  } else {
+    { kind: AdaptiveKeep({ keys: array, linear_lookups: 0, index: None }) }
+  }
 }
 
 ///|
 /// Create a Replacer that excludes the specified property keys.
-/// All other properties will be included in the output.
+/// All other properties will be included in the output. Keys are excluded at
+/// every nesting level, not just the top level.
+///
+/// `array` is read while the replacer is in use, and a large key list is
+/// indexed on first heavy use, so mutating `array` afterwards is not
+/// guaranteed to be observed.
 ///
 /// ## Example
 ///
@@ -197,7 +245,42 @@ pub fn Replacer::keep(array : ArrayView[StringView]) -> Replacer {
 /// }
 /// ```
 pub fn Replacer::exclude(array : ArrayView[StringView]) -> Replacer {
-  { f: (idx, value) => if array.contains(idx) { None } else { Some(value) } }
+  if array.length() < REPLACER_INDEX_MIN_KEY_COUNT {
+    { kind: Exclude(array) }
+  } else {
+    { kind: AdaptiveExclude({ keys: array, linear_lookups: 0, index: None }) }
+  }
+}
+
+///|
+fn ReplacerKeyLookup::contains(self : ReplacerKeyLookup, key : String) -> Bool {
+  match self.index {
+    Some(index) => index.contains(key)
+    None =>
+      if self.linear_lookups < REPLACER_INDEX_LOOKUP_THRESHOLD {
+        self.linear_lookups += 1
+        self.keys.contains(key)
+      } else {
+        let index : Map[StringView, Unit] = Map([], capacity=self.keys.length())
+        for indexed_key in self.keys {
+          index[indexed_key] = ()
+        }
+        self.index = Some(index)
+        index.contains(key)
+      }
+  }
+}
+
+///|
+#inline
+fn Replacer::apply(self : Replacer, key : String, value : Json) -> Json? {
+  match self.kind {
+    Custom(f) => f(key, value)
+    Keep(keys) => if keys.contains(key) { Some(value) } else { None }
+    Exclude(keys) => if keys.contains(key) { None } else { Some(value) }
+    AdaptiveKeep(keys) => if keys.contains(key) { Some(value) } else { None }
+    AdaptiveExclude(keys) => if keys.contains(key) { None } else { Some(value) }
+  }
 }
 
 ///|
@@ -348,7 +431,7 @@ pub fn Json::stringify(
               Some((k, v)) => {
                 let mut v2 = v
                 if replacer is Some(replacer) {
-                  if (replacer.f)(k, v) is Some(v) {
+                  if replacer.apply(k, v) is Some(v) {
                     v2 = v
                   } else {
                     continue None
@@ -533,7 +616,7 @@ pub fn Json::transform(self : Self, replacer : Replacer) -> Json {
       .iter()
       .filter_map(pair => {
         let (k, v) = pair
-        if (replacer.f)(k, v) is Some(v2) {
+        if replacer.apply(k, v) is Some(v2) {
           Some((k, v2.transform(replacer)))
         } else {
           None

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -194,6 +194,93 @@ test "stringify with replacer" {
 }
 
 ///|
+/// A key set large enough to be indexed must behave exactly like the linear
+/// path it replaces, including for keys absent from the object.
+test "Replacer::keep and exclude agree across the indexing threshold" {
+  let object = Map([])
+  for i in 0..<40 {
+    object["k\{i}"] = Json::number(i.to_double())
+  }
+  let json = Json::object(object)
+  let small : Array[StringView] = ["k1", "k2", "k3"]
+  let large : Array[StringView] = Array::makei(40, i => "k\{i * 2}")
+  // Small sets scan linearly, large sets build an index; both must agree with
+  // an equivalent custom replacer.
+  for keys in [small, large] {
+    let members = Map(keys.map(k => (k.to_owned(), true)))
+    let kept_by_list = json.stringify(replacer=@json.Replacer::keep(keys))
+    let kept_by_fn = json.stringify(
+      replacer=Replacer((k, v) => {
+        if members.contains(k) {
+          Some(v)
+        } else {
+          None
+        }
+      }),
+    )
+    assert_eq(kept_by_list, kept_by_fn)
+    let dropped_by_list = json.stringify(replacer=@json.Replacer::exclude(keys))
+    let dropped_by_fn = json.stringify(
+      replacer=Replacer((k, v) => {
+        if members.contains(k) {
+          None
+        } else {
+          Some(v)
+        }
+      }),
+    )
+    assert_eq(dropped_by_list, dropped_by_fn)
+  }
+}
+
+///|
+/// A replacer is reusable: the key set it was built from must still be honoured
+/// after the index has been built, and `transform` must agree with `stringify`.
+test "Replacer with an indexed key set is stable across reuse" {
+  let keys : Array[StringView] = Array::makei(12, i => "k\{i}")
+  let keep = @json.Replacer::keep(keys)
+  let exclude = @json.Replacer::exclude(keys)
+  let object = Map([])
+  // Comfortably past the point where the index is built.
+  for i in 0..<200 {
+    object["k\{i}"] = Json::number(i.to_double())
+  }
+  let json = Json::object(object)
+  let expected_keep = "{" +
+    Array::makei(12, i => "\"k\{i}\":\{i}").join(",") +
+    "}"
+  for _ in 0..<3 {
+    assert_eq(json.stringify(replacer=keep), expected_keep)
+    assert_eq(json.transform(keep).stringify(), expected_keep)
+    let dropped = json.stringify(replacer=exclude)
+    assert_false(dropped.contains("\"k0\":"))
+    assert_false(dropped.contains("\"k11\":"))
+    assert_true(dropped.contains("\"k12\":12"))
+    assert_true(dropped.contains("\"k199\":199"))
+  }
+}
+
+///|
+/// `keep` and `exclude` filter every nesting level, like JavaScript's
+/// `JSON.stringify(value, keys)`.
+test "Replacer::keep filters nested objects too" {
+  let json : Json = { "a": { "b": 1, "c": 2 }, "d": 3 }
+  inspect(
+    json.stringify(replacer=@json.Replacer::keep(["a"])),
+    content="{\"a\":{}}",
+  )
+  inspect(
+    json.stringify(replacer=@json.Replacer::keep(["a", "b"])),
+    content="{\"a\":{\"b\":1}}",
+  )
+  let nested : Json = { "a": [{ "b": 1, "z": 9 }] }
+  inspect(
+    nested.stringify(replacer=@json.Replacer::keep(["a"])),
+    content="{\"a\":[{}]}",
+  )
+}
+
+///|
 test "stringify with replace recursively" {
   let json : Json = {
     "a": 1.0,

--- a/json/replacer_bench_test.mbt
+++ b/json/replacer_bench_test.mbt
@@ -1,0 +1,69 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn make_replacer_bench_data(fields : Int) -> (Json, Array[StringView]) {
+  let object = Map([])
+  let keys : Array[StringView] = Array::makei(2500, i => {
+    "key-" + (i * 2).to_string()
+  })
+  for i in 0..<fields {
+    object["key-" + i.to_string()] = Json::number(i.to_double())
+  }
+  (Json::object(object), keys)
+}
+
+///|
+test "bench Json::stringify Replacer::keep keys=2500 fields=5" (it : @bench.T) {
+  let (json, keys) = make_replacer_bench_data(5)
+  let replacer = @json.Replacer::keep(keys)
+  it.bench(fn() { it.keep(json.stringify(replacer~).length()) })
+}
+
+///|
+test "bench Json::stringify Replacer::keep keys=2500 fields=50" (it : @bench.T) {
+  let (json, keys) = make_replacer_bench_data(50)
+  let replacer = @json.Replacer::keep(keys)
+  it.bench(fn() { it.keep(json.stringify(replacer~).length()) })
+}
+
+///|
+test "bench Json::stringify Replacer::keep keys=2500 fields=5000" (
+  it : @bench.T,
+) {
+  let (json, keys) = make_replacer_bench_data(5000)
+  let replacer = @json.Replacer::keep(keys)
+  it.bench(fn() { it.keep(json.stringify(replacer~).length()) })
+}
+
+///|
+test "bench Json::stringify Replacer::keep keys=3 fields=5000" (it : @bench.T) {
+  let (json, _) = make_replacer_bench_data(5000)
+  let keys : Array[StringView] = ["key-0", "key-2500", "key-4999"]
+  let replacer = @json.Replacer::keep(keys)
+  it.bench(fn() { it.keep(json.stringify(replacer~).length()) })
+}
+
+///|
+/// A replacer built fresh for each call must not pay for an index it never
+/// amortizes.
+test "bench Json::stringify Replacer::keep fresh keys=2500 fields=5" (
+  it : @bench.T,
+) {
+  let (json, keys) = make_replacer_bench_data(5)
+  it.bench(fn() {
+    let replacer = @json.Replacer::keep(keys)
+    it.keep(json.stringify(replacer~).length())
+  })
+}

--- a/json/types_test.mbt
+++ b/json/types_test.mbt
@@ -55,7 +55,7 @@ test "Debug for Replacer" {
   @debug.debug_inspect(
     r,
     content=(
-      #|{ f: <function: ...> }
+      #|{ kind: Custom(<function: ...>) }
     ),
   )
 }


### PR DESCRIPTION
Supersedes #4146 — the diagnosis and the original benchmark are @mizchi's; this changes where the index lives so no usage pattern regresses.

## Problem

`Replacer::keep` and `Replacer::exclude` closed over the key array and ran a linear `contains` for every object property, so stringifying an object with many properties against a large key list cost O(properties × keys).

## Approach

The replacer now carries its key set as *data* rather than as a closure, which is what makes indexing possible at all. On top of that:

- Key sets below a small threshold keep scanning linearly — cheaper than hashing at that size.
- Larger sets also scan linearly at first, and only build a `Map[StringView, Unit]` once the replacer has actually been consulted enough times to amortize it. The index then lives on the `Replacer` and is reused for its lifetime.

Deferring the build bounds the wasted work to `threshold × keys` and keeps one-shot uses allocation-free; caching it on the replacer means a reused replacer pays for the index once rather than once per call. `Map[StringView, Unit]` avoids copying every key with `to_owned()`.

## Results

Native, `Json::stringify` with 2,500 keep keys:

| object fields | main | this PR | |
| ---: | ---: | ---: | --- |
| 5 | 7.42 µs | 402.54 ns | 18× faster |
| 50 | 92.91 µs | 3.19 µs | 29× faster |
| 5,000 | 24.31 ms | 391.73 µs | 62× faster |

And the two cases that keep the design honest:

| case | main | this PR | |
| --- | ---: | ---: | --- |
| fresh replacer built per call, 2500 keys / 5 fields | 7.51 µs | 7.56 µs | unchanged |
| 3 keys / 5,000 fields | 91.4 µs | 95.1 µs | **~4% slower** |

That last row is a real regression and it reproduces: matching on the replacer enum costs a little more than the old direct closure call on the small-key hot path. I tried reordering the variants to recover it and it made no difference, so it looks like the indirection itself. It seems a fair trade for the rows above, but flagging it rather than burying it.

## Behaviour

Two things changed that are worth calling out:

**The key array is no longer re-read on every call.** Previously the replacer closed over the `ArrayView`, so mutating it between `stringify` calls was observed. Once a large key set has been indexed that no longer holds. This was an accident of closing over the view rather than an intended contract, so `keep`/`exclude` now document the key list as being read while the replacer is in use, with mutation afterwards not guaranteed to be observed.

**`Replacer`'s `@debug.Debug` output** is now `{ kind: Custom(<function: ...>) }` instead of `{ f: <function: ...> }`, reflecting the new private representation. `derive` is kept, so `pkg.generated.mbti` is byte-identical to main — no public API change.

## Also here

While documenting the above I noticed `keep`/`exclude` filter at *every* nesting level — `keep(["a"])` turns `{"a": {"b": 1}, "c": 2}` into `{"a": {}}`. That matches JavaScript's `JSON.stringify(value, keys)` and is not a change, but every doc comment and README example showed a flat object, so it was easy to be surprised by. Now documented and pinned by a test.

Tests: the new ones check that the indexed path agrees with an equivalent custom replacer for both `keep` and `exclude` across the threshold, that a replacer stays correct when reused after its index is built, and that `transform` agrees with `stringify`.

Validation: 218 tests pass on wasm, wasm-gc, JS and native; `moon check --target all`, `moon info` and `moon fmt` are clean; `pkg.generated.mbti` matches main exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWKp8X7A5VmoV1PxkT8zaS
