### PR TITLE
refactor(builtin): `<+>`-simplify Iter and Map Show and small write sequences

### DIFF
--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -81,8 +81,7 @@ fn base64_encode(data : FixedArray[Byte]) -> String {
     let x1 = base64[(b0 & 0x03) << 4]
     buf.write_char(x0.to_char())
     buf.write_char(x1.to_char())
-    buf.write_char('=')
-    buf.write_char('=')
+    buf <+ "=="
   } else if rem == 2 {
     let b0 = data[len - 2].to_int()
     let b1 = data[len - 1].to_int()

--- a/builtin/fixedarray.mbt
+++ b/builtin/fixedarray.mbt
@@ -1397,8 +1397,7 @@ test "iter" {
   let exb = StringBuilder()
   let mut i = 0
   iter.each(x => {
-    exb.write_string(x.to_string())
-    exb.write_char('\n')
+    exb <+ "\{x}\n"
     i += 1
   })
   assert_true(i == arr.length())

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -63,15 +63,14 @@ pub impl[X : Show] Show for Iter[X]
 
 ///|
 pub impl[X : Show] Show for Iter[X] with fn output(self, logger) {
-  logger.write_string("[")
+  logger <+ "["
   if self.next() is Some(x) {
     logger.write_object(x)
     while self.next() is Some(x) {
-      logger.write_string(", ")
-      logger.write_object(x)
+      logger <+ ", \{cb => cb.write_object(x)}"
     }
   }
-  logger.write_string("]")
+  logger <+ "]"
 }
 
 ///|

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -669,17 +669,16 @@ pub impl[K : Show, V : Show] Show for Map[K, V]
 
 ///|
 pub impl[K : Show, V : Show] Show for Map[K, V] with fn output(self, logger) {
-  logger.write_string("{")
+  logger <+ "{"
   for x = 0, y = self.head {
     match (x, y) {
-      (_, None) => break logger.write_string("}")
+      (_, None) => break logger <+ "}"
       (i, Some({ key, value, next, .. })) => {
         if i > 0 {
-          logger.write_string(", ")
+          logger <+ ", "
         }
-        logger.write_object(key)
-        logger.write_string(": ")
-        logger.write_object(value)
+        logger <+
+          "\{cb => cb.write_object(key)}: \{cb => cb.write_object(value)}"
         continue i + 1, next
       }
     }


### PR DESCRIPTION
Part of the `<+` template-writing simplification, split out of the closed
#4195 for reviewability.

- `Show for Iter` and `Show for Map` write their delimiters/separators
  through `<+` templates with `\{cb => ...}` writer holes, keeping
  `write_object` dispatch monomorphic
- base64 `==` tail and a FixedArray iterator-test builder collapse into
  single `<+` writes

Verified: `moon check` 0 warnings/0 errors, builtin suite 2988/2988.

Generated with SeekMoon