### PR TITLE
add `eprintln` function for output to standard error

### DIFF
--- a/builtin/console.mbt
+++ b/builtin/console.mbt
@@ -38,6 +38,33 @@ pub fn[T : Show] println(input : T) -> Unit {
 }
 
 ///|
+fn eprintln_mono(s : String) -> Unit = "%eprintln"
+
+///|
+/// Prints any value that implements the `Show` trait to the standard error channel,
+/// followed by a newline.
+///
+/// Currently not supported on Wasm-gc backend, will fallback to standard output.
+///
+/// Parameters:
+///
+/// * `value` : The value to be printed. Must implement the `Show` trait.
+///
+/// Example:
+///
+/// ```mbt check
+/// test {
+///   if false {
+///     eprintln(42)
+///     eprintln("Hello, World!")
+///   }
+/// }
+/// ```
+pub fn[T : Show] eprintln(input : T) -> Unit {
+  eprintln_mono(input.to_string())
+}
+
+///|
 /// Represents an error type used by the `inspect` function to indicate failures
 /// in value inspection. Contains a string message describing the nature of the
 /// inspection failure.

--- a/builtin/pkg.generated.mbti
+++ b/builtin/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub fn[A : Compare] compare(A, A) -> Int
 
 pub fn debug_assert(() -> Bool) -> Unit
 
+pub fn[T : Show] eprintln(T) -> Unit
+
 #callsite(autofill(loc))
 pub fn[T] fail(StringView, loc~ : SourceLoc) -> T raise Failure
 

--- a/prelude/pkg.generated.mbti
+++ b/prelude/pkg.generated.mbti
@@ -41,6 +41,8 @@ pub fn debug_inspect(&@debug.Debug, content? : String, loc~ : @builtin.SourceLoc
 #callsite(autofill(loc))
 pub fn[T : @debug.Debug] dump(T, name? : String, loc~ : @builtin.SourceLoc) -> T
 
+pub fn[T : @builtin.Show] eprintln(T) -> Unit
+
 #callsite(autofill(loc))
 pub fn[T] fail(StringView, loc~ : @builtin.SourceLoc) -> T raise @builtin.Failure
 

--- a/prelude/prelude.mbt
+++ b/prelude/prelude.mbt
@@ -35,6 +35,7 @@ pub using @builtin {
   panic,
   physical_equal,
   println,
+  eprintln,
   trait Eq,
   trait Compare,
   trait Hash,


### PR DESCRIPTION
Previously, the standard library only provide API for output to `stdout` (`println`). But logging to `stderr` is also useful in many cases, especially when `stdout` is reserved for IPC etc.

This PR introduces a new function `eprintln` to the prelude namespace, whose signature is exactly the same as `println`, except that it output content to standard error.