### PR TITLE
refactor(deque): skip the survivor shift on a tail drain, tighten two comments

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1052,8 +1052,8 @@ pub fn[A] Deque::rev_eachi(
 /// ```
 pub fn[A] Deque::clear(self : Deque[A]) -> Unit {
   // The surviving elements are none, so nothing moves: an emptied deque
-  // restarts at offset zero, the invariant `Deque::truncate` and
-  // `Deque::drain` also maintain.
+  // restarts at offset zero, as `Deque::truncate` and `Deque::drain` also
+  // arrange.
   self.len = 0
   self.head = 0
 }
@@ -1410,8 +1410,8 @@ pub fn[A] Deque::release_unused(self : Deque[A], placeholder~ : A) -> Unit {
 pub fn[A] Deque::truncate(self : Deque[A], len : Int) -> Unit {
   guard len >= 0 && len < self.len else { return }
   // The surviving elements keep their slots, so there is nothing to move: only
-  // the length changes. An emptied deque restarts at offset zero, matching the
-  // invariant `Deque::clear` and `Deque::drain` maintain.
+  // the length changes. An emptied deque restarts at offset zero, as
+  // `Deque::clear` and `Deque::drain` also arrange.
   self.len = len
   if len == 0 {
     self.head = 0
@@ -2098,12 +2098,16 @@ pub fn[A] Deque::drain(self : Deque[A], start~ : Int, len? : Int) -> Deque[A] {
       deque.buf.unsafe_blit(0, self.buf, front.start_offset() + start, len)
       if start == 0 && len == front_max_drain {
         self.head = 0
-      } else {
-        // move back
+      } else if len < front_max_drain || back.length() != 0 {
+        // Something survives after the drained range -- the rest of the front,
+        // or the back run -- so the front survivors move right to stay
+        // contiguous with it.
         let new_head = front.start_offset() + len
         self.buf.unsafe_blit(new_head, self.buf, front.start_offset(), start)
         self.head = new_head
       }
+      // Otherwise the drain took the tail of an unwrapped deque, and the
+      // survivors already sit at `[head, head + start)`.
     } else {
       // draining front and back
       // copy to deque

--- a/deque/deque_test.mbt
+++ b/deque/deque_test.mbt
@@ -3044,6 +3044,63 @@ test "deque release_unused releases what the pops leave behind" {
 /// The unused capacity of a deque can wrap, or straddle both ends of the
 /// buffer, so `release_unused` has to cover the complement of the occupied run
 /// rather than a single tail.
+test "deque release_unused covers both sides of an unwrapped run" {
+  let dq = @deque.from_array(["a", "b", "c", "d"])
+  let (view, _) = dq.as_views()
+  let _ = dq.pop_front()
+  let _ = dq.pop_back()
+  // The elements now sit at `[1, 3)`, leaving unused slots on both sides.
+  dq.release_unused(placeholder="-")
+  @debug.debug_inspect(
+    dq,
+    content=(
+      #|<Deque: ["b", "c"]>
+    ),
+  )
+  @debug.debug_inspect(
+    view,
+    content=(
+      #|<ArrayView: ["-", "b", "c", "-"]>
+    ),
+  )
+}
+
+///|
+/// Draining the tail of an unwrapped deque leaves the survivors where they
+/// are. A view taken beforehand makes that observable: the survivors are
+/// still at their original offsets and the drained slot keeps its occupant,
+/// rather than the survivors having been shifted right by the drained length.
+test "deque tail drain leaves the survivors in place" {
+  let dq = @deque.Deque([], capacity=4)
+  dq.push_back("x")
+  dq.push_back("a")
+  dq.push_back("b")
+  dq.push_back("c")
+  let _ = dq.pop_front()
+  let (front, back) = dq.as_views()
+  inspect(back.length(), content="0")
+  let drained = dq.drain(start=2)
+  @debug.debug_inspect(
+    drained,
+    content=(
+      #|<Deque: ["c"]>
+    ),
+  )
+  @debug.debug_inspect(
+    dq,
+    content=(
+      #|<Deque: ["a", "b"]>
+    ),
+  )
+  @debug.debug_inspect(
+    front,
+    content=(
+      #|<ArrayView: ["a", "b", "c"]>
+    ),
+  )
+}
+
+///|
 test "deque release_unused covers the wrapped case" {
   let dq = @deque.Deque([], capacity=4)
   dq.push_back("c")


### PR DESCRIPTION
Follow-up to #4189 (merged as d9930b60), carrying the items from its review that were not worth holding that PR for.

## One behaviour change: no survivor shift on a tail drain

`Deque::drain` handled a drain that ends at the end of the front run with a single `else` arm: shift the front survivors right by the drained length and advance `head`. That is required when something survives *after* the drained range (the rest of the front, or a non-empty back run) so the survivors stay contiguous with it. When the deque is unwrapped and the drain takes its tail, nothing survives after the range, the survivors already sit at `[head, head + start)`, and the shift was O(`start`) work that moved every survivor one slot for no reason. The arm is now guarded on `len < front_max_drain || back.length() != 0`; the tail case falls through with `head` untouched.

The new test `deque tail drain leaves the survivors in place` pins this through a view taken before the drain: the survivors stay at their original offsets and the drained slot keeps its occupant, whereas the old shift made the view read the first survivor twice. Reverting the guard fails exactly that test.

## Comment fixes

`clear` and `truncate` called "an emptied deque restarts at offset zero" an *invariant* that `clear`, `truncate` and `drain` maintain. It is not one: `pop_front` and `extract_if` can empty a deque without resetting `head`, and nothing depends on it. The comments now say those three functions arrange it.

## Extra test

`deque release_unused covers both sides of an unwrapped run` exercises a deque whose unused capacity sits before *and* after the occupied run, so each of the two `fill_slots` calls in the unwrapped branch is pinned by a test on its own.

## Testing

- `moon test -p moonbitlang/core/deque` on native (248), wasm-gc, js and wasm (258 each), all passing
- `moon check --deny-warn --target all` clean
- `moon fmt`, `moon info`: no drift, no interface change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjN1QF3HbJohHocMPBRcuw
