### PR TITLE
feat(builtin): complete clamped_view coverage

### DIFF
--- a/builtin/clamped_view_test.mbt
+++ b/builtin/clamped_view_test.mbt
@@ -315,3 +315,161 @@ test "FixedArray/ReadOnlyArray clamped_view agree with get_view" {
     }
   }
 }
+
+///|
+test "MutArrayView/UninitializedArray clamped_view bounds and offsets" {
+  let lo = @int.MIN_VALUE
+  let hi = @int.MAX_VALUE
+  let cases : ReadOnlyArray[(Int, Int, Int, Array[Int])] = [
+    (-5, 100, 0, [1, 2, 3, 4, 5]),
+    (-2, 2, 0, [1, 2]),
+    (1, 4, 1, [2, 3, 4]),
+    (3, 100, 3, [4, 5]),
+    (4, 1, 4, []),
+    (-9, -3, 0, []),
+    (100, 100, 5, []),
+    (lo, hi, 0, [1, 2, 3, 4, 5]),
+    (hi, lo, 5, []),
+    (lo, lo, 0, []),
+    (hi, hi, 5, []),
+  ]
+  let raw = @builtin.UninitializedArray::make(5)
+  for i in 0..<5 {
+    raw[i] = i + 1
+  }
+  let view = [0, 1, 2, 3, 4, 5, 6].mut_view(start=1, end=6)
+  for (start, end, offset, expected) in cases {
+    let raw_slice = raw.clamped_view(start~, end~)
+    let view_slice = view.clamped_view(start~, end~)
+    assert_eq(raw_slice.to_owned(), expected)
+    assert_eq(raw_slice.start_offset(), offset)
+    assert_eq(view_slice.to_owned(), expected)
+    assert_eq(view_slice.start_offset(), 1 + offset)
+  }
+}
+
+///|
+test "MutArrayView/UninitializedArray clamped_view omitted bounds" {
+  let raw = @builtin.UninitializedArray::make(3)
+  for i in 0..<3 {
+    raw[i] = i + 1
+  }
+  let view = [0, 1, 2, 3, 4].mut_view(start=1, end=4)
+  for result in [raw.clamped_view(), view.clamped_view()] {
+    assert_eq(result.to_owned(), [1, 2, 3])
+  }
+  for result in [raw.clamped_view(start=1), view.clamped_view(start=1)] {
+    assert_eq(result.to_owned(), [2, 3])
+  }
+  for result in [raw.clamped_view(end=2), view.clamped_view(end=2)] {
+    assert_eq(result.to_owned(), [1, 2])
+  }
+  for result in [raw.clamped_view(start=-1), view.clamped_view(start=-1)] {
+    assert_eq(result.to_owned(), [1, 2, 3])
+  }
+  for result in [raw.clamped_view(start=10), view.clamped_view(start=10)] {
+    assert_eq(result.length(), 0)
+  }
+}
+
+///|
+test "MutArrayView/UninitializedArray clamped_view nested views share storage" {
+  let arr = [0, 1, 2, 3, 4]
+  let mutable = arr.mut_view(start=1, end=4)
+  let view = mutable.clamped_view(start=-5, end=100)
+  let nested = view.clamped_view(start=1, end=100)
+  mutable[1] = 20
+  arr[3] = 30
+  json_inspect(view.to_owned(), content=[1, 20, 30])
+  json_inspect(nested.to_owned(), content=[20, 30])
+  inspect(nested.start_offset(), content="2")
+  let raw = @builtin.UninitializedArray::make(3)
+  for i in 0..<3 {
+    raw[i] = i + 1
+  }
+  let view = raw.clamped_view(start=1, end=100)
+  let nested = view.clamped_view(start=1, end=100)
+  raw[2] = 30
+  json_inspect(view.to_owned(), content=[2, 30])
+  json_inspect(nested.to_owned(), content=[30])
+  inspect(nested.start_offset(), content="2")
+}
+
+///|
+test "MutArrayView/UninitializedArray clamped_view empty arrays" {
+  let raw : @builtin.UninitializedArray[Int] = @builtin.UninitializedArray::make(
+    0,
+  )
+  let view = ([] : Array[Int]).mut_view()
+  for
+    (start, end) in [
+      (@int.MIN_VALUE, @int.MAX_VALUE),
+      (@int.MAX_VALUE, @int.MIN_VALUE),
+    ] {
+    for
+      result in [
+        raw.clamped_view(start~, end~),
+        view.clamped_view(start~, end~),
+      ] {
+      assert_eq(result.length(), 0)
+      assert_eq(result.start_offset(), 0)
+    }
+  }
+  let view = [0, 1, 2].mut_view(start=1, end=1)
+  inspect(view.clamped_view(start=-1, end=100).start_offset(), content="1")
+}
+
+///|
+test "Iter::clamped_view clamps finite iterator bounds" {
+  let arr = [1, 2, 3]
+  let cases : ReadOnlyArray[(Int, Int, Array[Int])] = [
+    (-5, 100, [1, 2, 3]),
+    (-2, 2, [1, 2]),
+    (1, 3, [2, 3]),
+    (2, 100, [3]),
+    (2, 1, []),
+    (-9, -3, []),
+    (100, 100, []),
+    (@int.MIN_VALUE, @int.MAX_VALUE, [1, 2, 3]),
+    (@int.MAX_VALUE, @int.MIN_VALUE, []),
+    (@int.MIN_VALUE, @int.MIN_VALUE, []),
+    (@int.MAX_VALUE, @int.MAX_VALUE, []),
+  ]
+  for (start, end, expected) in cases {
+    let result = arr.iter().clamped_view(start~, end~)
+    assert_eq(result.size_hint(), Some(expected.length()))
+    assert_eq(result.collect(), expected)
+    // Iter::new has no size hint, so it also exercises the streaming path.
+    let source = arr.iter()
+    assert_eq(
+      Iter::new(() => source.next()).clamped_view(start~, end~).collect(),
+      expected,
+    )
+  }
+  debug_inspect(arr.iter().clamped_view().collect(), content="[1, 2, 3]")
+  debug_inspect(arr.iter().clamped_view(start=1).collect(), content="[2, 3]")
+  debug_inspect(arr.iter().clamped_view(end=2).collect(), content="[1, 2]")
+  debug_inspect(
+    arr.iter().clamped_view(start=-1).collect(),
+    content="[1, 2, 3]",
+  )
+  debug_inspect(arr.iter().clamped_view(start=100).collect(), content="[]")
+  let empty : Iter[Int] = Iter::empty()
+  debug_inspect(
+    empty.clamped_view(start=@int.MIN_VALUE, end=@int.MAX_VALUE).collect(),
+    content="[]",
+  )
+}
+
+///|
+test "Iter::clamped_view stays lazy and composes" {
+  let mut reads = 0
+  let source = Iter::new(fn() {
+    reads += 1
+    Some(reads)
+  })
+  let view = source.clamped_view(start=1, end=5).clamped_view(start=1, end=3)
+  inspect(reads, content="0")
+  debug_inspect(view.collect(), content="[3, 4]")
+  inspect(reads, content="4")
+}

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -913,11 +913,30 @@ pub fn[X] Iter::intersperse(self : Iter[X], sep : X) -> Iter[X] {
 }
 
 ///|
