### PR TITLE
test(json, builtin, debug): use Json(...) in test blocks

### DIFF
--- a/builtin/json_test.mbt
+++ b/builtin/json_test.mbt
@@ -38,17 +38,17 @@ test "Json number equality" {
 
 ///|
 test "Json string equality" {
-  let a = Json::string("hi")
-  let b = Json::string("hi")
-  let c = Json::string("bye")
+  let a = Json("hi")
+  let b = Json("hi")
+  let c = Json("bye")
   debug_inspect(a == b, content="true")
   debug_inspect(a == c, content="false")
 }
 
 ///|
 test "Json array equality" {
-  let a = Json::array([Json::number(1), Json::string("x")])
-  let b = Json::array([Json::number(1), Json::string("x")])
+  let a = Json::array([Json::number(1), Json("x")])
+  let b = Json::array([Json::number(1), Json("x")])
   let c = Json::array([Json::number(2)])
   debug_inspect(a == b, content="true")
   debug_inspect(a == c, content="false")
@@ -56,8 +56,8 @@ test "Json array equality" {
 
 ///|
 test "Json object equality" {
-  let a = Json::object({ "x": Json::number(1), "y": Json::string("a") })
-  let b = Json::object({ "x": Json::number(1), "y": Json::string("a") })
+  let a = Json::object({ "x": Json::number(1), "y": Json("a") })
+  let b = Json::object({ "x": Json::number(1), "y": Json("a") })
   let c = Json::object({ "x": Json::number(2) })
   debug_inspect(a == b, content="true")
   debug_inspect(a == c, content="false")
@@ -66,7 +66,7 @@ test "Json object equality" {
 ///|
 test "Json equality mismatch" {
   let a = Json::null()
-  let b = Json::string("x")
+  let b = Json("x")
   debug_inspect(a == b, content="false")
 }
 
@@ -214,13 +214,13 @@ test "Result to_json with Err value" {
 ///|
 test "Bool::to_json true" {
   let result = true.to_json()
-  @test.assert_eq(result, Json::boolean(true))
+  @test.assert_eq(result, Json(true))
 }
 
 ///|
 test "to_hex_digit" {
   let str = "\n\r\b\t\u{0C}\u{00}"
-  guard! Json::string(str) is String(escaped)
+  guard! Json(str) is String(escaped)
   @test.assert_eq(escaped, "\n\r\b\t\u{0c}\u{00}")
 }
 

--- a/debug/debug_test.mbt
+++ b/debug/debug_test.mbt
@@ -31,7 +31,7 @@ test "inspect" {
 ///|
 test "debug repr for json" {
   @debug.debug_inspect(Json::null(), content="Null")
-  @debug.debug_inspect(Json::boolean(true), content="True")
+  @debug.debug_inspect(Json(true), content="True")
   @debug.debug_inspect(
     Json::number(@double.infinity, repr="1e999999999"),
     content=(

--- a/json/escape_quickcheck_wbtest.mbt
+++ b/json/escape_quickcheck_wbtest.mbt
@@ -123,7 +123,7 @@ test "quickcheck: write_escaped matches the per-code-unit model" {
 test "quickcheck: stringify/parse roundtrip on adversarial strings" {
   @quickcheck.check(count=300, (input : (Array[Int], Bool)) => {
     let (seeds, escape_slash) = input
-    let json = Json::string(adversarial_string(seeds, allow_surrogates=false))
+    let json = Json(adversarial_string(seeds, allow_surrogates=false))
     parse(json.stringify(escape_slash~)) == json
   })
 }

--- a/json/from_json_test.mbt
+++ b/json/from_json_test.mbt
@@ -30,7 +30,7 @@ test {
 
 ///|
 test {
-  let u = Json::array([Json::number(1), Json::string("str")])
+  let u = Json::array([Json::number(1), Json("str")])
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(u) : Array[Int])),
     "expected Array[Int] decode failure",
@@ -47,7 +47,7 @@ test {
 test {
   let u = Json::object({
     "x": Json::object({ "xx": Json::number(1) }),
-    "y": Json::object({ "yy": Json::string("str") }),
+    "y": Json::object({ "yy": Json("str") }),
   })
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(u) : Map[String, Map[String, Double]])),
@@ -393,22 +393,22 @@ test "bigint" {
 
 ///|
 test "jsonvalue" {
-  let u = Json::string("str")
+  let u = Json("str")
   let v : Json = @json.from_json(u)
   debug_inspect(v, content="String(\"str\")")
   let u = Json::number(123)
   let v : Json = @json.from_json(u)
   debug_inspect(v, content="Number(123)")
-  let u = Json::boolean(true)
+  let u = Json(true)
   let v : Json = @json.from_json(u)
   debug_inspect(v, content="True")
-  let u = Json::boolean(false)
+  let u = Json(false)
   let v : Json = @json.from_json(u)
   debug_inspect(v, content="False")
   let u = null
   let v : Json = @json.from_json(u)
   debug_inspect(v, content="Null")
-  let u = Json::array([Json::number(1), Json::string("str")])
+  let u = Json::array([Json::number(1), Json("str")])
   let v : Json = @json.from_json(u)
   debug_inspect(
     v,
@@ -636,7 +636,7 @@ test "Bool from_json error handling" {
       #|JsonDecodeError((Root, "Bool::from_json: expected boolean"))
     ),
   )
-  let json_string = Json::string("true")
+  let json_string = Json("true")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : Bool)),
     "expected Bool decode failure",
@@ -662,7 +662,7 @@ test "Int64 from_json error handling" {
       #|JsonDecodeError((Root, "Int64::from_json: expected number in string representation"))
     ),
   )
-  let json_invalid_string = Json::string("not a number")
+  let json_invalid_string = Json("not a number")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_invalid_string) : Int64)),
     "expected Int64 parse failure",
@@ -677,7 +677,7 @@ test "Int64 from_json error handling" {
 
 ///|
 test "UInt from_json error handling" {
-  let json_string = Json::string("123")
+  let json_string = Json("123")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : UInt)),
     "expected UInt decode failure",
@@ -703,7 +703,7 @@ test "UInt64 from_json error handling" {
       #|JsonDecodeError((Root, "UInt64::from_json: expected number in string representation"))
     ),
   )
-  let json_invalid_string = Json::string("not a number")
+  let json_invalid_string = Json("not a number")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_invalid_string) : UInt64)),
     "expected UInt64 parse failure",
@@ -759,7 +759,7 @@ test "Char from_json error handling" {
       #|JsonDecodeError((Root, "Char::from_json: expected string"))
     ),
   )
-  let json_empty_string = Json::string("")
+  let json_empty_string = Json("")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_empty_string) : Char)),
     "expected Char decode failure",
