### PR TITLE
refactor(builtin): dedupe BytesView escaping and template escape writes

### DIFF
--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -346,8 +346,10 @@ fn write_byte_hex(logger : &Logger, byte : Byte) -> Unit {
 }
 
 ///|
-pub impl Show for BytesView with fn output(self, logger) {
-  logger.write_string("b\"")
+/// Writes the bytes with printable ASCII kept as-is and everything else
+/// rendered as `\xHH`, without the surrounding `b"`/`"`. Shared by `Show`,
+/// which adds the quotes, and `ToJson`, which does not.
+pub fn BytesView::escape_to(self : BytesView, logger : &Logger) -> Unit {
   for byte in self {
     if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
       logger.write_char(byte.to_char())
@@ -356,7 +358,11 @@ pub impl Show for BytesView with fn output(self, logger) {
       write_byte_hex(logger, byte)
     }
   }
-  logger.write_string("\"")
+}
+
+///|
+pub impl Show for BytesView with fn output(self, logger) {
+  logger <+ "b\"\{cb => self.escape_to(cb)}\""
 }
 
 ///|
@@ -593,14 +599,7 @@ pub fn BytesView::to_owned(self : BytesView) -> Bytes {
 ///|
 pub impl ToJson for BytesView with fn to_json(self) -> Json {
   let sb = StringBuilder()
-  for byte in self {
-    if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
-      sb.write_char(byte.to_char())
-    } else {
-      sb.write_string("\\x")
-      write_byte_hex(sb, byte)
-    }
-  }
+  self.escape_to(sb)
   Json::string(sb.to_string())
 }
 

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -331,7 +331,7 @@ pub fn BytesView::iter2(self : BytesView) -> Iter2[Int, Byte] {
 }
 
 ///|
-fn write_byte_hex(logger : &Logger, byte : Byte) -> Unit {
+fn[T : Logger] write_byte_hex(logger : T, byte : Byte) -> Unit {
   fn hex_digit(value : Int) -> Char {
     if value < 10 {
       (value + '0'.to_int()).unsafe_to_char()
@@ -349,7 +349,7 @@ fn write_byte_hex(logger : &Logger, byte : Byte) -> Unit {
 /// Writes the bytes with printable ASCII kept as-is and everything else
 /// rendered as `\xHH`, without the surrounding `b"`/`"`. Shared by `Show`,
 /// which adds the quotes, and `ToJson`, which does not.
-pub fn BytesView::escape_to(self : BytesView, logger : &Logger) -> Unit {
+fn[T : Logger] BytesView::escape_to(self : BytesView, logger : T) -> Unit {
   for byte in self {
     if byte is (b' '..=b'~') && byte != b'"' && byte != b'\\' {
       logger.write_char(byte.to_char())

--- a/builtin/char.mbt
+++ b/builtin/char.mbt
@@ -504,9 +504,7 @@ fn Char::escape_to(self : Char, logger : &Logger, quote? : Bool = true) -> Unit 
     ' '..='~' => logger.write_char(self)
     _ =>
       if !self.is_printable() {
-        logger.write_string("\\u{")
-        logger.write_string(self.to_hex())
-        logger.write_char('}')
+        logger <+ "\\u{\{cb => cb.write_string(self.to_hex())}}"
       } else {
         logger.write_char(self)
       }

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -1170,6 +1170,7 @@ pub fn BytesView::compare(Self, Self) -> Int
 pub fn BytesView::data(Self) -> Bytes
 pub fn BytesView::equal(Self, Self) -> Bool
 pub fn BytesView::equal_to_bytes(Self, Bytes) -> Bool
+pub fn BytesView::escape_to(Self, &Logger) -> Unit
 pub fn BytesView::find(Self, Self) -> Int?
 pub fn BytesView::get(Self, Int) -> Byte?
 pub fn BytesView::get_view(Self, start? : Int, end? : Int) -> Self?

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -1170,7 +1170,6 @@ pub fn BytesView::compare(Self, Self) -> Int
 pub fn BytesView::data(Self) -> Bytes
 pub fn BytesView::equal(Self, Self) -> Bool
 pub fn BytesView::equal_to_bytes(Self, Bytes) -> Bool
-pub fn BytesView::escape_to(Self, &Logger) -> Unit
 pub fn BytesView::find(Self, Self) -> Int?
 pub fn BytesView::get(Self, Int) -> Byte?
 pub fn BytesView::get_view(Self, start? : Int, end? : Int) -> Self?

--- a/builtin/show.mbt
+++ b/builtin/show.mbt
@@ -191,9 +191,7 @@ fn StringView::escape_to(
       code =>
         if code < ' ' {
           flush_segment(seg, i)
-          logger.write_string("\\u{")
-          logger.write_string(code.to_byte().to_hex())
-          logger.write_char('}')
+          logger <+ "\\u{\{cb => cb.write_string(code.to_byte().to_hex())}}"
           continue i + 1, i + 1
         } else {
           continue i + 1, seg


### PR DESCRIPTION
Part of the `<+` template-writing simplification, split out of the closed
#4195 for reviewability.

- `BytesView` `Show` and `ToJson` now share one streaming `escape_to`
  helper, and `Show` renders through a `b"..."` `<+` template with the
  escaping delegated to the helper
- `Char` and `StringView` non-printable `\u{...}` writes collapse into
  single `<+` templates

Inline-writer holes use `\{cb => ...}` so delimiters stay paired and the
templates stay readable. Regenerated `builtin` interfaces include the new
`BytesView::escape_to`.

Verified: `moon check` 0 warnings/0 errors, builtin suite 2988/2988.

Generated with SeekMoon