### PR TITLE
feat(builtin): add clamped_view for Array, Bytes, FixedArray and ReadOnlyArray views

### DIFF
--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -429,6 +429,108 @@ pub fn[T] ArrayView::get_view(
 }
 
 ///|
+/// Creates a view of a portion of the array, clamping the requested range
+/// instead of rejecting it.
+///
+/// Total: `start` and `end` are each pulled into `[0, length()]`, and an
+/// inverted range yields an empty view at the clamped `start`, so this
+/// function never aborts and never rejects a range. Intended for windowing
+/// where the caller already knows the range may overrun, such as paging or
+/// chunking.
+///
+/// Parameters:
+///
+/// * `self` : The array to create a view from.
+/// * `start` : The starting index of the view (inclusive), clamped. Defaults
+/// to 0.
+/// * `end` : The ending index of the view (exclusive), clamped. Defaults to
+/// the length of the array.
+///
+/// Returns an `ArrayView` over the clamped range.
+///
+/// See `arr[start:end]` for the aborting variant and `Array::get_view` for the
+/// exact `Option`-returning variant.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let arr = [1, 2, 3, 4, 5]
+///   debug_inspect(
+///     arr.clamped_view(start=3, end=10),
+///     content=(
+///       #|<ArrayView: [4, 5]>
+///     ),
+///   )
+///   debug_inspect(
+///     arr.clamped_view(start=-2, end=2),
+///     content=(
+///       #|<ArrayView: [1, 2]>
+///     ),
+///   )
+///   debug_inspect(
+///     arr.clamped_view(start=4, end=1),
+///     content=(
+///       #|<ArrayView: []>
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] Array::clamped_view(
+  self : Array[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T] {
+  let len = self.length()
+  let lo = clamp_offset(start, len)
+  let hi = match end {
+    None => len
+    Some(end) => clamp_offset(end, len)
+  }
+  let count = if hi > lo { hi - lo } else { 0 }
+  ArrayView::make(self.buffer(), lo, count)
+}
+
+///|
+/// Creates a new view into a portion of the array view, clamping the requested
+/// range instead of rejecting it. The indices are relative to the start of the
+/// current view; same contract as `Array::clamped_view`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let view = [1, 2, 3, 4, 5][1:4] // [2, 3, 4]
+///   debug_inspect(
+///     view.clamped_view(start=1, end=10),
+///     content=(
+///       #|<ArrayView: [3, 4]>
+///     ),
+///   )
+///   debug_inspect(
+///     view.clamped_view(start=3, end=1),
+///     content=(
+///       #|<ArrayView: []>
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] ArrayView::clamped_view(
+  self : ArrayView[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T] {
+  let len = self.length()
+  let lo = clamp_offset(start, len)
+  let hi = match end {
+    None => len
+    Some(end) => clamp_offset(end, len)
+  }
+  let count = if hi > lo { hi - lo } else { 0 }
+  ArrayView::make(self.buf(), self.start() + lo, count)
+}
+
+///|
 fn[T] unsafe_cast_fixedarray_to_uninitializedarray(
   arr : FixedArray[T],
 ) -> UninitializedArray[T] = "%identity"

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -637,6 +637,44 @@ pub fn[T] FixedArray::get_view(
 }
 
 ///|
+/// Creates a view of a portion of the fixed array, clamping the requested
+/// range instead of rejecting it. Same contract as `Array::clamped_view`.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   let arr : FixedArray[Int] = [1, 2, 3, 4, 5]
+///   debug_inspect(
+///     arr.clamped_view(start=3, end=10),
+///     content=(
+///       #|<ArrayView: [4, 5]>
+///     ),
+///   )
+///   debug_inspect(
+///     arr.clamped_view(start=4, end=1),
+///     content=(
+///       #|<ArrayView: []>
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] FixedArray::clamped_view(
+  self : FixedArray[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T] {
+  let len = self.length()
+  let lo = clamp_offset(start, len)
+  let hi = match end {
+    None => len
+    Some(end) => clamp_offset(end, len)
+  }
+  let count = if hi > lo { hi - lo } else { 0 }
+  ArrayView::make(unsafe_cast_fixedarray_to_uninitializedarray(self), lo, count)
+}
+
+///|
 /// Return an iterator over suffix views of this array view.
 ///
 /// Set `include_empty=true` to include the empty suffix at the end.

--- a/builtin/bounds.mbt
+++ b/builtin/bounds.mbt
@@ -38,3 +38,18 @@ fn[T] index_out_of_bounds2(len : Int, i : Int, j : Int) -> T {
     "index out of bounds: the len is from 0 to \{len} but the index is (\{i}, \{j})",
   )
 }
