### PR TITLE
docs(core): refresh API contracts and contribution instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-This is the standard library for [MoonBit](docs.moonbitlang.com).
+This is the standard library for [MoonBit](https://docs.moonbitlang.com).
 
 # Refactoring tips
 
@@ -23,15 +23,13 @@ your changes indeed change the behavior of the code, you should run `moon test -
 
 - You can run `moon check` to check the code is linted correctly.
 
-- MoonBit packages are organized per directory, for each directory, there is a `package.json` file listing its dependencies.
+- MoonBit packages are organized per directory, for each directory, there is a `moon.pkg` file listing its dependencies.
 Each package has its files and blackbox test files (common, ending in `_test.mbt`) and whitebox test files (ending in `_wbtest.mbt`).
 
-- In the toplevel directory, this is a `moon.mod.json` file listing about the module and some meta information.
+- In the toplevel directory, this is a `moon.mod` file listing about the module and some meta information.
 
 - When writing tests, you are encouraged to use `inspect` and run `moon test --update` to update the snapshots, only use assertions
   like `assert_eq` when you are in some loops where each snapshot may vary. You can use `moon coverage analyze > uncovered.log` to see which parts of your code are not covered by tests.
-
-- agent-todo.md has some small tasks that are easy for AI to pick up, agent is welcome to finish the tasks and check the box when you are done
 
 # Trait-method promotion (`extend`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,37 +9,25 @@ For the latest stable release and installation instructions, contributors can vi
 
 ## Step 1: Clone the repository
 
-- To start working on the project, you need a local copy of the repository. Currently, `moon` looks for moonbitlang/core at `~/.moon/lib/core`. So, remove it if it exists:
+Clone the repository into a separate working directory and run the tools from its root:
 
-  ```bash
-  rm -rf ~/.moon/lib/core
-  ```
+```bash
+git clone https://github.com/moonbitlang/core.git
+cd core
+moon check
+moon test
+```
 
-- Then, use the following command to get the latest version of moonbitlang/core:
+These commands use the core sources in this checkout. There is no need to remove
+or replace the standard library installed with your toolchain in `~/.moon/lib/core`.
+Package dependencies are declared in `moon.pkg`; module metadata is in `moon.mod`.
+Generated build artifacts go under `_build/` by default.
 
-  ```bash
-  git clone https://github.com/moonbitlang/core ~/.moon/lib/core
-  ```
+To verify that the core can be bundled for all supported targets, run:
 
-- Run the following command to bundle moonbitlang/core:
-
-  ```bash
-  moon bundle --source-dir ~/.moon/lib/core
-  ```
-
-- If everything goes well, it will generate a bundled core file at `~/.moon/lib/core/target/bundle/core.core`.
-
-- Now, you can create a new project and run it to check if everything is working as expected:
-
-  ```bash
-  moon new hello
-  cd hello
-  echo """fn main {
-    println([1, 2, 3].rev())
-  }""" > cmd/main/main.mbt
-  moon run cmd/main
-  # Output: [3, 2, 1]
-  ```
+```bash
+moon bundle --all
+```
 
 ## Step 2: Make your change
 
@@ -59,10 +47,14 @@ After making your changes, it's important to test them to ensure they work as ex
   ```bash
   moon check
   moon test
+  moon bundle --all
+  moon info # Regenerate tracked package interfaces (.mbti)
   moon fmt
-  moon bundle
-  moon info // Generate mbti files, these files should be tracked by git
   ```
+
+Review the `.mbti` diff to confirm that public API changes are intentional. For
+changes that depend on backend behavior, also run `moon test --target all` and
+the relevant release-mode tests, as CI does.
 
 ## Step 4: Submit a pull request and request a review
 
@@ -94,7 +86,7 @@ After submitting your pull request, request a review from the project maintainer
 - New APIs with real meat
 
   We encourage you to add new APIs that are useful and have real meat, rather than just adding APIs for the sake of completeness.
-  If the new API can be composed with existing APIs without loosing efficiency, it is better to use the existing APIs instead of adding new ones, this is due to our current limited bandwidth of the core library.
+  If the new API can be composed with existing APIs without losing efficiency, it is better to use the existing APIs instead of adding new ones, this is due to our current limited bandwidth of the core library.
 
 # Naming conventions
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ It is experimental and under active development. At this early stage, our primar
 
 ⚠️**The API is subject to change.**
 
-### Timeline
-
-The core is making large changes in the last few months, we are expected to reach beta-preview status in mid-August.
-
 ## Contributing
 
 We are actively developing moonbitlang/core and appreciate your help!

--- a/array/README.mbt.md
+++ b/array/README.mbt.md
@@ -116,7 +116,8 @@ test "array views" {
 
 ## Fixed Arrays
 
-Fixed arrays provide immutable array operations:
+Fixed arrays have a fixed length, but their elements are mutable. Use
+`ReadOnlyArray` when element assignment should be unavailable:
 
 ```mbt check
 ///|

--- a/array/SORT_IMPLEMENTATION.md
+++ b/array/SORT_IMPLEMENTATION.md
@@ -4,8 +4,10 @@
 
 MoonBit's `Array::sort` is a sophisticated hybrid sorting algorithm that combines multiple strategies to achieve optimal performance across different scenarios. It's an **in-place, unstable sort** with guaranteed **O(n log n)** worst-case time complexity.
 
-The implementation lives in `builtin/array_sort_impl.mbt`, where every
-helper carries a `fixed_` prefix; the snippets below are abridged from it.
+The implementation lives in `builtin/array_sort_impl.mbt`, where the unstable-sort
+helpers carry a `fixed_` prefix. The same file also contains the separate
+TimSort implementation used by `stable_sort`. The snippets below describe the
+unstable sort.
 
 ## Core Strategy: Adaptive QuickSort
 
@@ -15,12 +17,12 @@ The main algorithm is an adaptive QuickSort implementation with several optimiza
 
 ```
 Array::sort(arr)
-    ├── Calculate recursion limit based on array length
+    ├── Calculate budget for unbalanced partitions
     └── fixed_quick_sort(arr, pred=None, limit)
-        ├── If len ≤ 16: Use Bubble Sort
+        ├── If len ≤ 16: Use Insertion Sort
         ├── If limit == 0: Use Heap Sort (fallback)
         ├── Choose pivot intelligently
-        ├── If likely sorted: Try Bubble Sort
+        ├── If likely sorted: Try Bounded Insertion Sort
         ├── Partition array around pivot
         ├── Track balance and adjust limit
         ├── Skip duplicate pivots if detected
@@ -35,36 +37,28 @@ Array::sort(arr)
 let bubble_sort_len = 16
 if len <= bubble_sort_len {
     if len >= 2 {
-        fixed_bubble_sort(arr)  // Small arrays: O(n²) but cache-friendly
+        fixed_bubble_sort(arr)  // Insertion sort despite the historical name
     }
     return
 }
 ```
 
-**Small Arrays (≤16 elements)**: Uses `fixed_bubble_sort` for its excellent cache locality and low overhead on small datasets.
+**Small Arrays (≤16 elements)**: Uses insertion sort, implemented by the historically named `fixed_bubble_sort`. It grows a sorted prefix by moving each new element left through adjacent swaps.
 
-### 2. Recursion Depth Limiting
+### 2. Unbalanced-Partition Budget
 
-```mbt
-fn fixed_get_limit(len: Int) -> Int {
-    // Returns log₂(len) - the maximum balanced recursion depth
-    let mut limit = 0
-    while len > 0 {
-        len = len / 2
-        limit += 1
-    }
-    limit
-}
-```
-
-The algorithm tracks recursion depth and switches to **Heap Sort** if the limit is exceeded, preventing O(n²) worst-case scenarios.
+`fixed_get_limit(len)` computes `floor(log₂(len)) + 1` for a non-empty
+array. Each partition whose smaller side has fewer than `len / 8` elements
+consumes one unit of this budget; balanced partitions do not consume it.
+When the budget reaches zero, `fixed_quick_sort` switches to heap sort.
+This limits the work spent on severely unbalanced partitions and guarantees
+O(n log n) worst-case time. It is not a limit on all recursive calls.
 
 ### 3. Intelligent Pivot Selection
 
-The `choose_pivot` function uses sophisticated heuristics:
+The `fixed_choose_pivot` function uses sophisticated heuristics:
 
-- **For arrays < 8 elements**: Simple middle element
-- **For arrays ≥ 8 elements**: Samples at 25%, 50%, 75% positions
+- **For arrays with 17–50 elements**: Samples near the 25%, 50%, and 75% positions (smaller arrays have already used insertion sort)
 - **For arrays > 50 elements**: Median-of-medians approach
   - Samples 9 elements (3 groups of 3)
   - Sorts each group and finds median-of-medians
@@ -75,14 +69,14 @@ The function also detects if the array appears sorted by counting swaps during p
 
 ```mbt
 if was_partitioned && balanced && likely_sorted {
-    if arr.try_bubble_sort(start, end) {
-        return  // Successfully sorted with bubble sort
+    if fixed_try_bubble_sort(arr) {
+        return  // Successfully sorted with insertion sort
     }
 }
 ```
 
-When the array appears nearly sorted, it attempts a **limited bubble sort** that:
-- Tolerates at most 8 unsorted elements
+When the array appears nearly sorted, it attempts a **bounded insertion sort** (named `fixed_try_bubble_sort`) that:
+- Returns `false` after the ninth element that needs to move left
 - Completes in O(n) for already sorted arrays
 - Falls back to QuickSort if too many inversions are found
 
@@ -90,36 +84,35 @@ When the array appears nearly sorted, it attempts a **limited bubble sort** that
 
 The partition function:
 - Uses the classic Lomuto partition scheme
-- Returns both the final pivot position and a boolean indicating if any swaps occurred
+- Returns the final pivot position and a boolean that stays true when the partition scan moves no elements; placing the pivot itself does not affect this flag
 - Tracks whether the array was already partitioned (helps detect sorted subarrays)
 
 ### 6. Balance Tracking
 
 ```mbt
 balanced = {
-    let pivot_pos = actual_pivot_pos - current_start
-    let diff = len - pivot_pos
-    (if pivot_pos < diff { pivot_pos } else { diff }) >= len / 8
+    minimum(pivot, len - pivot) >= len / 8
 }
 ```
 
-The algorithm tracks partition balance. If the pivot consistently creates unbalanced partitions (< 1/8 of elements on one side), it decrements the recursion limit faster.
+The algorithm tracks partition balance. Every unbalanced partition (smaller side below `len / 8`) decrements the budget once; balanced partitions leave it unchanged.
 
 ### 7. Duplicate Handling
 
 ```mbt
-if pred == arr[actual_pivot_pos] {
+if pred is Some(p) && p == arr.unsafe_get(pivot) {
     // Skip all elements equal to the pivot
-    let mut i = actual_pivot_pos
-    while i < current_end && pred == arr[i] {
+    let mut i = pivot
+    while i < len && p == arr.unsafe_get(i) {
         i = i + 1
     }
-    current_start = i
-    continue
+    // Continue sorting only arr.slice(i, len).
 }
 ```
 
-When consecutive equal pivots are detected, the algorithm skips over all equal elements, significantly improving performance on arrays with many duplicates.
+When the pivot equals the lower bound inherited from an earlier partition,
+the algorithm skips the contiguous equal prefix after partitioning. Further
+equal elements may remain later in the slice and are handled by later passes.
 
 ### 8. Tail Recursion Optimization
 
@@ -141,7 +134,7 @@ To minimize stack depth, the algorithm:
 ## Performance Characteristics
 
 ### Time Complexity
-- **Best case**: O(n) for already sorted arrays (detected and sorted with bubble sort)
+- **Best case**: O(n) for already sorted arrays (detected by the bounded insertion-sort pass)
 - **Average case**: O(n log n)
 - **Worst case**: O(n log n) (guaranteed by heap sort fallback)
 
@@ -177,10 +170,10 @@ assert_eq(arr, [1, 2, 3, 4, 5])
 Array Size?
 ├── ≤ 16 elements → Insertion Sort
 └── > 16 elements
-    ├── Recursion limit exceeded? → Heap Sort
+    ├── Unbalanced-partition budget exhausted? → Heap Sort
     └── Continue with QuickSort
         ├── Choose pivot (median-of-medians for large arrays)
-        ├── Array likely sorted? → Try Bubble Sort
+        ├── Array likely sorted? → Try Bounded Insertion Sort
         │   ├── Success → Done
         │   └── Failed → Continue partitioning
         ├── Partition around pivot

--- a/bigint/README.mbt.md
+++ b/bigint/README.mbt.md
@@ -1,6 +1,6 @@
 # BigInt Package Documentation
 
-This package provides arbitrary-precision integer arithmetic through the `BigInt` type. BigInt allows you to work with integers of unlimited size, making it perfect for cryptographic operations, mathematical computations, and any scenario where standard integer types are insufficient.
+This package provides arbitrary-precision integer arithmetic through the `BigInt` type. BigInt supports integers whose size is limited by available memory, for computations where fixed-width integer types are insufficient.
 
 ## Creating BigInt Values
 
@@ -255,12 +255,12 @@ test "json serialization" {
   let big = 12345678901234567890N
 
   // Convert to JSON (as string to preserve precision)
-  let json = big.to_json()
+  let json = Json(big)
   @debug.debug_inspect(json, content="String(\"12345678901234567890\")")
 
   // Large numbers that exceed JavaScript's safe integer range
   let very_big = @bigint.BigInt::from_string("123456789012345678901234567890")
-  let big_json = very_big.to_json()
+  let big_json = Json(very_big)
   @debug.debug_inspect(
     big_json,
     content="String(\"123456789012345678901234567890\")",
@@ -294,7 +294,7 @@ test "utility functions" {
 
 BigInt is particularly useful for:
 
-1. **Cryptography**: RSA encryption, digital signatures, and key generation
+1. **Number theory**: Modular arithmetic and prime number calculations
 2. **Mathematical computations**: Factorial calculations, Fibonacci sequences, prime number testing
 3. **Financial calculations**: High-precision monetary computations
 4. **Scientific computing**: Large integer calculations in physics and chemistry
@@ -305,13 +305,14 @@ BigInt is particularly useful for:
 - BigInt operations are slower than regular integer operations due to arbitrary precision
 - Addition and subtraction are generally fast
 - Multiplication and division become slower with larger numbers
-- Modular exponentiation is optimized for cryptographic use cases
+- Modular exponentiation reduces intermediate values modulo the supplied modulus
+- Arithmetic is variable-time; the package does not provide constant-time operations for secret values
 - String conversions can be expensive for very large numbers
 
 ## Best Practices
 
 1. **Use regular integers when possible**: Only use BigInt when you need arbitrary precision
 2. **Cache string representations**: If you need to display the same BigInt multiple times
-3. **Use modular arithmetic**: For cryptographic applications, always use modular exponentiation
+3. **Use modular arithmetic**: Supply a modulus when only the modular result is needed
 4. **Be careful with conversions**: Converting very large BigInt to regular integers will truncate
 5. **Consider memory usage**: Very large BigInt values consume more memory

--- a/builtin/README.mbt.md
+++ b/builtin/README.mbt.md
@@ -274,11 +274,11 @@ test "json" {
   // JSON values
   let json_null = null
   @debug.debug_inspect(json_null, content="Null")
-  let json_bool = true.to_json()
+  let json_bool = Json(true)
   @debug.debug_inspect(json_bool, content="True")
-  let json_number = (42 : Int).to_json()
+  let json_number = Json(42)
   @debug.debug_inspect(json_number, content="Number(42)")
-  let json_string = "hello".to_json()
+  let json_string = Json("hello")
   @debug.debug_inspect(
     json_string,
     content=(

--- a/builtin/double_ryu.mbt.md
+++ b/builtin/double_ryu.mbt.md
@@ -1,159 +1,50 @@
-# Double Internal Ryu Package Documentation
+# Double formatting in `builtin`
 
-This package provides the Ryu algorithm implementation for fast and accurate double-precision floating-point number to string conversion. Ryu is an optimized algorithm that produces the shortest decimal representation of floating-point numbers.
+`Double::to_string()` is implemented in `builtin`. On non-JavaScript backends,
+the private `ryu_to_string` helper uses Ryu to produce a decimal representation
+that parses back to the same finite value. On JavaScript, the helper delegates
+to the JavaScript number's `toString()` method.
 
-## Overview
+The private helper is an implementation detail. Applications use the public
+`Double::to_string()` method, string interpolation, or `Show`.
 
-The Ryu algorithm is used internally by the `double` package to convert floating-point numbers to their string representations efficiently and accurately. This is an internal implementation package that most users won't interact with directly.
-
-## Core Function
-
-The main function provided by this package:
-
-```mbt no-check nocheck
+```mbt check
 ///|
-test "ryu conversion" {
-  // The ryu_to_string function converts doubles to strings
-  let result = ryu_to_string(123.456)
-  inspect(result.length() > 0, content="true")
-
-  // Test with various double values
-  let zero_result = ryu_to_string(0.0)
-  inspect(zero_result, content="0")
-  let negative_result = ryu_to_string(-42.5)
-  inspect(negative_result.length() > 0, content="true")
-
-  // Test with large values
-  let large_result = ryu_to_string(12300000000.0) // 1.23e10
-  inspect(large_result.length() > 0, content="true")
+test "double decimal formatting" {
+  inspect(123.456.to_string(), content="123.456")
+  inspect(0.5.to_string(), content="0.5")
+  inspect(8.0.to_string(), content="8")
+  inspect((-42.5).to_string(), content="-42.5")
 }
 ```
 
-## Algorithm Properties
+The formatter follows ECMAScript's choice between fixed and exponential
+notation. It uses enough significant digits to distinguish the value, rather
+than printing its full exact decimal expansion.
 
-The Ryu algorithm provides several important properties:
-
-### Accuracy
-```mbt no-check nocheck
+```mbt check
 ///|
-test "accuracy properties" {
-  // Ryu produces the shortest decimal representation
-  let precise_value = 0.1
-  let result = ryu_to_string(precise_value)
-  inspect(result.length() > 0, content="true")
-
-  // Test with values that have exact representations
-  let exact_value = 0.5
-  let exact_result = ryu_to_string(exact_value)
-  inspect(exact_result, content="0.5")
-
-  // Test with powers of 2 (should be exact)
-  let power_of_two = 8.0
-  let power_result = ryu_to_string(power_of_two)
-  inspect(power_result, content="8")
+test "double notation boundaries" {
+  inspect(1.0e-6.to_string(), content="0.000001")
+  inspect(1.0e-7.to_string(), content="1e-7")
+  inspect(1.0e20.to_string(), content="100000000000000000000")
+  inspect(1.0e21.to_string(), content="1e+21")
 }
 ```
 
-### Edge Cases
-```mbt no-check nocheck
+Positive and negative zero both format as `"0"`; the sign of zero is not
+preserved. NaN and infinities use the following spellings:
+
+```mbt check
 ///|
-test "edge cases" {
-  // Test special values
-  let inf_result = ryu_to_string(1.0 / 0.0) // Infinity
-  inspect(inf_result.length() > 0, content="true")
-  let neg_inf_result = ryu_to_string(-1.0 / 0.0) // Negative infinity
-  inspect(neg_inf_result.length() > 0, content="true")
-
-  // Test very small values
-  let tiny_result = ryu_to_string(0.0000000001) // Very small
-  inspect(tiny_result.length() > 0, content="true")
-
-  // Test very large values  
-  let huge_result = ryu_to_string(1000000000000.0) // Large number
-  inspect(huge_result.length() > 0, content="true")
+test "double special value formatting" {
+  inspect((-0.0).to_string(), content="0")
+  inspect((0.0 / 0.0).to_string(), content="NaN")
+  inspect((1.0 / 0.0).to_string(), content="Infinity")
+  inspect((-1.0 / 0.0).to_string(), content="-Infinity")
 }
 ```
 
-## Performance Characteristics
-
-The Ryu algorithm is optimized for:
-
-1. **Speed**: Faster than traditional algorithms like Dragon4
-2. **Accuracy**: Always produces the shortest decimal representation
-3. **Determinism**: Same input always produces same output
-4. **Memory efficiency**: Uses minimal temporary storage
-
-```mbt no-check nocheck
-///|
-test "performance demonstration" {
-  // Ryu is designed to be fast for common values
-  let common_values = [0.0, 1.0, -1.0, 0.5, 0.25, 0.125]
-  for value in common_values {
-    let result = ryu_to_string(value)
-    inspect(result.length() > 0, content="true")
-  }
-
-  // Also efficient for complex values
-  let complex_values = [
-    3.141592653589793, 2.718281828459045, 1.4142135623730951,
-  ]
-  for value in complex_values {
-    let result = ryu_to_string(value)
-    inspect(result.length() > 0, content="true")
-  }
-}
-```
-
-## Internal Implementation Details
-
-This package implements the core Ryu algorithm with:
-
-- **Lookup tables**: Pre-computed powers of 5 and 10
-- **Bit manipulation**: Efficient operations on floating-point representation
-- **Optimized arithmetic**: 128-bit multiplication and division routines
-- **Special case handling**: NaN, infinity, and zero values
-
-## Usage Context
-
-This package is used internally by:
-
-- `double` package for `Double::to_string()` implementation
-- JSON serialization of floating-point numbers
-- String formatting operations involving doubles
-- Any operation that needs to display floating-point numbers
-
-## Technical Background
-
-The Ryu algorithm works by:
-
-1. **Extracting** the IEEE 754 representation of the double
-2. **Computing** the exact decimal representation using integer arithmetic
-3. **Optimizing** the output to the shortest possible form
-4. **Formatting** the result according to ECMAScript standards
-
-## Compliance
-
-This implementation:
-
-- Follows the ECMAScript number-to-string specification
-- Produces output compatible with JavaScript's `Number.prototype.toString()`
-- Handles all IEEE 754 double-precision values correctly
-- Maintains round-trip accuracy for string-to-number-to-string conversions
-
-## Alternative Approaches
-
-Before Ryu, common approaches included:
-
-- **Dragon4**: Accurate but slower
-- **Grisu**: Fast but not always shortest representation
-- **sprintf-style**: Simple but potentially inaccurate
-
-Ryu provides the best combination of speed and accuracy.
-
-## References
-
-- Original Ryu paper: "Ryu: fast float-to-string conversion" by Ulf Adams
-- ECMAScript specification for number-to-string conversion
-- IEEE 754 standard for floating-point arithmetic
-
-This package provides the foundation for accurate and efficient floating-point string conversion in MoonBit's double package.
+The non-JavaScript implementation uses precomputed powers, integer arithmetic,
+and a fast path for integral values. Its algorithm is based on Ulf Adams's
+paper *Ryu: fast float-to-string conversion*.

--- a/coverage/coverage.mbt
+++ b/coverage/coverage.mbt
@@ -28,6 +28,8 @@ pub fn CoverageCounter::new(size : Int) -> CoverageCounter {
 
 ///|
 /// Increment the specified tracking index.
+/// The compiler-generated caller must ensure `0 <= idx < size`, where `size`
+/// is the length supplied to `new`. This hot path uses unchecked array access.
 ///
 #coverage.skip
 pub fn CoverageCounter::incr(self : CoverageCounter, idx : Int) -> Unit {

--- a/deque/types.mbt
+++ b/deque/types.mbt
@@ -42,15 +42,16 @@
 ///
 /// Invariants:
 /// - `0 <= len <= buf.length()`
-/// - `0 <= head < buf.length()`
+/// - If the buffer is non-empty: `0 <= head < buf.length()`
+/// - If the buffer is empty: `head == 0` and `len == 0`
 /// - Element at index `i` is at `buf[(head + i) % buf.length()]`
 /// - When `len > 0`: front is `buf[head]`, back is `buf[(head + len - 1) % cap]`
-/// - When `len == 0`: no valid element, `head` can be any valid index
+/// - When `len == 0`: no valid element; `head` is zero or a valid buffer index
 struct Deque[A] {
   /// Circular buffer storing elements. May contain uninitialized slots.
   mut buf : UninitializedArray[A]
   /// Number of elements currently in the deque.
   mut len : Int
-  /// Index of the first element (front). Valid range: 0 <= head < buf.length().
+  /// Index of the first element (front), or zero when the buffer is empty.
   mut head : Int
 }

--- a/diff/hunk.mbt
+++ b/diff/hunk.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-priv struct Range(Int, Int) // line number, length
+priv struct Range(Int, Int) // zero-based start and exclusive end
 
 ///|
 impl Show for Range with fn output(self, logger) {

--- a/encoding/base64/README.mbt.md
+++ b/encoding/base64/README.mbt.md
@@ -36,7 +36,7 @@ test "decode" {
 }
 ```
 
-Set `ignore_whitespace=true` to skip ASCII whitespace in the input:
+Set `ignore_whitespace=true` to skip spaces, tabs, CR, and LF in the input:
 
 ```mbt check
 ///|
@@ -48,7 +48,9 @@ test "decode_ignore_whitespace" {
 
 ## Lossy Decoding
 
-Use `decode_lossy` to decode Base64 while skipping invalid characters instead of raising an error.
+Use `decode_lossy` to decode Base64 while skipping invalid characters instead of
+raising an error. Padding ends decoding. Spaces, tabs, CR, and LF also end
+decoding by default; set `ignore_whitespace=true` to skip them.
 
 ```mbt check
 ///|

--- a/encoding/base64/decode.mbt
+++ b/encoding/base64/decode.mbt
@@ -44,7 +44,7 @@ fn base64_value(code_unit : Int) -> Int {
 ///|
 /// Decodes a Base64 string into a byte array.
 ///
-/// When `ignore_whitespace` is true, ASCII whitespace is ignored.
+/// When `ignore_whitespace` is true, spaces, tabs, CR, and LF are ignored.
 /// Padding may only appear at the end. Both padded and unpadded input are
 /// accepted, but malformed padding raises `Malformed`.
 #cfg(not(any(target="native", target="wasm")))
@@ -58,7 +58,7 @@ pub fn decode(
 ///|
 /// Decodes a Base64 string into a byte array.
 ///
-/// When `ignore_whitespace` is true, ASCII whitespace is ignored.
+/// When `ignore_whitespace` is true, spaces, tabs, CR, and LF are ignored.
 /// Padding may only appear at the end. Both padded and unpadded input are
 /// accepted, but malformed padding raises `Malformed`.
 #cfg(any(target="native", target="wasm"))
@@ -161,8 +161,9 @@ fn decode_scalar(
 ///|
 /// Decodes a Base64 string into a byte array, skipping invalid characters.
 ///
-/// When `ignore_whitespace` is true, ASCII whitespace is ignored. Invalid
-/// characters are skipped, and decoding stops once padding is encountered.
+/// Other invalid characters are skipped. Spaces, tabs, CR, and LF stop
+/// decoding unless `ignore_whitespace` is true, in which case they are skipped.
+/// Decoding always stops once padding is encountered.
 pub fn decode_lossy(
   text : StringView,
   ignore_whitespace? : Bool = false,

--- a/encoding/utf8/README.mbt.md
+++ b/encoding/utf8/README.mbt.md
@@ -6,6 +6,10 @@ Encoding and decoding between strings and UTF-8 byte sequences.
 
 Use `encode` to convert a string to UTF-8 bytes. Set `bom=true` to prepend the UTF-8 BOM (U+FEFF).
 
+For unpaired UTF-16 surrogates, the JavaScript backend replaces each one with
+U+FFFD, following `TextEncoder`; other backends panic. Well-formed strings
+encode identically on all backends.
+
 ```mbt check
 ///|
 test "encode" {

--- a/immut/hashset/README.mbt.md
+++ b/immut/hashset/README.mbt.md
@@ -343,7 +343,7 @@ test "performance benefits" {
 Immutable sets are particularly useful for:
 
 1. **Functional programming**: Pure functions that don't modify data
-2. **Concurrent programming**: Safe sharing between threads
+2. **Shared state**: Keep multiple versions without copying every element
 3. **Undo/redo systems**: Keep history of set states
 4. **Caching**: Cache intermediate results without fear of modification
 5. **Configuration management**: Immutable configuration sets
@@ -355,12 +355,8 @@ Immutable sets are particularly useful for:
 ```mbt check
 ///|
 test "functional programming style" {
-  fn process_numbers(
-    _numbers : @hashset.HashSet[Int],
-  ) -> @hashset.HashSet[Int] {
-    // Manually create processed set (no built-in filter/map)
-    let positive_squares = @hashset.HashSet([1, 4, 9]) // Squares of 1, 2, 3
-    positive_squares.add(1) // Add the number 1 (though 1 already exists)
+  fn process_numbers(numbers : @hashset.HashSet[Int]) -> @hashset.HashSet[Int] {
+    @hashset.from_iter(numbers.iter().filter(x => x > 0).map(x => x * x))
   }
 
   let input = @hashset.HashSet([-2, -1, 0, 1, 2, 3])
@@ -407,9 +403,11 @@ test "configuration usage" {
 
 The HAMT structure provides:
 
-- **Logarithmic depth**: O(log n) operations
+- **Logarithmic depth**: O(log n) lookup, insertion, and removal for well-distributed hashes; a full-hash collision bucket is searched linearly
 - **Structural sharing**: Common subtrees shared between versions
 - **Compact representation**: Efficient memory usage
 - **Cache-friendly access patterns**: Good locality of reference
 
-The immutable hashset package provides efficient, thread-safe, and functionally pure set operations for MoonBit applications requiring persistent data structures.
+Updates preserve the set structure of earlier versions. Elements themselves are
+shared, so structural immutability does not make mutable elements thread-safe.
+An element's hash and equality must remain unchanged while it belongs to a set.

--- a/internal/edit_distance/edit_distance.mbt
+++ b/internal/edit_distance/edit_distance.mbt
@@ -250,7 +250,9 @@ pub fn[T : Eq] edit_distance(a : ArrayView[T], b : ArrayView[T]) -> Int {
 /// Unlike `edit_distance`, the search is banded: it only explores alignments
 /// within `max_distance` of the diagonal and bails out as soon as the bound
 /// is exceeded, so it runs in
-/// `O(min(max_distance, max(m, n)) * min(m, n))` time. This makes it the
+/// `O(m + n + min(max_distance + 1, n) * m)` time for `m >= n`,
+/// including input trimming and scratch-row initialization. It uses `O(n)`
+/// space. This makes it the
 /// right choice for threshold-based uses such as "did you mean" suggestions,
 /// where most candidates are far away.
 ///

--- a/internal/strconv/strconv_double.mbt
+++ b/internal/strconv/strconv_double.mbt
@@ -27,19 +27,19 @@ let double_info : FloatInfo = {
 }
 
 ///|
-/// TODO: For `f32` it is 23, but we don't have `f32` yet.
+/// Number of explicitly stored significand bits in binary64.
 let mantissa_explicit_bits = 52
 
 ///|
-/// TODO: For `f32` it is -10, but we don't have `f32` yet.
+/// Minimum decimal exponent for the binary64 fast path.
 let min_exponent_fast_path : Int64 = -22L
 
 ///|
-/// TODO: For `f32` it is 10, but we don't have `f32` yet.
+/// Maximum decimal exponent for the binary64 fast path.
 let max_exponent_fast_path : Int64 = 22L
 
 ///|
-/// TODO: For `f32` it is 17, but we don't have `f32` yet.
+/// Maximum decimal exponent after moving digits into the binary64 mantissa.
 let max_exponent_disguised_fast_path : Int64 = 37L
 
 ///|

--- a/list/list.mbt
+++ b/list/list.mbt
@@ -1485,7 +1485,8 @@ pub fn[A, E] List::scan_left(
 ///|
 /// Fold a list and return a list of successive reduced values from the right
 ///
-/// Note that the order of parameters on the accumulating function are reversed.
+/// Visits elements from right to left. As in `scan_left`, the callback receives
+/// the accumulator first and the element second.
 ///
 /// # Example
 /// ```mbt check

--- a/priority_queue/priority_queue.mbt
+++ b/priority_queue/priority_queue.mbt
@@ -49,8 +49,7 @@ pub fn[A : Compare] PriorityQueue::PriorityQueue(
 ///|
 fn[A] copy_node(x : Node[A]?) -> Node[A]? {
   // Use an explicit work stack to avoid stack overflow on deep sibling chains.
-  // Each stack entry is (original_node, cloned_parent, relation) where relation
-  // indicates whether original_node is the child or sibling of cloned_parent.
+  // Each stack entry pairs an original node with its cloned node to fill.
   match x {
     None => None
     Some(root) => {
@@ -88,7 +87,8 @@ fn[A] copy_node(x : Node[A]?) -> Node[A]? {
 }
 
 ///|
-/// Returns a deep copy of the queue.
+/// Copies the heap structure into independent nodes. Stored elements are shared,
+/// so mutations to an element are visible through both queues.
 ///
 /// # Example
 /// ```mbt check

--- a/random/README.mbt.md
+++ b/random/README.mbt.md
@@ -127,7 +127,8 @@ test {
 
 ## BigInt
 
-Generate a random non-negative `BigInt` with a given number of bits:
+Generate a random non-negative `BigInt` with at most the given number of bits
+(leading zero bits are allowed):
 
 ```mbt check
 ///|

--- a/random/random.mbt
+++ b/random/random.mbt
@@ -46,7 +46,9 @@ pub fn Rand::chacha8(
 let fixed_test_seed : Bytes = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"
 
 ///|
-/// Create a new random number generator with a given [Source] generator.
+/// Create a random number generator with the supplied [Source].
+/// Without a source, seeds ChaCha8 from platform entropy when available,
+/// falling back to the fixed default seed if entropy is unavailable.
 pub fn Rand::new(generator? : &Source) -> Rand {
   match generator {
     None =>
@@ -405,7 +407,8 @@ pub fn Rand::boolean(self : Rand) -> Bool {
 }
 
 ///|
-/// Generates a random non-negative `BigInt` with a specified number of bits.
+/// Generates a random non-negative `BigInt` with at most `bits` bits.
+/// Leading zero bits are allowed; `bits = 0` returns zero.
 ///
 /// Parameters:
 ///

--- a/string/DESIGN.mbt.md
+++ b/string/DESIGN.mbt.md
@@ -64,8 +64,9 @@ test "unsafe vs safe" {
   starts at the second half of a surrogate pair).
   When displaying invalid characters, a replacement character � will be shown.
 
-* **View**: A `View` represents a view of a String that maintains proper Unicode
-  character boundaries while providing efficient access to substrings. Views are
+* **View**: A `StringView` represents a window into a string. Slice syntax and
+  `exact_view` preserve character boundaries, while the deprecated `view` method
+  permits raw UTF-16 boundaries. Views are
   designed to be more performant than creating new String instances when working
   with substrings.
 
@@ -114,9 +115,7 @@ test "view conversion" {
       `String`, returns `String`. This preserves type consistency and user
       intent.
 
-  - **Unicode Safety and Validity**: Views maintain the same Unicode safety
-    guarantees as Strings, properly handling surrogate pairs and UTF-16 encoding
-    boundaries when iterating or accessing characters. When creating views, it
-    is required to provide valid String with valid offsets. Violating this will
-    result in the replacement character � being displayed when inspecting the
-    view.
+  - **Unicode Safety and Validity**: Use slice syntax or `exact_view` to avoid
+    splitting surrogate pairs. These operations validate the boundaries, not
+    every code unit inside the input. A view can still contain invalid UTF-16
+    inherited from an unchecked string or a raw `view` call.

--- a/string/string.mbt
+++ b/string/string.mbt
@@ -24,7 +24,7 @@
 ///
 /// Do not convert large data to `Array[Char]` and build a string with `String::from_array`.
 ///
-/// For efficiency considerations, it's recommended to use `Buffer` instead.
+/// For incremental string construction, use `StringBuilder`.
 #deprecated
 #doc(hidden)
 pub fn from_array(chars : ArrayView[Char]) -> String {

--- a/tuple/extends.mbt
+++ b/tuple/extends.mbt
@@ -148,7 +148,8 @@ type Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] = (
 
 // --- deprecated: hidden from the generated interface ---
 
-// Tuples have no promoted trait methods; every promotion below is deprecated.
+// Primary compare/equal/hash promotions above are hidden but remain supported.
+// Every promotion below is deprecated.
 
 ///|
 #deprecated("Use `Default::default` instead", skip_current_package=true)

--- a/uint/README.mbt.md
+++ b/uint/README.mbt.md
@@ -10,7 +10,7 @@ This package provides functionalities for handling 32-bit unsigned integers in M
 ///|
 test "uint basics" {
   // Default value is 0
-  inspect(@uint.default(), content="0")
+  inspect((0 : UInt), content="0")
 
   // Maximum and minimum values
   inspect(@uint.MAX_VALUE, content="4294967295")

--- a/unit/unit.mbt
+++ b/unit/unit.mbt
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 ///|
-/// same as `Unit::default`
-#deprecated("Use `Unit::default` instead")
+/// Returns the unit value `()`.
+#deprecated("Use `()` instead")
 pub fn default() -> Unit {
   ()
 }

--- a/v128/README.mbt.md
+++ b/v128/README.mbt.md
@@ -1,7 +1,9 @@
 # `v128`
 
-The `moonbitlang/core/v128` package provides SIMD-style constructors and lane
-extractors for the built-in `V128` type.
+The `moonbitlang/core/v128` package provides SIMD-style constructors, lane
+extractors, arithmetic, comparisons, bitwise operations, and memory operations
+for the built-in `V128` type. The SIMD functions are experimental and hidden
+from the generated public interface; their API may change without notice.
 
 ```mbt check
 ///|


### PR DESCRIPTION
Several documents describe APIs or invariants that no longer match the implementation: the contribution guide replaces the installed core, FixedArray is described as immutable, insertion sort is called bubble sort, and Ryu examples call a private helper.

Update contribution commands and manifest paths, collection sharing and sorting contracts, Unicode/encoding behavior, numeric and random-generator guidance, and deprecation messages. Replace the private Ryu examples with executable public-API examples and correct the immutable-set processing example.

Validation:

- `moon check --deny-warn`
- `moon test --target wasm-gc`
- `moon info`; generated interfaces unchanged
