### PR TITLE
refactor(hashset): reuse difference in symmetric_difference

### DIFF
--- a/hashset/hashset.mbt
+++ b/hashset/hashset.mbt
@@ -436,8 +436,7 @@ pub fn[K : Hash + Eq] HashSet::symmetric_difference(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
-  let m = new_hashset(default_init_capacity)
-  self.each(k => if !other.contains(k) { m.add(k) })
+  let m = self.difference(other)
   other.each(k => if !self.contains(k) { m.add(k) })
   m
 }


### PR DESCRIPTION
## Summary

`HashSet::symmetric_difference` re-spelled the entire body of
`HashSet::difference` before adding its mirrored second phase, so the "keys of
`self` that `other` lacks" policy had two owners 11 lines apart under the same
documented semantics. Delegate that first phase to the canonical operation:

```diff
 pub fn[K : Hash + Eq] HashSet::symmetric_difference(
   self : HashSet[K],
   other : HashSet[K],
 ) -> HashSet[K] {
-  let m = new_hashset(default_init_capacity)
-  self.each(k => if !other.contains(k) { m.add(k) })
+  let m = self.difference(other)
   other.each(k => if !self.contains(k) { m.add(k) })
   m
 }
```

The two removed lines are byte-identical to the first two statements of
`difference` (`hashset/hashset.mbt`), so the first phase now runs exactly the
same statements through the canonical function instead of a copy. Behavior is
unchanged:

- **membership / length** — still `self ∪ other \ self ∩ other`, built in the
  same single accumulator;
- **capacity** — `difference` allocates with the same
  `new_hashset(default_init_capacity)`, so the growth sequence is identical,
  including the aliasing case `s.symmetric_difference(s)` (empty set, capacity 8);
- **order** — the same `self` entries are visited in the same slot order and the
  mirrored phase runs over the same accumulator, so `iter()`/`to_array()` order
  is unchanged;
- **Hash/Eq evaluation** — identical call sequence; neither `self` nor `other`
  is mutated;
- **API** — no signature change, `hashset/pkg.generated.mbti` is untouched.

Changed file: `hashset/hashset.mbt` (1 insertion, 2 deletions), nothing else.

## Validation

Base `e6fdab5ba198349b80049cc0766ac863f25058c0`, head
`103722069386e7d86dee885ed52aba9c22c70634`, run in this worktree:

| command | result |
| --- | --- |
| `moon test hashset --target all` (before the change) | 77/77 passed — wasm, wasm-gc, js, native |
| `moon check --deny-warn --target all` | exit 0 |
| `moon test hashset --target all` (after) | 77/77 passed — all four targets |
| `moon test --target all` | 7609 / 7636 / 7569 / 7524 passed, 0 failed (wasm / wasm-gc / js / native) |
| `moon test hashset --release --target all` | 77/77 passed — all four targets |
| `moon bundle --all` | exit 0 |
| `moon info --target wasm,wasm-gc,js,native` + `moon fmt` | no diff, `.mbti` unchanged |

Beyond the suite, a temporary local probe (removed before committing, so it is
not part of this diff) rebuilt the pre-refactor body from the public API and
asserted equality of `length()`, `capacity()` and `to_array()` order against the
refactored function over 50 input pairs, including `a == b`, empty operands and
larger sets that grow the table. It passed, and a deliberately wrong capacity
assertion failed, so the probe was non-vacuous rather than silently green.

An independent worktree review against the base SHA reproduced the gates above
and reported **no blocker findings**; the delegated statements are byte-identical
to the removed ones and the generated interface matches the tracked `.mbti`. Its
one nit is a pre-existing coverage asymmetry (no quickcheck membership law for
`symmetric_difference`, unlike `difference`) that predates this change and lies
outside this one-file scope.

## CI

Observed at 2026-09-12 13:01 UTC: 1 in_progress, 2 skipped, 17 success. See the PR checks for the live status; pending checks are not reported as passed.
