### PR TITLE
refactor(ascii): drop the duplicate scalar decode loop in JS decode

### DIFF
--- a/encoding/ascii/decode.mbt
+++ b/encoding/ascii/decode.mbt
@@ -40,7 +40,6 @@ fn finish_string(buffer : FixedArray[UInt16], len : Int) -> String {
 }
 
 ///|
-#cfg(not(target="js"))
 #inline
 fn decode_scalar(bytes : BytesView) -> String raise Malformed {
   let t : FixedArray[UInt16] = FixedArray::make(bytes.length(), 0)
@@ -114,18 +113,7 @@ pub fn decode(bytes : BytesView) -> String raise Malformed {
 /// Raises `Malformed` if any byte is outside the ASCII range.
 #cfg(target="js")
 pub fn decode(bytes : BytesView) -> String raise Malformed {
-  let t : FixedArray[UInt16] = FixedArray::make(bytes.length(), 0)
-  let tlen = for tlen = 0, bs = bytes {
-    match (tlen, bs) {
-      (tlen, []) => break tlen
-      (tlen, [0..=0x7F as b, .. rest]) => {
-        t.unsafe_set(tlen, b.to_uint16())
-        continue tlen + 1, rest
-      }
-      (_, _ as bytes) => raise Malformed(bytes)
-    }
-  }
-  finish_string(t, tlen)
+  decode_scalar(bytes)
 }
 
 ///|


### PR DESCRIPTION
## What

`encoding/ascii/decode.mbt` carried the same scalar ASCII decode loop twice:
once as the private `decode_scalar` (gated `#cfg(not(target="js"))`) and once
open-coded inside the JS `pub fn decode` (`#cfg(target="js")`). The two bodies
were byte-identical — verified by direct comparison of the pre-edit file: the
12 loop lines inside the JS `decode` equal `decode_scalar`'s body, including the
`(_, _ as bytes) => raise Malformed(bytes)` arm and the shared `finish_string`
tail.

**Before:** on JS the ASCII acceptance rule and the `Malformed` payload
construction existed in a second, hand-maintained copy, separated from
`decode_scalar` by ~60 lines of v128 code.
**After:** `decode_scalar` loses the cfg and keeps its `#inline` (it names no
`@v128` API, unlike `decode_v128`), and the JS `decode` body becomes
`decode_scalar(bytes)`. Net −12 duplicated lines, −1 `#cfg`; the JS public doc
comment stays on the public function.

Behavior is unchanged:

- The JS success string is identical — the same code path runs.
- On JS the `Malformed` payload is still the remaining `BytesView` starting at
  the first non-ASCII byte, still a view (not a copy), and its `Debug` rendering
  (`Malformed(<BytesView: [0xff]>)`) is unchanged.
- The non-JS optimized `decode`, its 64-byte crossover to `decode_v128`,
  `decode_v128`'s error slicing and `suppress_unused_v128_import_on_js` are
  untouched.
- Public API unchanged: `pkg.generated.mbti` has no diff, and no test snapshot
  changed.

This follows the doctrine already used by the sibling encodings:
`encoding/hex/decode.mbt`, `encoding/base64/decode.mbt` and
`encoding/utf16/decode.mbt` each keep a single `decode_scalar` and have their
non-vector `decode` delegate to it (`encoding/utf16/decode.mbt:213-219` is the
same JS `decode` → `decode_scalar` delegation).

## Validation

Run on this exact tree, base `a0f0fb87cc0b506364f818c84725152bffbdbb97`:

- `moon test encoding/ascii --target all` → 15/15 wasm, 15/15 wasm-gc, 12/12 js,
  15/15 native, exit 0 — identical counts to the pre-edit baseline.
- `moon check --target all --deny-warn` → exit 0.
- `moon test` (full repository) → 7609 passed, 0 failed, exit 0.
- `moon bundle --all` → exit 0.
- `moon info` → exit 0, no `.mbti` changes.
- `moon fmt` → exit 0, file unchanged.

Changed paths: `encoding/ascii/decode.mbt` only (1 insertion, 13 deletions).

CI at the single post-publication snapshot (`gh pr checks 4235`, taken
immediately after opening): `version-check`, `misc-check`, `stable-check`
(ubuntu/windows/macos) and `stable-native-opt-test` (ubuntu/windows/macos) are
**pending**; `nightly-check` is skipping; `Devin Review` and
`GitGuardian Security Checks` pass. Pending is recorded as pending — no CI wait
or polling was performed.