-/// Return a sliced iterator view in range `[start, end)`.
-/// Function `view`.
+/// Returns a lazy iterator over the range `[start, end)`.
+/// Negative bounds are treated as zero, an inverted range yields no elements,
+/// and iteration stops when the source is exhausted even if `end` is larger.
+/// Omitting both bounds returns the full iterator.
+///
+/// Also available as `iter[start:end]`. The source iterator must not be used
+/// again after calling this method.
+///
+/// ```mbt check
+/// test {
+///   debug_inspect(
+///     [1, 2, 3].iter().clamped_view(start=1, end=10).collect(),
+///     content="[2, 3]",
+///   )
+/// }
+/// ```
 #alias("_[_:_]")
+#alias(view)
 #alias(sub, deprecated="Use _[_:_] instead")
-pub fn[X] Iter::view(self : Iter[X], start? : Int = 0, end? : Int) -> Iter[X] {
+pub fn[X] Iter::clamped_view(
+  self : Iter[X],
+  start? : Int = 0,
+  end? : Int,
+) -> Iter[X] {
   match (start, end) {
     (_..=0, None) => self
     (_..=0, Some(end)) => self.take(end)

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -385,6 +385,34 @@ pub fn[T] MutArrayView::view(
 }
 
 ///|
+/// Creates a read-only view of a portion of the mutable view without copying.
+/// The indices are relative to the current view. Each bound is clamped to
+/// `[0, length()]`; an inverted range yields an empty view at the clamped
+/// `start`. Defaults to the full view when both bounds are omitted.
+///
+/// ```mbt check
+/// test {
+///   let arr = [1, 2, 3, 4, 5]
+///   let view = arr.mut_view(start=1, end=4)
+///   json_inspect(view.clamped_view(start=1, end=10).to_owned(), content=[3, 4])
+/// }
+/// ```
+pub fn[T] MutArrayView::clamped_view(
+  self : MutArrayView[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T] {
+  let len = self.length()
+  let lo = clamp_offset(start, len)
+  let hi = match end {
+    None => len
+    Some(end) => clamp_offset(end, len)
+  }
+  let count = if hi > lo { hi - lo } else { 0 }
+  ArrayView::make(self.buf(), self.start() + lo, count)
+}
+
+///|
 /// Copies the elements of the mutable array view into a newly allocated `Array`.
 #alias(to_array, deprecated)
 pub fn[T] MutArrayView::to_owned(self : MutArrayView[T]) -> Array[T] {

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -285,6 +285,10 @@ type Iter[X]
 pub fn[T] Iter::add(Self[T], Self[T]) -> Self[T]
 pub fn[X] Iter::all(Self[X], (X) -> Bool) -> Bool
 pub fn[X] Iter::any(Self[X], (X) -> Bool) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view)
+pub fn[X] Iter::clamped_view(Self[X], start? : Int, end? : Int) -> Self[X]
 pub fn[X] Iter::concat(Self[X], Self[X]) -> Self[X]
 pub fn[X : Eq] Iter::contains(Self[X], X) -> Bool
 #alias(length)
@@ -327,9 +331,6 @@ pub fn[X] Iter::tap(Self[X], (X) -> Unit) -> Self[X]
 #alias(collect)
 pub fn[X] Iter::to_array(Self[X]) -> Array[X]
 pub fn[X : ToJson] Iter::to_json(Self[X]) -> Json
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn[X] Iter::view(Self[X], start? : Int, end? : Int) -> Self[X]
 #alias(combine)
 pub fn[X, Y] Iter::zip(Self[X], Self[Y]) -> Self[(X, Y)]
 pub impl[T] Add for Iter[T]
@@ -424,6 +425,7 @@ pub impl[K : Show, V : ToJson] ToJson for Map[K, V]
 type MutArrayView[T]
 #alias("_[_]")
 pub fn[T] MutArrayView::at(Self[T], Int) -> T
+pub fn[T] MutArrayView::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T : Compare] MutArrayView::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] MutArrayView::equal(Self[T], Self[T]) -> Bool
 pub fn[A : Hash] MutArrayView::hash(Self[A]) -> Int
@@ -482,6 +484,7 @@ pub impl Show for StringBuilder
 type UninitializedArray[T]
 #alias("_[_]")
 pub fn[T] UninitializedArray::at(Self[T], Int) -> T
+pub fn[T] UninitializedArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[A] UninitializedArray::length(Self[A]) -> Int
 pub fn[T] UninitializedArray::make(Int) -> Self[T]
 pub fn[T] UninitializedArray::make_and_blit(Self[T], allocate_len~ : Int, len~ : Int, src_offset? : Int, dst_offset? : Int) -> Self[T]

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -102,6 +102,37 @@ pub fn[T] UninitializedArray::sub(
 }
 
 ///|
+/// Creates a view of a portion of the uninitialized array without copying.
+/// Each bound is clamped to `[0, length()]`; an inverted range yields an empty
+/// view at the clamped `start`. Defaults to the full array when both bounds
+/// are omitted. Elements must be initialized before they are read through the
+/// returned view.
+///
+/// ```mbt check
+/// test {
+///   let arr = @builtin.UninitializedArray::make(3)
+///   for i in 0..<3 {
+///     arr[i] = i + 1
+///   }
+///   json_inspect(arr.clamped_view(start=1, end=10).to_owned(), content=[2, 3])
+/// }
+/// ```
+pub fn[T] UninitializedArray::clamped_view(
+  self : UninitializedArray[T],
+  start? : Int = 0,
+  end? : Int,
+) -> ArrayView[T] {
+  let len = self.length()
+  let lo = clamp_offset(start, len)
+  let hi = match end {
+    None => len
+    Some(end) => clamp_offset(end, len)
+  }
+  let count = if hi > lo { hi - lo } else { 0 }
+  ArrayView::make(self, lo, count)
+}
+
+///|
 /// Returns the length of an uninitialized array.
 ///
 /// Parameters:


### PR DESCRIPTION
Complete the named clamped slicing API before changing bracket syntax in #4215. Add `clamped_view` to `MutArrayView` and `UninitializedArray`, using the same bounds and empty-range contract as the other indexed built-ins. The returned views share storage; uninitialized elements must still be initialized before reading.

The coverage audit also found `Iter::view`, whose existing lazy behavior already clamps. Expose it as `Iter::clamped_view`, retaining `view` and the existing operator aliases. Indexed bracket slicing remains strict in this prerequisite.

Add tests for omitted and extreme bounds, relative offsets, empty arrays, nested views, shared storage, iterator size hints, and laziness. Regenerate the builtin interface.

Validation: `moon check --target all`, `moon info`, and `moon fmt` passed. Builtin tests passed in both debug and release modes on Wasm (3,017), Wasm GC (3,017), JavaScript (2,987), and native (2,976). Existing unused-package warnings remain.
