### PR TITLE
fix(quickcheck): exclude unchanged Float shrink candidates

### DIFF
--- a/quickcheck/shrink/shrink.mbt
+++ b/quickcheck/shrink/shrink.mbt
@@ -159,7 +159,8 @@ pub impl Shrink for Double with fn shrink(x) {
 
 ///|
 pub impl Shrink for Float with fn shrink(x) {
-  shrink_decimal(x.to_double()).map(Float::from_double)
+  // Narrowing a smaller Double can round back to the original Float.
+  shrink_decimal(x.to_double()).map(Float::from_double).filter(y => y != x)
 }
 
 ///|

--- a/quickcheck/shrink/shrink_test.mbt
+++ b/quickcheck/shrink/shrink_test.mbt
@@ -423,3 +423,12 @@ test "shrink float: basic" {
   assert_true(s.contains(3.0))
   assert_true(s.contains(0.0))
 }
+
+///|
+test "shrink float never returns the original value" {
+  for x in [3.14F, -3.14F, 0.1F, -0.1F] {
+    for candidate in @shrink.Shrink::shrink(x) {
+      assert_true(candidate != x)
+    }
+  }
+}


### PR DESCRIPTION
A smaller Double shrink candidate can round back to the original Float during conversion. For values such as `3.14F`, this returns an unchanged failing input and prevents shrinking from progressing.

Filter out candidates equal to the original value after narrowing to Float. Add a regression covering values that previously reproduced this behavior.

Validation:

- `moon check --deny-warn`
- `moon test quickcheck/shrink --target all`
- `moon info`; generated interfaces unchanged
