### PR TITLE
docs(builtin): expand documentation for integer min/max/clamp

### DIFF
--- a/builtin/int64.mbt
+++ b/builtin/int64.mbt
@@ -72,7 +72,24 @@ pub fn Int64::abs(self : Int64) -> Int64 {
 }
 
 ///|
-/// Returns the minimum of two 64-bit signed integers.
+/// Returns the smaller of two 64-bit signed integers.
+///
+/// Parameters:
+///
+/// * `self` : The first integer to compare.
+/// * `other` : The second integer to compare.
+///
+/// Returns `self` if it is not greater than `other`, `other` otherwise.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect(1L.min(2L), content="1")
+///   inspect(2L.min(1L), content="1")
+///   inspect((-1L).min(0L), content="-1")
+/// }
+/// ```
 pub fn Int64::min(self : Int64, other : Int64) -> Int64 {
   if self < other {
     self
@@ -82,7 +99,24 @@ pub fn Int64::min(self : Int64, other : Int64) -> Int64 {
 }
 
 ///|
-/// Returns the maximum of two 64-bit signed integers.
+/// Returns the larger of two 64-bit signed integers.
+///
+/// Parameters:
+///
+/// * `self` : The first integer to compare.
+/// * `other` : The second integer to compare.
+///
+/// Returns `self` if it is not less than `other`, `other` otherwise.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect(1L.max(2L), content="2")
+///   inspect(2L.max(1L), content="2")
+///   inspect((-1L).max(0L), content="0")
+/// }
+/// ```
 pub fn Int64::max(self : Int64, other : Int64) -> Int64 {
   if self > other {
     self
@@ -92,7 +126,26 @@ pub fn Int64::max(self : Int64, other : Int64) -> Int64 {
 }
 
 ///|
-/// Clamps the value `self` between `min` and `max`.
+/// Clamps a 64-bit signed integer into the inclusive range [`min`, `max`].
+///
+/// Parameters:
+///
+/// * `self` : The value to clamp.
+/// * `min` : The lower bound of the range.
+/// * `max` : The upper bound of the range.
+///
+/// Returns `min` if `self` is less than `min`, `max` if `self` is greater
+/// than `max`, and `self` otherwise. Aborts if `min` is greater than `max`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect(5L.clamp(min=0L, max=10L), content="5")
+///   inspect((-5L).clamp(min=0L, max=10L), content="0")
+///   inspect(15L.clamp(min=0L, max=10L), content="10")
+/// }
+/// ```
 pub fn Int64::clamp(self : Int64, min~ : Int64, max~ : Int64) -> Int64 {
   guard! min <= max
   if self < min {

--- a/builtin/uint.mbt
+++ b/builtin/uint.mbt
@@ -26,7 +26,24 @@
 pub fn UInt::UInt(self : UInt) -> UInt = "%identity"
 
 ///|
-/// Returns the minimum of two unsigned integers.
+/// Returns the smaller of two unsigned integers.
+///
+/// Parameters:
+///
+/// * `self` : The first integer to compare.
+/// * `other` : The second integer to compare.
+///
+/// Returns `self` if it is not greater than `other`, `other` otherwise.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect(UInt(1).min(UInt(2)), content="1")
+///   inspect(UInt(2).min(UInt(1)), content="1")
+///   inspect(UInt(0).min(UInt(0)), content="0")
+/// }
+/// ```
 pub fn UInt::min(self : UInt, other : UInt) -> UInt {
   if self < other {
     self
@@ -36,7 +53,24 @@ pub fn UInt::min(self : UInt, other : UInt) -> UInt {
 }
 
 ///|
-/// Returns the maximum of two unsigned integers.
+/// Returns the larger of two unsigned integers.
+///
+/// Parameters:
+///
+/// * `self` : The first integer to compare.
+/// * `other` : The second integer to compare.
+///
+/// Returns `self` if it is not less than `other`, `other` otherwise.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect(UInt(1).max(UInt(2)), content="2")
+///   inspect(UInt(2).max(UInt(1)), content="2")
+///   inspect(UInt(0).max(UInt(0)), content="0")
+/// }
+/// ```
 pub fn UInt::max(self : UInt, other : UInt) -> UInt {
   if self > other {
     self
@@ -46,7 +80,26 @@ pub fn UInt::max(self : UInt, other : UInt) -> UInt {
 }
 
 ///|
-/// Clamps the value `self` between `min` and `max`.
+/// Clamps an unsigned integer into the inclusive range [`min`, `max`].
+///
+/// Parameters:
+///
+/// * `self` : The value to clamp.
+/// * `min` : The lower bound of the range.
+/// * `max` : The upper bound of the range.
+///
+/// Returns `min` if `self` is less than `min`, `max` if `self` is greater
+/// than `max`, and `self` otherwise. Aborts if `min` is greater than `max`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   inspect(UInt(5).clamp(min=UInt(0), max=UInt(10)), content="5")
+///   inspect(UInt(0).clamp(min=UInt(2), max=UInt(10)), content="2")
+///   inspect(UInt(15).clamp(min=UInt(0), max=UInt(10)), content="10")
+/// }
+/// ```
 pub fn UInt::clamp(self : UInt, min~ : UInt, max~ : UInt) -> UInt {
   guard! min <= max
   if self < min {


### PR DESCRIPTION
Continues #623 (improve comment coverage for builtin).

`Int64::min`, `Int64::max`, `Int64::clamp`, `UInt::min`, `UInt::max` and `UInt::clamp` currently carry one-line comments. These are the only integer types with the `min`/`max`/`clamp` family, so this completes the family's documentation:

- semantics and parameters
- return behavior, including the abort when `min > max` in `clamp`
- executable `mbt check` examples in the existing `inspect` style

Documentation-only change; no signatures or behavior are affected.