### PR TITLE
refactor(builtin): add Array::Array constructor, deprecate Array::new

### DIFF
--- a/argparse/help_render.mbt
+++ b/argparse/help_render.mbt
@@ -125,7 +125,7 @@ fn required_option_token(arg : Arg) -> String? {
 
 ///|
 fn positional_usage(cmd : Command) -> String {
-  let parts = Array::new(capacity=cmd.args.length())
+  let parts = Array(capacity=cmd.args.length())
   for arg in positional_args(cmd.args) {
     if arg.hidden {
       continue
@@ -149,7 +149,7 @@ fn positional_usage(cmd : Command) -> String {
 ///|
 fn option_entries(cmd : Command) -> Array[String] {
   let args = cmd.args
-  let display = Array::new(capacity=args.length() + 2)
+  let display = Array(capacity=args.length() + 2)
   let builtin_help_short = help_flag_enabled(cmd) &&
     !has_short_option(args, 'h')
   let builtin_help_long = help_flag_enabled(cmd) &&
@@ -261,7 +261,7 @@ fn subcommand_entries(cmd : Command) -> Array[String] {
 
 ///|
 fn group_entries(cmd : Command) -> Array[String] {
-  let display = Array::new(capacity=cmd.groups.length())
+  let display = Array(capacity=cmd.groups.length())
   for group in cmd.groups {
     let members = group_members(cmd, group)
     if members == "" {
@@ -313,7 +313,7 @@ fn format_entries(display : Array[(String, String)]) -> Array[String] {
 
 ///|
 fn arg_display(arg : Arg) -> String {
-  let parts = Array::new(capacity=2)
+  let parts = Array(capacity=2)
   let (short, long) = match arg.info {
     OptionInfo(short~, long~, ..)
     | FlagInfo(short~, long~, ..)

--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -548,7 +548,7 @@ fn parse_command_impl(
           Some(v) => v
           None =>
             if default_subcommand is Some(sub) {
-              let remaining = Array::new(capacity=argv.length() - i)
+              let remaining = Array(capacity=argv.length() - i)
               remaining.push("-\{short}\{String::from_iter(chars)}")
               for rest in argv[i + 1:] {
                 remaining.push(rest)

--- a/bench/README.mbt.md
+++ b/bench/README.mbt.md
@@ -35,7 +35,7 @@ test "benchmark collection" {
 
   // Add multiple benchmarks to the collection
   bencher.bench(name="array_creation", fn() {
-    let arr = Array::new()
+    let arr = Array()
     for i in 0..<5 {
       arr.push(i)
     }
@@ -100,7 +100,7 @@ test "data structure benchmarks" {
 
   // Benchmark Array operations
   bencher.bench(name="array_append", fn() {
-    let arr = Array::new()
+    let arr = Array()
     for i in 0..<5 {
       arr.push(i)
     }
@@ -272,7 +272,7 @@ test "meaningful names" {
 
   // Good: Descriptive names that explain what's being measured
   bencher.bench(name="array_insert_10_items", fn() {
-    let arr = Array::new()
+    let arr = Array()
     for i in 0..<10 {
       arr.push(i * 2)
     }
@@ -310,7 +310,7 @@ test "performance regression test" {
   // Benchmark a critical path
   bencher.bench(name="critical_algorithm", fn() {
     let data = [5, 2, 8, 1, 9, 3, 7, 4, 6]
-    let sorted = Array::new()
+    let sorted = Array()
     for x in data {
       sorted.push(x)
     }

--- a/builtin/README.mbt.md
+++ b/builtin/README.mbt.md
@@ -141,7 +141,7 @@ Built-in array types for storing collections:
 ///|
 test "arrays" {
   // Dynamic arrays
-  let arr1 = Array::new()
+  let arr1 = Array()
   arr1.push(1)
   arr1.push(2)
   arr1.push(3)

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1302,7 +1302,7 @@ pub fn[T] Array::repeat(self : Array[T], times : Int) -> Array[T] {
   }
   let total = len * times
   guard total / times == len else { abort("repeat result too large") }
-  let v = Array::new(capacity=total)
+  let v = Array::Array(capacity=total)
   for _ in 0..<times {
     v.append(self)
   }
@@ -2117,8 +2117,8 @@ pub fn[A, B] Array::zip(self : Array[A], other : Array[B]) -> Array[(A, B)] {
 /// }
 /// ```
 pub fn[T1, T2] Array::unzip(self : Array[(T1, T2)]) -> (Array[T1], Array[T2]) {
-  let arr1 : Array[T1] = Array::new(capacity=self.length())
-  let arr2 : Array[T2] = Array::new(capacity=self.length())
+  let arr1 : Array[T1] = Array(capacity=self.length())
+  let arr2 : Array[T2] = Array(capacity=self.length())
   for pair in self {
     let (x, y) = pair
     arr1.push(x)

--- a/builtin/array_nonjs_test.mbt
+++ b/builtin/array_nonjs_test.mbt
@@ -14,13 +14,13 @@
 
 ///|
 test "array_capacity" {
-  let arr : Array[Int] = Array::new(capacity=10)
+  let arr : Array[Int] = Array(capacity=10)
   assert_true(arr.capacity() >= 10)
 }
 
 ///|
 test "array_append_reuses_capacity" {
-  let arr = Array::new(capacity=4)
+  let arr = Array(capacity=4)
   arr.push(1)
   arr.append([2, 3])
   inspect(arr.capacity(), content="4")
@@ -29,7 +29,7 @@ test "array_append_reuses_capacity" {
 
 ///|
 test "array_append_grows_geometrically" {
-  let arr = Array::new(capacity=4)
+  let arr = Array(capacity=4)
   arr.append([1, 2, 3, 4, 5])
   inspect(arr.capacity(), content="8")
   debug_inspect(arr, content="[1, 2, 3, 4, 5]")
@@ -37,7 +37,7 @@ test "array_append_grows_geometrically" {
 
 ///|
 test "array_blit_to_reuses_and_grows_capacity" {
-  let dst = Array::new(capacity=4)
+  let dst = Array(capacity=4)
   dst.push(0)
   [1, 2][:].blit_to(dst, dst_offset=1)
   inspect(dst.capacity(), content="4")
@@ -59,7 +59,7 @@ test "array_retain" {
 
 ///|
 test "shrink_to_fit" {
-  let v = Array::new(capacity=10)
+  let v = Array(capacity=10)
   v.push(1)
   v.push(2)
   v.push(3)

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 test "array_new" {
-  let arr : Array[Int] = Array::new()
+  let arr : Array[Int] = Array()
   @test.assert_eq(arr.length(), 0)
 }
 
@@ -39,7 +39,7 @@ test "array_make" {
 
 ///|
 test "array_realloc" {
-  let arr = Array::new(capacity=2)
+  let arr = Array(capacity=2)
   arr.push(1)
   arr.push(2)
   arr.push(3) // This should trigger a reallocation
@@ -149,7 +149,7 @@ test "array_append" {
   // @test.assert_eq(arr1.capacity(), 6)
   @test.assert_eq(arr1[3], 4)
   let cap = 20
-  let arr3 = Array::new(capacity=cap)
+  let arr3 = Array(capacity=cap)
   arr3.resize(cap, 10)
   arr1.append(arr3)
   @test.assert_eq(arr1.length(), 6 + cap)
@@ -303,7 +303,7 @@ test "array_filter" {
 
 ///|
 test "array_is_empty" {
-  let arr : Array[Int] = Array::new()
+  let arr : Array[Int] = Array()
   assert_true(arr.is_empty())
 }
 
@@ -662,7 +662,7 @@ test "array_reserve_capacity" {
 
 ///|
 test "array_shrink_to_fit" {
-  let arr = Array::new(capacity=10)
+  let arr = Array(capacity=10)
   arr.push(1)
   arr.push(2)
   arr.push(3)
@@ -755,7 +755,7 @@ test "array_binary_search_by_test" {
 
 ///|
 test "array of bytes, new & push" {
-  let bytes : Array[Byte] = Array::new(capacity=10)
+  let bytes : Array[Byte] = Array(capacity=10)
   bytes.push(b'a')
   debug_inspect(
     bytes,
@@ -1562,7 +1562,7 @@ test "Array::unsafe_pop" {
 test "Array::append/self_alias" {
   // Test appending array to itself - this should double the array
   // Using small capacity to force reallocation during append
-  let arr = Array::new(capacity=3)
+  let arr = Array(capacity=3)
   arr.push(1)
   arr.push(2)
   arr.push(3)
@@ -1573,7 +1573,7 @@ test "Array::append/self_alias" {
 ///|
 test "Array::append/self_alias_partial" {
   // Test appending a partial view of array to itself
-  let arr = Array::new(capacity=4)
+  let arr = Array(capacity=4)
   arr.push(1)
   arr.push(2)
   arr.push(3)

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -162,7 +162,7 @@ fn[T] Array::unsafe_resize_with_default(
 
 ///|
 /// Creates a new array.
-pub fn[T] Array::new(capacity? : Int = 0) -> Array[T] {
+pub fn[T] Array::Array(capacity? : Int = 0) -> Array[T] {
   ignore(capacity)
   []
 }
@@ -232,7 +232,7 @@ pub fn[T] Array::reserve_capacity(self : Array[T], capacity : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let v = Array::new(capacity=10)
+///   let v = Array(capacity=10)
 ///   v.push(1)
 ///   v.push(2)
 ///   v.push(3)

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -106,14 +106,14 @@ fn[T] Array::unsafe_resize_with_default(
 ///
 /// ```mbt check
 /// test {
-///   let arr : Array[Int] = Array::new(capacity=10)
+///   let arr : Array[Int] = Array(capacity=10)
 ///   inspect(arr.length(), content="0")
 ///   inspect(arr.capacity(), content="10")
-///   let arr : Array[Int] = Array::new()
+///   let arr : Array[Int] = Array()
 ///   inspect(arr.length(), content="0")
 /// }
 /// ```
-pub fn[T] Array::new(capacity? : Int = 0) -> Array[T] {
+pub fn[T] Array::Array(capacity? : Int = 0) -> Array[T] {
   if capacity == 0 {
     []
   } else {
@@ -273,7 +273,7 @@ test "UninitializedArray::unsafe_blit_fixed" {
 
 ///|
 test "Array::resize_buffer" {
-  let arr = Array::new(capacity=2)
+  let arr = Array::Array(capacity=2)
   arr.push(1)
   arr.push(2)
   arr.resize_buffer(4)
@@ -324,7 +324,7 @@ pub fn[T] Array::reserve_capacity(self : Array[T], capacity : Int) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let v = Array::new(capacity=10)
+///   let v = Array(capacity=10)
 ///   v.push(1)
 ///   v.push(2)
 ///   v.push(3)

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -110,3 +110,12 @@ pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
     c1.unsafe_to_char()
   }
 }
+
+///|
+/// Creates a new empty array with an optional initial capacity.
+///
+/// Deprecated: use `Array(capacity=...)` instead.
+#deprecated("Use `Array(capacity=...)` instead")
+pub fn[T] Array::new(capacity? : Int = 0) -> Array[T] {
+  Array(capacity~)
+}

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -813,7 +813,7 @@ pub impl[T] Add for Iter[T] with fn add(self, other) {
 #alias(collect)
 pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
   let result = match self.size_hint {
-    Some(n) => Array::new(capacity=n)
+    Some(n) => Array::Array(capacity=n)
     None => []
   }
   while self.next() is Some(x) {

--- a/builtin/linked_hash_map_wbtest.mbt
+++ b/builtin/linked_hash_map_wbtest.mbt
@@ -108,9 +108,9 @@ test "get_or_default" {
 ///|
 test "get_or_init" {
   let m : Map[String, Array[Int]] = Map([])
-  m.get_or_init("a", () => Array::new()).push(1)
-  m.get_or_init("b", () => Array::new()).push(2)
-  m.get_or_init("a", () => Array::new()).push(3)
+  m.get_or_init("a", () => Array()).push(1)
+  m.get_or_init("b", () => Array()).push(2)
+  m.get_or_init("a", () => Array()).push(3)
   assert_true(m.get("a") == Some([1, 3]))
   assert_true(m.get("b") == Some([2]))
   assert_true(m.length() == 2)
@@ -120,10 +120,10 @@ test "get_or_init" {
 test "get_or_init on push_back" {
   let m : Map[MyString, Array[Int]] = Map([], capacity=4)
   inspect(m.grow_at, content="3")
-  m.set("x", Array::new())
-  m.set("xx", Array::new())
+  m.set("x", Array())
+  m.set("xx", Array())
   // inspect(m._debug_entries(), content="_,(0,x,[]),(0,xx,[]),_")
-  m.get_or_init("a", () => Array::new()).push(1)
+  m.get_or_init("a", () => Array()).push(1)
   // inspect(m._debug_entries(), content="_,(0,x,[]),(1,a,[1]),(1,xx,[])")
 }
 

--- a/builtin/panic_nonjs_test.mbt
+++ b/builtin/panic_nonjs_test.mbt
@@ -14,6 +14,6 @@
 
 ///|
 test "panic array_pop_exn_empty" {
-  let arr : Array[Int] = Array::new()
+  let arr : Array[Int] = Array()
   arr.unsafe_pop() |> ignore // This should panic
 }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -64,6 +64,7 @@ pub fn ArgsLoc::to_string(Self) -> String
 pub impl Show for ArgsLoc
 
 type Array[T]
+pub fn[T] Array::Array(capacity? : Int) -> Self[T]
 pub fn[T] Array::add(Self[T], Self[T]) -> Self[T]
 #alias(every)
 pub fn[T] Array::all(Self[T], (T) -> Bool raise?) -> Bool raise?
@@ -128,6 +129,7 @@ pub fn[T, U] Array::mapi(Self[T], (Int, T) -> U raise?) -> Self[U] raise?
 #alias(mapi_inplace, deprecated)
 pub fn[T] Array::mapi_in_place(Self[T], (Int, T) -> T raise?) -> Unit raise?
 pub fn[T] Array::mut_view(Self[T], start? : Int, end? : Int) -> MutArrayView[T]
+#deprecated
 pub fn[T] Array::new(capacity? : Int) -> Self[T]
 pub fn[T] Array::pop(Self[T]) -> T?
 pub fn[T] Array::push(Self[T], T) -> Unit

--- a/builtin/string.mbt
+++ b/builtin/string.mbt
@@ -257,7 +257,7 @@ fn unsafe_to_bytes(array : FixedArray[Byte]) -> Bytes = "%identity"
 pub fn String::to_array(self : String) -> Array[Char] {
   self
   .iter()
-  .fold(init=Array::new(capacity=self.length()), (rv, c) => {
+  .fold(init=Array(capacity=self.length()), (rv, c) => {
     rv.push(c)
     rv
   })

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -422,7 +422,7 @@ pub fn StringView::strip_suffix(
 pub fn StringView::to_array(self : StringView) -> Array[Char] {
   self
   .iter()
-  .fold(init=Array::new(capacity=self.length()), (rv, c) => {
+  .fold(init=Array(capacity=self.length()), (rv, c) => {
     rv.push(c)
     rv
   })

--- a/builtin/to_string_test.mbt
+++ b/builtin/to_string_test.mbt
@@ -110,7 +110,7 @@ test "panic UInt::to_string invalid radix" {
 
 ///|
 test "to_string runtime zero paths" {
-  let arr = Array::new()
+  let arr = Array()
   arr.push(1)
   ignore(arr.pop())
   let zero = arr.length()
@@ -122,7 +122,7 @@ test "to_string runtime zero paths" {
 
 ///|
 test "panic UInt64::to_string invalid radix" {
-  let arr = Array::new()
+  let arr = Array()
   arr.push(1)
   ignore(arr.pop())
   let zero = arr.length().to_uint64()

--- a/diff/diff.mbt
+++ b/diff/diff.mbt
@@ -601,7 +601,7 @@ fn[T : Eq + Hash] collect_matches(
   new : ArrayView[T],
   algorithm : DiffAlgorithm,
 ) -> Array[(Int, Int)] {
-  let matches = Array::new(capacity=old.length().min(new.length()))
+  let matches = Array(capacity=old.length().min(new.length()))
   match algorithm {
     Patience => append_patience_matches(matches, cutoff, old, new, 0, 0)
     Myers => append_myers_matches(matches, cutoff, old, new, 0, 0)
@@ -664,7 +664,7 @@ pub fn[T : Hash + Eq] Diff::Diff(
   cutoff? : Int,
   algorithm? : DiffAlgorithm = Myers,
 ) -> Diff[T] {
-  let result : Array[Edit] = Array::new(capacity=old.length() + new.length())
+  let result : Array[Edit] = Array(capacity=old.length() + new.length())
   let matches = collect_matches(cutoff, old, new, algorithm)
   let mut prev_old_idx = 0
   let mut prev_new_idx = 0

--- a/diff/diff_test.mbt
+++ b/diff/diff_test.mbt
@@ -16,7 +16,7 @@
 fn[T] edits_to_string(d : @diff.Diff[T], show~ : (T) -> String) -> String {
   let old = d.old_view()
   let new = d.new_view()
-  let lines = Array::new()
+  let lines = Array()
   for edit in d.edits() {
     let (prefix, slice) = match edit {
       Insert(new_index~, new_len~, ..) =>
@@ -457,7 +457,7 @@ fn check_reconstruct(
   old : ArrayView[Int],
   new : ArrayView[Int],
 ) -> Unit raise {
-  let rebuilt = Array::new()
+  let rebuilt = Array()
   let mut oi = 0
   let mut ni = 0
   for edit in d.edits() {
@@ -502,7 +502,7 @@ test "property: edit scripts reconstruct new from old" {
   let seqs : Array[Array[Int]] = []
   for len in 0..<5 {
     for bits in 0..<(1 << len) {
-      let a = Array::new(capacity=len)
+      let a = Array(capacity=len)
       for i in 0..<len {
         a.push((bits >> i) & 1)
       }

--- a/diff/diff_wbtest.mbt
+++ b/diff/diff_wbtest.mbt
@@ -20,7 +20,7 @@ fn print_edits(
 ) -> String {
   let mut prev_old_idx = 0
   let mut prev_new_idx = 0
-  let result = Array::new(capacity=old.length() + new.length())
+  let result = Array(capacity=old.length() + new.length())
   let callback = fn(old_idx, new_idx) {
     for i in prev_old_idx..<old_idx {
       result.push("-  " + old[i])
@@ -315,7 +315,7 @@ test "reverse order" {
 test "integer arrays diff" {
   let old = [1, 2, 3, 4, 5][:]
   let new = [1, 3, 5, 6, 7][:]
-  let result = Array::new()
+  let result = Array()
   for old_idx, new_idx in iter_matches(old~, new~, cutoff=None) {
     result.push((old_idx, new_idx))
   }
@@ -383,9 +383,9 @@ test "nested insertions and deletions" {
 test "iter_matches callback verification" {
   let old = ['a', 'b', 'c', 'd'].map(x => String::make(3, x))[:]
   let new = ['a', 'x', 'c', 'y'].map(x => String::make(3, x))[:]
-  let matches = Array::new()
-  let old_indices = Array::new()
-  let new_indices = Array::new()
+  let matches = Array()
+  let old_indices = Array()
+  let new_indices = Array()
   for old_idx, new_idx in iter_matches(old~, new~, cutoff=None) {
     matches.push((old_idx, new_idx))
     old_indices.push(old_idx)
@@ -409,7 +409,7 @@ test "iter_matches callback verification" {
 test "string array edge cases" {
   let old = ["", "a", "", "b", ""][:]
   let new = ["", "b", "", "a", ""][:]
-  let result = Array::new()
+  let result = Array()
   for old_idx, new_idx in iter_matches(old~, new~, cutoff=None) {
     result.push((old_idx, new_idx))
   }
@@ -489,7 +489,7 @@ test "partial overlap sequence" {
 test "iter_matches parameter order" {
   let old = ['a', 'b', 'c'].map(x => String::make(3, x))[:]
   let new = ['a', 'x', 'c'].map(x => String::make(3, x))[:]
-  let matches = Array::new()
+  let matches = Array()
   let all_equal = @ref.Ref(true)
   for old_idx, new_idx in iter_matches(old~, new~, cutoff=None) {
     // Verify parameter order: old_idx should correspond to old array, new_idx to new array
@@ -511,7 +511,7 @@ test "iter_matches parameter order" {
 test "repeated subsequence" {
   let old = ['a', 'b', 'a', 'b', 'c'].map(x => String::make(3, x))[:]
   let new = ['a', 'b', 'c', 'a', 'b'].map(x => String::make(3, x))[:]
-  let result = Array::new()
+  let result = Array()
   for old_idx, new_idx in iter_matches(old~, new~, cutoff=None) {
     result.push((old_idx, new_idx))
   }
@@ -526,13 +526,13 @@ test "diff symmetry test" {
   let arr2 = ['a', 'x', 'c'].map(x => String::make(3, x))[:]
 
   // Calculate diff from arr1 -> arr2
-  let matches1 = Array::new()
+  let matches1 = Array()
   for old_idx, new_idx in iter_matches(old=arr1, new=arr2, cutoff=None) {
     matches1.push((old_idx, new_idx))
   }
 
   // Calculate diff from arr2 -> arr1
-  let matches2 = Array::new()
+  let matches2 = Array()
   for old_idx, new_idx in iter_matches(old=arr2, new=arr1, cutoff=None) {
     matches2.push((old_idx, new_idx))
   }

--- a/diff/edit.mbt
+++ b/diff/edit.mbt
@@ -96,8 +96,8 @@ fn[T] group_edits(
     return []
   }
   let n = edits.length()
-  let mut pending : Array[Edit] = Array::new()
-  let result : Array[Hunk[T]] = Array::new()
+  let mut pending : Array[Edit] = Array()
+  let result : Array[Hunk[T]] = Array()
   for i, edit in edits {
     match edit {
       Equal(old_index~, new_index~, len~) => {

--- a/diff/unique_lcs.mbt
+++ b/diff/unique_lcs.mbt
@@ -28,7 +28,7 @@ fn[T : Eq + Hash] unique_lcs(
   new~ : ArrayView[T],
 ) -> ArrayView[(Int, Int)] {
   let matches = find_unique(old~, new~)
-  let piles = Piles(Array::new(capacity=matches.length()))
+  let piles = Piles(Array(capacity=matches.length()))
   for place in 0..<matches.length() {
     let (_, new_idx) = matches[place]
     // Each pile top stores `(new_idx, place)`: the candidate tail in `new~`

--- a/env/README.mbt.md
+++ b/env/README.mbt.md
@@ -241,7 +241,7 @@ test "argument validation" {
       (args[0], []) // Program name only, no arguments
     } else {
       let program = args[0]
-      let arguments = Array::new()
+      let arguments = Array()
       for i in 1..<args.length() {
         arguments.push(args[i])
       }

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -58,9 +58,9 @@ test "get_or_default" {
 ///|
 test "get_or_init" {
   let m : @hashmap.HashMap[String, Array[Int]] = HashMap([])
-  m.get_or_init("a", () => Array::new()).push(1)
-  m.get_or_init("b", () => Array::new()).push(2)
-  m.get_or_init("a", () => Array::new()).push(3)
+  m.get_or_init("a", () => Array()).push(1)
+  m.get_or_init("b", () => Array()).push(2)
+  m.get_or_init("a", () => Array()).push(3)
   @test.assert_eq(m.get("a"), Some([1, 3]))
   @test.assert_eq(m.get("b"), Some([2]))
   @test.assert_eq(m.length(), 2)

--- a/immut/hashmap/HAMT.mbt
+++ b/immut/hashmap/HAMT.mbt
@@ -902,7 +902,7 @@ pub fn[K : Eq + Hash, V] HashMap::from_iter(
     return hash_map_from_iter_by_add(iter)
   }
   let entries = match iter.size_hint() {
-    Some(len) => Array::new(capacity=len)
+    Some(len) => Array(capacity=len)
     None => []
   }
   iter.each(e => entries.push({ key: e.0, value: e.1, path: @path.of(e.0), }))

--- a/immut/hashset/HAMT.mbt
+++ b/immut/hashset/HAMT.mbt
@@ -590,7 +590,7 @@ pub fn[A : Eq + Hash] HashSet::from_iter(iter : Iter[A]) -> HashSet[A] {
     return hash_set_from_iter_by_add(iter)
   }
   let entries = match iter.size_hint() {
-    Some(len) => Array::new(capacity=len)
+    Some(len) => Array(capacity=len)
     None => []
   }
   iter.each(value => entries.push({ value, path: @path.of(value), }))

--- a/immut/vector/vector.mbt
+++ b/immut/vector/vector.mbt
@@ -673,7 +673,7 @@ pub fn[A] Vector::filter(
   self : Vector[A],
   f : (A) -> Bool raise?,
 ) -> Vector[A] raise? {
-  let arr : Array[A] = Array::new(capacity=self.size)
+  let arr : Array[A] = Array(capacity=self.size)
   self.each(value => if f(value) { arr.push(value) })
   from_array(arr)
 }
@@ -758,7 +758,7 @@ pub impl[A : @json.FromJson] @json.FromJson for Vector[A] with fn from_json(
   }
   let len = arr.length()
   guard len != 0 else { return new() }
-  let values : Array[A] = Array::new(capacity=len)
+  let values : Array[A] = Array(capacity=len)
   for i, value in arr {
     values.push(A::from_json(value, path.add_index(i)))
   }

--- a/immut/vector_map/iter.mbt
+++ b/immut/vector_map/iter.mbt
@@ -92,7 +92,7 @@ pub fn[K, V, A] VectorMap::fold(
 ///|
 /// Collect the entries into an array, in insertion order. `O(n)`.
 pub fn[K, V] VectorMap::to_array(self : VectorMap[K, V]) -> Array[(K, V)] {
-  let result : Array[(K, V)] = Array::new(capacity=self.size)
+  let result : Array[(K, V)] = Array(capacity=self.size)
   self.each((k, v) => result.push((k, v)))
   result
 }

--- a/immut/vector_map/traits_impl.mbt
+++ b/immut/vector_map/traits_impl.mbt
@@ -94,7 +94,7 @@ pub impl[K : @json.FromJson + Eq + Hash, V : @json.FromJson] @json.FromJson for 
   guard json is Array(pairs) else {
     raise JsonDecodeError((path, "@immut/vector_map.from_json: expected array"))
   }
-  let entries : Array[(K, V)] = Array::new(capacity=pairs.length())
+  let entries : Array[(K, V)] = Array(capacity=pairs.length())
   for i, pair in pairs {
     let entry_path = path.add_index(i)
     guard pair is Array([key, value]) else {

--- a/immut/vector_map/vector_map.mbt
+++ b/immut/vector_map/vector_map.mbt
@@ -301,7 +301,7 @@ fn[K, V] VectorMap::should_compact(self : VectorMap[K, V]) -> Bool {
 /// without a single hash being recomputed.
 fn[K, V] VectorMap::compact(self : VectorMap[K, V]) -> VectorMap[K, V] {
   let remap = FixedArray::make(self.spine.length(), 0)
-  let kept : Array[(K, V)?] = Array::new(capacity=self.size)
+  let kept : Array[(K, V)?] = Array(capacity=self.size)
   self.spine.eachi((slot, entry) => {
     if entry is Some(_) {
       remap[slot] = kept.length()

--- a/json/json_traverse_test.mbt
+++ b/json/json_traverse_test.mbt
@@ -49,7 +49,7 @@ fn Json::prune_loc(self : Json) -> Json? {
   match self {
     Null | True | False | Number(_, ..) | String(_) => Some(self)
     Array(arr) => {
-      let pruned_arr = Array::new()
+      let pruned_arr = Array()
       for item in arr {
         guard item.prune_loc() is Some(pruned_item) else { () } // drop this item
         pruned_arr.push(pruned_item)

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -101,7 +101,7 @@ pub impl[A : Show] Show for List[A] with fn output(xs, logger) {
 pub impl[A : ToJson] ToJson for List[A] with fn to_json(self) {
   let capacity = self.length()
   guard capacity != 0 else { return [] }
-  let jsons = Array::new(capacity~)
+  let jsons = Array(capacity~)
   for a in self {
     jsons.push(a.to_json())
   }

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -108,7 +108,7 @@ pub fn[A] PriorityQueue::copy(self : PriorityQueue[A]) -> PriorityQueue[A] {
 pub fn[A : Compare] PriorityQueue::to_array(
   self : PriorityQueue[A],
 ) -> Array[A] {
-  let arr = Array::new(capacity=self.len)
+  let arr = Array(capacity=self.len)
   let stack : Array[Node[A]?] = [self.top]
   while stack.pop() is Some(node) {
     match node {

--- a/queue/queue_test.mbt
+++ b/queue/queue_test.mbt
@@ -88,7 +88,7 @@ test "from_array_2" {
       #|<Queue: [1, 2, 3]>
     ),
   )
-  let q : @queue.Queue[Int] = @queue.from_array(Array::new(capacity=10))
+  let q : @queue.Queue[Int] = @queue.from_array(Array(capacity=10))
   debug_inspect(
     q,
     content=(

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -562,7 +562,7 @@ pub fn[K] Set::iter(self : Set[K]) -> Iter[K] {
 ///|
 /// Converts the hash set to an array.
 pub fn[K] Set::to_array(self : Set[K]) -> Array[K] {
-  let arr = Array::new(capacity=self.size)
+  let arr = Array(capacity=self.size)
   for x = self.head {
     match x {
       Some({ key, next, .. }) => {
@@ -680,7 +680,7 @@ pub fn[K : Hash + Eq] Set::intersection(
 
 ///|
 pub impl[X : ToJson] ToJson for Set[X] with fn to_json(self) {
-  let res = Array::new(capacity=self.size)
+  let res = Array(capacity=self.size)
   for v in self {
     res.push(v.to_json())
   }

--- a/string/regex_bench_test.mbt
+++ b/string/regex_bench_test.mbt
@@ -45,7 +45,7 @@ test "bench regex large pattern" (it : @bench.T) {
     "\{i}".pad_start(3, '0')
   }
   fn make_large_pattern() -> String {
-    let parts = Array::new()
+    let parts = Array()
     for i in 0..<38 {
       let idx = padded3(i)
       parts.push(
@@ -55,7 +55,7 @@ test "bench regex large pattern" (it : @bench.T) {
     parts.join("|")
   }
   fn make_filenames() -> Array[String] {
-    let filenames = Array::new(capacity=20_000)
+    let filenames = Array(capacity=20_000)
     for i in 0..<20_000 {
       if i % 5 == 0 {
         let idx = padded3(i % 38)

--- a/test/README.mbt.md
+++ b/test/README.mbt.md
@@ -283,7 +283,7 @@ Keep tests focused on a single concept:
 ///|
 ///  Good - tests one specific behavior
 test "array_push_increases_length" {
-  let arr = Array::new()
+  let arr = Array()
   let initial_length = arr.length()
   arr.push(42)
   let new_length = arr.length()
@@ -293,7 +293,7 @@ test "array_push_increases_length" {
 ///|
 ///  Good - tests another specific behavior
 test "array_push_adds_element_at_end" {
-  let arr = Array::new()
+  let arr = Array()
   arr.push(10)
   arr.push(20)
   inspect(arr[arr.length() - 1], content="20")


### PR DESCRIPTION
## What

`Array::new` was one of the last holdouts of the `T::T` constructor convention. The mutable containers — `Map`, `HashMap`, `Set`, `Deque`, `Queue`, `SortedMap`, `HashSet`, `PriorityQueue`, `SortedSet` — already migrated, and their `::new` forms live in `deprecated.mbt` today.

This renames `Array::new(capacity?)` to `Array::Array(capacity?)` on both the js and non-js backends, enabling the bare sugar:

```moonbit
let a : Array[Int] = Array(capacity=10)
let b = Array(capacity=10)   // also infers fine
```

`Array::new` stays as a deprecated shim in `builtin/deprecated.mbt`, following the `Map::new` pattern.

## Why this signature

The house shape for the migrated containers is `T::T(ArrayView[elem], capacity? : Int)`, so the strictly consistent form would be `Array([], capacity=10)` mirroring `Map([], capacity=10)`.

The positional `ArrayView` slot is omitted here on purpose. For `Array` it degenerates into a copy constructor duplicating `to_array()`, and dropping it keeps downstream migration a plain textual substitution of `Array::new(` to `Array(` — a one-line codemod rather than a rewrite that teaches every caller a new argument shape.

## Note on the `Json` collision

`Json` declares an `Array(Array[Json])` constructor. Inside the `builtin` package, where `Json` is defined locally, the bare form is ambiguous:

> The constructor Array is ambiguous: it may come from type Array or Json.

Three call sites are affected and now spell it `Array::Array` — `builtin/array.mbt:1305`, `builtin/arraycore_nonjs.mbt:277`, `builtin/iterator.mbt:816`.

This does **not** propagate outward. Verified from `array/`, an ordinary package that receives `Json` via the implicit builtin import: both the annotated and the fully inferred forms resolve without ambiguity. Downstream code only hits this if it declares its own enum with an `Array` constructor in the same package, and the compiler names the fix in the error.

## Not included

The remaining `::new` holdouts are untouched: `Bytes::new`, `Iter::new` / `Iter2::new`, `Rand::new`, `CoverageCounter::new`. `Bytes::Bytes` would fit the pattern cleanly; `Iter::new` takes a closure rather than elements and is a genuinely different shape.

The immutable containers (`List`, `Vector`, `VectorMap`, immut `HashMap` / `HashSet` / `SortedMap` / `SortedSet`) keep a live `new()` alongside `T::T(view)`, where `new()` means "empty" and `T::T` means "from elements". Worth confirming that split is intentional, since `Array` now makes them the outliers.

## Verification

- `moon check --target all` — clean, 531 tasks, 0 warnings
- `moon test` — default 7573, js 7514, wasm 7573, native 7488, all passing
- `moon fmt` — no changes
- `moon bundle` — ok
- `moon info` — `builtin/pkg.generated.mbti` regenerated and committed

All 76 in-repo call sites plus 8 in `README.mbt.md` doctests were migrated to the bare form.