+
+///|
+/// Clamps a view offset into `[0, len]`.
+///
+/// Shared by the `clamped_view` family, whose contract is to never abort:
+/// offsets outside the container are pulled to the nearest end instead.
+fn clamp_offset(offset : Int, len : Int) -> Int {
+  if offset < 0 {
+    0
+  } else if offset > len {
+    len
+  } else {
+    offset
+  }
+}

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -270,6 +270,73 @@ pub fn BytesView::view(
 }
 
 ///|
+/// Returns a view of the bytes between `start` and `end`, clamping the
+/// requested range instead of rejecting it.
+///
+/// Total: `start` and `end` are each pulled into `[0, length()]`, and an
+/// inverted range yields an empty view at the clamped `start`, so this
+/// function never aborts and never rejects a range. Intended for windowing
+/// where the caller already knows the range may overrun, such as framing a
+/// byte stream.
+///
+/// See `bs[start:end]` for the aborting variant and `Bytes::get_view` for the
+/// exact `Option`-returning variant.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let bs = b"\x00\x01\x02\x03\x04\x05"
+///   inspect(bs.clamped_view(start=4, end=100).length(), content="2")
+///   inspect(bs.clamped_view(start=-2, end=2).length(), content="2")
+///   inspect(bs.clamped_view(start=4, end=1).length(), content="0")
+/// }
+/// ```
+pub fn Bytes::clamped_view(
+  self : Bytes,
+  start? : Int = 0,
+  end? : Int,
+) -> BytesView {
+  let len = self.length()
+  let lo = clamp_offset(start, len)
+  let hi = match end {
+    None => len
+    Some(end) => clamp_offset(end, len)
+  }
+  let count = if hi > lo { hi - lo } else { 0 }
+  BytesView::make(self, lo, count)
+}
+
+///|
+/// Returns a sub-view of the view between `start` and `end`, clamping the
+/// requested range instead of rejecting it. Offsets are relative to the view;
+/// same contract as `Bytes::clamped_view`.
+///
+/// # Example
+///
+/// ```mbt check
+/// test {
+///   let bv = b"\x00\x01\x02\x03\x04\x05"[1:4]
+///   inspect(bv.clamped_view(start=1, end=100).length(), content="2")
+///   inspect(bv.clamped_view(start=3, end=1).length(), content="0")
+/// }
+/// ```
+pub fn BytesView::clamped_view(
+  self : BytesView,
+  start? : Int = 0,
+  end? : Int,
+) -> BytesView {
+  let len = self.length()
+  let lo = clamp_offset(start, len)
+  let hi = match end {
+    None => len
+    Some(end) => clamp_offset(end, len)
+  }
+  let count = if hi > lo { hi - lo } else { 0 }
+  BytesView::make(self.bytes(), self.start() + lo, count)
+}
+
+///|
 /// Returns an iterator over the `View`.
 /// 
 /// # Example

--- a/builtin/clamped_view_test.mbt
+++ b/builtin/clamped_view_test.mbt
@@ -76,3 +76,130 @@ test "StringView::clamped_view uses view-relative offsets" {
   // nested truncation
   inspect(v.clamped_view(start=1).clamped_view(end=2), content="b")
 }
