### PR TITLE
refactor: remove redundant string view conversions

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -57,7 +57,7 @@ pub impl @json.FromJson for BigInt with fn from_json(json, path) {
       (path, "BigInt::from_json: expected number in string representation"),
     )
   }
-  parse_bigint(s.view()) catch {
+  parse_bigint(s) catch {
     _ =>
       raise JsonDecodeError(
         (path, "BigInt::from_json: invalid number in string representation"),

--- a/bigint/bigint_default.mbt
+++ b/bigint/bigint_default.mbt
@@ -1312,7 +1312,7 @@ pub fn parse_bigint(str : StringView, base? : Int = 10) -> BigInt raise {
 ///
 /// Panics if the input is malformed. Use `@string.parse_bigint` to handle errors.
 pub fn BigInt::from_string(input : String, radix? : Int = 10) -> BigInt {
-  parse_bigint(input.view(), base=radix) catch {
+  parse_bigint(input, base=radix) catch {
     Failure(msg) => abort(msg)
     _ => abort("invalid syntax")
   }

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -91,7 +91,7 @@ extern "js" fn BigInt::js_parse_string(
 ///
 /// Panics if the input is malformed. Use `@string.parse_bigint` to handle errors.
 pub fn BigInt::from_string(str : String, radix? : Int = 10) -> BigInt {
-  parse_bigint(str.view(), base=radix) catch {
+  parse_bigint(str, base=radix) catch {
     Failure(msg) => abort(msg)
     _ => abort("invalid syntax")
   }
@@ -222,7 +222,7 @@ pub fn BigInt::from_octets(octets : BytesView, signum? : Int = 1) -> BigInt {
   for octet in octets {
     str.write_string(hex2(octet))
   }
-  parse_bigint(str.to_string().view(), base=16) catch {
+  parse_bigint(str.to_string(), base=16) catch {
     Failure(msg) => abort(msg)
     _ => abort("invalid syntax")
   }

--- a/bigint/bigint_wide.mbt
+++ b/bigint/bigint_wide.mbt
@@ -945,7 +945,7 @@ pub fn parse_bigint(str : StringView, base? : Int = 10) -> BigInt raise {
 /// Panics if the input is malformed. Use `@string.parse_bigint` to handle
 /// errors.
 pub fn BigInt::from_string(input : String, radix? : Int = 10) -> BigInt {
-  parse_bigint(input.view(), base=radix) catch {
+  parse_bigint(input, base=radix) catch {
     Failure(msg) => abort(msg)
     _ => abort("invalid syntax")
   }

--- a/internal/strconv/strconv_int.mbt
+++ b/internal/strconv/strconv_int.mbt
@@ -93,7 +93,7 @@ test {
 ///
 pub fn parse_int64(str : StringView, base? : Int = 0) -> Int64 raise {
   guard str != "" else { syntax_err() }
-  let (neg, rest) = match str.view() {
+  let (neg, rest) = match str {
     ['+', .. rest] => (false, rest)
     ['-', .. rest] => (true, rest)
     rest => (false, rest)


### PR DESCRIPTION
Remove six redundant `.view()` calls from BigInt parsing and integer parsing. BigInt's parsers already accept implicit `String` to `StringView` conversion, and the integer parser already receives a `StringView`.

Extracted from #4217 onto `main`. Public APIs and parsing behavior are unchanged.

Validation with the stable CI toolchain:

- `moon check --deny-warn --target all` passed.
- BigInt and internal strconv tests passed on Wasm, Wasm GC, JavaScript, and native (575 / 602 / 573 / 575 tests).
- `moon info --target wasm,wasm-gc,js,native` and `moon fmt` passed; generated interfaces are unchanged.
