### PR TITLE
perf(quickcheck): build collection shrink candidates lazily

### DIFF
--- a/quickcheck/shrink/collection.mbt
+++ b/quickcheck/shrink/collection.mbt
@@ -30,7 +30,7 @@ pub impl[T : Shrink] Shrink for @list.List[T] with fn shrink(xs) {
   ]
   .rev_iter()
   .flat_map(k => removes_list(k, n, xs))
-  .concat(shr_sub_terms(xs))
+  .concat(deferred(() => shr_sub_terms(xs)))
 }
 
 ///|

--- a/quickcheck/shrink/composite.mbt
+++ b/quickcheck/shrink/composite.mbt
@@ -47,7 +47,7 @@ pub impl[X : Shrink] Shrink for Array[X] with fn shrink(xs) {
   ]
   .iter()
   .flat_map(k => removes_array(k, n, xs))
-  .concat(shr_sub_terms(view))
+  .concat(deferred(() => shr_sub_terms(view)))
 }
 
 ///|

--- a/quickcheck/shrink/moon.pkg
+++ b/quickcheck/shrink/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/core/float",
   "moonbitlang/core/int16",
   "moonbitlang/core/uint16",
+  "moonbitlang/core/lazy",
   "moonbitlang/core/ref",
   "moonbitlang/core/list",
   "moonbitlang/core/queue",

--- a/quickcheck/shrink/utils.mbt
+++ b/quickcheck/shrink/utils.mbt
@@ -13,15 +13,29 @@
 // limitations under the License.
 
 ///|
+/// Builds an iterator whose underlying chain is only constructed once the first
+/// element is demanded.
+///
+/// The collection shrink instances append a per-element candidate chain that
+/// costs `O(n)` to build. Structural candidates come first and usually settle
+/// the shrink, so building that chain up front is wasted work.
+fn[T] deferred(f : () -> Iter[T]) -> Iter[T] {
+  let cell = @lazy.Lazy(f)
+  Iter::new(fn() { cell.force().next() })
+}
+
+///|
+/// `n` must be `xs.length()`; the recursive call maintains that, and both
+/// guards below rely on it.
 fn[T] removes_array(k : Int, n : Int, xs : Array[T]) -> Iter[Array[T]] {
   guard k <= n else { [||] }
+  // Dropping every element leaves the empty array; taking the `k`-element
+  // prefix first would copy the whole array only to discard it. Past this
+  // guard `xs[k:]` is non-empty.
+  guard k < n else { [|[]|] }
   let xs2 = xs[:k].to_owned()
   let xs1 = xs[k:].to_owned()
-  if xs1.is_empty() {
-    [|[]|]
-  } else {
-    [|xs1|].add(removes_array(k, n - k, xs1).map(x => xs2 + x))
-  }
+  [|xs1|].add(removes_array(k, n - k, xs1).map(x => xs2 + x))
 }
 
 ///|

--- a/quickcheck/shrink_collection_bench_test.mbt
+++ b/quickcheck/shrink_collection_bench_test.mbt
@@ -1,0 +1,25 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "bench shrink Array first candidate size=1000" (it : @bench.T) {
+  let input = Array::make(1000, ())
+  it.bench(fn() { it.keep(@shrink.Shrink::shrink(input).next()) })
+}
+
+///|
+test "bench shrink List first candidate size=1000" (it : @bench.T) {
+  let input : @list.List[Unit] = List(Array::make(1000, ()))
+  it.bench(fn() { it.keep(@shrink.Shrink::shrink(input).next()) })
+}


### PR DESCRIPTION
Supersedes #4152 by @mizchi, rebased onto current `main` and narrowed to the changes that preserve the exact candidate sequence. Their branch is untouched; the commit carries their `Co-Authored-By`.

## Problem

`Shrink for Array` and `Shrink for @list.List` both end their candidate chain with `.concat(shr_sub_terms(..))`. `Iter::concat` takes its second iterator by value, so that per-element chain — an `O(n)` recursion allocating one iterator per element — was built before a single candidate was demanded. Structural candidates come first and usually settle the shrink, so the work was almost always thrown away. `removes_array(n, n, xs)` then copied all `n` elements into a prefix it immediately discarded, only to yield `[]`.

## Fix

- `deferred(f : () -> Iter[T]) -> Iter[T]` builds the chain on the first `next()` and memoises it (`defer` is a keyword, hence the name).
- `guard k < n else { [|[]|] }` in `removes_array` returns the empty array without the copy. `xs[k:]` is empty exactly when `k == n`, so the old code already yielded `[]` there. That also makes the `xs1.is_empty()` branch unreachable, so it goes, and the `n == xs.length()` invariant both guards depend on is now written down.

No `.mbti` changes — all three functions are private.

## What was dropped from #4152

The `[|xs.take(0)|]` prepend in `Shrink for @list.List`. That is the empty-first ordering from #4149, which was closed, and it is also where #4152's List number came from: with `main`'s ordering the first `k` is 1, so the first candidate *is* an `n - 1` element list, `O(n)` to materialise however lazily the chain is built. Only the second traversal can go away. `main` had separately already absorbed two pieces of #4152 — the `bench` test import in `quickcheck/moon.pkg`, and `k = n / 2` for `List`.

## Numbers

First candidate from a 1,000-element collection, native release:

| Collection | Before    | After     |
| --------- | --------: | --------: |
| Array     | 121.52 µs | 236.84 ns |
| List      | 287.79 µs | 147.79 µs |

That is the micro number and it overstates the practical effect, since `max_size` defaults to 100. End to end on `@quickcheck.check` with default settings (`count = 100`, `max_size = 100`, `max_shrinks = 100`), native release:

| scenario | before | after |
| --- | ---: | ---: |
| small counterexample (`len < 5`), Array | 35.07 µs | 33.57 µs |
| small counterexample (`len < 5`), List | 32.12 µs | 31.71 µs |
| large counterexample (`len < 90`), Array | 189.24 µs | 141.18 µs |
| large counterexample (`len < 90`), List | 331.74 µs | 264.34 µs |

So 20-25% when the counterexample is large enough to shrink from, and nothing measurable when it is small. Of that, the `k == n` guard alone accounts for 5-6%; `deferred` is the rest.

## Validation

- `moon test -p quickcheck/shrink --target all` 53/53 and `moon test -p quickcheck --target all` 157/157 on wasm, wasm-gc, js and native.
- `moon check --target all` clean, `moon fmt` clean, `moon info` produces no diff.
- No snapshot needed updating, which is the evidence that the candidate sequences are unchanged.
- Mutation-verified: replacing the `k == n` result with `[||]` fails 21 of 53 tests in `quickcheck/shrink`; making `deferred` never call `f` fails 22 of 53.
- Benchmarks run green on all four targets.

## A latent bug this uncovered (not fixed here)

The benchmark uses 1,000 elements rather than 10,000 because at 10,000 the `List` case dies with `RangeError: Maximum call stack size exceeded` on js, and the equivalent on wasm-gc. That is not a benchmark artifact: `removes_list` recurses once per element, so shrinking a large list overflows the stack on those backends independently of this PR — a property test with a large `max_size` would crash while shrinking instead of reporting its counterexample. Worth a separate issue.

## Review

No Codex sign-off: both accounts are out of quota until Sep 9. `/code-review high` was used as the independent adversarial pass instead. It found the js/wasm-gc benchmark crash and the now-dead `xs1.is_empty()` branch; both are addressed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jtBJHK749cpStav5ZMNCr
