### PR TITLE
refactor(argparse): drop the program name from argv with a list pattern

### DIFF
--- a/argparse/parser.mbt
+++ b/argparse/parser.mbt
@@ -79,10 +79,9 @@ fn raise_context_help(
 ///|
 fn default_argv() -> ArrayView[String] {
   let args = @env.args()
-  if args.length() > 1 {
-    args[1:]
-  } else {
-    []
+  match args {
+    [_, .. rest] => rest
+    [] => []
   }
 }
 


### PR DESCRIPTION
## Summary

`default_argv` returns the process arguments without the program name. It
did so with a length guard plus an `args[1:]` slice:

```moonbit
let args = @env.args()
if args.length() > 1 {
  args[1:]
} else {
  []
}
```

The `> 1` bound exists only because `args[1:]` would panic on an empty
array, so the emptiness handling is split across a comparison and a
branch. A list pattern says the same thing in one shape:

```moonbit
let args = @env.args()
match args {
  [_, .. rest] => rest
  [] => []
}
```

`.. rest` binds an `ArrayView[String]` — the same zero-copy view that
`args[1:]` produced — so behaviour and allocation profile are unchanged.

## Sweep for similar sites

Follow-up to #4158 / #4159 (list patterns instead of manual prefix or
head handling). A structural sweep (moongrep over `match` blocks that
destructure the head off a sequence and return the tail with an empty
fallback, plus `rg` over length-guarded `[1:]` slices and `.. rest]`
patterns) found no further instances of this shape. The remaining
`[.. rest]`-style code in the tree — char/byte decoders peeling one
element per iteration, `FixedArray::rev` and `debug::compact_lines`
needing the last element, quickcheck shrink and `ArrayView::join`
reconstruction — genuinely uses the head or tail values, so a slice or
drop would not be equivalent.

## Verification
- `moon check argparse` clean
- `moon fmt --check argparse` clean
- `moon test argparse`: 153 passed, 0 failed

Generated with SeekMoon