@@ -770,7 +770,7 @@ test "Char from_json error handling" {
       #|JsonDecodeError((Root, "Char::from_json: expected single character"))
     ),
   )
-  let json_long_string = Json::string("abc")
+  let json_long_string = Json("abc")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_long_string) : Char)),
     "expected Char decode failure",
@@ -796,7 +796,7 @@ test "BigInt from_json error handling" {
       #|JsonDecodeError((Root, "BigInt::from_json: expected number in string representation"))
     ),
   )
-  let json_invalid_number = Json::string("not-a-number")
+  let json_invalid_number = Json("not-a-number")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_invalid_number) : BigInt)),
     "expected invalid BigInt decode failure",
@@ -811,7 +811,7 @@ test "BigInt from_json error handling" {
 
 ///|
 test "Array from_json error handling" {
-  let json_string = Json::string("not an array")
+  let json_string = Json("not an array")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : Array[Int])),
     "expected Array decode failure",
@@ -826,7 +826,7 @@ test "Array from_json error handling" {
 
 ///|
 test "FixedArray from_json error handling" {
-  let json_string = Json::string("not an array")
+  let json_string = Json("not an array")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : FixedArray[Int])),
     "expected FixedArray decode failure",
@@ -856,7 +856,7 @@ test "Map from_json error handling" {
 
 ///|
 test "Option from_json error handling" {
-  let json_string = Json::string("not an option")
+  let json_string = Json("not an option")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : Int?)),
     "expected Option decode failure",
