### PR TITLE
refactor(bigint): share radix helpers across backends

### DIFF
--- a/bigint/bigint.mbt
+++ b/bigint/bigint.mbt
@@ -381,3 +381,32 @@ pub fn BigInt::to_int16(self : BigInt) -> Int16 {
 pub impl @debug.Debug for BigInt with fn to_repr(self) {
   @debug.Repr::integer(self.to_string())
 }
+
+///|
+fn digit_from_char(x : Int) -> Int? {
+  match x {
+    '0'..='9' => Some(x - '0')
+    'A'..='Z' => Some(x + (10 - 'A'))
+    'a'..='z' => Some(x + (10 - 'a'))
+    _ => None
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn char_from_digit(d : Int) -> Char {
+  if d < 10 {
+    (d + '0').unsafe_to_char()
+  } else {
+    (d - 10 + 'a').unsafe_to_char()
+  }
+}
+
+///|
+fn pow2_shift(radix : Int) -> Int? {
+  if radix >= 2 && (radix & (radix - 1)) == 0 {
+    Some(radix.ctz())
+  } else {
+    None
+  }
+}

--- a/bigint/bigint_default.mbt
+++ b/bigint/bigint_default.mbt
@@ -1074,34 +1074,6 @@ pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
 }
 
 ///|
-fn digit_from_char(x : Int) -> Int {
-  match x {
-    '0'..='9' => x - '0'
-    'A'..='Z' => x + (10 - 'A')
-    'a'..='z' => x + (10 - 'a')
-    _ => -1
-  }
-}
-
-///|
-fn char_from_digit(d : Int) -> Char {
-  if d < 10 {
-    (d + '0').unsafe_to_char()
-  } else {
-    (d - 10 + 'a').unsafe_to_char()
-  }
-}
-
-///|
-fn pow2_shift(radix : Int) -> Int? {
-  if radix >= 2 && (radix & (radix - 1)) == 0 {
-    Some(radix.ctz())
-  } else {
-    None
-  }
-}
-
-///|
 fn BigInt::to_string_radix(self : BigInt, radix : Int) -> String {
   if self.is_zero() {
     return "0"
@@ -1216,8 +1188,8 @@ fn BigInt::from_string_radix(input : StringView, radix : Int) -> BigInt raise {
       }
       let base = BigInt::from_int(radix)
       let acc = for i in start..<len; acc = zero {
-        let digit = digit_from_char(input.unsafe_get(i).to_int())
-        if digit < 0 || digit >= radix {
+        guard digit_from_char(input.unsafe_get(i).to_int()) is Some(digit) &&
+          digit < radix else {
           syntax_err()
         }
         continue acc * base + BigInt::from_int(digit)
@@ -1255,8 +1227,8 @@ fn BigInt::from_string_radix_pow2(
     if first >= len {
       break first
     }
-    let digit = digit_from_char(input.unsafe_get(first).to_int())
-    if digit < 0 || digit >= radix {
+    guard digit_from_char(input.unsafe_get(first).to_int()) is Some(digit) &&
+      digit < radix else {
       syntax_err()
     }
     if digit != 0 {
@@ -1272,8 +1244,8 @@ fn BigInt::from_string_radix_pow2(
   let b_len = (total_bits + RADIX_BIT_LEN - 1) / RADIX_BIT_LEN
   let limbs = FixedArray::make(b_len, 0U)
   for i in len>..first; bit_pos = 0 {
-    let digit = digit_from_char(input.unsafe_get(i).to_int())
-    if digit < 0 || digit >= radix {
+    guard digit_from_char(input.unsafe_get(i).to_int()) is Some(digit) &&
+      digit < radix else {
       syntax_err()
     }
     let limb_index = bit_pos / RADIX_BIT_LEN

--- a/bigint/bigint_js.mbt
+++ b/bigint/bigint_js.mbt
@@ -98,25 +98,6 @@ pub fn BigInt::from_string(str : String, radix? : Int = 10) -> BigInt {
 }
 
 ///|
-fn digit_from_char(x : Int) -> Int {
-  match x {
-    '0'..='9' => x - '0'
-    'A'..='Z' => x + (10 - 'A')
-    'a'..='z' => x + (10 - 'a')
-    _ => -1
-  }
-}
-
-///|
-fn pow2_shift(radix : Int) -> Int? {
-  if radix >= 2 && (radix & (radix - 1)) == 0 {
-    Some(radix.ctz())
-  } else {
-    None
-  }
-}
-
-///|
 fn BigInt::from_string_radix(str : StringView, radix : Int) -> BigInt raise {
   let len = str.length()
   let sign = if str.unsafe_get(0) == '-' { -1 } else { 1 }
@@ -128,8 +109,8 @@ fn BigInt::from_string_radix(str : StringView, radix : Int) -> BigInt raise {
   match pow2_shift(radix) {
     Some(shift) =>
       for i in start..<len {
-        let digit = digit_from_char(str.unsafe_get(i).to_int())
-        if digit < 0 || digit >= radix {
+        guard digit_from_char(str.unsafe_get(i).to_int()) is Some(digit) &&
+          digit < radix else {
           syntax_err()
         }
         acc = (acc << shift) | BigInt::from_int(digit)
@@ -137,8 +118,8 @@ fn BigInt::from_string_radix(str : StringView, radix : Int) -> BigInt raise {
     None => {
       let base = BigInt::from_int(radix)
       for i in start..<len {
-        let digit = digit_from_char(str.unsafe_get(i).to_int())
-        if digit < 0 || digit >= radix {
+        guard digit_from_char(str.unsafe_get(i).to_int()) is Some(digit) &&
+          digit < radix else {
           syntax_err()
         }
         acc = acc * base + BigInt::from_int(digit)

--- a/bigint/bigint_wide.mbt
+++ b/bigint/bigint_wide.mbt
@@ -715,34 +715,6 @@ fn maximum_int(a : Int, b : Int) -> Int {
 }
 
 ///|
-fn digit_from_char(x : Int) -> Int {
-  match x {
-    '0'..='9' => x - '0'
-    'A'..='Z' => x + (10 - 'A')
-    'a'..='z' => x + (10 - 'a')
-    _ => -1
-  }
-}
-
-///|
-fn char_from_digit(d : Int) -> Char {
-  if d < 10 {
-    (d + '0').unsafe_to_char()
-  } else {
-    (d - 10 + 'a').unsafe_to_char()
-  }
-}
-
-///|
-fn pow2_shift(radix : Int) -> Int? {
-  if radix >= 2 && (radix & (radix - 1)) == 0 {
-    Some(radix.ctz())
-  } else {
-    None
-  }
-}
-
-///|
 /// Converts this integer to a string in a radix between 2 and 36.
 pub fn BigInt::to_string(self : BigInt, radix? : Int = 10) -> String {
   if radix < 2 || radix > 36 {
@@ -829,8 +801,8 @@ fn BigInt::from_string_radix(input : StringView, radix : Int) -> BigInt raise {
       }
       let base = BigInt::from_int(radix)
       let acc = for i in start..<len; acc = zero {
-        let digit = digit_from_char(input.unsafe_get(i).to_int())
-        if digit < 0 || digit >= radix {
+        guard digit_from_char(input.unsafe_get(i).to_int()) is Some(digit) &&
+          digit < radix else {
           syntax_err()
         }
         continue acc * base + BigInt::from_int(digit)
@@ -859,8 +831,8 @@ fn BigInt::from_string_radix_pow2(
   }
   let mut first = start
   while first < len {
-    let digit = digit_from_char(input.unsafe_get(first).to_int())
-    if digit < 0 || digit >= radix {
+    guard digit_from_char(input.unsafe_get(first).to_int()) is Some(digit) &&
+      digit < radix else {
       syntax_err()
     }
     if digit != 0 {
@@ -875,8 +847,8 @@ fn BigInt::from_string_radix_pow2(
   let limbs_len = (total_bits + RADIX_BIT_LEN - 1) / RADIX_BIT_LEN
   let limbs = FixedArray::make(limbs_len, 0UL)
   for i in len>..first; bit_pos = 0 {
-    let digit = digit_from_char(input.unsafe_get(i).to_int())
-    if digit < 0 || digit >= radix {
+    guard digit_from_char(input.unsafe_get(i).to_int()) is Some(digit) &&
+      digit < radix else {
       syntax_err()
     }
     let limb_index = bit_pos / RADIX_BIT_LEN
@@ -910,8 +882,9 @@ fn BigInt::from_string_dec(input : StringView) -> BigInt raise {
   while i < len {
     let take = minimum_int(DECIMAL_CHUNK_DIGITS, len - i)
     let (chunk, scale) = for offset in 0..<take; chunk = 0UL, scale = 1UL {
-      let digit = digit_from_char(input.unsafe_get(i + offset).to_int())
-      if digit < 0 || digit > 9 {
+      guard digit_from_char(input.unsafe_get(i + offset).to_int())
+        is Some(digit) &&
+        digit <= 9 else {
         syntax_err()
       }
       continue chunk * 10 + digit.to_uint64(), scale * 10

--- a/bigint/parse_bigint_test.mbt
+++ b/bigint/parse_bigint_test.mbt
@@ -99,3 +99,21 @@ test "parse_bigint rejects trailing whitespace" {
     )
   }
 }
+
+///|
+test "parse_bigint rejects digits in shared radix loops" {
+  for
+    (input, base) in [
+      ("3", 3),
+      ("a", 3),
+      ("?", 3),
+      ("10?", 3),
+      ("4", 4),
+      ("?", 4),
+    ] {
+    assert_true(
+      @test.expect_error(() => @bigint.parse_bigint(input, base~))
+      is Failure::Failure("invalid syntax"),
+    )
+  }
+}


### PR DESCRIPTION
BigInt's three backends maintained eight copies of the same radix helpers. Share the three private helpers in bigint.mbt, retaining the non-JS guard on digit formatting. Invalid characters return None from digit_from_char, with all nine callers preserving their range checks and error messages. Add base-3/base-4 rejection cases to exercise unrecognized characters and recognized digits outside the radix, including JS's shared parser paths. Public interfaces and limb algorithms are unchanged.

Validation: baseline and final bigint tests pass on all targets (final: 167 wasm, 194 wasm-gc, 168 JS, 167 native). Full core tests pass: 7,610 wasm, 7,637 wasm-gc, 7,570 JS, 7,525 native. moon check --target all --deny-warn, moon bundle --all, moon info and moon fmt pass; no interface or snapshot changes. Final source review found no functional blocker; its radix-error coverage gap is addressed by the new assertions. CI at publication: no checks reported yet.
