### PR TITLE
chore: remove unused package imports

### DIFF
--- a/argparse/moon.pkg
+++ b/argparse/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/error",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/core/set",

--- a/array/moon.pkg
+++ b/array/moon.pkg
@@ -3,8 +3,6 @@ import {
 }
 
 import {
-  "moonbitlang/core/char",
-  "moonbitlang/core/debug",
   "moonbitlang/core/quickcheck",
 } for "test"
 

--- a/bench/moon.pkg
+++ b/bench/moon.pkg
@@ -1,7 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/double",
-  "moonbitlang/core/array",
   "moonbitlang/core/json",
   "moonbitlang/core/ref",
   "moonbitlang/core/test",

--- a/bool/moon.pkg
+++ b/bool/moon.pkg
@@ -1,8 +1,3 @@
 import {
   "moonbitlang/core/builtin",
 }
-
-import {
-  "moonbitlang/core/char",
-  "moonbitlang/core/int16",
-} for "test"

--- a/buffer/moon.pkg
+++ b/buffer/moon.pkg
@@ -1,10 +1,6 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
-  "moonbitlang/core/float",
-  "moonbitlang/core/int16",
-  "moonbitlang/core/uint16",
 }
 
 import {

--- a/builtin/moon.pkg
+++ b/builtin/moon.pkg
@@ -3,7 +3,6 @@ import {
 }
 
 import {
-  "moonbitlang/core/char",
   "moonbitlang/core/int",
   "moonbitlang/core/double",
   "moonbitlang/core/uint64",
@@ -11,13 +10,11 @@ import {
   "moonbitlang/core/int64",
   "moonbitlang/core/uint",
   "moonbitlang/core/json",
-  "moonbitlang/core/bigint",
   "moonbitlang/core/float",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
   "moonbitlang/core/random",
   "moonbitlang/core/math", // FIXME: IDE false alarm unused package
-  "moonbitlang/core/buffer",
   "moonbitlang/core/bench",
   "moonbitlang/core/debug",
 } for "test"

--- a/bytes/moon.pkg
+++ b/bytes/moon.pkg
@@ -3,14 +3,8 @@ import {
 }
 
 import {
-  "moonbitlang/core/array",
   "moonbitlang/core/bench",
-  "moonbitlang/core/double",
-  "moonbitlang/core/uint",
-  "moonbitlang/core/uint64",
   "moonbitlang/core/test",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/json",
-  "moonbitlang/core/float",
-  "moonbitlang/core/debug",
 } for "test"

--- a/cmp/moon.pkg
+++ b/cmp/moon.pkg
@@ -2,7 +2,3 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
-
-import {
-  "moonbitlang/core/int",
-} for "test"

--- a/debug/moon.pkg
+++ b/debug/moon.pkg
@@ -1,17 +1,12 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/double",
   "moonbitlang/core/float",
   "moonbitlang/core/int16",
-  "moonbitlang/core/int64",
-  "moonbitlang/core/uint",
-  "moonbitlang/core/uint16",
-  "moonbitlang/core/uint64",
 }
 
 import {
   "moonbitlang/core/deque",
-  "moonbitlang/core/error",
+  "moonbitlang/core/double",
   "moonbitlang/core/queue",
   "moonbitlang/core/test",
 } for "test"

--- a/deque/moon.pkg
+++ b/deque/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/json",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/test",
 }

--- a/diff/moon.pkg
+++ b/diff/moon.pkg
@@ -3,7 +3,6 @@ import {
   "moonbitlang/core/int",
   "moonbitlang/core/debug",
   "moonbitlang/core/hashmap",
-  "moonbitlang/core/string",
   "moonbitlang/core/internal/edit_distance",
 }
 

--- a/double/moon.pkg
+++ b/double/moon.pkg
@@ -2,10 +2,6 @@ import {
   "moonbitlang/core/builtin",
 }
 
