### PR TITLE
feat(encoding): add encoding/percent for RFC 3986 URI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changelog should follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Added new `moonbitlang/async` APIs including `@process.spawn`, advisory file locking, `@fs.tmpdir`, `@async.all`, and `@async.any`
 - Added `Array::release_unused(placeholder~)`, which overwrites the unused capacity of an array in place with a placeholder, releasing the elements that earlier removals left there
 - Added `Deque::release_unused(placeholder~)`, which overwrites the unused capacity of a deque in place with a placeholder, releasing the elements that earlier removals left there
+- Added the `encoding/percent` package: RFC 3986 percent-encoding of URI components. `encode` escapes every UTF-8 byte outside the unreserved set as uppercase `%XX` (stricter than JavaScript's `encodeURIComponent`, which keeps `!*'()`), `decode` reverses it and raises `Malformed` on a bad escape or invalid escaped UTF-8, and `decode_lossy` keeps a malformed `%` literally and replaces invalid UTF-8 with U+FFFD
 
 #### Changed
 

--- a/encoding/percent/README.mbt.md
+++ b/encoding/percent/README.mbt.md
@@ -1,0 +1,99 @@
+# Percent Encoding
+
+Package `encoding/percent` implements RFC 3986 percent-encoding for URI
+components: the escaping applied to a single path segment, query value or
+fragment before it is spliced into a URL.
+
+`encode` follows the strict rule of RFC 3986 section 2: the text is converted
+to UTF-8 and every byte outside the unreserved set `A-Z a-z 0-9 - . _ ~` is
+written as `%XX` with uppercase hexadecimal digits. This is the same set that
+Go's `url.PathEscape` and `url.QueryEscape` start from and is slightly
+stricter than JavaScript's `encodeURIComponent`, which leaves `!*'()`
+unescaped. `decode` follows `decodeURIComponent`: every `%XX` is decoded, the
+escaped bytes are interpreted as UTF-8, and malformed input raises.
+
+The package does not parse URLs, does not apply per-component rules such as
+keeping `/` in a path, and does not implement `application/x-www-form-urlencoded`
+(where a space is `+`).
+
+## Encoding
+
+Use `encode` to escape one URI component. A space becomes `%20` and every
+reserved delimiter (`/`, `?`, `#`, `&`, `=`, `:`, `@`, ...) is escaped, so the
+result cannot terminate or split the component it is spliced into. It is still
+the caller's job to reject values such as `.` and `..`, which contain only
+unreserved characters and keep their meaning inside a path.
+
+```mbt check
+///|
+test "encode" {
+  inspect(
+    @percent.encode("Application Support"),
+    content="Application%20Support",
+  )
+  inspect(@percent.encode("a+b/c?d#e&f=g"), content="a%2Bb%2Fc%3Fd%23e%26f%3Dg")
+  inspect(
+    @percent.encode("中文🌙"),
+    content="%E4%B8%AD%E6%96%87%F0%9F%8C%99",
+  )
+}
+```
+
+Unpaired surrogate code units are replaced by U+FFFD, so `encode` never
+raises.
+
+## Decoding
+
+Use `decode` to reverse the escaping. Hexadecimal digits are accepted in
+either case, escapes are decoded exactly once, and unescaped characters,
+including `+` and non-ASCII text, are copied through unchanged.
+
+```mbt check
+///|
+test "decode" {
+  inspect(
+    @percent.decode("Application%20Support"),
+    content="Application Support",
+  )
+  inspect(@percent.decode("%e4%b8%ad%E6%96%87"), content="中文")
+  inspect(@percent.decode("a+b%2520"), content="a+b%20")
+}
+```
+
+## Malformed Input
+
+`decode` raises `Malformed` when a `%` is not followed by two hexadecimal
+digits, or when a run of escaped bytes is not valid UTF-8. The error carries
+the whole input.
+
+```mbt check
+///|
+test "malformed" {
+  try {
+    let _ = @percent.decode("a%zz")
+    panic()
+  } catch {
+    Malformed(input) => inspect(input, content="a%zz")
+  }
+  try {
+    let _ = @percent.decode("%C0%AF")
+    panic()
+  } catch {
+    Malformed(input) => inspect(input, content="%C0%AF")
+  }
+}
+```
+
+`decode_lossy` repairs instead of raising: a malformed `%` is kept literally
+and decoding resumes at the next character, and invalid escaped UTF-8 is
+replaced by U+FFFD. It returns the same string as `decode` whenever `decode`
+succeeds.
+
+```mbt check
+///|
+test "decode_lossy" {
+  inspect(@percent.decode_lossy("a%zz%20b"), content="a%zz b")
+  inspect(@percent.decode_lossy("%2%41"), content="%2A")
+  inspect(@percent.decode_lossy("%C0%AF"), content="\u{FFFD}\u{FFFD}")
+}
+```

--- a/encoding/percent/decode.mbt
+++ b/encoding/percent/decode.mbt
@@ -1,0 +1,121 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Error type for malformed percent-encoded input.
+///
+/// `Malformed(input)` reports that `input` contains a `%` that is not
+/// followed by two hexadecimal digits, or a run of escaped bytes that is not
+/// valid UTF-8.
+pub suberror Malformed {
+  Malformed(StringView)
+} derive(@debug.Debug)
+
+///|
+fn hex_value(code_unit : Int) -> Int {
+  match code_unit {
+    '0'..='9' => code_unit - '0'
+    'a'..='f' => code_unit - 'a' + 10
+    'A'..='F' => code_unit - 'A' + 10
+    _ => -1
+  }
+}
+
+///|
+/// Decodes a percent-encoded URI component back to text.
+///
+/// Every `%XX` escape (hexadecimal digits in either case) is decoded to one
+/// byte, and each maximal run of consecutive escapes is decoded as UTF-8.
+/// Everything else, including unescaped non-ASCII characters, is copied
+/// through unchanged: a `+` stays a `+`, and a byte order mark is kept.
+/// Escapes are decoded exactly once, so `%2520` decodes to `%20`.
+///
+/// Raises `Malformed` if a `%` is not followed by two hexadecimal digits or
+/// if a run of escaped bytes is not valid UTF-8 (truncated or overlong
+/// sequences, encoded surrogates, and code points above U+10FFFF). This is
+/// the input that makes JavaScript's `decodeURIComponent` throw.
+pub fn decode(text : StringView) -> String raise Malformed {
+  match decode_impl(text, lossy=false) {
+    Some(decoded) => decoded
+    None => raise Malformed(text)
+  }
+}
+
+///|
+/// Decodes a percent-encoded URI component, repairing malformed input
+/// instead of raising.
+///
+/// A `%` that is not followed by two hexadecimal digits is kept as a literal
+/// `%` and decoding resumes at the next character, so `%2%41` decodes to
+/// `%2A`. A run of escaped bytes that is not valid UTF-8 is decoded like
+/// `@utf8.decode_lossy`, with each malformed subsequence replaced by U+FFFD.
+/// Whenever `decode` succeeds, `decode_lossy` returns the same string.
+pub fn decode_lossy(text : StringView) -> String {
+  // The implementation only reports failure in strict mode.
+  decode_impl(text, lossy=true).unwrap()
+}
+
+///|
+/// Shared scanner for `decode` and `decode_lossy`. Returns `None` when
+/// `lossy` is false and the input is malformed; with `lossy` set it always
+/// returns `Some`.
+fn decode_impl(text : StringView, lossy~ : Bool) -> String? {
+  let length = text.length()
+  // size_hint is measured in bytes; the output has at most `length` code
+  // units of two bytes each.
+  let builder = StringBuilder(size_hint=2 * length)
+  let bytes = @buffer.Buffer()
+  let mut i = 0
+  // Start of the pending span of literal characters, copied in one piece.
+  let mut literal_start = 0
+  while i < length {
+    if text.unsafe_get(i) != '%' {
+      i += 1
+      continue
+    }
+    builder.write_view(text.view(start_offset=literal_start, end_offset=i))
+    // Collect the maximal run of well-formed escapes into `bytes`.
+    bytes.reset()
+    let mut resume_after_percent = false
+    while i < length && text.unsafe_get(i) == '%' {
+      if i + 2 < length {
+        let hi = hex_value(text.unsafe_get(i + 1).to_int())
+        let lo = hex_value(text.unsafe_get(i + 2).to_int())
+        if hi >= 0 && lo >= 0 {
+          bytes.write_byte(((hi << 4) | lo).to_byte())
+          i += 3
+          continue
+        }
+      }
+      guard lossy else { return None }
+      resume_after_percent = true
+      break
+    }
+    if lossy {
+      builder.write_string(@utf8.decode_lossy(bytes.contents()))
+    } else {
+      let decoded = @utf8.decode(bytes.contents()) catch { _ => return None }
+      builder.write_string(decoded)
+    }
+    if resume_after_percent {
+      // The bytes decoded above precede the malformed escape, whose `%` is
+      // kept literally; scanning resumes at the character after it.
+      builder.write_char('%')
+      i += 1
+    }
+    literal_start = i
+  }
+  builder.write_view(text.view(start_offset=literal_start, end_offset=length))
+  Some(builder.to_string())
+}

--- a/encoding/percent/decode_test.mbt
+++ b/encoding/percent/decode_test.mbt
@@ -1,0 +1,219 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// The `Malformed` payload of `decode(text)`, or `None` when decoding
+/// succeeds.
+fn malformed_input(text : StringView) -> StringView? {
+  try @percent.decode(text) catch {
+    Malformed(input) => Some(input)
+  } noraise {
+    _ => None
+  }
+}
+
+///|
+test "decode well-formed input" {
+  inspect(@percent.decode(""), content="")
+  inspect(@percent.decode("plain"), content="plain")
+  inspect(
+    @percent.decode("Application%20Support"),
+    content="Application Support",
+  )
+  inspect(@percent.decode("%2F%3F%23%26%3D%3A"), content="/?#&=:")
+  inspect(@percent.decode("%00"), content="\u{0}")
+  inspect(@percent.decode("100%25"), content="100%")
+  // Hexadecimal digits in either case.
+  inspect(
+    @percent.decode("%e4%b8%ad%E6%96%87%F0%9F%8C%99"),
+    content="中文🌙",
+  )
+  // Escapes decode exactly once.
+  inspect(@percent.decode("%2520"), content="%20")
+  inspect(@percent.decode("a%20b%2520"), content="a b%20")
+  // Form encoding is not applied: `+` stays `+`.
+  inspect(@percent.decode("a+b%2Bc"), content="a+b+c")
+  // A byte order mark is kept, whether escaped or literal.
+  inspect(
+    @percent.decode("%EF%BB%BFx%EF%BB%BF\u{FEFF}"),
+    content="\u{FEFF}x\u{FEFF}\u{FEFF}",
+  )
+}
+
+///|
+test "literal characters pass through beside escapes" {
+  inspect(@percent.decode("中文%20🌙"), content="中文 🌙")
+  inspect(@percent.decode("é%C3%A9é"), content="ééé")
+  // Non-ASCII lookalikes are not hexadecimal digits.
+  @debug.debug_inspect(
+    malformed_input("%Ａ0"),
+    content=(
+      #|Some(<StringView: "%Ａ0">)
+    ),
+  )
+  // An escape run ends at a literal character, even mid-sequence.
+  @debug.debug_inspect(
+    malformed_input("%C3é"),
+    content=(
+      #|Some(<StringView: "%C3é">)
+    ),
+  )
+}
+
+///|
+test "literal unpaired surrogates are preserved" {
+  let high = (0xD800).unsafe_to_char()
+  let low = (0xDC00).unsafe_to_char()
+  for
+    text in [
+      String::from_array([high]),
+      String::from_array([low]),
+      String::from_array([low, high]),
+      String::from_array([high, high, low]),
+      String::from_array([high, low]),
+    ] {
+    assert_eq(@percent.decode(text), text)
+    assert_eq(@percent.decode_lossy(text), text)
+    let mixed = String::from_array([high, '%', '2', '0', low])
+    let expected = String::from_array([high, ' ', low])
+    assert_eq(@percent.decode(mixed), expected)
+    assert_eq(@percent.decode_lossy(mixed), expected)
+  }
+}
+
+///|
+test "views with a nonzero offset and a truncated escape at the view end" {
+  let text = "xx%20y%41"
+  inspect(@percent.decode(text[2:]), content=" yA")
+  inspect(@percent.decode(text[2:5]), content=" ")
+  // The digit after the view must not be read.
+  @debug.debug_inspect(
+    malformed_input(text[2:4]),
+    content=(
+      #|Some(<StringView: "%2">)
+    ),
+  )
+  inspect(@percent.decode_lossy(text[2:4]), content="%2")
+  @debug.debug_inspect(
+    malformed_input(text[6:8]),
+    content=(
+      #|Some(<StringView: "%4">)
+    ),
+  )
+}
+
+///|
+test "malformed escapes and escaped UTF-8 raise with the whole input" {
+  for
+    malformed in [
+      "%", "%2", "%zz", "%0g", "%g0", "%%41", "%2%41", "%80", "%BF", "%C0%AF", "%C1%BF",
+      "%C2", "%C2x%A0", "%E0%80%AF", "%E1%80", "%E1%80%41", "%E2x%82%AC", "%ED%A0%80",
+      "%ED%BF%BF", "%E2%82", "%F0%80%80%AF", "%F4%90%80%80", "%F5%80%80%80", "%FF",
+    ] {
+    // Earlier valid escapes must not leak into the error.
+    let input = "prefix%20\{malformed}%20suffix"
+    try @percent.decode(input) catch {
+      Malformed(reported) => assert_eq(reported, input)
+    } noraise {
+      decoded => fail("decoded \{input} as \{decoded}")
+    }
+  }
+}
+
+///|
+test "Malformed payload and Debug rendering" {
+  let text = "ab%zzcd"
+  try {
+    let _ = @percent.decode(text[1:])
+    panic()
+  } catch {
+    err => {
+      @debug.debug_inspect(
+        err,
+        content=(
+          #|Malformed(<StringView: "b%zzcd">)
+        ),
+      )
+      match err {
+        Malformed(view) => {
+          assert_eq(view.start_offset(), 1)
+          assert_eq(view.length(), 6)
+        }
+      }
+    }
+  }
+}
+
+///|
+test "decode_lossy keeps a malformed % and resumes right after it" {
+  inspect(@percent.decode_lossy("%"), content="%")
+  inspect(@percent.decode_lossy("%2"), content="%2")
+  inspect(@percent.decode_lossy("%zz"), content="%zz")
+  inspect(@percent.decode_lossy("%%41"), content="%A")
+  inspect(@percent.decode_lossy("%2%41"), content="%2A")
+  inspect(@percent.decode_lossy("a%20b%zz"), content="a b%zz")
+  inspect(@percent.decode_lossy("%41%zz%42"), content="A%zzB")
+  inspect(@percent.decode_lossy("100%"), content="100%")
+  inspect(@percent.decode_lossy("%%%"), content="%%%")
+}
+
+///|
+test "decode_lossy replaces invalid escaped UTF-8 with U+FFFD" {
+  inspect(@percent.decode_lossy("%80"), content="\u{FFFD}")
+  inspect(@percent.decode_lossy("%E1%80"), content="\u{FFFD}")
+  inspect(
+    @percent.decode_lossy("%ED%A0%80"),
+    content="\u{FFFD}\u{FFFD}\u{FFFD}",
+  )
+  inspect(@percent.decode_lossy("%C0%AF"), content="\u{FFFD}\u{FFFD}")
+  inspect(
+    @percent.decode_lossy("%F4%90%80%80"),
+    content="\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}",
+  )
+  inspect(@percent.decode_lossy("%C3é"), content="\u{FFFD}é")
+  inspect(
+    @percent.decode_lossy("%E2x%82%AC"),
+    content="\u{FFFD}x\u{FFFD}\u{FFFD}",
+  )
+  inspect(@percent.decode_lossy("%E1%80%41"), content="\u{FFFD}A")
+  // Bytes before a malformed escape are still decoded as their own run.
+  inspect(@percent.decode_lossy("%C3%A9%zz%C3"), content="é%zz\u{FFFD}")
+  inspect(@percent.decode_lossy("%C3%zz%A9"), content="\u{FFFD}%zz\u{FFFD}")
+}
+
+///|
+test "decode_lossy agrees with decode on well-formed input" {
+  for
+    text in [
+      "", "plain", "Application%20Support", "%e4%b8%ad%E6%96%87%F0%9F%8C%99", "中文%20🌙",
+      "a+b%2Bc", "%2520", "%EF%BB%BFx%EF%BB%BF", "%00", "%2F%3F%23%26%3D%3A",
+    ] {
+    assert_eq(@percent.decode_lossy(text), @percent.decode(text))
+  }
+}
+
+///|
+test "round trip" {
+  for
+    text in [
+      "", "Application Support", "中文🌙", "a+b/c?d#e&f=g", "100%", "\u{0}\u{7F}\u{80}\u{7FF}\u{800}\u{D7FF}\u{E000}\u{FFFF}\u{10000}\u{10FFFF}",
+      "\u{FEFF}BOM", "%zz",
+    ] {
+    assert_eq(@percent.decode(@percent.encode(text)), text)
+  }
+  for code in 0..<128 {
+    let text = code.unsafe_to_char().to_string()
+    assert_eq(@percent.decode(@percent.encode(text)), text)
+  }
+}

--- a/encoding/percent/encode.mbt
+++ b/encoding/percent/encode.mbt
@@ -1,0 +1,101 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+const HEX_UPPER : Bytes = b"0123456789ABCDEF"
+
+///|
+/// The RFC 3986 unreserved set (section 2.3): the only bytes that `encode`
+/// emits literally.
+fn is_unreserved(code_unit : Int) -> Bool {
+  match code_unit {
+    'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~' => true
+    _ => false
+  }
+}
+
+///|
+fn write_escape(builder : StringBuilder, byte : Int) -> Unit {
+  builder.write_char('%')
+  builder.write_char(HEX_UPPER[(byte >> 4) & 0x0F].to_char())
+  builder.write_char(HEX_UPPER[byte & 0x0F].to_char())
+}
+
+///|
+/// Percent-encodes a string as a single URI component (RFC 3986).
+///
+/// The text is converted to UTF-8 and every byte outside the unreserved set
+/// `A-Z a-z 0-9 - . _ ~` is written as `%XX` with uppercase hexadecimal
+/// digits; the unreserved bytes are copied through unchanged. A space becomes
+/// `%20`, never `+`. An unpaired surrogate code unit encodes as U+FFFD
+/// (`%EF%BF%BD`), so `encode` never raises.
+///
+/// This is stricter than JavaScript's `encodeURIComponent`, which leaves
+/// `!*'()` unescaped: those five characters are reserved sub-delimiters in
+/// RFC 3986 and are escaped here.
+pub fn encode(text : StringView) -> String {
+  // size_hint is measured in bytes: an ASCII input that needs no escaping
+  // produces `text.length()` code units of two bytes each.
+  let builder = StringBuilder(size_hint=2 * text.length())
+  let length = text.length()
+  let mut i = 0
+  // Start of the pending run of unreserved characters, copied in one piece.
+  let mut literal_start = 0
+  while i < length {
+    let unit = text.unsafe_get(i).to_int()
+    if unit < 0x80 {
+      if is_unreserved(unit) {
+        i += 1
+        continue
+      }
+      builder.write_view(text.view(start_offset=literal_start, end_offset=i))
+      write_escape(builder, unit)
+      i += 1
+    } else {
+      builder.write_view(text.view(start_offset=literal_start, end_offset=i))
+      if unit < 0x800 {
+        write_escape(builder, 0xC0 | (unit >> 6))
+        write_escape(builder, 0x80 | (unit & 0x3F))
+        i += 1
+      } else if unit.is_leading_surrogate() &&
+        i + 1 < length &&
+        text.unsafe_get(i + 1).is_trailing_surrogate() {
+        let low = text.unsafe_get(i + 1).to_int()
+        let code_point = 0x10000 + ((unit - 0xD800) << 10) + (low - 0xDC00)
+        write_escape(builder, 0xF0 | (code_point >> 18))
+        write_escape(builder, 0x80 | ((code_point >> 12) & 0x3F))
+        write_escape(builder, 0x80 | ((code_point >> 6) & 0x3F))
+        write_escape(builder, 0x80 | (code_point & 0x3F))
+        i += 2
+      } else {
+        // Either a BMP scalar value or an unpaired surrogate, which is
+        // replaced by U+FFFD (0xEF 0xBF 0xBD) like `@utf8.encode` does on
+        // the JavaScript backend.
+        let scalar = if unit.is_leading_surrogate() ||
+          unit.is_trailing_surrogate() {
+          0xFFFD
+        } else {
+          unit
+        }
+        write_escape(builder, 0xE0 | (scalar >> 12))
+        write_escape(builder, 0x80 | ((scalar >> 6) & 0x3F))
+        write_escape(builder, 0x80 | (scalar & 0x3F))
+        i += 1
+      }
+    }
+    literal_start = i
+  }
+  builder.write_view(text.view(start_offset=literal_start, end_offset=length))
+  builder.to_string()
+}

--- a/encoding/percent/encode_test.mbt
+++ b/encoding/percent/encode_test.mbt
@@ -1,0 +1,118 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "unreserved characters are copied through" {
+  let unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+  inspect(@percent.encode(unreserved) == unreserved, content="true")
+  inspect(@percent.encode(""), content="")
+}
+
+///|
+test "every other ASCII character escapes with uppercase hex" {
+  let builder = StringBuilder()
+  for code in 0..<128 {
+    let ch = code.unsafe_to_char()
+    let encoded = @percent.encode(ch.to_string())
+    if ch is ('A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~') {
+      assert_eq(encoded, ch.to_string())
+    } else {
+      assert_eq(encoded.length(), 3)
+      assert_eq(encoded[0], '%')
+      builder.write_string(encoded)
+    }
+  }
+  inspect(
+    builder.to_string(),
+    content=(
+      #|%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E%60%7B%7C%7D%7F
+    ),
+  )
+}
+
+///|
+test "space is %20 and reserved delimiters are escaped" {
+  inspect(@percent.encode("a b"), content="a%20b")
+  inspect(@percent.encode("a+b/c?d#e&f=g"), content="a%2Bb%2Fc%3Fd%23e%26f%3Dg")
+  inspect(@percent.encode("100%"), content="100%25")
+  // Stricter than JavaScript's encodeURIComponent, which keeps `!*'()`.
+  inspect(@percent.encode("!'()*"), content="%21%27%28%29%2A")
+}
+
+///|
+test "non-ASCII text is UTF-8 encoded" {
+  inspect(@percent.encode("é"), content="%C3%A9")
+  inspect(
+    @percent.encode("中文🌙"),
+    content="%E4%B8%AD%E6%96%87%F0%9F%8C%99",
+  )
+  inspect(@percent.encode("\u{7F}\u{80}"), content="%7F%C2%80")
+  inspect(@percent.encode("\u{7FF}\u{800}"), content="%DF%BF%E0%A0%80")
+  inspect(@percent.encode("\u{D7FF}\u{E000}"), content="%ED%9F%BF%EE%80%80")
+  inspect(@percent.encode("\u{FFFF}\u{10000}"), content="%EF%BF%BF%F0%90%80%80")
+  inspect(@percent.encode("\u{10FFFF}"), content="%F4%8F%BF%BF")
+  inspect(@percent.encode("\u{FEFF}x"), content="%EF%BB%BFx")
+  inspect(@percent.encode("\u{0}"), content="%00")
+}
+
+///|
+test "unpaired surrogates encode as U+FFFD" {
+  let high = (0xD800).unsafe_to_char()
+  let low = (0xDC00).unsafe_to_char()
+  inspect(@percent.encode(String::from_array([high])), content="%EF%BF%BD")
+  inspect(@percent.encode(String::from_array([low])), content="%EF%BF%BD")
+  // Reversed order is two unpaired surrogates, not a pair.
+  inspect(
+    @percent.encode(String::from_array([low, high])),
+    content="%EF%BF%BD%EF%BF%BD",
+  )
+  inspect(
+    @percent.encode(String::from_array([high, high, low])),
+    content="%EF%BF%BD%F0%90%80%80",
+  )
+  inspect(
+    @percent.encode(String::from_array([high, 'A', low, 'b'])),
+    content="%EF%BF%BDA%EF%BF%BDb",
+  )
+  // A high surrogate at the end of the view has nothing to pair with.
+  let text = String::from_array([high, low])
+  inspect(@percent.encode(text.view(end_offset=1)), content="%EF%BF%BD")
+  inspect(@percent.encode(text), content="%F0%90%80%80")
+}
+
+///|
+test "views with a nonzero offset" {
+  let text = "xx中 y"
+  inspect(@percent.encode(text[2:]), content="%E4%B8%AD%20y")
+  inspect(@percent.encode(text[2:3]), content="%E4%B8%AD")
+  inspect(@percent.encode(text[3:4]), content="%20")
+}
+
+///|
+test "long alternating literal and escaped spans" {
+  let builder = StringBuilder()
+  let expected = StringBuilder()
+  for i in 0..<300 {
+    builder.write_string("ab")
+    expected.write_string("ab")
+    if i % 2 == 0 {
+      builder.write_string(" ")
+      expected.write_string("%20")
+    } else {
+      builder.write_string("é")
+      expected.write_string("%C3%A9")
+    }
+  }
+  assert_eq(@percent.encode(builder.to_string()), expected.to_string())
+}

--- a/encoding/percent/extends.mbt
+++ b/encoding/percent/extends.mbt
@@ -1,0 +1,20 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --- deprecated: hidden from the generated interface ---
+
+///|
+#deprecated("Use `Debug::to_repr` instead", skip_current_package=true)
+#doc(hidden)
+pub extend Malformed with @debug.Debug::{to_repr}

--- a/encoding/percent/moon.pkg
+++ b/encoding/percent/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/builtin",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8",
+}
+
+import {
+  "moonbitlang/core/quickcheck",
+  "moonbitlang/core/quickcheck/shrink",
+} for "test"

