### PR TITLE
refactor(deque): pass the StringView separator straight to Iter::join

### DIFF
--- a/deque/deque.mbt
+++ b/deque/deque.mbt
@@ -1783,8 +1783,7 @@ pub fn[A] Deque::to_array(self : Deque[A]) -> Array[A] {
 /// }
 /// ```
 pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
-  let str = separator.to_owned()
-  self.iter().join(str)
+  self.iter().join(separator)
 }
 
 ///|


### PR DESCRIPTION
`Deque::join` converted its `StringView` separator into an owned `String` before calling `Iter::join`, which itself takes a `StringView` and only ever reads it through `write_view`. That conversion is residue: `Iter::join` was widened to accept a `StringView` in a098d7373 precisely so this call site no longer needed the owning copy, and the sibling APIs (`Array::join`, `ReadOnlyArray::join`, `FixedArray::join`) already forward their separator view unchanged.

The single-use local and the conversion are removed, leaving the body a direct delegation:

```moonbit
pub fn Deque::join(self : Deque[String], separator : StringView) -> String {
  self.iter().join(separator)
}
```

Behavior is unchanged: the same front-to-back iteration feeds the same `StringBuilder`, so the output bytes, the n-1 separator insertions, the empty-deque -> `""` case and the empty-separator -> direct concatenation case are all identical. The public signature is untouched, so `deque/pkg.generated.mbti` does not change and no caller is affected.

### Validation

All commands were run locally on the commit being published (`8a8e6367ba842875f9728dd3f4789cb2d89a1e8e`), based on `main@a0f0fb87cc0b506364f818c84725152bffbdbb97`:

- `moon check --target all --deny-warn` — exit 0
- `moon test --target all deque` before and after the change — 258/258 (wasm, wasm-gc, js) and 248/248 (native), exit 0
- `moon test` (full suite) — 7609/7609 passed, exit 0
- `moon bundle --all` — exit 0
- `moon info --target wasm,wasm-gc,js,native` and `moon fmt` — exit 0; `git status` lists only `deque/deque.mbt`, i.e. no `.mbti`, snapshot or other file changed
- `moon fmt --check` — exit 0

An independent source/diff review against base `a0f0fb87` raised no blocker: it confirmed the callee's separator parameter is `StringView` and read-only, that `Deque::iter()` yields `Iter[String]` with `String : ToStringView`, that the public signature and `.mbti` are unchanged, and that iteration/separator/output semantics are identical.

Observed CI status at publication — one `gh pr checks 4234` snapshot taken immediately after opening the PR, with no waiting (all 8 GitHub Actions checks were **pending**): `misc-check`, `stable-check` (ubuntu / macos / windows), `stable-native-opt-test` (ubuntu / macos / windows), `version-check`. The two non-Actions entries in that snapshot passed: `Devin Review` (pass; review skipped, trial expired) and `GitGuardian Security Checks` (pass). Pending means pending, not green.
