### PR TITLE
fix(quickcheck): produce shrink candidates without recursing per block

### DIFF
--- a/quickcheck/shrink/deep_recursion_wbtest.mbt
+++ b/quickcheck/shrink/deep_recursion_wbtest.mbt
@@ -1,0 +1,61 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// The size these tests use. It has to clear the js and wasm-gc stack limits
+/// (both are in the low tens of thousands of frames) while staying small
+/// enough that building one candidate is cheap.
+const DEEP : Int = 20000
+
+///|
+/// `removes_list` recurses once per removed block, and the recursive call sits
+/// in argument position, so the whole descent runs while the iterator is being
+/// built -- before it can yield anything. With `k = 1` that is one frame per
+/// element.
+test "removes_list builds its candidates without recursing per element" {
+  let xs : @list.List[Int] = List(Array::makei(DEEP, i => i))
+  guard removes_list(1, DEEP, xs).next() is Some(candidate) else {
+    abort("expected a candidate")
+  }
+  guard candidate.length() == DEEP - 1 else {
+    abort("expected \{DEEP - 1} elements, got \{candidate.length()}")
+  }
+}
+
+///|
+/// `removes_array` has the same shape. Its candidate order reaches `k = 1`
+/// only at the end of the sequence, so a property test hits this later than it
+/// hits the `List` case, but the recursion depth is the same.
+test "removes_array builds its candidates without recursing per element" {
+  let xs = Array::makei(DEEP, i => i)
+  guard removes_array(1, DEEP, xs).next() is Some(candidate) else {
+    abort("expected a candidate")
+  }
+  guard candidate.length() == DEEP - 1 else {
+    abort("expected \{DEEP - 1} elements, got \{candidate.length()}")
+  }
+}
+
+///|
+/// The user-visible symptom: a property test whose counterexample is a large
+/// list crashes while shrinking instead of reporting the counterexample.
+test "shrinking a large list yields a candidate" {
+  let xs : @list.List[Int] = List(Array::makei(DEEP, i => i))
+  guard Shrink::shrink(xs).next() is Some(candidate) else {
+    abort("expected a candidate")
+  }
+  guard candidate.length() == DEEP - 1 else {
+    abort("expected \{DEEP - 1} elements, got \{candidate.length()}")
+  }
+}

--- a/quickcheck/shrink/deep_recursion_wbtest.mbt
+++ b/quickcheck/shrink/deep_recursion_wbtest.mbt
@@ -19,10 +19,11 @@
 const DEEP : Int = 20000
 
 ///|