--- a/encoding/percent/pkg.generated.mbti
+++ b/encoding/percent/pkg.generated.mbti
@@ -1,0 +1,24 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/core/encoding/percent"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn decode(StringView) -> String raise Malformed
+
+pub fn decode_lossy(StringView) -> String
+
+pub fn encode(StringView) -> String
+
+// Errors
+pub suberror Malformed {
+  Malformed(StringView)
+} derive(@debug.Debug)
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/encoding/percent/quickcheck_test.mbt
+++ b/encoding/percent/quickcheck_test.mbt
@@ -1,0 +1,157 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Randomized properties for the percent codec, checked against independent
+// reference models. `encode` replaces unpaired surrogates, so the round-trip
+// property compares against a UTF-16 repair oracle rather than the input.
+
+///|
+/// Replaces every unpaired surrogate code unit with U+FFFD and keeps
+/// everything else, including well-formed pairs, unchanged.
+fn repair_utf16(text : String) -> String {
+  let units = text.code_units()
+  let out = StringBuilder(size_hint=2 * units.length())
+  let mut i = 0
+  while i < units.length() {
+    let unit = units[i]
+    if unit.is_leading_surrogate() &&
+      i + 1 < units.length() &&
+      units[i + 1].is_trailing_surrogate() {
+      let code_point = 0x10000 +
+        ((unit.to_int() - 0xD800) << 10) +
+        (units[i + 1].to_int() - 0xDC00)
+      out.write_char(code_point.unsafe_to_char())
+      i += 2
+    } else if unit.is_leading_surrogate() || unit.is_trailing_surrogate() {
+      out.write_char('\u{FFFD}')
+      i += 1
+    } else {
+      out.write_char(unit.to_int().unsafe_to_char())
+      i += 1
+    }
+  }
+  out.to_string()
+}
+
+///|
+/// Escapes every byte of the repaired text's UTF-8 form that is not in the
+/// unreserved set, one byte at a time.
+fn reference_encode(text : String) -> String {
+  let digits = "0123456789ABCDEF"
+  let out = StringBuilder()
+  for byte in @utf8.encode(repair_utf16(text)) {
+    let n = byte.to_int()
+    if n < 0x80 &&
+      n.unsafe_to_char()
+      is ('A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~') {
+      out.write_char(n.unsafe_to_char())
+    } else {
+      out.write_char('%')
+      out.write_char(digits.get_char(n >> 4).unwrap())
+      out.write_char(digits.get_char(n & 0x0F).unwrap())
+    }
+  }
+  out.to_string()
+}
+
+///|
+/// Strings whose code units are drawn from a small alphabet that mixes
+/// unreserved characters, `%`, hexadecimal digits, non-ASCII characters and
+/// both surrogate halves, so malformed escapes and unpaired surrogates are
+/// frequent.
+priv struct Spiky(String) derive(@debug.Debug)
+
+///|
+let spiky_alphabet : Array[Int] = [
+  'a', 'Z', '0', '-', '~', '%', '2', 'F', 'g', ' ', '+', 'é', '中', 0xFEFF, 0xFFFD,
+  0xD800, 0xDBFF, 0xDC00, 0xDFFF, 0x1F319,
+]
+
+///|
+impl @quickcheck.Arbitrary for Spiky with fn arbitrary(size, state) {
+  let len = if size == 0 { 0 } else { state.next_positive_int() % size }
+  let out = StringBuilder()
+  for _ in 0..<len {
+    let unit = spiky_alphabet[state.next_positive_int() %
+      spiky_alphabet.length()]
+    out.write_char(unit.unsafe_to_char())
+  }
+  Spiky(out.to_string())
+}
+
+///|
+impl @shrink.Shrink for Spiky with fn shrink(self) {
+  // Drop one code unit at a time so a counterexample stays in the alphabet.
+  let units = self.0.code_units()
+  let candidates = []
+  for i in 0..<units.length() {
+    let out = StringBuilder()
+    for j in 0..<units.length() {
+      if j != i {
+        out.write_char(units[j].to_int().unsafe_to_char())
+      }
+    }
+    candidates.push(Spiky(out.to_string()))
+  }
+  candidates.iter()
+}
+
+///|
+test "quickcheck: encode matches the reference and round-trips through decode" {
+  @quickcheck.check(
+    (text : String) => {
+      let encoded = @percent.encode(text)
+      encoded == reference_encode(text) &&
+      encoded.iter().all(c => c.to_int() < 0x80) &&
+      @percent.decode(encoded) == repair_utf16(text)
+    },
+    count=200,
+  )
+  @quickcheck.check(
+    (input : Spiky) => {
+      let text = input.0
+      let encoded = @percent.encode(text)
+      encoded == reference_encode(text) &&
+      @percent.decode(encoded) == repair_utf16(text) &&
+      @percent.decode_lossy(encoded) == repair_utf16(text)
+    },
+    count=300,
+  )
+}
+
+///|
+test "quickcheck: decode_lossy agrees with decode whenever decode succeeds" {
+  @quickcheck.check(
+    (input : Spiky) => {
+      try @percent.decode(input.0) catch {
+        Malformed(reported) => reported == input.0
+      } noraise {
+        decoded => @percent.decode_lossy(input.0) == decoded
+      }
+    },
+    count=300,
+  )
+}
+
+///|
+test "quickcheck: decoding never changes text without escapes" {
+  @quickcheck.check(
+    (input : Spiky) => {
+      let text = input.0
+      text.contains("%") ||
+      (@percent.decode(text) == text && @percent.decode_lossy(text) == text)
+    },
+    count=200,
+  )
+}


