### PR TITLE
refactor(encoding/ascii): derive Malformed views from the matched view

### DIFF
--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -64,10 +64,10 @@ fn decode_v128(bytes : BytesView) -> String raise Malformed {
   let result = FixedArray::make(length * 2, b'\x00')
   for rest = bytes, result_offset = 0 {
     match rest {
-      [v128le(block), .. tail] => {
+      [v128le(block), .. tail] as current => {
         let non_ascii = @v128.i8x16_bitmask(block)
         if non_ascii != 0 {
-          raise Malformed(bytes[result_offset / 2 + non_ascii.ctz():])
+          raise Malformed(current[non_ascii.ctz():])
         }
         @v128.v128_store(
           result,
@@ -87,7 +87,7 @@ fn decode_v128(bytes : BytesView) -> String raise Malformed {
         continue tail, result_offset + 2
       }
       [] => break
-      _ => raise Malformed(bytes[result_offset / 2:])
+      _ as invalid => raise Malformed(invalid)
     }
   }
   result.unsafe_reinterpret_as_bytes().to_unchecked_string()


### PR DESCRIPTION
Follow-up cleanup from the review of #4163 (1 of 2).

`decode_v128` recovers the offending input offset by dividing the *output* offset:

```moonbit
raise Malformed(bytes[result_offset / 2 + non_ascii.ctz():])
...
_ => raise Malformed(bytes[result_offset / 2:])
```

The matched view already starts at the offending byte, so the arithmetic is unnecessary — and it couples the error payload to the write cursor, which has to stay in lockstep at 2 output bytes per input byte for the division to be correct.

Bind the vector arm with `as current` and let the catch-all bind its view directly, so both payloads come from the view being matched. This is the shape `decode_scalar` in the same file already uses (`(_, _ as bytes) => raise Malformed(bytes)`).

No behavior change.

## Verification

- `moon check -p encoding/ascii --target all`, `moon fmt`, `moon info` (no `.mbti` change)
- `moon test -p encoding/ascii` on wasm / wasm-gc / js / native / llvm — all pass

The guard here is the existing quickcheck in `encoding/ascii/decode_v128_wbtest.mbt`, which compares `decode_v128` against `decode_scalar` on both the decoded string *and the remaining view on failure*, over arbitrary payloads seen through views with arbitrary unaligned start offsets — i.e. exactly the offsets this patch changes how it computes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wPGhicD5xMW9xH5Uk56iK