### PR TITLE
perf(bigint): use 64-bit limbs on native and wasm

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -46,6 +46,11 @@ Files `internal/strconv/strconv_eisel_lemire.mbt` and
 `internal/strconv/strconv_eisel_lemire_table.mbt` are adapted from Go 1.26.2's
 `internal/strconv/atofeisel.go` and generated `internal/strconv/pow10tab.go`.
 
+Files `bigint/arith_wide.mbt` and `bigint/bigint_wide.mbt` are adapted from
+Go's `math/big` package, specifically `src/math/big/arith.go`,
+`src/math/big/nat.go`, `src/math/big/natmul.go`, and
+`src/math/big/natdiv.go`.
+
 License from Golang:
 Copyright 2009 The Go Authors.
 

--- a/bigint/arith_wide.mbt
+++ b/bigint/arith_wide.mbt
@@ -1,0 +1,619 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Word-level and vector-level arithmetic primitives.
+//
+// Every routine here operates on full 64-bit words (limbs) with base B = 2^64,
+// so a "carry" is a whole word rather than the high half of a 32-bit product.
+//
+// The enabling primitive is `%u64.mul_wide`, which the native backend lowers to
+// a single `unsigned __int128` multiply. Without it, a 64x64->128 product would
+// cost four 32-bit multiplies plus the reassembly, which is exactly what the
+// 32-bit-limb representation already pays.
+
+///|
+/// Result of a 64x64 -> 128 unsigned multiplication.
+///
+/// Must be `#valtype`: native writes the two halves into separate C locals,
+/// while wasm1 can carry the pair as an unboxed value type. wasm-gc does not
+/// compile this file because it cannot represent that result efficiently.
+#valtype
+priv struct UMul {
+  lo : UInt64
+  hi : UInt64
+}
+
+///|
+/// `hi * 2^64 + lo == a * b`
+///
+/// The body is the portable 32x32 schoolbook fallback; on the native backend
+/// `#intrinsic` replaces it with the backend's wide multiply when available.
+/// Native uses `moonbit_umul_wide`; wasm1 currently executes this fallback.
+#intrinsic("%u64.mul_wide")
+fn umul_wide(a : UInt64, b : UInt64) -> UMul {
+  let mask = 0xffffffffUL
+  let alo = a & mask
+  let ahi = a >> 32
+  let blo = b & mask
+  let bhi = b >> 32
+  let ll = alo * blo
+  let lh = alo * bhi
+  let hl = ahi * blo
+  let mid = (ll >> 32) + (lh & mask) + (hl & mask)
+  let hi = ahi * bhi + (lh >> 32) + (hl >> 32) + (mid >> 32)
+  { lo: a * b, hi, }
+}
+
+///|
+/// A quotient/remainder pair from a 128-by-64 division.
+#valtype
+priv struct DivMod {
+  q : UInt64
+  r : UInt64
+}
+
+// Word primitives
+
+///|
+/// `hi * 2^64 + lo == x * y + c`. Cannot overflow: the maximum is
+/// (2^64-1)^2 + (2^64-1) = 2^128 - 2^64.
+fn mul_add_www(x : UInt64, y : UInt64, c : UInt64) -> UMul {
+  let m = umul_wide(x, y)
+  let lo = m.lo + c
+  { lo, hi: m.hi + (lo < m.lo).to_uint64(), }
+}
+
+///|
+/// Number of leading zero bits, as an `Int`.
+fn nlz(x : UInt64) -> Int {
+  x.clz()
+}
+
+///|
+/// `q, r = (u1 * 2^64 + u0) / v`, requiring `u1 < v` and `v != 0`.
+///
+/// Hacker's Delight `divlu`: a 128/64 division synthesized from four 64/64
+/// hardware divisions on 32-bit half-words. This is the slow path, used only to
+/// build the reciprocal below (once per big division), never in an inner loop.
+fn div_ww_slow(u1 : UInt64, u0 : UInt64, v : UInt64) -> DivMod {
+  let b = 1UL << 32
+  let s = nlz(v)
+  let v = v << s
+  let vn1 = v >> 32
+  let vn0 = v & 0xffffffffUL
+  // `u1 << 64 - s` is undefined for s == 0, so special-case it.
+  let un32 = if s == 0 { u1 } else { (u1 << s) | (u0 >> (64 - s)) }
+  let un10 = u0 << s
+  let un1 = un10 >> 32
+  let un0 = un10 & 0xffffffffUL
+  let mut q1 = un32 / vn1
+  let mut rhat = un32 - q1 * vn1
+  while q1 >= b || q1 * vn0 > b * rhat + un1 {
+    q1 -= 1
+    rhat += vn1
+    if rhat >= b {
+      break
+    }
+  }
+  let un21 = un32 * b + un1 - q1 * v
+  let mut q0 = un21 / vn1
+  rhat = un21 - q0 * vn1
+  while q0 >= b || q0 * vn0 > b * rhat + un0 {
+    q0 -= 1
+    rhat += vn1
+    if rhat >= b {
+      break
+    }
+  }
+  { q: (q1 << 32) | q0, r: (un21 * b + un0 - q0 * v) >> s, }
+}
+
+///|
+/// `floor((2^128 - 1) / d) - 2^64` for a normalized `d` (top bit set).
+///
+/// This is the Möller-Granlund 2/1 reciprocal. Computed once per division, so
+/// the slow software 128/64 path is fine here.
+fn reciprocal_word(d : UInt64) -> UInt64 {
+  div_ww_slow(d.lnot(), 0xffff_ffff_ffff_ffffUL, d).q
+}
+
+///|
+/// `q, r = (u1 * 2^64 + u0) / d` using a precomputed reciprocal `v`.
+///
+/// Requires `d` normalized (top bit set) and `u1 < d`. Möller-Granlund
+/// "Improved division by invariant integers", Algorithm 4. Two wide multiplies
+/// and a couple of conditional fixups replace a hardware 128/64 divide.
+fn div2by1(u1 : UInt64, u0 : UInt64, d : UInt64, v : UInt64) -> DivMod {
+  let m = umul_wide(v, u1)
+  // (q1, q0) = m + (u1, u0)
+  let q0 = m.lo + u0
+  let q1 = m.hi + u1 + (q0 < m.lo).to_uint64()
+  let q1 = q1 + 1
+  let mut r = u0 - q1 * d
+  let mut q1 = q1
+  if r > q0 {
+    q1 -= 1
+    r += d
+  }
+  if r >= d {
+    q1 += 1
+    r -= d
+  }
+  { q: q1, r, }
+}
+
+///|
+/// True when `(x1, x2) > (y1, y2)` as 128-bit values.
+fn greater_than(x1 : UInt64, x2 : UInt64, y1 : UInt64, y2 : UInt64) -> Bool {
+  x1 > y1 || (x1 == y1 && x2 > y2)
+}
+
+// Vector primitives
+//
+// Each takes explicit offsets and a length so callers can operate on slices of
+// a shared buffer without allocating views.
+
+///|
+/// `z[zi..zi+n] = x[xi..xi+n] + y[yi..yi+n]`, returns the carry out (0 or 1).
+fn add_vv(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  y : FixedArray[UInt64],
+  yi : Int,
+  n : Int,
+) -> UInt64 {
+  for i in 0..<n; c = 0UL {
+    let a = x.unsafe_get(xi + i)
+    let s = a + y.unsafe_get(yi + i)
+    let c1 = (s < a).to_uint64()
+    let t = s + c
+    z.unsafe_set(zi + i, t)
+    continue c1 + (t < s).to_uint64()
+  } nobreak {
+    c
+  }
+}
+
+///|
+/// `z[zi..zi+n] = x[xi..xi+n] - y[yi..yi+n]`, returns the borrow out (0 or 1).
+fn sub_vv(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  y : FixedArray[UInt64],
+  yi : Int,
+  n : Int,
+) -> UInt64 {
+  for i in 0..<n; c = 0UL {
+    let a = x.unsafe_get(xi + i)
+    let b = y.unsafe_get(yi + i)
+    let d = a - b
+    let c1 = (a < b).to_uint64()
+    let t = d - c
+    z.unsafe_set(zi + i, t)
+    continue c1 + (d < c).to_uint64()
+  } nobreak {
+    c
+  }
+}
+
+///|
+/// `z[zi..zi+n] = x[xi..xi+n] + y`, returns the carry out.
+fn add_vw(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  y : UInt64,
+  n : Int,
+) -> UInt64 {
+  for i in 0..<n; c = y {
+    if c == 0 {
+      // Carry died; the rest is a straight copy.
+      if !(physical_equal(z, x) && zi == xi) {
+        for j in i..<n {
+          z.unsafe_set(zi + j, x.unsafe_get(xi + j))
+        }
+      }
+      return 0
+    }
+    let a = x.unsafe_get(xi + i)
+    let s = a + c
+    z.unsafe_set(zi + i, s)
+    continue (s < a).to_uint64()
+  } nobreak {
+    c
+  }
+}
+
+///|
+/// `z[zi..zi+n] = x[xi..xi+n] - y`, returns the borrow out.
+fn sub_vw(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  y : UInt64,
+  n : Int,
+) -> UInt64 {
+  for i in 0..<n; c = y {
+    if c == 0 {
+      if !(physical_equal(z, x) && zi == xi) {
+        for j in i..<n {
+          z.unsafe_set(zi + j, x.unsafe_get(xi + j))
+        }
+      }
+      return 0
+    }
+    let a = x.unsafe_get(xi + i)
+    let d = a - c
+    z.unsafe_set(zi + i, d)
+    continue (a < c).to_uint64()
+  } nobreak {
+    c
+  }
+}
+
+///|
+/// `z[zi..zi+n] = x[xi..xi+n] * y + r`, returns the high carry word.
+///
+/// This is the n-by-1 multiply used by `mul_single_limb` and by the Knuth-D
+/// "multiply and subtract" step.
+fn mul_add_vww(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  y : UInt64,
+  r : UInt64,
+  n : Int,
+) -> UInt64 {
+  for i in 0..<n; c = r {
+    let m = mul_add_www(x.unsafe_get(xi + i), y, c)
+    z.unsafe_set(zi + i, m.lo)
+    continue m.hi
+  } nobreak {
+    c
+  }
+}
+
+///|
+/// `z[zi..zi+n] += x[xi..xi+n] * m`, returns the carry out.
+///
+/// The schoolbook multiply inner loop. Each step computes
+/// `x[i]*m + z[i] + carry`, which is at most
+/// (2^64-1)^2 + 2*(2^64-1) = 2^128 - 1, so the running carry is a full word and
+/// never overflows.
+fn add_mul_vvw(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  m : UInt64,
+  n : Int,
+) -> UInt64 {
+  for i in 0..<n; c = 0UL {
+    let p = umul_wide(x.unsafe_get(i + xi), m)
+    let zv = z.unsafe_get(zi + i)
+    let t0 = p.lo + zv
+    let cc0 = (t0 < p.lo).to_uint64()
+    let t1 = t0 + c
+    let cc1 = (t1 < t0).to_uint64()
+    z.unsafe_set(zi + i, t1)
+    continue p.hi + cc0 + cc1
+  } nobreak {
+    c
+  }
+}
+
+// Multiplication over limb vectors
+//
+// The scratch layout uses explicit base offsets into one shared array.
+
+///|
+/// `z[zi .. zi+an+bn) = x[xi..xi+an) * y[yi..yi+bn)`.
+///
+/// `z` need not be zeroed. The first row writes rather than accumulates, and a
+/// row skipped for a zero multiplier still stores its (zero) carry, so no read
+/// ever sees a word this call has not written. Karatsuba relies on that: its
+/// `z` is scratch space still holding earlier partial products.
+fn basic_mul(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  an : Int,
+  y : FixedArray[UInt64],
+  yi : Int,
+  bn : Int,
+) -> Unit {
+  z.unsafe_set(zi + an, mul_add_vww(z, zi, x, xi, y.unsafe_get(yi), 0, an))
+  for j in 1..<bn {
+    let m = y.unsafe_get(yi + j)
+    if m != 0 {
+      z.unsafe_set(zi + j + an, add_mul_vvw(z, zi + j, x, xi, m, an))
+    } else {
+      z.unsafe_set(zi + j + an, 0)
+    }
+  }
+}
+
+///|
+/// The largest `k <= n` of the form `t << i` with `t <= threshold`. Splitting
+/// at `k` makes every level of the recursion divide evenly, which is what lets
+/// the scratch layout below be a fixed size.
+fn karatsuba_len(n : Int, threshold : Int) -> Int {
+  let mut n = n
+  let mut i = 0
+  while n > threshold {
+    n = n >> 1
+    i += 1
+  }
+  n << i
+}
+
+///|
+/// `z[zi..zi+n) += x[xi..xi+n)`, with the carry absorbed by the following
+/// `n/2` words.
+fn karatsuba_add(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  n : Int,
+) -> Unit {
+  let c = add_vv(z, zi, z, zi, x, xi, n)
+  if c != 0 {
+    ignore(add_vw(z, zi + n, z, zi + n, c, n >> 1))
+  }
+}
+
+///|
+/// `z[zi..zi+n) -= x[xi..xi+n)`, with the borrow absorbed by the following
+/// `n/2` words.
+fn karatsuba_sub(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  n : Int,
+) -> Unit {
+  let c = sub_vv(z, zi, z, zi, x, xi, n)
+  if c != 0 {
+    ignore(sub_vw(z, zi + n, z, zi + n, c, n >> 1))
+  }
+}
+
+///|
+/// `z[zi..zi+2n) = x[xi..xi+n) * y[yi..yi+n)`.
+///
+/// `z` must have `6*n` words available from `zi`; the low `2n` receive the
+/// product and the rest is scratch. Callers get `n` from `karatsuba_len`, which
+/// guarantees the halving stays exact.
+///
+/// This identity needs one subtraction product rather than the textbook
+/// `(xh+xl)*(yh+yl)`, so no intermediate can carry past `n` words:
+///
+///   xd = x1 - x0,  yd = y0 - y1
+///   x*y = z2*B^2 + (xd*yd + z2 + z0)*B + z0    with z0 = x0*y0, z2 = x1*y1
+fn karatsuba(
+  z : FixedArray[UInt64],
+  zi : Int,
+  x : FixedArray[UInt64],
+  xi : Int,
+  y : FixedArray[UInt64],
+  yi : Int,
+  n : Int,
+) -> Unit {
+  if n % 2 != 0 || n < KARATSUBA_THRESHOLD || n < 2 {
+    basic_mul(z, zi, x, xi, n, y, yi, n)
+    return
+  }
+  let n2 = n >> 1
+  // z = [ .. | .. | xd*yd | yd:xd | x1*y1 | x0*y0 ]  (0, n, 2n, 3n, 4n, 6n)
+  karatsuba(z, zi, x, xi, y, yi, n2) // z0 = x0*y0
+  karatsuba(z, zi + n, x, xi + n2, y, yi + n2, n2) // z2 = x1*y1
+
+  // |x1-x0| and |y0-y1|, carrying the sign of their product in `s`.
+  let mut s = 1
+  let xd = zi + 2 * n
+  if sub_vv(z, xd, x, xi + n2, x, xi, n2) != 0 {
+    s = -s
+    ignore(sub_vv(z, xd, x, xi, x, xi + n2, n2))
+  }
+  let yd = xd + n2
+  if sub_vv(z, yd, y, yi, y, yi + n2, n2) != 0 {
+    s = -s
+    ignore(sub_vv(z, yd, y, yi + n2, y, yi, n2))
+  }
+  let p = zi + 3 * n
+  karatsuba(z, p, z, xd, z, yd, n2)
+
+  // Stash z2:z0 above p's result; the recursion is done, so z[4n..6n) is free.
+  let r = zi + 4 * n
+  z.unsafe_blit(r, z, zi, 2 * n)
+  karatsuba_add(z, zi + n2, z, r, n) // + z0 << n2
+  karatsuba_add(z, zi + n2, z, r + n, n) // + z2 << n2
+  if s > 0 {
+    karatsuba_add(z, zi + n2, z, p, n)
+  } else {
+    karatsuba_sub(z, zi + n2, z, p, n)
+  }
+}
+
+///|
+/// `z[i..zn) += x[0..xn)`.
+fn add_at(
+  z : FixedArray[UInt64],
+  zn : Int,
+  x : FixedArray[UInt64],
+  xn : Int,
+  i : Int,
+) -> Unit {
+  if xn == 0 {
+    return
+  }
+  let c = add_vv(z, i, z, i, x, 0, xn)
+  if c != 0 {
+    let j = i + xn
+    if j < zn {
+      ignore(add_vw(z, j, z, j, c, zn - j))
+    }
+  }
+}
+
+///|
+/// `q[0..n] = x[0..n] / d`, returns `x[0..n] % d`.
+///
+/// `s` must be `nlz(d)`, `dn` must be `d << s`, and `rec`
+/// `reciprocal_word(dn)`; hoisting them out lets a caller amortize the
+/// reciprocal across repeated divisions by the same `d` (decimal printing does
+/// exactly this).
+///
+/// `q` may alias `x`: step `i` reads `x[i]` and `x[i-1]` before writing `q[i]`,
+/// and later steps only look further down.
+fn div_w(
+  q : FixedArray[UInt64],
+  x : FixedArray[UInt64],
+  n : Int,
+  dn : UInt64,
+  rec : UInt64,
+  s : Int,
+) -> UInt64 {
+  let mut r = 0UL
+  if s == 0 {
+    for i = n - 1; i >= 0; i = i - 1 {
+      let dm = div2by1(r, x.unsafe_get(i), dn, rec)
+      q.unsafe_set(i, dm.q)
+      r = dm.r
+    }
+    return r
+  }
+  // Divide `x << s` by `d << s` without materializing the shifted dividend:
+  // limb i of the shifted value is `(x[i] << s) | (x[i-1] >> (64-s))`, and the
+  // bits shifted off the top become the initial remainder.
+  let t = 64 - s
+  r = x.unsafe_get(n - 1) >> t
+  for i = n - 1; i >= 0; i = i - 1 {
+    let cur = x.unsafe_get(i)
+    let lower = if i > 0 { x.unsafe_get(i - 1) } else { 0UL }
+    let dm = div2by1(r, (cur << s) | (lower >> t), dn, rec)
+    q.unsafe_set(i, dm.q)
+    r = dm.r
+  }
+  r >> s
+}
+
+// Montgomery arithmetic
+
+///|
+/// `-m^-1 mod 2^64`, the Montgomery constant. Requires `m` odd.
+///
+/// Newton-Raphson on the 2-adic inverse (Dumas, "On Newton-Raphson Iteration
+/// for Multiplicative Inverses Modulo Prime Powers"): each round doubles the
+/// number of correct low bits, so six rounds cover 64.
+fn mont_k0(m0 : UInt64) -> UInt64 {
+  let mut k0 = 2UL - m0
+  let mut t = m0 - 1
+  let mut i = 1
+  while i < 64 {
+    t = t * t
+    k0 = k0 * (t + 1)
+    i = i << 1
+  }
+  0UL - k0
+}
+
+///|
+/// `out[0..n) = x * y * R^-1 mod m` where `R = 2^(64n)` and `k = -m^-1 mod 2^64`.
+///
+/// `x`, `y` and `m` are each exactly `n` limbs; `t` is `2n` words of scratch.
+/// Interleaved multiply-and-reduce (CIOS) keeps the intermediate within `2n`
+/// words and requires no division.
+///
+/// `out` must not alias `x`, `y` or `m`.
+fn montgomery(
+  out : FixedArray[UInt64],
+  x : FixedArray[UInt64],
+  y : FixedArray[UInt64],
+  m : FixedArray[UInt64],
+  k : UInt64,
+  n : Int,
+  t : FixedArray[UInt64],
+) -> Unit {
+  // Only the low half needs clearing; t[n..2n) is written as the loop advances.
+  for i in 0..<n {
+    t.unsafe_set(i, 0)
+  }
+  for i in 0..<n; c = 0UL {
+    let c2 = add_mul_vvw(t, i, x, 0, y.unsafe_get(i), n)
+    // Choose the multiple of m that zeroes limb i.
+    let c3 = add_mul_vvw(t, i, m, 0, t.unsafe_get(i) * k, n)
+    let cx = c + c2
+    let cy = cx + c3
+    t.unsafe_set(n + i, cy)
+    continue if cx < c2 || cy < c3 { 1 } else { 0 }
+  } nobreak {
+    // The result is t[n..2n), one conditional subtraction away from reduced.
+    if c != 0 {
+      ignore(sub_vv(out, 0, t, n, m, 0, n))
+    } else {
+      out.unsafe_blit(0, t, n, n)
+    }
+  }
+}
+
+///|
+/// `z[0..n] = x[0..n] << s` for `0 < s < 64`, returns the bits shifted out.
+fn shl_vu(
+  z : FixedArray[UInt64],
+  x : FixedArray[UInt64],
+  s : Int,
+  n : Int,
+) -> UInt64 {
+  if n == 0 {
+    return 0
+  }
+  let t = 64 - s
+  let c = x.unsafe_get(n - 1) >> t
+  for i = n - 1; i > 0; i = i - 1 {
+    z.unsafe_set(i, (x.unsafe_get(i) << s) | (x.unsafe_get(i - 1) >> t))
+  }
+  z.unsafe_set(0, x.unsafe_get(0) << s)
+  c
+}
+
+///|
+/// `z[0..n] = x[0..n] >> s` for `0 < s < 64`, returns the bits shifted out
+/// (in the high end of the word).
+fn shr_vu(
+  z : FixedArray[UInt64],
+  x : FixedArray[UInt64],
+  s : Int,
+  n : Int,
+) -> UInt64 {
+  if n == 0 {
+    return 0
+  }
+  let t = 64 - s
+  let c = x.unsafe_get(0) << t
+  for i in 0..<(n - 1) {
+    z.unsafe_set(i, (x.unsafe_get(i) >> s) | (x.unsafe_get(i + 1) << t))
+  }
+  z.unsafe_set(n - 1, x.unsafe_get(n - 1) >> s)
+  c
+}

