### PR TITLE
docs(builtin): correct 16 inaccurate doc comments

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -175,7 +175,7 @@ pub fn[T] Array::unsafe_get(self : Array[T], idx : Int) -> T {
 ///
 /// ```mbt check
 /// test {
-///   let arr : ReadOnlyArray[Int] = [1, 2, 3]
+///   let arr : Array[Int] = [1, 2, 3]
 ///   inspect(arr[1], content="2")
 /// }
 /// ```
@@ -1510,7 +1510,7 @@ pub fn[T] Array::extract_if(
 }
 
 ///|
-/// Divides an array into smaller arrays (chunks) of the specified size.
+/// Divides an array into chunks (views) of the specified size.
 ///
 /// Parameters:
 ///
@@ -1518,8 +1518,8 @@ pub fn[T] Array::extract_if(
 /// * `size` : The size of each chunk. Must be a positive integer, otherwise it will panic.
 ///
 ///
-/// Returns an array of arrays, where each inner array is a chunk containing
-/// elements from the original array. If the length of the original array is not
+/// Returns an array of views, where each view is a chunk containing consecutive
+/// elements of the original array. If the length of the original array is not
 /// divisible by the chunk size, the last chunk will contain fewer elements.
 ///
 /// Example:
@@ -1562,7 +1562,7 @@ pub fn[T] Array::chunks(self : Array[T], size : Int) -> Array[ArrayView[T]] {
 /// * `predicate` : A function that takes two adjacent elements and returns
 /// `true` if they should be in the same chunk, `false` otherwise.
 ///
-/// Returns an array of arrays, where each inner array is a chunk of consecutive
+/// Returns an array of views, where each view is a chunk of consecutive
 /// elements that satisfy the predicate with their adjacent elements.
 ///
 /// Example:
@@ -2019,15 +2019,20 @@ pub fn[T] Array::shuffle(self : Array[T], rand~ : (Int) -> Int) -> Array[T] {
 }
 
 ///|
-/// Returns a new array containing the elements of the original array that satisfy the given predicate.
+/// Applies a function to each element of the array and collects the results
+/// that are `Some`, discarding the elements for which the function returns
+/// `None`.
 ///
 /// # Arguments
 ///
-/// * `self` - The array to filter.
-/// * `f` - The predicate function.
+/// * `self` - The array to filter and map.
+/// * `f` - The function applied to each element, returning `Some(value)` to
+/// keep the mapped `value`, or `None` to drop the element.
 ///
 /// # Returns
 ///
+/// A new array containing the unwrapped `Some` results, in the order the
+/// corresponding elements appeared in the original array.
 #locals(f)
 pub fn[A, B] Array::filter_map(
   self : Array[A],

--- a/builtin/array_sort.mbt
+++ b/builtin/array_sort.mbt
@@ -285,7 +285,7 @@ pub fn[T : Compare] FixedArray::stable_sort(self : FixedArray[T]) -> Unit {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [5, 3, 2, 4, 1]
+///   let arr : FixedArray[Int] = [5, 3, 2, 4, 1]
 ///   arr.sort_by_key(x => -x)
 ///   @test.assert_eq(arr, [5, 4, 3, 2, 1])
 /// }
@@ -316,7 +316,7 @@ test "FixedArray::sort_by_key/basic" {
 ///
 /// ```mbt check
 /// test {
-///   let arr = [5, 3, 2, 4, 1]
+///   let arr : FixedArray[Int] = [5, 3, 2, 4, 1]
 ///   arr.sort_by((a, b) => a - b)
 ///   @test.assert_eq(arr, [1, 2, 3, 4, 5])
 /// }

--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -199,7 +199,7 @@ fn collapse(runs : Array[TimSortRun], stop : Int) -> Int? {
 /// 
 /// ```mbt check
 /// test {
-///   let arr = [5, 4, 3, 2, 1]
+///   let arr : FixedArray[Int] = [5, 4, 3, 2, 1]
 ///   arr.sort()
 ///   @test.assert_eq(arr, [1, 2, 3, 4, 5])
 /// }
@@ -339,11 +339,9 @@ fn[T : Compare] fixed_try_bubble_sort(arr : MutArrayView[T]) -> Bool {
 }
 
 ///|
-/// Try to sort the array with bubble sort.
-/// 
-/// It will only tolerate at most 8 unsorted elements. The time complexity is O(n).
-/// 
-/// Returns whether the array is sorted.
+/// Sort the array with bubble sort.
+///
+/// It always sorts the whole array. The time complexity is O(n^2) in the worst case.
 fn[T : Compare] fixed_bubble_sort(arr : MutArrayView[T]) -> Unit {
   for i in 1..<arr.length() {
     for j = i; j > 0 && arr.unsafe_get(j - 1) > arr.unsafe_get(j); j = j - 1 {

--- a/builtin/array_sort_impl.mbt
+++ b/builtin/array_sort_impl.mbt
@@ -339,7 +339,8 @@ fn[T : Compare] fixed_try_bubble_sort(arr : MutArrayView[T]) -> Bool {
 }
 
 ///|
-/// Sort the array with bubble sort.
+/// Sort the array with insertion sort (despite the name): it grows a sorted
+/// prefix, moving each new element left by adjacent swaps until it is in place.
 ///
 /// It always sorts the whole array. The time complexity is O(n^2) in the worst case.
 fn[T : Compare] fixed_bubble_sort(arr : MutArrayView[T]) -> Unit {

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -134,9 +134,9 @@ pub fn[T] Array::new(capacity? : Int = 0) -> Array[T] {
 ///
 /// ```mbt check
 /// test {
-///   let arr : ReadOnlyArray[Int] = [1, 2, 3]
+///   let arr : Array[Int] = [1, 2, 3]
 ///   inspect(arr.length(), content="3")
-///   let empty : ReadOnlyArray[Int] = []
+///   let empty : Array[Int] = []
 ///   inspect(empty.length(), content="0")
 /// }
 /// ```
@@ -162,9 +162,8 @@ pub fn[T] Array::length(self : Array[T]) -> Int {
 ///
 /// # Errors
 ///
-/// - This function does not explicitly raise errors, but improper use (e.g.,
-/// setting `new_len` greater than the current length) can lead to undefined
-/// behavior.
+/// - This function does not raise errors, but it panics if `new_len` is greater
+/// than the current length of the array.
 ///
 /// TODO: this can be optimized by using the intrinsic to null out the range
 fn[T] Array::unsafe_truncate_to_length(self : Array[T], new_len : Int) -> Unit {

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -224,7 +224,7 @@ pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
 }
 
 ///|
-/// Creates a view of a portion of the array. The view provides read-write access
+/// Creates a view of a portion of the array. The view provides read-only access
 /// to the underlying array without copying the elements.
 ///
 /// Parameters:
@@ -731,7 +731,7 @@ pub fn[X] ArrayView::iter(self : ArrayView[X]) -> Iter[X] {
 ///|
 /// Return a reverse iterator over elements of this view.
 ///
-/// Deprecated alias for reverse iteration; prefer `rev_iterator`.
+/// `rev_iterator` is a deprecated alias for this function.
 ///
 /// Example:
 ///

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1565,7 +1565,7 @@ test "FixedArray::join" {
 ///|
 /// Return an iterator over elements of the fixed array.
 ///
-/// Deprecated alias; prefer `iterator`.
+/// `iterator` is a deprecated alias for this function.
 ///
 /// Example:
 ///
@@ -1585,7 +1585,7 @@ pub fn[X] FixedArray::iter(self : FixedArray[X]) -> Iter[X] {
 ///|
 /// Return an index-value iterator over the fixed array.
 ///
-/// Deprecated alias; prefer `iterator2`.
+/// `iterator2` is a deprecated alias for this function.
 ///
 /// Example:
 ///

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -362,9 +362,10 @@ pub fn[T] FixedArray::mut_view(
 /// Parameters:
 ///
 /// * `self` : The mutable array view to create a new view from.
-/// * `start` : The starting index in the array (inclusive). Defaults to 0.
-/// * `end` : The ending index in the array (exclusive). Defaults to the
-/// length of the array.
+/// * `start` : The starting index in the current view (inclusive). Defaults to
+/// 0.
+/// * `end` : The ending index in the current view (exclusive). Defaults to the
+/// length of the current view.
 #intrinsic("%mutarrayview.view")
 #alias("_[_:_]")
 #alias(sub, deprecated="Use _[_:_] instead")

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -458,7 +458,7 @@ pub fn[A, B] ReadOnlyArray::foldi(
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [2, 3]
 ///   let sum = arr.rev_foldi(init=0, fn(i, acc, x) { acc + i * x })
-///   inspect(sum, content="2") // 0 + (1*3) + (0*2) = 3
+///   inspect(sum, content="2") // 0 + (0*3) + (1*2) = 2
 /// }
 /// ```
 pub fn[A, B] ReadOnlyArray::rev_foldi(


### PR DESCRIPTION
Corrects **16 inaccurate documentation comments** across 8 files. Documentation only — **no code, signature, or `.mbti` interface is changed**.

### What was wrong

| Count | Class | |
|---:|---|---|
| 6 | `wrong-example` | asserted value or comment in an example did not match the code |
| 3 | `copy-paste-drift` | doc described a different function than the one it sits above |
| 3 | `contradicts-impl` | prose stated behavior the code does not have |
| 3 | `stale-reference` | reference to a renamed/removed item, or a dangling doc block |
| 1 | `wrong-panic-contract` | documented panic/error behavior was wrong |

### Representative fixes

**`Array::chunks`** — `builtin/array.mbt` (`contradicts-impl`)

> **Was:** Divides an array into smaller arrays (chunks) of the specified size. ... Returns an array of arrays, where each inner array is a chunk containing elements from the original array. If the length of the original array is not divisible by the chunk size, the last chunk will contain fewer elements.
>
> **Now:** Divides an array into chunks (views) of the specified size. ... Returns an array of views, where each view is a chunk containing consecutive elements of the original array. If the length of the original array is not divisible by the chunk size, the last chunk will contain fewer elements.

**`Array::chunk_by`** — `builtin/array.mbt` (`contradicts-impl`)

> **Was:** Returns an array of arrays, where each inner array is a chunk of consecutive elements that satisfy the predicate with their adjacent elements.
>
> **Now:** Returns an array of views, where each view is a chunk of consecutive elements that satisfy the predicate with their adjacent elements.

**`Array::view`** — `builtin/arrayview.mbt` (`contradicts-impl`)

> **Was:** Creates a view of a portion of the array. The view provides read-write access to the underlying array without copying the elements.
>
> **Now:** Creates a view of a portion of the array. The view provides read-only access to the underlying array without copying the elements.

**`Array::unsafe_truncate_to_length`** — `builtin/arraycore_nonjs.mbt` (`wrong-panic-contract`)

> **Was:** - This function does not explicitly raise errors, but improper use (e.g., setting `new_len` greater than the current length) can lead to undefined behavior.
>
> **Now:** - This function does not raise errors, but it panics if `new_len` is greater than the current length of the array.

### Files

- `builtin/array.mbt`
- `builtin/array_sort.mbt`
- `builtin/array_sort_impl.mbt`
- `builtin/arraycore_nonjs.mbt`
- `builtin/arrayview.mbt`
- `builtin/fixedarray.mbt`
- `builtin/mutarrayview.mbt`
- `builtin/readonlyarray.mbt`

### Validation

Run on the full change set before splitting into per-area PRs:

| Check | Result |
|---|---|
| `moon check --deny-warn --target all` | clean on all four backends |
| `moon test` | 7548 passed, 0 failed |
| `moon info` | no `.mbti` diff — zero API change |
| `moon fmt` | no reformatting needed |

Every changed line is a `///` documentation line; no executable code was modified. `missing_doc` is enabled repo-wide, so the passing `moon check` also confirms no documented item lost its docs.

### How this was produced

Each package was audited by one agent that read every `.mbt` file in full and checked each doc claim against the implementation, then a **second, independent agent** re-derived every claim from source and applied only what survived. 6 of 205 proposed changes were rejected at that stage (style complaints, unsupported guesses, one backend divergence that is a code issue rather than a doc issue). Findings without quoted implementation evidence were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z81qJ5vdYoxZ48JTKCdAy