### PR TITLE
fix(core): prevent overflow in range and capture checks

### DIFF
--- a/builtin/array.mbt
+++ b/builtin/array.mbt
@@ -1551,10 +1551,10 @@ pub fn[T] Array::chunks(self : Array[T], size : Int) -> Array[ArrayView[T]] {
   if len == 0 {
     return []
   }
-  let num_chunks = (len + size - 1) / size
+  let num_chunks = (len - 1) / size + 1
   Array::makei(num_chunks, i => {
     let start = i * size
-    let end = Int::min(start + size, len)
+    let end = start + Int::min(size, len - start)
     self[start:end]
   })
 }

--- a/builtin/array_test.mbt
+++ b/builtin/array_test.mbt
@@ -1622,3 +1622,10 @@ test "timsort_early_return_for_small_arrays" {
   // With the bug, we get at least 45 + 9 = 54 comparisons.
   inspect(count.val, content="45")
 }
+
+///|
+test "chunks accepts large positive sizes" {
+  let arr = [1, 2]
+  inspect(arr.chunks(2147483647).length(), content="1")
+  inspect(arr[:].chunks(2147483647).length(), content="1")
+}

--- a/builtin/arrayview.mbt
+++ b/builtin/arrayview.mbt
@@ -760,10 +760,10 @@ pub fn[T] ArrayView::chunks(
   if len == 0 {
     return []
   }
-  let num_chunks = (len + size - 1) / size
+  let num_chunks = (len - 1) / size + 1
   Array::makei(num_chunks, i => {
     let start = i * size
-    let end = Int::min(start + size, len)
+    let end = start + Int::min(size, len - start)
     self[start:end]
   })
 }

--- a/builtin/bytes.mbt
+++ b/builtin/bytes.mbt
@@ -81,13 +81,13 @@ pub fn Bytes::to_unchecked_string(
 ) -> String {
   let len = self.length()
   let length = if length is Some(l) { l } else { len - offset }
-  guard! offset >= 0 && length >= 0 && offset + length <= len
+  guard! offset >= 0 && offset <= len && length >= 0 && length <= len - offset
   unsafe_sub_string(self, offset, length)
 }
 
 ///|
-/// Copies characters from a string to a byte sequence in UTF-16LE encoding. Each
-/// character is converted into two bytes, with the lower byte stored first.
+/// Copies UTF-16 code units from a string to a byte sequence in UTF-16LE
+/// encoding. Each code unit becomes two bytes, with the lower byte first.
 ///
 /// Parameters:
 ///
