### PR TITLE
fix(bench): reject invalid sample counts before calibration

### DIFF
--- a/bench/README.mbt.md
+++ b/bench/README.mbt.md
@@ -25,7 +25,7 @@ test "basic benchmarking" {
 
 ## Benchmark Collection
 
-Use the `T` type to collect multiple benchmarks:
+Use the `Bench` type to collect multiple benchmarks:
 
 ```mbt check
 ///|

--- a/bench/bench.mbt
+++ b/bench/bench.mbt
@@ -24,7 +24,8 @@ fn iter_n_microseconds(inner : () -> Unit, k : Int) -> Double {
 
 ///|
 fn iter_count(name? : String, inner : () -> Unit, count : UInt) -> Summary {
-  let count = count.land(0x7FFFFFFF).reinterpret_as_int()
+  guard! count > 0 && count <= 0x7FFFFFFFU
+  let count = count.reinterpret_as_int()
   let threshold = 100000.0 // 100 ms
   let target_batch_size = for trial = 1 {
     let single_us = iter_n_microseconds(inner, trial) / trial.to_double()
@@ -49,7 +50,9 @@ fn iter_count(name? : String, inner : () -> Unit, count : UInt) -> Summary {
 }
 
 ///|
-/// Run a benchmark in batch mode
+/// Run a benchmark in batch mode.
+/// `count` must be between 1 and 2147483647 inclusive; otherwise panics
+/// before invoking the benchmark callback.
 pub fn Bench::bench(
   self : Bench,
   name? : String,
@@ -65,7 +68,9 @@ pub fn Bench::bench(
 }
 
 ///|
-/// Run a benchmark and return its summary
+/// Run a benchmark and return its summary.
+/// `count` must be between 1 and 2147483647 inclusive; otherwise panics
+/// before invoking the benchmark callback.
 pub fn single_bench(
   name? : String,
   f : () -> Unit,

--- a/bench/panic_test.mbt
+++ b/bench/panic_test.mbt
@@ -1,0 +1,28 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "panic single_bench rejects zero samples" {
+  ignore(@bench.single_bench(() => (), count=0))
+}
+
+///|
+test "panic single_bench rejects counts outside Int range" {
+  ignore(@bench.single_bench(() => (), count=0x80000001U))
+}
+
+///|
+test "panic bench rejects counts outside Int range" {
+  @bench.Bench().bench(() => (), count=0xFFFFFFFFU)
+}


### PR DESCRIPTION
Benchmark sample counts were converted to Int by clearing the high bit, silently changing large UInt counts. A zero count reached calibration and ran callbacks before failing on empty statistics.

Validate the count as 1 through 2147483647 before calibration. Add panic regressions for zero and out-of-range counts, and document the accepted range and Bench type name.

Validation:

- `moon check --deny-warn`
- `moon test bench --target all`
- `moon info`; generated interfaces unchanged