@@ -871,7 +871,7 @@ test "Option from_json error handling" {
 
 ///|
 test "Result from_json error handling" {
-  let json_string = Json::string("not a result")
+  let json_string = Json("not a result")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : Result[Int, String])),
     "expected Result decode failure",
@@ -908,7 +908,7 @@ test "Result from_json error handling" {
 
 ///|
 test "Unit from_json error handling" {
-  let json_string = Json::string("not null")
+  let json_string = Json("not null")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : Unit)),
     "expected Unit decode failure",
@@ -950,17 +950,17 @@ test "float roundtrip" {
 ///|
 test "float special values" {
   // Test NaN
-  let u = Json::string("NaN")
+  let u = Json("NaN")
   let v : Float = @json.from_json(u)
   inspect(v, content="NaN")
 
   // Test Infinity
-  let u = Json::string("Infinity")
+  let u = Json("Infinity")
   let v : Float = @json.from_json(u)
   inspect(v, content="Infinity")
 
   // Test -Infinity
-  let u = Json::string("-Infinity")
+  let u = Json("-Infinity")
   let v : Float = @json.from_json(u)
   inspect(v, content="-Infinity")
 
@@ -972,7 +972,7 @@ test "float special values" {
 
 ///|
 test "Float from_json error handling" {
-  let json_string = Json::string("not a number")
+  let json_string = Json("not a number")
   let err = expect_json_decode_error(
     () => ignore((@json.from_json(json_string) : Float)),
     "expected Float decode failure",
@@ -1032,14 +1032,14 @@ test "ArrayView::from_json" {
 
 ///|
 test "from_json special cases" {
-  let nan_value : Double = @json.from_json(Json::string("NaN"))
+  let nan_value : Double = @json.from_json(Json("NaN"))
   @json.json_inspect(nan_value, content="NaN")
-  let inf_value : Double = @json.from_json(Json::string("Infinity"))
+  let inf_value : Double = @json.from_json(Json("Infinity"))
   @json.json_inspect(inf_value, content="Infinity")
-  let neg_inf_value : Double = @json.from_json(Json::string("-Infinity"))
+  let neg_inf_value : Double = @json.from_json(Json("-Infinity"))
   @json.json_inspect(neg_inf_value, content="-Infinity")
   let array_view_err = expect_json_decode_error(
-    () => ignore((@json.from_json(Json::string("oops")) : ArrayView[Int])),
+    () => ignore((@json.from_json(Json("oops")) : ArrayView[Int])),
     "expected ArrayView::from_json error",
   )
   guard array_view_err
@@ -1055,7 +1055,7 @@ test "from_json special cases" {
     fail("expected Bytes::from_json type error")
   }
   let bytes_escape_err = expect_json_decode_error(
-    () => ignore((@json.from_json(Json::string("bad\\\\")) : Bytes)),
+    () => ignore((@json.from_json(Json("bad\\\\")) : Bytes)),
     "expected Bytes::from_json escape error",
   )
   guard bytes_escape_err
@@ -1063,7 +1063,7 @@ test "from_json special cases" {
     fail("expected Bytes::from_json escape error")
   }
   let bytes_invalid_err = expect_json_decode_error(
-    () => ignore((@json.from_json(Json::string("\u{0}")) : Bytes)),
+    () => ignore((@json.from_json(Json("\u{0}")) : Bytes)),
     "expected Bytes::from_json byte error",
   )
   guard bytes_invalid_err

--- a/json/json_test.mbt
+++ b/json/json_test.mbt
@@ -315,13 +315,13 @@ test "string from and to json round trip" {
 test "escape" {
   let s = "http://example.com/"
   inspect(
-    Json::string(s).stringify(escape_slash=true),
+    Json(s).stringify(escape_slash=true),
     content=(
       #|"http:\/\/example.com\/"
     ),
   )
   inspect(
-    Json::string(s).stringify(),
+    Json(s).stringify(),
     content=(
       #|"http://example.com/"
     ),

--- a/json/json_traverse_test.mbt
+++ b/json/json_traverse_test.mbt
@@ -90,13 +90,10 @@ fn Json::prune_loc_test(self : Json) -> Json {
 test "prune_loc - primitive values" {
   // Null, True, False, Number, String should be preserved as-is
   debug_inspect(null.prune_loc(), content="Some(Null)")
-  debug_inspect(Json::boolean(true).prune_loc(), content="Some(True)")
-  debug_inspect(Json::boolean(false).prune_loc(), content="Some(False)")
+  debug_inspect(Json(true).prune_loc(), content="Some(True)")
+  debug_inspect(Json(false).prune_loc(), content="Some(False)")
   debug_inspect(Json::number(42.0).prune_loc(), content="Some(Number(42))")
-  debug_inspect(
-    Json::string("hello").prune_loc(),
-    content="Some(String(\"hello\"))",
-  )
+  debug_inspect(Json("hello").prune_loc(), content="Some(String(\"hello\"))")
 }
 
 ///|
@@ -105,12 +102,7 @@ test "prune_loc - arrays" {
   debug_inspect(Json::array([]).prune_loc(), content="Some(Array([]))")
 
   // Array with primitives
-  let arr1 = Json::array([
-    null,
-    Json::boolean(true),
-    Json::number(123.0),
-    Json::string("test"),
-  ])
+  let arr1 = Json::array([null, Json(true), Json::number(123.0), Json("test")])
   @json.json_inspect(
     arr1.prune_loc_test(),
     content=[null, true, 123, "test"], // FIXME: support null
@@ -127,7 +119,7 @@ test "prune_loc - objects without loc" {
   debug_inspect(Json::object(Map([])).prune_loc(), content="None")
 
   // Object with no "loc" key
-  let obj1 : Json = { "name": Json::string("John"), "age": Json::number(30.0) }
+  let obj1 : Json = { "name": Json("John"), "age": Json::number(30.0) }
   @json.json_inspect(obj1.prune_loc(), content=[{ "name": "John", "age": 30 }])
 }
 
@@ -144,8 +136,8 @@ test "prune_loc - objects with loc key" {
 
   // Object with "loc" and other keys - "loc" should be removed
   let obj_with_loc : Json = {
-    "type": Json::string("function"),
-    "name": Json::string("myFunc"),
+    "type": Json("function"),
+    "name": Json("myFunc"),
     "loc": Json::object({
       "line": Json::number(10.0),
       "column": Json::number(5.0),
@@ -160,15 +152,13 @@ test "prune_loc - objects with loc key" {
 test "prune_loc - nested objects" {
   // Nested object where inner object becomes empty after pruning
   let nested1 : Json = {
-    "outer": Json::object({ "loc": Json::string("should be removed") }),
+    "outer": Json::object({ "loc": Json("should be removed") }),
     "value": Json::number(42.0),
   }
   @json.json_inspect(nested1.prune_loc(), content=[{ "value": 42 }])
 
   // Nested object where all objects are pruned
-  let nested2 : Json = {
-    "inner": Json::object({ "loc": Json::string("remove me") }),
-  }
+  let nested2 : Json = { "inner": Json::object({ "loc": Json("remove me") }) }
   @json.json_inspect(
     nested2.prune_loc(),
     content=null, // FIXME: None -> Null

--- a/json/lex_string_test.mbt
+++ b/json/lex_string_test.mbt
@@ -214,21 +214,19 @@ test "an escape naming a non-BMP character reports it whole" {
 ///|
 test "valid surrogate pairs decode to one scalar value" {
   // Both ends of the supplementary range.
-  assert_true(@json.parse("\"\\uD800\\uDC00\"") == Json::string("\u{10000}"))
-  assert_true(@json.parse("\"\\udbff\\udfff\"") == Json::string("\u{10FFFF}"))
+  assert_true(@json.parse("\"\\uD800\\uDC00\"") == Json("\u{10000}"))
+  assert_true(@json.parse("\"\\udbff\\udfff\"") == Json("\u{10FFFF}"))
   // Any hex digit case, and in any position within the string.
-  assert_true(@json.parse("\"\\uD83D\\uDE00\"") == Json::string("\u{1F600}"))
-  assert_true(
-    @json.parse("\"a\\uD83D\\uDE00b\\n\"") == Json::string("a\u{1F600}b\n"),
-  )
+  assert_true(@json.parse("\"\\uD83D\\uDE00\"") == Json("\u{1F600}"))
+  assert_true(@json.parse("\"a\\uD83D\\uDE00b\\n\"") == Json("a\u{1F600}b\n"))
   // Two pairs running together are decoded independently.
   assert_true(
     @json.parse("\"\\uD83D\\uDE00\\uD83D\\uDE01\"") ==
-    Json::string("\u{1F600}\u{1F601}"),
+    Json("\u{1F600}\u{1F601}"),
   )
   // Non-surrogate escapes are unaffected, including the replacement
   // character, which is a scalar value like any other.
-  assert_true(@json.parse("\"\\u0041\\uFFFD\"") == Json::string("A\u{FFFD}"))
+  assert_true(@json.parse("\"\\u0041\\uFFFD\"") == Json("A\u{FFFD}"))
 }
 
 ///|

--- a/json/parse_test.mbt
+++ b/json/parse_test.mbt
@@ -202,7 +202,7 @@ test "parses +1.23e100" {
 ///|
 test "parses string" {
   let json = test_parse("\"abc\"")
-  @debug.assert_eq(json, Json::string("abc"))
+  @debug.assert_eq(json, Json("abc"))
 }
 
 ///|
@@ -212,7 +212,7 @@ test "parses quotes in string" {
       #|["\"","'"]
     ),
   )
-  @debug.assert_eq(json, Json::array([Json::string("\""), Json::string("'")]))
+  @debug.assert_eq(json, Json::array([Json("\""), Json("'")]))
 }
 
 ///|
@@ -222,7 +222,7 @@ test "parses escaped characters" {
       #|"\b\f\n\r\t\u01fF\""
     ),
   )
-  @debug.assert_eq(json, Json::string("\u0008\u000C\n\r\t\u01FF\""))
+  @debug.assert_eq(json, Json("\u0008\u000C\n\r\t\u01FF\""))
 }
 //endregion
 
@@ -247,7 +247,7 @@ test "parses whitespace around separators" {
     json,
     Json::object({
       "a": Json::number(1.0),
-      "b": Json::array([Json::boolean(true), Json::boolean(false)]),
+      "b": Json::array([Json(true), Json(false)]),
     }),
   )
 }

--- a/json/quickcheck_test.mbt
+++ b/json/quickcheck_test.mbt
@@ -188,7 +188,7 @@ impl @shrink.Shrink for ArbJson with fn shrink(self) {
 /// stream on a small document: null first, then each child, then one-child
 /// dropped, then one-child shrunk.
 test "shrink_json candidate stream" {
-  let doc = Json::array([Json::number(5.0), Json::string("a")])
+  let doc = Json::array([Json::number(5.0), Json("a")])
   debug_inspect(
     shrink_json(doc).to_array(),
     content=(


### PR DESCRIPTION
## What

Refactor test code to construct `Json` string/bool values with the preferred
`Json(...)` constructor instead of the `Json::string(...)` /
`Json::boolean(...)` helpers, **inside `test { ... }` blocks only**.

`Bool` and `String` both implement `ToJson`, so `Json(true)` is exactly
`Json::boolean(true)` and `Json("x")` is exactly `Json::string("x")` — the
refactor is behavior-neutral and no snapshot or expectation changed.

## Scope

- Changed: 63 call sites across 9 test files (`json/*_test.mbt`,
  `builtin/json_test.mbt`, `debug/debug_test.mbt`), each inside a
  `test { ... }` block.
- Intentionally left untouched:
  - library code that uses these helpers for real construction
    (`json/parse.mbt`, `ToJson` impls in `builtin`, `bigint`, ...);
  - doc comments / generated `.mbti` / doc examples;
  - test-support helpers defined outside `test` blocks (QuickCheck
    generators/shrinkers in `json/quickcheck_test.mbt`, bench fixtures in
    `json/stringify_indent_bench_test.mbt`, the `ToJson` impl in
    `json/json_encode_decode_test.mbt`).

## Validation

- `moon check`: clean (0 errors, 0 warnings)
- `moon fmt --check`: clean
- `moon test`: json 219/219, builtin 2988/2988, debug 71/71

Generated with SeekMoon