### PR TITLE
feat(quickcheck): improve BigInt generation

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -240,7 +240,7 @@ test "builtin types" {
       #|  8766027650639656979,
       #|  0.23986786603927612,
       #|  0.7917029935679342,
-      #|  0,
+      #|  -2,
       #|)
     ),
   )
@@ -262,11 +262,16 @@ full-width random bit patterns, common small values, values next to powers of
 two and ten, and type extrema. This keeps the entire scalar domain reachable
 while regularly exercising overflow, bit-width, and formatting boundaries.
 `Byte` remains uniformly distributed across all 256 bit patterns so `Bytes`
-and other byte-oriented workloads retain broad payload coverage. Fixed-width
-integer shrinkers try a midpoint first, then progressively finer candidates
-approaching the original value, with zero as the final fallback. With the
-greedy shrink driver, large failures still converge without linearly walking
-the numeric range while avoiding a likely rejected zero at every level.
+and other byte-oriented workloads retain broad payload coverage. `BigInt`
+uses a separate portfolio: 35% arbitrary bit patterns, 25% canonical small
+values, 25% neighbors of common powers of two, and 15% neighbors of common
+powers of ten. Its random branch grows with the size hint up to 32 64-bit
+chunks, while boundary branches regularly cover important widths regardless
+of size. Fixed-width integer shrinkers try a midpoint first, then progressively
+finer candidates approaching the original value, with zero as the final
+fallback. With the greedy shrink driver, large failures still converge without
+linearly walking the numeric range while avoiding a likely rejected zero at
+every level.
 
 ## Custom Types
 

--- a/quickcheck/arbitrary.mbt
+++ b/quickcheck/arbitrary.mbt
@@ -153,15 +153,6 @@ pub impl[X : Arbitrary] Arbitrary for Array[X] with fn arbitrary(size, rs) {
 }
 
 ///|
-pub impl Arbitrary for @bigint.BigInt with fn arbitrary(size, rs) {
-  if size == 0 {
-    0
-  } else {
-    rs.next_int64() |> @bigint.BigInt::from_int64
-  }
-}
-
-///|
 pub impl[X : Arbitrary] Arbitrary for @ref.Ref[X] with fn arbitrary(size, rs) {
   @ref.new(X::arbitrary(size, rs))
 }

--- a/quickcheck/arbitrary_bigint.mbt
+++ b/quickcheck/arbitrary_bigint.mbt
@@ -1,0 +1,78 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn[T] @splitmix.RandomState::pick(
+  self : @splitmix.RandomState,
+  values : ReadOnlyArray[T],
+) -> T {
+  let index = self.next_uint(limit=values.length().reinterpret_as_uint())
+  values[index.reinterpret_as_int()]
+}
+
+///|
+fn with_random_sign(
+  magnitude : @bigint.BigInt,
+  rs : @splitmix.RandomState,
+) -> @bigint.BigInt {
+  if magnitude.is_zero() || rs.next_uint(limit=2U) == 0U {
+    magnitude
+  } else {
+    -magnitude
+  }
+}
+
+///|
+fn around(base : @bigint.BigInt, rs : @splitmix.RandomState) -> @bigint.BigInt {
+  with_random_sign(base + rs.pick([-1N, 0N, 1N]), rs)
+}
+
+///|
+fn random_bigint(size : Int, rs : @splitmix.RandomState) -> @bigint.BigInt {
+  let chunk_limit = size.clamp(min=0, max=31) + 1
+  let chunk_count = for count in 1..<chunk_limit {
+    guard rs.next_uint(limit=2U) == 0U else { break count }
+  } nobreak {
+    chunk_limit
+  }
+  let bytes = Bytes::makei(chunk_count * 8, _ => {
+    rs.next_uint(limit=256U).to_byte()
+  })
+  with_random_sign(@bigint.BigInt::from_octets(bytes), rs)
+}
+
+///|
+/// 35% arbitrary multi-word bit patterns, 25% canonical small values,
+/// 25% values next to common powers of two, and 15% values next to common
+/// powers of ten. `size` caps the random branch at one to 32 64-bit words;
+/// boundary branches deliberately exercise important widths independently.
+pub impl Arbitrary for @bigint.BigInt with fn arbitrary(size, rs) {
+  match rs.next_uint(limit=100U) {
+    0..<35 => random_bigint(size, rs)
+    35..<60 => rs.pick([0N, 1N, -1N, 2N, -2N, 10N, -10N])
+    60..<85 =>
+      around(
+        1N <<
+        rs.pick([0, 1, 7, 8, 15, 16, 31, 32, 52, 53, 63, 64, 127, 128, 255, 256]),
+        rs,
+      )
+    _ => {
+      let exponent = rs.pick([1, 2, 3, 6, 9, 18, 19, 38, 76, 100])
+      around(
+        (0 : Int).until(exponent).fold(init=1N, (power, _) => power * 10N),
+        rs,
+      )
+    }
+  }
+}