+
+///|
+test "Array::clamped_view clamps out-of-range and inverted offsets" {
+  let arr = [1, 2, 3, 4, 5]
+  json_inspect(arr.clamped_view().to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=1, end=4).to_owned(), content=[2, 3, 4])
+  json_inspect(arr.clamped_view(end=100).to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=-5).to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=100).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=4, end=1).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=-9, end=-3).to_owned(), content=[])
+  json_inspect(([] : Array[Int]).clamped_view(end=10).to_owned(), content=[])
+}
+
+///|
+test "Array::clamped_view agrees with get_view on valid ranges" {
+  let arr = [1, 2, 3, 4, 5]
+  for start in -1..<=6 {
+    for end in -1..<=6 {
+      // get_view rejects out-of-range and inverted ranges; clamped_view
+      // answers the same on every range get_view accepts.
+      guard arr.get_view(start~, end~) is Some(v) else { continue }
+      json_inspect(
+        arr.clamped_view(start~, end~).to_owned(),
+        content=v.to_owned().to_json(),
+      )
+    }
+  }
+}
+
+///|
+test "ArrayView::clamped_view uses view-relative offsets" {
+  let view = [1, 2, 3, 4, 5][1:4] // [2, 3, 4]
+  json_inspect(view.clamped_view().to_owned(), content=[2, 3, 4])
+  json_inspect(view.clamped_view(start=1, end=100).to_owned(), content=[3, 4])
+  json_inspect(view.clamped_view(start=-3, end=2).to_owned(), content=[2, 3])
+  json_inspect(view.clamped_view(start=3, end=1).to_owned(), content=[])
+  // nested truncation stays inside the original view
+  json_inspect(view.clamped_view(start=1).clamped_view(end=100).to_owned(), content=[
+    3, 4,
+  ])
+}
+
+///|
+test "Array::clamped_view aliases the backing array" {
+  let arr = [1, 2, 3, 4, 5]
+  let v = arr.clamped_view(start=1, end=100)
+  arr[1] = 20
+  json_inspect(v.to_owned(), content=[20, 3, 4, 5])
+}
+
+///|
+test "Bytes::clamped_view clamps out-of-range and inverted offsets" {
+  let bs = b"\x00\x01\x02\x03\x04\x05"
+  inspect(bs.clamped_view() == bs, content="true")
+  inspect(bs.clamped_view(start=4, end=100) == b"\x04\x05", content="true")
+  inspect(bs.clamped_view(start=-5, end=2) == b"\x00\x01", content="true")
+  inspect(bs.clamped_view(start=100).length(), content="0")
+  inspect(bs.clamped_view(start=4, end=1).length(), content="0")
+  inspect(bs.clamped_view(start=-9, end=-3).length(), content="0")
+  inspect(b"".clamped_view(end=10).length(), content="0")
+}
+
+///|
+test "Bytes::clamped_view agrees with get_view on valid ranges" {
+  let bs = b"\x00\x01\x02\x03\x04\x05"
+  for start in -1..<=7 {
+    for end in -1..<=7 {
+      guard bs.get_view(start~, end~) is Some(v) else { continue }
+      inspect(bs.clamped_view(start~, end~) == v, content="true")
+    }
+  }
+}
+
+///|
+test "BytesView::clamped_view uses view-relative offsets" {
+  let bv = b"\x00\x01\x02\x03\x04\x05"[1:4] // 0x01 0x02 0x03
+  inspect(bv.clamped_view() == bv, content="true")
+  inspect(bv.clamped_view(start=1, end=100) == b"\x02\x03", content="true")
+  inspect(bv.clamped_view(start=-3, end=2) == b"\x01\x02", content="true")
+  inspect(bv.clamped_view(start=3, end=1).length(), content="0")
+  // nested truncation stays inside the original view
+  inspect(
+    bv.clamped_view(start=1).clamped_view(end=100) == b"\x02\x03",
+    content="true",
+  )
+}
+
+///|
+test "clamped_view positions an empty result at the clamped start" {
+  let arr = [1, 2, 3, 4, 5]
+  inspect(arr.clamped_view(start=4, end=1).start_offset(), content="4")
+  inspect(arr.clamped_view(start=100).start_offset(), content="5")
+  inspect(arr.clamped_view(start=-9, end=-3).start_offset(), content="0")
+  let view = arr[1:4] // [2, 3, 4]
+  // view-relative offsets, but start_offset() is absolute in the array
+  inspect(view.clamped_view(start=2, end=1).start_offset(), content="3")
+  inspect(view.clamped_view(start=100).start_offset(), content="4")
+  let bs = b"\x00\x01\x02\x03\x04\x05"
+  inspect(bs.clamped_view(start=4, end=1).start_offset(), content="4")
+  inspect(bs.clamped_view(start=100).start_offset(), content="6")
+  let bv = bs[1:4] // 0x01 0x02 0x03
+  inspect(bv.clamped_view(start=2, end=1).start_offset(), content="3")
+  inspect(bv.clamped_view(start=100).start_offset(), content="4")
+}
+
+///|
+test "clamped_view saturates at the extremes of Int" {
+  let lo = @int.MIN_VALUE
+  let hi = @int.MAX_VALUE
+  let arr = [1, 2, 3, 4, 5]
+  json_inspect(arr.clamped_view(start=lo, end=hi).to_owned(), content=[
+    1, 2, 3, 4, 5,
+  ])
+  json_inspect(arr.clamped_view(start=hi, end=lo).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=lo, end=lo).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=hi, end=hi).to_owned(), content=[])
+  let view = arr[1:4]
+  json_inspect(view.clamped_view(start=lo, end=hi).to_owned(), content=[2, 3, 4])
+  inspect(view.clamped_view(start=hi, end=lo).start_offset(), content="4")
+  let bs = b"\x00\x01\x02\x03\x04\x05"
+  inspect(bs.clamped_view(start=lo, end=hi) == bs, content="true")
+  inspect(bs.clamped_view(start=hi, end=lo).length(), content="0")
+  let bv = bs[1:4]
+  inspect(bv.clamped_view(start=lo, end=hi) == bv, content="true")
+  inspect(bv.clamped_view(start=hi, end=lo).start_offset(), content="4")
+}

