### PR TITLE
perf(json): fill indent cache incrementally, plus oracle test and common-path benchmarks

### DIFF
--- a/json/json.mbt
+++ b/json/json.mbt
@@ -91,15 +91,19 @@ fn write_indent(
   buf : StringBuilder,
   cache : Array[String],
   level : Int,
-  unit : String,
+  indent : Int,
 ) -> Unit {
   // Each level is the previous one plus a single indentation unit, so filling
   // the cache costs O(indent) per new level rather than O(indent * level), and
   // never computes `indent * level` — a product that overflows `Int` to a
   // negative value for a large `indent`, which `String::repeat` rejects.
+  //
+  // The unit is built here rather than once per `stringify` call so that a
+  // document emitting no indentation at all never allocates it: callers reach
+  // this only when `indent > 0`, so `repeat` never sees a negative count.
   while cache.length() <= level {
     match cache {
-      [.., last] => cache.push(last + unit)
+      [.., last] => cache.push(last + " ".repeat(indent))
       [] => cache.push("\n")
     }
   }
@@ -281,7 +285,6 @@ pub fn Json::stringify(
 ) -> String {
   let buf = StringBuilder(size_hint=0)
   let indent_cache : Array[String] = []
-  let indent_unit = " ".repeat(indent)
 
   // Explicit stack to replace recursive calls
   let stack : Array[WriteFrame] = []
@@ -297,7 +300,7 @@ pub fn Json::stringify(
               depth += 1
               buf.write_char('{')
               if indent > 0 {
-                write_indent(buf, indent_cache, depth, indent_unit)
+                write_indent(buf, indent_cache, depth, indent)
               }
               // After child value printed, we resume from this frame
               stack.push(Object(members.iter(), first=true))
@@ -309,7 +312,7 @@ pub fn Json::stringify(
               depth += 1
               buf.write_char('[')
               if indent > 0 {
-                write_indent(buf, indent_cache, depth, indent_unit)
+                write_indent(buf, indent_cache, depth, indent)
               }
               stack.push(Array(arr, i=0))
             }
@@ -340,7 +343,7 @@ pub fn Json::stringify(
               if i > 0 {
                 buf.write_char(',')
                 if indent > 0 {
-                  write_indent(buf, indent_cache, depth, indent_unit)
+                  write_indent(buf, indent_cache, depth, indent)
                 }
               }
               continue Some(element)
@@ -348,7 +351,7 @@ pub fn Json::stringify(
               depth -= 1
               ignore(stack.pop())
               if indent > 0 {
-                write_indent(buf, indent_cache, depth, indent_unit)
+                write_indent(buf, indent_cache, depth, indent)
               }
               buf.write_char(']')
               continue None
@@ -367,7 +370,7 @@ pub fn Json::stringify(
                 if !first {
                   buf.write_char(',')
                   if indent > 0 {
-                    write_indent(buf, indent_cache, depth, indent_unit)
+                    write_indent(buf, indent_cache, depth, indent)
                   }
                 }
                 buf.write_char('\"')
@@ -384,7 +387,7 @@ pub fn Json::stringify(
                 depth -= 1
                 ignore(stack.pop())
                 if indent > 0 {
-                  write_indent(buf, indent_cache, depth, indent_unit)
+                  write_indent(buf, indent_cache, depth, indent)
                 }
                 buf.write_char('}')
                 continue None

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -93,10 +93,12 @@ fn write_indent(
   level : Int,
   indent : Int,
 ) -> Unit {
-  // Each level is the previous one plus a single indentation unit, so filling
-  // the cache costs O(indent) per new level rather than O(indent * level), and
-  // never computes `indent * level` — a product that overflows `Int` to a
-  // negative value for a large `indent`, which `String::repeat` rejects.
+  // Each level is the previous one plus a single indentation unit. Building a
+  // level is still O(indent * level) — concatenation copies `last` — but it
+  // replaces a fresh `repeat(indent * level)` with a `repeat(indent)`, roughly
+  // halving the bytes written per level. It also never computes the product
+  // `indent * level`, which overflows `Int` to a negative value for a large
+  // `indent` and is then rejected by `String::repeat`.
   //
   // The unit is built here rather than once per `stringify` call so that a
   // document emitting no indentation at all never allocates it: callers reach

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -91,10 +91,17 @@ fn write_indent(
   buf : StringBuilder,
   cache : Array[String],
   level : Int,
-  indent : Int,
+  unit : String,
 ) -> Unit {
+  // Each level is the previous one plus a single indentation unit, so filling
+  // the cache costs O(indent) per new level rather than O(indent * level), and
+  // never computes `indent * level` — a product that overflows `Int` to a
+  // negative value for a large `indent`, which `String::repeat` rejects.
   while cache.length() <= level {
-    cache.push("\n" + " ".repeat(indent * cache.length()))
+    match cache.last() {
+      None => cache.push("\n")
+      Some(prev) => cache.push(prev + unit)
+    }
   }
   buf.write_string(cache[level])
 }
@@ -274,6 +281,7 @@ pub fn Json::stringify(
 ) -> String {
   let buf = StringBuilder(size_hint=0)
   let indent_cache : Array[String] = []
+  let indent_unit = " ".repeat(indent)
 
   // Explicit stack to replace recursive calls
   let stack : Array[WriteFrame] = []
@@ -289,7 +297,7 @@ pub fn Json::stringify(
               depth += 1
               buf.write_char('{')
               if indent > 0 {
-                write_indent(buf, indent_cache, depth, indent)
+                write_indent(buf, indent_cache, depth, indent_unit)
               }
               // After child value printed, we resume from this frame
               stack.push(Object(members.iter(), first=true))
@@ -301,7 +309,7 @@ pub fn Json::stringify(
               depth += 1
               buf.write_char('[')
               if indent > 0 {
-                write_indent(buf, indent_cache, depth, indent)
+                write_indent(buf, indent_cache, depth, indent_unit)
               }
               stack.push(Array(arr, i=0))
             }
@@ -332,7 +340,7 @@ pub fn Json::stringify(
               if i > 0 {
                 buf.write_char(',')
                 if indent > 0 {
-                  write_indent(buf, indent_cache, depth, indent)
+                  write_indent(buf, indent_cache, depth, indent_unit)
                 }
               }
               continue Some(element)
@@ -340,7 +348,7 @@ pub fn Json::stringify(
               depth -= 1
               ignore(stack.pop())
               if indent > 0 {
-                write_indent(buf, indent_cache, depth, indent)
+                write_indent(buf, indent_cache, depth, indent_unit)
               }
               buf.write_char(']')
               continue None
@@ -359,7 +367,7 @@ pub fn Json::stringify(
                 if !first {
                   buf.write_char(',')
                   if indent > 0 {
-                    write_indent(buf, indent_cache, depth, indent)
+                    write_indent(buf, indent_cache, depth, indent_unit)
                   }
                 }
                 buf.write_char('\"')
@@ -376,7 +384,7 @@ pub fn Json::stringify(
                 depth -= 1
                 ignore(stack.pop())
                 if indent > 0 {
-                  write_indent(buf, indent_cache, depth, indent)
+                  write_indent(buf, indent_cache, depth, indent_unit)
                 }
                 buf.write_char('}')
                 continue None

--- a/json/json.mbt
+++ b/json/json.mbt
@@ -98,9 +98,9 @@ fn write_indent(
   // never computes `indent * level` — a product that overflows `Int` to a
   // negative value for a large `indent`, which `String::repeat` rejects.
   while cache.length() <= level {
-    match cache.last() {
-      None => cache.push("\n")
-      Some(prev) => cache.push(prev + unit)
+    match cache {
+      [.., last] => cache.push(last + unit)
+      [] => cache.push("\n")
     }
   }
   buf.write_string(cache[level])

--- a/json/stringify_indent_bench_test.mbt
+++ b/json/stringify_indent_bench_test.mbt
@@ -22,7 +22,48 @@ fn make_deep_wide_json() -> Json {
 }
 
 ///|
+/// A document shaped like ordinary API/config output: a few hundred small
+/// objects nested four deep. Unlike `make_deep_wide_json`, this does not park
+/// every separator past the old 8-space lookup cutoff, so it reflects what
+/// pretty-printing actually costs on realistic input.
+fn make_shallow_wide_json() -> Json {
+  let rows = Array::makei(500, i => {
+    let row : Json = {
+      "id": Json::number(i.to_double()),
+      "name": Json::string("item-\{i}"),
+      "meta": {
+        "active": Json::boolean(i % 2 == 0),
+        "score": Json::number(1.5),
+      },
+    }
+    row
+  })
+  { "items": rows.to_json(), "total": Json::number(500.0) }
+}
+
+///|
 test "bench Json::stringify deep wide indent=2 n=10000" (it : @bench.T) {
   let json = make_deep_wide_json()
   it.bench(fn() { it.keep(json.stringify(indent=2).length()) })
+}
+
+///|
+/// The default, and by far the most common, path. The indentation cache is
+/// never consulted here, so this guards the compact path against regressions
+/// from indentation work.
+test "bench Json::stringify compact n=10000" (it : @bench.T) {
+  let json = make_deep_wide_json()
+  it.bench(fn() { it.keep(json.stringify().length()) })
+}
+
+///|
+test "bench Json::stringify shallow wide indent=2 n=500" (it : @bench.T) {
+  let json = make_shallow_wide_json()
+  it.bench(fn() { it.keep(json.stringify(indent=2).length()) })
+}
+
+///|
+test "bench Json::stringify shallow wide compact n=500" (it : @bench.T) {
+  let json = make_shallow_wide_json()
+  it.bench(fn() { it.keep(json.stringify().length()) })
 }

--- a/json/stringify_indent_test.mbt
+++ b/json/stringify_indent_test.mbt
@@ -1,0 +1,82 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Counts the leading spaces of a line. The oracle below compares this against
+/// `indent * level` computed straight from the definition, rather than against
+/// anything the implementation produces, so it cannot reproduce a bug in the
+/// cached version.
+fn leading_spaces(line : StringView) -> Int {
+  let mut n = 0
+  for c in line {
+    if c != ' ' {
+      break
+    }
+    n += 1
+  }
+  n
+}
+
+///|
+/// `[[[...[0]...]]]` nested `depth` levels deep.
+fn nest(depth : Int) -> Json {
+  let mut value : Json = Json::number(0.0)
+  for _ in 0..<depth {
+    value = Json::array([value])
+  }
+  value
+}
+
+///|
+/// Exhaustive over the interesting domain: every indent width 0..=6 crossed
+/// with every nesting depth 0..=12. This spans both sides of the 8-space
+/// lookup cutoff that the pre-cache implementation special-cased, which the
+/// existing snapshots (indent 1/2/4/5/7 at shallow depth) never reach.
+test "stringify indentation matches the definition at every depth and width" {
+  for indent in 0..<=6 {
+    for depth in 0..<=12 {
+      let out = nest(depth).stringify(indent~)
+      if indent == 0 {
+        // Compact: no newlines at all.
+        assert_eq(out.contains("\n"), false)
+        continue
+      }
+      let lines = out.split("\n").collect()
+      // depth opening brackets + the scalar + depth closing brackets
+      assert_eq(lines.length(), depth * 2 + 1)
+      for i in 0..<lines.length() {
+        // Level rises to `depth` on the scalar line, then falls back.
+        let level = if i <= depth { i } else { depth * 2 - i }
+        let want = indent * level
+        assert_eq(leading_spaces(lines[i]), want)
+      }
+    }
+  }
+}
+
+///|
+/// The cache is filled lazily as depth increases, so a document that revisits
+/// shallower levels after going deep must still emit the right width. Guards
+/// against an off-by-one or a stale entry in the incremental fill.
+test "stringify indentation is stable when depth decreases again" {
+  let value : Json = {
+    "deep": [[[[[[Json::number(1.0)]]]]]],
+    "shallow": Json::number(2.0),
+  }
+  let out = value.stringify(indent=3)
+  for line in out.split("\n") {
+    assert_eq(leading_spaces(line) % 3, 0)
+  }
+  inspect(out.contains("\n                  "), content="true")
+}

--- a/json/stringify_indent_test.mbt
+++ b/json/stringify_indent_test.mbt
@@ -80,3 +80,24 @@ test "stringify indentation is stable when depth decreases again" {
   }
   inspect(out.contains("\n                  "), content="true")
 }
+
+///|
+/// A non-positive `indent` selects the compact path. It must not reach
+/// `String::repeat`, which aborts on a negative count, and must not allocate an
+/// indentation unit that is never used.
+test "stringify with non-positive indent is compact and never aborts" {
+  let doc : Json = { "a": [Json::number(1.0), { "b": Json::number(2.0) }] }
+  let compact = doc.stringify()
+  assert_eq(doc.stringify(indent=0), compact)
+  assert_eq(doc.stringify(indent=-1), compact)
+  assert_eq(doc.stringify(indent=-1000000000), compact)
+}
+
+///|
+/// A document that emits no indentation must not pay for the indentation unit,
+/// however large `indent` is. This would abort or exhaust memory if the unit
+/// were built eagerly per call.
+test "stringify of a scalar ignores a huge indent" {
+  inspect(Json::number(1.0).stringify(indent=1000000000), content="1")
+  inspect((Json::array([]) : Json).stringify(indent=1000000000), content="[]")
+}


### PR DESCRIPTION
Follow-up to #4145, which added the depth-indexed indentation cache. Three small things on top of it.

### 1. Fill the cache incrementally

```diff
- cache.push("\n" + " ".repeat(indent * cache.length()))
+ match cache.last() {
+   None => cache.push("\n")
+   Some(prev) => cache.push(prev + unit)
+ }
```

Each level is the previous level plus one indentation unit. Building a level is **still O(indent × level)** — the concatenation copies `last` — but it replaces a fresh `repeat(indent * level)` with a `repeat(indent)`, roughly halving the bytes written per level. (An earlier revision of this description claimed an asymptotic improvement; that was wrong, as Codex pointed out in review.)

The unit is built inside `write_indent` rather than once per `stringify` call, so a document that emits no indentation never allocates it.

It also removes the `indent * level` product. That matters because `String::repeat` **aborts on a negative count** (`builtin/string_methods.mbt:1606`), so an overflowing product yields `abort("negative repeat count")` — or, if it wraps to a small positive, silently emits the wrong indentation width. Reaching this needs an extreme `indent × depth`, so it is a robustness cleanup rather than a live bug.

**I want to be straight about the performance: it is not a measurable win.**

| Benchmark (native, release) | before | after | Δ |
|---|---|---|---|
| deep wide indent=2 n=10000 | 438.86 ± 7.01 µs | 428.88 ± 7.08 µs | −2.3% |
| compact n=10000 | 345.86 ± 9.09 µs | 341.59 ± 5.58 µs | −1.2% |
| shallow indent=2 n=500 | 165.93 ± 1.35 µs | 164.28 ± 4.02 µs | −1.0% |
| shallow compact n=500 | 140.55 ± 1.72 µs | 137.87 ± 1.85 µs | −1.9% |

Directionally consistent across all four, but every delta is within ~1–2σ. The reason is structural: that workload is ~84% double→string formatting (see the companion PR), so indentation changes cannot move it much. **If you'd rather drop this hunk and take only the tests and benchmarks below, that is a reasonable call.**

### 2. An oracle-driven regression test

`json/stringify_indent_test.mbt` checks indentation against `indent * level` computed straight from the definition, rather than against anything the implementation produces.

Exhaustive over indent widths 0..=6 crossed with nesting depths 0..=12 — spanning **both sides of the 8-space lookup cutoff** that the pre-cache implementation special-cased. The existing snapshots cover indent 1/2/4/5/7 at shallow depth and never reach past it, which is exactly where the cache changed behavior. A second test covers a document that returns to shallower levels after going deep, guarding the lazy fill against stale entries.

Mutation-checked: an off-by-one in the fill breaks 7 tests.

### 3. Benchmarks for the paths that were unguarded

The benchmark added in #4145 wraps a 10,000-element array in six singleton arrays, placing every separator at depth 7 — past the old fast path. That measures the best case and nothing else. Added:

- **compact path** (`indent=0`) — the default, and by far the most common
- **realistic shallow document** — 500 small objects nested four deep, like ordinary API/config output

so a future regression on the common paths is visible rather than silent.

### Verification

| | wasm | wasm-gc | js | native |
|---|---|---|---|---|
| `moon test` | 7553 ✓ | 7583 ✓ | 7523 ✓ | 7468 ✓ |

`moon check --deny-warn --target all` clean. `moon info` shows no `.mbti` diff.

Independent of the companion number-formatting PR — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z81qJ5vdYoxZ48JTKCdAy
