### PR TITLE
refactor(diff, v128): stream Show output through `<+>` and writer helpers

### DIFF
--- a/diff/hunk.mbt
+++ b/diff/hunk.mbt
@@ -26,8 +26,7 @@ impl Show for Range with fn output(self, logger) {
       // empty ranges begin at line just before the range
       beginning -= 1
     }
-    logger <+
-      "\{cb => cb.write_object(beginning)},\{cb => cb.write_object(len)}"
+    logger <+ "\{beginning},\{len}"
   }
 }
 

--- a/diff/hunk.mbt
+++ b/diff/hunk.mbt
@@ -20,15 +20,14 @@ impl Show for Range with fn output(self, logger) {
   let mut beginning = self.0 + 1 // from array index to line number
   let len = self.1 - self.0
   if len == 1 {
-    logger.write_string(beginning.to_string())
+    logger.write_object(beginning)
   } else {
     if len == 0 {
       // empty ranges begin at line just before the range
       beginning -= 1
     }
-    logger.write_string(beginning.to_string())
-    logger.write_char(',')
-    logger.write_string(len.to_string())
+    logger <+
+      "\{cb => cb.write_object(beginning)},\{cb => cb.write_object(len)}"
   }
 }
 
@@ -67,7 +66,7 @@ fn HunkHeader::new(edits : ArrayView[Edit]) -> Self {
 
 ///|
 impl Show for HunkHeader with fn output(self, logger) {
-  logger.write_string("@@ -\{self.0} +\{self.1} @@")
+  logger <+ "@@ -\{self.0} +\{self.1} @@"
 }
 
 ///|

--- a/v128/simd_basic.mbt
+++ b/v128/simd_basic.mbt
@@ -29,14 +29,19 @@ pub impl Eq for V128 with fn not_equal(self : V128, other : V128) -> Bool {
 }
 
 ///|
-fn u64_hex(value : UInt64) -> String {
+fn u64_hex_to(logger : &Logger, value : UInt64) -> Unit {
   let digits = value.to_string(radix=16)
-  let buf = StringBuilder()
-  buf.write_string("0x")
+  logger <+ "0x"
   for _ in digits.length()..<16 {
-    buf.write_char('0')
+    logger.write_char('0')
   }
-  buf.write_string(digits)
+  logger.write_string(digits)
+}
+
+///|
+fn u64_hex(value : UInt64) -> String {
+  let buf = StringBuilder()
+  u64_hex_to(buf, value)
   buf.to_string()
 }
 
@@ -46,11 +51,8 @@ fn u64_hex(value : UInt64) -> String {
 #internal(experimental, "subject to breaking change without notice")
 #doc(hidden)
 pub impl Show for V128 with fn output(self : V128, logger) {
-  logger.write_string("V128(")
-  logger.write_string(u64_hex(lo(self)))
-  logger.write_string(", ")
-  logger.write_string(u64_hex(hi(self)))
-  logger.write_string(")")
+  logger <+
+    "V128(\{cb => u64_hex_to(cb, lo(self))}, \{cb => u64_hex_to(cb, hi(self))})"
 }
 
 ///|


### PR DESCRIPTION
Part of the `<+>` template-writing simplification, split out of the closed
#4195 for reviewability.

- `Range`/`HunkHeader` `Show` write through `<+>` templates; a lone range
  is written via `write_object`
- `V128` hex formatting streams through a new `u64_hex_to` writer helper
  (the string `u64_hex` wrapper is kept for the Debug impl), and `Show`
  renders `V128(...)` through a `<+>` template with `\{cb => ...}` holes

Output is unchanged.

Verified: `moon check` 0 warnings/0 errors; diff 127/127, v128 50/50.

Generated with SeekMoon