### PR DESCRIPTION
## Summary

Adds `encoding/percent`, a string-to-string RFC 3986 percent-encoding codec for URI components, so applications stop hand-rolling it or shimming JavaScript's `encodeURIComponent` / `decodeURIComponent` (see moonbitlang/openseek#1408, which replaced those shims with a pure MoonBit `desktop/internal/uri` package).

```
pub fn encode(StringView) -> String
pub fn decode(StringView) -> String raise Malformed
pub fn decode_lossy(StringView) -> String
pub suberror Malformed { Malformed(StringView) } derive(@debug.Debug)
```

- `encode` converts the text to UTF-8 and escapes every byte outside the RFC 3986 unreserved set `A-Z a-z 0-9 - . _ ~` as uppercase `%XX`. A space is `%20`, never `+`. It is stricter than `encodeURIComponent`, which leaves `!*'()` unescaped. It walks UTF-16 code units itself and replaces an unpaired surrogate with U+FFFD, because `@utf8.encode` panics on one on the non-JS backends; so `encode` never raises.
- `decode` decodes every `%XX` (either hex case) exactly once, interprets each maximal escape run as UTF-8, copies literal code units through unchanged (including `+`, BOMs and unpaired surrogates), and raises `Malformed` with the whole input on a bad escape or invalid escaped UTF-8. This is the input that makes `decodeURIComponent` throw.
- `decode_lossy` keeps a malformed `%` literally and resumes at the next code unit (`%2%41` → `%2A`), and replaces invalid escaped UTF-8 with U+FFFD via `@utf8.decode_lossy`. It returns the same string as `decode` whenever `decode` succeeds.

