### PR TITLE
perf: build Array::copy and the to_array paths without a redundant fill

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -74,7 +74,7 @@ pub fn[T] Array::from_fixed_array(arr : FixedArray[T]) -> Array[T] {
 /// One should use makei() instead which creates an object for each index.
 #owned(elem)
 pub fn[T] Array::make(len : Int, elem : T) -> Array[T] {
-  let arr = Array::make_uninit(len)
+  let arr = Array::unsafe_make_uninit(len)
   for i in 0..<len {
     arr.unsafe_set(i, elem)
   }
@@ -109,7 +109,7 @@ pub fn[T] Array::makei(length : Int, f : (Int) -> T raise?) -> Array[T] raise? {
   if length <= 0 {
     []
   } else {
-    let array = Array::make_uninit(length)
+    let array = Array::unsafe_make_uninit(length)
     for i in 0..<length {
       array.unsafe_set(i, f(i))
     }
@@ -588,7 +588,7 @@ pub fn[T, U] Array::map(
   self : Array[T],
   f : (T) -> U raise?,
 ) -> Array[U] raise? {
-  let arr = Array::make_uninit(self.length())
+  let arr = Array::unsafe_make_uninit(self.length())
   for i, v in self {
     arr.unsafe_set(i, f(v))
   }
@@ -636,7 +636,7 @@ pub fn[T, U] Array::mapi(
   if self.is_empty() {
     return []
   }
-  let arr = Array::make_uninit(self.length())
+  let arr = Array::unsafe_make_uninit(self.length())
   for i, v in self {
     arr.unsafe_set(i, f(i, v))
   }
@@ -775,7 +775,7 @@ pub fn[T] Array::rev_in_place(self : Array[T]) -> Unit {
 /// ```
 pub fn[T] Array::rev(self : Array[T]) -> Array[T] {
   let len = self.length()
-  let arr = Array::make_uninit(len)
+  let arr = Array::unsafe_make_uninit(len)
   for i in 0..<len {
     arr.unsafe_set(i, self.unsafe_get(len - i - 1))
   }
@@ -818,7 +818,7 @@ pub fn[T] Array::split_at(self : Array[T], index : Int) -> (Array[T], Array[T]) 
       len=len2,
     )
   } else {
-    Array::make_uninit(0)
+    Array::unsafe_make_uninit(0)
   }
   (v1, v2)
 }
@@ -1271,7 +1271,7 @@ pub fn[T] Array::flatten(self : Array[Array[T]]) -> Array[T] {
   } nobreak {
     len
   }
-  let res = Array::make_uninit(len)
+  let res = Array::unsafe_make_uninit(len)
   for xs in self; i = 0 {
     res.unsafe_blit(i, xs, 0, xs.length())
     continue i + xs.length()

--- a/builtin/array_make_blit_bench_test.mbt
+++ b/builtin/array_make_blit_bench_test.mbt
@@ -116,3 +116,23 @@ test "bench Array::push Ref n=1000000 resize" (it : @bench.T) {
     it.keep(data)
   })
 }
+
+///|
+fn make_blit_int_array(len : Int) -> Array[Int] {
+  Array::makei(len, i => i)
+}
+
+///|
+/// `Array::copy` allocates and fills in one shot. The Int and Ref variants are
+/// both kept because the element type decides whether the per-element store
+/// carries reference-counting traffic.
+test "bench Array::copy Int n=1000000" (it : @bench.T) {
+  let data = make_blit_int_array(make_blit_ref_bench_size)
+  it.bench(fn() { it.keep(data.copy()) })
+}
+
+///|
+test "bench Array::copy Ref n=1000000" (it : @bench.T) {
+  let data = make_blit_ref_array(make_blit_ref_bench_size)
+  it.bench(fn() { it.keep(data.copy()) })
+}

--- a/builtin/array_wbtest.mbt
+++ b/builtin/array_wbtest.mbt
@@ -14,6 +14,6 @@
 
 ///|
 test {
-  let empty : Array[Unit] = Array::make_uninit(0)
+  let empty : Array[Unit] = Array::unsafe_make_uninit(0)
   assert_true(empty == [])
 }

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -106,7 +106,14 @@ extern "js" fn JSArray::copy(self : JSArray) -> JSArray =
 type Array[T]
 
 ///|
-fn[T] Array::make_uninit(len : Int) -> Array[T] = "%fixedarray.make_uninit"
+/// Creates an array of `len` elements whose contents are unspecified. The
+/// array reports `length() == len` immediately, so every slot is observable
+/// and the caller must write all of them before the array is read or escapes.
+///
+/// Prefer `Array::makei` unless the initializing loop cannot be expressed as
+/// a function of the index.
+#doc(hidden)
+pub fn[T] Array::unsafe_make_uninit(len : Int) -> Array[T] = "%fixedarray.make_uninit"
 
 ///|
 fn[T] Array::unsafe_make_and_blit(
@@ -116,7 +123,7 @@ fn[T] Array::unsafe_make_and_blit(
   src_offset? : Int = 0,
   dst_offset? : Int = 0,
 ) -> Array[T] {
-  let dst = Array::make_uninit(allocate_len)
+  let dst = Array::unsafe_make_uninit(allocate_len)
   UninitializedArray::unsafe_blit(
     dst.buffer(),
     dst_offset,
@@ -135,7 +142,7 @@ fn[T] Array::unsafe_make_and_blit_from_fixed(
   src_offset? : Int = 0,
   dst_offset? : Int = 0,
 ) -> Array[T] {
-  let dst = Array::make_uninit(allocate_len)
+  let dst = Array::unsafe_make_uninit(allocate_len)
   UninitializedArray::unsafe_blit_fixed(
     dst.buffer(),
     dst_offset,

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -781,10 +781,9 @@ pub fn[A] Array::fill(
 pub fn[T] Array::copy(self : Array[T]) -> Array[T] {
   let len = self.length()
   if len == 0 {
-    []
-  } else {
-    let arr = Array::make(len, self[0])
-    Array::unsafe_blit(arr, 0, self, 0, len)
-    arr
+    return []
   }
+  let arr = Array::unsafe_make_uninit(len)
+  Array::unsafe_blit(arr, 0, self, 0, len)
+  arr
 }

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -24,7 +24,14 @@ struct Array[T] {
 }
 
 ///|
-fn[T] Array::make_uninit(len : Int) -> Array[T] {
+/// Creates an array of `len` elements whose contents are unspecified. The
+/// array reports `length() == len` immediately, so every slot is observable
+/// and the caller must write all of them before the array is read or escapes.
+///
+/// Prefer `Array::makei` unless the initializing loop cannot be expressed as
+/// a function of the index.
+#doc(hidden)
+pub fn[T] Array::unsafe_make_uninit(len : Int) -> Array[T] {
   { buf: UninitializedArray::make(len), len, }
 }
 

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -1364,7 +1364,7 @@ pub fn[T, U] ArrayView::map(
   self : ArrayView[T],
   f : (T) -> U raise?,
 ) -> Array[U] raise? {
-  let arr = Array::make_uninit(self.length())
+  let arr = Array::unsafe_make_uninit(self.length())
   for i, x in self {
     arr.unsafe_set(i, f(x))
   }
@@ -1387,7 +1387,7 @@ pub fn[T, U] ArrayView::mapi(
   self : ArrayView[T],
   f : (Int, T) -> U raise?,
 ) -> Array[U] raise? {
-  let arr = Array::make_uninit(self.length())
+  let arr = Array::unsafe_make_uninit(self.length())
   for i, x in self {
     arr.unsafe_set(i, f(i, x))
   }
@@ -1584,7 +1584,7 @@ pub fn[T : Compare] ArrayView::lexical_compare(
 /// ```
 pub fn[T] ArrayView::rev(self : ArrayView[T]) -> Array[T] {
   let len = self.length()
-  let arr = Array::make_uninit(len)
+  let arr = Array::unsafe_make_uninit(len)
   for i in 0..<len {
     arr.unsafe_set(i, self.unsafe_get(len - i - 1))
   }

--- a/builtin/json.mbt
+++ b/builtin/json.mbt
@@ -291,7 +291,7 @@ pub impl[X : ToJson] ToJson for FixedArray[X] with fn to_json(self) {
   if len == 0 {
     return []
   }
-  let res = Array::make_uninit(self.length())
+  let res = Array::unsafe_make_uninit(self.length())
   for i, x in self {
     res.unsafe_set(i, ToJson::to_json(x))
   }
@@ -304,7 +304,7 @@ pub impl[X : ToJson] ToJson for ArrayView[X] with fn to_json(self) {
   if len == 0 {
     return []
   }
-  let res = Array::make_uninit(self.length())
+  let res = Array::unsafe_make_uninit(self.length())
   for i, x in self {
     res.unsafe_set(i, ToJson::to_json(x))
   }

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -816,7 +816,7 @@ pub fn[K, V] Map::values(self : Map[K, V]) -> Iter[V] {
 ///|
 /// Converts the hash map to an array.
 pub fn[K, V] Map::to_array(self : Map[K, V]) -> Array[(K, V)] {
-  let arr = Array::make_uninit(self.size)
+  let arr = Array::unsafe_make_uninit(self.size)
   let mut i = 0
   for x = self.head {
     match x {

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1691,14 +1691,14 @@ pub fn[A] Deque::from_iter(iter : Iter[A]) -> Deque[A] {
 pub fn[A] Deque::to_array(self : Deque[A]) -> Array[A] {
   let len = self.length()
   if len == 0 {
-    []
-  } else {
-    let xs = Array::make(len, self[0])
-    for i in 0..<len {
-      xs[i] = self[i]
-    }
-    xs
+    return []
   }
+  let xs = Array::unsafe_make_uninit(len)
+  for i in 0..<len {
+    let v = self[i]
+    xs.unsafe_set(i, v)
+  }
+  xs
 }
 
 ///|

--- a/deque/deque_bench_test.mbt
+++ b/deque/deque_bench_test.mbt
@@ -1,0 +1,31 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let deque_bench_n = 50000
+
+///|
+/// `to_array` copies every element out in index order. The Int and Ref
+/// variants are both kept because the element type decides whether the
+/// per-element store carries reference-counting traffic.
+test "bench Deque::to_array Int n=50000" (it : @bench.T) {
+  let d = @deque.from_array(Array::makei(deque_bench_n, i => i))
+  it.bench(fn() { it.keep(d.to_array()) })
+}
+
+///|
+test "bench Deque::to_array Ref n=50000" (it : @bench.T) {
+  let d = @deque.from_array(Array::makei(deque_bench_n, i => "value\{i}"))
+  it.bench(fn() { it.keep(d.to_array()) })
+}

--- a/deque/moon.pkg
+++ b/deque/moon.pkg
@@ -9,6 +9,7 @@ import {
 import {
   "moonbitlang/core/test",
   "moonbitlang/core/quickcheck",
+  "moonbitlang/core/bench",
 } for "test"
 
 options(

--- a/hashmap/hashmap_bench_test.mbt
+++ b/hashmap/hashmap_bench_test.mbt
@@ -106,3 +106,24 @@ test "bench HashMap::copy n=50000" (it : @bench.T) {
   }
   it.bench(fn() { it.keep(template.copy().length()) })
 }
+
+///|
+/// `to_array` walks the whole entry table and materializes the live pairs. The
+/// Int and Ref variants are both kept because the element type decides whether
+/// the per-element store carries reference-counting traffic.
+test "bench HashMap::to_array Int n=50000" (it : @bench.T) {
+  let m = @hashmap.HashMap([])
+  for i in 0..<hashmap_bench_n {
+    m.set(i * 1103515245, i)
+  }
+  it.bench(fn() { it.keep(m.to_array()) })
+}
+
+///|
+test "bench HashMap::to_array Ref n=50000" (it : @bench.T) {
+  let m = @hashmap.HashMap([])
+  for i in 0..<hashmap_bench_n {
+    m.set("key\{i}", "value\{i}")
+  }
+  it.bench(fn() { it.keep(m.to_array()) })
+}

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -167,24 +167,19 @@ pub fn[K : Hash + Eq, V] HashMap::from_iter(
 /// }
 /// ```
 pub fn[K, V] HashMap::to_array(self : HashMap[K, V]) -> Array[(K, V)] {
-  let mut i = 0
-  let res = while i < self.capacity {
-    if self.entries[i] is Some({ key, value, .. }) {
-      i += 1
-      break Array::make(self.size, (key, value))
-    }
-    i += 1
-  } nobreak {
-    []
+  if self.size == 0 {
+    return []
   }
-  if !res.is_empty() {
-    let mut res_idx = 1
-    while res_idx < res.length() && i < self.capacity {
-      if self.entries[i] is Some({ key, value, .. }) {
-        res[res_idx] = (key, value)
-        res_idx += 1
+  let res = Array::unsafe_make_uninit(self.size)
+  let mut n = 0
+  for i in 0..<self.capacity {
+    if self.entries[i] is Some({ key, value, .. }) {
+      let pair = (key, value)
+      res.unsafe_set(n, pair)
+      n += 1
+      if n == self.size {
+        break
       }
-      i += 1
     }
   }
   res

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbitlang/core/array",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
+  "moonbitlang/core/bench",
 } for "test"
 
 import {

--- a/sorted_set/set.mbt
+++ b/sorted_set/set.mbt
@@ -561,23 +561,22 @@ pub fn[V] SortedSet::eachi(
 /// Converts the set to an array.
 pub fn[V] SortedSet::to_array(self : SortedSet[V]) -> Array[V] {
   if self.size == 0 {
-    []
-  } else {
-    let padding = self.root.unwrap().value
-    let arr = Array::make(self.size, padding)
-    let mut i = 0
-    fn dfs(root : Node[V]?) -> Unit {
-      if root is Some(root) {
-        dfs(root.left)
-        arr[i] = root.value
-        i += 1
-        dfs(root.right)
-      }
-    }
-
-    dfs(self.root)
-    arr
+    return []
   }
+  let arr = Array::unsafe_make_uninit(self.size)
+  let mut n = 0
+  fn dfs(root : Node[V]?) -> Unit {
+    if root is Some(root) {
+      dfs(root.left)
+      let v = root.value
+      arr.unsafe_set(n, v)
+      n += 1
+      dfs(root.right)
+    }
+  }
+
+  dfs(self.root)
+  arr
 }
 
 ///|

--- a/sorted_set/sorted_set_bench_test.mbt
+++ b/sorted_set/sorted_set_bench_test.mbt
@@ -1,0 +1,35 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let sorted_set_bench_n = 50000
+
+///|
+/// `to_array` materializes the in-order traversal. The Int and Ref variants
+/// are both kept because the element type decides whether the per-element
+/// store carries reference-counting traffic.
+test "bench SortedSet::to_array Int n=50000" (it : @bench.T) {
+  let s = @sorted_set.from_array(
+    Array::makei(sorted_set_bench_n, i => i * 1103515245),
+  )
+  it.bench(fn() { it.keep(s.to_array()) })
+}
+
+///|
+test "bench SortedSet::to_array Ref n=50000" (it : @bench.T) {
+  let s = @sorted_set.from_array(
+    Array::makei(sorted_set_bench_n, i => "value\{i}"),
+  )
+  it.bench(fn() { it.keep(s.to_array()) })
+}


### PR DESCRIPTION
Builds `Array::copy`, `Deque::to_array`, `SortedSet::to_array` and `HashMap::to_array` by allocating the result at its final length and writing each slot once, instead of filling the array and then overwriting it.

`Array::make(len, elem)` is `Array::unsafe_make_uninit(len)` followed by `len` `unsafe_set` calls. For a reference element type each of those also increfs `elem` and decrefs the slot's previous contents. Where the array is immediately overwritten, all of that is dead.

## Commits

1. **`test:` benchmarks** for the four functions, each with an Int and a Ref (String) variant. The element type is not incidental — it decides whether the per-element store carries reference-counting traffic, and the spread is large enough that an Int-only benchmark would hide it.
2. **`refactor(builtin):`** rename `Array::make_uninit` to `Array::unsafe_make_uninit` and export it `#doc(hidden)`, so packages outside `builtin` can build an array without going through `push`. `pkg.generated.mbti` is unchanged. No behavior change.
3. **`perf:`** the four conversions.

## Numbers

Native, release. Every A/B varies **one file only**, with all other files pinned, and rebuilds each round.

**`Array::copy`** — 4 rounds, ranges disjoint. `FixedArray::copy` is a control: its code is identical in both arms.

| | main-form | branch | min Δ | wins |
|---|---|---|---|---|
| `Array::copy` Int n=1000000 | 104.7 / 111.5 / 111.1 / 112.9 µs | 53.8 / 55.6 / 51.6 / 53.5 µs | **−50.7%** | 4/4 |
| `Array::copy` Ref n=1000000 | 2240 / 2200 / 2260 / 2250 µs | 1620 / 1700 / 1640 / 1780 µs | **−26.4%** | 4/4 |
| `FixedArray::copy` Ref *(control)* | 1110 / 1060 / 1110 / 1080 µs | 1060 / 1110 / 1080 / 1120 µs | 0.0% | 2/4 |

**`to_array`** — 3 rounds, `builtin` identical in both arms so only the three consumer files vary. Min of rounds.

| | push | unsafe_set | Δ |
|---|---|---|---|
| `Deque::to_array` Int n=50000 | 35.2 µs | 27.5 µs | **−21.9%** (3/3) |
| `Deque::to_array` Ref n=50000 | 99.9 µs | 91.7 µs | **−8.2%** (3/3) |
| `HashMap::to_array` Int n=50000 | 496.0 µs | 462.4 µs | **−6.8%** (3/3) |
| `HashMap::to_array` Ref n=50000 | 783.1 µs | 845.0 µs | no signal — ranges overlap |
| `SortedSet::to_array` Int n=50000 | 205.8 µs | 204.4 µs | −0.7% — no signal |
| `SortedSet::to_array` Ref n=50000 | 240.5 µs | 236.5 µs | −1.7% — no signal |

The gain tracks how little else the loop does per element. `Deque` only indexes and stores, so the store path is most of the work. `HashMap` allocates a tuple per pair and increfs both halves when they are references, which dominates. `SortedSet` is dominated by its `dfs` recursion. `SortedSet` and `HashMap` keep the conversion despite showing no measurable gain, so all four paths build their result the same way.

`HashMap::to_array` Ref is reported as no signal rather than a regression: its own push arm spans 14% across rounds, wider than the difference between the arms.

## Two things reviewers should know

**Bind the value to a local before `unsafe_set`.** Written inline as `xs.unsafe_set(i, self[i])`, the call sits between the buffer field load and the store, so the reference-counting pass brackets the buffer borrow *inside* the loop and emits an `incref`/`decref` pair per element — costing more than the bounds check it saves. Generated C, before and after:

```c
buf = xs->$0;  incref(buf);  v = at(self,i);  buf[i] = v;  decref(buf);   /* inline  */
v = at(self,i);  buf = xs->$0;  buf[i] = v;                               /* hoisted */
```

This is why every converted loop binds first, and it's recorded on `unsafe_make_uninit`'s doc comment.

**`unsafe_make_uninit` is only genuinely uninitialized for primitive element types.**

```
Array[Int]     moonbit_make_int32_array_raw    -- raw
Array[Double]  moonbit_make_double_array_raw   -- raw
Array[String]  moonbit_make_ref_array(n, ...)  -- filled with a placeholder
```

For reference elements the runtime fills the store with a valid placeholder, so slots are type-safe but meaningless, and part of the initializing pass still happens inside the function. It still beats `Array::make` there — `Array::make` adds `len` increfs and `len` decrefs on top of the same fill — but the margin is smaller, which matches the Int-vs-Ref split in both tables.

## Verification

- `moon check --target all` clean
- `moon test` — wasm-gc 7578, js 7518, wasm 7548, native 7463; all passing, matching the `main` baseline on the same tree
- `moon fmt`, `moon bundle`, `moon info` clean; `pkg.generated.mbti` unchanged

Empty-input paths keep their `len == 0` fastpath; dropping it costs 6–31% on empty input because `unsafe_make_uninit(0)` has no `[]` shortcut and `SortedSet` would still allocate its `dfs` closure. Covered by existing tests (`builtin/array_test.mbt:1250`, `deque/deque_test.mbt:1262`, `sorted_set/set_test.mbt:156`).