--- a/builtin/clamped_view_test.mbt
+++ b/builtin/clamped_view_test.mbt
@@ -203,3 +203,115 @@ test "clamped_view saturates at the extremes of Int" {
   inspect(bv.clamped_view(start=lo, end=hi) == bv, content="true")
   inspect(bv.clamped_view(start=hi, end=lo).start_offset(), content="4")
 }
+
+///|
+test "FixedArray::clamped_view clamps out-of-range and inverted offsets" {
+  let arr : FixedArray[Int] = [1, 2, 3, 4, 5]
+  json_inspect(arr.clamped_view().to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=1, end=4).to_owned(), content=[2, 3, 4])
+  json_inspect(arr.clamped_view(end=100).to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=-5).to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=100).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=4, end=1).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=-9, end=-3).to_owned(), content=[])
+  json_inspect(
+    arr.clamped_view(start=@int.MIN_VALUE, end=@int.MAX_VALUE).to_owned(),
+    content=[1, 2, 3, 4, 5],
+  )
+  json_inspect(
+    arr.clamped_view(start=@int.MAX_VALUE, end=@int.MIN_VALUE).to_owned(),
+    content=[],
+  )
+  json_inspect(([] : FixedArray[Int]).clamped_view(end=10).to_owned(), content=[])
+  // empty results sit at the clamped start
+  inspect(arr.clamped_view(start=4, end=1).start_offset(), content="4")
+  inspect(arr.clamped_view(start=100).start_offset(), content="5")
+  inspect(arr.clamped_view(start=-9, end=-3).start_offset(), content="0")
+}
+
+///|
+test "FixedArray::clamped_view aliases the backing array" {
+  let arr : FixedArray[Int] = [1, 2, 3, 4, 5]
+  let v = arr.clamped_view(start=1, end=100)
+  arr[1] = 20
+  json_inspect(v.to_owned(), content=[20, 3, 4, 5])
+}
+
+///|
+test "ReadOnlyArray::clamped_view clamps out-of-range and inverted offsets" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+  json_inspect(arr.clamped_view().to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=1, end=4).to_owned(), content=[2, 3, 4])
+  json_inspect(arr.clamped_view(end=100).to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=-5).to_owned(), content=[1, 2, 3, 4, 5])
+  json_inspect(arr.clamped_view(start=100).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=4, end=1).to_owned(), content=[])
+  json_inspect(arr.clamped_view(start=-9, end=-3).to_owned(), content=[])
+  json_inspect(
+    arr.clamped_view(start=@int.MIN_VALUE, end=@int.MAX_VALUE).to_owned(),
+    content=[1, 2, 3, 4, 5],
+  )
+  json_inspect(
+    arr.clamped_view(start=@int.MAX_VALUE, end=@int.MIN_VALUE).to_owned(),
+    content=[],
+  )
+  json_inspect(([] : ReadOnlyArray[Int]).clamped_view(end=10).to_owned(), content=[])
+  // the `end=None` arm delegates separately; it must clamp `start` too
+  inspect(arr.clamped_view(start=100).start_offset(), content="5")
+  inspect(arr.clamped_view(start=4, end=1).start_offset(), content="4")
+}
+
+///|
+test "clamped_view with `end` omitted forwards `start` unchanged" {
+  // `ReadOnlyArray::clamped_view` handles `end=None` in a separate arm, so an
+  // interior start is what catches a mangled `start` there: 0 / negative /
+  // past-the-end starts all survive a doubled `start`.
+  let ro : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+  let fixed : FixedArray[Int] = [1, 2, 3, 4, 5]
+  json_inspect(ro.clamped_view(start=1).to_owned(), content=[2, 3, 4, 5])
+  json_inspect(fixed.clamped_view(start=1).to_owned(), content=[2, 3, 4, 5])
+  for start in -1..<=6 {
+    // omitting `end` must equal passing the full length explicitly
+    let ro_omitted = ro.clamped_view(start~)
+    let ro_explicit = ro.clamped_view(start~, end=5)
+    json_inspect(
+      ro_omitted.to_owned(),
+      content=ro_explicit.to_owned().to_json(),
+    )
+    inspect(
+      ro_omitted.start_offset() == ro_explicit.start_offset(),
+      content="true",
+    )
+    let fixed_omitted = fixed.clamped_view(start~)
+    let fixed_explicit = fixed.clamped_view(start~, end=5)
+    json_inspect(
+      fixed_omitted.to_owned(),
+      content=fixed_explicit.to_owned().to_json(),
+    )
+    inspect(
+      fixed_omitted.start_offset() == fixed_explicit.start_offset(),
+      content="true",
+    )
+  }
+}
+
+///|
+test "FixedArray/ReadOnlyArray clamped_view agree with get_view" {
+  let fixed : FixedArray[Int] = [1, 2, 3, 4, 5]
+  let ro : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+  for start in -1..<=6 {
+    for end in -1..<=6 {
+      // get_view rejects out-of-range and inverted ranges; clamped_view
+      // answers the same on every range get_view accepts.
+      guard fixed.get_view(start~, end~) is Some(v) else { continue }
+      json_inspect(
+        fixed.clamped_view(start~, end~).to_owned(),
+        content=v.to_owned().to_json(),
+      )
+      json_inspect(
+        ro.clamped_view(start~, end~).to_owned(),
+        content=v.to_owned().to_json(),
+      )
+    }
+  }
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -998,6 +998,7 @@ pub fn FixedArray::blit_from_bytes(Self[Byte], Int, Bytes, Int, Int) -> Unit
 pub fn FixedArray::blit_from_bytesview(Self[Byte], Int, BytesView) -> Unit
 pub fn FixedArray::blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
 pub fn[A] FixedArray::blit_to(Self[A], Self[A], len~ : Int, src_offset? : Int, dst_offset? : Int) -> Unit
+pub fn[T] FixedArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T : Compare] FixedArray::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] FixedArray::contains(Self[T], T) -> Bool
 #alias(clone, deprecated)
