### PR TITLE
refactor(argparse): use list pattern and split_once in hyphen-value checks

### DIFF
--- a/argparse/parser_lookup.mbt
+++ b/argparse/parser_lookup.mbt
@@ -105,11 +105,9 @@ fn resolve_help_target(
 
 ///|
 fn split_long(arg : String) -> (StringView, String?) {
-  let parts = [ for part in arg.split("=") => part ]
-  let name = parts[0].strip_prefix("--").unwrap_or(parts[0])
-  if parts.length() <= 1 {
-    (name, None)
-  } else {
-    (name, Some(parts[1:].join("=")))
+  let body = arg.strip_prefix("--").unwrap_or(arg)
+  match body.split_once("=") {
+    Some((name, value)) => (name, Some(value.to_owned()))
+    None => (body, None)
   }
 }

--- a/argparse/parser_positionals.mbt
+++ b/argparse/parser_positionals.mbt
@@ -87,10 +87,9 @@ fn should_parse_as_positional(
     let (name, _) = split_long(arg)
     return long_index.get_from_string(name) is None
   }
-  let short = arg.get_char(1)
-  match short {
-    Some(ch) => short_index.get(ch) is None
-    None => true
+  match arg {
+    ['-', second, ..] => short_index.get(second) is None
+    _ => true
   }
 }
 

--- a/argparse/positionals_test.mbt
+++ b/argparse/positionals_test.mbt
@@ -93,6 +93,20 @@ test "variadic positional keeps accepting hyphen values after first token" {
 }
 
 ///|
+test "allow_hyphen positional yields to a known short flag" {
+  let cmd = @argparse.Command("demo", flags=[FlagArg("quiet", short='q')], positionals=[
+    PositionArg("input", allow_hyphen_values=true),
+  ])
+  let flagged = cmd.parse(argv=["-q"], env=empty_env()) catch { _ => panic() }
+  assert_true(flagged.flags is { "quiet": true, .. })
+  assert_true(flagged.values is { "input"? : None, .. })
+
+  let unknown = cmd.parse(argv=["-z"], env=empty_env()) catch { _ => panic() }
+  assert_true(unknown.values is { "input": ["-z"], .. })
+  assert_true(unknown.flags is { "quiet"? : None, .. })
+}
+
+///|
 test "bounded positional does not greedily consume later required values" {
   let cmd = @argparse.Command("demo", positionals=[
     PositionArg("first", num_args=ValueRange(lower=1, upper=2)),


### PR DESCRIPTION
## Summary

Follow-up to #4158: the same "pattern match instead of manual prefix handling"
idea applied to the two remaining near-miss sites in `argparse`.

- `parser_positionals.mbt` — `should_parse_as_positional` peeked at the second
  character with `get_char(1)` and a `Some/None` match. A nested list pattern
  `['-', second, ..]` says the same thing in one shape and drops the
  unreachable `None` arm (the preceding guards already rule out `-` and
  `--...`; `get_char(1)` is never `None` here because index 1 is always a
  char boundary after the single-code-unit `-`).

- `parser_lookup.mbt` — `split_long` split on `=` and rejoined the tail to
  recover the inline value. `split_once` matches the first separator directly,
  avoiding the intermediate array and the rejoin.

A sweep of the rest of the repo (length-guards, `guard .. is [.. rest]` loops,
`for`-loops with `break false`/`nobreak true`) found no further instances of
the prefix+rest validation shape: the two sites converted in #4158 and the two
here were the only ones.

## Verification
- `moon check argparse` clean
- `moon fmt --check argparse` clean
- `moon test argparse`: 153 passed, 0 failed (incl. new test
  "allow_hyphen positional yields to a known short flag")

Generated with SeekMoon