### PR TITLE
docs(json, diff & debug docs): correct 10 inaccurate doc comments

### DIFF
--- a/debug/README.mbt.md
+++ b/debug/README.mbt.md
@@ -51,7 +51,7 @@ test "to_string" {
 }
 ```
 
-Use `to_repr` in string interpolation:
+Use `Repr(value)` in string interpolation:
 
 ```mbt check
 ///|

--- a/debug/delta.mbt
+++ b/debug/delta.mbt
@@ -152,9 +152,10 @@ fn diff_repr(
 ///
 /// Optional parameters:
 /// - `max_depth?`: maximum expansion depth; deeper subtrees are folded.
-///   Defaults to `4` when omitted. Values `<= 0` are treated as `1`.
-/// - `compact_threshold?`: compact-vs-multiline layout threshold (heuristic one-line vs multiline).
-///   Larger values prefer single-line output. Defaults to `30` when omitted.
+///   Defaults to `16` when omitted. Values `<= 0` are treated as `1`.
+/// - `compact_threshold?`: compact-vs-multiline layout threshold (maximum line
+///   width for keeping a node on one line).
+///   Larger values prefer single-line output. Defaults to `70` when omitted.
 /// - `use_ansi?`: whether to emit ANSI color escape codes (for +/- markers).
 ///   Defaults to `true` when omitted.
 fn pretty_print_delta(

--- a/debug/pretty_print.mbt
+++ b/debug/pretty_print.mbt
@@ -235,12 +235,11 @@ fn Repr::render_repr(self : Repr, threshold : Int) -> Content {
 ///
 /// Optional parameters:
 /// - `max_depth?`: maximum expansion depth; deeper subtrees are replaced with `...`.
-///   Defaults to `4` when `None`. Values `<= 0` are treated as `1`.
-/// - `compact_threshold?`: compact-vs-multiline layout threshold.
-///   The printer uses a heuristic "size" for nodes; when the structure is deemed
-///   small enough under this threshold, it is kept on one line, otherwise it is
-///   broken into multiple lines.
-///   Larger values prefer single-line output. Defaults to `80` when `None`.
+///   Defaults to `16` when `None`. Values `<= 0` are treated as `1`.
+///
+/// The compact-vs-multiline layout threshold is not configurable here: `render`
+/// always uses the internal default of `70`, keeping a node on one line when
+/// every line of its compacted form fits within that many characters.
 pub fn render(r : Repr, max_depth? : Int) -> String {
   let max_depth : Int? = match max_depth {
     Some(_) => max_depth

--- a/debug/printer.mbt
+++ b/debug/printer.mbt
@@ -16,7 +16,7 @@
 /// Rendered content with line layout and paren preference.
 ///
 /// This is an internal implementation detail of `pretty_print`.
-/// Users should rely on `pretty_print_repr` / `pretty_print_delta`.
+/// Users should rely on `render` / `pretty_print_delta`.
 priv struct Content {
   size : Int
   lines : Array[String]

--- a/diff/diff.mbt
+++ b/diff/diff.mbt
@@ -477,7 +477,8 @@ fn[T : Eq + Hash] diff_(
 ///
 /// The `cutoff` is an upper bound on the minimum edit distance between `old~` and `new~`. When
 /// `cutoff` is exceeded, `iter_matches` returns a correct, but not necessarily minimal
-/// diff. It defaults to about `sqrt(old.length() + new.length())`.
+/// diff. It defaults to about the square root of the compacted input sizes
+/// (elements present in both sequences), floored at 4096.
 fn[T : Eq + Hash] iter_matches(
   cutoff~ : Int?, // optional computation cost limit
   old~ : ArrayView[T], // original array

--- a/diff/pile.mbt
+++ b/diff/pile.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-/// `Pile[T]` models one pile in patience sorting.
+/// `Pile` models one pile in patience sorting.
 priv struct Pile(Array[BackPointer])
 
 ///|

--- a/json/from_json.mbt
+++ b/json/from_json.mbt
@@ -299,7 +299,8 @@ pub impl FromJson for Json with fn from_json(json, _path) {
 /// Converts a JSON string to `Bytes`.
 /// 
 /// The expected string format consists of:
-/// - Hexadecimal byte sequences represented as `\xNN`, where `NN` are two hex digits.
+/// - Hexadecimal byte sequences represented as `\xNN`, where `NN` are two lowercase
+///   hex digits (`0`-`9`, `a`-`f`); uppercase `A`-`F` is rejected.
 /// - Printable ASCII characters (except `\` and `"`), which are directly converted to their byte values.
 /// - Any invalid escape sequence or character will result in a `JsonDecodeError`.
 /// 

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -524,7 +524,9 @@ fn escape(str : String, escape_slash~ : Bool) -> String {
 /// ## Behavior
 /// 
 /// - Recursively applies the replacer to all nested objects
-/// - Non-object values (arrays, strings, numbers, etc.) are returned unchanged
+/// - Arrays are rebuilt element by element, so objects nested inside an array are
+///   transformed as well (the replacer itself is only applied to object members)
+/// - All other values (strings, numbers, booleans, null) are returned unchanged
 /// - The original JSON value is not modified; a new value is returned
 pub fn Json::transform(self : Self, replacer : Replacer) -> Json {
   match self {


### PR DESCRIPTION
Corrects **10 inaccurate documentation comments** across 8 files. Documentation only — **no code, signature, or `.mbti` interface is changed**.

### What was wrong

| Count | Class | |
|---:|---|---|
| 7 | `contradicts-impl` | prose stated behavior the code does not have |
| 3 | `stale-reference` | reference to a renamed/removed item, or a dangling doc block |

### Representative fixes

**`pretty_print_delta`** — `debug/delta.mbt` (`contradicts-impl`)

> **Was:** Defaults to `4` when omitted. Values `<= 0` are treated as `1`.
>
> **Now:** Defaults to `16` when omitted. Values `<= 0` are treated as `1`.

**`pretty_print_delta`** — `debug/delta.mbt` (`contradicts-impl`)

> **Was:** - `compact_threshold?`: compact-vs-multiline layout threshold (heuristic one-line vs multiline). Larger values prefer single-line output. Defaults to `30` when omitted.
>
> **Now:** - `compact_threshold?`: compact-vs-multiline layout threshold (maximum line width for keeping a node on one line). Larger values prefer single-line output. Defaults to `70` when omitted.

**`render`** — `debug/pretty_print.mbt` (`contradicts-impl`)

> **Was:** - `compact_threshold?`: compact-vs-multiline layout threshold. The printer uses a heuristic "size" for nodes; when the structure is deemed small enough under this threshold, it is kept on one line, otherwise it is broken into multiple lines. Larger values prefer single-line output. Defaults to `80`…
>
> **Now:** The compact-vs-multiline layout threshold is not configurable here: `render` always uses the internal default of `70`, keeping a node on one line when every line of its compacted form fits within that many characters.

**`render`** — `debug/pretty_print.mbt` (`contradicts-impl`)

> **Was:** Defaults to `4` when `None`. Values `<= 0` are treated as `1`.
>
> **Now:** Defaults to `16` when `None`. Values `<= 0` are treated as `1`.

### Files

- `debug/README.mbt.md`
- `debug/delta.mbt`
- `debug/pretty_print.mbt`
- `debug/printer.mbt`
- `diff/diff.mbt`
- `diff/pile.mbt`
- `json/from_json.mbt`
- `json/json.mbt`

### Validation

Run on the full change set before splitting into per-area PRs:

| Check | Result |
|---|---|
| `moon check --deny-warn --target all` | clean on all four backends |
| `moon test` | 7548 passed, 0 failed |
| `moon info` | no `.mbti` diff — zero API change |
| `moon fmt` | no reformatting needed |

Every changed line is a `///` documentation line; no executable code was modified. `missing_doc` is enabled repo-wide, so the passing `moon check` also confirms no documented item lost its docs.

### How this was produced

Each package was audited by one agent that read every `.mbt` file in full and checked each doc claim against the implementation, then a **second, independent agent** re-derived every claim from source and applied only what survived. 6 of 205 proposed changes were rejected at that stage (style complaints, unsupported guesses, one backend divergence that is a code issue rather than a doc issue). Findings without quoted implementation evidence were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z81qJ5vdYoxZ48JTKCdAy