### PR TITLE
refactor(encoding): use v128 bitstring patterns

### DIFF
--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -29,10 +29,6 @@ fn suppress_unused_v128_import_on_js() -> Unit {
 }
 
 ///|
-#cfg(not(target="js"))
-fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
-
-///|
 fn finish_string(buffer : FixedArray[UInt16], len : Int) -> String {
   if len == buffer.length() {
     unsafe_fixedarray_uint16_to_string(buffer)
@@ -66,40 +62,33 @@ fn decode_scalar(bytes : BytesView) -> String raise Malformed {
 fn decode_v128(bytes : BytesView) -> String raise Malformed {
   let length = bytes.length()
   let result = FixedArray::make(length * 2, b'\x00')
-  let source = unsafe_fixedarray_from_bytes(bytes.data())
-  let source_start = bytes.start_offset()
-  let source_end = source_start + length
-  let mut source_offset = source_start
-  let mut result_offset = 0
-  while source_offset + 16 <= source_end {
-    let block = @v128.v128_load(source, source_offset)
-    let non_ascii = @v128.i8x16_bitmask(block)
-    if non_ascii != 0 {
-      let malformed_offset = source_offset - source_start + non_ascii.ctz()
-      raise Malformed(bytes[malformed_offset:])
+  for rest = bytes, result_offset = 0 {
+    match rest {
+      [v128le(block), .. tail] => {
+        let non_ascii = @v128.i8x16_bitmask(block)
+        if non_ascii != 0 {
+          raise Malformed(bytes[result_offset / 2 + non_ascii.ctz():])
+        }
+        @v128.v128_store(
+          result,
+          result_offset,
+          @v128.i16x8_extend_low_i8x16_u(block),
+        )
+        @v128.v128_store(
+          result,
+          result_offset + 16,
+          @v128.i16x8_extend_high_i8x16_u(block),
+        )
+        continue tail, result_offset + 32
+      }
+      [0..=0x7F as byte, .. tail] => {
+        result.unsafe_set(result_offset, byte)
+        result.unsafe_set(result_offset + 1, b'\x00')
+        continue tail, result_offset + 2
+      }
+      [] => break
+      _ => raise Malformed(bytes[result_offset / 2:])
     }
-    @v128.v128_store(
-      result,
-      result_offset,
-      @v128.i16x8_extend_low_i8x16_u(block),
-    )
-    @v128.v128_store(
-      result,
-      result_offset + 16,
-      @v128.i16x8_extend_high_i8x16_u(block),
-    )
-    source_offset = source_offset + 16
-    result_offset = result_offset + 32
-  }
-  while source_offset < source_end {
-    let byte = source.unsafe_get(source_offset)
-    if byte > b'\x7F' {
-      raise Malformed(bytes[source_offset - source_start:])
-    }
-    result.unsafe_set(result_offset, byte)
-    result.unsafe_set(result_offset + 1, b'\x00')
-    source_offset = source_offset + 1
-    result_offset = result_offset + 2
   }
   result.unsafe_reinterpret_as_bytes().to_unchecked_string()
 }

--- a/encoding/base64/encode_v128.mbt
+++ b/encoding/base64/encode_v128.mbt
@@ -22,12 +22,6 @@
 // stored.
 
 ///|
-/// V128 loads require `FixedArray[Byte]`; these types share a representation
-/// on the linear-memory backends.
-#cfg(any(target="native", target="wasm"))
-fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
-
-///|
 /// Per-class offsets added to a sextet to reach its Base64 character, indexed
 /// by the class computed in `encode_block_v128`:
 /// 0 -> lowercase, 1..=10 -> digits, 11 -> `+`, 12 -> `/`, 13 -> uppercase.
@@ -119,46 +113,49 @@ fn encode_v128(bytes : BytesView, padding : Bool) -> String {
     char_count += if padding { 4 } else { remainder + 1 }
   }
   let out = FixedArray::make(char_count * 2, b'\x00')
-  let src = unsafe_fixedarray_from_bytes(bytes.data())
-  let end = bytes.start_offset() + length
-  let mut index = bytes.start_offset()
-  let mut written = 0
   // The load reads sixteen bytes but only twelve are consumed, so the loop
   // stops four bytes short of the end and the tail is encoded scalar.
-  while end - index >= 16 {
-    let chars = encode_block_v128(@v128.v128_load(src, index))
-    @v128.v128_store(out, written, @v128.i16x8_extend_low_i8x16_u(chars))
-    @v128.v128_store(out, written + 16, @v128.i16x8_extend_high_i8x16_u(chars))
-    index += 12
-    written += 32
-  }
-  while end - index >= 3 {
-    let n = (src[index].to_int() << 16) |
-      (src[index + 1].to_int() << 8) |
-      src[index + 2].to_int()
-    write_code_unit(out, written, BASE64_STD[(n >> 18) & 0x3F])
-    write_code_unit(out, written + 2, BASE64_STD[(n >> 12) & 0x3F])
-    write_code_unit(out, written + 4, BASE64_STD[(n >> 6) & 0x3F])
-    write_code_unit(out, written + 6, BASE64_STD[n & 0x3F])
-    index += 3
-    written += 8
-  }
-  let rest = end - index
-  if rest != 0 {
-    let mut n = src[index].to_int() << 16
-    if rest == 2 {
-      n = n | (src[index + 1].to_int() << 8)
-    }
-    write_code_unit(out, written, BASE64_STD[(n >> 18) & 0x3F])
-    write_code_unit(out, written + 2, BASE64_STD[(n >> 12) & 0x3F])
-    if rest == 2 {
-      write_code_unit(out, written + 4, BASE64_STD[(n >> 6) & 0x3F])
-      if padding {
-        write_code_unit(out, written + 6, b'=')
+  for rest = bytes, written = 0 {
+    match rest {
+      [v128le(block), ..] as current => {
+        let chars = encode_block_v128(block)
+        @v128.v128_store(out, written, @v128.i16x8_extend_low_i8x16_u(chars))
+        @v128.v128_store(
+          out,
+          written + 16,
+          @v128.i16x8_extend_high_i8x16_u(chars),
+        )
+        continue current[12:], written + 32
       }
-    } else if padding {
-      write_code_unit(out, written + 4, b'=')
-      write_code_unit(out, written + 6, b'=')
+      [b0, b1, b2, .. tail] => {
+        let n = (b0.to_int() << 16) | (b1.to_int() << 8) | b2.to_int()
+        write_code_unit(out, written, BASE64_STD[(n >> 18) & 0x3F])
+        write_code_unit(out, written + 2, BASE64_STD[(n >> 12) & 0x3F])
+        write_code_unit(out, written + 4, BASE64_STD[(n >> 6) & 0x3F])
+        write_code_unit(out, written + 6, BASE64_STD[n & 0x3F])
+        continue tail, written + 8
+      }
+      [b0, b1] => {
+        let n = (b0.to_int() << 16) | (b1.to_int() << 8)
+        write_code_unit(out, written, BASE64_STD[(n >> 18) & 0x3F])
+        write_code_unit(out, written + 2, BASE64_STD[(n >> 12) & 0x3F])
+        write_code_unit(out, written + 4, BASE64_STD[(n >> 6) & 0x3F])
+        if padding {
+          write_code_unit(out, written + 6, b'=')
+        }
+        break
+      }
+      [b0] => {
+        let n = b0.to_int() << 16
+        write_code_unit(out, written, BASE64_STD[(n >> 18) & 0x3F])
+        write_code_unit(out, written + 2, BASE64_STD[(n >> 12) & 0x3F])
+        if padding {
+          write_code_unit(out, written + 4, b'=')
+          write_code_unit(out, written + 6, b'=')
+        }
+        break
+      }
+      [] => break
     }
   }
   out.unsafe_reinterpret_as_bytes().to_unchecked_string()

--- a/encoding/hex/encode_v128.mbt
+++ b/encoding/hex/encode_v128.mbt
@@ -22,12 +22,6 @@
 // before being stored.
 
 ///|
-/// V128 loads require `FixedArray[Byte]`; these types share a representation
-/// on the linear-memory backends.
-#cfg(any(target="native", target="wasm"))
-fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
-
-///|
 /// The sixteen hex digits as swizzle-table lanes: lane `n` holds the ASCII
 /// code of the lowercase digit for nibble value `n`.
 #cfg(any(target="native", target="wasm"))
@@ -58,41 +52,36 @@ fn encode_v128(bytes : BytesView) -> String {
   guard length <= 0x1FFF_FFFF else { return encode_scalar(bytes) } // Int::MAX / 4
   // 2 output code units per byte, 2 bytes per UTF-16 code unit
   let out = FixedArray::make(length * 4, b'\x00')
-  let src = unsafe_fixedarray_from_bytes(bytes.data())
-  let base = bytes.start_offset()
-  let end = base + length
   let table = hex_digits_v128()
-  let mut index = base
-  let mut written = 0
-  // written as a subtraction so that a view sitting at the very end of a
-  // large buffer cannot wrap the bound into accepting a short block
-  while end - index >= 16 {
-    let data = @v128.v128_load(src, index)
-    let hi = @v128.i8x16_shr_u(data, 4)
-    let lo = @v128.v128_and_(data, @v128.i8x16_splat(0x0F))
-    // interleave: source byte k produces digits at output positions 2k
-    // (high nibble) and 2k + 1 (low nibble)
-    let first = @v128.i8x16_shuffle(
-      hi, lo, 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23,
-    )
-    let second = @v128.i8x16_shuffle(
-      hi, lo, 8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31,
-    )
-    let d0 = @v128.i8x16_swizzle(table, first)
-    let d1 = @v128.i8x16_swizzle(table, second)
-    @v128.v128_store(out, written, @v128.i16x8_extend_low_i8x16_u(d0))
-    @v128.v128_store(out, written + 16, @v128.i16x8_extend_high_i8x16_u(d0))
-    @v128.v128_store(out, written + 32, @v128.i16x8_extend_low_i8x16_u(d1))
-    @v128.v128_store(out, written + 48, @v128.i16x8_extend_high_i8x16_u(d1))
-    index += 16
-    written += 64
-  }
-  while index < end {
-    let n = src[index].to_int()
-    write_code_unit(out, written, HEX_DIGITS[(n >> 4) & 0x0F])
-    write_code_unit(out, written + 2, HEX_DIGITS[n & 0x0F])
-    index += 1
-    written += 4
+  for rest = bytes, written = 0 {
+    match rest {
+      [v128le(data), .. tail] => {
+        let hi = @v128.i8x16_shr_u(data, 4)
+        let lo = @v128.v128_and_(data, @v128.i8x16_splat(0x0F))
+        // interleave: source byte k produces digits at output positions 2k
+        // (high nibble) and 2k + 1 (low nibble)
+        let first = @v128.i8x16_shuffle(
+          hi, lo, 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23,
+        )
+        let second = @v128.i8x16_shuffle(
+          hi, lo, 8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31,
+        )
+        let d0 = @v128.i8x16_swizzle(table, first)
+        let d1 = @v128.i8x16_swizzle(table, second)
+        @v128.v128_store(out, written, @v128.i16x8_extend_low_i8x16_u(d0))
+        @v128.v128_store(out, written + 16, @v128.i16x8_extend_high_i8x16_u(d0))
+        @v128.v128_store(out, written + 32, @v128.i16x8_extend_low_i8x16_u(d1))
+        @v128.v128_store(out, written + 48, @v128.i16x8_extend_high_i8x16_u(d1))
+        continue tail, written + 64
+      }
+      [byte, .. tail] => {
+        let n = byte.to_int()
+        write_code_unit(out, written, HEX_DIGITS[(n >> 4) & 0x0F])
+        write_code_unit(out, written + 2, HEX_DIGITS[n & 0x0F])
+        continue tail, written + 4
+      }
+      [] => break
+    }
   }
   out.unsafe_reinterpret_as_bytes().to_unchecked_string()
 }

--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -32,19 +32,6 @@ fn suppress_unused_v128_import_on_js() -> Unit {
 
 ///|
 #cfg(not(target="js"))
-// V128 loads require FixedArray[Byte]; these types share a representation on
-// non-JS backends.
-fn unsafe_fixedarray_from_bytes(bytes : Bytes) -> FixedArray[Byte] = "%identity"
-
-///|
-#cfg(not(target="js"))
-fn is_utf16_surrogate(code_unit : UInt16) -> Bool {
-  let code = code_unit.to_int()
-  code >= 0xD800 && code <= 0xDFFF
-}
-
-///|
-#cfg(not(target="js"))
 fn utf16_swap_u16x8(value : V128) -> V128 {
   @v128.i8x16_shuffle(
     value, value, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14,
@@ -71,27 +58,23 @@ fn utf16_needs_scalar_le_v128(bytes : BytesView) -> Bool {
   if bytes.length() % 2 != 0 {
     return true
   }
-  let src = bytes.data()
-  if !bytes.is_empty() &&
-    is_utf16_surrogate(src.unsafe_read_uint16_le(bytes.start_offset())) {
+  if bytes is [u16le(0xD800..=0xDFFF), ..] {
     return true
   }
-  let src_bytes = unsafe_fixedarray_from_bytes(src)
-  let end = bytes.start_offset() + bytes.length()
-  let mut index = bytes.start_offset()
-  while index + 16 <= end {
-    if utf16_v128_has_surrogate(@v128.v128_load(src_bytes, index)) {
-      return true
+  for rest = bytes {
+    match rest {
+      [v128le(block), .. tail] => {
+        if utf16_v128_has_surrogate(block) {
+          return true
+        }
+        continue tail
+      }
+      [u16le(0xD800..=0xDFFF), ..] => return true
+      [u16le(_), .. tail] => continue tail
+      [] => break false
+      _ => break true
     }
-    index += 16
   }
-  while index < end {
-    if is_utf16_surrogate(src.unsafe_read_uint16_le(index)) {
-      return true
-    }
-    index += 2
-  }
-  false
 }
 
 ///|
@@ -100,52 +83,44 @@ fn utf16_needs_scalar_be_v128(bytes : BytesView) -> Bool {
   if bytes.length() % 2 != 0 {
     return true
   }
-  let src = bytes.data()
-  if !bytes.is_empty() &&
-    is_utf16_surrogate(src.unsafe_read_uint16_be(bytes.start_offset())) {
+  if bytes is [u16be(0xD800..=0xDFFF), ..] {
     return true
   }
-  let src_bytes = unsafe_fixedarray_from_bytes(src)
-  let end = bytes.start_offset() + bytes.length()
-  let mut index = bytes.start_offset()
-  while index + 16 <= end {
-    let swapped = utf16_swap_u16x8(@v128.v128_load(src_bytes, index))
-    if utf16_v128_has_surrogate(swapped) {
-      return true
+  for rest = bytes {
+    match rest {
+      [v128le(block), .. tail] => {
+        if utf16_v128_has_surrogate(utf16_swap_u16x8(block)) {
+          return true
+        }
+        continue tail
+      }
+      [u16be(0xD800..=0xDFFF), ..] => return true
+      [u16be(_), .. tail] => continue tail
+      [] => break false
+      _ => break true
     }
-    index += 16
   }
-  while index < end {
-    if is_utf16_surrogate(src.unsafe_read_uint16_be(index)) {
-      return true
-    }
-    index += 2
-  }
-  false
 }
 
 ///|
 #cfg(not(target="js"))
 fn utf16_decode_be_no_surrogate_v128(bytes : BytesView) -> String {
   // The caller guarantees an even byte length with no surrogate code units.
-  let src = bytes.data()
-  let src_bytes = unsafe_fixedarray_from_bytes(src)
   let string_bytes = FixedArray::make(bytes.length(), b'\x00')
-  let end = bytes.start_offset() + bytes.length()
-  let mut index = bytes.start_offset()
-  let mut written = 0
-  while index + 16 <= end {
-    let swapped = utf16_swap_u16x8(@v128.v128_load(src_bytes, index))
-    @v128.v128_store(string_bytes, written, swapped)
-    index += 16
-    written += 16
-  }
-  while index < end {
-    let code_unit = src.unsafe_read_uint16_be(index)
-    string_bytes[written] = (code_unit & 0xFF).to_byte()
-    string_bytes[written + 1] = (code_unit >> 8).to_byte()
-    index += 2
-    written += 2
+  for rest = bytes, written = 0 {
+    match rest {
+      [v128le(block), .. tail] => {
+        @v128.v128_store(string_bytes, written, utf16_swap_u16x8(block))
+        continue tail, written + 16
+      }
+      [u16be(code_unit), .. tail] => {
+        string_bytes.unsafe_set(written, (code_unit & 0xFF).to_byte())
+        string_bytes.unsafe_set(written + 1, (code_unit >> 8).to_byte())
+        continue tail, written + 2
+      }
+      [] => break
+      _ => break
+    }
   }
   string_bytes.unsafe_reinterpret_as_bytes().to_unchecked_string()
 }


### PR DESCRIPTION
## Summary

- replace manual `Bytes`/`FixedArray` conversions and indexed v128 loads with `v128le` bitstring patterns in ASCII, Base64, hex, and UTF-16 codecs
- express scalar tails in the same pattern matches while preserving malformed-input and UTF-16 surrogate behavior
- remove four private `%identity` conversion helpers

The updated compiler scalar-replaces the tail-consuming view loops, so the native hot loops no longer perform per-block reference counting. The Base64 loop retains its source once because its 16-byte load advances by 12 bytes.

## Native spot checks

- ASCII decode: 11.98 us for 100K, 90.08 us for 1M
- Base64 encode: 14.14 us for 64K
- hex encode: 14.11 us for 64K
- UTF-16 ASCII decode: 8.60 us LE, 15.51 us BE for 100K code units

I also tried converting `BytesView::lexical_compare`, but left its indexed loop unchanged because the pattern version was slower.

## Verification

- `moon check --target all` (0 errors; the updated toolchain reports 117 existing qualification warnings in unchanged Buffer docs/tests)
- `moon info --target wasm,wasm-gc,js,native` (no `.mbti` changes)
- `moon test --target all`
  - wasm: 7563 passed
  - wasm-gc: 7563 passed
  - JS: 7504 passed
  - native: 7478 passed
- `moon test --target native --release` (7478 passed)
