### PR TITLE
builtin: guard Logger with #must_implement_one(write_view, write_substring)

### DIFF
--- a/builtin/logger_test.mbt
+++ b/builtin/logger_test.mbt
@@ -27,3 +27,26 @@ test "logger trait object calls" {
     ),
   )
 }
+
+///|
+/// Implementing only `write_view` must make every other method route through
+/// it instead of recursing between the mutual defaults (#3805).
+priv struct ViewOnlyLogger {
+  mut buf : String
+}
+
+///|
+impl Logger for ViewOnlyLogger with fn write_view(self, value) {
+  for ch in value {
+    self.buf = self.buf + ch.to_string()
+  }
+}
+
+///|
+test "logger defaults route to the implemented write method" {
+  let v = ViewOnlyLogger::{ buf: "", }
+  Logger::write_string(v, "ab")
+  Logger::write_view(v, "cd"[0:2])
+  Logger::write_char(v, 'e')
+  inspect(v.buf, content="abcde")
+}

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -1483,6 +1483,7 @@ pub impl[A : Hash, B : Hash, C : Hash, D : Hash, E : Hash, F : Hash, G : Hash] H
 pub impl Hash for BytesView
 pub impl Hash for StringView
 
+#must_implement_one(write_view, write_substring)
 pub(open) trait Logger {
   fn write_string(Self, String) -> Unit = _
   #deprecated

--- a/builtin/traits.mbt
+++ b/builtin/traits.mbt
@@ -93,6 +93,12 @@ pub(open) trait Default {
 ///
 /// A logger receives formatted output without requiring callers to allocate a
 /// complete `String` first.
+///
+/// `write_view` and `write_substring` are mutually defaulted: implement at
+/// least one of them (`write_view` preferred). Without this requirement a type
+/// implementing only `write_string`/`write_char` would hit infinite mutual
+/// recursion between the two defaults at runtime.
+#must_implement_one(write_view, write_substring)
 pub(open) trait Logger {
   /// Writes a string to the logger.
   fn write_string(Self, String) -> Unit = _


### PR DESCRIPTION
Fixes #3805.

## Problem

`Logger`'s `write_view` and `write_substring` are mutually defaulted (`write_view` default → `write_substring`, `write_substring` default → `write_view`) with no guard, unlike `Show`'s `output`/`to_string` pair which carries `#must_implement_one(output, to_string)`.

A type implementing only `write_string` or `write_char` therefore compiles, but every write method ends up in the `write_view` ⇄ `write_substring` cycle at runtime — including `write_char`, whose default goes `write_char` → `write_string` → `write_view` → `write_substring` → … and never reaches a user-provided implementation. Confirmed with the issue's reproducer: `moon run` aborts with "Maximum call stack size exceeded", the stack showing only `write_substring`/`write_view` frames.

## Fix

Guard the trait the same way `Show` is guarded:

```moonbit
#must_implement_one(write_view, write_substring)
pub(open) trait Logger { ... }
```

The cycle is now rejected at compile time with "The trait `Logger` requires explicit implementation for at least one of write_view, write_substring" (verified with the issue's reproducer). Implementing the deprecated `write_substring` still satisfies the constraint, so the gradual migration path stays open; the deprecation messages keep steering new code toward `write_view`.

Existing impls in the repository (`StringBuilder` in `builtin`, `Buffer` in `buffer`) both implement `write_view` and are unaffected.

## Test

Added a regression test in `builtin/logger_test.mbt`: a `priv` type implementing only `write_view` must serve `write_string`, `write_view` and `write_char` correctly through the default chains, which is exactly the shape that used to overflow.

## Verification

- `moon check --deny-warn --target all`: clean.
- `moon test`: 7535/7535 passed.
- `moon fmt` + `moon info`: only expected `.mbti` diff is the `#must_implement_one(write_view, write_substring)` line on the trait.
