### PR TITLE
perf(bigint): add recursive division and decimal conversion

### DIFF
--- a/bigint/bigint_wide.mbt
+++ b/bigint/bigint_wide.mbt
@@ -345,11 +345,9 @@ fn BigInt::div_mod(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   if cmp == 0 {
     return (one.with_sign(q_sign), zero)
   }
-  let (q, r) = if other.len == 1 {
-    self.div_mod_single_limb(other.limbs.unsafe_get(0))
-  } else {
-    self.knuth_div(other)
-  }
+  let a = { ..self, sign: Positive, }
+  let b = { ..other, sign: Positive, }
+  let (q, r) = a.div_mod_mag(b)
   (q.with_sign(q_sign), r.with_sign(self.sign))
 }
 
@@ -558,36 +556,10 @@ const DECIMAL_CHUNK_DIGITS = 19
 let decimal_chunk_reciprocal : UInt64 = reciprocal_word(DECIMAL_CHUNK)
 
 ///|
-/// Decimal rendering by repeated division by 10^19, so each division peels off
-/// 19 digits at a time.
+/// Decimal rendering uses recursively tabulated powers of ten for large values
+/// and repeated division by 10^19 only at the leaves.
 fn BigInt::to_string_dec(self : BigInt) -> String {
-  if self.is_zero() {
-    return "0"
-  }
-  let n = self.len
-  let work = make(n)
-  work.unsafe_blit(0, self.limbs, 0, n)
-  let mut len = n
-  let chunks = []
-  while len > 1 || work.unsafe_get(0) != 0 {
-    chunks.push(
-      div_w(work, work, len, DECIMAL_CHUNK, decimal_chunk_reciprocal, 0),
-    )
-    len = normalize_len(work, len)
-  }
-  let buf = StringBuilder()
-  if self.sign == Negative {
-    buf.write_char('-')
-  }
-  buf.write_string(chunks[chunks.length() - 1].to_string())
-  for i = chunks.length() - 2; i >= 0; i = i - 1 {
-    let s = chunks[i].to_string()
-    for _ in 0..<(DECIMAL_CHUNK_DIGITS - s.length()) {
-      buf.write_char('0')
-    }
-    buf.write_string(s)
-  }
-  buf.to_string()
+  format_decimal(self)
 }
 
 ///|

--- a/bigint/bigint_wide_wbtest.mbt
+++ b/bigint/bigint_wide_wbtest.mbt
@@ -184,6 +184,21 @@ test "BigInt::bit_length" {
 }
 
 ///|
