### PR TITLE
refactor(json): template the ParseError/Json/JsonPath Show impls

### DIFF
--- a/json/json_path.mbt
+++ b/json/json_path.mbt
@@ -49,8 +49,8 @@ pub impl Show for JsonPath with fn output(self, logger) {
     }
     for ch in token.iter() {
       match ch {
-        '~' => logger.write_string("~0")
-        '/' => logger.write_string("~1")
+        '~' => logger <+ "~0"
+        '/' => logger <+ "~1"
         _ => logger.write_char(ch)
       }
     }
@@ -60,16 +60,12 @@ pub impl Show for JsonPath with fn output(self, logger) {
   fn build_path(path : JsonPath, logger : &Logger) -> Unit {
     match path {
       Root => ()
-      Key(parent, key~) => {
-        build_path(parent, logger)
-        logger.write_char('/')
-        write_token(logger, key)
-      }
-      Index(parent, index~) => {
-        build_path(parent, logger)
-        logger.write_char('/')
-        logger.write_object(index)
-      }
+      Key(parent, key~) =>
+        logger <+
+          "\{cb => build_path(parent, cb)}/\{cb => write_token(cb, key)}"
+      Index(parent, index~) =>
+        logger <+
+          "\{cb => build_path(parent, cb)}/\{cb => cb.write_object(index)}"
     }
   }
 

--- a/json/types.mbt
+++ b/json/types.mbt
@@ -35,7 +35,7 @@ pub impl Show for ParseError with fn output(self, logger) {
     InvalidChar({ line, column, }, c) =>
       logger <+
         $|Invalid character \{c.escape()} at line \{line}, column \{column}
-    InvalidEof => logger.write_string("Unexpected end of file")
+    InvalidEof => logger <+ "Unexpected end of file"
     InvalidNumber({ line, column, }, s) =>
       logger <+
         $|Invalid number \{s} at line \{line}, column \{column}
@@ -43,9 +43,8 @@ pub impl Show for ParseError with fn output(self, logger) {
       logger <+
         $|Invalid escape sequence in identifier at line \{line}, column \{column}
     DepthLimitExceeded =>
-      logger.write_string(
-        "Depth limit exceeded, please increase the max_nesting_depth parameter",
-      )
+      logger <+
+        $|Depth limit exceeded, please increase the max_nesting_depth parameter
   }
 }
 
@@ -57,34 +56,22 @@ pub impl Show for Json
 #warnings("-deprecated")
 pub impl Show for Json with fn output(self, logger) {
   match self {
-    Null => logger.write_string("Null")
-    True => logger.write_string("True")
-    False => logger.write_string("False")
+    Null => logger <+ "Null"
+    True => logger <+ "True"
+    False => logger <+ "False"
     Number(n, repr~) => {
-      logger.write_string("Number(")
-      Show::output(n, logger)
-      if repr is Some(repr) {
-        logger.write_string(", repr=")
-        logger.write_string("Some(")
-        Show::output(repr, logger)
-        logger.write_string(")")
+      fn write_contents(cb : &Logger) -> Unit {
+        Show::output(n, cb)
+        if repr is Some(repr) {
+          cb.write_string(", repr=Some(")
+          Show::output(repr, cb)
+          cb.write_string(")")
+        }
       }
-      logger.write_string(")")
+      logger <+ "Number(\{cb => write_contents(cb)})"
     }
-    String(s) => {
-      logger.write_string("String(")
-      Show::output(s, logger)
-      logger.write_string(")")
-    }
-    Array(a) => {
-      logger.write_string("Array(")
-      Show::output(a, logger)
-      logger.write_string(")")
-    }
-    Object(o) => {
-      logger.write_string("Object(")
-      Show::output(o, logger)
-      logger.write_string(")")
-    }
+    String(s) => logger <+ "String(\{cb => Show::output(s, cb)})"
+    Array(a) => logger <+ "Array(\{cb => Show::output(a, cb)})"
+    Object(o) => logger <+ "Object(\{cb => Show::output(o, cb)})"
   }
 }


### PR DESCRIPTION
Part of the `<+>` template-writing simplification, split out of the closed
#4195 for reviewability.

- `ParseError` variants and the deprecated `Json` `Show` render through
  `<+>` templates; the conditional `Number(...)` arm delegates to a local
  writer function so its delimiters stay paired in one template
- `JsonPath` JSON Pointer rendering streams each path step through a
  template with `\{cb => ...}` writer holes (recursion and token escaping
  delegated to local writer functions)

Inline-writer holes use `\{cb => ...}` so delimiters stay paired and the
templates stay readable. Output is unchanged.

Verified: `moon check` 0 warnings/0 errors, json suite 219/219.

Generated with SeekMoon