### PR TITLE
refactor(encoding/utf16): drop the dead leading surrogate checks

### DIFF
--- a/encoding/utf16/decode.mbt
+++ b/encoding/utf16/decode.mbt
@@ -58,9 +58,6 @@ fn utf16_needs_scalar_le_v128(bytes : BytesView) -> Bool {
   if bytes.length() % 2 != 0 {
     return true
   }
-  if bytes is [u16le(0xD800..=0xDFFF), ..] {
-    return true
-  }
   for rest = bytes {
     match rest {
       [v128le(block), .. tail] => {
@@ -81,9 +78,6 @@ fn utf16_needs_scalar_le_v128(bytes : BytesView) -> Bool {
 #cfg(not(target="js"))
 fn utf16_needs_scalar_be_v128(bytes : BytesView) -> Bool {
   if bytes.length() % 2 != 0 {
-    return true
-  }
-  if bytes is [u16be(0xD800..=0xDFFF), ..] {
     return true
   }
   for rest = bytes {


### PR DESCRIPTION
Follow-up cleanup from the review of #4163 (2 of 2).

`utf16_needs_scalar_le_v128` and `utf16_needs_scalar_be_v128` each test the first code unit for a surrogate before entering the scan loop:

```moonbit
if bytes is [u16le(0xD800..=0xDFFF), ..] {
  return true
}
```

That test can never fire:

- with >= 16 bytes remaining, the first loop arm checks all eight code units of the block — including the first — via `utf16_v128_has_surrogate`;
- with fewer, the `[u16le(0xD800..=0xDFFF), ..]` arm catches the first code unit itself.

The check dates from the indexed-loop version and was carried through the bitstring rewrite in #4163, where the loop's own arms took over the job. Removed from both functions.

No behavior change.

## Verification

- `moon check -p encoding/utf16 --target all`, `moon fmt`, `moon info` (no `.mbti` change)
- `moon test -p encoding/utf16` on wasm / wasm-gc / js / native / llvm — 28 tests, all pass

`encoding/utf16/quickcheck_test.mbt` covers the first-code-unit case directly, including "a surrogate at every position of a vectorized block" and "every pair of boundary code units matches the oracle".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wPGhicD5xMW9xH5Uk56iK