### PR TITLE
docs(builtin): correct 15 inaccurate doc comments

### DIFF
--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -348,7 +348,7 @@ pub fn Char::is_numeric(self : Self) -> Bool {
 /// - Format characters (Cf)
 /// - Line/paragraph separators (Zl, Zp)
 /// - Private use (Co)
-/// - Unassigned (Cn)
+/// - Noncharacters (U+FDD0-U+FDEF and the U+nFFFE/U+nFFFF pairs)
 /// - Surrogates (Cs)
 pub fn Char::is_printable(self : Self) -> Bool {
   // Check for control characters (Cc)

--- a/builtin/double.mbt
+++ b/builtin/double.mbt
@@ -55,8 +55,8 @@ pub fn Double::from_int(i : Int) -> Double {
 /// * `value` : The double-precision floating-point number to compute the
 /// absolute value of.
 ///
-/// Returns the absolute value of the input number. For any input `x`, the result
-/// is equivalent to `if x < 0.0 { -x } else { x }`.
+/// Returns the absolute value of the input number by clearing its sign bit, so
+/// the result is never negative. In particular, `(-0.0).abs()` is `0.0`.
 ///
 /// Example:
 ///
@@ -111,6 +111,7 @@ pub fn Double::max(self : Double, other : Double) -> Double {
 /// * `max` : The upper bound of the range.
 ///
 /// Returns `min` if `self < min`, `max` if `self > max`, and `self` otherwise.
+/// Aborts if `min` is greater than `max`.
 ///
 /// Example:
 ///
@@ -319,7 +320,8 @@ pub impl Show for Double with fn to_string(self) {
 ///
 /// Returns whether the two numbers are considered approximately equal. Returns
 /// `true` if the numbers are exactly equal or if they are within either the
-/// relative or absolute tolerance. Returns `false` if either number is infinite.
+/// relative or absolute tolerance. Returns `false` if the numbers are not
+/// exactly equal and either of them is infinite.
 ///
 /// Example:
 ///

--- a/builtin/double_to_int64_js_wasm.mbt
+++ b/builtin/double_to_int64_js_wasm.mbt
@@ -53,8 +53,8 @@ pub fn Double::to_int64(self : Double) -> Int64 = "%f64_to_i64_saturate"
 /// Returns an unsigned 64-bit integer value according to the following rules:
 ///
 /// * Returns 0 if the input is NaN
-/// * Returns `UInt64::max_value` (18446744073709551615UL) if the input is
-/// greater than or equal to `UInt64::max_value`
+/// * Returns `@uint64.MAX_VALUE` (18446744073709551615UL) if the input is
+/// greater than or equal to `@uint64.MAX_VALUE`
 /// * Returns 0UL if the input is less than or equal to 0
 /// * Otherwise returns the integer part of the input by truncating towards zero
 ///

--- a/builtin/int.mbt
+++ b/builtin/int.mbt
@@ -94,7 +94,8 @@ pub fn Int::max(self : Int, other : Int) -> Int {
 }
 
 ///|
-/// Clamps the value `self` between `min` and `max`.
+/// Clamps the value `self` between `min` and `max`. Aborts if `min` is greater
+/// than `max`.
 ///
 /// Example:
 /// ```mbt check
@@ -175,7 +176,9 @@ pub fn Int::is_surrogate(self : Int) -> Bool {
 ///
 /// * `self` : The integer whose absolute value is to be computed.
 ///
-/// Returns the absolute value of the integer.
+/// Returns the absolute value of the integer. When the input is
+/// `@int.min_value` (-2147483648), returns `@int.min_value` itself, since its
+/// absolute value is not representable as an `Int`.
 ///
 /// Example:
 ///

--- a/builtin/int64.mbt
+++ b/builtin/int64.mbt
@@ -53,8 +53,8 @@ pub fn Int64::from_int(i : Int) -> Int64 {
 /// * `self` : The 64-bit integer whose absolute value is to be computed.
 ///
 /// Returns the absolute value of the input integer. When the input is
-/// `Int64::min_value()`, returns `Int64::min_value()` itself, since its absolute
-/// value is not representable as an `Int64`.
+/// `@int64.MIN_VALUE` (-9223372036854775808), returns `@int64.MIN_VALUE`
+/// itself, since its absolute value is not representable as an `Int64`.
 ///
 /// Example:
 ///

--- a/builtin/int64.mbt
+++ b/builtin/int64.mbt
@@ -52,7 +52,9 @@ pub fn Int64::from_int(i : Int) -> Int64 {
 ///
 /// * `self` : The 64-bit integer whose absolute value is to be computed.
 ///
-/// Returns the absolute value of the input integer.
+/// Returns the absolute value of the input integer. When the input is
+/// `Int64::min_value()`, returns `Int64::min_value()` itself, since its absolute
+/// value is not representable as an `Int64`.
 ///
 /// Example:
 ///
@@ -654,7 +656,7 @@ pub fn Int64::clz(self : Int64) -> Int = "%i64_clz"
 ///
 /// ```mbt check
 /// test {
-///   let x = 0x7000_0001_1F00_100FL // 0111000000000000000000000001000111110000000100001111
+///   let x = 0x7000_0001_1F00_100FL // Binary: 0111 0000 ... 0001 1111 0000 0000 0001 0000 0000 1111
 ///   inspect(x.popcnt(), content="14")
 /// }
 /// ```
@@ -854,7 +856,7 @@ pub fn Int64::reinterpret_as_double(self : Int64) -> Double = "%i64_to_f64_reint
 ///
 /// ```mbt check
 /// test {
-///   // 0x4045000000000000 represents 42.0 in IEEE 754 double format
+///   // 0x4059000000000000 represents 100.0 in IEEE 754 double format
 ///   let n = 4636737291354636288UL
 ///   inspect(n.reinterpret_as_double(), content="100")
 /// }

--- a/builtin/intrinsics.mbt
+++ b/builtin/intrinsics.mbt
@@ -199,9 +199,9 @@ pub impl Default for Bool with fn default() = "%bool_default"
 /// * `self` : The integer value to negate.
 ///
 /// Returns the negation of the input value. For all inputs except
-/// `Int::min_value()`, returns the value with opposite sign. When the input is
-/// `Int::min_value()`, returns `Int::min_value()` due to two's complement
-/// representation.
+/// `@int.min_value` (-2147483648), returns the value with opposite sign. When
+/// the input is `@int.min_value`, returns `@int.min_value` due to two's
+/// complement representation.
 ///
 /// Example:
 ///
@@ -209,7 +209,7 @@ pub impl Default for Bool with fn default() = "%bool_default"
 /// test {
 ///   inspect(-42, content="-42")
 ///   inspect(42, content="42")
-///   inspect(2147483647, content="2147483647") // negating near min value
+///   inspect(2147483647, content="2147483647") // Int maximum value
 /// }
 /// ```
 pub impl Neg for Int with fn neg(self) = "%i32_neg"
@@ -1147,9 +1147,8 @@ pub fn Double::sqrt(self : Double) -> Double = "%f64_sqrt"
 
 ///|
 /// Compares two double-precision floating-point numbers for equality following
-/// IEEE 754 rules. Returns `true` if both numbers are equal, including when both
-/// are `NaN`. Note that this differs from the standard IEEE 754 behavior where
-/// `NaN` is not equal to any value, including itself.
+/// IEEE 754 rules. Returns `true` if both numbers are equal. `NaN` is not equal
+/// to any value, including itself, so `nan == nan` evaluates to `false`.
 ///
 /// Parameters:
 ///
@@ -1530,7 +1529,8 @@ pub fn Bytes::length(self : Bytes) -> Int = "%bytes_length"
 ///
 /// Parameters:
 ///
-/// * `length` : The length of the byte sequence to create. Must be non-negative.
+/// * `length` : The length of the byte sequence to create. A negative value
+/// produces an empty byte sequence.
 /// * `initial_value` : The byte value used to initialize each position in the
 /// sequence.
 ///
@@ -2703,7 +2703,8 @@ pub fn Int::to_int16(self : Int) -> Int16 = "%i32_to_i16"
 
 ///|
 /// Converts a byte value to a 16-bit signed integer. The byte value is
-/// sign-extended to 16 bits during the conversion.
+/// zero-extended to 16 bits during the conversion, so the result is always in
+/// the range [0, 255].
 ///
 /// Parameters:
 ///


### PR DESCRIPTION
Corrects **15 inaccurate documentation comments** across 6 files. Documentation only — **no code, signature, or `.mbti` interface is changed**.

### What was wrong

| Count | Class | |
|---:|---|---|
| 7 | `contradicts-impl` | prose stated behavior the code does not have |
| 3 | `wrong-panic-contract` | documented panic/error behavior was wrong |
| 3 | `wrong-example` | asserted value or comment in an example did not match the code |
| 2 | `stale-reference` | reference to a renamed/removed item, or a dangling doc block |

### Representative fixes

**`Char::is_printable`** — `builtin/char.mbt` (`contradicts-impl`)

> **Was:** - Unassigned (Cn)
>
> **Now:** - Noncharacters (U+FDD0-U+FDEF and the U+nFFFE/U+nFFFF pairs)

**`Double::is_close`** — `builtin/double.mbt` (`contradicts-impl`)

> **Was:** relative or absolute tolerance. Returns `false` if either number is infinite.
>
> **Now:** relative or absolute tolerance. Returns `false` if the numbers are not exactly equal and either of them is infinite.

**`Double::abs`** — `builtin/double.mbt` (`contradicts-impl`)

> **Was:** Returns the absolute value of the input number. For any input `x`, the result is equivalent to `if x < 0.0 { -x } else { x }`.
>
> **Now:** Returns the absolute value of the input number by clearing its sign bit, so the result is never negative. In particular, `(-0.0).abs()` is `0.0`.

**`Int::abs`** — `builtin/int.mbt` (`contradicts-impl`)

> **Was:** Returns the absolute value of the integer.
>
> **Now:** Returns the absolute value of the integer. When the input is `@int.min_value` (-2147483648), returns `@int.min_value` itself, since its absolute value is not representable as an `Int`.

### Files

- `builtin/char.mbt`
- `builtin/double.mbt`
- `builtin/double_to_int64_js_wasm.mbt`
- `builtin/int.mbt`
- `builtin/int64.mbt`
- `builtin/intrinsics.mbt`

### Validation

Run on the full change set before splitting into per-area PRs:

| Check | Result |
|---|---|
| `moon check --deny-warn --target all` | clean on all four backends |
| `moon test` | 7548 passed, 0 failed |
| `moon info` | no `.mbti` diff — zero API change |
| `moon fmt` | no reformatting needed |

Every changed line is a `///` documentation line; no executable code was modified. `missing_doc` is enabled repo-wide, so the passing `moon check` also confirms no documented item lost its docs.

### How this was produced

Each package was audited by one agent that read every `.mbt` file in full and checked each doc claim against the implementation, then a **second, independent agent** re-derived every claim from source and applied only what survived. 6 of 205 proposed changes were rejected at that stage (style complaints, unsupported guesses, one backend divergence that is a code issue rather than a doc issue). Findings without quoted implementation evidence were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z81qJ5vdYoxZ48JTKCdAy