@@ -97,7 +97,7 @@ pub fn Bytes::to_unchecked_string(
 /// * `str` : The source string containing the characters to copy.
 /// * `str_offset` : The starting position in the source string from which
 /// characters will be read.
-/// * `length` : The number of characters to copy.
+/// * `length` : The number of UTF-16 code units to copy.
 ///
 /// Throws a runtime error if:
 ///
@@ -129,13 +129,15 @@ pub fn FixedArray::blit_from_string(
   str_offset : Int,
   length : Int,
 ) -> Unit {
-  let s1 = bytes_offset
-  let s2 = str_offset
-  let e1 = bytes_offset + length * 2 - 1
-  let e2 = str_offset + length - 1
   let len1 = self.length()
   let len2 = str.length()
-  guard! length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
+  guard! length >= 0 &&
+    bytes_offset >= 0 &&
+    bytes_offset <= len1 &&
+    length <= (len1 - bytes_offset) / 2 &&
+    str_offset >= 0 &&
+    str_offset <= len2 &&
+    length <= len2 - str_offset
   let end_str_offset = str_offset + length
   for i = str_offset, j = bytes_offset; i < end_str_offset; i = i + 1, j = j + 2 {
     let c = str.unsafe_get(i).to_int().reinterpret_as_uint()
@@ -158,13 +160,15 @@ pub fn FixedArray::blit_from_bytes(
   src_offset : Int,
   length : Int,
 ) -> Unit {
-  let s1 = bytes_offset
-  let s2 = src_offset
-  let e1 = bytes_offset + length - 1
-  let e2 = src_offset + length - 1
   let len1 = self.length()
   let len2 = src.length()
-  guard! length >= 0 && s1 >= 0 && e1 < len1 && s2 >= 0 && e2 < len2
+  guard! length >= 0 &&
+    bytes_offset >= 0 &&
+    bytes_offset <= len1 &&
+    length <= len1 - bytes_offset &&
+    src_offset >= 0 &&
+    src_offset <= len2 &&
+    length <= len2 - src_offset
   FixedArray::unsafe_blit(
     self,
     bytes_offset,

--- a/builtin/bytes_test.mbt
+++ b/builtin/bytes_test.mbt
@@ -517,3 +517,40 @@ test "BytesView::to_array" {
     ),
   )
 }
+
+///|
+test "panic blit_from_string rejects overflowing source range" {
+  let bytes = FixedArray::make(4, b'\x00')
+  bytes.blit_from_string(0, "", 2147483647, 2)
+}
+
+///|
+test "panic unchecked string rejects overflowing byte range" {
+  ignore(b"".to_unchecked_string(offset=2147483647, length=1))
+}
+
+///|
+test "panic blit_from_bytes rejects overflowing source range" {
+  let bytes = FixedArray::make(4, b'\x00')
+  bytes.blit_from_bytes(0, b"", 2147483647, 2)
+}
+
+///|
+test "panic blit_from_bytes rejects overflowing destination range" {
+  let bytes = FixedArray::make(4, b'\x00')
+  bytes.blit_from_bytes(2147483647, b"ab", 0, 2)
+}
+
+///|
+test "panic blit_from_string rejects overflowing destination length" {
+  let bytes = FixedArray::make(4, b'\x00')
+  bytes.blit_from_string(0, "", 0, 1073741824)
+}
+
+///|
+test "byte copies accept empty ranges at the end" {
+  let bytes = FixedArray::make(4, b'\x00')
+  bytes.blit_from_bytes(4, b"ab", 2, 0)
+  bytes.blit_from_string(4, "ab", 2, 0)
+  inspect(b"ab".to_unchecked_string(offset=2, length=0), content="")
+}

--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -265,6 +265,7 @@ pub fn[A] Deque::copy(self : Deque[A]) -> Deque[A] {
 /// * `dst_offset` is negative
 /// * `dst_offset` exceeds the length of the destination deque
 /// * `src_offset + len` exceeds the length of the source deque
+/// * `dst_offset + len` exceeds the maximum representable `Int`
 pub fn[A] Deque::blit_to(
   self : Deque[A],
   dst : Deque[A],
@@ -276,7 +277,9 @@ pub fn[A] Deque::blit_to(
     dst_offset >= 0 &&
     src_offset >= 0 &&
     dst_offset <= dst.length() &&
-    src_offset + len <= self.length()
+    src_offset <= self.length() &&
+    len <= self.length() - src_offset &&
+    len <= 0x7fffffff - dst_offset
   if dst_offset + len > dst.buf.length() {
     dst.reserve_capacity(dst_offset + len)
     dst.head = 0
@@ -2072,7 +2075,7 @@ pub fn[A] Deque::drain(self : Deque[A], start~ : Int, len? : Int) -> Deque[A] {
   // Calculate and validate len
   let len = match len {
     Some(l) => {
-      guard l >= 0 && start + l <= self.len else {
+      guard l >= 0 && l <= self.len - start else {
         abort(
           "Deque::drain: len out of bounds (start=\{start}, len=\{l}, deque.length()=\{self.len})",
         )

--- a/deque/panic_test.mbt
+++ b/deque/panic_test.mbt
@@ -61,3 +61,15 @@ test "panic drain with negative len" {
 test "panic drain with len exceeding bounds" {
   @deque.from_array([5, 6]).drain(start=1, len=100) |> ignore
 }
+
+///|
+test "panic blit_to with overflowing source range" {
+  let source = @deque.from_array([1, 2, 3])
+  let destination = @deque.from_array([0])
+  source.blit_to(destination, src_offset=0x7fffffff, len=1)
+}
+
+///|
+test "panic drain with overflowing range" {
+  @deque.from_array([1, 2, 3]).drain(start=1, len=0x7fffffff) |> ignore
+}

--- a/string/internal/regex_engine/execute.mbt
+++ b/string/internal/regex_engine/execute.mbt
@@ -37,6 +37,8 @@ fn category_from_symbol(
 ///|
 /// Access capture `group` information.
 pub fn MatchResult::group(self : MatchResult, index : Int) -> (Int, Int)? {
+  // Validate before multiplying so large indices cannot wrap into a group.
+  guard index >= 0 && index < self.0.length() / 2 else { None }
   let start_pos = self.0.get(index * 2)
   guard start_pos is Some(start_pos) && start_pos >= 0 else { None }
   let end_pos = self.0[index * 2 + 1]

--- a/string/regex.mbt
+++ b/string/regex.mbt
@@ -112,7 +112,8 @@ pub fn MatchResult::content(self : MatchResult) -> StringView {
 }
 
 ///|
-/// Access capture `group` information.
+/// Returns a capture group; group `0` is the entire match.
+/// Returns `None` for an out-of-range index or a group that did not participate.
 pub fn MatchResult::group(self : MatchResult, group_index : Int) -> StringView? {
   match self.result.group(group_index) {
     None => None

--- a/string/regex_methods_test.mbt
+++ b/string/regex_methods_test.mbt
@@ -386,3 +386,12 @@ test "find/empty_pattern_progress_and_empty_input" {
   debug_inspect(surrogate_positions, content="[0, 1, 3, 4]")
   debug_inspect(empty_positions, content="[0]")
 }
+
+///|
+test "capture group indices cannot wrap around" {
+  let regex = re"(a)"
+  guard regex.execute("a") is Some(matched) else { fail("expected match") }
+  for index in [-2147483648, -1073741824, -1, 2, 1073741824, 2147483647] {
+    assert_eq(matched.group(index) is None, true)
+  }
+}


### PR DESCRIPTION
Large offsets, lengths, and capture indices can overflow signed `Int` arithmetic and bypass range checks. For example, `[1, 2].chunks(2147483647)` returns an empty array, and an overflowing regex group index can resolve to group 0.

Use subtraction-based bounds checks for byte copies and Deque ranges, overflow-safe chunk calculations, and validation before multiplying capture indices. Add regression cases for overflowing inputs and valid empty ranges.

Validation:

- `moon check --deny-warn`
- `moon test builtin deque string --target all`
- `moon info`; generated interfaces unchanged