-import {
-  "moonbitlang/core/buffer",
-} for "test"
-
 options(
   targets: {
     "cbrt_js.mbt": [ "js" ],

--- a/encoding/utf8/moon.pkg
+++ b/encoding/utf8/moon.pkg
@@ -4,7 +4,6 @@ import {
 }
 
 import {
-  "moonbitlang/core/buffer",
   "moonbitlang/core/quickcheck",
 } for "test"
 

--- a/error/moon.pkg
+++ b/error/moon.pkg
@@ -2,7 +2,3 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }
-
-import {
-  "moonbitlang/core/json",
-} for "test"

--- a/float/moon.pkg
+++ b/float/moon.pkg
@@ -1,12 +1,10 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/double",
-  "moonbitlang/core/uint",
 }
 
 import {
+  "moonbitlang/core/double",
   "moonbitlang/core/math",
-  "moonbitlang/core/debug",
 } for "test"
 
 options(

--- a/hashmap/moon.pkg
+++ b/hashmap/moon.pkg
@@ -1,9 +1,7 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/test",
-  "moonbitlang/core/int",
   "moonbitlang/core/json",
 }
 

--- a/hashset/moon.pkg
+++ b/hashset/moon.pkg
@@ -1,13 +1,11 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/test",
 }
 
 import {
   "moonbitlang/core/test",
-  "moonbitlang/core/int",
   "moonbitlang/core/json",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/bench",

--- a/immut/hashmap/moon.pkg
+++ b/immut/hashmap/moon.pkg
@@ -1,8 +1,6 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
-  "moonbitlang/core/tuple",
   "moonbitlang/core/immut/internal/sparse_array",
   "moonbitlang/core/immut/internal/path",
   "moonbitlang/core/list",
@@ -10,8 +8,6 @@ import {
 
 import {
   "moonbitlang/core/bench",
-  "moonbitlang/core/int",
-  "moonbitlang/core/option",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"

--- a/immut/hashset/moon.pkg
+++ b/immut/hashset/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/immut/internal/sparse_array",
   "moonbitlang/core/immut/internal/path",
@@ -10,7 +9,6 @@ import {
 
 import {
   "moonbitlang/core/bench",
-  "moonbitlang/core/int",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"

--- a/immut/internal/sparse_array/moon.pkg
+++ b/immut/internal/sparse_array/moon.pkg
@@ -1,5 +1,4 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
 }

--- a/immut/priority_queue/moon.pkg
+++ b/immut/priority_queue/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
 }
 

--- a/immut/sorted_map/moon.pkg
+++ b/immut/sorted_map/moon.pkg
@@ -1,7 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/tuple",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/test",

--- a/immut/sorted_set/moon.pkg
+++ b/immut/sorted_set/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/test",

--- a/immut/vector/moon.pkg
+++ b/immut/vector/moon.pkg
@@ -2,7 +2,6 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
-  "moonbitlang/core/array" @_,
 }
 
 import {

--- a/immut/vector_map/moon.pkg
+++ b/immut/vector_map/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/immut/hashmap",

--- a/int/moon.pkg
+++ b/int/moon.pkg
@@ -1,8 +1,3 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/uint",
 }
-
-import {
-  "moonbitlang/core/buffer",
-} for "test"

--- a/int16/moon.pkg
+++ b/int16/moon.pkg
@@ -4,6 +4,4 @@ import {
 
 import {
   "moonbitlang/core/debug",
-  "moonbitlang/core/uint16",
-  "moonbitlang/core/json",
 } for "test"

--- a/int64/moon.pkg
+++ b/int64/moon.pkg
@@ -1,9 +1,4 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/uint64",
   "moonbitlang/core/int16",
 }
-
-import {
-  "moonbitlang/core/buffer",
-} for "test"

--- a/internal/edit_distance/moon.pkg
+++ b/internal/edit_distance/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/int",
-  "moonbitlang/core/string",
 }
 
 import {

--- a/internal/strconv/moon.pkg
+++ b/internal/strconv/moon.pkg
@@ -3,8 +3,6 @@ import {
   "moonbitlang/core/double",
   "moonbitlang/core/error",
   "moonbitlang/core/uint64",
-  "moonbitlang/core/char",
-  "moonbitlang/core/array",
   "moonbitlang/core/test",
 }
 

--- a/json/moon.pkg
+++ b/json/moon.pkg
@@ -1,26 +1,19 @@
 import {
-  "moonbitlang/core/array",
   "moonbitlang/core/builtin",
-  "moonbitlang/core/char",
   "moonbitlang/core/debug",
   "moonbitlang/core/double",
   "moonbitlang/core/float",
   "moonbitlang/core/internal/strconv" @internal/strconv,
-  "moonbitlang/core/option",
   "moonbitlang/core/buffer",
   "moonbitlang/core/v128", // Used only by the native and wasm SIMD implementation.
 }
 
 import {
-  "moonbitlang/core/result",
-  "moonbitlang/core/unit",
-  "moonbitlang/core/bigint",
   "moonbitlang/core/bench",
   "moonbitlang/core/debug",
   "moonbitlang/core/double",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/quickcheck/shrink",
-  "moonbitlang/core/quickcheck/splitmix",
 } for "test"
 
 import {

--- a/lazy_list/moon.pkg
+++ b/lazy_list/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
 }
 

--- a/list/moon.pkg
+++ b/list/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }

--- a/math/moon.pkg
+++ b/math/moon.pkg
@@ -2,10 +2,8 @@ import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/double",
   "moonbitlang/core/float",
-  "moonbitlang/core/int",
   "moonbitlang/core/bigint",
   "moonbitlang/core/random",
-  "moonbitlang/core/array",
 }
 
 import {

--- a/option/moon.pkg
+++ b/option/moon.pkg
@@ -4,7 +4,6 @@ import {
 
 import {
   "moonbitlang/core/json",
-  "moonbitlang/core/array",
   "moonbitlang/core/test",
 } for "test"
 

--- a/priority_queue/moon.pkg
+++ b/priority_queue/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/debug",
 }
 

--- a/queue/moon.pkg
+++ b/queue/moon.pkg
@@ -6,7 +6,6 @@ import {
 }
 
 import {
-  "moonbitlang/core/array",
   "moonbitlang/core/test",
   "moonbitlang/core/quickcheck",
 } for "test"

--- a/quickcheck/moon.pkg
+++ b/quickcheck/moon.pkg
@@ -1,12 +1,9 @@
 import {
   "moonbitlang/core/debug",
   "moonbitlang/core/int",
-  "moonbitlang/core/int16",
   "moonbitlang/core/quickcheck/shrink",
   "moonbitlang/core/quickcheck/splitmix",
   "moonbitlang/core/builtin",
-  "moonbitlang/core/char",
-  "moonbitlang/core/array",
   "moonbitlang/core/bigint",
   "moonbitlang/core/ref",
   "moonbitlang/core/list",
@@ -28,6 +25,4 @@ import {
 
 import {
   "moonbitlang/core/bench",
-  "moonbitlang/core/float",
-  "moonbitlang/core/double",
 } for "test"

--- a/quickcheck/shrink/moon.pkg
+++ b/quickcheck/shrink/moon.pkg
@@ -1,10 +1,6 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/bigint",
-  "moonbitlang/core/float",
-  "moonbitlang/core/int16",
-  "moonbitlang/core/uint16",
   "moonbitlang/core/lazy",
   "moonbitlang/core/ref",
   "moonbitlang/core/list",

--- a/quickcheck/splitmix/moon.pkg
+++ b/quickcheck/splitmix/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/float",
   "moonbitlang/core/test",
   "moonbitlang/core/debug",
 }

--- a/random/internal/random_source/moon.pkg
+++ b/random/internal/random_source/moon.pkg
@@ -1,5 +1,4 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/array",
   "moonbitlang/core/test",
 }

--- a/range/moon.pkg
+++ b/range/moon.pkg
@@ -1,9 +1,6 @@
 import {
   "moonbitlang/core/builtin",
-  "moonbitlang/core/uint",
-  "moonbitlang/core/float",
   "moonbitlang/core/bigint",
-  "moonbitlang/core/int16",
 }
 
 import {

--- a/set/moon.pkg
+++ b/set/moon.pkg
@@ -1,12 +1,10 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
-  "moonbitlang/core/int",
 }
 
 import {
   "moonbitlang/core/json",
-  "moonbitlang/core/array",
   "moonbitlang/core/test",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/bench",

--- a/sorted_map/moon.pkg
+++ b/sorted_map/moon.pkg
@@ -1,13 +1,10 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
-  "moonbitlang/core/option",
-  "moonbitlang/core/tuple",
   "moonbitlang/core/json",
 }
 
 import {
-  "moonbitlang/core/array",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
 } for "test"

--- a/sorted_set/moon.pkg
+++ b/sorted_set/moon.pkg
@@ -1,12 +1,10 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
-  "moonbitlang/core/option",
   "moonbitlang/core/test",
 }
 
 import {
-  "moonbitlang/core/array",
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/test",
   "moonbitlang/core/bench",

--- a/string/moon.pkg
+++ b/string/moon.pkg
@@ -1,12 +1,10 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/bigint",
-  "moonbitlang/core/char",
   "moonbitlang/core/internal/strconv" @internal/strconv,
   "moonbitlang/core/string/internal/regex_engine" @re,
   "moonbitlang/core/string/internal/regex_parser",
   "moonbitlang/core/debug",
-  "moonbitlang/core/array",
   "moonbitlang/core/test",
 }
 