@@ -1072,6 +1073,7 @@ pub fn[T : Compare] ReadOnlyArray::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] ReadOnlyArray::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
 pub fn[T] ReadOnlyArray::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[ArrayView[T]] raise?
 pub fn[T] ReadOnlyArray::chunks(Self[T], Int) -> Array[ArrayView[T]]
+pub fn[T] ReadOnlyArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T : Compare] ReadOnlyArray::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] ReadOnlyArray::contains(Self[T], T) -> Bool
 pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -81,6 +81,7 @@ pub fn[A] Array::blit_to(Self[A], Self[A], len? : Int, src_offset? : Int, dst_of
 pub fn[T] Array::capacity(Self[T]) -> Int
 pub fn[T] Array::chunk_by(Self[T], (T, T) -> Bool raise?) -> Self[ArrayView[T]] raise?
 pub fn[T] Array::chunks(Self[T], Int) -> Self[ArrayView[T]]
+pub fn[T] Array::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] Array::clear(Self[T]) -> Unit
 pub fn[T : Compare] Array::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] Array::contains(Self[T], T) -> Bool
@@ -203,6 +204,7 @@ pub fn[T] ArrayView::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int,
 pub fn[A] ArrayView::blit_to(Self[A], Array[A], dst_offset? : Int) -> Unit
 pub fn[T] ArrayView::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[Self[T]] raise?
 pub fn[T] ArrayView::chunks(Self[T], Int) -> Array[Self[T]]