--- a/bigint/bigint_default.mbt
+++ b/bigint/bigint_default.mbt
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// The default implementation retains 32-bit limbs. In particular, wasm-gc
+// cannot currently represent wide arithmetic's multi-value results without a
+// performance regression.
+
 ///|
 /// A big integer represented as an array of Int.
 //
@@ -1472,7 +1476,7 @@ pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
   let byte_per_limb = RADIX_BIT_LEN / 8
   // tail: at RADIX_BIT_LEN == 32 a limb is exactly one big-endian 32-bit word,
   // so the shift-accumulate loop collapses to a single u32be read. That
-  // constant is pinned by a test in bigint_nonjs_wbtest.mbt, so narrowing it
+  // constant is pinned by a test in bigint_default_wbtest.mbt, so narrowing it
   // fails there rather than silently mis-decoding here.
   for i in 0..<div {
     guard! input[len - byte_per_limb - i * byte_per_limb:] is [u32be(word), ..]

--- a/bigint/bigint_default_wbtest.mbt
+++ b/bigint/bigint_default_wbtest.mbt
@@ -1,0 +1,199 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// White-box tests for the default 32-bit-limb implementation.
+
+///|
+priv struct MyBigInt(BigInt)
+
+///|
+impl Show for MyBigInt with fn output(self, logger) {
+  logger <+
+    "{limbs : \{@debug.Repr(self.limbs)}, sign : \{@debug.Repr(self.sign)}, len : \{self.len} }"
+}
+
+///|
+test "debug_string" {
+  let buf = StringBuilder()
+  let v : Array[MyBigInt] = [0, 1, 2, 3, 4, -0, -1, -2, -3]
+  (buf as &Logger).write_iter(v.iter(), sep="\n", prefix="", suffix="")
+  // Logger::writer_iter()
+  // trait logger has no method write_iter
+  // precise:
+  // (dyn Logger)::write_iter(buf,..)
+  //  Logger::trait_method()
+  inspect(
+    buf,
+    content=(
+      #|{limbs : <FixedArray: [0, 0]>, sign : Positive, len : 1 }
+      #|{limbs : <FixedArray: [1, 0]>, sign : Positive, len : 1 }
+      #|{limbs : <FixedArray: [2, 0]>, sign : Positive, len : 1 }
+      #|{limbs : <FixedArray: [3, 0]>, sign : Positive, len : 1 }
+      #|{limbs : <FixedArray: [4, 0]>, sign : Positive, len : 1 }
+      #|{limbs : <FixedArray: [0, 0]>, sign : Positive, len : 1 }
+      #|{limbs : <FixedArray: [1, 0]>, sign : Negative, len : 1 }
+      #|{limbs : <FixedArray: [2, 0]>, sign : Negative, len : 1 }
+      #|{limbs : <FixedArray: [3, 0]>, sign : Negative, len : 1 }
+    ),
+  )
+}
+
+///|
+fn check_invariant(a : BigInt) -> Unit raise {
+  guard a.len > 0 else { fail("invariant len > 0 is broken: len = \{a.len}") }
+  for i in 0..<a.len {
+    guard a.limbs[i].to_uint64() < RADIX else {
+      fail(
+        "invariant forall 0 <= i < len. 0 <= limbs[i] < radix is broken: a.limbs[\{i}] = \{a.limbs[i]}",
+      )
+    }
+  }
+  if a.limbs.iter().take(a.len).any(x => x > 0) {
+    guard a.limbs[a.len - 1] > 0 else {
+      fail(
+        "invariant (exists 0 <= i < len. limbs[i] > 0) => limbs[len-1] > 0 is broken",
+      )
+    }
+  } else {
+    guard a.len == 1 && a.limbs[0] == 0 else {
+      fail(
+        "invariant (forall 0 <= i < len. limbs[i] == 0) => limbs[0] == 0 and len == 1 is broken: len = \{a.len}, limbs = \{@debug.Repr(a.limbs)}",
+      )
+    }
+  }
+  guard a.limbs.iter().drop(a.len).all(x => x == 0) else {
+    fail(
+      "invariant forall len <= i < limbs.length(). limbs[i] == 0 is broken: len = \{a.len}, limbs = \{@debug.Repr(a.limbs)}",
+    )
+  }
+}
+
+///|
+test "shr" {
+  let a = BigInt::from_int64(1234567890123456789L)
+  let b = a >> 1
+  check_invariant(b)
+  inspect(b, content="617283945061728394")
+  let c = a >> 64
+  check_invariant(c)
+  inspect(c, content="0")
+  // 2^63 spans two 32-bit limbs; shifting right by 2 * RADIX_BIT_LEN bits
+  // (64) drops both limbs to 0. Built as a BigInt because 2^63 overflows the
+  // UInt64 product RADIX * RADIX (= 2^64, wraps to 0) and Int64's range.
+  let a = 1N << 63
+  let b = a >> (RADIX_BIT_LEN * 2)
+  check_invariant(b)
+  inspect(b, content="0")
+}
+
+///|
+test "mul_single_limb boundaries" {
+  // 1-limb x 1-limb with maximal carry-out: (2^32 - 1)^2
+  let max_limb = 4294967295N
+  let p = max_limb * max_limb
+  check_invariant(p)
+  inspect(p, content="18446744065119617025")
+  // all-max limbs: (2^96 - 1) * (2^32 - 1), carry grows len to n + 1
+  let a = (1N << 96) - 1N
+  let p = a * max_limb
+  check_invariant(p)
+  inspect(p, content="340282366841710300949110269833929293825")
+  // commuted operand order takes the same fast path
+  let p = max_limb * a
+  check_invariant(p)
+  inspect(p, content="340282366841710300949110269833929293825")
+  // no carry-out: len stays at self.len, the spare limb beyond len stays zero
+  let p = (1N << 64) * 2N
+  check_invariant(p)
+  inspect(p, content="36893488147419103232")
+  // the dispatch applies the sign on top of the magnitude-only helper
+  inspect(a * -max_limb, content="-340282366841710300949110269833929293825")
+  inspect(-a * max_limb, content="-340282366841710300949110269833929293825")
+  inspect(-a * -max_limb, content="340282366841710300949110269833929293825")
+  // fast path agrees with the general routine on the same magnitudes
+  let fast = a.mul_single_limb(4294967295U)
+  check_invariant(fast)
+  @test.assert_eq(fast, a.grade_school_mul(max_limb))
+}
+
+///|
+test "add coverage for max(self_len, other_len)" {
+  let a = BigInt::from_int(123456789)
+  let b = BigInt::from_int(987654321)
+  let result = a + b
+  inspect(a.len, content="1")
+  inspect(b.len, content="1")
+  inspect(result.len, content="1")
+}
+
+///|
+test "sub coverage for max(self_len, other_len)" {
+  let a = BigInt::from_int(987654321)
+  let b = BigInt::from_int(123456789)
+  let result = a - b
+  inspect(a.len, content="1")
+  inspect(b.len, content="1")
+  inspect(result.len, content="1")
+}
+
+///|
+test "BigInt::bit_length" {
+  inspect(0N.bit_length(), content="0")
+  inspect(1N.bit_length(), content="1")
+  inspect((-1N).bit_length(), content="0")
+  inspect(16N.bit_length(), content="5")
+  inspect((-16N).bit_length(), content="4")
+  inspect(42N.bit_length(), content="6")
+  inspect((-42N).bit_length(), content="6")
+  inspect(1024N.bit_length(), content="11")
+  inspect(10000000N.bit_length(), content="24")
+  inspect((1N << 31).bit_length(), content="32")
+  inspect((1N << 63).bit_length(), content="64")
+}
+
+///|
+test "BigInt::ctz" {
+  inspect(0N.ctz(), content="0")
+  inspect(1N.ctz(), content="0")
+  inspect(8N.ctz(), content="3") // 1000
+  inspect(12N.ctz(), content="2") // 1100
+  inspect(174056N.ctz(), content="3") // 101010011111101000
+  inspect((1N << 31).ctz(), content="31")
+  inspect((1N << 63).ctz(), content="63")
+}
+
+///|
+test {
+  inspect(
+    MyBigInt(-9223372036854775809N),
+    content="{limbs : <FixedArray: [1, 2147483648, 0]>, sign : Negative, len : 2 }",
+  ) // Int64.min_value - 1
+  inspect(
+    MyBigInt(-9223372036854775810N),
+    content="{limbs : <FixedArray: [2, 2147483648, 0]>, sign : Negative, len : 2 }",
+  ) // Int64.min_value - 2
+}
+
+///|
+/// `BigInt::from_octets` reads each tail limb with a single `u32be` bits
+/// pattern, which agrees with the shift-accumulate loop it replaced only when a
+/// limb is exactly four bytes wide. Pin the constant here so narrowing it fails
+/// this test instead of silently mis-decoding octets.
+///
+/// Deliberately `assert_eq` rather than `inspect`: a snapshot would be rewritten
+/// by `moon test --update`, which would silently retire this guard at exactly
+/// the moment it is supposed to fire.
+test "from_octets assumes 32-bit limbs" {
+  @test.assert_eq(RADIX_BIT_LEN, 32)
+}

--- a/bigint/bigint_wide.mbt
+++ b/bigint/bigint_wide.mbt
@@ -1,0 +1,1195 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A sign-magnitude arbitrary-precision integer over 64-bit limbs.
+//
+// Native and wasm1 use `FixedArray[UInt64]` limbs with base 2^64. wasm-gc
+// retains 32-bit limbs, and JavaScript keeps its host-BigInt implementation.
+//
+// Invariants:
+// - len > 0
+// - (exists 0 <= i < len. limbs[i] > 0) => limbs[len-1] > 0
+// - (forall 0 <= i < len. limbs[i] == 0) => limbs[0] == 0 and len == 1
+// - forall len <= i < limbs.length(). limbs[i] == 0
+
+///|
+#valtype
+struct BigInt {
+  limbs : FixedArray[UInt64]
+  sign : Sign
+  len : Int
+}
+
+///|
+priv enum Sign {
+  Positive
+  Negative
+} derive(Eq)
+
+///|
+/// Switch from schoolbook to Karatsuba at this many limbs.
+const KARATSUBA_THRESHOLD = 64
+
+///|
+/// Number of bits represented by each wide limb.
+const RADIX_BIT_LEN = 64
+
+///|
+let zero : BigInt = { limbs: FixedArray::make(1, 0UL), sign: Positive, len: 1, }
+
+///|
+let one : BigInt = { limbs: FixedArray::make(1, 1UL), sign: Positive, len: 1, }
+
+// Construction
+
+///|
+fn make(len : Int) -> FixedArray[UInt64] {
+  FixedArray::make(len, 0UL)
+}
+
+///|
+/// Drop leading zero limbs; never returns less than 1.
+fn normalize_len(limbs : FixedArray[UInt64], max_len : Int) -> Int {
+  let mut i = max_len
+  while i > 1 && limbs.unsafe_get(i - 1) == 0 {
+    i -= 1
+  }
+  i
+}
+
+///|
+/// Creates a non-negative `BigInt` from an unsigned 64-bit integer.
+pub fn BigInt::from_uint64(n : UInt64) -> BigInt {
+  { limbs: FixedArray::make(1, n), sign: Positive, len: 1, }
+}
+
+///|
+/// Creates a non-negative `BigInt` from an unsigned 32-bit integer.
+pub fn BigInt::from_uint(n : UInt) -> BigInt {
+  BigInt::from_uint64(n.to_uint64())
+}
+
+///|
+/// Creates a `BigInt` from a signed 64-bit integer.
+pub fn BigInt::from_int64(n : Int64) -> BigInt {
+  if n == 0 {
+    return zero
+  }
+  if n < 0 {
+    // Negating Int64::MIN overflows, so go through the unsigned domain.
+    let mag = 0UL - n.reinterpret_as_uint64()
+    { limbs: FixedArray::make(1, mag), sign: Negative, len: 1, }
+  } else {
+    {
+      limbs: FixedArray::make(1, n.reinterpret_as_uint64()),
+      sign: Positive,
+      len: 1,
+    }
+  }
+}
+
+///|
+/// Creates a `BigInt` from a signed 32-bit integer.
+pub fn BigInt::from_int(n : Int) -> BigInt {
+  BigInt::from_int64(n.to_int64())
+}
+
+///|
+/// Returns whether this integer is zero.
+pub fn BigInt::is_zero(self : BigInt) -> Bool {
+  self.len == 1 && self.limbs.unsafe_get(0) == 0
+}
+
+///|
+fn BigInt::with_sign(self : BigInt, sign : Sign) -> BigInt {
+  if self.is_zero() {
+    self
+  } else {
+    { ..self, sign, }
+  }
+}
+
+///|
+pub impl Neg for BigInt with fn neg(self : BigInt) -> BigInt {
+  if self.is_zero() {
+    return self
+  }
+  { ..self, sign: if self.sign == Positive { Negative } else { Positive }, }
+}
+
+// Magnitude comparison
+
+///|
+/// Compare |self| with |other|.
+fn BigInt::cmp_mag(self : BigInt, other : BigInt) -> Int {
+  if self.len != other.len {
+    return if self.len < other.len { -1 } else { 1 }
+  }
+  for i = self.len - 1; i >= 0; i = i - 1 {
+    let a = self.limbs.unsafe_get(i)
+    let b = other.limbs.unsafe_get(i)
+    if a != b {
+      return if a < b { -1 } else { 1 }
+    }
+  }
+  0
+}
+
+///|
+pub impl Compare for BigInt with fn compare(self : BigInt, other : BigInt) -> Int {
+  match (self.sign, other.sign) {
+    (Positive, Negative) =>
+      if self.is_zero() && other.is_zero() {
+        0
+      } else {
+        1
+      }
+    (Negative, Positive) =>
+      if self.is_zero() && other.is_zero() {
+        0
+      } else {
+        -1
+      }
+    (Positive, Positive) => self.cmp_mag(other)
+    (Negative, Negative) => -self.cmp_mag(other)
+  }
+}
+
+///|
+pub impl Eq for BigInt with fn equal(self : BigInt, other : BigInt) -> Bool {
+  self.compare(other) == 0
+}
+
+// Magnitude add / sub
+//
+// These ignore signs entirely; the signed `Add`/`Sub` impls dispatch to them.
+
+///|
+/// |self| + |other|, always positive.
+fn BigInt::add_mag(self : BigInt, other : BigInt) -> BigInt {
+  // Ensure self is the longer operand.
+  let (a, b) = if self.len >= other.len { (self, other) } else { (other, self) }
+  let an = a.len
+  let bn = b.len
+  let limbs = make(an + 1)
+  let c = add_vv(limbs, 0, a.limbs, 0, b.limbs, 0, bn)
+  let c = add_vw(limbs, bn, a.limbs, bn, c, an - bn)
+  limbs.unsafe_set(an, c)
+  { limbs, sign: Positive, len: if c != 0 { an + 1 } else { an }, }
+}
+
+///|
+/// |self| - |other|, requires |self| >= |other|. Always positive.
+fn BigInt::sub_mag(self : BigInt, other : BigInt) -> BigInt {
+  let an = self.len
+  let bn = other.len
+  let limbs = make(an)
+  let c = sub_vv(limbs, 0, self.limbs, 0, other.limbs, 0, bn)
+  ignore(sub_vw(limbs, bn, self.limbs, bn, c, an - bn))
+  { limbs, sign: Positive, len: normalize_len(limbs, an), }
+}
+
+///|
+pub impl Add for BigInt with fn add(self : BigInt, other : BigInt) -> BigInt {
+  if self.sign == other.sign {
+    self.add_mag(other).with_sign(self.sign)
+  } else if self.cmp_mag(other) >= 0 {
+    self.sub_mag(other).with_sign(self.sign)
+  } else {
+    other.sub_mag(self).with_sign(other.sign)
+  }
+}
+
+///|
+pub impl Sub for BigInt with fn sub(self : BigInt, other : BigInt) -> BigInt {
+  if self.sign != other.sign {
+    self.add_mag(other).with_sign(self.sign)
+  } else if self.cmp_mag(other) >= 0 {
+    self.sub_mag(other).with_sign(self.sign)
+  } else {
+    other
+    .sub_mag(self)
+    .with_sign(if self.sign == Positive { Negative } else { Positive })
+  }
+}
+
+// Multiplication
+
+///|
+pub impl Mul for BigInt with fn mul(self : BigInt, other : BigInt) -> BigInt {
+  if self.is_zero() || other.is_zero() {
+    return zero
+  }
+  let sign = if self.sign == other.sign { Positive } else { Negative }
+  // Dispatch on the shorter operand, with the longer operand first.
+  let (a, b) = if self.len >= other.len { (self, other) } else { (other, self) }
+  let ret = if b.len == 1 {
+    a.mul_single_limb(b.limbs.unsafe_get(0))
+  } else if b.len < KARATSUBA_THRESHOLD {
+    a.grade_school_mul(b)
+  } else {
+    a.karatsuba_mul(b)
+  }
+  { ..ret, sign, }
+}
+
+///|
+/// |self| * x for a single limb x. Requires x != 0 and self != 0.
+fn BigInt::mul_single_limb(self : BigInt, x : UInt64) -> BigInt {
+  let n = self.len
+  let limbs = make(n + 1)
+  let c = mul_add_vww(limbs, 0, self.limbs, 0, x, 0, n)
+  limbs.unsafe_set(n, c)
+  { limbs, sign: Positive, len: if c != 0 { n + 1 } else { n }, }
+}
+
+///|
+/// Schoolbook O(n*m) multiply of the magnitudes.
+fn BigInt::grade_school_mul(self : BigInt, other : BigInt) -> BigInt {
+  let an = self.len
+  let bn = other.len
+  let limbs = make(an + bn)
+  basic_mul(limbs, 0, self.limbs, 0, an, other.limbs, 0, bn)
+  { limbs, sign: Positive, len: normalize_len(limbs, an + bn), }
+}
+
+///|
+/// Karatsuba over one scratch buffer.
+///
+/// Requires `self.len >= other.len >= KARATSUBA_THRESHOLD`. Karatsuba itself
+/// only handles the low `k` limbs of each operand (`k` from `karatsuba_len`, so
+/// the recursion splits evenly); whatever sits above `k` is folded back in
+/// afterwards as three ordinary products.
+fn BigInt::karatsuba_mul(self : BigInt, other : BigInt) -> BigInt {
+  let m = self.len
+  let n = other.len
+  let k = karatsuba_len(n, KARATSUBA_THRESHOLD)
+  let scratch = make(6 * k)
+  karatsuba(scratch, 0, self.limbs, 0, other.limbs, 0, k)
+  let z = make(m + n)
+  z.unsafe_blit(0, scratch, 0, 2 * k)
+  if k < n || m != n {
+    // With B = 2^(64k), x = xh*B + x0 and y = yh*B + y0. The scratch pass
+    // produced x0*y0; add x0*yh*B, xh*y0*B and xh*yh*B^2.
+    let x0 = slice_mag(self.limbs, 0, k)
+    let xh = slice_mag(self.limbs, k, m - k)
+    let y0 = slice_mag(other.limbs, 0, k)
+    let yh = slice_mag(other.limbs, k, n - k)
+    add_term(z, m + n, x0 * yh, k)
+    add_term(z, m + n, xh * y0, k)
+    add_term(z, m + n, xh * yh, 2 * k)
+  }
+  { limbs: z, sign: Positive, len: normalize_len(z, m + n), }
+}
+
+///|
+/// `z[i..zn) += t`, skipping the no-op case so `add_at` never walks a zero.
+fn add_term(z : FixedArray[UInt64], zn : Int, t : BigInt, i : Int) -> Unit {
+  if !t.is_zero() {
+    add_at(z, zn, t.limbs, t.len, i)
+  }
+}
+
+///|
+/// A normalized magnitude holding `x[off..off+n)`; `zero` when `n <= 0`.
+fn slice_mag(x : FixedArray[UInt64], off : Int, n : Int) -> BigInt {
+  if n <= 0 {
+    return zero
+  }
+  let mut len = n
+  while len > 1 && x.unsafe_get(off + len - 1) == 0 {
+    len -= 1
+  }
+  let limbs = make(len)
+  limbs.unsafe_blit(0, x, off, len)
+  { limbs, sign: Positive, len, }
+}
+
+// Division
+
+///|
+pub impl Div for BigInt with fn div(self : BigInt, other : BigInt) -> BigInt {
+  let (q, _) = self.div_mod(other)
+  q
+}
+
+///|
+pub impl Mod for BigInt with fn mod(self : BigInt, other : BigInt) -> BigInt {
+  let (_, r) = self.div_mod(other)
+  r
+}
+
+///|
+/// Truncating division: the quotient rounds toward zero and the remainder takes
+/// the sign of the dividend, matching core's `Div`/`Mod`.
+fn BigInt::div_mod(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
+  if other.is_zero() {
+    abort("division by zero")
+  }
+  let cmp = self.cmp_mag(other)
+  if cmp < 0 {
+    return (zero, self)
+  }
+  let q_sign = if self.sign == other.sign { Positive } else { Negative }
+  if cmp == 0 {
+    return (one.with_sign(q_sign), zero)
+  }
+  let (q, r) = if other.len == 1 {
+    self.div_mod_single_limb(other.limbs.unsafe_get(0))
+  } else {
+    self.knuth_div(other)
+  }
+  (q.with_sign(q_sign), r.with_sign(self.sign))
+}
+
+///|
+/// |self| divmod a single limb, using the Möller-Granlund 2/1 divider so the
+/// inner loop is two wide multiplies rather than a hardware 128/64 divide.
+fn BigInt::div_mod_single_limb(self : BigInt, d : UInt64) -> (BigInt, BigInt) {
+  let n = self.len
+  let q = make(n)
+  if d == 1 {
+    q.unsafe_blit(0, self.limbs, 0, n)
+    return ({ limbs: q, sign: Positive, len: n, }, zero)
+  }
+  let s = nlz(d)
+  let dn = d << s
+  let r = div_w(q, self.limbs, n, dn, reciprocal_word(dn), s)
+  (
+    { limbs: q, sign: Positive, len: normalize_len(q, n), },
+    { limbs: FixedArray::make(1, r), sign: Positive, len: 1, },
+  )
+}
+
+///|
+/// Knuth TAOCP 4.3.1 Algorithm D over 64-bit limbs.
+///
+/// Requires `|self| > |other|` and `other.len >= 2`.
+fn BigInt::knuth_div(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
+  let n = other.len
+  let m = self.len - n
+
+  // D1. Normalize so the divisor's top limb has its high bit set.
+  let s = nlz(other.limbs.unsafe_get(n - 1))
+  let v = make(n)
+  if s == 0 {
+    v.unsafe_blit(0, other.limbs, 0, n)
+  } else {
+    ignore(shl_vu(v, other.limbs, s, n))
+  }
+  // u gets one extra limb to hold the shifted-out bits.
+  let u = make(self.len + 1)
+  if s == 0 {
+    u.unsafe_blit(0, self.limbs, 0, self.len)
+  } else {
+    let carry = shl_vu(u, self.limbs, s, self.len)
+    u.unsafe_set(self.len, carry)
+  }
+  let q = make(m + 1)
+  let vn1 = v.unsafe_get(n - 1)
+  let vn2 = v.unsafe_get(n - 2)
+  let rec = reciprocal_word(vn1)
+  let qhatv = make(n + 1)
+  for j = m; j >= 0; j = j - 1 {
+    // D3. Estimate q̂ from the top two limbs.
+    let ujn = u.unsafe_get(j + n)
+    let mut qhat = 0xffff_ffff_ffff_ffffUL
+    if ujn != vn1 {
+      let dm = div2by1(ujn, u.unsafe_get(j + n - 1), vn1, rec)
+      qhat = dm.q
+      let mut rhat = dm.r
+      // Refine: while q̂ * v[n-2] > (r̂ << 64) + u[j+n-2], decrement q̂.
+      let mut p = umul_wide(qhat, vn2)
+      let ujn2 = u.unsafe_get(j + n - 2)
+      while greater_than(p.hi, p.lo, rhat, ujn2) {
+        qhat -= 1
+        let prev = rhat
+        rhat += vn1
+        if rhat < prev {
+          break
+        }
+        p = umul_wide(qhat, vn2)
+      }
+    }
+
+    // D4. Multiply and subtract.
+    let c = mul_add_vww(qhatv, 0, v, 0, qhat, 0, n)
+    qhatv.unsafe_set(n, c)
+    let borrow = sub_vv(u, j, u, j, qhatv, 0, n + 1)
+
+    // D5/D6. Rare: q̂ was one too large, add the divisor back.
+    if borrow != 0 {
+      let carry = add_vv(u, j, u, j, v, 0, n)
+      u.unsafe_set(j + n, u.unsafe_get(j + n) + carry)
+      qhat -= 1
+    }
+    q.unsafe_set(j, qhat)
+  }
+
+  // D8. Unnormalize the remainder.
+  let r = make(n)
+  if s == 0 {
+    r.unsafe_blit(0, u, 0, n)
+  } else {
+    ignore(shr_vu(r, u, s, n))
+  }
+  (
+    { limbs: q, sign: Positive, len: normalize_len(q, m + 1), },
+    { limbs: r, sign: Positive, len: normalize_len(r, n), },
+  )
+}
+
+// Shifts
+
+///|
+pub impl Shl for BigInt with fn shl(self : BigInt, n : Int) -> BigInt {
+  if n < 0 {
+    abort("negative shift count")
+  }
+  if self.is_zero() || n == 0 {
+    return self
+  }
+  let words = n / 64
+  let bits = n % 64
+  let len = self.len + words + 1
+  let limbs = make(len)
+  if bits == 0 {
+    limbs.unsafe_blit(words, self.limbs, 0, self.len)
+  } else {
+    let shifted = make(self.len)
+    let carry = shl_vu(shifted, self.limbs, bits, self.len)
+    limbs.unsafe_blit(words, shifted, 0, self.len)
+    limbs.unsafe_set(words + self.len, carry)
+  }
+  { limbs, sign: self.sign, len: normalize_len(limbs, len), }
+}
+
+///|
+pub impl Shr for BigInt with fn shr(self : BigInt, n : Int) -> BigInt {
+  if n < 0 {
+    abort("negative shift count")
+  }
+  if self.is_zero() || n == 0 {
+    return self
+  }
+  let words = n / 64
+  let bits = n % 64
+  if words >= self.len {
+    // Arithmetic shift: negatives round toward -infinity, like core.
+    return if self.sign == Positive { zero } else { -one }
+  }
+  let len = self.len - words
+  let limbs = make(len)
+  if bits == 0 {
+    limbs.unsafe_blit(0, self.limbs, words, len)
+  } else {
+    let src = make(len)
+    src.unsafe_blit(0, self.limbs, words, len)
+    ignore(shr_vu(limbs, src, bits, len))
+  }
+  let res = { limbs, sign: self.sign, len: normalize_len(limbs, len), }
+  if self.sign == Negative {
+    // Check whether any bit was shifted out; if so round away from zero.
+    let lost = for i in 0..<words {
+      if self.limbs.unsafe_get(i) != 0 {
+        break true
+      }
+    } nobreak {
+      bits > 0 && (self.limbs.unsafe_get(words) & ((1UL << bits) - 1)) != 0
+    }
+    if lost {
+      return res - one
+    }
+  }
+  res
+}
+
+// Conversions
+
+///|
+/// Returns the number of bits in the minimal representation excluding its
+/// sign bit.
+pub fn BigInt::bit_length(self : BigInt) -> Int {
+  if self.is_zero() {
+    return 0
+  }
+  let mut bits = self.len * RADIX_BIT_LEN -
+    nlz(self.limbs.unsafe_get(self.len - 1))
+  if self.sign == Negative {
+    // Core defines negative bit length from the minimal two's-complement
+    // representation, so -2^k needs one fewer magnitude bit.
+    let is_power_of_two = for i in 0..<self.len; one_bits = 0 {
+      let one_bits = one_bits + self.limbs.unsafe_get(i).popcnt()
+      if one_bits > 1 {
+        break false
+      }
+      continue one_bits
+    } nobreak {
+      true
+    }
+    if is_power_of_two {
+      bits -= 1
+    }
+  }
+  bits
+}
+
+///|
+/// Largest power of ten that fits in a limb: 10^19 < 2^64.
+const DECIMAL_CHUNK : UInt64 = 10_000_000_000_000_000_000UL
+
+///|
+const DECIMAL_CHUNK_DIGITS = 19
+
+///|
+/// Decimal rendering by repeated division by 10^19, so each division peels off
+/// 19 digits at a time.
+fn BigInt::to_string_dec(self : BigInt) -> String {
+  if self.is_zero() {
+    return "0"
+  }
+  let n = self.len
+  let work = make(n)
+  work.unsafe_blit(0, self.limbs, 0, n)
+  let mut len = n
+  let chunks = []
+  // The reciprocal depends only on the divisor, so it is computed once for the
+  // whole conversion rather than once per 19-digit chunk.
+  let s = nlz(DECIMAL_CHUNK)
+  let dn = DECIMAL_CHUNK << s
+  let rec = reciprocal_word(dn)
+  while len > 1 || work.unsafe_get(0) != 0 {
+    chunks.push(div_w(work, work, len, dn, rec, s))
+    len = normalize_len(work, len)
+  }
+  let buf = StringBuilder()
+  if self.sign == Negative {
+    buf.write_char('-')
+  }
+  buf.write_string(chunks[chunks.length() - 1].to_string())
+  for i = chunks.length() - 2; i >= 0; i = i - 1 {
+    let s = chunks[i].to_string()
+    for _ in 0..<(DECIMAL_CHUNK_DIGITS - s.length()) {
+      buf.write_char('0')
+    }
+    buf.write_string(s)
+  }
+  buf.to_string()
+}
+
+///|
+/// `self ^ exp` by square-and-multiply.
+pub fn BigInt::pow(self : BigInt, exp : BigInt, modulus? : BigInt) -> BigInt {
+  if exp.sign == Negative {
+    abort("negative exponent")
+  }
+  match modulus {
+    None => {
+      let bits = exp.bit_length()
+      for i in 0..<bits; result = one, base = self {
+        let result = if exp.test_bit(i) { result * base } else { result }
+        let base = if i + 1 < bits { base * base } else { base }
+        continue result, base
+      } nobreak {
+        result
+      }
+    }
+    Some(m) => {
+      if m.is_zero() || m.sign == Negative {
+        abort("modulus must be positive")
+      }
+      if m.len == 1 && m.limbs.unsafe_get(0) == 1 {
+        return zero
+      }
+      if exp.is_zero() {
+        return one
+      }
+      // Reduce the base into [0, m), matching core's `(self % m + m) % m`.
+      let r = self % m
+      let base = if r.sign == Negative { r + m } else { r }
+      if base.is_zero() {
+        return zero
+      }
+      if (m.limbs.unsafe_get(0) & 1) == 1 {
+        base.pow_mont(exp, m)
+      } else {
+        base.pow_mod_plain(exp, m)
+      }
+    }
+  }
+}
+
+///|
+/// Bit `i` of the magnitude.
+fn BigInt::test_bit(self : BigInt, i : Int) -> Bool {
+  let w = i / 64
+  if w >= self.len {
+    return false
+  }
+  ((self.limbs.unsafe_get(w) >> (i % 64)) & 1) == 1
+}
+
+///|
+/// Square-and-multiply with an explicit reduction each step. Used when the
+/// modulus is even, where Montgomery does not apply (it needs `m` invertible
+/// mod 2^64).
+fn BigInt::pow_mod_plain(self : BigInt, exp : BigInt, m : BigInt) -> BigInt {
+  let bits = exp.bit_length()
+  for i in 0..<bits; result = one, base = self {
+    let result = if exp.test_bit(i) { result * base % m } else { result }
+    let base = if i + 1 < bits { base * base % m } else { base }
+    continue result, base
+  } nobreak {
+    result
+  }
+}
+
+///|
+/// Montgomery exponentiation with a 4-bit window.
+///
+/// Requires `0 < self < m`, `m` odd, `exp > 0`. The win over `pow_mod_plain` is
+/// that every reduction becomes a Montgomery multiply — O(n^2) shift-and-add
+/// instead of a full Knuth D division — and the window cuts the number of
+/// multiplies by roughly a third.
+fn BigInt::pow_mont(self : BigInt, exp : BigInt, m : BigInt) -> BigInt {
+  let n = m.len
+  let mlimbs = m.limbs
+  let k0 = mont_k0(mlimbs.unsafe_get(0))
+  let t = make(2 * n)
+
+  // x, one, and RR = 2^(128n) mod m, each padded to exactly n limbs.
+  let x = make(n)
+  x.unsafe_blit(0, self.limbs, 0, self.len)
+  let one_arr = make(n)
+  one_arr.unsafe_set(0, 1)
+  let rr_big = (one << (2 * 64 * n)) % m
+  let rr = make(n)
+  rr.unsafe_blit(0, rr_big.limbs, 0, rr_big.len)
+
+  // powers[i] = Montgomery form of self^i, for the 4-bit window.
+  let powers : Array[FixedArray[UInt64]] = []
+  for _ in 0..<16 {
+    powers.push(make(n))
+  }
+  montgomery(powers[0], one_arr, rr, mlimbs, k0, n, t)
+  montgomery(powers[1], x, rr, mlimbs, k0, n, t)
+  for i in 2..<16 {
+    montgomery(powers[i], powers[i - 1], powers[1], mlimbs, k0, n, t)
+  }
+  let mut z = make(n)
+  z.unsafe_blit(0, powers[0], 0, n)
+  let mut zz = make(n)
+  for i = exp.len - 1; i >= 0; i = i - 1 {
+    let mut yi = exp.limbs.unsafe_get(i)
+    let mut j = 0
+    while j < 64 {
+      // Four squarings per nibble, skipped only on the very first window.
+      if i != exp.len - 1 || j != 0 {
+        montgomery(zz, z, z, mlimbs, k0, n, t)
+        montgomery(z, zz, zz, mlimbs, k0, n, t)
+        montgomery(zz, z, z, mlimbs, k0, n, t)
+        montgomery(z, zz, zz, mlimbs, k0, n, t)
+      }
+      montgomery(zz, z, powers[(yi >> 60).to_int()], mlimbs, k0, n, t)
+      let swap = z
+      z = zz
+      zz = swap
+      yi = yi << 4
+      j += 4
+    }
+  }
+  // Leave Montgomery form.
+  montgomery(zz, z, one_arr, mlimbs, k0, n, t)
+  let res = { limbs: zz, sign: Positive, len: normalize_len(zz, n), }
+  // Montgomery's conditional subtraction leaves the result below 2m, not m.
+  if res.cmp_mag(m) >= 0 {
+    res.sub_mag(m)
+  } else {
+    res
+  }
+}
+
+// Conversions and bitwise operations.
+
+///|
+fn minimum_int(a : Int, b : Int) -> Int {
+  if a < b {
+    a
+  } else {
+    b
+  }
+}
+
+///|
+fn maximum_int(a : Int, b : Int) -> Int {
+  if a > b {
+    a
+  } else {
+    b
+  }
+}
+
+///|
+fn digit_from_char(x : Int) -> Int {
+  match x {
+    '0'..='9' => x - '0'
+    'A'..='Z' => x + (10 - 'A')
+    'a'..='z' => x + (10 - 'a')
+    _ => -1
+  }
+}
+
+///|
+fn char_from_digit(d : Int) -> Char {
+  if d < 10 {
+    (d + '0').unsafe_to_char()
+  } else {
+    (d - 10 + 'a').unsafe_to_char()
+  }
+}
+
+///|
+fn pow2_shift(radix : Int) -> Int? {
+  if radix >= 2 && (radix & (radix - 1)) == 0 {
+    Some(radix.ctz())
+  } else {
+    None
+  }
+}
+
+///|
+/// Converts this integer to a string in a radix between 2 and 36.
+pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
+  if radix < 2 || radix > 36 {
+    abort("radix must be between 2 and 36")
+  }
+  if radix == 10 {
+    self.to_string_dec()
+  } else {
+    self.to_string_radix(radix)
+  }
+}
+
+///|
+fn BigInt::to_string_radix(self : BigInt, radix : Int) -> String {
+  if self.is_zero() {
+    return "0"
+  }
+  match pow2_shift(radix) {
+    Some(shift) => self.to_string_radix_pow2(shift)
+    None => {
+      let is_negative = self.sign == Negative
+      let base = BigInt::from_int(radix)
+      let mut value = if is_negative { -self } else { self }
+      let digits = []
+      while !value.is_zero() {
+        let (q, r) = value.div_mod(base)
+        digits.push(char_from_digit(r.to_int()))
+        value = q
+      }
+      let builder = StringBuilder(
+        size_hint=digits.length() + (if is_negative { 1 } else { 0 }),
+      )
+      if is_negative {
+        builder.write_char('-')
+      }
+      for i in digits.length()>..0 {
+        builder.write_char(digits[i])
+      }
+      builder.to_string()
+    }
+  }
+}
+
+///|
+fn BigInt::to_string_radix_pow2(self : BigInt, shift : Int) -> String {
+  let is_negative = self.sign == Negative
+  let value = if is_negative { -self } else { self }
+  let bit_len = value.bit_length()
+  let digit_len = (bit_len + shift - 1) / shift
+  let builder = StringBuilder(
+    size_hint=digit_len + (if is_negative { 1 } else { 0 }),
+  )
+  if is_negative {
+    builder.write_char('-')
+  }
+  let mask = (1UL << shift) - 1
+  for pos in digit_len>..0 {
+    let bit_index = pos * shift
+    let limb_index = bit_index / RADIX_BIT_LEN
+    let offset = bit_index % RADIX_BIT_LEN
+    let mut chunk = value.limbs.unsafe_get(limb_index) >> offset
+    if offset + shift > RADIX_BIT_LEN && limb_index + 1 < value.len {
+      chunk = chunk |
+        (value.limbs.unsafe_get(limb_index + 1) << (RADIX_BIT_LEN - offset))
+    }
+    builder.write_char(char_from_digit((chunk & mask).to_int()))
+  }
+  builder.to_string()
+}
+
+///|
+fn BigInt::from_string_radix(input : StringView, radix : Int) -> BigInt raise {
+  match pow2_shift(radix) {
+    Some(shift) => BigInt::from_string_radix_pow2(input, radix, shift)
+    None => {
+      let len = input.length()
+      if len == 0 {
+        syntax_err()
+      }
+      let sign = if input.unsafe_get(0) == '-' { Negative } else { Positive }
+      let start = if sign == Negative { 1 } else { 0 }
+      if start == len {
+        syntax_err()
+      }
+      let base = BigInt::from_int(radix)
+      let acc = for i in start..<len; acc = zero {
+        let digit = digit_from_char(input.unsafe_get(i).to_int())
+        if digit < 0 || digit >= radix {
+          syntax_err()
+        }
+        continue acc * base + BigInt::from_int(digit)
+      } nobreak {
+        acc
+      }
+      acc.with_sign(sign)
+    }
+  }
+}
+
+///|
+fn BigInt::from_string_radix_pow2(
+  input : StringView,
+  radix : Int,
+  shift : Int,
+) -> BigInt raise {
+  let len = input.length()
+  if len == 0 {
+    syntax_err()
+  }
+  let sign = if input.unsafe_get(0) == '-' { Negative } else { Positive }
+  let start = if sign == Negative { 1 } else { 0 }
+  if start == len {
+    syntax_err()
+  }
+  let mut first = start
+  while first < len {
+    let digit = digit_from_char(input.unsafe_get(first).to_int())
+    if digit < 0 || digit >= radix {
+      syntax_err()
+    }
+    if digit != 0 {
+      break
+    }
+    first += 1
+  }
+  if first == len {
+    return zero
+  }
+  let total_bits = (len - first) * shift
+  let limbs_len = (total_bits + RADIX_BIT_LEN - 1) / RADIX_BIT_LEN
+  let limbs = FixedArray::make(limbs_len, 0UL)
+  for i in len>..first; bit_pos = 0 {
+    let digit = digit_from_char(input.unsafe_get(i).to_int())
+    if digit < 0 || digit >= radix {
+      syntax_err()
+    }
+    let limb_index = bit_pos / RADIX_BIT_LEN
+    let offset = bit_pos % RADIX_BIT_LEN
+    let value = digit.to_uint64()
+    limbs.unsafe_set(
+      limb_index,
+      limbs.unsafe_get(limb_index) | (value << offset),
+    )
+    if offset + shift > RADIX_BIT_LEN {
+      let hi = value >> (RADIX_BIT_LEN - offset)
+      limbs.unsafe_set(limb_index + 1, limbs.unsafe_get(limb_index + 1) | hi)
+    }
+    continue bit_pos + shift
+  }
+  { limbs, sign, len: normalize_len(limbs, limbs_len), }
+}
+
+///|
+fn BigInt::from_string_dec(input : StringView) -> BigInt raise {
+  let len = input.length()
+  if len == 0 {
+    syntax_err()
+  }
+  let sign = if input.unsafe_get(0) == '-' { Negative } else { Positive }
+  let mut i = if sign == Negative { 1 } else { 0 }
+  if i == len {
+    syntax_err()
+  }
+  let mut acc = zero
+  while i < len {
+    let take = minimum_int(DECIMAL_CHUNK_DIGITS, len - i)
+    let (chunk, scale) = for offset in 0..<take; chunk = 0UL, scale = 1UL {
+      let digit = digit_from_char(input.unsafe_get(i + offset).to_int())
+      if digit < 0 || digit > 9 {
+        syntax_err()
+      }
+      continue chunk * 10 + digit.to_uint64(), scale * 10
+    } nobreak {
+      (chunk, scale)
+    }
+    i += take
+    acc = acc * BigInt::from_uint64(scale) + BigInt::from_uint64(chunk)
+  }
+  acc.with_sign(sign)
+}
+
+///|
+/// Parses a string into a `BigInt` using a base between 2 and 36.
+#internal(internal, "use `@string.parse_bigint` instead")
+#doc(hidden)
+pub fn parse_bigint(str : StringView, base? : Int = 10) -> BigInt raise {
+  if base < 2 || base > 36 {
+    base_err()
+  }
+  if base == 10 {
+    BigInt::from_string_dec(str)
+  } else {
+    BigInt::from_string_radix(str, base)
+  }
+}
+
+///|
+/// Converts a string representation in the specified radix to a `BigInt`.
+///
+/// Panics if the input is malformed. Use `@string.parse_bigint` to handle
+/// errors.
+pub fn BigInt::from_string(input : String, radix? : Int = 10) -> BigInt {
+  parse_bigint(input.view(), base=radix) catch {
+    Failure(msg) => abort(msg)
+    _ => abort("invalid syntax")
+  }
+}
+
+///|
+/// Creates a magnitude from unsigned big-endian bytes.
+pub fn BigInt::from_octets(input : BytesView, signum? : Int = 1) -> BigInt {
+  if signum == 0 || input.length() == 0 {
+    return zero
+  }
+  if signum < 0 {
+    return -BigInt::from_octets(input)
+  }
+  let byte_len = input.length()
+  let full_limbs = byte_len / 8
+  let head_len = byte_len % 8
+  let limbs_len = if head_len == 0 { full_limbs } else { full_limbs + 1 }
+  let limbs = FixedArray::make(limbs_len, 0UL)
+  // Assemble the partial most-significant limb.
+  for i in 0..<head_len {
+    limbs.unsafe_set(
+      limbs_len - 1,
+      (limbs.unsafe_get(limbs_len - 1) << 8) | input.unsafe_get(i).to_uint64(),
+    )
+  }
+  // Each remaining limb is one full-width big-endian word.
+  for i in 0..<full_limbs {
+    guard! input[byte_len - 8 - i * 8:] is [u64be(word), ..]
+    limbs.unsafe_set(i, word)
+  }
+  { limbs, sign: Positive, len: normalize_len(limbs, limbs_len), }
+}
+
+///|
+/// Converts a non-negative integer to unsigned big-endian bytes.
+pub fn BigInt::to_octets(self : BigInt, length? : Int) -> Bytes {
+  let minimum_length = match length {
+    None => 1
+    Some(value) => if value <= 0 { abort("negative length") } else { value }
+  }
+  if self.is_zero() {
+    return Bytes::new(maximum_int(1, minimum_length))
+  }
+  if self.sign == Negative {
+    abort("negative BigInt")
+  }
+  let value_length = (self.bit_length() + 7) / 8
+  let result_length = maximum_int(minimum_length, value_length)
+  let result = FixedArray::make(result_length, b'\x00')
+  for i in 0..<value_length {
+    let word = self.limbs.unsafe_get(i / 8)
+    result.unsafe_set(
+      result_length - 1 - i,
+      ((word >> (i % 8 * 8)) & 0xffUL).to_int().to_byte(),
+    )
+  }
+  unsafe_fixedarray_to_bytes(result)
+}
+
+///|
+fn fill_twos_complement(value : BigInt, out : FixedArray[UInt64]) -> Unit {
+  out.unsafe_blit(0, value.limbs, 0, value.len)
+  if value.sign == Negative {
+    for i in 0..<out.length() {
+      out.unsafe_set(i, out.unsafe_get(i).lnot())
+    }
+    for i in 0..<out.length() {
+      let word = out.unsafe_get(i) + 1
+      out.unsafe_set(i, word)
+      if word != 0 {
+        break
+      }
+    }
+  }
+}
+
+///|
+fn BigInt::bitwise(
+  self : BigInt,
+  other : BigInt,
+  op : (UInt64, UInt64) -> UInt64,
+) -> BigInt {
+  let limbs_len = maximum_int(self.len, other.len) + 1
+  let x = FixedArray::make(limbs_len, 0UL)
+  let y = FixedArray::make(limbs_len, 0UL)
+  fill_twos_complement(self, x)
+  fill_twos_complement(other, y)
+  for i in 0..<limbs_len {
+    x.unsafe_set(i, op(x.unsafe_get(i), y.unsafe_get(i)))
+  }
+  let negative = x.unsafe_get(limbs_len - 1) == 0xffff_ffff_ffff_ffffUL
+  if negative {
+    for i in 0..<limbs_len {
+      let word = x.unsafe_get(i) - 1
+      x.unsafe_set(i, word)
+      if word != 0xffff_ffff_ffff_ffffUL {
+        break
+      }
+    }
+    for i in 0..<limbs_len {
+      x.unsafe_set(i, x.unsafe_get(i).lnot())
+    }
+  }
+  let len = normalize_len(x, limbs_len)
+  {
+    limbs: x,
+    sign: if negative && !(len == 1 && x.unsafe_get(0) == 0) {
+      Negative
+    } else {
+      Positive
+    },
+    len,
+  }
+}
+
+///|
+pub impl BitAnd for BigInt with fn land(self : BigInt, other : BigInt) -> BigInt {
+  self.bitwise(other, (a, b) => a & b)
+}
+
+///|
+pub impl BitOr for BigInt with fn lor(self : BigInt, other : BigInt) -> BigInt {
+  self.bitwise(other, (a, b) => a | b)
+}
+
+///|
+pub impl BitXOr for BigInt with fn lxor(self : BigInt, other : BigInt) -> BigInt {
+  self.bitwise(other, (a, b) => a ^ b)
+}
+
+///|
+/// Returns the low 32 bits reinterpreted as a signed integer.
+pub fn BigInt::to_int(self : BigInt) -> Int {
+  self.to_uint().reinterpret_as_int()
+}
+
+///|
+/// Returns the low 32 bits as an unsigned integer.
+pub fn BigInt::to_uint(self : BigInt) -> UInt {
+  let low = self.limbs.unsafe_get(0).to_uint()
+  if self.sign == Negative {
+    0U - low
+  } else {
+    low
+  }
+}
+
+///|
+/// Returns the low 64 bits reinterpreted as a signed integer.
+pub fn BigInt::to_int64(self : BigInt) -> Int64 {
+  self.to_uint64().reinterpret_as_int64()
+}
+
+///|
+/// Returns the low 64 bits as an unsigned integer.
+pub fn BigInt::to_uint64(self : BigInt) -> UInt64 {
+  let low = self.limbs.unsafe_get(0)
+  if self.sign == Negative {
+    0UL - low
+  } else {
+    low
+  }
+}
+
+///|
+/// Returns the number of trailing zero bits in the magnitude.
+pub fn BigInt::ctz(self : BigInt) -> Int {
+  if self.is_zero() {
+    return 0
+  }
+  let mut i = 0
+  while self.limbs.unsafe_get(i) == 0 {
+    i += 1
+  }
+  RADIX_BIT_LEN * i + self.limbs.unsafe_get(i).ctz()
+}
+
+///|
+fn unsafe_fixedarray_to_bytes(arr : FixedArray[Byte]) -> Bytes = "%identity"
+
+///|
+fn can_convert_to_int(x : BigInt) -> Bool {
+  x.len == 1 &&
+  (if x.sign == Negative {
+    x.limbs.unsafe_get(0) <= 0x8000_0000UL
+  } else {
+    x.limbs.unsafe_get(0) < 0x8000_0000UL
+  })
+}
+
+///|
+fn can_convert_to_int64(x : BigInt) -> Bool {
+  x.len == 1 &&
+  (if x.sign == Negative {
+    x.limbs.unsafe_get(0) <= 0x8000_0000_0000_0000UL
+  } else {
+    x.limbs.unsafe_get(0) < 0x8000_0000_0000_0000UL
+  })
+}
+
+///|
+fn is_neg(x : BigInt) -> Bool {
+  x.sign == Negative
+}
+
+///|
+/// Returns the magnitude as 32-bit words so hashing remains representation
+/// independent and agrees with the JavaScript backend.
+fn BigInt::limbs(self : Self) -> Array[UInt] {
+  let result = []
+  for i in 0..<self.len {
+    let word = self.limbs.unsafe_get(i)
+    result.push(word.to_uint())
+    let high = (word >> 32).to_uint()
+    if i + 1 < self.len || high != 0 {
+      result.push(high)
+    }
+  }
+  result
+}