--- a/tuple/moon.pkg
+++ b/tuple/moon.pkg
@@ -3,6 +3,5 @@ import {
 }
 
 import {
-  "moonbitlang/core/debug",
   "moonbitlang/core/test",
 } for "test"

--- a/uint/moon.pkg
+++ b/uint/moon.pkg
@@ -1,7 +1,3 @@
 import {
   "moonbitlang/core/builtin",
 }
-
-import {
-  "moonbitlang/core/buffer",
-} for "test"

--- a/uint16/moon.pkg
+++ b/uint16/moon.pkg
@@ -4,7 +4,5 @@ import {
 }
 
 import {
-  "moonbitlang/core/char",
   "moonbitlang/core/debug",
-  "moonbitlang/core/json",
 } for "test"

--- a/uint64/moon.pkg
+++ b/uint64/moon.pkg
@@ -1,7 +1,3 @@
 import {
   "moonbitlang/core/builtin",
 }
-
-import {
-  "moonbitlang/core/double",
-} for "test"

--- a/v128/moon.pkg
+++ b/v128/moon.pkg
@@ -1,14 +1,9 @@
 import {
   "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
-  "moonbitlang/core/float",
-  "moonbitlang/core/int16",
-  "moonbitlang/core/int64",
 }
 
 import {
   "moonbitlang/core/bench",
-  "moonbitlang/core/double",
-  "moonbitlang/core/float",
   "moonbitlang/core/quickcheck",
 } for "test"


### PR DESCRIPTION
Remove redundant imports from package manifests and move the `double` dependency into the test imports for `debug` and `float`. Public interfaces and runtime behavior are unchanged.

Five `unused_package` warnings remain on required method imports in `debug`, `int64`, `internal/strconv`, and `uint16`. Removing these imports breaks compilation; the compiler fix is being handled separately. This PR keeps those imports and leaves warning checks enabled.

Validation:

- `moon check --target all` and `moon check --release --target all`: pass with the five known compiler warnings.
- `moon test --target all`: all 30,038 tests pass (Wasm, Wasm GC, JavaScript, and native).
- `moon info` and `moon fmt`: complete; generated `.mbti` files are unchanged.
- `git diff --check`: passes.
