### PR TITLE
docs(quickcheck, splitmix & random docs): correct 8 inaccurate doc comments

### DIFF
--- a/quickcheck/generator.mbt
+++ b/quickcheck/generator.mbt
@@ -162,6 +162,9 @@ pub fn[T] Generator::resize(self : Generator[T], size : Int) -> Generator[T] {
 
 ///|
 /// Generates an integer in the half-open interval `[lower, upper)`.
+///
+/// The degenerate range where `lower == upper` always yields `lower`. Aborts
+/// if `lower` is greater than `upper`.
 pub fn int_range(lower : Int, upper : Int) -> Generator[Int] {
   guard lower < upper else {
     if lower == upper {

--- a/quickcheck/splitmix/README.mbt.md
+++ b/quickcheck/splitmix/README.mbt.md
@@ -282,7 +282,7 @@ SplitMix provides:
 ## Performance Characteristics
 
 - **Generation speed**: Very fast (few CPU cycles per number)
-- **Memory usage**: Minimal state (single 64-bit value)
+- **Memory usage**: Minimal state (two 64-bit values: `seed` and `gamma`)
 - **Quality**: Good statistical properties for testing
 - **Splitting**: O(1) to create independent generators
 

--- a/quickcheck/splitmix/random.mbt
+++ b/quickcheck/splitmix/random.mbt
@@ -106,7 +106,7 @@ pub fn RandomState::next_int64(self : RandomState) -> Int64 {
 }
 
 ///|
-/// Get the next two random number as 32-bit signed integers.
+/// Get the next two random numbers as 32-bit unsigned integers.
 pub fn RandomState::next_two_uint(self : RandomState) -> (UInt, UInt) {
   let g = self.next_uint64()
   ((g >> 32).to_uint(), g.to_uint())
@@ -131,14 +131,14 @@ pub fn RandomState::next_positive_int(self : RandomState) -> Int {
 }
 
 ///|
-/// Get the next random number as a float in [0, 1]
+/// Get the next random number as a float in [0, 1)
 pub fn RandomState::next_float(self : RandomState) -> Float {
   let u = self.next_uint64()
   Float::from_uint64(u >> 40) * float_ulp
 }
 
 ///|
-/// Get the next random number as a double in [0, 1]
+/// Get the next random number as a double in [0, 1)
 pub fn RandomState::next_double(self : RandomState) -> Double {
   let u = self.next_uint64()
   (u >> 11).to_double() * double_ulp

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -46,7 +46,7 @@ pub fn Rand::chacha8(
 let fixed_test_seed : Bytes = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"
 
 ///|
-/// Create a new random number generator with a given [Gen] source.
+/// Create a new random number generator with a given [Source] generator.
 pub fn Rand::new(generator? : &Source) -> Rand {
   match generator {
     None =>
@@ -405,11 +405,11 @@ pub fn Rand::boolean(self : Rand) -> Bool {
 }
 
 ///|
-/// Generates a random positive `BigInt` with a specified number of bits.
+/// Generates a random non-negative `BigInt` with a specified number of bits.
 ///
 /// Parameters:
 ///
-/// * `rand` : A random number generator that implements the `Rand` trait.
+/// * `self` : The random number generator to draw the bits from.
 /// * `bits` : The desired number of bits in the generated number.
 ///
 /// Example:


### PR DESCRIPTION
Corrects **8 inaccurate documentation comments** across 4 files. Documentation only — **no code, signature, or `.mbti` interface is changed**.

### What was wrong

| Count | Class | |
|---:|---|---|
| 3 | `contradicts-impl` | prose stated behavior the code does not have |
| 2 | `copy-paste-drift` | doc described a different function than the one it sits above |
| 1 | `wrong-panic-contract` | documented panic/error behavior was wrong |
| 1 | `stale-readme` | README prose no longer matched the package |
| 1 | `stale-reference` | reference to a renamed/removed item, or a dangling doc block |

### Representative fixes

**`RandomState::next_float`** — `quickcheck/splitmix/random.mbt` (`contradicts-impl`)

> **Was:** Get the next random number as a float in [0, 1]
>
> **Now:** Get the next random number as a float in [0, 1)

**`RandomState::next_double`** — `quickcheck/splitmix/random.mbt` (`contradicts-impl`)

> **Was:** Get the next random number as a double in [0, 1]
>
> **Now:** Get the next random number as a double in [0, 1)

**`Rand::bigint (summary line)`** — `random/random.mbt` (`contradicts-impl`)

> **Was:** Generates a random positive `BigInt` with a specified number of bits.
>
> **Now:** Generates a random non-negative `BigInt` with a specified number of bits.

**`int_range`** — `quickcheck/generator.mbt` (`wrong-panic-contract`)

> **Was:** Generates an integer in the half-open interval `[lower, upper)`.
>
> **Now:** Generates an integer in the half-open interval `[lower, upper)`.

### Files

- `quickcheck/generator.mbt`
- `quickcheck/splitmix/README.mbt.md`
- `quickcheck/splitmix/random.mbt`
- `random/random.mbt`

### Validation

Run on the full change set before splitting into per-area PRs:

| Check | Result |
|---|---|
| `moon check --deny-warn --target all` | clean on all four backends |
| `moon test` | 7548 passed, 0 failed |
| `moon info` | no `.mbti` diff — zero API change |
| `moon fmt` | no reformatting needed |

Every changed line is a `///` documentation line; no executable code was modified. `missing_doc` is enabled repo-wide, so the passing `moon check` also confirms no documented item lost its docs.

### How this was produced

Each package was audited by one agent that read every `.mbt` file in full and checked each doc claim against the implementation, then a **second, independent agent** re-derived every claim from source and applied only what survived. 6 of 205 proposed changes were rejected at that stage (style complaints, unsupported guesses, one backend divergence that is a code issue rather than a doc issue). Findings without quoted implementation evidence were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z81qJ5vdYoxZ48JTKCdAy