+pub fn[T] ArrayView::clamped_view(Self[T], start? : Int, end? : Int) -> Self[T]
 pub fn[T : Compare] ArrayView::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] ArrayView::contains(Self[T], T) -> Bool
 pub fn[T : Eq] ArrayView::count(Self[T], T) -> Int
@@ -1121,6 +1123,7 @@ pub fn Bytes::add(Bytes, Bytes) -> Bytes
 pub fn Bytes::at(Bytes, Int) -> Byte
 pub fn Bytes::chop_prefix(Bytes, BytesView) -> BytesView?
 pub fn Bytes::chop_suffix(Bytes, BytesView) -> BytesView?
+pub fn Bytes::clamped_view(Bytes, start? : Int, end? : Int) -> BytesView
 pub fn Bytes::compare(Bytes, Bytes) -> Int
 #alias(clone, deprecated)
 #deprecated
@@ -1166,6 +1169,7 @@ pub fn Bytes::view(Bytes, start? : Int, end? : Int) -> BytesView
 pub fn BytesView::at(Self, Int) -> Byte
 pub fn BytesView::chop_prefix(Self, Self) -> Self?
 pub fn BytesView::chop_suffix(Self, Self) -> Self?
+pub fn BytesView::clamped_view(Self, start? : Int, end? : Int) -> Self
 pub fn BytesView::compare(Self, Self) -> Int
 pub fn BytesView::data(Self) -> Bytes
 pub fn BytesView::equal(Self, Self) -> Bool

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -914,6 +914,40 @@ pub fn[T] ReadOnlyArray::get_view(
 }
 
 ///|
