### PR TITLE
docs(builtin): correct 7 inaccurate doc comments

### DIFF
--- a/builtin/LinkedHashMap.mbt.md
+++ b/builtin/LinkedHashMap.mbt.md
@@ -91,7 +91,7 @@ test {
 
 ### Size & Capacity
 
-You can use `size()` to get the number of key-value pairs in the map, or `capacity()` to get the current capacity.
+You can use `length()` to get the number of key-value pairs in the map, or `capacity()` to get the current capacity.
 
 ```mbt check
 ///|

--- a/builtin/autoloc.mbt
+++ b/builtin/autoloc.mbt
@@ -31,8 +31,8 @@ pub(all) type SourceLoc
 /// * `source_location` : A source code location containing information about the
 /// file path, line number, and column number.
 ///
-/// Returns a string representation of the source location, typically in the
-/// format "@package:file:start_line:start_column-end_line:end_column".
+/// Returns a string representation of the source location, in the format
+/// "file:start_line:start_column-end_line:end_column@module".
 ///
 /// Note: This function is primarily used internally by the compiler for error
 /// reporting and debugging purposes. Source locations are automatically created
@@ -106,15 +106,16 @@ pub impl Show for ArgsLoc with fn output(self, logger) {
 
 ///|
 /// Converts an array of optional source locations to its JSON string
-/// representation. Each location in the array is either represented as a string
-/// if present, or "null" if absent.
+/// representation. Each location in the array is either represented as a JSON
+/// object with `filename`, `start_line`, `start_column`, `end_line` and
+/// `end_column` fields if present, or "null" if absent.
 ///
 /// Parameters:
 ///
 /// * `self` : The array of optional source locations to be converted.
 ///
-/// Returns a JSON array string where each element is either a string
-/// representation of a source location or "null".
+/// Returns a JSON array string where each element is either a JSON object
+/// describing a source location or "null".
 pub fn ArgsLoc::to_json(self : ArgsLoc) -> String {
   let buf = StringBuilder(size_hint=10)
   let ArgsLoc(self) = self

--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -49,7 +49,7 @@ pub fn[T : Show] println(input : T) -> Unit {
 /// ```mbt check
 /// test {
 ///   let x : Int = 42
-///   inspect(x, content="42") // Raises InspectError with detailed failure message
+///   inspect(x, content="42") // A mismatch would raise InspectError with a detailed message
 /// }
 /// ```
 pub(all) suberror InspectError {

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -65,13 +65,13 @@ pub fn[K, V] Map::new(capacity? : Int = default_init_capacity) -> Map[K, V] {
 }
 
 ///|
+/// Shifts the bits of a `Byte` value to the left by the given number of bit
 /// positions.
 ///
 /// Parameters:
 ///
-/// - `byte_value` : The `Byte` value whose bits are to be shifted.
-/// - `shift_count` : The number of bit positions to shift the `byte_value` to
-///   the left.
+/// - `self` : The `Byte` value whose bits are to be shifted.
+/// - `count` : The number of bit positions to shift `self` to the left.
 ///
 /// Returns the resulting `Byte` value after the bitwise left shift operation.
 ///
@@ -82,12 +82,13 @@ pub fn Byte::lsl(self : Byte, count : Int) -> Byte {
 }
 
 ///|
-/// bits.
+/// Performs a logical (zero-filling) right shift of a `Byte` value by the
+/// given number of bits.
 ///
 /// Parameters:
 ///
-/// - `value` : The `Byte` value to be shifted.
-/// - `count` : The number of bits to shift the `value` to the right.
+/// - `self` : The `Byte` value to be shifted.
+/// - `count` : The number of bits to shift `self` to the right.
 ///
 /// Returns the result of the logical shift right operation as a `Byte`.
 ///

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -57,7 +57,8 @@ struct Hasher {
 /// Parameters:
 ///
 /// * `seed` : An integer value used to initialize the hasher's internal state.
-/// Defaults to 0.
+/// Defaults to 0 on every target except JavaScript, where the default is a
+/// randomly chosen per-process value.
 ///
 /// Returns a new `Hasher` instance initialized with the given seed value.
 ///


### PR DESCRIPTION
Corrects **7 inaccurate documentation comments** across 5 files. Documentation only — **no code, signature, or `.mbti` interface is changed**.

### What was wrong

| Count | Class | |
|---:|---|---|
| 3 | `contradicts-impl` | prose stated behavior the code does not have |
| 2 | `language-error` | typo or broken markdown that changed meaning |
| 1 | `stale-reference` | reference to a renamed/removed item, or a dangling doc block |
| 1 | `wrong-example` | asserted value or comment in an example did not match the code |

### Representative fixes

**`SourceLoc::repr`** — `builtin/autoloc.mbt` (`contradicts-impl`)

> **Was:** Returns a string representation of the source location, typically in the format "@package:file:start_line:start_column-end_line:end_column".
>
> **Now:** Returns a string representation of the source location, in the format "file:start_line:start_column-end_line:end_column@module".

**`ArgsLoc::to_json`** — `builtin/autoloc.mbt` (`contradicts-impl`)

> **Was:** representation. Each location in the array is either represented as a string if present, or "null" if absent. ... Returns a JSON array string where each element is either a string representation of a source location or "null".
>
> **Now:** representation. Each location in the array is either represented as a JSON object with `filename`, `start_line`, `start_column`, `end_line` and `end_column` fields if present, or "null" if absent. ... Returns a JSON array string where each element is either a JSON object describing a source location…

**`Hasher::Hasher`** — `builtin/hasher.mbt` (`contradicts-impl`)

> **Was:** * `seed` : An integer value used to initialize the hasher's internal state. Defaults to 0.
>
> **Now:** * `seed` : An integer value used to initialize the hasher's internal state. Defaults to 0 on every target except JavaScript, where the default is a randomly chosen per-process value.

**`InspectError`** — `builtin/console.mbt` (`wrong-example`)

> **Was:** inspect(x, content="42") // Raises InspectError with detailed failure message
>
> **Now:** inspect(x, content="42") // A mismatch would raise InspectError with a detailed message

### Files

- `builtin/LinkedHashMap.mbt.md`
- `builtin/autoloc.mbt`
- `builtin/console.mbt`
- `builtin/deprecated.mbt`
- `builtin/hasher.mbt`

### Validation

Run on the full change set before splitting into per-area PRs:

| Check | Result |
|---|---|
| `moon check --deny-warn --target all` | clean on all four backends |
| `moon test` | 7548 passed, 0 failed |
| `moon info` | no `.mbti` diff — zero API change |
| `moon fmt` | no reformatting needed |

Every changed line is a `///` documentation line; no executable code was modified. `missing_doc` is enabled repo-wide, so the passing `moon check` also confirms no documented item lost its docs.

### How this was produced

Each package was audited by one agent that read every `.mbt` file in full and checked each doc claim against the implementation, then a **second, independent agent** re-derived every claim from source and applied only what survived. 6 of 205 proposed changes were rejected at that stage (style complaints, unsupported guesses, one backend divergence that is a code issue rather than a doc issue). Findings without quoted implementation evidence were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z81qJ5vdYoxZ48JTKCdAy