### PR TITLE
refactor(builtin): name strict slices exact_view

### DIFF
--- a/array/README.mbt.md
+++ b/array/README.mbt.md
@@ -86,7 +86,10 @@ test "sorting" {
 
 ## Array Views
 
-Array views provide a lightweight way to work with array slices:
+Array views provide a lightweight way to work with array slices.
+Use `arr.exact_view(start~, end~)` to validate bounds, `arr.get_view(start~, end~)`
+to return `None` for invalid bounds, or `arr.clamped_view(start~, end~)` to clamp
+them. The old `view` and `sub` names are deprecated in favor of `exact_view`.
 
 ```mbt check
 ///|

--- a/bench/hash_bench_test.mbt
+++ b/bench/hash_bench_test.mbt
@@ -33,21 +33,21 @@ test "bench Hash for Bytes (large)" (it : @bench.T) {
 ///|
 test "bench Hash for BytesView (small)" (it : @bench.T) {
   let data = Bytes::make(16, 0xAB)
-  let view = data.view()
+  let view = data.exact_view()
   it.bench(fn() { it.keep(Hash::hash(view)) })
 }
 
 ///|
 test "bench Hash for BytesView (medium)" (it : @bench.T) {
   let data = Bytes::make(256, 0xAB)
-  let view = data.view()
+  let view = data.exact_view()
   it.bench(fn() { it.keep(Hash::hash(view)) })
 }
 
 ///|
 test "bench Hash for BytesView (large)" (it : @bench.T) {
   let data = Bytes::make(4096, 0xAB)
-  let view = data.view()
+  let view = data.exact_view()
   it.bench(fn() { it.keep(Hash::hash(view)) })
 }
 

--- a/bigint/parse_bigint_test.mbt
+++ b/bigint/parse_bigint_test.mbt
@@ -26,7 +26,7 @@ test "parse_bigint valid" {
 test "parse_bigint StringView" {
   let input = "prefix-ffsuffix"
   inspect(
-    @bigint.parse_bigint(input.view(start_offset=6, end_offset=9), base=16),
+    @bigint.parse_bigint(input.exact_view(start=6, end=9), base=16),
     content="-255",
   )
 }

--- a/builtin/LinkedHashMap.mbt.md
+++ b/builtin/LinkedHashMap.mbt.md
@@ -47,7 +47,7 @@ test {
   // Using get_from_string with StringView
   let string_map = { "hello": 1, "world": 2 }
   let full_string = "say hello to everyone"
-  let hello_view = full_string.view(start_offset=4, end_offset=9)
+  let hello_view = full_string.exact_view(start=4, end=9)
   debug_inspect(string_map.get_from_string(hello_view), content="Some(1)")
 
   // Using get_from_bytes with BytesView

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -271,8 +271,9 @@ pub fn[T] ArrayView::unsafe_get(self : ArrayView[T], index : Int) -> T {
 /// ```
 #intrinsic("%array.view")
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_] instead")
-pub fn[T] Array::view(
+#alias(view, deprecated="Use `exact_view` instead")
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn[T] Array::exact_view(
   self : Array[T],
   start? : Int = 0,
   end? : Int,
@@ -365,8 +366,9 @@ pub fn[T] Array::get_view(
 /// ```
 #intrinsic("%arrayview.view")
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_] instead")
-pub fn[T] ArrayView::view(
+#alias(view, deprecated="Use `exact_view` instead")
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn[T] ArrayView::exact_view(
   self : ArrayView[T],
   start? : Int = 0,
   end? : Int,
@@ -565,8 +567,9 @@ fn[T] unsafe_cast_fixedarray_to_uninitializedarray(
 /// ```
 #intrinsic("%fixedarray.view")
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_] instead")
-pub fn[T] FixedArray::view(
+#alias(view, deprecated="Use `exact_view` instead")
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn[T] FixedArray::exact_view(
   self : FixedArray[T],
   start? : Int = 0,
   end? : Int,

--- a/builtin/bytesview.mbt
+++ b/builtin/bytesview.mbt
@@ -179,8 +179,13 @@ pub fn BytesView::unsafe_get(self : BytesView, index : Int) -> Byte {
 /// ```
 #intrinsic("%bytes.view")
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_] instead")
-pub fn Bytes::view(self : Bytes, start? : Int = 0, end? : Int) -> BytesView {
+#alias(view, deprecated="Use `exact_view` instead")
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn Bytes::exact_view(
+  self : Bytes,
+  start? : Int = 0,
+  end? : Int,
+) -> BytesView {
   let len = self.length()
   let end = match end {
     Some(end) | (None with end = len) => end
@@ -193,7 +198,7 @@ pub fn Bytes::view(self : Bytes, start? : Int = 0, end? : Int) -> BytesView {
 
 ///|
 /// Returns a view of the bytes between `start` and `end`, or `None` if the range
-/// is invalid. Unlike `Bytes::view` (a.k.a. `b[start:end]`), this variant does
+/// is invalid. Unlike `Bytes::exact_view` (a.k.a. `b[start:end]`), this variant does
 /// not abort on out-of-bounds indices, making it suitable for composition with
 /// pattern matching:
 ///
@@ -223,7 +228,7 @@ pub fn Bytes::get_view(
 
 ///|
 /// Returns a sub-view of the view between `start` and `end`, or `None` if the
-/// range is invalid. The optional variant of `BytesView::view` (a.k.a.
+/// range is invalid. The optional variant of `BytesView::exact_view` (a.k.a.
 /// `bv[start:end]`).
 pub fn BytesView::get_view(
   self : BytesView,
@@ -253,8 +258,9 @@ pub fn BytesView::get_view(
 /// ```
 #intrinsic("%bytesview.view")
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_] instead")
-pub fn BytesView::view(
+#alias(view, deprecated="Use `exact_view` instead")
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn BytesView::exact_view(
   self : BytesView,
   start? : Int = 0,
   end? : Int,

--- a/builtin/clamped_view_test.mbt
+++ b/builtin/clamped_view_test.mbt
@@ -68,7 +68,7 @@ test "clamped_view chunking loop reassembles the original" {
 
 ///|
 test "StringView::clamped_view uses view-relative offsets" {
-  let v = "xx ab😀cd".view(start_offset=3) // "ab😀cd", 😀 at units 2-3
+  let v = "xx ab😀cd".exact_view(start=3) // "ab😀cd", 😀 at units 2-3
   inspect(v.clamped_view(end=3), content="ab")
   inspect(v.clamped_view(start=3), content="cd")
   inspect(v.clamped_view(start=3, end=3), content="")

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -119,3 +119,31 @@ pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
 pub fn[T] Array::new(capacity? : Int = 0) -> Array[T] {
   Array(capacity~)
 }
+
+///|
+/// Creates a view using raw UTF-16 code-unit offsets.
+/// Numeric bounds are checked; surrogate pairs may be split.
+/// Use `StringView::exact_view(start~, end~)` for validated text boundaries.
+#deprecated("Use `exact_view` with `start` and `end` instead; it also validates surrogate boundaries")
+pub fn StringView::view(
+  self : StringView,
+  start_offset? : Int = 0,
+  end_offset? : Int,
+) -> StringView {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
+  self.raw_view(start_offset~, end_offset~)
+}
+
+///|
+/// Creates a view using raw UTF-16 code-unit offsets.
+/// Numeric bounds are checked; surrogate pairs may be split.
+/// Use `String::exact_view(start~, end~)` for validated text boundaries.
+#deprecated("Use `exact_view` with `start` and `end` instead; it also validates surrogate boundaries")
+pub fn String::view(
+  self : String,
+  start_offset? : Int = 0,
+  end_offset? : Int,
+) -> StringView {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
+  self.raw_view(start_offset~, end_offset~)
+}

--- a/builtin/deprecated.mbt
+++ b/builtin/deprecated.mbt
@@ -119,31 +119,3 @@ pub fn String::unsafe_char_at(self : String, index : Int) -> Char {
 pub fn[T] Array::new(capacity? : Int = 0) -> Array[T] {
   Array(capacity~)
 }
-
-///|
-/// Creates a view using raw UTF-16 code-unit offsets.
-/// Numeric bounds are checked; surrogate pairs may be split.
-/// Use `StringView::exact_view(start~, end~)` for validated text boundaries.
-#deprecated("Use `exact_view` with `start` and `end` instead; it also validates surrogate boundaries")
-pub fn StringView::view(
-  self : StringView,
-  start_offset? : Int = 0,
-  end_offset? : Int,
-) -> StringView {
-  let end_offset = if end_offset is Some(o) { o } else { self.length() }
-  self.raw_view(start_offset~, end_offset~)
-}
-
-///|
-/// Creates a view using raw UTF-16 code-unit offsets.
-/// Numeric bounds are checked; surrogate pairs may be split.
-/// Use `String::exact_view(start~, end~)` for validated text boundaries.
-#deprecated("Use `exact_view` with `start` and `end` instead; it also validates surrogate boundaries")
-pub fn String::view(
-  self : String,
-  start_offset? : Int = 0,
-  end_offset? : Int,
-) -> StringView {
-  let end_offset = if end_offset is Some(o) { o } else { self.length() }
-  self.raw_view(start_offset~, end_offset~)
-}

--- a/builtin/exact_view_test.mbt
+++ b/builtin/exact_view_test.mbt
@@ -130,30 +130,30 @@ test "text operations retain raw UTF-16 behavior" {
 }
 
 ///|
-test "raw_view retains split UTF-16 pairs and relative offsets" {
+test "view retains split UTF-16 pairs and relative offsets" {
   let text = "ab😀cd"
-  let nested = "xxab😀cdyy".raw_view(start_offset=2, end_offset=8)
-  inspect(text.raw_view(), content="ab😀cd")
-  inspect(nested.raw_view(), content="ab😀cd")
-  for head in [text.raw_view(end_offset=3), nested.raw_view(end_offset=3)] {
+  let nested = "xxab😀cdyy".view(start_offset=2, end_offset=8)
+  inspect(text.view(), content="ab😀cd")
+  inspect(nested.view(), content="ab😀cd")
+  for head in [text.view(end_offset=3), nested.view(end_offset=3)] {
     assert_eq(head.length(), 3)
     assert_eq(head.code_unit_at(2).to_int(), 0xD83D)
   }
-  for tail in [text.raw_view(start_offset=3), nested.raw_view(start_offset=3)] {
+  for tail in [text.view(start_offset=3), nested.view(start_offset=3)] {
     assert_eq(tail.length(), 3)
     assert_eq(tail.code_unit_at(0).to_int(), 0xDE00)
-    assert_eq(tail.raw_view(start_offset=1).to_owned(), "cd")
+    assert_eq(tail.view(start_offset=1).to_owned(), "cd")
   }
-  inspect(text.raw_view(start_offset=3, end_offset=3).length(), content="0")
-  inspect(nested.raw_view(start_offset=3, end_offset=3).length(), content="0")
+  inspect(text.view(start_offset=3, end_offset=3).length(), content="0")
+  inspect(nested.view(start_offset=3, end_offset=3).length(), content="0")
 }
 
 ///|
-test "panic raw_view rejects negative string bounds" {
-  ignore("abc".raw_view(start_offset=-1))
+test "panic view rejects negative string bounds" {
+  ignore("abc".view(start_offset=-1))
 }
 
 ///|
-test "panic raw_view checks bounds against the nested view" {
-  ignore("xabcx".raw_view(start_offset=1, end_offset=4).raw_view(end_offset=4))
+test "panic view checks bounds against the nested view" {
+  ignore("xabcx".view(start_offset=1, end_offset=4).view(end_offset=4))
 }

--- a/builtin/exact_view_test.mbt
+++ b/builtin/exact_view_test.mbt
@@ -1,0 +1,130 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "exact_view uses the same bounds on all array types" {
+  let arr = [1, 2, 3, 4]
+  let fixed : FixedArray[Int] = [1, 2, 3, 4]
+  let ro : ReadOnlyArray[Int] = [1, 2, 3, 4]
+  let view = [0, 1, 2, 3, 4, 5][1:5]
+  let mutable = arr.mut_view()
+  let raw = @builtin.UninitializedArray::make(4)
+  for i in 0..<4 {
+    raw[i] = i + 1
+  }
+  for
+    result in [
+      arr.exact_view(start=1, end=3),
+      fixed.exact_view(start=1, end=3),
+      ro.exact_view(start=1, end=3),
+      view.exact_view(start=1, end=3),
+      mutable.exact_view(start=1, end=3),
+      raw.exact_view(start=1, end=3),
+    ] {
+    assert_eq(result.to_owned(), [2, 3])
+    assert_eq(result.exact_view().to_owned(), [2, 3])
+    assert_eq(result.exact_view(start=1).to_owned(), [3])
+    assert_eq(result.exact_view(end=1).to_owned(), [2])
+  }
+  let result = mutable.exact_view(start=1)
+  mutable[1] = 20
+  json_inspect(result.to_owned(), content=[20, 3, 4])
+}
+
+///|
+test "exact_view strings and bytes use start and end" {
+  let text = "ab😀cd"
+  let view = "xxab😀cdyy"[2:8]
+  inspect(text.exact_view(start=2, end=4), content="😀")
+  inspect(view.exact_view(start=2, end=4), content="😀")
+  inspect(view.exact_view(start=4), content="cd")
+  inspect(view.exact_view(end=2), content="ab")
+  inspect(view.exact_view(), content="ab😀cd")
+  let bytes = b"abcd"
+  let view = b"xabcdx"[1:5]
+  inspect(bytes.exact_view(start=1, end=3).to_owned(), content="b\"bc\"")
+  inspect(view.exact_view(start=1, end=3).to_owned(), content="b\"bc\"")
+  inspect(view.exact_view(start=2).to_owned(), content="b\"cd\"")
+  inspect(view.exact_view(end=2).to_owned(), content="b\"ab\"")
+  inspect(view.exact_view().to_owned(), content="b\"abcd\"")
+}
+
+///|
+test "panic exact_view rejects a negative array bound" {
+  ignore([1, 2, 3].exact_view(start=-1))
+}
+
+///|
+test "panic exact_view rejects an oversized fixed array bound" {
+  let fixed : FixedArray[Int] = [1, 2, 3]
+  ignore(fixed.exact_view(end=4))
+}
+
+///|
+test "panic exact_view rejects an inverted readonly array range" {
+  let ro : ReadOnlyArray[Int] = [1, 2, 3]
+  ignore(ro.exact_view(start=2, end=1))
+}
+
+///|
+test "panic exact_view rejects bounds outside an array view" {
+  ignore([0, 1, 2, 3][1:3].exact_view(end=3))
+}
+
+///|
+test "panic exact_view rejects bounds outside a mutable view" {
+  ignore([0, 1, 2, 3].mut_view(start=1, end=3).exact_view(end=3))
+}
+
+///|
+test "panic exact_view rejects uninitialized array bounds" {
+  let raw : @builtin.UninitializedArray[Int] = @builtin.UninitializedArray::make(
+    3,
+  )
+  ignore(raw.exact_view(end=4))
+}
+
+///|
+test "panic exact_view rejects a negative byte bound" {
+  ignore(b"abc".exact_view(start=-1))
+}
+
+///|
+test "panic exact_view rejects bounds outside a byte view" {
+  ignore(b"abcd"[1:3].exact_view(end=3))
+}
+
+///|
+test "panic exact_view rejects a split string surrogate pair" {
+  ignore("ab😀cd".exact_view(end=3))
+}
+
+///|
+test "panic exact_view rejects a split string view surrogate pair" {
+  ignore("xxab😀cdyy"[2:8].exact_view(start=3))
+}
+
+///|
+test "text operations retain raw UTF-16 behavior" {
+  // Testing a nonmatching one-unit prefix/suffix must not split the emoji
+  // through exact_view and panic before the comparison can return None.
+  debug_inspect("😀".strip_prefix("a"), content="None")
+  debug_inspect("😀".strip_suffix("a"), content="None")
+  let low = "😀".unsafe_substring(start=1, end=2)
+  let text = "a" + low + "b"
+  let stripped = text.strip_prefix("a").unwrap()
+  inspect(stripped.length(), content="2")
+  inspect(stripped.code_unit_at(0) == low.code_unit_at(0), content="true")
+  inspect(text.replace(old="a", new="x").length(), content="3")
+}

--- a/builtin/exact_view_test.mbt
+++ b/builtin/exact_view_test.mbt
@@ -128,3 +128,32 @@ test "text operations retain raw UTF-16 behavior" {
   inspect(stripped.code_unit_at(0) == low.code_unit_at(0), content="true")
   inspect(text.replace(old="a", new="x").length(), content="3")
 }
+
+///|
+test "raw_view retains split UTF-16 pairs and relative offsets" {
+  let text = "ab😀cd"
+  let nested = "xxab😀cdyy".raw_view(start_offset=2, end_offset=8)
+  inspect(text.raw_view(), content="ab😀cd")
+  inspect(nested.raw_view(), content="ab😀cd")
+  for head in [text.raw_view(end_offset=3), nested.raw_view(end_offset=3)] {
+    assert_eq(head.length(), 3)
+    assert_eq(head.code_unit_at(2).to_int(), 0xD83D)
+  }
+  for tail in [text.raw_view(start_offset=3), nested.raw_view(start_offset=3)] {
+    assert_eq(tail.length(), 3)
+    assert_eq(tail.code_unit_at(0).to_int(), 0xDE00)
+    assert_eq(tail.raw_view(start_offset=1).to_owned(), "cd")
+  }
+  inspect(text.raw_view(start_offset=3, end_offset=3).length(), content="0")
+  inspect(nested.raw_view(start_offset=3, end_offset=3).length(), content="0")
+}
+
+///|
+test "panic raw_view rejects negative string bounds" {
+  ignore("abc".raw_view(start_offset=-1))
+}
+
+///|
+test "panic raw_view checks bounds against the nested view" {
+  ignore("xabcx".raw_view(start_offset=1, end_offset=4).raw_view(end_offset=4))
+}

--- a/builtin/fixedarray_test.mbt
+++ b/builtin/fixedarray_test.mbt
@@ -369,7 +369,7 @@ test "fixedarray_fill - existing documentation example" {
 }
 
 ///|
-test "FixedArray::sub" {
+test "FixedArray::exact_view" {
   let arr = FixedArray::makei(10, i => i * i)
   let sub = arr[:]
   debug_inspect(
@@ -389,7 +389,7 @@ fn sum(xs : ArrayView[Int]) -> Int {
 ///|
 // TODO: fix(upstream) later
 #cfg(false)
-test "FixedArray::sub - sum" {
+test "FixedArray::exact_view - sum" {
   let arr = FixedArray::makei(10, i => i * i)
   inspect(sum(arr), content="385")
 }

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -379,7 +379,7 @@ pub fn Hasher::combine_byte(self : Hasher, value : Byte) -> Unit {
 /// }
 /// ```
 pub fn Hasher::combine_bytes(self : Hasher, value : Bytes) -> Unit {
-  for data = value.view() {
+  for data = value.exact_view() {
     if data is [u32le(x), .. rest] {
       self.consume4(x)
       continue rest

--- a/builtin/iter_test.mbt
+++ b/builtin/iter_test.mbt
@@ -334,11 +334,11 @@ test "size_hint" {
   debug_inspect([|1, 2, 3|][1:3].size_hint(), content="Some(2)")
   debug_inspect([|1, 2, 3|][3:5].size_hint(), content="Some(0)")
   debug_inspect(
-    Iter::new(() => Some(1)).view(start=2, end=1).size_hint(),
+    Iter::new(() => Some(1)).clamped_view(start=2, end=1).size_hint(),
     content="Some(0)",
   )
   debug_inspect(
-    Iter::new(() => Some(1)).view(start=1, end=3).size_hint(),
+    Iter::new(() => Some(1)).clamped_view(start=1, end=3).size_hint(),
     content="None",
   )
   debug_inspect([|1, 2, 3|].filter(x => x > 1).size_hint(), content="None")
@@ -1231,8 +1231,11 @@ test "Iter::maximum" {
 }
 
 ///|
-test "Iter::view variants" {
-  debug_inspect([|1, 2, 3|].view(start=-1).collect(), content="[1, 2, 3]")
+test "Iter::clamped_view variants" {
+  debug_inspect(
+    [|1, 2, 3|].clamped_view(start=-1).collect(),
+    content="[1, 2, 3]",
+  )
   debug_inspect([|1, 2, 3|][:2].collect(), content="[1, 2]")
   debug_inspect([|1, 2, 3|][1:].collect(), content="[2, 3]")
   debug_inspect([|1, 2, 3, 4|][1:3].collect(), content="[2, 3]")

--- a/builtin/iterator.mbt
+++ b/builtin/iterator.mbt
@@ -930,8 +930,8 @@ pub fn[X] Iter::intersperse(self : Iter[X], sep : X) -> Iter[X] {
 /// }
 /// ```
 #alias("_[_:_]")
-#alias(view)
-#alias(sub, deprecated="Use _[_:_] instead")
+#alias(view, deprecated="Use `clamped_view` instead")
+#alias(sub, deprecated="Use `clamped_view` instead")
 pub fn[X] Iter::clamped_view(
   self : Iter[X],
   start? : Int = 0,

--- a/builtin/linked_hash_map.mbt
+++ b/builtin/linked_hash_map.mbt
@@ -1241,7 +1241,7 @@ pub fn[V] Map::get_from_bytes(map : Self[Bytes, V], key : BytesView) -> V? {
 /// test {
 ///   let map = { "hello": 1, "world": 2 }
 ///   let str = "say hello to everyone"
-///   let view = str.view(start_offset=4, end_offset=9) // view of "hello"
+///   let view = str.exact_view(start=4, end=9) // view of "hello"
 ///   debug_inspect(map.get_from_string(view), content="Some(1)")
 /// }
 /// ```

--- a/builtin/linked_hash_map_test.mbt
+++ b/builtin/linked_hash_map_test.mbt
@@ -509,7 +509,7 @@ test "Map::get_from_string" {
 
   // Test string view from substring
   let full_str = "prefix_world_suffix"
-  let view2 = full_str.view(start_offset=7, end_offset=12)
+  let view2 = full_str.exact_view(start=7, end=12)
   debug_inspect(map.get_from_string(view2), content="Some(2)")
 
   // Test non-existent key
@@ -531,7 +531,7 @@ test "Map::get_from_string" {
 
   // Test with longer string containing the key as substring
   let longer = "this is a test string"
-  let test_view = longer.view(start_offset=10, end_offset=14)
+  let test_view = longer.exact_view(start=10, end=14)
   debug_inspect(map.get_from_string(test_view), content="Some(3)")
 }
 

--- a/builtin/mutarrayview.mbt
+++ b/builtin/mutarrayview.mbt
@@ -368,8 +368,9 @@ pub fn[T] FixedArray::mut_view(
 /// length of the current view.
 #intrinsic("%mutarrayview.view")
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_] instead")
-pub fn[T] MutArrayView::view(
+#alias(view, deprecated="Use `exact_view` instead")
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn[T] MutArrayView::exact_view(
   self : MutArrayView[T],
   start? : Int = 0,
   end? : Int,

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -95,6 +95,10 @@ pub fn[T] Array::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] Array::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] Array::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] Array::equal(Self[T], Self[T]) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view, deprecated)
+pub fn[T] Array::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] Array::extract_if(Self[T], (T) -> Bool raise?) -> Self[T] raise?
 pub fn[A] Array::fill(Self[A], A, start? : Int, end? : Int) -> Unit
 pub fn[T] Array::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
@@ -176,9 +180,6 @@ pub fn[A] Array::unsafe_blit_fixed(Self[A], Int, FixedArray[A], Int, Int) -> Uni
 pub fn[T] Array::unsafe_get(Self[T], Int) -> T
 pub fn[T] Array::unsafe_set(Self[T], Int, T) -> Unit
 pub fn[T1, T2] Array::unzip(Self[(T1, T2)]) -> (Self[T1], Self[T2])
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn[T] Array::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] Array::windows(Self[T], Int) -> Self[ArrayView[T]]
 pub fn[A, B] Array::zip(Self[A], Self[B]) -> Self[(A, B)]
 pub fn[A, B] Array::zip_to_iter2(Self[A], Self[B]) -> Iter2[A, B]
@@ -213,6 +214,10 @@ pub fn[T] ArrayView::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ArrayView::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ArrayView::ends_with(Self[T], Self[T]) -> Bool
 pub fn[T : Eq] ArrayView::equal(Self[T], Self[T]) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view, deprecated)
+pub fn[T] ArrayView::exact_view(Self[T], start? : Int, end? : Int) -> Self[T]
 pub fn[T] ArrayView::filter(Self[T], (T) -> Bool raise?) -> Array[T] raise?
 pub fn[A, B] ArrayView::filter_map(Self[A], (A) -> B? raise?) -> Array[B] raise?
 pub fn[A, B] ArrayView::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
@@ -249,9 +254,6 @@ pub fn[T] ArrayView::suffixes(Self[T], include_empty? : Bool) -> Iter[Self[T]]
 pub fn[X : ToJson] ArrayView::to_json(Self[X]) -> Json
 #alias(to_array, deprecated)
 pub fn[T] ArrayView::to_owned(Self[T]) -> Array[T]
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn[T] ArrayView::view(Self[T], start? : Int, end? : Int) -> Self[T]
 pub fn[T] ArrayView::windows(Self[T], Int) -> Array[Self[T]]
 pub impl[T] Add for ArrayView[T]
 pub impl[T : Compare] Compare for ArrayView[T]
@@ -287,7 +289,7 @@ pub fn[X] Iter::all(Self[X], (X) -> Bool) -> Bool
 pub fn[X] Iter::any(Self[X], (X) -> Bool) -> Bool
 #alias("_[_:_]")
 #alias(sub, deprecated)
-#alias(view)
+#alias(view, deprecated)
 pub fn[X] Iter::clamped_view(Self[X], start? : Int, end? : Int) -> Self[X]
 pub fn[X] Iter::concat(Self[X], Self[X]) -> Self[X]
 pub fn[X : Eq] Iter::contains(Self[X], X) -> Bool
@@ -428,6 +430,10 @@ pub fn[T] MutArrayView::at(Self[T], Int) -> T
 pub fn[T] MutArrayView::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T : Compare] MutArrayView::compare(Self[T], Self[T]) -> Int
 pub fn[T : Eq] MutArrayView::equal(Self[T], Self[T]) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view, deprecated)
+pub fn[T] MutArrayView::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[A : Hash] MutArrayView::hash(Self[A]) -> Int
 pub fn[T] MutArrayView::is_empty(Self[T]) -> Bool
 #alias(iterator, deprecated)
@@ -449,9 +455,6 @@ pub fn[T] MutArrayView::start_offset(Self[T]) -> Int
 pub fn[T] MutArrayView::to_owned(Self[T]) -> Array[T]
 pub fn[T] MutArrayView::unsafe_get(Self[T], Int) -> T
 pub fn[T] MutArrayView::unsafe_set(Self[T], Int, T) -> Unit
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn[T] MutArrayView::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub impl[T : Compare] Compare for MutArrayView[T]
 pub impl[T : Eq] Eq for MutArrayView[T]
 pub impl[A : Hash] Hash for MutArrayView[A]
@@ -485,13 +488,14 @@ type UninitializedArray[T]
 #alias("_[_]")
 pub fn[T] UninitializedArray::at(Self[T], Int) -> T
 pub fn[T] UninitializedArray::clamped_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
+#alias("_[_:_]")
+#alias(sub, deprecated)
+pub fn[T] UninitializedArray::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[A] UninitializedArray::length(Self[A]) -> Int
 pub fn[T] UninitializedArray::make(Int) -> Self[T]
 pub fn[T] UninitializedArray::make_and_blit(Self[T], allocate_len~ : Int, len~ : Int, src_offset? : Int, dst_offset? : Int) -> Self[T]
 #alias("_[_]=_")
 pub fn[T] UninitializedArray::set(Self[T], Int, T) -> Unit
-#alias("_[_:_]")
-pub fn[T] UninitializedArray::sub(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 
 pub fn Unit::compare(Unit, Unit) -> Int
 pub fn Unit::equal(Unit, Unit) -> Bool
@@ -868,6 +872,9 @@ pub fn String::contains_code_unit(String, UInt16) -> Bool
 pub fn String::equal(String, String) -> Bool
 pub fn String::equal_ignore_ascii_case(String, String) -> Bool
 pub fn String::escape(String, quote? : Bool) -> String
+#alias("_[_:_]")
+#alias(sub, deprecated)
+pub fn String::exact_view(String, start? : Int, end? : Int) -> StringView
 pub fn String::find(String, StringView) -> Int?
 pub fn String::find_by(String, (Char) -> Bool) -> Int?
 pub fn[A] String::fold(String, init~ : A, (A, Char) -> A raise?) -> A raise?
@@ -913,8 +920,6 @@ pub fn String::split_once(String, StringView) -> (StringView, StringView)?
 pub fn String::strip_prefix(String, StringView) -> StringView?
 #alias(chop_suffix)
 pub fn String::strip_suffix(String, StringView) -> StringView?
-#alias("_[_:_]")
-pub fn String::sub(String, start? : Int, end? : Int) -> StringView
 #deprecated
 pub fn String::substring(String, start? : Int, end? : Int) -> String
 pub fn String::suffixes(String, include_empty? : Bool) -> Iter[StringView]
@@ -937,6 +942,7 @@ pub fn String::trim_start(String, chars? : StringView) -> StringView
 #deprecated
 pub fn String::unsafe_char_at(String, Int) -> Char
 pub fn String::unsafe_substring(String, start~ : Int, end~ : Int) -> String
+#deprecated
 pub fn String::view(String, start_offset? : Int, end_offset? : Int) -> StringView
 
 pub fn[T, U] Option::bind(T?, (T) -> U? raise?) -> U? raise?
@@ -1010,6 +1016,10 @@ pub fn[T] FixedArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] FixedArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] FixedArray::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] FixedArray::equal(Self[T], Self[T]) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view, deprecated)
+pub fn[T] FixedArray::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] FixedArray::fill(Self[T], T, start? : Int, end? : Int) -> Unit
 pub fn[A, B] FixedArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
 pub fn[A, B] FixedArray::foldi(Self[A], init~ : B, (Int, B, A) -> B raise?) -> B raise?
@@ -1062,9 +1072,6 @@ pub fn FixedArray::unsafe_write_uint32_be(Self[Byte], Int, UInt) -> Unit
 pub fn FixedArray::unsafe_write_uint32_le(Self[Byte], Int, UInt) -> Unit
 pub fn FixedArray::unsafe_write_uint64_be(Self[Byte], Int, UInt64) -> Unit
 pub fn FixedArray::unsafe_write_uint64_le(Self[Byte], Int, UInt64) -> Unit
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn[T] FixedArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 
 #alias(every)
 pub fn[T] ReadOnlyArray::all(Self[T], (T) -> Bool raise?) -> Bool raise?
@@ -1083,6 +1090,10 @@ pub fn[T] ReadOnlyArray::each(Self[T], (T) -> Unit raise?) -> Unit raise?
 pub fn[T] ReadOnlyArray::eachi(Self[T], (Int, T) -> Unit raise?) -> Unit raise?
 pub fn[T : Eq] ReadOnlyArray::ends_with(Self[T], ArrayView[T]) -> Bool
 pub fn[T : Eq] ReadOnlyArray::equal(Self[T], Self[T]) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view, deprecated)
+pub fn[T] ReadOnlyArray::exact_view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] ReadOnlyArray::filter(Self[T], (T) -> Bool raise?) -> Self[T] raise?
 pub fn[A, B] ReadOnlyArray::filter_map(Self[A], (A) -> B? raise?) -> Self[B] raise?
 pub fn[A, B] ReadOnlyArray::fold(Self[A], init~ : B, (B, A) -> B raise?) -> B raise?
@@ -1118,9 +1129,6 @@ pub fn[T : Eq] ReadOnlyArray::strip_prefix(Self[T], ArrayView[T]) -> ArrayView[T
 pub fn[T : Eq] ReadOnlyArray::strip_suffix(Self[T], ArrayView[T]) -> ArrayView[T]?
 pub fn[T] ReadOnlyArray::suffixes(Self[T], include_empty? : Bool) -> Iter[ArrayView[T]]
 pub fn[T : ToJson] ReadOnlyArray::to_json(Self[T]) -> Json
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn[T] ReadOnlyArray::view(Self[T], start? : Int, end? : Int) -> ArrayView[T]
 pub fn[T] ReadOnlyArray::windows(Self[T], Int) -> Array[ArrayView[T]]
 
 pub fn Bytes::add(Bytes, Bytes) -> Bytes
@@ -1134,6 +1142,10 @@ pub fn Bytes::compare(Bytes, Bytes) -> Int
 #deprecated
 pub fn Bytes::copy(Bytes) -> Bytes
 pub fn Bytes::equal(Bytes, Bytes) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view, deprecated)
+pub fn Bytes::exact_view(Bytes, start? : Int, end? : Int) -> BytesView
 pub fn Bytes::find(Bytes, BytesView) -> Int?
 #alias(of, deprecated)
 pub fn Bytes::from_array(ArrayView[Byte]) -> Bytes
@@ -1166,9 +1178,6 @@ pub fn Bytes::to_fixedarray(Bytes, len? : Int) -> FixedArray[Byte]
 pub fn Bytes::to_json(Bytes) -> Json
 pub fn Bytes::to_string(Bytes) -> String
 pub fn Bytes::to_unchecked_string(Bytes, offset? : Int, length? : Int) -> String
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn Bytes::view(Bytes, start? : Int, end? : Int) -> BytesView
 
 #alias("_[_]")
 pub fn BytesView::at(Self, Int) -> Byte
@@ -1179,6 +1188,10 @@ pub fn BytesView::compare(Self, Self) -> Int
 pub fn BytesView::data(Self) -> Bytes
 pub fn BytesView::equal(Self, Self) -> Bool
 pub fn BytesView::equal_to_bytes(Self, Bytes) -> Bool
+#alias("_[_:_]")
+#alias(sub, deprecated)
+#alias(view, deprecated)
+pub fn BytesView::exact_view(Self, start? : Int, end? : Int) -> Self
 pub fn BytesView::find(Self, Self) -> Int?
 pub fn BytesView::get(Self, Int) -> Byte?
 pub fn BytesView::get_view(Self, start? : Int, end? : Int) -> Self?
@@ -1200,9 +1213,6 @@ pub fn BytesView::to_json(Self) -> Json
 #alias(to_bytes, deprecated)
 pub fn BytesView::to_owned(Self) -> Bytes
 pub fn BytesView::to_string(Self) -> String
-#alias("_[_:_]")
-#alias(sub, deprecated)
-pub fn BytesView::view(Self, start? : Int, end? : Int) -> Self
 
 pub fn StringView::add(Self, Self) -> Self
 pub fn StringView::after(Self, Self) -> Self?
@@ -1230,6 +1240,9 @@ pub fn StringView::equal(Self, Self) -> Bool
 pub fn StringView::equal_ignore_ascii_case(Self, Self) -> Bool
 pub fn StringView::equal_to_string(Self, String) -> Bool
 pub fn StringView::escape(Self, quote? : Bool) -> Self
+#alias("_[_:_]")
+#alias(sub, deprecated)
+pub fn StringView::exact_view(Self, start? : Int, end? : Int) -> Self
 pub fn StringView::find(Self, Self) -> Int?
 pub fn StringView::find_by(Self, (Char) -> Bool) -> Int?
 pub fn[A] StringView::fold(Self, init~ : A, (A, Char) -> A raise?) -> A raise?
@@ -1275,8 +1288,6 @@ pub fn StringView::start_offset(Self) -> Int
 pub fn StringView::strip_prefix(Self, Self) -> Self?
 #alias(chop_suffix)
 pub fn StringView::strip_suffix(Self, Self) -> Self?
-#alias("_[_:_]")
-pub fn StringView::sub(Self, start? : Int, end? : Int) -> Self
 pub fn StringView::suffixes(Self, include_empty? : Bool) -> Iter[Self]
 pub fn StringView::to_array(Self) -> Array[Char]
 #deprecated
@@ -1298,6 +1309,7 @@ pub fn StringView::trim_start(Self, chars? : Self) -> Self
 #deprecated
 pub fn StringView::unsafe_charcode_at(Self, Int) -> Int
 pub fn StringView::unsafe_get(Self, Int) -> UInt16
+#deprecated
 pub fn StringView::view(Self, start_offset? : Int, end_offset? : Int) -> Self
 
 // Type aliases

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -902,6 +902,8 @@ pub fn String::make(Int, Char) -> String
 pub fn String::offset_of_nth_char(String, Int, start_offset? : Int, end_offset? : Int) -> Int?
 pub fn String::pad_end(String, Int, Char) -> String
 pub fn String::pad_start(String, Int, Char) -> String
+#alias(view)
+pub fn String::raw_view(String, start_offset? : Int, end_offset? : Int) -> StringView
 pub fn String::repeat(String, Int) -> String
 pub fn String::replace(String, old~ : StringView, new~ : StringView) -> String
 pub fn String::replace_all(String, old~ : StringView, new~ : StringView) -> String
@@ -942,8 +944,6 @@ pub fn String::trim_start(String, chars? : StringView) -> StringView
 #deprecated
 pub fn String::unsafe_char_at(String, Int) -> Char
 pub fn String::unsafe_substring(String, start~ : Int, end~ : Int) -> String
-#deprecated
-pub fn String::view(String, start_offset? : Int, end_offset? : Int) -> StringView
 
 pub fn[T, U] Option::bind(T?, (T) -> U? raise?) -> U? raise?
 pub fn[X : Compare] Option::compare(X?, X?) -> Int
@@ -1269,6 +1269,8 @@ pub fn StringView::make(Int, Char) -> Self
 pub fn StringView::offset_of_nth_char(Self, Int) -> Int?
 pub fn StringView::pad_end(Self, Int, Char) -> String
 pub fn StringView::pad_start(Self, Int, Char) -> String
+#alias(view)
+pub fn StringView::raw_view(Self, start_offset? : Int, end_offset? : Int) -> Self
 pub fn StringView::repeat(Self, Int) -> Self
 pub fn StringView::replace(Self, old~ : Self, new~ : Self) -> Self
 pub fn StringView::replace_all(Self, old~ : Self, new~ : Self) -> Self
@@ -1309,8 +1311,6 @@ pub fn StringView::trim_start(Self, chars? : Self) -> Self
 #deprecated
 pub fn StringView::unsafe_charcode_at(Self, Int) -> Int
 pub fn StringView::unsafe_get(Self, Int) -> UInt16
-#deprecated
-pub fn StringView::view(Self, start_offset? : Int, end_offset? : Int) -> Self
 
 // Type aliases
 

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -902,8 +902,6 @@ pub fn String::make(Int, Char) -> String
 pub fn String::offset_of_nth_char(String, Int, start_offset? : Int, end_offset? : Int) -> Int?
 pub fn String::pad_end(String, Int, Char) -> String
 pub fn String::pad_start(String, Int, Char) -> String
-#alias(view)
-pub fn String::raw_view(String, start_offset? : Int, end_offset? : Int) -> StringView
 pub fn String::repeat(String, Int) -> String
 pub fn String::replace(String, old~ : StringView, new~ : StringView) -> String
 pub fn String::replace_all(String, old~ : StringView, new~ : StringView) -> String
@@ -944,6 +942,7 @@ pub fn String::trim_start(String, chars? : StringView) -> StringView
 #deprecated
 pub fn String::unsafe_char_at(String, Int) -> Char
 pub fn String::unsafe_substring(String, start~ : Int, end~ : Int) -> String
+pub fn String::view(String, start_offset? : Int, end_offset? : Int) -> StringView
 
 pub fn[T, U] Option::bind(T?, (T) -> U? raise?) -> U? raise?
 pub fn[X : Compare] Option::compare(X?, X?) -> Int
@@ -1269,8 +1268,6 @@ pub fn StringView::make(Int, Char) -> Self
 pub fn StringView::offset_of_nth_char(Self, Int) -> Int?
 pub fn StringView::pad_end(Self, Int, Char) -> String
 pub fn StringView::pad_start(Self, Int, Char) -> String
-#alias(view)
-pub fn StringView::raw_view(Self, start_offset? : Int, end_offset? : Int) -> Self
 pub fn StringView::repeat(Self, Int) -> Self
 pub fn StringView::replace(Self, old~ : Self, new~ : Self) -> Self
 pub fn StringView::replace_all(Self, old~ : Self, new~ : Self) -> Self
@@ -1311,6 +1308,7 @@ pub fn StringView::trim_start(Self, chars? : Self) -> Self
 #deprecated
 pub fn StringView::unsafe_charcode_at(Self, Int) -> Int
 pub fn StringView::unsafe_get(Self, Int) -> UInt16
+pub fn StringView::view(Self, start_offset? : Int, end_offset? : Int) -> Self
 
 // Type aliases
 

--- a/builtin/readonlyarray.mbt
+++ b/builtin/readonlyarray.mbt
@@ -869,15 +869,17 @@ pub fn[T : Compare] ReadOnlyArray::lexical_compare(
 /// ```
 #intrinsic("%readonlyarray.view")
 #alias("_[_:_]")
-#alias(sub, deprecated="Use _[_:_] instead")
-pub fn[T] ReadOnlyArray::view(
+#alias(view, deprecated="Use `exact_view` instead")
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn[T] ReadOnlyArray::exact_view(
   self : ReadOnlyArray[T],
   start? : Int = 0,
   end? : Int,
 ) -> ArrayView[T] {
+  let fixed = self.unsafe_reinterpret_to_fixed_array()
   match end {
-    None => self.unsafe_reinterpret_to_fixed_array()[start:]
-    Some(e) => self.unsafe_reinterpret_to_fixed_array()[start:e]
+    None => fixed.exact_view(start~)
+    Some(end) => fixed.exact_view(start~, end~)
   }
 }
 

--- a/builtin/split_at_test.mbt
+++ b/builtin/split_at_test.mbt
@@ -63,7 +63,7 @@ test "split_at treats unpaired surrogates as boundaries" {
 
 ///|
 test "StringView::split_at uses view-relative offsets and stays in window" {
-  let v = "xx ab😀cd yy".view(start_offset=3, end_offset=9) // "ab😀cd"
+  let v = "xx ab😀cd yy".exact_view(start=3, end=9) // "ab😀cd"
   let (p, q) = v.split_at(3)
   inspect(p, content="ab")
   inspect(q, content="😀cd")

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -368,8 +368,9 @@ pub fn StringView::strip_prefix(
   prefix : StringView,
 ) -> StringView? {
   let prefix_len = prefix.length()
-  if self.length() >= prefix_len && self.view(end_offset=prefix_len) == prefix {
-    Some(self.view(start_offset=prefix_len))
+  if self.length() >= prefix_len &&
+    self.raw_view(end_offset=prefix_len) == prefix {
+    Some(self.raw_view(start_offset=prefix_len))
   } else {
     None
   }
@@ -400,8 +401,8 @@ pub fn StringView::strip_suffix(
   let self_len = self.length()
   let suffix_len = suffix.length()
   if self_len >= suffix_len &&
-    self.view(start_offset=self_len - suffix_len) == suffix {
-    Some(self.view(end_offset=self_len - suffix_len))
+    self.raw_view(start_offset=self_len - suffix_len) == suffix {
+    Some(self.raw_view(end_offset=self_len - suffix_len))
   } else {
     None
   }
@@ -1697,7 +1698,7 @@ pub fn StringView::split(
 ) -> Iter[StringView] {
   let sep_len = sep.length()
   if sep_len == 0 {
-    return self.iter().map(c => c.to_string().view())
+    return self.iter().map(c => c.to_string().raw_view())
   }
   let mut remaining = Some(self)
   Iter::new(() => {
@@ -1706,8 +1707,8 @@ pub fn StringView::split(
       remaining = None
       Some(view)
     }
-    remaining = Some(view.view(start_offset=end + sep_len))
-    Some(view.view(end_offset=end))
+    remaining = Some(view.raw_view(start_offset=end + sep_len))
+    Some(view.raw_view(end_offset=end))
   })
 }
 
@@ -1739,8 +1740,8 @@ pub fn StringView::split_once(
     Some(index) =>
       Some(
         (
-          self.view(end_offset=index),
-          self.view(start_offset=index + needle.length()),
+          self.raw_view(end_offset=index),
+          self.raw_view(start_offset=index + needle.length()),
         ),
       )
     None => None
@@ -1772,7 +1773,7 @@ pub fn StringView::before(
   needle : StringView,
 ) -> StringView? {
   match self.find(needle) {
-    Some(index) => Some(self.view(end_offset=index))
+    Some(index) => Some(self.raw_view(end_offset=index))
     None => None
   }
 }
@@ -1795,7 +1796,7 @@ pub fn String::before(self : String, needle : StringView) -> StringView? {
 /// If the separator is empty, it returns the full string.
 pub fn StringView::after(self : StringView, needle : StringView) -> StringView? {
   match self.find(needle) {
-    Some(index) => Some(self.view(start_offset=index + needle.length()))
+    Some(index) => Some(self.raw_view(start_offset=index + needle.length()))
     None => None
   }
 }
@@ -1831,8 +1832,8 @@ pub fn StringView::rev_split_once(
     Some(index) =>
       Some(
         (
-          self.view(end_offset=index),
-          self.view(start_offset=index + needle.length()),
+          self.raw_view(end_offset=index),
+          self.raw_view(start_offset=index + needle.length()),
         ),
       )
     None => None
@@ -1875,7 +1876,7 @@ pub fn StringView::rev_before(
   needle : StringView,
 ) -> StringView? {
   match self.rev_find(needle) {
-    Some(index) => Some(self.view(end_offset=index))
+    Some(index) => Some(self.raw_view(end_offset=index))
     None => None
   }
 }
@@ -1913,7 +1914,7 @@ pub fn StringView::rev_after(
   needle : StringView,
 ) -> StringView? {
   match self.rev_find(needle) {
-    Some(index) => Some(self.view(start_offset=index + needle.length()))
+    Some(index) => Some(self.raw_view(start_offset=index + needle.length()))
     None => None
   }
 }
@@ -2019,9 +2020,9 @@ pub fn StringView::replace(
   match self.find(old) {
     Some(end) =>
       [
-        ..self.view(end_offset=end),
+        ..self.raw_view(end_offset=end),
         ..new,
-        ..self.view(start_offset=end + old.length()),
+        ..self.raw_view(start_offset=end + old.length()),
       ]
     None => self
   }
@@ -2040,9 +2041,9 @@ pub fn String::replace(
   match self.find(old) {
     Some(end) =>
       [
-        ..self.view(end_offset=end),
+        ..self.raw_view(end_offset=end),
         ..new,
-        ..self.view(start_offset=end + old.length()),
+        ..self.raw_view(start_offset=end + old.length()),
       ]
     None => self
   }
@@ -2086,12 +2087,12 @@ pub fn StringView::replace_all(
     let first_end = self.find(old)
     if first_end is Some(end) {
       for view = self, end = end {
-        let seg = view.view(end_offset=end)
+        let seg = view.raw_view(end_offset=end)
         buf.write_substring(seg.data(), seg.start_offset(), seg.length())
         buf.write_string(new)
         // check if there is no more characters after the last occurrence of `old`
         guard end + old_len <= len else { break }
-        let next_view = view.view(start_offset=end + old_len)
+        let next_view = view.raw_view(start_offset=end + old_len)
         guard next_view.find(old) is Some(next_end) else {
           buf.write_substring(
             next_view.data(),
@@ -2136,12 +2137,12 @@ pub fn String::replace_all(
     let first_end = self.find(old)
     if first_end is Some(end) {
       for view = self[:], end = end {
-        let seg = view.view(end_offset=end)
+        let seg = view.raw_view(end_offset=end)
         buf.write_substring(seg.data(), seg.start_offset(), seg.length())
         buf.write_string(new)
         // check if there is no more characters after the last occurrence of `old`
         guard end + old_len <= len else { break }
-        let next_view = view.view(start_offset=end + old_len)
+        let next_view = view.raw_view(start_offset=end + old_len)
         guard next_view.find(old) is Some(next_end) else {
           buf.write_substring(
             next_view.data(),
@@ -2388,7 +2389,7 @@ fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
   let len = view.length()
   let output : FixedArray[UInt16] = FixedArray::make(len, 0)
   output.unsafe_blit_from_string(0, view.data(), view.start_offset(), len)
-  let tail = view.view(start_offset=first_uppercase)
+  let tail = view.raw_view(start_offset=first_uppercase)
   // Keep `tail.code_units()` directly in the loop so compiler backends can
   // recognize and lower the zero-copy traversal at the use site.
   for i, u in tail.code_units() {
@@ -2439,9 +2440,9 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
+  let head = self.raw_view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
+  for c in self.raw_view(start_offset=idx) {
     if c.is_ascii_uppercase() {
       buf.write_char((c.to_int() + 32).unsafe_to_char())
     } else {
@@ -2462,9 +2463,9 @@ pub fn String::to_lower(self : String) -> String {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
+  let head = self.raw_view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
+  for c in self.raw_view(start_offset=idx) {
     if c.is_ascii_uppercase() {
       buf.write_char((c.to_int() + 32).unsafe_to_char())
     } else {
@@ -2527,9 +2528,9 @@ pub fn StringView::to_upper(self : StringView) -> StringView {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
+  let head = self.raw_view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
+  for c in self.raw_view(start_offset=idx) {
     if c.is_ascii_lowercase() {
       buf.write_char((c.to_int() - 32).unsafe_to_char())
     } else {
@@ -2549,9 +2550,9 @@ pub fn String::to_upper(self : String) -> String {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.view(end_offset=idx)
+  let head = self.raw_view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.view(start_offset=idx) {
+  for c in self.raw_view(start_offset=idx) {
     if c.is_ascii_lowercase() {
       buf.write_char((c.to_int() - 32).unsafe_to_char())
     } else {

--- a/builtin/string_methods.mbt
+++ b/builtin/string_methods.mbt
@@ -368,9 +368,8 @@ pub fn StringView::strip_prefix(
   prefix : StringView,
 ) -> StringView? {
   let prefix_len = prefix.length()
-  if self.length() >= prefix_len &&
-    self.raw_view(end_offset=prefix_len) == prefix {
-    Some(self.raw_view(start_offset=prefix_len))
+  if self.length() >= prefix_len && self.view(end_offset=prefix_len) == prefix {
+    Some(self.view(start_offset=prefix_len))
   } else {
     None
   }
@@ -401,8 +400,8 @@ pub fn StringView::strip_suffix(
   let self_len = self.length()
   let suffix_len = suffix.length()
   if self_len >= suffix_len &&
-    self.raw_view(start_offset=self_len - suffix_len) == suffix {
-    Some(self.raw_view(end_offset=self_len - suffix_len))
+    self.view(start_offset=self_len - suffix_len) == suffix {
+    Some(self.view(end_offset=self_len - suffix_len))
   } else {
     None
   }
@@ -1698,7 +1697,7 @@ pub fn StringView::split(
 ) -> Iter[StringView] {
   let sep_len = sep.length()
   if sep_len == 0 {
-    return self.iter().map(c => c.to_string().raw_view())
+    return self.iter().map(c => c.to_string().view())
   }
   let mut remaining = Some(self)
   Iter::new(() => {
@@ -1707,8 +1706,8 @@ pub fn StringView::split(
       remaining = None
       Some(view)
     }
-    remaining = Some(view.raw_view(start_offset=end + sep_len))
-    Some(view.raw_view(end_offset=end))
+    remaining = Some(view.view(start_offset=end + sep_len))
+    Some(view.view(end_offset=end))
   })
 }
 
@@ -1740,8 +1739,8 @@ pub fn StringView::split_once(
     Some(index) =>
       Some(
         (
-          self.raw_view(end_offset=index),
-          self.raw_view(start_offset=index + needle.length()),
+          self.view(end_offset=index),
+          self.view(start_offset=index + needle.length()),
         ),
       )
     None => None
@@ -1773,7 +1772,7 @@ pub fn StringView::before(
   needle : StringView,
 ) -> StringView? {
   match self.find(needle) {
-    Some(index) => Some(self.raw_view(end_offset=index))
+    Some(index) => Some(self.view(end_offset=index))
     None => None
   }
 }
@@ -1796,7 +1795,7 @@ pub fn String::before(self : String, needle : StringView) -> StringView? {
 /// If the separator is empty, it returns the full string.
 pub fn StringView::after(self : StringView, needle : StringView) -> StringView? {
   match self.find(needle) {
-    Some(index) => Some(self.raw_view(start_offset=index + needle.length()))
+    Some(index) => Some(self.view(start_offset=index + needle.length()))
     None => None
   }
 }
@@ -1832,8 +1831,8 @@ pub fn StringView::rev_split_once(
     Some(index) =>
       Some(
         (
-          self.raw_view(end_offset=index),
-          self.raw_view(start_offset=index + needle.length()),
+          self.view(end_offset=index),
+          self.view(start_offset=index + needle.length()),
         ),
       )
     None => None
@@ -1876,7 +1875,7 @@ pub fn StringView::rev_before(
   needle : StringView,
 ) -> StringView? {
   match self.rev_find(needle) {
-    Some(index) => Some(self.raw_view(end_offset=index))
+    Some(index) => Some(self.view(end_offset=index))
     None => None
   }
 }
@@ -1914,7 +1913,7 @@ pub fn StringView::rev_after(
   needle : StringView,
 ) -> StringView? {
   match self.rev_find(needle) {
-    Some(index) => Some(self.raw_view(start_offset=index + needle.length()))
+    Some(index) => Some(self.view(start_offset=index + needle.length()))
     None => None
   }
 }
@@ -2020,9 +2019,9 @@ pub fn StringView::replace(
   match self.find(old) {
     Some(end) =>
       [
-        ..self.raw_view(end_offset=end),
+        ..self.view(end_offset=end),
         ..new,
-        ..self.raw_view(start_offset=end + old.length()),
+        ..self.view(start_offset=end + old.length()),
       ]
     None => self
   }
@@ -2041,9 +2040,9 @@ pub fn String::replace(
   match self.find(old) {
     Some(end) =>
       [
-        ..self.raw_view(end_offset=end),
+        ..self.view(end_offset=end),
         ..new,
-        ..self.raw_view(start_offset=end + old.length()),
+        ..self.view(start_offset=end + old.length()),
       ]
     None => self
   }
@@ -2087,12 +2086,12 @@ pub fn StringView::replace_all(
     let first_end = self.find(old)
     if first_end is Some(end) {
       for view = self, end = end {
-        let seg = view.raw_view(end_offset=end)
+        let seg = view.view(end_offset=end)
         buf.write_substring(seg.data(), seg.start_offset(), seg.length())
         buf.write_string(new)
         // check if there is no more characters after the last occurrence of `old`
         guard end + old_len <= len else { break }
-        let next_view = view.raw_view(start_offset=end + old_len)
+        let next_view = view.view(start_offset=end + old_len)
         guard next_view.find(old) is Some(next_end) else {
           buf.write_substring(
             next_view.data(),
@@ -2137,12 +2136,12 @@ pub fn String::replace_all(
     let first_end = self.find(old)
     if first_end is Some(end) {
       for view = self[:], end = end {
-        let seg = view.raw_view(end_offset=end)
+        let seg = view.view(end_offset=end)
         buf.write_substring(seg.data(), seg.start_offset(), seg.length())
         buf.write_string(new)
         // check if there is no more characters after the last occurrence of `old`
         guard end + old_len <= len else { break }
-        let next_view = view.raw_view(start_offset=end + old_len)
+        let next_view = view.view(start_offset=end + old_len)
         guard next_view.find(old) is Some(next_end) else {
           buf.write_substring(
             next_view.data(),
@@ -2389,7 +2388,7 @@ fn ascii_lowercase_copy(view : StringView, first_uppercase : Int) -> String {
   let len = view.length()
   let output : FixedArray[UInt16] = FixedArray::make(len, 0)
   output.unsafe_blit_from_string(0, view.data(), view.start_offset(), len)
-  let tail = view.raw_view(start_offset=first_uppercase)
+  let tail = view.view(start_offset=first_uppercase)
   // Keep `tail.code_units()` directly in the loop so compiler backends can
   // recognize and lower the zero-copy traversal at the use site.
   for i, u in tail.code_units() {
@@ -2440,9 +2439,9 @@ pub fn StringView::to_lower(self : StringView) -> StringView {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.raw_view(end_offset=idx)
+  let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.raw_view(start_offset=idx) {
+  for c in self.view(start_offset=idx) {
     if c.is_ascii_uppercase() {
       buf.write_char((c.to_int() + 32).unsafe_to_char())
     } else {
@@ -2463,9 +2462,9 @@ pub fn String::to_lower(self : String) -> String {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.raw_view(end_offset=idx)
+  let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.raw_view(start_offset=idx) {
+  for c in self.view(start_offset=idx) {
     if c.is_ascii_uppercase() {
       buf.write_char((c.to_int() + 32).unsafe_to_char())
     } else {
@@ -2528,9 +2527,9 @@ pub fn StringView::to_upper(self : StringView) -> StringView {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.raw_view(end_offset=idx)
+  let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.raw_view(start_offset=idx) {
+  for c in self.view(start_offset=idx) {
     if c.is_ascii_lowercase() {
       buf.write_char((c.to_int() - 32).unsafe_to_char())
     } else {
@@ -2550,9 +2549,9 @@ pub fn String::to_upper(self : String) -> String {
     return self
   }
   let buf = StringBuilder(size_hint=self.length())
-  let head = self.raw_view(end_offset=idx)
+  let head = self.view(end_offset=idx)
   buf.write_substring(head.data(), head.start_offset(), head.length())
-  for c in self.raw_view(start_offset=idx) {
+  for c in self.view(start_offset=idx) {
     if c.is_ascii_lowercase() {
       buf.write_char((c.to_int() - 32).unsafe_to_char())
     } else {

--- a/builtin/string_test.mbt
+++ b/builtin/string_test.mbt
@@ -315,6 +315,6 @@ test "String get_char invalid surrogate pair" {
 
 ///|
 test "StringView repeat single" {
-  let view = "repeat".view()
+  let view = "repeat".exact_view()
   inspect(view.repeat(1), content="repeat")
 }

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -1028,8 +1028,15 @@ pub impl Add for StringView with fn add(self, other) {
 }
 
 ///|
-// Bounds-checked UTF-16 slicing for code-unit operations that may split pairs.
-fn StringView::raw_view(
+/// Creates a view using raw UTF-16 code-unit offsets relative to this view.
+///
+/// Requires `0 <= start_offset <= end_offset <= self.length()`; panics otherwise.
+/// Omitted bounds default to the start and end of this view. Surrogate pairs
+/// may be split. Use `exact_view(start~, end~)` to validate text boundaries.
+// The compiler generates calls to `view` for lexmatch/lexscan. Deprecate the
+// alias after compiler lowering uses `raw_view`, so --deny-warn stays usable.
+#alias(view)
+pub fn StringView::raw_view(
   self : StringView,
   start_offset? : Int = 0,
   end_offset? : Int,
@@ -1048,8 +1055,15 @@ fn StringView::raw_view(
 }
 
 ///|
-// Bounds-checked UTF-16 slicing for code-unit operations that may split pairs.
-fn String::raw_view(
+/// Creates a view using raw UTF-16 code-unit offsets.
+///
+/// Requires `0 <= start_offset <= end_offset <= self.length()`; panics otherwise.
+/// Omitted bounds default to the start and end of this string. Surrogate pairs
+/// may be split. Use `exact_view(start~, end~)` to validate text boundaries.
+// The compiler generates calls to `view` for lexmatch/lexscan. Deprecate the
+// alias after compiler lowering uses `raw_view`, so --deny-warn stays usable.
+#alias(view)
+pub fn String::raw_view(
   self : String,
   start_offset? : Int = 0,
   end_offset? : Int,

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -1033,10 +1033,9 @@ pub impl Add for StringView with fn add(self, other) {
 /// Requires `0 <= start_offset <= end_offset <= self.length()`; panics otherwise.
 /// Omitted bounds default to the start and end of this view. Surrogate pairs
 /// may be split. Use `exact_view(start~, end~)` to validate text boundaries.
-// The compiler generates calls to `view` for lexmatch/lexscan. Deprecate the
-// alias after compiler lowering uses `raw_view`, so --deny-warn stays usable.
-#alias(view)
-pub fn StringView::raw_view(
+// The compiler generates calls to `view` for lexmatch/lexscan. Keep this
+// method without deprecation until compiler lowering changes.
+pub fn StringView::view(
   self : StringView,
   start_offset? : Int = 0,
   end_offset? : Int,
@@ -1060,10 +1059,9 @@ pub fn StringView::raw_view(
 /// Requires `0 <= start_offset <= end_offset <= self.length()`; panics otherwise.
 /// Omitted bounds default to the start and end of this string. Surrogate pairs
 /// may be split. Use `exact_view(start~, end~)` to validate text boundaries.
-// The compiler generates calls to `view` for lexmatch/lexscan. Deprecate the
-// alias after compiler lowering uses `raw_view`, so --deny-warn stays usable.
-#alias(view)
-pub fn String::raw_view(
+// The compiler generates calls to `view` for lexmatch/lexscan. Keep this
+// method without deprecation until compiler lowering changes.
+pub fn String::view(
   self : String,
   start_offset? : Int = 0,
   end_offset? : Int,

--- a/builtin/stringview.mbt
+++ b/builtin/stringview.mbt
@@ -101,26 +101,6 @@ pub fn StringView::start_offset(self : StringView) -> Int {
 }
 
 ///|
-/// Returns a new view of the view with the given start and end offsets.
-pub fn StringView::view(
-  self : StringView,
-  start_offset? : Int = 0,
-  end_offset? : Int,
-) -> StringView {
-  let end_offset = if end_offset is Some(o) { o } else { self.length() }
-  guard start_offset >= 0 &&
-    start_offset <= end_offset &&
-    end_offset <= self.length() else {
-    abort("Invalid index for View")
-  }
-  StringView::make_view(
-    self.str(),
-    self.start() + start_offset,
-    self.start() + end_offset,
-  )
-}
-
-///|
 /// Returns the UTF-16 code unit at the given index without checking if the
 /// index is within bounds.
 ///
@@ -192,9 +172,9 @@ pub fn StringView::char_length(self : StringView) -> Int {
 /// ```mbt check
 /// test {
 ///   let str = "Hello World"
-///   let view = str.view(
-///     start_offset=str.offset_of_nth_char(0).unwrap(),
-///     end_offset=str.offset_of_nth_char(5).unwrap(),
+///   let view = str.exact_view(
+///     start=str.offset_of_nth_char(0).unwrap(),
+///     end=str.offset_of_nth_char(5).unwrap(),
 ///   ) // "Hello"
 ///   inspect(view.to_owned(), content="Hello")
 /// }
@@ -376,12 +356,9 @@ pub impl Eq for StringView with fn equal(self, other) {
 /// ```mbt check
 /// test {
 ///   let s = "say hello to everyone"
+///   inspect(s.exact_view(start=4, end=9).equal_to_string("hello"), content="true")
 ///   inspect(
-///     s.view(start_offset=4, end_offset=9).equal_to_string("hello"),
-///     content="true",
-///   )
-///   inspect(
-///     s.view(start_offset=4, end_offset=9).equal_to_string("world"),
+///     s.exact_view(start=4, end=9).equal_to_string("world"),
 ///     content="false",
 ///   )
 /// }
@@ -439,20 +416,20 @@ pub impl Compare for StringView with fn compare(self, other) {
 ///   let str = "abc"
 ///   inspect(
 ///     str
-///     .view(start_offset=0, end_offset=2)
-///     .lexical_compare(str.view(start_offset=0, end_offset=3)),
+///     .exact_view(start=0, end=2)
+///     .lexical_compare(str.exact_view(start=0, end=3)),
 ///     content="-1",
 ///   )
 ///   inspect(
 ///     str
-///     .view(start_offset=0, end_offset=3)
-///     .lexical_compare(str.view(start_offset=0, end_offset=2)),
+///     .exact_view(start=0, end=3)
+///     .lexical_compare(str.exact_view(start=0, end=2)),
 ///     content="1",
 ///   )
 ///   inspect(
 ///     str
-///     .view(start_offset=0, end_offset=2)
-///     .lexical_compare(str.view(start_offset=1, end_offset=3)),
+///     .exact_view(start=0, end=2)
+///     .lexical_compare(str.exact_view(start=1, end=3)),
 ///     content="-1",
 ///   )
 /// }
@@ -523,9 +500,18 @@ fn ascii_fold_lower_u16(c : UInt16) -> UInt16 {
 ///
 /// ```mbt check
 /// test {
-///   inspect("Hello".view().compare_ignore_ascii_case("hello".view()), content="0")
-///   inspect("ABC".view().compare_ignore_ascii_case("abd".view()), content="-1")
-///   inspect("abc".view().compare_ignore_ascii_case("AB".view()), content="1")
+///   inspect(
+///     "Hello".exact_view().compare_ignore_ascii_case("hello".exact_view()),
+///     content="0",
+///   )
+///   inspect(
+///     "ABC".exact_view().compare_ignore_ascii_case("abd".exact_view()),
+///     content="-1",
+///   )
+///   inspect(
+///     "abc".exact_view().compare_ignore_ascii_case("AB".exact_view()),
+///     content="1",
+///   )
 /// }
 /// ```
 pub fn StringView::compare_ignore_ascii_case(
@@ -565,14 +551,17 @@ pub fn StringView::compare_ignore_ascii_case(
 /// ```mbt check
 /// test {
 ///   inspect(
-///     "Hello".view().equal_ignore_ascii_case("hello".view()),
+///     "Hello".exact_view().equal_ignore_ascii_case("hello".exact_view()),
 ///     content="true",
 ///   )
 ///   inspect(
-///     "Hello".view().equal_ignore_ascii_case("world".view()),
+///     "Hello".exact_view().equal_ignore_ascii_case("world".exact_view()),
 ///     content="false",
 ///   )
-///   inspect("abc".view().equal_ignore_ascii_case("ab".view()), content="false")
+///   inspect(
+///     "abc".exact_view().equal_ignore_ascii_case("ab".exact_view()),
+///     content="false",
+///   )
 /// }
 /// ```
 pub fn StringView::equal_ignore_ascii_case(
@@ -598,36 +587,6 @@ pub fn StringView::equal_ignore_ascii_case(
 }
 
 ///|
-/// Creates a `View` into a `String`.
-/// 
-/// # Example
-/// 
-/// ```mbt check
-/// test {
-///   let str = "Hello🤣🤣🤣"
-///   let view1 = str.view()
-///   inspect(view1, content="Hello🤣🤣🤣")
-///   let start_offset = str.offset_of_nth_char(1).unwrap()
-///   let end_offset = str.offset_of_nth_char(6).unwrap() // the second emoji
-///   let view2 = str.view(start_offset~, end_offset~)
-///   inspect(view2, content="ello🤣")
-/// }
-/// ```
-pub fn String::view(
-  self : String,
-  start_offset? : Int = 0,
-  end_offset? : Int,
-) -> StringView {
-  let end_offset = if end_offset is Some(o) { o } else { self.length() }
-  guard start_offset >= 0 &&
-    start_offset <= end_offset &&
-    end_offset <= self.length() else {
-    abort("Invalid index for View")
-  }
-  StringView::make_view(self, start_offset, end_offset)
-}
-
-///|
 /// Convert char array to string view.
 pub fn StringView::from_array(chars : ArrayView[Char]) -> StringView {
   String::from_array(chars)
@@ -643,7 +602,7 @@ pub fn StringView::from_iter(iter : Iter[Char]) -> StringView {
 ///|
 /// Returns a view of the string between `start` and `end`, or `None` if the
 /// range is invalid — either out of bounds or splitting a UTF-16 surrogate
-/// pair. Unlike `String::sub` (a.k.a. `s[start:end]`), this variant does not
+/// pair. Unlike `String::exact_view` (a.k.a. `s[start:end]`), this variant does not
 /// abort, making it suitable for composition with pattern matching:
 ///
 /// ```mbt check
@@ -680,7 +639,7 @@ pub fn String::get_view(
 ///|
 /// Returns a sub-view of the view between `start` and `end`, or `None` if the
 /// range is invalid — either out of bounds or splitting a UTF-16 surrogate
-/// pair. The optional variant of `StringView::sub` (a.k.a. `sv[start:end]`).
+/// pair. The optional variant of `StringView::exact_view` (a.k.a. `sv[start:end]`).
 pub fn StringView::get_view(
   self : StringView,
   start? : Int = 0,
@@ -774,7 +733,7 @@ pub fn String::clamped_view(
 ///
 /// ```mbt check
 /// test {
-///   let v = "xx ab😀cd".view(start_offset=3)
+///   let v = "xx ab😀cd".exact_view(start=3)
 ///   inspect(v.clamped_view(end=3), content="ab")
 ///   inspect(v.clamped_view(start=3), content="cd")
 /// }
@@ -855,7 +814,7 @@ pub fn String::split_at(self : String, at : Int) -> (StringView, StringView) {
 ///
 /// ```mbt check
 /// test {
-///   let v = "xx ab😀cd".view(start_offset=3)
+///   let v = "xx ab😀cd".exact_view(start=3)
 ///   let (p, q) = v.split_at(3)
 ///   inspect(p, content="ab")
 ///   inspect(q, content="😀cd")
@@ -914,14 +873,19 @@ pub fn StringView::split_at(
 /// ```mbt check
 /// test {
 ///   let str = "Hello🤣World"
-///   let view1 = str[0:5]
+///   let view1 = str.exact_view(start=0, end=5)
 ///   inspect(view1, content="Hello")
-///   let view2 = str[7:]
+///   let view2 = str.exact_view(start=7)
 ///   inspect(view2, content="World")
 /// }
 /// ```
 #alias("_[_:_]")
-pub fn String::sub(self : String, start? : Int = 0, end? : Int) -> StringView {
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn String::exact_view(
+  self : String,
+  start? : Int = 0,
+  end? : Int,
+) -> StringView {
   let len = self.length()
   let end = match end {
     Some(end) | (None with end = len) => end
@@ -969,14 +933,15 @@ pub fn String::sub(self : String, start? : Int = 0, end? : Int) -> StringView {
 /// ```mbt check
 /// test {
 ///   let str = "Hello🤣World"[1:11] // "ello🤣Worl"
-///   let view1 = str[0:6]
+///   let view1 = str.exact_view(start=0, end=6)
 ///   inspect(view1, content="ello🤣")
-///   let view2 = str[8:]
+///   let view2 = str.exact_view(start=8)
 ///   inspect(view2, content="rl")
 /// }
 /// ```
 #alias("_[_:_]")
-pub fn StringView::sub(
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn StringView::exact_view(
   self : StringView,
   start? : Int = 0,
   end? : Int,
@@ -1060,4 +1025,40 @@ pub impl ToJson for StringView with fn to_json(self) {
 ///|
 pub impl Add for StringView with fn add(self, other) {
   [..self, ..other]
+}
+
+///|
+// Bounds-checked UTF-16 slicing for code-unit operations that may split pairs.
+fn StringView::raw_view(
+  self : StringView,
+  start_offset? : Int = 0,
+  end_offset? : Int,
+) -> StringView {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
+  guard start_offset >= 0 &&
+    start_offset <= end_offset &&
+    end_offset <= self.length() else {
+    abort("Invalid index for View")
+  }
+  StringView::make_view(
+    self.str(),
+    self.start() + start_offset,
+    self.start() + end_offset,
+  )
+}
+
+///|
+// Bounds-checked UTF-16 slicing for code-unit operations that may split pairs.
+fn String::raw_view(
+  self : String,
+  start_offset? : Int = 0,
+  end_offset? : Int,
+) -> StringView {
+  let end_offset = if end_offset is Some(o) { o } else { self.length() }
+  guard start_offset >= 0 &&
+    start_offset <= end_offset &&
+    end_offset <= self.length() else {
+    abort("Invalid index for View")
+  }
+  StringView::make_view(self, start_offset, end_offset)
 }

--- a/builtin/stringview_test.mbt
+++ b/builtin/stringview_test.mbt
@@ -16,7 +16,7 @@
 test "StringView::suffixes" {
   let str = "za🤣b"
   let start = str.offset_of_nth_char(1).unwrap()
-  let view = str.view(start_offset=start)
+  let view = str.exact_view(start~)
   let suffixes = view.suffixes().map(v => v.to_owned()).collect()
   @json.json_inspect(suffixes, content=["a🤣b", "🤣b", "b"])
   let suffixes_with_empty = view
@@ -102,7 +102,7 @@ test "StringView::code_units start offset" {
 
 ///|
 test "StringView core operations" {
-  let view = "ab😀c".view(start_offset=1)
+  let view = "ab😀c".exact_view(start=1)
   inspect(view.char_length(), content="3")
   inspect(view.char_length_eq(3), content="true")
   inspect(view.char_length_ge(4), content="false")
@@ -183,24 +183,24 @@ test "StringView sub valid cases" {
 }
 
 ///|
-test "panic String::sub invalid index" {
+test "panic String::exact_view invalid index" {
   ignore("A😀B"[0:2])
 }
 
 ///|
-test "panic String::sub index out of bounds" {
+test "panic String::exact_view index out of bounds" {
   ignore("A😀B"[0:10])
 }
 
 ///|
-test "panic StringView::sub invalid index" {
+test "panic StringView::exact_view invalid index" {
   let s = "A😀B"
   let view = s[1:3]
   ignore(view[:1])
 }
 
 ///|
-test "panic StringView::sub index out of bounds" {
+test "panic StringView::exact_view index out of bounds" {
   let s = "A😀B"
   let view = s[1:3]
   ignore(view[0:10])
@@ -212,13 +212,13 @@ test "panic StringView::at out of bounds" {
 }
 
 ///|
-test "panic StringView::view invalid range" {
-  ignore("abc"[:].view(start_offset=2, end_offset=1))
+test "panic StringView::exact_view invalid range" {
+  ignore("abc"[:].exact_view(start=2, end=1))
 }
 
 ///|
-test "panic String::view invalid range" {
-  ignore("abc".view(start_offset=2, end_offset=1))
+test "panic String::exact_view invalid range" {
+  ignore("abc".exact_view(start=2, end=1))
 }
 
 ///|
@@ -242,13 +242,13 @@ test "StringView compare physical equal" {
 }
 
 ///|
-test "panic String::sub invalid start index" {
+test "panic String::exact_view invalid start index" {
   let s = "\u{1F600}A"
   ignore(s[1:])
 }
 
 ///|
-test "panic StringView::sub invalid start index" {
+test "panic StringView::exact_view invalid start index" {
   let view = "\u{1F600}A"[:]
   ignore(view[1:])
 }
@@ -364,22 +364,16 @@ test "StringView::get_view" {
 test "StringView::equal_to_string" {
   let s = "say hello to everyone"
   // Sub-view of "hello" matches the owned string.
-  inspect(
-    s.view(start_offset=4, end_offset=9).equal_to_string("hello"),
-    content="true",
-  )
+  inspect(s.exact_view(start=4, end=9).equal_to_string("hello"), content="true")
   // Same length, different content.
   inspect(
-    s.view(start_offset=4, end_offset=9).equal_to_string("world"),
+    s.exact_view(start=4, end=9).equal_to_string("world"),
     content="false",
   )
   // Length mismatch short-circuits.
+  inspect(s.exact_view(start=4, end=9).equal_to_string("hell"), content="false")
   inspect(
-    s.view(start_offset=4, end_offset=9).equal_to_string("hell"),
-    content="false",
-  )
-  inspect(
-    s.view(start_offset=4, end_offset=9).equal_to_string("hello!"),
+    s.exact_view(start=4, end=9).equal_to_string("hello!"),
     content="false",
   )
   // Empty view vs empty string.

--- a/builtin/uninitialized_array.mbt
+++ b/builtin/uninitialized_array.mbt
@@ -86,7 +86,8 @@ fn[T] UninitializedArray::unsafe_set(
 /// Throws an error if the indices are out of bounds or if `start` is greater
 /// than `end`.
 #alias("_[_:_]")
-pub fn[T] UninitializedArray::sub(
+#alias(sub, deprecated="Use `exact_view` instead")
+pub fn[T] UninitializedArray::exact_view(
   self : UninitializedArray[T],
   start? : Int = 0,
   end? : Int,

--- a/bytes/README.mbt.md
+++ b/bytes/README.mbt.md
@@ -90,6 +90,11 @@ test "bytes conversion" {
 
 ## Working with Views
 
+Use `bytes.exact_view(start~, end~)` to validate bounds, `bytes.get_view(start~, end~)`
+to return `None` for invalid bounds, or `bytes.clamped_view(start~, end~)` to clamp
+them. These methods are also available on `BytesView`. The old `view` and `sub`
+names are deprecated in favor of `exact_view`.
+
 Views provide a way to work with portions of bytes and interpret them as various numeric types:
 
 ```mbt check

--- a/bytes/alias.mbt
+++ b/bytes/alias.mbt
@@ -25,7 +25,7 @@ pub fn default() -> Bytes {
 #deprecated("Use `Bytes::from_array` instead")
 #doc(hidden)
 pub fn from_fixedarray(arr : FixedArray[Byte], len? : Int) -> Bytes {
-  Bytes::from_array(arr[:len.unwrap_or(arr.length())])
+  Bytes::from_array(arr.exact_view(end=len.unwrap_or(arr.length())))
 }
 
 ///|

--- a/diff/README.mbt.md
+++ b/diff/README.mbt.md
@@ -156,15 +156,15 @@ test "git-style terminal colors from the public Hunk API" {
     for edit in h.edits() {
       match edit {
         Equal(old_index~, len~, ..) =>
-          for e in o.view(start=old_index, end=old_index + len) {
+          for e in o.exact_view(start=old_index, end=old_index + len) {
             buf <+ " \{e}\n"
           }
         Delete(old_index~, old_len~, ..) =>
-          for e in o.view(start=old_index, end=old_index + old_len) {
+          for e in o.exact_view(start=old_index, end=old_index + old_len) {
             buf <+ "\u{1b}[31m-\{e}\u{1b}[0m\n"
           }
         Insert(new_index~, new_len~, ..) =>
-          for e in n.view(start=new_index, end=new_index + new_len) {
+          for e in n.exact_view(start=new_index, end=new_index + new_len) {
             buf <+ "\u{1b}[32m+\{e}\u{1b}[0m\n"
           }
       }

--- a/diff/diff.mbt
+++ b/diff/diff.mbt
@@ -560,8 +560,8 @@ fn[T : Eq + Hash] append_patience_matches(
     append_myers_matches(
       matches,
       cutoff,
-      old.view(start=prev_old_idx, end=old_idx),
-      new.view(start=prev_new_idx, end=new_idx),
+      old.exact_view(start=prev_old_idx, end=old_idx),
+      new.exact_view(start=prev_new_idx, end=new_idx),
       old_offset + prev_old_idx,
       new_offset + prev_new_idx,
     )
@@ -573,8 +573,8 @@ fn[T : Eq + Hash] append_patience_matches(
   append_myers_matches(
     matches,
     cutoff,
-    old.view(start=prev_old_idx, end=old.length()),
-    new.view(start=prev_new_idx, end=new.length()),
+    old.exact_view(start=prev_old_idx, end=old.length()),
+    new.exact_view(start=prev_new_idx, end=new.length()),
     old_offset + prev_old_idx,
     new_offset + prev_new_idx,
   )

--- a/diff/diff_align_test.mbt
+++ b/diff/diff_align_test.mbt
@@ -51,7 +51,7 @@ fn weight(k : TokKind) -> Int {
 /// carry the low `Comment` weight, so similar comments pair while unrelated
 /// ones do not — a whole comment is never one opaque cheap token.
 fn push_comment_tokens(toks : Array[Tok], body : String) -> Unit {
-  let mut rest = body.view()
+  let mut rest = body.exact_view()
   while rest is [_, ..] {
     rest = lexmatch rest with longest {
       (re"^//+" as t, after=next) => {
@@ -86,10 +86,10 @@ fn tokenize_line(line : String) -> Array[Tok] {
   // the comment rule would otherwise swallow `///| x` whole.
   if line is ['/', '/', '/', '|', ..] {
     toks.push({ kind: Marker, text: "///|", })
-    push_comment_tokens(toks, line.view(start_offset=4).to_owned())
+    push_comment_tokens(toks, line.exact_view(start=4).to_owned())
     return toks
   }
-  let mut rest = line.view()
+  let mut rest = line.exact_view()
   while rest is [_, ..] {
     rest = lexmatch rest with longest {
       (re"^///\|" as t, after=next) => {

--- a/diff/diff_html_test.mbt
+++ b/diff/diff_html_test.mbt
@@ -46,8 +46,8 @@ fn side_by_side_html(
         Delete(old_index~, old_len~, ..) if i + 1 < edits.length() &&
           edits[i + 1] is Insert(..) => {
           guard! edits[i + 1] is Insert(new_index~, new_len~, ..)
-          let old_lines = o.view(start=old_index, end=old_index + old_len)
-          let new_lines = n.view(start=new_index, end=new_index + new_len)
+          let old_lines = o.exact_view(start=old_index, end=old_index + old_len)
+          let new_lines = n.exact_view(start=new_index, end=new_index + new_len)
           // dimension guards FIRST, then tokenize once per line with a
           // per-line token cap (which also bounds every budget term below
           // 1025 * 1025, so the accumulating Int cannot overflow), then an
@@ -116,19 +116,19 @@ fn side_by_side_html(
           i += 2
         }
         Equal(old_index~, len~, ..) => {
-          for l in o.view(start=old_index, end=old_index + len) {
+          for l in o.exact_view(start=old_index, end=old_index + len) {
             row(esc(l), "ctx", esc(l), "ctx")
           }
           i += 1
         }
         Delete(old_index~, old_len~, ..) => {
-          for l in o.view(start=old_index, end=old_index + old_len) {
+          for l in o.exact_view(start=old_index, end=old_index + old_len) {
             row(esc(l), "del", "", "empty")
           }
           i += 1
         }
         Insert(new_index~, new_len~, ..) => {
-          for l in n.view(start=new_index, end=new_index + new_len) {
+          for l in n.exact_view(start=new_index, end=new_index + new_len) {
             row("", "empty", esc(l), "add")
           }
           i += 1

--- a/diff/diff_test.mbt
+++ b/diff/diff_test.mbt
@@ -20,11 +20,11 @@ fn[T] edits_to_string(d : @diff.Diff[T], show~ : (T) -> String) -> String {
   for edit in d.edits() {
     let (prefix, slice) = match edit {
       Insert(new_index~, new_len~, ..) =>
-        ("+", new.view(start=new_index, end=new_index + new_len))
+        ("+", new.exact_view(start=new_index, end=new_index + new_len))
       Delete(old_index~, old_len~, ..) =>
-        ("-", old.view(start=old_index, end=old_index + old_len))
+        ("-", old.exact_view(start=old_index, end=old_index + old_len))
       Equal(old_index~, len~, ..) =>
-        (" ", old.view(start=old_index, end=old_index + len))
+        (" ", old.exact_view(start=old_index, end=old_index + len))
     }
     for s in slice {
       lines.push("\{prefix} \{show(s)}")
@@ -531,15 +531,15 @@ fn[T] ansi_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
   for edit in h.edits() {
     match edit {
       Equal(old_index~, len~, ..) =>
-        for e in old.view(start=old_index, end=old_index + len) {
+        for e in old.exact_view(start=old_index, end=old_index + len) {
           buf <+ " \{show(e)}\n"
         }
       Delete(old_index~, old_len~, ..) =>
-        for e in old.view(start=old_index, end=old_index + old_len) {
+        for e in old.exact_view(start=old_index, end=old_index + old_len) {
           buf <+ "\u{1b}[31m-\{show(e)}\u{1b}[0m\n"
         }
       Insert(new_index~, new_len~, ..) =>
-        for e in new.view(start=new_index, end=new_index + new_len) {
+        for e in new.exact_view(start=new_index, end=new_index + new_len) {
           buf <+ "\u{1b}[32m+\{show(e)}\u{1b}[0m\n"
         }
     }
@@ -577,15 +577,15 @@ fn[T] html_render(h : @diff.Hunk[T], show~ : (T) -> String) -> String {
   for edit in h.edits() {
     match edit {
       Equal(old_index~, len~, ..) =>
-        for e in old.view(start=old_index, end=old_index + len) {
+        for e in old.exact_view(start=old_index, end=old_index + len) {
           line(buf, "ctx", " ", esc(show(e)))
         }
       Delete(old_index~, old_len~, ..) =>
-        for e in old.view(start=old_index, end=old_index + old_len) {
+        for e in old.exact_view(start=old_index, end=old_index + old_len) {
           line(buf, "del", "-", esc(show(e)))
         }
       Insert(new_index~, new_len~, ..) =>
-        for e in new.view(start=new_index, end=new_index + new_len) {
+        for e in new.exact_view(start=new_index, end=new_index + new_len) {
           line(buf, "add", "+", esc(show(e)))
         }
     }
@@ -639,15 +639,15 @@ test "edits() with the views agrees with render()" {
     for edit in h.edits() {
       match edit {
         Equal(old_index~, len~, ..) =>
-          for e in o.view(start=old_index, end=old_index + len) {
+          for e in o.exact_view(start=old_index, end=old_index + len) {
             rebuilt <+ " \{e}\n"
           }
         Delete(old_index~, old_len~, ..) =>
-          for e in o.view(start=old_index, end=old_index + old_len) {
+          for e in o.exact_view(start=old_index, end=old_index + old_len) {
             rebuilt <+ "-\{e}\n"
           }
         Insert(new_index~, new_len~, ..) =>
-          for e in n.view(start=new_index, end=new_index + new_len) {
+          for e in n.exact_view(start=new_index, end=new_index + new_len) {
             rebuilt <+ "+\{e}\n"
           }
       }

--- a/diff/diff_word_test.mbt
+++ b/diff/diff_word_test.mbt
@@ -136,18 +136,18 @@ fn side_rows(inner : @diff.Diff[String], old_side~ : Bool) -> Array[String] {
   for edit in inner.edits() {
     match edit {
       Equal(old_index~, len~, ..) =>
-        for t in o.view(start=old_index, end=old_index + len) {
+        for t in o.exact_view(start=old_index, end=old_index + len) {
           emit(t, false)
         }
       Delete(old_index~, old_len~, ..) =>
         if old_side {
-          for t in o.view(start=old_index, end=old_index + old_len) {
+          for t in o.exact_view(start=old_index, end=old_index + old_len) {
             emit(t, true)
           }
         }
       Insert(new_index~, new_len~, ..) =>
         if !old_side {
-          for t in n.view(start=new_index, end=new_index + new_len) {
+          for t in n.exact_view(start=new_index, end=new_index + new_len) {
             emit(t, true)
           }
         }
@@ -177,11 +177,11 @@ fn word_diff_html(old~ : ArrayView[String], new~ : ArrayView[String]) -> String 
           edits[i + 1] is Insert(..) => {
           guard! edits[i + 1] is Insert(new_index~, new_len~, ..)
           let removed = o
-            .view(start=old_index, end=old_index + old_len)
+            .exact_view(start=old_index, end=old_index + old_len)
             .map(l => l)
             .join("\n")
           let added = n
-            .view(start=new_index, end=new_index + new_len)
+            .exact_view(start=new_index, end=new_index + new_len)
             .map(l => l)
             .join("\n")
           let inner = @diff.Diff(old=tokenize(removed), new=tokenize(added))
@@ -194,19 +194,19 @@ fn word_diff_html(old~ : ArrayView[String], new~ : ArrayView[String]) -> String 
           i += 2
         }
         Equal(old_index~, len~, ..) => {
-          for l in o.view(start=old_index, end=old_index + len) {
+          for l in o.exact_view(start=old_index, end=old_index + len) {
             buf <+ "<span class=\"ctx\"> \{esc(l)}</span>\n"
           }
           i += 1
         }
         Delete(old_index~, old_len~, ..) => {
-          for l in o.view(start=old_index, end=old_index + old_len) {
+          for l in o.exact_view(start=old_index, end=old_index + old_len) {
             buf <+ "<span class=\"del\">-\{esc(l)}</span>\n"
           }
           i += 1
         }
         Insert(new_index~, new_len~, ..) => {
-          for l in n.view(start=new_index, end=new_index + new_len) {
+          for l in n.exact_view(start=new_index, end=new_index + new_len) {
             buf <+ "<span class=\"add\">+\{esc(l)}</span>\n"
           }
           i += 1
@@ -270,8 +270,8 @@ impl Hash for Loose with fn hash_combine(self, hasher) {
 /// comment rewrite compares equal.
 fn loose(line : String) -> Loose {
   let code = match line.find("//") {
-    Some(i) => line.view(end_offset=i)
-    None => line.view()
+    Some(i) => line.exact_view(end=i)
+    None => line.exact_view()
   }
   let kept = tokenize(code).filter(t => !(t is [' ' | '\t', ..]))
   { text: line, key: kept.join("\u{0}"), }

--- a/diff/edit.mbt
+++ b/diff/edit.mbt
@@ -72,11 +72,11 @@ fn[T] Edit::view_from(
 ) -> ArrayView[T] {
   match self {
     Insert(new_index~, new_len~, ..) =>
-      new.view(start=new_index, end=new_index + new_len)
+      new.exact_view(start=new_index, end=new_index + new_len)
     Delete(old_index~, old_len~, ..) =>
-      old.view(start=old_index, end=old_index + old_len)
+      old.exact_view(start=old_index, end=old_index + old_len)
     Equal(old_index~, len~, ..) =>
-      old.view(start=old_index, end=old_index + len)
+      old.exact_view(start=old_index, end=old_index + len)
   }
 }
 

--- a/diff/levenshtein.mbt
+++ b/diff/levenshtein.mbt
@@ -124,8 +124,8 @@ pub fn[T : Eq] levenshtein_edits(
   new~ : ArrayView[T],
 ) -> Array[LevenshteinEdit] {
   let prefix = common_prefix_len(old, new)
-  let a = old.view(start=prefix)
-  let b = new.view(start=prefix)
+  let a = old.exact_view(start=prefix)
+  let b = new.exact_view(start=prefix)
   let m = a.length()
   let n = b.length()
   // widen before any arithmetic so the guard itself cannot overflow

--- a/hashmap/hashmap.mbt
+++ b/hashmap/hashmap.mbt
@@ -288,7 +288,7 @@ pub fn[V] HashMap::get_from_bytes(
 /// test {
 ///   let map = @hashmap.from_array([("hello", 1), ("world", 2)])
 ///   let str = "say hello to everyone"
-///   let view = str.view(start_offset=4, end_offset=9) // view of "hello"
+///   let view = str.exact_view(start=4, end=9) // view of "hello"
 ///   @debug.debug_inspect(map.get_from_string(view), content="Some(1)")
 /// }
 /// ```

--- a/hashmap/hashmap_test.mbt
+++ b/hashmap/hashmap_test.mbt
@@ -654,7 +654,7 @@ test "HashMap::get_from_string" {
 
   // String view from substring
   let full_str = "prefix_world_suffix"
-  let view2 = full_str.view(start_offset=7, end_offset=12)
+  let view2 = full_str.exact_view(start=7, end=12)
   debug_inspect(map.get_from_string(view2), content="Some(2)")
 
   // Non-existent key
@@ -676,7 +676,7 @@ test "HashMap::get_from_string" {
 
   // Substring of a longer string
   let longer = "this is a test string"
-  let test_view = longer.view(start_offset=10, end_offset=14)
+  let test_view = longer.exact_view(start=10, end=14)
   debug_inspect(map.get_from_string(test_view), content="Some(3)")
 }
 

--- a/immut/sorted_map/utils.mbt
+++ b/immut/sorted_map/utils.mbt
@@ -319,7 +319,7 @@ fn[K : Compare, V] sorted_map_from_unsorted_entries(
 ) -> SortedMap[K, V] {
   entries.sort()
   let len = sorted_map_compact_entries_in_place(entries)
-  sorted_map_from_sorted_entries(entries.view(), 0, len)
+  sorted_map_from_sorted_entries(entries.exact_view(), 0, len)
 }
 
 ///|

--- a/immut/sorted_set/immutable_set.mbt
+++ b/immut/sorted_set/immutable_set.mbt
@@ -88,7 +88,7 @@ fn[A : Compare] sorted_set_from_unsorted_buffer(
 ) -> SortedSet[A] {
   buf.stable_sort()
   let len = sorted_set_dedupe_in_place(buf)
-  sorted_set_from_ascending_array(buf.view(start=0, end=len), 0, len)
+  sorted_set_from_ascending_array(buf.exact_view(start=0, end=len), 0, len)
 }
 
 ///|

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -242,7 +242,7 @@ fn ParseContext::lex_integer_end(
       // infinity sentinel.
       // Malformed tokens may end inside a surrogate pair. Keep raw slicing
       // here and in lex_number_end so parsing reports an error without aborting.
-      let s = ctx.input.raw_view(start_offset=start, end_offset=end)
+      let s = ctx.input.view(start_offset=start, end_offset=end)
       try {
         let value = @internal/strconv.parse_double(s)
         return { value, repr: Some(s), }
@@ -428,7 +428,7 @@ fn ParseContext::lex_number_end(
       return { value: fast, repr: None, }
     }
   }
-  let s = ctx.input.raw_view(start_offset=start, end_offset=end)
+  let s = ctx.input.view(start_offset=start, end_offset=end)
   try {
     let d = @internal/strconv.parse_double(s)
     // For normal values, return without string representation

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -242,7 +242,7 @@ fn ParseContext::lex_integer_end(
       // infinity sentinel.
       // Malformed tokens may end inside a surrogate pair. Keep raw slicing
       // here and in lex_number_end so parsing reports an error without aborting.
-      let s = ctx.input.view(start_offset=start, end_offset=end)
+      let s = ctx.input.raw_view(start_offset=start, end_offset=end)
       try {
         let value = @internal/strconv.parse_double(s)
         return { value, repr: Some(s), }
@@ -428,7 +428,7 @@ fn ParseContext::lex_number_end(
       return { value: fast, repr: None, }
     }
   }
-  let s = ctx.input.view(start_offset=start, end_offset=end)
+  let s = ctx.input.raw_view(start_offset=start, end_offset=end)
   try {
     let d = @internal/strconv.parse_double(s)
     // For normal values, return without string representation

--- a/json/lex_number.mbt
+++ b/json/lex_number.mbt
@@ -240,6 +240,8 @@ fn ParseContext::lex_integer_end(
       // exact source text in `repr` so `stringify` stays lossless. Only a
       // literal strconv itself rejects (beyond double range) keeps the
       // infinity sentinel.
+      // Malformed tokens may end inside a surrogate pair. Keep raw slicing
+      // here and in lex_number_end so parsing reports an error without aborting.
       let s = ctx.input.view(start_offset=start, end_offset=end)
       try {
         let value = @internal/strconv.parse_double(s)

--- a/json/lex_number_test.mbt
+++ b/json/lex_number_test.mbt
@@ -212,3 +212,13 @@ test "parse preserves the sign of negative zero" {
   assert_true(is_negative("-4.9e-325"))
   assert_true(is_negative("-1e-999999999999999999999999999999999999"))
 }
+
+///|
+test "invalid integer followed by non-BMP text returns an error" {
+  inspect(@json.valid("9007199254740992😀"), content="false")
+}
+
+///|
+test "invalid decimal followed by non-BMP text returns an error" {
+  inspect(@json.valid("1.234567890123456789😀"), content="false")
+}

--- a/json/lex_string.mbt
+++ b/json/lex_string.mbt
@@ -21,7 +21,12 @@ fn ParseContext::lex_string(ctx : ParseContext) -> String raise ParseError {
     let c = ctx.input.unsafe_get(i)
     if c == '"' {
       ctx.offset = i + 1
-      return ctx.input.view(start_offset=string_start, end_offset=i).to_owned()
+      // The scan bounds guarantee these offsets are inside the input. Preserve
+      // raw code units, including unmatched surrogates, when copying the text.
+      let base = ctx.input.start_offset()
+      return ctx.input
+        .data()
+        .unsafe_substring(start=base + string_start, end=base + i)
     } else if c == '\\' {
       return ctx.lex_string_slow()
     } else if c < ' ' {

--- a/lexbuf/storage.mbt
+++ b/lexbuf/storage.mbt
@@ -131,21 +131,21 @@ fn LexbufStorage::get_stringview(
   let first_start = self.chunk_starts.unsafe_get(first)
   let first_end = first_start + first_chunk.length()
   // Lexbuf offsets and chunk boundaries are raw UTF-16 code-unit positions,
-  // so raw_view must preserve boundaries inside surrogate pairs.
+  // so view must preserve boundaries inside surrogate pairs.
   if end <= first_end {
-    return first_chunk.raw_view(
+    return first_chunk.view(
       start_offset=start - first_start,
       end_offset=end - first_start,
     )
   }
   let builder = StringBuilder(size_hint=(end - start) * 2)
-  builder.write_view(first_chunk.raw_view(start_offset=start - first_start))
+  builder.write_view(first_chunk.view(start_offset=start - first_start))
   for index in (first + 1)..<self.chunks.length() {
     let chunk = self.chunks.unsafe_get(index)
     let chunk_start = self.chunk_starts.unsafe_get(index)
     let chunk_end = chunk_start + chunk.length()
     if end <= chunk_end {
-      builder.write_view(chunk.raw_view(end_offset=end - chunk_start))
+      builder.write_view(chunk.view(end_offset=end - chunk_start))
       break
     }
     builder.write_string(chunk)

--- a/lexbuf/storage.mbt
+++ b/lexbuf/storage.mbt
@@ -130,22 +130,22 @@ fn LexbufStorage::get_stringview(
   let first_chunk = self.chunks.unsafe_get(first)
   let first_start = self.chunk_starts.unsafe_get(first)
   let first_end = first_start + first_chunk.length()
-  // Use views rather than `s[a:b]`: lexbuf offsets and chunk boundaries are raw
-  // UTF-16 code-unit positions, so they may fall inside a surrogate pair.
+  // Lexbuf offsets and chunk boundaries are raw UTF-16 code-unit positions,
+  // so raw_view must preserve boundaries inside surrogate pairs.
   if end <= first_end {
-    return first_chunk.view(
+    return first_chunk.raw_view(
       start_offset=start - first_start,
       end_offset=end - first_start,
     )
   }
   let builder = StringBuilder(size_hint=(end - start) * 2)
-  builder.write_view(first_chunk.view(start_offset=start - first_start))
+  builder.write_view(first_chunk.raw_view(start_offset=start - first_start))
   for index in (first + 1)..<self.chunks.length() {
     let chunk = self.chunks.unsafe_get(index)
     let chunk_start = self.chunk_starts.unsafe_get(index)
     let chunk_end = chunk_start + chunk.length()
     if end <= chunk_end {
-      builder.write_view(chunk.view(end_offset=end - chunk_start))
+      builder.write_view(chunk.raw_view(end_offset=end - chunk_start))
       break
     }
     builder.write_string(chunk)

--- a/string/DESIGN.mbt.md
+++ b/string/DESIGN.mbt.md
@@ -56,10 +56,10 @@ test "unsafe vs safe" {
 }
 ```
 
-* **Validity**: The string APIs assume the validity of strings and that provided
-  offsets don't fall between surrogate pairs. The APIs don't perform validity
-  checks for efficiency reasons. Creating invalid strings is possible (e.g.,
-  `"🍎".view(start_offset=1)` starts at the second half of a surrogate pair).
+* **Validity**: Strings store UTF-16 code units. `exact_view` validates bounds and
+  surrogate boundaries, while `clamped_view` trims split pairs inward. Creating
+  invalid strings is possible (e.g., `"🍎".unsafe_substring(start=1, end=2)`
+  starts at the second half of a surrogate pair).
   When displaying invalid characters, a replacement character � will be shown.
 
 * **View**: A `View` represents a view of a String that maintains proper Unicode
@@ -91,7 +91,7 @@ test "view conversion" {
   }
 
   let str = "Hello World"
-  let view = str.view(start_offset=0, end_offset=5)
+  let view = str.exact_view(start=0, end=5)
 
   // Both work due to implicit conversion
   let _ = process_text(str) // String implicitly converts to View

--- a/string/README.mbt.md
+++ b/string/README.mbt.md
@@ -129,7 +129,11 @@ String views provide efficient substring operations without copying. A
 `String` stores UTF-16 code units, and a view is just a `{str, start, end}`
 window into those units. A character outside the Basic Multilingual Plane is
 stored as a surrogate pair, and the `s[start:end]` slice syntax panics
-rather than split one:
+rather than split one. `s.exact_view(start~, end~)` provides the same validation;
+`s.clamped_view(start~, end~)` clamps bounds and trims split pairs inward.
+The old `sub` name is deprecated in favor of `exact_view`. The legacy `view`
+method is also deprecated; it retains its `start_offset`/`end_offset` labels and
+raw UTF-16 behavior for compatibility.
 
 ```d2
 direction: right

--- a/string/additional_coverage_test.mbt
+++ b/string/additional_coverage_test.mbt
@@ -61,7 +61,7 @@ test "View::pad_start and pad_end no padding" {
 ///|
 test "View::compare identical" {
   let str = "abcdef"
-  let v = str.view(start_offset=2, end_offset=4)
+  let v = str.exact_view(start=2, end=4)
   inspect(v.compare(v), content="0")
 }
 
@@ -69,8 +69,8 @@ test "View::compare identical" {
 test "View::default and hash" {
   let v : StringView = (Default::default() : StringView)
   inspect(v, content="")
-  let v1 = "abc".view()
-  let v2 = "abc".view()
+  let v1 = "abc".exact_view()
+  let v2 = "abc".exact_view()
   @test.assert_eq(hash(v1), hash(v2))
 }
 

--- a/string/op_as_view_test.mbt
+++ b/string/op_as_view_test.mbt
@@ -99,11 +99,11 @@ test "View::op_as_view with positive indices" {
 ///|
 test "View::op_as_view with nested views" {
   let s = "hello world"
-  let view1 = s.view(start_offset=0, end_offset=11)
+  let view1 = s.exact_view(start=0, end=11)
   inspect(view1, content="hello world")
-  let view2 = view1.view(start_offset=0, end_offset=5)
+  let view2 = view1.exact_view(start=0, end=5)
   inspect(view2, content="hello")
-  let view3 = view2.view(start_offset=1, end_offset=4)
+  let view3 = view2.exact_view(start=1, end=4)
   inspect(view3, content="ell")
 
   // Test with negative indices in nested views

--- a/string/view_test.mbt
+++ b/string/view_test.mbt
@@ -17,10 +17,13 @@ test "stringview basic" {
   let str = "Hello🤣🤣🤣"
   let start_offset = 1
   let end_offset = str.offset_of_nth_char(6).unwrap()
-  inspect(str.view(start_offset~), content="ello🤣🤣🤣")
-  inspect(str.view(end_offset~), content="Hello🤣")
-  inspect(str.view(start_offset~, end_offset~), content="ello🤣")
-  inspect(str.view(), content="Hello🤣🤣🤣")
+  inspect(str.exact_view(start=start_offset), content="ello🤣🤣🤣")
+  inspect(str.exact_view(end=end_offset), content="Hello🤣")
+  inspect(
+    str.exact_view(start=start_offset, end=end_offset),
+    content="ello🤣",
+  )
+  inspect(str.exact_view(), content="Hello🤣🤣🤣")
 }
 
 ///|
@@ -28,13 +31,10 @@ test "stringview basic2" {
   let str = "He🤣🤣🤣llo"
   let start = 1
   let end = 10
-  inspect(str.view(start_offset=start), content="e🤣🤣🤣llo")
-  inspect(str.view(end_offset=end), content="He🤣🤣🤣ll")
-  inspect(
-    str.view(start_offset=start, end_offset=end),
-    content="e🤣🤣🤣ll",
-  )
-  inspect(str.view(), content="He🤣🤣🤣llo")
+  inspect(str.exact_view(start~), content="e🤣🤣🤣llo")
+  inspect(str.exact_view(end~), content="He🤣🤣🤣ll")
+  inspect(str.exact_view(start~, end~), content="e🤣🤣🤣ll")
+  inspect(str.exact_view(), content="He🤣🤣🤣llo")
 }
 
 ///|
@@ -42,17 +42,17 @@ test "stringview subview" {
   let str = "Hello🤣🤣🤣"
   let start = 1
   let end = 7
-  let view = str.view(start_offset=start, end_offset=end)
-  inspect(view.view(start_offset=1), content="llo🤣")
-  inspect(view.view(start_offset=1, end_offset=4), content="llo")
-  inspect(view.view(end_offset=4), content="ello")
-  inspect(view.view(), content="ello🤣")
+  let view = str.exact_view(start~, end~)
+  inspect(view.exact_view(start=1), content="llo🤣")
+  inspect(view.exact_view(start=1, end=4), content="llo")
+  inspect(view.exact_view(end=4), content="ello")
+  inspect(view.exact_view(), content="ello🤣")
 }
 
 ///|
 test "stringview access" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.iter().nth(4).unwrap(), content="🤣")
   inspect(view.iter().nth(4).unwrap(), content="🤣")
 }
@@ -60,7 +60,7 @@ test "stringview access" {
 ///|
 test "stringview access iter" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.iter().nth(4).unwrap(), content="🤣")
   inspect(view.iter().nth(4).unwrap(), content="🤣")
 }
@@ -68,7 +68,7 @@ test "stringview access iter" {
 ///|
 test "stringview rev_get" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.rev_iter().nth(0).unwrap(), content="🤣")
   inspect(view.rev_iter().nth(4).unwrap(), content="e")
 }
@@ -76,7 +76,7 @@ test "stringview rev_get" {
 ///|
 test "stringview rev_get rev_iter" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.rev_iter().nth(0).unwrap(), content="🤣")
   inspect(view.rev_iter().nth(4).unwrap(), content="e")
 }
@@ -84,28 +84,28 @@ test "stringview rev_get rev_iter" {
 ///|
 test "stringview data" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.data(), content="Hello🤣🤣🤣")
 }
 
 ///|
 test "stringview start_offset" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.start_offset(), content="1")
 }
 
 ///|
 test "stringview length" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.length(), content="6")
 }
 
 ///|
 test "stingview length_eq" {
   let str = "hello"
-  let view = str.view(start_offset=1, end_offset=4)
+  let view = str.exact_view(start=1, end=4)
   inspect(view.char_length_eq(0), content="false")
   inspect(view.char_length_eq(1), content="false")
   inspect(view.char_length_eq(2), content="false")
@@ -117,7 +117,7 @@ test "stingview length_eq" {
 ///|
 test "stingview length_ge" {
   let str = "hello"
-  let view = str.view(start_offset=1, end_offset=4)
+  let view = str.exact_view(start=1, end=4)
   inspect(view.char_length_ge(0), content="true")
   inspect(view.char_length_ge(1), content="true")
   inspect(view.char_length_ge(2), content="true")
@@ -129,35 +129,35 @@ test "stingview length_ge" {
 ///|
 test "stringview empty" {
   let str = "hello"
-  let view = str.view(start_offset=0, end_offset=0)
+  let view = str.exact_view(start=0, end=0)
   inspect(view.length(), content="0")
 }
 
 ///|
 test "panic out of bounds1" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   let _ = view.iter().nth(5).unwrap()
 }
 
 ///|
 test "panic out of bounds2" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
-  let _ = view.view(start_offset=7)
+  let view = str.exact_view(start=1, end=7)
+  let _ = view.exact_view(start=7)
 }
 
 ///|
 test "panic out of bounds3" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
-  let _ = view.view(end_offset=7)
+  let view = str.exact_view(start=1, end=7)
+  let _ = view.exact_view(end=7)
 }
 
 ///|
 test "panic out of bounds4" {
   let str = "hello"
-  let view = str.view(start_offset=0, end_offset=0)
+  let view = str.exact_view(start=0, end=0)
   let _ = view.iter().nth(0).unwrap()
 }
 
@@ -218,71 +218,71 @@ test "panic negative index 1" {
   // index_at_rev fails
   let str = "hello"
   let str_view = str[:]
-  let _ = str_view.view(start_offset=-6)
+  let _ = str_view.exact_view(start=-6)
 }
 
 ///|
 test "panic negative index 2" {
   // index_at_rev fails
   let str = "hello"
-  let str_view = str.view()
-  let _ = str_view.view(end_offset=-6)
+  let str_view = str.exact_view()
+  let _ = str_view.exact_view(end=-6)
 }
 
 ///|
 test "panic negative index 3" {
   // index_at_rev returns an index not in bounds of the view
   let str = "hello"
-  let str_view = str.view(start_offset=1, end_offset=4)
-  let _ = str_view.view(start_offset=-4)
+  let str_view = str.exact_view(start=1, end=4)
+  let _ = str_view.exact_view(start=-4)
 }
 
 ///|
 test "panic negative index 4" {
   // index_at_rev returns an index not in bounds of the view
   let str = "hello"
-  let str_view = str.view(start_offset=1, end_offset=4)
-  let _ = str_view.view(end_offset=4)
+  let str_view = str.exact_view(start=1, end=4)
+  let _ = str_view.exact_view(end=4)
 }
 
 ///|
 test "panic negative index 5" {
   // index_at_rev returns an index not in bounds of the view
   let str = "hello"
-  let str_view = str.view(start_offset=1, end_offset=4)
-  let _ = str_view.view(start_offset=4)
+  let str_view = str.exact_view(start=1, end=4)
+  let _ = str_view.exact_view(start=4)
 }
 
 ///|
 test "panic negative index 6" {
   // index_at_rev returns an index not in bounds of the view
   let str = "hello"
-  let str_view = str.view(start_offset=1, end_offset=4)
-  let _ = str_view.view(end_offset=4)
+  let str_view = str.exact_view(start=1, end=4)
+  let _ = str_view.exact_view(end=4)
 }
 
 ///|
 test "panic negative index 7" {
   // start > end
   let str = "hello"
-  let str_view = str.view(start_offset=1, end_offset=4)
-  let _ = str_view.view(start_offset=-1, end_offset=-2)
+  let str_view = str.exact_view(start=1, end=4)
+  let _ = str_view.exact_view(start=-1, end=-2)
 }
 
 ///|
 test "panic negative index 8" {
   // start > end
   let str = "hello"
-  let str_view = str.view(start_offset=1, end_offset=4)
-  let _ = str_view.view(start_offset=-1, end_offset=1)
+  let str_view = str.exact_view(start=1, end=4)
+  let _ = str_view.exact_view(start=-1, end=1)
 }
 
 ///|
 test "panic negative index 9" {
   // start > end
   let str = "hello"
-  let str_view = str.view(start_offset=1, end_offset=4)
-  let _ = str_view.view(start_offset=2, end_offset=-2)
+  let str_view = str.exact_view(start=1, end=4)
+  let _ = str_view.exact_view(start=2, end=-2)
 }
 
 ///|
@@ -296,7 +296,7 @@ test "panic negative index 9" {
 ///|
 test "stringview iter" {
   let str = "hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.iter().count(), content="5")
   debug_inspect(
     view.iter().to_array(),
@@ -309,7 +309,7 @@ test "stringview iter" {
 ///|
 test "stringview rev_iter" {
   let str = "hello🤣🤣🤣"
-  let view = str.view(start_offset=1, end_offset=7)
+  let view = str.exact_view(start=1, end=7)
   inspect(view.rev_iter().count(), content="5")
   debug_inspect(
     view.rev_iter().to_array(),
@@ -322,25 +322,25 @@ test "stringview rev_iter" {
 ///|
 test "panic stringview negative index1" {
   let str = "hello🤣😭😂"
-  let _ = str.view(start_offset=-9)
+  let _ = str.exact_view(start=-9)
 }
 
 ///|
 test "panic stringview negative index2" {
   let str = "hello🤣😭😂"
-  let _ = str.view(end_offset=-9)
+  let _ = str.exact_view(end=-9)
 }
 
 ///|
 test "panic stringview negative index3" {
   let str = "hello🤣😭😂"
-  let _ = str.view(start_offset=-1, end_offset=-2)
+  let _ = str.exact_view(start=-1, end=-2)
 }
 
 ///|
 test "to_string" {
   let s = "Hello World"
-  let view = s.view(start_offset=0, end_offset=5)
+  let view = s.exact_view(start=0, end=5)
   let ss = "\{view} Moonbit"
   inspect(ss, content="Hello Moonbit")
 }
@@ -356,7 +356,7 @@ test "length_eq test with surrogate pair" {
 ///|
 test "length_ge with high surrogate" {
   let str = "🐰" // This emoji is represented using a surrogate pair
-  let view = str.view(start_offset=0)
+  let view = str.exact_view(start=0)
   @test.assert_eq(view.char_length_ge(1), true)
   @test.assert_eq(view.char_length_ge(2), false)
 }
@@ -364,27 +364,27 @@ test "length_ge with high surrogate" {
 ///|
 test "panic op_as_view with invalid positive start index" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view()
-  ignore(view.view(start_offset=100))
+  let view = str.exact_view()
+  ignore(view.exact_view(start=100))
 }
 
 ///|
 test "panic on accessing negative index" {
   let str = "Hello🤣🤣🤣"
-  let view = str.view()
-  ignore(view.view(start_offset=-1)) // This should panic due to invalid index
+  let view = str.exact_view()
+  ignore(view.exact_view(start=-1)) // This should panic due to invalid index
 }
 
 ///|
 test "panic on invalid start index" {
   let str = "Hello"
-  ignore(str.view(start_offset=10))
+  ignore(str.exact_view(start=10))
 }
 
 ///|
 test "panic on invalid end index" {
   let str = "Hello"
-  ignore(str.view(start_offset=0, end_offset=10))
+  ignore(str.exact_view(start=0, end=10))
 }
 
 ///|
@@ -411,7 +411,7 @@ test "panic_length_ge invalid surrogate pair" {
 ///|
 test "take first character from surrogate pairs" {
   let str = "Hello😀😃"
-  let view = str.view()
+  let view = str.exact_view()
   let result = view.iter().take(6).collect().length()
   // 6 characters total: 5 ASCII + 1 emoji
   inspect(result, content="6")
@@ -420,7 +420,7 @@ test "take first character from surrogate pairs" {
 ///|
 test "index_of_nth_char" {
   let str = "aa😭b😂cc"
-  let view = str.view(start_offset=1, end_offset=8)
+  let view = str.exact_view(start=1, end=8)
   inspect(view, content="a😭b😂c")
   debug_inspect(view.offset_of_nth_char(0), content="Some(0)")
   debug_inspect(view.offset_of_nth_char(1), content="Some(1)")
@@ -439,35 +439,35 @@ test "index_of_nth_char" {
 ///|
 test "char_length" {
   let str = "aa😭b😂cc"
-  let view = str.view(start_offset=1, end_offset=8)
+  let view = str.exact_view(start=1, end=8)
   inspect(view.char_length(), content="5")
 }
 
 ///|
 test "utf16 indexed view" {
   let str = "aa😭b😂cc"
-  let v0 = str.view()
+  let v0 = str.exact_view()
   inspect(v0, content="aa😭b😂cc")
   inspect(v0.char_length(), content="7")
-  let v1 = str.view(start_offset=1, end_offset=8)
+  let v1 = str.exact_view(start=1, end=8)
   inspect(v1, content="a😭b😂c")
   inspect(v1.char_length(), content="5")
-  let v2 = str.view(start_offset=1)
+  let v2 = str.exact_view(start=1)
   inspect(v2, content="a😭b😂cc")
   inspect(v2.char_length(), content="6")
-  let v3 = str.view(end_offset=4)
+  let v3 = str.exact_view(end=4)
   inspect(v3, content="aa😭")
   inspect(v3.char_length(), content="3")
-  let v4 = str.view(start_offset=1, end_offset=1)
+  let v4 = str.exact_view(start=1, end=1)
   inspect(v4, content="")
   inspect(v4.char_length(), content="0")
-  let v5 = str.view(end_offset=0)
+  let v5 = str.exact_view(end=0)
   inspect(v5, content="")
   inspect(v5.char_length(), content="0")
-  let v6 = str.view(start_offset=str.length())
+  let v6 = str.exact_view(start=str.length())
   inspect(v6, content="")
   inspect(v6.char_length(), content="0")
-  let v7 = str.view(start_offset=str.length(), end_offset=str.length())
+  let v7 = str.exact_view(start=str.length(), end=str.length())
   inspect(v7, content="")
   inspect(v7.char_length(), content="0")
 }
@@ -475,64 +475,57 @@ test "utf16 indexed view" {
 ///|
 test "op_equal" {
   let str = "012301230123"
-  inspect(str.view() == str.view(), content="true")
-  inspect(str.view() == str.view(start_offset=1), content="false")
+  inspect(str.exact_view() == str.exact_view(), content="true")
+  inspect(str.exact_view() == str.exact_view(start=1), content="false")
   inspect(
-    str.view(start_offset=0, end_offset=4) ==
-    str.view(start_offset=4, end_offset=8),
+    str.exact_view(start=0, end=4) == str.exact_view(start=4, end=8),
     content="true",
   )
   inspect(
-    str.view(start_offset=0, end_offset=4) ==
-    str.view(start_offset=8, end_offset=12),
+    str.exact_view(start=0, end=4) == str.exact_view(start=8, end=12),
     content="true",
   )
   inspect(
-    str.view(start_offset=0, end_offset=3) ==
-    str.view(start_offset=4, end_offset=7),
+    str.exact_view(start=0, end=3) == str.exact_view(start=4, end=7),
     content="true",
   )
   inspect(
-    str.view(start_offset=0, end_offset=3) ==
-    str.view(start_offset=0, end_offset=4),
+    str.exact_view(start=0, end=3) == str.exact_view(start=0, end=4),
     content="false",
   )
 
   // Test with surrogate pairs
   let emoji_str = "🤣abc🤣def"
   inspect(
-    emoji_str.view(start_offset=0, end_offset=2) ==
-    emoji_str.view(start_offset=5, end_offset=7),
+    emoji_str.exact_view(start=0, end=2) == emoji_str.exact_view(start=5, end=7),
     content="true",
   )
   inspect(
-    emoji_str.view(start_offset=2, end_offset=5) ==
-    emoji_str.view(start_offset=7, end_offset=10),
+    emoji_str.exact_view(start=2, end=5) ==
+    emoji_str.exact_view(start=7, end=10),
     content="false",
   )
   inspect(
-    emoji_str.view(start_offset=0, end_offset=5) ==
-    emoji_str.view(start_offset=5, end_offset=10),
+    emoji_str.exact_view(start=0, end=5) ==
+    emoji_str.exact_view(start=5, end=10),
     content="false",
   )
 
   // Test empty views
   inspect(
-    str.view(start_offset=0, end_offset=0) ==
-    str.view(start_offset=4, end_offset=4),
+    str.exact_view(start=0, end=0) == str.exact_view(start=4, end=4),
     content="true",
   )
   inspect(
-    str.view(start_offset=0, end_offset=0) ==
-    str.view(start_offset=0, end_offset=1),
+    str.exact_view(start=0, end=0) == str.exact_view(start=0, end=1),
     content="false",
   )
 
   // Test views from different strings
   let str1 = "bcabc"
   let str2 = "abcabc"
-  inspect(str1.view() == str2.view(), content="false")
-  inspect(str1.view() == str2.view(start_offset=1), content="true")
+  inspect(str1.exact_view() == str2.exact_view(), content="false")
+  inspect(str1.exact_view() == str2.exact_view(start=1), content="true")
 }
 
 ///|
@@ -541,39 +534,29 @@ test "stringview compare" {
 
   // Test equal views
   inspect(
-    str
-    .view(start_offset=0, end_offset=3)
-    .compare(str.view(start_offset=3, end_offset=6)),
+    str.exact_view(start=0, end=3).compare(str.exact_view(start=3, end=6)),
     content="0",
   )
 
   // Test lexicographically smaller view
   inspect(
-    str
-    .view(start_offset=0, end_offset=3)
-    .compare(str.view(start_offset=2, end_offset=5)),
+    str.exact_view(start=0, end=3).compare(str.exact_view(start=2, end=5)),
     content="-1",
   )
 
   // Test lexicographically larger view
   inspect(
-    str
-    .view(start_offset=1, end_offset=4)
-    .compare(str.view(start_offset=3, end_offset=6)),
+    str.exact_view(start=1, end=4).compare(str.exact_view(start=3, end=6)),
     content="1",
   )
 
   // Test different length views
   inspect(
-    str
-    .view(start_offset=0, end_offset=3)
-    .compare(str.view(start_offset=0, end_offset=4)),
+    str.exact_view(start=0, end=3).compare(str.exact_view(start=0, end=4)),
     content="-1",
   )
   inspect(
-    str
-    .view(start_offset=1, end_offset=5)
-    .compare(str.view(start_offset=2, end_offset=5)),
+    str.exact_view(start=1, end=5).compare(str.exact_view(start=2, end=5)),
     content="1",
   )
 
@@ -581,46 +564,44 @@ test "stringview compare" {
   let emoji_str = "🤣abc🤣def"
   inspect(
     emoji_str
-    .view(start_offset=0, end_offset=5)
-    .compare(emoji_str.view(start_offset=5, end_offset=10)),
+    .exact_view(start=0, end=5)
+    .compare(emoji_str.exact_view(start=5, end=10)),
     content="-1",
   )
 
   // Test empty views
   inspect(
-    str
-    .view(start_offset=0, end_offset=0)
-    .compare(str.view(start_offset=4, end_offset=4)),
+    str.exact_view(start=0, end=0).compare(str.exact_view(start=4, end=4)),
     content="0",
   )
 
   // Test views from different strings with same content
   let str1 = "bcabc"
   let str2 = "abcabc"
-  inspect(str1.view().compare(str2.view(start_offset=1)), content="0")
+  inspect(str1.exact_view().compare(str2.exact_view(start=1)), content="0")
 }
 
 ///|
 test "view of view" {
-  let v1 = "00abc😭def😂ghi11".view(start_offset=2, end_offset=15)
-  let v2 = v1.view(start_offset=3, end_offset=6)
+  let v1 = "00abc😭def😂ghi11".exact_view(start=2, end=15)
+  let v2 = v1.exact_view(start=3, end=6)
   inspect(v2, content="😭d")
-  let v3 = v2.view(start_offset=2, end_offset=3)
+  let v3 = v2.exact_view(start=2, end=3)
   inspect(v3, content="d")
-  let v4 = v1.view(start_offset=2, end_offset=6)
+  let v4 = v1.exact_view(start=2, end=6)
   inspect(v4, content="c😭d")
-  let v6 = v1.view(start_offset=5, end_offset=5)
+  let v6 = v1.exact_view(start=5, end=5)
   inspect(v6, content="")
-  let v7 = v1.view()
+  let v7 = v1.exact_view()
   inspect(v7, content="abc😭def😂ghi")
-  let v8 = v1.view(start_offset=3, end_offset=10)
+  let v8 = v1.exact_view(start=3, end=10)
   inspect(v8, content="😭def😂")
 }
 
 ///|
 test "iter2" {
   let str = "aa😭b😂cc"
-  let view = str.view(start_offset=1, end_offset=8)
+  let view = str.exact_view(start=1, end=8)
   debug_inspect(
     view.iter2().iter().collect(),
     content="[(0, 'a'), (1, '😭'), (2, 'b'), (3, '😂'), (4, 'c')]",
@@ -647,7 +628,7 @@ test "make" {
 
 ///|
 test "to_json" {
-  let v = "hello".view(start_offset=1, end_offset=4)
+  let v = "hello".exact_view(start=1, end=4)
   debug_inspect(
     v.to_json(),
     content=(
@@ -1025,7 +1006,7 @@ test "StringView add" {
 ///|
 test "panic view access out of bounds" {
   let str = "Hello"
-  let view = str.view(start_offset=0, end_offset=5)
+  let view = str.exact_view(start=0, end=5)
   view.code_unit_at(5) |> ignore
 }
 
@@ -1042,114 +1023,147 @@ test "stringview lexical_compare" {
   let str = "abc"
   inspect(
     str
-    .view(start_offset=0, end_offset=3)
-    .lexical_compare(str.view(start_offset=0, end_offset=3)),
+    .exact_view(start=0, end=3)
+    .lexical_compare(str.exact_view(start=0, end=3)),
     content="0",
   )
 
   // Test identical views from different strings
   let str1 = "abc"
   let str2 = "abc"
-  inspect(str1.view().lexical_compare(str2.view()), content="0")
+  inspect(str1.exact_view().lexical_compare(str2.exact_view()), content="0")
 
   // Test lexicographically less than
   inspect(
-    str.view(start_offset=0, end_offset=3).lexical_compare("abd".view()),
+    str.exact_view(start=0, end=3).lexical_compare("abd".exact_view()),
     content="-1",
   )
-  inspect("ab".view().lexical_compare("abc".view()), content="-1")
-  inspect("".view().lexical_compare("a".view()), content="-1")
+  inspect("ab".exact_view().lexical_compare("abc".exact_view()), content="-1")
+  inspect("".exact_view().lexical_compare("a".exact_view()), content="-1")
 
   // Test lexicographically greater than
-  inspect("abd".view().lexical_compare(str.view()), content="1")
-  inspect("abc".view().lexical_compare("ab".view()), content="1")
-  inspect("a".view().lexical_compare("".view()), content="1")
+  inspect("abd".exact_view().lexical_compare(str.exact_view()), content="1")
+  inspect("abc".exact_view().lexical_compare("ab".exact_view()), content="1")
+  inspect("a".exact_view().lexical_compare("".exact_view()), content="1")
 
   // Test different lengths with same prefix - Java behavior
   // In lexicographical comparison, "ab" < "abc" (shorter string is less when it's a prefix)
-  inspect("ab".view().lexical_compare("abc".view()), content="-1")
-  inspect("abc".view().lexical_compare("ab".view()), content="1")
+  inspect("ab".exact_view().lexical_compare("abc".exact_view()), content="-1")
+  inspect("abc".exact_view().lexical_compare("ab".exact_view()), content="1")
 
   // Test case sensitivity
-  inspect("ABC".view().lexical_compare("abc".view()), content="-1") // uppercase letters have lower code points
+  inspect("ABC".exact_view().lexical_compare("abc".exact_view()), content="-1") // uppercase letters have lower code points
 
   // Test with numbers
-  inspect("123".view().lexical_compare("124".view()), content="-1")
-  inspect("124".view().lexical_compare("123".view()), content="1")
+  inspect("123".exact_view().lexical_compare("124".exact_view()), content="-1")
+  inspect("124".exact_view().lexical_compare("123".exact_view()), content="1")
 
   // Test with surrogate pairs (emoji)
   let emoji1 = "🤣"
   let emoji2 = "😭"
   // Different emojis have different UTF-16 code units
-  inspect(emoji1.view().lexical_compare(emoji2.view()), content="1")
-  inspect(emoji2.view().lexical_compare(emoji1.view()), content="-1")
-  inspect(emoji1.view().lexical_compare(emoji1.view()), content="0")
+  inspect(emoji1.exact_view().lexical_compare(emoji2.exact_view()), content="1")
+  inspect(
+    emoji2.exact_view().lexical_compare(emoji1.exact_view()),
+    content="-1",
+  )
+  inspect(emoji1.exact_view().lexical_compare(emoji1.exact_view()), content="0")
 
   // Test mixed ASCII and emoji
-  inspect("a🤣".view().lexical_compare("a😭".view()), content="1")
-  inspect("abc🤣".view().lexical_compare("abc".view()), content="1")
-  inspect("abc".view().lexical_compare("abc🤣".view()), content="-1")
+  inspect(
+    "a🤣".exact_view().lexical_compare("a😭".exact_view()),
+    content="1",
+  )
+  inspect(
+    "abc🤣".exact_view().lexical_compare("abc".exact_view()),
+    content="1",
+  )
+  inspect(
+    "abc".exact_view().lexical_compare("abc🤣".exact_view()),
+    content="-1",
+  )
 
   // Test with views that have offsets
   let long_str = "xyzabcdefghijkl"
   inspect(
     long_str
-    .view(start_offset=3, end_offset=6)
-    .lexical_compare(long_str.view(start_offset=3, end_offset=9)),
+    .exact_view(start=3, end=6)
+    .lexical_compare(long_str.exact_view(start=3, end=9)),
     content="-1",
   )
   inspect(
     long_str
-    .view(start_offset=3, end_offset=9)
-    .lexical_compare(long_str.view(start_offset=3, end_offset=6)),
+    .exact_view(start=3, end=9)
+    .lexical_compare(long_str.exact_view(start=3, end=6)),
     content="1",
   )
 
   // Test views from different positions but same content
   inspect(
     long_str
-    .view(start_offset=3, end_offset=6)
-    .lexical_compare(long_str.view(start_offset=10, end_offset=13)),
+    .exact_view(start=3, end=6)
+    .lexical_compare(long_str.exact_view(start=10, end=13)),
     content="-1",
   ) // "abc" vs "jkl"
 
   // Test empty views
-  inspect("".view().lexical_compare("".view()), content="0")
+  inspect("".exact_view().lexical_compare("".exact_view()), content="0")
 
   // Test comparing common prefixes with different suffixes
   let str_a = "testing"
   let str_b = "tested"
-  inspect(str_b.view().lexical_compare(str_a.view()), content="-1") // "tested" < "testing"
+  inspect(str_b.exact_view().lexical_compare(str_a.exact_view()), content="-1") // "tested" < "testing"
 
   // Test comparison with special characters
-  inspect("hello!".view().lexical_compare("hello?".view()), content="-1") // '!' < '?'
+  inspect(
+    "hello!".exact_view().lexical_compare("hello?".exact_view()),
+    content="-1",
+  ) // '!' < '?'
 }
 
 ///|
 test "stringview compare_ignore_ascii_case" {
   // Equal under ASCII folding
-  inspect("".view().compare_ignore_ascii_case("".view()), content="0")
-  inspect("abc".view().compare_ignore_ascii_case("ABC".view()), content="0")
   inspect(
-    "MoonBit".view().compare_ignore_ascii_case("MOONBIT".view()),
+    "".exact_view().compare_ignore_ascii_case("".exact_view()),
+    content="0",
+  )
+  inspect(
+    "abc".exact_view().compare_ignore_ascii_case("ABC".exact_view()),
+    content="0",
+  )
+  inspect(
+    "MoonBit".exact_view().compare_ignore_ascii_case("MOONBIT".exact_view()),
     content="0",
   )
 
   // Less / greater after folding
-  inspect("ABC".view().compare_ignore_ascii_case("abd".view()), content="-1")
-  inspect("abd".view().compare_ignore_ascii_case("ABC".view()), content="1")
+  inspect(
+    "ABC".exact_view().compare_ignore_ascii_case("abd".exact_view()),
+    content="-1",
+  )
+  inspect(
+    "abd".exact_view().compare_ignore_ascii_case("ABC".exact_view()),
+    content="1",
+  )
 
   // Prefix relationship
-  inspect("ab".view().compare_ignore_ascii_case("ABC".view()), content="-1")
-  inspect("ABC".view().compare_ignore_ascii_case("ab".view()), content="1")
+  inspect(
+    "ab".exact_view().compare_ignore_ascii_case("ABC".exact_view()),
+    content="-1",
+  )
+  inspect(
+    "ABC".exact_view().compare_ignore_ascii_case("ab".exact_view()),
+    content="1",
+  )
 
   // Sub-views with different start offsets but equal-under-fold contents
   let long_a = "xyzHELLOxyz"
   let long_b = "qqhelloqq"
   inspect(
     long_a
-    .view(start_offset=3, end_offset=8)
-    .compare_ignore_ascii_case(long_b.view(start_offset=2, end_offset=7)),
+    .exact_view(start=3, end=8)
+    .compare_ignore_ascii_case(long_b.exact_view(start=2, end=7)),
     content="0",
   )
 
@@ -1159,43 +1173,65 @@ test "stringview compare_ignore_ascii_case" {
   let t = "XXXbbbDDD"
   inspect(
     s
-    .view(start_offset=3, end_offset=6)
-    .compare_ignore_ascii_case(t.view(start_offset=3, end_offset=6)),
+    .exact_view(start=3, end=6)
+    .compare_ignore_ascii_case(t.exact_view(start=3, end=6)),
     content="0",
   )
 
   // Non-ASCII letters are NOT folded
-  assert_true("Ä".view().compare_ignore_ascii_case("ä".view()) != 0)
+  assert_true(
+    "Ä".exact_view().compare_ignore_ascii_case("ä".exact_view()) != 0,
+  )
 
   // Surrogate pairs
-  inspect("A🤣".view().compare_ignore_ascii_case("a🤣".view()), content="0")
-  assert_true("a🤣".view().compare_ignore_ascii_case("a😭".view()) != 0)
+  inspect(
+    "A🤣".exact_view().compare_ignore_ascii_case("a🤣".exact_view()),
+    content="0",
+  )
+  assert_true(
+    "a🤣".exact_view().compare_ignore_ascii_case("a😭".exact_view()) != 0,
+  )
 }
 
 ///|
 test "stringview equal_ignore_ascii_case" {
   // Equal under ASCII folding
-  inspect("".view().equal_ignore_ascii_case("".view()), content="true")
-  inspect("abc".view().equal_ignore_ascii_case("ABC".view()), content="true")
   inspect(
-    "MoonBit".view().equal_ignore_ascii_case("MOONBIT".view()),
+    "".exact_view().equal_ignore_ascii_case("".exact_view()),
+    content="true",
+  )
+  inspect(
+    "abc".exact_view().equal_ignore_ascii_case("ABC".exact_view()),
+    content="true",
+  )
+  inspect(
+    "MoonBit".exact_view().equal_ignore_ascii_case("MOONBIT".exact_view()),
     content="true",
   )
 
   // Length mismatch fast path
-  inspect("ab".view().equal_ignore_ascii_case("ABC".view()), content="false")
-  inspect("ABC".view().equal_ignore_ascii_case("ab".view()), content="false")
+  inspect(
+    "ab".exact_view().equal_ignore_ascii_case("ABC".exact_view()),
+    content="false",
+  )
+  inspect(
+    "ABC".exact_view().equal_ignore_ascii_case("ab".exact_view()),
+    content="false",
+  )
 
   // Same length but different content
-  inspect("abc".view().equal_ignore_ascii_case("abd".view()), content="false")
+  inspect(
+    "abc".exact_view().equal_ignore_ascii_case("abd".exact_view()),
+    content="false",
+  )
 
   // Sub-views with different start offsets but equal-under-fold contents
   let long_a = "xyzHELLOxyz"
   let long_b = "qqhelloqq"
   inspect(
     long_a
-    .view(start_offset=3, end_offset=8)
-    .equal_ignore_ascii_case(long_b.view(start_offset=2, end_offset=7)),
+    .exact_view(start=3, end=8)
+    .equal_ignore_ascii_case(long_b.exact_view(start=2, end=7)),
     content="true",
   )
 
@@ -1205,21 +1241,24 @@ test "stringview equal_ignore_ascii_case" {
   let t = "XXXbbbDDD"
   inspect(
     s
-    .view(start_offset=3, end_offset=6)
-    .equal_ignore_ascii_case(t.view(start_offset=3, end_offset=6)),
+    .exact_view(start=3, end=6)
+    .equal_ignore_ascii_case(t.exact_view(start=3, end=6)),
     content="true",
   )
 
   // Non-ASCII letters are NOT folded
-  inspect("Ä".view().equal_ignore_ascii_case("ä".view()), content="false")
+  inspect(
+    "Ä".exact_view().equal_ignore_ascii_case("ä".exact_view()),
+    content="false",
+  )
 
   // Surrogate pairs
   inspect(
-    "A🤣".view().equal_ignore_ascii_case("a🤣".view()),
+    "A🤣".exact_view().equal_ignore_ascii_case("a🤣".exact_view()),
     content="true",
   )
   inspect(
-    "a🤣".view().equal_ignore_ascii_case("a😭".view()),
+    "a🤣".exact_view().equal_ignore_ascii_case("a😭".exact_view()),
     content="false",
   )
 
@@ -1228,8 +1267,8 @@ test "stringview equal_ignore_ascii_case" {
   for c in cases {
     let (x, y) = c
     @test.assert_eq(
-      x.view().equal_ignore_ascii_case(y.view()),
-      x.view().compare_ignore_ascii_case(y.view()) == 0,
+      x.exact_view().equal_ignore_ascii_case(y.exact_view()),
+      x.exact_view().compare_ignore_ascii_case(y.exact_view()) == 0,
     )
   }
 }


### PR DESCRIPTION
The strict slicing API is named `view` on some built-in types and `sub` on others. Rename it to `exact_view(start?, end?)` on all ten indexed built-in types, preserving strict bounds checks, intrinsics, and bracket-slicing behavior. The old strict names become deprecated aliases. `Iter::view` and `Iter::sub` instead deprecate toward their existing clamped behavior under `clamped_view`.

Based on `main`, which includes the merged #4216 and #4218. The bracket-slicing change in #4215 builds on this PR.

For strings, `exact_view` retains `sub`'s UTF-16 boundary validation. Keep the existing `String::view` and `StringView::view` methods for raw code-unit slicing with their `start_offset`/`end_offset` arguments. These methods also serve compiler-generated `lexmatch` and `lexscan` calls, so their deprecation is deferred to keep `--deny-warn` usable. String operations, JSON parsing, and lexbuf retain raw slicing where arbitrary UTF-16 boundaries are required.

Update callers, examples, documentation, and the generated interface. Strict ReadOnlyArray and bytes compatibility delegations call `exact_view` explicitly. Tests cover all renamed APIs, legacy raw UTF-16 boundaries and nested views, text operations, and malformed JSON numbers.

Validation:

- `moon check --deny-warn --target all` passed.
- `moon test --target all --deny-warn -p builtin -p json -p lexbuf` passed on Wasm (3,280), Wasm GC (3,280), JavaScript (3,250), and native (3,239).
- `moon info --target wasm,wasm-gc,js,native`, `moon fmt`, and `git diff --check` passed; the interface preserves the original string `view` signatures.