-/// `removes_list` recurses once per removed block, and the recursive call sits
-/// in argument position, so the whole descent runs while the iterator is being
-/// built -- before it can yield anything. With `k = 1` that is one frame per
-/// element.
+/// `removes_list` used to recurse once per removed block, with the recursive
+/// call in argument position, so the whole descent ran while the iterator was
+/// being built -- before it could yield anything. With `k = 1` that was one
+/// stack frame per element, and this test overflowed the stack on js, wasm and
+/// wasm-gc.
 test "removes_list builds its candidates without recursing per element" {
   let xs : @list.List[Int] = List(Array::makei(DEEP, i => i))
   guard removes_list(1, DEEP, xs).next() is Some(candidate) else {
@@ -34,9 +35,10 @@ test "removes_list builds its candidates without recursing per element" {
 }
 
 ///|
-/// `removes_array` has the same shape. Its candidate order reaches `k = 1`
-/// only at the end of the sequence, so a property test hits this later than it
-/// hits the `List` case, but the recursion depth is the same.
+/// `removes_array` had the same shape and overflowed the same way. Its
+/// candidate order reaches `k = 1` only at the end of the sequence, so a
+/// property test would have hit this later than it hits the `List` case, but
+/// the depth was the same.
 test "removes_array builds its candidates without recursing per element" {
   let xs = Array::makei(DEEP, i => i)
   guard removes_array(1, DEEP, xs).next() is Some(candidate) else {
@@ -48,8 +50,9 @@ test "removes_array builds its candidates without recursing per element" {
 }
 
 ///|
-/// The user-visible symptom: a property test whose counterexample is a large
-/// list crashes while shrinking instead of reporting the counterexample.
+/// The user-visible symptom this guards against: a property test whose
+/// counterexample was a large list crashed while shrinking instead of
+/// reporting the counterexample.
 test "shrinking a large list yields a candidate" {
   let xs : @list.List[Int] = List(Array::makei(DEEP, i => i))
   guard Shrink::shrink(xs).next() is Some(candidate) else {

--- a/quickcheck/shrink/removes_wbtest.mbt
+++ b/quickcheck/shrink/removes_wbtest.mbt
@@ -1,0 +1,79 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// The block offsets `removes_array` and `removes_list` remove, ascending:
+/// every multiple of `k` that still leaves a whole block inside `n`.
+fn block_offsets(k : Int, n : Int) -> Array[Int] {
+  let offsets = []
+  for start = 0; start + k <= n; start = start + k {
+    offsets.push(start)
+  }
+  offsets
+}
+
+///|
+/// Pins the candidate sequence of `removes_array` so that a change to how the
+/// candidates are produced cannot quietly change which candidates come out, or
+/// in what order. Every `(n, k)` pair up to 24 elements is covered.
+test "removes_array removes one block per offset, ascending" {
+  for n = 0; n <= 24; n = n + 1 {
+    let xs = Array::makei(n, i => i)
+    for k = 1; k <= n; k = k + 1 {
+      let expected = block_offsets(k, n).map(start => {
+        [..xs[:start], ..xs[start + k:]]
+      })
+      let candidates = removes_array(k, n, xs)
+      guard candidates.size_hint() is Some(hint) && hint == expected.length() else {
+        abort(
+          "n=\{n} k=\{k}: wrong size_hint for \{expected.length()} candidates",
+        )
+      }
+      guard candidates.collect() == expected else {
+        abort("n=\{n} k=\{k}: candidates differ")
+      }
+    }
+  }
+}
+
+///|
+/// The same for `removes_list`, whose offsets run the other way.
+test "removes_list removes one block per offset, descending" {
+  for n = 0; n <= 24; n = n + 1 {
+    let xs : @list.List[Int] = List(Array::makei(n, i => i))
+    for k = 1; k <= n; k = k + 1 {
+      let expected = block_offsets(k, n)
+        .rev()
+        .map(start => xs.take(start).concat(xs.drop(start + k)))
+      let candidates = removes_list(k, n, xs)
+      guard candidates.size_hint() is Some(hint) && hint == expected.length() else {
+        abort(
+          "n=\{n} k=\{k}: wrong size_hint for \{expected.length()} candidates",
+        )
+      }
+      guard candidates.collect() == expected else {
+        abort("n=\{n} k=\{k}: candidates differ")
+      }
+    }
+  }
+}
+
+///|
+/// `k` larger than the collection leaves nothing to remove.
+test "removing more than the collection holds yields nothing" {
+  let xs = Array::makei(4, i => i)
+  let ls : @list.List[Int] = List(xs)
+  guard removes_array(5, 4, xs).collect() is [] else { abort("array") }
+  guard removes_list(5, 4, ls).collect() is [] else { abort("list") }
+}

--- a/quickcheck/shrink/utils.mbt
+++ b/quickcheck/shrink/utils.mbt
@@ -25,29 +25,42 @@ fn[T] deferred(f : () -> Iter[T]) -> Iter[T] {
 }
 
 ///|
-/// `n` must be `xs.length()`; the recursive call maintains that, and both
-/// guards below rely on it.
+/// Yields `xs` with one block of `k` consecutive elements removed: one
+/// candidate per block offset `0, k, 2k, ..`, up to the last offset that still
+/// leaves a whole block, in ascending order.
+///
+/// `n` must be `xs.length()`.
 fn[T] removes_array(k : Int, n : Int, xs : Array[T]) -> Iter[Array[T]] {
   guard k <= n else { [||] }
-  // Dropping every element leaves the empty array; taking the `k`-element
-  // prefix first would copy the whole array only to discard it. Past this
-  // guard `xs[k:]` is non-empty.
-  guard k < n else { [|[]|] }
-  let xs2 = xs[:k].to_owned()
-  let xs1 = xs[k:].to_owned()
-  [|xs1|].add(removes_array(k, n - k, xs1).map(x => xs2 + x))
+  let mut start = 0
+  Iter::new(
+    fn() {
+      guard start + k <= n else { None }
+      let candidate = [..xs[:start], ..xs[start + k:]]
+      start += k
+      Some(candidate)
+    },
+    size_hint=(n - k) / k + 1,
+  )
 }
 
 ///|
+/// The `@list.List` counterpart of `removes_array`, except that the offsets
+/// descend: the block nearest the end is removed first.
+///
+/// `n` must be `xs.length()`.
 fn[T] removes_list(k : Int, n : Int, xs : @list.List[T]) -> Iter[@list.List[T]] {
   guard k <= n else { [||] }
-  let xs_drop = xs.drop(k)
-  if xs_drop.is_empty() {
-    [|List([])|]
-  } else {
-    let xs_take = xs.take(k)
-    removes_list(k, n - k, xs_drop).map(x => xs_take.concat(x)).add([|xs_drop|])
-  }
+  let mut start = (n - k) / k * k
+  Iter::new(
+    fn() {
+      guard start >= 0 else { None }
+      let candidate = xs.take(start).concat(xs.drop(start + k))
+      start -= k
+      Some(candidate)
+    },
+    size_hint=(n - k) / k + 1,
+  )
 }
 
 ///|

--- a/quickcheck/shrink_collection_bench_test.mbt
+++ b/quickcheck/shrink_collection_bench_test.mbt
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 ///|
-test "bench shrink Array first candidate size=1000" (it : @bench.T) {
-  let input = Array::make(1000, ())
+test "bench shrink Array first candidate size=10000" (it : @bench.T) {
+  let input = Array::make(10000, ())
   it.bench(fn() { it.keep(@shrink.Shrink::shrink(input).next()) })
 }
 
 ///|
-test "bench shrink List first candidate size=1000" (it : @bench.T) {
-  let input : @list.List[Unit] = List(Array::make(1000, ()))
+test "bench shrink List first candidate size=10000" (it : @bench.T) {
+  let input : @list.List[Unit] = List(Array::make(10000, ()))
   it.bench(fn() { it.keep(@shrink.Shrink::shrink(input).next()) })
 }


### PR DESCRIPTION
Shrinking a large collection crashes with a stack overflow on js, wasm and wasm-gc: a property test whose counterexample is big reports `RangeError: Maximum call stack size exceeded` instead of the counterexample.

Two commits, deliberately in this order.

## `6d03c2ae` — tests against the code as it stands

`removes_wbtest.mbt` pins what `removes_array` and `removes_list` produce — one candidate per block offset that still leaves a whole block, ascending for the array and descending for the list — together with their `size_hint`, for every `(n, k)` with `n <= 24` and `1 <= k <= n`. **It passes on this commit, before any production code changes**, so it is a characterisation of the existing behaviour rather than of the fix.

`deep_recursion_wbtest.mbt` shows the bug, and its three tests fail on this commit on js, wasm and wasm-gc (frames at `quickcheck/shrink/utils.mbt:49`) while passing on native.

## `ff70d6ce` — the fix

Both functions recursed once per removed block, with the recursive call in **argument position** — so the whole descent ran while the iterator was being *built*, before it could yield anything. With `k = 1` that is one stack frame per element. `Shrink for @list.List` asks for `k = 1` first (it iterates `[n/2, .., 1]` through `rev_iter`), so a list crashes on its very first candidate; `Shrink for Array` iterates the same list forward and reaches `k = 1` only at the end of the sequence — same depth, later.

They now walk the offsets with a cursor instead:

```moonbit
// removes_array: start = 0, step +k while start + k <= n
let candidate = [..xs[:start], ..xs[start + k:]]
// removes_list: start = (n - k) / k * k, step -k down to 0
let candidate = xs.take(start).concat(xs.drop(start + k))
```

Building the iterator is O(1) and yielding a candidate uses no stack beyond the call. `removes_wbtest.mbt` is untouched by this commit, which is the evidence that the sequences and hints did not move.

## Where this comes from

`removes_array` / `removes_list` arrived with #3955, transliterated from Haskell QuickCheck's `shrinkList`, where the shape is fine because the recursive call is a thunk and only the consumed elements get forced. In a strict language the same expression means "recurse to the bottom before returning anything". `shr_sub_terms` in the same package has the same origin; #4208 deferred its construction, and making it iterative needs a different fix — out of scope here.

## Numbers

Faster too, because the old form rebuilt each candidate through one `concat` per level on the way back up where the new one does a single `take`/`drop`/`concat`. First candidate from a 10,000-element collection, native release:

| Collection | Before    | After     |
| ---------- | --------: | --------: |
| Array      | 240.69 ns | 288.55 ns |
| List       |   1.32 ms | 213.65 µs |

The array case is a hair slower — it allocates the candidate through an array spread rather than returning a shared empty literal — and in exchange the `k == n` special case added in #4208 is gone, since taking a zero-length prefix already costs nothing. The benchmark also goes back to 10,000 elements; #4208 had to lower it to 1,000 precisely because of this bug.

## Validation

- `moon test -p quickcheck/shrink --target all` 59/59 and `moon test -p quickcheck --target all` 163/163 on wasm, wasm-gc, js and native. On `6d03c2ae` the first command gives 56/59 on the three non-native backends, failing exactly the three deep-recursion tests.
- `moon check --target all`, `moon fmt --check` and `moon info` clean; no `.mbti` diff (both functions are private).
- `moon bench -p quickcheck` passes on all four targets at 10,000 elements.
- Mutation-checked: flipping the list cursor to ascend fails `removes_wbtest.mbt:52`; `size_hint=(n - k) / k + 2` fails `removes_wbtest.mbt:30`.
- Codex CLI signed off on both commits, having built independent models of the old and new implementations and confirmed they agree on ordering and exact counts for all 5,050 valid `(n, k)` pairs through `n = 100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jtBJHK749cpStav5ZMNCr
