### PR TITLE
docs: fix documentation that the code no longer supports

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -23,9 +23,14 @@ chmod +x .githooks/*
 
 Runs before each commit to ensure code quality:
 
-- ✅ **moon check** - Validates code syntax, types, and formatting
-- ❌ **Blocks commit** if any issues are found
-- 💡 **Suggests fixes** like running `moon fmt`
+- ✅ **moon fmt** - Formats the staged MoonBit sources in place
+- ❌ **Blocks commit** if formatting changed any file, so the formatted
+  version is what gets committed
+- 💡 **Suggests the fix** - `git add . && git commit`
+
+> The `moon check` step is present in `pre-commit` but commented out, so
+> syntax and type errors are **not** caught at commit time — CI is what
+> catches them today.
 
 ### Usage
 
@@ -33,7 +38,7 @@ The hooks run automatically when you commit:
 
 ```bash
 git commit -m "your message"
-# → Runs moon check automatically
+# → Runs moon fmt automatically, and blocks the commit if it reformatted anything
 ```
 
 To bypass hooks temporarily (not recommended for production):
@@ -58,9 +63,11 @@ Run the auto-formatter:
 moon fmt
 ```
 
-### Hook fails due to type errors
+### The commit succeeded but CI reports type errors
 
-Fix the reported type errors and try committing again. The hook output will show specific error locations.
+The hook does not run `moon check` (that step is commented out in
+`pre-commit`), so type errors reach CI. Run `moon check` yourself before
+pushing.
 
 ## Contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,8 @@ For the latest stable release and installation instructions, contributors can vi
   cd hello
   echo """fn main {
     println([1, 2, 3].rev())
-  }""" > src/main/main.mbt
-  moon run src/main
+  }""" > cmd/main/main.mbt
+  moon run cmd/main
   # Output: [3, 2, 1]
   ```
 
@@ -89,7 +89,7 @@ After submitting your pull request, request a review from the project maintainer
 - Testing guidelines
 
   We encourage you to use `inspect` over `assert` in tests, as `inspect` provides more information about the values being tested and can
-  be updated easily. For testing in the loop, you may use `assert_` since snapshot testing does not work well in the loop.
+  be updated easily. For testing in the loop, you may use `assert_eq`/`assert_true` since snapshot testing does not work well in the loop.
 
 - New APIs with real meat
 

--- a/abort/README.mbt.md
+++ b/abort/README.mbt.md
@@ -1,6 +1,8 @@
 # Abort
 
-Terminates program execution with an error message. The `abort` function always panics and never returns.
+Terminates program execution by raising a panic; the `abort` function never
+returns. The message is printed only on the native backend — the
+wasm/js implementation discards it.
 
 ## Usage
 

--- a/array/SORT_IMPLEMENTATION.md
+++ b/array/SORT_IMPLEMENTATION.md
@@ -4,6 +4,9 @@
 
 MoonBit's `Array::sort` is a sophisticated hybrid sorting algorithm that combines multiple strategies to achieve optimal performance across different scenarios. It's an **in-place, unstable sort** with guaranteed **O(n log n)** worst-case time complexity.
 
+The implementation lives in `builtin/array_sort_impl.mbt`, where every
+helper carries a `fixed_` prefix; the snippets below are abridged from it.
+
 ## Core Strategy: Adaptive QuickSort
 
 The main algorithm is an adaptive QuickSort implementation with several optimizations and fallback strategies to handle edge cases efficiently.
@@ -13,8 +16,8 @@ The main algorithm is an adaptive QuickSort implementation with several optimiza
 ```
 Array::sort(arr)
     ├── Calculate recursion limit based on array length
-    └── quick_sort(arr, start=0, end=len, pred=None, limit)
-        ├── If len ≤ 16: Use Insertion Sort
+    └── fixed_quick_sort(arr, pred=None, limit)
+        ├── If len ≤ 16: Use Bubble Sort
         ├── If limit == 0: Use Heap Sort (fallback)
         ├── Choose pivot intelligently
         ├── If likely sorted: Try Bubble Sort
@@ -29,18 +32,21 @@ Array::sort(arr)
 ### 1. Size-Based Strategy Selection
 
 ```mbt
-let insertion_sort_len = 16
-if len <= insertion_sort_len {
-    arr.insertion_sort(start, end)  // Small arrays: O(n²) but cache-friendly
+let bubble_sort_len = 16
+if len <= bubble_sort_len {
+    if len >= 2 {
+        fixed_bubble_sort(arr)  // Small arrays: O(n²) but cache-friendly
+    }
+    return
 }
 ```
 
-**Small Arrays (≤16 elements)**: Uses insertion sort for its excellent cache locality and low overhead on small datasets.
+**Small Arrays (≤16 elements)**: Uses `fixed_bubble_sort` for its excellent cache locality and low overhead on small datasets.
 
 ### 2. Recursion Depth Limiting
 
 ```mbt
-fn get_limit(len: Int) -> Int {
+fn fixed_get_limit(len: Int) -> Int {
     // Returns log₂(len) - the maximum balanced recursion depth
     let mut limit = 0
     while len > 0 {
@@ -119,10 +125,11 @@ When consecutive equal pivots are detected, the algorithm skips over all equal e
 
 ```mbt
 // Recurse on smaller partition, iterate on larger
-if left_end - left_start < right_end - right_start {
-    arr.quick_sort(left_start, left_end, pred, limit)  // Recurse on smaller
-    current_start = right_start                         // Iterate on larger
-    current_end = right_end
+let left = arr.slice(0, pivot)
+let right = arr.slice(pivot + 1, len)
+if left.length() < right.length() {
+    fixed_quick_sort(left, pred, limit)  // Recurse on smaller
+    continue limit, right, Some(arr.unsafe_get(pivot)), ..  // Iterate on larger
 }
 ```
 

--- a/coverage/README.mbt.md
+++ b/coverage/README.mbt.md
@@ -317,7 +317,7 @@ test "coverage driven testing" {
 
 Coverage tracking integrates with MoonBit's build tools:
 
-- Use `moon test` to run tests with coverage tracking
+- Use `moon test --enable-coverage` to run tests with coverage tracking
 - Use `moon coverage analyze` to generate coverage reports
 - Coverage data helps identify untested code paths
 - Supports both line coverage and branch coverage analysis


### PR DESCRIPTION
Six documentation claims that the code no longer supports. Each was
found by an automated drift sweep and then re-checked by hand against the
code it cites — the verification is quoted below so a reviewer can
confirm without re-running anything.

| file | what it said | what the code does |
| --- | --- | --- |
| `CONTRIBUTING.md` | quickstart writes `src/main/main.mbt`, runs `moon run src/main` | `moon new hello` generates `hello/cmd/main/main.mbt`; there is no `src/`, and the command fails with exit 255, "failed to resolve path `src/main`" |
| `CONTRIBUTING.md` | "you may use `assert_`" | `assert_` is unbound anywhere in core; the non-snapshot assertions are `assert_eq` / `assert_true` |
| `coverage/README.mbt.md` | "Use `moon test` to run tests with coverage tracking" | plain `moon test` instruments nothing — `.github/workflows/misc-check.yml:53` passes `--enable-coverage`, and `moon test --help` lists it as "Enable coverage instrumentation" |
| `array/SORT_IMPLEMENTATION.md` | `arr.insertion_sort(start, end)`, `fn get_limit`, `arr.quick_sort(…)` | all three moved to `builtin/array_sort_impl.mbt` and gained a `fixed_` prefix: `fixed_bubble_sort` (`:252`), `fixed_get_limit` (`:303`), `fixed_quick_sort` (`:289`). None of the old names exists anywhere in the tree |
| `abort/README.mbt.md` | "Terminates program execution with an error message" | true only on native; the `#cfg(not(target="native"))` branch does `let _ = msg` before `panic_impl()` (`abort/abort.mbt:28`), so wasm/js never shows it |
| `.githooks/README.md` | "✅ **moon check** — Validates code syntax, types, and formatting" | the hook's entire `moon check` block is commented out (`pre-commit:49-69`), so it runs `moon fmt` plus a formatting-drift check and then prints "✅ All checks passed!" regardless |

I checked the `moon new` claim by actually running it in a scratch
directory, and the `.githooks` one by reading `pre-commit` in full.

### On `.githooks/README.md`

The `moon check` step was commented out deliberately (42d455bf, "disable
pre-commit hook"), so there are two honest fixes: document the hook as it
is, or re-enable the block. This PR takes the first — it also keeps a
note that the step exists but is disabled, so the option is not quietly
lost, and rewrites the troubleshooting section that described error
output the hook can no longer produce. Happy to switch to re-enabling it
instead if that is the intent.

### Checks

Docs only — no `.mbt` sources touched. `moon fmt --check` is clean across
the repo, `moon check -p abort` passes, and `moon test -p
moonbitlang/core/coverage` passes (14/14). The two `.mbt.md` files edited
had only their prose changed; every code block is untouched.

### Provenance

The sweep came from `moonbitlang/workflow`'s `examples/doc-audit.mbtx`,
which puts one read-only scout on each slice of each tracked document
with the claims in front of it and requires a `file:line` before a
finding counts. Of 20 core documents audited, 12 read true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXAZSnNythUMZG5HVV4ozb
