### PR TITLE
Revert "refactor(encoding/ascii): derive Malformed views from the matched view"

### DIFF
--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -64,10 +64,10 @@ fn decode_v128(bytes : BytesView) -> String raise Malformed {
   let result = FixedArray::make(length * 2, b'\x00')
   for rest = bytes, result_offset = 0 {
     match rest {
-      [v128le(block), .. tail] as current => {
+      [v128le(block), .. tail] => {
         let non_ascii = @v128.i8x16_bitmask(block)
         if non_ascii != 0 {
-          raise Malformed(current[non_ascii.ctz():])
+          raise Malformed(bytes[result_offset / 2 + non_ascii.ctz():])
         }
         @v128.v128_store(
           result,
@@ -87,7 +87,7 @@ fn decode_v128(bytes : BytesView) -> String raise Malformed {
         continue tail, result_offset + 2
       }
       [] => break
-      _ as invalid => raise Malformed(invalid)
+      _ => raise Malformed(bytes[result_offset / 2:])
     }
   }
   result.unsafe_reinterpret_as_bytes().to_unchecked_string()


### PR DESCRIPTION
Reverts moonbitlang/core#4185

Capturing the loop variable prevents it from being unboxed and caused performance regression. So revert it here.