### PR TITLE
feat(builtin)!: clamp bracket slicing bounds

### DIFF
--- a/array/README.mbt.md
+++ b/array/README.mbt.md
@@ -86,10 +86,15 @@ test "sorting" {
 
 ## Array Views
 
-Array views provide a lightweight way to work with array slices.
-Use `arr.exact_view(start~, end~)` to validate bounds, `arr.get_view(start~, end~)`
-to return `None` for invalid bounds, or `arr.clamped_view(start~, end~)` to clamp
-them. The old `view` and `sub` names are deprecated in favor of `exact_view`.
+Array views provide a lightweight way to work with array slices. The
+`arr[start:end]` syntax clamps each bound to `[0, arr.length()]`; negative
+bounds clamp to zero and inverted ranges produce empty views. Omitting either
+bound uses the corresponding end of the array. These rules also apply to
+`FixedArray`, `ReadOnlyArray`, `ArrayView`, and `MutArrayView`, with offsets
+relative to the current view. Use `arr.exact_view(start~, end~)` to require valid
+bounds, or `arr.get_view(start~, end~)` to return `None` for invalid bounds on
+types that provide it. The old `view` and `sub` names are deprecated in favor
+of `exact_view`.
 
 ```mbt check
 ///|

--- a/builtin/README.mbt.md
+++ b/builtin/README.mbt.md
@@ -206,9 +206,11 @@ owners.str -> views.strview: "s[start:end]"
 
 Views are ideal for rest patterns (`[first, .. rest]`) and for passing
 sub-sequences without allocation; functions taking a view also accept the
-owning container through implicit conversion. Note that the `s[start:end]`
-slice syntax on `String` panics when a boundary would split a UTF-16
-surrogate pair:
+owning container through implicit conversion. Bracket slices clamp bounds to
+the container or view, with negative bounds clamped to zero and inverted
+ranges producing empty views. String slices use UTF-16 code-unit offsets and
+trim split surrogate pairs inward. Use the named `exact_view` methods to require
+valid bounds; `split_at` provides a lossless string split.
 
 ```mbt check
 ///|

--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -797,12 +797,12 @@ pub fn[T] Array::rev(self : Array[T]) -> Array[T] {
 /// ```mbt check
 /// test {
 ///   let v = [3, 4, 5]
-///   let (v1, v2) = (v[:1], v[1:])
+///   let (v1, v2) = (v.exact_view(end=1), v.exact_view(start=1))
 ///   @test.assert_eq(v1, [3])
 ///   @test.assert_eq(v2, [4, 5])
 /// }
 /// ```
-#deprecated("Use ArrayView instead, e.g, (a[:index], a[index:])")
+#deprecated("Use ArrayView instead, e.g, (a.exact_view(end=index), a.exact_view(start=index))")
 #doc(hidden)
 pub fn[T] Array::split_at(self : Array[T], index : Int) -> (Array[T], Array[T]) {
   if index < 0 || index > self.length() {

--- a/builtin/array_block.mbt
+++ b/builtin/array_block.mbt
@@ -174,7 +174,7 @@ test "panic Array::blit_to/boundary_cases1" {
   let dst = [0, 0, 0, 0, 0]
 
   // Invalid range (start > end will panic)
-  ignore(src[3:1].blit_to(dst))
+  ignore(src.exact_view(start=3, end=1).blit_to(dst))
 }
 
 ///|
@@ -182,7 +182,7 @@ test "panic Array::blit_to/boundary_cases2" {
   let src = [1, 2, 3, 4, 5]
   let dst = [0, 0, 0, 0, 0]
   // Invalid src_offset (negative index in view creation will panic)
-  ignore(src[-1:1].blit_to(dst))
+  ignore(src.exact_view(start=-1, end=1).blit_to(dst))
 }
 
 ///|
@@ -190,7 +190,7 @@ test "panic Array::blit_to/boundary_cases3" {
   let src = [1, 2, 3, 4, 5]
   let dst = [0, 0, 0, 0, 0]
   // len exceeding src length
-  ignore(src[0:6].blit_to(dst))
+  ignore(src.exact_view(start=0, end=6).blit_to(dst))
 }
 
 ///|

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -264,13 +264,12 @@ pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
 /// ```mbt check
 /// test {
 ///   let arr = [1, 2, 3, 4, 5]
-///   let view = arr[1:4] // Create a view of elements at indices 1, 2, and 3
+///   let view = arr.exact_view(start=1, end=4)
 ///   inspect(view[0], content="2") // First element of view is arr[1]
 ///   inspect(view.length(), content="3") // View contains 3 elements
 /// }
 /// ```
 #intrinsic("%array.view")
-#alias("_[_:_]")
 #alias(view, deprecated="Use `exact_view` instead")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn[T] Array::exact_view(
@@ -360,12 +359,11 @@ pub fn[T] Array::get_view(
 /// test {
 ///   let arr = [1, 2, 3, 4, 5]
 ///   let view = arr[1:4] // view = [2, 3, 4]
-///   let subview = view[1:2] // subview = [3]
+///   let subview = view.exact_view(start=1, end=2) // subview = [3]
 ///   inspect(subview[0], content="3")
 /// }
 /// ```
 #intrinsic("%arrayview.view")
-#alias("_[_:_]")
 #alias(view, deprecated="Use `exact_view` instead")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn[T] ArrayView::exact_view(
@@ -450,8 +448,8 @@ pub fn[T] ArrayView::get_view(
 ///
 /// Returns an `ArrayView` over the clamped range.
 ///
-/// See `arr[start:end]` for the aborting variant and `Array::get_view` for the
-/// exact `Option`-returning variant.
+/// Also available as `arr[start:end]`. See `Array::exact_view` for the aborting
+/// variant and `Array::get_view` for the exact `Option`-returning variant.
 ///
 /// Example:
 ///
@@ -478,6 +476,7 @@ pub fn[T] ArrayView::get_view(
 ///   )
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn[T] Array::clamped_view(
   self : Array[T],
   start? : Int = 0,
@@ -497,6 +496,7 @@ pub fn[T] Array::clamped_view(
 /// Creates a new view into a portion of the array view, clamping the requested
 /// range instead of rejecting it. The indices are relative to the start of the
 /// current view; same contract as `Array::clamped_view`.
+/// Also available as `view[start:end]`. Use `ArrayView::exact_view` to validate bounds.
 ///
 /// Example:
 ///
@@ -517,6 +517,7 @@ pub fn[T] Array::clamped_view(
 ///   )
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn[T] ArrayView::clamped_view(
   self : ArrayView[T],
   start? : Int = 0,
@@ -561,12 +562,11 @@ fn[T] unsafe_cast_fixedarray_to_uninitializedarray(
 /// ```mbt check
 /// test {
 ///   let arr : FixedArray[Int] = [1, 2, 3, 4, 5]
-///   let view = arr[1:4] // view = [2, 3, 4]
+///   let view = arr.exact_view(start=1, end=4) // view = [2, 3, 4]
 ///   inspect(view[0], content="2")
 /// }
 /// ```
 #intrinsic("%fixedarray.view")
-#alias("_[_:_]")
 #alias(view, deprecated="Use `exact_view` instead")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn[T] FixedArray::exact_view(
@@ -642,6 +642,7 @@ pub fn[T] FixedArray::get_view(
 ///|
 /// Creates a view of a portion of the fixed array, clamping the requested
 /// range instead of rejecting it. Same contract as `Array::clamped_view`.
+/// Also available as `arr[start:end]`. Use `FixedArray::exact_view` to validate bounds.
 ///
 /// Example:
 ///
@@ -662,6 +663,7 @@ pub fn[T] FixedArray::get_view(
 ///   )
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn[T] FixedArray::clamped_view(
   self : FixedArray[T],
   start? : Int = 0,

--- a/builtin/arrayview_test.mbt
+++ b/builtin/arrayview_test.mbt
@@ -31,25 +31,25 @@ test "get" {
 ///|
 test "panic negative index1" {
   let arr = [1, 2, 3]
-  let _ = arr[-4:]
+  let _ = arr.exact_view(start=-4)
 }
 
 ///|
 test "panic negative index2" {
   let arr = [1, 2, 3]
-  let _ = arr[:-4]
+  let _ = arr.exact_view(end=-4)
 }
 
 ///|
 test "panic negative index3" {
   let arr = [1, 2, 3]
-  let _ = arr[-1:-2]
+  let _ = arr.exact_view(start=-1, end=-2)
 }
 
 ///|
 test "panic negative index4" {
   let arr = [1, 2, 3]
-  let _ = arr[-1:-3]
+  let _ = arr.exact_view(start=-1, end=-3)
 }
 
 ///|
@@ -60,9 +60,9 @@ test "ArrayView::start_offset" {
 }
 
 ///|
-test "panic FixedArray sub invalid range" {
+test "panic FixedArray view invalid range" {
   let arr : FixedArray[Int] = [1, 2, 3]
-  let _ = arr[2:1]
+  let _ = arr.exact_view(start=2, end=1)
 }
 
 ///|
@@ -75,25 +75,25 @@ test "ArrayView equality mismatch" {
 ///|
 test "panic negative index5" {
   let arr = [1, 2, 3][:]
-  let _ = arr[-4:]
+  let _ = arr.exact_view(start=-4)
 }
 
 ///|
 test "panic negative index6" {
   let arr = [1, 2, 3][:]
-  let _ = arr[:-4]
+  let _ = arr.exact_view(end=-4)
 }
 
 ///|
 test "panic negative index7" {
   let arr = [1, 2, 3][:]
-  let _ = arr[-1:-2]
+  let _ = arr.exact_view(start=-1, end=-2)
 }
 
 ///|
 test "panic negative index8" {
   let arr = [1, 2, 3][:]
-  let _ = arr[-1:-3]
+  let _ = arr.exact_view(start=-1, end=-3)
 }
 
 ///|

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -164,13 +164,14 @@ pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {
 
 ///|
 /// Creates a new `View` from the given `Bytes`.
+/// Panics unless `0 <= start <= end <= length()`.
 /// 
 /// # Example
 /// 
 /// ```mbt check
 /// test {
 ///   let bs = b"\x00\x01\x02\x03\x04\x05"
-///   let bv = bs[1:4]
+///   let bv = bs.exact_view(start=1, end=4)
 ///   inspect(bv.length(), content="3")
 ///   @test.assert_eq(bv[0], b'\x01')
 ///   @test.assert_eq(bv[1], b'\x02')
@@ -178,7 +179,6 @@ pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {
 /// }
 /// ```
 #intrinsic("%bytes.view")
-#alias("_[_:_]")
 #alias(view, deprecated="Use `exact_view` instead")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn Bytes::exact_view(
@@ -198,7 +198,7 @@ pub fn Bytes::exact_view(
 
 ///|
 /// Returns a view of the bytes between `start` and `end`, or `None` if the range
-/// is invalid. Unlike `Bytes::exact_view` (a.k.a. `b[start:end]`), this variant does
+/// is invalid. Unlike `Bytes::exact_view`, this variant does
 /// not abort on out-of-bounds indices, making it suitable for composition with
 /// pattern matching:
 ///
@@ -228,8 +228,7 @@ pub fn Bytes::get_view(
 
 ///|
 /// Returns a sub-view of the view between `start` and `end`, or `None` if the
-/// range is invalid. The optional variant of `BytesView::exact_view` (a.k.a.
-/// `bv[start:end]`).
+/// range is invalid. The optional variant of `BytesView::exact_view`.
 pub fn BytesView::get_view(
   self : BytesView,
   start? : Int = 0,
@@ -245,19 +244,19 @@ pub fn BytesView::get_view(
 
 ///|
 /// Creates a new `View` from the given `View`.
+/// Panics unless `0 <= start <= end <= length()` within the current view.
 ///
 /// # Example
 ///
 /// ```mbt check
 /// test {
 ///   let bv = b"\x00\x01\x02\x03\x04\x05"[:]
-///   let bv2 = bv[1:4]
+///   let bv2 = bv.exact_view(start=1, end=4)
 ///   inspect(bv2.length(), content="3")
 ///   @test.assert_eq(bv2[1], b'\x02')
 /// }
 /// ```
 #intrinsic("%bytesview.view")
-#alias("_[_:_]")
 #alias(view, deprecated="Use `exact_view` instead")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn BytesView::exact_view(
@@ -285,8 +284,8 @@ pub fn BytesView::exact_view(
 /// where the caller already knows the range may overrun, such as framing a
 /// byte stream.
 ///
-/// See `bs[start:end]` for the aborting variant and `Bytes::get_view` for the
-/// exact `Option`-returning variant.
+/// Also available as `bs[start:end]`. See `Bytes::exact_view` for the aborting
+/// variant and `Bytes::get_view` for the exact `Option`-returning variant.
 ///
 /// # Example
 ///
@@ -298,6 +297,7 @@ pub fn BytesView::exact_view(
 ///   inspect(bs.clamped_view(start=4, end=1).length(), content="0")
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn Bytes::clamped_view(
   self : Bytes,
   start? : Int = 0,
@@ -317,6 +317,7 @@ pub fn Bytes::clamped_view(
 /// Returns a sub-view of the view between `start` and `end`, clamping the
 /// requested range instead of rejecting it. Offsets are relative to the view;
 /// same contract as `Bytes::clamped_view`.
+/// Also available as `view[start:end]`. Use `BytesView::exact_view` to validate bounds.
 ///
 /// # Example
 ///
@@ -327,6 +328,7 @@ pub fn Bytes::clamped_view(
 ///   inspect(bv.clamped_view(start=3, end=1).length(), content="0")
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn BytesView::clamped_view(
   self : BytesView,
   start? : Int = 0,

--- a/builtin/bytesview_test.mbt
+++ b/builtin/bytesview_test.mbt
@@ -40,14 +40,14 @@ test "panic BytesView out of bounds" {
 }
 
 ///|
-test "panic Bytes sub invalid index" {
-  let _ = b"\x01\x02"[2:1]
+test "panic Bytes view invalid index" {
+  let _ = b"\x01\x02".exact_view(start=2, end=1)
 }
 
 ///|
-test "panic BytesView sub invalid index" {
+test "panic BytesView view invalid index" {
   let view = b"\x01\x02"[:]
-  let _ = view[2:1]
+  let _ = view.exact_view(start=2, end=1)
 }
 
 ///|

--- a/builtin/clamped_view_test.mbt
+++ b/builtin/clamped_view_test.mbt
@@ -473,3 +473,364 @@ test "Iter::clamped_view stays lazy and composes" {
   debug_inspect(view.collect(), content="[3, 4]")
   inspect(reads, content="4")
 }
+
+///|
+test "bracket slicing clamps bounds on arrays and bytes" {
+  let lo = @int.MIN_VALUE
+  let hi = @int.MAX_VALUE
+  let cases : ReadOnlyArray[(Int, Int, Int, Array[Int])] = [
+    (-5, 100, 0, [1, 2, 3, 4, 5]),
+    (-2, 2, 0, [1, 2]),
+    (1, 4, 1, [2, 3, 4]),
+    (3, 100, 3, [4, 5]),
+    (4, 1, 4, []),
+    (-9, -3, 0, []),
+    (100, 100, 5, []),
+    (lo, hi, 0, [1, 2, 3, 4, 5]),
+    (hi, lo, 5, []),
+    (lo, lo, 0, []),
+    (hi, hi, 5, []),
+  ]
+  let arr = [1, 2, 3, 4, 5]
+  let fixed : FixedArray[Int] = [1, 2, 3, 4, 5]
+  let ro : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+  let backing = [0, 1, 2, 3, 4, 5, 6]
+  let view = backing[1:6]
+  let mut_view = backing.mut_view(start=1, end=6)
+  let raw = @builtin.UninitializedArray::make(5)
+  for i in 0..<5 {
+    raw[i] = i + 1
+  }
+  let bytes = b"\x01\x02\x03\x04\x05"
+  let bv = b"\x00\x01\x02\x03\x04\x05\x06"[1:6]
+  for (start, end, offset, expected) in cases {
+    for
+      result in [
+        arr[start:end],
+        fixed[start:end],
+        ro[start:end],
+        raw[start:end],
+      ] {
+      assert_eq(result.to_owned(), expected)
+      assert_eq(result.start_offset(), offset)
+    }
+    for result in [view[start:end], mut_view[start:end]] {
+      assert_eq(result.to_owned(), expected)
+      assert_eq(result.start_offset(), 1 + offset)
+    }
+    assert_eq(bytes[start:end].to_array().map(b => b.to_int()), expected)
+    assert_eq(bytes[start:end].start_offset(), offset)
+    assert_eq(bv[start:end].to_array().map(b => b.to_int()), expected)
+    assert_eq(bv[start:end].start_offset(), 1 + offset)
+  }
+}
+
+///|
+test "bracket slicing defaults and nested array views" {
+  let arr = [1, 2, 3, 4, 5]
+  let fixed : FixedArray[Int] = [1, 2, 3, 4, 5]
+  let ro : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
+  let view = [0, 1, 2, 3, 4, 5, 6][1:6]
+  let mut_view = [0, 1, 2, 3, 4, 5, 6].mut_view(start=1, end=6)
+  let raw = @builtin.UninitializedArray::make(5)
+  for i in 0..<5 {
+    raw[i] = i + 1
+  }
+  for
+    result in [
+      arr[:].to_owned(),
+      fixed[:].to_owned(),
+      ro[:].to_owned(),
+      view[:].to_owned(),
+      mut_view[:].to_owned(),
+      raw[:].to_owned(),
+    ] {
+    assert_eq(result, [1, 2, 3, 4, 5])
+  }
+  for result in [arr[1:], fixed[1:], ro[1:], view[1:], mut_view[1:], raw[1:]] {
+    assert_eq(result.to_owned(), [2, 3, 4, 5])
+    assert_eq(result[1:][:-1].length(), 0)
+    assert_eq(result[1:][-9:100].to_owned(), [3, 4, 5])
+  }
+  for result in [arr[:2], fixed[:2], ro[:2], view[:2], mut_view[:2], raw[:2]] {
+    assert_eq(result.to_owned(), [1, 2])
+  }
+  for
+    result in [
+      arr[-1:],
+      fixed[-1:],
+      ro[-1:],
+      view[-1:],
+      mut_view[-1:],
+      raw[-1:],
+    ] {
+    assert_eq(result.to_owned(), [1, 2, 3, 4, 5])
+  }
+  for
+    result in [
+      arr[:100],
+      fixed[:100],
+      ro[:100],
+      view[:100],
+      mut_view[:100],
+      raw[:100],
+    ] {
+    assert_eq(result.to_owned(), [1, 2, 3, 4, 5])
+  }
+  for
+    result in [
+      arr[100:],
+      fixed[100:],
+      ro[100:],
+      view[100:],
+      mut_view[100:],
+      raw[100:],
+    ] {
+    assert_eq(result.length(), 0)
+  }
+  for
+    result in [
+      arr[:-1],
+      fixed[:-1],
+      ro[:-1],
+      view[:-1],
+      mut_view[:-1],
+      raw[:-1],
+    ] {
+    assert_eq(result.length(), 0)
+  }
+}
+
+///|
+test "bracket slicing defaults and nested byte views" {
+  let bytes = b"abcde"
+  let view = b"xabcdex"[1:6]
+  inspect(bytes[:].to_owned(), content="b\"abcde\"")
+  inspect(view[:].to_owned(), content="b\"abcde\"")
+  inspect(bytes[1:].to_owned(), content="b\"bcde\"")
+  inspect(view[1:].to_owned(), content="b\"bcde\"")
+  inspect(bytes[:2].to_owned(), content="b\"ab\"")
+  inspect(view[:2].to_owned(), content="b\"ab\"")
+  inspect(bytes[-1:].to_owned(), content="b\"abcde\"")
+  inspect(view[-1:].to_owned(), content="b\"abcde\"")
+  inspect(bytes[:100].to_owned(), content="b\"abcde\"")
+  inspect(view[:100].to_owned(), content="b\"abcde\"")
+  inspect(bytes[100:].length(), content="0")
+  inspect(view[100:].length(), content="0")
+  inspect(bytes[:-1].length(), content="0")
+  inspect(view[:-1].length(), content="0")
+  inspect(view[1:][-9:100].to_owned(), content="b\"bcde\"")
+  inspect(view[1:][100:].start_offset(), content="6")
+}
+
+///|
+test "bracket slicing clamps UTF-16 bounds and trims surrogate pairs inward" {
+  let lo = @int.MIN_VALUE
+  let hi = @int.MAX_VALUE
+  let cases : ReadOnlyArray[(Int, Int, Int, String)] = [
+    (-5, 100, 0, "ab😀cd"),
+    (-2, 2, 0, "ab"),
+    (1, 3, 1, "b"),
+    (3, 5, 4, "c"),
+    (2, 4, 2, "😀"),
+    (3, 3, 4, ""),
+    (4, 2, 4, ""),
+    (-9, -3, 0, ""),
+    (100, 100, 6, ""),
+    (lo, hi, 0, "ab😀cd"),
+    (hi, lo, 6, ""),
+    (lo, lo, 0, ""),
+    (hi, hi, 6, ""),
+  ]
+  let str = "ab😀cd"
+  let view = "xxab😀cdyy"[2:8]
+  for (start, end, offset, expected) in cases {
+    assert_eq(str[start:end].to_owned(), expected)
+    assert_eq(str[start:end].start_offset(), offset)
+    assert_eq(view[start:end].to_owned(), expected)
+    assert_eq(view[start:end].start_offset(), 2 + offset)
+  }
+  inspect(str[:], content="ab😀cd")
+  inspect(view[:], content="ab😀cd")
+  inspect(str[:3], content="ab")
+  inspect(view[:3], content="ab")
+  inspect(str[3:], content="cd")
+  inspect(view[3:], content="cd")
+  inspect(str[-1:], content="ab😀cd")
+  inspect(view[-1:], content="ab😀cd")
+  inspect(str[:100], content="ab😀cd")
+  inspect(view[:100], content="ab😀cd")
+  inspect(str[100:], content="")
+  inspect(view[100:], content="")
+  inspect(str[:-1], content="")
+  inspect(view[:-1], content="")
+  inspect(view[1:][:2], content="b")
+  inspect(view[1:][2:100], content="cd")
+  let (left, right) = str.split_at(3)
+  inspect(left + right, content="ab😀cd")
+}
+
+///|
+test "bracket slicing preserves unpaired surrogates" {
+  let high = "😀".unsafe_substring(start=0, end=1)
+  let low = "😀".unsafe_substring(start=1, end=2)
+  for lone in [high, low] {
+    let str = "a" + lone + "b"
+    let view = ("x" + str + "x")[1:4]
+    assert_eq(str[1:2].to_owned(), lone)
+    assert_eq(view[1:2].to_owned(), lone)
+    assert_eq(str[:2].length(), 2)
+    assert_eq(view[1:].length(), 2)
+  }
+}
+
+///|
+test "bracket slicing empty containers clamps integer extremes" {
+  let lo = @int.MIN_VALUE
+  let hi = @int.MAX_VALUE
+  let arr : Array[Int] = []
+  let fixed : FixedArray[Int] = []
+  let ro : ReadOnlyArray[Int] = []
+  let view = arr[:]
+  let mut_view = arr.mut_view()
+  let raw : @builtin.UninitializedArray[Int] = @builtin.UninitializedArray::make(
+    0,
+  )
+  for
+    result in [
+      arr[lo:hi],
+      fixed[lo:hi],
+      ro[lo:hi],
+      view[lo:hi],
+      mut_view[lo:hi],
+      raw[lo:hi],
+    ] {
+    assert_eq(result.length(), 0)
+    assert_eq(result.start_offset(), 0)
+  }
+  inspect(b""[lo:hi].length(), content="0")
+  inspect(b""[:][hi:lo].length(), content="0")
+  inspect(""[lo:hi], content="")
+  inspect(""[:][hi:lo], content="")
+}
+
+///|
+test "clamped bracket slices share backing storage" {
+  let arr = [1, 2, 3, 4, 5]
+  let slice = arr[1:100]
+  let nested = slice[1:100]
+  let mutable = arr.mut_view(start=1, end=4)
+  let read_view = mutable[-9:100]
+  mutable[1] = 30
+  arr[1] = 20
+  json_inspect(slice.to_owned(), content=[20, 30, 4, 5])
+  json_inspect(nested.to_owned(), content=[30, 4, 5])
+  json_inspect(read_view.to_owned(), content=[20, 30, 4])
+  let fixed : FixedArray[Int] = [1, 2, 3]
+  let slice = fixed[-1:100]
+  fixed[1] = 20
+  json_inspect(slice.to_owned(), content=[1, 20, 3])
+  let raw = @builtin.UninitializedArray::make(2)
+  raw[0] = 1
+  raw[1] = 2
+  let slice = raw[-1:100]
+  raw[1] = 20
+  json_inspect(slice.to_owned(), content=[1, 20])
+}
+
+///|
+test "bracket slicing evaluates receiver and bounds once in order" {
+  let events = []
+  let arr = [1, 2, 3]
+  let receiver = fn() {
+    events.push("receiver")
+    arr
+  }
+  let bound = fn(name, value) {
+    events.push(name)
+    value
+  }
+  json_inspect(receiver()[bound("start", -1):bound("end", 100)].to_owned(), content=[
+    1, 2, 3,
+  ])
+  json_inspect(receiver()[:bound("end", 2)].to_owned(), content=[1, 2])
+  json_inspect(receiver()[bound("start", 1):].to_owned(), content=[2, 3])
+  json_inspect(receiver()[:].to_owned(), content=[1, 2, 3])
+  json_inspect(events, content=[
+    "receiver", "start", "end", "receiver", "end", "receiver", "start", "receiver",
+  ])
+  // Default end is evaluated after the explicit start expression.
+  json_inspect(
+    arr[{
+      arr.push(4)
+      1
+    }:].to_owned(),
+    content=[2, 3, 4],
+  )
+}
+
+///|
+priv struct SliceProbe {
+  events : Array[String]
+}
+
+///|
+#alias("_[_:_]")
+fn SliceProbe::slice(
+  self : SliceProbe,
+  start? : Int = 17,
+  end? : Int = 23,
+) -> (Int, Int) {
+  self.events.push("slice")
+  (start, end)
+}
+
+///|
+test "custom slice operators receive raw bounds and their own defaults" {
+  let probe = SliceProbe::{ events: [], }
+  debug_inspect(probe[-100:100], content="(-100, 100)")
+  debug_inspect(probe[5:2], content="(5, 2)")
+  debug_inspect(probe[:], content="(17, 23)")
+  debug_inspect(probe[:100], content="(17, 100)")
+  debug_inspect(probe[-100:], content="(-100, 23)")
+  inspect(probe.events.length(), content="5")
+}
+
+///|
+test "rest patterns keep exact array byte and Unicode contents" {
+  let arr = [1, 2, 3, 4]
+  guard arr is [1, .. middle, 4] else { fail("array rest pattern") }
+  json_inspect(middle.to_owned(), content=[2, 3])
+  guard middle is [2, .. tail] else { fail("nested rest pattern") }
+  json_inspect(tail.to_owned(), content=[3])
+  guard b"abcd" is [b'a', .. middle, b'd'] else { fail("byte rest pattern") }
+  inspect(middle.to_owned(), content="b\"bc\"")
+  guard "ab😀cd" is ['a', .. middle, 'd'] else { fail("string rest pattern") }
+  inspect(middle, content="b😀c")
+  guard middle is ['b', '😀', .. tail] else { fail("Unicode rest pattern") }
+  inspect(tail, content="c")
+}
+
+///|
+test "panic ReadOnlyArray::exact_view rejects negative start with omitted end" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3]
+  ignore(arr.exact_view(start=-1))
+}
+
+///|
+test "panic ReadOnlyArray::exact_view rejects start beyond length with omitted end" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3]
+  ignore(arr.exact_view(start=4))
+}
+
+///|
+test "panic ReadOnlyArray::exact_view rejects end beyond length" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3]
+  ignore(arr.exact_view(start=1, end=4))
+}
+
+///|
+test "panic ReadOnlyArray::exact_view rejects inverted range" {
+  let arr : ReadOnlyArray[Int] = [1, 2, 3]
+  ignore(arr.exact_view(start=2, end=1))
+}

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -358,6 +358,7 @@ pub fn[T] FixedArray::mut_view(
 
 ///|
 /// Creates a new `ArrayView` from a `MutArrayView`.
+/// Panics unless `0 <= start <= end <= length()` within the current view.
 ///
 /// Parameters:
 ///
@@ -367,7 +368,6 @@ pub fn[T] FixedArray::mut_view(
 /// * `end` : The ending index in the current view (exclusive). Defaults to the
 /// length of the current view.
 #intrinsic("%mutarrayview.view")
-#alias("_[_:_]")
 #alias(view, deprecated="Use `exact_view` instead")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn[T] MutArrayView::exact_view(
@@ -391,6 +391,8 @@ pub fn[T] MutArrayView::exact_view(
 /// `[0, length()]`; an inverted range yields an empty view at the clamped
 /// `start`. Defaults to the full view when both bounds are omitted.
 ///
+/// Also available as `view[start:end]`. Use `MutArrayView::exact_view` to validate bounds.
+///
 /// ```mbt check
 /// test {
 ///   let arr = [1, 2, 3, 4, 5]
@@ -398,6 +400,7 @@ pub fn[T] MutArrayView::exact_view(
 ///   json_inspect(view.clamped_view(start=1, end=10).to_owned(), content=[3, 4])
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn[T] MutArrayView::clamped_view(
   self : MutArrayView[T],
   start? : Int = 0,

--- a/builtin/mutarrayview_test.mbt
+++ b/builtin/mutarrayview_test.mbt
@@ -321,10 +321,10 @@ test "panic FixedArray mut_view invalid range" {
 }
 
 ///|
-test "panic MutArrayView sub invalid range" {
+test "panic MutArrayView view invalid range" {
   let arr = [1, 2, 3]
   let view = arr.mut_view()
-  let _ = view[2:1]
+  let _ = view.exact_view(start=2, end=1)
 }
 
 ///|

--- a/builtin/panic_test.mbt
+++ b/builtin/panic_test.mbt
@@ -53,33 +53,33 @@ test "panic array_resize_negative" {
 }
 
 ///|
-test "panic array_as_view_start_index_error" {
-  [1, 2, 3][-1:0] |> ignore
+test "panic array_view_start_index_error" {
+  [1, 2, 3].exact_view(start=-1, end=0) |> ignore
 }
 
 ///|
-test "panic array_as_view_end_index_error" {
-  [1, 2, 3][0:-4] |> ignore
+test "panic array_view_end_index_error" {
+  [1, 2, 3].exact_view(start=0, end=-4) |> ignore
 }
 
 ///|
-test "panic array_as_view_length_index_error" {
-  [1, 2, 3][0:4] |> ignore
+test "panic array_view_length_index_error" {
+  [1, 2, 3].exact_view(start=0, end=4) |> ignore
 }
 
 ///|
-test "panic view_as_view_start_index_error" {
-  [1, 2, 3][:][-1:0] |> ignore
+test "panic arrayview_view_start_index_error" {
+  [1, 2, 3][:].exact_view(start=-1, end=0) |> ignore
 }
 
 ///|
-test "panic view_as_view_end_index_error" {
-  [1, 2, 3][:][0:-4] |> ignore
+test "panic arrayview_view_end_index_error" {
+  [1, 2, 3][:].exact_view(start=0, end=-4) |> ignore
 }
 
 ///|
-test "panic view_as_view_length_index_error" {
-  [1, 2, 3][:][0:4] |> ignore
+test "panic arrayview_view_length_index_error" {
+  [1, 2, 3][:].exact_view(start=0, end=4) |> ignore
 }
 
 ///|

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -81,6 +81,7 @@ pub fn[A] Array::blit_to(Self[A], Self[A], len? : Int, src_offset? : Int, dst_of
 pub fn[T] Array::capacity(Self[T]) -> Int
 pub fn[T] Array::chunk_by(Self[T], (T, T) -> Bool raise?) -> Self[ArrayView[T]] raise?
 pub fn[T] Array::chunks(Self[T], Int) -> Self[ArrayView[T]]
+#alias("_[_:_]")
 pub fn[T] Array::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] Array::clear(Self[T]) -> Unit
 pub fn[T : Compare] Array::compare(Self[T], Self[T]) -> Int
@@ -95,7 +96,6 @@ pub fn[T] Array::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] Array::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] Array::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] Array::equal(Self[T], Self[T]) -> Bool
-#alias("_[_:_]")
 #alias(sub, deprecated)
 #alias(view, deprecated)
 pub fn[T] Array::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
@@ -205,6 +205,7 @@ pub fn[T] ArrayView::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int,
 pub fn[A] ArrayView::blit_to(Self[A], Array[A], dst_offset? : Int) -> Unit
 pub fn[T] ArrayView::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[Self[T]] raise?
 pub fn[T] ArrayView::chunks(Self[T], Int) -> Array[Self[T]]
+#alias("_[_:_]")
 pub fn[T] ArrayView::clamped_view(Self[T], start? : Int, end? : Int) -> Self[T]
 pub fn[T : Compare] ArrayView::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] ArrayView::contains(Self[T], T) -> Bool
@@ -214,7 +215,6 @@ pub fn[T] ArrayView::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ArrayView::ends_with(Self[T], Self[T]) -> Bool
 pub fn[T : Eq] ArrayView::equal(Self[T], Self[T]) -> Bool
-#alias("_[_:_]")
 #alias(sub, deprecated)
 #alias(view, deprecated)
 pub fn[T] ArrayView::exact_view(Self[T], start? : Int, end? : Int) -> Self[T]
@@ -427,10 +427,10 @@ pub impl[K : Show, V : ToJson] ToJson for Map[K, V]
 type MutArrayView[T]
 #alias("_[_]")
 pub fn[T] MutArrayView::at(Self[T], Int) -> T
+#alias("_[_:_]")
 pub fn[T] MutArrayView::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T : Compare] MutArrayView::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] MutArrayView::equal(Self[T], Self[T]) -> Bool
-#alias("_[_:_]")
 #alias(sub, deprecated)
 #alias(view, deprecated)
 pub fn[T] MutArrayView::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
@@ -487,8 +487,8 @@ pub impl Show for StringBuilder
 type UninitializedArray[T]
 #alias("_[_]")
 pub fn[T] UninitializedArray::at(Self[T], Int) -> T
-pub fn[T] UninitializedArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 #alias("_[_:_]")
+pub fn[T] UninitializedArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 #alias(sub, deprecated)
 pub fn[T] UninitializedArray::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[A] UninitializedArray::length(Self[A]) -> Int
@@ -861,6 +861,7 @@ pub fn String::before(String, StringView) -> StringView?
 pub fn String::char_length(String, start_offset? : Int, end_offset? : Int) -> Int
 pub fn String::char_length_eq(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
 pub fn String::char_length_ge(String, Int, start_offset? : Int, end_offset? : Int) -> Bool
+#alias("_[_:_]")
 pub fn String::clamped_view(String, start? : Int, end? : Int) -> StringView
 pub fn String::code_units(String) -> ArrayView[UInt16]
 pub fn String::compare(String, String) -> Int
@@ -872,7 +873,6 @@ pub fn String::contains_code_unit(String, UInt16) -> Bool
 pub fn String::equal(String, String) -> Bool
 pub fn String::equal_ignore_ascii_case(String, String) -> Bool
 pub fn String::escape(String, quote? : Bool) -> String
-#alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn String::exact_view(String, start? : Int, end? : Int) -> StringView
 pub fn String::find(String, StringView) -> Int?
@@ -1006,6 +1006,7 @@ pub fn FixedArray::blit_from_bytes(Self[Byte], Int, Bytes, Int, Int) -> Unit
 pub fn FixedArray::blit_from_bytesview(Self[Byte], Int, BytesView) -> Unit
 pub fn FixedArray::blit_from_string(Self[Byte], Int, String, Int, Int) -> Unit
 pub fn[A] FixedArray::blit_to(Self[A], Self[A], len~ : Int, src_offset? : Int, dst_offset? : Int) -> Unit
+#alias("_[_:_]")
 pub fn[T] FixedArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T : Compare] FixedArray::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] FixedArray::contains(Self[T], T) -> Bool
@@ -1015,7 +1016,6 @@ pub fn[T] FixedArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] FixedArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] FixedArray::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] FixedArray::equal(Self[T], Self[T]) -> Bool
-#alias("_[_:_]")
 #alias(sub, deprecated)
 #alias(view, deprecated)
 pub fn[T] FixedArray::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
@@ -1082,6 +1082,7 @@ pub fn[T : Compare] ReadOnlyArray::binary_search(Self[T], T) -> Result[Int, Int]
 pub fn[T] ReadOnlyArray::binary_search_by(Self[T], (T) -> Int raise?) -> Result[Int, Int] raise?
 pub fn[T] ReadOnlyArray::chunk_by(Self[T], (T, T) -> Bool raise?) -> Array[ArrayView[T]] raise?
 pub fn[T] ReadOnlyArray::chunks(Self[T], Int) -> Array[ArrayView[T]]
+#alias("_[_:_]")
 pub fn[T] ReadOnlyArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T : Compare] ReadOnlyArray::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] ReadOnlyArray::contains(Self[T], T) -> Bool
@@ -1089,7 +1090,6 @@ pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ReadOnlyArray::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] ReadOnlyArray::equal(Self[T], Self[T]) -> Bool
-#alias("_[_:_]")
 #alias(sub, deprecated)
 #alias(view, deprecated)
 pub fn[T] ReadOnlyArray::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
@@ -1135,13 +1135,13 @@ pub fn Bytes::add(Bytes, Bytes) -> Bytes
 pub fn Bytes::at(Bytes, Int) -> Byte
 pub fn Bytes::chop_prefix(Bytes, BytesView) -> BytesView?
 pub fn Bytes::chop_suffix(Bytes, BytesView) -> BytesView?
+#alias("_[_:_]")
 pub fn Bytes::clamped_view(Bytes, start? : Int, end? : Int) -> BytesView
 pub fn Bytes::compare(Bytes, Bytes) -> Int
 #alias(clone, deprecated)
 #deprecated
 pub fn Bytes::copy(Bytes) -> Bytes
 pub fn Bytes::equal(Bytes, Bytes) -> Bool
-#alias("_[_:_]")
 #alias(sub, deprecated)
 #alias(view, deprecated)
 pub fn Bytes::exact_view(Bytes, start? : Int, end? : Int) -> BytesView
@@ -1182,12 +1182,12 @@ pub fn Bytes::to_unchecked_string(Bytes, offset? : Int, length? : Int) -> String
 pub fn BytesView::at(Self, Int) -> Byte
 pub fn BytesView::chop_prefix(Self, Self) -> Self?
 pub fn BytesView::chop_suffix(Self, Self) -> Self?
+#alias("_[_:_]")
 pub fn BytesView::clamped_view(Self, start? : Int, end? : Int) -> Self
 pub fn BytesView::compare(Self, Self) -> Int
 pub fn BytesView::data(Self) -> Bytes
 pub fn BytesView::equal(Self, Self) -> Bool
 pub fn BytesView::equal_to_bytes(Self, Bytes) -> Bool
-#alias("_[_:_]")
 #alias(sub, deprecated)
 #alias(view, deprecated)
 pub fn BytesView::exact_view(Self, start? : Int, end? : Int) -> Self
@@ -1226,6 +1226,7 @@ pub fn StringView::before(Self, Self) -> Self?
 pub fn StringView::char_length(Self) -> Int
 pub fn StringView::char_length_eq(Self, Int) -> Bool
 pub fn StringView::char_length_ge(Self, Int) -> Bool
+#alias("_[_:_]")
 pub fn StringView::clamped_view(Self, start? : Int, end? : Int) -> Self
 pub fn StringView::code_units(Self) -> ArrayView[UInt16]
 pub fn StringView::compare(Self, Self) -> Int
@@ -1239,7 +1240,6 @@ pub fn StringView::equal(Self, Self) -> Bool
 pub fn StringView::equal_ignore_ascii_case(Self, Self) -> Bool
 pub fn StringView::equal_to_string(Self, String) -> Bool
 pub fn StringView::escape(Self, quote? : Bool) -> Self
-#alias("_[_:_]")
 #alias(sub, deprecated)
 pub fn StringView::exact_view(Self, start? : Int, end? : Int) -> Self
 pub fn StringView::find(Self, Self) -> Int?

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -857,18 +857,18 @@ pub fn[T : Compare] ReadOnlyArray::lexical_compare(
 
 ///|
 /// Creates a view of a subarray.
+/// Panics unless `0 <= start <= end <= length()`.
 ///
 /// # Example
 /// ```mbt check
 /// test {
 ///   let arr : ReadOnlyArray[Int] = [1, 2, 3, 4, 5]
-///   let view = arr[1:4]
+///   let view = arr.exact_view(start=1, end=4)
 ///   inspect(view[0], content="2")
 ///   inspect(view[2], content="4")
 /// }
 /// ```
 #intrinsic("%readonlyarray.view")
-#alias("_[_:_]")
 #alias(view, deprecated="Use `exact_view` instead")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn[T] ReadOnlyArray::exact_view(
@@ -918,6 +918,7 @@ pub fn[T] ReadOnlyArray::get_view(
 ///|
 /// Creates a view of a subarray, clamping the requested range instead of
 /// rejecting it. Same contract as `Array::clamped_view`.
+/// Also available as `arr[start:end]`. Use `ReadOnlyArray::exact_view` to validate bounds.
 ///
 /// # Example
 /// ```mbt check
@@ -937,6 +938,7 @@ pub fn[T] ReadOnlyArray::get_view(
 ///   )
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn[T] ReadOnlyArray::clamped_view(
   self : ReadOnlyArray[T],
   start? : Int = 0,

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -602,7 +602,7 @@ pub fn StringView::from_iter(iter : Iter[Char]) -> StringView {
 ///|
 /// Returns a view of the string between `start` and `end`, or `None` if the
 /// range is invalid — either out of bounds or splitting a UTF-16 surrogate
-/// pair. Unlike `String::exact_view` (a.k.a. `s[start:end]`), this variant does not
+/// pair. Unlike `String::exact_view`, this variant does not
 /// abort, making it suitable for composition with pattern matching:
 ///
 /// ```mbt check
@@ -639,7 +639,7 @@ pub fn String::get_view(
 ///|
 /// Returns a sub-view of the view between `start` and `end`, or `None` if the
 /// range is invalid — either out of bounds or splitting a UTF-16 surrogate
-/// pair. The optional variant of `StringView::exact_view` (a.k.a. `sv[start:end]`).
+/// pair. The optional variant of `StringView::exact_view`.
 pub fn StringView::get_view(
   self : StringView,
   start? : Int = 0,
@@ -678,8 +678,11 @@ pub fn StringView::get_view(
 /// requested range on each side. Unpaired surrogates already present in the
 /// input are treated as boundaries and pass through unchanged.
 ///
-/// See `s[start:end]` for the aborting variant and `String::get_view` for
-/// the exact `Option`-returning variant.
+/// Also available as `s[start:end]`, with UTF-16 code-unit offsets. Negative
+/// offsets clamp to zero. See `String::exact_view` for the aborting variant and
+/// `String::get_view` for the exact `Option`-returning variant. Use
+/// `String::split_at` for a lossless split: `s[:i]` and `s[i:]` both exclude a
+/// character whose surrogate pair contains `i`.
 ///
 /// # Example
 ///
@@ -692,6 +695,7 @@ pub fn StringView::get_view(
 ///   inspect(s.clamped_view(start=3, end=3), content="") // inside the pair
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn String::clamped_view(
   self : String,
   start? : Int = 0,
@@ -728,6 +732,9 @@ pub fn String::clamped_view(
 /// `String::clamped_view`: clamps out-of-range offsets, snaps
 /// surrogate-splitting offsets inward, and yields an empty view for an
 /// inverted range.
+/// Also available as `view[start:end]`, with UTF-16 code-unit offsets relative
+/// to the view. Use `StringView::exact_view` to validate bounds and surrogate
+/// boundaries, or `StringView::split_at` for a lossless split.
 ///
 /// # Example
 ///
@@ -738,6 +745,7 @@ pub fn String::clamped_view(
 ///   inspect(v.clamped_view(start=3), content="cd")
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn StringView::clamped_view(
   self : StringView,
   start? : Int = 0,
@@ -879,7 +887,6 @@ pub fn StringView::split_at(
 ///   inspect(view2, content="World")
 /// }
 /// ```
-#alias("_[_:_]")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn String::exact_view(
   self : String,
@@ -939,7 +946,6 @@ pub fn String::exact_view(
 ///   inspect(view2, content="rl")
 /// }
 /// ```
-#alias("_[_:_]")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn StringView::exact_view(
   self : StringView,

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -184,26 +184,26 @@ test "StringView sub valid cases" {
 
 ///|
 test "panic String::exact_view invalid index" {
-  ignore("A😀B"[0:2])
+  ignore("A😀B".exact_view(start=0, end=2))
 }
 
 ///|
 test "panic String::exact_view index out of bounds" {
-  ignore("A😀B"[0:10])
+  ignore("A😀B".exact_view(start=0, end=10))
 }
 
 ///|
 test "panic StringView::exact_view invalid index" {
   let s = "A😀B"
   let view = s[1:3]
-  ignore(view[:1])
+  ignore(view.exact_view(end=1))
 }
 
 ///|
 test "panic StringView::exact_view index out of bounds" {
   let s = "A😀B"
   let view = s[1:3]
-  ignore(view[0:10])
+  ignore(view.exact_view(start=0, end=10))
 }
 
 ///|
@@ -244,13 +244,13 @@ test "StringView compare physical equal" {
 ///|
 test "panic String::exact_view invalid start index" {
   let s = "\u{1F600}A"
-  ignore(s[1:])
+  ignore(s.exact_view(start=1))
 }
 
 ///|
 test "panic StringView::exact_view invalid start index" {
   let view = "\u{1F600}A"[:]
-  ignore(view[1:])
+  ignore(view.exact_view(start=1))
 }
 
 ///|

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -83,9 +83,8 @@ fn[T] UninitializedArray::unsafe_set(
 /// Returns an `ArrayView` that provides a window into the specified portion of
 /// the array.
 ///
-/// Throws an error if the indices are out of bounds or if `start` is greater
+/// Panics if the indices are out of bounds or if `start` is greater
 /// than `end`.
-#alias("_[_:_]")
 #alias(sub, deprecated="Use `exact_view` instead")
 pub fn[T] UninitializedArray::exact_view(
   self : UninitializedArray[T],
@@ -109,6 +108,8 @@ pub fn[T] UninitializedArray::exact_view(
 /// are omitted. Elements must be initialized before they are read through the
 /// returned view.
 ///
+/// Also available as `arr[start:end]`. Use `UninitializedArray::exact_view` to validate bounds.
+///
 /// ```mbt check
 /// test {
 ///   let arr = @builtin.UninitializedArray::make(3)
@@ -118,6 +119,7 @@ pub fn[T] UninitializedArray::exact_view(
 ///   json_inspect(arr.clamped_view(start=1, end=10).to_owned(), content=[2, 3])
 /// }
 /// ```
+#alias("_[_:_]")
 pub fn[T] UninitializedArray::clamped_view(
   self : UninitializedArray[T],
   start? : Int = 0,
@@ -249,13 +251,13 @@ test "as_view with valid_range" {
 ///|
 test "panic as_view with invalid_start" {
   let arr : UninitializedArray[Int] = UninitializedArray::make(5)
-  ignore(arr[-1:])
+  ignore(arr.exact_view(start=-1))
 }
 
 ///|
 test "panic as_view with invalid_end" {
   let arr : UninitializedArray[Int] = UninitializedArray::make(5)
-  ignore(arr[2:10])
+  ignore(arr.exact_view(start=2, end=10))
 }
 
 ///|

--- a/bytes/README.mbt.md
+++ b/bytes/README.mbt.md
@@ -97,6 +97,12 @@ names are deprecated in favor of `exact_view`.
 
 Views provide a way to work with portions of bytes and interpret them as various numeric types:
 
+For `Bytes` and `BytesView`, `bytes[start:end]` clamps each bound to the current
+length, treats negative bounds as zero, and returns an empty view for an
+inverted range. Omitted bounds select the corresponding end of the bytes or
+view. Use `bytes.exact_view(start~, end~)` to require valid bounds, or
+`bytes.get_view(start~, end~)` to return `None` for an invalid range.
+
 ```mbt check
 ///|
 test "bytes view operations" {

--- a/bytes/quickcheck_test.mbt
+++ b/bytes/quickcheck_test.mbt
@@ -193,7 +193,7 @@ test "quickcheck: views agree with array-model slices" {
       bs[:] == bs[0:len] else {
       return false
     }
-    // get_view mirrors the aborting slice on valid input and rejects invalid
+    // get_view agrees with bracket slicing on valid input and rejects invalid
     // ranges instead of aborting.
     guard bs.get_view(start~, end~) == Some(v) else { return false }
     guard bs.get_view(start=-1) is None else { return false }

--- a/bytes/view_test.mbt
+++ b/bytes/view_test.mbt
@@ -72,37 +72,37 @@ test "basic3" {
 ///|
 test "panic invalid index1" {
   let bs = b"\x00\x01\x02\x03\x04\x05"
-  let _ = bs[-7:]
+  let _ = bs.exact_view(start=-7)
 }
 
 ///|
 test "panic invalid index2" {
   let bs = b"\x00\x01\x02\x03\x04\x05"
-  let _ = bs[:7]
+  let _ = bs.exact_view(end=7)
 }
 
 ///|
 test "panic invalid index3" {
   let bs = b"\x00\x01\x02\x03\x04\x05"
-  let _ = bs[3:2]
+  let _ = bs.exact_view(start=3, end=2)
 }
 
 ///|
 test "panic invalid index4" {
   let bs = b"\x00\x01\x02\x03\x04\x05"[:]
-  let _ = bs[:-7]
+  let _ = bs.exact_view(end=-7)
 }
 
 ///|
 test "panic invalid index5" {
   let bs = b"\x00\x01\x02\x03\x04\x05"[:]
-  let _ = bs[7:]
+  let _ = bs.exact_view(start=7)
 }
 
 ///|
 test "panic invalid index6" {
   let bs = b"\x00\x01\x02\x03\x04\x05"[:1]
-  let _ = bs[:2]
+  let _ = bs.exact_view(end=2)
 }
 
 ///|
@@ -132,13 +132,13 @@ test "iter2" {
 ///|
 test "panic negative index1" {
   let bs = b"\x01\x02\x03"
-  let _ = bs[-1:-2]
+  let _ = bs.exact_view(start=-1, end=-2)
 }
 
 ///|
 test "panic negative index2" {
   let bs = b"\x01\x02\x03"[:]
-  let _ = bs[-1:-2]
+  let _ = bs.exact_view(start=-1, end=-2)
 }
 
 ///|

--- a/string/DESIGN.mbt.md
+++ b/string/DESIGN.mbt.md
@@ -20,11 +20,13 @@
     the i-th UTF-16 code unit (charcode) for efficiency and consistency with
     other APIs. The return type of `s[i]` is `UInt16`, which reminds you that it
     returns the charcode.
-  - The slice operator `s[i:j]` is available but should also be used with
-    caution: it slices on charcode indices, not character indices, and it
-    aborts when an endpoint is out of range or would split a surrogate pair.
-    Use `s.get_view(start = i, end = j)`, which returns `None` instead of
-    aborting, when the range may be invalid.
+  - The slice operator `s[i:j]` uses UTF-16 code-unit indices. It clamps both
+    bounds to `[0, s.length()]`, trims split surrogate pairs inward, and
+    returns an empty view for an inverted range. Negative bounds clamp to
+    zero. Use `s.exact_view(start=i, end=j)` to require valid bounds and surrogate
+    boundaries, or `s.get_view(start=i, end=j)` to return `None` when they are
+    invalid. Use `s.split_at(i)` for a lossless split; two slices `s[:i]` and
+    `s[i:]` both omit a character split by `i`.
 
 * **Performance and Unicode Safety**:
   - Most APIs in this package operate on UTF-16 offsets rather than Unicode

--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -128,9 +128,17 @@ test "string comparison" {
 String views provide efficient substring operations without copying. A
 `String` stores UTF-16 code units, and a view is just a `{str, start, end}`
 window into those units. A character outside the Basic Multilingual Plane is
-stored as a surrogate pair, and the `s[start:end]` slice syntax panics
-rather than split one. `s.exact_view(start~, end~)` provides the same validation;
-`s.clamped_view(start~, end~)` clamps bounds and trims split pairs inward.
+stored as a surrogate pair. The `s[start:end]` slice syntax clamps both bounds
+to `[0, s.length()]` and trims split surrogate pairs inward: the start moves
+forward and the end moves backward. Negative offsets clamp to zero, and an
+inverted range produces an empty view. `StringView` uses the same rules with
+offsets relative to the view.
+
+Use `s.exact_view(start~, end~)` when invalid bounds or split surrogate pairs should
+panic, or `s.get_view(start~, end~)` to receive `None` for an invalid range.
+For a lossless split, use `s.split_at(i)`; `s[:i]` and `s[i:]` both exclude a
+character when `i` falls inside its surrogate pair.
+
 The old `sub` name is deprecated in favor of `exact_view`. The legacy `view`
 method is also deprecated; it retains its `start_offset`/`end_offset` labels and
 raw UTF-16 behavior for compatibility.
@@ -143,7 +151,7 @@ str: "String \"a😀b\" — UTF-16 code units" {
   u2: "[2] 0xDE00 low surrogate"
   u3: "[3] 'b'"
 }
-view: "StringView {str, start, end}\ns[1:3] is the full 😀 (ok)\ns[2:4] starts inside 😀 → panics"
+view: "StringView {str, start, end}\ns[1:3] is the full 😀\ns[2:4] trims the split pair → b"
 view -> str: "zero copy, indices are code units"
 ```
 
@@ -163,6 +171,19 @@ test "string views" {
   // Convert view back to string
   let substring = view.to_owned()
   inspect(substring, content="World")
+}
+```
+
+```mbt check
+///|
+test "clamped string slices" {
+  let text = "ab😀cd"
+  inspect(text[:3], content="ab")
+  inspect(text[3:], content="cd")
+  inspect(text[-5:100], content="ab😀cd")
+  inspect(text[4:2], content="")
+  let (left, right) = text.split_at(3)
+  inspect(left + right, content="ab😀cd")
 }
 ```
 

--- a/string/op_as_view_test.mbt
+++ b/string/op_as_view_test.mbt
@@ -41,21 +41,11 @@ test "String::op_as_view with positive indices" {
 
 ///|
 test "String::op_as_view with negative indices" {
-  // let s = "hello world"
-
-  // Test negative indices from end
-  // let view1 =   s.charcodes(start=-5)
-  // inspect(view1, content="world")
-  // let view2 = s.charcodes(end=-6)
-  // inspect(view2, content="hello")
-  // let view3 = s.charcodes(start=-5,end=-1)
-  // inspect(view3, content="worl")
-
-  // Test combining positive and negative indices
-  // let view4 = s.charcodes(start=0,end=-6)
-  // inspect(view4, content="hello")
-  // let view5 = s.charcodes(start=6,end=-1)
-  // inspect(view5, content="worl")
+  let s = "hello world"
+  inspect(s[-5:], content="hello world")
+  inspect(s[:-6], content="")
+  inspect(s[-5:-1], content="")
+  inspect(s[6:-1], content="")
 }
 
 ///|
@@ -83,18 +73,12 @@ test "View::op_as_view with positive indices" {
 }
 
 ///|
-// test "View::op_as_view with negative indices" {
-//   let s = "hello world"
-//   let view = s[:]
-
-//   // Test negative indices from end
-//   let subview1 = view[-5:]
-//   inspect(subview1, content="world")
-//   let subview2 = view[:-6]
-//   inspect(subview2, content="hello")
-//   let subview3 = view[-5:-1]
-//   inspect(subview3, content="worl")
-// }
+test "View::op_as_view with negative indices" {
+  let view = "hello world"[1:5]
+  inspect(view[-5:], content="ello")
+  inspect(view[:-6], content="")
+  inspect(view[-5:-1], content="")
+}
 
 ///|
 test "View::op_as_view with nested views" {
@@ -106,7 +90,5 @@ test "View::op_as_view with nested views" {
   let view3 = view2.exact_view(start=1, end=4)
   inspect(view3, content="ell")
 
-  // Test with negative indices in nested views
-  // let view4 = view2.charcodes(start=-3)
-  // inspect(view4, content="llo")
+  inspect(view3[-3:100], content="ell")
 }

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -302,8 +302,9 @@ pub impl BitOr for Regex with fn lor(self, other) -> Regex {
 /// unit of a surrogate pair).
 ///
 /// Passing a `last_index` in the middle of a surrogate pair may produce match
-/// offsets that later cause `MatchResult::before`, `MatchResult::content`, or
-/// `MatchResult::after` to panic when slicing.
+/// offsets that split a character. `MatchResult::before`, `MatchResult::content`,
+/// and `MatchResult::after` trim such boundaries inward when slicing, so their
+/// views may omit that character.
 ///
 /// `last_index` only controls where searching starts. It does **not** change
 /// anchor semantics:

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -713,28 +713,28 @@ test "String::op_as_view basic usage" {
 }
 
 ///|
-test "panic String::op_as_view splits surrogate pair end" {
-  ignore("Hello🤣World"[:6])
+test "panic String::exact_view splits surrogate pair end" {
+  ignore("Hello🤣World".exact_view(end=6))
 }
 
 ///|
-test "panic String::op_as_view beyond string length" {
-  ignore("Hello🤣World"[0:20])
+test "panic String::exact_view beyond string length" {
+  ignore("Hello🤣World".exact_view(start=0, end=20))
 }
 
 ///|
-test "panic String::op_as_view negative index too large" {
-  ignore("Hello🤣World"[-20:])
+test "panic String::exact_view negative index too large" {
+  ignore("Hello🤣World".exact_view(start=-20))
 }
 
 ///|
-test "panic String::op_as_view start > end" {
-  ignore("Hello🤣World"[5:3])
+test "panic String::exact_view start > end" {
+  ignore("Hello🤣World".exact_view(start=5, end=3))
 }
 
 ///|
-test "panic String::op_as_view start on trailing surrogate" {
-  ignore("Hello🤣World"[6:8])
+test "panic String::exact_view start on trailing surrogate" {
+  ignore("Hello🤣World".exact_view(start=6, end=8))
 }
 
 ///|
@@ -755,13 +755,13 @@ test "String::op_as_view with surrogate pairs" {
 }
 
 ///|
-test "panic String::op_as_view splits first emoji" {
-  ignore("Hello🤣😭😂World"[5:6])
+test "panic String::exact_view splits first emoji" {
+  ignore("Hello🤣😭😂World".exact_view(start=5, end=6))
 }
 
 ///|
-test "panic String::op_as_view splits second emoji" {
-  ignore("Hello🤣😭😂World"[7:8])
+test "panic String::exact_view splits second emoji" {
+  ignore("Hello🤣😭😂World".exact_view(start=7, end=8))
 }
 
 ///|
@@ -790,28 +790,28 @@ test "StringView::op_as_view basic usage" {
 }
 
 ///|
-test "panic StringView::op_as_view beyond view range" {
-  ignore("Hello🤣World"[1:11][0:15])
+test "panic StringView::exact_view beyond view range" {
+  ignore("Hello🤣World"[1:11].exact_view(start=0, end=15))
 }
 
 ///|
-test "panic StringView::op_as_view negative index too large" {
-  ignore("Hello🤣World"[1:11][-20:])
+test "panic StringView::exact_view negative index too large" {
+  ignore("Hello🤣World"[1:11].exact_view(start=-20))
 }
 
 ///|
-test "panic StringView::op_as_view start > end" {
-  ignore("Hello🤣World"[1:11][5:3])
+test "panic StringView::exact_view start > end" {
+  ignore("Hello🤣World"[1:11].exact_view(start=5, end=3))
 }
 
 ///|
-test "panic StringView::op_as_view splits surrogate pair" {
-  ignore("Hello🤣World"[1:11][:5])
+test "panic StringView::exact_view splits surrogate pair" {
+  ignore("Hello🤣World"[1:11].exact_view(end=5))
 }
 
 ///|
-test "panic StringView::op_as_view start beyond view" {
-  ignore("Hello🤣World"[1:11][11:])
+test "panic StringView::exact_view start beyond view" {
+  ignore("Hello🤣World"[1:11].exact_view(start=11))
 }
 
 ///|
@@ -832,13 +832,13 @@ test "StringView::op_as_view with surrogate pairs" {
 }
 
 ///|
-test "panic StringView::op_as_view splits first emoji in view" {
-  ignore("Hello🤣😭😂World"[1:15][4:5])
+test "panic StringView::exact_view splits first emoji in view" {
+  ignore("Hello🤣😭😂World"[1:15].exact_view(start=4, end=5))
 }
 
 ///|
-test "panic StringView::op_as_view splits second emoji in view" {
-  ignore("Hello🤣😭😂World"[1:15][6:7])
+test "panic StringView::exact_view splits second emoji in view" {
+  ignore("Hello🤣😭😂World"[1:15].exact_view(start=6, end=7))
 }
 
 ///|
@@ -909,8 +909,8 @@ test "StringView::op_as_view with complex Unicode" {
 }
 
 ///|
-test "panic String::op_as_view splits emoji in complex Unicode" {
-  ignore("Hello🤣😭😂🌍World"[5:6])
+test "panic String::exact_view splits emoji in complex Unicode" {
+  ignore("Hello🤣😭😂🌍World".exact_view(start=5, end=6))
 }
 
 ///|
@@ -969,15 +969,15 @@ test "StringView::op_as_view boundary validation" {
 }
 
 ///|
-test "panic String::op_as_view boundary beyond length" {
+test "panic String::exact_view boundary beyond length" {
   let str = "Hello🤣World"
-  ignore(str[str.length() + 1:])
+  ignore(str.exact_view(start=str.length() + 1))
 }
 
 ///|
-test "panic String::op_as_view boundary negative too large" {
+test "panic String::exact_view boundary negative too large" {
   let str = "Hello🤣World"
-  ignore(str[-str.length() - 1:])
+  ignore(str.exact_view(start=-str.length() - 1))
 }
 
 ///|
@@ -1011,10 +1011,10 @@ test "panic view access out of bounds" {
 }
 
 ///|
-test "panic StringView::op_as_view start on trailing surrogate" {
+test "panic StringView::exact_view start on trailing surrogate" {
   let base = "Hello🤣😭😂World"
   let view = base[1:15] // "ello🤣😭😂Worl"
-  ignore(view[5:])
+  ignore(view.exact_view(start=5))
 }
 
 ///|


### PR DESCRIPTION
Built-in bracket slices currently panic on invalid bounds. Route their operator aliases through `clamped_view` so negative bounds clamp to zero, oversized bounds clamp to the length, and inverted ranges return empty views. This covers all ten indexed built-in types.

Based on `main`, which includes the merged #4216, #4217, and #4218. This PR contains the bracket behavior change, documentation, and test migrations.

String indices remain UTF-16 code-unit offsets, with split surrogate pairs trimmed inward. For `s = "ab😀cd"`, `s[:3]` returns `"ab"` and `s[3:]` returns `"cd"`; `split_at` provides a lossless split. This is a breaking change to bracket syntax. `exact_view` retains strict validation and its intrinsics, and deprecated strict names remain compatible.

Update documentation and tests covering omitted bounds, integer extremes, nested views, Unicode boundaries, shared storage, evaluation order, custom slice operators, and rest patterns. The generated interface changes only the ten slicing aliases.

Validation after rebasing onto `main`:

- `moon check --deny-warn --target all`, `moon info --target wasm,wasm-gc,js,native`, `moon fmt`, and `git diff --check` passed; regeneration left the checkout clean.
- `moon test --target all --deny-warn -p builtin -p string -p bytes -p json -p lexbuf` passed on Wasm (3,831), Wasm GC (3,831), JavaScript (3,801), and native (3,790).
- `git range-diff` and a tree comparison confirm the rebase preserved the slicing patch without source changes.

Compiler-repository snapshot updates are outside this core PR.
