### PR TITLE
fix async lexbuf test, adapt new cancellation semantic

### DIFF
--- a/lexbuf/lexbuf_test.mbt
+++ b/lexbuf/lexbuf_test.mbt
@@ -132,10 +132,12 @@ test "Lexbuf returns an empty retained view" {
 }
 
 ///|
-async fn[T] lexbuf_test_suspend(register : ((T) -> Unit) -> Unit) -> T noraise = "%async.suspend"
+async fn[T] lexbuf_test_suspend(
+  register : ((T) -> Unit) -> Unit,
+) -> T noraise + nocancel = "%async.suspend"
 
 ///|
-fn lexbuf_test_run_async(work : async () -> Unit noraise) -> Unit = "%async.run"
+fn lexbuf_test_run_async(work : async () -> Unit noraise + nocancel) -> Unit = "%async.run"
 
 ///|
 struct LexbufTestScheduler {


### PR DESCRIPTION
We are adding first class support for cancellation in the compiler. A new `nocancel` effect is added to represent `async` function that are not cancellable. As a consequence, signature of certain async primitive should now be marked with `nocancel`. In particular, `%async.suspend` with `noraise` type should add `+ nocancel` to its signature, otherwise the code will trigger ICE. Test for async lexbuf in `moonbitlang/core` has binding for `%async.suspend` with `noraise` signature, so should be fixed.

Notice that raw async primitives are *not* stable, public API intended for end users. In general only `moonbitlang/async` should invoke them, and there is no guarantee at all for users binding `%async.suspend`/`%async.run` directly.