### PR TITLE
math: return 1 for pow(1, NaN) and pow(±1, ±inf) per IEEE 754

### DIFF
--- a/math/pow_double_js.mbt
+++ b/math/pow_double_js.mbt
@@ -37,4 +37,18 @@
 ///   inspect(@math.pow(@double.infinity, -1.0), content="0")
 /// }
 /// ```
-pub fn pow(base : Double, exponent : Double) -> Double = "Math" "pow"
+pub fn pow(base : Double, exponent : Double) -> Double {
+  // ECMAScript's Math.pow returns NaN for pow(1, NaN) and pow(+-1, +-inf);
+  // align with IEEE 754-2019 section 9.2.1 as the other backends do.
+  if base == 1.0 {
+    return 1.0
+  }
+  if base == -1.0 &&
+    (exponent == @double.infinity || exponent == @double.neg_infinity) {
+    return 1.0
+  }
+  math_pow_js(base, exponent)
+}
+
+///|
+fn math_pow_js(base : Double, exponent : Double) -> Double = "Math" "pow"

--- a/math/pow_double_nonjs.mbt
+++ b/math/pow_double_nonjs.mbt
@@ -205,6 +205,13 @@ pub fn pow(x : Double, y : Double) -> Double {
   if (iy.reinterpret_as_uint() | ly) == 0 {
     return ONE
   }
+  // |x|==1: pow(1,y) = 1 even if y is NaN, pow(-1,+-inf) = 1
+  // (IEEE 754-2019 section 9.2.1, same as powf)
+  if ix == 0x3ff00000 && lx == 0 {
+    if hx > 0 || (iy == 0x7ff00000 && ly == 0) {
+      return ONE
+    }
+  }
   // +-NaN return x+y
   if ix > 0x7FF00000 ||
     (ix == 0x7FF00000 && lx != 0) ||

--- a/math/pow_double_nonjs.mbt
+++ b/math/pow_double_nonjs.mbt
@@ -244,9 +244,7 @@ pub fn pow(x : Double, y : Double) -> Double {
   // special value of y
   if ly == 0 {
     if iy == 0x7ff00000 { // y is +-inf
-      if ((ix.reinterpret_as_uint() - 0x3ff00000) | lx) == 0 {
-        return y - y // inf**+-1 is NaN
-      } else if ix >= 0x3ff00000 { // (|x|>1)**+-inf = inf,0
+      if ix >= 0x3ff00000 { // (|x|>1)**+-inf = inf,0
         return if hy >= 0 { y } else { ZERO }
       } else { // (|x|<1)**-,+inf = inf,0
         return if hy < 0 { -y } else { ZERO }

--- a/math/pow_test.mbt
+++ b/math/pow_test.mbt
@@ -1242,8 +1242,26 @@ test "powf huge even exponent negative base" {
 
 ///|
 test "pow double infinity exponent branch" {
-  assert_true(@math.pow(1.0, @double.infinity).is_nan())
+  // IEEE 754-2019 section 9.2.1: pow(1, y) = 1 even when y is infinite.
+  assert_eq(@math.pow(1.0, @double.infinity), 1.0)
   assert_eq(@math.pow(2.0, 1.0), 2.0)
+}
+
+///|
+test "pow unit-base special cases" {
+  // IEEE 754-2019 section 9.2.1 / C99 F.9.4.4: pow(1, y) = 1 for any y,
+  // even a NaN, and pow(-1, +-inf) = 1; pow(-1, NaN) is unspecified and
+  // stays NaN. Matches powf and keeps every backend consistent.
+  inspect(@math.pow(1.0, @double.not_a_number), content="1")
+  inspect(@math.pow(1.0, @double.infinity), content="1")
+  inspect(@math.pow(1.0, @double.neg_infinity), content="1")
+  inspect(@math.pow(-1.0, @double.infinity), content="1")
+  inspect(@math.pow(-1.0, @double.neg_infinity), content="1")
+  inspect(@math.pow(-1.0, @double.not_a_number), content="NaN")
+  // Finite exponents keep their ordinary results.
+  inspect(@math.pow(-1.0, 3.0), content="-1")
+  inspect(@math.pow(-1.0, 2.0), content="1")
+  inspect(@math.pow(-1.0, 0.5), content="NaN")
 }
 
 ///|

--- a/math/quickcheck_test.mbt
+++ b/math/quickcheck_test.mbt
@@ -1081,6 +1081,14 @@ test "special values: pow and scalbn" {
   assert_true(same_bits(@math.pow(0.5, inf), 0.0))
   assert_eq(@math.pow(0.5, @double.neg_infinity), inf)
   assert_true(@math.pow(-2.0, 0.5).is_nan())
+  // IEEE 754-2019 section 9.2.1: pow(1, y) = 1 even when y is NaN, and
+  // pow(-1, +-inf) = 1; pow(-1, NaN) stays NaN.
+  assert_eq(@math.pow(1.0, nan), 1.0)
+  assert_eq(@math.pow(1.0, inf), 1.0)
+  assert_eq(@math.pow(1.0, @double.neg_infinity), 1.0)
+  assert_eq(@math.pow(-1.0, inf), 1.0)
+  assert_eq(@math.pow(-1.0, @double.neg_infinity), 1.0)
+  assert_true(@math.pow(-1.0, nan).is_nan())
   assert_true(same_bits(@math.scalbn(0.0, 100), 0.0))
   assert_true(same_bits(@math.scalbn(-0.0, 100), -0.0))
   assert_eq(@math.scalbn(1.0, 2000), inf)


### PR DESCRIPTION
Fixes #4059.

## Problem and resulting behavior

`@math.pow(1.0, NaN)`, `@math.pow(1.0, ±inf)`, and `@math.pow(-1.0, ±inf)` previously returned `NaN` on every backend. They now return `1.0`, matching IEEE 754-2019 §9.2.1, C99 Annex F.9.4.4, and the existing `powf` behavior.

The inconsistency came from different implementations. `powf` is a MoonBit port of FreeBSD's `e_powf.c`, shared by all backends, including JS; its unit-base special cases have returned `1` since the implementation was introduced. Double `pow` instead called `Math.pow` on JS and used an older fdlibm implementation on other backends, both producing `NaN` for these inputs. The [ECMAScript specification](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-number-exponentiate) explicitly retains these differing results for historical compatibility.

Aligning the Double implementation makes Float and Double agree on these special cases and fulfills `pow`'s documented IEEE 754 semantics. This changes the five special-value results above; `pow(-1, NaN)` and negative finite bases with non-integer finite exponents still return `NaN`. Public function signatures are unchanged.

## Changes

- Handle unit-base special cases before the non-JS NaN check, while preserving the existing zero-exponent handling.
- Wrap the JS `Math.pow` call with the same special-case guards.
- Remove the now-unreachable non-JS branch that returned `y - y` for unit bases with infinite exponents, along with its stale NaN comment.
- Update the previous expectation and add coverage for all five changed cases, NaN propagation for base `-1`, and ordinary finite exponents.

## Validation

After the cleanup and synchronization with `main` in `0844b77d1`:

- `moon test -p moonbitlang/core/math --target <backend>`: 196/196 passed on each of wasm-gc, wasm, js, and native.
- `moon check --target all`: passed.
- `moon info` followed by `moon fmt`: passed; no `.mbti` changes.
- `git diff --check`: passed.