+test "recursive division dispatch accounts for quotient width" {
+  @debug.debug_inspect(
+    [
+      use_recursive_division(64, 64),
+      use_recursive_division(65, 64),
+      use_recursive_division(66, 64),
+      use_recursive_division(128, 63),
+      use_recursive_division(129, 128),
+      use_recursive_division(130, 128),
+    ],
+    content="[false, false, true, false, false, true]",
+  )
+}
+
+///|
 test "decimal sizing avoids Int overflow" {
   let cases : Array[Int64] = [
     0L, 1L, 4095L, 4096L, 1740261L, 1740262L, 2147483647L, 2147483648L, 2147483649L,

--- a/bigint/bigint_wide_wbtest.mbt
+++ b/bigint/bigint_wide_wbtest.mbt
@@ -185,14 +185,30 @@ test "BigInt::bit_length" {
 
 ///|
 test "decimal sizing avoids Int overflow" {
-  let cases : Array[Int] = [0, 1, 4095, 4096, 1740261, 1740262, 2147483647]
+  let cases : Array[Int64] = [
+    0L, 1L, 4095L, 4096L, 1740261L, 1740262L, 2147483647L, 2147483648L, 2147483649L,
+  ]
   for bits in cases {
-    let wide = bits.to_int64()
-    let expected_hint = (wide * 1234L / 4096L + 1L).to_int()
-    let expected_half = ((wide + 1L) / 2L).to_int()
+    let expected_hint = bits * 1234L / 4096L + 1L
+    let expected_half = (bits + 1L) / 2L
     @test.assert_eq(decimal_digit_hint(bits), expected_hint)
     @test.assert_eq(decimal_half_bits(bits), expected_half)
   }
+}
+
+///|
+test "decimal bit length avoids Int overflow" {
+  @test.assert_eq(decimal_bit_length_from_parts(0, 0UL), 0L)
+  @test.assert_eq(decimal_bit_length_from_parts(1, 1UL), 1L)
+  @test.assert_eq(
+    decimal_bit_length_from_parts(33554432, 0x4000000000000000UL),
+    2147483647L,
+  )
+  @test.assert_eq(
+    decimal_bit_length_from_parts(33554432, 0x8000000000000000UL),
+    2147483648L,
+  )
+  @test.assert_eq(decimal_bit_length_from_parts(33554433, 1UL), 2147483649L)
 }
 
 ///|

--- a/bigint/bigint_wide_wbtest.mbt
+++ b/bigint/bigint_wide_wbtest.mbt
@@ -184,6 +184,15 @@ test "BigInt::bit_length" {
 }
 
 ///|
+test "decimal digit hint avoids Int overflow" {
+  let cases : Array[Int] = [0, 1, 4095, 4096, 1740261, 1740262, 2147483647]
+  for bits in cases {
+    let expected = (bits.to_int64() * 1234L / 4096L + 1L).to_int()
+    @test.assert_eq(decimal_digit_hint(bits), expected)
+  }
+}
+
+///|
 test "BigInt::ctz" {
   inspect(0N.ctz(), content="0")
   inspect(1N.ctz(), content="0")

--- a/bigint/bigint_wide_wbtest.mbt
+++ b/bigint/bigint_wide_wbtest.mbt
@@ -184,11 +184,14 @@ test "BigInt::bit_length" {
 }
 
 ///|
-test "decimal digit hint avoids Int overflow" {
+test "decimal sizing avoids Int overflow" {
   let cases : Array[Int] = [0, 1, 4095, 4096, 1740261, 1740262, 2147483647]
   for bits in cases {
-    let expected = (bits.to_int64() * 1234L / 4096L + 1L).to_int()
-    @test.assert_eq(decimal_digit_hint(bits), expected)
+    let wide = bits.to_int64()
+    let expected_hint = (wide * 1234L / 4096L + 1L).to_int()
+    let expected_half = ((wide + 1L) / 2L).to_int()
+    @test.assert_eq(decimal_digit_hint(bits), expected_hint)
+    @test.assert_eq(decimal_half_bits(bits), expected_half)
   }
 }
 

--- a/bigint/decimal_wide.mbt
+++ b/bigint/decimal_wide.mbt
@@ -15,8 +15,8 @@
 // Divide-and-conquer decimal conversion for native/wasm BigInts.
 
 ///|
-/// Stored inline in the divisor table to avoid a heap object per entry.
-#valtype
+/// Kept boxed because `BigInt` is already a value type and stable native
+/// backends cannot yet flatten nested value types.
 priv struct DecimalDivisor {
   value : BigInt
   digits : Int

--- a/bigint/decimal_wide.mbt
+++ b/bigint/decimal_wide.mbt
@@ -31,17 +31,39 @@ const DECIMAL_LEAF_CHUNKS = 16
 const DECIMAL_RECURSIVE_THRESHOLD = 32
 
 ///|
-/// A slight upper bound for the decimal digits in a nonzero value with `bits`
-/// significant bits. Splitting quotient and remainder keeps both products in
-/// range even when `bits * 1234` would overflow `Int`.
-fn decimal_digit_hint(bits : Int) -> Int {
-  bits / 4096 * 1234 + bits % 4096 * 1234 / 4096 + 1
+/// Bit length of a normalized magnitude represented by `limbs` limbs and its
+/// most significant limb. This stays wide enough even when the result exceeds
+/// `Int::max_value`.
+fn decimal_bit_length_from_parts(limbs : Int, top_limb : UInt64) -> Int64 {
+  if limbs == 0 {
+    return 0L
+  }
+  limbs.to_int64() * 64L - nlz(top_limb).to_int64()
 }
 
 ///|
-/// Ceiling division by two without overflowing at `Int::max_value`.
-fn decimal_half_bits(bits : Int) -> Int {
-  bits / 2 + bits % 2
+fn decimal_bit_length(value : BigInt) -> Int64 {
+  if value.is_zero() {
+    return 0L
+  }
+  decimal_bit_length_from_parts(
+    value.len,
+    value.limbs.unsafe_get(value.len - 1),
+  )
+}
+
+///|
+/// A slight upper bound for the decimal digits in a nonzero value with `bits`
+/// significant bits. All arithmetic remains wide because a native/wasm BigInt
+/// can have more than `Int::max_value` significant bits.
+fn decimal_digit_hint(bits : Int64) -> Int64 {
+  bits / 4096L * 1234L + bits % 4096L * 1234L / 4096L + 1L
+}
+
+///|
+/// Ceiling division by two without overflowing.
+fn decimal_half_bits(bits : Int64) -> Int64 {
+  bits / 2L + bits % 2L
 }
 
 ///|
@@ -50,9 +72,12 @@ fn format_decimal(value : BigInt) -> String {
     return "0"
   }
   let magnitude = { ..value, sign: Positive, }
-  let digit_hint = decimal_digit_hint(magnitude.bit_length())
+  let digit_hint = decimal_digit_hint(decimal_bit_length(magnitude)) +
+    (if value.sign == Negative { 1L } else { 0L })
   let builder = StringBuilder(
-    size_hint=digit_hint + (if value.sign == Negative { 1 } else { 0 }),
+    // An oversized result cannot be preallocated through the Int-sized API;
+    // let the builder grow instead of truncating the hint to a negative value.
+    size_hint=if digit_hint <= 2147483647L { digit_hint.to_int() } else { 0 },
   )
   if value.sign == Negative {
     builder.write_char('-')
@@ -77,10 +102,10 @@ fn decimal_divisor_table(value : BigInt) -> Array[DecimalDivisor] {
     divisor = divisor.mul_single_limb(DECIMAL_CHUNK)
   }
   let mut digits = DECIMAL_CHUNK_DIGITS * DECIMAL_LEAF_CHUNKS
-  let half_bits = decimal_half_bits(value.bit_length())
+  let half_bits = decimal_half_bits(decimal_bit_length(value))
   while true {
     table.push({ value: divisor, digits, })
-    if divisor.bit_length() >= half_bits {
+    if decimal_bit_length(divisor) >= half_bits {
       break
     }
     divisor = divisor * divisor

--- a/bigint/decimal_wide.mbt
+++ b/bigint/decimal_wide.mbt
@@ -31,13 +31,20 @@ const DECIMAL_LEAF_CHUNKS = 16
 const DECIMAL_RECURSIVE_THRESHOLD = 32
 
 ///|
+/// A slight upper bound for the decimal digits in a nonzero value with `bits`
+/// significant bits. Splitting quotient and remainder keeps both products in
+/// range even when `bits * 1234` would overflow `Int`.
+fn decimal_digit_hint(bits : Int) -> Int {
+  bits / 4096 * 1234 + bits % 4096 * 1234 / 4096 + 1
+}
+
+///|
 fn format_decimal(value : BigInt) -> String {
   if value.is_zero() {
     return "0"
   }
   let magnitude = { ..value, sign: Positive, }
-  // 1234/4096 is a slight upper bound for log10(2).
-  let digit_hint = magnitude.bit_length() * 1234 / 4096 + 1
+  let digit_hint = decimal_digit_hint(magnitude.bit_length())
   let builder = StringBuilder(
     size_hint=digit_hint + (if value.sign == Negative { 1 } else { 0 }),
   )

--- a/bigint/decimal_wide.mbt
+++ b/bigint/decimal_wide.mbt
@@ -1,0 +1,148 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Divide-and-conquer decimal conversion for native/wasm BigInts.
+
+///|
+/// Stored inline in the divisor table to avoid a heap object per entry.
+#valtype
+priv struct DecimalDivisor {
+  value : BigInt
+  digits : Int
+}
+
+///|
+/// A leaf contains at most this many base-10^19 chunks.
+const DECIMAL_LEAF_CHUNKS = 16
+
+///|
+/// Below this many binary limbs, tabulating divisors costs more than it saves.
+const DECIMAL_RECURSIVE_THRESHOLD = 32
+
+///|
+fn format_decimal(value : BigInt) -> String {
+  if value.is_zero() {
+    return "0"
+  }
+  let magnitude = { ..value, sign: Positive, }
+  // 1234/4096 is a slight upper bound for log10(2).
+  let digit_hint = magnitude.bit_length() * 1234 / 4096 + 1
+  let builder = StringBuilder(
+    size_hint=digit_hint + (if value.sign == Negative { 1 } else { 0 }),
+  )
+  if value.sign == Negative {
+    builder.write_char('-')
+  }
+  if magnitude.len < DECIMAL_RECURSIVE_THRESHOLD {
+    write_decimal_leaf(magnitude, 0, builder)
+  } else {
+    let table = decimal_divisor_table(magnitude)
+    write_decimal(magnitude, table, table.length() - 1, 0, builder)
+  }
+  builder.to_string()
+}
+
+///|
+/// Successive squares of 10^(19*DECIMAL_LEAF_CHUNKS), through the first power
+/// whose bit length reaches half the input's. The last entry is therefore a
+/// near-square-root split for the top-level conversion.
+fn decimal_divisor_table(value : BigInt) -> Array[DecimalDivisor] {
+  let table = []
+  let mut divisor = one
+  for _ in 0..<DECIMAL_LEAF_CHUNKS {
+    divisor = divisor.mul_single_limb(DECIMAL_CHUNK)
+  }
+  let mut digits = DECIMAL_CHUNK_DIGITS * DECIMAL_LEAF_CHUNKS
+  let half_bits = (value.bit_length() + 1) / 2
+  while true {
+    table.push({ value: divisor, digits, })
+    if divisor.bit_length() >= half_bits {
+      break
+    }
+    divisor = divisor * divisor
+    digits *= 2
+  }
+  table
+}
+
+///|
+/// Write `value`, padding it on the left to `width` digits when nonzero.
+fn write_decimal(
+  value : BigInt,
+  table : Array[DecimalDivisor],
+  max_index : Int,
+  width : Int,
+  builder : StringBuilder,
+) -> Unit {
+  let mut index = max_index
+  while index >= 0 && table[index].value.cmp_mag(value) > 0 {
+    index -= 1
+  }
+  if index < 0 {
+    write_decimal_leaf(value, width, builder)
+    return
+  }
+  let divisor = table[index]
+  let (quotient, remainder) = if value.cmp_mag(divisor.value) == 0 {
+    (one, zero)
+  } else {
+    value.div_mod_mag(divisor.value)
+  }
+  write_decimal(
+    quotient,
+    table,
+    index,
+    maximum_int(0, width - divisor.digits),
+    builder,
+  )
+  write_decimal(remainder, table, index - 1, divisor.digits, builder)
+}
+
+///|
+/// Convert a small block iteratively, padding lower recursive blocks exactly.
+fn write_decimal_leaf(
+  value : BigInt,
+  width : Int,
+  builder : StringBuilder,
+) -> Unit {
+  if value.is_zero() {
+    for _ in 0..<(if width == 0 { 1 } else { width }) {
+      builder.write_char('0')
+    }
+    return
+  }
+  let work = make(value.len)
+  work.unsafe_blit(0, value.limbs, 0, value.len)
+  let mut len = value.len
+  let chunks = []
+  while len > 1 || work.unsafe_get(0) != 0 {
+    chunks.push(
+      div_w(work, work, len, DECIMAL_CHUNK, decimal_chunk_reciprocal, 0),
+    )
+    len = normalize_len(work, len)
+  }
+  let head = chunks[chunks.length() - 1].to_string()
+  let digits = head.length() + (chunks.length() - 1) * DECIMAL_CHUNK_DIGITS
+  for _ in digits..<width {
+    builder.write_char('0')
+  }
+  builder.write_string(head)
+  for i = chunks.length() - 2; i >= 0; i = i - 1 {
+    let chunk = chunks[i].to_string()
+    for _ in chunk.length()..<DECIMAL_CHUNK_DIGITS {
+      builder.write_char('0')
+    }
+    builder.write_string(chunk)
+  }
+}

--- a/bigint/decimal_wide.mbt
+++ b/bigint/decimal_wide.mbt
@@ -39,6 +39,12 @@ fn decimal_digit_hint(bits : Int) -> Int {
 }
 
 ///|
+/// Ceiling division by two without overflowing at `Int::max_value`.
+fn decimal_half_bits(bits : Int) -> Int {
+  bits / 2 + bits % 2
+}
+
+///|
 fn format_decimal(value : BigInt) -> String {
   if value.is_zero() {
     return "0"
@@ -71,7 +77,7 @@ fn decimal_divisor_table(value : BigInt) -> Array[DecimalDivisor] {
     divisor = divisor.mul_single_limb(DECIMAL_CHUNK)
   }
   let mut digits = DECIMAL_CHUNK_DIGITS * DECIMAL_LEAF_CHUNKS
-  let half_bits = (value.bit_length() + 1) / 2
+  let half_bits = decimal_half_bits(value.bit_length())
   while true {
     table.push({ value: divisor, digits, })
     if divisor.bit_length() >= half_bits {

--- a/bigint/division_bench_test.mbt
+++ b/bigint/division_bench_test.mbt
@@ -41,6 +41,17 @@ fn make_balanced_division(digits : Int) -> (@bigint.BigInt, @bigint.BigInt) {
 }
 
 ///|
+/// Builds an unbalanced division with exact native/wasm 64-bit limb counts.
+fn make_unbalanced_division(
+  quotient_limbs : Int,
+  divisor_limbs : Int,
+) -> (@bigint.BigInt, @bigint.BigInt) {
+  let quotient = division_bench_dense(quotient_limbs * 8, 0x0f1e2d3c4b5a6978UL)
+  let divisor = division_bench_dense(divisor_limbs * 8, 0x8796a5b4c3d2e1f0UL)
+  (quotient * divisor + divisor - 1N, divisor)
+}
+
+///|
 test "bench BigInt balanced division n=4000 digits" (it : @bench.T) {
   let (dividend, divisor) = make_balanced_division(4000)
   it.bench(fn() { it.keep(dividend / divisor) })
@@ -55,5 +66,11 @@ test "bench BigInt balanced division n=40000 digits" (it : @bench.T) {
 ///|
 test "bench BigInt balanced division n=250000 digits" (it : @bench.T) {
   let (dividend, divisor) = make_balanced_division(250000)
+  it.bench(fn() { it.keep(dividend / divisor) })
+}
+
+///|
+test "bench BigInt unbalanced division q=65536 d=64 limbs" (it : @bench.T) {
+  let (dividend, divisor) = make_unbalanced_division(65536, 64)
   it.bench(fn() { it.keep(dividend / divisor) })
 }

--- a/bigint/division_bench_test.mbt
+++ b/bigint/division_bench_test.mbt
@@ -52,6 +52,17 @@ fn make_unbalanced_division(
 }
 
 ///|
+/// Builds the large-divisor, single-limb-quotient shape used by pidigits.
+fn make_narrow_division(
+  quotient : Int,
+  divisor_limbs : Int,
+) -> (@bigint.BigInt, @bigint.BigInt) {
+  let divisor = division_bench_dense(divisor_limbs * 8, 0x8796a5b4c3d2e1f0UL)
+  let quotient = @bigint.BigInt::from_int(quotient)
+  (quotient * divisor + divisor - 1N, divisor)
+}
+
+///|
 test "bench BigInt balanced division n=4000 digits" (it : @bench.T) {
   let (dividend, divisor) = make_balanced_division(4000)
   it.bench(fn() { it.keep(dividend / divisor) })
@@ -72,5 +83,11 @@ test "bench BigInt balanced division n=250000 digits" (it : @bench.T) {
 ///|
 test "bench BigInt unbalanced division q=65536 d=64 limbs" (it : @bench.T) {
   let (dividend, divisor) = make_unbalanced_division(65536, 64)
+  it.bench(fn() { it.keep(dividend / divisor) })
+}
+
+///|
+test "bench BigInt narrow division q=9 d=64 limbs" (it : @bench.T) {
+  let (dividend, divisor) = make_narrow_division(9, 64)
   it.bench(fn() { it.keep(dividend / divisor) })
 }

--- a/bigint/division_bench_test.mbt
+++ b/bigint/division_bench_test.mbt
@@ -1,0 +1,59 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn division_bench_mix64(input : UInt64) -> UInt64 {
+  let z = (input ^ (input >> 30)) * 0xbf58476d1ce4e5b9UL
+  let z = (z ^ (z >> 27)) * 0x94d049bb133111ebUL
+  z ^ (z >> 31)
+}
+
+///|
+fn division_bench_dense(bytes : Int, seed : UInt64) -> @bigint.BigInt {
+  @bigint.BigInt::from_octets(
+    Bytes::makei(bytes, i => {
+      let byte = (division_bench_mix64(seed + i.to_uint64()) & 0xffUL).to_int()
+      (if i == 0 { byte | 0x80 } else { byte }).to_byte()
+    }),
+  )
+}
+
+///|
+/// Builds a dense, balanced 2n-by-n division with roughly `digits` decimal
+/// digits in both the quotient and divisor.
+fn make_balanced_division(digits : Int) -> (@bigint.BigInt, @bigint.BigInt) {
+  // 3.322 is a slight upper bound for log2(10).
+  let bytes = (digits * 3322 / 1000 + 7) / 8
+  let quotient = division_bench_dense(bytes, 0x123456789abcdef0UL)
+  let divisor = division_bench_dense(bytes, 0xfedcba9876543210UL)
+  (quotient * divisor + divisor - 1N, divisor)
+}
+
+///|
+test "bench BigInt balanced division n=4000 digits" (it : @bench.T) {
+  let (dividend, divisor) = make_balanced_division(4000)
+  it.bench(fn() { it.keep(dividend / divisor) })
+}
+
+///|
+test "bench BigInt balanced division n=40000 digits" (it : @bench.T) {
+  let (dividend, divisor) = make_balanced_division(40000)
+  it.bench(fn() { it.keep(dividend / divisor) })
+}
+
+///|
+test "bench BigInt balanced division n=250000 digits" (it : @bench.T) {
+  let (dividend, divisor) = make_balanced_division(250000)
+  it.bench(fn() { it.keep(dividend / divisor) })
+}

--- a/bigint/division_wide.mbt
+++ b/bigint/division_wide.mbt
@@ -25,14 +25,23 @@
 const DIV_RECURSIVE_THRESHOLD = 64
 
 ///|
+/// Recursive division only pays off when both the divisor and quotient are
+/// wide. With at most two quotient-limb passes, Knuth D is linear in the large
+/// divisor and avoids recursive splitting, multiplication, and allocation.
+/// Requires `dividend_len >= divisor_len`.
+fn use_recursive_division(dividend_len : Int, divisor_len : Int) -> Bool {
+  divisor_len >= DIV_RECURSIVE_THRESHOLD && dividend_len - divisor_len > 1
+}
+
+///|
 /// Magnitude-only division. Both operands must be positive and `self > other`.
 fn BigInt::div_mod_mag(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
   if other.len == 1 {
     self.div_mod_single_limb(other.limbs.unsafe_get(0))
-  } else if other.len < DIV_RECURSIVE_THRESHOLD {
-    self.knuth_div(other)
-  } else {
+  } else if use_recursive_division(self.len, other.len) {
     self.div_mod_recursive(other)
+  } else {
+    self.knuth_div(other)
   }
 }
 
@@ -60,10 +69,10 @@ fn div_mod_normalized(u : BigInt, v : BigInt) -> (BigInt, BigInt) {
   if v.len == 1 {
     return u.div_mod_single_limb(v.limbs.unsafe_get(0))
   }
-  if v.len < DIV_RECURSIVE_THRESHOLD {
-    return u.knuth_div(v)
+  if use_recursive_division(u.len, v.len) {
+    return div_mod_recursive_steps(u, v)
   }
-  div_mod_recursive_steps(u, v)
+  u.knuth_div(v)
 }
 
 ///|

--- a/bigint/division_wide.mbt
+++ b/bigint/division_wide.mbt
@@ -1,0 +1,186 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Recursive wide-digit division for large native/wasm BigInts.
+//
+// Knuth D produces one 64-bit quotient limb per O(n) multiply/subtract pass,
+// which is quadratic for balanced operands. Here a group of half the divisor's
+// limbs is treated as one wide digit. A recursive division estimates that wide
+// digit and Karatsuba multiplication refines it, making division inherit the
+// subquadratic multiplication complexity for large operands.
+
+///|
+/// Divisors below this size are faster with ordinary Knuth D.
+const DIV_RECURSIVE_THRESHOLD = 64
+
+///|
+/// Magnitude-only division. Both operands must be positive and `self > other`.
+fn BigInt::div_mod_mag(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
+  if other.len == 1 {
+    self.div_mod_single_limb(other.limbs.unsafe_get(0))
+  } else if other.len < DIV_RECURSIVE_THRESHOLD {
+    self.knuth_div(other)
+  } else {
+    self.div_mod_recursive(other)
+  }
+}
+
+///|
+/// Normalize once around the recursive division. Every recursive divisor is a
+/// high slice of this normalized divisor, so its top bit remains set.
+fn BigInt::div_mod_recursive(self : BigInt, other : BigInt) -> (BigInt, BigInt) {
+  let shift = nlz(other.limbs.unsafe_get(other.len - 1))
+  let u = if shift == 0 { self } else { self << shift }
+  let v = if shift == 0 { other } else { other << shift }
+  let (q, r) = div_mod_normalized(u, v)
+  (q, if shift == 0 { r } else { r >> shift })
+}
+
+///|
+/// Divide positive magnitudes with a normalized divisor.
+fn div_mod_normalized(u : BigInt, v : BigInt) -> (BigInt, BigInt) {
+  let cmp = u.cmp_mag(v)
+  if cmp < 0 {
+    return (zero, u)
+  }
+  if cmp == 0 {
+    return (one, zero)
+  }
+  if v.len == 1 {
+    return u.div_mod_single_limb(v.limbs.unsafe_get(0))
+  }
+  if v.len < DIV_RECURSIVE_THRESHOLD {
+    return u.knuth_div(v)
+  }
+  div_mod_recursive_steps(u, v)
+}
+
+///|
+/// Long division in base 2^(64*block), where `block = floor(v.len/2)`.
+fn div_mod_recursive_steps(u : BigInt, v : BigInt) -> (BigInt, BigInt) {
+  let n = v.len
+  let block = n / 2
+  let m = u.len - n
+  let qlimbs = make(m + 1)
+  let mut work = u
+  let mut j = m
+  while j > block {
+    let offset = j - block
+    let window = work.high_mag(offset)
+    let (qhat, remainder) = div_recursive_step(window, v, block)
+    if !qhat.is_zero() {
+      add_at(qlimbs, m + 1, qhat.limbs, qhat.len, offset)
+    }
+    work = work.replace_high_mag(offset, remainder)
+    j -= block
+  }
+  let (qhat, remainder) = div_recursive_step(work, v, block)
+  if !qhat.is_zero() {
+    add_at(qlimbs, m + 1, qhat.limbs, qhat.len, 0)
+  }
+  (
+    { limbs: qlimbs, sign: Positive, len: normalize_len(qlimbs, m + 1), },
+    remainder,
+  )
+}
+
+///|
+/// Divide an at-most-three-wide-digit window by a two-wide-digit divisor.
+///
+/// Dropping `block - 1` low limbs gives a tightly bounded overestimate. The low
+/// halves refine it with one multiplication and, exceptionally, one or two
+/// add-back corrections.
+fn div_recursive_step(
+  window : BigInt,
+  divisor : BigInt,
+  block : Int,
+) -> (BigInt, BigInt) {
+  let split = block - 1
+  let high = window.high_mag(split)
+  let divisor_high = divisor.high_mag(split)
+  let (estimated, high_remainder) = div_mod_normalized(high, divisor_high)
+  let low = window.low_mag(split)
+  let divisor_low = divisor.low_mag(split)
+  let mut combined = join_mag(low, high_remainder, split)
+  let mut qhat = estimated
+  let mut product = qhat * divisor_low
+  let shifted_high = divisor_high.shl_mag_limbs(split)
+  let mut corrections = 0
+  while product.cmp_mag(combined) > 0 {
+    if corrections == 2 {
+      abort("internal recursive division error")
+    }
+    qhat = qhat.sub_mag(one)
+    product = product.sub_mag(divisor_low)
+    combined = combined.add_mag(shifted_high)
+    corrections += 1
+  }
+  (qhat, combined.sub_mag(product))
+}
+
+///|
+/// The low `count` limbs of a positive magnitude.
+fn BigInt::low_mag(self : BigInt, count : Int) -> BigInt {
+  slice_mag(self.limbs, 0, minimum_int(count, self.len))
+}
+
+///|
+/// The magnitude above the low `count` limbs.
+fn BigInt::high_mag(self : BigInt, count : Int) -> BigInt {
+  slice_mag(self.limbs, count, self.len - count)
+}
+
+///|
+/// Shift a positive magnitude by whole limbs without allocating a spare limb.
+fn BigInt::shl_mag_limbs(self : BigInt, count : Int) -> BigInt {
+  if self.is_zero() || count == 0 {
+    return self
+  }
+  let limbs = make(self.len + count)
+  limbs.unsafe_blit(count, self.limbs, 0, self.len)
+  { limbs, sign: Positive, len: self.len + count, }
+}
+
+///|
+/// Form `high * 2^(64*split) + low`; `low` must fit below `split`.
+fn join_mag(low : BigInt, high : BigInt, split : Int) -> BigInt {
+  let len = maximum_int(low.len, split + high.len)
+  let limbs = make(len)
+  if !low.is_zero() {
+    limbs.unsafe_blit(0, low.limbs, 0, low.len)
+  }
+  if !high.is_zero() {
+    limbs.unsafe_blit(split, high.limbs, 0, high.len)
+  }
+  { limbs, sign: Positive, len: normalize_len(limbs, len), }
+}
+
+///|
+/// Keep `self` below `offset` and replace its entire high part with `high`.
+fn BigInt::replace_high_mag(
+  self : BigInt,
+  offset : Int,
+  high : BigInt,
+) -> BigInt {
+  let low_len = minimum_int(offset, self.len)
+  let len = maximum_int(low_len, offset + high.len)
+  let limbs = make(len)
+  if low_len > 0 {
+    limbs.unsafe_blit(0, self.limbs, 0, low_len)
+  }
+  if !high.is_zero() {
+    limbs.unsafe_blit(offset, high.limbs, 0, high.len)
+  }
+  { limbs, sign: Positive, len: normalize_len(limbs, len), }
+}

--- a/bigint/division_wide.mbt
+++ b/bigint/division_wide.mbt
@@ -68,24 +68,36 @@ fn div_mod_normalized(u : BigInt, v : BigInt) -> (BigInt, BigInt) {
 
 ///|
 /// Long division in base 2^(64*block), where `block = floor(v.len/2)`.
+///
+/// `work` is cloned once and then updated in place. `work_end` excludes stale
+/// processed limbs, so each step copies only its at-most-three-digit window
+/// instead of rebuilding the entire unprocessed low prefix.
 fn div_mod_recursive_steps(u : BigInt, v : BigInt) -> (BigInt, BigInt) {
   let n = v.len
   let block = n / 2
   let m = u.len - n
   let qlimbs = make(m + 1)
-  let mut work = u
+  let work = make(u.len)
+  work.unsafe_blit(0, u.limbs, 0, u.len)
+  let mut work_end = u.len
   let mut j = m
   while j > block {
     let offset = j - block
-    let window = work.high_mag(offset)
+    let window = slice_mag(work, offset, work_end - offset)
     let (qhat, remainder) = div_recursive_step(window, v, block)
     if !qhat.is_zero() {
       add_at(qlimbs, m + 1, qhat.limbs, qhat.len, offset)
     }
-    work = work.replace_high_mag(offset, remainder)
+    if remainder.is_zero() {
+      work_end = offset
+    } else {
+      work.unsafe_blit(offset, remainder.limbs, 0, remainder.len)
+      work_end = offset + remainder.len
+    }
     j -= block
   }
-  let (qhat, remainder) = div_recursive_step(work, v, block)
+  let remaining = slice_mag(work, 0, work_end)
+  let (qhat, remainder) = div_recursive_step(remaining, v, block)
   if !qhat.is_zero() {
     add_at(qlimbs, m + 1, qhat.limbs, qhat.len, 0)
   }
@@ -162,25 +174,6 @@ fn join_mag(low : BigInt, high : BigInt, split : Int) -> BigInt {
   }
   if !high.is_zero() {
     limbs.unsafe_blit(split, high.limbs, 0, high.len)
-  }
-  { limbs, sign: Positive, len: normalize_len(limbs, len), }
-}
-
-///|
-/// Keep `self` below `offset` and replace its entire high part with `high`.
-fn BigInt::replace_high_mag(
-  self : BigInt,
-  offset : Int,
-  high : BigInt,
-) -> BigInt {
-  let low_len = minimum_int(offset, self.len)
-  let len = maximum_int(low_len, offset + high.len)
-  let limbs = make(len)
-  if low_len > 0 {
-    limbs.unsafe_blit(0, self.limbs, 0, low_len)
-  }
-  if !high.is_zero() {
-    limbs.unsafe_blit(offset, high.limbs, 0, high.len)
   }
   { limbs, sign: Positive, len: normalize_len(limbs, len), }
 }

--- a/bigint/moon.pkg
+++ b/bigint/moon.pkg
@@ -24,6 +24,8 @@ warnings = "-29"
 options(
   targets: {
     "arith_wide.mbt": [ "native", "wasm" ],
+    "division_wide.mbt": [ "native", "wasm" ],
+    "decimal_wide.mbt": [ "native", "wasm" ],
     "bigint_js.mbt": [ "js" ],
     "bigint_js_wbtest.mbt": [ "js" ],
     "bigint_default.mbt": [ "not", "js", "wasm", "native" ],

--- a/bigint/quickcheck_deep_test.mbt
+++ b/bigint/quickcheck_deep_test.mbt
@@ -231,6 +231,21 @@ test "recursive division across threshold and block boundaries" {
 }
 
 ///|
+test "recursive division with highly unbalanced operands" {
+  // On native/wasm the divisor is exactly at the 64-limb recursive threshold
+  // while the quotient spans 64 recursive blocks. This exercises repeated
+  // in-place replacement of the bounded high window without copying the long
+  // unprocessed low prefix.
+  let divisor = mag_of_limbs(0x64d1a150UL, 128)
+  let quotient = mag_of_limbs(0x4000b10cUL, 4096)
+  for remainder in ([0N, 1N, divisor >> 1, divisor - 1N] : Array[_]) {
+    let dividend = quotient * divisor + remainder
+    assert_eq(dividend / divisor, quotient)
+    assert_eq(dividend % divisor, remainder)
+  }
+}
+
+///|
 test "division with adversarial divisor top limbs" {
   // Knuth 4.3.1 quotient-digit estimation is most fragile when the
   // normalized divisor's top limb is minimal (0x80000000) or maximal

--- a/bigint/quickcheck_deep_test.mbt
+++ b/bigint/quickcheck_deep_test.mbt
@@ -20,8 +20,8 @@
 // * multiplication straddling the Karatsuba threshold (50 limbs),
 //   cross-checked against products reassembled from sub-threshold chunks
 //   and against closed forms with maximal carry chains;
-// * Knuth division (TAOCP 4.3.1) with adversarial divisor top limbs,
-//   where quotient-digit estimation is famously fragile;
+// * Knuth and recursive wide-digit division with adversarial divisor top
+//   limbs, where quotient-digit estimation is famously fragile;
 // * shifts, radix round-trips, pow/modpow, octet round-trips, and
 //   fixed-width truncation, at sizes crossing many limb boundaries.
 //
@@ -176,8 +176,10 @@ test "quickcheck: truncated division law across mixed size classes" {
   @quickcheck.check(
     (input : (Int, Int, Int, Bool, Bool)) => {
       let (s, i, j, na, nb) = input
-      let la = 1 + (i & 63) // 1..64 limbs
-      let lb = 1 + (j & 63)
+      // `mag_of_limbs` counts 32-bit chunks. Extending through 256 chunks
+      // crosses the native/wasm recursive-division threshold at 128 chunks.
+      let la = 1 + (i & 255)
+      let lb = 1 + (j & 255)
       let seed = seed_u64(s) * 0xDEADBEEFUL + 12345UL
       let a0 = mag_of_limbs(seed, la)
       let b0 = mag_of_limbs(seed + 424242UL, lb)
@@ -199,6 +201,33 @@ test "quickcheck: truncated division law across mixed size classes" {
     },
     count=120,
   )
+}
+
+///|
+test "recursive division across threshold and block boundaries" {
+  // Exact bit lengths put divisors immediately below, at, and above the
+  // 64-limb native/wasm threshold, with both normalized and heavily shifted
+  // top limbs. Quotients range from a partial block through several blocks.
+  let sizes : Array[(Int, Int)] = [
+    (4032, 4109),
+    (4033, 8197),
+    (4096, 12293),
+    (4097, 8203),
+    (8192, 16391),
+    (8209, 24631),
+  ]
+  for size in sizes {
+    let (divisor_bits, quotient_bits) = size
+    let divisor = (1N << (divisor_bits - 1)) +
+      (1N << (divisor_bits / 2)) +
+      0xfedcba987654321N
+    let quotient = (1N << quotient_bits) - 1N
+    for remainder in ([0N, 1N, divisor >> 1, divisor - 1N] : Array[_]) {
+      let dividend = quotient * divisor + remainder
+      assert_eq(dividend / divisor, quotient)
+      assert_eq(dividend % divisor, remainder)
+    }
+  }
 }
 
 ///|
@@ -338,6 +367,36 @@ test "huge decimal roundtrip anchored to a hex literal" {
   let big = mag_of_limbs(0xC0FFEEUL, 500)
   assert_eq(@bigint.BigInt::from_string(big.to_string()), big)
   assert_eq(@bigint.BigInt::from_string((-big).to_string()), -big)
+}
+
+///|
+test "recursive decimal conversion at power-table boundaries" {
+  // The conversion table starts at 10^(19*16) and squares from there. Values
+  // around twice and four times that exponent exercise exact divisors and the
+  // zero padding on either side of every recursive split.
+  for digits in ([607, 608, 609, 1215, 1216, 1217, 2432] : Array[_]) {
+    let power = 10N.pow(@bigint.BigInt::from_int(digits))
+    let exact = StringBuilder(size_hint=digits + 1)
+    exact.write_char('1')
+    for _ in 0..<digits {
+      exact.write_char('0')
+    }
+    assert_eq(power.to_string(), exact.to_string())
+
+    let below = StringBuilder(size_hint=digits)
+    for _ in 0..<digits {
+      below.write_char('9')
+    }
+    assert_eq((power - 1N).to_string(), below.to_string())
+
+    let above = StringBuilder(size_hint=digits + 1)
+    above.write_char('1')
+    for _ in 1..<digits {
+      above.write_char('0')
+    }
+    above.write_char('1')
+    assert_eq((power + 1N).to_string(), above.to_string())
+  }
 }
 
 ///|

--- a/bigint/quickcheck_deep_test.mbt
+++ b/bigint/quickcheck_deep_test.mbt
@@ -246,6 +246,29 @@ test "recursive division with highly unbalanced operands" {
 }
 
 ///|
+test "large divisors with narrow quotients" {
+  // On native/wasm these sizes straddle and exceed the 64-limb recursive
+  // divisor threshold. Their single-limb quotients must stay on Knuth D.
+  let divisor_sizes : Array[Int] = [126, 128, 130, 256]
+  let quotients : Array[@bigint.BigInt] = [
+    2N,
+    9N,
+    (1N << 63) - 1N,
+    (1N << 64) - 1N,
+  ]
+  for size in divisor_sizes {
+    let divisor = mag_of_limbs(seed_u64(size) + 0x51a11UL, size)
+    for quotient in quotients {
+      for remainder in ([0N, 1N, divisor >> 1, divisor - 1N] : Array[_]) {
+        let dividend = quotient * divisor + remainder
+        assert_eq(dividend / divisor, quotient)
+        assert_eq(dividend % divisor, remainder)
+      }
+    }
+  }
+}
+
+///|
 test "division with adversarial divisor top limbs" {
   // Knuth 4.3.1 quotient-digit estimation is most fragile when the
   // normalized divisor's top limb is minimal (0x80000000) or maximal

--- a/bigint/to_string_bench_test.mbt
+++ b/bigint/to_string_bench_test.mbt
@@ -43,3 +43,15 @@ test "bench BigInt::to_string n=4000 digits" (it : @bench.T) {
   let n = make_decimal(4000)
   it.bench(fn() { it.keep(n.to_string()) })
 }
+
+///|
+test "bench BigInt::to_string n=40000 digits" (it : @bench.T) {
+  let n = make_decimal(40000)
+  it.bench(fn() { it.keep(n.to_string()) })
+}
+
+///|
+test "bench BigInt::to_string n=250000 digits" (it : @bench.T) {
+  let n = make_decimal(250000)
+  it.bench(fn() { it.keep(n.to_string()) })
+}


### PR DESCRIPTION
## Summary

- use recursive wide-digit division for native/wasm BigInts only when the divisor is at least 64 limbs and the quotient needs more than two Knuth passes, retaining single-limb and Knuth division for smaller or narrow-quotient operands
- render large decimal values with recursively squared powers of ten, using iterative division by 10^19 only at the leaves
- keep recursive division's work in one mutable limb buffer so highly unbalanced operands copy only bounded high windows
- compute decimal sizing and split thresholds without `Int` overflow, and retain boxed decimal-divisor records for stable native-backend compatibility
- add threshold, boundary, round-trip, unbalanced-operand, and benchmark coverage

There are no public API changes.

## Performance

Native release benchmarks at 250,000 digits:

| operation | previous path | recursive path | speedup |
| --- | ---: | ---: | ---: |
| balanced division | 237.09 ms | 27.16 ms | 8.7x |
| decimal conversion | 362.88 ms | 21.44 ms | 16.9x |

The added 65,536-by-64-limb unbalanced benchmark improves from 29.83 ms with whole-prefix rebuilding to 5.35 ms with the mutable work buffer (5.6x). Its scaling is now linear in the number of quotient blocks rather than quadratic copying of the dividend prefix.

The quotient-width guard restores pidigits at 8,000 digits from 1,237.4 ± 0.8 ms to 795.2 ± 1.9 ms, matching the 795.4 ± 1.0 ms pre-feature baseline. The added 9-by-64-limb narrow-quotient benchmark improves from 489.8 ns on recursive division to 334.6 ns on Knuth D, while balanced and very-wide-quotient results remain unchanged.

The 250,001-digit edigits result was also compared byte-for-byte with Go; both produced SHA-256 `2e66b93581445e19afc0d73ca280ba6c68b3637c81b27283acb0da8715b65582`.

## Validation

- `moon check --deny-warn --target all --warn-list +73`
- `moon test bigint --target all` (wasm 165/165, wasm-gc 192/192, JS 166/166, native 165/165)
- `moon test --target native` (7,420/7,420)
- `moon info --target wasm,wasm-gc,js,native` (no `.mbti` changes)
- `moon fmt`
