### PR TITLE
fix(hash): give positive and negative zero the same hash

### DIFF
--- a/builtin/double_test.mbt
+++ b/builtin/double_test.mbt
@@ -212,3 +212,10 @@ test "Double::min and Double::max with NaN" {
   assert_true(@double.not_a_number.min(@double.not_a_number).is_nan())
   assert_true(@double.not_a_number.max(@double.not_a_number).is_nan())
 }
+
+///|
+test "equal double signed zero values hash equally" {
+  inspect(Hash::hash(0.0) == Hash::hash(-0.0), content="true")
+  let map : Map[Double, Int] = { 0.0: 42 }
+  inspect(map.get(-0.0) == Some(42), content="true")
+}

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -288,8 +288,8 @@ pub fn Hasher::combine_uint64(self : Hasher, value : UInt64) -> Unit {
 
 ///|
 /// Combines a double-precision floating-point number into the hasher's internal
-/// state by reinterpreting its bits as a 64-bit integer. Maintains consistent
-/// hashing behavior regardless of the floating-point value's representation.
+/// state by reinterpreting its bits as a 64-bit integer. Positive and negative
+/// zero have the same hash, consistently with floating-point equality.
 ///
 /// Parameters:
 ///
@@ -307,13 +307,19 @@ pub fn Hasher::combine_uint64(self : Hasher, value : UInt64) -> Unit {
 /// }
 /// ```
 pub fn Hasher::combine_double(self : Hasher, value : Double) -> Unit {
-  self.combine_int64(value.reinterpret_as_int64())
+  self.combine_int64(
+    if value == 0.0 {
+      0L
+    } else {
+      value.reinterpret_as_int64()
+    },
+  )
 }
 
 ///|
 /// Combines a 32-bit floating-point value into the hasher by reinterpreting its
-/// bit pattern as a 32-bit integer. The operation maintains the same hash result
-/// regardless of the floating-point value's representation.
+/// bit pattern as a 32-bit integer. Positive and negative zero have the same
+/// hash, consistently with floating-point equality.
 ///
 /// Parameters:
 ///
@@ -332,7 +338,8 @@ pub fn Hasher::combine_double(self : Hasher, value : Double) -> Unit {
 /// ```
 #deprecated
 pub fn Hasher::combine_float(self : Hasher, value : Float) -> Unit {
-  self.combine_uint(value.reinterpret_as_uint())
+  let bits = value.reinterpret_as_uint()
+  self.combine_uint(if bits == 0x80000000U { 0U } else { bits })
 }
 
 ///|

--- a/builtin/hasher.mbt
+++ b/builtin/hasher.mbt
@@ -307,13 +307,7 @@ pub fn Hasher::combine_uint64(self : Hasher, value : UInt64) -> Unit {
 /// }
 /// ```
 pub fn Hasher::combine_double(self : Hasher, value : Double) -> Unit {
-  self.combine_int64(
-    if value == 0.0 {
-      0L
-    } else {
-      value.reinterpret_as_int64()
-    },
-  )
+  self.combine_int64(if value is 0 { 0L } else { value.reinterpret_as_int64() })
 }
 
 ///|
@@ -338,8 +332,7 @@ pub fn Hasher::combine_double(self : Hasher, value : Double) -> Unit {
 /// ```
 #deprecated
 pub fn Hasher::combine_float(self : Hasher, value : Float) -> Unit {
-  let bits = value.reinterpret_as_uint()
-  self.combine_uint(if bits == 0x80000000U { 0U } else { bits })
+  self.combine_uint(if value is 0 { 0U } else { value.reinterpret_as_uint() })
 }
 
 ///|

--- a/builtin/hasher_test.mbt
+++ b/builtin/hasher_test.mbt
@@ -311,3 +311,22 @@ test "hash_combine for UInt" {
   Hash::hash_combine(value, hasher)
   inspect(hasher.finalize(), content="1161967057")
 }
+
+///|
+#warnings("-deprecated")
+test "combine_float normalizes signed zero and preserves nonzero bits" {
+  for
+    (value, bits) in [
+      (0.0F, 0U),
+      (-0.0F, 0U),
+      (1.0F, 0x3F800000U),
+      (-1.0F, 0xBF800000U),
+      (@float.infinity, 0x7F800000U),
+    ] {
+    let actual = Hasher(seed=0)
+    actual.combine_float(value)
+    let expected = Hasher(seed=0)
+    expected.combine_uint(bits)
+    assert_eq(actual.finalize(), expected.finalize())
+  }
+}

--- a/float/float_test.mbt
+++ b/float/float_test.mbt
@@ -251,3 +251,10 @@ test "Float constructor syntax" {
   let x : Float = 42
   inspect(Float(x), content="42")
 }
+
+///|
+test "equal signed zero values hash equally" {
+  inspect(Hash::hash(0.0F) == Hash::hash(-0.0F), content="true")
+  let map : Map[Float, Int] = { 0.0F: 42 }
+  inspect(map.get(-0.0F) == Some(42), content="true")
+}

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -52,13 +52,7 @@ pub impl Default for Float with fn default() {
 /// }
 /// ```
 pub impl Hash for Float with fn hash_combine(self, hasher) {
-  hasher.combine_uint(
-    if self == 0.0F {
-      0U
-    } else {
-      self.reinterpret_as_uint()
-    },
-  )
+  hasher.combine_uint(if self is 0 { 0U } else { self.reinterpret_as_uint() })
 }
 
 ///|

--- a/float/methods.mbt
+++ b/float/methods.mbt
@@ -52,7 +52,13 @@ pub impl Default for Float with fn default() {
 /// }
 /// ```
 pub impl Hash for Float with fn hash_combine(self, hasher) {
-  hasher.combine_uint(self.reinterpret_as_uint())
+  hasher.combine_uint(
+    if self == 0.0F {
+      0U
+    } else {
+      self.reinterpret_as_uint()
+    },
+  )
 }
 
 ///|


### PR DESCRIPTION
Positive and negative floating-point zero compare equal but previously hashed differently, so a Map entry inserted with one sign could not reliably be found with the other.

Canonicalize zero in Double/Float hashing and the corresponding Hasher helpers. Add regressions for equal hashes and Map lookups across signed zero.

Validation:

- `moon check --deny-warn`
- `moon test builtin float --target all`
- `moon info`; generated interfaces unchanged
