### PR TITLE
refactor(hashmap, set): remove the deprecated Show impls

### DIFF
--- a/hashmap/extends.mbt
+++ b/hashmap/extends.mbt
@@ -40,11 +40,6 @@ pub extend HashMap with Default::{default}
 pub extend HashMap with Eq::{not_equal}
 
 ///|
-#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
-#doc(hidden)
-pub extend HashMap with Show::{output, to_string}
-
-///|
 #deprecated("Use `@json.to_json` instead", skip_current_package=true)
 #doc(hidden)
 pub extend HashMap with ToJson::{to_json}

--- a/hashmap/hashmap_coverage_test.mbt
+++ b/hashmap/hashmap_coverage_test.mbt
@@ -130,25 +130,3 @@ test "get_from_bytes and get_from_string miss after probing" {
     @debug.assert_eq(str_map.get_from_string("missing\{i}"), None)
   }
 }
-
-///|
-/// Render a hashmap through its (deprecated) `Show` instance.
-#warnings("-deprecated")
-fn show_map(m : @hashmap.HashMap[Int, Int]) -> String {
-  m.to_string()
-}
-
-///|
-test "Show renders a hashmap as a from_array expression" {
-  let m : @hashmap.HashMap[Int, Int] = HashMap([])
-  m.set(1, 10)
-  m.set(2, 20)
-  let shown = show_map(m)
-  assert_true(shown.has_prefix("HashMap::from_array(["))
-  assert_true(shown.has_suffix("])"))
-  // two entries are separated by a comma
-  assert_true(shown.contains(", "))
-  // an empty map still renders the wrapper
-  let e : @hashmap.HashMap[Int, Int] = HashMap([])
-  inspect(show_map(e), content="HashMap::from_array([])")
-}

--- a/hashmap/pkg.generated.mbti
+++ b/hashmap/pkg.generated.mbti
@@ -61,8 +61,6 @@ pub fn[K : Hash + Eq, V] HashMap::update_or_default(Self[K, V], K, V, (V) -> V) 
 pub fn[K, V] HashMap::values(Self[K, V]) -> Iter[V]
 pub impl[K, V] Default for HashMap[K, V]
 pub impl[K : Hash + Eq, V : Eq] Eq for HashMap[K, V]
-#deprecated
-pub impl[K : Show, V : Show] Show for HashMap[K, V]
 pub impl[K : Show, V : ToJson] ToJson for HashMap[K, V]
 pub impl[K : @debug.Debug, V : @debug.Debug] @debug.Debug for HashMap[K, V]
 pub impl[V : @json.FromJson] @json.FromJson for HashMap[String, V]

--- a/hashmap/utils.mbt
+++ b/hashmap/utils.mbt
@@ -324,34 +324,6 @@ pub fn[K, V] HashMap::eachi(
 }
 
 ///|
-/// Provides string representation for hash maps.
-/// 
-/// Notice that the order of key-value pairs in the output string is not guaranteed
-///
-/// Parameters:
-///
-/// * `self` : The hash map to be converted to string.
-/// * `logger` : The buffer to write the string representation to.
-#deprecated("Use @debug.Debug instead of Show for debugging purposes. See https://github.com/moonbitlang/core/blob/main/debug/README.mbt.md")
-pub impl[K : Show, V : Show] Show for HashMap[K, V]
-
-///|
-pub impl[K : Show, V : Show] Show for HashMap[K, V] with fn output(self, logger) {
-  logger.write_string("HashMap::from_array([")
-  self.eachi((i, k, v) => {
-    if i > 0 {
-      logger.write_string(", ")
-    }
-    logger.write_string("(")
-    logger.write_object(k)
-    logger.write_string(", ")
-    logger.write_object(v)
-    logger.write_string(")")
-  })
-  logger.write_string("])")
-}
-
-///|
 /// Returns an iterator over all keys in the hash map.
 ///
 /// Parameters:

--- a/set/extends.mbt
+++ b/set/extends.mbt
@@ -47,11 +47,6 @@ pub extend Set with Default::{default}
 pub extend Set with Eq::{not_equal}
 
 ///|
-#deprecated("Use `@debug.Debug` instead of `Show` for collections", skip_current_package=true)
-#doc(hidden)
-pub extend Set with Show::{output, to_string}
-
-///|
 #deprecated("Use `@json.to_json` instead", skip_current_package=true)
 #doc(hidden)
 pub extend Set with ToJson::{to_json}

--- a/set/linked_hash_set.mbt
+++ b/set/linked_hash_set.mbt
@@ -463,27 +463,6 @@ fn[K] Set::rehash_place_entry(self : Set[K], outer : Entry[K]) -> Unit {
 // Utils
 
 ///|
-#deprecated("Use @debug.Debug instead of Show for debugging purposes. See https://github.com/moonbitlang/core/blob/main/debug/README.mbt.md")
-pub impl[K : Show] Show for Set[K]
-
-///|
-pub impl[K : Show] Show for Set[K] with fn output(self, logger) {
-  logger.write_string("{")
-  for i = 0, curr = self.head {
-    match (i, curr) {
-      (_, None) => break logger.write_string("}")
-      (i, Some({ key, next, .. })) => {
-        if i > 0 {
-          logger.write_string(", ")
-        }
-        logger.write_object(key)
-        continue i + 1, next
-      }
-    }
-  }
-}
-
-///|
 /// Get the number of keys in the set.
 #alias(size, deprecated)
 pub fn[K] Set::length(self : Set[K]) -> Int {

--- a/set/pkg.generated.mbti
+++ b/set/pkg.generated.mbti
@@ -58,8 +58,6 @@ pub impl[K : Hash + Eq] BitOr for Set[K]
 pub impl[K : Hash + Eq] BitXOr for Set[K]
 pub impl[K] Default for Set[K]
 pub impl[K : Hash + Eq] Eq for Set[K]
-#deprecated
-pub impl[K : Show] Show for Set[K]
 pub impl[K : Hash + Eq] Sub for Set[K]
 pub impl[X : ToJson] ToJson for Set[X]
 pub impl[K : @debug.Debug] @debug.Debug for Set[K]


### PR DESCRIPTION
Removes the deprecated `Show` impls for `HashMap` and linked-hash `Set`
(both were `#deprecated` in favor of `@debug.Debug`), together with their
hidden `Show::{output, to_string}` extends and the hashmap test that only
exercised the deprecated `Show` rendering. Nothing in the tree renders
these collections through `Show` anymore, so the impls are simply gone
(-85 lines).

Rewritten from the earlier `<+>`-refactor version of this PR after review
feedback: polishing deprecated impls is wasted effort, removing them is
cleaner.

Verified: `moon check` 0 warnings/0 errors; hashmap 139/139, set 70/70.

Generated with SeekMoon