Deliberately out of scope for this first version, documented in the README: byte-level entry points, per-component presets (path / query), `application/x-www-form-urlencoded`, and URL parsing. All can be added later without breaking these signatures.

## Design notes

- Literal spans are sliced with `StringView::view`, which checks bounds but not surrogate boundaries, so a view that splits a pair is handled instead of aborting.
- `Malformed` carries the whole input view, matching `encoding/hex` and `encoding/base64`.
- The escape-run approach (rather than UTF-8 encoding the entire input then decoding once) is what preserves literal unpaired surrogates.

## Testing

- `moon test -p encoding/percent --target all`: 24/24 on wasm, wasm-gc, js, native.
- `moon check --deny-warn --target all`, `moon info`, `moon fmt`: clean. `moon coverage analyze` reports no uncovered lines in the package.
- Tests cover the full ASCII table, every UTF-8 length boundary, surrogate pairing and ordering, nonzero-offset views (including a view ending in `%2` with a digit right after it), the malformed-escape and invalid-UTF-8 table from openseek, lossy replacement counts, and quickcheck properties against an independent UTF-16 repair oracle and a byte-at-a-time reference encoder.
- Mutation check: ten single-point mutations (drop surrogate replacement, lowercase hex, wrong 2-byte boundary, read past view end, lossy resume drops `%` / skips 3, no buffer reset between runs, strict path using lossy UTF-8, `!` unreserved, missing literal flush) each fail between 2 and 8 of the 24 tests.

## Review

Codex CLI reviewed the design (two blockers, both addressed: backend-independent surrogate policy; exact lossy consumption rule) and then the implementation: "No blocking issues found ... An independent transcription check passed for every code point and surrogate pair."

Signed-off-by: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVKQs2BgHmc3VBDXBU8AgD