--- a/bigint/bigint_wide_wbtest.mbt
+++ b/bigint/bigint_wide_wbtest.mbt
@@ -13,12 +13,16 @@
 // limitations under the License.
 
 ///|
-struct MyBigInt(BigInt)
+priv struct MyBigInt(BigInt)
 
 ///|
 impl Show for MyBigInt with fn output(self, logger) {
+  let sign = match self.sign {
+    Positive => "Positive"
+    Negative => "Negative"
+  }
   logger <+
-    "{limbs : \{@debug.Repr(self.limbs)}, sign : \{@debug.Repr(self.sign)}, len : \{self.len} }"
+    "{limbs : \{@debug.Repr(self.limbs)}, sign : \{sign}, len : \{self.len} }"
 }
 
 ///|
@@ -50,13 +54,6 @@ test "debug_string" {
 ///|
 fn check_invariant(a : BigInt) -> Unit raise {
   guard a.len > 0 else { fail("invariant len > 0 is broken: len = \{a.len}") }
-  for i in 0..<a.len {
-    guard a.limbs[i].to_uint64() < RADIX else {
-      fail(
-        "invariant forall 0 <= i < len. 0 <= limbs[i] < radix is broken: a.limbs[\{i}] = \{a.limbs[i]}",
-      )
-    }
-  }
   if a.limbs.iter().take(a.len).any(x => x > 0) {
     guard a.limbs[a.len - 1] > 0 else {
       fail(
@@ -86,10 +83,8 @@ test "shr" {
   let c = a >> 64
   check_invariant(c)
   inspect(c, content="0")
-  // 2^63 spans two 32-bit limbs; shifting right by 2 * RADIX_BIT_LEN bits
-  // (64) drops both limbs to 0. Built as a BigInt because 2^63 overflows the
-  // UInt64 product RADIX * RADIX (= 2^64, wraps to 0) and Int64's range.
-  let a = 1N << 63
+  // 2^127 spans two UInt64 limbs; shifting by two complete limbs drops it.
+  let a = 1N << 127
   let b = a >> (RADIX_BIT_LEN * 2)
   check_invariant(b)
   inspect(b, content="0")
@@ -97,32 +92,60 @@ test "shr" {
 
 ///|
 test "mul_single_limb boundaries" {
-  // 1-limb x 1-limb with maximal carry-out: (2^32 - 1)^2
-  let max_limb = 4294967295N
+  // One-limb by one-limb with maximal carry-out: (2^64 - 1)^2.
+  let max_limb = 18446744073709551615N
   let p = max_limb * max_limb
   check_invariant(p)
-  inspect(p, content="18446744065119617025")
-  // all-max limbs: (2^96 - 1) * (2^32 - 1), carry grows len to n + 1
-  let a = (1N << 96) - 1N
+  @test.assert_eq(p, (1N << 128) - (1N << 65) + 1N)
+  // Three all-max limbs times one max limb; carry grows len to n + 1.
+  let a = (1N << 192) - 1N
+  let expected = (1N << 256) - (1N << 192) - (1N << 64) + 1N
   let p = a * max_limb
   check_invariant(p)
-  inspect(p, content="340282366841710300949110269833929293825")
+  @test.assert_eq(p, expected)
   // commuted operand order takes the same fast path
   let p = max_limb * a
   check_invariant(p)
-  inspect(p, content="340282366841710300949110269833929293825")
+  @test.assert_eq(p, expected)
   // no carry-out: len stays at self.len, the spare limb beyond len stays zero
-  let p = (1N << 64) * 2N
+  let p = (1N << 128) * 2N
   check_invariant(p)
-  inspect(p, content="36893488147419103232")
+  @test.assert_eq(p, 1N << 129)
   // the dispatch applies the sign on top of the magnitude-only helper
-  inspect(a * -max_limb, content="-340282366841710300949110269833929293825")
-  inspect(-a * max_limb, content="-340282366841710300949110269833929293825")
-  inspect(-a * -max_limb, content="340282366841710300949110269833929293825")
+  @test.assert_eq(a * -max_limb, -expected)
+  @test.assert_eq(-a * max_limb, -expected)
+  @test.assert_eq(-a * -max_limb, expected)
   // fast path agrees with the general routine on the same magnitudes
-  let fast = a.mul_single_limb(4294967295U)
+  let fast = a.mul_single_limb(0xffff_ffff_ffff_ffffUL)
   check_invariant(fast)
   @test.assert_eq(fast, a.grade_school_mul(max_limb))
+}
+
+///|
+test "multiplication around the wide Karatsuba threshold" {
+  let cases : Array[(Int, Int)] = [
+    (63, 63), // schoolbook on both sides of the last pre-threshold case
+    (63, 64), // asymmetric input still dispatches on the shorter operand
+    (64, 64), // first exact Karatsuba case
+    (64, 65), // Karatsuba with one high tail limb
+    (65, 65),
+  ]
+  for case in cases {
+    let (limbs_a, limbs_b) = case
+    let bits_a = limbs_a * RADIX_BIT_LEN
+    let bits_b = limbs_b * RADIX_BIT_LEN
+    let a = (1N << bits_a) - 1N
+    let b = (1N << bits_b) - 1N
+    let expected = (1N << (bits_a + bits_b)) -
+      (1N << bits_a) -
+      (1N << bits_b) +
+      1N
+    @test.assert_eq(a.len, limbs_a)
+    @test.assert_eq(b.len, limbs_b)
+    let product = a * b
+    check_invariant(product)
+    @test.assert_eq(product, expected)
+  }
 }
 
 ///|
@@ -175,23 +198,10 @@ test "BigInt::ctz" {
 test {
   inspect(
     MyBigInt(-9223372036854775809N),
-    content="{limbs : <FixedArray: [1, 2147483648, 0]>, sign : Negative, len : 2 }",
+    content="{limbs : <FixedArray: [9223372036854775809, 0]>, sign : Negative, len : 1 }",
   ) // Int64.min_value - 1
   inspect(
     MyBigInt(-9223372036854775810N),
-    content="{limbs : <FixedArray: [2, 2147483648, 0]>, sign : Negative, len : 2 }",
+    content="{limbs : <FixedArray: [9223372036854775810, 0]>, sign : Negative, len : 1 }",
   ) // Int64.min_value - 2
-}
-
-///|
-/// `BigInt::from_octets` reads each tail limb with a single `u32be` bits
-/// pattern, which agrees with the shift-accumulate loop it replaced only when a
-/// limb is exactly four bytes wide. Pin the constant here so narrowing it fails
-/// this test instead of silently mis-decoding octets.
-///
-/// Deliberately `assert_eq` rather than `inspect`: a snapshot would be rewritten
-/// by `moon test --update`, which would silently retire this guard at exactly
-/// the moment it is supposed to fire.
-test "from_octets assumes 32-bit limbs" {
-  @test.assert_eq(RADIX_BIT_LEN, 32)
 }

--- a/bigint/moon.pkg
+++ b/bigint/moon.pkg
@@ -23,9 +23,12 @@ warnings = "-29"
 
 options(
   targets: {
+    "arith_wide.mbt": [ "native", "wasm" ],
     "bigint_js.mbt": [ "js" ],
     "bigint_js_wbtest.mbt": [ "js" ],
-    "bigint_nonjs.mbt": [ "not", "js" ],
-    "bigint_nonjs_wbtest.mbt": [ "not", "js" ],
+    "bigint_default.mbt": [ "not", "js", "wasm", "native" ],
+    "bigint_default_wbtest.mbt": [ "not", "js", "wasm", "native" ],
+    "bigint_wide.mbt": [ "native", "wasm" ],
+    "bigint_wide_wbtest.mbt": [ "native", "wasm" ],
   },
 )


### PR DESCRIPTION
## Summary

- use `FixedArray[UInt64]` limbs for BigInt on native and wasm1
- retain the existing 32-bit limb implementation on wasm-gc to avoid the multi-value result regression
- leave the JavaScript host-BigInt backend unchanged and preserve the generated public interface

## Implementation

- add full-width word/vector arithmetic, Karatsuba multiplication, reciprocal and Knuth division, and Montgomery exponentiation
- lower `%u64.mul_wide` on native while keeping a portable wasm1 fallback that can adopt wide arithmetic later
- select implementations and white-box tests with file-based target conditions
- make deprecated hexadecimal helpers representation-independent
- cover the UInt64 Karatsuba transition at 63, 64, and 65 limbs

## Testing

- `moon check bigint --target all --deny-warn`
- `moon test bigint --target all --release`
- `moon test --target all`
- `moon test --release --target js,wasm,wasm-gc`
- `moon test --target native --release`
- `moon info --target wasm,wasm-gc,js,native` with no `.mbti` diff
- `moon bundle --all`