--- a/quickcheck/arbitrary_type_test.mbt
+++ b/quickcheck/arbitrary_type_test.mbt
@@ -13,24 +13,62 @@
 // limitations under the License.
 
 ///|
+fn is_power_of_two_bigint(value : @bigint.BigInt) -> Bool {
+  value > 0N && (value & (value - 1N)) == 0N
+}
+
+///|
+fn is_noncanonical_binary_boundary_bigint(value : @bigint.BigInt) -> Bool {
+  let magnitude = if value < 0N { -value } else { value }
+  magnitude > 10N &&
+  [-1N, 0N, 1N].any(offset => is_power_of_two_bigint(magnitude + offset))
+}
+
+///|
 test "Arbitrary for BigInt" {
   let samples : Array[@bigint.BigInt] = @quickcheck.samples(10)
   debug_inspect(
     samples,
     content=(
       #|[
+      #|  8957778123143436869,
+      #|  224568372937935354752176555220923494950,
+      #|  4294967296,
       #|  0,
-      #|  2236702871533800590,
-      #|  4899806414470401660,
-      #|  -5076203457455444144,
-      #|  -3206590268553584789,
-      #|  -8738668918601119554,
-      #|  -5822442221117384418,
-      #|  4293417177517987002,
-      #|  -174397816515637542,
-      #|  -7574984457386592187,
+      #|  9007199254740991,
+      #|  -330974765789023695575794723562474317865,
+      #|  1321161328954558061203775241612665678662169762445949217122616206433285005712430002148382207261259,
+      #|  -14497849068316585071,
+      #|  1000,
+      #|  -2,
       #|]
     ),
+  )
+}
+
+///|
+test "Arbitrary for BigInt favors boundaries across multiple limbs" {
+  let samples : Array[@bigint.BigInt] = @quickcheck.samples(256)
+  let canonical : Array[@bigint.BigInt] = [0N, 1N, -1N, 2N, -2N, 10N, -10N]
+  let count : ((@bigint.BigInt) -> Bool) -> Int = predicate => {
+    samples.iter().filter(predicate).count()
+  }
+  let is_wide : (@bigint.BigInt) -> Bool = value => value.bit_length() > 64
+  let canonical_count = count(value => canonical.contains(value))
+  let binary_boundary_count = count(is_noncanonical_binary_boundary_bigint)
+  let wide_count = count(is_wide)
+  let positive_wide_count = count(value => value > 0N && is_wide(value))
+  let negative_wide_count = count(value => value < 0N && is_wide(value))
+  let max_bit_length = samples.fold(init=0, (maximum, value) => {
+    maximum.max(value.bit_length())
+  })
+  // canonical, binary boundary, wide, positive wide, negative wide, maximum bits
+  debug_inspect(
+    (
+      canonical_count, binary_boundary_count, wide_count, positive_wide_count, negative_wide_count,
+      max_bit_length,
+    ),
+    content="(73, 56, 64, 34, 30, 445)",
   )
 }
 


### PR DESCRIPTION
## Problem

The existing `Arbitrary for BigInt` always generated `0` at size zero and otherwise only converted a random `Int64`. It rarely exercised special values, numeric boundaries, or values wider than 64 bits.

## Changes

The generator now uses a boundary-biased portfolio:

- 35% arbitrary multi-chunk values
- 25% canonical values such as `0`, `±1`, `±2`, and `±10`
- 25% neighbors of common powers of two
- 15% neighbors of common powers of ten

No public API changes.