### PR TITLE
fix(builtin): stop nulling vacated Array slots so views cannot read invalid memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ changelog should follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Core commit: `bd827dc85`
 - Added `Debug` trait with `derive(Debug)` support, including `ignore=[..]` configuration for non-debuggable nested types
 - Added new `moonbitlang/async` APIs including `@process.spawn`, advisory file locking, `@fs.tmpdir`, `@async.all`, and `@async.any`
+- Added `Array::release_unused(placeholder~)`, which overwrites the unused capacity of an array in place with a placeholder, releasing the elements that earlier removals left there
 
 #### Changed
 
+- `Array` shrinking operations no longer null out the slots they vacate, so an `ArrayView` created before the mutation can no longer read uninitialized memory (previously a segfault on native and `null` on wasm-gc; the JavaScript backend is unchanged, and such a view still observes `undefined` past the array's current length there). Mutating an array while a view of it is alive remains a program error, but it now yields unspecified *valid* values rather than undefined behavior. The removed elements stay reachable from the buffer until later pushes reuse those slots, the buffer grows, or the array is dropped -- uniformly, `clear` included, which no longer releases them. `Array::release_unused(placeholder~)` overwrites the unused capacity in place with a placeholder to release them on demand, while `shrink_to_fit`, which already reallocated, lets them go with the old buffer. No existing signature changes
 - **BREAKING**: `@json.parse` now rejects unpaired `\uXXXX` surrogate escapes in strings, raising `ParseError::InvalidChar` at the backslash that opens the offending escape; an escaped leading surrogate must be followed immediately by an escaped trailing surrogate, and the pair decodes to the character it denotes. Previously such escapes were decoded unchecked and produced a `String` that was not well-formed Unicode. `@json.valid` reports the same documents as invalid. JSON emitted by `JSON.stringify` in JavaScript can contain these escapes, so input that JavaScript and Python accept may now be rejected — as it is by Rust's serde_json
 - `@json.inspect` has been migrated to `json_inspect`
 - `String::sub` and `StringView::sub` now panic on invalid indices instead of raising `CreatingViewError`. The `CreatingViewError` type has been removed.

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -560,6 +560,13 @@ pub fn[T] Array::any(self : Array[T], f : (T) -> Bool raise?) -> Bool raise? {
 ///
 /// This method has no effect on the allocated capacity of the array, only setting the length to 0.
 ///
+/// Emptying an array is a removal like any other: the buffer keeps referring to
+/// the elements that were in it, and they are released once later pushes reuse
+/// those slots, the buffer grows, or the array is dropped. Call
+/// `Array::release_unused` to overwrite them at once, or `Array::shrink_to_fit`
+/// to hand the buffer back entirely. On the JavaScript backend the removed
+/// elements are released right away and `Array::release_unused` is a no-op.
+///
 /// # Example
 /// ```mbt check
 /// test {
@@ -1861,6 +1868,14 @@ pub fn[A] Array::unsafe_pop_back(self : Array[A]) -> Unit {
 /// Important:
 ///   - If `len` is negative, the function does nothing.
 ///   - If `len` exceeds current length, the array remains unchanged.
+///
+/// Elements beyond `len` are removed from the array, but the backing buffer
+/// keeps referring to them: they are released once those slots are reused by
+/// later pushes, once the buffer grows, or once the array is dropped. Call
+/// `Array::release_unused` to overwrite them at once, or `Array::shrink_to_fit`
+/// to move the survivors into an exact-size buffer. On the JavaScript backend
+/// the removed elements are released right away and `Array::release_unused` is a
+/// no-op.
 ///
 /// Example:
 ///

--- a/builtin/array_nonjs_test.mbt
+++ b/builtin/array_nonjs_test.mbt
@@ -69,3 +69,209 @@ test "shrink_to_fit" {
   v.shrink_to_fit()
   inspect(v.capacity(), content="3")
 }
+
+///|
+/// Removing elements must never leave a slot a view could read as
+/// uninitialized memory, so nothing is written to the slots a removal vacates
+/// and a view taken beforehand still sees the original elements.
+test "clear leaves the emptied slots as they were" {
+  let arr = ["a", "b", "c"]
+  let view = arr[0:3]
+  arr.clear()
+  inspect(arr.length(), content="0")
+  debug_inspect(
+    view,
+    content=(
+      #|<ArrayView: ["a", "b", "c"]>
+    ),
+  )
+}
+
+///|
+test "release_unused after clear overwrites the whole buffer" {
+  let arr = ["a", "b", "c"]
+  let view = arr[0:3]
+  arr.clear()
+  arr.release_unused(placeholder="-")
+  inspect(arr.length(), content="0")
+  debug_inspect(
+    view,
+    content=(
+      #|<ArrayView: ["-", "-", "-"]>
+    ),
+  )
+}
+
+///|
+test "truncate keeps removed elements reachable until release_unused" {
+  let kept = ["a", "b", "c", "d"]
+  let kept_view = kept[0:4]
+  kept.truncate(2)
+  debug_inspect(
+    kept,
+    content=(
+      #|["a", "b"]
+    ),
+  )
+  debug_inspect(
+    kept_view,
+    content=(
+      #|<ArrayView: ["a", "b", "c", "d"]>
+    ),
+  )
+  let filled = ["a", "b", "c", "d"]
+  let filled_view = filled[0:4]
+  filled.truncate(2)
+  filled.release_unused(placeholder="-")
+  debug_inspect(
+    filled,
+    content=(
+      #|["a", "b"]
+    ),
+  )
+  debug_inspect(
+    filled_view,
+    content=(
+      #|<ArrayView: ["a", "b", "-", "-"]>
+    ),
+  )
+}
+
+///|
+/// No shrinking operation replaces the buffer, so emptying an array never
+/// costs an allocation -- whether it happens through `clear`, `truncate`,
+/// `remove` or `drain`. A later push makes that observable: it lands in the
+/// reused buffer, which a view taken beforehand still points at.
+test "no shrinking operation replaces the buffer" {
+  let cleared = ["a", "b", "c"]
+  let cleared_view = cleared[0:3]
+  cleared.clear()
+  cleared.push("x")
+  debug_inspect(
+    cleared_view,
+    content=(
+      #|<ArrayView: ["x", "b", "c"]>
+    ),
+  )
+  let truncated = ["a", "b", "c"]
+  let truncated_view = truncated[0:3]
+  truncated.truncate(0)
+  truncated.push("x")
+  debug_inspect(
+    truncated_view,
+    content=(
+      #|<ArrayView: ["x", "b", "c"]>
+    ),
+  )
+  // `remove(0)` shifts "b" down, so the buffer reads [b, b] before the push.
+  let removed = ["a", "b"]
+  let removed_view = removed[0:2]
+  let _ = removed.remove(0)
+  removed.push("x")
+  debug_inspect(
+    removed_view,
+    content=(
+      #|<ArrayView: ["b", "x"]>
+    ),
+  )
+  // `drain(0, 2)` shifts "c" down, so the buffer reads [c, b, c] before the push.
+  let drained = ["a", "b", "c"]
+  let drained_view = drained[0:3]
+  let _ = drained.drain(0, 2)
+  drained.push("x")
+  debug_inspect(
+    drained_view,
+    content=(
+      #|<ArrayView: ["c", "x", "c"]>
+    ),
+  )
+}
+
+///|
+test "release_unused overwrites the tail a drain vacated" {
+  let arr = ["a", "b", "c", "d"]
+  let view = arr[0:4]
+  let drained = arr.drain(1, 3)
+  arr.release_unused(placeholder="-")
+  debug_inspect(
+    drained,
+    content=(
+      #|["b", "c"]
+    ),
+  )
+  debug_inspect(
+    arr,
+    content=(
+      #|["a", "d"]
+    ),
+  )
+  debug_inspect(
+    view,
+    content=(
+      #|<ArrayView: ["a", "d", "-", "-"]>
+    ),
+  )
+}
+
+///|
+/// `pop`, `remove` and `retain` offer no fill value of their own, so the
+/// elements they remove stay in the buffer until something overwrites them.
+/// `release_unused` is what releases them without reallocating, and a view taken
+/// beforehand shows exactly which slots it reached.
+test "release_unused releases what pop and remove leave behind" {
+  let popped = ["a", "b", "c"]
+  let popped_view = popped[0:3]
+  let _ = popped.pop()
+  debug_inspect(
+    popped_view,
+    content=(
+      #|<ArrayView: ["a", "b", "c"]>
+    ),
+  )
+  popped.release_unused(placeholder="-")
+  debug_inspect(
+    popped_view,
+    content=(
+      #|<ArrayView: ["a", "b", "-"]>
+    ),
+  )
+  let removed = ["a", "b", "c"]
+  let removed_view = removed[0:3]
+  let _ = removed.remove(0)
+  removed.release_unused(placeholder="-")
+  debug_inspect(
+    removed,
+    content=(
+      #|["b", "c"]
+    ),
+  )
+  debug_inspect(
+    removed_view,
+    content=(
+      #|<ArrayView: ["b", "c", "-"]>
+    ),
+  )
+}
+
+///|
+/// `release_unused` covers the whole unused region, not just the slots the most
+/// recent operation vacated, so one call settles a run of removals.
+test "release_unused spans every outstanding removal" {
+  let arr = ["a", "b", "c", "d"]
+  let view = arr[0:4]
+  let _ = arr.pop()
+  arr.truncate(1)
+  arr.release_unused(placeholder="-")
+  debug_inspect(
+    arr,
+    content=(
+      #|["a"]
+    ),
+  )
+  debug_inspect(
+    view,
+    content=(
+      #|<ArrayView: ["a", "-", "-", "-"]>
+    ),
+  )
+}

--- a/builtin/arraycore_js.mbt
+++ b/builtin/arraycore_js.mbt
@@ -253,6 +253,29 @@ pub fn[T] Array::shrink_to_fit(self : Array[T]) -> Unit {
 }
 
 ///|
+/// Overwrites the array's unused capacity with `placeholder`, releasing
+/// whatever those slots held.
+///
+/// **NOTE**: This method does nothing on the js platform -- shrinking a
+/// JavaScript array releases the removed elements outright, so there is no
+/// unused capacity holding on to them.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let arr = ["a", "b", "c"]
+///   let _ = arr.pop()
+///   arr.release_unused(placeholder="")
+///   debug_inspect(arr, content="[\"a\", \"b\"]")
+/// }
+/// ```
+pub fn[T] Array::release_unused(self : Array[T], placeholder~ : T) -> Unit {
+  ignore(self)
+  ignore(placeholder)
+}
+
+///|
 /// Adds an element to the end of the array.
 ///
 /// If the array is at capacity, it will be reallocated.
@@ -430,6 +453,9 @@ pub fn[T] Array::remove(self : Array[T], index : Int) -> T {
 ///   @test.assert_eq(v, [3, 5])
 /// }
 /// ```
+///
+/// On this backend the underlying JavaScript array is spliced directly, which
+/// already releases the drained elements.
 pub fn[T] Array::drain(self : Array[T], begin : Int, end : Int) -> Array[T] {
   guard begin >= 0 && end <= self.length() && begin <= end else {
     abort(

--- a/builtin/arraycore_nonjs.mbt
+++ b/builtin/arraycore_nonjs.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-fn[T] UninitializedArray::set_null(self : UninitializedArray[T], index : Int) = "%fixedarray.set_null"
-
-///|
 /// An `Array` is a collection of values that supports random access and can
 /// grow in size.
 struct Array[T] {
@@ -172,13 +169,15 @@ pub fn[T] Array::length(self : Array[T]) -> Int {
 /// - This function does not raise errors, but it panics if `new_len` is greater
 /// than the current length of the array.
 ///
-/// TODO: this can be optimized by using the intrinsic to null out the range
+/// # Retention
+///
+/// The slots beyond `new_len` are left as they are rather than nulled out, so
+/// that an `ArrayView` created before the call can never observe uninitialized
+/// memory. The removed elements stay reachable from the buffer until those
+/// slots are reused by later pushes, until the buffer grows, or until the
+/// array is dropped; `Array::release_unused` overwrites them on demand.
 fn[T] Array::unsafe_truncate_to_length(self : Array[T], new_len : Int) -> Unit {
-  let len = self.length()
-  guard! new_len <= len
-  for i in new_len..<len {
-    self.buf.set_null(i)
-  }
+  guard! new_len <= self.length()
   self.len = new_len
 }
 
@@ -242,8 +241,11 @@ test "panic Array growth rejects a wrapped required size" {
 ///|
 fn[T] Array::resize_buffer(self : Array[T], new_capacity : Int) -> Unit {
   let old_buf = self.buf
-  let old_cap = old_buf.0.length()
-  let copy_len = if old_cap < new_capacity { old_cap } else { new_capacity }
+  // Only the live prefix is worth carrying over. The slots beyond `len` hold
+  // either NULL or the elements earlier removals left behind, and leaving them
+  // with the old buffer is what releases the latter when that buffer dies.
+  let len = self.len
+  let copy_len = if len < new_capacity { len } else { new_capacity }
   let new_buf = UninitializedArray::make_and_blit(
     old_buf,
     allocate_len=new_capacity,
@@ -339,11 +341,54 @@ pub fn[T] Array::reserve_capacity(self : Array[T], capacity : Int) -> Unit {
 ///   @test.assert_eq(v.capacity(), 3)
 /// }
 /// ```
+///
+/// The survivors are copied into the new buffer and the old one is released
+/// with them, so this also releases whatever earlier removals left in the
+/// unused capacity. It pays an allocation plus a copy of every survivor to do
+/// so; `Array::release_unused` releases the same elements in one pass over the
+/// unused region and no allocation, at the cost of leaving the capacity alone.
 pub fn[T] Array::shrink_to_fit(self : Array[T]) -> Unit {
   if self.capacity() <= self.length() {
     return
   }
   self.resize_buffer(self.length())
+}
+
+///|
+/// Overwrites the array's unused capacity -- every slot from `length()` up to
+/// `capacity()` -- with `placeholder`, releasing whatever those slots held.
+///
+/// Shrinking an array never clears the slots it vacates, so whatever they held
+/// -- a removed element, or a duplicate reference to a survivor that was
+/// shifted over it -- stays reachable from the buffer and unreleased until
+/// later pushes reuse those slots, the buffer grows, or the array is dropped.
+/// This releases them on demand without reallocating, which is what
+/// `Array::pop`, `Array::remove`, `Array::retain` and the other operations
+/// that take no placeholder leave outstanding. `Array::shrink_to_fit` releases
+/// them too, but by allocating an exact-size buffer and copying every survivor
+/// into it; this costs one pass over the unused region and no allocation.
+///
+/// An `ArrayView` created before the call observes `placeholder` in that region
+/// afterwards, in place of whatever it held.
+///
+/// This only matters for element types holding references -- for types such as
+/// `Int` there is nothing to release and the call merely costs a pass over the
+/// buffer.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let arr = ["a", "b", "c"]
+///   let _ = arr.pop()
+///   arr.release_unused(placeholder="")
+///   debug_inspect(arr, content="[\"a\", \"b\"]")
+/// }
+/// ```
+#owned(placeholder)
+pub fn[T] Array::release_unused(self : Array[T], placeholder~ : T) -> Unit {
+  let len = self.len
+  self.buf.unchecked_fill(len, placeholder, self.capacity() - len)
 }
 
 ///|
@@ -531,6 +576,11 @@ pub fn[A] ArrayView::blit_to(
 ///|
 /// Removes the last element from an array and returns it, or `None` if it is empty.
 ///
+/// The vacated slot goes on referring to the returned element, so an
+/// `ArrayView` created beforehand keeps observing that element, and it is
+/// released only once a later push reuses the slot, the buffer grows, or the
+/// buffer is dropped. Call `Array::release_unused` to release it at once.
+///
 /// # Example
 /// ```mbt check
 /// test {
@@ -546,7 +596,8 @@ pub fn[T] Array::pop(self : Array[T]) -> T? {
   } else {
     let index = len - 1
     let v = self.unsafe_get(index)
-    self.buf.set_null(index)
+    // The slot keeps referring to `v` until it is reused or the buffer dies;
+    // see `unsafe_truncate_to_length` for why it is not nulled out.
     self.len = index
     Some(v)
   }
@@ -560,6 +611,10 @@ pub fn[T] Array::pop(self : Array[T]) -> T? {
 /// * `array` : The array from which to remove and return the last element.
 ///
 /// Returns the last element of the array before removal.
+///
+/// As with `Array::pop`, the vacated slot goes on referring to the returned
+/// element until a later push reuses it, the buffer grows, the buffer is
+/// dropped, or `Array::release_unused` overwrites it.
 ///
 /// Example:
 ///
@@ -579,7 +634,6 @@ pub fn[T] Array::unsafe_pop(self : Array[T]) -> T {
   guard! len != 0
   let index = len - 1
   let v = self.unsafe_get(index)
-  self.buf.set_null(index)
   self.len = index
   v
 }
@@ -632,6 +686,14 @@ pub fn[T] Array::remove(self : Array[T], index : Int) -> T {
 ///   @test.assert_eq(v, [3, 5])
 /// }
 /// ```
+///
+/// The `end - begin` slots vacated at the end of the array are not cleared:
+/// each keeps whatever it held before the survivors were shifted down, so a
+/// drained element or a duplicate reference to a survivor stays reachable
+/// there until the slot is reused, the buffer grows, or the array is dropped.
+/// Call `Array::release_unused` to overwrite them at once, or
+/// `Array::shrink_to_fit` to move the survivors into an exact-size buffer.
+///
 pub fn[T] Array::drain(self : Array[T], begin : Int, end : Int) -> Array[T] {
   guard! begin >= 0 && end <= self.length() && begin <= end
   let num = end - begin

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -20,6 +20,25 @@
 /// over a view keeps using those bounds even if the underlying array is later
 /// structurally modified.
 ///
+/// Mutating an array while a view of it is alive is a program error. Because a
+/// view keeps its original bounds and does not track the array, after such a
+/// mutation it may observe elements that have since been removed, a value
+/// handed to `Array::release_unused`, or the contents of a buffer the array has
+/// stopped using. What it yields is always a valid value of `T` -- never
+/// uninitialized memory -- but is otherwise unspecified.
+///
+/// No removal writes to the slots it vacates, so the removed elements stay
+/// reachable, and so unreleased, until a later push reuses the slot, until the
+/// buffer grows, or until the buffer itself is dropped. That holds uniformly:
+/// `clear` empties an array the same way `pop` shortens it. Two operations
+/// release those elements on demand -- `Array::release_unused` overwrites the
+/// unused capacity in place, and `Array::shrink_to_fit` moves the survivors
+/// into an exact-size buffer and lets the old one go.
+///
+/// On the JavaScript backend this guarantee does not yet hold: operations such
+/// as `Array::pop` shrink the underlying JavaScript array, so a view reaching
+/// past the array's current length observes `undefined`.
+///
 /// # Example
 ///
 /// ```mbt check

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -134,6 +134,7 @@ pub fn[T] Array::new(capacity? : Int) -> Self[T]
 pub fn[T] Array::pop(Self[T]) -> T?
 pub fn[T] Array::push(Self[T], T) -> Unit
 pub fn[T] Array::push_iter(Self[T], Iter[T]) -> Unit
+pub fn[T] Array::release_unused(Self[T], placeholder~ : T) -> Unit
 pub fn[T] Array::remove(Self[T], Int) -> T
 pub fn[T] Array::repeat(Self[T], Int) -> Self[T]
 pub fn[T] Array::reserve_capacity(Self[T], Int) -> Unit


### PR DESCRIPTION
Split out of #4135 (the `Array` half; `Deque` is in its own PR) so that each container can be reviewed on its own. The two are independent and can land in either order; `%fixedarray.set_null` loses its last user in core once both are in.

Taking a view from an `Array` shares the underlying buffer, and every shrinking operation cleared the slots it vacated with `%fixedarray.set_null`. A view created before such a mutation then read a null slot. `Array::view` is plain `pub`, so this is undefined behaviour reachable from entirely safe code:

```moonbit
struct Box { v : Int; pad : String }
let arr = [Box::{ v: 11, pad: "a" }, Box::{ v: 22, pad: "b" }, Box::{ v: 33, pad: "c" }]
let view = arr[0:3]
let _ = arr.pop()
println(view[2].v)   // SIGSEGV on native (exit 139) with the current core
```

Native segfaults for reference element types; wasm-gc yields `null` and JS `undefined`. `String` masks it — a null `String` reports `.length() == 0` and compares `== ""` — so the value propagates silently into other containers instead of failing.

## Approach

Vacated slots are no longer cleared, so a view can only ever observe valid values of `T`. Mutating an array while a view of it is alive stays a program error, but what the view yields is now merely unspecified rather than invalid.

The cost is that a removal retains what it removes. That applies uniformly -- `clear` empties an array the same way `pop` shortens it, and neither writes to the slots it gives up -- so there is no operation-by-operation rule to learn and no existing signature changes. The elements are released when a later push reuses the slot, when the buffer grows, or when the array is dropped, which means the clear-and-refill pattern self-heals: each push releases one old occupant, so repeated fill/drain cycles on one array hold flat.

Reclaiming on demand is explicit, and there are two ways to do it:

| | cost | capacity |
| --- | --- | --- |
| `release_unused(placeholder~)` — new | one pass over the unused capacity, no allocation | kept |
| `shrink_to_fit()` — already existed | an allocation plus a copy of every survivor | dropped to `length()` |

`release_unused` overwrites every slot from `length()` to `capacity()`, which is exactly the region any removal leaves behind. `shrink_to_fit` was already releasing those elements by letting the old buffer go; that is now documented rather than incidental.

```
Array::release_unused(Self[T], placeholder~ : T)
```

One new method, nothing else in the public surface moves. `Array::resize` shrinks like `truncate` and no longer releases on that branch. On the JavaScript backend `release_unused` is a documented no-op: shrinking a JS array already releases the removed elements, and a view reaching past the current length observes `undefined` there as before, which the `ArrayView` documentation now states.

Writing into `[length(), capacity())` is safe without tracking a high-water mark: that region is always either NULL or a live reference, never garbage. `%fixedarray.make_uninit` NULL-fills for reference element types — it has to, since `moonbit_drop_object` walks a REF_ARRAY's full capacity and skips slots with `if (!obj) continue` — and `moonbit_make_ref_array_with_blit` NULL-fills everything outside the blitted range when a buffer grows. It is the same region `Array::push` writes into on every push past the previous high-water mark.

## Changes relative to #4135

An independent review pass over the split found two places where the code and the prose disagreed, both fixed here:

- `Array::resize_buffer` now copies only the live prefix into the new buffer. It used to copy the whole old capacity, which was a memcpy of NULLs before and would have carried the retained elements into the new buffer on the `reserve_capacity` path, contradicting the "released once the buffer grows" wording; every other growth path already copied only `length()` elements.
- `Array::release_unused` uses the `%fixedarray.fill` intrinsic with an `#owned` placeholder, exactly as `Array::fill` and `Array::resize` do for this same region, instead of a hand-written `unsafe_set` loop.

Docs were tightened where they were imprecise: after a shifting removal (`remove`, `drain`, `retain`, ...) the vacated tail holds duplicate references to shifted survivors, not "the removed elements"; the shared `clear`/`truncate` docs now say the JS backend releases immediately; the changelog gets an "Added" entry for the new method. The buffer-reuse test gained a `remove` that actually shifts and a `drain` leg, which its comment already claimed.

## Review notes

Consequences the review surfaced that are inherent to the retain-instead-of-null design and worth weighing explicitly:

- Long-lived reusable buffers of reference types keep their high-water-mark contents alive after `clear()` until overwritten. The in-core instance is `lexbuf/storage.mbt`, where `discard_before` calls `chunks.clear()` on an `Array[String]` of consumed input chunks, so a streaming lexer now keeps up to `capacity()` consumed chunks alive until later pushes overwrite them. Any FFI finalizers on those elements run later than before.
- A popped or removed value is no longer uniquely referenced until its slot is reused, so the runtime's unique-source fast paths (`moonbit_make_ref_array_with_blit`'s memcpy branch, in-place reuse) are not taken for it.
- `release_unused` needs a placeholder value of `T`; element types without a cheap one (closures, handles) can only release via `shrink_to_fit`.

## Testing

- `moon test` on `--target native` (7485), `wasm-gc` (7600), `js` (7533) and `wasm` (7570), all passing
- 7 new regression tests (`not js` targets) covering: views after `clear`/`truncate`/`pop`/`remove`/`drain`; `release_unused` after each of them and a run of removals settled by one call; and that no shrinking operation replaces the buffer, pinned by pushing after emptying and observing through a view taken beforehand
- `moon check --deny-warn --target all` clean
- `moon info`, `moon fmt` — `.mbti` churn is the one added method and nothing else
- The reproducer above was run against the installed core on native and exits with SIGSEGV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjN1QF3HbJohHocMPBRcuw