+/// Creates a view of a subarray, clamping the requested range instead of
+/// rejecting it. Same contract as `Array::clamped_view`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+///   debug_inspect(
+///     arr.clamped_view(start=3, end=10),
+///     content=(
+///       #|<ArrayView: [4, 5]>
+///     ),
+///   )
+///   debug_inspect(
+///     arr.clamped_view(start=4, end=1),
+///     content=(
+///       #|<ArrayView: []>
+///     ),
+///   )
+/// }
+/// ```
+pub fn[T] ReadOnlyArray::clamped_view(
+  self : ReadOnlyArray[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T] {
+  let fixed = self.unsafe_reinterpret_to_fixed_array()
+  match end {
+    None => fixed.clamped_view(start~)
+    Some(end) => fixed.clamped_view(start~, end~)
+  }
+}
+
+///|
 /// Joins the string-renderable elements with a separator.
 ///
 /// # Example


### PR DESCRIPTION
## What

`clamped_view` is the *total* member of the view family. It already exists for
strings; this PR adds it everywhere else that has `view` and `get_view` but no
total form.

| | bad range |
|---|---|
| `xs[start:end]` (`view`) | aborts |
| `xs.get_view(start~, end~)` | `None` |
| `xs.clamped_view(start~, end~)` | **always succeeds** |

```moonbit
pub fn[T] Array::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
pub fn[T] ArrayView::clamped_view(Self[T], start? : Int, end? : Int) -> Self[T]
pub fn[T] FixedArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
pub fn[T] ReadOnlyArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
pub fn Bytes::clamped_view(Bytes, start? : Int, end? : Int) -> BytesView
pub fn BytesView::clamped_view(Self, start? : Int, end? : Int) -> Self
```

## Contract

- `start` and `end` are each clamped independently into `[0, length()]`.
- An inverted range yields an **empty view at the clamped `start`** — matching
  what `String::clamped_view` does.
- Never aborts and never rejects a range, for any `Int` input including
  `Int::MIN_VALUE` / `Int::MAX_VALUE`.
- View receivers take view-relative offsets and stay inside the parent view.
- The result aliases the backing storage; nothing is copied.

The `String` versions do two things: clamp out-of-range offsets *and* snap
surrogate-splitting offsets inward. These containers carry no encoding
constraint, so they do the clamping half only.

## Implementation

A private `clamp_offset(offset, len)` in `builtin/bounds.mbt` backs them all.
Clamping happens **before** `self.start() + lo`, so no input can produce a
negative length or an offset past the end of the parent view.

```moonbit
let len = self.length()
let lo = clamp_offset(start, len)
let hi = match end {
  None => len
  Some(end) => clamp_offset(end, len)
}
let count = if hi > lo { hi - lo } else { 0 }
ArrayView::make(self.buf(), self.start() + lo, count)
```

`ReadOnlyArray::clamped_view` delegates to `FixedArray::clamped_view` via
`unsafe_reinterpret_to_fixed_array()`, the same way its existing `view` and
`get_view` delegate.

## Tests

Fourteen tests in `builtin/clamped_view_test.mbt` (the existing tests there
cover the `String` versions and are untouched): clamping, inverted ranges, `Int`
extremes, view-relative offsets, nested truncation, `start_offset()` placement
of empty results, aliasing of the backing storage, `end`-omitted delegation, and
enumeration tests asserting `clamped_view` agrees with `get_view` on every range
`get_view` accepts.

Each was mutation-verified rather than merely asserted — failing-test counts
when the implementation is broken on purpose:

| mutation | tests that fail |
|---|---|
| drop the `if hi > lo { … } else { 0 }` guard (negative length) | 8 |
| `clamp_offset` stops clamping negatives | 6 |
| `clamp_offset` stops clamping above `len` | 9 |
| view versions drop the `self.start() +` base | 3 |
| `FixedArray` drops the inverted-range guard | 4 |
| `FixedArray` stops clamping `start` | 2 |
| `ReadOnlyArray` drops `start~` in the `end=None` arm | 1 |
| `ReadOnlyArray` doubles `start` in the `end=None` arm | 1 |

## Validation

Nightly moon `0.1.20260827`. `moon check --deny-warn`, `moon check --target
all`, `moon bundle --all`, `moon fmt` and `moon info --target
wasm,wasm-gc,js,native` all clean; `builtin` tests pass 3008 / 3008 / 2978 /
2967 on wasm / wasm-gc / js / native, and the full suite passed repo-wide on all
four backends for the first commit.

## Review

Both commits reviewed and signed off by Codex CLI.

First commit: *"Approved; no blocking issues found. Clamping precedes
arithmetic, so offsets and lengths stay within valid parent views without
overflow. Defaults, aliasing, inverted-range positioning, `get_view`
equivalence, and the four interface additions match the contract."*

Second commit: *"No blocking issues in the uncommitted diff. `ReadOnlyArray`
correctly forwards `start` in both arms. Omitting `end` produces exactly the
same bounds as explicitly passing `length()`."* It also found a surviving
mutation — the `end=None` arm was only exercised at starts 0, -5 and 100, so a
`start * 2` there passed the suite. The added `end`-omitted test closes that.

Signed-off-by: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4N5Hc1TYuJW5oRDTY19Wf
